### PR TITLE
fix(SD-LEO-FEAT-FLEET-COLD-START-UX-001): canary guard was case-sensitive and bypassable

### DIFF
--- a/lib/fleet/role-startup-prompt.js
+++ b/lib/fleet/role-startup-prompt.js
@@ -19,7 +19,7 @@
  *   - respawnFleet, whose roles come from fleet_desired_slots and are deliberately un-allowlisted.
  */
 
-import { classifySessionByCallsign } from './startup-prompt-selection.js';
+import { classifySessionByCallsign, couldBeCanaryCallsign } from './startup-prompt-selection.js';
 
 /** The roles an operator may spawn from the Sessions page. */
 export const SPAWNABLE_ROLES = Object.freeze(['coordinator', 'worker', 'solomon', 'adam']);
@@ -59,7 +59,14 @@ export function isSpawnableRole(role) {
  * canaries: startup-prompt-selection.js's own header forbids role-keying for precisely this reason.
  */
 export function resolveRoleSpawnOpts(role) {
-  const prompt = ROLE_STARTUP_PROMPTS[role];
+  // Object.hasOwn, not a bare lookup — corrected after review. ROLE_STARTUP_PROMPTS is a plain
+  // object literal, so Object.prototype is on its chain and resolveRoleSpawnOpts('toString') or
+  // ('constructor') previously returned { startupPrompt: <Function> } with the key PRESENT: the
+  // exact pointer-suppression defect this function exists to prevent, reachable by any future
+  // caller that does not run the allowlist first. The route does run it, so this was latent rather
+  // than live — but the exported function carries no allowlist of its own, and the test's stated
+  // guarantee ("omits the key for an unknown role") was broader than the code delivered.
+  const prompt = Object.hasOwn(ROLE_STARTUP_PROMPTS, role) ? ROLE_STARTUP_PROMPTS[role] : undefined;
   return prompt === undefined ? {} : { startupPrompt: prompt };
 }
 
@@ -75,15 +82,40 @@ export function resolveRoleSpawnOpts(role) {
  * null prompt.
  */
 export function assertRoleCallsignCompatible(role, callsign) {
-  const { kind } = classifySessionByCallsign(callsign);
-  if (kind === 'canary' && role !== 'worker') {
+  if (role === 'worker') return { ok: true, reason: null };
+
+  // CASE-INSENSITIVE, via the shared predicate — corrected after a SECURITY review measured the
+  // bypass. This shipped delegating to classifySessionByCallsign, which matches 'Canary-' EXACTLY,
+  // so 'canary-pilot' and 'CANARY-pilot' were ALLOWED to receive '/coordinator start'. That is the
+  // could-this-be-a-canary question asked with the is-this-exactly-a-canary predicate, and the
+  // module I delegated to documents that asymmetry in its own SEC-1 block. Worse, SEC-1's own
+  // case-insensitive deny is STRUCTURALLY UNREACHABLE from this path: setting opts.startupPrompt
+  // short-circuits defaultStartupPrompt, so resolveStartupPromptForCallsign never runs for a
+  // non-worker role. This is the only guard, so it must ask the broad question.
+  if (couldBeCanaryCallsign(callsign)) {
     return {
       ok: false,
       reason:
-        `callsign "${callsign}" is in the canary namespace, which may only be spawned with ` +
-        `role "worker" — a canary started as "${role}" would receive that role's directive and, ` +
-        `for coordinator, would take over the fleet coordinator pointer`,
+        `callsign "${callsign}" is in the canary namespace (matched case-insensitively), which may ` +
+        `only be spawned with role "worker" — a canary started as "${role}" would receive that ` +
+        `role's directive and, for coordinator, would take over the fleet coordinator pointer`,
     };
   }
+
+  // UNIDENTIFIABLE refuses too. A non-string, empty or whitespace callsign classifies as
+  // unidentifiable rather than canary, so branching on kind==='canary' alone let ["Canary-pilot"],
+  // {} and "   " through for role=coordinator — the array form being a literal laundering of the
+  // value blocked above. This mirrors resolveStartupPromptForCallsign's own unidentifiable arm:
+  // an unidentified session must not receive a privileged directive.
+  const { kind } = classifySessionByCallsign(callsign);
+  if (kind === 'unidentifiable') {
+    return {
+      ok: false,
+      reason:
+        `callsign is not a usable identifier, so role "${role}" cannot be granted — an ` +
+        'unidentified session must never receive a privileged startup directive',
+    };
+  }
+
   return { ok: true, reason: null };
 }

--- a/lib/fleet/startup-prompt-selection.js
+++ b/lib/fleet/startup-prompt-selection.js
@@ -64,6 +64,24 @@ export function isCanaryCallsign(callsign) {
   return classifySessionByCallsign(callsign).kind === 'canary';
 }
 
+/**
+ * "COULD this be a canary?" — the broad, CASE-INSENSITIVE question, as opposed to
+ * classifySessionByCallsign's exact-prefix "IS this a canary?".
+ *
+ * Extracted (SD-LEO-FEAT-FLEET-COLD-START-UX-001, after a SECURITY review found the two had already
+ * drifted once) so every site that must DENY on possible-canary shares one definition. The asymmetry
+ * is documented in full at the SEC-1 block below: over-matching breaks drills, but UNDER-matching
+ * hands a canary a directive it must never receive — so any deny decision uses this, and only
+ * targeting uses the exact form.
+ *
+ * The drift this closes: assertRoleCallsignCompatible (role-startup-prompt.js) shipped delegating to
+ * the EXACT predicate, so 'canary-pilot' and 'CANARY-pilot' were refused by SEC-1 on the worker path
+ * while being ALLOWED to receive '/coordinator start' on the new role path — measured, not theorised.
+ */
+export function couldBeCanaryCallsign(callsign) {
+  return /^canary-/i.test(String(callsign ?? '').trim());
+}
+
 /** Thrown by assertSingleLinePrompt. Named so callers can distinguish it from an IO failure. */
 export class MultilinePromptError extends Error {
   constructor(message, details) {
@@ -161,7 +179,7 @@ export function resolveStartupPromptForCallsign(callsign, prompts) {
   // This says "could this be a canary?" — UNDER-matching here hands a canary the claiming directive.
   // So deny broadly. A worker legitimately named 'canary-something' losing its prompt is a session
   // that idles; the inverse is an unattended session that claims work.
-  if (kind === 'worker' && /^canary-/i.test(String(callsign).trim())) {
+  if (kind === 'worker' && couldBeCanaryCallsign(callsign)) {
     logFn(`[startup-prompt] callsign ${JSON.stringify(String(callsign))} is in the canary namespace `
       + 'by case-insensitive match but not the exact prefix. DENYING the worker directive: a misnamed '
       + 'canary must never be able to claim work. Fix the slot name to the exact "Canary-" prefix.');

--- a/tests/unit/fleet/role-startup-prompt.test.js
+++ b/tests/unit/fleet/role-startup-prompt.test.js
@@ -81,4 +81,50 @@ describe('assertRoleCallsignCompatible — coordinator-pointer hijack (FR-2, TS-
       expect(assertRoleCallsignCompatible(role, 'Alpha-2').ok).toBe(true);
     }
   });
+
+  // The bypasses a SECURITY review MEASURED against the first shipped version of this guard. Each
+  // one delivered '/coordinator start' to a canary. They are pinned individually rather than as a
+  // loop over one spelling, because one spelling is exactly how the gap survived review the
+  // first time.
+  it.each(['canary-pilot', 'CANARY-pilot', 'CaNaRy-pilot', 'canary-', '  Canary-pilot  '])(
+    'refuses canary-namespace callsign %j regardless of case or padding',
+    (callsign) => {
+      expect(assertRoleCallsignCompatible('coordinator', callsign).ok).toBe(false);
+    },
+  );
+
+  it('still allows those same spellings with role=worker — canaries ARE workers', () => {
+    // Control arm. Without it, a guard that simply refused every canary-ish callsign would pass
+    // the block above while breaking canary provisioning outright.
+    for (const callsign of ['canary-pilot', 'CANARY-pilot', 'Canary-pilot']) {
+      expect(assertRoleCallsignCompatible('worker', callsign).ok).toBe(true);
+    }
+  });
+
+  it('refuses an UNIDENTIFIABLE callsign for a privileged role', () => {
+    // These classify as 'unidentifiable', not 'canary', so a kind==='canary' branch let them
+    // through. The array form is a literal laundering of the value blocked above.
+    for (const callsign of [['Canary-pilot'], {}, '   ', '', null, undefined, 123]) {
+      const verdict = assertRoleCallsignCompatible('coordinator', callsign);
+      expect(verdict.ok, `expected refusal for ${JSON.stringify(callsign)}`).toBe(false);
+    }
+  });
+
+  it('does not refuse an ordinary callsign as unidentifiable', () => {
+    // Pairs with the above so the refusal cannot be over-broad and pass by refusing everything.
+    expect(assertRoleCallsignCompatible('coordinator', 'Coordinator-1').ok).toBe(true);
+  });
+});
+
+describe('resolveRoleSpawnOpts — prototype-chain keys (latent pointer suppression)', () => {
+  it('OMITS the key for inherited Object.prototype members', () => {
+    // ROLE_STARTUP_PROMPTS is a plain literal, so a bare lookup returned
+    // { startupPrompt: <Function> } for these — key PRESENT, which is precisely the
+    // pointer-suppression defect this function exists to prevent. Not reachable through the route
+    // (the allowlist runs first), but the exported function carries no allowlist of its own.
+    for (const key of ['constructor', 'toString', 'valueOf', 'hasOwnProperty', '__proto__']) {
+      const opts = resolveRoleSpawnOpts(key);
+      expect(Object.hasOwn(opts, 'startupPrompt'), `leaked via ${key}`).toBe(false);
+    }
+  });
 });


### PR DESCRIPTION
The guard I shipped in #6530 to stop a canary receiving the coordinator directive was
defeated by one character. Found by the EXEC SECURITY review, which MEASURED it rather
than reading it:

  REFUSED  Canary-pilot   <- the only spelling I tested
  ALLOWED  canary-pilot   -> spawns, delivers /coordinator start
  ALLOWED  CANARY-pilot   -> spawns, delivers /coordinator start
  ALLOWED  canary-        -> spawns, delivers /coordinator start

ROOT CAUSE, and it is not subtle. classifySessionByCallsign matches the prefix EXACTLY,
which is correct for TARGETING. This guard asks the opposite question. The module I
delegated to spells the asymmetry out in its own SEC-1 block: targeting asks is-this-
exactly-a-canary, where over-matching breaks drills; a deny asks could-this-be-a-canary,
where UNDER-matching hands a canary a directive it must never receive. I asked the second
question with the first predicate.

Worse, the case-insensitive deny I assumed was behind me is STRUCTURALLY UNREACHABLE from
this path: setting opts.startupPrompt short-circuits defaultStartupPrompt, so
resolveStartupPromptForCallsign never runs for a non-worker role. This guard is the ONLY
one. The build-session-launch backstop does not help either - it throws only when the
prompt is byte-equal to the WORKER directive.

FIX: extracted couldBeCanaryCallsign to startup-prompt-selection.js and used it at BOTH
decision sites, so the exact and broad predicates cannot drift apart again. That drift is
what produced this.

TWO MORE FROM THE SAME REVIEW:

1. UNIDENTIFIABLE was allowed. The guard branched on kind==='canary', but ["Canary-pilot"],
   {}, "   " and 123 classify as unidentifiable, not canary - so they passed for
   role=coordinator. The array form is a literal laundering of the value being blocked.
   Now refused, mirroring resolveStartupPromptForCallsign's own unidentifiable arm.

2. resolveRoleSpawnOpts leaked prototype-chain keys. ROLE_STARTUP_PROMPTS is a plain
   literal, so ('toString') returned { startupPrompt: <Function> } with the key PRESENT -
   the exact pointer-suppression defect that function exists to prevent. Latent, since the
   allowlist runs first at the route, but my test's stated guarantee was broader than the
   code delivered. Now uses Object.hasOwn.

Every bypass the review measured is pinned individually rather than as a loop over one
spelling - one spelling is exactly how this survived the first review. Control arms keep
role=worker working on the same callsigns, so canary provisioning is not broken by the fix.

Mutation-verified: restoring the exact-prefix predicate turns those 4 cases red.
1225 tests pass across 99 files.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

---

Follow-up to #6530, from the EXEC-phase SECURITY review of that PR. The guard #6530 added is the control this SD went out of its way to build, and it did not hold. Shipping the correction rather than deferring it, since the SD is still at EXEC and this is my own freshly-shipped defect.

**Not a capability gain over what the route already allowed** — `role=coordinator` + `callsign='Charlie'` was equally permitted and equally delivered `/coordinator start`. What the bypass defeated was the specific invariant this SD established. But the spelling that slipped through is materially *harder to remediate* than the one blocked: `assertCanaryTarget` requires `isCanaryCallsign`, so a coordinator running as `canary-pilot` is refused by `canaryStop`/`canaryRestart` with `not_canary_callsign`. `Canary-pilot` would have been killable; `canary-pilot` is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)