### PR TITLE
fix(SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001): repair the promotion-time resolution check instead of adding a second one

### DIFF
--- a/lib/coordinator/signal-router.cjs
+++ b/lib/coordinator/signal-router.cjs
@@ -99,9 +99,43 @@ async function findExistingFeedback(supabase, fp) {
   return data || null;
 }
 
+/**
+ * SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001 (FR-3): worker signal payloads DO carry
+ * sd_key, but nothing here ever mapped it onto the feedback row — measured consequence, across the
+ * 61 feedback rows behind the promoted-QF cohort: sd_id populated 0/61, strategic_directive_id
+ * 1/61. So the promoter could not know a signal already belonged to work in flight, and QFs were
+ * minted duplicating an SD's own scope.
+ *
+ * Resolves the key to the SD's UUID because that is what existing populated rows hold. Returns
+ * null on anything ambiguous — zero keys, MORE THAN ONE distinct key across the aggregated group,
+ * an unresolvable key, or a query error. A wrong FK is worse than a null one: it would point the
+ * resolution check at unrelated work and could suppress a real defect.
+ */
+async function resolveGroupSdId(supabase, group) {
+  try {
+    const keys = [...new Set((group.rows || []).map(r => r.payload?.sd_key).filter(Boolean))];
+    if (keys.length !== 1) return null;
+    const { data, error } = await supabase
+      .from('strategic_directives_v2')
+      .select('id')
+      .eq('sd_key', keys[0])
+      .limit(1);
+    if (error || !data || !data.length) return null;
+    return { sdId: data[0].id, sdKey: keys[0] };
+  } catch {
+    return null; // never block signal routing on this enrichment
+  }
+}
+
 async function insertFeedbackRow(supabase, group) {
   const title = (group.sample_body || `${group.signal_type} (recurring)`).slice(0, 120);
-  const description = `Worker signal aggregation (${group.callsigns.size} contributing callsign(s), severity ${group.max_severity}). Signal type: ${group.signal_type}. Sample body: ${group.sample_body.slice(0, 500)}`;
+  const linked = await resolveGroupSdId(supabase, group);
+  // The sd_key is also written into the description so it survives into the promoted QF's title/
+  // body, where extractWorkIdentifiers (lib/eva/feedback-premise-adapter.js, FR-2) can lift it back
+  // out as an exact lookup token. Belt and braces: the column enables the join, the text keeps the
+  // identifier recoverable even for rows whose key could not be resolved to a UUID.
+  const sdNote = linked ? ` Relates to: ${linked.sdKey}.` : '';
+  const description = `Worker signal aggregation (${group.callsigns.size} contributing callsign(s), severity ${group.max_severity}). Signal type: ${group.signal_type}.${sdNote} Sample body: ${group.sample_body.slice(0, 500)}`;
   const { data, error } = await supabase
     .from('feedback')
     .insert({
@@ -113,8 +147,11 @@ async function insertFeedbackRow(supabase, group) {
       source_type: 'manual_feedback',
       title,
       description,
+      // FR-3: only ever set when unambiguously resolved (see resolveGroupSdId).
+      ...(linked ? { sd_id: linked.sdId } : {}),
       metadata: {
         logged_via: 'signal-router.cjs',
+        ...(linked ? { sd_key: linked.sdKey } : {}),
         signal_fingerprint: group.fingerprint,
         signal_type: group.signal_type,
         contributing_workers: Array.from(group.callsigns),

--- a/lib/eva/feedback-premise-adapter.js
+++ b/lib/eva/feedback-premise-adapter.js
@@ -46,7 +46,33 @@ export function feedbackToPremiseDescriptor(feedbackRow = {}) {
     referenced_files: extractReferencedFiles(text),
     feedback_id: feedbackRow.id || null,
     category: feedbackRow.category || null,
+    // SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001 (FR-2): structured work identifiers
+    // lifted out of the prose. cluster_reason above is 80 chars of a worker's message body, which
+    // can never match an SD title or a git log entry — but workers DO name real rows inline
+    // ("duplicate of QF-20260713-175", "already covered by SD-LEO-INFRA-..."). Those strings are
+    // exact, so they give the resolution check something precise to look up.
+    //
+    // ADDITIVE ON PURPOSE: cluster_reason is left as the per-row title. QF-20260703-428 narrowed
+    // identity to the per-row title precisely because a coarse shared key (then `category`) let one
+    // row's shipped fix mark every same-bucket row STALE. Identifiers are offered as EXTRA lookup
+    // keys, never as a replacement identity, so that regression cannot recur through this door.
+    identifiers: extractWorkIdentifiers(text),
   };
+}
+
+/**
+ * Extract SD keys and QF ids appearing verbatim in signal prose.
+ * Deduped, order-preserving, capped — these become additional lookup tokens, not identity.
+ */
+export function extractWorkIdentifiers(text) {
+  const out = [];
+  const seen = new Set();
+  for (const re of [/\bQF-\d{8}-\d{3}\b/g, /\bSD-[A-Z0-9]+(?:-[A-Z0-9]+)*-\d{3}\b/g]) {
+    for (const m of String(text || '').toUpperCase().matchAll(re)) {
+      if (!seen.has(m[0])) { seen.add(m[0]); out.push(m[0]); }
+    }
+  }
+  return out.slice(0, 5);
 }
 
 /**

--- a/lib/eva/premise-liveness.js
+++ b/lib/eva/premise-liveness.js
@@ -51,6 +51,28 @@ function premiseToken(descriptor) {
   return (descriptor.gate_name || descriptor.cluster_reason || '').trim();
 }
 
+/**
+ * SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001 (FR-2): make a token safe to interpolate
+ * into a PostgREST `.or()` filter.
+ *
+ * PostgREST parses `.or(a.ilike.%x%,b.ilike.%x%)` as a comma-separated logic tree, so a token
+ * containing a comma or an unbalanced parenthesis silently produces "failed to parse logic tree"
+ * rather than a match. Tokens here are worker prose (feedback.title.slice(0,80), measured avg 117
+ * chars before truncation), so those characters are common, not exotic — this broke the lookup on
+ * a measured 785/973 (81%) of the live 14-day pool.
+ *
+ * Strips the logic-tree metacharacters and collapses whitespace. This trades a little recall (the
+ * remaining fragment is matched with ilike wildcards either side) for a query that actually runs;
+ * precision is recovered separately by the structured identifiers in FR-2's second half.
+ * Returns '' when nothing usable survives, which callers treat as "no token".
+ */
+export function sanitizeOrToken(token) {
+  return String(token || '')
+    .replace(/[(),"\\*]/g, ' ')   // logic-tree metacharacters + ilike wildcard
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
 /** Defensively extract a reason string from a heterogeneous handoff row. */
 function handoffReasonText(row) {
   const parts = [
@@ -110,14 +132,15 @@ async function findShippedFix(supabase, git, descriptor, completedDays, nowMs) {
   // was emitted, and `found` stayed false — INDISTINGUISHABLE from a clean "no completed SD
   // references this". The check FAILED GREEN on a measured 785/973 (81%) of the live 14-day
   // harness_backlog pool while every verdict still read as considered.
-  if (supabase && token) {
+  const safeToken = sanitizeOrToken(token);
+  if (supabase && safeToken) {
     try {
       const { data, error } = await supabase
         .from('strategic_directives_v2')
         .select('sd_key, title, completion_date')
         .eq('status', 'completed')
         .gte('completion_date', cutoffISO(completedDays, nowMs))
-        .or(`title.ilike.%${token}%,description.ilike.%${token}%`)
+        .or(`title.ilike.%${safeToken}%,description.ilike.%${safeToken}%`)
         .limit(5);
       if (error) {
         // Indeterminate, NOT "nothing found". Surfaced so an operator can tell the two apart.
@@ -130,6 +153,33 @@ async function findShippedFix(supabase, git, descriptor, completedDays, nowMs) {
     } catch (e) {
       lookupIndeterminate = true;
       evidence.push(`Completed-SD check skipped: ${e?.message || e}`);
+    }
+  }
+
+  // SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001 (FR-2, second half): EXACT lookup on any
+  // SD keys the signal names inline. The ilike-on-prose path above is inherently low-precision —
+  // this one is not, because an sd_key is an exact string. Runs in ADDITION to it, never instead:
+  // a signal naming no SD is unaffected, and a match here is the strongest "already handled"
+  // evidence available without any schema change.
+  const sdIdentifiers = (descriptor.identifiers || []).filter(id => /^SD-/.test(id));
+  if (supabase && sdIdentifiers.length) {
+    try {
+      const { data, error } = await supabase
+        .from('strategic_directives_v2')
+        .select('sd_key, title, status, completion_date')
+        .in('sd_key', sdIdentifiers)
+        .eq('status', 'completed')
+        .limit(5);
+      if (error) {
+        lookupIndeterminate = true;
+        evidence.push(`Named-SD check failed: ${error.message || error}`);
+      } else if (data && data.length > 0) {
+        found = true;
+        evidence.push(`Signal names already-completed SD(s): ${data.map(s => s.sd_key).join(', ')}`);
+      }
+    } catch (e) {
+      lookupIndeterminate = true;
+      evidence.push(`Named-SD check skipped: ${e?.message || e}`);
     }
   }
 

--- a/lib/eva/premise-liveness.js
+++ b/lib/eva/premise-liveness.js
@@ -96,22 +96,39 @@ async function findShippedFix(supabase, git, descriptor, completedDays, nowMs) {
   const evidence = [];
   let found = false;
   let fileMatch = false;
+  // FR-1: true when a resolution signal could not be evaluated at all (query error), as opposed
+  // to being evaluated and coming back empty. An indeterminate lookup must never help support an
+  // ARCHIVE recommendation — see the STALE branch in checkPremiseLiveness.
+  let lookupIndeterminate = false;
 
   // Completed SD referencing the token (reuses the kr-reality-checker ilike pattern)
+  //
+  // SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001 (FR-1): this block used to destructure
+  // ONLY { data }, discarding { error }. PostgREST rejects the .or() logic tree whenever the
+  // interpolated token carries a comma or parenthesis, and the token is routinely raw worker
+  // prose. The discarded error meant no throw, so the catch below never ran, no evidence line
+  // was emitted, and `found` stayed false — INDISTINGUISHABLE from a clean "no completed SD
+  // references this". The check FAILED GREEN on a measured 785/973 (81%) of the live 14-day
+  // harness_backlog pool while every verdict still read as considered.
   if (supabase && token) {
     try {
-      const { data } = await supabase
+      const { data, error } = await supabase
         .from('strategic_directives_v2')
         .select('sd_key, title, completion_date')
         .eq('status', 'completed')
         .gte('completion_date', cutoffISO(completedDays, nowMs))
         .or(`title.ilike.%${token}%,description.ilike.%${token}%`)
         .limit(5);
-      if (data && data.length > 0) {
+      if (error) {
+        // Indeterminate, NOT "nothing found". Surfaced so an operator can tell the two apart.
+        lookupIndeterminate = true;
+        evidence.push(`Completed-SD check failed: ${error.message || error}`);
+      } else if (data && data.length > 0) {
         found = true;
         evidence.push(`Completed SD(s) within ${completedDays}d reference "${token}": ${data.map(s => s.sd_key).join(', ')}`);
       }
     } catch (e) {
+      lookupIndeterminate = true;
       evidence.push(`Completed-SD check skipped: ${e?.message || e}`);
     }
   }
@@ -141,7 +158,7 @@ async function findShippedFix(supabase, git, descriptor, completedDays, nowMs) {
     }
   }
 
-  return { found, fileMatch, evidence };
+  return { found, fileMatch, evidence, lookupIndeterminate };
 }
 
 /**
@@ -186,6 +203,22 @@ export async function checkPremiseLiveness(descriptor = {}, deps = {}) {
       evidence.push(`${recentCount} rejection(s) cite "${token}" in the last ${recentDays}d`);
     }
     evidence.push(...fix.evidence);
+
+    // SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001 (FR-1 / TR-4): STALE recommends ARCHIVE,
+    // i.e. it DROPS the work — the dangerous direction. The verdict rests on two resolution
+    // signals (completed-SD lookup, git history). If one could not be evaluated at all, the
+    // checker does not have the evidence to call anything "provably dead", even when the other
+    // signal did match. Downgrade to HOLD_FOR_REVIEW rather than archive on partial evidence.
+    // This is deliberately asymmetric: an indeterminate lookup can only ever make the verdict
+    // MORE conservative, never less.
+    if (recentCount === 0 && fix.found && fix.lookupIndeterminate) {
+      return {
+        status: 'LIVE',
+        confidence_score: 0.3,
+        evidence: [...evidence, 'Verdict: LIVE (HOLD_FOR_REVIEW) — a shipped fix was found, but the completed-SD lookup could not be evaluated, so the premise is NOT provably dead'],
+        recommendation: 'HOLD_FOR_REVIEW',
+      };
+    }
 
     // STALE only when we have a real recount of ~0 AND a shipped fix exists.
     if (recentCount === 0 && fix.found) {

--- a/lib/feedback/promoted-severity.js
+++ b/lib/feedback/promoted-severity.js
@@ -1,0 +1,72 @@
+/**
+ * SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001 (FR-5) — derive the severity a promoted QF
+ * enters the belt with, instead of inheriting the reporter's own urgency wording verbatim.
+ *
+ * THE MEASURED PROBLEM. Severity was pure inheritance across eight hops with no reassignment point
+ * anywhere: the self-declared `--severity` flag on scripts/worker-signal.cjs flows into the signal
+ * payload, into the feedback row via signal-router, into group.max_severity, into the promoter's
+ * --severity argument, and into the QF. feedback.severity equalled quick_fixes.severity for 61/61
+ * rows of the cohort. The result: 49 of 53 promoted rows are severity=critical. critical-qf-jump
+ * exists to pull genuine criticals ahead of ranked SD work on EVERY seat — when nearly everything
+ * arrives critical it stops selecting and merely reorders, so the lane loses its meaning.
+ *
+ * THE POLICY, and why it is drawn here rather than at the promotion decision.
+ * A `critical` claim that no second reporter has corroborated is an UNWITNESSED claim. It should
+ * still become work immediately — it does — but it should not preempt every seat in the fleet on
+ * one author's adjective. So an uncorroborated critical enters at `high`.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO:
+ *  - It does NOT touch THRESHOLD or the single-critical bypass in lib/shared/content-fingerprint.cjs.
+ *    The SD forbids that, and rightly: a lone worker hitting a genuine fault must not have to wait
+ *    for two peers before the item exists at all. Promotion timing is unchanged — only the severity
+ *    the resulting QF carries is derived.
+ *  - It does NOT downgrade anything below critical. A `high`/`medium`/`low` signal is returned
+ *    untouched, so no existing non-critical path changes behaviour.
+ *  - It does NOT make critical unreachable. Corroboration by a second callsign, or a second
+ *    occurrence of the same fingerprint, yields critical — as does any manual escalation
+ *    afterwards. "Uncorroborated" is a statement about evidence, not a verdict about the defect.
+ *
+ * Pure and side-effect free ON PURPOSE: the promoter itself is a top-level-await ESM script, so
+ * importing it to test anything executes the whole promoter. That is a large part of why it has
+ * never had CI coverage. Keeping the policy in its own module makes it unit-testable under the
+ * runner that actually runs (see tests/unit/feedback/promoted-severity.test.js).
+ */
+
+/** Severities that a corroborated report may retain. Anything not listed passes through unchanged. */
+const CRITICAL = 'critical';
+const UNCORROBORATED_CRITICAL_CEILING = 'high';
+
+/**
+ * @param {Object} input
+ * @param {string} input.declared      - severity as reported (group.max_severity)
+ * @param {number} [input.callsigns]   - distinct contributing callsigns (corroborating reporters)
+ * @param {number} [input.occurrences] - contributing source rows in the fingerprint group
+ * @returns {{severity: string, derived: boolean, reason: string}}
+ *   `derived` is true only when the value differs from `declared`, so callers can log the
+ *   difference rather than silently substituting — an unexplained severity change is its own
+ *   observability problem.
+ */
+export function derivePromotedSeverity({ declared, callsigns = 0, occurrences = 0 } = {}) {
+  const value = String(declared || '').toLowerCase();
+
+  if (value !== CRITICAL) {
+    return { severity: declared, derived: false, reason: 'non-critical severity passes through unchanged' };
+  }
+
+  const corroborated = Number(callsigns) >= 2 || Number(occurrences) >= 2;
+  if (corroborated) {
+    return {
+      severity: CRITICAL,
+      derived: false,
+      reason: `critical retained — corroborated by ${callsigns} callsign(s) across ${occurrences} occurrence(s)`,
+    };
+  }
+
+  return {
+    severity: UNCORROBORATED_CRITICAL_CEILING,
+    derived: true,
+    reason: 'critical claimed by a single reporter with no second occurrence — promoted at high so it becomes work immediately without preempting every seat; corroboration or manual escalation restores critical',
+  };
+}
+
+export default derivePromotedSeverity;

--- a/scripts/feedback-fingerprint-promoter.mjs
+++ b/scripts/feedback-fingerprint-promoter.mjs
@@ -29,6 +29,7 @@ import { execFileSync } from 'node:child_process';
 import { createClient } from '@supabase/supabase-js';
 import { groupByFingerprint, shouldPromote } from '../lib/shared/content-fingerprint.cjs';
 import { fetchAllPaginated } from '../lib/db/fetch-all-paginated.mjs';
+import { derivePromotedSeverity } from '../lib/feedback/promoted-severity.js';
 
 const apply = process.argv.includes('--apply');
 const WINDOW_DAYS = 14;
@@ -107,14 +108,28 @@ for (const group of groups.values()) {
   }
 
   const title = `[Fingerprint x${sourceIds.length}] ${(group.sample_body.split('\n')[0] || group.fingerprint).slice(0, 100)}`;
-  const description = `Auto-promoted from ${sourceIds.length} harness_backlog occurrences sharing fingerprint ${group.fingerprint} within a ${WINDOW_DAYS}-day window. Source feedback row ids: ${sourceIds.join(', ')}.`;
+
+  // SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001 (FR-5): derive the severity the QF enters
+  // the belt with rather than inheriting the reporter's own adjective. Corroboration is counted
+  // from the distinct callsigns signal-router stamped across the contributing rows.
+  const callsigns = new Set();
+  for (const r of group.rows) for (const c of (r.metadata?.contributing_callsigns || [])) callsigns.add(c);
+  const sev = derivePromotedSeverity({
+    declared: group.max_severity,
+    callsigns: callsigns.size,
+    occurrences: sourceIds.length,
+  });
+  if (sev.derived) console.log(`  [SEVERITY] ${group.max_severity} -> ${sev.severity}: ${sev.reason}`);
+
+  const description = `Auto-promoted from ${sourceIds.length} harness_backlog occurrences sharing fingerprint ${group.fingerprint} within a ${WINDOW_DAYS}-day window. Source feedback row ids: ${sourceIds.join(', ')}.`
+    + (sev.derived ? ` Severity derived: reported ${group.max_severity}, promoted ${sev.severity} — ${sev.reason}` : '');
 
   try {
     execFileSync('node', [
       'scripts/create-quick-fix.js',
       '--title', title,
       '--type', 'bug',
-      '--severity', group.max_severity,
+      '--severity', sev.severity,
       '--description', description,
       '--feedback-id', sourceIds.join(','),
     ], { stdio: 'inherit' });

--- a/scripts/feedback-fingerprint-promoter.mjs
+++ b/scripts/feedback-fingerprint-promoter.mjs
@@ -53,6 +53,18 @@ try {
     .eq('category', 'harness_backlog')
     .is('archived_at', null)
     .gte('created_at', cutoff)
+    // SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001 (FR-4): this predicate had NO status
+    // filter at all, so a row already marked resolved stayed promotion-eligible for its whole
+    // 14-day window. Measured live at authoring time: 38 resolved + 1 invalid in-window rows were
+    // still eligible to be minted into fresh QFs.
+    //
+    // Written as "null OR not-in(terminal)" rather than an allow-list of good statuses, for two
+    // reasons. (1) SQL semantics: `status NOT IN (...)` evaluates to NULL for a NULL status, which
+    // would silently DROP those rows — the fail-closed direction, and dropping real work is the
+    // dangerous one here. (2) An allow-list would silently exclude any status added later, failing
+    // closed by default. Only known-terminal statuses are excluded; everything else, including
+    // NULL and any future value, still promotes exactly as before.
+    .or('status.is.null,status.not.in.(resolved,invalid)')
     .order('id', { ascending: true })); // unique tiebreaker (FR-6)
 } catch (e) {
   console.error('ERROR (select):', JSON.stringify({ message: e.message }));

--- a/tests/unit/feedback/promoted-severity.test.js
+++ b/tests/unit/feedback/promoted-severity.test.js
@@ -1,0 +1,65 @@
+// SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001 (FR-5) — promoted severity is DERIVED, not
+// inherited from the reporter's own adjective. Measured baseline: 49 of 53 promoted rows arrived
+// severity=critical because severity was pure inheritance across eight hops (feedback.severity
+// equalled quick_fixes.severity for 61/61), which left critical-qf-jump reordering rather than
+// selecting.
+//
+// Lives in tests/unit/feedback/ deliberately: per this SD's TR-2 the promoter's only pre-existing
+// test sits in the db project, gated to an empty include, and has never executed in CI. This path
+// matches unit-tier.yml's **/*.test.js glob and actually runs.
+import { describe, it, expect } from 'vitest';
+import { derivePromotedSeverity } from '../../../lib/feedback/promoted-severity.js';
+
+describe('derivePromotedSeverity (FR-5)', () => {
+  it('passes non-critical severities through completely unchanged', () => {
+    for (const declared of ['high', 'medium', 'low']) {
+      const r = derivePromotedSeverity({ declared, callsigns: 1, occurrences: 1 });
+      expect(r.severity).toBe(declared);
+      expect(r.derived).toBe(false);
+    }
+  });
+
+  it('caps an UNCORROBORATED critical at high — one author\'s adjective must not preempt every seat', () => {
+    const r = derivePromotedSeverity({ declared: 'critical', callsigns: 1, occurrences: 1 });
+    expect(r.severity).toBe('high');
+    expect(r.derived).toBe(true);
+    expect(r.reason).toMatch(/single reporter/i);
+  });
+
+  // The SD forbids anything that "breaks genuine worker criticals". These two are that guard.
+  it('RETAINS critical when a second callsign corroborates', () => {
+    const r = derivePromotedSeverity({ declared: 'critical', callsigns: 2, occurrences: 1 });
+    expect(r.severity).toBe('critical');
+    expect(r.derived).toBe(false);
+  });
+
+  it('RETAINS critical when the fingerprint recurs, even from one callsign', () => {
+    const r = derivePromotedSeverity({ declared: 'critical', callsigns: 1, occurrences: 2 });
+    expect(r.severity).toBe('critical');
+    expect(r.derived).toBe(false);
+  });
+
+  it('is case-insensitive on the declared value', () => {
+    expect(derivePromotedSeverity({ declared: 'CRITICAL', callsigns: 1, occurrences: 1 }).severity).toBe('high');
+    expect(derivePromotedSeverity({ declared: 'CRITICAL', callsigns: 3, occurrences: 3 }).severity).toBe('critical');
+  });
+
+  it('is total — missing/garbage input never throws and never invents a critical', () => {
+    for (const input of [undefined, {}, { declared: null }, { declared: '' }, { declared: 'nonsense' }]) {
+      const r = derivePromotedSeverity(input);
+      expect(r).toHaveProperty('severity');
+      expect(r.severity).not.toBe('critical');
+    }
+  });
+
+  it('always explains itself, so a severity change is never silent', () => {
+    for (const r of [
+      derivePromotedSeverity({ declared: 'critical', callsigns: 1, occurrences: 1 }),
+      derivePromotedSeverity({ declared: 'critical', callsigns: 2, occurrences: 2 }),
+      derivePromotedSeverity({ declared: 'low' }),
+    ]) {
+      expect(typeof r.reason).toBe('string');
+      expect(r.reason.length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/unit/premise-liveness.test.js
+++ b/tests/unit/premise-liveness.test.js
@@ -11,7 +11,7 @@ const NOW = Date.parse('2026-06-23T00:00:00Z');
 // Configurable supabase double supporting both query chains the checker uses:
 //   sd_phase_handoffs: select → eq → gte → order → range (paginated, FR-6 batch 7)
 //   strategic_directives_v2: select → eq → gte → or → limit
-function mockSb({ handoffs = [], handoffsError = null, completed = [] } = {}) {
+function mockSb({ handoffs = [], handoffsError = null, completed = [], completedError = null } = {}) {
   return {
     from(table) {
       if (table === 'sd_phase_handoffs') {
@@ -24,7 +24,7 @@ function mockSb({ handoffs = [], handoffsError = null, completed = [] } = {}) {
         return b;
       }
       if (table === 'strategic_directives_v2') {
-        return { select: () => ({ eq: () => ({ gte: () => ({ or: () => ({ limit: () => Promise.resolve({ data: completed, error: null }) }) }) }) }) };
+        return { select: () => ({ eq: () => ({ gte: () => ({ or: () => ({ limit: () => Promise.resolve({ data: completedError ? null : completed, error: completedError }) }) }) }) }) };
       }
       return null;
     },
@@ -173,5 +173,49 @@ describe('ingestProposalObject stale-guard (FR-2)', () => {
       { deps: { keyExists: async () => true, createSD: async () => {} } }
     );
     expect(res.action).toBe('skipped');
+  });
+});
+
+// SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001 (FR-1) — the completed-SD lookup must not
+// FAIL GREEN. premise-liveness.js:103 destructured only { data } from the strategic_directives_v2
+// .or(title.ilike,description.ilike) call, discarding { error }. PostgREST rejects the logic tree
+// whenever the interpolated token contains a comma or parenthesis — and the token is
+// feedback.title.slice(0,80), i.e. raw worker prose (measured avg 117 chars). With the error
+// discarded nothing throws, the catch never runs, no evidence line is emitted, and the verdict
+// still reads like a considered LIVE. Measured inert on 785/973 (81%) of the live 14-day pool.
+//
+// Failing OPEN to LIVE is the correct DIRECTION and is deliberately preserved here — dropping a
+// real premise is the dangerous direction. What this asserts is that the failure is OBSERVABLE:
+// an operator (and the promotion path that consumes this verdict) must be able to tell "the
+// resolution check could not run" apart from "the resolution check ran and found nothing".
+describe('checkPremiseLiveness — completed-SD lookup must surface query failure (FR-1)', () => {
+  const logicTreeError = { message: 'failed to parse logic tree ((title.ilike.%FOLLOW-UP on signal c6bfe6dc (venture_user_select%))' };
+
+  it('surfaces the failed completed-SD lookup in evidence instead of silently reporting nothing', async () => {
+    const res = await checkPremiseLiveness(
+      { gate_name: GATE },
+      { supabase: mockSb({ handoffs: [rejection(GATE)], completedError: logicTreeError }), git: noGit, nowMs: NOW }
+    );
+    const joined = res.evidence.join(' | ');
+    expect(joined).toMatch(/Completed-SD check (skipped|failed|unavailable)/i);
+    expect(joined).toMatch(/logic tree/i);
+  });
+
+  it('still fails OPEN to LIVE on lookup failure — never STALE (a failed check must not drop real work)', async () => {
+    const res = await checkPremiseLiveness(
+      { gate_name: GATE },
+      { supabase: mockSb({ handoffs: [], completedError: logicTreeError }), git: gitWithCommits, nowMs: NOW }
+    );
+    // recentCount===0 AND a git fix "found" would otherwise satisfy the STALE branch; an
+    // indeterminate SD lookup must not be allowed to help manufacture a STALE verdict.
+    expect(res.status).toBe('LIVE');
+  });
+
+  it('a successful lookup that genuinely finds nothing is DISTINGUISHABLE from a failed one', async () => {
+    const res = await checkPremiseLiveness(
+      { gate_name: GATE },
+      { supabase: mockSb({ handoffs: [rejection(GATE)], completed: [] }), git: noGit, nowMs: NOW }
+    );
+    expect(res.evidence.join(' | ')).not.toMatch(/Completed-SD check (skipped|failed|unavailable)/i);
   });
 });

--- a/tests/unit/premise-liveness.test.js
+++ b/tests/unit/premise-liveness.test.js
@@ -3,7 +3,8 @@
 // exists; LIVE when recent >= threshold; LIVE-but-warn on ambiguity (NEVER STALE). The leo-create-sd
 // stale-guard skips STALE diagnostic proposals (no SD created) and fails OPEN on any checker error.
 import { describe, it, expect } from 'vitest';
-import { checkPremiseLiveness } from '../../lib/eva/premise-liveness.js';
+import { checkPremiseLiveness, sanitizeOrToken } from '../../lib/eva/premise-liveness.js';
+import { extractWorkIdentifiers } from '../../lib/eva/feedback-premise-adapter.js';
 import { ingestProposalObject } from '../../scripts/leo-create-sd.js';
 
 const NOW = Date.parse('2026-06-23T00:00:00Z');
@@ -217,5 +218,54 @@ describe('checkPremiseLiveness — completed-SD lookup must surface query failur
       { supabase: mockSb({ handoffs: [rejection(GATE)], completed: [] }), git: noGit, nowMs: NOW }
     );
     expect(res.evidence.join(' | ')).not.toMatch(/Completed-SD check (skipped|failed|unavailable)/i);
+  });
+});
+
+// SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001 (FR-2) — the lookup token must be safe to
+// interpolate into a PostgREST .or() logic tree, and structured work identifiers named inline in
+// worker prose must be usable as exact lookup keys.
+describe('sanitizeOrToken + identifier extraction (FR-2)', () => {
+  // This is a REAL cohort title, taken verbatim from a promoted feedback row. Its parenthesis and
+  // comma are what produced "failed to parse logic tree" on 785/973 rows of the live pool.
+  const REAL = 'FOLLOW-UP on signal c6bfe6dc (venture_user_select_feedback anon-RLS exposure, P0';
+
+  it('strips the logic-tree metacharacters that break the query', () => {
+    const safe = sanitizeOrToken(REAL);
+    expect(safe).not.toMatch(/[(),"\*]/);
+    expect(safe).toMatch(/FOLLOW-UP on signal c6bfe6dc/);
+  });
+
+  it('is total — never returns null/undefined, and yields empty string for empty input', () => {
+    for (const input of [null, undefined, '', '   ', '(),"']) {
+      expect(typeof sanitizeOrToken(input)).toBe('string');
+    }
+    expect(sanitizeOrToken('(),"')).toBe('');
+  });
+
+  it('extracts SD keys and QF ids named inline in prose, deduped', () => {
+    const ids = extractWorkIdentifiers('MOOT — duplicate of QF-20260713-175, already covered by SD-LEO-INFRA-FIX-WINDOWS-SESSION-001 and QF-20260713-175 again');
+    expect(ids).toContain('QF-20260713-175');
+    expect(ids).toContain('SD-LEO-INFRA-FIX-WINDOWS-SESSION-001');
+    expect(ids.filter(i => i === 'QF-20260713-175')).toHaveLength(1);
+  });
+
+  it('returns no identifiers for prose that names none', () => {
+    expect(extractWorkIdentifiers('the coordinator inbox is noisy tonight')).toEqual([]);
+  });
+
+  it('a signal naming an already-completed SD is treated as an already-shipped fix', async () => {
+    const sb = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({ gte: () => ({ or: () => ({ limit: () => Promise.resolve({ data: [], error: null }) }) }) }),
+          in: () => ({ eq: () => ({ limit: () => Promise.resolve({ data: [{ sd_key: 'SD-LEO-INFRA-FIX-WINDOWS-SESSION-001' }], error: null }) }) }),
+        }),
+      }),
+    };
+    const res = await checkPremiseLiveness(
+      { cluster_reason: 'some prose', identifiers: ['SD-LEO-INFRA-FIX-WINDOWS-SESSION-001'] },
+      { supabase: sb, git: noGit, nowMs: NOW }
+    );
+    expect(res.evidence.join(' | ')).toMatch(/names already-completed SD/i);
   });
 });


### PR DESCRIPTION
## Summary

Auto-promotion turns worker signals into quick_fixes, and the dominant cancellation reason across the 53-row cohort was "MOOT/ALREADY-RESOLVED" or "ALREADY FIXED BEFORE THIS QF WAS EVEN AUTO-PROMOTED" — the fleet kept burning seats discovering an item was already handled.

The SD asked to **add** a resolution check. LEAD measurement found one **already running** at `scripts/create-quick-fix.js:246` and **silently dead**, so four of the five FRs are repairs to that one path rather than new machinery.

- **FR-1** `lib/eva/premise-liveness.js` — the completed-SD lookup destructured only `{ data }`, discarding `{ error }`. PostgREST rejects the `.or()` logic tree whenever the token carries a comma or parenthesis, and the token is 80 chars of raw worker prose. No throw, no evidence line, `found` stayed false — indistinguishable from a clean "no match". **Measured inert on 785/973 (81%)** of the live 14-day pool. Now reports an explicit indeterminate outcome, and an indeterminate lookup can no longer support an ARCHIVE verdict.
- **FR-2** — `sanitizeOrToken()` strips the logic-tree metacharacters; `extractWorkIdentifiers()` lifts SD keys / QF ids named verbatim in prose for an exact `.in('sd_key', …)` lookup. Additive: `cluster_reason` is untouched so QF-20260703-428's cross-row false-STALE regression cannot recur.
- **FR-3** `lib/coordinator/signal-router.cjs` — `insertFeedbackRow` never mapped `payload.sd_key` (measured `sd_id` 0/61). Now resolved to UUID, returning null on **any** ambiguity — a wrong FK could suppress a real defect.
- **FR-4** `scripts/feedback-fingerprint-promoter.mjs` — no status filter existed. Verified live: 973 eligible → 934, excluding exactly the 38 resolved + 1 invalid.
- **FR-5** `lib/feedback/promoted-severity.js` (new) — severity was pure inheritance across 8 hops (49/53 promoted rows arrived critical). An **uncorroborated** critical now enters at high. `THRESHOLD` and the single-critical bypass are untouched.

### Scope corrections made at LEAD
The SD's own FR-2 (Adam/Solomon "lane leak") was **refuted by measurement** — 2142/2142 signal-carrying rows are `sender_type=worker`, 0/632 advisories carry `signal_type` — and descoped. An earlier recommendation to gate the critical bypass at N>1 was **retracted**: it is on the SD's `do_not_accept` list, because "already fixed before promotion" means a higher N mints the same moot row later.

## Test plan

- [x] FR-1 tests **proven RED against HEAD** before the fix, green after. The second assertion surfaced a defect the SD never named: a `git --grep` match alone was already driving `STALE`/ARCHIVE while a resolution signal had silently failed.
- [x] 26/26 on new/changed unit tests; **full suite 6900 passing / 530 files**
- [x] Tests placed under `tests/unit/**` so `unit-tier.yml` actually runs them — the promoter's only prior test sits in the db project gated to an empty include and has never executed in CI
- [x] Live dry-run of the promoter confirms wiring and the FR-4 predicate
- [x] Sub-agents: Explore, VALIDATION, TESTING ×2, SECURITY, RETRO — all PASS
- [x] Handoffs: LEAD-TO-PLAN 95, PLAN-TO-EXEC 97, EXEC-TO-PLAN 94, PLAN-TO-LEAD 96

The one boundary-config-coherence suite error is a full-suite `process.exit` interaction — verified passing 8/8 isolated on **both** this branch and a checkout without these changes.

**Reporter conflict disclosed:** the author generated part of this SD's supporting evidence and is a producer of the offending input class; built to the SD's FRs and `do_not_accept` list rather than to earlier conclusions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)