### PR TITLE
fix(QF-20260727-574): v_active_sessions fanned out — the sessions page rendered a session twice

### DIFF
--- a/database/migrations/20260727_v_active_sessions_no_qf_fanout.sql
+++ b/database/migrations/20260727_v_active_sessions_no_qf_fanout.sql
@@ -1,0 +1,138 @@
+-- 20260727_v_active_sessions_no_qf_fanout.sql
+-- QF-20260727-574 — the sessions page rendered a session TWICE.
+--
+-- THE FAN-OUT. v_active_sessions joined quick_fixes with a plain LEFT JOIN on
+-- claiming_session_id. A LEFT JOIN against a NON-UNIQUE right side multiplies rows: one session
+-- holding N open-or-in_progress quick fixes produced N rows for that session, and
+-- server/routes/fleet-panel.js reads this view, so the chairman's page rendered that session N times.
+--
+-- MEASURED LIVE BEFORE CHANGING ANYTHING, and the correspondence was exact: at 2026-07-27T21:38:42Z
+-- exactly ONE session held more than one qualifying quick fix (b25ec3e5, 2 of them), and exactly
+-- that same session was the ONLY duplicated session_id in the view (2 rows). The fan-out set equals
+-- the multi-QF set — causal, not merely correlated.
+--
+-- WHY NOT A BARE EXISTS, WHICH IS WHAT THE TICKET PRESCRIBED. The ticket said qf_active "is used
+-- only to compute idle-vs-active in a CASE expression". Reading the view says otherwise: qf_active
+-- also PROJECTS THREE OUTPUT COLUMNS — qf_id, qf_title, qf_status. Replacing it with EXISTS would
+-- have silently dropped them, and they have live consumers:
+--   scripts/modules/sd-next/display/claim-formatters.js:43,49 renders [QF] ${s.qf_title || s.qf_id}
+--   scripts/sd-start.js:257 selects qf_id, qf_title from this view
+-- So the correct shape preserves the columns while refusing to multiply rows.
+--
+-- LEFT JOIN LATERAL ... LIMIT 1 does exactly that: at most one qf_active row per session, all three
+-- columns intact, and the computed_status CASE (which tests qf_active.id IS NULL) keeps its meaning
+-- because "at least one qualifying QF exists" is still expressed faithfully.
+--
+-- THE ORDERING IS DETERMINISTIC ON PURPOSE. Without a total order the view could pick a different
+-- quick fix between renders and the page would flicker between titles for no reason. in_progress
+-- sorts first because that is the one actually being worked; created_at then id break every
+-- remaining tie, and id is unique, so the choice is stable.
+--
+-- NOT FIXED DOWNSTREAM WITH DISTINCT. A DISTINCT in fleet-panel.js would hide the fan-out from that
+-- one caller while leaving it live for every other consumer of this view — the ticket names this
+-- and it is right.
+--
+-- OUT OF SCOPE, recorded so it is not mistaken for part of this change: the view returns 5,922 rows
+-- because its WHERE is cs.status <> 'released' — i.e. every non-released session ever, with
+-- "active" as a COMPUTED COLUMN rather than a filter. That is a naming/contract question, separately
+-- handed over unclassified, and is deliberately NOT touched here.
+
+CREATE OR REPLACE VIEW public.v_active_sessions AS
+ SELECT _v.id,
+    _v.session_id,
+    _v.sd_id,
+    _v.sd_key,
+    _v.sd_title,
+    _v.qf_id,
+    _v.qf_title,
+    _v.qf_status,
+    _v.track,
+    _v.tty,
+    _v.pid,
+    _v.hostname,
+    _v.codebase,
+    _v.current_branch,
+    _v.machine_id,
+    _v.terminal_id,
+    _v.terminal_identity,
+    _v.claimed_at,
+    _v.heartbeat_at,
+    _v.status,
+    _v.released_reason,
+    _v.released_at,
+    _v.stale_reason,
+    _v.stale_at,
+    _v.metadata,
+    _v.created_at,
+    _v.heartbeat_age_seconds,
+    _v.heartbeat_age_minutes,
+    _v.seconds_until_stale,
+    _v.computed_status,
+    _v.claim_duration_minutes,
+    _v.heartbeat_age_human,
+    _v.is_virtual,
+    _v.parent_session_id,
+    _cs.loop_state,
+    _cs.is_alive,
+    _cs.has_uncommitted_changes
+   FROM ( SELECT cs.id,
+            cs.session_id,
+            cs.sd_key AS sd_id,
+            cs.sd_key,
+            COALESCE(sd.title, qf.title::character varying) AS sd_title,
+            qf_active.id AS qf_id,
+            qf_active.title AS qf_title,
+            qf_active.status AS qf_status,
+            cs.track,
+            cs.tty,
+            cs.pid,
+            cs.hostname,
+            cs.codebase,
+            cs.current_branch,
+            cs.machine_id,
+            cs.terminal_id,
+            cs.terminal_identity,
+            cs.claimed_at,
+            cs.heartbeat_at,
+            cs.status,
+            cs.released_reason,
+            cs.released_at,
+            cs.stale_reason,
+            cs.stale_at,
+            cs.metadata,
+            cs.created_at,
+            EXTRACT(epoch FROM now() - cs.heartbeat_at) AS heartbeat_age_seconds,
+            EXTRACT(epoch FROM now() - cs.heartbeat_at) / 60.0 AS heartbeat_age_minutes,
+            GREATEST(0::numeric, 600.0 - EXTRACT(epoch FROM now() - cs.heartbeat_at)) AS seconds_until_stale,
+                CASE
+                    WHEN cs.status = 'released'::text THEN 'released'::text
+                    WHEN cs.status = 'stale'::text THEN 'stale'::text
+                    WHEN EXTRACT(epoch FROM now() - cs.heartbeat_at) > 600::numeric THEN 'stale'::text
+                    WHEN cs.sd_key IS NULL AND qf_active.id IS NULL THEN 'idle'::text
+                    ELSE 'active'::text
+                END AS computed_status,
+                CASE
+                    WHEN cs.claimed_at IS NOT NULL THEN EXTRACT(epoch FROM now() - cs.claimed_at) / 60.0
+                    ELSE NULL::numeric
+                END AS claim_duration_minutes,
+                CASE
+                    WHEN EXTRACT(epoch FROM now() - cs.heartbeat_at) < 60::numeric THEN EXTRACT(epoch FROM now() - cs.heartbeat_at)::integer || 's ago'::text
+                    WHEN EXTRACT(epoch FROM now() - cs.heartbeat_at) < 3600::numeric THEN (EXTRACT(epoch FROM now() - cs.heartbeat_at) / 60.0)::integer || 'm ago'::text
+                    ELSE (EXTRACT(epoch FROM now() - cs.heartbeat_at) / 3600.0)::integer || 'h ago'::text
+                END AS heartbeat_age_human,
+            cs.is_virtual,
+            cs.parent_session_id
+           FROM claude_sessions cs
+             LEFT JOIN strategic_directives_v2 sd ON cs.sd_key = sd.sd_key
+             LEFT JOIN quick_fixes qf ON cs.sd_key = qf.id
+             LEFT JOIN LATERAL (
+                            SELECT q.id, q.title, q.status
+                              FROM quick_fixes q
+                             WHERE q.claiming_session_id = cs.session_id
+                               AND q.status = ANY (ARRAY['open'::text, 'in_progress'::text])
+                             ORDER BY (q.status = 'in_progress'::text) DESC, q.created_at ASC, q.id ASC
+                             LIMIT 1
+                          ) qf_active ON true
+          WHERE cs.status <> 'released'::text
+          ORDER BY cs.track, cs.claimed_at DESC) _v
+     LEFT JOIN claude_sessions _cs ON _cs.session_id = _v.session_id;

--- a/scripts/one-off/verify-v-active-sessions-no-fanout.mjs
+++ b/scripts/one-off/verify-v-active-sessions-no-fanout.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Verify the DEPLOYED v_active_sessions does not fan out. QF-20260727-574.
+ *
+ * WHY A SCRIPT AND NOT A VITEST TEST: the db project resolves to ZERO files unless a designated
+ * non-prod target is named, so a "live" vitest check would report green having executed nothing —
+ * the same lie in a different costume. The migration file being correct is also not the claim;
+ * the claim is about the view that is actually deployed.
+ *
+ * IT CHECKS THE PROPERTY, NOT THE TEXT. A definition grep would pass on a view whose SQL contains
+ * LATERAL but still multiplies for some other reason. This counts rows.
+ *
+ * Read-only. Usage: node scripts/one-off/verify-v-active-sessions-no-fanout.mjs
+ */
+import 'dotenv/config';
+import pg from 'pg';
+
+async function main() {
+  const conn = process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL;
+  if (!conn) { console.error('FAIL: SUPABASE_POOLER_URL or DATABASE_URL required.'); process.exit(2); }
+  const client = new pg.Client({ connectionString: conn });
+  await client.connect();
+  let failed = 0;
+  try {
+    const at = (await client.query(`SELECT now() AT TIME ZONE 'utc' t`)).rows[0].t.toISOString();
+    console.log(`measured_at_utc=${at}`);
+
+    // 1. THE PROPERTY: one row per session, always.
+    const dup = await client.query(
+      `SELECT session_id, count(*)::int n FROM v_active_sessions GROUP BY 1 HAVING count(*) > 1`,
+    );
+    console.log(`${dup.rowCount === 0 ? 'PASS' : 'FAIL'}  one row per session (duplicated session_ids: ${dup.rowCount})`);
+    if (dup.rowCount > 0) { failed += 1; dup.rows.slice(0, 5).forEach((r) => console.log(`        ${r.session_id} -> ${r.n}`)); }
+
+    // 2. THE NEGATIVE CONTROL. If NO session currently holds >1 qualifying QF, check 1 passes
+    //    vacuously — it would pass against the OLD fanning-out view too. Say so rather than
+    //    reporting a green that proves nothing.
+    const multi = await client.query(
+      `SELECT count(*)::int n FROM (SELECT claiming_session_id FROM quick_fixes
+         WHERE status IN ('open','in_progress') AND claiming_session_id IS NOT NULL
+         GROUP BY 1 HAVING count(*) > 1) x`,
+    );
+    const exercised = multi.rows[0].n > 0;
+    console.log(`${exercised ? 'PASS' : 'WARN'}  the check is EXERCISED (sessions holding >1 qualifying QF: ${multi.rows[0].n})`);
+    if (!exercised) {
+      console.log('        No session currently fans out, so check 1 cannot distinguish fixed from unfixed.');
+      console.log('        This is a VACUOUS pass, not evidence. Re-run when a session holds 2+ open/in_progress QFs.');
+    }
+
+    // 3. The columns the fix had to preserve — a bare EXISTS would have dropped these, and
+    //    claim-formatters.js / sd-start.js read them.
+    const cols = await client.query(
+      `SELECT string_agg(column_name, ',' ORDER BY column_name) c FROM information_schema.columns
+        WHERE table_schema='public' AND table_name='v_active_sessions'
+          AND column_name IN ('qf_id','qf_title','qf_status')`,
+    );
+    const got = cols.rows[0].c || '';
+    const ok = ['qf_id', 'qf_status', 'qf_title'].every((k) => got.includes(k));
+    console.log(`${ok ? 'PASS' : 'FAIL'}  qf_id/qf_title/qf_status preserved (${got || 'none'})`);
+    if (!ok) failed += 1;
+  } finally {
+    await client.end();
+  }
+  console.log(failed === 0
+    ? '\nDEPLOYED v_active_sessions returns one row per session (checked by COUNTING, not by reading the definition).'
+    : `\n${failed} check(s) FAILED — the view still fans out, or lost a projected column.`);
+  process.exit(failed === 0 ? 0 : 1);
+}
+
+main().catch((e) => { console.error(`FAIL: ${e.message}`); process.exit(1); });


### PR DESCRIPTION
## Summary

**Chairman-visible.** The fleet sessions page rendered one session twice with identical values on both rows.

`v_active_sessions` joined `quick_fixes` with a plain `LEFT JOIN` on `claiming_session_id`. A `LEFT JOIN` against a **non-unique** right side multiplies rows — a session holding N open/in_progress quick fixes produced N rows, and `server/routes/fleet-panel.js` reads this view.

**Measured before changing anything, and the correspondence was exact.** At `2026-07-27T21:38:42Z`: exactly **one** session held more than one qualifying quick fix (`b25ec3e5`, 2 of them), and exactly that same session was the **only** duplicated `session_id` in the view. The fan-out set *equals* the multi-QF set — causal, not merely correlated.

## The ticket's prescribed fix was wrong and would have broken two consumers

The ticket said `qf_active` *"is used only to compute idle-vs-active in a CASE expression"* — so replace the join with `EXISTS`. Reading the view says otherwise: `qf_active` also **projects three output columns**, and they have live readers:

| column | consumer |
|---|---|
| `qf_title`, `qf_id` | `scripts/modules/sd-next/display/claim-formatters.js:43,49` — renders `[QF] ${s.qf_title \|\| s.qf_id}` |
| `qf_id`, `qf_title` | `scripts/sd-start.js:257` — selects them from this view |

A bare `EXISTS` would have silently dropped them. The fan-out diagnosis was right; the prescribed *shape* was not, and following it literally would have traded a visible duplicate row for two quieter breakages.

`LEFT JOIN LATERAL … LIMIT 1` keeps both properties: at most one `qf_active` row per session, all three columns intact, and the `computed_status` CASE (which tests `qf_active.id IS NULL`) keeps its exact meaning.

**The ordering is deterministic on purpose** — without a total order the view could pick a different quick fix between renders and the page would flicker between titles. `in_progress` sorts first (it's the one actually being worked), then `created_at`, then `id`, which is unique.

**Not fixed downstream with `DISTINCT`** in `fleet-panel.js` — that hides the fan-out from one caller while leaving it live for every other consumer.

## ⚠️ Not applied — needs a chairman apply-GO

`CREATE OR REPLACE VIEW` is classified **not delegatable** (`not_tier1:unrecognized_or_unsafe_statement`). The migration is staged and dry-run clean (1 declared object: `VIEW public.v_active_sessions`). I have **not** stamped the `@approved-by` header.

## Test plan

- [x] Live fan-out reproduced and root-caused; duplicate set == multi-QF set, exactly
- [x] `LATERAL` form validated **read-only** against the live fan-out session: 1 row (was 2), all three columns preserved, correctly picks the `in_progress` QF
- [x] Migration generated from the **live** view definition, not hand-copied
- [x] Ships a verifier that **counts rows** rather than grepping the definition — a grep would pass on a view that contains `LATERAL` and still multiplies
- [x] Verifier confirmed to **FAIL** against the current unfixed view, and to report the check as *exercised*, so the post-apply pass won't be vacuous

Out of scope, recorded so it isn't mistaken for part of this change: the view returns 5,922 rows because its `WHERE` is `cs.status <> 'released'` — every non-released session ever, with "active" as a computed column rather than a filter. Separately handed over unclassified; deliberately untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)