### PR TITLE
fix(QF-20260727-683): stop counting empty-bodied roll_calls as WORKER_SIGNAL_UNANSWERED

### DIFF
--- a/lib/coordinator/detectors.cjs
+++ b/lib/coordinator/detectors.cjs
@@ -22,8 +22,13 @@
  *  - STUCK_WORKER must NOT use claude_sessions.last_progress_at (NULL ~99.98%);
  *    it keys off heartbeat/SD-updated staleness + current_phase. Distinct from
  *    status-stuck STUCK_100/STUCK_APPROVAL.
- *  - REPLY_STARVATION: no signal_type column; a worker ask is sender_type==='worker';
- *    "answered" = acknowledged_at set OR payload.routed_to_feedback_id set.
+ *  - REPLY_STARVATION: a worker ask is sender_type==='worker' AND carries
+ *    payload.signal_type (QF-20260727-683 — hasSignalType(), mirroring
+ *    signal-router.cjs's own friction-signal filter, so an empty-bodied
+ *    payload.kind='roll_call' availability ping — which deliberately never sets
+ *    signal_type, see .claude/commands/checkin.md — is not miscounted as an
+ *    unanswered signal); "answered" = acknowledged_at set OR
+ *    payload.routed_to_feedback_id set.
  *
  * @module lib/coordinator/detectors
  */
@@ -31,6 +36,7 @@
 'use strict';
 
 const { hasCorrelatedReply } = require('./reply-correlation.cjs');
+const { hasSignalType } = require('./signal-router.cjs');
 
 /** Default freshness window (ms) for "is this session a live coordinator". */
 const DEFAULT_COORDINATOR_FRESH_MS = 10 * 60 * 1000;
@@ -125,6 +131,16 @@ function detectReplyStarvation(data) {
   const allSignals = (data && data.signals) || [];
   for (const sig of allSignals) {
     if ((sig && sig.sender_type) !== 'worker') continue;
+    // QF-20260727-683: only rows carrying payload.signal_type are friction signals.
+    // Every /checkin emits a fresh payload.kind='roll_call' availability ping with an
+    // empty body and NO signal_type BY DESIGN (.claude/commands/checkin.md: "deliberately
+    // NO payload.signal_type / intent_action, so the friction signal-router and the
+    // deconfliction sweep never scoop it") — counting it here contradicted that contract
+    // and made this gauge structurally unable to reach zero. hasSignalType() is the exact
+    // predicate signal-router.cjs's loadRecentSignals() applies at the DB layer
+    // (`.not('payload->>signal_type', 'is', null)`), reused rather than re-derived so the
+    // two readers of "is this a friction signal" cannot drift apart again.
+    if (!hasSignalType(sig)) continue;
     // SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 (closure map class C6): a reply
     // routinely arrives as a fresh correlated row, not an update to acknowledged_at.
     const answered = !!sig.acknowledged_at || !!(sig.payload && sig.payload.routed_to_feedback_id)

--- a/lib/coordinator/signal-router.cjs
+++ b/lib/coordinator/signal-router.cjs
@@ -42,6 +42,19 @@ async function fapPaginate(queryFactory, opts) {
   return _fapModule.fetchAllPaginated(queryFactory, opts);
 }
 
+// QF-20260727-683: the ONE predicate for "is this row a friction signal" — a row
+// whose payload carries signal_type. Exported so callers that already hold rows
+// fetched by someone else (e.g. detectReplyStarvation, which is handed a pre-fetched
+// signals array rather than issuing its own query) can apply the identical rule in
+// JS instead of re-deriving it. Mirrors the `.not('payload->>signal_type', 'is',
+// null)` filter below byte-for-byte in intent: a roll_call ping (payload.kind=
+// 'roll_call') deliberately never sets signal_type (.claude/commands/checkin.md), so
+// it is excluded here exactly as it is excluded from this query.
+function hasSignalType(row) {
+  const st = row && row.payload && row.payload.signal_type;
+  return st !== undefined && st !== null && st !== '';
+}
+
 async function loadRecentSignals(supabase, windowMin = WINDOW_MIN) {
   const cutoff = new Date(Date.now() - windowMin * 60_000).toISOString();
   let data;
@@ -398,6 +411,7 @@ module.exports = {
   severityRank,
   shouldPromote,
   groupByFingerprint,
+  hasSignalType,
   loadRecentSignals,
   findExistingFeedback,
   insertFeedbackRow,

--- a/tests/unit/coordinator/detectors.test.js
+++ b/tests/unit/coordinator/detectors.test.js
@@ -57,16 +57,16 @@ describe('detectThunderingHerd', () => {
 
 describe('detectReplyStarvation', () => {
   it('matches an old unanswered worker signal', () => {
-    const signals = [{ id: '1', sender_type: 'worker', sender_session: 'w1', created_at: minsAgo(45), acknowledged_at: null, read_at: null, payload: {} }];
+    const signals = [{ id: '1', sender_type: 'worker', sender_session: 'w1', created_at: minsAgo(45), acknowledged_at: null, read_at: null, payload: { signal_type: 'stuck' } }];
     const r = detectReplyStarvation({ signals, now: NOW, thresholdMs: 30 * 60_000 });
     expect(r.matched).toBe(true);
     expect(r.evidence.starved_count).toBe(1);
   });
   it('does not match answered / read / non-worker / recent signals', () => {
-    const base = { sender_type: 'worker', sender_session: 'w', created_at: minsAgo(45), acknowledged_at: null, read_at: null, payload: {} };
+    const base = { sender_type: 'worker', sender_session: 'w', created_at: minsAgo(45), acknowledged_at: null, read_at: null, payload: { signal_type: 'stuck' } };
     const signals = [
       { ...base, id: 'a', acknowledged_at: minsAgo(40) },                 // acknowledged
-      { ...base, id: 'b', payload: { routed_to_feedback_id: 'fb-1' } },   // routed (stampRouted)
+      { ...base, id: 'b', payload: { signal_type: 'stuck', routed_to_feedback_id: 'fb-1' } },   // routed (stampRouted)
       { ...base, id: 'c', read_at: minsAgo(40) },                          // read
       { ...base, id: 'd', sender_type: 'coordinator' },                   // not a worker ask
       { ...base, id: 'e', created_at: minsAgo(5) },                        // too recent
@@ -75,17 +75,68 @@ describe('detectReplyStarvation', () => {
   });
 
   it('SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001: a correlated reply row excludes the original from starvation', () => {
-    const original = { id: 'req-1', sender_type: 'worker', sender_session: 'w1', created_at: minsAgo(45), acknowledged_at: null, read_at: null, payload: {} };
+    const original = { id: 'req-1', sender_type: 'worker', sender_session: 'w1', created_at: minsAgo(45), acknowledged_at: null, read_at: null, payload: { signal_type: 'stuck' } };
     const reply = { id: 'reply-1', sender_type: 'coordinator', sender_session: 'c1', created_at: minsAgo(10), acknowledged_at: null, read_at: null, payload: { reply_to: 'req-1' } };
     expect(detectReplyStarvation({ signals: [original, reply], now: NOW, thresholdMs: 30 * 60_000 }).matched).toBe(false);
   });
 
   it('SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001: no correlated reply present still starves (genuine case preserved)', () => {
-    const original = { id: 'req-2', sender_type: 'worker', sender_session: 'w1', created_at: minsAgo(45), acknowledged_at: null, read_at: null, payload: {} };
+    const original = { id: 'req-2', sender_type: 'worker', sender_session: 'w1', created_at: minsAgo(45), acknowledged_at: null, read_at: null, payload: { signal_type: 'stuck' } };
     const unrelated = { id: 'other', sender_type: 'coordinator', sender_session: 'c1', created_at: minsAgo(10), acknowledged_at: null, read_at: null, payload: { reply_to: 'not-req-2' } };
     const r = detectReplyStarvation({ signals: [original, unrelated], now: NOW, thresholdMs: 30 * 60_000 });
     expect(r.matched).toBe(true);
     expect(r.evidence.samples.some((s) => s.id === 'req-2')).toBe(true);
+  });
+
+  // QF-20260727-683: every /checkin emits a fresh payload.kind='roll_call' availability
+  // ping (empty body, deliberately NO payload.signal_type per .claude/commands/checkin.md)
+  // — the sweep scooped these as WORKER_SIGNAL_UNANSWERED anyway, making the gauge
+  // structurally unable to reach zero (measured: 4 of 5 rows named on one tick were
+  // roll_calls). The fix mirrors signal-router.cjs's own friction-signal filter
+  // (payload.signal_type presence) via the shared hasSignalType() predicate.
+  describe('QF-20260727-683: roll_call / signal-type-less rows are not friction signals', () => {
+    it('(a) an empty-bodied roll_call row (payload.kind=roll_call, no signal_type) is NOT counted', () => {
+      const signals = [{
+        id: 'rc-1', sender_type: 'worker', sender_session: 'w1', created_at: minsAgo(45),
+        acknowledged_at: null, read_at: null, body: null,
+        payload: { kind: 'roll_call', sender_callsign: 'Bravo', available: true },
+      }];
+      const r = detectReplyStarvation({ signals, now: NOW, thresholdMs: 30 * 60_000 });
+      expect(r.matched).toBe(false);
+      expect(r.evidence.starved_count ?? 0).toBe(0);
+    });
+
+    it('(b) a row WITH a real payload.signal_type IS still counted — the gauge narrows, not disappears', () => {
+      const signals = [
+        // noise: excluded
+        { id: 'rc-2', sender_type: 'worker', sender_session: 'w1', created_at: minsAgo(45), acknowledged_at: null, read_at: null, body: null, payload: { kind: 'roll_call' } },
+        // signal: still counted
+        { id: 'sig-1', sender_type: 'worker', sender_session: 'w2', created_at: minsAgo(45), acknowledged_at: null, read_at: null, body: 'blocked on SD-X, need a utilization decision', payload: { signal_type: 'stuck', sender_callsign: 'Charlie' } },
+      ];
+      const r = detectReplyStarvation({ signals, now: NOW, thresholdMs: 30 * 60_000 });
+      expect(r.matched).toBe(true);
+      expect(r.evidence.starved_count).toBe(1);
+      expect(r.evidence.samples.some((s) => s.id === 'sig-1')).toBe(true);
+      expect(r.evidence.samples.some((s) => s.id === 'rc-2')).toBe(false);
+    });
+
+    it('(c) a row with neither payload.kind nor payload.signal_type is NOT counted', () => {
+      const signals = [{
+        id: 'bare-1', sender_type: 'worker', sender_session: 'w1', created_at: minsAgo(45),
+        acknowledged_at: null, read_at: null, body: null, payload: {},
+      }];
+      const r = detectReplyStarvation({ signals, now: NOW, thresholdMs: 30 * 60_000 });
+      expect(r.matched).toBe(false);
+    });
+
+    it('a coordinator_request (live-handshake, no signal_type) is also excluded — it is resolved by its own synchronous poll/timeout, not this gauge', () => {
+      const signals = [{
+        id: 'req-live', sender_type: 'worker', sender_session: 'w1', created_at: minsAgo(45),
+        acknowledged_at: null, read_at: null,
+        payload: { kind: 'coordinator_request', correlation_id: 'c-1', expects_reply: true },
+      }];
+      expect(detectReplyStarvation({ signals, now: NOW, thresholdMs: 30 * 60_000 }).matched).toBe(false);
+    });
   });
 });
 

--- a/tests/unit/coordinator/worker-signal-starvation.test.js
+++ b/tests/unit/coordinator/worker-signal-starvation.test.js
@@ -50,8 +50,8 @@ describe('reportWorkerSignalStarvation', () => {
   it('counts an unanswered worker signal past the threshold and reports the oldest age', async () => {
     const { lines, log } = capture();
     const r = await reportWorkerSignalStarvation(fakeSupabase([
-      { id: 's-old', sender_session: 'w1', sender_type: 'worker', created_at: minsAgo(80), payload: {} },
-      { id: 's-mid', sender_session: 'w2', sender_type: 'worker', created_at: minsAgo(45), payload: {} },
+      { id: 's-old', sender_session: 'w1', sender_type: 'worker', created_at: minsAgo(80), payload: { signal_type: 'stuck' } },
+      { id: 's-mid', sender_session: 'w2', sender_type: 'worker', created_at: minsAgo(45), payload: { signal_type: 'stuck' } },
     ]), { now: NOW, log, env: {} });
     expect(r.starved).toBe(2);
     expect(r.oldestMin).toBe(80);
@@ -65,13 +65,37 @@ describe('reportWorkerSignalStarvation', () => {
   it('does NOT count signals that are answered, read, routed, or under threshold, or non-worker senders', async () => {
     const { log } = capture();
     const r = await reportWorkerSignalStarvation(fakeSupabase([
-      { id: 'a', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(90), acknowledged_at: minsAgo(5), payload: {} },
-      { id: 'b', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(90), read_at: minsAgo(5), payload: {} },
-      { id: 'c', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(90), payload: { routed_to_feedback_id: 'f-1' } },
-      { id: 'd', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(10), payload: {} },   // too young
-      { id: 'e', sender_session: 'adam', sender_type: 'adam', created_at: minsAgo(90), payload: {} },  // not a worker
+      { id: 'a', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(90), acknowledged_at: minsAgo(5), payload: { signal_type: 'stuck' } },
+      { id: 'b', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(90), read_at: minsAgo(5), payload: { signal_type: 'stuck' } },
+      { id: 'c', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(90), payload: { signal_type: 'stuck', routed_to_feedback_id: 'f-1' } },
+      { id: 'd', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(10), payload: { signal_type: 'stuck' } },   // too young
+      { id: 'e', sender_session: 'adam', sender_type: 'adam', created_at: minsAgo(90), payload: { signal_type: 'stuck' } },  // not a worker
     ]), { now: NOW, log, env: {} });
     expect(r.starved).toBe(0);
+  });
+
+  // QF-20260727-683: every /checkin emits a fresh payload.kind='roll_call' availability
+  // ping with an empty body and deliberately NO payload.signal_type (contract stated in
+  // .claude/commands/checkin.md). The sweep counted these as WORKER_SIGNAL_UNANSWERED
+  // anyway, so the gauge could never reach zero — measured: 4 of 5 rows named on one tick
+  // were roll_calls. This exercises the fix end-to-end through the reporter, not just the
+  // pure detector (see tests/unit/coordinator/detectors.test.js for the predicate-level cases).
+  it('QF-20260727-683: does NOT count empty-bodied roll_call rows, but still counts a real payload.signal_type row', async () => {
+    const { lines, log } = capture();
+    const r = await reportWorkerSignalStarvation(fakeSupabase([
+      { id: 'rc-1', sender_session: 'w1', sender_type: 'worker', created_at: minsAgo(80), body: null, payload: { kind: 'roll_call', sender_callsign: 'Bravo', available: true } },
+      { id: 'rc-2', sender_session: 'w1', sender_type: 'worker', created_at: minsAgo(60), body: null, payload: { kind: 'roll_call', sender_callsign: 'Bravo', available: true } },
+      { id: 'bare-1', sender_session: 'w1', sender_type: 'worker', created_at: minsAgo(50), body: null, payload: {} }, // neither kind nor signal_type
+      { id: 'sig-1', sender_session: 'w2', sender_type: 'worker', created_at: minsAgo(117), body: 'handing off a utilization decision', payload: { signal_type: 'feedback', sender_callsign: 'Charlie' } },
+    ]), { now: NOW, log, env: {} });
+    expect(r.starved).toBe(1);
+    expect(r.oldestMin).toBe(117);
+    const line = lines.find((l) => l.startsWith('WORKER SIGNALS:'));
+    expect(line).toContain('unanswered_over_30m=1');
+    expect(lines.some((l) => l.includes('WORKER_SIGNAL_UNANSWERED: id=sig-1'))).toBe(true);
+    expect(lines.some((l) => l.includes('WORKER_SIGNAL_UNANSWERED: id=rc-1'))).toBe(false);
+    expect(lines.some((l) => l.includes('WORKER_SIGNAL_UNANSWERED: id=rc-2'))).toBe(false);
+    expect(lines.some((l) => l.includes('WORKER_SIGNAL_UNANSWERED: id=bare-1'))).toBe(false);
   });
 
   it('REGRESSION: fails OPEN but says NOT MEASURED out loud — a silent catch would recreate the bug', async () => {
@@ -88,7 +112,7 @@ describe('reportWorkerSignalStarvation', () => {
     const { lines, log } = capture();
     // COORD_DETECTORS_V2 explicitly off (its real default) — the counter must still report.
     await reportWorkerSignalStarvation(fakeSupabase([
-      { id: 'z', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(99), payload: {} },
+      { id: 'z', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(99), payload: { signal_type: 'stuck' } },
     ]), { now: NOW, log, env: { COORD_DETECTORS_V2: 'false' } });
     expect(lines.find((l) => l.startsWith('WORKER SIGNALS:'))).toContain('unanswered_over_30m=1');
   });


### PR DESCRIPTION
## Summary
- `lib/coordinator/detectors.cjs`'s `detectReplyStarvation()` — the real selector behind the sweep's `WORKER_SIGNAL_UNANSWERED` line (reached via `lib/coordinator/worker-signal-starvation.cjs`, called from both sweep twins) — counted every `sender_type='worker'` row regardless of payload shape, so the empty-bodied `payload.kind='roll_call'` availability ping every `/checkin` emits was miscounted as an unanswered signal, contradicting the writer's own documented contract (`.claude/commands/checkin.md`: "deliberately NO payload.signal_type / intent_action, so the friction signal-router and the deconfliction sweep never scoop it").
- Extracted the predicate `signal-router.cjs`'s `loadRecentSignals()` already applies at the DB layer (`.not('payload->>signal_type', 'is', null)`) into an exported pure function `hasSignalType(row)`, and reused it inside `detectReplyStarvation` instead of re-deriving a second, looser rule.
- Did **not** make `worker-checkin.cjs` stamp `signal_type` onto roll_calls — that would push the noise into the friction lane, the opposite of the check-in contract's intent.

## Measured defect (pre-fix, reproduced via `git stash` against unmodified `main`)
An empty-bodied roll_call row fed into `detectReplyStarvation` returned `matched:true, starved_count:1`. Live sample cited in the QF: 4 of 5 rows the sweep named on one tick were empty-bodied roll_calls; the one genuine signal sat at 117 minutes buried under three identically-weighted pings.

## Test plan
- [x] New coverage in `tests/unit/coordinator/detectors.test.js`: (a) empty-bodied roll_call excluded, (b) row with real `payload.signal_type` still counted (gauge narrows, not disappears), (c) row with neither `kind` nor `signal_type` excluded, plus a `coordinator_request` (live-handshake, also no signal_type) case documenting why that mechanism is out of scope for this gauge.
- [x] Extended `tests/unit/coordinator/worker-signal-starvation.test.js` end-to-end with the same roll_call/signal mix through `reportWorkerSignalStarvation`.
- [x] Updated pre-existing fixtures that used bare `payload: {}` for "genuine signal" cases to carry `payload.signal_type`, since that's now the load-bearing property.
- [x] `detectors.test.js` + `worker-signal-starvation.test.js` + `signal-router.test.js` + `signal-router.fr4.test.js`: **115/115 passing**.
- [x] Full coordinator + sweep unit surface (108 files): **1225/1225 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)