### PR TITLE
fix: unblock all commits — test:smoke fails on the gated db project

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "flags:review": "node scripts/flag-governance-review.mjs",
     "flags:stale": "node scripts/flags-stale.mjs",
     "flags:enroll": "node scripts/enroll-env-var-feature-flags.mjs",
-    "test:smoke": "vitest run tests/smoke.test.js",
+    "test:smoke": "vitest run tests/smoke.test.js --passWithNoTests",
     "test:session-tick": "node --test tests/unit/session-tick-heartbeat.test.mjs tests/unit/session-tick-release-on-exit.test.mjs tests/unit/session-tick-spawn-observe.test.mjs",
     "test:sd-key-generator-gate": "node --test tests/unit/sd-key-generator-coverage.test.mjs",
     "test:unit": "vitest run --project unit",


### PR DESCRIPTION
## Every commit in this repo currently fails

`.husky/pre-commit` runs `npm run test:smoke` → `vitest run tests/smoke.test.js`. My merge of **QF-20260726-459 Part 1b** (`ff95433c142`) gates the db vitest project to **zero files** unless a designated non-production target is named — and `tests/smoke.test.js` is matched by `DB_INCLUDE`. So the command resolves nothing and exits 1, failing the hook.

I hit this committing my own work on an unrelated SD.

### I got the blast radius wrong, and this is the correction

I told the coordinator developer commits were unaffected. I had grepped `.husky/` for `test:db`, `test:integration`, and `--project db` — and never considered that the hook invokes `test:smoke`, whose target file lives in the db project. **I checked for the names I expected instead of what the hook actually runs.**

### Why `--passWithNoTests` is the right fix, not a paper-over

`tests/smoke.test.js` already self-skips without a database — it wraps its suite in `describe.skipIf(!HAS_REAL_DB)`. So:

| | behaviour |
|---|---|
| Before the gate | file runs, all 15 tests **skip**, exit 0 |
| After the gate | file not found, **exit 1** |

The assertions were already inert. This restores the prior *effective* behaviour rather than silencing something that was running.

### Verified both directions

| condition | result |
|---|---|
| gate closed, no flag | **EXIT=1** — the breakage |
| gate closed, with flag | EXIT=0 |
| gate **open** (`VITEST_DB_ALLOW_REF` matching), with flag | file **is collected and runs** |

The third row is the control: the flag tolerates only the genuine zero-file case; it does not blanket-pass a real run.

### Flagged, not fixed here

`tests/smoke.test.js:19-22` still re-derives the **old** sentinel predicate inline — the one answering "is a DB reachable" rather than "is it safe to write here". It's one of the ~53 inline copies QF-459 never consolidated and should import the shared guard. Out of scope for an unblock-everything hotfix.
