### PR TITLE
fix(QF-20260726-908): flag fixture ventures so the chairman's queue shows real decisions

### DIFF
--- a/scripts/backfill-fixture-venture-is-demo.mjs
+++ b/scripts/backfill-fixture-venture-is-demo.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+/**
+ * Backfill ventures.is_demo=true for fixture ventures — QF-20260726-908.
+ *
+ * WHY THIS IS THE FIX RATHER THAN A NEW FILTER. The chairman's queue
+ * (chairman_pending_decisions -> chairman_unified_decisions) ALREADY excludes
+ * `COALESCE(is_demo,false)=true OR name ~ '^(__e2e_|__citest_|canonical-source-test-|Test Venture for)'`.
+ * Both legs currently miss the offending rows:
+ *   - the name regex is ANCHORED and the fixture family was renamed (HCGate-RealDB-*,
+ *     StageArtifactGate-RealDB-*), matching none of it — exactly the "a name-regex stopgap stops
+ *     working the first time a fixture is named something else" failure the QF predicted;
+ *   - the is_demo leg is barely populated: measured 74 fixture-named ventures, only 11 flagged.
+ * So the robust leg is inert. Populating it makes the EXISTING filter work with NO schema change —
+ * verified live by flagging one venture (its queue row vanished) and reverting.
+ *
+ * SAFETY. Identification is delegated to isFixtureVenture, the CANONICAL predicate already used by
+ * the chairman surfaces. A fourth private regex is how this class of bug happens, so there isn't
+ * one here. The write is POSITIVE-IDENTIFICATION ONLY: a venture is touched solely when the shared
+ * predicate says fixture. Never clears the flag — a false positive would be far worse than a miss,
+ * so this only ever sets true, and is a no-op on rows already flagged (idempotent, re-runnable).
+ *
+ * DRY RUN BY DEFAULT. Pass --apply to write. Prints the exact rows either way so the change is
+ * reviewable before it touches a governance-visible surface.
+ *
+ *   node scripts/backfill-fixture-venture-is-demo.mjs            # preview
+ *   node scripts/backfill-fixture-venture-is-demo.mjs --apply    # write
+ */
+import { createClient } from '@supabase/supabase-js';
+import { isFixtureVenture } from '../lib/chairman/chairman-actionable.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const LIMIT = 2000;
+
+function makeClient() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('Missing SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY');
+    process.exit(1);
+  }
+  return createClient(url, key);
+}
+
+export async function findUnflaggedFixtures(supabase) {
+  const { data, error } = await supabase
+    .from('ventures')
+    .select('id, name, is_demo')
+    .limit(LIMIT);
+  if (error) throw new Error(`ventures read failed: ${error.message}`);
+  // Positive identification only, and skip anything already flagged (idempotent).
+  return (data || []).filter((v) => v.is_demo !== true && isFixtureVenture(v));
+}
+
+async function main() {
+  const supabase = makeClient();
+  const targets = await findUnflaggedFixtures(supabase);
+
+  console.log(`${APPLY ? 'APPLYING' : 'DRY RUN'} — ${targets.length} unflagged fixture venture(s) identified by isFixtureVenture()`);
+  for (const v of targets.slice(0, 40)) console.log(`  ${v.id}  ${v.name}`);
+  if (targets.length > 40) console.log(`  ... and ${targets.length - 40} more`);
+
+  if (!APPLY) {
+    console.log('\nNo writes performed. Re-run with --apply to set is_demo=true on the rows above.');
+    return;
+  }
+  if (targets.length === 0) {
+    console.log('Nothing to do.');
+    return;
+  }
+
+  let updated = 0;
+  for (const v of targets) {
+    // Guard the write itself on is_demo IS NOT true, so a concurrent flagger cannot be clobbered
+    // and a re-run cannot double-count.
+    const { data, error } = await supabase
+      .from('ventures')
+      .update({ is_demo: true })
+      .eq('id', v.id)
+      .not('is_demo', 'is', true)
+      .select('id');
+    if (error) {
+      console.error(`  FAILED ${v.name}: ${error.message}`);
+      continue;
+    }
+    if (data?.length) updated += 1;
+  }
+  console.log(`\nFlagged ${updated} venture(s).`);
+
+  // Report the consumer-visible effect, not just the write count — the point of the change is
+  // what the chairman sees, and a write that did not move that number would be a false success.
+  const { count } = await supabase
+    .from('chairman_pending_decisions')
+    .select('*', { count: 'exact', head: true });
+  console.log(`chairman_pending_decisions now holds ${count} row(s).`);
+}
+
+// Only run when invoked directly, so the pure finder above stays importable by tests.
+if (process.argv[1] && process.argv[1].endsWith('backfill-fixture-venture-is-demo.mjs')) {
+  main().catch((e) => { console.error(e); process.exit(1); });
+}

--- a/tests/unit/backfill-fixture-venture-is-demo.test.js
+++ b/tests/unit/backfill-fixture-venture-is-demo.test.js
@@ -1,0 +1,64 @@
+/**
+ * QF-20260726-908 — the backfill's selection rule.
+ *
+ * The whole point is that identification is DELEGATED to isFixtureVenture, the canonical predicate
+ * the chairman surfaces already use. A private regex in this script would be a fourth copy of the
+ * rule, and a fourth copy is precisely how this defect happened: the JS predicate, the SQL function
+ * and the SQL view had drifted apart, and the one the chairman reads was the stale one.
+ *
+ * The write is positive-identification-only and never clears a flag: a false positive (hiding a
+ * REAL governance decision from the chairman) is far worse than a miss, so the asymmetry is
+ * deliberate and pinned here.
+ */
+import { describe, it, expect } from 'vitest';
+import { findUnflaggedFixtures } from '../../scripts/backfill-fixture-venture-is-demo.mjs';
+
+/** Minimal supabase double: ventures.select(...).limit(n). */
+function db(rows) {
+  return { from: () => ({ select: () => ({ limit: async () => ({ data: rows, error: null }) }) }) };
+}
+
+describe('findUnflaggedFixtures', () => {
+  it('selects fixture ventures that are NOT yet flagged', async () => {
+    const out = await findUnflaggedFixtures(db([
+      { id: '1', name: 'HCGate-RealDB-rpc-scope-178', is_demo: false },
+      { id: '2', name: 'StageArtifactGate-RealDB-complete-178', is_demo: null },
+    ]));
+    expect(out.map((v) => v.id)).toEqual(['1', '2']);
+  });
+
+  it('NEVER selects a real venture — the failure that would hide genuine governance items', async () => {
+    const out = await findUnflaggedFixtures(db([
+      { id: 'real-1', name: 'ApexNiche AI', is_demo: false },
+      { id: 'real-2', name: 'EHG operating-company SUBSTRATE', is_demo: false },
+    ]));
+    expect(out).toEqual([]);
+  });
+
+  it('is idempotent — already-flagged fixtures are not re-selected', async () => {
+    const out = await findUnflaggedFixtures(db([
+      { id: '1', name: 'HCGate-RealDB-x', is_demo: true },
+    ]));
+    expect(out).toEqual([]);
+  });
+
+  it('uses the CANONICAL predicate, so a family the shared list knows is caught here too', async () => {
+    // These come from FIXTURE_NAME_PATTERNS, not from any regex written in the backfill script.
+    const out = await findUnflaggedFixtures(db([
+      { id: 'a', name: '__e2e_park_status_178__', is_demo: false },
+      { id: 'b', name: 'Test Venture for Marketing', is_demo: false },
+      { id: 'c', name: 'TS-fixture-a6e265ae', is_demo: false },
+      { id: 'd', name: 'Pipeline-Test-178', is_demo: false },
+    ]));
+    expect(out).toHaveLength(4);
+  });
+
+  it('tolerates an empty table', async () => {
+    expect(await findUnflaggedFixtures(db([]))).toEqual([]);
+  });
+
+  it('surfaces a read error instead of silently reporting zero targets', async () => {
+    const failing = { from: () => ({ select: () => ({ limit: async () => ({ data: null, error: { message: 'boom' } }) }) }) };
+    await expect(findUnflaggedFixtures(failing)).rejects.toThrow(/ventures read failed/);
+  });
+});


### PR DESCRIPTION
## Measured effect, both channels, live

| | before | after |
|---|---|---|
| `chairman_pending_decisions` | 46 rows | **11 rows** — exactly the genuine items the row named |
| venture stall candidates | 38 | **1** — ApexNiche AI, a real venture |

**No schema change. No new filter.** The filters already existed and were inert.

## Why they were inert

The queue view already excludes `is_demo = true OR name ~ '^(__e2e_|__citest_|canonical-source-test-|Test Venture for)'`, and the stall detector already filters `.eq('is_demo', false)`. Both missed everything, for two compounding reasons:

1. **The name regex is anchored and the fixture family was renamed.** `HCGate-RealDB-*`, `StageArtifactGate-RealDB-*`, `ProductReviewGate-RealDB-*` match none of it. This is verbatim the failure the row predicted: *"a name-regex filter will silently stop working the first time a fixture is named something else."*
2. **The `is_demo` leg was barely populated** — 90 fixture ventures unflagged — so the robust leg matched almost nothing. Any fix that merely added `AND NOT is_demo` would have looked correct and changed nothing.

Populating `is_demo` makes **both** existing filters work at once, which is why one data change closes both channels — satisfying the row's requirement that fixing only the decision queue is unacceptable.

## Identification is delegated, not re-invented

No regex is written in this script. It calls `isFixtureVenture`, the canonical predicate the chairman surfaces already use — a fourth copy of the rule is exactly how this defect happened. Using the shared predicate also caught **90** rows rather than the 63 my own ad-hoc pattern found.

## Safety

- Dry-run by default; `--apply` to write.
- Positive identification only, and it **never clears** a flag — only sets `true`. A false positive would hide a real governance item, so the asymmetry is deliberate and tested.
- Per-row write guarded on `is_demo IS NOT true`: idempotent, and cannot clobber a concurrent flagger.
- Before applying I grouped all 90 by name family — 9 unambiguous fixture families, zero outliers — rather than trusting the count.

227 tests pass (6 new), including one asserting a real venture is never selected.

## Not done here — reported rather than guessed at

- The `*-realdb.test.js` suites **deliberately** create `is_demo=false` ventures and state their names *"do NOT match isFixtureVenture's regex"* so the real path is exercised. **That comment is now false** — `HCGate-RealDB-*` matches via `/-realdb-/i`, added later. So "mark at creation" conflicts with the tests' stated intent and isn't a safe unilateral change.
- Those suites also claim *"zero residue"* via `afterAll` cleanup, yet 37 rows had accumulated. **The leak is failing or skipped cleanup, not a missing flag** — that's where the recurrence fix belongs.
- The SQL **view** regex is still narrower than the JS and the SQL function (DDL, chairman-gated), and `fixture-pattern-parity.test.js` compares JS against a migration *file* with "no live DB needed" — so it's structurally blind to that divergence and has been green throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)