### PR TITLE
fix(QF-20260727-484): log 410 hits so the session-view soak can produce evidence

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -180,6 +180,24 @@ app.use(express.json());
 // DELETES NOTHING. server/public/fleet-ui/session-view.js stays on disk (its unit test still
 // imports it), and rollback is removing this block — one commit, no file resurrection.
 app.all(/^\/fleet-ui\/session-view\.[^/]*$/, (req, res) => {
+  // QF-20260727-484 — WITHOUT THIS LINE THE SOAK CANNOT PRODUCE EVIDENCE. The retirement above
+  // is dispositioned by a seven-day soak in which SILENCE IS THE EVIDENCE, but this server has no
+  // request logging of any kind (no morgan — it is not even a dependency), so a 410 hit wrote
+  // nothing anywhere. Silence was therefore GUARANTEED: at day 7 nobody could distinguish "nobody
+  // hit it" from "we could never have seen it". QF-20260725-096 already carried the warning that
+  // a zero from a file that could not be opened is not a zero — but pinned it on locked browser
+  // history. The real blind spot was server-side and total.
+  //
+  // Scoped to THIS handler on purpose: general request logging on /fleet-ui or on the app is a
+  // different change with a different justification (volume, privacy, noise) and is NOT in scope.
+  // stdout is durable here — scripts/leo-stack.ps1:171 runs the server as `node server.js >
+  // .logs/engineer-<timestamp>.log 2>&1` — so the soak reader has exactly one command:
+  //   grep fleet-ui-410 .logs/engineer-*.log
+  // An empty result now means genuinely unhit, which is the whole point.
+  console.log(
+    `[fleet-ui-410] ${new Date().toISOString()} ${req.method} ${req.originalUrl} ` +
+    `referer=${req.get('referer') || '-'}`
+  );
   res.status(410).type('text/plain').send(
     'Gone — the standalone fleet-ui session view was retired on 2026-07-27 (QF-20260725-096).\n\n' +
     'Session list: the Builder Sessions page in EHG.\n' +


### PR DESCRIPTION
## The soak could not produce evidence

[QF-20260725-096](https://github.com/rickfelix/EHG_Engineer/pull/6618) retires `/fleet-ui/session-view.*`
behind a 410 and dispositions it with a **seven-day soak in which silence is the evidence**.

That soak could not produce evidence. This server has **no request logging of any kind** — no morgan,
not even as a dependency — so a 410 hit wrote nothing anywhere. Silence was *guaranteed*: at day 7
nobody could distinguish "nobody hit it" from "we could never have seen it".

The irony is the point. The 096 row already carries the warning that *a zero from a file that could
not be opened is not a zero* — but pins it on a locked browser history file. Browser history was
never going to be the instrument. The server was, and it was not wired. The blind spot was
**server-side and total**.

## Scope

Scoped to **this handler only**. General request logging on `/fleet-ui` or on the app is a different
change with a different justification (volume, privacy, noise) and is explicitly out of scope.

Durability is the actual requirement, not the log call. `scripts/leo-stack.ps1:171` runs the server
as `node server.js > .logs/engineer-<timestamp>.log 2>&1`, so stdout is captured to disk. The soak
reader gets exactly one command:

```
grep fleet-ui-410 .logs/engineer-*.log
```

An empty result now means genuinely unhit.

## Verification

Server started from this worktree on `:3412`; four requests, two to the retired paths and two to
siblings under the same static mount:

| Request | Status | Logged? |
|---|---|---|
| `/fleet-ui/session-view.html` | 410 | **yes** |
| `/fleet-ui/session-view.js` | 410 | **yes** |
| `/fleet-ui/fleet-panel.html` | 200 | no |
| `/fleet-ui/vision.html` | 200 | no |

```
[fleet-ui-410] 2026-07-27T23:31:07.937Z GET /fleet-ui/session-view.html referer=http://example.test/probe
[fleet-ui-410] 2026-07-27T23:31:08.181Z GET /fleet-ui/session-view.js   referer=http://example.test/probe
```

Exactly two lines for two hits, and **zero** from pass-through traffic — that second half is the
scope-containment proof, not just the happy path.

`fleet-sessions.test.js` + `session-view.test.js`: **33 passed**. One file changed, +18.

## Sequencing

Per the coordinator ruling, **the seven-day soak clock does not start until this lands**. Running the
soak first would burn a week producing an unfalsifiable zero and hand the disposition a result that
cannot fail.

Separately raised and still open: the 410 is merged but **not yet live** — the shared root tree is
behind `origin/main`, so the running server still serves 200. The clock needs a deployed subject as
well as an instrument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
