### PR TITLE
fix(QF-20260725-096): the retirement 410 was circumventable four ways — close it and pin the axes

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -42,6 +42,9 @@ import {
 
 // Import state management
 import { loadState, dashboardState } from './state.js';
+// QF-20260725-096: retired-route matchers, kept in their own side-effect-free module so the scope
+// pins can import the real pattern without booting the server.
+import { RETIRED_SESSION_VIEW_RE } from './retired-routes.js';
 
 // Import WebSocket handler
 import { initializeWebSocket, broadcastUpdate } from './websocket.js';
@@ -174,12 +177,40 @@ app.use(express.json());
 // A raw RegExp rather than a string pattern: this is Express 5 (path-to-regexp v8), where the
 // old '*' string wildcard no longer means what it did in v4.
 //
+// *** BYPASS FIX (same QF, second pass). THE FIRST VERSION OF THIS MATCHER WAS CIRCUMVENTABLE. ***
+// It was `/^\/fleet-ui\/session-view\.[^/]*$/` — case-SENSITIVE and anchored on exactly one slash.
+// express.static resolves through a case-INSENSITIVE filesystem on this host, so it happily served
+// every one of these while the matcher never fired (all measured returning 200 against the running
+// server):
+//     /fleet-ui/Session-View.html   /fleet-ui/SESSION-VIEW.HTML   /fleet-ui/Session-View.js
+//     /FLEET-UI/session-view.html   /Fleet-UI/session-view.html
+//     /fleet-ui//session-view.html  /fleet-ui///session-view.html
+// So `i` for the case axis, and `\/+` for the repeated-slash axis. A guard that the server routes
+// around is not a guard, and it fails SILENTLY — the page kept serving and nothing recorded it.
+//
+// WORSE, AND THE REASON THIS IS CALLED OUT AT LENGTH: the QF-20260727-484 hit-logging below lives
+// INSIDE this handler, so a bypassing request logged NOTHING. The instrument inherited the guard's
+// blind spot because it was built into the guard. Seven days of that silence would have been read
+// as "nobody wanted the page" when the truth was "the page was still reachable four ways".
+//
+// HOW IT SURVIVED REVIEW: the original change shipped with a regex "proof" against nine paths —
+// every one of them lowercase and single-slash, because they were written from the same mental
+// model as the pattern. A negative control only controls for what you thought to vary. The variant
+// list is now pinned as a test (tests/unit/server/fleet-ui-410-scope.test.js) so the axes are
+// asserted rather than imagined.
+//
 // 410 Gone, deliberately, not 404: it asserts the resource was real and is intentionally
 // withdrawn, so a hit shows up as a decision rather than a broken link. That matters because
 // the disposition depends on watching for hits during the soak — silence is the evidence.
 // DELETES NOTHING. server/public/fleet-ui/session-view.js stays on disk (its unit test still
 // imports it), and rollback is removing this block — one commit, no file resurrection.
-app.all(/^\/fleet-ui\/session-view\.[^/]*$/, (req, res) => {
+//
+// The pattern lives in server/retired-routes.js so the scope pins can assert THIS regex without
+// booting the server — startServer() runs unconditionally on import of this file, so a test that
+// imported from here would open DB connections and bind a port just to check a regex. A test that
+// re-declares the pattern instead would prove only that its own copy behaves, which is exactly how
+// the circumventable first version passed review.
+app.all(RETIRED_SESSION_VIEW_RE, (req, res) => {
   // QF-20260727-484 — WITHOUT THIS LINE THE SOAK CANNOT PRODUCE EVIDENCE. The retirement above
   // is dispositioned by a seven-day soak in which SILENCE IS THE EVIDENCE, but this server has no
   // request logging of any kind (no morgan — it is not even a dependency), so a 410 hit wrote

--- a/server/retired-routes.js
+++ b/server/retired-routes.js
@@ -1,0 +1,36 @@
+/**
+ * Retired-route matchers, in their own module so they can be TESTED WITHOUT BOOTING THE SERVER.
+ *
+ * server/index.js calls startServer() unconditionally at import time (no main-module guard), so a
+ * test that imported the pattern from there would open DB connections, start chokidar watchers and
+ * attempt to bind a port as a side effect of asserting a regex. That is the shape that makes a
+ * guard's test flaky, and a flaky guard test is one CI-quarantine away from being no guard at all.
+ *
+ * QF-20260725-096.
+ */
+
+/**
+ * The standalone /fleet-ui session view, retired 2026-07-27 (chairman-ratified).
+ *
+ * TWO AXES, both learned the hard way — the first version of this matcher was circumventable and
+ * shipped that way. It read `/^\/fleet-ui\/session-view\.[^/]*$/`:
+ *
+ *   CASE — express.static resolves through a case-INSENSITIVE filesystem on the host, so it served
+ *   /fleet-ui/Session-View.html, /fleet-ui/SESSION-VIEW.HTML, /FLEET-UI/session-view.html and
+ *   /Fleet-UI/session-view.html with a 200 while the case-SENSITIVE matcher never fired.
+ *
+ *   SEPARATORS — anchoring on exactly one slash let /fleet-ui//session-view.html and
+ *   /fleet-ui///session-view.html through untouched.
+ *
+ * All of the above were measured returning 200 against the running server. Hence `i` and `\/+`.
+ *
+ * STILL FILE-SCOPED, NOT ROUTE-SCOPED, which is the original and still-correct design: session-view.*,
+ * fleet-panel.* and vision.* share the SAME /fleet-ui static mount, so anything looser than this
+ * would retire live sibling pages too. `[^/]*` cannot cross a segment boundary, so a nested
+ * /fleet-ui/sub/session-view.html is deliberately NOT matched, and the literal `\.` means an
+ * extensionless /fleet-ui/session-view is not matched either.
+ *
+ * NO `g` FLAG, deliberately: a global regex carries lastIndex between calls, so a per-request
+ * matcher would alternate true/false and silently serve the retired page every other hit.
+ */
+export const RETIRED_SESSION_VIEW_RE = /^\/+fleet-ui\/+session-view\.[^/]*$/i;

--- a/tests/unit/server/fleet-ui-410-scope.test.js
+++ b/tests/unit/server/fleet-ui-410-scope.test.js
@@ -1,0 +1,80 @@
+/**
+ * QF-20260725-096 (bypass fix) — scope pins for the retired /fleet-ui session-view 410.
+ *
+ * WHY THIS FILE EXISTS. The first version of the matcher shipped with a hand-written "proof"
+ * against nine paths, every one lowercase and single-slash, because the cases were invented from
+ * the same mental model that wrote the pattern. The proof therefore inherited the pattern's blind
+ * spot and the guard shipped circumventable: express.static resolves through a case-INSENSITIVE
+ * filesystem on the host, so `/fleet-ui/Session-View.html` was served with a 200 while the
+ * case-SENSITIVE matcher never fired. Four bypasses were live against the running server.
+ *
+ * So these cases are NOT invented. Every entry under BYPASSES_MEASURED_LIVE was observed returning
+ * 200 from the running server before the fix, and every entry under MUST_PASS_THROUGH was observed
+ * returning 200 or 404 and must keep doing so.
+ *
+ * The regex is IMPORTED, never re-declared. A test that copies the pattern proves only that its own
+ * copy behaves — which is precisely how the original defect passed review. It is imported from
+ * server/retired-routes.js rather than server/index.js because the latter calls startServer() at
+ * import time, so asserting a regex would otherwise open DB connections and bind a port.
+ */
+import { describe, it, expect } from 'vitest';
+import { RETIRED_SESSION_VIEW_RE as RE } from '../../../server/retired-routes.js';
+
+// Observed 200 against the running server BEFORE the fix. Each is a distinct bypass axis.
+const BYPASSES_MEASURED_LIVE = [
+  ['/fleet-ui/Session-View.html', 'filename case'],
+  ['/fleet-ui/SESSION-VIEW.HTML', 'filename case, upper'],
+  ['/fleet-ui/Session-View.js', 'filename case, non-html extension'],
+  ['/FLEET-UI/session-view.html', 'mount-segment case'],
+  ['/Fleet-UI/session-view.html', 'mount-segment mixed case'],
+  ['/fleet-ui//session-view.html', 'duplicated separator'],
+  ['/fleet-ui///session-view.html', 'triplicated separator'],
+];
+
+// Already 410 before the fix — must not regress.
+const ALREADY_RETIRED = [
+  '/fleet-ui/session-view.html',
+  '/fleet-ui/session-view.js',
+  '/fleet-ui/session-view.css',
+  '/fleet-ui/session-view.HTML',
+  '/fleet-ui/session-view.test.js',
+];
+
+// Must keep reaching the static mount (or 404) — the retirement is file-scoped, not route-scoped.
+// fleet-panel and vision live under the SAME mount; matching them would take down live pages.
+const MUST_PASS_THROUGH = [
+  ['/fleet-ui/fleet-panel.html', 'sibling page, live'],
+  ['/fleet-ui/vision.html', 'sibling page, live'],
+  ['/fleet-ui/fleet-panel-format.js', 'sibling asset'],
+  ['/fleet-ui/sub/session-view.html', 'nested path — [^/] must not cross a segment'],
+  ['/fleet-ui/session-view', 'no extension — the dot is required'],
+  ['/fleet-ui/session-viewXhtml', 'the dot is literal, not any-char'],
+  ['/api/fleet/sessions/abc/open', 'the live EHG route family, explicitly fenced'],
+];
+
+describe('QF-20260725-096: retired session-view 410 scope', () => {
+  it.each(BYPASSES_MEASURED_LIVE)('closes the measured bypass %s (%s)', (path) => {
+    expect(RE.test(path)).toBe(true);
+  });
+
+  it.each(ALREADY_RETIRED)('keeps retiring %s', (path) => {
+    expect(RE.test(path)).toBe(true);
+  });
+
+  it.each(MUST_PASS_THROUGH)('does NOT match %s (%s)', (path) => {
+    expect(RE.test(path)).toBe(false);
+  });
+
+  it('is case-insensitive and slash-tolerant by construction, not by accident', () => {
+    // Pin the two axes on the flags/source themselves, so a future edit that drops either one
+    // fails here even if someone also edits the case list above.
+    expect(RE.flags).toContain('i');
+    expect(RE.source).toContain('\\/+');
+  });
+
+  it('a global-flag regex would be stateful across calls — guard against that regression', () => {
+    // A `g` flag on a matcher used per-request makes lastIndex persist between requests, so
+    // alternating calls would silently return false. Express would then serve the retired page.
+    expect(RE.flags).not.toContain('g');
+  });
+});


### PR DESCRIPTION
I shipped this guard and I shipped it bypassable. Measured live against the running server — all
returning **200** while the 410 never fired:

| Bypass | Axis |
|---|---|
| `/fleet-ui/Session-View.html`, `/fleet-ui/SESSION-VIEW.HTML`, `/fleet-ui/Session-View.js` | filename case |
| `/FLEET-UI/session-view.html`, `/Fleet-UI/session-view.html` | mount-segment case |
| `/fleet-ui//session-view.html`, `/fleet-ui///session-view.html` | duplicated separator |

Two axes, both mine: the matcher was case-**sensitive** while `express.static` resolves through a
case-**insensitive** filesystem on this host, and it anchored on exactly one separator. Hence `i`
and `\/+`.

## The second-order failure is the worse one

The QF-20260727-484 hit-logging lives **inside** this handler, so every bypassing request logged
**nothing**. The instrument inherited the guard's blind spot because it was built into the guard.
Seven days of that silence would have read as *"nobody wanted the page"* when the truth was *"still
reachable four ways."*

Verified fixed: **14 logged hits** post-fix, including every previously-silent variant.

## How it passed review

The original shipped with a regex "proof" against nine paths — every one lowercase and
single-slash, because I invented them from the same mental model that wrote the pattern. The proof
inherited the blind spot. **A negative control only controls for what you thought to vary.**

So the pins are **measured, not invented**: every case under `BYPASSES_MEASURED_LIVE` was observed
returning 200 before this change. The test **imports the real regex** rather than re-declaring it —
a copied pattern proves only that the copy behaves, which is how this got through the first time.
Two assertions guard the flags themselves, plus one forbidding a `g` flag (`lastIndex` would persist
between requests and serve the page every other hit).

## Why the pattern moved to `server/retired-routes.js`

`server/index.js` calls `startServer()` unconditionally at import, so asserting a regex would
otherwise open DB connections, start watchers and bind a port. A flaky guard test is one CI
quarantine away from being no guard at all — which this repo already has a live example of.

## Scope unchanged, re-verified

`fleet-panel.html` still 200; nested `/fleet-ui/sub/session-view.html` and extensionless
`/fleet-ui/session-view` still pass through. **21 pins pass, no server boot required.**

The seven-day soak should restart from this commit — the prior window is uninterpretable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
