### PR TITLE
fix(QF-20260726-425): stop the pre-claim evidence probe blocking a proven self-owner

### DIFF
--- a/lib/claim/reacquire-self-live.mjs
+++ b/lib/claim/reacquire-self-live.mjs
@@ -232,10 +232,46 @@ export async function reacquireSelfLiveClaim(supabase, opts = {}) {
     // FR-2(b): no live foreign holder. allowReclaim === false means a live
     // holder blocks reclaim; anything else (unclaimed/clean, dead ghost, or
     // query degradation returning allowReclaim:true) permits it.
+    //
+    // QF-20260726-425 ITEM A — THE PROBE COULD BLOCK A *PROVEN* SELF-OWNER, and would have done so
+    // on the general case while passing on the specimen that motivated the fix.
+    //
+    // With no session claim, triangulate classifies the SD as 'orphaned' and computes
+    // reclaimSafe = !hasEvidenceOfLife, where evidence-of-life is branch_present /
+    // plan_file_present / recent_sub_agent_activity (triangulate.js:365-371, :423). Those signals
+    // are attributed to NO SESSION. So an EXEC-phase SD whose feature branch exists, or whose long
+    // sub-agent run just wrote a sub_agent_execution_results row — WHICH IS THE VERY CONDITION THAT
+    // CREATES THIS BUG — sets hasEvidenceOfLife and the probe returns allowReclaim:false. We would
+    // then abort as 'live_foreign_holder' against evidence that is OUR OWN.
+    //
+    // So when self-ownership is POSITIVELY PROVEN (worktree witness, or a deterministic own-session
+    // whose sd_key matches), those signals are read as SELF evidence and do not block. We STILL
+    // refuse when a DIFFERENT session is genuinely live on the SD — 'healthy' (claim + alive +
+    // fresh) and 'stale_alive' (claim + stale but PID alive or tick recent).
+    //
+    // STEAL-SAFETY IS UNCHANGED, and does not rest on this gate: the CAS below writes only where
+    // claiming_session_id IS NULL or already equals self, so a foreign claim can never be clobbered
+    // no matter what the probe says. This gate is defence-in-depth, and widening it for a proven
+    // self-owner cannot make a foreign claim reclaimable.
+    const LIVE_FOREIGN_CLASSIFICATIONS = new Set(['healthy', 'stale_alive']);
     let allowReclaim = true;
     try {
       const evidence = await checkPreClaimEvidence(supabase, sdKey, { mySessionId: ownership.sessionId || undefined });
-      allowReclaim = evidence?.allowReclaim !== false;
+      const classification = evidence?.classification ?? null;
+      if (evidence?.allowReclaim === false && !LIVE_FOREIGN_CLASSIFICATIONS.has(classification)) {
+        // Blocked only by evidence-of-life that this session owns.
+        log(JSON.stringify({
+          event: 'claim_reacquire_self_evidence_override',
+          sd_key: sdKey,
+          via: ownership.via,
+          classification,
+          evidence: evidence?.evidence || [],
+          note: 'evidence-of-life attributed to no session; ownership proven, so treated as SELF evidence (QF-20260726-425 item A)',
+        }));
+        allowReclaim = true;
+      } else {
+        allowReclaim = evidence?.allowReclaim !== false;
+      }
     } catch (egErr) {
       // Fail-open on the evidence probe ONLY (matches sweep's own degradation
       // policy); the CAS guard below still prevents clobbering a foreign claim.

--- a/scripts/modules/handoff/executors/BaseExecutor.js
+++ b/scripts/modules/handoff/executors/BaseExecutor.js
@@ -244,7 +244,18 @@ export class BaseExecutor {
             issues: [`NO_CLAIM: handoff_${this.handoffType} attempted on unclaimed SD ${sdKeyForGate} — ${noClaim.detail}`],
             score: 0,
             max_score: 100,
-            warnings: [`Acquire the claim first: node scripts/sd-start.js ${sdKeyForGate}`]
+            // QF-20260726-425 ITEM B: the bare form is a DEAD END for orchestrator PARENTS, which
+            // are a large share of the population that trips this gate — it routes orchestrators to
+            // leaves, so the operator follows the advice, watches it claim something else, and is
+            // no closer. Both working forms are listed. Verified present before being suggested:
+            // sd-start.js reads --parent/--confirm (scripts/sd-start.js:637-638) and
+            // scripts/claim-orchestrator-for-rollup.mjs exists.
+            warnings: [
+              `Acquire the claim first: node scripts/sd-start.js ${sdKeyForGate}`,
+              `If ${sdKeyForGate} is an ORCHESTRATOR PARENT the bare form above will not claim it — use one of:`,
+              `  node scripts/sd-start.js ${sdKeyForGate} --parent --confirm`,
+              '  node scripts/claim-orchestrator-for-rollup.mjs',
+            ]
           }, `NO_CLAIM: ${sdKeyForGate} is unclaimed — handoffs require the claim-holding session`);
         }
         if (noClaim.alreadyCompleted) {

--- a/tests/unit/claim-reacquire-self-evidence-override.test.js
+++ b/tests/unit/claim-reacquire-self-evidence-override.test.js
@@ -1,0 +1,135 @@
+/**
+ * QF-20260726-425 ITEM A — the pre-claim evidence probe must not block a PROVEN self-owner.
+ *
+ * THE DEFECT (raised by Echo, verified here): with no session claim, triangulate classifies the SD
+ * as 'orphaned' and computes reclaimSafe = !hasEvidenceOfLife, where evidence-of-life is
+ * branch_present / plan_file_present / recent_sub_agent_activity (triangulate.js:365-371, :423).
+ * Those signals are attributed to NO SESSION. So an EXEC-phase SD whose feature branch exists, or
+ * whose long sub-agent run just wrote a row — WHICH IS THE VERY CONDITION THAT CREATES THIS BUG —
+ * makes the probe return allowReclaim:false, and the re-acquire aborts as 'live_foreign_holder'
+ * against evidence that is the caller's OWN.
+ *
+ * Why this mattered more than a normal miss: it would have PASSED on the specimen that motivated
+ * the original fix (no branch, no plan file) and silently failed on the general case — shipping
+ * something that looks correct and is inert exactly when it is needed.
+ *
+ * Steal-safety does NOT rest on this gate: the CAS writes only where claiming_session_id IS NULL or
+ * equals self. These tests pin both halves — the override fires for self-owned orphans, and a
+ * genuinely live foreign holder still blocks.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { reacquireSelfLiveClaim } from '../../lib/claim/reacquire-self-live.mjs';
+
+const SD_KEY = 'SD-TEST-EVIDENCE-001';
+const SELF = 'sess-self';
+const WT = '/repo/.worktrees/SD-TEST-EVIDENCE-001';
+
+function buildSupabase({ freshRow, updateReturns = [{ sd_key: SD_KEY, is_working_on: true, claiming_session_id: SELF }] }) {
+  const updateCalls = [];
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: vi.fn(() => Promise.resolve({ data: freshRow, error: null })) })),
+      })),
+      update: vi.fn((payload) => ({
+        eq: vi.fn((col, val) => ({
+          or: vi.fn((orFilter) => ({
+            select: vi.fn(() => {
+              updateCalls.push({ payload, where: [col, val], orFilter });
+              return Promise.resolve({ data: updateReturns, error: null });
+            }),
+          })),
+        })),
+      })),
+    })),
+    _updateCalls: updateCalls,
+  };
+}
+
+/** The probe as it behaves for an orphan carrying evidence-of-life owned by nobody. */
+const orphanWithEvidence = () =>
+  vi.fn(() => Promise.resolve({
+    allowReclaim: false,
+    evidence: ['branch_present', 'recent_sub_agent_activity'],
+    classification: 'orphaned',
+  }));
+
+const liveForeign = (classification) =>
+  vi.fn(() => Promise.resolve({ allowReclaim: false, evidence: [], classification }));
+
+const releasedRow = {
+  sd_key: SD_KEY, is_working_on: false, claiming_session_id: null, active_session_id: null, worktree_path: WT,
+};
+
+const selfOwnedArgs = (sb, probe) => ({
+  sd: { sd_key: SD_KEY, is_working_on: false, worktree_path: WT },
+  resolveSession: vi.fn(() => Promise.resolve({ data: { session_id: SELF, sd_key: SD_KEY }, source: 'env_var' })),
+  checkPreClaimEvidence: probe,
+  cwd: WT,
+  platform: 'linux',
+  log: () => {},
+});
+
+describe('evidence override for a proven self-owner (QF-20260726-425 item A)', () => {
+  it('THE FIX: re-acquires an ORPHANED SD despite evidence-of-life, when the worktree proves self-ownership', async () => {
+    const sb = buildSupabase({ freshRow: releasedRow });
+    const result = await reacquireSelfLiveClaim(sb, selfOwnedArgs(sb, orphanWithEvidence()));
+
+    // Before the fix this returned { reacquired: false, reason: 'live_foreign_holder' }.
+    expect(result.reacquired).toBe(true);
+    expect(result.via).toBe('worktree_path');
+    expect(sb._updateCalls).toHaveLength(1);
+  });
+
+  it('reproduces the exact trigger condition: a feature branch alone was enough to block', async () => {
+    const sb = buildSupabase({ freshRow: releasedRow });
+    const probe = vi.fn(() => Promise.resolve({
+      allowReclaim: false, evidence: ['branch_present'], classification: 'orphaned',
+    }));
+    const result = await reacquireSelfLiveClaim(sb, selfOwnedArgs(sb, probe));
+    expect(result.reacquired).toBe(true);
+  });
+
+  it('STEAL-SAFETY: a genuinely live foreign holder (healthy) still blocks', async () => {
+    const sb = buildSupabase({ freshRow: releasedRow });
+    const result = await reacquireSelfLiveClaim(sb, selfOwnedArgs(sb, liveForeign('healthy')));
+    expect(result.reacquired).toBe(false);
+    expect(result.reason).toBe('live_foreign_holder');
+    expect(sb._updateCalls).toHaveLength(0); // never even attempted
+  });
+
+  it('STEAL-SAFETY: stale-but-alive foreign holder still blocks (busy, not dead)', async () => {
+    const sb = buildSupabase({ freshRow: releasedRow });
+    const result = await reacquireSelfLiveClaim(sb, selfOwnedArgs(sb, liveForeign('stale_alive')));
+    expect(result.reacquired).toBe(false);
+    expect(result.reason).toBe('live_foreign_holder');
+    expect(sb._updateCalls).toHaveLength(0);
+  });
+
+  it('the CAS still refuses a FOREIGN claim even when the evidence gate was overridden', async () => {
+    // Override fires, CAS runs, and the DB matches 0 rows because a peer holds it.
+    const sb = buildSupabase({ freshRow: releasedRow, updateReturns: [] });
+    const result = await reacquireSelfLiveClaim(sb, selfOwnedArgs(sb, orphanWithEvidence()));
+    expect(result.reacquired).toBe(false);
+    expect(result.reason).toBe('cas_noop_foreign_or_changed');
+    // The guarantee that actually protects a peer: the write is scoped to null-or-self.
+    expect(sb._updateCalls[0].orFilter).toContain('claiming_session_id.is.null');
+    expect(sb._updateCalls[0].orFilter).toContain(SELF);
+  });
+
+  it('does NOT override when self-ownership was never proven', async () => {
+    const sb = buildSupabase({ freshRow: { ...releasedRow, worktree_path: null } });
+    const result = await reacquireSelfLiveClaim(sb, {
+      sd: { sd_key: SD_KEY, is_working_on: false, worktree_path: null },
+      // Deterministic session, but its sd_key does NOT match — no witness.
+      resolveSession: vi.fn(() => Promise.resolve({ data: { session_id: SELF, sd_key: 'SD-OTHER-999' }, source: 'env_var' })),
+      checkPreClaimEvidence: orphanWithEvidence(),
+      cwd: '/somewhere/else',
+      platform: 'linux',
+      log: () => {},
+    });
+    expect(result.reacquired).toBe(false);
+    expect(result.reason).toBe('not_self_owned');
+    expect(sb._updateCalls).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Echo's **correction 2 of 2** to the `release_sd` work. Items A and B here; **item C was already shipped** as #6526 (release reason naming) — Echo root-caused that one independently, so that PR now has two seats behind it.

## Item A — the one that mattered

With no session claim, `triangulate` classifies the SD as `orphaned` and computes `reclaimSafe = !hasEvidenceOfLife`, where evidence-of-life is `branch_present` / `plan_file_present` / `recent_sub_agent_activity` (`triangulate.js:365-371`, `:423`).

**Those signals are attributed to no session at all.** So an EXEC-phase SD whose feature branch exists, or whose long sub-agent run just wrote a row — *which is the very condition that creates this bug* — made the probe return `allowReclaim: false`, and `reacquireSelfLiveClaim` aborted as `live_foreign_holder` against evidence that was its **own**.

Echo's framing is the important part: it would have **passed on the specimen** that motivated the original fix (no branch, no plan file) and **silently failed on the general case**. That's the worst outcome available — inert exactly when needed, while looking shipped.

### The change

When self-ownership is *positively proven* (worktree witness, or a deterministic own-session whose `sd_key` matches), those signals are read as **self** evidence and don't block. A different session that is genuinely live still blocks — `healthy` and `stale_alive`.

**Steal-safety does not rest on this gate and is unchanged.** The CAS writes only where `claiming_session_id IS NULL` or equals self, so a foreign claim cannot be clobbered whatever the probe says. Widening a defence-in-depth check for a proven self-owner cannot make a foreign claim reclaimable — and a test pins exactly that.

## Item B — a warning that pointed nowhere

The `GATE_CLAIM_VALIDITY` failure offered only `node scripts/sd-start.js <key>`, which routes orchestrators to leaves and **cannot claim a parent**. For a large share of the population hitting that gate, the operator follows the advice, watches something else get claimed, and is no closer.

Both working forms are now listed. Verified present before suggesting them rather than relayed: `sd-start.js` reads `--parent`/`--confirm` (`:637-638`), and `scripts/claim-orchestrator-for-rollup.mjs` exists.

## Verification

**1371 tests pass** across the full claim + handoff surface (6 new).

The new tests are **mutation-verified** — disabling the override turns 3 of them red, so they can actually fail. Existing `TS-2` (foreign holder blocks) still passes untouched: its fixture classifies as `healthy`, which remains a hard block.

## Process note

The auto-promoted feedback row for this QF is **truncated at 611 characters**, cut off mid-sentence. I recovered the full 3145-character signal from `session_coordination`. Anyone working an auto-promoted QF is reading a fragment with no indication that it's one — worth its own row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)