### PR TITLE
fix(QF-20260727-129): CONST-010 must key on urgency framing, not on tokens that are also data

### DIFF
--- a/lib/adam/rationale-bar.js
+++ b/lib/adam/rationale-bar.js
@@ -78,8 +78,34 @@ export const REQUIRED_RATIONALE_FIELDS = [
 // CONST-010: no manipulative/urgent/certainty/emotional framing.
 // Exported (SD-LEO-INFRA-SMS-CHANNEL-HARDENING-001-D) so the Adam Outbound Gate reuses the SAME
 // regex rather than re-deriving a parallel one that would silently drift from this authority.
+//
+// QF-20260727-129 — KEY ON FRAMING, NOT ON TOKENS THAT ARE ALSO DATA.
+// Two bare tokens made this match a SURFACE FEATURE instead of the thing it exists to catch:
+//
+//   'critical'    is a live PRIORITY/SEVERITY ENUM VALUE. Measured across four columns —
+//                 strategic_directives_v2.priority, quick_fixes.severity, feedback.severity,
+//                 feedback.priority — all of which use exactly {critical, high, medium, low}.
+//                 So ANY advisory reporting an SD/QF priority was refused. This blocked a
+//                 chairman-directed sessions-page inventory TWICE in one session.
+//   'immediately' is an ordinary temporal adverb. It was flagged inside a sentence describing
+//                 WHEN to re-read a database row — a statement of fact about ordering.
+//
+// Both now require an ACTION-URGING CONSTRUCTION around them, which is what CONST-010 is
+// actually about. Bare severity reporting passes; "act immediately" / "critically important"
+// / "it is critical that you ..." still do not.
+//
+// ACCEPTED TRADEOFF, stated so it is a decision and not an oversight: a bare assertion like
+// "this is critical" now passes. It is indistinguishable from severity reporting without
+// modelling intent, and the genuinely coercive constructs are covered by the untouched
+// alternatives (urgent, act now/fast, must act, you need/have to, last chance, don't miss).
+// Under-blocking one ambiguous phrasing beats a gate that makes accurate severity reporting
+// impossible — the documented escape hatch is an attestation flag, so the practical failure
+// mode of the old form was Adam either mangling accurate data or normalising attesting past
+// its own governance gate. Both are worse than this.
+//
+// 'urgent' stays bare-blocked: verified it is NOT an enum value on any of those columns.
 export const MANIPULATIVE_PATTERNS =
-  /\b(urgent(?:ly)?|immediately|act now|act fast|must act|critical(?:ly)?|guaranteed|certainly|definitely|absolutely|you (?:need|have) to|don'?t miss|last chance)\b/i;
+  /\b(urgent(?:ly)?|act now|act fast|must act|(?:act|respond|reply|decide|approve|escalate)\s+immediately|critical(?:ly)?\s+(?:important|urgent)|(?:it'?s|it is|is)\s+critical\s+that|guaranteed|certainly|definitely|absolutely|you (?:need|have) to|don'?t miss|last chance)\b/i;
 
 /**
  * Compute an OKR-weighted score for a candidate from the KR it cites.

--- a/tests/unit/coordinator/adam-outbound-gate.test.js
+++ b/tests/unit/coordinator/adam-outbound-gate.test.js
@@ -32,6 +32,57 @@ describe('rationaleBar — advisory rationale bar (FR-2 / TS-1, TS-2)', () => {
     expect(r.checks.rationaleBar.pass).toBe(false);
     expect(r.checks.rationaleBar.reason).toMatch(/manipulative|CONST-010/i);
   });
+  // ── QF-20260727-129: the guard must key on FRAMING, not on tokens that are also DATA ──
+  //
+  // Both cases below were witnessed on chairman-directed messages in one session
+  // (2026-07-27). The first blocked a chairman-directed sessions-page inventory TWICE.
+  describe('QF-20260727-129 — enum values and neutral temporal words are not manipulation', () => {
+    it('a priority/severity ENUM VALUE passes (measured: 4 live columns use {critical,high,medium,low})', () => {
+      const body = 'SD-X in_progress / PLAN_PRD / critical — reporting because the belt shows it unclaimed; rationale: priority audit.';
+      expect(MANIPULATIVE_PATTERNS.test(body)).toBe(false);
+      const r = checkAdamOutbound({ body, kind: ADVISORY });
+      expect(r.checks.rationaleBar.pass).toBe(true);
+    });
+
+    it('bare severity reporting in any of the live shapes passes', () => {
+      for (const body of [
+        'priority: critical',
+        'severity=critical',
+        '3 critical QFs and 2 high, because the sweep found them; rationale: inventory.',
+        'QF-20260726-996 critical open — evidence: measured live.',
+      ]) {
+        expect(MANIPULATIVE_PATTERNS.test(body)).toBe(false);
+      }
+    });
+
+    it('the neutral temporal adverb passes when it describes WHEN, not an action demanded', () => {
+      const body = 'Re-read the row immediately before the handoff, because the claim can lapse; rationale: staleness.';
+      expect(MANIPULATIVE_PATTERNS.test(body)).toBe(false);
+    });
+
+    it('STILL blocks genuine urgency framing around the same two words', () => {
+      for (const body of [
+        'act immediately',
+        'respond immediately',
+        'approve immediately',
+        'this is critically important',
+        'it is critical that you approve this',
+      ]) {
+        expect(MANIPULATIVE_PATTERNS.test(body)).toBe(true);
+      }
+    });
+
+    it('leaves every untouched alternative blocking (no collateral weakening)', () => {
+      for (const body of [
+        'urgent', 'urgently', 'act now', 'act fast', 'must act',
+        'guaranteed', 'certainly', 'definitely', 'absolutely',
+        'you need to', 'you have to', "don't miss", 'dont miss', 'last chance',
+      ]) {
+        expect(MANIPULATIVE_PATTERNS.test(body)).toBe(true);
+      }
+    });
+  });
+
   it('passes a well-reasoned advisory', () => {
     const r = checkAdamOutbound({ body: 'Recommend parking Alt-Text because demand-test CHECK forbids truth_ metrics; rationale: no live anchor.', kind: ADVISORY });
     expect(r.checks.rationaleBar.pass).toBe(true);


### PR DESCRIPTION
## Summary

`MANIPULATIVE_PATTERNS` matched two bare tokens that aren't manipulation, so Adam's own outbound choke refused ordinary operational reporting.

| Token | Why it isn't manipulation |
|---|---|
| the severity word | A live **priority/severity enum value**. Measured across four columns — `strategic_directives_v2.priority`, `quick_fixes.severity`, `feedback.severity`, `feedback.priority` — all using exactly `{critical, high, medium, low}`. So *any* advisory reporting an SD/QF priority was blocked. It blocked a chairman-directed sessions-page inventory **twice** in one session. |
| the temporal adverb | An ordinary word for without-delay. It was flagged inside a sentence describing **when** to re-read a database row — a statement of fact about ordering, not a demand. |

Both now require an **action-urging construction**, which is what CONST-010 is actually about. Bare severity reporting passes; `act immediately` / `critically important` / `it is critical that you …` still don't.

Everything else is untouched and asserted so: `urgent(ly)`, `act now`, `act fast`, `must act`, `guaranteed`, `certainly`, `definitely`, `absolutely`, `you need/have to`, `don't miss`, `last chance`. I verified the urgency token is **not** an enum value on any of those columns, so it stays bare-blocked.

## Accepted tradeoff (a decision, not an oversight)

A bare assertion of the form "this is `<severity>`" now passes. It's indistinguishable from severity reporting without modelling intent. Under-blocking one ambiguous phrasing beats a gate that makes accurate severity reporting impossible — the documented escape is an attestation flag, so the old form's practical failure mode was Adam either mangling accurate data **or normalising attesting past its own governance gate**. Both are worse than this false negative.

Same defect class the coordinator named across three other guards today: a check matching a *surface feature* instead of the thing.

The regex is single-sourced and reused by `lib/coordinator/adam-outbound-gate.js`, so this fixes both callers by construction rather than by parallel edit.

## Test plan

- [x] Enum value in a realistic advisory passes
- [x] All four live severity-reporting shapes pass (`priority: …`, `severity=…`, counts, `QF-… <sev> open`)
- [x] The neutral temporal use passes
- [x] **Genuine urgency framing around both words still blocks** (`act/respond/approve immediately`, `critically important`, `it is critical that you …`)
- [x] No-collateral-weakening sweep: every untouched alternative still matches
- [x] Pre-existing manipulative-framing test unchanged and still passing (its body carries `you need to`, `act now`, `approve immediately` — all still blocked)
- [x] 22/22 gate suite; 1025/1025 across `tests/unit/adam` + `tests/unit/coordinator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)