### PR TITLE
fix(QF-20260727-589): chairman-SMS gate held 100% of sends on two live paths, and holds were recorded as delivered

### DIFF
--- a/lib/chairman/record-pending-decision.mjs
+++ b/lib/chairman/record-pending-decision.mjs
@@ -211,7 +211,10 @@ export async function escalateChairmanDecision(supabase, decisionId, { spawn = d
     // caller that wires the hardening tree in. Best-effort + isolated: a rubric-held decision or a
     // gate error NEVER affects the email escalation above (already fired). Stamped into the return
     // so callers/tests can observe the gated-SMS outcome.
-    const smsGate = await gatedSms(merged, decisionId, {});
+    // QF-20260727-589 (b): pass a REAL context. This was `{}`, which resolved to
+    // opts.context||{} inside attemptGatedChairmanSms, so the rubric's etHour() threw and the
+    // gate returned held/gate_unavailable on EVERY escalation regardless of clock.
+    const smsGate = await gatedSms(merged, decisionId, { context: { now: Date.now() } });
 
     const base = isDigest ? { escalated: true, digest: true } : { escalated: true };
     return { ...base, smsGate };

--- a/lib/comms/adam-outbound/away-bridge/index.js
+++ b/lib/comms/adam-outbound/away-bridge/index.js
@@ -73,9 +73,31 @@ export async function processOwedDecisions(context = {}, opts = {}) {
       continue;
     }
     // Re-surface 'Still pending:' via the sender, then mark (idempotency).
+    //
+    // QF-20260727-589 (c): OBSERVE THE SENDER VERDICT. This previously discarded the sender's
+    // return value and then called markResurfaced() + reported action:'resurfaced'
+    // unconditionally. Combined with the empty-context bug (every send held), that meant an
+    // owed decision burned all K re-surfaces while ZERO texts were sent, and the scheduler
+    // reported each one as delivered. Silent failure reported as success, on the one channel
+    // where nobody downstream can notice — because the person who would notice is the person
+    // not being told. A held send must not consume a re-surface.
+    let sendResult;
     if (typeof sender === 'function') {
       const body = `Still pending: ${o.message && o.message.body ? o.message.body : ''}`.trim();
-      await sender({ ...(o.message || {}), body });
+      sendResult = await sender({ ...(o.message || {}), body });
+    }
+    // Treat ONLY an explicit hold as a hold. A sender that returns nothing (legacy shape) keeps
+    // its previous meaning, so this cannot silently start withholding marks from existing
+    // callers — the change is additive, not a redefinition of "no news".
+    const held = !!(sendResult && typeof sendResult === 'object'
+      && (sendResult.held === true || sendResult.sent === false));
+    if (held) {
+      results.push({
+        owedId: o.owedId,
+        action: 'resurface_held',
+        reason: sendResult.reason || 'held',
+      });
+      continue; // NOT marked — the re-surface did not happen, so it must not be spent.
     }
     if (typeof owedStore.markResurfaced === 'function') await owedStore.markResurfaced(o.owedId);
     results.push({ owedId: o.owedId, action: 'resurfaced' });

--- a/lib/comms/adam-outbound/decision-scheduler/index.js
+++ b/lib/comms/adam-outbound/decision-scheduler/index.js
@@ -121,9 +121,14 @@ export async function resolvePresenceContext(supabase) {
  */
 function buildSender() {
   return async (message) => {
-    await sendChairmanSMS(
+    // QF-20260727-589 (b): pass a REAL context. This was `{}`, and the rubric's etHour()
+    // throws without a usable `now`, so the gate returned held/gate_unavailable on EVERY
+    // invocation regardless of clock — 100% of sends on this path, time-independently.
+    // (c): RETURN the gate verdict instead of discarding it. The away-bridge needs to see a
+    // hold; swallowing it here is what let a held send be recorded as delivered.
+    return sendChairmanSMS(
       { decisionId: message.decisionId, body: message.body, type: 'decision' },
-      {},
+      { now: Date.now() },
       {}
     );
   };

--- a/lib/comms/adam-outbound/rubric-engine/lint.js
+++ b/lib/comms/adam-outbound/rubric-engine/lint.js
@@ -57,8 +57,18 @@ export function effectiveType(message = {}) {
  */
 export function etHour(context = {}) {
   if (Number.isInteger(context.nowHourET)) return context.nowHourET;
-  const d = context.now instanceof Date ? context.now : null;
-  if (!d) throw new Error('rubric-engine lint: quiet-hours needs context.nowHourET or context.now (Date)');
+  // QF-20260727-589 (a): accept a FINITE EPOCH NUMBER as well as a Date.
+  // away-bridge/index.js:35 and decision-scheduler/index.js:101 both treat `now` as an epoch
+  // number (Date.now() / Number.isFinite), while this function required a Date instance. That
+  // TYPE-CONVENTION MISMATCH meant even forwarding those modules' own context would still have
+  // thrown — verified by repro: etHour({now: Date.now()}) threw before this change. Widening
+  // here makes one convention serve both sides rather than forcing every caller to remember
+  // which flavour of "now" this particular module wants.
+  // Still fail-closed on anything else: the engine must never GUESS quiet-hours.
+  const d = context.now instanceof Date ? context.now
+    : (typeof context.now === 'number' && Number.isFinite(context.now)) ? new Date(context.now)
+      : null;
+  if (!d) throw new Error('rubric-engine lint: quiet-hours needs context.nowHourET, or context.now as a Date or finite epoch number');
   const hourStr = new Intl.DateTimeFormat('en-US', {
     timeZone: 'America/New_York', hour: '2-digit', hour12: false,
   }).format(d);

--- a/tests/unit/comms/adam-outbound/gate-context-and-held-resurface.test.js
+++ b/tests/unit/comms/adam-outbound/gate-context-and-held-resurface.test.js
@@ -1,0 +1,125 @@
+/**
+ * QF-20260727-589 — the chairman-SMS gate held 100% of sends on two live paths, and the
+ * away-bridge recorded those holds as delivered.
+ *
+ * Two defects, both on the chairman notification path:
+ *   (1) TYPE-CONVENTION MISMATCH. etHour() accepted only context.nowHourET (integer) or
+ *       context.now (Date). away-bridge and decision-scheduler both treat `now` as an epoch
+ *       NUMBER, and the two live call sites passed a literal `{}`. So the rubric threw
+ *       unconditionally and the gate returned held/gate_unavailable on EVERY invocation,
+ *       time-independently. Merely forwarding the schedulers' own context would ALSO have
+ *       thrown — that is why widening etHour is the fix, not just plumbing.
+ *   (2) SILENT FAILURE REPORTED AS SUCCESS. away-bridge discarded the sender's return value,
+ *       then called markResurfaced() and reported action:'resurfaced' regardless. An owed
+ *       decision therefore burned all K re-surfaces while zero texts were sent, and the
+ *       K-escalation was reached having reported K successful notifications.
+ *
+ * The coordinator made fixing (2) a BINDING condition of this row: restoring sends alone
+ * would leave a path that lies about outcomes the next time anything holds a send.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { etHour, inQuietHours } from '../../../../lib/comms/adam-outbound/rubric-engine/lint.js';
+import { processOwedDecisions } from '../../../../lib/comms/adam-outbound/away-bridge/index.js';
+
+// ── (a) etHour accepts the epoch-number convention ────────────────────────────
+describe('QF-20260727-589 (a) — etHour accepts a finite epoch number', () => {
+  const FIXED = Date.parse('2026-07-27T16:00:00Z'); // 12:00 ET (EDT)
+
+  it('accepts an epoch NUMBER — the convention away-bridge/decision-scheduler already use', () => {
+    // Threw before this change; this is the assertion that fails on the pre-fix code.
+    expect(etHour({ now: FIXED })).toBe(12);
+  });
+
+  it('still accepts a Date instance (unchanged contract)', () => {
+    expect(etHour({ now: new Date(FIXED) })).toBe(12);
+  });
+
+  it('still prefers an explicit nowHourET (deterministic tests keep winning)', () => {
+    expect(etHour({ nowHourET: 3, now: FIXED })).toBe(3);
+  });
+
+  it('epoch number and Date agree, so the two conventions cannot drift apart', () => {
+    expect(etHour({ now: FIXED })).toBe(etHour({ now: new Date(FIXED) }));
+  });
+
+  it('STILL FAILS CLOSED on an unusable now — the engine must never guess quiet-hours', () => {
+    for (const bad of [{}, { now: null }, { now: 'today' }, { now: NaN }, { now: Infinity }]) {
+      expect(() => etHour(bad)).toThrow(/quiet-hours needs/);
+    }
+  });
+
+  it('quiet-hours evaluates correctly from an epoch number (the derived consumer)', () => {
+    // 02:00 ET is inside the 22:00-05:59 window; 12:00 ET is outside.
+    expect(inQuietHours({ now: Date.parse('2026-07-27T06:00:00Z') })).toBe(true);
+    expect(inQuietHours({ now: FIXED })).toBe(false);
+  });
+});
+
+// ── (c) a HELD send must not be recorded as resurfaced ────────────────────────
+describe('QF-20260727-589 (c) — away-bridge observes the sender verdict', () => {
+  // isAway() derives presence from (now - lastInputAt) > awayThresholdMs, both finite NUMBERS —
+  // note this module's epoch-number convention, which is the same one etHour now accepts.
+  const NOW = Date.parse('2026-07-27T16:00:00Z');
+  const AWAY = { now: NOW, lastInputAt: NOW - (60 * 60 * 1000), awayThresholdMs: 5 * 60 * 1000 };
+
+  function makeOwedStore(owed) {
+    return {
+      getOwedDecisions: vi.fn(async () => owed),
+      markResurfaced: vi.fn(async () => {}),
+    };
+  }
+  const owedRow = { owedId: 'o1', message: { body: 'Approve X?', decisionId: 'd1' }, resurfaceCount: 0 };
+
+  it('does NOT mark resurfaced when the gate HELD the send', async () => {
+    const owedStore = makeOwedStore([{ ...owedRow }]);
+    const sender = vi.fn(async () => ({ sent: false, held: true, reason: 'gate_unavailable' }));
+
+    const results = await processOwedDecisions(AWAY, { owedStore, sender, K: 3 });
+
+    expect(sender).toHaveBeenCalledTimes(1);
+    // THE POINT: the re-surface was not spent on a text nobody received.
+    expect(owedStore.markResurfaced).not.toHaveBeenCalled();
+    expect(results).toEqual([{ owedId: 'o1', action: 'resurface_held', reason: 'gate_unavailable' }]);
+  });
+
+  it('treats sent:false as held even without an explicit held flag', async () => {
+    const owedStore = makeOwedStore([{ ...owedRow }]);
+    const sender = vi.fn(async () => ({ sent: false, reason: 'blocked' }));
+    const results = await processOwedDecisions(AWAY, { owedStore, sender, K: 3 });
+    expect(owedStore.markResurfaced).not.toHaveBeenCalled();
+    expect(results[0].action).toBe('resurface_held');
+  });
+
+  it('DOES mark resurfaced on a successful send (the happy path is unchanged)', async () => {
+    const owedStore = makeOwedStore([{ ...owedRow }]);
+    const sender = vi.fn(async () => ({ sent: true, held: false }));
+    const results = await processOwedDecisions(AWAY, { owedStore, sender, K: 3 });
+    expect(owedStore.markResurfaced).toHaveBeenCalledWith('o1');
+    expect(results).toEqual([{ owedId: 'o1', action: 'resurfaced' }]);
+  });
+
+  it('a legacy sender returning nothing keeps its previous meaning (additive, not a redefinition)', async () => {
+    const owedStore = makeOwedStore([{ ...owedRow }]);
+    const sender = vi.fn(async () => undefined);
+    const results = await processOwedDecisions(AWAY, { owedStore, sender, K: 3 });
+    expect(owedStore.markResurfaced).toHaveBeenCalledWith('o1');
+    expect(results[0].action).toBe('resurfaced');
+  });
+
+  it('THE COMPOUND FAILURE: K held sends must not silently spend all K re-surfaces', async () => {
+    // Pre-fix, each held send still incremented the count, so an owed decision reached the
+    // K-escalation having reported K deliveries while the chairman received nothing.
+    const sender = vi.fn(async () => ({ sent: false, held: true, reason: 'gate_unavailable' }));
+    let count = 0;
+    const owedStore = {
+      getOwedDecisions: vi.fn(async () => [{ ...owedRow, resurfaceCount: count }]),
+      markResurfaced: vi.fn(async () => { count += 1; }),
+    };
+    for (let i = 0; i < 3; i++) {
+      await processOwedDecisions(AWAY, { owedStore, sender, K: 3 });
+    }
+    expect(sender).toHaveBeenCalledTimes(3);
+    expect(owedStore.markResurfaced).not.toHaveBeenCalled();
+    expect(count).toBe(0); // no re-surface was consumed by an undelivered text
+  });
+});


### PR DESCRIPTION
## Summary

Two defects on the chairman notification path. The coordinator made fixing the **second** a binding condition of this row — and was right to: restoring sends alone would leave a path that lies about outcomes the next time anything holds a send.

Reproduced before fixing, all confirmed against pre-change source:

| Probe | Pre-change |
|---|---|
| `etHour({})` | **throws** |
| `etHour({now: Date.now()})` | **throws** — epoch number rejected |
| `etHour({now: new Date()})` | ok |
| `buildSender` | `await sendChairmanSMS(msg, {}, {})` — empty ctx, return discarded |
| `record-pending-decision:214` | `gatedSms(merged, decisionId, {})` — empty opts |
| away-bridge | **0** occurrences of any verdict observation |

### (a) Type-convention mismatch — the actual root cause

`etHour` accepted only `nowHourET` (integer) or `now` (Date), while `away-bridge:35` and `decision-scheduler:101` both treat `now` as an epoch **number**. So merely forwarding those modules' own context would **still** have thrown — plumbing alone was never sufficient. `etHour` now also accepts a finite epoch number, so one convention serves both sides. It still **fails closed** on anything unusable (`{}`, `null`, `'today'`, `NaN`, `Infinity`) — the engine must never guess quiet-hours.

### (b) Real context at both live call sites

Before, the gate returned `held/gate_unavailable` on **every** invocation regardless of clock — 100% of sends, time-independently — on the cron-driven away-bridge re-surface sender and the escalation path.

### (c) The binding half — silent failure reported as success

away-bridge discarded the sender's return, then called `markResurfaced()` and reported `action:'resurfaced'` unconditionally. Combined with (a)/(b), an owed decision **burned all K re-surfaces while zero texts were sent**, and the K-escalation was reached having reported K successful notifications.

It now observes the verdict, reports `action:'resurface_held'` with the reason, and does not spend a re-surface on a text nobody received. `buildSender` also **returns** the gate result rather than awaiting-and-discarding it — without that the bridge would have had nothing to observe.

Deliberately conservative: only an explicit hold (`held===true` or `sent===false`) counts. A legacy sender returning `undefined` keeps its previous meaning, so this is additive rather than a redefinition of "no news".

## Why this is rated above its tier

Everything else dispatched today fails **loudly**. This one failed **green**, on the one channel where nobody downstream can notice — because the person who would notice is the person not being told.

## Test plan

- [x] Epoch number accepted; Date and `nowHourET` unchanged; epoch and Date agree
- [x] **Still fails closed** on `{}` / `null` / `'today'` / `NaN` / `Infinity`
- [x] Quiet-hours evaluates correctly from an epoch number
- [x] Held send → **not** marked resurfaced, reports `resurface_held` + reason
- [x] `sent:false` without an explicit flag also treated as held
- [x] Happy path unchanged; legacy `undefined` sender unchanged
- [x] **Compound case**: K held sends consume **zero** re-surfaces
- [x] 28/28 adam-outbound; 317/317 across `tests/unit/comms` + `tests/unit/chairman` + the outbound gate suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)