### PR TITLE
fix(QF-20260727-909): stamp model/effort on non-fleet role sessions

### DIFF
--- a/scripts/adam-register.cjs
+++ b/scripts/adam-register.cjs
@@ -142,6 +142,37 @@ async function registerAdam(supabase, sessionId, opts = {}) {
     action = 'tagged_fallback';
     fallbackReason = wrote.reason;
   }
+
+  // QF-20260727-909: stamp model/effort on this role session. CHAIRMAN-REPORTED — the sessions
+  // page rendered adam/solomon as '--/--' PERMANENTLY, because the only two writers of
+  // metadata.model are the SessionStart hook (stamps only when stdin carries a model) and
+  // worker-checkin's --model self-report, which ONLY workers run. A non_fleet role session runs
+  // neither, so no path would EVER populate it. Distinct from the neighbouring account column,
+  // where a blank self-heals on restart; this one does not.
+  //
+  // Reuses the worker path's EXISTING writer rather than adding a third. The QF asked to
+  // establish how the coordinator gets a stamp before inventing one — measured: its
+  // effort_source reads 'worker_self_report', i.e. it has no special role-stamping path, it
+  // simply runs the worker check-in. So there was nothing to copy, only this writer to share.
+  //
+  // Placed AFTER the role tag is persisted and OUTSIDE the RPC/fallback branch, deliberately:
+  // the set_adam_flag RPC is the PRIMARY path and the JS merge only its fail-soft, so stamping
+  // inside the fallback would become dead code the moment the chairman-approved migration lands.
+  //
+  // Fail-soft throughout — a missing model stamp must never block role registration.
+  try {
+    const { parseCheckinArgs, mergeCheckinModelEffort } = require('./worker-checkin.cjs');
+    const { model, effort } = parseCheckinArgs(process.argv.slice(2));
+    if (model || effort) {
+      const { data: cur } = await supabase.from('claude_sessions')
+        .select('metadata').eq('session_id', sessionId).maybeSingle();
+      const { metadata: stamped, changed } = mergeCheckinModelEffort(cur?.metadata || {}, { model, effort });
+      if (changed) {
+        await supabase.from('claude_sessions').update({ metadata: stamped }).eq('session_id', sessionId);
+      }
+    }
+  } catch { /* never block registration on a stamp */ }
+
   // Retire stale priors — but RE-VALIDATE freshness right before clearing each, so a prior that
   // became fresh since the decision (a racing restart) is NEVER cleared (the deliberate divergence
   // holds even under a race). Residual: two simultaneous STALE restarts can both register briefly

--- a/scripts/solomon-register.cjs
+++ b/scripts/solomon-register.cjs
@@ -142,6 +142,37 @@ async function registerSolomon(supabase, sessionId, opts = {}) {
     action = 'tagged_fallback';
     fallbackReason = wrote.reason;
   }
+
+  // QF-20260727-909: stamp model/effort on this role session. CHAIRMAN-REPORTED — the sessions
+  // page rendered adam/solomon as '--/--' PERMANENTLY, because the only two writers of
+  // metadata.model are the SessionStart hook (stamps only when stdin carries a model) and
+  // worker-checkin's --model self-report, which ONLY workers run. A non_fleet role session runs
+  // neither, so no path would EVER populate it. Distinct from the neighbouring account column,
+  // where a blank self-heals on restart; this one does not.
+  //
+  // Reuses the worker path's EXISTING writer rather than adding a third. The QF asked to
+  // establish how the coordinator gets a stamp before inventing one — measured: its
+  // effort_source reads 'worker_self_report', i.e. it has no special role-stamping path, it
+  // simply runs the worker check-in. So there was nothing to copy, only this writer to share.
+  //
+  // Placed AFTER the role tag is persisted and OUTSIDE the RPC/fallback branch, deliberately:
+  // the set_solomon_flag RPC is the PRIMARY path and the JS merge only its fail-soft, so
+  // stamping inside the fallback would become dead code the moment the chairman-approved
+  // migration lands.
+  //
+  // Fail-soft throughout — a missing model stamp must never block role registration.
+  try {
+    const { parseCheckinArgs, mergeCheckinModelEffort } = require('./worker-checkin.cjs');
+    const { model, effort } = parseCheckinArgs(process.argv.slice(2));
+    if (model || effort) {
+      const { data: cur } = await supabase.from('claude_sessions')
+        .select('metadata').eq('session_id', sessionId).maybeSingle();
+      const { metadata: stamped, changed } = mergeCheckinModelEffort(cur?.metadata || {}, { model, effort });
+      if (changed) {
+        await supabase.from('claude_sessions').update({ metadata: stamped }).eq('session_id', sessionId);
+      }
+    }
+  } catch { /* never block registration on a stamp */ }
   // Retire stale priors — but RE-VALIDATE freshness right before clearing each, so a prior that
   // became fresh since the decision (a racing restart) is NEVER cleared (the deliberate divergence
   // holds even under a race). Residual: two simultaneous STALE restarts can both register briefly.

--- a/tests/unit/fleet/role-session-model-stamp.test.js
+++ b/tests/unit/fleet/role-session-model-stamp.test.js
@@ -1,0 +1,94 @@
+/**
+ * QF-20260727-909 — non-fleet role sessions (adam, solomon) must get a model/effort stamp.
+ *
+ * CHAIRMAN-REPORTED: the sessions page rendered his Adam row as '--/--'. Measured 2026-07-27:
+ * metadata.model present on 9/9 workers and 1/1 coordinator, ABSENT on adam and solomon.
+ *
+ * Root cause is structural, not transient: the only two writers of metadata.model are the
+ * SessionStart hook (stamps only when stdin carries a model) and worker-checkin's --model
+ * self-report, which ONLY workers run. A non_fleet role session runs neither, so nothing would
+ * EVER populate it. This is why it does not self-heal on restart, unlike the account column.
+ *
+ * The QF's open question — "why does the coordinator have one?" — resolved by measurement before
+ * building: its effort_source reads 'worker_self_report', i.e. it has no special role-stamping
+ * path; it simply runs the worker check-in. So there was no third path to copy, only the
+ * existing writer to share.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const require_ = createRequire(import.meta.url);
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const { mergeCheckinModelEffort, parseCheckinArgs } = require_('../../../scripts/worker-checkin.cjs');
+
+describe('the shared writer stamps a role session correctly', () => {
+  it('stamps model, family, effort and provenance onto adam metadata', () => {
+    const { metadata, changed } = mergeCheckinModelEffort(
+      { role: 'adam', non_fleet: true, adam_since: '2026-07-27T00:00:00Z' },
+      { model: 'opus', effort: 'high' },
+    );
+    expect(changed).toBe(true);
+    expect(metadata.model).toBe('opus');
+    expect(metadata.model_family).toBe('opus');
+    expect(metadata.effort).toBe('high');
+    expect(metadata.effort_source).toBe('worker_self_report');
+  });
+
+  it('PRESERVES the role keys — the stamp must not clobber the tag it sits beside', () => {
+    // The QF explicitly tested and REJECTED "adam-register clobbers the stamp via a read-merge-
+    // write". This asserts the converse does not happen either: stamping must not drop role /
+    // non_fleet / adam_since, or registration would silently un-tag the singleton.
+    const before = { role: 'adam', non_fleet: true, adam_since: '2026-07-27T00:00:00Z', callsign: 'x' };
+    const { metadata } = mergeCheckinModelEffort(before, { model: 'opus', effort: 'high' });
+    expect(metadata.role).toBe('adam');
+    expect(metadata.non_fleet).toBe(true);
+    expect(metadata.adam_since).toBe('2026-07-27T00:00:00Z');
+    expect(metadata.callsign).toBe('x');
+  });
+
+  it('is a no-op when neither flag is supplied (registration keeps working unflagged)', () => {
+    const before = { role: 'solomon', non_fleet: true };
+    const { metadata, changed } = mergeCheckinModelEffort(before, {});
+    expect(changed).toBe(false);
+    expect(metadata).toBe(before);
+  });
+
+  it('parses the same --model/--effort flags the worker path accepts', () => {
+    expect(parseCheckinArgs(['--model', 'opus', '--effort', 'high'])).toEqual({ model: 'opus', effort: 'high' });
+    expect(parseCheckinArgs([])).toEqual({ model: null, effort: null });
+  });
+});
+
+describe('BOTH role registrars call the shared writer', () => {
+  // A guard on one registrar is not a guard on the invariant — adam and solomon are mirrors and
+  // both were blank.
+  for (const f of ['scripts/adam-register.cjs', 'scripts/solomon-register.cjs']) {
+    it(`${f} stamps via mergeCheckinModelEffort`, () => {
+      const src = readFileSync(resolve(repoRoot, f), 'utf8');
+      expect(src).toMatch(/mergeCheckinModelEffort/);
+      expect(src).toMatch(/parseCheckinArgs/);
+    });
+
+    it(`${f} stamps OUTSIDE the RPC/fallback branch, not inside it`, () => {
+      // The RPC (set_*_flag) is the PRIMARY path; the JS merge is only its fail-soft. Stamping
+      // inside the fallback becomes dead code the moment the chairman-approved migration lands.
+      const src = readFileSync(resolve(repoRoot, f), 'utf8');
+      const fallbackIdx = src.indexOf("action = 'tagged_fallback';");
+      const stampIdx = src.indexOf('mergeCheckinModelEffort');
+      expect(fallbackIdx).toBeGreaterThan(-1);
+      expect(stampIdx).toBeGreaterThan(fallbackIdx); // after the branch closes, not within it
+    });
+
+    it(`${f} fails soft — a stamp failure must never block role registration`, () => {
+      const src = readFileSync(resolve(repoRoot, f), 'utf8');
+      const stampIdx = src.indexOf('mergeCheckinModelEffort');
+      const region = src.slice(Math.max(0, stampIdx - 600), stampIdx + 600);
+      expect(region).toMatch(/try\s*\{/);
+      expect(region).toMatch(/catch/);
+    });
+  }
+});


### PR DESCRIPTION
## The defect

Chairman-reported from the sessions page: his Adam row renders `--/--`.

**Verified live before building:**

| Role | Has `metadata.model` |
|---|---|
| worker | 9 / 9 |
| coordinator | 1 / 1 |
| **adam** | **0 / 1** |
| **solomon** | **0 / 1** |

Structural, not transient. There are exactly two writers of `metadata.model`: the SessionStart hook (stamps only when stdin carries a model) and `worker-checkin`'s `--model` self-report, which **only workers run**. A `non_fleet` role session runs neither — so no path would *ever* populate it. Unlike the neighbouring account column, this does not self-heal on restart.

## Answering the QF's open question first

The QF deliberately declined to guess why the coordinator *has* a stamp, and said to establish that before inventing a third writer. Measured: the coordinator's `effort_source` reads `worker_self_report` — identical to workers. It has no special role-stamping path; **it simply runs the worker check-in.**

So there was nothing to copy, only the existing writer to share. That answer turned a suspected three-writer problem into a one-line reuse.

## The fix

Both registrars now call `worker-checkin`'s `mergeCheckinModelEffort` + `parseCheckinArgs`. Requiring `worker-checkin.cjs` is side-effect-free (guarded by `require.main === module` at `:1697`).

**Placed outside the RPC/fallback branch, deliberately.** `set_adam_flag` / `set_solomon_flag` is the *primary* path; the JS merge is only its fail-soft. A stamp inside the fallback would become dead code the moment the chairman-approved migration lands — the same migration whose approval annotation I committed an hour ago in QF-20260727-646. A test pins the ordering so it can't drift back inside.

Fail-soft throughout: a stamp failure never blocks role registration. Verified the writer **preserves** `role` / `non_fleet` / `*_since` / `callsign` — the QF had tested and rejected *"adam-register clobbers metadata"*; this asserts the converse doesn't happen either.

## Tests

10 tests, mutation-verified:
- moving the stamp inside the fallback branch → **1 fails**
- removing the writer entirely → **3 fail**

One note on method: my first attempt at that second mutation used `String.replace` (first occurrence only), which left the call site intact and reported a false all-green. Re-run with `replaceAll` it fails correctly. The harness failed green, not the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)