### PR TITLE
fix(SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001): FR-3 resolution belongs at the choke point, not in restart()

### DIFF
--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -666,13 +666,65 @@ async function spawnReplacement({ oldIdentity, oldSession, accountProfile }, opt
   // cold start, which is the correct default when the conversation could not be verified.
   const launchCwd = (oldSession && oldSession.metadata && oldSession.metadata.launch_cwd) || opts.cwd;
 
+  // FR-3 RESOLUTION LIVES HERE, AT THE CHOKE POINT — moved from restart().
+  //
+  // The PRD specifies this convergence explicitly: "relaunchUnderProfile, canaryRestart and
+  // drainAndRestart, so ONE CHANGE REPAIRS FOUR PATHS". Resolving in restart() repaired only
+  // three: relaunchUnderProfile (and canaryRelaunchUnderProfile through it) call spawnReplacement
+  // DIRECTLY, so they kept cold-starting silently — the same defect, surviving in the one path the
+  // first fix did not route through. Coverage by call-routing is not coverage of the invariant.
+  //
+  // An explicit caller-supplied plan still wins; this only fills the gap when nobody decided.
+  let resumePlan = { resumeUuid: opts.resumeUuid, sessionId: opts.sessionId, forkSession: opts.forkSession };
+  if (opts.resumeUuid === undefined && opts.forkSession === undefined) {
+    const { resolveResumePlan, transcriptPathFor } = await import('./resume-context.mjs');
+    const fs = await import('node:fs');
+    const crypto = await import('node:crypto');
+
+    // The transcript slug derives from the MAIN worktree root, never .worktrees/<id> — a worktree
+    // path resolves to a directory that never exists, silently cold-starting every worktree seat.
+    // git-common-dir returns <main>/.git, so its parent is the main root. Fail soft -> cold start.
+    let mainRepoRoot = null;
+    try {
+      const { execFileSync } = await import('node:child_process');
+      const { fileURLToPath } = await import('node:url');
+      // ESM: __dirname does NOT exist here. Referencing it would throw ReferenceError and the catch
+      // would swallow it into a permanent silent cold start — the very defect this block removes.
+      const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+      const common = execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'],
+        { cwd: path.resolve(moduleDir, '..', '..'), encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+      if (common) mainRepoRoot = path.dirname(common);
+    } catch { /* fail soft -> cold start */ }
+
+    const transcriptPath = transcriptPathFor({ sessionId: oldIdentity.session_id, mainRepoRoot });
+    let transcriptExists = false;
+    try { transcriptExists = Boolean(transcriptPath) && fs.existsSync(transcriptPath); } catch { transcriptExists = false; }
+
+    const plan = resolveResumePlan({
+      sessionId: oldIdentity.session_id,
+      transcriptExists,
+      launchCwd: launchCwd || null,
+      newSessionId: opts.newSessionId || crypto.randomUUID(),
+      mainRepoRoot,
+    });
+
+    // Said out loud on purpose: a silent cold start lets the operator believe context survived.
+    console.log(JSON.stringify({
+      event: 'fleet.restart.resume_plan', session_id: oldIdentity.session_id,
+      mode: plan.mode, carries_context: plan.carriesContext, report: plan.report,
+      warnings: plan.warnings, transcript_path: transcriptPath,
+    }));
+
+    resumePlan = { resumeUuid: plan.resumeUuid, sessionId: plan.sessionId, forkSession: plan.mode === 'fork' };
+  }
+
   return spawn({ role, callsign, accountProfile }, {
     ...opts,
     skipDedup: true,
     cwd: launchCwd,
-    resumeUuid: opts.resumeUuid,
-    sessionId: opts.sessionId,
-    forkSession: opts.forkSession,
+    resumeUuid: resumePlan.resumeUuid,
+    sessionId: resumePlan.sessionId,
+    forkSession: resumePlan.forkSession,
   });
 }
 
@@ -725,60 +777,9 @@ export async function restart(target, opts = {}) {
     const { isCanaryMetadata } = await import('./canary-session.js');
     if (isCanaryMetadata(oldSession && oldSession.metadata)) accountProfile = CANARY_PROFILE;
   }
-  // SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 / FR-3 WIRING.
-  //
-  // spawnReplacement's own header says "the caller decides WHETHER to resume (it owns the
-  // transcript-existence check)". No caller ever did. resolveResumePlan, transcriptPathFor and
-  // resumeLaunchFlags shipped correct and fully tested with ZERO production importers, nothing
-  // anywhere stat'd a transcript, and nothing ever set forkSession — so opts.resumeUuid was always
-  // undefined and EVERY REAL RESTART COLD-STARTED SILENTLY, the exact failure FR-3 exists to
-  // prevent. The decision logic and the plumbing both shipped; they were never connected.
-  //
-  // An explicit caller-supplied plan still wins — this only fills the gap when nobody decided.
-  if (opts.resumeUuid === undefined && opts.forkSession === undefined) {
-    const { resolveResumePlan, transcriptPathFor } = await import('./resume-context.mjs');
-    const fs = await import('node:fs');
-    const crypto = await import('node:crypto');
-
-    // The transcript slug derives from the MAIN worktree root, never .worktrees/<id> — a worktree
-    // path resolves to a directory that never exists, silently cold-starting every worktree seat.
-    // git-common-dir returns <main>/.git, so its parent is the main root. Fail soft: if git cannot
-    // answer we pass null and resolveResumePlan cold-starts, which is the safe default.
-    let mainRepoRoot = null;
-    try {
-      const { execFileSync } = await import('node:child_process');
-      const { fileURLToPath } = await import('node:url');
-      // This module is ESM: __dirname does NOT exist here. Deriving it from import.meta.url —
-      // referencing __dirname would throw ReferenceError and the catch below would swallow it into
-      // a permanent silent cold start, which is the very defect this block exists to fix.
-      const moduleDir = path.dirname(fileURLToPath(import.meta.url));
-      const common = execFileSync('git', ['rev-parse', '--path-format=absolute', '--git-common-dir'],
-        { cwd: path.resolve(moduleDir, '..', '..'), encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
-      if (common) mainRepoRoot = path.dirname(common);
-    } catch { /* fail soft -> cold start */ }
-
-    const transcriptPath = transcriptPathFor({ sessionId: oldIdentity.session_id, mainRepoRoot });
-    let transcriptExists = false;
-    try { transcriptExists = Boolean(transcriptPath) && fs.existsSync(transcriptPath); } catch { transcriptExists = false; }
-
-    const plan = resolveResumePlan({
-      sessionId: oldIdentity.session_id,
-      transcriptExists,
-      launchCwd: (oldSession && oldSession.metadata && oldSession.metadata.launch_cwd) || null,
-      newSessionId: opts.newSessionId || crypto.randomUUID(),
-      mainRepoRoot,
-    });
-
-    // Said out loud on purpose: a silent cold start lets the operator believe context survived.
-    console.log(JSON.stringify({
-      event: 'fleet.restart.resume_plan', session_id: oldIdentity.session_id,
-      mode: plan.mode, carries_context: plan.carriesContext, report: plan.report,
-      warnings: plan.warnings, transcript_path: transcriptPath,
-    }));
-
-    opts = { ...opts, resumeUuid: plan.resumeUuid, sessionId: plan.sessionId, forkSession: plan.mode === 'fork' };
-  }
-
+  // FR-3 resume resolution now lives in spawnReplacement (the choke point), so restart(),
+  // relaunchUnderProfile(), canaryRestart() and drainAndRestart() all inherit it — the four paths
+  // the PRD names. Resolving here covered only the three that route through restart().
   const spawnResult = await spawnReplacement({ oldIdentity, oldSession, accountProfile }, opts);
 
   if (isSingletonRole(role)) {


### PR DESCRIPTION
## Summary

Follow-up to #6626. That fix resolved the resume plan in `restart()`, which covered **three of four** paths — `relaunchUnderProfile()` and `canaryRelaunchUnderProfile()` call `spawnReplacement` directly, so they kept cold-starting silently. The same defect, surviving in the one path the fix didn't route through. Coverage by call-routing is not coverage of the invariant.

The PRD specifies the convergence in its own words: *"relaunchUnderProfile, canaryRestart and drainAndRestart, so **one change repairs four paths**."* This moves the resolution into `spawnReplacement` so all four inherit it from a single definition.

Behaviour otherwise unchanged: an explicit caller-supplied `resumeUuid`/`forkSession` still wins, the main-repo-root derivation and transcript stat are identical, and the plan is still logged either way so a cold start is never silent.

## Test plan

- [x] Exactly **one** `resolveResumePlan` call site (was 1 in `restart()`, now 1 in `spawnReplacement`)
- [x] Both `spawnReplacement` callers — `restart` and `relaunchUnderProfile` — reach it
- [x] Module loads (catches the ESM/`__dirname` class of error that a `catch` would otherwise swallow into a permanent silent cold start)
- [x] 41 targeted tests green across `resume-context`, `spawn-resume-threading`, `fleet-kill-cli`, `graceful-kill`
- [x] `spawn-control.test.js` 64/64

Found by the STORIES sub-agent re-assessing the merged code — it enumerated the call routing rather than assuming inheritance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
