### PR TITLE
fix(SD-...-PROMPT-LIBRARY-001-D): pointer-file startup transport + callsign-keyed prompt selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -303,6 +303,11 @@ src/client/dist/
 # RELATIONSHIPAWARE-ORCH-001-B) can be tracked.
 .claude/session-identity/*
 !.claude/session-identity/README.md
+# SD-...-PROMPT-LIBRARY-001-D FR-1 — startup-prompt pointer files, one per spawned session.
+# MUST be ignored: these are written on every spawn, so if they were tracked each spawn would
+# dirty the worktree and could be swept into an unrelated commit.
+.claude/fleet-prompts/*
+!.claude/fleet-prompts/README.md
 .claude/fleet-identity*.json
 .claude/scheduled_tasks.lock
 

--- a/lib/fleet/build-session-launch.cjs
+++ b/lib/fleet/build-session-launch.cjs
@@ -92,7 +92,23 @@ function buildSessionLaunch(spec = {}, opts = {}) {
   childEnv.CLAUDE_CODE_FORCE_SESSION_PERSISTENCE = '1';
   if (profileDir) childEnv.CLAUDE_CONFIG_DIR = profileDir; // isolation, child env only
   if (sdToResume) childEnv.FLEET_AUTORESUME_SD = String(sdToResume); // SessionStart hook -> sd-start --force-reclaim
-  if (startupPrompt) childEnv.FLEET_WORKER_STARTUP_PROMPT = String(startupPrompt); // persistent replacement for headless -p
+  // SD-...-PROMPT-LIBRARY-001-D FR-2 — THE `FLEET_WORKER_STARTUP_PROMPT` ENV CARRIER IS DELETED.
+  //
+  // It was documented as "the persistent replacement for headless -p", seeded into the session by
+  // a SessionStart hook. THAT MECHANISM DOES NOT EXIST AND NEVER DID. Verified repo-wide: every
+  // occurrence of the name is this constant's definition, a WRITE like the one removed here, a
+  // comment describing the imagined hook, or a test asserting the write. There is not one
+  // `process.env.FLEET_WORKER_STARTUP_PROMPT` READ anywhere, and no SessionStart hook references
+  // it. Claude Code has no env var that seeds a first message, so nothing could have consumed it.
+  //
+  // Why removing it matters rather than being tidy-up: the write made the invocation LOOK like it
+  // delivered a prompt, so three call sites resolved a prompt, handed it over, and reported
+  // success while it was dropped on the floor. That appearance is what let the real defect
+  // (spawned sessions coming up with nothing to do, then ghosting) survive being "fixed" twice.
+  //
+  // `startupPrompt` is therefore ACCEPTED AND CURRENTLY UNUSED, deliberately and visibly, until
+  // FR-1 lands the real single-line pointer transport. Callers keep passing it; the resolution
+  // logic they run is still exercised. Do NOT re-add an env carrier to make it "used".
 
   // PERSISTENT visible wt.exe window; -d sets the start dir; NEVER headless -p/--print.
   //

--- a/lib/fleet/build-session-launch.cjs
+++ b/lib/fleet/build-session-launch.cjs
@@ -176,6 +176,23 @@ function buildSessionLaunch(spec = {}, opts = {}) {
   // pointer carries an ABSOLUTE path, so it resolves regardless of what cwd the session ends up
   // with. A relative pointer silently depends on a cwd nobody is asserting.
   let promptFilePath = null;
+
+  // F2 — DO NOT DISCARD A RESOLVED PROMPT SILENTLY. This is THIS SD'S OWN DEFECT CLASS, found by
+  // PLAN verification. A non-UUID sessionId is dropped above (correctly — the CLI would reject it
+  // and fail the launch), but the transport below is gated on `startupPrompt && sessionId`, so the
+  // caller's prompt was then thrown away with no throw and no log: the session comes up idle and
+  // nothing anywhere says why. That is precisely the failure this SD exists to eliminate, so it
+  // must not be reintroduced by the fix for it.
+  //
+  // Warn rather than throw: losing the directive is recoverable (the session ghosts, which is safe),
+  // while failing the launch outright is not. What matters is that it stops being SILENT.
+  if (startupPrompt && !sessionId) {
+    const warn = opts.logFn || console.warn;
+    warn('[build-session-launch] a startup prompt was resolved but NO usable session id exists '
+      + '(a non-UUID id is dropped), so the pointer transport is skipped and the spawned session will '
+      + 'come up with NO directive and idle. Pass a valid UUID sessionId/resumeUuid to deliver it.');
+  }
+
   if (startupPrompt && sessionId) {
     const { sweepStartupPromptFiles } = require('./startup-prompt-pointer.cjs');
     const { assertSingleLinePrompt } = requireStartupPromptSelection();

--- a/lib/fleet/build-session-launch.cjs
+++ b/lib/fleet/build-session-launch.cjs
@@ -190,6 +190,31 @@ function buildSessionLaunch(spec = {}, opts = {}) {
     // creating it HIDES the misconfiguration. It also meant unit tests that merely built an
     // invocation against a fixture path materialised `tests/fixtures/__no_such_tree__` in the repo.
     // The pointer is still emitted — it carries its own missing-file instruction, which idles.
+    // F1 — STRUCTURAL BACKSTOP: A CANARY MUST NEVER RECEIVE THE WORKER DIRECTIVE, ENFORCED HERE.
+    //
+    // Every spawner funnels through this function, and it receives BOTH the callsign and the
+    // prompt — yet the invariant was enforced only by convention at the three call sites. A PLAN
+    // verification probe called this directly with a Canary- callsign and the worker directive and
+    // got 1406 bytes written: byte-identical to the f060c6fb42b hazard. The three-site test
+    // hardcodes three sites, so a FOURTH spawner would not have caught it.
+    //
+    // That is the same defect class as f060c6fb42b (a fix applied at N-1 of N sites), one level up.
+    // The durable answer is not another per-site test — it is enforcing the invariant at the point
+    // they all pass through, so a new spawner inherits the guarantee instead of having to remember.
+    //
+    // Deliberately NARROW: it refuses only the specific hazard (canary namespace + the actual worker
+    // directive), so the documented explicit-prompt opt-out keeps working for every other payload.
+    if (callsign && /^canary-/i.test(String(callsign).trim())) {
+      const { FLEET_WORKER_STARTUP_PROMPT } = require('../coordinator/coordination-events.cjs');
+      if (String(startupPrompt) === FLEET_WORKER_STARTUP_PROMPT) {
+        throw new LaunchResolveError(
+          `refusing to launch canary-namespace callsign ${JSON.stringify(String(callsign))} with the WORKER `
+          + 'directive. A canary that receives the claiming directive starts claiming DRAFT SDs unattended '
+          + '(see f060c6fb42b). Select the prompt via resolveStartupPromptForCallsign.',
+        );
+      }
+    }
+
     // SEC-2 — VALIDATE ON BOTH BRANCHES. writeStartupPromptFile enforces a filename charset on
     // sessionId, but the missing-root branch below built the path INLINE with no check at all, and
     // sessionId can be a DB-sourced resumeUuid (which, unlike the minted id, is not isUuid-tested).

--- a/lib/fleet/build-session-launch.cjs
+++ b/lib/fleet/build-session-launch.cjs
@@ -190,6 +190,17 @@ function buildSessionLaunch(spec = {}, opts = {}) {
     // creating it HIDES the misconfiguration. It also meant unit tests that merely built an
     // invocation against a fixture path materialised `tests/fixtures/__no_such_tree__` in the repo.
     // The pointer is still emitted — it carries its own missing-file instruction, which idles.
+    // SEC-2 — VALIDATE ON BOTH BRANCHES. writeStartupPromptFile enforces a filename charset on
+    // sessionId, but the missing-root branch below built the path INLINE with no check at all, and
+    // sessionId can be a DB-sourced resumeUuid (which, unlike the minted id, is not isUuid-tested).
+    // A guard that only covers one of two path-construction routes is not a guard. Not exploitable
+    // as found — path.join normalised the traversal away — but the hole sat beside a load-bearing
+    // check on a value that comes from the database.
+    if (!/^[A-Za-z0-9._-]+$/.test(String(sessionId))) {
+      throw new LaunchResolveError(
+        `refusing to build a startup-prompt path from unsafe sessionId ${JSON.stringify(String(sessionId))}`,
+      );
+    }
     const rootExists = require('node:fs').existsSync(promptRoot);
     const written = rootExists
       ? writeFn({ repoRoot: promptRoot, sessionId, prompt: String(startupPrompt) })

--- a/lib/fleet/build-session-launch.cjs
+++ b/lib/fleet/build-session-launch.cjs
@@ -157,7 +157,74 @@ function buildSessionLaunch(spec = {}, opts = {}) {
     // would fail the whole launch. Losing correlation is recoverable; losing the session is not.
   }
 
-  return { program: 'wt.exe', args, env: childEnv, cwd: startDir, persistent: true, sessionId };
+  // FR-1 — POINTER-FILE STARTUP TRANSPORT. Must come AFTER the session id is minted: the pointer
+  // file is named for that id, which is how a spawned session's directive is correlated to it.
+  //
+  // The prompt is written to its own file and only a SINGLE-LINE pointer becomes the trailing
+  // positional. See startup-prompt-pointer.cjs for why a pointer rather than the prompt itself
+  // (cmd.exe truncates at the first LF — measured; wt.exe re-parses and was never verified).
+  //
+  // THE WRITE GOES THROUGH AN INJECTABLE SEAM (opts.writePromptFileFn). Two reasons, both learned
+  // the hard way here:
+  //   1. Building an invocation should not silently touch the filesystem. The first version wrote
+  //      unconditionally, and every unit test that merely BUILT a launch littered the repo — it
+  //      created a directory named `tests/fixtures/__no_such_tree__` containing 10+ prompt files.
+  //   2. Per the 2026-07-26 fleet-safety rule: probe through a seam you control, never by editing
+  //      the live path. A seam here means tests can assert the wiring without going near disk.
+  //
+  // The file is written under startDir — the directory the session actually starts in — and the
+  // pointer carries an ABSOLUTE path, so it resolves regardless of what cwd the session ends up
+  // with. A relative pointer silently depends on a cwd nobody is asserting.
+  let promptFilePath = null;
+  if (startupPrompt && sessionId) {
+    const { sweepStartupPromptFiles } = require('./startup-prompt-pointer.cjs');
+    const { assertSingleLinePrompt } = requireStartupPromptSelection();
+    const writeFn = opts.writePromptFileFn
+      || require('./startup-prompt-pointer.cjs').writeStartupPromptFile;
+
+    const promptRoot = path.resolve(startDir);
+
+    // NEVER FABRICATE A START DIRECTORY THAT DOES NOT EXIST. mkdir -p on the prompt dir would
+    // happily create the whole tree, so a launch pointed at a missing cwd would silently sprout
+    // one. That is wrong twice over: the spawn is already doomed (wt.exe -d needs a real dir), and
+    // creating it HIDES the misconfiguration. It also meant unit tests that merely built an
+    // invocation against a fixture path materialised `tests/fixtures/__no_such_tree__` in the repo.
+    // The pointer is still emitted — it carries its own missing-file instruction, which idles.
+    const rootExists = require('node:fs').existsSync(promptRoot);
+    const written = rootExists
+      ? writeFn({ repoRoot: promptRoot, sessionId, prompt: String(startupPrompt) })
+      : { promptFilePath: path.join(promptRoot, '.claude', 'fleet-prompts', `${sessionId}.txt`) };
+    promptFilePath = written.promptFilePath;
+
+    // THE NEWLINE TRIPWIRE, ON THE ONLY PATH THAT CAN CARRY THE DEFECT (FR-4 wired per
+    // metadata.fr1_exit_criterion_tripwire_must_be_wired). Asserted on the POINTER — the value
+    // that actually becomes argv — not on the prompt, which is now legitimately multi-line inside
+    // the file. A guard placed on the prompt here would fire on every correct spawn.
+    // Derived from the PATH, not from the writer's return value, so the pointer is identical
+    // whether or not the file was materialised — one code path, no divergence between them.
+    // opts.buildPointerLineFn is a SEAM FOR PROVING THE TRIPWIRE IS REACHABLE. A guard that only
+    // passes its own unit tests is not evidence it is wired to anything (2026-07-26 fleet-safety
+    // rule). Injecting a deliberately multi-line builder here must make THIS function throw — that
+    // is an in-suite reachability proof rather than a one-off in-place mutation, so it keeps
+    // holding for every future reader instead of being a claim in a commit message.
+    const buildPointerLine = opts.buildPointerLineFn || require('./startup-prompt-pointer.cjs').buildPointerLine;
+    args.push(assertSingleLinePrompt(buildPointerLine(promptFilePath), { where: 'buildSessionLaunch positional' }));
+
+    // Best-effort housekeeping; never allowed to fail a spawn. Skipped when the write was stubbed,
+    // since there is then no real directory to sweep.
+    if (!opts.writePromptFileFn) {
+      try { sweepStartupPromptFiles({ repoRoot: promptRoot }); } catch { /* non-fatal */ }
+    }
+  }
+
+  return { program: 'wt.exe', args, env: childEnv, cwd: startDir, persistent: true, sessionId, promptFilePath };
+}
+
+/** Seam: kept as a function so tests can stub the ESM import without editing this call site. */
+function requireStartupPromptSelection() {
+  // startup-prompt-selection.js is ESM; require() of an ESM file works here because the module has
+  // no top-level await and Node's require(esm) support is enabled on this runtime.
+  return require('./startup-prompt-selection.js');
 }
 
 /** Strict RFC-4122 shape check — the CLI requires a valid UUID and rejects anything else. */

--- a/lib/fleet/canary-guard.js
+++ b/lib/fleet/canary-guard.js
@@ -24,7 +24,10 @@ import {
   relaunchUnderProfile as spawnControlRelaunchUnderProfile,
 } from './spawn-control.js';
 
-const CANARY_CALLSIGN_PREFIX = 'Canary-';
+// FR-4: the prefix + namespace predicate now come from the single pure source. That module
+// imports NOTHING, so it cannot participate in the canary-guard -> spawn-control cycle that
+// forced this constant to be duplicated in the first place.
+import { isCanaryCallsign as isCanaryNamespaceCallsign } from './startup-prompt-selection.js';
 
 /**
  * True only when the operator has explicitly enabled the canary-kill surface. INDEPENDENT of
@@ -34,10 +37,16 @@ export function isCanaryKillEnabled(env = process.env) {
   return String(env.FLEET_CANARY_KILL_ENABLED || '').toLowerCase() === 'true';
 }
 
-/** True only for a callsign in the canary-only namespace (defence-in-depth alongside the account_profile check). */
-export function isCanaryCallsign(callsign) {
-  return typeof callsign === 'string' && callsign.startsWith(CANARY_CALLSIGN_PREFIX);
-}
+/**
+ * True only for a callsign in the canary-only namespace (defence-in-depth alongside the
+ * account_profile check). Re-exported from the shared source rather than re-implemented.
+ *
+ * NOTE the deliberate asymmetry: this boolean maps an UNIDENTIFIABLE callsign to false, which is
+ * safe HERE (false means "do not treat as a canary" — it withholds the kill surface) but is NOT
+ * safe for the startup-prompt decision, where false means "hand it the claiming worker directive".
+ * Same predicate, opposite blast radius. Prompt selection must use classifySessionByCallsign.
+ */
+export const isCanaryCallsign = isCanaryNamespaceCallsign;
 
 /**
  * Resolve a card/session identifier to ONE live identity WITH its server-side account_profile.

--- a/lib/fleet/canary-provision.js
+++ b/lib/fleet/canary-provision.js
@@ -25,8 +25,15 @@ import { loadDesiredSlots } from './desired-slots-store.js';
 import { resolveCanaryTarget, assertCanaryTarget } from './canary-guard.js';
 import { spawn as spawnControlSpawn } from './spawn-control.js';
 
+import { CANARY_CALLSIGN_PREFIX } from './startup-prompt-selection.js';
+
 const CANARY_PROFILE = 'canary';
-const CANARY_CALLSIGN_PREFIX = 'Canary-';
+
+// FR-4: the PREFIX is shared; assessCanarySlotNaming below is deliberately NOT folded into the
+// shared classifier. It answers a different question — "is this canary SLOT named correctly",
+// where the slot is already known to be a canary — so a name like "Charlie" is a misconfiguration
+// to it and a valid kind:'worker' to the classifier. Merging them would conflate the two and drop
+// its reason codes. Share the prefix, not the predicate.
 
 /**
  * Pick the enabled canary slot from the desired-slots manifest. Pure.

--- a/lib/fleet/reboot-respawn-runner.js
+++ b/lib/fleet/reboot-respawn-runner.js
@@ -43,9 +43,18 @@ async function defaultLogFn(supabase, event) {
  * nothing to do: it registers, heartbeats once, and exits (ghost), which is precisely what made the
  * respawn leg unverifiable post-hoc. Single source of truth — never re-author the prompt text here.
  */
-async function defaultStartupPrompt() {
+async function defaultStartupPrompt(callsign, logFn) {
   const { FLEET_WORKER_STARTUP_PROMPT } = await import('../coordinator/coordination-events.cjs');
-  return FLEET_WORKER_STARTUP_PROMPT;
+  const { resolveStartupPromptForCallsign } = await import('./startup-prompt-selection.js');
+  // SD-...-PROMPT-LIBRARY-001-D FR-3: keyed on the CALLSIGN NAMESPACE, so a canary can never be
+  // handed the claiming-worker directive. Canary + unidentifiable resolve to null (no prompt) until
+  // the canary prompt exists — see resolveStartupPromptForCallsign's header.
+  const { prompt } = resolveStartupPromptForCallsign(callsign, {
+    workerPrompt: FLEET_WORKER_STARTUP_PROMPT,
+    canaryPrompt: null, // FR-8 outstanding: no canary constant exists yet
+    logFn: logFn || (() => {}),
+  });
+  return prompt;
 }
 
 function defaultSleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
@@ -150,9 +159,20 @@ export async function runRebootRespawn(opts = {}) {
     now = () => new Date().toISOString(),
   } = opts;
   const live = opts.live ?? isLiveEnabled();
-  // QF-20260724-290: resolve ONCE per run, not per slot. Explicit-key check (not `??`) so a caller can
-  // pass startupPrompt:null to deliberately respawn without a keepalive; absent means "use canonical".
-  const startupPrompt = ('startupPrompt' in opts) ? opts.startupPrompt : await defaultStartupPrompt();
+  // SD-...-PROMPT-LIBRARY-001-D FR-3a — RESOLUTION MOVED INSIDE THE PER-SLOT LOOP. The previous
+  // comment here said "resolve ONCE per run, not per slot" (QF-20260724-290). That was correct while
+  // every slot got the same worker prompt; it is WRONG now that the prompt is keyed on the CALLSIGN
+  // NAMESPACE, because no callsign is in scope at this point — the loop below binds it at `slot.name`.
+  //
+  // THIS IS THE HIGHEST-RISK LINE IN THE SD. fleet_desired_slots currently holds exactly ONE row,
+  // Canary-pilot, so this runner is the ONLY path the fleet ever respawns. Hoisting the resolution
+  // back out of the loop silently hands that canary the claiming-worker directive while every other
+  // test stays green. See the mixed-namespace roster test that pins this.
+  //
+  // The explicit-key opt-out is PRESERVED: a caller passing startupPrompt (including null) still
+  // overrides for every slot, unchanged. Only the DEFAULT path became per-slot.
+  const startupPromptOverridden = 'startupPrompt' in opts;
+  const startupPromptOverride = startupPromptOverridden ? opts.startupPrompt : undefined;
 
   const slots = await loadFn(supabase);
   const roster = rosterFn(slots);
@@ -171,6 +191,11 @@ export async function runRebootRespawn(opts = {}) {
       try { profileDir = resolveProfileDirFn(slot.account_profile, opts); }
       catch (e) { log(`[reboot-respawn] profile resolve failed for ${callsign} (${slot.account_profile}): ${e && e.message}`); profileDir = null; }
     }
+
+    // FR-3a: resolve the prompt HERE, where `callsign` is finally in scope.
+    const startupPrompt = startupPromptOverridden
+      ? startupPromptOverride
+      : await defaultStartupPrompt(callsign, log);
 
     // FR-3: forward opts so the minted --session-id is injectable (uuidFn) rather than only
     // reachable via crypto.randomUUID inside the builder.

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -39,18 +39,18 @@ export const SESSION_BIND_MAX_ATTEMPTS = 20;
 export const SESSION_BIND_DELAY_MS = 500;
 
 /**
- * Canary namespace, duplicated from canary-guard.js's CANARY_CALLSIGN_PREFIX / CANARY_PROFILE ON
- * PURPOSE: canary-guard.js imports stop/restart/relaunchUnderProfile from THIS module, so importing
- * it back would be a cycle. Duplication risks drift, so a test asserts these agree with the canonical
- * constants -- the drift is caught rather than merely hoped against.
+ * CANARY_PROFILE stays duplicated from canary-guard.js ON PURPOSE: canary-guard.js imports
+ * stop/restart/relaunchUnderProfile from THIS module, so importing it back would be a cycle. A test
+ * asserts the two agree, so the drift is caught rather than merely hoped against.
+ *
+ * FR-4: the CALLSIGN prefix and its predicate no longer need that treatment. Both now come from
+ * startup-prompt-selection.js, which imports nothing and therefore cannot close the cycle — one
+ * real source instead of a copy plus a drift test. Re-exported here so existing importers of
+ * spawn-control's CANARY_CALLSIGN_PREFIX keep working unchanged.
  */
 export const CANARY_PROFILE = 'canary';
-export const CANARY_CALLSIGN_PREFIX = 'Canary-';
-
-/** True only for a callsign in the canary-only namespace. Mirrors canary-guard.js isCanaryCallsign. */
-function isCanaryNamespaceCallsign(callsign) {
-  return typeof callsign === 'string' && callsign.startsWith(CANARY_CALLSIGN_PREFIX);
-}
+export { CANARY_CALLSIGN_PREFIX } from './startup-prompt-selection.js';
+import { isCanaryCallsign as isCanaryNamespaceCallsign } from './startup-prompt-selection.js';
 const PROFILE_NAME_RE = /^[A-Za-z0-9_-]+$/;
 
 /** Derive a session's role from its metadata (mirrors coordination-events.cjs's own convention). */

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -99,10 +99,15 @@ export function isLiveEnabled(env = process.env) {
  * lives here anymore. `resumeUuid` still reattaches a captured session; `profileDir` is pre-resolved
  * by spawn() and passed through; the returned invocation additionally carries `cwd`+`persistent`.
  *
- * QF-20260724-290: `startupPrompt` is forwarded too. buildSessionLaunch has always destructured it
- * (and sets childEnv.FLEET_WORKER_STARTUP_PROMPT — the persistent replacement for headless -p), but
- * this hop did not, so a caller-supplied keepalive prompt was silently DISCARDED here and the launched
- * session came up with nothing to do: it heartbeat once and ghosted.
+ * QF-20260724-290: `startupPrompt` is forwarded too, because this hop used not to destructure it at
+ * all and silently DISCARDED a caller-supplied keepalive.
+ *
+ * FR-2 CORRECTION — that QF did not actually fix the ghosting it describes. It made this hop pass
+ * the prompt down to buildSessionLaunch, which wrote it to a `FLEET_WORKER_STARTUP_PROMPT` child
+ * env var said to be seeded by a SessionStart hook. No such hook exists and nothing ever read that
+ * variable (verified repo-wide), so the prompt was still discarded — one hop further along, and now
+ * invisibly. The env carrier is deleted; the prompt has NO delivery path until FR-1 lands the
+ * single-line pointer transport. Forwarding it here is still correct: FR-1 consumes it.
  */
 export function buildLiveSpawnInvocation({ role, callsign, profileDir, resumeUuid, cwd, sdToResume, startupPrompt, sessionId } = {}, opts = {}) {
   // FR-3: sessionId/uuidFn forwarded so the minted id is injectable (deterministic tests) rather

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -120,9 +120,26 @@ export function buildLiveSpawnInvocation({ role, callsign, profileDir, resumeUui
  * helper of the same name. Lazy dynamic import keeps this ESM module free of a load-time dependency
  * on the .cjs coordination-events surface (same idiom as the respawn runner).
  */
-async function defaultStartupPrompt() {
+async function defaultStartupPrompt(callsign, logFn) {
   const { FLEET_WORKER_STARTUP_PROMPT } = await import('../coordinator/coordination-events.cjs');
-  return FLEET_WORKER_STARTUP_PROMPT;
+  const { resolveStartupPromptForCallsign } = await import('./startup-prompt-selection.js');
+  // SD-...-PROMPT-LIBRARY-001-D FR-3 — SELECTION IS KEYED ON THE CALLSIGN NAMESPACE.
+  //
+  // THIS IS THE SECOND OF THE TWO COPIES, AND MISSING IT ARMED THE EXACT HAZARD THIS SD EXISTS TO
+  // PREVENT. It took no callsign and returned the worker directive UNCONDITIONALLY, so every canary
+  // spawned through spawn() was handed the claiming-worker prompt. That was harmless only while
+  // nothing was delivered; the moment FR-1's pointer transport worked, it began delivering cleanly
+  // — measured at the consumer: 1406 bytes, first line "/loop You are an autonomous LEO fleet
+  // worker...". Fixing the runner alone was not fixing FR-3.
+  //
+  // Canary and unidentifiable resolve to null (no prompt, so the session ghosts) until a canary
+  // prompt exists. Never fall through to the worker directive — see the resolver's header.
+  const { prompt } = resolveStartupPromptForCallsign(callsign, {
+    workerPrompt: FLEET_WORKER_STARTUP_PROMPT,
+    canaryPrompt: null, // outstanding: no canary constant exists yet (chairman-authored content)
+    logFn: logFn || (() => {}),
+  });
+  return prompt;
 }
 
 /**
@@ -165,7 +182,7 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
   // with no startupPrompt at all, so every session created through the generic spawn verb came up
   // with nothing to do, heartbeat once, and ghosted. Same opt-out semantics as the respawn runner
   // (reboot-respawn-runner.js:137): absent => canonical prompt, explicit null => deliberately none.
-  const startupPrompt = ('startupPrompt' in opts) ? opts.startupPrompt : await defaultStartupPrompt();
+  const startupPrompt = ('startupPrompt' in opts) ? opts.startupPrompt : await defaultStartupPrompt(callsign, log);
 
   // ADVERSARIAL-REVIEW NOTE (known, accepted limitation): this dedup check reads liveCallsigns at a
   // point in time with no reservation/lock written before the OS spawn -- two near-simultaneous calls

--- a/lib/fleet/startup-prompt-pointer.cjs
+++ b/lib/fleet/startup-prompt-pointer.cjs
@@ -1,0 +1,123 @@
+// SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-D FR-1 — POINTER-FILE STARTUP TRANSPORT.
+//
+// THE PROBLEM THIS SOLVES, MEASURED NOT ASSUMED. claude.cmd is a BATCH file, so cmd.exe is
+// unavoidable in the launch chain, and cmd.exe TERMINATES A MULTI-LINE ARGUMENT AT THE FIRST LF.
+// Measured from a live canary transcript: 97 characters / 1 line delivered against a 958-char,
+// 6-line constant. The worker directive degraded to a /loop with ZERO steps, after which every
+// worker falls back to CLAUDE.md and starts claiming DRAFT SDs unattended, fleet-wide.
+//
+// WHY A POINTER AND NOT A BIGGER/ESCAPED ARGUMENT (metadata.transport_decision): wt.exe is also in
+// the chain (`wt.exe -w new new-tab -d <dir> -- <cmd> <args>`) and re-parses the commandline.
+// Direct-CLI removes one KNOWN truncator and leaves a second UNVERIFIED one. A single-line pointer
+// is immune BY CONSTRUCTION to every layer — cmd.exe, wt.exe, and any future shim.
+//
+// BOTH HOPS ARE NOW MEASURED (metadata.fr1_transport_hops_measured), because "immune by
+// construction" is a prediction until someone runs it:
+//   HOP A: a single-line positional arrives BYTE-INTACT through the real wt.exe -> cmd.exe chain.
+//          Control arm: the same probe with a 3-line payload delivered only its first line, so the
+//          probe could have said otherwise and it reproduces the original defect independently.
+//   HOP B: Claude Code, given "Read the file X ... and follow it", READS the file and ACTS on its
+//          contents — verified with a token that existed only inside the file, never in the prompt.
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+/** Pointer files live beside the other per-session spawn artifacts. Gitignored — see .gitignore. */
+const PROMPT_DIR_REL = path.join('.claude', 'fleet-prompts');
+
+/** Keep the N newest files, mirroring capture-session-id.cjs's retain-by-mtime sweep. */
+const RETAIN_NEWEST = 5;
+
+/**
+ * MINIMUM AGE BEFORE A FILE IS ELIGIBLE FOR SWEEPING — this is NOT belt-and-braces, it is load
+ * bearing, and retain-N ALONE IS UNSAFE HERE. The session-identity precedent sweeps markers written
+ * by a session that has ALREADY started. A pointer file is the opposite: it is written BEFORE the
+ * session exists and is read at its first turn, so there is a live window where the file must
+ * survive. With a fleet of several workers, more than RETAIN_NEWEST spawns can easily occur inside
+ * that window, and a pure retain-N sweep would delete a pending session's pointer out from under
+ * it — producing exactly the dangling pointer this module exists to make safe.
+ */
+const MIN_SWEEP_AGE_MS = 15 * 60 * 1000;
+
+/**
+ * Build the SINGLE-LINE pointer that becomes the launcher's trailing positional.
+ *
+ * Two things are deliberate:
+ *  1. It is ONE LINE. assertSingleLinePrompt is applied to the result by the caller so this can
+ *     never silently regress into a multi-line value.
+ *  2. IT CARRIES ITS OWN DANGLING-POINTER INSTRUCTION. If the file is missing, the session is told
+ *     to IDLE rather than improvise. That direction matters: a session that improvises without its
+ *     directive falls back to CLAUDE.md and starts claiming work — the exact fleet-wide hazard.
+ *     Failing toward "do nothing" is always recoverable; failing toward "claim something" is not.
+ */
+function buildPointerLine(promptFilePath) {
+  const p = String(promptFilePath).replace(/\\/g, '/');
+  return `Read the file ${p} and follow the instructions in it exactly — it is your startup directive. `
+    + 'If that file does not exist or is empty, do NOT improvise, do NOT read other instructions, and do '
+    + 'NOT claim or start any work: report that the startup directive was missing and remain idle.';
+}
+
+/**
+ * Write a session's startup prompt to its own pointer file.
+ * @param {{repoRoot:string, sessionId:string, prompt:string}} spec
+ * @returns {{promptFilePath:string, pointerLine:string}}
+ */
+function writeStartupPromptFile({ repoRoot, sessionId, prompt }) {
+  if (typeof prompt !== 'string' || prompt.length === 0) {
+    throw new Error('writeStartupPromptFile: prompt must be a non-empty string');
+  }
+  if (!sessionId || !/^[A-Za-z0-9._-]+$/.test(String(sessionId))) {
+    // Guards path traversal: the id becomes a filename and is minted spawner-side, so a malformed
+    // one is a bug worth failing on rather than sanitising into something silently different.
+    throw new Error(`writeStartupPromptFile: unsafe sessionId ${JSON.stringify(sessionId)}`);
+  }
+
+  const dir = path.join(repoRoot, PROMPT_DIR_REL);
+  fs.mkdirSync(dir, { recursive: true });
+  const promptFilePath = path.join(dir, `${sessionId}.txt`);
+  fs.writeFileSync(promptFilePath, prompt, 'utf8');
+
+  // VERIFY THE WRITE LANDED before handing out a pointer to it. A pointer to a file that was never
+  // written is precisely the dangling case, and it is cheap to rule out here rather than discover
+  // it in a spawned session's first turn.
+  if (!fs.existsSync(promptFilePath)) {
+    throw new Error(`writeStartupPromptFile: wrote ${promptFilePath} but it does not exist`);
+  }
+  return { promptFilePath, pointerLine: buildPointerLine(promptFilePath) };
+}
+
+/**
+ * Delete stale pointer files. Best-effort and never throws: a failed sweep must not fail a spawn.
+ * @returns {{deleted:string[], kept:number}}
+ */
+function sweepStartupPromptFiles({ repoRoot, now = Date.now(), retain = RETAIN_NEWEST, minAgeMs = MIN_SWEEP_AGE_MS } = {}) {
+  const dir = path.join(repoRoot, PROMPT_DIR_REL);
+  const deleted = [];
+  let entries = [];
+  try {
+    entries = fs.readdirSync(dir)
+      .filter((f) => f.endsWith('.txt'))
+      .map((f) => ({ name: f, mtime: fs.statSync(path.join(dir, f)).mtimeMs }))
+      .sort((a, b) => b.mtime - a.mtime);
+  } catch {
+    return { deleted, kept: 0 }; // no dir yet — nothing to sweep
+  }
+
+  entries.forEach((e, i) => {
+    // BOTH conditions required. Older-than-retain alone would delete a pending session's pointer.
+    if (i < retain) return;
+    if (now - e.mtime < minAgeMs) return;
+    try { fs.unlinkSync(path.join(dir, e.name)); deleted.push(e.name); } catch { /* best effort */ }
+  });
+  return { deleted, kept: entries.length - deleted.length };
+}
+
+module.exports = {
+  buildPointerLine,
+  writeStartupPromptFile,
+  sweepStartupPromptFiles,
+  PROMPT_DIR_REL,
+  RETAIN_NEWEST,
+  MIN_SWEEP_AGE_MS,
+};

--- a/lib/fleet/startup-prompt-selection.js
+++ b/lib/fleet/startup-prompt-selection.js
@@ -1,0 +1,113 @@
+// SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-D — startup-prompt selection + the newline
+// tripwire. Pure module: no IO, no spawn, no DB. Both prompt-decision helpers call INTO this.
+//
+// WHY THIS MODULE EXISTS SEPARATELY FROM THE LAUNCH BUILDER: assertLaunchContract
+// (build-session-launch.cjs:157) has ZERO production callers — verified — so a tripwire placed
+// there ships INERT, a tripwire in dead code. Everything here is reachable from all THREE
+// prompt-decision sites (spawn-control.js:163, reboot-respawn-runner.js:155,
+// scripts/fleet/worker-spawn-executor.cjs:154), which is the only way it can actually fire.
+
+/** The canary-only callsign namespace. Mirrors CANARY_CALLSIGN_PREFIX in spawn-control.js:48,
+ *  canary-guard.js:27 and canary-provision.js:29 — four declarations exist and have drifted;
+ *  consolidation is tracked separately so this module does not import across a cycle. */
+export const CANARY_CALLSIGN_PREFIX = 'Canary-';
+
+/**
+ * THREE-ARM classification of a session by CALLSIGN NAMESPACE.
+ *
+ * ────────────────────────────────────────────────────────────────────────────────────────────
+ * READ THIS BEFORE SIMPLIFYING TO A BOOLEAN. The two-arm version looks cleaner and IS THE BUG.
+ *
+ * A boolean returns FALSE for a session that cannot be identified at all — and false means
+ * "not a canary", which hands that session the CLAIMING WORKER directive. So the fallthrough
+ * direction is the DANGEROUS one: an unidentifiable session does not idle, it starts claiming
+ * DRAFT SDs unattended. That is the exact fleet-wide hazard this SD exists to prevent, and it
+ * is invisible in a boolean because both "definitely a worker" and "no idea what this is"
+ * collapse to the same value.
+ *
+ * Hence three arms, and hence 'unidentifiable' must FAIL LOUD at the call site rather than
+ * defaulting. A later reviewer collapsing this back to Boolean(...) reintroduces the hazard
+ * silently — this comment is the only thing standing in the way.
+ *
+ * Precedent: assessCanarySlotNaming (canary-provision.js:56-63) already returns three outcomes
+ * and is the RICHEST of the four existing copies; the other two are byte-identical two-arm
+ * booleans. Note that its own caller at :143 does `if (naming.ok)`, which collapses the three
+ * back to two — so having the shape is not enough, the CALLER must honour it.
+ * ────────────────────────────────────────────────────────────────────────────────────────────
+ *
+ * @param {unknown} callsign
+ * @returns {{kind:'canary'|'worker'|'unidentifiable', callsign: (string|null)}}
+ */
+export function classifySessionByCallsign(callsign) {
+  if (typeof callsign !== 'string' || callsign.trim() === '') {
+    return { kind: 'unidentifiable', callsign: null };
+  }
+  const trimmed = callsign.trim();
+  if (trimmed.startsWith(CANARY_CALLSIGN_PREFIX)) return { kind: 'canary', callsign: trimmed };
+  return { kind: 'worker', callsign: trimmed };
+}
+
+/** Derived boolean, for call sites that genuinely only need the canary test. DERIVED FROM the
+ *  three-outcome shape, never the reverse — see the header. Deliberately does NOT accept
+ *  'unidentifiable' as a canary, so it is unsafe to use for the prompt DECISION; use
+ *  classifySessionByCallsign there and handle all three arms. */
+export function isCanaryCallsign(callsign) {
+  return classifySessionByCallsign(callsign).kind === 'canary';
+}
+
+/** Thrown by assertSingleLinePrompt. Named so callers can distinguish it from an IO failure. */
+export class MultilinePromptError extends Error {
+  constructor(message, details) {
+    super(message);
+    this.name = 'MultilinePromptError';
+    this.details = details;
+  }
+}
+
+/**
+ * THE NEWLINE TRIPWIRE — the most-wanted deliverable of this SD.
+ *
+ * FAILS LOUD if a prompt destined for the launcher's trailing positional contains a newline.
+ *
+ * WHY: claude.cmd is a BATCH file, so cmd.exe is unavoidable in the chain, and cmd.exe
+ * TERMINATES A MULTI-LINE ARGUMENT AT THE FIRST LF. Measured on the live constant:
+ * FLEET_WORKER_STARTUP_PROMPT is 1406 chars / 8 lines, its first line is 85 chars, so 94% is
+ * discarded in transit and the worker directive degrades to a /loop with ZERO steps — after
+ * which every worker falls back to CLAUDE.md and starts claiming DRAFT SDs, unattended and
+ * fleet-wide. wt.exe is also in the chain and re-parses the commandline; nobody has verified it
+ * preserves embedded newlines either.
+ *
+ * This throws rather than returning a verdict deliberately: the sibling contract checker
+ * returns {ok, violations} and has no production callers, so a soft verdict here would be
+ * discarded exactly like that one is. A hard failure at spawn time is recoverable; a silently
+ * truncated fleet directive is not.
+ *
+ * @param {string} prompt
+ * @param {{ where?: string }} [ctx] call-site label, surfaced in the error
+ * @returns {string} the prompt, unchanged, when it is safe
+ */
+export function assertSingleLinePrompt(prompt, ctx = {}) {
+  const where = ctx.where || 'unknown call site';
+  if (typeof prompt !== 'string') {
+    throw new MultilinePromptError(
+      `startup prompt must be a string before it reaches the launcher positional (${where}); got ${typeof prompt}`,
+      { where, type: typeof prompt },
+    );
+  }
+  const idx = prompt.search(/[\r\n]/);
+  if (idx !== -1) {
+    const lines = prompt.split(/\r\n|\r|\n/);
+    throw new MultilinePromptError(
+      `startup prompt contains a newline at index ${idx} and would be TRUNCATED BY cmd.exe at the first LF `
+      + `(${where}): ${prompt.length} chars / ${lines.length} lines would deliver only ${lines[0].length} chars. `
+      + 'Pass a single-line pointer instead of the multi-line prompt.',
+      { where, index: idx, totalChars: prompt.length, totalLines: lines.length, deliveredChars: lines[0].length },
+    );
+  }
+  return prompt;
+}
+
+export default {
+  classifySessionByCallsign, isCanaryCallsign, assertSingleLinePrompt,
+  MultilinePromptError, CANARY_CALLSIGN_PREFIX,
+};

--- a/lib/fleet/startup-prompt-selection.js
+++ b/lib/fleet/startup-prompt-selection.js
@@ -144,6 +144,30 @@ export function resolveStartupPromptForCallsign(callsign, prompts) {
   const { canaryPrompt = null, workerPrompt, logFn = console.warn } = prompts || {};
   const { kind } = classifySessionByCallsign(callsign);
 
+  // SEC-1 — CASE-INSENSITIVE DENY, AND IT APPLIES HERE AND ONLY HERE.
+  //
+  // classifySessionByCallsign matches 'Canary-' EXACTLY, which is correct for TARGETING: a kill
+  // surface or a drill target must not over-match. It is WRONG for this decision, because here the
+  // two directions have opposite blast radius — exactly the asymmetry documented on isCanaryCallsign
+  // in canary-guard.js, which I applied to the unidentifiable arm and missed for case.
+  //
+  // Measured by the SECURITY review at all three sites, with a control arm: 'canary-pilot' and
+  // 'CANARY-pilot' each received the FULL 1406-byte claiming-worker directive. A one-character typo
+  // in a fleet_desired_slots name reaches it, and assessCanarySlotNaming is deliberately fail-open,
+  // so a misnamed canary still spawns. Before this SD nothing was delivered and that was harmless;
+  // now delivery works.
+  //
+  // Targeting says "is this exactly a canary?" — over-matching there breaks drills.
+  // This says "could this be a canary?" — UNDER-matching here hands a canary the claiming directive.
+  // So deny broadly. A worker legitimately named 'canary-something' losing its prompt is a session
+  // that idles; the inverse is an unattended session that claims work.
+  if (kind === 'worker' && /^canary-/i.test(String(callsign).trim())) {
+    logFn(`[startup-prompt] callsign ${JSON.stringify(String(callsign))} is in the canary namespace `
+      + 'by case-insensitive match but not the exact prefix. DENYING the worker directive: a misnamed '
+      + 'canary must never be able to claim work. Fix the slot name to the exact "Canary-" prefix.');
+    return { prompt: null, kind: 'canary', reason: 'canary_namespace_case_mismatch' };
+  }
+
   if (kind === 'worker') return { prompt: workerPrompt, kind, reason: null };
 
   if (kind === 'canary') {

--- a/lib/fleet/startup-prompt-selection.js
+++ b/lib/fleet/startup-prompt-selection.js
@@ -29,10 +29,19 @@ export const CANARY_CALLSIGN_PREFIX = 'Canary-';
  * defaulting. A later reviewer collapsing this back to Boolean(...) reintroduces the hazard
  * silently — this comment is the only thing standing in the way.
  *
- * Precedent: assessCanarySlotNaming (canary-provision.js:56-63) already returns three outcomes
- * and is the RICHEST of the four existing copies; the other two are byte-identical two-arm
- * booleans. Note that its own caller at :143 does `if (naming.ok)`, which collapses the three
- * back to two — so having the shape is not enough, the CALLER must honour it.
+ * Precedent: assessCanarySlotNaming (canary-provision.js:56) already returns a reasoned verdict
+ * and is the RICHEST of the existing variants; the other two are byte-identical two-arm booleans.
+ *
+ * CORRECTION to an earlier note here, which claimed that function's caller "collapses the three
+ * back to two". It does branch on `naming.ok`, but it interpolates `naming.reason` into the
+ * warning it logs, so no information is lost — the caller DOES honour the richer shape.
+ *
+ * AND assessCanarySlotNaming IS NOT A DRIFTED COPY OF THIS FUNCTION — do not merge them. It asks
+ * a different question in a different context: "is this CANARY SLOT named correctly", where the
+ * slot is already known to be a canary. So "Charlie" is a MISCONFIGURATION to it and a perfectly
+ * valid kind:'worker' here. Folding it into this classifier would conflate the two questions and
+ * discard its slot-naming reason codes — consolidating toward the POORER contract, the exact
+ * failure mode the consolidation was meant to avoid. Share the PREFIX, not the predicate.
  * ────────────────────────────────────────────────────────────────────────────────────────────
  *
  * @param {unknown} callsign

--- a/lib/fleet/startup-prompt-selection.js
+++ b/lib/fleet/startup-prompt-selection.js
@@ -107,7 +107,53 @@ export function assertSingleLinePrompt(prompt, ctx = {}) {
   return prompt;
 }
 
+/**
+ * Resolve WHICH startup prompt a session should receive, keyed on the CALLSIGN NAMESPACE.
+ *
+ * SELECTION IS BY CALLSIGN, deliberately — NOT by role and NOT by account_profile:
+ *   - role: canaries ARE role='worker', so role-keying hands every canary the worker directive.
+ *     That is the trap this SD exists to close.
+ *   - account_profile: absent on the bypass paths, and the stamp lands up to 10s after launch
+ *     while a measured spawn registered at ~3s — the prompt fires AT registration, so the
+ *     discriminator would not exist yet.
+ * The callsign namespace is the only discriminator present on every path BEFORE launch.
+ *
+ * INTERIM BEHAVIOUR WHILE FR-8 IS OUTSTANDING — READ BEFORE "FIXING" THIS.
+ * No canary startup prompt exists in the repo yet (verified: no CANARY_STARTUP_PROMPT /
+ * FLEET_CANARY_PROMPT constant anywhere); authoring its CONTENT is a chairman decision, not an
+ * implementer's. Until it lands, a canary or an unidentifiable session resolves to NULL — i.e.
+ * it receives NO prompt and ghosts, which is exactly today's behaviour and is SAFE.
+ * It must NEVER fall through to the worker prompt: that is the fleet-wide hazard (a canary that
+ * self-claims DRAFT SDs unattended). Returning null preserves the safe status quo rather than
+ * arming the hazard early, and the loud log makes the gap visible instead of silent.
+ *
+ * @param {unknown} callsign
+ * @param {{ canaryPrompt?: (string|null), workerPrompt: string, logFn?: Function }} prompts
+ * @returns {{ prompt: (string|null), kind: string, reason: (string|null) }}
+ */
+export function resolveStartupPromptForCallsign(callsign, prompts) {
+  const { canaryPrompt = null, workerPrompt, logFn = console.warn } = prompts || {};
+  const { kind } = classifySessionByCallsign(callsign);
+
+  if (kind === 'worker') return { prompt: workerPrompt, kind, reason: null };
+
+  if (kind === 'canary') {
+    if (typeof canaryPrompt === 'string' && canaryPrompt.length > 0) {
+      return { prompt: canaryPrompt, kind, reason: null };
+    }
+    logFn(`[startup-prompt] canary ${String(callsign)} gets NO prompt: no canary prompt exists yet (FR-8). `
+      + 'Deliberately NOT falling back to the worker directive — that would make the canary self-claim.');
+    return { prompt: null, kind, reason: 'no_canary_prompt_available' };
+  }
+
+  // UNIDENTIFIABLE — the arm a boolean predicate silently maps to "worker". Fail loud, deliver
+  // nothing. An unidentified session that receives the worker directive starts claiming work.
+  logFn('[startup-prompt] UNIDENTIFIABLE session (no usable callsign) gets NO prompt. '
+    + 'Refusing to default to the worker directive; an unidentified session must not claim work.');
+  return { prompt: null, kind, reason: 'unidentifiable_session' };
+}
+
 export default {
   classifySessionByCallsign, isCanaryCallsign, assertSingleLinePrompt,
-  MultilinePromptError, CANARY_CALLSIGN_PREFIX,
+  resolveStartupPromptForCallsign, MultilinePromptError, CANARY_CALLSIGN_PREFIX,
 };

--- a/scripts/fleet/worker-spawn-executor.cjs
+++ b/scripts/fleet/worker-spawn-executor.cjs
@@ -42,8 +42,12 @@ function isLiveEnabled(env = process.env) {
 // SD-LEO-INFRA-LEO-APP-LAUNCHER-001 (FR-2): delegate to THE canonical buildSessionLaunch so worker
 // revival uses the SAME launch contract as every other path — a PERSISTENT wt.exe session (NOT the
 // old headless `claude -p`, which does not reliably register/persist in claude_sessions) with the full
-// claude.cmd path + explicit repo-root cwd + fail-loud. The /loop startup prompt is carried in the
-// child env (FLEET_WORKER_STARTUP_PROMPT) for the SessionStart hook to seed into the persistent session.
+// claude.cmd path + explicit repo-root cwd + fail-loud.
+//
+// FR-2: the /loop startup prompt used to be described as "carried in the child env
+// (FLEET_WORKER_STARTUP_PROMPT) for the SessionStart hook to seed". There is no such hook and no
+// reader of that variable anywhere in the repo, so the prompt was never delivered — which is why
+// executor-spawned sessions came up idle. The carrier is deleted; FR-1 supplies the real transport.
 const { buildSessionLaunch } = require('../../lib/fleet/build-session-launch.cjs');
 function buildSpawnInvocation(callsign, prompt) {
   return buildSessionLaunch({ callsign, startupPrompt: prompt });

--- a/scripts/fleet/worker-spawn-executor.cjs
+++ b/scripts/fleet/worker-spawn-executor.cjs
@@ -86,7 +86,21 @@ async function runExecutor(o) {
   let spawned = 0;
   let errors = 0;
   for (const req of decisions.toSpawn) {
-    const invocation = buildSpawnInvocation(req.requested_callsign, o.prompt);
+    // SD-...-PROMPT-LIBRARY-001-D FR-3, THIRD PROMPT-DECISION SITE. o.prompt is a SINGLE prompt
+    // resolved once for the whole executor run and previously applied to every request regardless
+    // of callsign — the same hoist shape as the respawn runner, and equally wrong once the prompt
+    // is keyed on the callsign namespace. The callsign is right here on the request, so resolve
+    // per request: a canary must never receive the claiming-worker directive.
+    const { resolveStartupPromptForCallsign } = require('../../lib/fleet/startup-prompt-selection.js');
+    const { prompt: perCallsignPrompt } = resolveStartupPromptForCallsign(req.requested_callsign, {
+      workerPrompt: o.prompt,
+      canaryPrompt: null, // outstanding: no canary constant exists yet (chairman-authored content)
+      logFn: log,
+    });
+    // Seam, matching the sibling spawners (reboot-respawn-runner's buildInvocationFn): lets this
+    // decision site be asserted without a real launch. Defaults to the production builder.
+    const buildFn = o.buildInvocationFn || buildSpawnInvocation;
+    const invocation = buildFn(req.requested_callsign, perCallsignPrompt);
     if (!o.live) {
       log(`[spawn-exec] DRY-RUN would spawn ${req.requested_callsign} (${req.id}): ${invocation.program} ${(invocation.args || []).join(' ').slice(0, 40)}… — row left pending (set WORKER_SPAWN_EXECUTOR_LIVE=true after host-validation to enable)`);
       continue;

--- a/tests/unit/fleet/canary-never-gets-worker-directive.test.js
+++ b/tests/unit/fleet/canary-never-gets-worker-directive.test.js
@@ -1,0 +1,96 @@
+/**
+ * SD-...-PROMPT-LIBRARY-001-D — THE HAZARD TEST. One file, ALL THREE prompt-decision sites.
+ *
+ * WHY THIS FILE EXISTS. FR-3 required patching every site that decides which prompt a session
+ * receives. There are three (LEAD review): spawn-control.js, reboot-respawn-runner.js and
+ * scripts/fleet/worker-spawn-executor.cjs. They were patched ONE AT A TIME, and in between, a
+ * canary spawned through spawn() was handed the full claiming-worker directive — verified at the
+ * consumer by reading the delivered file: 1406 bytes, first line "/loop You are an autonomous LEO
+ * fleet worker...". That is the precise fleet-wide hazard the SD exists to prevent, and it was
+ * invisible because each site's own tests passed.
+ *
+ * Per-site tests could not catch it: each one only ever looked at its own site. So this asserts the
+ * INVARIANT ACROSS THE POPULATION — no site, on any path, may hand a canary the worker directive.
+ * Adding a fourth spawner without wiring it in should fail HERE.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+
+const require = createRequire(import.meta.url);
+const { FLEET_WORKER_STARTUP_PROMPT } = require('../../../lib/coordinator/coordination-events.cjs');
+
+/**
+ * Whether a prompt was resolved AT ALL for this invocation. `promptFilePath` is non-null exactly
+ * when a prompt was selected, so it is the discriminator — and unlike reading the delivered file it
+ * does not depend on the repo root existing. That matters: under vitest resolveRepoRoot points at
+ * `tests/fixtures/__no_such_tree__`, and buildSessionLaunch deliberately refuses to fabricate a
+ * missing start directory, so no file is written and a payload-reading assertion cannot see the
+ * worker arm at all. It would have reported "canary safe" for the trivial reason that NOBODY gets
+ * a prompt — a check that cannot fail in the direction that matters.
+ */
+const gotAPrompt = (invocation) => Boolean(invocation && invocation.promptFilePath);
+
+describe('CANARY MUST NEVER RECEIVE THE WORKER DIRECTIVE — all three prompt-decision sites', () => {
+  it('SITE 1 spawn-control.spawn()', async () => {
+    const { spawn } = await import('../../../lib/fleet/spawn-control.js');
+    const canary = await spawn({ role: 'worker', callsign: 'Canary-pilot' }, { live: false });
+    const worker = await spawn({ role: 'worker', callsign: 'Charlie' }, { live: false });
+
+    expect(gotAPrompt(canary.invocation), 'a canary must resolve to NO prompt').toBe(false);
+    // CONTROL ARM — without it this passes even if nobody ever receives a prompt, which is exactly
+    // how the original defect hid: every site's own tests were green.
+    expect(gotAPrompt(worker.invocation), 'a worker MUST still get one').toBe(true);
+    // And a canary must carry no positional at all, so nothing can be read from argv either.
+    expect(canary.invocation.args.some((a) => /Read the file/.test(String(a)))).toBe(false);
+    expect(worker.invocation.args.some((a) => /Read the file/.test(String(a)))).toBe(true);
+  });
+
+  it('SITE 2 reboot-respawn-runner', async () => {
+    const { runRebootRespawn } = await import('../../../lib/fleet/reboot-respawn-runner.js');
+    const seen = [];
+    await runRebootRespawn({
+      loadFn: async () => ([{ name: 'Canary-pilot', role: 'worker' }, { name: 'Charlie', role: 'worker' }]),
+      rosterFn: (s) => s.map((x) => x.name),
+      buildInvocationFn: ({ callsign, startupPrompt }) => {
+        seen.push({ callsign, startupPrompt });
+        return { program: 'wt.exe', args: [], env: {}, sessionId: 'sid' };
+      },
+      live: false, log: () => {}, logFn: () => {},
+    });
+    const canary = seen.find((s) => s.callsign === 'Canary-pilot');
+    const worker = seen.find((s) => s.callsign === 'Charlie');
+    expect(canary.startupPrompt).not.toBe(FLEET_WORKER_STARTUP_PROMPT);
+    expect(worker.startupPrompt).toBe(FLEET_WORKER_STARTUP_PROMPT); // control arm
+  });
+
+  it('SITE 3 worker-spawn-executor', async () => {
+    const { runExecutor } = require('../../../scripts/fleet/worker-spawn-executor.cjs');
+    const built = [];
+    await runExecutor({
+      // status:'pending' is REQUIRED — resolveSpawnDecisions skips anything else as 'not_pending',
+      // which silently emptied toSpawn and made the first version of this test vacuous.
+      pendingRequests: [
+        { id: 'r1', requested_callsign: 'Canary-pilot', status: 'pending', requested_at: new Date(0).toISOString() },
+        { id: 'r2', requested_callsign: 'Charlie', status: 'pending', requested_at: new Date(0).toISOString() },
+      ],
+      liveCallsigns: new Set(),
+      nowMs: 0,
+      perTickCap: 10,
+      live: false,
+      prompt: FLEET_WORKER_STARTUP_PROMPT,
+      log: () => {},
+      buildInvocationFn: (callsign, prompt) => { built.push({ callsign, prompt }); return { program: 'wt.exe', args: [] }; },
+      spawnFn: vi.fn(),
+      supabase: null,
+    });
+
+    // The executor resolves per request; a hoisted single prompt would give BOTH the directive.
+    const canary = built.find((b) => b.callsign === 'Canary-pilot');
+    const worker = built.find((b) => b.callsign === 'Charlie');
+    if (canary) expect(canary.prompt).not.toBe(FLEET_WORKER_STARTUP_PROMPT);
+    if (worker) expect(worker.prompt).toBe(FLEET_WORKER_STARTUP_PROMPT); // control arm
+    // Guard: if the executor skipped both requests this test would pass vacuously.
+    expect(built.length, 'executor built no invocations — assertions above were vacuous').toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/fleet/canary-never-gets-worker-directive.test.js
+++ b/tests/unit/fleet/canary-never-gets-worker-directive.test.js
@@ -31,6 +31,47 @@ const { FLEET_WORKER_STARTUP_PROMPT } = require('../../../lib/coordinator/coordi
  */
 const gotAPrompt = (invocation) => Boolean(invocation && invocation.promptFilePath);
 
+describe('ACCEPTANCE STEP 2 — PAYLOAD HOP: the FILE bytes, per callsign class', () => {
+  // smoke_test_steps step 2 asks for the bytes of the file the pointer names, not just that a
+  // prompt was selected. That needs a start dir that EXISTS (buildSessionLaunch refuses to
+  // fabricate one), so cwd is an explicit temp dir here rather than the vitest repo root, which
+  // resolves to tests/fixtures/__no_such_tree__.
+  const os = require('node:os');
+  const path = require('node:path');
+  const { buildSessionLaunch } = require('../../../lib/fleet/build-session-launch.cjs');
+  const { resolveStartupPromptForCallsign } = require('../../../lib/fleet/startup-prompt-selection.js');
+
+  const launchFor = (callsign) => {
+    const cwd = fs.mkdtempSync(path.join(os.tmpdir(), 'payload-'));
+    const { prompt } = resolveStartupPromptForCallsign(callsign, {
+      workerPrompt: FLEET_WORKER_STARTUP_PROMPT, canaryPrompt: null, logFn: () => {},
+    });
+    const inv = buildSessionLaunch({ role: 'worker', callsign, cwd, startupPrompt: prompt });
+    return { inv, prompt, cwd };
+  };
+
+  it('WORKER: the file on disk is BYTE-EQUAL to the source constant', () => {
+    const { inv } = launchFor('Charlie');
+    expect(inv.promptFilePath).toBeTruthy();
+    expect(fs.existsSync(inv.promptFilePath)).toBe(true);
+    expect(fs.readFileSync(inv.promptFilePath, 'utf8')).toBe(FLEET_WORKER_STARTUP_PROMPT);
+  });
+
+  it('CANARY: no prompt, no file — absence asserted explicitly, with the worker as control', () => {
+    const canary = launchFor('Canary-pilot');
+    expect(canary.prompt).toBeNull();
+    expect(canary.inv.promptFilePath).toBeNull();
+    // CONTROL: absence-because-nobody-got-anything must not be able to pass.
+    expect(launchFor('Charlie').prompt).toBe(FLEET_WORKER_STARTUP_PROMPT);
+  });
+
+  it('UNIDENTIFIABLE: no prompt, no file', () => {
+    const { inv, prompt } = launchFor('');
+    expect(prompt).toBeNull();
+    expect(inv.promptFilePath).toBeNull();
+  });
+});
+
 describe('CANARY MUST NEVER RECEIVE THE WORKER DIRECTIVE — all three prompt-decision sites', () => {
   it('SITE 1 spawn-control.spawn()', async () => {
     const { spawn } = await import('../../../lib/fleet/spawn-control.js');

--- a/tests/unit/fleet/canary-never-gets-worker-directive.test.js
+++ b/tests/unit/fleet/canary-never-gets-worker-directive.test.js
@@ -142,3 +142,38 @@ describe('CANARY MUST NEVER RECEIVE THE WORKER DIRECTIVE — all three prompt-de
     expect(worker.prompt).toBe(FLEET_WORKER_STARTUP_PROMPT); // control arm
   });
 });
+
+describe('F1 — the CHOKE POINT refuses, so a FOURTH spawner inherits the guarantee', () => {
+  // Every spawner routes through buildSessionLaunch, which receives both the callsign and the
+  // prompt. Before this, the invariant was enforced only by convention at the three call sites, and
+  // a PLAN verification probe called this function directly with a Canary- callsign and the worker
+  // directive: 1406 bytes written, byte-identical to the f060c6fb42b hazard. The three-site test
+  // above hardcodes three sites and would not have caught a fourth.
+  const { buildSessionLaunch } = require('../../../lib/fleet/build-session-launch.cjs');
+  const os = require('node:os');
+  const path = require('node:path');
+  const tmp = () => fs.mkdtempSync(path.join(os.tmpdir(), 'f1-'));
+
+  it('REFUSES a canary-namespace callsign carrying the worker directive', () => {
+    expect(() => buildSessionLaunch({
+      role: 'worker', callsign: 'Canary-pilot', cwd: tmp(), startupPrompt: FLEET_WORKER_STARTUP_PROMPT,
+    })).toThrow(/refusing to launch canary-namespace/);
+  });
+
+  it('catches the case-mismatched spelling too (SEC-1 parity at the choke point)', () => {
+    expect(() => buildSessionLaunch({
+      role: 'worker', callsign: 'canary-pilot', cwd: tmp(), startupPrompt: FLEET_WORKER_STARTUP_PROMPT,
+    })).toThrow(/refusing to launch canary-namespace/);
+  });
+
+  it('CONTROL: a worker with the directive still builds, and a canary with a NON-worker prompt still builds', () => {
+    // Without these the guard could be always-on and the test above would still pass.
+    expect(() => buildSessionLaunch({
+      role: 'worker', callsign: 'Charlie', cwd: tmp(), startupPrompt: FLEET_WORKER_STARTUP_PROMPT,
+    })).not.toThrow();
+    // The documented explicit-prompt opt-out is deliberately NOT broken for other payloads.
+    expect(() => buildSessionLaunch({
+      role: 'worker', callsign: 'Canary-pilot', cwd: tmp(), startupPrompt: 'some benign canary instruction',
+    })).not.toThrow();
+  });
+});

--- a/tests/unit/fleet/canary-never-gets-worker-directive.test.js
+++ b/tests/unit/fleet/canary-never-gets-worker-directive.test.js
@@ -126,12 +126,19 @@ describe('CANARY MUST NEVER RECEIVE THE WORKER DIRECTIVE — all three prompt-de
       supabase: null,
     });
 
+    // POPULATION ASSERTION FIRST, and it is not decoration. This previously read
+    //   if (canary) expect(canary.prompt).not.toBe(...)
+    // guarded by expect(built.length).toBeGreaterThan(0). A TESTING sub-agent mutation proved that
+    // vacuous: make the executor silently DROP every Canary- request and the test stayed GREEN —
+    // built.length is still 1 from the worker, so the guard passed while the canary assertion was
+    // skipped entirely. A conditional assertion plus a count guard is NOT a covered case.
+    // Asserting the exact built set makes a dropped canary a failure instead of a skip.
+    expect(built.map((b) => b.callsign).sort()).toEqual(['Canary-pilot', 'Charlie']);
+
     // The executor resolves per request; a hoisted single prompt would give BOTH the directive.
     const canary = built.find((b) => b.callsign === 'Canary-pilot');
     const worker = built.find((b) => b.callsign === 'Charlie');
-    if (canary) expect(canary.prompt).not.toBe(FLEET_WORKER_STARTUP_PROMPT);
-    if (worker) expect(worker.prompt).toBe(FLEET_WORKER_STARTUP_PROMPT); // control arm
-    // Guard: if the executor skipped both requests this test would pass vacuously.
-    expect(built.length, 'executor built no invocations — assertions above were vacuous').toBeGreaterThan(0);
+    expect(canary.prompt).not.toBe(FLEET_WORKER_STARTUP_PROMPT);
+    expect(worker.prompt).toBe(FLEET_WORKER_STARTUP_PROMPT); // control arm
   });
 });

--- a/tests/unit/fleet/reboot-respawn-per-slot-prompt.test.js
+++ b/tests/unit/fleet/reboot-respawn-per-slot-prompt.test.js
@@ -1,0 +1,95 @@
+/**
+ * SD-...-PROMPT-LIBRARY-001-D FR-3a — the prompt must resolve PER SLOT, not once per run.
+ *
+ * WHY THIS TEST EXISTS AND WHY THE ROSTER IS MIXED. reboot-respawn-runner used to resolve the
+ * startup prompt outside the per-slot loop, behind a comment reading "resolve ONCE per run, not
+ * per slot". That was correct when every slot got the same worker prompt and WRONG once the
+ * prompt is keyed on the callsign namespace — no callsign is in scope at the hoist point.
+ *
+ * fleet_desired_slots currently holds exactly ONE row (Canary-pilot), so this runner is the only
+ * path the fleet ever respawns. That makes the hoist the single highest-risk regression in the SD.
+ *
+ * CRITICALLY, A ONE-CANARY FIXTURE CANNOT CATCH IT: with a single slot, "resolve per slot" and a
+ * wrong "resolve once from slots[0]" produce IDENTICAL output. The roster below is therefore
+ * MIXED-NAMESPACE and asserted in BOTH orders, so a per-run resolution cannot pass by accident.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { runRebootRespawn } from '../../../lib/fleet/reboot-respawn-runner.js';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { FLEET_WORKER_STARTUP_PROMPT } = require('../../../lib/coordinator/coordination-events.cjs');
+
+/** Capture the startupPrompt each slot's invocation was built with. */
+function harness(slots) {
+  const seen = [];
+  return {
+    seen,
+    opts: {
+      loadFn: async () => slots,
+      rosterFn: (s) => s.map((x) => x.name),
+      buildInvocationFn: ({ callsign, startupPrompt }) => {
+        seen.push({ callsign, startupPrompt });
+        return { program: 'wt.exe', args: [], env: {}, sessionId: 'sid' };
+      },
+      live: false,
+      log: () => {},
+      logFn: () => {},
+    },
+  };
+}
+
+const MIXED = [
+  { name: 'Canary-pilot', role: 'worker', account_profile: 'canary' },
+  { name: 'Charlie', role: 'worker' },
+];
+
+describe('FR-3a — per-slot prompt resolution in reboot-respawn-runner', () => {
+  it('gives the WORKER slot the worker prompt and the CANARY slot NOT the worker prompt', async () => {
+    const h = harness(MIXED);
+    await runRebootRespawn(h.opts);
+
+    const canary = h.seen.find((s) => s.callsign === 'Canary-pilot');
+    const worker = h.seen.find((s) => s.callsign === 'Charlie');
+
+    expect(worker.startupPrompt).toBe(FLEET_WORKER_STARTUP_PROMPT);
+    // THE HAZARD THIS SD EXISTS TO PREVENT: a canary must never receive the claiming directive.
+    expect(canary.startupPrompt).not.toBe(FLEET_WORKER_STARTUP_PROMPT);
+    // FR-8 outstanding: no canary prompt exists yet, so the safe interim is NO prompt (ghost),
+    // which is today's behaviour — never a fallthrough to the worker directive.
+    expect(canary.startupPrompt).toBeNull();
+  });
+
+  it('holds with the roster order REVERSED — a per-run resolution would leak slots[0] to both', async () => {
+    const h = harness([...MIXED].reverse());
+    await runRebootRespawn(h.opts);
+
+    const canary = h.seen.find((s) => s.callsign === 'Canary-pilot');
+    const worker = h.seen.find((s) => s.callsign === 'Charlie');
+
+    expect(worker.startupPrompt).toBe(FLEET_WORKER_STARTUP_PROMPT);
+    expect(canary.startupPrompt).toBeNull();
+    // The two slots must differ. A hoisted resolution makes them identical in BOTH orders, which
+    // is precisely what a single-slot fixture cannot distinguish.
+    expect(worker.startupPrompt).not.toBe(canary.startupPrompt);
+  });
+
+  it('an UNIDENTIFIABLE slot gets no prompt rather than defaulting to the worker directive', async () => {
+    const h = harness([{ name: '', role: 'worker' }]);
+    await runRebootRespawn(h.opts);
+    expect(h.seen[0].startupPrompt).toBeNull();
+    expect(h.seen[0].startupPrompt).not.toBe(FLEET_WORKER_STARTUP_PROMPT);
+  });
+
+  it('PRESERVES the explicit-key opt-out: an explicit startupPrompt still overrides every slot', async () => {
+    const h = harness(MIXED);
+    await runRebootRespawn({ ...h.opts, startupPrompt: 'EXPLICIT' });
+    expect(h.seen.map((s) => s.startupPrompt)).toEqual(['EXPLICIT', 'EXPLICIT']);
+  });
+
+  it('PRESERVES explicit null (deliberate respawn with no keepalive)', async () => {
+    const h = harness(MIXED);
+    await runRebootRespawn({ ...h.opts, startupPrompt: null });
+    expect(h.seen.map((s) => s.startupPrompt)).toEqual([null, null]);
+  });
+});

--- a/tests/unit/fleet/reboot-respawn-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-runner.test.js
@@ -260,29 +260,36 @@ describe('runRebootRespawn (QF-20260724-070): durable bind-time audit row', () =
 });
 
 /**
- * QF-20260724-290 — the keepalive prompt must survive BOTH hops (runner -> buildLiveSpawnInvocation
- * -> buildSessionLaunch) and land in the spawned child's env. Asserted on the env the REAL spawnFn
- * seam receives, not on an intermediate call arg: a prompt that is passed but silently discarded one
- * hop later is exactly the ghost this fixes, and an arg-level assertion would not have caught it.
+ * QF-20260724-290 asserted the keepalive prompt survived BOTH hops (runner ->
+ * buildLiveSpawnInvocation -> buildSessionLaunch) and landed in the spawned child's env. Its
+ * reasoning was explicitly right — assert at the spawnFn seam, not an intermediate call arg,
+ * because "passed but discarded one hop later" is the actual ghost.
+ *
+ * FR-2: it stopped ONE HOP TOO EARLY. The child env was not the consumer either. Nothing reads
+ * `FLEET_WORKER_STARTUP_PROMPT` — no SessionStart hook, no code path, verified repo-wide — so the
+ * prompt died in the env it had just been proven to reach. The right instinct, applied to the
+ * wrong endpoint: the seam that mattered was the SPAWNED SESSION'S FIRST MESSAGE, and no unit test
+ * can reach it. Hence the SD's acceptance criterion is a transcript read, not an argv assertion.
  */
-describe('runRebootRespawn keepalive prompt plumbing (QF-20260724-290)', () => {
-  it('forwards the canonical FLEET_WORKER_STARTUP_PROMPT into the respawned child env', async () => {
-    const { FLEET_WORKER_STARTUP_PROMPT } = await import('../../../lib/coordinator/coordination-events.cjs');
+describe('runRebootRespawn — the deleted env carrier (FR-2)', () => {
+  it('does NOT write the unread FLEET_WORKER_STARTUP_PROMPT into the respawned child env', async () => {
     let childEnv = null;
     await runRebootRespawn({
       supabase: null, loadFn: async () => [SLOTS[0]], logFn: async () => ({ ok: true }), live: true,
       spawnFn: (_p, _a, env) => { childEnv = env; return { pid: 0 }; },
     });
-    expect(childEnv.FLEET_WORKER_STARTUP_PROMPT).toBe(FLEET_WORKER_STARTUP_PROMPT);
-    expect(childEnv.FLEET_WORKER_STARTUP_PROMPT.length).toBeGreaterThan(0);
+    expect(childEnv).not.toBeNull(); // guard: a null env would make the assertion below vacuous
+    expect(childEnv.FLEET_WORKER_STARTUP_PROMPT).toBeUndefined();
   });
 
-  it('honors an explicit startupPrompt:null opt-out (env var left unset)', async () => {
+  it('does not smuggle an explicit prompt into the child env under any key', async () => {
+    const SENTINEL = 'explicit-keepalive-sentinel';
     let childEnv = null;
     await runRebootRespawn({
       supabase: null, loadFn: async () => [SLOTS[0]], logFn: async () => ({ ok: true }), live: true,
-      startupPrompt: null, spawnFn: (_p, _a, env) => { childEnv = env; return { pid: 0 }; },
+      startupPrompt: SENTINEL, spawnFn: (_p, _a, env) => { childEnv = env; return { pid: 0 }; },
     });
-    expect(childEnv.FLEET_WORKER_STARTUP_PROMPT).toBeUndefined();
+    expect(childEnv).not.toBeNull();
+    expect(Object.values(childEnv).filter((v) => String(v).includes(SENTINEL))).toEqual([]);
   });
 });

--- a/tests/unit/fleet/reboot-respawn-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-runner.test.js
@@ -38,10 +38,15 @@ describe('runRebootRespawn dry-run (FR-5) — default INERT', () => {
     expect(events[0].payload).toMatchObject({ verb: 'respawn', callsign: 'Worker-1', resume_uuid: 'u-1', live: false });
 
     // The per-slot invocation carries the correct --resume token (slot 1) / no token (slot 2).
-    expect(res.results[0].invocation.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1']);
+    // FR-1: a trailing single-line POINTER positional now follows. It embeds an absolute path, so
+    // it is asserted by SHAPE — exact-matching a machine-specific path would be brittle without
+    // testing anything more. The prefix is still pinned exactly.
+    expect(res.results[0].invocation.args.slice(0, 9))
+      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1']);
     // FR-3: a slot with no resume token gets a MINTED --session-id instead, so the spawner knows in
     // advance the id the child will register under. Injected via uuidFn for determinism.
-    expect(res.results[1].invocation.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]);
+    expect(res.results[1].invocation.args.slice(0, 9))
+      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]);
   });
 
   // QF-20260724-335: opts.sdKey stamps every fleet_verb_respawn event with an explicit run-correlator
@@ -75,8 +80,17 @@ describe('runRebootRespawn live (FR-5)', () => {
     });
     expect(res.live).toBe(true);
     expect(spawnFn).toHaveBeenCalledTimes(2);
-    expect(spawnCalls[0]).toEqual({ program: 'wt.exe', args: ['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1'] });
-    expect(spawnCalls[1].args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]); // slot 2 had no resume token -> minted id
+    expect(spawnCalls[0].program).toBe('wt.exe');
+    expect(spawnCalls[0].args.slice(0, 9))
+      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1']);
+    expect(spawnCalls[1].args.slice(0, 9))
+      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]); // slot 2 had no resume token -> minted id
+    // FR-1: whatever follows is the single-line pointer positional, asserted by shape below.
+    for (const c of spawnCalls) {
+      const last = c.args[c.args.length - 1];
+      expect(last).toMatch(/follow the instructions in it exactly/);
+      expect(last.split(/[\r\n]/).length, 'the positional must never be multi-line').toBe(1);
+    }
     expect(res.results.map((r) => r.spawned)).toEqual([true, true]);
   });
 

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -226,8 +226,13 @@ describe('spawn — the deleted env carrier (FR-2)', () => {
   // two "fixes" (QF-20260724-290, QF-20260725-757), each of which moved the drop one hop later.
   //
   // So they now pin the carrier's ABSENCE. Re-adding the write turns these RED.
+  // FIXTURE IS A WORKER, AND THAT IS THE WHOLE POINT. This used to spawn 'Canary-pilot', which now
+  // resolves to a NULL prompt — so the assertion passed GREEN even with the env carrier fully
+  // restored, proving nothing. Found by PLAN verification (F3). A worker actually resolves a prompt,
+  // so the carrier's absence is now a real observation rather than a side effect of there being
+  // nothing to carry. Same vacuity class this file's own comment below claims to have fixed.
   it('does NOT set the unread FLEET_WORKER_STARTUP_PROMPT env carrier', async () => {
-    const result = await spawn({ role: 'worker', callsign: 'Canary-pilot' }, { live: false });
+    const result = await spawn({ role: 'worker', callsign: 'Charlie' }, { live: false });
     expect(result.invocation.env.FLEET_WORKER_STARTUP_PROMPT).toBeUndefined();
     expect(Object.keys(result.invocation.env)).not.toContain('FLEET_WORKER_STARTUP_PROMPT');
   });

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -215,24 +215,46 @@ describe('buildLiveSpawnInvocation (FR-7: env isolation)', () => {
   });
 });
 
-describe('spawn (FR-1) — keepalive forwarding (QF-20260725-757)', () => {
-  // spawn() was the THIRD hop of the QF-20260724-290 keepalive drop: that QF fixed
-  // buildLiveSpawnInvocation and the respawn runner, but spawn() built its invocation with NO
-  // startupPrompt, so every session created through the generic spawn verb came up with nothing to
-  // do, heartbeat once, and ghosted. This is why provisioned canaries kept dying.
-  it('REGRESSION: forwards the canonical keepalive prompt into the invocation env', async () => {
+describe('spawn — the deleted env carrier (FR-2)', () => {
+  // THESE TESTS USED TO ASSERT THE OPPOSITE, AND THAT IS THE LESSON.
+  //
+  // They asserted `invocation.env.FLEET_WORKER_STARTUP_PROMPT` was populated, and passed, and were
+  // cited as proof the keepalive reached the spawned session. It never did: no SessionStart hook
+  // and no code anywhere reads that variable (verified repo-wide — the only occurrences are the
+  // constant, writes, comments and these assertions). The tests confirmed a WRITE and were read as
+  // confirming DELIVERY. A green test on an unread env var is what kept this defect alive across
+  // two "fixes" (QF-20260724-290, QF-20260725-757), each of which moved the drop one hop later.
+  //
+  // So they now pin the carrier's ABSENCE. Re-adding the write turns these RED.
+  it('does NOT set the unread FLEET_WORKER_STARTUP_PROMPT env carrier', async () => {
     const result = await spawn({ role: 'worker', callsign: 'Canary-pilot' }, { live: false });
-    expect(result.invocation.env.FLEET_WORKER_STARTUP_PROMPT).toBeTruthy();
-  });
-
-  it('honours an explicit startupPrompt override', async () => {
-    const result = await spawn({ role: 'worker', callsign: 'Canary-pilot' }, { live: false, startupPrompt: 'custom-keepalive' });
-    expect(result.invocation.env.FLEET_WORKER_STARTUP_PROMPT).toBe('custom-keepalive');
-  });
-
-  it('honours an explicit null as a deliberate no-keepalive opt-out (respawn-runner parity)', async () => {
-    const result = await spawn({ role: 'worker', callsign: 'Canary-pilot' }, { live: false, startupPrompt: null });
     expect(result.invocation.env.FLEET_WORKER_STARTUP_PROMPT).toBeUndefined();
+    expect(Object.keys(result.invocation.env)).not.toContain('FLEET_WORKER_STARTUP_PROMPT');
+  });
+
+  it('does not smuggle an explicit startupPrompt into the env under any key', async () => {
+    const SENTINEL = 'custom-keepalive-sentinel';
+    const result = await spawn(
+      { role: 'worker', callsign: 'Canary-pilot' },
+      { live: false, startupPrompt: SENTINEL },
+    );
+    // Key-agnostic: catches a rename as well as a reinstatement.
+    expect(Object.values(result.invocation.env).filter((v) => String(v).includes(SENTINEL))).toEqual([]);
+  });
+
+  // FR-1 TRIPWIRE — DELETE THIS TEST WHEN THE POINTER TRANSPORT LANDS, DELIBERATELY.
+  // Today the prompt reaches NO part of the invocation: not env, not args. That is the real gap
+  // the env carrier was concealing, so it is pinned rather than left implicit. FR-1 adding the
+  // single-line pointer positional MUST turn this RED — that is the point of it.
+  it('PINS THE FR-1 GAP: the prompt currently reaches no part of the invocation', async () => {
+    const SENTINEL = 'pointer-transport-not-built-yet';
+    const result = await spawn(
+      { role: 'worker', callsign: 'Canary-pilot' },
+      { live: false, startupPrompt: SENTINEL },
+    );
+    const inv = result.invocation;
+    const surfaces = [...Object.values(inv.env || {}), ...(inv.args || [])].map(String);
+    expect(surfaces.some((s) => s.includes(SENTINEL))).toBe(false);
   });
 });
 

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -242,19 +242,31 @@ describe('spawn — the deleted env carrier (FR-2)', () => {
     expect(Object.values(result.invocation.env).filter((v) => String(v).includes(SENTINEL))).toEqual([]);
   });
 
-  // FR-1 TRIPWIRE — DELETE THIS TEST WHEN THE POINTER TRANSPORT LANDS, DELIBERATELY.
-  // Today the prompt reaches NO part of the invocation: not env, not args. That is the real gap
-  // the env carrier was concealing, so it is pinned rather than left implicit. FR-1 adding the
-  // single-line pointer positional MUST turn this RED — that is the point of it.
-  it('PINS THE FR-1 GAP: the prompt currently reaches no part of the invocation', async () => {
-    const SENTINEL = 'pointer-transport-not-built-yet';
-    const result = await spawn(
-      { role: 'worker', callsign: 'Canary-pilot' },
-      { live: false, startupPrompt: SENTINEL },
-    );
-    const inv = result.invocation;
-    const surfaces = [...Object.values(inv.env || {}), ...(inv.args || [])].map(String);
-    expect(surfaces.some((s) => s.includes(SENTINEL))).toBe(false);
+  // FR-5 — this replaces the earlier "PINS THE FR-1 GAP" test, which asserted the prompt reached
+  // NO part of the invocation. FR-1 has landed, so that name now describes the opposite of what
+  // the code does; it kept passing only because the fixture used a CANARY callsign, which resolves
+  // to a null prompt while no canary prompt exists. A test that passes for a different reason than
+  // its name claims is worse than no test — it reads as coverage.
+  it('FR-1 DELIVERS-IN-ARGV: a WORKER spawn carries the pointer as the trailing positional', async () => {
+    const result = await spawn({ role: 'worker', callsign: 'Charlie' }, { live: false });
+    const args = result.invocation.args;
+    const last = args[args.length - 1];
+
+    // The assertion FR-5 asks for: it must FAIL if the positional is disabled. A bare "last arg is
+    // non-empty" check would be satisfied by the minted --session-id UUID and prove nothing.
+    expect(last).toMatch(/follow the instructions in it exactly/);
+    expect(last).not.toMatch(/^[0-9a-f-]{36}$/i); // explicitly not just the minted UUID
+    expect(last.split(/[\r\n]/).length).toBe(1);
+  });
+
+  it('and a CANARY spawn carries NO positional — the canary prompt does not exist yet', async () => {
+    const result = await spawn({ role: 'worker', callsign: 'Canary-pilot' }, { live: false });
+    const args = result.invocation.args;
+    expect(args.some((a) => /follow the instructions in it exactly/.test(String(a)))).toBe(false);
+    // The safe direction while the canary prompt is outstanding: a canary that receives nothing
+    // ghosts, which cannot claim work. It must NEVER receive the worker directive by fallthrough.
+    const { FLEET_WORKER_STARTUP_PROMPT } = require('../../../lib/coordinator/coordination-events.cjs');
+    expect(args.some((a) => String(a).includes(FLEET_WORKER_STARTUP_PROMPT.split('\n')[0]))).toBe(false);
   });
 });
 

--- a/tests/unit/fleet/startup-prompt-pointer.test.js
+++ b/tests/unit/fleet/startup-prompt-pointer.test.js
@@ -137,3 +137,36 @@ describe('FR-1 — the sweep must not delete a PENDING session\'s pointer', () =
     expect(() => sweepStartupPromptFiles({ repoRoot: path.join(root, 'nope') })).not.toThrow();
   });
 });
+
+describe('F2 — a resolved prompt is never discarded SILENTLY', () => {
+  // PLAN verification found this SD reintroducing its own defect class: a non-UUID sessionId is
+  // dropped (correctly), but the transport is gated on `startupPrompt && sessionId`, so the prompt
+  // was thrown away with no throw and NO LOG — the spawned session comes up idle and nothing says
+  // why. Warn, do not throw: losing the directive is recoverable, failing the launch is not.
+  const { buildSessionLaunch } = require('../../../lib/fleet/build-session-launch.cjs');
+
+  it('WARNS when a prompt is resolved but no usable session id exists', () => {
+    const lines = [];
+    buildSessionLaunch(
+      // spec.sessionId, NOT resumeUuid: the resumeUuid branch assigns sessionId unconditionally, so
+      // it never reaches the drop. The drop is on the MINTED branch, where a non-UUID is discarded.
+      // My first version of this test used resumeUuid and failed — the test was wrong, not the code.
+      { role: 'worker', callsign: 'Charlie', cwd: root, startupPrompt: 'the directive', sessionId: 'not-a-uuid' },
+      { logFn: (m) => lines.push(String(m)) },
+    );
+    expect(lines.join('\n')).toMatch(/NO usable session id/i);
+    expect(lines.join('\n')).toMatch(/idle/i);
+  });
+
+  it('CONTROL: says nothing when the transport actually works', () => {
+    // Without this the test above would pass even if the warning fired unconditionally.
+    const lines = [];
+    const inv = buildSessionLaunch(
+      { role: 'worker', callsign: 'Charlie', cwd: root, startupPrompt: 'the directive',
+        sessionId: '11111111-2222-4333-8444-555555555555' },
+      { logFn: (m) => lines.push(String(m)) },
+    );
+    expect(inv.promptFilePath).toBeTruthy();
+    expect(lines.join('\n')).not.toMatch(/NO usable session id/i);
+  });
+});

--- a/tests/unit/fleet/startup-prompt-pointer.test.js
+++ b/tests/unit/fleet/startup-prompt-pointer.test.js
@@ -1,0 +1,139 @@
+/**
+ * SD-...-PROMPT-LIBRARY-001-D FR-1 — pointer-file transport.
+ *
+ * These tests use a REAL temp directory rather than a mocked fs on purpose: the defect class this
+ * SD exists for is "the value looked delivered and was not", and a mocked fs is exactly the seam
+ * that hides a write which never happened.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const {
+  buildPointerLine, writeStartupPromptFile, sweepStartupPromptFiles, PROMPT_DIR_REL,
+} = require('../../../lib/fleet/startup-prompt-pointer.cjs');
+const { assertSingleLinePrompt, MultilinePromptError } = require('../../../lib/fleet/startup-prompt-selection.js');
+const { FLEET_WORKER_STARTUP_PROMPT } = require('../../../lib/coordinator/coordination-events.cjs');
+
+let root;
+beforeEach(() => { root = fs.mkdtempSync(path.join(os.tmpdir(), 'fr1-')); });
+afterEach(() => { try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+const dir = () => path.join(root, PROMPT_DIR_REL);
+
+describe('FR-1 — the pointer is single-line even when the prompt is not', () => {
+  it('THE WHOLE POINT: a multi-line prompt yields a pointer that survives the tripwire', () => {
+    // The live worker directive is multi-line, which is what cmd.exe truncated.
+    expect(FLEET_WORKER_STARTUP_PROMPT.split('\n').length).toBeGreaterThan(1);
+
+    const { pointerLine, promptFilePath } = writeStartupPromptFile({
+      repoRoot: root, sessionId: 'a1b2c3d4', prompt: FLEET_WORKER_STARTUP_PROMPT,
+    });
+
+    // The pointer is safe to put in argv...
+    expect(() => assertSingleLinePrompt(pointerLine, { where: 'test' })).not.toThrow();
+    expect(pointerLine.split(/[\r\n]/).length).toBe(1);
+    // ...while the FULL prompt is preserved on disk, byte for byte.
+    expect(fs.readFileSync(promptFilePath, 'utf8')).toBe(FLEET_WORKER_STARTUP_PROMPT);
+    // And the prompt itself would still be rejected in argv — the tripwire has not been weakened.
+    expect(() => assertSingleLinePrompt(FLEET_WORKER_STARTUP_PROMPT, { where: 't' }))
+      .toThrow(MultilinePromptError);
+  });
+
+  it('names the file after the session id, so a directive is correlatable to its session', () => {
+    const { promptFilePath } = writeStartupPromptFile({ repoRoot: root, sessionId: 'sess-9', prompt: 'x' });
+    expect(path.basename(promptFilePath)).toBe('sess-9.txt');
+  });
+
+  it('refuses a path-traversing session id rather than sanitising it into something else', () => {
+    expect(() => writeStartupPromptFile({ repoRoot: root, sessionId: '../escape', prompt: 'x' })).toThrow(/unsafe sessionId/);
+  });
+
+  it('refuses an empty prompt (a pointer to nothing is the dangling case)', () => {
+    expect(() => writeStartupPromptFile({ repoRoot: root, sessionId: 'ok', prompt: '' })).toThrow(/non-empty/);
+  });
+});
+
+describe('FR-1 — dangling-pointer handling fails toward IDLE, never toward claiming', () => {
+  it('the pointer instructs a session with a missing file to idle and not claim', () => {
+    const line = buildPointerLine('/some/where/x.txt');
+    expect(line).toMatch(/does not exist or is empty/i);
+    expect(line).toMatch(/not claim or start any work/i);
+    expect(line).toMatch(/remain idle/i);
+    // Direction matters: "do nothing" is recoverable, "claim something" is the fleet-wide hazard.
+    expect(line).not.toMatch(/use your best judg|proceed anyway|fall back to CLAUDE\.md/i);
+  });
+});
+
+describe('FR-1 — the newline tripwire is REACHABLE from the live launch path', () => {
+  // THIS IS THE TEST THE SD'S EXIT CRITERION ASKS FOR
+  // (metadata.fr1_exit_criterion_tripwire_must_be_wired). Before FR-1, assertSingleLinePrompt had
+  // ZERO production callers: it could have been deleted outright with every test outside its own
+  // file still green — "present, correct, and silently removable". Its own passing unit tests were
+  // not evidence it guarded anything.
+  //
+  // So this neuters the guard THROUGH AN INJECTED SEAM rather than by editing the live call site,
+  // and asserts buildSessionLaunch itself throws. If someone removes the assertSingleLinePrompt
+  // call from the positional path, this goes RED — which is what makes it a guard.
+  const { buildSessionLaunch } = require('../../../lib/fleet/build-session-launch.cjs');
+
+  const spec = () => ({
+    role: 'worker',
+    callsign: 'Charlie',
+    cwd: root,
+    sessionId: '11111111-2222-4333-8444-555555555555',
+    startupPrompt: 'anything',
+  });
+
+  it('THROWS when the value destined for argv is multi-line', () => {
+    expect(() => buildSessionLaunch(spec(), {
+      buildPointerLineFn: () => 'line one\nline two would be LOST to cmd.exe',
+    })).toThrow(MultilinePromptError);
+  });
+
+  it('and does NOT throw for the real single-line pointer (so the check is not always-on)', () => {
+    // Without this arm the test above would pass even if buildSessionLaunch threw unconditionally.
+    expect(() => buildSessionLaunch(spec(), {})).not.toThrow();
+  });
+
+  it('the real launch path puts a single-line pointer in the trailing positional', () => {
+    const inv = buildSessionLaunch(spec(), {});
+    const last = inv.args[inv.args.length - 1];
+    expect(last.split(/[\r\n]/).length).toBe(1);
+    expect(last).toMatch(/follow the instructions in it exactly/);
+  });
+});
+
+describe('FR-1 — the sweep must not delete a PENDING session\'s pointer', () => {
+  const write = (name, ageMs, now) => {
+    fs.mkdirSync(dir(), { recursive: true });
+    const p = path.join(dir(), name);
+    fs.writeFileSync(p, 'x');
+    fs.utimesSync(p, new Date(now - ageMs) / 1000, new Date(now - ageMs) / 1000);
+    return p;
+  };
+
+  it('RETAIN-N ALONE IS UNSAFE: 10 fresh spawns, none swept, because all are inside the live window', () => {
+    const now = 1_000_000_000_000;
+    for (let i = 0; i < 10; i++) write(`s${i}.txt`, i * 1000, now); // all seconds old
+    const { deleted } = sweepStartupPromptFiles({ repoRoot: root, now });
+    // A pure retain-5 sweep would have deleted 5 of these while their sessions were still starting.
+    expect(deleted).toEqual([]);
+  });
+
+  it('but genuinely old files beyond the retain window ARE swept', () => {
+    const now = 1_000_000_000_000;
+    const old = 60 * 60 * 1000; // 1h — well past the min age
+    for (let i = 0; i < 8; i++) write(`old${i}.txt`, old + i * 1000, now);
+    const { deleted, kept } = sweepStartupPromptFiles({ repoRoot: root, now });
+    expect(deleted.length).toBe(3); // 8 old files, 5 newest retained
+    expect(kept).toBe(5);
+  });
+
+  it('never throws when the directory does not exist', () => {
+    expect(() => sweepStartupPromptFiles({ repoRoot: path.join(root, 'nope') })).not.toThrow();
+  });
+});

--- a/tests/unit/fleet/startup-prompt-selection.test.js
+++ b/tests/unit/fleet/startup-prompt-selection.test.js
@@ -15,6 +15,7 @@ import {
   MultilinePromptError,
 } from '../../../lib/fleet/startup-prompt-selection.js';
 import { createRequire } from 'node:module';
+import fs from 'node:fs';
 
 const require = createRequire(import.meta.url);
 
@@ -42,9 +43,11 @@ describe('classifySessionByCallsign — three arms, and the third is the point',
     expect(kinds.every((k) => ['canary', 'worker', 'unidentifiable'].includes(k))).toBe(true);
   });
 
-  it('is not case- or whitespace-fooled into losing the canary namespace', () => {
+  it('is not whitespace-fooled into losing the canary namespace', () => {
     expect(classifySessionByCallsign('  Canary-pilot  ').kind).toBe('canary');
-    // lower-case 'canary-' is deliberately NOT the namespace — the prefix is exact.
+    // classify stays EXACT-match: it is the TARGETING predicate, and over-matching there would let
+    // a drill or kill surface aim at the wrong session. The case-insensitive DENY lives in
+    // resolveStartupPromptForCallsign, where under-matching is the dangerous direction. See SEC-1.
     expect(classifySessionByCallsign('canary-pilot').kind).toBe('worker');
   });
 
@@ -81,6 +84,61 @@ describe('FR-4 — the canary prefix has exactly ONE declaration', () => {
   it('and the one declaration is actually there (so the scan above cannot pass by finding nothing)', () => {
     const src = fs.readFileSync(new URL('startup-prompt-selection.js', FLEET_DIR), 'utf8');
     expect(DECL.test(src.replace('export ', ''))).toBe(true);
+  });
+});
+
+describe('SEC-1 — a case-mismatched canary is DENIED the worker directive', () => {
+  const { resolveStartupPromptForCallsign } = require('../../../lib/fleet/startup-prompt-selection.js');
+  const { FLEET_WORKER_STARTUP_PROMPT } = require('../../../lib/coordinator/coordination-events.cjs');
+  const resolve = (cs) => resolveStartupPromptForCallsign(cs, {
+    workerPrompt: FLEET_WORKER_STARTUP_PROMPT, canaryPrompt: null, logFn: () => {},
+  });
+
+  // MEASURED by the SECURITY review at all three sites, with a control arm: before this fix,
+  // 'canary-pilot' and 'CANARY-pilot' each received the full 1406-byte claiming directive. A
+  // one-character typo in a slot name reaches it, and assessCanarySlotNaming is fail-open.
+  it.each(['canary-pilot', 'CANARY-pilot', 'CaNaRy-pilot', '  canary-x  '])(
+    'denies %j — a misnamed canary must not be able to claim work', (cs) => {
+      const r = resolve(cs);
+      expect(r.prompt).toBeNull();
+      expect(r.prompt).not.toBe(FLEET_WORKER_STARTUP_PROMPT);
+      expect(r.reason).toBe('canary_namespace_case_mismatch');
+    },
+  );
+
+  it('CONTROL: an ordinary worker still receives the directive (the deny is not blanket)', () => {
+    expect(resolve('Charlie').prompt).toBe(FLEET_WORKER_STARTUP_PROMPT);
+    // and a name merely CONTAINING "canary" is not swept up — the deny is prefix-anchored.
+    expect(resolve('Bravo-canary-adjacent').prompt).toBe(FLEET_WORKER_STARTUP_PROMPT);
+  });
+
+  it('the exact-prefix canary still resolves through the canary arm, not the mismatch arm', () => {
+    const r = resolve('Canary-pilot');
+    expect(r.prompt).toBeNull();
+    expect(r.reason).toBe('no_canary_prompt_available');
+  });
+});
+
+describe('SEC-2 — an unsafe sessionId is refused on BOTH path-construction branches', () => {
+  const { buildSessionLaunch } = require('../../../lib/fleet/build-session-launch.cjs');
+  const os = require('node:os');
+  const nodePath = require('node:path');
+
+  // The missing-root branch built the prompt path inline with no charset check, and sessionId can
+  // be a DB-sourced resumeUuid. Both branches must refuse.
+  it('refuses on the MISSING-root branch (the one that was unguarded)', () => {
+    expect(() => buildSessionLaunch({
+      role: 'worker', callsign: 'Charlie', startupPrompt: 'x',
+      cwd: nodePath.join(os.tmpdir(), '__definitely_missing_dir__'), resumeUuid: '../../../../pwn',
+    })).toThrow(/unsafe sessionId/);
+  });
+
+  it('CONTROL: a legitimate uuid still builds (the guard is not always-on)', () => {
+    const cwd = fs.mkdtempSync(nodePath.join(os.tmpdir(), 'sec2-'));
+    expect(() => buildSessionLaunch({
+      role: 'worker', callsign: 'Charlie', startupPrompt: 'x', cwd,
+      sessionId: '11111111-2222-4333-8444-555555555555',
+    })).not.toThrow();
   });
 });
 

--- a/tests/unit/fleet/startup-prompt-selection.test.js
+++ b/tests/unit/fleet/startup-prompt-selection.test.js
@@ -1,0 +1,99 @@
+/**
+ * SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-D — three-arm selection + newline tripwire.
+ *
+ * THE ASSERTION THAT MATTERS MOST is the unidentifiable arm. A boolean predicate returns false
+ * for a session it cannot identify, and false means "not a canary", which hands that session the
+ * CLAIMING WORKER directive. So a two-arm version is not merely less informative — its
+ * fallthrough direction is the dangerous one, and it is invisible because "definitely a worker"
+ * and "no idea what this is" collapse to the same value.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  classifySessionByCallsign,
+  isCanaryCallsign,
+  assertSingleLinePrompt,
+  MultilinePromptError,
+} from '../../../lib/fleet/startup-prompt-selection.js';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+describe('classifySessionByCallsign — three arms, and the third is the point', () => {
+  it('classifies a canary-namespace callsign as canary', () => {
+    expect(classifySessionByCallsign('Canary-pilot')).toEqual({ kind: 'canary', callsign: 'Canary-pilot' });
+  });
+
+  it('classifies an ordinary callsign as worker', () => {
+    expect(classifySessionByCallsign('Charlie')).toEqual({ kind: 'worker', callsign: 'Charlie' });
+  });
+
+  it('classifies an UNIDENTIFIABLE session as its own third outcome — never as worker', () => {
+    // If any of these returned 'worker' the session would receive the claiming directive.
+    for (const bad of [undefined, null, '', '   ', 42, {}, []]) {
+      const r = classifySessionByCallsign(bad);
+      expect(r.kind, `input ${JSON.stringify(bad)} must not be classified worker`).toBe('unidentifiable');
+      expect(r.kind).not.toBe('worker');
+    }
+  });
+
+  it('the three arms are exhaustive and mutually exclusive', () => {
+    const kinds = ['Canary-x', 'Worker-x', ''].map((c) => classifySessionByCallsign(c).kind);
+    expect(new Set(kinds).size).toBe(3);
+    expect(kinds.every((k) => ['canary', 'worker', 'unidentifiable'].includes(k))).toBe(true);
+  });
+
+  it('is not case- or whitespace-fooled into losing the canary namespace', () => {
+    expect(classifySessionByCallsign('  Canary-pilot  ').kind).toBe('canary');
+    // lower-case 'canary-' is deliberately NOT the namespace — the prefix is exact.
+    expect(classifySessionByCallsign('canary-pilot').kind).toBe('worker');
+  });
+
+  it('the derived boolean does NOT treat unidentifiable as canary (so it is unsafe for the decision)', () => {
+    expect(isCanaryCallsign('Canary-pilot')).toBe(true);
+    expect(isCanaryCallsign('Charlie')).toBe(false);
+    expect(isCanaryCallsign(undefined)).toBe(false); // <- exactly why the decision must use the 3-arm form
+  });
+});
+
+describe('assertSingleLinePrompt — the newline tripwire', () => {
+  it('passes a single-line prompt through unchanged', () => {
+    const p = 'Read .claude/fleet-prompts/abc.txt and follow it exactly.';
+    expect(assertSingleLinePrompt(p, { where: 'test' })).toBe(p);
+  });
+
+  it('THROWS on an embedded newline, naming what would actually be delivered', () => {
+    const p = ['first line', 'second line', 'third'].join('\n');
+    let err;
+    try { assertSingleLinePrompt(p, { where: 'spawn-control' }); } catch (e) { err = e; }
+    expect(err).toBeInstanceOf(MultilinePromptError);
+    expect(err.details.totalLines).toBe(3);
+    expect(err.details.deliveredChars).toBe('first line'.length);
+    expect(err.message).toMatch(/TRUNCATED BY cmd\.exe/);
+    expect(err.message).toMatch(/spawn-control/);
+  });
+
+  it('catches CR and CRLF too, not just LF', () => {
+    for (const nl of ['\r', '\r\n']) {
+      expect(() => assertSingleLinePrompt(`a${nl}b`, { where: 't' })).toThrow(MultilinePromptError);
+    }
+  });
+
+  it('rejects a non-string before it can reach argv', () => {
+    expect(() => assertSingleLinePrompt(undefined, { where: 't' })).toThrow(MultilinePromptError);
+  });
+
+  it('WOULD HAVE CAUGHT THE ORIGINAL DEFECT — fires on the real live constant', () => {
+    // This is the regression the whole SD exists for: the shipped worker prompt is multi-line,
+    // so passing it as a positional silently delivers only its first line.
+    const { FLEET_WORKER_STARTUP_PROMPT } = require('../../../lib/coordinator/coordination-events.cjs');
+    expect(FLEET_WORKER_STARTUP_PROMPT.split('\n').length).toBeGreaterThan(1);
+
+    let err;
+    try { assertSingleLinePrompt(FLEET_WORKER_STARTUP_PROMPT, { where: 'real constant' }); } catch (e) { err = e; }
+    expect(err, 'the tripwire MUST fire on the real constant').toBeInstanceOf(MultilinePromptError);
+
+    // Pin the measured truncation: the delivered slice is a fraction of the whole.
+    expect(err.details.deliveredChars).toBeLessThan(err.details.totalChars);
+    expect(err.details.deliveredChars / err.details.totalChars).toBeLessThan(0.25);
+  });
+});

--- a/tests/unit/fleet/startup-prompt-selection.test.js
+++ b/tests/unit/fleet/startup-prompt-selection.test.js
@@ -55,6 +55,35 @@ describe('classifySessionByCallsign — three arms, and the third is the point',
   });
 });
 
+describe('FR-4 — the canary prefix has exactly ONE declaration', () => {
+  // The prefix was declared in four places. The duplication was deliberate and documented:
+  // canary-guard.js imports from spawn-control.js, so importing back would be a cycle, and a test
+  // asserted the copies AGREED. That test could only ever catch drift AFTER it was written into a
+  // copy — it made duplication survivable rather than removing it.
+  //
+  // startup-prompt-selection.js imports nothing, so it cannot close that cycle: one real source.
+  // This asserts the property directly (no other declaration exists) instead of comparing copies.
+  const FLEET_DIR = new URL('../../../lib/fleet/', import.meta.url);
+  const fs = require('node:fs');
+  const DECL = /(?:const|let|var)\s+CANARY_CALLSIGN_PREFIX\s*=\s*['"]/;
+
+  it('no module outside startup-prompt-selection.js declares its own CANARY_CALLSIGN_PREFIX', () => {
+    const files = fs.readdirSync(FLEET_DIR).filter((f) => /\.(js|cjs|mjs)$/.test(f));
+    expect(files.length).toBeGreaterThan(3); // guard: an empty listing would pass vacuously
+
+    const offenders = files.filter((f) => {
+      if (f === 'startup-prompt-selection.js') return false;
+      return DECL.test(fs.readFileSync(new URL(f, FLEET_DIR), 'utf8'));
+    });
+    expect(offenders, `these re-declare the prefix instead of importing it: ${offenders.join(', ')}`).toEqual([]);
+  });
+
+  it('and the one declaration is actually there (so the scan above cannot pass by finding nothing)', () => {
+    const src = fs.readFileSync(new URL('startup-prompt-selection.js', FLEET_DIR), 'utf8');
+    expect(DECL.test(src.replace('export ', ''))).toBe(true);
+  });
+});
+
 describe('assertSingleLinePrompt — the newline tripwire', () => {
   it('passes a single-line prompt through unchanged', () => {
     const p = 'Read .claude/fleet-prompts/abc.txt and follow it exactly.';

--- a/tests/unit/fleet/worker-spawn-executor.test.js
+++ b/tests/unit/fleet/worker-spawn-executor.test.js
@@ -134,7 +134,10 @@ describe('config + invocation helpers (FR-3)', () => {
     expect(Array.isArray(inv.args)).toBe(true);
     expect(inv.args).not.toContain('-p'); // never headless
     expect(inv.persistent).toBe(true);
-    expect(inv.env.FLEET_WORKER_STARTUP_PROMPT).toBe('PROMPT'); // /loop prompt carried in env for the SessionStart hook to seed
+    // FR-2: was `toBe('PROMPT')`, described as "carried in env for the SessionStart hook to seed".
+    // No such hook exists and nothing reads the variable, so this asserted a write that no consumer
+    // ever observed. The carrier is deleted; the prompt has no delivery path until FR-1.
+    expect(inv.env.FLEET_WORKER_STARTUP_PROMPT).toBeUndefined();
     expect(inv.env.FLEET_WORKER_CALLSIGN).toBe('Echo');
   });
 });


### PR DESCRIPTION
## Summary

Spawned fleet sessions received **no startup directive**. The prompt was passed as a trailing positional argument, and `claude.cmd` is a batch file — **cmd.exe truncates a multi-line argument at the first LF**. Measured from a live canary transcript: **97 of 958 characters delivered**, one line of six. Every spawned worker came up with an empty `/loop`, fell back to `CLAUDE.md`, and ghosted.

This replaces that with a **single-line pointer-file transport**, and makes prompt selection **keyed on the callsign namespace** so a canary can never receive the claiming-worker directive.

- **FR-1** — prompt written to `.claude/fleet-prompts/<sessionId>.txt`; only a single-line pointer reaches argv. Immune by construction to cmd.exe *and* to wt.exe, which also re-parses the commandline and had never been verified.
- **FR-2** — deleted the dead `FLEET_WORKER_STARTUP_PROMPT` env carrier. It had **zero readers**; the "SessionStart hook seeds it" mechanism does not exist and never did. It made the invocation *look* like it delivered, which is why the defect survived two prior fixes that each moved the drop one hop later.
- **FR-3** — selection keyed on callsign at **all three** prompt-decision sites.
- **FR-4** — newline tripwire, wired on the live positional path (not inert).
- **FR-5** — tests, including a cross-site hazard test.

## Verification

Both transport hops were **measured before building**, not inferred:

- A single-line positional arrives **byte-intact** through the real `wt.exe → cmd.exe → batch` chain. **Control arm:** the same probe with a 3-line payload delivered only its first line — so the probe could have said otherwise, and it reproduces the original defect through a different instrument.
- Acceptance verified **at the consumer**: a live spawn's delivered first user message, read from the spawned session's own transcript, is byte-identical to the emitted pointer (386/386). It also *acted* — replying with a token that exists only inside the pointed-to file, so prompt-echo cannot explain it.

## Defects found and fixed during the build

Recorded because the discovery pattern is the durable part — **none of these was found by reading the code or the test**:

- **A canary was being handed the full 1406-byte worker directive.** FR-3 had been applied to 1 of 3 sites; the FR-1 transport commit *armed* the previously-dormant gap. Caught pre-merge — `origin/main` was never exposed.
- **`canary-pilot` / `CANARY-pilot` also received it** — exact-prefix matching, reachable by a one-character typo in a slot name.
- **The tripwire had zero production callers** — present, correct, and silently removable.
- **The invariant was enforced by convention at N sites**, so it recurred one level up; it is now enforced at the choke point every spawner routes through.
- **Several tests were vacuous** — a conditional assertion plus a count guard, a fixture resolving to null, `toBeUndefined()` on a key that never existed.

Every guard added here is **mutation-verified through an injected seam**, with a control arm proving it is not always-on.

## Test plan

- [x] `tests/unit/fleet/` — 1101 passing / 90 files
- [x] The 5 non-fleet test files importing these modules — 66 passing
- [x] Per-callsign matrix verified at the consumer across all three sites
- [x] Mutation-verified: reverting any site turns the correct arm RED

**Note:** `ship-preflight` currently blocks on 107 full-suite failures. **Zero are under `tests/unit/fleet/`**; 42 of 44 failing files are `tests/integration/*` failing on shared-live-DB contention (`deadlock detected`, `transaction is aborted`, RLS `42501`), and the other 2 reproduce on `origin/main` at `3e2d9e71a7e`. This diff touches only fleet files. **Not merging pending a coordinator ruling on that gate.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
