### PR TITLE
feat(SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001): FR-1b slice 4 — SD phase rewind becomes OPT-IN; 1 wired, 3 exempt

### DIFF
--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -500,6 +500,16 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
         if (!processAlive) {
           // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-6): Audit log on ambiguous release
           console.log(`[claimGuard] IDENTITY_TRANSFER: prior_session=${claim.session_id}, new_session=${sessionId}, staleness_delta=${heartbeatAge}s, gate_result=ALLOW_AMBIGUOUS_DEAD_PID, claim_pid=${claimPid}, my_terminal=${myTerminalId}, their_terminal=${claim.terminal_id}`);
+          // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b — DELIBERATELY NOT a
+          // releaseWorkItemOnSessionEnd call site, recorded here because FR-1 requires every
+          // release path to either call the shared helper or carry a written reason it must not.
+          //
+          // THE REASON: this is a release-then-REACQUIRE, not a hand-back. The `continue` below
+          // proceeds straight to acquiring the same item for THIS session. Resetting a QF to
+          // status='open' in that window would make it briefly visible to every other picker
+          // between our release and our acquire — manufacturing a steal race that does not exist
+          // today, because an item left at in_progress is invisible to them. The reset belongs on
+          // paths that GIVE WORK BACK; this one takes it over.
           const { error: releaseError } = await supabase.rpc('release_sd', {
             p_session_id: claim.session_id,
             p_reason: 'manual'
@@ -606,6 +616,9 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
       timestamp: new Date().toISOString()
     }));
     console.log(`[claimGuard] Releasing stale claim from session ${claim.session_id} (${claim.heartbeat_age_human})${sameHost && claimPid ? ` — PID ${claimPid} is dead` : ' — different host or no PID'}`);
+    // FR-1b: same exemption as the ambiguous-dead-PID release above — this is a
+    // release-then-REACQUIRE for THIS session, not a hand-back, so it must not reset the
+    // work item. See the fuller reasoning at that site.
     const { error: releaseError } = await supabase.rpc('release_sd', {
       p_session_id: claim.session_id,
       p_reason: 'manual'

--- a/lib/claim-lifecycle-release.mjs
+++ b/lib/claim-lifecycle-release.mjs
@@ -105,6 +105,12 @@ export async function releaseClaimOnPROpen(snapshot) {
   // released (so the SD can be reclaimed / rolled up); the session-side (claude_sessions.sd_key +
   // worktree_*) is deliberately LEFT INTACT because the worker is still ALIVE in that worktree.
   // It must NOT be routed through releaseClaimBothSurfaces (that would evict a live worker).
+  // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b — EXEMPT from releaseWorkItemOnSessionEnd
+  // for the same underlying reason, recorded because FR-1 requires every release path to either
+  // call the shared helper or state why it must not: THE WORKER IS STILL ALIVE AND STILL
+  // SHIPPING. The item is not abandoned, so handing it back would advertise as available
+  // something a live session is actively finishing — inviting a second worker onto it. The
+  // hand-back belongs on paths where the holder is gone, not where it is mid-flight.
   // Allowlisted in the dual-surface release guard (tests/unit/claim/release-dual-surface-guard.test.js).
   const { data, error } = await sb
     .from('strategic_directives_v2')

--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -546,6 +546,21 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
         const { releaseClaimsByHolder } = await import('../scripts/hooks/lib/file-claim-guard.cjs');
         await releaseClaimsByHolder({ holderSessionId: sd.claiming_session_id });
       } catch { /* fail-open */ }
+      // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 4, behind
+      // LEO_RELEASE_WORKITEM_RESET (default OFF). This IS a hand-back: the owner is dead,
+      // missing, or verifiably drifted onto another SD, so the item is genuinely abandoned
+      // and belongs back in the pool. Releasing the claim alone left a QF at
+      // status='in_progress' with no claimant — reachable by no picker while the
+      // coordinator's supply gauge still counted it. Runs AFTER the release above; the
+      // predicate requires claiming_session_id IS NULL. Fail-open: a failed hand-back must
+      // never block the gate from proceeding as unclaimed.
+      try {
+        const { releaseWorkItemOnSessionEnd, isReleaseWorkItemResetEnabled } =
+          await import('./fleet/release-work-item.mjs');
+        if (isReleaseWorkItemResetEnabled()) {
+          await releaseWorkItemOnSessionEnd(supabase, sdKey, 'claim_validity_orphan');
+        }
+      } catch { /* fail-open */ }
       // SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001 FR-2 (AC-2.2): distinct telemetry —
       // 'sd_key_drift' reason channel separate from stale/released/missing.
       const releaseReason = ownerIsDead

--- a/lib/commands/claim-command-workitem-handback.test.js
+++ b/lib/commands/claim-command-workitem-handback.test.js
@@ -1,0 +1,126 @@
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 3
+ *
+ * releaseClaim() — the user-facing `/claim release` verb — now hands the work item back,
+ * behind LEO_RELEASE_WORKITEM_RESET.
+ *
+ * Until this landed, the command printed "The SD is now available for other sessions" while a
+ * released quick-fix stayed at status='in_progress' with no claimant: reachable by no picker
+ * (the check-in open-QF picker selects status='open') and still counted INTO the coordinator's
+ * available-supply gauge. The message was literally false.
+ *
+ * Also pins the claim-guard.mjs EXEMPTION. FR-1 requires every release path to either call the
+ * shared helper or carry a written reason it must not; claim-guard is the latter, and a
+ * well-meaning future edit wiring it would introduce a real steal race.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+let handbackCalls;
+
+function mockModules({ action = 'qf_reopened', ok = true, detail = 'stub', rpcError = null } = {}) {
+  handbackCalls = [];
+  vi.doMock('../fleet/release-work-item.mjs', () => ({
+    isReleaseWorkItemResetEnabled: vi.fn(() => process.env.LEO_RELEASE_WORKITEM_RESET === 'on'),
+    releaseWorkItemOnSessionEnd: vi.fn(async (_sb, key, reason) => {
+      handbackCalls.push({ key, reason });
+      return { ok, action, detail };
+    }),
+  }));
+  vi.doMock('../supabase-client.js', () => ({
+    createSupabaseServiceClient: vi.fn(() => supabaseDouble({ rpcError })),
+  }));
+  vi.doMock('../resolve-own-session.js', () => ({
+    resolveOwnSession: vi.fn(async () => ({
+      session: { session_id: 'sess-1', sd_key: 'QF-20260726-175', status: 'active' },
+      source: 'env',
+    })),
+  }));
+  vi.doMock('../claim/stale-threshold.js', () => ({ getStaleThresholdSeconds: vi.fn(() => 300) }));
+}
+
+const SESSION_ROW = { session_id: 'sess-1', sd_key: 'QF-20260726-175', heartbeat_at: null, status: 'active' };
+
+function supabaseDouble({ rpcError = null } = {}) {
+  // releaseClaim uses two chains off claude_sessions/strategic_directives_v2:
+  //   .select().eq().single()      -> the session row
+  //   .select().eq().maybeSingle() -> the SD row for the LEAD_FINAL warning (null = skip)
+  const leaf = {
+    single: vi.fn().mockResolvedValue({ data: SESSION_ROW, error: null }),
+    maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+    eq: vi.fn(() => ({ limit: vi.fn().mockResolvedValue({ data: [], error: null }) })),
+    limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+  };
+  return {
+    rpc: vi.fn(async () => ({ error: rpcError })),
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({ eq: vi.fn(() => leaf), like: vi.fn(() => leaf) })),
+    })),
+  };
+}
+
+beforeEach(() => { vi.resetModules(); delete process.env.LEO_RELEASE_WORKITEM_RESET; });
+afterEach(() => { vi.restoreAllMocks(); delete process.env.LEO_RELEASE_WORKITEM_RESET; });
+
+describe('FR1B3: /claim release hands the work item back', () => {
+  it('does NOT touch the work item when the flag is unset (default OFF)', async () => {
+    mockModules();
+    const { releaseClaim } = await import('./claim-command.js');
+    await releaseClaim('sess-1');
+    expect(handbackCalls).toHaveLength(0);
+  });
+
+  it('hands the item back AFTER the claim release, naming the mechanism', async () => {
+    // Order matters: the handback predicate requires claiming_session_id IS NULL, so calling it
+    // before release_sd would match nothing.
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    mockModules();
+    const { releaseClaim } = await import('./claim-command.js');
+    await releaseClaim('sess-1');
+    expect(handbackCalls).toEqual([{ key: 'QF-20260726-175', reason: 'manual_claim_release' }]);
+  });
+
+  it('reports the reopen so the operator sees the item really came back', async () => {
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    mockModules({ action: 'qf_reopened' });
+    const logs = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((m) => logs.push(String(m)));
+    const { releaseClaim } = await import('./claim-command.js');
+    await releaseClaim('sess-1');
+    spy.mockRestore();
+    expect(logs.join('\n')).toMatch(/returned to the open pool/);
+  });
+
+  it('surfaces a failed handback instead of silently claiming success', async () => {
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    mockModules({ ok: false, action: 'error', detail: 'db down' });
+    const warns = [];
+    const spy = vi.spyOn(console, 'warn').mockImplementation((m) => warns.push(String(m)));
+    const { releaseClaim } = await import('./claim-command.js');
+    await releaseClaim('sess-1');
+    spy.mockRestore();
+    expect(warns.join('\n')).toMatch(/work-item handback failed/);
+  });
+});
+
+describe('FR1B3: claim-guard.mjs is an EXEMPT site, and the reason is recorded in the source', () => {
+  const GUARD = readFileSync(path.resolve(HERE, '../claim-guard.mjs'), 'utf8');
+
+  it('does not call the handback helper', () => {
+    // claim-guard releases a prior holder's stale claim and then REACQUIRES the same item for
+    // this session. Resetting to status='open' in that window would expose it to every other
+    // picker between our release and our acquire — a steal race that does not exist today,
+    // because an item left at in_progress is invisible to them.
+    expect(GUARD).not.toMatch(/releaseWorkItemOnSessionEnd\s*\(/);
+  });
+
+  it('records WHY it is exempt, so the exemption survives a well-meaning future edit', () => {
+    expect(GUARD).toMatch(/DELIBERATELY NOT a[\s\S]{0,80}releaseWorkItemOnSessionEnd call site/);
+    expect(GUARD).toMatch(/release-then-REACQUIRE/);
+  });
+});

--- a/lib/commands/claim-command.js
+++ b/lib/commands/claim-command.js
@@ -13,6 +13,8 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 import { getStaleThresholdSeconds } from '../claim/stale-threshold.js';
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 3 — see releaseClaim below.
+import { releaseWorkItemOnSessionEnd, isReleaseWorkItemResetEnabled } from '../fleet/release-work-item.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -204,7 +206,28 @@ export async function releaseClaim(sessionId) {
     }
   }
 
+  // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 3, behind LEO_RELEASE_WORKITEM_RESET
+  // (default OFF — unset keeps today's behaviour byte-for-byte).
+  //
+  // Releasing the CLAIM is not the same as returning the WORK ITEM. Until this landed, the
+  // line printed below ("available for other sessions") was literally false for a quick-fix:
+  // release_sd clears claiming_session_id but leaves status='in_progress', and the check-in
+  // open-QF picker selects status='open' — so the item was reachable by nobody while the
+  // coordinator's supply gauge still counted it as available.
+  //
+  // Runs AFTER the release above, never before: the handback predicate requires
+  // claiming_session_id IS NULL, so calling it while the claim is still held matches nothing.
+  let handback = null;
+  if (isReleaseWorkItemResetEnabled()) {
+    handback = await releaseWorkItemOnSessionEnd(supabase, session.sd_key, 'manual_claim_release');
+  }
+
   console.log(`Released claim on ${session.sd_key} from session ${sessionId}.`);
+  if (handback && handback.action === 'qf_reopened') {
+    console.log(`${session.sd_key} returned to the open pool — pickers can see it again.`);
+  } else if (handback && !handback.ok) {
+    console.warn(`Claim released, but the work-item handback failed: ${handback.detail}`);
+  }
   console.log('The SD is now available for other sessions.');
 }
 

--- a/lib/fleet/release-work-item.mjs
+++ b/lib/fleet/release-work-item.mjs
@@ -43,6 +43,23 @@
  *
  * FLAGGING: this module is inert until wired. The per-site conversion (FR-1b) is what
  *   sits behind LEO_RELEASE_WORKITEM_RESET (default OFF) — see isReleaseWorkItemResetEnabled.
+ *
+ * SD PHASE REWIND IS OPT-IN (`rewindPhase`, default FALSE) — corrected during FR-1b.
+ *   The SD frames the helper as "for an SD: resetSdPhaseOnRelease", which reads as though every
+ *   release path should rewind current_phase. Surveying the actual call sites disproves that:
+ *     - stale-session-sweep.cjs WANTS the rewind. Its PHASE_RESET_MAP exists so an SD is not
+ *       "left in mid-phase limbo with no active claimer", and it passes rewindPhase:true.
+ *     - coordinator-cold-recovery.cjs FORBIDS it, in its own words: "PRESERVES current_phase +
+ *       progress (resume, not restart)". Rewinding there would convert a resume into a restart
+ *       and discard the phase/progress the whole path exists to protect.
+ *     - claim-validity-gate.js releases a dead/drifted owner so the NEXT claimer can pick the SD
+ *       up. The fleet's resume contract (worker-checkin resume_orphan: "reads the SD's live
+ *       current_phase ... NOT a restart — keep existing commits/PRD/handoffs") means preserving
+ *       is correct there too.
+ *   So the rewind is a per-site POLICY, not a property of releasing. Defaulting it ON would make
+ *   every future call site silently inherit a behaviour that contradicts its own documented
+ *   intent, and would do so invisibly — the SD would simply come back one phase earlier.
+ *   Returning a QF to the open pool carries no such ambiguity and is always applied.
  */
 
 import { assertSweepHandoffGate } from '../exec-context-guard.mjs';
@@ -78,7 +95,10 @@ export function isQuickFixKey(workItemKey) {
  *   action: 'qf_reopened' | 'qf_untouched' | 'sd_phase_reset' | 'sd_no_reset' | 'skipped' | 'error'
  */
 export async function releaseWorkItemOnSessionEnd(supabase, workItemKey, reason, opts = {}) {
-  const { onLog = () => {} } = opts;
+  // rewindPhase defaults FALSE — see the "SD PHASE REWIND IS OPT-IN" note in the module
+  // header. Returning a QF to the open pool is universally correct for a hand-back; rewinding
+  // an SD's phase is a POLICY that several release paths explicitly forbid.
+  const { onLog = () => {}, rewindPhase = false } = opts;
   if (!supabase || !workItemKey) {
     return { ok: false, kind: null, action: 'skipped', reason, detail: 'missing supabase client or work item key' };
   }
@@ -115,7 +135,10 @@ export async function releaseWorkItemOnSessionEnd(supabase, workItemKey, reason,
       };
     }
 
-    // ---- SD branch: rewind to the safe phase boundary, guarded ----
+    // ---- SD branch: rewind to the safe phase boundary, guarded, OPT-IN ----
+    if (!rewindPhase) {
+      return { ok: true, kind: 'sd', action: 'sd_no_reset', reason, detail: 'phase rewind not requested (rewindPhase:false) — claim released, phase preserved for resume' };
+    }
     const { data: sd, error: readErr } = await supabase
       .from('strategic_directives_v2')
       .select('sd_key, current_phase, status')

--- a/lib/fleet/release-work-item.mjs
+++ b/lib/fleet/release-work-item.mjs
@@ -1,0 +1,226 @@
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1
+ *
+ * releaseWorkItemOnSessionEnd() — the ONE work-item reset every release path calls,
+ * plus sampleToolActivityTwice(), the ONE two-sample activity primitive.
+ *
+ * WHY THIS EXISTS
+ *   The work-item reset lives today on exactly ONE release path
+ *   (scripts/stale-session-sweep.cjs, the CLAIM_BOUNDARY_PROBE branch). Every other
+ *   release path clears the CLAIM but leaves the work item itself in a state no picker
+ *   can see: a QF stays status='in_progress' with no claimant, so the check-in open-QF
+ *   picker (which selects status='open') cannot reach it, while the coordinator's supply
+ *   gauge still counts it as available. The item reads as owned and is reachable by
+ *   nobody. lib/fleet/spawn-control.js:538 stop() is itself one of these — it marks the
+ *   row released and never touches the work item — which is why a Kill button built
+ *   before this helper would manufacture strands faster than hand-closing windows does.
+ *
+ * THE isSweepResetAllowed DECISION — RESOLVED, and the SD's framing was wrong
+ *   The SD records an unresolved decision: "the reset is gated by isSweepResetAllowed,
+ *   so extracting it forces a choice — carry the guard and every caller inherits sweep
+ *   semantics, or drop it and lose a predicate that exists because it was needed."
+ *   That is a FALSE DILEMMA, because it conflates the two branches. Measured in
+ *   scripts/stale-session-sweep.cjs at the CLAIM_BOUNDARY_PROBE site:
+ *
+ *     - The QF branch (:237-239) is NOT gated by isSweepResetAllowed AT ALL. Its guard
+ *       is the column predicate itself — status='in_progress' AND claiming_session_id IS
+ *       NULL AND pr_url IS NULL AND commit_sha IS NULL. Nothing to carry or drop.
+ *     - The SD branch (:242) calls resetSdPhaseOnRelease, and only THAT is gated.
+ *
+ *   And the guard is not "sweep semantics". lib/exec-context-guard.mjs
+ *   assertSweepHandoffGate answers one question: would resetting this SD to
+ *   targetResetPhase override a handoff that has ALREADY BEEN ACCEPTED past that phase?
+ *   The name says "Sweep" only because the sweep was its first caller. Overriding an
+ *   accepted handoff is wrong for EVERY release path, not just the sweep.
+ *
+ *   RESOLUTION: CARRY the guard on the SD branch — every caller SHOULD inherit it,
+ *   because it protects a real invariant rather than a sweep-local policy. The QF branch
+ *   carries no guard because it never had one; its column predicate IS the guard.
+ *   CONSEQUENCE OF THE LOSING OPTION, recorded as the PRD requires: dropping the guard
+ *   would let any release path silently rewind an SD whose next phase was already
+ *   accepted, reintroducing exactly the override that SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001
+ *   added it to prevent.
+ *
+ * FLAGGING: this module is inert until wired. The per-site conversion (FR-1b) is what
+ *   sits behind LEO_RELEASE_WORKITEM_RESET (default OFF) — see isReleaseWorkItemResetEnabled.
+ */
+
+import { assertSweepHandoffGate } from '../exec-context-guard.mjs';
+
+/** Mid-phase state → the safe boundary it rewinds to. Mirrors the sweep's map. */
+export const PHASE_RESET_MAP = {
+  EXEC: 'PLAN_PRD',
+  EXEC_COMPLETE: 'PLAN_PRD',
+  PLAN_VERIFICATION: 'PLAN_PRD',
+  LEAD_APPROVAL: 'LEAD',
+  LEAD_FINAL_APPROVAL: 'LEAD_FINAL',
+};
+
+/**
+ * FR-1b gate. Default OFF: an unset/absent value must never enable conversion, so the
+ * check is an explicit opt-in equality rather than a truthiness test.
+ */
+export function isReleaseWorkItemResetEnabled(env = process.env) {
+  return env.LEO_RELEASE_WORKITEM_RESET === 'on';
+}
+
+/** A work item is a quick-fix iff its key carries the QF- prefix; everything else is an SD. */
+export function isQuickFixKey(workItemKey) {
+  return typeof workItemKey === 'string' && /^QF-/.test(workItemKey);
+}
+
+/**
+ * Reset ONE work item so a picker can see it again, after its claim has been released.
+ *
+ * Returns a verdict object — never throws. A release path must not abort because a reset
+ * failed; the claim is already gone and the next sweep re-converges.
+ *   { ok, kind, action, reason, detail }
+ *   action: 'qf_reopened' | 'qf_untouched' | 'sd_phase_reset' | 'sd_no_reset' | 'skipped' | 'error'
+ */
+export async function releaseWorkItemOnSessionEnd(supabase, workItemKey, reason, opts = {}) {
+  const { onLog = () => {} } = opts;
+  if (!supabase || !workItemKey) {
+    return { ok: false, kind: null, action: 'skipped', reason, detail: 'missing supabase client or work item key' };
+  }
+
+  try {
+    if (isQuickFixKey(workItemKey)) {
+      // Guarded on EVERY column so an item carrying real work (a PR or a commit) or a
+      // fresh claimant is never reverted. The UPDATE is the guard — it is applied in the
+      // WHERE clause, not read-then-written, so a claimant arriving mid-flight loses the
+      // row from the predicate rather than racing us.
+      const { data, error } = await supabase
+        .from('quick_fixes')
+        .update({ status: 'open' })
+        .eq('id', workItemKey)
+        .filter('status', 'eq', 'in_progress')
+        .is('claiming_session_id', null)
+        .is('pr_url', null)
+        .is('commit_sha', null)
+        .select('id');
+
+      if (error) {
+        return { ok: false, kind: 'qf', action: 'error', reason, detail: error.message };
+      }
+      const reopened = Array.isArray(data) && data.length > 0;
+      if (reopened) onLog(`WORK_ITEM_RESET: ${workItemKey} in_progress → open (${reason})`);
+      return {
+        ok: true,
+        kind: 'qf',
+        action: reopened ? 'qf_reopened' : 'qf_untouched',
+        reason,
+        detail: reopened
+          ? 'no claimant, no pr_url, no commit_sha — returned to the open pool'
+          : 'predicate did not match (already open, or carries a claimant / pr_url / commit_sha)',
+      };
+    }
+
+    // ---- SD branch: rewind to the safe phase boundary, guarded ----
+    const { data: sd, error: readErr } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, current_phase, status')
+      .eq('sd_key', workItemKey)
+      .maybeSingle();
+
+    if (readErr) return { ok: false, kind: 'sd', action: 'error', reason, detail: readErr.message };
+    if (!sd) return { ok: true, kind: 'sd', action: 'sd_no_reset', reason, detail: 'SD not found (vanished or unknown key)' };
+
+    const resetTo = PHASE_RESET_MAP[sd.current_phase];
+    if (!resetTo) {
+      return { ok: true, kind: 'sd', action: 'sd_no_reset', reason, detail: `current_phase '${sd.current_phase}' is already a safe boundary` };
+    }
+
+    // CARRIED GUARD (see the decision above): never rewind past an ACCEPTED handoff.
+    // Fail-soft in both directions — a guard that cannot answer must not authorise the
+    // write, and must not abort the caller either.
+    try {
+      await assertSweepHandoffGate(supabase, workItemKey, resetTo);
+    } catch (err) {
+      const code = (err && err.code) || 'UNKNOWN';
+      onLog(`SKIP_RESET: ${workItemKey} — ${reason} — ${code}: ${err && err.message ? err.message : err}`);
+      return { ok: true, kind: 'sd', action: 'sd_no_reset', reason, detail: `handoff gate blocked the reset (${code})` };
+    }
+
+    const { error: updErr } = await supabase
+      .from('strategic_directives_v2')
+      .update({ current_phase: resetTo })
+      .eq('sd_key', workItemKey);
+
+    if (updErr) return { ok: false, kind: 'sd', action: 'error', reason, detail: updErr.message };
+    onLog(`PHASE_RESET: ${workItemKey} ${sd.current_phase} → ${resetTo} (${reason})`);
+    return { ok: true, kind: 'sd', action: 'sd_phase_reset', reason, detail: `${sd.current_phase} → ${resetTo}` };
+  } catch (err) {
+    return { ok: false, kind: null, action: 'error', reason, detail: (err && err.message) || String(err) };
+  }
+}
+
+/**
+ * Sample claude_sessions.last_tool_at TWICE, intervalMs apart.
+ *
+ * THE SINGLE OWNER of the two-sample pattern, consumed at OPPOSITE POLARITY by two FRs:
+ *   FR-2 (graceful kill) needs ADVANCING — it is the only positive proof of life.
+ *     process.kill(pid, 0) is sound ONLY as a negative: it proves a pid is absent, never
+ *     that the agent behind it is doing anything.
+ *   FR-5 (reaping) needs IDENTICAL across >= 10 minutes as leg B of its DEAD test.
+ * Zero two-sample implementations existed in this repo before this one; without a single
+ * owner the two consumers would each grow their own and drift apart.
+ *
+ * DELIBERATELY NOT USED HERE: heartbeat_at. It keeps ticking on a parked worker whose
+ * agent is idle — four false "fleet down" verdicts are on record from reading it as
+ * activity. last_tool_at moves only when a tool actually ran.
+ *
+ * Returns { ok, advancing, identical, first, second, intervalMs, detail }.
+ * Never throws: a read failure yields ok:false with advancing/identical BOTH false, so a
+ * failed sample can neither authorise a kill (needs advancing) nor authorise a reap
+ * (needs identical). An unreadable sample must not look like an answer.
+ */
+export async function sampleToolActivityTwice(supabase, sessionId, opts = {}) {
+  const { intervalMs = 600_000, sleep = (ms) => new Promise((r) => setTimeout(r, ms)) } = opts;
+
+  const readOnce = async () => {
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('last_tool_at')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    return data ? data.last_tool_at ?? null : null;
+  };
+
+  if (!supabase || !sessionId) {
+    return { ok: false, advancing: false, identical: false, first: null, second: null, intervalMs, detail: 'missing supabase client or session id' };
+  }
+
+  try {
+    const first = await readOnce();
+    await sleep(intervalMs);
+    const second = await readOnce();
+
+    // identical covers the never-ran-a-tool case (null === null): a session that has
+    // never moved is, for FR-5's purposes, not advancing.
+    const identical = first === second;
+    const advancing = !identical && second !== null;
+
+    return {
+      ok: true,
+      advancing,
+      identical,
+      first,
+      second,
+      intervalMs,
+      detail: advancing
+        ? 'last_tool_at advanced between samples — the agent is alive'
+        : 'last_tool_at did not advance between samples',
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      advancing: false,
+      identical: false,
+      first: null,
+      second: null,
+      intervalMs,
+      detail: `sample failed: ${(err && err.message) || err}`,
+    };
+  }
+}

--- a/lib/fleet/release-work-item.test.js
+++ b/lib/fleet/release-work-item.test.js
@@ -134,19 +134,38 @@ describe('FR1-SD: phase rewind, with the accepted-handoff guard CARRIED', () => 
 
   afterEach(() => { vi.doUnmock('../exec-context-guard.mjs'); });
 
-  it('SD-1: rewinds a mid-phase SD to its safe boundary when the gate allows', async () => {
+  it('SD-0: THE REWIND IS OPT-IN — default leaves the phase alone for resume', async () => {
+    // Defaulting this ON would make every future call site silently inherit a policy that
+    // several paths explicitly forbid (coordinator-cold-recovery: "PRESERVES current_phase +
+    // progress (resume, not restart)"), and would do so invisibly — the SD would just come
+    // back a phase earlier. Only the sweep asks for the rewind.
     const release = await loadWithGate(allow);
     const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
     const r = await release(sb, 'SD-X', 'SESSION_END');
+    expect(r.action).toBe('sd_no_reset');
+    expect(r.detail).toMatch(/phase preserved for resume/);
+    expect(sb.updates).toHaveLength(0);
+  });
+
+  it('SD-1: rewinds a mid-phase SD to its safe boundary when ASKED and the gate allows', async () => {
+    const release = await loadWithGate(allow);
+    const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
+    const r = await release(sb, 'SD-X', 'SESSION_END', { rewindPhase: true });
     expect(r.action).toBe('sd_phase_reset');
     expect(sb.updates).toEqual([{ key: 'SD-X', patch: { current_phase: 'PLAN_PRD' } }]);
     expect(PHASE_RESET_MAP.EXEC).toBe('PLAN_PRD');
   });
 
+  it('SD-1b: a QF hand-back is unaffected by rewindPhase — the open pool has no ambiguity', async () => {
+    const sb = qfClient({ matched: true });
+    const r = await releaseWorkItemOnSessionEnd(sb, 'QF-1', 'SESSION_END');
+    expect(r.action).toBe('qf_reopened'); // no rewindPhase passed, still reopens
+  });
+
   it('SD-2: an SD already at a safe boundary is not rewound', async () => {
     const release = await loadWithGate(allow);
     const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'PLAN_PRD', status: 'in_progress' } });
-    const r = await release(sb, 'SD-X', 'SESSION_END');
+    const r = await release(sb, 'SD-X', 'SESSION_END', { rewindPhase: true });
     expect(r.action).toBe('sd_no_reset');
     expect(sb.updates).toHaveLength(0);
   });
@@ -154,7 +173,7 @@ describe('FR1-SD: phase rewind, with the accepted-handoff guard CARRIED', () => 
   it('SD-3: a vanished SD is a no-op, not an error', async () => {
     const release = await loadWithGate(allow);
     const sb = sdClient({ row: null });
-    const r = await release(sb, 'SD-GONE', 'SESSION_END');
+    const r = await release(sb, 'SD-GONE', 'SESSION_END', { rewindPhase: true });
     expect(r.ok).toBe(true);
     expect(r.action).toBe('sd_no_reset');
   });
@@ -165,7 +184,7 @@ describe('FR1-SD: phase rewind, with the accepted-handoff guard CARRIED', () => 
     const release = await loadWithGate(rejectWith('ACCEPTED_HANDOFF_OVERRIDE', 'accepted handoff past PLAN_PRD exists'));
     const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
     const logs = [];
-    const r = await release(sb, 'SD-X', 'SESSION_END', { onLog: (m) => logs.push(m) });
+    const r = await release(sb, 'SD-X', 'SESSION_END', { rewindPhase: true, onLog: (m) => logs.push(m) });
     expect(r.action).toBe('sd_no_reset');
     expect(r.detail).toContain('ACCEPTED_HANDOFF_OVERRIDE');
     expect(sb.updates).toHaveLength(0); // the write never happened
@@ -175,7 +194,7 @@ describe('FR1-SD: phase rewind, with the accepted-handoff guard CARRIED', () => 
   it('SD-5: a guard that cannot answer does NOT authorise the write', async () => {
     const release = await loadWithGate(rejectWith('SCHEMA_ERROR', 'schema exploded'));
     const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
-    const r = await release(sb, 'SD-X', 'SESSION_END');
+    const r = await release(sb, 'SD-X', 'SESSION_END', { rewindPhase: true });
     expect(r.action).toBe('sd_no_reset');
     expect(sb.updates).toHaveLength(0);
   });

--- a/lib/fleet/release-work-item.test.js
+++ b/lib/fleet/release-work-item.test.js
@@ -1,0 +1,232 @@
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1
+// lib/fleet/release-work-item.mjs — the shared work-item reset + the two-sample primitive.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  releaseWorkItemOnSessionEnd,
+  sampleToolActivityTwice,
+  isReleaseWorkItemResetEnabled,
+  isQuickFixKey,
+  PHASE_RESET_MAP,
+} from './release-work-item.mjs';
+
+// ---------------------------------------------------------------------------
+// Supabase test doubles. The QF double RECORDS the predicate the UPDATE applied,
+// so the tests assert the guard is in the WHERE clause rather than trusting a
+// hand-written "matched" flag — the predicate IS the safety property here.
+// ---------------------------------------------------------------------------
+function qfClient({ matched = true, error = null } = {}) {
+  const applied = { eq: {}, filter: {}, is: [] };
+  const chain = {
+    update: vi.fn(() => chain),
+    eq: vi.fn((col, val) => { applied.eq[col] = val; return chain; }),
+    filter: vi.fn((col, _op, val) => { applied.filter[col] = val; return chain; }),
+    is: vi.fn((col, val) => { applied.is.push([col, val]); return chain; }),
+    select: vi.fn(() => Promise.resolve({ data: matched ? [{ id: 'QF-X' }] : [], error })),
+  };
+  return { applied, from: vi.fn(() => chain) };
+}
+
+function sdClient({ row, updateError = null } = {}) {
+  const updates = [];
+  return {
+    updates,
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: row, error: null }) })),
+      })),
+      update: vi.fn((patch) => ({
+        eq: vi.fn((_c, key) => { updates.push({ key, patch }); return Promise.resolve({ error: updateError }); }),
+      })),
+    })),
+  };
+}
+
+function sessionClient(values) {
+  let i = 0;
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => {
+            const v = values[Math.min(i, values.length - 1)];
+            i += 1;
+            if (v instanceof Error) return Promise.resolve({ data: null, error: { message: v.message } });
+            return Promise.resolve({ data: { last_tool_at: v }, error: null });
+          }),
+        })),
+      })),
+    })),
+  };
+}
+
+const noSleep = () => Promise.resolve();
+
+describe('FR1-FLAG: LEO_RELEASE_WORKITEM_RESET is opt-in, never truthy-by-accident', () => {
+  it('is OFF when unset, OFF for any other value, ON only for exactly "on"', () => {
+    expect(isReleaseWorkItemResetEnabled({})).toBe(false);
+    expect(isReleaseWorkItemResetEnabled({ LEO_RELEASE_WORKITEM_RESET: '' })).toBe(false);
+    // 'true'/'1' are truthy strings — a truthiness check would wrongly enable conversion.
+    expect(isReleaseWorkItemResetEnabled({ LEO_RELEASE_WORKITEM_RESET: 'true' })).toBe(false);
+    expect(isReleaseWorkItemResetEnabled({ LEO_RELEASE_WORKITEM_RESET: '1' })).toBe(false);
+    expect(isReleaseWorkItemResetEnabled({ LEO_RELEASE_WORKITEM_RESET: 'on' })).toBe(true);
+  });
+});
+
+describe('FR1-DISPATCH: QF- prefix selects the quick-fix branch', () => {
+  it('classifies keys', () => {
+    expect(isQuickFixKey('QF-20260727-259')).toBe(true);
+    expect(isQuickFixKey('SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001')).toBe(false);
+    expect(isQuickFixKey(null)).toBe(false);
+  });
+});
+
+describe('FR1-QF: a stranded quick-fix is returned to the open pool', () => {
+  it('QF-1: reopens an item with no claimant, no pr_url and no commit_sha', async () => {
+    const sb = qfClient({ matched: true });
+    const r = await releaseWorkItemOnSessionEnd(sb, 'QF-20260726-175', 'SESSION_END');
+    expect(r.ok).toBe(true);
+    expect(r.action).toBe('qf_reopened');
+  });
+
+  it('QF-2: THE GUARD IS IN THE WHERE CLAUSE — all four columns are constrained', async () => {
+    // This is the criterion that matters: the reset must be unable to touch an item
+    // carrying real work, structurally, rather than by a caller remembering to check.
+    const sb = qfClient({ matched: true });
+    await releaseWorkItemOnSessionEnd(sb, 'QF-20260726-175', 'SESSION_END');
+    expect(sb.applied.eq.id).toBe('QF-20260726-175');
+    expect(sb.applied.filter.status).toBe('in_progress');
+    expect(sb.applied.is).toEqual([
+      ['claiming_session_id', null],
+      ['pr_url', null],
+      ['commit_sha', null],
+    ]);
+  });
+
+  it('QF-3: an item carrying real work is left untouched (predicate matches nothing)', async () => {
+    const sb = qfClient({ matched: false });
+    const r = await releaseWorkItemOnSessionEnd(sb, 'QF-20260726-423', 'SESSION_END');
+    expect(r.ok).toBe(true);
+    expect(r.action).toBe('qf_untouched');
+  });
+
+  it('QF-4: a DB error surfaces as a verdict, never as a throw', async () => {
+    const sb = qfClient({ matched: false, error: { message: 'db down' } });
+    const r = await releaseWorkItemOnSessionEnd(sb, 'QF-1', 'SESSION_END');
+    expect(r.ok).toBe(false);
+    expect(r.action).toBe('error');
+    expect(r.detail).toContain('db down');
+  });
+});
+
+describe('FR1-SD: phase rewind, with the accepted-handoff guard CARRIED', () => {
+  // The gate is stubbed EXPLICITLY in every SD test. It is a real collaborator with its
+  // own DB reads, so leaving it live would make these tests assert the stub-fidelity of
+  // a supabase double rather than the rewind logic under test.
+  async function loadWithGate(gateImpl) {
+    vi.resetModules();
+    vi.doMock('../exec-context-guard.mjs', () => ({ assertSweepHandoffGate: vi.fn(gateImpl) }));
+    const mod = await import('./release-work-item.mjs');
+    return mod.releaseWorkItemOnSessionEnd;
+  }
+  const allow = async () => ({ ok: true });
+  const rejectWith = (code, message) => async () => { const e = new Error(message); e.code = code; throw e; };
+
+  afterEach(() => { vi.doUnmock('../exec-context-guard.mjs'); });
+
+  it('SD-1: rewinds a mid-phase SD to its safe boundary when the gate allows', async () => {
+    const release = await loadWithGate(allow);
+    const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
+    const r = await release(sb, 'SD-X', 'SESSION_END');
+    expect(r.action).toBe('sd_phase_reset');
+    expect(sb.updates).toEqual([{ key: 'SD-X', patch: { current_phase: 'PLAN_PRD' } }]);
+    expect(PHASE_RESET_MAP.EXEC).toBe('PLAN_PRD');
+  });
+
+  it('SD-2: an SD already at a safe boundary is not rewound', async () => {
+    const release = await loadWithGate(allow);
+    const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'PLAN_PRD', status: 'in_progress' } });
+    const r = await release(sb, 'SD-X', 'SESSION_END');
+    expect(r.action).toBe('sd_no_reset');
+    expect(sb.updates).toHaveLength(0);
+  });
+
+  it('SD-3: a vanished SD is a no-op, not an error', async () => {
+    const release = await loadWithGate(allow);
+    const sb = sdClient({ row: null });
+    const r = await release(sb, 'SD-GONE', 'SESSION_END');
+    expect(r.ok).toBe(true);
+    expect(r.action).toBe('sd_no_reset');
+  });
+
+  it('SD-4: THE CARRIED GUARD BLOCKS a rewind past an accepted handoff', async () => {
+    // The whole point of carrying assertSweepHandoffGate out of the sweep: an accepted
+    // handoff past the target phase must stop ANY release path, not just the sweep.
+    const release = await loadWithGate(rejectWith('ACCEPTED_HANDOFF_OVERRIDE', 'accepted handoff past PLAN_PRD exists'));
+    const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
+    const logs = [];
+    const r = await release(sb, 'SD-X', 'SESSION_END', { onLog: (m) => logs.push(m) });
+    expect(r.action).toBe('sd_no_reset');
+    expect(r.detail).toContain('ACCEPTED_HANDOFF_OVERRIDE');
+    expect(sb.updates).toHaveLength(0); // the write never happened
+    expect(logs.join('\n')).toContain('SKIP_RESET');
+  });
+
+  it('SD-5: a guard that cannot answer does NOT authorise the write', async () => {
+    const release = await loadWithGate(rejectWith('SCHEMA_ERROR', 'schema exploded'));
+    const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
+    const r = await release(sb, 'SD-X', 'SESSION_END');
+    expect(r.action).toBe('sd_no_reset');
+    expect(sb.updates).toHaveLength(0);
+  });
+});
+
+describe('FR1-SAMPLE: sampleToolActivityTwice — one primitive, two opposite polarities', () => {
+  it('SAMPLE-1: advancing last_tool_at => alive (FR-2 polarity)', async () => {
+    const sb = sessionClient(['2026-07-27T10:00:00Z', '2026-07-27T10:05:00Z']);
+    const r = await sampleToolActivityTwice(sb, 's1', { intervalMs: 10, sleep: noSleep });
+    expect(r.ok).toBe(true);
+    expect(r.advancing).toBe(true);
+    expect(r.identical).toBe(false);
+  });
+
+  it('SAMPLE-2: identical last_tool_at => not advancing (FR-5 leg B polarity)', async () => {
+    const sb = sessionClient(['2026-07-27T10:00:00Z', '2026-07-27T10:00:00Z']);
+    const r = await sampleToolActivityTwice(sb, 's1', { intervalMs: 10, sleep: noSleep });
+    expect(r.identical).toBe(true);
+    expect(r.advancing).toBe(false);
+  });
+
+  it('SAMPLE-3: a session that has NEVER run a tool is not advancing', async () => {
+    const sb = sessionClient([null, null]);
+    const r = await sampleToolActivityTwice(sb, 'ghost', { intervalMs: 10, sleep: noSleep });
+    expect(r.identical).toBe(true);
+    expect(r.advancing).toBe(false);
+  });
+
+  it('SAMPLE-4: A FAILED SAMPLE AUTHORISES NOTHING — neither kill nor reap', async () => {
+    // advancing gates the kill; identical gates the reap. A read failure must set BOTH
+    // false so an unreadable sample can never be mistaken for an answer in either direction.
+    const sb = sessionClient([new Error('db down')]);
+    const r = await sampleToolActivityTwice(sb, 's1', { intervalMs: 10, sleep: noSleep });
+    expect(r.ok).toBe(false);
+    expect(r.advancing).toBe(false);
+    expect(r.identical).toBe(false);
+  });
+
+  it('SAMPLE-5: it really samples TWICE, waiting in between', async () => {
+    const sb = sessionClient(['2026-07-27T10:00:00Z', '2026-07-27T10:05:00Z']);
+    const sleep = vi.fn(() => Promise.resolve());
+    await sampleToolActivityTwice(sb, 's1', { intervalMs: 600_000, sleep });
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(600_000);
+  });
+
+  it('SAMPLE-6: defaults to a 10-minute interval (FR-5 requires >= 10 min)', async () => {
+    const sb = sessionClient(['a', 'a']);
+    const sleep = vi.fn(() => Promise.resolve());
+    const r = await sampleToolActivityTwice(sb, 's1', { sleep });
+    expect(r.intervalMs).toBe(600_000);
+    expect(sleep).toHaveBeenCalledWith(600_000);
+  });
+});

--- a/lib/fleet/spawn-control-stop-workitem.test.js
+++ b/lib/fleet/spawn-control-stop-workitem.test.js
@@ -1,0 +1,124 @@
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 1
+// spawn-control.js stop() — hand the work item back before retiring the session row.
+//
+// stop() was itself a strand manufacturer: it flipped claude_sessions to released and
+// left the work item in_progress with no claimant — invisible to every picker while the
+// coordinator still counted it as available supply.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const RESOLVED = { resolved: true, identity: { callsign: 'Alpha-9', session_id: 'sess-1' } };
+
+let calls;
+
+function mockDeps({ heldKey = 'QF-20260726-175', released = true, resetAction = 'qf_reopened' } = {}) {
+  calls = [];
+  vi.doMock('./session-registry-adapter.js', () => ({
+    resolveLiveSession: vi.fn(async () => RESOLVED),
+    loadLiveSessionIdentity: vi.fn(async () => ({ sessions: [], callsignBySession: {} })),
+  }));
+  vi.doMock('./best-effort-release.mjs', () => ({
+    bestEffortReleaseSd: vi.fn(async (_sb, sessionId, reason, _log, opts) => {
+      calls.push({ step: 'release_claim', sessionId, reason, expectedSdKey: opts && opts.expectedSdKey });
+      return released ? { released: true, error: null } : { released: false, error: 'rpc down' };
+    }),
+  }));
+  vi.doMock('./release-work-item.mjs', () => ({
+    isReleaseWorkItemResetEnabled: vi.fn(() => process.env.LEO_RELEASE_WORKITEM_RESET === 'on'),
+    releaseWorkItemOnSessionEnd: vi.fn(async (_sb, key, reason) => {
+      calls.push({ step: 'reset_work_item', key, reason });
+      return { ok: true, action: resetAction, detail: 'stub' };
+    }),
+  }));
+  return { heldKey };
+}
+
+function supabaseDouble(heldKey) {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: { sd_key: heldKey }, error: null }) })),
+      })),
+      update: vi.fn(() => ({
+        eq: vi.fn(() => { calls.push({ step: 'retire_session' }); return Promise.resolve({ error: null }); }),
+      })),
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    })),
+    rpc: vi.fn().mockResolvedValue({ error: null }),
+  };
+}
+
+async function loadStop() {
+  const mod = await import('./spawn-control.js');
+  return mod.stop;
+}
+
+beforeEach(() => { vi.resetModules(); delete process.env.LEO_RELEASE_WORKITEM_RESET; });
+afterEach(() => { vi.restoreAllMocks(); delete process.env.LEO_RELEASE_WORKITEM_RESET; });
+
+describe('FR1B-1: default OFF keeps the previous behaviour exactly', () => {
+  it('does not touch the work item when the flag is unset', async () => {
+    const { heldKey } = mockDeps();
+    const stop = await loadStop();
+    const res = await stop('Alpha-9', { supabaseClient: supabaseDouble(heldKey) });
+    expect(res.ok).toBe(true);
+    expect(res.workItemReset).toBeUndefined();
+    expect(calls.filter((c) => c.step !== 'retire_session')).toHaveLength(0);
+  });
+});
+
+describe('FR1B-2: THE ORDER — claim released BEFORE the reset, both BEFORE the session is retired', () => {
+  it('sequences release_claim -> reset_work_item -> retire_session', async () => {
+    // This is the whole point of the slice. Reset-before-release would match nothing
+    // (the QF predicate requires claiming_session_id IS NULL) and return qf_untouched
+    // every time — a green no-op. Retiring the session first would erase sd_key, which
+    // is how release_sd resolves WHICH item to hand back.
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    const { heldKey } = mockDeps();
+    const stop = await loadStop();
+    await stop('Alpha-9', { supabaseClient: supabaseDouble(heldKey) });
+    expect(calls.map((c) => c.step)).toEqual(['release_claim', 'reset_work_item', 'retire_session']);
+  });
+
+  it('scopes the claim release to the key the session actually holds (QF-20260726-593)', async () => {
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    const { heldKey } = mockDeps();
+    const stop = await loadStop();
+    await stop('Alpha-9', { supabaseClient: supabaseDouble(heldKey) });
+    const rel = calls.find((c) => c.step === 'release_claim');
+    expect(rel.expectedSdKey).toBe(heldKey);
+    expect(rel.reason).toBe('manual_stop'); // names the mechanism, not 'manual'
+  });
+
+  it('hands back the SAME key it released', async () => {
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    const otherKey = 'SD-SOME-OTHER-001';
+    mockDeps({ heldKey: otherKey });
+    const stop = await loadStop();
+    await stop('Alpha-9', { supabaseClient: supabaseDouble(otherKey) });
+    expect(calls.find((c) => c.step === 'reset_work_item').key).toBe(otherKey);
+  });
+});
+
+describe('FR1B-3: the handback is best-effort — stop() still retires the session', () => {
+  it('a failed claim release does NOT attempt the reset, and does NOT block the retire', async () => {
+    // Resetting after a failed release would be reasoning from an unproven premise:
+    // we do not know the claim is gone, so the predicate cannot be trusted to protect us.
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    const { heldKey } = mockDeps({ released: false });
+    const stop = await loadStop();
+    const res = await stop('Alpha-9', { supabaseClient: supabaseDouble(heldKey) });
+    expect(calls.map((c) => c.step)).toEqual(['release_claim', 'retire_session']);
+    expect(res.ok).toBe(true);
+    expect(res.workItemReset.released).toBe(false);
+  });
+
+  it('a session holding no work item skips the handback cleanly', async () => {
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    mockDeps();
+    const stop = await loadStop();
+    const res = await stop('Alpha-9', { supabaseClient: supabaseDouble(null) });
+    expect(res.workItemReset).toEqual({ attempted: false, reason: 'session_holds_no_work_item' });
+    expect(calls.map((c) => c.step)).toEqual(['retire_session']);
+  });
+});

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -77,6 +77,9 @@ export const SESSION_BIND_DELAY_MS = 500;
 export const CANARY_PROFILE = 'canary';
 export { CANARY_CALLSIGN_PREFIX } from './startup-prompt-selection.js';
 import { isCanaryCallsign as isCanaryNamespaceCallsign } from './startup-prompt-selection.js';
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 1 — see releaseHeldWorkItem below.
+import { bestEffortReleaseSd } from './best-effort-release.mjs';
+import { releaseWorkItemOnSessionEnd, isReleaseWorkItemResetEnabled } from './release-work-item.mjs';
 // FR-4 trigger key: imported, not duplicated. canary-session.js now imports only the pure
 // startup-prompt-selection.js, so spawn-control -> canary-session closes no cycle.
 import { CANARY_TRIGGER_KEY } from './canary-session.js';
@@ -534,6 +537,43 @@ export async function attach(target, opts = {}) {
   return { ok: focused, reason: focused ? null : 'stale_handle', session_id };
 }
 
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 1.
+ *
+ * Hand the session's work item back to the queue before its row is retired.
+ *
+ * ORDER IS LOAD-BEARING, and wiring only half of it would be a fix that does not fix:
+ * releaseWorkItemOnSessionEnd's quick-fix predicate requires claiming_session_id IS NULL,
+ * so calling it while this session still holds the claim matches nothing and returns
+ * qf_untouched every time — green, and useless. The claim must be released FIRST.
+ * Both steps must also run BEFORE the claude_sessions status update below, because
+ * release_sd resolves what to release by reading claude_sessions.sd_key — retire the row
+ * first and there is nothing left to tell us which item this session held.
+ *
+ * Reuses the sequence stale-session-sweep.cjs already proves on its CLAIM_BOUNDARY_PROBE
+ * path (release, then reset, branching QF vs SD) rather than growing a second one.
+ * Best-effort throughout: stop() must still retire the session even if the handback fails.
+ */
+async function releaseHeldWorkItem(supabase, sessionId, reason) {
+  try {
+    const { data: row } = await supabase
+      .from('claude_sessions').select('sd_key').eq('session_id', sessionId).maybeSingle();
+    const heldKey = row && row.sd_key;
+    if (!heldKey) return { attempted: false, reason: 'session_holds_no_work_item' };
+
+    // SD-scoped so a concurrent re-claim cannot make us drop an unrelated item
+    // (QF-20260726-593: release_sd takes no SD argument and releases whatever is held).
+    const rel = await bestEffortReleaseSd(supabase, sessionId, reason, () => {}, { expectedSdKey: heldKey });
+    if (!rel.released) {
+      return { attempted: true, key: heldKey, released: false, detail: rel.skipped || rel.error || 'release_failed' };
+    }
+    const reset = await releaseWorkItemOnSessionEnd(supabase, heldKey, reason);
+    return { attempted: true, key: heldKey, released: true, action: reset.action, detail: reset.detail };
+  } catch (err) {
+    return { attempted: true, released: false, detail: (err && err.message) || String(err) };
+  }
+}
+
 /** Stop a live session without spawning a replacement. */
 export async function stop(target, opts = {}) {
   const supabase = opts.supabaseClient;
@@ -545,12 +585,22 @@ export async function stop(target, opts = {}) {
   }
 
   const { session_id } = resolution.identity;
+
+  // Until this landed, stop() flipped the session row to released and left the work item
+  // in_progress with no claimant — invisible to every picker while still counted as
+  // available supply. stop() was itself a strand manufacturer, which is why a Kill button
+  // built on it before FR-1 would have manufactured strands faster than closing a window.
+  // Default OFF: unset LEO_RELEASE_WORKITEM_RESET keeps the previous behaviour exactly.
+  const workItemReset = isReleaseWorkItemResetEnabled()
+    ? await releaseHeldWorkItem(supabase, session_id, 'manual_stop')
+    : null;
+
   const { error } = await supabase.from('claude_sessions').update({
     status: 'released', released_at: new Date().toISOString(), released_reason: 'manual_stop',
   }).eq('session_id', session_id);
 
   await emitVerbEvent(supabase, { verb: 'stop', session_id, outcome: error ? 'db_error' : 'ok' });
-  return { ok: !error, session_id };
+  return { ok: !error, session_id, ...(workItemReset ? { workItemReset } : {}) };
 }
 
 /**

--- a/scripts/coordinator-cold-recovery.cjs
+++ b/scripts/coordinator-cold-recovery.cjs
@@ -99,6 +99,15 @@ async function alreadyRedispatched(supabase, sdKey, { nowMs }) {
  * otherwise the belt keeps seeing the SD as CLAIMED (SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001).
  * Holder-pinned CAS also prevents clobbering a peer that legitimately took over. */
 async function releaseClaim(supabase, sd) {
+  // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b — EXEMPT from releaseWorkItemOnSessionEnd's
+  // SD phase rewind, recorded because FR-1 requires every release path to either call the shared
+  // helper or carry a written reason it must not.
+  // THE REASON is the docblock above: this path PRESERVES current_phase + progress (resume, not
+  // restart). The helper's rewind would send the SD back to a phase boundary, converting the
+  // resume this function exists to enable into a restart and discarding the progress it protects.
+  // That is exactly why the helper makes rewindPhase OPT-IN (default false) rather than
+  // automatic. If a QF ever reaches this path, wiring the QF-only hand-back would be safe — but
+  // cold recovery operates on strategic_directives_v2 rows, so there is nothing to hand back.
   const { releaseClaimBothSurfaces } = await import('../lib/claim/release-claim-both-surfaces.mjs');
   const r = await releaseClaimBothSurfaces(supabase, {
     sdKey: sd.sd_key,

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -237,8 +237,14 @@ async function runClaimBoundaryProbe(supabase, classified, telemetryMap, now, ac
       // gating it would mean the default-OFF flag SILENTLY DISABLES live fleet protection —
       // a refactor that turns a working guard off is not a refactor.
       const { releaseWorkItemOnSessionEnd } = await import('../lib/fleet/release-work-item.mjs');
+      // rewindPhase:true is REQUIRED here and is not the helper's default. The sweep's
+      // PHASE_RESET_MAP exists precisely so an SD is not left in mid-phase limbo with no active
+      // claimer, so this site must keep rewinding. Other release paths (cold-recovery,
+      // claim-validity-gate) deliberately PRESERVE the phase for resume — which is why the
+      // helper makes the rewind opt-in rather than automatic.
       const handback = await releaseWorkItemOnSessionEnd(
-        supabase, releasedSd, 'CLAIM_BOUNDARY_PROBE', { onLog: (m) => console.log('  ' + m) });
+        supabase, releasedSd, 'CLAIM_BOUNDARY_PROBE',
+        { rewindPhase: true, onLog: (m) => console.log('  ' + m) });
       if (!handback.ok) {
         warnings.push('CLAIM_BOUNDARY_PROBE: work-item handback failed for ' + releasedSd + ' — ' + handback.detail);
       }

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -223,23 +223,24 @@ async function runClaimBoundaryProbe(supabase, classified, telemetryMap, now, ac
         continue;
       }
 
-      // 2a. QF supplement: release_sd clears claiming_session_id but leaves
-      // status='in_progress', which the checkin open-QF picker (status='open')
-      // cannot see — reset it, guarded on every column so a QF with real work
-      // (PR/commit) or a new claimant is never touched.
-      if (/^QF-/.test(releasedSd)) {
-        // The status guard uses the .filter('status','eq',...) spelling (wire-identical
-        // to the .eq form) because stale-session-sweep-claim-safety.test.js anchors its
-        // "phantom in_progress scan" SD-TEST-exclusion window on the FIRST eq-form
-        // status/in_progress match in this file's source — and this quick_fixes UPDATE
-        // (id-scoped; the table has no sd_key column) is outside that guarded
-        // strategic_directives_v2 QA class.
-        await supabase.from('quick_fixes').update({ status: 'open' })
-          .eq('id', releasedSd).filter('status', 'eq', 'in_progress')
-          .is('claiming_session_id', null).is('pr_url', null).is('commit_sha', null);
-      } else {
-        // 2b. SD supplement: phase-boundary reset, parity with the dead-session release loop.
-        try { await resetSdPhaseOnRelease(releasedSd, 'CLAIM_BOUNDARY_PROBE'); } catch { /* best-effort */ }
+      // 2. Work-item supplement. release_sd clears claiming_session_id but leaves a QF at
+      // status='in_progress', which the checkin open-QF picker (status='open') cannot see;
+      // an SD is left mid-phase. Hand the item back so a picker can reach it again.
+      //
+      // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 2: this WAS the only
+      // implementation of that reset in the codebase — the "exactly ONE release path" the SD
+      // names. It now delegates to the shared lib/fleet/release-work-item.mjs helper, which
+      // owns the QF column predicate and the SD phase-boundary rewind for all sixteen sites.
+      //
+      // DELIBERATELY NOT BEHIND LEO_RELEASE_WORKITEM_RESET. That flag gates ADDING the reset
+      // to the fifteen paths that never had it. This site ALREADY HAS the behaviour, so
+      // gating it would mean the default-OFF flag SILENTLY DISABLES live fleet protection —
+      // a refactor that turns a working guard off is not a refactor.
+      const { releaseWorkItemOnSessionEnd } = await import('../lib/fleet/release-work-item.mjs');
+      const handback = await releaseWorkItemOnSessionEnd(
+        supabase, releasedSd, 'CLAIM_BOUNDARY_PROBE', { onLog: (m) => console.log('  ' + m) });
+      if (!handback.ok) {
+        warnings.push('CLAIM_BOUNDARY_PROBE: work-item handback failed for ' + releasedSd + ' — ' + handback.detail);
       }
 
       // 3. Quarantine (QF-193 provenance convention). Read-modify-write on FRESH

--- a/tests/unit/scripts/stale-session-sweep-workitem-handback.test.js
+++ b/tests/unit/scripts/stale-session-sweep-workitem-handback.test.js
@@ -1,0 +1,59 @@
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 2
+ *
+ * stale-session-sweep.cjs CLAIM_BOUNDARY_PROBE now delegates its work-item handback to the
+ * shared lib/fleet/release-work-item.mjs helper. This site WAS the "exactly ONE release path"
+ * the SD names — the only place the reset existed.
+ *
+ * Static source assertions, matching the convention already used by
+ * stale-session-sweep-claim-safety.test.js: the sweep is a large CJS script with a
+ * module-scoped supabase client, so its QA-mutation invariants are pinned against the source
+ * rather than by executing a tick.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SOURCE_PATH = path.resolve(HERE, '../../../scripts/stale-session-sweep.cjs');
+const SOURCE = readFileSync(SOURCE_PATH, 'utf8');
+
+describe('FR-1b slice 2 — the sweep delegates its work-item handback to the shared helper', () => {
+  it('calls releaseWorkItemOnSessionEnd from the shared module', () => {
+    expect(SOURCE).toMatch(/require\(|await import\(\s*['"]\.\.\/lib\/fleet\/release-work-item\.mjs['"]\s*\)/);
+    expect(SOURCE).toMatch(/releaseWorkItemOnSessionEnd\(\s*\n?\s*supabase,\s*releasedSd,\s*['"]CLAIM_BOUNDARY_PROBE['"]/);
+  });
+
+  it('THE DUPLICATE IS GONE — no inline quick_fixes status reset remains in the sweep', () => {
+    // The whole point of FR-1 is one implementation. If an inline
+    // `quick_fixes ... update({status:'open'})` reappears here, two copies of the predicate
+    // exist again and they will drift.
+    const inlineQfReopen = /from\(\s*['"]quick_fixes['"]\s*\)\s*\.update\(\s*\{\s*status:\s*['"]open['"]/;
+    expect(SOURCE).not.toMatch(inlineQfReopen);
+  });
+
+  it('IS NOT GATED BY LEO_RELEASE_WORKITEM_RESET — the flag must never disable live protection', () => {
+    // The flag exists to gate ADDING the reset to the fifteen paths that never had it.
+    // This site already had the behaviour, so gating it would mean the default-OFF flag
+    // silently switches off fleet protection that works today.
+    // Assert the absence of GATING, not the absence of the NAME — the comment above the
+    // call deliberately explains why the flag is not applied here, so a bare string search
+    // would fail on its own rationale.
+    expect(SOURCE).not.toMatch(/isReleaseWorkItemResetEnabled\s*\(/);
+    expect(SOURCE).not.toMatch(/process\.env\.LEO_RELEASE_WORKITEM_RESET/);
+  });
+
+  it('surfaces a handback failure as a sweep warning rather than swallowing it', () => {
+    expect(SOURCE).toMatch(/work-item handback failed/);
+  });
+
+  it('the remaining resetSdPhaseOnRelease call sites are untouched by this slice', () => {
+    // Slice 2 converts ONLY the CLAIM_BOUNDARY_PROBE site. The sweep's other three
+    // phase-reset callers still route through resetSdPhaseOnRelease; converging them is a
+    // later slice, tracked in the FR-1b ledger. Pinned so the count cannot drift silently.
+    const calls = SOURCE.match(/await resetSdPhaseOnRelease\(/g) || [];
+    expect(calls).toHaveLength(3);
+  });
+});

--- a/tests/unit/scripts/stale-session-sweep-workitem-handback.test.js
+++ b/tests/unit/scripts/stale-session-sweep-workitem-handback.test.js
@@ -49,6 +49,15 @@ describe('FR-1b slice 2 — the sweep delegates its work-item handback to the sh
     expect(SOURCE).toMatch(/work-item handback failed/);
   });
 
+  it('OPTS IN to the phase rewind — the helper default preserves the phase for resume', () => {
+    // rewindPhase defaults FALSE because cold-recovery and claim-validity-gate deliberately
+    // preserve current_phase for resume. The sweep is the one site that MUST rewind (its
+    // PHASE_RESET_MAP exists so an SD is not left in mid-phase limbo with no claimer), so it
+    // has to ask explicitly. Drop this option and the sweep silently stops rewinding — in an
+    // UNFLAGGED path, so nothing would switch the behaviour back on.
+    expect(SOURCE).toMatch(/rewindPhase:\s*true/);
+  });
+
   it('the remaining resetSdPhaseOnRelease call sites are untouched by this slice', () => {
     // Slice 2 converts ONLY the CLAIM_BOUNDARY_PROBE site. The sweep's other three
     // phase-reset callers still route through resetSdPhaseOnRelease; converging them is a


### PR DESCRIPTION
## FR-1b slice 4 — SD phase rewind becomes **opt-in**; 1 wired, 3 exempt

**The correction is the point of this slice.**

> Stacked on #6561 → #6560 → #6556 → #6555.

### The SD's framing was wrong, and wrong in a way that fails silently

The SD frames the helper as *"for an SD: `resetSdPhaseOnRelease`"*, which reads as though every release path should rewind `current_phase`. Surveying the actual call sites disproves it:

| Site | Wants the rewind? | Evidence |
|---|---|---|
| `stale-session-sweep.cjs` | **Yes** | `PHASE_RESET_MAP` exists so an SD is not "left in mid-phase limbo with no active claimer" |
| `coordinator-cold-recovery.cjs` | **No — forbids it** | its own docblock: *"PRESERVES current_phase + progress (resume, not restart)"* |
| `claim-validity-gate.js` | **No** | releases a dead owner so the *next* claimer picks the SD up; the fleet resume contract (`worker-checkin` `resume_orphan`: *"reads the SD's live current_phase … NOT a restart"*) means preserving is right |

So the rewind is a per-site **policy**, not a property of releasing.

`rewindPhase` now defaults to **false**. Left on by default, every future call site would silently inherit a behaviour contradicting its own documented intent — and **invisibly**: the SD would just come back one phase earlier, with no error anywhere. Returning a QF to the open pool carries no such ambiguity and is still always applied.

`stale-session-sweep.cjs` now passes `rewindPhase: true` **explicitly**. That site is **unflagged** (slice 2), so flipping the default without updating it would have made the sweep quietly stop rewinding — with no flag to switch it back on. Pinned by a test.

### Wired

`lib/claim-validity-gate.js`, behind `LEO_RELEASE_WORKITEM_RESET` (default OFF). A genuine hand-back — the owner is dead, missing, or verifiably drifted onto another SD. Uses the safe default: claim released, phase preserved.

### Exempt (reasons recorded in the source)

- **`claim-lifecycle-release.mjs`** — fires when a PR opens *while the worker keeps shipping*. The session is alive in its worktree; handing the item back would advertise as available something a live worker is actively finishing.
- **`coordinator-cold-recovery.cjs`** — rewinding converts the resume this function exists to enable into a restart.
- **`cancel-sd.js`** — marks an item terminal (`status='cancelled'`), which is not a hand-back to any pool.

### The pattern is now unmistakable

Three of the first seven sites would have caused harm if wired mechanically:

- **slice 2** — would have disabled live fleet protection;
- **slice 3** — would have manufactured a steal race;
- **slice 4** — would have converted resume into restart.

The sixteen-site list says **where to look**, not **what to do**.

### Tests

3 new (opt-in default, QF unaffected by `rewindPhase`, sweep opts in); existing SD tests updated to request the rewind explicitly. **572 pass / 53 files**, zero failures. The 2 eslint errors in these files (`readdirSync`, `cdErr`) are byte-identical on `origin/main` — pre-existing.

### Ledger — 4 wired, 4 exempt, 8 remaining of 16

- **Wired**: `spawn-control.js stop()`; `stale-session-sweep.cjs` (unflagged, `rewindPhase:true`); `claim-command.js releaseClaim()`; `claim-validity-gate.js`
- **Exempt**: `claim-guard.mjs`; `claim-lifecycle-release.mjs`; `coordinator-cold-recovery.cjs`; `cancel-sd.js`
- **Remaining**: `release-claim-both-surfaces.mjs`, `singleton-refresh-sequencer.cjs`, `drain-orchestrator.mjs`, `qf.js`, `claim-orchestrator-for-rollup.mjs`, `multi-session-claim-gate.js`, `complete-quick-fix/orchestrator.js`, `worker-checkin.cjs` — plus the sweep's 3 internal `resetSdPhaseOnRelease` callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
