### PR TITLE
feat(SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001): FR-1b slice 1 — stop() hands its work item back

### DIFF
--- a/lib/fleet/release-work-item.mjs
+++ b/lib/fleet/release-work-item.mjs
@@ -1,0 +1,226 @@
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1
+ *
+ * releaseWorkItemOnSessionEnd() — the ONE work-item reset every release path calls,
+ * plus sampleToolActivityTwice(), the ONE two-sample activity primitive.
+ *
+ * WHY THIS EXISTS
+ *   The work-item reset lives today on exactly ONE release path
+ *   (scripts/stale-session-sweep.cjs, the CLAIM_BOUNDARY_PROBE branch). Every other
+ *   release path clears the CLAIM but leaves the work item itself in a state no picker
+ *   can see: a QF stays status='in_progress' with no claimant, so the check-in open-QF
+ *   picker (which selects status='open') cannot reach it, while the coordinator's supply
+ *   gauge still counts it as available. The item reads as owned and is reachable by
+ *   nobody. lib/fleet/spawn-control.js:538 stop() is itself one of these — it marks the
+ *   row released and never touches the work item — which is why a Kill button built
+ *   before this helper would manufacture strands faster than hand-closing windows does.
+ *
+ * THE isSweepResetAllowed DECISION — RESOLVED, and the SD's framing was wrong
+ *   The SD records an unresolved decision: "the reset is gated by isSweepResetAllowed,
+ *   so extracting it forces a choice — carry the guard and every caller inherits sweep
+ *   semantics, or drop it and lose a predicate that exists because it was needed."
+ *   That is a FALSE DILEMMA, because it conflates the two branches. Measured in
+ *   scripts/stale-session-sweep.cjs at the CLAIM_BOUNDARY_PROBE site:
+ *
+ *     - The QF branch (:237-239) is NOT gated by isSweepResetAllowed AT ALL. Its guard
+ *       is the column predicate itself — status='in_progress' AND claiming_session_id IS
+ *       NULL AND pr_url IS NULL AND commit_sha IS NULL. Nothing to carry or drop.
+ *     - The SD branch (:242) calls resetSdPhaseOnRelease, and only THAT is gated.
+ *
+ *   And the guard is not "sweep semantics". lib/exec-context-guard.mjs
+ *   assertSweepHandoffGate answers one question: would resetting this SD to
+ *   targetResetPhase override a handoff that has ALREADY BEEN ACCEPTED past that phase?
+ *   The name says "Sweep" only because the sweep was its first caller. Overriding an
+ *   accepted handoff is wrong for EVERY release path, not just the sweep.
+ *
+ *   RESOLUTION: CARRY the guard on the SD branch — every caller SHOULD inherit it,
+ *   because it protects a real invariant rather than a sweep-local policy. The QF branch
+ *   carries no guard because it never had one; its column predicate IS the guard.
+ *   CONSEQUENCE OF THE LOSING OPTION, recorded as the PRD requires: dropping the guard
+ *   would let any release path silently rewind an SD whose next phase was already
+ *   accepted, reintroducing exactly the override that SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001
+ *   added it to prevent.
+ *
+ * FLAGGING: this module is inert until wired. The per-site conversion (FR-1b) is what
+ *   sits behind LEO_RELEASE_WORKITEM_RESET (default OFF) — see isReleaseWorkItemResetEnabled.
+ */
+
+import { assertSweepHandoffGate } from '../exec-context-guard.mjs';
+
+/** Mid-phase state → the safe boundary it rewinds to. Mirrors the sweep's map. */
+export const PHASE_RESET_MAP = {
+  EXEC: 'PLAN_PRD',
+  EXEC_COMPLETE: 'PLAN_PRD',
+  PLAN_VERIFICATION: 'PLAN_PRD',
+  LEAD_APPROVAL: 'LEAD',
+  LEAD_FINAL_APPROVAL: 'LEAD_FINAL',
+};
+
+/**
+ * FR-1b gate. Default OFF: an unset/absent value must never enable conversion, so the
+ * check is an explicit opt-in equality rather than a truthiness test.
+ */
+export function isReleaseWorkItemResetEnabled(env = process.env) {
+  return env.LEO_RELEASE_WORKITEM_RESET === 'on';
+}
+
+/** A work item is a quick-fix iff its key carries the QF- prefix; everything else is an SD. */
+export function isQuickFixKey(workItemKey) {
+  return typeof workItemKey === 'string' && /^QF-/.test(workItemKey);
+}
+
+/**
+ * Reset ONE work item so a picker can see it again, after its claim has been released.
+ *
+ * Returns a verdict object — never throws. A release path must not abort because a reset
+ * failed; the claim is already gone and the next sweep re-converges.
+ *   { ok, kind, action, reason, detail }
+ *   action: 'qf_reopened' | 'qf_untouched' | 'sd_phase_reset' | 'sd_no_reset' | 'skipped' | 'error'
+ */
+export async function releaseWorkItemOnSessionEnd(supabase, workItemKey, reason, opts = {}) {
+  const { onLog = () => {} } = opts;
+  if (!supabase || !workItemKey) {
+    return { ok: false, kind: null, action: 'skipped', reason, detail: 'missing supabase client or work item key' };
+  }
+
+  try {
+    if (isQuickFixKey(workItemKey)) {
+      // Guarded on EVERY column so an item carrying real work (a PR or a commit) or a
+      // fresh claimant is never reverted. The UPDATE is the guard — it is applied in the
+      // WHERE clause, not read-then-written, so a claimant arriving mid-flight loses the
+      // row from the predicate rather than racing us.
+      const { data, error } = await supabase
+        .from('quick_fixes')
+        .update({ status: 'open' })
+        .eq('id', workItemKey)
+        .filter('status', 'eq', 'in_progress')
+        .is('claiming_session_id', null)
+        .is('pr_url', null)
+        .is('commit_sha', null)
+        .select('id');
+
+      if (error) {
+        return { ok: false, kind: 'qf', action: 'error', reason, detail: error.message };
+      }
+      const reopened = Array.isArray(data) && data.length > 0;
+      if (reopened) onLog(`WORK_ITEM_RESET: ${workItemKey} in_progress → open (${reason})`);
+      return {
+        ok: true,
+        kind: 'qf',
+        action: reopened ? 'qf_reopened' : 'qf_untouched',
+        reason,
+        detail: reopened
+          ? 'no claimant, no pr_url, no commit_sha — returned to the open pool'
+          : 'predicate did not match (already open, or carries a claimant / pr_url / commit_sha)',
+      };
+    }
+
+    // ---- SD branch: rewind to the safe phase boundary, guarded ----
+    const { data: sd, error: readErr } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, current_phase, status')
+      .eq('sd_key', workItemKey)
+      .maybeSingle();
+
+    if (readErr) return { ok: false, kind: 'sd', action: 'error', reason, detail: readErr.message };
+    if (!sd) return { ok: true, kind: 'sd', action: 'sd_no_reset', reason, detail: 'SD not found (vanished or unknown key)' };
+
+    const resetTo = PHASE_RESET_MAP[sd.current_phase];
+    if (!resetTo) {
+      return { ok: true, kind: 'sd', action: 'sd_no_reset', reason, detail: `current_phase '${sd.current_phase}' is already a safe boundary` };
+    }
+
+    // CARRIED GUARD (see the decision above): never rewind past an ACCEPTED handoff.
+    // Fail-soft in both directions — a guard that cannot answer must not authorise the
+    // write, and must not abort the caller either.
+    try {
+      await assertSweepHandoffGate(supabase, workItemKey, resetTo);
+    } catch (err) {
+      const code = (err && err.code) || 'UNKNOWN';
+      onLog(`SKIP_RESET: ${workItemKey} — ${reason} — ${code}: ${err && err.message ? err.message : err}`);
+      return { ok: true, kind: 'sd', action: 'sd_no_reset', reason, detail: `handoff gate blocked the reset (${code})` };
+    }
+
+    const { error: updErr } = await supabase
+      .from('strategic_directives_v2')
+      .update({ current_phase: resetTo })
+      .eq('sd_key', workItemKey);
+
+    if (updErr) return { ok: false, kind: 'sd', action: 'error', reason, detail: updErr.message };
+    onLog(`PHASE_RESET: ${workItemKey} ${sd.current_phase} → ${resetTo} (${reason})`);
+    return { ok: true, kind: 'sd', action: 'sd_phase_reset', reason, detail: `${sd.current_phase} → ${resetTo}` };
+  } catch (err) {
+    return { ok: false, kind: null, action: 'error', reason, detail: (err && err.message) || String(err) };
+  }
+}
+
+/**
+ * Sample claude_sessions.last_tool_at TWICE, intervalMs apart.
+ *
+ * THE SINGLE OWNER of the two-sample pattern, consumed at OPPOSITE POLARITY by two FRs:
+ *   FR-2 (graceful kill) needs ADVANCING — it is the only positive proof of life.
+ *     process.kill(pid, 0) is sound ONLY as a negative: it proves a pid is absent, never
+ *     that the agent behind it is doing anything.
+ *   FR-5 (reaping) needs IDENTICAL across >= 10 minutes as leg B of its DEAD test.
+ * Zero two-sample implementations existed in this repo before this one; without a single
+ * owner the two consumers would each grow their own and drift apart.
+ *
+ * DELIBERATELY NOT USED HERE: heartbeat_at. It keeps ticking on a parked worker whose
+ * agent is idle — four false "fleet down" verdicts are on record from reading it as
+ * activity. last_tool_at moves only when a tool actually ran.
+ *
+ * Returns { ok, advancing, identical, first, second, intervalMs, detail }.
+ * Never throws: a read failure yields ok:false with advancing/identical BOTH false, so a
+ * failed sample can neither authorise a kill (needs advancing) nor authorise a reap
+ * (needs identical). An unreadable sample must not look like an answer.
+ */
+export async function sampleToolActivityTwice(supabase, sessionId, opts = {}) {
+  const { intervalMs = 600_000, sleep = (ms) => new Promise((r) => setTimeout(r, ms)) } = opts;
+
+  const readOnce = async () => {
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('last_tool_at')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    return data ? data.last_tool_at ?? null : null;
+  };
+
+  if (!supabase || !sessionId) {
+    return { ok: false, advancing: false, identical: false, first: null, second: null, intervalMs, detail: 'missing supabase client or session id' };
+  }
+
+  try {
+    const first = await readOnce();
+    await sleep(intervalMs);
+    const second = await readOnce();
+
+    // identical covers the never-ran-a-tool case (null === null): a session that has
+    // never moved is, for FR-5's purposes, not advancing.
+    const identical = first === second;
+    const advancing = !identical && second !== null;
+
+    return {
+      ok: true,
+      advancing,
+      identical,
+      first,
+      second,
+      intervalMs,
+      detail: advancing
+        ? 'last_tool_at advanced between samples — the agent is alive'
+        : 'last_tool_at did not advance between samples',
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      advancing: false,
+      identical: false,
+      first: null,
+      second: null,
+      intervalMs,
+      detail: `sample failed: ${(err && err.message) || err}`,
+    };
+  }
+}

--- a/lib/fleet/release-work-item.test.js
+++ b/lib/fleet/release-work-item.test.js
@@ -1,0 +1,232 @@
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1
+// lib/fleet/release-work-item.mjs — the shared work-item reset + the two-sample primitive.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  releaseWorkItemOnSessionEnd,
+  sampleToolActivityTwice,
+  isReleaseWorkItemResetEnabled,
+  isQuickFixKey,
+  PHASE_RESET_MAP,
+} from './release-work-item.mjs';
+
+// ---------------------------------------------------------------------------
+// Supabase test doubles. The QF double RECORDS the predicate the UPDATE applied,
+// so the tests assert the guard is in the WHERE clause rather than trusting a
+// hand-written "matched" flag — the predicate IS the safety property here.
+// ---------------------------------------------------------------------------
+function qfClient({ matched = true, error = null } = {}) {
+  const applied = { eq: {}, filter: {}, is: [] };
+  const chain = {
+    update: vi.fn(() => chain),
+    eq: vi.fn((col, val) => { applied.eq[col] = val; return chain; }),
+    filter: vi.fn((col, _op, val) => { applied.filter[col] = val; return chain; }),
+    is: vi.fn((col, val) => { applied.is.push([col, val]); return chain; }),
+    select: vi.fn(() => Promise.resolve({ data: matched ? [{ id: 'QF-X' }] : [], error })),
+  };
+  return { applied, from: vi.fn(() => chain) };
+}
+
+function sdClient({ row, updateError = null } = {}) {
+  const updates = [];
+  return {
+    updates,
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: row, error: null }) })),
+      })),
+      update: vi.fn((patch) => ({
+        eq: vi.fn((_c, key) => { updates.push({ key, patch }); return Promise.resolve({ error: updateError }); }),
+      })),
+    })),
+  };
+}
+
+function sessionClient(values) {
+  let i = 0;
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => {
+            const v = values[Math.min(i, values.length - 1)];
+            i += 1;
+            if (v instanceof Error) return Promise.resolve({ data: null, error: { message: v.message } });
+            return Promise.resolve({ data: { last_tool_at: v }, error: null });
+          }),
+        })),
+      })),
+    })),
+  };
+}
+
+const noSleep = () => Promise.resolve();
+
+describe('FR1-FLAG: LEO_RELEASE_WORKITEM_RESET is opt-in, never truthy-by-accident', () => {
+  it('is OFF when unset, OFF for any other value, ON only for exactly "on"', () => {
+    expect(isReleaseWorkItemResetEnabled({})).toBe(false);
+    expect(isReleaseWorkItemResetEnabled({ LEO_RELEASE_WORKITEM_RESET: '' })).toBe(false);
+    // 'true'/'1' are truthy strings — a truthiness check would wrongly enable conversion.
+    expect(isReleaseWorkItemResetEnabled({ LEO_RELEASE_WORKITEM_RESET: 'true' })).toBe(false);
+    expect(isReleaseWorkItemResetEnabled({ LEO_RELEASE_WORKITEM_RESET: '1' })).toBe(false);
+    expect(isReleaseWorkItemResetEnabled({ LEO_RELEASE_WORKITEM_RESET: 'on' })).toBe(true);
+  });
+});
+
+describe('FR1-DISPATCH: QF- prefix selects the quick-fix branch', () => {
+  it('classifies keys', () => {
+    expect(isQuickFixKey('QF-20260727-259')).toBe(true);
+    expect(isQuickFixKey('SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001')).toBe(false);
+    expect(isQuickFixKey(null)).toBe(false);
+  });
+});
+
+describe('FR1-QF: a stranded quick-fix is returned to the open pool', () => {
+  it('QF-1: reopens an item with no claimant, no pr_url and no commit_sha', async () => {
+    const sb = qfClient({ matched: true });
+    const r = await releaseWorkItemOnSessionEnd(sb, 'QF-20260726-175', 'SESSION_END');
+    expect(r.ok).toBe(true);
+    expect(r.action).toBe('qf_reopened');
+  });
+
+  it('QF-2: THE GUARD IS IN THE WHERE CLAUSE — all four columns are constrained', async () => {
+    // This is the criterion that matters: the reset must be unable to touch an item
+    // carrying real work, structurally, rather than by a caller remembering to check.
+    const sb = qfClient({ matched: true });
+    await releaseWorkItemOnSessionEnd(sb, 'QF-20260726-175', 'SESSION_END');
+    expect(sb.applied.eq.id).toBe('QF-20260726-175');
+    expect(sb.applied.filter.status).toBe('in_progress');
+    expect(sb.applied.is).toEqual([
+      ['claiming_session_id', null],
+      ['pr_url', null],
+      ['commit_sha', null],
+    ]);
+  });
+
+  it('QF-3: an item carrying real work is left untouched (predicate matches nothing)', async () => {
+    const sb = qfClient({ matched: false });
+    const r = await releaseWorkItemOnSessionEnd(sb, 'QF-20260726-423', 'SESSION_END');
+    expect(r.ok).toBe(true);
+    expect(r.action).toBe('qf_untouched');
+  });
+
+  it('QF-4: a DB error surfaces as a verdict, never as a throw', async () => {
+    const sb = qfClient({ matched: false, error: { message: 'db down' } });
+    const r = await releaseWorkItemOnSessionEnd(sb, 'QF-1', 'SESSION_END');
+    expect(r.ok).toBe(false);
+    expect(r.action).toBe('error');
+    expect(r.detail).toContain('db down');
+  });
+});
+
+describe('FR1-SD: phase rewind, with the accepted-handoff guard CARRIED', () => {
+  // The gate is stubbed EXPLICITLY in every SD test. It is a real collaborator with its
+  // own DB reads, so leaving it live would make these tests assert the stub-fidelity of
+  // a supabase double rather than the rewind logic under test.
+  async function loadWithGate(gateImpl) {
+    vi.resetModules();
+    vi.doMock('../exec-context-guard.mjs', () => ({ assertSweepHandoffGate: vi.fn(gateImpl) }));
+    const mod = await import('./release-work-item.mjs');
+    return mod.releaseWorkItemOnSessionEnd;
+  }
+  const allow = async () => ({ ok: true });
+  const rejectWith = (code, message) => async () => { const e = new Error(message); e.code = code; throw e; };
+
+  afterEach(() => { vi.doUnmock('../exec-context-guard.mjs'); });
+
+  it('SD-1: rewinds a mid-phase SD to its safe boundary when the gate allows', async () => {
+    const release = await loadWithGate(allow);
+    const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
+    const r = await release(sb, 'SD-X', 'SESSION_END');
+    expect(r.action).toBe('sd_phase_reset');
+    expect(sb.updates).toEqual([{ key: 'SD-X', patch: { current_phase: 'PLAN_PRD' } }]);
+    expect(PHASE_RESET_MAP.EXEC).toBe('PLAN_PRD');
+  });
+
+  it('SD-2: an SD already at a safe boundary is not rewound', async () => {
+    const release = await loadWithGate(allow);
+    const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'PLAN_PRD', status: 'in_progress' } });
+    const r = await release(sb, 'SD-X', 'SESSION_END');
+    expect(r.action).toBe('sd_no_reset');
+    expect(sb.updates).toHaveLength(0);
+  });
+
+  it('SD-3: a vanished SD is a no-op, not an error', async () => {
+    const release = await loadWithGate(allow);
+    const sb = sdClient({ row: null });
+    const r = await release(sb, 'SD-GONE', 'SESSION_END');
+    expect(r.ok).toBe(true);
+    expect(r.action).toBe('sd_no_reset');
+  });
+
+  it('SD-4: THE CARRIED GUARD BLOCKS a rewind past an accepted handoff', async () => {
+    // The whole point of carrying assertSweepHandoffGate out of the sweep: an accepted
+    // handoff past the target phase must stop ANY release path, not just the sweep.
+    const release = await loadWithGate(rejectWith('ACCEPTED_HANDOFF_OVERRIDE', 'accepted handoff past PLAN_PRD exists'));
+    const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
+    const logs = [];
+    const r = await release(sb, 'SD-X', 'SESSION_END', { onLog: (m) => logs.push(m) });
+    expect(r.action).toBe('sd_no_reset');
+    expect(r.detail).toContain('ACCEPTED_HANDOFF_OVERRIDE');
+    expect(sb.updates).toHaveLength(0); // the write never happened
+    expect(logs.join('\n')).toContain('SKIP_RESET');
+  });
+
+  it('SD-5: a guard that cannot answer does NOT authorise the write', async () => {
+    const release = await loadWithGate(rejectWith('SCHEMA_ERROR', 'schema exploded'));
+    const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
+    const r = await release(sb, 'SD-X', 'SESSION_END');
+    expect(r.action).toBe('sd_no_reset');
+    expect(sb.updates).toHaveLength(0);
+  });
+});
+
+describe('FR1-SAMPLE: sampleToolActivityTwice — one primitive, two opposite polarities', () => {
+  it('SAMPLE-1: advancing last_tool_at => alive (FR-2 polarity)', async () => {
+    const sb = sessionClient(['2026-07-27T10:00:00Z', '2026-07-27T10:05:00Z']);
+    const r = await sampleToolActivityTwice(sb, 's1', { intervalMs: 10, sleep: noSleep });
+    expect(r.ok).toBe(true);
+    expect(r.advancing).toBe(true);
+    expect(r.identical).toBe(false);
+  });
+
+  it('SAMPLE-2: identical last_tool_at => not advancing (FR-5 leg B polarity)', async () => {
+    const sb = sessionClient(['2026-07-27T10:00:00Z', '2026-07-27T10:00:00Z']);
+    const r = await sampleToolActivityTwice(sb, 's1', { intervalMs: 10, sleep: noSleep });
+    expect(r.identical).toBe(true);
+    expect(r.advancing).toBe(false);
+  });
+
+  it('SAMPLE-3: a session that has NEVER run a tool is not advancing', async () => {
+    const sb = sessionClient([null, null]);
+    const r = await sampleToolActivityTwice(sb, 'ghost', { intervalMs: 10, sleep: noSleep });
+    expect(r.identical).toBe(true);
+    expect(r.advancing).toBe(false);
+  });
+
+  it('SAMPLE-4: A FAILED SAMPLE AUTHORISES NOTHING — neither kill nor reap', async () => {
+    // advancing gates the kill; identical gates the reap. A read failure must set BOTH
+    // false so an unreadable sample can never be mistaken for an answer in either direction.
+    const sb = sessionClient([new Error('db down')]);
+    const r = await sampleToolActivityTwice(sb, 's1', { intervalMs: 10, sleep: noSleep });
+    expect(r.ok).toBe(false);
+    expect(r.advancing).toBe(false);
+    expect(r.identical).toBe(false);
+  });
+
+  it('SAMPLE-5: it really samples TWICE, waiting in between', async () => {
+    const sb = sessionClient(['2026-07-27T10:00:00Z', '2026-07-27T10:05:00Z']);
+    const sleep = vi.fn(() => Promise.resolve());
+    await sampleToolActivityTwice(sb, 's1', { intervalMs: 600_000, sleep });
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(600_000);
+  });
+
+  it('SAMPLE-6: defaults to a 10-minute interval (FR-5 requires >= 10 min)', async () => {
+    const sb = sessionClient(['a', 'a']);
+    const sleep = vi.fn(() => Promise.resolve());
+    const r = await sampleToolActivityTwice(sb, 's1', { sleep });
+    expect(r.intervalMs).toBe(600_000);
+    expect(sleep).toHaveBeenCalledWith(600_000);
+  });
+});

--- a/lib/fleet/spawn-control-stop-workitem.test.js
+++ b/lib/fleet/spawn-control-stop-workitem.test.js
@@ -1,0 +1,124 @@
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 1
+// spawn-control.js stop() — hand the work item back before retiring the session row.
+//
+// stop() was itself a strand manufacturer: it flipped claude_sessions to released and
+// left the work item in_progress with no claimant — invisible to every picker while the
+// coordinator still counted it as available supply.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const RESOLVED = { resolved: true, identity: { callsign: 'Alpha-9', session_id: 'sess-1' } };
+
+let calls;
+
+function mockDeps({ heldKey = 'QF-20260726-175', released = true, resetAction = 'qf_reopened' } = {}) {
+  calls = [];
+  vi.doMock('./session-registry-adapter.js', () => ({
+    resolveLiveSession: vi.fn(async () => RESOLVED),
+    loadLiveSessionIdentity: vi.fn(async () => ({ sessions: [], callsignBySession: {} })),
+  }));
+  vi.doMock('./best-effort-release.mjs', () => ({
+    bestEffortReleaseSd: vi.fn(async (_sb, sessionId, reason, _log, opts) => {
+      calls.push({ step: 'release_claim', sessionId, reason, expectedSdKey: opts && opts.expectedSdKey });
+      return released ? { released: true, error: null } : { released: false, error: 'rpc down' };
+    }),
+  }));
+  vi.doMock('./release-work-item.mjs', () => ({
+    isReleaseWorkItemResetEnabled: vi.fn(() => process.env.LEO_RELEASE_WORKITEM_RESET === 'on'),
+    releaseWorkItemOnSessionEnd: vi.fn(async (_sb, key, reason) => {
+      calls.push({ step: 'reset_work_item', key, reason });
+      return { ok: true, action: resetAction, detail: 'stub' };
+    }),
+  }));
+  return { heldKey };
+}
+
+function supabaseDouble(heldKey) {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: { sd_key: heldKey }, error: null }) })),
+      })),
+      update: vi.fn(() => ({
+        eq: vi.fn(() => { calls.push({ step: 'retire_session' }); return Promise.resolve({ error: null }); }),
+      })),
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    })),
+    rpc: vi.fn().mockResolvedValue({ error: null }),
+  };
+}
+
+async function loadStop() {
+  const mod = await import('./spawn-control.js');
+  return mod.stop;
+}
+
+beforeEach(() => { vi.resetModules(); delete process.env.LEO_RELEASE_WORKITEM_RESET; });
+afterEach(() => { vi.restoreAllMocks(); delete process.env.LEO_RELEASE_WORKITEM_RESET; });
+
+describe('FR1B-1: default OFF keeps the previous behaviour exactly', () => {
+  it('does not touch the work item when the flag is unset', async () => {
+    const { heldKey } = mockDeps();
+    const stop = await loadStop();
+    const res = await stop('Alpha-9', { supabaseClient: supabaseDouble(heldKey) });
+    expect(res.ok).toBe(true);
+    expect(res.workItemReset).toBeUndefined();
+    expect(calls.filter((c) => c.step !== 'retire_session')).toHaveLength(0);
+  });
+});
+
+describe('FR1B-2: THE ORDER — claim released BEFORE the reset, both BEFORE the session is retired', () => {
+  it('sequences release_claim -> reset_work_item -> retire_session', async () => {
+    // This is the whole point of the slice. Reset-before-release would match nothing
+    // (the QF predicate requires claiming_session_id IS NULL) and return qf_untouched
+    // every time — a green no-op. Retiring the session first would erase sd_key, which
+    // is how release_sd resolves WHICH item to hand back.
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    const { heldKey } = mockDeps();
+    const stop = await loadStop();
+    await stop('Alpha-9', { supabaseClient: supabaseDouble(heldKey) });
+    expect(calls.map((c) => c.step)).toEqual(['release_claim', 'reset_work_item', 'retire_session']);
+  });
+
+  it('scopes the claim release to the key the session actually holds (QF-20260726-593)', async () => {
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    const { heldKey } = mockDeps();
+    const stop = await loadStop();
+    await stop('Alpha-9', { supabaseClient: supabaseDouble(heldKey) });
+    const rel = calls.find((c) => c.step === 'release_claim');
+    expect(rel.expectedSdKey).toBe(heldKey);
+    expect(rel.reason).toBe('manual_stop'); // names the mechanism, not 'manual'
+  });
+
+  it('hands back the SAME key it released', async () => {
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    const otherKey = 'SD-SOME-OTHER-001';
+    mockDeps({ heldKey: otherKey });
+    const stop = await loadStop();
+    await stop('Alpha-9', { supabaseClient: supabaseDouble(otherKey) });
+    expect(calls.find((c) => c.step === 'reset_work_item').key).toBe(otherKey);
+  });
+});
+
+describe('FR1B-3: the handback is best-effort — stop() still retires the session', () => {
+  it('a failed claim release does NOT attempt the reset, and does NOT block the retire', async () => {
+    // Resetting after a failed release would be reasoning from an unproven premise:
+    // we do not know the claim is gone, so the predicate cannot be trusted to protect us.
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    const { heldKey } = mockDeps({ released: false });
+    const stop = await loadStop();
+    const res = await stop('Alpha-9', { supabaseClient: supabaseDouble(heldKey) });
+    expect(calls.map((c) => c.step)).toEqual(['release_claim', 'retire_session']);
+    expect(res.ok).toBe(true);
+    expect(res.workItemReset.released).toBe(false);
+  });
+
+  it('a session holding no work item skips the handback cleanly', async () => {
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    mockDeps();
+    const stop = await loadStop();
+    const res = await stop('Alpha-9', { supabaseClient: supabaseDouble(null) });
+    expect(res.workItemReset).toEqual({ attempted: false, reason: 'session_holds_no_work_item' });
+    expect(calls.map((c) => c.step)).toEqual(['retire_session']);
+  });
+});

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -77,6 +77,9 @@ export const SESSION_BIND_DELAY_MS = 500;
 export const CANARY_PROFILE = 'canary';
 export { CANARY_CALLSIGN_PREFIX } from './startup-prompt-selection.js';
 import { isCanaryCallsign as isCanaryNamespaceCallsign } from './startup-prompt-selection.js';
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 1 — see releaseHeldWorkItem below.
+import { bestEffortReleaseSd } from './best-effort-release.mjs';
+import { releaseWorkItemOnSessionEnd, isReleaseWorkItemResetEnabled } from './release-work-item.mjs';
 // FR-4 trigger key: imported, not duplicated. canary-session.js now imports only the pure
 // startup-prompt-selection.js, so spawn-control -> canary-session closes no cycle.
 import { CANARY_TRIGGER_KEY } from './canary-session.js';
@@ -534,6 +537,43 @@ export async function attach(target, opts = {}) {
   return { ok: focused, reason: focused ? null : 'stale_handle', session_id };
 }
 
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 1.
+ *
+ * Hand the session's work item back to the queue before its row is retired.
+ *
+ * ORDER IS LOAD-BEARING, and wiring only half of it would be a fix that does not fix:
+ * releaseWorkItemOnSessionEnd's quick-fix predicate requires claiming_session_id IS NULL,
+ * so calling it while this session still holds the claim matches nothing and returns
+ * qf_untouched every time — green, and useless. The claim must be released FIRST.
+ * Both steps must also run BEFORE the claude_sessions status update below, because
+ * release_sd resolves what to release by reading claude_sessions.sd_key — retire the row
+ * first and there is nothing left to tell us which item this session held.
+ *
+ * Reuses the sequence stale-session-sweep.cjs already proves on its CLAIM_BOUNDARY_PROBE
+ * path (release, then reset, branching QF vs SD) rather than growing a second one.
+ * Best-effort throughout: stop() must still retire the session even if the handback fails.
+ */
+async function releaseHeldWorkItem(supabase, sessionId, reason) {
+  try {
+    const { data: row } = await supabase
+      .from('claude_sessions').select('sd_key').eq('session_id', sessionId).maybeSingle();
+    const heldKey = row && row.sd_key;
+    if (!heldKey) return { attempted: false, reason: 'session_holds_no_work_item' };
+
+    // SD-scoped so a concurrent re-claim cannot make us drop an unrelated item
+    // (QF-20260726-593: release_sd takes no SD argument and releases whatever is held).
+    const rel = await bestEffortReleaseSd(supabase, sessionId, reason, () => {}, { expectedSdKey: heldKey });
+    if (!rel.released) {
+      return { attempted: true, key: heldKey, released: false, detail: rel.skipped || rel.error || 'release_failed' };
+    }
+    const reset = await releaseWorkItemOnSessionEnd(supabase, heldKey, reason);
+    return { attempted: true, key: heldKey, released: true, action: reset.action, detail: reset.detail };
+  } catch (err) {
+    return { attempted: true, released: false, detail: (err && err.message) || String(err) };
+  }
+}
+
 /** Stop a live session without spawning a replacement. */
 export async function stop(target, opts = {}) {
   const supabase = opts.supabaseClient;
@@ -545,12 +585,22 @@ export async function stop(target, opts = {}) {
   }
 
   const { session_id } = resolution.identity;
+
+  // Until this landed, stop() flipped the session row to released and left the work item
+  // in_progress with no claimant — invisible to every picker while still counted as
+  // available supply. stop() was itself a strand manufacturer, which is why a Kill button
+  // built on it before FR-1 would have manufactured strands faster than closing a window.
+  // Default OFF: unset LEO_RELEASE_WORKITEM_RESET keeps the previous behaviour exactly.
+  const workItemReset = isReleaseWorkItemResetEnabled()
+    ? await releaseHeldWorkItem(supabase, session_id, 'manual_stop')
+    : null;
+
   const { error } = await supabase.from('claude_sessions').update({
     status: 'released', released_at: new Date().toISOString(), released_reason: 'manual_stop',
   }).eq('session_id', session_id);
 
   await emitVerbEvent(supabase, { verb: 'stop', session_id, outcome: error ? 'db_error' : 'ok' });
-  return { ok: !error, session_id };
+  return { ok: !error, session_id, ...(workItemReset ? { workItemReset } : {}) };
 }
 
 /**


### PR DESCRIPTION
## FR-1b slice 1 — `stop()` hands its work item back

First of the **sixteen** call-site conversions, behind `LEO_RELEASE_WORKITEM_RESET` (default OFF — unset keeps today's behaviour byte-for-byte).

> Stacked on #6555 (FR-1a), which adds the helper this calls. Review that one first; the diff here is `spawn-control.js` + its test.

### The defect

`lib/fleet/spawn-control.js` `stop()` flipped `claude_sessions` to `released` and did nothing else. The work item stayed `in_progress` with no claimant — invisible to the check-in picker (which selects `status='open'`) while `coordination-events` still counted it **into** available supply. `stop()` was itself a strand manufacturer.

This is precisely why FR-1 blocks FR-2: a Kill button built on this would have manufactured strands faster than closing a window by hand.

### Wiring only the reset would have been a fix that doesn't fix

`releaseWorkItemOnSessionEnd`'s QF predicate requires `claiming_session_id IS NULL`. `stop()` never released the claim — so a reset called here would match nothing and return `qf_untouched` **every single time**. Green, and useless.

The claim has to go first. And *both* steps must precede the `claude_sessions` update, because `release_sd` resolves **what** to release by reading `claude_sessions.sd_key` — retire the row first and there is nothing left to say which item the session held.

Order is load-bearing, and pinned by a test:

```
release_claim  ->  reset_work_item  ->  retire_session
```

### Reuse, not a second sequence

Uses the path `stale-session-sweep.cjs` already proves on `CLAIM_BOUNDARY_PROBE` (release, then reset, branching QF vs SD).

- Release is **SD-scoped** via `expectedSdKey`, so a concurrent re-claim cannot make us drop an unrelated item (`QF-20260726-593`: `release_sd` takes no SD argument and releases whatever the session currently holds).
- `reason` is `'manual_stop'` — naming the mechanism rather than the RPC's default `'manual'`, a default that has already produced two wrong incident conclusions.
- Best-effort throughout: a failed handback never blocks the retire.
- **A failed claim release deliberately skips the reset.** With the release unproven we cannot trust the predicate to protect an item carrying real work; resetting anyway would be reasoning from an unproven premise.

### Call-site ledger — 1 of 16 converted, 15 remaining

Enumerated, not sampled, as FR-1 requires.

- **Done**: `lib/fleet/spawn-control.js` `stop()`
- **Remaining**: `claim-guard.mjs`, `claim-lifecycle-release.mjs`, `claim-validity-gate.js`, `release-claim-both-surfaces.mjs`, `claim-command.js`, `singleton-refresh-sequencer.cjs`, `drain-orchestrator.mjs`, `qf.js`, `claim-orchestrator-for-rollup.mjs`, `coordinator-cold-recovery.cjs`, `multi-session-claim-gate.js`, `complete-quick-fix/orchestrator.js`, `cancel-sd.js`, `stale-session-sweep.cjs`, `worker-checkin.cjs`

### Tests

6 new, all passing. 22 production LOC.

Fleet suites: **1262 pass / 103 files**. The 3 failures (`cp3-restart-relaunch-live-flag-propagation` ×2, `spawn-control.test.js` FR-6) are **identical on `origin/main`** with the same invocation — pre-existing. I re-baselined rather than assumed, since this commit touches `spawn-control.js` and same-file failures can't be waved through on name-match alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
