### PR TITLE
fix(QF-20260727-380): deliver the reply before retiring the advisory, and reply to cron senders

### DIFF
--- a/scripts/coordinator-ack-adam.cjs
+++ b/scripts/coordinator-ack-adam.cjs
@@ -173,6 +173,65 @@ function parseArgs(argv) {
   return { flags, positional };
 }
 
+/**
+ * QF-20260727-380: send the coordinator's reply and VERIFY delivery, before anything retires the
+ * advisory. Any failure exits non-zero with the advisory still unactioned — a dropped body must
+ * never be indistinguishable from an answered one.
+ *
+ * (B) NON-UUID SENDERS ARE REPLIABLE NOW. Advisories are not all session-emitted: measured over a
+ * 500-row sample (a FLOOR, not the population — PostgREST caps at 1000 and the sample was not
+ * paginated), 73 adam_advisory rows carried sender_session=null and 4 carried the literal
+ * 'adam-coordinator-health-cron' — ~15% with no repliable sender. The old guard ran isFullUuid on
+ * the ORIGINATOR and refused outright, which made the coordinator structurally unable to answer its
+ * own governance probes through the lane they arrive on. resolveAdamReplyTarget already resolves the
+ * live Adam via getActiveAdamId and only falls back to the originator, so the fix is simply to
+ * validate the RESOLVED TARGET instead of the originator.
+ *
+ * Deliberately NOT done (the QF names this as the wrong fix): widening coordinator-reply.cjs to
+ * accept a non-UUID target. That would write a row nothing can deliver — converting a loud refusal
+ * into the silent drop this whole change exists to remove. When no live Adam can be resolved we
+ * fail LOUD and leave the advisory unactioned.
+ *
+ * @returns {Promise<{replyId:string, adamSession:string, correlationId:string}>}
+ */
+async function deliverReplyOrExit(supabase, { adv, replyBody, coordinatorSession }) {
+  if (!replyBody) { console.error('ERROR: --reply requires a body.'); process.exit(2); }
+  const originator = adv.sender_session;
+  const correlationId = adv.payload && adv.payload.correlation_id;
+  if (!correlationId) { console.error('ERROR: advisory carries no payload.correlation_id (not replyable).'); process.exit(1); }
+
+  // FR-1: target the CURRENT live Adam, never a stale originating session.
+  const { target: adamSession, retargeted } = await resolveAdamReplyTarget(supabase, originator);
+  if (!isFullUuid(adamSession)) {
+    console.error(
+      `ERROR: no live Adam session to reply to (advisory sender_session ${JSON.stringify(originator)} `
+      + 'is not a full UUID, and no session with role=adam is currently live). '
+      + 'The advisory was NOT actioned and the reply body was NOT discarded — re-run once an Adam session is up.'
+    );
+    process.exit(1);
+  }
+  if (retargeted) {
+    console.log(`  ↻ re-targeted from ${isFullUuid(originator) ? 'stale originator' : 'non-session sender'} ${JSON.stringify(originator)} → live Adam ${adamSession}`);
+    // FR-2: recover any prior unread inbound stuck at the stale originator. Only meaningful for a
+    // real session id — a cron sender string was never a deliverable target to begin with.
+    if (isFullUuid(originator)) {
+      const rec = await retargetStaleAdamInbound(supabase, { staleOriginator: originator, liveAdam: adamSession });
+      if (rec.error) console.error('  WARN: stuck-inbound recovery error:', rec.error);
+      else if (rec.retargeted > 0) console.log(`  ↻ recovered ${rec.retargeted} prior unread message(s) to the live Adam`);
+    }
+  }
+
+  const { data, error } = await sendCoordinatorReply(supabase, { coordinatorSession, workerSession: adamSession, correlationId, body: replyBody });
+  if (error) { console.error('ERROR: failed to send reply (advisory NOT actioned):', error.message); process.exit(1); }
+  // FR-3: verify delivery (send != delivered) — fail loud if the row cannot be confirmed.
+  const delivered = await verifyReplyDelivered(supabase, data && data.id);
+  if (!delivered) {
+    console.error('ERROR: reply send reported success but the row could not be confirmed (delivery NOT verified) — failing loud, advisory NOT actioned.');
+    process.exit(1);
+  }
+  return { replyId: data.id, adamSession, correlationId };
+}
+
 async function main() {
   const { flags, positional } = parseArgs(process.argv);
   const advisoryId = typeof flags.advisory === 'string' ? flags.advisory : null;
@@ -195,6 +254,19 @@ async function main() {
   const { row: adv, error: fErr } = await fetchAdvisory(supabase, advisoryId);
   if (fErr) { console.error('ERROR: advisory lookup failed:', fErr.message); process.exit(1); }
   if (!adv) { console.error('ERROR: advisory not found:', advisoryId); process.exit(1); }
+
+  // QF-20260727-380 (A) DELIVER BEFORE RETIRING. actioned_at used to be stamped first and the
+  // reply attempted second, so a failed reply left the advisory reading ACTIONED to every gauge
+  // (the drain loop, the QF-298 gauge, the relay-drop gauge) with the response body discarded —
+  // a ~2000-char substantive answer was lost that way on 2026-07-27. "Actioned" must never mean
+  // "answered" by accident, so when a reply is requested the delivery is verified FIRST and any
+  // failure exits non-zero with the advisory STILL UNACTIONED for the drain loop to retry.
+  // The reply-less ack path and the COORDINATOR_TWOWAY_V2=off path are deliberately unchanged.
+  const twoWayEnabled = isTwoWayV2Enabled();
+  let replyOutcome = null;
+  if (wantsReply && twoWayEnabled) {
+    replyOutcome = await deliverReplyOrExit(supabase, { adv, replyBody, coordinatorSession });
+  }
 
   // Stage 2: stamp actioned_at — the only thing that retires the advisory (idempotent).
   // SD-LEO-FIX-SOLOMON-MULTI-PART-001 (FR-3): resolve the FULL multi-part group this
@@ -241,33 +313,15 @@ async function main() {
   }
 
   if (wantsReply) {
-    if (!isTwoWayV2Enabled()) {
+    if (!twoWayEnabled) {
       console.error('NOTE: --reply skipped — COORDINATOR_TWOWAY_V2 is OFF (advisory was still actioned).');
       process.exit(0);
     }
-    if (!replyBody) { console.error('ERROR: --reply requires a body.'); process.exit(2); }
-    const originator = adv.sender_session;
-    const correlationId = adv.payload && adv.payload.correlation_id;
-    if (!isFullUuid(originator)) { console.error('ERROR: advisory sender_session is not a full UUID:', JSON.stringify(originator)); process.exit(1); }
-    if (!correlationId) { console.error('ERROR: advisory carries no payload.correlation_id (not replyable).'); process.exit(1); }
-    // FR-1: target the CURRENT live Adam, never a stale originating session.
-    const { target: adamSession, retargeted } = await resolveAdamReplyTarget(supabase, originator);
-    if (retargeted) {
-      console.log(`  ↻ re-targeted from stale originator ${originator} → live Adam ${adamSession}`);
-      // FR-2: recover any prior unread inbound stuck at the stale originator.
-      const rec = await retargetStaleAdamInbound(supabase, { staleOriginator: originator, liveAdam: adamSession });
-      if (rec.error) console.error('  WARN: stuck-inbound recovery error:', rec.error);
-      else if (rec.retargeted > 0) console.log(`  ↻ recovered ${rec.retargeted} prior unread message(s) to the live Adam`);
-    }
-    const { data, error } = await sendCoordinatorReply(supabase, { coordinatorSession, workerSession: adamSession, correlationId, body: replyBody });
-    if (error) { console.error('ERROR: failed to send reply:', error.message); process.exit(1); }
-    // FR-3: verify delivery (send != delivered) — fail loud if the row cannot be confirmed.
-    const delivered = await verifyReplyDelivered(supabase, data && data.id);
-    if (!delivered) { console.error('ERROR: reply send reported success but the row could not be confirmed (delivery NOT verified) — failing loud.'); process.exit(1); }
+    // The send + delivery verification already happened above, BEFORE the advisory was retired.
     console.log('✓ Coordinator reply sent to Adam (delivery verified)');
-    console.log('  reply_id:', data.id);
-    console.log('  to_adam:', adamSession);
-    console.log('  reply_to:', correlationId);
+    console.log('  reply_id:', replyOutcome.replyId);
+    console.log('  to_adam:', replyOutcome.adamSession);
+    console.log('  reply_to:', replyOutcome.correlationId);
   }
 }
 

--- a/tests/unit/coordinator-ack-adam-reply-ordering.test.js
+++ b/tests/unit/coordinator-ack-adam-reply-ordering.test.js
@@ -1,0 +1,100 @@
+/**
+ * QF-20260727-380 — an advisory must never read ACTIONED when its reply was dropped.
+ *
+ * Two independent defects, both covered here:
+ *   (A) ORDERING: coordinator-ack-adam.cjs stamped payload.actioned_at BEFORE attempting the reply,
+ *       so a failed reply retired the advisory with the response body discarded. Every downstream
+ *       gauge then read clean while a ~2000-char substantive answer was gone (live, 2026-07-27).
+ *   (B) SCOPE: a non-UUID sender_session (e.g. 'adam-coordinator-health-cron', or null) was refused
+ *       outright, making cron-emitted advisories structurally unrepliable — ~15% of a 500-row sample.
+ *
+ * These are behavioural contracts on the SEQUENCE and the TARGET RESOLUTION, so the test asserts
+ * the source ordering and the guard's subject rather than shelling out to the live CLI (which needs
+ * a coordinator session, a live Adam and real credentials).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(path.resolve(__dirname, '../../scripts/coordinator-ack-adam.cjs'), 'utf8');
+
+const idx = (needle) => SRC.indexOf(needle);
+
+describe('QF-20260727-380 (A): deliver the reply before retiring the advisory', () => {
+  it('calls deliverReplyOrExit BEFORE stampActionedGroup', () => {
+    const deliverCall = idx('await deliverReplyOrExit(supabase');
+    const stampCall = idx('await stampActionedGroup(supabase');
+    expect(deliverCall).toBeGreaterThan(-1);
+    expect(stampCall).toBeGreaterThan(-1);
+    // The whole point of the fix: a failed reply must exit before anything is retired.
+    expect(deliverCall).toBeLessThan(stampCall);
+  });
+
+  it('every FATAL branch in the delivery helper exits non-zero', () => {
+    const helper = SRC.slice(idx('async function deliverReplyOrExit'), idx('async function main()'));
+    // Distinguish fatal errors from the one non-fatal WARN: a stuck-inbound recovery failure must
+    // NOT abort a reply that can still be delivered — recovery is best-effort and reported.
+    const fatalLines = helper.split('\n')
+      .filter((l) => l.includes('console.error(') && !l.includes('WARN:'));
+    const warnLines = helper.split('\n')
+      .filter((l) => l.includes('console.error(') && l.includes('WARN:'));
+    const exits = helper.split('\n').filter((l) => l.includes('process.exit('));
+
+    expect(fatalLines.length).toBeGreaterThan(0);
+    expect(warnLines.length).toBe(1);              // the recovery warning, deliberately non-fatal
+    expect(exits.length).toBe(fatalLines.length);  // one exit per fatal branch, no more, no fewer
+    // And none of them exit 0 — a dropped reply is never a success.
+    expect(helper).not.toMatch(/process\.exit\(0\)/);
+  });
+
+  it('states in the failure text that the advisory was NOT actioned, so the operator can retry', () => {
+    const helper = SRC.slice(idx('async function deliverReplyOrExit'), idx('async function main()'));
+    expect(helper).toMatch(/NOT actioned/i);
+  });
+});
+
+describe('QF-20260727-380 (B): a non-UUID sender is resolved by role, not refused', () => {
+  it('validates the RESOLVED target, never the raw originator', () => {
+    const helper = SRC.slice(idx('async function deliverReplyOrExit'), idx('async function main()'));
+    // The resolved live-Adam target is what must be UUID-checked.
+    expect(helper).toMatch(/isFullUuid\(adamSession\)/);
+    // The old guard — refusing on the originator — must be gone from the reply path.
+    expect(helper).not.toMatch(/if\s*\(!isFullUuid\(originator\)\)\s*\{\s*console\.error\('ERROR: advisory sender_session is not a full UUID'/);
+  });
+
+  it('resolves the target before checking it, so a cron sender can still be answered', () => {
+    const helper = SRC.slice(idx('async function deliverReplyOrExit'), idx('async function main()'));
+    expect(idx('async function deliverReplyOrExit')).toBeGreaterThan(-1);
+    expect(helper.indexOf('resolveAdamReplyTarget')).toBeLessThan(helper.indexOf('isFullUuid(adamSession)'));
+  });
+
+  it('only attempts stuck-inbound recovery for a real session id', () => {
+    const helper = SRC.slice(idx('async function deliverReplyOrExit'), idx('async function main()'));
+    // A cron sender string was never a deliverable target, so there is nothing stuck at it.
+    const recoveryIdx = helper.indexOf('retargetStaleAdamInbound');
+    const guardIdx = helper.indexOf('if (isFullUuid(originator))');
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(recoveryIdx);
+  });
+
+  it('does NOT widen coordinator-reply to accept a non-UUID target (the named wrong fix)', () => {
+    // The QF is explicit: writing a row nothing can deliver converts a loud refusal into a silent
+    // drop. coordinator-ack-adam must not relax the target contract, only resolve a better target.
+    const replySrc = readFileSync(path.resolve(__dirname, '../../scripts/coordinator-reply.cjs'), 'utf8');
+    expect(replySrc).toMatch(/isFullUuid|FULL_UUID_RE|assertValidTarget/);
+  });
+});
+
+describe('unchanged paths', () => {
+  it('the reply-less ack still stamps without any delivery attempt', () => {
+    // deliverReplyOrExit is gated on wantsReply — a bare --advisory ack must not enter it.
+    expect(SRC).toMatch(/if \(wantsReply && twoWayEnabled\)/);
+  });
+
+  it('COORDINATOR_TWOWAY_V2=off still actions the advisory and exits 0', () => {
+    expect(SRC).toMatch(/--reply skipped — COORDINATOR_TWOWAY_V2 is OFF \(advisory was still actioned\)/);
+  });
+});


### PR DESCRIPTION
## Summary

Two independent, compounding defects in `coordinator-ack-adam.cjs`. Both fixed per the QF's own prescribed shape.

**(A) Retire-then-reply.** `payload.actioned_at` was stamped *before* the reply was attempted, so a failed reply retired the advisory with the response body discarded. Every downstream gauge then read clean while a ~2000-char substantive answer was gone (observed live 2026-07-27, noticed only because the CLI happened to print the error after the success line). Delivery is now verified **first**; any failure exits non-zero with the advisory **still unactioned** so the drain loop retries it.

**(B) Cron-emitted advisories were structurally unrepliable.** The guard ran `isFullUuid` on the *originator*, so an advisory from `adam-coordinator-health-cron` (or with `sender_session` null) could never be answered — ~15% of a 500-row sample. `resolveAdamReplyTarget` already resolves the live Adam, so the fix is to validate the **resolved target** instead. No live Adam ⇒ fail loud, leave unactioned.

**Explicitly not done** (the QF names it as the wrong fix): widening `coordinator-reply` to accept a non-UUID target. That writes a row nothing can deliver — converting a loud refusal into the silent drop this change removes.

Unchanged: the reply-less ack path and the `COORDINATOR_TWOWAY_V2=off` path.

## Test plan
- [x] 26/26 (new ordering suite + existing disposition suite)
- [x] Pins the **sequence** (deliver before stamp) — the actual contract
- [x] Pins that every fatal branch exits non-zero, while the one best-effort recovery WARN deliberately does not
- [x] Pins that the **resolved** target is UUID-checked, not the originator

🤖 Generated with [Claude Code](https://claude.com/claude-code)