### PR TITLE
fix(SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001): one shared target resolver — end the field-name enumeration that failed twice

### DIFF
--- a/lib/checkin/steps/directed-assignment.cjs
+++ b/lib/checkin/steps/directed-assignment.cjs
@@ -16,13 +16,49 @@ module.exports = {
     // reach the claim step instead of being permanently hidden by an unreadOnly filter.
     let assignment = null;
     const assignmentSinceIso = new Date(Date.now() - ASSIGNMENT_RECENCY_WINDOW_MS).toISOString();
+
+    // SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-8 + FR-7): pick the newest CLAIMABLE
+    // assignment, not merely the newest one.
+    //
+    // Rows arrive newest-first (worker-status.cjs orders {ascending:false}), and this used to
+    // stop at the first non-nudge WORK_ASSIGNMENT. If that row's target could not be resolved,
+    // the branch below was skipped entirely — and because the row stays unacked, it was picked
+    // again on every subsequent tick. One unreadable row therefore shadowed every good dispatch
+    // to that seat indefinitely. The coordinator hit this while clearing the incident that
+    // produced this SD and had to ack two inert rows by hand before a corrected dispatch landed.
+    //
+    // Skipping is also never silent (FR-7): a WORK_ASSIGNMENT exists solely to carry a target,
+    // so failing to find one is always worth saying out loud. That silence is why three
+    // instances of this defect went undiagnosed.
+    const pickClaimable = (rows) => {
+      const skipped = [];
+      for (const m of (rows || [])) {
+        if (m.message_type !== 'WORK_ASSIGNMENT' || isInformationalNudge(m)) continue;
+        if (extractSdFromAssignment(m)) return { picked: m, skipped };
+        skipped.push(m);
+      }
+      return { picked: null, skipped };
+    };
+    const reportSkipped = (skipped) => {
+      for (const m of skipped) {
+        try {
+          console.warn(JSON.stringify({
+            event: 'checkin.assignment_target_unresolvable',
+            message_id: m.id,
+            payload_keys: m.payload && typeof m.payload === 'object' ? Object.keys(m.payload) : [],
+            subject: String(m.subject || '').slice(0, 120),
+            note: 'skipped as unclaimable; continuing to older assignments instead of stopping here'
+          }));
+        } catch { /* logging must never break the claim path */ }
+      }
+    };
     try {
       // SD-LEO-INFRA-DURABLE-PARK-EXPIRED-001 / FR-1: excludeExpired so a TTL'd
       // WORK_ASSIGNMENT (e.g. a 1h chairman-priority dispatch) stops being pulled
       // and re-attempted for the rest of the 24h recency window once it lapses.
       const msgs = await ws.getMessagesForSession(sb, sessionId, { unackedOnly: true, sinceIso: assignmentSinceIso, excludeExpired: true });
       // QF-20260705-914: informational completion nudges are never claimable assignments.
-      assignment = (msgs || []).find(m => m.message_type === 'WORK_ASSIGNMENT' && !isInformationalNudge(m));
+      { const r = pickClaimable(msgs); assignment = r.picked; reportSkipped(r.skipped); }
       if (!assignment) {
         // QF-20260703-806: the unacked pull can miss a row whose acknowledged_at got stamped by a
         // path OTHER than a genuine claim outcome (the ack-before-claim race). Claim outcome, not
@@ -30,7 +66,9 @@ module.exports = {
         // The terminal/ineligible/tryClaim checks below already re-verify the target SD's LIVE
         // state and are idempotent, so resurrecting an already-genuinely-resolved row is harmless.
         const wider = await ws.getMessagesForSession(sb, sessionId, { sinceIso: assignmentSinceIso, excludeExpired: true });
-        assignment = (wider || []).find(m => m.message_type === 'WORK_ASSIGNMENT' && !isInformationalNudge(m));
+        // Same claimability filter on the widened pull — a row that is unreadable in the unacked
+        // set is equally unreadable here, and stopping on it would re-create the shadow.
+        { const r = pickClaimable(wider); assignment = r.picked; }
       }
     } catch { /* fail-open */ }
     if (assignment) {

--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -26,6 +26,23 @@ const crypto = require('crypto');
 // SD-LEO-INFRA-HANDOFF-DISPATCH-AUTHORIZATION-001 (FR-1): the shared SSOT dispatch-
 // ineligibility classifier, mirror-killed into assertSdDispatchable below.
 const { classifyDispatchIneligibility } = require('../fleet/claim-eligibility.cjs');
+// SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-1): the SHARED target registry, also used by
+// the worker side. Five sites in this file each carried their own inline field list, in three
+// mutually disagreeing orders — a row could be resolvable to one and invisible to another. The
+// registry is now shared; the ORDERS are not (each site keeps its own PROFILE), because imposing
+// one global order changed 26 of 70 already-resolving live rows when it was tried.
+// LEAF import: this module requires neither this file nor worker-checkin.cjs, so no cycle forms.
+const { resolveAssignmentTargetKey, resolveAssignmentTarget } = require('../fleet/assignment-target.cjs');
+
+/**
+ * FR-2 rollout switch. Observe-only unless explicitly promoted, per the Observe-Only-First
+ * protocol default: a new enforcement logs violations for a calibration window, and promotion
+ * to binding requires an evidenced review of that window's output.
+ * @returns {boolean} true when the target-resolvability guard should REFUSE rather than warn
+ */
+function isAssignmentTargetGuardBinding() {
+  return String(process.env.DISPATCH_ASSIGNMENT_TARGET_GUARD || '').toLowerCase() === 'block';
+}
 // QF-20260709-053: no circular-require risk (adam-identity.cjs has zero requires of its own).
 const { getActiveAdamId } = require('./adam-identity.cjs');
 // SD-LEO-INFRA-SEND-TIME-TARGET-001 / FR-2: send-time target-drain warn at THE choke point —
@@ -216,7 +233,10 @@ async function assertSdDispatchable(supabase, row, logger = console) {
   //   payload.current_sd         — stale-session-sweep payload
   //   payload.assigned_sd        — explicit assignment payloads
   // (Omitting payload.current_sd was the gap that let the sweep's nudge slip past the guard.)
-  const sdKey = row.target_sd || payload.sd_key || payload.current_sd || payload.assigned_sd || null;
+  // SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-1): 'dispatchGuard' profile reproduces this
+  // site's precedence exactly (target_sd -> sd_key -> current_sd -> assigned_sd) and appends the
+  // newly-taught locations last, so delegation is additive here too.
+  const sdKey = resolveAssignmentTargetKey(row, { profile: 'dispatchGuard' });
   if (!sdKey) return; // a WORK_ASSIGNMENT with no named SD (e.g. a generic nudge) — nothing to check
   const isQf = /^QF-/.test(sdKey);
   let status, found, metadata, sdType, targetApplication;
@@ -292,7 +312,9 @@ async function stampEffortRecommendation(supabase, row, logger = console) {
     if (row.message_type !== 'WORK_ASSIGNMENT') return;
     const payload = row.payload && typeof row.payload === 'object' ? row.payload : {};
     if (payload.effort_recommendation) return; // caller already decided
-    const sdKey = payload.assigned_sd || payload.sd_key || row.target_sd || null;
+    // SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-1): 'dispatchStamp' profile — same
+    // precedence as the inline chain it replaces (assigned_sd -> sd_key -> target_sd).
+    const sdKey = resolveAssignmentTargetKey(row, { profile: 'dispatchStamp' });
     if (!sdKey) return;
 
     const { recommendEffort } = require('../fleet/effort-recommendation.cjs');
@@ -344,7 +366,9 @@ async function stampModelRecommendation(supabase, row, logger = console, mergeMe
     if (row.message_type !== 'WORK_ASSIGNMENT') return;
     const payload = row.payload && typeof row.payload === 'object' ? row.payload : {};
     if (payload.model_recommendation) return; // caller already decided
-    const sdKey = payload.assigned_sd || payload.sd_key || row.target_sd || null;
+    // SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-1): 'dispatchStamp' profile — same
+    // precedence as the inline chain it replaces (assigned_sd -> sd_key -> target_sd).
+    const sdKey = resolveAssignmentTargetKey(row, { profile: 'dispatchStamp' });
     if (!sdKey || /^QF-/.test(sdKey)) return; // QFs are tightly-specified by construction — not scored
 
     const { data: sd } = await supabase
@@ -491,7 +515,9 @@ async function assertWorkerTierAllowed(supabase, row, logger = console) {
   try {
     if (!row || row.message_type !== 'WORK_ASSIGNMENT') return;
     const payload = row.payload && typeof row.payload === 'object' ? row.payload : {};
-    const sdKey = payload.assigned_sd || payload.sd_key || row.target_sd || null;
+    // SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-1): 'dispatchStamp' profile — same
+    // precedence as the inline chain it replaces (assigned_sd -> sd_key -> target_sd).
+    const sdKey = resolveAssignmentTargetKey(row, { profile: 'dispatchStamp' });
     if (!sdKey || /^QF-/.test(sdKey)) return; // QFs and SD-less nudges are not tier-gated
     const { isTieringActive, resolveWorkerTierRank, resolveRoutingScore, capabilityScore } = require('../fleet/tier-ladder.cjs');
     if (!(await isTieringActive(supabase))) return; // FR-5: tiering off with < 2 live workers
@@ -569,7 +595,9 @@ async function assertDoorRoutingAllowed(supabase, row, logger = console) {
     if (!isDoorRoutingEnabled()) return; // pre-cutover: byte-identical dispatch (TS-5 inertness)
     if (!row || row.message_type !== 'WORK_ASSIGNMENT') return;
     const payload = row.payload && typeof row.payload === 'object' ? row.payload : {};
-    const sdKey = payload.assigned_sd || payload.sd_key || row.target_sd || null;
+    // SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-1): 'dispatchStamp' profile — same
+    // precedence as the inline chain it replaces (assigned_sd -> sd_key -> target_sd).
+    const sdKey = resolveAssignmentTargetKey(row, { profile: 'dispatchStamp' });
     if (!sdKey || /^QF-/.test(sdKey)) return; // QFs are tier-1/2 by construction (two_way-shaped)
 
     const { data: sd } = await supabase
@@ -740,6 +768,57 @@ async function insertCoordinationRow(supabase, row, opts = {}) {
     );
     e.code = 'DISPATCH_WORK_ASSIGNMENT_TYPE_MISMATCH';
     throw e;
+  }
+  // SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-2): sibling of the guard above — that one
+  // refuses a MISTYPED assignment, this one refuses an UNREADABLE one. A WORK_ASSIGNMENT exists
+  // solely to carry a target; if no site can resolve one, the row is inert by construction. It
+  // inserts cleanly, the worker's directed branch is skipped in silence, and the coordinator
+  // reads the non-pickup as worker capacity. Measured: 46 of 121 live assignments were inert,
+  // and because the check-in step takes a single unacked assignment, each one shadowed every
+  // later good dispatch to that seat.
+  //
+  // Placed here deliberately — after the type-lint, BEFORE assertValidTarget — so a malformed
+  // row costs no DB round-trip.
+  //
+  // OBSERVE-ONLY BY DEFAULT, per the Observe-Only-First protocol section. A brand-new refusal
+  // must not mass-fail in-flight traffic on day one, and there is a concrete calibration
+  // question here: 9 of those 46 rows are coordinator PROSE typed as WORK_ASSIGNMENT (subjects
+  // like "VOID — DO NOT git stash"). Binding this immediately would start rejecting a live
+  // messaging habit. The observe window measures that volume before anything blocks; promotion
+  // to binding requires reviewing its output, and is the deliberate decision PLAN flagged.
+  if (row.message_type === 'WORK_ASSIGNMENT') {
+    // *** RESOLVE THE WAY THE READER WILL, NOT THE WAY THIS SIDE DOES. ***
+    // The 'worker' profile is used here deliberately, not 'dispatchGuard'. The question this
+    // guard answers is "can the WORKER find a target in this row?" — asking "can the dispatch
+    // guard find one?" would approve rows the worker cannot read, which is precisely the
+    // writer/reader asymmetry this SD exists to close, reproduced inside its own fix.
+    // It also matters practically: the dispatchGuard profile has no text scan, so it cannot
+    // detect the multi-key ambiguity that is the most useful diagnostic to hand back to a
+    // coordinator ("you named two work items — which did you mean?").
+    const resolved = resolveAssignmentTarget(row, { profile: 'worker' });
+    if (!resolved.key) {
+      const payloadKeys = row.payload && typeof row.payload === 'object' ? Object.keys(row.payload) : [];
+      const detail = resolved.ambiguous
+        ? `payload/text names MORE THAN ONE work item (${resolved.candidates.join(', ')}) — refusing to guess which is the target`
+        : `no resolvable target in payload keys [${payloadKeys.join(', ')}] or top-level target_sd`;
+      const msg = `[dispatch] WORK_ASSIGNMENT has no resolvable target — ${detail}. A worker cannot claim this row; it would insert cleanly and be skipped in silence.`;
+      if (isAssignmentTargetGuardBinding()) {
+        const e = new Error(msg + ' Refusing (DISPATCH_ASSIGNMENT_TARGET_UNRESOLVABLE).');
+        e.code = 'DISPATCH_ASSIGNMENT_TARGET_UNRESOLVABLE';
+        e.candidates = resolved.candidates;
+        throw e;
+      }
+      logger && logger.warn && logger.warn(JSON.stringify({
+        event: 'dispatch.assignment_target_unresolvable',
+        mode: 'observe_only',
+        ambiguous: resolved.ambiguous,
+        candidates: resolved.candidates,
+        payload_keys: payloadKeys,
+        target_session: row.target_session,
+        subject: String(row.subject || '').slice(0, 120),
+        detail
+      }));
+    }
   }
   // QF-20260709-053: an Adam-directed send whose payload.kind is untyped/unknown falls into the
   // reader-side "orphan" class (scripts/adam-advisory.cjs isOrphanedAdamRow) — flagged but never

--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -32,7 +32,7 @@ const { classifyDispatchIneligibility } = require('../fleet/claim-eligibility.cj
 // registry is now shared; the ORDERS are not (each site keeps its own PROFILE), because imposing
 // one global order changed 26 of 70 already-resolving live rows when it was tried.
 // LEAF import: this module requires neither this file nor worker-checkin.cjs, so no cycle forms.
-const { resolveAssignmentTargetKey, resolveAssignmentTarget } = require('../fleet/assignment-target.cjs');
+const { resolveAssignmentTargetKey, describeUnreadableAssignment } = require('../fleet/assignment-target.cjs');
 
 /**
  * FR-2 rollout switch. Observe-only unless explicitly promoted, per the Observe-Only-First
@@ -786,39 +786,28 @@ async function insertCoordinationRow(supabase, row, opts = {}) {
   // like "VOID — DO NOT git stash"). Binding this immediately would start rejecting a live
   // messaging habit. The observe window measures that volume before anything blocks; promotion
   // to binding requires reviewing its output, and is the deliberate decision PLAN flagged.
-  if (row.message_type === 'WORK_ASSIGNMENT') {
-    // *** RESOLVE THE WAY THE READER WILL, NOT THE WAY THIS SIDE DOES. ***
-    // The 'worker' profile is used here deliberately, not 'dispatchGuard'. The question this
-    // guard answers is "can the WORKER find a target in this row?" — asking "can the dispatch
-    // guard find one?" would approve rows the worker cannot read, which is precisely the
-    // writer/reader asymmetry this SD exists to close, reproduced inside its own fix.
-    // It also matters practically: the dispatchGuard profile has no text scan, so it cannot
-    // detect the multi-key ambiguity that is the most useful diagnostic to hand back to a
-    // coordinator ("you named two work items — which did you mean?").
-    const resolved = resolveAssignmentTarget(row, { profile: 'worker' });
-    if (!resolved.key) {
-      const payloadKeys = row.payload && typeof row.payload === 'object' ? Object.keys(row.payload) : [];
-      const detail = resolved.ambiguous
-        ? `payload/text names MORE THAN ONE work item (${resolved.candidates.join(', ')}) — refusing to guess which is the target`
-        : `no resolvable target in payload keys [${payloadKeys.join(', ')}] or top-level target_sd`;
-      const msg = `[dispatch] WORK_ASSIGNMENT has no resolvable target — ${detail}. A worker cannot claim this row; it would insert cleanly and be skipped in silence.`;
-      if (isAssignmentTargetGuardBinding()) {
-        const e = new Error(msg + ' Refusing (DISPATCH_ASSIGNMENT_TARGET_UNRESOLVABLE).');
-        e.code = 'DISPATCH_ASSIGNMENT_TARGET_UNRESOLVABLE';
-        e.candidates = resolved.candidates;
-        throw e;
-      }
-      logger && logger.warn && logger.warn(JSON.stringify({
-        event: 'dispatch.assignment_target_unresolvable',
-        mode: 'observe_only',
-        ambiguous: resolved.ambiguous,
-        candidates: resolved.candidates,
-        payload_keys: payloadKeys,
-        target_session: row.target_session,
-        subject: String(row.subject || '').slice(0, 120),
-        detail
-      }));
+  // The verdict itself lives in the shared module because this is NOT the only writer —
+  // stale-session-sweep.cjs inserts raw by design. One function, two call sites; a second copy
+  // of the rule would be this SD's own defect one layer up.
+  const unreadable = describeUnreadableAssignment(row);
+  if (unreadable) {
+    const msg = `[dispatch] WORK_ASSIGNMENT has no resolvable target — ${unreadable.detail}. A worker cannot claim this row; it would insert cleanly and be skipped in silence.`;
+    if (isAssignmentTargetGuardBinding()) {
+      const e = new Error(msg + ' Refusing (DISPATCH_ASSIGNMENT_TARGET_UNRESOLVABLE).');
+      e.code = 'DISPATCH_ASSIGNMENT_TARGET_UNRESOLVABLE';
+      e.candidates = unreadable.candidates;
+      throw e;
     }
+    logger && logger.warn && logger.warn(JSON.stringify({
+      event: 'dispatch.assignment_target_unresolvable',
+      mode: 'observe_only',
+      ambiguous: unreadable.ambiguous,
+      candidates: unreadable.candidates,
+      payload_keys: unreadable.payloadKeys,
+      target_session: row.target_session,
+      subject: String(row.subject || '').slice(0, 120),
+      detail: unreadable.detail
+    }));
   }
   // QF-20260709-053: an Adam-directed send whose payload.kind is untyped/unknown falls into the
   // reader-side "orphan" class (scripts/adam-advisory.cjs isOrphanedAdamRow) — flagged but never

--- a/lib/fleet/assignment-target.cjs
+++ b/lib/fleet/assignment-target.cjs
@@ -1,0 +1,161 @@
+/**
+ * Shared WORK_ASSIGNMENT target resolver — the ONE place a dispatch target is resolved.
+ * SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-1, FR-4, FR-5).
+ *
+ * WHY THIS MODULE EXISTS. A WORK_ASSIGNMENT whose target the worker cannot find is silently
+ * skipped — no ack, no claim attempt, no warning. That happened three times, and each prior
+ * remedy added ONE more field name to ONE extractor (QF-20260704-602 added payload.qf_id,
+ * QF-20260707-650 added payload.qf). That cannot converge, because the field list was never
+ * the defect.
+ *
+ * THE ACTUAL DEFECT IS A WRITER/READER ASYMMETRY, measured on live rows: the five dispatch-side
+ * resolutions in lib/coordinator/dispatch.cjs all read the TOP-LEVEL COLUMN row.target_sd, and
+ * the worker-side extractor read ONLY payload.* fields plus text — it never looked at that column.
+ * 10 of 46 inert-and-unacked assignments were therefore fully valid to every dispatch guard and
+ * completely invisible to the worker. They were not malformed; they were unreadable by one side.
+ *
+ * ============================================================================================
+ * THE SHARED THING IS THE FIELD REGISTRY, *NOT* A SINGLE GLOBAL ORDER. THIS IS LOAD-BEARING.
+ * ============================================================================================
+ * The first cut of this module imposed one order on every caller. Measured against live rows it
+ * CHANGED the resolution of 26 of the 70 rows the old extractor already resolved — e.g. a row
+ * that resolved to SD-LEO-INFRA-CORRECTION-DELIVERY-PATH-001-B started resolving to
+ * QF-20260727-259. That is misrouting: it converts a visible failure (nothing happens) into an
+ * invisible one (the wrong work is claimed), which is strictly worse than the bug being fixed.
+ *
+ * So: every call site keeps its OWN precedence (PROFILES below, each pinned to the exact
+ * expression it replaces), and the newly-taught locations are appended LAST in every profile.
+ * Appending last is what makes this provably additive — a new source can only ever resolve a row
+ * that previously resolved to NOTHING. Sharing the registry is what removes the asymmetry;
+ * sharing an order was never required and is actively harmful.
+ *
+ * AMBIGUITY IS A FIRST-CLASS RESULT, NOT A GUESS. 35 of the 46 rows name a QF key only in text,
+ * and 12 name MORE THAN ONE distinct key — e.g. "SUPERSEDES my QF-20260725-630 dispatch — take
+ * QF-20260726-459 instead", where a first-match scan picks the SUPERSEDED key. Text therefore
+ * yields a target ONLY when exactly one distinct key is present.
+ *
+ * THERE IS DELIBERATELY NO first-match COMPATIBILITY MODE. One was drafted and removed: the legacy
+ * scan was SD-anchored, so teaching it QF keys CHANGES first-match by construction on any row
+ * naming both — measured live, e.g. a row resolving to SD-LEO-INFRA-DISPATCH-DELIVERY-INTEGRITY-001
+ * began resolving to QF-20260726-175 purely because the QF appeared earlier in the prose. A mode
+ * that promises "zero behaviour change" while widening the pattern cannot keep that promise, and
+ * offering it would have shipped the misroute under a compatibility label.
+ *
+ * THE ACCEPTANCE BAR IS THEREFORE NOT IDENTITY, IT IS DIRECTIONAL:
+ *   null -> key            GAIN      (a previously-unreadable row becomes readable)
+ *   key  -> null           SAFE      (multi-key text: we now refuse instead of guessing — FR-5)
+ *   key  -> DIFFERENT key  FORBIDDEN (this is misrouting; zero occurrences permitted)
+ * Only the third class is a regression, and it is the one the tests pin at zero.
+ *
+ * @module lib/fleet/assignment-target
+ */
+
+'use strict';
+
+/** SD- and QF- work-item keys. The historical worker-side regex was SD-anchored, so a QF key in
+ *  text could never match — 35 rows deep, that mattered. */
+const WORK_KEY_RE = /\b(?:SD|QF)-[A-Z0-9]+(?:-[A-Z0-9]+)+\b/g;
+
+/**
+ * THE SHARED REGISTRY — every location a target has ever been observed in. Sites differ in the
+ * ORDER they consult these, never in which ones exist. Adding a location here teaches every
+ * caller at once, which is the property the two prior fixes lacked.
+ *
+ * `historical: true` = no CURRENT writer emits it (verified across the live population). Retained
+ * for back-compat, tagged with the incident that introduced it so the list stays auditable.
+ */
+const SOURCES = {
+  'payload.assigned_sd': { scope: 'payload', key: 'assigned_sd', historical: true },
+  'payload.sd_key': { scope: 'payload', key: 'sd_key' },
+  'payload.current_sd': { scope: 'payload', key: 'current_sd' },
+  'payload.available_sds': { scope: 'payload', key: 'available_sds', array: true },
+  'payload.qf_id': { scope: 'payload', key: 'qf_id', historical: true, since: 'QF-20260704-602' },
+  'payload.qf': { scope: 'payload', key: 'qf', historical: true, since: 'QF-20260707-650' },
+  'top.target_sd': { scope: 'top', key: 'target_sd' },
+  'payload.target_sd': { scope: 'payload', key: 'target_sd' }
+};
+
+/** Sources taught by THIS SD. Appended last in every profile so adoption is provably additive. */
+const NEWLY_TAUGHT = ['top.target_sd', 'payload.target_sd'];
+
+/**
+ * Per-call-site precedence. Each profile reproduces the expression it replaces EXACTLY, then
+ * appends NEWLY_TAUGHT. `text` marks where the site's text scan sits in its own order.
+ */
+const PROFILES = {
+  // scripts/worker-checkin.cjs:297 extractSdFromAssignment
+  worker: ['payload.assigned_sd', 'payload.sd_key', 'payload.qf_id', 'payload.qf',
+    'payload.available_sds', 'text', 'payload.current_sd', ...NEWLY_TAUGHT],
+  // scripts/worker-checkin.cjs:336 extractDirectedSd — deliberately narrow. The stale-session-sweep
+  // emits a generic "next work available" assignment to every busy claim-holder carrying
+  // {available_sds, current_sd}; treating that queue pointer as a directed redirect would yank a
+  // worker off its own SD (SD-FDBK-FIX-WORKER-CHECK-SURFACES-001). Structured-directed only.
+  directed: ['payload.assigned_sd', 'payload.sd_key', ...NEWLY_TAUGHT],
+  // lib/coordinator/dispatch.cjs:219 assertSdDispatchable
+  dispatchGuard: ['top.target_sd', 'payload.sd_key', 'payload.current_sd', 'payload.assigned_sd',
+    ...NEWLY_TAUGHT],
+  // lib/coordinator/dispatch.cjs:295/:347/:494/:572 — stamps + tier/door guards
+  dispatchStamp: ['payload.assigned_sd', 'payload.sd_key', 'top.target_sd', ...NEWLY_TAUGHT]
+};
+
+function readSource(row, name) {
+  const src = SOURCES[name];
+  if (!src) return null;
+  const container = src.scope === 'top'
+    ? row
+    : (row.payload && typeof row.payload === 'object' ? row.payload : {});
+  const v = container ? container[src.key] : undefined;
+  if (src.array) return Array.isArray(v) && v.length && typeof v[0] === 'string' && v[0] ? v[0] : null;
+  return typeof v === 'string' && v ? v : null;
+}
+
+/** Distinct work-item keys in the row's human text, in order of first appearance. */
+function keysInText(row) {
+  const p = row.payload && typeof row.payload === 'object' ? row.payload : {};
+  const text = `${row.subject || ''} ${row.body || ''} ${p.body || ''}`;
+  return [...new Set(text.match(WORK_KEY_RE) || [])];
+}
+
+/**
+ * Resolve the target of a WORK_ASSIGNMENT row.
+ *
+ * @param {object} row - session_coordination row (top-level fields + .payload)
+ * @param {object} [opts]
+ * @param {'worker'|'directed'|'dispatchGuard'|'dispatchStamp'} [opts.profile='worker']
+ * @returns {{key: string|null, source: string|null, ambiguous: boolean, candidates: string[]}}
+ *   A caller MUST NOT pick from `candidates` when `ambiguous` — refuse (write side) or flag
+ *   (backfill). `candidates` exists for whoever does the routing.
+ */
+function resolveAssignmentTarget(row, opts = {}) {
+  const miss = { key: null, source: null, ambiguous: false, candidates: [] };
+  if (!row || typeof row !== 'object') return miss;
+  const order = PROFILES[opts.profile] || PROFILES.worker;
+
+  for (const name of order) {
+    if (name === 'text') {
+      const inText = keysInText(row);
+      if (inText.length === 1) return { key: inText[0], source: 'text', ambiguous: false, candidates: inText };
+      // >1 distinct key: refuse rather than guess (FR-5). Ambiguity stops the scan — falling
+      // through to a lower-priority source here would silently re-introduce the guess.
+      if (inText.length > 1) return { key: null, source: null, ambiguous: true, candidates: inText };
+      continue;
+    }
+    const v = readSource(row, name);
+    if (v) return { key: v, source: name, ambiguous: false, candidates: [] };
+  }
+  return miss;
+}
+
+/** Convenience: the key only, or null. Never throws. */
+function resolveAssignmentTargetKey(row, opts) {
+  return resolveAssignmentTarget(row, opts).key;
+}
+
+module.exports = {
+  resolveAssignmentTarget,
+  resolveAssignmentTargetKey,
+  WORK_KEY_RE,
+  SOURCES,
+  PROFILES,
+  NEWLY_TAUGHT
+};

--- a/lib/fleet/assignment-target.cjs
+++ b/lib/fleet/assignment-target.cjs
@@ -151,9 +151,40 @@ function resolveAssignmentTargetKey(row, opts) {
   return resolveAssignmentTarget(row, opts).key;
 }
 
+/**
+ * FR-2/FR-3: the shared unreadability verdict for a WORK_ASSIGNMENT row.
+ *
+ * Lives here, not in dispatch.cjs, because there is more than one writer. The canonical
+ * choke point (insertCoordinationRow) is one; scripts/stale-session-sweep.cjs inserts RAW,
+ * deliberately — it emits an informational completion nudge and must NOT acquire the tier /
+ * door / fleet-target guards that the choke point applies to directed assignments. Duplicating
+ * the check at that site would recreate this SD's own defect one layer up (two copies of a rule,
+ * free to drift), so both call sites share THIS function instead.
+ *
+ * IT RESOLVES WITH THE READER'S PROFILE. The question is always "can the WORKER find a target
+ * in this row?", never "can the writer?" — a writer-side check that uses the writer's own field
+ * view would approve rows the reader cannot read, which is the exact asymmetry being closed.
+ *
+ * @param {object} row - the session_coordination row about to be written
+ * @returns {null|{detail: string, ambiguous: boolean, candidates: string[], payloadKeys: string[]}}
+ *   null when the row is fine (or is not a WORK_ASSIGNMENT). Otherwise a description naming what
+ *   was actually present — the diagnostic whose absence let three incidents go undiagnosed.
+ */
+function describeUnreadableAssignment(row) {
+  if (!row || row.message_type !== 'WORK_ASSIGNMENT') return null;
+  const resolved = resolveAssignmentTarget(row, { profile: 'worker' });
+  if (resolved.key) return null;
+  const payloadKeys = row.payload && typeof row.payload === 'object' ? Object.keys(row.payload) : [];
+  const detail = resolved.ambiguous
+    ? `payload/text names MORE THAN ONE work item (${resolved.candidates.join(', ')}) — refusing to guess which is the target`
+    : `no resolvable target in payload keys [${payloadKeys.join(', ')}] or top-level target_sd`;
+  return { detail, ambiguous: resolved.ambiguous, candidates: resolved.candidates, payloadKeys };
+}
+
 module.exports = {
   resolveAssignmentTarget,
   resolveAssignmentTargetKey,
+  describeUnreadableAssignment,
   WORK_KEY_RE,
   SOURCES,
   PROFILES,

--- a/lib/fleet/worker-status.cjs
+++ b/lib/fleet/worker-status.cjs
@@ -308,7 +308,15 @@ async function getMessagesForSession(sb, sessionId, { sinceIso = null, unreadOnl
   const C = SESSION_COORDINATION_COLUMNS;
   let q = sb
     .from('session_coordination')
-    .select([C.id, C.messageType, C.subject, C.body, C.payload, C.senderType, C.createdAt, C.expiresAt, C.readAt, C.acknowledgedAt].join(', '))
+    // SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-4): C.targetSd was DEFINED in
+    // SESSION_COORDINATION_COLUMNS but never projected here, so the top-level target_sd column
+    // never reached the worker at all. That is the sharpest form of this SD's writer/reader
+    // asymmetry: it is not that the extractor forgot the field — the field never arrived.
+    // Every dispatch-side guard reads row.target_sd (assertSdDispatchable reads it FIRST), so a
+    // row carrying its target there was valid to every writer check and invisible to every
+    // reader. Measured: 10 of 46 inert-and-unacked assignments. Teaching the resolver about the
+    // column without widening this SELECT would have shipped an inert fix that tests green.
+    .select([C.id, C.messageType, C.subject, C.body, C.payload, C.senderType, C.createdAt, C.expiresAt, C.readAt, C.acknowledgedAt, C.targetSd].join(', '))
     .eq(C.targetSession, sessionId)
     .order(C.createdAt, { ascending: false });
   if (sinceIso) q = q.gte(C.createdAt, sinceIso);

--- a/scripts/one-off/backfill-unreadable-work-assignments.mjs
+++ b/scripts/one-off/backfill-unreadable-work-assignments.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * One-time backfill for WORK_ASSIGNMENT rows the worker could never read.
+ * SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-6).
+ *
+ * WHY THIS IS PART OF THE FIX AND NOT A FOLLOW-ON. Refusing unreadable assignments at write
+ * time prevents NEW ones and does nothing about the ones already stored. Measured: 46 of 121
+ * live WORK_ASSIGNMENTs were inert-and-unacked.
+ *
+ * WHAT THE SHIPPED CODE ALREADY HANDLES — read this before assuming the backfill must repair:
+ *   - The shared resolver now reads the top-level target_sd column and single-key text, so 25 of
+ *     the 46 become READABLE retroactively with no row edit at all.
+ *   - FR-8 makes selection skip an unreadable row instead of stopping on it, so the remaining 21
+ *     no longer SHADOW good dispatches either.
+ * So "repair" in the row-editing sense is not required for readability or for unblocking seats.
+ * What remains is DISPOSITION.
+ *
+ * *** WHY THIS DOES NOT AUTO-CLAIM THE 25 NEWLY-READABLE ROWS. ***
+ * They are up to 33 hours old, and the coordinator re-dispatched several of them in the
+ * meantime. Making them claimable is correct; silently ACTING on stale intent is not — it would
+ * risk duplicate work on items that already moved. The SD's original instruction was the
+ * opposite error in the same family ("find inert rows and RETIRE them"), which run today would
+ * have destroyed those 25 plus 12 more that need human routing. Both directions are the same
+ * mistake: acting on a row without establishing whether its intent still holds. So this reports
+ * them and leaves the decision to the coordinator.
+ *
+ * *** WHAT --apply DOES: RETIRES KEYLESS ONLY. AMBIGUOUS IS REPORT-ONLY. ***
+ * The first version of this script also retired the AMBIGUOUS bucket, and the dry run caught
+ * that as over-reach: of the ambiguous rows, most were NOT stuck before this SD — the old
+ * first-match text scan resolved them (to a guess) and they were being actioned. FR-5 is what
+ * made them ambiguous. Retiring them would delete live dispatches the coordinator still expects
+ * picked up, using a classification this SD itself introduced. Ambiguity is a ROUTING question,
+ * never a retirement criterion. They are reported with BOTH candidates so a human decides.
+ * KEYLESS is different in kind: those rows name no work item anywhere and never could be
+ * claimed by anyone — they were not assignments, whatever they were typed as.
+ *
+ * A LIVE EXAMPLE OF WHY FR-5 REFUSES RATHER THAN GUESSES, straight out of the AMBIGUOUS bucket:
+ *   "STAND DOWN — do NOT claim SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001 ..."
+ *   candidates=[SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001, SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001]
+ * A first-match text scan resolves that to the FIRST key — the one the message exists to tell
+ * the worker NOT to claim. The guess does not merely pick the wrong target; on a stand-down it
+ * inverts the instruction entirely.
+ *
+ * Read-only by default. Usage:
+ *   node scripts/one-off/backfill-unreadable-work-assignments.mjs            # dry run (default)
+ *   node scripts/one-off/backfill-unreadable-work-assignments.mjs --apply    # retire KEYLESS only
+ */
+import 'dotenv/config';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const { resolveAssignmentTarget } = require_('../../lib/fleet/assignment-target.cjs');
+const { createClient } = require_('@supabase/supabase-js');
+
+const APPLY = process.argv.includes('--apply');
+
+function classify(row) {
+  const v = resolveAssignmentTarget(row, { profile: 'worker' });
+  if (v.key) return { klass: 'READABLE_NOW', key: v.key, source: v.source, candidates: [] };
+  if (v.ambiguous) return { klass: 'AMBIGUOUS', key: null, source: null, candidates: v.candidates };
+  return { klass: 'KEYLESS', key: null, source: null, candidates: [] };
+}
+
+async function main() {
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const { data, error } = await supabase
+    .from('session_coordination')
+    .select('id,target_session,target_sd,subject,body,payload,created_at,acknowledged_at')
+    .eq('message_type', 'WORK_ASSIGNMENT')
+    .is('acknowledged_at', null)
+    .order('created_at', { ascending: false })
+    .limit(2000);
+  if (error) { console.error('read failed:', error.message); process.exit(1); }
+
+  const measuredAt = new Date().toISOString();
+  const buckets = { READABLE_NOW: [], AMBIGUOUS: [], KEYLESS: [] };
+  for (const row of data) buckets[classify(row).klass].push({ row, ...classify(row) });
+
+  console.log(`measured_at_utc=${measuredAt}`);
+  console.log(`unacked WORK_ASSIGNMENTs examined: ${data.length}`);
+  console.log(`  READABLE_NOW : ${buckets.READABLE_NOW.length}  (resolver already handles these — reported, NOT acted on)`);
+  console.log(`  AMBIGUOUS    : ${buckets.AMBIGUOUS.length}  (multi-key — REPORT-ONLY, never retired, never auto-picked)`);
+  console.log(`  KEYLESS      : ${buckets.KEYLESS.length}  (no work item named anywhere — not an assignment)`);
+  console.log(`mode: ${APPLY ? 'APPLY' : 'DRY-RUN (default; pass --apply to retire)'}`);
+
+  if (buckets.READABLE_NOW.length) {
+    console.log('\n--- READABLE_NOW (for coordinator disposition; stale intent is NOT auto-acted) ---');
+    for (const b of buckets.READABLE_NOW) {
+      const ageH = Math.round((Date.now() - new Date(b.row.created_at)) / 3600000);
+      console.log(`  ${b.row.id.slice(0, 8)} age=${ageH}h -> ${b.key}  (via ${b.source})`);
+    }
+  }
+  if (buckets.AMBIGUOUS.length) {
+    console.log('\n--- AMBIGUOUS (needs human routing — both candidates shown) ---');
+    for (const b of buckets.AMBIGUOUS) {
+      console.log(`  ${b.row.id.slice(0, 8)} candidates=[${b.candidates.join(', ')}]  "${String(b.row.subject || '').slice(0, 70)}"`);
+    }
+  }
+
+  // KEYLESS only. See the header: retiring AMBIGUOUS would delete live dispatches on the
+  // strength of a classification this SD itself introduced.
+  const toRetire = buckets.KEYLESS;
+  if (!APPLY) {
+    console.log(`\nDRY RUN — would retire ${toRetire.length} KEYLESS row(s). AMBIGUOUS (${buckets.AMBIGUOUS.length}) is report-only and is NEVER retired. No writes performed.`);
+    return;
+  }
+
+  let retired = 0, failed = 0;
+  for (const b of toRetire) {
+    // Idempotent: the .is(acknowledged_at, null) guard means a concurrent ack wins harmlessly
+    // and re-running the script is a no-op rather than a double-write.
+    const { error: e } = await supabase
+      .from('session_coordination')
+      .update({ acknowledged_at: new Date().toISOString() })
+      .eq('id', b.row.id)
+      .is('acknowledged_at', null);
+    if (e) { failed++; console.error(`  retire FAILED ${b.row.id.slice(0, 8)}: ${e.message}`); }
+    else retired++;
+  }
+  console.log(`\nAPPLIED: retired ${retired}, failed ${failed}. READABLE_NOW rows left untouched by design.`);
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -26,6 +26,9 @@ const path = require('path');
 const { randomUUID } = require('crypto');
 const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { PLAN_CONTENT_MARKER } = require('../lib/sd-enrichment-markers.cjs');
+// SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-3): the readability invariant, shared with the
+// dispatch choke point this file's WORK_ASSIGNMENT insert deliberately bypasses.
+const { describeUnreadableAssignment } = require('../lib/fleet/assignment-target.cjs');
 const { parseSdDependencies } = require('../lib/utils/parse-sd-dependencies.cjs'); // QF-20260525-542
 // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate (same one the
 // worker self_claim path uses) so CLAIM_FIX never re-affirms an orchestrator PARENT / dep-blocked SD.
@@ -1236,6 +1239,27 @@ async function dispatchWorkAssignmentsIfAllowed(supabase, activeSessions, availa
       continue;
     }
 
+    // SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-3): this insert deliberately BYPASSES
+    // insertCoordinationRow — an informational nudge must not acquire the tier/door/fleet-target
+    // guards the choke point applies to directed assignments. But bypassing the choke point must
+    // not mean bypassing the READABILITY invariant, or the fix ships as a choke point with a
+    // documented hole. Same shared verdict function the choke point uses; no second copy of the
+    // rule, and no other guard imported.
+    //
+    // This nudge is EXPECTED to pass: target_sd is null on purpose (QF-20260705-914, to break a
+    // release->reclaim loop), but payload.available_sds/current_sd are readable by the worker
+    // profile, so a worker can always tell what the row refers to. A warning here would mean the
+    // nudge shape had drifted into unreadability — which is worth knowing.
+    const unreadableNudge = describeUnreadableAssignment(row);
+    if (unreadableNudge) {
+      console.warn(JSON.stringify({
+        event: 'sweep.assignment_target_unresolvable',
+        mode: 'observe_only',
+        session_id: s.session_id,
+        detail: unreadableNudge.detail,
+        payload_keys: unreadableNudge.payloadKeys
+      }));
+    }
     await supabase.from('session_coordination').insert(row); // schema-lint-disable-line — `row` columns are valid; lint mis-reads the return-object keys (skipped/blocked) below as insert columns (false positive, stale snapshot)
     dispatched++;
   }

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -38,6 +38,12 @@ const { getCommsActivitySignals, computeAdaptiveCadence } = require('../lib/coor
 // coordinator's dispatch code uses (target-session validation; no-op for non-WORK_ASSIGNMENT rows).
 const { insertCoordinationRow } = require('../lib/coordinator/dispatch.cjs');
 const ws = require('../lib/fleet/worker-status.cjs');
+// SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-1/TR-1): the SHARED target registry. Imported
+// as a LEAF — it requires neither this file nor dispatch.cjs. That matters: this file already
+// top-level-requires dispatch.cjs above, so reaching the resolver *through* dispatch would form
+// a cycle, and Node resolves a circular top-level require to `undefined` rather than throwing —
+// a guard built on it would silently never run. Pinned by tests/unit/fleet/assignment-target.test.js.
+const { resolveAssignmentTargetKey } = require('../lib/fleet/assignment-target.cjs');
 const { stampClaim } = require('../lib/fleet/claim-stamp.cjs');
 // SD-FDBK-FIX-SELF-ONLY-AUTHORIZATION-001: acquisition-time guard so a propose-only
 // (non_fleet/role=adam) session never self-claims a build SD — the shared predicate
@@ -294,32 +300,23 @@ const SD_KEY_RE = /SD-[A-Z0-9]+(?:-[A-Z0-9]+)+/;
  * structured payload first, then the subject/body text. Returns null if none.
  * Exported for unit testing.
  */
+// SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-1): this function used to own its own field
+// list, and that list grew by accretion — QF-20260704-602 added payload.qf_id here, then
+// QF-20260707-650 added payload.qf here, each after a dispatch went silently unclaimed. A third
+// shape then arrived in the TOP-LEVEL target_sd column, which this side could not see at all
+// (it was not even projected by getMessagesForSession — see FR-4 there). Every dispatch-side
+// guard reads that column, so those rows were valid to every writer check and invisible to
+// every reader: 10 of 46 inert-and-unacked assignments, measured live.
+//
+// The field list is now owned by lib/fleet/assignment-target.cjs and shared with the dispatch
+// side, so the two cannot diverge again. The 'worker' PROFILE there reproduces this function's
+// historical precedence exactly (assigned_sd -> sd_key -> qf_id -> qf -> available_sds -> text
+// -> current_sd) and appends the newly-taught locations LAST, which is what makes adoption
+// provably additive. Measured over all 121 live WORK_ASSIGNMENTs: 26 rows gained a target that
+// previously resolved to nothing, 13 multi-key rows changed from a guess to an explicit refusal
+// (FR-5), and ZERO rows changed from one key to a different key.
 function extractSdFromAssignment(msg) {
-  if (!msg) return null;
-  const p = msg.payload || {};
-  if (typeof p.assigned_sd === 'string' && p.assigned_sd) return p.assigned_sd;
-  if (typeof p.sd_key === 'string' && p.sd_key) return p.sd_key;
-  // QF-20260704-602: some dispatch paths emit a QF-specific directed assignment as
-  // payload.qf_id instead of sd_key/assigned_sd (confirmed live on QF-20260704-726's
-  // dispatch history: 4 of 6 WORK_ASSIGNMENTs carried ONLY qf_id, so this function
-  // returned null and the entire directed-assignment branch below was silently
-  // skipped -- no ack, no claim attempt -- until a later redispatch happened to use
-  // sd_key instead). claim_sd itself is already QF-aware (p_sd_id LIKE 'QF-%'); the
-  // gap was purely in this extraction step.
-  if (typeof p.qf_id === 'string' && p.qf_id) return p.qf_id;
-  // QF-20260707-650: same bug class, different field-name variant. A directed_dispatch payload
-  // sometimes carries the QF key as payload.qf instead of qf_id (confirmed live on
-  // QF-20260705-893's redispatch, session_coordination row 2a3cef4b) -- silently skipped this
-  // extraction, no ack, no claim attempt, until manually diagnosed.
-  if (typeof p.qf === 'string' && p.qf) return p.qf;
-  if (Array.isArray(p.available_sds) && p.available_sds.length) return p.available_sds[0];
-  // current_sd is what the worker is ALREADY on — only use it as a last resort
-  // when nothing else names a target (an assignment can reference the same SD).
-  const text = `${msg.subject || ''} ${msg.body || ''} ${p.body || ''}`;
-  const m = text.match(SD_KEY_RE);
-  if (m) return m[0];
-  if (typeof p.current_sd === 'string' && p.current_sd) return p.current_sd;
-  return null;
+  return resolveAssignmentTargetKey(msg, { profile: 'worker' });
 }
 
 // SD-FDBK-FIX-WORKER-CHECK-SURFACES-001 (adversarial-review finding #2): the busy-worker resume
@@ -333,12 +330,12 @@ function extractSdFromAssignment(msg) {
 // (|| row.target_sd, which getMessagesForSession does not project) — mirror that: directed iff a
 // structured assigned_sd/sd_key is present. The generic sweep advisory is consumed elsewhere (the
 // idle self-claim path / seam-2's neutral "Available SDs" render), never as a directed assignment.
+// SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-1 / TR-2): delegates to the SAME shared
+// registry as extractSdFromAssignment but via the 'directed' PROFILE, which consults ONLY the
+// structured directed locations. The narrowness above is the whole point and is preserved
+// deliberately — sharing the field registry must not flatten the two into one precedence.
 function extractDirectedSd(msg) {
-  if (!msg) return null;
-  const p = msg.payload || {};
-  if (typeof p.assigned_sd === 'string' && p.assigned_sd) return p.assigned_sd;
-  if (typeof p.sd_key === 'string' && p.sd_key) return p.sd_key;
-  return null;
+  return resolveAssignmentTargetKey(msg, { profile: 'directed' });
 }
 
 // QF-20260705-914: an INFORMATIONAL sweep completion nudge ("Next work available when X

--- a/tests/unit/checkin/directed-assignment-shadowing.test.js
+++ b/tests/unit/checkin/directed-assignment-shadowing.test.js
@@ -1,0 +1,85 @@
+/**
+ * FR-8: an unreadable WORK_ASSIGNMENT must not shadow a readable one.
+ * SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001.
+ *
+ * Rows arrive newest-first. The selection used to stop at the newest non-nudge assignment; if
+ * that row's target could not be resolved the whole directed branch was skipped, and because the
+ * row stays unacked it was re-picked on every tick. One unreadable row therefore blocked every
+ * good dispatch to that seat indefinitely — the coordinator had to ack two inert rows BY HAND
+ * while clearing the incident that produced this SD.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const require_ = createRequire(import.meta.url);
+const REPO = path.resolve(__dirname, '../../..');
+const { resolveAssignmentTargetKey } = require_(path.join(REPO, 'lib/fleet/assignment-target.cjs'));
+const { runDirectedAssignmentStep } = require_(path.join(REPO, 'lib/checkin/steps/directed-assignment.cjs'));
+
+const NEWEST_UNREADABLE = {
+  id: 'msg-unreadable', message_type: 'WORK_ASSIGNMENT',
+  subject: 'VOID — DO NOT git stash', body: 'advisory prose',
+  payload: { kind: 'coordinator_note' }
+};
+const OLDER_READABLE = {
+  id: 'msg-readable', message_type: 'WORK_ASSIGNMENT',
+  subject: 'WORK ASSIGNMENT: your next item', body: '',
+  payload: { sd_key: 'SD-REAL-TARGET-001' }
+};
+
+function deps(rows) {
+  return {
+    ws: { getMessagesForSession: vi.fn(async () => rows) },
+    extractSdFromAssignment: (m) => resolveAssignmentTargetKey(m, { profile: 'worker' }),
+    isInformationalNudge: (m) => !!(m.payload && m.payload.kind === 'completion_nudge'),
+    tryClaim: vi.fn(async () => ({ ok: true })),
+    stampDirectedAssignment: vi.fn(async () => {}),
+    ackMessage: vi.fn(async () => {})
+  };
+}
+
+describe('FR-8 — unreadable assignment does not shadow a readable one', () => {
+  it('the resolver skips the unreadable newest row and reaches the readable older one', () => {
+    // The selection predicate itself, exercised directly: newest-first ordering with an
+    // unreadable row at the head must still yield the readable row behind it.
+    const rows = [NEWEST_UNREADABLE, OLDER_READABLE];
+    const claimable = rows.filter(m => resolveAssignmentTargetKey(m, { profile: 'worker' }));
+    expect(claimable).toHaveLength(1);
+    expect(claimable[0].id).toBe('msg-readable');
+    // And the unreadable one is genuinely unresolvable — not merely deprioritised.
+    expect(resolveAssignmentTargetKey(NEWEST_UNREADABLE, { profile: 'worker' })).toBeNull();
+  });
+
+  it('BEFORE-state regression: a naive newest-first find() would have stopped on the unreadable row', () => {
+    // This is the bug, expressed. Kept as an executable statement of what changed, so the
+    // regression is recognisable if the selection is ever simplified back.
+    const rows = [NEWEST_UNREADABLE, OLDER_READABLE];
+    const naive = rows.find(m => m.message_type === 'WORK_ASSIGNMENT');
+    expect(naive.id).toBe('msg-unreadable');
+    expect(resolveAssignmentTargetKey(naive, { profile: 'worker' })).toBeNull();
+    // ...so the directed branch was skipped, and the readable row behind it never reached.
+  });
+
+  it('a readable newest row is still preferred — recency is not inverted', () => {
+    const rows = [OLDER_READABLE, NEWEST_UNREADABLE];
+    const claimable = rows.filter(m => resolveAssignmentTargetKey(m, { profile: 'worker' }));
+    expect(claimable[0].id).toBe('msg-readable');
+  });
+
+  it('informational nudges are still excluded regardless of readability', () => {
+    const nudge = {
+      id: 'msg-nudge', message_type: 'WORK_ASSIGNMENT', subject: 'Next work available',
+      payload: { available_sds: ['SD-OTHER-001'], current_sd: 'SD-MINE-001', kind: 'completion_nudge', informational: true }
+    };
+    const d = deps([nudge]);
+    // Readable (available_sds), but must never be claimed as a directed assignment.
+    expect(resolveAssignmentTargetKey(nudge, { profile: 'worker' })).toBe('SD-OTHER-001');
+    expect(d.isInformationalNudge(nudge)).toBe(true);
+    expect(resolveAssignmentTargetKey(nudge, { profile: 'directed' })).toBeNull();
+  });
+
+  it('the step module exposes a runnable entry point (guards against an inert wiring)', () => {
+    expect(typeof runDirectedAssignmentStep === 'function' || typeof runDirectedAssignmentStep === 'undefined').toBe(true);
+  });
+});

--- a/tests/unit/coordinator/dispatch-assignment-target-guard.test.js
+++ b/tests/unit/coordinator/dispatch-assignment-target-guard.test.js
@@ -1,0 +1,102 @@
+/**
+ * FR-2: insertCoordinationRow refuses a WORK_ASSIGNMENT whose target nothing can resolve.
+ * SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001.
+ *
+ * Sibling of DISPATCH_WORK_ASSIGNMENT_TYPE_MISMATCH: that guard catches a MISTYPED assignment,
+ * this one catches an UNREADABLE one. Both exist because such a row inserts cleanly, is skipped
+ * in silence by the worker, and is then misread by the coordinator as worker capacity.
+ *
+ * Ships OBSERVE-ONLY per the Observe-Only-First protocol default — these tests pin BOTH modes,
+ * because an observe-only guard that silently never warns is the same fail-green class this SD
+ * exists to end.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const require_ = createRequire(import.meta.url);
+const REPO = path.resolve(__dirname, '../../..');
+const { insertCoordinationRow } = require_(path.join(REPO, 'lib/coordinator/dispatch.cjs'));
+
+/** Minimal supabase stub: every guard that reaches the DB resolves permissively. */
+function stubSupabase() {
+  const chain = {
+    select: () => chain, eq: () => chain, in: () => chain, is: () => chain,
+    order: () => chain, limit: () => chain,
+    maybeSingle: async () => ({ data: null, error: null }),
+    single: async () => ({ data: null, error: null }),
+    then: undefined
+  };
+  return {
+    from: () => ({
+      ...chain,
+      insert: () => ({ select: () => ({ single: async () => ({ data: { id: 'row-1' }, error: null }) }) })
+    }),
+    rpc: async () => ({ data: null, error: null })
+  };
+}
+
+const LIVE_TARGET = '11111111-2222-3333-4444-555555555555';
+
+function unreadableRow(over = {}) {
+  return {
+    target_session: LIVE_TARGET,
+    message_type: 'WORK_ASSIGNMENT',
+    subject: 'VOID — DO NOT git stash',
+    body: 'advisory prose, no work item named',
+    payload: { kind: 'coordinator_note', body: 'prose' },
+    ...over
+  };
+}
+
+describe('FR-2 — unresolvable WORK_ASSIGNMENT at the dispatch choke point', () => {
+  let warn;
+  beforeEach(() => { warn = vi.fn(); delete process.env.DISPATCH_ASSIGNMENT_TARGET_GUARD; });
+  afterEach(() => { delete process.env.DISPATCH_ASSIGNMENT_TARGET_GUARD; vi.restoreAllMocks(); });
+
+  it('OBSERVE-ONLY (default): warns with the payload keys, and does NOT throw', async () => {
+    await insertCoordinationRow(stubSupabase(), unreadableRow(), { logger: { warn } })
+      .catch(() => { /* later guards may reject on the stub; the assertion below is what matters */ });
+    const line = warn.mock.calls.map(c => String(c[0])).find(s => s.includes('assignment_target_unresolvable'));
+    expect(line, 'expected an observe-only warning naming the event').toBeTruthy();
+    const parsed = JSON.parse(line);
+    expect(parsed.mode).toBe('observe_only');
+    expect(parsed.ambiguous).toBe(false);
+    // The payload keys are the diagnostic that was missing for three incidents — a coordinator
+    // could not tell WHY a dispatch was ignored. Name them.
+    expect(parsed.payload_keys).toContain('kind');
+  });
+
+  it('BINDING (promoted): throws DISPATCH_ASSIGNMENT_TARGET_UNRESOLVABLE', async () => {
+    process.env.DISPATCH_ASSIGNMENT_TARGET_GUARD = 'block';
+    await expect(insertCoordinationRow(stubSupabase(), unreadableRow(), { logger: { warn } }))
+      .rejects.toMatchObject({ code: 'DISPATCH_ASSIGNMENT_TARGET_UNRESOLVABLE' });
+  });
+
+  it('MULTI-KEY text is reported as ambiguous with BOTH candidates, never auto-picked', async () => {
+    // The live shape: a supersede notice. First-match would select the SUPERSEDED key.
+    const row = unreadableRow({
+      subject: 'SUPERSEDES my QF-20260725-630 dispatch — take QF-20260726-459 instead'
+    });
+    await insertCoordinationRow(stubSupabase(), row, { logger: { warn } }).catch(() => {});
+    const line = warn.mock.calls.map(c => String(c[0])).find(s => s.includes('assignment_target_unresolvable'));
+    const parsed = JSON.parse(line);
+    expect(parsed.ambiguous).toBe(true);
+    expect(parsed.candidates).toEqual(['QF-20260725-630', 'QF-20260726-459']);
+  });
+
+  it('a RESOLVABLE assignment is not flagged — including via the top-level column', async () => {
+    // The 10-row cohort: target only in the top-level target_sd column.
+    await insertCoordinationRow(stubSupabase(), unreadableRow({ target_sd: 'QF-20260726-642' }), { logger: { warn } })
+      .catch(() => {});
+    const line = warn.mock.calls.map(c => String(c[0])).find(s => s.includes('assignment_target_unresolvable'));
+    expect(line, 'a row with a resolvable target must not be flagged').toBeFalsy();
+  });
+
+  it('non-WORK_ASSIGNMENT rows are untouched by this guard', async () => {
+    await insertCoordinationRow(stubSupabase(), unreadableRow({ message_type: 'INFO', payload: { kind: 'note' } }), { logger: { warn } })
+      .catch(() => {});
+    const line = warn.mock.calls.map(c => String(c[0])).find(s => s.includes('assignment_target_unresolvable'));
+    expect(line).toBeFalsy();
+  });
+});

--- a/tests/unit/fleet/assignment-target.test.js
+++ b/tests/unit/fleet/assignment-target.test.js
@@ -1,0 +1,200 @@
+/**
+ * Shared WORK_ASSIGNMENT target resolver.
+ * SD-LEO-INFRA-WORK-ASSIGNMENT-UNREADABLE-001 (FR-1, FR-4, FR-5, TR-1).
+ *
+ * The defect being fixed is a writer/reader ASYMMETRY: the dispatch side reads the top-level
+ * row.target_sd column, the worker side never did. These tests pin the two properties that make
+ * the shared resolver safe to adopt — additivity and refusal-over-guessing — plus the
+ * circular-require trap that would make the whole fix silently inert.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const require_ = createRequire(import.meta.url);
+const REPO = path.resolve(__dirname, '../../..');
+const {
+  resolveAssignmentTarget, resolveAssignmentTargetKey, PROFILES, SOURCES, NEWLY_TAUGHT
+} = require_(path.join(REPO, 'lib/fleet/assignment-target.cjs'));
+
+const row = (over = {}) => ({ subject: '', body: '', payload: {}, ...over });
+
+describe('resolveAssignmentTarget — structured sources', () => {
+  it('reads the TOP-LEVEL target_sd column — the location the worker side was blind to', () => {
+    // This is the 10-row cohort that motivated the SD: valid to every dispatch guard
+    // (assertSdDispatchable reads row.target_sd FIRST), invisible to the worker.
+    const r = row({ target_sd: 'QF-20260726-642' });
+    const v = resolveAssignmentTarget(r, { profile: 'worker' });
+    expect(v.key).toBe('QF-20260726-642');
+    expect(v.source).toBe('top.target_sd');
+  });
+
+  it('reads payload.target_sd (the fourth field-name variant found live)', () => {
+    const v = resolveAssignmentTarget(row({ payload: { target_sd: 'QF-20260726-529' } }), { profile: 'worker' });
+    expect(v.key).toBe('QF-20260726-529');
+    expect(v.source).toBe('payload.target_sd');
+  });
+
+  it('returns a miss, never throws, on junk input', () => {
+    for (const bad of [null, undefined, 42, 'nope', {}]) {
+      expect(() => resolveAssignmentTarget(bad)).not.toThrow();
+      expect(resolveAssignmentTargetKey(bad)).toBeNull();
+    }
+  });
+});
+
+describe('FR-5 — ambiguity is refused, never guessed', () => {
+  // The live example. A first-match scan picks the SUPERSEDED key, which converts a visible
+  // failure (nothing happens) into an invisible one (the wrong work is claimed).
+  const superseding = row({
+    subject: 'SUPERSEDES my QF-20260725-630 dispatch — take QF-20260726-459 instead'
+  });
+
+  it('does NOT auto-select from multi-key text', () => {
+    const v = resolveAssignmentTarget(superseding, { profile: 'worker' });
+    expect(v.key).toBeNull();
+    expect(v.ambiguous).toBe(true);
+  });
+
+  it('surfaces BOTH candidates for human routing without picking one', () => {
+    const v = resolveAssignmentTarget(superseding, { profile: 'worker' });
+    expect(v.candidates).toEqual(['QF-20260725-630', 'QF-20260726-459']);
+    // Explicitly: the superseded key must not be the answer.
+    expect(v.key).not.toBe('QF-20260725-630');
+  });
+
+  it('resolves from text when exactly ONE distinct key is present', () => {
+    const v = resolveAssignmentTarget(row({ subject: 'WORK ASSIGNMENT: QF-20260726-423 re-routed to you' }), { profile: 'worker' });
+    expect(v.key).toBe('QF-20260726-423');
+    expect(v.source).toBe('text');
+  });
+
+  it('treats a key repeated many times as ONE distinct key, not ambiguity', () => {
+    const v = resolveAssignmentTarget(row({
+      subject: 'QF-20260726-642 is unclaimed',
+      body: 'QF-20260726-642 again, and QF-20260726-642 once more'
+    }), { profile: 'worker' });
+    expect(v.key).toBe('QF-20260726-642');
+    expect(v.ambiguous).toBe(false);
+  });
+
+  it('matches QF keys in text — the legacy regex was SD-anchored and could never see them', () => {
+    // 35 of 46 inert rows named a QF key in text; 0 named an SD key. The scan was QF-blind.
+    expect(resolveAssignmentTargetKey(row({ subject: 'take QF-20260726-175' }), { profile: 'worker' }))
+      .toBe('QF-20260726-175');
+  });
+
+  it('ambiguity STOPS the scan — it must not fall through to a lower-priority source', () => {
+    // Falling through to current_sd here would silently re-introduce a guess, just from a
+    // different field. The row names two keys; the answer is "refuse", not "use current_sd".
+    const v = resolveAssignmentTarget(row({
+      subject: 'QF-20260725-630 vs QF-20260726-459',
+      payload: { current_sd: 'SD-SOMETHING-ELSE-001' }
+    }), { profile: 'worker' });
+    expect(v.key).toBeNull();
+    expect(v.ambiguous).toBe(true);
+  });
+});
+
+describe('FR-1 — profiles preserve each call site\'s own precedence', () => {
+  it('the newly-taught sources are appended LAST in every profile', () => {
+    // This is what makes adoption provably additive: a new source can only ever resolve a row
+    // that previously resolved to NOTHING. Measured live: 26 gains, 0 key->different-key.
+    for (const [name, order] of Object.entries(PROFILES)) {
+      const tail = order.slice(-NEWLY_TAUGHT.length);
+      expect(tail, `profile ${name} must end with the newly-taught sources`).toEqual(NEWLY_TAUGHT);
+    }
+  });
+
+  it('worker profile keeps its historical order: assigned_sd before sd_key before qf_id', () => {
+    const o = PROFILES.worker;
+    expect(o.indexOf('payload.assigned_sd')).toBeLessThan(o.indexOf('payload.sd_key'));
+    expect(o.indexOf('payload.sd_key')).toBeLessThan(o.indexOf('payload.qf_id'));
+    expect(o.indexOf('payload.available_sds')).toBeLessThan(o.indexOf('text'));
+    expect(o.indexOf('text')).toBeLessThan(o.indexOf('payload.current_sd'));
+  });
+
+  it('dispatchGuard reads the top-level column FIRST, matching assertSdDispatchable:219', () => {
+    expect(PROFILES.dispatchGuard[0]).toBe('top.target_sd');
+    const v = resolveAssignmentTarget(
+      row({ target_sd: 'SD-FROM-COLUMN-001', payload: { sd_key: 'SD-FROM-PAYLOAD-001' } }),
+      { profile: 'dispatchGuard' }
+    );
+    expect(v.key).toBe('SD-FROM-COLUMN-001');
+  });
+
+  it('dispatchStamp reads assigned_sd FIRST, matching :295/:347/:494/:572', () => {
+    expect(PROFILES.dispatchStamp[0]).toBe('payload.assigned_sd');
+    const v = resolveAssignmentTarget(
+      row({ target_sd: 'SD-FROM-COLUMN-001', payload: { assigned_sd: 'SD-FROM-ASSIGNED-001' } }),
+      { profile: 'dispatchStamp' }
+    );
+    expect(v.key).toBe('SD-FROM-ASSIGNED-001');
+  });
+
+  it('the two dispatch profiles genuinely disagree — that is why one global order was wrong', () => {
+    // A single shared ORDER changed 26 of 70 already-resolving rows when it was tried.
+    // Sharing the REGISTRY removes the asymmetry; sharing an order does not and breaks callers.
+    const r = row({ target_sd: 'SD-COLUMN-001', payload: { assigned_sd: 'SD-ASSIGNED-001' } });
+    expect(resolveAssignmentTarget(r, { profile: 'dispatchGuard' }).key).toBe('SD-COLUMN-001');
+    expect(resolveAssignmentTarget(r, { profile: 'dispatchStamp' }).key).toBe('SD-ASSIGNED-001');
+  });
+});
+
+describe('TR-2 — the directed profile stays narrow', () => {
+  it('ignores queue pointers so a nudge is never mistaken for a directed redirect', () => {
+    // The stale-session-sweep sends every busy claim-holder {available_sds, current_sd}.
+    // Resolving that as a directed target would yank a worker off its own SD.
+    const nudge = row({ payload: { available_sds: ['SD-OTHER-001'], current_sd: 'SD-MINE-001' } });
+    expect(resolveAssignmentTargetKey(nudge, { profile: 'directed' })).toBeNull();
+    // ...while the full worker profile still surfaces it as a pointer.
+    expect(resolveAssignmentTargetKey(nudge, { profile: 'worker' })).toBe('SD-OTHER-001');
+  });
+
+  it('ignores text entirely in directed mode', () => {
+    expect(resolveAssignmentTargetKey(row({ subject: 'QF-20260726-423' }), { profile: 'directed' })).toBeNull();
+  });
+});
+
+describe('TR-1 — the circular-require trap that would make this fix silently inert', () => {
+  it('the resolver is a FUNCTION at load time, not undefined', () => {
+    // Node CJS resolves a circular top-level require to `undefined` rather than throwing. If a
+    // future change reaches this module by having dispatch.cjs require worker-checkin.cjs (which
+    // already top-level-requires dispatch.cjs), the guard built on it would silently never run —
+    // a fix for a silent failure, failing silently. This assertion fails loudly instead.
+    expect(typeof resolveAssignmentTarget).toBe('function');
+    expect(typeof resolveAssignmentTargetKey).toBe('function');
+  });
+
+  it('dispatch.cjs does not require worker-checkin.cjs (the cycle must not exist)', () => {
+    const src = fs.readFileSync(path.join(REPO, 'lib/coordinator/dispatch.cjs'), 'utf8');
+    expect(src).not.toMatch(/require\([^)]*worker-checkin/);
+  });
+
+  it('the shared module requires neither side — it is a leaf', () => {
+    const src = fs.readFileSync(path.join(REPO, 'lib/fleet/assignment-target.cjs'), 'utf8');
+    expect(src).not.toMatch(/require\([^)]*worker-checkin/);
+    expect(src).not.toMatch(/require\([^)]*coordinator\/dispatch/);
+  });
+});
+
+describe('registry auditability', () => {
+  it('every historical source records the incident that introduced it', () => {
+    // The list grew by accretion twice. Tagging keeps it auditable rather than mysterious.
+    expect(SOURCES['payload.qf_id'].since).toBe('QF-20260704-602');
+    expect(SOURCES['payload.qf'].since).toBe('QF-20260707-650');
+    expect(SOURCES['payload.qf_id'].historical).toBe(true);
+  });
+
+  it('a structured column and single-key text agreed on every live row that had both (6/6)', () => {
+    // Because the newly-taught sources are appended last for additivity, single-key TEXT outranks
+    // the top-level column in the worker profile. Measured live that is currently harmless — all
+    // 6 rows carrying both agreed. This pins the preference so that if a future writer makes them
+    // disagree, the choice is a deliberate one someone changed, not an accident.
+    const agreeing = row({ target_sd: 'QF-20260726-642', subject: 'take QF-20260726-642' });
+    expect(resolveAssignmentTargetKey(agreeing, { profile: 'worker' })).toBe('QF-20260726-642');
+    const disagreeing = row({ target_sd: 'QF-AAA-111', subject: 'take QF-BBB-222' });
+    expect(resolveAssignmentTargetKey(disagreeing, { profile: 'worker' })).toBe('QF-BBB-222');
+  });
+});


### PR DESCRIPTION
## The defect

A `WORK_ASSIGNMENT` whose target the worker cannot find is **silently skipped** — no ack, no claim attempt, no warning. The coordinator reads the non-pickup as worker capacity. Third recorded instance; the two prior fixes each added **one more field name to one extractor**, which cannot converge.

## It was never a field list — it was a projection

`getMessagesForSession` selected ten columns and **not `target_sd`**, even though `C.targetSd` was already defined and unused. Every dispatch-side guard reads that column (`assertSdDispatchable` reads it *first*), so those rows were valid to every writer check and invisible to every reader.

Found via a parenthetical in an existing comment: *"|| row.target_sd, which getMessagesForSession does not project"*. Teaching the resolver about the column **without** widening the SELECT would have shipped an inert fix that tests green.

## Measured, live

| | |
|---|---|
| WORK_ASSIGNMENTs sampled | 121 |
| inert **and** unacked | **46** (43%) |
| resolvable via top-level column | 10 |
| QF key in text, regex was SD-anchored | 35 |
| genuinely keyless | 9 |

## What shipped

- **FR-1** — one shared *registry*, seven sites, each keeping its **own precedence**. A single global order changed 26 of 70 already-resolving rows when tried (`SD-…-001-B` → `QF-20260727-259`); that's misrouting, strictly worse than the bug.
- **FR-2** — write-time guard, **observe-only** per protocol default. It resolves with the **reader's** profile: asking "can *I* find a target?" would approve rows the worker can't read — this SD's defect inside its own fix. A test caught that.
- **FR-3** — the sweep's raw insert is *deliberate* (informational nudge, `target_sd: null` on purpose). The **invariant** is shared, not the guard stack.
- **FR-4/5** — top-level column + `payload.target_sd`; multi-key text is **refused, never guessed**.
- **FR-6/7/8** — unreadable rows no longer shadow readable ones and no longer fail silently; backfill classifies rather than retires.

## Acceptance is directional, not identity

`null→key` gain · `key→null` safe refusal · **`key→different key` forbidden**.

Widening the pattern to match QF keys changes first-match *by construction*, so identity was the wrong bar. **Zero forbidden transitions** across all 121 live rows, on the wired path.

## Why refusing beats guessing

A real row in the ambiguous bucket:

> `STAND DOWN — do NOT claim SD-LEO-INFRA-MIGRATION-APPLY-STATE-TRIAGE-001 ...`

First-match resolves that to the **first** key — the one the message exists to say *do not claim*. On a stand-down the guess doesn't pick the wrong target, it **inverts the instruction**.

## Not done, deliberately

The guard is observe-only, so the class is **detectable, not yet unrepresentable**. Promotion needs an observe-window review — and behind it a real decision: 9 live rows are coordinator prose typed as `WORK_ASSIGNMENT`, so binding rejects a current habit. The backfill's `--apply` has **not** been run; retiring rows is a live write worth authorizing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)