### PR TITLE
fix(SD-LEO-INFRA-COMPLETION-EVIDENCE-RUNTIME-001): act on SECURITY findings — disable a repair that wrote false inheritance

### DIFF
--- a/scripts/audit/escalated-qf-orphans.mjs
+++ b/scripts/audit/escalated-qf-orphans.mjs
@@ -155,21 +155,38 @@ async function main() {
   }
 
   if (repair) {
-    // Only LINK_DROPPED is repaired. NEVER_CREATED is deliberately untouched: inventing a link
-    // would convert "nobody picked this up" into "handled", which is the exact false-completion
-    // shape this SD exists to stop.
-    let repaired = 0;
-    for (const f of dropped) {
-      const target = f.referencing_sds[0].sd_key;
-      const { error: uErr } = await supabase
-        .from('quick_fixes')
-        .update({ escalated_to_sd_id: target })
-        .eq('id', f.id)
-        .is('escalated_to_sd_id', null); // guarded: never clobber a link written since the read
-      if (uErr) console.error(`  repair FAILED ${f.id}: ${uErr.message}`);
-      else { repaired++; console.log(`  linked ${f.id} -> ${target}`); }
-    }
-    console.log(`\n  repaired ${repaired} of ${dropped.length} link-dropped orphans; ${never.length} never-created left for materialisation.`);
+    // ── DISABLED. The SECURITY sub-agent found this write to be WRONG, not merely risky. ────────
+    //
+    // It was never run in production. It is disabled rather than deleted so the reasoning survives
+    // next to the code, and re-enabling requires answering the three defects below.
+    //
+    // S1 (HIGH) — IT WROTE A FALSE INHERITANCE. classifyOrphan treats "an SD is referenced" as
+    // "an SD inherits this work", but sdKeysNamedInQf() evidences only that a QF MENTIONS an SD.
+    // Simulated read-only over the real 18 orphans: 12 resolvable pairs, ALL targeting SDs with
+    // status='completed', of which exactly ONE would have landed —
+    // QF-20260722-214 -> SD-LEARN-FIX-ADDRESS-SAL-SECURITY-001 — and it is BACKWARDS: that QF was
+    // auto-promoted FROM that SD's retrospective, six hours AFTER it, and its work is to re-run
+    // that SD's blocking sub-agents. So the single successful "repair" would have converted
+    // "nobody picked this up" into "handled" — verbatim what the comment below promises to avoid.
+    // A report written to detect false completion contained a repair that manufactured it.
+    //
+    // S2 (HIGH) — WRONG KEY SPACE. escalated_to_sd_id is TEXT with an FK to
+    // strategic_directives_v2(id); all 41 existing values are UUID-shaped. This wrote .sd_key,
+    // which succeeds ONLY on legacy rows where id == sd_key, depositing a second dialect beside
+    // the UUIDs. The FK rejected 11 of 12 — correctness by accident. Worse, failures only printed:
+    // the exit code keyed off criticalNever alone, so 11 failed writes still exited 0.
+    //
+    // Also unresolved: 4 QFs resolve MORE THAN ONE candidate SD, and [0] picked from an unordered
+    // .limit(5) query is arbitrary.
+    //
+    // TO RE-ENABLE, all three must hold: write .id not .sd_key; take the target from a real
+    // inheritance signal rather than a text mention; refuse when the target is completed/cancelled
+    // or when >1 candidate resolves. Failures must also reach the exit code.
+    console.error('\n  --repair-links is DISABLED (see the comment in this file).');
+    console.error('  It wrote a MENTION as if it were an INHERITANCE, and wrote sd_key into a column whose FK targets id.');
+    console.error('  Simulated over the live data: 1 write would land and it is backwards; 11 of 12 would fail while still exiting 0.');
+    console.error(`  ${dropped.length} link-dropped and ${never.length} never-created orphans remain, unmodified and still listed above.`);
+    process.exit(3);
   }
 
   // Exit non-zero when a CRITICAL orphan is unreferenced — a report nobody notices is the failure

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -8,7 +8,11 @@
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
 import path from 'path';
+import { createRequire } from 'module';
 import { fileURLToPath, pathToFileURL } from 'url';
+// Reuse the SAME redaction the coordination channel already applies, rather than rolling a second
+// set of patterns that would drift from it (lib/shared/body-cap.cjs is CJS, hence createRequire).
+const { redact, capBodySafe, BODY_HARD_CAP } = createRequire(import.meta.url)('../../../lib/shared/body-cap.cjs');
 import { restartLeoStack } from '../../../lib/server-manager.js';
 import { runSelfVerification } from '../../../lib/quickfix-self-verifier.js';
 import {
@@ -177,7 +181,21 @@ export function buildRuntimeObservation({ existing = null, observation = null, m
   // Real evidence already on the row wins over anything this close would write.
   if (existing && typeof existing === 'object' && Object.keys(existing).length > 0) return existing;
 
-  const text = typeof observation === 'string' ? observation.trim() : '';
+  // SECURITY S3 — REDACT AND CAP. This field is the WORSE one to leave raw, not the safer one: its
+  // own column comment and method vocabulary (http_probe, log_grep) actively invite pasting request
+  // /response and log text, which is exactly where bearer tokens and signed URLs live. The one real
+  // observation in the column is literal HTTP probe output. worker-signal.cjs already routes its
+  // bodies through the same helper; leaving this path raw was an ASYMMETRY, not a considered choice.
+  // capBody() redacts internally and THROWS over the cap; capBodySafe() adapts that to a
+  // {value, error} tuple. Neither TRUNCATES — and dropping an over-long observation would leave
+  // this function recording declared:false, manufacturing the exact false absence FR-1 exists to
+  // stop. So an over-cap observation is truncated and SAID SO in the stored text, rather than
+  // silently becoming an absence.
+  const raw = typeof observation === 'string' ? observation.trim() : '';
+  const capped = raw ? capBodySafe(raw) : { value: '', error: null };
+  const text = capped.error
+    ? `${redact(raw).slice(0, BODY_HARD_CAP - 60)} … [TRUNCATED at ${BODY_HARD_CAP} chars]`
+    : (capped.value || '');
   if (!text) {
     return {
       declared: false,

--- a/tests/unit/complete-quick-fix/merged-reconcile-verification.test.js
+++ b/tests/unit/complete-quick-fix/merged-reconcile-verification.test.js
@@ -425,3 +425,35 @@ describe('reconcile path carries FR-1 through from parsed argv (regression)', ()
     expect(u.runtime_observation.observation).toBe('explicit');
   });
 });
+
+// SECURITY S3 — the observation is redacted and capped before it is stored.
+describe('buildRuntimeObservation redacts secrets (SECURITY S3)', () => {
+  const nowIso = '2026-07-28T13:00:00.000Z';
+
+  it('does not store a bearer token pasted from probe output verbatim', () => {
+    const o = buildRuntimeObservation({
+      observation: 'curl -H "Authorization: Bearer sk-live-ABCDEF1234567890abcdef" https://api/x -> 200',
+      nowIso
+    });
+    expect(o.observation).not.toContain('sk-live-ABCDEF1234567890abcdef');
+  });
+
+  it('still records the observation — redaction must not empty it into a false absence', () => {
+    // The failure mode to avoid: redaction so aggressive the text becomes blank and the row then
+    // records declared:false, which would manufacture the very false absence FR-1 exists to stop.
+    const o = buildRuntimeObservation({ observation: 'GET /fleet-ui/session-view.html -> 410', nowIso });
+    expect(o.observation).toBe('GET /fleet-ui/session-view.html -> 410');
+    expect(o.declared).toBeUndefined();
+  });
+});
+
+describe('buildRuntimeObservation over-cap handling (SECURITY S3)', () => {
+  it('truncates and SAYS SO rather than silently becoming an absence', () => {
+    // The trap: capBody THROWS over the cap. Swallowing that would leave text empty, and the
+    // function would then record declared:false — manufacturing the exact false absence FR-1
+    // exists to stop. An over-long observation must stay an observation.
+    const o = buildRuntimeObservation({ observation: 'x'.repeat(9000), nowIso: '2026-07-28T13:00:00.000Z' });
+    expect(o.declared).toBeUndefined();
+    expect(o.observation).toMatch(/TRUNCATED at \d+ chars/);
+  });
+});


### PR DESCRIPTION
Acts on the SECURITY sub-agent review of this SD’s EXEC deliverables. Two HIGH findings, both in `--repair-links` — a path I had deliberately never run. That caution was right, but for a weaker reason than the real one: I withheld it as *a belt-visible write needing authorisation*. **The logic was wrong.**

## S1 · HIGH — it wrote a false inheritance

`sdKeysNamedInQf()` evidences that a QF **mentions** an SD, not that the SD **inherits** its work. `classifyOrphan` treated the two as the same thing.

Simulated read-only over the real 18 orphans: 12 resolvable pairs, **all** targeting SDs with `status=completed`, of which exactly **one** write would land — `QF-20260722-214 → SD-LEARN-FIX-ADDRESS-SAL-SECURITY-001` — **and it is backwards.** That QF was auto-promoted *from* that SD’s retrospective, six hours *after* it, and its work is to re-run that SD’s blocking sub-agents.

So the single successful "repair" would have converted *"nobody picked this up"* into *"handled"* — verbatim what the comment three lines above it promises to avoid. A report written to **detect** false completion contained a repair that **manufactured** it.

## S2 · HIGH — wrong key space, failing silently

`escalated_to_sd_id` is TEXT with an FK to `strategic_directives_v2(id)`; all 41 existing values are UUID-shaped. It wrote `.sd_key`, which succeeds only on legacy rows where `id == sd_key`. The FK rejected **11 of 12** — correctness by accident — and failures only printed, because the exit code keyed off `criticalNever` alone. 11 failed writes still exited 0.

Also unresolved: 4 QFs resolve **more than one** candidate, and `[0]` from an unordered `.limit(5)` is arbitrary.

## Disabled, not patched

Re-enabling requires answering all three defects: write `.id`; take the target from a real inheritance signal rather than a text mention; refuse completed/cancelled targets and multi-candidate cases. It now exits 3, prints why, and leaves every orphan **listed and unmodified**. The reasoning lives next to the code so the next person inherits the analysis, not just a disabled flag.

## S3 · MEDIUM — redaction asymmetry

`worker-signal.cjs` routes bodies through `lib/shared/body-cap.cjs`; this path stored operator text raw. It is the **worse** field to leave raw, not the safer one — its own method vocabulary (`http_probe`, `log_grep`) invites pasting request/response and log text, which is where bearer tokens and signed URLs live. The one real observation in the column is literal HTTP probe output. Now routed through the **same** helper rather than a second pattern set that would drift from it.

Over-cap is **truncated and labelled, never dropped**: `capBody` throws, and swallowing that would leave the text empty and record `declared: false` — manufacturing the exact false absence FR-1 exists to stop. Pinned.

## Not changed, and why

- **S4** RLS is enabled and the new column inherits cleanly (grants are table-level; `pg_attribute.attacl` empty on all 43 columns, so no policy became incomplete). The `anon` SELECT `USING(true)` is pre-existing and out of scope here.
- **S6** Nothing renders `runtime_observation` today, so stored-XSS is **latent, not live** — worth knowing before a dashboard ships, since it would inherit S3’s secrets and the rendering surface together.
- **S7** No secrets in shipped files; both writes are parameterised `supabase-js` `.update()`, no concatenated SQL, text never reaches `execSync`.

326 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)