### PR TITLE
fix(QF-20260726-423b): tree-currency refusal must name BEING BEHIND as the fault, not the dirt

### DIFF
--- a/lib/fleet/tree-currency.cjs
+++ b/lib/fleet/tree-currency.cjs
@@ -262,10 +262,40 @@ function enforceTreeCurrency({
       + `${assessment.error ? ` — ${assessment.error}` : ''}]`
     : '';
 
+  // QF-20260726-423(b): SEPARATE THE FAULT FROM THE REMEDY-BLOCKER.
+  //
+  // The previous wording ran the two together — "N behind and NOT safely healable (dirty=…)
+  // — refusing rather than mutating a dirty tree" — which reads as though DIRT is what
+  // failed the check. It is not, and that misreading has already cost real time: the row
+  // that commissioned this change described the guard as one that "refuses a spawn from the
+  // chronically-dirty shared root" and posed the design question as whether "spawn should
+  // not require a clean root". Spawn does not require a clean root. assessTreeCurrency
+  // returns current:true whenever behind === 0 REGARDLESS of dirty; dirt enters in exactly
+  // one place (selfHealable = !dirty && branch === SELF_HEALABLE_BRANCH), where it disables
+  // the automatic fast-forward. So BEING BEHIND is the fault; DIRT only blocks the auto-fix.
+  //
+  // Stating that split explicitly is the whole point of this edit — the guard's behaviour is
+  // deliberately UNCHANGED. Nothing here relaxes it, and the dirty/off-branch self-heal
+  // refusal stays exactly as it was, because mutating a dirty or off-branch tree risks
+  // clobbering a peer worktree.
+  const blocker = assessment.reason !== 'behind' ? null
+    : assessment.dirty && assessment.branch !== SELF_HEALABLE_BRANCH
+      ? `the tree is DIRTY and on '${assessment.branch}' rather than '${SELF_HEALABLE_BRANCH}'`
+      : assessment.dirty ? 'the tree is DIRTY'
+        : assessment.branch !== SELF_HEALABLE_BRANCH
+          ? `the tree is on '${assessment.branch}' rather than '${SELF_HEALABLE_BRANCH}'`
+          : null;
+
   const why = assessment.reason === 'behind'
-    ? `${assessment.behind} commit(s) behind ${baseRef} and NOT safely healable `
-      + `(dirty=${assessment.dirty}, branch=${assessment.branch}) — refusing rather than mutating a `
-      + `dirty or off-branch tree, which would risk clobbering a peer worktree`
+    ? `THE FAULT IS BEING BEHIND: ${assessment.behind} commit(s) behind ${baseRef}`
+      + (blocker
+        // Behind AND un-healable: name why the auto-fix could not run, and be explicit that
+        // the dirt is not itself the failure — otherwise the reader "fixes" the wrong thing.
+        ? `. The auto-fast-forward could not run because ${blocker} `
+          + `(dirty=${assessment.dirty}, branch=${assessment.branch}); refusing rather than mutating a `
+          + `dirty or off-branch tree, which would risk clobbering a peer worktree. `
+          + `NOTE: dirt alone never fails this check — a dirty tree that is CURRENT passes`
+        : `. Self-heal was permitted but the tree is still not current`)
     : `currency could not be established (reason=${assessment.reason})${detail}`;
 
   throw new TreeStaleError(

--- a/lib/fleet/tree-currency.cjs
+++ b/lib/fleet/tree-currency.cjs
@@ -295,7 +295,14 @@ function enforceTreeCurrency({
           + `(dirty=${assessment.dirty}, branch=${assessment.branch}); refusing rather than mutating a `
           + `dirty or off-branch tree, which would risk clobbering a peer worktree. `
           + `NOTE: dirt alone never fails this check — a dirty tree that is CURRENT passes`
-        : `. Self-heal was permitted but the tree is still not current`)
+        // Clean AND on the base branch, so a fast-forward WOULD have been safe — this path is
+        // reached only when the CALLER forbade healing (allowSelfHeal:false, which is the
+        // reaper's deliberate posture: unattended, shared root, refusing costs it nothing).
+        // The failed-fast-forward and did-not-converge cases throw earlier with their own
+        // messages, so they never land here. Saying "self-heal was permitted" would be exactly
+        // backwards for the only caller that reaches this branch.
+        : `. A fast-forward would have been safe (clean, on '${SELF_HEALABLE_BRANCH}') but this `
+          + `caller may not heal (allowSelfHeal=${allowSelfHeal}) — it refuses rather than mutating a shared tree`)
     : `currency could not be established (reason=${assessment.reason})${detail}`;
 
   throw new TreeStaleError(

--- a/tests/unit/fleet/tree-currency.test.js
+++ b/tests/unit/fleet/tree-currency.test.js
@@ -194,6 +194,19 @@ describe('TS-3: the decision table (injected runner)', () => {
     expect(r.selfHealable).toBe(false);
   });
 
+  // QF-20260726-423(b): DIRT IS NOT THE FAULT — BEING BEHIND IS.
+  //
+  // This is the semantic the commissioning row got wrong: it described the guard as one that
+  // "refuses a spawn from the chronically-dirty shared root" and asked whether "spawn should
+  // not require a clean root". Spawn never required a clean root. Pinning it here so the next
+  // reader cannot re-derive the same wrong conclusion from prose.
+  it('LOAD-BEARING: a DIRTY tree that is CURRENT passes — dirt alone never fails the check', () => {
+    const r = assessTreeCurrency({ dir: '/x', runner: runnerFor({ behind: '0', dirty: ' M a.txt\n M b.txt\n' }) });
+    expect(r.current).toBe(true);   // <-- dirt is irrelevant when behind === 0
+    expect(r.dirty).toBe(true);
+    expect(r.reason).toBe('current');
+  });
+
   it('behind + OFF-MAIN => NOT-CURRENT and NOT self-healable', () => {
     const r = assessTreeCurrency({ dir: '/x', runner: runnerFor({ behind: '4', branch: 'feat/x' }) });
     expect(r.current).toBe(false);
@@ -262,6 +275,36 @@ describe('FR-2: enforceTreeCurrency self-heals or REFUSES', () => {
       dir: '/x', runner: runnerFor({ behind: '4', branch: 'feat/x', calls }), env: {}, logger: silent,
     })).toThrow(/REFUSED/);
     expect(calls.some((c) => c.startsWith('pull'))).toBe(false);
+  });
+
+  // QF-20260726-423(b): the refusal message must SEPARATE the fault from the remedy-blocker.
+  // The old wording ran them together and read as though dirt failed the check; that misreading
+  // is on the record — it is how the commissioning row framed the whole problem.
+  it('the DIRTY refusal names BEING BEHIND as the fault and says dirt alone never fails the check', () => {
+    let msg = '';
+    try {
+      enforceTreeCurrency({
+        dir: '/x', runner: runnerFor({ behind: '4', dirty: ' M a.txt\n' }), env: {}, logger: silent,
+      });
+    } catch (e) { msg = e.message; }
+    expect(msg).toContain('THE FAULT IS BEING BEHIND');
+    expect(msg).toContain('4 commit(s) behind');
+    expect(msg).toContain('the tree is DIRTY');            // named as the BLOCKER, not the fault
+    expect(msg).toContain('dirt alone never fails this check');
+    // still states the real hazard it refuses to risk
+    expect(msg).toContain('clobbering a peer worktree');
+  });
+
+  it('the OFF-MAIN refusal names the BRANCH as the blocker and does not blame dirt', () => {
+    let msg = '';
+    try {
+      enforceTreeCurrency({
+        dir: '/x', runner: runnerFor({ behind: '2', branch: 'feat/x' }), env: {}, logger: silent,
+      });
+    } catch (e) { msg = e.message; }
+    expect(msg).toContain('THE FAULT IS BEING BEHIND');
+    expect(msg).toContain("on 'feat/x' rather than 'main'");
+    expect(msg).not.toContain('the tree is DIRTY');        // clean tree must not be called dirty
   });
 
   it('a git ERROR REFUSES — fail closed, never proceed on uncertainty', () => {

--- a/tests/unit/fleet/tree-currency.test.js
+++ b/tests/unit/fleet/tree-currency.test.js
@@ -295,6 +295,27 @@ describe('FR-2: enforceTreeCurrency self-heals or REFUSES', () => {
     expect(msg).toContain('clobbering a peer worktree');
   });
 
+  // Caught in self-review of this very change: the clean+on-main fall-through is reached ONLY
+  // when the CALLER forbade healing (the reaper's allowSelfHeal:false). An earlier draft of the
+  // message said "self-heal was permitted" there, which is exactly backwards for the only caller
+  // that gets here — the failed-fast-forward and did-not-converge cases throw earlier.
+  it('a clean on-main tree refused because the CALLER may not heal says so, and does not claim self-heal was permitted', () => {
+    const calls = [];
+    let msg = '';
+    try {
+      enforceTreeCurrency({
+        dir: '/x', runner: runnerFor({ behind: '5', calls }), env: {}, logger: silent, allowSelfHeal: false,
+      });
+    } catch (e) { msg = e.message; }
+    expect(msg).toContain('THE FAULT IS BEING BEHIND');
+    expect(msg).toContain('may not heal');
+    expect(msg).toContain('allowSelfHeal=false');
+    expect(msg).not.toContain('Self-heal was permitted');
+    expect(msg).not.toContain('the tree is DIRTY');       // it is clean; do not blame dirt
+    // and it must genuinely not have mutated the tree
+    expect(calls.some((c) => c.startsWith('pull'))).toBe(false);
+  });
+
   it('the OFF-MAIN refusal names the BRANCH as the blocker and does not blame dirt', () => {
     let msg = '';
     try {


### PR DESCRIPTION
## QF-20260726-423 part (b) — the tree-currency refusal blamed the wrong thing

Part (a) is deliberately **not** in this PR (see below).

### The row that commissioned this got the mechanism wrong, and the message is why
QF-20260726-423 describes the guard as one that *"refuses a spawn from the chronically-dirty shared root"* and poses the design question as whether *"spawn should not require a clean root."*

**Spawn never required a clean root.** Read at source, then confirmed by executing the real guard against the live shared root:
```
{"current":false,"selfHealable":false,"reason":"behind","behind":3,"dirty":true,"branch":"main"}
```
`reason` is **`behind`**, not dirty. `assessTreeCurrency` returns `current:true` whenever `behind === 0` *regardless of* `dirty` (line 141). Dirt enters in exactly one place — `selfHealable = !dirty && branch === SELF_HEALABLE_BRANCH` (line 150) — where it disables the automatic fast-forward.

So **being behind is the fault; dirt or an off-branch checkout is only a remedy-blocker.** The old message ran the two together:
> `N commit(s) behind … and NOT safely healable (dirty=true, branch=main) — refusing rather than mutating a dirty or off-branch tree`

which reads as though dirt failed the check. That misreading is on the record — it's how the commissioning row framed the entire problem, and it nearly cost me a wrong fix too.

### The change
The refusal now states which is which, names the specific blocker, and says outright that dirt alone never fails the check.

**Behaviour is deliberately unchanged.** The row warned against silently relaxing this guard and that warning is right — the dirty/off-branch self-heal refusal stands exactly as before, because mutating a dirty or off-branch tree risks clobbering a peer worktree. This is a diagnostics change only.

### Tests
- the dirty refusal names **being behind** as the fault, names dirt as the *blocker*, still cites the peer-worktree hazard
- the off-branch refusal names the branch and does **not** call a clean tree dirty
- **characterization pin:** a DIRTY tree that is CURRENT passes (`current:true`, `reason:'current'`) — the exact semantic the row got wrong

Mutation-verified: replacing the `THE FAULT IS BEING BEHIND` prefix fails both message tests, with the mutation confirmed present via `grep -c` before reading the result. The characterization pin does **not** bite on this change — it pins pre-existing correct behaviour that was merely mis-described, and I'd rather say so than imply it's a regression guard.

Suite: **94 files / 1189 tests pass.**

### The decision the row actually asked for (recorded, not implemented here)
The row said to decide deliberately which side is wrong and record it. My answer is **neither**:

1. *Keep the root clean* — non-durable. It has carried 41–58 dirty files all night, much of it another session's legitimate in-progress work. A protection whose precondition is humans keeping a shared tree pristine fails continuously.
2. *Let self-heal run on a dirty tree* — rejected, and the code already says why. That's the silent relaxation the row forbids.
3. **Decouple the execution source from the human-shared root** — spawn and the reaper run from a dedicated always-current checkout. Human dirt becomes irrelevant and the invariant is preserved *absolutely* rather than relaxed.

The mistake is that the execution source and the human working tree are **the same tree** — the coupling is the defect, not either side of it. (3) is an architectural change (a managed checkout, its refresh cadence, repointing two subsystems) and is an SD, not a ≤50 LOC QF; it is **not** started here.

### Part (a) untouched, on purpose
The row says *"do not let (a) design work hold (b) hostage."* (a) is the Add-session 401 needing a **scoped** credential — a real design task with a security constraint and named prior art to read (the FOLD-LEO Sessions view behind `ProtectedRouteWrapper`, passing the operator's own JWT). I have not designed it and have **not** gone near the app-wide admin bypass, which the row explicitly forbids widening. It deserves its own row.
