### PR TITLE
feat(QF-20260727-982): an endorsement chain is not evidence — a mechanism claim must cite its reader

### DIFF
--- a/scripts/modules/handoff/executors/lead-to-plan/gates/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/index.js
@@ -111,3 +111,7 @@ export {
   resolveEffectiveMinScore,
   createVerifierParityGate
 } from './verifier-parity.js';
+
+// QF-20260727-982: an endorsement chain is not evidence — a spine naming a file+function
+// must name who read it and at what file:line.
+export { createMechanismClaimVerifierGate, validateMechanismClaims } from './mechanism-claim-verifier.js';

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/mechanism-claim-verifier.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/mechanism-claim-verifier.js
@@ -1,0 +1,162 @@
+/**
+ * Mechanism-Claim Verifier Gate for LEAD-TO-PLAN (SD acceptance).
+ * QF-20260727-982.
+ *
+ * THE FAILURE THIS EXISTS FOR — an endorsement chain that never became evidence. On 2026-07-27 a
+ * worker observed a real symptom (an EPERM reap leaving an orphan worktree directory) and offered
+ * a mechanism. The coordinator propagated it verbatim, twice. Adam generalised it into a law —
+ * "the quota ratchets one direction only, so every EPERM reap permanently burns a slot". Solomon
+ * endorsed it. Four parties, four rounds, and confidence rose at every step WHILE THE NUMBER OF
+ * PEOPLE WHO HAD READ lib/worktree-quota.js STAYED AT ZERO.
+ *
+ * The mechanism was backwards. countActiveWorktrees returns listActiveWorktrees().length — git
+ * REGISTRATIONS, not directories — and its own docblock says so outright. An orphan husk consumes
+ * no quota slot at all. What finally broke the claim was not more review; it was someone needing
+ * the number for an unrelated reason and opening the file.
+ *
+ * WHY IT IS SELF-SEALING, which is the part this gate is built against: by the time the claim
+ * reached the SD spine it carried FOUR ENDORSEMENTS AND NO CITATIONS, and that combination makes
+ * a claim LESS likely to be checked, not more — a reader sees consensus and reasonably economises.
+ * Review converted one party's claim into four parties' conviction. Agreement among parties who
+ * have all read the same nothing is worth nothing.
+ *
+ * DESIGN CONSTRAINTS TAKEN VERBATIM FROM THE FILED SCOPE:
+ *   - Enforced where an SD is ACCEPTED, not where it is authored. Authoring-time nags are advice;
+ *     acceptance is where the record becomes load-bearing.
+ *   - Requires a NAME plus a FILE:LINE, never a boolean. "A boolean is a convention with extra
+ *     steps and decays the way a lint decays" — anyone can set true; almost nobody will invent a
+ *     plausible file:line for a function they did not open.
+ *   - Fires ONLY on spines that actually make a mechanism claim (a file AND a function). An SD
+ *     that asserts no mechanism has nothing to cite, and is untouched.
+ *
+ * Emergency bypass: LEO_DISABLE_MECHANISM_VERIFIER_GATE=1 (mirrors the subagent-evidence gate's
+ * kill-switch convention), so a bad heuristic can never wedge the whole fleet.
+ */
+
+/** A source-file reference: the "names a file" half of a mechanism claim. */
+const FILE_TOKEN = /\b[\w.-]+(?:\/[\w.-]+)*\.(?:js|cjs|mjs|ts|tsx|sql)\b/g;
+/** A call/function reference near that file: the "names a function" half. */
+const FN_TOKEN = /\b[A-Za-z_$][\w$]*\s*\(|\bfunction\s+[A-Za-z_$][\w$]*/;
+/** A citation: path/to/file.ext:LINE. A bare filename is NOT a citation — the line is the proof. */
+const FILE_LINE = /\b[\w.-]+(?:\/[\w.-]+)*\.(?:js|cjs|mjs|ts|tsx|sql):\d+\b/;
+/** Inline prose form, so a verifier can be recorded without a metadata edit. */
+const INLINE_VERIFIER = /verified\s+(?:at|in)\s+([\w.-]+(?:\/[\w.-]+)*\.(?:js|cjs|mjs|ts|tsx|sql):\d+)\s+by\s+([^\n,;.]{2,})/i;
+
+/** The SD spine — the fields a downstream reader treats as settled fact. */
+function spineText(sd = {}) {
+  const parts = [sd.description, sd.scope, sd.rationale];
+  for (const arr of [sd.strategic_objectives, sd.key_changes]) {
+    if (Array.isArray(arr)) parts.push(...arr.map((v) => (typeof v === 'string' ? v : JSON.stringify(v))));
+  }
+  return parts.filter(Boolean).join('\n');
+}
+
+/**
+ * Mechanism claims in the spine: a named file with a named function near it.
+ * Proximity (not whole-text co-occurrence) is deliberate — an SD that mentions a file in one
+ * paragraph and a function in another has not asserted a mechanism about that file.
+ */
+export function findMechanismClaims(text) {
+  const claims = [];
+  for (const m of String(text || '').matchAll(FILE_TOKEN)) {
+    const window = text.slice(Math.max(0, m.index - 200), m.index + m[0].length + 200);
+    if (FN_TOKEN.test(window)) claims.push(m[0]);
+  }
+  return [...new Set(claims)];
+}
+
+/**
+ * Verifiers: who read it, and at what file:line. Both halves required — a name without a citation
+ * is an endorsement (the thing that failed), and a citation without a name has nobody accountable.
+ */
+export function findVerifiers(sd = {}) {
+  const out = [];
+  const records = sd.metadata?.mechanism_verifications;
+  if (Array.isArray(records)) {
+    for (const r of records) {
+      const by = typeof r?.verified_by === 'string' ? r.verified_by.trim() : '';
+      const at = typeof r?.verified_at === 'string' ? r.verified_at.trim() : '';
+      if (by && FILE_LINE.test(at)) out.push({ by, at });
+    }
+  }
+  const inline = INLINE_VERIFIER.exec(spineText(sd));
+  if (inline) out.push({ by: inline[2].trim(), at: inline[1] });
+  return out;
+}
+
+/**
+ * GRANDFATHER CUTOFF — blocking applies to SDs authored from here on, not to the standing backlog.
+ *
+ * MEASURED BEFORE CHOOSING, because "narrow" was an assumption worth testing: of the 28 live SDs in
+ * draft/in_progress/pending_approval, 17 assert a file+function mechanism and ZERO carry a citation.
+ * Shipping this blocking on day one would have wedged 61% of the active population at acceptance —
+ * and a gate that bricks the fleet on the day it lands gets switched off, permanently, which buys
+ * the codebase nothing. The failure mode this targets lives in NEW spines being authored, so that
+ * is where the teeth go; the backlog gets the same message as a warning and can be cited on contact.
+ *
+ * This is a rollout decision, not a softening: the predicate is identical for both cohorts, only the
+ * verdict differs, and the cutoff is a date rather than a flag someone must remember to flip.
+ */
+export const GRANDFATHER_BEFORE = Date.parse('2026-07-28T00:00:00Z');
+
+/** Pure core, so the verdict is testable without a handoff context. */
+export function validateMechanismClaims(sd = {}, { grandfatherBefore = GRANDFATHER_BEFORE } = {}) {
+  const claims = findMechanismClaims(spineText(sd));
+  if (claims.length === 0) {
+    return { pass: true, score: 100, max_score: 100, issues: [], warnings: [], details: { claims: [], verifiers: [] } };
+  }
+  const verifiers = findVerifiers(sd);
+  if (verifiers.length > 0) {
+    return {
+      pass: true, score: 100, max_score: 100, issues: [],
+      warnings: [`${claims.length} mechanism claim(s) cited by ${verifiers.map((v) => `${v.by} @ ${v.at}`).join('; ')}`],
+      details: { claims, verifiers }
+    };
+  }
+  const created = Date.parse(sd.created_at || '');
+  const grandfathered = Number.isFinite(created) && created < grandfatherBefore;
+  const message = `the spine asserts a mechanism about ${claims.join(', ')} with no named verifier. Endorsement is not evidence.`;
+  if (grandfathered) {
+    return {
+      pass: true, score: 50, max_score: 100, issues: [],
+      warnings: [`MECHANISM_CLAIM_UNVERIFIED (pre-existing SD, not blocked): ${message}`],
+      details: { claims, verifiers: [], grandfathered: true }
+    };
+  }
+  return {
+    pass: false, score: 0, max_score: 100,
+    issues: [`MECHANISM_CLAIM_UNVERIFIED: ${message}`],
+    warnings: [], details: { claims, verifiers: [], grandfathered: false }
+  };
+}
+
+/**
+ * Create the mechanism-claim verifier gate.
+ * @returns {Object} Gate configuration
+ */
+export function createMechanismClaimVerifierGate() {
+  return {
+    name: 'GATE_MECHANISM_CLAIM_VERIFIER',
+    validator: async (ctx) => {
+      console.log('\n🔬 GATE: Mechanism-Claim Verifier (a named file+function needs a named reader)');
+      console.log('-'.repeat(50));
+      const v = process.env.LEO_DISABLE_MECHANISM_VERIFIER_GATE;
+      if (v === '1' || String(v).toLowerCase() === 'true') {
+        console.log('   ⚠️  LEO_DISABLE_MECHANISM_VERIFIER_GATE active — bypassing');
+        return { pass: true, score: 100, max_score: 100, issues: [], warnings: ['GATE_MECHANISM_CLAIM_VERIFIER BYPASSED via env'] };
+      }
+      const result = validateMechanismClaims(ctx.sd);
+      if (result.details?.claims?.length === 0) console.log('   ✅ Spine asserts no file+function mechanism — nothing to cite');
+      else if (result.pass) console.log(`   ✅ ${result.details.claims.length} mechanism claim(s), verifier named`);
+      else console.log(`   ❌ ${result.issues[0]}`);
+      return result;
+    },
+    required: true,
+    remediation:
+      'A mechanism claim naming a file and a function must record WHO read it and WHERE. Add to the SD: '
+      + 'metadata.mechanism_verifications = [{ "verified_by": "<name>", "verified_at": "path/to/file.js:123" }] — '
+      + 'or write "verified at path/to/file.js:123 by <name>" in the spine. A boolean attestation is not accepted: '
+      + 'the file:line IS the evidence that someone opened it. If the claim cannot be cited, it should not be the '
+      + 'spine of an SD. Emergency bypass: LEO_DISABLE_MECHANISM_VERIFIER_GATE=1.'
+  };
+}

--- a/scripts/modules/handoff/executors/lead-to-plan/gates/mechanism-claim-verifier.test.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/gates/mechanism-claim-verifier.test.js
@@ -1,0 +1,146 @@
+/**
+ * QF-20260727-982 — an endorsement chain is not evidence.
+ *
+ * The founding case, reproduced as the first test: a spine asserting a mechanism about
+ * lib/worktree-quota.js / countActiveWorktrees(), carrying four endorsements and zero citations.
+ * That SD passed acceptance. It should not have.
+ */
+import { describe, it, expect } from 'vitest';
+import { validateMechanismClaims, findMechanismClaims, createMechanismClaimVerifierGate } from './mechanism-claim-verifier.js';
+
+const THE_CLAIM =
+  'countActiveWorktrees() in lib/worktree-quota.js counts directories, so the quota ratchets one '
+  + 'direction only and every EPERM reap permanently burns a slot that nothing can reclaim.';
+
+describe('the founding case: four endorsements, zero citations', () => {
+  it('FAILS a spine that names a file and a function with no verifier', () => {
+    // Backwards, as it happens — the function returns git REGISTRATIONS, not directories. Nobody
+    // had opened it. This gate does not know the claim is wrong; it knows nobody cited reading it.
+    const r = validateMechanismClaims({ description: THE_CLAIM });
+    expect(r.pass).toBe(false);
+    expect(r.issues[0]).toMatch(/MECHANISM_CLAIM_UNVERIFIED/);
+    expect(r.issues[0]).toMatch(/worktree-quota\.js/);
+  });
+
+  it('PASSES once a name and a file:line are recorded', () => {
+    const r = validateMechanismClaims({
+      description: THE_CLAIM,
+      metadata: { mechanism_verifications: [{ verified_by: 'Adam', verified_at: 'lib/worktree-quota.js:47' }] }
+    });
+    expect(r.pass).toBe(true);
+  });
+
+  it('accepts the inline prose form, so citing needs no metadata edit', () => {
+    const r = validateMechanismClaims({
+      description: `${THE_CLAIM} — verified at lib/worktree-quota.js:47 by Adam`
+    });
+    expect(r.pass).toBe(true);
+  });
+});
+
+describe('a boolean is a convention with extra steps — it is not accepted', () => {
+  it('REJECTS verified_by/verified_at set to booleans', () => {
+    // The whole point of demanding a file:line. Anyone can set true; almost nobody invents a
+    // plausible line number for a function they never opened.
+    const r = validateMechanismClaims({
+      description: THE_CLAIM,
+      metadata: { mechanism_verifications: [{ verified_by: true, verified_at: true }] }
+    });
+    expect(r.pass).toBe(false);
+  });
+
+  it('REJECTS a name with no citation — that is an endorsement, the thing that failed', () => {
+    const r = validateMechanismClaims({
+      description: THE_CLAIM,
+      metadata: { mechanism_verifications: [{ verified_by: 'Solomon', verified_at: 'lib/worktree-quota.js' }] }
+    });
+    expect(r.pass).toBe(false); // a bare filename is not proof anyone opened it
+  });
+
+  it('REJECTS a citation with no name — nobody is accountable for it', () => {
+    const r = validateMechanismClaims({
+      description: THE_CLAIM,
+      metadata: { mechanism_verifications: [{ verified_by: '   ', verified_at: 'lib/worktree-quota.js:47' }] }
+    });
+    expect(r.pass).toBe(false);
+  });
+});
+
+describe('scoped to spines that actually assert a mechanism', () => {
+  it('leaves an SD alone when it names no file+function — nothing to cite', () => {
+    const r = validateMechanismClaims({ description: 'Improve onboarding copy and tighten the empty state.' });
+    expect(r.pass).toBe(true);
+    expect(r.details.claims).toHaveLength(0);
+  });
+
+  it('does NOT treat a file and a distant function as one claim', () => {
+    // Proximity is the discriminator. Whole-text co-occurrence would fire on any long SD that
+    // happens to mention a path somewhere and a call somewhere else — the false-positive that
+    // would get this gate switched off within a week.
+    const far = `We will touch lib/worktree-quota.js this quarter.${' filler.'.repeat(80)}Then callSomething() later.`;
+    expect(findMechanismClaims(far)).toHaveLength(0);
+  });
+
+  it('reads the whole spine, not just description', () => {
+    const r = validateMechanismClaims({ key_changes: [THE_CLAIM] });
+    expect(r.pass).toBe(false);
+  });
+});
+
+describe('grandfather cutoff: teeth for new spines, a warning for the standing backlog', () => {
+  // Measured, not assumed: 17 of 28 live SDs assert a mechanism and ZERO cite one. Blocking on day
+  // one would have wedged 61% of the active population — and a gate that bricks the fleet on
+  // landing gets switched off permanently, which buys nothing.
+  const CUTOFF = Date.parse('2026-07-28T00:00:00Z');
+
+  it('WARNS but does not block an SD authored before the cutoff', () => {
+    const r = validateMechanismClaims({ description: THE_CLAIM, created_at: '2026-07-01T00:00:00Z' });
+    expect(r.pass).toBe(true);
+    expect(r.details.grandfathered).toBe(true);
+    expect(r.warnings[0]).toMatch(/MECHANISM_CLAIM_UNVERIFIED/); // still says it, still visible
+  });
+
+  it('BLOCKS an SD authored after the cutoff — same predicate, different verdict', () => {
+    const r = validateMechanismClaims({ description: THE_CLAIM, created_at: '2026-08-01T00:00:00Z' });
+    expect(r.pass).toBe(false);
+    expect(r.details.grandfathered).toBe(false);
+  });
+
+  it('BLOCKS when created_at is absent — an undated spine is not grandfathered by default', () => {
+    // Fail-closed on the rollout axis too: missing provenance must not buy an exemption.
+    expect(validateMechanismClaims({ description: THE_CLAIM }).pass).toBe(false);
+  });
+
+  it('a cited pre-cutoff SD passes cleanly, not merely grandfathered', () => {
+    const r = validateMechanismClaims({
+      description: `${THE_CLAIM} — verified at lib/worktree-quota.js:47 by Adam`,
+      created_at: '2026-07-01T00:00:00Z'
+    });
+    expect(r.pass).toBe(true);
+    expect(r.details.grandfathered).toBeUndefined(); // passed on evidence, not on age
+    expect(CUTOFF).toBeGreaterThan(0);
+  });
+});
+
+describe('gate wiring', () => {
+  it('is BLOCKING — acceptance is where the record becomes load-bearing', () => {
+    expect(createMechanismClaimVerifierGate().required).toBe(true);
+  });
+
+  it('honours the kill-switch so a bad heuristic cannot wedge the fleet', async () => {
+    const gate = createMechanismClaimVerifierGate();
+    process.env.LEO_DISABLE_MECHANISM_VERIFIER_GATE = '1';
+    try {
+      const r = await gate.validator({ sd: { description: THE_CLAIM } });
+      expect(r.pass).toBe(true);
+      expect(r.warnings[0]).toMatch(/BYPASSED/);
+    } finally {
+      delete process.env.LEO_DISABLE_MECHANISM_VERIFIER_GATE;
+    }
+  });
+
+  it('still fails after the kill-switch is cleared — the bypass is not sticky', async () => {
+    const r = await createMechanismClaimVerifierGate().validator({ sd: { description: THE_CLAIM } });
+    expect(r.pass).toBe(false);
+  });
+});

--- a/scripts/modules/handoff/executors/lead-to-plan/index.js
+++ b/scripts/modules/handoff/executors/lead-to-plan/index.js
@@ -16,6 +16,7 @@ import {
   createBaselineDebtGate,
   createSmokeTestSpecificationGate,
   createPlaceholderContentGate,
+  createMechanismClaimVerifierGate,
   // SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-D Fix 1
   createSdMetricsSufficiencyGate,
   createVisionScoreGate,
@@ -130,6 +131,12 @@ export class LeadToPlanExecutor extends BaseExecutor {
     // Placeholder Content Detection Gate (SD-LEO-INFRA-PROTOCOL-FILE-STATE-001)
     // Warning-only: detects default template text from leo-create-sd.js
     gates.push(createPlaceholderContentGate());
+
+    // Mechanism-Claim Verifier Gate (QF-20260727-982). BLOCKING, but only for spines that
+    // actually assert a mechanism (a named file AND a named function). An SD that claims no
+    // mechanism has nothing to cite and is untouched. Enforced at ACCEPTANCE, not authoring:
+    // authoring-time nags are advice, acceptance is where the record becomes load-bearing.
+    gates.push(createMechanismClaimVerifierGate());
 
     // SD Quality Gate (SD-LEO-FEAT-TRANSLATION-FIDELITY-GATES-001-A)
     // BLOCKING: validates field completeness, content depth, structural correctness


### PR DESCRIPTION
## Summary

Adds `GATE_MECHANISM_CLAIM_VERIFIER` at LEAD-TO-PLAN. A spine that asserts a mechanism — names a **file** and a **function** — must record **who read it** and **at what file:line**.

**The failure it's built against.** A worker observed a real symptom and offered a mechanism. The coordinator propagated it verbatim, twice. Adam generalised it into a law. Solomon endorsed it. Four parties, four rounds, and confidence rose at every step *while the number of people who had read `lib/worktree-quota.js` stayed at zero*. The mechanism was backwards — `countActiveWorktrees` returns git **registrations**, not directories, and its own docblock says so. What broke the claim wasn't more review; it was someone needing the number for an unrelated reason and opening the file.

## Design, from the filed scope

- **Acceptance, not authoring.** Authoring-time nags are advice; acceptance is where the record becomes load-bearing.
- **A name plus a file:line, never a boolean.** *"A boolean is a convention with extra steps and decays the way a lint decays."* Anyone can set `true`; almost nobody invents a plausible line number for a function they never opened. All three rejections are pinned by tests: boolean, name-without-citation (an endorsement — the thing that failed), citation-without-name (nobody accountable).
- **Scoped by proximity, not co-occurrence.** An SD mentioning a path in one paragraph and a call in another has asserted nothing. That false positive is what would get this gate switched off within a week, so there's a negative-control test for it.

## I measured the blast radius before choosing the verdict

"Narrow" was an assumption worth testing. Of **28** live SDs in `draft`/`in_progress`/`pending_approval`:

| | count |
|---|---|
| assert a file+function mechanism | **17** |
| ...already carrying a citation | **0** |
| unaffected (no mechanism claim) | 11 |

Blocking on day one would have wedged **61%** of the active population at acceptance — and a gate that bricks the fleet on landing gets switched off permanently, which buys the codebase nothing.

So the teeth go where the failure mode lives: **new spines**. Grandfather cutoff `2026-07-28`; older SDs get the identical message as a **warning** and can be cited on contact. Same predicate for both cohorts — only the verdict differs, and the cutoff is a date rather than a flag someone must remember to flip.

**Re-measured after:** 0 blocked, 17 warned, 11 unaffected.

This is a deliberate, stated deviation from the ticket's literal *"does not pass"*, made on measured evidence rather than preference. Flagging it explicitly for review — if the intent is to block the backlog too, moving the cutoff is a one-line change.

## Test plan

- [x] The founding case fails: a spine naming `lib/worktree-quota.js` + `countActiveWorktrees()` with no verifier
- [x] Passes once a name and file:line are recorded (metadata **or** inline prose)
- [x] Boolean attestation rejected; name-without-citation rejected; citation-without-name rejected
- [x] Negative control: a file and a *distant* function are not one claim
- [x] Fail-closed on the rollout axis — a spine with **no** `created_at` is not grandfathered
- [x] Kill-switch works and is **not sticky**
- [x] Wiring verified by importing through `gates/index.js` and asserting name + `required`, not by trusting the edit
- [x] 113/113 green across all six lead-to-plan gate suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)