### PR TITLE
fix(SD-LEO-INFRA-WORKTREE-LIFECYCLE-FAILS-001): stop worktree cleanup reporting outcomes that contradict the disk

### DIFF
--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -1777,7 +1777,19 @@ export function cleanupWorktree(sdKey, { force = false } = {}) {
   }
 
   console.info(`[worktree-manager] Cleanup started for sdKey=${sdKey}`);
-  removeWorktree(sdKey);
+  // SD-LEO-INFRA-WORKTREE-LIFECYCLE-FAILS-001 (FR-3): this result used to be DISCARDED, and the
+  // verdict below re-derived solely from `git worktree list --porcelain` containment. When
+  // removeWorktree() refused and ARCHIVED instead (unpushed commits — _archiveWorktreeDir at
+  // :1704 MOVES the directory), the moved path is absent from that listing, so `stillExists`
+  // was false and this returned {cleaned:true, reason:'success'}. Callers then reported the
+  // worktree as removed while the code sat in .worktrees/_archive/ — a REFUSAL rendered as a
+  // SUCCESS, which is strictly worse than the post-merge path's refusal-rendered-as-protected.
+  // Propagate the real outcome instead of inferring one.
+  const removal = removeWorktree(sdKey);
+  if (removal && removal.removed === false) {
+    console.warn(`[worktree-manager] Cleanup refused for ${sdKey}: ${removal.reason}`);
+    return { cleaned: false, ...removal };
+  }
 
   // Verify removal
   const porcelain = execSync('git worktree list --porcelain', {
@@ -1792,7 +1804,14 @@ export function cleanupWorktree(sdKey, { force = false } = {}) {
     return { cleaned: false, reason: 'removal_incomplete' };
   }
 
-  return { cleaned: true, reason: 'success' };
+  // A gone-from-porcelain path is only a genuine removal if the directory is gone too;
+  // otherwise it is the husk (registration dropped, directory left behind).
+  if (fs.existsSync(worktreePath)) {
+    console.warn(`[worktree-manager] Husk for ${sdKey}: deregistered from git but directory remains at ${worktreePath}`);
+    return { cleaned: false, reason: 'husk_directory_remains', husk: true, worktreePath };
+  }
+
+  return { cleaned: true, reason: 'success', archived: false };
 }
 
 /**

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -855,12 +855,21 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
       console.log('\n🌲 Worktree Cleanup');
       console.log('-'.repeat(50));
       worktreeCleanupResult = cleanupWorktree(sdKey);
-      if (worktreeCleanupResult.cleaned) {
+      // SD-LEO-INFRA-WORKTREE-LIFECYCLE-FAILS-001 (FR-3): never tell the operator a worktree
+      // was "removed" when it was ARCHIVED. cleanupWorktree used to infer success from
+      // `git worktree list` containment, so an archived (MOVED) directory read as removed and
+      // this line printed a flat success. The library now reports the archive; surface it here
+      // with the path and the trigger, so "removed" means removed and nothing else does.
+      if (worktreeCleanupResult.archived && worktreeCleanupResult.archivePath) {
+        console.warn(`   ⚠️  Worktree NOT removed — archived to ${worktreeCleanupResult.archivePath} (${worktreeCleanupResult.reason}). The code is preserved there, not deleted.`);
+      } else if (worktreeCleanupResult.cleaned) {
         console.log(`   ✅ Worktree .worktrees/${sdKey} removed`);
       } else if (worktreeCleanupResult.reason === 'worktree_not_found') {
         console.log(`   ℹ️  No worktree found for ${sdKey} (may not have been created)`);
       } else if (worktreeCleanupResult.reason === 'dirty_worktree') {
         console.warn('   ⚠️  Worktree has uncommitted changes — run /ship first, then re-run LEAD-FINAL-APPROVAL');
+      } else if (worktreeCleanupResult.reason === 'husk_directory_remains') {
+        console.warn(`   ⚠️  Husk: ${sdKey} was deregistered from git but its directory remains at ${worktreeCleanupResult.worktreePath || `.worktrees/${sdKey}`} — invisible to git-based sweeps, safe to delete manually.`);
       } else {
         console.warn(`   ⚠️  Worktree cleanup incomplete: ${worktreeCleanupResult.reason}`);
       }

--- a/scripts/modules/shipping/__tests__/post-merge-worktree-cleanup-claim-protect.test.js
+++ b/scripts/modules/shipping/__tests__/post-merge-worktree-cleanup-claim-protect.test.js
@@ -258,7 +258,13 @@ describe('cleanupWorktreeByPath — claim-protect integration', () => {
   beforeEach(() => { env = setupTmpRepo(); });
   afterEach(() => cleanupTmp(env));
 
-  it('archives instead of deletes when active claim matches', async () => {
+  // SD-LEO-INFRA-WORKTREE-LIFECYCLE-FAILS-001 (FR-1): this assertion is INVERTED on purpose.
+  // It previously pinned that an active-claim protect MOVED the holder's directory to _archive
+  // (fs.existsSync(wtPath) === false). That is the defect: the holder is alive and standing in
+  // that directory, so relocating it produced ENOENT on the holder's next command while the
+  // return value claimed the worktree was 'protected'. A branch that protects a live holder
+  // must leave the holder's directory exactly where it is.
+  it('does NOT touch the worktree when an active claim matches (protect means no mutation)', async () => {
     const sb = mockSupabase({
       data: [{
         session_id: 'sess-A',
@@ -273,11 +279,13 @@ describe('cleanupWorktreeByPath — claim-protect integration', () => {
     expect(result.cleaned).toBe(false);
     expect(result.reason).toBe('active_claim_protect');
     expect(result.claim?.session_id).toBe('sess-A');
-    // archive succeeded → original wtPath no longer present
-    expect(fs.existsSync(env.wtPath)).toBe(false);
-    // archive should exist under .worktrees/_archive
+    // The live holder's worktree MUST still be where it was.
+    expect(fs.existsSync(env.wtPath)).toBe(true);
+    // ...and nothing may have been archived on this path.
+    expect(result.archived).toBe(false);
+    expect(result.archivePath).toBeUndefined();
     const archiveDir = path.join(env.main, '.worktrees', '_archive');
-    expect(fs.existsSync(archiveDir)).toBe(true);
+    expect(fs.existsSync(archiveDir)).toBe(false);
   });
 
   it('proceeds with cleanup when no active claim matches', async () => {
@@ -301,6 +309,13 @@ describe('cleanupWorktreeByPath — claim-protect integration', () => {
     expect(fs.existsSync(env.wtPath)).toBe(false);
     const archiveDir = path.join(env.main, '.worktrees', '_archive');
     expect(fs.existsSync(archiveDir)).toBe(true);
+    // SD-LEO-INFRA-WORKTREE-LIFECYCLE-FAILS-001 (FR-2): archiving here is still correct
+    // (unknown DB state, work may be uncommitted) — but the RETURN must say the directory
+    // moved. A caller that sees only {cleaned:false} would reasonably assume it was left
+    // alone, which is exactly the contradiction this SD exists to remove.
+    expect(result.archived).toBe(true);
+    expect(result.archivePath).toBeTruthy();
+    expect(fs.existsSync(result.archivePath)).toBe(true);
   });
 });
 

--- a/scripts/modules/shipping/post-merge-worktree-cleanup.js
+++ b/scripts/modules/shipping/post-merge-worktree-cleanup.js
@@ -340,17 +340,21 @@ async function cleanupWorktreeByPath(wtPath, options = {}) {
     return { cleaned: false, reason: 'db_error_fail_safe', error: err.message, ...archive, mainRepoPath, workKey: sdKey };
   }
   if (claim) {
-    const archive = archiveWorktree(wtPath, sdKey);
+    // SD-LEO-INFRA-WORKTREE-LIFECYCLE-FAILS-001 (FR-1): a branch whose whole purpose is to
+    // protect a LIVE holder must not move that holder's directory. archiveWorktree() is an
+    // fs.renameSync (:92) — a MOVE — so calling it here relocated a worktree the holder was
+    // standing in (witnessed: ENOENT on the holder's very next command) while this return
+    // told the caller the worktree had been 'protected'. Report the refusal, mutate nothing.
     const blockedEntry = {
       event: 'worktree.cleanup_blocked_by_claim',
       wtPath,
       sdKey,
       claim,
-      archivePath: archive.archivePath,
+      archived: false,
       timestamp: new Date().toISOString()
     };
     console.warn(JSON.stringify(blockedEntry));
-    return { cleaned: false, reason: 'active_claim_protect', claim, ...archive, mainRepoPath, workKey: sdKey };
+    return { cleaned: false, reason: 'active_claim_protect', claim, archived: false, mainRepoPath, workKey: sdKey };
   }
 
   // SD-MAN-INFRA-WORKTREE-CODE-LOSS-001 (FR-2): Block cleanup if unpushed commits
@@ -370,10 +374,44 @@ async function cleanupWorktreeByPath(wtPath, options = {}) {
     return { cleaned: false, reason: gitRemove.reason, marked: marker.written, mainRepoPath, workKey: sdKey };
   }
   if (!gitRemove.ok && fs.existsSync(wtPath)) {
-    safeRecursiveRm(wtPath);
-    execSync('git worktree prune', { cwd: mainRepoPath, stdio: 'pipe' });
+    // SD-LEO-INFRA-WORKTREE-LIFECYCLE-FAILS-001 (FR-4): this fallback previously had NO
+    // try/catch, so a locked file made safeRecursiveRm throw an uncaught EPERM instead of
+    // returning a structured refusal — and `git worktree prune` ran unconditionally on the
+    // next line without ever checking the directory actually went away.
+    //
+    // THE HUSK: `git worktree remove --force` deregisters from git before/independently of a
+    // successful directory delete (reproduced live: a foreign process resident in the worktree
+    // makes the delete fail "Permission denied" while the registration is ALREADY gone). The
+    // leftover directory is invisible to every git-based sweep. It does NOT consume a quota
+    // slot — countActiveWorktrees counts git REGISTRATIONS (lib/worktree-quota.js:174-176), so
+    // the harm is wasted disk and an operator reading .worktrees/ that cannot be trusted.
+    // Surface it explicitly rather than letting it disappear.
+    try {
+      safeRecursiveRm(wtPath);
+    } catch (err) {
+      const husk = fs.existsSync(wtPath);
+      console.warn(JSON.stringify({
+        event: husk ? 'worktree.husk_detected' : 'worktree.cleanup_rm_failed',
+        wtPath,
+        sdKey,
+        husk,
+        error: err?.message || String(err),
+        timestamp: new Date().toISOString()
+      }));
+      return {
+        cleaned: false,
+        reason: husk ? 'husk_directory_remains' : 'rm_failed',
+        husk,
+        error: err?.message || String(err),
+        mainRepoPath,
+        workKey: sdKey
+      };
+    }
+    try {
+      execSync('git worktree prune', { cwd: mainRepoPath, stdio: 'pipe' });
+    } catch { /* best effort — the directory is already gone, which is the outcome that matters */ }
   }
-  return { cleaned: true, mainRepoPath, workKey: sdKey };
+  return { cleaned: true, archived: false, mainRepoPath, workKey: sdKey };
 }
 
 /**

--- a/tests/quarantine-manifest.json
+++ b/tests/quarantine-manifest.json
@@ -217,14 +217,6 @@
       "triaged_by": "SD-REFILL-00L29WFH"
     },
     {
-      "file": "scripts/modules/shipping/__tests__/post-merge-worktree-cleanup-claim-protect.test.js",
-      "reason_class": "assertion-drift",
-      "error_signature": "AssertionError: expected -1 to be greater than 662",
-      "linked_ref": "feedback:65fce396-3dfb-4fda-b9d4-81417d7205f7",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
       "file": "scripts/twoway-roundtrip.test.js",
       "reason_class": "assertion-drift",
       "error_signature": "AssertionError: expected false to be true // Object.is equality",

--- a/tests/unit/post-merge-orphan-from-merge.test.js
+++ b/tests/unit/post-merge-orphan-from-merge.test.js
@@ -73,7 +73,14 @@ describe('cleanupOrphanFromMergeOutput (FR-2 detector wiring)', () => {
     expect(res.candidate.replace(/\\/g, '/')).toMatch(/\.worktrees\/qf\/QF-20260101-001$/);
   });
 
-  it('TS-6: orphan detected + live claim → archived (claim-aware, NOT hard-deleted)', async () => {
+  // SD-LEO-INFRA-WORKTREE-LIFECYCLE-FAILS-001 (FR-1): assertions amended, intent PRESERVED.
+  // This test's purpose is "a live-claimed worktree must not be destroyed by the orphan
+  // detector", and that still holds — more strongly than before. It used to be satisfied by
+  // ARCHIVING (fs.renameSync, a MOVE), which protected the bytes but still yanked the
+  // directory out from under a live holder and produced ENOENT on its next command. The
+  // protect branch now performs no filesystem mutation at all, so the holder's worktree is
+  // left exactly where it is. Same guarantee, one step stronger: not deleted AND not moved.
+  it('TS-6: orphan detected + live claim → left in place (claim-aware, NOT deleted, NOT moved)', async () => {
     const mainRepoPath = makeTmpRepo();
     const wt = path.join(mainRepoPath, '.worktrees', 'SD-FOO-001');
     fs.mkdirSync(wt, { recursive: true });
@@ -93,14 +100,17 @@ describe('cleanupOrphanFromMergeOutput (FR-2 detector wiring)', () => {
       { mainRepoPath, supabase }
     );
 
-    // Routed through claim-aware cleanup → archived, not deleted.
+    // Routed through claim-aware cleanup → refused, and nothing on disk was touched.
     expect(res.cleaned).toBe(false);
     expect(res.reason).toBe('active_claim_protect');
-    expect(res.archived).toBe(true);
+    expect(res.archived).toBe(false);
     expect(res.source).toBe('merge_output_detector');
-    // Original worktree dir moved out (archived), not left in place or hard-removed silently.
-    expect(fs.existsSync(wt)).toBe(false);
-    expect(fs.existsSync(res.archivePath)).toBe(true);
+    // The live holder's worktree is still exactly where it was, contents intact.
+    expect(fs.existsSync(wt)).toBe(true);
+    expect(fs.readFileSync(path.join(wt, 'marker.txt'), 'utf8')).toBe('work in progress');
+    // ...and nothing was archived on this path.
+    expect(res.archivePath).toBeUndefined();
+    expect(fs.existsSync(path.join(mainRepoPath, '.worktrees', '_archive'))).toBe(false);
   });
 
   it('advisory: never throws on negative/absent inputs (does not hard-fail /ship)', async () => {

--- a/tests/unit/worktree-manager.test.js
+++ b/tests/unit/worktree-manager.test.js
@@ -3,7 +3,7 @@
  * SD-LEO-INFRA-REFACTOR-WORKTREE-MANAGER-001
  */
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
@@ -313,6 +313,69 @@ describe('Worktree Manager', () => {
 
     it('should reject invalid sdKey', () => {
       expect(() => cleanupWorktree('../bad')).toThrow('invalid sdKey');
+    });
+
+    // SD-LEO-INFRA-WORKTREE-LIFECYCLE-FAILS-001 (FR-3).
+    // cleanupWorktree used to DISCARD removeWorktree's return value and re-derive its
+    // verdict purely from `git worktree list --porcelain` containment. When removeWorktree
+    // refused and ARCHIVED instead (unpushed commits — _archiveWorktreeDir MOVES the
+    // directory), the moved path was absent from that listing, so the function reported
+    // {cleaned:true, reason:'success'} and callers told the operator the worktree had been
+    // removed while the code sat in .worktrees/_archive/. These two tests pin the fix; they
+    // are the first behavioural coverage cleanupWorktree's non-trivial branches have had.
+    describe('outcome propagation (FR-3)', () => {
+      const ROOT = process.platform === 'win32' ? 'C:\\repo' : '/repo';
+
+      // These tests spy on the real fs module. Without an explicit restore the stubs leak
+      // into every later test in this file (safeRecursiveCp then fails ENOENT against a
+      // stubbed mkdirSync/copyFileSync) — a self-inflicted failure that looks like a
+      // product regression. Restore after each.
+      afterEach(() => { vi.restoreAllMocks(); });
+
+      /** Route execSync by command so the mock does not depend on call ordering. */
+      function routeExecSync({ unpushed = '', porcelainIncludesPath = false, wtPath = '' }) {
+        execSync.mockImplementation((cmd) => {
+          const c = String(cmd);
+          if (c.includes('rev-parse --show-toplevel')) return `${ROOT}\n`;
+          if (c.includes('git log')) return unpushed;
+          if (c.includes('worktree list --porcelain')) {
+            return porcelainIncludesPath ? `worktree ${wtPath}\n` : 'worktree /other\n';
+          }
+          return '';
+        });
+      }
+
+      it('does NOT report success when removeWorktree archived instead of removing', () => {
+        const wtPath = path.join(ROOT, '.worktrees', 'sd-archived');
+        routeExecSync({ unpushed: 'abc1234 unpushed work\n', wtPath });
+        // Directory present throughout; the archive move itself is stubbed.
+        vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+        vi.spyOn(fs, 'mkdirSync').mockImplementation(() => undefined);
+        vi.spyOn(fs, 'renameSync').mockImplementation(() => undefined);
+
+        const result = cleanupWorktree('sd-archived', { force: true });
+
+        // The regression this SD exists to kill:
+        expect(result.cleaned).toBe(false);
+        expect(result.reason).toBe('unpushed_commits');
+        // ...and the archive must be visible to the caller, not inferred.
+        expect(result.archived).toBe(true);
+        expect(result.reason).not.toBe('success');
+      });
+
+      it('reports a husk when the registration is gone but the directory remains', () => {
+        const wtPath = path.join(ROOT, '.worktrees', 'sd-husk');
+        // No unpushed commits, and porcelain no longer lists the path (deregistered)...
+        routeExecSync({ unpushed: '', porcelainIncludesPath: false, wtPath });
+        // ...but the directory is still on disk — the EPERM husk.
+        vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+        const result = cleanupWorktree('sd-husk', { force: true });
+
+        expect(result.cleaned).toBe(false);
+        expect(result.reason).toBe('husk_directory_remains');
+        expect(result.husk).toBe(true);
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

The worktree lifecycle failed at both ends by **reporting an outcome that did not match what happened on disk**.

- **FR-1** — `active_claim_protect` no longer mutates. `archiveWorktree()` is an `fs.renameSync` (a MOVE) and was called inside the branch whose entire purpose is protecting a *live* holder, relocating the holder's directory out from under it (witnessed as ENOENT on the holder's next command) while the return said "protected". That branch now archives nothing and returns `archived:false`.
- **FR-2** — the branches that *do* still archive (`db_error_fail_safe`, `unpushed_commits`) keep archiving for code-loss prevention, but the caller can now tell from the return value that the directory moved.
- **FR-3** — `cleanupWorktree` stopped discarding `removeWorktree`'s result. It re-derived its verdict purely from `git worktree list` containment, so a worktree *archived* due to unpushed commits was absent from the listing and returned `cleaned:true / reason:success`. Callers then told the operator it was removed while the code sat in `.worktrees/_archive/`. **A refusal rendered as a success is strictly worse than a refusal rendered as a protect.**
- **FR-4** — the post-merge fallback had no try/catch (uncaught EPERM) and pruned unconditionally without checking the directory had gone. Now returns `husk_directory_remains` and logs `worktree.husk_detected`.
- **FR-7** — un-quarantined the pinning test suite.

## The husk, reproduced

With a foreign process resident in a worktree, `git worktree remove --force` fails *Permission denied* while the git registration is **already gone**, leaving a directory invisible to every git-based sweep. It consumes **no quota slot** — `countActiveWorktrees` counts git *registrations* — so the harm is disk and legibility.

## Deliberately NOT changed

`countActiveWorktrees`. This SD carries a **retracted** claim that it counts directories and ratchets the quota. It counts registrations (`lib/worktree-quota.js:174-176`) and is correct.

## Why it survived

The tests pinning this behaviour were **quarantined since 2026-06-11** for a signature that no longer reproduces. The invariant was not untested — it was *tested-but-never-run*. Amending the pins without un-quarantining would have left CI green with dead assertions.

## Verification

71/71 across the four affected suites (69 baseline + 2 new). The two new FR-3 tests were **proven in both directions**: they fail against `HEAD~1` with `expected true to be false` and pass against `HEAD`. A new test that cannot fail against the old code is not a regression test.

Note: `vitest.config.js` excludes `**/.worktrees/**`, so a plain in-place run collects **zero files and reports success**; verification used an explicit config so the changed files were the ones under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)