### PR TITLE
feat(SD-LEO-INFRA-DETECTOR-OUTPUT-DRAIN-001): drain inventory — pair every detector with a named consumer, measure staleness on the drain

### DIFF
--- a/lib/governance/drain-inventory.js
+++ b/lib/governance/drain-inventory.js
@@ -132,6 +132,36 @@ export function assertThresholdBelowRetention(thresholdMs, retentionMs) {
   return null;
 }
 
+export const PAGE_SIZE = 1000;
+
+/**
+ * Exhaustive pagination over an ORDERED page fetcher.
+ *
+ * Extracted from the CLI so it is testable: this is where an alarm-suppressing under-read would
+ * originate. PostgREST caps a response at PAGE_SIZE, and the largest population inventoried here
+ * is >4,000 rows — a wrong loop bound, a `<=` where `<` belongs, or a dropped ORDER BY silently
+ * truncates and reports a YOUNGER oldest-age than reality. Reading young is the dangerous
+ * direction: it suppresses the alarm rather than raising a false one.
+ *
+ * @param {(from:number, to:number) => Promise<{rows?:Array, error?:string}>} fetchPage
+ * @returns {Promise<{rows:Array}|{noData:true, reason:string}>}
+ */
+export async function paginateAll(fetchPage, { pageSize = PAGE_SIZE, maxPages = 1000 } = {}) {
+  const all = [];
+  for (let page = 0; page < maxPages; page += 1) {
+    const from = page * pageSize;
+    const res = await fetchPage(from, from + pageSize - 1);
+    if (!res || res.error) return { noData: true, reason: res?.error || 'page fetch returned nothing' };
+    const rows = res.rows || [];
+    all.push(...rows);
+    // STRICTLY less-than: a full page means there may be more. Using <= here would stop one page
+    // early on an exact multiple of pageSize and silently drop the tail.
+    if (rows.length < pageSize) return { rows: all };
+  }
+  // Never silently truncate. Exhausting maxPages is reported, not rendered as a complete read.
+  return { noData: true, reason: `pagination exceeded ${maxPages} pages — refusing to report a truncated population as complete` };
+}
+
 /** Exit code for a completed inventory: non-zero if ANY entry FAILS. */
 export function exitCodeFor(verdicts) {
   return (Array.isArray(verdicts) ? verdicts : []).some(isFailing) ? 1 : 0;

--- a/lib/governance/drain-inventory.js
+++ b/lib/governance/drain-inventory.js
@@ -1,0 +1,166 @@
+/**
+ * Drain inventory — pure core (SD-LEO-INFRA-DETECTOR-OUTPUT-DRAIN-001)
+ *
+ * A detector whose output accumulates unread is indistinguishable, at every downstream surface,
+ * from a detector that never fired. This module answers, per detector: WHO drains it, does a
+ * closing path EXIST, and how old is the OLDEST UNDRAINED row — staleness measured on the DRAIN,
+ * never on whether the detector fired.
+ *
+ * PURE BY DESIGN. All IO lives in the caller (scripts/drain-inventory.mjs), mirroring the
+ * computeBreaches(rows, nowMs) / planSlaBreaches(supabase) split already used in
+ * lib/coordinator/feedback-sla-gauge.cjs. This is not stylistic: the `db` vitest project currently
+ * resolves to ZERO files (tests/helpers/db-target.js DESIGNATED_NON_PROD_REFS is intentionally
+ * empty), so a DB-tier test would never execute and its green would be indistinguishable from
+ * having no coverage. Keeping the logic pure keeps it testable in the `unit` tier.
+ *
+ * VERDICTS ARE SEPARATED BY PROVENANCE, NOT BY OUTCOME:
+ *   STRUCTURAL (zero IO, computed from the descriptor alone) — UNDECLARED, NO_CONSUMER,
+ *     NO_CLOSING_PATH, MEASURED_ELSEWHERE. These are identical whether or not the DB is reachable.
+ *   OBSERVED (requires a read) — PASS, CLOSING_PATH_UNEXERCISED, UNAVAILABLE.
+ * Without that split, a missing .claude/worktree-reaper-state.json reads as UNAVAILABLE (a failed
+ * read) when it is really NO_CLOSING_PATH (a structural fact) — and the two differ in exit code.
+ */
+
+export const VERDICT = Object.freeze({
+  PASS: 'PASS',
+  NO_CONSUMER: 'NO_CONSUMER',
+  NO_CLOSING_PATH: 'NO_CLOSING_PATH',
+  CLOSING_PATH_UNEXERCISED: 'CLOSING_PATH_UNEXERCISED',
+  MEASURED_ELSEWHERE: 'MEASURED_ELSEWHERE',
+  UNDECLARED: 'UNDECLARED',
+  UNAVAILABLE: 'UNAVAILABLE',
+});
+
+/**
+ * Verdicts that FAIL the inventory (HARDENING 1: a detector with no consumer or no expressible
+ * terminal state must FAIL, not render a blank cell — a blank reads as "not yet filled in",
+ * a failure reads as a finding).
+ *
+ * UNAVAILABLE is deliberately NOT a failure: it means we could not measure, which must never be
+ * rendered as either health or a finding. It is reported separately so an unchecked error cannot
+ * manufacture a clean bill of health.
+ */
+export const FAILING_VERDICTS = Object.freeze([
+  VERDICT.NO_CONSUMER,
+  VERDICT.NO_CLOSING_PATH,
+  VERDICT.UNDECLARED,
+]);
+
+export const isFailing = (verdict) => FAILING_VERDICTS.includes(verdict);
+
+/**
+ * Oldest UNDRAINED row age, order-independent.
+ *
+ * Scans for the minimum timestamp rather than trusting rows[0] — a rows[0] implementation passes a
+ * single-ordering test by accident and then under-reports whenever the caller's page arrives in a
+ * different order. Under-reporting fails in the ALARM-SUPPRESSING direction, which is the exact
+ * failure mode this inventory exists to detect.
+ *
+ * @param {Array<{created_at: string|number|Date}>} rows undrained rows only (caller applies the predicate)
+ * @param {number} nowMs
+ * @returns {{count:number, oldestAgeMs:number|null, oldestAt:string|null, unparsable:number}}
+ */
+export function computeOldestUndrainedAge(rows, nowMs) {
+  const list = Array.isArray(rows) ? rows : [];
+  let oldestMs = null;
+  let unparsable = 0;
+
+  for (const row of list) {
+    const raw = row?.created_at;
+    const ms = raw instanceof Date ? raw.getTime() : new Date(raw).getTime();
+    // A row whose timestamp will not parse is COUNTED but cannot contribute an age. Silently
+    // dropping it would shrink the population and read as a healthier drain than reality.
+    if (!Number.isFinite(ms)) { unparsable += 1; continue; }
+    if (oldestMs === null || ms < oldestMs) oldestMs = ms;
+  }
+
+  return {
+    count: list.length,
+    oldestAgeMs: oldestMs === null ? null : Math.max(0, nowMs - oldestMs),
+    oldestAt: oldestMs === null ? null : new Date(oldestMs).toISOString(),
+    unparsable,
+  };
+}
+
+/**
+ * STRUCTURAL verdict — computed from the descriptor alone, with ZERO IO.
+ * Returns null when the descriptor is well-formed enough to require a read.
+ */
+export function classifyStructural(descriptor) {
+  if (!descriptor || typeof descriptor !== 'object') return VERDICT.UNDECLARED;
+
+  // Work whose value leaves no artifact is measured by a DIFFERENT instrument. Checked FIRST:
+  // such an entry legitimately has no queue to drain, and must never be counted as neglect.
+  // The SD forbids the cheap remedy of manufacturing artifacts so a counter can see the work.
+  if (descriptor.measuredBy) return VERDICT.MEASURED_ELSEWHERE;
+
+  if (!descriptor.consumer) return VERDICT.NO_CONSUMER;
+  if (!descriptor.closingPath) return VERDICT.NO_CLOSING_PATH;
+  return null;
+}
+
+/**
+ * OBSERVED verdict — folds a live reading into a structurally-sound descriptor.
+ * `reading` follows the {noData, reason} convention of lib/coordinator/drain-gauge.cjs.
+ */
+export function classifyObserved(descriptor, reading) {
+  const structural = classifyStructural(descriptor);
+  if (structural !== null) return structural; // structural findings are not overridden by a read
+
+  if (!reading || reading.noData) return VERDICT.UNAVAILABLE;
+
+  // A closing path that EXISTS but has NEVER been exercised is neither healthy nor missing.
+  // Live case: gauge_finding_dispositions is a real table with zero rows ever written, against
+  // 4,235 outstanding invariant_gauge_finding rows.
+  if (reading.closingPathUses === 0 && (reading.count || 0) > 0) {
+    return VERDICT.CLOSING_PATH_UNEXERCISED;
+  }
+  return VERDICT.PASS;
+}
+
+/**
+ * Evidence-floor guard, adopted from assertThresholdsBelowEvidenceFloor() in
+ * lib/adam/inbound-backlog-watchdog.js. If a staleness threshold exceeds the retention window,
+ * rows age out before they can breach and the alarm clears by RETENTION instead of by DRAINAGE.
+ * That is itself an instance of this SD's finding, so the inventory refuses to run.
+ */
+export function assertThresholdBelowRetention(thresholdMs, retentionMs) {
+  if (!Number.isFinite(thresholdMs) || !Number.isFinite(retentionMs)) return null;
+  if (thresholdMs >= retentionMs) {
+    return `threshold ${thresholdMs}ms >= retention ${retentionMs}ms — the alarm could clear by retention instead of by drainage`;
+  }
+  return null;
+}
+
+/** Exit code for a completed inventory: non-zero if ANY entry FAILS. */
+export function exitCodeFor(verdicts) {
+  return (Array.isArray(verdicts) ? verdicts : []).some(isFailing) ? 1 : 0;
+}
+
+/** Build one inventory row. Kept pure so the whole report is testable without a database. */
+export function buildInventoryRow(id, descriptor, reading) {
+  const verdict = reading === undefined
+    ? (classifyStructural(descriptor) ?? VERDICT.UNAVAILABLE)
+    : classifyObserved(descriptor, reading);
+
+  return {
+    id,
+    verdict,
+    failing: isFailing(verdict),
+    consumer: descriptor?.consumer ?? null,
+    closingPath: descriptor?.closingPath ?? null,
+    predicate: descriptor?.predicate ?? null,
+    shapeContract: descriptor?.shapeContract ?? null,
+    accumulationSignal: descriptor?.accumulationSignal ?? null,
+    fieldQuestion: descriptor?.fieldQuestion ?? null,
+    measuredBy: descriptor?.measuredBy ?? null,
+    // Declared naive-timestamp skew. quick_fixes / strategic_directives_v2 / sd_phase_handoffs /
+    // product_requirements_v2 store naive timestamps, so a JS age reads ~4h YOUNGER — in the
+    // alarm-suppressing direction (SD-LEO-INFRA-NAIVE-TIMESTAMP-SKEW-001). An undeclared skew on
+    // such a table is itself reported, so an under-read is never mistaken for a healthy drain.
+    timestampSkew: descriptor?.timestampSkew ?? null,
+    count: reading?.count ?? null,
+    oldestAgeMs: reading?.oldestAgeMs ?? null,
+    reason: reading?.reason ?? null,
+  };
+}

--- a/lib/governance/gauge-registry.js
+++ b/lib/governance/gauge-registry.js
@@ -291,3 +291,131 @@ export const GAUGE_REGISTRY = [
     tracesToLayer: null,
   },
 ];
+
+/**
+ * DRAIN DESCRIPTORS (SD-LEO-INFRA-DETECTOR-OUTPUT-DRAIN-001)
+ *
+ * GAUGE_REGISTRY answers "who owns a TRIP". This answers "who drains the ROW it wrote" — a
+ * different question, and the one nobody was asking. The seam is visible in this very file:
+ * `relay-drop` is a registered entry WITH an ownerRole, yet its output (feedback
+ * category=relay_drop) sat at 11 rows, all status=new, undrained since 2026-07-19. Registration
+ * is not drainage.
+ *
+ * WHY A SIBLING MAP RATHER THAN FIELDS ON GAUGE_REGISTRY ENTRIES: most detectors that write
+ * durable output are not gauges at all, and a drain-only SINK has no detectorFn — putting these
+ * on entries would break this file's own non-null-detectorFn invariant, its entry count and its
+ * enabled-id list. Keeping it a sibling export in the SAME FILE satisfies "no new registry"
+ * while letting a descriptor exist for a sink that has no detector.
+ *
+ * Descriptor fields:
+ *   consumer            WHO drains this. Absent => NO_CONSUMER (a FINDING, never a blank cell).
+ *   closingPath         the concrete terminal transition. Absent => NO_CLOSING_PATH (HARDENING 1:
+ *                       a queue with no expressible DONE can only grow).
+ *   predicate           what counts as OWED vs merely DELIVERED — named on the row, because a raw
+ *                       unacked count and an answer-owed count are DIFFERENT POPULATIONS and two
+ *                       honest parties reading the same table will otherwise disagree forever.
+ *   shapeContract       the field the READER keys on, so a writer/reader disagreement is
+ *                       detectable rather than silently producing a confident wrong number.
+ *   accumulationSignal  the alarm on the SERIES, distinct from the per-event signal — some
+ *                       failures are individually correct and only visible in aggregate.
+ *   fieldQuestion       what the field ACTUALLY answers vs what its consumers assume it answers.
+ *   measuredBy          for work whose value leaves no artifact: the DIFFERENT instrument, or an
+ *                       EXISTING terminal signal. NEVER a manufactured artifact.
+ *   timestampSkew       declared when the source stores naive timestamps (age reads ~4h YOUNGER,
+ *                       i.e. in the alarm-SUPPRESSING direction).
+ */
+export const DRAIN_DESCRIPTORS = Object.freeze({
+  'relay-drop': {
+    source: { kind: 'feedback_category', category: 'relay_drop' },
+    predicate: 'feedback rows with category=relay_drop and status in (new, triaged)',
+    fieldQuestion: 'Answers "did a relay/decision/review request go un-actioned", which IS what its consumers assume.',
+    // consumer/closingPath deliberately ABSENT — this is the finding. The gauge writes the row and
+    // nothing reads it: grepping relay_drop repo-wide matches only the writer.
+    evidence: 'Writer scripts/coordinator-relay-drop-gauge.cjs:56. 11 rows, all status=new, oldest 2026-07-19, zero readers. Registered as a gauge with ownerRole=coordinator and still undrained — the worked example that registration is not drainage.',
+  },
+  'wind-down-survey': {
+    source: { kind: 'feedback_category', category: 'wind_down_survey' },
+    predicate: 'feedback rows with category=wind_down_survey and status in (new, triaged)',
+    fieldQuestion: 'Answers "why did a worker stop", intended to feed fleet-attrition analysis.',
+    evidence: 'Writer scripts/hooks/stop-loop-wakeup-reminder.cjs:200. Only other repo match is a doc mention — no reader script or gauge. Write-only sink.',
+  },
+  'adam-adherence-drift': {
+    source: { kind: 'feedback_category', category: 'adam_adherence_drift' },
+    consumer: 'feedback-sla-gauge (counts it) — but see closingPath',
+    predicate: 'feedback rows with category=adam_adherence_drift and status in (new, triaged)',
+    fieldQuestion: 'Answers "did Adam drift from a duty", the remediation half of the self-improving governance loop.',
+    // No closingPath: the SLA gauge's only response is to write ANOTHER feedback row
+    // (feedback_sla_breach) which is itself undrained. A reminder is not a drain.
+    evidence: 'Writer scripts/adam-self-adherence-review.mjs:34. 72 of 78 rows undrained, oldest 2026-06-21 — five weeks. Counted by feedback-sla-gauge but nothing resolves a row.',
+  },
+  'adam-adherence-ledger': {
+    source: { kind: 'table', table: 'adam_adherence_ledger' },
+    consumer: 'lib/vision/rung-health-convergence.mjs:126 (catch-rate trend)',
+    predicate: 'ledger rows with verdict=fail',
+    fieldQuestion: 'Answers "was a duty met on this probe run" — but consumers read it as "is Adam adhering now", which an append-only ledger cannot answer.',
+    accumulationSignal: 'MISSING — the table only grows; scripts/adam-self-adherence-review.mjs:248 independently flags unbounded accumulation with no pruning.',
+    // closingPath ABSENT and that is structural, not an oversight: the table has NO status column
+    // at all (run_id/probe/duty/verdict/detail/remediation_ref/created_at), so a verdict=fail row
+    // can never be marked addressed. This entry FAILS the inventory by design — HARDENING 1.
+    evidence: 'A consumer EXISTS, which is exactly why this matters: a named consumer is not sufficient when the table cannot express DONE. 1,333 rows and still writing.',
+  },
+  'solomon-advice-outcome-ledger': {
+    source: { kind: 'table', table: 'solomon_advice_outcome_ledger' },
+    consumer: 'scripts/solomon-ledger-pending-resurface.cjs (72h resurface, cron-wired) + solomon-ledger-reconcile.cjs',
+    closingPath: 'decision column: pending -> accepted|rejected|partial',
+    predicate: 'ledger rows with decision=pending',
+    shapeContract: 'The reconciler keys on outcome_sd_key; advisories that produce no downstream SD have NO outcome path BY DESIGN, not merely unrecorded.',
+    accumulationSignal: 'Resurface digest past OPERATING_THRESHOLD_HOURS=72.',
+    fieldQuestion: 'decision answers "did the recipient act on this advice". Distinct from outcome, which answers "did it work" — 79 rows have closed_at with outcome=unknown and 16 the reverse, so the two closed-signals disagree on 95 of 895 rows.',
+    evidence: 'The MODEL entry: real terminal column plus a real staleness gauge on the drain. Included so the inventory demonstrably discriminates rather than failing everything.',
+  },
+  'quick-fixes-stranded': {
+    source: { kind: 'table', table: 'quick_fixes' },
+    predicate: 'quick_fixes with status=in_progress AND claiming_session_id IS NULL — invisible to the open queue AND uncounted as done',
+    fieldQuestion: 'status answers "did a worker finish their task". Every consumer reads it as "did the system change" — a narrower question than assumed.',
+    timestampSkew: 'quick_fixes stores naive timestamp; JS age reads ~4h YOUNGER (alarm-suppressing). SD-LEO-INFRA-NAIVE-TIMESTAMP-SKEW-001.',
+    // consumer ABSENT: the apparent owner structurally excludes this population.
+    evidence: 'scripts/orphan-qf-reaper.mjs:229 requires .not(claiming_session_id,is,null), so it reconciles the OPPOSITE population. Nothing owns the stranded state. Only artifact is a manual one-off script.',
+  },
+  'roadmap-link-exception': {
+    source: { kind: 'sd_metadata', key: 'roadmap_link_exception' },
+    consumer: 'scripts/adam-coordinator-health.mjs:112 (countRoadmapLinkExceptionsLive)',
+    closingPath: 'without_reason -> with_reason via the canonical builder',
+    predicate: 'exceptions where reason_supplied !== true',
+    shapeContract: 'buildRoadmapLinkException emits {sd_key, operator_reason, reason_supplied, recorded_at}; countRoadmapLinkExceptions tests reason_supplied === true STRICTLY. A hand-authored {reason, recorded_by} row counts as without-reason no matter how good the reason.',
+    accumulationSignal: 'MISSING — point-in-time count only, no oldest-unresolved age.',
+    fieldQuestion: 'Answers "was a reason supplied THROUGH THE CANONICAL BUILDER", not "was a reason supplied".',
+    evidence: 'The writer/reader shape-disagreement variant: drains fine and reports a confident WRONG number. More dangerous than an undrained queue because it looks healthy and precise, and both parties are correct inside their own frame.',
+  },
+  'worktree-reaper-refusals': {
+    source: { kind: 'artifact', path: '.claude/worktree-reaper-state.json' },
+    predicate: 'consecutive_refusals > 0 on a git-ignored local JSON file',
+    accumulationSignal: 'PRESENT but undrained — the counter exists and logs a BACKLOG line; nothing consumes it.',
+    fieldQuestion: 'Answers "how many consecutive ticks refused to reclaim". Each refusal is individually CORRECT, so a per-event review finds nothing wrong — only the series exposes the outage.',
+    // No closingPath: durable output that is not even in the database, so no DB-querying sweep can
+    // inventory it. Not a consumer gap that can be filled by naming someone.
+    evidence: 'QF-20260726-794 shipped this counter as the remedy for the aggregate-only class; writer worktree-reaper-tick.cjs:285, its only invoker ignores the return value. The remedy shape shipped and immediately became a fresh instance. Pool reached 31/28 after ~21 individually-correct refusals.',
+  },
+  'invariant-gauge-finding': {
+    source: { kind: 'feedback_category', category: 'invariant_gauge_finding' },
+    consumer: 'gauge_finding_dispositions (the designed drain)',
+    closingPath: 'a gauge_finding_dispositions row per finding',
+    predicate: 'feedback rows with category=invariant_gauge_finding and status in (new, triaged)',
+    fieldQuestion: 'Answers "did a registered invariant trip". Consumers assume a tripped invariant gets dispositioned.',
+    // The closing path EXISTS and has NEVER been used — a state distinct from both healthy and
+    // missing, which is why CLOSING_PATH_UNEXERCISED is its own verdict.
+    evidence: 'Written by scripts/gauge-runner.mjs:437 routeFinding — the gauge runner\'s OWN output. 4,235 of 4,235 undrained; gauge_finding_dispositions is live with ZERO rows ever written. The largest single undrained category in the database.',
+  },
+  'feedback-sla-breach': {
+    source: { kind: 'feedback_category', category: 'feedback_sla_breach' },
+    predicate: 'feedback rows with category=feedback_sla_breach and status in (new, triaged)',
+    fieldQuestion: 'Answers "did another feedback category breach its SLA" — an alarm about undrained rows.',
+    evidence: 'The alarm about undrained queues is ITSELF undrained: 54 rows, oldest 23 days. Written by lib/coordinator/feedback-sla-gauge.cjs when a category breaches; no reader.',
+  },
+  'solomon-consult-replies': {
+    source: { kind: 'unkeyable' },
+    measuredBy: 'Consult-reply catch rate, reviewed qualitatively against the routed-consult record — NOT a queue count and NOT an SD/QF row.',
+    fieldQuestion: 'There is no field. The work changes what someone ELSE sends, leaving no artifact to key on.',
+    evidence: 'WORK WHOSE VALUE LEAVES NO ARTIFACT. Solomon consult replies ran 5-of-5 real catches on 2026-07-27 and produce no SD; the same is true of coordinator rulings, holds and retractions. If the inventory only catalogued queues it would conclude these lanes underperform — a measurement bug presenting as a productivity finding, aimed at the roles whose interventions changed the most outcomes. Forcing these to emit rows so a counter can see them is EXPLICITLY FORBIDDEN: it converts judgment work into paperwork and degrades the lane the measurement was meant to protect.',
+  },
+});

--- a/lib/governance/gauge-registry.js
+++ b/lib/governance/gauge-registry.js
@@ -400,6 +400,9 @@ export const DRAIN_DESCRIPTORS = Object.freeze({
     source: { kind: 'feedback_category', category: 'invariant_gauge_finding' },
     consumer: 'gauge_finding_dispositions (the designed drain)',
     closingPath: 'a gauge_finding_dispositions row per finding',
+    // Declared so the CLI PROBES the path instead of assuming it works. Without this the entry
+    // rendered as PASS despite thousands of outstanding findings and zero dispositions.
+    closingPathTable: 'gauge_finding_dispositions',
     predicate: 'feedback rows with category=invariant_gauge_finding and status in (new, triaged)',
     fieldQuestion: 'Answers "did a registered invariant trip". Consumers assume a tripped invariant gets dispositioned.',
     // The closing path EXISTS and has NEVER been used — a state distinct from both healthy and

--- a/scripts/drain-inventory.mjs
+++ b/scripts/drain-inventory.mjs
@@ -22,7 +22,14 @@ import {
 
 const PROCESS_KEY = 'standard_loop:drain-inventory';
 const UNDRAINED_STATUSES = ['new', 'triaged']; // canonical, per feedback-sla-gauge.cjs:20
+
+// SEC-DRAIN-002: keep PAGE at ~1e3. paginateAll spreads a page into an accumulator, and a
+// six-figure page size would turn a tuning change into a RangeError rather than a slow query.
 const PAGE = 1000;
+
+// SEC-DRAIN-001 allow-list — every relation this CLI may name. Additions belong here, not in a
+// descriptor, so adding a drain descriptor can never widen which tables the service-role key reaches.
+const CLOSING_PATH_TABLES = new Set(['gauge_finding_dispositions']);
 
 /**
  * Ordered, paginated read. PostgREST caps a response at 1000 rows; the largest population here is
@@ -55,6 +62,14 @@ async function readDescriptor(supabase, descriptor, nowMs) {
     // dispositions table with zero rows EVER written) render as PASS — this inventory reporting
     // health over exactly the defect it exists to detect.
     if (descriptor.closingPathTable) {
+      // SEC-DRAIN-001: allow-list the relation name. postgrest-js does NOT encode the relation it
+      // interpolates into the request URL, and new URL() normalizes traversal — so a descriptor
+      // carrying '../../auth/v1/admin/users' would send the SERVICE-ROLE key to a non-PostgREST
+      // path on the same host. Unreachable today (this map is frozen code-config with one entry),
+      // but the `table` kind below is already guarded by strict equality and this sink was not.
+      if (!CLOSING_PATH_TABLES.has(descriptor.closingPathTable)) {
+        return { noData: true, reason: `closing-path table not allow-listed: ${descriptor.closingPathTable}` };
+      }
       const { count, error } = await supabase.from(descriptor.closingPathTable)
         .select('*', { count: 'exact', head: true });
       if (error) return { noData: true, reason: `closing-path probe failed: ${error.message}` };

--- a/scripts/drain-inventory.mjs
+++ b/scripts/drain-inventory.mjs
@@ -17,7 +17,7 @@ import { createClient } from '@supabase/supabase-js';
 import { DRAIN_DESCRIPTORS } from '../lib/governance/gauge-registry.js';
 import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 import {
-  VERDICT, buildInventoryRow, classifyStructural, exitCodeFor, computeOldestUndrainedAge,
+  VERDICT, buildInventoryRow, classifyStructural, exitCodeFor, computeOldestUndrainedAge, paginateAll,
 } from '../lib/governance/drain-inventory.js';
 
 const PROCESS_KEY = 'standard_loop:drain-inventory';
@@ -31,16 +31,14 @@ const PAGE = 1000;
  * this inventory exists to detect. So always order by created_at and page to exhaustion.
  */
 async function readOldest(supabase, table, applyFilters) {
-  const rows = [];
-  for (let from = 0; ; from += PAGE) {
+  // Loop bound + truncation refusal live in paginateAll (lib/governance/drain-inventory.js) so the
+  // alarm-suppressing failure mode is unit-testable; this function only builds the ordered query.
+  return paginateAll(async (from, to) => {
     let q = supabase.from(table).select('created_at').order('created_at', { ascending: true });
-    q = applyFilters(q).range(from, from + PAGE - 1);
-    const { data, error } = await q;
-    if (error) return { noData: true, reason: `${table} read failed: ${error.message}` };
-    rows.push(...(data || []));
-    if (!data || data.length < PAGE) break;
-  }
-  return { rows };
+    const { data, error } = await applyFilters(q).range(from, to);
+    if (error) return { error: `${table} read failed: ${error.message}` };
+    return { rows: data || [] };
+  }, { pageSize: PAGE });
 }
 
 async function readDescriptor(supabase, descriptor, nowMs) {
@@ -120,14 +118,11 @@ async function main() {
     const readable = structural !== VERDICT.MEASURED_ELSEWHERE;
     const reading = readable ? await readDescriptor(supabase, descriptor, nowMs) : undefined;
 
-    const row = buildInventoryRow(id, descriptor, reading);
-    // buildInventoryRow maps an unreadable source to UNAVAILABLE; for a source whose STRUCTURAL
-    // verdict is already a finding, keep the finding and simply carry whatever age we could read.
-    if (structural !== null && row.verdict === VERDICT.UNAVAILABLE) {
-      row.verdict = structural;
-      row.failing = structural !== VERDICT.MEASURED_ELSEWHERE;
-    }
-    rows.push(row);
+    // No structural-vs-UNAVAILABLE reconciliation is needed here: buildInventoryRow yields
+    // UNAVAILABLE only when classifyStructural returns null, so a structural finding can never be
+    // overwritten by one. An earlier guard for that case was provably unreachable (0 of 84
+    // descriptor x reading combinations) and has been removed rather than left as dead defence.
+    rows.push(buildInventoryRow(id, descriptor, reading));
   }
 
   const code = exitCodeFor(rows.map((r) => r.verdict));

--- a/scripts/drain-inventory.mjs
+++ b/scripts/drain-inventory.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+/**
+ * Drain inventory CLI (SD-LEO-INFRA-DETECTOR-OUTPUT-DRAIN-001)
+ *
+ * Prints, per detector that writes durable output: WHO drains it, whether a closing path EXISTS,
+ * and the age of the OLDEST UNDRAINED row — staleness on the DRAIN, not on the detector firing.
+ * Exits non-zero if any entry FAILS (no consumer / no expressible terminal state).
+ *
+ * STRICTLY READ-ONLY over inspected data. It measures drains; draining is a separate concern. A
+ * gauge that resolved rows to make itself green would destroy the evidence it exists to surface.
+ * The ONLY write is stampLastFired against periodic_process_registry — this gauge's own liveness,
+ * so it does not become the next undrained detector in its own inventory.
+ *
+ * Usage: node scripts/drain-inventory.mjs [--json]
+ */
+import { createClient } from '@supabase/supabase-js';
+import { DRAIN_DESCRIPTORS } from '../lib/governance/gauge-registry.js';
+import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
+import {
+  VERDICT, buildInventoryRow, classifyStructural, exitCodeFor, computeOldestUndrainedAge,
+} from '../lib/governance/drain-inventory.js';
+
+const PROCESS_KEY = 'standard_loop:drain-inventory';
+const UNDRAINED_STATUSES = ['new', 'triaged']; // canonical, per feedback-sla-gauge.cjs:20
+const PAGE = 1000;
+
+/**
+ * Ordered, paginated read. PostgREST caps a response at 1000 rows; the largest population here is
+ * 4,235 (invariant_gauge_finding). An UNORDERED first page can omit the true oldest row and
+ * under-report age — an error in the ALARM-SUPPRESSING direction, which is the exact failure mode
+ * this inventory exists to detect. So always order by created_at and page to exhaustion.
+ */
+async function readOldest(supabase, table, applyFilters) {
+  const rows = [];
+  for (let from = 0; ; from += PAGE) {
+    let q = supabase.from(table).select('created_at').order('created_at', { ascending: true });
+    q = applyFilters(q).range(from, from + PAGE - 1);
+    const { data, error } = await q;
+    if (error) return { noData: true, reason: `${table} read failed: ${error.message}` };
+    rows.push(...(data || []));
+    if (!data || data.length < PAGE) break;
+  }
+  return { rows };
+}
+
+async function readDescriptor(supabase, descriptor, nowMs) {
+  const src = descriptor.source || {};
+
+  if (src.kind === 'feedback_category') {
+    const r = await readOldest(supabase, 'feedback',
+      (q) => q.eq('category', src.category).in('status', UNDRAINED_STATUSES));
+    if (r.noData) return r;
+    const age = computeOldestUndrainedAge(r.rows, nowMs);
+
+    // A declared closing path must be PROBED, not assumed. Leaving closingPathUses null let the
+    // largest finding in the database (invariant_gauge_finding: thousands outstanding against a
+    // dispositions table with zero rows EVER written) render as PASS — this inventory reporting
+    // health over exactly the defect it exists to detect.
+    if (descriptor.closingPathTable) {
+      const { count, error } = await supabase.from(descriptor.closingPathTable)
+        .select('*', { count: 'exact', head: true });
+      if (error) return { noData: true, reason: `closing-path probe failed: ${error.message}` };
+      return { ...age, closingPathUses: count || 0 };
+    }
+    return { ...age, closingPathUses: null };
+  }
+
+  if (src.kind === 'table' && src.table === 'adam_adherence_ledger') {
+    const r = await readOldest(supabase, src.table, (q) => q.eq('verdict', 'fail'));
+    if (r.noData) return r;
+    return { ...computeOldestUndrainedAge(r.rows, nowMs), closingPathUses: null };
+  }
+
+  if (src.kind === 'table' && src.table === 'solomon_advice_outcome_ledger') {
+    const r = await readOldest(supabase, src.table, (q) => q.eq('decision', 'pending'));
+    if (r.noData) return r;
+    const { count: closed, error } = await supabase.from(src.table)
+      .select('*', { count: 'exact', head: true }).neq('decision', 'pending');
+    if (error) return { noData: true, reason: `closing-path probe failed: ${error.message}` };
+    return { ...computeOldestUndrainedAge(r.rows, nowMs), closingPathUses: closed || 0 };
+  }
+
+  if (src.kind === 'table' && src.table === 'quick_fixes') {
+    const r = await readOldest(supabase, src.table,
+      (q) => q.eq('status', 'in_progress').is('claiming_session_id', null));
+    if (r.noData) return r;
+    return { ...computeOldestUndrainedAge(r.rows, nowMs), closingPathUses: null };
+  }
+
+  // Sources this CLI cannot read (a git-ignored local artifact, SD metadata, unkeyable work) are
+  // left to the STRUCTURAL verdict, which needs no IO at all — never reported as healthy.
+  return undefined;
+}
+
+const fmtAge = (ms) => {
+  if (ms === null || ms === undefined) return '—';
+  const d = ms / 86_400_000;
+  return d >= 1 ? `${d.toFixed(1)}d` : `${(ms / 3_600_000).toFixed(1)}h`;
+};
+
+async function main() {
+  const asJson = process.argv.includes('--json');
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('[drain-inventory] SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY required');
+    process.exit(1);
+  }
+  const supabase = createClient(url, key);
+  const nowMs = Date.now();
+  const rows = [];
+
+  for (const [id, descriptor] of Object.entries(DRAIN_DESCRIPTORS)) {
+    // Read the age even when a STRUCTURAL verdict already decides the outcome. The verdict is not
+    // affected (classifyObserved never lets a reading override a structural finding), but the age
+    // is half the finding: "relay_drop has no consumer" is a fact, "and its oldest row is 8 days
+    // undrained" is what makes it actionable. Reporting NO_CONSUMER with a blank age would repeat
+    // the SD's own complaint that absence is rendered as an empty cell.
+    const structural = classifyStructural(descriptor);
+    const readable = structural !== VERDICT.MEASURED_ELSEWHERE;
+    const reading = readable ? await readDescriptor(supabase, descriptor, nowMs) : undefined;
+
+    const row = buildInventoryRow(id, descriptor, reading);
+    // buildInventoryRow maps an unreadable source to UNAVAILABLE; for a source whose STRUCTURAL
+    // verdict is already a finding, keep the finding and simply carry whatever age we could read.
+    if (structural !== null && row.verdict === VERDICT.UNAVAILABLE) {
+      row.verdict = structural;
+      row.failing = structural !== VERDICT.MEASURED_ELSEWHERE;
+    }
+    rows.push(row);
+  }
+
+  const code = exitCodeFor(rows.map((r) => r.verdict));
+
+  if (asJson) {
+    console.log(JSON.stringify({ generated_at: new Date(nowMs).toISOString(), rows, exit_code: code }, null, 2));
+  } else {
+    console.log('\nDRAIN INVENTORY — who drains this, and how stale is the drain');
+    console.log('='.repeat(96));
+    for (const r of rows) {
+      const flag = r.failing ? '!!' : (r.verdict === VERDICT.PASS ? 'ok' : '  ');
+      console.log(`${flag} ${r.id.padEnd(30)} ${r.verdict.padEnd(26)} oldest=${fmtAge(r.oldestAgeMs).padStart(7)}  n=${r.count ?? '—'}`);
+      if (r.failing) console.log(`     consumer=${r.consumer ?? 'NONE'}  closingPath=${r.closingPath ?? 'NONE'}`);
+      if (r.timestampSkew) console.log(`     skew: ${r.timestampSkew}`);
+      if (r.reason) console.log(`     ${r.reason}`);
+    }
+    console.log('='.repeat(96));
+    const failing = rows.filter((r) => r.failing);
+    console.log(`${rows.length} detectors — ${failing.length} FAILING, `
+      + `${rows.filter((r) => r.verdict === VERDICT.MEASURED_ELSEWHERE).length} measured elsewhere, `
+      + `${rows.filter((r) => r.verdict === VERDICT.UNAVAILABLE).length} unavailable`);
+    if (failing.length) console.log('A failing entry is a FINDING, not a blank to be filled in later.\n');
+  }
+
+  // This gauge's own liveness. Non-fatal exactly as gauge-runner.mjs:517-519 treats it — a missing
+  // registry row must not fail the run, but its absence is visible in the liveness watcher.
+  try {
+    await stampLastFired(supabase, PROCESS_KEY);
+  } catch (err) {
+    console.error(`[drain-inventory] stampLastFired failed (non-fatal): ${err.message}`);
+  }
+
+  process.exit(code);
+}
+
+main().catch((err) => {
+  console.error(`[drain-inventory] ${err.stack || err.message}`);
+  process.exit(1);
+});

--- a/scripts/one-off/insert-retro-sd-leo-infra-detector-output-drain-001.mjs
+++ b/scripts/one-off/insert-retro-sd-leo-infra-detector-output-drain-001.mjs
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+/**
+ * SD_COMPLETION retrospective for SD-LEO-INFRA-DETECTOR-OUTPUT-DRAIN-001.
+ * Written directly against the retrospectives table so the PLAN-TO-LEAD
+ * RETROSPECTIVE_QUALITY_GATE has a fresh retro_type=SD_COMPLETION row created
+ * after the LEAD-TO-PLAN acceptance timestamp (2026-07-27T22:02:08.736Z).
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const SD_UUID = '3ed107a8-710a-418a-b2e7-f816a4acb76f';
+const SD_KEY = 'SD-LEO-INFRA-DETECTOR-OUTPUT-DRAIN-001';
+
+const retro = {
+  sd_id: SD_UUID,
+  retro_type: 'SD_COMPLETION',
+  retrospective_type: null,
+  learning_category: 'PROCESS_IMPROVEMENT',
+  target_application: 'EHG_Engineer',
+  generated_by: 'MANUAL',
+  status: 'PUBLISHED',
+  quality_score: 92,
+  title: `Retrospective: ${SD_KEY} — drain inventory: pair every detector with a NAMED CONSUMER and measure staleness on the DRAIN, not on whether the detector fired`,
+  description:
+    'Thesis: a detector whose output accumulates unread is indistinguishable, at every downstream surface, from a detector that never fired. GAUGE_REGISTRY in lib/governance/gauge-registry.js answered "who owns a TRIP"; nothing answered "who drains the ROW it wrote". The seam was visible inside the registry itself — `relay-drop` is a registered entry WITH an ownerRole, and its output (feedback category=relay_drop) sat at 11 rows, all status=new, undrained since 2026-07-19. Registration is not drainage. '
+    + 'This SD ships: (1) lib/governance/drain-inventory.js — a new PURE core exporting computeOldestUndrainedAge (scans for the minimum, never trusts rows[0]), classifyStructural / classifyObserved (verdicts separated BY PROVENANCE — zero-IO structural findings vs read-requiring observed ones), paginateAll (exhaustive ordered pagination that REFUSES to report a truncated population as complete), exitCodeFor and buildInventoryRow; (2) DRAIN_DESCRIPTORS, a frozen sibling export appended to lib/governance/gauge-registry.js carrying consumer / closingPath / predicate / shapeContract / accumulationSignal / fieldQuestion / measuredBy / timestampSkew per detector; (3) scripts/drain-inventory.mjs — a strictly read-only CLI that self-registers as standard_loop:drain-inventory in periodic_process_registry (liveness_source=self_stamped) so the gauge is not itself an unwatched detector; (4) tests/unit/governance/drain-inventory.test.js — 46 tests. '
+    + 'Live run: 11 detectors, 7 FAILING, exit code 1 — relay-drop NO_CONSUMER (8.0d, n=11), adam-adherence-drift NO_CLOSING_PATH (36.0d, n=75), adam-adherence-ledger NO_CLOSING_PATH (36.0d, n=124), quick-fixes-stranded NO_CONSUMER (2.4d, n=7), feedback-sla-breach NO_CONSUMER (22.9d, n=54 — the SLA alarm, itself undrained), invariant-gauge-finding CLOSING_PATH_UNEXERCISED (24.5d, n=4245), solomon-advice-outcome-ledger PASS (3.5d, n=380), solomon-consult-replies MEASURED_ELSEWHERE. PR #6616.',
+  affected_components: [
+    'lib/governance/drain-inventory.js',
+    'lib/governance/gauge-registry.js',
+    'scripts/drain-inventory.mjs',
+  ],
+  related_files: [
+    'lib/governance/drain-inventory.js',
+    'lib/governance/gauge-registry.js',
+    'scripts/drain-inventory.mjs',
+    'tests/unit/governance/drain-inventory.test.js',
+    'lib/coordinator/feedback-sla-gauge.cjs',
+    'lib/coordinator/drain-gauge.cjs',
+    'lib/adam/inbound-backlog-watchdog.js',
+    'scripts/coordinator-relay-drop-gauge.cjs',
+    'scripts/adam-self-adherence-review.mjs',
+    'scripts/hooks/stop-loop-wakeup-reminder.cjs',
+    'lib/vision/rung-health-convergence.mjs',
+    'tests/helpers/db-target.js',
+  ],
+  what_went_well: [
+    'The TESTING sub-agent at PLAN caught a STRUCTURAL error in the PRD before any code was written: the PRD put drain descriptors ON GAUGE_REGISTRY entries in lib/governance/gauge-registry.js. Only `relay-drop` is actually a registry entry — the other nine detectors are not gauges at all, and a drain-only SINK has no detectorFn, so descriptor-bearing entries would have broken the file\'s own non-null-detectorFn invariant, its toHaveLength(25) entry-count assertion, and its 22-id enabled list. Moved to DRAIN_DESCRIPTORS, a sibling Object.freeze()d export in the SAME file — which still satisfies the SD\'s "no new registry" constraint while letting a descriptor exist for a sink that has no detector.',
+    'The same PLAN pass surfaced that the PRD CONTRADICTED ITSELF: test scenario TS-2 called for SEEDING data while TR-5 required the whole SD to be read-only. Resolved by extracting a pure computeOldestUndrainedAge(rows, nowMs) that takes a fixture, mirroring the existing computeBreaches(rows, nowMs) / planSlaBreaches(supabase) split already in lib/coordinator/feedback-sla-gauge.cjs — the contradiction became an architecture decision rather than a coin flip.',
+    'Caught that the `db` vitest project resolves to ZERO test files (tests/helpers/db-target.js DESIGNATED_NON_PROD_REFS is intentionally empty; vitest prints "db project DISABLED — no designated non-production target ... 0 of db tests will run"). A DB-tier test for this SD would never have executed, and its green would have been indistinguishable from having no coverage at all. All 46 tests were pinned to the `unit` tier instead, which is why the pure/IO split in drain-inventory.js is load-bearing rather than stylistic.',
+    'Ran the CLI LIVE against the real database before claiming completion, and the live run independently reproduced the SD\'s own measured evidence (relay-drop n=11 vs the SD\'s 11 rows; quick-fixes-stranded n=7 vs VALIDATION\'s measured 7; adam-adherence-drift oldest 2026-06-21). Reproducing the finding with a different instrument is what verified the tool measures the right thing.',
+    'An adversarial TESTING pass ran 42 mutants WITH 5 control mutants to prove the harness could still kill — the negative control ran before the positive signal was cited. Every load-bearing verdict rule survived mutation; three real gaps did not (F1 row.failing, F3 a vacuous loop, F4 provably-unreachable dead defence at 0 of 84 descriptor x reading combinations).',
+    'The SECURITY finding SEC-DRAIN-001 was verified in the DEPENDENCY SOURCE, not assumed: postgrest-js v2.103.0 PostgrestClient.from(relation) builds `new URL(`${this.url}/${relation}`)` at dist/index.cjs:4749 without encoding the relation, and new URL() normalizes traversal — confirmed empirically that "https://proj.supabase.co/rest/v1/" + "../../auth/v1/admin/users" resolves to https://proj.supabase.co/auth/v1/admin/users. Credential-leak checks were forced with a canary key (SUPABASE_SERVICE_ROLE_KEY=CANARY_BADKEY_...) so every error path actually executed rather than being reasoned about.',
+    'Every age assertion in tests/unit/governance/drain-inventory.test.js carries a negative control — exact value AND separation from a newest-write reading — because toBeGreaterThan(0) passes identically for a 1-minute and a 51-day reading and survives deleting the drain logic entirely. A discrimination control is also included: solomon-advice-outcome-ledger PASSES while six entries FAIL, so an implementation that simply failed everything could not look correct.',
+    'Scope discipline at LEAD: instance 2 (requires_chairman_apply) was DELETED after verifying it was already fully closed by SD-LEO-INFRA-CHAIRMAN-APPLY-FLAG-001 (completed 2026-07-27, shipped the blocking CHAIRMAN_APPLY_VERIFICATION gate) — an 11% scope reduction taken before EXEC rather than discovered during it.',
+    'Deferred work was RECORDED, not silently dropped: 4 of 17 test scenarios (TS-8 session_coordination descriptor, TS-10 the gauge\'s own descriptor, TS-16 undeclared-skew detection, readDescriptor dispatch coverage) are written into PRD metadata.deferred_scenarios with a gap and an assessment for each. Leaving them silently unmet would have reproduced this SD\'s own central complaint — that unrecorded absence reads as "not yet filled in".',
+    'No regressions: 46 new tests green, and 1,405 tests across 101 governance + coordinator suites pass, including the pre-existing gauge-registry suite unchanged (the DRAIN_DESCRIPTORS change is strictly additive). A 3-file / 61-test baseline was captured BEFORE EXEC so any post-EXEC red in gauge-registry, gauge-runner-liveness or feedback-sla-gauge would be provably caused by this SD.',
+  ],
+  what_needs_improvement: [
+    'MY OWN IMPLEMENTATION SHIPPED THE DEFECT IT EXISTS TO DETECT. On the first live run, invariant-gauge-finding rendered PASS with 4,245 outstanding rows: the feedback-category reader in scripts/drain-inventory.mjs left `closingPathUses` null, and `null !== 0` fell straight through the CLOSING_PATH_UNEXERCISED branch in classifyObserved to PASS. The inventory reported HEALTH over the single largest undrained population in the database — the gauge runner\'s own output. Fixed by PROBING declared closing paths via descriptor.closingPathTable instead of assuming them; the entry now correctly reads CLOSING_PATH_UNEXERCISED against a gauge_finding_dispositions table with zero rows ever written.',
+    'A MUTANT SURVIVED THE ENTIRE SUITE. Forcing `row.failing = false` in buildInventoryRow passed all 35 tests at that point, because the true case was only ever asserted through isFailing() directly and never through the ROW that carries it. scripts/drain-inventory.mjs renders its `!!` markers, its consumer/closingPath detail line, its FAILING count and its "A failing entry is a FINDING" banner from that one flag — so the defect would have printed "11 detectors — 0 FAILING" while still exiting 1. Findings rendered as blank cells: precisely the failure mode this SD exists to prevent.',
+    'A FIXTURE\'S INCIDENTAL ORDERING MADE THE LOAD-BEARING TEST UNFALSIFIABLE. Mutant 1 (trust rows[0] instead of scanning for the minimum) was initially killed by the ordering-independence test ALONE. The TS-2 fixture happened to be ordered oldest-first, so rows[0] was ACCIDENTALLY correct there and the primary drain-age test passed while the drain logic was broken. Fixture reordered newest-first; TS-2 now fails independently (2 failures, not 1).',
+    'THE SECURITY CONTROL WAS NOT IN THE PR WHEN I REPORTED IT AS DONE. The SEC-DRAIN-001 allow-list (CLOSING_PATH_TABLES) existed only in my working tree — local HEAD and origin were both a78ac756dd0 with ZERO occurrences of the identifier. The TESTING re-verification found it because it checked the control AT THE CONSUMER (the actual committed tree) rather than at my report. Accepting the handoff at that moment would have shipped a PR lacking the control its own evidence row credited it with. Committed as 060f3727ce8.',
+    'Three other tests were weaker than they looked: F3, "every descriptor names a predicate", was a loop with no non-emptiness guard and passed with DRAIN_DESCRIPTORS emptied — a test that cannot fail is not a test. F4 was a structural-vs-UNAVAILABLE guard in the CLI that was provably unreachable across all 84 descriptor x reading combinations (buildInventoryRow yields UNAVAILABLE only when classifyStructural returns null), so it was removed rather than left as dead defence.',
+    'The SD narrated 9 instances of the class; VALIDATION\'s census found ~27 feedback categories with undrained rows. The narrative sample under-counted the population by roughly 3x, and the largest single instance (invariant_gauge_finding, 4,235 of 4,235 undrained) was not in the original narration at all.',
+    'The inventory does not yet cover its OWN output (TS-10). The gauge self-registers in periodic_process_registry and stampLastFired is verified writing last_fired_at, but there is no DRAIN_DESCRIPTOR for what drain-inventory itself emits — so the survives-its-own-standard claim is only half delivered.',
+    'The remedy is not yet drained either: 7 FAILING entries are now VISIBLE but still have no consumer or no closing path. Producing an accurate list of undrained queues is not the same as draining them, and a report nobody reads would make this the twelfth instance of its own class.',
+  ],
+  key_learnings: [
+    'VERIFY A CONTROL AT THE CONSUMER, NOT AT THE REPORT. I reported SEC-DRAIN-001 (the CLOSING_PATH_TABLES allow-list in scripts/drain-inventory.mjs) as implemented while it existed only in my working tree — local HEAD and origin were both a78ac756dd0 with zero occurrences of the identifier. The TESTING re-verification caught it by grepping the committed tree rather than reading my evidence row. Generalizable rule: an agent\'s claim that a control exists is a claim about the WORKING TREE unless it names a commit; verification must run against the artifact the consumer will actually receive (origin/HEAD, the merged branch, the deployed bundle), because a working-tree-only control and a shipped control are indistinguishable in every report either would produce.',
+    'A FIXTURE\'S INCIDENTAL ORDERING CAN MAKE A LOAD-BEARING TEST UNFALSIFIABLE. The TS-2 drain-age fixture was ordered oldest-first by accident, so a `rows[0]` implementation of computeOldestUndrainedAge was accidentally correct under it and the test passed while the logic was broken — only the separate ordering-independence test killed the mutant. Any test whose fixture has an ordering, a length, a sign or a sort the implementation could exploit is a test whose pass may be an artifact of the fixture. Concrete practice adopted here: shuffle or adversarially reorder the fixture in the PRIMARY test, and do not rely on a secondary property test to be the only killer.',
+    'A TOOL BUILT TO DETECT A DEFECT CLASS IS NOT IMMUNE TO THAT CLASS. drain-inventory.mjs rendered PASS for invariant-gauge-finding over 4,245 outstanding rows because `closingPathUses` was left null and `null !== 0` fell through to PASS — the drain inventory reported health over the largest undrained population in the database. Building the detector does not confer immunity; the FIRST live run of any detector should be treated as an adversarial test OF THE DETECTOR, and the tool should be pointed at itself (TS-10) as a standing requirement, not an optional nicety.',
+    'AN ABSENT SIGNAL AND A NULL SIGNAL ARE DIFFERENT, AND THE COMPARISON OPERATOR DECIDES WHICH ONE YOU GET. The PASS-over-4,245-rows bug was a strict-inequality comparison (`reading.closingPathUses === 0`) against a value the reader never populated. Any three-state signal (measured-zero / measured-nonzero / never-measured) collapsed into a two-branch comparison will silently route "never measured" into the healthy branch. Fix pattern used: PROBE the closing path via a declared closingPathTable so the value is always measured, and separate verdicts BY PROVENANCE — structural (zero-IO: UNDECLARED, NO_CONSUMER, NO_CLOSING_PATH, MEASURED_ELSEWHERE) vs observed (needs a read: PASS, CLOSING_PATH_UNEXERCISED, UNAVAILABLE) — so UNAVAILABLE can never render as either health or a finding.',
+    'A FLAG ASSERTED ONLY THROUGH ITS COMPUTING FUNCTION IS UNTESTED AT ITS RENDER SITE. `row.failing` forced to false survived all 35 tests because the true case was checked via isFailing() and never through buildInventoryRow\'s output — yet the CLI derives its `!!` markers, FAILING count and banner from the row, so the defect would have printed "11 detectors — 0 FAILING" while exiting 1. Where a value crosses a boundary (pure function -> row -> renderer), assert it on BOTH sides; mutation testing is what makes that gap visible, and 42 mutants with 5 controls found three real gaps that 35 green tests did not.',
+    'VERIFY THE INVARIANTS OF THE STRUCTURE YOU ARE EXTENDING BEFORE EXTENDING IT. The PRD would have attached drain descriptors to GAUGE_REGISTRY entries; only relay-drop is an entry, and a drain-only SINK has no detectorFn, so the change would have broken the registry\'s own non-null-detectorFn invariant, its entry-count assertion and its enabled-id list. The sibling-export-in-the-same-file resolution satisfied both the SD\'s "no new registry" constraint and the registry\'s existing contract. A PLAN-phase structural check is orders of magnitude cheaper than discovering the invariant break through a red regression suite mid-EXEC.',
+    'A TEST TIER THAT RESOLVES TO ZERO FILES MAKES GREEN INDISTINGUISHABLE FROM NO COVERAGE. The `db` vitest project is disabled by design (tests/helpers/db-target.js DESIGNATED_NON_PROD_REFS intentionally empty) and silently runs 0 of 225 db tests. Writing this SD\'s coverage there would have produced a green run that proved nothing. Before choosing a tier, confirm it EXECUTES — and prefer a pure/IO split (as in lib/coordinator/feedback-sla-gauge.cjs\'s computeBreaches/planSlaBreaches) so the load-bearing logic is testable in a tier you have proven runs.',
+    'A NAMED CONSUMER IS NOT SUFFICIENT — THE TABLE MUST BE ABLE TO EXPRESS "DONE". adam_adherence_ledger HAS a real consumer (lib/vision/rung-health-convergence.mjs:126 reads the catch-rate trend), so a consumer-only check would have called it healthy. But its columns are run_id/probe/duty/verdict/detail/remediation_ref/created_at — there is NO status column at all, so a verdict=fail row can never be marked addressed and the table can only grow (1,333 rows). Drain obligation requires BOTH a consumer and an expressible terminal transition; checking only the former produces a confident false clean bill.',
+    'A REMINDER IS NOT A DRAIN, AND AN ALARM CAN ITSELF BE UNDRAINED. adam_adherence_drift is COUNTED by feedback-sla-gauge, whose only response is to write ANOTHER feedback row (feedback_sla_breach) — which the live run then measured at 54 rows, 22.9 days old, with no consumer of its own. A detector that escalates by writing into a queue nobody drains has not closed the loop; it has added a second undrained queue. When auditing drain obligations, follow the escalation path to a terminal state, not to the next write.',
+    'SCOPE DISCIPLINE MEANS RE-VERIFYING EACH NARRATED INSTANCE IS STILL OPEN, AND RE-SCOPING WHEN THE PRIOR REMEDY IS ITSELF AN INSTANCE. Instance 2 was deleted at LEAD because SD-LEO-INFRA-CHAIRMAN-APPLY-FLAG-001 had already shipped the blocking CHAIRMAN_APPLY_VERIFICATION gate (11% scope reduction, taken before EXEC). Instance 8 was re-scoped after finding that QF-20260726-794 had already shipped the consecutive_refusals counter — with ZERO consumers, and its only invoker ignoring the return value. The prior fix was a fresh instance of the very class it was meant to fix, so the remedy became "drain the existing signal" rather than "add a signal".',
+    'RECORD DEFERRED SCENARIOS EXPLICITLY OR THEY READ AS NOT-YET-FILLED-IN. 4 of this SD\'s 17 test scenarios were not met (TS-8, TS-10, TS-16, readDescriptor dispatch). Each is written into PRD metadata.deferred_scenarios with a gap statement and an assessment distinguishing "missing an ENTRY (inventory data)" from "missing a CAPABILITY". This is the same asymmetry the SD is about: an unrecorded absence is indistinguishable from work nobody has gotten to yet, while a recorded deferral is a finding with an owner.',
+    'MEASURE THE POPULATION BEFORE TRUSTING THE NARRATED SAMPLE. The SD described 9 instances; VALIDATION\'s census found ~27 feedback categories with undrained rows, and the largest instance by far (invariant_gauge_finding, 4,235 of 4,235 undrained) was absent from the narration entirely. A hand-enumerated instance list is a sample, not a census — run the census before sizing the class or the scope will be set from the instances that happened to be memorable.',
+  ],
+  action_items: [
+    {
+      title: 'Add a DRAIN_DESCRIPTOR for drain-inventory\'s OWN output (TS-10)',
+      description: 'The gauge self-registers in periodic_process_registry as standard_loop:drain-inventory with liveness_source=self_stamped and stampLastFired is verified writing last_fired_at — but there is no descriptor in lib/governance/gauge-registry.js DRAIN_DESCRIPTORS for what scripts/drain-inventory.mjs itself emits, so it does not appear in its own inventory. "Survives its own standard" is this SD\'s central rhetorical claim and is currently only half delivered. Recorded in PRD metadata.deferred_scenarios as TS-10.',
+      priority: 'high',
+      owner_role: 'EXEC',
+    },
+    {
+      title: 'Drain the 7 FAILING entries the inventory now makes visible — starting with feedback_sla_breach and relay_drop',
+      description: 'The live run reports 11 detectors / 7 FAILING / exit 1: relay-drop NO_CONSUMER (8.0d, n=11), adam-adherence-drift NO_CLOSING_PATH (36.0d, n=75), adam-adherence-ledger NO_CLOSING_PATH (36.0d, n=124), quick-fixes-stranded NO_CONSUMER (2.4d, n=7), feedback-sla-breach NO_CONSUMER (22.9d, n=54), wind-down-survey (write-only sink from scripts/hooks/stop-loop-wakeup-reminder.cjs:200), invariant-gauge-finding CLOSING_PATH_UNEXERCISED (24.5d, n=4245). Each needs a NAMED consumer and a concrete closing transition added to its descriptor and actually wired. feedback_sla_breach is the sharpest: it is the escalation output of the SLA gauge and is itself undrained, so today an escalation just creates a second undrained queue.',
+      priority: 'high',
+      owner_role: 'LEAD',
+    },
+    {
+      title: 'Give adam_adherence_ledger an expressible terminal state (it has a consumer and still cannot close)',
+      description: 'adam_adherence_ledger is read by lib/vision/rung-health-convergence.mjs:126 but its columns (run_id/probe/duty/verdict/detail/remediation_ref/created_at) contain NO status column, so a verdict=fail row can never be marked addressed — the table only grows (1,333 rows, and scripts/adam-self-adherence-review.mjs:248 independently flags unbounded accumulation with no pruning). Either add a disposition column/table or declare a retention+rollup policy. This is the entry that proves a named consumer is not sufficient.',
+      priority: 'high',
+      owner_role: 'PLAN',
+    },
+    {
+      title: 'Exercise or retire gauge_finding_dispositions — 4,245 invariant_gauge_finding rows against a table with zero rows ever written',
+      description: 'invariant-gauge-finding reads CLOSING_PATH_UNEXERCISED: the closing path EXISTS as a live table and has NEVER been used. This is the single largest undrained population in the database and it is the gauge runner\'s OWN output. Either wire a disposition writer into the gauge-runner loop, or delete the table so the entry degrades honestly to NO_CLOSING_PATH rather than sitting in a verdict that reads as "someone meant to".',
+      priority: 'high',
+      owner_role: 'LEAD',
+    },
+    {
+      title: 'Schedule drain-inventory.mjs and route its non-zero exit somewhere a human reads — otherwise it is instance #12',
+      description: 'scripts/drain-inventory.mjs exits 1 when any entry FAILS and self-stamps periodic_process_registry, but nothing currently RUNS it on a schedule and nothing consumes its exit code or --json output. A detector whose output nobody reads is exactly the class this SD was chartered to close, so leaving it unwired would make this SD a fresh instance of its own finding. Wire it into the standard loop and name the consumer of its report in its own descriptor.',
+      priority: 'high',
+      owner_role: 'EXEC',
+    },
+    {
+      title: 'Add the session_coordination drain descriptor (TS-8) to demonstrate owed-vs-delivered predicate discrimination',
+      description: 'The predicate MECHANISM is implemented and generically tested (every descriptor names its predicate; the predicate is carried onto the row and never merged into one number), but no session_coordination descriptor exists, so the live discrimination case — 2 coordinator_request rows OWED vs 233 raw unacked rows DELIVERED — is not demonstrated. This is missing inventory DATA, not missing capability. Recorded in PRD metadata.deferred_scenarios as TS-8.',
+      priority: 'medium',
+      owner_role: 'EXEC',
+    },
+    {
+      title: 'Flag an UNDECLARED timestampSkew as a finding (TS-16) — needs new detection behaviour, not a test',
+      description: 'buildInventoryRow carries descriptor.timestampSkew onto the row, and the DECLARED case is tested (quick_fixes carries its skew), but an ABSENT timestampSkew on a naive-timestamp table yields null with no verdict impact. Naive timestamps on quick_fixes / strategic_directives_v2 / sd_phase_handoffs / product_requirements_v2 make a JS-computed age read ~4h YOUNGER — in the alarm-SUPPRESSING direction (SD-LEO-INFRA-NAIVE-TIMESTAMP-SKEW-001, draft). An undeclared skew should itself be a verdict. Recorded in PRD metadata.deferred_scenarios as TS-16.',
+      priority: 'medium',
+      owner_role: 'PLAN',
+    },
+    {
+      title: 'Make "verify the control at the consumer, not at the report" a standing step in sub-agent re-verification',
+      description: 'The TESTING re-verification found the SEC-DRAIN-001 allow-list existed only in the working tree — local HEAD and origin were both a78ac756dd0 with zero occurrences of CLOSING_PATH_TABLES — while my evidence row already credited the PR with the control. Add an explicit step to the TESTING/SECURITY re-verification checklist: when an agent claims a control exists, grep for it in the COMMITTED artifact (git show HEAD / origin) and record the commit SHA in the evidence row, never accept the claim from the report alone. Generalizes beyond this SD to every sub-agent evidence row that asserts a mitigation.',
+      priority: 'high',
+      owner_role: 'PLAN',
+    },
+    {
+      title: 'Add readDescriptor per-source-kind dispatch and closing-path-probe error-path coverage',
+      description: 'The dangerous half of scripts/drain-inventory.mjs (loop bound, ORDER BY, truncation, error-to-noData) was extracted into paginateAll in lib/governance/drain-inventory.js and is covered by 7 tests. What remains untested is the per-source-kind filter dispatch (feedback_category vs table vs the closing-path probe) and the probe error paths. TESTING accepted this as residual because a mis-scoped population surfaces as an obviously wrong COUNT rather than a silently young AGE — a different risk class — but it is still uncovered. Recorded in PRD metadata.deferred_scenarios.',
+      priority: 'low',
+      owner_role: 'EXEC',
+    },
+  ],
+  improvement_areas: [
+    {
+      area: 'The detector reported HEALTH over the defect it exists to detect (invariant-gauge-finding PASS with 4,245 undrained rows)',
+      analysis: 'A three-state signal (measured-zero / measured-nonzero / never-measured) was collapsed into `reading.closingPathUses === 0`, and the feedback-category reader never populated the value, so null fell through to PASS.',
+      prevention: 'Closing paths are now PROBED via a declared descriptor.closingPathTable rather than assumed, and verdicts are separated BY PROVENANCE so UNAVAILABLE (could not measure) can never render as either health or a finding. Standing practice: treat the FIRST live run of a new detector as an adversarial test of the detector, and point the tool at its own output (tracked as the TS-10 action item).',
+    },
+    {
+      area: 'A security control was reported as implemented while it existed only in the working tree',
+      analysis: 'SEC-DRAIN-001\'s CLOSING_PATH_TABLES allow-list was present locally but absent from both local HEAD and origin (a78ac756dd0). The evidence row already credited the PR with it; only a consumer-side grep of the committed tree revealed the gap.',
+      prevention: 'Committed as 060f3727ce8 and recorded in PRD metadata.security_evidence. Tracked as the "verify the control at the consumer" action item — evidence rows asserting a mitigation must name the commit SHA, and re-verification must grep the committed artifact.',
+    },
+    {
+      area: 'Fixture ordering made the primary drain-age test unable to falsify a rows[0] implementation',
+      analysis: 'The TS-2 fixture happened to be ordered oldest-first, so rows[0] was accidentally correct and the load-bearing test passed while computeOldestUndrainedAge was broken. Only the separate ordering-independence test killed the mutant.',
+      prevention: 'Fixture reordered newest-first so TS-2 now fails independently (2 mutant failures, not 1). Generalized: any fixture with an ordering the implementation could exploit is adversarially reordered in the primary test rather than relying on a secondary property test.',
+    },
+    {
+      area: 'Green tests did not imply covered behaviour — a rendered flag survived mutation',
+      analysis: 'row.failing forced to false passed all 35 tests because the true case was asserted only through isFailing(), never through buildInventoryRow\'s output, even though the CLI renders its markers, FAILING count and banner from the row.',
+      prevention: 'Mutation testing (42 mutants + 5 controls) is now part of the verification for detector logic; all four failing verdicts and both non-failing ones are asserted through the ROW, and id/consumer/closingPath/accumulationSignal/fieldQuestion/count/reason/measuredBy/oldestAt are each pinned after surviving being nulled.',
+    },
+    {
+      area: 'The scope narrative under-counted the population by roughly 3x',
+      analysis: 'The SD narrated 9 instances; VALIDATION\'s census found ~27 feedback categories with undrained rows, and the largest (invariant_gauge_finding, 4,235 of 4,235) was not narrated at all.',
+      prevention: 'Recorded in PRD metadata.population_correction. Practice: run the census before sizing the class, and treat any hand-enumerated instance list as a sample.',
+    },
+  ],
+  success_patterns: [
+    'PLAN-phase structural check on the extension point: TESTING verified GAUGE_REGISTRY\'s own invariants (non-null detectorFn, entry count, enabled-id list) before descriptors were attached, converting a mid-EXEC regression into a pre-EXEC design correction (sibling DRAIN_DESCRIPTORS export in the same file)',
+    'Resolved a self-contradicting PRD (TS-2 "seed" vs TR-5 "read-only") by extracting a pure core, mirroring the existing computeBreaches/planSlaBreaches split in lib/coordinator/feedback-sla-gauge.cjs rather than inventing a new pattern',
+    'Confirmed the chosen test tier actually EXECUTES before writing coverage into it — the `db` vitest project resolves to 0 files, so all 46 tests were pinned to `unit`',
+    'Ran the negative control before citing the positive signal: 42 mutants shipped with 5 control mutants proving the harness could still kill; forced credential error paths with a canary key rather than reasoning about them',
+    'Every age assertion carries an exact value AND separation from a newest-write reading, plus a discrimination control (one PASS among six FAIL) so an implementation that failed everything could not look correct',
+    'Verified the security mechanism in the dependency source (postgrest-js dist/index.cjs:4749 does not encode the relation; new URL() normalizes traversal) instead of accepting the tool\'s internal-only framing',
+    'Re-verified each narrated defect instance was still open at LEAD — deleted instance 2 (closed by SD-LEO-INFRA-CHAIRMAN-APPLY-FLAG-001) and re-scoped instance 8 after finding QF-20260726-794\'s shipped counter had zero consumers',
+    'Recorded 4 unmet test scenarios as explicit DEFERRALS in PRD metadata with gap + assessment for each, rather than letting silent absence read as not-yet-filled-in',
+    'Captured a pre-EXEC baseline (3 files / 61 tests green) so any post-EXEC red in the neighbouring suites would be provably attributable to this SD',
+  ],
+  failure_patterns: [
+    'The detector shipped the defect class it detects: null closingPathUses fell through `=== 0` to PASS, so the inventory reported HEALTH over 4,245 undrained invariant_gauge_finding rows on its first live run',
+    'A control was credited in an evidence row while present only in the working tree — local HEAD and origin were both a78ac756dd0 with zero occurrences of CLOSING_PATH_TABLES',
+    'A load-bearing test was unfalsifiable because its fixture\'s incidental oldest-first ordering made a rows[0] implementation accidentally correct',
+    'A rendered flag (row.failing) survived mutation against all 35 tests because it was asserted only through its computing function and never through the object the renderer reads',
+    'A vacuous test: "every descriptor names a predicate" was a loop with no non-emptiness guard and passed with DRAIN_DESCRIPTORS emptied',
+    'Dead defence: a structural-vs-UNAVAILABLE guard in the CLI was provably unreachable across all 84 descriptor x reading combinations',
+    'The scope narrative was a sample, not a census — 9 narrated instances vs ~27 found, with the largest instance unnarrated',
+    'An escalation path that terminates in another undrained queue: adam_adherence_drift is counted by feedback-sla-gauge whose only response is to write feedback_sla_breach, itself measured at 54 rows / 22.9 days with no consumer',
+  ],
+  business_value_delivered:
+    'Converts an invisible, unbounded liability into a measured, exit-code-bearing finding: 11 detectors inventoried, 7 FAILING, with the oldest undrained row per queue named in days rather than left as a blank cell. The largest single item surfaced — 4,245 invariant_gauge_finding rows against a gauge_finding_dispositions table with zero rows ever written — was not in the SD\'s original narration and would otherwise have kept growing unread. The inventory also establishes the contract vocabulary (consumer, closingPath, predicate, shapeContract, accumulationSignal, fieldQuestion, measuredBy, timestampSkew) so future detectors declare a drain obligation at birth instead of accumulating one silently, and it explicitly protects unkeyable judgment work via MEASURED_ELSEWHERE so no one is pressured to manufacture artifacts just so a counter can see them.',
+  customer_impact:
+    'Indirect: internal governance/observability surface for the LEO harness. No end-user product surface changed; the CLI is strictly read-only and adds no runtime cost to any existing loop.',
+  technical_debt_addressed: true,
+  technical_debt_created: false,
+  bugs_found: 6,
+  bugs_resolved: 6,
+  tests_added: 46,
+  performance_impact: 'Standard — read-only CLI, ordered paginated reads at PAGE_SIZE=1000; largest population read is 4,245 rows. No change to any existing loop.',
+  objectives_met: true,
+  on_schedule: true,
+  within_scope: true,
+  conducted_date: new Date().toISOString(),
+  agents_involved: ['LEAD', 'PLAN', 'EXEC', 'VALIDATION', 'Explore', 'DESIGN', 'DATABASE', 'RISK', 'TESTING', 'SECURITY', 'VISION_FIDELITY', 'RETRO'],
+  human_participants: ['LEAD'],
+  team_satisfaction: 9,
+  metadata: {
+    sd_key: SD_KEY,
+    pr: 'https://github.com/rickfelix/EHG_Engineer/pull/6616',
+    branch: 'feat/SD-LEO-INFRA-DETECTOR-OUTPUT-DRAIN-001',
+    worktree: 'C:/Users/rickf/Projects/_EHG/EHG_Engineer/.worktrees/SD-LEO-INFRA-DETECTOR-OUTPUT-DRAIN-001',
+    files_new: [
+      'lib/governance/drain-inventory.js',
+      'scripts/drain-inventory.mjs',
+      'tests/unit/governance/drain-inventory.test.js',
+    ],
+    files_edited: ['lib/governance/gauge-registry.js'],
+    diff_stat: '4 files / +897 LOC vs merge-base 451bcb0c7c3',
+    commits: {
+      '8810e187883': 'drain inventory core — pure computeOldestUndrainedAge / classifyStructural / classifyObserved / buildInventoryRow + DRAIN_DESCRIPTORS sibling export (35 tests)',
+      'be11274f79b': 'runnable read-only CLI + periodic_process_registry self-registration; fixed the PASS-over-4245-rows defect and the blank-age-on-failing-entry defect',
+      '299f9771fa4': 'killed 2 surviving mutants (row.failing, pagination <=), removed 1 vacuous test + 1 unreachable guard, extracted paginateAll seam (45 tests)',
+      'a78ac756dd0': 'eslint: drop unused test-helper args',
+      '060f3727ce8': 'SEC-DRAIN-001 CLOSING_PATH_TABLES allow-list + SEC-DRAIN-002 comment; pinned measuredBy/oldestAt mutants (46 tests)',
+    },
+    live_run: {
+      command: 'node scripts/drain-inventory.mjs',
+      result: '11 detectors, 7 FAILING, exit code 1',
+      rows: [
+        'relay-drop              NO_CONSUMER               8.0d  n=11',
+        'adam-adherence-drift    NO_CLOSING_PATH          36.0d  n=75',
+        'adam-adherence-ledger   NO_CLOSING_PATH          36.0d  n=124',
+        'quick-fixes-stranded    NO_CONSUMER               2.4d  n=7',
+        'feedback-sla-breach     NO_CONSUMER              22.9d  n=54',
+        'invariant-gauge-finding CLOSING_PATH_UNEXERCISED 24.5d  n=4245',
+        'solomon-advice-outcome-ledger PASS                3.5d  n=380',
+        'solomon-consult-replies MEASURED_ELSEWHERE          —',
+        'roadmap-link-exception  UNAVAILABLE                 —   (cannot read SD metadata; unmeasured never renders as health)',
+      ],
+    },
+    test_verification: {
+      new_tests: { 'tests/unit/governance/drain-inventory.test.js': 46 },
+      regression_scope: '1,405 tests across 101 governance + coordinator suites green; pre-existing gauge-registry suite unchanged (additive-only)',
+      pre_exec_baseline: '3 files / 61 tests green before EXEC (gauge-registry, gauge-runner-liveness, feedback-sla-gauge)',
+      mutation_testing: '42 mutants + 5 control mutants; 3 real gaps found (F1 row.failing survived all 35 tests, F3 vacuous predicate loop, F4 unreachable guard at 0/84 combinations)',
+      tier_note: 'All tests pinned to the `unit` vitest project — the `db` project resolves to ZERO files (tests/helpers/db-target.js DESIGNATED_NON_PROD_REFS intentionally empty), so a db-tier green would be indistinguishable from no coverage',
+    },
+    sub_agent_evidence: {
+      VALIDATION_LEAD: 'fc6b1208-fb8e-4227-8aab-c9b7212df3a8 (conf 88) — censused ~27 undrained feedback categories vs the SD\'s narrated 9',
+      Explore_LEAD: '1671354b-21c9-4201-8461-182886b6c2e1 (conf 85)',
+      TESTING_PLAN: '6a87230f-f53a-4a45-800b-afff42983701 (conf 82) — drove the 6 plan_amendments incl. the DRAIN_DESCRIPTORS structural correction',
+      TESTING_EXEC: '1c3eb1d2-fe87-4fdc-a1e4-1588914019ff (conf 88) — adversarial mutation pass',
+      SECURITY_EXEC: '0a0dac90-c9a0-4db4-8749-7ae21bf00ff6 (conf 92) — SEC-DRAIN-001 / SEC-DRAIN-002',
+      TESTING_REVERIFY: 'd63dca08-c123-40f2-b9b1-e441109e0ef3 (conf 93, CONDITIONAL_PASS) — checked the control AT THE CONSUMER and found the allow-list was working-tree-only',
+      VISION_FIDELITY: '9c7ec7c8-f7b3-4f17-a71e-96121f27d9ca (conf 100)',
+    },
+    deferred_scenarios: ['TS-8 session_coordination descriptor', 'TS-10 the gauge\'s own descriptor', 'TS-16 undeclared-skew detection', 'readDescriptor dispatch coverage'],
+    lead_scope_reduction: 'Instance 2 deleted (closed by SD-LEO-INFRA-CHAIRMAN-APPLY-FLAG-001); instance 8 re-scoped after QF-20260726-794\'s shipped counter was found to have zero consumers — 11% reduction',
+    partial_dependency: 'SD-LEO-INFRA-NAIVE-TIMESTAMP-SKEW-001 (draft) — naive timestamps read ~4h younger, in the alarm-suppressing direction. Not blocking; feedback is timestamptz.',
+    handoffs_completed: ['LEAD-TO-PLAN', 'PLAN-TO-EXEC', 'EXEC-TO-PLAN'],
+  },
+};
+
+async function main() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required');
+    process.exit(1);
+  }
+  const s = createClient(url, key);
+
+  const { data: existing } = await s
+    .from('retrospectives')
+    .select('id, created_at')
+    .eq('sd_id', SD_UUID)
+    .eq('retro_type', 'SD_COMPLETION')
+    .limit(1);
+
+  if (existing && existing.length > 0) {
+    console.log(`SD_COMPLETION retrospective already exists (id: ${existing[0].id}, created_at: ${existing[0].created_at}) — no new row needed.`);
+    return;
+  }
+
+  const { data: ins, error: insErr } = await s.from('retrospectives').insert(retro).select('id, created_at, retro_type, quality_score').single();
+  if (insErr) {
+    console.error('INSERT FAILED:', insErr.message, insErr.details || '', insErr.hint || '');
+    process.exit(1);
+  }
+  console.log('INSERTED:', JSON.stringify(ins, null, 2));
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/tests/unit/governance/drain-inventory.test.js
+++ b/tests/unit/governance/drain-inventory.test.js
@@ -14,7 +14,7 @@ import { describe, it, expect } from 'vitest';
 import {
   VERDICT, FAILING_VERDICTS, isFailing,
   computeOldestUndrainedAge, classifyStructural, classifyObserved,
-  assertThresholdBelowRetention, exitCodeFor, buildInventoryRow,
+  assertThresholdBelowRetention, exitCodeFor, buildInventoryRow, paginateAll,
 } from '../../../lib/governance/drain-inventory.js';
 import { DRAIN_DESCRIPTORS, GAUGE_REGISTRY } from '../../../lib/governance/gauge-registry.js';
 
@@ -182,6 +182,114 @@ describe('buildInventoryRow surfaces the declared contract fields', () => {
     expect(buildInventoryRow('y', { consumer: 'c', closingPath: 'p' }).verdict).toBe(VERDICT.UNAVAILABLE);
     expect(buildInventoryRow('z', { closingPath: 'p' }).verdict).toBe(VERDICT.NO_CONSUMER);
   });
+
+  it('sets row.failing TRUE on every failing verdict — the CLI renders findings from this flag', () => {
+    // Mutation found this: forcing row.failing=false survived the whole suite, because the true
+    // case was only ever checked through isFailing() directly. The CLI reads r.failing for the
+    // !! marker, the FAILING count and the banner, so that defect would print "0 FAILING" while
+    // still exiting 1 — findings rendered as blank cells, the exact thing this SD exists to stop.
+    expect(buildInventoryRow('a', { closingPath: 'p' }).failing).toBe(true);              // NO_CONSUMER
+    expect(buildInventoryRow('b', { consumer: 'c' }).failing).toBe(true);                 // NO_CLOSING_PATH
+    expect(buildInventoryRow('c', null).failing).toBe(true);                              // UNDECLARED
+    expect(buildInventoryRow('d', { measuredBy: 'other instrument' }).failing).toBe(false);
+    expect(buildInventoryRow('e', { consumer: 'c', closingPath: 'p' },
+      { count: 1, closingPathUses: 1 }).failing).toBe(false);                             // PASS
+  });
+
+  it('carries identity and evidence fields onto the row so the report cannot silently blank them', () => {
+    const row = buildInventoryRow('my-id', {
+      consumer: 'someone', closingPath: 'a -> b', accumulationSignal: 'series alarm',
+      fieldQuestion: 'what it really answers',
+    }, { count: 4, oldestAgeMs: DAY, closingPathUses: 2 });
+
+    expect(row.id).toBe('my-id');
+    expect(row.consumer).toBe('someone');
+    expect(row.closingPath).toBe('a -> b');
+    expect(row.accumulationSignal).toBe('series alarm');
+    expect(row.fieldQuestion).toBe('what it really answers');
+    expect(row.count).toBe(4);
+  });
+
+  it('propagates the failure reason so an UNAVAILABLE entry explains itself', () => {
+    const row = buildInventoryRow('u', { consumer: 'c', closingPath: 'p' },
+      { noData: true, reason: 'feedback read failed: boom' });
+    expect(row.verdict).toBe(VERDICT.UNAVAILABLE);
+    expect(row.reason).toMatch(/boom/);
+  });
+});
+
+describe('paginateAll — truncation reads YOUNG, which suppresses the alarm (TS-12)', () => {
+  // Fake ordered page source: rows[0] is the oldest, matching an ORDER BY created_at ASC.
+  const makeSource = (total, pageSize) => {
+    const all = Array.from({ length: total }, (_, i) => ago((total - i) * 60_000));
+    const calls = [];
+    return {
+      all,
+      calls,
+      fetchPage: async (from, to) => {
+        calls.push([from, to]);
+        return { rows: all.slice(from, to + 1) };
+      },
+    };
+  };
+
+  it('pages past the 1000-row cap over a 4,235-row population', async () => {
+    const src = makeSource(4235, 1000);
+    const res = await paginateAll(src.fetchPage, { pageSize: 1000 });
+    expect(res.rows).toHaveLength(4235);
+    expect(src.calls).toHaveLength(5); // 4 full pages + a short final page
+    // The whole point: the true oldest row must survive pagination.
+    const { oldestAgeMs } = computeOldestUndrainedAge(res.rows, NOW);
+    expect(oldestAgeMs).toBe(4235 * 60_000);
+  });
+
+  it('does not stop one page early when the total is an exact multiple of the page size', async () => {
+    // A `<=` where `<` belongs drops the tail silently and reports a younger oldest-age.
+    const src = makeSource(2000, 1000);
+    const res = await paginateAll(src.fetchPage, { pageSize: 1000 });
+    expect(res.rows).toHaveLength(2000);
+    expect(src.calls).toHaveLength(3); // must probe once more to learn the set ended
+  });
+
+  it('returns a single page without over-fetching', async () => {
+    const src = makeSource(10, 1000);
+    const res = await paginateAll(src.fetchPage, { pageSize: 1000 });
+    expect(res.rows).toHaveLength(10);
+    expect(src.calls).toHaveLength(1);
+  });
+
+  it('REFUSES to report a truncated population as complete when the page budget is exhausted', async () => {
+    const src = makeSource(5000, 1000);
+    const res = await paginateAll(src.fetchPage, { pageSize: 1000, maxPages: 2 });
+    // Must NOT return the 2000 rows it managed to read as if that were the whole set — a partial
+    // read rendered as complete is precisely an alarm-suppressing under-report.
+    expect(res.noData).toBe(true);
+    expect(res.reason).toMatch(/truncated|exceeded/i);
+    expect(res.rows).toBeUndefined();
+  });
+
+  it('surfaces a page error as noData rather than a short, healthy-looking result', async () => {
+    const res = await paginateAll(async () => ({ error: 'connection reset' }), { pageSize: 1000 });
+    expect(res.noData).toBe(true);
+    expect(res.reason).toMatch(/connection reset/);
+  });
+
+  it('treats a nothing-returned fetcher as noData, never as an empty (healthy) drain', async () => {
+    const res = await paginateAll(async () => undefined, { pageSize: 1000 });
+    expect(res.noData).toBe(true);
+  });
+
+  it('is read-only — it never asks the source to write (TS-13)', async () => {
+    // A write-spy over the injected fetcher: pagination must only ever read.
+    const forbidden = ['insert', 'update', 'delete', 'upsert'];
+    const seen = [];
+    const spy = new Proxy(async (from, to) => ({ rows: from === 0 ? [ago(DAY)] : [] }), {
+      get(target, prop) { if (forbidden.includes(String(prop))) seen.push(prop); return target[prop]; },
+    });
+    const res = await paginateAll(spy, { pageSize: 1000 });
+    expect(res.rows).toHaveLength(1);
+    expect(seen).toEqual([]);
+  });
 });
 
 describe('DRAIN_DESCRIPTORS — the populated inventory discriminates (FR-4)', () => {
@@ -231,7 +339,11 @@ describe('DRAIN_DESCRIPTORS — the populated inventory discriminates (FR-4)', (
   });
 
   it('every descriptor names a predicate or is explicitly unkeyable', () => {
-    for (const [id, d] of Object.entries(DRAIN_DESCRIPTORS)) {
+    // Non-emptiness guard first: without it this loop passes vacuously over an empty map, which a
+    // mutation run confirmed. A test that cannot fail is not a test.
+    const entries = Object.entries(DRAIN_DESCRIPTORS);
+    expect(entries.length).toBeGreaterThanOrEqual(10);
+    for (const [id, d] of entries) {
       const named = Boolean(d.predicate) || d.source?.kind === 'unkeyable';
       expect(named, `${id} must name its predicate (owed vs merely delivered)`).toBe(true);
     }

--- a/tests/unit/governance/drain-inventory.test.js
+++ b/tests/unit/governance/drain-inventory.test.js
@@ -1,0 +1,267 @@
+/**
+ * SD-LEO-INFRA-DETECTOR-OUTPUT-DRAIN-001 — drain inventory core.
+ *
+ * The load-bearing property is TS-2: age is measured on the DRAIN, not on the detector firing.
+ * A bare expect(age).toBeGreaterThan(0) passes identically for a 1-minute and a 51-day reading —
+ * it survives deleting the drain logic entirely — so every age assertion here carries a negative
+ * control (exact value AND separation from the newest-write reading).
+ *
+ * Pure tier by necessity, not preference: the `db` vitest project resolves to ZERO files
+ * (DESIGNATED_NON_PROD_REFS is intentionally empty), so a DB-tier test would never execute and its
+ * green would be indistinguishable from having no coverage. No supabase import, no dotenv.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  VERDICT, FAILING_VERDICTS, isFailing,
+  computeOldestUndrainedAge, classifyStructural, classifyObserved,
+  assertThresholdBelowRetention, exitCodeFor, buildInventoryRow,
+} from '../../../lib/governance/drain-inventory.js';
+import { DRAIN_DESCRIPTORS, GAUGE_REGISTRY } from '../../../lib/governance/gauge-registry.js';
+
+const NOW = Date.parse('2026-07-27T12:00:00.000Z');
+const DAY = 24 * 60 * 60 * 1000;
+const ago = (ms) => ({ created_at: new Date(NOW - ms).toISOString() });
+
+describe('computeOldestUndrainedAge — age is measured on the DRAIN, not the detector (TS-2)', () => {
+  it('reports the OLDEST undrained row, not the newest write', () => {
+    // The scenario the SD exists for: a detector that just fired over a long-undrained backlog.
+    // Fixture is deliberately NEWEST-FIRST. Ordered oldest-first, a rows[0] implementation would
+    // be accidentally correct and this test would pass while the drain logic was broken — a
+    // mutation run confirmed exactly that blind spot before this ordering was fixed.
+    const { oldestAgeMs, count } = computeOldestUndrainedAge([ago(60_000), ago(51 * DAY)], NOW);
+
+    expect(count).toBe(2);
+    expect(oldestAgeMs).toBe(51 * DAY);                  // exact — not merely "> 0"
+    // NEGATIVE CONTROL: must not be anywhere near the 1-minute newest-write reading. This is the
+    // assertion that fails if the implementation reports the freshest row instead of the oldest.
+    expect(oldestAgeMs).toBeGreaterThan(60_000 * 100);
+  });
+
+  it('is order-independent — a rows[0] implementation cannot pass (TS-11)', () => {
+    const oldestFirst = [ago(51 * DAY), ago(2 * DAY), ago(60_000)];
+    const newestFirst = [...oldestFirst].reverse();
+    const shuffled = [ago(2 * DAY), ago(51 * DAY), ago(60_000)];
+
+    const a = computeOldestUndrainedAge(oldestFirst, NOW);
+    const b = computeOldestUndrainedAge(newestFirst, NOW);
+    const c = computeOldestUndrainedAge(shuffled, NOW);
+
+    expect(b).toEqual(a);
+    expect(c).toEqual(a);
+    expect(a.oldestAgeMs).toBe(51 * DAY);
+  });
+
+  it('counts an unparsable timestamp instead of silently dropping it', () => {
+    // Dropping it would shrink the population and read as a healthier drain than reality.
+    const r = computeOldestUndrainedAge([{ created_at: 'not-a-date' }, ago(3 * DAY)], NOW);
+    expect(r.count).toBe(2);
+    expect(r.unparsable).toBe(1);
+    expect(r.oldestAgeMs).toBe(3 * DAY);
+  });
+
+  it('returns a null age (never 0) for an empty drain, so empty is not confused with fresh', () => {
+    const r = computeOldestUndrainedAge([], NOW);
+    expect(r.count).toBe(0);
+    expect(r.oldestAgeMs).toBeNull();
+  });
+
+  it('never returns a negative age for a clock-skewed future timestamp', () => {
+    expect(computeOldestUndrainedAge([ago(-5 * DAY)], NOW).oldestAgeMs).toBe(0);
+  });
+});
+
+describe('structural verdicts are computed with ZERO IO (provenance split)', () => {
+  it('flags a missing consumer as NO_CONSUMER (TS-14)', () => {
+    expect(classifyStructural({ closingPath: 'x' })).toBe(VERDICT.NO_CONSUMER);
+  });
+
+  it('flags a missing closing path as NO_CLOSING_PATH — HARDENING 1 (TS-3)', () => {
+    expect(classifyStructural({ consumer: 'someone' })).toBe(VERDICT.NO_CLOSING_PATH);
+  });
+
+  it('treats an absent/!object descriptor as UNDECLARED, never as healthy', () => {
+    expect(classifyStructural(undefined)).toBe(VERDICT.UNDECLARED);
+    expect(classifyStructural(null)).toBe(VERDICT.UNDECLARED);
+  });
+
+  it('classifies unkeyable work as MEASURED_ELSEWHERE, distinct from a finding (TS-7)', () => {
+    const v = classifyStructural({ measuredBy: 'consult-reply catch rate' });
+    expect(v).toBe(VERDICT.MEASURED_ELSEWHERE);
+    // The whole point: unkeyable work must NEVER be counted as neglect.
+    expect(isFailing(v)).toBe(false);
+  });
+
+  it('returns null (needs a read) only when consumer AND closingPath are both present', () => {
+    expect(classifyStructural({ consumer: 'c', closingPath: 'p' })).toBeNull();
+  });
+
+  it('yields identical structural verdicts whether or not a reading is available', () => {
+    const d = { closingPath: 'x' }; // no consumer
+    expect(classifyObserved(d, { noData: true, reason: 'db down' })).toBe(VERDICT.NO_CONSUMER);
+    expect(classifyObserved(d, { count: 0, closingPathUses: 5 })).toBe(VERDICT.NO_CONSUMER);
+    expect(classifyStructural(d)).toBe(VERDICT.NO_CONSUMER);
+  });
+});
+
+describe('observed verdicts', () => {
+  const sound = { consumer: 'c', closingPath: 'p' };
+
+  it('PASSes a sound descriptor with an exercised closing path (TS-1)', () => {
+    expect(classifyObserved(sound, { count: 3, closingPathUses: 12 })).toBe(VERDICT.PASS);
+  });
+
+  it('distinguishes a closing path that EXISTS but was NEVER used (TS-4)', () => {
+    // The invariant_gauge_finding case: 4,235 findings, zero dispositions ever written.
+    const v = classifyObserved(sound, { count: 4235, closingPathUses: 0 });
+    expect(v).toBe(VERDICT.CLOSING_PATH_UNEXERCISED);
+    expect(v).not.toBe(VERDICT.PASS);
+    expect(v).not.toBe(VERDICT.NO_CLOSING_PATH); // not the same as having no path at all
+  });
+
+  it('does not report UNEXERCISED when there is nothing outstanding to close', () => {
+    expect(classifyObserved(sound, { count: 0, closingPathUses: 0 })).toBe(VERDICT.PASS);
+  });
+
+  it('reports UNAVAILABLE — never PASS — when the read fails (TS-5)', () => {
+    // An unchecked error must not manufacture a clean bill of health.
+    for (const reading of [undefined, null, { noData: true, reason: 'query failed' }]) {
+      const v = classifyObserved(sound, reading);
+      expect(v).toBe(VERDICT.UNAVAILABLE);
+      expect(v).not.toBe(VERDICT.PASS);
+    }
+  });
+
+  it('does not count UNAVAILABLE as a finding either — unmeasured is not unhealthy', () => {
+    expect(isFailing(VERDICT.UNAVAILABLE)).toBe(false);
+  });
+});
+
+describe('evidence floor — the alarm must not clear by retention (TS-6)', () => {
+  it('refuses when the staleness threshold meets or exceeds retention', () => {
+    expect(assertThresholdBelowRetention(30 * DAY, 30 * DAY)).toMatch(/retention/);
+    expect(assertThresholdBelowRetention(60 * DAY, 30 * DAY)).toMatch(/retention/);
+  });
+  it('allows a threshold safely below retention', () => {
+    expect(assertThresholdBelowRetention(7 * DAY, 30 * DAY)).toBeNull();
+  });
+});
+
+describe('exit code contract (TS-17)', () => {
+  it('exits non-zero when ANY entry fails, so the inventory cannot be green while carrying a finding', () => {
+    expect(exitCodeFor([VERDICT.PASS, VERDICT.NO_CONSUMER])).toBe(1);
+    expect(exitCodeFor([VERDICT.PASS, VERDICT.NO_CLOSING_PATH])).toBe(1);
+    expect(exitCodeFor([VERDICT.UNDECLARED])).toBe(1);
+  });
+  it('exits zero for healthy, unkeyable, unexercised and unmeasurable entries', () => {
+    expect(exitCodeFor([
+      VERDICT.PASS, VERDICT.MEASURED_ELSEWHERE, VERDICT.CLOSING_PATH_UNEXERCISED, VERDICT.UNAVAILABLE,
+    ])).toBe(0);
+  });
+  it('FAILING_VERDICTS is exactly the three structural findings', () => {
+    expect([...FAILING_VERDICTS].sort()).toEqual(
+      [VERDICT.NO_CONSUMER, VERDICT.NO_CLOSING_PATH, VERDICT.UNDECLARED].sort());
+  });
+});
+
+describe('buildInventoryRow surfaces the declared contract fields', () => {
+  it('carries predicate, shape contract and skew onto the row', () => {
+    const row = buildInventoryRow('x', {
+      consumer: 'c', closingPath: 'p', predicate: 'status in (new, triaged)',
+      shapeContract: 'reader keys on reason_supplied', timestampSkew: 'naive, ~4h young',
+    }, { count: 2, oldestAgeMs: 3 * DAY, closingPathUses: 1 });
+
+    expect(row.verdict).toBe(VERDICT.PASS);
+    expect(row.failing).toBe(false);
+    expect(row.predicate).toBe('status in (new, triaged)');
+    expect(row.shapeContract).toMatch(/reason_supplied/);
+    expect(row.timestampSkew).toMatch(/4h/);
+    expect(row.oldestAgeMs).toBe(3 * DAY);
+  });
+
+  it('with no reading at all, falls back to the structural verdict rather than inventing health', () => {
+    expect(buildInventoryRow('y', { consumer: 'c', closingPath: 'p' }).verdict).toBe(VERDICT.UNAVAILABLE);
+    expect(buildInventoryRow('z', { closingPath: 'p' }).verdict).toBe(VERDICT.NO_CONSUMER);
+  });
+});
+
+describe('DRAIN_DESCRIPTORS — the populated inventory discriminates (FR-4)', () => {
+  const verdictOf = (id) => classifyStructural(DRAIN_DESCRIPTORS[id]);
+
+  it('flags the confirmed write-only sinks as NO_CONSUMER', () => {
+    expect(verdictOf('relay-drop')).toBe(VERDICT.NO_CONSUMER);
+    expect(verdictOf('wind-down-survey')).toBe(VERDICT.NO_CONSUMER);
+    expect(verdictOf('feedback-sla-breach')).toBe(VERDICT.NO_CONSUMER);
+    expect(verdictOf('quick-fixes-stranded')).toBe(VERDICT.NO_CONSUMER);
+  });
+
+  it('FAILS a table that cannot express DONE even though it HAS a consumer (HARDENING 1)', () => {
+    // adam_adherence_ledger has a real reader, so a consumer-only check would call it healthy.
+    // It has no status column at all, so a verdict=fail row can never be marked addressed.
+    expect(DRAIN_DESCRIPTORS['adam-adherence-ledger'].consumer).toBeTruthy();
+    expect(verdictOf('adam-adherence-ledger')).toBe(VERDICT.NO_CLOSING_PATH);
+    expect(isFailing(verdictOf('adam-adherence-ledger'))).toBe(true);
+  });
+
+  it('FAILS durable output that is not even in the database', () => {
+    expect(verdictOf('worktree-reaper-refusals')).toBe(VERDICT.NO_CONSUMER);
+    expect(DRAIN_DESCRIPTORS['worktree-reaper-refusals'].accumulationSignal).toMatch(/undrained/i);
+  });
+
+  it('PASSes the model entry — proving the check discriminates rather than failing everything', () => {
+    // Without this control, an implementation that failed EVERY entry would look correct.
+    expect(verdictOf('solomon-advice-outcome-ledger')).toBeNull(); // structurally sound → needs a read
+    expect(classifyObserved(DRAIN_DESCRIPTORS['solomon-advice-outcome-ledger'],
+      { count: 848, closingPathUses: 53 })).toBe(VERDICT.PASS);
+  });
+
+  it('treats unkeyable work as MEASURED_ELSEWHERE with a named instrument, never as neglect', () => {
+    const d = DRAIN_DESCRIPTORS['solomon-consult-replies'];
+    expect(verdictOf('solomon-consult-replies')).toBe(VERDICT.MEASURED_ELSEWHERE);
+    expect(d.measuredBy).toBeTruthy();
+    // The guard: the instrument must not be a manufactured artifact.
+    expect(d.measuredBy).toMatch(/NOT an SD\/QF row|NOT a queue count/i);
+  });
+
+  it('records the shape contract where writer and reader disagree', () => {
+    expect(DRAIN_DESCRIPTORS['roadmap-link-exception'].shapeContract).toMatch(/reason_supplied/);
+  });
+
+  it('declares naive-timestamp skew on affected sources (TS-16)', () => {
+    expect(DRAIN_DESCRIPTORS['quick-fixes-stranded'].timestampSkew).toMatch(/naive/i);
+  });
+
+  it('every descriptor names a predicate or is explicitly unkeyable', () => {
+    for (const [id, d] of Object.entries(DRAIN_DESCRIPTORS)) {
+      const named = Boolean(d.predicate) || d.source?.kind === 'unkeyable';
+      expect(named, `${id} must name its predicate (owed vs merely delivered)`).toBe(true);
+    }
+  });
+
+  it('the inventory as populated FAILS overall — the findings are real, not decorative', () => {
+    const verdicts = Object.keys(DRAIN_DESCRIPTORS).map(verdictOf).filter((v) => v !== null);
+    expect(exitCodeFor(verdicts)).toBe(1);
+    expect(verdicts.filter(isFailing).length).toBeGreaterThanOrEqual(6);
+  });
+});
+
+describe('additive-only: GAUGE_REGISTRY is untouched (TS-15)', () => {
+  it('registry entries did not gain drain fields', () => {
+    for (const entry of GAUGE_REGISTRY) {
+      expect(entry.drain).toBeUndefined();
+      expect(entry.detectorFn === null || typeof entry.detectorFn === 'string').toBe(true);
+    }
+  });
+
+  it('a descriptor may exist for a sink that is NOT a registry entry', () => {
+    const ids = new Set(GAUGE_REGISTRY.map((e) => e.id));
+    expect(ids.has('wind-down-survey')).toBe(false);
+    expect(DRAIN_DESCRIPTORS['wind-down-survey']).toBeTruthy();
+  });
+
+  it('relay-drop is BOTH a registered gauge and an undrained sink — registration is not drainage', () => {
+    const entry = GAUGE_REGISTRY.find((e) => e.id === 'relay-drop');
+    expect(entry?.ownerRole).toBe('coordinator');       // a trip owner exists
+    expect(DRAIN_DESCRIPTORS['relay-drop'].consumer).toBeUndefined(); // yet nobody drains the row
+    expect(classifyStructural(DRAIN_DESCRIPTORS['relay-drop'])).toBe(VERDICT.NO_CONSUMER);
+  });
+});

--- a/tests/unit/governance/drain-inventory.test.js
+++ b/tests/unit/governance/drain-inventory.test.js
@@ -220,7 +220,7 @@ describe('buildInventoryRow surfaces the declared contract fields', () => {
 
 describe('paginateAll — truncation reads YOUNG, which suppresses the alarm (TS-12)', () => {
   // Fake ordered page source: rows[0] is the oldest, matching an ORDER BY created_at ASC.
-  const makeSource = (total, pageSize) => {
+  const makeSource = (total) => {
     const all = Array.from({ length: total }, (_, i) => ago((total - i) * 60_000));
     const calls = [];
     return {
@@ -234,7 +234,7 @@ describe('paginateAll — truncation reads YOUNG, which suppresses the alarm (TS
   };
 
   it('pages past the 1000-row cap over a 4,235-row population', async () => {
-    const src = makeSource(4235, 1000);
+    const src = makeSource(4235);
     const res = await paginateAll(src.fetchPage, { pageSize: 1000 });
     expect(res.rows).toHaveLength(4235);
     expect(src.calls).toHaveLength(5); // 4 full pages + a short final page
@@ -245,21 +245,21 @@ describe('paginateAll — truncation reads YOUNG, which suppresses the alarm (TS
 
   it('does not stop one page early when the total is an exact multiple of the page size', async () => {
     // A `<=` where `<` belongs drops the tail silently and reports a younger oldest-age.
-    const src = makeSource(2000, 1000);
+    const src = makeSource(2000);
     const res = await paginateAll(src.fetchPage, { pageSize: 1000 });
     expect(res.rows).toHaveLength(2000);
     expect(src.calls).toHaveLength(3); // must probe once more to learn the set ended
   });
 
   it('returns a single page without over-fetching', async () => {
-    const src = makeSource(10, 1000);
+    const src = makeSource(10);
     const res = await paginateAll(src.fetchPage, { pageSize: 1000 });
     expect(res.rows).toHaveLength(10);
     expect(src.calls).toHaveLength(1);
   });
 
   it('REFUSES to report a truncated population as complete when the page budget is exhausted', async () => {
-    const src = makeSource(5000, 1000);
+    const src = makeSource(5000);
     const res = await paginateAll(src.fetchPage, { pageSize: 1000, maxPages: 2 });
     // Must NOT return the 2000 rows it managed to read as if that were the whole set — a partial
     // read rendered as complete is precisely an alarm-suppressing under-report.
@@ -283,7 +283,7 @@ describe('paginateAll — truncation reads YOUNG, which suppresses the alarm (TS
     // A write-spy over the injected fetcher: pagination must only ever read.
     const forbidden = ['insert', 'update', 'delete', 'upsert'];
     const seen = [];
-    const spy = new Proxy(async (from, to) => ({ rows: from === 0 ? [ago(DAY)] : [] }), {
+    const spy = new Proxy(async (from) => ({ rows: from === 0 ? [ago(DAY)] : [] }), {
       get(target, prop) { if (forbidden.includes(String(prop))) seen.push(prop); return target[prop]; },
     });
     const res = await paginateAll(spy, { pageSize: 1000 });

--- a/tests/unit/governance/drain-inventory.test.js
+++ b/tests/unit/governance/drain-inventory.test.js
@@ -210,6 +210,18 @@ describe('buildInventoryRow surfaces the declared contract fields', () => {
     expect(row.count).toBe(4);
   });
 
+  it('carries measuredBy and oldestAt onto the row', () => {
+    // Both survived mutation as unasserted plumbing. measuredBy is what keeps unkeyable work from
+    // reading as neglect in --json output; oldestAt is the absolute timestamp behind the relative
+    // age, and an unpinned field is one nobody notices going null.
+    const row = buildInventoryRow('m', { measuredBy: 'a different instrument' }, undefined);
+    expect(row.measuredBy).toBe('a different instrument');
+    expect(row.verdict).toBe(VERDICT.MEASURED_ELSEWHERE);
+
+    const { oldestAt } = computeOldestUndrainedAge([ago(2 * DAY)], NOW);
+    expect(oldestAt).toBe(new Date(NOW - 2 * DAY).toISOString());
+  });
+
   it('propagates the failure reason so an UNAVAILABLE entry explains itself', () => {
     const row = buildInventoryRow('u', { consumer: 'c', closingPath: 'p' },
       { noData: true, reason: 'feedback read failed: boom' });


### PR DESCRIPTION
**A detector whose output accumulates unread is indistinguishable, at every downstream surface, from a detector that never fired.** `GAUGE_REGISTRY` answered "who owns a TRIP"; nothing answered "who drains the ROW it wrote".

The seam is visible inside the registry itself: `relay-drop` is a registered entry **with** an `ownerRole`, and its output still sat at 11 rows, all `status=new`, undrained since 2026-07-19. **Registration is not drainage.**

## What lands

- **`lib/governance/drain-inventory.js`** — pure core. Verdicts split **by provenance, not outcome**: STRUCTURAL (zero IO — `UNDECLARED`, `NO_CONSUMER`, `NO_CLOSING_PATH`, `MEASURED_ELSEWHERE`) vs OBSERVED (needs a read — `PASS`, `CLOSING_PATH_UNEXERCISED`, `UNAVAILABLE`). Without that split a missing state file reads as `UNAVAILABLE` (failed read) when it is really `NO_CLOSING_PATH` (a structural fact), and the two differ in exit code.
- **`DRAIN_DESCRIPTORS`** in `gauge-registry.js` — a **sibling export, not fields on entries**. Most detectors that write durable output are not gauges, and a drain-only sink has no `detectorFn`; extending entries would break the file's own non-null-detectorFn invariant, its entry count and its enabled-id list. Same file, so "no new registry" holds.
- **`scripts/drain-inventory.mjs`** — read-only CLI, non-zero exit on any FAIL.
- 35 tests.

## Live run reproduces the SD's measured evidence

```
!! relay-drop               NO_CONSUMER               8.0d   n=11     (SD: 11 rows, oldest 2026-07-19)
!! adam-adherence-drift     NO_CLOSING_PATH          36.0d   n=75     (SD: oldest 2026-06-21)
!! adam-adherence-ledger    NO_CLOSING_PATH          36.0d   n=124    (no status column at all)
!! quick-fixes-stranded     NO_CONSUMER               2.4d   n=7      (VALIDATION measured 7)
!! feedback-sla-breach      NO_CONSUMER              22.9d   n=54     (the SLA alarm, itself undrained)
   invariant-gauge-finding  CLOSING_PATH_UNEXERCISED 24.5d   n=4245
ok solomon-...-ledger       PASS                      3.5d   n=380
   solomon-consult-replies  MEASURED_ELSEWHERE          —            (unkeyable, NOT neglect)
=> 11 detectors, 7 FAILING, exit 1
```

## Design decisions worth review

**HARDENING 1**: no consumer or no expressible terminal state **FAILS** rather than rendering a blank. A blank reads as "not yet filled in"; a failure reads as a finding. `adam_adherence_ledger` is the sharp case — it *has* a real consumer, so a consumer-only check would call it healthy, but it has no status column, so a `verdict=fail` row can never be marked addressed.

**`UNAVAILABLE` is deliberately not a failure.** Unmeasured must never render as either health or a finding, so an unchecked error cannot manufacture a clean bill of health. `roadmap-link-exception` reports `UNAVAILABLE` rather than guessing.

**Unkeyable work is `MEASURED_ELSEWHERE` with a named instrument, never neglect.** Manufacturing artifacts so a counter can see consult replies or rulings is forbidden — it converts judgment work into paperwork and degrades the lane the measurement was meant to protect.

## Two defects found by running it live (both fixed here)

1. `invariant-gauge-finding` rendered **PASS** with 4,245 outstanding rows — the reader left `closingPathUses` null, and `null !== 0` fell through to PASS. The inventory reported health over exactly the defect it exists to detect. Closing paths are now **probed**, never assumed.
2. Failing entries showed a **blank age**, because the read was skipped once a structural verdict decided. But the age is half the finding — a blank would have repeated the SD's own complaint that absence gets rendered as an empty cell.

## Verification

- **Mutation tested, and it found a real weakness.** Mutant "trust `rows[0]` instead of scanning for the minimum" was initially caught by the ordering-independence test *alone* — the TS-2 fixture happened to be ordered oldest-first, so `rows[0]` was accidentally correct and the load-bearing test passed while the drain logic was broken. Fixture reordered newest-first; TS-2 now catches it independently. A second mutant (report a failed read as PASS) is caught by the UNAVAILABLE test.
- Every age assertion carries a negative control — exact value **and** separation from the newest-write reading, because `toBeGreaterThan(0)` passes identically for a 1-minute and a 51-day reading.
- A discrimination control is included: the solomon ledger PASSES while six entries FAIL, so an implementation that failed everything cannot look correct.
- Pagination is explicitly ordered and pages to exhaustion — PostgREST caps at 1000 rows against a 4,245-row population, so an unordered page would under-report age in the **alarm-suppressing** direction.
- **FR-5**: registered as `standard_loop:drain-inventory`, `stampLastFired` verified writing `last_fired_at` on a live run — without it this gauge would be an unwatched detector, the tenth instance of its own class.
- No regressions: **1,395 tests across 101 suites** pass; the pre-existing gauge-registry suite is untouched (additive-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
