### PR TITLE
fix(QF-20260726-409): D8 measures dead-lettering, the signal its provenance always claimed

### DIFF
--- a/lib/adam/self-assessment.cjs
+++ b/lib/adam/self-assessment.cjs
@@ -105,9 +105,32 @@ const SCORERS = {
     if (s.advisory_deliverability == null) return { score: null, provenance: 'no advisory_deliverability signal (inconclusive)' };
     const r = s.advisory_deliverability;
     const score = r >= 0.98 ? 5 : r >= 0.9 ? 4 : r >= 0.75 ? 3 : r >= 0.5 ? 2 : 1;
-    return { score, signal: `advisory_deliverability=${r}`, provenance: 'advisories delivered vs dead-lettered' };
+    return { score, signal: `advisory_deliverability=${r}`, provenance: 'advisories delivered vs dead-lettered (payload.dead_letter, e.g. target_dead)' };
   },
 };
+
+/**
+ * QF-20260726-409 — the D8 numerator, extracted as a PURE function so the predicate that decides
+ * "delivered" is testable against fixtures instead of only being exercised by a live Supabase query
+ * inside the writer.
+ *
+ * DELIVERED MEANS NOT DEAD-LETTERED. It deliberately does NOT mean `read_at != null`: that is the
+ * recipient's inbox-drain rate, it carries no Adam-side signal, and measured against live data it
+ * inverted this dimension outright — all 27 dead-lettered advisories in the sample had a non-null
+ * read_at, so every genuine delivery failure scored as a success.
+ *
+ * Returns null (INCONCLUSIVE) rather than 1.0 for an empty set — a fabricated perfect score is worse
+ * than an admitted absence of signal, and the scorer already has an inconclusive arm for null.
+ */
+function computeAdvisoryDeliverability(rows) {
+  if (!Array.isArray(rows)) return null;
+  const adv = rows.filter((r) => r && r.payload && r.payload.kind === 'adam_advisory');
+  if (adv.length === 0) return null;
+  // Strict === true: dead_letter is simply absent on healthy rows, and truthy-coercion would let a
+  // future non-boolean value silently mark an advisory undelivered.
+  const delivered = adv.filter((r) => r.payload.dead_letter !== true).length;
+  return delivered / adv.length;
+}
 
 const ADAM_CONFIG = {
   role: 'adam',
@@ -167,6 +190,7 @@ module.exports = {
   ACTION_HINTS,
   SCORERS,
   ADAM_CONFIG,
+  computeAdvisoryDeliverability,
   shouldFire,
   freshState,
   scoreDimensions,

--- a/scripts/adam-self-assessment-writer.cjs
+++ b/scripts/adam-self-assessment-writer.cjs
@@ -94,19 +94,48 @@ async function gatherSignals(sb) {
     }
   })();
 
-  // D8: advisory deliverability = adam_advisory rows read / total (last 7d)
+  // D8: advisory deliverability = adam_advisory rows DELIVERED (not dead-lettered) / total, last 7d.
+  //
+  // QF-20260726-409. This previously counted `read_at != null`, which is a RECIPIENT READ RATE, not
+  // deliverability -- it told you how promptly the coordinator drains its inbox and contained no
+  // Adam-side signal at all. Two consequences, both measured against live data before this change:
+  //
+  //  1. IT INVERTED THE SIGNAL ITS OWN PROVENANCE CLAIMS. Of 218 live adam_advisory rows, 27 are
+  //     dead-lettered (payload.dead_letter === true, every one reason 'target_dead') -- and ALL 27
+  //     carry a non-null read_at. So each genuine delivery FAILURE was being scored as a success.
+  //     Real delivery rate 0.876; the read-rate proxy was scoring 0.729.
+  //  2. IT COULD NOT BE SATISFIED. Every advisory is created with read_at NULL, so sending more
+  //     advisories LOWERED the score whenever the recipient's drain lagged -- penalising exactly the
+  //     behaviour D8 exists to encourage, with no action available to Adam that improved it.
+  //
+  // Dead-lettering IS the Adam-controlled signal, and it is the one D8 already documents: the
+  // dimension is defined as 'clear advisories, CORRECT LANE/TARGET, <=1 per tick', and 'target_dead'
+  // means the advisory was addressed to a session that was not alive. So the provenance string
+  // 'advisories delivered vs dead-lettered' was right all along -- the code simply never implemented
+  // it. Fixed by implementing it literally rather than by renaming the dimension to match the broken
+  // measurement (the D8 key is load-bearing: leo_protocol_sections id=601, CLAUDE_ADAM.md, the
+  // coordinator hourly-review prompt, and every historical adam_self_assessment feedback row).
+  //
+  // A fresh advisory is not dead-lettered, so recency no longer counts as failure and no settle
+  // window is needed.
   signals.advisory_deliverability = await (async () => {
     try {
+      // The 'last 7d' the old comment asserted was never implemented -- there was NO date filter,
+      // just an unordered .limit(500). It spanned ~7d only because Adam has only been sending for
+      // ~7d (293 rows total, under the cap), so the cap was not even binding yet: as volume grows
+      // the window would have silently narrowed instead. Filter and ordering are now explicit.
+      const sinceIso = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
       const { data, error } = await sb
         .from('session_coordination')
         .select('read_at, payload')
         .eq('sender_type', 'adam')
+        .gte('created_at', sinceIso)
+        .order('created_at', { ascending: false })
         .limit(500);
       if (error || !Array.isArray(data) || data.length === 0) return null;
-      const adv = data.filter((r) => r.payload && r.payload.kind === 'adam_advisory');
-      if (adv.length === 0) return null;
-      const delivered = adv.filter((r) => r.read_at != null).length;
-      return delivered / adv.length;
+      // Delegates to the shared pure predicate rather than re-implementing it here — one definition
+      // of "delivered", unit-tested against fixtures.
+      return core.computeAdvisoryDeliverability(data);
     } catch {
       return null;
     }

--- a/tests/unit/adam/self-assessment.test.js
+++ b/tests/unit/adam/self-assessment.test.js
@@ -202,3 +202,55 @@ describe('isFlagEnabled (ADAM_SELF_SCORE_CADENCE)', () => {
     expect(isFlagEnabled({ ADAM_SELF_SCORE_CADENCE: 'TRUE' })).toBe(true);
   });
 });
+
+describe('computeAdvisoryDeliverability (QF-20260726-409)', () => {
+  // NB: payload is built LAST. Spreading `over` after it would re-add the caller's raw payload and
+  // silently drop kind:'adam_advisory', so every fixture would be filtered out and the tests would
+  // pass for the wrong reason.
+  const adv = (over = {}) => ({ ...over, payload: { kind: 'adam_advisory', ...(over.payload || {}) } });
+
+  it('THE REGRESSION GUARD: a dead-lettered advisory is NOT delivered even though it was read', () => {
+    // The exact live shape that inverted D8 — all 27 dead-lettered rows in the sample carried a
+    // non-null read_at, so the old `read_at != null` predicate scored every delivery FAILURE as a
+    // success. A read-rate implementation passes this file's other cases but fails this one.
+    const rows = [
+      adv({ read_at: '2026-07-26T00:00:00Z', payload: { dead_letter: true, dead_letter_reason: 'target_dead' } }),
+      adv({ read_at: '2026-07-26T00:00:00Z' }),
+    ];
+    expect(core.computeAdvisoryDeliverability(rows)).toBe(0.5);
+  });
+
+  it('an UNREAD but successfully delivered advisory counts as delivered', () => {
+    // The other half of the old defect: a freshly-sent advisory was counted as a failure until the
+    // recipient got round to reading it, so sending more advisories lowered the score.
+    const rows = [adv({ read_at: null }), adv({ read_at: null })];
+    expect(core.computeAdvisoryDeliverability(rows)).toBe(1);
+  });
+
+  it('ignores rows that are not adam advisories', () => {
+    const rows = [
+      adv({ read_at: null }),
+      { read_at: null, payload: { kind: 'coordinator_request' } },
+      { read_at: null, payload: null },
+    ];
+    expect(core.computeAdvisoryDeliverability(rows)).toBe(1);
+  });
+
+  it('returns null (inconclusive) rather than a fabricated 1.0 when there are no advisories', () => {
+    expect(core.computeAdvisoryDeliverability([])).toBeNull();
+    expect(core.computeAdvisoryDeliverability([{ payload: { kind: 'other' } }])).toBeNull();
+    expect(core.computeAdvisoryDeliverability(null)).toBeNull();
+  });
+
+  it('does not truthy-coerce dead_letter — only a strict true marks an advisory undelivered', () => {
+    const rows = [adv({ payload: { dead_letter: false } }), adv({ payload: { dead_letter: 'no' } })];
+    expect(core.computeAdvisoryDeliverability(rows)).toBe(1);
+  });
+
+  it('CONTROL: the D8 scorer still bands the value it is given, unchanged', () => {
+    // Proves the tests above are not passing because scoring stopped happening.
+    expect(core.SCORERS.D8_interface_clarity({ advisory_deliverability: 0.876 }).score).toBe(3);
+    expect(core.SCORERS.D8_interface_clarity({ advisory_deliverability: 0.99 }).score).toBe(5);
+    expect(core.SCORERS.D8_interface_clarity({ advisory_deliverability: null }).score).toBeNull();
+  });
+});


### PR DESCRIPTION
`D8_interface_clarity` scored `read_at != null` — a **recipient inbox-drain rate** with no Adam-side signal in it. The QF row diagnosed that correctly. But measuring the live data before building refuted the row on *why*, and the truth is worse than reported.

## The metric was scoring delivery failures as successes

The row states nothing is dead-lettered, and that the provenance describes a failure mode that does not occur. Measured against live data:

| | |
|---|---|
| live `adam_advisory` rows | 218 |
| `dead_letter === true` | **27** (every one `reason=target_dead`) |
| of those, with a **non-null `read_at`** | **27 of 27** |
| real delivery rate | 0.876 |
| what the read-rate proxy scored | 0.729 |

Every genuine delivery failure was counted as a success, because a dead-lettered advisory still gets read.

## So the fix is not a rename

The provenance string *"advisories delivered vs dead-lettered"* was right all along — the code simply never implemented it. And `target_dead` is squarely Adam-controlled, matching D8's own definition (`self-assessment.cjs:42`): *"clear advisories, **correct lane/target**, <=1 per tick"*. Implemented literally rather than renaming the dimension to match the broken measurement.

The `D8` key is left alone deliberately — it is load-bearing across `leo_protocol_sections` id=601, `CLAUDE_ADAM.md`, the coordinator hourly-review prompt, and every historical `adam_self_assessment` feedback row. Renaming it is well beyond a QF.

This also removes the unsatisfiable-by-construction problem **without** needing a settle window: advisories are created with `read_at` NULL, so sending more used to lower the score whenever the recipient's drain lagged. A fresh advisory is simply not dead-lettered.

## Latent window defect, with a correction to the row

The `last 7d` comment was never implemented — no date filter, just an unordered `.limit(500)`. Refining the row's account: the cap is **not binding yet** (293 rows total), so the query returned *every Adam row ever* and spanned ~7d only because Adam has been sending for ~7d. Filter and ordering are now explicit.

## Tests

Predicate extracted as a pure exported function so it is tested against fixtures rather than only through a live Supabase query. **22 pass (was 16)**, including a control that the D8 scorer still bands normally. The regression guard is falsifiable — the old read-rate implementation returns `1.0` where it asserts `0.5`.

D1_proactive_sourcing is untouched; the row explicitly leaves that finding standing and so do I.

🤖 Generated with [Claude Code](https://claude.com/claude-code)