### PR TITLE
fix(QF-20260726-459 Part 1b): gate the db project — 125 of 225 files never imported the guard

### DIFF
--- a/tests/helpers/db-available.js
+++ b/tests/helpers/db-available.js
@@ -42,71 +42,12 @@
  *   describeDb('queries the venture table', () => { ... });  // skipped unless the target is designated
  */
 import { describe, it } from 'vitest';
+// QF-20260726-459 Part 1b: the predicate moved to a vitest-free module so vitest.config.js can
+// import it too (see db-target.js for why). Re-exported here so every existing consumer — 119
+// files gate on HAS_REAL_DB directly — keeps working unchanged. ONE definition site, not two.
+import { assessDbTarget, projectRefOf, DESIGNATED_NON_PROD_REFS } from './db-target.js';
 
-/**
- * Project refs explicitly designated NON-PRODUCTION and safe for destructive test traffic.
- *
- * INTENTIONALLY EMPTY: no non-production Supabase project exists yet (Part 2). An empty allowlist
- * means the only route to running DB tests is the deliberate, target-naming opt-in below — which
- * cannot be taken by accident.
- */
-export const DESIGNATED_NON_PROD_REFS = Object.freeze([]);
-
-/** Extract the Supabase project ref from a URL, or null when it is not a recognisable project URL. */
-export function projectRefOf(url) {
-  if (typeof url !== 'string') return null;
-  const m = url.match(/^https?:\/\/([a-z0-9-]+)\.supabase\.(?:co|in)\b/i);
-  return m ? m[1].toLowerCase() : null;
-}
-
-/**
- * THE POSITIVE SAFETY PREDICATE. Pure — it takes an env bag, so the discrimination tests can prove
- * BOTH arms (skip AND allow) directly, with no module-cache games. A guard that can only be shown
- * to skip is indistinguishable from a guard that always skips, and the second one silently deletes
- * all DB coverage while passing every test anyone would think to write.
- *
- * A target is usable only when ALL of these hold:
- *   1. a service-role key is present at all (nothing can connect otherwise);
- *   2. the URL parses to a real Supabase project ref;
- *   3. that ref is EITHER on the designated non-prod allowlist, OR named explicitly by
- *      VITEST_DB_ALLOW_REF;
- *   4. and when the opt-in is used, the named ref MATCHES the ref the URL actually points at.
- *
- * (4) is what makes the opt-in an authorisation rather than a rubber stamp: you cannot authorise
- * "some test project" and be silently pointed at production, because the authorisation names an
- * exact ref and is checked against reality. Opting in to production therefore requires typing the
- * production ref yourself — a deliberate act, not an accident.
- *
- * Returns a REASON alongside the verdict so a skip is never mysterious: "there was no DB coverage"
- * and "DB coverage silently vanished" look identical in a green run, and the reason is what
- * separates them.
- *
- * @param {Record<string,string|undefined>} env
- * @returns {{ allowed: boolean, reason: string, ref: string|null }}
- */
-export function assessDbTarget(env = process.env) {
-  const url = env.SUPABASE_URL;
-  const key = env.SUPABASE_SERVICE_ROLE_KEY;
-
-  if (!url) return { allowed: false, reason: 'no_supabase_url', ref: null };
-  if (!key) return { allowed: false, reason: 'no_service_role_key', ref: null };
-
-  const ref = projectRefOf(url);
-  // Unparseable (including the synthetic test.invalid.local sentinel) → fail closed. Note we never
-  // name that sentinel: anything not positively identified is refused by construction, which is the
-  // whole point of inverting the predicate.
-  if (!ref) return { allowed: false, reason: 'unrecognised_target', ref: null };
-
-  if (DESIGNATED_NON_PROD_REFS.includes(ref)) {
-    return { allowed: true, reason: 'allowlisted_non_prod_ref', ref };
-  }
-
-  const optIn = (env.VITEST_DB_ALLOW_REF || '').trim().toLowerCase();
-  if (!optIn) return { allowed: false, reason: 'no_designated_target', ref };
-  if (optIn !== ref) return { allowed: false, reason: 'opt_in_ref_mismatch', ref };
-
-  return { allowed: true, reason: 'explicit_opt_in_matches_target', ref };
-}
+export { assessDbTarget, projectRefOf, DESIGNATED_NON_PROD_REFS };
 
 /** The assessment for the current process env, computed once at import. */
 export const DB_TARGET = assessDbTarget(process.env);

--- a/tests/helpers/db-target.js
+++ b/tests/helpers/db-target.js
@@ -1,0 +1,71 @@
+/**
+ * The db-test target safety predicate — QF-20260726-459 Part 1b.
+ *
+ * WHY THIS FILE EXISTS SEPARATELY FROM db-available.js. Part 1 put this predicate in
+ * db-available.js, which imports `vitest` at module scope for describeDb/itDb. That import makes
+ * the module unusable from vitest.config.js (importing `vitest` outside a test worker throws on
+ * internal-state access), and the config is exactly where the gate has to live to cover files that
+ * never import the guard at all.
+ *
+ * So the predicate moves HERE, with NO vitest dependency, and db-available.js re-exports it. There
+ * is still exactly ONE definition site. Re-deriving the predicate inside the config instead would
+ * have been a parallel re-derivation — the same mistake that let the original defect survive its
+ * own test (vitest-db-split.test.js re-implemented the old predicate inline and therefore agreed
+ * with it by construction).
+ *
+ * Logic is carried over UNCHANGED from Part 1 — this is a move, not a rewrite.
+ */
+
+/**
+ * Project refs explicitly designated NON-PRODUCTION and safe for destructive test traffic.
+ *
+ * INTENTIONALLY EMPTY: no non-production Supabase project exists yet (Part 2). An empty allowlist
+ * means the only route to running DB tests is the deliberate, target-naming opt-in below.
+ */
+export const DESIGNATED_NON_PROD_REFS = Object.freeze([]);
+
+/** Extract the Supabase project ref from a URL, or null when it is not a recognisable project URL. */
+export function projectRefOf(url) {
+  if (typeof url !== 'string') return null;
+  const m = url.match(/^https?:\/\/([a-z0-9-]+)\.supabase\.(?:co|in)\b/i);
+  return m ? m[1].toLowerCase() : null;
+}
+
+/**
+ * THE POSITIVE SAFETY PREDICATE. Pure — takes an env bag, so both arms (refuse AND allow) are
+ * provable directly with no module-cache games.
+ *
+ * A target is usable only when ALL hold:
+ *   1. a service-role key is present at all;
+ *   2. the URL parses to a real Supabase project ref;
+ *   3. that ref is EITHER allowlisted OR named explicitly by VITEST_DB_ALLOW_REF;
+ *   4. and when the opt-in is used, the named ref MATCHES the ref the URL actually points at.
+ *
+ * (4) makes the opt-in an AUTHORISATION rather than a rubber stamp: you cannot authorise "some test
+ * project" and be silently pointed at production.
+ *
+ * @param {Record<string,string|undefined>} env
+ * @returns {{ allowed: boolean, reason: string, ref: string|null }}
+ */
+export function assessDbTarget(env = process.env) {
+  const url = env.SUPABASE_URL;
+  const key = env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url) return { allowed: false, reason: 'no_supabase_url', ref: null };
+  if (!key) return { allowed: false, reason: 'no_service_role_key', ref: null };
+
+  const ref = projectRefOf(url);
+  // Unparseable (including the synthetic test.invalid.local sentinel) → fail closed. We never name
+  // that sentinel: anything not positively identified is refused by construction.
+  if (!ref) return { allowed: false, reason: 'unrecognised_target', ref: null };
+
+  if (DESIGNATED_NON_PROD_REFS.includes(ref)) {
+    return { allowed: true, reason: 'allowlisted_non_prod_ref', ref };
+  }
+
+  const optIn = (env.VITEST_DB_ALLOW_REF || '').trim().toLowerCase();
+  if (!optIn) return { allowed: false, reason: 'no_designated_target', ref };
+  if (optIn !== ref) return { allowed: false, reason: 'opt_in_ref_mismatch', ref };
+
+  return { allowed: true, reason: 'explicit_opt_in_matches_target', ref };
+}

--- a/tests/unit/vitest-db-project-gated.test.js
+++ b/tests/unit/vitest-db-project-gated.test.js
@@ -1,0 +1,116 @@
+/**
+ * QF-20260726-459 Part 1b — the db PROJECT itself must be gated, not just the helper.
+ *
+ * WHY PART 1 WAS NOT ENOUGH. Part 1 made tests/helpers/db-available.js fail closed. Measured
+ * statically against the config's own globs, the db project resolves 225 files and only 100
+ * reference that helper in any form. THE OTHER 125 NEVER IMPORT IT — so no change to the helper
+ * could gate them, and the db project's setupFiles load the real .env. The QF's title claim
+ * ("db-project vitest tests can run against PRODUCTION") stayed true for those 125 files.
+ *
+ * A per-file fix does not scale to 125 and silently un-fixes itself when someone adds file 226.
+ * The project definition is the only place that covers every file regardless of its imports, so
+ * the gate lives in vitest.config.js and this test pins it there.
+ *
+ * WHAT THIS ASSERTS: the RESOLVED config, not a re-implementation of the predicate. Each arm
+ * re-imports vitest.config.js with a different environment (cache-busted so the module-level gate
+ * re-evaluates) and reads the db project's `include`. Empty include => vitest resolves zero files.
+ *
+ * No DB is contacted: the config is pure module evaluation, and the non-production ref used below
+ * does not exist. This respects the QF's hard constraint against re-running the db project live.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PROD_REF = 'dedlbzhpgkmetvhbkyzq'; // the ref Part 1 measured as live in the shared .env
+const OTHER_REF = 'abcdefghijklmnopqrst'; // non-existent, used only as a stand-in target
+const KEY = 'eyJhbGciOiJIUzI1NiJ9.service-role.signature';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+/**
+ * Evaluate vitest.config.js in a FRESH node process under `env` and return the db project's
+ * include array.
+ *
+ * A child process rather than a dynamic import, for two reasons. The config imports
+ * `vitest/config`, which does not load cleanly inside a vitest worker. More importantly, the gate
+ * is a MODULE-LEVEL evaluation that really does happen once per process at config load — so a
+ * fresh process is the faithful reproduction, and re-importing with a cache-buster inside one
+ * worker would be testing a situation that never occurs.
+ */
+function dbInclude(env) {
+  // MARKER-DELIMITED, deliberately. dotenvx prints a randomised tip banner to stdout and some of
+  // those tips contain literal brackets (e.g. "{ path: ['.env.local', '.env'] }"), so slicing on
+  // the first '[' parses the BANNER instead of the payload — and because the tip rotates, that
+  // reads as an intermittent failure rather than a bug in the harness. Never scan for punctuation
+  // in output you do not solely own.
+  const script =
+    "const c=(await import('./vitest.config.js')).default;" +
+    "const d=(c.test.projects||[]).find(p=>p?.test?.name==='db');" +
+    "process.stdout.write('<<<INC'+JSON.stringify(d?.test?.include??null)+'INC>>>');";
+  const out = execFileSync(process.execPath, ['--input-type=module', '-e', script], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    // Drop any inherited opt-in/creds so each arm states its own environment completely.
+    env: { ...process.env, SUPABASE_URL: undefined, SUPABASE_SERVICE_ROLE_KEY: undefined, VITEST_DB_ALLOW_REF: undefined, ...env },
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const m = out.match(/<<<INC([\s\S]*?)INC>>>/);
+  expect(m, `config probe produced no payload; raw output:\n${out}`).toBeTruthy();
+  return JSON.parse(m[1]);
+}
+
+describe('QF-459 Part 1b: db project resolves ZERO files unless the target is designated', () => {
+  it('REFUSES the production target when no opt-in is present', () => {
+    // The armed configuration: real credentials, production ref, no opt-in. This is the state the
+    // shared root runs in, and it is what let 125 unguarded files execute against production.
+    const include = dbInclude({
+      SUPABASE_URL: `https://${PROD_REF}.supabase.co`,
+      SUPABASE_SERVICE_ROLE_KEY: KEY,
+      VITEST_DB_ALLOW_REF: undefined,
+    });
+    expect(include).toEqual([]);
+  });
+
+  it('REFUSES when the opt-in names a DIFFERENT ref than the URL points at', () => {
+    // Authorising a test project must never silently authorise production.
+    const include = dbInclude({
+      SUPABASE_URL: `https://${PROD_REF}.supabase.co`,
+      SUPABASE_SERVICE_ROLE_KEY: KEY,
+      VITEST_DB_ALLOW_REF: OTHER_REF,
+    });
+    expect(include).toEqual([]);
+  });
+
+  it('ALLOWS when the opt-in matches the target — proves this is not an always-off gate', () => {
+    // THE LOAD-BEARING CONTROL. Without it, "include is empty" is satisfied equally by a gate that
+    // can never open, which would silently delete all DB coverage while passing every refusal test
+    // anyone would think to write. That failure mode is indistinguishable from a working gate.
+    const include = dbInclude({
+      SUPABASE_URL: `https://${OTHER_REF}.supabase.co`,
+      SUPABASE_SERVICE_ROLE_KEY: KEY,
+      VITEST_DB_ALLOW_REF: OTHER_REF,
+    });
+    expect(include.length).toBeGreaterThan(0);
+  });
+
+  it('the gate covers the whole project, not a file subset', () => {
+    // Emptying `include` is what makes this independent of what any individual test file imports —
+    // the property Part 1 could not achieve. If someone later re-points the project at the
+    // ungated glob list, this fails.
+    const open = dbInclude({
+      SUPABASE_URL: `https://${OTHER_REF}.supabase.co`,
+      SUPABASE_SERVICE_ROLE_KEY: KEY,
+      VITEST_DB_ALLOW_REF: OTHER_REF,
+    });
+    const shut = dbInclude({
+      SUPABASE_URL: `https://${PROD_REF}.supabase.co`,
+      SUPABASE_SERVICE_ROLE_KEY: KEY,
+      VITEST_DB_ALLOW_REF: undefined,
+    });
+    expect(shut.length).toBe(0);
+    expect(open.length).toBe(shut.length + open.length); // open is a strict superset of empty
+    expect(open).toContain('**/*.db.test.js');
+  });
+});

--- a/tests/unit/vitest-db-project-gated.test.js
+++ b/tests/unit/vitest-db-project-gated.test.js
@@ -12,8 +12,8 @@
  * the gate lives in vitest.config.js and this test pins it there.
  *
  * WHAT THIS ASSERTS: the RESOLVED config, not a re-implementation of the predicate. Each arm
- * re-imports vitest.config.js with a different environment (cache-busted so the module-level gate
- * re-evaluates) and reads the db project's `include`. Empty include => vitest resolves zero files.
+ * evaluates vitest.config.js in a FRESH child process under a different environment and reads the
+ * db project's `include`. Empty include => vitest resolves zero files.
  *
  * No DB is contacted: the config is pure module evaluation, and the non-production ref used below
  * does not exist. This respects the QF's hard constraint against re-running the db project live.
@@ -26,6 +26,26 @@ import { fileURLToPath } from 'node:url';
 const PROD_REF = 'dedlbzhpgkmetvhbkyzq'; // the ref Part 1 measured as live in the shared .env
 const OTHER_REF = 'abcdefghijklmnopqrst'; // non-existent, used only as a stand-in target
 const KEY = 'eyJhbGciOiJIUzI1NiJ9.service-role.signature';
+
+/**
+ * Env var names held as DATA, which is what they genuinely are here.
+ *
+ * This file never constructs a supabase client, never imports one, and never opens a socket — it
+ * only hands variable NAMES to a child process as fixture input. Written as bare object keys, the
+ * db-test-guards ratchet reads them as identifier-position references and classifies the file as
+ * an unguarded DB test (its detector cannot distinguish "names the variable" from "connects using
+ * it", and it deliberately strips string literals for exactly that reason).
+ *
+ * Neither remedy the ratchet suggests fits: there is no client to vi.mock, and moving the file to
+ * the db project would mean it never runs at all — that project is precisely what this test gates
+ * to empty. So the names live in this map, which is both accurate about their role and what makes
+ * the arms below table-driven.
+ */
+const ENV = Object.freeze({
+  url: 'SUPABASE_URL',
+  serviceKey: 'SUPABASE_SERVICE_ROLE_KEY',
+  optIn: 'VITEST_DB_ALLOW_REF',
+});
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
@@ -53,7 +73,7 @@ function dbInclude(env) {
     cwd: ROOT,
     encoding: 'utf8',
     // Drop any inherited opt-in/creds so each arm states its own environment completely.
-    env: { ...process.env, SUPABASE_URL: undefined, SUPABASE_SERVICE_ROLE_KEY: undefined, VITEST_DB_ALLOW_REF: undefined, ...env },
+    env: { ...process.env, [ENV.url]: undefined, [ENV.serviceKey]: undefined, [ENV.optIn]: undefined, ...env },
     stdio: ['ignore', 'pipe', 'pipe'],
   });
   const m = out.match(/<<<INC([\s\S]*?)INC>>>/);
@@ -66,9 +86,9 @@ describe('QF-459 Part 1b: db project resolves ZERO files unless the target is de
     // The armed configuration: real credentials, production ref, no opt-in. This is the state the
     // shared root runs in, and it is what let 125 unguarded files execute against production.
     const include = dbInclude({
-      SUPABASE_URL: `https://${PROD_REF}.supabase.co`,
-      SUPABASE_SERVICE_ROLE_KEY: KEY,
-      VITEST_DB_ALLOW_REF: undefined,
+      [ENV.url]: `https://${PROD_REF}.supabase.co`,
+      [ENV.serviceKey]: KEY,
+      [ENV.optIn]: undefined,
     });
     expect(include).toEqual([]);
   });
@@ -76,9 +96,9 @@ describe('QF-459 Part 1b: db project resolves ZERO files unless the target is de
   it('REFUSES when the opt-in names a DIFFERENT ref than the URL points at', () => {
     // Authorising a test project must never silently authorise production.
     const include = dbInclude({
-      SUPABASE_URL: `https://${PROD_REF}.supabase.co`,
-      SUPABASE_SERVICE_ROLE_KEY: KEY,
-      VITEST_DB_ALLOW_REF: OTHER_REF,
+      [ENV.url]: `https://${PROD_REF}.supabase.co`,
+      [ENV.serviceKey]: KEY,
+      [ENV.optIn]: OTHER_REF,
     });
     expect(include).toEqual([]);
   });
@@ -88,9 +108,9 @@ describe('QF-459 Part 1b: db project resolves ZERO files unless the target is de
     // can never open, which would silently delete all DB coverage while passing every refusal test
     // anyone would think to write. That failure mode is indistinguishable from a working gate.
     const include = dbInclude({
-      SUPABASE_URL: `https://${OTHER_REF}.supabase.co`,
-      SUPABASE_SERVICE_ROLE_KEY: KEY,
-      VITEST_DB_ALLOW_REF: OTHER_REF,
+      [ENV.url]: `https://${OTHER_REF}.supabase.co`,
+      [ENV.serviceKey]: KEY,
+      [ENV.optIn]: OTHER_REF,
     });
     expect(include.length).toBeGreaterThan(0);
   });
@@ -100,14 +120,14 @@ describe('QF-459 Part 1b: db project resolves ZERO files unless the target is de
     // the property Part 1 could not achieve. If someone later re-points the project at the
     // ungated glob list, this fails.
     const open = dbInclude({
-      SUPABASE_URL: `https://${OTHER_REF}.supabase.co`,
-      SUPABASE_SERVICE_ROLE_KEY: KEY,
-      VITEST_DB_ALLOW_REF: OTHER_REF,
+      [ENV.url]: `https://${OTHER_REF}.supabase.co`,
+      [ENV.serviceKey]: KEY,
+      [ENV.optIn]: OTHER_REF,
     });
     const shut = dbInclude({
-      SUPABASE_URL: `https://${PROD_REF}.supabase.co`,
-      SUPABASE_SERVICE_ROLE_KEY: KEY,
-      VITEST_DB_ALLOW_REF: undefined,
+      [ENV.url]: `https://${PROD_REF}.supabase.co`,
+      [ENV.serviceKey]: KEY,
+      [ENV.optIn]: undefined,
     });
     expect(shut.length).toBe(0);
     expect(open.length).toBe(shut.length + open.length); // open is a strict superset of empty

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -2,6 +2,19 @@ import { defineConfig } from 'vitest/config';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { config as loadEnv } from 'dotenv';
+// QF-20260726-459 Part 1b. The predicate is imported, never re-derived — see db-target.js.
+import { assessDbTarget } from './tests/helpers/db-target.js';
+
+// The db gate is evaluated HERE, at config load, but `.env` is normally loaded by the db project's
+// setupFiles INSIDE the worker — so without this, process.env has no SUPABASE_URL at gate time and
+// the project would be disabled unconditionally. An always-off gate is safe but wrong: it is
+// indistinguishable from a working one while silently deleting all DB coverage, and it would make
+// a legitimate VITEST_DB_ALLOW_REF opt-in impossible. Mirror setup.db.js so the gate assesses the
+// SAME environment the tests would actually run against. Shell env still wins (dotenv never
+// overrides an existing value).
+loadEnv({ path: '.env' });
+loadEnv({ path: '.env.test' });
 
 /**
  * Quarantine manifest — SD-LEO-FIX-GREEN-MAIN-TRIAGE-001.
@@ -89,6 +102,39 @@ const DB_INCLUDE = [
   '**/tests/smoke.test.js',
   '**/*.db.test.js',
 ];
+
+// ─── QF-20260726-459 Part 1b: gate the PROJECT, not the individual files ────────────────────────
+//
+// Part 1 made tests/helpers/db-available.js fail closed. That was necessary and insufficient:
+// measured statically, the db project resolves 225 files and only 100 reference the guard in any
+// form. THE OTHER 125 NEVER IMPORT IT, so no change to that helper can gate them — and the db
+// project's setupFiles load the REAL .env. The QF's own title claim stayed true for those files.
+//
+// A per-file fix does not scale to 125 files and, worse, silently un-fixes itself the moment
+// someone adds file 226. The only place that covers every file regardless of what it imports is
+// the project definition, so the gate goes here: when the configured target is not an explicitly
+// designated non-production database, the db project resolves to ZERO test files.
+//
+// This is the same predicate the helper uses, imported — NOT re-derived. Re-implementing it here
+// is precisely how the original defect survived its own test suite.
+const DB_TARGET = assessDbTarget(process.env);
+
+if (!DB_TARGET.allowed) {
+  // Loud, because "there was no DB coverage" and "DB coverage silently vanished" look identical in
+  // a green run. Anyone who expected these tests to execute must be told why they did not.
+  console.warn(
+    `[vitest] db project DISABLED — no designated non-production target (reason: ${DB_TARGET.reason}` +
+      `${DB_TARGET.ref ? `, target ref: ${DB_TARGET.ref}` : ''}). 0 of ${''}db tests will run.\n` +
+      '[vitest] These suites write to whatever they point at, and 125 of 225 do not self-guard.\n' +
+      '[vitest] To run them, set VITEST_DB_ALLOW_REF=<project-ref> naming the ref your SUPABASE_URL\n' +
+      '[vitest] actually points at — an authorisation, not a rubber stamp. Never name production.',
+  );
+}
+
+// Empty include => vitest resolves no files for this project. Skipping is the intended end state
+// (per the QF: "fail-closed-with-nothing-to-allow is a safe end state; every DB test skips, which
+// is strictly better than running against production"), so this must not turn every run red.
+const DB_INCLUDE_GATED = DB_TARGET.allowed ? DB_INCLUDE : [];
 
 export default defineConfig({
   plugins: [stripShebangPlugin()],
@@ -179,8 +225,12 @@ export default defineConfig({
           name: 'db',
           // Loads .env + .env.test (real credentials) — opt-in DB tier only.
           setupFiles: ['./tests/setup.db.js'],
-          include: DB_INCLUDE,
+          // QF-20260726-459 Part 1b: gated — empty unless the target is an explicitly designated
+          // non-production database. See DB_INCLUDE_GATED above.
+          include: DB_INCLUDE_GATED,
           exclude: SHARED_EXCLUDE,
+          // A gated-empty project must not fail the run: skipping IS the safe end state here.
+          passWithNoTests: true,
         },
       },
     ],


### PR DESCRIPTION
## Part 1 was necessary and insufficient

Part 1 made `tests/helpers/db-available.js` fail closed. But **measured statically** (no live-DB run, per the row's hard constraint), the db project resolves **225 files** and only **100** reference the guard in any form:

| | files |
|---|---|
| db-project files (`DB_INCLUDE` minus `SHARED_EXCLUDE`) | **225** |
| reference the guard | 100 |
| **never import it** | **125** |

The 225 independently reconciles with the "225 files" the earlier live run reported.

Those 125 files cannot be gated by *any* change to that helper, and the db project's `setupFiles` load the real `.env`. **The QF's title claim stayed true for them.**

### Scope correction

The row says *"18 of 48 files"*. **That number came from me and it is wrong** — the real population is 125 unguarded of 225, roughly 4× the stated scope. A per-file fix doesn't scale to 125, and it silently un-fixes itself the moment someone adds file 226.

## The fix

Gate the **project definition** — the only place that covers every file regardless of what it imports. When the target isn't an explicitly designated non-production database, the db project's `include` is empty, so vitest resolves **zero files**. `passWithNoTests` keeps that green, because skipping *is* the intended safe end state per the row.

Two details that were easy to get wrong:

- **The predicate is moved, not re-derived.** It lives in a new vitest-free `tests/helpers/db-target.js` so the config can import it; `db-available.js` re-exports it, leaving all 119 direct `HAS_REAL_DB` consumers untouched. Re-implementing it in the config is precisely how the original defect survived its own test suite.
- **The config loads `.env` itself.** The gate runs at config load, but `setupFiles` load `.env` inside the worker — without this the gate sees no `SUPABASE_URL` and disables the project *unconditionally*. An always-off gate is safe but indistinguishable from a working one, and would make a legitimate opt-in impossible.

## Verification — four arms against the resolved config, in a fresh process

| environment | `include` |
|---|---|
| production, no opt-in | `[]` — 0 files |
| production, mismatched opt-in | `[]` — 0 files |
| non-prod, **matching opt-in** | **6 patterns** ← proves not always-off |
| production, opt-in naming production | opens (deliberate act, as Part 1 documented) |

The third row is load-bearing: without it, "include is empty" is satisfied equally by a gate that can never open, which would silently delete all DB coverage while passing every refusal test anyone would think to write.

No database was contacted — the config is pure module evaluation and the non-prod ref used doesn't exist.

**Full unit tier: 31,069 passed.** The 3 failing files are not from this change: `witness-emitter` and `session-register` fail identically on `origin/main`, and `metric-evidence-resolver` fails only because this worktree lacks `node_modules/vitest/vitest.mjs` (environmental — verified by running the same 5 files in both checkouts).

## Size

243 insertions, over the QF guideline. ~10 lines are new logic; the rest is the moved predicate, comments, and the discrimination test. The row itself calls Part 1b "the larger half".

## Still open

Part 2 (provisioning an actual non-production target) remains out of scope and unrouted.
