### PR TITLE
feat(SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001): FR-1 writer + fix an option name that made FR-2 precedence dead

### DIFF
--- a/scripts/modules/complete-quick-fix/cli.js
+++ b/scripts/modules/complete-quick-fix/cli.js
@@ -96,6 +96,12 @@ export function parseArguments(args) {
       // merged-PR witness alone proves only that code landed, so it now reconciles NON-TERMINAL;
       // this flag is what makes 'completed' truthful. Value names who/why for the audit trail.
       'scope-accepted':     { type: 'string' },
+      // SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001 FR-1: one observation of the RUNNING system at
+      // close time (a probe, a render, a status code) — NOT a merge SHA, which commit_sha already
+      // witnesses. Omitting it is allowed and is recorded EXPLICITLY as declared:false rather than
+      // left null, so a later reader can tell "nobody declared one" from "not applicable".
+      'runtime-observation': { type: 'string' },
+      'observation-method':  { type: 'string' },
       'skip-tests':         { type: 'boolean' },
       'tests-pass':         { type: 'string' },
       'skip-typecheck':     { type: 'boolean' },
@@ -209,6 +215,8 @@ export function parseArguments(args) {
     actualTestLoc:     values['actual-test-loc']   != null ? parseInt(values['actual-test-loc'], 10) : undefined,
     prUrl:             values['pr-url'],
     scopeAccepted:     values['scope-accepted'],
+    runtimeObservation: values['runtime-observation'],
+    observationMethod:  values['observation-method'],
     skipTestRun:       values['skip-tests']       || false,
     testsPass:         values['tests-pass']       != null ? values['tests-pass'].toLowerCase().startsWith('y') : undefined,
     skipTypeCheck:     values['skip-typecheck']   || false,

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -115,7 +115,86 @@ export function completionModeStamp({ forceComplete = false, scopeAcceptedBy = n
   return who ? `${who} (${mode})` : mode;
 }
 
-export function buildMergedReconcileUpdate({ qf = {}, prUrl, mergeSha = null, nowIso, scopeAcceptedBy = null }) {
+/**
+ * Bridge the CLI options object to completionModeStamp, and pin the property NAME.
+ *
+ * THIS EXISTS BECAUSE THE NAME WAS WRONG IN SHIPPED CODE. FR-2 read `options.scopeAcceptedBy`
+ * while cli.js has always produced `options.scopeAccepted`, so the value was permanently
+ * `undefined` and the documented precedence — prefer the scope-accepter over the operator session
+ * — COULD NEVER FIRE. It degraded silently to the session id, which looks like a working stamp.
+ *
+ * The FR-2 pins did not catch it because they call completionModeStamp DIRECTLY with explicit
+ * arguments: the function was correct, the CALL SITE handed it the wrong key. Unit verified,
+ * consumer not. Routing both call sites through one exported bridge makes the option name an
+ * executable contract that a test can drive with a REAL parsed-argv options object, instead of a
+ * spelling that has to be re-checked by eye at every call site.
+ *
+ * @param {object} options - the options object built by cli.js
+ * @param {string|null} sessionId
+ * @returns {string}
+ */
+export function completionStampFromOptions(options = {}, sessionId = null) {
+  return completionModeStamp({
+    forceComplete: options.forceComplete,
+    scopeAcceptedBy: options.scopeAccepted,
+    sessionId
+  });
+}
+
+/**
+ * SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001 FR-1 — build the runtime_observation value.
+ *
+ * WHAT THIS IS FOR. commit_sha and pr_url already witness that CODE LANDED. This SD exists because
+ * landing is not running, so FR-1 wants one observation of the RUNNING system at close time. The
+ * shape is fixed by precedent, not invented here: Adam recorded the first real observation on
+ * QF-20260725-096 using {observed_at, method, observation, declared_by}, so this conforms to what
+ * is already in the column rather than introducing a second dialect one table over — which is the
+ * exact collision that ruled out compliance_details as a home in the first place.
+ *
+ * ABSENCE IS RECORDED, NOT LEFT BLANK. When nothing is declared, this returns an explicit
+ * `declared: false` record instead of null. That is the FR-1 acceptance criterion verbatim: the
+ * absence must be explicit "so silence is distinguishable from not applicable". A null column
+ * cannot carry that distinction — it reads identically whether nobody looked, nobody thought to
+ * look, or looking was genuinely irrelevant.
+ *
+ * THE HONEST LIMITATION, kept next to the code rather than in a doc nobody opens: the FR-1 trigger
+ * is worker-DECLARED, not detected. Nothing on quick_fixes can decide "this row's acceptance
+ * depends on runtime behaviour" — the LEAD survey looked and found no mechanical discriminator. So
+ * `declared: false` means NOBODY DECLARED ONE. It is not evidence that none was needed, and must
+ * never be read as an all-clear.
+ *
+ * NEVER CLOBBERS. An existing observation is returned untouched. Re-running a completion must not
+ * overwrite a probe someone actually performed with a fresh "nobody declared one" — that would
+ * destroy real evidence to record its absence, which is worse than either outcome alone.
+ *
+ * Pure: the caller passes nowIso and the identity. No clock, no env, no DB.
+ *
+ * @param {{existing?: object|null, observation?: string|null, method?: string|null,
+ *          declaredBy?: string|null, nowIso: string}} args
+ * @returns {object} always an object — the column is never left silently empty by this path
+ */
+export function buildRuntimeObservation({ existing = null, observation = null, method = null, declaredBy = null, nowIso }) {
+  // Real evidence already on the row wins over anything this close would write.
+  if (existing && typeof existing === 'object' && Object.keys(existing).length > 0) return existing;
+
+  const text = typeof observation === 'string' ? observation.trim() : '';
+  if (!text) {
+    return {
+      declared: false,
+      observed_at: nowIso,
+      declared_by: declaredBy || null,
+      note: 'No runtime observation declared at close. The FR-1 trigger is worker-DECLARED, not detected — nothing on quick_fixes can decide whether acceptance depends on runtime behaviour. So this records that NOBODY DECLARED ONE; it is not evidence that none was applicable.'
+    };
+  }
+  return {
+    observed_at: nowIso,
+    method: (typeof method === 'string' && method.trim()) || 'declared',
+    observation: text,
+    declared_by: declaredBy || null
+  };
+}
+
+export function buildMergedReconcileUpdate({ qf = {}, prUrl, mergeSha = null, nowIso, scopeAcceptedBy = null, runtimeObservation = null, observationMethod = null }) {
   // QF-20260725-691: a merged PR witnesses that CODE LANDED. Terminal `completed` asserts that
   // the QF's SCOPE WAS SATISFIED. Those are different propositions and this path used to
   // substitute one for the other silently — invisible precisely because the merge really did
@@ -166,6 +245,16 @@ export function buildMergedReconcileUpdate({ qf = {}, prUrl, mergeSha = null, no
     // being ANONYMOUS. "accepted on merge evidence alone" is a legitimate value here; nothing at all
     // is not, because an empty witness is indistinguishable from a close nobody thought about.
     verified_by: witnessNameFrom(scopeAcceptedBy),
+    // SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001 FR-1. Written on EVERY terminal close, including
+    // when nothing was declared — an explicit `declared: false` record, never a silent null, so a
+    // later reader can tell "nobody declared one" from "not applicable". Existing evidence wins.
+    runtime_observation: buildRuntimeObservation({
+      existing: qf.runtime_observation,
+      observation: runtimeObservation,
+      method: observationMethod,
+      declaredBy: witnessNameFrom(scopeAcceptedBy),
+      nowIso
+    }),
     verification_notes,
     completed_at: qf.completed_at || nowIso,
     // QF-20260711-176: a completed QF has no holder. Leaving claiming_session_id set made the
@@ -767,10 +856,15 @@ export async function completeQuickFix(qfId, options = {}) {
       // Prefer a real identity when one exists: the scope-accepter, else the operator session that
       // ran the command. The mode is preserved as a suffix so nothing that reads these values for
       // classification loses the distinction it relied on.
-      verified_by: completionModeStamp({
-        forceComplete: options.forceComplete,
-        scopeAcceptedBy: options.scopeAcceptedBy,
-        sessionId: process.env.CLAUDE_SESSION_ID || null
+      verified_by: completionStampFromOptions(options, process.env.CLAUDE_SESSION_ID || null),
+      // FR-1, second writer — same contract as the reconcile path above: always an explicit
+      // record, existing evidence never clobbered.
+      runtime_observation: buildRuntimeObservation({
+        existing: qf?.runtime_observation,
+        observation: options.runtimeObservation,
+        method: options.observationMethod,
+        declaredBy: completionStampFromOptions(options, process.env.CLAUDE_SESSION_ID || null),
+        nowIso: new Date().toISOString()
       }),
       verification_notes: finalVerificationNotes,
       files_changed: filesChanged.length > 0 ? filesChanged : null,

--- a/tests/unit/complete-quick-fix/merged-reconcile-verification.test.js
+++ b/tests/unit/complete-quick-fix/merged-reconcile-verification.test.js
@@ -8,7 +8,7 @@
 // the CHECK without fabricating uat_verified.
 
 import { describe, it, expect } from 'vitest';
-import { buildMergedReconcileUpdate, witnessNameFrom, completionModeStamp } from '../../../scripts/modules/complete-quick-fix/orchestrator.js';
+import { buildMergedReconcileUpdate, witnessNameFrom, completionModeStamp, buildRuntimeObservation, completionStampFromOptions } from '../../../scripts/modules/complete-quick-fix/orchestrator.js';
 
 // Mirror of the live completed_requires_verification CHECK predicate (asserted against the DB
 // constraint def: (tests_passing AND uat_verified) OR force_completed when status='completed').
@@ -264,5 +264,114 @@ describe('completionModeStamp — FR-2 second writer', () => {
   it('is callable with no arguments at all', () => {
     // Guards the default-parameter object: a bare call must not throw on destructuring.
     expect(completionModeStamp()).toBe('UAT_AGENT');
+  });
+});
+
+// ── SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001 FR-1 ────────────────────────────────────────────
+//
+// buildRuntimeObservation: one observation of the RUNNING system at close time. The shape is fixed
+// by PRECEDENT, not invented — Adam recorded the first real observation on QF-20260725-096 using
+// {observed_at, method, observation, declared_by}, so these pin conformance to what is already in
+// the column rather than a second dialect.
+describe('buildRuntimeObservation — FR-1', () => {
+  const nowIso = '2026-07-28T11:00:00.000Z';
+
+  it('records a declared observation in the shape already in the column', () => {
+    const o = buildRuntimeObservation({
+      observation: 'GET /fleet-ui/session-view.html -> 410', method: 'http_probe',
+      declaredBy: 'Alpha-4', nowIso
+    });
+    expect(o).toEqual({
+      observed_at: nowIso, method: 'http_probe',
+      observation: 'GET /fleet-ui/session-view.html -> 410', declared_by: 'Alpha-4'
+    });
+  });
+
+  it('records ABSENCE EXPLICITLY rather than leaving the column null', () => {
+    // The FR-1 acceptance criterion verbatim: absence must be explicit "so silence is
+    // distinguishable from not applicable". A null cannot carry that distinction.
+    const o = buildRuntimeObservation({ declaredBy: 'Alpha-4', nowIso });
+    expect(o.declared).toBe(false);
+    expect(o.observed_at).toBe(nowIso);
+    expect(o).not.toBeNull();
+  });
+
+  it('says in the row itself that absence is NOT an all-clear', () => {
+    // The trigger is worker-DECLARED, not detected. If the note ever stops saying so, a reader
+    // will mistake declared:false for "runtime evidence was not applicable here".
+    const o = buildRuntimeObservation({ nowIso });
+    expect(o.note).toMatch(/nobody declared one/i);
+    expect(o.note).toMatch(/not evidence that none was applicable/i);
+  });
+
+  it('NEVER clobbers an observation already on the row', () => {
+    // Re-running a completion must not overwrite a probe someone actually performed with a fresh
+    // "nobody declared one" — that destroys real evidence in order to record its absence.
+    const existing = { observed_at: '2026-07-28T10:35:34.327Z', method: 'http_probe', observation: 'real probe', declared_by: 'adam' };
+    expect(buildRuntimeObservation({ existing, observation: 'later text', nowIso })).toEqual(existing);
+    expect(buildRuntimeObservation({ existing, nowIso })).toEqual(existing);
+  });
+
+  it('treats an empty or whitespace-only observation as undeclared, not as a blank observation', () => {
+    for (const v of ['', '   ', null, undefined]) {
+      expect(buildRuntimeObservation({ observation: v, nowIso }).declared).toBe(false);
+    }
+  });
+
+  it('defaults method when text is given without one, and ignores a blank existing object', () => {
+    expect(buildRuntimeObservation({ observation: 'saw it', nowIso }).method).toBe('declared');
+    expect(buildRuntimeObservation({ existing: {}, observation: 'saw it', nowIso }).observation).toBe('saw it');
+  });
+});
+
+// completionStampFromOptions: the CALL-SITE contract. This is the pin that was missing.
+describe('completionStampFromOptions — the option NAME is the contract', () => {
+  it('reads the key cli.js actually produces (scopeAccepted), not scopeAcceptedBy', () => {
+    // THE SHIPPED BUG: FR-2 read options.scopeAcceptedBy while cli.js has always produced
+    // options.scopeAccepted, so the value was permanently undefined and the documented precedence
+    // could never fire — it degraded silently to the session id, which LOOKS like a working stamp.
+    // The FR-2 pins missed it because they called completionModeStamp directly with explicit args:
+    // the function was right, the call site handed it the wrong key.
+    expect(completionStampFromOptions({ forceComplete: true, scopeAccepted: 'Alpha-4 — why' }, 'sess-1'))
+      .toBe('Alpha-4 (FORCE_COMPLETE)');
+  });
+
+  it('regression guard: the misspelled key must NOT satisfy the precedence', () => {
+    // If someone reintroduces scopeAcceptedBy at the call site, this fails instead of silently
+    // falling back to the session id.
+    expect(completionStampFromOptions({ forceComplete: true, scopeAcceptedBy: 'Ghost — why' }, 'sess-1'))
+      .toBe('sess-1 (FORCE_COMPLETE)');
+  });
+
+  it('falls back to the session when no scope-accepter was supplied', () => {
+    expect(completionStampFromOptions({ forceComplete: false }, 'sess-2')).toBe('sess-2 (UAT_AGENT)');
+  });
+});
+
+// END-TO-END OPTION CONTRACT, driven by the REAL parser rather than a hand-made options object.
+// A stand-in object only proves the stand-in spells the key the way I spelled it in the test —
+// which is the same mental model that produced the bug. Importing parseArguments makes the two
+// modules agree in the test the way they must agree at runtime.
+describe('cli.parseArguments -> completionStampFromOptions (cross-module contract)', () => {
+  it('a real --scope-accepted argv reaches the stamp', async () => {
+    const { parseArguments } = await import('../../../scripts/modules/complete-quick-fix/cli.js');
+    // parseArguments returns { qfId, options } — NOT a flat object. Learned by driving the real
+    // parser: a hand-made stand-in would have encoded my wrong assumption about the return shape
+    // and passed forever. --force-complete also genuinely requires --reason.
+    const { options } = parseArguments(['QF-20260725-096', '--force-complete', '--reason', 'audit', '--scope-accepted', 'Alpha-4 — scope satisfied']);
+    expect(options.scopeAccepted).toBe('Alpha-4 — scope satisfied');
+    expect(completionStampFromOptions(options, 'sess-x')).toBe('Alpha-4 (FORCE_COMPLETE)');
+  });
+
+  it('a real --runtime-observation argv reaches buildRuntimeObservation', async () => {
+    const { parseArguments } = await import('../../../scripts/modules/complete-quick-fix/cli.js');
+    const { options } = parseArguments(['QF-20260725-096', '--runtime-observation', 'GET / -> 410', '--observation-method', 'http_probe']);
+    const o = buildRuntimeObservation({
+      observation: options.runtimeObservation, method: options.observationMethod,
+      declaredBy: 'Alpha-4', nowIso: '2026-07-28T11:00:00.000Z'
+    });
+    expect(o.observation).toBe('GET / -> 410');
+    expect(o.method).toBe('http_probe');
+    expect(o.declared).toBeUndefined();
   });
 });


### PR DESCRIPTION
Completes **FR-1** of SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001, and fixes a shipped bug in my own FR-2 work that I found while wiring it.

## FR-1 — record a runtime observation

`--runtime-observation "<what was seen>"` (plus optional `--observation-method`) records one observation of the **running** system at close time. `commit_sha` and `pr_url` already witness that code landed; this SD exists because landing is not running.

**The shape conforms to precedent rather than invention.** Adam recorded the first real observation on `QF-20260725-096` using `{observed_at, method, observation, declared_by}` — before this code existed. Introducing a second dialect would recreate, one column over, exactly the collision that ruled out `compliance_details` as a home.

**Absence is explicit, never a silent null.** Omitting the flag writes `declared: false` with a note stating the trigger is worker-*declared*, not detected — so "nobody declared one" is distinguishable from "not applicable". That is the FR-1 acceptance criterion verbatim, and a null column cannot carry the distinction: it reads identically whether nobody looked, nobody thought to look, or looking was irrelevant.

**Existing observations are never clobbered.** Re-running a completion must not overwrite a probe someone actually performed with a fresh "nobody declared one" — that destroys real evidence in order to record its absence, which is worse than either outcome alone.

## The bug this found — FR-2's precedence was dead on arrival

The call site read `options.scopeAcceptedBy`. `cli.js` has always produced `options.scopeAccepted`. So the value was permanently `undefined` and the documented precedence — *prefer the scope-accepter over the operator session* — **could never fire**. It degraded silently to the session id, which looks like a perfectly good stamp.

**Why the FR-2 pins missed it:** they call `completionModeStamp` directly with explicit arguments. The function was correct; the *call site* handed it the wrong key. Unit verified, consumer not — the same failure shape this SD keeps surfacing.

Both call sites now route through one exported `completionStampFromOptions`, so the option name is an executable contract rather than a spelling to be re-checked by eye at each site.

## Pins — 11 new, and proof they can fail

Two mutations, each reverting one behaviour:

| mutation | result |
|---|---|
| reinstate `options.scopeAcceptedBy` (the original bug) | **3 failed** |
| make absence silent (`return null`) | **3 failed** |

Full file: 41 passed.

**The cross-module contract is driven by the real parser**, not a hand-made options object — and that immediately earned its keep. My first attempt asserted `opts.scopeAccepted`; `parseArguments` actually returns `{ qfId, options }`. A stand-in object would have encoded my wrong assumption about the return shape and passed forever. It also surfaced that `--force-complete` genuinely requires `--reason`.

## Pre-existing failures, disclosed

`external-timeout-and-coverage-gate.test.js` has 2 failures (ANSI colour codes in subprocess stdout: `[33m12345[39m` vs `12345`). **Not caused by this branch** — verified by negative control, running the same file from the shared root on clean `main` without these commits: same 2 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
