### PR TITLE
fix(SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E): canary sessions can no longer claim real work

### DIFF
--- a/lib/checkin/steps/canary-claim-fence.cjs
+++ b/lib/checkin/steps/canary-claim-fence.cjs
@@ -27,6 +27,23 @@
 // The verdict reason is carried into the message deliberately. A fence that short-circuits silently
 // is indistinguishable from an idle seat, and "the canary just looked idle" is how this class of
 // defect hides.
+//
+// ── KNOWN RESIDUAL: THE RPC-SIDE CLAIM PATH (PRD AC-6 / TR-4) ─────────────────────────────────
+// THIS FENCE IS CHECK-IN-SCOPED, AND THAT IS A REAL LIMIT, NOT AN OVERSIGHT. It gates the eight
+// acquisition tiers that run inside the check-in pipeline. It does NOT sit inside the `claim_sd` RPC,
+// so it cannot stop a claim issued by any path that calls that RPC without coming through here —
+// scripts/sd-start.js run by hand, a coordinator-side directed claim, or any future caller. A canary
+// that reached one of those would still take real work.
+//
+// Why it is accepted rather than closed here: the defence-in-depth that matters most is UPSTREAM of
+// any claim path — FR-4 stamps the canary at spawn time so every consumer can identify it, and the
+// canary's own loop reaches work only through check-in. Pushing the predicate into the RPC would mean
+// a DB-side function reading session metadata on every claim in the fleet, which is a materially
+// larger blast radius (and gated DDL) than the defect justifies today.
+//
+// What would change that calculus: a canary observed acquiring work while this fence reports it
+// fenced. That is the signal the residual has become a live defect rather than a documented gap, and
+// it is worth a follow-up SD at that point — not a silent widening of this step.
 module.exports = {
   name: 'canary-claim-fence',
   async run(ctx) {

--- a/lib/checkin/steps/canary-claim-fence.cjs
+++ b/lib/checkin/steps/canary-claim-fence.cjs
@@ -1,0 +1,80 @@
+// CANARY CLAIM FENCE — SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E (FR-3).
+//
+// A canary is a PROBE session that must never acquire real work. Before this step existed, nothing
+// stopped one: the self-claim fence (self-claim-gates.cjs) sits at position 13 of 17, while THREE
+// acquiring tiers run ahead of it — directed-assignment (8), recover-stranded-final (10) and
+// adopt-orphan (11) — and resume.cjs (6) short-circuits the whole pipeline once a session already
+// holds a claim. So metadata.self_claim=false could never have been a complete canary fence, which
+// is the finding this step is built on.
+//
+// ── WHY THIS SLOT ─────────────────────────────────────────────────────────────────────────────
+// Registered adjacent to build-forbidden-guard (7), i.e. BEFORE every acquisition tier. Verified
+// coverage: that position already gates 8, 10, 11, 14 (critical-qf-jump), 15 (merged-pool-self-claim)
+// and 16 (self-claim-qf). The only tier it does not cover is 6 (resume) — and resume is reachable
+// ONLY when the canary already holds a claim, which is precisely what this fence prevents. One step
+// here is therefore materially cheaper, and easier to reason about, than gating each of the eight
+// individual claim sites.
+//
+// ── WHY IT ACKS-AND-DECLINES INSTEAD OF JUST SHORT-CIRCUITING ─────────────────────────────────
+// Returning a truthy resolution stops the pipeline (pipeline.cjs:14-22), so directed-assignment (8)
+// never runs and a WORK_ASSIGNMENT aimed at this canary would sit unacked forever. That is the exact
+// shape dispatch.cjs:472-481 refuses to create, citing incident b8eb6111: an assignment left
+// invisible to every claim path. The canary MUST stay dispatchable — reachability is the whole point
+// of a probe, and making it undispatchable (non_fleet / role=adam) would hide it from
+// fleet-dashboard, rollcall, capacity-forecast and the liveness set. So it accepts the message and
+// declines it explicitly, satisfying both invariants: addressable canary, no stranded assignment.
+//
+// The verdict reason is carried into the message deliberately. A fence that short-circuits silently
+// is indistinguishable from an idle seat, and "the canary just looked idle" is how this class of
+// defect hides.
+module.exports = {
+  name: 'canary-claim-fence',
+  async run(ctx) {
+    const { sb, sessionId, sessionMetadata, sessionRole } = ctx;
+    const { ws, ackMessage, isInformationalNudge, ASSIGNMENT_RECENCY_WINDOW_MS, DEFAULT_IDLE_WAKEUP_SECONDS } = ctx.helpers;
+
+    // canary-session.js is ESM; this step is CJS. Dynamic import is the established idiom here
+    // (lib/coordinator/reply-class.cjs does the same for fetch-all-paginated.mjs).
+    let isCanarySession;
+    try {
+      ({ isCanarySession } = await import('../../fleet/canary-session.js'));
+    } catch {
+      // A module-resolution failure must NOT silently disable the fence. Fail CLOSED: if we cannot
+      // evaluate canary-ness we do not let this session proceed to an acquisition tier.
+      return {
+        ...ctx.base,
+        action: 'idle',
+        recommended_wakeup_seconds: DEFAULT_IDLE_WAKEUP_SECONDS || 1200,
+        message: 'Canary claim fence could not load its predicate — failing CLOSED and not self-claiming. This is a harness fault, not an idle seat: report it rather than waiting it out.',
+      };
+    }
+
+    const verdict = await isCanarySession(sb, { sessionId, metadata: sessionMetadata });
+    if (!verdict || !verdict.isCanary) return; // not a canary — fall through to the normal ladder
+
+    // ACK-AND-DECLINE any directed WORK_ASSIGNMENT so none is stranded (incident b8eb6111).
+    // Best-effort and non-fatal: failing to ack must never convert the fence into a pass-through,
+    // so this is deliberately INSIDE its own try and AFTER the canary verdict.
+    let declined = 0;
+    try {
+      const sinceIso = new Date(Date.now() - ASSIGNMENT_RECENCY_WINDOW_MS).toISOString();
+      const msgs = await ws.getMessagesForSession(sb, sessionId, { unackedOnly: true, sinceIso, excludeExpired: true });
+      for (const m of (msgs || [])) {
+        if (m.message_type !== 'WORK_ASSIGNMENT' || isInformationalNudge(m)) continue;
+        await ackMessage(sb, m.id, { role: sessionRole, messageType: m.message_type, kind: m.payload && m.payload.kind });
+        declined += 1;
+      }
+    } catch { /* the fence stands regardless; a failed decline is reported below, never swallowed silently */ }
+
+    const declinedNote = declined > 0
+      ? ` Declined ${declined} directed WORK_ASSIGNMENT(s) explicitly so none is left unclaimed and invisible (incident b8eb6111).`
+      : '';
+    return {
+      ...ctx.base,
+      action: 'idle',
+      recommended_wakeup_seconds: DEFAULT_IDLE_WAKEUP_SECONDS || 1200,
+      canary_fence_reason: verdict.reason,
+      message: `Canary probe session (${verdict.reason}): claim acquisition is FENCED — a canary must never take real work. All acquisition tiers (directed assignment, stranded-final recovery, orphan adoption, critical-QF jump, self-claim, QF self-claim) are skipped.${declinedNote} This session remains dispatchable and visible to the fleet on purpose; it simply does not claim.`,
+    };
+  },
+};

--- a/lib/checkin/steps/index.cjs
+++ b/lib/checkin/steps/index.cjs
@@ -41,6 +41,13 @@ module.exports = [
   require('./release-request.cjs'),
   require('./resume.cjs'),
   require('./build-forbidden-guard.cjs'),
+  // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E (FR-3): a canary probe must never acquire
+  // real work. Positioned HERE — immediately after build-forbidden-guard and strictly BEFORE
+  // directed-assignment — because this one slot gates every acquisition tier (8, 10, 11, 14, 15, 16).
+  // The only tier it does not cover is resume (6), which is reachable only when a claim is ALREADY
+  // held, i.e. the state this fence exists to prevent. Moving it below directed-assignment would
+  // silently un-fence the very tier a coordinator dispatch travels through.
+  require('./canary-claim-fence.cjs'),
   require('./directed-assignment.cjs'),
   require('./seat-busy-fence.cjs'),
   require('./recover-stranded-final.cjs'),

--- a/lib/fleet/canary-guard.js
+++ b/lib/fleet/canary-guard.js
@@ -25,6 +25,8 @@ import {
 } from './spawn-control.js';
 
 const CANARY_CALLSIGN_PREFIX = 'Canary-';
+// FR-4 trigger key. Cycle-forced literal: canary-session.js imports isCanaryCallsign from here.
+const CANARY_TRIGGER_KEY = 'canary_session';
 
 /**
  * True only when the operator has explicitly enabled the canary-kill surface. INDEPENDENT of
@@ -190,7 +192,13 @@ export async function stampRespawnedCanary(supabase, { pid, callsign, sessionId 
         const fi = md.fleet_identity || {};
         const setCallsign = isCanaryCallsign(callsign) && !isCanaryCallsign(fi.callsign);
         if (md.account_profile === 'canary' && !setCallsign) return { stamped: true, already: true, session_id: row.session_id };
-        const metadata = { ...md, account_profile: 'canary', ...(setCallsign ? { fleet_identity: { ...fi, callsign } } : {}) };
+        // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E FR-4: stamp the trigger key alongside
+        // account_profile. This is the SECOND (and last) place that writes canary metadata; a VALIDATION
+        // review found the key was read by isCanaryMetadata but written nowhere, i.e. an unreachable
+        // disjunct — exactly what canary-session.js's header warns against. Literal rather than an
+        // import because canary-session.js imports isCanaryCallsign from THIS file, so importing back
+        // would be a cycle (the same constraint spawn-control.js documents); a test pins the two agree.
+        const metadata = { ...md, account_profile: 'canary', [CANARY_TRIGGER_KEY]: true, ...(setCallsign ? { fleet_identity: { ...fi, callsign } } : {}) };
         await supabase.from('claude_sessions').update({ metadata }).eq('session_id', row.session_id);
         return { stamped: true, session_id: row.session_id };
       }

--- a/lib/fleet/canary-session.js
+++ b/lib/fleet/canary-session.js
@@ -1,0 +1,123 @@
+/**
+ * CANARY SESSION PREDICATE — SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E (FR-1, FR-2, FR-4).
+ *
+ * A canary is a PROBE session that must never acquire real work. This module answers exactly one
+ * question — "is the session I am running in a canary?" — and it is consumed by the checkin claim
+ * fence. It does NOT kill, claim, or mutate anything.
+ *
+ * ── WHY THIS IS AN OR, WHEN assertCanaryTarget IS AN AND ──────────────────────────────────────
+ * canary-guard.js's assertCanaryTarget ANDs its conjuncts because it guards a DESTRUCTIVE verb:
+ * "do not kill unless I am CERTAIN this is a canary." A claim fence is RESTRICTIVE, so fail-closed
+ * INVERTS: "do not claim if there is ANY chance this is a canary." Hence a disjunction, and hence
+ * an unavailable signal means NO EVIDENCE — never evidence of non-canary.
+ *
+ * ── WHY THERE IS NO ENV DISJUNCT (and why you must not add one) ───────────────────────────────
+ * An earlier draft made process.env.FLEET_WORKER_CALLSIGN the primary signal. It is DEAD: measured
+ * null on a live fleet worker, and build-session-launch.cjs:118-121 documents the mechanism — only
+ * six CLAUDE_-prefixed vars reach hook subprocesses, which is exactly why sibling FLEET_AUTORESUME_SD
+ * has zero readers repo-wide. Do not substitute a different env carrier; the BOUNDARY is what kills
+ * it, not the variable name. An unreachable disjunct is worse than a stated gap because it reads as
+ * coverage.
+ *
+ * ── THE SIGNAL THAT SURVIVES THE HOOK BOUNDARY ────────────────────────────────────────────────
+ * It survives because it never crosses it. build-session-launch.cjs:128-141 shows the SPAWNER mints
+ * the child session UUID and passes `claude --session-id <uuid>`, so the spawner knows the child's
+ * identity BEFORE the child process exists. It can therefore PRE-REGISTER "this session id is a
+ * canary" at spawn time. The child reads its own CLAUDE_SESSION_ID (populated from instruction zero)
+ * and looks the marker up. No env propagation, and no 0-10s registration gap — which is the window
+ * every metadata-based signal is blind in, because the account_profile and fleet_identity.callsign
+ * stamps both land inside the session-bind loop (spawn-control.js:326-389, up to 10s after launch)
+ * and reboot-respawn-runner.js never writes them at all.
+ */
+
+import { isCanaryCallsign } from './canary-guard.js';
+
+/**
+ * The FR-4 canary-specific metadata trigger. Deliberately NOT non_fleet / role='adam' /
+ * is_coordinator: those trip isDispatchableFleetMember and isFleetWorker, which would hide the
+ * canary from fleet-dashboard, rollcall, capacity-forecast and the liveness set — and, sharpest,
+ * dispatch.cjs:472-481 would make the coordinator HARD-REFUSE to dispatch at it. A probe whose value
+ * is being reachable by the same paths as a real worker must stay addressable.
+ *
+ * A NEW key is safe by construction: every one of those predicates is a CLOSED ALLOWLIST of named
+ * keys (session-predicates.mjs:92-112, genuine-worker.mjs:33-39) — none does a generic truthiness
+ * sweep of metadata.
+ *
+ * The token "probe" is deliberately absent: isFixtureSession matches SESSION IDs against a regex
+ * including (^|[-_])probe([-_]|$), and keeping the vocabulary clear of it avoids inviting a
+ * canary session id that would be silently dropped from every dispatchable set.
+ */
+export const CANARY_TRIGGER_KEY = 'canary_session';
+
+/** payload.kind of the spawn-time pre-registration row (session_coordination, no DDL required). */
+export const CANARY_PRE_REGISTRATION_KIND = 'canary_pre_registration';
+
+export const CANARY_PROFILE = 'canary';
+
+/**
+ * The three signals readable from session metadata already in hand. PURE and synchronous — the
+ * checkin pipeline has already fetched sessionMetadata before any step runs, so this needs no I/O
+ * and cannot throw on a network fault.
+ *
+ * All three are LATE signals: they are blind during the 0-10s registration window and absent
+ * entirely on the reboot-respawn path. They are defence-in-depth behind the pre-registration.
+ * @param {object|null} metadata claude_sessions.metadata
+ */
+export function isCanaryMetadata(metadata) {
+  const md = metadata && typeof metadata === 'object' ? metadata : {};
+  if (md[CANARY_TRIGGER_KEY] === true) return true;
+  if (md.account_profile === CANARY_PROFILE) return true;
+  const identity = md.fleet_identity && typeof md.fleet_identity === 'object' ? md.fleet_identity : {};
+  return isCanaryCallsign(identity.callsign) || isCanaryCallsign(md.callsign);
+}
+
+/**
+ * Look up the spawn-time pre-registration for THIS session id.
+ * @returns {Promise<{found:boolean, lookupFailed:boolean}>} — `lookupFailed` is deliberately
+ *   distinct from `found:false`. Collapsing "no marker" and "could not read" into one falsy value is
+ *   the precise conflation that let a reconciler report a healthy quiet lane while failing on every
+ *   write; the caller decides the policy, this reports the state.
+ */
+export async function findCanaryPreRegistration(supabase, sessionId) {
+  if (!supabase || !sessionId) return { found: false, lookupFailed: false };
+  try {
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .select('id')
+      .eq('target_session', sessionId)
+      .eq('payload->>kind', CANARY_PRE_REGISTRATION_KIND)
+      .limit(1);
+    if (error) return { found: false, lookupFailed: true };
+    return { found: Array.isArray(data) && data.length > 0, lookupFailed: false };
+  } catch {
+    return { found: false, lookupFailed: true };
+  }
+}
+
+/**
+ * THE FENCE PREDICATE. Returns a verdict object rather than a bare boolean so a fenced session can
+ * state WHY — a fence that short-circuits the pipeline silently is indistinguishable from an idle
+ * seat, and "the canary looked idle" is how this class of bug hides.
+ *
+ * FAIL-CLOSED (FR-2). If the pre-registration lookup could not complete, this fences. That is the
+ * opposite of every neighbouring predicate in this codebase, which deliberately fail TOWARD
+ * permissiveness (session-predicates.mjs:115 "fail toward member"; build-forbidden-session.cjs:11-13
+ * "only an EXPLICIT ... returns true"). Reusing their idiom here would make the fence a silent no-op
+ * exactly when something is already wrong.
+ *
+ * The usual objection to fail-closed — "a DB fault would fence the whole fleet" — does not apply:
+ * every acquisition tier this fence guards performs a DB WRITE to claim. If the database is
+ * unreachable, no session can claim anything regardless, so fencing costs nothing real while
+ * removing the window in which a canary could slip through unidentified.
+ *
+ * @param {object} supabase
+ * @param {{sessionId?:string, metadata?:object}} session
+ * @returns {Promise<{isCanary:boolean, reason:string}>}
+ */
+export async function isCanarySession(supabase, { sessionId, metadata } = {}) {
+  if (isCanaryMetadata(metadata)) return { isCanary: true, reason: 'canary_metadata' };
+  const pre = await findCanaryPreRegistration(supabase, sessionId);
+  if (pre.found) return { isCanary: true, reason: 'canary_pre_registration' };
+  if (pre.lookupFailed) return { isCanary: true, reason: 'canary_check_indeterminate_fail_closed' };
+  return { isCanary: false, reason: 'not_canary' };
+}

--- a/lib/fleet/canary-session.js
+++ b/lib/fleet/canary-session.js
@@ -95,6 +95,61 @@ export async function findCanaryPreRegistration(supabase, sessionId) {
 }
 
 /**
+ * FR-4 THE WRITER. Pre-register a MINTED-but-not-yet-existing session id as a canary.
+ *
+ * WHY THIS CAN WORK AT ALL: no foreign key. The only constraint on the column is
+ * `valid_target CHECK (target_session IS NOT NULL OR target_sd IS NOT NULL)` — verified against the
+ * live catalogue, not assumed — so a row may reference a session that does not exist yet. That is the
+ * whole mechanism: the spawner knows the child's id before the child exists, so the marker can be in
+ * place BEFORE the process starts and there is no window to lose.
+ *
+ * WHY NOT JUST STAMP claude_sessions.metadata: the account_profile stamp lives inside spawn-control's
+ * session-bind loop, and that loop is measured to MISS — on 2026-07-25 it closed 1.3s before the
+ * child finished registering, silently discarding the window handle, the profile stamp and the
+ * session bind together, leaving a perfect-looking spawn with empty metadata. A marker that depends on
+ * winning that race is not a marker.
+ *
+ * CALLER CONTRACT — FAIL CLOSED, and this one is deliberate. Unlike enqueueCanaryRequest (advisory,
+ * explicitly fire-and-forget) this is a SAFETY marker: a canary that could not be marked is a canary
+ * that will pass the claim fence and take real work. So callers must REFUSE THE SPAWN when this
+ * returns ok:false rather than proceeding unmarked. This function still never throws — it reports.
+ *
+ * @param {object} supabase
+ * @param {string} sessionId the minted (`claude --session-id`) uuid
+ * @param {{callsign?:string, reason?:string, senderSession?:string}} [meta]
+ * @returns {Promise<{ok:boolean, inserted?:boolean, error?:string}>}
+ */
+export async function writeCanaryPreRegistration(supabase, sessionId, meta = {}) {
+  if (!supabase) return { ok: false, error: 'no_supabase_client' };
+  if (!sessionId) return { ok: false, error: 'no_session_id' };
+  try {
+    const payload = {
+      kind: CANARY_PRE_REGISTRATION_KIND,
+      // Mirror the metadata trigger key so a consumer reading either surface sees the same fact.
+      [CANARY_TRIGGER_KEY]: true,
+      account_profile: CANARY_PROFILE,
+      callsign: meta.callsign || null,
+      spawn_reason: meta.reason || null,
+      // INVARIANT copied from canary-trigger.cjs: advisory lane only — never signal_type /
+      // intent_action, or the friction signal-router and deconfliction sweep scoop the row.
+    };
+    const { error } = await supabase.from('session_coordination').insert({
+      sender_session: meta.senderSession || 'canary-pre-registration',
+      target_session: sessionId,
+      message_type: 'INFO',
+      subject: `[CANARY_PRE_REGISTRATION] ${meta.callsign || sessionId}`,
+      body: 'Spawn-time canary marker: this session id is a PROBE and must not acquire real work.',
+      payload,
+      sender_type: 'spawn-control',
+    });
+    if (error) return { ok: false, error: error.message };
+    return { ok: true, inserted: true };
+  } catch (e) {
+    return { ok: false, error: String((e && e.message) || e) };
+  }
+}
+
+/**
  * THE FENCE PREDICATE. Returns a verdict object rather than a bare boolean so a fenced session can
  * state WHY — a fence that short-circuits the pipeline silently is indistinguishable from an idle
  * seat, and "the canary looked idle" is how this class of bug hides.

--- a/lib/fleet/canary-session.js
+++ b/lib/fleet/canary-session.js
@@ -81,6 +81,18 @@ export function isCanaryMetadata(metadata) {
 export async function findCanaryPreRegistration(supabase, sessionId) {
   if (!supabase || !sessionId) return { found: false, lookupFailed: false };
   try {
+    // LIFECYCLE-BLIND ON PURPOSE, AND THIS IS LOAD-BEARING — do not "tidy" it.
+    //
+    // The filter is target_session + payload->>kind and NOTHING else. It deliberately ignores
+    // read_at, acknowledged_at, expires_at and dead_letter, because this row is a REGISTRY ENTRY, not
+    // a message: its meaning is "this session id is a probe", which does not stop being true when
+    // something marks it read, acknowledges it, expires it, or dead-letters it. The writer
+    // pre-stamps read_at/acknowledged_at precisely so the row stays out of the message lanes, so any
+    // added `.is('acknowledged_at', null)` here would match ZERO rows and silently disable the fence
+    // fleet-wide. An `excludeExpired`/TTL clause would do the same an hour after each spawn.
+    //
+    // Each such addition looks locally harmless and is individually plausible, which is exactly why
+    // it is written down here and pinned by tests ("survives read/ack/expiry/dead-letter").
     const { data, error } = await supabase
       .from('session_coordination')
       .select('id')
@@ -133,6 +145,26 @@ export async function writeCanaryPreRegistration(supabase, sessionId, meta = {})
       // INVARIANT copied from canary-trigger.cjs: advisory lane only — never signal_type /
       // intent_action, or the friction signal-router and deconfliction sweep scoop the row.
     };
+    // THIS IS A REGISTRY ROW, NOT A MESSAGE — and the three fields below are what make it one.
+    //
+    // A SECURITY review caught this as a live defect in the first version, MEASURED against the real
+    // table rather than reasoned about: session_coordination.expires_at DEFAULTS to now() + 1 hour,
+    // and cleanup_expired_coordination() DELETEs any row WHERE expires_at < now() AND
+    // acknowledged_at IS NOT NULL. Because roll-call (checkin step 4) surfaces coordinator pushes
+    // BEFORE this fence (step 8) and stamps read_at then acknowledged_at on a non-directive INFO row,
+    // the canary's OWN check-ins armed the deletion of its own safety marker. Roughly an hour after
+    // spawn the lookup returned {found:false, lookupFailed:false} — indistinguishable from "never was
+    // a canary" — so the fence silently OPENED, in the UNSAFE direction, on exactly the sessions FR-4
+    // exists for. No unit test could see it: every suite mocks the client, so neither the DB default
+    // nor the roll-call ack is visible from here.
+    //
+    // expires_at:null makes `expires_at < now()` evaluate to NULL (never true), so the reaper cannot
+    // match this row. Pre-stamping read_at/acknowledged_at takes it out of the coordinator push lane
+    // (it is not a message and must never be delivered to anyone) and also excludes it from the
+    // dead-letter pass, which selects on both being NULL. findCanaryPreRegistration deliberately
+    // ignores all three columns — see the lifecycle-blindness note there, which is load-bearing.
+    const nowIso = new Date().toISOString();
+    // eslint-disable-next-line session-coordination-insert-classguard/no-raw-session-coordination-insert -- insertCoordinationRow()'s assertValidTarget REFUSES a target_session that does not already name a row in claude_sessions (dispatch.cjs:142-155). Pre-registering the MINTED-but-not-yet-existing session id is precisely this module's mechanism, so the canonical choke point cannot express this write by construction.
     const { error } = await supabase.from('session_coordination').insert({
       sender_session: meta.senderSession || 'canary-pre-registration',
       target_session: sessionId,
@@ -141,11 +173,17 @@ export async function writeCanaryPreRegistration(supabase, sessionId, meta = {})
       body: 'Spawn-time canary marker: this session id is a PROBE and must not acquire real work.',
       payload,
       sender_type: 'spawn-control',
+      expires_at: null,
+      read_at: nowIso,
+      acknowledged_at: nowIso,
     });
-    if (error) return { ok: false, error: error.message };
+    // CODE, never the driver message. Postgres puts row content ("Failing row contains (…)", carrying
+    // the whole JSONB) into the error payload, and this string travels outward through spawn()'s
+    // `reason` and is printed by scripts/fleet/provision-canary.mjs.
+    if (error) return { ok: false, error: error.code || 'insert_failed' };
     return { ok: true, inserted: true };
   } catch (e) {
-    return { ok: false, error: String((e && e.message) || e) };
+    return { ok: false, error: String((e && e.code) || (e && e.message) || e) };
   }
 }
 

--- a/lib/fleet/canary-session.js
+++ b/lib/fleet/canary-session.js
@@ -115,9 +115,18 @@ export async function findCanaryPreRegistration(supabase, sessionId) {
  * @returns {Promise<{isCanary:boolean, reason:string}>}
  */
 export async function isCanarySession(supabase, { sessionId, metadata } = {}) {
-  if (isCanaryMetadata(metadata)) return { isCanary: true, reason: 'canary_metadata' };
+  if (isCanaryMetadata(metadata)) return { isCanary: true, reason: 'canary_metadata', indeterminate: false };
   const pre = await findCanaryPreRegistration(supabase, sessionId);
-  if (pre.found) return { isCanary: true, reason: 'canary_pre_registration' };
-  if (pre.lookupFailed) return { isCanary: true, reason: 'canary_check_indeterminate_fail_closed' };
-  return { isCanary: false, reason: 'not_canary' };
+  if (pre.found) return { isCanary: true, reason: 'canary_pre_registration', indeterminate: false };
+  if (pre.lookupFailed) {
+    // isCanary:true is the SAFE DEFAULT so a caller that ignores the flag still fails closed. But
+    // `indeterminate` is reported SEPARATELY because the right policy is caller-specific, and baking
+    // one policy in here was a real defect: the claim fence should fence on indeterminacy (claiming
+    // needs the DB anyway, so it costs nothing), whereas the callsign writers must NOT freeze naming
+    // for the whole fleet on a transient fault — "every worker unnamed" reads as a quiet fleet rather
+    // than a broken one. findCanaryPreRegistration already says the caller decides the policy; this
+    // now honours that one level up instead of contradicting it.
+    return { isCanary: true, reason: 'canary_check_indeterminate_fail_closed', indeterminate: true };
+  }
+  return { isCanary: false, reason: 'not_canary', indeterminate: false };
 }

--- a/lib/fleet/reboot-respawn-runner.js
+++ b/lib/fleet/reboot-respawn-runner.js
@@ -29,7 +29,7 @@
  * the REAL invocation argv and the REAL event payloads this runner builds).
  */
 import { loadDesiredSlots, slotsToRoster } from './desired-slots-store.js';
-import { buildLiveSpawnInvocation, resolveProfileDir, isLiveEnabled } from './spawn-control.js';
+import { buildLiveSpawnInvocation, resolveProfileDir, isLiveEnabled, CANARY_PROFILE } from './spawn-control.js';
 // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-F (FR-1): the launch-contract predicate, wired
 // at the live spawn seam below. Same .cjs-from-ESM interop spawn-control.js already uses.
 import { assertLaunchContract } from './build-session-launch.cjs';
@@ -205,6 +205,30 @@ export async function runRebootRespawn(opts = {}) {
         const contract = assertLaunchContract(invocation);
         if (!contract.ok) {
           throw new Error(`LAUNCH CONTRACT VIOLATION — refusing to respawn ${role}/${callsign}: ${contract.violations.join('; ')}`);
+        }
+        // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E FR-4 — PRE-REGISTER A CANARY SLOT.
+        //
+        // THIS PATH IS THE WORST CASE and the reason FR-4 could not be metadata-only: this runner
+        // writes NO canary metadata at any point, so account_profile and fleet_identity.callsign are
+        // not merely late here, they never arrive. A canary respawned at boot was therefore
+        // indistinguishable from an ordinary worker for its entire life, and the claim fence had
+        // nothing to read. The spawner-minted invocation.sessionId is the only signal available
+        // before the process exists.
+        //
+        // Immediately before spawnFn on purpose: the child can check in within milliseconds.
+        //
+        // FAIL CLOSED, DELIBERATELY AGAINST THIS FILE'S FAIL-SOFT HOUSE STYLE (an unresolvable profile
+        // above degrades and still spawns). That policy is right for a profile dir and wrong for a
+        // safety marker: an unmarked canary passes the claim fence and takes real work off the shared
+        // queue. Throwing here is caught by this block's existing handler, which logs and leaves
+        // spawned=false, so the blast radius is EXACTLY this slot — every other slot still respawns and
+        // the fleet still comes back from a reboot, minus one probe.
+        if (slot.account_profile === CANARY_PROFILE) {
+          const { writeCanaryPreRegistration } = await import('./canary-session.js');
+          const preReg = await writeCanaryPreRegistration(supabase, invocation.sessionId, { callsign, reason: 'reboot_respawn' });
+          if (!preReg.ok) {
+            throw new Error(`CANARY PRE-REGISTRATION FAILED — refusing to respawn ${callsign} unmarked: ${preReg.error}`);
+          }
         }
         child = spawnFn(invocation.program, invocation.args, invocation.env);
         spawned = true;

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -248,6 +248,38 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
     if (currency.currencyBypassed) invocation.currencyBypassed = true;
   }
 
+  // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E FR-4 — PRE-REGISTER THE CANARY BEFORE IT RUNS.
+  //
+  // Placed HERE for one reason: the child can check in within milliseconds of starting, and the claim
+  // fence can only see a marker that already exists. Writing it after spawn would recreate the exact
+  // window this SD closes. It is also AFTER the dry-run return above, so a dry run writes nothing.
+  //
+  // FAIL CLOSED — REFUSE THE SPAWN. A canary that cannot be marked is a canary that passes the claim
+  // fence and takes real work off the shared queue, which is the defect this SD exists to prevent. A
+  // refused canary provision costs one retry; an unmarked one corrupts a peer's queue. Note the
+  // metadata stamp further down is NOT a fallback for this: it lives inside the session-bind loop that
+  // was measured missing its window by 1.3s, discarding all three of its writes at once.
+  //
+  // SCOPED TO CANARY SPAWNS, and I am stating why explicitly: a near-miss on 2026-07-26 left a
+  // hardcoded ok:false at this call site that would have refused EVERY spawn, restart, relaunch and
+  // canary-provision — a fleet-wide outage from one line. So this refusal is gated on
+  // accountProfile === CANARY_PROFILE and cannot reach an ordinary worker. A negative control in
+  // tests/unit/fleet/canary-pre-registration.test.js drives an ordinary spawn with a client that
+  // throws on every call and asserts it STILL spawns; if that test ever passes vacuously, this comment
+  // is the record of what it was protecting.
+  if (accountProfile === CANARY_PROFILE) {
+    const { writeCanaryPreRegistration } = await import('./canary-session.js');
+    const preReg = await writeCanaryPreRegistration(supabase, invocation && invocation.sessionId, {
+      callsign,
+      reason: `spawn:${role || 'unknown'}`,
+    });
+    if (!preReg.ok) {
+      log(`[spawn-control] REFUSING canary spawn ${callsign}: pre-registration failed (${preReg.error}) — an unmarked canary can claim real work`);
+      await emitVerbEvent(supabase, { verb: 'spawn', outcome: 'canary_pre_registration_failed' });
+      return { live: false, skipped: true, reason: `canary_pre_registration_failed:${preReg.error}` };
+    }
+  }
+
   const spawner = opts.spawnFn || ((program, args, env) => {
     // FR-2: carry the invocation's repo-root cwd (paired with new-tab -d) so the session registers in claude_sessions.
     // Strip the spawner's OWN Claude Code session markers before inheriting. These identify the
@@ -499,7 +531,24 @@ export async function restart(target, opts = {}) {
   // (catch and degrade to the un-isolated path) would silently reinstate the very defect this FR
   // fixes: a canary without its profile isolation is not a canary. A loud failure on a misconfigured
   // host is the correct outcome for a session whose whole purpose depends on that isolation.
-  const accountProfile = (oldSession && oldSession.metadata && oldSession.metadata.account_profile) || undefined;
+  //
+  // FR-4 FOLLOW-ON: reading account_profile ALONE reproduced FR-5's own blind spot one level down. That
+  // stamp is written inside the session-bind loop, which is measured to miss (1.3s on 2026-07-25,
+  // discarding all three of its writes), and reboot-respawn-runner never writes it at all. So the
+  // sessions most likely to reach a restart UNSTAMPED are exactly the canaries — and an unstamped
+  // canary restarted here came back as an ordinary worker with no profile isolation AND no spawn-time
+  // marker, i.e. free to claim real work. Falling back to the full predicate (which also recognises the
+  // 'Canary-' namespace callsign) means one surviving signal is enough to carry the identity forward.
+  //
+  // This widens FR-6's fail-loud consequence to callsign-only canaries: resolveProfileDir throws on a
+  // host with no FLEET_ACCOUNT_PROFILES_DIR. That is the same trade FR-6 already accepted deliberately
+  // — a canary without its account isolation is not a canary, so refusing loudly beats silently
+  // restarting it as an ordinary un-isolated worker.
+  let accountProfile = (oldSession && oldSession.metadata && oldSession.metadata.account_profile) || undefined;
+  if (!accountProfile) {
+    const { isCanaryMetadata } = await import('./canary-session.js');
+    if (isCanaryMetadata(oldSession && oldSession.metadata)) accountProfile = CANARY_PROFILE;
+  }
   const spawnResult = await spawnReplacement({ oldIdentity, oldSession, accountProfile }, opts);
 
   if (isSingletonRole(role)) {

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -26,6 +26,7 @@ import { resolveSpawnDecisions } from './spawn-executor-core.cjs';
 import { captureNewWindowHandle, enumerateWindows, focusWindow } from './window-handle.js';
 import { evaluateClaimBoundary } from './claim-boundary-probe.cjs';
 
+
 const SINGLETON_ROLES = new Set(['coordinator', 'adam', 'solomon']);
 
 /**
@@ -45,6 +46,10 @@ export const SESSION_BIND_DELAY_MS = 500;
  * constants -- the drift is caught rather than merely hoped against.
  */
 export const CANARY_PROFILE = 'canary';
+// FR-4 trigger key, duplicated here for the SAME cycle reason as CANARY_PROFILE above: importing it
+// from canary-session.js would create spawn-control -> canary-session -> canary-guard -> spawn-control.
+// The drift test below covers it alongside the other two.
+export const CANARY_TRIGGER_KEY = 'canary_session';
 export const CANARY_CALLSIGN_PREFIX = 'Canary-';
 
 /** True only for a callsign in the canary-only namespace. Mirrors canary-guard.js isCanaryCallsign. */
@@ -407,6 +412,20 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
                 ? { window_handle_diagnostics: handleResult.diagnostics }
                 : {}),
               ...(accountProfile ? { account_profile: accountProfile } : {}),
+              // FR-4 (PRD implementation_approach step 5): STAMP THE TRIGGER KEY.
+              //
+              // A VALIDATION review caught that CANARY_TRIGGER_KEY was READ by isCanaryMetadata and
+              // mirrored into the marker payload but written to claude_sessions.metadata NOWHERE — an
+              // unreachable disjunct, which is precisely what canary-session.js's own header forbids
+              // ("worse than a stated gap because it reads as coverage"). I wrote that sentence and
+              // then created an instance of it.
+              //
+              // Stamped here and in canary-guard.js stampRespawnedCanary, the two places that write
+              // canary metadata at all. reboot-respawn-runner deliberately gets NO metadata stamp: it
+              // writes none today and adding one would mean inventing a metadata write on the boot
+              // path; that path is covered by the spawn-time marker instead, which is the whole reason
+              // the marker exists. Stated rather than left as an apparent omission.
+              ...(accountProfile === CANARY_PROFILE ? { [CANARY_TRIGGER_KEY]: true } : {}),
               // SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 — MINT THE CANARY CALLSIGN.
               //
               // assertCanaryTarget is a TWO-CONJUNCT guard: account_profile==='canary' AND a

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -483,7 +483,24 @@ export async function restart(target, opts = {}) {
   const { data: oldSession } = await supabase.from('claude_sessions').select('metadata').eq('session_id', oldIdentity.session_id).maybeSingle();
   const role = roleOf(oldSession);
 
-  const spawnResult = await spawnReplacement({ oldIdentity, oldSession }, opts);
+  // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E (FR-5): thread the OLD session's
+  // account_profile into the replacement. It was omitted here while oldSession.metadata was already
+  // in hand three lines above, so a restarted canary came back as an ORDINARY, UN-ISOLATED worker:
+  // accountProfile drives BOTH the profileDir/CLAUDE_CONFIG_DIR account isolation (spawn():189) AND
+  // the metadata stamp that gates the canary-callsign mint (:358, :381). relaunchUnderProfile already
+  // passed it correctly, so restart() was the only verb missing it — and canaryRestart,
+  // drainAndRestart and fleet-supervisor all converge on THIS call, so one line repairs three paths.
+  //
+  // FR-6 DECISION — FAIL LOUD, made explicitly rather than discovered. resolveProfileDir THROWS when
+  // FLEET_ACCOUNT_PROFILES_DIR is unset (:74). restart() never reached that code before, so this is a
+  // real behaviour change: restarting a profile-stamped session on an unconfigured host now throws
+  // where it previously succeeded. Accepted, on measurement rather than intuition — of 16 live
+  // active/idle sessions exactly ONE carries account_profile, and it is the canary. The alternative
+  // (catch and degrade to the un-isolated path) would silently reinstate the very defect this FR
+  // fixes: a canary without its profile isolation is not a canary. A loud failure on a misconfigured
+  // host is the correct outcome for a session whose whole purpose depends on that isolation.
+  const accountProfile = (oldSession && oldSession.metadata && oldSession.metadata.account_profile) || undefined;
+  const spawnResult = await spawnReplacement({ oldIdentity, oldSession, accountProfile }, opts);
 
   if (isSingletonRole(role)) {
     // FR-4: never a bespoke retire-then-spawn sequence -- the EXISTING register-then-retire mutex owns

--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -239,6 +239,72 @@ function reserveParkedIdentities(usedCallsigns, usedColors, recentSessions, acti
 // last one actually broadcast (metadata.fleet_identity_last_sent, distinct from fleet_identity
 // itself so a partially-failed send is retried next tick) — true means re-send is due.
 /**
+ * Split the worker set into the three naming buckets. EXTRACTED so the load-bearing property is
+ * TESTABLE: a canary must never enter `assignedRaw`.
+ *
+ * WHY THAT SPECIFIC PROPERTY. The first version of FR-7 put canaries in assignedRaw, which looked
+ * right — they are "already assigned", they keep their identity. A TESTING review then showed it was
+ * INERT for every case FR-7 had just added: dedupeAssignedCallsigns treats a worker with no
+ * metadata.fleet_identity.callsign as "not really assigned" and DEMOTES it into needsAssignment, where
+ * it is renamed to a NATO callsign and broadcast. An unstamped canary has no callsign by definition,
+ * so the pre-registration disjunct bought nothing — only the case that already worked before FR-7 (a
+ * canary already holding 'Canary-N') survived. The verdict was correct and the pipeline overrode it
+ * two steps later, which is why the assertion has to be about the BUCKET, not the verdict.
+ *
+ * @returns {{canaryProtected:Array, assignedRaw:Array, needsAssignment:Array}}
+ */
+function partitionWorkersForNaming(workers, preRegisteredCanaries, forceReassign, isCanaryMd) {
+  const canaryProtected = [];
+  const assignedRaw = [];
+  const needsAssignment = [];
+  for (const worker of workers || []) {
+    const verdict = classifyWorkerNaming(worker, preRegisteredCanaries, forceReassign, isCanaryMd);
+    if (verdict === 'canary_marker' || verdict === 'canary_metadata') canaryProtected.push(worker);
+    else if (verdict === 'needs_assignment') needsAssignment.push(worker);
+    else assignedRaw.push(worker);
+  }
+  return { canaryProtected, assignedRaw, needsAssignment };
+}
+
+/**
+ * Load the set of session ids carrying a spawn-time canary pre-registration marker (FR-7).
+ *
+ * EXTRACTED FROM main() BECAUSE IT WAS UNTESTABLE THERE, and a TESTING review proved that mattered:
+ * with this inline, three separate mutations stayed green across the whole suite — deleting the
+ * fail-closed `return`, deleting `if (error) throw error`, and making the Set-population loop a no-op
+ * (which disables FR-7's cron protection entirely). The only assertion reaching any of it was a regex
+ * that matched the console.log STRING, not the control flow. The classifier was always driven with a
+ * hand-built Set, so nothing ever exercised DB → Set.
+ *
+ * CHUNKED: a single `.in()` over every worker builds one long URL and PostgREST/proxies answer an
+ * oversized query string with 414 — which would land in the fail-closed path and name NOBODY. That
+ * gets likelier as the fleet grows and presents as an idle cron rather than an error, so an unchunked
+ * fail-closed quietly becomes fail-always at scale.
+ *
+ * @returns {Promise<{ok:boolean, canaries:Set<string>, error?:string}>} ok:false means the caller must
+ *   NOT rename anyone this run. Reports rather than throws so the policy stays visible at the call site.
+ */
+async function loadPreRegisteredCanaries(supabase, sessionIds, kind, chunkSize = 50) {
+  const canaries = new Set();
+  const ids = (sessionIds || []).filter(Boolean);
+  try {
+    for (let i = 0; i < ids.length; i += chunkSize) {
+      const { data, error } = await supabase
+        .from('session_coordination')
+        .select('target_session')
+        .in('target_session', ids.slice(i, i + chunkSize))
+        .eq('payload->>kind', kind);
+      if (error) throw error;
+      for (const row of (data || [])) canaries.add(row.target_session);
+    }
+    return { ok: true, canaries };
+  } catch (e) {
+    // CODE before message: a driver error string can carry row content outward into a shared log.
+    return { ok: false, canaries, error: (e && (e.code || e.message)) || 'lookup_failed' };
+  }
+}
+
+/**
  * Decide whether a worker keeps its identity or gets (re)named. EXTRACTED FROM main() so it can be
  * tested: while this lived inline, the only available assertion was a source regex for
  * `preRegisteredCanaries.has(...)`, and a mutation wrapping that call in `false &&` left the regex
@@ -432,35 +498,33 @@ async function main() {
   // namespace discriminator. Batch-fetch the spawn-time PRE-REGISTERED markers ONCE (keyed on the
   // spawner-minted session id) rather than one lookup per worker — a per-worker await here would be an
   // N+1 against a table this cron already reads in bulk.
-  const preRegisteredCanaries = new Set();
-  let isCanaryMetadata;
-  try {
-    const mod = await import('../lib/fleet/canary-session.js');
-    const { CANARY_PRE_REGISTRATION_KIND } = mod;
-    isCanaryMetadata = mod.isCanaryMetadata;
-    const ids = uniqueWorkers.map((w) => w.session_id).filter(Boolean);
-    if (ids.length) {
-      const { data, error } = await supabase
-        .from('session_coordination')
-        .select('target_session')
-        .in('target_session', ids)
-        .eq('payload->>kind', CANARY_PRE_REGISTRATION_KIND);
-      if (error) throw error;
-      for (const row of (data || [])) preRegisteredCanaries.add(row.target_session);
-    }
-  } catch (e) {
+  const mod = await import('../lib/fleet/canary-session.js');
+  const isCanaryMetadata = mod.isCanaryMetadata;
+  const preReg = await loadPreRegisteredCanaries(supabase, uniqueWorkers.map((w) => w.session_id), mod.CANARY_PRE_REGISTRATION_KIND);
+  if (!preReg.ok) {
     // FAIL CLOSED on this one axis: renaming is IRREVERSIBLE, so if the marker set cannot be read we
     // must not rename anyone this run. Skipping a genuine worker costs one unnamed cron tick; renaming
     // a canary destroys the discriminator for good.
-    console.log(`[assign-fleet-identities] canary pre-registration lookup FAILED (${e?.message}) — skipping all naming this run rather than risk renaming a canary`);
+    console.log(`[assign-fleet-identities] canary pre-registration lookup FAILED (${preReg.error}) — skipping all naming this run rather than risk renaming a canary`);
     return;
   }
+  const preRegisteredCanaries = preReg.canaries;
 
-  for (const worker of uniqueWorkers) {
-    const verdict = classifyWorkerNaming(worker, preRegisteredCanaries, forceReassign, isCanaryMetadata);
-    if (verdict === 'needs_assignment') needsAssignment.push(worker);
-    else assignedRaw.push(worker);
-  }
+  // CANARIES GO IN THEIR OWN BUCKET, not into assignedRaw. A TESTING review proved the earlier version
+  // was INERT for the exact case FR-7 added: classifyWorkerNaming correctly returned a canary verdict,
+  // the worker went into assignedRaw, and then dedupeAssignedCallsigns — which treats any worker with
+  // no metadata.fleet_identity.callsign as "not really assigned" — DEMOTED it straight back into
+  // needsAssignment, where it was renamed to a NATO callsign and broadcast. An unstamped canary has no
+  // callsign by definition, so every newly-protected case was demoted and only the case that already
+  // worked before FR-7 (one already holding 'Canary-N') survived. The verdict was right and the
+  // pipeline overrode it downstream — a fix verified at the decision instead of at the consumer.
+  //
+  // Canaries live outside the NATO tier-band scheme entirely, so they must not participate in
+  // band-dedupe at all: this bucket is simply left alone.
+  const parts = partitionWorkersForNaming(uniqueWorkers, preRegisteredCanaries, forceReassign, isCanaryMetadata);
+  const canaryProtected = parts.canaryProtected;
+  assignedRaw.push(...parts.assignedRaw);
+  needsAssignment.push(...parts.needsAssignment);
 
   // QF-20260528-581 (Bug A): resolve duplicate callsigns within the assigned set
   // (e.g. "Alpha" on two sessions after session_id rotation). Keep the most-recent
@@ -478,6 +542,17 @@ async function main() {
   // so a demoted duplicate's callsign/color is free for reassignment.
   const usedCallsigns = new Set(assigned.map(w => w.metadata.fleet_identity.callsign));
   const usedColors = new Set(assigned.map(w => w.metadata.fleet_identity.color));
+
+  // A protected canary is not named by this cron, but any label it ALREADY holds must stay reserved.
+  // Otherwise a canary that an earlier clobber renamed to a NATO callsign (still protected, because the
+  // spawn-time marker survives the rename) would have that callsign handed to a second worker as well —
+  // trading a rename bug for a duplicate-identity bug.
+  for (const c of canaryProtected) {
+    const cs = c.metadata?.fleet_identity?.callsign;
+    const col = c.metadata?.fleet_identity?.color;
+    if (cs) usedCallsigns.add(cs);
+    if (col) usedColors.add(col);
+  }
 
   // SD-FDBK-ENH-COORDINATOR-TOOLING-DELTA-001: also reserve callsigns/colors of recently-seen,
   // non-terminated sessions that are temporarily OUT of the 5-min active-view (parked between SDs
@@ -515,6 +590,7 @@ async function main() {
         .update({ metadata })
         .eq('session_id', w.session_id);
       // Send updated identity message so worker's local file refreshes
+      // eslint-disable-next-line session-coordination-insert-classguard/no-raw-session-coordination-insert -- PRE-EXISTING site, not introduced by this SD; flagged only because --diff mode lints whole changed files and SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E (FR-7) touches this file. It is part of the ~28-site backlog this lint deliberately does not convert en masse (see its header), and the DB-level advisory trigger in 20260702_session_coordination_insert_lint.sql covers it regardless. Converting SET_IDENTITY broadcast semantics to insertCoordinationRow would add assertValidTarget THROW-on-lookup-failure into this naming loop, which can abort naming mid-run — a real behaviour change that belongs in its own SD, not smuggled into a canary-fence change.
       await supabase
         .from('session_coordination')
         .insert({
@@ -609,6 +685,7 @@ async function main() {
     }
 
     // Send SET_IDENTITY coordination message
+    // eslint-disable-next-line session-coordination-insert-classguard/no-raw-session-coordination-insert -- PRE-EXISTING site, not introduced by this SD; flagged only because --diff mode lints whole changed files and SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E (FR-7) touches this file. It is part of the ~28-site backlog this lint deliberately does not convert en masse (see its header), and the DB-level advisory trigger in 20260702_session_coordination_insert_lint.sql covers it regardless. Converting SET_IDENTITY broadcast semantics to insertCoordinationRow would add assertValidTarget THROW-on-lookup-failure into this naming loop, which can abort naming mid-run — a real behaviour change that belongs in its own SD, not smuggled into a canary-fence change.
     const { error: msgErr } = await supabase
       .from('session_coordination')
       .insert({
@@ -653,7 +730,7 @@ function identityAccountUuid8(metadata, accountIdentity) {
   return (accountIdentity && accountIdentity.accountUuid8) || null;
 }
 
-module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, extendCallsign, buildTierCallsignBands, tierRankOf, pickCallsignForTier, callsignInTierBand, classifyWorkerNaming, identityNeedsRebroadcast, identityAccountUuid8 };
+module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, extendCallsign, buildTierCallsignBands, tierRankOf, pickCallsignForTier, callsignInTierBand, classifyWorkerNaming, loadPreRegisteredCanaries, partitionWorkersForNaming, identityNeedsRebroadcast, identityAccountUuid8 };
 
 if (require.main === module) {
   main().then(async () => {

--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -239,6 +239,46 @@ function reserveParkedIdentities(usedCallsigns, usedColors, recentSessions, acti
 // last one actually broadcast (metadata.fleet_identity_last_sent, distinct from fleet_identity
 // itself so a partially-failed send is retried next tick) — true means re-send is due.
 /**
+ * Reserve the labels a PROTECTED CANARY already holds, so they are not also handed to a real worker.
+ *
+ * A protected canary is not named by this cron, so it never reaches the `assigned` set that seeds
+ * usedCallsigns/usedColors. Without this, a canary that an earlier clobber renamed to a NATO callsign —
+ * still protected, because the spawn-time marker survives the rename — would have that callsign issued
+ * to a second session as well, trading the rename bug for a duplicate-identity bug.
+ *
+ * Extracted (R6) because the inline version was unverified: removing the add() left the whole suite
+ * green. Mirrors reserveParkedIdentities' mutate-the-sets shape deliberately. Pure + DB-free.
+ */
+function reserveCanaryLabels(usedCallsigns, usedColors, canaryProtected) {
+  for (const c of canaryProtected || []) {
+    const cs = c && c.metadata && c.metadata.fleet_identity && c.metadata.fleet_identity.callsign;
+    const col = c && c.metadata && c.metadata.fleet_identity && c.metadata.fleet_identity.color;
+    if (cs) usedCallsigns.add(cs);
+    if (col) usedColors.add(col);
+  }
+  return { usedCallsigns, usedColors };
+}
+
+/**
+ * Plan a naming run: read the markers, then bucket the workers. Returns `skip:true` when the marker
+ * lookup failed, in which case NOBODY may be named this run.
+ *
+ * WHY THIS EXISTS (R3). The loader already reported ok:false correctly, but nothing proved main() ACTED
+ * on it — deleting the fail-closed `return` left the entire suite green. That is the identical shape as
+ * F2 earlier in this SD (a correct decision whose consumer silently discarded it), and it is the reason
+ * this SD needed a second review pass at all. Combining the two steps here makes the CONSEQUENCE
+ * testable rather than the flag: on a failed lookup this returns no buckets at all, so there is no list
+ * a caller could name from even if it ignored `skip`.
+ *
+ * @returns {Promise<{skip:true, error:string}|{skip:false, canaryProtected:Array, assignedRaw:Array, needsAssignment:Array}>}
+ */
+async function planNamingRun(supabase, workers, kind, forceReassign, isCanaryMd, chunkSize = 50) {
+  const preReg = await loadPreRegisteredCanaries(supabase, (workers || []).map((w) => w && w.session_id), kind, chunkSize);
+  if (!preReg.ok) return { skip: true, error: preReg.error };
+  return { skip: false, ...partitionWorkersForNaming(workers, preReg.canaries, forceReassign, isCanaryMd) };
+}
+
+/**
  * Split the worker set into the three naming buckets. EXTRACTED so the load-bearing property is
  * TESTABLE: a canary must never enter `assignedRaw`.
  *
@@ -500,15 +540,14 @@ async function main() {
   // N+1 against a table this cron already reads in bulk.
   const mod = await import('../lib/fleet/canary-session.js');
   const isCanaryMetadata = mod.isCanaryMetadata;
-  const preReg = await loadPreRegisteredCanaries(supabase, uniqueWorkers.map((w) => w.session_id), mod.CANARY_PRE_REGISTRATION_KIND);
-  if (!preReg.ok) {
+  const plan = await planNamingRun(supabase, uniqueWorkers, mod.CANARY_PRE_REGISTRATION_KIND, forceReassign, isCanaryMetadata);
+  if (plan.skip) {
     // FAIL CLOSED on this one axis: renaming is IRREVERSIBLE, so if the marker set cannot be read we
     // must not rename anyone this run. Skipping a genuine worker costs one unnamed cron tick; renaming
     // a canary destroys the discriminator for good.
-    console.log(`[assign-fleet-identities] canary pre-registration lookup FAILED (${preReg.error}) — skipping all naming this run rather than risk renaming a canary`);
+    console.log(`[assign-fleet-identities] canary pre-registration lookup FAILED (${plan.error}) — skipping all naming this run rather than risk renaming a canary`);
     return;
   }
-  const preRegisteredCanaries = preReg.canaries;
 
   // CANARIES GO IN THEIR OWN BUCKET, not into assignedRaw. A TESTING review proved the earlier version
   // was INERT for the exact case FR-7 added: classifyWorkerNaming correctly returned a canary verdict,
@@ -521,10 +560,9 @@ async function main() {
   //
   // Canaries live outside the NATO tier-band scheme entirely, so they must not participate in
   // band-dedupe at all: this bucket is simply left alone.
-  const parts = partitionWorkersForNaming(uniqueWorkers, preRegisteredCanaries, forceReassign, isCanaryMetadata);
-  const canaryProtected = parts.canaryProtected;
-  assignedRaw.push(...parts.assignedRaw);
-  needsAssignment.push(...parts.needsAssignment);
+  const canaryProtected = plan.canaryProtected;
+  assignedRaw.push(...plan.assignedRaw);
+  needsAssignment.push(...plan.needsAssignment);
 
   // QF-20260528-581 (Bug A): resolve duplicate callsigns within the assigned set
   // (e.g. "Alpha" on two sessions after session_id rotation). Keep the most-recent
@@ -543,16 +581,7 @@ async function main() {
   const usedCallsigns = new Set(assigned.map(w => w.metadata.fleet_identity.callsign));
   const usedColors = new Set(assigned.map(w => w.metadata.fleet_identity.color));
 
-  // A protected canary is not named by this cron, but any label it ALREADY holds must stay reserved.
-  // Otherwise a canary that an earlier clobber renamed to a NATO callsign (still protected, because the
-  // spawn-time marker survives the rename) would have that callsign handed to a second worker as well —
-  // trading a rename bug for a duplicate-identity bug.
-  for (const c of canaryProtected) {
-    const cs = c.metadata?.fleet_identity?.callsign;
-    const col = c.metadata?.fleet_identity?.color;
-    if (cs) usedCallsigns.add(cs);
-    if (col) usedColors.add(col);
-  }
+  reserveCanaryLabels(usedCallsigns, usedColors, canaryProtected);
 
   // SD-FDBK-ENH-COORDINATOR-TOOLING-DELTA-001: also reserve callsigns/colors of recently-seen,
   // non-terminated sessions that are temporarily OUT of the 5-min active-view (parked between SDs
@@ -730,7 +759,7 @@ function identityAccountUuid8(metadata, accountIdentity) {
   return (accountIdentity && accountIdentity.accountUuid8) || null;
 }
 
-module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, extendCallsign, buildTierCallsignBands, tierRankOf, pickCallsignForTier, callsignInTierBand, classifyWorkerNaming, loadPreRegisteredCanaries, partitionWorkersForNaming, identityNeedsRebroadcast, identityAccountUuid8 };
+module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, extendCallsign, buildTierCallsignBands, tierRankOf, pickCallsignForTier, callsignInTierBand, classifyWorkerNaming, loadPreRegisteredCanaries, partitionWorkersForNaming, planNamingRun, reserveCanaryLabels, identityNeedsRebroadcast, identityAccountUuid8 };
 
 if (require.main === module) {
   main().then(async () => {

--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -238,6 +238,40 @@ function reserveParkedIdentities(usedCallsigns, usedColors, recentSessions, acti
 // forever — the chairman saw 3x "Charlie". Compares the CURRENTLY-desired identity against the
 // last one actually broadcast (metadata.fleet_identity_last_sent, distinct from fleet_identity
 // itself so a partially-failed send is retried next tick) — true means re-send is due.
+/**
+ * Decide whether a worker keeps its identity or gets (re)named. EXTRACTED FROM main() so it can be
+ * tested: while this lived inline, the only available assertion was a source regex for
+ * `preRegisteredCanaries.has(...)`, and a mutation wrapping that call in `false &&` left the regex
+ * matching and every test green. A guard whose only observer is a text match is not covered — the
+ * text is present in the broken version too.
+ *
+ * `isCanaryMd` is INJECTED rather than imported: this is a .cjs file and lib/fleet/canary-session.js
+ * is ESM, so main() dynamic-imports it once and passes it down. That also keeps this function pure.
+ *
+ * @returns {'canary_marker'|'canary_metadata'|'in_band'|'needs_assignment'} — distinct
+ *   reasons, not a bare boolean, so a test can tell WHICH guard fired. Collapsing them would let the
+ *   pre-registration guard rot undetected behind the late metadata guard.
+ */
+function classifyWorkerNaming(worker, preRegisteredCanaries, forceReassign, isCanaryMd) {
+  const identity = worker.metadata?.fleet_identity;
+  // FR-7: the spawn-time marker is FIRST because it is the only signal readable during the 0-10s
+  // registration window and on the reboot-respawn path, where both metadata signals below are absent.
+  if (preRegisteredCanaries.has(worker.session_id)) return 'canary_marker';
+  // QF-20260724-521: canaries live outside the NATO tier-band scheme entirely — canary-guard requires
+  // a 'Canary-' callsign, so 'Canary-1' is in no band and would fail the tier check below and be
+  // renamed mid-drill. Delegated to the canonical predicate instead of re-typing the prefix test,
+  // which already exists in five other places in this repo.
+  if (isCanaryMd(worker.metadata)) return 'canary_metadata';
+  // QF-20260627-108 (FR-1): a worker is "assigned" ONLY if its callsign is in its tier band
+  // (effort-encoded SoT). A callsign from the wrong band (e.g. a tier-2 worker still holding
+  // "Bravo") is re-derived, so the chairman scheme self-heals instead of being preserved-wrong.
+  if (identity?.callsign && identity?.color && !forceReassign
+      && callsignInTierBand(identity.callsign, tierRankOf(worker))) {
+    return 'in_band';
+  }
+  return 'needs_assignment';
+}
+
 function identityNeedsRebroadcast(worker, expectedIdentity) {
   const lastSent = worker?.metadata?.fleet_identity_last_sent;
   if (!lastSent) return true;
@@ -391,26 +425,41 @@ async function main() {
   const assignedRaw = [];
   const needsAssignment = [];
 
+  // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E (FR-7): the skip below relies on two LATE
+  // signals (account_profile / 'Canary-' callsign) that are both written inside the session-bind loop
+  // and are both ABSENT during the 0-10s registration window and on the reboot-respawn path. This
+  // cron would therefore rename an unstamped canary to a NATO callsign, permanently destroying the
+  // namespace discriminator. Batch-fetch the spawn-time PRE-REGISTERED markers ONCE (keyed on the
+  // spawner-minted session id) rather than one lookup per worker — a per-worker await here would be an
+  // N+1 against a table this cron already reads in bulk.
+  const preRegisteredCanaries = new Set();
+  let isCanaryMetadata;
+  try {
+    const mod = await import('../lib/fleet/canary-session.js');
+    const { CANARY_PRE_REGISTRATION_KIND } = mod;
+    isCanaryMetadata = mod.isCanaryMetadata;
+    const ids = uniqueWorkers.map((w) => w.session_id).filter(Boolean);
+    if (ids.length) {
+      const { data, error } = await supabase
+        .from('session_coordination')
+        .select('target_session')
+        .in('target_session', ids)
+        .eq('payload->>kind', CANARY_PRE_REGISTRATION_KIND);
+      if (error) throw error;
+      for (const row of (data || [])) preRegisteredCanaries.add(row.target_session);
+    }
+  } catch (e) {
+    // FAIL CLOSED on this one axis: renaming is IRREVERSIBLE, so if the marker set cannot be read we
+    // must not rename anyone this run. Skipping a genuine worker costs one unnamed cron tick; renaming
+    // a canary destroys the discriminator for good.
+    console.log(`[assign-fleet-identities] canary pre-registration lookup FAILED (${e?.message}) — skipping all naming this run rather than risk renaming a canary`);
+    return;
+  }
+
   for (const worker of uniqueWorkers) {
-    const identity = worker.metadata?.fleet_identity;
-    // QF-20260724-521: canary sessions (account_profile='canary', callsign 'Canary-N') live
-    // outside the NATO tier-band scheme entirely -- canary-guard requires the callsign to
-    // start with 'Canary-'. Without this skip, the tier-band check below always fails for
-    // them (Canary-1 is never in any NATO band), so they get demoted to needsAssignment and
-    // reassigned a NATO callsign, breaking canary-guard mid-drill.
-    if (worker.metadata?.account_profile === 'canary' || identity?.callsign?.startsWith('Canary-')) {
-      assignedRaw.push(worker);
-      continue;
-    }
-    // QF-20260627-108 (FR-1): a worker is "assigned" ONLY if its callsign is in its tier band
-    // (effort-encoded SoT). A callsign from the wrong band (e.g. a tier-2 worker still holding
-    // "Bravo") is re-derived, so the chairman scheme self-heals instead of being preserved-wrong.
-    if (identity?.callsign && identity?.color && !forceReassign
-        && callsignInTierBand(identity.callsign, tierRankOf(worker))) {
-      assignedRaw.push(worker);
-    } else {
-      needsAssignment.push(worker);
-    }
+    const verdict = classifyWorkerNaming(worker, preRegisteredCanaries, forceReassign, isCanaryMetadata);
+    if (verdict === 'needs_assignment') needsAssignment.push(worker);
+    else assignedRaw.push(worker);
   }
 
   // QF-20260528-581 (Bug A): resolve duplicate callsigns within the assigned set
@@ -604,7 +653,7 @@ function identityAccountUuid8(metadata, accountIdentity) {
   return (accountIdentity && accountIdentity.accountUuid8) || null;
 }
 
-module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, extendCallsign, buildTierCallsignBands, tierRankOf, pickCallsignForTier, callsignInTierBand, identityNeedsRebroadcast, identityAccountUuid8 };
+module.exports = { filterOutCoordinators, filterOutGhostSessions, isTestSessionId, dedupeAssignedCallsigns, reserveParkedIdentities, NATO, COLORS, nextAvailable, extendCallsign, buildTierCallsignBands, tierRankOf, pickCallsignForTier, callsignInTierBand, classifyWorkerNaming, identityNeedsRebroadcast, identityAccountUuid8 };
 
 if (require.main === module) {
   main().then(async () => {

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -1384,7 +1384,33 @@ async function assignFleetIdentityAtCheckin(sb, sessionId, claimSd) {
     // Two independent conditions, matching the cron's: the account_profile stamp (authoritative, but
     // written only once FR-1/FR-3 land) OR the 'Canary-' callsign prefix (works today). Deliberately
     // an OR so this is NOT inert while the stamp is still being wired.
-    if (myMeta.account_profile === 'canary' || (existing && typeof existing.callsign === 'string' && existing.callsign.startsWith('Canary-'))) {
+    // FR-7 (SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E): both conditions above are LATE —
+    // account_profile and fleet_identity.callsign are written by ONE metadata update inside the
+    // session-bind loop (spawn-control.js:326-389, up to 10s post-launch), and reboot-respawn-runner.js
+    // writes neither, ever. So mid-registration NEITHER holds, the skip misses, and the canary is
+    // renamed to a NATO callsign — PERMANENTLY, since stampRespawnedCanary only carries a callsign
+    // forward when the incoming one is already canary-shaped. Delegating to isCanarySession adds the
+    // spawn-time pre-registered marker (keyed on the minted session id, readable from instruction zero)
+    // and drops one more hand-rolled copy of the 'Canary-' prefix test.
+    let canaryVerdict = null;
+    try {
+      const { isCanarySession } = await import('../lib/fleet/canary-session.js');
+      canaryVerdict = await isCanarySession(sb, { sessionId, metadata: myMeta });
+    } catch {
+      const nameless = !(existing && existing.callsign);
+      canaryVerdict = { isCanary: nameless, reason: nameless ? 'canary_check_unavailable_nameless' : 'canary_check_unavailable_established' };
+    }
+    // FAIL-CLOSED BUT SCOPED, and the scoping is load-bearing. The predicate defaults an indeterminate
+    // check to isCanary:true, which is right for the claim fence but wrong here: blanket fail-closed
+    // would freeze naming FLEET-WIDE on any lookup fault, and "every worker unnamed" reads as a quiet
+    // fleet rather than a broken one. isCanaryMetadata runs first and needs no I/O, so a stamped canary
+    // never depends on the lookup; of the rest, only a NAMELESS session can be an unstamped canary
+    // mid-registration. A session already holding a callsign is an established worker — renaming it
+    // destroys no canary signal, so it proceeds even while the check is unreadable.
+    if (canaryVerdict && canaryVerdict.indeterminate && existing && existing.callsign) {
+      canaryVerdict = { isCanary: false, reason: 'canary_check_indeterminate_established' };
+    }
+    if (canaryVerdict && canaryVerdict.isCanary) {
       return existing && existing.callsign && existing.color
         ? { callsign: existing.callsign, color: existing.color }
         : null;

--- a/scripts/worker-checkin.test.js
+++ b/scripts/worker-checkin.test.js
@@ -72,6 +72,17 @@ function makeStub(cfg) {
       if (table === 'session_coordination') {
         // recent roll_calls dedup query (sender_session filter) vs messages query (target_session)
         if ('sender_session' in state.filters) return Promise.resolve({ data: cfg.recentRollCalls || [], error: null });
+        // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E: HONOUR payload->>kind.
+        //
+        // This stub previously returned cfg.messages for ANY target_session query, ignoring further
+        // filters. That is not a harmless simplification: the FR-1 canary lookup filters
+        // target_session + payload->>kind, so it received the seeded WORK_ASSIGNMENT row, concluded a
+        // marker existed, and the claim fence fired on an ORDINARY worker — the pipeline returned
+        // 'idle' instead of 'claimed_assignment'. Production is unaffected (PostgREST applies the
+        // filter), so this was pure stub infidelity, and it produced a red test that pointed at the
+        // wrong thing. A stub that drops discriminants makes every predicate keyed on one over-fire.
+        const kind = state.filters['payload->>kind'];
+        if (kind) return Promise.resolve({ data: (cfg.coordinationByKind && cfg.coordinationByKind[kind]) || [], error: null });
         return Promise.resolve({ data: cfg.messages || [], error: null });
       }
       if (table === 'v_sd_next_candidates') return Promise.resolve({ data: cfg.candidates || [], error: null });

--- a/tests/unit/assign-fleet-identities-coordinator-filter.test.js
+++ b/tests/unit/assign-fleet-identities-coordinator-filter.test.js
@@ -18,7 +18,8 @@ const {
   filterOutGhostSessions,
   isTestSessionId,
   dedupeAssignedCallsigns,
-  reserveParkedIdentities
+  reserveParkedIdentities,
+  classifyWorkerNaming
 } = require('../../scripts/assign-fleet-identities.cjs');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -348,24 +349,47 @@ describe('filterOutGhostSessions + shared isFixtureSession (SD-FDBK-INFRA-SHARED
 // canary sessions from tier-band reassignment entirely, mirroring the fixture/probe skip
 // in filterOutGhostSessions. main() is not exported (only called via require.main), so this
 // is a source-pin regex test on the call site, matching the pattern used above.
+// RETARGETED, not weakened (SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E FR-7). These two
+// cases were source-pin regexes on the inline condition, because main() was not exported. The loop
+// body is now the exported pure `classifyWorkerNaming`, so the QF's actual invariant — a canary is
+// never sent to tier-band reassignment — is asserted by BEHAVIOUR instead of by text.
+//
+// The old pins had to go, and not merely because the text moved: mutation testing showed they could
+// not fail. Wrapping the guard in `false &&` left both regexes matching and the whole suite green. The
+// literals they searched for are also gone on purpose — the metadata test is delegated to the
+// canonical isCanaryMetadata (which spells it with a CANARY_PROFILE constant) rather than being a
+// sixth hand-rolled copy of `startsWith('Canary-')`.
 describe('QF-20260724-521: canary sessions are skipped from callsign reassignment', () => {
-  const src = readFileSync(ASSIGNER, 'utf8');
+  const isCanaryMd = (m) => m?.account_profile === 'canary' || !!m?.fleet_identity?.callsign?.startsWith('Canary-');
+  const worker = (metadata) => ({ session_id: 's-canary', metadata });
 
-  it('the assignedRaw/needsAssignment loop checks account_profile===canary or a Canary- callsign', () => {
-    expect(src).toMatch(/account_profile\s*===\s*['"]canary['"]/);
-    expect(src).toMatch(/callsign\?\.startsWith\(['"]Canary-['"]\)/);
+  it('a Canary- callsign is kept, never sent to tier-band reassignment', () => {
+    // 'Canary-1' is in no NATO tier band, so before the skip existed it always fell to
+    // needsAssignment and was renamed to a band callsign (the original Charlie clobber).
+    const out = classifyWorkerNaming(
+      worker({ fleet_identity: { callsign: 'Canary-1', color: 'yellow' }, tier_rank: 1 }),
+      new Set(), false, isCanaryMd,
+    );
+    expect(out).toBe('canary_metadata');
   });
 
-  it('the canary check pushes straight to assignedRaw and continues, BEFORE the tier-band check', () => {
-    const loopStart = src.indexOf('const assignedRaw = [];');
-    const canaryCheckIdx = src.indexOf("account_profile === 'canary'", loopStart);
-    const tierBandCheckIdx = src.indexOf('callsignInTierBand(identity.callsign, tierRankOf(worker))', loopStart);
-    expect(loopStart).toBeGreaterThan(-1);
-    expect(canaryCheckIdx).toBeGreaterThan(loopStart);
-    expect(tierBandCheckIdx).toBeGreaterThan(canaryCheckIdx); // canary skip runs first
-    // the canary branch must `continue` (skip the tier-band check for that worker), not fall through
-    const canaryBlock = src.slice(canaryCheckIdx, tierBandCheckIdx);
-    expect(canaryBlock).toContain('assignedRaw.push(worker)');
-    expect(canaryBlock).toContain('continue;');
+  it('the account_profile stamp alone is enough, even with a NATO callsign', () => {
+    // Defence-in-depth alongside the callsign: a canary already renamed by an earlier clobber must
+    // still be recognised and left alone.
+    const out = classifyWorkerNaming(
+      worker({ account_profile: 'canary', fleet_identity: { callsign: 'Charlie', color: 'blue' }, tier_rank: 1 }),
+      new Set(), false, isCanaryMd,
+    );
+    expect(out).toBe('canary_metadata');
+  });
+
+  it('NEGATIVE CONTROL — the same out-of-band callsign IS reassigned for a non-canary', () => {
+    // Proves the verdict above comes from the canary signal and not from the callsign being
+    // out-of-band. Without this, a guard that protected every worker would pass both cases.
+    const out = classifyWorkerNaming(
+      { session_id: 's-plain', metadata: { fleet_identity: { callsign: 'Canary-1', color: 'yellow' }, tier_rank: 1 } },
+      new Set(), false, () => false,
+    );
+    expect(out).toBe('needs_assignment');
   });
 });

--- a/tests/unit/checkin-pipeline.test.js
+++ b/tests/unit/checkin-pipeline.test.js
@@ -20,6 +20,12 @@ describe('checkin step registry (lib/checkin/steps/index.cjs)', () => {
       'release-request',
       'resume',
       'build-forbidden-guard',
+      // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E FR-3: canary probes must never acquire
+      // real work. This ONE slot gates every acquisition tier (directed-assignment,
+      // recover-stranded-final, adopt-orphan, critical-qf-jump, merged-pool-self-claim,
+      // self-claim-qf); resume sits above it deliberately, being reachable only when a claim is
+      // already held. Demoting it below directed-assignment silently un-fences coordinator dispatch.
+      'canary-claim-fence',
       'directed-assignment',
       'seat-busy-fence',
       'recover-stranded-final',

--- a/tests/unit/checkin/canary-claim-fence.test.js
+++ b/tests/unit/checkin/canary-claim-fence.test.js
@@ -1,0 +1,188 @@
+/**
+ * SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E — FR-3 canary claim fence.
+ *
+ * TR-6 REQUIRED THIS FIXTURE TO BE BUILT, not skipped. There was no tests/unit/checkin/ directory;
+ * checkin-pipeline.test.js pins ORDER but runs SYNTHETIC steps only. The cheap path here was to
+ * assert the predicate in isolation and call it done — which would have dropped ALL of FR-3's
+ * pipeline coverage while still reading green. So these tests drive the REAL exported step array
+ * through the REAL pipeline runner, with only the DB and the acquiring tiers stubbed.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+
+const STEPS = require('../../../lib/checkin/steps/index.cjs');
+const fence = require('../../../lib/checkin/steps/canary-claim-fence.cjs');
+const { runSteps } = require('../../../lib/checkin/pipeline.cjs');
+
+const CANARY_PRE_REGISTRATION_KIND = 'canary_pre_registration';
+
+/** Minimal supabase double: only the shape canary-session.js actually uses. */
+function sbWithPreRegistration({ rows = [], error = null } = {}) {
+  const api = {
+    from() { return api; },
+    select() { return api; },
+    eq() { return api; },
+    limit() { return Promise.resolve({ data: rows, error }); },
+  };
+  return api;
+}
+
+/** ctx mirroring resolveCheckin's real construction (worker-checkin.cjs:1609-1621). */
+function makeCtx({ metadata = {}, sb = sbWithPreRegistration(), helpers = {} } = {}) {
+  return {
+    sb,
+    sessionId: 'sess-under-test',
+    opts: {},
+    coordinatorId: 'coord-1',
+    callsign: null,
+    mySd: null,
+    sessionRole: null,
+    sessionMetadata: metadata,
+    base: { callsign: null },
+    helpers: {
+      ws: { getMessagesForSession: async () => [], DIRECTIVE_KINDS: [] },
+      ackMessage: async () => {},
+      isInformationalNudge: () => false,
+      ASSIGNMENT_RECENCY_WINDOW_MS: 86_400_000,
+      DEFAULT_IDLE_WAKEUP_SECONDS: 1200,
+      ...helpers,
+    },
+  };
+}
+
+describe('FR-3 placement — the fence must sit above every acquisition tier', () => {
+  const names = STEPS.map((s) => s.name);
+
+  it('is registered in the pipeline at all', () => {
+    expect(names).toContain('canary-claim-fence');
+  });
+
+  it('runs BEFORE every acquiring step', () => {
+    // TS-10: a future insertion must not be able to silently demote the fence below a claim tier.
+    // Asserting against the REAL exported array is what makes this a regression guard rather than
+    // a restatement of the source.
+    const fenceIdx = names.indexOf('canary-claim-fence');
+    const acquiring = [
+      'directed-assignment',        // 8  — coordinator dispatch
+      'recover-stranded-final',     // 10 — stranded LEAD_FINAL recovery
+      'adopt-orphan',               // 11 — orphan in_progress adoption
+      'critical-qf-jump',           // 14
+      'merged-pool-self-claim',     // 15 (two claim sites)
+      'self-claim-qf',              // 16
+    ];
+    for (const step of acquiring) {
+      const idx = names.indexOf(step);
+      expect(idx, `${step} must be present`).toBeGreaterThan(-1);
+      expect(fenceIdx, `fence must precede ${step}`).toBeLessThan(idx);
+    }
+  });
+
+  it('sits after resume, which is deliberately NOT fenced', () => {
+    // resume is reachable only when a claim is ALREADY held — the state the fence prevents. Fencing
+    // it would strand a canary that somehow acquired one, instead of letting it resume and be seen.
+    expect(names.indexOf('resume')).toBeLessThan(names.indexOf('canary-claim-fence'));
+  });
+});
+
+describe('FR-3 behaviour through the REAL pipeline runner', () => {
+  it('TS-1: a canary short-circuits and NO acquiring step runs', async () => {
+    const ran = [];
+    const spy = (name) => ({ name, async run() { ran.push(name); return null; } });
+    // Real fence, real runner; downstream tiers replaced with recorders so "did not run" is provable.
+    const pipeline = [fence, spy('directed-assignment'), spy('recover-stranded-final'), spy('adopt-orphan'), spy('self-claim-qf')];
+    const ctx = makeCtx({ metadata: { account_profile: 'canary' } });
+
+    const out = await runSteps(pipeline, ctx);
+
+    expect(out.action).toBe('idle');
+    expect(out.canary_fence_reason).toBe('canary_metadata');
+    expect(out.message).toMatch(/FENCED/);
+    expect(ran).toEqual([]); // the whole point: zero acquisition attempts
+  });
+
+  it('TS-13: fences from the PRE-REGISTRATION alone with metadata EMPTY (the 0-10s window)', async () => {
+    const ran = [];
+    const pipeline = [fence, { name: 'directed-assignment', async run() { ran.push('x'); return null; } }];
+    const ctx = makeCtx({ metadata: {}, sb: sbWithPreRegistration({ rows: [{ id: 'pre-1' }] }) });
+
+    const out = await runSteps(pipeline, ctx);
+
+    expect(out.canary_fence_reason).toBe('canary_pre_registration');
+    expect(ran).toEqual([]);
+  });
+
+  it('TS-4 NEGATIVE CONTROL: an ordinary worker is NOT fenced and DOES reach the tiers', async () => {
+    // Without this the fence could be unconditional and every other test would still pass.
+    const ran = [];
+    const pipeline = [fence, { name: 'directed-assignment', async run() { ran.push('directed-assignment'); return { action: 'claimed_assignment' }; } }];
+    const ctx = makeCtx({ metadata: { account_profile: 'live', fleet_identity: { callsign: 'Bravo' } } });
+
+    const out = await runSteps(pipeline, ctx);
+
+    expect(ran).toEqual(['directed-assignment']);
+    expect(out.action).toBe('claimed_assignment');
+    expect(out.canary_fence_reason).toBeUndefined();
+  });
+
+  it('TS-11: ACKS-AND-DECLINES a directed WORK_ASSIGNMENT so none is stranded (b8eb6111)', async () => {
+    const acked = [];
+    const ctx = makeCtx({
+      metadata: { canary_session: true },
+      helpers: {
+        ws: {
+          getMessagesForSession: async () => [
+            { id: 'wa-1', message_type: 'WORK_ASSIGNMENT', payload: { kind: 'work_assignment' } },
+            { id: 'info-1', message_type: 'WORK_ASSIGNMENT', payload: { kind: 'completion_nudge' } },
+            { id: 'other', message_type: 'INFO', payload: {} },
+          ],
+          DIRECTIVE_KINDS: [],
+        },
+        isInformationalNudge: (m) => m.payload && m.payload.kind === 'completion_nudge',
+        ackMessage: async (_sb, id) => { acked.push(id); },
+      },
+    });
+
+    const out = await runSteps([fence], ctx);
+
+    expect(acked).toEqual(['wa-1']); // the real assignment only — nudge and INFO untouched
+    expect(out.message).toMatch(/Declined 1 directed WORK_ASSIGNMENT/);
+    expect(out.message).toMatch(/b8eb6111/);
+  });
+
+  it('a failing ack does NOT convert the fence into a pass-through', async () => {
+    // The fence standing is more important than the decline succeeding.
+    const ran = [];
+    const ctx = makeCtx({
+      metadata: { canary_session: true },
+      helpers: {
+        ws: { getMessagesForSession: async () => { throw new Error('inbox unreachable'); }, DIRECTIVE_KINDS: [] },
+      },
+    });
+
+    const out = await runSteps([fence, { name: 'directed-assignment', async run() { ran.push('x'); return null; } }], ctx);
+
+    expect(out.action).toBe('idle');
+    expect(out.canary_fence_reason).toBe('canary_metadata');
+    expect(ran).toEqual([]);
+  });
+
+  it('FR-2: an INDETERMINATE canary check fences (fail-closed) rather than falling through', async () => {
+    const ran = [];
+    const ctx = makeCtx({ metadata: {}, sb: sbWithPreRegistration({ error: { message: 'db down' } }) });
+
+    const out = await runSteps([fence, { name: 'directed-assignment', async run() { ran.push('x'); return null; } }], ctx);
+
+    expect(out.canary_fence_reason).toBe('canary_check_indeterminate_fail_closed');
+    expect(ran).toEqual([]);
+  });
+
+  it('states a REASON so a fenced canary is never mistaken for an idle seat', () => {
+    // "The canary just looked idle" is how this defect class hides; the reason is load-bearing.
+    const src = require('node:fs').readFileSync(
+      require.resolve('../../../lib/checkin/steps/canary-claim-fence.cjs'), 'utf8');
+    expect(src).toMatch(/canary_fence_reason/);
+  });
+});
+
+void CANARY_PRE_REGISTRATION_KIND;

--- a/tests/unit/fleet/canary-callsign-clobber.test.js
+++ b/tests/unit/fleet/canary-callsign-clobber.test.js
@@ -27,7 +27,8 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const CHECKIN = resolve(__dirname, '../../../scripts/worker-checkin.cjs');
 const CRON = resolve(__dirname, '../../../scripts/assign-fleet-identities.cjs');
 const { classifyWorkerNaming, pickCallsignForTier, callsignInTierBand, NATO,
-  partitionWorkersForNaming, loadPreRegisteredCanaries, dedupeAssignedCallsigns } =
+  partitionWorkersForNaming, loadPreRegisteredCanaries, dedupeAssignedCallsigns,
+  planNamingRun, reserveCanaryLabels } =
   createRequire(import.meta.url)('../../../scripts/assign-fleet-identities.cjs');
 
 function sbWith(rows, error = null) {
@@ -203,6 +204,85 @@ describe('F3: loadPreRegisteredCanaries — the marker lookup itself', () => {
     const out = await loadPreRegisteredCanaries(api, [null, undefined, ''], 'k');
     expect(out.ok).toBe(true);
     expect(calls).toHaveLength(0);
+  });
+});
+
+/**
+ * R3 — the fail-closed CONSEQUENCE, not the flag. The loader reported ok:false correctly, but nothing
+ * proved the caller acted on it: deleting the fail-closed `return` left the whole suite green. That is
+ * the same "correct decision, unverified consumer" shape as F2, which is why this SD needed a second
+ * review pass. planNamingRun makes the consequence structural — on a failed lookup there are no buckets
+ * at all, so there is no list to name anyone from even if a caller ignored `skip`.
+ */
+describe('R3: a failed marker lookup yields NO nameable buckets', () => {
+  const canaryMd = () => false;
+  const brokenSb = () => ({
+    from() { return this; }, select() { return this; }, in() { return this; },
+    eq() { return Promise.resolve({ data: null, error: { code: '42501' } }); },
+  });
+
+  it('returns skip:true AND withholds every bucket', async () => {
+    const workers = [{ session_id: 's-1', metadata: {} }, { session_id: 's-2', metadata: {} }];
+    const plan = await planNamingRun(brokenSb(), workers, 'k', false, canaryMd);
+    expect(plan.skip).toBe(true);
+    expect(plan.error).toBe('42501');
+    // The point: even a caller that ignored `skip` has nothing to iterate.
+    expect(plan.assignedRaw).toBeUndefined();
+    expect(plan.needsAssignment).toBeUndefined();
+  });
+
+  it('NEGATIVE CONTROL — a healthy lookup does produce buckets', async () => {
+    // Without this, a planner hardcoded to skip would pass the test above and freeze all naming.
+    const okSb = {
+      from() { return this; }, select() { return this; }, in() { return this; },
+      eq() { return Promise.resolve({ data: [{ target_session: 's-1' }], error: null }); },
+    };
+    const workers = [{ session_id: 's-1', metadata: {} }, { session_id: 's-2', metadata: {} }];
+    const plan = await planNamingRun(okSb, workers, 'k', false, canaryMd);
+    expect(plan.skip).toBe(false);
+    expect(plan.canaryProtected.map((w) => w.session_id)).toEqual(['s-1']); // marker honoured
+    expect(plan.needsAssignment.map((w) => w.session_id)).toEqual(['s-2']); // ordinary still named
+  });
+});
+
+/**
+ * R6 — the duplicate-identity mitigation, which was itself unverified: removing the reservation left the
+ * whole suite green. A protected canary never reaches the `assigned` set that seeds usedCallsigns, so
+ * without this its held label would be issued to a second session as well.
+ */
+describe('R6: labels held by a protected canary stay reserved', () => {
+  it('reserves the callsign and colour of an already-clobbered canary', () => {
+    // The realistic case: an earlier clobber renamed this canary to 'Bravo'. It is still protected
+    // (the spawn-time marker survives a rename), so 'Bravo' must not be handed out again.
+    const used = new Set(['Alpha']);
+    const colors = new Set(['blue']);
+    reserveCanaryLabels(used, colors, [
+      { session_id: 's-c', metadata: { fleet_identity: { callsign: 'Bravo', color: 'yellow' } } },
+    ]);
+    expect(used.has('Bravo')).toBe(true);
+    expect(colors.has('yellow')).toBe(true);
+    expect(used.has('Alpha')).toBe(true); // pre-existing entries untouched
+  });
+
+  it('tolerates a canary with NO identity yet (the unstamped case) without polluting the sets', () => {
+    // The primary FR-7 target has no callsign at all; reserving `undefined` would poison nextAvailable.
+    const used = new Set();
+    const colors = new Set();
+    reserveCanaryLabels(used, colors, [{ session_id: 's-c', metadata: {} }, null, undefined]);
+    expect(used.size).toBe(0);
+    expect(colors.size).toBe(0);
+  });
+
+  it('END-TO-END: a reserved canary label is not reissued by the real allocator', () => {
+    // Drives the ACTUAL pickCallsignForTier, so this fails if the reservation is dropped — rather than
+    // asserting only that a Set was mutated.
+    const rank = 1;
+    const held = pickCallsignForTier(rank, new Set()); // the label the allocator would hand out next
+    const used = new Set();
+    reserveCanaryLabels(used, new Set(), [
+      { session_id: 's-c', metadata: { fleet_identity: { callsign: held, color: 'yellow' } } },
+    ]);
+    expect(pickCallsignForTier(rank, used)).not.toBe(held);
   });
 });
 

--- a/tests/unit/fleet/canary-callsign-clobber.test.js
+++ b/tests/unit/fleet/canary-callsign-clobber.test.js
@@ -26,7 +26,8 @@ import { isCanarySession, CANARY_PRE_REGISTRATION_KIND } from '../../../lib/flee
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CHECKIN = resolve(__dirname, '../../../scripts/worker-checkin.cjs');
 const CRON = resolve(__dirname, '../../../scripts/assign-fleet-identities.cjs');
-const { classifyWorkerNaming, pickCallsignForTier, callsignInTierBand, NATO } =
+const { classifyWorkerNaming, pickCallsignForTier, callsignInTierBand, NATO,
+  partitionWorkersForNaming, loadPreRegisteredCanaries, dedupeAssignedCallsigns } =
   createRequire(import.meta.url)('../../../scripts/assign-fleet-identities.cjs');
 
 function sbWith(rows, error = null) {
@@ -73,13 +74,14 @@ describe('FR-7: both writers consult the canonical predicate', () => {
     expect(src).toMatch(/isCanary: nameless/);
   });
 
-  it('assign-fleet-identities.cjs batches the markers and FAILS CLOSED', () => {
+  it('assign-fleet-identities.cjs consults the shared kind constant and can refuse the run', () => {
     const src = readFileSync(CRON, 'utf8');
     expect(src).toMatch(/CANARY_PRE_REGISTRATION_KIND/);
-    // Batched, not per-worker: a per-worker await in that loop would be an N+1 against a table the
-    // cron already reads in bulk.
-    expect(src).toMatch(/\.in\('target_session', ids\)/);
-    // On lookup failure it returns rather than naming anyone this run.
+    // The fail-closed BRANCH is asserted here only as "this message still exists"; what actually
+    // protects it is the behavioural ok:false case in the loadPreRegisteredCanaries block below. The
+    // batching/no-N+1 property used to be pinned by a regex for `.in('target_session', ids)` — that
+    // literal is gone now the lookup is chunked, and a regex could not have told a 50-per-request
+    // chunk from one oversized query anyway. Both properties moved to real assertions.
     expect(src).toMatch(/skipping all naming this run rather than risk renaming a canary/);
   });
 
@@ -97,6 +99,113 @@ describe('FR-7: both writers consult the canonical predicate', () => {
  * covered, which is the same defect shape as a stubbed writer or an unasserted counter. These drive
  * the extracted decision directly so the classification itself has to be right.
  */
+/**
+ * F2 REGRESSION — the fix that was INERT. A TESTING review proved the first version of FR-7's cron half
+ * protected nothing: classifyWorkerNaming returned the right canary verdict, the worker went into
+ * assignedRaw, and then dedupeAssignedCallsigns — which treats a worker with no
+ * metadata.fleet_identity.callsign as "not really assigned" — demoted it back into needsAssignment,
+ * where it was renamed and broadcast. An unstamped canary has no callsign by definition, so EVERY newly
+ * protected case was demoted; only the case that already worked before FR-7 survived.
+ *
+ * So the property under test is the BUCKET, not the verdict: a canary must never enter assignedRaw,
+ * because everything downstream of that list can undo the decision. Asserting the verdict alone is
+ * exactly the mistake that shipped.
+ */
+describe('F2: a canary must never enter the list that dedupe can demote', () => {
+  const canaryMd = (m) => m?.account_profile === 'canary' || !!m?.fleet_identity?.callsign?.startsWith('Canary-');
+
+  it('a pre-registered, CALLSIGN-LESS canary is bucketed away from assignedRaw entirely', () => {
+    const w = { session_id: 's-canary', metadata: {} };
+    const parts = partitionWorkersForNaming([w], new Set(['s-canary']), false, canaryMd);
+    expect(parts.canaryProtected).toHaveLength(1);
+    expect(parts.assignedRaw).toHaveLength(0);      // <- the inert version put it HERE
+    expect(parts.needsAssignment).toHaveLength(0);
+  });
+
+  it('END-TO-END of the regression: running the real dedupe over the buckets cannot demote it', () => {
+    // This is the assertion whose absence let the inert version ship. It drives the ACTUAL
+    // dedupeAssignedCallsigns over the ACTUAL partition output, rather than trusting the verdict.
+    const canary = { session_id: 's-canary', metadata: {} };
+    const worker = { session_id: 's-worker', metadata: { fleet_identity: { callsign: 'Zulu', color: 'blue' }, tier_rank: 1 } };
+    const parts = partitionWorkersForNaming([canary, worker], new Set(['s-canary']), false, canaryMd);
+    const { demoted } = dedupeAssignedCallsigns(parts.assignedRaw);
+    expect(demoted.map((d) => d.session_id)).not.toContain('s-canary');
+    // And the control: had it been placed in assignedRaw, dedupe WOULD have demoted it — proving the
+    // hazard is real and the bucket is what avoids it, not some property of the canary itself.
+    expect(dedupeAssignedCallsigns([canary]).demoted.map((d) => d.session_id)).toContain('s-canary');
+  });
+
+  it('an account_profile-stamped canary with no callsign is also protected', () => {
+    const w = { session_id: 's-c2', metadata: { account_profile: 'canary' } };
+    const parts = partitionWorkersForNaming([w], new Set(), false, canaryMd);
+    expect(parts.canaryProtected.map((c) => c.session_id)).toEqual(['s-c2']);
+    expect(parts.assignedRaw).toHaveLength(0);
+  });
+
+  it('NEGATIVE CONTROL — ordinary workers still flow to their normal buckets', () => {
+    // Without this the partition could route EVERYTHING to canaryProtected, freezing all naming, and
+    // both tests above would still pass.
+    const inBandCallsign = pickCallsignForTier(1, new Set());
+    const inBand = { session_id: 's-a', metadata: { fleet_identity: { callsign: inBandCallsign, color: 'blue' }, tier_rank: 1 } };
+    const unnamed = { session_id: 's-b', metadata: {} };
+    const parts = partitionWorkersForNaming([inBand, unnamed], new Set(), false, canaryMd);
+    expect(parts.canaryProtected).toHaveLength(0);
+    expect(parts.assignedRaw.map((w) => w.session_id)).toEqual(['s-a']);
+    expect(parts.needsAssignment.map((w) => w.session_id)).toEqual(['s-b']);
+  });
+});
+
+/**
+ * F3 — the DB→Set path. While this lived inline in main() it had NO reachable assertion: three separate
+ * mutations stayed green across the whole suite (deleting the fail-closed return, deleting
+ * `if (error) throw error`, and making the Set-population loop a no-op, which disables FR-7's cron
+ * protection outright). The only thing pointing at it was a regex matching the console.log STRING.
+ */
+describe('F3: loadPreRegisteredCanaries — the marker lookup itself', () => {
+  function fakeSb({ pages = [[]], error = null } = {}) {
+    const calls = [];
+    let i = 0;
+    const api = {
+      from() { return api; },
+      select() { return api; },
+      in(col, vals) { calls.push(vals); return api; },
+      eq() { return Promise.resolve({ data: error ? null : (pages[i++] || []), error }); },
+    };
+    return { api, calls };
+  }
+
+  it('populates the Set from the rows returned', async () => {
+    const { api } = fakeSb({ pages: [[{ target_session: 'a' }, { target_session: 'b' }]] });
+    const out = await loadPreRegisteredCanaries(api, ['a', 'b', 'c'], 'canary_pre_registration');
+    expect(out.ok).toBe(true);
+    expect([...out.canaries].sort()).toEqual(['a', 'b']);
+  });
+
+  it('CHUNKS the id list so a large fleet cannot 414 into the fleet-wide fail-closed', async () => {
+    // Unchunked, the fail-closed quietly becomes fail-ALWAYS as the fleet grows — and it presents as
+    // an idle cron, not an error.
+    const ids = Array.from({ length: 120 }, (_, n) => `s-${n}`);
+    const { api, calls } = fakeSb({ pages: [[], [], []] });
+    const out = await loadPreRegisteredCanaries(api, ids, 'k', 50);
+    expect(out.ok).toBe(true);
+    expect(calls.map((c) => c.length)).toEqual([50, 50, 20]);
+  });
+
+  it('reports ok:false on a query error so the caller names NOBODY that run', async () => {
+    const { api } = fakeSb({ error: { code: '42501', message: 'permission denied for relation ...' } });
+    const out = await loadPreRegisteredCanaries(api, ['a'], 'k');
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe('42501'); // code, not the driver message
+  });
+
+  it('skips falsy ids and makes no query at all for an empty fleet', async () => {
+    const { api, calls } = fakeSb();
+    const out = await loadPreRegisteredCanaries(api, [null, undefined, ''], 'k');
+    expect(out.ok).toBe(true);
+    expect(calls).toHaveLength(0);
+  });
+});
+
 describe('FR-7: classifyWorkerNaming — the cron decision, exercised not grepped', () => {
   const md = (metadata) => ({ session_id: 's-1', metadata });
   const canaryMd = (m) => m?.account_profile === 'canary' || !!m?.fleet_identity?.callsign?.startsWith('Canary-');

--- a/tests/unit/fleet/canary-callsign-clobber.test.js
+++ b/tests/unit/fleet/canary-callsign-clobber.test.js
@@ -1,0 +1,172 @@
+/**
+ * SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E — FR-7: the NATO-callsign clobber.
+ *
+ * THE DEFECT: both callsign writers skip canaries using two LATE signals — account_profile and
+ * fleet_identity.callsign — which are written by the SAME metadata update inside the session-bind
+ * loop and are BOTH absent during the 0-10s registration window and on the reboot-respawn path. So an
+ * unstamped canary fell through to pickCallsignForTier and was renamed to a NATO callsign. That loss
+ * is PERMANENT: stampRespawnedCanary only carries a callsign forward when the incoming one is already
+ * canary-shaped, so once renamed the discriminator never comes back.
+ *
+ * COVERAGE SPLIT, stated honestly because it changed mid-build. This file originally leaned on source
+ * regexes for both writers. Mutation testing then showed that was not coverage at all: wrapping the
+ * cron's guard in `false &&` left every regex matching and all tests green. So the cron decision was
+ * extracted (classifyWorkerNaming) and is now exercised behaviourally below, and the checkin writer's
+ * behaviour lives in tests/unit/worker-checkin-canary-identity-skip.test.js. The few remaining source
+ * assertions cover only things behaviour cannot see — that the batched lookup is not an N+1, and that
+ * the removed inline condition has not crept back.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { isCanarySession, CANARY_PRE_REGISTRATION_KIND } from '../../../lib/fleet/canary-session.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CHECKIN = resolve(__dirname, '../../../scripts/worker-checkin.cjs');
+const CRON = resolve(__dirname, '../../../scripts/assign-fleet-identities.cjs');
+const { classifyWorkerNaming, pickCallsignForTier, callsignInTierBand, NATO } =
+  createRequire(import.meta.url)('../../../scripts/assign-fleet-identities.cjs');
+
+function sbWith(rows, error = null) {
+  const api = {
+    from() { return api; }, select() { return api; }, eq() { return api; }, in() { return api; },
+    limit() { return Promise.resolve({ data: rows, error }); },
+  };
+  return api;
+}
+
+describe('FR-7: an UNSTAMPED canary must be recognised before it can be renamed', () => {
+  it('the 0-10s window: empty metadata + pre-registration => canary', async () => {
+    // This is the exact state in which the old two-signal skip did NOT fire.
+    const out = await isCanarySession(sbWith([{ id: 'pre-1' }]), { sessionId: 's-canary', metadata: {} });
+    expect(out.isCanary).toBe(true);
+    expect(out.reason).toBe('canary_pre_registration');
+  });
+
+  it('the reboot-respawn case: no metadata written EVER + pre-registration => canary', async () => {
+    // reboot-respawn-runner.js bypasses spawn() entirely and stamps nothing, so metadata is not
+    // merely late here — it never arrives. Only a spawn-time marker can see this session.
+    const out = await isCanarySession(sbWith([{ id: 'pre-2' }]), { sessionId: 's-respawned', metadata: null });
+    expect(out.isCanary).toBe(true);
+  });
+
+  it('NEGATIVE CONTROL: an unstamped ORDINARY worker is NOT protected and can still be named', async () => {
+    // Without this the fix could over-fire and silently stop naming the entire fleet — which would
+    // look like an idle cron rather than a bug.
+    const out = await isCanarySession(sbWith([]), { sessionId: 's-worker', metadata: {} });
+    expect(out.isCanary).toBe(false);
+  });
+});
+
+describe('FR-7: both writers consult the canonical predicate', () => {
+  it('worker-checkin.cjs delegates to isCanarySession and FAILS CLOSED', () => {
+    const src = readFileSync(CHECKIN, 'utf8');
+    expect(src).toMatch(/await import\('\.\.\/lib\/fleet\/canary-session\.js'\)/);
+    expect(src).toMatch(/isCanarySession\(sb, \{ sessionId, metadata: myMeta \}\)/);
+    // Renaming is irreversible, so an unavailable check must NOT fall through to the rename path for
+    // a session that could still be an unstamped canary. The fail-closed is SCOPED to nameless
+    // sessions on purpose — see the comment at the call site; a blanket version would stop naming the
+    // whole fleet on a transient fault, which looks like an idle cron rather than a bug.
+    expect(src).toMatch(/canary_check_unavailable_nameless/);
+    expect(src).toMatch(/isCanary: nameless/);
+  });
+
+  it('assign-fleet-identities.cjs batches the markers and FAILS CLOSED', () => {
+    const src = readFileSync(CRON, 'utf8');
+    expect(src).toMatch(/CANARY_PRE_REGISTRATION_KIND/);
+    // Batched, not per-worker: a per-worker await in that loop would be an N+1 against a table the
+    // cron already reads in bulk.
+    expect(src).toMatch(/\.in\('target_session', ids\)/);
+    // On lookup failure it returns rather than naming anyone this run.
+    expect(src).toMatch(/skipping all naming this run rather than risk renaming a canary/);
+  });
+
+  it('the checkin writer no longer relies on the two LATE signals alone', () => {
+    // The old condition was exactly `account_profile === 'canary' || callsign.startsWith('Canary-')`.
+    // Its survival as the ONLY gate is the regression this guards.
+    expect(readFileSync(CHECKIN, 'utf8')).not.toMatch(/if \(myMeta\.account_profile === 'canary' \|\| \(existing/);
+  });
+});
+
+/**
+ * BEHAVIOURAL, not textual. The cron's guard was previously pinned only by a source regex for
+ * `preRegisteredCanaries.has(worker.session_id)` — and a mutation wrapping that very call in
+ * `false &&` left the regex matching and all 1087 tests green. The guard was uncovered while looking
+ * covered, which is the same defect shape as a stubbed writer or an unasserted counter. These drive
+ * the extracted decision directly so the classification itself has to be right.
+ */
+describe('FR-7: classifyWorkerNaming — the cron decision, exercised not grepped', () => {
+  const md = (metadata) => ({ session_id: 's-1', metadata });
+  const canaryMd = (m) => m?.account_profile === 'canary' || !!m?.fleet_identity?.callsign?.startsWith('Canary-');
+
+  it('a PRE-REGISTERED session is protected even with metadata completely empty', () => {
+    // The 0-10s window and the reboot-respawn path. No metadata signal can see this.
+    const out = classifyWorkerNaming(md({}), new Set(['s-1']), false, canaryMd);
+    expect(out).toBe('canary_marker');
+  });
+
+  it('protection survives a metadata shape that would otherwise be renamed', () => {
+    // An unstamped canary that an earlier clobber already renamed to a NATO callsign in the WRONG
+    // tier band: every other path sends this to needs_assignment. Only the marker saves it.
+    const worker = { session_id: 's-1', metadata: { fleet_identity: { callsign: 'Bravo', color: 'blue' }, tier_rank: 3 } };
+    expect(classifyWorkerNaming(worker, new Set(['s-1']), false, canaryMd)).toBe('canary_marker');
+    // ...and WITHOUT the marker the same worker is renamed — proving the marker is what did it.
+    expect(classifyWorkerNaming(worker, new Set(), false, canaryMd)).toBe('needs_assignment');
+  });
+
+  it('forceReassign does NOT override the canary marker', () => {
+    // --force exists to re-derive drifted NATO callsigns; applying it to a canary would destroy the
+    // discriminator the flag was never meant to touch.
+    expect(classifyWorkerNaming(md({}), new Set(['s-1']), true, canaryMd)).toBe('canary_marker');
+  });
+
+  it('NEGATIVE CONTROL — an in-band ordinary worker is kept, an out-of-band one is renamed', () => {
+    // Without both halves the guard could be widened to protect everyone (freezing the tier-band
+    // self-heal this cron exists to perform) and still pass.
+    //
+    // The fixtures are DERIVED from the shipped band helpers, not hardcoded. My first version pinned
+    // 'Alpha' as tier-1 and failed: bands are computed from the LIVE ladderTopRank(), which is not 4
+    // here, so 'Alpha' sits in a different band than the legacy map implies. A hardcoded callsign in
+    // this test asserts the ladder's current shape rather than the classifier's logic, and breaks on
+    // any fleet resize — which is exactly the hardcoded-4-rung assumption the ladder module removed.
+    const RANK = 1;
+    const inBandCallsign = pickCallsignForTier(RANK, new Set());
+    const outOfBandCallsign = NATO.find((c) => !callsignInTierBand(c, RANK));
+    // Precondition, asserted rather than assumed: if the pool ever collapses to one band there is no
+    // out-of-band letter and the second half below would be vacuous.
+    expect(callsignInTierBand(inBandCallsign, RANK)).toBe(true);
+    expect(outOfBandCallsign, 'no out-of-band callsign exists — control would be vacuous').toBeDefined();
+
+    const inBand = { session_id: 's-2', metadata: { fleet_identity: { callsign: inBandCallsign, color: 'blue' }, tier_rank: RANK } };
+    expect(classifyWorkerNaming(inBand, new Set(), false, canaryMd)).toBe('in_band');
+    const outOfBand = { session_id: 's-3', metadata: { fleet_identity: { callsign: outOfBandCallsign, color: 'blue' }, tier_rank: RANK } };
+    expect(classifyWorkerNaming(outOfBand, new Set(), false, canaryMd)).toBe('needs_assignment');
+  });
+
+  it('reports WHICH guard fired, so the pre-registration path cannot rot behind the metadata path', () => {
+    // A bare boolean would let the marker check break silently on any session that also happens to
+    // carry the late stamp — the majority case once the stamp lands.
+    const stamped = md({ account_profile: 'canary' });
+    expect(classifyWorkerNaming(stamped, new Set(), false, canaryMd)).toBe('canary_metadata');
+    expect(classifyWorkerNaming(stamped, new Set(['s-1']), false, canaryMd)).toBe('canary_marker');
+  });
+
+  it('delegates the metadata test to the injected predicate instead of a sixth inline copy', () => {
+    // Proves delegation by INJECTING a predicate that disagrees with the old inline logic: a hardcoded
+    // startsWith('Canary-') would ignore this and return needs_assignment.
+    const worker = { session_id: 's-9', metadata: { some_future_marker: true } };
+    expect(classifyWorkerNaming(worker, new Set(), false, () => true)).toBe('canary_metadata');
+    const cron = readFileSync(CRON, 'utf8');
+    const body = cron.slice(cron.indexOf('function classifyWorkerNaming'));
+    expect(body.slice(0, body.indexOf('\n}'))).not.toMatch(/startsWith\(\s*['"]Canary-/);
+  });
+
+  it('the pre-registration kind is a single shared constant, not a duplicated literal', () => {
+    // Two writers keyed on independently-typed strings is a drift waiting to happen.
+    expect(CANARY_PRE_REGISTRATION_KIND).toBe('canary_pre_registration');
+    const cron = readFileSync(CRON, 'utf8');
+    expect(cron).not.toMatch(/'canary_pre_registration'/); // imported, never re-typed
+  });
+});

--- a/tests/unit/fleet/canary-pre-registration.test.js
+++ b/tests/unit/fleet/canary-pre-registration.test.js
@@ -1,0 +1,316 @@
+/**
+ * SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E — FR-4: the spawn-time canary marker (WRITER).
+ *
+ * FR-1 gave the fence a signal it could read. FR-4 is what actually puts that signal there, and the
+ * only property that makes it worth anything is ORDERING: the marker must exist BEFORE the child
+ * process starts, because a child can check in within milliseconds and the claim fence can only see
+ * what is already written. A marker written after spawn recreates the window this SD closes, and would
+ * pass every test that merely asserts "the marker was written".
+ *
+ * Why not lean on claude_sessions.metadata instead: that stamp lives inside spawn-control's
+ * session-bind loop, which was MEASURED missing its window by 1.3s on 2026-07-25 — discarding the
+ * window handle, the profile stamp and the session bind together and leaving a perfect-looking spawn
+ * with empty metadata. So the metadata stamp is explicitly NOT a fallback for this, and these tests
+ * never treat it as one.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { writeCanaryPreRegistration, CANARY_PRE_REGISTRATION_KIND, CANARY_TRIGGER_KEY } from '../../../lib/fleet/canary-session.js';
+
+/** Records inserts so the ROW SHAPE can be asserted, not just the fact of a call. */
+function insertRecorder({ error = null, throws = false } = {}) {
+  const rows = [];
+  return {
+    rows,
+    from(table) {
+      if (table !== 'session_coordination') throw new Error(`unexpected table: ${table}`);
+      return {
+        insert: async (row) => {
+          if (throws) throw new Error('transport exploded');
+          rows.push(row);
+          return { error };
+        },
+      };
+    },
+  };
+}
+
+describe('writeCanaryPreRegistration — FR-4 writer', () => {
+  it('keys the marker on the MINTED session id, on the column the reader queries', async () => {
+    // The reader (findCanaryPreRegistration) filters target_session + payload->>kind. If the writer
+    // used any other column or kind the two would never meet, and the fence would read as "no marker"
+    // for every canary — a silent, total no-op that still logs a successful spawn.
+    const sb = insertRecorder();
+    const out = await writeCanaryPreRegistration(sb, 'minted-uuid-1', { callsign: 'Canary-pilot' });
+    expect(out).toMatchObject({ ok: true, inserted: true });
+    expect(sb.rows).toHaveLength(1);
+    expect(sb.rows[0].target_session).toBe('minted-uuid-1');
+    expect(sb.rows[0].payload.kind).toBe(CANARY_PRE_REGISTRATION_KIND);
+  });
+
+  it('mirrors the metadata trigger key and profile into the payload', async () => {
+    const sb = insertRecorder();
+    await writeCanaryPreRegistration(sb, 'minted-uuid-2', { callsign: 'Canary-pilot' });
+    expect(sb.rows[0].payload[CANARY_TRIGGER_KEY]).toBe(true);
+    expect(sb.rows[0].payload.account_profile).toBe('canary');
+  });
+
+  it('stays OUT of the friction signal lane (no signal_type / intent_action)', async () => {
+    // Invariant copied from canary-trigger.cjs: a payload carrying either key gets scooped by the
+    // signal-router and the deconfliction sweep, which would consume the marker as a message.
+    const sb = insertRecorder();
+    await writeCanaryPreRegistration(sb, 'minted-uuid-3', {});
+    expect(sb.rows[0].payload.signal_type).toBeUndefined();
+    expect(sb.rows[0].payload.intent_action).toBeUndefined();
+    expect(sb.rows[0].target_session).not.toBeNull(); // valid_target CHECK: never null
+  });
+
+  it('REPORTS a failed insert instead of throwing, and never claims success', async () => {
+    // The caller refuses the spawn on ok:false. If this threw instead, the throw would unwind through
+    // spawn() and the refusal decision would never be reached.
+    const sb = insertRecorder({ error: { message: 'insert denied' } });
+    const out = await writeCanaryPreRegistration(sb, 'minted-uuid-4', {});
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe('insert denied');
+  });
+
+  it('also reports (not throws) when the transport itself explodes', async () => {
+    const sb = insertRecorder({ throws: true });
+    const out = await writeCanaryPreRegistration(sb, 'minted-uuid-5', {});
+    expect(out.ok).toBe(false);
+    expect(out.error).toMatch(/transport exploded/);
+  });
+
+  it('refuses to write without a session id — the marker would be unfindable', async () => {
+    // A row whose target_session is null cannot be matched by the reader and would also violate the
+    // valid_target CHECK. Reporting ok:false makes the caller refuse rather than spawn unmarked.
+    const sb = insertRecorder();
+    expect((await writeCanaryPreRegistration(sb, null, {})).ok).toBe(false);
+    expect((await writeCanaryPreRegistration(sb, '', {})).ok).toBe(false);
+    expect(sb.rows).toHaveLength(0);
+    expect((await writeCanaryPreRegistration(null, 'minted-uuid-6', {})).ok).toBe(false);
+  });
+});
+
+describe('FR-4 wiring in spawn() — ordering, refusal, and the blast-radius control', () => {
+  const CURRENT_RUNNER = (args) => {
+    if (args[0] === 'fetch') return '';
+    if (args.includes('--abbrev-ref')) return 'main\n';
+    if (args[0] === 'status') return '';
+    if (args[0] === 'rev-list') return '0\n';
+    return '';
+  };
+  const enumExec = (handle = 131074) => {
+    let call = 0;
+    return vi.fn(async () => { call += 1; return { stdout: call === 1 ? '' : `${handle}|5555|WindowsTerminal|Claude Code` }; });
+  };
+
+  /** Fake that records the ORDER of coordination inserts vs claude_sessions writes. */
+  function orderedFake({ coordinationInsertError = null } = {}) {
+    const order = [];
+    const rows = [];
+    return {
+      order,
+      rows,
+      from(table) {
+        if (table === 'session_coordination') {
+          return {
+            select: () => ({ eq: () => ({ gte: async () => ({ count: 0 }) }) }),
+            insert: async (row) => { order.push('pre_registration'); rows.push(row); return { error: coordinationInsertError }; },
+          };
+        }
+        if (table === 'claude_sessions') {
+          return {
+            select: () => ({
+              in: async () => ({ data: [] }),
+              eq: () => ({ maybeSingle: async () => ({ data: null }) }),
+            }),
+            update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+          };
+        }
+        throw new Error(`unexpected table: ${table}`);
+      },
+    };
+  }
+
+  it('THE ORDERING PROPERTY: the marker is written BEFORE the process is spawned', async () => {
+    // The whole point of FR-4. A child can check in within milliseconds, so a marker written after
+    // spawn leaves exactly the unfenced window this SD exists to close. An assertion that the marker
+    // merely EXISTS would pass against that broken ordering, which is why this records sequence.
+    const { spawn } = await import('../../../lib/fleet/spawn-control.js');
+    const sb = orderedFake();
+    const spawnFn = vi.fn(() => { sb.order.push('spawn'); return { pid: 4242, unref: vi.fn() }; });
+    await spawn({ role: 'worker', callsign: 'Canary-pilot', accountProfile: 'canary' }, {
+      live: true, spawnFn, supabaseClient: sb, currencyRunner: CURRENT_RUNNER, execFn: enumExec(), sleepFn: vi.fn(),
+      baseDir: 'C:\\fleet\\profiles',
+    });
+    expect(spawnFn).toHaveBeenCalled();
+    expect(sb.order.indexOf('pre_registration')).toBeGreaterThan(-1);
+    expect(sb.order.indexOf('pre_registration')).toBeLessThan(sb.order.indexOf('spawn'));
+  });
+
+  it('the marker carries the id actually passed to the child as --session-id', async () => {
+    // If the marker were keyed on a different id than the one the child registers under, the fence
+    // would look up the child's real id, find nothing, and let a canary claim — while this test file
+    // still showed a marker being written.
+    const { spawn } = await import('../../../lib/fleet/spawn-control.js');
+    const sb = orderedFake();
+    const result = await spawn({ role: 'worker', callsign: 'Canary-pilot', accountProfile: 'canary' }, {
+      live: true, spawnFn: vi.fn(() => ({ pid: 1, unref: vi.fn() })), supabaseClient: sb,
+      currencyRunner: CURRENT_RUNNER, execFn: enumExec(), sleepFn: vi.fn(), baseDir: 'C:\\fleet\\profiles',
+    });
+    expect(result.invocation.sessionId).toBeTruthy();
+    expect(sb.rows[0].target_session).toBe(result.invocation.sessionId);
+  });
+
+  it('REFUSES the canary spawn when the marker cannot be written — fail closed', async () => {
+    // An unmarked canary passes the claim fence and takes real work off the shared queue. A refused
+    // provision costs one retry; proceeding unmarked corrupts a peer's queue.
+    const { spawn } = await import('../../../lib/fleet/spawn-control.js');
+    const sb = orderedFake({ coordinationInsertError: { message: 'insert denied' } });
+    const spawnFn = vi.fn(() => ({ pid: 4242, unref: vi.fn() }));
+    const result = await spawn({ role: 'worker', callsign: 'Canary-pilot', accountProfile: 'canary' }, {
+      live: true, spawnFn, supabaseClient: sb, currencyRunner: CURRENT_RUNNER, execFn: enumExec(), sleepFn: vi.fn(),
+      baseDir: 'C:\\fleet\\profiles',
+    });
+    expect(spawnFn).not.toHaveBeenCalled(); // never started at all
+    expect(result.live).toBe(false);
+    expect(result.skipped).toBe(true);
+    expect(result.reason).toMatch(/canary_pre_registration_failed/);
+  });
+
+  it('BLAST-RADIUS CONTROL: an ORDINARY spawn still succeeds even if every DB call fails', async () => {
+    // THIS IS THE TEST THE CODE COMMENT POINTS AT. On 2026-07-26 a probe left a hardcoded ok:false at
+    // this exact call site; committed, it would have refused every spawn, restart, relaunch and
+    // canary-provision — a fleet-wide outage from one line. The refusal must therefore be unreachable
+    // for a non-canary spawn, and the only convincing way to show that is to make the marker path
+    // fail as hard as possible and prove an ordinary worker is untouched.
+    const { spawn } = await import('../../../lib/fleet/spawn-control.js');
+    const hostile = {
+      from(table) {
+        if (table === 'claude_sessions') {
+          return {
+            select: () => ({ in: async () => ({ data: [] }), eq: () => ({ maybeSingle: async () => ({ data: null }) }) }),
+            update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+          };
+        }
+        // Any coordination write/read detonates.
+        return { select: () => { throw new Error('hostile'); }, insert: () => { throw new Error('hostile'); } };
+      },
+    };
+    const spawnFn = vi.fn(() => ({ pid: 4242, unref: vi.fn() }));
+    const result = await spawn({ role: 'worker', callsign: 'Bravo' }, {
+      live: true, spawnFn, supabaseClient: hostile, currencyRunner: CURRENT_RUNNER, execFn: enumExec(), sleepFn: vi.fn(),
+    });
+    expect(spawnFn, 'an ordinary spawn must never be gated on the canary marker').toHaveBeenCalled();
+    expect(result.live).toBe(true);
+  });
+
+  it('restart() carries canary identity forward from the CALLSIGN when the profile stamp never landed', async () => {
+    // The sessions most likely to reach a restart UNSTAMPED are exactly the canaries: the
+    // account_profile stamp is written inside the bind loop that is measured to miss, and
+    // reboot-respawn writes it never. Reading account_profile alone therefore reproduced the same
+    // blind spot one level down — an unstamped canary came back as an ordinary worker with no profile
+    // isolation and no marker. Observable proof: the marker is written at all, which only happens if
+    // accountProfile resolved to 'canary' from the namespace callsign.
+    const { restart } = await import('../../../lib/fleet/spawn-control.js');
+    const rows = [];
+    const session = {
+      session_id: 's-unstamped-canary', status: 'active',
+      // Resolution matches on metadata.fleet_identity.callsign, so the target below must equal THIS.
+      // NOTE what is absent: account_profile. Only the namespace callsign survives.
+      metadata: { fleet_identity: { callsign: 'Canary-1', color: 'yellow' }, role: 'worker' },
+    };
+    const sb = {
+      from(table) {
+        if (table === 'session_coordination') {
+          return {
+            select: () => ({ eq: () => ({ gte: async () => ({ count: 0 }) }) }),
+            insert: async (row) => { rows.push(row); return { error: null }; },
+          };
+        }
+        return {
+          select: () => ({
+            in: async () => ({ data: [session] }),
+            eq: () => ({ maybeSingle: async () => ({ data: session }) }),
+          }),
+          update: () => ({ eq: () => Promise.resolve({ error: null }) }),
+        };
+      },
+    };
+    await restart('Canary-1', {
+      supabaseClient: sb, by: 'callsign', live: true, spawnFn: vi.fn(() => ({ pid: 7, unref: vi.fn() })),
+      currencyRunner: CURRENT_RUNNER, execFn: enumExec(), sleepFn: vi.fn(), baseDir: 'C:\\fleet\\profiles',
+    });
+    expect(rows.length, 'an unstamped canary restart must still be marked').toBeGreaterThan(0);
+    expect(rows[0].payload.kind).toBe(CANARY_PRE_REGISTRATION_KIND);
+  });
+
+  describe('reboot-respawn-runner — the worst case: this path writes NO canary metadata, ever', () => {
+    /** Records marker inserts and spawn order for the respawn runner. */
+    function respawnFake({ error = null } = {}) {
+      const order = [];
+      const rows = [];
+      return {
+        order,
+        rows,
+        from: () => ({
+          insert: async (row) => { order.push('pre_registration'); rows.push(row); return { error }; },
+          select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null }) }) }),
+        }),
+      };
+    }
+    const canarySlot = { name: 'Canary-1', role: 'worker', account_profile: 'canary', resume_uuid: 'u-c' };
+
+    it('marks the canary slot BEFORE spawning it', async () => {
+      // reboot-respawn writes neither account_profile nor fleet_identity.callsign at any point, so a
+      // canary respawned at boot was indistinguishable from an ordinary worker for its whole life.
+      const { runRebootRespawn } = await import('../../../lib/fleet/reboot-respawn-runner.js');
+      const sb = respawnFake();
+      const res = await runRebootRespawn({
+        supabase: sb, loadFn: async () => [canarySlot], logFn: async () => ({ ok: true }), live: true,
+        resolveProfileDirFn: (n) => `C:\\profiles\\${n}`, sleepFn: vi.fn(),
+        spawnFn: () => { sb.order.push('spawn'); return { pid: 11 }; },
+      });
+      expect(res.results[0].spawned).toBe(true);
+      expect(sb.order).toEqual(['pre_registration', 'spawn']);
+    });
+
+    it('REFUSES that slot when the marker cannot be written, and the refusal is bounded to it', async () => {
+      // Deliberately against this file's fail-soft house style (an unresolvable profile still spawns):
+      // that is right for a profile dir and wrong for a safety marker. The bound matters as much as the
+      // refusal — a reboot must still bring the rest of the fleet back.
+      const { runRebootRespawn } = await import('../../../lib/fleet/reboot-respawn-runner.js');
+      const sb = respawnFake({ error: { message: 'insert denied' } });
+      const spawnFn = vi.fn(() => ({ pid: 12 }));
+      const res = await runRebootRespawn({
+        supabase: sb, logFn: async () => ({ ok: true }), live: true, sleepFn: vi.fn(),
+        resolveProfileDirFn: (n) => `C:\\profiles\\${n}`,
+        loadFn: async () => [canarySlot, { name: 'Bravo', role: 'worker', resume_uuid: 'u-b' }],
+        spawnFn,
+      });
+      expect(res.results[0].spawned, 'the canary slot must be refused').toBe(false);
+      expect(res.results[1].spawned, 'an ordinary slot must still respawn after the refusal').toBe(true);
+      expect(spawnFn).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT mark an ordinary slot (the guard stays canary-scoped)', async () => {
+      const { runRebootRespawn } = await import('../../../lib/fleet/reboot-respawn-runner.js');
+      const sb = respawnFake();
+      await runRebootRespawn({
+        supabase: sb, loadFn: async () => [{ name: 'Bravo', role: 'worker', resume_uuid: 'u-b' }],
+        logFn: async () => ({ ok: true }), live: true, sleepFn: vi.fn(), spawnFn: () => ({ pid: 13 }),
+      });
+      expect(sb.rows).toHaveLength(0);
+    });
+  });
+
+  it('a DRY RUN writes no marker (nothing was spawned to mark)', async () => {
+    // The write sits after the dry-run return on purpose: a dry run that inserted rows would leave
+    // markers for session ids that never existed, which the fence would carry forever.
+    const { spawn } = await import('../../../lib/fleet/spawn-control.js');
+    const sb = orderedFake();
+    const result = await spawn({ role: 'worker', callsign: 'Canary-pilot', accountProfile: 'canary' }, { live: false, supabaseClient: sb, baseDir: 'C:\\fleet\\profiles' });
+    expect(result.live).toBe(false);
+    expect(sb.rows).toHaveLength(0);
+  });
+});

--- a/tests/unit/fleet/canary-pre-registration.test.js
+++ b/tests/unit/fleet/canary-pre-registration.test.js
@@ -14,7 +14,7 @@
  * never treat it as one.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { writeCanaryPreRegistration, CANARY_PRE_REGISTRATION_KIND, CANARY_TRIGGER_KEY } from '../../../lib/fleet/canary-session.js';
+import { writeCanaryPreRegistration, findCanaryPreRegistration, CANARY_PRE_REGISTRATION_KIND, CANARY_TRIGGER_KEY } from '../../../lib/fleet/canary-session.js';
 
 /** Records inserts so the ROW SHAPE can be asserted, not just the fact of a call. */
 function insertRecorder({ error = null, throws = false } = {}) {
@@ -70,7 +70,9 @@ describe('writeCanaryPreRegistration — FR-4 writer', () => {
     const sb = insertRecorder({ error: { message: 'insert denied' } });
     const out = await writeCanaryPreRegistration(sb, 'minted-uuid-4', {});
     expect(out.ok).toBe(false);
-    expect(out.error).toBe('insert denied');
+    // A code-less driver error degrades to a fixed sentinel rather than passing the message through —
+    // see the log-leakage case in the SEC-1 block below. What matters here is ok:false, not the text.
+    expect(out.error).toBe('insert_failed');
   });
 
   it('also reports (not throws) when the transport itself explodes', async () => {
@@ -88,6 +90,71 @@ describe('writeCanaryPreRegistration — FR-4 writer', () => {
     expect((await writeCanaryPreRegistration(sb, '', {})).ok).toBe(false);
     expect(sb.rows).toHaveLength(0);
     expect((await writeCanaryPreRegistration(null, 'minted-uuid-6', {})).ok).toBe(false);
+  });
+});
+
+/**
+ * SEC-1 REGRESSION. The first version of this writer omitted expires_at, and the column DEFAULTS to
+ * now() + 1 hour; cleanup_expired_coordination() then DELETEs any row WHERE expires_at < now() AND
+ * acknowledged_at IS NOT NULL. Roll-call (checkin step 4) runs BEFORE this fence (step 8) and stamps
+ * read_at then acknowledged_at on a non-directive INFO row, so the canary's OWN check-ins armed the
+ * deletion of its own safety marker. ~1h after spawn the lookup returned {found:false,
+ * lookupFailed:false} — indistinguishable from "never was a canary" — and the fence silently opened.
+ *
+ * These pin BOTH halves: the writer makes the row un-reapable, and the reader stays blind to the
+ * lifecycle columns. Either half alone is insufficient — a later "tidy-up" adding
+ * `.is('acknowledged_at', null)` to the reader would match zero rows and disable the fence fleet-wide.
+ */
+describe('SEC-1: the marker is a REGISTRY row, not a message — it must not be reapable', () => {
+  it('writes expires_at:null so `expires_at < now()` can never be true', async () => {
+    const sb = insertRecorder();
+    await writeCanaryPreRegistration(sb, 'minted-ttl', { callsign: 'Canary-pilot' });
+    // NOT merely "some future timestamp" — a TTL of any length reopens the fence when it lapses.
+    expect(sb.rows[0]).toHaveProperty('expires_at');
+    expect(sb.rows[0].expires_at).toBeNull();
+  });
+
+  it('pre-stamps read_at and acknowledged_at so no lane ever delivers or reaps it', async () => {
+    // Pre-stamping takes the row out of the coordinator push lane (it is not a message) and out of
+    // the dead-letter pass, which selects on both being NULL.
+    const sb = insertRecorder();
+    await writeCanaryPreRegistration(sb, 'minted-ack', {});
+    expect(sb.rows[0].read_at).toBeTruthy();
+    expect(sb.rows[0].acknowledged_at).toBeTruthy();
+  });
+
+  it('the READER still finds a row that is read, acknowledged, expired AND dead-lettered', async () => {
+    // The lifecycle-blindness is load-bearing: "this session id is a probe" does not stop being true
+    // because something stamped the row. A reader that filtered on any of these would see zero rows.
+    const seen = {};
+    const api = {
+      from(t) { seen.table = t; return api; },
+      select() { return api; },
+      eq(col, val) { seen[col] = val; return api; },
+      limit() {
+        return Promise.resolve({
+          data: [{
+            id: 'pre-1', read_at: '2020-01-01T00:00:00Z', acknowledged_at: '2020-01-01T00:00:00Z',
+            expires_at: '2020-01-01T00:00:00Z', dead_letter: true,
+          }],
+          error: null,
+        });
+      },
+    };
+    const out = await findCanaryPreRegistration(api, 'sess-x');
+    expect(out).toEqual({ found: true, lookupFailed: false });
+    // And prove the query itself carries no lifecycle predicate that could exclude such a row.
+    expect(Object.keys(seen)).toEqual(['table', 'target_session', 'payload->>kind']);
+  });
+
+  it('reports an insert failure by CODE, never the driver message', async () => {
+    // Postgres embeds row content ("Failing row contains (…)", carrying the whole JSONB) in the error,
+    // and this string travels outward through spawn()'s `reason` into shared logs.
+    const sb = insertRecorder({ error: { code: '23505', message: 'duplicate key ... Failing row contains (secret-payload)' } });
+    const out = await writeCanaryPreRegistration(sb, 'minted-err', {});
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe('23505');
+    expect(out.error).not.toMatch(/Failing row contains/);
   });
 });
 

--- a/tests/unit/fleet/canary-session.test.js
+++ b/tests/unit/fleet/canary-session.test.js
@@ -60,7 +60,7 @@ describe('isCanarySession — FR-1 disjunction', () => {
     // metadata signal is blind. Only the spawner-minted-id marker can see it.
     const { api, seen } = fakeSb({ rows: [{ id: 'pre-1' }] });
     const out = await isCanarySession(api, { sessionId: 'sess-canary', metadata: {} });
-    expect(out).toEqual({ isCanary: true, reason: 'canary_pre_registration' });
+    expect(out).toMatchObject({ isCanary: true, reason: 'canary_pre_registration', indeterminate: false });
     expect(seen.table).toBe('session_coordination');
     expect(seen.target_session).toBe('sess-canary');
     expect(seen['payload->>kind']).toBe(CANARY_PRE_REGISTRATION_KIND);
@@ -80,7 +80,7 @@ describe('isCanarySession — FR-1 disjunction', () => {
       sessionId: 'sess-bravo',
       metadata: { account_profile: 'live', fleet_identity: { callsign: 'Bravo' } },
     });
-    expect(out).toEqual({ isCanary: false, reason: 'not_canary' });
+    expect(out).toMatchObject({ isCanary: false, reason: 'not_canary', indeterminate: false });
   });
 
   it('FR-2: a FAILED lookup fences (fail-closed), and says so distinctly', async () => {
@@ -88,7 +88,7 @@ describe('isCanarySession — FR-1 disjunction', () => {
     // reason string is distinct so an operator can tell a real canary from an indeterminate check.
     const { api } = fakeSb({ error: { message: 'boom' } });
     const out = await isCanarySession(api, { sessionId: 's', metadata: {} });
-    expect(out).toEqual({ isCanary: true, reason: 'canary_check_indeterminate_fail_closed' });
+    expect(out).toMatchObject({ isCanary: true, reason: 'canary_check_indeterminate_fail_closed', indeterminate: true });
   });
 
   it('FR-2: a THROWING transport also fences, never returns false', async () => {

--- a/tests/unit/fleet/canary-session.test.js
+++ b/tests/unit/fleet/canary-session.test.js
@@ -1,0 +1,130 @@
+/**
+ * SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E — FR-1 / FR-2 canary fence predicate.
+ *
+ * The defect this SD exists to prevent is a canary acquiring real work. The defect THIS FILE exists
+ * to prevent is subtler: a predicate that looks like it fences and cannot. Every case below is
+ * written so it can FAIL — see the negative control (TS-4) and the no-env-read guard.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isCanarySession,
+  isCanaryMetadata,
+  findCanaryPreRegistration,
+  CANARY_TRIGGER_KEY,
+  CANARY_PRE_REGISTRATION_KIND,
+} from '../../../lib/fleet/canary-session.js';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(__dirname, '../../../lib/fleet/canary-session.js');
+
+/** Fake supabase modelling ONLY the shape the predicate uses. */
+function fakeSb({ rows = [], error = null, throws = false } = {}) {
+  const seen = {};
+  const api = {
+    from(t) { seen.table = t; return api; },
+    select() { return api; },
+    eq(col, val) { seen[col] = val; return api; },
+    limit() {
+      if (throws) throw new Error('transport exploded');
+      return Promise.resolve({ data: rows, error });
+    },
+  };
+  return { api, seen };
+}
+
+describe('isCanaryMetadata — the LATE (defence-in-depth) signals', () => {
+  it('fires on the FR-4 trigger key', () => {
+    expect(isCanaryMetadata({ [CANARY_TRIGGER_KEY]: true })).toBe(true);
+  });
+  it('fires on account_profile=canary', () => {
+    expect(isCanaryMetadata({ account_profile: 'canary' })).toBe(true);
+  });
+  it('fires on a canary-namespace callsign even when the profile stamp never landed', () => {
+    // The reboot-respawn / bind-loop-exhausted case: one signal present, the other permanently absent.
+    expect(isCanaryMetadata({ fleet_identity: { callsign: 'Canary-1' } })).toBe(true);
+  });
+  it('NEGATIVE CONTROL — an ordinary worker is NOT canary', () => {
+    // Without this the whole suite could pass against a predicate hardcoded to true.
+    expect(isCanaryMetadata({ account_profile: 'live', fleet_identity: { callsign: 'Bravo' } })).toBe(false);
+    expect(isCanaryMetadata({})).toBe(false);
+    expect(isCanaryMetadata(null)).toBe(false);
+  });
+});
+
+describe('isCanarySession — FR-1 disjunction', () => {
+  it('TS-13: fences from the PRE-REGISTRATION alone, with metadata EMPTY', async () => {
+    // THE POINT OF FR-1. This is the 0-10s registration window: nothing is stamped yet, and every
+    // metadata signal is blind. Only the spawner-minted-id marker can see it.
+    const { api, seen } = fakeSb({ rows: [{ id: 'pre-1' }] });
+    const out = await isCanarySession(api, { sessionId: 'sess-canary', metadata: {} });
+    expect(out).toEqual({ isCanary: true, reason: 'canary_pre_registration' });
+    expect(seen.table).toBe('session_coordination');
+    expect(seen.target_session).toBe('sess-canary');
+    expect(seen['payload->>kind']).toBe(CANARY_PRE_REGISTRATION_KIND);
+  });
+
+  it('fences from metadata WITHOUT any lookup when the stamp has landed', async () => {
+    const sb = { from: vi.fn(() => { throw new Error('must not be queried'); }) };
+    const out = await isCanarySession(sb, { sessionId: 's', metadata: { account_profile: 'canary' } });
+    expect(out.isCanary).toBe(true);
+    expect(out.reason).toBe('canary_metadata');
+    expect(sb.from).not.toHaveBeenCalled(); // cheap path first; no I/O when the answer is in hand
+  });
+
+  it('TS-4 NEGATIVE CONTROL — an ordinary worker with no marker is NOT fenced', async () => {
+    const { api } = fakeSb({ rows: [] });
+    const out = await isCanarySession(api, {
+      sessionId: 'sess-bravo',
+      metadata: { account_profile: 'live', fleet_identity: { callsign: 'Bravo' } },
+    });
+    expect(out).toEqual({ isCanary: false, reason: 'not_canary' });
+  });
+
+  it('FR-2: a FAILED lookup fences (fail-closed), and says so distinctly', async () => {
+    // Neighbouring predicates deliberately fail toward permissiveness; this one must not. The
+    // reason string is distinct so an operator can tell a real canary from an indeterminate check.
+    const { api } = fakeSb({ error: { message: 'boom' } });
+    const out = await isCanarySession(api, { sessionId: 's', metadata: {} });
+    expect(out).toEqual({ isCanary: true, reason: 'canary_check_indeterminate_fail_closed' });
+  });
+
+  it('FR-2: a THROWING transport also fences, never returns false', async () => {
+    const { api } = fakeSb({ throws: true });
+    const out = await isCanarySession(api, { sessionId: 's', metadata: {} });
+    expect(out.isCanary).toBe(true);
+    expect(out.reason).toBe('canary_check_indeterminate_fail_closed');
+  });
+
+  it('findCanaryPreRegistration reports lookupFailed DISTINCTLY from not-found', async () => {
+    // Collapsing these two into one falsy value is the exact conflation that let a reconciler
+    // report a healthy quiet lane while failing on every write.
+    const ok = await findCanaryPreRegistration(fakeSb({ rows: [] }).api, 's');
+    expect(ok).toEqual({ found: false, lookupFailed: false });
+    const bad = await findCanaryPreRegistration(fakeSb({ error: { message: 'x' } }).api, 's');
+    expect(bad).toEqual({ found: false, lookupFailed: true });
+  });
+});
+
+describe('FR-1 anti-regression: the predicate must never read env for canary identity', () => {
+  it('reads NO process.env at all in the source', () => {
+    // The original FR-1 named process.env.FLEET_WORKER_CALLSIGN as the primary signal. It is DEAD
+    // (measured null on a live worker; only six CLAUDE_-prefixed vars cross the hook boundary).
+    // A source-level pin is the only assertion that survives someone "helpfully" re-adding it,
+    // because an injected-env test would pass against a variable production never receives.
+    const src = readFileSync(SRC, 'utf8');
+    const code = src.replace(/\/\*\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    expect(code).not.toMatch(/process\s*\.\s*env/);
+    expect(code).not.toMatch(/FLEET_WORKER_CALLSIGN/);
+  });
+
+  it('reuses the shipped isCanaryCallsign rather than re-implementing the prefix test', () => {
+    // There are already five inline copies of this check in the repo; a sixth is how they drift.
+    const src = readFileSync(SRC, 'utf8');
+    expect(src).toMatch(/import\s*\{[^}]*isCanaryCallsign[^}]*\}\s*from\s*'\.\/canary-guard\.js'/);
+    const code = src.replace(/\/\*\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    expect(code).not.toMatch(/startsWith\(\s*['"]Canary-/);
+  });
+});

--- a/tests/unit/fleet/canary-session.test.js
+++ b/tests/unit/fleet/canary-session.test.js
@@ -108,6 +108,63 @@ describe('isCanarySession — FR-1 disjunction', () => {
   });
 });
 
+/**
+ * FR-4 AC-1 / TS-6 — THE PIN PRD risks[3] NAMES AS ITS SOLE MITIGATION, and which a VALIDATION review
+ * found had no assertion anywhere.
+ *
+ * The trigger key was chosen to be a NEW key rather than reusing non_fleet / role='adam' /
+ * is_coordinator precisely because those trip isDispatchableFleetMember and isFleetWorker — which would
+ * hide the canary from fleet-dashboard, rollcall, capacity-forecast and the liveness set, and (sharpest)
+ * make the coordinator HARD-REFUSE to dispatch at it. A probe whose whole value is being reachable by
+ * the same paths as a real worker must stay addressable.
+ *
+ * The safety argument was that every one of those predicates is a CLOSED ALLOWLIST of named keys, so a
+ * new key cannot trip them. That argument is only worth as much as this test: it is asserted against the
+ * REAL shipped predicates, so if any of them ever switches to a generic truthiness sweep of metadata,
+ * this fails instead of the canary silently vanishing from the fleet's view of itself.
+ */
+describe('FR-4 AC-1: the trigger key must not trip any fleet-membership predicate', () => {
+  // DIFFERENTIAL, not absolute — and my first draft got this wrong in a way worth recording. I asserted
+  // isFleetWorker(canary) === true; it is false, because that predicate requires everClaimed and a fresh
+  // canary has never claimed. That has nothing to do with the trigger key. The property that actually
+  // matters is INERTNESS: adding the key must not CHANGE any verdict. So each case compares the same
+  // session with and without it.
+  const base = {
+    session_id: 's-canary', status: 'active', heartbeat_at: new Date().toISOString(),
+    metadata: { account_profile: 'canary', role: 'worker', fleet_identity: { callsign: 'Canary-1' } },
+  };
+  const withKey = { ...base, metadata: { ...base.metadata, [CANARY_TRIGGER_KEY]: true } };
+
+  it('is INERT for isFleetWorker and isDispatchableFleetMember', async () => {
+    const preds = await import('../../../lib/fleet/session-predicates.mjs');
+    expect(preds.isFleetWorker(withKey)).toBe(preds.isFleetWorker(base));
+    expect(preds.isDispatchableFleetMember(withKey)).toBe(preds.isDispatchableFleetMember(base));
+    // And pin the one that carries the FR's actual argument: a canary must stay DISPATCHABLE, or the
+    // probe cannot exercise the paths a real worker does — which is the whole point of running one.
+    expect(preds.isDispatchableFleetMember(withKey)).toBe(true);
+  });
+
+  it('is INERT for the claim-side build-forbidden predicate', async () => {
+    // NOTE THE SIGNATURE: isBuildForbiddenSession takes METADATA, not a session row. My first draft
+    // passed a session object, so `md.non_fleet` was undefined and the assertion passed VACUOUSLY —
+    // caught only because the control below then failed. That is the control earning its place.
+    const { isBuildForbiddenSession } = await import('../../../lib/claim/build-forbidden-session.cjs');
+    expect(isBuildForbiddenSession(withKey.metadata)).toBe(isBuildForbiddenSession(base.metadata));
+    expect(isBuildForbiddenSession(withKey.metadata)).toBe(false); // fenced by the CLAIM FENCE, not by reclassification
+  });
+
+  it('CONTROL — the keys we deliberately did NOT reuse really do trip these predicates', async () => {
+    // Without this, the inertness above could hold simply because the predicates ignore everything,
+    // proving nothing about the key choice. This shows the hazard is real and the choice avoided it.
+    const { isBuildForbiddenSession } = await import('../../../lib/claim/build-forbidden-session.cjs');
+    expect(isBuildForbiddenSession({ non_fleet: true, role: 'worker' })).toBe(true);
+    expect(isBuildForbiddenSession({ role: 'adam' })).toBe(true);
+    expect(isBuildForbiddenSession({ is_coordinator: true })).toBe(true);
+    const preds = await import('../../../lib/fleet/session-predicates.mjs');
+    expect(preds.isDispatchableFleetMember({ ...base, metadata: { ...base.metadata, role: 'adam' } })).toBe(false);
+  });
+});
+
 describe('FR-1 anti-regression: the predicate must never read env for canary identity', () => {
   it('reads NO process.env at all in the source', () => {
     // The original FR-1 named process.env.FLEET_WORKER_CALLSIGN as the primary signal. It is DEAD

--- a/tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js
+++ b/tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js
@@ -95,7 +95,12 @@ describe('QF-20260724-499: restart/relaunch honor an explicit opts.live even whe
     const supabase = makeFakeSupabase({ sessions: [canaryWorker] });
 
     const result = await canaryRestart('Canary-Alpha-1', {
-      supabase, by: 'callsign', env: GUARD_ENV, live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn: vi.fn(),
+      // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E FR-5/FR-6: restart() now threads the old
+      // session's account_profile, so restarting a PROFILE-STAMPED session resolves a profile dir.
+      // resolveProfileDir fails loud when unconfigured (that is the accepted FR-6 decision), so a canary
+      // restart must supply baseDir. This is incidental setup — these cases assert live-flag
+      // propagation, not profile behaviour, and the assertions below are unchanged.
+      supabase, by: 'callsign', env: GUARD_ENV, live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn: vi.fn(), baseDir: 'C:\fleet\profiles',
     });
 
     expect(result.ok).toBe(true);
@@ -110,7 +115,12 @@ describe('QF-20260724-499: restart/relaunch honor an explicit opts.live even whe
     const supabase = makeFakeSupabase({ sessions: [{ ...canaryWorker, session_id: 's-canary-worker-2' }] });
 
     const result = await canaryRestart('Canary-Alpha-1', {
-      supabase, by: 'callsign', env: GUARD_ENV, spawnFn, execFn, sleepFn: vi.fn(),
+      // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E FR-5/FR-6: restart() now threads the old
+      // session's account_profile, so restarting a PROFILE-STAMPED session resolves a profile dir.
+      // resolveProfileDir fails loud when unconfigured (that is the accepted FR-6 decision), so a canary
+      // restart must supply baseDir. This is incidental setup — these cases assert live-flag
+      // propagation, not profile behaviour, and the assertions below are unchanged.
+      supabase, by: 'callsign', env: GUARD_ENV, spawnFn, execFn, sleepFn: vi.fn(), baseDir: 'C:\fleet\profiles',
     });
 
     expect(spawnFn).not.toHaveBeenCalled(); // dry-run: opts.live undefined -> isLiveEnabled() (env unset) -> false

--- a/tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js
+++ b/tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js
@@ -46,8 +46,10 @@ const CURRENT_RUNNER = (args) => {
 /** Same in-memory fake shape as spawn-control.test.js / canary-guard.test.js. */
 function makeFakeSupabase({ sessions = [] } = {}) {
   const store = new Map(sessions.map((s) => [s.session_id, { ...s }]));
+  const coordinationInserts = [];
   return {
     _store: store,
+    _coordinationInserts: coordinationInserts,
     from(table) {
       if (table === 'claude_sessions') {
         return {
@@ -71,7 +73,14 @@ function makeFakeSupabase({ sessions = [] } = {}) {
         };
       }
       if (table === 'session_coordination') {
-        return { select: () => ({ eq: () => ({ gte: async () => ({ count: 0 }) }) }) };
+        return {
+          select: () => ({ eq: () => ({ gte: async () => ({ count: 0 }) }) }),
+          // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E FR-4: a canary spawn writes its
+          // spawn-time marker here BEFORE spawning and refuses the spawn if the write fails. Without
+          // this the restart/relaunch legs read as a failed marker write and reported live=false —
+          // the assertion these tests exist to make.
+          insert: async (row) => { coordinationInserts.push(row); return { error: null }; },
+        };
       }
       throw new Error(`unexpected table: ${table}`);
     },

--- a/tests/unit/fleet/reboot-respawn-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-runner.test.js
@@ -80,12 +80,19 @@ describe('runRebootRespawn live (FR-5)', () => {
     expect(res.results.map((r) => r.spawned)).toEqual([true, true]);
   });
 
+  // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E FR-4: a canary slot now writes a spawn-time
+  // pre-registration marker before spawnFn and REFUSES the slot if that write fails (an unmarked canary
+  // passes the claim fence and takes real work). `supabase: {}` has no .from, so it read as a failed
+  // write. Both production entry points supply a real service client — reboot-respawn.cjs:29 and the
+  // drill runner — so modelling the insert here matches production rather than papering over it.
+  const canaryMarkerOk = () => ({ from: () => ({ insert: async () => ({ error: null }) }) });
+
   it('resolves account_profile into CLAUDE_CONFIG_DIR via the injected resolver, and is fail-soft if it throws', async () => {
     const okResolver = (name) => `C:\\profiles\\${name}`;
     const spawnCalls = [];
     const spawnFn = (program, args, env) => { spawnCalls.push(env); return { pid: 1 }; };
     const res = await runRebootRespawn({
-      supabase: {}, loadFn: async () => [{ name: 'Canary-1', role: 'worker', account_profile: 'canary', resume_uuid: 'u-c' }],
+      supabase: canaryMarkerOk(), loadFn: async () => [{ name: 'Canary-1', role: 'worker', account_profile: 'canary', resume_uuid: 'u-c' }],
       spawnFn, logFn: async () => ({ ok: true }), live: true, resolveProfileDirFn: okResolver, sleepFn: vi.fn(),
     });
     expect(spawnCalls[0].CLAUDE_CONFIG_DIR).toBe('C:\\profiles\\canary');

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -56,6 +56,7 @@ const CURRENT_RUNNER = (args) => {
 const { logCoordinationEvent } = await import('../../../lib/coordinator/coordination-events.cjs');
 const { sequenceSingletonRefresh } = await import('../../../lib/coordinator/singleton-refresh-sequencer.cjs');
 const { spawn: childProcessSpawnSpy } = await import('node:child_process');
+const canarySession = await import('../../../lib/fleet/canary-session.js');
 
 /**
  * FR-3: the spawner MINTS the session id and passes it as `claude --session-id <uuid>`, so the child
@@ -136,7 +137,9 @@ describe('module surface (TS-10: exactly six named verbs, no more)', () => {
     // wall-clock; they are values, not verbs, so they belong on this allowlist.
     const helperNames = ['roleOf', 'isSingletonRole', 'resolveProfileDir', 'isLiveEnabled', 'buildLiveSpawnInvocation',
       'SESSION_BIND_MAX_ATTEMPTS', 'SESSION_BIND_DELAY_MS',
-      'CANARY_PROFILE', 'CANARY_CALLSIGN_PREFIX'];
+      'CANARY_PROFILE', 'CANARY_CALLSIGN_PREFIX',
+      // FR-4: third cycle-forced constant (see the drift pin). A value, not a verb.
+      'CANARY_TRIGGER_KEY'];
     const unexpected = Object.keys(mod).filter((k) => !verbNames.includes(k) && !helperNames.includes(k));
     expect(unexpected).toEqual([]);
   });
@@ -603,6 +606,47 @@ describe('spawn (FR-1)', () => {
     expect(guard.isCanaryCallsign(`${mod.CANARY_CALLSIGN_PREFIX}1`)).toBe(true);
     expect(guard.isCanaryCallsign('Bravo')).toBe(false);
     expect(mod.CANARY_PROFILE).toBe('canary');
+    // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E FR-4: the trigger key is duplicated here for
+    // the same cycle reason, so it joins the same drift pin — against the canonical module this time,
+    // since that is what READS the key out of metadata. A rename on either side breaks this.
+    expect(mod.CANARY_TRIGGER_KEY).toBe(canarySession.CANARY_TRIGGER_KEY);
+    expect(canarySession.isCanaryMetadata({ [mod.CANARY_TRIGGER_KEY]: true })).toBe(true);
+  });
+
+  it('FR-4: the stamped trigger key is REACHABLE — a canary spawn writes it into metadata', async () => {
+    // A VALIDATION review found CANARY_TRIGGER_KEY was read by isCanaryMetadata and mirrored into the
+    // marker payload but written to claude_sessions.metadata NOWHERE — an unreachable disjunct, which is
+    // exactly what canary-session.js's own header forbids. This asserts the write happens, so the
+    // disjunct cannot silently become decorative again.
+    const nowMs = 1_800_000_000_000;
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: MINTED_SESSION_ID, pid: 4242, status: 'active', created_at: new Date(nowMs).toISOString(), metadata: {} }],
+    });
+    await spawn({ role: 'worker', callsign: 'Canary-pilot', accountProfile: 'canary' }, {
+      live: true, spawnFn: vi.fn(() => ({ pid: 4242, unref: vi.fn() })), supabaseClient,
+      currencyRunner: CURRENT_RUNNER, execFn: enumExec(), sleepFn: vi.fn(), nowMs,
+      baseDir: 'C:\\fleet\\profiles', uuidFn: () => MINTED_SESSION_ID,
+    });
+    const md = supabaseClient._store.get(MINTED_SESSION_ID).metadata;
+    expect(md[canarySession.CANARY_TRIGGER_KEY]).toBe(true);
+    expect(canarySession.isCanaryMetadata(md)).toBe(true);
+  });
+
+  it('FR-4 NEGATIVE CONTROL: an ORDINARY spawn does not get the trigger key', async () => {
+    // Without this the stamp could be unconditional, marking every worker a canary — which the claim
+    // fence would then read as "nobody may claim anything".
+    const nowMs = 1_800_000_000_000;
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: MINTED_SESSION_ID, pid: 4242, status: 'active', created_at: new Date(nowMs).toISOString(), metadata: {} }],
+    });
+    await spawn({ role: 'worker', callsign: 'Bravo' }, {
+      live: true, spawnFn: vi.fn(() => ({ pid: 4242, unref: vi.fn() })), supabaseClient,
+      currencyRunner: CURRENT_RUNNER, execFn: enumExec(), sleepFn: vi.fn(), nowMs,
+      uuidFn: () => MINTED_SESSION_ID,
+    });
+    const md = supabaseClient._store.get(MINTED_SESSION_ID).metadata;
+    expect(md[canarySession.CANARY_TRIGGER_KEY]).toBeUndefined();
+    expect(canarySession.isCanaryMetadata(md)).toBe(false);
   });
 
   it('FR-1/FR-3: does NOT stamp account_profile when none was requested', async () => {

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -751,6 +751,60 @@ describe('restart (FR-4 singleton-serial / FR-5 worker-parallel)', () => {
     expect(supabaseClient._store.get('s1').status).toBe('released');
   });
 
+  // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E (FR-5 / FR-6).
+  it('FR-5: threads the old session account_profile into the replacement (was DROPPED)', async () => {
+    // Asserting the value that REACHES the child launch, not merely that spawnReplacement was
+    // called — a "was called" assertion passes against the exact bug this fixes. accountProfile
+    // drives CLAUDE_CONFIG_DIR isolation, so the proof is that the profile dir lands in the env.
+    const spawnFn = vi.fn().mockReturnValue({ pid: 5150 });
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Canary-1' }, role: 'worker', account_profile: 'canary' } }],
+    });
+
+    const result = await restart('Canary-1', {
+      supabaseClient, live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn: enumExec(),
+      sleepFn: vi.fn(), baseDir: 'C:\\fleet\\profiles',
+    });
+
+    expect(result.ok).toBe(true);
+    const env = spawnFn.mock.calls[0][2]; // spawnFn(program, args, env) — arg[2] IS the env
+    expect(env.CLAUDE_CONFIG_DIR).toBe('C:\\fleet\\profiles\\canary');
+  });
+
+  it('FR-5: a session with NO account_profile still restarts normally (negative control)', async () => {
+    // Proves the threading is conditional, not a blanket requirement — otherwise every ordinary
+    // worker restart would start demanding a profile dir.
+    const spawnFn = vi.fn().mockReturnValue({ pid: 5151 });
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' } }],
+    });
+
+    const result = await restart('Alpha-5', {
+      supabaseClient, live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn: enumExec(), sleepFn: vi.fn(),
+    });
+
+    expect(result.ok).toBe(true);
+    const env = spawnFn.mock.calls[0][2]; // spawnFn(program, args, env) — arg[2] IS the env
+    expect(env.CLAUDE_CONFIG_DIR).toBeUndefined();
+  });
+
+  it('FR-6: restarting a profile-stamped session with NO profiles dir configured FAILS LOUD', async () => {
+    // The behaviour change this FR accepts deliberately. resolveProfileDir throws when
+    // FLEET_ACCOUNT_PROFILES_DIR is unset; restart() never reached that path before. Measured
+    // blast radius: 1 of 16 live sessions carries account_profile, and it is the canary. Degrading
+    // to the un-isolated path instead would silently reinstate the defect FR-5 fixes — a canary
+    // without its profile isolation is not a canary.
+    const spawnFn = vi.fn().mockReturnValue({ pid: 5152 });
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Canary-1' }, role: 'worker', account_profile: 'canary' } }],
+    });
+
+    await expect(restart('Canary-1', {
+      supabaseClient, live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn: enumExec(),
+      sleepFn: vi.fn(), baseDir: null,
+    })).rejects.toThrow(/FLEET_ACCOUNT_PROFILES_DIR/);
+  });
+
   it('singleton path defers until a newSessionId is supplied (never a bespoke retire-first sequence)', async () => {
     const supabaseClient = makeFakeSupabase({
       sessions: [{ session_id: 's1', status: 'active', metadata: { role: 'coordinator', is_coordinator: 'true' } }],

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -82,10 +82,12 @@ function enumExec(handle = 131074) {
 }
 
 /** Minimal in-memory fake covering exactly the claude_sessions/session_coordination shapes spawn-control.js touches. */
-function makeFakeSupabase({ sessions = [] } = {}) {
+function makeFakeSupabase({ sessions = [], coordinationInsertError = null } = {}) {
   const store = new Map(sessions.map((s) => [s.session_id, { ...s }]));
+  const coordinationInserts = [];
   return {
     _store: store,
+    _coordinationInserts: coordinationInserts,
     from(table) {
       if (table === 'claude_sessions') {
         return {
@@ -109,7 +111,14 @@ function makeFakeSupabase({ sessions = [] } = {}) {
         };
       }
       if (table === 'session_coordination') {
-        return { select: () => ({ eq: () => ({ gte: async () => ({ count: 0 }) }) }) };
+        return {
+          select: () => ({ eq: () => ({ gte: async () => ({ count: 0 }) }) }),
+          // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E FR-4: canary spawns now write a
+          // spawn-time pre-registration marker here BEFORE spawning, and refuse the spawn if it
+          // cannot be written (an unmarked canary would pass the claim fence and take real work).
+          // Recorded rather than swallowed so tests can assert the marker and its ordering.
+          insert: async (row) => { coordinationInserts.push(row); return { error: coordinationInsertError }; },
+        };
       }
       throw new Error(`unexpected table: ${table}`);
     },

--- a/tests/unit/worker-checkin-callsign-collision-fix.test.js
+++ b/tests/unit/worker-checkin-callsign-collision-fix.test.js
@@ -31,12 +31,19 @@ function stub(cfg = {}) {
     const st = { op: 'select', payload: null };
     const chain = {
       select() { return chain; }, eq() { return chain; }, gte() { return chain; }, neq() { return chain; },
+      // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E (FR-7): the canary pre-registration
+      // lookup terminates in .limit(). Without it the call THREW, and because that check fails
+      // closed for a session with no callsign, these first-time-assignment cases were fenced and
+      // stopped assigning at all. Modelling the query means the default here is "lookup succeeded
+      // and found no marker" — an ordinary worker — instead of "lookup broken".
+      limit() { return chain; },
       update(p) { st.op = 'update'; st.payload = p; return chain; },
       insert(p) { st.op = 'insert'; st.payload = p; return chain; },
       maybeSingle() { return Promise.resolve({ data: cfg.selfRow ?? null, error: null }); },
       then(res, rej) {
         let out;
-        if (table === 'claude_sessions' && st.op === 'select') out = { data: cfg.live ?? [], error: null };
+        if (table === 'session_coordination' && st.op === 'select') out = { data: cfg.preReg ?? [], error: null };
+        else if (table === 'claude_sessions' && st.op === 'select') out = { data: cfg.live ?? [], error: null };
         else if (table === 'claude_sessions' && st.op === 'update') { rec.update = st.payload; out = { data: null, error: null }; }
         else if (table === 'session_coordination' && st.op === 'insert') { rec.insert = st.payload; out = { data: { id: 'm' }, error: null }; }
         else out = { data: null, error: null };

--- a/tests/unit/worker-checkin-canary-identity-skip.test.js
+++ b/tests/unit/worker-checkin-canary-identity-skip.test.js
@@ -30,7 +30,7 @@ const HERE = path.dirname(fileURLToPath(import.meta.url));
  * Fake covering only the shapes this function touches. RECORDS every update so a silent rename is
  * detectable -- asserting the return value alone would miss a write that clobbers the stored identity.
  */
-function fakeClient(metadata, { live = [], onLiveQuery } = {}) {
+function fakeClient(metadata, { live = [], onLiveQuery, preRegRows = [], preRegBroken = false } = {}) {
   const updates = [];
   return {
     updates,
@@ -39,6 +39,12 @@ function fakeClient(metadata, { live = [], onLiveQuery } = {}) {
         select: () => builder,
         eq: () => builder,
         neq: () => builder,
+        // The FR-7 pre-registration lookup terminates in .limit(). Modelling it explicitly (rather
+        // than letting an undefined method throw) is what makes "lookup worked and found nothing"
+        // testable as a state DISTINCT from "lookup broken" — the two must not behave alike.
+        limit: () => Promise.resolve(
+          preRegBroken ? { data: null, error: { message: 'lookup down' } } : { data: preRegRows, error: null },
+        ),
         // The slot-picking query over live sessions. Instrumented because REACHING it is what
         // distinguishes "fell through to re-derive" from "short-circuited by the canary branch" --
         // the returned callsign cannot tell those apart.
@@ -96,15 +102,29 @@ describe('FR-6 canary identity skip — the second clobber writer', () => {
     const source = fs.readFileSync(path.join(HERE, '../../scripts/worker-checkin.cjs'), 'utf8');
     const fnStart = source.indexOf('async function assignFleetIdentityAtCheckin');
     expect(fnStart).toBeGreaterThan(-1);
-    // CODE LINES ONLY. The first version of this assertion scanned raw text and matched
-    // "callsignInTierBand" inside the explanatory COMMENT above the guard, reporting the guard as
-    // mis-ordered when it was correct. Comments describe the code they sit next to, so any
-    // position assertion over raw source will eventually match prose instead of behaviour.
+    // SCOPE TO THE ACTUAL FUNCTION, not a magic byte count. This originally sliced a fixed 4000
+    // chars, which silently became too small when the guard grew: the window fell BETWEEN the two
+    // markers, tierBandLine went to -1, and the failure read as "tier-band check not found" — a
+    // missing-code message for code that was present and correctly ordered. A bound that can drift
+    // out from under the invariant it protects is a false failure waiting to happen (and, had the
+    // clipping gone the other way, a false PASS: two -1s compare equal-ish and the order assertion
+    // would never have run). The function's own closing brace cannot drift.
+    const rel = /\r?\n\}\r?\n/.exec(source.slice(fnStart));
+    expect(rel, 'could not find the end of assignFleetIdentityAtCheckin').not.toBeNull();
+    // CODE LINES ONLY. An earlier version scanned raw text and matched "callsignInTierBand" inside
+    // the explanatory COMMENT above the guard, reporting the guard as mis-ordered when it was
+    // correct. Comments describe the code they sit next to, so any position assertion over raw
+    // source will eventually match prose instead of behaviour.
     const codeLines = source
-      .slice(fnStart, fnStart + 4000)
+      .slice(fnStart, fnStart + rel.index)
       .split('\n')
       .filter((l) => !l.trim().startsWith('//') && !l.trim().startsWith('*') && !l.trim().startsWith('/*'));
-    const canaryLine = codeLines.findIndex((l) => l.includes("startsWith('Canary-')"));
+    // SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-E FR-7: the guard no longer hand-rolls
+    // startsWith('Canary-') — it delegates to the canonical isCanarySession predicate, which adds the
+    // spawn-time pre-registration disjunct so an UNSTAMPED canary (0-10s window, or reboot-respawn
+    // where metadata is never written) is recognised before it can be renamed. This pin tracks the
+    // delegation call instead of the removed literal; the ORDERING invariant it protects is unchanged.
+    const canaryLine = codeLines.findIndex((l) => l.includes('isCanarySession(sb,'));
     const tierBandLine = codeLines.findIndex((l) => l.includes('callsignInTierBand('));
     expect(canaryLine, 'canary guard not found in code').toBeGreaterThan(-1);
     expect(tierBandLine, 'tier-band check not found in code').toBeGreaterThan(-1);
@@ -129,6 +149,45 @@ describe('FR-6 canary identity skip — the second clobber writer', () => {
     );
     await assignFleetIdentityAtCheckin(client, 'sess-worker-1', null);
     expect(reachedLiveQuery, 'an ordinary worker must NOT be short-circuited by the canary branch').toBe(true);
+  });
+
+  it('FR-7: an UNSTAMPED canary is protected by the pre-registration alone', async () => {
+    // The state the old two-signal skip could not see: metadata carries nothing, because both stamps
+    // land later in the session-bind loop (and never at all on the reboot-respawn path).
+    let reachedLiveQuery = false;
+    const client = fakeClient(
+      { tier_rank: 1 },
+      { preRegRows: [{ id: 'pre-1' }], onLiveQuery: () => { reachedLiveQuery = true; } },
+    );
+    await assignFleetIdentityAtCheckin(client, CANARY_ID, null);
+    expect(reachedLiveQuery, 'a pre-registered canary must not reach the rename path').toBe(false);
+    expect(client.updates).toHaveLength(0);
+  });
+
+  it('FR-7: a NAMELESS session is protected when the check is INDETERMINATE (fail-closed)', async () => {
+    // Renaming is irreversible, so an unreadable check must not rename a session that could still be
+    // an unstamped canary. "Nameless" is the at-risk set: a session with no callsign at all.
+    let reachedLiveQuery = false;
+    const client = fakeClient(
+      { tier_rank: 1 },
+      { preRegBroken: true, onLiveQuery: () => { reachedLiveQuery = true; } },
+    );
+    await assignFleetIdentityAtCheckin(client, 'sess-unknown', null);
+    expect(reachedLiveQuery, 'an indeterminate check must not rename a nameless session').toBe(false);
+  });
+
+  it('FR-7: but an ESTABLISHED worker still gets named when the check is indeterminate', async () => {
+    // The other half, and the reason the fail-closed is SCOPED rather than blanket. A blanket version
+    // would freeze naming for the entire fleet on any transient DB fault — and "every worker unnamed"
+    // reads as a quiet cron rather than a broken one. This pair pins the boundary in both directions;
+    // either test alone is satisfied by a guard that is simply always-on or always-off.
+    let reachedLiveQuery = false;
+    const client = fakeClient(
+      { fleet_identity: { callsign: 'Delta', color: 'red' }, tier_rank: 1 },
+      { preRegBroken: true, onLiveQuery: () => { reachedLiveQuery = true; } },
+    );
+    await assignFleetIdentityAtCheckin(client, 'sess-worker-2', null);
+    expect(reachedLiveQuery, 'an established worker must not be frozen by an unreadable check').toBe(true);
   });
 
   it('a CANARY is short-circuited before that same query (the positive half of the control)', async () => {


### PR DESCRIPTION
## Summary

A **canary** is a probe session that must never acquire real work off the shared LEO queue. Before this, nothing could reliably stop one: canaries were identified only by two **late** metadata signals (`metadata.account_profile='canary'` and a `Canary-` callsign), both written by a single update inside spawn-control's session-bind loop up to 10s after launch — and never written at all on the reboot-respawn path. During that window a canary was indistinguishable from a real worker.

- **FR-1/FR-2** `lib/fleet/canary-session.js` — the canary predicate. A **disjunction** that fails **closed**, reporting `indeterminate` separately so each caller sets its own policy. Deliberately the opposite polarity to `canary-guard.js`'s `assertCanaryTarget`, which is a conjunction because it guards a *destructive* verb ("never kill unless certain"); a claim fence is restrictive, so fail-closed inverts.
- **FR-3** `lib/checkin/steps/canary-claim-fence.cjs` — the fence, at position 8 of 17, ahead of all eight acquisition tiers. It **acks-and-declines** a directed assignment rather than silently short-circuiting, so a canary stays addressable and no WORK_ASSIGNMENT is stranded.
- **FR-4** `writeCanaryPreRegistration` + wiring at **all three** spawn sites. The marker is keyed on the spawner-**minted** session id and written **before the child process starts** — the ordering is the whole property, since a child can check in within milliseconds.
- **FR-5/FR-6** `restart()` threads the old session's `account_profile` (falling back to the metadata predicate, since the sessions most likely to reach a restart unstamped *are* the canaries), and fails **loud** on an unconfigured profile dir.
- **FR-7** both callsign writers consult the canonical predicate, so an unstamped canary is not renamed to a NATO callsign — an **irreversible** loss, since `stampRespawnedCanary` only carries a callsign forward when the incoming one is already canary-shaped.

## Why it needed three review rounds

Every defect found was the same shape — **a guard whose observer couldn't see it**:

| | Defect | How it hid |
|---|---|---|
| F2 | FR-7's cron half was **inert** | Verdict was correct; `dedupeAssignedCallsigns` demoted the callsign-less canary back into the rename path two steps later |
| SEC-1 | The marker **self-destructed after 60 min** | `expires_at` defaults to `now()+1h`; the reaper deletes expired+acked rows, and roll-call acked it *before* the fence ran. Every test mocks the client, so neither the DB default nor the ack was visible |
| V-1 | `CANARY_TRIGGER_KEY` was an **unreachable disjunct** | Read by the predicate, mirrored into the payload, written to metadata by nothing |
| F3/R3/R6 | Three guards had **no reachable assertion** | Pinned only by source regexes that still matched when the guarded call was wrapped in `false &&` |

Consequently the coverage here is behavioural, not textual, and **23/23 mutations are caught** — including widening the spawn refusal from canary-only to every spawn, which is the shape of a near-miss that nearly caused a fleet-wide outage on 2026-07-26.

## Test plan

- `npx vitest run tests/unit/fleet/ tests/unit/checkin/ tests/unit/checkin-pipeline.test.js scripts/worker-checkin.test.js tests/unit/assign-fleet-identities-coordinator-filter.test.js --project unit` → **1271 passing / 95 files**
- Classguard lint in blocking `--diff` mode → **0 violations**
- Sub-agents: TESTING **PASS**, SECURITY **PASS**, VALIDATION conditional, REGRESSION conditional, GITHUB conditional (all four findings closed in-branch)

## PR size — honest disclosure

**~631 production LOC across 19 files, over the 400 max.** The fence core (~434 LOC) genuinely is atomic: the fence without every writer is a dormant guard that never fires, and the writers without the fence are an unreachable disjunct — which is literally the V-1 defect above. But **FR-7 was separable** and already sits in its own commit (`8f0d2a111d2`); the seam existed and I didn't take it. Even split, the remainder exceeds 400 and needs this justification. Recorded rather than argued away.

## Known residuals (documented, not silently carried)

1. **RPC-side claim path** — this fence is check-in-scoped and cannot stop a claim issued directly through `claim_sd`. Accepted with reasoning in the fence header; pushing the predicate into the RPC means DB-side metadata reads on every claim in the fleet.
2. **Marker lookup seq-scans** — measured on the live DB: Seq Scan, 5331 rows filtered, ~3ms per check-in. Caused by my own SEC-1 fix: pre-stamping `acknowledged_at` excludes the row from the only `target_session` index (partial, `WHERE acknowledged_at IS NULL`). Fix is a partial index on `(target_session) WHERE payload->>'kind' = 'canary_pre_registration'` — **DDL, so gated**; filed as a follow-up rather than added unilaterally.
3. **Five lint workflows have unreachable path filters** — they use brace expansion (`lib/**/*.{js,mjs,cjs}`), which GitHub Actions path filters do not support, so `session-coordination-insert-classguard-lint` and four siblings effectively never run on PRs. Pre-existing, unrelated to this SD, worth its own item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
