### PR TITLE
fix(QF-20260727-404): stamp sub-agent repo evidence via the canonical writer

### DIFF
--- a/lib/sub-agent-executor/executor.js
+++ b/lib/sub-agent-executor/executor.js
@@ -17,6 +17,9 @@ import { resolveSdKeyToUUID } from './sd-resolver.js';
 import { getModelForAgentAndPhase } from './model-routing.js';
 import { loadSubAgentInstructions } from './instruction-loader.js';
 import { storeSubAgentResults, storeValidationResults } from './results-storage.js';
+// QF-20260727-404: the canonical repo-evidence writer. CLAUDE.md prologue item 11 makes this the
+// only sanctioned way to set metadata.repo_path / executed_from_cwd — never hand-rolled columns.
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../sub-agents/resolve-repo.js';
 import {
   createTaskContract,
   completeTaskContract,
@@ -387,6 +390,44 @@ export async function executeSubAgent(code, sdId, options = {}) {
     // sub-phases, reintroducing the created_at-freezing bug fb 0b12ca77
     // targeted). An explicit caller-supplied options.phase still wins if ever
     // provided.
+    // QF-20260727-404: stamp repo evidence through the CANONICAL writer BEFORE storing.
+    //
+    // Until now the CLI/executor path wrote every evidence row with NO metadata.repo_path. It has
+    // been invisible because it is MASKED, not harmless: a missing repo_path classifies as
+    // explicit_null, and for an INTRA_REPO target the SD-FDBK-ENH-LLM-SUB-AGENT-001 carve-out
+    // degrades it to explicit_null_intra, which gate.js lists in CONDITIONAL_STATUSES — a
+    // conditional pass. So every intra-repo SD sailed through on an UNSTAMPED row and the gate's
+    // central comparison (metadata.repo_path vs applications.local_path) was never exercised here.
+    // On a CROSS-REPO target explicit_null stays explicit_null and BLOCKS, so the first venture SD
+    // driven through this path would hard-fail PLAN-TO-EXEC looking like a gate bug rather than a
+    // missing stamp. That is the dormant half.
+    //
+    // NOTE FOR ANYONE RE-READING THE QF: it named scripts/execute-subagent.js, but that file is a
+    // thin wrapper — it calls executeSubAgent and never touches storage. This is the real call site.
+    //
+    // Routed through resolveSubAgentRepo -> applySubAgentRepoVerdict deliberately. CLAUDE.md
+    // prologue item 11 forbids hand-setting metadata.repo_path, and hand-rolling the columns is the
+    // exact folklore that produced malformed evidence the gate cannot read.
+    //
+    // targetApplication is recomputed here rather than reused: the copy at the module-invocation
+    // branch above is block-scoped and does not reach this point.
+    try {
+      const resolution = await resolveSubAgentRepo({
+        sdId: sdKey || sdUUID || sdId,
+        targetApplication: options.target_application ?? resolved?.target_application ?? null,
+        subAgentCode: code,
+        fallback: 'EHG_Engineer',
+        supabase: await getSupabaseClient(),
+      });
+      applySubAgentRepoVerdict(results, resolution);
+    } catch (repoErr) {
+      // Fail-SOFT but LOUD. Soft because a throw here would lose the evidence row entirely, which
+      // is a worse outage than a missing stamp. Loud because a silently-unstamped row is precisely
+      // the defect being fixed — it would be indistinguishable from the pre-fix behaviour and would
+      // surface later as an unexplained cross-repo gate block.
+      console.warn(`   ⚠️  repo-evidence stamp FAILED (${repoErr?.message || repoErr}) — storing UNSTAMPED. This is a FAULT, not a normal path: the row will conditional-pass intra-repo but BLOCK a cross-repo handoff.`);
+    }
+
     const stored = await storeSubAgentResults(code, sdUUID, subAgent, results, { sdKey, phase: options.phase || rawCurrentPhase });
 
     console.log(`\n${code} execution complete (${executionTime}ms)`);

--- a/tests/unit/sub-agent-executor-repo-stamp.test.js
+++ b/tests/unit/sub-agent-executor-repo-stamp.test.js
@@ -1,0 +1,86 @@
+/**
+ * QF-20260727-404 — the executor path must stamp repo evidence through the CANONICAL writer.
+ *
+ * Before this fix, every evidence row written by lib/sub-agent-executor/executor.js had NO
+ * metadata.repo_path. It was invisible because it was MASKED, not harmless: missing repo_path
+ * classifies as explicit_null, an INTRA_REPO target degrades that to explicit_null_intra, and the
+ * gate lists explicit_null_intra in CONDITIONAL_STATUSES — a conditional pass. On a CROSS-REPO
+ * target explicit_null BLOCKS, so the first venture SD through this path would hard-fail
+ * PLAN-TO-EXEC looking like a gate bug rather than a missing stamp.
+ *
+ * WHY THE STRUCTURAL ASSERTIONS, STATED HONESTLY: executeSubAgent is a long IO-bound function
+ * (Supabase, dynamic sub-agent module import, contract completion) with no existing unit harness,
+ * and standing one up to drive it end-to-end would be a far larger change than the fix. What these
+ * assert is exactly the thing that was WRONG — the canonical writer was never invoked on this path
+ * — and they are deliberately written on ORDER OF OCCURRENCE rather than line numbers, because a
+ * line-pinned test breaks on every legitimate insertion above it and gets deleted rather than fixed.
+ *
+ * The limitation is real and named: these prove the call EXISTS and RUNS BEFORE the store. They do
+ * not prove the arguments are right. The behavioural block below covers the writer itself, so the
+ * suite demonstrates the instrument can actually fire rather than only that a string is present.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { applySubAgentRepoVerdict } from '../../lib/sub-agents/resolve-repo.js';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const EXECUTOR = path.join(REPO_ROOT, 'lib/sub-agent-executor/executor.js');
+const src = fs.readFileSync(EXECUTOR, 'utf8');
+
+describe('executor repo-evidence stamp (QF-20260727-404)', () => {
+  it('imports the canonical writer from lib/sub-agents/resolve-repo.js', () => {
+    expect(src).toMatch(/import\s*\{[^}]*resolveSubAgentRepo[^}]*\}\s*from\s*['"][^'"]*sub-agents\/resolve-repo\.js['"]/);
+    expect(src).toMatch(/applySubAgentRepoVerdict/);
+  });
+
+  it('invokes applySubAgentRepoVerdict BEFORE the results are stored', () => {
+    // Order of occurrence, not line numbers — robust to insertions above either call.
+    const stampAt = src.indexOf('applySubAgentRepoVerdict(results');
+    const storeAt = src.indexOf('await storeSubAgentResults(code, sdUUID, subAgent, results');
+    expect(stampAt, 'applySubAgentRepoVerdict(results, …) must be called on the executor path').toBeGreaterThan(-1);
+    expect(storeAt, 'the main storeSubAgentResults call must still exist').toBeGreaterThan(-1);
+    expect(stampAt).toBeLessThan(storeAt);
+  });
+
+  it('resolves the repo through resolveSubAgentRepo rather than hand-setting the path columns', () => {
+    // CLAUDE.md prologue item 11: metadata.repo_path / executed_from_cwd are the canonical writer's
+    // to set. Hand-rolling them is the folklore that produces evidence the gate cannot read.
+    expect(src).toMatch(/resolveSubAgentRepo\(\s*\{/);
+    expect(src).not.toMatch(/metadata\.repo_path\s*=/);
+    expect(src).not.toMatch(/repo_path:\s*(?!.*resolution)/);
+  });
+
+  it('a stamp failure is surfaced, never swallowed silently', () => {
+    // The whole class this QF belongs to is "reports success while producing nothing". If the stamp
+    // throws, the row still stores (losing evidence entirely would be worse) — but it must SAY so,
+    // or an unstamped row is indistinguishable from the pre-fix behaviour.
+    const catchBlock = src.slice(src.indexOf('applySubAgentRepoVerdict(results'), src.indexOf('await storeSubAgentResults(code, sdUUID, subAgent, results'));
+    expect(catchBlock).toMatch(/catch/);
+    expect(catchBlock).toMatch(/console\.(warn|error)/);
+    expect(catchBlock).toMatch(/FAULT|FAILED/);
+  });
+});
+
+describe('applySubAgentRepoVerdict actually stamps (the instrument can fire)', () => {
+  it('writes repo_path and executed_from_cwd into results.metadata', () => {
+    const results = { verdict: 'PASS', metadata: { existing: 'kept' } };
+    applySubAgentRepoVerdict(results, {
+      repoPath: 'C:/Users/rickf/Projects/_EHG/EHG_Engineer',
+      repoResolved: true,
+      registrySource: 'applications',
+    });
+    expect(results.metadata.repo_path).toBeTruthy();
+    expect(results.metadata.executed_from_cwd).toBeTruthy();
+    expect(results.metadata.existing).toBe('kept'); // additive, never clobbers caller metadata
+  });
+
+  it('an UNSTAMPED result has no repo_path — the pre-fix shape, shown explicitly', () => {
+    // Makes the defect concrete: this is exactly what every CLI-path row looked like, and why the
+    // gate's repo_path-vs-local_path comparison was never exercised.
+    const unstamped = { verdict: 'PASS', metadata: {} };
+    expect(unstamped.metadata.repo_path).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## The defect

Every evidence row written by the executor path had **no `metadata.repo_path`** — the canonical writer was never invoked there.

It stayed invisible because it is **masked, not harmless**. Missing `repo_path` classifies as `explicit_null`; for an INTRA_REPO target the `SD-FDBK-ENH-LLM-SUB-AGENT-001` carve-out degrades that to `explicit_null_intra`, which `gate.js` lists in `CONDITIONAL_STATUSES` — a conditional pass. So every intra-repo SD sailed through on an unstamped row, and the gate's central comparison (`metadata.repo_path` vs `applications.local_path`) was **never exercised on this path**.

On a **cross-repo** target `explicit_null` stays `explicit_null` and **blocks**. The first venture SD driven through here would hard-fail PLAN-TO-EXEC looking like a gate bug rather than a missing stamp. That's the dormant half.

## Correction to the QF's fix location

The QF named `scripts/execute-subagent.js`. That file is a 254-line wrapper that calls `executeSubAgent` and never touches storage — grepping it for `storeSubAgentResults` returns nothing but a `console.log`. The real call site is **`lib/sub-agent-executor/executor.js`**, immediately before the main store. The diagnosis was right; the pointer was one layer off.

## The fix

- Routed through `resolveSubAgentRepo` → `applySubAgentRepoVerdict`, **not** a hand-set `metadata.repo_path`. Prologue item 11 makes the canonical writer the only sanctioned path; hand-rolled path columns are the exact folklore that produces evidence the gate can't read (RCA `9d33b954`).
- `targetApplication` recomputed with the same upstream expression — the existing copy is block-scoped and doesn't reach the store call.
- **Fail-soft but loud.** Soft, because throwing would lose the evidence row entirely (worse than a missing stamp). Loud, because a silently unstamped row is indistinguishable from the pre-fix behaviour — which is the very defect class being fixed.

**Did not touch the intra-repo carve-out**, per the QF's explicit instruction. It's load-bearing for older rows and for sub-agents that legitimately resolve no repo; tightening it in the same change would turn a quiet gap into a fleet-wide handoff outage.

## Mutation-verified

Removing the `applySubAgentRepoVerdict` call **kills 2 of 6** new tests (ordering + fault-surfacing). The import test correctly survives, since the import remains — stated rather than glossed.

The structural assertions are deliberate and their limit is named in the test file: `executeSubAgent` is long and IO-bound with no existing harness, so these assert the thing that was actually **wrong** (the writer was never invoked, and must run *before* the store), using **order of occurrence rather than line numbers** so a legitimate insertion above doesn't break them. A behavioural block covers `applySubAgentRepoVerdict` itself, so the suite demonstrates the instrument can fire rather than only that a string is present.

## Not in scope, flagged

The error path (`storeSubAgentResults(code, sdId, null, errorResult)`) is also unstamped. Left alone: stamping inside error handling adds a second failure surface during an already-failing run, and error rows don't satisfy the evidence gate anyway.

## Testing

**381 passed across 44 sub-agent suites**; eslint and `node --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
