### PR TITLE
fix(QF-20260727-031): sweep had no detector for an SD pointing at a dead session

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1274,8 +1274,8 @@ async function dispatchWorkAssignmentsIfAllowed(supabase, activeSessions, availa
 // migration. Called from main() via the shared sweepPassCtx (supabase/now/classified/
 // actions), same ctx bag MAIN_PASSES already reuses.
 async function runQaFixtureScan(ctx) {
-  // `warnings` was already carried on sweepPassCtx but never destructured here; FIX #3's
-  // fail-closed guards report through it, so it is pulled in rather than routed into `actions`
+  // `warnings` was already carried on sweepPassCtx but never destructured here; the
+  // half-released-claim guards report through it, so it is pulled in rather than routed into `actions`
   // (a skipped safety guard is not an action taken). Defaulted so a caller that omits it cannot
   // turn a guard message into a ReferenceError mid-sweep.
   const { supabase, now, classified, actions, warnings = [] } = ctx;
@@ -1577,7 +1577,7 @@ async function runQaFixtureScan(ctx) {
     }
   }
 
-  // FIX #3 (QF-20260727-031): SD-SIDE HALF-RELEASED CLAIM.
+  // SD-SIDE HALF-RELEASED CLAIM (QF-20260727-031).
   // A claim is a TWO-SIDED FACT, and every detector above scans only the SESSION side. When the
   // session half of a release completes (status=released, sd_key=null) but the SD half does not,
   // there is NO ROW LEFT FOR THE SWEEP TO ITERATE — this is not a threshold being too slow, it is
@@ -1586,16 +1586,29 @@ async function runQaFixtureScan(ctx) {
   // orphan path requires claiming_session_id IS NULL while this row's pointer is NON-null — the
   // rescue is gated on the exact field that is wrong. The row therefore reads CLAIMED to every
   // dispatch surface, is worked by nobody, and is adoptable by nothing: invisible both ways at once.
-  const halfReleasedClaims = await clearHalfReleasedSdClaims(supabase, actions, warnings);
+  // Deliberately NOT added to the return below: nothing at the call site consumes it, and
+  // tests/unit/lib/sweep/pass-registry.test.js pins that return to EXACTLY the five
+  // formerly-main()-scoped locals. Widening a pinned contract for an unread value is a bad trade.
+  await clearHalfReleasedSdClaims(supabase, actions, warnings);
 
   // Adversarial-review fix (PR #5755): main() still consumes these five locals after the
   // hoist (dead-release cross-signal gate, CLAIM_RELEASED announce, QA summary) — return
   // them so the call site can rebind what used to be main()-scoped declarations.
-  return { sdStatusMap, workingOnCompleted, orphanedClaims, stuckApproval, terminalWithClaims, halfReleasedClaims };
+  return { sdStatusMap, workingOnCompleted, orphanedClaims, stuckApproval, terminalWithClaims };
 }
 
 /**
- * FIX #3 (QF-20260727-031): clear SD-side HALF-RELEASED claims.
+ * SD-SIDE HALF-RELEASED CLAIM (QF-20260727-031): clear an SD pointing at a dead session.
+ *
+ * DELIBERATELY NOT LABELLED WITH THE NUMBERED "FIX #<n>" SCHEME USED ELSEWHERE IN THIS FILE.
+ * That namespace is load-bearing: tests/unit/coord-adam-comms-resilient.test.js isolates the
+ * dead/gone-session cleanup section by indexOf() on one of those literal labels. A second
+ * occurrence EARLIER in the file silently captures the anchor, and the pin then asserts against
+ * the wrong section entirely — which is exactly what this change did on its first CI run.
+ *
+ * Note the second-order trap, since it cost a round too: a comment EXPLAINING the collision must
+ * not itself contain the literal token, or it becomes the earlier occurrence it warns about.
+ * Hence the periphrasis here. Named rather than numbered, so neither can recur.
  *
  * Its own function, mirroring clearStaleQfClaims, so the regression test can drive the REAL code
  * path against a fake client instead of asserting on a re-implementation.

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1274,7 +1274,11 @@ async function dispatchWorkAssignmentsIfAllowed(supabase, activeSessions, availa
 // migration. Called from main() via the shared sweepPassCtx (supabase/now/classified/
 // actions), same ctx bag MAIN_PASSES already reuses.
 async function runQaFixtureScan(ctx) {
-  const { supabase, now, classified, actions } = ctx;
+  // `warnings` was already carried on sweepPassCtx but never destructured here; FIX #3's
+  // fail-closed guards report through it, so it is pulled in rather than routed into `actions`
+  // (a skipped safety guard is not an action taken). Defaulted so a caller that omits it cannot
+  // turn a guard message into a ReferenceError mid-sweep.
+  const { supabase, now, classified, actions, warnings = [] } = ctx;
 
   // 3b. QA — detect sessions working on completed SDs
   const claimedSdKeys = [...new Set(classified.map(s => s.sd_key).filter(Boolean))];
@@ -1573,10 +1577,94 @@ async function runQaFixtureScan(ctx) {
     }
   }
 
+  // FIX #3 (QF-20260727-031): SD-SIDE HALF-RELEASED CLAIM.
+  // A claim is a TWO-SIDED FACT, and every detector above scans only the SESSION side. When the
+  // session half of a release completes (status=released, sd_key=null) but the SD half does not,
+  // there is NO ROW LEFT FOR THE SWEEP TO ITERATE — this is not a threshold being too slow, it is
+  // a population the scan never visits. Measured: the founding instance survived FIVE consecutive
+  // sweeps under direct observation. adoptOrphanInProgress cannot rescue it either, because its
+  // orphan path requires claiming_session_id IS NULL while this row's pointer is NON-null — the
+  // rescue is gated on the exact field that is wrong. The row therefore reads CLAIMED to every
+  // dispatch surface, is worked by nobody, and is adoptable by nothing: invisible both ways at once.
+  const halfReleasedClaims = await clearHalfReleasedSdClaims(supabase, actions, warnings);
+
   // Adversarial-review fix (PR #5755): main() still consumes these five locals after the
   // hoist (dead-release cross-signal gate, CLAIM_RELEASED announce, QA summary) — return
   // them so the call site can rebind what used to be main()-scoped declarations.
-  return { sdStatusMap, workingOnCompleted, orphanedClaims, stuckApproval, terminalWithClaims };
+  return { sdStatusMap, workingOnCompleted, orphanedClaims, stuckApproval, terminalWithClaims, halfReleasedClaims };
+}
+
+/**
+ * FIX #3 (QF-20260727-031): clear SD-side HALF-RELEASED claims.
+ *
+ * Its own function, mirroring clearStaleQfClaims, so the regression test can drive the REAL code
+ * path against a fake client instead of asserting on a re-implementation.
+ *
+ * @param {object} supabase
+ * @param {string[]} actions - appended: one line per cleared row
+ * @param {string[]} warnings - appended: one line when the guard makes it skip the tick
+ * @returns {Promise<Array>} the rows it judged half-released (empty when it skipped)
+ */
+async function clearHalfReleasedSdClaims(supabase, actions, warnings) {
+  let halfReleasedClaims = [];
+  try {
+    // CANONICAL LIVENESS, NOT A SECOND DEFINITION. loadLiveSessionIds is exported precisely so
+    // every consumer resolves the live-session set through ONE implementation; a private cutoff
+    // here would drift from the session-side releases and convert this gap into a split-brain —
+    // the two halves disagreeing about who is alive is strictly worse than the hole it patches.
+    // It returns null (never an empty Set) when it cannot measure, so null is already fail-closed.
+    const liveSessions = await loadLiveSessionIds(supabase);
+
+    // FAIL CLOSED ON UNREADABLE *OR* EMPTY. If the live set cannot be measured, every claim in the
+    // fleet looks dead and this loop would clear all of them. The asymmetry decides it: skipping
+    // costs one delayed cleanup the next tick repeats, while proceeding on a bad read could strip
+    // every active claim at once. Empty means "cannot measure", never "nobody is alive".
+    // Both branches fail closed, but they are DIFFERENT facts and an operator needs to know which:
+    // null means the read failed (loadLiveSessionIds swallows its own cause and returns null),
+    // while an empty Set means the read SUCCEEDED and measured nobody alive. Collapsing them into
+    // one message would hide a broken liveness read behind a plausible-looking quiet-fleet report.
+    if (!liveSessions) {
+      warnings.push('GUARD_UNAVAILABLE: SD-side half-released-claim check skipped this tick — live-session set UNREADABLE (loadLiveSessionIds returned null)');
+    } else if (liveSessions.size === 0) {
+      warnings.push('GUARD_UNAVAILABLE: SD-side half-released-claim check skipped this tick — live-session set measured EMPTY (treated as unmeasurable, never as all-dead)');
+    } else {
+      const claimed = await fapPaginate(() => supabase
+        .from('strategic_directives_v2')
+        .select('sd_key, status, claiming_session_id, metadata')
+        .not('status', 'in', '(completed,cancelled)') // terminal rows are FIX #2's job
+        .not('claiming_session_id', 'is', null)
+        .not('sd_key', 'like', TEST_FIXTURE_SD_KEY_LIKE) // FR-3: never touch SD-TEST-* fixtures
+        .order('sd_key', { ascending: true })); // unique tiebreaker (FR-6)
+      halfReleasedClaims = (claimed || []).filter((sd) => !liveSessions.has(sd.claiming_session_id));
+    }
+  } catch (e) {
+    halfReleasedClaims = []; // fail-closed: a failed read clears nothing
+    warnings.push('GUARD_UNAVAILABLE: SD-side half-released-claim check skipped this tick — read failed (' + ((e && e.message) || 'unknown') + ')');
+  }
+
+  for (const sd of halfReleasedClaims) {
+    const { error } = await supabase
+      .from('strategic_directives_v2')
+      // Preserve the prior claim for reversibility, matching the provenance convention the sweep's
+      // other release paths already use rather than inventing a second shape.
+      .update({
+        claiming_session_id: null,
+        active_session_id: null,
+        is_working_on: false,
+        metadata: { ...(sd.metadata || {}), half_released_prior_claim: sd.claiming_session_id }
+      })
+      .eq('sd_key', sd.sd_key)
+      // CAS on the claimant we actually read: a live session may have re-claimed this row between
+      // the read and this write, and clearing that would recreate the stranding from the other side.
+      .eq('claiming_session_id', sd.claiming_session_id)
+      .select();
+
+    if (!error) {
+      actions.push('QA: cleared half-released claim on ' + sd.sd_key + ' — claimant ' + String(sd.claiming_session_id).slice(0, 8) + ' has no live session');
+    }
+  }
+
+  return halfReleasedClaims;
 }
 
 // SD-ARCH-HOTSPOT-SWEEP-001 (main()-line-count acceptance criterion): the tail-of-tick
@@ -3684,3 +3772,7 @@ module.exports.reapPhantomSessionClaims = reapPhantomSessionClaims;
 // SD-LEO-INFRA-SWEEP-LEGACY-KILL-SWITCH-RETIRE-001: exported so its shape (owner/condition/
 // retirement_action all present and non-empty) is unit-testable.
 module.exports.SWEEP_PASS_REGISTRY_RETIREMENT = SWEEP_PASS_REGISTRY_RETIREMENT;
+
+// QF-20260727-031: exported so the regression test drives the REAL SD-side half-released-claim
+// detector (fake client, real code path) rather than asserting against a re-implementation.
+module.exports.clearHalfReleasedSdClaims = clearHalfReleasedSdClaims;

--- a/tests/unit/stale-sweep-half-released-sd-claim.test.js
+++ b/tests/unit/stale-sweep-half-released-sd-claim.test.js
@@ -1,0 +1,161 @@
+/**
+ * QF-20260727-031 — SD-SIDE HALF-RELEASED CLAIM.
+ *
+ * THE DEFECT. A claim is a two-sided fact. When the SESSION half of a release completes
+ * (status=released, sd_key=null) but the SD half does not, the SD row points at a corpse. Every
+ * pre-existing detector in the sweep iterates SESSIONS holding stale claims — and this session
+ * holds nothing — so there is no row to iterate and the scan never visits the population. It is
+ * not a threshold being too slow. The founding instance survived FIVE consecutive sweeps under
+ * direct observation.
+ *
+ * WHY THE RESCUE PATH CANNOT REACH IT EITHER: adoptOrphanInProgress requires
+ * claiming_session_id IS NULL to treat a row as an orphan, and this row's pointer is NON-null.
+ * The mechanism built for abandoned work is gated on the exact field that is wrong. So the row
+ * reads CLAIMED to every dispatch surface, is worked by nobody, and is adoptable by nothing.
+ *
+ * BEHAVIOURAL, not source-pinned: this drives the REAL exported detector against a fake client.
+ * The sibling guard tests in this directory use static source assertions because their target was
+ * unexported; that convention decays (a fixed slice() window silently stops covering the guard it
+ * asserts once the function grows past it), so where a behavioural test is possible it is used.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const { clearHalfReleasedSdClaims } = require_('../../scripts/stale-session-sweep.cjs');
+
+const DEAD = 'a695dfe8-dead-4000-8000-000000000001'; // the released session's id
+const LIVE = 'b7c1f0a2-live-4000-8000-000000000002';
+
+/**
+ * Minimal chainable fake. Every filter returns `this`; the object is awaitable AND supports
+ * .range() so fapPaginate's pagination terminates (full page first, empty page second).
+ */
+function makeClient({ liveSessions, sds, onUpdate = () => ({ error: null }) }) {
+  const updates = [];
+  const client = {
+    updates,
+    from(table) {
+      const state = { table, isUpdate: false, payload: null, eqs: [], page: 0 };
+      const builder = {
+        select() { return builder; },
+        or() { return builder; },
+        not() { return builder; },
+        in() { return builder; },
+        gte() { return builder; },
+        order() { return builder; },
+        limit() { return builder; },
+        update(payload) { state.isUpdate = true; state.payload = payload; return builder; },
+        eq(col, val) { state.eqs.push([col, val]); return builder; },
+        range() {
+          // fapPaginate: serve the whole set once, then an empty page to stop.
+          const rows = state.page++ === 0 ? builder._rows() : [];
+          return Promise.resolve({ data: rows, error: null });
+        },
+        _rows() {
+          if (state.table === 'v_active_sessions') return liveSessions.map((id) => ({ session_id: id, computed_status: 'active' }));
+          if (state.table === 'strategic_directives_v2') return sds;
+          return [];
+        },
+        then(resolve, reject) {
+          if (state.isUpdate) {
+            updates.push({ payload: state.payload, eqs: state.eqs });
+            return Promise.resolve(onUpdate(state)).then(resolve, reject);
+          }
+          return Promise.resolve({ data: builder._rows(), error: null }).then(resolve, reject);
+        }
+      };
+      return builder;
+    }
+  };
+  return client;
+}
+
+const strandedSd = () => ({
+  sd_key: 'SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001',
+  status: 'in_progress',
+  claiming_session_id: DEAD,
+  metadata: { existing: 'preserved' }
+});
+
+describe('QF-20260727-031: the sweep detects an SD pointing at a dead session', () => {
+  it('CLEARS the exact founding state — released session, SD still pointing at it', async () => {
+    // The whole defect in one assertion. Pre-fix this function does not exist, and no other
+    // detector visits this row, so nothing clears it.
+    const actions = [], warnings = [];
+    const client = makeClient({ liveSessions: [LIVE], sds: [strandedSd()] });
+
+    const found = await clearHalfReleasedSdClaims(client, actions, warnings);
+
+    expect(found).toHaveLength(1);
+    expect(client.updates).toHaveLength(1);
+    const { payload } = client.updates[0];
+    expect(payload.claiming_session_id).toBeNull();
+    expect(payload.is_working_on).toBe(false);
+    expect(payload.active_session_id).toBeNull(); // co-cleared, or it dangles
+    expect(actions[0]).toMatch(/half-released claim/);
+  });
+
+  it('PRESERVES the prior claim for reversibility, without dropping existing metadata', async () => {
+    const client = makeClient({ liveSessions: [LIVE], sds: [strandedSd()] });
+    await clearHalfReleasedSdClaims(client, [], []);
+    const { payload } = client.updates[0];
+    expect(payload.metadata.half_released_prior_claim).toBe(DEAD);
+    expect(payload.metadata.existing).toBe('preserved'); // read-modify-write, not clobber
+  });
+
+  it('CAS-guards the write against a re-claim landing between read and write', async () => {
+    // Without this, a session that legitimately re-claimed the row mid-sweep would have its
+    // claim cleared — recreating the same stranding from the opposite direction.
+    const client = makeClient({ liveSessions: [LIVE], sds: [strandedSd()] });
+    await clearHalfReleasedSdClaims(client, [], []);
+    expect(client.updates[0].eqs).toContainEqual(['claiming_session_id', DEAD]);
+  });
+
+  it('LEAVES a live claimant alone — the arm an always-clear implementation fails', async () => {
+    const sd = strandedSd();
+    sd.claiming_session_id = LIVE;
+    const client = makeClient({ liveSessions: [LIVE], sds: [sd] });
+
+    const found = await clearHalfReleasedSdClaims(client, [], []);
+
+    expect(found).toHaveLength(0);
+    expect(client.updates).toHaveLength(0);
+  });
+});
+
+describe('QF-20260727-031: the guard fails CLOSED, never all-dead', () => {
+  it('clears NOTHING when the live-session set is empty', async () => {
+    // The catastrophic direction. An unmeasurable live set makes every claim in the fleet look
+    // dead; proceeding would strip them all in one pass. Empty means "cannot measure".
+    const actions = [], warnings = [];
+    const client = makeClient({ liveSessions: [], sds: [strandedSd()] });
+
+    const found = await clearHalfReleasedSdClaims(client, actions, warnings);
+
+    expect(found).toHaveLength(0);
+    expect(client.updates).toHaveLength(0);
+    expect(warnings.join(' ')).toMatch(/GUARD_UNAVAILABLE/);
+  });
+
+  it('DISTINGUISHES an unreadable live set from a measured-empty one', async () => {
+    // Both fail closed, but they are different facts. loadLiveSessionIds swallows its own cause
+    // and returns null, so the cause string is unrecoverable here — what IS recoverable, and what
+    // an operator needs, is whether the read failed or genuinely measured nobody. Collapsing them
+    // would hide a broken liveness read behind a plausible-looking quiet-fleet report.
+    const unreadable = [];
+    await clearHalfReleasedSdClaims({ from() { throw new Error('connection reset'); } }, [], unreadable);
+    expect(unreadable.join(' ')).toMatch(/UNREADABLE/);
+
+    const empty = [];
+    await clearHalfReleasedSdClaims(makeClient({ liveSessions: [], sds: [strandedSd()] }), [], empty);
+    expect(empty.join(' ')).toMatch(/measured EMPTY/);
+
+    expect(unreadable.join(' ')).not.toEqual(empty.join(' ')); // the two states are not interchangeable
+  });
+
+  it('does not throw out of the sweep — one bad tick must not kill the pass', async () => {
+    const client = { from() { throw new Error('boom'); } };
+    await expect(clearHalfReleasedSdClaims(client, [], [])).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

A claim is a **two-sided fact**, and every existing sweep detector scans only the session side. When the session half of a release completes (`status=released`, `sd_key=null`) but the SD half does not, there is **no row left to iterate** — not a threshold being too slow, a population the scan never visits. The founding instance survived **five consecutive sweeps** under direct observation.

The rescue path couldn't reach it either: `adoptOrphanInProgress` requires `claiming_session_id IS NULL` to treat a row as an orphan, and this row's pointer is **non-null**. The mechanism built for abandoned work is gated on the exact field that is wrong. The row reads CLAIMED to every dispatch surface, is worked by nobody, and is adoptable by nothing — invisible in both directions at once.

Fixed for the **class**, not the instance. The instance was cleared by hand hours ago; that retires "this SD is stuck", not "this class can strand SDs".

## Design decisions worth reviewing

- **Canonical liveness, not a second definition.** My first draft hand-rolled a 10-minute heartbeat cutoff. `loadLiveSessionIds` already exists and is exported precisely so every consumer resolves the live set through *one* implementation — a private cutoff would drift from the session-side releases and turn this gap into a split-brain, which is worse than the hole it patches.
- **Fails closed in the direction that matters.** If the live set is unreadable *or* measures empty, every claim in the fleet looks dead and this loop would clear all of them. Skipping costs one delayed cleanup the next tick repeats; proceeding on a bad read could strip every active claim at once. The two states emit **different** warnings — collapsing them would hide a broken liveness read behind a plausible quiet-fleet report.
- **CAS on the claimant actually read**, so a session that re-claimed mid-sweep is never clobbered — that would recreate the same stranding from the opposite direction.
- **Provenance preserved** as `metadata.half_released_prior_claim` via read-modify-write, matching the convention the sweep's other release paths already use rather than inventing a second shape.

## Caught while writing it

`runQaFixtureScan` never destructured `warnings` from a ctx that already carried it — the new guard messages would have thrown a `ReferenceError` mid-sweep. `node --check` passed, because it's a scope error, not syntax.

## Test plan

Extracted to its own exported function (mirroring `clearStaleQfClaims`) so the test drives the **real** code path against a fake client rather than asserting on a re-implementation.

- [x] Clears the exact founding state — released session, SD still pointing at it
- [x] Leaves a **live** claimant alone — the arm an always-clear implementation fails
- [x] Preserves prior claim without clobbering existing metadata
- [x] CAS present on the write
- [x] Both fail-closed directions, and that they stay distinguishable
- [x] 93/93 green across 10 sweep test files — no regression in the siblings

Scope: 44 code lines (+50 comment/blank), within Tier 2 QF range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)