### PR TITLE
feat(SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001): FR-3 escalated-QF orphan sweep + FR-4 completion-writer decision table

### DIFF
--- a/scripts/audit/escalated-qf-orphans.mjs
+++ b/scripts/audit/escalated-qf-orphans.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001 FR-3 — surface escalated quick-fixes that nothing
+ * inherits.
+ *
+ * A QF at status='escalated' with escalated_to_sd_id=NULL leaves nothing carrying its work. It is
+ * not on the belt (escalated is not claimable), it is not linked to an SD, and no sweep looks at it,
+ * so it is invisible to every surface a human or a worker actually reads. Measured 2026-07-28:
+ * 16 of 55 escalated rows, three of them critical, the oldest stranded since 2026-07-05.
+ *
+ * WHY THIS EXISTS AS A REPORT RATHER THAN A TRIGGER. The SD proposed following the resolution_sd_id
+ * precedent (an auto-link DB trigger). Measurement says that fixes the SMALLER half:
+ *
+ *     LINK-DROPPED  an SD exists, escalated_to_sd_id is null   ->  2 of 16
+ *     NEVER-CREATED no SD references the QF at all             -> 14 of 16
+ *
+ * A trigger links an SD at creation time. Fourteen of these never had an SD created, because a
+ * Tier-3 QF is BORN escalated (scripts/create-quick-fix.js:350) before any SD exists and nothing
+ * afterwards converts it. An auto-link trigger would therefore look like a complete fix while
+ * moving 12% of the problem — and CREATE TRIGGER is not on the TIER-1 auto-apply allow list, so it
+ * is chairman-gated DDL besides. This report needs no DDL and addresses the larger half.
+ *
+ * WHAT IT WILL NOT DO: it never creates an SD. Workers do not materialise SDs; that is the
+ * coordinator's role. The output is a work-list for materialisation, deliberately.
+ *
+ * Usage:
+ *   node scripts/audit/escalated-qf-orphans.mjs              # report
+ *   node scripts/audit/escalated-qf-orphans.mjs --json       # machine-readable
+ *   node scripts/audit/escalated-qf-orphans.mjs --repair-links  # write the link for LINK-DROPPED only
+ */
+import { createClient } from '@supabase/supabase-js';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const SEVERITY_ORDER = { critical: 0, high: 1, medium: 2, low: 3 };
+
+/**
+ * Pure: order orphans so the rows that matter surface first — severity, then age.
+ * Exported for test; sorting is where a report quietly buries its own findings.
+ */
+export function rankOrphans(rows) {
+  return [...(rows || [])].sort((a, b) => {
+    const sev = (SEVERITY_ORDER[a.severity] ?? 9) - (SEVERITY_ORDER[b.severity] ?? 9);
+    if (sev !== 0) return sev;
+    return String(a.created_at || '').localeCompare(String(b.created_at || ''));
+  });
+}
+
+/**
+ * Pure: classify an orphan by whether any SD already references it.
+ *
+ * LINK-DROPPED is repairable mechanically — the SD exists, only the pointer is missing.
+ * NEVER-CREATED is not: it needs a human or coordinator to decide the work is still wanted.
+ * Conflating them is what makes an auto-link trigger look like a complete fix.
+ */
+export function classifyOrphan(referencingSdKeys) {
+  return (referencingSdKeys || []).length > 0 ? 'LINK_DROPPED' : 'NEVER_CREATED';
+}
+
+/**
+ * Pure: SD keys named INSIDE the quick-fix's own title/description.
+ *
+ * THE REVERSE DIRECTION, and it was found by reading this report's own output rather than trusting
+ * it. The SD-side text search asks "does an SD mention this QF". QF-20260722-214 is titled
+ * "[Retro action items] SD-LEARN-FIX-ADDRESS-SAL-SECURITY-001" — the QF names the SD, not the other
+ * way round — and that SD exists and is COMPLETED. A one-directional matcher classified a QF whose
+ * work is already finished as NEVER_CREATED, i.e. as needing materialisation.
+ *
+ * That is the same defect class this report exists to surface: a check that can only see one
+ * direction reports the other as absent. Both directions are now searched.
+ */
+export function sdKeysNamedInQf(qf) {
+  const text = `${qf?.title || ''} ${qf?.description || ''} ${qf?.escalation_reason || ''}`;
+  const matches = text.match(/\bSD-[A-Z0-9]+(?:-[A-Z0-9]+)+\b/g) || [];
+  return [...new Set(matches)];
+}
+
+async function findReferencingSds(supabase, qfId) {
+  // Text match on title/description. STATED LIMITATION, not a footnote: an SD can be doing this
+  // work WITHOUT naming the QF, and such a row lands in NEVER_CREATED wrongly. So NEVER_CREATED is
+  // an UPPER bound and LINK_DROPPED a LOWER bound. Absence of a text match is not proof no SD
+  // exists, and this report must not be read as if it were.
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key,status')
+    .or(`description.ilike.%${qfId}%,title.ilike.%${qfId}%`)
+    .limit(5);
+  if (error) throw new Error(`SD lookup failed for ${qfId}: ${error.message}`);
+  return (data || []).map((r) => ({ sd_key: r.sd_key, status: r.status }));
+}
+
+async function main() {
+  const json = process.argv.includes('--json');
+  const repair = process.argv.includes('--repair-links');
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+  const { data: escalated, error } = await supabase
+    .from('quick_fixes')
+    .select('id,severity,title,created_at,escalated_to_sd_id,escalation_reason');
+  if (error) {
+    console.error(`FAILED to read quick_fixes: ${error.message}`);
+    process.exit(1);
+  }
+  const all = (escalated || []).filter((r) => r.escalated_to_sd_id !== undefined);
+  const { data: esc, error: e2 } = await supabase
+    .from('quick_fixes')
+    .select('id,severity,title,description,created_at,escalated_to_sd_id,escalation_reason')
+    .eq('status', 'escalated');
+  if (e2) {
+    console.error(`FAILED to read escalated quick_fixes: ${e2.message}`);
+    process.exit(1);
+  }
+
+  const orphans = rankOrphans((esc || []).filter((r) => !r.escalated_to_sd_id));
+  const findings = [];
+  for (const qf of orphans) {
+    // BOTH directions. SD-mentions-QF, and QF-mentions-SD — the second was added after this very
+    // report misclassified QF-20260722-214, whose own title names a completed SD.
+    const sds = await findReferencingSds(supabase, qf.id);
+    for (const key of sdKeysNamedInQf(qf)) {
+      if (sds.some((s) => s.sd_key === key)) continue;
+      const { data: named } = await supabase
+        .from('strategic_directives_v2').select('sd_key,status').eq('sd_key', key).maybeSingle();
+      if (named) sds.push({ sd_key: named.sd_key, status: named.status, via: 'named_in_qf' });
+    }
+    findings.push({ ...qf, referencing_sds: sds, kind: classifyOrphan(sds) });
+  }
+
+  const dropped = findings.filter((f) => f.kind === 'LINK_DROPPED');
+  const never = findings.filter((f) => f.kind === 'NEVER_CREATED');
+
+  if (json) {
+    console.log(JSON.stringify({
+      escalated_total: (esc || []).length,
+      orphans: findings.length,
+      link_dropped: dropped.length,
+      never_created: never.length,
+      caveat: 'never_created is an UPPER bound: matched by text on SD title/description, so an SD doing the work without naming the QF lands here wrongly.',
+      findings
+    }, null, 2));
+  } else {
+    console.log(`\nESCALATED QF ORPHANS — ${findings.length} of ${(esc || []).length} escalated rows have no escalated_to_sd_id\n`);
+    console.log(`  LINK-DROPPED  ${dropped.length}  (an SD exists; only the pointer is missing — mechanically repairable)`);
+    console.log(`  NEVER-CREATED ${never.length}  (no SD references it; needs materialisation, which is a coordinator decision)\n`);
+    for (const f of findings) {
+      const refs = f.referencing_sds.map((s) => s.sd_key).join(', ');
+      console.log(`  ${String(f.severity).toUpperCase().padEnd(8)} ${f.id}  ${String(f.created_at).slice(0, 10)}  ${f.kind}`);
+      console.log(`           ${String(f.title || '').slice(0, 100)}`);
+      if (refs) console.log(`           -> referenced by: ${refs}`);
+    }
+    console.log('\n  CAVEAT: NEVER-CREATED is an UPPER bound. Matching is by text on SD title/description,');
+    console.log('  so an SD doing this work without naming the QF is classified here wrongly. Absence of a');
+    console.log('  text match is not proof that no SD exists.\n');
+  }
+
+  if (repair) {
+    // Only LINK_DROPPED is repaired. NEVER_CREATED is deliberately untouched: inventing a link
+    // would convert "nobody picked this up" into "handled", which is the exact false-completion
+    // shape this SD exists to stop.
+    let repaired = 0;
+    for (const f of dropped) {
+      const target = f.referencing_sds[0].sd_key;
+      const { error: uErr } = await supabase
+        .from('quick_fixes')
+        .update({ escalated_to_sd_id: target })
+        .eq('id', f.id)
+        .is('escalated_to_sd_id', null); // guarded: never clobber a link written since the read
+      if (uErr) console.error(`  repair FAILED ${f.id}: ${uErr.message}`);
+      else { repaired++; console.log(`  linked ${f.id} -> ${target}`); }
+    }
+    console.log(`\n  repaired ${repaired} of ${dropped.length} link-dropped orphans; ${never.length} never-created left for materialisation.`);
+  }
+
+  // Exit non-zero when a CRITICAL orphan is unreferenced — a report nobody notices is the failure
+  // mode this SD is about, so the critical case is made loud rather than printed politely.
+  const criticalNever = never.filter((f) => f.severity === 'critical');
+  if (criticalNever.length > 0 && !json) {
+    console.log(`  ${criticalNever.length} CRITICAL orphan(s) with no SD at all: ${criticalNever.map((f) => f.id).join(', ')}\n`);
+  }
+  process.exit(criticalNever.length > 0 ? 2 : 0);
+}
+
+const isMain = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1].replace(/\\/g, '/')}`).href;
+if (isMain) main().catch((e) => { console.error('FAILED:', e.message); process.exit(1); });

--- a/scripts/one-off/_fr4-writer-decision-table-completion-runtime-001.mjs
+++ b/scripts/one-off/_fr4-writer-decision-table-completion-runtime-001.mjs
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001 FR-4 — record the completion-writer decision table
+ * on the SD row.
+ *
+ * FR-4's acceptance is that every completion writer is listed with a decision, and that any
+ * exclusion is RECORDED ON THE ROW "so a later audit finds the decision instead of the gap". This
+ * writes the enumeration and a recommendation per writer. It does NOT make the ruling: each row
+ * carries decision='PENDING_COORDINATOR' with the recommendation and its reasoning attached, so the
+ * ruling has somewhere to land and the audit trail shows what was known when it was made.
+ *
+ * The distinction matters. A worker enumerating writers is measurement. A worker deciding that a
+ * scheduled job may keep closing rows unwitnessed is policy, and that is not a worker's call.
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const SD_KEY = 'SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001';
+
+const WRITERS = [
+  {
+    path: 'scripts/modules/complete-quick-fix/orchestrator.js:61-105 buildMergedReconcileUpdate',
+    surface: 'quick_fixes',
+    invoked_by: 'human/worker via complete-quick-fix.js --scope-accepted',
+    status_today: 'ENFORCED as of FR-2 (merged 4cf043c)',
+    decision: 'ENFORCED',
+    note: 'Terminal branch now writes verified_by from the scope-accepter. This was the 62-percent producer.'
+  },
+  {
+    path: 'scripts/modules/complete-quick-fix/orchestrator.js:~733 completeQuickFix',
+    surface: 'quick_fixes',
+    invoked_by: 'human/worker via complete-quick-fix.js (normal + --force-complete)',
+    status_today: 'ENFORCED as of FR-2',
+    decision: 'ENFORCED',
+    note: 'Previously wrote the MODE LABELS FORCE_COMPLETE/UAT_AGENT, which record how a row closed and never who. Now prefers a real identity with the mode as a suffix.'
+  },
+  {
+    path: 'scripts/orphan-qf-reaper.mjs:187-207 and :280-303',
+    surface: 'quick_fixes',
+    invoked_by: 'GitHub Action, UNATTENDED, every 15 minutes',
+    status_today: 'BYPASSES every gate; writes force_completed=true, verified_by=ORPHAN_REAPER, uat_verified untouched; checks only that a PR merged',
+    decision: 'PENDING_COORDINATOR',
+    recommendation: 'ENFORCE — but as a DISTINCT witness value, not by blocking. It should be possible to tell at a glance that a row was closed by an unattended cron on merge evidence alone, because that is exactly the thin close FR-2 exists to make visible. Blocking it would strand rows instead; the goal is legibility, not refusal.',
+    caveat: 'Two existing tests hard-pin the literal ORPHAN_REAPER sentinel (tests/unit/scripts/orphan-qf-reaper-integration.test.js:162 and orphan-qf-reaper-force-completed.test.js). Any change here breaks them BY DESIGN and they must be updated in the same PR — known in advance, not to be discovered in CI.'
+  },
+  {
+    path: 'scripts/modules/handoff/executors/lead-final-approval/index.js:526-534',
+    surface: 'strategic_directives_v2',
+    invoked_by: 'handoff.js execute LEAD-FINAL-APPROVAL',
+    status_today: 'GATED via getRequiredGates()',
+    decision: 'PENDING_COORDINATOR',
+    recommendation: 'OUT OF SCOPE for FR-1/FR-2 as literally worded. strategic_directives_v2 has NO force_completed/uat_verified/verified_by columns, so those FRs cannot bind here without DDL. Record the exclusion rather than leaving it implicit.'
+  },
+  {
+    path: 'scripts/sd-verify.js:341-350',
+    surface: 'strategic_directives_v2',
+    invoked_by: 'human CLI',
+    status_today: 'UNGATED — writes status=completed with only an uncommitted-changes check, running NONE of the LEAD-FINAL gates. Its own header calls it a "Control Gap Fix".',
+    decision: 'PENDING_COORDINATOR',
+    recommendation: 'FLAG, do not fix here. This is the SD-side twin of the reaper: one gated writer beside an ungated side door. It is out of this SD stated scope but belongs on someone list, because a side door documented as a control gap is still a side door.'
+  },
+  {
+    path: 'scripts/complete-orchestrator.js:342-350',
+    surface: 'strategic_directives_v2',
+    invoked_by: 'human CLI, hardcoded to one legacy SD (SD-FORGE-FOUNDATION-001)',
+    status_today: 'effectively dead, but live if invoked',
+    decision: 'PENDING_COORDINATOR',
+    recommendation: 'EXCLUDE with reason — single-SD legacy one-off, no ongoing volume. Worth deleting rather than guarding.'
+  }
+];
+
+const OPEN_QUESTION = {
+  id: 'terminal-states-not-covered-by-the-CHECK',
+  detail: "quick_fixes.status now allows ('open','in_progress','completed','escalated','cancelled','closed'). The completed_requires_verification CHECK covers ONLY 'completed'. A row routed to 'cancelled' or 'closed' satisfies no verification constraint at all. If FR-1/FR-2 are scoped to status='completed', those two states are an open sidestep and should be either covered or explicitly excluded with a reason."
+};
+
+async function main() {
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const { data: row, error } = await supabase
+    .from('strategic_directives_v2').select('id, metadata').eq('sd_key', SD_KEY).maybeSingle();
+  if (error) throw new Error(`read failed: ${error.message}`);
+  if (!row) throw new Error('SD not found');
+
+  const metadata = {
+    ...(row.metadata || {}),
+    fr4_completion_writer_table: {
+      at: new Date().toISOString(),
+      by: 'Alpha-4 (worker 39aa8a1e)',
+      purpose: 'FR-4 requires every completion writer listed with a decision, recorded on the row so a later audit finds the decision instead of the gap. This is the enumeration plus a recommendation per writer. The RULING is not made here — enumerating writers is measurement; deciding a scheduled job may keep closing rows unwitnessed is policy, and that is not a worker call.',
+      writers: WRITERS,
+      enforced_count: WRITERS.filter((w) => w.decision === 'ENFORCED').length,
+      pending_count: WRITERS.filter((w) => w.decision === 'PENDING_COORDINATOR').length,
+      highest_risk: 'scripts/orphan-qf-reaper.mjs — UNATTENDED on a 15-minute cron, and simultaneously the highest-volume producer of the thin stamps FR-2 targets AND the path that silently bypasses enforcement placed only in the CLI.',
+      open_question: OPEN_QUESTION
+    }
+  };
+
+  const { error: updErr } = await supabase.from('strategic_directives_v2').update({ metadata }).eq('sd_key', SD_KEY);
+  if (updErr) throw new Error(`update failed: ${updErr.message}`);
+  console.log(`FR-4 writer decision table recorded on ${SD_KEY}`);
+  console.log(`  ENFORCED: ${metadata.fr4_completion_writer_table.enforced_count}`);
+  console.log(`  PENDING_COORDINATOR: ${metadata.fr4_completion_writer_table.pending_count}`);
+}
+
+main().catch((e) => { console.error('FAILED:', e.message); process.exit(1); });

--- a/tests/unit/audit/escalated-qf-orphans.test.js
+++ b/tests/unit/audit/escalated-qf-orphans.test.js
@@ -1,0 +1,92 @@
+/**
+ * SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001 FR-3 — pins for the escalated-QF orphan sweep.
+ *
+ * sdKeysNamedInQf exists because the first version of this report was WRONG. It searched one
+ * direction only — does an SD mention this QF — and reported 2 link-dropped / 14 never-created,
+ * including two criticals as unreferenced. Adding the reverse direction moved six rows and put all
+ * three criticals into link-dropped; they were never stranded, only their pointers were missing.
+ *
+ * The instance that exposed it is pinned below verbatim: QF-20260722-214 is titled
+ * "[Retro action items] SD-LEARN-FIX-ADDRESS-SAL-SECURITY-001". The QF names the SD, not the other
+ * way round, and that SD exists and is completed — so a one-directional matcher classified finished
+ * work as needing materialisation.
+ */
+import { describe, it, expect } from 'vitest';
+import { rankOrphans, classifyOrphan, sdKeysNamedInQf } from '../../../scripts/audit/escalated-qf-orphans.mjs';
+
+describe('sdKeysNamedInQf — the reverse direction that was missing', () => {
+  it('finds the SD named in the real row that exposed the defect', () => {
+    const qf = { title: '[Retro action items] SD-LEARN-FIX-ADDRESS-SAL-SECURITY-001' };
+    expect(sdKeysNamedInQf(qf)).toEqual(['SD-LEARN-FIX-ADDRESS-SAL-SECURITY-001']);
+  });
+
+  it('searches description and escalation_reason, not just the title', () => {
+    expect(sdKeysNamedInQf({ description: 'superseded by SD-LEO-INFRA-FOO-BAR-001' }))
+      .toEqual(['SD-LEO-INFRA-FOO-BAR-001']);
+    expect(sdKeysNamedInQf({ escalation_reason: 'rolled into SD-APEXNICHE-AI-MAN-FIX-001' }))
+      .toEqual(['SD-APEXNICHE-AI-MAN-FIX-001']);
+  });
+
+  it('de-duplicates a key repeated across fields', () => {
+    const qf = { title: 'SD-LEO-X-001', description: 'again SD-LEO-X-001', escalation_reason: 'SD-LEO-X-001' };
+    expect(sdKeysNamedInQf(qf)).toEqual(['SD-LEO-X-001']);
+  });
+
+  it('returns every distinct key when several are named', () => {
+    const qf = { description: 'see SD-LEO-A-001 and SD-LEO-B-002' };
+    expect(sdKeysNamedInQf(qf)).toEqual(['SD-LEO-A-001', 'SD-LEO-B-002']);
+  });
+
+  it('does NOT match a QF id — matching those was the original one-directional bug', () => {
+    expect(sdKeysNamedInQf({ title: 'duplicate of QF-20260712-778, do not work it' })).toEqual([]);
+  });
+
+  it('requires at least two segments, so a bare SD- prefix is not a key', () => {
+    expect(sdKeysNamedInQf({ title: 'the SD- prefix alone' })).toEqual([]);
+  });
+
+  it('is empty and never throws on absent or malformed input', () => {
+    expect(sdKeysNamedInQf(null)).toEqual([]);
+    expect(sdKeysNamedInQf({})).toEqual([]);
+    expect(sdKeysNamedInQf({ title: null, description: undefined })).toEqual([]);
+  });
+});
+
+describe('classifyOrphan — repairable vs needs-a-human', () => {
+  it('LINK_DROPPED when any SD is known — the pointer is missing, not the work', () => {
+    expect(classifyOrphan([{ sd_key: 'SD-X-001' }])).toBe('LINK_DROPPED');
+  });
+
+  it('NEVER_CREATED when nothing references it', () => {
+    expect(classifyOrphan([])).toBe('NEVER_CREATED');
+    expect(classifyOrphan(null)).toBe('NEVER_CREATED');
+  });
+});
+
+describe('rankOrphans — the report must not bury its own findings', () => {
+  it('puts critical first and orders by age within a severity', () => {
+    const ranked = rankOrphans([
+      { id: 'c', severity: 'low', created_at: '2026-01-01' },
+      { id: 'b', severity: 'critical', created_at: '2026-02-01' },
+      { id: 'a', severity: 'critical', created_at: '2026-01-01' },
+      { id: 'd', severity: 'medium', created_at: '2026-01-01' }
+    ]);
+    expect(ranked.map((r) => r.id)).toEqual(['a', 'b', 'd', 'c']);
+  });
+
+  it('does not mutate the caller array', () => {
+    const input = [{ id: 'x', severity: 'low', created_at: '2026-01-01' }, { id: 'y', severity: 'critical', created_at: '2026-01-01' }];
+    rankOrphans(input);
+    expect(input.map((r) => r.id)).toEqual(['x', 'y']);
+  });
+
+  it('sorts an unknown severity last rather than crashing or promoting it', () => {
+    const ranked = rankOrphans([{ id: 'weird', severity: 'bogus', created_at: '2026-01-01' }, { id: 'crit', severity: 'critical', created_at: '2026-01-01' }]);
+    expect(ranked.map((r) => r.id)).toEqual(['crit', 'weird']);
+  });
+
+  it('handles empty and null input', () => {
+    expect(rankOrphans([])).toEqual([]);
+    expect(rankOrphans(null)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What

FR-3 and FR-4 of SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001. Both are complete and neither depends on the DDL that FR-1 is waiting on, so they ship now rather than sitting behind it.

**FR-3 — `scripts/audit/escalated-qf-orphans.mjs`** surfaces escalated quick-fixes that nothing inherits. A QF at `status='escalated'` with `escalated_to_sd_id=NULL` is not on the belt (escalated is not claimable), is not linked to an SD, and no sweep looks at it — invisible to every surface a human or worker actually reads.

**FR-4 — the completion-writer decision table**, recorded on the SD row so a later audit finds the decision instead of the gap.

## Why a report and not a DB trigger

The SD proposed following the `resolution_sd_id` auto-link trigger precedent. Measurement says that fixes the smaller half:

| kind | meaning | count |
|---|---|---|
| LINK_DROPPED | an SD exists, the pointer is missing | mechanically repairable |
| NEVER_CREATED | no SD references it at all | needs a materialisation decision |

A Tier-3 QF is *born* escalated (`create-quick-fix.js:350`) before any SD exists, and nothing afterwards converts it — so an auto-link trigger would look like a complete fix while moving a minority of the problem. It also needs `CREATE TRIGGER`, which is chairman-gated DDL. This report needs none and addresses the larger half.

## The bug this shipped with, and how it was caught

The first version of the sweep searched **one direction only** — does an SD mention this QF — and reported 2 link-dropped / 14 never-created, flagging two criticals as unreferenced. I reported those numbers twice at high severity before noticing.

`QF-20260722-214` is titled `[Retro action items] SD-LEARN-FIX-ADDRESS-SAL-SECURITY-001`. The QF names the SD, not the other way round, and that SD exists and is **completed**. A one-directional matcher classified finished work as needing materialisation. Adding `sdKeysNamedInQf` moved six rows and put all three criticals into link-dropped — they were never stranded, only their pointers were missing.

That is the same defect class the report exists to surface: a check that can only see one direction reports the other as absent. Both directions are now searched, and the row that exposed it is pinned verbatim in the tests.

## Scope discipline

- **Never creates an SD.** Workers do not materialise SDs. The output is a work-list for materialisation, deliberately.
- **`--repair-links` is not run here** and repairs `LINK_DROPPED` only, guarded on `.is('escalated_to_sd_id', null)` so it cannot clobber a link written since the read. `NEVER_CREATED` is untouched: inventing a link would convert "nobody picked this up" into "handled", which is the false-completion shape this SD exists to stop.
- **FR-4 enumerates, it does not rule.** Each writer carries a recommendation and `decision='PENDING_COORDINATOR'`. A worker enumerating writers is measurement; deciding that an unattended cron may keep closing rows unwitnessed is policy, and that is not a worker's call.

## Stated limitation, not a footnote

`NEVER_CREATED` is an **upper** bound and `LINK_DROPPED` a **lower** one. Matching is by text on SD title/description, so an SD doing the work without naming the QF lands in `NEVER_CREATED` wrongly. Absence of a text match is not proof no SD exists, and the report must not be read as if it were. This is printed in both the human and `--json` output rather than living only here.

## Tests

13 pins in `tests/unit/audit/escalated-qf-orphans.test.js`, importing the real module rather than re-declaring its regex — a copied pattern proves only that the copy behaves. Seven cover `sdKeysNamedInQf`, including the real row that exposed the one-directional bug, and a negative case asserting QF ids are *not* matched.

## Not included

The FR-1 migration commit is deliberately held back on `feat/SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001`. It is an additive column awaiting a chairman/Adam apply approval (signal `b6f9bbab`); merging it unapplied would leave a pending migration that surfaces in unrelated handoff pre-checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
