### PR TITLE
fix(QF-20260727-934): let a reviewed drain-set absence stop re-alarming, without blinding the signal

### DIFF
--- a/lib/adam/inbound-backlog.js
+++ b/lib/adam/inbound-backlog.js
@@ -85,6 +85,46 @@ export function isExcludedKind(kind) {
   return false;
 }
 
+/**
+ * QF-20260727-934: kinds whose absence from DRAIN_SETS.adam has been REVIEWED and ACCEPTED.
+ *
+ * THE PROBLEM THIS SOLVES: the `undrained_kind_in_lane` signal exists so a drain-set gap
+ * cannot hide silently. But a gap that is PERMANENT AND DELIBERATE re-fires forever — it
+ * alarms every tick, auto-promotes at x3 into a high-severity QF, and consumes a worker seat
+ * that can do nothing about it, because the "gap" is the intended design. Three identical
+ * firings (2026-07-25/26/27) promoted into this QF; the underlying exclusion was correct
+ * every time. An alarm nobody can ever action is how a lane teaches its readers to ignore it.
+ *
+ * WHY NOT JUST ADD THESE TO ADAM_EXCLUDED_KINDS (the one-line option): that set is consumed
+ * by scripts/adam-advisory.cjs, where ADAM_INBOX_KINDS subtracts it from Adam's ACTUAL inbox
+ * (:453), and by lib/coordination/lane-lint-gauge.cjs (:108). The solomon_ledger_* rows are
+ * Adam's disposition queue, not terminal acknowledgements — filing them as "terminal-by-design"
+ * would delete them from the surfaces Adam reads. That is a worse bug than the alarm.
+ *
+ * WHY THIS IS NOT THE "ALLOWLIST INSIDE A DETECTOR" ANTI-PATTERN: this detector's job is to
+ * surface UNKNOWN gaps for triage, not to gate a destructive or safety-critical action. A
+ * reviewed, justified declaration IS the intended resolution for a triage signal. An unlisted
+ * kind still alarms exactly as before, so the signal keeps its whole purpose — it just stops
+ * re-reporting the answers somebody already gave.
+ *
+ * ADDING TO THIS LIST IS A DECISION, NOT A SILENCER. Each entry must say why the kind is
+ * legitimately undrainable in the Adam lane. If a kind SHOULD be drained, put it in
+ * DRAIN_SETS.adam instead — do not park it here.
+ */
+export const ACKNOWLEDGED_UNDRAINABLE_KINDS = Object.freeze([
+  // Continuously replenished by .github/workflows/solomon-ledger-resurface-cron.yml (twice
+  // hourly). Deliberately absent from DRAIN_SETS.adam so age-of-oldest cannot be pinned ON
+  // permanently by a self-refilling queue — the rationale documented at :68-78 above.
+  // Adam still SEES these (they are not in ADAM_EXCLUDED_KINDS); they are simply not part of
+  // the generic drain, and their staleness is owned by lib/coordination/lane-lint-gauge.cjs's
+  // resurface_dedup_drift check rather than by this backlog watchdog.
+  'solomon_ledger_pending_resurface',
+  // The batched digest form of the same producer (scripts/solomon-ledger-pending-resurface.cjs
+  // DIGEST_KIND). Same lane, same owner, same rationale — listed explicitly rather than
+  // prefix-matched so a NEW solomon_ledger_* kind still alarms and gets triaged.
+  'solomon_ledger_pending_digest',
+]);
+
 /** Pure: split excluded rows into the two halves so callers can alarm on them differently. */
 export function partitionUndrained(rows) {
   const undrainedKinds = new Set();
@@ -92,6 +132,8 @@ export function partitionUndrained(rows) {
     const kind = r && r.payload && r.payload.kind;
     if (kind == null || kind === '') continue;
     if (ADAM_EXCLUDED_KINDS.includes(kind)) continue; // terminal-by-design, not a gap
+    // QF-20260727-934: reviewed-and-accepted absence — a decided gap, not an undiscovered one.
+    if (ACKNOWLEDGED_UNDRAINABLE_KINDS.includes(kind)) continue;
     const adamDrainSet = DRAIN_SETS && DRAIN_SETS.adam;
     if (Array.isArray(adamDrainSet) && !adamDrainSet.includes(kind)) undrainedKinds.add(kind);
   }

--- a/tests/unit/adam/inbound-backlog.test.js
+++ b/tests/unit/adam/inbound-backlog.test.js
@@ -111,12 +111,72 @@ describe('TS-15 — excluding undrained kinds must NOT hide a real drain-set gap
   it('surfaces undrained kinds separately from the terminal-by-design ones', () => {
     const rows = [
       row({ payload: { kind: 'cross_party_ping' } }),
-      row({ payload: { kind: 'solomon_ledger_pending_resurface' } })
+      // QF-20260727-934: this assertion previously used solomon_ledger_pending_resurface as its
+      // stand-in for "absent from DRAIN_SETS.adam". That kind is now a REVIEWED-and-ACCEPTED
+      // absence, so an UNDECIDED kind is needed to prove the signal still works. The property
+      // under test is unchanged — only the fixture moved off a now-decided kind.
+      row({ payload: { kind: 'some_brand_new_unreviewed_kind' } })
     ];
     const { undrainedKinds } = partitionUndrained(rows);
-    expect(undrainedKinds).toContain('solomon_ledger_pending_resurface');
+    expect(undrainedKinds).toContain('some_brand_new_unreviewed_kind');
     // cross_party_ping is terminal-by-design, NOT a drain-set gap — must not be reported as one.
     expect(undrainedKinds).not.toContain('cross_party_ping');
+  });
+});
+
+// ── QF-20260727-934: a DECIDED absence must stop re-alarming ────────────────────
+//
+// The undrained_kind_in_lane signal fired identically on 2026-07-25, -26 and -27 and
+// auto-promoted at x3 into a high-severity QF. Every firing was CORRECT — the exclusion is
+// deliberate (a self-refilling cron queue that would pin age-of-oldest ON permanently). An
+// alarm that is always right and never actionable is how a lane trains its readers to ignore
+// it, so a reviewed absence is now declared rather than re-reported.
+describe('QF-20260727-934 — reviewed-and-accepted undrainable kinds stop alarming', () => {
+  it('does NOT report an acknowledged-undrainable kind as a drain-set gap', () => {
+    const { undrainedKinds } = partitionUndrained([
+      row({ payload: { kind: 'solomon_ledger_pending_resurface' } })
+    ]);
+    expect(undrainedKinds).toEqual([]);
+  });
+
+  it('covers the digest form of the same producer', () => {
+    const { undrainedKinds } = partitionUndrained([
+      row({ payload: { kind: 'solomon_ledger_pending_digest' } })
+    ]);
+    expect(undrainedKinds).toEqual([]);
+  });
+
+  it('STILL alarms for an undeclared kind — the signal keeps its whole purpose', () => {
+    const { undrainedKinds } = partitionUndrained([
+      row({ payload: { kind: 'solomon_ledger_pending_resurface' } }),
+      row({ payload: { kind: 'solomon_ledger_pending_something_new' } })
+    ]);
+    // Listed explicitly rather than prefix-matched, so a NEW kind in the same family is
+    // still surfaced for triage instead of being silently absorbed by its neighbours.
+    expect(undrainedKinds).toEqual(['solomon_ledger_pending_something_new']);
+  });
+
+  it('does not change the BREACH computation — these rows were already excluded from the age alarm', () => {
+    // isExcludedKind is deliberately untouched: the reporting changed, the exclusion did not.
+    expect(isExcludedKind('solomon_ledger_pending_resurface')).toBe(true);
+    expect(isExcludedKind('solomon_ledger_pending_digest')).toBe(true);
+    const v = classifyBacklog([
+      row({ id: 'r1', payload: { kind: 'solomon_ledger_pending_resurface' }, created_at: ago(600 * MIN) })
+    ], NOW);
+    expect(v.breaching).toBe(false);
+  });
+
+  it('every declared entry carries a justification comment, and none is smuggled into ADAM_EXCLUDED_KINDS', async () => {
+    const { ACKNOWLEDGED_UNDRAINABLE_KINDS } = await import('../../../lib/adam/inbound-backlog.js');
+    const mod = await import('../../../lib/fleet/worker-status.cjs');
+    const excluded = mod.default?.ADAM_EXCLUDED_KINDS || mod.ADAM_EXCLUDED_KINDS || [];
+    expect(ACKNOWLEDGED_UNDRAINABLE_KINDS.length).toBeGreaterThan(0);
+    for (const k of ACKNOWLEDGED_UNDRAINABLE_KINDS) {
+      // Must NOT be in ADAM_EXCLUDED_KINDS — that set is subtracted from Adam's real inbox
+      // (adam-advisory.cjs ADAM_INBOX_KINDS), so parking them there would hide Adam's own
+      // disposition queue from the surfaces Adam reads.
+      expect(excluded).not.toContain(k);
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

The `undrained_kind_in_lane` signal fired identically on **2026-07-25, -26 and -27** and auto-promoted at x3 into this high-severity QF. **Every firing was correct.** The exclusion is deliberate — `solomon_ledger_pending_resurface` is replenished twice-hourly by cron, so counting it in age-of-oldest would pin the alarm ON permanently (rationale already documented at `lib/adam/inbound-backlog.js:68-78`).

So the defect isn't the exclusion. It's that a **permanent, deliberate gap is indistinguishable from an undiscovered one**, so it re-alarms forever, promotes into QF rows, and consumes a worker seat that can do nothing about it. An alarm that is always right and never actionable is how a lane teaches its readers to ignore it.

**Fix:** declare the reviewed absences. `ACKNOWLEDGED_UNDRAINABLE_KINDS` carries a per-entry justification; `partitionUndrained` skips them. An **undeclared** kind still alarms exactly as before, so the signal keeps its entire purpose — it just stops re-reporting answers somebody already gave. Listed explicitly rather than prefix-matched, so a *new* `solomon_ledger_*` kind is still surfaced for triage.

## Why not the one-line option

Adding these to `ADAM_EXCLUDED_KINDS` would also silence it — `partitionUndrained` already skips that set. But it is subtracted from Adam's **actual inbox** (`adam-advisory.cjs` `ADAM_INBOX_KINDS`, `:453`) and consumed by `lane-lint-gauge.cjs` (`:108`). These rows are Adam's **disposition queue**, not terminal acknowledgements — filing them as terminal-by-design would delete them from the surfaces Adam reads. That's a worse bug than the alarm.

## Not the "allowlist inside a detector" anti-pattern

This detector surfaces **unknown** gaps for triage; it does not gate a destructive or safety-critical action. A reviewed, justified declaration *is* the intended resolution for a triage signal. Contrast QF-20260726-996, where an allowlist would have sat inside a fail-**closed** guard deciding whether spawning is safe — different risk class, opposite conclusion.

## Scope discipline

`isExcludedKind` is **untouched**. These rows were already excluded from the breach computation and still are; only the reporting changed. Asserted directly in a test.

One existing fixture used `solomon_ledger_pending_resurface` as its stand-in for "absent from `DRAIN_SETS.adam`". That kind is now a *decided* absence, so the fixture moved to an undecided kind — the property under test is unchanged.

## Test plan

- [x] Acknowledged kinds no longer reported as a gap (both resurface and digest forms)
- [x] **Still alarms for an undeclared kind** — the signal keeps its purpose
- [x] Breach computation unchanged (`isExcludedKind` still true; `classifyBacklog` still non-breaching)
- [x] Guard: no declared entry is smuggled into `ADAM_EXCLUDED_KINDS`
- [x] 460/460 adam suites, 171/171 coordination suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)