### PR TITLE
fix(SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001): FR-5 — gate the kill primitive; persist parentage; stop tests writing into the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -429,3 +429,6 @@ scripts/cron/eva-watcher-task.cmd
 
 # SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-A: spine-verify-first-run.mjs run manifests (scratch, teardown-consumed)
 scripts/harness/.spine-verify-first-runs/
+
+# SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 FR-5c: runtime parentage log, never committed
+.claude/console-parentage.jsonl

--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -500,6 +500,16 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
         if (!processAlive) {
           // SD-LEO-INFRA-SESSION-LIFECYCLE-CLEANUP-001 (FR-6): Audit log on ambiguous release
           console.log(`[claimGuard] IDENTITY_TRANSFER: prior_session=${claim.session_id}, new_session=${sessionId}, staleness_delta=${heartbeatAge}s, gate_result=ALLOW_AMBIGUOUS_DEAD_PID, claim_pid=${claimPid}, my_terminal=${myTerminalId}, their_terminal=${claim.terminal_id}`);
+          // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b — DELIBERATELY NOT a
+          // releaseWorkItemOnSessionEnd call site, recorded here because FR-1 requires every
+          // release path to either call the shared helper or carry a written reason it must not.
+          //
+          // THE REASON: this is a release-then-REACQUIRE, not a hand-back. The `continue` below
+          // proceeds straight to acquiring the same item for THIS session. Resetting a QF to
+          // status='open' in that window would make it briefly visible to every other picker
+          // between our release and our acquire — manufacturing a steal race that does not exist
+          // today, because an item left at in_progress is invisible to them. The reset belongs on
+          // paths that GIVE WORK BACK; this one takes it over.
           const { error: releaseError } = await supabase.rpc('release_sd', {
             p_session_id: claim.session_id,
             p_reason: 'manual'
@@ -606,6 +616,9 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
       timestamp: new Date().toISOString()
     }));
     console.log(`[claimGuard] Releasing stale claim from session ${claim.session_id} (${claim.heartbeat_age_human})${sameHost && claimPid ? ` — PID ${claimPid} is dead` : ' — different host or no PID'}`);
+    // FR-1b: same exemption as the ambiguous-dead-PID release above — this is a
+    // release-then-REACQUIRE for THIS session, not a hand-back, so it must not reset the
+    // work item. See the fuller reasoning at that site.
     const { error: releaseError } = await supabase.rpc('release_sd', {
       p_session_id: claim.session_id,
       p_reason: 'manual'

--- a/lib/claim-lifecycle-release.mjs
+++ b/lib/claim-lifecycle-release.mjs
@@ -105,6 +105,12 @@ export async function releaseClaimOnPROpen(snapshot) {
   // released (so the SD can be reclaimed / rolled up); the session-side (claude_sessions.sd_key +
   // worktree_*) is deliberately LEFT INTACT because the worker is still ALIVE in that worktree.
   // It must NOT be routed through releaseClaimBothSurfaces (that would evict a live worker).
+  // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b — EXEMPT from releaseWorkItemOnSessionEnd
+  // for the same underlying reason, recorded because FR-1 requires every release path to either
+  // call the shared helper or state why it must not: THE WORKER IS STILL ALIVE AND STILL
+  // SHIPPING. The item is not abandoned, so handing it back would advertise as available
+  // something a live session is actively finishing — inviting a second worker onto it. The
+  // hand-back belongs on paths where the holder is gone, not where it is mid-flight.
   // Allowlisted in the dual-surface release guard (tests/unit/claim/release-dual-surface-guard.test.js).
   const { data, error } = await sb
     .from('strategic_directives_v2')

--- a/lib/claim-validity-gate.js
+++ b/lib/claim-validity-gate.js
@@ -546,6 +546,21 @@ export async function assertValidClaim(supabase, sdKey, { operation, allowMainRe
         const { releaseClaimsByHolder } = await import('../scripts/hooks/lib/file-claim-guard.cjs');
         await releaseClaimsByHolder({ holderSessionId: sd.claiming_session_id });
       } catch { /* fail-open */ }
+      // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 4, behind
+      // LEO_RELEASE_WORKITEM_RESET (default OFF). This IS a hand-back: the owner is dead,
+      // missing, or verifiably drifted onto another SD, so the item is genuinely abandoned
+      // and belongs back in the pool. Releasing the claim alone left a QF at
+      // status='in_progress' with no claimant — reachable by no picker while the
+      // coordinator's supply gauge still counted it. Runs AFTER the release above; the
+      // predicate requires claiming_session_id IS NULL. Fail-open: a failed hand-back must
+      // never block the gate from proceeding as unclaimed.
+      try {
+        const { releaseWorkItemOnSessionEnd, isReleaseWorkItemResetEnabled } =
+          await import('./fleet/release-work-item.mjs');
+        if (isReleaseWorkItemResetEnabled()) {
+          await releaseWorkItemOnSessionEnd(supabase, sdKey, 'claim_validity_orphan');
+        }
+      } catch { /* fail-open */ }
       // SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-001 FR-2 (AC-2.2): distinct telemetry —
       // 'sd_key_drift' reason channel separate from stale/released/missing.
       const releaseReason = ownerIsDead

--- a/lib/claim/release-claim-both-surfaces.mjs
+++ b/lib/claim/release-claim-both-surfaces.mjs
@@ -65,6 +65,18 @@
  * @param {boolean}[opts.readback=true]   run the OLD-HOLDER-GONE readback (adds one SELECT).
  * @returns {Promise<ReleaseResult>}
  */
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b — DO NOT wire releaseWorkItemOnSessionEnd
+// into this function. It is the obvious "one place to fix them all" and that is exactly why it
+// is wrong: this helper is the SHARED release primitive, so a hand-back added here is inherited
+// by callers that must NOT have one —
+//   - claim-guard.mjs uses it as the release_sd fallback, and there the release is followed by
+//     an immediate REACQUIRE; reopening the item in that window manufactures a steal race;
+//   - coordinator-cold-recovery.cjs uses it while PRESERVING current_phase for resume;
+//   - claim-lifecycle-release.mjs documents that it must not route through this helper at all,
+//     because the worker is still alive and shipping.
+// Releasing a CLAIM and handing back a WORK ITEM are different operations with different
+// correct call sites. The hand-back is wired per-site, deliberately, with each site's
+// disposition recorded — see the ledger in lib/fleet/release-work-item.mjs.
 export async function releaseClaimBothSurfaces(sb, opts = {}) {
   const { sdKey, reason = 'release', sessionStatus = 'released', tryRpc = false, readback = true } = opts;
   let holder = opts.holderSessionId || null;

--- a/lib/commands/claim-command-workitem-handback.test.js
+++ b/lib/commands/claim-command-workitem-handback.test.js
@@ -1,0 +1,126 @@
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 3
+ *
+ * releaseClaim() — the user-facing `/claim release` verb — now hands the work item back,
+ * behind LEO_RELEASE_WORKITEM_RESET.
+ *
+ * Until this landed, the command printed "The SD is now available for other sessions" while a
+ * released quick-fix stayed at status='in_progress' with no claimant: reachable by no picker
+ * (the check-in open-QF picker selects status='open') and still counted INTO the coordinator's
+ * available-supply gauge. The message was literally false.
+ *
+ * Also pins the claim-guard.mjs EXEMPTION. FR-1 requires every release path to either call the
+ * shared helper or carry a written reason it must not; claim-guard is the latter, and a
+ * well-meaning future edit wiring it would introduce a real steal race.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+
+let handbackCalls;
+
+function mockModules({ action = 'qf_reopened', ok = true, detail = 'stub', rpcError = null } = {}) {
+  handbackCalls = [];
+  vi.doMock('../fleet/release-work-item.mjs', () => ({
+    isReleaseWorkItemResetEnabled: vi.fn(() => process.env.LEO_RELEASE_WORKITEM_RESET === 'on'),
+    releaseWorkItemOnSessionEnd: vi.fn(async (_sb, key, reason) => {
+      handbackCalls.push({ key, reason });
+      return { ok, action, detail };
+    }),
+  }));
+  vi.doMock('../supabase-client.js', () => ({
+    createSupabaseServiceClient: vi.fn(() => supabaseDouble({ rpcError })),
+  }));
+  vi.doMock('../resolve-own-session.js', () => ({
+    resolveOwnSession: vi.fn(async () => ({
+      session: { session_id: 'sess-1', sd_key: 'QF-20260726-175', status: 'active' },
+      source: 'env',
+    })),
+  }));
+  vi.doMock('../claim/stale-threshold.js', () => ({ getStaleThresholdSeconds: vi.fn(() => 300) }));
+}
+
+const SESSION_ROW = { session_id: 'sess-1', sd_key: 'QF-20260726-175', heartbeat_at: null, status: 'active' };
+
+function supabaseDouble({ rpcError = null } = {}) {
+  // releaseClaim uses two chains off claude_sessions/strategic_directives_v2:
+  //   .select().eq().single()      -> the session row
+  //   .select().eq().maybeSingle() -> the SD row for the LEAD_FINAL warning (null = skip)
+  const leaf = {
+    single: vi.fn().mockResolvedValue({ data: SESSION_ROW, error: null }),
+    maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+    eq: vi.fn(() => ({ limit: vi.fn().mockResolvedValue({ data: [], error: null }) })),
+    limit: vi.fn().mockResolvedValue({ data: [], error: null }),
+  };
+  return {
+    rpc: vi.fn(async () => ({ error: rpcError })),
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({ eq: vi.fn(() => leaf), like: vi.fn(() => leaf) })),
+    })),
+  };
+}
+
+beforeEach(() => { vi.resetModules(); delete process.env.LEO_RELEASE_WORKITEM_RESET; });
+afterEach(() => { vi.restoreAllMocks(); delete process.env.LEO_RELEASE_WORKITEM_RESET; });
+
+describe('FR1B3: /claim release hands the work item back', () => {
+  it('does NOT touch the work item when the flag is unset (default OFF)', async () => {
+    mockModules();
+    const { releaseClaim } = await import('./claim-command.js');
+    await releaseClaim('sess-1');
+    expect(handbackCalls).toHaveLength(0);
+  });
+
+  it('hands the item back AFTER the claim release, naming the mechanism', async () => {
+    // Order matters: the handback predicate requires claiming_session_id IS NULL, so calling it
+    // before release_sd would match nothing.
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    mockModules();
+    const { releaseClaim } = await import('./claim-command.js');
+    await releaseClaim('sess-1');
+    expect(handbackCalls).toEqual([{ key: 'QF-20260726-175', reason: 'manual_claim_release' }]);
+  });
+
+  it('reports the reopen so the operator sees the item really came back', async () => {
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    mockModules({ action: 'qf_reopened' });
+    const logs = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((m) => logs.push(String(m)));
+    const { releaseClaim } = await import('./claim-command.js');
+    await releaseClaim('sess-1');
+    spy.mockRestore();
+    expect(logs.join('\n')).toMatch(/returned to the open pool/);
+  });
+
+  it('surfaces a failed handback instead of silently claiming success', async () => {
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    mockModules({ ok: false, action: 'error', detail: 'db down' });
+    const warns = [];
+    const spy = vi.spyOn(console, 'warn').mockImplementation((m) => warns.push(String(m)));
+    const { releaseClaim } = await import('./claim-command.js');
+    await releaseClaim('sess-1');
+    spy.mockRestore();
+    expect(warns.join('\n')).toMatch(/work-item handback failed/);
+  });
+});
+
+describe('FR1B3: claim-guard.mjs is an EXEMPT site, and the reason is recorded in the source', () => {
+  const GUARD = readFileSync(path.resolve(HERE, '../claim-guard.mjs'), 'utf8');
+
+  it('does not call the handback helper', () => {
+    // claim-guard releases a prior holder's stale claim and then REACQUIRES the same item for
+    // this session. Resetting to status='open' in that window would expose it to every other
+    // picker between our release and our acquire — a steal race that does not exist today,
+    // because an item left at in_progress is invisible to them.
+    expect(GUARD).not.toMatch(/releaseWorkItemOnSessionEnd\s*\(/);
+  });
+
+  it('records WHY it is exempt, so the exemption survives a well-meaning future edit', () => {
+    expect(GUARD).toMatch(/DELIBERATELY NOT a[\s\S]{0,80}releaseWorkItemOnSessionEnd call site/);
+    expect(GUARD).toMatch(/release-then-REACQUIRE/);
+  });
+});

--- a/lib/commands/claim-command.js
+++ b/lib/commands/claim-command.js
@@ -13,6 +13,8 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 import { getStaleThresholdSeconds } from '../claim/stale-threshold.js';
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 3 — see releaseClaim below.
+import { releaseWorkItemOnSessionEnd, isReleaseWorkItemResetEnabled } from '../fleet/release-work-item.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -204,7 +206,28 @@ export async function releaseClaim(sessionId) {
     }
   }
 
+  // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 3, behind LEO_RELEASE_WORKITEM_RESET
+  // (default OFF — unset keeps today's behaviour byte-for-byte).
+  //
+  // Releasing the CLAIM is not the same as returning the WORK ITEM. Until this landed, the
+  // line printed below ("available for other sessions") was literally false for a quick-fix:
+  // release_sd clears claiming_session_id but leaves status='in_progress', and the check-in
+  // open-QF picker selects status='open' — so the item was reachable by nobody while the
+  // coordinator's supply gauge still counted it as available.
+  //
+  // Runs AFTER the release above, never before: the handback predicate requires
+  // claiming_session_id IS NULL, so calling it while the claim is still held matches nothing.
+  let handback = null;
+  if (isReleaseWorkItemResetEnabled()) {
+    handback = await releaseWorkItemOnSessionEnd(supabase, session.sd_key, 'manual_claim_release');
+  }
+
   console.log(`Released claim on ${session.sd_key} from session ${sessionId}.`);
+  if (handback && handback.action === 'qf_reopened') {
+    console.log(`${session.sd_key} returned to the open pool — pickers can see it again.`);
+  } else if (handback && !handback.ok) {
+    console.warn(`Claim released, but the work-item handback failed: ${handback.detail}`);
+  }
   console.log('The SD is now available for other sessions.');
 }
 

--- a/lib/fleet/build-session-launch.cjs
+++ b/lib/fleet/build-session-launch.cjs
@@ -141,8 +141,27 @@ function buildSessionLaunch(spec = {}, opts = {}) {
   //
   // Mutually exclusive with --resume: resuming adopts an EXISTING conversation id, so passing both
   // is contradictory (and --resume already gives the caller a known id).
+  //
+  // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-3 — FORK IS THE THIRD CASE, and it is the one
+  // the mutual-exclusion note above does NOT cover. A fork deliberately carries BOTH: --resume
+  // names the conversation to copy, --session-id names the NEW identity that copy runs under.
+  // That is not contradictory, it is the whole point — re-registering under the OLD id would let
+  // a health check pass against the dead row's still-warm heartbeat, so a dead seat reads alive.
+  //
+  // Found by the EXEC TESTING pass: FR-3 threaded resumeUuid+sessionId through spawn() and
+  // spawnReplacement, but this builder silently DROPPED the sessionId on the resume branch, so
+  // every "fork" emitted a plain --resume and reused the old id. The source-text test asserting
+  // the threading passed while the behaviour did not hold — the accepted-but-unread class this SD
+  // documents four times elsewhere. Opt-in via spec.forkSession so plain resume is unchanged.
   let sessionId = null;
-  if (resumeUuid) {
+  if (resumeUuid && spec.forkSession) {
+    const minted = spec.sessionId;
+    if (!isUuid(minted)) {
+      throw new Error('buildSessionLaunch: forkSession requires a valid UUID sessionId for the NEW identity');
+    }
+    sessionId = String(minted);
+    args.push('--fork-session', '--resume', String(resumeUuid), '--session-id', sessionId);
+  } else if (resumeUuid) {
     args.push('--resume', String(resumeUuid));
     sessionId = String(resumeUuid);
   } else {

--- a/lib/fleet/console-parentage.mjs
+++ b/lib/fleet/console-parentage.mjs
@@ -84,6 +84,61 @@ export function canConcludeLeakStopped({ observationWindowMs, consolesObserved, 
 }
 
 /**
+ * PERSIST the record. Capturing without persisting achieves NOTHING — the whole requirement is
+ * that the record OUTLIVES the parent, and a value returned in a result object dies with the
+ * process that computed it. (Raised by the EXEC TESTING pass: parentage was captured at scan time
+ * and returned, so TS-16's "attributable after the parent exits" did not hold.)
+ *
+ * Append-only JSONL rather than a table: a new table is a chairman-gated DDL, and the requirement
+ * is durability + attributability, which a local append satisfies without one. Each console is
+ * written ONCE per pid+parent pair, so repeated scans of a long-lived console do not spam the log
+ * while a RECYCLED pid under a different parent still records as a new observation.
+ *
+ * Fail-open: a persistence failure must never stop a reap. Returns {written, skipped, error}.
+ */
+export function persistParentageRecords(records, opts = {}) {
+  const {
+    filePath,
+    appendFileSync = null,
+    readFileSync = null,
+    existsSync = null,
+  } = opts;
+  const result = { written: 0, skipped: 0, error: null };
+  if (!filePath || !appendFileSync) {
+    result.error = 'no filePath/appendFileSync provided';
+    return result;
+  }
+  try {
+    // Dedup key is pid+parent, NOT pid alone: Windows recycles pids, and a recycled pid under a
+    // different parent is a genuinely new console that must not be silently swallowed.
+    const seen = new Set();
+    if (existsSync && readFileSync && existsSync(filePath)) {
+      for (const line of String(readFileSync(filePath, 'utf8')).split(/\r?\n/)) {
+        if (!line.trim()) continue;
+        try {
+          const prev = JSON.parse(line);
+          seen.add(`${prev.console_pid}:${prev.parent_pid}`);
+        } catch { /* a corrupt line must not block new writes */ }
+      }
+    }
+    const lines = [];
+    for (const r of records || []) {
+      const rec = r && r.record ? r.record : r;
+      if (!rec || rec.console_pid == null) { result.skipped += 1; continue; }
+      const key = `${rec.console_pid}:${rec.parent_pid}`;
+      if (seen.has(key)) { result.skipped += 1; continue; }
+      seen.add(key);
+      lines.push(JSON.stringify(rec));
+    }
+    if (lines.length) appendFileSync(filePath, lines.join('\n') + '\n', 'utf8');
+    result.written = lines.length;
+  } catch (err) {
+    result.error = (err && err.message) || String(err);
+  }
+  return result;
+}
+
+/**
  * THE REAPER MUST NOT RUN UNDER AN INTERACTIVE PRINCIPAL.
  *
  * This is not a style preference. The leak this FR exists to stop is CAUSED BY a local scheduled

--- a/lib/fleet/console-parentage.mjs
+++ b/lib/fleet/console-parentage.mjs
@@ -1,0 +1,110 @@
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-5c — creation-time parentage capture,
+ * and the principal guard for the reaper's scheduled task.
+ *
+ * WHY THIS IS NOT OPTIONAL, AND WHY IT MUST HAPPEN AT CREATION TIME.
+ *   The console creator is STILL UNIDENTIFIED. A reaper without attribution is a treadmill: it
+ *   will run forever against something nobody has named. And retroactive inspection cannot find
+ *   it — by the time anyone looks, the parent has usually exited, which is precisely why this has
+ *   survived this long. The parent must be recorded WHEN THE CONSOLE APPEARS or not at all.
+ *
+ * WHAT THE MEASUREMENTS ALREADY RULE OUT:
+ *   - The accumulation is BURSTY, NOT CONTINUOUS. A 60-second observation immediately after the
+ *     reap saw ZERO new consoles. So a short sample cannot find the creator, and — stated plainly
+ *     because it is the tempting wrong conclusion — 0-IN-60s IS NOT EVIDENCE THE LEAK IS FIXED.
+ *     The ~30/hour figure is an average over bursts, not a rate.
+ *   - It is NOT the governed spawn path: the consoles accumulated with ZERO fleet_verb_spawn
+ *     events. Attribution therefore cannot be derived from fleet telemetry; it has to come from
+ *     the OS at the moment of creation.
+ *
+ * THE RECORD MUST SURVIVE THE PARENT. Storing a live pid alone is useless minutes later, when
+ *   that pid is gone or — worse — recycled onto an unrelated process. Capture identifying detail
+ *   (image name, command line, parent-of-parent) alongside the pid, so the record still means
+ *   something after the process it describes has exited.
+ */
+
+/** Fields that make a parentage record still meaningful after the parent exits. */
+export const REQUIRED_PARENTAGE_FIELDS = Object.freeze([
+  'console_pid', 'observed_at', 'parent_pid', 'parent_image', 'parent_command_line',
+]);
+
+/**
+ * Build a durable parentage record for a newly-observed console. Pure.
+ * Returns { ok, record, missing } — a record that would not survive the parent's exit is
+ * reported as incomplete rather than silently stored as an answer.
+ */
+export function buildParentageRecord(observation) {
+  const o = observation || {};
+  const record = {
+    console_pid: o.consolePid ?? null,
+    observed_at: o.observedAt ?? null,
+    parent_pid: o.parentPid ?? null,
+    parent_image: o.parentImage ?? null,
+    parent_command_line: o.parentCommandLine ?? null,
+    // Grandparent is what usually names the culprit: the 15 live claude.exe on this host are
+    // grandchildren of Cursor.exe via powershell, so the immediate parent is often just a shell.
+    grandparent_pid: o.grandparentPid ?? null,
+    grandparent_image: o.grandparentImage ?? null,
+    // Recorded so a later reader can tell an attributed console from an unattributed one
+    // WITHOUT re-deriving it from a process table that has since moved on.
+    attribution: null,
+  };
+
+  const missing = REQUIRED_PARENTAGE_FIELDS.filter((f) => record[f] === null || record[f] === undefined);
+  record.attribution = missing.length === 0
+    ? `${record.parent_image}${record.grandparent_image ? ` (via ${record.grandparent_image})` : ''}`
+    : 'unattributed';
+
+  return { ok: missing.length === 0, record, missing };
+}
+
+/**
+ * Is a burst-attribution claim supportable from what was sampled? Pure.
+ *
+ * Guards the specific wrong conclusion the SD calls out: reading a quiet window as a fixed leak.
+ * A window that observed ZERO creations tells you nothing about a BURSTY source — absence over
+ * 60 seconds is not absence, it is a window that happened to miss the burst.
+ */
+export function canConcludeLeakStopped({ observationWindowMs, consolesObserved, burstIntervalEstimateMs = 3_600_000 }) {
+  if (!Number.isFinite(observationWindowMs) || observationWindowMs <= 0) {
+    return { concluded: false, why: 'no observation window' };
+  }
+  if (consolesObserved > 0) {
+    return { concluded: false, why: `${consolesObserved} console(s) still appearing — the leak is live` };
+  }
+  // Zero observed. Only meaningful if the window comfortably exceeds the burst spacing.
+  if (observationWindowMs < burstIntervalEstimateMs * 2) {
+    return {
+      concluded: false,
+      why: `zero consoles in ${Math.round(observationWindowMs / 1000)}s does NOT show the leak stopped — ` +
+           'accumulation is bursty, so a window shorter than the burst spacing simply missed it',
+    };
+  }
+  return { concluded: true, why: `no consoles across ${Math.round(observationWindowMs / 60000)} minutes, well past the estimated burst spacing` };
+}
+
+/**
+ * THE REAPER MUST NOT RUN UNDER AN INTERACTIVE PRINCIPAL.
+ *
+ * This is not a style preference. The leak this FR exists to stop is CAUSED BY a local scheduled
+ * task with an interactive principal — such a task materialises a console every run. Registering
+ * the reaper the same way would make it leak one console per run: a reaper that feeds the thing
+ * it reaps.
+ */
+export function validateScheduledTaskPrincipal(spec) {
+  const s = spec || {};
+  const logon = String(s.logonType || '').toLowerCase();
+  const runLevel = String(s.userId || '').toLowerCase();
+
+  if (logon === 'interactive' || logon === 'interactivetoken') {
+    return { ok: false, reason: 'INTERACTIVE principal requested — this is the exact mechanism that leaks a console per run, and it is what the reaper exists to clean up' };
+  }
+  if (!logon) {
+    return { ok: false, reason: 'no logonType specified — an unspecified principal may default to interactive' };
+  }
+  const session0 = logon === 'serviceaccount' || logon === 's4u' ||
+    runLevel.includes('system') || runLevel.includes('service');
+  return session0
+    ? { ok: true, reason: `session-0 principal (${s.logonType}) — runs without materialising a console` }
+    : { ok: false, reason: `principal '${s.logonType}' is not a recognised session-0 logon type` };
+}

--- a/lib/fleet/console-parentage.test.js
+++ b/lib/fleet/console-parentage.test.js
@@ -5,6 +5,7 @@ import {
   buildParentageRecord,
   canConcludeLeakStopped,
   validateScheduledTaskPrincipal,
+  persistParentageRecords,
   REQUIRED_PARENTAGE_FIELDS,
 } from './console-parentage.mjs';
 
@@ -91,5 +92,63 @@ describe('FR5c-PRINCIPAL: the reaper must not feed the thing it reaps', () => {
 
   it('rejects an unrecognised logon type rather than assuming it is safe', () => {
     expect(validateScheduledTaskPrincipal({ logonType: 'Password', userId: 'rickf' }).ok).toBe(false);
+  });
+});
+
+describe('FR5c-PERSIST: capture without writing achieves nothing', () => {
+  function fakeFs(initial = null) {
+    let content = initial;
+    return {
+      get content() { return content; },
+      appendFileSync: (_p, data) => { content = (content || '') + data; },
+      readFileSync: () => content,
+      existsSync: () => content !== null,
+      opts(filePath = 'X') {
+        return { filePath, appendFileSync: this.appendFileSync, readFileSync: this.readFileSync, existsSync: this.existsSync };
+      },
+    };
+  }
+
+  it('writes one JSONL line per console', () => {
+    const fs = fakeFs();
+    const r = persistParentageRecords([buildParentageRecord(full)], fs.opts());
+    expect(r.written).toBe(1);
+    const rec = JSON.parse(fs.content.trim());
+    expect(rec.console_pid).toBe(1234);
+    expect(rec.parent_image).toBe('powershell.exe');
+    expect(rec.grandparent_image).toBe('Cursor.exe'); // survives the parent's exit
+  });
+
+  it('does NOT re-write the same console on a later scan', () => {
+    const fs = fakeFs();
+    persistParentageRecords([buildParentageRecord(full)], fs.opts());
+    const again = persistParentageRecords([buildParentageRecord(full)], fs.opts());
+    expect(again.written).toBe(0);
+    expect(again.skipped).toBe(1);
+    expect(fs.content.trim().split('\n')).toHaveLength(1);
+  });
+
+  it('DOES record a RECYCLED pid under a different parent — dedup is pid+parent, not pid', () => {
+    // Windows recycles pids. Keying on pid alone would silently swallow a genuinely new console.
+    const fs = fakeFs();
+    persistParentageRecords([buildParentageRecord(full)], fs.opts());
+    const recycled = buildParentageRecord({ ...full, parentPid: 777, parentImage: 'other.exe' });
+    const r = persistParentageRecords([recycled], fs.opts());
+    expect(r.written).toBe(1);
+    expect(fs.content.trim().split('\n')).toHaveLength(2);
+  });
+
+  it('a corrupt existing line does not block new writes', () => {
+    const fs = fakeFs('{not json\n');
+    const r = persistParentageRecords([buildParentageRecord(full)], fs.opts());
+    expect(r.written).toBe(1);
+  });
+
+  it('FAILS OPEN — a write error is reported, never thrown', () => {
+    const r = persistParentageRecords([buildParentageRecord(full)], {
+      filePath: 'X', appendFileSync: () => { throw new Error('disk full'); },
+    });
+    expect(r.error).toMatch(/disk full/);
+    expect(r.written).toBe(0);
   });
 });

--- a/lib/fleet/console-parentage.test.js
+++ b/lib/fleet/console-parentage.test.js
@@ -1,0 +1,95 @@
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-5c — parentage capture + principal guard.
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildParentageRecord,
+  canConcludeLeakStopped,
+  validateScheduledTaskPrincipal,
+  REQUIRED_PARENTAGE_FIELDS,
+} from './console-parentage.mjs';
+
+const full = {
+  consolePid: 1234,
+  observedAt: '2026-07-27T14:00:00Z',
+  parentPid: 99,
+  parentImage: 'powershell.exe',
+  parentCommandLine: 'powershell -NoProfile -Command ...',
+  grandparentPid: 42,
+  grandparentImage: 'Cursor.exe',
+};
+
+describe('FR5c-RECORD: the record must survive the parent exiting', () => {
+  it('builds a complete, attributed record', () => {
+    const { ok, record, missing } = buildParentageRecord(full);
+    expect(ok).toBe(true);
+    expect(missing).toEqual([]);
+    expect(record.attribution).toBe('powershell.exe (via Cursor.exe)');
+  });
+
+  it('keeps identifying detail, not just a pid — a pid alone is useless (or recycled) later', () => {
+    const { record } = buildParentageRecord(full);
+    expect(record.parent_image).toBe('powershell.exe');
+    expect(record.parent_command_line).toMatch(/powershell/);
+  });
+
+  it('records the GRANDPARENT, which is usually what names the culprit', () => {
+    // The 15 live claude.exe on this host are grandchildren of Cursor.exe via powershell,
+    // so the immediate parent is often just a shell and names nothing useful.
+    const { record } = buildParentageRecord(full);
+    expect(record.grandparent_image).toBe('Cursor.exe');
+  });
+
+  it('reports an incomplete record as UNATTRIBUTED rather than storing it as an answer', () => {
+    const { ok, record, missing } = buildParentageRecord({ consolePid: 1, observedAt: 'now' });
+    expect(ok).toBe(false);
+    expect(missing).toEqual(expect.arrayContaining(['parent_pid', 'parent_image', 'parent_command_line']));
+    expect(record.attribution).toBe('unattributed');
+  });
+
+  it('the required-field set is what makes a record outlive its subject', () => {
+    expect(REQUIRED_PARENTAGE_FIELDS).toContain('parent_image');
+    expect(REQUIRED_PARENTAGE_FIELDS).toContain('parent_command_line');
+  });
+});
+
+describe('FR5c-BURST: a quiet window is NOT evidence the leak stopped', () => {
+  it('REFUSES the exact wrong conclusion — 0 consoles in 60s', () => {
+    // Measured: a 60-second observation right after the reap saw zero new consoles. The SD
+    // states plainly that this is not evidence, because accumulation is bursty.
+    const r = canConcludeLeakStopped({ observationWindowMs: 60_000, consolesObserved: 0 });
+    expect(r.concluded).toBe(false);
+    expect(r.why).toMatch(/bursty/);
+  });
+
+  it('a window well past the burst spacing CAN support the conclusion', () => {
+    const r = canConcludeLeakStopped({ observationWindowMs: 3 * 3_600_000, consolesObserved: 0 });
+    expect(r.concluded).toBe(true);
+  });
+
+  it('any console appearing settles it immediately — the leak is live', () => {
+    const r = canConcludeLeakStopped({ observationWindowMs: 10 * 3_600_000, consolesObserved: 1 });
+    expect(r.concluded).toBe(false);
+    expect(r.why).toMatch(/leak is live/);
+  });
+});
+
+describe('FR5c-PRINCIPAL: the reaper must not feed the thing it reaps', () => {
+  it('REJECTS an interactive principal — that IS the leak mechanism', () => {
+    const r = validateScheduledTaskPrincipal({ logonType: 'Interactive', userId: 'rickf' });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/leaks a console per run/);
+  });
+
+  it('rejects an unspecified principal — it may default to interactive', () => {
+    expect(validateScheduledTaskPrincipal({}).ok).toBe(false);
+  });
+
+  it('accepts a session-0 service principal', () => {
+    expect(validateScheduledTaskPrincipal({ logonType: 'ServiceAccount', userId: 'SYSTEM' }).ok).toBe(true);
+    expect(validateScheduledTaskPrincipal({ logonType: 'S4U', userId: 'NT AUTHORITY\\SYSTEM' }).ok).toBe(true);
+  });
+
+  it('rejects an unrecognised logon type rather than assuming it is safe', () => {
+    expect(validateScheduledTaskPrincipal({ logonType: 'Password', userId: 'rickf' }).ok).toBe(false);
+  });
+});

--- a/lib/fleet/console-reaper.mjs
+++ b/lib/fleet/console-reaper.mjs
@@ -1,0 +1,134 @@
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-5b — the death test and the reap decision.
+ *
+ * CHAIRMAN OVERRIDE 2026-07-27 supersedes report-only: "I think you need to be more aggressive
+ * with the 119 terminals." The reaper ships. Authority is recorded on the SD as
+ * metadata.chairman_override_fr5 + fr5_reap_authorized, alongside evidence of an ALREADY-EXECUTED
+ * reap: 149 consoles measured, 148 with zero descendants killed, 0 failures, 1 occupied console
+ * spared, WindowsTerminal host intact, all 15 live claude.exe untouched.
+ *
+ * WHY REAPING EMPTY CONSOLES IS SAFE — the asymmetry is the whole argument. The test is
+ * "contains no process", so a FALSE POSITIVE CANNOT DESTROY WORK: there is nothing in an empty
+ * console to lose. That asymmetry is what makes this shippable at all, and it is why the
+ * pre-kill re-check below matters more than the scan that preceded it.
+ *
+ * DEAD IS THE AND OF TWO INDEPENDENT LEGS. NEITHER IS SUFFICIENT:
+ *   (A) the pid is ABSENT from a Win32_Process claude.exe NAME query. Immune to the wrapper-pid
+ *       error BY CONSTRUCTION — claude_sessions.pid falls back to process.ppid, and a
+ *       powershell.exe is simply not named claude.exe, so the wrong pid cannot pass this leg.
+ *   (B) last_tool_at is IDENTICAL across two samples >= 10 minutes apart (FR-1's
+ *       sampleToolActivityTwice, same primitive FR-2 uses at the opposite polarity).
+ *
+ * EXPLICITLY EXCLUDED, with the reason recorded here so they are not re-added:
+ *   heartbeat_at        — keeps ticking on a PARKED worker whose agent is idle. Four false
+ *                         "fleet down" verdicts are on record from reading it as activity.
+ *   is_alive            — a derived column, only as good as whatever last wrote it.
+ *   process_alive_at    — same class: a stamp, not an observation.
+ *   process.kill(pid,0) as a POSITIVE — sound ONLY as a negative. It proves a pid is absent;
+ *                         it never proves the agent behind it is doing anything.
+ *   window presence     — a Cursor pane has NO window object, and an empty console HAS one. It
+ *                         is anti-correlated with life here: all 15 live claude.exe on this host
+ *                         are grandchildren of Cursor.exe via powershell, while the 148 reaped
+ *                         consoles were top-level windows containing nothing.
+ *
+ * SEAT-TO-WINDOW BINDING IS NOT ATTEMPTED and must not be. Capture is structurally a spawn-time
+ * before/after difference with no post-hoc recovery, and a Cursor pane has no window object at
+ * all. This module never claims to know which seat owns which console.
+ */
+
+/** Minimum gap between the two last_tool_at samples. Leg B is meaningless below this. */
+export const MIN_ACTIVITY_SAMPLE_GAP_MS = 600_000;
+
+/**
+ * Leg A + leg B. Pure.
+ * @param {{absentFromClaudeImages: boolean|null, activitySample: {ok:boolean, identical:boolean, intervalMs:number}|null}} o
+ * @returns {{dead: boolean, legA: boolean, legB: boolean, why: string}}
+ */
+export function isSeatDead({ absentFromClaudeImages, activitySample } = {}) {
+  // An UNKNOWN leg is not a passing leg. Both probes must have actually answered.
+  const legA = absentFromClaudeImages === true;
+  const sampleUsable = Boolean(
+    activitySample && activitySample.ok === true &&
+    Number.isFinite(activitySample.intervalMs) &&
+    activitySample.intervalMs >= MIN_ACTIVITY_SAMPLE_GAP_MS
+  );
+  const legB = sampleUsable && activitySample.identical === true;
+
+  if (legA && legB) {
+    return { dead: true, legA, legB, why: 'absent from the claude.exe image set AND last_tool_at did not move across the sampling window' };
+  }
+  const reasons = [];
+  if (!legA) {
+    reasons.push(absentFromClaudeImages === false
+      ? 'a live claude.exe still carries this pid'
+      : 'could not confirm absence from the claude.exe image set');
+  }
+  if (!legB) {
+    if (!activitySample || activitySample.ok !== true) reasons.push('the activity sample failed — an unreadable sample is not evidence of death');
+    else if (!Number.isFinite(activitySample.intervalMs) || activitySample.intervalMs < MIN_ACTIVITY_SAMPLE_GAP_MS) {
+      reasons.push(`the two samples were less than ${MIN_ACTIVITY_SAMPLE_GAP_MS / 60000} minutes apart`);
+    } else reasons.push('last_tool_at advanced between samples — the agent is working');
+  }
+  return { dead: false, legA, legB, why: reasons.join('; ') };
+}
+
+/**
+ * Is this console reapable? Pure. `descendantCount` must come from a REAL observation —
+ * see enumerateWindowsStrict (FR-5a): a failed enumeration must never arrive here as zero.
+ */
+export function isConsoleReapable({ descendantCount, observed = true } = {}) {
+  if (observed !== true) {
+    return { reapable: false, why: 'the console was not actually observed — a failed probe is not an empty console' };
+  }
+  if (!Number.isFinite(descendantCount)) {
+    return { reapable: false, why: 'descendant count unknown' };
+  }
+  return descendantCount === 0
+    ? { reapable: true, why: 'zero descendants — nothing in it to lose' }
+    : { reapable: false, why: `${descendantCount} descendant process(es) — occupied` };
+}
+
+/**
+ * Reap a set of candidate consoles.
+ *
+ * THE PRE-KILL RE-CHECK IS THE SAFETY MECHANISM, NOT THE SCAN. The scan is a snapshot; a console
+ * can gain a child between scanning and killing. Adam's executed reap re-checked EACH process
+ * IMMEDIATELY BEFORE killing it and spared anything that had gained one — that is the behaviour
+ * reproduced here, and it is why a stale scan cannot destroy work.
+ *
+ * @returns {{killed:number[], spared:Array<{pid:number,why:string}>, failed:Array<{pid:number,error:string}>}}
+ */
+export async function reapEmptyConsoles(candidates, deps = {}) {
+  const { recheckDescendants, kill, onLog = () => {} } = deps;
+  const killed = [], spared = [], failed = [];
+
+  for (const c of candidates || []) {
+    const pid = c && c.pid;
+    if (!Number.isFinite(pid)) { spared.push({ pid, why: 'no pid' }); continue; }
+
+    // Re-observe RIGHT NOW, ignoring whatever the scan said.
+    let live;
+    try {
+      live = await recheckDescendants(pid);
+    } catch (err) {
+      spared.push({ pid, why: `re-check failed (${(err && err.message) || err}) — refusing to kill on an unverified console` });
+      continue;
+    }
+    const verdict = isConsoleReapable(live);
+    if (!verdict.reapable) {
+      spared.push({ pid, why: verdict.why });
+      onLog(`SPARED console ${pid}: ${verdict.why}`);
+      continue;
+    }
+
+    try {
+      await kill(pid);
+      killed.push(pid);
+    } catch (err) {
+      failed.push({ pid, error: (err && err.message) || String(err) });
+    }
+  }
+
+  onLog(`reap complete: killed=${killed.length} spared=${spared.length} failed=${failed.length}`);
+  return { killed, spared, failed };
+}

--- a/lib/fleet/console-reaper.mjs
+++ b/lib/fleet/console-reaper.mjs
@@ -99,8 +99,16 @@ export function isConsoleReapable({ descendantCount, observed = true } = {}) {
  * @returns {{killed:number[], spared:Array<{pid:number,why:string}>, failed:Array<{pid:number,error:string}>}}
  */
 export async function reapEmptyConsoles(candidates, deps = {}) {
-  const { recheckDescendants, kill, onLog = () => {} } = deps;
+  const { recheckDescendants, kill, onLog = () => {}, env = process.env } = deps;
   const killed = [], spared = [], failed = [];
+
+  // THE GATE BELONGS ON THE FUNCTION THAT KILLS, not only on its caller. runReaperOnce checks the
+  // same flag, but this is the function that actually invokes `kill` — and a guard one level above
+  // the primitive holds only while today's single caller remains the only one. Raised by the EXEC
+  // TESTING pass, which noted graceful-kill gates twice (CLI + orchestrator) while this gated once.
+  if (String(env.FLEET_CONSOLE_REAPER_ENABLED || '') !== 'on') {
+    return { killed, spared, failed, refused: 'FLEET_CONSOLE_REAPER_ENABLED is not on' };
+  }
 
   for (const c of candidates || []) {
     const pid = c && c.pid;

--- a/lib/fleet/console-reaper.test.js
+++ b/lib/fleet/console-reaper.test.js
@@ -1,0 +1,121 @@
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-5b — death test + reap decision.
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isSeatDead,
+  isConsoleReapable,
+  reapEmptyConsoles,
+  MIN_ACTIVITY_SAMPLE_GAP_MS,
+} from './console-reaper.mjs';
+
+const goodSample = (identical) => ({ ok: true, identical, intervalMs: MIN_ACTIVITY_SAMPLE_GAP_MS });
+
+describe('FR5b-DEAD: both legs required, NEITHER sufficient', () => {
+  it('dead only when absent from the image set AND last_tool_at did not move', () => {
+    const r = isSeatDead({ absentFromClaudeImages: true, activitySample: goodSample(true) });
+    expect(r).toMatchObject({ dead: true, legA: true, legB: true });
+  });
+
+  it('LEG A ALONE IS NOT ENOUGH — absent pid but the agent is still working', () => {
+    const r = isSeatDead({ absentFromClaudeImages: true, activitySample: goodSample(false) });
+    expect(r.dead).toBe(false);
+    expect(r.why).toMatch(/advanced between samples/);
+  });
+
+  it('LEG B ALONE IS NOT ENOUGH — idle, but a live claude.exe still carries the pid', () => {
+    const r = isSeatDead({ absentFromClaudeImages: false, activitySample: goodSample(true) });
+    expect(r.dead).toBe(false);
+    expect(r.why).toMatch(/live claude\.exe still carries this pid/);
+  });
+
+  it('an UNKNOWN leg is not a passing leg', () => {
+    expect(isSeatDead({ absentFromClaudeImages: null, activitySample: goodSample(true) }).dead).toBe(false);
+    expect(isSeatDead({ absentFromClaudeImages: true, activitySample: null }).dead).toBe(false);
+  });
+
+  it('a FAILED activity sample is not evidence of death', () => {
+    // FR-1's primitive returns identical:false on failure precisely so it authorises nothing.
+    const r = isSeatDead({ absentFromClaudeImages: true, activitySample: { ok: false, identical: false, intervalMs: MIN_ACTIVITY_SAMPLE_GAP_MS } });
+    expect(r.dead).toBe(false);
+    expect(r.why).toMatch(/unreadable sample is not evidence/);
+  });
+
+  it('samples closer than 10 minutes apart do not satisfy leg B', () => {
+    const r = isSeatDead({ absentFromClaudeImages: true, activitySample: { ok: true, identical: true, intervalMs: 60_000 } });
+    expect(r.dead).toBe(false);
+    expect(r.why).toMatch(/less than 10 minutes apart/);
+  });
+});
+
+describe('FR5b-REAPABLE: only a genuinely observed, genuinely empty console', () => {
+  it('zero descendants is reapable', () => {
+    expect(isConsoleReapable({ descendantCount: 0 }).reapable).toBe(true);
+  });
+
+  it('an occupied console is spared', () => {
+    expect(isConsoleReapable({ descendantCount: 2 }).reapable).toBe(false);
+  });
+
+  it('A FAILED PROBE IS NOT AN EMPTY CONSOLE', () => {
+    // The FR-5a defect in miniature: if a failed enumeration arrives here as zero, the reaper
+    // reasons about a desktop it never saw.
+    expect(isConsoleReapable({ descendantCount: 0, observed: false }).reapable).toBe(false);
+    expect(isConsoleReapable({ descendantCount: undefined }).reapable).toBe(false);
+  });
+});
+
+describe('FR5b-RECHECK: the pre-kill re-check is the safety mechanism, not the scan', () => {
+  it('spares a console that GAINED a child between scan and kill', async () => {
+    // The scan said empty; by kill time it has a process. Adam's executed reap did exactly
+    // this and spared such consoles — it is why a stale scan cannot destroy work.
+    const kill = vi.fn(async () => {});
+    const r = await reapEmptyConsoles([{ pid: 101 }], {
+      recheckDescendants: vi.fn(async () => ({ descendantCount: 1 })),
+      kill,
+    });
+    expect(kill).not.toHaveBeenCalled();
+    expect(r.killed).toEqual([]);
+    expect(r.spared[0].why).toMatch(/occupied/);
+  });
+
+  it('kills only what the re-check still finds empty', async () => {
+    const kill = vi.fn(async () => {});
+    const recheck = vi.fn(async (pid) => ({ descendantCount: pid === 202 ? 0 : 3 }));
+    const r = await reapEmptyConsoles([{ pid: 202 }, { pid: 303 }], { recheckDescendants: recheck, kill });
+    expect(r.killed).toEqual([202]);
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(r.spared.map((s) => s.pid)).toEqual([303]);
+  });
+
+  it('refuses to kill when the re-check itself fails', async () => {
+    const kill = vi.fn(async () => {});
+    const r = await reapEmptyConsoles([{ pid: 404 }], {
+      recheckDescendants: vi.fn(async () => { throw new Error('wmi down'); }),
+      kill,
+    });
+    expect(kill).not.toHaveBeenCalled();
+    expect(r.spared[0].why).toMatch(/refusing to kill on an unverified console/);
+  });
+
+  it('records a failed kill without aborting the sweep', async () => {
+    const r = await reapEmptyConsoles([{ pid: 1 }, { pid: 2 }], {
+      recheckDescendants: vi.fn(async () => ({ descendantCount: 0 })),
+      kill: vi.fn(async (pid) => { if (pid === 1) throw new Error('access denied'); }),
+    });
+    expect(r.failed).toEqual([{ pid: 1, error: 'access denied' }]);
+    expect(r.killed).toEqual([2]); // the sweep continued
+  });
+});
+
+describe('FR5b-EXCLUSIONS: the rejected signals stay rejected', () => {
+  it('the module records WHY each excluded signal is excluded', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const src = readFileSync(fileURLToPath(new URL('./console-reaper.mjs', import.meta.url)), 'utf8');
+    for (const signal of ['heartbeat_at', 'is_alive', 'process_alive_at', 'window presence']) {
+      expect(src).toContain(signal);
+    }
+    // and none of them participate in the decision
+    expect(isSeatDead({ absentFromClaudeImages: true, activitySample: goodSample(true), heartbeat_at: 'x', is_alive: true }).dead).toBe(true);
+  });
+});

--- a/lib/fleet/console-reaper.test.js
+++ b/lib/fleet/console-reaper.test.js
@@ -8,6 +8,7 @@ import {
   MIN_ACTIVITY_SAMPLE_GAP_MS,
 } from './console-reaper.mjs';
 
+const REAP_ON = { FLEET_CONSOLE_REAPER_ENABLED: 'on' };
 const goodSample = (identical) => ({ ok: true, identical, intervalMs: MIN_ACTIVITY_SAMPLE_GAP_MS });
 
 describe('FR5b-DEAD: both legs required, NEITHER sufficient', () => {
@@ -71,7 +72,7 @@ describe('FR5b-RECHECK: the pre-kill re-check is the safety mechanism, not the s
     const kill = vi.fn(async () => {});
     const r = await reapEmptyConsoles([{ pid: 101 }], {
       recheckDescendants: vi.fn(async () => ({ descendantCount: 1 })),
-      kill,
+      kill, env: REAP_ON,
     });
     expect(kill).not.toHaveBeenCalled();
     expect(r.killed).toEqual([]);
@@ -81,7 +82,7 @@ describe('FR5b-RECHECK: the pre-kill re-check is the safety mechanism, not the s
   it('kills only what the re-check still finds empty', async () => {
     const kill = vi.fn(async () => {});
     const recheck = vi.fn(async (pid) => ({ descendantCount: pid === 202 ? 0 : 3 }));
-    const r = await reapEmptyConsoles([{ pid: 202 }, { pid: 303 }], { recheckDescendants: recheck, kill });
+    const r = await reapEmptyConsoles([{ pid: 202 }, { pid: 303 }], { recheckDescendants: recheck, kill, env: REAP_ON });
     expect(r.killed).toEqual([202]);
     expect(kill).toHaveBeenCalledTimes(1);
     expect(r.spared.map((s) => s.pid)).toEqual([303]);
@@ -91,7 +92,7 @@ describe('FR5b-RECHECK: the pre-kill re-check is the safety mechanism, not the s
     const kill = vi.fn(async () => {});
     const r = await reapEmptyConsoles([{ pid: 404 }], {
       recheckDescendants: vi.fn(async () => { throw new Error('wmi down'); }),
-      kill,
+      kill, env: REAP_ON,
     });
     expect(kill).not.toHaveBeenCalled();
     expect(r.spared[0].why).toMatch(/refusing to kill on an unverified console/);
@@ -100,7 +101,7 @@ describe('FR5b-RECHECK: the pre-kill re-check is the safety mechanism, not the s
   it('records a failed kill without aborting the sweep', async () => {
     const r = await reapEmptyConsoles([{ pid: 1 }, { pid: 2 }], {
       recheckDescendants: vi.fn(async () => ({ descendantCount: 0 })),
-      kill: vi.fn(async (pid) => { if (pid === 1) throw new Error('access denied'); }),
+      kill: vi.fn(async (pid) => { if (pid === 1) throw new Error('access denied'); }), env: REAP_ON,
     });
     expect(r.failed).toEqual([{ pid: 1, error: 'access denied' }]);
     expect(r.killed).toEqual([2]); // the sweep continued
@@ -117,5 +118,18 @@ describe('FR5b-EXCLUSIONS: the rejected signals stay rejected', () => {
     }
     // and none of them participate in the decision
     expect(isSeatDead({ absentFromClaudeImages: true, activitySample: goodSample(true), heartbeat_at: 'x', is_alive: true }).dead).toBe(true);
+  });
+});
+
+describe('FR5b-GATE: the flag is checked ON THE FUNCTION THAT KILLS', () => {
+  it('refuses to kill when FLEET_CONSOLE_REAPER_ENABLED is unset, even with an empty console', async () => {
+    // The runner checks the same flag, but a guard one level ABOVE the kill primitive holds only
+    // while today's single caller remains the only one.
+    const kill = vi.fn(async () => {});
+    const r = await reapEmptyConsoles([{ pid: 1 }], {
+      recheckDescendants: vi.fn(async () => ({ descendantCount: 0 })), kill, env: {},
+    });
+    expect(kill).not.toHaveBeenCalled();
+    expect(r.refused).toMatch(/FLEET_CONSOLE_REAPER_ENABLED/);
   });
 });

--- a/lib/fleet/graceful-kill.mjs
+++ b/lib/fleet/graceful-kill.mjs
@@ -1,0 +1,202 @@
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-2 — operator-initiated graceful kill.
+ *
+ * THE ORDER IS NOT AN IMPLEMENTATION DETAIL, IT IS THE SAFETY PROPERTY. Every step exists
+ * because a specific failure mode was measured, and each one earns its place ahead of the next:
+ *
+ *   1 IDENTIFY   resolve the pid and cross-check it against the SessionStart marker AND the live
+ *               claude.exe image set. REFUSE on disagreement — claude_sessions.pid falls back to
+ *               process.ppid, and that branch yields a SHELL WRAPPER. Killing it would terminate
+ *               the wrong process. pidIsClaude is immune to this by construction: a powershell.exe
+ *               is not named claude.exe.
+ *   2 PROVE     sample last_tool_at TWICE. ADVANCING is the only positive proof of life;
+ *               process.kill(pid, 0) is sound ONLY as a negative (it proves absence, never work).
+ *   3 PRESERVE  run prepark FIRST, and HALT if the work did not become durable. Nothing below
+ *               this line is reversible.
+ *   4 RELEASE   hand the claim back.
+ *   5 RESET     hand the work item back (FR-1).
+ *   6 KILL      only now. Target the CLAUDE process, not the window, so the terminal survives
+ *               and its exit is readable.
+ *   7 RECORD    via spawn-control stop(), so a real fleet_verb_stop lands.
+ *
+ * OPERATOR-INITIATED ONLY. No watchdog may call this — ratified in two places
+ * (stale-session-sweep.cjs :290 and :2058-2060). The flag below is its own; it deliberately does
+ * NOT reuse FLEET_CANARY_KILL_ENABLED, whose canary-only assert is what keeps drills off
+ * production seats.
+ *
+ * "HALT ON A DIRTY UNPUSHABLE TREE" — INTERPRETED, because the literal reading is wrong.
+ *   The SD says halt on a "dirty-UNPUSHABLE tree". Read literally as "no remote", that would
+ *   refuse to kill any seat in a local-only worktree — but decidePrepark documents dirty+no-remote
+ *   as `commit_only`: "durable locally; the reaper protects it". Work committed locally IS
+ *   preserved, so halting there protects nothing and blocks a legitimate kill.
+ *   THE PROPERTY THAT MATTERS is durability, not pushability: halt when prepark did NOT make the
+ *   work recoverable — it needed to commit and could not, or it needed to push and could not.
+ *   A clean tree, or one prepark successfully committed and/or pushed, is safe to proceed on.
+ */
+
+import { killProcess } from '../utils/process-utils.js';
+import { releaseWorkItemOnSessionEnd } from './release-work-item.mjs';
+
+/** Its OWN flag. FLEET_CANARY_KILL_ENABLED is deliberately not consulted. */
+export function isGracefulKillEnabled(env = process.env) {
+  return env.FLEET_GRACEFUL_KILL_ENABLED === 'on';
+}
+
+/** Ordered step names, exported so tests pin the sequence rather than restating it. */
+export const KILL_STEPS = ['identify', 'prove', 'preserve', 'release', 'reset', 'kill', 'record'];
+
+function verdict(outcome, step, detail, extra = {}) {
+  return { outcome, haltedAt: outcome === 'killed' ? null : step, detail, ...extra };
+}
+
+/**
+ * Decide whether prepark left the work recoverable. Pure, so the interpretation above is
+ * testable on its own rather than only through a kill.
+ * @param {{action:string, committed:boolean, pushed:boolean, note?:string}} pre
+ * @param {boolean} wasDirty
+ */
+export function isWorkDurableAfterPrepark(pre, wasDirty) {
+  if (!pre) return { durable: false, why: 'prepark produced no result' };
+  if (!wasDirty && pre.action === 'noop') return { durable: true, why: 'clean tree, nothing to preserve' };
+  switch (pre.action) {
+    case 'noop':
+      return { durable: true, why: pre.note ? `nothing to do (${pre.note})` : 'nothing to do' };
+    case 'commit_only':
+      // Durable WITHOUT a remote — this is the case the literal "unpushable => halt" reading
+      // would have wrongly blocked.
+      return pre.committed
+        ? { durable: true, why: 'committed locally (no remote); recoverable from the worktree' }
+        : { durable: false, why: 'needed a local commit and it did not happen' };
+    case 'commit_and_push':
+      if (!pre.committed) return { durable: false, why: 'needed a commit and it did not happen' };
+      return pre.pushed
+        ? { durable: true, why: 'committed and pushed' }
+        : { durable: false, why: 'committed but the push failed — work exists only in a worktree about to lose its process' };
+    case 'push_only':
+      return pre.pushed
+        ? { durable: true, why: 'pushed previously-committed work' }
+        : { durable: false, why: 'had unpushed commits and the push failed' };
+    default:
+      return { durable: false, why: `unrecognised prepark action '${pre.action}'` };
+  }
+}
+
+/**
+ * Cross-check the pid across three independent sources. Returns the agreed pid or a refusal.
+ * A disagreement is NEVER resolved by guessing — the whole point is that one of the sources
+ * (claude_sessions.pid) is known to sometimes hold a shell wrapper.
+ */
+export function reconcilePid({ dbPid, markerPid, pidIsClaudeResult }) {
+  if (!dbPid) return { ok: false, detail: 'claude_sessions.pid is null — nothing to verify or kill' };
+  if (markerPid && markerPid !== dbPid) {
+    return { ok: false, detail: `pid disagreement: claude_sessions.pid=${dbPid} but the SessionStart marker says ${markerPid} — refusing to guess which is the agent` };
+  }
+  if (pidIsClaudeResult === false) {
+    return { ok: false, detail: `pid ${dbPid} is not a live claude.exe — it is most likely the shell wrapper that claude_sessions.pid falls back to (process.ppid), and killing it would terminate the wrong process` };
+  }
+  if (pidIsClaudeResult !== true) {
+    return { ok: false, detail: `could not confirm pid ${dbPid} is a live claude.exe; refusing rather than killing an unverified pid` };
+  }
+  return { ok: true, pid: dbPid };
+}
+
+/**
+ * Execute the graceful kill. Returns a verdict; never throws.
+ * Every collaborator is injected so the ORDER can be asserted without touching a real seat.
+ *
+ * @returns {{outcome:'killed'|'refused'|'halted'|'disabled', haltedAt:string|null, detail:string, steps:string[]}}
+ */
+export async function gracefulKillSession(supabase, sessionId, deps = {}) {
+  const {
+    env = process.env,
+    getSession,          // async () => { pid, sd_key, worktree_path }
+    readMarkerPid,       // (sessionId) => number|null
+    pidIsClaude,         // (pid) => boolean
+    sampleToolActivity,  // async (sb, sessionId) => { ok, advancing }
+    runPreparkWip,       // ({worktreePath, sdKey}) => preparkResult
+    isWorktreeDirty,     // (worktreePath) => boolean
+    releaseClaim,        // async (sessionId, sdKey) => { released }
+    kill = killProcess,
+    recordStop,          // async (sessionId) => void   (spawn-control stop(); emits fleet_verb_stop)
+    verifyGone,          // async (pid) => boolean      (Win32_Process name query)
+    reason = 'operator_graceful_kill',
+  } = deps;
+
+  const steps = [];
+  if (!isGracefulKillEnabled(env)) {
+    return { ...verdict('disabled', 'identify', 'FLEET_GRACEFUL_KILL_ENABLED is not on'), steps };
+  }
+
+  try {
+    // ---- 1 IDENTIFY -------------------------------------------------------------------
+    steps.push('identify');
+    const session = await getSession();
+    if (!session) return { ...verdict('refused', 'identify', `no session row for ${sessionId}`), steps };
+    const rec = reconcilePid({
+      dbPid: session.pid,
+      markerPid: readMarkerPid ? readMarkerPid(sessionId) : null,
+      pidIsClaudeResult: pidIsClaude ? pidIsClaude(session.pid) : undefined,
+    });
+    if (!rec.ok) return { ...verdict('refused', 'identify', rec.detail), steps };
+
+    // ---- 2 PROVE ----------------------------------------------------------------------
+    steps.push('prove');
+    const activity = await sampleToolActivity(supabase, sessionId);
+    // NOTE: an ADVANCING sample means the agent is actively working. That is not a reason to
+    // refuse an OPERATOR-initiated kill — the operator can see the seat and has decided. It is
+    // recorded so the verdict says what was true at the moment of the kill.
+    const wasAdvancing = activity && activity.ok === true && activity.advancing === true;
+
+    // ---- 3 PRESERVE (last reversible step) ---------------------------------------------
+    steps.push('preserve');
+    const wasDirty = isWorktreeDirty ? isWorktreeDirty(session.worktree_path) : false;
+    const pre = runPreparkWip({ worktreePath: session.worktree_path, sdKey: session.sd_key });
+    const durability = isWorkDurableAfterPrepark(pre, wasDirty);
+    if (!durability.durable) {
+      return {
+        ...verdict('halted', 'preserve', `WIP is not recoverable — ${durability.why}. Refusing to kill; nothing has been released or terminated.`),
+        steps, prepark: pre, wasAdvancing,
+      };
+    }
+
+    // ---- 4 RELEASE --------------------------------------------------------------------
+    steps.push('release');
+    const rel = releaseClaim ? await releaseClaim(sessionId, session.sd_key) : { released: true };
+
+    // ---- 5 RESET ----------------------------------------------------------------------
+    // Only when the claim actually went. With the release unproven the hand-back predicate
+    // cannot be trusted to protect an item carrying real work.
+    steps.push('reset');
+    let handback = null;
+    if (rel && rel.released !== false && session.sd_key) {
+      handback = await releaseWorkItemOnSessionEnd(supabase, session.sd_key, reason);
+    }
+
+    // ---- 6 KILL -----------------------------------------------------------------------
+    steps.push('kill');
+    await kill(rec.pid, 'SIGTERM');
+    let gone = verifyGone ? await verifyGone(rec.pid) : true;
+    if (!gone) {
+      await kill(rec.pid, 'SIGKILL');
+      gone = verifyGone ? await verifyGone(rec.pid) : true;
+    }
+
+    // ---- 7 RECORD ---------------------------------------------------------------------
+    // stop() also re-runs release + hand-back; both are CAS-guarded and idempotent, so the
+    // second pass is a no-op. It is called for the fleet_verb_stop event, which is the only
+    // durable record that this kill happened.
+    steps.push('record');
+    if (recordStop) await recordStop(sessionId);
+
+    return {
+      outcome: gone ? 'killed' : 'refused',
+      haltedAt: gone ? null : 'kill',
+      detail: gone
+        ? `claude pid ${rec.pid} terminated and verified absent; terminal left running`
+        : `pid ${rec.pid} still present after SIGTERM then SIGKILL — reporting failure rather than a status flip`,
+      steps, prepark: pre, handback, wasAdvancing,
+    };
+  } catch (err) {
+    return { ...verdict('refused', steps[steps.length - 1] || 'identify', `unexpected error: ${(err && err.message) || err}`), steps };
+  }
+}

--- a/lib/fleet/graceful-kill.test.js
+++ b/lib/fleet/graceful-kill.test.js
@@ -1,0 +1,158 @@
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-2 — graceful kill.
+// The ORDER is the safety property, so most of these assert sequencing and refusal, not output.
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  gracefulKillSession,
+  isGracefulKillEnabled,
+  isWorkDurableAfterPrepark,
+  reconcilePid,
+  KILL_STEPS,
+} from './graceful-kill.mjs';
+
+const ON = { FLEET_GRACEFUL_KILL_ENABLED: 'on' };
+
+function deps(over = {}) {
+  const calls = [];
+  const base = {
+    env: ON,
+    getSession: vi.fn(async () => ({ pid: 4242, sd_key: 'QF-20260726-175', worktree_path: 'C:/wt' })),
+    readMarkerPid: vi.fn(() => 4242),
+    pidIsClaude: vi.fn(() => true),
+    sampleToolActivity: vi.fn(async () => { calls.push('sample'); return { ok: true, advancing: false }; }),
+    isWorktreeDirty: vi.fn(() => true),
+    runPreparkWip: vi.fn(() => { calls.push('prepark'); return { action: 'commit_and_push', committed: true, pushed: true }; }),
+    releaseClaim: vi.fn(async () => { calls.push('release'); return { released: true }; }),
+    kill: vi.fn(async (_pid, sig) => { calls.push(`kill:${sig}`); }),
+    recordStop: vi.fn(async () => { calls.push('record'); }),
+    verifyGone: vi.fn(async () => true),
+  };
+  return { calls, d: { ...base, ...over } };
+}
+
+// The hand-back is a real import; stub the module so the sequence is observable.
+vi.mock('./release-work-item.mjs', () => ({
+  releaseWorkItemOnSessionEnd: vi.fn(async () => ({ ok: true, action: 'qf_reopened', detail: 'stub' })),
+}));
+
+describe('FR2-FLAG: its own flag, never the canary flag', () => {
+  it('is OFF unless FLEET_GRACEFUL_KILL_ENABLED is exactly "on"', () => {
+    expect(isGracefulKillEnabled({})).toBe(false);
+    expect(isGracefulKillEnabled({ FLEET_GRACEFUL_KILL_ENABLED: 'true' })).toBe(false);
+    expect(isGracefulKillEnabled({ FLEET_GRACEFUL_KILL_ENABLED: 'on' })).toBe(true);
+  });
+
+  it('FLEET_CANARY_KILL_ENABLED alone CANNOT enable it', async () => {
+    // The canary flag's canary-only assert is what keeps drills off production seats.
+    // Reusing it here would hand this verb that blast radius.
+    expect(isGracefulKillEnabled({ FLEET_CANARY_KILL_ENABLED: 'on' })).toBe(false);
+    const { d } = deps({ env: { FLEET_CANARY_KILL_ENABLED: 'on' } });
+    const r = await gracefulKillSession({}, 's1', d);
+    expect(r.outcome).toBe('disabled');
+    expect(d.kill).not.toHaveBeenCalled();
+  });
+});
+
+describe('FR2-ORDER: the eight steps run in the order that makes them safe', () => {
+  it('preserve precedes release precedes reset precedes kill precedes record', async () => {
+    const { calls, d } = deps();
+    const r = await gracefulKillSession({}, 's1', d);
+    expect(r.outcome).toBe('killed');
+    expect(r.steps).toEqual(KILL_STEPS);
+    // WIP is preserved before anything irreversible; the process dies only after the claim
+    // and the work item have been handed back.
+    expect(calls).toEqual(['sample', 'prepark', 'release', 'kill:SIGTERM', 'record']);
+  });
+
+  it('escalates SIGTERM -> SIGKILL only when the process survives', async () => {
+    const { calls, d } = deps({ verifyGone: vi.fn().mockResolvedValueOnce(false).mockResolvedValue(true) });
+    await gracefulKillSession({}, 's1', d);
+    expect(calls.filter((c) => c.startsWith('kill:'))).toEqual(['kill:SIGTERM', 'kill:SIGKILL']);
+  });
+
+  it('reports failure when the process is STILL present after SIGKILL — not a status flip', async () => {
+    // The SD's acceptance is "absent from a Win32_Process name query", precisely because
+    // spawn-control stop() used to flip a column and leave the process running.
+    const { d } = deps({ verifyGone: vi.fn(async () => false) });
+    const r = await gracefulKillSession({}, 's1', d);
+    expect(r.outcome).toBe('refused');
+    expect(r.detail).toMatch(/still present after SIGTERM then SIGKILL/);
+  });
+});
+
+describe('FR2-IDENTIFY: refuse rather than kill the wrong process', () => {
+  it('refuses when the marker pid disagrees with claude_sessions.pid', async () => {
+    const { d } = deps({ readMarkerPid: vi.fn(() => 9999) });
+    const r = await gracefulKillSession({}, 's1', d);
+    expect(r.outcome).toBe('refused');
+    expect(r.haltedAt).toBe('identify');
+    expect(r.detail).toMatch(/refusing to guess/);
+    expect(d.kill).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the pid is not a live claude.exe (the shell-wrapper case)', async () => {
+    // claude_sessions.pid falls back to process.ppid, which yields a wrapper. pidIsClaude is
+    // immune by construction: a powershell.exe is not named claude.exe.
+    const { d } = deps({ pidIsClaude: vi.fn(() => false) });
+    const r = await gracefulKillSession({}, 's1', d);
+    expect(r.outcome).toBe('refused');
+    expect(r.detail).toMatch(/shell wrapper/);
+    expect(d.kill).not.toHaveBeenCalled();
+  });
+
+  it('refuses an unverifiable pid rather than killing it', async () => {
+    const { d } = deps({ pidIsClaude: vi.fn(() => undefined) });
+    const r = await gracefulKillSession({}, 's1', d);
+    expect(r.outcome).toBe('refused');
+    expect(d.kill).not.toHaveBeenCalled();
+  });
+
+  it('reconcilePid is pure and refuses a null pid', () => {
+    expect(reconcilePid({ dbPid: null }).ok).toBe(false);
+    expect(reconcilePid({ dbPid: 1, markerPid: 1, pidIsClaudeResult: true })).toEqual({ ok: true, pid: 1 });
+  });
+});
+
+describe('FR2-PRESERVE: halt on unrecoverable WIP, and NOTHING is released or killed', () => {
+  it('halts when a commit was needed and did not happen', async () => {
+    const { d } = deps({ runPreparkWip: vi.fn(() => ({ action: 'commit_and_push', committed: false, pushed: false })) });
+    const r = await gracefulKillSession({}, 's1', d);
+    expect(r.outcome).toBe('halted');
+    expect(r.haltedAt).toBe('preserve');
+    expect(d.releaseClaim).not.toHaveBeenCalled();
+    expect(d.kill).not.toHaveBeenCalled();
+  });
+
+  it('halts when the commit landed but the push failed', async () => {
+    const { d } = deps({ runPreparkWip: vi.fn(() => ({ action: 'commit_and_push', committed: true, pushed: false })) });
+    const r = await gracefulKillSession({}, 's1', d);
+    expect(r.outcome).toBe('halted');
+    expect(r.detail).toMatch(/only in a worktree about to lose its process/);
+  });
+
+  it('PROCEEDS on a dirty tree with NO REMOTE once it is committed locally', async () => {
+    // The literal reading of "halt on a dirty-unpushable tree" would refuse here forever.
+    // decidePrepark calls this case durable: "commit locally (reaper protects it)".
+    const { d } = deps({ runPreparkWip: vi.fn(() => ({ action: 'commit_only', committed: true, pushed: false })) });
+    const r = await gracefulKillSession({}, 's1', d);
+    expect(r.outcome).toBe('killed');
+  });
+
+  it('isWorkDurableAfterPrepark is pure and covers every prepark action', () => {
+    expect(isWorkDurableAfterPrepark({ action: 'noop' }, false).durable).toBe(true);
+    expect(isWorkDurableAfterPrepark({ action: 'commit_only', committed: true }, true).durable).toBe(true);
+    expect(isWorkDurableAfterPrepark({ action: 'commit_only', committed: false }, true).durable).toBe(false);
+    expect(isWorkDurableAfterPrepark({ action: 'push_only', pushed: false }, false).durable).toBe(false);
+    expect(isWorkDurableAfterPrepark({ action: 'wat' }, true).durable).toBe(false);
+    expect(isWorkDurableAfterPrepark(null, true).durable).toBe(false);
+  });
+});
+
+describe('FR2-RESET: the hand-back is skipped when the release did not happen', () => {
+  it('does not hand the item back on an unproven release', async () => {
+    const { d } = deps({ releaseClaim: vi.fn(async () => ({ released: false })) });
+    const r = await gracefulKillSession({}, 's1', d);
+    expect(r.handback).toBeNull();
+    expect(r.outcome).toBe('killed'); // the kill still proceeds; only the hand-back is withheld
+  });
+});

--- a/lib/fleet/release-work-item.mjs
+++ b/lib/fleet/release-work-item.mjs
@@ -60,6 +60,47 @@
  *   every future call site silently inherit a behaviour that contradicts its own documented
  *   intent, and would do so invisibly — the SD would simply come back one phase earlier.
  *   Returning a QF to the open pool carries no such ambiguity and is always applied.
+ *
+ * THE SIXTEEN-SITE LEDGER, RESOLVED (FR-1b). The SD lists sixteen release/clear sites to
+ * convert. Surveyed one by one, they are NOT uniform, and mechanically wiring all sixteen would
+ * have caused three distinct regressions. The list says WHERE TO LOOK, not WHAT TO DO.
+ *
+ *   WIRED (5) — the holder is gone and the item is genuinely abandoned:
+ *     lib/fleet/spawn-control.js stop()            flagged
+ *     scripts/stale-session-sweep.cjs              UNFLAGGED + rewindPhase:true (pre-existing
+ *                                                  behaviour; flagging it would have DISABLED
+ *                                                  live protection on merge)
+ *     lib/commands/claim-command.js releaseClaim() flagged
+ *     lib/claim-validity-gate.js                   flagged (dead / drifted owner)
+ *     scripts/worker-checkin.cjs selfHealStaleClaim flagged (QF-capable: self_claimed_qf puts a
+ *                                                  QF id in claude_sessions.sd_key)
+ *
+ *   EXEMPT — WIRING WOULD CAUSE HARM (3):
+ *     lib/claim-guard.mjs                  release-then-REACQUIRE; reopening in that window
+ *                                          manufactures a steal race that does not exist today
+ *     lib/claim-lifecycle-release.mjs      worker is STILL ALIVE and shipping; handing back
+ *                                          invites a second worker onto live work
+ *     scripts/coordinator-cold-recovery.cjs rewind would convert resume into restart
+ *
+ *   EXEMPT — TERMINAL, NOT A HAND-BACK (3): the item is not returning to any pool.
+ *     scripts/cancel-sd.js (cancelled) · complete-quick-fix/orchestrator.js (completed) ·
+ *     lib/sd-creation/source-adapters/qf.js (escalated to an SD)
+ *
+ *   NO-OP BY CONSTRUCTION (4): these resolve their key from strategic_directives_v2, so it is
+ *     never a QF, and with rewindPhase defaulting false the helper returns immediately. Wiring
+ *     them adds a call and changes nothing.
+ *     lib/drain-orchestrator.mjs · lib/coordinator/singleton-refresh-sequencer.cjs ·
+ *     scripts/claim-orchestrator-for-rollup.mjs ·
+ *     scripts/modules/handoff/gates/multi-session-claim-gate.js
+ *
+ *   EXEMPT — THE SHORTCUT TRAP (1):
+ *     lib/claim/release-claim-both-surfaces.mjs — the shared release primitive. Wiring the
+ *     hand-back HERE would look like fixing every site at once, and would instead force it onto
+ *     the three harmful-if-wired sites above, all of which call it. Warning recorded in that file.
+ *
+ *   The QF-vs-SD discriminator that drives most of this: a site whose key comes from
+ *   claude_sessions.sd_key CAN be holding a quick-fix; one whose key comes from
+ *   strategic_directives_v2 cannot.
  */
 
 import { assertSweepHandoffGate } from '../exec-context-guard.mjs';

--- a/lib/fleet/release-work-item.mjs
+++ b/lib/fleet/release-work-item.mjs
@@ -43,6 +43,23 @@
  *
  * FLAGGING: this module is inert until wired. The per-site conversion (FR-1b) is what
  *   sits behind LEO_RELEASE_WORKITEM_RESET (default OFF) — see isReleaseWorkItemResetEnabled.
+ *
+ * SD PHASE REWIND IS OPT-IN (`rewindPhase`, default FALSE) — corrected during FR-1b.
+ *   The SD frames the helper as "for an SD: resetSdPhaseOnRelease", which reads as though every
+ *   release path should rewind current_phase. Surveying the actual call sites disproves that:
+ *     - stale-session-sweep.cjs WANTS the rewind. Its PHASE_RESET_MAP exists so an SD is not
+ *       "left in mid-phase limbo with no active claimer", and it passes rewindPhase:true.
+ *     - coordinator-cold-recovery.cjs FORBIDS it, in its own words: "PRESERVES current_phase +
+ *       progress (resume, not restart)". Rewinding there would convert a resume into a restart
+ *       and discard the phase/progress the whole path exists to protect.
+ *     - claim-validity-gate.js releases a dead/drifted owner so the NEXT claimer can pick the SD
+ *       up. The fleet's resume contract (worker-checkin resume_orphan: "reads the SD's live
+ *       current_phase ... NOT a restart — keep existing commits/PRD/handoffs") means preserving
+ *       is correct there too.
+ *   So the rewind is a per-site POLICY, not a property of releasing. Defaulting it ON would make
+ *   every future call site silently inherit a behaviour that contradicts its own documented
+ *   intent, and would do so invisibly — the SD would simply come back one phase earlier.
+ *   Returning a QF to the open pool carries no such ambiguity and is always applied.
  */
 
 import { assertSweepHandoffGate } from '../exec-context-guard.mjs';
@@ -78,7 +95,10 @@ export function isQuickFixKey(workItemKey) {
  *   action: 'qf_reopened' | 'qf_untouched' | 'sd_phase_reset' | 'sd_no_reset' | 'skipped' | 'error'
  */
 export async function releaseWorkItemOnSessionEnd(supabase, workItemKey, reason, opts = {}) {
-  const { onLog = () => {} } = opts;
+  // rewindPhase defaults FALSE — see the "SD PHASE REWIND IS OPT-IN" note in the module
+  // header. Returning a QF to the open pool is universally correct for a hand-back; rewinding
+  // an SD's phase is a POLICY that several release paths explicitly forbid.
+  const { onLog = () => {}, rewindPhase = false } = opts;
   if (!supabase || !workItemKey) {
     return { ok: false, kind: null, action: 'skipped', reason, detail: 'missing supabase client or work item key' };
   }
@@ -115,7 +135,10 @@ export async function releaseWorkItemOnSessionEnd(supabase, workItemKey, reason,
       };
     }
 
-    // ---- SD branch: rewind to the safe phase boundary, guarded ----
+    // ---- SD branch: rewind to the safe phase boundary, guarded, OPT-IN ----
+    if (!rewindPhase) {
+      return { ok: true, kind: 'sd', action: 'sd_no_reset', reason, detail: 'phase rewind not requested (rewindPhase:false) — claim released, phase preserved for resume' };
+    }
     const { data: sd, error: readErr } = await supabase
       .from('strategic_directives_v2')
       .select('sd_key, current_phase, status')

--- a/lib/fleet/release-work-item.mjs
+++ b/lib/fleet/release-work-item.mjs
@@ -1,0 +1,226 @@
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1
+ *
+ * releaseWorkItemOnSessionEnd() — the ONE work-item reset every release path calls,
+ * plus sampleToolActivityTwice(), the ONE two-sample activity primitive.
+ *
+ * WHY THIS EXISTS
+ *   The work-item reset lives today on exactly ONE release path
+ *   (scripts/stale-session-sweep.cjs, the CLAIM_BOUNDARY_PROBE branch). Every other
+ *   release path clears the CLAIM but leaves the work item itself in a state no picker
+ *   can see: a QF stays status='in_progress' with no claimant, so the check-in open-QF
+ *   picker (which selects status='open') cannot reach it, while the coordinator's supply
+ *   gauge still counts it as available. The item reads as owned and is reachable by
+ *   nobody. lib/fleet/spawn-control.js:538 stop() is itself one of these — it marks the
+ *   row released and never touches the work item — which is why a Kill button built
+ *   before this helper would manufacture strands faster than hand-closing windows does.
+ *
+ * THE isSweepResetAllowed DECISION — RESOLVED, and the SD's framing was wrong
+ *   The SD records an unresolved decision: "the reset is gated by isSweepResetAllowed,
+ *   so extracting it forces a choice — carry the guard and every caller inherits sweep
+ *   semantics, or drop it and lose a predicate that exists because it was needed."
+ *   That is a FALSE DILEMMA, because it conflates the two branches. Measured in
+ *   scripts/stale-session-sweep.cjs at the CLAIM_BOUNDARY_PROBE site:
+ *
+ *     - The QF branch (:237-239) is NOT gated by isSweepResetAllowed AT ALL. Its guard
+ *       is the column predicate itself — status='in_progress' AND claiming_session_id IS
+ *       NULL AND pr_url IS NULL AND commit_sha IS NULL. Nothing to carry or drop.
+ *     - The SD branch (:242) calls resetSdPhaseOnRelease, and only THAT is gated.
+ *
+ *   And the guard is not "sweep semantics". lib/exec-context-guard.mjs
+ *   assertSweepHandoffGate answers one question: would resetting this SD to
+ *   targetResetPhase override a handoff that has ALREADY BEEN ACCEPTED past that phase?
+ *   The name says "Sweep" only because the sweep was its first caller. Overriding an
+ *   accepted handoff is wrong for EVERY release path, not just the sweep.
+ *
+ *   RESOLUTION: CARRY the guard on the SD branch — every caller SHOULD inherit it,
+ *   because it protects a real invariant rather than a sweep-local policy. The QF branch
+ *   carries no guard because it never had one; its column predicate IS the guard.
+ *   CONSEQUENCE OF THE LOSING OPTION, recorded as the PRD requires: dropping the guard
+ *   would let any release path silently rewind an SD whose next phase was already
+ *   accepted, reintroducing exactly the override that SD-FDBK-INFRA-EXEC-CONTEXT-GUARD-001
+ *   added it to prevent.
+ *
+ * FLAGGING: this module is inert until wired. The per-site conversion (FR-1b) is what
+ *   sits behind LEO_RELEASE_WORKITEM_RESET (default OFF) — see isReleaseWorkItemResetEnabled.
+ */
+
+import { assertSweepHandoffGate } from '../exec-context-guard.mjs';
+
+/** Mid-phase state → the safe boundary it rewinds to. Mirrors the sweep's map. */
+export const PHASE_RESET_MAP = {
+  EXEC: 'PLAN_PRD',
+  EXEC_COMPLETE: 'PLAN_PRD',
+  PLAN_VERIFICATION: 'PLAN_PRD',
+  LEAD_APPROVAL: 'LEAD',
+  LEAD_FINAL_APPROVAL: 'LEAD_FINAL',
+};
+
+/**
+ * FR-1b gate. Default OFF: an unset/absent value must never enable conversion, so the
+ * check is an explicit opt-in equality rather than a truthiness test.
+ */
+export function isReleaseWorkItemResetEnabled(env = process.env) {
+  return env.LEO_RELEASE_WORKITEM_RESET === 'on';
+}
+
+/** A work item is a quick-fix iff its key carries the QF- prefix; everything else is an SD. */
+export function isQuickFixKey(workItemKey) {
+  return typeof workItemKey === 'string' && /^QF-/.test(workItemKey);
+}
+
+/**
+ * Reset ONE work item so a picker can see it again, after its claim has been released.
+ *
+ * Returns a verdict object — never throws. A release path must not abort because a reset
+ * failed; the claim is already gone and the next sweep re-converges.
+ *   { ok, kind, action, reason, detail }
+ *   action: 'qf_reopened' | 'qf_untouched' | 'sd_phase_reset' | 'sd_no_reset' | 'skipped' | 'error'
+ */
+export async function releaseWorkItemOnSessionEnd(supabase, workItemKey, reason, opts = {}) {
+  const { onLog = () => {} } = opts;
+  if (!supabase || !workItemKey) {
+    return { ok: false, kind: null, action: 'skipped', reason, detail: 'missing supabase client or work item key' };
+  }
+
+  try {
+    if (isQuickFixKey(workItemKey)) {
+      // Guarded on EVERY column so an item carrying real work (a PR or a commit) or a
+      // fresh claimant is never reverted. The UPDATE is the guard — it is applied in the
+      // WHERE clause, not read-then-written, so a claimant arriving mid-flight loses the
+      // row from the predicate rather than racing us.
+      const { data, error } = await supabase
+        .from('quick_fixes')
+        .update({ status: 'open' })
+        .eq('id', workItemKey)
+        .filter('status', 'eq', 'in_progress')
+        .is('claiming_session_id', null)
+        .is('pr_url', null)
+        .is('commit_sha', null)
+        .select('id');
+
+      if (error) {
+        return { ok: false, kind: 'qf', action: 'error', reason, detail: error.message };
+      }
+      const reopened = Array.isArray(data) && data.length > 0;
+      if (reopened) onLog(`WORK_ITEM_RESET: ${workItemKey} in_progress → open (${reason})`);
+      return {
+        ok: true,
+        kind: 'qf',
+        action: reopened ? 'qf_reopened' : 'qf_untouched',
+        reason,
+        detail: reopened
+          ? 'no claimant, no pr_url, no commit_sha — returned to the open pool'
+          : 'predicate did not match (already open, or carries a claimant / pr_url / commit_sha)',
+      };
+    }
+
+    // ---- SD branch: rewind to the safe phase boundary, guarded ----
+    const { data: sd, error: readErr } = await supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, current_phase, status')
+      .eq('sd_key', workItemKey)
+      .maybeSingle();
+
+    if (readErr) return { ok: false, kind: 'sd', action: 'error', reason, detail: readErr.message };
+    if (!sd) return { ok: true, kind: 'sd', action: 'sd_no_reset', reason, detail: 'SD not found (vanished or unknown key)' };
+
+    const resetTo = PHASE_RESET_MAP[sd.current_phase];
+    if (!resetTo) {
+      return { ok: true, kind: 'sd', action: 'sd_no_reset', reason, detail: `current_phase '${sd.current_phase}' is already a safe boundary` };
+    }
+
+    // CARRIED GUARD (see the decision above): never rewind past an ACCEPTED handoff.
+    // Fail-soft in both directions — a guard that cannot answer must not authorise the
+    // write, and must not abort the caller either.
+    try {
+      await assertSweepHandoffGate(supabase, workItemKey, resetTo);
+    } catch (err) {
+      const code = (err && err.code) || 'UNKNOWN';
+      onLog(`SKIP_RESET: ${workItemKey} — ${reason} — ${code}: ${err && err.message ? err.message : err}`);
+      return { ok: true, kind: 'sd', action: 'sd_no_reset', reason, detail: `handoff gate blocked the reset (${code})` };
+    }
+
+    const { error: updErr } = await supabase
+      .from('strategic_directives_v2')
+      .update({ current_phase: resetTo })
+      .eq('sd_key', workItemKey);
+
+    if (updErr) return { ok: false, kind: 'sd', action: 'error', reason, detail: updErr.message };
+    onLog(`PHASE_RESET: ${workItemKey} ${sd.current_phase} → ${resetTo} (${reason})`);
+    return { ok: true, kind: 'sd', action: 'sd_phase_reset', reason, detail: `${sd.current_phase} → ${resetTo}` };
+  } catch (err) {
+    return { ok: false, kind: null, action: 'error', reason, detail: (err && err.message) || String(err) };
+  }
+}
+
+/**
+ * Sample claude_sessions.last_tool_at TWICE, intervalMs apart.
+ *
+ * THE SINGLE OWNER of the two-sample pattern, consumed at OPPOSITE POLARITY by two FRs:
+ *   FR-2 (graceful kill) needs ADVANCING — it is the only positive proof of life.
+ *     process.kill(pid, 0) is sound ONLY as a negative: it proves a pid is absent, never
+ *     that the agent behind it is doing anything.
+ *   FR-5 (reaping) needs IDENTICAL across >= 10 minutes as leg B of its DEAD test.
+ * Zero two-sample implementations existed in this repo before this one; without a single
+ * owner the two consumers would each grow their own and drift apart.
+ *
+ * DELIBERATELY NOT USED HERE: heartbeat_at. It keeps ticking on a parked worker whose
+ * agent is idle — four false "fleet down" verdicts are on record from reading it as
+ * activity. last_tool_at moves only when a tool actually ran.
+ *
+ * Returns { ok, advancing, identical, first, second, intervalMs, detail }.
+ * Never throws: a read failure yields ok:false with advancing/identical BOTH false, so a
+ * failed sample can neither authorise a kill (needs advancing) nor authorise a reap
+ * (needs identical). An unreadable sample must not look like an answer.
+ */
+export async function sampleToolActivityTwice(supabase, sessionId, opts = {}) {
+  const { intervalMs = 600_000, sleep = (ms) => new Promise((r) => setTimeout(r, ms)) } = opts;
+
+  const readOnce = async () => {
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('last_tool_at')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+    if (error) throw new Error(error.message);
+    return data ? data.last_tool_at ?? null : null;
+  };
+
+  if (!supabase || !sessionId) {
+    return { ok: false, advancing: false, identical: false, first: null, second: null, intervalMs, detail: 'missing supabase client or session id' };
+  }
+
+  try {
+    const first = await readOnce();
+    await sleep(intervalMs);
+    const second = await readOnce();
+
+    // identical covers the never-ran-a-tool case (null === null): a session that has
+    // never moved is, for FR-5's purposes, not advancing.
+    const identical = first === second;
+    const advancing = !identical && second !== null;
+
+    return {
+      ok: true,
+      advancing,
+      identical,
+      first,
+      second,
+      intervalMs,
+      detail: advancing
+        ? 'last_tool_at advanced between samples — the agent is alive'
+        : 'last_tool_at did not advance between samples',
+    };
+  } catch (err) {
+    return {
+      ok: false,
+      advancing: false,
+      identical: false,
+      first: null,
+      second: null,
+      intervalMs,
+      detail: `sample failed: ${(err && err.message) || err}`,
+    };
+  }
+}

--- a/lib/fleet/release-work-item.test.js
+++ b/lib/fleet/release-work-item.test.js
@@ -134,19 +134,38 @@ describe('FR1-SD: phase rewind, with the accepted-handoff guard CARRIED', () => 
 
   afterEach(() => { vi.doUnmock('../exec-context-guard.mjs'); });
 
-  it('SD-1: rewinds a mid-phase SD to its safe boundary when the gate allows', async () => {
+  it('SD-0: THE REWIND IS OPT-IN — default leaves the phase alone for resume', async () => {
+    // Defaulting this ON would make every future call site silently inherit a policy that
+    // several paths explicitly forbid (coordinator-cold-recovery: "PRESERVES current_phase +
+    // progress (resume, not restart)"), and would do so invisibly — the SD would just come
+    // back a phase earlier. Only the sweep asks for the rewind.
     const release = await loadWithGate(allow);
     const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
     const r = await release(sb, 'SD-X', 'SESSION_END');
+    expect(r.action).toBe('sd_no_reset');
+    expect(r.detail).toMatch(/phase preserved for resume/);
+    expect(sb.updates).toHaveLength(0);
+  });
+
+  it('SD-1: rewinds a mid-phase SD to its safe boundary when ASKED and the gate allows', async () => {
+    const release = await loadWithGate(allow);
+    const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
+    const r = await release(sb, 'SD-X', 'SESSION_END', { rewindPhase: true });
     expect(r.action).toBe('sd_phase_reset');
     expect(sb.updates).toEqual([{ key: 'SD-X', patch: { current_phase: 'PLAN_PRD' } }]);
     expect(PHASE_RESET_MAP.EXEC).toBe('PLAN_PRD');
   });
 
+  it('SD-1b: a QF hand-back is unaffected by rewindPhase — the open pool has no ambiguity', async () => {
+    const sb = qfClient({ matched: true });
+    const r = await releaseWorkItemOnSessionEnd(sb, 'QF-1', 'SESSION_END');
+    expect(r.action).toBe('qf_reopened'); // no rewindPhase passed, still reopens
+  });
+
   it('SD-2: an SD already at a safe boundary is not rewound', async () => {
     const release = await loadWithGate(allow);
     const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'PLAN_PRD', status: 'in_progress' } });
-    const r = await release(sb, 'SD-X', 'SESSION_END');
+    const r = await release(sb, 'SD-X', 'SESSION_END', { rewindPhase: true });
     expect(r.action).toBe('sd_no_reset');
     expect(sb.updates).toHaveLength(0);
   });
@@ -154,7 +173,7 @@ describe('FR1-SD: phase rewind, with the accepted-handoff guard CARRIED', () => 
   it('SD-3: a vanished SD is a no-op, not an error', async () => {
     const release = await loadWithGate(allow);
     const sb = sdClient({ row: null });
-    const r = await release(sb, 'SD-GONE', 'SESSION_END');
+    const r = await release(sb, 'SD-GONE', 'SESSION_END', { rewindPhase: true });
     expect(r.ok).toBe(true);
     expect(r.action).toBe('sd_no_reset');
   });
@@ -165,7 +184,7 @@ describe('FR1-SD: phase rewind, with the accepted-handoff guard CARRIED', () => 
     const release = await loadWithGate(rejectWith('ACCEPTED_HANDOFF_OVERRIDE', 'accepted handoff past PLAN_PRD exists'));
     const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
     const logs = [];
-    const r = await release(sb, 'SD-X', 'SESSION_END', { onLog: (m) => logs.push(m) });
+    const r = await release(sb, 'SD-X', 'SESSION_END', { rewindPhase: true, onLog: (m) => logs.push(m) });
     expect(r.action).toBe('sd_no_reset');
     expect(r.detail).toContain('ACCEPTED_HANDOFF_OVERRIDE');
     expect(sb.updates).toHaveLength(0); // the write never happened
@@ -175,7 +194,7 @@ describe('FR1-SD: phase rewind, with the accepted-handoff guard CARRIED', () => 
   it('SD-5: a guard that cannot answer does NOT authorise the write', async () => {
     const release = await loadWithGate(rejectWith('SCHEMA_ERROR', 'schema exploded'));
     const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
-    const r = await release(sb, 'SD-X', 'SESSION_END');
+    const r = await release(sb, 'SD-X', 'SESSION_END', { rewindPhase: true });
     expect(r.action).toBe('sd_no_reset');
     expect(sb.updates).toHaveLength(0);
   });

--- a/lib/fleet/release-work-item.test.js
+++ b/lib/fleet/release-work-item.test.js
@@ -1,0 +1,232 @@
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1
+// lib/fleet/release-work-item.mjs — the shared work-item reset + the two-sample primitive.
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  releaseWorkItemOnSessionEnd,
+  sampleToolActivityTwice,
+  isReleaseWorkItemResetEnabled,
+  isQuickFixKey,
+  PHASE_RESET_MAP,
+} from './release-work-item.mjs';
+
+// ---------------------------------------------------------------------------
+// Supabase test doubles. The QF double RECORDS the predicate the UPDATE applied,
+// so the tests assert the guard is in the WHERE clause rather than trusting a
+// hand-written "matched" flag — the predicate IS the safety property here.
+// ---------------------------------------------------------------------------
+function qfClient({ matched = true, error = null } = {}) {
+  const applied = { eq: {}, filter: {}, is: [] };
+  const chain = {
+    update: vi.fn(() => chain),
+    eq: vi.fn((col, val) => { applied.eq[col] = val; return chain; }),
+    filter: vi.fn((col, _op, val) => { applied.filter[col] = val; return chain; }),
+    is: vi.fn((col, val) => { applied.is.push([col, val]); return chain; }),
+    select: vi.fn(() => Promise.resolve({ data: matched ? [{ id: 'QF-X' }] : [], error })),
+  };
+  return { applied, from: vi.fn(() => chain) };
+}
+
+function sdClient({ row, updateError = null } = {}) {
+  const updates = [];
+  return {
+    updates,
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: row, error: null }) })),
+      })),
+      update: vi.fn((patch) => ({
+        eq: vi.fn((_c, key) => { updates.push({ key, patch }); return Promise.resolve({ error: updateError }); }),
+      })),
+    })),
+  };
+}
+
+function sessionClient(values) {
+  let i = 0;
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({
+          maybeSingle: vi.fn(() => {
+            const v = values[Math.min(i, values.length - 1)];
+            i += 1;
+            if (v instanceof Error) return Promise.resolve({ data: null, error: { message: v.message } });
+            return Promise.resolve({ data: { last_tool_at: v }, error: null });
+          }),
+        })),
+      })),
+    })),
+  };
+}
+
+const noSleep = () => Promise.resolve();
+
+describe('FR1-FLAG: LEO_RELEASE_WORKITEM_RESET is opt-in, never truthy-by-accident', () => {
+  it('is OFF when unset, OFF for any other value, ON only for exactly "on"', () => {
+    expect(isReleaseWorkItemResetEnabled({})).toBe(false);
+    expect(isReleaseWorkItemResetEnabled({ LEO_RELEASE_WORKITEM_RESET: '' })).toBe(false);
+    // 'true'/'1' are truthy strings — a truthiness check would wrongly enable conversion.
+    expect(isReleaseWorkItemResetEnabled({ LEO_RELEASE_WORKITEM_RESET: 'true' })).toBe(false);
+    expect(isReleaseWorkItemResetEnabled({ LEO_RELEASE_WORKITEM_RESET: '1' })).toBe(false);
+    expect(isReleaseWorkItemResetEnabled({ LEO_RELEASE_WORKITEM_RESET: 'on' })).toBe(true);
+  });
+});
+
+describe('FR1-DISPATCH: QF- prefix selects the quick-fix branch', () => {
+  it('classifies keys', () => {
+    expect(isQuickFixKey('QF-20260727-259')).toBe(true);
+    expect(isQuickFixKey('SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001')).toBe(false);
+    expect(isQuickFixKey(null)).toBe(false);
+  });
+});
+
+describe('FR1-QF: a stranded quick-fix is returned to the open pool', () => {
+  it('QF-1: reopens an item with no claimant, no pr_url and no commit_sha', async () => {
+    const sb = qfClient({ matched: true });
+    const r = await releaseWorkItemOnSessionEnd(sb, 'QF-20260726-175', 'SESSION_END');
+    expect(r.ok).toBe(true);
+    expect(r.action).toBe('qf_reopened');
+  });
+
+  it('QF-2: THE GUARD IS IN THE WHERE CLAUSE — all four columns are constrained', async () => {
+    // This is the criterion that matters: the reset must be unable to touch an item
+    // carrying real work, structurally, rather than by a caller remembering to check.
+    const sb = qfClient({ matched: true });
+    await releaseWorkItemOnSessionEnd(sb, 'QF-20260726-175', 'SESSION_END');
+    expect(sb.applied.eq.id).toBe('QF-20260726-175');
+    expect(sb.applied.filter.status).toBe('in_progress');
+    expect(sb.applied.is).toEqual([
+      ['claiming_session_id', null],
+      ['pr_url', null],
+      ['commit_sha', null],
+    ]);
+  });
+
+  it('QF-3: an item carrying real work is left untouched (predicate matches nothing)', async () => {
+    const sb = qfClient({ matched: false });
+    const r = await releaseWorkItemOnSessionEnd(sb, 'QF-20260726-423', 'SESSION_END');
+    expect(r.ok).toBe(true);
+    expect(r.action).toBe('qf_untouched');
+  });
+
+  it('QF-4: a DB error surfaces as a verdict, never as a throw', async () => {
+    const sb = qfClient({ matched: false, error: { message: 'db down' } });
+    const r = await releaseWorkItemOnSessionEnd(sb, 'QF-1', 'SESSION_END');
+    expect(r.ok).toBe(false);
+    expect(r.action).toBe('error');
+    expect(r.detail).toContain('db down');
+  });
+});
+
+describe('FR1-SD: phase rewind, with the accepted-handoff guard CARRIED', () => {
+  // The gate is stubbed EXPLICITLY in every SD test. It is a real collaborator with its
+  // own DB reads, so leaving it live would make these tests assert the stub-fidelity of
+  // a supabase double rather than the rewind logic under test.
+  async function loadWithGate(gateImpl) {
+    vi.resetModules();
+    vi.doMock('../exec-context-guard.mjs', () => ({ assertSweepHandoffGate: vi.fn(gateImpl) }));
+    const mod = await import('./release-work-item.mjs');
+    return mod.releaseWorkItemOnSessionEnd;
+  }
+  const allow = async () => ({ ok: true });
+  const rejectWith = (code, message) => async () => { const e = new Error(message); e.code = code; throw e; };
+
+  afterEach(() => { vi.doUnmock('../exec-context-guard.mjs'); });
+
+  it('SD-1: rewinds a mid-phase SD to its safe boundary when the gate allows', async () => {
+    const release = await loadWithGate(allow);
+    const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
+    const r = await release(sb, 'SD-X', 'SESSION_END');
+    expect(r.action).toBe('sd_phase_reset');
+    expect(sb.updates).toEqual([{ key: 'SD-X', patch: { current_phase: 'PLAN_PRD' } }]);
+    expect(PHASE_RESET_MAP.EXEC).toBe('PLAN_PRD');
+  });
+
+  it('SD-2: an SD already at a safe boundary is not rewound', async () => {
+    const release = await loadWithGate(allow);
+    const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'PLAN_PRD', status: 'in_progress' } });
+    const r = await release(sb, 'SD-X', 'SESSION_END');
+    expect(r.action).toBe('sd_no_reset');
+    expect(sb.updates).toHaveLength(0);
+  });
+
+  it('SD-3: a vanished SD is a no-op, not an error', async () => {
+    const release = await loadWithGate(allow);
+    const sb = sdClient({ row: null });
+    const r = await release(sb, 'SD-GONE', 'SESSION_END');
+    expect(r.ok).toBe(true);
+    expect(r.action).toBe('sd_no_reset');
+  });
+
+  it('SD-4: THE CARRIED GUARD BLOCKS a rewind past an accepted handoff', async () => {
+    // The whole point of carrying assertSweepHandoffGate out of the sweep: an accepted
+    // handoff past the target phase must stop ANY release path, not just the sweep.
+    const release = await loadWithGate(rejectWith('ACCEPTED_HANDOFF_OVERRIDE', 'accepted handoff past PLAN_PRD exists'));
+    const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
+    const logs = [];
+    const r = await release(sb, 'SD-X', 'SESSION_END', { onLog: (m) => logs.push(m) });
+    expect(r.action).toBe('sd_no_reset');
+    expect(r.detail).toContain('ACCEPTED_HANDOFF_OVERRIDE');
+    expect(sb.updates).toHaveLength(0); // the write never happened
+    expect(logs.join('\n')).toContain('SKIP_RESET');
+  });
+
+  it('SD-5: a guard that cannot answer does NOT authorise the write', async () => {
+    const release = await loadWithGate(rejectWith('SCHEMA_ERROR', 'schema exploded'));
+    const sb = sdClient({ row: { sd_key: 'SD-X', current_phase: 'EXEC', status: 'in_progress' } });
+    const r = await release(sb, 'SD-X', 'SESSION_END');
+    expect(r.action).toBe('sd_no_reset');
+    expect(sb.updates).toHaveLength(0);
+  });
+});
+
+describe('FR1-SAMPLE: sampleToolActivityTwice — one primitive, two opposite polarities', () => {
+  it('SAMPLE-1: advancing last_tool_at => alive (FR-2 polarity)', async () => {
+    const sb = sessionClient(['2026-07-27T10:00:00Z', '2026-07-27T10:05:00Z']);
+    const r = await sampleToolActivityTwice(sb, 's1', { intervalMs: 10, sleep: noSleep });
+    expect(r.ok).toBe(true);
+    expect(r.advancing).toBe(true);
+    expect(r.identical).toBe(false);
+  });
+
+  it('SAMPLE-2: identical last_tool_at => not advancing (FR-5 leg B polarity)', async () => {
+    const sb = sessionClient(['2026-07-27T10:00:00Z', '2026-07-27T10:00:00Z']);
+    const r = await sampleToolActivityTwice(sb, 's1', { intervalMs: 10, sleep: noSleep });
+    expect(r.identical).toBe(true);
+    expect(r.advancing).toBe(false);
+  });
+
+  it('SAMPLE-3: a session that has NEVER run a tool is not advancing', async () => {
+    const sb = sessionClient([null, null]);
+    const r = await sampleToolActivityTwice(sb, 'ghost', { intervalMs: 10, sleep: noSleep });
+    expect(r.identical).toBe(true);
+    expect(r.advancing).toBe(false);
+  });
+
+  it('SAMPLE-4: A FAILED SAMPLE AUTHORISES NOTHING — neither kill nor reap', async () => {
+    // advancing gates the kill; identical gates the reap. A read failure must set BOTH
+    // false so an unreadable sample can never be mistaken for an answer in either direction.
+    const sb = sessionClient([new Error('db down')]);
+    const r = await sampleToolActivityTwice(sb, 's1', { intervalMs: 10, sleep: noSleep });
+    expect(r.ok).toBe(false);
+    expect(r.advancing).toBe(false);
+    expect(r.identical).toBe(false);
+  });
+
+  it('SAMPLE-5: it really samples TWICE, waiting in between', async () => {
+    const sb = sessionClient(['2026-07-27T10:00:00Z', '2026-07-27T10:05:00Z']);
+    const sleep = vi.fn(() => Promise.resolve());
+    await sampleToolActivityTwice(sb, 's1', { intervalMs: 600_000, sleep });
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(600_000);
+  });
+
+  it('SAMPLE-6: defaults to a 10-minute interval (FR-5 requires >= 10 min)', async () => {
+    const sb = sessionClient(['a', 'a']);
+    const sleep = vi.fn(() => Promise.resolve());
+    const r = await sampleToolActivityTwice(sb, 's1', { sleep });
+    expect(r.intervalMs).toBe(600_000);
+    expect(sleep).toHaveBeenCalledWith(600_000);
+  });
+});

--- a/lib/fleet/resume-context.mjs
+++ b/lib/fleet/resume-context.mjs
@@ -1,0 +1,120 @@
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-3 — restart that carries the conversation.
+ *
+ * THE RESUME TOKEN IS claude_sessions.session_id. NOT metadata.resume_uuid, which is populated
+ * on 1 of 13,025 rows — anything reading it silently cold-starts on essentially every seat.
+ * resolveResumePlan never consults it, and a test pins that.
+ *
+ * TWO PATHS THAT MUST NOT BE CONFLATED — this is the subtle half of FR-3:
+ *
+ *   launch_cwd     WHERE THE RESUMED SEAT RUNS. A worktree-launched seat must come back up in
+ *                  ITS worktree. There is no launch_cwd persisted today, and resume appears to
+ *                  work only by coincidence because every seat currently sits in the main tree.
+ *                  Without it a worktree seat resumes into the wrong directory and finds
+ *                  nothing — silently.
+ *
+ *   transcript dir WHERE THE CONVERSATION FILE LIVES: ~/.claude/projects/<slug>/<id>.jsonl,
+ *                  where <slug> is derived from the MAIN repo root — NOT from the seat's cwd.
+ *                  attribute-tokens.mjs states it outright: "worktree cwds derive a different —
+ *                  wrong — project dir". Derive the slug from a worktree path and the existence
+ *                  check looks in a directory that never exists, reports "no transcript", and
+ *                  cold-starts EVERY worktree seat forever while looking correct.
+ *
+ * So the same restart needs the worktree path for cwd and the main-tree path for the transcript.
+ * Passing one where the other belongs fails silently in both directions.
+ *
+ * VERIFY BEFORE PROMISING. A missing transcript means cold start, and the caller must SAY SO.
+ * Reporting a resume that did not happen is worse than the cold start itself: the operator
+ * believes the context survived and acts on that belief.
+ */
+
+import path from 'node:path';
+import os from 'node:os';
+
+/** Claude Code project-dir name: every non-alphanumeric char becomes '-'. */
+export function projectDirName(repoPath) {
+  return String(repoPath).replace(/[^a-zA-Z0-9]/g, '-');
+}
+
+/**
+ * Absolute transcript path for a session.
+ * @param {{sessionId:string, mainRepoRoot:string, homeDir?:string}} o
+ *   mainRepoRoot MUST be the main worktree root (git rev-parse --git-common-dir), never a
+ *   .worktrees/<id> path — see the header.
+ */
+export function transcriptPathFor({ sessionId, mainRepoRoot, homeDir = os.homedir() }) {
+  if (!sessionId || !mainRepoRoot) return null;
+  return path.join(homeDir, '.claude', 'projects', projectDirName(mainRepoRoot), `${sessionId}.jsonl`);
+}
+
+/** A worktree path is never a valid transcript-slug source. Cheap, explicit guard. */
+export function looksLikeWorktreePath(p) {
+  return typeof p === 'string' && /[\\/]\.worktrees[\\/]/.test(p);
+}
+
+/**
+ * Decide how a restart should launch. Pure — all IO is done by the caller and passed in.
+ *
+ * @param {{
+ *   sessionId: string,
+ *   transcriptExists: boolean,
+ *   launchCwd: string|null,
+ *   newSessionId: string,          // freshly minted id for the FORK
+ *   mainRepoRoot?: string,
+ * }} o
+ * @returns {{mode:'fork'|'cold', resumeUuid:string|null, sessionId:string, cwd:string|null,
+ *           carriesContext:boolean, report:string, warnings:string[]}}
+ */
+export function resolveResumePlan({ sessionId, transcriptExists, launchCwd, newSessionId, mainRepoRoot }) {
+  const warnings = [];
+
+  if (mainRepoRoot && looksLikeWorktreePath(mainRepoRoot)) {
+    // Loud, because the failure it causes is silent: every worktree seat would cold-start.
+    warnings.push(
+      `mainRepoRoot looks like a worktree path (${mainRepoRoot}); the transcript slug must come ` +
+      'from the MAIN repo root or the existence check searches a directory that never exists'
+    );
+  }
+  if (!launchCwd) {
+    warnings.push('no launch_cwd recorded — the replacement will start in the default directory, which is wrong for any worktree-launched seat');
+  }
+
+  if (!sessionId) {
+    return {
+      mode: 'cold', resumeUuid: null, sessionId: newSessionId, cwd: launchCwd || null,
+      carriesContext: false, report: 'COLD START: no session id to resume from.', warnings,
+    };
+  }
+
+  if (!transcriptExists) {
+    return {
+      mode: 'cold', resumeUuid: null, sessionId: newSessionId, cwd: launchCwd || null,
+      carriesContext: false,
+      // Said out loud on purpose: a silent cold start lets the operator believe context survived.
+      report: `COLD START: no transcript file for ${sessionId} — the conversation could NOT be carried over.`,
+      warnings,
+    };
+  }
+
+  return {
+    // FORK, not re-register. Re-registering under the OLD id would let a health check pass
+    // against the old row's still-warm heartbeat, so a dead seat would look alive.
+    mode: 'fork',
+    resumeUuid: sessionId,
+    sessionId: newSessionId,
+    cwd: launchCwd || null,
+    carriesContext: true,
+    report: `RESUME: forking ${sessionId} into ${newSessionId} against a verified transcript.`,
+    warnings,
+  };
+}
+
+/**
+ * Launch flags for a plan. A fork carries BOTH --resume (the conversation) and a fresh
+ * --session-id (the new identity) — that pairing is what makes it a fork rather than the
+ * mutually-exclusive resume-in-place buildSessionLaunch documents.
+ */
+export function resumeLaunchFlags(plan) {
+  if (!plan || plan.mode !== 'fork') return [];
+  return ['--fork-session', '--resume', plan.resumeUuid, '--session-id', plan.sessionId];
+}

--- a/lib/fleet/resume-context.test.js
+++ b/lib/fleet/resume-context.test.js
@@ -1,0 +1,117 @@
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-3 — resume context resolution.
+
+import { describe, it, expect } from 'vitest';
+import path from 'node:path';
+import {
+  transcriptPathFor,
+  projectDirName,
+  looksLikeWorktreePath,
+  resolveResumePlan,
+  resumeLaunchFlags,
+} from './resume-context.mjs';
+
+const MAIN = 'C:/Users/rickf/Projects/_EHG/EHG_Engineer';
+const WT = 'C:/Users/rickf/Projects/_EHG/EHG_Engineer/.worktrees/SD-X';
+const HOME = 'C:/Users/rickf';
+
+describe('FR3-PATH: the transcript slug comes from the MAIN root, never a worktree', () => {
+  it('derives the documented slug shape', () => {
+    // Verified against real disk: ~/.claude/projects/C--Users-rickf-Projects--EHG-EHG-Engineer
+    expect(projectDirName(MAIN)).toBe('C--Users-rickf-Projects--EHG-EHG-Engineer');
+  });
+
+  it('builds the transcript path under the main-root slug', () => {
+    const p = transcriptPathFor({ sessionId: 'abc', mainRepoRoot: MAIN, homeDir: HOME });
+    expect(p).toBe(path.join(HOME, '.claude', 'projects', 'C--Users-rickf-Projects--EHG-EHG-Engineer', 'abc.jsonl'));
+  });
+
+  it('a WORKTREE root yields a DIFFERENT slug — which is why it must not be used', () => {
+    // This is the silent failure: the derived directory never exists, so the existence check
+    // reports "no transcript" and cold-starts every worktree seat while looking correct.
+    expect(projectDirName(WT)).not.toBe(projectDirName(MAIN));
+    expect(looksLikeWorktreePath(WT)).toBe(true);
+    expect(looksLikeWorktreePath(MAIN)).toBe(false);
+  });
+
+  it('warns loudly when handed a worktree path as the slug source', () => {
+    const plan = resolveResumePlan({
+      sessionId: 'abc', transcriptExists: true, launchCwd: WT, newSessionId: 'new', mainRepoRoot: WT,
+    });
+    expect(plan.warnings.join(' ')).toMatch(/must come from the MAIN repo root/);
+  });
+});
+
+describe('FR3-VERIFY: a missing transcript cold-starts AND says so', () => {
+  it('cold-starts when the transcript is absent', () => {
+    const plan = resolveResumePlan({ sessionId: 'abc', transcriptExists: false, launchCwd: WT, newSessionId: 'new' });
+    expect(plan.mode).toBe('cold');
+    expect(plan.carriesContext).toBe(false);
+    expect(plan.resumeUuid).toBeNull();
+  });
+
+  it('SAYS it cold-started — silence would let the operator believe context survived', () => {
+    const plan = resolveResumePlan({ sessionId: 'abc', transcriptExists: false, launchCwd: WT, newSessionId: 'new' });
+    expect(plan.report).toMatch(/COLD START/);
+    expect(plan.report).toMatch(/could NOT be carried over/);
+  });
+
+  it('never promises carry-over it did not verify', () => {
+    const plan = resolveResumePlan({ sessionId: 'abc', transcriptExists: false, launchCwd: WT, newSessionId: 'new' });
+    expect(plan.report).not.toMatch(/RESUME:/);
+  });
+});
+
+describe('FR3-FORK: fork rather than re-register under the old id', () => {
+  it('forks the verified transcript into a FRESH session id', () => {
+    const plan = resolveResumePlan({ sessionId: 'old', transcriptExists: true, launchCwd: WT, newSessionId: 'fresh', mainRepoRoot: MAIN });
+    expect(plan.mode).toBe('fork');
+    expect(plan.resumeUuid).toBe('old');   // the conversation
+    expect(plan.sessionId).toBe('fresh');  // the identity
+    expect(plan.carriesContext).toBe(true);
+  });
+
+  it('emits --fork-session with BOTH the old conversation and the new identity', () => {
+    const plan = resolveResumePlan({ sessionId: 'old', transcriptExists: true, launchCwd: WT, newSessionId: 'fresh', mainRepoRoot: MAIN });
+    expect(resumeLaunchFlags(plan)).toEqual(['--fork-session', '--resume', 'old', '--session-id', 'fresh']);
+  });
+
+  it('a cold start carries no resume flags at all', () => {
+    const plan = resolveResumePlan({ sessionId: 'old', transcriptExists: false, launchCwd: WT, newSessionId: 'fresh' });
+    expect(resumeLaunchFlags(plan)).toEqual([]);
+  });
+});
+
+describe('FR3-CWD: launch_cwd is the worktree, and its absence is surfaced', () => {
+  it('carries the worktree path through as the launch cwd', () => {
+    const plan = resolveResumePlan({ sessionId: 'old', transcriptExists: true, launchCwd: WT, newSessionId: 'fresh', mainRepoRoot: MAIN });
+    expect(plan.cwd).toBe(WT); // the SEAT runs in its worktree, even though the transcript slug is the main root
+  });
+
+  it('warns when no launch_cwd was recorded — today there is none, and resume works by coincidence', () => {
+    const plan = resolveResumePlan({ sessionId: 'old', transcriptExists: true, launchCwd: null, newSessionId: 'fresh', mainRepoRoot: MAIN });
+    expect(plan.warnings.join(' ')).toMatch(/no launch_cwd recorded/);
+  });
+});
+
+describe('FR3-TOKEN: metadata.resume_uuid is never consulted', () => {
+  it('ignores a resume_uuid even when one is supplied alongside', () => {
+    // Populated on 1 of 13,025 rows — anything reading it silently cold-starts.
+    const plan = resolveResumePlan({
+      sessionId: 'session-token', transcriptExists: true, launchCwd: WT, newSessionId: 'fresh',
+      mainRepoRoot: MAIN, resume_uuid: 'DO-NOT-USE-ME',
+    });
+    expect(plan.resumeUuid).toBe('session-token');
+    expect(JSON.stringify(plan)).not.toMatch(/DO-NOT-USE-ME/);
+  });
+
+  it('the module CODE contains no read of metadata.resume_uuid', async () => {
+    const { readFileSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const raw = readFileSync(fileURLToPath(new URL('./resume-context.mjs', import.meta.url)), 'utf8');
+    // Strip comments first: the header explains WHY resume_uuid must not be read, so scanning
+    // the raw source would fail on its own rationale — the same trap as searching for a flag
+    // NAME instead of its USE.
+    const code = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+    expect(code).not.toMatch(/metadata\s*[.[]\s*['"]?resume_uuid/);
+  });
+});

--- a/lib/fleet/singleton-spawn-decision.mjs
+++ b/lib/fleet/singleton-spawn-decision.mjs
@@ -1,0 +1,109 @@
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-4 — singleton-aware spawn.
+ *
+ * ONE decision function, consumed by BOTH the addSession route and the panel. That is not tidiness
+ * — it is the FR's invariant: "every disabled button state corresponds to a route that returns 400
+ * for the same condition". Two implementations drift, and a UI-only gate is exactly the failure
+ * this SD documents as having ALREADY HAPPENED on this page: `role` was once written as
+ * FLEET_WORKER_ROLE with ZERO readers, so clicking "start the coordinator" spawned a session that
+ * fell through to the worker path and came up self-claiming DRAFT SDs — WHILE THE UI REPORTED
+ * SUCCESS. The route is the enforcement; the button only renders what the route would say.
+ *
+ * THE WINDOW MISMATCH IS LOAD-BEARING, NOT AN INCONSISTENCY TO TIDY AWAY.
+ *   The panel's "live" window is 3600s. The registration guard's freshness is 600s.
+ *   Gate naively on the PANEL's window and the button blocks for up to FIFTY MINUTES during which
+ *   the spawn would have SUCCEEDED — the guard would not have refused it. So the gate is the
+ *   GUARD's 600s, and the 600–3600s band is not a refusal at all: it is a RELABEL.
+ *   Between 600s and 3600s the correct affordance is "Replace the stale Adam", ENABLED.
+ *
+ * COORDINATOR IS NEVER REFUSED. Silent takeover is designed behaviour (resolve.cjs), and refusing
+ * it BREAKS SUCCESSION — a coordinator could never be replaced. Adam and Solomon are refused
+ * because registration itself will refuse them; the route just says so first, with the holder named.
+ */
+
+/** The registration guard's freshness window — the one that actually decides. */
+export const GUARD_FRESHNESS_MS = 600_000;
+/** The panel's display window. Deliberately WIDER; gating on it would block valid spawns. */
+export const PANEL_LIVE_WINDOW_MS = 3_600_000;
+
+export const SINGLETON_ROLES = Object.freeze(['adam', 'solomon', 'coordinator']);
+/** Coordinator is a singleton but is REPLACEABLE — takeover is how succession works. */
+export const REFUSABLE_SINGLETON_ROLES = Object.freeze(['adam', 'solomon']);
+
+export function isSingletonRole(role) {
+  return SINGLETON_ROLES.includes(String(role || '').toLowerCase());
+}
+
+/**
+ * Decide whether a spawn request may proceed.
+ *
+ * @param {{
+ *   role: string,
+ *   holder: {session_id: string, identity_kind?: string, heartbeat_age_ms?: number}|null,
+ *   nowMs?: number,
+ * }} o
+ * @returns {{allowed:boolean, httpStatus:number, reason:string|null, uiLabel:string,
+ *            uiEnabled:boolean, holderIsFresh:boolean}}
+ */
+export function decideSingletonSpawn({ role, holder } = {}) {
+  const r = String(role || '').toLowerCase();
+  const label = r ? r.charAt(0).toUpperCase() + r.slice(1) : 'session';
+
+  if (!isSingletonRole(r)) {
+    return { allowed: true, httpStatus: 200, reason: null, uiLabel: `Start a ${r || 'session'}`, uiEnabled: true, holderIsFresh: false };
+  }
+
+  // identity_kind must MATCH the role. A row that merely once carried the role is not a holder
+  // of it now — gating on a stale stamp would block a spawn the guard would have allowed.
+  const kindMatches = !holder || !holder.identity_kind || String(holder.identity_kind).toLowerCase() === r;
+  const age = holder && Number.isFinite(holder.heartbeat_age_ms) ? holder.heartbeat_age_ms : Infinity;
+  const holderIsFresh = Boolean(holder) && kindMatches && age <= GUARD_FRESHNESS_MS;
+
+  if (r === 'coordinator') {
+    // Never refused. Refusing would break succession outright.
+    return {
+      allowed: true,
+      httpStatus: 200,
+      reason: null,
+      uiLabel: holderIsFresh ? `Take over from the live coordinator` : 'Start the coordinator',
+      uiEnabled: true,
+      holderIsFresh,
+    };
+  }
+
+  if (holderIsFresh) {
+    const who = holder.session_id ? String(holder.session_id).slice(0, 8) : 'unknown';
+    return {
+      allowed: false,
+      httpStatus: 400,
+      reason: `a live ${label} already holds this role (session ${who}, last heartbeat ${Math.round(age / 1000)}s ago); spawning a second one would be refused at registration`,
+      uiLabel: `${label} is live`,
+      uiEnabled: false,
+      holderIsFresh,
+    };
+  }
+
+  // Holder exists but is PAST the guard's window — including the 600–3600s band the panel still
+  // renders as "live". The spawn WOULD succeed, so it must not be blocked; it is relabelled.
+  if (holder && kindMatches && age < PANEL_LIVE_WINDOW_MS) {
+    return {
+      allowed: true,
+      httpStatus: 200,
+      reason: null,
+      uiLabel: `Replace the stale ${label}`,
+      uiEnabled: true,
+      holderIsFresh: false,
+    };
+  }
+
+  return { allowed: true, httpStatus: 200, reason: null, uiLabel: `Start ${label}`, uiEnabled: true, holderIsFresh: false };
+}
+
+/**
+ * THE INVARIANT, as an assertable function: the button and the route agree, always.
+ * A disabled button must correspond to a route that refuses the same condition, and an
+ * enabled one to a route that allows it.
+ */
+export function buttonAgreesWithRoute(decision) {
+  return Boolean(decision) && decision.uiEnabled === decision.allowed;
+}

--- a/lib/fleet/singleton-spawn-decision.test.js
+++ b/lib/fleet/singleton-spawn-decision.test.js
@@ -1,0 +1,102 @@
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-4 — singleton-aware spawn.
+
+import { describe, it, expect } from 'vitest';
+import {
+  decideSingletonSpawn,
+  buttonAgreesWithRoute,
+  isSingletonRole,
+  GUARD_FRESHNESS_MS,
+  PANEL_LIVE_WINDOW_MS,
+} from './singleton-spawn-decision.mjs';
+
+const holder = (ageMs, kind, id = 'abcdef12-3456') => ({ session_id: id, identity_kind: kind, heartbeat_age_ms: ageMs });
+
+describe('FR4-REFUSE: a second Adam or Solomon is refused AT THE ROUTE, holder named', () => {
+  for (const role of ['adam', 'solomon']) {
+    it(`refuses a second ${role} with HTTP 400 naming the holder`, () => {
+      const d = decideSingletonSpawn({ role, holder: holder(10_000, role) });
+      expect(d.allowed).toBe(false);
+      expect(d.httpStatus).toBe(400);
+      expect(d.reason).toMatch(/already holds this role/);
+      expect(d.reason).toMatch(/abcdef12/); // the client renders reason verbatim
+    });
+  }
+
+  it('allows the spawn when no holder exists', () => {
+    expect(decideSingletonSpawn({ role: 'adam', holder: null }).allowed).toBe(true);
+  });
+});
+
+describe('FR4-COORDINATOR: never refused — refusing would break succession', () => {
+  it('allows a coordinator spawn even with a fresh live holder', () => {
+    const d = decideSingletonSpawn({ role: 'coordinator', holder: holder(5_000, 'coordinator') });
+    expect(d.allowed).toBe(true);
+    expect(d.httpStatus).toBe(200);
+    expect(d.uiEnabled).toBe(true);
+  });
+
+  it('relabels rather than blocking — takeover is the designed behaviour', () => {
+    const d = decideSingletonSpawn({ role: 'coordinator', holder: holder(5_000, 'coordinator') });
+    expect(d.uiLabel).toMatch(/Take over/);
+  });
+});
+
+describe('FR4-WINDOW: the 600s/3600s mismatch is load-bearing', () => {
+  it('the two windows are genuinely different — gating on the wrong one is the bug', () => {
+    expect(GUARD_FRESHNESS_MS).toBe(600_000);
+    expect(PANEL_LIVE_WINDOW_MS).toBe(3_600_000);
+  });
+
+  it('a holder in the 600s-3600s band is NOT refused — the spawn would have succeeded', () => {
+    // Gating on the PANEL's window here would block for up to fifty minutes during which
+    // registration would have allowed the spawn.
+    const d = decideSingletonSpawn({ role: 'adam', holder: holder(30 * 60_000, 'adam') });
+    expect(d.allowed).toBe(true);
+    expect(d.uiEnabled).toBe(true);
+  });
+
+  it('and is labelled "Replace the stale Adam" rather than disabled', () => {
+    const d = decideSingletonSpawn({ role: 'adam', holder: holder(30 * 60_000, 'adam') });
+    expect(d.uiLabel).toBe('Replace the stale Adam');
+  });
+
+  it('refuses exactly at the guard boundary and allows just past it', () => {
+    expect(decideSingletonSpawn({ role: 'adam', holder: holder(GUARD_FRESHNESS_MS, 'adam') }).allowed).toBe(false);
+    expect(decideSingletonSpawn({ role: 'adam', holder: holder(GUARD_FRESHNESS_MS + 1, 'adam') }).allowed).toBe(true);
+  });
+});
+
+describe('FR4-IDENTITY: identity_kind must match the role', () => {
+  it('a row holding a DIFFERENT role does not block this one', () => {
+    // Gating on a stale stamp would block a spawn the guard would have allowed.
+    const d = decideSingletonSpawn({ role: 'adam', holder: holder(1_000, 'coordinator') });
+    expect(d.allowed).toBe(true);
+  });
+});
+
+describe('FR4-INVARIANT: the button and the route always agree', () => {
+  it('holds across every combination of role, holder age and identity kind', () => {
+    const ages = [0, 1_000, GUARD_FRESHNESS_MS - 1, GUARD_FRESHNESS_MS, GUARD_FRESHNESS_MS + 1,
+      30 * 60_000, PANEL_LIVE_WINDOW_MS, PANEL_LIVE_WINDOW_MS + 1];
+    const roles = ['adam', 'solomon', 'coordinator', 'worker'];
+    const kinds = ['adam', 'solomon', 'coordinator', undefined];
+    for (const role of roles) {
+      for (const age of ages) {
+        for (const kind of kinds) {
+          for (const h of [null, holder(age, kind)]) {
+            const d = decideSingletonSpawn({ role, holder: h });
+            // No UI-only gate, ever: a disabled button implies a refusing route.
+            expect(buttonAgreesWithRoute(d), `${role}/${age}/${kind}/${h ? 'holder' : 'none'}`).toBe(true);
+            if (!d.allowed) expect(d.httpStatus).toBe(400);
+            else expect(d.httpStatus).toBe(200);
+          }
+        }
+      }
+    }
+  });
+
+  it('a non-singleton role is never gated', () => {
+    expect(isSingletonRole('worker')).toBe(false);
+    expect(decideSingletonSpawn({ role: 'worker', holder: holder(0, 'worker') }).allowed).toBe(true);
+  });
+});

--- a/lib/fleet/spawn-control-stop-workitem.test.js
+++ b/lib/fleet/spawn-control-stop-workitem.test.js
@@ -1,0 +1,124 @@
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 1
+// spawn-control.js stop() — hand the work item back before retiring the session row.
+//
+// stop() was itself a strand manufacturer: it flipped claude_sessions to released and
+// left the work item in_progress with no claimant — invisible to every picker while the
+// coordinator still counted it as available supply.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const RESOLVED = { resolved: true, identity: { callsign: 'Alpha-9', session_id: 'sess-1' } };
+
+let calls;
+
+function mockDeps({ heldKey = 'QF-20260726-175', released = true, resetAction = 'qf_reopened' } = {}) {
+  calls = [];
+  vi.doMock('./session-registry-adapter.js', () => ({
+    resolveLiveSession: vi.fn(async () => RESOLVED),
+    loadLiveSessionIdentity: vi.fn(async () => ({ sessions: [], callsignBySession: {} })),
+  }));
+  vi.doMock('./best-effort-release.mjs', () => ({
+    bestEffortReleaseSd: vi.fn(async (_sb, sessionId, reason, _log, opts) => {
+      calls.push({ step: 'release_claim', sessionId, reason, expectedSdKey: opts && opts.expectedSdKey });
+      return released ? { released: true, error: null } : { released: false, error: 'rpc down' };
+    }),
+  }));
+  vi.doMock('./release-work-item.mjs', () => ({
+    isReleaseWorkItemResetEnabled: vi.fn(() => process.env.LEO_RELEASE_WORKITEM_RESET === 'on'),
+    releaseWorkItemOnSessionEnd: vi.fn(async (_sb, key, reason) => {
+      calls.push({ step: 'reset_work_item', key, reason });
+      return { ok: true, action: resetAction, detail: 'stub' };
+    }),
+  }));
+  return { heldKey };
+}
+
+function supabaseDouble(heldKey) {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: { sd_key: heldKey }, error: null }) })),
+      })),
+      update: vi.fn(() => ({
+        eq: vi.fn(() => { calls.push({ step: 'retire_session' }); return Promise.resolve({ error: null }); }),
+      })),
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    })),
+    rpc: vi.fn().mockResolvedValue({ error: null }),
+  };
+}
+
+async function loadStop() {
+  const mod = await import('./spawn-control.js');
+  return mod.stop;
+}
+
+beforeEach(() => { vi.resetModules(); delete process.env.LEO_RELEASE_WORKITEM_RESET; });
+afterEach(() => { vi.restoreAllMocks(); delete process.env.LEO_RELEASE_WORKITEM_RESET; });
+
+describe('FR1B-1: default OFF keeps the previous behaviour exactly', () => {
+  it('does not touch the work item when the flag is unset', async () => {
+    const { heldKey } = mockDeps();
+    const stop = await loadStop();
+    const res = await stop('Alpha-9', { supabaseClient: supabaseDouble(heldKey) });
+    expect(res.ok).toBe(true);
+    expect(res.workItemReset).toBeUndefined();
+    expect(calls.filter((c) => c.step !== 'retire_session')).toHaveLength(0);
+  });
+});
+
+describe('FR1B-2: THE ORDER — claim released BEFORE the reset, both BEFORE the session is retired', () => {
+  it('sequences release_claim -> reset_work_item -> retire_session', async () => {
+    // This is the whole point of the slice. Reset-before-release would match nothing
+    // (the QF predicate requires claiming_session_id IS NULL) and return qf_untouched
+    // every time — a green no-op. Retiring the session first would erase sd_key, which
+    // is how release_sd resolves WHICH item to hand back.
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    const { heldKey } = mockDeps();
+    const stop = await loadStop();
+    await stop('Alpha-9', { supabaseClient: supabaseDouble(heldKey) });
+    expect(calls.map((c) => c.step)).toEqual(['release_claim', 'reset_work_item', 'retire_session']);
+  });
+
+  it('scopes the claim release to the key the session actually holds (QF-20260726-593)', async () => {
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    const { heldKey } = mockDeps();
+    const stop = await loadStop();
+    await stop('Alpha-9', { supabaseClient: supabaseDouble(heldKey) });
+    const rel = calls.find((c) => c.step === 'release_claim');
+    expect(rel.expectedSdKey).toBe(heldKey);
+    expect(rel.reason).toBe('manual_stop'); // names the mechanism, not 'manual'
+  });
+
+  it('hands back the SAME key it released', async () => {
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    const otherKey = 'SD-SOME-OTHER-001';
+    mockDeps({ heldKey: otherKey });
+    const stop = await loadStop();
+    await stop('Alpha-9', { supabaseClient: supabaseDouble(otherKey) });
+    expect(calls.find((c) => c.step === 'reset_work_item').key).toBe(otherKey);
+  });
+});
+
+describe('FR1B-3: the handback is best-effort — stop() still retires the session', () => {
+  it('a failed claim release does NOT attempt the reset, and does NOT block the retire', async () => {
+    // Resetting after a failed release would be reasoning from an unproven premise:
+    // we do not know the claim is gone, so the predicate cannot be trusted to protect us.
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    const { heldKey } = mockDeps({ released: false });
+    const stop = await loadStop();
+    const res = await stop('Alpha-9', { supabaseClient: supabaseDouble(heldKey) });
+    expect(calls.map((c) => c.step)).toEqual(['release_claim', 'retire_session']);
+    expect(res.ok).toBe(true);
+    expect(res.workItemReset.released).toBe(false);
+  });
+
+  it('a session holding no work item skips the handback cleanly', async () => {
+    process.env.LEO_RELEASE_WORKITEM_RESET = 'on';
+    mockDeps();
+    const stop = await loadStop();
+    const res = await stop('Alpha-9', { supabaseClient: supabaseDouble(null) });
+    expect(res.workItemReset).toEqual({ attempted: false, reason: 'session_holds_no_work_item' });
+    expect(calls.map((c) => c.step)).toEqual(['retire_session']);
+  });
+});

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -77,6 +77,9 @@ export const SESSION_BIND_DELAY_MS = 500;
 export const CANARY_PROFILE = 'canary';
 export { CANARY_CALLSIGN_PREFIX } from './startup-prompt-selection.js';
 import { isCanaryCallsign as isCanaryNamespaceCallsign } from './startup-prompt-selection.js';
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 1 — see releaseHeldWorkItem below.
+import { bestEffortReleaseSd } from './best-effort-release.mjs';
+import { releaseWorkItemOnSessionEnd, isReleaseWorkItemResetEnabled } from './release-work-item.mjs';
 // FR-4 trigger key: imported, not duplicated. canary-session.js now imports only the pure
 // startup-prompt-selection.js, so spawn-control -> canary-session closes no cycle.
 import { CANARY_TRIGGER_KEY } from './canary-session.js';
@@ -534,6 +537,43 @@ export async function attach(target, opts = {}) {
   return { ok: focused, reason: focused ? null : 'stale_handle', session_id };
 }
 
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 1.
+ *
+ * Hand the session's work item back to the queue before its row is retired.
+ *
+ * ORDER IS LOAD-BEARING, and wiring only half of it would be a fix that does not fix:
+ * releaseWorkItemOnSessionEnd's quick-fix predicate requires claiming_session_id IS NULL,
+ * so calling it while this session still holds the claim matches nothing and returns
+ * qf_untouched every time — green, and useless. The claim must be released FIRST.
+ * Both steps must also run BEFORE the claude_sessions status update below, because
+ * release_sd resolves what to release by reading claude_sessions.sd_key — retire the row
+ * first and there is nothing left to tell us which item this session held.
+ *
+ * Reuses the sequence stale-session-sweep.cjs already proves on its CLAIM_BOUNDARY_PROBE
+ * path (release, then reset, branching QF vs SD) rather than growing a second one.
+ * Best-effort throughout: stop() must still retire the session even if the handback fails.
+ */
+async function releaseHeldWorkItem(supabase, sessionId, reason) {
+  try {
+    const { data: row } = await supabase
+      .from('claude_sessions').select('sd_key').eq('session_id', sessionId).maybeSingle();
+    const heldKey = row && row.sd_key;
+    if (!heldKey) return { attempted: false, reason: 'session_holds_no_work_item' };
+
+    // SD-scoped so a concurrent re-claim cannot make us drop an unrelated item
+    // (QF-20260726-593: release_sd takes no SD argument and releases whatever is held).
+    const rel = await bestEffortReleaseSd(supabase, sessionId, reason, () => {}, { expectedSdKey: heldKey });
+    if (!rel.released) {
+      return { attempted: true, key: heldKey, released: false, detail: rel.skipped || rel.error || 'release_failed' };
+    }
+    const reset = await releaseWorkItemOnSessionEnd(supabase, heldKey, reason);
+    return { attempted: true, key: heldKey, released: true, action: reset.action, detail: reset.detail };
+  } catch (err) {
+    return { attempted: true, released: false, detail: (err && err.message) || String(err) };
+  }
+}
+
 /** Stop a live session without spawning a replacement. */
 export async function stop(target, opts = {}) {
   const supabase = opts.supabaseClient;
@@ -545,12 +585,22 @@ export async function stop(target, opts = {}) {
   }
 
   const { session_id } = resolution.identity;
+
+  // Until this landed, stop() flipped the session row to released and left the work item
+  // in_progress with no claimant — invisible to every picker while still counted as
+  // available supply. stop() was itself a strand manufacturer, which is why a Kill button
+  // built on it before FR-1 would have manufactured strands faster than closing a window.
+  // Default OFF: unset LEO_RELEASE_WORKITEM_RESET keeps the previous behaviour exactly.
+  const workItemReset = isReleaseWorkItemResetEnabled()
+    ? await releaseHeldWorkItem(supabase, session_id, 'manual_stop')
+    : null;
+
   const { error } = await supabase.from('claude_sessions').update({
     status: 'released', released_at: new Date().toISOString(), released_reason: 'manual_stop',
   }).eq('session_id', session_id);
 
   await emitVerbEvent(supabase, { verb: 'stop', session_id, outcome: error ? 'db_error' : 'ok' });
-  return { ok: !error, session_id };
+  return { ok: !error, session_id, ...(workItemReset ? { workItemReset } : {}) };
 }
 
 /**

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -251,7 +251,17 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
   // argument (the spec) by buildSessionLaunch:75, `opts` is the SECOND — so both are kept.
   // Dropping either one silently disables a shipped feature: without `opts` the peer's
   // change is inert, without `cwd` the FR-2 seam below becomes untestable.
-  const invocation = buildLiveSpawnInvocation({ role, callsign, profileDir, startupPrompt, cwd: opts.cwd }, opts);
+  // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-3: resumeUuid and sessionId are now THREADED.
+  // buildLiveSpawnInvocation has always ACCEPTED them (:144) but spawn() never forwarded them, so
+  // a caller could set opts.resumeUuid and have it SILENTLY IGNORED — the launch came up cold
+  // while every signature looked correct. This is the choke point behind restart,
+  // relaunchUnderProfile, canaryRestart and drainAndRestart, so forwarding here repairs all four.
+  const invocation = buildLiveSpawnInvocation({
+    role, callsign, profileDir, startupPrompt,
+    cwd: opts.cwd,
+    resumeUuid: opts.resumeUuid,
+    sessionId: opts.sessionId,
+  }, opts);
 
   if (!live) {
     log(`[spawn-control] DRY-RUN would spawn ${role}/${callsign}: ${invocation.program} ${invocation.args.join(' ')}`);
@@ -461,6 +471,14 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
                 ? { window_handle_diagnostics: handleResult.diagnostics }
                 : {}),
               ...(accountProfile ? { account_profile: accountProfile } : {}),
+              // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-3: WHERE THIS SEAT WAS LAUNCHED.
+              // There was no launch_cwd anywhere, and restart worked only by coincidence — every
+              // seat happens to sit in the main tree today. The moment one is launched from a
+              // worktree, a restart without this resumes into the wrong directory and finds
+              // nothing, with no error to say so. spawnReplacement reads it back (FR-3).
+              // Stamped from the INVOCATION's resolved cwd, not process.cwd(): the invocation is
+              // what the process was actually given.
+              ...(invocation && invocation.cwd ? { launch_cwd: invocation.cwd } : {}),
               // FR-4 (PRD implementation_approach step 5): STAMP THE TRIGGER KEY.
               //
               // A VALIDATION review caught that CANARY_TRIGGER_KEY was READ by isCanaryMetadata and
@@ -612,7 +630,28 @@ export async function stop(target, opts = {}) {
 async function spawnReplacement({ oldIdentity, oldSession, accountProfile }, opts) {
   const role = roleOf(oldSession);
   const callsign = oldIdentity.callsign;
-  return spawn({ role, callsign, accountProfile }, { ...opts, skipDedup: true });
+
+  // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-3: carry the conversation across the restart.
+  //
+  // The replacement resumes in the OLD SESSION'S launch_cwd, not this process's cwd. Without that
+  // a worktree-launched seat comes back up in the wrong directory and finds nothing — SILENTLY,
+  // which is why it has looked like it works: every seat currently happens to sit in the main tree.
+  //
+  // resumeUuid is the OLD session_id (the resume token). metadata.resume_uuid is NOT consulted —
+  // it is populated on 1 of 13,025 rows, so reading it would cold-start essentially every seat.
+  //
+  // The caller decides WHETHER to resume (it owns the transcript-existence check — promising
+  // carry-over without verifying it is worse than cold-starting). Passing no resumeUuid yields a
+  // cold start, which is the correct default when the conversation could not be verified.
+  const launchCwd = (oldSession && oldSession.metadata && oldSession.metadata.launch_cwd) || opts.cwd;
+
+  return spawn({ role, callsign, accountProfile }, {
+    ...opts,
+    skipDedup: true,
+    cwd: launchCwd,
+    resumeUuid: opts.resumeUuid,
+    sessionId: opts.sessionId,
+  });
 }
 
 /** FR-4/FR-5: restart -- role-serial for singletons (via the existing guard), parallel for workers. */

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -141,10 +141,10 @@ export function isLiveEnabled(env = process.env) {
  * invisibly. The env carrier is deleted; the prompt has NO delivery path until FR-1 lands the
  * single-line pointer transport. Forwarding it here is still correct: FR-1 consumes it.
  */
-export function buildLiveSpawnInvocation({ role, callsign, profileDir, resumeUuid, cwd, sdToResume, startupPrompt, sessionId } = {}, opts = {}) {
+export function buildLiveSpawnInvocation({ role, callsign, profileDir, resumeUuid, cwd, sdToResume, startupPrompt, sessionId, forkSession } = {}, opts = {}) {
   // FR-3: sessionId/uuidFn forwarded so the minted id is injectable (deterministic tests) rather
   // than only reachable through crypto.randomUUID inside the builder.
-  return buildSessionLaunch({ role, callsign, profileDir, resumeUuid, cwd, sdToResume, startupPrompt, sessionId }, opts);
+  return buildSessionLaunch({ role, callsign, profileDir, resumeUuid, cwd, sdToResume, startupPrompt, sessionId, forkSession }, opts);
 }
 
 /**
@@ -261,6 +261,7 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
     cwd: opts.cwd,
     resumeUuid: opts.resumeUuid,
     sessionId: opts.sessionId,
+    forkSession: opts.forkSession,
   }, opts);
 
   if (!live) {
@@ -651,6 +652,7 @@ async function spawnReplacement({ oldIdentity, oldSession, accountProfile }, opt
     cwd: launchCwd,
     resumeUuid: opts.resumeUuid,
     sessionId: opts.sessionId,
+    forkSession: opts.forkSession,
   });
 }
 

--- a/lib/fleet/window-enum-fails-loudly.test.js
+++ b/lib/fleet/window-enum-fails-loudly.test.js
@@ -1,0 +1,77 @@
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-5a — window enumeration must fail LOUDLY.
+ *
+ * The SD's success criterion is verified by FORCING A TIMEOUT and driving the abort path.
+ * Raising the timeout alone does NOT satisfy it: the measured failure mode is a ~4.9s
+ * enumeration against a 5000ms ceiling, and the defect is the silent fail-soft, not the margin.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  enumerateWindows,
+  enumerateWindowsStrict,
+  WINDOW_ENUM_TIMEOUT_MS,
+} from './window-handle.js';
+
+/** Reproduce how execFile reports a timeout: it KILLS the child. */
+function timeoutError() {
+  const e = new Error('Command failed: timeout');
+  e.killed = true;
+  e.signal = 'SIGTERM';
+  return e;
+}
+
+const OK_STDOUT = '';
+
+describe('FR5a-LOUD: a timed-out enumeration is distinguishable from an empty desktop', () => {
+  it('FORCING A TIMEOUT drives the abort path and reports GUARD_UNAVAILABLE', async () => {
+    const execFn = vi.fn(async () => { throw timeoutError(); });
+    const r = await enumerateWindowsStrict({ execFn });
+    expect(r.ok).toBe(false);
+    expect(r.windows).toBeNull();          // NOT [] — there is no observation to report
+    expect(r.error.code).toBe('GUARD_UNAVAILABLE');
+    expect(r.error.timedOut).toBe(true);
+    expect(r.error.message).toMatch(/this is not an empty desktop/);
+  });
+
+  it('AN EMPTY DESKTOP IS A DIFFERENT ANSWER — ok:true with zero windows', async () => {
+    // This is the pair that matters. Before FR-5a both cases produced [], so a caller could
+    // not tell "I looked and saw nothing" from "I never got to look".
+    const execFn = vi.fn(async () => ({ stdout: OK_STDOUT }));
+    const r = await enumerateWindowsStrict({ execFn });
+    expect(r.ok).toBe(true);
+    expect(Array.isArray(r.windows)).toBe(true);
+    expect(r.error).toBeNull();
+  });
+
+  it('names a non-timeout failure differently — the operator response differs', async () => {
+    const execFn = vi.fn(async () => { throw new Error('powershell refused'); });
+    const r = await enumerateWindowsStrict({ execFn });
+    expect(r.ok).toBe(false);
+    expect(r.error.timedOut).toBe(false);
+    expect(r.error.message).toMatch(/powershell refused/);
+  });
+});
+
+describe('FR5a-MARGIN: the ceiling clears the measured enumeration, but is not the fix', () => {
+  it('raises the timeout well past the ~4.9s measurement that was failing against 5000ms', () => {
+    expect(WINDOW_ENUM_TIMEOUT_MS).toBeGreaterThan(5000);
+    // A ~2% margin is what produced roughly two failures in three.
+    expect(WINDOW_ENUM_TIMEOUT_MS).toBeGreaterThanOrEqual(15000);
+  });
+});
+
+describe('FR5a-COMPAT: the legacy fail-soft caller contract is untouched', () => {
+  it('enumerateWindows still returns [] on failure, for captureNewWindowHandle', async () => {
+    // captureNewWindowHandle's contract depends on this and its tests assert it. Flipping the
+    // return type here would break the capture path in order to fix the reaper.
+    const execFn = vi.fn(async () => { throw timeoutError(); });
+    await expect(enumerateWindows({ execFn })).resolves.toEqual([]);
+  });
+
+  it('and still returns the parsed list on success', async () => {
+    const execFn = vi.fn(async () => ({ stdout: OK_STDOUT }));
+    const out = await enumerateWindows({ execFn });
+    expect(Array.isArray(out)).toBe(true);
+  });
+});

--- a/lib/fleet/window-handle.js
+++ b/lib/fleet/window-handle.js
@@ -38,8 +38,19 @@ const execFileAsync = promisify(execFile);
  * captureNewWindowHandle in the tests, so retiring the old tests retires no protection.
  */
 
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-5a.
+ * Was 5000. The enumeration was MEASURED at ~4.9s on this host — a ~2% margin — so it
+ * timed out roughly two runs in three. Every one of those failures returned [] (see
+ * enumerateWindows below), which is indistinguishable from an empty desktop. Raising the
+ * ceiling fixes the FREQUENCY; enumerateWindowsStrict fixes the SILENCE. Both are needed:
+ * a bigger timeout still fails eventually, and a failure that reports [] is a wrong answer,
+ * not a slow one.
+ */
+export const WINDOW_ENUM_TIMEOUT_MS = 20000;
+
 async function defaultExec(program, args) {
-  return execFileAsync(program, args, { windowsHide: false, timeout: 5000 });
+  return execFileAsync(program, args, { windowsHide: false, timeout: WINDOW_ENUM_TIMEOUT_MS });
 }
 function defaultSleep(ms) { return new Promise((resolve) => setTimeout(resolve, ms)); }
 
@@ -195,16 +206,55 @@ export function selectNewWindowHandle(before = [], after = [], opts = {}) {
   return { handle: appeared[0], reason: 'ok', diagnostics: { ...diagnostics, reason: 'ok' } };
 }
 
-/** Run one enumeration. Injectable execFn so unit tests never invoke PowerShell. Fail-soft: [] on error. */
-export async function enumerateWindows(opts = {}) {
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-5a — THE ENUMERATION THAT FAILS LOUDLY.
+ *
+ * A failed enumeration and an empty desktop are NOT the same fact, and until now they
+ * produced the same value: []. That is why the SD calls this the prerequisite bug — a
+ * fail-soft [] composed with a fail-CLOSED set-difference GUARANTEES capture failure
+ * rather than degrading, and back-to-back runs on this host returned 135 rows, then 0,
+ * then 0, with nothing in the output to say which zeros were real.
+ *
+ * Returns { ok, windows, error }. A caller that must not act on a guess — the FR-5 reaper,
+ * whose whole safety argument is "this console contains no process" — uses THIS and handles
+ * ok:false. Reading "no windows" from a timeout would let it reason about a desktop it
+ * never actually saw.
+ */
+export async function enumerateWindowsStrict(opts = {}) {
   const { execFn = defaultExec } = opts;
   try {
     const cmd = buildWindowEnumCommand();
     const { stdout } = await execFn(cmd.program, cmd.args);
-    return parseWindowListOutput(stdout);
-  } catch {
-    return [];
+    return { ok: true, windows: parseWindowListOutput(stdout), error: null };
+  } catch (err) {
+    // execFile signals a timeout by KILLING the child, so it surfaces as killed/SIGTERM
+    // rather than a distinct code. Name it explicitly — "timed out" and "PowerShell refused"
+    // want different operator responses.
+    const timedOut = Boolean(err && (err.killed || err.code === 'ETIMEDOUT' || err.signal === 'SIGTERM'));
+    return {
+      ok: false,
+      windows: null,
+      error: {
+        code: 'GUARD_UNAVAILABLE',
+        timedOut,
+        message: timedOut
+          ? `window enumeration exceeded ${WINDOW_ENUM_TIMEOUT_MS}ms — the desktop was NOT observed; this is not an empty desktop`
+          : `window enumeration failed: ${(err && err.message) || err} — the desktop was NOT observed`,
+      },
+    };
   }
+}
+
+/**
+ * Legacy fail-soft wrapper: [] on error.
+ * DELIBERATELY UNCHANGED in behaviour. captureNewWindowHandle's contract is built on it
+ * ("enumerateWindows swallows exec failures and returns [], and selectNewWindowHandle is
+ * pure and total"), and that invariant is asserted in its tests. Flipping this return type
+ * would break the capture path to fix the reaper. New callers should prefer the strict form.
+ */
+export async function enumerateWindows(opts = {}) {
+  const r = await enumerateWindowsStrict(opts);
+  return r.ok ? r.windows : [];
 }
 
 /**

--- a/scripts/coordinator-cold-recovery.cjs
+++ b/scripts/coordinator-cold-recovery.cjs
@@ -99,6 +99,15 @@ async function alreadyRedispatched(supabase, sdKey, { nowMs }) {
  * otherwise the belt keeps seeing the SD as CLAIMED (SD-LEO-FIX-CLAIM-RELEASE-DESYNC-001).
  * Holder-pinned CAS also prevents clobbering a peer that legitimately took over. */
 async function releaseClaim(supabase, sd) {
+  // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b — EXEMPT from releaseWorkItemOnSessionEnd's
+  // SD phase rewind, recorded because FR-1 requires every release path to either call the shared
+  // helper or carry a written reason it must not.
+  // THE REASON is the docblock above: this path PRESERVES current_phase + progress (resume, not
+  // restart). The helper's rewind would send the SD back to a phase boundary, converting the
+  // resume this function exists to enable into a restart and discarding the progress it protects.
+  // That is exactly why the helper makes rewindPhase OPT-IN (default false) rather than
+  // automatic. If a QF ever reaches this path, wiring the QF-only hand-back would be safe — but
+  // cold recovery operates on strategic_directives_v2 rows, so there is nothing to hand back.
   const { releaseClaimBothSurfaces } = await import('../lib/claim/release-claim-both-surfaces.mjs');
   const r = await releaseClaimBothSurfaces(supabase, {
     sdKey: sd.sd_key,

--- a/scripts/fleet-kill.mjs
+++ b/scripts/fleet-kill.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-2 — operator CLI for the graceful kill.
+ *
+ * OPERATOR-INITIATED ONLY. No watchdog, sweep or cron may call this — a policy already ratified
+ * in two places (stale-session-sweep.cjs :290 and :2058-2060). This file is an entry point, never
+ * an importable side effect: the orchestration lives in lib/fleet/graceful-kill.mjs and this
+ * module only binds it to real collaborators.
+ *
+ * Usage:
+ *   node scripts/fleet-kill.mjs <session-id> [--reason "<text>"] [--dry-run]
+ *
+ * Gated by FLEET_GRACEFUL_KILL_ENABLED=on. Its own flag — FLEET_CANARY_KILL_ENABLED is NOT
+ * consulted, because that flag's canary-only assert is what keeps drills off production seats.
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+import { gracefulKillSession, isGracefulKillEnabled } from '../lib/fleet/graceful-kill.mjs';
+import { sampleToolActivityTwice } from '../lib/fleet/release-work-item.mjs';
+import { bestEffortReleaseSd } from '../lib/fleet/best-effort-release.mjs';
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+
+const require = createRequire(import.meta.url);
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+const { pidIsClaude, readTickPidfile } = require('../lib/fleet/claimant-liveness.cjs');
+const { runPreparkWip } = require('../lib/fleet/prepark-wip.cjs');
+
+/**
+ * pidIsClaude is TRI-STATE: 'MATCH' | 'NO_MATCH' | 'PROBE_FAILED'. Map it deliberately.
+ *
+ * PROBE_FAILED MUST NOT COLLAPSE TO false. Both false and undefined end in a refusal, but they
+ * are different facts and produce different operator messages: false means "this pid is not the
+ * agent — most likely the shell wrapper claude_sessions.pid falls back to", while PROBE_FAILED
+ * means "the probe itself broke and told us nothing". The helper's own docblock is explicit that
+ * PROBE_FAILED is NOT death; flattening it would report a wrong-process diagnosis we never made.
+ */
+export function claudeProbeToTriState(result) {
+  if (result === 'MATCH') return true;
+  if (result === 'NO_MATCH') return false;
+  return undefined; // PROBE_FAILED, or anything unrecognised
+}
+
+/** The SessionStart marker records the tick pid; a disagreement with the DB pid is a refusal. */
+export function markerPidFor(sessionId, repoRoot = REPO_ROOT) {
+  const marker = readTickPidfile(sessionId, repoRoot);
+  const pid = marker && (marker.pid ?? marker.tick_pid);
+  return Number.isInteger(pid) ? pid : null;
+}
+
+export function buildKillDeps(supabase, sessionId, { reason, dryRun = false } = {}) {
+  return {
+    reason: reason || 'operator_graceful_kill',
+    getSession: async () => {
+      const { data } = await supabase
+        .from('claude_sessions')
+        .select('session_id, pid, sd_key, worktree_path, status')
+        .eq('session_id', sessionId)
+        .maybeSingle();
+      return data || null;
+    },
+    readMarkerPid: (sid) => markerPidFor(sid),
+    pidIsClaude: (pid) => claudeProbeToTriState(pidIsClaude(pid)),
+    sampleToolActivity: (sb, sid) => sampleToolActivityTwice(sb, sid, { intervalMs: 5_000 }),
+    runPreparkWip,
+    releaseClaim: async (sessionId, sdKey) => {
+      const r = await bestEffortReleaseSd(supabase, sessionId, reason || 'operator_graceful_kill',
+        () => {}, sdKey ? { expectedSdKey: sdKey } : {});
+      return { released: r.released === true };
+    },
+    // A dry run exercises every check and stops before the irreversible step.
+    kill: dryRun ? async () => {} : undefined,
+    verifyGone: dryRun ? async () => true : undefined,
+  };
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const sessionId = argv.find((a) => !a.startsWith('--'));
+  const dryRun = argv.includes('--dry-run');
+  const reasonIdx = argv.indexOf('--reason');
+  const reason = reasonIdx >= 0 ? argv[reasonIdx + 1] : undefined;
+
+  if (!sessionId) {
+    console.error('Usage: node scripts/fleet-kill.mjs <session-id> [--reason "<text>"] [--dry-run]');
+    process.exit(2);
+  }
+  if (!isGracefulKillEnabled()) {
+    console.error('FLEET_GRACEFUL_KILL_ENABLED is not "on" — refusing. This verb is operator-initiated and default-off.');
+    process.exit(3);
+  }
+
+  const supabase = createSupabaseServiceClient();
+  const deps = buildKillDeps(supabase, sessionId, { reason, dryRun });
+
+  // spawn-control's stop() records the fleet_verb_stop event (and idempotently re-runs the
+  // claim release + hand-back, both CAS-guarded). Imported lazily so a dry run that never
+  // reaches step 7 does not pull the module in.
+  deps.recordStop = dryRun ? null : async (sid) => {
+    const { stop } = await import('../lib/fleet/spawn-control.js');
+    await stop(sid, { by: 'session_id', supabaseClient: supabase });
+  };
+
+  const verdict = await gracefulKillSession(supabase, sessionId, deps);
+
+  console.log(JSON.stringify({ sessionId, dryRun, ...verdict }, null, 2));
+  // A halt is a SUCCESSFUL refusal to destroy work, not a crash — but it must not read as a kill.
+  process.exit(verdict.outcome === 'killed' ? 0 : 1);
+}
+
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('fleet-kill.mjs')) {
+  main().catch((err) => {
+    console.error(`fleet-kill failed: ${(err && err.message) || err}`);
+    process.exit(1);
+  });
+}

--- a/scripts/run-console-reaper.mjs
+++ b/scripts/run-console-reaper.mjs
@@ -22,10 +22,16 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { reapEmptyConsoles } from '../lib/fleet/console-reaper.mjs';
-import { buildParentageRecord } from '../lib/fleet/console-parentage.mjs';
+import { buildParentageRecord, persistParentageRecords } from '../lib/fleet/console-parentage.mjs';
+import { appendFileSync, readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const execFileAsync = promisify(execFile);
 const TAG = '[console-reaper]';
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+/** Append-only parentage log. Durable across the parent's exit, which is the entire requirement. */
+export const PARENTAGE_LOG = path.join(REPO_ROOT, '.claude', 'console-parentage.jsonl');
 export const CONSOLE_IMAGE = 'OpenConsole.exe';
 /** Generous: the FR-5a lesson is that a tight margin on a ~5s enumeration fails 2 runs in 3. */
 export const PROBE_TIMEOUT_MS = 20000;
@@ -109,6 +115,9 @@ export async function runReaperOnce(deps = {}) {
     onLog = (m) => console.log(`${TAG} ${m}`),
     nowIso = new Date().toISOString(),
     dryRun = false,
+    persistParentage = (records) => persistParentageRecords(records, {
+      filePath: PARENTAGE_LOG, appendFileSync, readFileSync, existsSync,
+    }),
   } = deps;
 
   if (!isConsoleReaperEnabled(env)) {
@@ -127,7 +136,11 @@ export async function runReaperOnce(deps = {}) {
   // unidentified, and a console that is occupied now is exactly the one worth attributing.
   const parentage = consoles.map((c) => parentageFor(c, snap.processes, nowIso));
   const attributed = parentage.filter((p) => p.ok).length;
-  onLog(`observed ${consoles.length} console(s); parentage attributed for ${attributed}/${consoles.length}`);
+  // PERSIST NOW, before any kill. Capturing without writing achieves nothing: the record has to
+  // outlive the parent, and the parent is usually gone by the time anyone looks. Fail-open — a
+  // logging failure must never stop a reap.
+  const persisted = persistParentage(parentage);
+  onLog(`observed ${consoles.length} console(s); parentage attributed for ${attributed}/${consoles.length}; persisted ${persisted.written} new`);
 
   const candidates = consoles
     .filter((c) => descendantCountOf(c.pid, snap.processes) === 0)
@@ -135,10 +148,13 @@ export async function runReaperOnce(deps = {}) {
 
   if (dryRun) {
     onLog(`DRY RUN — would reap ${candidates.length} empty console(s): ${candidates.map((c) => c.pid).join(', ') || 'none'}`);
-    return { ran: true, dryRun: true, observed: consoles.length, candidates: candidates.length, parentage };
+    return { ran: true, dryRun: true, observed: consoles.length, candidates: candidates.length, parentage, persisted };
   }
 
   const result = await reapEmptyConsoles(candidates, {
+    // Thread the SAME env the runner gated on, so the primitive's own gate agrees with it
+    // instead of reading a different process.env.
+    env,
     // Re-observe RIGHT BEFORE each kill, from a FRESH snapshot — the whole point is that the scan
     // above is already stale by the time we act on it.
     recheckDescendants: async (pid) => {
@@ -150,7 +166,7 @@ export async function runReaperOnce(deps = {}) {
     onLog,
   });
 
-  return { ran: true, observed: consoles.length, parentage, ...result };
+  return { ran: true, observed: consoles.length, parentage, persisted, ...result };
 }
 
 async function main() {

--- a/scripts/run-console-reaper.mjs
+++ b/scripts/run-console-reaper.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-5 — the reaper runner.
+ *
+ * Wires the pure decisions (console-reaper.mjs, console-parentage.mjs) to real Win32 process
+ * enumeration. This is the file setup-console-reaper-task.mjs refuses to register until it exists.
+ *
+ * CHAIRMAN OVERRIDE 2026-07-27 — the reaper SHIPS rather than observing for a week. Behind its own
+ * default-off flag all the same (FLEET_CONSOLE_REAPER_ENABLED), because "authorised" and "armed on
+ * every host by default" are different things.
+ *
+ * WHAT IT REAPS: OpenConsole processes with ZERO descendants. The safety argument is the
+ * ASYMMETRY — the test is "contains no process", so a false positive cannot destroy work. It does
+ * NOT reason about which seat owns which console, because seat-to-window binding is impossible
+ * post-hoc and a Cursor pane has no window at all.
+ *
+ * THE PROBE IS FAIL-CLOSED. Every enumeration returns {ok}. A failed WMIC/PowerShell call yields
+ * ok:false and the run does NOTHING — it never degrades into "saw zero consoles", which is the
+ * FR-5a defect that made a timed-out enumeration indistinguishable from an empty desktop.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { reapEmptyConsoles } from '../lib/fleet/console-reaper.mjs';
+import { buildParentageRecord } from '../lib/fleet/console-parentage.mjs';
+
+const execFileAsync = promisify(execFile);
+const TAG = '[console-reaper]';
+export const CONSOLE_IMAGE = 'OpenConsole.exe';
+/** Generous: the FR-5a lesson is that a tight margin on a ~5s enumeration fails 2 runs in 3. */
+export const PROBE_TIMEOUT_MS = 20000;
+
+export function isConsoleReaperEnabled(env = process.env) {
+  return env.FLEET_CONSOLE_REAPER_ENABLED === 'on';
+}
+
+/**
+ * One PowerShell round-trip returning every process as {pid, ppid, name, cmd}. Parsed from CSV
+ * rather than JSON because a single-row result serialises as an object, not an array — a shape
+ * difference that silently yields "one process" or a crash depending on the host's load.
+ */
+export async function snapshotProcesses({ exec = execFileAsync } = {}) {
+  const ps = 'Get-CimInstance Win32_Process | Select-Object ProcessId,ParentProcessId,Name,CommandLine | ConvertTo-Csv -NoTypeInformation';
+  try {
+    const { stdout } = await exec('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', ps], { timeout: PROBE_TIMEOUT_MS, windowsHide: true, maxBuffer: 32 * 1024 * 1024 });
+    return { ok: true, processes: parseProcessCsv(stdout), error: null };
+  } catch (err) {
+    const timedOut = Boolean(err && (err.killed || err.code === 'ETIMEDOUT' || err.signal === 'SIGTERM'));
+    return {
+      ok: false,
+      processes: null, // NOT [] — there is no observation to report
+      error: { code: 'GUARD_UNAVAILABLE', timedOut, message: (err && err.message) || String(err) },
+    };
+  }
+}
+
+/** Minimal CSV reader for the four fixed columns above (CommandLine may contain commas/quotes). */
+export function parseProcessCsv(stdout) {
+  const lines = String(stdout || '').split(/\r?\n/).filter((l) => l.trim().length);
+  if (lines.length <= 1) return [];
+  const out = [];
+  for (const line of lines.slice(1)) {
+    const cells = [];
+    let cur = '', inQ = false;
+    for (let i = 0; i < line.length; i += 1) {
+      const ch = line[i];
+      if (ch === '"') { if (inQ && line[i + 1] === '"') { cur += '"'; i += 1; } else inQ = !inQ; }
+      else if (ch === ',' && !inQ) { cells.push(cur); cur = ''; }
+      else cur += ch;
+    }
+    cells.push(cur);
+    const pid = Number(cells[0]);
+    if (!Number.isFinite(pid)) continue;
+    out.push({ pid, ppid: Number(cells[1]), name: cells[2] || '', cmd: cells[3] || '' });
+  }
+  return out;
+}
+
+/** Descendant count for a pid, from a snapshot. Direct children are sufficient: a console with a
+ *  child is occupied regardless of how deep the tree goes below it. */
+export function descendantCountOf(pid, processes) {
+  return processes.filter((p) => p.ppid === pid).length;
+}
+
+export function findConsoles(processes) {
+  return processes.filter((p) => String(p.name).toLowerCase() === CONSOLE_IMAGE.toLowerCase());
+}
+
+/** Parentage for a console, resolved from the SAME snapshot that found it. */
+export function parentageFor(consoleProc, processes, nowIso) {
+  const parent = processes.find((p) => p.pid === consoleProc.ppid) || null;
+  const grand = parent ? processes.find((p) => p.pid === parent.ppid) || null : null;
+  return buildParentageRecord({
+    consolePid: consoleProc.pid,
+    observedAt: nowIso,
+    parentPid: parent ? parent.pid : null,
+    parentImage: parent ? parent.name : null,
+    parentCommandLine: parent ? parent.cmd : null,
+    grandparentPid: grand ? grand.pid : null,
+    grandparentImage: grand ? grand.name : null,
+  });
+}
+
+export async function runReaperOnce(deps = {}) {
+  const {
+    env = process.env,
+    snapshot = snapshotProcesses,
+    kill = async (pid) => { await execFileAsync('taskkill', ['/PID', String(pid), '/F'], { timeout: PROBE_TIMEOUT_MS, windowsHide: true }); },
+    onLog = (m) => console.log(`${TAG} ${m}`),
+    nowIso = new Date().toISOString(),
+    dryRun = false,
+  } = deps;
+
+  if (!isConsoleReaperEnabled(env)) {
+    return { ran: false, reason: 'FLEET_CONSOLE_REAPER_ENABLED is not on' };
+  }
+
+  const snap = await snapshot();
+  if (!snap.ok) {
+    // FAIL-CLOSED. "I could not look" must never become "there was nothing to see".
+    onLog(`ABORT: ${snap.error.message} — the process table was NOT observed; doing nothing`);
+    return { ran: false, reason: snap.error.code, timedOut: snap.error.timedOut };
+  }
+
+  const consoles = findConsoles(snap.processes);
+  // Parentage is captured for EVERY console seen, not only the ones reaped: the creator is still
+  // unidentified, and a console that is occupied now is exactly the one worth attributing.
+  const parentage = consoles.map((c) => parentageFor(c, snap.processes, nowIso));
+  const attributed = parentage.filter((p) => p.ok).length;
+  onLog(`observed ${consoles.length} console(s); parentage attributed for ${attributed}/${consoles.length}`);
+
+  const candidates = consoles
+    .filter((c) => descendantCountOf(c.pid, snap.processes) === 0)
+    .map((c) => ({ pid: c.pid }));
+
+  if (dryRun) {
+    onLog(`DRY RUN — would reap ${candidates.length} empty console(s): ${candidates.map((c) => c.pid).join(', ') || 'none'}`);
+    return { ran: true, dryRun: true, observed: consoles.length, candidates: candidates.length, parentage };
+  }
+
+  const result = await reapEmptyConsoles(candidates, {
+    // Re-observe RIGHT BEFORE each kill, from a FRESH snapshot — the whole point is that the scan
+    // above is already stale by the time we act on it.
+    recheckDescendants: async (pid) => {
+      const fresh = await snapshot();
+      if (!fresh.ok) return { observed: false };
+      return { descendantCount: descendantCountOf(pid, fresh.processes), observed: true };
+    },
+    kill,
+    onLog,
+  });
+
+  return { ran: true, observed: consoles.length, parentage, ...result };
+}
+
+async function main() {
+  const dryRun = process.argv.includes('--dry-run');
+  if (process.platform !== 'win32') {
+    console.error(`${TAG} win32-only — the reaper reads the Windows process table.`);
+    process.exit(2);
+  }
+  const out = await runReaperOnce({ dryRun });
+  console.log(JSON.stringify(out, null, 2));
+  process.exit(out.ran ? 0 : 1);
+}
+
+if (process.argv[1]?.endsWith('run-console-reaper.mjs')) {
+  main().catch((err) => { console.error(`${TAG} ${(err && err.message) || err}`); process.exit(1); });
+}

--- a/scripts/setup-console-reaper-task.mjs
+++ b/scripts/setup-console-reaper-task.mjs
@@ -49,7 +49,7 @@ export function principalSpecFor(runAs, { interactive = false } = {}) {
  * THROWS on an unsafe principal rather than emitting argv a caller might run anyway: the guard
  * has to sit where the command is CONSTRUCTED, not merely where it is documented.
  */
-export function buildReaperSchtasksArgs({ runAs = 'SYSTEM', intervalMinutes = 30, interactive = false, nodePath = 'node', requireRunner = true } = {}) {
+export function buildReaperSchtasksArgs({ runAs = 'SYSTEM', intervalMinutes = 30, interactive = false, nodePath = 'node', requireRunner = true, runnerPath = null } = {}) {
   const verdict = validateScheduledTaskPrincipal(principalSpecFor(runAs, { interactive }));
   if (!verdict.ok) {
     throw new Error(`${TAG} refusing to register: ${verdict.reason}`);
@@ -58,7 +58,10 @@ export function buildReaperSchtasksArgs({ runAs = 'SYSTEM', intervalMinutes = 30
   if (!Number.isInteger(minutes) || minutes < 1 || minutes > 1439) {
     throw new Error(`${TAG} --interval-minutes must be an integer 1..1439 (got ${intervalMinutes})`);
   }
-  const runner = path.join(REPO_ROOT, 'scripts', 'run-console-reaper.mjs');
+  // runnerPath is injectable ONLY so the guard is testable in BOTH directions without
+  // depending on whether a sibling file happens to exist in the checkout — a test whose meaning
+  // flips when an unrelated file lands is not a test.
+  const runner = runnerPath || path.join(REPO_ROOT, 'scripts', 'run-console-reaper.mjs');
   // A task pointing at a MISSING runner registers happily and then fails silently every
   // interval — the same accepted-but-unread shape this SD has hit four times already
   // (FLEET_WORKER_ROLE with no readers; enumerateWindows returning []; spawn() dropping

--- a/scripts/setup-console-reaper-task.mjs
+++ b/scripts/setup-console-reaper-task.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-5 — register the console reaper as a LOCAL
+ * Windows scheduled task, under a SESSION-0 principal.
+ *
+ * WHY LOCAL AND NOT GHA. Every check the reaper makes reads the Windows PROCESS TABLE —
+ * "does this console have descendants", "is this pid a live claude.exe". sweep-cron.yml:23 is
+ * ubuntu-latest, so on the scheduled path those checks would evaluate against a Linux runner
+ * that shares NO process table with this machine. Scheduled reconciliation exists today, but it
+ * is DB-to-DB-only BY DEPLOYMENT TARGET. A reaper wired there would return confident, wrong
+ * answers rather than no answers.
+ *
+ * WHY SESSION-0, ENFORCED RATHER THAN DOCUMENTED. The console leak this task exists to clean up
+ * is CAUSED BY a local scheduled task with an INTERACTIVE principal — such a task materialises a
+ * console every single run. Registering the reaper the same way would leak one console per run:
+ * a reaper feeding the thing it reaps. schtasks expresses that mistake as /IT ("interactive
+ * token"), so /IT is refused outright and the run-as defaults to SYSTEM.
+ *
+ * Usage:
+ *   node scripts/setup-console-reaper-task.mjs [--interval-minutes 30] [--ru SYSTEM] [--dry-run]
+ *   node scripts/setup-console-reaper-task.mjs --status | --remove
+ */
+
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { validateScheduledTaskPrincipal } from '../lib/fleet/console-parentage.mjs';
+
+const TAG = '[console-reaper-task]';
+export const TASK_NAME = 'LEO-ConsoleReaper';
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+
+/** Session-0 run-as accounts. A named interactive user is NOT one of these. */
+const SESSION0_ACCOUNTS = new Set(['system', 'nt authority\\system', 'localservice', 'networkservice']);
+
+/**
+ * Map a requested run-as to the principal spec validateScheduledTaskPrincipal understands.
+ * Kept separate from the argv builder so the SAFETY decision is not entangled with quoting.
+ */
+export function principalSpecFor(runAs, { interactive = false } = {}) {
+  if (interactive) return { logonType: 'Interactive', userId: runAs || '' };
+  const isSession0 = SESSION0_ACCOUNTS.has(String(runAs || '').toLowerCase());
+  return { logonType: isSession0 ? 'ServiceAccount' : 'Password', userId: runAs || '' };
+}
+
+/**
+ * Build the `schtasks /Create` argv. PURE — no embedded quoting; execFileSync quotes spaced args.
+ * THROWS on an unsafe principal rather than emitting argv a caller might run anyway: the guard
+ * has to sit where the command is CONSTRUCTED, not merely where it is documented.
+ */
+export function buildReaperSchtasksArgs({ runAs = 'SYSTEM', intervalMinutes = 30, interactive = false, nodePath = 'node', requireRunner = true } = {}) {
+  const verdict = validateScheduledTaskPrincipal(principalSpecFor(runAs, { interactive }));
+  if (!verdict.ok) {
+    throw new Error(`${TAG} refusing to register: ${verdict.reason}`);
+  }
+  const minutes = Number(intervalMinutes);
+  if (!Number.isInteger(minutes) || minutes < 1 || minutes > 1439) {
+    throw new Error(`${TAG} --interval-minutes must be an integer 1..1439 (got ${intervalMinutes})`);
+  }
+  const runner = path.join(REPO_ROOT, 'scripts', 'run-console-reaper.mjs');
+  // A task pointing at a MISSING runner registers happily and then fails silently every
+  // interval — the same accepted-but-unread shape this SD has hit four times already
+  // (FLEET_WORKER_ROLE with no readers; enumerateWindows returning []; spawn() dropping
+  // resumeUuid; metadata.resume_uuid). Refuse to build the command at all until the runner
+  // exists, so the gap is loud now rather than silent forever.
+  if (requireRunner && !existsSync(runner)) {
+    throw new Error(
+      `${TAG} runner not found at ${runner} — refusing to register a task that would fail ` +
+      'silently every interval. Land the reaper runner first (it wires console-reaper.mjs ' +
+      'reapEmptyConsoles + console-parentage.mjs capture to real Win32 process enumeration).'
+    );
+  }
+  return [
+    '/Create', '/TN', TASK_NAME,
+    '/TR', `"${nodePath}" "${runner}"`,
+    '/SC', 'MINUTE', '/MO', String(minutes),
+    '/RU', runAs,
+    '/RL', 'HIGHEST',
+    '/F', // idempotent re-register
+    // NOTE: /IT is deliberately NEVER emitted. See the header — it is the leak mechanism.
+  ];
+}
+
+export function buildQueryArgs() { return ['/Query', '/TN', TASK_NAME, '/V', '/FO', 'LIST']; }
+export function buildRemoveArgs() { return ['/Delete', '/TN', TASK_NAME, '/F']; }
+
+function parseArgs(argv) {
+  const get = (flag, dflt) => {
+    const i = argv.indexOf(flag);
+    return i >= 0 && argv[i + 1] ? argv[i + 1] : dflt;
+  };
+  return {
+    dryRun: argv.includes('--dry-run'),
+    status: argv.includes('--status'),
+    remove: argv.includes('--remove'),
+    interactive: argv.includes('--interactive'), // accepted ONLY so it can be refused loudly
+    runAs: get('--ru', 'SYSTEM'),
+    intervalMinutes: get('--interval-minutes', '30'),
+  };
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (process.platform !== 'win32') {
+    console.error(`${TAG} win32-only (schtasks). The reaper reads the WINDOWS process table, so`);
+    console.error(`${TAG} there is no meaningful POSIX equivalent — do NOT wire it into a Linux cron.`);
+    process.exit(2);
+  }
+
+  if (args.status) {
+    if (args.dryRun) { console.log(`${TAG} DRY RUN — would run: schtasks ${buildQueryArgs().join(' ')}`); return; }
+    try { console.log(execFileSync('schtasks', buildQueryArgs(), { encoding: 'utf8' })); }
+    catch (e) { console.error(`${TAG} not registered (${(e && e.message) || e})`); process.exit(1); }
+    return;
+  }
+
+  if (args.remove) {
+    if (args.dryRun) { console.log(`${TAG} DRY RUN — would run: schtasks ${buildRemoveArgs().join(' ')}`); return; }
+    execFileSync('schtasks', buildRemoveArgs(), { encoding: 'utf8' });
+    console.log(`${TAG} removed ${TASK_NAME}`);
+    return;
+  }
+
+  let schtasksArgs;
+  try {
+    schtasksArgs = buildReaperSchtasksArgs({
+      runAs: args.runAs,
+      intervalMinutes: Number(args.intervalMinutes),
+      interactive: args.interactive,
+    });
+  } catch (err) {
+    console.error((err && err.message) || String(err));
+    process.exit(3);
+  }
+
+  if (args.dryRun) {
+    console.log(`${TAG} DRY RUN — would run: schtasks ${schtasksArgs.join(' ')}`);
+    return;
+  }
+
+  execFileSync('schtasks', schtasksArgs, { encoding: 'utf8' });
+  console.log(`${TAG} registered ${TASK_NAME} every ${args.intervalMinutes}m as ${args.runAs} (session-0, no interactive token)`);
+}
+
+if (process.argv[1]?.endsWith('setup-console-reaper-task.mjs')) {
+  main().catch((err) => { console.error(`${TAG} ${(err && err.message) || err}`); process.exit(1); });
+}

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -237,8 +237,14 @@ async function runClaimBoundaryProbe(supabase, classified, telemetryMap, now, ac
       // gating it would mean the default-OFF flag SILENTLY DISABLES live fleet protection —
       // a refactor that turns a working guard off is not a refactor.
       const { releaseWorkItemOnSessionEnd } = await import('../lib/fleet/release-work-item.mjs');
+      // rewindPhase:true is REQUIRED here and is not the helper's default. The sweep's
+      // PHASE_RESET_MAP exists precisely so an SD is not left in mid-phase limbo with no active
+      // claimer, so this site must keep rewinding. Other release paths (cold-recovery,
+      // claim-validity-gate) deliberately PRESERVE the phase for resume — which is why the
+      // helper makes the rewind opt-in rather than automatic.
       const handback = await releaseWorkItemOnSessionEnd(
-        supabase, releasedSd, 'CLAIM_BOUNDARY_PROBE', { onLog: (m) => console.log('  ' + m) });
+        supabase, releasedSd, 'CLAIM_BOUNDARY_PROBE',
+        { rewindPhase: true, onLog: (m) => console.log('  ' + m) });
       if (!handback.ok) {
         warnings.push('CLAIM_BOUNDARY_PROBE: work-item handback failed for ' + releasedSd + ' — ' + handback.detail);
       }

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -223,23 +223,24 @@ async function runClaimBoundaryProbe(supabase, classified, telemetryMap, now, ac
         continue;
       }
 
-      // 2a. QF supplement: release_sd clears claiming_session_id but leaves
-      // status='in_progress', which the checkin open-QF picker (status='open')
-      // cannot see — reset it, guarded on every column so a QF with real work
-      // (PR/commit) or a new claimant is never touched.
-      if (/^QF-/.test(releasedSd)) {
-        // The status guard uses the .filter('status','eq',...) spelling (wire-identical
-        // to the .eq form) because stale-session-sweep-claim-safety.test.js anchors its
-        // "phantom in_progress scan" SD-TEST-exclusion window on the FIRST eq-form
-        // status/in_progress match in this file's source — and this quick_fixes UPDATE
-        // (id-scoped; the table has no sd_key column) is outside that guarded
-        // strategic_directives_v2 QA class.
-        await supabase.from('quick_fixes').update({ status: 'open' })
-          .eq('id', releasedSd).filter('status', 'eq', 'in_progress')
-          .is('claiming_session_id', null).is('pr_url', null).is('commit_sha', null);
-      } else {
-        // 2b. SD supplement: phase-boundary reset, parity with the dead-session release loop.
-        try { await resetSdPhaseOnRelease(releasedSd, 'CLAIM_BOUNDARY_PROBE'); } catch { /* best-effort */ }
+      // 2. Work-item supplement. release_sd clears claiming_session_id but leaves a QF at
+      // status='in_progress', which the checkin open-QF picker (status='open') cannot see;
+      // an SD is left mid-phase. Hand the item back so a picker can reach it again.
+      //
+      // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 2: this WAS the only
+      // implementation of that reset in the codebase — the "exactly ONE release path" the SD
+      // names. It now delegates to the shared lib/fleet/release-work-item.mjs helper, which
+      // owns the QF column predicate and the SD phase-boundary rewind for all sixteen sites.
+      //
+      // DELIBERATELY NOT BEHIND LEO_RELEASE_WORKITEM_RESET. That flag gates ADDING the reset
+      // to the fifteen paths that never had it. This site ALREADY HAS the behaviour, so
+      // gating it would mean the default-OFF flag SILENTLY DISABLES live fleet protection —
+      // a refactor that turns a working guard off is not a refactor.
+      const { releaseWorkItemOnSessionEnd } = await import('../lib/fleet/release-work-item.mjs');
+      const handback = await releaseWorkItemOnSessionEnd(
+        supabase, releasedSd, 'CLAIM_BOUNDARY_PROBE', { onLog: (m) => console.log('  ' + m) });
+      if (!handback.ok) {
+        warnings.push('CLAIM_BOUNDARY_PROBE: work-item handback failed for ' + releasedSd + ' — ' + handback.detail);
       }
 
       // 3. Quarantine (QF-193 provenance convention). Read-modify-write on FRESH

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -1266,6 +1266,21 @@ async function selfHealStaleClaim(sb, sessionId, sdKey) {
       .eq('sd_key', sdKey)
       .eq('claiming_session_id', sessionId); // CAS: only while the SD is still ours
   } catch { /* fail-open */ }
+  // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 5, behind
+  // LEO_RELEASE_WORKITEM_RESET (default OFF). A genuine hand-back: this session is abandoning
+  // a stale pointer, so the item belongs back in the pool.
+  // sdKey here CAN be a quick-fix — self_claimed_qf writes a QF id into claude_sessions.sd_key
+  // — and the QF is exactly the case that needs it: the SDv2 update above no-ops for a QF (no
+  // such row), so without this the QF stays at status='in_progress' with no claimant, invisible
+  // to the very open-QF picker this check-in is about to run. Fail-open, matching both clears
+  // above: a failed hand-back must never block self-claim.
+  try {
+    const { releaseWorkItemOnSessionEnd, isReleaseWorkItemResetEnabled } =
+      await import('../lib/fleet/release-work-item.mjs');
+    if (isReleaseWorkItemResetEnabled()) {
+      await releaseWorkItemOnSessionEnd(sb, sdKey, 'checkin_self_heal_stale_claim');
+    }
+  } catch { /* fail-open */ }
 }
 
 /**

--- a/server/routes/fleet-actions.js
+++ b/server/routes/fleet-actions.js
@@ -21,6 +21,8 @@ import {
   assertRoleCallsignCompatible,
 } from '../../lib/fleet/role-startup-prompt.js';
 import fleetIdentityPool from '../../scripts/assign-fleet-identities.cjs';
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-4 — the SAME decision the panel renders.
+import { decideSingletonSpawn, isSingletonRole } from '../../lib/fleet/singleton-spawn-decision.mjs';
 
 // QF-20260726-607: reuse the coordinator cron's pool + picker rather than inventing a second
 // naming path. assign-fleet-identities.cjs:119-122 states outright that nextAvailable was hoisted
@@ -115,6 +117,62 @@ export async function mintCallsign(supabase) {
  * failed. An explicitly supplied callsign is still honoured for the manifest/canary callers that
  * legitimately name their slots; only the requirement is dropped.
  */
+/**
+ * Holder identity from the CANONICAL resolvers — the same ones registration uses, so the route
+ * and registration can never disagree about WHO holds the role. Injectable purely so the verdict
+ * logic is testable without standing up three CJS identity modules.
+ */
+async function defaultResolveHolderId(supabase, role) {
+  if (role === 'adam') {
+    const { getActiveAdamId } = await import('../../lib/coordinator/adam-identity.cjs');
+    return getActiveAdamId(supabase, {});
+  }
+  if (role === 'solomon') {
+    const { getActiveSolomonId } = await import('../../lib/coordinator/solomon-identity.cjs');
+    return getActiveSolomonId(supabase, {});
+  }
+  // coordinator: resolved for LABELLING only — it is never refused.
+  const { getActiveCoordinatorId } = await import('../../lib/coordinator/resolve.cjs');
+  return getActiveCoordinatorId(supabase);
+}
+
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-4.
+ * Resolve the live holder of a singleton role and decide whether a spawn may proceed.
+ * Exported for tests. NEVER throws: an unresolvable holder must not manufacture a refusal —
+ * spawn()'s own dedup remains the backstop and answers honestly.
+ */
+export async function resolveSingletonSpawnVerdict(supabase, role, deps = {}) {
+  const { decide = decideSingletonSpawn, resolveHolderId = defaultResolveHolderId } = deps;
+  try {
+    if (!isSingletonRole(role)) return decide({ role, holder: null });
+
+    const holderId = await resolveHolderId(supabase, role);
+    if (!holderId) return decide({ role, holder: null });
+
+    // Freshness is computed against the GUARD's window, not the panel's (see the call site).
+    const { data: row } = await supabase
+      .from('claude_sessions')
+      .select('session_id, heartbeat_at, metadata')
+      .eq('session_id', holderId)
+      .maybeSingle();
+    if (!row) return decide({ role, holder: null });
+
+    const hb = row.heartbeat_at ? Date.parse(row.heartbeat_at) : NaN;
+    return decide({
+      role,
+      holder: {
+        session_id: row.session_id,
+        identity_kind: (row.metadata && row.metadata.role) || role,
+        heartbeat_age_ms: Number.isFinite(hb) ? Date.now() - hb : Infinity,
+      },
+    });
+  } catch {
+    // Fail-open: never invent a refusal from a resolver failure.
+    return decideSingletonSpawn({ role, holder: null });
+  }
+}
+
 export async function addSession(req, res) {
   const supabase = resolveServiceClient(req);
   const { role, callsign, accountProfile } = req.body || {};
@@ -129,6 +187,27 @@ export async function addSession(req, res) {
   // fleet_desired_slots, not from an operator.
   if (!isSpawnableRole(role)) {
     res.status(400).json({ ok: false, reason: `role must be one of ${SPAWNABLE_ROLES.join(', ')}` });
+    return;
+  }
+
+  // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-4 — SINGLETON REFUSAL AT THE ROUTE.
+  //
+  // SERVER FIRST, deliberately. A UI-only gate is the failure this SD records as having already
+  // happened on this page (`role` written as FLEET_WORKER_ROLE with zero readers: the UI reported
+  // success while the session came up on the worker path). The panel calls the SAME
+  // decideSingletonSpawn and only renders what this route would answer.
+  //
+  // Holder IDENTITY comes from the canonical resolvers registration itself uses, so the route and
+  // registration can never disagree about WHO holds the role. Only the freshness arithmetic is
+  // local, and that is the point: it uses the GUARD's 600s window, not the panel's 3600s. Gating
+  // on the panel's would block for up to fifty minutes during which the spawn would have SUCCEEDED.
+  //
+  // Coordinator is never refused — silent takeover is designed, and refusing it breaks succession.
+  // Fail-open: if the holder cannot be resolved we do NOT invent a refusal; spawn()'s own dedup
+  // still answers honestly with skipped:already_live.
+  const singletonVerdict = await resolveSingletonSpawnVerdict(supabase, role);
+  if (!singletonVerdict.allowed) {
+    res.status(singletonVerdict.httpStatus).json({ ok: false, reason: singletonVerdict.reason });
     return;
   }
 

--- a/tests/unit/fleet/addsession-singleton-refusal.test.js
+++ b/tests/unit/fleet/addsession-singleton-refusal.test.js
@@ -1,0 +1,50 @@
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-4 — route-level singleton refusal.
+
+import { describe, it, expect, vi } from 'vitest';
+import { resolveSingletonSpawnVerdict } from '../../../server/routes/fleet-actions.js';
+
+function sbWith(row) {
+  return {
+    from: vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq: vi.fn(() => ({ maybeSingle: vi.fn().mockResolvedValue({ data: row, error: null }) })),
+      })),
+    })),
+  };
+}
+
+describe('FR4-ROUTE: the refusal is computed by the SHARED decision, not re-derived', () => {
+  it('a non-singleton role is allowed without touching any resolver', async () => {
+    const decide = vi.fn(() => ({ allowed: true, httpStatus: 200, reason: null }));
+    const v = await resolveSingletonSpawnVerdict(sbWith(null), 'worker', { decide });
+    expect(v.allowed).toBe(true);
+    expect(decide).toHaveBeenCalledWith({ role: 'worker', holder: null });
+  });
+
+  it('passes the holder to the shared decision with a GUARD-window age', async () => {
+    // The route contributes identity + freshness; the VERDICT is the shared function's.
+    const decide = vi.fn(() => ({ allowed: false, httpStatus: 400, reason: 'stub' }));
+    const row = { session_id: 'holder-1', heartbeat_at: new Date().toISOString(), metadata: { role: 'adam' } };
+    await resolveSingletonSpawnVerdict(sbWith(row), 'adam', { decide, resolveHolderId: async () => 'holder-1' });
+    const arg = decide.mock.calls[0][0];
+    expect(arg.role).toBe('adam');
+    expect(arg.holder.session_id).toBe('holder-1');
+    expect(arg.holder.identity_kind).toBe('adam');
+    expect(arg.holder.heartbeat_age_ms).toBeLessThan(10_000);
+  });
+
+  it('treats a holder row that cannot be read as NO holder rather than inventing a refusal', async () => {
+    const decide = vi.fn(() => ({ allowed: true, httpStatus: 200, reason: null }));
+    await resolveSingletonSpawnVerdict(sbWith(null), 'adam', { decide, resolveHolderId: async () => 'holder-1' });
+    expect(decide).toHaveBeenCalledWith({ role: 'adam', holder: null });
+  });
+
+  it('FAILS OPEN — a throwing resolver never manufactures a 400', async () => {
+    // spawn()'s own dedup is the backstop and answers honestly (skipped:already_live). A route
+    // that refused on its own infrastructure failure would block legitimate spawns.
+    const exploding = { from: () => { throw new Error('db down'); } };
+    const v = await resolveSingletonSpawnVerdict(exploding, 'adam', { resolveHolderId: async () => { throw new Error('resolver down'); } });
+    expect(v.allowed).toBe(true);
+    expect(v.httpStatus).toBe(200);
+  });
+});

--- a/tests/unit/fleet/console-reaper-task-registration.test.js
+++ b/tests/unit/fleet/console-reaper-task-registration.test.js
@@ -33,9 +33,14 @@ describe('FR5-TASK: the reaper must never be registered interactively', () => {
 
   it('REFUSES to build a command pointing at a MISSING runner', () => {
     // Registering a task whose target does not exist succeeds, then fails silently every
-    // interval — the accepted-but-unread shape this SD has now hit five times.
-    expect(() => buildReaperSchtasksArgs({ requireRunner: true }))
+    // interval — the accepted-but-unread shape this SD has now hit five times. The path is
+    // injected so this asserts the GUARD, not the incidental presence of a sibling file.
+    expect(() => buildReaperSchtasksArgs({ requireRunner: true, runnerPath: 'C:/nope/missing-runner.mjs' }))
       .toThrow(/runner not found/);
+  });
+
+  it('ACCEPTS the real runner, which now exists — the gate releases', () => {
+    expect(() => buildReaperSchtasksArgs({ requireRunner: true })).not.toThrow();
   });
 
   it('maps run-as to the principal spec the shared validator understands', () => {

--- a/tests/unit/fleet/console-reaper-task-registration.test.js
+++ b/tests/unit/fleet/console-reaper-task-registration.test.js
@@ -1,0 +1,67 @@
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-5 — reaper scheduled-task registration.
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildReaperSchtasksArgs,
+  principalSpecFor,
+  TASK_NAME,
+} from '../../../scripts/setup-console-reaper-task.mjs';
+
+describe('FR5-TASK: the reaper must never be registered interactively', () => {
+  it('REFUSES --interactive at CONSTRUCTION, not merely in docs', () => {
+    // The guard sits where the command is BUILT. Emitting argv and trusting the caller not to
+    // run it would leave the unsafe command one copy-paste away.
+    expect(() => buildReaperSchtasksArgs({ interactive: true }))
+      .toThrow(/leaks a console per run/);
+  });
+
+  it('NEVER emits /IT — that flag IS the leak mechanism', () => {
+    const args = buildReaperSchtasksArgs({ requireRunner: false });
+    expect(args).not.toContain('/IT');
+  });
+
+  it('refuses a named interactive user, because that is not a session-0 principal', () => {
+    expect(() => buildReaperSchtasksArgs({ runAs: 'rickf' }))
+      .toThrow(/not a recognised session-0 logon type/);
+  });
+
+  it('accepts the session-0 accounts', () => {
+    for (const acct of ['SYSTEM', 'NT AUTHORITY\\SYSTEM', 'LocalService', 'NetworkService']) {
+      expect(() => buildReaperSchtasksArgs({ runAs: acct, requireRunner: false })).not.toThrow();
+    }
+  });
+
+  it('REFUSES to build a command pointing at a MISSING runner', () => {
+    // Registering a task whose target does not exist succeeds, then fails silently every
+    // interval — the accepted-but-unread shape this SD has now hit five times.
+    expect(() => buildReaperSchtasksArgs({ requireRunner: true }))
+      .toThrow(/runner not found/);
+  });
+
+  it('maps run-as to the principal spec the shared validator understands', () => {
+    expect(principalSpecFor('SYSTEM').logonType).toBe('ServiceAccount');
+    expect(principalSpecFor('rickf').logonType).toBe('Password');
+    expect(principalSpecFor('SYSTEM', { interactive: true }).logonType).toBe('Interactive');
+  });
+});
+
+describe('FR5-TASK: argv shape', () => {
+  it('defaults to SYSTEM at HIGHEST run level and is idempotent (/F)', () => {
+    const args = buildReaperSchtasksArgs({ requireRunner: false });
+    expect(args).toEqual(expect.arrayContaining(['/RU', 'SYSTEM', '/RL', 'HIGHEST', '/F']));
+    expect(args).toEqual(expect.arrayContaining(['/TN', TASK_NAME]));
+  });
+
+  it('schedules on a MINUTE interval', () => {
+    const args = buildReaperSchtasksArgs({ intervalMinutes: 15, requireRunner: false });
+    const i = args.indexOf('/MO');
+    expect(args[i - 1]).toBe('MINUTE');
+    expect(args[i + 1]).toBe('15');
+  });
+
+  it('rejects a nonsense interval rather than registering a task that never fires sanely', () => {
+    for (const bad of [0, -1, 1440, 2.5, 'soon']) {
+      expect(() => buildReaperSchtasksArgs({ intervalMinutes: bad, requireRunner: false })).toThrow(/interval-minutes/);
+    }
+  });
+});

--- a/tests/unit/fleet/fleet-kill-cli.test.js
+++ b/tests/unit/fleet/fleet-kill-cli.test.js
@@ -1,0 +1,30 @@
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-2 — CLI adapter.
+// The orchestration is tested in lib/fleet/graceful-kill.test.js; these cover the ADAPTER,
+// where a wrong mapping would silently change what the operator is told.
+
+import { describe, it, expect } from 'vitest';
+import { claudeProbeToTriState } from '../../../scripts/fleet-kill.mjs';
+
+describe('FR2-CLI: pidIsClaude is TRI-STATE and must not be flattened', () => {
+  it('MATCH means the pid IS the agent', () => {
+    expect(claudeProbeToTriState('MATCH')).toBe(true);
+  });
+
+  it('NO_MATCH means the pid is NOT the agent — the shell-wrapper case', () => {
+    expect(claudeProbeToTriState('NO_MATCH')).toBe(false);
+  });
+
+  it('PROBE_FAILED IS NOT false — a broken probe is not a wrong-process diagnosis', () => {
+    // Both end in a refusal, but they are different FACTS and produce different messages:
+    // false says "this is the shell wrapper claude_sessions.pid falls back to"; undefined says
+    // "the probe broke and told us nothing". claimant-liveness's own docblock is explicit that
+    // PROBE_FAILED is NOT death, so flattening it would report a diagnosis we never made.
+    expect(claudeProbeToTriState('PROBE_FAILED')).toBeUndefined();
+  });
+
+  it('an unrecognised probe result is treated as unverifiable, never as a pass', () => {
+    expect(claudeProbeToTriState(undefined)).toBeUndefined();
+    expect(claudeProbeToTriState('')).toBeUndefined();
+    expect(claudeProbeToTriState(true)).toBeUndefined();
+  });
+});

--- a/tests/unit/fleet/fleet-panel-no-ui-only-gate.test.js
+++ b/tests/unit/fleet/fleet-panel-no-ui-only-gate.test.js
@@ -1,0 +1,66 @@
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-4 — "the button and the route agree".
+ *
+ * WHAT THE SD ASSUMED VS WHAT IS THERE. FR-4 says to "generalise the existing
+ * deriveCoordinatorState into deriveRoleState and pendingCoordinatorSessionId into pendingByRole".
+ * NEITHER SYMBOL EXISTS ANYWHERE IN THIS REPO — verified by a repo-wide grep. The fleet panel is a
+ * minimal prompt()-based form with NO role-aware button state at all. Generalising them would have
+ * meant inventing the UI the SD assumed, against buttons that do not exist. (Same class as the
+ * SD's spawn-control line numbers, which were stale by +25 and pointed at the wrong verb.)
+ *
+ * SO THE INVARIANT HOLDS TODAY BY CONSTRUCTION, and that is worth LOCKING rather than rebuilding:
+ *   - there is NO client-side role gate, so no UI-only enforcement can exist; the route is the
+ *     only enforcement, which is the direction FR-4 demands;
+ *   - the panel renders the route's `reason` VERBATIM, so the 400 the addSession route now returns
+ *     actually reaches the operator.
+ *
+ * These tests fail loudly if someone later adds a client-side role gate without a matching route
+ * refusal — which is precisely the regression that already happened once on this page
+ * (FLEET_WORKER_ROLE with zero readers: the UI reported success while the session came up wrong).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const PANEL = readFileSync(path.resolve(HERE, '../../../server/public/fleet-ui/fleet-panel.js'), 'utf8');
+
+describe('FR4-UI: the route reason reaches the operator', () => {
+  it('extracts payload.reason from a non-ok response', () => {
+    expect(PANEL).toMatch(/payload\.message\s*\|\|\s*payload\.reason/);
+  });
+
+  it('renders the failure text rather than a generic message', () => {
+    // A generic "action failed" would swallow the named holder the route puts in `reason`,
+    // which is the whole point of refusing WITH a reason.
+    expect(PANEL).toMatch(/Action failed: \$\{err\.message\}/);
+  });
+});
+
+describe('FR4-UI: there is NO client-side role gate — the route is the only enforcement', () => {
+  it('the panel does not disable buttons by ROLE', () => {
+    // The only `disabled` writes are the generic in-flight toggle, which is restored in a
+    // finally block. If a role-keyed disable appears here without a matching route refusal,
+    // this SD regresses to the exact failure it documents.
+    const disables = PANEL.match(/\.disabled\s*=\s*[^;]+/g) || [];
+    expect(disables.length).toBeGreaterThan(0);
+    for (const d of disables) {
+      expect(d).toMatch(/\.disabled\s*=\s*(true|false)\b/);
+    }
+  });
+
+  it('does not re-derive singleton/role state client-side', () => {
+    // Any of these appearing client-side means the button is deciding for itself instead of
+    // rendering what the route would answer.
+    for (const forbidden of ['isSingletonRole', 'decideSingletonSpawn', 'getActiveAdamId', 'getActiveSolomonId']) {
+      expect(PANEL).not.toContain(forbidden);
+    }
+  });
+
+  it('the SD-named symbols genuinely do not exist, so nothing was "generalised" away', () => {
+    expect(PANEL).not.toContain('deriveCoordinatorState');
+    expect(PANEL).not.toContain('pendingCoordinatorSessionId');
+  });
+});

--- a/tests/unit/fleet/run-console-reaper.test.js
+++ b/tests/unit/fleet/run-console-reaper.test.js
@@ -1,0 +1,125 @@
+// SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-5 — the reaper runner.
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runReaperOnce,
+  parseProcessCsv,
+  descendantCountOf,
+  findConsoles,
+  parentageFor,
+  isConsoleReaperEnabled,
+} from '../../../scripts/run-console-reaper.mjs';
+
+const ON = { FLEET_CONSOLE_REAPER_ENABLED: 'on' };
+
+// pid 100 = empty console; pid 200 = occupied console (child 201).
+const PROCS = [
+  { pid: 10, ppid: 1, name: 'Cursor.exe', cmd: 'cursor' },
+  { pid: 20, ppid: 10, name: 'powershell.exe', cmd: 'powershell -c ...' },
+  { pid: 100, ppid: 20, name: 'OpenConsole.exe', cmd: 'openconsole' },
+  { pid: 200, ppid: 20, name: 'OpenConsole.exe', cmd: 'openconsole' },
+  { pid: 201, ppid: 200, name: 'claude.exe', cmd: 'claude' },
+];
+const okSnap = async () => ({ ok: true, processes: PROCS, error: null });
+
+describe('FR5-RUN: the flag is opt-in', () => {
+  it('does nothing unless FLEET_CONSOLE_REAPER_ENABLED is exactly "on"', async () => {
+    expect(isConsoleReaperEnabled({})).toBe(false);
+    expect(isConsoleReaperEnabled({ FLEET_CONSOLE_REAPER_ENABLED: 'true' })).toBe(false);
+    const r = await runReaperOnce({ env: {}, snapshot: okSnap, kill: vi.fn() });
+    expect(r.ran).toBe(false);
+  });
+});
+
+describe('FR5-RUN: FAIL-CLOSED — "could not look" never becomes "nothing to see"', () => {
+  it('a failed snapshot reaps NOTHING', async () => {
+    // This is the FR-5a defect in runner form: degrading to "zero consoles" would let the
+    // reaper reason about a process table it never observed.
+    const kill = vi.fn();
+    const r = await runReaperOnce({
+      env: ON,
+      snapshot: async () => ({ ok: false, processes: null, error: { code: 'GUARD_UNAVAILABLE', timedOut: true, message: 'timeout' } }),
+      kill,
+    });
+    expect(r.ran).toBe(false);
+    expect(r.reason).toBe('GUARD_UNAVAILABLE');
+    expect(kill).not.toHaveBeenCalled();
+  });
+
+  it('refuses the kill when the PRE-KILL re-check cannot observe', async () => {
+    const kill = vi.fn();
+    let n = 0;
+    const snapshot = async () => (n++ === 0
+      ? { ok: true, processes: PROCS, error: null }
+      : { ok: false, processes: null, error: { code: 'GUARD_UNAVAILABLE', timedOut: false, message: 'wmi down' } });
+    const r = await runReaperOnce({ env: ON, snapshot, kill });
+    expect(kill).not.toHaveBeenCalled();
+    expect(r.spared[0].why).toMatch(/not actually observed/);
+  });
+});
+
+describe('FR5-RUN: only zero-descendant consoles, re-checked immediately before the kill', () => {
+  it('kills the empty console and spares the occupied one', async () => {
+    const kill = vi.fn(async () => {});
+    const r = await runReaperOnce({ env: ON, snapshot: okSnap, kill });
+    expect(r.killed).toEqual([100]);
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(kill).toHaveBeenCalledWith(100);
+  });
+
+  it('spares a console that GAINED a child between the scan and the kill', async () => {
+    const kill = vi.fn(async () => {});
+    let n = 0;
+    const snapshot = async () => {
+      n += 1;
+      if (n === 1) return { ok: true, processes: PROCS, error: null };
+      return { ok: true, processes: [...PROCS, { pid: 101, ppid: 100, name: 'claude.exe', cmd: 'c' }], error: null };
+    };
+    const r = await runReaperOnce({ env: ON, snapshot, kill });
+    expect(kill).not.toHaveBeenCalled();
+    expect(r.killed).toEqual([]);
+  });
+
+  it('--dry-run reports candidates and kills nothing', async () => {
+    const kill = vi.fn();
+    const r = await runReaperOnce({ env: ON, snapshot: okSnap, kill, dryRun: true });
+    expect(r.dryRun).toBe(true);
+    expect(r.candidates).toBe(1);
+    expect(kill).not.toHaveBeenCalled();
+  });
+});
+
+describe('FR5-RUN: parentage is captured for EVERY console, not only the reaped ones', () => {
+  it('attributes both consoles, including the occupied one', async () => {
+    const r = await runReaperOnce({ env: ON, snapshot: okSnap, kill: vi.fn(async () => {}) });
+    expect(r.parentage).toHaveLength(2);
+    expect(r.parentage.every((p) => p.ok)).toBe(true);
+  });
+
+  it('names the GRANDPARENT, which is what identifies the culprit', () => {
+    // The immediate parent is powershell; Cursor.exe is the informative one.
+    const rec = parentageFor(PROCS[2], PROCS, '2026-07-27T00:00:00Z');
+    expect(rec.record.parent_image).toBe('powershell.exe');
+    expect(rec.record.grandparent_image).toBe('Cursor.exe');
+    expect(rec.record.attribution).toBe('powershell.exe (via Cursor.exe)');
+  });
+});
+
+describe('FR5-RUN: CSV parsing', () => {
+  it('parses quoted command lines containing commas', () => {
+    const csv = '"ProcessId","ParentProcessId","Name","CommandLine"\n"12","3","a.exe","x.exe -a 1,2 -b ""q"""';
+    const rows = parseProcessCsv(csv);
+    expect(rows).toEqual([{ pid: 12, ppid: 3, name: 'a.exe', cmd: 'x.exe -a 1,2 -b "q"' }]);
+  });
+
+  it('a header-only result is zero processes, not a crash', () => {
+    expect(parseProcessCsv('"ProcessId","ParentProcessId","Name","CommandLine"')).toEqual([]);
+    expect(parseProcessCsv('')).toEqual([]);
+  });
+
+  it('counts direct children and finds consoles case-insensitively', () => {
+    expect(descendantCountOf(200, PROCS)).toBe(1);
+    expect(descendantCountOf(100, PROCS)).toBe(0);
+    expect(findConsoles(PROCS).map((c) => c.pid)).toEqual([100, 200]);
+  });
+});

--- a/tests/unit/fleet/run-console-reaper.test.js
+++ b/tests/unit/fleet/run-console-reaper.test.js
@@ -1,6 +1,6 @@
 // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-5 — the reaper runner.
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   runReaperOnce,
   parseProcessCsv,
@@ -22,11 +22,18 @@ const PROCS = [
 ];
 const okSnap = async () => ({ ok: true, processes: PROCS, error: null });
 
+// Persistence is ALWAYS injected here. Without it the default writer appends to the REAL
+// .claude/console-parentage.jsonl — a unit test writing fixture data into the repo, which is
+// how an empty log file ended up staged in the first place. Captured so it can be asserted.
+let persistedCalls;
+const noPersist = (records) => { persistedCalls.push(records); return { written: records.length, skipped: 0, error: null }; };
+beforeEach(() => { persistedCalls = []; });
+
 describe('FR5-RUN: the flag is opt-in', () => {
   it('does nothing unless FLEET_CONSOLE_REAPER_ENABLED is exactly "on"', async () => {
     expect(isConsoleReaperEnabled({})).toBe(false);
     expect(isConsoleReaperEnabled({ FLEET_CONSOLE_REAPER_ENABLED: 'true' })).toBe(false);
-    const r = await runReaperOnce({ env: {}, snapshot: okSnap, kill: vi.fn() });
+    const r = await runReaperOnce({ env: {}, snapshot: okSnap, kill: vi.fn(), persistParentage: noPersist });
     expect(r.ran).toBe(false);
   });
 });
@@ -39,7 +46,7 @@ describe('FR5-RUN: FAIL-CLOSED — "could not look" never becomes "nothing to se
     const r = await runReaperOnce({
       env: ON,
       snapshot: async () => ({ ok: false, processes: null, error: { code: 'GUARD_UNAVAILABLE', timedOut: true, message: 'timeout' } }),
-      kill,
+      kill, persistParentage: noPersist,
     });
     expect(r.ran).toBe(false);
     expect(r.reason).toBe('GUARD_UNAVAILABLE');
@@ -52,7 +59,7 @@ describe('FR5-RUN: FAIL-CLOSED — "could not look" never becomes "nothing to se
     const snapshot = async () => (n++ === 0
       ? { ok: true, processes: PROCS, error: null }
       : { ok: false, processes: null, error: { code: 'GUARD_UNAVAILABLE', timedOut: false, message: 'wmi down' } });
-    const r = await runReaperOnce({ env: ON, snapshot, kill });
+    const r = await runReaperOnce({ env: ON, snapshot, kill, persistParentage: noPersist });
     expect(kill).not.toHaveBeenCalled();
     expect(r.spared[0].why).toMatch(/not actually observed/);
   });
@@ -61,7 +68,7 @@ describe('FR5-RUN: FAIL-CLOSED — "could not look" never becomes "nothing to se
 describe('FR5-RUN: only zero-descendant consoles, re-checked immediately before the kill', () => {
   it('kills the empty console and spares the occupied one', async () => {
     const kill = vi.fn(async () => {});
-    const r = await runReaperOnce({ env: ON, snapshot: okSnap, kill });
+    const r = await runReaperOnce({ env: ON, snapshot: okSnap, kill, persistParentage: noPersist });
     expect(r.killed).toEqual([100]);
     expect(kill).toHaveBeenCalledTimes(1);
     expect(kill).toHaveBeenCalledWith(100);
@@ -75,14 +82,14 @@ describe('FR5-RUN: only zero-descendant consoles, re-checked immediately before 
       if (n === 1) return { ok: true, processes: PROCS, error: null };
       return { ok: true, processes: [...PROCS, { pid: 101, ppid: 100, name: 'claude.exe', cmd: 'c' }], error: null };
     };
-    const r = await runReaperOnce({ env: ON, snapshot, kill });
+    const r = await runReaperOnce({ env: ON, snapshot, kill, persistParentage: noPersist });
     expect(kill).not.toHaveBeenCalled();
     expect(r.killed).toEqual([]);
   });
 
   it('--dry-run reports candidates and kills nothing', async () => {
     const kill = vi.fn();
-    const r = await runReaperOnce({ env: ON, snapshot: okSnap, kill, dryRun: true });
+    const r = await runReaperOnce({ env: ON, snapshot: okSnap, kill, dryRun: true, persistParentage: noPersist });
     expect(r.dryRun).toBe(true);
     expect(r.candidates).toBe(1);
     expect(kill).not.toHaveBeenCalled();
@@ -91,7 +98,7 @@ describe('FR5-RUN: only zero-descendant consoles, re-checked immediately before 
 
 describe('FR5-RUN: parentage is captured for EVERY console, not only the reaped ones', () => {
   it('attributes both consoles, including the occupied one', async () => {
-    const r = await runReaperOnce({ env: ON, snapshot: okSnap, kill: vi.fn(async () => {}) });
+    const r = await runReaperOnce({ env: ON, snapshot: okSnap, kill: vi.fn(async () => {}), persistParentage: noPersist });
     expect(r.parentage).toHaveLength(2);
     expect(r.parentage.every((p) => p.ok)).toBe(true);
   });
@@ -121,5 +128,18 @@ describe('FR5-RUN: CSV parsing', () => {
     expect(descendantCountOf(200, PROCS)).toBe(1);
     expect(descendantCountOf(100, PROCS)).toBe(0);
     expect(findConsoles(PROCS).map((c) => c.pid)).toEqual([100, 200]);
+  });
+});
+
+describe('FR5-RUN: parentage is PERSISTED before any kill', () => {
+  it('hands every observed console to the persister', async () => {
+    await runReaperOnce({ env: ON, snapshot: okSnap, kill: vi.fn(async () => {}), persistParentage: noPersist });
+    expect(persistedCalls).toHaveLength(1);
+    expect(persistedCalls[0]).toHaveLength(2); // both consoles, occupied one included
+  });
+
+  it('persists even on a dry run — attribution is the point, not the reap', async () => {
+    await runReaperOnce({ env: ON, snapshot: okSnap, kill: vi.fn(), dryRun: true, persistParentage: noPersist });
+    expect(persistedCalls).toHaveLength(1);
   });
 });

--- a/tests/unit/fleet/spawn-resume-threading.test.js
+++ b/tests/unit/fleet/spawn-resume-threading.test.js
@@ -1,0 +1,64 @@
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-3 — resume threading through the choke point.
+ *
+ * Static source assertions. spawn() launches a detached process and writes claude_sessions, so
+ * executing it in a unit test would either mock away the very wiring under test or touch the DB.
+ * The invariants here are about WHAT IS PASSED, which the source states exactly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SOURCE = readFileSync(path.resolve(HERE, '../../../lib/fleet/spawn-control.js'), 'utf8');
+
+describe('FR3-THREAD: resumeUuid reaches the launch builder', () => {
+  it('spawn() FORWARDS resumeUuid — it was accepted by the builder but never passed', () => {
+    // buildLiveSpawnInvocation has always accepted resumeUuid. spawn() did not forward it, so a
+    // caller could set opts.resumeUuid and have it silently ignored: the launch came up cold
+    // while every signature looked correct.
+    const call = SOURCE.match(/buildLiveSpawnInvocation\(\{[\s\S]{0,320}?\}, opts\)/);
+    expect(call, 'buildLiveSpawnInvocation call not found').toBeTruthy();
+    expect(call[0]).toMatch(/resumeUuid:\s*opts\.resumeUuid/);
+  });
+
+  it('spawn() also forwards sessionId, so a FORK can carry a fresh identity', () => {
+    const call = SOURCE.match(/buildLiveSpawnInvocation\(\{[\s\S]{0,320}?\}, opts\)/);
+    expect(call[0]).toMatch(/sessionId:\s*opts\.sessionId/);
+  });
+});
+
+describe('FR3-CWD: the replacement resumes where the OLD seat lived', () => {
+  it('spawnReplacement reads launch_cwd off the OLD session, not this process cwd', () => {
+    const fn = SOURCE.slice(SOURCE.indexOf('async function spawnReplacement'));
+    expect(fn).toMatch(/oldSession\.metadata\.launch_cwd/);
+    expect(fn).toMatch(/cwd:\s*launchCwd/);
+  });
+
+  it('spawnReplacement threads resumeUuid through rather than dropping it', () => {
+    const fn = SOURCE.slice(SOURCE.indexOf('async function spawnReplacement'));
+    expect(fn).toMatch(/resumeUuid:\s*opts\.resumeUuid/);
+  });
+
+  it('spawn() PERSISTS launch_cwd, so the read above has something to find', () => {
+    // Threading without persisting would leave the read permanently undefined — wiring that
+    // looks complete and does nothing.
+    expect(SOURCE).toMatch(/launch_cwd:\s*invocation\.cwd/);
+  });
+
+  it('launch_cwd is stamped from the INVOCATION, never process.cwd()', () => {
+    const stamp = SOURCE.match(/launch_cwd:[^\n,}]*/)[0];
+    expect(stamp).not.toMatch(/process\.cwd/);
+  });
+});
+
+describe('FR3-TOKEN: metadata.resume_uuid is not the token', () => {
+  it('spawn-control never reads metadata.resume_uuid', () => {
+    // Populated on 1 of 13,025 rows. Comments are stripped first so the guard tests CODE, not
+    // the rationale that explains why the field must not be read.
+    const code = SOURCE.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+    expect(code).not.toMatch(/metadata\s*[.[]\s*['"]?resume_uuid/);
+  });
+});

--- a/tests/unit/fleet/spawn-resume-threading.test.js
+++ b/tests/unit/fleet/spawn-resume-threading.test.js
@@ -1,64 +1,75 @@
 /**
- * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-3 — resume threading through the choke point.
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-3 — resume threading, asserted BEHAVIOURALLY.
  *
- * Static source assertions. spawn() launches a detached process and writes claude_sessions, so
- * executing it in a unit test would either mock away the very wiring under test or touch the DB.
- * The invariants here are about WHAT IS PASSED, which the source states exactly.
+ * THIS FILE PREVIOUSLY ASSERTED SOURCE TEXT AND WAS WRONG ABOUT REALITY. It matched
+ * `sessionId: opts.sessionId` in spawn-control.js and claimed "so a FORK can carry a fresh
+ * identity". The threading was real; the FORK was not. build-session-launch.cjs treated --resume
+ * and --session-id as MUTUALLY EXCLUSIVE, so the sessionId was silently dropped and every "fork"
+ * emitted a plain --resume that reused the OLD id — precisely the case FR-3 forbids, because
+ * re-registering under the old id lets a health check pass against the dead row's warm heartbeat.
+ *
+ * The test passed the whole time. That is the accepted-but-unread class this SD documents four
+ * times about OTHER code, committed here in its own verification. Caught by the EXEC TESTING pass.
+ *
+ * The builder is PURE and INJECTABLE, so there was never a reason to substitute source-matching
+ * for execution here. Now it executes and asserts the ACTUAL EMITTED ARGV.
  */
 
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
-import { fileURLToPath } from 'node:url';
-import path from 'node:path';
+import { buildLiveSpawnInvocation } from '../../../lib/fleet/spawn-control.js';
 
-const HERE = path.dirname(fileURLToPath(import.meta.url));
-const SOURCE = readFileSync(path.resolve(HERE, '../../../lib/fleet/spawn-control.js'), 'utf8');
+const OLD = '11111111-1111-4111-8111-111111111111';
+const NEW = '22222222-2222-4222-8222-222222222222';
+const base = { role: 'worker', callsign: 'Alpha-1' };
 
-describe('FR3-THREAD: resumeUuid reaches the launch builder', () => {
-  it('spawn() FORWARDS resumeUuid — it was accepted by the builder but never passed', () => {
-    // buildLiveSpawnInvocation has always accepted resumeUuid. spawn() did not forward it, so a
-    // caller could set opts.resumeUuid and have it silently ignored: the launch came up cold
-    // while every signature looked correct.
-    const call = SOURCE.match(/buildLiveSpawnInvocation\(\{[\s\S]{0,320}?\}, opts\)/);
-    expect(call, 'buildLiveSpawnInvocation call not found').toBeTruthy();
-    expect(call[0]).toMatch(/resumeUuid:\s*opts\.resumeUuid/);
+/** Index of a flag's value in argv. */
+const valueAfter = (args, flag) => args[args.indexOf(flag) + 1];
+
+describe('FR3-FORK: a fork carries BOTH the old conversation and a NEW identity', () => {
+  it('emits --fork-session, --resume <old> AND --session-id <new>', () => {
+    const { args } = buildLiveSpawnInvocation({ ...base, resumeUuid: OLD, sessionId: NEW, forkSession: true }, {});
+    expect(args).toContain('--fork-session');
+    expect(valueAfter(args, '--resume')).toBe(OLD);
+    expect(valueAfter(args, '--session-id')).toBe(NEW);
   });
 
-  it('spawn() also forwards sessionId, so a FORK can carry a fresh identity', () => {
-    const call = SOURCE.match(/buildLiveSpawnInvocation\(\{[\s\S]{0,320}?\}, opts\)/);
-    expect(call[0]).toMatch(/sessionId:\s*opts\.sessionId/);
-  });
-});
-
-describe('FR3-CWD: the replacement resumes where the OLD seat lived', () => {
-  it('spawnReplacement reads launch_cwd off the OLD session, not this process cwd', () => {
-    const fn = SOURCE.slice(SOURCE.indexOf('async function spawnReplacement'));
-    expect(fn).toMatch(/oldSession\.metadata\.launch_cwd/);
-    expect(fn).toMatch(/cwd:\s*launchCwd/);
+  it('does NOT reuse the old id as the new identity', () => {
+    // The specific defect: re-registering under the OLD id lets a health check pass against the
+    // dead row's still-warm heartbeat, so a dead seat reads as alive.
+    const inv = buildLiveSpawnInvocation({ ...base, resumeUuid: OLD, sessionId: NEW, forkSession: true }, {});
+    expect(inv.sessionId).toBe(NEW);
+    expect(inv.sessionId).not.toBe(OLD);
   });
 
-  it('spawnReplacement threads resumeUuid through rather than dropping it', () => {
-    const fn = SOURCE.slice(SOURCE.indexOf('async function spawnReplacement'));
-    expect(fn).toMatch(/resumeUuid:\s*opts\.resumeUuid/);
-  });
-
-  it('spawn() PERSISTS launch_cwd, so the read above has something to find', () => {
-    // Threading without persisting would leave the read permanently undefined — wiring that
-    // looks complete and does nothing.
-    expect(SOURCE).toMatch(/launch_cwd:\s*invocation\.cwd/);
-  });
-
-  it('launch_cwd is stamped from the INVOCATION, never process.cwd()', () => {
-    const stamp = SOURCE.match(/launch_cwd:[^\n,}]*/)[0];
-    expect(stamp).not.toMatch(/process\.cwd/);
+  it('REFUSES a fork without a valid new UUID rather than silently degrading to plain resume', () => {
+    // Silent degradation is exactly how the original defect stayed invisible.
+    expect(() => buildLiveSpawnInvocation({ ...base, resumeUuid: OLD, sessionId: 'not-a-uuid', forkSession: true }, {}))
+      .toThrow(/forkSession requires a valid UUID/);
+    expect(() => buildLiveSpawnInvocation({ ...base, resumeUuid: OLD, forkSession: true }, {}))
+      .toThrow(/forkSession requires a valid UUID/);
   });
 });
 
-describe('FR3-TOKEN: metadata.resume_uuid is not the token', () => {
-  it('spawn-control never reads metadata.resume_uuid', () => {
-    // Populated on 1 of 13,025 rows. Comments are stripped first so the guard tests CODE, not
-    // the rationale that explains why the field must not be read.
-    const code = SOURCE.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
-    expect(code).not.toMatch(/metadata\s*[.[]\s*['"]?resume_uuid/);
+describe('FR3-RESUME: plain resume is unchanged', () => {
+  it('emits --resume alone and adopts the existing id', () => {
+    const inv = buildLiveSpawnInvocation({ ...base, resumeUuid: OLD }, {});
+    expect(inv.args).not.toContain('--fork-session');
+    expect(inv.args).not.toContain('--session-id');
+    expect(inv.sessionId).toBe(OLD);
+  });
+
+  it('a cold start mints a fresh --session-id and never resumes', () => {
+    const inv = buildLiveSpawnInvocation({ ...base, sessionId: NEW }, { uuidFn: () => NEW });
+    expect(inv.args).not.toContain('--resume');
+    expect(inv.args).not.toContain('--fork-session');
+    expect(valueAfter(inv.args, '--session-id')).toBe(NEW);
+  });
+});
+
+describe('FR3-CWD: launch_cwd, asserted through the invocation', () => {
+  it('the resolved cwd is what the process will be given', () => {
+    const wt = 'C:/Users/rickf/Projects/_EHG/EHG_Engineer/.worktrees/SD-X';
+    const inv = buildLiveSpawnInvocation({ ...base, cwd: wt }, {});
+    expect(inv.cwd).toBe(wt);
   });
 });

--- a/tests/unit/scripts/stale-session-sweep-workitem-handback.test.js
+++ b/tests/unit/scripts/stale-session-sweep-workitem-handback.test.js
@@ -1,0 +1,59 @@
+/**
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-1b slice 2
+ *
+ * stale-session-sweep.cjs CLAIM_BOUNDARY_PROBE now delegates its work-item handback to the
+ * shared lib/fleet/release-work-item.mjs helper. This site WAS the "exactly ONE release path"
+ * the SD names — the only place the reset existed.
+ *
+ * Static source assertions, matching the convention already used by
+ * stale-session-sweep-claim-safety.test.js: the sweep is a large CJS script with a
+ * module-scoped supabase client, so its QA-mutation invariants are pinned against the source
+ * rather than by executing a tick.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const SOURCE_PATH = path.resolve(HERE, '../../../scripts/stale-session-sweep.cjs');
+const SOURCE = readFileSync(SOURCE_PATH, 'utf8');
+
+describe('FR-1b slice 2 — the sweep delegates its work-item handback to the shared helper', () => {
+  it('calls releaseWorkItemOnSessionEnd from the shared module', () => {
+    expect(SOURCE).toMatch(/require\(|await import\(\s*['"]\.\.\/lib\/fleet\/release-work-item\.mjs['"]\s*\)/);
+    expect(SOURCE).toMatch(/releaseWorkItemOnSessionEnd\(\s*\n?\s*supabase,\s*releasedSd,\s*['"]CLAIM_BOUNDARY_PROBE['"]/);
+  });
+
+  it('THE DUPLICATE IS GONE — no inline quick_fixes status reset remains in the sweep', () => {
+    // The whole point of FR-1 is one implementation. If an inline
+    // `quick_fixes ... update({status:'open'})` reappears here, two copies of the predicate
+    // exist again and they will drift.
+    const inlineQfReopen = /from\(\s*['"]quick_fixes['"]\s*\)\s*\.update\(\s*\{\s*status:\s*['"]open['"]/;
+    expect(SOURCE).not.toMatch(inlineQfReopen);
+  });
+
+  it('IS NOT GATED BY LEO_RELEASE_WORKITEM_RESET — the flag must never disable live protection', () => {
+    // The flag exists to gate ADDING the reset to the fifteen paths that never had it.
+    // This site already had the behaviour, so gating it would mean the default-OFF flag
+    // silently switches off fleet protection that works today.
+    // Assert the absence of GATING, not the absence of the NAME — the comment above the
+    // call deliberately explains why the flag is not applied here, so a bare string search
+    // would fail on its own rationale.
+    expect(SOURCE).not.toMatch(/isReleaseWorkItemResetEnabled\s*\(/);
+    expect(SOURCE).not.toMatch(/process\.env\.LEO_RELEASE_WORKITEM_RESET/);
+  });
+
+  it('surfaces a handback failure as a sweep warning rather than swallowing it', () => {
+    expect(SOURCE).toMatch(/work-item handback failed/);
+  });
+
+  it('the remaining resetSdPhaseOnRelease call sites are untouched by this slice', () => {
+    // Slice 2 converts ONLY the CLAIM_BOUNDARY_PROBE site. The sweep's other three
+    // phase-reset callers still route through resetSdPhaseOnRelease; converging them is a
+    // later slice, tracked in the FR-1b ledger. Pinned so the count cannot drift silently.
+    const calls = SOURCE.match(/await resetSdPhaseOnRelease\(/g) || [];
+    expect(calls).toHaveLength(3);
+  });
+});

--- a/tests/unit/scripts/stale-session-sweep-workitem-handback.test.js
+++ b/tests/unit/scripts/stale-session-sweep-workitem-handback.test.js
@@ -49,6 +49,15 @@ describe('FR-1b slice 2 — the sweep delegates its work-item handback to the sh
     expect(SOURCE).toMatch(/work-item handback failed/);
   });
 
+  it('OPTS IN to the phase rewind — the helper default preserves the phase for resume', () => {
+    // rewindPhase defaults FALSE because cold-recovery and claim-validity-gate deliberately
+    // preserve current_phase for resume. The sweep is the one site that MUST rewind (its
+    // PHASE_RESET_MAP exists so an SD is not left in mid-phase limbo with no claimer), so it
+    // has to ask explicitly. Drop this option and the sweep silently stops rewinding — in an
+    // UNFLAGGED path, so nothing would switch the behaviour back on.
+    expect(SOURCE).toMatch(/rewindPhase:\s*true/);
+  });
+
   it('the remaining resetSdPhaseOnRelease call sites are untouched by this slice', () => {
     // Slice 2 converts ONLY the CLAIM_BOUNDARY_PROBE site. The sweep's other three
     // phase-reset callers still route through resetSdPhaseOnRelease; converging them is a


### PR DESCRIPTION
## FR-5 — gate the kill primitive itself; **persist** parentage

Closes two of the gaps the EXEC TESTING sub-agent found. Both were real.

> Stacked on #6597 → #6590 → … → #6555. Supersedes the branch `…-fr5-testing-gaps`, which diverged when I amended after pushing (force-push is blocked by ENF-15, so this is the same work on a clean branch rather than a rewritten history).

### 1. The flag now gates the function that kills

`runReaperOnce` checked `FLEET_CONSOLE_REAPER_ENABLED`, but `reapEmptyConsoles` — the function that actually invokes `kill` — had **no check of its own**. The invariant held only because `runReaperOnce` is today's *only* caller.

`graceful-kill` gates **twice** (CLI + orchestrator); this gated once, one level *above* the primitive. Now gated on the primitive too, and the runner **threads its own `env` down** so the two gates agree instead of reading different `process.env` objects.

### 2. Parentage is now persisted

It was captured at scan time and returned in the result object — **which dies with the process that computed it**. The entire requirement is that the record *outlives the parent*, so capture-without-write achieved nothing and TS-16 ("attributable after the parent exits") did not hold.

Appended as JSONL to `.claude/console-parentage.jsonl`, written **before any kill**, fail-open. An append-only file rather than a table: a new table is a chairman-gated DDL, and durability + attributability is satisfied without one.

**Dedup is `pid+parent`, not `pid`** — Windows recycles pids, so keying on pid alone would silently swallow a genuinely new console under a different parent. A corrupt existing line doesn't block new writes.

### 3. And the tests were writing into the repo

The first commit here staged a 506-byte `.claude/console-parentage.jsonl`. That wasn't fixture data I added — **the test run wrote it**: `run-console-reaper.test.js` called `runReaperOnce` without overriding `persistParentage`, so the default fs writer appended fake `PROCS` fixtures to a real file in the working tree.

`persistParentage` is now always injected there, and the injected stub **captures** what it was handed — so the persistence path is asserted rather than merely bypassed. Verified by deleting the file, running the full suite, and confirming it is **not** recreated.

### One framing correction, checked against the SD rather than acted on

The agent reported `isSeatDead` as unwired because "the reaper reaps on descendant-count alone". The observation is right; the implied fix is not.

Both DEAD legs are properties of a **seat** — (A) absent from a `Win32_Process` **claude.exe** name query, (B) `last_tool_at` identical across two samples. **A console has no `last_tool_at`**, so applying `isSeatDead` to a console requires binding a console to a seat — which the SD forbids outright: *"BINDING SEATS TO WINDOWS IS IMPOSSIBLE TODAY and must not be attempted."*

Descendant-count is the correct and only permissible console test. The genuine gap is that **seat reconciliation has no caller** — recorded here, not silently wired.

### Tests

8 new (1 gate + 5 persistence + 2 persistence-invoked). `lib/fleet` + `tests/unit/fleet`: **1421 pass**; the 3 failures are the known pre-existing pair. ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
