### PR TITLE
fix(QF-20260727-360): repoint the LLM cost task at the tracked script, and stop the alert text being destroyed on breach

### DIFF
--- a/scripts/ops/llm-cost-check.ps1
+++ b/scripts/ops/llm-cost-check.ps1
@@ -35,7 +35,16 @@ $Stamp     = (Get-Date).ToString('yyyy-MM-dd HH:mm:ss')
 # --- Run the check ----------------------------------------------------------
 Push-Location $RepoRoot
 try {
-  $output = & node $Report --check --max-daily-usd $MaxDailyUsd --max-daily-calls $MaxDailyCalls --spike $SpikeFactor 2>&1 | Out-String
+  # QF-20260727-360: llm-cost-report.mjs writes its ALERT LINE TO STDERR (verified:
+  # `node scripts/llm-cost-report.mjs --check 2>/dev/null` prints nothing, `2>&1 1>/dev/null`
+  # prints the alert). In Windows PowerShell 5.1, `2>&1` on a NATIVE command wraps each stderr
+  # line in an ErrorRecord, so Out-String rendered the record's formatting — the log and the
+  # alert file recorded "+ FullyQualifiedErrorId : NativeCommandError" INSTEAD of the message.
+  # i.e. the alert text was destroyed in exactly the case the alert exists for. Unwrap each
+  # ErrorRecord back to its message so a breach reads as a breach.
+  $output = & node $Report --check --max-daily-usd $MaxDailyUsd --max-daily-calls $MaxDailyCalls --spike $SpikeFactor 2>&1 |
+    ForEach-Object { if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { $_ } } |
+    Out-String
   $code = $LASTEXITCODE
 } catch {
   $output = "wrapper exception: $($_.Exception.Message)"

--- a/scripts/ops/register-llm-cost-task.ps1
+++ b/scripts/ops/register-llm-cost-task.ps1
@@ -1,0 +1,90 @@
+<#
+.SYNOPSIS
+  Idempotently (re)point the "LEO LLM Cost Check" scheduled task at the TRACKED
+  cost-check script. QF-20260727-360.
+
+.DESCRIPTION
+  WHAT WENT WRONG. The task was registered against an UNTRACKED wrapper:
+
+      wscript.exe "<repo>\scripts\ops\llm-cost-check-hidden.vbs"
+
+  That .vbs was never in git (git ls-files scripts/ops/ lists only
+  llm-cost-check.ps1 and set-gemini-key.ps1, and .gitignore covers the .log and the
+  alert .txt, not a .vbs). So a clean, a checkout or a reset deleted it and nothing
+  restored it. Measured on 2026-07-27: the task fired at 08:00:01 with
+  LastTaskResult 2147943467 = 0x8007042B ERROR_PROCESS_ABORTED and
+  NumberOfMissedRuns 0 — firing reliably, failing reliably. Output side agreed:
+  llm-cost-check.log last written 2026-07-11, LLM-COST-ALERT.txt 2026-07-02. About
+  16 days with NO LLM cost monitoring, on a system where plan quota IS the cost
+  currency.
+
+  WHY THIS SCRIPT EXISTS RATHER THAN A ONE-OFF schtasks COMMAND. Recreating the
+  missing .vbs would re-arm the identical failure — the row says so explicitly, and
+  it is right: the untracked-ness was the defect, not the file's contents. This
+  provisioning step is therefore TRACKED, so the task can be re-applied after any
+  host reset without depending on somebody remembering the incantation.
+
+  The real script (scripts/ops/llm-cost-check.ps1) is tracked and resolves its own
+  paths from $PSScriptRoot, so it needs no working directory. Hidden execution comes
+  from -WindowStyle Hidden on powershell.exe itself, which is what the .vbs wrapper
+  was only ever there to provide.
+
+  NOT CHANGED HERE, deliberately: Principal.LogonType. The whole EHG task family is
+  registered Interactive and pops visible consoles — that is QF-20260726-677, a
+  different defect on the same family, and its row says "file both, do not merge".
+  This script preserves whatever principal the existing task already has.
+
+.NOTES
+  Safe to re-run. Reports the before/after action so a run is self-evidencing.
+  Requires the same elevation the original registration needed.
+#>
+
+[CmdletBinding()]
+param(
+  [string] $TaskName = 'LEO LLM Cost Check',
+  # Resolve the MAIN repo root, NOT the caller's cwd. --git-common-dir points at the
+  # main .git even from inside a linked worktree, so running this from a worktree
+  # cannot register an ephemeral path — which would be the very bug this fixes.
+  [string] $RepoRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $RepoRoot) {
+  $commonDir = (& git rev-parse --path-format=absolute --git-common-dir 2>$null)
+  if (-not $commonDir) { throw 'Not inside a git repository and no -RepoRoot supplied.' }
+  $RepoRoot = Split-Path -Parent ($commonDir -replace '/', '\')
+}
+
+$Target = Join-Path $RepoRoot 'scripts\ops\llm-cost-check.ps1'
+if (-not (Test-Path $Target)) {
+  throw "Cost-check script not found at $Target - refusing to register a task pointing at a missing file (that is the bug this closes)."
+}
+
+$existing = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+if ($existing) {
+  Write-Output '=== BEFORE ==='
+  foreach ($a in $existing.Actions) { Write-Output ("  " + $a.Execute + " " + $a.Arguments) }
+} else {
+  Write-Output '=== BEFORE === (task not registered)'
+}
+
+$action = New-ScheduledTaskAction `
+  -Execute 'powershell.exe' `
+  -Argument ('-NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File "{0}"' -f $Target)
+
+if ($existing) {
+  # Repoint ONLY the action. Trigger, principal and settings are left exactly as the
+  # host already has them (see the LogonType note above).
+  Set-ScheduledTask -TaskName $TaskName -Action $action | Out-Null
+} else {
+  $trigger = New-ScheduledTaskTrigger -Daily -At 08:00
+  Register-ScheduledTask -TaskName $TaskName -Action $action -Trigger $trigger | Out-Null
+}
+
+$after = Get-ScheduledTask -TaskName $TaskName
+Write-Output '=== AFTER ==='
+foreach ($a in $after.Actions) { Write-Output ("  " + $a.Execute + " " + $a.Arguments) }
+Write-Output ''
+Write-Output ("Verify with: Start-ScheduledTask -TaskName '{0}' then Get-ScheduledTaskInfo -TaskName '{0}'" -f $TaskName)
+Write-Output 'Expect LastTaskResult 0 and a fresh write to scripts/ops/llm-cost-check.log.'


### PR DESCRIPTION
## Summary

The daily **LEO LLM Cost Check** task executed an **untracked** wrapper (`llm-cost-check-hidden.vbs`). That file was never in git, so a clean/checkout/reset deleted it and nothing restored it.

Verified every claim on the live host before fixing:

| | |
|---|---|
| action | `wscript.exe "...\llm-cost-check-hidden.vbs"` |
| `Test-Path` .vbs | **False** (`llm-cost-check.ps1`: True, and tracked) |
| LastRunTime | 2026-07-27 08:00:01 |
| LastTaskResult | `2147943467` = `0x8007042B` ERROR_PROCESS_ABORTED |
| MissedRuns | **0** — firing reliably, *failing* reliably |
| log / alert last written | 2026-07-11 / 2026-07-02 |

~16 days with no LLM cost monitoring, on a system where plan quota *is* the cost currency.

## Fix 1 — host (applied and verified)

The task now runs `powershell.exe -NoProfile -ExecutionPolicy Bypass -WindowStyle Hidden -File <repo>\scripts\ops\llm-cost-check.ps1`. Hidden execution comes from `-WindowStyle Hidden`, which is all the `.vbs` ever provided.

The missing `.vbs` was **deliberately not recreated** — being untracked *was* the defect, so restoring it re-arms the identical failure. Shipped instead as a **tracked** provisioning script so the task survives any host reset. It resolves the main repo root via `git rev-parse --git-common-dir`, so running it from a linked worktree can't register an ephemeral path — which would be this very bug again. It repoints **only** the action; trigger, principal and settings untouched.

## Fix 2 — the restored monitoring was still half-blind

`llm-cost-report.mjs` writes its alert to **stderr** (verified: `2>/dev/null` prints nothing; `2>&1 1>/dev/null` prints the alert). In PowerShell 5.1, `2>&1` on a *native* command wraps each stderr line in an ErrorRecord, so `Out-String` recorded the record's formatting instead of the message. Measured on the first live run after the repoint:

```
2026-07-27 11:49:44  exit=1  + FullyQualifiedErrorId : NativeCommandError
```

The alert text was destroyed in exactly the case the alert exists for. After unwrapping, same data:

```
2026-07-27 11:51:41  exit=1  🚨 [llm-cost-report] 2026-07-26 ALERT: spend $0.53 > 2x trailing avg $0.24
```

## The restored check immediately found a real breach

`exit=1` is **correct** — 1 = threshold breach per the script's own contract, not a residual failure. The row's "expect LastTaskResult 0" assumed a healthy day; after 16 dark days the first run found a spike. Worth knowing on its own.

## Not touched, deliberately

`Principal.LogonType`. The whole EHG task family is registered Interactive and pops visible consoles — that's QF-20260726-677, whose row says *"file both, do not merge."* Verified this task is still Interactive and left it so.

## Test plan

- [x] Host task action repointed; before/after captured by the provisioning script
- [x] Forced run: log advanced after a 16-day gap
- [x] Alert text now readable in the log (was `NativeCommandError`)
- [x] Generated `.log` / alert `.txt` confirmed gitignored — neither committed
- [x] LogonType confirmed unchanged

**Note on sequencing:** the host task repoint is live now. The log-readability fix reaches the host when the shared root pulls this merge, since the task points at the shared-root copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)