### PR TITLE
chore(SD-LEO-INFRA-DISPATCH-DELIVERY-INTEGRITY-001): chairman apply-GO stamp + fix a verifier that could only pass while the fix was absent

### DIFF
--- a/database/migrations/20260727_release_sd_qf_reopen.sql
+++ b/database/migrations/20260727_release_sd_qf_reopen.sql
@@ -1,5 +1,19 @@
 -- 20260727_release_sd_qf_reopen.sql
 -- SD-LEO-INFRA-DISPATCH-DELIVERY-INTEGRITY-001 (FR-2)
+-- Date: 2026-07-27
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- CHAIRMAN APPLY-GO: verbal, 2026-07-27T14:32:39Z, granted by the chairman (Rick Felix,
+-- codestreetlabs@gmail.com) and recorded durably on the SD row as metadata.chairman_apply_go
+-- (scribe: adam session af78b5da-b6a1-4aa2-95a4-8c4ebf8edf0d). Stamped by the LEO worker as
+-- SCRIBE under the 2026-07-11 policy: the chairman approves, a session runs the ceremony.
+--
+-- CONTENT BINDING VERIFIED before stamping, because an approval binds to exact content. The
+-- reviewed artifact hashed to 3d867f110a8da4cae999be3caf6c9073562f3fadab953c70e233cace306a2be3
+-- while origin/main stored e318f905eb782e8545127dab84fa5316506150bf8a4dfdb0dadbdfbe4670b12a.
+-- That gap is LINE ENDINGS ONLY, not a post-review edit: git stores LF and checks out CRLF on
+-- Windows, and a fresh checkout of origin/main reproduces the reviewed hash exactly on disk.
+-- (The chairman moved this fleet off Cursor to native Windows terminals the same day.)
 --
 -- THE ROOT OF PART A. release_sd's QF branch cleared claiming_session_id and left status alone:
 --

--- a/scripts/one-off/measure-qf-stranded-population.cjs
+++ b/scripts/one-off/measure-qf-stranded-population.cjs
@@ -1,0 +1,19 @@
+require('dotenv').config();
+const { Client } = require('pg');
+(async () => {
+  const c = new Client({ connectionString: process.env.SUPABASE_POOLER_URL, ssl: { rejectUnauthorized: false } });
+  await c.connect();
+  const now = (await c.query('SELECT now() AT TIME ZONE \'utc\' AS t')).rows[0].t.toISOString();
+  const r = (await c.query(`SELECT
+      count(*) FILTER (WHERE status='in_progress' AND claiming_session_id IS NULL AND pr_url IS NULL AND commit_sha IS NULL) AS stranded,
+      count(*) FILTER (WHERE status='in_progress' AND (pr_url IS NOT NULL OR commit_sha IS NOT NULL)) AS merge_witnessed,
+      count(*) FILTER (WHERE status='in_progress') AS in_progress_total,
+      count(*) FILTER (WHERE status='open') AS open_claimable
+    FROM public.quick_fixes`)).rows[0];
+  console.log(`[${process.argv[2] || 'MEASURE'}] measured_at_utc=${now}`);
+  console.log(`  stranded_signature = ${r.stranded}`);
+  console.log(`  merge_witnessed    = ${r.merge_witnessed}  (deliberate carve-out, never reopened)`);
+  console.log(`  in_progress_total  = ${r.in_progress_total}`);
+  console.log(`  open_claimable     = ${r.open_claimable}`);
+  await c.end();
+})().catch(e => { console.log('FATAL', e.message); process.exit(1); });

--- a/scripts/one-off/verify-release-sd-qf-branch.mjs
+++ b/scripts/one-off/verify-release-sd-qf-branch.mjs
@@ -50,9 +50,39 @@ async function main() {
   // Scope every assertion to the QF branch. Checking the whole body would let the SD branch's own
   // CAS satisfy the CAS check — the wrong-referent mistake this SD is full of examples of.
   const start = def.indexOf("IF v_sd_key LIKE 'QF-%' THEN");
-  const end = def.indexOf('ELSE', start);
+
+  // BOUNDARY FIX — the scoping INTENT above was right; the boundary TOKEN was not.
+  //
+  // This previously ended the window at def.indexOf('ELSE', start). The FR-2 fix introduces
+  //     status = CASE WHEN ... THEN 'open' ELSE status END
+  // and that inline "ELSE status" is the FIRST literal 'ELSE' after the branch start — so the
+  // window truncated mid-CASE, BEFORE the holder CAS that follows it. The check therefore reported
+  // "holder CAS on the QF branch: FAIL" against a live function carrying the CAS verbatim.
+  //
+  // Worth naming precisely, because it is this SD's own defect class: the check was UNSATISFIABLE
+  // BY CONSTRUCTION on the very fix it exists to verify. It could only ever report a full pass
+  // against a release_sd containing no CASE at all — i.e. the UNFIXED one. A verifier that goes
+  // green only while the fix is absent is worse than no verifier, because it is trusted.
+  //
+  // 'UPDATE strategic_directives_v2' is the SD branch's first statement and cannot occur inside the
+  // QF branch, so it is a boundary the QF branch's own contents can never move.
+  const end = def.indexOf('UPDATE strategic_directives_v2', start);
   if (start < 0 || end < 0) { console.error('FAIL: could not isolate the QF branch in the live definition.'); process.exit(1); }
   const branch = def.slice(start, end);
+
+  // SELF-TEST THE WINDOW BEFORE TRUSTING WHAT IT SAYS. A mis-scoped window fails silently in both
+  // directions, and each direction lies differently: over-capture lets the SD branch's CAS satisfy
+  // the CAS check (false PASS), under-capture hides the QF branch's own CAS (false FAIL — the bug
+  // that was actually here). Guard the first, then prove the CAS check can still FAIL at all.
+  if (branch.includes('strategic_directives_v2')) {
+    console.error('FAIL: window over-captured into the SD branch — its CAS would satisfy the CAS check.');
+    process.exit(1);
+  }
+  const casCheck = CHECKS.find((c) => c.name.startsWith('holder CAS'));
+  if (casCheck.re.test(branch.replace(/AND\s+claiming_session_id\s*=\s*p_session_id/, ''))) {
+    console.error('FAIL: negative control — the CAS check still matches after the CAS is removed. It cannot fail, so it cannot detect.');
+    process.exit(1);
+  }
 
   let failed = 0;
   for (const c of CHECKS) {


### PR DESCRIPTION
## Summary

Closes the FR-2 loop on SD-LEO-INFRA-DISPATCH-DELIVERY-INTEGRITY-001. The code shipped in #6543; this is the chairman-gated apply and one real defect it exposed.

- **Stamped the chairman apply-GO** on `20260727_release_sd_qf_reopen.sql` (comment-only: 14 lines added, 0 removed — the `CREATE OR REPLACE FUNCTION` body is byte-for-byte untouched). Verbal GO granted 2026-07-27T14:32:39Z, recorded durably on the SD row as `metadata.chairman_apply_go`. Stamped as SCRIBE under the 2026-07-11 policy; the worker deliberately did **not** self-stamp earlier despite holding a matching git identity, because that header *is* the deliberate-authority proof the 3-factor guard exists to capture.
- **Applied to production** — `[MIGRATION_APPLY_PROD_PASS]`.
- **Fixed `verify-release-sd-qf-branch.mjs`**, which reported a false FAIL on the correct deployment.

## Content binding was verified before stamping, not asserted

The row carried a `hold_reason`: reviewed hash `3d867f11…` vs `origin/main` `e318f905…`, held until explained, because an approval binds to exact content. Measured independently:

| form | sha256 |
|---|---|
| `origin/main` as stored (LF) | `e318f905…` |
| same content CRLF-ised | `3d867f11…` ← the reviewed hash, exactly |
| fresh checkout, on disk | `3d867f11…` ← reproduces it |

Git stores LF and checks out CRLF on Windows, and `apply-migration.js` reads the **on-disk** form — so the reviewed hash was always the right artifact. Line endings only; no post-review edit.

## The verifier could only pass while the fix was absent

It isolated the QF branch with `indexOf('ELSE', start)`. FR-2 introduces `status = CASE … THEN 'open' ELSE status END`, and that inline `ELSE status` is the first literal `ELSE` after the branch start — so the window truncated mid-CASE, before the holder CAS that follows it.

Proven rather than inferred: the CAS regex matches the full live `pg_get_functiondef` (**true**) but not the verifier's slice (**false**).

So the check was **unsatisfiable by construction on the very fix it exists to verify** — it could only report 5/5 against a `release_sd` containing no CASE at all, i.e. the unfixed one. A verifier that goes green only while the fix is absent is worse than none, because it is trusted.

**The fix is the boundary, never the assertion.** All five checks are unchanged. The window now ends at `UPDATE strategic_directives_v2` — the SD branch's first statement, which cannot occur inside the QF branch, so the branch's own contents can never move it. The original scoping intent (keep the SD branch's CAS from satisfying the CAS check) is preserved exactly.

Added a two-way self-test, since a mis-scoped window fails silently in both directions and each lies differently — over-capture gives a false PASS, under-capture a false FAIL. It now refuses to run if the window reaches `strategic_directives_v2`, and runs a negative control proving the CAS check still fails when the CAS is removed.

## Test plan

- [x] Dry-run clean, 1 declared object (`FUNCTION public.release_sd`)
- [x] `[MIGRATION_APPLY_PROD_PASS]`
- [x] Corrected verifier: **5/5 PASS**, exit 0, against `pg_get_functiondef` — not the `.sql` file
- [x] Negative control passes: the CAS check still fails when the CAS is removed
- [x] Population stated as a NUMBER, each freshly stamped — BEFORE `18:52:16Z` stranded=1 / AFTER `18:53:13Z` stranded=1. Unchanged is **correct**: the migration stops *new* stranding at the RPC root, it does not retroactively reopen already-stranded rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)