### PR TITLE
fix(QF-20260727-703): tick marker must follow an adopted parent PID

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "flags:stale": "node scripts/flags-stale.mjs",
     "flags:enroll": "node scripts/enroll-env-var-feature-flags.mjs",
     "test:smoke": "vitest run tests/smoke.test.js",
-    "test:session-tick": "node --test tests/unit/session-tick-heartbeat.test.mjs tests/unit/session-tick-release-on-exit.test.mjs tests/unit/session-tick-spawn-observe.test.mjs",
+    "test:session-tick": "node --test tests/unit/session-tick-heartbeat.test.mjs tests/unit/session-tick-release-on-exit.test.mjs tests/unit/session-tick-spawn-observe.test.mjs tests/unit/session-tick-marker-pid-refresh.test.mjs",
     "test:sd-key-generator-gate": "node --test tests/unit/sd-key-generator-coverage.test.mjs",
     "test:unit": "vitest run --project unit",
     "test:db": "vitest run --project db",

--- a/scripts/session-tick.cjs
+++ b/scripts/session-tick.cjs
@@ -85,6 +85,11 @@ const markerPath = path.join(pidsDir, `tick-${sessionId}.json`);
 
 // ── Marker management ────────────────────────────────────────────────────────
 
+// Captured ONCE. The marker is rewritten on parent-PID adoption (see parentInterval below), and
+// started_at means "when this tick daemon started" — recomputing it per write would silently
+// convert it into "time of last rewrite" for any reader that treats it as a daemon age.
+const markerStartedAt = new Date().toISOString();
+
 function writeMarker() {
   try {
     fs.mkdirSync(pidsDir, { recursive: true });
@@ -92,7 +97,7 @@ function writeMarker() {
       session_id: sessionId,
       tick_pid: process.pid,
       cc_parent_pid: parentPid,
-      started_at: new Date().toISOString(),
+      started_at: markerStartedAt,
       hostname: require('os').hostname(),
     };
     fs.writeFileSync(markerPath, JSON.stringify(marker, null, 2));
@@ -518,6 +523,16 @@ const parentInterval = setInterval(async () => {
   }
   if (rediscovered) {
     parentPid = rediscovered; // adopt the live PID; keep ticking
+    // QF-20260727-703: PERSIST the adoption. lib/fleet/claimant-liveness.cjs treats this marker's
+    // cc_parent_pid as its STRONGEST signal ("the only artifact that ties a pid back to the session
+    // that owns it") and it is that classifier's ONLY path to a DEAD verdict — every other path
+    // fails open to INDETERMINATE precisely because a recorded pid goes stale on rotation. The
+    // marker was written once at spawn, so adopting in memory alone left it naming the DEAD pid:
+    // a session that survives a /clear, reconnect or compaction then classified DEAD while alive,
+    // and its claims refused or reaped. Only long-lived sessions rotate their PID, so the failure
+    // was INVERTED WITH USEFULNESS — the more work a seat did, the likelier it got reaped.
+    // rediscoverParentPid() has already verified this pid is live, so the value written is sound.
+    writeMarker();
     parentMissCount = 0;
     return;
   }

--- a/tests/test-estate-mjs-allowlist.json
+++ b/tests/test-estate-mjs-allowlist.json
@@ -4,7 +4,8 @@
     "tests/unit/venture-email/provision-venture-email.test.mjs": "vitest unit project include (vitest.config.js **/tests/unit/venture-email/**/*.test.mjs)",
     "tests/unit/session-tick-heartbeat.test.mjs": "npm run test:session-tick (.github/workflows/unit-tier.yml)",
     "tests/unit/session-tick-release-on-exit.test.mjs": "npm run test:session-tick (.github/workflows/unit-tier.yml)",
-    "tests/unit/session-tick-spawn-observe.test.mjs": "npm run test:session-tick (.github/workflows/unit-tier.yml)"
+    "tests/unit/session-tick-spawn-observe.test.mjs": "npm run test:session-tick (.github/workflows/unit-tier.yml)",
+    "tests/unit/session-tick-marker-pid-refresh.test.mjs": "npm run test:session-tick (.github/workflows/unit-tier.yml)"
   },
   "legacy_unaudited": {
     "_doc": "DEBT REGISTER (pre-QF-20260712-023 files with no verified CI runner at seeding time — audit each: wire a lane and move it to lanes{}, or archive the file). Adding NEW entries here defeats the check's purpose.",

--- a/tests/unit/session-tick-marker-pid-refresh.test.mjs
+++ b/tests/unit/session-tick-marker-pid-refresh.test.mjs
@@ -1,0 +1,159 @@
+/**
+ * QF-20260727-703 — the tick marker must FOLLOW an adopted parent PID.
+ *
+ * THE BUG. scripts/session-tick.cjs wrote .claude/pids/tick-<session>.json exactly once, at
+ * spawn. When the pinned CC parent died and rediscoverParentPid() adopted a live replacement
+ * (/clear, reconnect, compaction), the adoption happened IN MEMORY ONLY — the marker kept
+ * naming the dead original pid.
+ *
+ * WHY THAT IS CRITICAL. lib/fleet/claimant-liveness.cjs treats this marker's cc_parent_pid as
+ * its strongest signal ("the only artifact that ties a pid back to the session that owns it")
+ * and it is that classifier's ONLY path to a DEAD verdict — every other path deliberately fails
+ * open to INDETERMINATE because a recorded pid goes stale on rotation. So a stale marker turned
+ * a LIVE session into a DEAD verdict and its claims were refused or reaped. Only long-lived
+ * sessions rotate their PID, so the failure was inverted with usefulness: the more work a seat
+ * did, the likelier it was reaped. Reported by session 24ca166f (38h old, 2 SDs shipped that
+ * day) after its own claim was cleared as a "corpse claim".
+ *
+ * Behavioral, not source-pinned: spawns the real script against a local mock PostgREST and
+ * observes the marker file on disk. Safety mirrors session-tick-spawn-observe.test.mjs — the
+ * child gets a 127.0.0.1 mock URL, a dummy key, and a test-prefixed CLAUDE_SESSION_ID, so it
+ * cannot reach or mutate a live claude_sessions row.
+ *
+ * MUST live in the main repo tree: vitest config excludes .worktrees, so a test authored only
+ * in a worktree would silently never run in CI.
+ */
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import http from 'node:http';
+import { readFileSync, existsSync, rmSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '../..');
+const tickPath = resolve(repoRoot, 'scripts/session-tick.cjs');
+
+const TEST_SESSION_ID = 'test-tick-marker-refresh-0000-0000-0000';
+const markerPath = resolve(repoRoot, '.claude/pids', `tick-${TEST_SESSION_ID}.json`);
+const FAST_TICK_MS = 150;
+const FAST_POLL_MS = 150;
+
+/** Minimal PostgREST-shaped mock: GET answers the re-query with state.pid. */
+function startMockServer(state) {
+  const server = http.createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => { body += c; });
+    req.on('end', () => {
+      const url = new URL(req.url, 'http://127.0.0.1');
+      const sessionId = url.searchParams.get('session_id')?.replace(/^eq\./, '');
+      // Guard: this mock only ever answers about the disposable test session_id.
+      if (sessionId && !sessionId.startsWith('test-tick-')) {
+        res.writeHead(400).end('refused: non-test session_id');
+        return;
+      }
+      if (url.pathname === '/rest/v1/session_lifecycle_events') {
+        res.writeHead(200, { 'Content-Type': 'application/json' }).end('[]');
+        return;
+      }
+      if (url.pathname !== '/rest/v1/claude_sessions') {
+        res.writeHead(404).end();
+        return;
+      }
+      if (req.method === 'GET') {
+        res.writeHead(200, { 'Content-Type': 'application/json' })
+          .end(JSON.stringify(state.exists ? [{ pid: state.pid }] : []));
+        return;
+      }
+      if (req.method === 'PATCH') {
+        const filter = url.searchParams.get('status') || '';
+        const allowed = filter.startsWith('in.(') ? filter.slice(4, -1).split(',') : [];
+        const matches = state.exists && allowed.includes(state.status);
+        if (matches) state.lastPatchAt = Date.now();
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Content-Range': `0-${matches ? 0 : -1}/${matches ? 1 : 0}`,
+        }).end();
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' }).end('[]');
+    });
+  });
+  return new Promise((r) => { server.listen(0, '127.0.0.1', () => r(server)); });
+}
+
+function spawnFakeParent() {
+  return spawn(process.execPath, ['-e', 'setInterval(() => {}, 999999)'], { stdio: 'ignore' });
+}
+
+function spawnTick({ port, ccParentPid }) {
+  return spawn(process.execPath, [tickPath], {
+    env: {
+      ...process.env,
+      SUPABASE_URL: `http://127.0.0.1:${port}`,
+      SUPABASE_SERVICE_ROLE_KEY: 'test-dummy-key',
+      CLAUDE_SESSION_ID: TEST_SESSION_ID,
+      CC_PARENT_PID: String(ccParentPid),
+      LEO_TICK_MS: String(FAST_TICK_MS),
+      LEO_PARENT_POLL_MS: String(FAST_POLL_MS),
+      LEO_TELEMETRY_DEBUG: '0',
+    },
+    stdio: 'ignore',
+  });
+}
+
+function readMarker() {
+  try { return JSON.parse(readFileSync(markerPath, 'utf8')); } catch { return null; }
+}
+
+async function waitUntil(predicate, { timeoutMs = 8000, intervalMs = 25 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return true;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return false;
+}
+
+test('QF-703: marker cc_parent_pid is rewritten when a rotated parent PID is adopted',
+  { timeout: 20000 }, async () => {
+    // state.pid is THIS test process — a genuinely live pid, and necessarily different from the
+    // fake parent's, which is what rediscoverParentPid() requires before it will adopt.
+    const state = { exists: true, status: 'active', pid: process.pid, lastPatchAt: 0 };
+    const server = await startMockServer(state);
+    const fakeParent = spawnFakeParent();
+    let tick;
+    try {
+      tick = spawnTick({ port: server.address().port, ccParentPid: fakeParent.pid });
+
+      const wroteMarker = await waitUntil(() => readMarker()?.cc_parent_pid === fakeParent.pid);
+      assert.ok(wroteMarker, 'tick should write a marker naming its original CC parent pid');
+      const before = readMarker();
+
+      // Rotate: the pinned parent dies, a live replacement is discoverable via the re-query.
+      fakeParent.kill('SIGKILL');
+
+      const adopted = await waitUntil(() => readMarker()?.cc_parent_pid === process.pid);
+      const after = readMarker();
+      assert.ok(
+        adopted,
+        `marker must follow the adopted pid: expected cc_parent_pid=${process.pid}, ` +
+        `found ${after?.cc_parent_pid} (a stale marker makes claimant-liveness classify this ` +
+        'LIVE session DEAD — the only path to that verdict — and its claims get reaped)',
+      );
+      assert.equal(tick.exitCode, null, 'tick must still be running after adopting the new pid');
+
+      // started_at means "when this daemon started". Rewriting the marker must not silently
+      // convert it into "time of last rewrite" for any reader treating it as a daemon age.
+      assert.equal(after.started_at, before.started_at,
+        'started_at must be captured once, not recomputed on every marker write');
+      assert.equal(after.session_id, TEST_SESSION_ID, 'session_id must survive the rewrite');
+      assert.equal(after.tick_pid, before.tick_pid, 'tick_pid must survive the rewrite');
+    } finally {
+      if (tick && !tick.killed) { try { tick.kill('SIGKILL'); } catch { /* gone */ } }
+      if (!fakeParent.killed) { try { fakeParent.kill('SIGKILL'); } catch { /* gone */ } }
+      server.close();
+      if (existsSync(markerPath)) rmSync(markerPath, { force: true });
+    }
+  });


### PR DESCRIPTION
## The bug

`scripts/session-tick.cjs` wrote `.claude/pids/tick-<session>.json` **exactly once**, at spawn. When the pinned CC parent died and `rediscoverParentPid()` adopted a live replacement (`/clear`, reconnect, compaction), the adoption happened **in memory only** — the marker kept naming the dead original pid.

That marker is not decorative. `lib/fleet/claimant-liveness.cjs` treats its `cc_parent_pid` as the strongest signal it has ("the only artifact that ties a pid back to the session that owns it") and it is that classifier's **only path to a `DEAD` verdict** — every other path deliberately fails open to `INDETERMINATE`, precisely because a recorded pid goes stale on rotation.

So a stale marker turned a **live** session into a `DEAD` verdict, and its claims were refused or reaped.

The failure was **inverted with usefulness**: only long-lived sessions rotate their PID, so the more work a seat did, the likelier it was reaped. Reported by session `24ca166f` (38h old, two SDs shipped that day) after its own claim was cleared as a "corpse claim" — that SD still carries `corpse_claim_prior_holder` naming the reporter.

## The fix

Call `writeMarker()` on adoption (~5 functional lines). `rediscoverParentPid()` has already verified the candidate is live via `process.kill(candidate, 0)`, so the persisted value is sound.

`started_at` is now captured once, so rewriting the marker cannot silently redefine it from "when this daemon started" to "time of last rewrite" for any reader treating it as daemon age.

## What was NOT implemented, and why

The reporter's suggested fix was *"prefer `heartbeat_at` recency over a recorded-pid probe"*. That is **not** what this does. `heartbeat_at` is forged by orphaned tickers (a detached tick re-latches onto an unrelated live claude and keeps stamping liveness for its own dead session), so keying liveness on it swaps the *direction* of the error rather than removing it. The two signals fail in opposite directions; this change instead makes the self-declared session→pid binding **stay true**, which is what the classifier already assumes it is.

## Verification

- **Behavioral test, not source-pinned** — spawns the real script against a mock PostgREST on 127.0.0.1, kills the pinned parent, asserts the on-disk marker follows the adopted pid.
- **Negative control run first**: RED against unfixed code with the exact stale-pid signature (`expected cc_parent_pid=61492, found 9748`), then GREEN after the fix (8124ms timeout → 324ms adoption).
- `npm run test:session-tick` — 33/33 pass (was 32; +1 new).
- `claim-liveness-fence-classifier` + `-wiring` — 16/16 pass.
- Test is wired into the `test:session-tick` CI lane **and** `tests/test-estate-mjs-allowlist.json`. Without both it would have been a **dead verifier**: vitest's unit `include` does not cover `tests/unit/*.test.mjs`, so the file would have looked green in the editor and never executed in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)