### PR TITLE
feat(SD-LEO-INFRA-CORRECTION-DELIVERY-PATH-001-D): a mid-EXEC SD amendment must reach the worker

### DIFF
--- a/lib/sd/amend-sd.js
+++ b/lib/sd/amend-sd.js
@@ -93,6 +93,13 @@ export const PROTECTED_METADATA_KEYS = Object.freeze([
   'lead_blocker',
   'min_tier_rank',
   'governance_metadata',
+  // door_class is a DIFFERENT key from door_class_note: an OBJECT {door:'one_way'|'two_way'}
+  // read by assertDoorRoutingAllowed (lib/coordinator/dispatch.cjs:566-582), which fails OPEN on
+  // an unstamped value. Round 2 of the adversarial review caught this — the first enumeration was
+  // drawn from claim-eligibility.cjs alone and missed the dispatch-side consumer, so
+  // {door_class: null} would have erased a one-way-door supervision requirement in one call.
+  'door_class',
+  'requires_human_action',
 ]);
 
 /**
@@ -130,7 +137,10 @@ export function isInActiveBuildPhase(row) {
  * @returns {Promise<{sdUpdated:boolean, noticeDelivered:boolean, noticeRequired:boolean, warning:(string|null), errorCode:(string|null)}>}
  */
 export async function amendSd(supabase, sdKey, patch, opts = {}) {
-  const { senderSession = process.env.CLAUDE_SESSION_ID, reason = null, logger = console, dispatch } = opts;
+  const {
+    senderSession = process.env.CLAUDE_SESSION_ID, reason = null, logger = console,
+    dispatch, mergeMetadata,
+  } = opts;
   const out = { sdUpdated: false, noticeDelivered: false, noticeRequired: false, warning: null, errorCode: null };
 
   if (!patch || typeof patch !== 'object' || Object.keys(patch).length === 0) {
@@ -164,48 +174,78 @@ export async function amendSd(supabase, sdKey, patch, opts = {}) {
     return out;
   }
 
-  // metadata is MERGED onto what is already there, never substituted for it, and the governance
-  // holds above are refused outright — a JSONB replace would delete whichever holds were set.
-  let effectivePatch = patch;
-  if (Object.prototype.hasOwnProperty.call(patch, 'metadata')) {
+  const hasMetadata = Object.prototype.hasOwnProperty.call(patch, 'metadata');
+  if (hasMetadata) {
     const incoming = patch.metadata;
     if (!incoming || typeof incoming !== 'object' || Array.isArray(incoming)) {
       out.errorCode = 'AMEND_METADATA_NOT_OBJECT';
-      out.warning = 'metadata must be a plain object — it is merged, not replaced';
+      out.warning = 'metadata must be a plain object — it is merged key-wise, not replaced';
       return out;
     }
     const protectedHit = Object.keys(incoming).filter((k) => PROTECTED_METADATA_KEYS.includes(k));
     if (protectedHit.length > 0) {
       out.errorCode = 'AMEND_PROTECTED_METADATA_KEY';
       out.warning = `refusing to write governance-hold metadata key(s): ${protectedHit.join(', ')}. `
-        + 'These are fail-open holds read by claim-eligibility; clearing one silently makes an SD '
-        + 'claimable. Change them through their owning subsystem, not the amendment path.';
+        + 'These are fail-open holds read by claim-eligibility and dispatch door-routing; clearing '
+        + 'one silently lifts the hold. Change them through their owning subsystem, not here.';
       return out;
     }
-    effectivePatch = { ...patch, metadata: { ...(sd.metadata || {}), ...incoming } };
+    // An explicit undefined is dropped by JSON.stringify before the request is built, so it reads
+    // as "leave alone" but would delete the key under a full-blob write. Refuse it rather than let
+    // the caller's intent be ambiguous.
+    const undef = Object.keys(incoming).filter((k) => incoming[k] === undefined);
+    if (undef.length > 0) {
+      out.errorCode = 'AMEND_METADATA_UNDEFINED_VALUE';
+      out.warning = `metadata key(s) ${undef.join(', ')} are undefined — pass null to set JSON null, `
+        + 'or omit the key. undefined is silently dropped during serialization.';
+      return out;
+    }
   }
 
-  // .select() so a zero-row UPDATE is distinguishable from a successful one: PostgREST returns no
-  // error when nothing matched, so without this the helper would report sdUpdated=true and the CLI
-  // would exit 0 having written nothing — the exact silent success FR-3 exists to prevent.
-  const { data: updated, error: upErr } = await supabase
-    .from('strategic_directives_v2')
-    .update(effectivePatch)
-    .eq('sd_key', sdKey)
-    .select('sd_key');
+  // description/scope go through the normal column update; metadata does NOT.
+  const columnPatch = Object.fromEntries(Object.entries(patch).filter(([k]) => k !== 'metadata'));
 
-  if (upErr) {
-    out.errorCode = 'AMEND_UPDATE_FAILED';
-    out.warning = `update failed: ${upErr.message}`;
-    return out;
+  if (Object.keys(columnPatch).length > 0) {
+    // .select() so a zero-row UPDATE is distinguishable from a successful one: PostgREST returns no
+    // error when nothing matched, so without this the helper would report sdUpdated=true and the CLI
+    // would exit 0 having written nothing — the exact silent success FR-3 exists to prevent.
+    const { data: updated, error: upErr } = await supabase
+      .from('strategic_directives_v2')
+      .update(columnPatch)
+      .eq('sd_key', sdKey)
+      .select('sd_key');
+
+    if (upErr) {
+      out.errorCode = 'AMEND_UPDATE_FAILED';
+      out.warning = `update failed: ${upErr.message}`;
+      return out;
+    }
+    if (!Array.isArray(updated) || updated.length === 0) {
+      out.errorCode = 'AMEND_NO_ROWS_UPDATED';
+      out.warning = `update matched no rows for ${sdKey} — the SD may have been deleted, renamed or `
+        + 'filtered by RLS between read and write. Nothing was written and nobody was notified.';
+      return out;
+    }
+    out.sdUpdated = true;
   }
-  if (!Array.isArray(updated) || updated.length === 0) {
-    out.errorCode = 'AMEND_NO_ROWS_UPDATED';
-    out.warning = `update matched no rows for ${sdKey} — the SD may have been deleted, renamed or `
-      + 'filtered by RLS between read and write. Nothing was written and nobody was notified.';
-    return out;
+
+  if (hasMetadata) {
+    // ATOMIC key-wise merge at the DB layer (metadata = COALESCE(metadata,'{}') || $patch), NOT a
+    // JS read-spread-write. lib/coordinator/safe-metadata-merge.mjs exists precisely to stop that
+    // anti-pattern: a spread built from a snapshot read moments earlier RESURRECTS any hold flag a
+    // concurrent process cleared in between (QF-20260720-597; live near-miss RCA a4587e48). Round 2
+    // of the adversarial review caught this module reintroducing exactly that shape — a
+    // purpose-built fix existing and not being reused is this SD family's own thesis, for the
+    // fourth time in one family.
+    const merge = mergeMetadata || (await import('../coordinator/safe-metadata-merge.mjs')).mergeMetadataKeys;
+    const mergeRes = await merge(sdKey, patch.metadata);
+    if (!mergeRes || mergeRes.merged !== true) {
+      out.errorCode = 'AMEND_METADATA_MERGE_FAILED';
+      out.warning = `metadata merge failed for ${sdKey}: ${mergeRes?.error || 'no rows merged'}`;
+      return out;
+    }
+    out.sdUpdated = true;
   }
-  out.sdUpdated = true;
 
   // FR-4: an amendment with no in-flight consumer emits nothing and warns about nothing. A notice
   // on every SD edit would flood the priority-exempt lane this SD depends on being trustworthy.

--- a/lib/sd/amend-sd.js
+++ b/lib/sd/amend-sd.js
@@ -52,6 +52,22 @@ export const ACTIVE_BUILD_PHASES = Object.freeze([
 ]);
 
 /**
+ * The ONLY columns this helper will write. SECURITY (cbe69100) found that passing `patch` straight
+ * into .update() lets a caller reach governance-relevant columns. status and sd_type are covered by
+ * their own triggers (trg_enforce_sd_quality_advancement, trg_enforce_sd_type_change_governance),
+ * but claiming_session_id is a plain nullable TEXT column normally written ONLY via the claim_sd /
+ * release_sd RPCs — which add FOR UPDATE SKIP LOCKED row-locking and conflict-matrix checks that a
+ * raw column write bypasses entirely.
+ *
+ * SECURITY rated this non-blocking because today's only caller (scripts/amend-sd.js) never builds
+ * those keys, and deferred it as a condition binding on the NEXT caller. It is enforced here now
+ * instead: this helper is advertised as the canonical amendment path, and leaving a hazard whose
+ * only guard is a future author reading a condition is precisely the failure mode this SD family
+ * exists to remove. A correction that depends on someone remembering it has not been delivered.
+ */
+export const AMENDABLE_FIELDS = Object.freeze(['description', 'scope', 'metadata']);
+
+/**
  * PURE: does this SD row sit in a phase where an amendment has a live consumer?
  * Composes the EXISTING active-SD predicate (status/is_active/archived_at, lib/sd/active-sd-predicate.js)
  * rather than re-deriving it — that helper is the established SSOT for the status dimension and
@@ -92,6 +108,19 @@ export async function amendSd(supabase, sdKey, patch, opts = {}) {
   if (!patch || typeof patch !== 'object' || Object.keys(patch).length === 0) {
     out.errorCode = 'AMEND_EMPTY_PATCH';
     out.warning = 'refusing to amend with an empty patch';
+    return out;
+  }
+
+  // Fail CLOSED on an out-of-scope column rather than silently dropping it: a caller who thinks it
+  // just released a claim, and got a success back because the key was quietly ignored, is worse off
+  // than one that got an error.
+  const illegal = Object.keys(patch).filter((k) => !AMENDABLE_FIELDS.includes(k));
+  if (illegal.length > 0) {
+    out.errorCode = 'AMEND_FIELD_NOT_AMENDABLE';
+    out.warning = `refusing to write non-amendable column(s): ${illegal.join(', ')}. `
+      + `This path writes only ${AMENDABLE_FIELDS.join('/')}. claiming_session_id must go through `
+      + 'the claim_sd/release_sd RPCs (row-locking + conflict matrix); status/sd_type have their own '
+      + 'governance triggers.';
     return out;
   }
 

--- a/lib/sd/amend-sd.js
+++ b/lib/sd/amend-sd.js
@@ -1,0 +1,182 @@
+/**
+ * Canonical SD-amendment path — SD-LEO-INFRA-CORRECTION-DELIVERY-PATH-001-D.
+ *
+ * THE DEFECT: once a PRD exists, editing an SD's description/scope reaches nobody. EXEC builds to
+ * the PRD it already holds (CLAUDE_EXEC.md:60-69 consults the SD only on ambiguity, and only for
+ * strategic_objectives), and the one content-comparison gate (plan-to-exec/gates/sd-prd-drift.js)
+ * runs once at PLAN-TO-EXEC and is advisory by default. So the ORIGINAL flows and the CORRECTION
+ * stalls one hop short, silently, with no error to its author.
+ *
+ * WHY THIS DOES NOT TOUCH THE DRIFT GATE. Flipping SD_PRD_DRIFT_ENFORCING=true looks like the fix
+ * and is not one. Measured over the 400 most recently created SDs with the gate's own exported
+ * extractSdFrs(): 354 (88.5%) have NO extractable FRs, so sd-prd-drift.js:166-168 takes its
+ * {passed:true, skipped:true} branch BEFORE `enforcing` is ever consulted — `required` only decides
+ * whether a FAILING gate blocks, and a vacuously PASSING gate blocks nothing. VALIDATION
+ * (2ba1c482) reproduced all five figures exactly and confirmed the branch ordering structurally.
+ *
+ * WHAT THIS DOES INSTEAD: wires the missing PRODUCER for payload kind 'fence_notice'.
+ * SD-LEO-INFRA-MID-FLIGHT-DIRECTIVE-001 purpose-built that kind for exactly this shape — a busy
+ * worker that must see something promptly, deliver-not-consume, priority-exempt from the inbox row
+ * cap — and it has consumers and drain-set wiring but NO producer anywhere in the codebase. The
+ * mechanism existed and simply never travelled, which is this SD family's own thesis.
+ *
+ * SCOPE LIMIT, stated rather than implied: there is no chokepoint for SD writes (~30+ one-off
+ * scripts call .update() on strategic_directives_v2 directly). This establishes the canonical
+ * amendment path and notifies through it; it does not retrofit historical call sites. Universal
+ * coverage would need a DB trigger on description/scope, which is chairman-gated DDL and is
+ * deliberately left as a separate follow-on.
+ *
+ * @module lib/sd/amend-sd
+ */
+
+import { createRequire } from 'module';
+import { isActiveSD } from './active-sd-predicate.js';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Phases in which a worker may already be building against a PRD, so an amendment has a consumer
+ * that must be told. Measured 2026-07-27 against the live in-flight population (14 SDs with
+ * status in_progress/active): {EXEC:9, PLAN_VERIFICATION:4, PLAN_PRD:1}. EXEC_COMPLETE is included
+ * because a parent/child can be amended between EXEC and its verification handoff.
+ *
+ * LEAD_* phases are deliberately absent: no PRD exists yet, so there is nothing to have drifted
+ * from — and FR-4 requires those amendments stay silent rather than train workers to ignore the
+ * channel. The PRD-existence check below enforces that independently of this list.
+ */
+export const ACTIVE_BUILD_PHASES = Object.freeze([
+  'PLAN_PRD',
+  'PLAN_VERIFICATION',
+  'EXEC',
+  'EXEC_COMPLETE',
+]);
+
+/**
+ * PURE: does this SD row sit in a phase where an amendment has a live consumer?
+ * Composes the EXISTING active-SD predicate (status/is_active/archived_at, lib/sd/active-sd-predicate.js)
+ * rather than re-deriving it — that helper is the established SSOT for the status dimension and
+ * re-deriving it inline is the writer/consumer asymmetry its own module comment warns about.
+ * This function adds only the phase dimension, which that helper does not cover.
+ *
+ * @param {Object} row - SD row with status, is_active, archived_at, current_phase.
+ * @returns {boolean}
+ */
+export function isInActiveBuildPhase(row) {
+  if (!isActiveSD(row)) return false;
+  return ACTIVE_BUILD_PHASES.includes(String(row?.current_phase || '').toUpperCase());
+}
+
+/**
+ * Amend an SD and notify the session building it.
+ *
+ * The SD update is applied FIRST and independently of delivery: a notice that cannot be delivered
+ * must never roll back the amendment (FR-3). The caller is told both facts via the return contract
+ * so "the row changed but nobody was told" is a reportable state rather than a silent success.
+ *
+ * @param {Object} supabase
+ * @param {string} sdKey
+ * @param {Object} patch - fields to update (e.g. {description, scope}).
+ * @param {Object} [opts]
+ * @param {string} [opts.senderSession] - amending session id; defaults to CLAUDE_SESSION_ID.
+ * @param {string} [opts.reason] - short human-readable note carried in the notice body.
+ * @param {Function} [opts.dispatch] - seam for tests ONLY; defaults to the real dispatchToWorker.
+ *   Injected rather than module-mocked so a unit test never needs live credentials to prove the
+ *   payload shape — probing via an injected seam, never by editing the live call site.
+ * @param {Object} [opts.logger]
+ * @returns {Promise<{sdUpdated:boolean, noticeDelivered:boolean, noticeRequired:boolean, warning:(string|null), errorCode:(string|null)}>}
+ */
+export async function amendSd(supabase, sdKey, patch, opts = {}) {
+  const { senderSession = process.env.CLAUDE_SESSION_ID, reason = null, logger = console, dispatch } = opts;
+  const out = { sdUpdated: false, noticeDelivered: false, noticeRequired: false, warning: null, errorCode: null };
+
+  if (!patch || typeof patch !== 'object' || Object.keys(patch).length === 0) {
+    out.errorCode = 'AMEND_EMPTY_PATCH';
+    out.warning = 'refusing to amend with an empty patch';
+    return out;
+  }
+
+  const { data: sd, error: readErr } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, status, is_active, archived_at, current_phase, claiming_session_id')
+    .eq('sd_key', sdKey)
+    .maybeSingle();
+
+  if (readErr || !sd) {
+    out.errorCode = readErr ? 'AMEND_READ_FAILED' : 'AMEND_SD_NOT_FOUND';
+    out.warning = readErr ? `read failed: ${readErr.message}` : `SD not found: ${sdKey}`;
+    return out;
+  }
+
+  const { error: upErr } = await supabase
+    .from('strategic_directives_v2')
+    .update(patch)
+    .eq('sd_key', sdKey);
+
+  if (upErr) {
+    out.errorCode = 'AMEND_UPDATE_FAILED';
+    out.warning = `update failed: ${upErr.message}`;
+    return out;
+  }
+  out.sdUpdated = true;
+
+  // FR-4: an amendment with no in-flight consumer emits nothing and warns about nothing. A notice
+  // on every SD edit would flood the priority-exempt lane this SD depends on being trustworthy.
+  if (!isInActiveBuildPhase(sd)) return out;
+
+  // FR-4: no PRD means nothing has been built against yet — nothing to have drifted from. Checked
+  // on sd_id, NOT directive_id: product_requirements_v2 keys the SD by sd_id, and querying
+  // directive_id returns 0 rows for every SD, which reads as a false "no PRD".
+  const { data: prds } = await supabase
+    .from('product_requirements_v2')
+    .select('id')
+    .eq('sd_id', sd.id)
+    .limit(1);
+  if (!prds || prds.length === 0) return out;
+
+  out.noticeRequired = true;
+
+  if (!sd.claiming_session_id) {
+    out.errorCode = 'AMEND_NO_CONSUMER';
+    out.warning = `${sdKey} is in ${sd.current_phase} with a PRD but has no claiming session — `
+      + 'the amendment reached the row and no worker. Re-dispatch or re-claim before relying on it.';
+    return out;
+  }
+
+  // Reuse the validated coordination writer. dispatchToWorker wraps insertCoordinationRow and adds
+  // the 'worker' role hint; hand-rolling a session_coordination insert would bypass its target
+  // liveness/tier/terminal guards.
+  const dispatchToWorker = dispatch || require('../coordinator/dispatch.cjs').dispatchToWorker;
+  const changed = Object.keys(patch).join(', ');
+
+  try {
+    await dispatchToWorker(supabase, {
+      sender_session: senderSession,
+      target_session: sd.claiming_session_id,
+      message_type: 'INFO',
+      subject: `[SD AMENDED] ${sdKey} — ${changed} changed mid-build`,
+      payload: {
+        // FR-5: reuse the EXISTING kind verbatim. It is already in DIRECTIVE_KINDS and
+        // PRIORITY_EXEMPT_DIRECTIVE_KINDS, and tests/unit/coord-adam-comms-resilient.test.js
+        // source-pins that array with toEqual — minting a new kind would break that pin plus the
+        // duplicated array in tests/unit/fleet/drain-sets-adam-reconciliation.test.js.
+        kind: 'fence_notice',
+        // FR-5 disjointness from sibling -C: this stays a ONE-WAY directive. No reply_class and no
+        // adam_advisory kind, so it never enters -C's alreadyAnswered dedup / ping-on-silence path.
+        sd_key: sdKey,
+        amended_fields: Object.keys(patch),
+        body: `${sdKey} was amended while you hold it in ${sd.current_phase}. Fields changed: `
+          + `${changed}. You are building to a PRD written before this change — re-read the SD `
+          + `before continuing.${reason ? ` Reason: ${reason}` : ''}`,
+      },
+    }, { logger });
+    out.noticeDelivered = true;
+  } catch (e) {
+    // Typed codes from assertValidTarget (dispatch.cjs:129-178): DISPATCH_TARGET_INVALID /
+    // DISPATCH_TARGET_UNKNOWN / DISPATCH_TARGET_STALE / DISPATCH_LOOKUP_FAILED. Translate rather
+    // than invent new error vocabulary.
+    out.errorCode = e?.code || 'AMEND_DISPATCH_FAILED';
+    out.warning = `${sdKey} was updated but the worker was NOT notified (${out.errorCode}): ${e?.message || e}`;
+  }
+
+  return out;
+}

--- a/lib/sd/amend-sd.js
+++ b/lib/sd/amend-sd.js
@@ -100,7 +100,24 @@ export const PROTECTED_METADATA_KEYS = Object.freeze([
   // {door_class: null} would have erased a one-way-door supervision requirement in one call.
   'door_class',
   'requires_human_action',
+  // Strict === true, fail-open on absence (claim-eligibility.cjs:270-271 and
+  // lib/coordinator/sd-exclusion.mjs): keeps a throwaway test-clone build tree off the belt.
+  // Clearing it makes a disposable venture claimable again — capacity waste rather than an
+  // authorization bypass, but there is no legitimate reason to set it from an amendment.
+  'test_clone_build_tree',
 ]);
+
+/**
+ * DELIBERATELY NOT PROTECTED: depends_on / dependencies / soft_depends_on.
+ *
+ * They do gate claiming (parse-sd-dependencies.cjs feeding claim-eligibility.cjs:439-465, fail-open
+ * when absent), so by the logic above they look like candidates. They are excluded because unlike
+ * the governance holds, re-sequencing an SD's dependencies is a LEGITIMATE amendment — it is
+ * ordinary scope correction, which is the entire purpose of this path. Blanket-refusing them would
+ * break the use case the module exists to serve, and a refusal that blocks correct work trains
+ * callers to route around the safe path. Recorded here so the omission reads as a decision rather
+ * than a third incomplete enumeration.
+ */
 
 /**
  * PURE: does this SD row sit in a phase where an amendment has a live consumer?

--- a/lib/sd/amend-sd.js
+++ b/lib/sd/amend-sd.js
@@ -68,6 +68,34 @@ export const ACTIVE_BUILD_PHASES = Object.freeze([
 export const AMENDABLE_FIELDS = Object.freeze(['description', 'scope', 'metadata']);
 
 /**
+ * metadata is NOT an inert blob: strategic_directives_v2.metadata stores fail-open governance holds
+ * that lib/fleet/claim-eligibility.cjs reads. Every one of these blocks on an EXPLICIT value and is
+ * fail-OPEN on absence, so DELETING a key silently lifts the hold:
+ *   chairman_ratified === false     -> chairman_ratification_pending (claim-eligibility.cjs:236)
+ *   co_author_pending === true      -> co_author_pending            (:227)
+ *   needs_coordinator_review === true -> needs_coordinator_review   (:250)
+ *   door_class_note === 'one_way'   -> one_way_door_requires_supervision (:218)
+ *   lead_blocker (active shapes)    -> lead_blocker_active          (:261)
+ *   min_tier_rank                   -> tier floor                   (:313)
+ *
+ * A plain supabase .update({metadata:{...}}) REPLACES the whole JSONB column, so amending metadata
+ * naively would drop whichever of these were set — turning an SD awaiting chairman ratification into
+ * a claimable one, silently. Found by the deep-tier adversarial review of PR #6559; the original
+ * allowlist closed exactly this hazard class for claiming_session_id and then failed to apply the
+ * same reasoning one line later. Hence: metadata is MERGED, never replaced, and these keys cannot be
+ * written through this path at all.
+ */
+export const PROTECTED_METADATA_KEYS = Object.freeze([
+  'chairman_ratified',
+  'co_author_pending',
+  'needs_coordinator_review',
+  'door_class_note',
+  'lead_blocker',
+  'min_tier_rank',
+  'governance_metadata',
+]);
+
+/**
  * PURE: does this SD row sit in a phase where an amendment has a live consumer?
  * Composes the EXISTING active-SD predicate (status/is_active/archived_at, lib/sd/active-sd-predicate.js)
  * rather than re-deriving it — that helper is the established SSOT for the status dimension and
@@ -126,7 +154,7 @@ export async function amendSd(supabase, sdKey, patch, opts = {}) {
 
   const { data: sd, error: readErr } = await supabase
     .from('strategic_directives_v2')
-    .select('id, sd_key, status, is_active, archived_at, current_phase, claiming_session_id')
+    .select('id, sd_key, status, is_active, archived_at, current_phase, claiming_session_id, metadata')
     .eq('sd_key', sdKey)
     .maybeSingle();
 
@@ -136,14 +164,45 @@ export async function amendSd(supabase, sdKey, patch, opts = {}) {
     return out;
   }
 
-  const { error: upErr } = await supabase
+  // metadata is MERGED onto what is already there, never substituted for it, and the governance
+  // holds above are refused outright — a JSONB replace would delete whichever holds were set.
+  let effectivePatch = patch;
+  if (Object.prototype.hasOwnProperty.call(patch, 'metadata')) {
+    const incoming = patch.metadata;
+    if (!incoming || typeof incoming !== 'object' || Array.isArray(incoming)) {
+      out.errorCode = 'AMEND_METADATA_NOT_OBJECT';
+      out.warning = 'metadata must be a plain object — it is merged, not replaced';
+      return out;
+    }
+    const protectedHit = Object.keys(incoming).filter((k) => PROTECTED_METADATA_KEYS.includes(k));
+    if (protectedHit.length > 0) {
+      out.errorCode = 'AMEND_PROTECTED_METADATA_KEY';
+      out.warning = `refusing to write governance-hold metadata key(s): ${protectedHit.join(', ')}. `
+        + 'These are fail-open holds read by claim-eligibility; clearing one silently makes an SD '
+        + 'claimable. Change them through their owning subsystem, not the amendment path.';
+      return out;
+    }
+    effectivePatch = { ...patch, metadata: { ...(sd.metadata || {}), ...incoming } };
+  }
+
+  // .select() so a zero-row UPDATE is distinguishable from a successful one: PostgREST returns no
+  // error when nothing matched, so without this the helper would report sdUpdated=true and the CLI
+  // would exit 0 having written nothing — the exact silent success FR-3 exists to prevent.
+  const { data: updated, error: upErr } = await supabase
     .from('strategic_directives_v2')
-    .update(patch)
-    .eq('sd_key', sdKey);
+    .update(effectivePatch)
+    .eq('sd_key', sdKey)
+    .select('sd_key');
 
   if (upErr) {
     out.errorCode = 'AMEND_UPDATE_FAILED';
     out.warning = `update failed: ${upErr.message}`;
+    return out;
+  }
+  if (!Array.isArray(updated) || updated.length === 0) {
+    out.errorCode = 'AMEND_NO_ROWS_UPDATED';
+    out.warning = `update matched no rows for ${sdKey} — the SD may have been deleted, renamed or `
+      + 'filtered by RLS between read and write. Nothing was written and nobody was notified.';
     return out;
   }
   out.sdUpdated = true;

--- a/scripts/amend-sd.js
+++ b/scripts/amend-sd.js
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+/**
+ * amend-sd — the canonical way to change an SD's scope/description after work has started.
+ * SD-LEO-INFRA-CORRECTION-DELIVERY-PATH-001-D.
+ *
+ * Use this instead of a raw .update() on strategic_directives_v2 whenever an SD may already be
+ * claimed: a raw update reaches the row and nobody, because EXEC builds to the PRD it already
+ * holds. This path also emits a directed fence_notice to the claiming session.
+ *
+ * EXIT CONTRACT (FR-3 — being wrong must be loud, not silent):
+ *   0  amended, and either delivered to the claiming worker or no consumer was required
+ *   1  amended but the worker was NOT notified (or the amendment itself failed)
+ * The SD update is never rolled back by a delivery failure — both facts are printed.
+ *
+ * Usage:
+ *   node scripts/amend-sd.js <SD-KEY> --append "<text>"        append to description AND scope
+ *   node scripts/amend-sd.js <SD-KEY> --description "<text>"   replace description
+ *   node scripts/amend-sd.js <SD-KEY> --scope "<text>"         replace scope
+ *   [--reason "<why>"]                                          carried in the notice body
+ */
+
+import path from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+import { createClient } from '@supabase/supabase-js';
+import { amendSd } from '../lib/sd/amend-sd.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
+
+function arg(flag) {
+  const i = process.argv.indexOf(flag);
+  return i !== -1 ? process.argv[i + 1] : undefined;
+}
+
+async function main() {
+  const sdKey = process.argv.slice(2).find((a) => !a.startsWith('--') && a !== arg('--append')
+    && a !== arg('--description') && a !== arg('--scope') && a !== arg('--reason'));
+  const append = arg('--append');
+  const description = arg('--description');
+  const scope = arg('--scope');
+  const reason = arg('--reason');
+
+  if (!sdKey || (!append && !description && !scope)) {
+    console.error('Usage: node scripts/amend-sd.js <SD-KEY> (--append|--description|--scope) "<text>" [--reason "<why>"]');
+    process.exit(2);
+  }
+
+  const sb = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY
+  );
+
+  let patch = {};
+  if (append) {
+    const { data: cur } = await sb
+      .from('strategic_directives_v2')
+      .select('description, scope')
+      .eq('sd_key', sdKey)
+      .maybeSingle();
+    if (!cur) { console.error(`[amend-sd] SD not found: ${sdKey}`); process.exit(1); }
+    patch = {
+      description: `${cur.description || ''}\n\n${append}`,
+      scope: `${cur.scope || ''}\n\n${append}`,
+    };
+  } else {
+    if (description) patch.description = description;
+    if (scope) patch.scope = scope;
+  }
+
+  const res = await amendSd(sb, sdKey, patch, { reason });
+
+  console.log(`[amend-sd] ${sdKey}`);
+  console.log(`   sd_updated       : ${res.sdUpdated}`);
+  console.log(`   notice_required  : ${res.noticeRequired}`);
+  console.log(`   notice_delivered : ${res.noticeDelivered}`);
+  if (res.warning) console.log(`   ⚠️  ${res.warning}`);
+  if (res.errorCode) console.log(`   error_code       : ${res.errorCode}`);
+
+  // Loud, not silent: a required-but-undelivered notice is a failure even though the row changed.
+  const failed = !res.sdUpdated || (res.noticeRequired && !res.noticeDelivered);
+  process.exit(failed ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(`[amend-sd] fatal: ${e?.message || e}`);
+  process.exit(1);
+});

--- a/scripts/amend-sd.js
+++ b/scripts/amend-sd.js
@@ -34,15 +34,28 @@ function arg(flag) {
 }
 
 async function main() {
-  const sdKey = process.argv.slice(2).find((a) => !a.startsWith('--') && a !== arg('--append')
-    && a !== arg('--description') && a !== arg('--scope') && a !== arg('--reason'));
+  // The SD key is the FIRST positional argument, full stop. The earlier version derived it by
+  // filtering out tokens equal to any flag's VALUE, which the deep-tier adversarial review broke:
+  // an unquoted multi-word --description that happens to begin with the SD's own key fragments into
+  // stray positionals, the real key gets filtered out by value, and the NEXT stray word is picked —
+  // silently amending a different SD and notifying its unrelated worker. Positional-by-index cannot
+  // do that.
+  const sdKey = process.argv[2];
   const append = arg('--append');
   const description = arg('--description');
   const scope = arg('--scope');
   const reason = arg('--reason');
 
-  if (!sdKey || (!append && !description && !scope)) {
+  if (!sdKey || sdKey.startsWith('--') || (!append && !description && !scope)) {
     console.error('Usage: node scripts/amend-sd.js <SD-KEY> (--append|--description|--scope) "<text>" [--reason "<why>"]');
+    console.error('       <SD-KEY> must be the FIRST argument. Quote multi-word values.');
+    process.exit(2);
+  }
+
+  // Refuse ambiguity rather than silently dropping a value: the old code let --append quietly win
+  // over a simultaneously-supplied --description.
+  if (append && (description || scope)) {
+    console.error('[amend-sd] --append cannot be combined with --description/--scope — pick one.');
     process.exit(2);
   }
 

--- a/scripts/amend-sd.js
+++ b/scripts/amend-sd.js
@@ -90,8 +90,12 @@ async function main() {
   if (res.warning) console.log(`   ⚠️  ${res.warning}`);
   if (res.errorCode) console.log(`   error_code       : ${res.errorCode}`);
 
-  // Loud, not silent: a required-but-undelivered notice is a failure even though the row changed.
-  const failed = !res.sdUpdated || (res.noticeRequired && !res.noticeDelivered);
+  // Loud, not silent. errorCode is the primary failure signal: it is null on every success path and
+  // non-null on every failure path, which makes it strictly more correct than the compound boolean
+  // alone. Without it a PARTIAL patch — description column written, metadata merge failed — returns
+  // sdUpdated:true with noticeRequired never reached, and the old expression exited 0 on a
+  // half-applied amendment. Found by the deep-tier review of PR #6559.
+  const failed = !res.sdUpdated || res.errorCode !== null || (res.noticeRequired && !res.noticeDelivered);
   process.exit(failed ? 1 : 0);
 }
 

--- a/tests/unit/sd/amend-sd.test.js
+++ b/tests/unit/sd/amend-sd.test.js
@@ -224,27 +224,53 @@ describe('SECURITY cbe69100 F1: the patch is allowlisted, not passed through', (
   it('still allows the three legitimate amendable fields', async () => {
     for (const col of ['description', 'scope', 'metadata']) {
       const sb = makeSb({ sd: activeSd(), prds: [] });
-      const res = await amendSd(sb, 'SD-TEST-AMEND-001', { [col]: col === 'metadata' ? {} : 'text' }, {});
+      const res = await amendSd(sb, 'SD-TEST-AMEND-001', { [col]: col === 'metadata' ? { k: 1 } : 'text' }, {
+        // metadata takes the atomic-merge path, so it needs the seam rather than the column update.
+        mergeMetadata: async (key) => ({ merged: true, sdKey: key }),
+      });
       expect(res.sdUpdated).toBe(true);
       expect(res.errorCode).toBeNull();
     }
   });
 });
 
-describe('PR #6559 adversarial CRITICAL: metadata is merged, never replaced', () => {
-  it('preserves a fail-open governance hold that a JSONB replace would have deleted', async () => {
-    // chairman_ratified===false BLOCKS belt-claim, and ABSENCE is fail-open — so dropping the key
-    // silently makes an unratified SD claimable. This is the exact bug the review caught.
+describe('PR #6559 adversarial CRITICAL: metadata is merged atomically, never replaced', () => {
+  it('routes metadata through the atomic DB-side merge, never a read-spread-write', async () => {
+    // Round 2 finding: a JS spread built from a snapshot resurrects a hold a concurrent process
+    // just cleared. lib/coordinator/safe-metadata-merge.mjs exists to prevent exactly that, so the
+    // contract under test is "metadata never rides the column .update()".
+    const merged = [];
     const sd = activeSd({ metadata: { chairman_ratified: false, note: 'keep me' } });
     const sb = makeSb({ sd, prds: [] });
 
-    const res = await amendSd(sb, 'SD-TEST-AMEND-001', { metadata: { extra: 1 } }, {});
+    const res = await amendSd(sb, 'SD-TEST-AMEND-001', { metadata: { extra: 1 } }, {
+      mergeMetadata: async (key, patch) => { merged.push({ key, patch }); return { merged: true, sdKey: key }; },
+    });
 
     expect(res.sdUpdated).toBe(true);
-    const written = sb.updates.at(-1).patch.metadata;
-    expect(written.chairman_ratified).toBe(false); // hold survived
-    expect(written.note).toBe('keep me');          // unrelated key survived
-    expect(written.extra).toBe(1);                 // new key applied
+    // Only the keys the caller asked for are sent; every other key is untouched BY THE DB, so no
+    // snapshot of chairman_ratified is ever written back.
+    expect(merged).toEqual([{ key: 'SD-TEST-AMEND-001', patch: { extra: 1 } }]);
+    // And metadata must NOT have gone through the column update path at all.
+    expect(sb.updates).toHaveLength(0);
+  });
+
+  it('reports failure when the atomic merge matches no rows', async () => {
+    const sb = makeSb({ sd: activeSd(), prds: [] });
+    const res = await amendSd(sb, 'SD-TEST-AMEND-001', { metadata: { a: 1 } }, {
+      mergeMetadata: async () => ({ merged: false, sdKey: 'x', error: 'no rows' }),
+    });
+    expect(res.sdUpdated).toBe(false);
+    expect(res.errorCode).toBe('AMEND_METADATA_MERGE_FAILED');
+  });
+
+  it('refuses an explicit undefined value, which serialization would silently drop', async () => {
+    const sb = makeSb({ sd: activeSd(), prds: [] });
+    const res = await amendSd(sb, 'SD-TEST-AMEND-001', { metadata: { note: undefined } }, {
+      mergeMetadata: async () => { throw new Error('must not merge'); },
+    });
+    expect(res.sdUpdated).toBe(false);
+    expect(res.errorCode).toBe('AMEND_METADATA_UNDEFINED_VALUE');
   });
 
   it.each([...PROTECTED_METADATA_KEYS])('refuses to write the governance key %s at all', async (key) => {

--- a/tests/unit/sd/amend-sd.test.js
+++ b/tests/unit/sd/amend-sd.test.js
@@ -14,7 +14,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { amendSd, isInActiveBuildPhase, ACTIVE_BUILD_PHASES } from '../../../lib/sd/amend-sd.js';
+import { amendSd, isInActiveBuildPhase, ACTIVE_BUILD_PHASES, PROTECTED_METADATA_KEYS } from '../../../lib/sd/amend-sd.js';
 import { extractSdFrs } from '../../../scripts/modules/handoff/executors/plan-to-exec/gates/sd-prd-drift.js';
 import { DIRECTIVE_KINDS, PAYLOAD_KINDS } from '../../../lib/fleet/worker-status.cjs';
 
@@ -25,7 +25,7 @@ const CLAIM_SESSION = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
  * Minimal supabase stub. `sd` is the row returned for strategic_directives_v2;
  * `prds` is what product_requirements_v2 returns; updates are recorded.
  */
-function makeSb({ sd, prds = [{ id: 'prd-1' }], updateError = null }) {
+function makeSb({ sd, prds = [{ id: 'prd-1' }], updateError = null, updatedRows = [{ sd_key: 'SD-TEST-AMEND-001' }] }) {
   const updates = [];
   return {
     updates,
@@ -42,7 +42,8 @@ function makeSb({ sd, prds = [{ id: 'prd-1' }], updateError = null }) {
         maybeSingle() { return Promise.resolve({ data: sd, error: null }); },
         update(patch) {
           updates.push({ table: api._table, patch });
-          return { eq: () => Promise.resolve({ error: updateError }) };
+          // Mirrors the real chain: .update(...).eq(...).select(...) resolves to the affected rows.
+          return { eq: () => ({ select: () => Promise.resolve({ data: updatedRows, error: updateError }) }) };
         },
       };
       return api;
@@ -227,6 +228,57 @@ describe('SECURITY cbe69100 F1: the patch is allowlisted, not passed through', (
       expect(res.sdUpdated).toBe(true);
       expect(res.errorCode).toBeNull();
     }
+  });
+});
+
+describe('PR #6559 adversarial CRITICAL: metadata is merged, never replaced', () => {
+  it('preserves a fail-open governance hold that a JSONB replace would have deleted', async () => {
+    // chairman_ratified===false BLOCKS belt-claim, and ABSENCE is fail-open — so dropping the key
+    // silently makes an unratified SD claimable. This is the exact bug the review caught.
+    const sd = activeSd({ metadata: { chairman_ratified: false, note: 'keep me' } });
+    const sb = makeSb({ sd, prds: [] });
+
+    const res = await amendSd(sb, 'SD-TEST-AMEND-001', { metadata: { extra: 1 } }, {});
+
+    expect(res.sdUpdated).toBe(true);
+    const written = sb.updates.at(-1).patch.metadata;
+    expect(written.chairman_ratified).toBe(false); // hold survived
+    expect(written.note).toBe('keep me');          // unrelated key survived
+    expect(written.extra).toBe(1);                 // new key applied
+  });
+
+  it.each([...PROTECTED_METADATA_KEYS])('refuses to write the governance key %s at all', async (key) => {
+    const sb = makeSb({ sd: activeSd({ metadata: {} }), prds: [] });
+    const res = await amendSd(sb, 'SD-TEST-AMEND-001', { metadata: { [key]: 'anything' } }, {});
+
+    expect(res.sdUpdated).toBe(false);
+    expect(res.errorCode).toBe('AMEND_PROTECTED_METADATA_KEY');
+    expect(sb.updates).toHaveLength(0);
+  });
+
+  it('rejects a non-object metadata rather than replacing the column with it', async () => {
+    for (const bad of ['a string', 42, ['an', 'array'], null]) {
+      const sb = makeSb({ sd: activeSd(), prds: [] });
+      const res = await amendSd(sb, 'SD-TEST-AMEND-001', { metadata: bad }, {});
+      expect(res.sdUpdated).toBe(false);
+      expect(sb.updates).toHaveLength(0);
+    }
+  });
+});
+
+describe('PR #6559 adversarial WARNING: a zero-row UPDATE is not a success', () => {
+  it('reports AMEND_NO_ROWS_UPDATED instead of claiming the write happened', async () => {
+    const sent = [];
+    // PostgREST returns no error when nothing matched — only the returned row set reveals it.
+    const sb = makeSb({ sd: activeSd(), updatedRows: [] });
+    const res = await amendSd(sb, 'SD-TEST-AMEND-001', { description: 'x' }, {
+      dispatch: async (_sb, row) => { sent.push(row); },
+    });
+
+    expect(res.sdUpdated).toBe(false);
+    expect(res.errorCode).toBe('AMEND_NO_ROWS_UPDATED');
+    // And crucially: no notice claiming a change that never landed.
+    expect(sent).toHaveLength(0);
   });
 });
 

--- a/tests/unit/sd/amend-sd.test.js
+++ b/tests/unit/sd/amend-sd.test.js
@@ -1,0 +1,223 @@
+/**
+ * SD-LEO-INFRA-CORRECTION-DELIVERY-PATH-001-D — a mid-EXEC SD amendment must reach the worker.
+ *
+ * Covers TS-1..TS-5 plus the four conditions TESTING made binding at PLAN-TO-EXEC
+ * (evidence 30c9d925-8897-4f5b-ac43-612b4ce23d72):
+ *   TC-1 TS-2 must SELF-VERIFY its fixture with the gate's own extractSdFrs, or it can pass
+ *        vacuously without ever exercising the 88.5% blind-spot path.
+ *   TC-2 FR-3 needs a named return contract, asserted here field by field.
+ *   TC-3 TS-3 split into its two distinct triggers (no consumer vs dispatch failure).
+ *   TC-5 FR-1 AC-4 gets a real scenario: prove no NEW payload kind is needed.
+ *
+ * No live credentials: the supabase client is a hand-built stub and dispatch is injected through
+ * the opts seam, so this is a true unit test and never writes to a real project.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { amendSd, isInActiveBuildPhase, ACTIVE_BUILD_PHASES } from '../../../lib/sd/amend-sd.js';
+import { extractSdFrs } from '../../../scripts/modules/handoff/executors/plan-to-exec/gates/sd-prd-drift.js';
+import { DIRECTIVE_KINDS, PAYLOAD_KINDS } from '../../../lib/fleet/worker-status.cjs';
+
+const SD_UUID = '11111111-2222-3333-4444-555555555555';
+const CLAIM_SESSION = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+/**
+ * Minimal supabase stub. `sd` is the row returned for strategic_directives_v2;
+ * `prds` is what product_requirements_v2 returns; updates are recorded.
+ */
+function makeSb({ sd, prds = [{ id: 'prd-1' }], updateError = null }) {
+  const updates = [];
+  return {
+    updates,
+    from(table) {
+      const api = {
+        _table: table,
+        select() { return api; },
+        eq() { return api; },
+        limit() {
+          // product_requirements_v2 lookup resolves here (no maybeSingle in that path)
+          if (api._table === 'product_requirements_v2') return Promise.resolve({ data: prds, error: null });
+          return api;
+        },
+        maybeSingle() { return Promise.resolve({ data: sd, error: null }); },
+        update(patch) {
+          updates.push({ table: api._table, patch });
+          return { eq: () => Promise.resolve({ error: updateError }) };
+        },
+      };
+      return api;
+    },
+  };
+}
+
+const activeSd = (over = {}) => ({
+  id: SD_UUID,
+  sd_key: 'SD-TEST-AMEND-001',
+  status: 'in_progress',
+  is_active: true,
+  archived_at: null,
+  current_phase: 'EXEC',
+  claiming_session_id: CLAIM_SESSION,
+  ...over,
+});
+
+describe('isInActiveBuildPhase', () => {
+  it('accepts the phases a worker can actually be building in', () => {
+    for (const phase of ACTIVE_BUILD_PHASES) {
+      expect(isInActiveBuildPhase(activeSd({ current_phase: phase }))).toBe(true);
+    }
+  });
+
+  it('rejects LEAD phases, terminal SDs and archived rows', () => {
+    expect(isInActiveBuildPhase(activeSd({ current_phase: 'LEAD' }))).toBe(false);
+    expect(isInActiveBuildPhase(activeSd({ status: 'completed' }))).toBe(false);
+    expect(isInActiveBuildPhase(activeSd({ archived_at: '2026-01-01' }))).toBe(false);
+    expect(isInActiveBuildPhase(activeSd({ is_active: false }))).toBe(false);
+  });
+});
+
+describe('TS-1: a mid-EXEC amendment notifies the claiming session', () => {
+  it('dispatches a fence_notice addressed to claiming_session_id', async () => {
+    const sent = [];
+    const sb = makeSb({ sd: activeSd() });
+    const res = await amendSd(sb, 'SD-TEST-AMEND-001', { description: 'new text' }, {
+      dispatch: async (_sb, row) => { sent.push(row); },
+      senderSession: 'sender-1',
+    });
+
+    expect(res.sdUpdated).toBe(true);
+    expect(res.noticeRequired).toBe(true);
+    expect(res.noticeDelivered).toBe(true);
+    expect(res.errorCode).toBeNull();
+    expect(sent).toHaveLength(1);
+    expect(sent[0].target_session).toBe(CLAIM_SESSION);
+    expect(sent[0].payload.kind).toBe('fence_notice');
+    expect(sent[0].payload.sd_key).toBe('SD-TEST-AMEND-001');
+    // The body must name the SD and the change, so the recipient acts without opening another table.
+    expect(sent[0].payload.body).toContain('SD-TEST-AMEND-001');
+    expect(sent[0].payload.body).toContain('description');
+  });
+});
+
+describe('TS-2: the fix must work for the 88.5% of SDs the drift gate cannot see', () => {
+  it('notifies even when the SD has ZERO extractable FRs (fixture self-verified — TC-1)', async () => {
+    // TC-1: prove the fixture really is a zero-extractable-FR SD using the GATE'S OWN function,
+    // the same one LEAD measured with. Without this the scenario could pass vacuously and the
+    // blind-spot path would never actually be exercised.
+    const fixtureSd = {
+      ...activeSd(),
+      description: 'A prose description with no functional-requirement markers at all.',
+      scope: 'Likewise no markers here. Criteria are labelled AC-1 and AC-2, not the FR form.',
+      metadata: {},
+    };
+    expect(extractSdFrs(fixtureSd)).toHaveLength(0);
+
+    const sent = [];
+    const sb = makeSb({ sd: fixtureSd });
+    const res = await amendSd(sb, 'SD-TEST-AMEND-001', { scope: 'amended scope' }, {
+      dispatch: async (_sb, row) => { sent.push(row); },
+    });
+
+    expect(res.noticeDelivered).toBe(true);
+    expect(sent).toHaveLength(1);
+  });
+
+  it('a fixture WITH extractable FRs is a different case — guards the self-check itself', () => {
+    const withFrs = { description: 'FR-1 the first requirement text', scope: '', metadata: {} };
+    expect(extractSdFrs(withFrs).length).toBeGreaterThan(0);
+  });
+});
+
+describe('TS-3a (TC-3): amendment with no consumer fails loudly, and does not roll back', () => {
+  it('reports AMEND_NO_CONSUMER while keeping sdUpdated true', async () => {
+    const sb = makeSb({ sd: activeSd({ claiming_session_id: null }) });
+    const res = await amendSd(sb, 'SD-TEST-AMEND-001', { description: 'x' }, {
+      dispatch: async () => { throw new Error('must not dispatch'); },
+    });
+
+    expect(res.sdUpdated).toBe(true);        // the amendment persisted...
+    expect(res.noticeRequired).toBe(true);
+    expect(res.noticeDelivered).toBe(false); // ...and the caller is told nobody heard it
+    expect(res.errorCode).toBe('AMEND_NO_CONSUMER');
+    expect(res.warning).toMatch(/no claiming session/i);
+  });
+});
+
+describe('TS-3b (TC-3): dispatch failure is surfaced with the dispatcher\'s own typed code', () => {
+  it.each([
+    'DISPATCH_TARGET_INVALID',
+    'DISPATCH_TARGET_UNKNOWN',
+    'DISPATCH_TARGET_STALE',
+    'DISPATCH_LOOKUP_FAILED',
+  ])('translates %s rather than inventing new error vocabulary', async (code) => {
+    const sb = makeSb({ sd: activeSd() });
+    const res = await amendSd(sb, 'SD-TEST-AMEND-001', { description: 'x' }, {
+      dispatch: async () => { const e = new Error('boom'); e.code = code; throw e; },
+      logger: { warn() {}, error() {} },
+    });
+
+    expect(res.sdUpdated).toBe(true);
+    expect(res.noticeDelivered).toBe(false);
+    expect(res.errorCode).toBe(code);
+    expect(res.warning).toContain('NOT notified');
+  });
+});
+
+describe('TS-4: no false blockers', () => {
+  it('emits nothing and warns about nothing when no PRD exists', async () => {
+    const sent = [];
+    const sb = makeSb({ sd: activeSd(), prds: [] });
+    const res = await amendSd(sb, 'SD-TEST-AMEND-001', { description: 'x' }, {
+      dispatch: async (_sb, row) => { sent.push(row); },
+    });
+
+    expect(res.sdUpdated).toBe(true);
+    expect(res.noticeRequired).toBe(false);
+    expect(res.warning).toBeNull();
+    expect(res.errorCode).toBeNull();
+    expect(sent).toHaveLength(0);
+  });
+
+  it('emits nothing for a draft/LEAD SD or a completed one', async () => {
+    for (const over of [{ current_phase: 'LEAD', status: 'draft' }, { status: 'completed' }]) {
+      const sent = [];
+      const sb = makeSb({ sd: activeSd(over) });
+      const res = await amendSd(sb, 'SD-TEST-AMEND-001', { description: 'x' }, {
+        dispatch: async (_sb, row) => { sent.push(row); },
+      });
+      expect(res.noticeRequired).toBe(false);
+      expect(sent).toHaveLength(0);
+    }
+  });
+
+  it('refuses an empty patch instead of writing nothing and claiming success', async () => {
+    const sb = makeSb({ sd: activeSd() });
+    const res = await amendSd(sb, 'SD-TEST-AMEND-001', {}, {});
+    expect(res.sdUpdated).toBe(false);
+    expect(res.errorCode).toBe('AMEND_EMPTY_PATCH');
+  });
+});
+
+describe('TS-5 / FR-1 AC-4 (TC-5): no NEW payload kind is introduced', () => {
+  it('reuses a kind already registered in DIRECTIVE_KINDS', () => {
+    // The whole reuse-vs-mint argument rests on this: fence_notice is already a directive kind,
+    // so no drain-set test and no source-pinned array needs touching.
+    expect(DIRECTIVE_KINDS).toContain('fence_notice');
+    expect(Object.values(PAYLOAD_KINDS)).toContain('fence_notice');
+  });
+
+  it('FR-5 disjointness from sibling -C: the notice is one-way, never an advisory reply', async () => {
+    const sent = [];
+    const sb = makeSb({ sd: activeSd() });
+    await amendSd(sb, 'SD-TEST-AMEND-001', { description: 'x' }, {
+      dispatch: async (_sb, row) => { sent.push(row); },
+    });
+
+    const payload = sent[0].payload;
+    // -C's alreadyAnswered dedup is scoped to payload.kind === 'ADAM_ADVISORY' and reply rows.
+    // Staying out of both keeps the two children mechanically disjoint, which the parent requires.
+    expect(String(payload.kind).toLowerCase()).not.toBe('adam_advisory');
+    expect(payload.reply_class).toBeUndefined();
+    expect(payload.reply_to).toBeUndefined();
+  });
+});

--- a/tests/unit/sd/amend-sd.test.js
+++ b/tests/unit/sd/amend-sd.test.js
@@ -198,6 +198,38 @@ describe('TS-4: no false blockers', () => {
   });
 });
 
+describe('SECURITY cbe69100 F1: the patch is allowlisted, not passed through', () => {
+  it.each(['claiming_session_id', 'status', 'sd_type', 'is_active'])(
+    'refuses to write %s and does NOT touch the table',
+    async (col) => {
+      const sb = makeSb({ sd: activeSd() });
+      const res = await amendSd(sb, 'SD-TEST-AMEND-001', { [col]: 'x' }, {});
+
+      expect(res.sdUpdated).toBe(false);
+      expect(res.errorCode).toBe('AMEND_FIELD_NOT_AMENDABLE');
+      // Fails CLOSED — the column is refused, never silently dropped while reporting success.
+      expect(sb.updates).toHaveLength(0);
+    }
+  );
+
+  it('refuses a mixed patch outright rather than applying only the legal half', async () => {
+    const sb = makeSb({ sd: activeSd() });
+    const res = await amendSd(sb, 'SD-TEST-AMEND-001', { description: 'ok', claiming_session_id: null }, {});
+    expect(res.sdUpdated).toBe(false);
+    expect(res.warning).toMatch(/claim_sd\/release_sd/);
+    expect(sb.updates).toHaveLength(0);
+  });
+
+  it('still allows the three legitimate amendable fields', async () => {
+    for (const col of ['description', 'scope', 'metadata']) {
+      const sb = makeSb({ sd: activeSd(), prds: [] });
+      const res = await amendSd(sb, 'SD-TEST-AMEND-001', { [col]: col === 'metadata' ? {} : 'text' }, {});
+      expect(res.sdUpdated).toBe(true);
+      expect(res.errorCode).toBeNull();
+    }
+  });
+});
+
 describe('TS-5 / FR-1 AC-4 (TC-5): no NEW payload kind is introduced', () => {
   it('reuses a kind already registered in DIRECTIVE_KINDS', () => {
     // The whole reuse-vs-mint argument rests on this: fence_notice is already a directive kind,


### PR DESCRIPTION
## Summary

Child -D of SD-LEO-INFRA-CORRECTION-DELIVERY-PATH-001 ("the harness propagates findings faster than retractions").

Once a PRD exists, editing an SD's scope reaches nobody: EXEC builds to the PRD it already holds, and the one content-comparison gate runs once at PLAN-TO-EXEC and is advisory by default. The original flows; the correction stalls one hop short, silently, with no error to its author.

**The obvious fix is a non-fix, and only measuring caught it.** Flipping `SD_PRD_DRIFT_ENFORCING=true` does nothing for **354 of the 400** most recent SDs (88.5%): they have no extractable FRs, so `sd-prd-drift.js:166-168` takes a vacuous `{passed:true, skipped:true}` branch *before* `enforcing` is consulted. `required` only decides whether a FAILING gate blocks; a vacuously PASSING gate blocks nothing. VALIDATION reproduced all five figures independently. **So this PR does not touch the drift gate at all.**

Instead it wires the missing **producer** for payload kind `fence_notice` — purpose-built by SD-LEO-INFRA-MID-FLIGHT-DIRECTIVE-001 for exactly this shape, already in `DIRECTIVE_KINDS` and `PRIORITY_EXEMPT_DIRECTIVE_KINDS`, with consumers and drain-set wiring but no code emitting it. The only pre-existing `fence_notice` rows were hand-authored coordinator corrections (all five dead-lettered) — corrections were travelling this lane by hand because nothing emitted them programmatically.

### Changes
- `lib/sd/amend-sd.js` — `amendSd()`, `isInActiveBuildPhase()`, `ACTIVE_BUILD_PHASES`, `AMENDABLE_FIELDS`
- `scripts/amend-sd.js` — CLI with an exit contract (exit 1 when a required notice was not delivered)
- `tests/unit/sd/amend-sd.test.js` — 21 tests

### Scope limit (stated, not implied)
There is no chokepoint for SD writes (~30+ one-off scripts update the table directly). This establishes the canonical amendment path; it does **not** retrofit history. Universal coverage needs a trigger on description/scope — chairman-gated DDL, deliberately left as a separate follow-on.

## Test plan
- [x] 21/21 unit tests
- [x] 81/81 across the reuse-vs-mint risk surface (drain sets, priority-exempt, source-pinned DIRECTIVE_KINDS array, dispatch) — reuse touched zero existing tests
- [x] **Live end-to-end, self-referential**: the EXEC note on this SD was appended *through* the new helper; the resulting notice arrived back via the real worker inbox as a `pending_directive` and was acked
- [x] SECURITY finding fixed inline rather than deferred: `patch` is now allowlisted to description/scope/metadata, failing CLOSED (`claiming_session_id` is not trigger-protected and must go through the claim_sd/release_sd RPCs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)