### PR TITLE
SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001: one correlation convention across both advisory senders

### DIFF
--- a/lib/coordinator/argv-body.cjs
+++ b/lib/coordinator/argv-body.cjs
@@ -1,0 +1,45 @@
+/**
+ * SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 / FR-1 — shared argv→body extraction.
+ *
+ * THE DEFECT THIS REMOVES. Both senders built their message body by excluding a hand-maintained list
+ * of argv INDEXES:
+ *
+ *   const flagValueIdxs = new Set([tIdx, tIdx + 1, rIdx, rIdx + 1, ... ].filter(i => i >= 0));
+ *   const body = argv.slice(1).filter((a, i) => !flagValueIdxs.has(i + 1)).join(' ').trim();
+ *
+ * Every flag added to the parse had to be remembered a second time, in a different shape, further
+ * down the function. Solomon's list had drifted from its parse by THREE flags — measured, not
+ * assumed: `--framing-class`, `--message-kind` and `--part` all shipped their own flag token and
+ * value inside the message body (`--part 2/3 real body` instead of `real body`), while `--kind`,
+ * which was on the list, came through clean.
+ *
+ * The fix is to derive the exclusion from the flag NAMES, so the parse and the body-exclusion read
+ * the same list and cannot drift. Adding `--part` to Adam by copying the index-list idiom would have
+ * propagated the defect to a second sender, which is why this lives in lib/ rather than in either
+ * script: the two senders now share one implementation instead of two lists that must agree.
+ *
+ * Lists are per-PATH, not per-file. `--eta` belongs to the status sub-command and `--part` to send;
+ * a single superset would strip a legitimate `--eta` token out of a message body — the same class of
+ * asymmetry in the opposite direction.
+ */
+
+/**
+ * Join argv into a message body, excluding flags and the values they consume.
+ *
+ * @param {string[]} argv          full argv slice (argv[0] is the sub-command)
+ * @param {string[]} opts.valueFlags flags that consume the FOLLOWING token
+ * @param {string[]} opts.boolFlags  flags that consume nothing
+ * @param {number}   opts.from       first index to treat as body (default 1, past the sub-command)
+ * @returns {string} the body with no flag tokens in it
+ */
+function bodyFromArgv(argv, { valueFlags = [], boolFlags = [], from = 1 } = {}) {
+  const drop = new Set();
+  for (let i = from; i < argv.length; i++) {
+    const a = String(argv[i]);
+    if (valueFlags.includes(a)) { drop.add(i); drop.add(i + 1); }
+    else if (boolFlags.includes(a)) { drop.add(i); }
+  }
+  return argv.slice(from).filter((_, i) => !drop.has(i + from)).join(' ').trim();
+}
+
+module.exports = { bodyFromArgv };

--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -23,6 +23,7 @@ const FULL_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{
 
 const { PROTOCOL_COMMS_VERSION } = require('./protocol-comms-version.cjs');
 const { CORRECTION_KIND_SET, DISPOSITION_KIND } = require('./message-kinds.cjs');
+const { MAX_PARTS } = require('./multi-part-reply.cjs');
 const crypto = require('crypto');
 // SD-LEO-INFRA-HANDOFF-DISPATCH-AUTHORIZATION-001 (FR-1): the shared SSOT dispatch-
 // ineligibility classifier, mirror-killed into assertSdDispatchable below.
@@ -773,6 +774,28 @@ async function assertDoorRoutingAllowed(supabase, row, logger = console) {
  *
  * @throws {Error} code DISPATCH_CORRELATION_DISPOSED when the correlation is already disposed
  */
+/**
+ * Is this payload a part of a BOUNDED ordered series?
+ *
+ * SECURITY sub-agent finding (EXEC review, evidence aa192915), and it was right. The first version of
+ * exemption (3) tested only `part_index != null && part_total > 1`, which made the exemption
+ * unbounded: any sender could bypass the disposition lock forever, on any correlation, by stamping
+ * every message `--part 1/2` — never once using a documented correction path. MAX_PARTS was enforced
+ * at the CLI and in buildAdvisoryPayload, but NOT here, and this guard is the security control.
+ *
+ * That is the same mistake buildAdvisoryPayload's own comment warns about — "a bound checked only at
+ * the outermost layer is not a bound" — made one layer further out. The ceiling is re-validated here,
+ * at the choke, against the shared MAX_PARTS constant. A malformed or over-wide pair is NOT exempt,
+ * so it falls through to the lock rather than past it: the failure direction is refuse, not admit.
+ */
+function isBoundedSeriesPart(p) {
+  if (p.part_index == null || p.part_total == null) return false;
+  const pi = Number(p.part_index);
+  const pt = Number(p.part_total);
+  if (!Number.isInteger(pi) || !Number.isInteger(pt)) return false;
+  return pi >= 1 && pt > 1 && pi <= pt && pt <= MAX_PARTS;
+}
+
 async function assertCorrelationNotDisposed(supabase, row, logger = console) {
   try {
     const p = row && typeof row.payload === 'object' ? row.payload : null;
@@ -781,7 +804,7 @@ async function assertCorrelationNotDisposed(supabase, row, logger = console) {
     if (!corr) return;
     if (p.via === 'cc_originator') return;                         // (1)
     if (CORRECTION_KIND_SET.has(p.message_kind)) return;           // (2)
-    if (p.part_index != null && Number(p.part_total) > 1) return;  // (3)
+    if (isBoundedSeriesPart(p)) return;                            // (3)
 
     const { data, error } = await supabase
       .from('session_coordination')

--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -22,6 +22,7 @@
 const FULL_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 const { PROTOCOL_COMMS_VERSION } = require('./protocol-comms-version.cjs');
+const { CORRECTION_KIND_SET, DISPOSITION_KIND } = require('./message-kinds.cjs');
 const crypto = require('crypto');
 // SD-LEO-INFRA-HANDOFF-DISPATCH-AUTHORIZATION-001 (FR-1): the shared SSOT dispatch-
 // ineligibility classifier, mirror-killed into assertSdDispatchable below.
@@ -743,6 +744,69 @@ async function assertDoorRoutingAllowed(supabase, row, logger = console) {
  * @returns {Promise<{data:any,error:any}>} the Supabase insert result
  * @throws {Error} with err.code DISPATCH_TARGET_INVALID|DISPATCH_TARGET_UNKNOWN|DISPATCH_LOOKUP_FAILED on refusal
  */
+/**
+ * SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 / FR-2 — refuse a further answer on a correlation
+ * that already carries a terminal disposition.
+ *
+ * FAIL POSTURE, split deliberately (this file already mixes both, so it must be stated rather than
+ * inferred): fail-CLOSED on a genuine disposed-correlation match — that is the whole point — and
+ * fail-OPEN on the guard's OWN internal error. A bug in this guard must never block a send.
+ *
+ * THE THREE EXEMPTIONS ARE LOAD-BEARING. PLAN's review found that this FR as first written was a
+ * safety regression no test in the repo would have caught, and each exemption prevents a specific
+ * documented failure:
+ *
+ *  (1) via='cc_originator' — ensureOriginatorCc re-enters THIS SAME choke with THE SAME correlation
+ *      AFTER the primary insert. A lock without this exemption refuses that leg, ensureOriginatorCc's
+ *      own catch swallows the throw, and main() still prints its success line and exits 0. That is
+ *      verbatim QF-20260705-488, the incident where the chairman had to hand-relay a verdict: a
+ *      disposition that reports success while its originator never receives it.
+ *
+ *  (2) correction kinds — a wrong disposition must stay retractable, or this guard permanently
+ *      freezes the first verdict written, right or wrong (SD-...-CORRECTION-DELIVERY-PATH-001-C).
+ *      Keyed on CORRECTION_KINDS, never on MESSAGE_KINDS — see message-kinds.cjs for why that
+ *      distinction is the difference between a working lock and a silently self-exempting one.
+ *
+ *  (3) in-flight parts — FR-1 makes ordered parts of ONE logical message share a correlation. Without
+ *      this, the lock refuses part 2 onward and cancels FR-1 outright. FR-1 and FR-2 genuinely
+ *      contradict, and FR-1 yields first; the resolution lives in this predicate, not in prose.
+ *
+ * @throws {Error} code DISPATCH_CORRELATION_DISPOSED when the correlation is already disposed
+ */
+async function assertCorrelationNotDisposed(supabase, row, logger = console) {
+  try {
+    const p = row && typeof row.payload === 'object' ? row.payload : null;
+    if (!p) return;
+    const corr = p.correlation_id;
+    if (!corr) return;
+    if (p.via === 'cc_originator') return;                         // (1)
+    if (CORRECTION_KIND_SET.has(p.message_kind)) return;           // (2)
+    if (p.part_index != null && Number(p.part_total) > 1) return;  // (3)
+
+    const { data, error } = await supabase
+      .from('session_coordination')
+      .select('id')
+      .eq('payload->>correlation_id', String(corr))
+      .eq('payload->>message_kind', DISPOSITION_KIND)
+      .limit(1);
+    // Queried on payload->>, not the bare column: the session_coordination.correlation_id column is
+    // populated on 6.5% of rows and written by nothing in the repo, so a column-keyed lookup here
+    // would find nothing and the guard would be inert while reading as enforced.
+    if (error) {
+      logger && logger.warn && logger.warn(`[dispatch] disposition check skipped (fail-open): ${error.message}`);
+      return;
+    }
+    if (Array.isArray(data) && data.length > 0) {
+      const err = new Error(`DISPATCH_CORRELATION_DISPOSED: correlation ${corr} already carries a terminal disposition (row ${data[0].id}). Send a retraction/amend/supersede to revise it.`);
+      err.code = 'DISPATCH_CORRELATION_DISPOSED';
+      throw err;
+    }
+  } catch (e) {
+    if (e && e.code === 'DISPATCH_CORRELATION_DISPOSED') throw e; // fail CLOSED on a confirmed match
+    logger && logger.warn && logger.warn(`[dispatch] disposition check skipped (fail-open): ${e.message}`);
+  }
+}
+
 async function insertCoordinationRow(supabase, row, opts = {}) {
   const { logger = console, select = null, single = false, topicId = null } = opts;
   if (!row || typeof row !== 'object') {
@@ -926,6 +990,9 @@ async function insertCoordinationRow(supabase, row, opts = {}) {
   if (row.body == null && row.payload && typeof row.payload === 'object' && row.payload.body != null) {
     row.body = row.payload.body;
   }
+  // FR-2: the LAST guard before the write. Placed at the shared choke so both senders and every
+  // other caller inherit it — a per-sender check would leave the other sender unguarded.
+  await assertCorrelationNotDisposed(supabase, row, logger);
   let q = supabase.from('session_coordination').insert(row);
   if (select) {
     q = q.select(select);
@@ -1028,4 +1095,5 @@ module.exports = {
   assertFleetAssignmentTarget, // QF-20260719-662 — exported for the choke-guard unit fixtures
   assertWorkerTierAllowed,
   assertDoorRoutingAllowed, // SD-LEO-INFRA-TIERED-ORCHESTRATION-FABLE-001 — exported for TS-3/TS-5 fixtures
+  assertCorrelationNotDisposed, // SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 FR-2 — exported for the choke-guard fixtures
 };

--- a/lib/coordinator/message-kinds.cjs
+++ b/lib/coordinator/message-kinds.cjs
@@ -1,0 +1,40 @@
+/**
+ * SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 / FR-2 — message_kind vocabulary.
+ *
+ * Shared because two modules now read it: solomon-advisory.cjs validates --message-kind against it,
+ * and dispatch.cjs's disposition lock decides exemptions from it. Two copies would be a drift pair,
+ * which is the defect class this SD closes.
+ *
+ * ── THE TRAP THIS FILE EXISTS TO PREVENT ───────────────────────────────────────────────────────
+ * CORRECTION_KINDS and MESSAGE_KINDS are deliberately DIFFERENT sets, and the disposition lock's
+ * exemption must be keyed on CORRECTION_KINDS.
+ *
+ * Before this FR, MESSAGE_KINDS was exactly ['retraction','amend','supersede'] — identical to the
+ * correction set. Adding 'disposition' to it makes them diverge for the first time. If a later edit
+ * derives the lock's exemption from MESSAGE_KINDS instead (an easy and natural-looking
+ * simplification, since they were the same list for the module's whole history), then 'disposition'
+ * exempts ITSELF, the lock never fires on the thing it exists to lock, and every test asserting that
+ * corrections stay possible keeps passing. That failure is silent and total.
+ *
+ * The two sets are therefore defined independently, and MESSAGE_KINDS is composed FROM
+ * CORRECTION_KINDS rather than the reverse, so the composition direction makes the wrong
+ * simplification harder to write than the right one.
+ */
+'use strict';
+
+/**
+ * Kinds that RETRACT or REVISE an earlier message. Exempt from the disposition lock — otherwise a
+ * wrong disposition could never be taken back, the exact defect closed by
+ * SD-LEO-INFRA-CORRECTION-DELIVERY-PATH-001-C.
+ */
+const CORRECTION_KINDS = Object.freeze(['retraction', 'amend', 'supersede']);
+const CORRECTION_KIND_SET = new Set(CORRECTION_KINDS);
+
+/** The terminal verdict kind. NOT a correction, and never exempt from its own lock. */
+const DISPOSITION_KIND = 'disposition';
+
+/** Everything --message-kind accepts. Composed from the correction set; never the source of it. */
+const MESSAGE_KINDS = Object.freeze([...CORRECTION_KINDS, DISPOSITION_KIND]);
+const MESSAGE_KIND_SET = new Set(MESSAGE_KINDS);
+
+module.exports = { CORRECTION_KINDS, CORRECTION_KIND_SET, DISPOSITION_KIND, MESSAGE_KINDS, MESSAGE_KIND_SET };

--- a/lib/coordinator/multi-part-reply.cjs
+++ b/lib/coordinator/multi-part-reply.cjs
@@ -1,20 +1,49 @@
 /**
  * Multi-part Solomon reply grouping — SD-LEO-FIX-SOLOMON-MULTI-PART-001.
  *
- * Ground-truthed against live session_coordination rows (2026-07-17): a split
- * Solomon reply does NOT share payload.correlation_id across parts — Solomon's
- * own body text on a live part-2 row explains why: "the send-path dedup blocks
- * a second row on the same correlation, so the contract-documented ordered-
- * parts mechanism cannot deliver -- part 2 rides clean" (a fresh, unrelated
- * correlation_id). The only signal both parts reliably carry is the subject-
- * line "N/M" marker plus the leading title text before it (e.g. a subject
- * "[SOLOMON_ORACLE] [oracle] COMMISSION VERDICT 1/2 -- ..." and a sibling
- * "... COMMISSION VERDICT 2/2 -- ..." share the "COMMISSION VERDICT" prefix
- * even though their trailing text diverges completely).
+ * CURRENT CONVENTION: ordered parts of one logical reply SHARE a single
+ * payload.correlation_id, and carry first-class payload.part_index /
+ * payload.part_total. Read readExplicitPartMarker() below — that is the path
+ * live senders take today.
+ *
+ * ── HISTORICAL, retained because it is why the fallback exists ──────────────
+ * The paragraph below described the state on 2026-07-17 and was accurate then.
+ * It is NOT the current contract; it was superseded when the send-path dedup
+ * became discriminator-aware (SD-LEO-INFRA-CORRECTION-DELIVERY-PATH-001-C).
+ * It is flagged rather than deleted because rows written under it still exist
+ * and still need the subject-regex fallback to group correctly.
+ *
+ *   Ground-truthed against live session_coordination rows (2026-07-17): a split
+ *   Solomon reply did NOT share payload.correlation_id across parts — Solomon's
+ *   own body text on a live part-2 row explains why: "the send-path dedup blocks
+ *   a second row on the same correlation, so the contract-documented ordered-
+ *   parts mechanism cannot deliver -- part 2 rides clean" (a fresh, unrelated
+ *   correlation_id). The only signal both parts reliably carried was the subject-
+ *   line "N/M" marker plus the leading title text before it (e.g. a subject
+ *   "[SOLOMON_ORACLE] [oracle] COMMISSION VERDICT 1/2 -- ..." and a sibling
+ *   "... COMMISSION VERDICT 2/2 -- ..." share the "COMMISSION VERDICT" prefix
+ *   even though their trailing text diverges completely).
+ *
+ * Two conventions genuinely coexist in the DATA; only one is correct for new
+ * sends. Stating the current one first is the whole point of this edit — the
+ * stale paragraph led the reading of this module for months.
  *
  * Pure, no I/O.
  */
 'use strict';
+
+/**
+ * Ceiling on ordered parts per reply. The part dimension deliberately relaxes the "one answer per
+ * correlation" invariant (that is the point), but an UNBOUNDED relaxation is not a narrowing at all:
+ * a sender could post arbitrarily many rows on one correlation just by incrementing part_index.
+ * MAX_PARTS keeps the relaxed bound finite and small.
+ *
+ * Lives HERE, in the module that owns the part concept, rather than in either sender. It began as a
+ * local const in solomon-advisory.cjs; giving Adam the same capability by copying the literal would
+ * have created two constants that must agree and no mechanism making them agree — which is the exact
+ * defect class SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 exists to close.
+ */
+const MAX_PARTS = 20;
 
 const BRACKET_TAG_RE = /^(\s*\[[^\]]+\]\s*)+/;
 const PART_MARKER_RE = /^(.*?)\s*(\d+)\s*\/\s*(\d+)\b/;
@@ -128,4 +157,4 @@ function groupMultiPartAdvisories(rows) {
   return groups;
 }
 
-module.exports = { parsePartMarker, readExplicitPartMarker, groupMultiPartAdvisories, reassembleGroupBody };
+module.exports = { MAX_PARTS, parsePartMarker, readExplicitPartMarker, groupMultiPartAdvisories, reassembleGroupBody };

--- a/lib/coordinator/reply-class.test.js
+++ b/lib/coordinator/reply-class.test.js
@@ -183,6 +183,33 @@ describe('checkAndPingOverdueReplies — single-fire PING-ON-SILENCE', () => {
     expect(inserts).toHaveLength(0);
   });
 
+  it('a terminal DISPOSITION clears the outstanding consult — no ping is sent', async () => {
+    // FR-3 criterion 1 / TS-4, added after VALIDATION flagged it as PARTIALLY MET: the claim was
+    // sound by code inspection but nothing demonstrated it. The answered-predicate (:158-159) matches
+    // rows whose payload.kind is the ANSWER kind and which echo the correlation — a disposition is
+    // exactly such a row, so posting one should clear the outstanding state with no ping code change.
+    // That is the evidence behind FR-3 shipping nothing.
+    //
+    // The disposition is built through Solomon's REAL buildAdvisoryPayload rather than hand-shaped
+    // here, so the test breaks if a disposition stops being emitted under the answer kind — a
+    // hand-written fixture would keep passing and hide it.
+    const solomon = require('../../scripts/solomon-advisory.cjs');
+    const disposition = solomon.buildAdvisoryPayload({
+      body: 'verdict: proceed', senderCallsign: 'Solomon', replyTo: 'corr-x', messageKind: 'disposition',
+    });
+    expect(disposition.kind).toBe('adam_advisory');       // the ANSWER kind the predicate matches
+    expect(disposition.message_kind).toBe('disposition'); // and it is terminal
+
+    const { sb } = makeFakeSupabase({
+      rows: [overdueRow],
+      answeredRows: [{ id: 'row-disposition', payload: { ...disposition, reply_to: 'corr-x' } }],
+    });
+    const inserts = [];
+    const result = await checkAndPingOverdueReplies(sb, { sessionId: 'me', senderType: 'adam', now: NOW, insert: makeStubInsert(inserts) });
+    expect(result.pinged).toBe(0);
+    expect(inserts).toHaveLength(0);
+  });
+
   it('asks the DATABASE to exclude already-pinged rows — not just the in-memory gate', async () => {
     // FR-3 residual gap. reply-class.cjs:213 (.is('payload->>ping_sent_at', null)) reads as redundant
     // with the :63 in-memory gate, and mutation proves the whole suite stays green without it. It is

--- a/lib/coordinator/reply-class.test.js
+++ b/lib/coordinator/reply-class.test.js
@@ -138,7 +138,8 @@ describe('checkAndPingOverdueReplies — single-fire PING-ON-SILENCE', () => {
   }
 
   it('pings exactly once for one overdue, unanswered, un-pinged row', async () => {
-    const { sb, inserts: rawInserts, updates } = makeFakeSupabase({ rows: [overdueRow], answeredRows: [] });
+    // The stub insert below collects into its own array; the fake's `inserts` is unused here.
+    const { sb, updates } = makeFakeSupabase({ rows: [overdueRow], answeredRows: [] });
     const inserts = [];
     const result = await checkAndPingOverdueReplies(sb, { sessionId: 'me', senderType: 'adam', now: NOW, insert: makeStubInsert(inserts) });
     expect(result.pinged).toBe(1);

--- a/lib/coordinator/reply-class.test.js
+++ b/lib/coordinator/reply-class.test.js
@@ -77,6 +77,14 @@ describe('findOverdueReplyNeeded — classification matrix', () => {
 function makeFakeSupabase({ rows = [], answeredRows = [] } = {}) {
   const inserts = [];
   const updates = [];
+  // SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 / FR-3: record the filters each query applies.
+  // The sweep has TWO independent single-fire mechanisms — the server-side .is('payload->>ping_sent_at',
+  // null) at reply-class.cjs:213 and the in-memory gate at :63 — and the second makes the first
+  // BEHAVIOURALLY INVISIBLE: delete :213 and :63 still filters the row, so pings stay at 0 and every
+  // behavioural test stays green (verified by mutation — all 36 passed with :213 removed). Recording
+  // the query shape is therefore the only way to pin it. See the test below for why it is load-bearing
+  // rather than redundant.
+  const filters = [];
   const sb = {
     from(table) {
       if (table !== 'session_coordination') throw new Error('unexpected table ' + table);
@@ -88,8 +96,8 @@ function makeFakeSupabase({ rows = [], answeredRows = [] } = {}) {
           this._mode = cols === 'id, payload' ? 'answered' : 'sweep';
           return this;
         },
-        eq() { return this; },
-        is() { return this; },
+        eq(col, val) { filters.push({ mode: this._mode, op: 'eq', col, val }); return this; },
+        is(col, val) { filters.push({ mode: this._mode, op: 'is', col, val }); return this; },
         in() { return this; },
         // FR-6 (count-truncation discipline): resolveAnsweredSet paginates via
         // fetchAllPaginated, so its chain ends .order(...).range(from, to).
@@ -114,7 +122,7 @@ function makeFakeSupabase({ rows = [], answeredRows = [] } = {}) {
       return b;
     },
   };
-  return { sb, inserts, updates };
+  return { sb, inserts, updates, filters };
 }
 
 // TS-3: single-fire dedup across repeated ticks. `insert` is stubbed directly (DI'd via
@@ -159,14 +167,38 @@ describe('checkAndPingOverdueReplies — single-fire PING-ON-SILENCE', () => {
     expect(inserts).toHaveLength(0);
   });
 
-  it('a SECOND tick against the same (now-pinged) row sends nothing — the query itself excludes ping_sent_at rows', async () => {
-    // Once ping_sent_at is stamped, the real query's .is('payload->>ping_sent_at', null) excludes the
-    // row server-side. Simulate the post-first-tick DB state directly (empty query result).
-    const { sb } = makeFakeSupabase({ rows: [], answeredRows: [] });
+  it('a SECOND tick against the same (now-pinged) row sends nothing', async () => {
+    // REWRITTEN (FR-3). This previously seeded rows:[] and claimed it proved "the query itself
+    // excludes ping_sent_at rows" — but an empty result set passes whether or not that filter
+    // exists, so it could not fail for its stated reason. It now seeds the ACTUAL post-first-tick
+    // row, with ping_sent_at stamped, and asserts nothing is sent. That exercises the real
+    // second-tick state through the in-memory gate. The server-side filter is pinned separately
+    // below, because no behavioural test can see it while the in-memory gate also holds.
+    const pingedRow = { ...overdueRow, payload: { ...overdueRow.payload, ping_sent_at: '2026-07-02T11:00:00.000Z' } };
+    const { sb } = makeFakeSupabase({ rows: [pingedRow], answeredRows: [] });
     const inserts = [];
     const result = await checkAndPingOverdueReplies(sb, { sessionId: 'me', senderType: 'adam', now: NOW, insert: makeStubInsert(inserts) });
     expect(result.pinged).toBe(0);
     expect(inserts).toHaveLength(0);
+  });
+
+  it('asks the DATABASE to exclude already-pinged rows — not just the in-memory gate', async () => {
+    // FR-3 residual gap. reply-class.cjs:213 (.is('payload->>ping_sent_at', null)) reads as redundant
+    // with the :63 in-memory gate, and mutation proves the whole suite stays green without it. It is
+    // NOT redundant: the sweep query is .limit(200) with NO .order(), so which 200 rows come back is
+    // arbitrary. Drop the server-side filter and already-pinged rows compete for that budget; a sender
+    // holding more than 200 reply-needed rows can have its 200 filled with rows :63 then discards,
+    // yielding zero pings while genuinely overdue rows are never looked at. The failure is silent —
+    // pinged:0 is indistinguishable from "nothing was overdue".
+    //
+    // Dormant, not live: the census found 9 ping_sent_at stamps ever, so no sender is near 200 today.
+    // It becomes reachable purely with volume, which is exactly the kind of guard that gets deleted as
+    // dead weight during a later cleanup. Pinning the query shape is the only instrument that can see
+    // it; a behavioural assertion cannot.
+    const { sb, filters } = makeFakeSupabase({ rows: [overdueRow], answeredRows: [] });
+    await checkAndPingOverdueReplies(sb, { sessionId: 'me', senderType: 'adam', now: NOW, insert: makeStubInsert([]) });
+    const sweepFilters = filters.filter((f) => f.mode === 'sweep');
+    expect(sweepFilters).toContainEqual({ mode: 'sweep', op: 'is', col: 'payload->>ping_sent_at', val: null });
   });
 });
 

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -63,7 +63,7 @@ const { routeFraming, FRAMING_ROUTES } = require('../lib/governance/fw3-framing-
 // primary, body-column fallback) — closes instance 4, the coordinator_request body-drop below.
 const { readCanonicalBody } = require('../lib/coordination/lane-contract.cjs');
 // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C: sender-stamped reply_class SSOT.
-const { REPLY_CLASSES, isValidReplyClass, computeReplyExpectedBy, checkAndPingOverdueReplies, reconcileLateVerdicts } = require('../lib/coordinator/reply-class.cjs');
+const { REPLY_CLASSES, isValidReplyClass, computeReplyExpectedBy, checkAndPingOverdueReplies, reconcileLateVerdicts, alreadyAnswered } = require('../lib/coordinator/reply-class.cjs');
 // SD-LEO-FIX-ADAM-INBOX-FULL-LANE-001: reuse the canonical Adam-session resolver for the unattended
 // full-lane tick (env vars are not reliably propagated to cron subprocesses).
 const { resolveAdamSessionId } = require('./read-adam-directives.cjs');
@@ -1278,6 +1278,28 @@ async function main() {
   } else if ((process.env.ADAM_PRE_SEND_CONSULT || 'on') === 'off') {
     // Never let a silently-off safety gate leave no trace (security-review finding #5).
     console.warn('[adam-advisory] ⚠ PRE-SEND CONSULT GATE DISABLED (ADAM_PRE_SEND_CONSULT=off) — sending without Solomon-consult review.');
+  }
+
+  // SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 / FR-1 (AC-2): PRE-SEND dedup, mirroring
+  // solomon-advisory.cjs:1012 verbatim in shape. Adam had NO dedup wiring at all — zero
+  // alreadyAnswered call sites — so a re-run answered the same correlation twice while Solomon's
+  // identical path short-circuited.
+  //
+  // The discriminators are the point. Passing message_kind and part_index makes the guard ask "has
+  // THIS kind of message already been posted here?" rather than "has anything been posted here?",
+  // which is what lets FR-1's multi-part consults share ONE correlation without the dedup eating
+  // parts 2..N. Omitting them would make --part unusable on Adam the moment it shipped.
+  //
+  // WHY THIS IS A GRACEFUL RETURN, NOT A THROW: I initially deferred this, arguing it added a
+  // blocking refusal to a path that never refuses, and cited QF-20260705-488. VALIDATION (evidence
+  // a499aa47) pushed back and was right — that incident was the FR-2 CHOKE-level lock swallowing
+  // ensureOriginatorCc's throw, a different layer. This check short-circuits before the insert and
+  // returns cleanly, which is the same mechanism that CLOSED that incident, not the one that caused
+  // it. Adam has no originator-CC leg to heal (grep: ensureOriginatorCc is Solomon-only), so the
+  // heal branch is deliberately absent rather than copied.
+  if (replyTo && (await alreadyAnswered(supabase, replyTo, { messageKind: payload.message_kind, partIndex: payload.part_index }))) {
+    console.log(`(dedup) consult ${String(replyTo).slice(0, 8)} already answered — not re-sending.`);
+    return;
   }
 
   // FR-6: route through the validated dispatch writer. insertCoordinationRow THROWS

--- a/scripts/adam-advisory.cjs
+++ b/scripts/adam-advisory.cjs
@@ -53,6 +53,8 @@ const { detectVersionSkew } = require('../lib/coordinator/protocol-comms-version
 const { warnIfCheckoutStale } = require('../lib/coordinator/checkout-staleness.cjs');
 const { PEER_KINDS } = require('../lib/coordinator/peer-target.cjs');
 const { enqueueRelayRequest } = require('../lib/coordinator/relay-queue.cjs');
+const { bodyFromArgv } = require('../lib/coordinator/argv-body.cjs');
+const { MAX_PARTS } = require('../lib/coordinator/multi-part-reply.cjs');
 const { PAYLOAD_KINDS, DIRECTIVE_KINDS, ADAM_EXCLUDED_KINDS, DRAIN_SETS } = require('../lib/fleet/worker-status.cjs');
 // SD-LEO-INFRA-FW3-FRAMING-PLUMBING-001-C: fail-closed pick-vs-instrument routing predicate
 // (consumes the -B framing_class contract; FRAMING_CLASSES matching now lives in the router).
@@ -208,7 +210,24 @@ function extractEmbeddedPeerDirective(rawPeerArg, rawBody) {
 // filters on (lib/fleet/worker-status.cjs) -- never a second hand-maintained list.
 const KNOWN_SEND_KINDS = new Set([...Object.values(PAYLOAD_KINDS), ...DIRECTIVE_KINDS]);
 
-function buildAdvisoryPayload({ body, senderCallsign, repo, correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes, replyTo, via, replyClass, replyWindowMs, now, addressee, kind }) {
+// SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 / FR-1 — flag names, not argv indices.
+//
+// This file previously built its message body by excluding a hand-maintained Set of argv INDEXES.
+// Its list happened to be complete; Solomon's, which used the identical idiom, had drifted from its
+// parse by THREE flags (--framing-class, --message-kind, --part all shipped inside message bodies).
+// Adding --part here by extending the index list would have been mirroring the defect onto a second
+// sender rather than fixing it, so both senders now derive exclusions from the flag NAMES via one
+// shared helper. Lists are per-PATH so no path strips another's flags out of a legitimate body.
+const VALUE_FLAGS = ['--to', '--kind', '--part', '--reply-class', '--reply-to', '--reply-window-ms', '--timeout'];
+const BOOL_FLAGS = ['--direct'];
+const STATUS_VALUE_FLAGS = ['--eta'];
+const SWEEP_VALUE_FLAGS = ['--window'];
+// Bound to the send path's own lists and used verbatim at the call site — a test that supplied its
+// own lists would prove the helper works while saying nothing about whether the send path hands it
+// the right ones, which is exactly where the Solomon defect lived.
+const sendBodyFromArgv = (argv) => bodyFromArgv(argv, { valueFlags: VALUE_FLAGS, boolFlags: BOOL_FLAGS });
+
+function buildAdvisoryPayload({ body, senderCallsign, repo, correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes, replyTo, via, replyClass, replyWindowMs, now, addressee, kind, partIndex, partTotal }) {
   // request mode (expectsReply) is always live-handshake (synchronous, bounded-timeout await);
   // send mode defaults to fire-and-forget unless the sender opts into reply-needed via --reply-class
   // (SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C).
@@ -237,6 +256,26 @@ function buildAdvisoryPayload({ body, senderCallsign, repo, correlationId, expec
   if (addressee) payload.addressee = addressee;
   if (reuseClass) payload.reuse_class = reuseClass;
   if (Array.isArray(appliesToScopes) && appliesToScopes.length) payload.applies_to_scopes = appliesToScopes;
+  // SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 / FR-1: ordered parts of ONE logical consult
+  // share a correlation_id and carry first-class part_index/part_total — the capability Solomon
+  // already had and Adam did not, which is why "one correlation convention" was not expressible at
+  // all. Written to the PAYLOAD, never the session_coordination.correlation_id column: measured over
+  // the full 6435-row population, the column is populated on 6.5% and the payload on 84.2%, and
+  // nothing in the repo has ever written the column. A column-keyed version of this would ship fully
+  // green and fully inert.
+  //
+  // Both fields required together (a part_index with no total is unorderable by the reader), and the
+  // bound is enforced HERE as well as at the CLI because buildAdvisoryPayload is exported and the CLI
+  // is not its only caller. A bound checked only at the outermost layer is not a bound.
+  if (partIndex != null && partTotal != null) {
+    const pi = Number(partIndex);
+    const pt = Number(partTotal);
+    if (!Number.isInteger(pi) || !Number.isInteger(pt) || pi < 1 || pt < 1 || pi > pt || pt > MAX_PARTS) {
+      throw new Error(`INVALID_PART: expected integers 1 <= part_index <= part_total <= ${MAX_PARTS} (got ${partIndex}/${partTotal}).`);
+    }
+    payload.part_index = pi;
+    payload.part_total = pt;
+  }
   if (body) {
     // Prefix the body with [<scope_key>] so a delivered-but-ignored advisory stays
     // scannable by scope. Prefix BEFORE the hard-cap check so the tag counts against it.
@@ -999,8 +1038,30 @@ async function main() {
   const toArg = toIdx >= 0 ? (argv[toIdx + 1] || '').toLowerCase() || null : null;
   const directIdx = argv.indexOf('--direct');
   const rawPeerArg = toArg || (directIdx >= 0 ? 'solomon' : null);
-  const flagValueIdxs = new Set([tIdx, tIdx + 1, rIdx, rIdx + 1, rcIdx, rcIdx + 1, rwIdx, rwIdx + 1, toIdx, toIdx + 1, directIdx, kIdx, kIdx + 1].filter(i => i >= 0));
-  const rawBody = argv.slice(1).filter((a, i) => !flagValueIdxs.has(i + 1)).join(' ').trim();
+  // FR-1: `--part N/M` sends ordered parts of one long consult on ONE correlation_id. Parsed as a
+  // pair because a part index without a total cannot be reassembled by the reader. Mirrors
+  // solomon-advisory.cjs's parse and shares its MAX_PARTS ceiling from multi-part-reply.cjs.
+  const partIdx = argv.indexOf('--part');
+  let partIndexArg = null;
+  let partTotalArg = null;
+  if (partIdx >= 0) {
+    const m = /^(\d+)\/(\d+)$/.exec(String(argv[partIdx + 1] || ''));
+    if (!m) {
+      console.error(`ERROR: --part must look like N/M (got "${argv[partIdx + 1] || ''}").`);
+      process.exit(2);
+    }
+    partIndexArg = Number(m[1]);
+    partTotalArg = Number(m[2]);
+    if (partIndexArg < 1 || partTotalArg < 1 || partIndexArg > partTotalArg) {
+      console.error(`ERROR: --part N/M requires 1 <= N <= M (got "${partIndexArg}/${partTotalArg}").`);
+      process.exit(2);
+    }
+    if (partTotalArg > MAX_PARTS) {
+      console.error(`ERROR: --part total exceeds MAX_PARTS (${MAX_PARTS}); got ${partTotalArg}. Link an artifact instead of splitting further.`);
+      process.exit(2);
+    }
+  }
+  const rawBody = sendBodyFromArgv(argv);
   // QF-20260707-114: a caller (confirmed live: Adam) sometimes embeds `--to <peer>` / `--direct`
   // INSIDE the quoted body instead of passing it as a separate CLI arg (the whole message ends
   // in the literal trailing text "--to solomon"). argv.indexOf('--to') then finds nothing (it's
@@ -1091,7 +1152,7 @@ async function main() {
   }
   // FR-1: scope-tag the advisory from the sending repo (reuse-first, fail-soft).
   const { scopeKey, reuseClass, appliesToScopes } = await resolveScopeForSend(supabase, process.cwd());
-  const payload = buildAdvisoryPayload({ body, senderCallsign, repo: process.cwd(), correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes, replyTo, via, replyClass: replyClassArg, replyWindowMs, addressee, kind: kindArg });
+  const payload = buildAdvisoryPayload({ body, senderCallsign, repo: process.cwd(), correlationId, expectsReply, scopeKey, reuseClass, appliesToScopes, replyTo, via, replyClass: replyClassArg, replyWindowMs, addressee, kind: kindArg, partIndex: partIndexArg, partTotal: partTotalArg });
   // R1 (QF-20260703-964): the addressee-vs-target divergence WARN lives ONE place — the
   // insertCoordinationRow choke point (lib/coordinator/dispatch.cjs) — not duplicated here.
   // SD-REFILL-00XK256L: the 2-hypothesis-bar GATE. Block an UNATTESTED urgent model-availability
@@ -1289,7 +1350,7 @@ async function drainAdamOutbound(supabase, { newSessionId, oldSessionIds } = {})
   }
 }
 
-module.exports = { buildAdvisoryPayload, advisoryExpiresAt, ADVISORY_TTL_MS, buildPreSendConsultBody, sanityCheckUrgentAdvisory, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow, drainInbox, isDirectiveRow, isAdamInboxRow, ADAM_INBOX_KINDS, drainAdamOutbound, isOrphanedAdamRow, EXCLUDED_KINDS, resolveAdamAdvisoryTarget, classifyDirectTarget, extractEmbeddedPeerDirective, windowSweep, parseSweepWindowMs, DEFAULT_SWEEP_WINDOW_MS, stampSurfaced, ackRows, DEFAULT_DRAIN_WINDOW_MS, KNOWN_SEND_KINDS };
+module.exports = { buildAdvisoryPayload, sendBodyFromArgv, VALUE_FLAGS, BOOL_FLAGS, STATUS_VALUE_FLAGS, SWEEP_VALUE_FLAGS, advisoryExpiresAt, ADVISORY_TTL_MS, buildPreSendConsultBody, sanityCheckUrgentAdvisory, resolveScopeForSend, resolveReplyToCorrelation, drainReplies, isReplyRow, drainInbox, isDirectiveRow, isAdamInboxRow, ADAM_INBOX_KINDS, drainAdamOutbound, isOrphanedAdamRow, EXCLUDED_KINDS, resolveAdamAdvisoryTarget, classifyDirectTarget, extractEmbeddedPeerDirective, windowSweep, parseSweepWindowMs, DEFAULT_SWEEP_WINDOW_MS, stampSurfaced, ackRows, DEFAULT_DRAIN_WINDOW_MS, KNOWN_SEND_KINDS };
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -56,6 +56,7 @@ const { PEER_KINDS } = require('../lib/coordinator/peer-target.cjs');
 const { enqueueRelayRequest } = require('../lib/coordinator/relay-queue.cjs');
 const { bodyFromArgv } = require('../lib/coordinator/argv-body.cjs');
 const { MAX_PARTS } = require('../lib/coordinator/multi-part-reply.cjs');
+const { MESSAGE_KINDS, MESSAGE_KIND_SET } = require('../lib/coordinator/message-kinds.cjs');
 // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C: sender-stamped reply_class SSOT.
 const {
   REPLY_CLASSES, isValidReplyClass, computeReplyExpectedBy, checkAndPingOverdueReplies,
@@ -82,8 +83,7 @@ const SOLOMON_CONSULT_KIND = 'solomon_consult';
 // scripts/hooks/coordination-inbox.cjs) plus the per-role DRAIN_SETS allowlist. A new top-level kind
 // would post a retraction that is INVISIBLE to exactly that audience. Same reuse-with-sub-discriminator
 // pattern as framing_class below (CLAUDE_SOLOMON.md:227 names it the standing decision).
-const MESSAGE_KINDS = Object.freeze(['retraction', 'amend', 'supersede']);
-const MESSAGE_KIND_SET = new Set(MESSAGE_KINDS);
+
 
 // MAX_PARTS moved to lib/coordinator/multi-part-reply.cjs (imported above) when Adam gained the same
 // --part capability: two senders enforcing the same ceiling from two local literals is a drift pair,

--- a/scripts/solomon-advisory.cjs
+++ b/scripts/solomon-advisory.cjs
@@ -54,6 +54,8 @@ const { getActiveAdamId } = require('../lib/coordinator/adam-identity.cjs');
 const { assertSenderRole, assertTargetRole } = require('../lib/coordinator/role-comms-guard.cjs');
 const { PEER_KINDS } = require('../lib/coordinator/peer-target.cjs');
 const { enqueueRelayRequest } = require('../lib/coordinator/relay-queue.cjs');
+const { bodyFromArgv } = require('../lib/coordinator/argv-body.cjs');
+const { MAX_PARTS } = require('../lib/coordinator/multi-part-reply.cjs');
 // SD-LEO-INFRA-ROLE-BASED-COMMS-ROUTING-PROTOCOL-001-C: sender-stamped reply_class SSOT.
 const {
   REPLY_CLASSES, isValidReplyClass, computeReplyExpectedBy, checkAndPingOverdueReplies,
@@ -83,12 +85,9 @@ const SOLOMON_CONSULT_KIND = 'solomon_consult';
 const MESSAGE_KINDS = Object.freeze(['retraction', 'amend', 'supersede']);
 const MESSAGE_KIND_SET = new Set(MESSAGE_KINDS);
 
-// Ceiling on ordered parts per reply. The part dimension deliberately relaxes the "one answer per
-// correlation" invariant (that is the point — see FR-3), but an UNBOUNDED relaxation is not a
-// narrowing at all: a sender could post arbitrarily many rows on one correlation just by
-// incrementing part_index. MAX_PARTS keeps the relaxed bound finite and small, so the worst case is
-// MESSAGE_KINDS.length x MAX_PARTS rows per correlation rather than unlimited.
-const MAX_PARTS = 20;
+// MAX_PARTS moved to lib/coordinator/multi-part-reply.cjs (imported above) when Adam gained the same
+// --part capability: two senders enforcing the same ceiling from two local literals is a drift pair,
+// not a shared bound. The rationale for the ceiling itself now lives with the constant.
 
 const ADVISORY_TTL_MS = 24 * 60 * 60_000; // 24h durable delivery window (mirrors the Adam lane).
 function advisoryExpiresAt(nowMs) {
@@ -698,6 +697,42 @@ async function drainSolomonOutbound(supabase, { newSessionId, oldSessionIds } = 
   }
 }
 
+/**
+ * SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 / FR-1 — derive the message body by NAME, not by
+ * a hand-maintained index list.
+ *
+ * THE DEFECT CLASS THIS REMOVES. The previous code built a Set of flag indices by hand
+ * ([tIdx, tIdx+1, rIdx, ... ]) and every new flag had to be remembered in two places: where it is
+ * parsed, and where its value is excluded from the body. --part and --message-kind were added to the
+ * first and forgotten in the second, so `send --part 2/3 --message-kind amend "real body"` shipped
+ * body === "--part 2/3 --message-kind amend real body" on the LIVE Solomon path. Proven by execution
+ * before fixing. No test caught it because every part/message-kind assertion calls
+ * buildAdvisoryPayload with NAMED ARGS and never crosses argv.
+ *
+ * Patching the list would fix this instance and leave the next flag to rediscover it. Deriving the
+ * exclusions from the flag NAMES makes the omission unrepresentable: a flag that is parsed is a flag
+ * that is stripped, because both read the same list.
+ *
+ * Exported so the argv path is testable — the parse lives in an unexported main(), which is the
+ * other half of why this went unseen.
+ */
+// ENUMERATED FROM THE SOURCE, not from memory. My first draft of this list guessed '--ref' and
+// '--reply-window' (neither exists) and omitted --framing-class and --timeout entirely — which would
+// have re-created the very leak this removes, for different flags. These are every value-consuming
+// flag the SEND path parses; a drift test pins them against the source so a newly parsed flag cannot
+// be added without appearing here.
+const VALUE_FLAGS = ['--to', '--kind', '--part', '--message-kind', '--reply-class', '--reply-to', '--reply-window-ms', '--timeout', '--framing-class'];
+const BOOL_FLAGS = ['--direct'];
+// The status sub-command has its own narrower parse. Keeping it separate stops a legitimate '--eta'
+// token inside a message body from being stripped by the send path — the same asymmetry the leak
+// caused, pointing the other way.
+const STATUS_VALUE_FLAGS = ['--eta'];
+
+// Bound to the send path's OWN lists and used verbatim at the call site. The binding is the point:
+// a test that passed its own flag lists would prove the helper strips flags while saying nothing
+// about whether the send path hands it the right ones — which is precisely where the defect lived.
+const sendBodyFromArgv = (argv) => bodyFromArgv(argv, { valueFlags: VALUE_FLAGS, boolFlags: BOOL_FLAGS });
+
 // SD-LEO-INFRA-COMMS-PRESENCE-GROUNDING-SIGNALS-001 (FR-7) — mirrors adam-advisory.cjs's printStatus
 // exactly, using the SAME shared helper (no per-role reimplementation).
 function formatPresence(p) {
@@ -712,8 +747,10 @@ async function printStatus(supabase, sessionId, argv) {
   if (workingIdx >= 0) {
     const etaIdx = argv.indexOf('--eta');
     const etaMs = etaIdx >= 0 ? Number(argv[etaIdx + 1]) || null : null;
-    const flagValueIdxs = new Set([etaIdx, etaIdx + 1].filter(i => i >= 0));
-    const body = argv.slice(workingIdx + 1).filter((a, i) => !flagValueIdxs.has(i + 1 + workingIdx)).join(' ').trim();
+    // Same helper as the send path, with this path's own narrower flag list — the last hand-built
+    // index Set in this file. Its list happened to match its parse, but only by being small enough
+    // to hold in your head, which is exactly the property the send path lost as it grew.
+    const body = bodyFromArgv(argv, { valueFlags: STATUS_VALUE_FLAGS, from: workingIdx + 1 });
     const res = await writeWorkingSignal(supabase, sessionId, { body, etaMs });
     console.log(res.persisted
       ? `Working-signal set: "${body}"${etaMs ? ` (ETA ~${Math.round(etaMs / 60000)}min)` : ''}`
@@ -880,8 +917,15 @@ async function main() {
   const toArg = toIdx >= 0 ? (argv[toIdx + 1] || '').toLowerCase() || null : null;
   const directIdx = argv.indexOf('--direct');
   const peerArg = toArg || (directIdx >= 0 ? 'adam' : null);
-  const flagValueIdxs = new Set([tIdx, tIdx + 1, rIdx, rIdx + 1, rcIdx, rcIdx + 1, rwIdx, rwIdx + 1, toIdx, toIdx + 1, directIdx, kIdx, kIdx + 1].filter((i) => i >= 0));
-  const body = argv.slice(1).filter((a, i) => !flagValueIdxs.has(i + 1)).join(' ').trim();
+  // SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 / FR-1: partIdx and mkIdx were MISSING here,
+  // so --part and --message-kind and their values fell through into the message BODY. Proven by
+  // execution before fixing: `send --part 2/3 --message-kind amend "real body here"` produced
+  //   body === "--part 2/3 --message-kind amend real body here"
+  // Every existing part/message-kind assertion calls buildAdvisoryPayload with NAMED ARGS and never
+  // crosses argv, which is exactly why a live defect on the shipped Solomon path stayed green.
+  // Found at PLAN by TESTING while reviewing whether to MIRROR this list onto Adam — mirroring it
+  // faithfully would have propagated the leak to a second sender. Fixed at source instead.
+  const body = sendBodyFromArgv(argv);
   if (!body) { console.error('ERROR: advisory body required.'); process.exit(2); }
 
   if (mode === 'request' && !isTwoWayV2Enabled()) {
@@ -1037,6 +1081,10 @@ module.exports = {
   drainInbox, resolveReplyToCorrelation, drainSolomonOutbound, captureLedgerRow,
   checkLedgerCaptureHealth, resolveSolomonAdvisoryTarget, resolveConsultOriginator, ensureOriginatorCc,
   stampSurfaced, ackRows, KNOWN_SEND_KINDS, MESSAGE_KINDS,
+  // SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 / FR-1: exported so the ARGV path is testable.
+  // The parse lives in an unexported main(), which is half of why the flag-leak went unseen — every
+  // existing assertion called buildAdvisoryPayload with named args and never crossed argv.
+  bodyFromArgv, sendBodyFromArgv, VALUE_FLAGS, BOOL_FLAGS, STATUS_VALUE_FLAGS,
 };
 
 if (require.main === module) {

--- a/tests/unit/adam-advisory-part.test.js
+++ b/tests/unit/adam-advisory-part.test.js
@@ -60,12 +60,20 @@ describe('FR-1: Adam stamps first-class part fields on the PAYLOAD', () => {
     expect(marker.prefix).not.toContain('COLUMN-VALUE');
   });
 
-  it('emits no top-level correlation_id column key — the write side of the same point', () => {
+  it('carries the part fields in the payload object the sender hands to the choke', () => {
+    // REWRITTEN after the TESTING sub-agent flagged the original (evidence f8a6bbdc). It was titled
+    // "emits no top-level correlation_id column key" but asserted hasOwnProperty(payload,
+    // 'correlation_id') === true — the payload, not the row. It therefore tested nothing about the
+    // row-vs-column distinction its name promised, and was redundant with the assertion above it.
+    // A test whose name claims more than its body checks is worse than no test: it reads as coverage.
+    //
+    // What is actually assertable here: buildAdvisoryPayload returns a PAYLOAD, so the honest claim is
+    // that every correlation field the reader needs lives inside that object and none of it depends on
+    // a sibling column. The row-level column is pinned where it belongs, at the dispatch choke, in
+    // tests/unit/coordinator/disposition-lock.test.js ("reads payload->>correlation_id, NOT the bare
+    // column") and by the divergent-value reader fixture above.
     const p = buildAdvisoryPayload({ body: 'x', senderCallsign: 'Adam', correlationId: 'CORR', partIndex: 1, partTotal: 2 });
-    // The correlation lives INSIDE the payload object. buildAdvisoryPayload returns the payload, so
-    // the assertion that matters is that it is present here — the row-level column is written by
-    // nothing in the repo, which is exactly why the payload must carry it.
-    expect(Object.prototype.hasOwnProperty.call(p, 'correlation_id')).toBe(true);
+    expect(p).toMatchObject({ correlation_id: 'CORR', part_index: 1, part_total: 2 });
   });
 });
 

--- a/tests/unit/adam-advisory-part.test.js
+++ b/tests/unit/adam-advisory-part.test.js
@@ -1,0 +1,129 @@
+/**
+ * SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 / FR-1 — Adam's --part capability.
+ *
+ * WHY THIS FILE EXISTS. The SD asked to apply ONE correlation convention symmetrically across both
+ * advisory senders. That was not implementable: Solomon parsed --part N/M and stamped first-class
+ * payload.part_index / payload.part_total, while adam-advisory.cjs had no --part flag and its
+ * buildAdvisoryPayload omitted both fields. There was nothing for a convention to converge ON. These
+ * tests pin the missing half.
+ *
+ * PAYLOAD, NEVER THE COLUMN. Measured over the full paginated population (6435 rows):
+ * session_coordination.correlation_id is populated on 6.5%, the payload carries it on 84.2%,
+ * column-only rows are ZERO, and nothing in the repo has ever written the column (created at
+ * 20260702_session_coordination_insert_lint.sql:16 behind a trigger that only RAISE NOTICEs). A
+ * column-keyed implementation of this FR would have shipped fully green and fully inert, so the
+ * payload-keyed assertions below are load-bearing, not decorative.
+ */
+import { describe, it, expect } from 'vitest';
+import { fileURLToPath } from 'node:url';
+import { parsedFlags } from './helpers/parsed-flags.js';
+import adamAdvisory from '../../scripts/adam-advisory.cjs';
+import multiPart from '../../lib/coordinator/multi-part-reply.cjs';
+
+const { buildAdvisoryPayload, sendBodyFromArgv, VALUE_FLAGS, BOOL_FLAGS, STATUS_VALUE_FLAGS, SWEEP_VALUE_FLAGS } = adamAdvisory;
+const { MAX_PARTS, readExplicitPartMarker } = multiPart;
+const SRC = fileURLToPath(new URL('../../scripts/adam-advisory.cjs', import.meta.url));
+
+describe('FR-1: Adam stamps first-class part fields on the PAYLOAD', () => {
+  it('builds a real multi-part Adam consult carrying part_index and part_total', () => {
+    const p = buildAdvisoryPayload({
+      body: 'second half of the consult',
+      senderCallsign: 'Adam',
+      correlationId: 'CORR-ADAM-1',
+      partIndex: 2,
+      partTotal: 3,
+    });
+    expect(p.part_index).toBe(2);
+    expect(p.part_total).toBe(3);
+    expect(p.correlation_id).toBe('CORR-ADAM-1');
+  });
+
+  it('shares ONE correlation across the parts of one logical consult', () => {
+    // The convention itself: N parts, ONE correlation — not N correlations.
+    const parts = [1, 2, 3].map((i) =>
+      buildAdvisoryPayload({ body: `part ${i}`, senderCallsign: 'Adam', correlationId: 'CORR-ADAM-2', partIndex: i, partTotal: 3 }),
+    );
+    expect(new Set(parts.map((p) => p.correlation_id)).size).toBe(1);
+    expect(parts.map((p) => p.part_index)).toEqual([1, 2, 3]);
+  });
+
+  it('the reader groups those parts off the PAYLOAD, not the table column', () => {
+    // TS-6's non-vacuous form. A column-NULL fixture proves nothing here — column-NULL is already
+    // the default state of every fixture in the repo. This fixture makes the two sources DIVERGE and
+    // asserts which one the reader actually follows; a column-keyed reader cannot satisfy it.
+    const row = {
+      correlation_id: 'COLUMN-VALUE',
+      payload: buildAdvisoryPayload({ body: 'x', senderCallsign: 'Adam', correlationId: 'PAYLOAD-VALUE', partIndex: 1, partTotal: 2 }),
+    };
+    const marker = readExplicitPartMarker(row);
+    expect(marker).toEqual({ prefix: 'corr:PAYLOAD-VALUE', index: 1, total: 2 });
+    expect(marker.prefix).not.toContain('COLUMN-VALUE');
+  });
+
+  it('emits no top-level correlation_id column key — the write side of the same point', () => {
+    const p = buildAdvisoryPayload({ body: 'x', senderCallsign: 'Adam', correlationId: 'CORR', partIndex: 1, partTotal: 2 });
+    // The correlation lives INSIDE the payload object. buildAdvisoryPayload returns the payload, so
+    // the assertion that matters is that it is present here — the row-level column is written by
+    // nothing in the repo, which is exactly why the payload must carry it.
+    expect(Object.prototype.hasOwnProperty.call(p, 'correlation_id')).toBe(true);
+  });
+});
+
+describe('FR-1: Adam enforces the SAME part bounds as Solomon', () => {
+  it('requires both halves — a part_index with no total is unorderable', () => {
+    const p = buildAdvisoryPayload({ body: 'x', senderCallsign: 'Adam', partIndex: 2 });
+    expect('part_index' in p).toBe(false);
+    expect('part_total' in p).toBe(false);
+  });
+
+  it('rejects out-of-range and non-integer pairs', () => {
+    const bad = [[0, 3], [3, 2], [1.5, 3], ['a', 3], [1, MAX_PARTS + 1]];
+    for (const [i, t] of bad) {
+      expect(() => buildAdvisoryPayload({ body: 'x', partIndex: i, partTotal: t })).toThrow(/INVALID_PART/);
+    }
+  });
+
+  it('enforces the ceiling from the SHARED constant, not a local literal', () => {
+    // The ceiling moved to multi-part-reply.cjs when Adam gained this capability. Two senders holding
+    // two copies of the literal 20 would be a drift pair with no mechanism keeping them equal — the
+    // same defect class this SD closes. Pin that Adam's bound tracks the shared constant: at the
+    // ceiling it is accepted, one past it throws, and both are computed FROM MAX_PARTS.
+    expect(buildAdvisoryPayload({ body: 'x', partIndex: 1, partTotal: MAX_PARTS }).part_total).toBe(MAX_PARTS);
+    expect(() => buildAdvisoryPayload({ body: 'x', partIndex: 1, partTotal: MAX_PARTS + 1 })).toThrow(/INVALID_PART/);
+  });
+
+  it('omitting --part is byte-identical to pre-SD behavior', () => {
+    const p = buildAdvisoryPayload({ body: 'x', senderCallsign: 'Adam' });
+    expect('part_index' in p).toBe(false);
+    expect('part_total' in p).toBe(false);
+  });
+});
+
+describe('FR-1: Adam does not inherit the body-leak defect', () => {
+  it('keeps --part and its value out of the message body', () => {
+    // TESTING's PLAN review called this out explicitly: mirroring Solomon's index-list idiom onto
+    // Adam would have made Adam INHERIT the leak while this suite stayed green.
+    expect(sendBodyFromArgv(['send', '--part', '2/3', '--to', 'solomon', 'real', 'body', 'here']))
+      .toBe('real body here');
+  });
+
+  it('every flag Adam parses is covered by one of its path lists', () => {
+    const covered = new Set([...VALUE_FLAGS, ...BOOL_FLAGS, ...STATUS_VALUE_FLAGS, ...SWEEP_VALUE_FLAGS]);
+    // --working is printStatus's sub-command marker (the body FOLLOWS it), not a send-path flag.
+    const uncovered = [...parsedFlags(SRC)].filter((f) => !covered.has(f) && f !== '--working');
+    expect(uncovered).toEqual([]);
+  });
+
+  it('no list entry is stale — it would strip real body text', () => {
+    const parsed = parsedFlags(SRC);
+    expect(VALUE_FLAGS.filter((f) => !parsed.has(f))).toEqual([]);
+  });
+
+  it('the guard can actually SEE Adam\'s parse — negative control', () => {
+    // Both assertions above pass just as happily against an empty set. Without this, a regex that
+    // stopped matching would read as "no drift" forever.
+    const parsed = parsedFlags(SRC);
+    expect(parsed.size).toBeGreaterThan(5);
+    expect(parsed.has('--part')).toBe(true);
+  });
+});

--- a/tests/unit/adam-advisory-part.test.js
+++ b/tests/unit/adam-advisory-part.test.js
@@ -16,12 +16,15 @@
  */
 import { describe, it, expect } from 'vitest';
 import { fileURLToPath } from 'node:url';
+import fs from 'node:fs';
 import { parsedFlags } from './helpers/parsed-flags.js';
 import adamAdvisory from '../../scripts/adam-advisory.cjs';
 import multiPart from '../../lib/coordinator/multi-part-reply.cjs';
+import replyClass from '../../lib/coordinator/reply-class.cjs';
 
 const { buildAdvisoryPayload, sendBodyFromArgv, VALUE_FLAGS, BOOL_FLAGS, STATUS_VALUE_FLAGS, SWEEP_VALUE_FLAGS } = adamAdvisory;
 const { MAX_PARTS, readExplicitPartMarker } = multiPart;
+const { alreadyAnswered } = replyClass;
 const SRC = fileURLToPath(new URL('../../scripts/adam-advisory.cjs', import.meta.url));
 
 describe('FR-1: Adam stamps first-class part fields on the PAYLOAD', () => {
@@ -104,6 +107,54 @@ describe('FR-1: Adam enforces the SAME part bounds as Solomon', () => {
     const p = buildAdvisoryPayload({ body: 'x', senderCallsign: 'Adam' });
     expect('part_index' in p).toBe(false);
     expect('part_total' in p).toBe(false);
+  });
+});
+
+describe('FR-1 AC-2: Adam consults dedup, and it discriminates by part_index', () => {
+  // Records the filters a query applies, so we can see WHICH discriminators reached the DB.
+  function filterRecordingSb(rows = []) {
+    const filters = [];
+    const sb = {
+      from() {
+        const chain = {
+          select() { return chain; },
+          eq(col, val) { filters.push({ col, val }); return chain; },
+          limit() { return Promise.resolve({ data: rows, error: null }); },
+        };
+        return chain;
+      },
+    };
+    return { sb, filters };
+  }
+
+  it('adds the part_index filter ONLY when a part index is supplied', async () => {
+    // The discrimination is what lets FR-1's multi-part consults share one correlation without dedup
+    // eating parts 2..N. Without it, part 2 is deduped against part 1 and --part is unusable.
+    const withPart = filterRecordingSb([]);
+    await alreadyAnswered(withPart.sb, 'CORR', { messageKind: undefined, partIndex: 2 });
+    expect(withPart.filters.map((f) => f.col)).toContain('payload->>part_index');
+
+    const withoutPart = filterRecordingSb([]);
+    await alreadyAnswered(withoutPart.sb, 'CORR', {});
+    // Strictly conditional: omitting it must reproduce the legacy query exactly, because the
+    // fixed-depth stubs elsewhere in the repo mock exactly two .eq() calls before .limit().
+    expect(withoutPart.filters.map((f) => f.col)).not.toContain('payload->>part_index');
+  });
+
+  it('ADAM\'S SEND PATH passes the discriminators — the wiring, not just the capability', () => {
+    // Adam had ZERO alreadyAnswered call sites; the capability existed and Adam never used it.
+    // The call lives in an unexported main(), so this pins the call SHAPE in source rather than
+    // driving it. That is a weaker instrument than a behavioural test and worth naming as such: it
+    // proves the discriminators are passed, not that the surrounding branch behaves correctly. It is
+    // here because dropping `partIndex` from this call is a silent, one-token regression that makes
+    // --part unusable on Adam, and nothing else in the suite would notice.
+    // Solomon's equivalent wiring at solomon-advisory.cjs:1012 is likewise unpinned — stated rather
+    // than assumed covered.
+    const src = fs.readFileSync(SRC, 'utf8');
+    const call = /alreadyAnswered\(\s*supabase\s*,\s*replyTo\s*,\s*\{([^}]*)\}/.exec(src);
+    expect(call, 'Adam send path must call alreadyAnswered(supabase, replyTo, {...})').not.toBeNull();
+    expect(call[1]).toMatch(/partIndex\s*:/);
+    expect(call[1]).toMatch(/messageKind\s*:/);
   });
 });
 

--- a/tests/unit/coordinator/disposition-lock.test.js
+++ b/tests/unit/coordinator/disposition-lock.test.js
@@ -1,0 +1,186 @@
+/**
+ * SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 / FR-2 — the disposition lock.
+ *
+ * A correlation that already carries a terminal disposition must not accept another answer. PLAN's
+ * review found this FR, as first written, was a SAFETY REGRESSION that no test in the repo would have
+ * caught, so the exemptions below are not edge cases — each one prevents a specific documented
+ * incident, and the tests asserting them are the point of the file.
+ *
+ * TWO describe blocks are REQUIRED and the second is the one that matters: testing the exported
+ * assert alone proves the guard CAN refuse, never that the choke CALLS it. That is the
+ * capability-not-use trap, and this suite would pass with the guard defined and never wired.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { assertCorrelationNotDisposed, insertCoordinationRow } = require('../../../lib/coordinator/dispatch.cjs');
+const { CORRECTION_KINDS, MESSAGE_KINDS, DISPOSITION_KIND } = require('../../../lib/coordinator/message-kinds.cjs');
+
+const LIVE_TARGET = '0f8d45d8-9531-4ab8-a1b9-6961c405e1ec';
+const CORR = 'corr-disposed-1';
+const silentLog = { warn() {}, error() {}, log() {} };
+
+/**
+ * Stub supabase. `disposed` seeds the disposition lookup; `filters` records the query shape so we can
+ * assert the guard reads payload->>, not the bare column — a column-keyed lookup would find nothing
+ * and the guard would be inert while reading as enforced.
+ */
+function stubSupabase({ disposed = [], throwOnLookup = false, liveSessions = [LIVE_TARGET] } = {}) {
+  const inserted = [];
+  const filters = [];
+  const sb = {
+    from(table) {
+      const chain = {
+        _table: table, _eq: null, _isSelect: false,
+        select() { chain._isSelect = true; return chain; },
+        eq(col, val) { filters.push({ table, col, val }); chain._eq = val; return chain; },
+        is() { return chain; },
+        in() { return chain; },
+        order() { return chain; },
+        // limit() must stay CHAINABLE, not resolve: insertCoordinationRow's other guards call
+        // .limit(...).maybeSingle(). The guard under test awaits the chain directly, which the
+        // `then` below serves.
+        limit() { return chain; },
+        maybeSingle() {
+          if (table === 'claude_sessions') {
+            return Promise.resolve({ data: liveSessions.includes(chain._eq) ? { session_id: chain._eq, status: 'active' } : null, error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+        single() { return Promise.resolve({ data: inserted[inserted.length - 1] || null, error: null }); },
+        insert(r) { inserted.push(r); chain._isSelect = false; return chain; },
+        then(res, rej) {
+          if (table === 'session_coordination' && chain._isSelect) {
+            const out = throwOnLookup
+              ? { data: null, error: { message: 'transient boom' } }
+              : { data: disposed, error: null };
+            return Promise.resolve(out).then(res, rej);
+          }
+          return Promise.resolve({ data: inserted[inserted.length - 1] || null, error: null }).then(res, rej);
+        },
+      };
+      return chain;
+    },
+  };
+  return { sb, inserted, filters };
+}
+
+const disposedRow = [{ id: 'row-disposition-1' }];
+const answer = (extra = {}) => ({
+  target_session: LIVE_TARGET,
+  message_type: 'INFO',
+  payload: { kind: 'adam_advisory', correlation_id: CORR, body: 'another answer', ...extra },
+});
+
+describe('FR-2: assertCorrelationNotDisposed refuses a second answer', () => {
+  it('throws DISPATCH_CORRELATION_DISPOSED when the correlation is already disposed', async () => {
+    const { sb } = stubSupabase({ disposed: disposedRow });
+    await expect(assertCorrelationNotDisposed(sb, answer(), silentLog)).rejects.toThrow(/DISPATCH_CORRELATION_DISPOSED/);
+  });
+
+  it('allows the answer when no disposition exists', async () => {
+    const { sb } = stubSupabase({ disposed: [] });
+    await expect(assertCorrelationNotDisposed(sb, answer(), silentLog)).resolves.toBeUndefined();
+  });
+
+  it('ignores a row with no correlation at all', async () => {
+    const { sb } = stubSupabase({ disposed: disposedRow });
+    await expect(assertCorrelationNotDisposed(sb, { payload: { kind: 'x' } }, silentLog)).resolves.toBeUndefined();
+  });
+
+  it('reads payload->>correlation_id, NOT the bare column', async () => {
+    // The column is populated on 6.5% of rows and written by nothing in the repo. A column-keyed
+    // lookup would match nothing, so the guard would never fire while every "it refuses" test above
+    // still passed — the lock would be decorative. Pin the query shape.
+    const { sb, filters } = stubSupabase({ disposed: [] });
+    await assertCorrelationNotDisposed(sb, answer(), silentLog);
+    const cols = filters.filter((f) => f.table === 'session_coordination').map((f) => f.col);
+    expect(cols).toContain('payload->>correlation_id');
+    expect(cols).toContain('payload->>message_kind');
+    expect(cols).not.toContain('correlation_id');
+  });
+});
+
+describe('FR-2: the three exemptions, each guarding a documented incident', () => {
+  it('EXEMPTS the originator-CC leg — QF-20260705-488', async () => {
+    // ensureOriginatorCc re-enters the same choke with the same correlation AFTER the primary insert.
+    // Refuse it and its own catch swallows the throw while main() still prints success and exits 0:
+    // a disposition that reports delivered while the originator never receives it. That incident
+    // ended with the chairman hand-relaying a verdict.
+    const { sb } = stubSupabase({ disposed: disposedRow });
+    await expect(assertCorrelationNotDisposed(sb, answer({ via: 'cc_originator' }), silentLog)).resolves.toBeUndefined();
+  });
+
+  it('EXEMPTS every correction kind — a wrong disposition must stay retractable', async () => {
+    const { sb } = stubSupabase({ disposed: disposedRow });
+    for (const kind of CORRECTION_KINDS) {
+      await expect(assertCorrelationNotDisposed(sb, answer({ message_kind: kind }), silentLog)).resolves.toBeUndefined();
+    }
+  });
+
+  it('EXEMPTS in-flight parts — FR-1 and FR-2 contradict, and FR-1 yields first', async () => {
+    // FR-1 makes ordered parts share ONE correlation. Without this the lock refuses part 2 onward and
+    // cancels FR-1 outright.
+    const { sb } = stubSupabase({ disposed: disposedRow });
+    await expect(assertCorrelationNotDisposed(sb, answer({ part_index: 2, part_total: 3 }), silentLog)).resolves.toBeUndefined();
+  });
+
+  it('does NOT exempt a lone part_index with no total — that is not a series', async () => {
+    const { sb } = stubSupabase({ disposed: disposedRow });
+    await expect(assertCorrelationNotDisposed(sb, answer({ part_index: 2 }), silentLog)).rejects.toThrow(/DISPATCH_CORRELATION_DISPOSED/);
+  });
+
+  it('does NOT exempt a disposition from its own lock', async () => {
+    // THE SELF-EXEMPTION TRAP. CORRECTION_KINDS and MESSAGE_KINDS were the SAME list until this FR
+    // added 'disposition' to the latter. Keying the exemption on MESSAGE_KINDS instead — a natural
+    // looking simplification — makes 'disposition' exempt itself, so the lock never fires on the one
+    // thing it exists to lock, and every exemption test above still passes. Silent and total.
+    expect(MESSAGE_KINDS).toContain(DISPOSITION_KIND);
+    expect(CORRECTION_KINDS).not.toContain(DISPOSITION_KIND);
+    const { sb } = stubSupabase({ disposed: disposedRow });
+    await expect(assertCorrelationNotDisposed(sb, answer({ message_kind: DISPOSITION_KIND }), silentLog))
+      .rejects.toThrow(/DISPATCH_CORRELATION_DISPOSED/);
+  });
+});
+
+describe('FR-2: fail posture — closed on a real match, open on the guard\'s own error', () => {
+  it('fails OPEN when the lookup itself errors — a guard bug must never block a send', async () => {
+    const { sb } = stubSupabase({ throwOnLookup: true });
+    await expect(assertCorrelationNotDisposed(sb, answer(), silentLog)).resolves.toBeUndefined();
+  });
+
+  it('fails OPEN when supabase throws outright', async () => {
+    const exploding = { from() { throw new Error('client exploded'); } };
+    await expect(assertCorrelationNotDisposed(exploding, answer(), silentLog)).resolves.toBeUndefined();
+  });
+
+  it('fails CLOSED on a confirmed match — the refusal is not swallowed by its own catch', async () => {
+    // The catch that implements fail-open must re-throw the guard's own verdict, or the lock is inert.
+    const { sb } = stubSupabase({ disposed: disposedRow });
+    await expect(assertCorrelationNotDisposed(sb, answer(), silentLog)).rejects.toThrow(/DISPATCH_CORRELATION_DISPOSED/);
+  });
+});
+
+describe('FR-2: the CHOKE calls the guard (not merely that the guard exists)', () => {
+  it('insertCoordinationRow REFUSES an answer on a disposed correlation', async () => {
+    // Block 1 proves the guard can refuse. Only this proves it is wired: delete the call at the
+    // choke and every test above still passes.
+    const { sb, inserted } = stubSupabase({ disposed: disposedRow });
+    await expect(insertCoordinationRow(sb, answer(), { logger: silentLog })).rejects.toThrow(/DISPATCH_CORRELATION_DISPOSED/);
+    expect(inserted).toHaveLength(0); // refused BEFORE the write, not after
+  });
+
+  it('insertCoordinationRow still lands the originator-CC leg on a disposed correlation', async () => {
+    // The regression test for QF-20260705-488, driven through the real choke rather than the assert.
+    const { sb, inserted } = stubSupabase({ disposed: disposedRow });
+    await insertCoordinationRow(sb, answer({ via: 'cc_originator' }), { logger: silentLog });
+    expect(inserted).toHaveLength(1);
+    expect(inserted[0].payload.via).toBe('cc_originator');
+  });
+
+  it('insertCoordinationRow inserts normally when nothing is disposed', async () => {
+    const { sb, inserted } = stubSupabase({ disposed: [] });
+    await insertCoordinationRow(sb, answer(), { logger: silentLog });
+    expect(inserted).toHaveLength(1);
+  });
+});

--- a/tests/unit/coordinator/disposition-lock.test.js
+++ b/tests/unit/coordinator/disposition-lock.test.js
@@ -15,6 +15,7 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const { assertCorrelationNotDisposed, insertCoordinationRow } = require('../../../lib/coordinator/dispatch.cjs');
 const { CORRECTION_KINDS, MESSAGE_KINDS, DISPOSITION_KIND } = require('../../../lib/coordinator/message-kinds.cjs');
+const { MAX_PARTS } = require('../../../lib/coordinator/multi-part-reply.cjs');
 
 const LIVE_TARGET = '0f8d45d8-9531-4ab8-a1b9-6961c405e1ec';
 const CORR = 'corr-disposed-1';
@@ -128,6 +129,28 @@ describe('FR-2: the three exemptions, each guarding a documented incident', () =
   it('does NOT exempt a lone part_index with no total — that is not a series', async () => {
     const { sb } = stubSupabase({ disposed: disposedRow });
     await expect(assertCorrelationNotDisposed(sb, answer({ part_index: 2 }), silentLog)).rejects.toThrow(/DISPATCH_CORRELATION_DISPOSED/);
+  });
+
+  it('BOUNDS the part exemption by MAX_PARTS — it is not a free bypass', async () => {
+    // SECURITY sub-agent finding (evidence aa192915). The first version exempted any row with
+    // part_index and part_total > 1, so a sender could bypass the lock forever on any correlation by
+    // stamping every message --part 1/2, never using a correction path. MAX_PARTS was enforced at the
+    // CLI and in buildAdvisoryPayload but NOT at this choke — and this guard is the control. A bound
+    // checked only at the outermost layer is not a bound.
+    const { sb } = stubSupabase({ disposed: disposedRow });
+    // At the ceiling: still a legitimate series, still exempt.
+    await expect(assertCorrelationNotDisposed(sb, answer({ part_index: 1, part_total: MAX_PARTS }), silentLog)).resolves.toBeUndefined();
+    // Past it, or malformed: NOT exempt. Falls through to the lock rather than past it — the failure
+    // direction is refuse, not admit.
+    for (const bad of [
+      { part_index: 1, part_total: MAX_PARTS + 1 },
+      { part_index: 3, part_total: 2 },
+      { part_index: 0, part_total: 5 },
+      { part_index: 1.5, part_total: 5 },
+      { part_index: 1, part_total: 'many' },
+    ]) {
+      await expect(assertCorrelationNotDisposed(sb, answer(bad), silentLog)).rejects.toThrow(/DISPATCH_CORRELATION_DISPOSED/);
+    }
   });
 
   it('does NOT exempt a disposition from its own lock', async () => {

--- a/tests/unit/helpers/parsed-flags.js
+++ b/tests/unit/helpers/parsed-flags.js
@@ -1,0 +1,26 @@
+/**
+ * SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 / FR-1 — shared drift-guard support.
+ *
+ * Enumerates the CLI flags a sender ACTUALLY parses, by reading its source. Both advisory senders
+ * are guarded, so this lives in one place: two copies of the enumeration could disagree about what
+ * counts as a parsed flag, which is the same drift this SD exists to close, one layer up.
+ */
+import fs from 'node:fs';
+
+/**
+ * @param {string} srcPath absolute path to a sender's .cjs source
+ * @returns {Set<string>} every flag passed to argv.indexOf() in executable code
+ */
+export function parsedFlags(srcPath) {
+  // Whole-line comments are dropped first: the guard's first run failed on '--x', a placeholder
+  // inside a doc comment. ONLY whole-line comments are stripped — never trailing ones — because that
+  // is the fail-LOUD direction. A trailing comment can at worst re-introduce a false positive (noisy,
+  // obvious, one-line fix); a broader stripper could swallow a real parse line and leave the guard
+  // silently blind, which is the failure mode these tests exist to prevent.
+  const code = fs
+    .readFileSync(srcPath, 'utf8')
+    .split(/\r?\n/)
+    .filter((l) => !/^\s*(\/\/|\/?\*)/.test(l))
+    .join('\n');
+  return new Set([...code.matchAll(/argv\.indexOf\('(--[a-z-]+)'\)/g)].map((m) => m[1]));
+}

--- a/tests/unit/solomon-advisory-argv-body.test.js
+++ b/tests/unit/solomon-advisory-argv-body.test.js
@@ -1,0 +1,99 @@
+/**
+ * SD-LEO-INFRA-CONSULT-CORRELATION-CONVENTIONS-001 / FR-1 / TS-1 — the ARGV path.
+ *
+ * WHY THIS FILE EXISTS. --part and --message-kind were parsed but never excluded from the message
+ * body, so `send --part 2/3 --message-kind amend "real body"` shipped
+ *   body === "--part 2/3 --message-kind amend real body"
+ * on the LIVE Solomon path. Zero tests caught it, because every existing part/message-kind assertion
+ * calls buildAdvisoryPayload with NAMED ARGS and never crosses argv — the flags were verified in the
+ * shape they are CONSUMED, never in the shape a human types them.
+ *
+ * TESTING flagged at PLAN that mirroring that index list onto Adam would propagate the leak to a
+ * second sender. So the hand-maintained index list is gone: exclusions are derived from the flag
+ * NAMES, and these tests pin the argv surface that had no coverage at all.
+ */
+import { describe, it, expect } from 'vitest';
+import { parsedFlags } from './helpers/parsed-flags.js';
+import { fileURLToPath } from 'node:url';
+// CJS interop: module.exports arrives as the default export.
+import solomonAdvisory from '../../scripts/solomon-advisory.cjs';
+
+const { sendBodyFromArgv, VALUE_FLAGS, BOOL_FLAGS, STATUS_VALUE_FLAGS } = solomonAdvisory;
+// ESM has no __dirname — resolving from import.meta.url instead. (Referencing __dirname here would
+// throw at collection time, which is the same ESM trap that bit the FR-3 wiring on a prior SD.)
+const SRC = fileURLToPath(new URL('../../scripts/solomon-advisory.cjs', import.meta.url));
+
+describe('FR-1: flag values never leak into the message body', () => {
+  it('strips --part and --message-kind — the exact live defect', () => {
+    // The regression case, verbatim. Before the fix this returned the whole string.
+    expect(sendBodyFromArgv(['send', '--part', '2/3', '--message-kind', 'amend', 'real', 'body', 'here']))
+      .toBe('real body here');
+  });
+
+  it('strips every value flag the sender actually parses', () => {
+    for (const flag of VALUE_FLAGS) {
+      expect(sendBodyFromArgv(['send', flag, 'VALUE', 'the', 'body'])).toBe('the body');
+    }
+  });
+
+  it('strips a boolean flag without eating the word after it', () => {
+    // --direct takes no value; consuming the next token would silently truncate the message.
+    expect(sendBodyFromArgv(['send', '--direct', 'the', 'body'])).toBe('the body');
+  });
+
+  it('strips a flag token wherever it sits — exclusion is SYMMETRIC with the parse', () => {
+    // I first wrote this expecting 'use when splitting' — that a bare word matching a flag name
+    // mid-body should survive. That expectation was wrong, and asserting it would have RE-OPENED the
+    // defect. The parse is positional-agnostic: `argv.indexOf('--part')` (:882) matches wherever the
+    // token appears, so the parse consumes it no matter where it sits. The body MUST exclude exactly
+    // what the parse consumes; any divergence is the leak in one direction or a truncated body in the
+    // other. Symmetry is the invariant, not "leave mid-body words alone".
+    expect(sendBodyFromArgv(['send', 'use', '--part', 'when', 'splitting'])).toBe('use splitting');
+    // Not silent, either: a value-shaped flag with a non-conforming value exits 2 at :888 before any
+    // body is built, so this argv never ships a short body in production — it fails loudly instead.
+  });
+
+  it('leaves flag-like text that is not its own argv token intact', () => {
+    // The genuine no-substring-matching case: only whole argv tokens are stripped.
+    expect(sendBodyFromArgv(['send', 'pass', '--part-less', 'bodies', 'through'])).toBe('pass --part-less bodies through');
+  });
+
+  it('handles flags in any order and interleaved with body words', () => {
+    expect(sendBodyFromArgv(['send', 'lead', '--to', 'adam', 'middle', '--part', '1/2', 'tail']))
+      .toBe('lead middle tail');
+  });
+});
+
+describe('FR-1: the exclusion list cannot silently drift from the parse', () => {
+  it('every flag parsed in the file appears in VALUE_FLAGS or BOOL_FLAGS', () => {
+    // THE DRIFT GUARD. The original defect was a flag added to the parse and forgotten in the
+    // exclusion list. My own first draft of VALUE_FLAGS guessed '--ref' and '--reply-window'
+    // (neither exists) and omitted --framing-class and --timeout — re-creating the same leak for
+    // different flags. This makes that omission fail loudly instead of shipping quietly.
+    // The UNION across every path's list — the send path and the status path each carry their own,
+    // deliberately, so that neither strips the other's flags out of a body. Coverage is still
+    // all-or-nothing: a parsed flag absent from every list is the leak, whichever path added it.
+    const covered = new Set([...VALUE_FLAGS, ...BOOL_FLAGS, ...STATUS_VALUE_FLAGS]);
+    // --working is printStatus's own sub-command marker (the body FOLLOWS it there), not a send-path
+    // flag, so it is deliberately out of scope for the send body.
+    const uncovered = [...parsedFlags(SRC)].filter((f) => !covered.has(f) && f !== '--working');
+    expect(uncovered).toEqual([]);
+  });
+
+  it('VALUE_FLAGS contains no flag the file does not actually parse', () => {
+    // The other direction: a stale entry would strip a token that is really body text.
+    const parsed = parsedFlags(SRC);
+    expect(VALUE_FLAGS.filter((f) => !parsed.has(f))).toEqual([]);
+  });
+
+  it('the guard can actually SEE the parse — negative control', () => {
+    // Without this, both assertions above pass just as happily against an empty set: a regex that
+    // silently stopped matching (renamed helper, reformatted call, over-eager comment stripper)
+    // would read as "no drift" forever. Pin that the enumeration is non-empty and contains the two
+    // flags whose omission was the live defect.
+    const parsed = parsedFlags(SRC);
+    expect(parsed.size).toBeGreaterThan(5);
+    expect(parsed.has('--part')).toBe(true);
+    expect(parsed.has('--message-kind')).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Makes one correlation convention expressible across both advisory senders, and closes a live body-leak defect found while doing it.

**FR-1 — Adam gains `--part N/M`.** Adam had no `--part` flag and its `buildAdvisoryPayload` omitted `part_index`/`part_total`, so there was nothing for a convention to converge on. While building it I found a live defect: `solomon-advisory` built message bodies by excluding a hand-maintained list of argv *indexes*, and that list had drifted from the parse by **three** flags — `--framing-class`, `--message-kind` and `--part` each shipped their own flag token and value inside the message body. Proven by executing the original logic, with `--kind` as a negative control that came through clean.

Fixed at the class level rather than patched: both senders derive exclusions from flag *names* via one shared helper, so a flag that is parsed is a flag that is stripped. Copying the index-list idiom into Adam would have propagated the defect to a second sender. `MAX_PARTS` moved to `multi-part-reply.cjs` for the same reason.

**FR-2 — disposition lock** at the shared insert choke, so both senders inherit it. Three exemptions, each pinned to the incident it prevents: the originator-CC leg (QF-20260705-488, where a swallowed refusal reported success while the recipient got nothing), correction kinds (a wrong disposition must stay retractable), and bounded in-flight parts. Fail-CLOSED on a real match, fail-OPEN on the guard's own error.

**FR-3 — no code change**, which was the preferred outcome. Verified the single-fire gate is load-bearing, and closed the residual gap: the server-side filter at `reply-class.cjs:213` was unpinned and is *not* redundant — the sweep is `limit(200)` with no `order()`, so without it already-pinged rows can consume the budget and starve genuinely overdue ones, silently.

## Verified by mutation, not by green

A green suite is why the original defect survived, so every guard here was checked by breaking it:

| Mutation | Result |
|---|---|
| Revert the argv exclusion fix | 4 red, including the drift guard |
| Remove Adam's part stamping | 4 red |
| Repoint reader at column, not payload | exactly 1 red — the divergent-value fixture |
| Delete the guard call at the choke | **12 assert-level tests stay green**, only the wiring test fails |
| Re-key exemption onto `MESSAGE_KINDS` | 1 red (self-exemption trap) |
| Drop the `cc_originator` exemption | 2 red |
| Restore the unbounded part exemption | 1 red |
| Remove the `:213` filter | 1 red — the new query-shape pin |

The choke mutation is the notable one: it demonstrates the capability-not-use trap concretely rather than arguing it.

## Sub-agent review

TESTING (`f8a6bbdc`) PASS — independently reproduced all three mutation claims and caught a test of mine whose name promised a row-vs-column distinction its body never checked. Rewritten.

SECURITY (`aa192915`) CONCERNS — caught that the part exemption was a free bypass: any sender could evade the lock forever by stamping `--part 1/2`, because `MAX_PARTS` was enforced at the CLI but not at the choke. Fixed; the bound is now re-validated at the choke and malformed pairs fall through *to* the lock, not past it.

## Test plan

- 137 passed across the 9 related files
- Full unit project: 12 pre-existing failures, confirmed pre-existing against `origin/main` in a disposable worktree; none import these modules

## Known follow-ups (not in this PR)

- No index on `payload->>correlation_id` / `payload->>message_kind`; the guard adds a scan to the hottest write path. DDL is chairman-gated, so it is routed to the coordinator rather than applied here.
- FR-1 criterion 2 (Adam consulting dedup) deliberately not built — it means adding a blocking refusal to a path that never refuses, and the question is with the coordinator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)