### PR TITLE
fix(QF-20260727-709): the pre-send consult must say WHO the message is addressed to

### DIFF
--- a/lib/adam/presend-consult-lane.cjs
+++ b/lib/adam/presend-consult-lane.cjs
@@ -52,6 +52,10 @@ async function runPreSendConsultLane(input = {}, deps = {}) {
   const {
     subject = '', body = '', senderCallsign, sessionId, repo, expiresAt,
     isChairmanTargeted = false,
+    // QF-20260727-709: { role, sessionId } of the party the ADVISORY is addressed to — not the
+    // reviewer. Already resolved at the send call site, so this threads an existing value rather
+    // than deriving a new one. Optional; omitting it reproduces the previous envelope byte-for-byte.
+    addressee = null,
   } = input;
   const {
     evaluatePreSendConsult, performBoundedConsult, getActiveSolomonId,
@@ -78,7 +82,10 @@ async function runPreSendConsultLane(input = {}, deps = {}) {
       const correlationId = randomUUID();
       const cp = buildSolomonConsultPayload({
         correlationId,
-        body: buildPreSendConsultBody(body),
+        // QF-20260727-709: forward WHO the message is addressed to. Without it the reviewer reads
+        // second-person prose aimed at a different party as aimed at himself. Optional and
+        // undefined-safe — an omitted addressee reproduces the previous envelope exactly.
+        body: buildPreSendConsultBody(body, addressee),
         senderCallsign,
         repo,
         severity: 'high',

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -95,8 +95,35 @@ function advisoryExpiresAt(nowMs) {
 // body ('your packet ends mid-sentence at Two; the findings this consult exists FOR are invisible
 // to me' — Solomon advisory 97cf4e3e, recurred ~9x). The prefix is inside the cap so the tail the
 // consult exists to check is never dropped. PURE + exported for tests.
-function buildPreSendConsultBody(body) {
-  return capBody(`[PRE-SEND CONSULT] ${body ?? ''}`);
+// QF-20260727-709: the envelope also has to say WHO THE MESSAGE IS FOR. Forwarding only the raw
+// body hands the reviewer second-person prose written to a DIFFERENT party, with no field that
+// disambiguates it — so every "you"/"your" silently re-points at the reviewer. Witnessed live: an
+// advisory correctly addressed to the coordinator was read by Solomon as crediting HIM with editing
+// SD row descriptions. He is propose-only under CONST-002 and has edited zero rows, so the omission
+// manufactured a false governance-violation record against the oracle, stripped credit from the
+// party who actually did the work, and burned a consult round-trip on a problem that did not exist.
+// THE REVIEWER CANNOT RECOVER THIS ON HIS OWN: no amount of care recovers a field never transmitted.
+//
+// `addressee` is OPTIONAL and the no-arg call is byte-identical to before, so existing callers and
+// tests are unaffected. The header sits INSIDE capBody for the same reason the prefix does
+// (QF-20260720-729): anything outside the cap can be the thing that gets dropped.
+function formatConsultAddressee(addressee) {
+  if (!addressee) return '';
+  const role = typeof addressee === 'string' ? addressee : addressee.role;
+  const sessionId = typeof addressee === 'string' ? null : addressee.sessionId;
+  if (!role && !sessionId) return '';
+  const idPrefix = typeof sessionId === 'string' && sessionId.length > 0 ? ` ${sessionId.slice(0, 8)}` : '';
+  return ` -> ${role || 'unknown-role'}${idPrefix}`;
+}
+
+function buildPreSendConsultBody(body, addressee) {
+  const to = formatConsultAddressee(addressee);
+  // The pronoun note is not padding: the reviewer's failure mode was resolving second person to
+  // himself, and naming the addressee alone still leaves that reading available on a skim.
+  const orientation = to
+    ? `[PRE-SEND CONSULT${to}] (second-person pronouns below refer to the ADDRESSEE, not to you) `
+    : '[PRE-SEND CONSULT] ';
+  return capBody(`${orientation}${body ?? ''}`);
 }
 
 // SD-REFILL-00XK256L: the 2-hypothesis-bar guard for Adam urgent operational broadcasts. Adam's web-
@@ -1127,7 +1154,19 @@ async function main() {
       // Adam advisories target the coordinator/Solomon, never the chairman directly, so this
       // send path is not chairman-targeted (a chairman-facing send path would pass true).
       const outcome = await runPreSendConsultLane(
-        { subject, body: payload.body, senderCallsign, sessionId, repo: process.cwd(), expiresAt, isChairmanTargeted: false },
+        // QF-20260727-709: pass the resolved ADDRESSEE so the reviewer can resolve second-person
+        // pronouns in the body. `target` and the role are already computed above for the send
+        // itself; this threads them, it does not re-derive them.
+        {
+          subject,
+          body: payload.body,
+          senderCallsign,
+          sessionId,
+          repo: process.cwd(),
+          expiresAt,
+          isChairmanTargeted: false,
+          addressee: { role: isDirectTarget ? peerArg : (toSolomon ? 'solomon' : 'coordinator'), sessionId: target },
+        },
         {
           evaluatePreSendConsult,
           performBoundedConsult,

--- a/tests/unit/adam-advisory-presend-consult-body.test.js
+++ b/tests/unit/adam-advisory-presend-consult-body.test.js
@@ -24,6 +24,53 @@ describe('buildPreSendConsultBody (QF-20260720-729)', () => {
     expect(out).toBe('[PRE-SEND CONSULT] hello world');
   });
 
+  // ── QF-20260727-709: the envelope must also say WHO the message is for ───────────────────────
+  // Solomon received an advisory addressed to the COORDINATOR, read its second-person prose as
+  // aimed at himself, and objected to being credited with editing SD rows — a CONST-002 breach
+  // that never happened. The reviewer could not have resolved it: the addressee was never sent.
+  describe('addressee (QF-20260727-709)', () => {
+    it('names the addressee role and session prefix when one is supplied', () => {
+      const out = buildPreSendConsultBody('your dispatch constraints are wrong', {
+        role: 'coordinator', sessionId: '1449a046-0f83-4b8e-b6f2-ad26510d0c05',
+      });
+      expect(out).toContain('coordinator');
+      expect(out).toContain('1449a046');           // prefix only — never the full session id
+      expect(out).not.toContain('0f83-4b8e');      // …so the header stays scannable
+      expect(out).toContain('your dispatch constraints are wrong');
+    });
+
+    it('states that second-person pronouns refer to the ADDRESSEE, not the reviewer', () => {
+      // Naming the addressee alone still leaves the wrong reading available on a skim, and a skim
+      // is exactly what happened. This sentence is the actual repair for the misread.
+      const out = buildPreSendConsultBody('you credited me with X', { role: 'coordinator', sessionId: 'abcdef12' });
+      expect(out).toMatch(/ADDRESSEE, not to you/);
+    });
+
+    it('is BYTE-IDENTICAL to the previous envelope when no addressee is supplied', () => {
+      // Back-compat is the whole reason the parameter is optional: every existing caller and the
+      // three tests above must be unaffected.
+      expect(buildPreSendConsultBody('hello world')).toBe('[PRE-SEND CONSULT] hello world');
+      expect(buildPreSendConsultBody('hello world', null)).toBe('[PRE-SEND CONSULT] hello world');
+      expect(buildPreSendConsultBody('hello world', undefined)).toBe('[PRE-SEND CONSULT] hello world');
+      expect(buildPreSendConsultBody('hello world', {})).toBe('[PRE-SEND CONSULT] hello world');
+    });
+
+    it('still preserves the full body when an addressee is present (no truncation regression)', () => {
+      // The QF-20260720-729 contract must survive the new header — the header sits INSIDE capBody
+      // for exactly this reason, so it can never be the thing that pushes the tail out.
+      const body = 'x'.repeat(350) + 'VISIBLE_TAIL';
+      const out = buildPreSendConsultBody(body, { role: 'coordinator', sessionId: 'abcdef12' });
+      expect(out).toContain('VISIBLE_TAIL');
+    });
+
+    it('degrades sensibly on a partial addressee rather than emitting undefined', () => {
+      expect(buildPreSendConsultBody('b', { role: 'solomon' })).toContain('solomon');
+      expect(buildPreSendConsultBody('b', { role: 'solomon' })).not.toMatch(/undefined/);
+      expect(buildPreSendConsultBody('b', { sessionId: 'abcdef12' })).not.toMatch(/undefined/);
+      expect(buildPreSendConsultBody('b', 'coordinator')).toContain('coordinator');
+    });
+  });
+
   it('fails LOUD on genuine overflow instead of silently clipping (loss-proof contract)', () => {
     // > 4096-char hard cap => capBody throws BODY_TOO_LONG; the degrade-safe caller fails OPEN
     // (consult skipped) rather than consulting on a misleading fragment.

--- a/tests/unit/adam/presend-consult-lane.test.js
+++ b/tests/unit/adam/presend-consult-lane.test.js
@@ -117,4 +117,38 @@ describe('runPreSendConsultLane — FR-1 non-blocking + FR-2 discriminator', () 
     expect(out.action).toBe('hold-and-surface');
     expect(ledger).toHaveLength(0); // chairman branch deliberately writes no ledger row
   });
+
+  // ── QF-20260727-709 ──────────────────────────────────────────────────────────────────────────
+  // The lane must FORWARD the addressee, not merely tolerate one. Note the default fake above is
+  // `(b) => ...` — single-arg, so it silently discards a second argument. A test written against
+  // that fake would pass whether or not the lane threads the value, which is precisely the shape
+  // of the bug this QF exists to fix. These use a CAPTURING fake instead.
+  it('forwards the resolved addressee into the consult envelope', async () => {
+    const seen = [];
+    const { deps, inserted } = makeDeps({
+      buildPreSendConsultBody: (b, addressee) => {
+        seen.push(addressee);
+        return `[PRE-SEND CONSULT -> ${addressee?.role} ${String(addressee?.sessionId).slice(0, 8)}] ${b}`;
+      },
+    });
+    const addressee = { role: 'coordinator', sessionId: '1449a046-0f83-4b8e-b6f2-ad26510d0c05' };
+    await runPreSendConsultLane({ ...INPUT, addressee }, deps);
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toEqual(addressee);            // the value ARRIVED, not just the parameter slot
+    expect(inserted[0].row.payload.body).toContain('coordinator');
+    expect(inserted[0].row.payload.body).toContain('1449a046');
+  });
+
+  it('omitting the addressee passes undefined rather than inventing one', async () => {
+    // The degrade path: no addressee resolved upstream must not fabricate a plausible-looking one,
+    // because a WRONG addressee is worse than none — it would re-point the pronouns confidently.
+    const seen = [];
+    const { deps } = makeDeps({
+      buildPreSendConsultBody: (b, addressee) => { seen.push(addressee); return `[PRE-SEND CONSULT] ${b}`; },
+    });
+    await runPreSendConsultLane({ ...INPUT }, deps);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toBeNull();
+  });
 });


### PR DESCRIPTION
## The defect

`buildPreSendConsultBody` forwarded the raw body and **nothing else**. The reviewer received second-person prose written to a *different* party, with no field that disambiguates it — so every "you"/"your" silently re-pointed at the reviewer.

**Witnessed live.** An advisory correctly addressed to the coordinator was read by Solomon as crediting **him** with editing SD row descriptions. He is propose-only under CONST-002 and has edited zero rows. His reasoning was sound and his counts were right — he proved non-authorship from his own outbound — but his conclusion was wrong, because the one field that resolves it was never transmitted.

The omission therefore:
1. manufactured a **false governance-violation record** against the oracle,
2. **stripped credit** from the party who actually did the work,
3. burned a consult round-trip while the real send sat at the gate.

**The reviewer cannot self-correct this.** No amount of care recovers a field that was never sent — which is why the fix belongs in the envelope, not in guidance.

## The fix

- `buildPreSendConsultBody(body, addressee)` — optional second arg, emitting `[PRE-SEND CONSULT -> <role> <id-prefix>]` plus an explicit note that second-person pronouns refer to the **addressee**. That note isn't padding: the failure mode was resolving second person to self, and naming the addressee alone still leaves that reading available on a skim.
- Header sits **inside** `capBody`, for the same reason the prefix does (QF-20260720-729) — anything outside the cap can be the thing that gets dropped.
- The lane threads `addressee`; the call site passes the **already-resolved** role and target, so this moves an existing value rather than deriving a new one.
- Omitting the addressee is **byte-identical** to the previous envelope.

## Mutation-verified, not assumed

Reverting the lane to `buildPreSendConsultBody(body)` **kills both new lane tests**.

That check mattered here: the suite's existing fake is `(b) => …` — single-arg, so it silently discards a second argument. A test written against it would have passed whether or not the value was threaded, **which is the same shape as the bug being fixed**. The new tests use a *capturing* fake and assert the addressee **arrived**, not merely that the parameter slot exists.

The degrade path is pinned too: no addressee passes `null` rather than inventing a plausible one — a **wrong** addressee is worse than none, because it would re-point the pronouns confidently.

## Testing

**471 passed across 35 adam suites** (17 in the two directly-touched files).

## Raised, deliberately out of scope

This is the **second** loss through this one function — QF-20260720-729 was a `.slice(0, 300)` that hid the very tail Solomon was asked to check (recurred ~9×). Two different fields lost through the same envelope suggests it should carry the full send context rather than be patched per-field. Flagged for the owning SD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
