### PR TITLE
fix(QF-20260726-677): add /RU principal to the EVA watcher scheduled task

### DIFF
--- a/scripts/__tests__/eva-host-and-arm.test.js
+++ b/scripts/__tests__/eva-host-and-arm.test.js
@@ -192,6 +192,36 @@ describe('FR-1 setup-eva-watcher-task builders', () => {
     expect(args[args.indexOf('/TR') + 1]).toContain('eva-watcher-task.cmd');
   });
 
+  // QF-20260726-677: without /RU, schtasks /Create registers LogonType=Interactive, which is what
+  // materialised a visible OpenConsole.exe window on every 5-minute fire (148 orphaned consoles
+  // measured on the chairman's desktop). Assert the principal flag is present so this regression
+  // cannot re-land silently — the generated wrapper .cmd is gitignored, so this test + the builder
+  // are the only durable place the fix lives.
+  it('schtasks argv carries a /RU principal by default (non-interactive S4U logon, not Interactive)', () => {
+    const args = buildSchtasksArgs({ wrapperPath: 'C:\\repo\\EHG\\scripts\\cron\\eva-watcher-task.cmd' });
+    expect(args).toContain('/RU');
+    const runAs = args[args.indexOf('/RU') + 1];
+    expect(typeof runAs).toBe('string');
+    expect(runAs.length).toBeGreaterThan(0);
+    // Default must be the current user (S4U), NOT SYSTEM — SYSTEM needs elevation to register and
+    // drops the user profile/PATH that `call npm run ...` in the wrapper depends on.
+    expect(runAs.toUpperCase()).not.toBe('SYSTEM');
+    // S4U ("no stored password") logon — non-interactive, session 0, no console window.
+    expect(args).toContain('/NP');
+  });
+
+  it('honors an explicit --ru override (e.g. SYSTEM) and skips /NP for well-known service accounts', () => {
+    const args = buildSchtasksArgs({ wrapperPath: 'x', runAs: 'SYSTEM' });
+    expect(args[args.indexOf('/RU') + 1]).toBe('SYSTEM');
+    expect(args).not.toContain('/NP');
+  });
+
+  it('honors an explicit --ru override to a named user and still appends /NP', () => {
+    const args = buildSchtasksArgs({ wrapperPath: 'x', runAs: 'CUSTOMUSER' });
+    expect(args[args.indexOf('/RU') + 1]).toBe('CUSTOMUSER');
+    expect(args).toContain('/NP');
+  });
+
   it('honors a custom interval and rejects an invalid one', () => {
     expect(buildSchtasksArgs({ wrapperPath: 'x', intervalMinutes: 3 }).join(' ')).toContain('/MO 3');
     expect(() => buildSchtasksArgs({ wrapperPath: 'x', intervalMinutes: 0 })).toThrow();
@@ -212,6 +242,7 @@ describe('FR-1 setup-eva-watcher-task builders', () => {
     expect(parseTaskArgs(['node', 'x', '--remove']).mode).toBe('remove');
     expect(parseTaskArgs(['node', 'x', '--status']).mode).toBe('status');
     expect(parseTaskArgs(['node', 'x', '--dry-run']).dryRun).toBe(true);
+    expect(parseTaskArgs(['node', 'x', '--ru', 'SYSTEM']).runAs).toBe('SYSTEM');
   });
 });
 

--- a/scripts/setup-eva-watcher-task.mjs
+++ b/scripts/setup-eva-watcher-task.mjs
@@ -31,6 +31,7 @@
  */
 import 'dotenv/config';
 import fs from 'fs';
+import os from 'os';
 import path from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { execFileSync } from 'child_process';
@@ -44,6 +45,35 @@ export const TASK_ENV = Object.freeze({
   OKR_REQUIRE_ACCEPTANCE: 'true',
 });
 const DEFAULT_INTERVAL_MINUTES = 5;
+
+/**
+ * QF-20260726-677 — schtasks /Create WITHOUT /RU registers the task under the current user with
+ * Principal.LogonType=Interactive. In an attended session that materialises a visible OpenConsole.exe
+ * window on every 5-minute fire (measured: 148 orphaned zero-descendant consoles). The fix is a /RU
+ * principal, same shape as the fork at scripts/setup-reboot-respawn-task.mjs:76 — but a DIFFERENT
+ * default: that fork defaults /RU to SYSTEM (needs elevation to register, loses the user's PATH/profile,
+ * which this wrapper's `call npm run ...` depends on). This module defaults to an S4U logon as the
+ * CURRENT user instead (/RU <user> /NP): non-interactive, session 0, no window, keeps the profile/PATH,
+ * and normally needs no elevation to register. SYSTEM (or another account) remains available via --ru.
+ */
+function resolveDefaultRunAs() {
+  try {
+    return process.env.USERNAME || process.env.USER || os.userInfo().username || null;
+  } catch {
+    return null;
+  }
+}
+export const DEFAULT_RUN_AS = resolveDefaultRunAs();
+
+/** Well-known service accounts don't take /NP (S4U "no stored password") — they already run without one. */
+const WELL_KNOWN_SERVICE_ACCOUNTS = new Set([
+  'SYSTEM', 'NT AUTHORITY\\SYSTEM',
+  'LOCALSERVICE', 'LOCAL SERVICE', 'NT AUTHORITY\\LOCAL SERVICE',
+  'NETWORKSERVICE', 'NETWORK SERVICE', 'NT AUTHORITY\\NETWORK SERVICE',
+]);
+function isWellKnownServiceAccount(runAs) {
+  return typeof runAs === 'string' && WELL_KNOWN_SERVICE_ACCOUNTS.has(runAs.toUpperCase());
+}
 
 /**
  * Build the wrapper .cmd content (PURE). Sets the safety flags, cd's to the repo root, and
@@ -64,11 +94,20 @@ export function buildWrapperScript({ repoRoot, npmCommand = NPM_COMMAND, env = T
  * containing spaces). Every-N-minutes trigger via /SC MINUTE /MO <n>; /F overwrites an existing
  * task so re-running is idempotent. The /TR target is the wrapper batch (which carries the env).
  */
-export function buildSchtasksArgs({ taskName = TASK_NAME, wrapperPath, intervalMinutes = DEFAULT_INTERVAL_MINUTES, extraArgs = [] } = {}) {
+export function buildSchtasksArgs({ taskName = TASK_NAME, wrapperPath, intervalMinutes = DEFAULT_INTERVAL_MINUTES, runAs = DEFAULT_RUN_AS, extraArgs = [] } = {}) {
   if (!wrapperPath) throw new Error('buildSchtasksArgs: wrapperPath required');
   const mo = parseInt(intervalMinutes, 10);
   if (!Number.isFinite(mo) || mo < 1) throw new Error(`buildSchtasksArgs: invalid intervalMinutes ${intervalMinutes}`);
-  return ['/Create', '/TN', taskName, '/TR', wrapperPath, '/SC', 'MINUTE', '/MO', String(mo), '/F', ...extraArgs];
+  const args = ['/Create', '/TN', taskName, '/TR', wrapperPath, '/SC', 'MINUTE', '/MO', String(mo), '/F'];
+  // QF-20260726-677: without /RU, schtasks registers LogonType=Interactive and every fire opens a
+  // visible console. /RU <user> /NP is an S4U logon (non-interactive, session 0, no window, keeps the
+  // profile/PATH this wrapper's `call npm run` needs) — /NP is skipped for well-known service accounts
+  // (e.g. an explicit --ru SYSTEM override), which don't take it.
+  if (runAs) {
+    args.push('/RU', runAs);
+    if (!isWellKnownServiceAccount(runAs)) args.push('/NP');
+  }
+  return [...args, ...extraArgs];
 }
 
 export function buildRemoveArgs(taskName = TASK_NAME) {
@@ -89,18 +128,19 @@ function runSchtasks(args, { logger = console } = {}) {
 }
 
 export function parseArgs(argv) {
-  const args = { mode: 'register', dryRun: false, help: false };
+  const args = { mode: 'register', dryRun: false, help: false, runAs: undefined };
   for (let i = 2; i < argv.length; i++) {
     const a = argv[i];
     if (a === '--remove' || a === '--delete') args.mode = 'remove';
     else if (a === '--status' || a === '--query') args.mode = 'status';
     else if (a === '--dry-run') args.dryRun = true;
+    else if (a === '--ru') { args.runAs = argv[i + 1]; i++; }
     else if (a === '--help' || a === '-h') args.help = true;
   }
   return args;
 }
 
-const USAGE = 'setup-eva-watcher-task [--status|--remove|--dry-run]  (Windows Task Scheduler host for the EVA watcher)';
+const USAGE = 'setup-eva-watcher-task [--status|--remove|--dry-run] [--ru <user>]  (Windows Task Scheduler host for the EVA watcher; /RU defaults to the current user via S4U — see QF-20260726-677)';
 
 export async function main(argv = process.argv, deps = {}) {
   const args = parseArgs(argv);
@@ -135,7 +175,8 @@ export async function main(argv = process.argv, deps = {}) {
 
   // register (default): write the wrapper, then create/refresh the task.
   const wrapperContent = buildWrapperScript({ repoRoot });
-  const schtasksArgs = buildSchtasksArgs({ wrapperPath });
+  const schtasksArgs = buildSchtasksArgs({ wrapperPath, runAs: args.runAs });
+  const effectiveRunAs = args.runAs || DEFAULT_RUN_AS;
   if (args.dryRun) {
     logger.log(`${tag} DRY RUN — would write wrapper ${wrapperPath}:`);
     logger.log(wrapperContent.replace(/\r\n/g, '\n'));
@@ -156,9 +197,9 @@ export async function main(argv = process.argv, deps = {}) {
     logger.error(`${tag} schtasks /Create failed (code ${res.code}): ${res.stderr}`);
     return { exitCode: 1, action: 'create_failed' };
   }
-  logger.log(`${tag} registered '${TASK_NAME}' — every ${DEFAULT_INTERVAL_MINUTES} min → ${WRAPPER_REL_PATH}`);
+  logger.log(`${tag} registered '${TASK_NAME}' — every ${DEFAULT_INTERVAL_MINUTES} min, /RU ${effectiveRunAs || '(none — Interactive logon, will leak a console; pass --ru)'} → ${WRAPPER_REL_PATH}`);
   logger.log(`${tag} env: EVA_SCHEDULER_OBSERVE_ONLY=true OKR_REQUIRE_ACCEPTANCE=true (observe-only bring-up; full-dispatch needs chairman GO)`);
-  return { exitCode: 0, action: 'registered', wrapperPath };
+  return { exitCode: 0, action: 'registered', wrapperPath, runAs: effectiveRunAs };
 }
 
 const isMain = !!process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;


### PR DESCRIPTION
## Summary
- Fixes QF-20260726-677: the "EHG EVA Scheduler Watcher" Windows scheduled task leaked a visible, empty `OpenConsole.exe` every 5 minutes (148 accumulated with zero descendants before being reaped). `LastTaskResult=0` throughout — the task always succeeded, which is why it went unnoticed.
- Root cause (Adam re-scope, in-repo, not a host-settings item): `buildSchtasksArgs()` in `scripts/setup-eva-watcher-task.mjs` never passed `/RU` to `schtasks /Create`, so the task registered with `Principal.LogonType=Interactive`. Every 5-minute fire in an attended session materialised a console window.
- Fix: `buildSchtasksArgs` now appends `/RU <user> /NP` by default — an S4U logon (non-interactive, session 0, no window, keeps the user profile/PATH the wrapper's `call npm run ...` depends on, normally needs no elevation). The sibling fork `scripts/setup-reboot-respawn-task.mjs` defaults `/RU` to `SYSTEM`, but that requires elevation to register and drops the profile — rejected as the default here, kept available via `--ru SYSTEM` (which correctly skips `/NP` for well-known service accounts).
- The default user is resolved at runtime (`USERNAME`/`USER`/`os.userInfo()`), matching the `LogonType Interactive UserId` measured live (`rickf`) rather than being hardcoded.

## Design choice (made deliberately, per the row)
- **(a) `/RU <user> /NP`** — S4U, non-interactive, keeps profile/PATH, no elevation needed. **Chosen** (Adam's recommendation).
- **(b) `/RU SYSTEM`** — what the fork defaults to, but needs elevation and drops the user profile (breaks `npm`/`node` on PATH for the wrapper's `call npm run`). Rejected as default; still reachable via `--ru`.

## Evaluated, left out of scope
`ExecutionTimeLimit` (currently `PT72H`) has no `schtasks /Create` CLI switch — `/ET`, `/DU`, `/K` only govern the repetition trigger's end time/duration, not `Settings.ExecutionTimeLimit`. Lowering it would require switching the builder from flag-based `/Create` to a full `/XML` task definition, which widens scope beyond this Tier 1 fix. Left alone.

## Scope boundary
This PR changes only the repo builder + its test. **No live Windows scheduled task was re-registered, mutated, or reaped** as part of this work — that re-registration (`npm run eva:scheduler:setup-task`) is a separate host-mutation step for the operator (chairman) to run.

## Test plan
- [x] `npx vitest run --project unit scripts/__tests__/eva-host-and-arm.test.js tests/unit/fleet/setup-reboot-respawn-task.test.js` → **36 passed** (was 33 passed on unmodified `main`, confirmed via `git stash`; 3 new assertions added, 0 failures either state).
- [ ] Operator step (not part of this PR): re-register the task (`npm run eva:scheduler:setup-task`), then confirm `Get-ScheduledTask 'EHG EVA Scheduler Watcher' | select -expand Principal` shows `LogonType` no longer `Interactive`, and watch `OpenConsole.exe` count over ~15 min (3 fires) to confirm it does not climb. Also confirm the EvaMasterScheduler daemon the watcher spawns still runs under the new S4U session (per the row's named risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)