### PR TITLE
fix(QF-20260727-064): session-arm the chairman inbound SMS drain — the GHA cron reports green at 1-3.7h, not 5 minutes

### DIFF
--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -73,6 +73,7 @@ export const RESPONSIBILITIES = [
 //   unranked-gauge             | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic invariant gauge
 //   singleton-relaunch          | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic detection+scheduling only
 //   relay-drain                | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic queue drain
+//   sms-relay-drain             | SCRIPT-SHAPED  | YES (sms-relay-drain-cron.yml) | QF-20260727-064: GHA-backed but session-armed ANYWAY — the workflow declares */5 and reports green while Actions deprioritisation makes the real cadence 1-3.7h (measured). The chairman's inbound lane cannot depend on a deprioritised runner.
 //   relay-drop-gauge           | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic invariant gauge
 //   fleet-retro                | SCRIPT-SHAPED  | pending (FR-2 batch)      | capture is deterministic (label says capture/synthesis — FR-2 scopes strictly to the capture path; any judgment-shaped synthesis stays session-armed)
 //   row-growth                 | SCRIPT-SHAPED  | pending (FR-2 batch)      | deterministic daily snapshot
@@ -103,6 +104,7 @@ export const RESPONSIBILITIES = [
 //   unranked-gauge            | SAFE    | gauge-unranked-claimable-leaves.mjs is read + log only (no .insert/.upsert calls) — a pure gauge has nothing to duplicate
 //   singleton-relaunch        | SAFE    | singleton-relaunch-scheduler.mjs defaults to dry-run/report-only (SINGLETON_RELAUNCH_SCHEDULING_ENABLED gate) and guards real writes behind its own stampLastFired marker
 //   relay-drain                | SAFE    | coordinator-relay-drain.cjs only selects UNDRAINED relay_request rows (relay-queue.cjs's drainOne marks a row drained as part of processing it) — a second concurrent run finds nothing left to drain
+//   sms-relay-drain             | SAFE    | QF-20260727-064. Verified IN THIS SCRIPT, not by analogy to relay-drain above (this table's own rule): lib/chairman/sms-bridge.js drainSmsRelayStaging selects `.is('drained_at', null)` (:803) and stamps `.update({drained_at})` per row as part of processing it (:817-819), so a redundant fire finds nothing left to drain. Additionally gated: the runner is a NO-OP unless SMS_RELAY_DRAIN_ENABLED is truthy, and is fail-soft (a drain error logs and exits 0)
 //   relay-drop-gauge          | SAFE    | coordinator-relay-drop-gauge.cjs's own header: "Idempotent per (correlationId): a row already flagged for the same correlation is [skipped]"
 //   fleet-retro               | SAFE    | coordinator-fleet-retro.mjs's insert uses an explicit dedup key on the capture path (source_id/type-scoped)
 //   row-growth                | SAFE    | row-growth-snapshot.cjs is internally due-gated (~22h) per its own STANDARD_LOOPS comment above — an extra run inside the gate window is a documented no-op
@@ -209,6 +211,32 @@ export const STANDARD_LOOPS = [
   { key: 'relay-drain', label: 'Relay-request queue drain + confirm-on-relay', script: 'coordinator-relay-drain.cjs', cron: '1,16,31,46 * * * *',
     gha_backed: true,
     prompt: 'node scripts/coordinator-relay-drain.cjs' },
+  // QF-20260727-064: the CHAIRMAN's inbound SMS drain. sms-relay-drain-cron.yml declares
+  // '*/5 * * * *' and every run reports SUCCESS, but GitHub Actions DEPRIORITISES scheduled
+  // workflows on a busy repo, so the real cadence is nothing like 5 minutes. Measured run
+  // starts (UTC 2026-07-26/27) 19:50, 20:44, 21:43, 22:43, 23:43, 01:20, 05:01, 08:41,
+  // 11:59, 14:55 — gaps of 54, 59, 60, 60, 97, 221, 220, 197, 176 minutes. Hourly at best,
+  // 3.7h at worst, never 5 minutes. Live consequence 2026-07-27: the chairman texted ~09:45Z,
+  // the last drain had run 08:41Z, and at 11:47Z the row was STILL undrained.
+  //
+  // This is the fails-green class — flag on, workflow green, outcome absent — so it stays
+  // gha_backed:true (the workflow is real and does fire) while ALSO being session-armed here,
+  // exactly the "harmless redundant backup" posture the header table already sanctions for
+  // GHA-backed loops. A live coordinator ticks far more reliably than a deprioritised runner.
+  //
+  // This also REPAIRS THE FR-3 ALARM rather than retuning it away. sms-relay-drain.cjs's
+  // backlog-stall signal fires on rows undrained > SMS_RELAY_DRAIN_STALL_MINUTES (default 15).
+  // Under a 1-3.7h effective cadence that threshold is breached by NORMAL operation, so the
+  // alarm was either permanently firing or tuned to ignore the real failure. Restoring a true
+  // ~5-minute cadence makes 15 minutes meaningful again — the honest fix, versus relaxing the
+  // threshold to match a broken cadence and calling the silence health.
+  //
+  // NOT FIXED HERE, and deliberately so: draining a text into chairman_decisions is not the
+  // same as ANSWERING it. A live Adam session must still read and reply, so out-of-session
+  // inbound remains unanswered even at a correct cadence. The row says so explicitly.
+  { key: 'sms-relay-drain', label: 'Chairman inbound SMS relay-staging drain', script: 'sms-relay-drain.cjs', cron: '*/5 * * * *',
+    gha_backed: true,
+    prompt: 'node scripts/sms-relay-drain.cjs' },
   // FR-3: the drop-gauge — flags any inbound RELAY/DECISION/REVIEW row with no matching
   // outbound within the window (default ~15min). Offset from relay-drain so it observes a
   // just-drained queue rather than racing it.

--- a/tests/unit/gha-loop-migration-parity.test.js
+++ b/tests/unit/gha-loop-migration-parity.test.js
@@ -166,3 +166,42 @@ describe('GHA loop migration — concurrency-group uniqueness across all workflo
     }
   });
 });
+
+// ── QF-20260727-064: the chairman's inbound SMS drain is session-armed AS WELL AS GHA-backed ──
+//
+// sms-relay-drain-cron.yml declares '*/5 * * * *' and every run reports SUCCESS, but GitHub
+// Actions deprioritises scheduled workflows on a busy repo. Measured gaps between consecutive
+// run starts (UTC 2026-07-26/27): 54, 59, 60, 60, 97, 221, 220, 197, 176 minutes — hourly at
+// best, 3.7h at worst, never 5. A chairman text sat undrained for over 2 hours while the lane
+// reported healthy. It is therefore ALSO armed as a coordinator STANDARD_LOOPS entry, which is
+// the "harmless redundant backup" posture the registry header already sanctions.
+//
+// MIGRATED_KEYS is the historical FR-2 batch record and is deliberately NOT extended here, so
+// these assertions pin the new entry explicitly instead of mutating that batch's meaning.
+describe('QF-20260727-064 — sms-relay-drain loop/workflow parity', () => {
+  const KEY = 'sms-relay-drain';
+
+  it('is registered in STANDARD_LOOPS and points at the real runner', () => {
+    const loop = loopByKey(KEY);
+    expect(loop.script).toBe('sms-relay-drain.cjs');
+    expect(loop.prompt).toContain('scripts/sms-relay-drain.cjs');
+  });
+
+  it('its cron matches the workflow exactly (the whole point — a 5-minute contract on both sides)', () => {
+    const doc = loadWorkflow(KEY); // resolves .github/workflows/sms-relay-drain-cron.yml
+    const crons = (doc.on.schedule || []).map((s) => s.cron);
+    expect(crons).toHaveLength(1);
+    expect(crons[0]).toBe(loopByKey(KEY).cron);
+    expect(loopByKey(KEY).cron).toBe('*/5 * * * *');
+  });
+
+  it('is marked gha_backed (the workflow is real and does fire — it is the CADENCE that is unreliable)', () => {
+    expect(loopByKey(KEY).gha_backed).toBe(true);
+  });
+
+  it('does not disturb the FR-2 batch pin — those 13 keys are still all gha_backed', () => {
+    const flagged = STANDARD_LOOPS.filter((l) => l.gha_backed === true).map((l) => l.key);
+    for (const key of MIGRATED_KEYS) expect(flagged).toContain(key);
+    expect(flagged).toContain(KEY);
+  });
+});


### PR DESCRIPTION
## Summary

`sms-relay-drain-cron.yml` declares `*/5 * * * *`, the enable flag has been on since 2026-07-17, and **every run reports SUCCESS**. The drain still doesn't happen anywhere near a 5-minute cadence, because GitHub Actions deprioritises scheduled workflows on a busy repo.

Measured run starts (UTC 2026-07-26/27), reproduced independently before fixing:

| Gaps between consecutive runs |
|---|
| 54, 59, 60, 60, 97, **221, 220, 197, 176** minutes |

Hourly at best, **3.7h at worst**, never 5 minutes. Live consequence on 2026-07-27: the chairman texted ~09:45Z, the last drain had run 08:41Z, and at 11:47Z the row was **still undrained**. Fails-green — flag on, workflow green, outcome absent.

**Fix:** register the drain as a coordinator `STANDARD_LOOPS` entry at the same `*/5` contract, so a live coordinator ticks it rather than the chairman's inbound lane depending on a deprioritised runner. It stays `gha_backed: true` — the workflow is real and does fire; it's the *cadence* that's unreliable. This is the "harmless redundant backup" posture the registry header already sanctions, and the same shape as the sibling `relay-drain` entry (itself armed after a confirmed ~2h-undrained incident).

## This repairs the FR-3 alarm rather than retuning it away

The runner's backlog-stall signal fires on rows undrained > 15 minutes (default). Under a 1–3.7h effective cadence that threshold is breached by **normal operation**, so the alarm was either permanently firing or tuned to ignore the real failure. Restoring a true ~5-minute cadence makes 15 minutes meaningful again.

Relaxing the threshold to match a broken cadence — one of the row's three candidate fixes — would have made the silence look like health. That's the same defect one layer up.

## Idempotency verified in this script, not by analogy

The registry's own table forbids asserting safety by analogy to a sibling. Verified directly: `drainSmsRelayStaging` selects `.is('drained_at', null)` (`sms-bridge.js:803`) and stamps `.update({drained_at})` per row as part of processing it (`:817-819`), so a session+GHA double-fire finds nothing left to drain. The runner is additionally a no-op unless the enable flag is truthy, and fail-soft.

## Not fixed here

Draining a text into `chairman_decisions` is **not** the same as answering it. A live Adam session must still read and reply, so out-of-session inbound remains unanswered even at a correct cadence. Stated in the row and repeated in the code so it isn't mistaken for closed.

## Test plan

- [x] Entry registered and pointing at the real runner
- [x] **Cron matches the workflow exactly on both sides** — the whole contract
- [x] `gha_backed: true` (the workflow fires; the cadence is the problem)
- [x] FR-2 batch pin undisturbed — `MIGRATED_KEYS` is the historical batch record and was deliberately not extended
- [x] 146/146 across parity + startup-check + periodic-liveness (which statically parses the registry)
- [x] 717/717 across `tests/unit/coordinator` + `tests/unit/cron`

Both registry header tables updated (durability + per-entry idempotency verdict) so the entry carries its rationale where the next reader will look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)