### PR TITLE
fix(QF-20260725-096): stop serving the superseded /fleet-ui session view (scoped 410)

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -161,6 +161,34 @@ app.all('/api/webhooks/twilio-status', express.urlencoded({ extended: false }), 
 
 app.use(express.json());
 
+// QF-20260725-096 — the standalone /fleet-ui session view is RETIRED (chairman-ratified
+// 2026-07-27). EHG's BuilderSessionsPage is the session list, and the terminal is the detail
+// surface. Registered AHEAD of the static mount below because that is the only thing serving
+// these files; anything after it never runs.
+//
+// FILE-SCOPED, NOT ROUTE-SCOPED, and that distinction is the whole point: session-view.*,
+// fleet-panel.* and vision.* all live under the SAME /fleet-ui static mount, so retiring the
+// mount — or matching a prefix any looser than this — would take the other two pages down with
+// it. The anchored regex matches session-view.<ext> and nothing else: not fleet-panel.html, not
+// vision.html, and not a nested path, because [^/]* cannot cross a segment boundary.
+// A raw RegExp rather than a string pattern: this is Express 5 (path-to-regexp v8), where the
+// old '*' string wildcard no longer means what it did in v4.
+//
+// 410 Gone, deliberately, not 404: it asserts the resource was real and is intentionally
+// withdrawn, so a hit shows up as a decision rather than a broken link. That matters because
+// the disposition depends on watching for hits during the soak — silence is the evidence.
+// DELETES NOTHING. server/public/fleet-ui/session-view.js stays on disk (its unit test still
+// imports it), and rollback is removing this block — one commit, no file resurrection.
+app.all(/^\/fleet-ui\/session-view\.[^/]*$/, (req, res) => {
+  res.status(410).type('text/plain').send(
+    'Gone — the standalone fleet-ui session view was retired on 2026-07-27 (QF-20260725-096).\n\n' +
+    'Session list: the Builder Sessions page in EHG.\n' +
+    'Session detail (TTY, narration, agent-browser, takeover/hand-back): use the terminal.\n\n' +
+    'This capability is knowingly unavailable from the web surface. If you needed this page,\n' +
+    'that is a signal worth raising — the retirement is reversible.\n'
+  );
+});
+
 // Fleet-launcher operator UI static assets (SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-B): the
 // Session View pane fragment, mountable into the parent shell. See the ARCH-007 exception
 // note at the top of this file.


### PR DESCRIPTION
Chairman-ratified 2026-07-27. EHG's BuilderSessionsPage is the session list and the terminal is
the detail surface, so the standalone `/fleet-ui` session view is retired.

## Why file-scoped, not route-scoped

`session-view.*`, `fleet-panel.*` and `vision.*` all sit under the **same** `/fleet-ui` static
mount. Retiring the mount — or matching any looser prefix — would take the other two pages down
with it. That is the exact regression this scoping exists to prevent.

The anchored regex matches `session-view.<ext>` and nothing else. `[^/]*` cannot cross a segment
boundary, so a nested path never matches:

| Path | Result |
|---|---|
| `/fleet-ui/session-view.html` / `.js` / `.css` | **410** |
| `/fleet-ui/fleet-panel.html` | pass through |
| `/fleet-ui/vision.html` | pass through |
| `/fleet-ui/sub/session-view.html` | pass through |
| `/fleet-ui/session-view` (no extension) | pass through |

A raw `RegExp` rather than a string pattern because this is **Express 5** (path-to-regexp v8),
where the old `*` string wildcard changed meaning.

**410 Gone, not 404** — it asserts the resource was real and is intentionally withdrawn, so a hit
reads as a decision rather than a broken link. That matters because the disposition depends on
watching for hits during the soak.

## Verification

Run against a server started from this worktree on `:3411`. `vision.html` is untracked in-flight
work that does not exist on `origin/main`, so for the named check I copied the real file in,
probed, and removed it — the first probe's 404 was a missing file, not my middleware.

```
PRE    session-view.html 200 | fleet-panel.html 200 | vision.html 200
POST   session-view.html 410 | session-view.js 410 | session-view.css 410
       fleet-panel.html  200 | vision.html      200

server/routes/fleet-sessions.test.js        21 passed
server/public/fleet-ui/session-view.test.js 12 passed
```

That second suite is the point of the delete-nothing fence: the **-12 unit-test hazard dissolves**
because `session-view.js` is still on disk for the test to import. The 410 is a *serving*
decision, not a *source* decision.

## Fences — verified, not asserted

| File | State |
|---|---|
| `server/routes/fleet-sessions.js` | **untouched** — `POST /:id/open` is live-called by EHG `useFleetSessions.ts:442` |
| `lib/fleet/session-detail-view.js` | **untouched** — different artefact, same name |
| `lib/fleet/browser-control.js` | **untouched** |
| deletions | **zero**; one file changed |

## Accepted capability loss

The session detail pane (TTY, narration, agent-browser, takeover/hand-back) has **no successor**
in EHG. This was put to the chairman explicitly before he chose. The terminal is the detail
surface for the soak window.

**Rollback:** remove the block. One commit, no file resurrection.
**Soak:** hold 7 days and watch for a hit. Silence is the evidence — but note a zero from a browser
history nobody could open is not a zero.

**Unblocks:** the fleet-panel auth-tightening that FOLD-001 records as blocked on this disposition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
