### PR TITLE
fix(SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001): FR-2 and FR-3 shipped their logic and never wired it

### DIFF
--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -705,6 +705,60 @@ export async function restart(target, opts = {}) {
     const { isCanaryMetadata } = await import('./canary-session.js');
     if (isCanaryMetadata(oldSession && oldSession.metadata)) accountProfile = CANARY_PROFILE;
   }
+  // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-3 WIRING.
+  //
+  // spawnReplacement's own header says "the caller decides WHETHER to resume (it owns the
+  // transcript-existence check)". No caller ever did. resolveResumePlan, transcriptPathFor and
+  // resumeLaunchFlags shipped correct and fully tested with ZERO production importers, nothing
+  // anywhere stat'd a transcript, and nothing ever set forkSession — so opts.resumeUuid was always
+  // undefined and EVERY REAL RESTART COLD-STARTED SILENTLY, the exact failure FR-3 exists to
+  // prevent. The decision logic and the plumbing both shipped; they were never connected.
+  //
+  // An explicit caller-supplied plan still wins — this only fills the gap when nobody decided.
+  if (opts.resumeUuid === undefined && opts.forkSession === undefined) {
+    const { resolveResumePlan, transcriptPathFor } = await import('./resume-context.mjs');
+    const fs = await import('node:fs');
+    const crypto = await import('node:crypto');
+
+    // The transcript slug derives from the MAIN worktree root, never .worktrees/<id> — a worktree
+    // path resolves to a directory that never exists, silently cold-starting every worktree seat.
+    // git-common-dir returns <main>/.git, so its parent is the main root. Fail soft: if git cannot
+    // answer we pass null and resolveResumePlan cold-starts, which is the safe default.
+    let mainRepoRoot = null;
+    try {
+      const { execFileSync } = await import('node:child_process');
+      const { fileURLToPath } = await import('node:url');
+      // This module is ESM: __dirname does NOT exist here. Deriving it from import.meta.url —
+      // referencing __dirname would throw ReferenceError and the catch below would swallow it into
+      // a permanent silent cold start, which is the very defect this block exists to fix.
+      const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+      const common = execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+        { cwd: path.resolve(moduleDir, '..', '..'), encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+      if (common) mainRepoRoot = path.dirname(common);
+    } catch { /* fail soft -> cold start */ }
+
+    const transcriptPath = transcriptPathFor({ sessionId: oldIdentity.session_id, mainRepoRoot });
+    let transcriptExists = false;
+    try { transcriptExists = Boolean(transcriptPath) && fs.existsSync(transcriptPath); } catch { transcriptExists = false; }
+
+    const plan = resolveResumePlan({
+      sessionId: oldIdentity.session_id,
+      transcriptExists,
+      launchCwd: (oldSession && oldSession.metadata && oldSession.metadata.launch_cwd) || null,
+      newSessionId: opts.newSessionId || crypto.randomUUID(),
+      mainRepoRoot,
+    });
+
+    // Said out loud on purpose: a silent cold start lets the operator believe context survived.
+    console.log(JSON.stringify({
+      event: 'fleet.restart.resume_plan', session_id: oldIdentity.session_id,
+      mode: plan.mode, carries_context: plan.carriesContext, report: plan.report,
+      warnings: plan.warnings, transcript_path: transcriptPath,
+    }));
+
+    opts = { ...opts, resumeUuid: plan.resumeUuid, sessionId: plan.sessionId, forkSession: plan.mode === 'fork' };
+  }
+
   const spawnResult = await spawnReplacement({ oldIdentity, oldSession, accountProfile }, opts);
 
   if (isSingletonRole(role)) {

--- a/scripts/fleet-kill.mjs
+++ b/scripts/fleet-kill.mjs
@@ -73,7 +73,18 @@ export function buildKillDeps(supabase, sessionId, { reason, dryRun = false } = 
     },
     // A dry run exercises every check and stops before the irreversible step.
     kill: dryRun ? async () => {} : undefined,
-    verifyGone: dryRun ? async () => true : undefined,
+    // verifyGone MUST be supplied on the production path. It was previously left undefined here,
+    // and graceful-kill reads it as `gone = verifyGone ? await verifyGone(pid) : true` — so `gone`
+    // was unconditionally true, the SIGKILL escalation was dead code, and the verdict returned
+    // "terminated and verified absent" having verified nothing. A destructive op asserting an
+    // observation it never made is the failure mode this SD exists to remove, not one to ship.
+    //
+    // FAIL CLOSED on the tri-state, for the same reason claudeProbeToTriState refuses to flatten
+    // PROBE_FAILED: gone is true ONLY on a definitive NO_MATCH (the pid is no longer the agent).
+    // MATCH means still alive; undefined means the probe told us nothing. Neither is evidence of
+    // death, so both report not-gone — which escalates to SIGKILL and then honestly returns
+    // 'refused' rather than a status flip we cannot back up.
+    verifyGone: dryRun ? async () => true : async (pid) => claudeProbeToTriState(pidIsClaude(pid)) === false,
   };
 }
 

--- a/tests/unit/fleet/fleet-kill-cli.test.js
+++ b/tests/unit/fleet/fleet-kill-cli.test.js
@@ -3,7 +3,7 @@
 // where a wrong mapping would silently change what the operator is told.
 
 import { describe, it, expect } from 'vitest';
-import { claudeProbeToTriState } from '../../../scripts/fleet-kill.mjs';
+import { claudeProbeToTriState, buildKillDeps } from '../../../scripts/fleet-kill.mjs';
 
 describe('FR2-CLI: pidIsClaude is TRI-STATE and must not be flattened', () => {
   it('MATCH means the pid IS the agent', () => {
@@ -26,5 +26,40 @@ describe('FR2-CLI: pidIsClaude is TRI-STATE and must not be flattened', () => {
     expect(claudeProbeToTriState(undefined)).toBeUndefined();
     expect(claudeProbeToTriState('')).toBeUndefined();
     expect(claudeProbeToTriState(true)).toBeUndefined();
+  });
+});
+
+// FR-2 AC-2-3. buildKillDeps had NO test, and that is exactly where the defect lived: verifyGone
+// was left undefined on the production path, graceful-kill reads it as
+// `gone = verifyGone ? await verifyGone(pid) : true`, so `gone` was unconditionally true, the
+// SIGKILL escalation was dead code, and the verdict claimed "terminated and verified absent"
+// having verified nothing. These assert the DEP SET the operator actually gets.
+describe('FR2-CLI: buildKillDeps supplies verifyGone and it FAILS CLOSED', () => {
+  const deps = (opts) => buildKillDeps({}, 'sess-1', opts);
+
+  it('supplies verifyGone on the PRODUCTION path — the regression that made the kill lie', () => {
+    // Was `undefined` before the fix. If this ever regresses, graceful-kill silently reports a
+    // verification it never performed, so this assertion is the whole point of the file.
+    expect(typeof deps({ dryRun: false }).verifyGone).toBe('function');
+  });
+
+  it('a dry run still short-circuits to true', async () => {
+    await expect(deps({ dryRun: true }).verifyGone(4321)).resolves.toBe(true);
+  });
+
+  // WHY THE MAPPING IS NOT MOCK-TESTED HERE, stated instead of quietly omitted:
+  // fleet-kill.mjs pulls pidIsClaude through createRequire (`require('../lib/fleet/
+  // claimant-liveness.cjs')`), which vi.mock cannot intercept — a mock-based MATCH/PROBE_FAILED
+  // test SILENTLY runs the real probe and passes for the wrong reason. I tried it; every pid came
+  // back NO_MATCH. Asserting the composed expression against a re-derivation instead would be the
+  // same source-text/self-comparison anti-pattern this SD is full of, so it is not done.
+  // The mapping IS covered: the tri-state block above pins claudeProbeToTriState exhaustively, and
+  // verifyGone composes exactly `claudeProbeToTriState(pidIsClaude(pid)) === false`, so only
+  // NO_MATCH yields gone. Making this directly observable needs an injectable probe in
+  // buildKillDeps — a refactor, deliberately outside this wiring fix's scope fence.
+  it('is exactly the fail-closed composition: only NO_MATCH maps to gone', () => {
+    expect(claudeProbeToTriState('NO_MATCH') === false).toBe(true);   // gone
+    expect(claudeProbeToTriState('MATCH') === false).toBe(false);     // still alive
+    expect(claudeProbeToTriState('PROBE_FAILED') === false).toBe(false); // unverifiable -> NOT gone
   });
 });


### PR DESCRIPTION
## Summary

Both FRs merged in the 22-commit stack (#6602) with correct, well-tested logic that **nothing calls**. This connects them. Wiring only, no refactor, per the coordinator's scope fence.

**FR-2 — the kill asserted a verification it never performed.**
`buildKillDeps` left `verifyGone` undefined on the production path (only dry-run supplied a stub). `graceful-kill` reads it as `gone = verifyGone ? await verifyGone(pid) : true`, so `gone` was **unconditionally true**: the SIGKILL escalation was dead code, the `refused` branch unreachable, and the verdict returned *"terminated and verified absent"* having verified nothing.

Now wired to the existing probe and **fail-closed** on its tri-state — `gone` is true only on a definitive `NO_MATCH`. `MATCH` means still alive; `PROBE_FAILED` means the probe told us nothing. Neither is evidence of death, so both report not-gone, escalate, and then honestly return `refused`.

**FR-3 — every real restart cold-started, silently.**
`resolveResumePlan` / `transcriptPathFor` / `resumeLaunchFlags` shipped with **zero production importers**. Nothing stat'd a transcript, nothing ever set `forkSession`, and `opts.resumeUuid` was always undefined. `spawnReplacement`'s own header says *"the caller owns the transcript-existence check"* — no caller did.

`restart()` now resolves the plan: derives the **main** worktree root via `git-common-dir` (never `.worktrees/<id>`, which resolves to a directory that never exists and cold-starts every worktree seat), stats the transcript, and threads `resumeUuid`/`sessionId`/`forkSession`. An explicit caller-supplied plan still wins. The plan is logged either way — a silent cold start lets the operator believe context survived, which is the failure AC-3-2 exists to prevent.

## Test plan

- [x] 41 tests green across `graceful-kill`, `fleet-kill-cli`, `resume-context`, `spawn-resume-threading`
- [x] Added the missing `buildKillDeps` coverage — it had **no** test, which is exactly where the defect lived
- [x] FR-3 verified **behaviourally**, not by source text: run from the worktree it resolves `mainRepoRoot` to the main repo, finds a real transcript, returns `mode=fork carriesContext=true`

**Documented honestly in-file:** the MATCH/PROBE_FAILED mapping is *not* mock-tested because `fleet-kill.mjs` pulls `pidIsClaude` through `createRequire`, which `vi.mock` cannot intercept — a mock-based test silently runs the real probe and passes for the wrong reason (tried it; every pid returned `NO_MATCH`). Asserting a re-derivation instead would repeat the source-text anti-pattern this SD is full of. Making it directly observable needs an injectable probe — a refactor, out of scope.

**Pre-existing, not introduced here:** `tests/unit/fleet/spawn-control.test.js` FR-6 fails in the worktree and passes in the shared root at the same commit — verified by stashing this change and re-running. Environment-dependent, reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
