### PR TITLE
fix(QF-20260726-175): a diagnostic side-write can no longer kill the API server

### DIFF
--- a/lib/rca-runtime-triggers.js
+++ b/lib/rca-runtime-triggers.js
@@ -338,9 +338,45 @@ export async function monitorHandoffRejections() {
  * @param {Object} params.evidence_refs - Evidence references
  * @param {string} params.impact_level - Impact level (CRITICAL, HIGH, MEDIUM, LOW)
  * @param {string} params.likelihood_level - Likelihood level
- * @returns {Promise<string>} RCR ID
+ * @returns {Promise<string|null>} RCR ID, or null if the diagnostic write failed.
+ *
+ * NEVER REJECTS. QF-20260726-175: this function threw on any Supabase error, and all six call
+ * sites are `await triggerRCA(...)` inside Supabase REALTIME SUBSCRIPTION CALLBACKS. An async
+ * callback that throws produces an unhandled rejection, and under Node's default
+ * --unhandled-rejections=throw that TERMINATES THE PROCESS. On 2026-07-26 an RLS denial here
+ * (code 42501 inserting into root_cause_reports) killed the entire API server for 1h45m; port
+ * 8080 stayed up so the app looked alive, and the chairman's page was dead the whole time.
+ *
+ * The asymmetry is the point: THIS IS A DIAGNOSTIC SIDE-WRITE. It exists to record why something
+ * else broke. It must never be able to break the thing it is observing. So every failure degrades
+ * to a loud log line and a null return.
+ *
+ * Fail-soft is safe for the return value specifically because no call site consumes it — all six
+ * are fire-and-forget (lines 41, 70, 138, 198, 227, 290). Verified before making this change; a
+ * future caller that needs the id must handle null rather than assume a string.
  */
 async function triggerRCA(params) {
+  try {
+    return await triggerRCAOrThrow(params);
+  } catch (err) {
+    // Loud, not silent: an RCR that failed to record is a real loss of diagnostic coverage, and
+    // the QF is explicit that silently dropping RCRs is the same class of invisible failure as
+    // the crash. It just must not be a FATAL loss.
+    console.error(
+      '[rca-runtime-triggers] RCR NOT RECORDED — diagnostic write failed, continuing anyway. '
+      + `signature=${params?.failure_signature ?? '<none>'} code=${err?.code ?? '<none>'} `
+      + `message=${err?.message ?? String(err)}`,
+    );
+    return null;
+  }
+}
+
+/**
+ * The original body, unchanged in behaviour. Kept as a separate throwing function so the happy
+ * path and its error semantics stay readable, and so a caller that genuinely wants the throw can
+ * still reach it deliberately rather than by accident.
+ */
+async function triggerRCAOrThrow(params) {
   const supabase = createSupabaseClient();
 
   // Check for duplicate RCR with same failure signature

--- a/server/index.js
+++ b/server/index.js
@@ -309,6 +309,31 @@ async function startServer() {
     console.log('🎯 STORY Agent initialized');
   }
 
+  // QF-20260726-175 (b) — PROCESS-LEVEL BACKSTOP. Registered BEFORE listen, so it covers startup
+  // rejections too, and before RCA monitoring specifically because that subsystem caused the
+  // outage this fixes.
+  //
+  // WHY THIS EXISTS: on 2026-07-26 a single unhandled rejection — an RLS denial on a DIAGNOSTIC
+  // side-write into root_cause_reports — terminated this entire API process for 1h45m under
+  // Node's default --unhandled-rejections=throw. Part (a) fixes that one call path; this fixes
+  // the CLASS, so the next un-caught await anywhere in the server cannot kill the control plane.
+  //
+  // DELIBERATELY REJECTIONS ONLY, NOT uncaughtException. lib/feedback-capture.js
+  // initializeErrorHandlers() would install both, but its uncaughtException arm swallows the
+  // error with the re-throw commented out — and resuming after a genuine uncaught exception can
+  // continue from corrupt state, which is a different and riskier trade than the one this QF
+  // asks for. (Separately: that function is never called anywhere in the repo — a crash backstop
+  // built and never wired. Reported as its own finding rather than silently adopted here.)
+  process.on('unhandledRejection', (reason) => {
+    const err = reason instanceof Error ? reason : new Error(String(reason));
+    console.error(
+      '[server] UNHANDLED REJECTION — logged, NOT fatal. The API stays up deliberately; '
+      + 'investigate this, it is a real defect.\n'
+      + `  code=${err?.code ?? '<none>'} message=${err?.message ?? String(err)}\n`
+      + `  stack=${err?.stack ?? '<no stack>'}`,
+    );
+  });
+
   // Initialize RCA runtime monitoring (SD-RCA-001)
   await bootstrapRCAMonitoring();
   registerRCAShutdownHandlers();

--- a/tests/unit/rca-trigger-failsoft.test.js
+++ b/tests/unit/rca-trigger-failsoft.test.js
@@ -1,0 +1,110 @@
+/**
+ * QF-20260726-175 — triggerRCA must NEVER reject.
+ *
+ * THE OUTAGE THIS PINS: on 2026-07-26 an RLS denial (code 42501) on the diagnostic insert into
+ * root_cause_reports threw out of triggerRCA. All six call sites are `await triggerRCA(...)`
+ * inside Supabase realtime subscription callbacks, so the throw became an unhandled rejection and
+ * Node's default --unhandled-rejections=throw terminated the whole API process for 1h45m. Port
+ * 8080 stayed up, so the app looked alive while the control plane was gone.
+ *
+ * These tests exercise the REAL exported triggerRCA. The pre-existing suite in
+ * rca-runtime-triggers.test.js declares its own local createRCR copy, which cannot catch a
+ * regression in the shipped function — that is the trap this file deliberately avoids.
+ */
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+
+const createSupabaseClient = vi.fn();
+vi.mock('../../lib/supabase-client.js', () => ({ createSupabaseClient: () => createSupabaseClient() }));
+// The RCA sub-agent is irrelevant here and must not reach the network on the happy path.
+vi.mock('../../lib/sub-agents/rca.js', () => ({ execute: vi.fn(async () => ({ ok: true })) }));
+
+const { triggerRCA } = await import('../../lib/rca-runtime-triggers.js');
+
+/** Minimal chain stub: .from().select().eq().maybeSingle() for dedup, .insert().select().single() for create. */
+function clientWithInsertResult(insertResult) {
+  // NB: `.in()` is required — the dedup query is
+  // .select(...).eq('failure_signature', ...).in('status', ['OPEN','IN_REVIEW']).maybeSingle().
+  // Omitting it made every call throw "….in is not a function", which the fail-soft wrapper duly
+  // caught — so the tests failed for a scaffolding reason while LOOKING like a code failure.
+  const chain = {
+    select: () => chain,
+    eq: () => chain,
+    in: () => chain,
+    order: () => chain,
+    limit: () => chain,
+    maybeSingle: async () => ({ data: null, error: null }),
+    single: async () => insertResult,
+    insert: () => chain,
+    update: () => chain,
+  };
+  return { from: () => chain };
+}
+
+const PARAMS = {
+  scope_type: 'RUNTIME',
+  trigger_source: 'RUNTIME',
+  trigger_tier: 1,
+  failure_signature: 'rls-denial-fixture',
+  problem_statement: 'fixture',
+  observed: {},
+  expected: {},
+  evidence_refs: {},
+  impact_level: 'CRITICAL',
+  likelihood_level: 'RARE',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+describe('triggerRCA fail-soft (QF-20260726-175)', () => {
+  test('THE REGRESSION GUARD: an RLS denial resolves to null instead of rejecting', async () => {
+    // The exact shape from the crash log: .../engineer-20260726-185743.log
+    //   Failed to create RCR: { code: '42501', message: 'new row violates row-level security policy...' }
+    // The OLD implementation threw here, which killed the process. If the throw is restored, this
+    // test fails — it is the falsifiable half.
+    createSupabaseClient.mockReturnValue(clientWithInsertResult({
+      data: null,
+      error: { code: '42501', message: 'new row violates row-level security policy for table "root_cause_reports"' },
+    }));
+
+    await expect(triggerRCA(PARAMS)).resolves.toBeNull();
+  });
+
+  test('the failure is LOUD — a dropped RCR is still a real loss of diagnostic coverage', async () => {
+    // Fail-soft must not mean fail-silent: the QF is explicit that silently losing RCRs is the
+    // same class of invisible failure as the crash itself.
+    createSupabaseClient.mockReturnValue(clientWithInsertResult({
+      data: null,
+      error: { code: '42501', message: 'denied' },
+    }));
+
+    await triggerRCA(PARAMS);
+
+    const logged = console.error.mock.calls.flat().join(' ');
+    expect(logged).toMatch(/RCR NOT RECORDED/);
+    expect(logged).toContain('42501');
+    expect(logged).toContain('rls-denial-fixture');
+  });
+
+  test('a thrown (non-Supabase-error) failure is also contained', async () => {
+    // Covers the class, not just the one error shape — e.g. the client itself blowing up.
+    createSupabaseClient.mockImplementation(() => { throw new Error('client exploded'); });
+
+    await expect(triggerRCA(PARAMS)).resolves.toBeNull();
+    expect(console.error.mock.calls.flat().join(' ')).toContain('client exploded');
+  });
+
+  test('CONTROL: a successful write still returns the RCR id and is not swallowed', async () => {
+    // Proves the tests above pass because failures are contained, NOT because triggerRCA has
+    // stopped doing its job and returns null unconditionally.
+    createSupabaseClient.mockReturnValue(clientWithInsertResult({
+      data: { id: 'rcr-abc-123' },
+      error: null,
+    }));
+
+    await expect(triggerRCA(PARAMS)).resolves.toBe('rcr-abc-123');
+  });
+});


### PR DESCRIPTION
One unhandled rejection took down the control plane for 1h45m. An RLS denial (`42501`) inserting into `root_cause_reports` threw out of `triggerRCA`; all six call sites are `await triggerRCA(...)` inside **Supabase realtime subscription callbacks**, so the throw became an unhandled rejection and Node's default `--unhandled-rejections=throw` terminated the process.

Port 8080 stayed up, so the app looked alive while the API behind it was gone — and the dead API then told the chairman *no coordinator is live*, which would have had him spawn a second one and silently depose the live incumbent.

## (a) `triggerRCA` never rejects

The original body is preserved verbatim as `triggerRCAOrThrow`; the exported wrapper catches everything, logs loudly, and returns `null`.

Fixed **centrally** rather than wrapping six awaits — safe because no call site consumes the return value (verified at lines 41, 70, 138, 198, 227, 290 *before* making the change). The asymmetry is the point: this is a **diagnostic side-write** whose job is to record why something else broke, so it must never be able to break the thing it observes.

Loud, not silent — a dropped RCR is still a real loss of diagnostic coverage, it just must not be a *fatal* one.

## (b) Process-level backstop

Registered in `server/index.js` before `listen`, so it also covers startup rejections. This fixes the **class**, not just this call path.

**Deliberately rejections only.** `lib/feedback-capture.js` `initializeErrorHandlers()` would install both handlers, but its `uncaughtException` arm swallows the error with the re-throw commented out — resuming after a genuine uncaught exception can continue from corrupt state, a riskier trade than this QF asks for.

> **Separate finding, reported not adopted:** `initializeErrorHandlers()` is *never called anywhere in the repo*. The crash backstop was built and never wired.

## (c) Not done here — this row must not close on this PR

The RLS denial itself is unresolved. An RLS/policy change is a Tier 3 risk keyword and cannot ride a QF. **Until it is fixed, RCRs are still not being recorded** — the server just survives it now. The QF says explicitly not to close without resolving this.

## Tests

Exercise the **real exported** `triggerRCA`. The pre-existing suite declares its own local `createRCR` copy, which could never catch a regression in the shipped function. **30 pass across both suites** (4 new), including a control that a successful write still returns its id — so the fail-soft tests can't pass by `triggerRCA` simply having stopped working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)