### PR TITLE
fix(SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001): stop the three displays that produced fabricated identifiers

### DIFF
--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -392,6 +392,24 @@ const ANSI = {
   reset: '\x1b[0m', bold: '\x1b[1m', dim: '\x1b[2m'
 };
 
+/**
+ * SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001 FR-1 — the Fleet Identity Roster session column.
+ *
+ * These rows used to print `session_id.substring(0, 12) + '...'` and NEVER printed the full id
+ * anywhere in the same output. That is the measured producer of a real incident: the coordinator
+ * read a roster row, completed the remaining hex BY GUESSING without noticing it had guessed, and
+ * wrote a fabricated identifier into a dispatch. It cost nothing only because the write-side choke
+ * happened to fail loud — a well-formed prefix would have passed silently, which is exactly what
+ * happened twice elsewhere with an 8-character correlation id.
+ *
+ * A UUID column is fixed-width, so printing it in full keeps the table scannable and removes the
+ * abbreviation entirely — there is no short form left in the output for anyone to copy. That is
+ * deliberately NOT `full (short: abcd1234)`: the SD prescribes printing both only where a short
+ * form is genuinely wanted, and re-emitting an abbreviation beside the full value would reinstate
+ * the copyable hazard this fix exists to remove.
+ */
+const sessionCol = (sessionId) => String(sessionId || '(unknown)');
+
 async function main() {
   require('dotenv').config();
   const fs = require('fs');
@@ -520,7 +538,7 @@ async function main() {
         .eq('session_id', worker.session_id);
 
       if (rankErr) {
-        console.error(`  Failed to refresh tier_rank for ${worker.session_id.substring(0, 12)}: ${rankErr.message}`);
+        console.error(`  Failed to refresh tier_rank for ${sessionCol(worker.session_id)}: ${rankErr.message}`);
       } else {
         worker.metadata = metadata; // keep in-memory copy fresh for this run's banding decisions
       }
@@ -572,7 +590,7 @@ async function main() {
   for (const w of demoted) {
     const dupCallsign = w.metadata?.fleet_identity?.callsign;
     const dupCount = assignedRaw.filter(a => a.metadata?.fleet_identity?.callsign === dupCallsign).length;
-    console.log(`${ANSI.dim}↻ collision: ${dupCallsign} was on ${dupCount} sessions, reassigning ${w.session_id.substring(0, 12)}...${ANSI.reset}`);
+    console.log(`${ANSI.dim}↻ collision: ${dupCallsign} was on ${dupCount} sessions, reassigning ${sessionCol(w.session_id)}${ANSI.reset}`);
     needsAssignment.push(w);
   }
 
@@ -645,7 +663,7 @@ async function main() {
       const id = w.metadata.fleet_identity;
       const ansi = ANSI[id.color] || '';
       const sdLabel = w.sd_key || 'idle';
-      console.log(`  ${ansi}\u25cf${ANSI.reset} ${id.callsign.padEnd(10)} ${ansi}${id.color.padEnd(8)}${ANSI.reset} ${w.session_id.substring(0, 12)}...  ${sdLabel}`);
+      console.log(`  ${ansi}\u25cf${ANSI.reset} ${id.callsign.padEnd(10)} ${ansi}${id.color.padEnd(8)}${ANSI.reset} ${sessionCol(w.session_id)}  ${sdLabel}`);
     }
     console.log('');
     return;
@@ -671,7 +689,7 @@ async function main() {
     const id = w.metadata.fleet_identity;
     const ansi = ANSI[id.color] || '';
     const sdLabel = w.sd_key || 'idle';
-    console.log(`  ${ansi}\u25cf${ANSI.reset} ${id.callsign.padEnd(10)} ${ansi}${id.color.padEnd(8)}${ANSI.reset} ${w.session_id.substring(0, 12)}...  ${sdLabel} ${ANSI.dim}(existing)${ANSI.reset}`);
+    console.log(`  ${ansi}\u25cf${ANSI.reset} ${id.callsign.padEnd(10)} ${ansi}${id.color.padEnd(8)}${ANSI.reset} ${sessionCol(w.session_id)}  ${sdLabel} ${ANSI.dim}(existing)${ANSI.reset}`);
   }
 
   // Assign new workers
@@ -709,7 +727,7 @@ async function main() {
       .eq('session_id', worker.session_id);
 
     if (updateErr) {
-      console.error(`  Failed to update metadata for ${worker.session_id.substring(0, 12)}: ${updateErr.message}`);
+      console.error(`  Failed to update metadata for ${sessionCol(worker.session_id)}: ${updateErr.message}`);
       continue;
     }
 
@@ -729,12 +747,12 @@ async function main() {
       });
 
     if (msgErr) {
-      console.error(`  Failed to send identity to ${worker.session_id.substring(0, 12)}: ${msgErr.message}`);
+      console.error(`  Failed to send identity to ${sessionCol(worker.session_id)}: ${msgErr.message}`);
       continue;
     }
 
     const ansi = ANSI[color] || '';
-    console.log(`  ${ansi}\u25cf${ANSI.reset} ${callsign.padEnd(10)} ${ansi}${color.padEnd(8)}${ANSI.reset} ${worker.session_id.substring(0, 12)}...  ${sdLabel} ${ANSI.bold}(NEW)${ANSI.reset}`);
+    console.log(`  ${ansi}\u25cf${ANSI.reset} ${callsign.padEnd(10)} ${ansi}${color.padEnd(8)}${ANSI.reset} ${sessionCol(worker.session_id)}  ${sdLabel} ${ANSI.bold}(NEW)${ANSI.reset}`);
     newCount++;
   }
 

--- a/scripts/coordinator-hourly-review.cjs
+++ b/scripts/coordinator-hourly-review.cjs
@@ -323,7 +323,14 @@ async function main() {
     if (gauge.flagged > 0) {
       console.log('\n[HOURLY-REVIEW] RELAY/DECISION/REVIEW DROPS — ' + gauge.flagged + ' row(s) with no matching outbound within the window:');
       gauge.decisions.filter(function (d) { return d.action === 'flag'; }).slice(0, 10).forEach(function (d) {
-        console.log('  • [' + String(d.id).slice(0, 8) + '] correlation=' + String(d.correlationId).slice(0, 8) + ' | unactioned ' + Math.floor(d.ageMs / 60000) + 'm | ' + d.reason);
+        // SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001 FR-1: id and correlation were printed as 8-char
+        // prefixes here. This is the most likely literal source of the twice-repeated incident in
+        // which an agent copied its own diagnostic output into a --reply-to: an 8-character
+        // correlation stores verbatim, prints a success checkmark, and threads to NOTHING. Full
+        // values only — a short form beside them would leave the copyable hazard in place.
+        // (The .slice(0, 10) on the line above caps the ARRAY to 10 rows and is untouched: it
+        // shortens no identifier.)
+        console.log('  • [' + String(d.id) + '] correlation=' + String(d.correlationId) + ' | unactioned ' + Math.floor(d.ageMs / 60000) + 'm | ' + d.reason);
       });
     }
   } catch (e) {

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -2233,7 +2233,10 @@ async function printRelayDropGauge() {
   for (const d of flagged) {
     const ageMin = Math.floor(d.ageMs / 60_000);
     const ageStr = ageMin < 60 ? ageMin + 'm' : Math.floor(ageMin / 60) + 'h';
-    console.log('  • [' + String(d.id).slice(0, 8) + '] correlation=' + String(d.correlationId).slice(0, 8) + ' | unactioned ' + ageStr + ' | ' + d.reason);
+    // SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001 FR-1: byte-identical duplicate of the relay-drop line
+    // in scripts/coordinator-hourly-review.cjs. Fixed in the same change deliberately — leaving the
+    // copy truncated would keep the defect alive in the surface most people actually read.
+    console.log('  • [' + String(d.id) + '] correlation=' + String(d.correlationId) + ' | unactioned ' + ageStr + ' | ' + d.reason);
   }
   console.log('');
 }

--- a/scripts/hooks/__tests__/session-role-orient.test.js
+++ b/scripts/hooks/__tests__/session-role-orient.test.js
@@ -40,8 +40,16 @@ describe('decide()', () => {
   });
 
   it('returns workerLines when coord file points to a different session', () => {
+    // SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001 FR-1: this assertion previously pinned
+    // `session=coord-uu.` — the 8-character truncation — and so ENCODED the defect. A worker
+    // addressing the coordinator builds target_session from this line, and an 8-char prefix stores,
+    // prints success, and threads to nothing. The assertion is updated because the behaviour was
+    // deliberately changed, not to chase a test green.
     const out = decide('worker-uuid', { callsign: 'Bravo' }, { session_id: 'coord-uuid-12345678' });
-    expect(out[0]).toMatch(/WORKER \(callsign: Bravo\) under coordinator session=coord-uu\./);
+    expect(out[0]).toMatch(/WORKER \(callsign: Bravo\) under coordinator session=coord-uuid-12345678\./);
+    // The negative half is the one that matters: the full id must not be accompanied by a
+    // copyable abbreviation of itself.
+    expect(out[0]).not.toMatch(/coord-uu[^i]/);
     expect(out[1]).toMatch(/\/signal <type>/);
     expect(out[2]).toMatch(/Types: stuck \| need-sweep/);
   });

--- a/scripts/hooks/session-role-orient.cjs
+++ b/scripts/hooks/session-role-orient.cjs
@@ -18,8 +18,8 @@ const COORDINATOR = [
   '[ROLE] Drain worker signals via /coordinator inbox (filtered by payload->signal_type IS NOT NULL).',
   '[ROLE] 3+ matching signals within 60min auto-promote to feedback (category=harness_backlog) → SD pipeline.'
 ];
-const workerLines = (callsign, coordShort) => [
-  `[ROLE] WORKER (${callsign ? `callsign: ${callsign}` : 'no callsign'}) under coordinator session=${coordShort}.`,
+const workerLines = (callsign, coordSessionId) => [
+  `[ROLE] WORKER (${callsign ? `callsign: ${callsign}` : 'no callsign'}) under coordinator session=${coordSessionId}.`,
   '[ROLE] /signal <type> "<body>" when ANY: recurrence (gate 2×, RCA 2×, tool 3×) | about to bypass | spec/PRD friction | harness-bug recognized | memory-trend match.',
   '[ROLE] Types: stuck | need-sweep | prd-ambiguous | gate-bug | spec-conflict | harness-bug | feedback | other. Severity --low|medium|high|critical (critical bypasses 3× threshold).',
   '[ROLE] Coordinator check-in EVERY /loop iteration: FIRST run /checkin — check in AS A LOOP STEP, NEVER a hand-rolled bounded Bash poll (those overshoot the 120000ms Bash timeout and exit-143). /checkin is the ONLY command that DRAINS a directed row (sole path to ackMessage); `node scripts/fleet-dashboard.cjs inbox` is a READ-ONLY view that stamps NOTHING and is NOT a substitute — polling only the dashboard leaves your rows unread indefinitely (SD-LEO-INFRA-WORKER-INBOX-DRAIN-SUBSET-001). Work any WORK_ASSIGNMENT/routing before the open queue, ACK any comms-check in one line (/signal feedback "comms-check ack"). An unread coordinator→worker message is a silent break. Announce /signal feedback "online" on loop start, FLEET-RETRO on loop stop.',
@@ -79,7 +79,18 @@ async function findActiveCoord() {
 function decide(sessionId, meta, coordFile) {
   if (meta?.is_coordinator) return COORDINATOR;
   if (coordFile?.session_id === sessionId) return COORDINATOR;
-  if (coordFile?.session_id) return workerLines(meta?.callsign, coordFile.session_id.slice(0, 8));
+  // SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001 FR-1: this used to pass coordFile.session_id.slice(0, 8).
+  // The [ROLE] line below is the ONLY place a worker is told who its coordinator is, and a worker
+  // that addresses the coordinator builds target_session from it — so an 8-character prefix here is
+  // an identifier shortened for display and then re-consumed as input, which is this SD's whole
+  // defect class. A truncated correlation is indistinguishable from a valid smaller one: it stores,
+  // it prints a success checkmark, and it threads to nothing.
+  //
+  // Full id only, deliberately NOT `full (short: abcd1234)`. The SD prescribes printing both only
+  // "where a short form is genuinely wanted for scanning" — that applies to a roster of many rows,
+  // not to a single value in a prompt line. Emitting a short form here would leave an abbreviation
+  // sitting in the worker's context to be copied, which is precisely the hazard being closed.
+  if (coordFile?.session_id) return workerLines(meta?.callsign, coordFile.session_id);
   return SOLO;
 }
 function main() {

--- a/scripts/one-off/_exec-testing-evidence-silent-truncation-one-001.mjs
+++ b/scripts/one-off/_exec-testing-evidence-silent-truncation-one-001.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * One-off: record TESTING sub-agent evidence at the EXEC phase for
+ * SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001 (EXEC-TO-PLAN handoff).
+ *
+ * Adversarial verification of Child 1's shipped fix (commit 1516709e3b2, 5 files, +60/-13,
+ * PR https://github.com/rickfelix/EHG_Engineer/pull/6622) against the plan captured in
+ * scripts/one-off/_plan-testing-evidence-silent-truncation-one-001.mjs. Written through the
+ * canonical writer (CLAUDE.md prologue rule 11).
+ */
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../../lib/sub-agent-executor/results-storage.js';
+import { getSupabaseClient } from '../../lib/sub-agent-executor/supabase-client.js';
+
+const SD_ID = '4d825dee-12c2-43da-ab32-5b2bb4ae6f36';
+const SD_KEY = 'SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001';
+
+async function main() {
+  const supabase = await getSupabaseClient();
+  const resolution = await resolveSubAgentRepo({ sdId: SD_KEY, targetApplication: 'EHG_Engineer', subAgentCode: 'TESTING', supabase });
+
+  let results = {
+    verdict: 'PASS',
+    confidence: 85,
+    findings: [
+      {
+        id: 'F1-diff-matches-claim-exactly',
+        severity: 'INFO',
+        summary: "git diff origin/main...HEAD confirms the claimed shape exactly: 5 files changed, 60 insertions(+), 13 deletions(-) at commit 1516709e3b2 -- scripts/assign-fleet-identities.cjs (+32/-5, new sessionCol() helper used at 7 sites: 3 roster rows + 4 sibling diagnostics), scripts/hooks/session-role-orient.cjs (+17/-2, decide() now passes the full coordinator session_id into workerLines() instead of .slice(0,8)), scripts/coordinator-hourly-review.cjs (+9/-1) and scripts/fleet-dashboard.cjs (+5/-1, byte-similar relay-drop line, both drop .slice(0,8) on d.id and d.correlationId), and scripts/hooks/__tests__/session-role-orient.test.js (+10/-1, the fixture assertion updated). No undisclosed files touched.",
+      },
+      {
+        id: 'F2-tests-run-live-counts',
+        severity: 'INFO',
+        summary: "Ran the affected suite directly: scripts/hooks/__tests__/session-role-orient.test.js -- 23/23 passed. Widened to every test file that references any of the 4 changed source files (grep across tests/ and scripts/__tests__): tests/unit/assign-fleet-identities-{coordinator-filter,rebroadcast,sdkey-and-panel-fields,tier-callsign}.test.js, tests/unit/coordinator-hourly-review-solomon-leg.test.js, tests/unit/coordinator/relay-drop-gauge.test.js -- 81/81 passed. Widened further to the full tests/unit/coordinator/, tests/unit/fleet/, tests/unit/fleet-dashboard-*.test.js, tests/unit/fleet-panel-identity-kind-order.test.js neighborhood as a regression sweep -- 167 test files / 2038 tests passed, 1 pre-existing unrelated skip. Zero failures anywhere in the run.",
+      },
+      {
+        id: 'F3-test-edit-judged-legitimate-not-greened',
+        severity: 'INFO',
+        summary: "The PLAN-phase evidence (finding F3 in the PLAN TESTING row) predicted this exact break BEFORE the fix landed: 'scripts/hooks/__tests__/session-role-orient.test.js:44 ... WILL BREAK on Child 1 fix ... must be updated in the same PR.' EXEC's diff does exactly that, and does it correctly: (a) the positive assertion changed from a truncated-form regex (`session=coord-uu\\.`) to the full fixture value (`session=coord-uuid-12345678\\.`) -- a like-for-like widening driven by a real behavior change in session-role-orient.cjs:82 (decide() no longer calls .slice(0,8)), not an unrelated loosening; (b) a NEW negative assertion was added -- `expect(out[0]).not.toMatch(/coord-uu[^i]/)` -- which is strictly MORE restrictive than the old test: it positively forbids the abbreviated-copy-hazard pattern (a truncated echo sitting beside or instead of the full value) that this SD exists to eliminate. A test edit that adds a negative assertion pinning against the very defect being fixed, on top of updating the positive assertion to match new intended behavior, is the correct outcome for a defect-encoding test -- not test-greening. Verdict: legitimate.",
+      },
+      {
+        id: 'F4-exemption-regression-clean',
+        severity: 'INFO',
+        summary: "Verified with git, not by reading: `git diff origin/main...HEAD --name-only` returns exactly the 5 files above -- none of the 7 exempt paths (lib/genesis/branch-lifecycle.js, lib/sub-agents/rca.js, lib/session-manager.mjs, lib/eva/eva-master-scheduler.js, lib/eva/concurrent-venture-orchestrator.js, lib/terminal-identity.js, lib/coordinator/detectors.cjs) appear in the changed-file list, and `git diff origin/main...HEAD --stat -- <path>` against each of the 7 individually returns empty output (zero diff). No exemption regression.",
+      },
+      {
+        id: 'F5-fix-exercised-live-not-just-read',
+        severity: 'INFO',
+        summary: "session-role-orient.cjs's decide() is directly requirable and was called live with a full-length UUID coordinator session_id ('coord-uuid-12345678-abcd-ef01-2345-6789abcdef01'): output line was `[ROLE] WORKER (callsign: Bravo) under coordinator session=coord-uuid-12345678-abcd-ef01-2345-6789abcdef01.` -- full id present, zero truncation, zero '...' suffix. For assign-fleet-identities.cjs, main() requires live Supabase state and a coordinator-guard check with real mutation side effects (message sends, metadata writes) with no dry-run/quiet flag in the file -- ran it live against real data, not attempted, to avoid an uncontrolled write. Instead extracted the ACTUAL sessionCol() source line verbatim via regex from the shipped file (not a manual reproduction) and eval'd it standalone: sessionCol('a1b2c3d4-e5f6-7890-abcd-ef0123456789') -> the full 36-char value unchanged; sessionCol(null) -> '(unknown)'; sessionCol(undefined) -> '(unknown)'. No .substring/.slice anywhere in the extracted line. Both changed functions confirmed to do what the diff claims when actually run, not just inspected.",
+      },
+      {
+        id: 'F6-collateral-consumer-search-clean-plus-one-new-out-of-scope-site',
+        severity: 'MEDIUM',
+        summary: "Searched for any OTHER code that regex-parses these specific console.log lines (roster rows, [ROLE] line, relay-drop line) rather than just referencing the script file paths in comments/docs. No execSync/spawn call anywhere in the repo captures and parses the stdout of assign-fleet-identities.cjs, coordinator-hourly-review.cjs, fleet-dashboard.cjs, or session-role-orient.cjs by pattern-matching a fixed-width id substring. The two other hits on 'correlation=' were this SD's own prior LEAD-phase evidence files documenting the original defect (not consumers). Existing test suites for these files (grepped for console.log/consoleSpy/logSpy assertions) do not assert on printed format anywhere except the one file already updated. HOWEVER: found a genuinely separate, uncovered instance of the SAME truncation pattern that Child 1 did NOT touch and that is out of this diff's stated scope -- scripts/coordinator-relay-drop-gauge.cjs:61 builds a DB `feedback.title` field as `Relay/decision/review drop: correlation ${String(d.correlationId).slice(0, 8)}` (writes to DB, not console). This is not a regression introduced by Child 1 -- it pre-exists and sits in a different file from the three the commit message names ('the three displays') -- but it is the same hazard class (SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001's own taxonomy) left unaddressed. Flagging for PLAN/LEAD scope-tracking, not blocking this handoff.",
+      },
+      {
+        id: 'F7-eva-master-scheduler-quarantine-confirmed',
+        severity: 'MEDIUM',
+        summary: "Confirmed via `npx vitest run tests/unit/eva-master-scheduler.test.js` with vitest's own project-filter dump: the file is NOT in the `unit` project's include set and IS explicitly named in the `unit` project's exclude array (sourced from tests/quarantine-manifest.json's QUARANTINE_EXCLUDE, entry at manifest line 502: reason_class='assertion-drift', quarantined_at=2026-06-11, linked_ref=feedback:65fce396). It is also absent from the `db` and `smoke` project include sets. Net effect: 'No test files found, exiting with code 1' when targeted directly under the normal config. This means the PLAN-phase finding F2's cited precedent (tests/unit/eva-master-scheduler.test.js:242's `expect(scheduler.instanceId).toMatch(/^scheduler-[a-f0-9]{8}$/)` exemption pin for lib/eva/eva-master-scheduler.js:146) is real CODE but a DORMANT precedent, not a running one -- it cannot currently catch a regression to that minting site because it never executes in CI or local `npm test`. Confirmed, not refuted.",
+      },
+    ],
+    metadata: {
+      diff_verification: {
+        commit: '1516709e3b2',
+        files_changed: 5,
+        insertions: 60,
+        deletions: 13,
+        stat_matches_claim: true,
+        pr: 'https://github.com/rickfelix/EHG_Engineer/pull/6622',
+      },
+      test_counts: {
+        'scripts/hooks/__tests__/session-role-orient.test.js': '23/23 passed',
+        'assign-fleet-identities + coordinator-hourly-review + relay-drop-gauge suites (6 files)': '81/81 passed',
+        'broader regression sweep (tests/unit/coordinator/, tests/unit/fleet/, fleet-dashboard-*, fleet-panel-identity-kind-order)': '167 files / 2038 tests passed, 1 pre-existing unrelated skip',
+      },
+      test_edit_judgement: 'LEGITIMATE — positive assertion widened in lockstep with a real, intentional behavior change; a new negative assertion was added that is strictly stricter than before (forbids the truncated-abbreviation-beside-full-value pattern). This is exactly what the PLAN-phase evidence predicted would need to happen, done correctly.',
+      exemption_regression_result: 'CLEAN — verified via git diff --name-only and per-file git diff --stat against origin/main for all 7 exempt paths; zero touched.',
+      live_exercise: {
+        'session-role-orient.cjs decide()': "called directly with full UUID; output = '[ROLE] WORKER (callsign: Bravo) under coordinator session=coord-uuid-12345678-abcd-ef01-2345-6789abcdef01.'",
+        'assign-fleet-identities.cjs sessionCol()': "main() requires live DB + has real mutation side effects with no dry-run flag, so not run wholesale; extracted the literal source line via regex and eval'd it standalone instead — confirmed no truncation on real and null/undefined inputs.",
+      },
+      collateral_consumers_found: 'None that parse these specific console.log lines programmatically. One genuinely separate, pre-existing, out-of-scope truncation site newly discovered: scripts/coordinator-relay-drop-gauge.cjs:61 (feedback.title field, correlationId.slice(0,8)) — not touched by Child 1, not named in the commit message, flagged for tracking only.',
+      eva_master_scheduler_quarantine: 'CONFIRMED excluded from unit/db/smoke vitest projects via tests/quarantine-manifest.json (reason_class=assertion-drift, quarantined 2026-06-11). The exemption-pin precedent PLAN cited (instanceId regex assertion) is real but dormant — never executes.',
+      known_gaps_carried_forward: [
+        'FR-5 (Class B typed envelope constructor) still has no test_scenario as of this EXEC verification pass — this handoff only covers Child 1 / FR-1/FR-2 scope.',
+        'scripts/coordinator-relay-drop-gauge.cjs:61 correlationId truncation (new finding, F6) — same hazard class, not remediated by this child.',
+      ],
+    },
+    phase: 'EXEC',
+    summary: "PASS for EXEC-TO-PLAN on Child 1's shipped fix (commit 1516709e3b2, PR #6622). Diff matches the stated claim exactly (5 files, +60/-13, no undisclosed files). All directly affected and neighborhood tests pass live: 23/23 in the updated test file, 81/81 across the six related suites, 2038/2038 (1 unrelated pre-existing skip) across a 167-file regression sweep of the coordinator/fleet-dashboard/fleet neighborhood. The test-edit question resolves cleanly: the previously-defect-encoding assertion was widened to match a real, intentional behavior change AND a new negative assertion was added that is strictly stricter than before — this is legitimate defect-test correction, not greening. Exemption regression check is clean: git diff confirms none of the 7 exempt files were touched, verified structurally not by reading. Both changed code paths were exercised live where feasible: session-role-orient.cjs's decide() was called directly and produced a full unabbreviated id; assign-fleet-identities.cjs's sessionCol() helper was extracted verbatim from the shipped source and eval'd standalone (full wholesale execution was deliberately avoided — main() has real DB-mutation side effects and no dry-run flag). Collateral search found no programmatic consumer of these console.log formats, but surfaced one new, genuinely out-of-scope finding worth tracking: scripts/coordinator-relay-drop-gauge.cjs:61 truncates a correlationId into a DB feedback.title field via the same hazard pattern and was not touched by this child. Finally, the known gap is CONFIRMED, not refuted: tests/unit/eva-master-scheduler.test.js is explicitly excluded from the unit/db/smoke vitest projects via the quarantine manifest, so the exemption-pin precedent PLAN cited for KIND2 minting sites exists in the codebase but never runs.",
+  };
+
+  results = applySubAgentRepoVerdict(results, resolution);
+  const stored = await storeSubAgentResults('TESTING', SD_ID, { name: 'TESTING (QA Engineering Director)' }, results, { sdKey: SD_KEY, phase: 'EXEC' });
+  console.log('TESTING result stored:', stored.id, stored.verdict, stored.confidence);
+}
+
+main().catch((e) => { console.error('FAILED:', e.message); process.exit(1); });

--- a/scripts/one-off/_lead-explore-evidence-silent-truncation-one-001.mjs
+++ b/scripts/one-off/_lead-explore-evidence-silent-truncation-one-001.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * One-off: record Explore LEAD-phase evidence for SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001.
+ * The Explore sub-agent runs read-only and cannot write to the DB, so its returned triage is
+ * recorded here through the canonical writer (CLAUDE.md prologue rule 11).
+ */
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../../lib/sub-agent-executor/results-storage.js';
+import { getSupabaseClient } from '../../lib/sub-agent-executor/supabase-client.js';
+
+const SD_ID = '4d825dee-12c2-43da-ab32-5b2bb4ae6f36';
+const SD_KEY = 'SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001';
+
+async function main() {
+  const supabase = await getSupabaseClient();
+  const resolution = await resolveSubAgentRepo({ sdId: SD_KEY, targetApplication: 'EHG_Engineer', subAgentCode: 'Explore', supabase });
+
+  let results = {
+    verdict: 'PASS',
+    confidence: 85,
+    findings: [
+      {
+        id: 'F1-population-is-heterogeneous-blanket-sweep-would-break-code',
+        severity: 'HIGH',
+        summary: "The raw identifier-truncation population does NOT sort into one fix set. Triaged: KIND 1 HAZARD ~50 found / ~43 live after excluding archived duplicates (an existing id shortened for display and re-consumable as input); KIND 2 MINTING 17 sites where randomUUID().slice(0,8) CONSTRUCTS a new short id -- no full value is hidden and 'fixing' these breaks id generation; KIND 3 DERIVED LABEL 9 sites (sim/<8> git branch names, PAT-<cat>-<8> pattern ids) which are keys in their own right. Only KIND 1 is the defect.",
+      },
+      {
+        id: 'F2-NEW-kind-4-git-sha-prefixes-exempt-by-design',
+        severity: 'MEDIUM',
+        summary: "A FOURTH category the worker's triage did not have: ~19 sites truncate a git commit SHA for display. Structurally these match the hazard definition (a full value exists, shortened for display) BUT git itself resolves an unambiguous short SHA to the correct object, or refuses on ambiguity -- so no guessing occurs and no fabrication is possible. Session/correlation ids have no prefix-resolve support, which is exactly why they fabricate. Recommend the SD name git-SHA prefixes as an explicit exempt-by-design 4th category rather than leaving 19 call sites to be individually re-litigated.",
+      },
+      {
+        id: 'F3-array-cap-false-positives-must-be-excluded-before-counting',
+        severity: 'MEDIUM',
+        summary: "lib/coordinator/detectors.cjs:71 and :95 do `.map(c => c.session_id).filter(Boolean).slice(0, 10)` -- the slice caps the ARRAY to 10 elements; every session_id inside is full-length and untouched. This is list truncation, not string truncation, and a naive regex over identifier-named variables catches it. Any raw count (the worker's 114, VALIDATION's 153-438 range) includes an unknown number of these and must be filtered before the fix set is sized.",
+      },
+      {
+        id: 'F4-first-fix-target-located-precisely',
+        severity: 'HIGH',
+        summary: "The literal 'Fleet Identity Roster' is scripts/assign-fleet-identities.cjs (title printed at :643). The truncating call sites are :648, :674, :737 (three roster-row shapes, all `w.session_id.substring(0, 12)` followed by '...') plus sibling diagnostics at :523, :575, :712, :732. NONE of these print the full session_id anywhere in the same output -- this is the exact producer the SD blames for the coordinator's fabricated-id DISPATCH_TARGET_UNKNOWN.",
+      },
+      {
+        id: 'F5-two-sites-match-the-incident-narrative-beyond-the-named-target',
+        severity: 'HIGH',
+        summary: "scripts/hooks/session-role-orient.cjs:82 prints `coordinator session=${coordFile.session_id.slice(0,8)}` into the [ROLE] orientation line delivered to EVERY worker at session start, with no full id anywhere in the hook -- a worker addressing the coordinator from that string alone reproduces the printed-success-threaded-to-nothing failure exactly. scripts/coordinator-hourly-review.cjs:326 prints `[<id 8>] correlation=<correlationId 8>` in the Solomon leg of the hourly review and is the most likely literal source of the 'Solomon copied his own diagnostic output into --reply-to' incident; scripts/fleet-dashboard.cjs:2236 is a byte-identical duplicate.",
+      },
+      {
+        id: 'F6-five-kind-1-sites-are-already-compliant-do-not-over-count',
+        severity: 'MEDIUM',
+        summary: "At least 5 sites already carry the full value alongside the short one and are functionally safe: scripts/coordinator-reply.cjs:53 (short form in the subject line only; buildReplyPayload stamps the FULL correlationId into payload.reply_to and payload.correlation_id, which is what worker-signal.cjs:318 actually matches on), lib/npm-install-lock.cjs:75 (short in body text, full holder_session in the same insert's payload), server/routes/fleet-panel.js:108 (emits session_id FULL; the fleet-ui client renders what the API sends and truncates nothing), scripts/worker-signal.cjs:403 and :571 (print the full correlation_id).",
+      },
+      {
+        id: 'F7-the-working-pattern-is-not-the-SD-literal-prescription',
+        severity: 'HIGH',
+        summary: "The SD prescribes printing `id=<full> (short: abcd1234)`. NOTHING in the codebase does that verbatim. The pattern that actually works in the compliant sites is different and better: the FULL value goes in the machine-consumed field (payload, DB column, API response) and the short form appears ONLY in a human free-text label that nothing parses. The PRD should adopt the observed working pattern rather than mandating a literal output format, or it will churn ~43 call sites into a shape the codebase has no precedent for.",
+      },
+      {
+        id: 'F8-decomposition-required-with-a-natural-split',
+        severity: 'HIGH',
+        summary: "Kind 1 alone spans ~43 live sites across ~25 files with materially different call shapes (CLI table renderers, coordination-message bodies, log lines, a session hook) -- too large and too heterogeneous for one PR under the <=100 LOC target. Natural split: (a) the fleet-identity-roster family (assign-fleet-identities.cjs + session-role-orient.cjs -- the two closest to the cited incidents); (b) the scripts/stale-session-sweep.cjs cluster (20 sites, one file, mechanically uniform, one PR); (c) the remaining ~20 scattered single/double-site files, batchable by directory into 2-3 small PRs.",
+      },
+      {
+        id: 'F9-adjacent-real-bug-out-of-scope',
+        severity: 'LOW',
+        summary: "lib/rca/rca-orchestrator.js:405 and :451 query `.ilike('pattern_id', 'PAT-AUTO-' + fingerprint.slice(0,8) + '%')` then `.limit(1).maybeSingle()`. Two fingerprints sharing an 8-hex prefix would both match the wildcard and the wrong pattern's assigned_sd_id could be picked silently. NOT this SD's defect (nothing is displayed then retyped) but a real collision bug for whoever owns lib/rca/.",
+      },
+    ],
+    metadata: {
+      counts: { kind1_hazard_found: 50, kind1_live_after_excluding_archived: 43, kind2_minting: 17, kind3_derived_label: 9, kind4_git_sha_exempt: 19, array_cap_false_positives_confirmed: 2 },
+      not_fully_swept: 'Identifier families covered: session_id, correlation_id, sha/commit, uuid/randomUUID, PAT-, sim/, accountUuid8. NOT swept: feedback c.id, qf_id, sd_key, worktree hash, token/key families -- a plausible further ~15-20 kind-1/kind-3 sites.',
+      decomposition_verdict: 'REQUIRED — kind 1 alone is ~43 live sites over ~25 files.',
+      binding_note: 'Only KIND 1 may be changed. Kinds 2, 3 and 4 must be named as explicit exemptions in the PRD or the next worker greps the raw population and sweeps them.',
+    },
+    phase: 'LEAD',
+    summary: "PASS for LEAD-TO-PLAN, with a hard constraint attached. The Class A population is heterogeneous and a mechanical sweep would BREAK WORKING CODE: only ~43 live sites are the genuine hazard, while 17 are id MINTING (randomUUID().slice — no full value hidden), 9 are deliberate derived labels (sim/<8>, PAT-<cat>-<8>), and a NEW fourth category of ~19 git-SHA prefixes is exempt-by-design because git resolves an unambiguous short SHA correctly or refuses — session ids have no such prefix-resolve, which is precisely why they fabricate. Array-cap false positives (detectors.cjs:71,95 slice the ARRAY not the id) must also be filtered before any count is trusted. First fix target located exactly: scripts/assign-fleet-identities.cjs :648/:674/:737 (+ :523/:575/:712/:732), the literal Fleet Identity Roster. Two further sites match the incident narrative directly and belong in the first child: session-role-orient.cjs:82 (ships a truncated coordinator session id to EVERY worker at startup) and coordinator-hourly-review.cjs:326 (the likely literal source of the copied correlation prefix). Finally, the SD's literal prescription id=<full> (short: abcd1234) has NO precedent in the codebase; the pattern that demonstrably works in 5 already-compliant sites is full value in the machine-consumed field, short form only in an unparsed human label — the PRD should adopt that instead.",
+  };
+
+  results = applySubAgentRepoVerdict(results, resolution);
+  const stored = await storeSubAgentResults('Explore', SD_ID, { name: 'Explore (read-only triage sub-agent)' }, results, { sdKey: SD_KEY, phase: 'LEAD' });
+  console.log('Explore result stored:', stored.id, stored.verdict, stored.confidence);
+}
+
+main().catch((e) => { console.error('FAILED:', e.message); process.exit(1); });

--- a/scripts/one-off/_lead-scope-correction-silent-truncation-one-001.mjs
+++ b/scripts/one-off/_lead-scope-correction-silent-truncation-one-001.mjs
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+/**
+ * One-off: LEAD scope correction for SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001.
+ *
+ * Closes the two BLOCKING conditions on the VALIDATION LEAD evidence row
+ * (817946d3-14ac-4c40-bb97-83cbbe3ce68d, CONDITIONAL_PASS):
+ *   1. two COMPLETED SDs already ship remedies for instances 1 and 6 — add to do-not-duplicate
+ *   2. the population must not be swept mechanically — name the exemption categories
+ *
+ * Original description is PRESERVED below the correction. The point of a correction is to stop the
+ * next reader inheriting a stale premise, not to erase the evidence trail that produced it.
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const SD_KEY = 'SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001';
+
+const CORRECTION = `*** LEAD SCOPE CORRECTION 2026-07-28 (Alpha-4, worker 39aa8a1e). READ BEFORE PLANNING. TWO OF THE TEN INSTANCES ARE ALREADY FIXED, AND THE POPULATION MUST NOT BE SWEPT MECHANICALLY. ***
+
+=== A. ALREADY SHIPPED — ADD TO do-not-duplicate BEFORE SCOPING ANYTHING ===
+Found by querying for overlap rather than assuming the instance list was current:
+  - SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 (status=COMPLETED) already ships exact-head-count,
+    paginated bulk read, and count-null-fail-loud. THAT IS THE REMEDY FOR INSTANCE 6 (the PostgREST
+    1000-row cap). Do not re-scope it.
+  - SD-LEO-INFRA-CORRECTION-DELIVERY-PATH-001-A (status=COMPLETED) already ships the capBody
+    propagation fix for INSTANCE 1 (mid-word promotion-pipeline truncation, QF-20260726-425).
+    lib/shared/body-cap.cjs credits this SD in its own header.
+  - QF-20260727-709 (status=COMPLETED) added an addressee to buildPreSendConsultBody — but as an
+    OPTIONAL bolt-on parameter, NOT the typed constructor this SD proposes. The Class B half of this
+    SD therefore remains genuinely non-redundant. Verified in code.
+  - SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (status=DRAFT, not started) IS this SD's own fourth
+    named Class B instance, already living as an independent sibling row. Two rows, one defect, and
+    the relationship was unstated. PLAN must decide: fold, depend on, or explicitly divide.
+
+=== B. THE POPULATION IS HETEROGENEOUS. A MECHANICAL SWEEP WOULD BREAK WORKING CODE. ===
+Measured across lib/, scripts/, server/ (non-test). Raw regex counts range 114-438 depending on
+tightness, and that spread is itself the argument: this cannot be sorted by pattern-match alone.
+
+  KIND 1 — GENUINE HAZARD (~43 live, ~50 before excluding archived duplicates). An EXISTING
+    identifier shortened for display and re-consumable as input. THIS IS THE ONLY FIX SET.
+  KIND 2 — MINTING, NOT TRUNCATING (17 sites). randomUUID().slice(0,8) CONSTRUCTS a new short id.
+    No full value is hidden. "Fixing" these BREAKS ID GENERATION.
+  KIND 3 — DELIBERATE DERIVED LABEL (9 sites). sim/<8> git branch names (lib/genesis/
+    branch-lifecycle.js), PAT-<category>-<8> pattern ids (lib/sub-agents/rca.js:487). These are keys
+    in their own right, not abbreviations of a value anyone reconstructs.
+  KIND 4 — GIT COMMIT SHA PREFIXES (~19 sites). EXEMPT BY DESIGN, and this one is subtle enough to
+    state explicitly: a short SHA structurally matches the hazard definition, BUT GIT ITSELF resolves
+    an unambiguous prefix to the correct object, or refuses on ambiguity. No guessing occurs, so no
+    fabrication is possible. Session and correlation ids have NO prefix-resolve — an exact string
+    match against a UUID column is the only lookup — which is precisely WHY they fabricate and SHAs
+    do not. Name this exemption or 19 call sites get re-litigated individually.
+  FALSE POSITIVE — ARRAY CAP, NOT STRING TRUNCATION. lib/coordinator/detectors.cjs:71 and :95 do
+    .map(c => c.session_id).filter(Boolean).slice(0, 10) — the slice caps the ARRAY to 10 elements
+    and every session_id inside is FULL LENGTH. Filter these before trusting any count.
+
+=== C. FIVE KIND-1 SITES ARE ALREADY COMPLIANT — DO NOT OVER-COUNT THE FIX SET ===
+scripts/coordinator-reply.cjs:53, lib/npm-install-lock.cjs:75, server/routes/fleet-panel.js:108,
+scripts/worker-signal.cjs:403 and :571. Each already keeps the full value where it matters.
+
+=== D. CORRECTION TO THIS SD'S OWN PRESCRIPTION — THE LITERAL FORMAT HAS NO PRECEDENT ===
+The SD mandates printing id=<full> (short: abcd1234). NOTHING in this codebase does that verbatim.
+The pattern that demonstrably WORKS, in all five compliant sites above, is different and better:
+THE FULL VALUE GOES IN THE MACHINE-CONSUMED FIELD (payload, DB column, API response) AND THE SHORT
+FORM APPEARS ONLY IN A HUMAN LABEL THAT NOTHING PARSES.
+coordinator-reply.cjs is the model: the subject line carries a short correlation prefix for
+legibility, while buildReplyPayload stamps the FULL correlationId into payload.reply_to and
+payload.correlation_id — and payload.reply_to is what worker-signal.cjs:318 actually matches on. The
+short form is decorative and never re-consumed. PLAN should adopt this observed pattern rather than a
+literal output format, or it churns ~43 call sites into a shape with no precedent.
+
+=== E. DECOMPOSITION IS REQUIRED, WITH A NATURAL SPLIT ===
+Kind 1 alone is ~43 live sites across ~25 files with materially different call shapes (CLI table
+renderers, coordination-message bodies, log lines, a session hook) — past the <=100 LOC target.
+  CHILD 1 (highest value, smallest): the fleet identity roster family.
+    scripts/assign-fleet-identities.cjs :648 :674 :737 (roster rows, w.session_id.substring(0,12)
+    followed by "...") plus sibling diagnostics :523 :575 :712 :732. The roster title prints at :643.
+    This is the exact producer the SD blames for the coordinator's fabricated-id
+    DISPATCH_TARGET_UNKNOWN.
+    INCLUDE TWO MORE, both matching the incident narrative directly:
+      scripts/hooks/session-role-orient.cjs:82 — prints "coordinator session=<8 chars>" into the
+        [ROLE] orientation line delivered to EVERY WORKER AT SESSION START, with no full id anywhere
+        in the hook. A worker addressing the coordinator from that string reproduces the
+        printed-success-threaded-to-nothing failure exactly.
+      scripts/coordinator-hourly-review.cjs:326 — prints correlation=<8 chars> in the Solomon leg of
+        the hourly review; the most likely literal source of the copied --reply-to prefix.
+        scripts/fleet-dashboard.cjs:2236 is a byte-identical duplicate.
+  CHILD 2: the scripts/stale-session-sweep.cjs cluster — ~20 sites, one file, mechanically uniform.
+  CHILD 3+: the remaining ~20 scattered single/double-site files, batchable by directory.
+
+=== F. NOT SWEPT, STATED SO IT IS NOT MISTAKEN FOR ZERO ===
+The triage covered session_id, correlation_id, sha/commit, uuid/randomUUID, PAT-, sim/ and
+accountUuid8. It did NOT sweep feedback c.id, qf_id, sd_key, worktree hash, or token/key families — a
+plausible further ~15-20 kind-1/kind-3 sites. Absence of a finding there is absence of a look.
+
+=== ORIGINAL DESCRIPTION AS FILED (PRESERVED; INSTANCES 1 AND 6 SUPERSEDED PER SECTION A) ===
+
+`;
+
+async function main() {
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const { data: row, error: readErr } = await supabase
+    .from('strategic_directives_v2').select('id, description, metadata').eq('sd_key', SD_KEY).maybeSingle();
+  if (readErr) throw new Error(`read failed: ${readErr.message}`);
+  if (!row) throw new Error('SD not found');
+
+  if (String(row.description || '').includes('LEAD SCOPE CORRECTION 2026-07-28')) {
+    console.log('Already corrected (idempotent no-op).');
+    return;
+  }
+
+  const metadata = {
+    ...(row.metadata || {}),
+    lead_scope_correction_20260728: {
+      at: new Date().toISOString(),
+      by: 'Alpha-4 (worker 39aa8a1e)',
+      closes: 'VALIDATION LEAD evidence 817946d3-14ac-4c40-bb97-83cbbe3ce68d (CONDITIONAL_PASS) — both blocking conditions',
+      already_shipped_do_not_duplicate: [
+        'SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 (completed) — covers instance 6, PostgREST 1000-row cap',
+        'SD-LEO-INFRA-CORRECTION-DELIVERY-PATH-001-A (completed) — covers instance 1, mid-word promotion truncation',
+        'QF-20260727-709 (completed) — addressee added as OPTIONAL bolt-on; Class B typed constructor still non-redundant',
+        'SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (draft) — sibling row IS this SD 4th Class B instance; PLAN must fold/depend/divide',
+      ],
+      triage_counts: { kind1_hazard_live: 43, kind2_minting: 17, kind3_derived_label: 9, kind4_git_sha_exempt: 19, already_compliant: 5 },
+      exempt_categories: 'KIND 2 minting, KIND 3 derived labels, KIND 4 git SHA prefixes (git resolves unambiguous prefixes; session ids have no prefix-resolve), and array-cap false positives (detectors.cjs:71,95).',
+      prescription_correction: 'The literal id=<full> (short: abcd1234) form has NO precedent. Observed working pattern: full value in the machine-consumed field, short only in an unparsed human label. Model: coordinator-reply.cjs:53 + buildReplyPayload.',
+      decomposition: 'REQUIRED. Child 1 = fleet identity roster family + session-role-orient.cjs:82 + coordinator-hourly-review.cjs:326. Child 2 = stale-session-sweep.cjs cluster. Child 3+ = scattered remainder.',
+      evidence_rows: ['817946d3-14ac-4c40-bb97-83cbbe3ce68d (VALIDATION)', '3254fd2c-257d-4139-9cbc-05f72d910053 (Explore)'],
+    },
+  };
+
+  const { error: updErr } = await supabase.from('strategic_directives_v2')
+    .update({ description: CORRECTION + String(row.description || ''), metadata })
+    .eq('sd_key', SD_KEY);
+  if (updErr) throw new Error(`update failed: ${updErr.message}`);
+  console.log('LEAD scope correction applied to', SD_KEY);
+}
+
+main().catch((e) => { console.error('FAILED:', e.message); process.exit(1); });

--- a/scripts/one-off/_plan-testing-evidence-silent-truncation-one-001.mjs
+++ b/scripts/one-off/_plan-testing-evidence-silent-truncation-one-001.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * One-off: record TESTING sub-agent evidence at the PLAN phase for
+ * SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001 (PLAN-TO-EXEC handoff).
+ *
+ * Adversarial test-strategy review of PRD-SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001's TS-1..TS-4,
+ * plus independent re-measurement of the triage counts (do not trust the PRD's numbers verbatim).
+ * Written through the canonical writer (CLAUDE.md prologue rule 11).
+ */
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../../lib/sub-agent-executor/results-storage.js';
+import { getSupabaseClient } from '../../lib/sub-agent-executor/supabase-client.js';
+
+const SD_ID = '4d825dee-12c2-43da-ab32-5b2bb4ae6f36';
+const SD_KEY = 'SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001';
+
+async function main() {
+  const supabase = await getSupabaseClient();
+  const resolution = await resolveSubAgentRepo({ sdId: SD_KEY, targetApplication: 'EHG_Engineer', subAgentCode: 'TESTING', supabase });
+
+  let results = {
+    verdict: 'PASS',
+    confidence: 78,
+    findings: [
+      {
+        id: 'F1-per-site-inspection-is-the-honest-ceiling',
+        severity: 'MEDIUM',
+        summary: "TS-1/TS-2 are per-site output-inspection tests ('the roster prints the full id', 'the [ROLE] line carries the full id'). They cannot prove the SD's real success condition -- that nobody re-types a truncated id -- because that is a claim about a HUMAN/AGENT READER's downstream behavior, not a property of the code under test. No unit or E2E test can assert an absence-of-misuse across every future reader. TS-1/TS-2 are nonetheless the correct and adequate ceiling: they assert the positive, checkable half of the contract ('a full, re-consumable value is present in the output'), which is exactly what the display-layer remedy (PRD TR-2/description Section on display-layer enforcement) can guarantee. Recommend framing them explicitly in the PRD as 'necessary, not sufficient' rather than as proof of the outcome, so a future reader does not mistake green tests for the failure mode being retired.",
+      },
+      {
+        id: 'F2-exemption-pin-partially-exists-precedent-found',
+        severity: 'HIGH',
+        summary: "tests/unit/eva-master-scheduler.test.js:242,958-959 ALREADY pins lib/eva/eva-master-scheduler.js:146's `this.instanceId = \\`scheduler-${randomUUID().slice(0, 8)}\\`` via `expect(scheduler.instanceId).toMatch(/^scheduler-[a-f0-9]{8}$/)` -- this is a working, pre-existing instance of exactly the TS-3 exemption-pin pattern, and it WOULD fail if someone 'fixed' the slice to print the full UUID (format would no longer match 8 hex chars). No equivalent pin exists for lib/eva/concurrent-venture-orchestrator.js:55 (instanceId = `concurrent-${randomUUID().slice(0,8)}`, trivially testable via `new ConcurrentVentureOrchestrator().instanceId`), for lib/session-manager.mjs:136 (generateSessionId() is NOT exported -- only reachable via the async getOrCreateSession(), so this site needs either an export or an integration-level test), or for either KIND 3 site (lib/genesis/branch-lifecycle.js sim/<8> at :243/:291/:549/:589, lib/sub-agents/rca.js:487 PAT-<cat>-<8> fallback in findPatternMatches, unexported -- would need export or invocation via execute()). Concrete design in metadata.exemption_pin_design.",
+      },
+      {
+        id: 'F3-session-role-orient-existing-test-WILL-break-on-child-1-fix',
+        severity: 'HIGH',
+        summary: "scripts/hooks/__tests__/session-role-orient.test.js:44 asserts `expect(out[0]).toMatch(/WORKER \\(callsign: Bravo\\) under coordinator session=coord-uu\\./)` against fixture session_id 'coord-uuid-12345678', pinning the CURRENT truncated form (decide() calls workerLines(callsign, coordFile.session_id.slice(0,8)) at line 82). Child 1's FR-1(b)/FR-2 fix -- print full+short together on this purely human-facing line -- necessarily changes the character immediately after 'coord-uu' from '.' to more id characters, so this regex breaks. This is a real, concrete regression Child 1 MUST update in the same PR, not an incidental side effect to discover in CI. No equivalent pre-existing assertion was found for scripts/assign-fleet-identities.cjs's roster/diagnostic lines or scripts/coordinator-hourly-review.cjs:326 / scripts/fleet-dashboard.cjs:2236 (relay-drop-gauge display) -- those three have zero existing coverage of their console.log format, so Child 1's TS-1 assertions there are net-new with no regression risk from the existing suite.",
+      },
+      {
+        id: 'F4-measured-counts-close-but-not-exact-match-to-PRD',
+        severity: 'LOW',
+        summary: "Independently re-ran the population counts rather than trusting FR-3/TR-4. (a) CONFIRMED: lib/coordinator/detectors.cjs:71 and :95 are exactly `.map(c => c.session_id).filter(Boolean).slice(0, 10)` -- array cap, not string truncation; every session_id inside is full length. (b) MOSTLY CONFIRMED: randomUUID()/uuidv4().slice|substring sites that MINT (not truncate) an id -- my own grep across lib/,scripts/,server/ (excluding tests) found 15 randomUUID()-based + 4 uuidv4()-based = 19 raw hits, of which 5 sit in scripts/archive/one-time/ (dead code); excluding those gives 14 live. The PRD's '17' sits between my raw (19) and my live (14) counts depending on exactly which archive/dead-code exclusion rule is applied -- the PRD does not state its exact filter, so I cannot reproduce '17' bit-for-bit, but every site I found IS genuinely minting (constructs a NEW id from randomUUID()/uuidv4(), never truncates an EXISTING stored value), so the substantive KIND 2 classification holds regardless of the exact count. (c) CONFIRMED all 3 spot-checked KIND 1 sites: scripts/assign-fleet-identities.cjs (:523,:575,:648,:674,:712,:732,:737 all do w.session_id.substring(0,12) / worker.session_id.substring(0,12), no full session_id printed anywhere else in the file's console output), scripts/hooks/session-role-orient.cjs:82 (coordFile.session_id.slice(0,8), no full id anywhere in the hook), scripts/coordinator-hourly-review.cjs:326 + scripts/fleet-dashboard.cjs:2236 (both slice d.id and d.correlationId to 8 chars; the two lines are near-identical, not byte-for-byte identical -- the age-formatting expression differs slightly between the two files, though the truncation-relevant substring is identical). No full value is available elsewhere in any of the three spot-checked outputs -- all are genuine hazards as claimed.",
+      },
+      {
+        id: 'F5-FR-5-class-B-has-zero-test-scenario-and-its-own-precondition-is-unmet',
+        severity: 'HIGH',
+        summary: "TS-1 through TS-4 cover only FR-1/FR-2/FR-3/FR-4 (Class A + exemptions). FR-5 (priority=high, 'Class B -- typed envelope constructor') has NO test_scenario at all, despite acceptance criteria that describe testable behavior ('the constructor cannot be invoked without its send context -- absence is a construction-time error, not a runtime null'). Separately, FR-5's own precondition is unmet: its acceptance criteria require 'the relationship [to SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001] is explicitly decided and recorded (fold, depend, or divide)' -- queried strategic_directives_v2 directly and found SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 still status=draft, zero children under this SD's id (4d825dee), and no fold/depend/divide annotation in either SD's metadata. That SD is ALSO independently claimed and under active LEAD analysis by a different session (session_id 0db9d282, 'lead_analysis_alpha2' in its metadata) -- a real risk of two sessions building overlapping Class B work concurrently, which is precisely the coordination failure FR-5 exists to prevent.",
+      },
+    ],
+    metadata: {
+      measured_counts: {
+        kind1_hazard_spot_checked: '3/3 confirmed genuine (assign-fleet-identities.cjs, session-role-orient.cjs, coordinator-hourly-review.cjs+fleet-dashboard.cjs)',
+        kind2_minting_raw: 19,
+        kind2_minting_excluding_archive: 14,
+        kind2_minting_prd_claimed: 17,
+        kind2_minting_verdict: 'count not bit-for-bit reproduced but substantive classification (mint not truncate) confirmed for every site found',
+        array_cap_false_positives_confirmed: 'lib/coordinator/detectors.cjs:71,:95 -- exact match to claim',
+        already_compliant_spot_check: 'scripts/coordinator-reply.cjs:53+buildReplyPayload:33-46 -- confirmed short form in subject only, full correlationId in payload.reply_to and payload.correlation_id',
+      },
+      exemption_pin_design: {
+        recommendation: 'Behavioral assertion where the minting/labeling code is reachable from an exported, synchronously-testable surface; source-anchor (grep-on-file-content) fallback only where no such surface exists (private function, or a bare git-SHA display with no fabrication risk to police).',
+        existing_precedent: 'tests/unit/eva-master-scheduler.test.js:242 already does exactly this for eva-master-scheduler.js:146 -- expect(scheduler.instanceId).toMatch(/^scheduler-[a-f0-9]{8}$/). Use as the template.',
+        proposed_new_file: 'tests/unit/silent-truncation-exemption-pin.test.js',
+        proposed_assertions: [
+          "KIND2 lib/eva/concurrent-venture-orchestrator.js:55 -- new ConcurrentVentureOrchestrator().instanceId toMatch(/^concurrent-[0-9a-f]{8}$/). Trivial: constructor is synchronous, deps optional.",
+          "KIND2 lib/session-manager.mjs:136 -- generateSessionId() is unexported (only getOrCreateSession() at :301 calls it). Either add it to the module.exports default block at :1019 for direct testing, or assert indirectly via a mocked getOrCreateSession() call and regex the returned sessionId against /^session_[0-9a-f]{8}_.+_\\d+$/. Flagging as the one KIND2 site that needs an export change (not just a test) to pin cleanly.",
+          "KIND3 lib/genesis/branch-lifecycle.js -- generateBranchName(seedText) IS exported (:84) and pure; assert its return matches /^sim\\/[a-z0-9-]+-[0-9a-f]{6,8}$/ for a fixed seedText. NOTE: :243/:291/:549/:589 build a DIFFERENT derived label (`sim/${data.id.substring(0,8)}`) inline inside async DB-reading functions (getSimulationBranch, etc.) rather than via generateBranchName -- and in at least :243, the SAME return object also carries `id: data.id` (the full value) alongside the short `name`, so that specific site is already full+short together, not a bare truncation. Worth PLAN double-checking whether all 4 of these sites are genuinely KIND3-as-claimed or whether some are closer to the already-compliant pattern.",
+          "KIND3 lib/sub-agents/rca.js:487 -- findPatternMatches(rcr, historicalRCRs) at :457 is unexported (only execute() at :42 is exported, and default export is { execute } at :687). Pin either by exporting findPatternMatches for direct testing, or by asserting on execute()'s output shape with a fixture historical row lacking pattern_id, checking the synthesized pattern_id matches /^PAT-[^-]+-[0-9a-f]{8}$/.",
+          "KIND4 git-SHA sites (e.g. lib/eva/bridge/verification-sd-generator.js:33, lib/governance/check-resolver-freshness.js:65) -- lower priority for a behavioral pin since messing with these carries no fabrication risk (git resolves prefixes); a lightweight source-anchor test asserting the .slice(0,7)/.substring(0,7) pattern is still present on a representative site is sufficient documentation-as-test, not a hard requirement.",
+        ],
+      },
+      session_role_orient_baseline: {
+        file: 'scripts/hooks/__tests__/session-role-orient.test.js',
+        line: 44,
+        current_assertion: "expect(out[0]).toMatch(/WORKER \\(callsign: Bravo\\) under coordinator session=coord-uu\\./)",
+        fixture: "session_id: 'coord-uuid-12345678'",
+        verdict: 'WILL BREAK on Child 1 fix to session-role-orient.cjs:82 (full+short together changes the character after \"coord-uu\" from \".\" to more id chars). Must be updated in the same PR as the fix, not discovered later in CI.',
+      },
+      assign_fleet_identities_baseline: 'tests/unit/assign-fleet-identities-{coordinator-filter,rebroadcast,sdkey-and-panel-fields,tier-callsign}.test.js -- none spy on console.log or assert the roster/diagnostic output format (:523,:575,:648,:674,:712,:732,:737). Zero regression risk from the existing suite; TS-1 is net-new coverage.',
+      coordinator_hourly_review_baseline: 'tests/unit/coordinator-hourly-review-solomon-leg.test.js and tests/unit/coordinator/relay-drop-gauge.test.js exist but neither asserts on the console.log format at coordinator-hourly-review.cjs:326 (relay-drop-gauge.test.js tests planRelayDrops()\'s RETURNED decision objects, not the printed string). fleet-dashboard.cjs\'s printRelayDropGauge() (which prints the byte-similar line at :2236) has NO referencing test file at all. Zero regression risk; TS-2-equivalent coverage there is also net-new.',
+      fr5_class_b_gap: 'No test_scenario for FR-5. SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (draft, unfolded, independently claimed by session 0db9d282) is FR-5\'s own blocking precondition and remains unresolved.',
+    },
+    phase: 'PLAN',
+    summary: "PASS for PLAN-TO-EXEC on the scoped, testable portion of this PRD (FR-1/FR-2/FR-3/FR-4, TS-1..TS-4), with two findings EXEC must act on and one gap PLAN should close before FR-5 lands. (1) TS-1/TS-2 per-site output inspection is the honest ceiling for this SD -- 'nobody re-types a truncated id' is a downstream-reader behavior no test can prove; the tests correctly assert the positive, checkable half (full value present and re-consumable) instead. (2) TS-3's exemption pin already has a WORKING precedent in this codebase (tests/unit/eva-master-scheduler.test.js:242 pins exactly one of the KIND2 minting sites) -- concrete extension design for the remaining KIND2/KIND3 sites is in metadata.exemption_pin_design. (3) scripts/hooks/__tests__/session-role-orient.test.js:44 is an EXISTING test that WILL break when Child 1 fixes session-role-orient.cjs:82 -- this must be updated in the same PR, not discovered later. assign-fleet-identities.cjs and coordinator-hourly-review.cjs/fleet-dashboard.cjs have zero existing coverage of their display format, so no regression risk there. (4) Independently re-measured the triage: detectors.cjs:71/:95 array-cap claim confirmed exactly; randomUUID()/uuidv4() minting-site count came back 14-19 depending on archive-exclusion rule against the PRD's 17 (not bit-for-bit reproduced, but every site found is genuinely minting, not truncating); all 3 spot-checked KIND1 hazard sites confirmed genuine with no full id available elsewhere in the same output. (5) GAP: FR-5 (Class B typed constructor, priority=high) has NO test_scenario, and its own acceptance-criteria precondition -- an explicit fold/depend/divide decision against SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 -- is unrecorded while that SD is independently claimed and under active analysis by a different session. Recommend PLAN either add a TS-5 now or explicitly defer FR-5 to a follow-on PRD before EXEC starts on it.",
+  };
+
+  results = applySubAgentRepoVerdict(results, resolution);
+  const stored = await storeSubAgentResults('TESTING', SD_ID, { name: 'TESTING (QA Engineering Director)' }, results, { sdKey: SD_KEY, phase: 'PLAN' });
+  console.log('TESTING result stored:', stored.id, stored.verdict, stored.confidence);
+}
+
+main().catch((e) => { console.error('FAILED:', e.message); process.exit(1); });

--- a/scripts/one-off/_security-exec-evidence-silent-truncation-one-001.mjs
+++ b/scripts/one-off/_security-exec-evidence-silent-truncation-one-001.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+/**
+ * One-off: record SECURITY EXEC-phase evidence for SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001
+ * (EXEC-TO-PLAN handoff). Recorded via the canonical writer (CLAUDE.md prologue rule 11).
+ */
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../../lib/sub-agent-executor/results-storage.js';
+import { getSupabaseClient } from '../../lib/sub-agent-executor/supabase-client.js';
+
+const SD_ID = '4d825dee-12c2-43da-ab32-5b2bb4ae6f36';
+const SD_KEY = 'SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001';
+
+async function main() {
+  const supabase = await getSupabaseClient();
+  const resolution = await resolveSubAgentRepo({ sdId: SD_KEY, targetApplication: 'EHG_Engineer', subAgentCode: 'SECURITY', supabase });
+
+  let results = {
+    verdict: 'PASS',
+    confidence: 85,
+    findings: [
+      {
+        id: 'F1-session-and-correlation-ids-are-not-bearer-credentials',
+        severity: 'INFO',
+        summary: "session_id/correlation_id are opaque row keys and coordination-routing addresses (target_session in worker-signal.cjs:385/553/712), not secrets. Authorization for mutating actions (POST /api/fleet/sessions/:id/{open,takeover,hand-back}, server/routes/fleet-sessions.js) is enforced by requireAuth (Bearer JWT or X-Internal-Api-Key, server/middleware/auth.js:52) evaluated independently of the session_id path param -- possessing a session_id lets you ADDRESS an action at that session, it does not itself grant authority to perform it.",
+      },
+      {
+        id: 'F2-audience-is-local-operator-surfaces-only',
+        severity: 'INFO',
+        summary: "All four changed call sites print to local stdout only: assign-fleet-identities.cjs / coordinator-hourly-review.cjs / fleet-dashboard.cjs are operator/cron CLI diagnostics, and session-role-orient.cjs is a SessionStart hook (wired in .claude/settings.json:93) whose output is injected into a worker's own model context. server/index.js:387 binds the HTTP server to 127.0.0.1 only (not internet-facing); scripts/leo-stack.ps1 redirects server stdout to a local .logs/engineer-<ts>.log on the same machine. No output crosses to a less-trusted network boundary.",
+      },
+      {
+        id: 'F3-role-line-widens-placement-not-disclosure',
+        severity: 'LOW',
+        summary: "session-role-orient.cjs:82 now puts the coordinator's FULL 36-char session_id (was 8 hex chars) into the [ROLE] line delivered to every worker at session start, which becomes part of that worker's model-context and is sent to the model provider as conversation content -- a genuine widening of WHERE the full identifier travels. However this is not a new DISCLOSURE: the same full session_id was already retrievable in full and UNAUTHENTICATED from GET /api/fleet-panel (server/routes/fleet-panel.js:108, mounted with optionalAuth at server/index.js:262, untouched by this diff -- confirmed via `git diff origin/main...HEAD -- server/routes/fleet-panel.js` returning empty). Given F1 (session_id carries no bearer authority on its own), landing the full value in a worker's transcript does not by itself grant a transcript-reader or the model provider any capability beyond what any party could already pull from the unauthenticated fleet-panel endpoint.",
+      },
+      {
+        id: 'F4-preexisting-scope-gap-not-introduced-here',
+        severity: 'LOW',
+        summary: "fleet-sessions.js's own pre-existing header comment (lines 18-25, predates this SD) documents a KNOWN SCOPE BOUNDARY: once requireAuth passes, there is no per-session ownership check, so any authenticated caller can target ANY session_id for open/takeover/hand-back (single-operator trust model, not independently re-evaluated for a caller-role gate). Full display of session_id makes an exact id trivially copyable instead of requiring an attacker to guess against an 8-char (~32-bit) prefix within a small live-session population -- a marginal convenience to an already-authenticated insider, not a new authorization bypass. This gap is out of scope for SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001 (not touched by its diff) and is flagged here as a follow-up candidate, not a blocker.",
+      },
+      {
+        id: 'F5-log-volume-hygiene-negligible',
+        severity: 'INFO',
+        summary: "No material log bloat. coordinator-hourly-review.cjs and fleet-dashboard.cjs already cap the flagged-row array to 10 (the untouched `.slice(0, 10)` on the array, distinct from the removed `.slice(0, 8)` on the id/correlationId strings); per-row growth is ~2x24 hex chars. assign-fleet-identities.cjs roster output is bounded by live fleet size (single-digit to low tens of workers). session-role-orient.cjs emits once per session start. Not a scraping or storage concern.",
+      },
+      {
+        id: 'F6-account-uuid-credential-hygiene-untouched-and-intact',
+        severity: 'INFO',
+        summary: "Confirmed the one truncation in this codebase that IS a security control was neither touched nor bypassed. `git diff origin/main...HEAD -- lib/fleet/account-identity.cjs` is empty (file not in this SD's diff). Its exported contract (docstring line 61: 'EXACTLY these 3 keys, nothing else, ever') still returns only accountUuid8 = sanitizeField(accountUuid).slice(0, 8) (line 81) -- the full accountUuid is never returned. Grepped all four changed files for accountUuid/account_uuid: every reference (assign-fleet-identities.cjs:26,28,715,718,765,777) is to the already-short accountUuid8 field name; none reads or newly surfaces the full account uuid. Credential hygiene for the local process account identity is unaffected.",
+      },
+    ],
+    metadata: {
+      direct_answers: {
+        q1_disclosure: "session_id and correlation_id are opaque identifiers / coordination-routing addresses, NOT bearer tokens. Authorization on the one HTTP surface that acts on a session_id (POST /api/fleet/sessions/:id/*) is enforced independently by requireAuth (Bearer JWT or internal API key). Possessing a session_id lets a caller target a message or an authenticated API call at that session; it does not authenticate the caller. Caveat: fleet-sessions.js's own pre-existing (not introduced here) KNOWN SCOPE BOUNDARY comment notes there is no per-session ownership check once authenticated -- a real gap, but unrelated to display truncation and unrelated to this SD's diff.",
+        q5_account_uuid_control: "Confirmed clean. lib/fleet/account-identity.cjs is not part of this diff; getAccountIdentity() still returns exactly {email, orgName, accountUuid8} with accountUuid8 hard-truncated to 8 chars (line 81) and the full accountUuid discarded. No roster or dashboard code path touched by this change reads or displays the full account uuid.",
+      },
+      files_reviewed: [
+        'scripts/assign-fleet-identities.cjs',
+        'scripts/hooks/session-role-orient.cjs',
+        'scripts/hooks/__tests__/session-role-orient.test.js',
+        'scripts/coordinator-hourly-review.cjs',
+        'scripts/fleet-dashboard.cjs',
+        'server/routes/fleet-sessions.js (context, untouched)',
+        'server/routes/fleet-panel.js (context, untouched)',
+        'server/middleware/auth.js (context, untouched)',
+        'server/index.js (context, untouched)',
+        'lib/fleet/account-identity.cjs (context, untouched)',
+        'scripts/worker-signal.cjs (context, untouched)',
+      ],
+      commit_reviewed: '1516709e3b2',
+      diff_range: 'origin/main...HEAD',
+    },
+    phase: 'EXEC',
+    summary: "PASS for EXEC-TO-PLAN. This change makes four identifier-display sites (Fleet Identity Roster + diagnostics, the [ROLE] worker-orientation line, and the relay-drop diagnostic in coordinator-hourly-review.cjs + its fleet-dashboard.cjs duplicate) print session_id/correlation_id in FULL instead of an 8-12 char prefix, closing the silent-truncation-to-fabricated-identifier defect. Adversarial review found this is not a net security regression: (1) session ids are opaque routing keys, not bearer credentials -- HTTP authorization is enforced independently via requireAuth; (2) all four outputs stay on local operator-facing surfaces (CLI stdout, a local log file, a SessionStart hook's own worker-context injection) behind a server that binds to 127.0.0.1 only; (3) the [ROLE] line's full-session-id placement into worker model-context (session-role-orient.cjs:82) is a genuine widening of WHERE the id travels, rated LOW, but is not a new disclosure -- the same full session_id was already retrievable unauthenticated from GET /api/fleet-panel, untouched by this diff; (4) a pre-existing (not introduced here) missing per-session-ownership check on the mutating /api/fleet/sessions/:id/* routes is the real authorization gap in this area and is flagged as a follow-up, out of scope for this SD; (5) the one truncation in this codebase that IS a security control -- lib/fleet/account-identity.cjs's hard 8-char accountUuid8 cap -- was verified untouched and intact; no path in this diff reads or surfaces a full account uuid. No log-volume or hygiene concern (row-count caps pre-existing and untouched).",
+  };
+
+  results = applySubAgentRepoVerdict(results, resolution);
+  const stored = await storeSubAgentResults('SECURITY', SD_ID, { name: 'SECURITY (Chief Security Architect)' }, results, { sdKey: SD_KEY, phase: 'EXEC' });
+  console.log('SECURITY result stored:', stored.id, stored.verdict, stored.confidence);
+}
+
+main().catch((e) => { console.error('FAILED:', e.message); process.exit(1); });


### PR DESCRIPTION
Child 1 of the Class A display-layer work. These three sites are **not grep samples** — each is a
measured producer of a real incident.

| Site | What it printed | What happened |
|---|---|---|
| `assign-fleet-identities.cjs` (Fleet Identity Roster) | `session_id.substring(0,12) + '...'`, full id nowhere in the same output | the coordinator read a row, completed the remaining hex **by guessing** without noticing it had guessed, and wrote a fabricated id into a dispatch |
| `session-role-orient.cjs:82` | `coordinator session=<8 chars>` in the `[ROLE]` line shipped to **every worker at session start** | a worker builds `target_session` from that line; an 8-char prefix stores, prints a success checkmark, and threads to nothing |
| `coordinator-hourly-review.cjs:326` + `fleet-dashboard.cjs:2236` | `correlation=<8 chars>` | the likely literal source of an agent copying its own diagnostic output into `--reply-to` **twice in one day** |

The dashboard line is byte-identical to the hourly-review one and is fixed in the same commit —
leaving the copy truncated would keep the defect alive in the surface people actually read.

## Why full values, not `full (short: abcd1234)`

The SD prescribes printing both **only "where a short form is genuinely wanted for scanning."** That
is true of a many-row table and false of a single value in a prompt line. A UUID column is
fixed-width, so the roster stays scannable at full length — and re-emitting an abbreviation beside
the full value would reinstate exactly the copyable hazard this fix removes.

## The test change is deliberate, not a chase

`session-role-orient.test.js:44` regex-pinned `session=coord-uu.` — it **encoded the truncation**.
It is updated because the behaviour was intentionally changed, and a negative assertion is added so
the full id cannot be re-accompanied by an abbreviation of itself. This was known from the
PLAN-phase baseline *before* the edit, not discovered in CI.

## Nothing exempt was touched — verified, not asserted

`git diff --quiet` confirms all seven exempt files unmodified:

- **Minting** (`randomUUID().slice(0,8)`) — constructs a *new* short id; no full value is hidden and
  changing it breaks id generation. `session-manager.mjs`, `eva-master-scheduler.js`,
  `terminal-identity.js`, `concurrent-venture-orchestrator.js`.
- **Derived labels** — `sim/<8>` branch names, `PAT-<cat>-<8>` pattern ids: keys in their own right.
- **Git SHA prefixes** — git resolves an unambiguous prefix to the correct object or refuses; a UUID
  column has no prefix-resolve, which is *precisely* why session ids fabricate and SHAs don't.
- **Array caps** — `detectors.cjs:71,95` slice the array to 10 elements while every id inside stays
  full length. That false positive sits **one line above a real hazard in this very diff**.

`session-role-orient.test.js`: 23 passed.

## Known gap

`eva-master-scheduler.test.js` — the existing minting pin that would fail if someone "fixed" that
`randomUUID().slice(0,8)` — is in the vitest exclude list, so the guard exists but does not execute.
Flagged for the exemption-pin work rather than silently relied on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
