### PR TITLE
fix(SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001): FR-1 was dead on the reconcile path — it recorded a FALSE absence

### DIFF
--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -194,7 +194,15 @@ export function buildRuntimeObservation({ existing = null, observation = null, m
   };
 }
 
-export function buildMergedReconcileUpdate({ qf = {}, prUrl, mergeSha = null, nowIso, scopeAcceptedBy = null, runtimeObservation = null, observationMethod = null }) {
+export function buildMergedReconcileUpdate({ qf = {}, prUrl, mergeSha = null, nowIso, scopeAcceptedBy = null, runtimeObservation = null, observationMethod = null, options = {} }) {
+  // Accept the CLI options object as a FALLBACK source for the FR-1 fields, not only explicit
+  // args. Two named params were declared here and the sole production call site passed NEITHER, so
+  // the feature was dead on this path while the unit tests passed — they supplied the args by hand,
+  // reproducing in the test the exact plumbing production omitted. Reading from `options` means the
+  // only way to break it again is to drop `options` entirely, which also breaks scopeAcceptedBy and
+  // fails loudly instead of silently recording a false absence.
+  const declaredObservation = runtimeObservation ?? options.runtimeObservation ?? null;
+  const declaredMethod = observationMethod ?? options.observationMethod ?? null;
   // QF-20260725-691: a merged PR witnesses that CODE LANDED. Terminal `completed` asserts that
   // the QF's SCOPE WAS SATISFIED. Those are different propositions and this path used to
   // substitute one for the other silently — invisible precisely because the merge really did
@@ -250,8 +258,8 @@ export function buildMergedReconcileUpdate({ qf = {}, prUrl, mergeSha = null, no
     // later reader can tell "nobody declared one" from "not applicable". Existing evidence wins.
     runtime_observation: buildRuntimeObservation({
       existing: qf.runtime_observation,
-      observation: runtimeObservation,
-      method: observationMethod,
+      observation: declaredObservation,
+      method: declaredMethod,
       declaredBy: witnessNameFrom(scopeAcceptedBy),
       nowIso
     }),
@@ -375,7 +383,12 @@ export async function completeQuickFix(qfId, options = {}) {
       // SD-REFILL-00QQ60BN: preserve the verification-column stamping the
       // completed_requires_verification CHECK demands, now with the SELF-DERIVED pr_url.
       const reconcileUpdate = buildMergedReconcileUpdate({
-        qf, prUrl: probeWitness.prUrl, mergeSha, nowIso: new Date().toISOString(), scopeAcceptedBy
+        qf, prUrl: probeWitness.prUrl, mergeSha, nowIso: new Date().toISOString(), scopeAcceptedBy,
+        // THIS LINE WAS MISSING AND IT MATTERED. Without it a real --runtime-observation was
+        // dropped here and the row recorded declared:false — a MANUFACTURED FALSE ABSENCE over an
+        // operator's actual declaration, which the never-clobber guard then made permanent. Worse
+        // than a null: FR-1 exists so absence is honest, and this asserted absence that was false.
+        options
       });
       const { error: reconcileErr } = await supabase
         .from('quick_fixes')

--- a/tests/unit/complete-quick-fix/external-timeout-and-coverage-gate.test.js
+++ b/tests/unit/complete-quick-fix/external-timeout-and-coverage-gate.test.js
@@ -157,7 +157,33 @@ describe('FR-4 already-MERGED probe (witness-gated)', () => {
     // SD-REFILL-00QQ60BN: the reconcile UPDATE payload is built by buildMergedReconcileUpdate
     // (stamping the verification columns the completed_requires_verification CHECK demands) and
     // applied via .update(reconcileUpdate) — now with the SELF-DERIVED pr_url.
-    expect(orchSrc).toMatch(/buildMergedReconcileUpdate\(\{[\s\S]{0,160}qf,[\s\S]{0,160}\}\)/);
+    // RE-ANCHORED (SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001). The old bound was {0,160}, so
+    // this broke the moment the call site grew — an explanatory comment and one more argument were
+    // enough. A bounded-length SOURCE regex fails on legitimate insertions rather than on the
+    // defect it names, which is the failure mode this SD is about, in the test layer.
+    //
+    // Widened AND strengthened: `options` is now required, because its ABSENCE was a real shipped
+    // bug — FR-1 fields were declared on buildMergedReconcileUpdate and the sole call site passed
+    // none, so a real --runtime-observation was dropped and the row recorded a FALSE absence.
+    // Tolerating the new argument would have re-anchored the pin around the fix without pinning it.
+    // Slice the ACTUAL call site rather than regex-scanning the whole file. Two traps avoided,
+    // both of which I walked into while writing this:
+    //   1. a bounded-length regex ({0,160}) broke the moment the call grew by a comment and one
+    //      argument — it failed on a legitimate insertion, not on the defect it names;
+    //   2. widening it to {0,600} made it match PAST the call's closing brace, so `options` was
+    //      satisfied by a LATER line (autoDetectGitInfo(testDir, options)). Deleting the argument
+    //      under test failed NOTHING. Verified by mutation: a pin that cannot fail is decoration.
+    // Anchoring on the assignment disambiguates the CALL from the function DEFINITION, which also
+    // contains the text `buildMergedReconcileUpdate({`.
+    const callStart = orchSrc.indexOf('const reconcileUpdate = buildMergedReconcileUpdate({');
+    expect(callStart).toBeGreaterThan(-1);
+    const callText = orchSrc.slice(callStart, orchSrc.indexOf('});', callStart));
+    expect(callText).toContain('qf,');
+    // `options` MUST be threaded: its absence was a real shipped bug. FR-1 fields were declared on
+    // buildMergedReconcileUpdate while the sole call site passed none, so a real
+    // --runtime-observation was dropped and the row recorded a FALSE absence, which the
+    // never-clobber guard then made permanent.
+    expect(callText).toContain('options');
     expect(orchSrc).toMatch(/\.update\(reconcileUpdate\)[\s\S]{0,80}\.eq\('id',\s*qfId\)[\s\S]{0,80}\.neq\('status',\s*'completed'\)/);
     // The probe must return BEFORE autoDetectGitInfo (which is the next major step).
     const probeIdx = orchSrc.indexOf('probeWitness.verified');

--- a/tests/unit/complete-quick-fix/merged-reconcile-verification.test.js
+++ b/tests/unit/complete-quick-fix/merged-reconcile-verification.test.js
@@ -375,3 +375,53 @@ describe('cli.parseArguments -> completionStampFromOptions (cross-module contrac
     expect(o.declared).toBeUndefined();
   });
 });
+
+// ── THE PIN THAT WAS MISSING, and the reason it was missing ──────────────────────────────────────
+//
+// buildMergedReconcileUpdate declared runtimeObservation/observationMethod and its SOLE production
+// call site passed NEITHER. So on the reconcile path a real --runtime-observation was dropped and
+// the row recorded declared:false — a MANUFACTURED FALSE ABSENCE over an operator's actual
+// declaration, made permanent by the never-clobber guard. Strictly worse than a null: FR-1 exists
+// so that absence is honest, and this asserted an absence that was false.
+//
+// The existing FR-1 pins could not catch it because they pass `observation:` BY HAND, reproducing
+// in the test the exact plumbing production omitted — the same "unit verified, consumer not"
+// failure as the FR-2 call-site bug, committed one function over while fixing that one.
+//
+// These drive the REAL parser into the REAL builder and assert on the ASSEMBLED payload.
+describe('reconcile path carries FR-1 through from parsed argv (regression)', () => {
+  const base = { qf: {}, prUrl: 'https://github.com/x/y/pull/1', nowIso: '2026-07-28T12:00:00.000Z' };
+
+  it('a real --runtime-observation reaches the assembled reconcile payload', async () => {
+    const { parseArguments } = await import('../../../scripts/modules/complete-quick-fix/cli.js');
+    const { options } = parseArguments(['QF-1', '--runtime-observation', 'GET /health -> 200', '--observation-method', 'http_probe']);
+    const u = buildMergedReconcileUpdate({ ...base, scopeAcceptedBy: 'Alpha-4 — why', options });
+    expect(u.runtime_observation.observation).toBe('GET /health -> 200');
+    expect(u.runtime_observation.method).toBe('http_probe');
+    // The precise regression: a real declaration must NEVER be recorded as an absence.
+    expect(u.runtime_observation.declared).toBeUndefined();
+  });
+
+  it('still records EXPLICIT absence when the operator genuinely declared nothing', async () => {
+    const { parseArguments } = await import('../../../scripts/modules/complete-quick-fix/cli.js');
+    const { options } = parseArguments(['QF-1', '--pr-url', 'https://github.com/x/y/pull/1']);
+    const u = buildMergedReconcileUpdate({ ...base, scopeAcceptedBy: 'Alpha-4 — why', options });
+    expect(u.runtime_observation.declared).toBe(false);
+  });
+
+  it('the field exists at all — deleting it from the payload must fail a test', () => {
+    // Coverage guard: before this, removing runtime_observation from the reconcile builder failed
+    // ZERO tests. An FR deliverable that can be deleted invisibly is not delivered.
+    const u = buildMergedReconcileUpdate({ ...base, scopeAcceptedBy: 'Alpha-4 — why' });
+    expect(u).toHaveProperty('runtime_observation');
+    expect(u.runtime_observation).not.toBeNull();
+  });
+
+  it('explicit args still win over options, so callers that pass them directly are unaffected', () => {
+    const u = buildMergedReconcileUpdate({
+      ...base, scopeAcceptedBy: 'Alpha-4 — why',
+      runtimeObservation: 'explicit', options: { runtimeObservation: 'from-options' }
+    });
+    expect(u.runtime_observation.observation).toBe('explicit');
+  });
+});


### PR DESCRIPTION
Found by the TESTING sub-agent during EXEC-TO-PLAN evidence gathering, in code I merged 30 minutes earlier.

## The defect

`buildMergedReconcileUpdate` declared `runtimeObservation` / `observationMethod`, and its **sole production call site passed neither**. On that path a real `--runtime-observation` was dropped and the row recorded `declared: false`.

That is **strictly worse than a null**. FR-1 exists so that absence is honest and distinguishable from "not applicable". This asserted an absence that was *false* — over an operator’s actual declaration — and the never-clobber guard then made it permanent, so re-running could never correct it.

Runnable repro through the real parser and real builder, before the fix:

```
--runtime-observation "GET /health -> 200 OK"
  → options.runtimeObservation === "GET /health -> 200 OK"
  → written: { declared: false, note: "...NOBODY DECLARED ONE" }
```

## It is the same bug I fixed one commit earlier

The previous commit fixed FR-2 reading `options.scopeAcceptedBy` where the CLI produces `options.scopeAccepted`, and introduced `completionStampFromOptions` so the option name became an executable contract. I bridged the **direct** writer and left the **reconcile** writer unbridged — committing the identical class of defect while fixing it. Unit verified, consumer not.

## Why the tests could not catch it

The FR-1 pins pass `observation:` **by hand**, reproducing in the test the exact plumbing production omitted. The agent devised a mutation I had not proposed — delete `runtime_observation` from the reconcile builder entirely — and it failed **zero** tests. An FR deliverable that can be deleted invisibly is not delivered.

## Fix

The builder reads the CLI `options` object as a fallback source. The only way to break it again is to drop `options` wholesale, which also breaks `scopeAcceptedBy` and fails loudly rather than silently recording a falsehood.

## Pins — 4 new, driving the real parser into the real builder

Asserting on the **assembled payload**, not hand-wired args. Mutation-verified:

| mutation | before | now |
|---|---|---|
| builder ignores `options` (the shipped bug) | 0 failed | **1 failed** |
| delete `runtime_observation` from the payload | **0 failed** | **4 failed** |

45 passed on the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)