### PR TITLE
fix(QF-20260727-733): reaper must resolve the work-item key from the branch ref, not the directory basename

### DIFF
--- a/lib/worktree-reaper/detectors.js
+++ b/lib/worktree-reaper/detectors.js
@@ -27,6 +27,22 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 /**
+ * Resolve the canonical work-item key from a worktree's BRANCH REF.
+ * QF-20260727-733: the branch carries the full id in every observed case
+ * (refs/heads/qf/QF-YYYYMMDD-NNN, refs/heads/feat/SD-...), whereas the directory
+ * basename is frequently shortened and is not enforced anywhere. Mirrors the
+ * prefix set already used by keyFromWorktree in scripts/worktree-reaper.mjs.
+ *
+ * @param {string|undefined} branch
+ * @returns {string|null} the key, or null when the ref carries no parseable key
+ *   (e.g. plain `main`) — callers must treat null as "unknown", never as orphan.
+ */
+export function keyFromBranch(branch) {
+  const m = String(branch || '').match(/^(?:refs\/heads\/)?(?:feat|qf|fix|chore|hotfix)\/(.+)$/);
+  return (m && m[1]) ? m[1] : null;
+}
+
+/**
  * AC1 — Zombie on main.
  * A worktree is a zombie when its checked-out branch is `main`/`master` and
  * no active session claim exists for the worktree path. These accumulate
@@ -95,14 +111,23 @@ export function isNested(wt) {
 export function hasOrphanSD(wt, ctx) {
   const readFile = ctx?.readFile || defaultReadFile;
   const declaredKey = readDeclaredSdKey(wt.path, readFile);
+  // QF-20260727-733: the BRANCH REF is authoritative; the directory basename is not.
+  // Worktree dirs are routinely shortened (.worktrees/QF-757 on branch
+  // refs/heads/qf/QF-20260726-757) and that naming is not enforced anywhere, so keying
+  // off the basename asks the DB about "QF-757" — a row that does not exist — and routes
+  // a LIVE quick-fix to stage2_remove. Three live QFs (QF-425/757/908) were sitting in
+  // exactly that state at 86% pool utilization, i.e. the moment someone reclaims slots.
+  // Branch first, basename only as a fallback. Never make the basename primary, and do
+  // NOT "fix" this by forbidding shortened dir names — a convention is not a guard.
+  const branchKey = keyFromBranch(wt?.branch);
   const basenameKey = wt.key || path.basename(wt.path || '');
-  const candidateKeys = [declaredKey, basenameKey].filter(Boolean);
+  const candidateKeys = [...new Set([branchKey, declaredKey, basenameKey].filter(Boolean))];
 
   if (candidateKeys.length === 0) {
     return {
       matched: false,
       reason: 'no_sdkey_declared',
-      evidence: { declared: null, basename: basenameKey },
+      evidence: { declared: null, branch_key: branchKey, basename: basenameKey },
     };
   }
 
@@ -144,10 +169,31 @@ export function hasOrphanSD(wt, ctx) {
     };
   }
 
+  // QF-20260727-733: FAIL CLOSED when we could not actually verify. With no usable
+  // sd/qf map (DB read failed, or maps not supplied) EVERY worktree looks unknown and
+  // the whole pool would become a removal candidate. "I could not determine what this
+  // belongs to" must mean KEEP, never orphan-sd -> stage2_remove.
+  //
+  // Placed HERE, immediately before the only removal-producing return, on purpose: it
+  // must gate the orphan verdict without shadowing the more specific keep reasons above
+  // (sdkey_found / sdkey_found_via_suffix / non_sd_prefix), which are all still correct
+  // and more informative when the maps happen to be empty.
+  const lookupSize = (ctx?.sdMap?.size ?? 0) + (ctx?.qfMap?.size ?? 0);
+  if (lookupSize === 0) {
+    return {
+      matched: false,
+      reason: 'lookup_unavailable',
+      evidence: { candidates: candidateKeys, branch_key: branchKey, basename: basenameKey },
+    };
+  }
+
   return {
     matched: true,
     reason: 'sdkey_not_in_db',
-    evidence: { candidates: candidateKeys, basename: basenameKey },
+    // branch_key surfaced so a reader can tell WHICH key was actually looked up.
+    // The original incident was invisible in the JSON precisely because evidence
+    // showed only the (shortened) basename.
+    evidence: { candidates: candidateKeys, branch_key: branchKey, basename: basenameKey },
   };
 }
 

--- a/tests/unit/worktree-reaper/detectors.test.js
+++ b/tests/unit/worktree-reaper/detectors.test.js
@@ -114,7 +114,10 @@ describe('hasOrphanSD (AC3)', () => {
     const res = hasOrphanSD(
       { path: '/repo/.worktrees/SD-GHOST', key: 'SD-GHOST' },
       {
-        sdMap: new Set(),
+        // QF-20260727-733: the map must be NON-EMPTY for this assertion to mean
+        // "this key is unknown". An empty map now means "lookup unavailable" and
+        // fails CLOSED (keep) — this test's intent was always the former.
+        sdMap: new Set(['SD-SOMETHING-ELSE']),
         qfMap: new Set(),
         readFile: readFileStub(null),
       },
@@ -164,11 +167,76 @@ describe('hasOrphanSD (AC3)', () => {
   it('matches when basename is a non-SD name and no metadata resolves it (conservative orphan)', () => {
     const res = hasOrphanSD(
       { path: '/repo/.worktrees/random-dir', key: 'random-dir' },
-      { sdMap: new Set(), qfMap: new Set(), readFile: readFileStub(null) },
+      // Non-empty map per QF-20260727-733 — see note above.
+      { sdMap: new Set(['SD-SOMETHING-ELSE']), qfMap: new Set(), readFile: readFileStub(null) },
     );
     expect(res.matched).toBe(true);
     expect(res.reason).toBe('sdkey_not_in_db');
     expect(res.evidence.candidates).toContain('random-dir');
+  });
+
+  // ── QF-20260727-733 regression: branch ref is authoritative, not the dir basename ──
+  //
+  // Live incident: three worktrees with SHORTENED directory names
+  // (.worktrees/QF-757 on branch refs/heads/qf/QF-20260726-757, likewise QF-908 and
+  // QF-425) were classified orphan-sd / sdkey_not_in_db and routed to stage2_remove
+  // while all three QFs were LIVE in the DB — discovered at 86% pool utilization,
+  // exactly when someone reclaims slots. The classifier never asked the branch.
+
+  it('does NOT flag a live QF whose worktree dir is shortened relative to its branch key', () => {
+    const res = hasOrphanSD(
+      { path: '/repo/.worktrees/QF-757', branch: 'refs/heads/qf/QF-20260726-757' },
+      {
+        sdMap: new Set(),
+        qfMap: new Set(['QF-20260726-757']),
+        readFile: readFileStub(null),
+      },
+    );
+    expect(res.matched).toBe(false);
+    expect(res.reason).toBe('sdkey_found');
+    expect(res.evidence.matched_key).toBe('QF-20260726-757');
+    expect(res.evidence.source).toBe('qf');
+  });
+
+  it('resolves an SD worktree from a feat/ branch when the dir is shortened', () => {
+    const res = hasOrphanSD(
+      { path: '/repo/.worktrees/SD-SHORT', branch: 'refs/heads/feat/SD-LEO-INFRA-EXAMPLE-001' },
+      {
+        sdMap: new Set(['SD-LEO-INFRA-EXAMPLE-001']),
+        qfMap: new Set(),
+        readFile: readFileStub(null),
+      },
+    );
+    expect(res.matched).toBe(false);
+    expect(res.evidence.matched_key).toBe('SD-LEO-INFRA-EXAMPLE-001');
+  });
+
+  it('surfaces the branch-derived key in evidence so a misroute is visible in the JSON', () => {
+    const res = hasOrphanSD(
+      { path: '/repo/.worktrees/QF-999', branch: 'refs/heads/qf/QF-20260726-999' },
+      { sdMap: new Set(['SD-OTHER']), qfMap: new Set(), readFile: readFileStub(null) },
+    );
+    expect(res.matched).toBe(true);
+    expect(res.evidence.branch_key).toBe('QF-20260726-999');
+    expect(res.evidence.candidates).toContain('QF-20260726-999');
+  });
+
+  it('still uses the basename when the branch carries no parseable key (e.g. main)', () => {
+    const res = hasOrphanSD(
+      { path: '/repo/.worktrees/SD-REAL', branch: 'refs/heads/main' },
+      { sdMap: new Set(['SD-REAL']), qfMap: new Set(), readFile: readFileStub(null) },
+    );
+    expect(res.matched).toBe(false);
+    expect(res.evidence.matched_key).toBe('SD-REAL');
+  });
+
+  it('FAILS CLOSED (keep) when the lookup maps are unavailable — never orphan the whole pool', () => {
+    const res = hasOrphanSD(
+      { path: '/repo/.worktrees/QF-757', branch: 'refs/heads/qf/QF-20260726-757' },
+      { sdMap: new Set(), qfMap: new Set(), readFile: readFileStub(null) },
+    );
+    expect(res.matched).toBe(false);
+    expect(res.reason).toBe('lookup_unavailable');
   });
 
   it('matches basename <sd_key>-<suffix> via prefix fallback (multi-worktree SD)', () => {


### PR DESCRIPTION
## Summary

`hasOrphanSD` keyed off the worktree **directory basename**. Worktree dirs are routinely shortened — `.worktrees/QF-757` on branch `refs/heads/qf/QF-20260726-757` — and that naming is not enforced anywhere, so the classifier asked the DB about `QF-757`, a row that does not exist, and routed a **live** quick-fix to `stage2_remove`. Three live QFs (QF-425 / QF-757 / QF-908) were in exactly that state at **86% pool utilization** — the moment someone goes looking for slots to reclaim.

The claim guard was **not** at fault and is unchanged; it correctly protected 18 worktrees. These three had no active claim but a live work-item, which is precisely the case where basename-vs-branch matters and the only case the claim guard has nothing to say about.

- `keyFromBranch()` parses `refs/heads/{feat,qf,fix,chore,hotfix}/<KEY>`, mirroring the prefix set already used by `keyFromWorktree` in `scripts/worktree-reaper.mjs`
- Branch key is now the **primary** candidate; declared key and basename remain fallbacks, so nothing that resolved before stops resolving
- **Fail closed**: with no usable sd/qf map, every worktree looks unknown and the whole pool would become a removal candidate → now `keep` / `lookup_unavailable`. Placed immediately before the only removal-producing return so it gates the orphan verdict without shadowing the more specific keep reasons
- `evidence.branch_key` added — the original incident was invisible in the JSON because evidence showed only the shortened basename

Deliberately **not** done, per the row: no forbidding of shortened dir names. Those dirs already exist across the live pool, and a convention is not a guard.

## Verified at the consumer, not just in unit tests

Live `node scripts/worktree-reaper.mjs --stage0`:

| Worktree | Branch | Before | After |
|---|---|---|---|
| QF-425 | `qf/QF-20260726-425` | orphan-sd / stage2_remove | **keep** |
| QF-757 | `qf/QF-20260726-757` | orphan-sd / stage2_remove | **keep** |
| QF-908 | `qf/QF-20260726-908` | orphan-sd / stage2_remove | **keep** |

The two remaining `orphan-sd` verdicts (`mig-20260615` on `chore/approve-rol…`, `hotfix-smoke` on `qf/hotfix-smoke-g…`) carry no parseable work-item key in their refs, so those stay correct.

## Note on two pre-existing tests

Two tests passed **empty** maps while asserting "unknown key → orphan". Their intent was always the former; an empty map now means "lookup unavailable". They were given a populated map containing an unrelated key so the precondition is explicit rather than incidental.

## Test plan

- [x] Regression case the row asked for: dir `QF-757` + branch `qf/QF-20260726-757` + QF live in DB → `keep`. Fails on pre-change code.
- [x] `feat/` branch with shortened SD dir resolves
- [x] `evidence.branch_key` surfaced so a future misroute is visible in the JSON
- [x] Basename still used when the branch carries no key (e.g. `main`)
- [x] Fail-closed when lookup maps are unavailable
- [x] 98/98 across the 5 reaper suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)