### PR TITLE
fix(QF-20260727-794): name the Windows Terminal tab at spawn — "<n> · <callsign>", number first

### DIFF
--- a/lib/fleet/build-session-launch.cjs
+++ b/lib/fleet/build-session-launch.cjs
@@ -70,8 +70,34 @@ function resolveProfileDir(profileName, opts = {}) {
  * @param {{env?:object}} [opts]
  * @returns {{program:string, args:string[], env:object, cwd:string, persistent:boolean}}
  */
+/**
+ * QF-20260727-794 — the Windows Terminal tab title for a spawned session.
+ *
+ * Contract (chairman's amendment): "<n> · <callsign-at-spawn>", e.g. "3 · Alpha".
+ * The NUMBER LEADS because it is the anchor and can never be wrong; the name may age if the
+ * callsign is later reassigned. Degrades in the order number+name -> name -> role -> constant,
+ * so a spec with no identity still produces something better than a conversation summary.
+ *
+ * @param {{windowNumber?: number|string, callsign?: string, role?: string}} spec
+ * @returns {string} a non-empty title
+ */
+function formatTabTitle(spec = {}) {
+  const name = String(spec.callsign || spec.role || '').trim();
+  // null/undefined must read as ABSENT, not as zero: Number(null) === 0 is finite, which would
+  // have rendered an unallocated session as "0 · Alpha". Allocation is 1..N (lowest free slot
+  // among live sessions), so anything below 1 is a sentinel or a bug, never a real window.
+  const nRaw = spec.windowNumber;
+  const nNum = (nRaw === null || nRaw === undefined || String(nRaw).trim() === '') ? NaN : Number(nRaw);
+  const n = (Number.isFinite(nNum) && nNum >= 1) ? String(Math.trunc(nNum)) : null;
+  if (n && name) return `${n} · ${name}`;
+  if (n) return `${n} · session`;
+  return name || 'LEO session';
+}
+
 function buildSessionLaunch(spec = {}, opts = {}) {
   const env = opts.env || process.env;
+  // QF-20260727-794: windowNumber is read via formatTabTitle(spec) below. Named here so the
+  // accepted-input surface stays visible in one place.
   const { role, callsign, profile, profileDir: preResolved, cwd, sdToResume, resumeUuid, startupPrompt } = spec;
 
   // Profile -> CLAUDE_CONFIG_DIR. Fail LOUD on a REQUESTED-but-unresolvable profile.
@@ -121,7 +147,33 @@ function buildSessionLaunch(spec = {}, opts = {}) {
   //
   // `-w` is a GLOBAL wt option and MUST precede the `new-tab` subcommand -- `wt new-tab -w new` would
   // be parsed as an argument to new-tab, not as the window selector. Hence the position here.
-  const args = ['-w', 'new', 'new-tab', '-d', startDir, '--', claudeCmd];
+  // QF-20260727-794 — NAME THE TAB. Chairman-reported: with nine worker windows plus three role
+  // sessions open, the tab strip is the only way to find a seat, and it identified none of them
+  // (a coordinator tab read "Load and Execute Startup" — Claude Code's conversation summary).
+  //
+  // THE TITLE MUST BE SET HERE, AT SPAWN. A running session CANNOT retitle its own tab; both
+  // runtime routes were measured dead by the coordinator before this row was filed:
+  // $Host.UI.RawUI.WindowTitle reports success but retitles the tool call's own detached console,
+  // and a bash OSC escape never reaches the emulator (Claude Code pipes stdout; /dev/tty is absent).
+  //
+  // --suppressApplicationTitle IS LOAD-BEARING, NOT DECORATION. Without it Claude Code's own title
+  // updates overwrite --title within seconds and the fix looks like it did not work.
+  //
+  // VERIFIED ON THIS HOST rather than from docs (the row required it; `wt --help` renders to a GUI
+  // dialog here so the flags could not be confirmed by inspection). Windows Terminal 1.24.11911.0:
+  // a throwaway tab spawned with these flags, running a command that otherwise self-titles
+  // "Start-Sleep", showed the --title value instead — proving BOTH that --title lands and that
+  // --suppressApplicationTitle beats the application's own title.
+  //
+  // NUMBER FIRST, per the chairman's design amendment. The tab title is IMMUTABLE after spawn
+  // (see above), while a callsign is MUTABLE — assign-fleet-identities.cjs can turn 'Alpha' into
+  // 'Alpha-3'. Putting a mutable value in an immutable slot is what would have made the title age
+  // into a lie. The NUMBER is immutable by construction, so it is the anchor and can never be
+  // wrong; the name trailing it is a convenience that was true at spawn. The Sessions page — which
+  // CAN update live — carries the number->current-callsign mapping, so the volatile half lives
+  // where volatility is free. If the two ever disagree, the number wins.
+  const tabTitle = formatTabTitle(spec);
+  const args = ['-w', 'new', 'new-tab', '--title', tabTitle, '--suppressApplicationTitle', '-d', startDir, '--', claudeCmd];
 
   // SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 FR-3 — MINT THE SESSION ID SPAWNER-SIDE.
   //
@@ -388,6 +440,7 @@ function assertLaunchContract(inv, { expectProfile = false, expectResume = false
 module.exports = {
   buildSessionLaunch,
   assertLaunchContract,
+  formatTabTitle, // QF-20260727-794 — exported so the title contract is unit-testable directly
   resolveClaudeCmd,
   resolveRepoRoot,
   resolveProfileDir,

--- a/tests/unit/fleet/reboot-respawn-runner.test.js
+++ b/tests/unit/fleet/reboot-respawn-runner.test.js
@@ -41,12 +41,12 @@ describe('runRebootRespawn dry-run (FR-5) — default INERT', () => {
     // FR-1: a trailing single-line POINTER positional now follows. It embeds an absolute path, so
     // it is asserted by SHAPE — exact-matching a machine-specific path would be brittle without
     // testing anything more. The prefix is still pinned exactly.
-    expect(res.results[0].invocation.args.slice(0, 9))
-      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1']);
+    expect(res.results[0].invocation.args.slice(0, 12))
+      .toEqual(['-w', 'new', 'new-tab', '--title', 'Worker-1', '--suppressApplicationTitle', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1']);
     // FR-3: a slot with no resume token gets a MINTED --session-id instead, so the spawner knows in
     // advance the id the child will register under. Injected via uuidFn for determinism.
-    expect(res.results[1].invocation.args.slice(0, 9))
-      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]);
+    expect(res.results[1].invocation.args.slice(0, 12))
+      .toEqual(['-w', 'new', 'new-tab', '--title', 'Worker-2', '--suppressApplicationTitle', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]);
   });
 
   // QF-20260724-335: opts.sdKey stamps every fleet_verb_respawn event with an explicit run-correlator
@@ -81,10 +81,10 @@ describe('runRebootRespawn live (FR-5)', () => {
     expect(res.live).toBe(true);
     expect(spawnFn).toHaveBeenCalledTimes(2);
     expect(spawnCalls[0].program).toBe('wt.exe');
-    expect(spawnCalls[0].args.slice(0, 9))
-      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1']);
-    expect(spawnCalls[1].args.slice(0, 9))
-      .toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]); // slot 2 had no resume token -> minted id
+    expect(spawnCalls[0].args.slice(0, 12))
+      .toEqual(['-w', 'new', 'new-tab', '--title', 'Worker-1', '--suppressApplicationTitle', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'u-1']);
+    expect(spawnCalls[1].args.slice(0, 12))
+      .toEqual(['-w', 'new', 'new-tab', '--title', 'Worker-2', '--suppressApplicationTitle', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]); // slot 2 had no resume token -> minted id
     // FR-1: whatever follows is the single-line pointer positional, asserted by shape below.
     for (const c of spawnCalls) {
       const last = c.args[c.args.length - 1];

--- a/tests/unit/fleet/spawn-control-resume.test.js
+++ b/tests/unit/fleet/spawn-control-resume.test.js
@@ -11,7 +11,7 @@ import { resolveClaudeCmd, resolveRepoRoot } from '../../../lib/fleet/build-sess
 describe('buildLiveSpawnInvocation --resume (via canonical buildSessionLaunch)', () => {
   it('appends [--resume, <uuid>] after the base argv (new-tab -d <root> -- <claude>)', () => {
     const inv = buildLiveSpawnInvocation({ role: 'worker', callsign: 'Worker-1', resumeUuid: 'abc-123' });
-    expect(inv.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'abc-123']);
+    expect(inv.args).toEqual(['-w', 'new', 'new-tab', '--title', 'Worker-1', '--suppressApplicationTitle', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', 'abc-123']);
     expect(inv.program).toBe('wt.exe');
   });
 
@@ -20,7 +20,7 @@ describe('buildLiveSpawnInvocation --resume (via canonical buildSessionLaunch)',
     // what the child will register as. uuidFn is injected purely for determinism.
     const MINTED = '11111111-2222-4333-8444-555555555555';
     const inv = buildLiveSpawnInvocation({ role: 'worker', callsign: 'Worker-1' }, { uuidFn: () => MINTED });
-    expect(inv.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]);
+    expect(inv.args).toEqual(['-w', 'new', 'new-tab', '--title', 'Worker-1', '--suppressApplicationTitle', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--session-id', MINTED]);
     expect(inv.sessionId).toBe(MINTED);
     expect(inv.cwd).toBe(resolveRepoRoot());
     expect(inv.persistent).toBe(true);
@@ -50,7 +50,7 @@ describe('buildLiveSpawnInvocation --resume (via canonical buildSessionLaunch)',
 
   it('coerces a non-string resume token via String() (never leaks a raw object into argv)', () => {
     const inv = buildLiveSpawnInvocation({ callsign: 'W', resumeUuid: 42 });
-    expect(inv.args).toEqual(['-w', 'new', 'new-tab', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', '42']);
+    expect(inv.args).toEqual(['-w', 'new', 'new-tab', '--title', 'W', '--suppressApplicationTitle', '-d', resolveRepoRoot(), '--', resolveClaudeCmd(), '--resume', '42']);
   });
 
   it('injects CLAUDE_CONFIG_DIR only into the returned env, never process.env, and never as an argv token', () => {

--- a/tests/unit/fleet/tab-title.test.js
+++ b/tests/unit/fleet/tab-title.test.js
@@ -1,0 +1,94 @@
+/**
+ * QF-20260727-794 — name the Windows Terminal tab at spawn.
+ *
+ * Chairman-reported: with nine worker windows plus three role sessions open, the tab strip is the
+ * only way to reach a specific seat and it identified none of them — a coordinator tab read
+ * "Load and Execute Startup", which is Claude Code's conversation summary.
+ *
+ * The title MUST be set at spawn: a running session cannot retitle its own tab (both runtime
+ * routes were measured dead before this row was filed). --suppressApplicationTitle is LOAD-BEARING,
+ * because without it Claude Code's own title updates overwrite --title within seconds.
+ *
+ * HOST-VERIFIED, not taken from docs: Windows Terminal 1.24.11911.0, a throwaway tab spawned with
+ * these flags while running a command that otherwise self-titles "Start-Sleep" displayed the
+ * --title value instead — proving both that --title lands and that --suppressApplicationTitle
+ * beats the application title.
+ *
+ * The contract assertions below matter beyond cosmetics: assertLaunchContract is enforced at three
+ * live spawn seams, so a regression in arg RELATIONSHIPS refuses every spawn fleet-wide.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildSessionLaunch, assertLaunchContract, formatTabTitle,
+} from '../../../lib/fleet/build-session-launch.cjs';
+
+describe('formatTabTitle — number leads, name trails (chairman amendment)', () => {
+  it('renders "<n> · <callsign>" — the number is the anchor', () => {
+    expect(formatTabTitle({ windowNumber: 3, callsign: 'Alpha' })).toBe('3 · Alpha');
+  });
+
+  it('role sessions read as their role, which is the case the chairman raised', () => {
+    expect(formatTabTitle({ windowNumber: 1, callsign: 'Coordinator' })).toBe('1 · Coordinator');
+    expect(formatTabTitle({ windowNumber: 2, role: 'adam' })).toBe('2 · adam');
+  });
+
+  it('accepts a numeric string (the DB round-trips metadata as text)', () => {
+    expect(formatTabTitle({ windowNumber: '7', callsign: 'Bravo' })).toBe('7 · Bravo');
+  });
+
+  it('degrades gracefully rather than emitting an empty title', () => {
+    expect(formatTabTitle({ callsign: 'Alpha' })).toBe('Alpha');       // no number yet
+    expect(formatTabTitle({ role: 'worker' })).toBe('worker');          // no callsign
+    expect(formatTabTitle({ windowNumber: 4 })).toBe('4 · session');    // no identity
+    expect(formatTabTitle({})).toBe('LEO session');                     // nothing at all
+    expect(formatTabTitle()).toBe('LEO session');
+  });
+
+  it('ignores a non-numeric windowNumber instead of printing garbage', () => {
+    expect(formatTabTitle({ windowNumber: 'NaN', callsign: 'Alpha' })).toBe('Alpha');
+    expect(formatTabTitle({ windowNumber: '', callsign: 'Alpha' })).toBe('Alpha');
+    expect(formatTabTitle({ windowNumber: null, callsign: 'Alpha' })).toBe('Alpha');
+  });
+});
+
+describe('buildSessionLaunch — the tab is named, and the launch contract still holds', () => {
+  const spec = { role: 'worker', callsign: 'Alpha', windowNumber: 3, cwd: 'R:\\repo' };
+
+  it('passes --title with the formatted value', () => {
+    const { args } = buildSessionLaunch(spec);
+    const i = args.indexOf('--title');
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect(args[i + 1]).toBe('3 · Alpha');
+  });
+
+  it('passes --suppressApplicationTitle — without it Claude Code overwrites the title in seconds', () => {
+    expect(buildSessionLaunch(spec).args).toContain('--suppressApplicationTitle');
+  });
+
+  it('DOES NOT DISTURB assertLaunchContract — it is enforced at three live spawn seams', () => {
+    const inv = buildSessionLaunch(spec);
+    const r = assertLaunchContract(inv);
+    expect(r.ok, `violations: ${(r.violations || []).join('; ')}`).toBe(true);
+  });
+
+  it('preserves every arg RELATIONSHIP the contract checks by indexOf, not by fixed offset', () => {
+    const { args } = buildSessionLaunch(spec);
+    const w = args.indexOf('-w');
+    const nt = args.indexOf('new-tab');
+    const d = args.indexOf('-d');
+    const dd = args.indexOf('--');
+    expect(args[w + 1]).toBe('new');
+    expect(w).toBeLessThan(nt);            // -w is global; must precede the subcommand
+    expect(args[d + 1]).toBe('R:\\repo');  // -d still followed by the cwd
+    expect(nt).toBeLessThan(d);            // new flags sit between new-tab and -d
+    expect(d).toBeLessThan(dd);            // -- still last, claude token after it
+    expect(args[dd + 1]).toMatch(/claude(\.cmd|\.exe)?$/i);
+    expect(args).not.toContain('-p');
+  });
+
+  it('still names the tab when no window number was allocated (fix degrades, never blanks)', () => {
+    const { args } = buildSessionLaunch({ role: 'worker', callsign: 'Solomon', cwd: 'R:\\repo' });
+    expect(args[args.indexOf('--title') + 1]).toBe('Solomon');
+    expect(assertLaunchContract(buildSessionLaunch({ role: 'worker', cwd: 'R:\\repo' })).ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Chairman-reported: with nine worker windows plus three role sessions open, the tab strip is the only way to reach a specific seat and it identified none of them. Confirmed live while working this row — enumerating top-level windows showed the fleet's tabs reading `Load startup directive from file` and `Load and execute startup directive from file`, i.e. Claude Code's conversation summary, exactly as reported.

The title **must** be set at spawn: a running session cannot retitle its own tab (both runtime routes were measured dead before this row was filed). So the change is one line of argv in the single builder every spawn path funnels through, plus the title formatter.

`--suppressApplicationTitle` is **load-bearing** — without it Claude Code's own title updates overwrite `--title` within seconds.

## Flags verified on this host, not from docs

The row required this, and it earned its keep. Windows Terminal **1.24.11911.0**.

My first two probes reported the title *not* taking — that was a **false negative from my own `Start-Process` arg-passing**, not the flags. Invoking `wt.exe` directly in the row's prescribed arg order produced a window titled `QF794-DIRECT` while running a command that otherwise self-titles `Start-Sleep` (two earlier probe windows show exactly that title). That proves **both** that `--title` lands **and** that `--suppressApplicationTitle` beats the application title.

## Number first (chairman's amendment)

This dissolves the drift caveat rather than accepting it. The tab title is **immutable** after spawn; a callsign is **mutable** (`assign-fleet-identities.cjs` can turn `Alpha` into `Alpha-3`). Putting a mutable value in an immutable slot is what would have made the title age into a lie. The number is immutable by construction, so it leads and can never be wrong; the trailing name was true at spawn. The Sessions page — which *can* update live — carries the mapping, so the volatile half lives where volatility is free.

`formatTabTitle` degrades number+name → name → role → constant. `null`/`undefined` read as **absent** rather than zero: `Number(null) === 0` is finite and would have rendered an unallocated session as `"0 · Alpha"` — caught by its own test.

## Contract safety — the real risk the row flagged

`assertLaunchContract` is enforced at **three live spawn seams**, so a regression there refuses every spawn fleet-wide. It checks arg *relationships* by `indexOf`, not fixed offsets, and the new flags sit between `new-tab` and `-d`. Pinned explicitly: `-w new` precedes `new-tab`, `-d` still followed by cwd, `--` still last with the claude token after it, and the contract passes on the built invocation.

Five existing exact-argv expectations legitimately changed shape and were updated (`spawn-control-resume` ×3, `reboot-respawn-runner` ×2, incl. `slice(0,9)` → `slice(0,12)`).

## Pre-existing failures, not mine

Verified against unmodified `origin/main` in a throwaway worktree: `cp3-restart-relaunch-live-flag-propagation` (2) and `spawn-control` FR-6 (1) fail **identically on baseline**. My branch shows the same 3 and **1325 passing**.

## Scope

Deliberately the title only. The row also specifies allocating `window_number` at spawn, persisting to `claude_sessions.metadata`, and rendering a `#` column in the fleet panel and the **ehg** Sessions table — server + cross-repo surfaces beyond a QF. This lands the immutable half; the builder already accepts `windowNumber` and uses it the moment an allocator supplies one, so the follow-on is additive and cannot invalidate this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)