### PR TITLE
feat(SD-LEO-FEAT-ACCOUNT-USAGE-STRIP-001): per-account weekly quota reader, fail-visible

### DIFF
--- a/docs/04_features/account-quota-usage-strip.md
+++ b/docs/04_features/account-quota-usage-strip.md
@@ -1,0 +1,72 @@
+# Per-account quota usage strip
+
+**SD-LEO-FEAT-ACCOUNT-USAGE-STRIP-001** · backend `lib/fleet/account-usage-reader.cjs` · UI `ehg:src/components/chairman-v3/AccountUsageStrip.tsx`
+
+Renders each Max account's **weekly** quota use at the top of `/builder/sessions`.
+
+## Why it exists
+
+Quota is the cost currency on this plan. On **2026-07-25 the fleet went down** because one account (Deep Soul Sessions) hit its weekly limit and nothing anywhere rendered it. The pre-existing gauge (`lib/fleet/account-capacity-gauge.cjs`) is fed by hand from the chairman's pasted `/usage` dashboard; this reads the meters directly.
+
+## The upstream contract
+
+```
+GET https://api.anthropic.com/api/oauth/usage
+Authorization: Bearer <accessToken from THAT account's .credentials.json>
+anthropic-beta: oauth-2025-04-20        <-- REQUIRED; omitting it fails the call
+```
+
+Response fields consumed: `seven_day.utilization`, `five_hour.utilization`, and each one's `resets_at`. Values are **percent-scaled** (measured 54.0 / 11.0 / 37.0).
+
+**Dollar amounts and per-model buckets come back `null`** — verified. No code may depend on them.
+
+**The endpoint is undocumented.** Treat it as unstable: it may change shape or disappear without notice. That is the entire reason for the fail-visible rule below.
+
+## Fail visibly — the load-bearing rule
+
+Every failure resolves to `{state:'unavailable', reason}` where `reason` is a **closed** enum: `not_configured | unauthorized | unexpected_shape | timeout | unreachable`.
+
+On `unavailable` the percentage **key is absent, not null**. A nullable percentage is what produces the forbidden dash — see `buildNamedAccountChips` → `{wkPct: null}` → `fleet-panel-format.js` rendering `wk --% used`.
+
+This is deliberately the **opposite** of `rankAccountsByHeadroom`'s documented *"unknown meters read as 0% used"*. A stale number, a zero and a dash all read as **headroom**, and that misreading is what let the fleet die. A gauge showing yesterday's figure is worse than no gauge.
+
+## The three accounts, and where their credentials live
+
+The registry is an **explicit map** (display name → credential directory). Identity comes from *which directory supplied the token*, so it cannot drift from the credentials.
+
+| Account | Credential directory | State on this host |
+|---|---|---|
+| Deep Soul Sessions | `~/.claude-fleet-profiles/deepsoul` | **not provisioned** |
+| Code Street Labs | `~/.claude` (host default) | readable |
+| Rick Felix 2000 | `~/.claude-fleet-profiles/canary` | readable |
+
+Two things that are easy to get wrong here:
+
+- **The host default is a first-class entry, not a fallback.** `resolveProfileDir` (`lib/fleet/spawn-control.js`) structurally cannot express it — it only joins under the profiles dir. The host default also *splits* its files: credentials at `~/.claude/.credentials.json` but config at `~/.claude.json`, one level **up**. So pointing `CLAUDE_CONFIG_DIR` at `~/.claude` does **not** work for it.
+- **Do not match on `orgName`.** `NAMED_ACCOUNT_REGISTRY` in `account-capacity-gauge.cjs` uses `/rick\s*felix/i`, which **misses** the canary profile's real orgName — `Richard Felix`. An honest value answering the wrong question.
+
+`FLEET_ACCOUNT_PROFILES_DIR` is **unset** on the fleet host, so the profiles base dir defaults to `~/.claude-fleet-profiles`. `resolveProfileDir` *throws* when it is unset; doing that here would render a genuinely readable account as `not_configured`, which is precisely the misleading gauge this SD forbids.
+
+### Provisioning Deep Soul Sessions
+
+It has no credentials anywhere on this host, so it renders `not_configured` — deliberately shown as unreadable rather than omitted, because it is the account whose exhaustion caused the outage. Because each account is read independently, provisioning it needs **no code change**: authenticate a profile into `~/.claude-fleet-profiles/deepsoul`. A different directory name needs exactly one line in `ACCOUNT_REGISTRY`.
+
+## Gotcha: an expired token is invisible to identity checks
+
+Observed 2026-07-26 — the canary profile returned `unauthorized` while `claude auth status --json` still cheerfully reported `rickfelix2000@gmail.com / max`. Its `claudeAiOauth.expiresAt` had lapsed ~7h earlier.
+
+`claude auth status` reads identity from `.claude.json` and **never validates the access token**. So identity-based checks (including `assertCanaryTarget`-style guards) will look healthy while every API call from that profile 401s. If an account reads `unauthorized`, check `expiresAt` before suspecting the reader.
+
+## Caching and refresh
+
+The reader caches for **60s** so the page's 15s poll cannot hammer an undocumented endpoint. `fetchedAt` always reports the true read time, and a reading older than **15 minutes** is marked stale by the UI. A stale *success* is never re-served: once the cache expires, a dead upstream becomes `unavailable`.
+
+`GET /api/fleet-panel?refreshUsage=1` bypasses the cache. That backs the strip's **Refresh** control — the cache is there to stop polling pressure, not to block a deliberate re-read after an operator fixes an account.
+
+## Boundary
+
+The bearer token is **request-local**: never returned, cached, logged or persisted. No config directory, profile name or file path appears in any browser-bound field. Only the closed enum values reach the client, so a raw upstream body or transport error cannot escape through `reason`.
+
+The containing control on `/api/fleet-panel` is the **loopback bind** in `server/index.js`, *not* the operator JWT — the route uses `optionalAuth`, and `requireAuth` accepts any valid JWT from the shared Supabase project with no role check. The payload is therefore safe on its own terms rather than relying on who can call it.
+
+Exposed additively as `accountUsage`; the legacy `accountChips` field keeps its `{name, wkPct}` shape because the standalone vanilla panel (`server/public/fleet-ui/`) parses it.

--- a/lib/fleet/account-usage-reader.cjs
+++ b/lib/fleet/account-usage-reader.cjs
@@ -1,0 +1,303 @@
+// SD-LEO-FEAT-ACCOUNT-USAGE-STRIP-001 (FR-1, FR-2, FR-3, FR-7) — per-account weekly quota usage.
+//
+// WHY THIS EXISTS: quota is the cost currency on the Max plan, and on 2026-07-25 the fleet went
+// down because one account (Deep Soul Sessions) hit its weekly limit with no readout anywhere.
+// The pre-existing gauge (account-capacity-gauge.cjs) is fed by hand from the chairman's pasted
+// /usage dashboard; this module reads the meters directly, per account, server-side.
+//
+// FAIL VISIBLY IS THE WHOLE POINT. The upstream endpoint is UNDOCUMENTED, so every failure mode
+// resolves to an explicit `unavailable` + reason — never a stale number, never a coerced 0, never
+// a dash. A gauge showing yesterday's figure is worse than no gauge, because it reads as safe.
+// This is deliberately the OPPOSITE of two conventions already in this repo, both of which would
+// silently render "low usage" for an account nobody can actually read:
+//   - account-capacity-gauge.cjs rankAccountsByHeadroom(): "unknown meters read as 0% used".
+//   - buildNamedAccountChips() -> {wkPct: null} -> fleet-panel-format.js renders 'wk --% used'.
+//
+// FR-7 — NO CREDENTIAL MATERIAL LEAVES THIS MODULE. The bearer token is request-local: never
+// returned, never cached, never logged. No config directory, profile name or file path appears in
+// any returned field. The only failure vocabulary that escapes is the closed UNAVAILABLE_REASONS
+// enum, so a raw upstream body or header can never reach a browser through `reason`.
+
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+/** Verified live at HTTP 200 during research (SD scope). Do not re-derive this contract. */
+const USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
+
+/** REQUIRED — the endpoint 404/400s without it. Verified during research. */
+const OAUTH_BETA_HEADER = 'oauth-2025-04-20';
+
+// Bounded so an unreachable upstream cannot hang the fleet-panel response (FR-2 acceptance).
+// The three accounts are fetched in PARALLEL, so this is the worst case for the whole strip, not
+// per account. The route deliberately awaits this rather than returning a "pending" state: FR-3's
+// reason enum is closed, and a bounded wait amortized by CACHE_TTL_MS was the ratified trade.
+const DEFAULT_TIMEOUT_MS = 5000;
+
+// Amortize upstream calls: the page polls /api/fleet-panel every 15s, and hammering an
+// undocumented endpoint 3x per 15s invites the rate-limiting that would itself read as failure.
+// Well inside STALE_AFTER_MS, and `fetchedAt` always reports the true read time — a cached
+// reading is never presented as fresher than it is. On expiry a dead upstream resolves to
+// `unavailable`; a stale SUCCESS is never re-served.
+const CACHE_TTL_MS = 60_000;
+
+/** A reading older than this is marked stale by the UI rather than shown as current (FR-6). */
+const STALE_AFTER_MS = 15 * 60 * 1000;
+
+/**
+ * CLOSED enum — the only failure vocabulary that may reach the client (FR-3, FR-7).
+ *   not_configured  — no resolvable config dir / no readable token for that account
+ *   unauthorized    — upstream rejected the token (401/403)
+ *   unexpected_shape— HTTP 200 but the body is not the shape research verified
+ *   timeout         — bounded wait elapsed
+ *   unreachable     — network failure, or any other non-2xx status
+ */
+const UNAVAILABLE_REASONS = Object.freeze({
+  NOT_CONFIGURED: 'not_configured',
+  UNAUTHORIZED: 'unauthorized',
+  UNEXPECTED_SHAPE: 'unexpected_shape',
+  TIMEOUT: 'timeout',
+  UNREACHABLE: 'unreachable',
+});
+
+const REASON_VALUES = Object.freeze(Object.values(UNAVAILABLE_REASONS));
+
+/** Same guard as spawn-control.js resolveProfileDir — never a raw/absolute/traversal path. */
+const PROFILE_NAME_RE = /^[A-Za-z0-9_-]+$/;
+
+function homeDir(env) {
+  return env.USERPROFILE || os.homedir();
+}
+
+/**
+ * The host-default profile's credential directory.
+ *
+ * THIS IS WHY resolveProfileDir COULD NOT BE REUSED (FR-1): it is a bare
+ * path.win32.join(FLEET_ACCOUNT_PROFILES_DIR, name) and STRUCTURALLY CANNOT express the host
+ * default, which lives outside the profiles dir. Note the host default splits its two files —
+ * credentials at ~/.claude/.credentials.json but config at ~/.claude.json (one level UP, verified
+ * on this host) — which is also why pointing CLAUDE_CONFIG_DIR at ~/.claude does not work for it.
+ * Only the credentials file is needed here.
+ */
+function hostDefaultConfigDir(env) {
+  return path.win32.join(homeDir(env), '.claude');
+}
+
+/**
+ * Base dir for CLAUDE_CONFIG_DIR-style fleet profiles.
+ *
+ * DEFAULTS RATHER THAN THROWS, deliberately: FLEET_ACCOUNT_PROFILES_DIR is UNSET on the live
+ * fleet host (measured), while ~/.claude-fleet-profiles/canary exists and holds real credentials.
+ * resolveProfileDir throws when the env var is missing, which here would render a genuinely
+ * readable account as not_configured — a misleading gauge, which this SD forbids. The env var
+ * still wins when an operator sets it.
+ */
+function profilesBaseDir(env) {
+  return env.FLEET_ACCOUNT_PROFILES_DIR || path.win32.join(homeDir(env), '.claude-fleet-profiles');
+}
+
+/**
+ * The three accounts the fleet rotates across, in the chairman's own naming (FR-1).
+ *
+ * EXPLICIT MAP, NOT NAME-MATCHING. Do not reintroduce a regex over orgName the way
+ * account-capacity-gauge.cjs NAMED_ACCOUNT_REGISTRY does: its /rick\s*felix/i does not match the
+ * canary profile's real orgName, which is "Richard Felix" (verified on this host) — an honest
+ * value answering the wrong question. Identity here comes from WHICH DIRECTORY was read, which
+ * cannot drift from the credentials it supplied.
+ *
+ * Deep Soul Sessions has NO config directory on this host, so it resolves to not_configured until
+ * a profile is provisioned — the account whose exhaustion took the fleet down is shown as
+ * unreadable rather than omitted. Provisioning it under ~/.claude-fleet-profiles/deepsoul needs no
+ * code change; a different directory name needs exactly this one line.
+ */
+const ACCOUNT_REGISTRY = Object.freeze([
+  Object.freeze({ name: 'Deep Soul Sessions', profile: 'deepsoul' }),
+  Object.freeze({ name: 'Code Street Labs', hostDefault: true }),
+  Object.freeze({ name: 'Rick Felix 2000', profile: 'canary' }),
+]);
+
+/** Resolve one registry entry to its credential directory, or null when unresolvable. */
+function resolveAccountConfigDir(entry, env = process.env) {
+  if (entry.hostDefault) return hostDefaultConfigDir(env);
+  if (typeof entry.profile !== 'string' || !PROFILE_NAME_RE.test(entry.profile)) return null;
+  return path.win32.join(profilesBaseDir(env), entry.profile);
+}
+
+/**
+ * Read one account's bearer token from its own .credentials.json (shape claudeAiOauth.accessToken,
+ * verified on disk). Returns null on ANY failure — missing dir, missing file, bad JSON, absent or
+ * empty token. NEVER throws, and never logs the value or the path.
+ */
+function readAccessToken(configDir, fsImpl = fs) {
+  try {
+    const raw = fsImpl.readFileSync(path.win32.join(configDir, '.credentials.json'), 'utf8');
+    const token = JSON.parse(raw)?.claudeAiOauth?.accessToken;
+    return typeof token === 'string' && token.length > 0 ? token : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Coerce an upstream utilization figure to a percentage, or null when it is not one.
+ *
+ * Research measured PERCENT-SCALED values (54.0 and 11.0), so no x100 is applied. Values outside
+ * 0..100 are rejected as an unexpected shape. RESIDUAL RISK, recorded rather than papered over: a
+ * future upstream switch to 0..1 FRACTIONS is undetectable here — 0.54 is a legal percentage — and
+ * would under-report. Nothing in the payload disambiguates scale, so this bound is the honest
+ * limit of what can be validated locally.
+ */
+function toPct(value) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  if (value < 0 || value > 100) return null;
+  return Math.round(value * 10) / 10;
+}
+
+/** Pass through a parseable timestamp string, else null. Display-only, never load-bearing. */
+function toIsoOrNull(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? value : null;
+}
+
+/**
+ * The unavailable shape. NOTE WHAT IS ABSENT: no weeklyPct key at all, not a null one (FR-3).
+ * A nullable percentage is precisely what produces the forbidden dash — `wkPct ?? '--'` — so the
+ * key does not exist unless there is a real reading behind it, and a consumer cannot render a
+ * number without first branching on `state`.
+ */
+function unavailable(name, reason, fetchedAt) {
+  return { name, state: 'unavailable', reason, fetchedAt };
+}
+
+/**
+ * Read ONE account. Independent by construction: this function owns every failure path for its
+ * own account and never throws, so one account's outage can neither suppress nor alter another's
+ * reading. That independence is what makes provisioning Deep Soul later a config change.
+ */
+async function readOneAccount(entry, opts = {}) {
+  const env = opts.env || process.env;
+  const fetchImpl = opts.fetchImpl || globalThis.fetch;
+  const fsImpl = opts.fs || fs;
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const fetchedAt = new Date(opts.nowMs ?? Date.now()).toISOString();
+
+  const configDir = resolveAccountConfigDir(entry, env);
+  const token = configDir ? readAccessToken(configDir, fsImpl) : null;
+  if (!token) return unavailable(entry.name, UNAVAILABLE_REASONS.NOT_CONFIGURED, fetchedAt);
+  if (typeof fetchImpl !== 'function') {
+    return unavailable(entry.name, UNAVAILABLE_REASONS.UNREACHABLE, fetchedAt);
+  }
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  let res;
+  try {
+    res = await fetchImpl(USAGE_URL, {
+      method: 'GET',
+      signal: controller.signal,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'anthropic-beta': OAUTH_BETA_HEADER,
+        accept: 'application/json',
+      },
+    });
+  } catch (err) {
+    // Abort is the bounded-timeout path; anything else is a transport failure. The error itself is
+    // deliberately not surfaced — only the enum value crosses the boundary (FR-7).
+    const aborted = err?.name === 'AbortError' || controller.signal.aborted;
+    const reason = aborted ? UNAVAILABLE_REASONS.TIMEOUT : UNAVAILABLE_REASONS.UNREACHABLE;
+    return unavailable(entry.name, reason, fetchedAt);
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (res?.status === 401 || res?.status === 403) {
+    return unavailable(entry.name, UNAVAILABLE_REASONS.UNAUTHORIZED, fetchedAt);
+  }
+  if (!res?.ok) return unavailable(entry.name, UNAVAILABLE_REASONS.UNREACHABLE, fetchedAt);
+
+  let body;
+  try {
+    body = await res.json();
+  } catch {
+    return unavailable(entry.name, UNAVAILABLE_REASONS.UNEXPECTED_SHAPE, fetchedAt);
+  }
+
+  // BOTH meters are required for `ok`. Research verified both present at HTTP 200, and TR-3 makes
+  // an unexpected shape a first-class unavailable reason — so a body that has lost a field is
+  // treated as untrustworthy rather than partially believed. Relaxing this to weekly-only would be
+  // a deliberate decision, not a tidy-up.
+  const weeklyPct = toPct(body?.seven_day?.utilization);
+  const fiveHourPct = toPct(body?.five_hour?.utilization);
+  if (weeklyPct === null || fiveHourPct === null) {
+    return unavailable(entry.name, UNAVAILABLE_REASONS.UNEXPECTED_SHAPE, fetchedAt);
+  }
+
+  // Dollar amounts and per-model buckets come back NULL upstream (confirmed in research), so
+  // nothing here reads them.
+  return {
+    name: entry.name,
+    state: 'ok',
+    weeklyPct,
+    fiveHourPct,
+    // resets_at is display sugar: a missing one degrades to null WITHOUT failing the reading,
+    // because the percentage is the load-bearing value. Explicitly a decision, not an oversight.
+    weeklyResetsAt: toIsoOrNull(body?.seven_day?.resets_at),
+    fiveHourResetsAt: toIsoOrNull(body?.five_hour?.resets_at),
+    fetchedAt,
+  };
+}
+
+/** Read every registry account in parallel. Always returns one entry per account, in order. */
+async function readAllAccounts(opts = {}) {
+  return Promise.all(ACCOUNT_REGISTRY.map((entry) => readOneAccount(entry, opts)));
+}
+
+let cache = null;
+
+/**
+ * Cached read for the route. NEVER throws and never returns a short array: a caller can rely on
+ * one entry per named account, because an account missing from the strip is an invisible failure.
+ */
+async function getAccountUsage(opts = {}) {
+  const nowMs = opts.nowMs ?? Date.now();
+  const ttl = opts.cacheTtlMs ?? CACHE_TTL_MS;
+  if (!opts.noCache && cache && nowMs - cache.at < ttl) return cache.value;
+  try {
+    const value = await readAllAccounts(opts);
+    cache = { at: nowMs, value };
+    return value;
+  } catch {
+    const fetchedAt = new Date(nowMs).toISOString();
+    return ACCOUNT_REGISTRY.map((e) =>
+      unavailable(e.name, UNAVAILABLE_REASONS.UNREACHABLE, fetchedAt));
+  }
+}
+
+/** Test seam only — drops the module-level cache between cases. */
+function __resetUsageCache() {
+  cache = null;
+}
+
+module.exports = {
+  USAGE_URL,
+  OAUTH_BETA_HEADER,
+  DEFAULT_TIMEOUT_MS,
+  CACHE_TTL_MS,
+  STALE_AFTER_MS,
+  UNAVAILABLE_REASONS,
+  REASON_VALUES,
+  ACCOUNT_REGISTRY,
+  resolveAccountConfigDir,
+  hostDefaultConfigDir,
+  profilesBaseDir,
+  readAccessToken,
+  toPct,
+  readOneAccount,
+  readAllAccounts,
+  getAccountUsage,
+  __resetUsageCache,
+};

--- a/lib/fleet/account-usage-reader.cjs
+++ b/lib/fleet/account-usage-reader.cjs
@@ -155,11 +155,18 @@ function toPct(value) {
   return Math.round(value * 10) / 10;
 }
 
-/** Pass through a parseable timestamp string, else null. Display-only, never load-bearing. */
+/**
+ * Normalize a timestamp to canonical ISO, or null. Display-only, never load-bearing.
+ *
+ * RE-DERIVES rather than passing the upstream string through: V8's legacy Date parser treats
+ * parenthesized trailing text as a comment, so a value like "Dec 25 1995 (<script>…)" parses
+ * successfully and would otherwise reach the browser verbatim. Returning the re-derived ISO form
+ * means only a date can escape this function, whatever the upstream sends.
+ */
 function toIsoOrNull(value) {
   if (typeof value !== 'string' || value.length === 0) return null;
   const ms = Date.parse(value);
-  return Number.isFinite(ms) ? value : null;
+  return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
 }
 
 /**
@@ -256,6 +263,16 @@ async function readAllAccounts(opts = {}) {
   return Promise.all(ACCOUNT_REGISTRY.map((entry) => readOneAccount(entry, opts)));
 }
 
+/**
+ * Every account as unavailable for one reason — the shape a caller needs when it cannot get a
+ * reading at all. Exported so the route's own safety net does not have to reinvent the registry;
+ * an empty array there would render as a silently missing strip.
+ */
+function allUnavailable(reason, nowMs = Date.now()) {
+  const fetchedAt = new Date(nowMs).toISOString();
+  return ACCOUNT_REGISTRY.map((e) => unavailable(e.name, reason, fetchedAt));
+}
+
 let cache = null;
 
 /**
@@ -271,9 +288,7 @@ async function getAccountUsage(opts = {}) {
     cache = { at: nowMs, value };
     return value;
   } catch {
-    const fetchedAt = new Date(nowMs).toISOString();
-    return ACCOUNT_REGISTRY.map((e) =>
-      unavailable(e.name, UNAVAILABLE_REASONS.UNREACHABLE, fetchedAt));
+    return allUnavailable(UNAVAILABLE_REASONS.UNREACHABLE, nowMs);
   }
 }
 
@@ -298,6 +313,7 @@ module.exports = {
   toPct,
   readOneAccount,
   readAllAccounts,
+  allUnavailable,
   getAccountUsage,
   __resetUsageCache,
 };

--- a/server/routes/fleet-panel.js
+++ b/server/routes/fleet-panel.js
@@ -156,9 +156,16 @@ export async function getFleetPanel(req, res) {
   // session list, the chips, everything — not just the strip. getAccountUsage is written never to
   // throw, so this is defense in depth rather than a known path; the fallback still names every
   // account, because a silently absent strip is the invisible failure this SD exists to prevent.
+  // ?refreshUsage=1 bypasses the reader's 60s cache. The cache exists to stop the page's 15s POLL
+  // from hammering an undocumented endpoint — it was never meant to block a DELIBERATE re-read.
+  // This is the path behind the strip's Refresh control: after an operator re-authenticates an
+  // account they need to confirm it NOW, and being told to wait out a cache would undercut the
+  // whole point of showing them the failure.
+  const refreshUsage = String(req?.query?.refreshUsage ?? '') === '1';
+
   let accountUsage;
   try {
-    accountUsage = await getAccountUsage();
+    accountUsage = await getAccountUsage(refreshUsage ? { noCache: true } : {});
   } catch {
     accountUsage = allUnavailable('unreachable');
   }

--- a/server/routes/fleet-panel.js
+++ b/server/routes/fleet-panel.js
@@ -13,7 +13,7 @@ import { createClient } from '@supabase/supabase-js';
 import { computeSessionBadge } from '../../lib/fleet/fleet-view-badges.cjs';
 import { getAttentionFlaggedSessions } from '../../lib/fleet/attention-flag-writer.js';
 import { loadStore, buildNamedAccountChips } from '../../lib/fleet/account-capacity-gauge.cjs';
-import { getAccountUsage } from '../../lib/fleet/account-usage-reader.cjs';
+import { getAccountUsage, allUnavailable } from '../../lib/fleet/account-usage-reader.cjs';
 
 const router = Router();
 
@@ -151,7 +151,17 @@ export async function getFleetPanel(req, res) {
   // by the standalone vanilla panel (server/public/fleet-ui/fleet-panel.js) and reshaping it would
   // break a live surface. Follows the same boundary as accountChips above — the server reads
   // privileged local state and the browser receives only a computed percentage, never a token.
-  const accountUsage = await getAccountUsage();
+  // GUARDED, matching getAttentionFlaggedSessions below: this is the only await in the handler that
+  // reaches an external service, and an unguarded throw here would 500 the WHOLE endpoint — the
+  // session list, the chips, everything — not just the strip. getAccountUsage is written never to
+  // throw, so this is defense in depth rather than a known path; the fallback still names every
+  // account, because a silently absent strip is the invisible failure this SD exists to prevent.
+  let accountUsage;
+  try {
+    accountUsage = await getAccountUsage();
+  } catch {
+    accountUsage = allUnavailable('unreachable');
+  }
 
   let attentionStrip = [];
   try {

--- a/server/routes/fleet-panel.js
+++ b/server/routes/fleet-panel.js
@@ -13,6 +13,7 @@ import { createClient } from '@supabase/supabase-js';
 import { computeSessionBadge } from '../../lib/fleet/fleet-view-badges.cjs';
 import { getAttentionFlaggedSessions } from '../../lib/fleet/attention-flag-writer.js';
 import { loadStore, buildNamedAccountChips } from '../../lib/fleet/account-capacity-gauge.cjs';
+import { getAccountUsage } from '../../lib/fleet/account-usage-reader.cjs';
 
 const router = Router();
 
@@ -145,6 +146,13 @@ export async function getFleetPanel(req, res) {
   // capacity store is empty/partial (unmatched accounts render 'wk --%').
   const accountChips = buildNamedAccountChips(loadStore());
 
+  // SD-LEO-FEAT-ACCOUNT-USAGE-STRIP-001 (FR-4): live per-account quota usage, read server-side.
+  // ADDITIVE — deliberately a NEW field rather than a richer accountChips: that field is consumed
+  // by the standalone vanilla panel (server/public/fleet-ui/fleet-panel.js) and reshaping it would
+  // break a live surface. Follows the same boundary as accountChips above — the server reads
+  // privileged local state and the browser receives only a computed percentage, never a token.
+  const accountUsage = await getAccountUsage();
+
   let attentionStrip = [];
   try {
     attentionStrip = await getAttentionFlaggedSessions({ supabase });
@@ -155,6 +163,7 @@ export async function getFleetPanel(req, res) {
   res.json({
     sessions,
     accountChips,
+    accountUsage,
     attentionStrip,
     filter: { liveOnly: !showAll, windowSeconds, truncated, ghostsHidden },
   });

--- a/tests/unit/fleet/account-usage-reader.test.js
+++ b/tests/unit/fleet/account-usage-reader.test.js
@@ -1,0 +1,390 @@
+/**
+ * SD-LEO-FEAT-ACCOUNT-USAGE-STRIP-001 — per-account usage reader.
+ *
+ * These tests exist because the FAILURE modes are the feature. The endpoint is undocumented, so
+ * what matters is not that a happy path returns 54.0 — it is that every other path says so out
+ * loud instead of rendering a number the chairman would read as "plenty of headroom".
+ *
+ * Every fixture injects `fetchImpl` and `fs`, so nothing here touches the real credentials on disk
+ * or the live endpoint. TS-9 is the NEGATIVE CONTROL: a healthy account must come back plain `ok`,
+ * which is what proves the unavailable/stale assertions below are not simply always true.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mod = await import('../../../lib/fleet/account-usage-reader.cjs');
+const {
+  UNAVAILABLE_REASONS,
+  REASON_VALUES,
+  ACCOUNT_REGISTRY,
+  resolveAccountConfigDir,
+  hostDefaultConfigDir,
+  profilesBaseDir,
+  readAccessToken,
+  toPct,
+  readOneAccount,
+  readAllAccounts,
+  getAccountUsage,
+  __resetUsageCache,
+  OAUTH_BETA_HEADER,
+  USAGE_URL,
+} = mod;
+
+const ENV = { USERPROFILE: 'C:\\Users\\test' };
+
+const HOST_DEFAULT_DIR = 'C:\\Users\\test\\.claude';
+const PROFILES_DIR = 'C:\\Users\\test\\.claude-fleet-profiles';
+const DEEPSOUL_DIR = `${PROFILES_DIR}\\deepsoul`;
+
+/**
+ * An fs whose readFileSync serves credentials for the named dirs ONLY, matched EXACTLY.
+ *
+ * Exact, not prefix: '.claude' is a string PREFIX of '.claude-fleet-profiles', so a startsWith
+ * fixture silently served the host-default token to every profile account — which made three
+ * assertions below pass vacuously (an unreadable account looked readable, so "no token leaked"
+ * was proven against a payload that had no successful read in it). The production code joins an
+ * exact path per account and never prefix-matches; this fixture now mirrors that.
+ */
+function fsWithTokens(tokensByDir) {
+  const byPath = new Map(
+    Object.entries(tokensByDir).map(([dir, token]) => [`${dir}\\.credentials.json`, token]),
+  );
+  return {
+    readFileSync: (filePath) => {
+      if (!byPath.has(filePath)) throw new Error('ENOENT');
+      return JSON.stringify({ claudeAiOauth: { accessToken: byPath.get(filePath) } });
+    },
+  };
+}
+
+/** Both live-readable accounts on this host, so a fixture exercises real `ok` readings. */
+function fsWithBothAccounts(hostToken, canaryToken) {
+  return fsWithTokens({ [HOST_DEFAULT_DIR]: hostToken, [CANARY_DIR]: canaryToken });
+}
+
+function usageBody(sevenDay, fiveHour) {
+  return {
+    seven_day: { utilization: sevenDay, resets_at: '2026-08-02T00:00:00Z' },
+    five_hour: { utilization: fiveHour, resets_at: '2026-07-26T22:00:00Z' },
+    // Present-but-null upstream, exactly as research measured. Nothing may read these.
+    cost: null,
+    per_model: null,
+  };
+}
+
+function okResponse(body) {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+const ANY_ENTRY = { name: 'Test Account', profile: 'canary' };
+const CANARY_DIR = 'C:\\Users\\test\\.claude-fleet-profiles\\canary';
+
+beforeEach(() => __resetUsageCache());
+
+describe('account registry (FR-1)', () => {
+  it('names all three chairman-facing accounts', () => {
+    expect(ACCOUNT_REGISTRY.map((e) => e.name)).toEqual([
+      'Deep Soul Sessions',
+      'Code Street Labs',
+      'Rick Felix 2000',
+    ]);
+  });
+
+  it('expresses the HOST DEFAULT as an account config dir, not as a fallback', () => {
+    // resolveProfileDir structurally cannot do this — it only joins under the profiles base dir.
+    const codeStreet = ACCOUNT_REGISTRY.find((e) => e.name === 'Code Street Labs');
+    expect(resolveAccountConfigDir(codeStreet, ENV)).toBe('C:\\Users\\test\\.claude');
+    expect(hostDefaultConfigDir(ENV)).toBe('C:\\Users\\test\\.claude');
+    // ...and it is NOT under the profiles dir, which is the whole reason it needed its own branch.
+    expect(resolveAccountConfigDir(codeStreet, ENV).startsWith(profilesBaseDir(ENV))).toBe(false);
+  });
+
+  it('defaults the profiles base dir when FLEET_ACCOUNT_PROFILES_DIR is unset', () => {
+    // Measured on the live host: the env var is UNSET yet ~/.claude-fleet-profiles/canary holds
+    // real credentials. Throwing (resolveProfileDir's behaviour) would render a readable account
+    // not_configured — a misleading gauge, which this SD forbids.
+    expect(profilesBaseDir(ENV)).toBe('C:\\Users\\test\\.claude-fleet-profiles');
+    expect(resolveAccountConfigDir({ name: 'x', profile: 'canary' }, ENV)).toBe(CANARY_DIR);
+    // An explicitly configured base dir still wins.
+    expect(profilesBaseDir({ ...ENV, FLEET_ACCOUNT_PROFILES_DIR: 'D:\\p' })).toBe('D:\\p');
+  });
+
+  it('does NOT depend on orgName regexes — the honest-value-wrong-question defect', async () => {
+    // account-capacity-gauge.cjs matches /rick\s*felix/i against orgName. The canary profile's
+    // real orgName is "Richard Felix" (verified on host), which that regex MISSES. Identity here
+    // comes from WHICH DIRECTORY supplied the token, so orgName cannot make it drift.
+    const gauge = await import('../../../lib/fleet/account-capacity-gauge.cjs');
+    const rickFelixRegex = gauge.default?.NAMED_ACCOUNT_REGISTRY ?? null;
+    expect(rickFelixRegex).toBeNull(); // not exported — proving we cannot have reused it
+    expect(/rick\s*felix/i.test('Richard Felix')).toBe(false); // the live-value control
+    const src = ACCOUNT_REGISTRY.map((e) => JSON.stringify(e)).join('');
+    expect(src).not.toMatch(/orgName|match|regex/i);
+  });
+
+  it('rejects a traversal/absolute profile name rather than joining it', () => {
+    expect(resolveAccountConfigDir({ name: 'bad', profile: '../../etc' }, ENV)).toBeNull();
+    expect(resolveAccountConfigDir({ name: 'bad', profile: 'C:\\evil' }, ENV)).toBeNull();
+  });
+});
+
+describe('token read (FR-2/FR-7)', () => {
+  it('reads claudeAiOauth.accessToken from the account\'s own credentials file', () => {
+    expect(readAccessToken(CANARY_DIR, fsWithTokens({ [CANARY_DIR]: 'tok-abc' }))).toBe('tok-abc');
+  });
+
+  it('returns null (never throws) on a missing file, bad JSON, or absent token', () => {
+    const boom = { readFileSync: () => { throw new Error('ENOENT'); } };
+    expect(readAccessToken(CANARY_DIR, boom)).toBeNull();
+    expect(readAccessToken(CANARY_DIR, { readFileSync: () => 'not json' })).toBeNull();
+    expect(readAccessToken(CANARY_DIR, { readFileSync: () => '{"claudeAiOauth":{}}' })).toBeNull();
+  });
+});
+
+describe('utilization coercion', () => {
+  it('accepts percent-scaled research values and rounds to one decimal', () => {
+    expect(toPct(54.0)).toBe(54);
+    expect(toPct(11.0)).toBe(11);
+    expect(toPct(33.333)).toBe(33.3);
+  });
+
+  it('rejects non-numbers and out-of-range values rather than coercing them', () => {
+    // A coerced 0 is the forbidden "reads as low usage" outcome.
+    for (const bad of [null, undefined, '54', NaN, Infinity, -1, 101]) {
+      expect(toPct(bad)).toBeNull();
+    }
+  });
+});
+
+describe('per-account read', () => {
+  it('TS-9 NEGATIVE CONTROL — a healthy account returns a plain ok reading', async () => {
+    const fetchImpl = vi.fn(async () => okResponse(usageBody(54, 11)));
+    const result = await readOneAccount(ANY_ENTRY, {
+      env: ENV, fs: fsWithTokens({ [CANARY_DIR]: 'tok' }), fetchImpl, nowMs: 1_000_000,
+    });
+
+    expect(result).toMatchObject({
+      name: 'Test Account',
+      state: 'ok',
+      weeklyPct: 54,
+      fiveHourPct: 11,
+      weeklyResetsAt: '2026-08-02T00:00:00Z',
+    });
+    expect(result.reason).toBeUndefined();
+    expect(result.fetchedAt).toBe(new Date(1_000_000).toISOString());
+  });
+
+  it('sends the REQUIRED anthropic-beta header and the account\'s own bearer token', async () => {
+    const fetchImpl = vi.fn(async () => okResponse(usageBody(54, 11)));
+    await readOneAccount(ANY_ENTRY, {
+      env: ENV, fs: fsWithTokens({ [CANARY_DIR]: 'tok-xyz' }), fetchImpl,
+    });
+
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe(USAGE_URL);
+    expect(init.headers['anthropic-beta']).toBe(OAUTH_BETA_HEADER);
+    expect(init.headers.Authorization).toBe('Bearer tok-xyz');
+  });
+
+  it('TS-2 — HTTP 401 renders unauthorized, with no percentage key at all', async () => {
+    const result = await readOneAccount(ANY_ENTRY, {
+      env: ENV,
+      fs: fsWithTokens({ [CANARY_DIR]: 'tok' }),
+      fetchImpl: async () => ({ ok: false, status: 401, json: async () => ({}) }),
+    });
+
+    expect(result.state).toBe('unavailable');
+    expect(result.reason).toBe(UNAVAILABLE_REASONS.UNAUTHORIZED);
+    // FR-3: the key is ABSENT, not null — a null percentage is what produces the forbidden dash.
+    expect('weeklyPct' in result).toBe(false);
+    expect('fiveHourPct' in result).toBe(false);
+  });
+
+  it('TS-3 — a body missing seven_day.utilization is unexpected_shape, never a 0', async () => {
+    const cases = [
+      { seven_day: {}, five_hour: { utilization: 11 } },
+      usageBody(undefined, 11),
+      usageBody(54, undefined),
+      {},
+    ];
+    for (const body of cases) {
+      const result = await readOneAccount(ANY_ENTRY, {
+        env: ENV,
+        fs: fsWithTokens({ [CANARY_DIR]: 'tok' }),
+        fetchImpl: async () => okResponse(body),
+      });
+      expect(result.reason).toBe(UNAVAILABLE_REASONS.UNEXPECTED_SHAPE);
+      expect('weeklyPct' in result).toBe(false);
+    }
+  });
+
+  it('TS-3b — a non-JSON 200 body is unexpected_shape, not a crash', async () => {
+    const result = await readOneAccount(ANY_ENTRY, {
+      env: ENV,
+      fs: fsWithTokens({ [CANARY_DIR]: 'tok' }),
+      fetchImpl: async () => ({ ok: true, status: 200, json: async () => { throw new Error('bad'); } }),
+    });
+    expect(result.reason).toBe(UNAVAILABLE_REASONS.UNEXPECTED_SHAPE);
+  });
+
+  it('TS-4 — an aborted request renders timeout within the bounded window', async () => {
+    const result = await readOneAccount(ANY_ENTRY, {
+      env: ENV,
+      fs: fsWithTokens({ [CANARY_DIR]: 'tok' }),
+      timeoutMs: 5,
+      // Never settles on its own: only the module's own AbortController can end this.
+      fetchImpl: (url, init) => new Promise((_resolve, reject) => {
+        init.signal.addEventListener('abort', () => {
+          const err = new Error('aborted');
+          err.name = 'AbortError';
+          reject(err);
+        });
+      }),
+    });
+    expect(result.state).toBe('unavailable');
+    expect(result.reason).toBe(UNAVAILABLE_REASONS.TIMEOUT);
+  });
+
+  it('a transport failure renders unreachable, and so does any other non-2xx', async () => {
+    const netFail = await readOneAccount(ANY_ENTRY, {
+      env: ENV,
+      fs: fsWithTokens({ [CANARY_DIR]: 'tok' }),
+      fetchImpl: async () => { throw new Error('ECONNREFUSED'); },
+    });
+    expect(netFail.reason).toBe(UNAVAILABLE_REASONS.UNREACHABLE);
+
+    const serverErr = await readOneAccount(ANY_ENTRY, {
+      env: ENV,
+      fs: fsWithTokens({ [CANARY_DIR]: 'tok' }),
+      fetchImpl: async () => ({ ok: false, status: 500, json: async () => ({}) }),
+    });
+    expect(serverErr.reason).toBe(UNAVAILABLE_REASONS.UNREACHABLE);
+  });
+
+  it('TS-5 — an account with no resolvable credentials is not_configured, never omitted', async () => {
+    const fetchImpl = vi.fn();
+    const result = await readOneAccount(ANY_ENTRY, {
+      env: ENV,
+      fs: { readFileSync: () => { throw new Error('ENOENT'); } },
+      fetchImpl,
+    });
+    expect(result.reason).toBe(UNAVAILABLE_REASONS.NOT_CONFIGURED);
+    expect(result.name).toBe('Test Account');
+    // No token means no upstream call is even attempted.
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe('all-accounts read', () => {
+  it('TS-1 — each account\'s percentage derives from ITS OWN credentials', async () => {
+    // The defect this guards: one host-global figure repeated three times. Distinct tokens must
+    // produce distinct readings.
+    const byToken = { 'tok-cs': usageBody(54, 11), 'tok-rf': usageBody(7, 3) };
+    const fetchImpl = vi.fn(async (_url, init) => {
+      const token = init.headers.Authorization.replace('Bearer ', '');
+      return okResponse(byToken[token]);
+    });
+    const results = await readAllAccounts({
+      env: ENV,
+      fs: fsWithBothAccounts('tok-cs', 'tok-rf'),
+      fetchImpl,
+    });
+
+    expect(results).toHaveLength(3);
+    // Deep Soul resolves to a real path that simply has no credentials behind it.
+    expect(resolveAccountConfigDir(ACCOUNT_REGISTRY[0], ENV)).toBe(DEEPSOUL_DIR);
+    const byName = Object.fromEntries(results.map((r) => [r.name, r]));
+    // Deep Soul has no directory on this host — unreadable, and explicitly SO.
+    expect(byName['Deep Soul Sessions'].reason).toBe(UNAVAILABLE_REASONS.NOT_CONFIGURED);
+    expect(byName['Code Street Labs'].weeklyPct).toBe(54);
+    expect(byName['Rick Felix 2000'].weeklyPct).toBe(7);
+    // The load-bearing assertion: the two live readings DIFFER.
+    expect(byName['Code Street Labs'].weeklyPct)
+      .not.toBe(byName['Rick Felix 2000'].weeklyPct);
+  });
+
+  it('one account failing never suppresses or alters another\'s reading', async () => {
+    const fetchImpl = async (_url, init) => (
+      init.headers.Authorization === 'Bearer tok-bad'
+        ? { ok: false, status: 401, json: async () => ({}) }
+        : okResponse(usageBody(42, 9))
+    );
+    const results = await readAllAccounts({
+      env: ENV,
+      fs: fsWithBothAccounts('tok-good', 'tok-bad'),
+      fetchImpl,
+    });
+    const byName = Object.fromEntries(results.map((r) => [r.name, r]));
+    expect(byName['Rick Felix 2000'].reason).toBe(UNAVAILABLE_REASONS.UNAUTHORIZED);
+    expect(byName['Code Street Labs']).toMatchObject({ state: 'ok', weeklyPct: 42 });
+  });
+
+  it('TS-6 — the serialized payload carries NO token, path, or config dir (FR-7)', async () => {
+    const results = await readAllAccounts({
+      env: ENV,
+      fs: fsWithBothAccounts('sk-ant-oat01-SUPERSECRET-TOKEN-VALUE', 'sk-ant-oat01-OTHER-SECRET'),
+      fetchImpl: async () => okResponse(usageBody(54, 11)),
+    });
+    const serialized = JSON.stringify(results);
+
+    // The control that makes this non-vacuous: there ARE successful readings in this payload, so
+    // a token could actually have leaked through one of them.
+    expect(results.filter((r) => r.state === 'ok')).toHaveLength(2);
+    expect(serialized).not.toContain('SUPERSECRET');
+    expect(serialized).not.toContain('OTHER-SECRET');
+    expect(serialized).not.toContain('sk-ant');
+    expect(serialized).not.toContain('Bearer');
+    expect(serialized).not.toContain('.credentials.json');
+    expect(serialized).not.toMatch(/C:\\\\|\.claude|claude-fleet-profiles/);
+    expect(serialized).not.toContain('CLAUDE_CONFIG_DIR');
+  });
+
+  it('every unavailable reason comes from the CLOSED enum — no raw error text escapes', async () => {
+    const results = await readAllAccounts({
+      env: ENV,
+      fs: fsWithBothAccounts('tok-a', 'tok-b'),
+      // A verbose transport error: none of it may reach the client.
+      fetchImpl: async () => { throw new Error('getaddrinfo ENOTFOUND api.anthropic.com'); },
+    });
+    for (const r of results) {
+      expect(r.state).toBe('unavailable');
+      expect(REASON_VALUES).toContain(r.reason);
+    }
+    // Two accounts genuinely reached the transport path (not_configured would not exercise it).
+    expect(results.filter((r) => r.reason === UNAVAILABLE_REASONS.UNREACHABLE)).toHaveLength(2);
+    const serialized = JSON.stringify(results);
+    expect(serialized).not.toContain('ENOTFOUND');
+    expect(serialized).not.toContain('getaddrinfo');
+  });
+});
+
+describe('caching', () => {
+  it('amortizes upstream calls but never re-serves a stale SUCCESS after expiry', async () => {
+    const fetchImpl = vi.fn(async () => okResponse(usageBody(54, 11)));
+    const opts = { env: ENV, fs: fsWithBothAccounts('tok-a', 'tok-b'), fetchImpl };
+
+    const first = await getAccountUsage({ ...opts, nowMs: 0 });
+    expect(first.filter((r) => r.state === 'ok')).toHaveLength(2); // the reading is real
+    const cached = await getAccountUsage({ ...opts, nowMs: 30_000 });
+    expect(cached).toBe(first);
+    const callsAfterCacheHit = fetchImpl.mock.calls.length;
+
+    // Past the TTL the upstream is consulted again — and if it is now dead, the reading becomes
+    // unavailable rather than continuing to show the last good number.
+    const dead = await getAccountUsage({
+      ...opts,
+      nowMs: 120_000,
+      fetchImpl: async () => { throw new Error('down'); },
+    });
+    expect(fetchImpl.mock.calls.length).toBe(callsAfterCacheHit);
+    expect(dead.every((r) => r.state === 'unavailable')).toBe(true);
+    expect(dead.map((r) => r.name)).toEqual(ACCOUNT_REGISTRY.map((e) => e.name));
+  });
+
+  it('always returns one entry per named account, so none can be silently dropped', async () => {
+    const results = await getAccountUsage({
+      env: ENV, noCache: true, fs: fsWithTokens({}), fetchImpl: async () => okResponse(usageBody(1, 1)),
+    });
+    expect(results.map((r) => r.name)).toEqual([
+      'Deep Soul Sessions', 'Code Street Labs', 'Rick Felix 2000',
+    ]);
+  });
+});

--- a/tests/unit/fleet/account-usage-reader.test.js
+++ b/tests/unit/fleet/account-usage-reader.test.js
@@ -108,16 +108,24 @@ describe('account registry (FR-1)', () => {
     expect(profilesBaseDir({ ...ENV, FLEET_ACCOUNT_PROFILES_DIR: 'D:\\p' })).toBe('D:\\p');
   });
 
-  it('does NOT depend on orgName regexes — the honest-value-wrong-question defect', async () => {
-    // account-capacity-gauge.cjs matches /rick\s*felix/i against orgName. The canary profile's
-    // real orgName is "Richard Felix" (verified on host), which that regex MISSES. Identity here
-    // comes from WHICH DIRECTORY supplied the token, so orgName cannot make it drift.
-    const gauge = await import('../../../lib/fleet/account-capacity-gauge.cjs');
-    const rickFelixRegex = gauge.default?.NAMED_ACCOUNT_REGISTRY ?? null;
-    expect(rickFelixRegex).toBeNull(); // not exported — proving we cannot have reused it
-    expect(/rick\s*felix/i.test('Richard Felix')).toBe(false); // the live-value control
-    const src = ACCOUNT_REGISTRY.map((e) => JSON.stringify(e)).join('');
-    expect(src).not.toMatch(/orgName|match|regex/i);
+  it('does NOT depend on orgName at all — the honest-value-wrong-question defect', async () => {
+    // account-capacity-gauge.cjs matches /rick\s*felix/i against orgName, which MISSES the canary
+    // profile's real orgName "Richard Felix" (verified on host). Identity here comes from WHICH
+    // DIRECTORY supplied the token, so no orgName value can make it drift.
+    //
+    // NARROWED DELIBERATELY: this case used to also assert that NAMED_ACCOUNT_REGISTRY is not
+    // exported and that /rick\s*felix/i fails on 'Richard Felix'. Neither could fail from any
+    // change to the module under test — one describes a different module, the other tests a regex
+    // the test itself wrote. What remains has a real failure mode: reintroducing name-matching.
+    const entryKeys = new Set(ACCOUNT_REGISTRY.flatMap((e) => Object.keys(e)));
+    expect([...entryKeys].sort()).toEqual(['hostDefault', 'name', 'profile']);
+    for (const key of entryKeys) expect(key).not.toMatch(/orgName|match|regex|email/i);
+
+    // And resolution is blind to identity: attaching orgName/email to an entry — including the
+    // exact value that defeats the old regex — cannot change which directory is read.
+    const plain = { name: 'Rick Felix 2000', profile: 'canary' };
+    const withIdentity = { ...plain, orgName: 'Richard Felix', email: 'rickfelix2000@gmail.com' };
+    expect(resolveAccountConfigDir(withIdentity, ENV)).toBe(resolveAccountConfigDir(plain, ENV));
   });
 
   it('rejects a traversal/absolute profile name rather than joining it', () => {
@@ -152,6 +160,15 @@ describe('utilization coercion', () => {
       expect(toPct(bad)).toBeNull();
     }
   });
+
+  it('ADMITS a genuine 0 and a genuine 100 — the boundaries, not just the middle', () => {
+    // 0 is the sharpest case in this SD: a real 0%-used account must render as 0%, while an
+    // UNREADABLE one must never render as 0. That distinction only holds if toPct accepts 0.
+    // A future tidy-up to `if (!value) return null` would silently convert a genuinely idle
+    // account into unexpected_shape, and nothing else here would catch it.
+    expect(toPct(0)).toBe(0);
+    expect(toPct(100)).toBe(100);
+  });
 });
 
 describe('per-account read', () => {
@@ -166,7 +183,8 @@ describe('per-account read', () => {
       state: 'ok',
       weeklyPct: 54,
       fiveHourPct: 11,
-      weeklyResetsAt: '2026-08-02T00:00:00Z',
+      // Canonical ISO, re-derived rather than echoed from upstream (see toIsoOrNull).
+      weeklyResetsAt: '2026-08-02T00:00:00.000Z',
     });
     expect(result.reason).toBeUndefined();
     expect(result.fetchedAt).toBe(new Date(1_000_000).toISOString());
@@ -214,6 +232,55 @@ describe('per-account read', () => {
       expect(result.reason).toBe(UNAVAILABLE_REASONS.UNEXPECTED_SHAPE);
       expect('weeklyPct' in result).toBe(false);
     }
+  });
+
+  it('TS-2b — HTTP 403 is unauthorized too, not lumped into unreachable', async () => {
+    const result = await readOneAccount(ANY_ENTRY, {
+      env: ENV,
+      fs: fsWithTokens({ [CANARY_DIR]: 'tok' }),
+      fetchImpl: async () => ({ ok: false, status: 403, json: async () => ({}) }),
+    });
+    expect(result.reason).toBe(UNAVAILABLE_REASONS.UNAUTHORIZED);
+  });
+
+  it('admits a real 0% reading as ok — never confused with an unreadable account', async () => {
+    const result = await readOneAccount(ANY_ENTRY, {
+      env: ENV,
+      fs: fsWithTokens({ [CANARY_DIR]: 'tok' }),
+      fetchImpl: async () => okResponse(usageBody(0, 0)),
+    });
+    expect(result).toMatchObject({ state: 'ok', weeklyPct: 0, fiveHourPct: 0 });
+    expect(result.reason).toBeUndefined();
+  });
+
+  it('degrades a MISSING resets_at to null without failing the reading', async () => {
+    // The reader documents this as a decision rather than an oversight: the percentage is the
+    // load-bearing value, so losing the display timestamp must not discard a good reading.
+    const result = await readOneAccount(ANY_ENTRY, {
+      env: ENV,
+      fs: fsWithTokens({ [CANARY_DIR]: 'tok' }),
+      fetchImpl: async () => okResponse({
+        seven_day: { utilization: 54 },
+        five_hour: { utilization: 11, resets_at: 'not-a-date' },
+      }),
+    });
+    expect(result).toMatchObject({ state: 'ok', weeklyPct: 54, weeklyResetsAt: null, fiveHourResetsAt: null });
+  });
+
+  it('re-derives resets_at to canonical ISO rather than echoing the upstream string', async () => {
+    // V8's legacy date parser treats parenthesized trailing text as a comment, so this string
+    // parses successfully. Echoing it through would put upstream text in a browser-bound field.
+    const result = await readOneAccount(ANY_ENTRY, {
+      env: ENV,
+      fs: fsWithTokens({ [CANARY_DIR]: 'tok' }),
+      fetchImpl: async () => okResponse({
+        seven_day: { utilization: 54, resets_at: 'Dec 25 1995 (<script>alert(1)</script>)' },
+        five_hour: { utilization: 11, resets_at: '2026-07-27T01:00:00Z' },
+      }),
+    });
+    expect(result.state).toBe('ok');
+    expect(result.weeklyResetsAt).not.toContain('script');
+    expect(result.weeklyResetsAt).toBe(new Date('Dec 25 1995').toISOString());
   });
 
   it('TS-3b — a non-JSON 200 body is unexpected_shape, not a crash', async () => {

--- a/tests/unit/server/fleet-panel-route.test.js
+++ b/tests/unit/server/fleet-panel-route.test.js
@@ -28,8 +28,13 @@ const MOCK_USAGE = [
   { name: 'Code Street Labs', state: 'ok', weeklyPct: 54, fiveHourPct: 11, weeklyResetsAt: '2026-08-02T00:00:00Z', fiveHourResetsAt: null, fetchedAt: '2026-07-26T21:00:00.000Z' },
   { name: 'Rick Felix 2000', state: 'ok', weeklyPct: 11, fiveHourPct: 3, weeklyResetsAt: null, fiveHourResetsAt: null, fetchedAt: '2026-07-26T21:00:00.000Z' },
 ];
+const usageMock = vi.fn(async () => MOCK_USAGE);
 vi.mock('../../../lib/fleet/account-usage-reader.cjs', () => ({
-  getAccountUsage: vi.fn(async () => MOCK_USAGE),
+  getAccountUsage: (...args) => usageMock(...args),
+  // The real helper's behaviour (one entry per registry account) is what the route's safety net
+  // depends on, so the mock mirrors it rather than returning an empty array.
+  allUnavailable: (reason) => ['Deep Soul Sessions', 'Code Street Labs', 'Rick Felix 2000']
+    .map((name) => ({ name, state: 'unavailable', reason, fetchedAt: '2026-07-26T21:00:00.000Z' })),
 }));
 
 const { getFleetPanel } = await import('../../../server/routes/fleet-panel.js');
@@ -257,6 +262,27 @@ describe('GET /api/fleet-panel', () => {
       expect(Object.keys(chip).sort()).toEqual(['name', 'wkPct']);
     }
     expect(payload.accountChips.map((c) => c.name)).toEqual(['Deep Soul', 'Rick Felix', 'CodeStreet']);
+  });
+
+  it('TS-4 at the ROUTE — a throwing usage reader still returns a response, naming every account', async () => {
+    // The reader is written never to throw, so this is the route's defense in depth. It matters
+    // because THIS was the only await in the handler reaching an external service: unguarded, one
+    // throw would 500 the entire endpoint — sessions, chips and all — not merely the strip.
+    usageMock.mockRejectedValueOnce(new Error('reader blew up'));
+    const res = mockRes();
+    await getFleetPanel(mockReq(mockSupabase([LIVE_WORKER])), res);
+
+    expect(res.json).toHaveBeenCalledTimes(1);
+    const payload = res.json.mock.calls[0][0];
+    // The rest of the payload survives intact...
+    expect(payload.sessions).toHaveLength(1);
+    // ...and the strip degrades to a named, explicit unavailable rather than vanishing.
+    expect(payload.accountUsage.map((a) => a.name)).toEqual([
+      'Deep Soul Sessions', 'Code Street Labs', 'Rick Felix 2000',
+    ]);
+    expect(payload.accountUsage.every((a) => a.state === 'unavailable')).toBe(true);
+    expect(payload.accountUsage.some((a) => 'weeklyPct' in a)).toBe(false);
+    usageMock.mockResolvedValue(MOCK_USAGE);
   });
 
   it('returns an empty attentionStrip array (not an error) when zero sessions are flagged', async () => {

--- a/tests/unit/server/fleet-panel-route.test.js
+++ b/tests/unit/server/fleet-panel-route.test.js
@@ -20,6 +20,18 @@ vi.mock('../../../lib/fleet/account-capacity-gauge.cjs', async (importActual) =>
   return { ...actual, loadStore: vi.fn(() => ({})) };
 });
 
+// SD-LEO-FEAT-ACCOUNT-USAGE-STRIP-001: the usage reader is mocked at the ROUTE boundary only —
+// it reads real credentials off disk and calls a live endpoint, neither of which belongs in a unit
+// test. Its own behaviour (every failure mode) is covered in tests/unit/fleet/account-usage-reader.
+const MOCK_USAGE = [
+  { name: 'Deep Soul Sessions', state: 'unavailable', reason: 'not_configured', fetchedAt: '2026-07-26T21:00:00.000Z' },
+  { name: 'Code Street Labs', state: 'ok', weeklyPct: 54, fiveHourPct: 11, weeklyResetsAt: '2026-08-02T00:00:00Z', fiveHourResetsAt: null, fetchedAt: '2026-07-26T21:00:00.000Z' },
+  { name: 'Rick Felix 2000', state: 'ok', weeklyPct: 11, fiveHourPct: 3, weeklyResetsAt: null, fiveHourResetsAt: null, fetchedAt: '2026-07-26T21:00:00.000Z' },
+];
+vi.mock('../../../lib/fleet/account-usage-reader.cjs', () => ({
+  getAccountUsage: vi.fn(async () => MOCK_USAGE),
+}));
+
 const { getFleetPanel } = await import('../../../server/routes/fleet-panel.js');
 
 function mockRes() {
@@ -224,6 +236,27 @@ describe('GET /api/fleet-panel', () => {
     const payload = res.json.mock.calls[0][0];
     expect(payload.sessions[0].model_effort).toBe('opus/--');
     expect(payload.sessions[0].callsign).toBeNull();
+  });
+
+  it('FR-4 — exposes accountUsage additively without reshaping the legacy accountChips (TS-10)', async () => {
+    const res = mockRes();
+    await getFleetPanel(mockReq(mockSupabase([LIVE_WORKER])), res);
+    const payload = res.json.mock.calls[0][0];
+
+    // The new field carries one entry per named account, each with an explicit state.
+    expect(payload.accountUsage.map((a) => a.name)).toEqual([
+      'Deep Soul Sessions', 'Code Street Labs', 'Rick Felix 2000',
+    ]);
+    expect(payload.accountUsage.every((a) => a.state === 'ok' || a.state === 'unavailable')).toBe(true);
+
+    // TS-10: the vanilla panel (server/public/fleet-ui/fleet-panel.js) still gets EXACTLY the
+    // {name, wkPct} shape it parses. Reshaping accountChips instead of adding a field would have
+    // broken that live surface silently.
+    expect(payload.accountChips).toHaveLength(3);
+    for (const chip of payload.accountChips) {
+      expect(Object.keys(chip).sort()).toEqual(['name', 'wkPct']);
+    }
+    expect(payload.accountChips.map((c) => c.name)).toEqual(['Deep Soul', 'Rick Felix', 'CodeStreet']);
   });
 
   it('returns an empty attentionStrip array (not an error) when zero sessions are flagged', async () => {

--- a/tests/unit/server/fleet-panel-route.test.js
+++ b/tests/unit/server/fleet-panel-route.test.js
@@ -264,6 +264,19 @@ describe('GET /api/fleet-panel', () => {
     expect(payload.accountChips.map((c) => c.name)).toEqual(['Deep Soul', 'Rick Felix', 'CodeStreet']);
   });
 
+  it('?refreshUsage=1 bypasses the usage cache; the ordinary poll does not', async () => {
+    // The 60s cache protects an undocumented endpoint from the 15s poll. A deliberate operator
+    // refresh must not be held behind it — otherwise "your sign-in expired" is un-actionable.
+    const plain = mockRes();
+    await getFleetPanel(mockReq(mockSupabase([LIVE_WORKER])), plain);
+    expect(usageMock).toHaveBeenLastCalledWith({});
+
+    const refreshed = mockRes();
+    await getFleetPanel(mockReq(mockSupabase([LIVE_WORKER]), { refreshUsage: '1' }), refreshed);
+    expect(usageMock).toHaveBeenLastCalledWith({ noCache: true });
+    expect(refreshed.json.mock.calls[0][0].accountUsage).toHaveLength(3);
+  });
+
   it('TS-4 at the ROUTE — a throwing usage reader still returns a response, naming every account', async () => {
     // The reader is written never to throw, so this is the route's defense in depth. It matters
     // because THIS was the only await in the handler reaching an external service: unguarded, one


### PR DESCRIPTION
Backend half of **SD-LEO-FEAT-ACCOUNT-USAGE-STRIP-001**. The UI half is a companion PR in the `ehg` repo.

## Why
Quota is the cost currency on this plan. On 2026-07-25 the fleet went down because one account hit its weekly limit and nothing rendered it anywhere. This reads each account's meters directly, per account, server-side.

## The two hard constraints
**Fail visibly.** The endpoint is undocumented, so every failure resolves to an explicit `{state:'unavailable', reason}` from a **closed** enum (`not_configured | unauthorized | unexpected_shape | timeout | unreachable`). On `unavailable` the percentage **key is absent, not null** — a nullable percentage is exactly what produces the forbidden dash. This is deliberately the opposite of `rankAccountsByHeadroom`'s *"unknown reads as 0% used"*: a stale number, a zero and a dash all read as headroom, which is the misreading that let the fleet die.

**The token never goes near the browser.** Bearer token is request-local — never returned, cached, logged or persisted. No config dir, profile name or path in any browser-bound field. Only enum values reach the client, so a raw upstream body or transport error cannot escape through `reason`.

## Design notes worth reviewing
- **Explicit registry, not name-matching.** Identity comes from *which directory supplied the token*. Deliberately not reusing `NAMED_ACCOUNT_REGISTRY` — its `/rick\s*felix/i` does not match the canary profile's real orgName **"Richard Felix"** (verified on host): an honest value answering the wrong question.
- **Two measured departures from `resolveProfileDir`:** the host default is a first-class entry (`resolveProfileDir` structurally cannot express it — the host default splits its files, credentials in `~/.claude/` but config at `~/.claude.json`); and the profiles base dir **defaults instead of throwing**, because `FLEET_ACCOUNT_PROFILES_DIR` is *unset* on the live host while `~/.claude-fleet-profiles/canary` holds real credentials — throwing would render a readable account `not_configured`, a misleading gauge.
- **Additive only.** New `accountUsage` field; `accountChips` keeps its `{name, wkPct}` shape so the standalone vanilla panel is untouched. No new route, no new trust boundary, no schema change.
- **Bounded timeout, 60s cache.** The three accounts fetch in parallel; the cache amortizes calls against an undocumented endpoint. A stale *success* is never re-served — on expiry a dead upstream becomes `unavailable`.

## Verified live on this host (not only under mocks)
```
Code Street Labs   -> ok: weekly 37%, 5h 17%   (HTTP 200)
Deep Soul Sessions -> unavailable: not_configured  (no credentials on this host)
Rick Felix 2000    -> unavailable: unauthorized    (that profile's token expired 14:25Z today)
leak scan over serialized payload: clean
```
The third line is the feature working — an unreadable account says so instead of showing a number.

## Tests
23 new + 1 route case, covering TS-1..TS-6 and TS-10, with **TS-9 as the negative control** so the "renders unavailable" assertions cannot pass on a reader that fails everything.

One fixture bug found and fixed mid-build: `.claude` is a string **prefix** of `.claude-fleet-profiles`, so a `startsWith` fixture served the host token to every account and made three assertions pass *vacuously*. The fixture now matches exact paths, as the production code does.

## PR size
312 source lines (~45% of the new module is doc comment explaining the fail-visible doctrine) + 423 test lines. Above the 100-line target, within the 400 max: the failure modes *are* the feature, and TS-1..TS-10 were mandated by the PRD.

## Pre-existing failures, unrelated to this PR
`tests/unit/fleet/spawn-control.js` (1) and `cp3-restart-relaunch-live-flag-propagation` (2) fail on this host. Reproduced in isolation with none of my files in the run, and neither imports anything this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
