### PR TITLE
fix(QF-20260726-575): spawn-control docblock reads 'INERT BY DEFAULT' while the flag is set on this host — reasoning about spawn safety from the header returns 'safe' about an armed surface

### DIFF
--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -8,11 +8,36 @@
  * DB adapter over SD-A's pure registry/manifest libs. Adds the three genuinely-new pieces: window-handle
  * capture (window-handle.js), CLAUDE_CONFIG_DIR profile injection, and this six-verb composition layer.
  *
- * SAFETY -- STAGED / INERT BY DEFAULT (mirrors WORKER_SPAWN_EXECUTOR_LIVE, TR-4): the live OS spawn
- * (a visible Windows Terminal process) is default-OFF behind FLEET_SPAWN_CONTROL_LIVE. With the flag
- * unset every verb that would spawn/relaunch a process instead logs the invocation it WOULD run and
- * returns { live:false, invocation }. Flipping the flag on requires the same operator host-validation
- * gate worker-spawn-executor.cjs already documents (the exact wt.exe invocation is host-specific).
+ * SAFETY -- THE DEFAULT IS INERT. THIS HOST MAY NOT BE. *** DO NOT READ THIS COMMENT AS THE ANSWER
+ * TO "IS SPAWNING ARMED RIGHT NOW". *** The live OS spawn (a visible Windows Terminal process) is
+ * default-OFF behind FLEET_SPAWN_CONTROL_LIVE. With the flag unset every verb that would
+ * spawn/relaunch a process instead logs the invocation it WOULD run and returns
+ * { live:false, invocation }. Flipping the flag on requires the same operator host-validation gate
+ * worker-spawn-executor.cjs already documents (the exact wt.exe invocation is host-specific).
+ *
+ * HOW TO CHECK THE ACTUAL STATE (QF-20260726-575). A static comment cannot track an env var, and
+ * this one previously opened "STAGED / INERT BY DEFAULT" on a host where the flag WAS set -- so a
+ * reader answering "is this safe to touch" from the header got the wrong answer in the PERMISSIVE
+ * direction. In order of reliability:
+ *   1. GET /api/fleet-panel -> spawnControl.live
+ *   2. isLiveEnabled() from this module, IN THE PROCESS YOU CARE ABOUT
+ *
+ * WHY (1) IS AUTHORITATIVE, and it is not "because the server loads .env": it reports the state of
+ * THE PROCESS THAT WOULD ACTUALLY PERFORM THE SPAWN. This flag is per-process, not per-host, so the
+ * only honest answer is the one measured inside the spawning process.
+ *
+ * *** DO NOT infer it from process.env in some OTHER process. *** FLEET_SPAWN_CONTROL_LIVE lives in
+ * .env, so a bare `node -e "process.env.FLEET_SPAWN_CONTROL_LIVE"` prints undefined on a host where
+ * the flag is set -- and ABSENT READS AS INERT, the same permissive-direction error by a second
+ * route that never touches this comment. Measured while writing this fix: a probe run from a git
+ * WORKTREE resolved a .env that does not exist there, injected 0 vars, and reported live:false on
+ * this armed host. Nothing was wrong with the code -- that process really was inert. Which is the
+ * whole point: ask the process that spawns, not a comment and not a different process.
+ *
+ * (The original text claimed parity with WORKER_SPAWN_EXECUTOR_LIVE. That is a DESIGN-INTENT note
+ * about a different variable, not a statement about this gate: isLiveEnabled() reads
+ * FLEET_SPAWN_CONTROL_LIVE and nothing else. Kept here as history so the parenthetical is not
+ * re-added as if it described the mechanism.)
  */
 import { spawn as spawnProcess } from 'node:child_process';
 import path from 'node:path';

--- a/server/routes/fleet-panel.js
+++ b/server/routes/fleet-panel.js
@@ -14,6 +14,7 @@ import { computeSessionBadge } from '../../lib/fleet/fleet-view-badges.cjs';
 import { getAttentionFlaggedSessions } from '../../lib/fleet/attention-flag-writer.js';
 import { loadStore, buildNamedAccountChips } from '../../lib/fleet/account-capacity-gauge.cjs';
 import { getAccountUsage, allUnavailable } from '../../lib/fleet/account-usage-reader.cjs';
+import { isLiveEnabled } from '../../lib/fleet/spawn-control.js';
 
 const router = Router();
 
@@ -179,6 +180,16 @@ export async function getFleetPanel(req, res) {
     accountUsage = allUnavailable('unreachable');
   }
 
+  // QF-20260726-575: the RESOLVED spawn live-state, so "is the live OS spawn armed on this host"
+  // is answerable by OBSERVATION instead of by reading a static docblock that cannot track an env
+  // var. spawn-control.js opened "STAGED / INERT BY DEFAULT" on a host where the flag was SET, so a
+  // reader got the wrong answer in the PERMISSIVE direction — and a bare process.env read is the
+  // same error by a second route, because FLEET_SPAWN_CONTROL_LIVE lives in .env and reads as
+  // undefined until it is loaded. This server always has env loaded, which is what makes it the
+  // authoritative answer. Calls the SAME exported predicate the verbs gate on — deliberately not a
+  // re-implemented env read, which would be free to drift from the thing it claims to describe.
+  const spawnControl = { live: isLiveEnabled() };
+
   let attentionStrip = [];
   try {
     attentionStrip = await getAttentionFlaggedSessions({ supabase });
@@ -190,6 +201,7 @@ export async function getFleetPanel(req, res) {
     sessions,
     accountChips,
     accountUsage,
+    spawnControl,
     attentionStrip,
     filter: { liveOnly: !showAll, windowSeconds, truncated, ghostsHidden },
   });

--- a/tests/unit/server/fleet-panel-route.test.js
+++ b/tests/unit/server/fleet-panel-route.test.js
@@ -37,6 +37,15 @@ vi.mock('../../../lib/fleet/account-usage-reader.cjs', () => ({
     .map((name) => ({ name, state: 'unavailable', reason, fetchedAt: '2026-07-26T21:00:00.000Z' })),
 }));
 
+// QF-20260726-575: isLiveEnabled is mocked so the test can drive BOTH arms. Importing the real one
+// would make the assertion depend on whether THIS host happens to have FLEET_SPAWN_CONTROL_LIVE set
+// — i.e. the test would agree with the host instead of checking the route, and would pass just as
+// happily against a hardcoded `live: true`.
+const liveEnabledMock = vi.fn(() => false);
+vi.mock('../../../lib/fleet/spawn-control.js', () => ({
+  isLiveEnabled: (...args) => liveEnabledMock(...args),
+}));
+
 const { getFleetPanel } = await import('../../../server/routes/fleet-panel.js');
 
 function mockRes() {
@@ -296,6 +305,43 @@ describe('GET /api/fleet-panel', () => {
     expect(payload.accountUsage.every((a) => a.state === 'unavailable')).toBe(true);
     expect(payload.accountUsage.some((a) => 'weeklyPct' in a)).toBe(false);
     usageMock.mockResolvedValue(MOCK_USAGE);
+  });
+
+  it('QF-575 — reports the RESOLVED spawn live-state, tracking the predicate in both directions', async () => {
+    // The defect this closes: spawn-control.js asserted "STAGED / INERT BY DEFAULT" in a static
+    // docblock while the flag was SET on the host, so a reader answering "is spawning armed" got
+    // the wrong answer in the PERMISSIVE direction. Observation replaces prose.
+    liveEnabledMock.mockReturnValue(true);
+    const armed = mockRes();
+    await getFleetPanel(mockReq(mockSupabase([LIVE_WORKER])), armed);
+    expect(armed.json.mock.calls[0][0].spawnControl).toEqual({ live: true });
+
+    // THE CONTROL THAT MATTERS: it must be able to say false. Without this, the assertion above
+    // passes identically against a hardcoded `live: true`, which is the same class of always-on
+    // reading the docblock defect was made of.
+    liveEnabledMock.mockReturnValue(false);
+    const inert = mockRes();
+    await getFleetPanel(mockReq(mockSupabase([LIVE_WORKER])), inert);
+    expect(inert.json.mock.calls[0][0].spawnControl).toEqual({ live: false });
+
+    // And it is the module's own exported predicate being consulted, not a re-derived env read that
+    // would be free to drift from the gate the verbs actually use.
+    expect(liveEnabledMock).toHaveBeenCalled();
+    liveEnabledMock.mockReturnValue(false);
+  });
+
+  it('QF-575 — spawnControl is additive: it does not disturb the existing payload fields', async () => {
+    const res = mockRes();
+    await getFleetPanel(mockReq(mockSupabase([LIVE_WORKER])), res);
+    const payload = res.json.mock.calls[0][0];
+
+    expect(payload.sessions).toHaveLength(1);
+    expect(payload.accountChips).toHaveLength(3);
+    expect(payload.accountUsage).toHaveLength(3);
+    expect(payload.filter).toMatchObject({ liveOnly: true });
+    // Present on every response, never conditional — an absent field reads as "not armed".
+    expect(payload.spawnControl).toBeDefined();
+    expect(typeof payload.spawnControl.live).toBe('boolean');
   });
 
   it('returns an empty attentionStrip array (not an error) when zero sessions are flagged', async () => {


### PR DESCRIPTION
## Quick-Fix: QF-20260726-575

**Type:** bug
**Severity:** high

### Issue Description
SAFETY-REASONING HAZARD. Not a crash — a doc/state divergence that makes a reader conclude SAFE about a surface that is ARMED. Found by the coordinator; I re-derived it independently and the conclusion holds while the stated mechanism does not, so the corrected mechanism is recorded here.

*** THE HAZARD *** lib/fleet/spawn-control.js:11 opens 'SAFETY -- STAGED / INERT BY DEFAULT'. On this host the gate is SET: FLEET_SPAWN_CONTROL_LIVE=true (WORKER_SPAWN_EXECUTOR_LIVE is unset). isLiveEnabled() at :92 therefore returns TRUE and the live OS spawn — a real Windows Terminal process — will actually run. Anyone who reads the header to answer 'is spawning safe to touch right now' gets the wrong answer IN THE PERMISSIVE DIRECTION. The coordinator reports nearly concluding 'release gains nothing because spawn is inert', which would have been backwards.

*** CORRECTED MECHANISM — do not fix the wrong thing *** The original report said the docblock NAMES THE WRONG VARIABLE and that isLiveEnabled reads a DIFFERENT one. That is not so, and fixing it as stated would close the row without closing the hazard. :12 says verbatim 'default-OFF behind FLEET_SPAWN_CONTROL_LIVE' — which IS what isLiveEnabled() reads at :92. The docblock names the correct gate. The only misleading token is the parenthetical '(mirrors WORKER_SPAWN_EXECUTOR_LIVE, TR-4)', a design-parity claim about a second variable, not the gate.

So the defect is NOT a naming error. It is that a STATIC header asserts a DYNAMIC fact. 'Inert by default' is true of the default and false of this host, and the reader has no signal telling them which they are in.

*** FIX SHAPE *** Make the live/inert state observable at the moment of reasoning rather than asserted in prose. Options, implementer's call: (a) have the module log its resolved live-state on load, so it appears wherever spawn code runs; (b) expose the resolved state on the fleet-panel payload so the UI can show that spawning is armed; (c) at minimum, reword the header so it states the DEFAULT and points at how to check the ACTUAL — 'default-OFF; call isLiveEnabled() or read FLEET_SPAWN_CONTROL_LIVE to see this host's state' — and drop or clarify the mirrors-parenthetical. (a) or (b) beats (c): prose cannot track env.

*** DO NOT ACCEPT *** Editing only the parenthetical and closing the row — that fixes a token and leaves 'INERT BY DEFAULT' as the first and most memorable line a reader sees on a host where it is armed. Also do not flip the flag off: this is a documentation/observability defect, and the live path is what makes operator respawn work at all.

### Steps to Reproduce
Read lib/fleet/spawn-control.js:11-16, then run: node -e "require('dotenv').config();console.log(process.env.FLEET_SPAWN_CONTROL_LIVE)"

### Expected Behavior
A reader can tell from the module whether the live spawn surface is armed on THIS host

### Actual Behavior
The header asserts 'STAGED / INERT BY DEFAULT' while FLEET_SPAWN_CONTROL_LIVE=true, so the surface is live and reads as inert

### Changes
- **Files Changed:** 3
  - lib/fleet/spawn-control.js
  - server/routes/fleet-panel.js
  - tests/unit/server/fleet-panel-route.test.js
- **LOC:** 42 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol