### PR TITLE
fix(QF-20260726-757): spawn LEO sessions in auto permission mode

### DIFF
--- a/lib/fleet/build-session-launch.cjs
+++ b/lib/fleet/build-session-launch.cjs
@@ -70,6 +70,39 @@ function resolveProfileDir(profileName, opts = {}) {
  * @param {{env?:object}} [opts]
  * @returns {{program:string, args:string[], env:object, cwd:string, persistent:boolean}}
  */
+/**
+ * QF-20260726-757 — resolve the CLI permission mode for a spawned session.
+ *
+ * Values are the ones `claude --help` actually accepts on this host (CLI 2.1.220):
+ * acceptEdits, auto, bypassPermissions, manual, dontAsk, plan. Verified against --help rather than
+ * assumed, because an invalid --permission-mode makes the CLI reject the whole invocation — a typo
+ * here costs the entire launch, not just the flag.
+ *
+ * NOTE: the QF row enumerated only the first FOUR. Running --help on this host (same 2.1.220) shows
+ * six — 'dontAsk' and 'plan' are also accepted. Copying the row's list would have made those two
+ * silently fall back to 'auto' instead of being honoured, so the list here comes from the CLI.
+ *
+ * Defaults to 'auto' (the chairman's instruction). An unrecognised override falls back to the
+ * default instead of being forwarded, for the same reason: passing a bad value through would turn
+ * a config typo into a dead spawn, and a spawn that comes up in auto is a far better failure than
+ * one that does not come up at all.
+ *
+ * @param {object} [env=process.env]
+ * @returns {string} a permission mode safe to pass to the CLI
+ */
+const VALID_PERMISSION_MODES = Object.freeze([
+  'acceptEdits', 'auto', 'bypassPermissions', 'manual', 'dontAsk', 'plan',
+]);
+const DEFAULT_PERMISSION_MODE = 'auto';
+
+function resolvePermissionMode(env = process.env) {
+  const raw = String((env && env.FLEET_SPAWN_PERMISSION_MODE) || '').trim();
+  if (!raw) return DEFAULT_PERMISSION_MODE;
+  // Case-insensitive match, but emit the CLI's exact spelling — 'acceptedits' would be rejected.
+  const match = VALID_PERMISSION_MODES.find((m) => m.toLowerCase() === raw.toLowerCase());
+  return match || DEFAULT_PERMISSION_MODE;
+}
+
 function buildSessionLaunch(spec = {}, opts = {}) {
   const env = opts.env || process.env;
   const { role, callsign, profile, profileDir: preResolved, cwd, sdToResume, resumeUuid, startupPrompt } = spec;
@@ -122,6 +155,33 @@ function buildSessionLaunch(spec = {}, opts = {}) {
   // `-w` is a GLOBAL wt option and MUST precede the `new-tab` subcommand -- `wt new-tab -w new` would
   // be parsed as an argument to new-tab, not as the window selector. Hence the position here.
   const args = ['-w', 'new', 'new-tab', '-d', startDir, '--', claudeCmd];
+
+  // QF-20260726-757 — PERMISSION MODE. Chairman-directed: "We need to run these claude sessions
+  // with auto mode on by default."
+  //
+  // WHY THIS IS A CORRECTNESS REQUIREMENT AND NOT A PREFERENCE: a LEO-spawned session has NO
+  // OPERATOR AT THE KEYBOARD. Without a permission mode the CLI comes up in its prompting default,
+  // and the first tool call needing approval blocks forever waiting for an answer nobody will give.
+  // From outside, that seat is INDISTINGUISHABLE FROM A DEAD ONE — loop_state stays active, the tick
+  // daemon keeps the heartbeat fresh, and last_tool_at freezes. That is the exact phantom-seat
+  // signature diagnosed on Alpha-5, so the fleet's own liveness instruments cannot tell a
+  // permission-blocked worker from a crashed one.
+  //
+  // Placed BEFORE the --resume / --session-id branch below deliberately: those two paths diverge,
+  // and a flag pushed inside either branch would apply to only one of them. Both spawn paths need
+  // this, so it goes on the shared array.
+  //
+  // 'auto' NOT '--dangerously-skip-permissions'. The CLI (2.1.220) offers both, and the bypass flag
+  // is a strictly WIDER grant that disables more than prompting. The chairman asked for auto; auto
+  // is sufficient for the unattended-spawn problem and is the narrower of the two. Do not substitute
+  // the bypass flag because it looks equivalent — it is not.
+  //
+  // CONFIGURABLE, NOT HARD-CODED: FLEET_SPAWN_PERMISSION_MODE overrides the default so a canary or a
+  // debugging spawn can be launched in 'manual' (a seat that DOES pause is occasionally exactly what
+  // you want). Unrecognised values fall back to the default rather than being passed through, since
+  // the CLI rejects an invalid --permission-mode and would fail the entire launch.
+  const permissionMode = resolvePermissionMode(env);
+  if (permissionMode) args.push('--permission-mode', permissionMode);
 
   // SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-3 — MINT THE SESSION ID SPAWNER-SIDE.
   //
@@ -352,4 +412,9 @@ module.exports = {
   resolveProfileDir,
   LaunchResolveError,
   PROFILE_NAME_RE,
+  // QF-20260726-757: exported so the mode resolution is testable directly, rather than only
+  // observable through a full built invocation.
+  resolvePermissionMode,
+  VALID_PERMISSION_MODES,
+  DEFAULT_PERMISSION_MODE,
 };

--- a/tests/unit/fleet/reboot-respawn-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-runner.test.js
@@ -41,12 +41,12 @@ describe('runRebootRespawn dry-run (FR-5) — default INERT', () => {
     // FR-1: a trailing single-line POINTER positional now follows. It embeds an absolute path, so
     // it is asserted by SHAPE — exact-matching a machine-specific path would be brittle without
     // testing anything more. The prefix is still pinned exactly.
-    expect(res.results[0].invocation.args.slice(0, 9))
-      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1']);
+    expect(res.results[0].invocation.args.slice(0, 11))
+      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--permission-mode', 'auto', '--resume', 'u-1']);
     // FR-3: a slot with no resume token gets a MINTED --session-id instead, so the spawner knows in
     // advance the id the child will register under. Injected via uuidFn for determinism.
-    expect(res.results[1].invocation.args.slice(0, 9))
-      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]);
+    expect(res.results[1].invocation.args.slice(0, 11))
+      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--permission-mode', 'auto', '--session-id', MINTED]);
   });
 
   // QF-20260724-335: opts.sdKey stamps every fleet_verb_respawn event with an explicit run-correlator
@@ -81,10 +81,10 @@ describe('runRebootRespawn live (FR-5)', () => {
     expect(res.live).toBe(true);
     expect(spawnFn).toHaveBeenCalledTimes(2);
     expect(spawnCalls[0].program).toBe('wt.exe');
-    expect(spawnCalls[0].args.slice(0, 9))
-      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1']);
-    expect(spawnCalls[1].args.slice(0, 9))
-      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]); // slot 2 had no resume token -> minted id
+    expect(spawnCalls[0].args.slice(0, 11))
+      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--permission-mode', 'auto', '--resume', 'u-1']);
+    expect(spawnCalls[1].args.slice(0, 11))
+      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--permission-mode', 'auto', '--session-id', MINTED]); // slot 2 had no resume token -> minted id
     // FR-1: whatever follows is the single-line pointer positional, asserted by shape below.
     for (const c of spawnCalls) {
       const last = c.args[c.args.length - 1];

--- a/tests/unit/fleet/spawn-control-resume.test.js
+++ b/tests/unit/fleet/spawn-control-resume.test.js
@@ -11,7 +11,7 @@ import { resolveClaudeCmd, resolveRepoRoot } from '../../../lib/fleet/build-sess
 describe('buildLiveSpawnInvocation --resume (via canonical buildSessionLaunch)', () => {
   it('appends [--resume, <uuid>] after the base argv (new-tab -d <root> -- <claude>)', () => {
     const inv = buildLiveSpawnInvocation({ role: 'worker', callsign: 'Worker-1', resumeUuid: 'abc-123' });
-    expect(inv.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'abc-123']);
+    expect(inv.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--permission-mode', 'auto', '--resume', 'abc-123']);
     expect(inv.program).toBe('wt.exe');
   });
 
@@ -20,7 +20,7 @@ describe('buildLiveSpawnInvocation --resume (via canonical buildSessionLaunch)',
     // what the child will register as. uuidFn is injected purely for determinism.
     const MINTED = '11111111-2222-4333-8444-555555555555';
     const inv = buildLiveSpawnInvocation({ role: 'worker', callsign: 'Worker-1' }, { uuidFn: () => MINTED });
-    expect(inv.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]);
+    expect(inv.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--permission-mode', 'auto', '--session-id', MINTED]);
     expect(inv.sessionId).toBe(MINTED);
     expect(inv.cwd).toBe(resolveRepoRoot());
     expect(inv.persistent).toBe(true);
@@ -50,7 +50,7 @@ describe('buildLiveSpawnInvocation --resume (via canonical buildSessionLaunch)',
 
   it('coerces a non-string resume token via String() (never leaks a raw object into argv)', () => {
     const inv = buildLiveSpawnInvocation({ callsign: 'W', resumeUuid: 42 });
-    expect(inv.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', '42']);
+    expect(inv.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--permission-mode', 'auto', '--resume', '42']);
   });
 
   it('injects CLAUDE_CONFIG_DIR only into the returned env, never process.env, and never as an argv token', () => {

--- a/tests/unit/fleet/spawn-permission-mode.test.js
+++ b/tests/unit/fleet/spawn-permission-mode.test.js
@@ -1,0 +1,84 @@
+/**
+ * QF-20260726-757 — LEO-spawned sessions must not come up in a prompting permission mode.
+ *
+ * Chairman-directed: "We need to run these claude sessions with auto mode on by default."
+ *
+ * WHY IT IS A CORRECTNESS BUG, not a preference: a spawned session has no operator at the keyboard,
+ * so the first tool call needing approval blocks forever. From outside, that seat is
+ * INDISTINGUISHABLE FROM A DEAD ONE — loop_state stays active, the tick daemon keeps the heartbeat
+ * fresh, and last_tool_at freezes. That is the phantom-seat signature diagnosed on Alpha-5, so the
+ * fleet's liveness instruments cannot separate a permission-blocked worker from a crashed one.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  buildSessionLaunch,
+  resolvePermissionMode,
+  VALID_PERMISSION_MODES,
+  DEFAULT_PERMISSION_MODE,
+} = require('../../../lib/fleet/build-session-launch.cjs');
+
+const FRESH = { role: 'worker', callsign: 'T1', cwd: process.cwd() };
+const RESUME = { role: 'worker', callsign: 'T2', cwd: process.cwd(), resumeUuid: '11111111-1111-4111-8111-111111111111' };
+
+const modeOf = (args) => {
+  const i = args.indexOf('--permission-mode');
+  return i === -1 ? null : args[i + 1];
+};
+
+describe('spawn permission mode', () => {
+  it('FRESH spawns carry --permission-mode auto', () => {
+    expect(modeOf(buildSessionLaunch(FRESH, { env: {} }).args)).toBe('auto');
+  });
+
+  it('RESUME spawns carry it too — the two paths diverge and BOTH need it', () => {
+    // The row called out "applying it to the resume path only or the fresh path only" as a
+    // do-not-accept, because --resume and --session-id are set in different branches.
+    expect(modeOf(buildSessionLaunch(RESUME, { env: {} }).args)).toBe('auto');
+  });
+
+  it('uses auto and NEVER substitutes the bypass flag', () => {
+    for (const spec of [FRESH, RESUME]) {
+      const { args } = buildSessionLaunch(spec, { env: {} });
+      // --dangerously-skip-permissions is a strictly WIDER grant that disables more than
+      // prompting. The chairman asked for auto; auto is sufficient and narrower.
+      expect(args).not.toContain('--dangerously-skip-permissions');
+      expect(args).not.toContain('--allow-dangerously-skip-permissions');
+    }
+  });
+
+  it('is CONFIGURABLE — an override can spawn a seat that DOES pause', () => {
+    const { args } = buildSessionLaunch(FRESH, { env: { FLEET_SPAWN_PERMISSION_MODE: 'manual' } });
+    expect(modeOf(args)).toBe('manual');
+  });
+
+  it('accepts every mode the CLI accepts, including the two the QF row omitted', () => {
+    // `claude --help` on 2.1.220 lists SIX choices; the row enumerated four. Copying the row would
+    // have made these two silently fall back to auto instead of being honoured.
+    expect(VALID_PERMISSION_MODES).toContain('dontAsk');
+    expect(VALID_PERMISSION_MODES).toContain('plan');
+    for (const m of VALID_PERMISSION_MODES) expect(resolvePermissionMode({ FLEET_SPAWN_PERMISSION_MODE: m })).toBe(m);
+  });
+
+  it('emits the CLI’s exact spelling for a case-mismatched override', () => {
+    // 'acceptedits' would be rejected by the CLI and fail the whole launch.
+    expect(resolvePermissionMode({ FLEET_SPAWN_PERMISSION_MODE: 'acceptedits' })).toBe('acceptEdits');
+  });
+
+  it('falls back to the default on an unrecognised override rather than forwarding it', () => {
+    // A config typo must not become a dead spawn: an invalid --permission-mode makes the CLI
+    // reject the entire invocation, so a bad value is worse than no value.
+    expect(resolvePermissionMode({ FLEET_SPAWN_PERMISSION_MODE: 'nonsense' })).toBe(DEFAULT_PERMISSION_MODE);
+    expect(resolvePermissionMode({ FLEET_SPAWN_PERMISSION_MODE: '   ' })).toBe(DEFAULT_PERMISSION_MODE);
+    expect(resolvePermissionMode({})).toBe(DEFAULT_PERMISSION_MODE);
+  });
+
+  it('places the flag among the claude args, after the wt.exe separator', () => {
+    const { args } = buildSessionLaunch(FRESH, { env: {} });
+    // `--` separates wt.exe's own options from the command it runs. A permission flag landing
+    // before it would be parsed by wt.exe and never reach claude.
+    expect(args.indexOf('--permission-mode')).toBeGreaterThan(args.indexOf('--'));
+  });
+});


### PR DESCRIPTION
Chairman-directed: *"We need to run these claude sessions with auto mode on by default."*

## Why this is a correctness bug, not a preference

`build-session-launch.cjs` set **no permission mode at all**, so every LEO-spawned session came up in the CLI's prompting default. A spawned session has no operator at the keyboard, so the first tool call needing approval blocks forever.

From outside, that seat is **indistinguishable from a dead one** — `loop_state` active, the tick daemon keeping the heartbeat fresh, `last_tool_at` frozen. That's the exact phantom-seat signature diagnosed on Alpha-5, so the fleet's own liveness instruments cannot separate a permission-blocked worker from a crash.

## The change

- `--permission-mode` is pushed onto the **shared** args array, before the `--resume`/`--session-id` branch. Those paths diverge, so a flag added inside either would cover only one — the row called that out as a do-not-accept. Both verified.
- **`auto`, not `--dangerously-skip-permissions`.** The CLI offers both; the bypass flag is a strictly wider grant that disables more than prompting. `auto` is what was asked for and is sufficient here.
- Configurable via `FLEET_SPAWN_PERMISSION_MODE`, so a canary or debugging spawn can still launch in `manual` — a seat that *does* pause is occasionally exactly what you want.
- An unrecognised override falls back to the default rather than being forwarded: an invalid `--permission-mode` makes the CLI reject the whole invocation, so a config typo would otherwise become a dead spawn.

## Correction to the row

Found by running `--help` rather than trusting it: the row lists **four** accepted modes. This host's CLI — the same 2.1.220 the row cites — accepts **six**, adding `dontAsk` and `plan`. Copying the row's list would have made those two silently fall back to `auto` instead of being honoured.

## Five pre-existing tests updated deliberately

Three pinned the full argv (now including the flag). Two used `args.slice(0, 9)` to pin a prefix — the two new tokens pushed `--resume` past that window, so the slice widens to 11. **Behaviour was correct throughout; only the pinned shape moved.**

## Verification

**1226 tests pass** across the whole fleet suite (8 new), covering both spawn paths, the bypass-flag exclusion, case-mismatched override normalisation, and flag placement *after* the `wt.exe` `--` separator — a flag landing before it would be consumed by `wt.exe` and never reach claude.

**Not verified here:** that a *resumed* session adopts the flag rather than the transcript's original mode. That needs a live spawn to observe, and I didn't have one — flagged rather than assumed, since the row named it as a do-not-accept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)