### PR TITLE
fix(QF-20260727-713): resolve QF claim keys against quick_fixes so QF holders are not false orphans

### DIFF
--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -372,6 +372,31 @@ async function loadData() {
     (extraSds || []).forEach(sd => { sdStatusMap[sd.sd_key] = sd; });
   }
 
+  // QF-20260727-713: a claim key can be a QUICK-FIX id, which lives in quick_fixes and NEVER in
+  // strategic_directives_v2. Resolving only against the SD table made every QF-claiming worker a
+  // false ORPHAN (measured 2026-07-27: 4 of 4 flagged keys present in quick_fixes with the correct
+  // claiming_session_id, 0 of 4 in strategic_directives_v2), which in turn made a REAL orphan
+  // undetectable — the false positives are indistinguishable from a true one.
+  //
+  // Kept as a SEPARATE map rather than merged into sdStatusMap: the other QA checks read
+  // sdStatusMap for SD-shaped fields (progress_percentage, completion_date) that quick_fixes does
+  // not have, so merging would silently change their behaviour. This map is consulted only by the
+  // ORPHAN check.
+  //
+  // Deliberately UNFILTERED by status (unlike the open/in_progress QUICK FIXES section below): a
+  // worker holding a completed/closed/cancelled QF is not an orphan — the key still resolves.
+  let qfStatusMap = {};
+  const qfClaimKeys = allSdKeys.filter(k => !sdStatusMap[k] && /^QF-/i.test(k));
+  if (qfClaimKeys.length > 0) {
+    try {
+      const { data: qfClaimRows } = await supabase
+        .from('quick_fixes')
+        .select('id, title, status')
+        .in('id', qfClaimKeys);
+      (qfClaimRows || []).forEach(qf => { qfStatusMap[qf.id] = qf; });
+    } catch { /* degrade-safe: unresolved keys stay ORPHAN, i.e. exactly the pre-fix behaviour */ }
+  }
+
   // Detect bare-shell SDs: title == description, no real scope, not child stubs
   const pendingKeys = workable.map(sd => sd.sd_key);
   let bareShells = [];
@@ -430,7 +455,7 @@ async function loadData() {
   } catch { /* degrade-safe: empty QF section */ }
 
   return {
-    sessions, allSessions, children, workable, coordMessages, rawSessions, sdStatusMap,
+    sessions, allSessions, children, workable, coordMessages, rawSessions, sdStatusMap, qfStatusMap,
     claimedSdIds, activeSessions, staleSessions, idleSessions,
     completedChildren, totalChildren, orchPct,
     unclaimedChildren, unclaimedStandalone, bareShellSDs: bareShells,
@@ -981,12 +1006,15 @@ function printQA(d) {
     });
   });
 
-  // QA 3: Orphaned claims (SD not in DB)
-  recentRaw.filter(s => !d.sdStatusMap[s.sd_key]).forEach(s => {
+  // QA 3: Orphaned claims (claim key resolves in NEITHER strategic_directives_v2 NOR quick_fixes).
+  // QF-20260727-713: a QF id is a valid claim key; checking only sdStatusMap flagged every
+  // QF-holding worker as an orphan and buried any genuine one in the noise.
+  const qfMap = d.qfStatusMap || {};
+  recentRaw.filter(s => !d.sdStatusMap[s.sd_key] && !qfMap[s.sd_key]).forEach(s => {
     issues.push({
       severity: 'MED',
       check: 'ORPHAN',
-      msg: s.tty + ' claims ' + s.sd_key.substring(0, 30) + '… — SD not found in DB'
+      msg: s.tty + ' claims ' + s.sd_key.substring(0, 30) + '… — key not found in strategic_directives_v2 or quick_fixes'
     });
   });
 
@@ -2560,7 +2588,7 @@ async function main() {
 }
 
 // Export read-only renderers for unit testing (SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001).
-module.exports = { printFeedback, reconcilePAliveWithLiveness, computeSolomonLedgerRollup, printWorkers, printChairmanEmailChannelHealth, printAvailable, printWorkerInbox, resolveInboxAudience, printAttentionStrip };
+module.exports = { printFeedback, reconcilePAliveWithLiveness, computeSolomonLedgerRollup, printWorkers, printChairmanEmailChannelHealth, printAvailable, printWorkerInbox, resolveInboxAudience, printAttentionStrip, printQA };
 
 // Only run the CLI when invoked directly, so requiring this module in a test does
 // not execute main() against the live database.

--- a/tests/unit/coordinator/fleet-dashboard-orphan-qf-resolution.test.js
+++ b/tests/unit/coordinator/fleet-dashboard-orphan-qf-resolution.test.js
@@ -1,0 +1,108 @@
+/**
+ * QF-20260727-713 — the QA ORPHAN check resolved a session's claim key ONLY against
+ * strategic_directives_v2. Quick-fix ids live in quick_fixes and NEVER in strategic_directives_v2,
+ * so every worker holding a QF claim was reported "SD not found in DB".
+ *
+ * Measured 2026-07-27: all 4 flagged keys (QF-20260727-088, -154, -397/-663, -978) were present in
+ * quick_fixes with the correct claiming_session_id, and 0 of 4 were in strategic_directives_v2.
+ *
+ * The damage is not the noise — it is that a false positive is indistinguishable from a real
+ * orphan, so a genuine orphan becomes undetectable. That makes the second half of this suite the
+ * important half: a fix that merely silences ORPHAN would be worse than the bug, so these tests
+ * pin that unresolvable keys STILL report.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { printQA } = require('../../../scripts/fleet-dashboard.cjs');
+
+let logSpy;
+beforeEach(() => { logSpy = vi.spyOn(console, 'log').mockImplementation(() => {}); });
+afterEach(() => { logSpy.mockRestore(); });
+const output = () => logSpy.mock.calls.map((c) => c.map(String).join(' ')).join('\n');
+
+// A live-looking claim: heartbeat inside the 10-minute recency window printQA filters on.
+const claim = (tty, sd_key) => ({
+  tty, sd_key, status: 'active', heartbeat_at: new Date().toISOString(),
+});
+
+// printQA reads several optional collections; supply the minimum plus whatever the case needs.
+const data = ({ rawSessions = [], sdStatusMap = {}, qfStatusMap = {} } = {}) => ({
+  rawSessions, sdStatusMap, qfStatusMap, bareShellSDs: [],
+});
+
+describe('QA ORPHAN — quick-fix claim keys resolve against quick_fixes (QF-20260727-713)', () => {
+  it('does NOT flag a worker holding a QF that exists in quick_fixes', () => {
+    printQA(data({
+      rawSessions: [claim('win-6712', 'QF-20260727-713')],
+      qfStatusMap: { 'QF-20260727-713': { id: 'QF-20260727-713', title: 'x', status: 'in_progress' } },
+    }));
+    expect(output()).not.toContain('ORPHAN');
+  });
+
+  it('reproduces the measured incident: 4 QF claims, 0 orphans, checks PASS', () => {
+    const keys = ['QF-20260727-088', 'QF-20260727-154', 'QF-20260727-663', 'QF-20260727-978'];
+    printQA(data({
+      rawSessions: keys.map((k, i) => claim(`win-${i}`, k)),
+      sdStatusMap: {}, // none of them are in strategic_directives_v2 — that is the whole point
+      qfStatusMap: Object.fromEntries(keys.map(k => [k, { id: k, status: 'in_progress' }])),
+    }));
+    const out = output();
+    expect(out).not.toContain('ORPHAN');
+    expect(out).toContain('QA CHECKS [PASS]');
+  });
+
+  it('resolves a QF in a terminal state — completed/closed/cancelled is not an orphan', () => {
+    for (const status of ['completed', 'closed', 'cancelled']) {
+      logSpy.mockClear();
+      printQA(data({
+        rawSessions: [claim('win-1', 'QF-20260727-999')],
+        qfStatusMap: { 'QF-20260727-999': { id: 'QF-20260727-999', status } },
+      }));
+      expect(output(), `status=${status}`).not.toContain('ORPHAN');
+    }
+  });
+
+  it('still resolves ordinary SD claims through strategic_directives_v2', () => {
+    printQA(data({
+      rawSessions: [claim('win-2', 'SD-LEO-INFRA-REAL-001')],
+      sdStatusMap: { 'SD-LEO-INFRA-REAL-001': { sd_key: 'SD-LEO-INFRA-REAL-001', status: 'active' } },
+    }));
+    expect(output()).not.toContain('ORPHAN');
+  });
+});
+
+// The fix must NARROW the false positives, not disable the check.
+describe('QA ORPHAN — a genuine orphan is still detected (QF-20260727-713)', () => {
+  it('flags an SD-shaped key present in NEITHER table', () => {
+    printQA(data({ rawSessions: [claim('win-3', 'SD-LEO-INFRA-GHOST-404')] }));
+    const out = output();
+    expect(out).toContain('ORPHAN');
+    expect(out).toContain('win-3');
+  });
+
+  it('flags a QF-shaped key that is absent from quick_fixes (deleted/typo id)', () => {
+    printQA(data({
+      rawSessions: [claim('win-4', 'QF-20260727-000')],
+      qfStatusMap: {}, // lookup ran and found nothing — a real orphan, not a table-blindness artifact
+    }));
+    expect(output()).toContain('ORPHAN');
+  });
+
+  it('separates a real orphan from valid QF claims in the same fleet', () => {
+    printQA(data({
+      rawSessions: [claim('win-good', 'QF-20260727-713'), claim('win-bad', 'QF-20260727-000')],
+      qfStatusMap: { 'QF-20260727-713': { id: 'QF-20260727-713', status: 'in_progress' } },
+    }));
+    const out = output();
+    expect(out).toContain('win-bad');
+    expect(out).not.toContain('win-good'); // the signal is no longer buried in false positives
+  });
+
+  it('degrades to the pre-fix behaviour when qfStatusMap is absent (query failed)', () => {
+    // loadData's lookup is wrapped in try/catch; on failure qfStatusMap is missing/empty and an
+    // unresolved key must still surface rather than silently vanish.
+    printQA({ rawSessions: [claim('win-5', 'QF-20260727-713')], sdStatusMap: {}, bareShellSDs: [] });
+    expect(output()).toContain('ORPHAN');
+  });
+});


### PR DESCRIPTION
The fleet-dashboard QA **ORPHAN** check resolved a session's claim key only against `strategic_directives_v2`. Quick-fix ids live in `quick_fixes` and never in `strategic_directives_v2`, so **every** worker holding a QF claim was reported "SD not found in DB".

Reproduced before touching anything — 4 of 4 flagged keys present in `quick_fixes` with the correct `claiming_session_id`, 0 of 4 in `strategic_directives_v2` (including this session's own claim on -713):

```
QA CHECKS [4 ISSUES]
  !  [ORPHAN      ] win-11940 claims QF-20260727-663… — SD not found in DB
  !  [ORPHAN      ] win-29928 claims QF-20260727-978… — SD not found in DB
  !  [ORPHAN      ] win-6712  claims QF-20260727-713… — SD not found in DB
  !  [ORPHAN      ] win-35320 claims QF-20260727-154… — SD not found in DB
```

## The check had to be narrowed, not silenced

The noise isn't the real damage — a false positive is **indistinguishable from a real orphan**, so a genuine orphan was undetectable in that output. A "fix" that made ORPHAN stop firing would be strictly worse than the bug. Half the new suite exists to pin that unresolvable keys still report.

## Implementation

Mirrors the existing `missingKeys` pattern: after resolving against `strategic_directives_v2`, still-unresolved `QF-`prefixed keys are looked up in `quick_fixes`. Two deliberate choices:

- **Separate `qfStatusMap`, not merged into `sdStatusMap`** — the other QA checks read `sdStatusMap` for SD-shaped fields (`progress_percentage`, `completion_date`) that `quick_fixes` lacks, so merging would silently change their behaviour. Only the ORPHAN check consults the new map.
- **Unfiltered by status**, unlike the open/in_progress QUICK FIXES section — a worker holding a `completed`/`closed`/`cancelled` QF is not an orphan, the key still resolves. (Confirmed those statuses exist in the table.)

The lookup is wrapped in `try/catch`: on query failure the map is empty and keys fall through to ORPHAN — exactly the pre-fix behaviour. The message now names both tables instead of "SD not found in DB".

## Verification

- **Live**: QA CHECKS `[4 ISSUES]` → `[PASS]`.
- **8 new tests** — 4 pin the false positives gone (including the measured 4-key incident and terminal-status QFs), 4 pin that genuine orphans still fire (SD-shaped ghost key, QF-shaped id absent from `quick_fixes`, a real orphan alongside valid QF claims, and the degraded no-`qfStatusMap` path).
- **Negative control**: reverting the fix fails exactly the 4 false-positive tests while all 4 genuine-orphan tests keep passing — the check was narrowed, not disabled.
- **No regressions**: 631 tests across 53 fleet-dashboard/coordinator suites pass. Full-suite failures are pre-existing on `origin/main`, verified by running the differing files against a reverted `fleet-dashboard.cjs` (identical both ways).

`printQA` is now exported for testability; no behaviour change from that. 16 code LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
