### PR TITLE
test(SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001): pin FR-2 second writer, which shipped unpinned

### DIFF
--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -84,6 +84,37 @@ export function witnessNameFrom(scopeAcceptedBy) {
   return name.length > 120 ? `${name.slice(0, 117)}...` : name;
 }
 
+/**
+ * SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001 FR-2, second writer — build the verified_by stamp
+ * for the direct completion path.
+ *
+ * EXTRACTED FROM AN INLINE IIFE SO IT CAN BE ASSERTED, and that is the whole point of this change:
+ * the behaviour was already shipped but UNPINNED, and unpinned in the specific way that hides a
+ * regression. The only test naming FORCE_COMPLETE asserts FORCE_COMPLETE_NO_REASON — a different
+ * thing — so nothing covered this value. Worse, the fallback makes the gap invisible: under test
+ * CLAUDE_SESSION_ID is unset and no --scope-accepted is passed, so `who` is null and the function
+ * returns the bare mode label. A test written against the live behaviour would therefore have
+ * observed EXACTLY the pre-FR-2 output and passed, certifying the old behaviour while the
+ * improvement went unexercised. Reverting the identity logic entirely would not have failed a
+ * single test.
+ *
+ * Pure by construction — sessionId is a PARAMETER, not a process.env read — because a function that
+ * reaches for ambient state can only be tested by mutating the environment, and the branch that
+ * matters here is precisely the one ambient state suppresses.
+ *
+ * BEHAVIOUR IS UNCHANGED, deliberately: same precedence (explicit scope-accepter, then the operator
+ * session, then neither), same `<who> (<MODE>)` shape, same bare-mode fallback. The mode is kept as
+ * a suffix so anything classifying rows on these literals keeps the distinction it relied on.
+ *
+ * @param {{forceComplete?: boolean, scopeAcceptedBy?: string|null, sessionId?: string|null}} args
+ * @returns {string} never null — a close is always attributable to at least its mode
+ */
+export function completionModeStamp({ forceComplete = false, scopeAcceptedBy = null, sessionId = null } = {}) {
+  const mode = forceComplete ? 'FORCE_COMPLETE' : 'UAT_AGENT';
+  const who = witnessNameFrom(scopeAcceptedBy) || sessionId || null;
+  return who ? `${who} (${mode})` : mode;
+}
+
 export function buildMergedReconcileUpdate({ qf = {}, prUrl, mergeSha = null, nowIso, scopeAcceptedBy = null }) {
   // QF-20260725-691: a merged PR witnesses that CODE LANDED. Terminal `completed` asserts that
   // the QF's SCOPE WAS SATISFIED. Those are different propositions and this path used to
@@ -736,11 +767,11 @@ export async function completeQuickFix(qfId, options = {}) {
       // Prefer a real identity when one exists: the scope-accepter, else the operator session that
       // ran the command. The mode is preserved as a suffix so nothing that reads these values for
       // classification loses the distinction it relied on.
-      verified_by: (() => {
-        const mode = options.forceComplete ? 'FORCE_COMPLETE' : 'UAT_AGENT';
-        const who = witnessNameFrom(options.scopeAcceptedBy) || process.env.CLAUDE_SESSION_ID || null;
-        return who ? `${who} (${mode})` : mode;
-      })(),
+      verified_by: completionModeStamp({
+        forceComplete: options.forceComplete,
+        scopeAcceptedBy: options.scopeAcceptedBy,
+        sessionId: process.env.CLAUDE_SESSION_ID || null
+      }),
       verification_notes: finalVerificationNotes,
       files_changed: filesChanged.length > 0 ? filesChanged : null,
       completed_at: new Date().toISOString(),

--- a/tests/unit/complete-quick-fix/merged-reconcile-verification.test.js
+++ b/tests/unit/complete-quick-fix/merged-reconcile-verification.test.js
@@ -8,7 +8,7 @@
 // the CHECK without fabricating uat_verified.
 
 import { describe, it, expect } from 'vitest';
-import { buildMergedReconcileUpdate, witnessNameFrom } from '../../../scripts/modules/complete-quick-fix/orchestrator.js';
+import { buildMergedReconcileUpdate, witnessNameFrom, completionModeStamp } from '../../../scripts/modules/complete-quick-fix/orchestrator.js';
 
 // Mirror of the live completed_requires_verification CHECK predicate (asserted against the DB
 // constraint def: (tests_passing AND uat_verified) OR force_completed when status='completed').
@@ -199,5 +199,70 @@ describe('FR-2: witnessNameFrom extracts an identity, not a paragraph', () => {
   it('does not choke on a hyphenated name with no separator spaces', () => {
     // "well-known" must not be split at the hyphen — only a SPACED separator delimits who from why.
     expect(witnessNameFrom('well-known-agent')).toBe('well-known-agent');
+  });
+});
+
+// SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001 FR-2, SECOND WRITER.
+//
+// FR-2 has two writers. The reconcile path above was pinned; the DIRECT completion path was not,
+// and it was unpinned in the way that hides a regression rather than merely leaving a hole.
+//
+// The value lived in an inline IIFE, so nothing could import it. The only test naming
+// FORCE_COMPLETE asserts FORCE_COMPLETE_NO_REASON — a different thing entirely. And the fallback
+// made the gap self-concealing: under test CLAUDE_SESSION_ID is unset and no --scope-accepted is
+// passed, so `who` is null and the stamp degrades to the bare mode label — EXACTLY the pre-FR-2
+// output. A test written against observed behaviour would have certified the old behaviour and
+// passed. Deleting the identity logic outright would not have failed a single test.
+//
+// Hence these pins target the branches ambient state suppresses, not the one it exposes.
+describe('completionModeStamp — FR-2 second writer', () => {
+  it('prefers the explicit scope-accepter over the operator session', () => {
+    // Precedence matters: the human/agent who attested to SCOPE outranks whoever happened to run
+    // the command. Both are present here so the test cannot pass by accident of absence.
+    expect(completionModeStamp({
+      forceComplete: true,
+      scopeAcceptedBy: 'Alpha-4 (worker 39aa8a1e) — scope satisfied across two PRs',
+      sessionId: 'session-should-not-win'
+    })).toBe('Alpha-4 (worker 39aa8a1e) (FORCE_COMPLETE)');
+  });
+
+  it('falls back to the operator session when no scope-accepter was given', () => {
+    // THE BRANCH THE ENVIRONMENT HID. With CLAUDE_SESSION_ID unset in test, live behaviour never
+    // reached this, which is why the improvement shipped unexercised.
+    expect(completionModeStamp({ forceComplete: true, sessionId: '39aa8a1e' }))
+      .toBe('39aa8a1e (FORCE_COMPLETE)');
+  });
+
+  it('carries the mode as a suffix so classification on these literals still works', () => {
+    // Anything grouping rows by how they closed must still find the mode inside the value.
+    expect(completionModeStamp({ forceComplete: false, sessionId: 'x' })).toContain('(UAT_AGENT)');
+    expect(completionModeStamp({ forceComplete: true, sessionId: 'x' })).toContain('(FORCE_COMPLETE)');
+  });
+
+  it('degrades to the bare mode label when there is no identity at all', () => {
+    // The documented fallback, pinned so it stays DELIBERATE rather than becoming the default
+    // again by accident. This is the shape FR-2 exists to make rare — not impossible.
+    expect(completionModeStamp({ forceComplete: true })).toBe('FORCE_COMPLETE');
+    expect(completionModeStamp({ forceComplete: false })).toBe('UAT_AGENT');
+  });
+
+  it('never returns null or empty — a close is always attributable to at least its mode', () => {
+    // The regression that would matter most: a close attributed to NOBODY. 392 of 629 force-
+    // completed rows already carry verified_by=null; this function must never add to that set.
+    for (const args of [{}, { forceComplete: true }, { scopeAcceptedBy: '   ' }, { sessionId: null }]) {
+      const out = completionModeStamp(args);
+      expect(out).toBeTruthy();
+      expect(typeof out).toBe('string');
+    }
+  });
+
+  it('treats a whitespace-only scope-accepter as absent rather than stamping blank', () => {
+    expect(completionModeStamp({ forceComplete: true, scopeAcceptedBy: '   ', sessionId: 's1' }))
+      .toBe('s1 (FORCE_COMPLETE)');
+  });
+
+  it('is callable with no arguments at all', () => {
+    // Guards the default-parameter object: a bare call must not throw on destructuring.
+    expect(completionModeStamp()).toBe('UAT_AGENT');
   });
 });


### PR DESCRIPTION
## What

Pins FR-2's **second writer** for SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001, and extracts it to a pure function so it can be asserted at all. Behaviour is unchanged.

FR-2 has two writers. PR #6627 shipped both and pinned one. The direct completion path went out unpinned — and unpinned in the way that *hides* a regression rather than merely leaving a hole.

## Why the gap was invisible

Three things stacked:

1. The value lived in an **inline IIFE**, so nothing could import it.
2. The only test naming `FORCE_COMPLETE` asserts `FORCE_COMPLETE_NO_REASON` — a different thing. Grepping for the constant finds a hit and suggests coverage that does not exist.
3. **The fallback conceals it.** Under test `CLAUDE_SESSION_ID` is unset and no `--scope-accepted` is passed, so `who` is null and the stamp degrades to the bare mode label — which is *exactly* the pre-FR-2 output.

So a test written against observed behaviour would have certified the **old** behaviour and passed. Deleting the identity logic outright would not have failed a single test. That is the failure mode this SD is about, one level up: a check that cannot see the thing it is supposed to be checking.

## The fix

`completionModeStamp()` is pure — `sessionId` is a **parameter, not a `process.env` read**. A function that reaches for ambient state can only be tested by mutating the environment, and the branch that matters here is precisely the one ambient state suppresses.

Behaviour is byte-identical: same precedence (explicit scope-accepter → operator session → neither), same `<who> (<MODE>)` shape, same bare-mode fallback. The mode stays a suffix so anything classifying rows on these literals keeps the distinction it relied on.

## Pins, and proof they can fail

7 new pins, targeting the branches ambient state suppresses rather than the one it exposes:

- precedence — scope-accepter outranks session, with **both present** so it cannot pass by accident of absence
- session fallback — the branch the unset env var hid
- mode preserved as a suffix for classification
- bare-mode fallback, pinned so it stays deliberate rather than becoming the default again
- never null/empty across four argument shapes
- whitespace-only scope-accepter treated as absent, not stamped blank
- callable with no arguments (guards the default-parameter destructure)

**Mutation-tested rather than assumed green.** Reverting `completionModeStamp` to the pre-FR-2 `return mode` fails **4 of 30**. A suite that passes is not evidence it can fail, and this one was written specifically because the previous suite could not.

Full file: 30 passed.

## Scope

One function extracted, one call site updated, one test file extended. No behaviour change, no schema change, no new dependency. The FR-1 migration remains held unapplied on its own branch per coordinator directive `39f47bba` — it is not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
