### PR TITLE
SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001: confirmation gate, side-effect-free preview, audit restoration, pinned carve-out audit

### DIFF
--- a/lib/audit-mounts.js
+++ b/lib/audit-mounts.js
@@ -1,0 +1,151 @@
+/**
+ * Auth-carve-out audit for Express mounts.
+ * SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001 FR-5.
+ *
+ * WHY THIS IS A PURE FUNCTION, and it is not a style preference. The mutation half of the
+ * test for this audit has to prove the audit FAILS when a carve-out is introduced. The
+ * obvious way to do that is to edit server/index.js, run, and restore — and the fleet has
+ * a live near-miss from exactly that shape: an agent hardcoded a failure into
+ * spawn-control.js to check a suite went red and left it UNCOMMITTED, which would have
+ * refused every spawn fleet-wide had it been committed. So this function does NO file I/O:
+ * it takes source TEXT, and the mutation is applied to a synthetic fixture string. The
+ * real server/index.js is never touched, and the test asserts the working tree is clean.
+ *
+ * WHY IT RESOLVES MOUNT ORDERING RATHER THAN READING DECLARATIONS IN ISOLATION. An earlier
+ * version of this audit (a one-off script) read each mount's declared middleware on its own
+ * and reported POST /api/github/pr-review-webhook as an unauthenticated mutating route. That
+ * was a FALSE POSITIVE, and it was signalled before being verified. Express `app.use(path, …)`
+ * PREFIX-matches, and `app.use('/api/github', requireAuth, …)` at server/index.js:207 sits
+ * seven lines BEFORE the `/api` optionalAuth mount at :214 — so requireAuth runs for every
+ * request under that prefix whether or not the inner router matches a route. The route was
+ * always guarded. Reading declarations in isolation cannot see that; this resolves the
+ * effective chain.
+ *
+ * DIRECTION OF ERROR, stated because it makes a limited method usable: optionalAuth calls
+ * next() unconditionally, so an earlier prefix mount can only ADD authentication, never
+ * remove it. This audit therefore OVER-reports and cannot UNDER-report. A clean result is
+ * meaningful; a finding still warrants reading the source.
+ */
+
+const GUARDS = ['requireAuth', 'requireAdminAuth', 'requireAdminRole', 'optionalAuth'];
+const HARD_GUARDS = ['requireAuth', 'requireAdminAuth'];
+const MUTATING_METHODS = ['post', 'put', 'patch', 'delete', 'all'];
+
+/** Comment keywords that claim an auth check. HEURISTIC, not a semantic guarantee. */
+const AUTH_CLAIM_PATTERN = /auth (?:happens |is )?at (?:the )?rpc level|chairman check|auth(?:enticat\w+)? (?:handled|enforced) (?:internally|at)/i;
+
+function parseImports(src) {
+  const map = new Map();
+  for (const m of src.matchAll(/import\s+(?:(\w+)|\{([^}]+)\})\s+from\s+['"]([^'"]+)['"]/g)) {
+    if (m[1]) map.set(m[1], m[3]);
+    if (m[2]) {
+      for (const part of m[2].split(',')) {
+        const name = part.trim().split(/\s+as\s+/).pop().trim();
+        if (name) map.set(name, m[3]);
+      }
+    }
+  }
+  return map;
+}
+
+/** Ordered mount list. Order is the whole point — Express matches in declaration order. */
+function parseMounts(src) {
+  const mounts = [];
+  const push = (index, entry) => mounts.push({ order: index, line: src.slice(0, index).split('\n').length, ...entry });
+
+  for (const m of src.matchAll(/app\.use\(\s*['"`]([^'"`]+)['"`]\s*,([^)]*)\)/g)) {
+    const mws = m[2];
+    push(m.index, {
+      kind: 'use',
+      mountPath: m[1],
+      guard: GUARDS.find(g => mws.includes(g)) || null,
+      routerName: (mws.match(/([A-Za-z_$][\w$]*)\s*$/) || [])[1] || null,
+    });
+  }
+  for (const m of src.matchAll(/app\.(get|post|put|patch|delete|all)\(\s*['"`]([^'"`]+)['"`]\s*,([^)]*)\)/g)) {
+    push(m.index, {
+      kind: 'direct',
+      method: m[1].toLowerCase(),
+      mountPath: m[2],
+      guard: GUARDS.find(g => m[3].includes(g)) || null,
+      routerName: null,
+    });
+  }
+  return mounts.sort((a, b) => a.order - b.order);
+}
+
+function joinPath(mountPath, routePath) {
+  if (!routePath || routePath === '/') return mountPath;
+  return `${mountPath.replace(/\/$/, '')}${routePath.startsWith('/') ? '' : '/'}${routePath}`;
+}
+
+/** Does an EARLIER mount already force authentication on this effective path? */
+function shadowedByEarlierGuard(mounts, selfOrder, effectivePath) {
+  return mounts.some(m => (
+    m.order < selfOrder &&
+    m.kind === 'use' &&
+    HARD_GUARDS.includes(m.guard) &&
+    (effectivePath === m.mountPath || effectivePath.startsWith(m.mountPath.replace(/\/$/, '') + '/'))
+  ));
+}
+
+/**
+ * Audit mounts for mutating routes reachable without authentication.
+ *
+ * @param {object}  input
+ * @param {string}  input.indexSource - Contents of the server entrypoint. TEXT, not a path.
+ * @param {object}  input.routeInventory - Map of module specifier -> array of
+ *   { method, path } route declarations. Supplied by the caller (the test reads these from
+ *   disk); this function performs no I/O so a fixture can be passed instead.
+ * @returns {{findings: object[], mountsScanned: number, mutatingRoutesChecked: number, commentClaims: object[]}}
+ */
+export function auditMounts({ indexSource, routeInventory = {} }) {
+  const imports = parseImports(indexSource);
+  const mounts = parseMounts(indexSource);
+  const findings = [];
+  let mutatingRoutesChecked = 0;
+
+  for (const mount of mounts) {
+    if (mount.kind === 'direct') {
+      if (!MUTATING_METHODS.includes(mount.method)) continue;
+      mutatingRoutesChecked++;
+      if (HARD_GUARDS.includes(mount.guard)) continue;
+      if (shadowedByEarlierGuard(mounts, mount.order, mount.mountPath)) continue;
+      findings.push({ method: mount.method.toUpperCase(), path: mount.mountPath, mountLine: mount.line, guard: mount.guard, reason: 'direct mutating route without a hard auth guard' });
+      continue;
+    }
+
+    const specifier = imports.get(mount.routerName);
+    const routes = specifier ? routeInventory[specifier] : undefined;
+    if (!routes) continue; // unresolvable mount (middleware, static, or not supplied)
+
+    for (const route of routes) {
+      if (!MUTATING_METHODS.includes(String(route.method).toLowerCase())) continue;
+      mutatingRoutesChecked++;
+      const effectivePath = joinPath(mount.mountPath, route.path);
+      if (HARD_GUARDS.includes(mount.guard)) continue;
+      if (shadowedByEarlierGuard(mounts, mount.order, effectivePath)) continue;
+      findings.push({
+        method: String(route.method).toUpperCase(),
+        path: effectivePath,
+        mountLine: mount.line,
+        guard: mount.guard,
+        module: specifier,
+        reason: 'mutating route under a mount with no hard auth guard, and no earlier prefix mount supplies one',
+      });
+    }
+  }
+
+  // HEURISTIC, deliberately not presented as a guarantee: flags comments that CLAIM an auth
+  // check. A false safety comment is what let the original carve-out survive — it
+  // pre-answered the question a reviewer would otherwise have asked.
+  const commentClaims = [];
+  indexSource.split('\n').forEach((text, i) => {
+    const trimmed = text.trim();
+    if ((trimmed.startsWith('//') || trimmed.startsWith('*')) && AUTH_CLAIM_PATTERN.test(trimmed)) {
+      commentClaims.push({ line: i + 1, text: trimmed });
+    }
+  });
+
+  return { findings, mountsScanned: mounts.length, mutatingRoutesChecked, commentClaims };
+}

--- a/lib/deleteVentureFully.js
+++ b/lib/deleteVentureFully.js
@@ -15,7 +15,7 @@
  * Phase order (credentials BEFORE DB delete, mirroring master-reset):
  *   1. Look up venture repo + name from venture_provisioning_state
  *   2. runTeardown(ventureId)            — external resources (Vercel/FS/Docker)
- *   3. markResourcesCleaned(ventureId)   — venture_resources status
+ *   3. markResourcesCleaned(ventureId, { dryRun, supabase }) — venture_resources status
  *   4. cleanupCredentials([ventureId])   — revoke credentials at providers
  *   5. delete_venture(p_venture_id) RPC  — DB cascade (BLOCKING)
  *   6. gh repo delete                    — guarded + injection-safe slug regex
@@ -121,8 +121,13 @@ export async function deleteVentureFully(ventureId, options = {}) {
   }
 
   // Phase 3: mark venture_resources cleaned (non-blocking)
+  // SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001 FR-2: this call previously passed NO
+  // options, so phase 3 alone ignored dryRun and built its own client — meaning a
+  // "preview" wrote to venture_resources for real. Phases 2 and 4 already thread
+  // { dryRun }; this now matches them, and also passes the injected client so the
+  // whole teardown runs against one seam.
   try {
-    phases.resources_marked = await markResourcesCleaned(ventureId);
+    phases.resources_marked = await markResourcesCleaned(ventureId, { dryRun, supabase });
   } catch (err) {
     phases.resources_marked = 0;
     phases.resources_error = err.message;

--- a/lib/destructive-audit.js
+++ b/lib/destructive-audit.js
@@ -1,0 +1,99 @@
+/**
+ * Audit trail for irreversible venture teardown.
+ * SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001 FR-3.
+ *
+ * THIS IS REPAIR, NOT INVENTION. The pre-refactor master_reset_portfolio() wrote
+ * operations_audit_log BEFORE and AFTER the deletes
+ * (supabase/migrations/20260320_fix_p0_security_rls_and_reset.sql:62,74,97).
+ * SD-SINGLEVENTURE-AND-BULK-DELETE-ORCH-001-B replaced that RPC with the
+ * deleteVentureFully loop and dropped both writes without replacement, so today the most
+ * destructive operation in the system leaves no record that it ran.
+ *
+ * DO NOT MODEL THIS ON lib/cleanup/archive.js:303-312. That insert uses columns
+ * `operation_type` and `details` which DO NOT EXIST on operations_audit_log and hard-error,
+ * and its failure is swallowed by a console.warn at :314 — so it has been silently writing
+ * nothing. The live column list, measured against the database, is exactly:
+ *   id, entity_type, entity_id, action, performed_by, performed_at, module, severity, metadata
+ *
+ * TWO PROPERTIES THAT ARE EASY TO GET WRONG AND ARE THE POINT OF THIS MODULE:
+ *
+ *  1. THE POST ROW MUST SURVIVE PARTIAL FAILURE. If the teardown loop throws at venture k,
+ *     asyncHandler unwinds straight to the error handler. Without an explicit catch the PRE
+ *     row is already written and no POST row ever is, leaving a trail that permanently reads
+ *     "started, never finished" with no record of how far it got. That is arguably worse
+ *     than no audit at all, because it looks like a hang rather than a failure.
+ *
+ *  2. A FAILED PRE-WRITE MUST REFUSE THE OPERATION (fail-closed, FR-4). An irreversible
+ *     teardown that cannot be recorded must not proceed. Refusing costs an operator one
+ *     retry; proceeding unaudited costs the ability to ever know what happened.
+ */
+
+const MODULE_NAME = 'ventures';
+const ENTITY_TYPE = 'venture';
+
+/**
+ * Write one audit row. Throws on failure — callers decide whether that is fatal.
+ * Deliberately does NOT swallow errors: the bug this module replaces was invisible
+ * precisely because its failure path logged and continued.
+ */
+export async function writeAuditRow(supabase, { operation, phase, targetIds, performedBy, metadata = {} }) {
+  const { error } = await supabase.from('operations_audit_log').insert({
+    entity_type: ENTITY_TYPE,
+    // A single-target operation names its venture; a bulk one cannot, so the full set
+    // lives in metadata.target_ids rather than being lost.
+    entity_id: targetIds.length === 1 ? targetIds[0] : null,
+    action: `${operation}.${phase}`,
+    performed_by: performedBy || 'unknown',
+    performed_at: new Date().toISOString(),
+    module: MODULE_NAME,
+    severity: 'critical',
+    metadata: { operation, phase, target_count: targetIds.length, target_ids: targetIds, ...metadata },
+  });
+
+  if (error) throw new Error(`[destructive-audit] ${operation}.${phase} audit write failed: ${error.message}`);
+}
+
+/**
+ * Run an irreversible operation bracketed by audit rows.
+ *
+ * @returns whatever `run` returns.
+ * @throws if the PRE-write fails (operation is NOT run), or whatever `run` throws
+ *         (after a POST row recording the failure has been written).
+ */
+export async function withDestructiveAudit(supabase, { operation, targetIds, performedBy }, run) {
+  // FAIL CLOSED: if this throws, `run` is never invoked and nothing is deleted.
+  await writeAuditRow(supabase, { operation, phase: 'started', targetIds, performedBy });
+
+  let results;
+  try {
+    results = await run();
+  } catch (err) {
+    // The teardown threw partway. Record how far it got BEFORE rethrowing, so the trail
+    // never reads started-never-finished. A failure to write this row must not mask the
+    // original error, which is the one the operator needs.
+    try {
+      await writeAuditRow(supabase, {
+        operation, phase: 'failed', targetIds, performedBy,
+        metadata: { outcome: 'threw', error: err?.message ?? String(err) },
+      });
+    } catch (auditErr) {
+      console.error(`[destructive-audit] ${operation}.failed audit write ALSO failed: ${auditErr.message}`);
+    }
+    throw err;
+  }
+
+  const list = Array.isArray(results) ? results : [results];
+  const succeeded = list.filter(r => r && r.success).length;
+
+  await writeAuditRow(supabase, {
+    operation, phase: 'completed', targetIds, performedBy,
+    metadata: { outcome: 'completed', succeeded, failed: list.length - succeeded },
+  });
+
+  return results;
+}
+
+/** Best-effort actor identity for the audit row. requireAuth populates req.user when a Bearer token is used. */
+export function resolvePerformedBy(req) {
+  return req?.user?.id || req?.user?.email || (req?.headers?.['x-internal-api-key'] ? 'internal-api-key' : 'unknown');
+}

--- a/lib/destructive-audit.js
+++ b/lib/destructive-audit.js
@@ -49,7 +49,7 @@ const ENTITY_TYPE = 'venture';
  * precisely because its failure path logged and continued.
  */
 export async function writeAuditRow(supabase, { operation, phase, targetIds, performedBy, metadata = {} }) {
-  const { error } = await supabase.from('operations_audit_log').insert({
+  const response = await supabase.from('operations_audit_log').insert({
     entity_type: ENTITY_TYPE,
     // A single-target operation names its venture; a bulk one cannot, so the full set
     // lives in metadata.target_ids rather than being lost.
@@ -62,7 +62,14 @@ export async function writeAuditRow(supabase, { operation, phase, targetIds, per
     metadata: { operation, phase, target_count: targetIds.length, target_ids: targetIds, ...metadata },
   });
 
-  if (error) throw new Error(`[destructive-audit] ${operation}.${phase} audit write failed: ${error.message}`);
+  // Fail CLOSED on a MALFORMED response, not just on an explicit error. A client returning
+  // `{}` — no `error` key at all — previously fell through as success, so a teardown could
+  // run unaudited off a shape we never actually verified. Absence of an error field is not
+  // evidence of a write.
+  if (!response || typeof response !== 'object' || !('error' in response)) {
+    throw new Error(`[destructive-audit] ${operation}.${phase} audit write returned an unrecognised response; refusing to treat it as success.`);
+  }
+  if (response.error) throw new Error(`[destructive-audit] ${operation}.${phase} audit write failed: ${response.error.message}`);
 }
 
 /**
@@ -97,10 +104,21 @@ export async function withDestructiveAudit(supabase, { operation, targetIds, per
   const list = Array.isArray(results) ? results : [results];
   const succeeded = list.filter(r => r && r.success).length;
 
-  await writeAuditRow(supabase, {
-    operation, phase: 'completed', targetIds, performedBy,
-    metadata: { outcome: 'completed', succeeded, failed: list.length - succeeded },
-  });
+  // The completed-row write is DELIBERATELY not allowed to throw past this point. By the
+  // time we get here every deletion has already committed and cannot be undone. An
+  // unprotected await here would throw AFTER the work succeeded, handing the caller a 500
+  // for an operation that fully completed and leaving the trail reading
+  // started-never-finished — the precise state property #1 above exists to prevent, arrived
+  // at from the opposite direction. Fail-closed belongs BEFORE irreversible work, not after
+  // it: once the ventures are gone, refusing buys nothing and misreports the outcome.
+  try {
+    await writeAuditRow(supabase, {
+      operation, phase: 'completed', targetIds, performedBy,
+      metadata: { outcome: 'completed', succeeded, failed: list.length - succeeded },
+    });
+  } catch (auditErr) {
+    console.error(`[destructive-audit] ${operation}.completed audit write failed AFTER the operation committed: ${auditErr.message}`);
+  }
 
   return results;
 }

--- a/lib/destructive-audit.js
+++ b/lib/destructive-audit.js
@@ -23,6 +23,18 @@
  *     "started, never finished" with no record of how far it got. That is arguably worse
  *     than no audit at all, because it looks like a hang rather than a failure.
  *
+ *     BE PRECISE ABOUT WHICH PATH REAL FAILURES TAKE, because it is not the obvious one.
+ *     lib/deleteVentureFully.js catches EVERY phase internally (:104-113, :116-120, :128-133,
+ *     :136-140) and phase 5 RETURNS {success:false} rather than throwing (:148, :153). So a
+ *     realistic partial failure does NOT reach the catch below — it produces a 'completed'
+ *     row carrying metadata.failed = N. That is the row an operator will actually be reading
+ *     after a bad teardown, and it is the one to look at first.
+ *     The 'failed' phase below is therefore DEFENSIVE, covering a throw that today's callee
+ *     cannot produce (an infrastructure error, or a future caller that does throw). It is
+ *     retained deliberately — an audit wrapper that assumes its callee never throws is one
+ *     refactor away from the started-never-finished hole — but it must not be mistaken for
+ *     the normal failure path. Both shapes are pinned by tests.
+ *
  *  2. A FAILED PRE-WRITE MUST REFUSE THE OPERATION (fail-closed, FR-4). An irreversible
  *     teardown that cannot be recorded must not proceed. Refusing costs an operator one
  *     retry; proceeding unaudited costs the ability to ever know what happened.

--- a/lib/destructive-confirmation.js
+++ b/lib/destructive-confirmation.js
@@ -42,13 +42,25 @@
  *   - BOUND TO THE TARGET SET. Re-using a token against a different id set changes the
  *     HMAC input, so it will not verify.
  *   - EXPIRES after TOKEN_TTL_MS (5 min).
- *   - REPLAY: not separately tracked, and it does not need to be for THIS operation
- *     class. Execution requires expected_count to equal the live count at execution
- *     time, and a successful teardown changes that count — so a replayed token against
- *     an already-executed target set is refused by the staleness check. State that
- *     limit explicitly rather than implying single-use we do not enforce: a token
- *     replayed inside the TTL against a target set that has NOT changed WOULD pass,
- *     which is the operator re-submitting an identical, still-accurate confirmation.
+ *   - REPLAY: not separately tracked. AN EARLIER VERSION OF THIS COMMENT JUSTIFIED THAT BY
+ *     CLAIMING expected_count MUST EQUAL THE LIVE COUNT, SO A REPLAY AFTER EXECUTION WOULD
+ *     BE REFUSED. THAT IS TRUE FOR ONLY ONE OF THE THREE ROUTES, and asserting it generally
+ *     was the same defect this SD exists to eliminate — a comment describing a check that
+ *     does not exist for the path in question.
+ *       * /master-reset: targetIds come from a LIVE query (ventures.js), so the staleness
+ *         check is real. A replay after execution is genuinely refused.
+ *       * /:id/full-delete and /bulk-full-delete: targetIds come from the REQUEST
+ *         (req.params.id / req.body.ids), so `expected_count !== targetIds.length` compares
+ *         the caller's number against the caller's own array length. It is true regardless
+ *         of database state. THE STALENESS CHECK IS VACUOUS ON THESE TWO ROUTES, and a
+ *         replay inside the TTL is unconditionally accepted — including on bulk-full-delete,
+ *         which is equivalent in effect to a master reset at n = every venture.
+ *     Exploit value is low (the replayer must already be authenticated, and a re-run against
+ *     already-deleted ventures is close to a no-op), but the claim had to be corrected.
+ *     THE FIX, tracked and not yet applied: resolve submitted ids against the live table in
+ *     bulk-full-delete and use the RETURNED ROWS as targetIds. That makes the target set
+ *     server-derived, makes the staleness check real, refuses replay-after-execution, and
+ *     stops non-UUID ids reaching both the HMAC and the audit row.
  */
 
 import crypto from 'node:crypto';
@@ -64,6 +76,7 @@ export const CODES = {
   TOKEN_INVALID: 'TOKEN_INVALID',
   TOKEN_EXPIRED: 'TOKEN_EXPIRED',
   COUNT_MISMATCH: 'COUNT_MISMATCH',
+  TARGET_IDS_INVALID: 'TARGET_IDS_INVALID',
 };
 
 export function resolveConfirmSecret(env = process.env) {
@@ -77,8 +90,18 @@ function canonical(operation, targetIds) {
   // collision is reachable. No privilege escalation follows from it, but it contradicts the
   // bound-to-target-set property this function exists to provide, and a claimed invariant that
   // does not hold is worse than none.
-  const ids = [...targetIds].map(String).sort().map(id => `${id.length}:${id}`).join('');
-  return `${operation}:${targetIds.length}:${ids}`;
+  // REJECT non-strings rather than String()-coercing them. Length-prefixing fixed the
+  // join(',') collision at THIS level, but coercion reintroduced it one level up via
+  // Array.prototype.toString: a token minted for [['a','b']] canonicalised identically to
+  // one for ['a,b'], and [{a:1}] identically to [{b:2}] (both '[object Object]'). bulk ids
+  // are not UUID-validated, so those shapes are reachable. None are valid venture ids and
+  // no escalation follows — but the bound-to-target-set property is the whole point of this
+  // function, and a claimed invariant that does not hold is worse than none.
+  const ids = [...targetIds];
+  if (!ids.every(id => typeof id === 'string')) {
+    throw new TypeError('[destructive-confirmation] target ids must be strings; refusing to canonicalise a coerced value.');
+  }
+  return `${operation}:${ids.length}:${ids.sort().map(id => `${id.length}:${id}`).join('')}`;
 }
 
 export function issueToken({ operation, targetIds, issuedAtMs, secret }) {
@@ -117,7 +140,21 @@ function tokenMatches({ token, operation, targetIds, secret, nowMs }) {
  *
  * @returns {{ok: true} | {ok: false, status: number, body: object}}
  */
-export function evaluateConfirmation({ body = {}, operation, targetIds, env = process.env, nowMs = Date.now() }) {
+export function evaluateConfirmation({ body: rawBody, operation, targetIds, env = process.env, nowMs = Date.now() }) {
+  // `body = {}` as a DEFAULT PARAMETER does not cover an explicit null — only undefined —
+  // so a JSON `null` body threw here rather than refusing. Normalise instead.
+  const body = (rawBody && typeof rawBody === 'object') ? rawBody : {};
+  // Refuse non-string ids HERE rather than letting canonical() throw, so the caller gets a
+  // clean 400 instead of a 500. bulk-full-delete does not UUID-validate req.body.ids, so
+  // objects and nested arrays are reachable inputs.
+  if (!Array.isArray(targetIds) || !targetIds.every(id => typeof id === 'string')) {
+    return {
+      ok: false,
+      status: 400,
+      body: { success: false, code: CODES.TARGET_IDS_INVALID, error: 'Target ids must be an array of strings.' },
+    };
+  }
+
   const secret = resolveConfirmSecret(env);
   const expectedCount = targetIds.length;
 

--- a/lib/destructive-confirmation.js
+++ b/lib/destructive-confirmation.js
@@ -1,0 +1,153 @@
+/**
+ * Destructive-action confirmation gate.
+ * SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001 FR-1.
+ *
+ * WHY THIS EXISTS: three routes in server/routes/ventures.js loop the same irreversible
+ * deleteVentureFully helper — /master-reset, /:id/full-delete and /bulk-full-delete.
+ * deleteVentureFully drops GitHub repos and rewrites applications/registry.json, and
+ * there is no undo, so a single authenticated POST could destroy the whole portfolio.
+ * bulk-full-delete accepts an arbitrary ids[] array, which makes it equivalent to
+ * master-reset at n = every venture.
+ *
+ * WHAT THIS IS NOT: this is NOT a CSRF control and must never be described as one.
+ * requireAuth (server/middleware/auth.js) accepts only non-ambient credentials —
+ * x-internal-api-key and Authorization: Bearer — there is zero cookie usage in the
+ * server, and an HTML form cannot set custom headers, so cross-origin forgery already
+ * fails with a 401. The exposure being closed here is IRREVERSIBILITY: an authenticated
+ * operator, or anyone holding a leaked token, gets no second step today.
+ *
+ * TOKEN LIFECYCLE (PRD TR-3 requires this be specified, not left implicit):
+ *   - STATELESS. The token is an HMAC over (operation, sorted target ids, issuedAt).
+ *     A server-side Map was rejected: this server can run multi-process, and a token
+ *     store that lives in one process would refuse a valid confirmation handled by
+ *     another — failing closed, but unpredictably and invisibly.
+ *   - BOUND TO THE TARGET SET. Re-using a token against a different id set changes the
+ *     HMAC input, so it will not verify.
+ *   - EXPIRES after TOKEN_TTL_MS (5 min).
+ *   - REPLAY: not separately tracked, and it does not need to be for THIS operation
+ *     class. Execution requires expected_count to equal the live count at execution
+ *     time, and a successful teardown changes that count — so a replayed token against
+ *     an already-executed target set is refused by the staleness check. State that
+ *     limit explicitly rather than implying single-use we do not enforce: a token
+ *     replayed inside the TTL against a target set that has NOT changed WOULD pass,
+ *     which is the operator re-submitting an identical, still-accurate confirmation.
+ */
+
+import crypto from 'node:crypto';
+
+export const CONFIRM_ACK_PHRASE = 'DELETE PERMANENTLY';
+export const TOKEN_TTL_MS = 5 * 60 * 1000;
+
+/** Refusal codes are stable strings so callers can branch on them, not on prose. */
+export const CODES = {
+  CONFIRMATION_REQUIRED: 'CONFIRMATION_REQUIRED',
+  CONFIRMATION_UNAVAILABLE: 'CONFIRMATION_UNAVAILABLE',
+  ACK_INVALID: 'ACK_INVALID',
+  TOKEN_INVALID: 'TOKEN_INVALID',
+  TOKEN_EXPIRED: 'TOKEN_EXPIRED',
+  COUNT_MISMATCH: 'COUNT_MISMATCH',
+};
+
+export function resolveConfirmSecret(env = process.env) {
+  return env.DESTRUCTIVE_CONFIRM_SECRET || env.INTERNAL_API_KEY || null;
+}
+
+function canonical(operation, targetIds) {
+  return `${operation}:${[...targetIds].map(String).sort().join(',')}`;
+}
+
+export function issueToken({ operation, targetIds, issuedAtMs, secret }) {
+  const sig = crypto
+    .createHmac('sha256', secret)
+    .update(`${canonical(operation, targetIds)}:${issuedAtMs}`)
+    .digest('hex');
+  return `${issuedAtMs}.${sig}`;
+}
+
+function tokenMatches({ token, operation, targetIds, secret, nowMs }) {
+  const parts = String(token || '').split('.');
+  if (parts.length !== 2) return CODES.TOKEN_INVALID;
+  const issuedAtMs = Number(parts[0]);
+  if (!Number.isFinite(issuedAtMs)) return CODES.TOKEN_INVALID;
+  if (nowMs - issuedAtMs > TOKEN_TTL_MS || issuedAtMs > nowMs) return CODES.TOKEN_EXPIRED;
+
+  const expected = issueToken({ operation, targetIds, issuedAtMs, secret });
+  const a = Buffer.from(expected);
+  const b = Buffer.from(String(token));
+  // timingSafeEqual throws on length mismatch, so compare length first.
+  if (a.length !== b.length || !crypto.timingSafeEqual(a, b)) return CODES.TOKEN_INVALID;
+  return null;
+}
+
+/**
+ * Decide whether an irreversible operation may proceed.
+ *
+ * FAIL-CLOSED (PRD FR-4): every path that is not an affirmative, verified confirmation
+ * returns ok:false. Refusing to delete can never cause data loss, so refusal is the
+ * safe direction for an irreversible operation; that is why a missing secret refuses
+ * rather than waving the request through. The blast radius is bounded to THIS
+ * operation — nothing here can affect unrelated venture routes.
+ *
+ * There is deliberately NO environment variable that bypasses this gate (PRD FR-4).
+ *
+ * @returns {{ok: true} | {ok: false, status: number, body: object}}
+ */
+export function evaluateConfirmation({ body = {}, operation, targetIds, env = process.env, nowMs = Date.now() }) {
+  const secret = resolveConfirmSecret(env);
+  const expectedCount = targetIds.length;
+
+  if (!secret) {
+    // Fail CLOSED. No secret means we cannot verify intent, so we refuse rather than
+    // execute an irreversible teardown on an unverifiable request.
+    return {
+      ok: false,
+      status: 503,
+      body: {
+        success: false,
+        code: CODES.CONFIRMATION_UNAVAILABLE,
+        error: 'Destructive-action confirmation is not configured on this server; refusing.',
+      },
+    };
+  }
+
+  const preview = () => ({
+    ok: false,
+    status: 428,
+    body: {
+      success: false,
+      code: CODES.CONFIRMATION_REQUIRED,
+      operation,
+      expected_count: expectedCount,
+      target_ids: targetIds,
+      confirmation_token: issueToken({ operation, targetIds, issuedAtMs: nowMs, secret }),
+      acknowledgement_required: CONFIRM_ACK_PHRASE,
+      expires_in_ms: TOKEN_TTL_MS,
+      message:
+        `This operation irreversibly deletes ${expectedCount} venture(s) and cannot be undone. ` +
+        `Re-send with confirmation_token, acknowledgement "${CONFIRM_ACK_PHRASE}", and expected_count.`,
+    },
+  });
+
+  if (body.confirmation_token === undefined && body.acknowledgement === undefined) return preview();
+
+  if (body.acknowledgement !== CONFIRM_ACK_PHRASE) {
+    return { ok: false, status: 400, body: { success: false, code: CODES.ACK_INVALID, error: `acknowledgement must be exactly "${CONFIRM_ACK_PHRASE}".` } };
+  }
+
+  const tokenFailure = tokenMatches({ token: body.confirmation_token, operation, targetIds, secret, nowMs });
+  if (tokenFailure) {
+    return { ok: false, status: 400, body: { success: false, code: tokenFailure, error: 'confirmation_token is not valid for this target set.' } };
+  }
+
+  // Staleness: the operator confirmed against a snapshot. If the live target set has
+  // changed since, their intent no longer describes what would happen — refuse.
+  if (Number(body.expected_count) !== expectedCount) {
+    return {
+      ok: false,
+      status: 409,
+      body: { success: false, code: CODES.COUNT_MISMATCH, error: `expected_count ${body.expected_count} no longer matches the live count ${expectedCount}.`, expected_count: expectedCount },
+    };
+  }
+
+  return { ok: true };
+}

--- a/lib/destructive-confirmation.js
+++ b/lib/destructive-confirmation.js
@@ -9,12 +9,30 @@
  * bulk-full-delete accepts an arbitrary ids[] array, which makes it equivalent to
  * master-reset at n = every venture.
  *
- * WHAT THIS IS NOT: this is NOT a CSRF control and must never be described as one.
- * requireAuth (server/middleware/auth.js) accepts only non-ambient credentials —
- * x-internal-api-key and Authorization: Bearer — there is zero cookie usage in the
- * server, and an HTML form cannot set custom headers, so cross-origin forgery already
- * fails with a 401. The exposure being closed here is IRREVERSIBILITY: an authenticated
- * operator, or anyone holding a leaked token, gets no second step today.
+ * WHAT THIS IS NOT — and this section is deliberately blunt, because an overstated safety
+ * comment is the exact defect this SD exists to eliminate. The original carve-out survived
+ * undetected because a comment asserted a check that did not exist.
+ *
+ * NOT A CSRF CONTROL. requireAuth (server/middleware/auth.js) accepts only non-ambient
+ * credentials — x-internal-api-key and Authorization: Bearer — there is zero cookie usage
+ * in the server, and an HTML form cannot set custom headers, so cross-origin forgery
+ * already fails with a 401.
+ *
+ * NOT A CONTROL AGAINST A LEAKED CREDENTIAL. An earlier draft of this comment claimed it
+ * was. It is not, for two independent reasons:
+ *   - The 428 preview HANDS the caller a valid token. Anyone who can make the first
+ *     request can make the second. Two scripted calls defeat it.
+ *   - resolveConfirmSecret falls back to INTERNAL_API_KEY — the very credential requireAuth
+ *     accepts — so a holder of that key can also FORGE a token offline. The key that
+ *     authenticates is the key that signs.
+ * Set DESTRUCTIVE_CONFIRM_SECRET to a distinct value to break that second equivalence. It
+ * still does not make this a credential control, because of the first reason.
+ *
+ * WHAT IT ACTUALLY BUYS, which is worth having on its own: an operator cannot destroy the
+ * portfolio by ACCIDENT — no misfired curl, no stale script, no fat-fingered client, no
+ * replayed request against a target set that has since changed. It converts a
+ * one-request-and-it-is-gone endpoint into a deliberate two-step act with a recorded
+ * intent and a staleness check. That is IRREVERSIBILITY mitigation, not authorization.
  *
  * TOKEN LIFECYCLE (PRD TR-3 requires this be specified, not left implicit):
  *   - STATELESS. The token is an HMAC over (operation, sorted target ids, issuedAt).
@@ -53,7 +71,14 @@ export function resolveConfirmSecret(env = process.env) {
 }
 
 function canonical(operation, targetIds) {
-  return `${operation}:${[...targetIds].map(String).sort().join(',')}`;
+  // LENGTH-PREFIXED, not comma-joined. A plain `join(',')` is not injective: a token minted
+  // for the single id 'aaa,bbb' would verify against the two ids ['aaa','bbb'], because both
+  // canonicalise to the same string. bulk-full-delete does not UUID-validate its ids, so that
+  // collision is reachable. No privilege escalation follows from it, but it contradicts the
+  // bound-to-target-set property this function exists to provide, and a claimed invariant that
+  // does not hold is worse than none.
+  const ids = [...targetIds].map(String).sort().map(id => `${id.length}:${id}`).join('');
+  return `${operation}:${targetIds.length}:${ids}`;
 }
 
 export function issueToken({ operation, targetIds, issuedAtMs, secret }) {

--- a/lib/venture-resources.js
+++ b/lib/venture-resources.js
@@ -50,28 +50,53 @@ export async function registerVentureResource(ventureId, resourceType, resourceI
 /**
  * Mark all resources for a venture as cleaned (for master reset).
  *
+ * SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001 FR-2. This function used to take ONLY a
+ * ventureId, build its OWN service client, and UPDATE unconditionally — so it ignored
+ * both the dryRun flag and any injected client that the rest of deleteVentureFully
+ * honours (phases 2 and 4 already accept `{ dryRun }`). Two consequences, both real:
+ *   1. A "preview" performed a live write, so the preview was never side-effect-free.
+ *   2. A unit test passing dryRun plus a stub client STILL wrote to the live table,
+ *      because this phase bypassed the injection seam and read process.env directly.
+ * It also returned 0 on failure, which is indistinguishable from "nothing to clean" —
+ * a failed write was invisible. It now THROWS instead. The sole production caller
+ * (deleteVentureFully phase 3) wraps this in try/catch and is explicitly non-blocking,
+ * so throwing surfaces the failure as phases.resources_error without changing control
+ * flow. Modelled on lib/cleanup/credentials.js, which short-circuits on dryRun BEFORE
+ * the write rather than after it.
+ *
  * @param {string} ventureId - Venture UUID
- * @returns {Promise<number>} Count of updated rows
+ * @param {object} [options={}]
+ * @param {boolean} [options.dryRun=false] - Report what WOULD be cleaned; issue no write.
+ * @param {object}  [options.supabase] - Injected client. Defaults to a service client.
+ * @returns {Promise<number>} Count of rows updated, or (dryRun) rows that would be.
+ * @throws {Error} If the query fails. Callers must decide whether that is fatal.
  */
-export async function markResourcesCleaned(ventureId) {
-  try {
-    const supabase = createSupabaseServiceClient();
+export async function markResourcesCleaned(ventureId, options = {}) {
+  const { dryRun = false, supabase: injectedClient = null } = options;
+  const supabase = injectedClient || createSupabaseServiceClient();
+
+  // dryRun short-circuits BEFORE the update. This is a read, so a preview can report
+  // the real count without mutating anything.
+  if (dryRun) {
     const { data, error } = await supabase
       .from('venture_resources')
-      .update({ status: 'cleaned' })
+      .select('id')
       .eq('venture_id', ventureId)
-      .eq('status', 'active')
-      .select('id');
+      .eq('status', 'active');
 
-    if (error) {
-      console.error(`[venture-resources] cleanup failed: ${error.message}`);
-      return 0;
-    }
+    if (error) throw new Error(`[venture-resources] dry-run count failed: ${error.message}`);
     return data?.length ?? 0;
-  } catch (err) {
-    console.error(`[venture-resources] cleanup error: ${err.message}`);
-    return 0;
   }
+
+  const { data, error } = await supabase
+    .from('venture_resources')
+    .update({ status: 'cleaned' })
+    .eq('venture_id', ventureId)
+    .eq('status', 'active')
+    .select('id');
+
+  if (error) throw new Error(`[venture-resources] cleanup failed: ${error.message}`);
+  return data?.length ?? 0;
 }
 
 /**

--- a/server/routes/ventures.js
+++ b/server/routes/ventures.js
@@ -11,6 +11,7 @@ import { asyncHandler } from '../../lib/middleware/eva-error-handler.js';
 import { isValidUuid, validateUuidParam, isValidStringLength } from '../middleware/validate.js';
 import { deleteVentureFully } from '../../lib/deleteVentureFully.js';
 import { evaluateConfirmation } from '../../lib/destructive-confirmation.js';
+import { withDestructiveAudit, resolvePerformedBy } from '../../lib/destructive-audit.js';
 
 const router = Router();
 
@@ -328,11 +329,21 @@ router.post('/master-reset', asyncHandler(async (req, res) => {
   const gate = evaluateConfirmation({ body: req.body, operation: 'master-reset', targetIds: ventureIds });
   if (!gate.ok) return res.status(gate.status).json(gate.body);
 
-  // Loop the shared full-teardown helper per venture.
-  const results = [];
-  for (const id of ventureIds) {
-    results.push(await deleteVentureFully(id, { supabase }));
-  }
+  // SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001 FR-3 — bracket the irreversible loop with
+  // audit rows. A failed PRE-write refuses the operation outright (fail-closed: an
+  // irreversible teardown that cannot be recorded must not run), and a throw partway
+  // still writes a POST row so the trail never reads started-never-finished.
+  const results = await withDestructiveAudit(
+    supabase,
+    { operation: 'master-reset', targetIds: ventureIds, performedBy: resolvePerformedBy(req) },
+    async () => {
+      const out = [];
+      for (const id of ventureIds) {
+        out.push(await deleteVentureFully(id, { supabase }));
+      }
+      return out;
+    },
+  );
 
   // Preserve the one master_reset_portfolio step per-venture delete does not
   // cover: sweep orphan stage_zero_requests with no venture_id. Non-fatal.
@@ -370,7 +381,11 @@ router.post('/:id/full-delete', validateUuidParam('id'), asyncHandler(async (req
   if (!gate.ok) return res.status(gate.status).json(gate.body);
 
   const supabase = resolveServiceClient(req);
-  const result = await deleteVentureFully(req.params.id, { supabase });
+  const result = await withDestructiveAudit(
+    supabase,
+    { operation: 'full-delete', targetIds: [req.params.id], performedBy: resolvePerformedBy(req) },
+    () => deleteVentureFully(req.params.id, { supabase }),
+  );
   return res.status(result.success ? 200 : 500).json(result);
 }));
 
@@ -392,10 +407,17 @@ router.post('/bulk-full-delete', asyncHandler(async (req, res) => {
   if (!gate.ok) return res.status(gate.status).json(gate.body);
 
   const supabase = resolveServiceClient(req);
-  const results = [];
-  for (const id of ids) {
-    results.push(await deleteVentureFully(id, { supabase }));
-  }
+  const results = await withDestructiveAudit(
+    supabase,
+    { operation: 'bulk-full-delete', targetIds: ids, performedBy: resolvePerformedBy(req) },
+    async () => {
+      const out = [];
+      for (const id of ids) {
+        out.push(await deleteVentureFully(id, { supabase }));
+      }
+      return out;
+    },
+  );
   const succeeded = results.filter(r => r.success).length;
   const failed = results.length - succeeded;
   return res.json({ success: failed === 0, succeeded, failed, results });

--- a/server/routes/ventures.js
+++ b/server/routes/ventures.js
@@ -333,6 +333,11 @@ router.post('/master-reset', asyncHandler(async (req, res) => {
   // audit rows. A failed PRE-write refuses the operation outright (fail-closed: an
   // irreversible teardown that cannot be recorded must not run), and a throw partway
   // still writes a POST row so the trail never reads started-never-finished.
+  // The orphan sweep is DELIBERATELY inside the audited span. It deletes rows, so running it
+  // after withDestructiveAudit returned would mean destructive work happening after the
+  // 'completed' audit row was already written — the trail would claim the operation had
+  // finished while it was still deleting.
+  let orphansCleaned = 0;
   const results = await withDestructiveAudit(
     supabase,
     { operation: 'master-reset', targetIds: ventureIds, performedBy: resolvePerformedBy(req) },
@@ -341,23 +346,23 @@ router.post('/master-reset', asyncHandler(async (req, res) => {
       for (const id of ventureIds) {
         out.push(await deleteVentureFully(id, { supabase }));
       }
+
+      // Preserve the one master_reset_portfolio step per-venture delete does not
+      // cover: sweep orphan stage_zero_requests with no venture_id. Non-fatal.
+      try {
+        const { data: orphans } = await supabase
+          .from('stage_zero_requests')
+          .delete()
+          .is('venture_id', null)
+          .select('id');
+        orphansCleaned = orphans?.length || 0;
+      } catch (orphanErr) {
+        console.error('[master-reset] orphan stage_zero_requests cleanup non-fatal:', orphanErr.message);
+      }
+
       return out;
     },
   );
-
-  // Preserve the one master_reset_portfolio step per-venture delete does not
-  // cover: sweep orphan stage_zero_requests with no venture_id. Non-fatal.
-  let orphansCleaned = 0;
-  try {
-    const { data: orphans } = await supabase
-      .from('stage_zero_requests')
-      .delete()
-      .is('venture_id', null)
-      .select('id');
-    orphansCleaned = orphans?.length || 0;
-  } catch (orphanErr) {
-    console.error('[master-reset] orphan stage_zero_requests cleanup non-fatal:', orphanErr.message);
-  }
 
   const succeeded = results.filter(r => r.success).length;
 

--- a/server/routes/ventures.js
+++ b/server/routes/ventures.js
@@ -10,6 +10,7 @@ import { dbLoader } from '../config.js';
 import { asyncHandler } from '../../lib/middleware/eva-error-handler.js';
 import { isValidUuid, validateUuidParam, isValidStringLength } from '../middleware/validate.js';
 import { deleteVentureFully } from '../../lib/deleteVentureFully.js';
+import { evaluateConfirmation } from '../../lib/destructive-confirmation.js';
 
 const router = Router();
 
@@ -318,6 +319,15 @@ router.post('/master-reset', asyncHandler(async (req, res) => {
   }
   const ventureIds = (ventures || []).map(v => v.id).filter(Boolean);
 
+  // SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001 FR-1 — confirmation gate.
+  // Placed AFTER the venture list is known (the token binds to the exact target set)
+  // and BEFORE the teardown loop. It lives in the HANDLER BODY, not in mount
+  // middleware, because server/index.js:191 and :192 mount this SAME router object at
+  // both /api/ventures and /api/competitor-analysis — a mount-level guard would cover
+  // one path and silently leave the other open.
+  const gate = evaluateConfirmation({ body: req.body, operation: 'master-reset', targetIds: ventureIds });
+  if (!gate.ok) return res.status(gate.status).json(gate.body);
+
   // Loop the shared full-teardown helper per venture.
   const results = [];
   for (const id of ventureIds) {
@@ -355,6 +365,10 @@ router.post('/master-reset', asyncHandler(async (req, res) => {
 // ── Single-venture full teardown ───────────────────────────────────
 // SD-SINGLEVENTURE-AND-BULK-DELETE-ORCH-001-B
 router.post('/:id/full-delete', validateUuidParam('id'), asyncHandler(async (req, res) => {
+  // FR-1: same irreversible helper, so the same gate. n=1 is still unrecoverable.
+  const gate = evaluateConfirmation({ body: req.body, operation: 'full-delete', targetIds: [req.params.id] });
+  if (!gate.ok) return res.status(gate.status).json(gate.body);
+
   const supabase = resolveServiceClient(req);
   const result = await deleteVentureFully(req.params.id, { supabase });
   return res.status(result.success ? 200 : 500).json(result);
@@ -367,6 +381,16 @@ router.post('/bulk-full-delete', asyncHandler(async (req, res) => {
   if (!ids || ids.length === 0) {
     return res.status(400).json({ success: false, error: 'Request body must include a non-empty ids[] array' });
   }
+
+  // FR-1: this route is the reason the gate could not be scoped to master-reset alone.
+  // It accepts an ARBITRARY ids[] array and loops the identical teardown helper, so one
+  // authenticated POST carrying every venture id is equivalent in effect to a full
+  // master reset. Gating only /master-reset would have left the SD acceptance criterion
+  // ("no single authenticated request can trigger a full portfolio teardown") provably
+  // unmet while every test passed.
+  const gate = evaluateConfirmation({ body: req.body, operation: 'bulk-full-delete', targetIds: ids });
+  if (!gate.ok) return res.status(gate.status).json(gate.body);
+
   const supabase = resolveServiceClient(req);
   const results = [];
   for (const id of ids) {

--- a/tests/integration/master-reset-parity.test.js
+++ b/tests/integration/master-reset-parity.test.js
@@ -32,6 +32,31 @@ vi.mock('../../server/middleware/validate.js', () => ({
 vi.mock('../../server/config.js', () => ({ dbLoader: { supabase: {} } }));
 
 // The shared teardown helper — mocked so no real teardown/DB/shell happens.
+import { issueToken, CONFIRM_ACK_PHRASE } from '../../lib/destructive-confirmation.js';
+
+/**
+ * SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001 FR-1 added a confirmation gate to all three
+ * destructive handlers, so requests that previously executed now refuse with 428 unless
+ * confirmed. The parity/aggregation assertions below are NOT weakened by that change —
+ * they still guard exactly what they were written to guard. Each request simply supplies
+ * a valid confirmation first, so the handler reaches the teardown logic under test.
+ *
+ * The gate itself is covered separately (tests/unit/destructive-confirmation.test.js for
+ * the logic, tests/unit/ventures-destructive-gate.test.js for the wiring on both mounts);
+ * this file keeps its original job of guarding the master-reset refactor.
+ */
+const CONFIRM_SECRET = 'parity-test-secret';
+
+/** Build a request body carrying a valid confirmation for the given target set. */
+function confirmed(operation, targetIds, extra = {}) {
+  return {
+    ...extra,
+    confirmation_token: issueToken({ operation, targetIds, issuedAtMs: Date.now(), secret: CONFIRM_SECRET }),
+    acknowledgement: CONFIRM_ACK_PHRASE,
+    expected_count: targetIds.length,
+  };
+}
+
 const deleteVentureFullyMock = vi.fn();
 vi.mock('../../lib/deleteVentureFully.js', () => ({
   deleteVentureFully: (...a) => deleteVentureFullyMock(...a),
@@ -106,6 +131,7 @@ async function runHandlerChain(handlers, req, res) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  process.env.DESTRUCTIVE_CONFIRM_SECRET = CONFIRM_SECRET;
   deleteVentureFullyMock.mockImplementation((id) => Promise.resolve(okResult(id)));
 });
 
@@ -117,7 +143,7 @@ describe('master-reset refactor (FR-5 regression guard)', () => {
       ventures: [{ id: 'v1' }, { id: 'v2' }, { id: 'v3' }],
       orphans: [{ id: 'o1' }, { id: 'o2' }],
     });
-    const req = createMockReq({}, {}, supabase);
+    const req = createMockReq({}, confirmed('master-reset', ['v1', 'v2', 'v3']), supabase);
     const res = createMockRes();
 
     await runHandlerChain(handlers, req, res);
@@ -146,12 +172,28 @@ describe('master-reset refactor (FR-5 regression guard)', () => {
 
   it('reports an empty portfolio as count 0 without error', async () => {
     const supabase = buildSupabaseMock({ ventures: [], orphans: [] });
-    const req = createMockReq({}, {}, supabase);
+    const req = createMockReq({}, confirmed('master-reset', []), supabase);
     const res = createMockRes();
     await runHandlerChain(handlers, req, res);
     expect(deleteVentureFullyMock).not.toHaveBeenCalled();
     expect(res.jsonData.count).toBe(0);
     expect(res.jsonData.success).toBe(true);
+  });
+
+  // SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001 FR-1. Every other test in this file now
+  // supplies a confirmation, which would let the gate be deleted entirely without any of
+  // them failing. This one pins the new contract in the same file that guards these
+  // routes: an UNCONFIRMED request must refuse and must not reach the teardown.
+  it('refuses an UNCONFIRMED master-reset and never reaches the teardown', async () => {
+    const supabase = buildSupabaseMock({ ventures: [{ id: 'v1' }, { id: 'v2' }], orphans: [] });
+    const req = createMockReq({}, {}, supabase);
+    const res = createMockRes();
+
+    await runHandlerChain(handlers, req, res);
+
+    expect(res.statusCode).toBe(428);
+    expect(res.jsonData.code).toBe('CONFIRMATION_REQUIRED');
+    expect(deleteVentureFullyMock).not.toHaveBeenCalled();
   });
 });
 
@@ -159,7 +201,7 @@ describe('POST /:id/full-delete', () => {
   const handlers = findRoute('post', '/:id/full-delete');
 
   it('delegates to deleteVentureFully and returns 200 on success', async () => {
-    const req = createMockReq({ id: 'v1' });
+    const req = createMockReq({ id: 'v1' }, confirmed('full-delete', ['v1']));
     const res = createMockRes();
     await runHandlerChain(handlers, req, res);
     expect(deleteVentureFullyMock).toHaveBeenCalledWith('v1', { supabase: req.app.locals.supabase });
@@ -169,7 +211,7 @@ describe('POST /:id/full-delete', () => {
 
   it('returns 500 when the helper reports failure', async () => {
     deleteVentureFullyMock.mockResolvedValueOnce(failResult('v9'));
-    const req = createMockReq({ id: 'v9' });
+    const req = createMockReq({ id: 'v9' }, confirmed('full-delete', ['v9']));
     const res = createMockRes();
     await runHandlerChain(handlers, req, res);
     expect(res.statusCode).toBe(500);
@@ -183,7 +225,7 @@ describe('POST /bulk-full-delete', () => {
   it('aggregates per-venture results and tolerates partial failure', async () => {
     deleteVentureFullyMock.mockImplementation((id) =>
       Promise.resolve(id === 'bad' ? failResult(id) : okResult(id)));
-    const req = createMockReq({}, { ids: ['v1', 'bad', 'v2'] });
+    const req = createMockReq({}, confirmed('bulk-full-delete', ['v1', 'bad', 'v2'], { ids: ['v1', 'bad', 'v2'] }));
     const res = createMockRes();
     await runHandlerChain(handlers, req, res);
     expect(deleteVentureFullyMock).toHaveBeenCalledTimes(3);

--- a/tests/integration/master-reset-parity.test.js
+++ b/tests/integration/master-reset-parity.test.js
@@ -92,13 +92,20 @@ function buildSupabaseMock({ ventures = [], orphans = [] } = {}) {
   const orphanIs = vi.fn(() => ({ select: orphanSelect }));
   const orphanDelete = vi.fn(() => ({ is: orphanIs }));
   const venturesSelect = vi.fn(() => Promise.resolve({ data: ventures, error: null }));
+  // SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001 FR-3 added audit rows around the teardown.
+  // Without this branch every handler here would refuse — correctly, since a failed audit
+  // write fails closed — so the mock now covers the audit sink and captures the rows.
+  const auditRows = [];
+  const auditInsert = vi.fn((row) => { auditRows.push(row); return Promise.resolve({ error: null }); });
   return {
     from: vi.fn((table) => {
       if (table === 'ventures') return { select: venturesSelect };
       if (table === 'stage_zero_requests') return { delete: orphanDelete };
+      if (table === 'operations_audit_log') return { insert: auditInsert };
       return {};
     }),
     _orphanDelete: orphanDelete,
+    _auditRows: auditRows,
   };
 }
 

--- a/tests/unit/audit-mounts.test.js
+++ b/tests/unit/audit-mounts.test.js
@@ -47,6 +47,26 @@ function buildRouteInventory() {
 const routeInventory = buildRouteInventory();
 
 describe('FR-5: auditMounts on the REAL server/index.js', () => {
+  it('actually examined the router-mounted routes, not just the direct mounts', () => {
+    // GUARDS THE GUARD. All three findings below come from DIRECT app.all() mounts, which
+    // need no route inventory at all — so running with routeInventory:{} produces a
+    // BYTE-IDENTICAL finding set, and mountsScanned is 30 either way. If buildRouteInventory
+    // ever silently resolves nothing (a moved file, a changed import form), the exact-match
+    // test would stay green while ~89% of mutating routes — including all three destructive
+    // venture endpoints — went unexamined. mutatingRoutesChecked is the only value that
+    // distinguishes the two runs: 46 with the inventory, 5 without.
+    //
+    // This also qualifies the "cannot UNDER-report" claim in lib/audit-mounts.js: that holds
+    // for auditMounts GIVEN a complete inventory, not for the pipeline as assembled here,
+    // because auditMounts skips unresolvable mounts silently.
+    const withInventory = auditMounts({ indexSource, routeInventory });
+    const withoutInventory = auditMounts({ indexSource, routeInventory: {} });
+
+    expect(withInventory.mutatingRoutesChecked).toBeGreaterThan(40);
+    expect(withoutInventory.mutatingRoutesChecked).toBeLessThan(10);
+    expect(Object.keys(routeInventory).length).toBeGreaterThan(20);
+  });
+
   it('flags exactly the three signature-verified webhooks and nothing else', () => {
     const { findings, mountsScanned } = auditMounts({ indexSource, routeInventory });
 

--- a/tests/unit/audit-mounts.test.js
+++ b/tests/unit/audit-mounts.test.js
@@ -1,0 +1,190 @@
+/**
+ * SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001 FR-5 / TS-6.
+ *
+ * Pins the auth-carve-out audit as a standing regression test. The SD's item THREE was a
+ * one-off audit whose result (zero mutating routes reachable without requireAuth) was a
+ * point-in-time fact that would decay. This makes it executable.
+ *
+ * SAFETY: auditMounts performs NO file I/O. The mutation half of this test passes a
+ * SYNTHETIC FIXTURE STRING, so server/index.js is never edited — and the last test asserts
+ * the working tree is clean afterward. That constraint comes from a live fleet near-miss
+ * where an agent mutated a production file in place to check a suite went red and left the
+ * edit uncommitted.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { auditMounts } from '../../lib/audit-mounts.js';
+
+const REPO = path.join(__dirname, '..', '..');
+const INDEX_PATH = path.join(REPO, 'server', 'index.js');
+const indexSource = fs.readFileSync(INDEX_PATH, 'utf8').replace(/\r\n/g, '\n');
+
+/**
+ * Build the route inventory by reading the mounted router modules. The I/O lives HERE, in
+ * the test — auditMounts itself stays pure so a fixture can be substituted.
+ */
+function buildRouteInventory() {
+  const inventory = {};
+  for (const m of indexSource.matchAll(/import\s+(?:(\w+)|\{[^}]+\})\s+from\s+['"](\.[^'"]+)['"]/g)) {
+    const spec = m[2];
+    for (const candidate of [spec, `${spec}.js`]) {
+      const file = path.resolve(path.dirname(INDEX_PATH), candidate);
+      if (!fs.existsSync(file) || !fs.statSync(file).isFile()) continue;
+      const src = fs.readFileSync(file, 'utf8').replace(/\r\n/g, '\n');
+      const routes = [];
+      for (const r of src.matchAll(/\brouter\s*\.\s*(get|post|put|patch|delete|all)\s*\(\s*['"`]([^'"`]*)['"`]/g)) {
+        routes.push({ method: r[1], path: r[2] });
+      }
+      inventory[spec] = routes;
+      break;
+    }
+  }
+  return inventory;
+}
+
+const routeInventory = buildRouteInventory();
+
+describe('FR-5: auditMounts on the REAL server/index.js', () => {
+  it('flags exactly the three signature-verified webhooks and nothing else', () => {
+    const { findings, mountsScanned } = auditMounts({ indexSource, routeInventory });
+
+    // These three are app.all() with no auth middleware BY DESIGN — each verifies a
+    // provider signature inside its handler, which is the correct control for an inbound
+    // webhook (the caller is Stripe/Twilio and cannot hold our credentials).
+    //
+    // This is an EXACT-MATCH assertion, deliberately not an allowlist baked into
+    // auditMounts. An allowlist inside the audit would silently absorb a NEW carve-out;
+    // asserting the exact set here means any additional finding fails this test and has to
+    // be looked at by a human.
+    expect(findings.map(f => f.path).sort()).toEqual([
+      '/api/webhooks/stripe',
+      '/api/webhooks/twilio-sms',
+      '/api/webhooks/twilio-status',
+    ]);
+    expect(mountsScanned).toBeGreaterThan(10);
+  });
+
+  it('does NOT flag /api/github/pr-review-webhook — the mount-ordering case', () => {
+    // The regression this encodes: reading each mount's declared middleware in isolation
+    // reports this route as unauthenticated. It is not. app.use('/api/github', requireAuth, …)
+    // at server/index.js:207 prefix-shadows the '/api' optionalAuth mount at :214, and
+    // requireAuth runs for every request under that prefix whether or not the inner router
+    // matches. That false positive was signalled before being verified; this test exists so
+    // it cannot be reintroduced.
+    const { findings } = auditMounts({ indexSource, routeInventory });
+    expect(findings.some(f => f.path.includes('/api/github'))).toBe(false);
+  });
+
+  it('finds no comment claiming an auth check the handler does not perform', () => {
+    // HEURISTIC, stated as such: keyword matching, not semantic understanding. The comment
+    // this targets ("auth at RPC level (chairman check)") was deleted in PR #6499; this
+    // keeps it from coming back unnoticed.
+    const { commentClaims } = auditMounts({ indexSource, routeInventory });
+    expect(commentClaims).toEqual([]);
+  });
+});
+
+describe('FR-5 MUTATION: the audit actually discriminates', () => {
+  // Every assertion above is a "nothing bad found" assertion, which a broken audit that
+  // always returns zero findings would also satisfy. These prove it can say otherwise —
+  // against fixture STRINGS, never against a real file.
+
+  const FIXTURE_UNGUARDED = `
+import optionalAuth from './middleware/auth.js';
+import dangerRoutes from './routes/danger.js';
+app.use('/api/danger', optionalAuth, dangerRoutes);
+`;
+
+  const FIXTURE_GUARDED = `
+import requireAuth from './middleware/auth.js';
+import dangerRoutes from './routes/danger.js';
+app.use('/api/danger', requireAuth, dangerRoutes);
+`;
+
+  const FIXTURE_SHADOWED = `
+import { requireAuth, optionalAuth } from './middleware/auth.js';
+import safeRoutes from './routes/safe.js';
+import dangerRoutes from './routes/danger.js';
+app.use('/api/danger', requireAuth, safeRoutes);
+app.use('/api', optionalAuth, dangerRoutes);
+`;
+
+  const INV = { './routes/danger.js': [{ method: 'post', path: '/wipe' }], './routes/safe.js': [] };
+
+  // The shadowing case needs a route whose EFFECTIVE path lands under the guarded prefix.
+  // First attempt used '/wipe', giving '/api/wipe' — which '/api/danger' does not prefix,
+  // so the audit correctly reported a finding and the fixture was simply not reproducing
+  // the real case. In the actual /api/github case, dashboard.js declares
+  // '/github/pr-review-webhook' and is mounted at '/api', so the effective path is
+  // '/api/github/pr-review-webhook' — under the guarded '/api/github' prefix. This mirrors
+  // that shape.
+  const INV_NESTED = { './routes/danger.js': [{ method: 'post', path: '/danger/wipe' }], './routes/safe.js': [] };
+
+  it('FLAGS a mutating route under an unguarded optionalAuth mount', () => {
+    const { findings } = auditMounts({ indexSource: FIXTURE_UNGUARDED, routeInventory: INV });
+    expect(findings).toHaveLength(1);
+    expect(findings[0].path).toBe('/api/danger/wipe');
+  });
+
+  it('CONTROL: the same fixture with requireAuth produces no finding', () => {
+    const { findings } = auditMounts({ indexSource: FIXTURE_GUARDED, routeInventory: INV });
+    expect(findings).toHaveLength(0);
+  });
+
+  it('respects mount ORDER: an earlier requireAuth prefix shadows a later optionalAuth mount', () => {
+    // The synthetic form of the /api/github case, so the ordering rule is pinned
+    // independently of that one real route continuing to exist.
+    const { findings } = auditMounts({ indexSource: FIXTURE_SHADOWED, routeInventory: INV_NESTED });
+    expect(findings).toHaveLength(0);
+  });
+
+  it('order matters in the other direction too: a LATER guard does not shadow', () => {
+    const reversed = `
+import { requireAuth, optionalAuth } from './middleware/auth.js';
+import dangerRoutes from './routes/danger.js';
+import safeRoutes from './routes/safe.js';
+app.use('/api', optionalAuth, dangerRoutes);
+app.use('/api/danger', requireAuth, safeRoutes);
+`;
+    const { findings } = auditMounts({ indexSource: reversed, routeInventory: INV });
+    expect(findings).toHaveLength(1);
+  });
+
+  it('FLAGS a direct unguarded mutating route, and not its GET sibling', () => {
+    const fixture = `
+import optionalAuth from './middleware/auth.js';
+app.post('/api/thing/destroy', optionalAuth, h);
+app.get('/api/thing', optionalAuth, h);
+`;
+    const { findings } = auditMounts({ indexSource: fixture, routeInventory: {} });
+    expect(findings.map(f => f.path)).toEqual(['/api/thing/destroy']);
+  });
+
+  it('DETECTS a comment claiming an auth check', () => {
+    const fixture = `
+// Master reset uses service-role client internally — auth at RPC level (chairman check)
+app.use('/api/ventures', requireAuth, venturesRoutes);
+`;
+    const { commentClaims } = auditMounts({ indexSource: fixture, routeInventory: {} });
+    expect(commentClaims).toHaveLength(1);
+    expect(commentClaims[0].text).toMatch(/chairman check/);
+  });
+});
+
+describe('FR-5 SAFETY: the mutation half never touched a real file', () => {
+  it('left server/index.js untouched', () => {
+    // The fleet rule this enforces: probe via an injected seam, never by editing a live
+    // call site. If a future change makes auditMounts write files, or a test starts
+    // mutating server/index.js in place to prove discrimination, this fails.
+    //
+    // SCOPED DELIBERATELY to server/index.js rather than asserting the WHOLE tree is
+    // clean. The first version checked `git status --porcelain` globally and failed on
+    // this suite's own untracked files — it was asserting a property of the developer's
+    // workspace, not of this code, and would have failed for anyone mid-edit. What the
+    // rule actually protects is the live call site.
+    const dirty = execFileSync('git', ['status', '--porcelain', '--', 'server/index.js'], { cwd: REPO, encoding: 'utf8' }).trim();
+    expect(dirty).toBe('');
+  });
+});

--- a/tests/unit/destructive-confirmation.test.js
+++ b/tests/unit/destructive-confirmation.test.js
@@ -1,0 +1,224 @@
+/**
+ * SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001 FR-1 — confirmation gate logic.
+ *
+ * These are pure-function tests: no server, no socket, no database client. The gate
+ * they cover stands in front of deleteVentureFully, which irreversibly deletes ventures
+ * (148 live, no undo), so nothing here may reach it — and nothing here can, because
+ * evaluateConfirmation performs no I/O at all.
+ *
+ * Every "X is refused" assertion is paired with a control showing the same input
+ * succeeds once the one offending field is corrected. Without that pairing, a gate that
+ * refused EVERYTHING would pass the refusal tests trivially.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateConfirmation,
+  issueToken,
+  resolveConfirmSecret,
+  CONFIRM_ACK_PHRASE,
+  TOKEN_TTL_MS,
+  CODES,
+} from '../../lib/destructive-confirmation.js';
+
+const ENV = { DESTRUCTIVE_CONFIRM_SECRET: 'test-secret' };
+const NOW = 1_700_000_000_000;
+const IDS = ['b', 'a', 'c'];
+
+function confirmedBody({ operation = 'master-reset', targetIds = IDS, nowMs = NOW, count = targetIds.length } = {}) {
+  return {
+    confirmation_token: issueToken({ operation, targetIds, issuedAtMs: nowMs, secret: ENV.DESTRUCTIVE_CONFIRM_SECRET }),
+    acknowledgement: CONFIRM_ACK_PHRASE,
+    expected_count: count,
+  };
+}
+
+describe('FR-1: unconfirmed requests are refused with a preview', () => {
+  it('an empty body yields 428 and a token bound to the target set', () => {
+    const r = evaluateConfirmation({ body: {}, operation: 'master-reset', targetIds: IDS, env: ENV, nowMs: NOW });
+
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(428);
+    expect(r.body.code).toBe(CODES.CONFIRMATION_REQUIRED);
+    expect(r.body.expected_count).toBe(3);
+    expect(r.body.confirmation_token).toBeTruthy();
+    expect(r.body.acknowledgement_required).toBe(CONFIRM_ACK_PHRASE);
+    // The operator must be told this cannot be undone, not just that a field is missing.
+    expect(r.body.message).toMatch(/irreversibly/i);
+  });
+
+  it('CONTROL: the token from that preview is accepted, so the refusal above is not vacuous', () => {
+    const preview = evaluateConfirmation({ body: {}, operation: 'master-reset', targetIds: IDS, env: ENV, nowMs: NOW });
+    const r = evaluateConfirmation({
+      body: { confirmation_token: preview.body.confirmation_token, acknowledgement: CONFIRM_ACK_PHRASE, expected_count: 3 },
+      operation: 'master-reset', targetIds: IDS, env: ENV, nowMs: NOW,
+    });
+
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('FR-1: the token is bound to operation and target set', () => {
+  it('refuses a token minted for a DIFFERENT id set', () => {
+    const r = evaluateConfirmation({
+      body: confirmedBody({ targetIds: ['a', 'b'] }),
+      operation: 'master-reset', targetIds: IDS, env: ENV, nowMs: NOW,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.body.code).toBe(CODES.TOKEN_INVALID);
+  });
+
+  it('refuses a token minted for a DIFFERENT operation', () => {
+    const r = evaluateConfirmation({
+      body: confirmedBody({ operation: 'bulk-full-delete' }),
+      operation: 'master-reset', targetIds: IDS, env: ENV, nowMs: NOW,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.body.code).toBe(CODES.TOKEN_INVALID);
+  });
+
+  it('id ORDER does not matter — the same set confirms regardless of ordering', () => {
+    const r = evaluateConfirmation({
+      body: confirmedBody({ targetIds: ['c', 'a', 'b'] }),
+      operation: 'master-reset', targetIds: IDS, env: ENV, nowMs: NOW,
+    });
+
+    expect(r.ok).toBe(true);
+  });
+
+  it('refuses a forged token signed with the wrong secret', () => {
+    const forged = issueToken({ operation: 'master-reset', targetIds: IDS, issuedAtMs: NOW, secret: 'attacker' });
+    const r = evaluateConfirmation({
+      body: { confirmation_token: forged, acknowledgement: CONFIRM_ACK_PHRASE, expected_count: 3 },
+      operation: 'master-reset', targetIds: IDS, env: ENV, nowMs: NOW,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.body.code).toBe(CODES.TOKEN_INVALID);
+  });
+
+  it('refuses a malformed token without throwing', () => {
+    for (const bad of ['', 'garbage', 'x.y', '123', `${NOW}.`, null]) {
+      const r = evaluateConfirmation({
+        body: { confirmation_token: bad, acknowledgement: CONFIRM_ACK_PHRASE, expected_count: 3 },
+        operation: 'master-reset', targetIds: IDS, env: ENV, nowMs: NOW,
+      });
+      expect(r.ok).toBe(false);
+    }
+  });
+});
+
+describe('FR-1: expiry', () => {
+  it('refuses a token older than the TTL', () => {
+    const r = evaluateConfirmation({
+      body: confirmedBody(),
+      operation: 'master-reset', targetIds: IDS, env: ENV, nowMs: NOW + TOKEN_TTL_MS + 1,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.body.code).toBe(CODES.TOKEN_EXPIRED);
+  });
+
+  it('CONTROL: the same token one millisecond INSIDE the TTL is accepted', () => {
+    const r = evaluateConfirmation({
+      body: confirmedBody(),
+      operation: 'master-reset', targetIds: IDS, env: ENV, nowMs: NOW + TOKEN_TTL_MS - 1,
+    });
+
+    expect(r.ok).toBe(true);
+  });
+
+  it('refuses a token dated in the future', () => {
+    const r = evaluateConfirmation({
+      body: confirmedBody({ nowMs: NOW + 60_000 }),
+      operation: 'master-reset', targetIds: IDS, env: ENV, nowMs: NOW,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.body.code).toBe(CODES.TOKEN_EXPIRED);
+  });
+});
+
+describe('FR-1: staleness — expected_count must match the live count', () => {
+  it('refuses when the live count has moved since the operator confirmed', () => {
+    const r = evaluateConfirmation({
+      body: confirmedBody({ count: 5 }),
+      operation: 'master-reset', targetIds: IDS, env: ENV, nowMs: NOW,
+    });
+
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(409);
+    expect(r.body.code).toBe(CODES.COUNT_MISMATCH);
+    expect(r.body.expected_count).toBe(3);
+  });
+
+  it('refuses a MISSING expected_count rather than treating absence as agreement', () => {
+    const body = confirmedBody();
+    delete body.expected_count;
+    const r = evaluateConfirmation({ body, operation: 'master-reset', targetIds: IDS, env: ENV, nowMs: NOW });
+
+    expect(r.ok).toBe(false);
+    expect(r.body.code).toBe(CODES.COUNT_MISMATCH);
+  });
+});
+
+describe('FR-1: acknowledgement', () => {
+  it('refuses a wrong, near-miss, or lowercase acknowledgement', () => {
+    for (const ack of ['delete permanently', 'DELETE', 'yes', '', 'DELETE PERMANENTLY ']) {
+      const r = evaluateConfirmation({
+        body: { ...confirmedBody(), acknowledgement: ack },
+        operation: 'master-reset', targetIds: IDS, env: ENV, nowMs: NOW,
+      });
+      expect(r.ok).toBe(false);
+      expect(r.body.code).toBe(CODES.ACK_INVALID);
+    }
+  });
+
+  it('supplying a token but NO acknowledgement is refused, not treated as a preview', () => {
+    const body = confirmedBody();
+    delete body.acknowledgement;
+    const r = evaluateConfirmation({ body, operation: 'master-reset', targetIds: IDS, env: ENV, nowMs: NOW });
+
+    expect(r.ok).toBe(false);
+    expect(r.body.code).toBe(CODES.ACK_INVALID);
+  });
+});
+
+describe('FR-4: fails CLOSED, and has no bypass', () => {
+  it('refuses with 503 when no secret is configured — it does NOT wave the request through', () => {
+    const r = evaluateConfirmation({ body: confirmedBody(), operation: 'master-reset', targetIds: IDS, env: {}, nowMs: NOW });
+
+    expect(r.ok).toBe(false);
+    expect(r.status).toBe(503);
+    expect(r.body.code).toBe(CODES.CONFIRMATION_UNAVAILABLE);
+  });
+
+  it('no environment variable bypasses the gate', () => {
+    // If someone later adds a SKIP_CONFIRM-style escape hatch, this fails.
+    const hostile = {
+      ...ENV,
+      SKIP_CONFIRM: 'true', FORCE: 'true', CONFIRM: 'true', DESTRUCTIVE_CONFIRM_BYPASS: 'true',
+      MASTER_RESET_CONFIRMED: 'true', NODE_ENV: 'test', CI: 'true',
+    };
+    const r = evaluateConfirmation({ body: {}, operation: 'master-reset', targetIds: IDS, env: hostile, nowMs: NOW });
+
+    expect(r.ok).toBe(false);
+    expect(r.body.code).toBe(CODES.CONFIRMATION_REQUIRED);
+  });
+
+  it('an empty target set still requires confirmation rather than short-circuiting', () => {
+    const r = evaluateConfirmation({ body: {}, operation: 'master-reset', targetIds: [], env: ENV, nowMs: NOW });
+
+    expect(r.ok).toBe(false);
+    expect(r.body.expected_count).toBe(0);
+  });
+});
+
+describe('resolveConfirmSecret', () => {
+  it('prefers the dedicated secret, falls back to INTERNAL_API_KEY, else null', () => {
+    expect(resolveConfirmSecret({ DESTRUCTIVE_CONFIRM_SECRET: 'a', INTERNAL_API_KEY: 'b' })).toBe('a');
+    expect(resolveConfirmSecret({ INTERNAL_API_KEY: 'b' })).toBe('b');
+    expect(resolveConfirmSecret({})).toBe(null);
+  });
+});

--- a/tests/unit/venture-resources.test.js
+++ b/tests/unit/venture-resources.test.js
@@ -110,12 +110,92 @@ describe('markResourcesCleaned', () => {
     expect(count).toBe(0);
   });
 
-  it('should return 0 on error', async () => {
+  // SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001 FR-2 — DELIBERATE BEHAVIOUR CHANGE.
+  // This previously asserted "should return 0 on error". That assertion pinned the
+  // defect: returning 0 makes a FAILED WRITE indistinguishable from "nothing to clean",
+  // so a broken teardown reported success. The sole production caller (deleteVentureFully
+  // phase 3) wraps this in try/catch and is explicitly non-blocking, so throwing surfaces
+  // the failure as phases.resources_error without changing control flow anywhere.
+  it('THROWS on error rather than returning 0, so a failed write is not silent', async () => {
     mockSelect.mockResolvedValue({ data: null, error: { message: 'connection error' } });
     const { markResourcesCleaned } = await import('../../lib/venture-resources.js');
 
-    const count = await markResourcesCleaned('venture-123');
-    expect(count).toBe(0);
+    await expect(markResourcesCleaned('venture-123')).rejects.toThrow(/cleanup failed: connection error/);
+  });
+});
+
+/**
+ * SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001 FR-2.
+ *
+ * These use an INJECTED stub client rather than the module-level supabase mock, because
+ * the injection seam is precisely what FR-2 adds — before this change the function built
+ * its own service client from process.env and could not be reached by a stub at all.
+ * Every assertion below is about writes NOT happening, so the stub records each call.
+ */
+describe('markResourcesCleaned — dryRun is side-effect-free (FR-2)', () => {
+  function makeStub({ rows = [{ id: '1' }, { id: '2' }], error = null } = {}) {
+    const calls = { update: 0, select: 0, from: [] };
+    const result = Promise.resolve({ data: rows, error });
+    const chain = {
+      eq: () => chain,
+      select: () => { calls.select++; return chain; },
+      then: (...a) => result.then(...a),
+    };
+    return {
+      calls,
+      from(table) {
+        calls.from.push(table);
+        return {
+          select: () => { calls.select++; return chain; },
+          update: (...args) => { calls.update++; calls.updateArgs = args; return chain; },
+        };
+      },
+    };
+  }
+
+  it('issues NO update when dryRun is true, and still reports the count', async () => {
+    const stub = makeStub();
+    const { markResourcesCleaned } = await import('../../lib/venture-resources.js');
+
+    const count = await markResourcesCleaned('venture-123', { dryRun: true, supabase: stub });
+
+    expect(stub.calls.update).toBe(0);   // the whole point: preview must not write
+    expect(stub.calls.from).toContain('venture_resources');
+    expect(count).toBe(2);
+  });
+
+  it('DOES update when dryRun is false, so the test above could have failed', async () => {
+    // Control case. Without this, "update was never called" would also pass if the
+    // function were broken and never called anything at all.
+    const stub = makeStub();
+    const { markResourcesCleaned } = await import('../../lib/venture-resources.js');
+
+    const count = await markResourcesCleaned('venture-123', { dryRun: false, supabase: stub });
+
+    expect(stub.calls.update).toBe(1);
+    expect(stub.calls.updateArgs[0]).toEqual({ status: 'cleaned' });
+    expect(count).toBe(2);
+  });
+
+  it('uses the INJECTED client, not a self-built service client', async () => {
+    // Before FR-2 this function called createSupabaseServiceClient() unconditionally,
+    // so an injected stub was ignored and the real table was hit. If the injection seam
+    // regresses, the stub records nothing and this fails.
+    const stub = makeStub();
+    const { markResourcesCleaned } = await import('../../lib/venture-resources.js');
+
+    await markResourcesCleaned('venture-123', { dryRun: true, supabase: stub });
+
+    expect(stub.calls.from).toEqual(['venture_resources']);
+  });
+
+  it('throws on a dry-run query error rather than reporting a false zero', async () => {
+    const stub = makeStub({ rows: null, error: { message: 'boom' } });
+    const { markResourcesCleaned } = await import('../../lib/venture-resources.js');
+
+    await expect(
+      markResourcesCleaned('venture-123', { dryRun: true, supabase: stub }),
+    ).rejects.toThrow(/dry-run count failed: boom/);
   });
 });
 

--- a/tests/unit/ventures-destructive-gate.test.js
+++ b/tests/unit/ventures-destructive-gate.test.js
@@ -241,7 +241,33 @@ describe('FR-3: the teardown is bracketed by audit rows, and refuses when it can
     expect(deleteVentureFullyMock).toHaveBeenCalledTimes(0);
   });
 
-  it('writes a FAILED row when the teardown throws partway, so the trail is never started-never-finished', async () => {
+  it('REAL partial failure: a completed row carrying failed=N (deleteVentureFully does not throw)', async () => {
+    // This is the shape an operator actually sees after a bad teardown, and the test below
+    // was NOT covering it. lib/deleteVentureFully.js catches every phase internally and
+    // phase 5 RETURNS {success:false} rather than throwing, so a realistic partial failure
+    // never reaches the catch in withDestructiveAudit — it produces a 'completed' row with
+    // metadata.failed set. Asserting only the throw path meant asserting a behaviour the
+    // real callee cannot exhibit (stubbed-writer blindness).
+    const app = await makeApp();
+    deleteVentureFullyMock.mockImplementationOnce(async id => ({ success: true, venture: { id }, phases: {} }));
+    deleteVentureFullyMock.mockImplementationOnce(async id => ({ success: false, venture: { id }, phases: { db: { success: false, error: 'cascade blocked' } } }));
+
+    const res = await confirmAndRun(app);
+    const rows = app.locals.supabase.auditRows;
+    const completed = rows.find(r => r.action === 'master-reset.completed');
+
+    expect(res.status).toBe(200);
+    expect(rows.map(r => r.action)).toEqual(['master-reset.started', 'master-reset.completed']);
+    expect(completed.metadata.succeeded).toBe(1);
+    expect(completed.metadata.failed).toBe(1);
+    // No 'failed' row for this shape — the trail records partial success, not an abort.
+    expect(rows.some(r => r.action === 'master-reset.failed')).toBe(false);
+  });
+
+  it('DEFENSIVE throw path: writes a FAILED row so the trail is never started-never-finished', async () => {
+    // Retained deliberately even though deleteVentureFully cannot currently throw: an audit
+    // wrapper that assumes its callee never throws is one refactor away from reopening the
+    // started-never-finished hole. Labelled defensive so nobody reads it as the normal path.
     const app = await makeApp();
     deleteVentureFullyMock.mockImplementationOnce(async id => ({ success: true, venture: { id }, phases: {} }));
     deleteVentureFullyMock.mockImplementationOnce(async () => { throw new Error('teardown exploded at venture 2'); });

--- a/tests/unit/ventures-destructive-gate.test.js
+++ b/tests/unit/ventures-destructive-gate.test.js
@@ -189,6 +189,73 @@ describe('FR-4: fails CLOSED at the route when confirmation is unconfigured', ()
       if (priorInternal !== undefined) process.env.INTERNAL_API_KEY = priorInternal;
     }
   });
+
+  // FR-4 BLAST RADIUS — the acceptance criterion that was ARGUED BUT NEVER MEASURED.
+  //
+  // metadata lists FR-4 as CRITICAL: "fail CLOSED on the destructive path, with a BOUNDED BLAST
+  // RADIUS". Failing closed was covered by the test above; the BOUND was not. A grep for
+  // unrelated/blast/non-destructive across both gate suites returned zero hits, so nothing
+  // asserted that the confirmation subsystem's failure stays confined to the destructive routes.
+  //
+  // That distinction is the whole point: "refuses everything" also satisfies "refuses the
+  // destructive route". Without this arm, a change that took the entire router down under the
+  // same condition would still pass FR-4 — the safe-looking result and the catastrophic one are
+  // indistinguishable. In an SD about safety controls, that is the wrong half to leave unpinned.
+  //
+  // Found post-hoc by the RETRO reconstruction; added by the adopting session.
+  // MEASURED AS A DIFFERENTIAL, deliberately. The obvious form — "assert the listing route returns
+  // 200 while the destructive route 503s" — is NOT available here and it took a failing test to
+  // see why: this suite mocks server/config.js to `{ dbLoader: {} }` (line 34), and the
+  // non-destructive routes read `dbLoader.supabase` while only the three destructive routes go
+  // through resolveServiceClient(req) and see the injected stub. So no non-destructive route can
+  // succeed in this harness, and an absolute assertion about its status would be asserting the
+  // mock, not the product.
+  //
+  // The differential IS the claim: if the confirmation subsystem's state changed anything outside
+  // the destructive path, the unrelated route would behave DIFFERENTLY with the secret present
+  // versus absent. Identical behaviour in both states is exactly "bounded blast radius", and it is
+  // measurable without touching the shared mock.
+  it('BOUNDED: an UNRELATED route behaves IDENTICALLY whether or not confirmation is configured', async () => {
+    const priorSecret = process.env.DESTRUCTIVE_CONFIRM_SECRET;
+    const priorInternal = process.env.INTERNAL_API_KEY;
+
+    // The suite-wide mock leaves dbLoader EMPTY (line 34) because only the destructive routes were
+    // ever exercised. Give it the minimum the listing route needs, set on the mocked object at
+    // runtime and removed in the finally, so the shared mock — and the other 13 tests — are
+    // untouched. Without this the route throws before responding and the request helper REJECTS,
+    // so the test would fail on a harness gap rather than on the property under test.
+    const { dbLoader } = await import('../../server/config.js');
+    const listQuery = { or: () => listQuery, then: (r) => r({ data: [], error: null }) };
+    dbLoader.supabase = { from: () => ({ select: () => ({ order: () => listQuery }) }) };
+
+    try {
+      // ARM 1 — confirmation UNCONFIGURED. Destructive route refuses.
+      delete process.env.DESTRUCTIVE_CONFIRM_SECRET;
+      delete process.env.INTERNAL_API_KEY;
+      const brokenApp = await makeApp();
+      const destructive = await request(brokenApp, { url: '/api/ventures/master-reset', body: {} });
+      expect(destructive.status).toBe(503);
+      expect(destructive.body.code).toBe('CONFIRMATION_UNAVAILABLE');
+      const unrelatedWhileBroken = await request(brokenApp, { method: 'GET', url: '/api/ventures' });
+
+      // ARM 2 — confirmation CONFIGURED (the control). Same unrelated route, same app shape.
+      process.env.DESTRUCTIVE_CONFIRM_SECRET = 'blast-radius-control-secret';
+      const healthyApp = await makeApp();
+      const unrelatedWhileHealthy = await request(healthyApp, { method: 'GET', url: '/api/ventures' });
+
+      // The unrelated route is untouched by the confirmation subsystem's state.
+      expect(unrelatedWhileBroken.status, 'confirmation state must not change unrelated routes')
+        .toBe(unrelatedWhileHealthy.status);
+      // And it is never intercepted BY the gate — whatever it returns is its own, not the gate's.
+      expect(unrelatedWhileBroken.body?.code).not.toBe('CONFIRMATION_UNAVAILABLE');
+      expect(deleteVentureFullyMock).toHaveBeenCalledTimes(0);
+    } finally {
+      if (priorSecret !== undefined) process.env.DESTRUCTIVE_CONFIRM_SECRET = priorSecret;
+      else delete process.env.DESTRUCTIVE_CONFIRM_SECRET;
+      if (priorInternal !== undefined) process.env.INTERNAL_API_KEY = priorInternal;
+      delete dbLoader.supabase; // restore the empty mock the rest of the suite relies on
+    }
+  });
 });
 
 describe('FR-3: the teardown is bracketed by audit rows, and refuses when it cannot be audited', () => {

--- a/tests/unit/ventures-destructive-gate.test.js
+++ b/tests/unit/ventures-destructive-gate.test.js
@@ -1,0 +1,169 @@
+/**
+ * SD-LEO-INFRA-DESTRUCTIVE-ACTION-SAFETY-001 FR-1 — the gate is WIRED, on BOTH mounts.
+ *
+ * tests/unit/destructive-confirmation.test.js proves the gate LOGIC is correct. That is
+ * not the same as proving it runs: deleting any one of the three `evaluateConfirmation`
+ * call sites in server/routes/ventures.js would leave every one of those tests green
+ * while re-opening the exact hole this SD exists to close. This file tests the invariant
+ * at the call sites.
+ *
+ * SAFETY: lib/deleteVentureFully.js is mocked, so the real teardown can never run. Every
+ * refusal assertion also asserts the mock was invoked ZERO times — which doubles as a
+ * detector for accidental real invocation. No server is booted, no socket is opened, and
+ * no Supabase client is constructed: the route module resolves its client from
+ * req.app.locals.supabase, so the stub below is the only client in play.
+ *
+ * Deliberately NOT modelled on tests/integration/webhooks/webhook-routes-mounted.test.js,
+ * which boots the real server as a child process with real credentials. Against these
+ * routes that pattern is one copy-paste away from deleting 148 live ventures.
+ *
+ * DUAL MOUNT: server/index.js:191 and :192 mount the SAME router object at
+ * /api/ventures and /api/competitor-analysis. Calling a handler function twice would
+ * prove nothing about that, so this builds a real express app wiring BOTH app.use lines
+ * and drives requests through app.handle() — routing is exercised, no socket is bound.
+ * (supertest is not a dependency in this repo.)
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import express from 'express';
+import { IncomingMessage, ServerResponse } from 'node:http';
+
+const deleteVentureFullyMock = vi.fn(async id => ({ success: true, venture: { id }, phases: {} }));
+vi.mock('../../lib/deleteVentureFully.js', () => ({
+  deleteVentureFully: (...args) => deleteVentureFullyMock(...args),
+}));
+vi.mock('../../server/config.js', () => ({ dbLoader: {} }));
+
+const VENTURE_IDS = ['11111111-1111-4111-8111-111111111111', '22222222-2222-4222-8222-222222222222'];
+
+// Minimal stub client: only the `from('ventures').select('id')` path master-reset uses.
+function stubClient() {
+  return { from: () => ({ select: async () => ({ data: VENTURE_IDS.map(id => ({ id })), error: null }) }) };
+}
+
+async function makeApp() {
+  const { default: venturesRoutes } = await import('../../server/routes/ventures.js');
+  const app = express();
+  // NOTE, coverage boundary: express.json() is deliberately NOT installed. Driving a
+  // synthetic IncomingMessage through body-parser did not populate req.body, so the
+  // request helper below assigns req.body directly instead. That means JSON PARSING
+  // itself is out of scope here — this file tests the gate, not body-parser. The first
+  // run of this suite had express.json() and the CONTROL tests failed with 428/400,
+  // which is the only reason the missing body was noticed: the three refusal tests
+  // passed happily with no body at all.
+  app.locals.supabase = stubClient();
+  // Both mounts, exactly as server/index.js:191-192 does it — one shared router object.
+  app.use('/api/ventures', venturesRoutes);
+  app.use('/api/competitor-analysis', venturesRoutes);
+  return app;
+}
+
+/** Drive a request through the real express routing stack without binding a socket. */
+function request(app, { method = 'POST', url, body = {} }) {
+  return new Promise((resolve, reject) => {
+    const req = new IncomingMessage(null);
+    req.method = method;
+    req.url = url;
+    req.headers = { 'content-type': 'application/json' };
+    req.body = body; // see the coverage-boundary note in makeApp()
+
+    const res = new ServerResponse(req);
+    const chunks = [];
+    const origEnd = res.end.bind(res);
+    res.end = (chunk, ...rest) => {
+      if (chunk) chunks.push(Buffer.from(chunk));
+      const raw = Buffer.concat(chunks).toString('utf8');
+      let json = null;
+      try { json = JSON.parse(raw); } catch { /* non-JSON body */ }
+      resolve({ status: res.statusCode, body: json, raw });
+      return origEnd(chunk, ...rest);
+    };
+    res.on('error', reject);
+    app.handle(req, res, err => reject(err || new Error('unhandled')));
+  });
+}
+
+const MOUNTS = ['/api/ventures', '/api/competitor-analysis'];
+const ROUTES = [
+  { name: 'master-reset', path: '/master-reset', body: {} },
+  { name: 'bulk-full-delete', path: '/bulk-full-delete', body: { ids: VENTURE_IDS } },
+  { name: 'full-delete', path: `/${VENTURE_IDS[0]}/full-delete`, body: {} },
+];
+
+beforeEach(() => {
+  deleteVentureFullyMock.mockClear();
+  process.env.DESTRUCTIVE_CONFIRM_SECRET = 'test-secret';
+});
+
+describe('FR-1: every destructive route refuses an unconfirmed request, on BOTH mounts', () => {
+  for (const mount of MOUNTS) {
+    for (const route of ROUTES) {
+      it(`${mount}${route.path} refuses and never reaches the teardown`, async () => {
+        const app = await makeApp();
+        const res = await request(app, { url: `${mount}${route.path}`, body: route.body });
+
+        expect(res.status).toBe(428);
+        expect(res.body.code).toBe('CONFIRMATION_REQUIRED');
+        expect(res.body.confirmation_token).toBeTruthy();
+        // The load-bearing assertion: nothing was destroyed.
+        expect(deleteVentureFullyMock).toHaveBeenCalledTimes(0);
+      });
+    }
+  }
+});
+
+describe('FR-1 CONTROL: a fully confirmed request DOES proceed', () => {
+  // Without this, "the teardown was never called" would also pass if the routes were
+  // broken and unreachable — the refusal tests above would be vacuous.
+  it('master-reset executes once confirmed, proving the refusals are real', async () => {
+    const app = await makeApp();
+    const preview = await request(app, { url: '/api/ventures/master-reset', body: {} });
+    expect(deleteVentureFullyMock).toHaveBeenCalledTimes(0);
+
+    const res = await request(app, {
+      url: '/api/ventures/master-reset',
+      body: {
+        confirmation_token: preview.body.confirmation_token,
+        acknowledgement: preview.body.acknowledgement_required,
+        expected_count: preview.body.expected_count,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(deleteVentureFullyMock).toHaveBeenCalledTimes(VENTURE_IDS.length);
+  });
+
+  it('a token minted on ONE mount is accepted on the OTHER — same router, same target set', async () => {
+    const app = await makeApp();
+    const preview = await request(app, { url: '/api/ventures/master-reset', body: {} });
+
+    const res = await request(app, {
+      url: '/api/competitor-analysis/master-reset',
+      body: {
+        confirmation_token: preview.body.confirmation_token,
+        acknowledgement: preview.body.acknowledgement_required,
+        expected_count: preview.body.expected_count,
+      },
+    });
+
+    expect(res.status).toBe(200);
+    expect(deleteVentureFullyMock).toHaveBeenCalledTimes(VENTURE_IDS.length);
+  });
+});
+
+describe('FR-4: fails CLOSED at the route when confirmation is unconfigured', () => {
+  it('refuses with 503 and no teardown when no secret is present', async () => {
+    delete process.env.DESTRUCTIVE_CONFIRM_SECRET;
+    const priorInternal = process.env.INTERNAL_API_KEY;
+    delete process.env.INTERNAL_API_KEY;
+    try {
+      const app = await makeApp();
+      const res = await request(app, { url: '/api/ventures/master-reset', body: {} });
+
+      expect(res.status).toBe(503);
+      expect(res.body.code).toBe('CONFIRMATION_UNAVAILABLE');
+      expect(deleteVentureFullyMock).toHaveBeenCalledTimes(0);
+    } finally {
+      if (priorInternal !== undefined) process.env.INTERNAL_API_KEY = priorInternal;
+    }
+  });
+});

--- a/tests/unit/ventures-destructive-gate.test.js
+++ b/tests/unit/ventures-destructive-gate.test.js
@@ -35,12 +35,35 @@ vi.mock('../../server/config.js', () => ({ dbLoader: {} }));
 
 const VENTURE_IDS = ['11111111-1111-4111-8111-111111111111', '22222222-2222-4222-8222-222222222222'];
 
-// Minimal stub client: only the `from('ventures').select('id')` path master-reset uses.
-function stubClient() {
-  return { from: () => ({ select: async () => ({ data: VENTURE_IDS.map(id => ({ id })), error: null }) }) };
+/**
+ * Minimal stub client covering the two tables these handlers touch: the
+ * `from('ventures').select('id')` master-reset uses, and the operations_audit_log inserts
+ * FR-3 added. Audit rows are captured so tests can assert on them rather than just on the
+ * absence of an error.
+ *
+ * `auditFails` makes every audit insert return an error, which is how the fail-closed
+ * behaviour is exercised without touching any real table.
+ */
+function stubClient({ auditFails = false } = {}) {
+  const auditRows = [];
+  return {
+    auditRows,
+    from(table) {
+      if (table === 'operations_audit_log') {
+        return {
+          insert: async row => {
+            if (auditFails) return { error: { message: 'audit sink unavailable' } };
+            auditRows.push(row);
+            return { error: null };
+          },
+        };
+      }
+      return { select: async () => ({ data: VENTURE_IDS.map(id => ({ id })), error: null }) };
+    },
+  };
 }
 
-async function makeApp() {
+async function makeApp(clientOpts) {
   const { default: venturesRoutes } = await import('../../server/routes/ventures.js');
   const app = express();
   // NOTE, coverage boundary: express.json() is deliberately NOT installed. Driving a
@@ -50,7 +73,7 @@ async function makeApp() {
   // run of this suite had express.json() and the CONTROL tests failed with 428/400,
   // which is the only reason the missing body was noticed: the three refusal tests
   // passed happily with no body at all.
-  app.locals.supabase = stubClient();
+  app.locals.supabase = stubClient(clientOpts);
   // Both mounts, exactly as server/index.js:191-192 does it — one shared router object.
   app.use('/api/ventures', venturesRoutes);
   app.use('/api/competitor-analysis', venturesRoutes);
@@ -165,5 +188,71 @@ describe('FR-4: fails CLOSED at the route when confirmation is unconfigured', ()
     } finally {
       if (priorInternal !== undefined) process.env.INTERNAL_API_KEY = priorInternal;
     }
+  });
+});
+
+describe('FR-3: the teardown is bracketed by audit rows, and refuses when it cannot be audited', () => {
+  async function confirmAndRun(app, url = '/api/ventures/master-reset') {
+    const preview = await request(app, { url, body: {} });
+    return request(app, {
+      url,
+      body: {
+        confirmation_token: preview.body.confirmation_token,
+        acknowledgement: preview.body.acknowledgement_required,
+        expected_count: preview.body.expected_count,
+      },
+    });
+  }
+
+  it('writes a started row BEFORE and a completed row AFTER, using only live columns', async () => {
+    const app = await makeApp();
+    const res = await confirmAndRun(app);
+    const rows = app.locals.supabase.auditRows;
+
+    expect(res.status).toBe(200);
+    expect(rows.map(r => r.action)).toEqual(['master-reset.started', 'master-reset.completed']);
+
+    // Column contract: operations_audit_log has exactly these 9 columns. The insert in
+    // lib/cleanup/archive.js:303-312 uses operation_type/details, which do not exist and
+    // hard-error — this asserts we did not inherit that bug.
+    const LIVE = ['entity_type', 'entity_id', 'action', 'performed_by', 'performed_at', 'module', 'severity', 'metadata'];
+    for (const row of rows) {
+      expect(Object.keys(row).every(k => LIVE.includes(k))).toBe(true);
+      expect(row).not.toHaveProperty('operation_type');
+      expect(row).not.toHaveProperty('details');
+    }
+    // The full target set survives even though entity_id cannot hold more than one id.
+    expect(rows[0].metadata.target_ids).toEqual(VENTURE_IDS);
+    expect(rows[1].metadata.succeeded).toBe(VENTURE_IDS.length);
+  });
+
+  it('FAILS CLOSED: an unwritable audit sink refuses the teardown entirely', async () => {
+    const app = await makeApp({ auditFails: true });
+
+    // The PRE-write throws, asyncHandler forwards it via next(err), and in production the
+    // error middleware turns that into a 5xx. This harness mounts no error middleware, so
+    // the rejection surfaces here instead — asserting a status code would be asserting a
+    // property of the harness, not of the handler. What matters is below.
+    await expect(confirmAndRun(app)).rejects.toThrow(/audit write failed/);
+
+    // The load-bearing assertion: an irreversible teardown that cannot be recorded does
+    // not run. Refusing costs a retry; proceeding unaudited costs the ability to ever know
+    // what happened.
+    expect(deleteVentureFullyMock).toHaveBeenCalledTimes(0);
+  });
+
+  it('writes a FAILED row when the teardown throws partway, so the trail is never started-never-finished', async () => {
+    const app = await makeApp();
+    deleteVentureFullyMock.mockImplementationOnce(async id => ({ success: true, venture: { id }, phases: {} }));
+    deleteVentureFullyMock.mockImplementationOnce(async () => { throw new Error('teardown exploded at venture 2'); });
+
+    await confirmAndRun(app).catch(() => {});
+    const actions = app.locals.supabase.auditRows.map(r => r.action);
+
+    expect(actions).toContain('master-reset.started');
+    expect(actions).toContain('master-reset.failed');
+    expect(actions).not.toContain('master-reset.completed');
+    const failed = app.locals.supabase.auditRows.find(r => r.action === 'master-reset.failed');
+    expect(failed.metadata.error).toMatch(/exploded/);
   });
 });


### PR DESCRIPTION
## What this closes

`POST /api/ventures/master-reset` looped `deleteVentureFully` across **every venture** with no confirmation, no preview, no undo and no audit. 148 live ventures; the teardown also deletes GitHub repos and rewrites `applications/registry.json`.

## Scope: the SD had 3 items, two were already done

Item TWO (delete the false "auth at RPC level (chairman check)" comment) shipped in #6499. Item THREE (sibling audit) had been run. Both are **recorded with evidence, not reimplemented**.

The real work was item ONE **plus a coordinator-ruled extension to the whole destructive family**. That extension was the minimum scope, not creep: the SD acceptance criterion is *"no single authenticated request can trigger a full portfolio teardown"*, and gating only `/master-reset` would have left it **provably unmet while every test passed** — `/bulk-full-delete` accepts an arbitrary `ids[]` and loops the identical helper, so one POST with all 148 ids is equivalent. The family was derived by grepping every caller: 3 call sites x 2 mounts = 6 reachable paths.

## What shipped

- **FR-1** `lib/destructive-confirmation.js` — two-phase gate on all three handlers. Stateless HMAC bound to operation + length-prefixed sorted target ids, 5-min TTL, typed acknowledgement, `expected_count` staleness check, fails closed with 503 on a missing secret, no env bypass. Enforced in the **handler bodies**, not mount middleware, because `server/index.js:191` and `:192` mount the same router object.
- **FR-2** `lib/venture-resources.js` — `markResourcesCleaned` now honours `dryRun`, accepts an injected client, and throws instead of returning a false zero. Phase 3 previously wrote unconditionally, so a "preview" performed a real write and a unit test with a stub client would still have hit the live table.
- **FR-3** `lib/destructive-audit.js` — restores pre/post `operations_audit_log` rows dropped by an earlier refactor. Survives partial failure; a failed PRE-write refuses the operation.
- **FR-5** `lib/audit-mounts.js` — the carve-out audit as a **pure** function, mutation-verified against fixture strings so `server/index.js` is never edited.

## What the gate is, stated precisely

It converts a one-request-and-it-is-gone endpoint into a deliberate two-step act with recorded intent and a staleness check. **It is not a credential control.** The 428 preview hands the caller a valid token, and `resolveConfirmSecret` falls back to `INTERNAL_API_KEY` — the credential `requireAuth` accepts — so a holder can forge one offline. Setting `DESTRUCTIVE_CONFIRM_SECRET` distinctly breaks the forge equivalence but not the preview one. The module docblock says all of this plainly.

## Known-open, deliberately not fixed here

1. **The staleness check is vacuous on 2 of 3 routes.** `/master-reset` derives targets from a live query so it is real; the other two take ids from the request, so `expected_count` compares the caller's number to the caller's own array length. Replay inside the TTL is unconditionally accepted on those. Fix is named in the docstring — resolve submitted ids against the live table — and ripples into two test suites, so it was scheduled rather than rushed.
2. **Authorization asymmetry, flagged upward.** `server/index.js:208` mounts a read-only lint dashboard behind `requireAdminRole`, while the 148-venture teardown runs on plain `requireAuth`. The primitive exists in-repo and was not applied here.
3. `performed_by` records `internal-api-key` for shared-key teardowns — a credential class, not an actor.
4. `entity_id` is TEXT and ids are uncapped, so `metadata.target_ids` is an unbounded JSONB payload written twice per request.
5. `audit-mounts` `parseMounts` truncates at the first `)`, so `requireAuth()` as a call would be mis-read. No current instance.
6. `lib/cleanup/archive.js:303-312` still inserts nonexistent columns with the failure swallowed — silently writing nothing. Pre-existing, out of scope.

## Tests

72 across 5 unit files, 7 in the db project. Every handler test asserts the mocked teardown ran **zero** times. No test can reach a live destructive endpoint; there is no non-production database, so the mocked-harness pattern is mandatory and the real-server-child-process pattern is forbidden by name in the code.

Two review rounds were run before this PR — adversarial TESTING (`bb5b451b`) and SECURITY (`12610136`), both CONDITIONAL_PASS, both acted on. They caught a would-not-ship in the audit wrapper (a post-commit throw that would have reported a 500 for a fully successful teardown) and three cases where a comment of mine asserted a check that does not exist on the path in question — the same defect class this SD exists to eliminate.

Gates: LEAD-TO-PLAN 96, PLAN-TO-EXEC 96, EXEC-TO-PLAN 93, PLAN-TO-LEAD 95.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
