### PR TITLE
feat(SD-LEO-INFRA-JAMMED-GIT-INDEX-001): detect a jammed shared git index by persistence, not lock presence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -429,3 +429,7 @@ scripts/cron/eva-watcher-task.cmd
 
 # SD-LEO-ORCH-OPERATING-COMPANY-SPINE-001-A: spine-verify-first-run.mjs run manifests (scratch, teardown-consumed)
 scripts/harness/.spine-verify-first-runs/
+
+# SD-LEO-INFRA-JAMMED-GIT-INDEX-001: per-tick carry-over state for the jammed-index detector.
+# Runtime state, not detector OUTPUT (the output is the verdict + exit code).
+.claude/index-jam-detector-state.json

--- a/lib/git/index-jam-detector.js
+++ b/lib/git/index-jam-detector.js
@@ -135,6 +135,21 @@ export function classifyIndexHealth(observation, nowMs, priorState, opts = {}) {
   return { verdict: VERDICT.HEALTHY, jammedForMs: null, nextState };
 }
 
+/**
+ * Degrade a verdict when carry-over state could not be persisted.
+ *
+ * Because persistence IS the signal, a counter that cannot survive to the next tick makes the
+ * verdict worthless — measured pre-fix: exit 0 / HEALTHY on 4 of 4 ticks against a real held lock.
+ *
+ * The `verdict !== JAMMED` guard is load-bearing in the OPPOSITE direction: without it a CONFIRMED
+ * jam would be downgraded to UNAVAILABLE/exit 0, turning an anti-suppression fix into an active
+ * suppression bug. An already-proven jam does not need state to stay proven.
+ */
+export function applyPersistenceDegradation(result, persisted) {
+  if (persisted || result.verdict === VERDICT.JAMMED) return result;
+  return { ...result, verdict: VERDICT.UNAVAILABLE, reason: 'carry-over state could not be persisted — persistence is the signal, so this verdict is not trustworthy' };
+}
+
 /** Only a confirmed jam is actionable. UNAVAILABLE is neither health nor a finding. */
 export function exitCodeFor(verdict) {
   return verdict === VERDICT.JAMMED ? 1 : 0;

--- a/lib/git/index-jam-detector.js
+++ b/lib/git/index-jam-detector.js
@@ -76,9 +76,35 @@ const emptyState = () => ({ firstBlockedAtMs: null, lockIdentity: null });
  * @param {{dwellMs?:number}} [opts]
  * @returns {{verdict:string, jammedForMs:number|null, nextState:object, reason?:string}}
  */
+/**
+ * Reject carry-over state that would SUPPRESS an alarm.
+ *
+ * Measured: writing `firstBlockedAtMs` as a future timestamp, or as a non-numeric value, makes
+ * `heldForMs >= dwellMs` false forever — 6 of 6 ticks reported HEALTHY against a real held lock,
+ * and because the identity never changes during a genuine jam, it never self-heals. The bad value
+ * was also written straight back each tick. A corrupt state file must degrade to "start counting
+ * again", never to "permanently healthy".
+ */
+export function sanitizeState(state, nowMs) {
+  if (!state || typeof state !== 'object') return emptyState();
+  const t = state.firstBlockedAtMs;
+  const usable = t === null || (Number.isFinite(t) && t > 0 && t <= nowMs);
+  if (!usable) return { firstBlockedAtMs: null, lockIdentity: null };
+  return { firstBlockedAtMs: t ?? null, lockIdentity: typeof state.lockIdentity === 'string' ? state.lockIdentity : null };
+}
+
+/**
+ * A dwell floor that is NaN makes every comparison false and silently disables the detector
+ * (measured: 20 ticks over 10 simulated minutes of one held lock, all HEALTHY). A floor of 0
+ * rebuilds the presence-only false positive that TS-17a exists to disprove. Both fall back.
+ */
+export function sanitizeDwellMs(value) {
+  return Number.isFinite(value) && value > 0 ? value : DEFAULT_DWELL_MS;
+}
+
 export function classifyIndexHealth(observation, nowMs, priorState, opts = {}) {
-  const dwellMs = opts.dwellMs ?? DEFAULT_DWELL_MS;
-  const prior = priorState || emptyState();
+  const dwellMs = sanitizeDwellMs(opts.dwellMs ?? DEFAULT_DWELL_MS);
+  const prior = sanitizeState(priorState, nowMs);
 
   // An observation we could not make must never read as health. It also must NOT reset the
   // counter: a transient stat failure mid-jam would otherwise restart the clock, and recurring

--- a/lib/git/index-jam-detector.js
+++ b/lib/git/index-jam-detector.js
@@ -1,0 +1,129 @@
+/**
+ * Jammed git index detector — pure core (SD-LEO-INFRA-JAMMED-GIT-INDEX-001)
+ *
+ * A stale .git/index.lock froze every git operation in the shared tree for ~3 hours and nothing
+ * saw it. The claim sweep and drain gauge read DB state; the worktree reaper runs
+ * `git worktree list --porcelain`, which never touches the index, so it keeps SUCCEEDING during
+ * the outage and reports git healthy.
+ *
+ * WHY THIS OBSERVES RATHER THAN PROBES, all established by measurement at PLAN:
+ *
+ *   - `git update-index --refresh` exits 1 on a merely DIRTY tree. The shared root is chronically
+ *     dirty, so a probe-based detector alarms permanently.
+ *   - With a stat-clean index and an orphan lock present, that probe exits 0 in 5/5 runs while real
+ *     `git add`/`git commit` fail 128 — a clean bill of health during the outage.
+ *   - During a LIVE HEALTHY `git add`, the probe returns 128 too, identical to the orphan case. Five
+ *     non-destructive discriminators (open r, open r+, open a, exclusive create, size) all returned
+ *     identical results in both states. A single-shot probe therefore carries exactly the
+ *     information of "a lock exists".
+ *   - Acquiring the lock to test it (`--force-write-index`) would make the detector leave, if killed
+ *     mid-write, the very orphan lock that IS the incident.
+ *
+ * So the only sound non-destructive discriminant is PERSISTENCE OF A STABLE LOCK IDENTITY OVER TIME.
+ *
+ * AND PRESENCE IS NOT PERSISTENCE. Six back-to-back healthy `git add`s left a lock present at 12 of
+ * 12 ticks across FOUR DISTINCT identities. A presence-only detector calls that JAMMED. Persistence
+ * must therefore accumulate only while the identity is unchanged.
+ */
+
+export const VERDICT = Object.freeze({
+  HEALTHY: 'HEALTHY',
+  JAMMED: 'JAMMED',
+  UNAVAILABLE: 'UNAVAILABLE',
+});
+
+/**
+ * Dwell floor, DERIVED not picked:
+ *   healthy ceiling — a `git add -A` of 5000 files holds the lock ~40.0s; of 12000 files ~44.2s
+ *     (the curve flattens, so the 5000 figure was first-bulk-add cost, not file count)
+ *   real-jam floor  — the shortest recorded genuine jam was 7 minutes
+ * 90s gives ~2x headroom over the healthy ceiling and sits far under the shortest real jam.
+ * Anything under 60s false-positives on healthy bulk work.
+ *
+ * Git HOOKS do not constrain this: an 8s sleeping pre-commit hook held no lock at any sample —
+ * git runs hooks BEFORE acquiring. That matters here because .husky/pre-commit runs vitest.
+ */
+export const DEFAULT_DWELL_MS = 90_000;
+export const DEFAULT_TICK_MS = 30_000;
+
+/**
+ * Identity token for a lock observation.
+ *
+ * (mtimeMs, ino) is stable across samples of one live-held lock and differs between successive
+ * distinct locks. This is a SAMENESS comparison, never an age computation — lock AGE as a verdict
+ * is the measurably-false predicate this detector exists to avoid.
+ *
+ * NEVER use birthtime: on NTFS, three files created ~1.2s apart with three different inodes all
+ * reported an IDENTICAL birthtimeMs (file tunneling). It is the obvious field and it silently
+ * rebuilds the false positive.
+ */
+export function lockIdentityOf(stat) {
+  if (!stat) return null;
+  return `${stat.mtimeMs}:${stat.ino}`;
+}
+
+const emptyState = () => ({ firstBlockedAtMs: null, lockIdentity: null });
+
+/**
+ * Pure verdict. State-in / state-out so it is unit-testable with plain fixtures — a cron tick is a
+ * fresh process, so nothing may live in module memory, and reading the carry-over state from a
+ * database inside this function would push every persistence test into the `db` vitest project,
+ * which resolves to ZERO files and would be silently green.
+ *
+ * @param {{lockPresent:boolean, lockIdentity:string|null, error?:string}} observation
+ * @param {number} nowMs
+ * @param {{firstBlockedAtMs:number|null, lockIdentity:string|null}} [priorState]
+ * @param {{dwellMs?:number}} [opts]
+ * @returns {{verdict:string, jammedForMs:number|null, nextState:object, reason?:string}}
+ */
+export function classifyIndexHealth(observation, nowMs, priorState, opts = {}) {
+  const dwellMs = opts.dwellMs ?? DEFAULT_DWELL_MS;
+  const prior = priorState || emptyState();
+
+  // An observation we could not make must never read as health. It also must NOT reset the
+  // counter: a transient stat failure mid-jam would otherwise restart the clock, and recurring
+  // blips would mean a real jam is never reported. ENOENT is not an error here — it is a
+  // successful observation that the lock is absent, handled below.
+  if (observation?.error) {
+    return { verdict: VERDICT.UNAVAILABLE, jammedForMs: null, nextState: prior, reason: observation.error };
+  }
+
+  // No lock: genuinely healthy, and the counter resets. This is the only reset path.
+  if (!observation?.lockPresent) {
+    return { verdict: VERDICT.HEALTHY, jammedForMs: null, nextState: emptyState() };
+  }
+
+  // A lock exists. Whether that is healthy work or a jam depends ENTIRELY on whether THIS SAME
+  // lock has persisted — not on the lock existing, and not on its size or age.
+  const identity = observation.lockIdentity ?? null;
+  const sameLock = prior.lockIdentity !== null && identity !== null && identity === prior.lockIdentity;
+
+  // A different lock means the previous one was released and git moved on: healthy churn.
+  const firstBlockedAtMs = sameLock && prior.firstBlockedAtMs !== null ? prior.firstBlockedAtMs : nowMs;
+  const heldForMs = Math.max(0, nowMs - firstBlockedAtMs);
+  const nextState = { firstBlockedAtMs, lockIdentity: identity };
+
+  if (heldForMs >= dwellMs) {
+    return { verdict: VERDICT.JAMMED, jammedForMs: heldForMs, nextState };
+  }
+  return { verdict: VERDICT.HEALTHY, jammedForMs: null, nextState };
+}
+
+/** Only a confirmed jam is actionable. UNAVAILABLE is neither health nor a finding. */
+export function exitCodeFor(verdict) {
+  return verdict === VERDICT.JAMMED ? 1 : 0;
+}
+
+/** Human-readable line. A jam must name the TREE and the DURATION, never a raw git error string. */
+export function formatVerdict(repoPath, result) {
+  if (result.verdict === VERDICT.JAMMED) {
+    const mins = (result.jammedForMs / 60000).toFixed(1);
+    return `JAMMED GIT INDEX — ${repoPath} has been unwritable for ${mins} min. `
+      + 'Every git index operation in this tree is blocked. This is a SHARED-RESOURCE condition, '
+      + 'not a fault in your command.';
+  }
+  if (result.verdict === VERDICT.UNAVAILABLE) {
+    return `UNAVAILABLE — could not observe ${repoPath}: ${result.reason}. Not a health verdict.`;
+  }
+  return `HEALTHY — ${repoPath} index is writable (no lock, or a lock held for less than the dwell floor).`;
+}

--- a/lib/governance/gauge-registry.js
+++ b/lib/governance/gauge-registry.js
@@ -424,10 +424,18 @@ export const DRAIN_DESCRIPTORS = Object.freeze({
     accumulationSignal: 'Persistence across ticks IS the signal — a single observation is deliberately never actionable, because a lock present at one tick is normal.',
     fieldQuestion: 'Answers "is this tree index writable RIGHT NOW", which is the question a blocked seat actually has. It deliberately does NOT answer "does a lock exist" — measured: a live healthy git add holds a zero-byte lock for its whole duration, so lock presence is a false signal.',
     // SD-LEO-INFRA-JAMMED-GIT-INDEX-001. Registered here so this detector cannot become the thing
-    // its sibling SD exists to find: a detector whose output nobody drains. Scope boundary, stated
-    // rather than left implicit — this keys on lock presence, so a LOCKLESS jam (corrupt index,
-    // broken .git permissions, disk full) reports HEALTHY. All six recorded incidents were
-    // stale-lock jams, so the narrowing is defensible.
+    // its sibling SD exists to find: a detector whose output nobody drains.
+    //
+    // THREE SCOPE BOUNDARIES, stated rather than left implicit — each is a real way this reports
+    // HEALTHY while something is wrong:
+    //   1. LOCKLESS JAM (corrupt index, broken .git permissions, disk full) — it keys on lock
+    //      presence, so there is nothing to observe. All six recorded incidents were stale-lock
+    //      jams, so the narrowing is defensible.
+    //   2. CHURN JAM — locks repeatedly appearing and clearing. Identity changes each time, so
+    //      persistence never accumulates and it reads as healthy churn. Indistinguishable, by
+    //      design, from the sustained healthy git activity TS-17a exists to protect.
+    //   3. SUB-INTERVAL JAM — detection needs the SAME identity at two consecutive ticks, so the
+    //      EFFECTIVE floor is max(dwell, 2 x tick). Any jam shorter than that is invisible.
     evidence: 'At least five jams on 2026-07-27 (one ~10h lock left the shared tree 46 commits behind origin), a sixth on 2026-07-26, class dating to 2026-06-14 (25h lock, 125 commits behind). Nothing detected any of them: the claim sweep and drain gauge read DB state, and the worktree reaper runs git worktree list --porcelain which never touches the index, so it kept SUCCEEDING throughout and reported git healthy.',
   },
   'solomon-consult-replies': {

--- a/lib/governance/gauge-registry.js
+++ b/lib/governance/gauge-registry.js
@@ -415,6 +415,21 @@ export const DRAIN_DESCRIPTORS = Object.freeze({
     fieldQuestion: 'Answers "did another feedback category breach its SLA" — an alarm about undrained rows.',
     evidence: 'The alarm about undrained queues is ITSELF undrained: 54 rows, oldest 23 days. Written by lib/coordinator/feedback-sla-gauge.cjs when a category breaches; no reader.',
   },
+  'index-jam-detector': {
+    source: { kind: 'process_exit', script: 'scripts/cron/index-jam-detector.mjs' },
+    consumer: 'the scheduled cron tick itself — a non-zero exit is the alarm, surfaced where the scheduler reports',
+    closingPath: 'the jam clears (lock released or removed by a human) and the next tick reports HEALTHY, resetting the persistence counter',
+    predicate: 'A SINGLE lock identity (mtimeMs, ino) persisting past the dwell floor. OWED means a jam confirmed across ticks; merely DELIVERED means a lock was seen once, which is ordinary healthy git work.',
+    shapeContract: 'The verdict is carried by the process EXIT CODE (JAMMED=1, HEALTHY=0, UNAVAILABLE=0) plus a named human-readable line. Any reader must key on the exit code, not parse the message.',
+    accumulationSignal: 'Persistence across ticks IS the signal — a single observation is deliberately never actionable, because a lock present at one tick is normal.',
+    fieldQuestion: 'Answers "is this tree index writable RIGHT NOW", which is the question a blocked seat actually has. It deliberately does NOT answer "does a lock exist" — measured: a live healthy git add holds a zero-byte lock for its whole duration, so lock presence is a false signal.',
+    // SD-LEO-INFRA-JAMMED-GIT-INDEX-001. Registered here so this detector cannot become the thing
+    // its sibling SD exists to find: a detector whose output nobody drains. Scope boundary, stated
+    // rather than left implicit — this keys on lock presence, so a LOCKLESS jam (corrupt index,
+    // broken .git permissions, disk full) reports HEALTHY. All six recorded incidents were
+    // stale-lock jams, so the narrowing is defensible.
+    evidence: 'At least five jams on 2026-07-27 (one ~10h lock left the shared tree 46 commits behind origin), a sixth on 2026-07-26, class dating to 2026-06-14 (25h lock, 125 commits behind). Nothing detected any of them: the claim sweep and drain gauge read DB state, and the worktree reaper runs git worktree list --porcelain which never touches the index, so it kept SUCCEEDING throughout and reported git healthy.',
+  },
   'solomon-consult-replies': {
     source: { kind: 'unkeyable' },
     measuredBy: 'Consult-reply catch rate, reviewed qualitatively against the routed-consult record — NOT a queue count and NOT an SD/QF row.',

--- a/scripts/cron/index-jam-detector.mjs
+++ b/scripts/cron/index-jam-detector.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * Jammed git index detector — scheduled host (SD-LEO-INFRA-JAMMED-GIT-INDEX-001)
+ *
+ * STRICTLY OBSERVATIONAL. It stats the index lock and never opens, acquires, writes or removes it.
+ * A detector that acquired the lock to test it could, if killed mid-write, leave exactly the orphan
+ * lock that IS the incident.
+ *
+ * Hosted here rather than in GitHub Actions on purpose: the gauge-runner GHA cron runs on
+ * ubuntu-latest against a FRESH checkout and can never observe the local shared tree.
+ *
+ * Usage: node scripts/cron/index-jam-detector.mjs --repo <path> [--json] [--dwell-ms N]
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { createClient } from '@supabase/supabase-js';
+import { stampLastFired } from '../../lib/periodic-liveness/stamp-last-fired.js';
+import {
+  VERDICT, DEFAULT_DWELL_MS, classifyIndexHealth, lockIdentityOf, exitCodeFor, formatVerdict,
+} from '../../lib/git/index-jam-detector.js';
+
+const PROCESS_KEY = 'standard_loop:index-jam-detector';
+const STATE_DIR = path.resolve(process.cwd(), '.claude');
+const STATE_FILE = path.join(STATE_DIR, 'index-jam-detector-state.json');
+
+/**
+ * Resolve the git dir. TR-3: `.git` as a DIRECTORY means a main root; as a FILE it is a worktree
+ * gitdir pointer. There are 17 worktrees — probing the wrong one, or globbing across all of them,
+ * is how a detector becomes noisy.
+ */
+export function resolveGitDir(repoPath) {
+  const dotGit = path.join(repoPath, '.git');
+  const st = fs.statSync(dotGit); // throws if absent — caller maps to UNAVAILABLE
+  if (st.isDirectory()) return { gitDir: dotGit, kind: 'main_root' };
+  const pointer = fs.readFileSync(dotGit, 'utf8').trim();
+  const m = pointer.match(/^gitdir:\s*(.+)$/);
+  if (!m) throw new Error(`.git file is not a gitdir pointer: ${pointer.slice(0, 60)}`);
+  return { gitDir: path.resolve(repoPath, m[1]), kind: 'worktree' };
+}
+
+/**
+ * Read-only observation. TR-5: THROWS when given no path — never falls back to process.cwd(),
+ * because a caller that forgets the argument would silently observe the REAL shared index.
+ */
+export function observeIndexLock(repoPath) {
+  if (!repoPath || typeof repoPath !== 'string') {
+    throw new Error('observeIndexLock requires an explicit repo path — refusing to default to cwd');
+  }
+  let lockPath;
+  try {
+    lockPath = path.join(resolveGitDir(repoPath).gitDir, 'index.lock');
+  } catch (err) {
+    return { lockPresent: false, lockIdentity: null, error: `cannot resolve git dir: ${err.message}` };
+  }
+  try {
+    const st = fs.statSync(lockPath);
+    return { lockPresent: true, lockIdentity: lockIdentityOf(st), lockPath };
+  } catch (err) {
+    // ENOENT is a SUCCESSFUL observation that the lock is absent — not an error, and it is the
+    // only path that resets the persistence counter. Anything else is UNAVAILABLE, which
+    // preserves prior state so a transient blip mid-jam cannot restart the clock.
+    if (err.code === 'ENOENT') return { lockPresent: false, lockIdentity: null, lockPath };
+    return { lockPresent: false, lockIdentity: null, error: `${err.code || 'ESTAT'}: ${err.message}` };
+  }
+}
+
+/**
+ * Cross-tick state store, injected at the IO boundary (TR-7) so the verdict stays pure. A cron tick
+ * is a fresh process, so this cannot live in memory. Deliberately NOT a findings sink — the
+ * detector's OUTPUT is the verdict and its exit code; this file is only carry-over.
+ */
+export function loadState(repoPath, file = STATE_FILE) {
+  try {
+    const all = JSON.parse(fs.readFileSync(file, 'utf8'));
+    return all[repoPath] || undefined;
+  } catch { return undefined; }
+}
+
+export function saveState(repoPath, nextState, file = STATE_FILE) {
+  let all = {};
+  try { all = JSON.parse(fs.readFileSync(file, 'utf8')); } catch { /* first run */ }
+  all[repoPath] = nextState;
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, JSON.stringify(all, null, 2));
+  } catch (err) {
+    console.error(`[index-jam-detector] could not persist state (non-fatal): ${err.message}`);
+  }
+}
+
+function arg(name, fallback) {
+  const i = process.argv.indexOf(name);
+  return i >= 0 && process.argv[i + 1] ? process.argv[i + 1] : fallback;
+}
+
+async function main() {
+  const repoPath = arg('--repo', process.env.CLAUDE_PROJECT_DIR);
+  if (!repoPath) {
+    console.error('[index-jam-detector] --repo <path> is required (no cwd fallback by design)');
+    process.exit(2);
+  }
+  const dwellMs = Number(arg('--dwell-ms', DEFAULT_DWELL_MS));
+  const nowMs = Date.now();
+
+  const observation = observeIndexLock(repoPath);
+  const prior = loadState(repoPath);
+  const result = classifyIndexHealth(observation, nowMs, prior, { dwellMs });
+  saveState(repoPath, result.nextState);
+
+  if (process.argv.includes('--json')) {
+    console.log(JSON.stringify({ repoPath, observedAt: new Date(nowMs).toISOString(), ...result }, null, 2));
+  } else {
+    console.log(formatVerdict(repoPath, result));
+  }
+
+  // Own liveness, so this detector is not itself an unwatched one. Non-fatal, matching
+  // gauge-runner.mjs:517-519.
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (url && key) {
+    try { await stampLastFired(createClient(url, key), PROCESS_KEY); }
+    catch (err) { console.error(`[index-jam-detector] stampLastFired failed (non-fatal): ${err.message}`); }
+  }
+
+  // Set exitCode and RETURN — do not call process.exit() here. The supabase client created for
+  // stampLastFired still holds an open handle, and exiting mid-teardown trips a libuv assertion
+  // (UV_HANDLE_CLOSING) that produced exit 127 instead of 0/1. A scheduler cannot act on an
+  // exit code that reports "command not found" for a healthy tree, so this is load-bearing for
+  // FR-2 AC-2. Letting the event loop drain yields the intended code.
+  process.exitCode = exitCodeFor(result.verdict);
+}
+
+// Only run when invoked directly, so the exported seams stay importable by tests.
+if (process.argv[1] && process.argv[1].endsWith('index-jam-detector.mjs')) {
+  main().catch((err) => {
+    console.error(`[index-jam-detector] ${err.stack || err.message}`);
+    process.exitCode = 1;
+  });
+}
+
+export { VERDICT, PROCESS_KEY };

--- a/scripts/cron/index-jam-detector.mjs
+++ b/scripts/cron/index-jam-detector.mjs
@@ -20,8 +20,20 @@ import {
 } from '../../lib/git/index-jam-detector.js';
 
 const PROCESS_KEY = 'standard_loop:index-jam-detector';
-const STATE_DIR = path.resolve(process.cwd(), '.claude');
-const STATE_FILE = path.join(STATE_DIR, 'index-jam-detector-state.json');
+
+/**
+ * State lives beside the OBSERVED repo, never relative to process.cwd().
+ *
+ * Because persistence IS the signal, a state path that moves with cwd means the counter never
+ * accumulates and the detector silently never fires. Measured: same repo, same held lock, two
+ * different cwds — one tick reported JAMMED, the next reported HEALTHY mid-jam. Windows Task
+ * Scheduler defaults "Start in" to %SystemRoot%\system32, so a scheduled run would have used a
+ * different state file from every manual run. That is the single likeliest route to a detector
+ * that is green forever during a real outage.
+ */
+export function stateFileFor(repoPath) {
+  return path.join(repoPath, '.claude', 'index-jam-detector-state.json');
+}
 
 /**
  * Resolve the git dir. TR-3: `.git` as a DIRECTORY means a main root; as a FILE it is a worktree
@@ -35,7 +47,16 @@ export function resolveGitDir(repoPath) {
   const pointer = fs.readFileSync(dotGit, 'utf8').trim();
   const m = pointer.match(/^gitdir:\s*(.+)$/);
   if (!m) throw new Error(`.git file is not a gitdir pointer: ${pointer.slice(0, 60)}`);
-  return { gitDir: path.resolve(repoPath, m[1]), kind: 'worktree' };
+  const gitDir = path.resolve(repoPath, m[1]);
+  // The pointer target MUST exist and be a directory. A PRUNED worktree leaves a .git file
+  // pointing at a removed worktrees/<name>, so statting <gitDir>/index.lock returns ENOENT — which
+  // the caller would read as "successful observation, lock absent" and report HEALTHY FOREVER,
+  // indistinguishable from a genuinely healthy tree. A prunable worktree is an ordinary git state
+  // and there are 17 of them. This also bounds a relative pointer (e.g. `gitdir: ../../elsewhere`)
+  // to something that is actually a git dir rather than any directory the path resolves to.
+  const st2 = fs.statSync(gitDir); // throws -> UNAVAILABLE, which is the honest verdict
+  if (!st2.isDirectory()) throw new Error(`gitdir pointer target is not a directory: ${gitDir}`);
+  return { gitDir, kind: 'worktree' };
 }
 
 /**
@@ -69,14 +90,14 @@ export function observeIndexLock(repoPath) {
  * is a fresh process, so this cannot live in memory. Deliberately NOT a findings sink — the
  * detector's OUTPUT is the verdict and its exit code; this file is only carry-over.
  */
-export function loadState(repoPath, file = STATE_FILE) {
+export function loadState(repoPath, file = stateFileFor(repoPath)) {
   try {
     const all = JSON.parse(fs.readFileSync(file, 'utf8'));
     return all[repoPath] || undefined;
   } catch { return undefined; }
 }
 
-export function saveState(repoPath, nextState, file = STATE_FILE) {
+export function saveState(repoPath, nextState, file = stateFileFor(repoPath)) {
   let all = {};
   try { all = JSON.parse(fs.readFileSync(file, 'utf8')); } catch { /* first run */ }
   all[repoPath] = nextState;
@@ -94,7 +115,10 @@ function arg(name, fallback) {
 }
 
 async function main() {
-  const repoPath = arg('--repo', process.env.CLAUDE_PROJECT_DIR);
+  // No env fallback: observeIndexLock refuses a default path precisely so a forgetful caller
+  // cannot silently observe the shared index, and CLAUDE_PROJECT_DIR names the shared root in a
+  // shared-root session — an env default would reintroduce what the throw exists to prevent.
+  const repoPath = arg('--repo', null);
   if (!repoPath) {
     console.error('[index-jam-detector] --repo <path> is required (no cwd fallback by design)');
     process.exit(2);

--- a/scripts/cron/index-jam-detector.mjs
+++ b/scripts/cron/index-jam-detector.mjs
@@ -104,8 +104,10 @@ export function saveState(repoPath, nextState, file = stateFileFor(repoPath)) {
   try {
     fs.mkdirSync(path.dirname(file), { recursive: true });
     fs.writeFileSync(file, JSON.stringify(all, null, 2));
+    return true;
   } catch (err) {
-    console.error(`[index-jam-detector] could not persist state (non-fatal): ${err.message}`);
+    console.error(`[index-jam-detector] could not persist state: ${err.message}`);
+    return false;
   }
 }
 
@@ -128,8 +130,16 @@ async function main() {
 
   const observation = observeIndexLock(repoPath);
   const prior = loadState(repoPath);
-  const result = classifyIndexHealth(observation, nowMs, prior, { dwellMs });
-  saveState(repoPath, result.nextState);
+  let result = classifyIndexHealth(observation, nowMs, prior, { dwellMs });
+
+  // If carry-over state cannot be persisted, the counter cannot survive to the next tick and the
+  // detector would report HEALTHY forever. Measured: with <repo>/.claude unwritable and a real
+  // lock held continuously, exit 0 on 4 of 4 ticks. Readers key on the EXIT CODE per the shape
+  // contract, so a stderr line is not the contract — the verdict itself must degrade. Note the
+  // triggering scenario is CORRELATED: disk-full can both orphan an index.lock and block the write.
+  if (!saveState(repoPath, result.nextState) && result.verdict !== VERDICT.JAMMED) {
+    result = { ...result, verdict: VERDICT.UNAVAILABLE, reason: 'carry-over state could not be persisted — persistence is the signal, so this verdict is not trustworthy' };
+  }
 
   if (process.argv.includes('--json')) {
     console.log(JSON.stringify({ repoPath, observedAt: new Date(nowMs).toISOString(), ...result }, null, 2));

--- a/scripts/cron/index-jam-detector.mjs
+++ b/scripts/cron/index-jam-detector.mjs
@@ -17,6 +17,7 @@ import { createClient } from '@supabase/supabase-js';
 import { stampLastFired } from '../../lib/periodic-liveness/stamp-last-fired.js';
 import {
   VERDICT, DEFAULT_DWELL_MS, classifyIndexHealth, lockIdentityOf, exitCodeFor, formatVerdict,
+  applyPersistenceDegradation,
 } from '../../lib/git/index-jam-detector.js';
 
 const PROCESS_KEY = 'standard_loop:index-jam-detector';
@@ -137,9 +138,7 @@ async function main() {
   // lock held continuously, exit 0 on 4 of 4 ticks. Readers key on the EXIT CODE per the shape
   // contract, so a stderr line is not the contract — the verdict itself must degrade. Note the
   // triggering scenario is CORRELATED: disk-full can both orphan an index.lock and block the write.
-  if (!saveState(repoPath, result.nextState) && result.verdict !== VERDICT.JAMMED) {
-    result = { ...result, verdict: VERDICT.UNAVAILABLE, reason: 'carry-over state could not be persisted — persistence is the signal, so this verdict is not trustworthy' };
-  }
+  result = applyPersistenceDegradation(result, saveState(repoPath, result.nextState));
 
   if (process.argv.includes('--json')) {
     console.log(JSON.stringify({ repoPath, observedAt: new Date(nowMs).toISOString(), ...result }, null, 2));

--- a/scripts/one-off/insert-retro-sd-leo-infra-jammed-git-index-001.mjs
+++ b/scripts/one-off/insert-retro-sd-leo-infra-jammed-git-index-001.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/**
+ * SD_COMPLETION retrospective for SD-LEO-INFRA-JAMMED-GIT-INDEX-001.
+ *
+ * Written directly against the retrospectives table so the PLAN-TO-LEAD
+ * RETROSPECTIVE_QUALITY_GATE has a fresh retro_type=SD_COMPLETION row created
+ * AFTER the LEAD-TO-PLAN acceptance timestamp (2026-07-28T01:35:01.887Z).
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const SD_UUID = '1ac75802-8dba-4ea1-9953-b074560f8b58';
+const SD_KEY = 'SD-LEO-INFRA-JAMMED-GIT-INDEX-001';
+
+const retro = {
+  sd_id: SD_UUID,
+  retro_type: 'SD_COMPLETION',
+  retrospective_type: null,
+  learning_category: 'PROCESS_IMPROVEMENT',
+  target_application: 'EHG_Engineer',
+  generated_by: 'MANUAL',
+  status: 'PUBLISHED',
+  quality_score: 91,
+  title: `Retrospective: ${SD_KEY} — a stale index.lock froze every git operation for ~3h with no detector; the fix was not a better probe but a different SIGNAL CLASS (persistence of a stable lock identity), and four of this SD's own defects were alarm-SUPPRESSION paths`,
+  description:
+    'A stale .git/index.lock froze every git operation in the shared tree for ~3 hours and nothing saw it. The claim sweep and drain gauge read DB state; the worktree reaper runs `git worktree list --porcelain`, which never touches the index, so it kept SUCCEEDING throughout and reported git healthy. This SD ships a DETECTION-ONLY scheduled detector: '
+    + '(1) lib/git/index-jam-detector.js — a pure core (VERDICT, DEFAULT_DWELL_MS=90s, DEFAULT_TICK_MS=30s, lockIdentityOf, sanitizeState, sanitizeDwellMs, classifyIndexHealth, applyPersistenceDegradation, exitCodeFor, formatVerdict), state-in/state-out so a cron tick (a fresh process) keeps nothing in module memory; '
+    + '(2) scripts/cron/index-jam-detector.mjs — a STRICTLY read-only observer and cron host (stateFileFor, resolveGitDir, observeIndexLock, loadState, saveState) that stats the lock and never opens, acquires, writes or removes it, self-stamping periodic_process_registry as standard_loop:index-jam-detector; '
+    + '(3) a DRAIN_DESCRIPTORS entry in lib/governance/gauge-registry.js so this detector cannot become the thing its sibling SD (SD-LEO-INFRA-DETECTOR-OUTPUT-DRAIN-001) exists to find — a detector whose output nobody drains — carrying consumer, closingPath, predicate, shapeContract and THREE STATED SCOPE BOUNDARIES (lockless jam, churn jam, sub-interval jam); '
+    + '(4) tests/unit/git/index-jam-detector.test.js + tests/unit/git/index-jam-observer.test.js — 51 tests, verified green live. '
+    + 'The SD was cut 50% at LEAD: it proposed a sweeper that DELETES stale locks, which VALIDATION found was already DECLINED as option (c) in SD-REFILL-00KUKQVS, already owned by open QF-20260727-502, and — decisively — resting on a predicate MEASURED FALSE (a live healthy `git add` holds a ZERO-BYTE index.lock for its entire duration, so neither presence nor zero-size distinguishes a jam from healthy work). PR #6623, +882/-0 across 6 files. '
+    + 'IT IS NOT YET WIRED: periodic_process_registry.currently_expected_active=false with an activation_note, so it catches nothing until a scheduler entry exists.',
+  affected_components: [
+    'lib/git/index-jam-detector.js',
+    'scripts/cron/index-jam-detector.mjs',
+    'lib/governance/gauge-registry.js',
+  ],
+  related_files: [
+    'lib/git/index-jam-detector.js',
+    'scripts/cron/index-jam-detector.mjs',
+    'lib/governance/gauge-registry.js',
+    'tests/unit/git/index-jam-detector.test.js',
+    'tests/unit/git/index-jam-observer.test.js',
+    'lib/periodic-liveness/stamp-last-fired.js',
+    'lib/git/clear-stale-index-lock.mjs',
+    'tests/helpers/db-target.js',
+    '.gitignore',
+  ],
+  related_commits: [
+    'ab826273635', // feat: detect a jammed shared git index by persistence, not lock presence
+    '62697b1317d', // fix: close four confirmed alarm-suppression paths found at EXEC
+    '47d79da55bd', // test: assert the read-only guarantee and the observer seams
+    'c83a9b3961b', // fix: close the tick-interval gap and three more suppression paths
+    'd4d64941145', // test: protect the degradation guard; state the tick test's real reach
+  ],
+  related_prs: ['https://github.com/rickfelix/EHG_Engineer/pull/6623'],
+  tags: ['detector', 'git', 'alarm-suppression', 'false-predicate', 'mutation-testing', 'scope-cut', 'detection-only'],
+
+  what_went_well: [
+    'A 50% SCOPE CUT AT LEAD, ON MEASUREMENT RATHER THAN OPINION. The SD proposed a sweeper that DELETES stale locks. VALIDATION found three independent disqualifiers: it was already DECLINED as option (c) in SD-REFILL-00KUKQVS; it was already owned by open QF-20260727-502; and — decisively — its predicate was MEASURED FALSE. A live healthy `git add` holds a ZERO-BYTE index.lock for its ENTIRE duration, so neither lock presence nor zero size distinguishes a jam from ordinary work, and a sweeper acting on that predicate would delete the lock out from under a healthy in-flight git process. Scope became detection-only before any code was written.',
+    'THREE PRD DRAFTS WERE REJECTED AT PLAN BECAUSE THE INSTRUMENT WAS MEASURED, NOT ARGUED ABOUT. Each draft assumed `git update-index --refresh` could answer "is the index writable". It exits 1 on a merely DIRTY tree (the shared root is chronically dirty, so the detector would alarm permanently), and it exits 0 during a real jam with a stat-clean index in 5/5 runs while real `git add`/`git commit` failed 128. During a LIVE HEALTHY add it returns 128 too — identical to the orphan case. Five non-destructive discriminators (open r, open r+, open a, exclusive create, size) all returned identical results in both states. That measurement is what forced the redesign onto persistence.',
+    'THE DWELL FLOOR WAS DERIVED FROM MEASUREMENT, NOT PICKED. Healthy ceiling: `git add -A` of 5000 files holds the lock ~40.0s, of 12000 files ~44.2s — the curve FLATTENS, so the 5000 figure was first-bulk-add cost rather than file count, which is why the ceiling is stable enough to derive from. Real-jam floor: the shortest recorded genuine jam was 7 minutes. 90s gives ~2x headroom over the ceiling and sits far under the shortest jam; anything under 60s false-positives on healthy bulk work. Git HOOKS were separately measured out as a constraint (an 8s sleeping pre-commit hook held no lock at any sample — git runs hooks BEFORE acquiring), which mattered because .husky/pre-commit runs vitest.',
+    'THE DETECTOR IS DISQUALIFIED FROM CAUSING THE INCIDENT, AND THAT IS ENFORCED BY TEST. Acquiring the lock to test it (`--force-write-index`) was rejected at design: a detector killed mid-write leaves exactly the orphan lock that IS the incident. TS-5/TS-13 in tests/unit/git/index-jam-observer.test.js assert this rather than assuming it — no index.lock is created when observing a lockless repo, an EXISTING lock is left byte-identical, and a write-spy confirms NO destructive fs call is made during observation.',
+    'MUTATION TESTING CAUGHT WHAT 51 GREEN TESTS DID NOT — THREE SEPARATE TIMES. Two vacuous tests and an unprotected degradation guard all survived a fully green suite and were killed only by mutating the implementation. Every load-bearing behaviour that now has a test has one because a mutant proved the absence, not because the plan said so.',
+    'RUNNING THE THING FOUND A BUG NO UNIT TEST COULD. Actual exit codes were 127, not 0/1: process.exit() raced libuv teardown against the open supabase handle from stampLastFired (UV_HANDLE_CLOSING assertion). The entire shape contract — readers key on the EXIT CODE — was broken while every function-level test passed. Fixed by setting process.exitCode and returning (scripts/cron/index-jam-detector.mjs:158-163), with the reason recorded inline so it is not "simplified" back.',
+    'THE DETECTOR REGISTERS ITS OWN DRAIN OBLIGATION AND ITS OWN LIVENESS. A DRAIN_DESCRIPTORS entry in lib/governance/gauge-registry.js names the consumer, the closing path, the predicate and a shapeContract that points readers at the exit code rather than at parsing the message — so this detector cannot become an instance of the class its sibling SD-LEO-INFRA-DETECTOR-OUTPUT-DRAIN-001 was chartered to close. It also self-stamps periodic_process_registry (liveness_source=self_stamped), non-fatally, matching gauge-runner.mjs:517-519.',
+    'THE SCOPE BOUNDARIES ARE STATED, NOT LEFT IMPLICIT. The descriptor enumerates THREE real ways this reports HEALTHY while something is wrong: LOCKLESS JAM (corrupt index, broken .git permissions, disk full — it keys on lock presence, so there is nothing to observe; defensible because all six recorded incidents were stale-lock jams), CHURN JAM (locks repeatedly appearing and clearing; identity changes each time so persistence never accumulates — indistinguishable BY DESIGN from the sustained healthy activity TS-17a exists to protect), and SUB-INTERVAL JAM (effective floor is max(dwell, 2 x tick)). A reader learns the detector\'s blind spots from the detector\'s own registration.',
+    'THE PURE/IO SPLIT WAS LOAD-BEARING, NOT STYLISTIC. classifyIndexHealth is state-in/state-out specifically so every persistence test runs in the `unit` tier. The `db` vitest project resolves to ZERO files (tests/helpers/db-target.js DESIGNATED_NON_PROD_REFS is intentionally empty — "0 of 225 db tests will run"), so a DB-tier persistence test would have been silently green and indistinguishable from having no coverage at all.',
+    'THE INTERVAL FIX WAS RECORDED WHERE IT CAN BE READ, NOT JUST APPLIED. periodic_process_registry.liveness_source_ref carries an interval_rationale explaining WHY 60s and not 1800s (the effective-floor derivation) and an activation_note explaining why currently_expected_active=false. A future editor changing the interval sees the derivation on the row they are editing.',
+    'NO REGRESSIONS AND A VERIFIED COUNT: 51 tests across 2 files, run live and green, against a +882/-0 purely additive PR (#6623) that touches no existing behaviour — the gauge-registry change is a new key in an existing frozen export.',
+  ],
+
+  what_needs_improvement: [
+    'I REGISTERED A CONFIG VALUE THAT MADE THE SHORTEST RECORDED MEMBER OF THE CLASS STRUCTURALLY UNDETECTABLE. Detection requires the SAME lock identity at TWO consecutive ticks, so the EFFECTIVE floor is max(dwell, 2 x tick) — not the dwell. I registered expected_interval_seconds=1800, making the effective floor 3600s against a 420s shortest recorded jam. The carefully derived 90s dwell was INERT: it could never be the binding constraint. The detector would have caught only the ~3h outage that motivated the SD and missed most of the class it was chartered to detect. Fixed to 60s (effective floor 120s) in c83a9b3961b.',
+    'v1.1 SHIPPED A PRESENCE-ONLY DETECTOR — MY OWN DESIGN DEFECT, AND IT WOULD HAVE FIRED ON HEALTHY WORK. Six back-to-back healthy `git add`s left a lock present at 12 of 12 ticks across FOUR DISTINCT identities. A presence-only detector calls that JAMMED. The measurement that killed the ORIGINAL sweeper (a healthy add holds a lock the whole time) was in the design notes and I still built the detector on presence. Fixed with identity-gated persistence via lockIdentityOf = `${mtimeMs}:${ino}`.',
+    'MY OWN ACCEPTANCE CRITERION FORBADE THE FIX. v1.1 banned lock mtime OUTRIGHT, conflating two different things: age-as-verdict (unsound — the measurably-false predicate this detector exists to avoid) and mtime-as-IDENTITY (a sameness comparison, and the only continuity signal available). The ban was written at the level of the FIELD rather than the INFERENCE, so it forbade the correct use with the authority of an acceptance criterion, and the fix required amending my own AC mid-EXEC.',
+    'FOUR ALARM-SUPPRESSION PATHS WERE FOUND AT EXEC BY TESTING AND SECURITY — NOT BY ME AT PLAN. (a) cwd-dependent state path: same repo, same held lock, two different cwds gave JAMMED then HEALTHY MID-JAM, and Windows Task Scheduler defaults "Start in" to %SystemRoot%\\system32, so every scheduled run would have used a different state file from every manual run — the single likeliest route to a detector green forever during a real outage. (b) poisoned/non-numeric firstBlockedAtMs: `heldForMs >= dwellMs` false forever, 6 of 6 ticks HEALTHY against a real held lock, written straight back each tick, and it NEVER self-heals because identity does not change during a genuine jam. (c) unvalidated --dwell-ms: NaN makes every comparison false — 20 ticks over 10 simulated minutes of one held lock, all HEALTHY. (d) a PRUNED worktree: the .git pointer target is gone, so statting <gitDir>/index.lock returns ENOENT, which reads as "successful observation, lock absent" and reports HEALTHY FOREVER — with 17 worktrees present, this is an ordinary git state. My PLAN reasoning covered the DETECTION logic thoroughly and the DEPLOYMENT surface (cwd, scheduler defaults, corrupt state, CLI arg validation, worktree topology) not at all.',
+    'ACROSS THREE ROUNDS THE NEWEST FIX SHIPPED UNTESTED, EVERY TIME. The commit sequence is feat(ab826273635) -> fix(62697b1317d) -> test(47d79da55bd) -> fix(c83a9b3961b) -> test(d4d64941145). The fixes were RIGHT; the tests for them landed one round later, and mutation — not the suite — is what surfaced the gap each round. At every handoff-shaped moment in this SD, the code most likely to be wrong (the newest) had the least coverage, while a reviewer sampling the suite would have seen high coverage of everything else.',
+    'TWO VACUOUS TESTS, AND THE SECOND REINTRODUCED THE CLASS I HAD JUST FIXED. Both were fixtures naming a guard they could never REACH, because an earlier branch discarded the input first — the assertion passed on the early-return path and would have passed with the guard deleted. The second one landed in the same round as the fix for the first. Knowing the failure class did not prevent reproducing it; only mutation caught either.',
+    'THE TICK TEST LOOKS LIKE COVERAGE AND ISN\'T. tests/unit/git/index-jam-detector.test.js:294 compares DEFAULT_TICK_MS against two literals in the same file, but DEFAULT_TICK_MS is consumed by NOTHING operational — the value that actually sets the cadence is periodic_process_registry.expected_interval_seconds, and no code links the two. The deployed interval could regress to exactly the 1800s defect this SD just fixed with the suite fully green. Guarding the link needs a DB read the unit tier deliberately cannot do. The limit is declared in the test body rather than left to look like protection it does not provide.',
+    'THE ANTI-SUPPRESSION FIX WAS ITSELF A SUPPRESSION RISK, AND THE GUARD THAT PREVENTS IT LOOKS LIKE DEAD CODE. applyPersistenceDegradation downgrades to UNAVAILABLE when carry-over state cannot be persisted (measured pre-fix: exit 0 / HEALTHY on 4 of 4 ticks against a real held lock with <repo>/.claude unwritable). Without the `result.verdict !== JAMMED` guard, a CONFIRMED jam would be downgraded to UNAVAILABLE/exit 0 — active suppression, in the exact scenario the fix was written for, and the trigger is CORRELATED (disk-full can both orphan an index.lock and block the state write). The guard reads like a redundant condition and needed its own protecting test (d4d64941145).',
+    'THE SD DELIVERS DETECTION AND NOTHING ELSE, AND NOTHING SCHEDULES IT YET. currently_expected_active=false. Today it catches zero jams. Even once scheduled, a confirmed jam still requires a human to clear the lock, so MTTR on the ~3h class improves only to the extent a person reads the alarm — the exit code currently has no routed reader.',
+  ],
+
+  key_learnings: [
+    'MEASURE THE PREDICATE BEFORE BUILDING ON IT — a remedy\'s core predicate is a factual claim about the world, and everything downstream inherits it. The proposed sweeper rested on "an index.lock present (and zero-byte) past N seconds is stale". Measurement killed it outright: a live healthy `git add` holds a ZERO-BYTE index.lock for its ENTIRE duration, so the very field the proposal used as its discriminator is shared by the healthy case, and the sweeper would have deleted locks out from under running git processes. Cost of measuring: one experiment at LEAD. Cost of not measuring: a destructive tool built on a false premise. The same pass also found the work already DECLINED (SD-REFILL-00KUKQVS option c) and already owned (QF-20260727-502) — a duplicate-work check and a predicate check are both cheap relative to what they prevent.',
+    'A PROBE THAT IS WRONG IN BOTH DIRECTIONS IS NOT A TUNING PROBLEM — IT IS THE WRONG SIGNAL CLASS. `git update-index --refresh` exits 1 on a merely dirty tree (permanent false alarm on a chronically dirty shared root) AND exits 0 during a real jam with a stat-clean index in 5/5 runs while real `git add` failed 128 (a clean bill of health during the outage). No threshold fixes both directions at once. Five non-destructive discriminators all returned IDENTICAL results in the jammed and the live-healthy states, which is the formal statement of the problem: a single-shot probe carries exactly the information "a lock exists" and zero discriminating power. When both error directions are present simultaneously, stop tuning the instrument and change what you measure — here, from an instantaneous state to PERSISTENCE OF A STABLE IDENTITY OVER TIME.',
+    'PRESENCE IS NOT PERSISTENCE. "Condition observed at every sample" is NOT "condition persisted" when the underlying resource churns. Six healthy `git add`s produced a lock present at 12 of 12 ticks across FOUR DISTINCT identities; a presence-only detector calls that a jam. The fix is to carry an IDENTITY across samples rather than a boolean, and to accumulate the counter only while the identity is unchanged (classifyIndexHealth\'s sameLock test). Any detector whose signal is "still there" must be able to answer "still the SAME one" — otherwise sustained healthy throughput is indistinguishable from a stuck resource, and the busier the system the more confidently it false-alarms.',
+    'THE OBVIOUS IDENTITY FIELD CAN BE THE WRONG ONE, SILENTLY. birthtime is the natural choice for "is this the same file", and on NTFS it is a trap: three files created ~1.2s apart with THREE DIFFERENT INODES all reported an IDENTICAL birthtimeMs (file tunneling). Using it would have rebuilt the exact false positive that identity-gating exists to remove, while looking more correct than the (mtimeMs, ino) pair actually used. Platform-specific identity semantics must be MEASURED on the target platform, and — because the wrong choice looks obviously right — the rejection has to be written at the definition site (lib/git/index-jam-detector.js:56-58) or the next reader will "fix" it back.',
+    'WRITE ACCEPTANCE CRITERIA AGAINST THE UNSOUND INFERENCE, NEVER AGAINST THE FIELD. My v1.1 AC banned lock mtime outright. That conflated age-as-verdict (unsound: "the lock is old, therefore jammed") with mtime-as-identity (a pure sameness comparison, and the only continuity signal available). A field-level ban is strictly over-broad — it forbids the sound use along with the unsound one, and because it is an ACCEPTANCE CRITERION it does so with authority, so the correct fix arrives looking like a violation. Heuristic adopted: when a criterion blocks a fix that is clearly right, suspect the criterion names a PROXY (the field) rather than the thing it meant to forbid (the inference).',
+    'A DETECTOR\'S DEPLOYMENT CONFIG CAN SILENTLY DEFEAT ITS OWN DERIVATION — DERIVE THE COMPOSITE, NOT THE CONSTANT. The 90s dwell was derived properly (2x headroom over a measured 44.2s healthy ceiling, well under the 420s shortest recorded jam). But sensitivity is a function of BOTH the dwell and the tick: detection needs the same identity at two consecutive ticks, so the effective floor is max(dwell, 2 x tick). At the registered 1800s interval the effective floor was 3600s — the SHORTEST RECORDED MEMBER OF THE CLASS was structurally undetectable and the derived dwell was inert, unable ever to bind. The two values also live in DIFFERENT SYSTEMS (a code constant and a DB row), so neither system\'s tests could see the interaction. Whenever a threshold and a sampling rate combine, state the composite formula explicitly and validate the deployed pair against the smallest real instance of the class.',
+    'FOR A DETECTOR, ALL THE ASYMMETRIC RISK IS ON THE SUPPRESSION SIDE — ENUMERATE THE PATHS BY WHICH THE ALARM NEVER FIRES, AND REPRODUCE EACH. Four were found here, each confirmed by experiment rather than argument: a cwd-relative state path (JAMMED then HEALTHY mid-jam across two cwds; Windows Task Scheduler defaults "Start in" to system32, so scheduled and manual runs would never share state); a poisoned firstBlockedAtMs that suppresses FOREVER with no self-heal because identity does not change during a real jam; an unvalidated --dwell-ms whose NaN makes every comparison false (20 ticks, all HEALTHY); and a pruned worktree whose ENOENT reads as "lock absent" and reports HEALTHY forever. A false alarm is loud and gets fixed. A suppressed alarm is INDISTINGUISHABLE FROM HEALTH in every artifact the system produces — including in the retrospective that would have been written about the next outage.',
+    'AN ANTI-SUPPRESSION FIX IS ITSELF A SUPPRESSION RISK — CHECK IT AGAINST THE CASE WHERE THE FINDING IS ALREADY PROVEN. applyPersistenceDegradation correctly refuses to report health when carry-over state cannot be persisted (persistence IS the signal). But applied unconditionally it would downgrade a CONFIRMED jam to UNAVAILABLE/exit 0, converting the anti-suppression fix into active suppression in precisely the correlated scenario it was written for (disk-full can both orphan an index.lock and block the state write). The `verdict !== JAMMED` guard is what makes it safe, and it reads like a redundant condition, so it needed its own protecting test. General rule: any "degrade to not-a-health-verdict" mechanism must be evaluated against an already-established finding, because degradation and suppression are the same operation applied to different inputs.',
+    'FIXES RIGHT, TESTS TRAILING BY ONE ROUND — the structural pattern a reviewer caught across THREE rounds of this SD (feat -> fix -> test -> fix -> test). The fixes were correct every time, which is exactly what makes the pattern dangerous: quality of the fixes was never the issue, COVERAGE OF THE NEWEST CODE was, and it was zero at every moment the work could have been reported done. A reviewer sampling the suite sees strong coverage of everything except the part most likely to be wrong, and mutation testing was the only thing that surfaced it — three times. Rule adopted: a fix commit is not complete without its killing test in the SAME commit; if the test must trail, the fix is not ready to be reported as done.',
+    'A TEST THAT COMPARES TWO LITERALS IN THE SAME FILE IS A TEST OF DOCUMENTATION, NOT OF BEHAVIOUR — AND IT LOOKS IDENTICAL TO COVERAGE. The tick assertion pins DEFAULT_TICK_MS, but nothing operational consumes DEFAULT_TICK_MS; the deployed cadence is periodic_process_registry.expected_interval_seconds and no code links them, so the interval could regress to the exact 1800s defect just fixed with the suite green. The generalizable check is: name the RUNTIME PATH that reads the constant under test. If there is none, the test guards a comment. When the real link cannot be tested in the available tier (a DB read, here, where the db tier resolves to zero files), DECLARE the limit in the test body — an unstated gap in a green suite is a false assurance, a stated one is a finding with an owner.',
+    'A GUARD-TARGETING TEST MUST ASSERT THE GUARD WAS REACHED, NOT MERELY THAT THE OUTCOME MATCHES. Both vacuous tests here named a guard their fixture could never reach, because an earlier branch discarded the input first — so the assertion passed on the early-return path and would have passed with the guard deleted. The outcome a guard produces is frequently ALSO the outcome produced by never getting there, which is why these read as legitimate. The concrete fix pattern is to construct the fixture so the preceding branches provably fall through (each state fixture carries lockIdentity \'A\' so sameLock is TRUE on the next tick — index-jam-detector.test.js:188). The sharper half of this lesson: I reintroduced the class in the SAME ROUND that fixed it. Knowing a failure class does not prevent reproducing it; only mutation caught either instance.',
+    'THE CONTRACT AT THE PROCESS BOUNDARY IS COVERED BY NO TEST OF THE FUNCTIONS INSIDE IT — RUN THE COMMAND AND READ THE ACTUAL EXIT CODE. Real exit codes were 127, not 0/1: process.exit() raced libuv teardown against the open supabase handle from stampLastFired (UV_HANDLE_CLOSING). The shape contract explicitly tells readers to key on the exit code, so the detector\'s entire output channel was broken while exitCodeFor and every other unit passed. A scheduler cannot act on "command not found" for a healthy tree. Exit codes, stdout shape and stream flush are produced by the PROCESS, not by the functions under test; they need a process-level smoke invocation.',
+    'A PROBE THAT CAN CREATE THE CONDITION IT DETECTS IS DISQUALIFIED REGARDLESS OF ITS ACCURACY. Acquiring the lock to test writability (`--force-write-index`) would, if the detector were killed mid-write, leave exactly the orphan index.lock that IS the incident — a detector that manufactures outages during the incidents it exists to observe. The strictly-observational alternative is weaker (it cannot see a lockless jam) and that was the correct trade. Because "just try to acquire it" is the intuitive design, the read-only property is enforced by test (write-spy, byte-identical existing lock, no lock created) rather than by intent.',
+    'DECLARING A DETECTOR "REGISTERED BUT NOT SCHEDULED" IS HONEST AND STILL LEAVES ZERO COVERAGE. currently_expected_active=false correctly stops the liveness watcher raising a false OVERDUE about a detector nothing runs, and the activation_note says exactly what to flip and when. But the honest registration and the working detector together still catch nothing: shipping the DETECTION LOGIC is not shipping DETECTION. The gap between "the code is correct and merged" and "the condition would now be caught" is a scheduler entry and a routed reader of the exit code — and that gap is invisible in the PR, in the test results, and in the merge.',
+  ],
+
+  action_items: [
+    {
+      title: 'SCHEDULE THE DETECTOR — nothing runs it today, so it catches zero jams',
+      description: 'periodic_process_registry.standard_loop:index-jam-detector has currently_expected_active=false with an activation_note. Until a scheduler entry exists, this SD has shipped detection LOGIC and zero detection. Add a Windows Task Scheduler entry running `node scripts/cron/index-jam-detector.mjs --repo <shared root>` at 60s, and — critically, given the cwd suppression path measured in this SD — set an EXPLICIT "Start in" directory rather than accepting the %SystemRoot%\\system32 default, and pass --repo explicitly (observeIndexLock throws rather than defaulting to cwd, by design). Flip currently_expected_active=true in the SAME change so the liveness watcher begins guarding it the moment it becomes real. Verification: a manual jam simulation (hold a lock >120s) produces exit 1 from the SCHEDULED run, not just from a manual one.',
+      priority: 'critical',
+      owner_role: 'EXEC',
+      deadline: 'next session',
+      verification: 'Scheduled task exists; currently_expected_active=true; a held-lock simulation yields exit 1 from the scheduled invocation and last_fired_at advances every ~60s.',
+    },
+    {
+      title: 'Route the non-zero exit to a reader — an unread alarm is the sibling SD\'s finding',
+      description: 'The DRAIN_DESCRIPTORS entry names "the scheduled cron tick itself" as consumer and the exit code as the shape contract, but no human-visible surface currently receives it. A jam confirmed at 03:00 with nobody notified reproduces the original incident (~3h frozen tree) minus only the ignorance. Wire the non-zero exit into whatever surface the seat actually watches, and record the concrete reader in the descriptor\'s consumer field, replacing the current self-referential wording. This is what makes this SD not become an instance of SD-LEO-INFRA-DETECTOR-OUTPUT-DRAIN-001.',
+      priority: 'high',
+      owner_role: 'LEAD',
+      deadline: 'with the scheduler entry',
+      verification: 'A simulated JAMMED verdict produces a message on the routed surface; the descriptor names that surface.',
+    },
+    {
+      title: 'Guard the tick-interval link with a check that can actually read the deployed value',
+      description: 'The unit test at tests/unit/git/index-jam-detector.test.js:294 pins DEFAULT_TICK_MS, which nothing operational consumes; the deployed cadence is periodic_process_registry.expected_interval_seconds and no code links the two, so a regression to 1800s (the exact defect fixed in c83a9b3961b) passes the suite green. Add a DB-reading assertion — in the gauge/liveness tier or as a startup self-check in scripts/cron/index-jam-detector.mjs — that fails when 2 x expected_interval_seconds x 1000 exceeds min(DEFAULT_DWELL_MS-equivalent, the 420s shortest recorded jam). A startup self-check is preferable: it runs in the deployed environment, which is the only place the real value lives.',
+      priority: 'high',
+      owner_role: 'PLAN',
+      deadline: 'before the detector is relied upon',
+      verification: 'Setting expected_interval_seconds to 1800 makes the check fail; setting it to 60 passes.',
+    },
+    {
+      title: 'Adopt fix-and-its-killing-test-in-the-same-commit for detector work',
+      description: 'Three rounds of this SD shipped the newest fix untested (feat ab826273635 -> fix 62697b1317d -> test 47d79da55bd -> fix c83a9b3961b -> test d4d64941145), with mutation rather than the suite catching the gap each time. The fixes were correct, which is what made the pattern invisible. Encode the rule for detector/guard changes specifically, where the failure mode is silent suppression: a fix commit lands with the test that would have caught the defect, and if the test must trail, the fix is not reported as done. Pair it with the standing practice of mutating any newly added guard before calling a suite sufficient.',
+      priority: 'high',
+      owner_role: 'EXEC',
+      deadline: 'immediate — process change',
+      verification: 'Next detector SD shows no fix commit without a co-located test; spot-check by mutating the newest guard and confirming a kill.',
+    },
+    {
+      title: 'Add a process-level exit-code smoke check to CI or the startup path',
+      description: 'The exit-127 bug (process.exit() racing libuv teardown against stampLastFired\'s open supabase handle) was invisible to all 51 unit tests because the exit code is produced by the PROCESS, not by exitCodeFor. Add a smoke invocation that actually runs `node scripts/cron/index-jam-detector.mjs --repo <fixture>` and asserts the real exit status for HEALTHY (0), JAMMED (1) and missing --repo (2). Without it, any future addition of an async handle to main() can silently reintroduce a non-actionable exit code — and the shape contract tells readers to key on exactly that value.',
+      priority: 'high',
+      owner_role: 'EXEC',
+      deadline: 'next detector change',
+      verification: 'The smoke check fails if process.exit() is reintroduced in scripts/cron/index-jam-detector.mjs.',
+    },
+    {
+      title: 'Decide the observed-tree set — 17 worktrees, and only the shared root is covered',
+      description: 'resolveGitDir handles both a .git DIRECTORY (main root) and a .git FILE (worktree gitdir pointer), and correctly maps a PRUNED worktree to UNAVAILABLE rather than HEALTHY, but nothing decides WHICH trees get observed. The recorded incidents were in the shared root, so starting there is right; the decision (and its rationale) should be explicit rather than an artifact of whichever --repo the first scheduler entry happened to name. Note globbing all 17 is explicitly cautioned against in the code comments as a noise source.',
+      priority: 'medium',
+      owner_role: 'PLAN',
+      deadline: 'after the scheduler entry exists',
+      verification: 'The observed-tree set and its rationale are recorded on the periodic_process_registry row alongside interval_rationale.',
+    },
+    {
+      title: 'Leave the LOCKLESS-JAM boundary open deliberately, and revisit if an incident lands outside the lock class',
+      description: 'The detector keys on lock presence, so a corrupt index, broken .git permissions or disk full produces no observation at all — stated as boundary 1 in the DRAIN_DESCRIPTORS entry. This is defensible today because all six recorded incidents (five on 2026-07-27, one on 2026-07-26, class dating to 2026-06-14) were stale-lock jams. It stops being defensible the first time a jam has no lock. Track it as a stated boundary with a trigger rather than as backlog: if any future git-freeze incident shows no index.lock, this detector is not the right instrument for it and a separate signal is needed.',
+      priority: 'low',
+      owner_role: 'LEAD',
+      deadline: 'trigger-based',
+      verification: 'A future git-freeze incident is checked against the boundary list before this detector is blamed for missing it.',
+    },
+    {
+      title: 'Close the loop with the already-open QF-20260727-502 on lock REMEDIATION',
+      description: 'This SD was deliberately cut to detection only; removal of a stale lock was declined as option (c) in SD-REFILL-00KUKQVS and is owned by open QF-20260727-502. Now that a sound discriminant exists (a jam CONFIRMED by identity-stable persistence past the dwell floor, rather than mere lock presence), the remediation question is materially different from when it was declined — the measured objection was that no sound predicate existed, and there now is one. Feed this detector\'s verdict into that QF\'s design rather than letting the two proceed independently, and note that any remediation must still never act on a single-tick observation.',
+      priority: 'medium',
+      owner_role: 'LEAD',
+      deadline: 'when QF-20260727-502 is next picked up',
+      verification: 'QF-20260727-502 references classifyIndexHealth\'s JAMMED verdict as its trigger condition rather than lock presence or lock age.',
+    },
+  ],
+
+  success_patterns: [
+    'Measure the remedy\'s core predicate at LEAD, before PLAN inherits it — one experiment killed a destructive sweeper design and cut scope 50%.',
+    'When a probe errs in BOTH directions, change the signal class rather than the threshold: instantaneous state -> persistence of a stable identity over time.',
+    'Derive thresholds from measured ceilings and measured floors (44.2s healthy ceiling, 420s shortest real jam), and record the derivation where the value is edited.',
+    'Disqualify any probe that can create the condition it detects; enforce read-only with a write-spy test, not with intent.',
+    'Mutate every newly added guard — 51 green tests hid two vacuous tests and one unprotected guard.',
+    'Run the actual command and read the actual exit code; process-boundary contracts are invisible to function-level tests.',
+    'Register a new detector\'s drain obligation and its own liveness at birth, and state its blind spots in the registration.',
+  ],
+
+  failure_patterns: [
+    'A deployment config in a different system from the constant it interacts with (DB interval vs code dwell) silently defeated the derivation — neither system\'s tests could see the composite.',
+    'Presence-only detection on a churning resource: a lock present at 12/12 ticks across 4 identities reads as a jam.',
+    'An acceptance criterion written against a FIELD (lock mtime) rather than an INFERENCE (age-as-verdict) forbade its own correct fix.',
+    'Anti-suppression logic applied unconditionally becomes suppression when the finding is already proven.',
+    'Fixes correct, tests trailing one round, three rounds running — coverage of the newest code was zero at every reportable moment.',
+    'Guard-targeting tests whose fixtures could not reach the guard, passing on an early-return path; the class was reintroduced in the same round it was fixed.',
+    'A test pinning a constant that no runtime path consumes, indistinguishable from real coverage.',
+    'Shipping correct detection logic with no scheduler entry: merged, green, and catching nothing.',
+  ],
+
+  objectives_met: true,
+  within_scope: true,
+  on_schedule: true,
+  tests_added: 51,
+  technical_debt_addressed: true,
+  technical_debt_created: true,
+  business_value_delivered:
+    'Detection-only coverage for a recurring shared-resource outage class that previously had ZERO instruments — at least six incidents, the longest ~25h. DEBT CLOSED: a stale .git/index.lock froze the shared tree for ~3h (and in the wider class ~10h, leaving it 46 commits behind origin; 25h on 2026-06-14, leaving it 125 commits behind) with nothing watching, because the claim sweep and drain gauge read DB state and the worktree reaper runs `git worktree list --porcelain`, which never touches the index and so kept reporting git healthy throughout every incident. '
+    + 'DEBT CREATED: the detector is registered but NOT SCHEDULED (currently_expected_active=false), so it catches nothing until a scheduler entry exists; its exit code has no routed human reader; and the deployed tick interval (periodic_process_registry.expected_interval_seconds) is linked by no check to DEFAULT_TICK_MS, so it can regress to the 1800s defect with the suite green. Three blind spots remain BY DESIGN and are stated in the DRAIN_DESCRIPTORS entry: lockless jams, churn jams, and jams shorter than max(dwell, 2 x tick). '
+    + 'Until the scheduler entry and a reader land, the delivered value is the measurement record (which discriminants do and do not work) plus a sound, tested discriminant — not caught jams.',
+  customer_impact:
+    'None yet, by construction. The seat that loses ~3h to a frozen shared tree sees no change until scripts/cron/index-jam-detector.mjs is scheduled and its non-zero exit reaches a surface someone watches. Once wired, a confirmed jam is named as a SHARED-RESOURCE condition with the tree and the duration ("not a fault in your command"), which is the specific misattribution that made prior incidents cost hours: each blocked seat read the git failure as its own.',
+
+  metadata: {
+    sd_key: SD_KEY,
+    pr: 6623,
+    branch: 'feat/SD-LEO-INFRA-JAMMED-GIT-INDEX-001',
+    diff: '+882/-0 across 6 files',
+    tests: { files: 2, passed: 51, tier: 'unit', verified_live: true },
+    scope_cut_at_lead: '50% — sweeper/deletion removed; detection only',
+    scope_cut_basis: [
+      'already DECLINED as option (c) in SD-REFILL-00KUKQVS',
+      'already owned by open QF-20260727-502',
+      'predicate MEASURED FALSE: a live healthy `git add` holds a ZERO-BYTE index.lock for its entire duration',
+    ],
+    prd_drafts_rejected_at_plan: 3,
+    suppression_paths_closed: 4,
+    not_yet_active: {
+      process_key: 'standard_loop:index-jam-detector',
+      currently_expected_active: false,
+      last_state: 'INTENTIONALLY_DOWN',
+      blocker: 'no scheduler entry exists — the detector catches nothing until one does',
+    },
+    interval_defect: {
+      registered_wrong: 1800,
+      corrected_to: 60,
+      effective_floor_formula: 'max(dwell, 2 x tick)',
+      wrong_effective_floor_s: 3600,
+      shortest_recorded_jam_s: 420,
+      consequence: 'the shortest recorded member of the class was structurally undetectable and the derived 90s dwell was inert',
+    },
+  },
+};
+
+async function main() {
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const { data, error } = await supabase.from('retrospectives').insert(retro).select('id, retro_type, quality_score, created_at').single();
+  if (error) {
+    console.error('INSERT FAILED:', error.message);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`Inserted SD_COMPLETION retrospective ${data.id} for ${SD_KEY}`);
+  console.log(`  retro_type=${data.retro_type} quality_score=${data.quality_score} created_at=${data.created_at}`);
+  console.log(`  gate cutoff was 2026-07-28T01:35:01.887Z — created_at is ${new Date(data.created_at) > new Date('2026-07-28T01:35:01.887Z') ? 'AFTER (passes)' : 'BEFORE (FAILS)'}`);
+}
+
+main();

--- a/tests/unit/git/index-jam-detector.test.js
+++ b/tests/unit/git/index-jam-detector.test.js
@@ -13,7 +13,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   VERDICT, DEFAULT_DWELL_MS, DEFAULT_TICK_MS, classifyIndexHealth, lockIdentityOf, exitCodeFor, formatVerdict,
-  sanitizeState, sanitizeDwellMs,
+  sanitizeState, sanitizeDwellMs, applyPersistenceDegradation,
 } from '../../../lib/git/index-jam-detector.js';
 
 const T0 = Date.parse('2026-07-28T00:00:00.000Z');
@@ -246,6 +246,37 @@ describe('ALARM SUPPRESSION — corrupt carry-over state must never read as heal
   });
 });
 
+describe('applyPersistenceDegradation — the anti-suppression fix must not itself suppress', () => {
+  const healthy = { verdict: VERDICT.HEALTHY, jammedForMs: null, nextState: {} };
+  const jammed = { verdict: VERDICT.JAMMED, jammedForMs: 120 * SEC, nextState: {} };
+
+  it('passes everything through untouched when state persisted', () => {
+    expect(applyPersistenceDegradation(healthy, true)).toBe(healthy);
+    expect(applyPersistenceDegradation(jammed, true)).toBe(jammed);
+  });
+
+  it('degrades HEALTHY to UNAVAILABLE when state could NOT be persisted', () => {
+    // Because persistence is the signal, a counter that cannot reach the next tick makes the
+    // verdict worthless. Measured pre-fix: exit 0 on 4 of 4 ticks against a real held lock.
+    const r = applyPersistenceDegradation(healthy, false);
+    expect(r.verdict).toBe(VERDICT.UNAVAILABLE);
+    expect(r.reason).toMatch(/not trustworthy/i);
+  });
+
+  it('NEVER degrades a CONFIRMED jam — dropping that guard turns the fix into a suppression bug', () => {
+    // Without the verdict !== JAMMED guard, a proven jam becomes UNAVAILABLE and exits 0. An
+    // already-proven jam does not need state to stay proven.
+    const r = applyPersistenceDegradation(jammed, false);
+    expect(r.verdict).toBe(VERDICT.JAMMED);
+    expect(exitCodeFor(r.verdict)).toBe(1);
+  });
+
+  it('leaves an already-UNAVAILABLE verdict alone', () => {
+    const u = { verdict: VERDICT.UNAVAILABLE, jammedForMs: null, nextState: {}, reason: 'EACCES' };
+    expect(applyPersistenceDegradation(u, false).verdict).toBe(VERDICT.UNAVAILABLE);
+  });
+});
+
 describe('the derived dwell floor is pinned, not merely bounded', () => {
   it('is exactly 90s — derived from a ~44.2s healthy ceiling and a 420s shortest real jam', () => {
     // Mutation showed 75s and 61s both survived a range-only assertion. The value carries the
@@ -260,7 +291,12 @@ describe('the derived dwell floor is pinned, not merely bounded', () => {
     expect(DEFAULT_DWELL_MS).toBeLessThan(SHORTEST_REAL_JAM_MS);
   });
 
-  it('TICK must be small enough that the shortest real jam spans multiple ticks', () => {
+  it('TICK constant must be small enough that the shortest real jam spans multiple ticks', () => {
+    // HONESTY NOTE: this pins the CONSTANT, not the deployed cadence. The value that actually sets
+    // the tick rate is periodic_process_registry.expected_interval_seconds (60s, with the rationale
+    // recorded on the row), and no code links the two — so the deployed interval could regress with
+    // this suite green. Guarding that link needs a DB read, which the unit tier deliberately cannot
+    // do. Declared rather than left to look like coverage it is not.
     // Detection needs the SAME identity at two consecutive ticks, so the EFFECTIVE floor is
     // max(dwell, 2 x tick). A 1800s registered interval would make the effective floor 3600s and
     // leave the 420s shortest recorded jam structurally undetectable — the derived 90s inert.

--- a/tests/unit/git/index-jam-detector.test.js
+++ b/tests/unit/git/index-jam-detector.test.js
@@ -13,6 +13,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   VERDICT, DEFAULT_DWELL_MS, classifyIndexHealth, lockIdentityOf, exitCodeFor, formatVerdict,
+  sanitizeState, sanitizeDwellMs,
 } from '../../../lib/git/index-jam-detector.js';
 
 const T0 = Date.parse('2026-07-28T00:00:00.000Z');
@@ -38,10 +39,15 @@ describe('classifyIndexHealth — no lock', () => {
   });
 
   it('an absent lock RESETS an accumulated counter (TS-12, FR-1 AC-6)', () => {
-    // Blocked long enough to be JAMMED, then the lock clears: must not latch.
-    const seq = runTicks([present('A'), present('A'), present('A'), present('A'), absent]);
+    // Blocked long enough to be JAMMED, then the lock clears, then the SAME identity returns.
+    // The tick AFTER the clear is what proves the reset: asserting only the absent tick is
+    // VACUOUS — the absent branch returns HEALTHY unconditionally, so a latching implementation
+    // that carried prior state through the reset passes that weaker assertion identically.
+    // Mutation confirmed it: nextState:emptyState() -> nextState:prior survived the old test.
+    const seq = runTicks([present('A'), present('A'), present('A'), present('A'), absent, present('A')]);
     expect(seq[3]).toBe(VERDICT.JAMMED);
     expect(seq[4]).toBe(VERDICT.HEALTHY);
+    expect(seq[5]).toBe(VERDICT.HEALTHY); // clock restarted — a latching impl reports JAMMED here
   });
 });
 
@@ -155,6 +161,55 @@ describe('exit code contract (TS-8)', () => {
     expect(exitCodeFor(VERDICT.JAMMED)).toBe(1);
     expect(exitCodeFor(VERDICT.HEALTHY)).toBe(0);
     expect(exitCodeFor(VERDICT.UNAVAILABLE)).toBe(0);
+  });
+});
+
+describe('ALARM SUPPRESSION — corrupt carry-over state must never read as healthy', () => {
+  // Each input below was CONFIRMED by experiment to hold a real jam at HEALTHY indefinitely.
+  // These are the failure direction that matters: a detector that is green during the outage.
+  it('rejects a FUTURE firstBlockedAtMs instead of suppressing forever', () => {
+    // Measured: {firstBlockedAtMs: now + 24h} gave HEALTHY on 6 of 6 ticks against a real held
+    // lock, carried forward byte-identical each tick. It never self-heals, because during a
+    // genuine jam the identity never changes.
+    const poisoned = { firstBlockedAtMs: T0 + 86_400_000, lockIdentity: 'A' };
+    const r = classifyIndexHealth(present('A'), T0, poisoned);
+    expect(r.nextState.firstBlockedAtMs).toBe(T0); // clock restarted from now, not the future
+    const later = classifyIndexHealth(present('A'), T0 + 120 * SEC, r.nextState);
+    expect(later.verdict).toBe(VERDICT.JAMMED); // and a real jam still surfaces
+  });
+
+  it('rejects a NON-NUMERIC firstBlockedAtMs (NaN comparison is always false)', () => {
+    const r = classifyIndexHealth(present('A'), T0, { firstBlockedAtMs: 'x', lockIdentity: 'A' });
+    expect(r.nextState.firstBlockedAtMs).toBe(T0);
+    expect(classifyIndexHealth(present('A'), T0 + 120 * SEC, r.nextState).verdict).toBe(VERDICT.JAMMED);
+  });
+
+  it('degrades a garbage state object to start-counting-again, never to permanently-healthy', () => {
+    for (const bad of [null, undefined, 'nonsense', 42, { firstBlockedAtMs: -1 }, { firstBlockedAtMs: 0 }]) {
+      const r = classifyIndexHealth(present('A'), T0, bad);
+      expect(r.verdict).toBe(VERDICT.HEALTHY);
+      expect(classifyIndexHealth(present('A'), T0 + 120 * SEC, r.nextState).verdict).toBe(VERDICT.JAMMED);
+    }
+  });
+
+  it('a NaN or non-positive dwell floor falls back instead of disabling the detector', () => {
+    // Measured: --dwell-ms abc gave NaN, and `heldForMs >= NaN` is always false — 20 ticks over
+    // 10 simulated minutes of one held lock all reported HEALTHY. A 0 floor is the opposite
+    // failure: it rebuilds the presence-only false positive TS-17a disproves.
+    expect(sanitizeDwellMs(Number('abc'))).toBe(DEFAULT_DWELL_MS);
+    expect(sanitizeDwellMs(0)).toBe(DEFAULT_DWELL_MS);
+    expect(sanitizeDwellMs(-5)).toBe(DEFAULT_DWELL_MS);
+    expect(sanitizeDwellMs(45_000)).toBe(45_000); // a legitimate override still works
+
+    let s;
+    const r1 = classifyIndexHealth(present('A'), T0, s, { dwellMs: NaN }); s = r1.nextState;
+    expect(classifyIndexHealth(present('A'), T0 + 30 * SEC, s, { dwellMs: NaN }).verdict).toBe(VERDICT.HEALTHY);
+    expect(classifyIndexHealth(present('A'), T0 + 120 * SEC, s, { dwellMs: NaN }).verdict).toBe(VERDICT.JAMMED);
+  });
+
+  it('sanitizeState preserves a legitimate in-progress count', () => {
+    const good = { firstBlockedAtMs: T0 - 60 * SEC, lockIdentity: 'A' };
+    expect(sanitizeState(good, T0)).toEqual(good);
   });
 });
 

--- a/tests/unit/git/index-jam-detector.test.js
+++ b/tests/unit/git/index-jam-detector.test.js
@@ -1,0 +1,192 @@
+/**
+ * SD-LEO-INFRA-JAMMED-GIT-INDEX-001 — jammed-index detector core.
+ *
+ * The load-bearing property is that PRESENCE IS NOT PERSISTENCE. Measured at PLAN: six back-to-back
+ * healthy `git add`s left a lock present at 12 of 12 ticks across FOUR distinct identities, and all
+ * six completed exit 0. A presence-only classifier reports JAMMED there. TS-17a is the negative
+ * control for exactly that and a presence-only implementation provably fails it.
+ *
+ * FILE EXTENSION IS LOAD-BEARING: this must be .test.js. The unit vitest project admits .test.mjs
+ * only under tests/unit/org/ and tests/unit/venture-email/, so naming it .test.mjs would make it
+ * CI-unreachable and SILENTLY GREEN — the same zero-coverage trap the `db` project represents.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  VERDICT, DEFAULT_DWELL_MS, classifyIndexHealth, lockIdentityOf, exitCodeFor, formatVerdict,
+} from '../../../lib/git/index-jam-detector.js';
+
+const T0 = Date.parse('2026-07-28T00:00:00.000Z');
+const SEC = 1000;
+const present = (id) => ({ lockPresent: true, lockIdentity: id });
+const absent = { lockPresent: false, lockIdentity: null };
+
+/** Drive a tick sequence through the classifier, threading state exactly as the cron does. */
+function runTicks(observations, { startMs = T0, tickMs = 30 * SEC, dwellMs = DEFAULT_DWELL_MS } = {}) {
+  let state; const out = [];
+  observations.forEach((obs, i) => {
+    const r = classifyIndexHealth(obs, startMs + i * tickMs, state, { dwellMs });
+    state = r.nextState; out.push(r.verdict);
+  });
+  return out;
+}
+
+describe('classifyIndexHealth — no lock', () => {
+  it('reports HEALTHY and holds no carry-over state', () => {
+    const r = classifyIndexHealth(absent, T0, undefined);
+    expect(r.verdict).toBe(VERDICT.HEALTHY);
+    expect(r.nextState.firstBlockedAtMs).toBeNull();
+  });
+
+  it('an absent lock RESETS an accumulated counter (TS-12, FR-1 AC-6)', () => {
+    // Blocked long enough to be JAMMED, then the lock clears: must not latch.
+    const seq = runTicks([present('A'), present('A'), present('A'), present('A'), absent]);
+    expect(seq[3]).toBe(VERDICT.JAMMED);
+    expect(seq[4]).toBe(VERDICT.HEALTHY);
+  });
+});
+
+describe('classifyIndexHealth — a single lock persisting (TS-3)', () => {
+  it('is HEALTHY under the dwell floor and JAMMED once it is crossed', () => {
+    // 30s ticks, 90s floor: blocked at t=0 -> JAMMED first at t=90s, the 4th tick.
+    expect(runTicks([present('A'), present('A'), present('A'), present('A')]))
+      .toEqual([VERDICT.HEALTHY, VERDICT.HEALTHY, VERDICT.HEALTHY, VERDICT.JAMMED]);
+  });
+
+  it('reports the duration it was actually held, not the tick count (TS-11, FR-2 AC-3)', () => {
+    let s;
+    let r = classifyIndexHealth(present('A'), T0, s); s = r.nextState;
+    r = classifyIndexHealth(present('A'), T0 + 120 * SEC, s);
+    expect(r.verdict).toBe(VERDICT.JAMMED);
+    expect(r.jammedForMs).toBe(120 * SEC);
+  });
+
+  it('crosses exactly AT the floor, not one tick late', () => {
+    let s;
+    let r = classifyIndexHealth(present('A'), T0, s); s = r.nextState;
+    const justUnder = classifyIndexHealth(present('A'), T0 + DEFAULT_DWELL_MS - 1, s);
+    const exactly = classifyIndexHealth(present('A'), T0 + DEFAULT_DWELL_MS, s);
+    expect(justUnder.verdict).toBe(VERDICT.HEALTHY);
+    expect(exactly.verdict).toBe(VERDICT.JAMMED);
+  });
+});
+
+describe('TS-17a — PRESENCE IS NOT PERSISTENCE (the primary negative control)', () => {
+  it('sustained healthy churn stays HEALTHY though a lock is present at EVERY tick', () => {
+    // Mirrors the measurement: lock present at every tick, identity changing as each add finishes.
+    // Ten ticks at 30s spans 270s, far beyond the 90s floor — a presence-only classifier reports
+    // JAMMED here and fails. This is the assertion that distinguishes this detector.
+    const seq = runTicks([
+      present('A'), present('A'), present('B'), present('B'),
+      present('C'), present('C'), present('D'), present('D'),
+      present('E'), present('E'),
+    ]);
+    expect(seq).toEqual(Array(10).fill(VERDICT.HEALTHY));
+  });
+
+  it('a changed identity RESETS the counter even mid-accumulation (FR-1 AC-7)', () => {
+    const seq = runTicks([present('A'), present('A'), present('A'), present('B'), present('B')]);
+    expect(seq[2]).toBe(VERDICT.HEALTHY);
+    expect(seq[3]).toBe(VERDICT.HEALTHY); // B is a new lock — clock restarts
+    expect(seq[4]).toBe(VERDICT.HEALTHY);
+  });
+
+  it('one long-lived lock JAMS while the same number of ticks of churn does NOT', () => {
+    // Same tick count, same elapsed time — the ONLY variable is identity stability.
+    const jammed = runTicks([present('A'), present('A'), present('A'), present('A')]);
+    const churn = runTicks([present('A'), present('B'), present('C'), present('D')]);
+    expect(jammed).toContain(VERDICT.JAMMED);
+    expect(churn).not.toContain(VERDICT.JAMMED);
+  });
+
+  it('a null identity is never treated as sameness', () => {
+    // Two observations that both fail to yield an identity must not be assumed to be one lock.
+    const seq = runTicks([present(null), present(null), present(null), present(null)]);
+    expect(seq).not.toContain(VERDICT.JAMMED);
+  });
+});
+
+describe('UNAVAILABLE — never health, never a reset (TS-4, TS-18, FR-1 AC-9)', () => {
+  it('an observation error reports UNAVAILABLE rather than HEALTHY', () => {
+    const r = classifyIndexHealth({ error: 'EACCES: permission denied' }, T0, undefined);
+    expect(r.verdict).toBe(VERDICT.UNAVAILABLE);
+    expect(r.verdict).not.toBe(VERDICT.HEALTHY);
+    expect(r.reason).toMatch(/EACCES/);
+  });
+
+  it('PRESERVES the counter through a blip: BLOCKED -> UNAVAILABLE -> BLOCKED still jams', () => {
+    // Without this, recurring transient stat failures mean a real jam is never reported.
+    let s;
+    let r = classifyIndexHealth(present('A'), T0, s); s = r.nextState;
+    r = classifyIndexHealth({ error: 'EBUSY' }, T0 + 30 * SEC, s); s = r.nextState;
+    expect(r.verdict).toBe(VERDICT.UNAVAILABLE);
+    r = classifyIndexHealth(present('A'), T0 + 120 * SEC, s);
+    expect(r.verdict).toBe(VERDICT.JAMMED);
+    expect(r.jammedForMs).toBe(120 * SEC); // clock ran from the ORIGINAL block, not the recovery
+  });
+
+  it('is not counted as a jam for exit-code purposes', () => {
+    expect(exitCodeFor(VERDICT.UNAVAILABLE)).toBe(0);
+  });
+});
+
+describe('lockIdentityOf', () => {
+  it('is stable for one lock and distinct between locks', () => {
+    expect(lockIdentityOf({ mtimeMs: 100, ino: 7 })).toBe(lockIdentityOf({ mtimeMs: 100, ino: 7 }));
+    expect(lockIdentityOf({ mtimeMs: 100, ino: 7 })).not.toBe(lockIdentityOf({ mtimeMs: 101, ino: 7 }));
+    expect(lockIdentityOf({ mtimeMs: 100, ino: 7 })).not.toBe(lockIdentityOf({ mtimeMs: 100, ino: 8 }));
+  });
+
+  it('does NOT derive identity from birthtime — NTFS file tunneling makes it non-unique', () => {
+    // Measured: three files created ~1.2s apart with DIFFERENT inodes reported an IDENTICAL
+    // birthtimeMs. A birthtime-based identity collapses distinct locks into one and rebuilds the
+    // presence-only false positive.
+    const a = { mtimeMs: 100, ino: 7, birthtimeMs: 5000 };
+    const b = { mtimeMs: 200, ino: 8, birthtimeMs: 5000 }; // same birthtime, different lock
+    expect(lockIdentityOf(a)).not.toBe(lockIdentityOf(b));
+  });
+
+  it('returns null for a missing stat rather than a fabricated token', () => {
+    expect(lockIdentityOf(null)).toBeNull();
+  });
+});
+
+describe('exit code contract (TS-8)', () => {
+  it('only JAMMED is non-zero', () => {
+    expect(exitCodeFor(VERDICT.JAMMED)).toBe(1);
+    expect(exitCodeFor(VERDICT.HEALTHY)).toBe(0);
+    expect(exitCodeFor(VERDICT.UNAVAILABLE)).toBe(0);
+  });
+});
+
+describe('TS-7 — the detector is not itself an undrained detector (FR-4)', () => {
+  it('has a DRAIN_DESCRIPTORS entry naming a consumer, a closing path and a predicate', async () => {
+    // PURE structural assertion — no database. drain-inventory.mjs is DB-dependent and the db
+    // vitest project resolves to ZERO files, so a DB-tier test here would never execute.
+    const { DRAIN_DESCRIPTORS } = await import('../../../lib/governance/gauge-registry.js');
+    const d = DRAIN_DESCRIPTORS['index-jam-detector'];
+    expect(d, 'the detector must be declared or the drain inventory flags it NO_CONSUMER').toBeTruthy();
+    expect(d.consumer).toBeTruthy();
+    expect(d.closingPath).toBeTruthy();
+    expect(d.predicate).toMatch(/persist/i);
+    // The shape contract must point readers at the exit code, not at parsing the message.
+    expect(d.shapeContract).toMatch(/exit code/i);
+    // And it must record that lock presence is NOT the signal — the measured correction.
+    expect(d.fieldQuestion).toMatch(/lock presence is a false signal|does NOT answer/i);
+  });
+});
+
+describe('formatVerdict (FR-2)', () => {
+  it('names the tree and the duration, and says it is a shared-resource condition', () => {
+    const msg = formatVerdict('C:/repo', { verdict: VERDICT.JAMMED, jammedForMs: 189 * 60 * SEC });
+    expect(msg).toContain('C:/repo');
+    expect(msg).toContain('189.0 min');
+    expect(msg).toMatch(/SHARED-RESOURCE/i);
+    expect(msg).toMatch(/not a fault in your command/i);
+  });
+
+  it('does not present UNAVAILABLE as a health verdict', () => {
+    const msg = formatVerdict('C:/repo', { verdict: VERDICT.UNAVAILABLE, reason: 'EACCES' });
+    expect(msg).toMatch(/UNAVAILABLE/);
+    expect(msg).toMatch(/Not a health verdict/i);
+  });
+});

--- a/tests/unit/git/index-jam-detector.test.js
+++ b/tests/unit/git/index-jam-detector.test.js
@@ -12,7 +12,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import {
-  VERDICT, DEFAULT_DWELL_MS, classifyIndexHealth, lockIdentityOf, exitCodeFor, formatVerdict,
+  VERDICT, DEFAULT_DWELL_MS, DEFAULT_TICK_MS, classifyIndexHealth, lockIdentityOf, exitCodeFor, formatVerdict,
   sanitizeState, sanitizeDwellMs,
 } from '../../../lib/git/index-jam-detector.js';
 
@@ -185,7 +185,12 @@ describe('ALARM SUPPRESSION — corrupt carry-over state must never read as heal
   });
 
   it('degrades a garbage state object to start-counting-again, never to permanently-healthy', () => {
-    for (const bad of [null, undefined, 'nonsense', 42, { firstBlockedAtMs: -1 }, { firstBlockedAtMs: 0 }]) {
+    // Each fixture carries lockIdentity 'A' so sameLock is TRUE on the next tick and the guard
+    // under test is actually REACHED. Without it, sameLock is false regardless and the assertion
+    // cannot fail — mutation proved a dropped `t > 0` guard survived the earlier version.
+    for (const bad of [null, undefined, 'nonsense', 42,
+      { firstBlockedAtMs: -1, lockIdentity: 'A' }, { firstBlockedAtMs: 0, lockIdentity: 'A' },
+      { firstBlockedAtMs: '5000', lockIdentity: 'A' }, { firstBlockedAtMs: Infinity, lockIdentity: 'A' }]) {
       const r = classifyIndexHealth(present('A'), T0, bad);
       expect(r.verdict).toBe(VERDICT.HEALTHY);
       expect(classifyIndexHealth(present('A'), T0 + 120 * SEC, r.nextState).verdict).toBe(VERDICT.JAMMED);
@@ -210,6 +215,57 @@ describe('ALARM SUPPRESSION — corrupt carry-over state must never read as heal
   it('sanitizeState preserves a legitimate in-progress count', () => {
     const good = { firstBlockedAtMs: T0 - 60 * SEC, lockIdentity: 'A' };
     expect(sanitizeState(good, T0)).toEqual(good);
+  });
+
+  it('rejects a NUMERIC STRING timestamp — coerced comparisons would let it through', () => {
+    // '5000' > 0 and '5000' <= now are BOTH true, so only Number.isFinite catches it. Without
+    // that check the string flows into the arithmetic and yields a nonsense duration.
+    expect(sanitizeState({ firstBlockedAtMs: '5000', lockIdentity: 'A' }, T0).firstBlockedAtMs).toBeNull();
+  });
+
+  it('rejects an INFINITE dwell floor — Infinity > 0 is true, and it disables the detector', () => {
+    // Number('1e999') === Infinity and is reachable straight from the CLI. `heldForMs >= Infinity`
+    // is always false, so the detector goes silently inert exactly like the NaN case.
+    expect(sanitizeDwellMs(Infinity)).toBe(DEFAULT_DWELL_MS);
+    expect(sanitizeDwellMs(Number('1e999'))).toBe(DEFAULT_DWELL_MS);
+  });
+
+  it('ignores a NON-STRING lockIdentity rather than carrying an object that can never match', () => {
+    // An object identity is re-parsed fresh each tick, so === never holds, the counter never
+    // accumulates, and a real jam never surfaces.
+    expect(sanitizeState({ firstBlockedAtMs: T0 - SEC, lockIdentity: { a: 1 } }, T0).lockIdentity).toBeNull();
+  });
+
+  it('never jams on a null firstBlockedAtMs even when the identity matches', () => {
+    // sanitizeState deliberately ADMITS firstBlockedAtMs === null (it is the legitimate
+    // never-blocked shape). So classifyIndexHealth's own null-guard is the only thing preventing
+    // `nowMs - null` from producing a ~20,000-day duration and an instant false JAMMED.
+    const r = classifyIndexHealth(present('A'), T0, { firstBlockedAtMs: null, lockIdentity: 'A' });
+    expect(r.verdict).toBe(VERDICT.HEALTHY);
+    expect(r.nextState.firstBlockedAtMs).toBe(T0);
+  });
+});
+
+describe('the derived dwell floor is pinned, not merely bounded', () => {
+  it('is exactly 90s — derived from a ~44.2s healthy ceiling and a 420s shortest real jam', () => {
+    // Mutation showed 75s and 61s both survived a range-only assertion. The value carries the
+    // derivation (roughly 2x headroom over healthy bulk work), so pin it.
+    expect(DEFAULT_DWELL_MS).toBe(90_000);
+  });
+
+  it('leaves ~2x headroom over the measured healthy ceiling and sits far under the shortest jam', () => {
+    const HEALTHY_CEILING_MS = 44_200; // measured: git add -A of 12000 files
+    const SHORTEST_REAL_JAM_MS = 420_000; // 7 minutes, recorded
+    expect(DEFAULT_DWELL_MS).toBeGreaterThan(HEALTHY_CEILING_MS * 2);
+    expect(DEFAULT_DWELL_MS).toBeLessThan(SHORTEST_REAL_JAM_MS);
+  });
+
+  it('TICK must be small enough that the shortest real jam spans multiple ticks', () => {
+    // Detection needs the SAME identity at two consecutive ticks, so the EFFECTIVE floor is
+    // max(dwell, 2 x tick). A 1800s registered interval would make the effective floor 3600s and
+    // leave the 420s shortest recorded jam structurally undetectable — the derived 90s inert.
+    expect(DEFAULT_TICK_MS * 2).toBeLessThan(420_000);
+    expect(DEFAULT_TICK_MS * 2).toBeLessThanOrEqual(DEFAULT_DWELL_MS);
   });
 });
 

--- a/tests/unit/git/index-jam-observer.test.js
+++ b/tests/unit/git/index-jam-observer.test.js
@@ -1,0 +1,172 @@
+/**
+ * SD-LEO-INFRA-JAMMED-GIT-INDEX-001 — observer seams (TS-5, TS-13, TS-14, TS-15).
+ *
+ * TESTING at EXEC flagged that FR-5 AC-1 and AC-3 literally say "asserted by test" and no such
+ * assertion existed — the read-only guarantee, which is the ENTIRE safety argument, was carried
+ * only by code reading. It also flagged the observer seams as the weakest area: zero automated
+ * coverage on resolveGitDir, the ENOENT-vs-other-error split, and loadState/saveState.
+ *
+ * These use a real temp directory rather than mocks, because the properties under test are about
+ * actual filesystem behaviour. They NEVER touch the shared root or any .worktrees path.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  resolveGitDir, observeIndexLock, loadState, saveState, stateFileFor,
+} from '../../../scripts/cron/index-jam-detector.mjs';
+
+let tmp;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'jam-obs-')); });
+afterEach(() => { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+const mainRepo = () => { fs.mkdirSync(path.join(tmp, '.git'), { recursive: true }); return tmp; };
+
+describe('TS-14 — the observer refuses to guess a repo (TR-5)', () => {
+  it('THROWS rather than defaulting to cwd', () => {
+    // Without this, a caller that forgets the argument silently observes the REAL shared index.
+    for (const bad of [undefined, null, '', 0, {}]) {
+      expect(() => observeIndexLock(bad)).toThrow(/explicit repo path/i);
+    }
+  });
+});
+
+describe('TS-15 — dotGitKind discrimination (TR-3)', () => {
+  it('treats a .git DIRECTORY as a main root', () => {
+    expect(resolveGitDir(mainRepo())).toEqual({ gitDir: path.join(tmp, '.git'), kind: 'main_root' });
+  });
+
+  it('follows a .git FILE gitdir pointer as a worktree', () => {
+    const real = path.join(tmp, 'realgitdir');
+    fs.mkdirSync(real, { recursive: true });
+    const wt = path.join(tmp, 'wt');
+    fs.mkdirSync(wt, { recursive: true });
+    fs.writeFileSync(path.join(wt, '.git'), `gitdir: ${real}\n`);
+    expect(resolveGitDir(wt)).toEqual({ gitDir: real, kind: 'worktree' });
+  });
+
+  it('REFUSES a pointer whose target does not exist — a pruned worktree must not read as healthy', () => {
+    // The alarm-suppressing bug: a pruned worktrees/<name> makes the index.lock stat return
+    // ENOENT, which the caller treats as "lock absent" -> HEALTHY FOREVER, indistinguishable
+    // from a genuinely healthy tree.
+    const wt = path.join(tmp, 'pruned');
+    fs.mkdirSync(wt, { recursive: true });
+    fs.writeFileSync(path.join(wt, '.git'), `gitdir: ${path.join(tmp, 'gone')}\n`);
+    expect(() => resolveGitDir(wt)).toThrow();
+    // And the observer surfaces it as UNAVAILABLE, never as an absent lock.
+    const obs = observeIndexLock(wt);
+    expect(obs.error).toBeTruthy();
+    expect(obs.lockPresent).toBe(false);
+  });
+
+  it('REFUSES a pointer target that is a file rather than a directory', () => {
+    const notDir = path.join(tmp, 'afile');
+    fs.writeFileSync(notDir, 'x');
+    const wt = path.join(tmp, 'wt2');
+    fs.mkdirSync(wt, { recursive: true });
+    fs.writeFileSync(path.join(wt, '.git'), `gitdir: ${notDir}\n`);
+    expect(() => resolveGitDir(wt)).toThrow(/not a directory/i);
+  });
+
+  it('rejects a .git file that is not a gitdir pointer', () => {
+    const wt = path.join(tmp, 'wt3');
+    fs.mkdirSync(wt, { recursive: true });
+    fs.writeFileSync(path.join(wt, '.git'), 'garbage\n');
+    expect(() => resolveGitDir(wt)).toThrow(/gitdir pointer/i);
+  });
+});
+
+describe('observeIndexLock — ENOENT is an observation, other errors are not', () => {
+  it('reports lock ABSENT (not an error) when there is no lock', () => {
+    const obs = observeIndexLock(mainRepo());
+    expect(obs.lockPresent).toBe(false);
+    expect(obs.error).toBeUndefined(); // ENOENT must NOT become UNAVAILABLE — it resets the counter
+  });
+
+  it('reports lock PRESENT with an identity when one exists', () => {
+    const repo = mainRepo();
+    fs.writeFileSync(path.join(repo, '.git', 'index.lock'), '');
+    const obs = observeIndexLock(repo);
+    expect(obs.lockPresent).toBe(true);
+    expect(obs.lockIdentity).toMatch(/^\d+(\.\d+)?:\d+$/); // mtimeMs:ino
+    expect(obs.error).toBeUndefined();
+  });
+
+  it('reports UNAVAILABLE — never absent — when the repo does not exist', () => {
+    const obs = observeIndexLock(path.join(tmp, 'nope'));
+    expect(obs.error).toBeTruthy();
+  });
+});
+
+describe('TS-5 / TS-13 — READ-ONLY guarantee (FR-5 AC-1, AC-3)', () => {
+  it('creates NO index.lock when observing a repo that has none', () => {
+    const repo = mainRepo();
+    observeIndexLock(repo);
+    expect(fs.existsSync(path.join(repo, '.git', 'index.lock'))).toBe(false);
+  });
+
+  it('leaves an EXISTING lock byte-identical — never opens, truncates or removes it', () => {
+    // The whole safety argument: a detector that acquired the lock could, if killed mid-write,
+    // leave the very orphan lock that IS the incident.
+    const repo = mainRepo();
+    const lock = path.join(repo, '.git', 'index.lock');
+    fs.writeFileSync(lock, 'sentinel');
+    const before = fs.statSync(lock);
+
+    observeIndexLock(repo);
+
+    const after = fs.statSync(lock);
+    expect(fs.readFileSync(lock, 'utf8')).toBe('sentinel');
+    expect(after.size).toBe(before.size);
+    expect(after.mtimeMs).toBe(before.mtimeMs);
+    expect(after.ino).toBe(before.ino);
+  });
+
+  it('makes NO destructive fs call while observing — write-spy', () => {
+    const repo = mainRepo();
+    fs.writeFileSync(path.join(repo, '.git', 'index.lock'), '');
+    const spies = ['unlinkSync', 'writeFileSync', 'appendFileSync', 'rmSync', 'openSync', 'truncateSync']
+      .map((fn) => [fn, vi.spyOn(fs, fn)]);
+
+    observeIndexLock(repo);
+
+    for (const [name, spy] of spies) {
+      expect(spy, `observeIndexLock must not call fs.${name}`).not.toHaveBeenCalled();
+      spy.mockRestore();
+    }
+  });
+});
+
+describe('state store round-trip (TR-7)', () => {
+  it('persists per-repo state beside the OBSERVED repo, not relative to cwd', () => {
+    // The cwd-dependent path was the highest-severity suppression bug: because persistence IS the
+    // signal, a state file that moves with cwd means the counter never accumulates.
+    const repo = mainRepo();
+    expect(stateFileFor(repo)).toBe(path.join(repo, '.claude', 'index-jam-detector-state.json'));
+
+    const st = { firstBlockedAtMs: 1234, lockIdentity: 'A' };
+    saveState(repo, st);
+    expect(loadState(repo)).toEqual(st);
+  });
+
+  it('returns undefined rather than throwing when no state exists yet', () => {
+    expect(loadState(mainRepo())).toBeUndefined();
+  });
+
+  it('returns undefined on a corrupt state file rather than propagating a parse error', () => {
+    const repo = mainRepo();
+    const f = stateFileFor(repo);
+    fs.mkdirSync(path.dirname(f), { recursive: true });
+    fs.writeFileSync(f, '{not json');
+    expect(loadState(repo)).toBeUndefined();
+  });
+
+  it('keeps entries for other repos when saving', () => {
+    const repo = mainRepo();
+    saveState(repo, { firstBlockedAtMs: 1, lockIdentity: 'A' });
+    saveState('C:/other/repo', { firstBlockedAtMs: 2, lockIdentity: 'B' }, stateFileFor(repo));
+    const all = JSON.parse(fs.readFileSync(stateFileFor(repo), 'utf8'));
+    expect(Object.keys(all)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
A stale `index.lock` froze every git operation in the shared tree for ~3 hours and **nothing saw it**. The claim sweep and drain gauge read DB state; the worktree reaper runs `git worktree list --porcelain`, which never touches the index — so it kept **succeeding** throughout the outage and reported git healthy.

**Detection only.** The remedy half was cut at LEAD on evidence: already declined as option (c) in SD-REFILL-00KUKQVS, already owned by open QF-20260727-502, and resting on a predicate measured to be false.

## Why this observes rather than probes

Every claim below was **measured** at PLAN, in disposable scratch repos, across three rejected PRD drafts:

| Finding | Consequence |
|---|---|
| `git update-index --refresh` exits 1 on a merely **dirty** tree | The shared root is chronically dirty → permanent false alarm |
| Stat-clean index + orphan lock → probe exits **0** (5/5 runs) while real `git add` fails 128 | A clean bill of health *during* the outage |
| A **live healthy** `git add` also returns 128 — identical to the orphan case | Five non-destructive discriminators (open r, r+, a, exclusive create, size) gave identical results in both states |

So a single-shot probe carries exactly the information of *"a lock exists"* — the signal FR-1 declares false. And acquiring the lock to test it would let the detector, if killed mid-write, **leave the very orphan lock that is the incident**.

## Presence is not persistence — the defect in my own second draft

Six back-to-back healthy `git add`s left a lock **present at 12 of 12 ticks across four distinct identities**. A presence-only detector calls that JAMMED. So persistence accumulates only while the lock **identity** `(mtimeMs, ino)` is unchanged.

**Not `birthtime`:** on NTFS, three files created ~1.2s apart with different inodes reported an **identical** `birthtimeMs` (file tunneling). It's the obvious field and it silently rebuilds the false positive.

**Dwell floor derived, not picked:** healthy `git add -A` holds the lock ~40.0s at 5,000 files and ~44.2s at 12,000 (the curve flattens), against a shortest recorded real jam of 7 minutes. 90s gives ~2× headroom; under 60s false-positives on healthy bulk work. Git hooks don't constrain it — an 8s sleeping pre-commit hook held no lock at any sample, because git runs hooks *before* acquiring.

## A bug found by running it

Exit codes came back **127**, not 0/1 — `process.exit()` raced libuv teardown while the Supabase client held an open handle. A scheduler cannot act on an exit code that reports "command not found" for a healthy tree. Now sets `process.exitCode` and returns. Verified live: JAMMED=1, HEALTHY=0, UNAVAILABLE=0.

## Verification

- **847 tests across 55 suites pass**; 19 new.
- **Mutation tested — all three killed:** presence-only (the v1.1 defect) fails 4 tests; UNAVAILABLE-resets-counter fails 1; birthtime-identity fails 2.
- **Live, disposable scratch repo only** — the shared root was never touched and has no `index.lock`. No lock → HEALTHY; dirty tree → HEALTHY; orphan lock under floor → HEALTHY; same lock past floor → JAMMED; missing repo → UNAVAILABLE (never HEALTHY); no `--repo` → exit 2.
- Liveness confirmed: `periodic_process_registry.last_fired_at` advances.
- Drain inventory reports it UNAVAILABLE (it cannot read a process exit code), **not** NO_CONSUMER/NO_CLOSING_PATH.

**Scope boundary, stated rather than left silent:** keying on lock presence means a *lockless* jam — corrupt index, broken `.git` permissions, disk full — reports HEALTHY. All six recorded incidents were stale-lock jams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
