### PR TITLE
fix(SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001): the graceful kill was not graceful, and restart left the predecessor alive

### DIFF
--- a/docs/06_deployment/fleet-session-lifecycle.md
+++ b/docs/06_deployment/fleet-session-lifecycle.md
@@ -1,0 +1,115 @@
+---
+category: deployment
+status: approved
+version: 1.0.0
+author: EXEC (Alpha-2) — SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001
+last_updated: 2026-07-28
+tags: [deployment, fleet, sessions, kill, restart, reconcile, operations]
+---
+# Fleet session lifecycle — kill, restart, reconcile
+
+Before this SD, closing the terminal window was the only way an operator could end a fleet
+session, and it **stranded the work**: the claim stayed held, the work item stayed advancing, and
+uncommitted WIP in the seat's worktree was simply lost.
+
+Chairman-directed design, 2026-07-26. The investigation that produced it refuted 24 claims before
+synthesis — including "there is no kill primitive", which was wrong. **Three of the four
+capabilities were substantially built already; the gap was exposure and wiring, not construction.**
+That framing matters operationally: if something here looks missing, look for an unwired module
+before building a second one.
+
+## The verbs
+
+| Need | Command | Default |
+|---|---|---|
+| End a session, preserving its work | `node scripts/fleet-kill.mjs <session-id> [--reason "…"] [--dry-run]` | **OFF** — `FLEET_GRACEFUL_KILL_ENABLED=on` |
+| Replace a session, carrying its conversation | `restart()` / `relaunchUnderProfile()` / `drainAndRestart()` in `lib/fleet/spawn-control.js` | on |
+| Reconcile seats against reality | FR-5 seat reconciliation | on |
+
+`fleet-kill` is **operator-initiated only**. No watchdog, sweep or cron may reach it — a policy
+ratified twice in `stale-session-sweep.cjs` and enforced by the fact that its only production
+importer is the CLI itself. It has its own flag; `FLEET_CANARY_KILL_ENABLED` deliberately cannot
+enable it, because that flag's canary-only assert is what keeps drills off production seats.
+
+## The kill order IS the safety property
+
+Not an implementation detail — the sequence is what makes the verb safe to run on a working seat:
+
+**identify → sample → preserve → release → reset → kill → record**
+
+- **identify** — if `claude_sessions.pid`, the SessionStart marker and the live `claude.exe` image
+  set disagree, the kill **refuses and names the disagreement**. A disputed pid is never guessed at.
+- **preserve** — `prepark-wip` commits and pushes the seat's WIP *before* anything is released or
+  signalled. An **unrecoverable** tree HALTS the whole operation with nothing released and nothing
+  terminated. The property that matters is *durability*, not pushability: work committed locally is
+  preserved, so a dirty tree with no remote proceeds once committed.
+- **release → reset** — the claim is released before the work item is handed back, and the hand-back
+  is skipped entirely if the release was not proven.
+- **record** — a `fleet_verb_stop` event is the durable record that the kill happened.
+
+A test pins this order, so an order regression fails CI rather than reaching a seat.
+
+## Two things that will surprise you
+
+### "Graceful" was a name before it was a behaviour
+
+The kill originally went through `killProcess` → tree-kill, which on Windows is
+`taskkill /pid N /T /F`. Two consequences that contradicted the docs:
+
+- **`/T` killed every descendant** of the seat — dev server, leo-stack, background shells.
+- **The signal argument is ignored on win32**, so the documented "SIGTERM, then escalate to
+  SIGKILL" was two identical *forced* kills. The agent never got a chance to flush.
+
+Use **`killProcessOnly`** (`lib/utils/process-utils.js`) for anything session-shaped. It targets one
+process, and `taskkill /PID n` *without* `/F` is the genuine Windows analogue of SIGTERM, with `/F`
+reserved for the escalation — so the distinction a caller writes is the one that happens.
+`killProcess` still exists for callers that genuinely want a process tree.
+
+### A restart used to leave the predecessor running
+
+Restart retired the old **row** — the singleton mutex, or a `status='released'` update — and never
+touched the old **process**. Two claude processes then held one seat while only one had a live row,
+and the survivor kept heartbeating its claim, kept its worktree, and was **invisible to every gauge
+that reads the registry rather than the process table**.
+
+`retirePredecessorProcess` now runs at the end of both restart paths. It is deliberately
+conservative:
+
+- It runs **only after** the replacement is confirmed live *and* succession actually completed. A
+  `hold_old` verdict leaves the predecessor running on purpose. Terminating first would, on a dry
+  run or a failed spawn, kill the incumbent and leave the seat empty — worse than the defect.
+- It is **fail-closed on identity**. A pid is signalled only when the process table positively says
+  it is still claude. `NO_MATCH` means it already exited. **`PROBE_FAILED` refuses** — pids are
+  recycled, and killing one we cannot identify takes out an unrelated process.
+- An unverifiable outcome reports `unverified` rather than attesting a clean succession. The
+  outcome appears on the restart's verb event and return value; **silence here would be the defect**.
+
+This is not the FR-2 graceful kill and does not call it. That entrypoint stays operator-only; this
+is restart completing its own contract on a process it has already replaced.
+
+## Restart carries the conversation
+
+`claude_sessions.session_id` **is** Claude Code's resume token — not `metadata.resume_uuid`, which
+is populated on 1 of 13,025 rows and would silently cold-start anything that read it. A repo-wide
+test enforces that nothing reads it.
+
+- The transcript's existence is proven by a **real `stat`**, never inferred from the id.
+- A restart with a token emits `--fork-session` with a **fresh** `--session-id`; re-registering
+  under the old id would let a health check pass against the old row's warm heartbeat.
+- The transcript slug derives from the **main worktree root**, never `.worktrees/<id>` — a worktree
+  path resolves to a directory that never exists, which silently cold-started every worktree seat.
+- A missing transcript cold-starts **and says so** (`fleet.restart.resume_plan`, logged
+  unconditionally). A silent cold start is a defect, not a fallback.
+
+Resolution lives in `spawnReplacement`, the single choke point, so `restart`,
+`relaunchUnderProfile`, `canaryRestart` and `drainAndRestart` all inherit it. Placing it in
+`restart()` covered only three of the four — **coverage by call-routing is not coverage of the
+invariant**.
+
+## Operating notes
+
+- Rehearse with `--dry-run` first; it exercises identify/sample/preserve without signalling.
+- If a session reports `unauthorized` rather than dying, check the profile's token `expiresAt` —
+  `claude auth status` reports identity happily while every API call 401s.
+- A refusal is a **result**, not a failure of the tool. `refused` with a named reason is the design
+  working: it means the system declined to act on something it could not verify.

--- a/lib/fleet/graceful-kill.mjs
+++ b/lib/fleet/graceful-kill.mjs
@@ -34,7 +34,12 @@
  *   A clean tree, or one prepark successfully committed and/or pushed, is safe to proceed on.
  */
 
-import { killProcess } from '../utils/process-utils.js';
+// killProcessOnly, NOT killProcess: the latter routes through tree-kill, which on win32 is
+// `taskkill /pid N /T /F` — it takes every DESCENDANT of the seat (dev server, leo-stack,
+// background shells) and IGNORES the signal, so the SIGTERM-then-SIGKILL escalation below was two
+// identical forced kills on the only platform this fleet runs on. The agent never got the chance
+// to flush that the word "graceful" in this module's name promises.
+import { killProcessOnly } from '../utils/process-utils.js';
 import { releaseWorkItemOnSessionEnd } from './release-work-item.mjs';
 
 /** Its OWN flag. FLEET_CANARY_KILL_ENABLED is deliberately not consulted. */
@@ -116,7 +121,7 @@ export async function gracefulKillSession(supabase, sessionId, deps = {}) {
     runPreparkWip,       // ({worktreePath, sdKey}) => preparkResult
     isWorktreeDirty,     // (worktreePath) => boolean
     releaseClaim,        // async (sessionId, sdKey) => { released }
-    kill = killProcess,
+    kill = killProcessOnly,
     recordStop,          // async (sessionId) => void   (spawn-control stop(); emits fleet_verb_stop)
     verifyGone,          // async (pid) => boolean      (Win32_Process name query)
     reason = 'operator_graceful_kill',

--- a/lib/fleet/predecessor-retirement.test.js
+++ b/lib/fleet/predecessor-retirement.test.js
@@ -1,0 +1,101 @@
+/**
+ * AC-3-6: the predecessor must not outlive the restart — and must never be killed on a guess.
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 (US-003).
+ *
+ * THE DEFECT THIS PINS. restart() retired the old DB ROW (the singleton mutex for singletons, a
+ * status='released' update for workers) and never touched the old PROCESS. Two claude processes
+ * then held one seat while only one had a live row — and the survivor kept heartbeating its claim,
+ * kept its worktree, and was invisible to every gauge that reads the registry rather than the
+ * process table.
+ *
+ * The dangerous fix is worse than the defect, so most of these tests are about REFUSING: pids are
+ * recycled, and killing one whose identity we cannot confirm takes out an unrelated process. Every
+ * kill is injected; no real process is ever signalled.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { retirePredecessorProcess } from './spawn-control.js';
+
+/** probe returns a fixed tri-state; kill records; verifyGone reports absence after N calls. */
+function deps({ probe = 'MATCH', goneAfter = 1 } = {}) {
+  const kills = [];
+  let verifies = 0;
+  return {
+    kills,
+    probeClaude: () => probe,
+    kill: vi.fn(async (pid, sig) => { kills.push(`${sig}:${pid}`); }),
+    verifyGone: vi.fn(async () => { verifies += 1; return verifies >= goneAfter; }),
+  };
+}
+
+describe('the happy path terminates the predecessor', () => {
+  it('a graceful signal alone suffices when the process exits', async () => {
+    const d = deps({ goneAfter: 1 });
+    const r = await retirePredecessorProcess(4321, d);
+    expect(r.outcome).toBe('terminated');
+    expect(d.kills).toEqual(['SIGTERM:4321']);
+  });
+
+  it('escalates to a forced kill only when the graceful one did not take', async () => {
+    const d = deps({ goneAfter: 2 });
+    const r = await retirePredecessorProcess(4321, d);
+    expect(r.outcome).toBe('terminated');
+    expect(d.kills).toEqual(['SIGTERM:4321', 'SIGKILL:4321']);
+  });
+});
+
+describe('FAIL-CLOSED — a pid we cannot identify is never signalled', () => {
+  it('REFUSES when the probe fails, rather than guessing', async () => {
+    // The load-bearing one. Pids are recycled; a PROBE_FAILED that fell through to a kill would
+    // terminate whatever now owns that number. Refusing is the only safe reading of "we do not know".
+    const d = deps({ probe: 'PROBE_FAILED' });
+    const r = await retirePredecessorProcess(4321, d);
+    expect(r.outcome).toBe('refused');
+    expect(d.kill).not.toHaveBeenCalled();
+    expect(r.detail).toMatch(/cannot confirm/i);
+  });
+
+  it('treats a pid that is no longer claude as already gone, and kills nothing', async () => {
+    const d = deps({ probe: 'NO_MATCH' });
+    const r = await retirePredecessorProcess(4321, d);
+    expect(r.outcome).toBe('already_gone');
+    expect(d.kill).not.toHaveBeenCalled();
+  });
+
+  it('NEGATIVE CONTROL — a positive identification DOES kill', async () => {
+    // Without this, every assertion above would also pass on an implementation that never kills
+    // anything, which would leave the original defect fully intact.
+    const d = deps({ probe: 'MATCH' });
+    await retirePredecessorProcess(4321, d);
+    expect(d.kill).toHaveBeenCalled();
+  });
+
+  it('skips a missing or malformed pid without throwing', async () => {
+    for (const bad of [undefined, null, 0, -1, 'abc', NaN]) {
+      const d = deps();
+      const r = await retirePredecessorProcess(bad, d);
+      expect(r.outcome).toBe('skipped');
+      expect(d.kill).not.toHaveBeenCalled();
+    }
+  });
+});
+
+describe('an unverifiable outcome is REPORTED, never claimed as success', () => {
+  it('reports unverified when absence cannot be confirmed after both signals', async () => {
+    // Silence here is the defect: a restart that says "ok" while the predecessor may still be
+    // running is exactly the false attestation this SD exists to remove.
+    const d = deps({ goneAfter: 99 });
+    const r = await retirePredecessorProcess(4321, d);
+    expect(r.outcome).toBe('unverified');
+    expect(r.detail).toMatch(/could not verify/i);
+  });
+
+  it('never throws — a failing kill degrades to a reported error', async () => {
+    const r = await retirePredecessorProcess(4321, {
+      probeClaude: () => 'MATCH',
+      kill: async () => { throw new Error('Access is denied.'); },
+      verifyGone: async () => false,
+    });
+    expect(r.outcome).toBe('error');
+    expect(r.detail).toMatch(/Access is denied/);
+  });
+});

--- a/lib/fleet/resume-context.test.js
+++ b/lib/fleet/resume-context.test.js
@@ -114,4 +114,46 @@ describe('FR3-TOKEN: metadata.resume_uuid is never consulted', () => {
     const code = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
     expect(code).not.toMatch(/metadata\s*[.[]\s*['"]?resume_uuid/);
   });
+
+  it('NO PRODUCTION MODULE ANYWHERE READS metadata.resume_uuid', async () => {
+    // AC-3-4 asks for a REPO-WIDE grep, and the test above is module-scoped. A guard that can only
+    // see the one file already known to be correct is not a guard on the invariant — the reader
+    // that would actually hurt us is by definition somewhere else. Scoping it to this module made
+    // it unfalsifiable.
+    //
+    // The invariant is about READS of claude_sessions.metadata.resume_uuid, which is populated on
+    // 1 of 13,025 rows, so any reader silently cold-starts. It is NOT about the
+    // fleet_desired_slots.resume_uuid COLUMN, which is a different, legitimately-populated field —
+    // conflating the two is what made an earlier assessment report a false positive here.
+    const { readFileSync, readdirSync, statSync } = await import('node:fs');
+    const { fileURLToPath } = await import('node:url');
+    const path = await import('node:path');
+    const repo = path.resolve(fileURLToPath(new URL('.', import.meta.url)), '../..');
+
+    const offenders = [];
+    const walk = (dir) => {
+      for (const entry of readdirSync(dir)) {
+        if (entry === 'node_modules' || entry === '.git' || entry === '.worktrees') continue;
+        const full = path.join(dir, entry);
+        if (statSync(full).isDirectory()) { walk(full); continue; }
+        if (!/\.(?:js|cjs|mjs)$/.test(entry)) continue;
+        if (/\.test\.(?:js|cjs|mjs)$/.test(entry)) continue;   // tests may name it to assert absence
+        const raw = readFileSync(full, 'utf8');
+        // Comments explain WHY it must not be read; scanning them would fail on the rationale —
+        // the same trap as searching for a flag NAME rather than its USE.
+        const code = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+        // A READ, not a write: `metadata.resume_uuid` on the right of an assignment or in an
+        // expression. `resume_uuid:` (an object key being SET) is excluded by requiring the
+        // metadata prefix and rejecting a following colon.
+        if (/metadata\s*[.[]\s*['"]?resume_uuid['"]?\]?\s*(?!:)/.test(code)) {
+          offenders.push(path.relative(repo, full));
+        }
+      }
+    };
+    for (const top of ['lib', 'scripts', 'server']) {
+      try { walk(path.join(repo, top)); } catch { /* dir may not exist */ }
+    }
+
+    expect(offenders, `metadata.resume_uuid is READ in: ${offenders.join(', ')}`).toEqual([]);
+  });
 });

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -643,6 +643,69 @@ export async function stop(target, opts = {}) {
 }
 
 /**
+ * Retire the PREDECESSOR OS PROCESS after a restart has been proven to succeed.
+ *
+ * WHY THIS EXISTS (FR-3 / AC-3-6). Restart retired the old DB *row* — sequenceSingletonRefresh for
+ * singletons, a status='released' update for workers — and never touched the old *process*. So a
+ * restart left two claude processes holding one seat while only one had a live row: the survivor
+ * kept its claim heartbeat, kept its worktree, and was invisible to every gauge that reads the
+ * registry rather than the process table. "Exactly one process holds the seat" was asserted by
+ * nothing.
+ *
+ * THE ORDER IS THE SAFETY PROPERTY, exactly as in graceful-kill: this runs only AFTER the
+ * replacement is confirmed live and the old row retired. Terminating first would, on a dry run or
+ * a failed spawn, kill the incumbent and leave the seat empty — strictly worse than the defect.
+ *
+ * FAIL-CLOSED ON AN UNCERTAIN PROBE. A pid is only killed when the process table positively says
+ * it is still claude. NO_MATCH means it already exited (nothing to do); PROBE_FAILED means the
+ * probe told us nothing, and a pid whose identity we cannot confirm is never signalled — pids are
+ * recycled, so guessing here kills an unrelated process. Refusing is reported, never silent.
+ *
+ * This is NOT the FR-2 graceful kill and deliberately does not call it: that entrypoint is
+ * operator-initiated by contract (AC-2-8) and default-off. This is a restart completing its own
+ * contract on a process it has already replaced.
+ *
+ * @returns {Promise<{outcome:string, pid:number|null, detail:string}>} never throws
+ */
+export async function retirePredecessorProcess(oldPid, deps = {}) {
+  const {
+    probeClaude,                       // (pid) => 'MATCH' | 'NO_MATCH' | 'PROBE_FAILED'
+    kill,                              // (pid, signal) => Promise<void>
+    verifyGone,                        // async (pid) => boolean | undefined
+  } = deps;
+
+  const pid = Number(oldPid);
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return { outcome: 'skipped', pid: null, detail: 'no usable predecessor pid recorded' };
+  }
+  try {
+    const probe = probeClaude ? probeClaude(pid) : 'PROBE_FAILED';
+    if (probe === 'NO_MATCH') {
+      return { outcome: 'already_gone', pid, detail: `pid ${pid} is no longer a claude process` };
+    }
+    if (probe !== 'MATCH') {
+      // Refuse loudly rather than kill on a guess.
+      return { outcome: 'refused', pid, detail: `cannot confirm pid ${pid} is still claude (${probe}) — not signalling a pid we cannot identify` };
+    }
+
+    await kill(pid, 'SIGTERM');
+    let gone = verifyGone ? await verifyGone(pid) : undefined;
+    if (gone !== true) {
+      await kill(pid, 'SIGKILL');
+      gone = verifyGone ? await verifyGone(pid) : undefined;
+    }
+    if (gone === true) return { outcome: 'terminated', pid, detail: `predecessor pid ${pid} terminated and verified absent` };
+    return {
+      outcome: 'unverified',
+      pid,
+      detail: `signalled pid ${pid} but could not verify absence — reporting rather than claiming a clean succession`,
+    };
+  } catch (err) {
+    return { outcome: 'error', pid, detail: `predecessor retirement failed: ${(err && err.message) || err}` };
+  }
+}
+
+/**
  * Internal: spawn a replacement session under the same role/callsign (shared by restart + relaunch).
  * skipDedup:true -- restart()/relaunchUnderProfile() already resolved ONE specific old session to
  * replace (not a speculative fresh request), so spawn()'s FR-5 already-live dedup would otherwise
@@ -793,8 +856,13 @@ export async function restart(target, opts = {}) {
       return { ok: false, reason: 'awaiting_new_session_registration', spawnResult, role: 'singleton' };
     }
     const seqResult = await sequenceSingletonRefresh(supabase, { newSessionId: opts.newSessionId, oldSessionId: oldIdentity.session_id });
-    await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: seqResult.action, sdKey });
-    return { ok: seqResult.retired || seqResult.action === 'hold_old', role: 'singleton', spawnResult, seqResult };
+    // AC-3-6: the row is retired; the PROCESS is not. Only once the mutex actually retired the old
+    // session — hold_old means succession did not happen, so the predecessor must keep running.
+    const predecessor = seqResult.retired && spawnResult && spawnResult.live === true
+      ? await retirePredecessorProcessFor(oldIdentity, opts)
+      : { outcome: 'skipped', pid: null, detail: 'succession not completed — predecessor deliberately left running' };
+    await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: seqResult.action, sdKey, predecessor: predecessor.outcome });
+    return { ok: seqResult.retired || seqResult.action === 'hold_old', role: 'singleton', spawnResult, seqResult, predecessor };
   }
 
   // FR-5: worker restart is parallel-safe by construction -- no shared mutex, resolveSpawnDecisions
@@ -811,8 +879,42 @@ export async function restart(target, opts = {}) {
   const { error } = await supabase.from('claude_sessions').update({
     status: 'released', released_at: new Date().toISOString(), released_reason: 'restart',
   }).eq('session_id', oldIdentity.session_id);
-  await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: error ? 'db_error' : 'ok', sdKey });
-  return { ok: !error, role: 'worker', spawnResult };
+  // AC-3-6: released the ROW above; the predecessor PROCESS is still holding the seat until here.
+  // Gated on the DB update succeeding — if the row still reads live, two live rows plus one dead
+  // process is a worse state than two processes.
+  const predecessor = error
+    ? { outcome: 'skipped', pid: null, detail: 'old row not released — predecessor deliberately left running' }
+    : await retirePredecessorProcessFor(oldIdentity, opts);
+  await emitVerbEvent(supabase, { verb: 'restart', session_id: oldIdentity.session_id, outcome: error ? 'db_error' : 'ok', sdKey, predecessor: predecessor.outcome });
+  return { ok: !error, role: 'worker', spawnResult, predecessor };
+}
+
+/**
+ * Resolve the probe/kill/verify deps and retire the predecessor. Injectable for tests; in
+ * production it wires the SAME single-process kill and the SAME tri-state claude probe the
+ * operator kill path uses, so there is one spelling of "is this still claude" in the codebase.
+ */
+async function retirePredecessorProcessFor(oldIdentity, opts = {}) {
+  if (opts.retirePredecessor === false) {
+    return { outcome: 'disabled', pid: null, detail: 'predecessor retirement disabled by caller' };
+  }
+  if (typeof opts.retirePredecessorImpl === 'function') return opts.retirePredecessorImpl(oldIdentity, opts);
+  try {
+    const { killProcessOnly } = await import('../utils/process-utils.js');
+    const { createRequire } = await import('node:module');
+    const require_ = createRequire(import.meta.url);
+    const { pidIsClaude } = require_('./claimant-liveness.cjs');
+    return await retirePredecessorProcess(oldIdentity && oldIdentity.pid, {
+      probeClaude: (pid) => pidIsClaude(pid),
+      kill: killProcessOnly,
+      // NO_MATCH (definitively not claude any more) is the only "gone"; MATCH means still alive and
+      // PROBE_FAILED means we learned nothing — both must read as not-gone. Same fail-closed
+      // mapping scripts/fleet-kill.mjs uses.
+      verifyGone: async (pid) => pidIsClaude(pid) === 'NO_MATCH',
+    });
+  } catch (err) {
+    return { outcome: 'error', pid: null, detail: `predecessor retirement unavailable: ${(err && err.message) || err}` };
+  }
 }
 
 /** FR-7: the ratified account-switch verb -- isolated to the target session only. */

--- a/lib/utils/process-utils.js
+++ b/lib/utils/process-utils.js
@@ -81,6 +81,49 @@ export async function killProcess(pid, signal = 'SIGKILL') {
 }
 
 /**
+ * Kill ONE process — never its descendants — honouring graceful-vs-forced on every platform.
+ *
+ * WHY THIS EXISTS SEPARATELY FROM killProcess. killProcess goes through tree-kill, which on win32
+ * shells out to `taskkill /pid N /T /F`. Two consequences that are wrong for a *session* kill:
+ *
+ *   1. `/T` terminates every DESCENDANT. A fleet seat's claude process routinely parents a dev
+ *      server, a leo-stack, background shells — killing the seat took all of them with it.
+ *   2. The signal argument is IGNORED on win32; `/F` is unconditional. So a documented
+ *      "SIGTERM, then escalate to SIGKILL" sequence was, on the only platform this fleet runs on,
+ *      two identical forced kills. The agent never got a chance to flush, which is precisely the
+ *      property a module named "graceful kill" claims to provide. The escalation was decorative.
+ *
+ * Here, `taskkill /PID n` WITHOUT /F is the genuine Windows analogue of SIGTERM — it asks the
+ * process to close and lets it run its exit path — and /F is reserved for the escalation. The
+ * distinction the caller writes is therefore the distinction that actually happens.
+ *
+ * lib/fleet/console-reaper.mjs already reached the single-process conclusion independently; this
+ * generalises it rather than adding a third spelling.
+ *
+ * @param {number} pid
+ * @param {string} signal - 'SIGKILL' forces; anything else requests a graceful close
+ * @returns {Promise<void>} resolves even when the process was already gone
+ */
+export async function killProcessOnly(pid, signal = 'SIGKILL') {
+  const force = signal === 'SIGKILL';
+  try {
+    if (process.platform === 'win32') {
+      const { execFile } = await import('node:child_process');
+      const { promisify } = await import('node:util');
+      const args = force ? ['/PID', String(pid), '/F'] : ['/PID', String(pid)];
+      await promisify(execFile)('taskkill', args);
+    } else {
+      process.kill(pid, signal);
+    }
+  } catch (error) {
+    // Already gone is success, not failure — the caller wanted the process not running.
+    const msg = String(error?.message || error);
+    if (error?.code === 'ESRCH' || /not found|no such process|not running/i.test(msg)) return;
+    console.warn(`Error killing process ${pid}:`, msg);
+  }
+}
+
+/**
  * Kill all processes using a specific port
  * Cross-platform replacement for: lsof -t -i :PORT | xargs kill -9
  *

--- a/lib/utils/process-utils.kill-only.test.js
+++ b/lib/utils/process-utils.kill-only.test.js
@@ -1,0 +1,98 @@
+/**
+ * killProcessOnly — the graceful/forced distinction must be REAL, not decorative.
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 (US-002 / AC-2-4).
+ *
+ * WHAT WENT WRONG BEFORE, and why these assertions are shaped this way. graceful-kill called
+ * killProcess -> tree-kill, which on win32 is `taskkill /pid N /T /F`. The signal argument is
+ * ignored there and /F is unconditional, so "SIGTERM, then escalate to SIGKILL" was two identical
+ * forced kills; and `/T` took every descendant of the seat with it. Both defects are invisible to
+ * any test that asserts only "kill was called with SIGTERM" — the caller's intent was recorded
+ * faithfully while the platform did something else entirely.
+ *
+ * So these tests assert the ARGV actually handed to the OS. That is the layer where the two
+ * defects lived, and the only layer at which their absence can be witnessed.
+ *
+ * No process is ever signalled: execFile is injected.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+const REAL_PLATFORM = process.platform;
+function setPlatform(p) {
+  Object.defineProperty(process, 'platform', { value: p, configurable: true });
+}
+afterEach(() => {
+  setPlatform(REAL_PLATFORM);
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+/** Capture the argv taskkill would receive, without running it. */
+async function runWin32(pid, signal) {
+  const calls = [];
+  vi.doMock('node:child_process', () => ({
+    execFile: (cmd, args, cb) => { calls.push({ cmd, args }); cb(null, '', ''); },
+  }));
+  setPlatform('win32');
+  vi.resetModules();
+  const { killProcessOnly } = await import('./process-utils.js');
+  await killProcessOnly(pid, signal);
+  return calls;
+}
+
+describe('AC-2-4: one process, never the tree', () => {
+  it('does NOT pass /T — descendants of the seat are not collateral', async () => {
+    // The seat's claude process routinely parents a dev server, a leo-stack and background
+    // shells. /T killed all of them, which is far wider than "stop this session".
+    const calls = await runWin32(4321, 'SIGKILL');
+    expect(calls).toHaveLength(1);
+    expect(calls[0].args).not.toContain('/T');
+    expect(calls[0].args).toEqual(['/PID', '4321', '/F']);
+  });
+});
+
+describe('AC-2-4: the escalation is real, not decorative', () => {
+  it('a graceful request omits /F, so the process can run its exit path', async () => {
+    // `taskkill /PID n` without /F is the genuine win32 analogue of SIGTERM. This is the whole
+    // difference between a module named "graceful kill" and one that merely says so.
+    const calls = await runWin32(4321, 'SIGTERM');
+    expect(calls[0].args).toEqual(['/PID', '4321']);
+    expect(calls[0].args).not.toContain('/F');
+  });
+
+  it('THE DISCRIMINATOR — graceful and forced produce DIFFERENT argv', async () => {
+    // Before this fix both spellings produced the identical forced command. A test that only
+    // checked "SIGTERM was requested" passed throughout. Comparing the two argvs to each other is
+    // what makes the regression impossible to reintroduce silently.
+    const term = await runWin32(9, 'SIGTERM');
+    const kill = await runWin32(9, 'SIGKILL');
+    expect(term[0].args).not.toEqual(kill[0].args);
+  });
+});
+
+describe('already gone is success, not an error', () => {
+  it('swallows a not-found failure without warning', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.doMock('node:child_process', () => ({
+      execFile: (_c, _a, cb) => cb(Object.assign(new Error('The process "9" not found.'), { code: 128 })),
+    }));
+    setPlatform('win32');
+    vi.resetModules();
+    const { killProcessOnly } = await import('./process-utils.js');
+    await expect(killProcessOnly(9, 'SIGKILL')).resolves.toBeUndefined();
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('NEGATIVE CONTROL — an unrecognised failure IS surfaced', async () => {
+    // Swallowing everything would turn a broken kill into a silent success, which is the failure
+    // mode this SD exists to remove. Only "already gone" may be quiet.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.doMock('node:child_process', () => ({
+      execFile: (_c, _a, cb) => cb(new Error('Access is denied.')),
+    }));
+    setPlatform('win32');
+    vi.resetModules();
+    const { killProcessOnly } = await import('./process-utils.js');
+    await killProcessOnly(9, 'SIGKILL');
+    expect(warn).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -135,9 +135,13 @@ describe('module surface (TS-10: exactly six named verbs, no more)', () => {
     // The guard exists to catch an undocumented 7th VERB, not to freeze the helper surface. The two
     // session-bind constants are exported so the budget can be asserted directly instead of by
     // wall-clock; they are values, not verbs, so they belong on this allowlist.
+    // retirePredecessorProcess (FR-3 / AC-3-6) is a HELPER, not a verb: an operator never invokes
+    // it, restart() calls it internally once succession is proven. It is exported solely so its
+    // fail-closed refusals can be asserted directly — a pid whose identity cannot be confirmed must
+    // never be signalled, and that is not reachable through restart() without real processes.
     const helperNames = ['roleOf', 'isSingletonRole', 'resolveProfileDir', 'isLiveEnabled', 'buildLiveSpawnInvocation',
       'SESSION_BIND_MAX_ATTEMPTS', 'SESSION_BIND_DELAY_MS',
-      'CANARY_PROFILE', 'CANARY_CALLSIGN_PREFIX'];
+      'CANARY_PROFILE', 'CANARY_CALLSIGN_PREFIX', 'retirePredecessorProcess'];
     const unexpected = Object.keys(mod).filter((k) => !verbNames.includes(k) && !helperNames.includes(k));
     expect(unexpected).toEqual([]);
   });


### PR DESCRIPTION
## Summary

Closes the three acceptance criteria still open on US-002 and US-003 after the earlier slices merged.

**AC-2-4 — "graceful" was a name, not a behaviour.** `graceful-kill` called `killProcess` → tree-kill, which on win32 is `taskkill /pid N /T /F`. Two consequences the module's own docblock denies:

- `/T` terminated every **descendant** of the seat — dev server, leo-stack, background shells.
- The signal argument is **ignored** there, so the documented SIGTERM-then-SIGKILL escalation was two identical *forced* kills. The agent never got the flush window the word "graceful" promises.

New `killProcessOnly` targets one process and makes the distinction real: `taskkill /PID n` without `/F` is the genuine win32 analogue of SIGTERM; `/F` is reserved for the escalation. `console-reaper.mjs` had independently reached the single-process conclusion — this generalises it rather than adding a third spelling.

**AC-3-6 — a restart left two processes on one seat.** It retired the old *row* (singleton mutex, or a `released` update) and never touched the old *process*. The survivor kept heartbeating its claim, kept its worktree, and was invisible to every gauge that reads the registry rather than the process table.

**AC-3-4 — the enforcing guard could not fail.** The repo-wide grep AC-3-4 asks for was module-scoped, so it only ever inspected the one file already known to be correct.

## What to look at in review

**The order is the safety property**, exactly as in `graceful-kill`. Predecessor retirement runs only after the replacement is confirmed live *and* succession actually completed — `hold_old` deliberately leaves the predecessor running. Terminating first would, on a dry run or failed spawn, kill the incumbent and leave the seat empty: strictly worse than the defect.

**It is fail-closed.** A pid is signalled only on a positive `MATCH` from the same tri-state claude probe the operator kill path uses. `NO_MATCH` is already-gone and kills nothing; **`PROBE_FAILED` refuses** — pids are recycled, so a pid whose identity we cannot confirm would take out an unrelated process. An unverifiable outcome reports `unverified` rather than attesting a clean succession.

This does **not** call the FR-2 graceful kill, so AC-2-8 ("operator-initiated only, no watchdog") still holds: that entrypoint is default-off and operator-contracted. This is restart completing its own contract on a process it has already replaced.

## Test plan

2192 tests green across `lib/fleet`, `tests/unit/fleet`, `lib/utils`, `lib/coordinator` (176 files).

Assertions were chosen for where the defects actually lived:

- The kill tests assert the **argv handed to the OS**, because "kill was called with SIGTERM" recorded the caller's intent faithfully while the platform did something else entirely.
- The predecessor tests are weighted toward the **refusals**, with a negative control that a positive identification *does* kill — without it, every refusal assertion would also pass on an implementation that never kills anything.
- The repo-wide guard was proven **falsifiable** by planting a reader and watching it name the file, not merely observed to pass.

Every new assertion was verified to fail against its reverted code, with the mutation confirmed applied on disk before the result was trusted.

## Correction to an earlier assessment

AC-3-4's PARTIAL rested on a conflation: `fleet_desired_slots.resume_uuid` (a legitimately-populated **column**) versus `claude_sessions.metadata.resume_uuid` (populated on 1 of 13,025 rows). Nothing reads the latter. AC-3-8's PARTIAL is likewise stale — PR #6628 moved resume resolution into `spawnReplacement`, so `relaunchUnderProfile` now inherits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)