### PR TITLE
fix(QF-20260726-222): Role rows render lowercase (adam/solomon/coordinator) while every worker is capitalized

### DIFF
--- a/server/routes/fleet-panel.js
+++ b/server/routes/fleet-panel.js
@@ -57,6 +57,26 @@ function sessionIdentityKind(meta = {}) {
   return null;                          // no identity at all -> ghost
 }
 
+/**
+ * QF-20260726-222 — capitalize a role name for DISPLAY only.
+ *
+ * Chairman-reported: workers render Foxtrot / Alpha-4 / Golf-2 while the three role rows rendered
+ * adam / solomon / coordinator — one column, two capitalization conventions. The docblock on the
+ * callsign fallback below already SAID "coordinator/Adam/Solomon"; the string was just passed
+ * through raw.
+ *
+ * *** DISPLAY LAYER ONLY. This must never touch identity_kind. *** identity_kind is the MACHINE KEY
+ * the frontend groups, filters and sorts roles on — verified at the consumer, not assumed:
+ * ehg useFleetSessions.ts:318 does String(r.identity_kind) === 'coordinator' (an exact lowercase
+ * match) and :284-285 filter and sort the role group by it. Capitalizing the key to fix a label is
+ * how a cosmetic change becomes a grouping bug. Nothing compares `callsign` to a lowercase role
+ * literal anywhere in EHG_Engineer or ehg, which is what makes the display fix safe.
+ */
+function capitalizeRoleLabel(value) {
+  if (typeof value !== 'string' || value.length === 0) return value;
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
 // QF-20260726-642: exported (additively, no behaviour change) so the per-session account fields
 // below are unit-testable. An emitted field with no test is how element 5 got dropped the first time.
 export function formatSessionRow(row) {
@@ -69,7 +89,8 @@ export function formatSessionRow(row) {
     session_id: row.session_id,
     // Fall back to the role name so the coordinator/Adam/Solomon rows read as themselves
     // instead of as blanks. Fleet callsign still wins when present.
-    callsign: identity.callsign || (kind && kind !== 'unstamped' ? kind : null),
+    callsign: identity.callsign || (kind && kind !== 'unstamped' ? capitalizeRoleLabel(kind) : null),
+    // NOT capitalized, deliberately — this is the machine key the frontend groups/sorts on.
     identity_kind: kind,
     color: identity.color || null,
     role: identity.role || null,

--- a/tests/unit/server/fleet-panel-route.test.js
+++ b/tests/unit/server/fleet-panel-route.test.js
@@ -209,10 +209,36 @@ describe('GET /api/fleet-panel', () => {
     const payload = res.json.mock.calls[0][0];
     expect(payload.filter.ghostsHidden).toBe(0);
     expect(payload.sessions).toHaveLength(2);
-    // A role session reads as itself rather than as a blank row.
-    expect(payload.sessions[0]).toMatchObject({ callsign: 'solomon', identity_kind: 'solomon' });
+    // A role session reads as itself rather than as a blank row. QF-20260726-222: the DISPLAY name
+    // is capitalized to match worker callsigns, while identity_kind stays the lowercase machine key.
+    expect(payload.sessions[0]).toMatchObject({ callsign: 'Solomon', identity_kind: 'solomon' });
     // A freshly spawned worker has no callsign yet — that is honest, not a ghost.
     expect(payload.sessions[1]).toMatchObject({ callsign: null, identity_kind: 'unstamped' });
+  });
+
+  it('QF-222 — capitalizes the role DISPLAY name while leaving identity_kind lowercase', async () => {
+    // Chairman-reported: workers render Foxtrot/Alpha-4 but roles rendered adam/solomon/coordinator.
+    const roleRow = (id, meta) => ({
+      session_id: id, sd_key: null, computed_status: 'active',
+      heartbeat_age_human: '2s ago', heartbeat_age_seconds: 2, metadata: meta,
+    });
+    const res = mockRes();
+    await getFleetPanel(mockReq(mockSupabase([
+      roleRow('r-adam', { role: 'adam' }),
+      roleRow('r-sol', { role: 'solomon' }),
+      roleRow('r-coord', { is_coordinator: true }),
+      // A real worker: its stamped callsign must pass through UNCHANGED, not be re-capitalized.
+      roleRow('w-1', { fleet_identity: { callsign: 'Alpha-4' }, model: 'opus', effort: 'xhigh' }),
+    ])), res);
+    const rows = res.json.mock.calls[0][0].sessions;
+
+    expect(rows.map((r) => r.callsign)).toEqual(['Adam', 'Solomon', 'Coordinator', 'Alpha-4']);
+
+    // THE LOAD-BEARING HALF, and the reason this is not a one-liner: identity_kind must stay
+    // lowercase. Verified at the consumer — ehg useFleetSessions.ts:318 does
+    // String(r.identity_kind) === 'coordinator' (exact lowercase match) and :284-285 filter and sort
+    // the ROLES group by it. Capitalizing the key to fix a label would silently break grouping.
+    expect(rows.map((r) => r.identity_kind)).toEqual(['adam', 'solomon', 'coordinator', 'worker']);
   });
 
   it('reports truncated=true when the page hits the row cap, false otherwise', async () => {


### PR DESCRIPTION
## Quick-Fix: QF-20260726-222

**Type:** polish
**Severity:** medium

### Issue Description
CHAIRMAN-REPORTED on his sole-focus /builder/sessions view, verbatim: 'All the workers have a capital letter as they start their name. I think we should do the same thing with Adam the coordinator and Solomon.'

CONFIRMED against the live payload, not inferred: workers render Foxtrot / Alpha-4 / Alpha / Golf-2; the three role rows render adam / solomon / coordinator. Same column, two capitalization conventions.

*** THE SITE IS ONE LINE: server/routes/fleet-panel.js:71 ***
  callsign: identity.callsign || (kind && kind !== 'unstamped' ? kind : null),
For a role there is no fleet_identity.callsign, so the raw lowercase identity_kind is used as the DISPLAY fallback. The docblock immediately above it already writes them capitalized ('so the coordinator/Adam/Solomon rows read as themselves') — the intent was there and the string was passed through raw.

*** FIX AT THE DISPLAY LAYER ONLY. DO NOT RENAME ANYTHING IN THE DATABASE. ***
Capitalize the fallback where it is emitted for display. Do NOT write a capitalized callsign into claude_sessions, and do NOT capitalize identity_kind on line 72 — identity_kind is the MACHINE KEY the frontend groups and sorts roles on (groupSessions orders roles by identity_kind). Capitalizing the key to fix a label is how a cosmetic change becomes a grouping bug.

Checked before scoping rather than assumed: no eq('callsign','adam'|'solomon'|'coordinator') DB filter and no callsign===<role literal> comparison exists under lib/, scripts/ or server/. The lowercase string is not load-bearing AS A CALLSIGN — which is exactly why the display-layer fix is safe and the DB rename is both unnecessary and risky.

### Steps to Reproduce
Open /builder/sessions and compare the name column across the worker rows and the three role rows

### Expected Behavior
Adam, Coordinator and Solomon are capitalized like every worker callsign

### Actual Behavior
adam, solomon and coordinator render lowercase; workers render Foxtrot, Alpha-4, Golf-2

### Changes
- **Files Changed:** 2
  - server/routes/fleet-panel.js
  - tests/unit/server/fleet-panel-route.test.js
- **LOC:** 22 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol