### PR TITLE
feat(SD-EHG-IDEATION-PIPELINE-SEAMS-001): FR-5 witness-request builder with AC-9 attribution guard

### DIFF
--- a/lib/eva/stage-zero/nursery-reeval-request.js
+++ b/lib/eva/stage-zero/nursery-reeval-request.js
@@ -1,0 +1,95 @@
+/**
+ * SD-EHG-IDEATION-PIPELINE-SEAMS-001 (FR-5, AC-9)
+ *
+ * Builds the stage_zero_requests row that carries a named nursery candidate into
+ * Stage-0. Zero rows with strategy=nursery_reeval have ever been enqueued, so this
+ * shape has never been exercised — every default below is a live trap:
+ *
+ *   - stage-zero-queue-processor.js:206 defaults metadata.path to 'blueprint_browse'.
+ *     A request that omits path does NOT fail; it silently runs a different path and
+ *     produces a completed row that proves nothing.
+ *   - stage-zero-queue-processor.js:232 defaults metadata.strategy to 'trend_scanner'.
+ *     Same failure mode, one layer down: strategy-only requests never reach the nursery.
+ *   - The must_reference_blueprint_venture_or_path CHECK is satisfied by metadata->>'path'
+ *     alone, so a path-less nursery request is rejected by the database rather than
+ *     mis-dispatched — but a path-with-wrong-strategy request passes the CHECK.
+ *
+ * Both keys are therefore written explicitly and asserted, never defaulted.
+ */
+
+export const NURSERY_REEVAL_PATH = 'discovery_mode';
+export const NURSERY_REEVAL_STRATEGY = 'nursery_reeval';
+
+/**
+ * Registered non-human principals permitted to author a Stage-0 witness row.
+ *
+ * ALLOWLIST, NOT A DENYLIST — deliberate. stage_zero_requests.requested_by is
+ * `uuid NOT NULL REFERENCES auth.users(id)`, and the only auth.users row that has ever
+ * appeared in that column is the chairman's own account. A denylist of known humans
+ * fails OPEN: the next human account added is silently acceptable. An allowlist fails
+ * CLOSED, which is the correct direction for an attribution guard.
+ *
+ * Empty until a service principal is provisioned (chairman decision, signal e33a6f45).
+ * While it is empty this module refuses to build ANY request — that is the intended
+ * behaviour, not a gap: it makes "FR-5 has no honest author yet" a runtime fact rather
+ * than a line of prose someone can skim past.
+ */
+export const REGISTERED_SERVICE_PRINCIPALS = Object.freeze([]);
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export class UnregisteredPrincipalError extends Error {
+  constructor(requestedBy, registered = REGISTERED_SERVICE_PRINCIPALS) {
+    super(
+      `requested_by ${requestedBy || '(missing)'} is not a registered service principal. ` +
+      'AC-9 forbids attributing a Stage-0 witness row to a human account, and the registry ' +
+      `currently holds ${registered.length} entr${registered.length === 1 ? 'y' : 'ies'}. ` +
+      'Provision a service principal in auth.users and register its id before enqueuing.'
+    );
+    this.name = 'UnregisteredPrincipalError';
+    this.requestedBy = requestedBy ?? null;
+  }
+}
+
+/**
+ * Build the insert payload for a nursery re-evaluation request.
+ *
+ * @param {Object} params
+ * @param {string} params.requestedBy - service-principal auth.users id (must be registered)
+ * @param {string} params.nurseryId - venture_nursery row this request is raised for
+ * @param {number} [params.candidateCount=1] - FR-5 targets ONE named row, so default 1
+ * @param {Object} [params.constraints={}]
+ * @param {Object} [deps] - injection seam, matching the (params, deps) convention used
+ *   throughout stage-zero. `registeredPrincipals` defaults to the frozen empty registry,
+ *   so PRODUCTION callers get fail-closed behaviour without opting in. Only tests pass a
+ *   list; a production call site that supplies its own registry is defeating AC-9 and
+ *   should be treated as a review failure.
+ * @returns {Object} row shaped for supabase.from('stage_zero_requests').insert(...)
+ */
+export function buildNurseryReevalRequest({
+  requestedBy,
+  nurseryId,
+  candidateCount = 1,
+  constraints = {},
+} = {}, { registeredPrincipals = REGISTERED_SERVICE_PRINCIPALS } = {}) {
+  if (!registeredPrincipals.includes(requestedBy)) {
+    throw new UnregisteredPrincipalError(requestedBy, registeredPrincipals);
+  }
+  if (!nurseryId || !UUID_RE.test(nurseryId)) {
+    // FR-5 names its target by UUID because five nursery rows tie at score 90 and one of
+    // them is the live first-revenue venture — "the 90-scorer" is not a referent.
+    throw new Error(`nurseryId must be a UUID naming the target row; got ${JSON.stringify(nurseryId)}`);
+  }
+
+  return {
+    requested_by: requestedBy,
+    prompt: `Nursery re-evaluation for candidate ${nurseryId}`,
+    metadata: {
+      path: NURSERY_REEVAL_PATH,
+      strategy: NURSERY_REEVAL_STRATEGY,
+      candidate_count: candidateCount,
+      constraints,
+      nursery_id: nurseryId,
+    },
+  };
+}

--- a/tests/unit/eva/stage-zero/nursery-reeval-request.test.js
+++ b/tests/unit/eva/stage-zero/nursery-reeval-request.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildNurseryReevalRequest,
+  UnregisteredPrincipalError,
+  REGISTERED_SERVICE_PRINCIPALS,
+  NURSERY_REEVAL_PATH,
+  NURSERY_REEVAL_STRATEGY,
+} from '../../../../lib/eva/stage-zero/nursery-reeval-request.js';
+
+// The FR-5 target, named by UUID because five nursery rows tie at score 90.
+const HEADLINE_TRANSFORMER = '3d95f7ea-7d6e-4ffd-ba14-2d915b65fda1';
+
+// rickfelix2000@gmail.com — the chairman's own auth.users row, and the ONLY id that has
+// ever appeared in stage_zero_requests.requested_by. Pinned here as the concrete thing
+// AC-9 forbids, not as a denylist the module consults.
+const CHAIRMAN_HUMAN_UID = '69c8aa7a-7661-48ed-9779-746fa6290873';
+
+const FAKE_PRINCIPAL = '00000000-0000-4000-8000-00000000dead';
+const withPrincipal = { registeredPrincipals: [FAKE_PRINCIPAL] };
+
+describe('buildNurseryReevalRequest — AC-9 attribution guard', () => {
+  it('refuses every request while the production registry is empty', () => {
+    // Not an incidental assertion: the empty registry IS the current state, and this test
+    // is what makes "FR-5 has no honest author yet" fail loudly instead of silently
+    // defaulting to whatever uid a caller happens to pass.
+    expect(REGISTERED_SERVICE_PRINCIPALS).toHaveLength(0);
+    expect(() =>
+      buildNurseryReevalRequest({ requestedBy: FAKE_PRINCIPAL, nurseryId: HEADLINE_TRANSFORMER })
+    ).toThrow(UnregisteredPrincipalError);
+  });
+
+  it('refuses the chairman human account even when other principals are registered', () => {
+    expect(() =>
+      buildNurseryReevalRequest(
+        { requestedBy: CHAIRMAN_HUMAN_UID, nurseryId: HEADLINE_TRANSFORMER },
+        withPrincipal
+      )
+    ).toThrow(UnregisteredPrincipalError);
+  });
+
+  it('refuses a missing requested_by rather than emitting a null-attributed row', () => {
+    expect(() => buildNurseryReevalRequest({ nurseryId: HEADLINE_TRANSFORMER }, withPrincipal))
+      .toThrow(UnregisteredPrincipalError);
+  });
+
+  it('is an allowlist, not a denylist — an unknown uuid is refused, not admitted', () => {
+    // A denylist would admit this; the direction of the check is the point.
+    expect(() =>
+      buildNurseryReevalRequest(
+        { requestedBy: '11111111-2222-4333-8444-555555555555', nurseryId: HEADLINE_TRANSFORMER },
+        withPrincipal
+      )
+    ).toThrow(UnregisteredPrincipalError);
+  });
+});
+
+describe('buildNurseryReevalRequest — dispatch shape', () => {
+  const build = (over = {}) =>
+    buildNurseryReevalRequest(
+      { requestedBy: FAKE_PRINCIPAL, nurseryId: HEADLINE_TRANSFORMER, ...over },
+      withPrincipal
+    );
+
+  it('writes BOTH path and strategy as own properties', () => {
+    // The failure mode here is OMISSION, not a wrong value: the queue processor defaults
+    // metadata.path to 'blueprint_browse' (:206) and metadata.strategy to 'trend_scanner'
+    // (:232), so an omitted key produces a request that completes successfully down the
+    // wrong path and witnesses nothing. Assert presence, then value.
+    const { metadata } = build();
+    expect(Object.hasOwn(metadata, 'path')).toBe(true);
+    expect(Object.hasOwn(metadata, 'strategy')).toBe(true);
+    expect(metadata.path).toBe(NURSERY_REEVAL_PATH);
+    expect(metadata.strategy).toBe(NURSERY_REEVAL_STRATEGY);
+  });
+
+  it('pins the literals the processor dispatches on', () => {
+    expect(NURSERY_REEVAL_PATH).toBe('discovery_mode');
+    expect(NURSERY_REEVAL_STRATEGY).toBe('nursery_reeval');
+    // Neither may silently become the processor's default.
+    expect(NURSERY_REEVAL_PATH).not.toBe('blueprint_browse');
+    expect(NURSERY_REEVAL_STRATEGY).not.toBe('trend_scanner');
+  });
+
+  it('satisfies must_reference_blueprint_venture_or_path via metadata.path', () => {
+    // The CHECK admits a row with no blueprint_id and no venture_id only when
+    // metadata->>'path' is non-null.
+    const row = build();
+    expect(row.blueprint_id).toBeUndefined();
+    expect(row.venture_id).toBeUndefined();
+    expect(row.metadata.path).not.toBeNull();
+  });
+
+  it('carries the target nursery id and defaults candidate_count to 1', () => {
+    const { metadata } = build();
+    expect(metadata.nursery_id).toBe(HEADLINE_TRANSFORMER);
+    // FR-5 promotes ONE named row; a larger slate would make the witness ambiguous.
+    expect(metadata.candidate_count).toBe(1);
+  });
+
+  it('uses candidate_count snake_case, the casing the dedup key reads first', () => {
+    const { metadata } = build({ candidateCount: 3 });
+    expect(metadata.candidate_count).toBe(3);
+  });
+
+  it('rejects a nurseryId that is absent or not a UUID', () => {
+    expect(() => build({ nurseryId: undefined })).toThrow(/must be a UUID/);
+    expect(() => build({ nurseryId: 'Headline Transformer' })).toThrow(/must be a UUID/);
+  });
+});


### PR DESCRIPTION
Second PR for SD-EHG-IDEATION-PIPELINE-SEAMS-001, after #6493 (FR-1, FR-2, FR-3 AC-2, FR-4, COND-2). This is the FR-5 request shape and its AC-9 attribution guard. **Nothing is enqueued and no venture is created** — the remaining FR-5 step is gated on two pending decisions, both described below.

## The dispatch defaults are a live trap, not a theoretical one

Zero `stage_zero_requests` rows with `strategy=nursery_reeval` have ever been enqueued, so this shape has never once been exercised. Two defaults sit directly in its path:

| site | key | default |
|---|---|---|
| `stage-zero-queue-processor.js:206` | `metadata.path` | `blueprint_browse` |
| `stage-zero-queue-processor.js:232` | `metadata.strategy` | `trend_scanner` |

A request omitting either key **does not fail**. It completes down the wrong path and produces a `status=completed` row that witnesses nothing — the worst possible outcome for a requirement whose entire job is to produce a credible witness.

So the failure mode is **omission**, and the test asserts own-property *presence* before it asserts value. That distinction is load-bearing, and I verified it rather than assuming: deleting the `strategy` key from the builder turns exactly that one test red, and the other nine stay green.

## AC-9 is a runtime refusal, not prose

AC-9 requires that no witness row be attributed to a human. Two findings shaped how that is enforced:

- `stage_zero_requests.requested_by` is `uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE`, read from the live schema via the pooler and declared identically at `supabase/migrations/20260303_stage_zero_requests.sql:25`. Schema and migration agree.
- The only id that has ever appeared in that column, across all four historical rows, is `69c8aa7a-…` — the chairman's own account.

> **Correction to an earlier revision of this description.** It claimed the migration was stale — that `20260209_stage0_venture_entry_schema.sql:394` declared this column `TEXT DEFAULT 'stage0_engine'` while live disagreed. **That was wrong; there is no drift.** Two compounding mistakes: this repo has *two* migration roots (`database/migrations`, ~1375 files, and `supabase/migrations`, ~88, with overlapping basenames) and I searched only the first, so the real definition was never in my search space; and the hit I did find belongs to a **different table in that same file** — `modeling_requests`, per the `COMMENT ON TABLE` four lines below it. Nothing downstream changes, because the live type was read from the pooler rather than from any file. Nobody should go looking for schema drift here; there is none.

The guard is therefore an **allowlist, not a denylist of known humans**. A denylist fails open the moment another human account is added; an allowlist fails closed. Direction matters more than contents here.

**The registry ships empty, and so the module refuses every request.** That is the intended state, not a gap — it makes "FR-5 has no honest author yet" a runtime fact rather than a line reviewers can skim past. The registry is injectable only through the standard `(params, deps)` seam so tests can reach the happy path; production callers get the frozen empty default, and any production call site that supplies its own registry is defeating AC-9 and should fail review.

## Still blocked, on two decisions

1. **Service principal** — provisioning an `auth.users` row for a machine actor. Not self-authorized: identity creation is Tier-3 security per the routing table.
2. **WIP capacity (A/B/C)** — unchanged. Worth restating that the gate sits inside `persistVentureBrief` (`chairman-review.js:230`), not `conductChairmanReview`, and the venture it guards is inserted `status: 'paused'` with `awaiting_chairman_decision: true`, then handed to a separate approval gate in `decision-activation.js`. Raising the limit 2→3 does not approve a third *live* venture; it lets a third venture reach the chairman's decision queue.

## Verification

**851 stage-zero tests green across 57 files** (up from 841/56 — the 10 new tests in 1 new file). Re-run green after rebasing onto current `main`. Nothing imports this module yet, so there is no runtime behaviour change in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
