### PR TITLE
fix(QF-20260727-454): couple ack to a genuine read for chairman directives

### DIFF
--- a/scripts/ack-chairman-directive.cjs
+++ b/scripts/ack-chairman-directive.cjs
@@ -11,19 +11,57 @@
  *
  * Ack is keyed by directive_id (NOT topic_id) so this child is dependency-free.
  *
+ * QF-20260727-454: a chairman directive was acknowledged before it was ever read (self-reported
+ * by Solomon 2026-07-27) — this verb used to accept ANY --id string and write the ack with ZERO
+ * DB verification, so an ack could be issued for a directive_id nothing here had actually fetched
+ * (including one that never existed). The root shape: a target resolved by proxy ("the newest
+ * unacked row") instead of taken from the row genuinely read. The fix couples the two: the ack
+ * now REFUSES unless it can fetch the directive it is stamping, in THIS SAME operation, and the
+ * fetched body is surfaced in the confirmation output. A missing/unknown directive_id is a loud
+ * refusal (exit 1), never a silent best-guess — "handled" can no longer outrun "read".
+ *
  * Usage:
  *   node scripts/ack-chairman-directive.cjs --id <directive_id> --role <adam|coordinator|solomon> [--note "<text>"]
  */
 'use strict';
 
-const { getServiceClient } = require('../lib/fleet/worker-status.cjs');
+const { getServiceClient, PAYLOAD_KINDS } = require('../lib/fleet/worker-status.cjs');
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
 
+const CHAIRMAN_DIRECTIVE_KIND = PAYLOAD_KINDS.CHAIRMAN_DIRECTIVE; // 'chairman_directive'
 const CHAIRMAN_DIRECTIVE_ACK_KIND = 'chairman_directive_ack';
 
 function argVal(argv, flag) {
   const i = argv.indexOf(flag);
   return i >= 0 && i + 1 < argv.length ? argv[i + 1] : null;
+}
+
+/**
+ * QF-20260727-454: fetch the CURRENT (latest-issued, SUPERSEDES-aware — mirrors
+ * lib/coordinator/chairman-directive-gauge.cjs's decideChairmanDirectiveCompliance) row for an
+ * EXPLICIT directiveId. This is the ONLY lookup the ack path performs, and it is REQUIRED before
+ * any ack write. Explicit directiveId in, the one row it genuinely identifies out — never a
+ * newest-unacked / most-recent-across-ALL-directives substitute standing in for it.
+ * Exported for tests.
+ * @returns {Promise<{row: object|null, error: object|null}>}
+ */
+async function fetchDirectiveForAck(supabase, directiveId) {
+  const { data, error } = await supabase
+    .from('session_coordination')
+    .select('id, subject, body, payload, created_at')
+    .eq('payload->>kind', CHAIRMAN_DIRECTIVE_KIND)
+    .eq('payload->>directive_id', directiveId)
+    .order('created_at', { ascending: false })
+    .limit(1);
+  if (error) return { row: null, error };
+  const row = Array.isArray(data) && data.length > 0 ? data[0] : null;
+  return { row, error: null };
+}
+
+/** Pure: the text to surface as "what this operation read", from a fetched directive row. */
+function directiveBodyText(directiveRow) {
+  if (!directiveRow) return '';
+  return String(directiveRow.body || (directiveRow.payload && directiveRow.payload.body) || '');
 }
 
 async function main() {
@@ -35,6 +73,22 @@ async function main() {
     console.error('Usage: node scripts/ack-chairman-directive.cjs --id <directive_id> --role <adam|coordinator|solomon> [--note "<text>"]');
     process.exit(2);
   }
+
+  const supabase = getServiceClient();
+
+  // QF-20260727-454: REFUSE — never silently ack a directive_id this operation could not read.
+  const { row: directiveRow, error: fetchErr } = await fetchDirectiveForAck(supabase, directiveId);
+  if (fetchErr) { console.error('ERROR: directive lookup failed:', fetchErr.message); process.exit(1); }
+  if (!directiveRow) {
+    console.error(
+      `ERROR: refusing to ack — no chairman_directive found for directive_id=${directiveId}. ` +
+      'An ack must read the directive it stamps handled in the SAME operation; there is nothing ' +
+      'here to read, so there is nothing here to ack. If you meant a different directive_id, re-run ' +
+      'with the id of the row you actually read.'
+    );
+    process.exit(1);
+  }
+
   const actionedAt = new Date().toISOString();
 
   const payload = {
@@ -46,7 +100,6 @@ async function main() {
   };
   if (note) payload.note = String(note);
 
-  const supabase = getServiceClient();
   await insertCoordinationRow(supabase, {
     sender_session: role,
     sender_type: role,
@@ -57,7 +110,16 @@ async function main() {
     payload,
   });
 
+  // QF-20260727-454: surface what THIS operation read, in the SAME call that performs the ack —
+  // the transcript itself carries evidence the read happened here, not via a separate/earlier/
+  // different lookup.
+  const bodyText = directiveBodyText(directiveRow);
   console.log(`✓ chairman_directive_ack recorded: id=${directiveId} role=${role} actioned_at=${actionedAt}`);
+  console.log(`  directive_read (${bodyText.length} chars): ${bodyText.slice(0, 300)}${bodyText.length > 300 ? '…' : ''}`);
 }
 
-main().catch((e) => { console.error('ack-chairman-directive failed:', (e && e.message) || e); process.exit(1); });
+module.exports = { fetchDirectiveForAck, directiveBodyText, CHAIRMAN_DIRECTIVE_KIND, CHAIRMAN_DIRECTIVE_ACK_KIND };
+
+if (require.main === module) {
+  main().catch((e) => { console.error('ack-chairman-directive failed:', (e && e.message) || e); process.exit(1); });
+}

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -416,6 +416,13 @@ async function stampSurfaced(supabase, ids, { background = false } = {}) {
  * sanctioned action-time stamp for the Adam lane (chairman directives keep
  * scripts/ack-chairman-directive.cjs). Stamps acknowledged_at (only where NULL) and
  * backfills read_at where NULL (an actioned row was necessarily seen). Idempotent.
+ *
+ * QF-20260727-454 (part b, WARN strictness): the UPDATE...RETURNING now also reads back
+ * payload/body — the SAME atomic operation that stamps the ack now surfaces the content it
+ * acked, instead of confirming a bare id. This is a batch, multi-id CLI (cron + interactive
+ * callers ack legitimate rows that occasionally carry no readable body), so an empty body WARNS
+ * rather than refuses — refusing here would break real callers; ack-chairman-directive.cjs (a
+ * single, high-stakes, always-has-a-body chairman lane) is where this class hard-refuses instead.
  */
 async function ackRows(supabase, ids, { expectedTarget = null } = {}) {
   const now = new Date().toISOString();
@@ -430,14 +437,19 @@ async function ackRows(supabase, ids, { expectedTarget = null } = {}) {
       .eq('id', id)
       .is('acknowledged_at', null);
     if (expectedTarget) q = q.eq('target_session', expectedTarget);
-    const { data, error } = await q.select('id, read_at');
+    const { data, error } = await q.select('id, read_at, payload, body');
     if (error) { console.error(`ERROR: ack failed for ${id}: ${error.message}`); continue; }
     if (data && data.length > 0) {
       acked += 1;
       if (data[0].read_at == null) {
         await supabase.from('session_coordination').update({ read_at: now }).eq('id', id).is('read_at', null);
       }
-      console.log(`  ✓ acked ${id}`);
+      const bodyText = (data[0].payload && data[0].payload.body) || data[0].body || '';
+      if (bodyText) {
+        console.log(`  ✓ acked ${id} — body read (${String(bodyText).length} chars): ${String(bodyText).slice(0, 120)}${String(bodyText).length > 120 ? '…' : ''}`);
+      } else {
+        console.warn(`  ⚠ acked ${id} but it carries no readable body/payload.body — could not surface content to confirm against`);
+      }
     } else {
       console.log(`  • ${id} already acked, not found, or not targeted at this Adam session — no-op`);
     }

--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -440,6 +440,12 @@ async function stampSurfaced(supabase, ids, { background = false } = {}) {
  * QF-20260710-593 (mirrors adam-advisory.ackRows) — the single sanctioned action-time stamp for
  * the Solomon lane. Stamps acknowledged_at (only where NULL) and backfills read_at where NULL (an
  * actioned row was necessarily seen). Ownership-scoped when expectedTarget is given. Idempotent.
+ *
+ * QF-20260727-454 (part b, WARN strictness — mirrors adam-advisory.ackRows): the
+ * UPDATE...RETURNING now also reads back payload/body, so the SAME atomic call that stamps the
+ * ack surfaces the content it acked. Batch/multi-id CLI (cron + interactive) — an empty body
+ * WARNS rather than refuses, since a hard refusal here would break legitimate callers acking a
+ * row that happens to carry no readable body.
  */
 async function ackRows(supabase, ids, { expectedTarget = null } = {}) {
   const now = new Date().toISOString();
@@ -454,14 +460,19 @@ async function ackRows(supabase, ids, { expectedTarget = null } = {}) {
     // sentinel lane (Solomon is that sentinel's intended consumer), so the ownership scope
     // must admit those rows too or a surfaced fallback row could never be acked.
     if (expectedTarget) q = q.in('target_session', [expectedTarget, 'broadcast-solomon']);
-    const { data, error } = await q.select('id, read_at');
+    const { data, error } = await q.select('id, read_at, payload, body');
     if (error) { console.error(`ERROR: ack failed for ${id}: ${error.message}`); continue; }
     if (data && data.length > 0) {
       acked += 1;
       if (data[0].read_at == null) {
         await supabase.from('session_coordination').update({ read_at: now }).eq('id', id).is('read_at', null);
       }
-      console.log(`  ✓ acked ${id}`);
+      const bodyText = (data[0].payload && data[0].payload.body) || data[0].body || '';
+      if (bodyText) {
+        console.log(`  ✓ acked ${id} — body read (${String(bodyText).length} chars): ${String(bodyText).slice(0, 120)}${String(bodyText).length > 120 ? '…' : ''}`);
+      } else {
+        console.warn(`  ⚠ acked ${id} but it carries no readable body/payload.body — could not surface content to confirm against`);
+      }
     } else {
       console.log(`  • ${id} already acked, not found, or not targeted at this Solomon session — no-op`);
     }

--- a/tests/unit/coordination/ack-chairman-directive-read-coupling.test.js
+++ b/tests/unit/coordination/ack-chairman-directive-read-coupling.test.js
@@ -1,0 +1,102 @@
+// QF-20260727-454: a chairman directive was acknowledged before it was ever read (self-reported
+// by Solomon, 2026-07-27). Root cause: the ack target was resolved by a proxy ("the newest
+// unacked row") instead of taken from the row genuinely read; two rows were unacked, they
+// diverged, and the wrong one was resolved. This pins the fix in scripts/ack-chairman-directive.cjs:
+//   (a) the ack path resolves ONLY the EXPLICIT directive_id it was given — never a newest-unacked
+//       scan across all outstanding directives — and refuses (returns row:null) when that id
+//       matches nothing.
+//   (b) the fetch (the "read") happens in the SAME operation as the ack, and the fetched body is
+//       what main() prints — "handled" cannot outrun "read".
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { fetchDirectiveForAck, directiveBodyText, CHAIRMAN_DIRECTIVE_KIND } = require('../../../scripts/ack-chairman-directive.cjs');
+
+/**
+ * Minimal PostgREST-shaped mock: records every .eq() filter applied to the chain and resolves
+ * to the rows in `rows` that satisfy an exact match on payload->>directive_id (when such a
+ * filter is present) — enough to prove fetchDirectiveForAck resolves by EXPLICIT id, not by
+ * scanning/ordering across all rows.
+ */
+function makeMock(rows) {
+  const queries = [];
+  const supabase = {
+    from: (table) => {
+      const state = { table, filters: [] };
+      const c = {
+        select: () => c,
+        eq: (col, v) => { state.filters.push(['eq', col, v]); return c; },
+        order: (col, opts) => { state.filters.push(['order', col, opts]); return c; },
+        limit: (n) => { state.filters.push(['limit', n]); return c; },
+        then: (res, rej) => {
+          queries.push(state);
+          const idFilter = state.filters.find((f) => f[0] === 'eq' && f[1] === 'payload->>directive_id');
+          const matched = idFilter ? rows.filter((r) => r.payload && r.payload.directive_id === idFilter[2]) : rows;
+          return Promise.resolve({ data: matched, error: null }).then(res, rej);
+        },
+      };
+      return c;
+    },
+  };
+  return { supabase, queries };
+}
+
+describe('QF-20260727-454 (a): fetchDirectiveForAck resolves by EXPLICIT directive_id, never newest-unacked', () => {
+  it('returns the row asked for, not the newest row overall, when a newer unrelated directive also exists', async () => {
+    // dir-A is what was actually read (the 3608-char chairman directive in the real incident).
+    // dir-B is a LATER, unrelated directive — the row a naive "newest unacked" lookup would pick.
+    const rowA = { id: 'row-a', body: 'DIRECTIVE A — the one actually read', payload: { kind: CHAIRMAN_DIRECTIVE_KIND, directive_id: 'dir-A' }, created_at: '2026-07-27T10:00:00Z' };
+    const rowB = { id: 'row-b', body: 'DIRECTIVE B — unrelated, newer', payload: { kind: CHAIRMAN_DIRECTIVE_KIND, directive_id: 'dir-B' }, created_at: '2026-07-27T11:00:00Z' };
+    const { supabase, queries } = makeMock([rowA, rowB]);
+
+    const { row, error } = await fetchDirectiveForAck(supabase, 'dir-A');
+
+    expect(error).toBeNull();
+    expect(row.id).toBe('row-a');
+    expect(row.id).not.toBe('row-b');
+    expect(queries[0].filters).toContainEqual(['eq', 'payload->>directive_id', 'dir-A']);
+  });
+
+  it('an unknown directive_id resolves to row:null — a hard refusal, never a silent newest-unacked substitute', async () => {
+    const rowB = { id: 'row-b', body: 'unrelated', payload: { kind: CHAIRMAN_DIRECTIVE_KIND, directive_id: 'dir-B' }, created_at: '2026-07-27T11:00:00Z' };
+    const { supabase } = makeMock([rowB]);
+
+    const { row, error } = await fetchDirectiveForAck(supabase, 'dir-does-not-exist');
+
+    expect(error).toBeNull();
+    expect(row).toBeNull(); // main() turns a null row into process.exit(1), never falls back to rowB
+  });
+
+  it('(b) exact reproduction — two unacked directives present; asking for A returns ONLY A, B is never touched by the read', async () => {
+    const rowA = { id: 'row-a', body: 'A', payload: { kind: CHAIRMAN_DIRECTIVE_KIND, directive_id: 'dir-A' }, created_at: '2026-07-27T09:00:00Z' };
+    const rowB = { id: 'row-b', body: 'B', payload: { kind: CHAIRMAN_DIRECTIVE_KIND, directive_id: 'dir-B' }, created_at: '2026-07-27T09:05:00Z' };
+    const { supabase } = makeMock([rowA, rowB]);
+
+    const resultA = await fetchDirectiveForAck(supabase, 'dir-A');
+    const resultB = await fetchDirectiveForAck(supabase, 'dir-B');
+
+    expect(resultA.row.id).toBe('row-a');
+    expect(resultB.row.id).toBe('row-b');
+    expect(resultA.row.id).not.toBe(resultB.row.id);
+  });
+
+  it('propagates a query error instead of masking it as "not found"', async () => {
+    const supabase = { from: () => ({ select: () => ({ eq: () => ({ eq: () => ({ order: () => ({ limit: () => ({ then: (res) => Promise.resolve({ data: null, error: { message: 'db down' } }).then(res) }) }) }) }) }) }) };
+    const { row, error } = await fetchDirectiveForAck(supabase, 'dir-A');
+    expect(row).toBeNull();
+    expect(error).toBeTruthy();
+  });
+});
+
+describe('QF-20260727-454 (c): directiveBodyText — the content surfaced by the coupled read', () => {
+  it('prefers the top-level body column', () => {
+    expect(directiveBodyText({ body: 'top-level', payload: { body: 'nested' } })).toBe('top-level');
+  });
+  it('falls back to payload.body when the top-level body is empty', () => {
+    expect(directiveBodyText({ body: null, payload: { body: 'nested' } })).toBe('nested');
+  });
+  it('is empty (never throws) for a missing/empty row', () => {
+    expect(directiveBodyText(null)).toBe('');
+    expect(directiveBodyText({})).toBe('');
+  });
+});

--- a/tests/unit/coordination/ack-paths-explicit-id-source-pins.test.js
+++ b/tests/unit/coordination/ack-paths-explicit-id-source-pins.test.js
@@ -1,0 +1,83 @@
+// QF-20260727-454 (a): SOURCE PINS across the audited ack surface. The incident: a chairman
+// directive was acknowledged before it was read because the ack target was resolved by fetching
+// "the newest unacked row" as a PROXY for "the row I am reading". These pins assert, for every
+// sanctioned ack path (worker-ack-directive.cjs, coordinator-ack-adam.cjs,
+// coordinator-ack-signal.cjs, ack-chairman-directive.cjs, adam-advisory.cjs/`ack`,
+// solomon-advisory.cjs/`ack`):
+//   (1) an explicit identifier is REQUIRED — a missing one is a loud usage refusal, never a
+//       silently-resolved default; and
+//   (2) none of them contain the "order by created_at DESC, gated only on acknowledged_at IS
+//       NULL, feeding limit(1)" shape that would pick a target BY RECENCY rather than by id.
+// This does not re-assert full runtime behavior (see ack-chairman-directive-read-coupling.test.js
+// and ack-rows-exact-id-and-body-read.test.js for that) — it pins the ABSENCE of the specific
+// defect shape this QF closes, across the whole surface the QF asked to be checked.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const REPO_ROOT = path.resolve(fileURLToPath(new URL('../../../', import.meta.url)));
+const read = (rel) => readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+
+const ACK_PATHS = [
+  'scripts/worker-ack-directive.cjs',
+  'scripts/coordinator-ack-adam.cjs',
+  'scripts/coordinator-ack-signal.cjs',
+  'scripts/ack-chairman-directive.cjs',
+  'scripts/adam-advisory.cjs',
+  'scripts/solomon-advisory.cjs',
+];
+
+// The textual signature of "give me THE most recent unacked row" (order desc + a bare
+// acknowledged_at-IS-NULL gate + limit(1)), in either filter order, within a small window.
+function hasNewestUnackedTargetShape(src) {
+  return /ascending:\s*false[\s\S]{0,200}is\(\s*'acknowledged_at',\s*null\)[\s\S]{0,80}limit\(1\)/.test(src)
+    || /is\(\s*'acknowledged_at',\s*null\)[\s\S]{0,200}ascending:\s*false[\s\S]{0,80}limit\(1\)/.test(src);
+}
+
+describe('QF-20260727-454 (a): no ack path resolves its target via a newest-unacked scan', () => {
+  for (const rel of ACK_PATHS) {
+    it(`${rel} contains no newest-unacked-row-feeds-the-ack shape`, () => {
+      expect(hasNewestUnackedTargetShape(read(rel))).toBe(false);
+    });
+  }
+});
+
+describe('QF-20260727-454 (a): each ack path REQUIRES an explicit identifier — a missing one refuses loudly', () => {
+  it('worker-ack-directive.cjs requires --id', () => {
+    const src = read('scripts/worker-ack-directive.cjs');
+    expect(src).toContain("argVal(argv, '--id')");
+    expect(src).toMatch(/if\s*\(!id\)\s*\{/);
+  });
+
+  it('ack-chairman-directive.cjs requires --id AND refuses without a fetched row (part b coupling)', () => {
+    const src = read('scripts/ack-chairman-directive.cjs');
+    expect(src).toContain("argVal(argv, '--id')");
+    expect(src).toMatch(/if\s*\(!directiveId \|\| !role\)\s*\{/);
+    expect(src).toContain('fetchDirectiveForAck');
+    expect(src).toContain('refusing to ack');
+  });
+
+  it('adam-advisory.cjs and solomon-advisory.cjs `ack` mode require positional row ids', () => {
+    for (const rel of ['scripts/adam-advisory.cjs', 'scripts/solomon-advisory.cjs']) {
+      const src = read(rel);
+      expect(src).toMatch(/if\s*\(ids\.length === 0\)\s*\{/);
+    }
+  });
+
+  it('coordinator-ack-adam.cjs requires --advisory; coordinator-ack-signal.cjs requires --signal', () => {
+    expect(read('scripts/coordinator-ack-adam.cjs')).toContain('if (!advisoryId)');
+    expect(read('scripts/coordinator-ack-signal.cjs')).toContain('if (!signalId)');
+  });
+});
+
+describe('QF-20260727-454 (b): the two batch ack lanes (adam/solomon) now read payload+body in the same UPDATE...RETURNING', () => {
+  it('adam-advisory.cjs ackRows selects payload and body alongside id/read_at', () => {
+    const src = read('scripts/adam-advisory.cjs');
+    expect(src).toContain("q.select('id, read_at, payload, body')");
+  });
+  it('solomon-advisory.cjs ackRows selects payload and body alongside id/read_at', () => {
+    const src = read('scripts/solomon-advisory.cjs');
+    expect(src).toContain("q.select('id, read_at, payload, body')");
+  });
+});

--- a/tests/unit/coordination/ack-rows-exact-id-and-body-read.test.js
+++ b/tests/unit/coordination/ack-rows-exact-id-and-body-read.test.js
@@ -1,0 +1,113 @@
+// QF-20260727-454: a chairman directive was acknowledged before it was ever read. The reporter's
+// own diagnosis: the ack target was resolved by fetching "the newest unacked row" as a PROXY for
+// "the row I am reading" — with two rows unacked, they diverged and the wrong one was resolved.
+//
+// scripts/adam-advisory.cjs's ackRows and scripts/solomon-advisory.cjs's ackRows already take an
+// EXPLICIT ids array (never an internal newest-unacked query) — this file pins that invariant with
+// the QF's own reproduction shape, plus the part-(b) hardening: the UPDATE...RETURNING now also
+// reads back payload/body in the SAME call that stamps acknowledged_at, and surfaces (or WARNs on
+// the absence of) that content instead of confirming a bare id.
+import { describe, it, expect, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { ackRows: adamAckRows } = require('../../../scripts/adam-advisory.cjs');
+const { ackRows: solomonAckRows } = require('../../../scripts/solomon-advisory.cjs');
+
+const TARGET = 'role-session-uuid';
+
+/**
+ * Stateful mock: a tiny in-memory `session_coordination` store keyed by id. Applies filters
+ * (eq/is/in) to select the matching rows and, for an update chain, writes updatePayload onto the
+ * matched rows before returning them — enough to prove id-exact scoping (row B is never touched
+ * when only row A's id is acked) without a real DB.
+ */
+function makeStatefulMock(rows) {
+  const store = new Map(rows.map((r) => [r.id, { ...r }]));
+  function chain() {
+    let op = null;
+    let updatePayload = null;
+    const filters = [];
+    const c = {
+      update(payload) { op = 'update'; updatePayload = payload; return c; },
+      eq(col, v) { filters.push({ col, v, type: 'eq' }); return c; },
+      is(col, v) { filters.push({ col, v, type: 'is' }); return c; },
+      in(col, v) { filters.push({ col, v, type: 'in' }); return c; },
+      async select() {
+        const matches = [...store.values()].filter((r) => filters.every((f) => {
+          if (f.type === 'eq') return r[f.col] === f.v;
+          if (f.type === 'is') return (r[f.col] ?? null) === f.v;
+          if (f.type === 'in') return f.v.includes(r[f.col]);
+          return true;
+        }));
+        if (op === 'update') {
+          for (const r of matches) Object.assign(r, updatePayload);
+        }
+        return { data: matches.map((r) => ({ id: r.id, read_at: r.read_at, payload: r.payload, body: r.body })), error: null };
+      },
+    };
+    return c;
+  }
+  return { supabase: { from: () => chain() }, store };
+}
+
+for (const [label, ackRows] of [['adam-advisory', adamAckRows], ['solomon-advisory', solomonAckRows]]) {
+  describe(`QF-20260727-454 (${label}): ackRows exact-id scoping + read/ack coupling`, () => {
+    it('(a)+(b) exact reproduction: with two unacked rows present, acking row A stamps A and leaves B untouched', async () => {
+      const rowA = { id: 'row-A', target_session: TARGET, acknowledged_at: null, read_at: '2026-07-27T09:00:00Z', payload: { body: 'the directive actually read' }, body: null };
+      const rowB = { id: 'row-B', target_session: TARGET, acknowledged_at: null, read_at: '2026-07-27T09:05:00Z', payload: { body: 'unrelated row' }, body: null };
+      const { supabase, store } = makeStatefulMock([rowA, rowB]);
+
+      await ackRows(supabase, ['row-A'], { expectedTarget: TARGET });
+
+      expect(store.get('row-A').acknowledged_at).not.toBeNull();
+      expect(store.get('row-B').acknowledged_at).toBeNull(); // never touched — no newest-unacked substitution
+    });
+
+    it('acking an explicit id never falls back to any other unacked row when the id is wrong/missing', async () => {
+      const rowB = { id: 'row-B', target_session: TARGET, acknowledged_at: null, read_at: null, payload: {}, body: null };
+      const { supabase, store } = makeStatefulMock([rowB]);
+
+      await ackRows(supabase, ['row-does-not-exist'], { expectedTarget: TARGET });
+
+      expect(store.get('row-B').acknowledged_at).toBeNull(); // no silent "closest match" ack
+    });
+  });
+}
+
+describe('QF-20260727-454 (b): ackRows surfaces the body it just read (or WARNs on an empty one)', () => {
+  const origLog = console.log;
+  const origWarn = console.warn;
+  afterEach(() => { console.log = origLog; console.warn = origWarn; });
+
+  function captureConsole() {
+    const logs = [];
+    const warns = [];
+    console.log = (...a) => logs.push(a.join(' '));
+    console.warn = (...a) => warns.push(a.join(' '));
+    return { logs, warns };
+  }
+
+  it('adam-advisory: prints the fetched body text for a row that carries one, warns for a row that carries none', async () => {
+    const { logs, warns } = captureConsole();
+    const rowWithBody = { id: 'row-C', target_session: TARGET, acknowledged_at: null, read_at: null, payload: { body: 'directive content to surface' }, body: null };
+    const rowEmpty = { id: 'row-D', target_session: TARGET, acknowledged_at: null, read_at: null, payload: {}, body: null };
+    const { supabase } = makeStatefulMock([rowWithBody, rowEmpty]);
+
+    await adamAckRows(supabase, ['row-C', 'row-D'], { expectedTarget: TARGET });
+
+    expect(logs.some((l) => l.includes('row-C') && l.includes('directive content to surface'))).toBe(true);
+    expect(warns.some((w) => w.includes('row-D'))).toBe(true);
+  });
+
+  it('solomon-advisory: same body-read coupling', async () => {
+    const { logs, warns } = captureConsole();
+    const rowWithBody = { id: 'row-E', target_session: TARGET, acknowledged_at: null, read_at: null, payload: { body: 'oracle answer content' }, body: null };
+    const rowEmpty = { id: 'row-F', target_session: TARGET, acknowledged_at: null, read_at: null, payload: {}, body: null };
+    const { supabase } = makeStatefulMock([rowWithBody, rowEmpty]);
+
+    await solomonAckRows(supabase, ['row-E', 'row-F'], { expectedTarget: TARGET });
+
+    expect(logs.some((l) => l.includes('row-E') && l.includes('oracle answer content'))).toBe(true);
+    expect(warns.some((w) => w.includes('row-F'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes QF-20260727-454, self-reported by Solomon (2026-07-27): a chairman
directive was acknowledged before it was ever read. Two directive rows were
unacked; the ack target was resolved as a proxy ("the newest unacked row")
instead of taken from the row genuinely read, so the wrong one got stamped
and a reply was threaded onto its correlation.

## Investigation (where the defect was, and wasn't)

Audited every `acknowledged_at` writer in the coordination lane:
`scripts/worker-ack-directive.cjs`, `scripts/coordinator-ack-adam.cjs`,
`scripts/coordinator-ack-signal.cjs`, `scripts/coordinator-reply.cjs`,
`scripts/adam-advisory.cjs`/`scripts/solomon-advisory.cjs` `ack`, and
`scripts/ack-chairman-directive.cjs`. **All of them already require an
explicit id/correlation from the caller — none resolve a target via a
newest-unacked scan.** Part (a) of the QF's fix shape was already
structurally satisfied across the whole surface (pinned with source tests so
it stays that way).

The real gap was part (b), the **read/ack coupling**:

- `scripts/ack-chairman-directive.cjs` wrote the ack row with **zero DB
  verification** — any `--id` string was accepted, no fetch, no existence
  check. This is the exact lane the incident touched.
- `scripts/adam-advisory.cjs` / `scripts/solomon-advisory.cjs` `ackRows()`
  blindly `UPDATE`d by id without ever reading content back.

## Fix

- **`scripts/ack-chairman-directive.cjs`** — added `fetchDirectiveForAck()`:
  fetches the chairman_directive row for the given `directive_id` (latest
  issued version, mirrors the gauge's SUPERSEDES semantics) in the same
  operation. **Hard refusal** (exit 1) if nothing is found — this is a
  single, high-stakes, always-has-a-body lane; no legitimate caller acks a
  directive that doesn't exist. The fetched body is printed in the same call
  that performs the ack.
- **`scripts/adam-advisory.cjs` / `scripts/solomon-advisory.cjs`
  `ackRows()`** — extended the existing `UPDATE...RETURNING` to also select
  `payload, body`, and surface (or **WARN** on the absence of) that content.
  **Warn, not refuse** here, since these are batch/cron ack lanes where a
  legitimate row can carry no readable body — a hard refusal would break
  real callers.

## Tests

New: `tests/unit/coordination/ack-chairman-directive-read-coupling.test.js`,
`ack-rows-exact-id-and-body-read.test.js`,
`ack-paths-explicit-id-source-pins.test.js` — 25 tests covering the QF's
exact reproduction (two unacked rows, acking A leaves B untouched), the
"newer row would win a naive lookup but doesn't" case, the refusal path, and
source pins across the whole ack surface.

All 535 tests across the 51 existing files that import these modules still
pass unchanged (no pre-existing failures encountered).

## Test plan

- [x] New suite: 25/25 passing
- [x] Existing suites touching the 3 changed files: 535/535 passing
- [x] `node -e "require(...)"` sanity check on all 3 edited files (no syntax
      errors, `main()` does not auto-run on require)

🤖 Generated with [Claude Code](https://claude.com/claude-code)