### PR TITLE
fix(SD-LEO-INFRA-THREE-REFUSAL-TESTS-001): stop three refusal tests taking their verdict from operator .env

### DIFF
--- a/scripts/one-off/_lead-evidence-explore-three-refusal-tests-001.mjs
+++ b/scripts/one-off/_lead-evidence-explore-three-refusal-tests-001.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * One-off: record Explore LEAD-phase evidence for SD-LEO-INFRA-THREE-REFUSAL-TESTS-001.
+ *
+ * The Explore sub-agent ran read-only (it cannot write to the DB by construction), so this
+ * script records its returned survey verdict through the canonical writer rather than a
+ * hand-rolled insert (CLAUDE.md prologue rule 11: metadata.repo_path + executed_from_cwd via
+ * lib/sub-agents/resolve-repo.js applySubAgentRepoVerdict; there are NO top-level repo_path
+ * columns).
+ *
+ * Survey question: how widespread is the `opts.X ?? process.env.Y` pattern that makes the three
+ * refusal tests take their verdict from operator .env? Answer: the call-site pattern is narrow,
+ * but the ENV-ISOLATION gap underneath it is suite-level, which is what decides the fix shape.
+ */
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../../lib/sub-agent-executor/results-storage.js';
+import { getSupabaseClient } from '../../lib/sub-agent-executor/supabase-client.js';
+
+const SD_ID = '581a0da1-331a-4429-9969-a45667df076f';
+const SD_KEY = 'SD-LEO-INFRA-THREE-REFUSAL-TESTS-001';
+
+async function main() {
+  const supabase = await getSupabaseClient();
+  const resolution = await resolveSubAgentRepo({ sdId: SD_KEY, targetApplication: 'EHG_Engineer', subAgentCode: 'Explore', supabase });
+
+  let results = {
+    verdict: 'PASS',
+    confidence: 88,
+    findings: [
+      {
+        id: 'F1-root-cause-is-suite-level-env-leak-not-three-call-sites',
+        severity: 'HIGH',
+        summary: "vitest.config.js:16-17 unconditionally loadEnv('.env') + loadEnv('.env.test') in the PARENT process at config-evaluation time, and pool:'forks' (vitest.config.js:166) means every forked worker INHERITS that process.env. tests/setup.unit.js deliberately does NOT call dotenv.config() (comment: 'unit tests must not reach the live DB'), but that is moot -- the real .env is already present in each fork before setup runs. This single gap explains the three refusal-test failures AND the separately-red tests/unit/setup/env-isolation-guard.test.js.",
+      },
+      {
+        id: 'F2-precedent-exists-for-the-fix-in-the-same-file',
+        severity: 'INFO',
+        summary: "vitest.config.js:219 already defines a unit-project-level env override neutralizing FLEET_REPO_ROOT to './tests/fixtures/__no_such_tree__'. That is exactly the mechanism needed here, already proven in-repo -- it simply does not cover FLEET_ACCOUNT_PROFILES_DIR, FLEET_SPAWN_CONTROL_LIVE, FLEET_BROWSER_PROFILES_DIR or FLEET_CANARY_KILL_ENABLED. Argues for extending an existing pattern, not inventing one.",
+      },
+      {
+        id: 'F3-call-site-inventory-pattern-A-and-B',
+        severity: 'MEDIUM',
+        summary: "Pattern A (opts.X ?? process.env.Y, X may legitimately be null meaning absent): lib/fleet/spawn-control.js:103, lib/fleet/browser-control.js:42, lib/fleet/build-session-launch.cjs:57 (ternary near-variant), lib/programmatic/tools/ollama-tool.js:27-28, lib/eva/stage-17/qa-rubric.js:276. Pattern B (indirect -- helper internally defaults to process.env, called with ZERO args so an explicit opts.env is bypassed): lib/fleet/spawn-control.js:227 and lib/fleet/reboot-respawn-runner.js:182, both `opts.live ?? isLiveEnabled()`. Pattern C (opts.env || process.env, ~17 sites) is SAFE -- it swaps the whole env object so a test retains full control; excluded from the blast radius.",
+      },
+      {
+        id: 'F4-live-blast-radius-is-two-vars-today',
+        severity: 'MEDIUM',
+        summary: "Intersection of the opts-fallback consumers with vars actually SET in this repo's .env (no .env.test/.env.local exist): FLEET_ACCOUNT_PROFILES_DIR (.env:183) and FLEET_SPAWN_CONTROL_LIVE=true (.env:186). Those two are the entire live blast radius. FLEET_BROWSER_PROFILES_DIR is UNSET today, so tests/unit/fleet/browser-control.test.js:108 ('not configured' throw) currently passes -- but it has zero protection and is the same latent shape, i.e. it would break silently for any operator who exports that var.",
+      },
+      {
+        id: 'F5-author-already-knew-locally-sibling-test-self-protects',
+        severity: 'INFO',
+        summary: "tests/unit/fleet/spawn-control.test.js:181-203 ('throws if no base dir is configured') explicitly deletes process.env.FLEET_ACCOUNT_PROFILES_DIR and restores it in a finally, with a comment naming the exact leak ('Pre-existing env leakage... neutralize it for the duration of this one assertion'). The sibling refusal test at :882 does not. tests/unit/eva/imagen-logo-renderer.test.js:70-101 does the same save/delete/restore for GEMINI_API_KEY. So the correct per-test idiom already exists in-repo and was applied inconsistently -- further evidence the durable fix belongs at the suite level, not in three more hand-rolled save/restore blocks.",
+      },
+      {
+        id: 'F6-env-isolation-guard-red-for-the-same-root-cause',
+        severity: 'HIGH',
+        summary: "tests/unit/setup/env-isolation-guard.test.js asserts process.env.SUPABASE_URL === 'https://test.invalid.local', the synthetic sentinel set by tests/setup.unit.js:15 via ||=. Because the parent-process .env load leaks the REAL SUPABASE_URL (.env:5) into every fork, the ||= sees a truthy value and never overwrites it, so the assertion fails against the real URL. Same root cause as the three refusal tests, manifesting through a ||= sentinel instead of a ?? opts-fallback -- confirms the gap is architectural, not incidental.",
+      },
+    ],
+    metadata: {
+      survey_scope: 'lib/ and scripts/, excluding node_modules, archive/, and other worktrees',
+      counts: { pattern_A_direct: 5, pattern_B_indirect_via_helper: 2, pattern_C_whole_env_swap_safe: 17, live_blast_radius_vars: 2 },
+      recommended_fix_shape: 'Suite-level: strip/neutralize operator-set FLEET_* (and the SUPABASE_URL sentinel path) for the unit vitest project, extending the existing vitest.config.js:219 FLEET_REPO_ROOT override precedent. NOT: editing the three fenced refusal assertions, and NOT: loosening the source guards.',
+      binding_ruling_honored: 'Read-only survey. No test edited, no source edited.',
+      recorded_by: 'Alpha-4 (worker session 39aa8a1e) on behalf of the read-only Explore sub-agent, which cannot write to the DB by construction. Findings are the Explore agent’s returned survey, not a re-derivation.',
+    },
+    phase: 'LEAD',
+    summary: "PASS for LEAD-TO-PLAN. Survey answers the scoping question the determination raised: the `opts.X ?? process.env.Y` CALL-SITE pattern is narrow (5 direct + 2 indirect via isLiveEnabled(), plus 1 ternary near-variant), and only 2 of those env vars (FLEET_ACCOUNT_PROFILES_DIR, FLEET_SPAWN_CONTROL_LIVE) are live-blast on this host -- but the ROOT CAUSE is one level up and architectural: vitest.config.js:16-17 loads the real .env into the parent process and pool:'forks' inherits it into every unit worker, so tests/setup.unit.js's ||= sentinels never fire. That same gap independently breaks tests/unit/setup/env-isolation-guard.test.js (SUPABASE_URL sentinel). A fix precedent already exists in the same file (vitest.config.js:219 neutralizes FLEET_REPO_ROOT for the unit project) and simply needs extending. Conclusion for PLAN: scope the fix at the suite/env-isolation level rather than patching three call sites or editing three fenced assertions.",
+  };
+
+  results = applySubAgentRepoVerdict(results, resolution);
+  const stored = await storeSubAgentResults('Explore', SD_ID, { name: 'Explore (read-only survey sub-agent)' }, results, { sdKey: SD_KEY, phase: 'LEAD' });
+  console.log('Explore result stored:', stored.id, stored.verdict, stored.confidence);
+}
+
+main().catch((e) => { console.error('FAILED:', e.message); console.error(e.stack); process.exit(1); });

--- a/scripts/one-off/_lead-evidence-three-refusal-tests-001.mjs
+++ b/scripts/one-off/_lead-evidence-three-refusal-tests-001.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * One-off: write VALIDATION LEAD-phase evidence for
+ * SD-LEO-INFRA-THREE-REFUSAL-TESTS-001, independently verifying the worker's
+ * DETERMINATION (not a fix — binding coordinator ruling forbids editing the
+ * three tests) that all three red tests are environment-dependent, the
+ * refusal/isolation logic is INTACT, and there is NO fail-open.
+ *
+ * Independently re-ran both the baseline and the neutralized reproduction,
+ * read the two `??` fallback sites named in the claim, and adversarially
+ * checked whether restart() reaching ok:true with a resolvable profile dir
+ * constitutes a loss of isolation (it does not — CLAUDE_CONFIG_DIR is set to
+ * the real profiles-dir subpath, sourced from process.env instead of failing
+ * loud, and that directory genuinely exists on this host).
+ *
+ * Canonical repo-evidence pattern (lib/sub-agents/resolve-repo.js
+ * applySubAgentRepoVerdict + lib/sub-agent-executor/results-storage.js
+ * storeSubAgentResults) per CLAUDE.md prologue rule 11 — no hand-rolled insert.
+ */
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../../lib/sub-agent-executor/results-storage.js';
+import { getSupabaseClient } from '../../lib/sub-agent-executor/supabase-client.js';
+
+const SD_ID = '581a0da1-331a-4429-9969-a45667df076f';
+const SD_KEY = 'SD-LEO-INFRA-THREE-REFUSAL-TESTS-001';
+
+async function main() {
+  const supabase = await getSupabaseClient();
+  const resolution = await resolveSubAgentRepo({ sdId: SD_KEY, targetApplication: 'EHG_Engineer', subAgentCode: 'VALIDATION', supabase });
+
+  let results = {
+    verdict: 'PASS',
+    confidence: 92,
+    findings: [
+      {
+        id: 'F1-baseline-reproduced-3-failed-66-passed',
+        severity: 'INFO',
+        summary: "Independently re-ran `npx vitest run tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js tests/unit/fleet/spawn-control.test.js` against this worktree's real, unmodified .env (which sets FLEET_SPAWN_CONTROL_LIVE=true at line 186 and FLEET_ACCOUNT_PROFILES_DIR=C:\\Users\\rickf\\.claude-fleet-profiles at line 183). Result: 3 failed / 66 passed — matches the worker's reported baseline exactly (same 2 files, same test names: the two 'WITHOUT opts.live' cp3 propagation tests, and spawn-control.test.js's 'FR-6: restarting a profile-stamped session with NO profiles dir configured FAILS LOUD').",
+      },
+      {
+        id: 'F2-neutralized-69-passed-confirmed',
+        severity: 'INFO',
+        summary: 'Independently re-ran the same command with FLEET_SPAWN_CONTROL_LIVE=false and FLEET_ACCOUNT_PROFILES_DIR= exported ahead of dotenvx injection (dotenvx does not override already-set shell vars by default, confirmed by the tool\'s own "injected env (0)" output). Result: 69 passed / 69 total, 2 test files passed. Matches the worker\'s reported neutralized count exactly.',
+      },
+      {
+        id: 'F3-mechanism-confirmed-at-both-cited-line-numbers',
+        severity: 'INFO',
+        summary: "Read lib/fleet/spawn-control.js directly. Line 227: `const live = opts.live ?? isLiveEnabled();` — isLiveEnabled() is called with zero arguments. Its signature at line 115 is `export function isLiveEnabled(env = process.env)`, so the no-arg call defaults to reading process.env directly, NOT the opts.env (GUARD_ENV = {FLEET_CANARY_KILL_ENABLED:'true'}) the two cp3 tests thread through canaryRestart/canaryRelaunchUnderProfile. Line 103: `const baseDir = opts.baseDir ?? process.env.FLEET_ACCOUNT_PROFILES_DIR ?? null;` — an explicit `baseDir: null` from a caller (as spawn-control.test.js:882's FR-6 case supplies) is nullish and therefore falls through to process.env.FLEET_ACCOUNT_PROFILES_DIR rather than staying null. Both `??` chains match the claim's description exactly; this is one root-cause class (env-var fallback shadowing an explicit test-supplied absence), not two independent defects.",
+      },
+      {
+        id: 'F4-code-idiom-corroborates-the-env-var-is-a-known-narrow-carrier-not-general-override',
+        severity: 'INFO',
+        summary: "spawn-control.js:302-317 (the tree-currency check inside spawn()) carries an explicit, on-the-record comment explaining why opts.env is deliberately NOT read there: 'callers such as canaryRestart/relaunchUnderProfile pass a NARROW opts.env carrying one unrelated feature flag..., and because that value REPLACES process.env wholesale rather than extending it, keying the currency check off it made [the bypass] silently unreachable on every canary path.' This independently corroborates that opts.env in this codebase is a narrow, single-purpose carrier (not a general environment override plumbed into every env-reading helper) and that isLiveEnabled() reading real process.env instead of the narrow opts.env is consistent with an established, deliberate idiom elsewhere in the same file — not an isolated oversight invented for this claim.",
+      },
+      {
+        id: 'F5-adversarial-check-fr6-restart-still-applies-real-isolation-not-fail-open',
+        severity: 'INFO',
+        summary: "Directly inspected the FR-6 test's actual (not expected) result under the real .env: restart('Canary-1', {..., baseDir: null}) resolves and returns ok:true with spawnFn's captured env.CLAUDE_CONFIG_DIR === 'C:\\\\Users\\\\rickf\\\\.claude-fleet-profiles\\\\canary' — i.e. the profile-isolation directory IS applied, sourced from process.env.FLEET_ACCOUNT_PROFILES_DIR instead of throwing as the test (which assumes a totally unconfigured host) expects. Verified C:\\Users\\rickf\\.claude-fleet-profiles\\canary genuinely exists on this host (not a dangling/fabricated path). This directly answers the SD title's fail-open framing ('a profile-stamped restart can launch without its isolation and report success'): the restart here launches WITH its isolation (env-resolved profiles dir) and reports success; nothing launches unisolated. No regression found under this reading — the only defect is that resolveProfileDir treats caller-supplied `baseDir: null` as absent (falls through to env) rather than as an explicit deliberate-unconfigured signal, which is a test-fixture/production-env mismatch, not a live isolation loss.",
+      },
+      {
+        id: 'F6-adversarial-check-cp3-is-live-true-here-actually-wrong',
+        severity: 'INFO',
+        summary: "For the two cp3 propagation tests: isLiveEnabled()'s own doc comment (spawn-control.js:114) states 'True only when the operator has explicitly enabled the live OS spawn/relaunch surface.' This repo's operator (this developer) HAS explicitly set FLEET_SPAWN_CONTROL_LIVE=true in their local, gitignored .env (confirmed untracked via `git check-ignore`/`git ls-files`) — so honoring that as 'live' is the function's documented contract working as designed, not a defect. The tests' own header comment (line 96) states they reproduce 'the exact real-world condition (drill process without the env var exported)' — an assumption about a DIFFERENT process's environment (the CP3 drill runner) that does not hold for this developer's persistent local shell. Additionally, in both failing cp3 cases spawnFn is a vi.fn() mock (never a real OS spawn), so 'live=true here' produces zero real side effects in the test process — the failure is purely an assertion mismatch (spawnFn WAS called when the test expected it NOT to be), not evidence of an unguarded real launch.",
+      },
+    ],
+    warnings: [
+      "The determination is sound but exposes a real (non-blocking) test-fragility class worth flagging for a future SD/QF, NOT for this one under the binding no-edit ruling: these 3 tests silently change verdict based on the developer's local, gitignored .env rather than an isolated/controlled env, which is a general hazard for reproducibility across machines/CI. Recommend a follow-up (separate from this SD, which is scoped to the DETERMINATION only) to either (a) have isLiveEnabled()/resolveProfileDir consistently read the SAME env carrier callers already thread through opts.env, or (b) have the test harness explicitly clear FLEET_SPAWN_CONTROL_LIVE/FLEET_ACCOUNT_PROFILES_DIR for this suite. Not raised as a finding against the current determination — the determination correctly identifies the CURRENT behavior as environment-dependent and non-fail-open.",
+    ],
+    recommendations: [
+      'Accept the DETERMINATION as CONFIRMED: the live restart/relaunch/spawn refusal and profile-isolation logic is intact on origin/main; the 3 red tests are caused by this developer\'s local .env supplying values the tests assumed absent, not by a fail-open code defect.',
+      'Do not edit the three tests per the binding coordinator ruling; any follow-on hardening (env-carrier consistency or test-env isolation) belongs in a separate SD/QF, not this one.',
+    ],
+    detailed_analysis: JSON.stringify({
+      sd_key: SD_KEY,
+      verification_method: 'Independent re-run of both cited vitest commands against this worktree, direct read of lib/fleet/spawn-control.js lines 97-234, git check-ignore/ls-files check on .env, and a filesystem existence check on the resolved profiles directory.',
+      baseline_measured: { command: 'npx vitest run tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js tests/unit/fleet/spawn-control.test.js', result: '3 failed / 66 passed', matches_claim: true },
+      neutralized_measured: { command: 'FLEET_SPAWN_CONTROL_LIVE=false FLEET_ACCOUNT_PROFILES_DIR= <same command>', result: '69 passed (69)', matches_claim: true },
+      env_dot_file: { tracked: false, gitignored: true, FLEET_SPAWN_CONTROL_LIVE: 'true (line 186)', FLEET_ACCOUNT_PROFILES_DIR: 'C:\\Users\\rickf\\.claude-fleet-profiles (line 183, directory exists with a canary/ subdir)' },
+      code_sites: {
+        'spawn-control.js:227': "const live = opts.live ?? isLiveEnabled(); -- isLiveEnabled() called with no arg, defaults to process.env per its own signature (line 115).",
+        'spawn-control.js:103': "const baseDir = opts.baseDir ?? process.env.FLEET_ACCOUNT_PROFILES_DIR ?? null; -- caller's explicit baseDir:null is nullish, falls through to env.",
+      },
+      fr6_actual_result_under_real_env: { ok: true, 'spawnResult.env.CLAUDE_CONFIG_DIR': 'C:\\Users\\rickf\\.claude-fleet-profiles\\canary', interpretation: 'profile isolation IS applied via env fallback; no unisolated launch occurs' },
+    }),
+    metadata: {
+      verified_claims: {
+        baseline_3_failed_66_passed: 'CONFIRMED (independently re-run, exact match)',
+        neutralized_69_passed: 'CONFIRMED (independently re-run, exact match)',
+        root_cause_single_class_nullish_coalescing_env_fallback: 'CONFIRMED (read both cited lines, both match)',
+        refusal_logic_intact_no_fail_open: 'CONFIRMED — adversarial check on FR-6 shows restart() reaching ok:true still applies real, existing-on-disk profile isolation via the env fallback, not a bypass of isolation',
+      },
+      binding_ruling_honored: 'Did not edit tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js or tests/unit/fleet/spawn-control.test.js; validation-only.',
+    },
+    phase: 'LEAD',
+    validation_mode: 'retrospective',
+    summary: "PASS for LEAD-TO-PLAN. Independently re-ran both cited vitest commands and got identical counts to the worker's report (3 failed/66 passed baseline; 69 passed neutralized). Read spawn-control.js:103 and :227 directly and confirmed the described `opts.X ?? process.env.Y` nullish-coalescing pattern at both sites, one root-cause class. Adversarially checked the strongest counter-reading (does restart() reaching ok:true under FR-6's baseDir:null actually skip isolation?) and found it does not: CLAUDE_CONFIG_DIR is still set to the real, on-disk, env-resolved profile subdirectory — the profile-stamped restart launches WITH isolation and reports success, contradicting the possibility of the title's fail-open framing being literally true in the current codebase. The determination that all three failures are environment-dependent (this developer's persistent, gitignored .env), the refusal/isolation logic is intact, and there is no fail-open is CONFIRMED with high confidence. One non-blocking observation logged as a warning for a future, separate SD/QF: the tests' verdict is sensitive to an uncontrolled local env, which is a reproducibility hazard independent of today's determination.",
+  };
+
+  results = applySubAgentRepoVerdict(results, resolution);
+  const stored = await storeSubAgentResults('VALIDATION', SD_ID, { name: 'Principal Systems Analyst (validation-agent)' }, results, { sdKey: SD_KEY, phase: 'LEAD' });
+  console.log('VALIDATION result stored:', stored.id, stored.verdict, stored.confidence);
+}
+
+main().catch((e) => { console.error('FAILED:', e.message); console.error(e.stack); process.exit(1); });

--- a/scripts/one-off/_plan-testing-evidence-three-refusal-tests-001.mjs
+++ b/scripts/one-off/_plan-testing-evidence-three-refusal-tests-001.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+/**
+ * One-off: write TESTING sub-agent evidence at the PLAN phase for
+ * SD-LEO-INFRA-THREE-REFUSAL-TESTS-001, ahead of the PLAN-TO-EXEC handoff.
+ *
+ * Scope: assess the PRD's TEST STRATEGY (not implement it -- EXEC has not run yet).
+ *   1. Capture the baseline unit-tier failure SET (membership, not just count) via a real
+ *      `npx vitest run --project unit --reporter=verbose` on this worktree, unmodified.
+ *   2. Judge FR-1's `baseDir: ''` mechanism against the real resolveProfileDir source.
+ *   3. Judge FR-2's risk: does clearing FLEET_ACCOUNT_PROFILES_DIR / FLEET_SPAWN_CONTROL_LIVE /
+ *      FLEET_BROWSER_PROFILES_DIR / FLEET_CANARY_KILL_ENABLED at the unit-project env level break
+ *      any OTHER unit test that depends on one of those vars being SET via ambient process.env.
+ *   4. Flag test-strategy gaps.
+ *
+ * Canonical repo-evidence pattern (lib/sub-agents/resolve-repo.js applySubAgentRepoVerdict +
+ * lib/sub-agent-executor/results-storage.js storeSubAgentResults) per CLAUDE.md prologue rule 11
+ * -- no hand-rolled repo_path/local_path columns.
+ */
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../../lib/sub-agent-executor/results-storage.js';
+import { getSupabaseClient } from '../../lib/sub-agent-executor/supabase-client.js';
+
+const SD_ID = '581a0da1-331a-4429-9969-a45667df076f';
+const SD_KEY = 'SD-LEO-INFRA-THREE-REFUSAL-TESTS-001';
+
+// Baseline captured live: `npx vitest run --project unit --reporter=verbose` on this worktree,
+// working tree unmodified (tests/unit/fleet/spawn-control.test.js,
+// tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js, vitest.config.js all at
+// their pre-fix content). Ambient env: this worktree's real .env
+// (FLEET_SPAWN_CONTROL_LIVE=true, FLEET_ACCOUNT_PROFILES_DIR set, FLEET_CANARY_KILL_ENABLED=true).
+const BASELINE = {
+  command: 'npx vitest run --project unit --reporter=verbose',
+  result_line: 'Test Files  9 failed | 2671 passed | 3 skipped (2683); Tests  14 failed | 32025 passed | 83 skipped | 2 todo (32124)',
+  duration_s: 129.3,
+  failed_tests: [
+    { file: 'lib/crm/pipeline-integration.e2e.test.js', test: 'Relationship Engine — fixture-venture traversal (TS-1..TS-5) > TS-4: EVA meeting surface reads live pipeline data for the venture', in_scope: false },
+    { file: 'tests/unit/append-fleet-commit-trailer.test.js', test: 'leaves the message unchanged when the session lookup finds nothing (fail-open, bad session id)', in_scope: false },
+    { file: 'tests/unit/append-fleet-commit-trailer.test.js', test: 'is idempotent: running twice never double-stamps', in_scope: false },
+    { file: 'tests/unit/unit-tier-env-isolation.test.js', test: 'does NOT leak SUPABASE_URL from the repo .env file into the unit project', in_scope: false, note: 'SAME root-cause CLASS (host .env leaking into unit tier via vitest.config.js parent-process loadEnv) but for SUPABASE_URL, not the FLEET_* vars this PRD scopes. Directly relevant precedent for FR-2, not itself in scope.' },
+    { file: 'tests/unit/unit-tier-env-isolation.test.js', test: 'uses the synthetic sentinels when no host-shell creds exist', in_scope: false, note: 'same note as above' },
+    { file: 'tests/unit/complete-quick-fix/external-timeout-and-coverage-gate.test.js', test: 'honors a valid LEO_QF_EXTERNAL_STEP_TIMEOUT_MS env override (computed at import)', in_scope: false },
+    { file: 'tests/unit/complete-quick-fix/external-timeout-and-coverage-gate.test.js', test: 'falls back to the default on an invalid env override', in_scope: false },
+    { file: 'tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js', test: "canaryRestart: WITHOUT opts.live (pre-fix call shape), the same real chain honestly reports replacement_not_live -- reproduces the exact production bug", in_scope: true, sd_target: 'FR-2' },
+    { file: 'tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js', test: 'canaryRelaunchUnderProfile: WITHOUT opts.live (pre-fix call shape), honestly reports replacement_not_live', in_scope: true, sd_target: 'FR-2' },
+    { file: 'tests/unit/fleet/spawn-control.test.js', test: 'restart (FR-4 singleton-serial / FR-5 worker-parallel) > FR-6: restarting a profile-stamped session with NO profiles dir configured FAILS LOUD', in_scope: true, sd_target: 'FR-1' },
+    { file: 'tests/unit/golden-references/witness-emitter-acceptance.test.js', test: 'doctrine mutations fail named checks (miss direction) > action OUTSIDE the transaction fails action_inside_transaction', in_scope: false },
+    { file: 'tests/unit/hooks/session-register-created-emission.test.js', test: 'QF-20260725-480: SESSION_CREATED is emitted by the session-register hook > is actually WIRED INTO the hook: main() probes first, then calls it on success', in_scope: false },
+    { file: 'tests/unit/setup/env-isolation-guard.test.js', test: 'FR-1 env isolation guard (per-test process.env reset) > the synthetic test.invalid default survives the per-test restore', in_scope: false, note: 'same env-isolation failure class as unit-tier-env-isolation.test.js above (SUPABASE_URL), unrelated to FLEET_*' },
+    { file: 'tests/unit/setup/env-isolation-guard.test.js', test: 'FR-1 env isolation guard (per-test process.env reset) > SUPABASE_URL is back after the delete in the prior test (restore on delete)', in_scope: false },
+  ],
+};
+const BASELINE_FAILED_SET = new Set(BASELINE.failed_tests.map(t => `${t.file} :: ${t.test}`));
+const IN_SCOPE_COUNT = BASELINE.failed_tests.filter(t => t.in_scope).length; // expect exactly 3
+
+async function main() {
+  const supabase = await getSupabaseClient();
+  const resolution = await resolveSubAgentRepo({ sdId: SD_KEY, targetApplication: 'EHG_Engineer', subAgentCode: 'TESTING', supabase });
+
+  if (IN_SCOPE_COUNT !== 3) {
+    throw new Error(`Expected exactly 3 in-scope baseline failures (the SD's three refusal tests), found ${IN_SCOPE_COUNT}. Re-check BASELINE before writing evidence.`);
+  }
+
+  let results = {
+    verdict: 'PASS',
+    confidence: 87,
+    findings: [
+      {
+        id: 'F1-baseline-failure-set-captured',
+        severity: 'INFO',
+        summary: `Ran \`${BASELINE.command}\` live on this unmodified worktree (working tree matches origin/main for every file this PRD's editable set touches: tests/unit/fleet/spawn-control.test.js, tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js, vitest.config.js). Result: ${BASELINE.result_line} (${BASELINE.duration_s}s). This is the single most valuable PLAN-phase artifact for EXEC: 11 of 14 failures are pre-existing and OUT of this PRD's scope (2 distinct unrelated classes: a second, already-present instance of the SAME root-cause pattern this PRD fixes -- host .env SUPABASE_URL leaking into the unit tier via vitest.config.js's parent-process loadEnv, hitting tests/unit/unit-tier-env-isolation.test.js and tests/unit/setter/env-isolation-guard.test.js -- plus 7 genuinely unrelated failures in append-fleet-commit-trailer, external-timeout-and-coverage-gate, witness-emitter-acceptance, session-register-created-emission, and lib/crm/pipeline-integration.e2e.test.js). Exactly 3 failures are in-scope: the two cp3 'WITHOUT opts.live' tests (FR-2 target) and spawn-control.test.js's FR-6 case (FR-1 target) -- matching the SD's stated count exactly. Full membership list is recorded in this row's detailed_analysis.baseline_failed_tests for EXEC to diff against post-fix.`,
+      },
+      {
+        id: 'F2-fr1-mechanism-confirmed-against-real-source',
+        severity: 'INFO',
+        summary: "Read lib/fleet/spawn-control.js:102-104 directly: `const baseDir = opts.baseDir ?? process.env.FLEET_ACCOUNT_PROFILES_DIR ?? null; if (!baseDir) throw ...`. Confirmed both halves of FR-1's claim: (a) `null` IS nullish, so `opts.baseDir ?? X` treats an explicit `baseDir: null` from spawn-control.test.js:895 as absent and falls through to `process.env.FLEET_ACCOUNT_PROFILES_DIR` (which this .env sets), so the throw never arms; (b) `''` is NOT nullish (`?? ` only substitutes on null/undefined), so `baseDir: ''` survives the `??` chain unchanged, and the following `if (!baseDir)` guard IS tripped by `''` (empty string is falsy). The mechanism is correct: changing line 895's `baseDir: null` to `baseDir: ''` makes the throw arm regardless of ambient FLEET_ACCOUNT_PROFILES_DIR, without touching the assertion (`.rejects.toThrow(/FLEET_ACCOUNT_PROFILES_DIR/)` at line 896 is unchanged) or any production file.",
+      },
+      {
+        id: 'F3-fr2-risk-search-low-risk-confirmed',
+        severity: 'INFO',
+        summary: "Searched tests/ for every read of FLEET_ACCOUNT_PROFILES_DIR, FLEET_SPAWN_CONTROL_LIVE, FLEET_BROWSER_PROFILES_DIR, FLEET_CANARY_KILL_ENABLED and classified each site by whether it reads real process.env (at risk from FR-2's vitest-project env override) or an explicitly-passed opts.env / function arg (unaffected, dependency-injected). RESULT: every production call site that a unit test exercises threads env explicitly EXCEPT lib/fleet/spawn-control.js:227 (`const live = opts.live ?? isLiveEnabled();` -- isLiveEnabled() called with ZERO args, defaulting to real process.env per its own signature `isLiveEnabled(env = process.env)` at line 115) -- and that IS the exact site the two cp3 tests exist to exercise (they intentionally omit opts.live and rely on the env fallback), so it is FR-2's actual target, not collateral risk. The one direct process.env.FLEET_ACCOUNT_PROFILES_DIR read inside a test (spawn-control.test.js:196-201, 'throws if no base dir is configured') already deletes-then-restores it around its own assertion specifically because of this pre-existing leak; under FR-2 the delete becomes a no-op (already absent) and the restore is a no-op (saved is already undefined) -- compatible either way, no behavior change. lib/fleet/reboot-respawn-runner.js:182 has the SAME `opts.live ?? isLiveEnabled()` shape (a second instance of the class), but every call in tests/unit/fleet/reboot-respawn-runner.test.js supplies `live: true` or `live: false` explicitly, so its isLiveEnabled() fallback is never reached by any current unit test -- zero exposure today. scripts/fleet/worker-spawn-executor.cjs has its own separate isLiveEnabled() reading a DIFFERENT var (WORKER_SPAWN_EXECUTOR_LIVE), confirmed by its test always passing explicit env objects -- unaffected. isCanaryKillEnabled (lib/fleet/canary-guard.js:38, FLEET_CANARY_KILL_ENABLED) is called at its one production site as `isCanaryKillEnabled(opts.env)` -- opts.env is always threaded, never defaults to bare process.env -- and every canary-guard.test.js case passes an explicit env object, several of which assert 'is OFF by default' using `{}`, not ambient process.env; unaffected by FR-2 either way. FLEET_BROWSER_PROFILES_DIR is unset in this .env today, so clearing it in FR-2's scope (per the PRD's runtime_config note) is a no-op on this host but closes the same latent host-dependency in tests/unit/fleet/browser-control.test.js's 'requires FLEET_BROWSER_PROFILES_DIR' case for any OTHER host whose .env happens to set it. CONCLUSION: FR-2's env-clearing carries LOW collateral risk -- no currently-passing unit test depends on ambient truthiness of any of the four named vars via direct process.env reads.",
+      },
+      {
+        id: 'F4-fr2-precedent-mechanism-sound',
+        severity: 'INFO',
+        summary: "Read vitest.config.js:196-219: the unit project already neutralises FLEET_REPO_ROOT via a project-level `env: { FLEET_REPO_ROOT: './tests/fixtures/__no_such_tree__' }` override, applied inside the forked worker after the parent process's dotenv loadEnv (lines 16-17) has already populated process.env -- the exact mechanism FR-2 proposes reusing for FLEET_ACCOUNT_PROFILES_DIR / FLEET_SPAWN_CONTROL_LIVE. Setting the override value to '' (not literally deleting the key) is consistent with TR-4's 'empty string, not delete' precondition mechanism: '' still trips resolveProfileDir's `!baseDir` guard (empty string is falsy) and still fails isLiveEnabled's `=== 'true'` check, so either an explicit '' or an omitted key produces the same refusal outcome for the two production functions in scope.",
+      },
+    ],
+    warnings: [
+      "Baseline captured 14 failed / 32025 passed on this host today -- the SD's own text estimated '~23 pre-existing unrelated failures', a higher number from a stale prior measurement. This is expected drift (main has moved since that number was written) and does not affect the strategy assessment, since the comparison EXEC needs is membership-delta on ITS OWN before/after runs, not a match to this SD's narrative number. Recorded here so a future reader does not treat the ~23 figure as authoritative.",
+      "TS-4 ('Regression guard on the rest of the unit tier after the vitest.config.js env override') has no numbered AC of its own beyond AC-6 ('pre-existing unit-tier failures are not broadened') -- satisfied by this row's captured baseline failure SET, which EXEC should diff by membership (not count) against its post-fix run. Flagging that the PRD does not explicitly tell EXEC where that baseline is recorded; this row is now that location.",
+      "The PRD's FR-2 acceptance criteria bullets name only FLEET_ACCOUNT_PROFILES_DIR and FLEET_SPAWN_CONTROL_LIVE explicitly; FLEET_BROWSER_PROFILES_DIR appears only in the narrative runtime_config section ('worth neutralising with the others'), not as a numbered AC. Minor scope ambiguity for EXEC: recommend including it in the vitest.config.js env block anyway (F3/F4 above show it is a no-op on this host and closes the same latent class for other hosts), but it is not enforceable as a gate failure if EXEC omits it, since no AC names it.",
+    ],
+    recommendations: [
+      "EXEC: use this row's detailed_analysis.baseline_failed_tests as the pre-fix membership set. After applying FR-1+FR-2, re-run `npx vitest run --project unit --reporter=verbose` under BOTH ambient env and an explicitly-cleared env (FLEET_SPAWN_CONTROL_LIVE= FLEET_ACCOUNT_PROFILES_DIR= in the invoking shell), and confirm: (a) all 3 in-scope tests move from failed to passed in both runs, (b) all 11 out-of-scope pre-existing failures are still present and unchanged in both runs (membership match, not just count), (c) the two ambient/cleared runs report identical pass/fail counts for the two target files per AC-1/AC-2.",
+      "EXEC: include FLEET_BROWSER_PROFILES_DIR: '' alongside FLEET_ACCOUNT_PROFILES_DIR: '' and FLEET_SPAWN_CONTROL_LIVE: '' in the vitest.config.js unit-project env override, even though only the first two are named in FR-2's numbered AC -- it is a no-op on this host and forward-hardens tests/unit/fleet/browser-control.test.js.",
+    ],
+    detailed_analysis: JSON.stringify({
+      sd_key: SD_KEY,
+      phase: 'PLAN',
+      scope_note: 'TEST-STRATEGY assessment only -- no code has been written yet (PLAN-TO-EXEC handoff evidence, not post-implementation verification). No files were modified by this evidence run.',
+      baseline: BASELINE,
+      baseline_failed_tests: BASELINE.failed_tests,
+      in_scope_baseline_failure_count: IN_SCOPE_COUNT,
+      out_of_scope_baseline_failure_count: BASELINE.failed_tests.length - IN_SCOPE_COUNT,
+      fr1_mechanism_verified: {
+        file: 'lib/fleet/spawn-control.js',
+        lines: '102-104',
+        source_read: "const baseDir = opts.baseDir ?? process.env.FLEET_ACCOUNT_PROFILES_DIR ?? null; if (!baseDir) throw new Error('resolveProfileDir: FLEET_ACCOUNT_PROFILES_DIR is not configured');",
+        null_survives_qq: false,
+        empty_string_survives_qq: true,
+        empty_string_trips_guard: true,
+        verdict: 'CONFIRMED correct',
+      },
+      fr2_risk_scan: {
+        vars_searched: ['FLEET_ACCOUNT_PROFILES_DIR', 'FLEET_SPAWN_CONTROL_LIVE', 'FLEET_BROWSER_PROFILES_DIR', 'FLEET_CANARY_KILL_ENABLED'],
+        direct_process_env_reads_in_tests: [
+          { file: 'tests/unit/fleet/spawn-control.test.js', lines: '196-201', var: 'FLEET_ACCOUNT_PROFILES_DIR', self_compensating: true },
+        ],
+        bare_isLiveEnabled_fallback_sites: [
+          { file: 'lib/fleet/spawn-control.js', line: 227, exercised_by: ['tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js'], is_fr2_target: true },
+          { file: 'lib/fleet/reboot-respawn-runner.js', line: 182, exercised_by: [], note: 'every call in reboot-respawn-runner.test.js passes opts.live explicitly; fallback never reached; zero exposure' },
+        ],
+        distinct_isLiveEnabled_copies_unaffected: ['scripts/fleet/worker-spawn-executor.cjs (reads WORKER_SPAWN_EXECUTOR_LIVE, not FLEET_SPAWN_CONTROL_LIVE)'],
+        isCanaryKillEnabled: { call_site: 'lib/fleet/canary-guard.js:101', reads: 'opts.env (always threaded, never bare process.env)', unaffected: true },
+        FLEET_BROWSER_PROFILES_DIR: { currently_set_in_dotenv: false, clearing_is_noop_on_this_host: true, closes_latent_gap_for_other_hosts: true },
+        overall_risk: 'LOW',
+      },
+      gaps_flagged: [
+        'Baseline failure SET was not previously recorded anywhere in the PRD/SD row; this evidence row is now the recorded location EXEC must diff against.',
+        'FLEET_BROWSER_PROFILES_DIR scope ambiguity (narrative-only, not a numbered FR-2 AC).',
+      ],
+    }),
+    metadata: {
+      test_strategy_verified: {
+        fr1_baseDir_empty_string_mechanism: 'CONFIRMED against real source at spawn-control.js:102-104',
+        fr2_env_clearing_collateral_risk: 'LOW -- searched all 4 named vars across tests/, only 1 in-scope bare-fallback site (the FR-2 target itself), 1 self-compensating direct read, everything else dependency-injected',
+        baseline_failure_membership_captured: true,
+        in_scope_failure_count_matches_sd_claim_of_3: true,
+      },
+    },
+    phase: 'PLAN',
+    validation_mode: 'prospective',
+    summary: `PASS for PLAN-TO-EXEC. Ran the real unit-tier suite unmodified on this worktree: ${BASELINE.result_line}. Exactly 3 of 14 failures are in-scope (the two cp3 'WITHOUT opts.live' tests + spawn-control.test.js FR-6), matching the SD's claim; the other 11 are pre-existing and out of scope (2 of which are the SAME leak-class for SUPABASE_URL, not FLEET_*). FR-1's baseDir:'' mechanism is CONFIRMED correct against the real resolveProfileDir source (null is nullish and falls through ??, '' is not nullish and survives ?? while still tripping the falsy guard). FR-2's env-clearing risk is LOW: searched every test read of the four named FLEET_* vars; the only bare-process.env fallback a unit test exercises is spawn-control.js:227, which is FR-2's actual target, not collateral; every other site is either dependency-injected via an explicit opts.env / function arg, or reads a differently-named variable in an unrelated module. The full baseline failure-set membership is recorded in detailed_analysis.baseline_failed_tests for EXEC's before/after diff (TS-4 / AC-6). One scope-ambiguity gap flagged as a warning (FLEET_BROWSER_PROFILES_DIR is narrative-only, not a numbered FR-2 AC) with a non-blocking recommendation to include it anyway.`,
+  };
+
+  results = applySubAgentRepoVerdict(results, resolution);
+  const stored = await storeSubAgentResults('TESTING', SD_ID, { name: 'Enhanced QA Engineering Director (testing-agent)' }, results, { sdKey: SD_KEY, phase: 'PLAN' });
+  console.log('TESTING result stored:', stored.id, stored.verdict, stored.confidence);
+}
+
+main().catch((e) => { console.error('FAILED:', e.message); console.error(e.stack); process.exit(1); });

--- a/scripts/one-off/_rescope-three-refusal-tests-001.mjs
+++ b/scripts/one-off/_rescope-three-refusal-tests-001.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * One-off: LEAD re-scope of SD-LEO-INFRA-THREE-REFUSAL-TESTS-001.
+ *
+ * Required by the coordinator ruling (msg 52646e3b) and by
+ * metadata.coordinator_fence_review_20260727.headline_correction: the SD headline is FALSIFIED by
+ * the test output and must be restated before PLAN.
+ *
+ * The original description is PRESERVED verbatim below the correction — the provenance (Alpha-3's
+ * baseline reproduction, the binding no-edit ruling) is the valuable part of the row and the point
+ * of a re-scope is to stop the next reader inheriting a false premise, not to erase the history.
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const SD_KEY = 'SD-LEO-INFRA-THREE-REFUSAL-TESTS-001';
+
+const NEW_TITLE = 'Three refusal tests take their verdict from operator .env and never exercise the guard they assert - host-environment leakage into the unit tier, NOT a fail-open';
+
+const CORRECTION = `*** LEAD RE-SCOPE 2026-07-27 (Alpha-4, worker 39aa8a1e). THE HEADLINE BELOW WAS FALSIFIED BY MEASUREMENT. READ THIS FIRST. ***
+
+THERE IS NO FAIL-OPEN. ALL THREE REFUSALS ARE INTACT. The original title asserted "a profile-stamped
+restart can launch without its isolation and report success". It does not: the FR-6 failure diff shows
+the spawn env carried CLAUDE_CONFIG_DIR=C:\\Users\\rickf\\.claude-fleet-profiles\\canary, i.e. it launched
+WITH its isolation, to a directory that exists on this host. Materially less severe than the headline.
+
+THE NEGATIVE CONTROL — the required first acceptance evidence, on the SAME commit that yields 3 failures
+under ambient env, with UNMODIFIED tests and UNMODIFIED source:
+  baseline                                                    -> 3 failed / 66 passed
+  FLEET_SPAWN_CONTROL_LIVE=false FLEET_ACCOUNT_PROFILES_DIR=  -> 69 passed / 0 failed
+The earlier throwaway-worktree reproduction could NOT discriminate a code regression from host env,
+because .env is gitignored and reaches every checkout on this host identically. This control can.
+
+ONE ROOT CAUSE, NOT THREE: \`opts.X ?? process.env.Y\`, where a test passes a NULLISH opt meaning
+"absent" and ?? falls through to an operator env var that this repo's own .env sets.
+  - lib/fleet/spawn-control.js:227  \`const live = opts.live ?? isLiveEnabled();\` — isLiveEnabled() is
+    called with NO ARGUMENT, so it reads process.env and BYPASSES the \`env: GUARD_ENV\` the cp3 tests
+    thread in precisely to control it (GUARD_ENV is only {FLEET_CANARY_KILL_ENABLED}). .env:186 sets
+    FLEET_SPAWN_CONTROL_LIVE=true, so "opts.live absent" resolves LIVE and the spawn the test forbids
+    is CORRECT behaviour on this host. Accounts for cp3 tests 1 and 2.
+  - lib/fleet/spawn-control.js:103  \`const baseDir = opts.baseDir ?? process.env.FLEET_ACCOUNT_PROFILES_DIR ?? null;\`
+    The FR-6 test passes baseDir:null meaning "no profiles dir"; ?? treats explicit null as absent and
+    .env supplies one, so the fail-loud never arms. Accounts for test 3.
+
+THE ACTUAL DEFECT, STATED NARROWLY: three REFUSAL tests silently take their verdict from operator
+environment, so on any host where these vars are set the guard they exist to prove is NEVER EXERCISED —
+they report green or red for the wrong reason. A refusal test that cannot establish its own precondition
+is not evidence. The root cause sits one level above the call sites: vitest.config.js:16-17 loads the
+real .env into the PARENT process and pool:'forks' inherits it into every unit worker, so
+tests/setup.unit.js's \`||=\` sentinels never fire. That same gap independently explains the red
+tests/unit/setup/env-isolation-guard.test.js (its SUPABASE_URL sentinel is never applied).
+
+RULED SCOPE (coordinator msg 52646e3b + metadata.coordinator_fence_review_20260727):
+  IN  — (i) test-side: spawn-control.test.js FR-6 baseDir:null -> baseDir:"" so the test establishes its
+        own precondition regardless of host; AND the durable half, fix the HARNESS LEAK so the unit tier
+        does not inherit operator .env. Editable files are exactly: tests/unit/fleet/spawn-control.test.js,
+        tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js, vitest.config.js.
+  OUT — (ii) source-side (making resolveProfileDir honour an explicitly-passed null). It is the RIGHT fix
+        — ?? is the wrong operator for a caller-supplied "none" — but lib/fleet/spawn-control.js is
+        CONTESTED: SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 has ~20 open PRs and every one modifies it.
+        The coordinator owns filing it, sequenced behind that stack. DO NOT scope-creep into it.
+  NOTE — the two cp3 tests CANNOT be fixed test-side: their whole subject is the "opts.live ABSENT"
+        call shape, so passing live:false to make them host-independent would delete the case under test.
+        The harness fix is the only correct lever for those two.
+
+THE BINDING NO-EDIT RULING WAS RIGHT AND IT HELD. Greening these by editing the assertions would have
+destroyed three good guards to chase a host config. The ruling permitted a proposal once the refusal
+question was answered; it now is, by two independent paths (this determination and the coordinator's
+14-agent fence review), which is why the test-side edit is authorised rather than forbidden.
+
+=================== ORIGINAL DESCRIPTION AS FILED (PRESERVED, PREMISE FALSIFIED ABOVE) ===================
+
+`;
+
+async function main() {
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const { data: row, error: readErr } = await supabase
+    .from('strategic_directives_v2').select('id, title, description, metadata').eq('sd_key', SD_KEY).maybeSingle();
+  if (readErr) throw new Error(`read failed: ${readErr.message}`);
+  if (!row) throw new Error('SD not found');
+
+  if (String(row.description || '').includes('LEAD RE-SCOPE 2026-07-27')) {
+    console.log('Already re-scoped (idempotent no-op).');
+    return;
+  }
+
+  const metadata = {
+    ...(row.metadata || {}),
+    lead_rescope_20260727: {
+      at: new Date().toISOString(),
+      by: 'Alpha-4 (worker 39aa8a1e)',
+      original_title: row.title,
+      verdict: 'NO fail-open; all three refusals intact. Host-environment leakage into the unit tier.',
+      negative_control: 'FLEET_SPAWN_CONTROL_LIVE=false FLEET_ACCOUNT_PROFILES_DIR= npx vitest run <both files> => 69 passed / 0 failed on the same commit that yields 3 failed / 66 passed under ambient env.',
+      authorised_scope: ['tests/unit/fleet/spawn-control.test.js', 'tests/unit/fleet/cp3-restart-relaunch-live-flag-propagation.test.js', 'vitest.config.js'],
+      excluded_scope: 'lib/fleet/spawn-control.js — contested by SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 (~20 open PRs); source-side fix owned by coordinator, sequenced behind that stack.',
+      ruling_ref: 'coordinator msg 52646e3b + metadata.coordinator_fence_review_20260727',
+    },
+  };
+
+  const { error: updErr } = await supabase.from('strategic_directives_v2')
+    .update({ title: NEW_TITLE, description: CORRECTION + String(row.description || ''), metadata })
+    .eq('sd_key', SD_KEY);
+  if (updErr) throw new Error(`update failed: ${updErr.message}`);
+  console.log('Re-scoped', SD_KEY);
+  console.log('  new title:', NEW_TITLE);
+}
+
+main().catch((e) => { console.error('FAILED:', e.message); process.exit(1); });

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -890,9 +890,17 @@ describe('restart (FR-4 singleton-serial / FR-5 worker-parallel)', () => {
       sessions: [{ session_id: 's1', status: 'active', metadata: { fleet_identity: { callsign: 'Canary-1' }, role: 'worker', account_profile: 'canary' } }],
     });
 
+    // SD-LEO-INFRA-THREE-REFUSAL-TESTS-001 FR-1: baseDir was `null` here, which never created
+    // the "NO profiles dir configured" precondition this test's own name claims. resolveProfileDir
+    // (lib/fleet/spawn-control.js:103) is `opts.baseDir ?? process.env.FLEET_ACCOUNT_PROFILES_DIR
+    // ?? null`, and `??` treats an explicit null as ABSENT — so on any host that sets the env var
+    // (this repo's .env does) the caller's "none" was discarded, the fail-loud never armed, and
+    // restart() resolved { ok: true }. '' is falsy but NOT nullish: it survives `??` and trips the
+    // `if (!baseDir)` guard on the next line, so the refusal is now asserted on every host rather
+    // than borrowed from operator environment. The assertion below is deliberately unchanged.
     await expect(restart('Canary-1', {
       supabaseClient, live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn: enumExec(),
-      sleepFn: vi.fn(), baseDir: null,
+      sleepFn: vi.fn(), baseDir: '',
     })).rejects.toThrow(/FLEET_ACCOUNT_PROFILES_DIR/);
   });
 

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -216,7 +216,38 @@ export default defineConfig({
           // inject opts.currencyRunner now fails FAST and IDENTICALLY on every machine.
           // This is deliberately not a bypass: it makes nothing pass that would otherwise
           // fail. It converts a hidden environmental accident into a loud, uniform one.
-          env: { FLEET_REPO_ROOT: './tests/fixtures/__no_such_tree__' },
+          //
+          // SD-LEO-INFRA-THREE-REFUSAL-TESTS-001 FR-2 — same class, same remedy, three more
+          // vars. The unit tier still inherits the operator's real .env DESPITE line 201's
+          // intent: vitest.config.js:16-17 loads .env in the PARENT process (for DB-target
+          // gating), and `pool: 'forks'` means every worker inherits that process.env before
+          // setup.unit.js can do anything about it. Not loading .env in the project is not
+          // the same as the project not HAVING it.
+          //
+          // What that cost: three REFUSAL tests in tests/unit/fleet/ took their verdict from
+          // whether an operator happened to export a variable. They assert "no profiles dir
+          // configured" / "spawn-control live flag off" by passing a nullish option, but
+          // lib/fleet/spawn-control.js resolves `opts.X ?? process.env.Y` — and `??` treats an
+          // explicit null as ABSENT, so the caller's "none" is discarded in favour of the env
+          // var. Measured on one commit, unmodified tests and source: ambient env gave
+          // 3 failed / 66 passed; `FLEET_SPAWN_CONTROL_LIVE= FLEET_ACCOUNT_PROFILES_DIR=` gave
+          // 69 passed. The guards were never broken — they were never EXERCISED.
+          //
+          // Empty string, not delete: '' is falsy but NOT nullish, so it survives `??` and
+          // still trips the `if (!baseDir)` / `=== 'true'` guards. Deleting the key would let
+          // `??` fall through to the next candidate again, which is the whole defect.
+          //
+          // FLEET_CANARY_KILL_ENABLED is deliberately NOT listed: every call site passes it
+          // explicitly via opts.env, so it has no ambient-fallback path to close.
+          env: {
+            FLEET_REPO_ROOT: './tests/fixtures/__no_such_tree__',
+            FLEET_ACCOUNT_PROFILES_DIR: '',
+            FLEET_SPAWN_CONTROL_LIVE: '',
+            // Unset on this host today, so neutralising it is a no-op here — which is exactly
+            // why it belongs: tests/unit/fleet/browser-control.test.js currently passes by
+            // accident and would go red for any operator who exports it.
+            FLEET_BROWSER_PROFILES_DIR: '',
+          },
           include: [
             '**/__tests__/**/*.test.js',
             '**/*.test.js',


### PR DESCRIPTION
## The filed premise was falsified

The SD reported three red refusal tests "all failing in the fail-open direction", concluding a
profile-stamped restart could launch **without its isolation** and report success.

It doesn't. The FR-6 failure diff shows the spawn carried
`CLAUDE_CONFIG_DIR=…\.claude-fleet-profiles\canary` — a directory that exists on this host. It
launched **with** isolation. All three refusals are intact. They were never *exercised*.

A binding ruling forbade editing these tests until that question was answered. It was the right
call: greening them would have destroyed three good guards to chase a host config.

## One root cause, not three

Each test expresses *"this operator setting is absent"* by passing a nullish option. But
`lib/fleet/spawn-control.js` resolves `opts.X ?? process.env.Y`, and `??` treats an explicit
`null` as **absent** — so the caller's "none" is discarded in favour of a var this repo's own
`.env` sets.

| Site | Why the test's control is bypassed |
|---|---|
| `:227` `opts.live ?? isLiveEnabled()` | `isLiveEnabled()` is called with **no argument**, so it reads `process.env` and bypasses the `env: GUARD_ENV` the cp3 tests thread in precisely to control it. `.env:186` sets `FLEET_SPAWN_CONTROL_LIVE=true`. |
| `:103` `opts.baseDir ?? process.env.FLEET_ACCOUNT_PROFILES_DIR` | The FR-6 test passes `baseDir: null`, so the fail-loud never arms. |

## The change

**FR-1** `spawn-control.test.js` — `baseDir: null` → `baseDir: ''`. `''` is falsy but **not
nullish**, so it survives `??` and trips `if (!baseDir)`. The assertion is untouched; only the
precondition changes, and it changes to assert *more* strictly.

**FR-2** `vitest.config.js` — the unit tier still inherited the operator `.env` despite its stated
intent, because `vitest.config.js:16-17` loads `.env` in the **parent** process and `pool: 'forks'`
inherits it before `setup.unit.js` runs. Not loading `.env` in the project is not the same as the
project not *having* it. Neutralised via the `FLEET_REPO_ROOT` precedent already in that block.

## Acceptance is sameness, not greenness

A test that passes because a var happens to be unset is in the same failure class as one that fails
because it happens to be set. So the signal is that both runs agree:

```
ambient (.env intact)                                        69 passed (69)
FLEET_SPAWN_CONTROL_LIVE=false FLEET_ACCOUNT_PROFILES_DIR=   69 passed (69)
```

Baseline on the same commit was `3 failed / 66 passed`.

**Full unit tier:** the 3 in-scope failures are gone; the 7 pre-existing unrelated failing files are
unchanged in membership. Two full-suite-only flakes appeared (`worktree-delete-primitive-static-guard`
once, `eva/complexity-scorer` twice) — both pass in isolation **with and without** this change, and
`complexity-scorer` contains zero `process.env` references, so an env-only change cannot reach it.
Reported rather than swept up.

## Deliberately not fixed here

Making `resolveProfileDir` honour an explicitly-passed `null` is the better fix — `??` is the wrong
operator for a caller-supplied "none", and today any caller passing `baseDir: null` silently receives
the env dir instead of a refusal. It is excluded **only** because `lib/fleet/spawn-control.js` is
contested by ~20 open PRs from `SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001`. The coordinator owns filing
it behind that stack. **`spawn-control.js` is byte-identical to `origin/main` in this PR.**

The two cp3 tests are also untouched by design: their subject *is* the `opts.live` **absent** call
shape, so passing `live: false` would delete the case under test. They are fixed entirely by the
harness change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
