### PR TITLE
fix(QF-20260727-168): resolve QF dependency refs, and stop the gate asserting a diagnosis it cannot make

### DIFF
--- a/lib/claim/gates/dependency-gate.cjs
+++ b/lib/claim/gates/dependency-gate.cjs
@@ -61,6 +61,27 @@ function extractDependencyRefs(sd) {
  *   queryError: string|null
  * }>} raw axes; on queryError the axis arrays are empty and callers apply
  *   their native error polarity (checkin: skip; sd-start: proceed-with-warning)
+ *
+ * QF-20260727-168 — THE CALLER DIVERGENCE IS A DECISION, NOT AN ACCIDENT.
+ * The row that commissioned the QF-aware lookup asked that the split verdict be settled
+ * deliberately, either way, rather than left as two callers reading one gate differently.
+ * IT IS DELIBERATELY KEPT, and here is the reasoning so nobody "fixes" it later by accident:
+ *
+ *   worker-checkin  FAILS CLOSED on an unresolved ref (depsSatisfiedFromVerdict => false).
+ *                   It self-claims work autonomously with no human in the loop; a ref it
+ *                   cannot resolve is a fact it does not have, and guessing "probably fine"
+ *                   is how a seat starts work whose real blocker nobody has seen.
+ *   sd-start        PROCEEDS WITH A WARNING. A human (or an agent under one) is invoking it
+ *                   deliberately on a named SD and can read the warning and judge. Failing
+ *                   closed there would refuse hand-claims of SDs whose refs are merely
+ *                   mistyped, which is a worse failure than a visible warning.
+ *
+ * The polarity difference is therefore ABOUT WHO IS WATCHING, not about the data. What the
+ * two callers must NOT diverge on is the DIAGNOSIS — both now resolve QF refs, and both
+ * describe an unresolved ref by the scope actually searched (formatDependencyRefusal in
+ * lib/sd-start/dependency-gate.mjs) instead of asserting deletion. Before this change the
+ * shared gate could not see quick_fixes at all, so the divergence was not a considered
+ * split of responsibility — it was two callers disagreeing about a blind spot.
  */
 async function evaluateClaimDependencyGate(supabase, sd) {
   const empty = { blocking: [], unresolved: [], satisfied: [], resolved: [], queryError: null };
@@ -96,6 +117,39 @@ async function evaluateClaimDependencyGate(supabase, sd) {
       if (r.sd_key) statusByRef[r.sd_key] = r.status;
       if (r.id) statusByRef[r.id] = r.status;
     }
+
+    // QF-20260727-168: a dependency ref may name a QUICK-FIX, not an SD. Resolving only
+    // against strategic_directives_v2 meant such a ref could NEVER resolve, and the two
+    // consumers then diverged on it: sd-start warns and proceeds, worker-checkin's
+    // depsSatisfiedFromVerdict fails CLOSED. Net effect — the SD stayed hand-claimable but
+    // was never SELF-claimable, sitting in the belt as "BLOCKED (deps unmet)" forever while
+    // every dependency it named was visible and progressing (live: SD-LEO-FEAT-FLEET-
+    // SESSION-LIFECYCLE-001, 3 of its 4 refs are QF ids).
+    //
+    // ADDITIVE, never a replacement: SD refs keep their existing resolution untouched, and
+    // only refs still unresolved after that are looked up in quick_fixes. So an id that
+    // somehow exists in both tables keeps its SD meaning, and this cannot regress SD refs.
+    //
+    // 'completed' is the satisfied status in BOTH vocabularies, so the filters below need no
+    // change. MEASURED, not assumed (the row explicitly warned against assuming the SD set):
+    // the live quick_fixes CHECK constraint is
+    //   open | in_progress | completed | escalated | cancelled | closed
+    // — note there is NO 'deferred' status, contrary to the row's own example. QF deferral is
+    // expressed as not_before with status left 'open' (see scripts/defer-quick-fix.js), so a
+    // deferred QF correctly reads as a live, unsatisfied dependency rather than a terminal one.
+    const unresolvedAfterSd = refs.filter((k) => !statusByRef[k]);
+    if (unresolvedAfterSd.length) {
+      const qfKeyList = unresolvedAfterSd.map((k) => `"${String(k).replace(/"/g, '')}"`).join(',');
+      const { data: qfData, error: qfError } = await supabase
+        .from('quick_fixes')
+        .select('id, status')
+        .or(`id.in.(${qfKeyList})`);
+      if (qfError) throw qfError;
+      for (const r of qfData || []) {
+        if (r.id && !statusByRef[r.id]) statusByRef[r.id] = r.status;
+      }
+    }
+
     const resolved = refs.map((k) => ({ sd_id: k, status: statusByRef[k] || null }));
     return {
       blocking: resolved.filter((d) => d.status && d.status !== 'completed'),

--- a/lib/sd-start/dependency-gate.mjs
+++ b/lib/sd-start/dependency-gate.mjs
@@ -52,6 +52,14 @@ export function evaluateDependencyGate(resolved, opts = {}) {
 export function formatDependencyRefusal(blocking = [], unresolved = []) {
   const lines = [];
   for (const d of blocking) lines.push(`  • ${d.sd_id} — status='${d.status}' (not completed)`);
-  for (const d of unresolved) lines.push(`  • ${d.sd_id} — could not resolve (deleted or typo?)`);
+  // QF-20260727-168: the old text asserted "could not resolve (deleted or typo?)" — a
+  // DIAGNOSIS the gate is not entitled to make. It sent readers hunting a data-integrity bug
+  // that did not exist: all three refs on the reporting SD were present in quick_fixes, and
+  // the gate simply had not looked in that table. A gate that cannot see a table must report
+  // WHERE IT LOOKED, not claim absence everywhere. State the searched scope and let the
+  // reader draw the conclusion; deletion and typo are now offered as possibilities, not facts.
+  for (const d of unresolved) {
+    lines.push(`  • ${d.sd_id} — matched no strategic_directives_v2.sd_key/id and no quick_fixes.id (deleted, mistyped, or not yet created)`);
+  }
   return lines.join('\n');
 }

--- a/tests/unit/claim/gates/dependency-gate.test.js
+++ b/tests/unit/claim/gates/dependency-gate.test.js
@@ -9,7 +9,7 @@ import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 import { createRequire } from 'module';
-import { evaluateDependencyGate } from '../../../../lib/sd-start/dependency-gate.mjs';
+import { evaluateDependencyGate, formatDependencyRefusal } from '../../../../lib/sd-start/dependency-gate.mjs';
 
 const require = createRequire(import.meta.url);
 const {
@@ -166,6 +166,119 @@ describe('FR-1 superset (SD-LEO-INFRA-MAKE-WSJF-SELF-001) — metadata dep sourc
     expect(v.queryError).toBeNull();
     expect(v.blocking.map((d) => d.sd_id)).toEqual(['SD-SELF-001']);
     expect(depsSatisfiedFromVerdict(v)).toBe(false);
+  });
+});
+
+// ── QF-20260727-168: QF-aware dependency resolution ────────────────────────────
+//
+// A dependency ref may name a QUICK-FIX. Resolving only against
+// strategic_directives_v2 meant such a ref could NEVER resolve, and the two callers then
+// diverged: sd-start warned and proceeded, worker-checkin failed CLOSED. The SD stayed
+// hand-claimable but never SELF-claimable, sitting in the belt as "BLOCKED (deps unmet)"
+// forever (live: SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001, 3 of 4 refs are QF ids).
+//
+// This mock is table-AWARE on purpose: the shared makeSb above returns the same rows for
+// every .from(), which cannot express "absent from SDs but present in quick_fixes" — the
+// exact condition under test. A table-blind mock would pass either way.
+function makeSbByTable({ sds = [], qfs = [], depsRow, qfFailWith = null } = {}) {
+  return {
+    from(table) {
+      const rows = table === 'quick_fixes' ? qfs : sds;
+      const fail = table === 'quick_fixes' ? qfFailWith : null;
+      const builder = {
+        select() { return builder; },
+        or() { return builder; },
+        in() { return builder; },
+        maybeSingle() { return Promise.resolve({ data: depsRow !== undefined ? depsRow : null, error: null }); },
+        then(res, rej) {
+          if (fail) return Promise.resolve({ data: null, error: { message: fail } }).then(res, rej);
+          return Promise.resolve({ data: rows, error: null }).then(res, rej);
+        },
+      };
+      return builder;
+    },
+  };
+}
+
+describe('QF-20260727-168 — dependency refs that name a quick-fix', () => {
+  it('a COMPLETED quick-fix dependency is SATISFIED (was permanently unresolved)', async () => {
+    const sb = makeSbByTable({ sds: [], qfs: [{ id: 'QF-20260725-096', status: 'completed' }] });
+    const v = await evaluateClaimDependencyGate(sb, sdWith([{ sd_key: 'QF-20260725-096' }]));
+    expect(v.unresolved).toEqual([]);
+    expect(v.satisfied.map((d) => d.sd_id)).toEqual(['QF-20260725-096']);
+    // The whole point: worker-checkin can now SELF-claim this SD.
+    expect(depsSatisfiedFromVerdict(v)).toBe(true);
+  });
+
+  it('an OPEN quick-fix dependency BLOCKS — resolved, and legitimately unsatisfied', async () => {
+    const sb = makeSbByTable({ sds: [], qfs: [{ id: 'QF-20260726-677', status: 'open' }] });
+    const v = await evaluateClaimDependencyGate(sb, sdWith([{ sd_key: 'QF-20260726-677' }]));
+    // Resolved (so no false "deleted or typo") but blocking — a real, live dependency.
+    expect(v.unresolved).toEqual([]);
+    expect(v.blocking.map((d) => d.sd_id)).toEqual(['QF-20260726-677']);
+    expect(depsSatisfiedFromVerdict(v)).toBe(false);
+  });
+
+  it('mixed SD + QF refs each resolve against their own table', async () => {
+    const sb = makeSbByTable({
+      sds: [{ id: 'u-a', sd_key: 'SD-A-001', status: 'completed' }],
+      qfs: [{ id: 'QF-20260726-641', status: 'completed' }],
+    });
+    const v = await evaluateClaimDependencyGate(sb, sdWith([{ sd_key: 'SD-A-001' }, { sd_key: 'QF-20260726-641' }]));
+    expect(v.unresolved).toEqual([]);
+    expect(v.satisfied.map((d) => d.sd_id).sort()).toEqual(['QF-20260726-641', 'SD-A-001']);
+    expect(depsSatisfiedFromVerdict(v)).toBe(true);
+  });
+
+  it('SD resolution WINS — the QF lookup is additive and cannot override an SD hit', async () => {
+    // Same id present in both tables with different statuses. The SD meaning must survive.
+    const sb = makeSbByTable({
+      sds: [{ id: 'DUPE-001', sd_key: 'DUPE-001', status: 'in_progress' }],
+      qfs: [{ id: 'DUPE-001', status: 'completed' }],
+    });
+    const v = await evaluateClaimDependencyGate(sb, sdWith([{ sd_key: 'DUPE-001' }]));
+    expect(v.blocking.map((d) => d.sd_id)).toEqual(['DUPE-001']);
+    expect(v.satisfied).toEqual([]);
+  });
+
+  it('a ref in NEITHER table is still unresolved (fail-closed for checkin preserved)', async () => {
+    const sb = makeSbByTable({ sds: [], qfs: [] });
+    const v = await evaluateClaimDependencyGate(sb, sdWith([{ sd_key: 'QF-99999999-000' }]));
+    expect(v.unresolved.map((d) => d.sd_id)).toEqual(['QF-99999999-000']);
+    expect(depsSatisfiedFromVerdict(v)).toBe(false);
+  });
+
+  it('a quick_fixes query error surfaces as queryError, not as a silent "satisfied"', async () => {
+    const sb = makeSbByTable({ sds: [], qfs: [], qfFailWith: 'qf lookup exploded' });
+    const v = await evaluateClaimDependencyGate(sb, sdWith([{ sd_key: 'QF-20260725-096' }]));
+    expect(v.queryError).toBeTruthy();
+    expect(depsSatisfiedFromVerdict(v)).toBe(false);
+  });
+
+  it('does NOT hit quick_fixes when every ref already resolved as an SD (no wasted query)', async () => {
+    const tables = [];
+    const base = makeSbByTable({ sds: [{ id: 'u-a', sd_key: 'SD-A-001', status: 'completed' }] });
+    const sb = { from(t) { tables.push(t); return base.from(t); } };
+    const v = await evaluateClaimDependencyGate(sb, sdWith([{ sd_key: 'SD-A-001' }]));
+    expect(v.satisfied.map((d) => d.sd_id)).toEqual(['SD-A-001']);
+    expect(tables).not.toContain('quick_fixes');
+  });
+});
+
+describe('QF-20260727-168 — the unresolved message must not assert a diagnosis', () => {
+  it('names the scope actually searched instead of claiming deletion', () => {
+    const out = formatDependencyRefusal([], [{ sd_id: 'QF-20260725-096', status: null }]);
+    // The old text asserted "could not resolve (deleted or typo?)" for rows that existed —
+    // it sent readers hunting a data-integrity bug that was not there.
+    expect(out).not.toMatch(/deleted or typo\?/);
+    expect(out).toMatch(/strategic_directives_v2/);
+    expect(out).toMatch(/quick_fixes/);
+    expect(out).toMatch(/QF-20260725-096/);
+  });
+
+  it('still reports a blocking dep with its real status', () => {
+    const out = formatDependencyRefusal([{ sd_id: 'SD-A-001', status: 'in_progress' }], []);
+    expect(out).toMatch(/status='in_progress'/);
   });
 });
 


### PR DESCRIPTION
## Summary

`evaluateClaimDependencyGate` resolved refs **only** against `strategic_directives_v2`, so a ref naming a quick-fix could never resolve. The two callers then diverged on that unresolved ref — sd-start warned and proceeded, worker-checkin's `depsSatisfiedFromVerdict` failed **closed**. Net effect: the SD stayed hand-claimable but was never *self*-claimable, sitting in the belt as "BLOCKED (deps unmet)" forever while every dependency it named was visible and progressing. Live case: `SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001`, 3 of its 4 refs are QF ids.

**1. QF-aware resolution, additive.** Refs still unresolved after the SD lookup are looked up against `quick_fixes.id`. SD refs keep their existing resolution untouched, and an id present in both tables keeps its SD meaning (asserted). The QF query is skipped entirely when every ref already resolved.

**2. The message no longer asserts a diagnosis.** `could not resolve (deleted or typo?)` sent readers hunting a data-integrity bug that didn't exist — all three refs *were* in `quick_fixes`; the gate had never looked there. It now names the scope actually searched. A gate that cannot see a table must report where it looked, not claim absence everywhere.

**3. The caller divergence is now a recorded decision, kept deliberately.** worker-checkin fails closed because it self-claims with no human in the loop; sd-start proceeds-with-warning because a human is invoking it on a named SD and can judge. The polarity difference is about *who is watching*, not about the data. What they must not diverge on is the **diagnosis** — both now resolve QF refs and describe an unresolved ref identically. Before this change the shared gate couldn't see `quick_fixes` at all, so the split wasn't considered responsibility; it was two callers disagreeing about a blind spot.

## Status vocabulary: measured, not assumed

The row warned against assuming the SD status set — and was right to. The live CHECK constraint is:

```
open | in_progress | completed | escalated | cancelled | closed
```

**There is no `deferred` status**, contrary to the row's own example. QF deferral is `not_before` with status left `open` (`scripts/defer-quick-fix.js`), so a deferred QF correctly reads as a *live unsatisfied* dependency rather than a terminal one — exactly the quieter bug the row warned about swapping in. `completed` is the satisfied status in both vocabularies, so the existing axis filters needed no change.

## Test plan

- [x] Completed QF → satisfied, and `depsSatisfiedFromVerdict` now returns true (the actual unblock)
- [x] Open QF → resolved but blocking (a real, live dependency)
- [x] Mixed SD + QF refs each resolve against their own table
- [x] **SD resolution wins** on an id present in both tables — the QF lookup can't override
- [x] Ref in neither table still unresolved (checkin's fail-closed preserved)
- [x] A `quick_fixes` query error surfaces as `queryError`, never a silent "satisfied"
- [x] No wasted `quick_fixes` query when every ref resolved as an SD
- [x] Message names both tables and no longer says "deleted or typo?"
- [x] 23/23 unit gate suite; 7/7 `tests/sd-start-dependency-gate.test.mjs` via `node --test` (that file sits outside the vitest project includes)

The new mock is **table-aware** on purpose: the shared `makeSb` returns identical rows for every `.from()`, which cannot express "absent from SDs but present in quick_fixes" — the exact condition under test. A table-blind mock would have passed either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)