### PR TITLE
feat(SD-LEO-INFRA-RECLAIMSAFE-CANNOT-TELL-001): reclaim evidence now says WHOSE life it witnessed

### DIFF
--- a/lib/claim/evidence-attribution-decisions.mjs
+++ b/lib/claim/evidence-attribution-decisions.mjs
@@ -1,0 +1,63 @@
+/**
+ * lib/claim/evidence-attribution-decisions.mjs — SD-LEO-INFRA-RECLAIMSAFE-CANNOT-TELL-001.
+ *
+ * The two decisions that consume triangulate()'s per-witness `evidenceAttribution` (FR-1).
+ *
+ * WHY THESE LIVE HERE RATHER THAN INLINE IN THE TWO CLI SCRIPTS: both consumers are
+ * entrypoint scripts whose logic sits inside main(), so nothing importable existed to test.
+ * The first cut of this SD tested local RE-IMPLEMENTATIONS of these predicates inside the test
+ * file, which a negative control exposed as near-vacuous: reverting stale-session-sweep.cjs
+ * entirely produced ZERO test failures, and reverting sd-start.js failed only a string-grep.
+ * The predicates were right and the tests were green, and neither fact protected the shipped
+ * code. Extracting them means the real consumers and the tests exercise the SAME function, so
+ * an inverted boolean or a deleted branch fails a test instead of passing one.
+ *
+ * Both are pure and side-effect free: the same inputs always give the same answer, and neither
+ * touches the database, the filesystem, or process state.
+ */
+
+/**
+ * FR-2 — scripts/sd-start.js asks "may I take this?".
+ *
+ * The evidence gate's witnesses are mostly SD-keyed, so this session's own branch reads as
+ * somebody else's evidence of life and locks it out of reclaiming a claim it demonstrably
+ * owns. Override that ONLY when both hold:
+ *   1. self-ownership is PROVEN (cwd inside the SD's worktree, or a deterministic
+ *      resolveOwnSession whose sd_key already equals this SD), and
+ *   2. the blocking evidence is entirely UNATTRIBUTED — nothing that fired names any session.
+ *
+ * Requiring BOTH is what keeps a strand fix from becoming a steal: if any witness points at a
+ * live session, this returns false and the caller blocks exactly as it did before this SD.
+ *
+ * @param {object} args
+ * @param {boolean} args.selfOwned - result of resolveSelfOwnership().selfOwned
+ * @param {{allUnattributed?: boolean}|null} [args.evidenceAttribution] - from checkPreClaimEvidence
+ * @returns {boolean} true = safe to override the gate for THIS session
+ */
+export function selfOwnedOverridesEvidenceGate({ selfOwned, evidenceAttribution } = {}) {
+  return Boolean(selfOwned) && evidenceAttribution?.allUnattributed === true;
+}
+
+/**
+ * FR-3 — scripts/stale-session-sweep.cjs asks "may I release someone ELSE's?".
+ *
+ * A structurally different question: the sweep iterates other sessions' claims, so
+ * "am I the owner" (resolveSelfOwnership) is the wrong primitive and is deliberately not used
+ * there. What matters is whether the evidence was produced by a session OTHER than the dead
+ * one under evaluation. Holding on unattributed evidence meant a verifiably dead session's
+ * claim stayed held by its own leftover footprint — the same strand, seen from the reaper side.
+ *
+ * Sibling attribution is liveness-filtered upstream (buildSiblingSessionMap selects only
+ * sessions with a recent heartbeat), so a named peer is a live peer.
+ *
+ * @param {object} args
+ * @param {string} args.evaluatedSessionId - the session whose claim is being considered for release
+ * @param {{sessionIds?: string[]}|null} [args.evidenceAttribution] - from checkPreClaimEvidence
+ * @returns {boolean} true = HOLD the release (a live peer is demonstrably on this SD)
+ */
+export function sweepShouldHoldRelease({ evaluatedSessionId, evidenceAttribution } = {}) {
+  const others = (evidenceAttribution?.sessionIds || []).filter(id => id !== evaluatedSessionId);
+  return others.length > 0;
+}
+
+export default { selfOwnedOverridesEvidenceGate, sweepShouldHoldRelease };

--- a/scripts/modules/claim-health/triangulate.js
+++ b/scripts/modules/claim-health/triangulate.js
@@ -370,6 +370,53 @@ export async function triangulate(supabase, sdKey = null, opts = {}) {
     if (signals.pidAlive) evidenceOfLifeSignals.push('pid_alive');
     const hasEvidenceOfLife = evidenceOfLifeSignals.length > 0;
 
+    // SD-LEO-INFRA-RECLAIMSAFE-CANNOT-TELL-001 / FR-1: report ATTRIBUTION, not just presence.
+    //
+    // hasEvidenceOfLife above answers "was SOMEONE alive on this SD". Callers were consuming it
+    // as "is it safe for THIS session to reclaim" — a different question — because three of the
+    // witnesses are keyed on the SD and carry no session identity at all: branch_present and
+    // plan_file_present come from SD-keyed name matching, and recent_sub_agent_activity comes
+    // from a query that selects only sd_id (sub_agent_execution_results has no session column).
+    // That conflation fails BOTH ways: a session is blocked from reclaiming its own claim
+    // because its own branch reads as somebody else's life, and the protection is absent
+    // precisely when no branch exists yet — early in a claim, when a strand is most likely.
+    //
+    // This block is deliberately ADDITIVE. reclaimSafe and evidenceOfLifeSignals keep their
+    // existing values and meaning so every current consumer behaves identically; the new
+    // question is answered by new fields, and the CONSUMERS decide (see FR-2 / FR-3). If you
+    // find yourself changing either of those two, stop — that is redefining the field in place,
+    // which this SD explicitly rejects.
+    const attributedEvidence = [];
+    const unattributedEvidence = [];
+    const evidenceSessionIds = new Set();
+    // SD-keyed witnesses: they prove activity exists, never whose it is.
+    for (const sig of ['branch_present', 'plan_file_present', 'recent_sub_agent_activity']) {
+      if (evidenceOfLifeSignals.includes(sig)) unattributedEvidence.push(sig);
+    }
+    // Session-attributed witnesses. sibling_session_on_branch already carries session ids via
+    // buildSiblingSessionMap (and already excludes mySessionId); tick_recent / pid_alive are
+    // derived from the claim holder's own row, so they attribute to that session.
+    if (evidenceOfLifeSignals.includes('sibling_session_on_branch')) {
+      attributedEvidence.push('sibling_session_on_branch');
+      for (const s of otherSiblings) evidenceSessionIds.add(s);
+    }
+    for (const sig of ['tick_recent', 'pid_alive']) {
+      if (evidenceOfLifeSignals.includes(sig)) {
+        attributedEvidence.push(sig);
+        if (sessionClaim?.session_id) evidenceSessionIds.add(sessionClaim.session_id);
+      }
+    }
+    const evidenceAttribution = {
+      attributed: attributedEvidence,
+      unattributed: unattributedEvidence,
+      // Sessions the attributable evidence points at. mySessionId is already excluded from the
+      // sibling set upstream, so a non-empty list here means SOMEONE ELSE is demonstrably alive.
+      sessionIds: [...evidenceSessionIds],
+      // True when evidence exists but NONE of it identifies a session — the case where the old
+      // predicate silently answered a question it could not actually answer.
+      allUnattributed: hasEvidenceOfLife && attributedEvidence.length === 0
+    };
+
     const entry = {
       sdKey: key,
       signals,
@@ -383,6 +430,7 @@ export async function triangulate(supabase, sdKey = null, opts = {}) {
       worktreePath: worktree?.path || null,
       worktreeHasChanges: worktree?.hasChanges || false,
       evidenceOfLifeSignals,           // FR1: surfaces which signals fired
+      evidenceAttribution,             // SD-...-RECLAIMSAFE-CANNOT-TELL-001 FR-1: WHOSE life, additive
       siblingSessionIds: [...otherSiblings]
     };
 
@@ -471,6 +519,10 @@ export async function checkPreClaimEvidence(supabase, sdKey, opts = {}) {
       allowReclaim: allow,
       evidence,
       classification: entry.category,
+      // SD-LEO-INFRA-RECLAIMSAFE-CANNOT-TELL-001 / FR-1: surfaced at the gate's own return so
+      // the two unwired consumers (sd-start.js, stale-session-sweep.cjs) do not have to reach
+      // into `entry` to learn WHOSE evidence blocked them. allowReclaim is UNCHANGED.
+      evidenceAttribution: entry.evidenceAttribution || null,
       entry
     };
   }
@@ -479,6 +531,7 @@ export async function checkPreClaimEvidence(supabase, sdKey, opts = {}) {
     allowReclaim: true,
     evidence: [],
     classification: null,
+    evidenceAttribution: null,
     entry: null
   };
 }

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -1013,7 +1013,55 @@ async function main() {
       const evidenceCheck = await checkPreClaimEvidence(supabase, effectiveId, {
         mySessionId: session.session_id
       });
+
+      // SD-LEO-INFRA-RECLAIMSAFE-CANNOT-TELL-001 / FR-2: before blocking, ask whether the
+      // evidence that is blocking us is OUR OWN.
+      //
+      // The gate's witnesses are mostly SD-keyed (branch/plan/sub-agent-activity), so this
+      // session's own branch reads as somebody else's "evidence of life" and locks it out of
+      // reclaiming a claim it demonstrably owns — the strand this SD exists to fix.
+      //
+      // The override is deliberately NARROW. It fires only when BOTH hold:
+      //   1. self-ownership is PROVEN (cwd inside the SD's worktree, or a deterministic
+      //      resolveOwnSession whose sd_key already equals this SD), and
+      //   2. the blocking evidence is entirely UNATTRIBUTED — i.e. nothing that fired names
+      //      any session. If any witness points at a live session, we still block.
+      // So a genuinely live foreign holder is refused exactly as before.
+      //
+      // HONEST LIMIT (do not read this as parity with BaseExecutor): sd-start is the one
+      // operation legitimately run from the MAIN REPO, usually BEFORE a worktree exists, so
+      // the cwd-in-worktree witness rarely fires here and the deterministic fallback carries
+      // most real cases. It only succeeds when this session's claude_sessions.sd_key is
+      // already stamped to this SD — the resume-after-compaction case.
+      //
+      // BACKSTOP (TR-2): this only relaxes a PRE-claim filter. The heartbeat-TTL check below
+      // (QF-20260722-842 / classifyOwnerLiveness) still refuses to release a provably-live
+      // owner, so passing this gate is not sufficient to take an active claim.
+      let selfOwnership = { selfOwned: false, via: 'none', sessionId: null };
       if (!evidenceCheck.allowReclaim && !forceReclaim) {
+        try {
+          const { resolveSelfOwnership } = await import('../lib/claim/reacquire-self-live.mjs');
+          selfOwnership = await resolveSelfOwnership({
+            sd, cwd: process.cwd(), resolveSession: resolveOwnSession
+          });
+        } catch (ownErr) {
+          console.log(`${colors.dim}(self-ownership probe skipped: ${ownErr.message})${colors.reset}`);
+        }
+      }
+      const blockingEvidenceIsAllMine = selfOwnership.selfOwned
+        && evidenceCheck.evidenceAttribution?.allUnattributed === true;
+      if (blockingEvidenceIsAllMine) {
+        console.log(
+          `${colors.yellow}⚠️  Evidence-of-life gate OVERRIDDEN — self-ownership proven (via ${selfOwnership.via}).${colors.reset}`
+        );
+        console.log(
+          `   Blocking evidence [${(evidenceCheck.evidence || []).join(', ')}] is entirely UNATTRIBUTED —`
+        );
+        console.log('   it names no session, and this session owns the SD, so it is our own footprint.');
+        console.log('   (SD-LEO-INFRA-RECLAIMSAFE-CANNOT-TELL-001 FR-2. Heartbeat-TTL guard below still applies.)');
+      }
+
+      if (!evidenceCheck.allowReclaim && !forceReclaim && !blockingEvidenceIsAllMine) {
         const evidenceList = (evidenceCheck.evidence || []).join(', ') || 'unknown';
         console.log(
           `\n${colors.red}═══════════════════════════════════════════════════════════════════${colors.reset}`
@@ -1027,6 +1075,14 @@ async function main() {
         console.log(`  SD:             ${effectiveId}`);
         console.log(`  Classification: ${evidenceCheck.classification}`);
         console.log(`  Evidence:       ${evidenceList}`);
+        // SD-LEO-INFRA-RECLAIMSAFE-CANNOT-TELL-001 FR-1: say WHOSE evidence blocked, so a
+        // strand is diagnosable from the record instead of re-derived later.
+        const att = evidenceCheck.evidenceAttribution;
+        if (att) {
+          console.log(`  Attributed to:  ${att.sessionIds.length ? att.sessionIds.join(', ') : '(no session — evidence names nobody)'}`);
+          console.log(`  Unattributed:   ${att.unattributed.length ? att.unattributed.join(', ') : '(none)'}`);
+          console.log(`  Self-owned:     ${selfOwnership.selfOwned ? `yes (via ${selfOwnership.via})` : 'no — could not prove this session owns the SD'}`);
+        }
         console.log(`  My session:     ${session.session_id}`);
         console.log(`  Owner session:  ${claimResult.owner?.session_id || '(none)'}`);
         console.log('');

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -41,6 +41,9 @@ import { checkClaimGateFreshness } from '../lib/claim/gate-freshness-check.mjs';
 // when the prior session has been released but its CC conversation is still active
 // under a rotated session_id (the 2026-04-24 incident class).
 import { checkPreClaimEvidence } from './modules/claim-health/triangulate.js';
+// SD-LEO-INFRA-RECLAIMSAFE-CANNOT-TELL-001 FR-2: the self-ownership override decision, shared
+// with its tests so the shipped predicate is the one under test.
+import { selfOwnedOverridesEvidenceGate } from '../lib/claim/evidence-attribution-decisions.mjs';
 import { isSDClaimed } from '../lib/session-conflict-checker.mjs';
 import { isProcessRunning, startHeartbeat, stopHeartbeat } from '../lib/heartbeat-manager.mjs';
 import { classifyOwnerLiveness } from '../lib/claim/owner-liveness.js';
@@ -1048,8 +1051,13 @@ async function main() {
           console.log(`${colors.dim}(self-ownership probe skipped: ${ownErr.message})${colors.reset}`);
         }
       }
-      const blockingEvidenceIsAllMine = selfOwnership.selfOwned
-        && evidenceCheck.evidenceAttribution?.allUnattributed === true;
+      // Decision lives in lib/claim/evidence-attribution-decisions.mjs so the tests exercise
+      // THIS function rather than a copy of it. An earlier cut inlined it and tested a
+      // re-implementation; a negative control showed reverting this block broke nothing.
+      const blockingEvidenceIsAllMine = selfOwnedOverridesEvidenceGate({
+        selfOwned: selfOwnership.selfOwned,
+        evidenceAttribution: evidenceCheck.evidenceAttribution
+      });
       if (blockingEvidenceIsAllMine) {
         console.log(
           `${colors.yellow}⚠️  Evidence-of-life gate OVERRIDDEN — self-ownership proven (via ${selfOwnership.via}).${colors.reset}`

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -2613,12 +2613,43 @@ async function main() {
         const { checkPreClaimEvidence } = await import('./modules/claim-health/triangulate.js');
         const evidence = await checkPreClaimEvidence(supabase, s.sd_key, { mySessionId: s.session_id });
         if (!evidence.allowReclaim) {
+          // SD-LEO-INFRA-RECLAIMSAFE-CANNOT-TELL-001 / FR-3: the sweep asks a DIFFERENT question
+          // from every other consumer of this gate. It is not asking "may I take this" — it is
+          // iterating OTHER sessions' claims asking "may I release THIS one". So the relevant
+          // question is not whether evidence exists, but whether the evidence was produced by a
+          // session OTHER than the dead one under evaluation.
+          //
+          // Three of the gate's witnesses are SD-keyed and name nobody (branch/plan/sub-agent
+          // activity). Holding on those alone means a verifiably dead session's claim stays held
+          // by its OWN leftover footprint — the strand this SD is about, seen from the reaper
+          // side. Conversely, evidence attributed to a live PEER must still hold.
+          //
+          // NOTE: resolveSelfOwnership (used by sd-start and BaseExecutor) is deliberately NOT
+          // used here. It answers "am I the owner", but this loop's cwd has no relationship to
+          // the SDs it evaluates — applying it would be a category error.
+          //
+          // Sibling attribution is liveness-filtered upstream (buildSiblingSessionMap selects
+          // only sessions with a recent heartbeat), so a named peer is a live peer.
+          const att = evidence.evidenceAttribution;
+          const otherLiveSessions = (att?.sessionIds || []).filter(id => id !== s.session_id);
+          if (otherLiveSessions.length > 0) {
+            warnings.push(
+              'WIP_GUARD_CROSS_SIGNAL: ' + s.session_id + ' SD=' + s.sd_key +
+              ' has evidence-of-life (' + (evidence.evidence || []).join(',') +
+              ') attributed to LIVE peer(s) [' + otherLiveSessions.join(',') + ']' +
+              ' classification=' + evidence.classification + ' — HOLDING release (SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001)'
+            );
+            continue;
+          }
+          // Nothing that fired names a session other than the dead one under evaluation. The
+          // heartbeat / PID / MC gates above already established THIS session is gone, so the
+          // remaining evidence is its own residue and must not keep its claim held.
           warnings.push(
-            'WIP_GUARD_CROSS_SIGNAL: ' + s.session_id + ' SD=' + s.sd_key +
-            ' has evidence-of-life (' + (evidence.evidence || []).join(',') +
-            ') classification=' + evidence.classification + ' — HOLDING release (SD-LEO-FIX-CROSS-SIGNAL-CLAIM-001)'
+            'CROSS_SIGNAL_UNATTRIBUTED: ' + s.session_id + ' SD=' + s.sd_key +
+            ' evidence (' + (evidence.evidence || []).join(',') + ') names no OTHER live session' +
+            ' [unattributed: ' + ((att?.unattributed || []).join(',') || 'none') + '] —' +
+            ' proceeding with release (SD-LEO-INFRA-RECLAIMSAFE-CANNOT-TELL-001 FR-3)'
           );
-          continue;
         }
       } catch (egErr) {
         // Evidence gate must fail-open: if the import or query fails, fall through to

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -2630,9 +2630,14 @@ async function main() {
           //
           // Sibling attribution is liveness-filtered upstream (buildSiblingSessionMap selects
           // only sessions with a recent heartbeat), so a named peer is a live peer.
+          // Decision lives in lib/claim/evidence-attribution-decisions.mjs so the tests
+          // exercise THIS function rather than a copy of it. An earlier cut inlined it and
+          // tested a re-implementation; a negative control showed that reverting this whole
+          // block produced ZERO test failures — green tests protecting nothing.
+          const { sweepShouldHoldRelease } = await import('../lib/claim/evidence-attribution-decisions.mjs');
           const att = evidence.evidenceAttribution;
           const otherLiveSessions = (att?.sessionIds || []).filter(id => id !== s.session_id);
-          if (otherLiveSessions.length > 0) {
+          if (sweepShouldHoldRelease({ evaluatedSessionId: s.session_id, evidenceAttribution: att })) {
             warnings.push(
               'WIP_GUARD_CROSS_SIGNAL: ' + s.session_id + ' SD=' + s.sd_key +
               ' has evidence-of-life (' + (evidence.evidence || []).join(',') +

--- a/tests/unit/reclaimsafe-consumer-attribution.test.js
+++ b/tests/unit/reclaimsafe-consumer-attribution.test.js
@@ -17,23 +17,23 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
+// IMPORT THE SHIPPED PREDICATES — do not re-implement them here.
+// The first cut of this file defined local copies. They were logically identical to the real
+// code and all green, and a negative control showed that reverting stale-session-sweep.cjs
+// produced ZERO failures while reverting sd-start.js failed only a string-grep. Testing a copy
+// of the logic proves the copy works; it says nothing about what ships.
+import {
+  selfOwnedOverridesEvidenceGate,
+  sweepShouldHoldRelease,
+} from '../../lib/claim/evidence-attribution-decisions.mjs';
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
 
-// ── FR-2: sd-start override predicate ────────────────────────────────────────
-// Mirrors scripts/sd-start.js: override iff self-ownership is PROVEN and the blocking
-// evidence is entirely unattributed.
-function sdStartOverrides({ selfOwned, attribution }) {
-  return Boolean(selfOwned) && attribution?.allUnattributed === true;
-}
+const sdStartOverrides = ({ selfOwned, attribution }) =>
+  selfOwnedOverridesEvidenceGate({ selfOwned, evidenceAttribution: attribution });
 
-// ── FR-3: sweep hold predicate ───────────────────────────────────────────────
-// Mirrors scripts/stale-session-sweep.cjs: hold iff evidence names a live session OTHER
-// than the (already-established-dead) session under evaluation.
-function sweepHolds({ evaluatedSessionId, attribution }) {
-  const others = (attribution?.sessionIds || []).filter(id => id !== evaluatedSessionId);
-  return others.length > 0;
-}
+const sweepHolds = ({ evaluatedSessionId, attribution }) =>
+  sweepShouldHoldRelease({ evaluatedSessionId, evidenceAttribution: attribution });
 
 const UNATTRIBUTED_ONLY = {
   attributed: [], unattributed: ['branch_present', 'recent_sub_agent_activity'],
@@ -114,5 +114,30 @@ describe('TS-16: the sweep must not reach for the self-ownership primitive', () 
     // trivially passing because the symbol appears nowhere in the repo.
     const src = readFileSync(path.join(repoRoot, 'scripts/sd-start.js'), 'utf8');
     expect(src).toContain('resolveSelfOwnership');
+  });
+});
+
+describe('the shipped consumers are actually WIRED to these decisions', () => {
+  // Testing the predicates proves the predicates work. These assertions prove the two
+  // consumers still CALL them — the gap a negative control exposed, where reverting
+  // stale-session-sweep.cjs wholesale broke no test at all. Deleting either call site now
+  // fails here instead of passing silently.
+  it('sd-start.js calls selfOwnedOverridesEvidenceGate', () => {
+    const src = readFileSync(path.join(repoRoot, 'scripts/sd-start.js'), 'utf8');
+    expect(src).toContain('selfOwnedOverridesEvidenceGate');
+    expect(src).toContain('lib/claim/evidence-attribution-decisions.mjs');
+  });
+
+  it('stale-session-sweep.cjs calls sweepShouldHoldRelease', () => {
+    const src = readFileSync(path.join(repoRoot, 'scripts/stale-session-sweep.cjs'), 'utf8');
+    expect(src).toContain('sweepShouldHoldRelease');
+    expect(src).toContain('lib/claim/evidence-attribution-decisions.mjs');
+  });
+
+  it('the sweep consumes evidenceAttribution, not a bare allowReclaim boolean', () => {
+    // The defect was consuming one undifferentiated boolean. Pin that the sweep reads the
+    // attribution, so a revert to `if (!evidence.allowReclaim) { hold }` fails here.
+    const src = readFileSync(path.join(repoRoot, 'scripts/stale-session-sweep.cjs'), 'utf8');
+    expect(src).toContain('evidenceAttribution');
   });
 });

--- a/tests/unit/reclaimsafe-consumer-attribution.test.js
+++ b/tests/unit/reclaimsafe-consumer-attribution.test.js
@@ -1,0 +1,118 @@
+/**
+ * SD-LEO-INFRA-RECLAIMSAFE-CANNOT-TELL-001 / FR-2 + FR-3 — the two consumers that call the
+ * claim-health evidence gate WITHOUT a self-ownership override.
+ *
+ * Both consumers were handed one boolean built from a question neither of them asked:
+ *   - sd-start.js asks "may I take this", and was blocked from reclaiming its OWN claim
+ *     because its own branch counts as somebody's evidence of life.
+ *   - stale-session-sweep.cjs asks "may I release someone ELSE's", and was held open by
+ *     evidence that names nobody, even when the session under evaluation is verifiably dead.
+ *
+ * These tests pin the DECISION LOGIC of each consumer against the attribution FR-1 added.
+ * They deliberately test the predicate rather than spawning the CLIs: the failure mode being
+ * guarded is a wrong decision, and asserting on the decision keeps the test honest instead of
+ * asserting that some helper was called.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+
+// ── FR-2: sd-start override predicate ────────────────────────────────────────
+// Mirrors scripts/sd-start.js: override iff self-ownership is PROVEN and the blocking
+// evidence is entirely unattributed.
+function sdStartOverrides({ selfOwned, attribution }) {
+  return Boolean(selfOwned) && attribution?.allUnattributed === true;
+}
+
+// ── FR-3: sweep hold predicate ───────────────────────────────────────────────
+// Mirrors scripts/stale-session-sweep.cjs: hold iff evidence names a live session OTHER
+// than the (already-established-dead) session under evaluation.
+function sweepHolds({ evaluatedSessionId, attribution }) {
+  const others = (attribution?.sessionIds || []).filter(id => id !== evaluatedSessionId);
+  return others.length > 0;
+}
+
+const UNATTRIBUTED_ONLY = {
+  attributed: [], unattributed: ['branch_present', 'recent_sub_agent_activity'],
+  sessionIds: [], allUnattributed: true,
+};
+const LIVE_PEER = {
+  attributed: ['sibling_session_on_branch'], unattributed: ['branch_present'],
+  sessionIds: ['peer-session'], allUnattributed: false,
+};
+const NO_EVIDENCE = { attributed: [], unattributed: [], sessionIds: [], allUnattributed: false };
+
+describe('FR-2: sd-start reclaims its own claim, but never a live peer\'s', () => {
+  it('TS-1/TS-3: overrides the gate when self-ownership is proven and evidence names nobody', () => {
+    expect(sdStartOverrides({ selfOwned: true, attribution: UNATTRIBUTED_ONLY })).toBe(true);
+  });
+
+  it('TS-2: does NOT override when evidence is attributed to a live foreign holder', () => {
+    // The single most important assertion in this SD: the strand fix must not become a steal.
+    expect(sdStartOverrides({ selfOwned: true, attribution: LIVE_PEER })).toBe(false);
+  });
+
+  it('TS-4: does NOT override when self-ownership cannot be proven', () => {
+    // The honest limit. sd-start usually runs from the main repo, so the worktree witness
+    // rarely fires; without a prior sd_key stamp the fallback does not resolve either, and
+    // the gate must behave exactly as it did before this SD.
+    expect(sdStartOverrides({ selfOwned: false, attribution: UNATTRIBUTED_ONLY })).toBe(false);
+  });
+
+  it('requires BOTH conditions — neither alone is sufficient', () => {
+    expect(sdStartOverrides({ selfOwned: false, attribution: LIVE_PEER })).toBe(false);
+    expect(sdStartOverrides({ selfOwned: true, attribution: NO_EVIDENCE })).toBe(false);
+  });
+});
+
+describe('FR-3: the sweep releases a dead session\'s own residue, but holds for a live peer', () => {
+  it('TS-6: releases when the only evidence is unattributed', () => {
+    expect(sweepHolds({ evaluatedSessionId: 'dead-session', attribution: UNATTRIBUTED_ONLY })).toBe(false);
+  });
+
+  it('TS-5: holds when evidence is attributed to a live peer', () => {
+    expect(sweepHolds({ evaluatedSessionId: 'dead-session', attribution: LIVE_PEER })).toBe(true);
+  });
+
+  it('does NOT hold when the only attributed session IS the dead one under evaluation', () => {
+    // A zombie tick from the dead session must not keep its own claim alive. This is the
+    // per-evaluated-session question the old undifferentiated boolean could not express.
+    const selfAttributed = {
+      attributed: ['tick_recent'], unattributed: [],
+      sessionIds: ['dead-session'], allUnattributed: false,
+    };
+    expect(sweepHolds({ evaluatedSessionId: 'dead-session', attribution: selfAttributed })).toBe(false);
+  });
+
+  it('holds when a live peer is named alongside the dead session', () => {
+    const mixed = {
+      attributed: ['tick_recent', 'sibling_session_on_branch'], unattributed: [],
+      sessionIds: ['dead-session', 'peer-session'], allUnattributed: false,
+    };
+    expect(sweepHolds({ evaluatedSessionId: 'dead-session', attribution: mixed })).toBe(true);
+  });
+});
+
+describe('TS-16: the sweep must not reach for the self-ownership primitive', () => {
+  it('stale-session-sweep.cjs never calls resolveSelfOwnership', () => {
+    // resolveSelfOwnership answers "am I the owner". The sweep iterates OTHER sessions'
+    // claims, so its own cwd has no relationship to the SDs it evaluates — applying it here
+    // is a category error, and the familiar helper is exactly what an implementer would
+    // reach for. This pins that it stays out.
+    const src = readFileSync(path.join(repoRoot, 'scripts/stale-session-sweep.cjs'), 'utf8');
+    const callSites = src
+      .split('\n')
+      .filter(l => l.includes('resolveSelfOwnership') && !l.trimStart().startsWith('//'));
+    expect(callSites).toEqual([]);
+  });
+
+  it('sd-start.js DOES use it — the same helper, where the question fits', () => {
+    // Negative control for the assertion above: proves the check discriminates rather than
+    // trivially passing because the symbol appears nowhere in the repo.
+    const src = readFileSync(path.join(repoRoot, 'scripts/sd-start.js'), 'utf8');
+    expect(src).toContain('resolveSelfOwnership');
+  });
+});

--- a/tests/unit/triangulate-evidence-attribution.test.js
+++ b/tests/unit/triangulate-evidence-attribution.test.js
@@ -1,0 +1,130 @@
+/**
+ * SD-LEO-INFRA-RECLAIMSAFE-CANNOT-TELL-001 / FR-1 — evidence attribution.
+ *
+ * triangulate.js aggregated six witnesses into one boolean, hasEvidenceOfLife, and derived
+ * `reclaimSafe = !hasEvidenceOfLife`. That boolean answers "was SOMEONE alive on this SD", but
+ * three of its witnesses carry no session identity whatsoever — branch_present and
+ * plan_file_present are SD-keyed name matches, and recent_sub_agent_activity comes from a query
+ * selecting only sd_id (sub_agent_execution_results has no session column). Consumers were
+ * reading the result as "is it safe for THIS session to reclaim", which is a different question.
+ *
+ * These tests pin the ATTRIBUTION the gate now reports, and — just as importantly — pin that the
+ * change is ADDITIVE: reclaimSafe and evidenceOfLifeSignals keep their old values and meaning.
+ * TS-15 is the regression that fails if someone "simplifies" this by redefining reclaimSafe in
+ * place, which is the one thing the SD forbids.
+ */
+import { describe, it, expect } from 'vitest';
+import { triangulate } from '../../scripts/modules/claim-health/triangulate.js';
+
+const SD_UUID = '11111111-2222-3333-4444-555555555555';
+const SD_KEY = 'SD-ATTRIB-TEST-001';
+
+/**
+ * Minimal supabase stub shaped to triangulate()'s reads.
+ * @param {object} o
+ * @param {object[]} o.sessions   - claude_sessions rows
+ * @param {object[]} o.workingSds - strategic_directives_v2 rows (is_working_on)
+ * @param {boolean}  o.activity   - whether a sub_agent_execution_results row exists for the SD
+ */
+function stubSupabase({ sessions = [], workingSds = [], activity = false } = {}) {
+  return {
+    from(table) {
+      const api = {
+        select() { return this; }, eq() { return this; }, gte() { return this; },
+        lte() { return this; }, in() { return this; }, not() { return this; },
+        is() { return this; }, order() { return this; }, limit() { return this; },
+        maybeSingle() { return Promise.resolve({ data: null, error: null }); },
+        then(resolve) {
+          if (table === 'claude_sessions') return resolve({ data: sessions, error: null });
+          if (table === 'strategic_directives_v2') return resolve({ data: workingSds, error: null });
+          if (table === 'sub_agent_execution_results') {
+            return resolve({ data: activity ? [{ sd_id: SD_UUID }] : [], error: null });
+          }
+          return resolve({ data: [], error: null });
+        },
+      };
+      return api;
+    },
+  };
+}
+
+async function entryFor(opts, triangulateOpts = {}) {
+  const sb = stubSupabase(opts);
+  const res = await triangulate(sb, SD_KEY, { skipGit: true, skipPlanFiles: true, ...triangulateOpts });
+  for (const bucket of ['healthy', 'orphaned', 'ghost', 'discrepancies']) {
+    const e = (res[bucket] || []).find(x => x.sdKey === SD_KEY);
+    if (e) return { entry: e, bucket };
+  }
+  return { entry: null, bucket: null };
+}
+
+describe('FR-1: triangulate reports WHOSE evidence, not just that evidence exists', () => {
+  it('classifies sub-agent activity as UNATTRIBUTED — it is keyed on sd_id alone', async () => {
+    const { entry } = await entryFor({
+      workingSds: [{ id: SD_UUID, sd_key: SD_KEY, is_working_on: true }],
+      activity: true,
+    });
+    expect(entry).toBeTruthy();
+    expect(entry.evidenceOfLifeSignals).toContain('recent_sub_agent_activity');
+    expect(entry.evidenceAttribution.unattributed).toContain('recent_sub_agent_activity');
+    expect(entry.evidenceAttribution.attributed).not.toContain('recent_sub_agent_activity');
+    // The whole point: evidence fired, and NONE of it says who.
+    expect(entry.evidenceAttribution.allUnattributed).toBe(true);
+    expect(entry.evidenceAttribution.sessionIds).toEqual([]);
+  });
+
+  it('allUnattributed is false when a session-attributed witness fires, and names the session', async () => {
+    // A live peer on the same branch — buildSiblingSessionMap carries real session ids here.
+    const { entry } = await entryFor({
+      sessions: [
+        { session_id: 'peer-session', sd_key: SD_KEY, worktree_branch: `feat/${SD_KEY}`, status: 'active', heartbeat_at: new Date().toISOString(), process_alive_at: new Date().toISOString() },
+      ],
+      workingSds: [{ id: SD_UUID, sd_key: SD_KEY, is_working_on: true }],
+    }, { mySessionId: 'my-session' });
+    expect(entry).toBeTruthy();
+    // Assert the PRECONDITION rather than guarding on it. An `if` here would let the whole
+    // case skip silently if the sibling witness ever stopped firing, and the test would still
+    // report green — the vacuousness this SD's own PRD warns about.
+    expect(entry.evidenceOfLifeSignals).toContain('sibling_session_on_branch');
+    expect(entry.evidenceAttribution.attributed).toContain('sibling_session_on_branch');
+    expect(entry.evidenceAttribution.allUnattributed).toBe(false);
+    expect(entry.evidenceAttribution.sessionIds).toContain('peer-session');
+    // mySessionId is excluded upstream, so a named session means SOMEONE ELSE is alive.
+    expect(entry.evidenceAttribution.sessionIds).not.toContain('my-session');
+  });
+
+  it('reports no evidence and no attribution when nothing fired', async () => {
+    const { entry } = await entryFor({
+      workingSds: [{ id: SD_UUID, sd_key: SD_KEY, is_working_on: true }],
+      activity: false,
+    });
+    expect(entry).toBeTruthy();
+    expect(entry.evidenceOfLifeSignals).toEqual([]);
+    expect(entry.evidenceAttribution.attributed).toEqual([]);
+    expect(entry.evidenceAttribution.unattributed).toEqual([]);
+    // No evidence at all is NOT the same as unattributed evidence — this is the false-positive
+    // direction the SD names, where protection was absent because no branch existed yet.
+    expect(entry.evidenceAttribution.allUnattributed).toBe(false);
+  });
+
+  // TS-15 — the regression that matters most.
+  it('is ADDITIVE: reclaimSafe and evidenceOfLifeSignals keep their pre-change meaning', async () => {
+    const { entry } = await entryFor({
+      workingSds: [{ id: SD_UUID, sd_key: SD_KEY, is_working_on: true }],
+      activity: true,
+    });
+    // Unattributed evidence still suppresses reclaimSafe exactly as before. The fix does NOT
+    // make the gate smarter on its own — it hands consumers the information to decide, and
+    // FR-2/FR-3 are where that decision is made. A diff that flips this has redefined the
+    // field in place, which the SD forbids and which would regress BaseExecutor's own tests.
+    // Asserted unguarded, for the same anti-vacuousness reason as above.
+    expect(entry.category).toBe('orphaned');
+    expect(entry.reclaimSafe).toBe(false);
+    expect(Array.isArray(entry.evidenceOfLifeSignals)).toBe(true);
+    expect(entry.evidenceOfLifeSignals).toContain('recent_sub_agent_activity');
+    // And the new field is genuinely additive, not a rename of an old one.
+    expect(entry).toHaveProperty('evidenceAttribution');
+    expect(entry).toHaveProperty('evidenceOfLifeSignals');
+    expect(entry).toHaveProperty('siblingSessionIds');
+  });
+});

--- a/tests/unit/triangulate-multi-signal.test.js
+++ b/tests/unit/triangulate-multi-signal.test.js
@@ -89,7 +89,18 @@ describe('triangulate() — AC1 + AC4: evidence-of-life prevents hostile reclaim
     expect(result.ghost).toHaveLength(0);
     const orph = result.orphaned.find(o => o.sdKey === SD_KEY);
     expect(orph).toBeTruthy();
+    // SD-LEO-INFRA-RECLAIMSAFE-CANNOT-TELL-001 (FR-4): this assertion is STILL CORRECT after
+    // that SD, and must not be flipped. That SD is about the fact that
+    // recent_sub_agent_activity cannot say WHOSE activity it is (it comes from a query
+    // selecting only sd_id), so `reclaimSafe` here answers "was someone alive", not "may I
+    // reclaim". The fix is ADDITIVE — entry.evidenceAttribution now reports that this witness
+    // is UNATTRIBUTED, and the CONSUMERS (sd-start.js, stale-session-sweep.cjs) decide from
+    // that. reclaimSafe deliberately keeps its old value and meaning, because BaseExecutor
+    // consumes the same computation. If a change makes this line fail, the additive premise
+    // has been violated — stop rather than editing the expected value.
     expect(orph.reclaimSafe).toBe(false);
+    expect(orph.evidenceAttribution.unattributed).toContain('recent_sub_agent_activity');
+    expect(orph.evidenceAttribution.allUnattributed).toBe(true);
     expect(orph.autoReleasable).toBe(false);
     expect(orph.signals.recentSubAgentActivity).toBe(true);
     expect(orph.evidenceOfLifeSignals).toContain('recent_sub_agent_activity');
@@ -109,7 +120,13 @@ describe('triangulate() — AC1 + AC4: evidence-of-life prevents hostile reclaim
     const result = await triangulate(supabase, SD_KEY, { mySessionId: 'reclaimer-sess' });
     const orph = result.orphaned.find(o => o.sdKey === SD_KEY);
     expect(orph).toBeTruthy();
+    // SD-LEO-INFRA-RECLAIMSAFE-CANNOT-TELL-001 (FR-4): also still correct, and also must not be
+    // flipped. Note this is the FALSE-POSITIVE direction that SD names — protection is absent
+    // here (reclaimSafe=true) precisely because no branch/plan/activity exists yet, which is
+    // early in a claim, when a strand is most likely. The gate cannot fix that alone; the
+    // consumer-side fail-closed CAS is what actually prevents a steal.
     expect(orph.reclaimSafe).toBe(true);
+    expect(orph.evidenceAttribution.allUnattributed).toBe(false);
     expect(orph.autoReleasable).toBe(true);
     expect(orph.action).toMatch(/Re-claim with: npm run sd:start/);
   });


### PR DESCRIPTION
## The defect

`triangulate.js` computed `reclaimSafe = !hasEvidenceOfLife`. That boolean answers **"was SOMEONE alive on this SD"**, but three of its four orphan-branch witnesses carry no session identity at all — `branch_present` and `plan_file_present` are SD-keyed name matches, and `recent_sub_agent_activity` comes from a query selecting only `sd_id` (`sub_agent_execution_results` has no session column). Callers consumed it as **"is it safe for THIS session to reclaim"**.

It fails in both directions: a session is blocked from reclaiming its **own** claim because its own branch reads as somebody else's life, and the protection is **absent** when no branch exists yet — early in a claim, when a strand is most likely.

## What changed

Three consumers call this gate and ask three *different* questions. That, not the predicate line, is the architectural root.

- **FR-1** `triangulate.js` — additive `evidenceAttribution` reporting which witnesses are session-attributable, whose they are, and whether *nothing* that fired names anyone. `reclaimSafe` and `evidenceOfLifeSignals` are unchanged by design.
- **FR-2** `sd-start.js` (asks *may I take this*) — overrides the gate only when self-ownership is **proven** AND the blocking evidence is entirely unattributed.
- **FR-3** `stale-session-sweep.cjs` (asks *may I release someone else's*) — holds only when evidence names a live session **other** than the dead one under evaluation.
- `BaseExecutor` — untouched. It was already correct and is the reference implementation.

`resolveSelfOwnership` is deliberately **not** used in the sweep: it answers "am I the owner", but that loop's cwd bears no relation to the SDs it evaluates. A test pins that it stays out, with a negative control asserting `sd-start` *does* use it.

## Honest limits, stated rather than glossed

`sd-start` is the one operation legitimately run from the main repo, usually before a worktree exists — so the cwd-in-worktree witness rarely fires there and the deterministic fallback carries most real cases. This is **weaker** protection than `BaseExecutor`'s, and a test pins the non-resolving case so it can't be quietly claimed as parity.

## Safety

The strand fix must not become a steal. SECURITY review found no steal path, via an invariant stronger than hand-reasoning: `allUnattributed === true` can never coincide with a genuinely live claim, because `pidAlive`/`tickRecent` always attribute to the claim holder. The fail-closed CAS and the heartbeat-TTL guard both remain intact downstream and are untouched.

## Testing

57/57 green across six suites; all pre-existing assertions unchanged.

One thing worth flagging for review: the first cut of the consumer tests was **near-vacuous** — a negative control showed reverting the sweep entirely broke *nothing*. Both consumers are CLI entrypoints with logic inline in `main()`, so the tests were exercising local re-implementations. The decisions are now extracted to `lib/claim/evidence-attribution-decisions.mjs` so the shipped predicates are the ones under test, with separate assertions pinning the wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)