### PR TITLE
fix: restore the pre-commit smoke gate (blocking all commits repo-wide since 10:56)

### DIFF
--- a/tests/smoke.test.js
+++ b/tests/smoke.test.js
@@ -11,15 +11,19 @@ import dotenv from 'dotenv';
 dotenv.config();
 
 
-// Gate on a real database. CI without secrets sets the synthetic
-// 'test.invalid.local' URL via tests/setup.js — every assertion that touches
-// a real Supabase table fails (or worse, passes vacuously after a soft-error
-// from the JS client) under that URL. SD-LEO-INFRA-COVERAGE-CI-TRIAGE-001
-// CAPA CA-1: gate the suite so CI skips cleanly.
-const HAS_REAL_DB = process.env.SUPABASE_URL
-  && !process.env.SUPABASE_URL.includes('test.invalid.local')
-  && process.env.SUPABASE_SERVICE_ROLE_KEY
-  && !process.env.SUPABASE_SERVICE_ROLE_KEY.includes('test-service-role-key-not-real');
+// Gate on a DESIGNATED non-production database — imported, never re-derived.
+//
+// This file used to carry its own copy of the gate: a NEGATIVE check asserting the URL was not
+// 'test.invalid.local' and the key was not 'test-service-role-key-not-real'. That predicate is
+// exactly the defect QF-20260726-459 was raised to close, because it evaluates TRUE AGAINST
+// PRODUCTION — a real URL and a real key satisfy "is not the fake sentinel". tests/helpers/
+// db-available.js re-pointed HAS_REAL_DB at the positive designated-target predicate for the 119
+// call sites that gate on it directly; this file was never migrated and kept the old logic.
+//
+// It matters more here than anywhere else: this suite runs on EVERY commit via .husky/pre-commit,
+// so an unsafe predicate here reads live production on every commit in the repo. Re-deriving the
+// check locally is precisely how the original defect survived its own test suite.
+import { HAS_REAL_DB } from './helpers/db-available.js';
 describe.skipIf(!HAS_REAL_DB)('Smoke Tests - Critical System Validation', () => {
   describe('Environment Configuration', () => {
     test('should have Supabase URL configured', () => {

--- a/tests/unit/quarantine-manifest.test.js
+++ b/tests/unit/quarantine-manifest.test.js
@@ -76,7 +76,17 @@ describe('quarantine-manifest shape (debt register integrity)', () => {
     expect(config).toContain('quarantine-manifest.json');
     expect(config).toContain('QUARANTINE_EXCLUDE');
     // The unit project's exclude must include the quarantine list.
-    expect(config).toMatch(/exclude:\s*\[\.\.\.SHARED_EXCLUDE,\s*\.\.\.DB_INCLUDE,\s*\.\.\.QUARANTINE_EXCLUDE\]/);
+    //
+    // Matches the required spreads IN ORDER but tolerates additional ones between them, rather than
+    // pinning the exact adjacency. The old regex demanded literally
+    // [...SHARED_EXCLUDE, ...DB_INCLUDE, ...QUARANTINE_EXCLUDE] and so failed the moment a fourth
+    // legitimate spread was added (...SMOKE_INCLUDE, restoring the pre-commit smoke gate) — a
+    // source-pin breaking on an unrelated edit, not a real regression. The INVARIANT this test
+    // exists to protect is unchanged and still enforced: removing QUARANTINE_EXCLUDE from the unit
+    // project's exclude still fails here.
+    expect(config).toMatch(
+      /exclude:\s*\[[^\]]*\.\.\.SHARED_EXCLUDE[^\]]*\.\.\.DB_INCLUDE[^\]]*\.\.\.QUARANTINE_EXCLUDE[^\]]*\]/,
+    );
   });
 
   it('this test file itself is not quarantined (self-hosting guard)', () => {

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -99,9 +99,28 @@ const DB_INCLUDE = [
   '**/tests/database/**/*.test.js',
   '**/tests/db-invariants/**/*.test.js',
   '**/tests/migration-readiness/**/*.test.js',
-  '**/tests/smoke.test.js',
   '**/*.db.test.js',
 ];
+
+/**
+ * The pre-commit smoke gate, in its OWN project — deliberately NOT part of DB_INCLUDE.
+ *
+ * WHY IT IS SEPARATE: QF-20260726-459 Part 1b (d031c798f86) gated the whole db PROJECT behind
+ * DB_TARGET.allowed, which was correct for the 225 DB suites. But tests/smoke.test.js was a member
+ * of DB_INCLUDE, so gating the project made it a member of ZERO projects — and `.husky/pre-commit`
+ * runs `vitest run tests/smoke.test.js` unconditionally. A filter that matches no file exits 1, so
+ * EVERY commit in the repo failed from 2026-07-26 10:56 onward. The outage was invisible in CI
+ * because it only manifests through the commit hook.
+ *
+ * This project is UNGATED on purpose: the gate belongs at runtime, inside the suite, not at file
+ * discovery. The file must always be FOUND (so the hook can run it and exit 0); whether it executes
+ * live queries is decided by the shared production-ref-aware predicate it imports.
+ *
+ * It stays out of the `unit` tier — see the unit project's exclude, which lists this constant. The
+ * suite calls dotenv.config() at module top level regardless of setupFiles, so admitting it to
+ * `unit` would leak real credentials into the unit tier.
+ */
+const SMOKE_INCLUDE = ['**/tests/smoke.test.js'];
 
 // ─── QF-20260726-459 Part 1b: gate the PROJECT, not the individual files ────────────────────────
 //
@@ -216,7 +235,10 @@ export default defineConfig({
           ],
           // QUARANTINE_EXCLUDE: tracked red files (tests/quarantine-manifest.json)
           // — SD-LEO-FIX-GREEN-MAIN-TRIAGE-001. The manifest is the debt register.
-          exclude: [...SHARED_EXCLUDE, ...DB_INCLUDE, ...QUARANTINE_EXCLUDE],
+          // SMOKE_INCLUDE is listed explicitly: it used to be covered by DB_INCLUDE, and removing
+          // it from there must not silently admit the smoke suite (and its real credentials) into
+          // the unit tier.
+          exclude: [...SHARED_EXCLUDE, ...DB_INCLUDE, ...SMOKE_INCLUDE, ...QUARANTINE_EXCLUDE],
         },
       },
       {
@@ -231,6 +253,20 @@ export default defineConfig({
           exclude: SHARED_EXCLUDE,
           // A gated-empty project must not fail the run: skipping IS the safe end state here.
           passWithNoTests: true,
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: 'smoke',
+          // Same real-credential setup as the db tier — the suite is read-only and gates itself at
+          // runtime on the shared designated-target predicate, so pointing at an undesignated
+          // target makes it SKIP, not run.
+          setupFiles: ['./tests/setup.db.js'],
+          // UNGATED by design. See SMOKE_INCLUDE: the pre-commit hook filters to this exact file,
+          // and a filter that resolves to zero files exits 1 and blocks every commit in the repo.
+          include: SMOKE_INCLUDE,
+          exclude: SHARED_EXCLUDE,
         },
       },
     ],


### PR DESCRIPTION
## Summary

**The pre-commit smoke gate has blocked every commit in this repo since 10:56 today.** Any worker running `git commit` on a non-exempt branch hits:

```
Running smoke tests before commit...
No test files found, exiting with code 1
husky - pre-commit script failed (code 1)
```

**Root cause:** `d031c798f86` (QF-20260726-459 Part 1b) gated the db **project** behind `DB_TARGET.allowed` — correct for the 225 DB suites. But `tests/smoke.test.js` was a member of `DB_INCLUDE`, so gating the project made it a member of **zero** projects, while `.husky/pre-commit` still runs `vitest run tests/smoke.test.js` unconditionally. A filter matching no file exits 1. Invisible in CI, because it only manifests through the commit hook.

## Restoring project membership alone would have been harmful

`tests/smoke.test.js` carried its **own** pre-QF copy of the gate:

```js
const HAS_REAL_DB = process.env.SUPABASE_URL
  && !process.env.SUPABASE_URL.includes('test.invalid.local')
  && ...
```

That is the exact defect QF-20260726-459 exists to close: a **negative** check that **evaluates true against production**, since a real URL and a real key both satisfy "is not the fake sentinel." `db-available.js` re-pointed `HAS_REAL_DB` at the positive designated-target predicate for its 119 direct call sites; this file was never migrated. It matters more here than anywhere else — **this suite runs on every commit**, so simply making it reachable again would have read live production on every commit in the repo.

So this PR is two changes, both required:

1. **`tests/smoke.test.js`** imports the shared gate instead of re-deriving it.
2. **`vitest.config.js`** gets `SMOKE_INCLUDE` and an **ungated** `smoke` project. The gate belongs at *runtime*, inside the suite — not at file discovery. The file must always be **found** so the hook can run it and exit 0; whether it executes live queries is decided by the imported predicate. `SMOKE_INCLUDE` is also added explicitly to the `unit` project's exclude, because `DB_INCLUDE` used to cover that — without it the suite (which calls `dotenv.config()` at module top level regardless of `setupFiles`) would leak real credentials into the unit tier.

## Test plan

| Check | Result |
|---|---|
| `npm run test:smoke` | **exit 0** — `1 skipped (15 skipped)`: found, and does **not** query production against the undesignated ref |
| `vitest --project unit tests/smoke.test.js` | `No test files found` — still correctly excluded from the unit tier |
| `vitest --project unit tests/unit/worktree-guards.test.js` | 15/15 pass — unit tier unaffected |
| `git commit` on this branch | **succeeds** — the hook that was blocking everyone now passes. That commit is the end-to-end proof. |

## Blast radius

None of the other 224 `DB_INCLUDE` files change reachability — they stay behind `DB_INCLUDE_GATED` exactly as Part 1b intended. Only `tests/smoke.test.js` regains project membership; it is read-only (`.select().limit(1)`) and is now gated by the same production-ref-aware predicate as everything else, so it stays skipped until someone sets a matching `VITEST_DB_ALLOW_REF`. Nothing here weakens the QF-20260726-459 safety mechanism.

Found while working SD-LEO-INFRA-CLAIM-LIVENESS-FENCE-001, which could not commit. Root-caused via the RCA sub-agent rather than bypassed with `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
