### PR TITLE
fix(QF-20260727-846): isTreeComplete must test TERMINAL, not enumerate the still-working states

### DIFF
--- a/lib/eva/bridge/venture-build-consumer.js
+++ b/lib/eva/bridge/venture-build-consumer.js
@@ -227,9 +227,29 @@ export async function fetchDescendants(supabase, topId) {
   return all;
 }
 
-/** True when no descendant is still draft/active (aligns with the worker's terminal-tolerance). */
+/**
+ * True only when EVERY descendant has reached a TERMINAL status.
+ *
+ * QF-20260727-846. This deliberately tests TERMINAL membership rather than asking "is any descendant
+ * still NON_TERMINAL". The old form was an allowlist of still-working states, so any status the
+ * author had not enumerated defaulted to COMPLETE — and 'in_progress' is in neither list. Since
+ * POST_HANDOFF_SD_STATE force-normalizes every handoff outcome to 'in_progress', that became the
+ * common in-flight status while 'active' stopped being written, so a venture whose whole tree was
+ * still building read as finished and could be marked done=SHIPPED mid-build.
+ *
+ * Adding 'in_progress' to NON_TERMINAL would have fixed this instance and left the defect class
+ * intact — the next status anyone introduces (blocked, on_hold, pending_approval …) would silently
+ * re-create it. Testing TERMINAL makes the failure direction safe BY CONSTRUCTION: an unknown status
+ * counts as NOT complete, so the worst case is a venture that needs a nudge rather than one falsely
+ * shipped. Prefer that direction whenever this predicate is changed.
+ *
+ * NOTE: NON_TERMINAL is still used by computeWorkableLeaves (leaf selection). That call site has the
+ * same enumerate-the-working-states shape but the OPPOSITE failure direction (work not selected
+ * rather than falsely complete), and changing it alters which SDs get driven — out of scope here and
+ * flagged separately.
+ */
 export function isTreeComplete(descendants) {
-  return !descendants.some((d) => NON_TERMINAL.includes(d.status));
+  return descendants.every((d) => TERMINAL.includes(d.status));
 }
 
 /**

--- a/tests/unit/eva/bridge/venture-build-consumer.test.js
+++ b/tests/unit/eva/bridge/venture-build-consumer.test.js
@@ -6,8 +6,8 @@ import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 import {
-  runConsume, computeWorkableLeaves, isTreeComplete, fetchDescendants,
-  ventureEligibility, maybeIdleNudge, tryAdvisoryLock, finalizeConsume, TERMINAL, NON_TERMINAL,
+  runConsume, computeWorkableLeaves, isTreeComplete,
+  maybeIdleNudge, tryAdvisoryLock, finalizeConsume, TERMINAL,
   // SD-LEO-FIX-STAGE-BUILD-CONSOLIDATE-001
   consolidateGeneratedTests, detectPackageManager, enumerateChildWorktrees, resolveVentureRepoPath,
 } from '../../../../lib/eva/bridge/venture-build-consumer.js';
@@ -123,6 +123,44 @@ describe('venture-build-consumer — introspection', () => {
     expect(isTreeComplete(sds)).toBe(false);
     sds.forEach((s) => { s.status = 'completed'; });
     expect(isTreeComplete(sds)).toBe(true);
+  });
+
+  // QF-20260727-846. isTreeComplete used to ask "is any descendant still draft/active?" — an
+  // ALLOWLIST OF STILL-WORKING STATES, so every status the author did not enumerate defaulted to
+  // COMPLETE. 'in_progress' is in neither NON_TERMINAL nor TERMINAL, and it is now the overwhelmingly
+  // common in-flight status (POST_HANDOFF_SD_STATE force-normalizes every handoff outcome to
+  // in_progress; the audit table shows pre_active writes falling 125 -> 5 -> 12 -> ZERO across
+  // 2026-04..07). So a venture whose entire tree was actively building read as finished and could be
+  // marked done=SHIPPED mid-build.
+  //
+  // The fix inverts the predicate to test TERMINAL membership, which makes the failure direction safe
+  // BY CONSTRUCTION: an unrecognised status counts as NOT complete. These assertions therefore pin the
+  // DEFAULT DIRECTION, not just the one status that exposed it — a future 'blocked'/'on_hold' must not
+  // silently re-create the bug.
+  it('isTreeComplete blocks on any status that is not TERMINAL, including unknown ones', () => {
+    const sds = nestedTree({ children: 1, grandkidsEach: 2 }).filter((s) => s.id !== 'orch-top');
+
+    // The exact reported defect: a tree that is entirely in_progress is NOT complete.
+    sds.forEach((s) => { s.status = 'in_progress'; });
+    expect(isTreeComplete(sds)).toBe(false);
+
+    // The defect CLASS: a status nobody has invented yet must also block completion.
+    sds.forEach((s) => { s.status = 'some_future_status_nobody_enumerated'; });
+    expect(isTreeComplete(sds)).toBe(false);
+
+    // A single non-terminal descendant is enough to block an otherwise-finished tree.
+    sds.forEach((s) => { s.status = 'completed'; });
+    sds[sds.length - 1].status = 'in_progress';
+    expect(isTreeComplete(sds)).toBe(false);
+
+    // Every TERMINAL member still counts as complete (the fix must not over-block).
+    for (const terminal of TERMINAL) {
+      sds.forEach((s) => { s.status = terminal; });
+      expect(isTreeComplete(sds), `${terminal} should count as complete`).toBe(true);
+    }
+
+    // Degenerate case: no descendants is vacuously complete (unchanged by the inversion).
+    expect(isTreeComplete([])).toBe(true);
   });
 });
 


### PR DESCRIPTION
## The defect

`isTreeComplete` asked *"is any descendant still draft/active?"* — an **allowlist of still-working states**, so every status the author did not enumerate defaulted to **COMPLETE**. `'in_progress'` is in neither `NON_TERMINAL` nor `TERMINAL`.

```js
export const NON_TERMINAL = ['draft', 'active'];
export const TERMINAL = ['completed', 'cancelled', 'archived'];
export function isTreeComplete(descendants) {
  return !descendants.some((d) => NON_TERMINAL.includes(d.status));  // in_progress -> "complete"
}
```

## Why it isn't theoretical — the population moved under it

`POST_HANDOFF_SD_STATE` force-normalizes every handoff outcome to `in_progress` milliseconds after the executors write `'active'`. The audit table shows `pre_active` writes collapsing across 2026-04..07: **125 → 5 → 12 → ZERO**.

So `'active'` — one of only two states this predicate recognised as still-working — effectively stopped being written, while `in_progress` became the universal in-flight status. A venture whose entire build tree was **actively building** read as finished and could be marked `done=SHIPPED` mid-build.

## The fix: invert, don't extend the list

Adding `'in_progress'` to `NON_TERMINAL` would fix this instance and leave the **defect class** intact — the next status anyone introduces (`blocked`, `on_hold`, `pending_approval`, …) silently re-creates it.

```js
export function isTreeComplete(descendants) {
  return descendants.every((d) => TERMINAL.includes(d.status));
}
```

Testing `TERMINAL` makes the failure direction **safe by construction**: an unknown status counts as NOT complete, so the worst case is a venture that needs a nudge rather than one falsely shipped.

## Regression test pins the direction, not the symptom

Verified it **FAILS before the fix** (`expected false, received true` on the all-`in_progress` assertion, reproducing the report exactly). It asserts:

- an all-`in_progress` tree is not complete (the reported defect)
- a status **nobody has invented yet** also blocks completion (the defect class)
- one non-terminal descendant among completed siblings blocks the tree
- every `TERMINAL` member still counts as complete — the fix must not over-block
- no descendants is still vacuously complete

## Scope

`NON_TERMINAL` is **retained** — `computeWorkableLeaves` uses it at `:250` and `:261`. Those share the enumerate-the-working-states shape but fail in the **opposite** direction (work not selected, rather than falsely complete), and changing them alters which SDs actually get driven. Out of scope for a QF; flagged separately.

Also removed three pre-existing unused imports so the touched test file lints clean.

## Testing

- `35 passed` — consumer suite (34 pre-existing + 1 new)
- `442 passed` across all 34 `tests/unit/eva/bridge` files
- eslint clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
