### PR TITLE
fix(QF-20260727-205): a role stamp outranks a worker callsign — branch order only

### DIFF
--- a/server/routes/fleet-panel.js
+++ b/server/routes/fleet-panel.js
@@ -50,9 +50,28 @@ function resolveServiceClient(req) {
  * they heartbeat; the absence of ANY identity is what distinguishes them.
  */
 function sessionIdentityKind(meta = {}) {
-  if (meta.fleet_identity?.callsign) return 'worker';
+  // QF-20260727-205: A ROLE STAMP OUTRANKS A WORKER CALLSIGN — this is branch ORDER, nothing else.
+  // The callsign branch used to run FIRST and return unconditionally, so any row carrying BOTH a
+  // fleet callsign and is_coordinator resolved to 'worker' and the coordinator branch was
+  // unreachable. identity_kind is the machine key ehg groups on (useFleetSessions.ts:318 does an
+  // exact === 'coordinator' match), so the live coordinator landed in workers[] and the Sessions
+  // page rendered ROLES 0 / "No coordinator is live" while 1449a046 WAS the registered active
+  // coordinator (chairman-observed 2026-07-27, screenshot-confirmed).
+  //
+  // The contradictory pair is reachable by RACE, not merely operator error:
+  // assign-fleet-identities.cjs stamps a NATO callsign onto any live session in the worker cohort,
+  // and its filterOutCoordinators() (QF-20260508-648) can only exclude rows ALREADY flagged
+  // is_coordinator. A session that registers, gets stamped, and only LATER runs /coordinator start
+  // keeps the worker stamp permanently. Measured in the incident: registered 10:00:47Z, stamped
+  // 'Alpha' 10:01:31Z (44s later), became coordinator ~10:20Z. The identity cron ticks every 5
+  // minutes, so any /coordinator start whose priming reads outlast one tick opens the window.
+  //
+  // Note the symmetry, which is the actual lesson: QF-20260508-648 fixed this SAME writer/consumer
+  // asymmetry on the WRITER side, and its own comment names it. This READER carried the identical
+  // asymmetry and was never fixed. Fixing one side of a two-sided asymmetry is what left it live.
   if (meta.is_coordinator) return 'coordinator';
   if (meta.role) return String(meta.role);
+  if (meta.fleet_identity?.callsign) return 'worker';
   if (meta.model) return 'unstamped';   // real session, identity not yet assigned
   return null;                          // no identity at all -> ghost
 }

--- a/tests/unit/fleet-panel-identity-kind-order.test.js
+++ b/tests/unit/fleet-panel-identity-kind-order.test.js
@@ -1,0 +1,85 @@
+/**
+ * QF-20260727-205 — a once-stamped coordinator must not be classed as a worker.
+ *
+ * LIVE INCIDENT 2026-07-27 (chairman-observed, screenshot-confirmed): the Sessions page rendered
+ * ROLES 0 and "No coordinator is live" while session 1449a046 WAS the registered active
+ * coordinator. Cause: sessionIdentityKind tested fleet_identity.callsign FIRST and returned
+ * unconditionally, so any row carrying BOTH a callsign and is_coordinator resolved to 'worker' and
+ * the coordinator branch was unreachable.
+ *
+ * The contradictory pair is reachable by RACE: assign-fleet-identities.cjs stamps a callsign onto
+ * any live worker-cohort session, and filterOutCoordinators() can only exclude rows ALREADY flagged
+ * is_coordinator. Register → stamped 44s later → /coordinator start ~19min later leaves the worker
+ * stamp permanently. So this is not merely operator error and cannot be fixed by hygiene alone.
+ *
+ * These tests pin BRANCH ORDER, which is the whole defect.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(path.resolve(__dirname, '../../server/routes/fleet-panel.js'), 'utf8');
+
+/** Mirror of the shipped function, extracted so the ordering contract is executable. */
+function sessionIdentityKind(meta = {}) {
+  if (meta.is_coordinator) return 'coordinator';
+  if (meta.role) return String(meta.role);
+  if (meta.fleet_identity?.callsign) return 'worker';
+  if (meta.model) return 'unstamped';
+  return null;
+}
+
+describe('QF-20260727-205: a role stamp outranks a worker callsign', () => {
+  it('classes a coordinator that ALSO carries a stale callsign as coordinator', () => {
+    // The exact live shape: stamped 'Alpha' at 10:01Z, became coordinator ~10:20Z.
+    const meta = { fleet_identity: { callsign: 'Alpha' }, is_coordinator: true, model: 'opus' };
+    expect(sessionIdentityKind(meta)).toBe('coordinator');
+  });
+
+  it('classes a role session that ALSO carries a stale callsign by its role', () => {
+    for (const role of ['adam', 'solomon']) {
+      const meta = { fleet_identity: { callsign: 'Golf-2' }, role, model: 'opus' };
+      expect(sessionIdentityKind(meta)).toBe(role);
+    }
+  });
+
+  it('still classes a genuine worker as worker', () => {
+    expect(sessionIdentityKind({ fleet_identity: { callsign: 'Alpha-2' }, model: 'opus' })).toBe('worker');
+  });
+
+  it('preserves the unstamped and ghost verdicts unchanged', () => {
+    expect(sessionIdentityKind({ model: 'opus' })).toBe('unstamped');
+    expect(sessionIdentityKind({})).toBeNull();
+    expect(sessionIdentityKind()).toBeNull();
+  });
+});
+
+describe('the shipped source carries the fixed order, not just this mirror', () => {
+  it('tests is_coordinator BEFORE fleet_identity.callsign', () => {
+    const fn = SRC.slice(SRC.indexOf('function sessionIdentityKind'));
+    const body = fn.slice(0, fn.indexOf('\n}'));
+    const coordIdx = body.indexOf('meta.is_coordinator');
+    const callsignIdx = body.indexOf('meta.fleet_identity?.callsign');
+    expect(coordIdx).toBeGreaterThan(-1);
+    expect(callsignIdx).toBeGreaterThan(-1);
+    expect(coordIdx).toBeLessThan(callsignIdx); // the entire defect, in one assertion
+  });
+
+  it('tests meta.role BEFORE the callsign branch too', () => {
+    const fn = SRC.slice(SRC.indexOf('function sessionIdentityKind'));
+    const body = fn.slice(0, fn.indexOf('\n}'));
+    expect(body.indexOf('meta.role')).toBeLessThan(body.indexOf('meta.fleet_identity?.callsign'));
+  });
+
+  it('does NOT touch identity_kind casing — the QF names that as the wrong fix', () => {
+    // identity_kind is the machine key ehg groups on (exact lowercase === 'coordinator').
+    // capitalizeRoleLabel must remain display-only.
+    const fn = SRC.slice(SRC.indexOf('function sessionIdentityKind'));
+    const body = fn.slice(0, fn.indexOf('\n}'));
+    expect(body).not.toMatch(/toUpperCase|capitalizeRoleLabel/);
+    expect(body).toMatch(/return 'coordinator'/);
+  });
+});


### PR DESCRIPTION
## Summary
The Sessions page showed `ROLES 0` / "No coordinator is live" while 1449a046 **was** the registered active coordinator.

`sessionIdentityKind` tested `fleet_identity.callsign` **first** and returned unconditionally, so a row with **both** a callsign and `is_coordinator` resolved to `'worker'` — and `identity_kind` is the machine key `ehg` groups on (exact `=== 'coordinator'`), so the coordinator landed in `workers[]`.

Reachable by **race**, not just operator error: a session can be stamped with a callsign 44s after registering and become coordinator ~19min later; `filterOutCoordinators()` can only exclude rows *already* flagged.

**The lesson is the symmetry** — QF-20260508-648 fixed this same writer/consumer asymmetry on the **writer** side. This **reader** had the identical asymmetry and was never fixed.

Did **not** rename/capitalize `identity_kind` — the QF names that as the wrong fix.

## Partial scope (stated, not implied)
Ships fix **(a)** the ordering, which closes the reported symptom. Fix **(b)** — `setActiveCoordinator` deleting stale `fleet_identity` on promotion — is **not** here: it's belt-and-braces per the QF, and that function has two divergent flag paths deserving their own verification. Filed as remainder rather than quietly folded in.

## Test plan
- [x] 7/7 — pins branch order (`is_coordinator` before `callsign`), role-before-callsign, genuine workers still `worker`, unstamped/ghost verdicts unchanged, and that `identity_kind` casing is untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)