### PR TITLE
fix(QF-20260727-088): clear stale fleet_identity when a session is promoted to coordinator

### DIFF
--- a/lib/coordinator/resolve.cjs
+++ b/lib/coordinator/resolve.cjs
@@ -314,6 +314,11 @@ async function upsertCoordinatorMetadata(supabase, sessionId) {
     coordinator_since: new Date().toISOString()
   };
 
+  // QF-20260727-088: a promoted session must not keep a worker callsign. This write already
+  // read-merge-writes the whole metadata object, so dropping the key here costs no extra
+  // round trip and covers BOTH callers (the FLAG-OFF path and the FLAG-ON RPC fallback).
+  delete merged.fleet_identity;
+
   // UPSERT so the row is created if absent (SD-FDBK-INFRA-COORDINATOR-IDENTITY-SILENTLY-001).
   await supabase
     .from('claude_sessions')
@@ -323,6 +328,46 @@ async function upsertCoordinatorMetadata(supabase, sessionId) {
       heartbeat_at: new Date().toISOString(),
       status: 'active'
     }, { onConflict: 'session_id' });
+}
+
+// QF-20260727-088 (belt-and-braces half of QF-20260727-205): drop a stale worker callsign when a
+// session is promoted to coordinator, so the contradictory pair (metadata.fleet_identity.callsign
+// + is_coordinator) cannot persist at all. The pair arises because assign-fleet-identities.cjs
+// stamps any live worker-cohort session and its filterOutCoordinators() can only exclude rows
+// ALREADY flagged is_coordinator — a /coordinator start whose priming outlasts one 5-min identity
+// tick opens the window.
+//
+// The FLAG-ON path registers via the atomic set_coordinator_flag RPC (jsonb `||`), which cannot
+// also DELETE a key, and adding an RPC would need a chairman-gated migration — out of scope here.
+// So this is a JS read-merge-write, made safe by writing NOTHING in the common case: if there is
+// no stale stamp we never issue an UPDATE, so the narrow lost-update window only exists on the
+// rare promotion that actually has a callsign to clear. FAIL-OPEN — never throws, never blocks
+// coordinator startup.
+async function clearFleetIdentityFromSession(supabase, sessionId) {
+  if (!supabase || !sessionId) return;
+  try {
+    const { data: row } = await supabase
+      .from('claude_sessions')
+      .select('metadata')
+      .eq('session_id', sessionId)
+      .maybeSingle();
+
+    const metadata = row?.metadata;
+    if (!metadata || metadata.fleet_identity === undefined) return; // nothing stale → no write
+
+    const { fleet_identity: _stale, ...rest } = metadata;
+    // UPDATE (not upsert): this only ever strips a key off an existing row.
+    const { error } = await supabase
+      .from('claude_sessions')
+      .update({ metadata: rest })
+      .eq('session_id', sessionId);
+    if (error) {
+      console.warn(`   ⚠️  [COORD_IDENTITY_CLEAR_FAILED] clearFleetIdentityFromSession(${sessionId}): ${error.message} (non-fatal; stale callsign persists)`);
+    }
+  } catch (e) {
+    console.warn(`   ⚠️  [COORD_IDENTITY_CLEAR_THREW] clearFleetIdentityFromSession(${sessionId}): ${(e && e.message) || e} (non-fatal)`);
+    /* fail-open — an identity cleanup MUST NOT interrupt coordinator registration */
+  }
 }
 
 // SD-LEO-INFRA-COORDINATOR-FLAG-RPC-FALLBACK-001 (FR-2): loud canary for the unapplied-migration
@@ -474,6 +519,12 @@ async function setActiveCoordinator(supabase, sessionId) {
     }
     /* fail-open */
   }
+
+  // Step 2b (QF-20260727-088): now that this session is registered as coordinator, drop any stale
+  // worker callsign the identity cron stamped on it. Deliberately placed AFTER step 2 and BEFORE
+  // step 3 so the FR-1 register-before-retire ordering contract is untouched; the FLAG-OFF path
+  // gets the same clear for free inside upsertCoordinatorMetadata. Fail-open (never throws).
+  await clearFleetIdentityFromSession(supabase, sessionId);
 
   // Step 3: retire OTHER incumbent coordinators (metadata-only clear, no pointer touch).
   // Finding 1 (MEDIUM mutual annihilation): a naive `!== sessionId` retire loop means two
@@ -630,5 +681,7 @@ module.exports = {
   // startup/CI canary and tests.
   isFunctionNotFoundError,
   upsertCoordinatorMetadata,
-  assertCoordinatorRpcsExist
+  assertCoordinatorRpcsExist,
+  // QF-20260727-088 (belt-and-braces stale-callsign clear) — exported for tests.
+  clearFleetIdentityFromSession
 };

--- a/tests/unit/coordinator-promotion-clears-fleet-identity.test.js
+++ b/tests/unit/coordinator-promotion-clears-fleet-identity.test.js
@@ -1,0 +1,149 @@
+/**
+ * QF-20260727-088 — belt-and-braces half of QF-20260727-205.
+ *
+ * Promoting a session to coordinator must leave no stale `metadata.fleet_identity` behind, so the
+ * contradictory pair (worker callsign + is_coordinator) cannot persist. QF-205 shipped the panel-side
+ * branch-order fix; this pins the write-side cleanup.
+ *
+ * Pinned behavior:
+ *   - FLAG-ON  (atomic set_coordinator_flag RPC): a separate metadata UPDATE strips fleet_identity,
+ *     issued AFTER registration so the FR-1 register-before-retire ordering contract is untouched.
+ *   - FLAG-OFF (legacy read-merge-write upsert): the same key is dropped inside the upsert payload,
+ *     with no extra round trip and no change to the legacy pointer-first ordering.
+ *   - Sibling metadata keys survive on BOTH paths.
+ *   - When there is NO stale stamp, NO metadata write is issued at all (keeps the lost-update
+ *     window closed on the common promotion).
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'node:module';
+
+const req = createRequire(import.meta.url);
+const { setActiveCoordinator, clearFleetIdentityFromSession } = req('../../lib/coordinator/resolve.cjs');
+
+// Mirrors tests/unit/coordinator-flag-rpc-fallback.test.js, plus an ordered `seq` log and
+// order/range so the Step-3 incumbent snapshot resolves to [] instead of throwing.
+function makeSupabase({ sessionRow = null, rpcImpl } = {}) {
+  const calls = { rpc: [], upserts: [], updates: [], seq: [] };
+  const defaultRpc = (name) => {
+    // exec_sql backs the pg_proc canary; an empty result just makes it warn (behavior-neutral).
+    if (name === 'exec_sql') return { data: [{ result: [] }], error: null };
+    return { error: null };
+  };
+  const impl = rpcImpl || defaultRpc;
+  const supabase = {
+    rpc: async (name, args) => {
+      calls.rpc.push({ name, args });
+      calls.seq.push(`rpc:${name}`);
+      return impl(name, args);
+    },
+    from(table) {
+      const builder = {
+        update: (patch) => {
+          calls.updates.push({ table, patch });
+          if (patch && patch.metadata) calls.seq.push('update:metadata');
+          return builder;
+        },
+        select: () => builder,
+        eq: () => builder,
+        gte: async () => ({ data: [], error: null }),
+        filter: () => builder,
+        order: () => builder,
+        range: async () => ({ data: [], error: null }),
+        maybeSingle: async () => ({ data: sessionRow, error: null }),
+        upsert: (payload) => {
+          calls.upserts.push({ table, payload });
+          calls.seq.push('upsert:metadata');
+          return Promise.resolve({ data: null, error: null });
+        },
+        then: (resolve) => resolve({ data: [], error: null }),
+      };
+      return builder;
+    },
+    _calls: calls,
+  };
+  return supabase;
+}
+
+const STALE = {
+  fleet_identity: { callsign: 'Alpha', assigned_at: '2026-07-27T10:01:31Z' },
+  model: 'opus',
+};
+
+// The metadata writes that carry a full metadata object (the drain's target_session update does not).
+const metadataUpdates = (sb) => sb._calls.updates.filter(u => u.patch && u.patch.metadata);
+
+describe('QF-20260727-088 FLAG-ON: promotion clears a stale fleet_identity', () => {
+  const PREV = process.env.COORDINATOR_TWOWAY_V2;
+  beforeEach(() => { process.env.COORDINATOR_TWOWAY_V2 = 'on'; });
+  afterEach(() => { process.env.COORDINATOR_TWOWAY_V2 = PREV; });
+
+  it('strips fleet_identity while preserving sibling keys', async () => {
+    const sb = makeSupabase({ sessionRow: { metadata: { ...STALE } } });
+    await setActiveCoordinator(sb, 'sess-flag-on');
+
+    const writes = metadataUpdates(sb);
+    expect(writes).toHaveLength(1);
+    expect(writes[0].patch.metadata.fleet_identity).toBeUndefined();
+    expect(writes[0].patch.metadata.model).toBe('opus'); // siblings survive
+  });
+
+  it('clears AFTER registering, so register-before-retire ordering is untouched', async () => {
+    const sb = makeSupabase({ sessionRow: { metadata: { ...STALE } } });
+    await setActiveCoordinator(sb, 'sess-order');
+
+    const { seq } = sb._calls;
+    const registeredAt = seq.indexOf('rpc:set_coordinator_flag');
+    const clearedAt = seq.indexOf('update:metadata');
+    expect(registeredAt).toBeGreaterThanOrEqual(0);
+    expect(clearedAt).toBeGreaterThan(registeredAt);
+  });
+
+  it('issues NO metadata write when there is no stale stamp', async () => {
+    const sb = makeSupabase({ sessionRow: { metadata: { model: 'opus' } } });
+    await setActiveCoordinator(sb, 'sess-clean');
+    expect(metadataUpdates(sb)).toHaveLength(0);
+  });
+
+});
+
+// Fail-open is asserted against the helper directly. Killing supabase.from() wholesale would
+// instead trip the (pre-existing, unguarded) broadcast-drain step earlier in setActiveCoordinator,
+// which would test that step rather than this one.
+describe('QF-20260727-088 clearFleetIdentityFromSession is fail-open', () => {
+  it('resolves when the read/update throws', async () => {
+    const exploding = { from: () => { throw new Error('DB down'); } };
+    await expect(clearFleetIdentityFromSession(exploding, 'sess-x')).resolves.toBeUndefined();
+  });
+
+  it('resolves when the UPDATE returns an error', async () => {
+    const sb = makeSupabase({ sessionRow: { metadata: { ...STALE } } });
+    sb.from = () => ({
+      select: () => sb.from(),
+      eq: () => sb.from(),
+      maybeSingle: async () => ({ data: { metadata: { ...STALE } }, error: null }),
+      update: () => ({ eq: async () => ({ error: { message: 'write rejected' } }) }),
+    });
+    await expect(clearFleetIdentityFromSession(sb, 'sess-y')).resolves.toBeUndefined();
+  });
+
+  it('no-ops on a missing supabase client or session id', async () => {
+    await expect(clearFleetIdentityFromSession(null, 'sess-z')).resolves.toBeUndefined();
+    await expect(clearFleetIdentityFromSession(makeSupabase(), '')).resolves.toBeUndefined();
+  });
+});
+
+describe('QF-20260727-088 FLAG-OFF: legacy upsert drops fleet_identity', () => {
+  const PREV = process.env.COORDINATOR_TWOWAY_V2;
+  beforeEach(() => { process.env.COORDINATOR_TWOWAY_V2 = 'off'; });
+  afterEach(() => { process.env.COORDINATOR_TWOWAY_V2 = PREV; });
+
+  it('upserts is_coordinator without the stale callsign, keeping siblings', async () => {
+    const sb = makeSupabase({ sessionRow: { metadata: { ...STALE } } });
+    await setActiveCoordinator(sb, 'sess-flag-off');
+
+    const upsert = sb._calls.upserts.find(u => u.payload?.metadata?.is_coordinator === true);
+    expect(upsert).toBeTruthy();
+    expect(upsert.payload.metadata.fleet_identity).toBeUndefined();
+    expect(upsert.payload.metadata.model).toBe('opus');
+  });
+});

--- a/tests/unit/coordinator-promotion-clears-fleet-identity.test.js
+++ b/tests/unit/coordinator-promotion-clears-fleet-identity.test.js
@@ -14,11 +14,21 @@
  *   - When there is NO stale stamp, NO metadata write is issued at all (keeps the lost-update
  *     window closed on the common promotion).
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createRequire } from 'node:module';
 
 const req = createRequire(import.meta.url);
 const { setActiveCoordinator, clearFleetIdentityFromSession } = req('../../lib/coordinator/resolve.cjs');
+
+// setActiveCoordinator also writes the real .claude/active-coordinator.json pointer, whose path is a
+// module const with no injection seam. lib/coordinator/resolve.test.js round-trips that same default
+// path, so any suite that promotes a coordinator races it (a pre-existing flake — the already-merged
+// coordinator-flag-rpc-fallback.test.js hits it too). Stub the write: this suite asserts on metadata,
+// never on the pointer file. `require('fs')` so we spy the exact object resolve.cjs holds.
+const fs = req('fs');
+let writeSpy;
+beforeEach(() => { writeSpy = vi.spyOn(fs, 'writeFileSync').mockImplementation(() => {}); });
+afterEach(() => { writeSpy.mockRestore(); });
 
 // Mirrors tests/unit/coordinator-flag-rpc-fallback.test.js, plus an ordered `seq` log and
 // order/range so the Step-3 incumbent snapshot resolves to [] instead of throwing.


### PR DESCRIPTION
Belt-and-braces half of **QF-20260727-205**. QF-205 shipped fix (a) — the branch order in `server/routes/fleet-panel.js` so `is_coordinator`/role test BEFORE `fleet_identity.callsign` (PR #6581). That made the contradictory pair harmless to the Sessions page; this removes the pair itself so it cannot persist at all.

## Why the pair arises

`assign-fleet-identities.cjs` stamps a NATO callsign onto any live worker-cohort session, and its `filterOutCoordinators()` can only exclude rows ALREADY flagged `is_coordinator`. In the 2026-07-27 incident the session registered at 10:00:47Z, was stamped `Alpha` 44s later, and became coordinator at ~10:20Z — the identity cron ticks every 5 min, so any `/coordinator start` whose priming reads outlast one tick opens the window.

## Both paths, neither ordering contract perturbed

- **FLAG-OFF** (legacy pointer-first order): the key is dropped inside `upsertCoordinatorMetadata`'s existing read-merge-write — no extra round trip, no reordering. This also covers the FLAG-ON RPC fallback, which calls the same helper.
- **FLAG-ON** (FR-1 register-before-retire): the atomic `set_coordinator_flag` RPC uses jsonb `||` and cannot DELETE a key, and adding an RPC would need a chairman-gated migration — out of QF scope. So a new fail-open `clearFleetIdentityFromSession()` does a JS read-merge-write as **Step 2b**, strictly AFTER registration and BEFORE the retire loop.

The helper writes **nothing** when there is no stale stamp, so the lost-update window only exists on the rare promotion that actually has a callsign to clear. It never throws — an identity cleanup must not block coordinator startup.

Per the QF: did **not** re-open the (a) fix (branch order stays as shipped; its pinning test passes unchanged) and did **not** rename or capitalize `identity_kind`.

## Verification

- New `tests/unit/coordinator-promotion-clears-fleet-identity.test.js` (7 tests): strip-on-both-paths, sibling keys survive, clear-after-register ordering, no-write-when-clean, fail-open on throw and on returned error.
- **Negative control**: reverting `resolve.cjs` fails 6 of the 7 (the 7th is the no-write-when-clean guard, true either way).
- **No regressions**: all 5 other suites importing `resolve.cjs` pass (99 tests); QF-205's `fleet-panel-identity-kind-order.test.js` still passes.
- **Full unit suite**: 14 failures across 9 files, byte-identical with and without this change — pre-existing on `origin/main` (env-isolation leak et al), verified by running the same 10 files against a reverted `resolve.cjs`.

Size: 26 code LOC in `resolve.cjs` (plus comments) and one new pinning suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
