### PR TITLE
fix(QF-20260727-259): coordinator election must not elect a process-less ghost

### DIFF
--- a/lib/coordinator/coordination-events.cjs
+++ b/lib/coordinator/coordination-events.cjs
@@ -22,7 +22,7 @@ const { runDetectors, detectInertWorkerRevival, detectCompletionBoundaryExit } =
 const { insertCoordinationRow } = require('./dispatch.cjs');
 // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-A / FR-2: auto-resolve SPLIT_BRAIN via
 // the same election helpers already proven in resolve.cjs (GG: reuse, don't re-implement).
-const { isTwoWayV2Enabled, pickCanonicalCoordinator, clearCoordinatorFlagFromSession, STALE_THRESHOLD_MIN } = require('./resolve.cjs');
+const { isTwoWayV2Enabled, pickCanonicalCoordinator, clearCoordinatorFlagFromSession, STALE_THRESHOLD_MIN, COORDINATOR_ROW_COLUMNS } = require('./resolve.cjs');
 
 /** detector_version stamped on every emitted coordination_events row. */
 const DETECTOR_VERSION = 'COORD_DETECTORS_V2';
@@ -317,9 +317,13 @@ async function runAndLogDetectors(supabase, data, opts) {
       const cutoff = new Date((opts.now ?? Date.now()) - STALE_THRESHOLD_MIN * 60_000).toISOString();
       // FR-6 GUARD read for the retire mutation below — paginated so a capped snapshot can
       // never elect against a partial holder set; on failure the catch below SKIPS retirement.
+      // QF-20260727-259: request the liveness columns. pickCanonicalCoordinator's ghost guard
+      // fails OPEN on rows that don't carry them, and THIS snapshot feeds the retire mutation
+      // below — a narrow select here would let a process-less ghost win and clear the flag off
+      // the live coordinator (exactly the 2026-07-27T02:00 deposition).
       const snapshot = await fapPaginate(() => supabase
         .from('claude_sessions')
-        .select('session_id, heartbeat_at, metadata')
+        .select(COORDINATOR_ROW_COLUMNS)
         .gte('heartbeat_at', cutoff)
         .filter('metadata->>is_coordinator', 'eq', 'true')
         .order('session_id')); // unique-key tiebreaker for stable pagination

--- a/lib/coordinator/resolve.cjs
+++ b/lib/coordinator/resolve.cjs
@@ -33,14 +33,17 @@ async function queryDbForCoordinator(supabase) {
   const cutoff = new Date(Date.now() - STALE_THRESHOLD_MIN * 60_000).toISOString();
   const { data, error } = await supabase
     .from('claude_sessions')
-    .select('session_id, heartbeat_at, metadata')
+    .select(COORDINATOR_ROW_COLUMNS)
     .gte('heartbeat_at', cutoff)
     .filter('metadata->>is_coordinator', 'eq', 'true')
     .order('heartbeat_at', { ascending: false })
-    .limit(1);
+    // QF-20260727-259: was .limit(1). A ghost with a freshly-stamped heartbeat sorts FIRST, so
+    // limit-1 would return the ghost and the guard below would leave us with nothing. Take a
+    // small window instead and return the freshest row an actual process backs.
+    .limit(10);
 
   if (error || !data || data.length === 0) return null;
-  return data[0];
+  return data.find(r => !isGhostSessionRow(r)) || null;
 }
 
 // SD-LEO-INFRA-COMPLETE-TWO-WAY-001 / FR-1: feature flag, default-OFF.
@@ -64,6 +67,42 @@ function isAdamSolomonTwoWayV1Enabled() {
   return process.env.ADAM_SOLOMON_TWOWAY_V1 !== 'off';
 }
 
+// QF-20260727-259: process-backed guard on coordinator resolution.
+// INCIDENT (2026-07-27T02:00:08Z): claude_sessions row 00000000-0000-0000-0000-000000000000 —
+//   minted 2026-06-23, STALE_CLEANUP-released the same day, and never once backed by a process
+//   (pid NULL, last_tool_at NULL) — was stamped is_coordinator=true. set_coordinator_flag also
+//   bumps heartbeat_at=now() and status='active', so the ghost satisfied BOTH election
+//   predicates, and its fresh coordinator_since beat the live coordinator's on the
+//   coordinator_since DESC sort. It won deterministically and every worker signal routed to a
+//   session no process has ever backed (worker-signal.cjs "can no longer reach you").
+// Liveness was never a predicate of the election — only the flag and heartbeat freshness, and
+//   the write-path RPC manufactures both. The guard therefore lives on the READ side, so it
+//   holds regardless of which writer stamps the flag (incl. direct DB writes).
+// NOT electable:
+//   - the all-zero UUID: never a real Claude session id, so this can have no false positive;
+//   - a row no process has ever backed (last_tool_at NULL and pid NULL) that is older than
+//     NEVER_ALIVE_GRACE_MIN.
+// The grace window preserves set_coordinator_flag's create-if-absent path: a genuinely new
+//   coordinator's row is seconds old and has not yet run a tool, so it stays electable.
+// FAIL-OPEN: a row that does not carry the liveness columns (narrow SELECTs, test fixtures)
+//   means "cannot tell" → electable. A guard that cannot see the constraint never excludes.
+const NIL_SESSION_ID = '00000000-0000-0000-0000-000000000000';
+const NEVER_ALIVE_GRACE_MIN = 15;
+
+function isGhostSessionRow(row, nowMs = Date.now()) {
+  if (!row) return false;
+  if (row.session_id === NIL_SESSION_ID) return true;
+  // Only judge liveness when the row actually carries the liveness columns (fail-open).
+  if (!('last_tool_at' in row) || !('pid' in row) || !row.created_at) return false;
+  if (row.last_tool_at || row.pid !== null) return false;
+  const created = Date.parse(row.created_at);
+  return Number.isFinite(created) && nowMs - created > NEVER_ALIVE_GRACE_MIN * 60_000;
+}
+
+// The column set every coordinator-resolution read must request, so isGhostSessionRow can
+// actually see the liveness columns rather than fail-open on every row.
+const COORDINATOR_ROW_COLUMNS = 'session_id, heartbeat_at, metadata, last_tool_at, pid, created_at';
+
 // SD-LEO-INFRA-COMPLETE-TWO-WAY-001 / FR-3: deterministic single-winner election.
 // Pure: given candidate coordinator rows, pick ONE authoritative winner by
 // (coordinator_since DESC, NULLS LAST, session_id ASC). Most-recently-started
@@ -74,7 +113,10 @@ function isAdamSolomonTwoWayV1Enabled() {
 function pickCanonicalCoordinator(rows) {
   if (!Array.isArray(rows) || rows.length === 0) return null;
   const candidates = rows
-    .filter(r => r && typeof r.session_id === 'string')
+    // QF-20260727-259: a process-less ghost is never a candidate. This is the shared chokepoint
+    // for BOTH the election and setActiveCoordinator's retire snapshot, so a ghost can neither
+    // win resolution nor make the live coordinator defer its retire as a phantom "winner".
+    .filter(r => r && typeof r.session_id === 'string' && !isGhostSessionRow(r))
     .map(r => ({
       session_id: r.session_id,
       since: (r.metadata && typeof r.metadata.coordinator_since === 'string')
@@ -117,7 +159,7 @@ async function electCoordinatorFromDb(supabase) {
     const cutoff = new Date(Date.now() - STALE_THRESHOLD_MIN * 60_000).toISOString();
     const data = await fapPaginate(() => supabase
       .from('claude_sessions')
-      .select('session_id, heartbeat_at, metadata')
+      .select(COORDINATOR_ROW_COLUMNS)
       .gte('heartbeat_at', cutoff)
       .filter('metadata->>is_coordinator', 'eq', 'true')
       .order('session_id')); // unique-key tiebreaker for stable pagination
@@ -150,12 +192,14 @@ async function getActiveCoordinatorId(supabase) {
     const cutoff = new Date(Date.now() - STALE_THRESHOLD_MIN * 60_000).toISOString();
     const { data: row } = await supabase
       .from('claude_sessions')
-      .select('session_id, heartbeat_at')
+      .select(COORDINATOR_ROW_COLUMNS)
       .eq('session_id', pointer.session_id)
       .gte('heartbeat_at', cutoff)
       .maybeSingle();
-    if (row) return pointer.session_id;
-    // file is stale; fall through to DB scan
+    // QF-20260727-259: the third resolution path needs the same guard as the other two — a
+    // pointer file written for a ghost must not resolve just because the file says so.
+    if (row && !isGhostSessionRow(row)) return pointer.session_id;
+    // file is stale or points at a ghost; fall through to DB scan
   }
 
   // 2) DB fallback. Scans for any session with metadata.is_coordinator=true
@@ -269,6 +313,11 @@ async function assertCoordinatorRpcsExist(supabase) {
 async function setActiveCoordinator(supabase, sessionId) {
   if (!sessionId || typeof sessionId !== 'string') {
     throw new Error('setActiveCoordinator: sessionId required');
+  }
+  // QF-20260727-259: belt-and-braces on the write side. The read-side guard already refuses to
+  // elect the nil UUID; refusing to STAMP it stops the ghost being minted in the first place.
+  if (sessionId === NIL_SESSION_ID) {
+    throw new Error(`setActiveCoordinator: refusing to register the nil session id ${NIL_SESSION_ID} as coordinator`);
   }
 
   // SD-LEO-INFRA-ROLE-SESSION-NAMING-001: give this coordinator session a stable status-line NAME
@@ -388,7 +437,7 @@ async function setActiveCoordinator(supabase, sessionId) {
     try {
       incumbents = await fapPaginate(() => supabase
         .from('claude_sessions')
-        .select('session_id, heartbeat_at, metadata')
+        .select(COORDINATOR_ROW_COLUMNS)
         .gte('heartbeat_at', cutoff)
         .filter('metadata->>is_coordinator', 'eq', 'true')
         .order('session_id')); // unique-key tiebreaker for stable pagination
@@ -507,6 +556,12 @@ module.exports = {
   isAdamSolomonTwoWayV1Enabled,
   pickCanonicalCoordinator,
   electCoordinatorFromDb,
+  // QF-20260727-259 (process-backed election guard) — exported for tests and for any other
+  // resolver that needs the same "is this row backed by a real process?" predicate.
+  isGhostSessionRow,
+  NIL_SESSION_ID,
+  NEVER_ALIVE_GRACE_MIN,
+  COORDINATOR_ROW_COLUMNS,
   // SD-LEO-INFRA-COORDINATOR-FLAG-RPC-FALLBACK-001 (defense-in-depth) — exported for the
   // startup/CI canary and tests.
   isFunctionNotFoundError,

--- a/lib/coordinator/resolve.test.js
+++ b/lib/coordinator/resolve.test.js
@@ -452,6 +452,78 @@ describe('ELECT: pickCanonicalCoordinator (FR-3, pure)', () => {
   });
 });
 
+// ============================================================================
+// QF-20260727-259 — the coordinator election must not elect a session no process
+// has ever backed. Incident 2026-07-27T02:00:08Z: the nil-UUID row was stamped
+// is_coordinator with a fresh coordinator_since and deposed the live coordinator,
+// so every worker signal routed into a session that had never run a tool.
+// ============================================================================
+describe('GHOST: isGhostSessionRow + process-backed election guard (QF-20260727-259)', () => {
+  const OLD = '2026-06-23T06:04:53Z';   // ghost row's real created_at, comfortably past grace
+  const nowIso = () => new Date().toISOString();
+
+  it('GHOST-1: the nil UUID is never electable even holding the newest coordinator_since', () => {
+    const w = resolve.pickCanonicalCoordinator([
+      { session_id: 'live', metadata: { coordinator_since: '2026-07-25T22:24:44Z' } },
+      { session_id: resolve.NIL_SESSION_ID, metadata: { coordinator_since: '2026-07-27T02:00:08Z' } }
+    ]);
+    expect(w.session_id).toBe('live');
+  });
+
+  it('GHOST-2: an aged row with no pid and no last_tool_at is never electable', () => {
+    const w = resolve.pickCanonicalCoordinator([
+      { session_id: 'live', last_tool_at: nowIso(), pid: 99, created_at: OLD,
+        metadata: { coordinator_since: '2026-07-25T22:24:44Z' } },
+      { session_id: 'never-alive', last_tool_at: null, pid: null, created_at: OLD,
+        metadata: { coordinator_since: '2026-07-27T02:00:08Z' } }
+    ]);
+    expect(w.session_id).toBe('live');
+  });
+
+  it('GHOST-3: a row younger than the grace window stays electable (set_coordinator_flag create-if-absent)', () => {
+    // A genuinely new coordinator registers before it has run its first tool. Excluding it
+    // would break the create-if-absent path the RPC exists to serve.
+    const fresh = new Date(Date.now() - 60_000).toISOString();
+    expect(resolve.isGhostSessionRow(
+      { session_id: 'brand-new', last_tool_at: null, pid: null, created_at: fresh }
+    )).toBe(false);
+  });
+
+  it('GHOST-4: a pid-less row that HAS run a tool stays electable (pid is null for most live seats)', () => {
+    // Measured 2026-07-27: 16 of 31 sessions heartbeating in the last 24h carry pid NULL.
+    // pid alone would be a false-positive machine; only pid AND last_tool_at absent is a ghost.
+    expect(resolve.isGhostSessionRow(
+      { session_id: 'pidless-but-working', last_tool_at: nowIso(), pid: null, created_at: OLD }
+    )).toBe(false);
+  });
+
+  it('GHOST-5: rows without the liveness columns fail OPEN (a guard that cannot see, cannot exclude)', () => {
+    expect(resolve.isGhostSessionRow({ session_id: 'narrow-select', metadata: {} })).toBe(false);
+    expect(resolve.isGhostSessionRow({ session_id: 'no-created-at', last_tool_at: null, pid: null })).toBe(false);
+    expect(resolve.isGhostSessionRow(null)).toBe(false);
+  });
+
+  it('GHOST-7: setActiveCoordinator refuses to STAMP the nil session id', async () => {
+    await expect(resolve.setActiveCoordinator(null, resolve.NIL_SESSION_ID)).rejects.toThrow(/nil session id/i);
+  });
+
+  it('GHOST-8: the legacy DB scan skips a ghost that sorts first and returns the live coordinator', async () => {
+    delete process.env.COORDINATOR_TWOWAY_V2; // legacy path
+    if (fs.existsSync(resolve.ACTIVE_COORDINATOR_FILE)) fs.unlinkSync(resolve.ACTIVE_COORDINATOR_FILE);
+    const sb = buildSupabaseMock({
+      claude_sessions: {
+        // heartbeat_at DESC — the ghost's freshly-stamped heartbeat puts it FIRST, which is
+        // exactly why the old .limit(1) handed the caller a ghost.
+        gteFilterOrderLimit: { data: [
+          { session_id: resolve.NIL_SESSION_ID, heartbeat_at: nowIso(), last_tool_at: null, pid: null, created_at: OLD, metadata: {} },
+          { session_id: 'live-coord', heartbeat_at: nowIso(), last_tool_at: nowIso(), pid: 4242, created_at: OLD, metadata: {} }
+        ], error: null }
+      }
+    });
+    expect(await resolve.getActiveCoordinatorId(sb)).toBe('live-coord');
+  });
+});
+
 describe('ELECT: electCoordinatorFromDb (FR-3, fail-open)', () => {
   it('ELECT-5: returns elected winner session_id from fresh coordinators', async () => {
     const sb = buildV2Mock({ coordinatorRows: [
@@ -497,6 +569,21 @@ describe('V2: getActiveCoordinatorId DB-canonical when flag ON (FR-3 + FR-4)', (
     const sb = buildV2Mock({ coordinatorRows: [], fileVerifyRow: { session_id: 'file-coord', heartbeat_at: new Date().toISOString() } });
     const id = await resolve.getActiveCoordinatorId(sb);
     expect(id).toBe('file-coord'); // election empty → legacy chain returns file pointer
+  });
+
+  it('GHOST-6: flag ON + a ghost holding the NEWEST coordinator_since elects the live coordinator (the 2026-07-27 incident)', async () => {
+    process.env.COORDINATOR_TWOWAY_V2 = 'on';
+    if (fs.existsSync(resolve.ACTIVE_COORDINATOR_FILE)) fs.unlinkSync(resolve.ACTIVE_COORDINATOR_FILE);
+    const sb = buildV2Mock({ coordinatorRows: [
+      // The live coordinator: older coordinator_since, but a real process is behind it.
+      { session_id: 'live-coord', heartbeat_at: new Date().toISOString(), last_tool_at: new Date().toISOString(),
+        pid: 4242, created_at: '2026-07-27T10:00:47Z', metadata: { coordinator_since: '2026-07-25T22:24:44Z' } },
+      // The ghost: set_coordinator_flag stamped a fresh heartbeat, status and coordinator_since
+      // onto a 2026-06-23 row that no process has ever backed. It USED to win on since DESC.
+      { session_id: resolve.NIL_SESSION_ID, heartbeat_at: new Date().toISOString(), last_tool_at: null,
+        pid: null, created_at: '2026-06-23T06:04:53Z', metadata: { coordinator_since: '2026-07-27T02:00:08Z' } }
+    ]});
+    expect(await resolve.getActiveCoordinatorId(sb)).toBe('live-coord');
   });
 
   it('V2-3: flag ON + missing pointer file still resolves the DB coordinator (file not required)', async () => {


### PR DESCRIPTION
## QF-20260727-259 — the coordinator election must not elect a process-less ghost

### The incident (2026-07-27T02:00:08Z)
`claude_sessions` row `00000000-0000-0000-0000-000000000000` — minted 2026-06-23, `STALE_CLEANUP`-released the same day, and **never once backed by a process** (`pid` NULL, `last_tool_at` NULL) — was stamped `is_coordinator=true`.

`set_coordinator_flag` also bumps `heartbeat_at=now()` and `status='active'`, so the ghost satisfied **both** election predicates, and its fresh `coordinator_since` beat the live coordinator's on the `coordinator_since DESC` sort. It won deterministically, deposed the live coordinator, and every worker signal routed into a session that had never run a tool — the reported symptom, *"worker-signal.cjs can no longer reach you"*.

The flags were hand-stripped at 02:03 and the row released at 03:31 by coordinator `a59441f4`. **The code path that let it happen was never fixed.** This PR fixes it.

### Why the guard is on the read side
Liveness was never a predicate of the election — only the flag and heartbeat freshness, and the write-path RPC manufactures both. A write-side check alone would not hold for direct DB writes, so the guard goes where resolution happens.

Not electable:
- the all-zero UUID — never a real Claude session id, so this rule cannot have a false positive;
- any row no process has ever backed (`last_tool_at` NULL **and** `pid` NULL) older than a 15-minute grace window.

The grace window preserves `set_coordinator_flag`'s create-if-absent path: a genuinely new coordinator's row is seconds old and has not yet run a tool, so it stays electable. **Fail-open** — a row that does not carry the liveness columns means "cannot tell" and stays electable.

### Applied at every resolution path, not one
A guard inside one code path is not a guard on the invariant:

| Path | Change |
|---|---|
| `electCoordinatorFromDb` | ghost filtered at `pickCanonicalCoordinator` |
| `queryDbForCoordinator` (legacy scan) | `.limit(1)` → `.limit(10)` + skip ghosts — a ghost with a freshly stamped heartbeat sorts **first**, so limit-1 handed the caller the ghost |
| file-first pointer verify | pointer at a ghost no longer resolves |
| `setActiveCoordinator` retire snapshot | ghost can't pose as the "winner" and make the live coordinator defer its retire |
| `coordination-events.cjs` SPLIT_BRAIN auto-resolve | the **mutating** path that clears flags off non-winners — i.e. the one that actually deposed the live coordinator |

Side effect worth having: because ghosts stay *in* the snapshot but can never *win* it, the live coordinator now clears the ghost's flag on its next registration. The state self-heals.

`setActiveCoordinator` additionally refuses to stamp the nil session id (belt-and-braces, write side).

### Evidence
Replayed against the **real** incident rows read live from the DB, with the unpatched module from `main` as the control:

```
CASE A — the real nil-UUID ghost (the actual incident):
  BEFORE (main)    elected: 00000000-0000-0000-0000-000000000000
  AFTER  (patched) elected: 1449a046-0f83-4b8e-b6f2-ad26510d0c05   <- the live coordinator

CASE B — a NON-nil never-alive row (isolates the liveness rule from the nil check):
  BEFORE (main)    elected: aaaaaaaa-1111-2222-3333-444444444444
  AFTER  (patched) elected: 1449a046-0f83-4b8e-b6f2-ad26510d0c05
```

Population measured 2026-07-27T10:58Z before choosing the predicate: of 31 sessions heartbeating in 24h, 3 are never-alive (all `released`, none live) and **0** fall inside the 10-minute election window — so the guard excludes nothing that is currently electable. 16 of 31 carry `pid` NULL, so **pid alone would have been a false-positive machine**; only `pid` *and* `last_tool_at` absent identifies a ghost.

### Tests
- `lib/coordinator/`: **236 pass**, 7 new (GHOST-1…8), including an end-to-end replay of the incident through `getActiveCoordinatorId`.
- Full unit project: 31,477 pass. The 13 failures across 8 files are **identical on `main`** with the same invocation — pre-existing and unrelated (env-isolation guard, fleet spawn-control, tree-currency).

### Size
28 production LOC (Tier 1, ≤30). Diff is +157/−11 with tests and the incident write-up in comments.

### Provenance note for the coordinator
QF-20260727-259 was itself auto-minted from a coordination **message body** by `signal-router.cjs`'s single-critical-signal bypass — it is one of the 13 advisories-wearing-QF-rows that **QF-20260726-578** (escalated) covers. Its *engineering* content was a real, unfixed defect, so I built the fix; the mis-minting class stays with QF-578.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
