### PR TITLE
feat(SD-PAT-FIX-STUBBED-WRITER-BLINDNESS-001): stubbed-writer blindness — attestation + a narrow lint, not a mutation harness

### DIFF
--- a/.github/workflows/no-mocked-sut-import-lint.yml
+++ b/.github/workflows/no-mocked-sut-import-lint.yml
@@ -1,0 +1,49 @@
+name: Mocked-SUT Import Lint
+
+# SD-PAT-FIX-STUBBED-WRITER-BLINDNESS-001 (FR-3)
+#
+# Surfaces test files that BOTH vi.mock/jest.mock a RELATIVE specifier AND import a binding from
+# that same specifier — the signature of STUBBED-WRITER BLINDNESS
+# (PAT-TEST-STUBBED-WRITER-UNVERIFIED-001): the suite asserts against the stub it installed, so the
+# real module's contract is unverified whatever colour the suite reports.
+#
+# WHY THIS WORKFLOW EXISTS AT ALL, and it is the same reason the sibling class-guard workflows do:
+# this repo's `npm run lint` (the eslint.config.js flat-config run) is not invoked by any other CI
+# workflow, and this rule is deliberately NOT registered there. Without a dedicated workflow the
+# driver would only ever execute inside its own unit test — a detection control that never runs
+# unattended, which for THIS SD would be self-refuting. Caught in security review of PR #6568.
+#
+# NON-BLOCKING BY DESIGN THIS INCREMENT: the driver exits 0 unless BOTH --diff mode and
+# NO_MOCKED_SUT_IMPORT_MODE=block are set, and this job sets neither. 165 pre-existing findings
+# across 2806 test files mean day-one blocking would fail unrelated PRs that merely touch an
+# offending file. The findings are printed to the job log so they are VISIBLE while the backlog is
+# burned down; promote by adding `env: NO_MOCKED_SUT_IMPORT_MODE: block` below.
+
+on:
+  pull_request:
+    paths:
+      - 'tests/**'
+      - 'eslint-rules/no-mocked-sut-import.js'
+      - 'scripts/lint/no-mocked-sut-import-lint.mjs'
+      - '.github/workflows/no-mocked-sut-import-lint.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  no-mocked-sut-import-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so `git merge-base HEAD origin/main` resolves; a shallow clone would make
+          # the driver degrade to an --all sweep and re-surface the whole 165-finding backlog on
+          # every PR instead of just this PR's changed test files.
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - name: Detect tests that mock their own subject (changed files only, warn-only)
+        run: node scripts/lint/no-mocked-sut-import-lint.mjs

--- a/eslint-rules/no-mocked-sut-import.js
+++ b/eslint-rules/no-mocked-sut-import.js
@@ -1,0 +1,155 @@
+/**
+ * ESLint Rule: no-mocked-sut-import
+ *
+ * Flags a test file that BOTH `vi.mock('<relative-spec>', …)`s a module AND imports a binding from
+ * that same specifier. That combination is the signature of STUBBED-WRITER BLINDNESS
+ * (PAT-TEST-STUBBED-WRITER-UNVERIFIED-001): the suite asserts against the stub it installed, so the
+ * real module's contract is UNVERIFIED no matter what colour the suite reports. The canonical
+ * incident was 47 green tests over a production no-op, one of which asserted that the real writer is
+ * never reached.
+ *
+ * SCOPE — RELATIVE SPECIFIERS ONLY, and that limit is the whole reason this rule is usable.
+ * Mocking a package or IO boundary (`@supabase/supabase-js`, `node:fs`, global fetch) is legitimate
+ * isolation and is NOT flagged, even when the test also imports from it. Measured on this repo: 334
+ * of 3082 unit test files mock a local module and sampling showed most are ordinary collaborator
+ * isolation — which is why this ships WARN-ONLY behind its own driver rather than as a blocking gate.
+ *
+ * *** WHAT THIS RULE PROVABLY DOES NOT CATCH — read before trusting it. ***
+ * The canonical witness stubbed its writer by DEPENDENCY INJECTION, not `vi.mock`:
+ *   tests/unit/coordinator/reconcile-late-verdicts.test.js contains ZERO vi.mock calls and passes
+ *   `recordDisposition` in as an option. This rule is structurally blind to that, and
+ *   tests/unit/eslint-rules/no-mocked-sut-import.test.js asserts the non-detection on purpose so the
+ *   limit stays executable rather than drifting into folklore. The DI class is covered by the
+ *   real-callee attestation field, not by this rule. Do not describe this rule as closing the pattern.
+ *
+ * HEURISTIC, STATED PLAINLY: it flags ANY binding imported from a mocked relative specifier, not only
+ * one provably used in an assertion — "used in an assertion" is not decidable from the AST alone.
+ * That is why the escape hatch exists and why the rollout is warn-only.
+ *
+ * Same 3-part class-guard shape as no-raw-session-coordination-insert.js: rule + driver script
+ * (scripts/lint/no-mocked-sut-import-lint.mjs) + dedicated tests. Deliberately NOT registered in
+ * eslint.config.js — every sibling class-guard rule is standalone and enforced only via its driver.
+ *
+ * Escape hatch (REQUIRES a non-empty REASON after the `--` separator):
+ *
+ *   // eslint-disable-next-line no-mocked-sut-import -- <REASON>
+ *   import { thing } from './mocked-module.js';
+ *
+ * @module eslint-rules/no-mocked-sut-import
+ */
+
+const RULE_NAME = 'no-mocked-sut-import';
+
+const PRAGMA_DETECT_RE = new RegExp(
+  String.raw`eslint-disable-next-line\s+(?:[^,\n]*,\s*)*(?:[\w@-]+(?:[/][\w@-]+)*/)?` +
+    RULE_NAME.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+    String.raw`(?:\s*,[^\n]*)?(.*)$`
+);
+
+/** Relative specifiers only — a bare package or node: builtin is a BOUNDARY, never the SUT. */
+function isRelativeSpecifier(value) {
+  return typeof value === 'string' && (value.startsWith('./') || value.startsWith('../'));
+}
+
+/** Is this `vi.mock('<spec>', …)` or `jest.mock('<spec>', …)`? Returns the specifier or null. */
+function mockedSpecifierOf(node) {
+  if (!node || node.type !== 'CallExpression') return null;
+  const callee = node.callee;
+  if (!callee || callee.type !== 'MemberExpression' || callee.computed) return null;
+  if (!callee.object || callee.object.type !== 'Identifier') return null;
+  if (callee.object.name !== 'vi' && callee.object.name !== 'jest') return null;
+  if (!callee.property || callee.property.type !== 'Identifier') return null;
+  if (callee.property.name !== 'mock' && callee.property.name !== 'doMock') return null;
+  const arg = node.arguments && node.arguments[0];
+  if (!arg || arg.type !== 'Literal' || typeof arg.value !== 'string') return null;
+  return arg.value;
+}
+
+function classifyPragma(commentValue) {
+  if (!commentValue) return { targets: false };
+  const match = commentValue.match(PRAGMA_DETECT_RE);
+  if (!match) return { targets: false };
+  const suffix = match[1] || '';
+  const markerIdx = suffix.indexOf('--');
+  if (markerIdx === -1) return { targets: true, hasMarker: false, reason: '' };
+  return { targets: true, hasMarker: true, reason: suffix.slice(markerIdx + 2).trim() };
+}
+
+function hasDisablePragmaAbove(sourceCode, node) {
+  const comments = sourceCode.getCommentsBefore(node);
+  if (!comments || comments.length === 0) return null;
+  const last = comments[comments.length - 1];
+  if (!last || (last.type !== 'Line' && last.type !== 'Block')) return null;
+  if (last.loc && node.loc && last.loc.end.line < node.loc.start.line - 1) return null;
+  const verdict = classifyPragma(last.value);
+  return verdict.targets ? { comment: last, verdict } : null;
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow a test that mocks a relative module and also imports a binding from that same specifier — the suite would be asserting against its own stub',
+      category: 'Best Practices',
+      recommended: true,
+      url: 'https://github.com/rickfelix/EHG_Engineer/blob/main/eslint-rules/no-mocked-sut-import.js',
+    },
+    messages: {
+      mockedSutImport:
+        'This file mocks "{{specifier}}" and also imports {{binding}} from it, so any assertion on {{binding}} is describing the stub, not the real module — its contract stays unverified however green the suite is. ' +
+        'Either drive the real module (mock only the IO boundary beneath it), or override: // eslint-disable-next-line no-mocked-sut-import -- <reason>',
+      pragmaMissingReason:
+        'eslint-disable-next-line no-mocked-sut-import requires a non-empty REASON after `--`. ' +
+        'Example: // eslint-disable-next-line no-mocked-sut-import -- collaborator isolation; the real contract is covered by <named test>',
+    },
+    schema: [],
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode || context.getSourceCode();
+    /** @type {Set<string>} specifiers passed to vi.mock/jest.mock */
+    const mockedSpecs = new Set();
+    /** @type {Array<{node: object, specifier: string, binding: string}>} */
+    const relativeImports = [];
+
+    return {
+      CallExpression(node) {
+        const spec = mockedSpecifierOf(node);
+        // Record every mocked specifier, relative or not; the relative filter is applied to the
+        // IMPORT side so a boundary mock can never pair into a finding.
+        if (spec !== null) mockedSpecs.add(spec);
+      },
+
+      ImportDeclaration(node) {
+        const spec = node.source && node.source.value;
+        if (!isRelativeSpecifier(spec)) return;
+        if (!node.specifiers || node.specifiers.length === 0) return; // side-effect import binds nothing
+        const names = node.specifiers.map((s) => (s.local && s.local.name) || '?');
+        relativeImports.push({ node, specifier: spec, binding: names.join(', ') });
+      },
+
+      'Program:exit'() {
+        for (const entry of relativeImports) {
+          if (!mockedSpecs.has(entry.specifier)) continue;
+
+          const pragma = hasDisablePragmaAbove(sourceCode, entry.node);
+          if (pragma) {
+            // A pragma with no `--` reason is itself the violation — an unexplained suppression on
+            // exactly this class of defect is how a blind suite gets waved through.
+            if (!pragma.verdict.hasMarker || pragma.verdict.reason.length === 0) {
+              context.report({ loc: pragma.comment.loc, messageId: 'pragmaMissingReason' });
+            }
+            continue;
+          }
+
+          context.report({
+            node: entry.node,
+            messageId: 'mockedSutImport',
+            data: { specifier: entry.specifier, binding: entry.binding },
+          });
+        }
+      },
+    };
+  },
+};

--- a/eslint-rules/no-mocked-sut-import.js
+++ b/eslint-rules/no-mocked-sut-import.js
@@ -26,9 +26,21 @@
  * one provably used in an assertion — "used in an assertion" is not decidable from the AST alone.
  * That is why the escape hatch exists and why the rollout is warn-only.
  *
+ * KNOWN BLIND SPOTS beyond the DI case above — real, and listed so nobody assumes wider coverage:
+ *   - DYNAMIC import('./foo.js') is invisible: only static ImportDeclaration nodes are visited.
+ *   - SPECIFIER MISMATCH BY EXTENSION escapes: matching is exact string equality, so
+ *     vi.mock('./foo') paired with import { x } from './foo.js' is missed even though Vitest
+ *     resolves them to the same module. Widening this needs real resolution, not string munging.
+ * Both are untested and unimplemented on purpose — they widen the rule, and widening a heuristic
+ * with a 165-finding backlog is a separate decision from shipping it.
+ *
  * Same 3-part class-guard shape as no-raw-session-coordination-insert.js: rule + driver script
  * (scripts/lint/no-mocked-sut-import-lint.mjs) + dedicated tests. Deliberately NOT registered in
- * eslint.config.js — every sibling class-guard rule is standalone and enforced only via its driver.
+ * eslint.config.js — this repo's `npm run lint` is not invoked by any CI workflow, so registering
+ * it there would enforce nothing. Real enforcement is `npm run lint:mocked-sut-import` and
+ * .github/workflows/no-mocked-sut-import-lint.yml, which runs the driver on every PR touching
+ * tests/. Without that workflow the driver would execute only inside its own unit test — a
+ * detection control that never runs unattended, which for THIS rule would be self-refuting.
  *
  * Escape hatch (REQUIRES a non-empty REASON after the `--` separator):
  *

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "lint:realtime-teardown": "node scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs",
     "lint:count-delta-gate": "node scripts/lint/count-delta-gate-lint.mjs",
     "lint:ismainmodule-classguard": "node scripts/lint/ismainmodule-classguard-lint.mjs",
+    "lint:mocked-sut-import": "node scripts/lint/no-mocked-sut-import-lint.mjs",
     "lint:session-coordination-insert": "node scripts/lint/session-coordination-insert-classguard-lint.mjs",
     "lint:repo-resolution-drift": "node scripts/lint-repo-resolution-drift.mjs",
     "flags:review": "node scripts/flag-governance-review.mjs",

--- a/scripts/lint/no-mocked-sut-import-lint.mjs
+++ b/scripts/lint/no-mocked-sut-import-lint.mjs
@@ -21,7 +21,7 @@
  */
 
 import { Linter } from 'eslint';
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -75,8 +75,12 @@ function candidateFilesAll(root) {
 }
 
 function candidateFilesDiff(root) {
-  const base = execSync('git merge-base HEAD origin/main', { cwd: root, encoding: 'utf8' }).trim();
-  const names = execSync(`git diff --name-only ${base}...HEAD`, { cwd: root, encoding: 'utf8' })
+  // execFileSync, not execSync: neither command needs shell features, so there is no reason to hand
+  // an interpolated string to a shell at all. `base` is git's own SHA output and not attacker-
+  // controlled today, but "safe because of what the output happens to look like" is a weaker
+  // guarantee than "no shell is involved". Matches how this driver's own test invokes it.
+  const base = execFileSync('git', ['merge-base', 'HEAD', 'origin/main'], { cwd: root, encoding: 'utf8' }).trim();
+  const names = execFileSync('git', ['diff', '--name-only', `${base}...HEAD`], { cwd: root, encoding: 'utf8' })
     .split('\n').map((s) => s.trim()).filter(Boolean);
   return names
     .filter((n) => TEST_FILE_RE.test(n) && SCAN_DIRS.some((d) => n.startsWith(`${d}/`)))

--- a/scripts/lint/no-mocked-sut-import-lint.mjs
+++ b/scripts/lint/no-mocked-sut-import-lint.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Driver for eslint-rules/no-mocked-sut-import.js — SD-PAT-FIX-STUBBED-WRITER-BLINDNESS-001 (FR-3).
+ *
+ * Same 3-part class-guard shape as scripts/lint/session-coordination-insert-classguard-lint.mjs,
+ * with one inversion: this rule targets TEST files, so SCAN_DIRS is tests/ rather than scripts+lib.
+ *
+ * *** WARN-ONLY THIS INCREMENT, AND THAT IS A MEASURED DECISION, NOT TIMIDITY. ***
+ * 334 of 3082 unit test files (~10.8%) mock a local module, and sampling showed most are ordinary
+ * collaborator isolation. Blocking on day one would flag hundreds of correct files and the rule
+ * would simply be disabled. Promotion is one env var away once the backlog is burned down:
+ *   NO_MOCKED_SUT_IMPORT_MODE=block
+ * Default is OFF, matching ACCEPTANCE_TIER_DOWNGRADE_GATE_BINDING / INVOCATION_PATH_PROOF_MODE.
+ *
+ * Modes: --diff (default, changed files only) | --all (full sweep) | --json.
+ *
+ * Usage:
+ *   node scripts/lint/no-mocked-sut-import-lint.mjs           # changed test files
+ *   node scripts/lint/no-mocked-sut-import-lint.mjs --all     # full sweep (baseline count)
+ *   node scripts/lint/no-mocked-sut-import-lint.mjs --all --json
+ */
+
+import { Linter } from 'eslint';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import rule from '../../eslint-rules/no-mocked-sut-import.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+const SCAN_DIRS = ['tests'];
+const EXCLUDE_DIR_SEGMENTS = ['node_modules', '.git', '.worktrees', 'dist', 'build', 'coverage', 'archived'];
+const TEST_FILE_RE = /\.(test|spec)\.[cm]?js$/i;
+
+const RULE_ID = 'mocked-sut-import/no-mocked-sut-import';
+
+const FLAT_CONFIG = {
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    globals: {
+      console: 'readonly', process: 'readonly', require: 'readonly', module: 'readonly',
+      exports: 'readonly', __dirname: 'readonly', __filename: 'readonly', Buffer: 'readonly',
+      setTimeout: 'readonly', setInterval: 'readonly', clearTimeout: 'readonly', clearInterval: 'readonly',
+      vi: 'readonly', jest: 'readonly', describe: 'readonly', it: 'readonly', expect: 'readonly',
+      beforeEach: 'readonly', afterEach: 'readonly', beforeAll: 'readonly', afterAll: 'readonly',
+    },
+  },
+  plugins: { 'mocked-sut-import': { rules: { 'no-mocked-sut-import': rule } } },
+  rules: { [RULE_ID]: 'error' },
+};
+
+function walk(dir, out) {
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    if (EXCLUDE_DIR_SEGMENTS.includes(e.name)) continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) walk(full, out);
+    else if (TEST_FILE_RE.test(e.name)) out.push(full);
+  }
+  return out;
+}
+
+function candidateFilesAll(root) {
+  const out = [];
+  for (const d of SCAN_DIRS) walk(path.join(root, d), out);
+  return out;
+}
+
+function candidateFilesDiff(root) {
+  const base = execSync('git merge-base HEAD origin/main', { cwd: root, encoding: 'utf8' }).trim();
+  const names = execSync(`git diff --name-only ${base}...HEAD`, { cwd: root, encoding: 'utf8' })
+    .split('\n').map((s) => s.trim()).filter(Boolean);
+  return names
+    .filter((n) => TEST_FILE_RE.test(n) && SCAN_DIRS.some((d) => n.startsWith(`${d}/`)))
+    .map((n) => path.join(root, n))
+    .filter((p) => fs.existsSync(p));
+}
+
+function lintFile(linter, filePath) {
+  let code;
+  try {
+    code = fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return [];
+  }
+  const rel = path.relative(REPO_ROOT, filePath).replace(/\\/g, '/');
+  let messages;
+  try {
+    messages = linter.verify(code, FLAT_CONFIG, { filename: filePath });
+  } catch (e) {
+    // A file this parser cannot read is NOT a violation — say so rather than silently dropping it,
+    // because a silent drop is indistinguishable from a clean file.
+    console.warn(`⚠️  skipped (parse): ${rel} — ${String(e.message).split('\n')[0]}`);
+    return [];
+  }
+  return messages
+    .filter((m) => m.ruleId === RULE_ID)
+    .map((m) => ({ filePath: rel, line: m.line, column: m.column, message: m.message }));
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const jsonMode = argv.includes('--json');
+  const wantAll = argv.includes('--all');
+  const scanRoot = REPO_ROOT;
+
+  let mode = 'diff';
+  let scanned;
+  if (wantAll) {
+    mode = 'all';
+    scanned = candidateFilesAll(scanRoot);
+  } else {
+    try {
+      scanned = candidateFilesDiff(scanRoot);
+    } catch (e) {
+      console.warn(`⚠️  diff base unavailable (${String(e.message).split('\n')[0]}) — falling back to --all (advisory)`);
+      mode = 'all (degraded)';
+      scanned = candidateFilesAll(scanRoot);
+    }
+  }
+
+  const linter = new Linter({ cwd: scanRoot });
+  const violations = scanned.flatMap((f) => lintFile(linter, f));
+
+  // Promotion gate: blocking requires BOTH true diff mode AND an explicit opt-in. Default is
+  // warn-only, so this can never fail a merge in this increment.
+  const promoted = process.env.NO_MOCKED_SUT_IMPORT_MODE === 'block';
+  const blocking = mode === 'diff' && promoted;
+
+  if (jsonMode) {
+    console.log(JSON.stringify({ mode, scanned: scanned.length, violations, blocking, promoted }, null, 2));
+  } else if (violations.length === 0) {
+    console.log(`✅ no-mocked-sut-import-lint (${mode}): 0 findings across ${scanned.length} test file(s)`);
+  } else if (!blocking) {
+    console.warn(`⚠️  no-mocked-sut-import-lint (${mode}, WARN-ONLY): ${violations.length} finding(s) across ${scanned.length} test file(s) — not blocking\n`);
+    for (const v of violations) console.warn(`  ${v.filePath}:${v.line}:${v.column}  ${v.message}`);
+    console.warn('\nA suite that mocks its own subject is describing the stub. Drive the real module and mock only the IO boundary beneath it,');
+    console.warn('or suppress with a reason: // eslint-disable-next-line no-mocked-sut-import -- <why the real contract is covered elsewhere>');
+  } else {
+    console.error(`❌ no-mocked-sut-import-lint (${mode}): ${violations.length} finding(s) across ${scanned.length} test file(s)\n`);
+    for (const v of violations) console.error(`  ${v.filePath}:${v.line}:${v.column}  ${v.message}`);
+  }
+
+  process.exit(violations.length > 0 && blocking ? 1 : 0);
+}
+
+main();

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/index.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/index.js
@@ -38,6 +38,12 @@ export { createCrossChildIntegrationGate } from './cross-child-integration-gate.
 // Wiring Validation (SD-LEO-WIRING-VERIFICATION-FRAMEWORK-ORCH-001-D)
 export { createWiringValidationGate } from './wiring-validation.js';
 
+// Real-callee attestation (SD-PAT-FIX-STUBBED-WRITER-BLINDNESS-001 / FR-1)
+// Presence-only check that the author named the test driving each REAL callee, or
+// declared it UNTESTED. The one control covering DEPENDENCY-INJECTION stubbing, which
+// eslint-rules/no-mocked-sut-import.js is structurally blind to.
+export { createRealCalleeAttestationGate, classifyAttestation } from './real-callee-attestation.js';
+
 // Advisory wire-reachability check (SD-FDBK-ENH-WIRE-CHECK-GATE-002)
 // Non-blocking early twin of the LEAD-FINAL WIRE_CHECK_GATE — surfaces unwired
 // new CLIs at EXEC-TO-PLAN so they are fixed before the blocking final gate.

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/real-callee-attestation.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/real-callee-attestation.js
@@ -1,0 +1,124 @@
+/**
+ * REAL_CALLEE_ATTESTATION — SD-PAT-FIX-STUBBED-WRITER-BLINDNESS-001 (FR-1).
+ *
+ * Asks the author to name, for each changed call into a foreign module, the test that exercises the
+ * REAL callee — or to say plainly that the integration is UNTESTED. It is the only control in this SD
+ * that touches the mechanism behind the canonical incident: that suite stubbed its writer by
+ * DEPENDENCY INJECTION, not vi.mock, so eslint-rules/no-mocked-sut-import.js is structurally blind to
+ * it. A lint can see a mock; only the author can see an injected fake.
+ *
+ * *** PRESENCE, NEVER CONTENT. ***
+ * The literal value "none" PASSES. That is deliberate and is the whole reason this gate is
+ * acceptable: a gate that judged attestation quality would be guessing, would be argued with, and
+ * would get bypassed. Its entire job is to force the question to be ANSWERED at the moment the author
+ * still has the context, and to make "untested" a thing someone had to type rather than a silence.
+ *
+ * SELF-AWARE NOTE ON THIS GATE'S OWN FAILURE MODE, given what this SD is about: a presence-check
+ * implemented as `return true` would pass every "present" case identically to a correct one. So the
+ * missing-field case returns passed:false with a distinct reason code, and
+ * tests/unit/gates/real-callee-attestation.test.js asserts THAT RETURN VALUE — not merely that a run
+ * completed. A gate whose absence-branch is never asserted is exactly the blindness being fixed.
+ *
+ * NON-BLOCKING THIS INCREMENT (`required: false`), matching FR-3's warn-only rollout. It surfaces and
+ * scores; it does not fail a handoff. Promote by flipping `required` once the fleet is used to it.
+ *
+ * @module scripts/modules/handoff/executors/exec-to-plan/gates/real-callee-attestation
+ */
+
+const FIELD = 'real_callee_attestation';
+
+/**
+ * Pure: classify an attestation value. Exported for direct unit testing — the classification, not the
+ * DB plumbing, is where the contract lives.
+ *
+ * @param {unknown} value
+ * @returns {{ present: boolean, declaredNone: boolean, entries: number, reason: string }}
+ */
+export function classifyAttestation(value) {
+  if (value === null || value === undefined) {
+    return { present: false, declaredNone: false, entries: 0, reason: 'ATTESTATION_MISSING' };
+  }
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) {
+      // An empty string is an absent answer wearing the shape of one.
+      return { present: false, declaredNone: false, entries: 0, reason: 'ATTESTATION_EMPTY' };
+    }
+    const declaredNone = trimmed.toLowerCase() === 'none';
+    return { present: true, declaredNone, entries: declaredNone ? 0 : 1, reason: 'ATTESTATION_PRESENT' };
+  }
+  if (Array.isArray(value)) {
+    const nonEmpty = value.filter((v) => typeof v === 'string' ? v.trim().length > 0 : v != null);
+    if (nonEmpty.length === 0) {
+      return { present: false, declaredNone: false, entries: 0, reason: 'ATTESTATION_EMPTY' };
+    }
+    return { present: true, declaredNone: false, entries: nonEmpty.length, reason: 'ATTESTATION_PRESENT' };
+  }
+  if (typeof value === 'object') {
+    const keys = Object.keys(value);
+    if (keys.length === 0) {
+      return { present: false, declaredNone: false, entries: 0, reason: 'ATTESTATION_EMPTY' };
+    }
+    return { present: true, declaredNone: false, entries: keys.length, reason: 'ATTESTATION_PRESENT' };
+  }
+  return { present: false, declaredNone: false, entries: 0, reason: 'ATTESTATION_MISSING' };
+}
+
+/**
+ * @param {Object} supabase - unused; kept for signature parity with sibling gate factories
+ * @returns {Object} gate configuration
+ */
+export function createRealCalleeAttestationGate(/* supabase */) {
+  return {
+    name: 'REAL_CALLEE_ATTESTATION',
+    validator: async (ctx) => {
+      console.log('\n🧪 REAL_CALLEE_ATTESTATION: which test drives the REAL callee?');
+      console.log('-'.repeat(50));
+
+      const sd = ctx?.sd || {};
+      const value = sd?.metadata?.[FIELD];
+      const verdict = classifyAttestation(value);
+
+      if (!verdict.present) {
+        console.log(`   ⚠️  ${verdict.reason}: strategic_directives_v2.metadata.${FIELD} is not set.`);
+        console.log('   For each changed call into a foreign module, name the test that exercises the REAL');
+        console.log('   callee — or set the field to "none" to declare the integration UNTESTED on purpose.');
+        console.log('   A stub-heavy suite is green whether or not the real contract holds; this is the');
+        console.log('   only place that distinction gets written down.');
+        return {
+          passed: false,
+          score: 0,
+          max_score: 100,
+          issues: [`[${verdict.reason}] metadata.${FIELD} is absent — name the test that drives each real callee, or set it to "none".`],
+          warnings: [],
+          remediation: `Set strategic_directives_v2.metadata.${FIELD} — a string, array or object. The literal "none" is a valid answer.`,
+          details: { field: FIELD, reason: verdict.reason, entries: 0, blocking: false },
+        };
+      }
+
+      if (verdict.declaredNone) {
+        console.log(`   ✅ ${FIELD} = "none" — integrations explicitly declared UNTESTED. Recorded, not judged.`);
+        return {
+          passed: true,
+          score: 100,
+          max_score: 100,
+          issues: [],
+          warnings: [`${FIELD} declared "none": real-callee integrations are attested as UNTESTED for this SD.`],
+          details: { field: FIELD, reason: verdict.reason, entries: 0, declared_none: true },
+        };
+      }
+
+      console.log(`   ✅ ${FIELD} present (${verdict.entries} entr${verdict.entries === 1 ? 'y' : 'ies'}) — presence checked, content deliberately not judged.`);
+      return {
+        passed: true,
+        score: 100,
+        max_score: 100,
+        issues: [],
+        warnings: [],
+        details: { field: FIELD, reason: verdict.reason, entries: verdict.entries, declared_none: false },
+      };
+    },
+    // Non-blocking this increment — see the module docstring. Flip to true to promote.
+    required: false,
+  };
+}

--- a/scripts/modules/handoff/executors/exec-to-plan/index.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/index.js
@@ -37,6 +37,7 @@ import {
   createWiringValidationGate,
   // Advisory wire-reachability check (SD-FDBK-ENH-WIRE-CHECK-GATE-002)
   createWireCheckAdvisoryGate,
+  createRealCalleeAttestationGate,
   // Consumer Impact advisory (SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001)
   createConsumerImpactGate,
   // UI Interactivity Check (SD-MAN-INFRA-LEO-GATE-IMPROVEMENTS-001)
@@ -357,6 +358,15 @@ export class ExecToPlanExecutor extends BaseExecutor {
     // wiring it sees the gap here (and can fix it in the same PR) instead of being
     // blocked at the FINAL handoff and forced to open a 2nd PR.
     gates.push(createWireCheckAdvisoryGate(this.supabase));
+
+    // Real-callee attestation (SD-PAT-FIX-STUBBED-WRITER-BLINDNESS-001 / FR-1)
+    // Non-blocking (required:false): asks the author to name the test that drives each REAL
+    // callee, or to declare the integration UNTESTED. PRESENCE only — the literal "none" is a
+    // valid answer, because a gate that graded the answer would be guessing and would get
+    // bypassed. Its job is to make "untested" something someone had to type rather than a
+    // silence. This is the only control here that reaches DEPENDENCY-INJECTION stubbing, which
+    // a mock-detecting lint cannot see.
+    gates.push(createRealCalleeAttestationGate(this.supabase));
 
     // Consumer Impact advisory (SD-LEO-INFRA-FIRST-PARTY-CODEBASE-STRUCTURAL-ANALYSIS-001)
     // Non-blocking (required:false): blast-radius of modified/removed exported

--- a/scripts/modules/handoff/executors/exec-to-plan/index.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/index.js
@@ -518,10 +518,23 @@ export class ExecToPlanExecutor extends BaseExecutor {
       console.log('\n📊 Step 1.5: AnalysisStep — EXEC Phase Intelligence Synthesis');
       console.log('-'.repeat(50));
 
-      // Fetch PLAN-TO-EXEC handoff for this SD
-      const { data: planHandoff } = await this.supabase
+      // Fetch PLAN-TO-EXEC handoff for this SD.
+      //
+      // SD-PAT-FIX-STUBBED-WRITER-BLINDNESS-001: this select named TWO columns that do not exist on
+      // sd_phase_handoffs — `score` (the real column is validation_score) and `output_artifact`.
+      // PostgREST rejects the whole query on an unknown column, so `data` was ALWAYS null; the
+      // destructure discarded `error`; and the guard below then reported "No PLAN-TO-EXEC handoff
+      // found" and returned null. _synthesizeExecAnalysis was therefore a permanent no-op for EVERY
+      // SD since the phantom names were introduced, while logging a benign, plausible reason.
+      //
+      // That is this SD's own pattern one level up: a swallowed error is indistinguishable from a
+      // genuine absence. The fix is both halves — correct the column names AND stop discarding the
+      // error, so a future schema change fails loudly instead of silently disabling the feature.
+      // Verified against the live DB: the corrected select returns a real row (validation_score=97
+      // on this SD's own PLAN-TO-EXEC handoff), so the data was always there.
+      const { data: planHandoff, error: planHandoffError } = await this.supabase
         .from('sd_phase_handoffs')
-        .select('score, validation_details, output_artifact, created_at')
+        .select('validation_score, validation_details, created_at')
         .eq('sd_id', sd.id)
         .eq('handoff_type', 'PLAN-TO-EXEC')
         .eq('status', 'accepted')
@@ -529,12 +542,19 @@ export class ExecToPlanExecutor extends BaseExecutor {
         .limit(1)
         .single();
 
+      // PGRST116 is "no rows" from .single() — a genuine absence, and the expected quiet path.
+      // Anything else is a real fault and must NOT masquerade as "nothing to analyse".
+      if (planHandoffError && planHandoffError.code !== 'PGRST116') {
+        console.log(`   ⚠️  PLAN-TO-EXEC handoff query FAILED (${planHandoffError.message}) — analysisStep skipped. This is a fault, not an absence.`);
+        return null;
+      }
+
       if (!planHandoff) {
         console.log('   ℹ️  No PLAN-TO-EXEC handoff found — skipping analysisStep');
         return null;
       }
 
-      const planScore = planHandoff.score;
+      const planScore = planHandoff.validation_score;
       const validationDetails = planHandoff.validation_details || {};
 
       const analysisStep = {

--- a/tests/unit/eslint-rules/no-mocked-sut-import-driver.test.js
+++ b/tests/unit/eslint-rules/no-mocked-sut-import-driver.test.js
@@ -1,0 +1,54 @@
+/**
+ * SD-PAT-FIX-STUBBED-WRITER-BLINDNESS-001 (FR-3 / TS-7) — driver contract.
+ *
+ * Asserts BOTH halves, because either alone is uninformative:
+ *   - exit code 0 (warn-only this increment, so it can never fail a merge), and
+ *   - findings > 0 on a full sweep.
+ * The second is the load-bearing one. A driver that is mis-wired — wrong glob, rule not registered,
+ * plugin id mismatch — also exits 0 with zero findings, which reads as "the repo is clean". Against a
+ * repo measured at 334/3082 files mocking a local module, a suspiciously clean sweep is evidence of a
+ * broken driver, not a healthy codebase. Asserting only the exit code would be exactly the
+ * cannot-fail shape this SD exists to eliminate.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const DRIVER = path.join(REPO_ROOT, 'scripts', 'lint', 'no-mocked-sut-import-lint.mjs');
+
+function runDriver(args) {
+  const stdout = execFileSync(process.execPath, [DRIVER, ...args], {
+    cwd: REPO_ROOT, encoding: 'utf8', maxBuffer: 32 * 1024 * 1024,
+  });
+  return JSON.parse(stdout.slice(stdout.indexOf('{')));
+}
+
+describe('no-mocked-sut-import driver (FR-3)', () => {
+  it('a full sweep exits 0 AND reports a non-zero baseline — both halves matter', () => {
+    // execFileSync throws on a non-zero exit, so reaching the assertions IS the exit-0 proof.
+    const result = runDriver(['--all', '--json']);
+
+    expect(result.mode).toBe('all');
+    expect(result.scanned).toBeGreaterThan(1000); // the sweep actually walked the tests tree
+    expect(result.violations.length).toBeGreaterThan(0); // the rule is wired and capable of firing
+    expect(result.blocking).toBe(false); // warn-only this increment
+    expect(result.promoted).toBe(false); // promotion flag defaults OFF
+  });
+
+  it('the known-positive fixture appears in the sweep', () => {
+    // Ties the repo-wide run back to the specific file the PRD names, so a driver that scans the
+    // wrong tree cannot pass merely by finding *something* somewhere.
+    const result = runDriver(['--all', '--json']);
+    const hit = result.violations.find((v) => v.filePath === 'tests/unit/value-authenticity/panel-assembly.test.js');
+    expect(hit, 'the PRD-named known-positive must be among the sweep findings').toBeTruthy();
+  });
+
+  it('the canonical witness does NOT appear — the documented DI blind spot, asserted at driver level too', () => {
+    const result = runDriver(['--all', '--json']);
+    const hit = result.violations.find((v) => v.filePath === 'tests/unit/coordinator/reconcile-late-verdicts.test.js');
+    expect(hit, 'reconcile-late-verdicts stubs by dependency injection; this rule is blind to it by design').toBeFalsy();
+  });
+});

--- a/tests/unit/eslint-rules/no-mocked-sut-import.test.js
+++ b/tests/unit/eslint-rules/no-mocked-sut-import.test.js
@@ -1,0 +1,156 @@
+/**
+ * SD-PAT-FIX-STUBBED-WRITER-BLINDNESS-001 — tests for eslint-rules/no-mocked-sut-import.js.
+ *
+ * STRUCTURAL REQUIREMENT, NOT A STYLE CHOICE: the can-fire proof (TS-1, TS-8) and the
+ * must-not-fire proofs (TS-2, TS-3, TS-4) live in ONE RuleTester.run() call. Split apart, a
+ * "no findings here" assertion is indistinguishable from a rule that never fires at all — every
+ * negative control would pass against `create() { return {}; }`. For an SD whose whole subject is
+ * suites that cannot fail, shipping that shape would be self-refuting. Co-locating them means the
+ * same run that proves silence also proves capability.
+ *
+ * The two REAL fixtures are read off disk rather than hand-copied, so they cannot drift from the
+ * files the PRD names.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { RuleTester, Linter } from 'eslint';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import rule from '../../../eslint-rules/no-mocked-sut-import.js';
+
+RuleTester.describe = describe;
+RuleTester.it = it;
+RuleTester.itOnly = it.only;
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const readFixture = (rel) => fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+
+/** TS-1 — the real known-positive named by the PRD. */
+const KNOWN_POSITIVE = 'tests/unit/value-authenticity/panel-assembly.test.js';
+/** TS-4 — the canonical witness. Stubs by DI, contains zero vi.mock; the rule is blind to it BY DESIGN. */
+const CANONICAL_WITNESS = 'tests/unit/coordinator/reconcile-late-verdicts.test.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+});
+
+ruleTester.run('no-mocked-sut-import', rule, {
+  valid: [
+    {
+      name: 'TS-2 negative control: a BARE-PACKAGE boundary mock, imported from the identical specifier',
+      // Structurally identical to the positive except the specifier is a package rather than
+      // relative — so this exercises the actual relative-vs-bare discriminator rather than merely
+      // being a case where no mock/import pairing exists at all.
+      code: [
+        "import { createClient } from '@supabase/supabase-js';",
+        "vi.mock('@supabase/supabase-js');",
+        'export const c = createClient;',
+      ].join('\n'),
+    },
+    {
+      name: 'TS-3 negative control: a relative module is mocked but NOTHING is imported from it',
+      code: [
+        "vi.mock('../../../lib/governance/emit-feedback.js', () => ({ emitFeedback: (...a) => hoisted(...a) }));",
+        'export const x = 1;',
+      ].join('\n'),
+    },
+    {
+      name: 'TS-4 residual gap, ASSERTED not assumed: the canonical witness stubs by DEPENDENCY INJECTION, so the rule is blind to it',
+      // This is the pattern's own headline incident. The rule provably does not catch it, and that
+      // limit is pinned here so nobody later describes this rule as closing the pattern. It passes
+      // in the SAME run as TS-1/TS-8, which is what stops it meaning "the rule never fires".
+      code: readFixture(CANONICAL_WITNESS),
+    },
+    {
+      name: 'TS-5a escape hatch WITH a reason is honoured',
+      // RuleTester registers the rule under the `rule-to-test/` plugin prefix, so an unprefixed
+      // pragma makes ESLint itself emit "Definition for rule ... was not found". The rule's
+      // PRAGMA_DETECT_RE accepts an optional plugin prefix, which is what makes this work in both
+      // the RuleTester harness and real files where the driver registers it as `local/`.
+      code: [
+        "vi.mock('./writer.js', () => ({ write: () => {} }));",
+        '// eslint-disable-next-line rule-to-test/no-mocked-sut-import -- collaborator isolation; real contract covered by writer-contract.test.js',
+        "import { write } from './writer.js';",
+        'export const w = write;',
+      ].join('\n'),
+    },
+    {
+      name: 'a side-effect-only import from a mocked relative module binds nothing and is not a finding',
+      code: [
+        "vi.mock('./side-effect.js', () => ({}));",
+        "import './side-effect.js';",
+        'export const y = 1;',
+      ].join('\n'),
+    },
+  ],
+
+  invalid: [
+    {
+      name: 'TS-1 known-positive: the REAL panel-assembly suite mocks disposition.js and imports recordDisposition from it',
+      code: readFixture(KNOWN_POSITIVE),
+      errors: [{ messageId: 'mockedSutImport' }],
+    },
+    {
+      name: 'TS-8 synthetic positive: same general shape, a DIFFERENT path — defeats a rule that hardcodes the fixture path',
+      // With only the real fixture as a positive, a rule that special-cased that one path string
+      // would pass every test here. This is the assertion that forces a general AST check.
+      code: [
+        "vi.mock('./foo.js', () => ({ bar: () => {} }));",
+        "import { bar } from './foo.js';",
+        'export const b = bar;',
+      ].join('\n'),
+      errors: [{ messageId: 'mockedSutImport' }],
+    },
+    {
+      name: 'TS-5b escape hatch with NO reason is itself reported — an unexplained suppression on this class is how a blind suite gets waved through',
+      code: [
+        "vi.mock('./writer.js', () => ({ write: () => {} }));",
+        '// eslint-disable-next-line rule-to-test/no-mocked-sut-import',
+        "import { write } from './writer.js';",
+        'export const w = write;',
+      ].join('\n'),
+      errors: [{ messageId: 'pragmaMissingReason' }],
+    },
+    {
+      name: 'jest.mock is treated the same as vi.mock',
+      code: [
+        "jest.mock('./legacy.js', () => ({ doThing: () => {} }));",
+        "import { doThing } from './legacy.js';",
+        'export const d = doThing;',
+      ].join('\n'),
+      errors: [{ messageId: 'mockedSutImport' }],
+    },
+  ],
+});
+
+/**
+ * GUT CHECK (test-of-the-test). Everything above is a RuleTester contract; this asserts the property
+ * that makes the negative controls meaningful in the first place — that a no-op rule would FAIL the
+ * positive cases. Without it, "the negatives pass" carries no information.
+ */
+describe('no-mocked-sut-import — the suite cannot pass against a gutted rule', () => {
+  const CONFIG = (r) => ({
+    files: ['**/*.js'],
+    languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+    plugins: { local: { rules: { 'no-mocked-sut-import': r } } },
+    rules: { 'local/no-mocked-sut-import': 'error' },
+  });
+  const GUTTED = { meta: { type: 'problem', messages: {}, schema: [] }, create() { return {}; } };
+  const positive = readFixture(KNOWN_POSITIVE);
+
+  it('the real rule fires exactly once on the known-positive fixture', () => {
+    const msgs = new Linter().verify(positive, CONFIG(rule), { filename: KNOWN_POSITIVE });
+    expect(msgs.filter((m) => m.ruleId?.includes('no-mocked-sut-import'))).toHaveLength(1);
+  });
+
+  it('a gutted no-op rule finds NOTHING on that same fixture — which is why silence alone proves nothing', () => {
+    const msgs = new Linter().verify(positive, CONFIG(GUTTED), { filename: KNOWN_POSITIVE });
+    expect(msgs.filter((m) => m.ruleId?.includes('no-mocked-sut-import'))).toHaveLength(0);
+  });
+
+  it('the canonical witness is silent under the REAL rule — the documented DI blind spot, not a broken rule', () => {
+    const msgs = new Linter().verify(readFixture(CANONICAL_WITNESS), CONFIG(rule), { filename: CANONICAL_WITNESS });
+    expect(msgs.filter((m) => m.ruleId?.includes('no-mocked-sut-import'))).toHaveLength(0);
+  });
+});

--- a/tests/unit/eslint-rules/no-mocked-sut-import.test.js
+++ b/tests/unit/eslint-rules/no-mocked-sut-import.test.js
@@ -113,6 +113,17 @@ ruleTester.run('no-mocked-sut-import', rule, {
       errors: [{ messageId: 'pragmaMissingReason' }],
     },
     {
+      name: 'vi.doMock is treated the same as vi.mock',
+      // Shares the same conditional as vi.mock in the rule, but "shares a branch" is an argument,
+      // not evidence — pinned so a future narrowing of that condition is caught.
+      code: [
+        "vi.doMock('./deferred.js', () => ({ run: () => {} }));",
+        "import { run } from './deferred.js';",
+        'export const r = run;',
+      ].join('\n'),
+      errors: [{ messageId: 'mockedSutImport' }],
+    },
+    {
       name: 'jest.mock is treated the same as vi.mock',
       code: [
         "jest.mock('./legacy.js', () => ({ doThing: () => {} }));",

--- a/tests/unit/gates/real-callee-attestation.test.js
+++ b/tests/unit/gates/real-callee-attestation.test.js
@@ -1,0 +1,94 @@
+/**
+ * SD-PAT-FIX-STUBBED-WRITER-BLINDNESS-001 (FR-1 / TS-6) — REAL_CALLEE_ATTESTATION gate.
+ *
+ * THE POINT OF THIS FILE, stated because it is easy to write the useless version: a presence-check
+ * gate implemented as `return true` passes every "present" case identically to a correct one. So the
+ * MISSING case asserts the gate's ACTUAL return value (passed === false, plus a distinguishing reason
+ * code), not merely that a run completed. Alongside it sits an explicit gut check confirming a
+ * always-true gate FAILS that assertion — without which "present passes" carries no information.
+ *
+ * That is the same discipline this whole SD exists to install: an assertion of acceptance is only
+ * evidence if something in the same file proves the check can reject.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  createRealCalleeAttestationGate,
+  classifyAttestation,
+} from '../../../scripts/modules/handoff/executors/exec-to-plan/gates/real-callee-attestation.js';
+
+const gate = createRealCalleeAttestationGate();
+const runWith = (metadata) => gate.validator({ sd: { sd_key: 'SD-TEST-001', metadata } });
+
+describe('REAL_CALLEE_ATTESTATION — presence, never content', () => {
+  it('TS-6a: an ABSENT field FAILS with a distinguishing reason code', async () => {
+    // The load-bearing assertion. If this only checked "a result came back", a `return true` gate
+    // would satisfy it.
+    const r = await runWith({});
+    expect(r.passed).toBe(false);
+    expect(r.details.reason).toBe('ATTESTATION_MISSING');
+    expect(r.issues).toHaveLength(1);
+    expect(r.issues[0]).toMatch(/real_callee_attestation/);
+  });
+
+  it('TS-6b: the literal "none" PASSES — declaring it untested is a valid answer', async () => {
+    const r = await runWith({ real_callee_attestation: 'none' });
+    expect(r.passed).toBe(true);
+    expect(r.details.declared_none).toBe(true);
+    // Recorded as a warning so it stays visible rather than reading as ordinary success.
+    expect(r.warnings.join(' ')).toMatch(/UNTESTED/);
+  });
+
+  it('TS-6c: arbitrary content PASSES and is NOT judged', async () => {
+    const r = await runWith({
+      real_callee_attestation: ['recordDisposition -> tests/unit/decision-binding-disposition.test.js'],
+    });
+    expect(r.passed).toBe(true);
+    expect(r.details.entries).toBe(1);
+    expect(r.issues).toHaveLength(0);
+  });
+
+  it('TS-6d: obviously low-quality content still PASSES — content is deliberately out of scope', async () => {
+    // A gate that started grading answers would be guessing, would be argued with, and would get
+    // bypassed. This pins that non-behaviour so nobody "improves" it into a quality judge.
+    const r = await runWith({ real_callee_attestation: 'asdf' });
+    expect(r.passed).toBe(true);
+  });
+
+  it('an EMPTY string or empty array is an absent answer wearing the shape of one', async () => {
+    expect((await runWith({ real_callee_attestation: '   ' })).passed).toBe(false);
+    expect((await runWith({ real_callee_attestation: [] })).passed).toBe(false);
+    expect((await runWith({ real_callee_attestation: ['  ', null] })).passed).toBe(false);
+    expect((await runWith({ real_callee_attestation: {} })).passed).toBe(false);
+  });
+
+  it('is NON-BLOCKING this increment', async () => {
+    expect(gate.required).toBe(false);
+  });
+});
+
+describe('the gate can actually reject — otherwise "present passes" proves nothing', () => {
+  const ALWAYS_TRUE = { validator: async () => ({ passed: true, score: 100, max_score: 100, issues: [], warnings: [] }) };
+
+  it('a stub always-true gate PASSES the missing-field input that the real gate FAILS', async () => {
+    const stubResult = await ALWAYS_TRUE.validator({ sd: { metadata: {} } });
+    const realResult = await runWith({});
+    expect(stubResult.passed).toBe(true);   // the useless implementation
+    expect(realResult.passed).toBe(false);  // the real one
+    // Asserting they DIFFER is what makes every "passes" assertion above meaningful.
+    expect(realResult.passed).not.toBe(stubResult.passed);
+  });
+});
+
+describe('classifyAttestation (pure core)', () => {
+  it('separates missing, empty and present without touching a database', () => {
+    expect(classifyAttestation(undefined).reason).toBe('ATTESTATION_MISSING');
+    expect(classifyAttestation(null).reason).toBe('ATTESTATION_MISSING');
+    expect(classifyAttestation(42).reason).toBe('ATTESTATION_MISSING');
+    expect(classifyAttestation('').reason).toBe('ATTESTATION_EMPTY');
+    expect(classifyAttestation('none').declaredNone).toBe(true);
+    expect(classifyAttestation('NONE').declaredNone).toBe(true);
+    expect(classifyAttestation(['a', 'b']).entries).toBe(2);
+    expect(classifyAttestation({ writeX: 'test-y' }).entries).toBe(1);
+  });
+});


### PR DESCRIPTION
## The pattern

`PAT-TEST-STUBBED-WRITER-UNVERIFIED-001` (critical, 5 occurrences): *wherever a test stubs the very writer whose contract is in question, that contract is UNVERIFIED regardless of suite colour.* The canonical incident was **47 green tests over a production no-op** — one of which asserted that the real writer is never reached.

## What shipped

| FR | Deliverable |
|---|---|
| FR-1 | `REAL_CALLEE_ATTESTATION` gate — name the test driving each REAL callee, or declare it UNTESTED |
| FR-2 | `eslint-rules/no-mocked-sut-import.js` — flags a test that mocks a **relative** specifier and imports a binding from it |
| FR-3 | Warn-only, changed-files-only driver; promotion via `NO_MOCKED_SUT_IMPORT_MODE=block` |
| FR-4 | Pattern resolved with an **honest residual-gap** note |
| FR-5 | The rejected alternative recorded with reasoning + revisit trigger |

## What I rejected, and why

The SD prescribed mechanizing *"what would this suite look like if the source file were deleted?"* Evidence said no:

- **It proves file-level sensitivity only.** The real blind spot was a *transitive* dependency behind an injected callback. Post-fix, neutering `computeQuestionKey` reddens 3 of ~15 tests while the file still reads "sensitive" and ~10 tests stay decorative.
- **Cost:** 2420 unit test files, a 25-minute CI tier, **no reverse test→source dependency graph** in the repo — 3–5× a 9-minute run per PR.
- The pattern's own `proven_solutions` already credited the **manual** adversarial re-review.

Recorded as a decision with a revisit trigger, not an omission.

## The limit is asserted, not footnoted

The canonical witness stubbed by **dependency injection**, not `vi.mock` — `reconcile-late-verdicts.test.js` has zero `vi.mock` calls. The lint is structurally blind to it. **TS-4 asserts that non-detection at both rule and driver level**, and the resolution notes refuse to credit the lint with closing the pattern. FR-1 is the control that reaches the DI class.

## The test design is the point

TESTING evidence found the original plan would have passed against a **gutted** rule — every negative control expects "no finding", which is exactly what `create() { return {} }` emits. For an SD about suites that cannot fail, that would have *been* the defect. Four discriminating requirements went in first:

1. TS-1 (can-fire) and TS-4 (must-not-fire) share **one** `RuleTester.run()`.
2. A second **synthetic** positive defeats path-hardcoding.
3. An explicit gut check runs the real rule and a no-op rule over the same fixture and asserts they **differ**.
4. The driver test asserts `findings > 0`, not just exit 0 — a mis-wired driver also exits 0 and reads as a clean repo.

The same discipline is applied to FR-1's gate: a `return true` presence-check would pass every "present" case, so the missing case asserts the actual return value, paired with a stub-vs-real comparison.

## Rollout

Warn-only is **measured, not timid**: 334 of 3082 unit test files mock a local module and sampling showed most are legitimate collaborator isolation. Baseline captured: **165 findings across 2806 test files, exit 0**.

Not registered in `eslint.config.js` — every sibling class-guard rule is standalone.

## Testing

**89 passed across 9 files.** Dogfooded: this SD sets its own `metadata.real_callee_attestation`, including one entry declaring an UNTESTED integration rather than quietly omitting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
