### PR TITLE
docs(SD-LEO-INFRA-ACCOUNT-QUOTA-STRIP-001): retained history, new failure states, operating it

### DIFF
--- a/docs/04_features/account-quota-usage-strip.md
+++ b/docs/04_features/account-quota-usage-strip.md
@@ -1,6 +1,16 @@
 # Per-account quota usage strip
 
-**SD-LEO-FEAT-ACCOUNT-USAGE-STRIP-001** · backend `lib/fleet/account-usage-reader.cjs` · UI `ehg:src/components/chairman-v3/AccountUsageStrip.tsx`
+**SD-LEO-FEAT-ACCOUNT-USAGE-STRIP-001**, extended by **SD-LEO-INFRA-ACCOUNT-QUOTA-STRIP-001** · backend `lib/fleet/account-usage-reader.cjs`, `lib/fleet/account-usage-snapshot-writer.cjs` · UI `ehg:src/components/chairman-v3/AccountUsageStrip.tsx`
+
+<!--
+Category: Feature
+Status: Approved
+Version: 2.0.0
+Author: EXEC (Alpha-2)
+Last Updated: 2026-07-28
+Tags: fleet, quota, accounts, observability
+-->
+
 
 Renders each Max account's **weekly** quota use at the top of `/builder/sessions`.
 
@@ -24,7 +34,17 @@ Response fields consumed: `seven_day.utilization`, `five_hour.utilization`, and 
 
 ## Fail visibly — the load-bearing rule
 
-Every failure resolves to `{state:'unavailable', reason}` where `reason` is a **closed** enum: `not_configured | unauthorized | unexpected_shape | timeout | unreachable`.
+Every failure resolves to `{state:'unavailable', reason}` where `reason` is a **closed** enum: `not_configured | unauthorized | unexpected_shape | timeout | unreachable | exhausted | duplicate_identity`.
+
+### `exhausted` is not `unreachable` (SD-LEO-INFRA-ACCOUNT-QUOTA-STRIP-001)
+
+An account that is **out of quota answered** — it is the fact that explains why the fleet stopped. An unreachable one told us nothing. Until this SD a 429 fell through the `!res.ok` branch into `unreachable`, so "exhausted" was not merely un-rendered, it was **unrepresentable**: the reader had no way to say it and the strip had no way to show it. The 429 check therefore sits **before** the catch-all, and the strip renders *"Quota spent"* (rose) distinctly from *"Unavailable"* (amber).
+
+### `duplicate_identity` — refusing to attribute
+
+A duplicate is only visible **across** slots: one account read in isolation looks perfectly healthy, which is exactly why the defect reached the chairman's screen instead of a log. When two registry slots resolve to the same account we cannot say whose usage a number belongs to, so the honest output is **no figure at all** — never a number under a label we cannot vouch for. That refusal is enforced in three places (reader, `withLastKnown`, and the component), because the number could otherwise re-enter through the retained-value path.
+
+**This fires on the live fleet today**: `Code Street Labs` and `Rick Felix 2000` currently resolve to the same account, and `Deep Soul Sessions` is `not_configured` — so the strip has **zero** readable accounts. That is the detector working, not failing; it is a provisioning fault, routed to the coordinator.
 
 On `unavailable` the percentage **key is absent, not null**. A nullable percentage is what produces the forbidden dash — see `buildNamedAccountChips` → `{wkPct: null}` → `fleet-panel-format.js` rendering `wk --% used`.
 
@@ -63,9 +83,48 @@ The reader caches for **60s** so the page's 15s poll cannot hammer an undocument
 
 `GET /api/fleet-panel?refreshUsage=1` bypasses the cache. That backs the strip's **Refresh** control — the cache is there to stop polling pressure, not to block a deliberate re-read after an operator fixes an account.
 
+## Retained history — the last known reading
+
+*(SD-LEO-INFRA-ACCOUNT-QUOTA-STRIP-001 · `lib/fleet/account-usage-snapshot-writer.cjs`)*
+
+When an account stops being readable, its **final** reading — the number that explains why the fleet stopped — used to vanish with it. Successful reads are now appended to `account_usage_snapshots`, and an unavailable account renders `Last known 92% · 3h ago` beneath its state.
+
+Three rules make this safe rather than dangerous:
+
+- **History is added, never substituted.** The live `state`/`reason` are preserved exactly and history arrives under separate `lastKnown*` keys. Overwriting the live state with a stored one would make a stale value indistinguishable from a current reading — the failure this feature exists to *end*, not relocate.
+- **The age is relative, never a bare clock.** `formatClock` renders hour:minute with no date, so a value retained three days ago read exactly like one from this morning. `formatAge` carries its own staleness (`3d ago`) and cannot be misread.
+- **"Last KNOWN" means the last row that actually carried a number.** The lookup filters on `weekly_pct`/`five_hour_pct` being non-null and runs **one query per account**. Both are load-bearing: the route persists the current reading *before* reading history back, so an exhausted account's just-written NULL row would otherwise shadow the very number being recovered; and a row budget shared across accounts let the busy accounts crowd an exhausted one out of the window within about half an hour, while exhaustion lasts *hours*.
+
+Persistence is **wholly fail-soft** — no client, no table, transport error and malformed reading all resolve to a counted skip. It is a side effect of rendering the strip and must never break it.
+
+> **The migration is TIER-2 chairman-gated, so this makes history *possible*, not *present*.** Nothing is retained until `database/migrations/20260728_account_usage_snapshots.sql` is applied. Until then `pending_migration: true` appears in the write log — an expected state, not an alarm.
+
+### Operating it
+
+| Concern | Where |
+|---|---|
+| Cadence | `scripts/cron/account-usage-sample.mjs`, every 15 min, registered `standard_loop:account-usage-sample` |
+| Retention | `lib/retention/policies.js` → `account_usage_snapshots`, 90-day archive on `created_at` |
+| Table | `account_usage_snapshots` — name, percentages, reset times, `fetched_at`, state, `account_uuid8` |
+
+**Why a cron and not the page.** Snapshot writes began as a side effect of rendering the panel, which meant history existed only while somebody was watching — and the fleet going down is precisely when nobody is. The record would have been thinnest in exactly the window that needed it. It is hosted locally rather than in GitHub Actions because the meters need credentials that live in this host's config directories; a GHA runner would report the whole fleet `not_configured` — a green cron manufacturing a false record.
+
+## `FLEET_ACCOUNT_IDENTITY_MAP` (optional, currently unset)
+
+JSON mapping `accountUuid8 → display name`, letting a slot be labelled from its **credentials** rather than its directory. Malformed config never breaks the strip (it falls back to registry names), and control characters are stripped — the value reaches both the API response and a log line.
+
+Two collision rules, because a display name is not merely cosmetic: it is the key `account_usage_snapshots` stores under, so two slots sharing a name would share a history row-space and could show each other's numbers.
+
+- Two accounts mapped to the **same** label → the label is not applied; both slots keep their own names and fail as `duplicate_identity`.
+- A label equal to a **different** slot's own registry name → same treatment. Self-mapping (a slot's own account mapped to its own name) is legitimate and contests nothing.
+
 ## Boundary
 
-The bearer token is **request-local**: never returned, cached, logged or persisted. No config directory, profile name or file path appears in any browser-bound field. Only the closed enum values reach the client, so a raw upstream body or transport error cannot escape through `reason`.
+The bearer token is **request-local**: never returned, cached, logged or persisted. No config directory, profile name or file path appears in any browser-bound field. Only the closed enum values reach the client, so a raw upstream body or transport error cannot escape through `reason`. The credentialed request sets `redirect: 'error'` — undici happens to strip `Authorization` cross-origin, but a same-origin 302 *does* forward it, so refusing outright keeps the guarantee local to the code holding the token.
+
+**The email is a resolution input only.** It is never a stored column, log line, error message or API field — `toSnapshotRow` is a fixed 8-key literal with no spread, and a unit test asserts the exact key set as a whitelist so a future field cannot slip in. `account_usage_snapshots` has RLS enabled with a service-role-only policy plus `REVOKE ALL FROM anon, authenticated`; the REVOKE is load-bearing, since `pg_default_acl` auto-grants public-schema tables to anon and authenticated.
+
+> Note: `/api/fleet-panel` already emits `account_email` from `claude_sessions.metadata` via a **different, pre-existing** field (QF-20260726-642). This SD's table stays email-free; if "no email in fleet surfaces" is meant to be a global invariant, that field is where to look next.
 
 The containing control on `/api/fleet-panel` is the **loopback bind** in `server/index.js`, *not* the operator JWT — the route uses `optionalAuth`, and `requireAuth` accepts any valid JWT from the shared Supabase project with no role check. The payload is therefore safe on its own terms rather than relying on who can call it.
 


### PR DESCRIPTION
## Summary

Post-completion documentation for SD-LEO-INFRA-ACCOUNT-QUOTA-STRIP-001 (merged in #6629 / rickfelix/ehg#782).

Updates the **existing** feature doc rather than adding a second one — the topic was already covered by `docs/04_features/account-quota-usage-strip.md`, and a parallel file would have split the truth.

- The closed reason enum gains `exhausted` and `duplicate_identity`, each with *why it is not the neighbouring state*.
- New section on the retained last-known reading, including the two rules that make it safe: history is **added, never substituted**, and the age is **relative, never a bare clock**.
- Operating table: the sampler cadence, the retention policy, and what the table actually stores.
- `FLEET_ACCOUNT_IDENTITY_MAP` collision rules, since a display name is not cosmetic — it is the key history is stored under.
- Security boundary extended: `redirect: 'error'`, the email-as-input-only rule, and the RLS/REVOKE posture.

## Two things stated plainly rather than buried

**The migration is chairman-gated, so this makes history *possible*, not *present*.** Nothing is retained until it is applied.

**The strip currently has zero readable accounts** — one slot `not_configured`, two resolving to the same account. That is the new detector working on a real provisioning fault, not a regression; it is routed to the coordinator separately.

## Test plan

Documentation only — no code. Verified the file is the sole change, that it stays in `docs/04_features/` (correct location for its type), and that it now carries a metadata header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)