### PR TITLE
fix(QF-20260727-488): make defaultStartupPrompt role-aware on every spawn path

### DIFF
--- a/lib/fleet/build-session-launch.cjs
+++ b/lib/fleet/build-session-launch.cjs
@@ -232,6 +232,40 @@ function buildSessionLaunch(spec = {}, opts = {}) {
       }
     }
 
+    // F2 — STRUCTURAL BACKSTOP, BESIDE F1: A NON-WORKER ROLE MUST NEVER RECEIVE THE WORKER
+    // DIRECTIVE, ENFORCED HERE (QF-20260727-488).
+    //
+    // role-startup-prompt.js's mapping was consumed at exactly ONE call site (the add-session
+    // route's resolveRoleSpawnOpts spread) -- every other spawner (spawn-control.js
+    // spawnReplacement, behind restart()/relaunchUnderProfile(); reboot-respawn-runner.js) fell
+    // through to callsign-namespace selection, which classifies any non-canary callsign as
+    // 'worker' and hands back the 1406-byte claiming directive regardless of the ROLE the caller
+    // declared. A privileged session that receives it does not idle -- it starts claiming DRAFT
+    // SDs unattended, the same hazard class F1 exists to prevent, one field over (role instead of
+    // callsign).
+    //
+    // defaultStartupPrompt (spawn-control.js, reboot-respawn-runner.js) is now role-aware and
+    // resolves the role's own directive BEFORE falling through to callsign-namespace selection, so
+    // this combination should NEVER occur on any current path -- that is what makes this a safe
+    // tripwire rather than a behaviour change. It exists so a FOURTH spawner inherits the
+    // guarantee instead of having to remember it, same lesson F1 already documents above.
+    //
+    // Deliberately keyed on ROLE, never on callsign alone -- the inverse of F1, and just as
+    // deliberately NOT keyed on role alone for the DECISION upstream in defaultStartupPrompt (see
+    // that function's header): canaries ARE role='worker', so this check only ever fires for a
+    // role that is NOT 'worker', which a canary spawn never declares.
+    if (role && role !== 'worker') {
+      const { FLEET_WORKER_STARTUP_PROMPT } = require('../coordinator/coordination-events.cjs');
+      const { isSpawnableRole } = requireRoleStartupPrompt();
+      if (isSpawnableRole(role) && String(startupPrompt) === FLEET_WORKER_STARTUP_PROMPT) {
+        throw new LaunchResolveError(
+          `refusing to launch role ${JSON.stringify(String(role))} with the WORKER directive. A privileged `
+          + 'role that receives the claiming directive starts claiming DRAFT SDs unattended '
+          + '(QF-20260727-488). Select the prompt via resolveRoleSpawnOpts / defaultStartupPrompt(callsign, role).',
+        );
+      }
+    }
+
     // SEC-2 — VALIDATE ON BOTH BRANCHES. writeStartupPromptFile enforces a filename charset on
     // sessionId, but the missing-root branch below built the path INLINE with no check at all, and
     // sessionId can be a DB-sourced resumeUuid (which, unlike the minted id, is not isUuid-tested).
@@ -278,6 +312,13 @@ function requireStartupPromptSelection() {
   // startup-prompt-selection.js is ESM; require() of an ESM file works here because the module has
   // no top-level await and Node's require(esm) support is enabled on this runtime.
   return require('./startup-prompt-selection.js');
+}
+
+/** Seam: kept as a function so tests can stub the ESM import without editing this call site. */
+function requireRoleStartupPrompt() {
+  // role-startup-prompt.js is ESM; require() of an ESM file works here for the same reason
+  // requireStartupPromptSelection's target does (no top-level await, Node's require(esm) enabled).
+  return require('./role-startup-prompt.js');
 }
 
 /** Strict RFC-4122 shape check — the CLI requires a valid UUID and rejects anything else. */

--- a/lib/fleet/reboot-respawn-runner.js
+++ b/lib/fleet/reboot-respawn-runner.js
@@ -45,10 +45,28 @@ async function defaultLogFn(supabase, event) {
  * worker-spawn-executor.cjs launches its workers with. A respawned tab that receives no prompt has
  * nothing to do: it registers, heartbeats once, and exits (ghost), which is precisely what made the
  * respawn leg unverifiable post-hoc. Single source of truth — never re-author the prompt text here.
+ *
+ * QF-20260727-488 — NOW ROLE-AWARE, in this order (do not reorder, do not key on role alone):
+ *   (a) couldBeCanaryCallsign(callsign) -> ALWAYS FIRST, UNCONDITIONALLY WINS. Canaries ARE
+ *       role='worker', so keying selection on role alone would hand every canary the claiming
+ *       directive — startup-prompt-selection.js's own header forbids exactly that.
+ *   (b) role is a known non-worker spawnable role (coordinator/solomon/adam) -> that role's
+ *       directive, via resolveRoleSpawnOpts so the role->prompt map has one owner.
+ *   (c) otherwise -> today's callsign-namespace selection, UNCHANGED.
+ * fleet_desired_slots currently holds only role='worker' rows, so this arm is LATENT today — it
+ * arms the moment a non-worker slot is added, closing the gap before it goes live rather than
+ * after.
  */
-async function defaultStartupPrompt(callsign, logFn) {
+async function defaultStartupPrompt(callsign, role, logFn) {
   const { FLEET_WORKER_STARTUP_PROMPT } = await import('../coordinator/coordination-events.cjs');
-  const { resolveStartupPromptForCallsign } = await import('./startup-prompt-selection.js');
+  const { couldBeCanaryCallsign, resolveStartupPromptForCallsign } = await import('./startup-prompt-selection.js');
+
+  if (!couldBeCanaryCallsign(callsign)) {
+    const { resolveRoleSpawnOpts } = await import('./role-startup-prompt.js');
+    const roleOpts = resolveRoleSpawnOpts(role);
+    if (Object.hasOwn(roleOpts, 'startupPrompt')) return roleOpts.startupPrompt;
+  }
+
   // SD-...-PROMPT-LIBRARY-001-D FR-3: keyed on the CALLSIGN NAMESPACE, so a canary can never be
   // handed the claiming-worker directive. Canary + unidentifiable resolve to null (no prompt) until
   // the canary prompt exists — see resolveStartupPromptForCallsign's header.
@@ -196,9 +214,11 @@ export async function runRebootRespawn(opts = {}) {
     }
 
     // FR-3a: resolve the prompt HERE, where `callsign` is finally in scope.
+    // QF-20260727-488: `role` is threaded in too — it has been in scope since :186, unused by
+    // prompt selection until now.
     const startupPrompt = startupPromptOverridden
       ? startupPromptOverride
-      : await defaultStartupPrompt(callsign, log);
+      : await defaultStartupPrompt(callsign, role, log);
 
     // FR-3: forward opts so the minted --session-id is injectable (uuidFn) rather than only
     // reachable via crypto.randomUUID inside the builder.

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -148,10 +148,30 @@ export function buildLiveSpawnInvocation({ role, callsign, profileDir, resumeUui
  * QF-20260725-757: the canonical keepalive prompt, mirroring reboot-respawn-runner.js's private
  * helper of the same name. Lazy dynamic import keeps this ESM module free of a load-time dependency
  * on the .cjs coordination-events surface (same idiom as the respawn runner).
+ *
+ * QF-20260727-488 — NOW ROLE-AWARE, in this order (do not reorder, do not key on role alone):
+ *   (a) couldBeCanaryCallsign(callsign) -> ALWAYS FIRST, UNCONDITIONALLY WINS. Canaries ARE
+ *       role='worker', so keying selection on role alone would hand every canary the claiming
+ *       directive — startup-prompt-selection.js's own header forbids exactly that.
+ *   (b) role is a known non-worker spawnable role (coordinator/solomon/adam) -> that role's
+ *       directive, via resolveRoleSpawnOpts so the role->prompt map has one owner.
+ *   (c) otherwise -> today's callsign-namespace selection, UNCHANGED.
+ * Before this, only server/routes/fleet-actions.js addSession applied the role mapping (via
+ * resolveRoleSpawnOpts spread into spawn()'s opts). spawnReplacement() (behind restart() and
+ * relaunchUnderProfile()) calls spawn() with the EXISTING session's role but no startupPrompt key,
+ * so this function is the only thing standing between a relaunched coordinator/solomon/adam and the
+ * self-claiming worker /loop.
  */
-async function defaultStartupPrompt(callsign, logFn) {
+async function defaultStartupPrompt(callsign, role, logFn) {
   const { FLEET_WORKER_STARTUP_PROMPT } = await import('../coordinator/coordination-events.cjs');
-  const { resolveStartupPromptForCallsign } = await import('./startup-prompt-selection.js');
+  const { couldBeCanaryCallsign, resolveStartupPromptForCallsign } = await import('./startup-prompt-selection.js');
+
+  if (!couldBeCanaryCallsign(callsign)) {
+    const { resolveRoleSpawnOpts } = await import('./role-startup-prompt.js');
+    const roleOpts = resolveRoleSpawnOpts(role);
+    if (Object.hasOwn(roleOpts, 'startupPrompt')) return roleOpts.startupPrompt;
+  }
+
   // SD-...-PROMPT-LIBRARY-001-D FR-3 — SELECTION IS KEYED ON THE CALLSIGN NAMESPACE.
   //
   // THIS IS THE SECOND OF THE TWO COPIES, AND MISSING IT ARMED THE EXACT HAZARD THIS SD EXISTS TO
@@ -211,7 +231,7 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
   // with no startupPrompt at all, so every session created through the generic spawn verb came up
   // with nothing to do, heartbeat once, and ghosted. Same opt-out semantics as the respawn runner
   // (reboot-respawn-runner.js:137): absent => canonical prompt, explicit null => deliberately none.
-  const startupPrompt = ('startupPrompt' in opts) ? opts.startupPrompt : await defaultStartupPrompt(callsign, log);
+  const startupPrompt = ('startupPrompt' in opts) ? opts.startupPrompt : await defaultStartupPrompt(callsign, role, log);
 
   // ADVERSARIAL-REVIEW NOTE (known, accepted limitation): this dedup check reads liveCallsigns at a
   // point in time with no reservation/lock written before the OS spawn -- two near-simultaneous calls

--- a/tests/unit/fleet/qf-20260727-488-role-aware-default-prompt.test.js
+++ b/tests/unit/fleet/qf-20260727-488-role-aware-default-prompt.test.js
@@ -1,0 +1,171 @@
+/**
+ * QF-20260727-488 — role-to-startup-prompt mapping was applied ONLY at the add-session route
+ * (server/routes/fleet-actions.js addSession, via resolveRoleSpawnOpts(role)). Every OTHER spawn
+ * path — spawn-control.js spawnReplacement() behind restart()/relaunchUnderProfile(), and
+ * reboot-respawn-runner.js — fell through to callsign-namespace selection, which classifies any
+ * non-canary callsign as 'worker' and hands back the 1406-byte claiming-worker directive
+ * regardless of the ROLE the caller declared. relaunching a coordinator/solomon/adam session
+ * therefore handed it the self-claiming /loop.
+ *
+ * THE FIX taught defaultStartupPrompt (spawn-control.js, reboot-respawn-runner.js) this order:
+ *   (a) couldBeCanaryCallsign(callsign) -> canary prompt or null. ALWAYS FIRST, UNCONDITIONALLY
+ *       WINS — canaries ARE role='worker', so role-keying alone would hand every canary the
+ *       claiming directive (startup-prompt-selection.js's own header forbids exactly that).
+ *   (b) role is a known non-worker spawnable role (coordinator/solomon/adam) -> that role's
+ *       directive.
+ *   (c) otherwise -> today's callsign-namespace selection, unchanged.
+ * Plus a STRUCTURAL BACKSTOP in buildSessionLaunch (beside the existing canary guard): throw
+ * LaunchResolveError when spec.role is a non-worker spawnable role AND startupPrompt is
+ * byte-equal to the worker directive — the single funnel every spawner passes through, so a
+ * fourth spawner inherits the guarantee.
+ *
+ * This suite pins the invariant that forbids role-alone keying (a canary must win regardless of
+ * what role a caller declares) alongside the positive case (a declared non-worker role gets its
+ * own directive on every current path), plus the backstop tripwire itself.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const require = createRequire(import.meta.url);
+const { FLEET_WORKER_STARTUP_PROMPT } = require('../../../lib/coordinator/coordination-events.cjs');
+
+const tmpCwd = () => fs.mkdtempSync(path.join(os.tmpdir(), 'qf488-'));
+
+describe('spawn-control.spawn() — defaultStartupPrompt is role-aware (QF-20260727-488, SITE 1)', () => {
+  const { spawn } = require('../../../lib/fleet/spawn-control.js');
+
+  /** Resolves the actual bytes delivered for a given role/callsign, or null if none. */
+  const promptFor = async (role, callsign) => {
+    const { invocation } = await spawn({ role, callsign }, { live: false, cwd: tmpCwd() });
+    if (!invocation.promptFilePath || !fs.existsSync(invocation.promptFilePath)) return null;
+    return fs.readFileSync(invocation.promptFilePath, 'utf8');
+  };
+
+  it('a canary callsign with role="worker" still gets the CANARY arm, never the worker directive', async () => {
+    expect(await promptFor('worker', 'Canary-pilot')).not.toBe(FLEET_WORKER_STARTUP_PROMPT);
+  });
+
+  it('a canary callsign gets the CANARY arm even when role="coordinator" — canary wins unconditionally', async () => {
+    // THE invariant this QF forbids violating: role-alone keying would deliver '/coordinator
+    // start' here. It must not, regardless of what role the caller (wrongly or rightly) declares.
+    const prompt = await promptFor('coordinator', 'Canary-pilot');
+    expect(prompt).not.toBe(FLEET_WORKER_STARTUP_PROMPT);
+    expect(prompt).not.toBe('/coordinator start');
+  });
+
+  it('role="coordinator" with a NON-canary callsign gets the coordinator directive, not the worker one', async () => {
+    expect(await promptFor('coordinator', 'Alpha-1')).toBe('/coordinator start');
+  });
+
+  it('role="solomon" with a NON-canary callsign gets the solomon directive', async () => {
+    expect(await promptFor('solomon', 'Alpha-2')).toBe('/solomon');
+  });
+
+  it('role="adam" with a NON-canary callsign gets the adam directive', async () => {
+    expect(await promptFor('adam', 'Alpha-3')).toBe('/adam');
+  });
+
+  it('CONTROL: a plain worker callsign with role="worker" (or no role) still gets today\'s result, unchanged', async () => {
+    expect(await promptFor('worker', 'Charlie')).toBe(FLEET_WORKER_STARTUP_PROMPT);
+    expect(await promptFor(undefined, 'Charlie')).toBe(FLEET_WORKER_STARTUP_PROMPT);
+  });
+});
+
+describe('reboot-respawn-runner — defaultStartupPrompt is role-aware (QF-20260727-488, SITE 2)', () => {
+  const { runRebootRespawn } = require('../../../lib/fleet/reboot-respawn-runner.js');
+
+  /** Captures the {callsign, role, startupPrompt} the runner resolved for each desired slot. */
+  const runFor = async (slots) => {
+    const seen = [];
+    await runRebootRespawn({
+      loadFn: async () => slots,
+      rosterFn: (s) => s.map((x) => x.name),
+      buildInvocationFn: ({ callsign, role, startupPrompt }) => {
+        seen.push({ callsign, role, startupPrompt });
+        return { program: 'wt.exe', args: [], env: {}, sessionId: 'sid' };
+      },
+      live: false, log: () => {}, logFn: () => {},
+    });
+    return seen;
+  };
+
+  it('a canary slot with role="worker" never gets the worker directive', async () => {
+    const [canary] = await runFor([{ name: 'Canary-pilot', role: 'worker' }]);
+    expect(canary.startupPrompt).not.toBe(FLEET_WORKER_STARTUP_PROMPT);
+  });
+
+  it('a canary slot gets the CANARY arm even when role="coordinator" — canary wins unconditionally', async () => {
+    const [canary] = await runFor([{ name: 'Canary-pilot', role: 'coordinator' }]);
+    expect(canary.startupPrompt).not.toBe(FLEET_WORKER_STARTUP_PROMPT);
+    expect(canary.startupPrompt).not.toBe('/coordinator start');
+  });
+
+  it('a coordinator slot with a NON-canary name gets the coordinator directive (LATENT until a non-worker slot exists)', async () => {
+    const [coord] = await runFor([{ name: 'Coord-1', role: 'coordinator' }]);
+    expect(coord.startupPrompt).toBe('/coordinator start');
+  });
+
+  it('solomon / adam slots with NON-canary names get their own directives', async () => {
+    const [solomon, adam] = await runFor([
+      { name: 'Sol-1', role: 'solomon' },
+      { name: 'Adam-1', role: 'adam' },
+    ]);
+    expect(solomon.startupPrompt).toBe('/solomon');
+    expect(adam.startupPrompt).toBe('/adam');
+  });
+
+  it('CONTROL: a mixed roster still delivers the unchanged worker directive to plain workers', async () => {
+    const [worker, noRole] = await runFor([
+      { name: 'Worker-1', role: 'worker' },
+      { name: 'Worker-2', role: null }, // runner defaults slot.role || 'worker'
+    ]);
+    expect(worker.startupPrompt).toBe(FLEET_WORKER_STARTUP_PROMPT);
+    expect(noRole.startupPrompt).toBe(FLEET_WORKER_STARTUP_PROMPT);
+  });
+});
+
+describe('buildSessionLaunch F2 — structural backstop refuses a non-worker role carrying the worker directive', () => {
+  const { buildSessionLaunch, LaunchResolveError } = require('../../../lib/fleet/build-session-launch.cjs');
+
+  it('THROWS for role="coordinator" + the byte-equal worker directive', () => {
+    expect(() => buildSessionLaunch({
+      role: 'coordinator', callsign: 'Alpha-1', cwd: tmpCwd(), startupPrompt: FLEET_WORKER_STARTUP_PROMPT,
+    })).toThrow(LaunchResolveError);
+  });
+
+  it('THROWS for role="solomon" and role="adam" too', () => {
+    expect(() => buildSessionLaunch({
+      role: 'solomon', callsign: 'Alpha-2', cwd: tmpCwd(), startupPrompt: FLEET_WORKER_STARTUP_PROMPT,
+    })).toThrow(LaunchResolveError);
+    expect(() => buildSessionLaunch({
+      role: 'adam', callsign: 'Alpha-3', cwd: tmpCwd(), startupPrompt: FLEET_WORKER_STARTUP_PROMPT,
+    })).toThrow(LaunchResolveError);
+  });
+
+  it('CONTROL: does NOT throw for a legitimate worker spawn carrying the worker directive', () => {
+    expect(() => buildSessionLaunch({
+      role: 'worker', callsign: 'Alpha-4', cwd: tmpCwd(), startupPrompt: FLEET_WORKER_STARTUP_PROMPT,
+    })).not.toThrow();
+    // Absent role defaults to 'worker' throughout this module — must not throw either.
+    expect(() => buildSessionLaunch({
+      callsign: 'Alpha-5', cwd: tmpCwd(), startupPrompt: FLEET_WORKER_STARTUP_PROMPT,
+    })).not.toThrow();
+  });
+
+  it('CONTROL: does NOT throw when a non-worker role carries its OWN directive', () => {
+    expect(() => buildSessionLaunch({
+      role: 'coordinator', callsign: 'Alpha-6', cwd: tmpCwd(), startupPrompt: '/coordinator start',
+    })).not.toThrow();
+  });
+
+  it('CONTROL: does NOT throw for an unknown/non-spawnable role, even carrying the worker directive', () => {
+    // The backstop is keyed on isSpawnableRole, not "any string that is not literally worker" —
+    // narrower than that would risk refusing a legitimate future role before it is allowlisted.
+    expect(() => buildSessionLaunch({
+      role: 'not-a-real-role', callsign: 'Alpha-7', cwd: tmpCwd(), startupPrompt: FLEET_WORKER_STARTUP_PROMPT,
+    })).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

`lib/fleet/role-startup-prompt.js`'s role→directive mapping (`resolveRoleSpawnOpts`) was consumed at exactly **one** call site — `server/routes/fleet-actions.js` `addSession`. Every other spawn path fell through to callsign-namespace selection, which classifies any non-canary callsign as `'worker'` and hands back the 1406-byte claiming-worker directive **regardless of the role the caller declared**:

- `spawn-control.js` `spawnReplacement()` (behind `restart()`/`relaunchUnderProfile()`) reads `role` off the *existing* session but passes no `startupPrompt` key, so `spawn():214` fell to `defaultStartupPrompt(callsign)` → worker directive. **Live-reachable**: relaunching a coordinator/solomon/adam session from the Sessions page handed it the self-claiming worker `/loop`.
- `reboot-respawn-runner.js:199-205` resolved its prompt from callsign alone, ignoring `slot.role` entirely. **Latent today** (`fleet_desired_slots` holds only `role='worker'` rows) but arms the moment a non-worker slot is added.

## Fix

Teach `defaultStartupPrompt` (duplicated in both files) a role-aware order — **exactly** as prescribed by the QF, no substitutions:

1. `couldBeCanaryCallsign(callsign)` → canary arm. **Always first, unconditional.** Canaries ARE `role='worker'`, so keying selection on role alone would hand every canary the claiming directive — `startup-prompt-selection.js`'s own header forbids exactly that, so this branch cannot be reordered or removed.
2. `role` is a known non-worker spawnable role (`coordinator`/`solomon`/`adam`) → that role's directive, via the existing `resolveRoleSpawnOpts` so the role→prompt map keeps one owner.
3. Otherwise → today's callsign-namespace selection, unchanged.

Then thread `role` into the two callers that already had it in scope (`spawn():214`, `reboot-respawn-runner.js:199`).

Per-call-site allowlisting is exactly what produced this N-1-of-N gap in the first place, so the fix lives in the shared default-resolution helper rather than at each new spawner (per `build-session-launch.cjs`'s own documented lesson for the canary guard).

**Structural backstop**: `buildSessionLaunch` — the single funnel every spawner passes through — now throws `LaunchResolveError` when `spec.role` is a non-worker spawnable role AND `startupPrompt` is byte-equal to the worker directive, placed beside the existing canary guard (F1). With step 2 above in place this should never fire on any current path; it exists purely so a fourth spawner inherits the guarantee instead of having to remember it.

**Hard constraint honored**: prompt selection is never keyed on role alone — the canary check runs first and unconditionally in every arm, so a canary spawned as `role='coordinator'` still gets the canary arm, never `/coordinator start`.

## Files changed

- `lib/fleet/spawn-control.js` — `defaultStartupPrompt(callsign, role, logFn)`, threaded into `spawn()`
- `lib/fleet/reboot-respawn-runner.js` — `defaultStartupPrompt(callsign, role, logFn)`, threaded into the per-slot loop
- `lib/fleet/build-session-launch.cjs` — F2 structural backstop beside the existing F1 canary guard
- `tests/unit/fleet/qf-20260727-488-role-aware-default-prompt.test.js` — new suite (16 cases)

## Test plan

- [x] New suite: `tests/unit/fleet/qf-20260727-488-role-aware-default-prompt.test.js` — 16/16 passing. Covers: canary + role='worker' still gets canary arm; canary + role='coordinator' still gets canary arm (canary wins unconditionally); role=coordinator/solomon/adam + ordinary callsign gets that role's directive on both spawn sites; plain worker/no-role control arm unchanged; `buildSessionLaunch` throws for coordinator/solomon/adam + worker directive, does not throw for a legitimate worker spawn, a role's own directive, or an unknown/non-spawnable role.
- [x] Existing suites covering the touched files, run together: `role-startup-prompt.test.js`, `build-session-launch.test.js`, `canary-never-gets-worker-directive.test.js`, `spawn-control.test.js`, `spawn-control-resume.test.js`, `reboot-respawn-runner.test.js`, `startup-prompt-selection.test.js`, `launch-contract-conformance.test.js`, `worker-spawn-executor.test.js`, plus the new suite — **188/189 passing**. The one failure (`spawn-control.test.js` FR-6, "restarting a profile-stamped session with NO profiles dir configured FAILS LOUD") reproduces byte-identical on the unmodified `main` baseline (confirmed via `git stash`) — a pre-existing environment leak where this machine's `.env` sets `FLEET_ACCOUNT_PROFILES_DIR`, unrelated to this change.
- [x] Full `tests/unit/fleet/` sweep: 1315/1318 passing, same 3 pre-existing environment-dependent failures reproduced on baseline (2 more in `cp3-restart-relaunch-live-flag-propagation.test.js`, same root cause).

Not merging and not running `complete-quick-fix.js` per instructions — scope attestation and merge are being done separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)