### PR TITLE
fix(QF-20260727-858): requires_human_action must name a decider

### DIFF
--- a/lib/coordinator/safe-metadata-merge.mjs
+++ b/lib/coordinator/safe-metadata-merge.mjs
@@ -19,6 +19,9 @@
  * this goes through the raw pg connection (same seam clear-coordinator-review.js uses).
  */
 import { createDatabaseClient } from '../../scripts/lib/supabase-connection.js';
+import {
+  checkDeciderPairing, isHumanActionRequested, namedDecider,
+} from '../governance/human-action-decider.mjs';
 
 /**
  * @param {string} sdKey
@@ -46,6 +49,20 @@ export async function mergeMetadataKeys(sdKey, patch, opts = {}) {
   }
 
   try {
+    // QF-20260727-858: requires_human_action=true must name a decider. This helper is the
+    // canonical chokepoint for hold-flag writes (see docblock above — it exists precisely to stop
+    // future stampers reintroducing an unsafe hold-flag write), so the pairing rule belongs here
+    // rather than in each caller. Only a patch that TURNS THE FLAG ON is constrained; the row's
+    // existing decider satisfies it, so re-stamping an already-routed row is unaffected.
+    if (isHumanActionRequested(patch.requires_human_action) && !namedDecider(patch)) {
+      const { rows } = await client.query(
+        'SELECT metadata FROM strategic_directives_v2 WHERE sd_key = $1',
+        [sdKey],
+      );
+      const verdict = checkDeciderPairing(patch, rows?.[0]?.metadata || null);
+      if (!verdict.ok) return { merged: false, sdKey, error: verdict.reason };
+    }
+
     // COALESCE guards a SQL-NULL metadata column (NULL::jsonb || x evaluates to NULL in
     // Postgres — see clear-coordinator-review.js's identical guard) from silently wiping
     // the whole blob on a row whose metadata has never been set.

--- a/lib/eva/lifecycle-sd-bridge.js
+++ b/lib/eva/lifecycle-sd-bridge.js
@@ -634,6 +634,11 @@ export async function convertSprintToSDs(params, deps = {}) {
     const reviewHoldReason = holdForReview
       ? `BUILD_SD_REVIEW hold (enforcing): ${buildReview.flags.map((f) => `${f.dimension}:${f.reason}`).join('; ')}`
       : null;
+    // QF-20260727-858: this is the second write path that can SET requires_human_action, and it
+    // creates the row, so a fence stamped here with no decider is unroutable from birth. A
+    // BUILD_SD_REVIEW hold is an activate/defer capability call — chairman, matching all three
+    // rows that already name one. Null when not holding, so no stray key on unheld SDs.
+    const reviewHoldDecider = holdForReview ? 'chairman' : null;
 
     // Generate orchestrator SD key
     const orchestratorKey = await generateSDKey({
@@ -696,6 +701,7 @@ export async function convertSprintToSDs(params, deps = {}) {
           // only). metadata.requires_human_action is the proven non-claimable mechanism
           // — lib/fleet/claim-eligibility.cjs reads it and returns 'human_action_required'.
           requires_human_action: holdForReview,
+          human_decider: reviewHoldDecider,
           // SD-LEO-INFRA-BUILD-SD-REVIEW-GATE-001: persist the review verdict for audit.
           build_sd_review: {
             verdict: buildReview.verdict,
@@ -820,6 +826,7 @@ export async function convertSprintToSDs(params, deps = {}) {
             // flagged only). metadata.requires_human_action blocks the claim via
             // lib/fleet/claim-eligibility.cjs -> 'human_action_required'.
             requires_human_action: holdForReview,
+            human_decider: reviewHoldDecider,
             review_hold_reason: reviewHoldReason,
             created_at: new Date().toISOString(),
           },

--- a/lib/governance/human-action-decider.mjs
+++ b/lib/governance/human-action-decider.mjs
@@ -1,0 +1,73 @@
+/**
+ * requires_human_action must name a decider — QF-20260727-858.
+ *
+ * THE DEFECT. `metadata.requires_human_action=true` fences an SD out of dispatch
+ * (lib/fleet/claim-eligibility.cjs returns 'human_action_required'), but nothing required the row
+ * to say WHO decides. Such a row documents THAT a human must act and not WHO, so it enters no
+ * queue and simply ages — unroutable by construction, and invisible because it looks correctly
+ * fenced.
+ *
+ * MEASURED 2026-07-27: 12 live non-terminal SDs carry the flag; 3 name a decider, 9 do not —
+ * including two `critical` operating-company children (SD-FDBK-ENH-EHG-OPERATING-COMPANY-001-B
+ * and -001-C). The coordinator had already caught ONE instance by hand
+ * (SD-LEO-INFRA-DOOR-ROUTING-INERT-DECIDE-001, fenced with the verbatim reason "THIS SD ASKS FOR A
+ * DECISION AND NAMES NOBODY TO MAKE IT") — a correct catch that was never generalised, which is
+ * what makes this a class rather than an oversight.
+ *
+ * WHY A WRITE-PATH GUARD RATHER THAN A READ-TIME CHECK: a read-time warning leaves the
+ * unroutable row created and merely reports it later, which is how the previous single instance
+ * was caught — once, by a human, after the fact. Refusing the WRITE means the state cannot exist.
+ *
+ * TWO KEYS ARE CANONICAL, BOTH READ. Measured across the 3 correct rows: `human_decider` (2) and
+ * `decider` (1). New writes should prefer `human_decider`; `decider` stays accepted so this guard
+ * does not reject rows that already follow the older convention.
+ */
+
+/** Both spellings in live use. Order = preference for new writes. */
+export const DECIDER_KEYS = ['human_decider', 'decider'];
+
+/** Truthy flag values seen in live data (boolean true and the string 'true'). */
+export function isHumanActionRequested(value) {
+  return value === true || value === 'true';
+}
+
+/** Does this metadata object name someone? Empty string / whitespace does NOT count. */
+export function namedDecider(metadata) {
+  if (!metadata || typeof metadata !== 'object') return null;
+  for (const k of DECIDER_KEYS) {
+    const v = metadata[k];
+    if (typeof v === 'string' && v.trim()) return v.trim();
+  }
+  return null;
+}
+
+/**
+ * Is this metadata patch allowed?
+ *
+ * Only constrains a patch that TURNS THE FLAG ON. Clearing it, leaving it alone, or writing any
+ * other key is unaffected — the guard must not make ordinary metadata writes harder, or callers
+ * will route around it.
+ *
+ * A decider already present on the row satisfies the pairing: re-stamping the flag on a row that
+ * is already correctly routed is not the defect.
+ *
+ * @param {object} patch            keys being written
+ * @param {object} [existing]       the row's current metadata, if known
+ * @returns {{ok: boolean, reason?: string, decider?: string}}
+ */
+export function checkDeciderPairing(patch, existing = null) {
+  if (!patch || typeof patch !== 'object') return { ok: true };
+  if (!('requires_human_action' in patch)) return { ok: true };
+  if (!isHumanActionRequested(patch.requires_human_action)) return { ok: true };
+
+  const decider = namedDecider(patch) || namedDecider(existing);
+  if (decider) return { ok: true, decider };
+
+  return {
+    ok: false,
+    reason:
+      'requires_human_action=true without a decider: set metadata.human_decider (e.g. "chairman") '
+      + 'in the same write, or clear the flag. A fence that names nobody is unroutable — it enters '
+      + 'no queue and ages silently (QF-20260727-858).',
+  };
+}

--- a/scripts/one-off/_backfill-human-decider-qf-20260727-858.mjs
+++ b/scripts/one-off/_backfill-human-decider-qf-20260727-858.mjs
@@ -1,0 +1,83 @@
+/**
+ * Backfill `metadata.human_decider` on SDs fenced with requires_human_action=true but naming
+ * nobody — QF-20260727-858.
+ *
+ * The write-path guard stops NEW unroutable rows; it does nothing for the 9 that already exist,
+ * which is why the QF asks for both. Without this pass the guard ships and the two critical
+ * operating-company children keep ageing in nobody's queue.
+ *
+ * WHY 'chairman' AND NOT A CLEARED FLAG. Two options were available: name a decider, or clear the
+ * fence as stale. Naming is the conservative one — it ROUTES the decision to an identified
+ * authority, whereas clearing UNBLOCKS an SD for dispatch on my say-so, which is a governance act
+ * I have no basis for. Every one of the 3 already-correct rows names `chairman`, and these are
+ * activate/defer/priority calls of the same kind, so 'chairman' matches the established
+ * convention rather than inventing one.
+ *
+ * The 2 SD-REFILL rows are flagged separately in the output: they are `deferred` AND carry no
+ * reason text, which is the signature of a stale fence rather than a live decision. They are
+ * still routed (not cleared) for the reason above, but they are the ones worth a human look.
+ *
+ * Goes through mergeMetadataKeys so the backfill uses the same atomic JSONB merge as every other
+ * metadata stamper — and so it exercises the new guard's ALLOW path end to end.
+ *
+ * Idempotent: rows that already name a decider are skipped.
+ *
+ * Usage: node scripts/one-off/_backfill-human-decider-qf-20260727-858.mjs [--apply]
+ *        (dry-run by default — prints the plan and changes nothing)
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { mergeMetadataKeys } from '../../lib/coordinator/safe-metadata-merge.mjs';
+import { namedDecider, isHumanActionRequested } from '../../lib/governance/human-action-decider.mjs';
+
+const APPLY = process.argv.includes('--apply');
+const DECIDER = 'chairman';
+
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const { data, error } = await supabase
+  .from('strategic_directives_v2')
+  .select('sd_key,status,priority,metadata')
+  .not('status', 'in', '(completed,cancelled)');
+
+if (error) {
+  console.error('query failed:', error.message);
+  process.exit(1);
+}
+
+const fenced = (data || []).filter((r) => isHumanActionRequested(r.metadata?.requires_human_action));
+const unrouted = fenced.filter((r) => !namedDecider(r.metadata));
+
+console.log(`fenced (requires_human_action=true, non-terminal): ${fenced.length}`);
+console.log(`already routed                                   : ${fenced.length - unrouted.length}`);
+console.log(`UNROUTED (to backfill)                           : ${unrouted.length}\n`);
+
+let applied = 0;
+const failures = [];
+for (const r of unrouted) {
+  const m = r.metadata || {};
+  const hasReason = Boolean(m.requires_human_action_reason || m.rha_reason);
+  const staleCandidate = !hasReason && r.status === 'deferred';
+  const tag = staleCandidate ? '  [STALE-FENCE CANDIDATE — no reason text + deferred]' : '';
+  console.log(`${APPLY ? 'SET ' : 'PLAN'} ${r.priority?.padEnd(8)} ${r.sd_key}${tag}`);
+
+  if (!APPLY) continue;
+  const res = await mergeMetadataKeys(r.sd_key, {
+    human_decider: DECIDER,
+    human_decider_backfilled_by: 'QF-20260727-858',
+    human_decider_backfilled_at: new Date().toISOString(),
+  });
+  if (res.merged) applied++;
+  else failures.push(`${r.sd_key}: ${res.error || 'no row matched'}`);
+}
+
+if (APPLY) {
+  console.log(`\napplied: ${applied}/${unrouted.length}`);
+  if (failures.length) {
+    console.error('FAILURES:');
+    for (const f of failures) console.error('  -', f);
+    process.exit(1);
+  }
+} else {
+  console.log('\nDRY RUN — re-run with --apply to write.');
+}

--- a/tests/unit/governance/human-action-decider.test.js
+++ b/tests/unit/governance/human-action-decider.test.js
@@ -1,0 +1,146 @@
+/**
+ * QF-20260727-858 — requires_human_action must name a decider.
+ *
+ * The defect: an SD could be fenced out of dispatch with metadata.requires_human_action=true while
+ * naming nobody to decide, producing a row that is unroutable by construction and ages silently.
+ * Measured 2026-07-27: 12 live fenced SDs, 9 with no decider, two of them `critical`.
+ *
+ * These tests pin the WRITE-PATH rule. A read-time check would only report the bad row after it
+ * exists — which is exactly how the single prior instance was caught, by hand, once.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DECIDER_KEYS, isHumanActionRequested, namedDecider, checkDeciderPairing,
+} from '../../../lib/governance/human-action-decider.mjs';
+
+describe('isHumanActionRequested', () => {
+  it('accepts boolean true and the string "true" (both occur live)', () => {
+    expect(isHumanActionRequested(true)).toBe(true);
+    expect(isHumanActionRequested('true')).toBe(true);
+  });
+  it('rejects everything else, including truthy non-flag values', () => {
+    for (const v of [false, 'false', null, undefined, 0, 1, '', 'yes', {}]) {
+      expect(isHumanActionRequested(v)).toBe(false);
+    }
+  });
+});
+
+describe('namedDecider — both live spellings', () => {
+  it('reads human_decider and decider', () => {
+    // Measured across the 3 correctly-fenced rows: 2 use human_decider, 1 uses decider.
+    expect(namedDecider({ human_decider: 'chairman' })).toBe('chairman');
+    expect(namedDecider({ decider: 'chairman' })).toBe('chairman');
+    expect(DECIDER_KEYS).toEqual(['human_decider', 'decider']);
+  });
+  it('prefers human_decider when both are present', () => {
+    expect(namedDecider({ human_decider: 'chairman', decider: 'adam' })).toBe('chairman');
+  });
+  it('does NOT accept an empty or whitespace-only name', () => {
+    // A blank string would satisfy a naive truthiness check while naming nobody — the exact
+    // shape of the bug, one level down.
+    expect(namedDecider({ human_decider: '' })).toBeNull();
+    expect(namedDecider({ human_decider: '   ' })).toBeNull();
+    expect(namedDecider({ decider: '\t' })).toBeNull();
+  });
+  it('tolerates missing/!object metadata', () => {
+    for (const v of [null, undefined, 'nope', 42, []]) expect(namedDecider(v)).toBeNull();
+  });
+});
+
+describe('checkDeciderPairing — only constrains turning the flag ON', () => {
+  it('BLOCKS setting the flag with no decider anywhere', () => {
+    const r = checkDeciderPairing({ requires_human_action: true });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/human_decider/);
+  });
+
+  it('ALLOWS when the same patch names the decider', () => {
+    expect(checkDeciderPairing({ requires_human_action: true, human_decider: 'chairman' }).ok).toBe(true);
+    expect(checkDeciderPairing({ requires_human_action: true, decider: 'chairman' }).ok).toBe(true);
+  });
+
+  it('ALLOWS when the ROW already names one (re-stamping a routed row is not the defect)', () => {
+    const r = checkDeciderPairing({ requires_human_action: true }, { human_decider: 'chairman' });
+    expect(r.ok).toBe(true);
+    expect(r.decider).toBe('chairman');
+  });
+
+  it('BLOCKS when the row has the flag but still no decider', () => {
+    const existing = { requires_human_action: true, requires_human_action_reason: 'documented why' };
+    // Reason text is NOT a decider — 7 of the 9 live offenders had a documented WHY and were
+    // still unroutable. Explaining the fence is not the same as routing it.
+    expect(checkDeciderPairing({ requires_human_action: true }, existing).ok).toBe(false);
+  });
+
+  it('does NOT constrain unrelated writes — the guard must not tax ordinary metadata', () => {
+    // If the guard made normal writes harder, callers would route around it.
+    for (const patch of [{ foo: 'bar' }, { model_recommendation: 'opus' }, {}]) {
+      expect(checkDeciderPairing(patch).ok).toBe(true);
+    }
+  });
+
+  it('does NOT constrain CLEARING the flag', () => {
+    expect(checkDeciderPairing({ requires_human_action: false }).ok).toBe(true);
+    expect(checkDeciderPairing({ requires_human_action: 'false' }).ok).toBe(true);
+  });
+
+  it('tolerates a malformed patch without throwing', () => {
+    for (const v of [null, undefined, 'nope', 42]) expect(checkDeciderPairing(v).ok).toBe(true);
+  });
+});
+
+describe('the two live write paths carry the pairing', () => {
+  // BEHAVIOURAL, via the module's own createClientFn seam — NOT a source-text pin.
+  // The first version of this test asserted the source contained "checkDeciderPairing" and
+  // ran before the UPDATE. It passed with the enforcement GUTTED, because the identifier still
+  // appeared in the import line. Matching a symbol is not observing a call.
+  const fakeClient = (calls) => async () => ({
+    query: async (sql, params) => {
+      calls.push({ sql: String(sql).trim().split('\n')[0], params });
+      return /^SELECT/i.test(String(sql).trim()) ? { rows: [{ metadata: {} }] } : { rowCount: 1 };
+    },
+    end: async () => {},
+  });
+
+  it('safe-metadata-merge REFUSES the write when no decider is named', async () => {
+    const { mergeMetadataKeys } = await import('../../../lib/coordinator/safe-metadata-merge.mjs');
+    const calls = [];
+    const res = await mergeMetadataKeys('SD-TEST-PAIRING-001',
+      { requires_human_action: true }, { createClientFn: fakeClient(calls) });
+    expect(res.merged).toBe(false);
+    expect(res.error).toMatch(/human_decider/);
+    // and crucially: no UPDATE was issued — the unroutable row is never created.
+    expect(calls.some((c) => /^UPDATE/i.test(c.sql))).toBe(false);
+  });
+
+  it('safe-metadata-merge ALLOWS the write when the patch names a decider', async () => {
+    const { mergeMetadataKeys } = await import('../../../lib/coordinator/safe-metadata-merge.mjs');
+    const calls = [];
+    const res = await mergeMetadataKeys('SD-TEST-PAIRING-001',
+      { requires_human_action: true, human_decider: 'chairman' }, { createClientFn: fakeClient(calls) });
+    expect(res.merged).toBe(true);
+    expect(calls.some((c) => /^UPDATE/i.test(c.sql))).toBe(true);
+  });
+
+  it('safe-metadata-merge leaves unrelated writes untouched (no extra SELECT round trip)', async () => {
+    const { mergeMetadataKeys } = await import('../../../lib/coordinator/safe-metadata-merge.mjs');
+    const calls = [];
+    const res = await mergeMetadataKeys('SD-TEST-PAIRING-001',
+      { model_recommendation: 'opus' }, { createClientFn: fakeClient(calls) });
+    expect(res.merged).toBe(true);
+    // The guard must not add a lookup to every metadata write — only to flag-setting ones.
+    expect(calls.filter((c) => /^SELECT/i.test(c.sql))).toHaveLength(0);
+  });
+
+  it('lifecycle-sd-bridge names a decider at BOTH sites that set the flag', async () => {
+    const { readFileSync } = await import('node:fs');
+    const src = readFileSync('lib/eva/lifecycle-sd-bridge.js', 'utf8');
+    const flagSites = (src.match(/requires_human_action: holdForReview,/g) || []).length;
+    const deciderSites = (src.match(/human_decider: reviewHoldDecider,/g) || []).length;
+    // A guard on one of two creation sites is not a guard on the invariant.
+    expect(flagSites).toBeGreaterThan(0);
+    expect(deciderSites).toBe(flagSites);
+    expect(src).toMatch(/reviewHoldDecider = holdForReview \? 'chairman' : null/);
+  });
+});


### PR DESCRIPTION
## The defect

An SD can be fenced out of dispatch with `metadata.requires_human_action=true` while naming **nobody** to decide. Such a row documents *that* a human must act, not *who* — so it enters no queue and ages silently. Unroutable by construction, and invisible because it looks correctly fenced.

**Verified live before building** (not taken on report):

| | |
|---|---|
| Non-terminal SDs with the flag | 12 |
| Name a decider | 3 |
| **Name nobody** | **9** |

Two of the nine are `critical` — `SD-FDBK-ENH-EHG-OPERATING-COMPANY-001-B` and `-001-C`.

This is a **class, not an oversight**: the coordinator had already caught one instance by hand (`SD-LEO-INFRA-DOOR-ROUTING-INERT-DECIDE-001`, fenced with the verbatim reason *"THIS SD ASKS FOR A DECISION AND NAMES NOBODY TO MAKE IT"*) and never generalised it.

## The fix

**Guard at the write path, not at read time.** A read-time check leaves the unroutable row created and reports it afterwards — which is exactly how the prior instance surfaced: once, by a human, late. Refusing the *write* means the state cannot exist.

**Both write paths**, because a guard in one path is not a guard on the invariant:

- `lib/coordinator/safe-metadata-merge.mjs` — the canonical chokepoint, whose own docblock already names `requires_human_action` as a hold flag it exists to protect.
- `lib/eva/lifecycle-sd-bridge.js` — the path that *creates* held SDs, at **both** sites. A fence stamped here with no decider is unroutable from birth.

Scoped narrowly so the guard isn't routed around: only a patch **turning the flag on** is constrained; an existing decider on the row satisfies it; ordinary metadata writes pay no extra lookup.

Both live spellings accepted (`human_decider` ×2, `decider` ×1 across the correct rows). A blank/whitespace name does **not** satisfy the pairing — that would be the same bug one level down.

## Backfill

**9/9 routed to `chairman`**, re-measured afterwards to 0 unrouted.

Naming rather than clearing is deliberate: naming **routes** the decision to an identified authority; clearing **unblocks** an SD for dispatch on my say-so, which is a governance act I have no basis for. The 2 `SD-REFILL` rows (deferred, no reason text) are flagged in the script output as stale-fence candidates worth a human look — routed, not cleared.

## Resolving the report's open question

The report declined to assert whether these rows carry reason text, having probed three key names. **They do** — under `requires_human_action_reason` / `rha_reason`. 7 of 9 have it, which reconciles the report's 9-of-12 with Solomon's 7-of-10 exactly: the 2 without reason are the 2 deferred REFILL rows he excluded. Both counts were right about different populations.

## Tests

17 tests, mutation-verified — gutting the pairing rule (3 fail), accepting a blank decider (1), gutting write-path enforcement (1), pairing only one of the two bridge sites (1).

The write-path test is **behavioural**, via the module's own `createClientFn` seam, asserting no `UPDATE` is issued. An earlier source-text version passed with enforcement removed, because the identifier still appeared in the import line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)