### PR TITLE
feat(SD-LEO-INFRA-CHAIRMAN-APPLY-FLAG-001): make the chairman-apply flag refuse completion

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/chairman-apply-state.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/chairman-apply-state.js
@@ -1,0 +1,60 @@
+/**
+ * SD-LEO-INFRA-CHAIRMAN-APPLY-FLAG-001 — migration apply-state, reused not rebuilt.
+ *
+ * Invokes scripts/verify-migration-apply-state.mjs and returns its per-file classification.
+ * That module is left COMPLETELY UNCHANGED by this SD, which is the point: it already folds
+ * the migration corpus chronologically, resolves live pg_catalog state in bulk, and applies a
+ * disposition ledger whose own comments document a CI false-pass inversion it exists to
+ * prevent. Re-implementing that inside a gate would duplicate carefully-reasoned safety code
+ * and any divergence between the copies would be silent — the exact defect class this SD fixes.
+ *
+ * NOT inherited: .github/workflows/migration-deploy-drift-guard.yml greps the classifier's
+ * INFRA_ERROR marker and converts it to exit 0. That fail-open lives in the workflow, not in
+ * the script, so invoking the script directly does not pick it up — and every failure path
+ * below returns an `error`, which the calling gate treats as BLOCK.
+ *
+ * @module lead-final-approval/chairman-apply-state
+ */
+
+import { execFileSync } from 'child_process';
+import path from 'path';
+import { ENGINEER_ROOT } from '../../../../../lib/repo-paths.js';
+
+/**
+ * Classify every migration file as APPLIED | PARTIAL | NOT_APPLIED | NO_DDL.
+ *
+ * @returns {Promise<{ files: Array<{file: string, status: string, missing?: string[]}>, error: string|null }>}
+ *   `error` non-null means the state could NOT be determined. Callers must treat that as a
+ *   block, never as a pass.
+ */
+export async function classifyMigrationApplyState() {
+  try {
+    const script = path.join(ENGINEER_ROOT, 'scripts', 'verify-migration-apply-state.mjs');
+    const raw = execFileSync(process.execPath, [script, '--json'], {
+      cwd: ENGINEER_ROOT,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024 * 1024, // ~460KB today across 1324 files; headroom for growth
+      timeout: 120_000
+    });
+
+    // stdout is NOT clean JSON. dotenvx prints a banner first, and that banner itself contains
+    // the substring "{ override: true }" — so a naive raw.indexOf('{') lands INSIDE the banner
+    // and the parse fails (confirmed empirically, 2026-07-27). Anchor on the first line whose
+    // column 0 is '{'.
+    const lines = raw.split(/\r?\n/);
+    const start = lines.findIndex((l) => l.startsWith('{'));
+    if (start === -1) {
+      return { files: [], error: 'classifier produced no JSON object on stdout' };
+    }
+
+    const parsed = JSON.parse(lines.slice(start).join('\n'));
+    if (!Array.isArray(parsed.files)) {
+      return { files: [], error: 'classifier output contained no files[] array' };
+    }
+    return { files: parsed.files, error: null };
+  } catch (e) {
+    // Non-zero exit, timeout, unreadable output or malformed JSON all land here and all mean
+    // the same thing: we do not know. Fail closed.
+    return { files: [], error: e.message };
+  }
+}

--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -1234,7 +1234,15 @@ export function createChairmanApplyVerificationGate() {
 
       const sd = ctx.sd || {};
       const sdKey = sd.sd_key || sd.id || 'unknown';
-      const gated = sd.metadata?.requires_chairman_apply === true;
+      // Accept the string 'true' as well as the boolean. Not defensive clutter: the flag's
+      // sibling consumer check-migration-readiness.mjs resolveSdGated() (:141) already guards
+      // `flag === 'true' || flag === true`, because it reads via raw SQL ->> which always
+      // returns text — in-repo evidence that this field demonstrably arrives as a string on
+      // some paths. This gate is the HIGHER-consequence consumer (it blocks completion, that
+      // one only quiets a warning), so it must not be the LESS tolerant of the two. Erring
+      // toward gating is the safe direction; erring toward skipping is the incident.
+      const rawFlag = sd.metadata?.requires_chairman_apply;
+      const gated = rawFlag === true || rawFlag === 'true';
 
       // Not flagged → not applicable. Unflagged SDs must see no behaviour change at all.
       if (!gated) {
@@ -1262,18 +1270,33 @@ export function createChairmanApplyVerificationGate() {
           return failClosed(`apply-state could not be determined: ${error}`, sdKey);
         }
 
-        const owned = declared.length
-          ? files.filter(f => declared.includes(f.file))
-          : files.filter(f => f.file.includes(sdKey));
+        // UNION, never an exclusive branch. An earlier cut used
+        //   declared.length ? filter(declared) : filter(sdKey)
+        // which the EXEC security and testing reviews independently broke: the moment
+        // metadata.migration_files was non-empty — honest partial declaration, stale
+        // copy-paste, or a deliberate decoy — the SD-key fallback was SKIPPED ENTIRELY, so a
+        // declared already-APPLIED file passed the gate while the real SD-key-named
+        // NOT_APPLIED migration sat untouched in the same files[] the gate already held.
+        // metadata is a DATABASE WRITE, not part of any git diff, so that bypass would have
+        // been invisible to review of the PR that introduced it. A declaration may only ever
+        // ADD to what is checked; it can never subtract.
+        const owned = files.filter(f => declared.includes(f.file) || f.file.includes(sdKey));
+
+        // A declaration that names a file the corpus does not contain is itself unverifiable.
+        // Without this, declaring ['real.sql','typo.sql'] checked only real.sql and silently
+        // dropped the other — a partial match reported as a full pass.
+        const missingDeclared = declared.filter(d => !files.some(f => f.file === d));
+        if (missingDeclared.length) {
+          return failClosed(
+            `declared migration(s) not found in the migration corpus: ${missingDeclared.join(', ')}`,
+            sdKey,
+            ['Correct metadata.migration_files, or remove entries that no longer exist.']
+          );
+        }
 
         if (!owned.length) {
-          return failClosed(
-            declared.length
-              ? `declared migration(s) ${declared.join(', ')} not found in the migration corpus`
-              : `no migration file could be associated with ${sdKey}`,
-            sdKey,
-            ['Declare the SD\'s migration(s) in metadata.migration_files so this gate can verify them.']
-          );
+          return failClosed(`no migration file could be associated with ${sdKey}`, sdKey,
+            ['Declare the SD\'s migration(s) in metadata.migration_files so this gate can verify them.']);
         }
 
         // PARTIAL is not APPLIED. A half-applied migration is precisely the state this gate exists

--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -1205,6 +1205,126 @@ export function createPhaseCoverageExitGate(supabase) {
  * @param {Object} sd - Strategic Directive (optional, for SD Start Gate)
  * @returns {Array} Array of gate definitions
  */
+/**
+ * SD-LEO-INFRA-CHAIRMAN-APPLY-FLAG-001 — make metadata.requires_chairman_apply mean something.
+ *
+ * The flag READ as protection and provided none. Its only functional consumer was
+ * check-migration-readiness.mjs, which uses it to make a PR-time drift detector QUIETER, and
+ * this executor could not see it at all (verified: zero matches for the flag across the whole
+ * lead-final-approval tree, against a populated 31-file/17-gate negative control, plus a live
+ * dry-run manifest of 30 gates with none migration-related). So a chairman-gated SD parked at
+ * pending_approval/LEAD_FINAL was one adopt-and-auto-chain away from being marked completed
+ * with its production migration never applied.
+ *
+ * THREE migration checks already existed and NOT ONE enforced: verify-migration-apply-state.mjs
+ * (mature classifier, CI-only, behind a wrapper that converts errors to exit 0),
+ * pending-migrations-check.js (wired into every handoff but defaulted to warn), and
+ * LeadFinalApprovalExecutor.verifyMigrationsApplied() (runs here, but CREATE-TABLE-only and
+ * fail-open). This gate is the reconciliation, not a fourth mechanism: it REUSES the mature
+ * classifier verbatim, by invoking it, and adds the one thing missing — refusal.
+ *
+ * @returns {Object} Gate definition
+ */
+export function createChairmanApplyVerificationGate() {
+  return {
+    name: 'CHAIRMAN_APPLY_VERIFICATION',
+    validator: async (ctx) => {
+      console.log('\n🔒 GATE: Chairman-Apply Verification');
+      console.log('-'.repeat(50));
+
+      const sd = ctx.sd || {};
+      const sdKey = sd.sd_key || sd.id || 'unknown';
+      const gated = sd.metadata?.requires_chairman_apply === true;
+
+      // Not flagged → not applicable. Unflagged SDs must see no behaviour change at all.
+      if (!gated) {
+        console.log('   ℹ️  metadata.requires_chairman_apply not set — not applicable');
+        return {
+          passed: true, score: 100, max_score: 100, issues: [], warnings: [],
+          details: { applicable: false }
+        };
+      }
+
+      try {
+        // Which migration(s) does this SD own? Deliberately does NOT reuse or improve
+        // pending-migrations-check.js's filename-substring heuristic — sharpening that
+        // matching pushes more work into execute-manual-migrations.js, which has no
+        // chairman-gate awareness and could auto-apply the very migration being gated.
+        // Prefer an explicit declaration; fall back to an SD-key-bearing filename.
+        const declared = Array.isArray(sd.metadata?.migration_files) ? sd.metadata.migration_files : [];
+        const { classifyMigrationApplyState } = await import('./chairman-apply-state.js');
+        const { files, error } = await classifyMigrationApplyState();
+
+        if (error) {
+          // FR-3: could-not-determine BLOCKS. Verification failure is not verification success —
+          // the same lesson PR_MERGE_VERIFICATION records above, and the reason the CI wrapper's
+          // error-to-exit-0 conversion is deliberately NOT inherited here.
+          return failClosed(`apply-state could not be determined: ${error}`, sdKey);
+        }
+
+        const owned = declared.length
+          ? files.filter(f => declared.includes(f.file))
+          : files.filter(f => f.file.includes(sdKey));
+
+        if (!owned.length) {
+          return failClosed(
+            declared.length
+              ? `declared migration(s) ${declared.join(', ')} not found in the migration corpus`
+              : `no migration file could be associated with ${sdKey}`,
+            sdKey,
+            ['Declare the SD\'s migration(s) in metadata.migration_files so this gate can verify them.']
+          );
+        }
+
+        // PARTIAL is not APPLIED. A half-applied migration is precisely the state this gate exists
+        // to refuse, and treating it as good would rebuild the fail-open it replaces.
+        const unapplied = owned.filter(f => f.status !== 'APPLIED' && f.status !== 'NO_DDL');
+        if (unapplied.length) {
+          console.log(`   ❌ ${unapplied.length} migration(s) not applied`);
+          return {
+            passed: false, score: 0, max_score: 100,
+            issues: [
+              `${sdKey} is chairman-gated but its migration is NOT applied to the live database.`,
+              ...unapplied.map(f => `  ${f.file} → ${f.status}${f.missing?.length ? ` (missing: ${f.missing.slice(0, 3).join(', ')})` : ''}`),
+              '',
+              'REMEDIATION: obtain the chairman GO and apply the migration, then re-run this handoff.',
+              'Completing now would mark the SD done against a production migration that was never applied.'
+            ],
+            warnings: [],
+            details: { applicable: true, unapplied: unapplied.map(f => ({ file: f.file, status: f.status })) }
+          };
+        }
+
+        console.log(`   ✅ ${owned.length} chairman-gated migration(s) verified applied`);
+        return {
+          passed: true, score: 100, max_score: 100, issues: [], warnings: [],
+          details: { applicable: true, verified: owned.map(f => f.file) }
+        };
+      } catch (e) {
+        return failClosed(e.message, sdKey);
+      }
+    },
+    required: true
+  };
+}
+
+/** Shared fail-closed shape for CHAIRMAN_APPLY_VERIFICATION (FR-3). */
+function failClosed(reason, sdKey, extra = []) {
+  console.log(`   ❌ Chairman-apply verification could not run: ${reason}`);
+  return {
+    passed: false, score: 0, max_score: 100,
+    issues: [
+      `Chairman-apply verification could not be completed for ${sdKey}: ${reason}`,
+      'This BLOCKS rather than passes: an unverifiable migration is not a verified one.',
+      ...extra,
+      '',
+      'Bypass available for documented emergencies: --bypass-validation --bypass-reason "<reason>"'
+    ],
+    warnings: [],
+    details: { failed: true, reason, fail_closed: true }
+  };
+}
+
 export function getRequiredGates(supabase, prdRepo, sd = null) {
   const gates = [];
 
@@ -1220,6 +1340,13 @@ export function getRequiredGates(supabase, prdRepo, sd = null) {
   gates.push(createUserStoriesCompleteGate(supabase, prdRepo));
   gates.push(createRetrospectiveExistsGate(supabase));
   gates.push(createPRMergeVerificationGate());
+
+  // Chairman-Apply Verification (SD-LEO-INFRA-CHAIRMAN-APPLY-FLAG-001) — refuses completion of
+  // a chairman-gated SD whose staged migration was never applied. Registration is a manual push
+  // (there is no directory scan here), so a gate that is written but not pushed silently does
+  // nothing — which is how the flag it enforces became decorative in the first place.
+  gates.push(createChairmanApplyVerificationGate());
+
   gates.push(createPipelineFlowGate());
 
   // FR Delivery Verification (CONST-012 — SD-MAN-ORCH-SCOPE-INTEGRITY-CONSTITUTIONAL-001-C)

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -1071,6 +1071,31 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
    * @param {Object} sd - Strategic directive object
    * @returns {{hasMigrations: boolean, migrationFiles: string[], foundTables: string[], missingTables: string[]}}
    */
+  /**
+   * ADVISORY ONLY. THIS IS NOT THE APPLY-STATE AUTHORITY.
+   * SD-LEO-INFRA-CHAIRMAN-APPLY-FLAG-001.
+   *
+   * The authority for "was this SD's migration actually applied" is the
+   * CHAIRMAN_APPLY_VERIFICATION gate (gates.js), which reuses
+   * scripts/verify-migration-apply-state.mjs and fails CLOSED when it cannot tell.
+   *
+   * Be precise about what this method does, because the imprecise version is the bug: it DOES
+   * reject (UNAPPLIED_MIGRATIONS, index.js:431) when it finds a missing table — it is not
+   * warn-and-proceed. Its fail-open is narrower and easier to miss: it blocks only on what it
+   * can SEE, and it sees very little. Unreadable files are swallowed, anything that is not a
+   * CREATE TABLE is invisible, and it never reads metadata.requires_chairman_apply. A migration
+   * that only adds a function, trigger, index, constraint or column passes it silently.
+   *
+   * IT IS KEPT, NOT SUBSUMED, AND THE REASON IS COVERAGE — the two are not interchangeable:
+   *   - this method scans EVERY implementation repo across database/migrations,
+   *     supabase/migrations and migrations/, but only understands CREATE TABLE;
+   *   - the authoritative classifier understands tables, views, matviews, functions, triggers,
+   *     indexes, constraints and columns, but is hard-scoped to EHG_Engineer/database/migrations
+   *     (MIGRATIONS_DIR, verify-migration-apply-state.mjs:30).
+   * Collapsing this into the gate would have silently dropped cross-repo and alternate-directory
+   * migrations from any check at all. Broad-but-shallow advisory here; narrow-but-deep enforcement
+   * there. If the classifier ever becomes multi-repo, retire this method rather than leaving two.
+   */
   async verifyMigrationsApplied(sd) {
     const { existsSync } = await import('fs');
     const { readdir, readFile } = await import('fs/promises');

--- a/tests/unit/lead-final-chairman-apply-verification.test.js
+++ b/tests/unit/lead-final-chairman-apply-verification.test.js
@@ -33,12 +33,23 @@ describe('TS-3: an SD without the flag is completely unaffected', () => {
     expect(classifyMigrationApplyState).not.toHaveBeenCalled();
   });
 
-  it('treats a non-true flag value as not applicable', async () => {
-    for (const v of [false, 'true', 1, null, undefined]) {
+  it('treats a non-affirmative flag value as not applicable', async () => {
+    for (const v of [false, 'false', 1, null, undefined, 'yes']) {
       const r = await gate().validator(sdWith({ requires_chairman_apply: v }));
       expect(r.passed).toBe(true);
       expect(r.details.applicable).toBe(false);
     }
+  });
+
+  it('treats the STRING "true" as gated, matching the flag\'s other consumer', async () => {
+    // check-migration-readiness.mjs resolveSdGated() guards `=== 'true' || === true` because it
+    // reads via raw SQL ->> which always returns text. This gate blocks completion where that one
+    // only quiets a warning, so it must not be the less tolerant of the two: a string-valued flag
+    // must still gate. Erring toward gating is safe; erring toward skipping is the incident.
+    classifyMigrationApplyState.mockResolvedValue({ files: [], error: null });
+    const r = await gate().validator(sdWith({ requires_chairman_apply: 'true' }));
+    expect(r.passed).toBe(false);
+    expect(classifyMigrationApplyState).toHaveBeenCalled();
   });
 });
 
@@ -177,6 +188,63 @@ describe('association falls back to the SD key without sharpening the shared heu
     const r = await gate().validator(sdWith({ requires_chairman_apply: true }));
     expect(r.passed).toBe(false);
     expect(r.issues.join('\n')).toContain('20260101_SD-TEST-001_add_thing.sql');
+  });
+});
+
+describe('a declaration can only ADD to what is checked - never subtract (shadow-bypass guard)', () => {
+  it('still blocks when a declared APPLIED decoy sits alongside an undeclared SD-key NOT_APPLIED file', async () => {
+    // The bypass both EXEC reviews found independently. An earlier cut used an EXCLUSIVE branch
+    // (declared.length ? filter(declared) : filter(sdKey)), so declaring one already-applied file
+    // skipped the SD-key fallback entirely and the real unapplied migration passed unexamined -
+    // while sitting in the very files[] the gate already had. metadata is a DATABASE write, not
+    // part of any git diff, so this would have been invisible to PR review.
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [
+        { file: '20260102_unrelated.sql', status: 'APPLIED' },
+        { file: '20260101_SD-TEST-001_add_thing.sql', status: 'NOT_APPLIED', missing: [] }
+      ],
+      error: null
+    });
+    const r = await gate().validator(sdWith({
+      requires_chairman_apply: true,
+      migration_files: ['20260102_unrelated.sql']
+    }));
+    expect(r.passed).toBe(false);
+    expect(r.issues.join('\n')).toContain('20260101_SD-TEST-001_add_thing.sql');
+  });
+
+  it('blocks a PARTIAL declaration rather than silently checking only the entries it found', async () => {
+    // declared ['real','typo'] previously checked only `real` and dropped `typo` without a word -
+    // a partial match reported as a full pass.
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [{ file: '20260101_real.sql', status: 'APPLIED' }],
+      error: null
+    });
+    const r = await gate().validator(sdWith({
+      requires_chairman_apply: true,
+      migration_files: ['20260101_real.sql', '20260101_typo.sql']
+    }));
+    expect(r.passed).toBe(false);
+    expect(r.details.fail_closed).toBe(true);
+    expect(r.issues.join('\n')).toContain('20260101_typo.sql');
+  });
+
+  it('still passes when the declaration and the SD-key file are both applied', async () => {
+    // The union must not over-block: adding the fallback back in cannot turn a legitimately
+    // fully-applied SD into a failure.
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [
+        { file: '20260102_declared.sql', status: 'APPLIED' },
+        { file: '20260101_SD-TEST-001_add_thing.sql', status: 'APPLIED' }
+      ],
+      error: null
+    });
+    const r = await gate().validator(sdWith({
+      requires_chairman_apply: true,
+      migration_files: ['20260102_declared.sql']
+    }));
+    expect(r.passed).toBe(true);
+    expect(r.details.verified).toHaveLength(2);
   });
 });
 

--- a/tests/unit/lead-final-chairman-apply-verification.test.js
+++ b/tests/unit/lead-final-chairman-apply-verification.test.js
@@ -1,0 +1,190 @@
+// SD-LEO-INFRA-CHAIRMAN-APPLY-FLAG-001
+// CHAIRMAN_APPLY_VERIFICATION — the gate that makes metadata.requires_chairman_apply mean
+// something. Before this gate, the flag's only functional consumer made a drift detector
+// QUIETER, and this executor could not see the flag at all: a chairman-gated SD parked at
+// pending_approval/LEAD_FINAL was one adopt-and-auto-chain away from being marked completed
+// with its production migration never applied.
+//
+// Every case below fails against the pre-change code, where no such gate existed.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const classifyMigrationApplyState = vi.fn();
+vi.mock(
+  '../../scripts/modules/handoff/executors/lead-final-approval/chairman-apply-state.js',
+  () => ({ classifyMigrationApplyState: (...a) => classifyMigrationApplyState(...a) })
+);
+
+const { createChairmanApplyVerificationGate } = await import(
+  '../../scripts/modules/handoff/executors/lead-final-approval/gates.js'
+);
+
+const gate = () => createChairmanApplyVerificationGate();
+const sdWith = (metadata) => ({ sd: { sd_key: 'SD-TEST-001', metadata } });
+
+beforeEach(() => classifyMigrationApplyState.mockReset());
+
+describe('TS-3: an SD without the flag is completely unaffected', () => {
+  it('passes as not-applicable and never consults the classifier', async () => {
+    const r = await gate().validator(sdWith({}));
+    expect(r.passed).toBe(true);
+    expect(r.details.applicable).toBe(false);
+    // The regression that matters: unflagged SDs must not gain a new dependency or failure mode.
+    expect(classifyMigrationApplyState).not.toHaveBeenCalled();
+  });
+
+  it('treats a non-true flag value as not applicable', async () => {
+    for (const v of [false, 'true', 1, null, undefined]) {
+      const r = await gate().validator(sdWith({ requires_chairman_apply: v }));
+      expect(r.passed).toBe(true);
+      expect(r.details.applicable).toBe(false);
+    }
+  });
+});
+
+describe('TS-1: a flagged SD whose migration is NOT applied is blocked', () => {
+  it('blocks and names the migration file and its status', async () => {
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [
+        { file: '20260101_SD-TEST-001_add_thing.sql', status: 'NOT_APPLIED', missing: ['table:thing'] },
+        { file: '20260102_unrelated.sql', status: 'APPLIED' }
+      ],
+      error: null
+    });
+
+    const r = await gate().validator(sdWith({
+      requires_chairman_apply: true,
+      migration_files: ['20260101_SD-TEST-001_add_thing.sql']
+    }));
+
+    expect(r.passed).toBe(false);
+    expect(r.score).toBe(0);
+    const text = r.issues.join('\n');
+    expect(text).toContain('20260101_SD-TEST-001_add_thing.sql');
+    expect(text).toContain('NOT_APPLIED');
+    expect(text).toMatch(/never applied/i);
+    // The unrelated APPLIED migration must not be dragged in.
+    expect(text).not.toContain('20260102_unrelated.sql');
+  });
+});
+
+describe('TS-2: a flagged SD whose migration IS applied completes normally', () => {
+  it('passes - the gate discriminates rather than blanket-blocking flagged SDs', async () => {
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [{ file: '20260101_SD-TEST-001_add_thing.sql', status: 'APPLIED' }],
+      error: null
+    });
+    const r = await gate().validator(sdWith({
+      requires_chairman_apply: true,
+      migration_files: ['20260101_SD-TEST-001_add_thing.sql']
+    }));
+    expect(r.passed).toBe(true);
+    expect(r.details.verified).toEqual(['20260101_SD-TEST-001_add_thing.sql']);
+  });
+
+  it('accepts NO_DDL as nothing-to-apply', async () => {
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [{ file: '20260101_SD-TEST-001_comment_only.sql', status: 'NO_DDL' }],
+      error: null
+    });
+    const r = await gate().validator(sdWith({
+      requires_chairman_apply: true,
+      migration_files: ['20260101_SD-TEST-001_comment_only.sql']
+    }));
+    expect(r.passed).toBe(true);
+  });
+});
+
+describe('TS-5: PARTIAL is not APPLIED', () => {
+  it('blocks a half-applied migration', async () => {
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [{ file: '20260101_SD-TEST-001_add_thing.sql', status: 'PARTIAL', missing: ['index:thing_idx'] }],
+      error: null
+    });
+    const r = await gate().validator(sdWith({
+      requires_chairman_apply: true,
+      migration_files: ['20260101_SD-TEST-001_add_thing.sql']
+    }));
+    expect(r.passed).toBe(false);
+    expect(r.issues.join('\n')).toContain('PARTIAL');
+  });
+});
+
+describe('TS-4: fail closed - could-not-determine BLOCKS, it never passes', () => {
+  it('blocks when the classifier reports an error (e.g. database unreachable)', async () => {
+    classifyMigrationApplyState.mockResolvedValue({ files: [], error: 'connect ECONNREFUSED' });
+    const r = await gate().validator(sdWith({ requires_chairman_apply: true, migration_files: ['x.sql'] }));
+    expect(r.passed).toBe(false);
+    expect(r.details.fail_closed).toBe(true);
+    const text = r.issues.join('\n');
+    expect(text).toContain('ECONNREFUSED');
+    // Must be distinguishable from a determinate not-applied result (FR-3 acceptance).
+    expect(text).toMatch(/could not be completed/i);
+    expect(text).not.toMatch(/is NOT applied to the live database/);
+  });
+
+  it('blocks when the classifier returns something unusable (throw inside the gate)', async () => {
+    // Exercises the gate's catch via a NATURALLY-ARISING throw: destructuring { files, error }
+    // from null raises a TypeError inside the try. Deliberately not `mockImplementation(() =>
+    // { throw new Error(...) })` — vitest's unhandled-error tracking reports any Error
+    // CONSTRUCTED inside a vi.fn as a test failure even when the code under test catches it,
+    // which reads like a fail-open that isn't one. Verified outside vitest (direct node call):
+    // the validator RETURNS passed=false / fail_closed=true and never throws.
+    classifyMigrationApplyState.mockResolvedValue(null);
+    const r = await gate().validator(sdWith({ requires_chairman_apply: true, migration_files: ['x.sql'] }));
+    expect(r.passed).toBe(false);
+    expect(r.details.fail_closed).toBe(true);
+    expect(r.issues.join('\n')).toMatch(/could not be completed/i);
+  });
+
+  it('blocks when no migration can be associated with the SD', async () => {
+    // Observed live 2026-07-27 against SD-LEO-INFRA-DISPATCH-DELIVERY-INTEGRITY-001: the SD is
+    // flagged but declares no migration and no filename carries its key. Unverifiable is not
+    // verified, so this blocks - and says how to fix it.
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [{ file: '20260102_unrelated.sql', status: 'APPLIED' }],
+      error: null
+    });
+    const r = await gate().validator(sdWith({ requires_chairman_apply: true }));
+    expect(r.passed).toBe(false);
+    expect(r.details.fail_closed).toBe(true);
+    expect(r.issues.join('\n')).toMatch(/metadata\.migration_files/);
+  });
+
+  it('blocks when a DECLARED migration is absent from the corpus', async () => {
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [{ file: '20260102_unrelated.sql', status: 'APPLIED' }],
+      error: null
+    });
+    const r = await gate().validator(sdWith({
+      requires_chairman_apply: true,
+      migration_files: ['20260101_missing.sql']
+    }));
+    expect(r.passed).toBe(false);
+    expect(r.issues.join('\n')).toContain('20260101_missing.sql');
+  });
+});
+
+describe('association falls back to the SD key without sharpening the shared heuristic', () => {
+  it('matches a migration filename containing the SD key when none is declared', async () => {
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [
+        { file: '20260101_SD-TEST-001_add_thing.sql', status: 'NOT_APPLIED', missing: [] },
+        { file: '20260102_unrelated.sql', status: 'APPLIED' }
+      ],
+      error: null
+    });
+    const r = await gate().validator(sdWith({ requires_chairman_apply: true }));
+    expect(r.passed).toBe(false);
+    expect(r.issues.join('\n')).toContain('20260101_SD-TEST-001_add_thing.sql');
+  });
+});
+
+describe('gate shape matches the executor contract', () => {
+  it('is named and required', () => {
+    const g = gate();
+    expect(g.name).toBe('CHAIRMAN_APPLY_VERIFICATION');
+    expect(g.required).toBe(true);
+    expect(typeof g.validator).toBe('function');
+  });
+});


### PR DESCRIPTION
## What this fixes

`metadata.requires_chairman_apply` **read as protection and provided none.** Its only functional consumer used it to make a PR-time drift detector *quieter*, and `LEAD-FINAL-APPROVAL` could not see it at all. A chairman-gated SD parked at `pending_approval/LEAD_FINAL` was one adopt-and-auto-chain away from being marked **completed against a production migration that was never applied**.

## Verified at runtime, not only by grep

The SD arrived with an explicit open caveat: both its legs were code-surface greps and nobody had watched this fail. Closed that **before building**, read-only:

`handoff.js dry-run LEAD-FINAL-APPROVAL` against the real chairman-gated SD printed the live manifest — **30 gates, none about migration application**. `PR_MERGE_VERIFICATION`, the only thing that had ever stopped an auto-chain, verifies the PR **merged**, not the migration **applied**. Different facts; one checked.

## The discovery that shaped the fix

**Three migration checks already existed. Not one enforced.**

| Mechanism | Why it doesn't bite |
|---|---|
| `verify-migration-apply-state.mjs` | Mature classifier — but CI-only, behind a wrapper converting errors to exit 0 |
| `pending-migrations-check.js` | Runs on *every* handoff and can block — but enforcement defaults to `warn` |
| `verifyMigrationsApplied()` | Already runs at this gate — but CREATE-TABLE-only and flag-blind |

So this is a **reconciliation, not a construction**. A fourth parallel mechanism would have reproduced exactly the defect being fixed.

## What landed

`CHAIRMAN_APPLY_VERIFICATION`, registered **Required**. It reuses the existing classifier by invoking it — `verify-migration-apply-state.mjs` is **unchanged by this PR** (git diff: zero lines) — and adds the one thing missing: **refusal**.

**Fails closed, deliberately.** Classifier error, non-zero exit, unparseable output, unassociable migration, or a declared migration absent from the corpus all **block**. `PARTIAL` is treated as not-applied. The message distinguishes *"not applied"* from *"could not determine"* so an operator knows which they're in. This mirrors `createPRMergeVerificationGate`, whose own comment records the same lesson: *verification failure is not equivalent to verification success.*

**Association is conservative on purpose.** It prefers an explicit `metadata.migration_files` declaration, falling back to an SD-key-bearing filename. It deliberately does **not** sharpen `pending-migrations-check.js`'s filename heuristic — doing so pushes more work into `execute-manual-migrations.js`, which has zero chairman-gate awareness and could auto-apply the very migration being gated.

## Two decisions I reversed, with evidence

**Integration path.** PLAN pinned in-process reuse on the premise it needed "one export keyword." Reading the module first showed that's false — `classifyFiles()` is driven by a whole pipeline including a disposition ledger whose own comments document a CI false-pass inversion it exists to prevent. Duplicating that inside a gate isn't reuse, and divergence would be silent. Invoking the CLI reuses all of it, ledger included.

One real hazard, measured: the classifier's stdout **isn't clean JSON** — a dotenvx banner precedes it and itself contains `{ override: true }`, so a naive `indexOf('{')` lands inside the banner and the parse fails (confirmed empirically). Extraction anchors on the first line whose column 0 is a brace. **That fragility fails safe** — a parse failure blocks; it cannot produce a false pass.

**FR-2.** Asked for exactly one apply-state code path. Implementing it literally would have caused a **coverage regression**: the legacy scan is multi-repo/multi-dir but CREATE-TABLE-only, while the classifier is deep but hard-scoped to `EHG_Engineer/database/migrations`. Collapsing them drops cross-repo migrations from *any* check. So the boundary is written into the code instead, with a retirement trigger.

I also corrected my own PRD: it called `verifyMigrationsApplied()` fail-open. It isn't — it **rejects** at `index.js:431`. Its real fail-open is that it only *sees* CREATE TABLE. An inaccurate safety comment is worse than none.

## Proven against the live system

- Gate appears in the manifest: **31 gates, was 30**
- **Blocks** the real chairman-gated `SD-LEO-INFRA-DISPATCH-DELIVERY-INTEGRITY-001`, with actionable remediation
- Direct node invocation confirms the validator *returns* a fail-closed result rather than throwing

## Tests

12 new cases: not-applicable, `NOT_APPLIED`, `APPLIED`, `NO_DDL`, `PARTIAL`, classifier error, unassociable SD, declared-but-missing, key-fallback association, gate shape. **Every one fails against the pre-change code**, where no such gate existed.

**924 passing across 90** handoff / lead-final / migration suites — no regressions.

## Size

187 source LOC against the 100 target (400 max). The operator-facing remediation messages and the comments recording why each fail-closed branch exists are the bulk; executable logic is roughly a third. Given this SD exists because a control was silently decorative, comments stating what this one does and does **not** guarantee are load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
