### PR TITLE
fix(QF-20260727-510): stop file_content_hash hashing its own generation timestamp

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-<!-- file_content_hash: 4f1026f580dbdad2 -->
+<!-- file_content_hash: 91b0c479ced58edc -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE.md - LEO Protocol Orchestrator
 
@@ -199,4 +199,4 @@ Use `*_DIGEST.md` variants only when context is constrained (e.g. smaller models
 > Sub-agent routing and background execution rules are enforced by PreToolUse hooks. See `scripts/hooks/pre-tool-enforce.cjs`.
 
 ---
-*Generated: 2026-07-27 4:05:26 AM | Protocol: LEO 4.4.1 | Source: Database*
+*Generated: 2026-07-27 1:30:53 PM | Protocol: LEO 4.4.1 | Source: Database*

--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: e9f925de912ea458 -->
+<!-- file_content_hash: a04c972e94faa021 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-07-27 4:05:26 AM
+**Generated**: 2026-07-27 1:30:53 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-27T08:05:26.344Z -->
-<!-- git_commit: 690bf02e -->
+<!-- generated_at: 2026-07-27T17:30:53.431Z -->
+<!-- git_commit: 77197c5a -->
 <!-- db_snapshot_hash: 7eabaf04b99ecbde -->
-<!-- file_content_hash: 1b1b71078e53ee40 -->
+<!-- file_content_hash: 871462a7690a79c8 -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_COORDINATOR.md
+++ b/CLAUDE_COORDINATOR.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 3f37af21c910fc7b -->
+<!-- file_content_hash: 1ca7286a566c2e34 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_COORDINATOR.md - Coordinator Role Contract
 
-**Generated**: 2026-07-27 4:05:26 AM
+**Generated**: 2026-07-27 1:30:53 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical coordinator role + SRE charter — fleet supervisor session
 **Load when**: Running /coordinator, or orienting a fleet-coordinator session

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-27T08:05:26.344Z -->
-<!-- git_commit: 690bf02e -->
+<!-- generated_at: 2026-07-27T17:30:53.431Z -->
+<!-- git_commit: 77197c5a -->
 <!-- db_snapshot_hash: 7eabaf04b99ecbde -->
-<!-- file_content_hash: c009e987736d9b55 -->
+<!-- file_content_hash: 280bee02a0e1c007 -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: fc093ac06a8367ff -->
+<!-- file_content_hash: 45dcebdbe5a0f914 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-07-27 4:05:26 AM
+**Generated**: 2026-07-27 1:30:53 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-27T08:05:26.344Z -->
-<!-- git_commit: 690bf02e -->
+<!-- generated_at: 2026-07-27T17:30:53.431Z -->
+<!-- git_commit: 77197c5a -->
 <!-- db_snapshot_hash: 7eabaf04b99ecbde -->
-<!-- file_content_hash: c73b78748a43e6e2 -->
+<!-- file_content_hash: dde4eb32e7f32eaf -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -270,5 +270,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-07-27 4:05:26 AM*
+*DIGEST generated: 2026-07-27 1:30:53 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-27T08:05:26.344Z -->
-<!-- git_commit: 690bf02e -->
+<!-- generated_at: 2026-07-27T17:30:53.431Z -->
+<!-- git_commit: 77197c5a -->
 <!-- db_snapshot_hash: 7eabaf04b99ecbde -->
-<!-- file_content_hash: 202b19d40e256a5d -->
+<!-- file_content_hash: 56be33b0069b2965 -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -159,5 +159,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-07-27 4:05:26 AM*
+*DIGEST generated: 2026-07-27 1:30:53 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 8814b0f0e1dcb35d -->
+<!-- file_content_hash: 79a659fde755f087 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-07-27 4:05:26 AM
+**Generated**: 2026-07-27 1:30:53 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-27T08:05:26.344Z -->
-<!-- git_commit: 690bf02e -->
+<!-- generated_at: 2026-07-27T17:30:53.431Z -->
+<!-- git_commit: 77197c5a -->
 <!-- db_snapshot_hash: 7eabaf04b99ecbde -->
-<!-- file_content_hash: 7c5859485147fd9f -->
+<!-- file_content_hash: 99c578d3ca799133 -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-07-27 4:05:26 AM*
+*DIGEST generated: 2026-07-27 1:30:53 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: e8bc1593768eeee6 -->
+<!-- file_content_hash: 27ce8adce69b5c66 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-07-27 4:05:26 AM
+**Generated**: 2026-07-27 1:30:53 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-27T08:05:26.344Z -->
-<!-- git_commit: 690bf02e -->
+<!-- generated_at: 2026-07-27T17:30:53.431Z -->
+<!-- git_commit: 77197c5a -->
 <!-- db_snapshot_hash: 7eabaf04b99ecbde -->
-<!-- file_content_hash: b57fb5b4fd05104e -->
+<!-- file_content_hash: 42b407cb2b032a1c -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-07-27 4:05:26 AM*
+*DIGEST generated: 2026-07-27 1:30:53 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 4ef15486eef14b9b -->
+<!-- file_content_hash: dbae9fb2248615d5 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-07-27 4:05:26 AM
+**Generated**: 2026-07-27 1:30:53 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-27T08:05:26.344Z -->
-<!-- git_commit: 690bf02e -->
+<!-- generated_at: 2026-07-27T17:30:53.431Z -->
+<!-- git_commit: 77197c5a -->
 <!-- db_snapshot_hash: 7eabaf04b99ecbde -->
-<!-- file_content_hash: 7f44b23bf6bd5d6a -->
+<!-- file_content_hash: bfe9c6450c713021 -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-07-27 4:05:26 AM*
+*DIGEST generated: 2026-07-27 1:30:53 PM*
 *Protocol: 4.4.1*

--- a/CLAUDE_SOLOMON.md
+++ b/CLAUDE_SOLOMON.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: bd80e985b1108630 -->
+<!-- file_content_hash: 942f3514fa1e54b1 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_SOLOMON.md - Solomon Role Contract
 
-**Generated**: 2026-07-27 4:05:26 AM
+**Generated**: 2026-07-27 1:30:53 PM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Solomon oracle role contract — deep-reasoning session
 **Load when**: Running /solomon, or orienting a deep-reasoning oracle session

--- a/CLAUDE_SOLOMON_DIGEST.md
+++ b/CLAUDE_SOLOMON_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-07-27T08:05:26.344Z -->
-<!-- git_commit: 690bf02e -->
+<!-- generated_at: 2026-07-27T17:30:53.431Z -->
+<!-- git_commit: 77197c5a -->
 <!-- db_snapshot_hash: 7eabaf04b99ecbde -->
-<!-- file_content_hash: ae14e949d9f24c60 -->
+<!-- file_content_hash: e3e04fbe3eb8561b -->
 
 # CLAUDE_SOLOMON_DIGEST.md - Solomon Role (Oracle)
 

--- a/scripts/modules/claude-md-generator/index.js
+++ b/scripts/modules/claude-md-generator/index.js
@@ -269,14 +269,15 @@ class CLAUDEMDGeneratorV3 {
       content = `${GENERATED_BANNER}\n${content}`;
     }
 
-    // file_content_hash: body = content minus the hash line; header = sha256(body)[:16].
+    // file_content_hash: body = content minus every VOLATILE line (see stripVolatileLines);
+    // header = sha256(body)[:16]. QF-20260727-510 — the hash previously excluded only its own
+    // line, so the generation timestamp sat INSIDE the hashed region and the hash could never
+    // answer "did the content actually change?" with no. The guard defeated itself.
     const HASH_LINE_RE = /^<!-- file_content_hash: [^>]*-->\r?\n/m;
+    const bodyHash = this.computeHash(stripVolatileLines(content));
     if (HASH_LINE_RE.test(content)) {
-      const body = content.replace(HASH_LINE_RE, '');
-      const bodyHash = this.computeHash(body);
       content = content.replace(HASH_LINE_RE, `<!-- file_content_hash: ${bodyHash} -->\n`);
     } else {
-      const bodyHash = this.computeHash(content);
       content = `<!-- file_content_hash: ${bodyHash} -->\n${content}`;
     }
     return content;
@@ -377,9 +378,37 @@ class CLAUDEMDGeneratorV3 {
     // (FR-5 banner + file_content_hash injection) — byte-identical to renderAll()'s
     // output, so the drift check can never diverge from what is written here.
     const content = this.renderFileContent(generatorFn, data);
-    const contentHash = this.computeHash(content);
+    // QF-20260727-510 (c): hash the STRIPPED body, not the raw render. This value is stored as
+    // the manifest's per-file content_hash, and hashing the timestamped render made all 16
+    // entries change on every run — which churned the manifest even once the .md files
+    // themselves had stopped moving. Measured: two consecutive runs differed ONLY in
+    // generated_at and all 16 content_hash values. Same input as the header hash, so the two
+    // now agree by construction instead of by coincidence.
+    const contentHash = this.computeHash(stripVolatileLines(content));
 
-    writeFileAtomic(filePath, content);
+    // QF-20260727-510 (b) — SKIP THE WRITE when the substantive body is unchanged.
+    //
+    // (a) alone makes the hash HONEST; it does not stop the churn, because the rendered
+    // content still carries a fresh timestamp and writing it still dirties the file. This is
+    // the half that actually keeps the shared root clean: regeneration with no DB change
+    // becomes a true no-op, so `git status --porcelain` stays clean, shared-root-freshness can
+    // pull again, and tree-currency stops refusing spawns from an un-healable tree.
+    //
+    // Compared on the STRIPPED body, so a differing timestamp alone is not a reason to write.
+    // Fail-OPEN by design: any read problem (missing file, unreadable, first generation) falls
+    // through to the write. A generator that silently skipped writing because it could not read
+    // the old file would be a far worse defect than an extra write.
+    let unchanged = false;
+    try {
+      if (fs.existsSync(filePath)) {
+        const onDisk = fs.readFileSync(filePath, 'utf-8');
+        unchanged = this.computeHash(stripVolatileLines(onDisk)) === this.computeHash(stripVolatileLines(content));
+      }
+    } catch {
+      unchanged = false; // unreadable -> write
+    }
+
+    if (!unchanged) writeFileAtomic(filePath, content);
 
     const size = (content.length / 1024).toFixed(1);
     const charCount = content.length;
@@ -402,7 +431,58 @@ class CLAUDEMDGeneratorV3 {
    */
   writeManifest() {
     const manifestPath = path.join(this.baseDir, 'claude-generation-manifest.json');
-    writeFileAtomic(manifestPath, JSON.stringify(this.manifest, null, 2));
+
+    // QF-20260727-510 (c) — the manifest churned 34+34 lines per run for the same reason the
+    // .md files did: it stores the self-invalidating hashes plus its own volatile stamps. With
+    // (a) the per-file hashes are now stable, so the only remaining churn is metadata that
+    // carries no information about whether the protocol content changed.
+    //
+    // `path` is included in the ignore set deliberately, and it is NOT in the row: the manifest
+    // records ABSOLUTE paths, so regenerating from any linked worktree rewrites all 16 of them
+    // to that worktree's location and dirties the tracked file in the shared root. Comparing
+    // without them stops a worktree run from claiming the shared root's manifest. The values are
+    // still written whenever a real change lands; they are only excluded from the "did anything
+    // meaningful change?" decision.
+    //
+    // Same fail-OPEN posture as the file write: any read/parse problem falls through to writing.
+    // Canonical (key-ORDER-independent) serialisation. JSON.stringify preserves insertion
+    // order, so the parsed on-disk object and the freshly-built one can hold identical content
+    // yet stringify differently — which silently defeated the skip on the first attempt and
+    // rewrote the manifest every run for a differing `generated_at` alone. Sort keys so the
+    // comparison is about CONTENT, not construction order.
+    const canonical = (v) => {
+      if (Array.isArray(v)) return `[${v.map(canonical).join(',')}]`;
+      if (v && typeof v === 'object') {
+        return `{${Object.keys(v).sort().map((k) => `${JSON.stringify(k)}:${canonical(v[k])}`).join(',')}}`;
+      }
+      return JSON.stringify(v);
+    };
+    const stripManifestVolatile = (m) => {
+      try {
+        const { generated_at: _g, git_commit: _c, ...rest } = m || {};
+        const files = Object.fromEntries(
+          Object.entries(rest.files || {}).map(([k, v]) => {
+            const { path: _p, ...fileRest } = v || {};
+            return [k, fileRest];
+          }),
+        );
+        return canonical({ ...rest, files });
+      } catch { return null; }
+    };
+
+    let manifestUnchanged = false;
+    try {
+      if (fs.existsSync(manifestPath)) {
+        const onDisk = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+        const a = stripManifestVolatile(onDisk);
+        const b = stripManifestVolatile(this.manifest);
+        manifestUnchanged = a !== null && b !== null && a === b;
+      }
+    } catch {
+      manifestUnchanged = false;
+    }
+
+    if (!manifestUnchanged) writeFileAtomic(manifestPath, JSON.stringify(this.manifest, null, 2));
     console.log('\nManifest written: claude-generation-manifest.json');
   }
 }
@@ -463,12 +543,61 @@ export function computeSectionDigests(sections) {
   return { global, byId, meta };
 }
 
+/**
+ * QF-20260727-510 — strip every line whose value changes on EVERY regeneration regardless of
+ * whether the DB content changed, so file_content_hash means what it claims: "did the
+ * substantive body change?"
+ *
+ * THE SELF-DEFEATING GUARD THIS FIXES. The hash previously excluded only its own line, so the
+ * generation timestamp was INSIDE the hashed region. Every regeneration therefore produced a
+ * different hash even when the protocol text was byte-identical, which dirtied ~17 tracked
+ * files (CLAUDE.md + the CLAUDE_* family + their _DIGEST siblings + the manifest) on every run.
+ *
+ * THAT NOISE BROKE TWO SAFETY MECHANISMS AND ONE OPERATOR ACTION:
+ *   - shared-root-freshness pulls only when `git status --porcelain` is clean, so it could
+ *     NEVER pull and the shared root could not self-heal;
+ *   - tree-currency refuses to spawn from a stale tree that is not safely healable, and
+ *     dirty=true is exactly what makes it unhealable;
+ *   - observed live: the chairman clicked "Start the coordinator" and got
+ *     "[tree-currency] REFUSED ... NOT safely healable (dirty=true)". The guard was working
+ *     correctly on a tree a generator had made permanently un-healable.
+ *
+ * The line shapes below were ENUMERATED FROM THE LIVE GENERATED FILES, not guessed:
+ *   <!-- file_content_hash: … -->   the hash's own line (cannot hash itself)
+ *   <!-- generated_at: … -->        DIGEST header timestamp
+ *   <!-- git_commit: … -->          DIGEST header commit stamp — changes with HEAD, not content
+ *   **Generated**: …                CLAUDE_CORE and siblings
+ *   *DIGEST generated: …*           DIGEST footer
+ *   *Generated: … | Protocol: … | Source: Database*   CLAUDE.md footer
+ *
+ * The timestamp is deliberately NOT removed from the files — the row forbids that without
+ * checking readers. It stays visible; it simply stops being hashed.
+ *
+ * MUST be shared by the compute and verify sides. If they ever strip different sets, the drift
+ * check (scripts/check-claude-md-drift.cjs) reports drift on every file forever.
+ */
+const VOLATILE_LINE_RE = new RegExp(
+  [
+    String.raw`^<!-- file_content_hash: [^>]*-->\r?\n?`,
+    String.raw`^<!-- generated_at: [^>]*-->\r?\n?`,
+    String.raw`^<!-- git_commit: [^>]*-->\r?\n?`,
+    String.raw`^\*\*Generated\*\*:.*\r?\n?`,
+    String.raw`^\*DIGEST generated:.*\r?\n?`,
+    String.raw`^\*Generated:.*\r?\n?`,
+  ].join('|'),
+  'gm',
+);
+
+export function stripVolatileLines(content) {
+  return String(content == null ? '' : content).replace(VOLATILE_LINE_RE, '');
+}
+
 export function verifyFileContentHash(filePath) {
   const content = fs.readFileSync(filePath, 'utf-8');
   const m = content.match(/^<!-- file_content_hash: ([0-9a-f]{16}) -->\r?\n/m);
   if (!m) return { ok: false, expected: null, actual: null };
-  const body = content.replace(/^<!-- file_content_hash: [^>]*-->\r?\n/m, '');
-  const expected = crypto.createHash('sha256').update(body).digest('hex').substring(0, 16);
+  // Same stripping as the compute side — see stripVolatileLines. These MUST agree.
+  const expected = crypto.createHash('sha256').update(stripVolatileLines(content)).digest('hex').substring(0, 16);
   return { ok: expected === m[1], expected, actual: m[1] };
 }
 

--- a/tests/claude-md-generator/content-hash-timestamp-blindness.test.js
+++ b/tests/claude-md-generator/content-hash-timestamp-blindness.test.js
@@ -1,0 +1,94 @@
+/**
+ * QF-20260727-510 — file_content_hash must be BLIND to the generation timestamp.
+ *
+ * THE SELF-DEFEATING GUARD. The hash exists precisely to answer "did the content actually
+ * change?" — and it was computed over a region that included the `Generated:` timestamp, so it
+ * was structurally incapable of ever answering "no". Every regeneration dirtied ~17 tracked
+ * files (CLAUDE.md + the CLAUDE_* family + their _DIGEST siblings + the manifest) even when the
+ * protocol text was byte-identical.
+ *
+ * That noise broke two safety mechanisms and one operator action:
+ *   - shared-root-freshness pulls only when `git status --porcelain` is clean, so it could
+ *     NEVER pull and the shared root could not self-heal;
+ *   - tree-currency refuses to spawn from a stale tree that is not safely healable, and
+ *     dirty=true is what makes it unhealable;
+ *   - observed live: the chairman clicked "Start the coordinator" and got
+ *     "[tree-currency] REFUSED ... NOT safely healable (dirty=true)".
+ *
+ * This records the decision QF-20260726-423(b) deliberately left open: the ROOT SHOULD NOT BE
+ * DIRTY. The dominant cause was a two-line generator artifact carrying zero information — not
+ * real work in progress — so relaxing the spawn guard would have weakened a real protection to
+ * accommodate noise.
+ */
+import { describe, it, expect } from 'vitest';
+import crypto from 'crypto';
+import { stripVolatileLines } from '../../scripts/modules/claude-md-generator/index.js';
+
+const sha16 = (s) => crypto.createHash('sha256').update(s).digest('hex').substring(0, 16);
+
+/** A file shaped like the real generated output, parameterised on the volatile values. */
+function renderLike({ stamp, isoStamp, commit, hash = 'deadbeefdeadbeef' }) {
+  return [
+    `<!-- file_content_hash: ${hash} -->`,
+    `<!-- generated_at: ${isoStamp} -->`,
+    `<!-- git_commit: ${commit} -->`,
+    '<!-- GENERATED FILE - DO NOT EDIT DIRECTLY. -->',
+    '# CLAUDE.md - LEO Protocol Orchestrator',
+    '',
+    'Substantive protocol body that did NOT change.',
+    '',
+    `**Generated**: ${stamp}`,
+    `*DIGEST generated: ${stamp}*`,
+    `*Generated: ${stamp} | Protocol: LEO 4.4.1 | Source: Database*`,
+    '',
+  ].join('\n');
+}
+
+const A = renderLike({ stamp: '2026-07-27 4:05:26 AM', isoStamp: '2026-07-27T08:05:26.344Z', commit: '690bf02e' });
+const B = renderLike({ stamp: '2026-07-27 5:58:59 AM', isoStamp: '2026-07-27T09:58:59.494Z', commit: '36f8a75b', hash: 'cafecafecafecafe' });
+
+describe('stripVolatileLines — every shape enumerated from the LIVE files', () => {
+  it('removes all six volatile line shapes', () => {
+    const out = stripVolatileLines(A);
+    expect(out).not.toMatch(/file_content_hash/);
+    expect(out).not.toMatch(/generated_at/);
+    expect(out).not.toMatch(/git_commit/);
+    expect(out).not.toMatch(/\*\*Generated\*\*:/);
+    expect(out).not.toMatch(/DIGEST generated:/);
+    expect(out).not.toMatch(/^\*Generated:/m);
+  });
+
+  it('KEEPS the substantive body — this is a hashing change, not a content change', () => {
+    const out = stripVolatileLines(A);
+    expect(out).toMatch(/# CLAUDE\.md - LEO Protocol Orchestrator/);
+    expect(out).toMatch(/Substantive protocol body that did NOT change\./);
+    expect(out).toMatch(/GENERATED FILE - DO NOT EDIT DIRECTLY/); // the banner is NOT volatile
+  });
+
+  it('THE POINT: two renders differing ONLY in timestamps hash identically', () => {
+    expect(A).not.toBe(B);                                  // raw bytes differ
+    expect(sha16(stripVolatileLines(A))).toBe(sha16(stripVolatileLines(B)));
+  });
+
+  it('a REAL content change still changes the hash — the guard is narrowed, not disabled', () => {
+    const changed = A.replace('Substantive protocol body that did NOT change.', 'A real protocol edit.');
+    expect(sha16(stripVolatileLines(A))).not.toBe(sha16(stripVolatileLines(changed)));
+  });
+
+  it('is total on empty/nullish input (never throws inside a write path)', () => {
+    expect(stripVolatileLines('')).toBe('');
+    expect(stripVolatileLines(null)).toBe('');
+    expect(stripVolatileLines(undefined)).toBe('');
+  });
+
+  it('handles CRLF, since these files are generated on Windows', () => {
+    const crlf = A.replace(/\n/g, '\r\n');
+    expect(stripVolatileLines(crlf)).not.toMatch(/\*\*Generated\*\*:/);
+    expect(stripVolatileLines(crlf)).toMatch(/Substantive protocol body/);
+  });
+
+  it('does not strip a body line that merely MENTIONS a volatile key mid-sentence', () => {
+    const body = 'The file_content_hash exists to answer whether content changed.\n';
+    expect(stripVolatileLines(body)).toBe(body); // anchored at line start, not a substring match
+  });
+});


### PR DESCRIPTION
## Summary

`file_content_hash` exists precisely to answer *"did the content actually change?"* — and it was computed over a region that **included the generation timestamp**, so it was structurally incapable of ever answering no. Every regeneration dirtied ~17 tracked files even when the protocol text was byte-identical. The guard defeated itself.

## Why this wasn't cosmetic

It broke two safety mechanisms and one operator action:

- **shared-root-freshness** pulls only when `git status --porcelain` is clean → it could **never** pull, and the shared root could not self-heal
- **tree-currency** refuses to spawn from a stale tree that isn't safely healable, and `dirty=true` is exactly what makes it unhealable
- **Observed live:** the chairman clicked "Start the coordinator" and got `[tree-currency] REFUSED … NOT safely healable (dirty=true)`. The guard was working correctly on a tree a *generator* had made permanently un-healable. The operator experienced it as "the button is broken".

## Records the decision QF-20260726-423(b) left open

That row asked which side is wrong and said to decide explicitly rather than silently relax the guard. **The root should not be dirty.** The dominant cause was a two-line generator artifact carrying zero information — not real work in progress. Relaxing tree-currency would have removed a protection that exists *because* executing from a stale tree has already shipped inert defects, and relaxed it to accommodate noise.

## The fix

**(a) Hash the substantive body.** `stripVolatileLines()` removes six volatile shapes, each **enumerated from the live files** rather than guessed: the hash's own line, `generated_at`, `git_commit`, `**Generated**:`, `*DIGEST generated:*`, and CLAUDE.md's `*Generated: … | Protocol: …*` footer. Shared by compute **and** verify — if they ever strip different sets, the drift check reports drift on every file forever. The timestamp is **not** removed from the files (the row forbids that without checking readers); it stays visible and simply stops being hashed.

**(b) Skip the write** when the stripped body is unchanged. (a) alone makes the hash honest but doesn't stop the churn — the render still carries a fresh timestamp. This is the half that keeps the root clean. **Fail-open**: any read problem falls through to writing, because a generator that silently skipped writing would be far worse than an extra write.

**(c) The manifest — two bugs, the second found only by measuring.** Its per-file `content_hash` was computed over the raw timestamped render, so all 16 entries changed every run *even after the `.md` files had stabilised*. It now hashes the stripped body, agreeing with the header hash by construction. And the comparison is canonical (key-sorted): `JSON.stringify` is insertion-order sensitive, which silently defeated the skip on my first attempt. `path` is excluded from the comparison — **not in the row**, but the manifest stores absolute paths, so regenerating from any worktree rewrote all 16 and dirtied the shared root's tracked file.

## Verified by running it

Three consecutive regenerations leave the dirty count identical and `CLAUDE.md` / `CLAUDE_CORE_DIGEST.md` / the manifest **byte-identical**. Regeneration with no DB change is now a true no-op. `check-claude-md-drift.cjs` passes (exit 0) — the check that fails first if compute and verify disagree.

## What's included, and what isn't

The 16 regenerated `.md` files **are** included: their committed hashes were computed the old way and must be rewritten once with honest values, or the first regeneration anywhere dirties them again. Verified their diffs contain **only** hash/timestamp lines.

The manifest is **deliberately excluded**: this worktree's copy embeds worktree-absolute paths and committing it would bake them in. It gets rewritten once, correctly, by the next shared-root regeneration.

**Not sufficient alone**, per the row: three genuinely-modified tracked files remain in the shared root (`registry.json`, `session-state.md`, a migration). Those need human triage — but they're a handful, not 17 files of noise that regenerate the moment they're reverted.

## Test plan

- [x] All six volatile shapes stripped; substantive body preserved (banner is *not* volatile)
- [x] **Core property**: two renders differing only in timestamps hash identically
- [x] A **real** content change still changes the hash — the guard is narrowed, not disabled
- [x] CRLF (these are generated on Windows), nullish input, and a body line merely *mentioning* a volatile key
- [x] 22/22 across generator + drift suites; drift check exit 0
- [x] Idempotence proven across 3 live regenerations

🤖 Generated with [Claude Code](https://claude.com/claude-code)