### PR TITLE
QF-20260728-458: normalise the path before matching the retired /fleet-ui 410

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -44,7 +44,7 @@ import {
 import { loadState, dashboardState } from './state.js';
 // QF-20260725-096: retired-route matchers, kept in their own side-effect-free module so the scope
 // pins can import the real pattern without booting the server.
-import { RETIRED_SESSION_VIEW_RE } from './retired-routes.js';
+import { isRetiredSessionView } from './retired-routes.js';
 
 // Import WebSocket handler
 import { initializeWebSocket, broadcastUpdate } from './websocket.js';
@@ -210,7 +210,17 @@ app.use(express.json());
 // imported from here would open DB connections and bind a port just to check a regex. A test that
 // re-declares the pattern instead would prove only that its own copy behaves, which is exactly how
 // the circumventable first version passed review.
-app.all(RETIRED_SESSION_VIEW_RE, (req, res) => {
+// QF-20260728-458: MIDDLEWARE, NOT `app.all(<regex>)`. Express matches a route regex against the
+// RAW pathname, so a normalise-then-match design cannot be expressed as a route pattern at all —
+// the normalisation has to happen before the decision. That is the whole reason three spellings
+// kept getting served: the guard was matching a different string than the file server resolved.
+// Registered here, still ahead of the /fleet-ui static mount below, so the retirement wins.
+app.use((req, res, next) => {
+  if (!isRetiredSessionView(req.path)) return next();
+  return retiredSessionViewHandler(req, res);
+});
+
+function retiredSessionViewHandler(req, res) {
   // QF-20260727-484 — WITHOUT THIS LINE THE SOAK CANNOT PRODUCE EVIDENCE. The retirement above
   // is dispositioned by a seven-day soak in which SILENCE IS THE EVIDENCE, but this server has no
   // request logging of any kind (no morgan — it is not even a dependency), so a 410 hit wrote
@@ -236,7 +246,7 @@ app.all(RETIRED_SESSION_VIEW_RE, (req, res) => {
     'This capability is knowingly unavailable from the web surface. If you needed this page,\n' +
     'that is a signal worth raising — the retirement is reversible.\n'
   );
-});
+}
 
 // Fleet-launcher operator UI static assets (SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-B): the
 // Session View pane fragment, mountable into the parent shell. See the ARCH-007 exception

--- a/server/retired-routes.js
+++ b/server/retired-routes.js
@@ -10,27 +10,72 @@
  */
 
 /**
- * The standalone /fleet-ui session view, retired 2026-07-27 (chairman-ratified).
+ * NORMALISE, THEN MATCH — QF-20260728-458.
  *
- * TWO AXES, both learned the hard way — the first version of this matcher was circumventable and
- * shipped that way. It read `/^\/fleet-ui\/session-view\.[^/]*$/`:
+ * THE ROOT CAUSE, MEASURED RATHER THAN REASONED: the guard and the file server disagree about what
+ * the path IS. Express does NOT percent-decode the pathname before route matching, while
+ * express.static DOES decode before resolving on the filesystem. So `/fleet-ui/session%2Dview.html`
+ * reached the guard as the literal `session%2Dview.html` (no match) and reached the static mount as
+ * `session-view.html` (served, 200). Verified live against the running server: that path returned
+ * 200 while the exact-literal control returned 410.
  *
- *   CASE — express.static resolves through a case-INSENSITIVE filesystem on the host, so it served
- *   /fleet-ui/Session-View.html, /fleet-ui/SESSION-VIEW.HTML, /FLEET-UI/session-view.html and
- *   /Fleet-UI/session-view.html with a 200 while the case-SENSITIVE matcher never fired.
+ * WHY THIS IS A NORMALISER AND NOT A FOURTH LITERAL. This is the THIRD iteration of the same shape
+ * on this one guard. v1 was case-sensitive and single-slash; v2 (8bdb6eccd0b) added `i` and `\/+`
+ * for casing and repeated separators; percent-encoding survived it. A fourth spelling — mixed-case
+ * hex, backslash, double-encoding — would survive a fourth pass the same way. Enumeration does not
+ * terminate. Normalisation does: reduce the path ONCE to the form the filesystem will actually
+ * resolve, then match a single exact pattern against that.
  *
- *   SEPARATORS — anchoring on exactly one slash let /fleet-ui//session-view.html and
- *   /fleet-ui///session-view.html through untouched.
+ * SINGLE DECODE, DELIBERATELY, NOT A LOOP. The normaliser must model what express.static does, and
+ * static decodes exactly once. Decoding repeatedly would over-normalise: `%252Dview` is a request
+ * for a file literally named `%2Dview`, which static will NOT resolve to `-view`, so collapsing it
+ * would retire a path the file server never serves. Matching static's behaviour beats matching
+ * every conceivable spelling.
  *
- * All of the above were measured returning 200 against the running server. Hence `i` and `\/+`.
- *
- * STILL FILE-SCOPED, NOT ROUTE-SCOPED, which is the original and still-correct design: session-view.*,
- * fleet-panel.* and vision.* share the SAME /fleet-ui static mount, so anything looser than this
- * would retire live sibling pages too. `[^/]*` cannot cross a segment boundary, so a nested
- * /fleet-ui/sub/session-view.html is deliberately NOT matched, and the literal `\.` means an
- * extensionless /fleet-ui/session-view is not matched either.
+ * STILL FILE-SCOPED, NOT ROUTE-SCOPED — the original and still-correct design. session-view.*,
+ * fleet-panel.* and vision.* share the SAME /fleet-ui static mount, so anything looser retires live
+ * sibling pages. `[^/]*` cannot cross a segment boundary, so nested /fleet-ui/sub/session-view.html
+ * is deliberately NOT matched, and the literal `\.` means extensionless /fleet-ui/session-view is
+ * not matched either.
  *
  * NO `g` FLAG, deliberately: a global regex carries lastIndex between calls, so a per-request
  * matcher would alternate true/false and silently serve the retired page every other hit.
  */
-export const RETIRED_SESSION_VIEW_RE = /^\/+fleet-ui\/+session-view\.[^/]*$/i;
+
+/**
+ * Reduce a request path to the form the static file server will actually resolve.
+ *
+ * Order matters: decode first (so an encoded separator becomes a real one and is then collapsed),
+ * then unify separators, then collapse, then case-fold.
+ *
+ * @param {string} rawPath a request pathname, e.g. req.path
+ * @returns {string} the normalised path
+ */
+export function normalizeRequestPath(rawPath) {
+  let p = String(rawPath ?? '');
+  try {
+    p = decodeURIComponent(p);
+  } catch {
+    // A malformed escape (`%ZZ`, a lone `%`) throws. Keep the raw form and carry on: a guard must
+    // never turn a weird URL into a 500. An undecodable path also cannot be decoded by static, so
+    // the raw form is exactly what static will see — the fallback is correct, not merely safe.
+  }
+  return p
+    .replace(/\\/g, '/')      // Windows resolves \ and / alike, so the guard must too
+    .replace(/\/{2,}/g, '/')  // collapse duplicate separators
+    .toLowerCase();           // the host filesystem is case-insensitive; the matcher must be too
+}
+
+/**
+ * The retired path, expressed ONCE against the normalised form. Exported so the scope pins can
+ * assert the pattern itself, but callers should prefer isRetiredSessionView().
+ */
+export const RETIRED_SESSION_VIEW_RE = /^\/fleet-ui\/session-view\.[^/]*$/;
+
+/**
+ * Is this request for the retired standalone session view?
+ * @param {string} rawPath a request pathname, e.g. req.path
+ */
+export function isRetiredSessionView(rawPath) {
+  return RETIRED_SESSION_VIEW_RE.test(normalizeRequestPath(rawPath));
+}

--- a/tests/unit/server/fleet-ui-410-scope.test.js
+++ b/tests/unit/server/fleet-ui-410-scope.test.js
@@ -1,80 +1,178 @@
 /**
- * QF-20260725-096 (bypass fix) — scope pins for the retired /fleet-ui session-view 410.
+ * QF-20260728-458 — the retired /fleet-ui session view must be blocked on EVERY spelling of the
+ * path, not on an enumerated list of them.
  *
- * WHY THIS FILE EXISTS. The first version of the matcher shipped with a hand-written "proof"
- * against nine paths, every one lowercase and single-slash, because the cases were invented from
- * the same mental model that wrote the pattern. The proof therefore inherited the pattern's blind
- * spot and the guard shipped circumventable: express.static resolves through a case-INSENSITIVE
- * filesystem on the host, so `/fleet-ui/Session-View.html` was served with a 200 while the
- * case-SENSITIVE matcher never fired. Four bypasses were live against the running server.
+ * WHY THIS FILE EXISTS, and why it has now been rewritten twice. The matcher has been circumvented
+ * three times, each by a spelling the previous fix did not enumerate:
+ *   v1  exact literal                     → defeated by filename case, directory case, repeated separators
+ *   v2  8bdb6eccd0b, added `i` and `\/+`  → defeated by percent-encoding
+ *   v3  this one                          → normalise the path once, then match once
  *
- * So these cases are NOT invented. Every entry under BYPASSES_MEASURED_LIVE was observed returning
- * 200 from the running server before the fix, and every entry under MUST_PASS_THROUGH was observed
- * returning 200 or 404 and must keep doing so.
+ * The original suite's cases were invented from the same mental model that wrote the pattern, so
+ * the proof inherited the pattern's blind spot. These cases are NOT invented — the axes below were
+ * MEASURED LIVE against the running server (localhost:3000, running pre-8bdb6eccd0b) before the fix:
+ *   /fleet-ui/session-view.html      410   control, the one axis that held
+ *   /FLEET-UI/session-view.html      200   STILL SERVED
+ *   /fleet-ui/SESSION-VIEW.HTML      200   STILL SERVED
+ *   /fleet-ui//session-view.html     200   STILL SERVED
+ *   /fleet-ui/session%2Dview.html    200   STILL SERVED
  *
- * The regex is IMPORTED, never re-declared. A test that copies the pattern proves only that its own
- * copy behaves — which is precisely how the original defect passed review. It is imported from
+ * ROOT CAUSE, measured rather than reasoned: Express does NOT percent-decode the pathname before
+ * route matching, but express.static DOES decode before resolving on disk. The guard and the file
+ * server were matching different strings. Normalising to the form static will actually resolve is
+ * what makes the axis list finite.
+ *
+ * WHY EACH AXIS IS ASSERTED SEPARATELY, never in aggregate: an aggregate ratio over a mixed list
+ * hides a wholly-failing axis behind passing ones. blocked/attempted must be 1 PER AXIS with a
+ * stated denominator. A suite asserting only "the lowercase path is blocked" is INVALID — that is
+ * exactly what passed while three other spellings served the page.
+ *
+ * The matcher is IMPORTED, never re-declared: a test that copies the pattern proves only that its
+ * own copy behaves, which is precisely how the original defect passed review. Imported from
  * server/retired-routes.js rather than server/index.js because the latter calls startServer() at
- * import time, so asserting a regex would otherwise open DB connections and bind a port.
+ * import time, so asserting a matcher would otherwise open DB connections and bind a port.
  */
 import { describe, it, expect } from 'vitest';
-import { RETIRED_SESSION_VIEW_RE as RE } from '../../../server/retired-routes.js';
+import {
+  isRetiredSessionView,
+  normalizeRequestPath,
+  RETIRED_SESSION_VIEW_RE as RE,
+} from '../../../server/retired-routes.js';
 
-// Observed 200 against the running server BEFORE the fix. Each is a distinct bypass axis.
-const BYPASSES_MEASURED_LIVE = [
-  ['/fleet-ui/Session-View.html', 'filename case'],
-  ['/fleet-ui/SESSION-VIEW.HTML', 'filename case, upper'],
-  ['/fleet-ui/Session-View.js', 'filename case, non-html extension'],
-  ['/FLEET-UI/session-view.html', 'mount-segment case'],
-  ['/Fleet-UI/session-view.html', 'mount-segment mixed case'],
-  ['/fleet-ui//session-view.html', 'duplicated separator'],
-  ['/fleet-ui///session-view.html', 'triplicated separator'],
+/**
+ * The bypass axes. Each is asserted on its OWN, so a regression reopening one axis cannot be
+ * masked by the other four passing.
+ */
+const AXES = [
+  ['lowercase', [
+    '/fleet-ui/session-view.html',
+    '/fleet-ui/session-view.js',
+    '/fleet-ui/session-view.css',
+  ]],
+  ['filename case', [
+    '/fleet-ui/Session-View.html',
+    '/fleet-ui/SESSION-VIEW.HTML',
+    '/fleet-ui/Session-View.js',
+  ]],
+  ['directory case', [
+    '/FLEET-UI/session-view.html',
+    '/Fleet-UI/session-view.html',
+  ]],
+  ['duplicate separator', [
+    '/fleet-ui//session-view.html',
+    '/fleet-ui///session-view.html',
+    '//fleet-ui/session-view.html',
+  ]],
+  ['percent-encoded', [
+    '/fleet-ui/session%2Dview.html',
+    '/fleet-ui/session%2dview.html',   // lowercase hex — a distinct spelling of the same byte
+  ]],
 ];
 
-// Already 410 before the fix — must not regress.
-const ALREADY_RETIRED = [
-  '/fleet-ui/session-view.html',
-  '/fleet-ui/session-view.js',
-  '/fleet-ui/session-view.css',
-  '/fleet-ui/session-view.HTML',
-  '/fleet-ui/session-view.test.js',
+/**
+ * FORWARD COVER: axes NOT known to fail today. The point of normalising rather than enumerating is
+ * that spellings nobody has tried yet are already closed. If any of these ever needs its own case
+ * added to the matcher, the normalise-then-match design has failed and a fourth enumeration pass
+ * has begun.
+ */
+const FORWARD_COVER = [
+  ['encoded separator', '/fleet-ui%2Fsession-view.html'],
+  ['encoded separator, lowercase hex', '/fleet-ui%2fsession-view.html'],
+  ['backslash separator', '\\fleet-ui\\session-view.html'],
+  ['mixed backslash and slash', '/fleet-ui\\session-view.html'],
+  ['mixed case and encoding together', '/FLEET-UI/SESSION%2DVIEW.HTML'],
+  ['encoded separator plus duplicate slash', '/fleet-ui%2F/session-view.html'],
 ];
 
-// Must keep reaching the static mount (or 404) — the retirement is file-scoped, not route-scoped.
-// fleet-panel and vision live under the SAME mount; matching them would take down live pages.
+/**
+ * MUST PASS THROUGH. The retirement is FILE-scoped, not ROUTE-scoped: session-view.*,
+ * fleet-panel.* and vision.* share the same /fleet-ui static mount, so an over-broad matcher takes
+ * live sibling pages down. Normalising makes over-matching EASIER to do by accident, so this half
+ * is pinned at least as hard as the bypasses.
+ */
 const MUST_PASS_THROUGH = [
   ['/fleet-ui/fleet-panel.html', 'sibling page, live'],
   ['/fleet-ui/vision.html', 'sibling page, live'],
   ['/fleet-ui/fleet-panel-format.js', 'sibling asset'],
+  ['/FLEET-UI/FLEET-PANEL.HTML', 'sibling page upper — case-folding must not widen the match'],
   ['/fleet-ui/sub/session-view.html', 'nested path — [^/] must not cross a segment'],
+  ['/fleet-ui//sub//session-view.html', 'nested with duplicated separators — still nested after collapse'],
   ['/fleet-ui/session-view', 'no extension — the dot is required'],
   ['/fleet-ui/session-viewXhtml', 'the dot is literal, not any-char'],
+  ['/fleet-ui/session-view-notes.html', 'longer filename sharing the prefix'],
   ['/api/fleet/sessions/abc/open', 'the live EHG route family, explicitly fenced'],
+  ['/fleet-ui/session%252Dview.html', 'DOUBLE-encoded — static decodes once, so this resolves a file literally named %2Dview and never reaches session-view'],
 ];
 
-describe('QF-20260725-096: retired session-view 410 scope', () => {
-  it.each(BYPASSES_MEASURED_LIVE)('closes the measured bypass %s (%s)', (path) => {
-    expect(RE.test(path)).toBe(true);
+describe('QF-20260728-458: every spelling of the retired path is blocked — per axis', () => {
+  it.each(AXES)('axis "%s": blocked/attempted === 1', (_axis, spellings) => {
+    const attempted = spellings.length;
+    const blocked = spellings.filter((p) => isRetiredSessionView(p)).length;
+    expect(attempted).toBeGreaterThan(0);   // a zero denominator would pass vacuously
+    expect(`${blocked}/${attempted}`).toBe(`${attempted}/${attempted}`);
   });
 
-  it.each(ALREADY_RETIRED)('keeps retiring %s', (path) => {
-    expect(RE.test(path)).toBe(true);
+  it('the historically-failing axes are covered as DISTINCT axes, not one blob', () => {
+    // Guards the SHAPE of this suite. Collapsing these into a single list would let a wholly-broken
+    // axis hide behind passing siblings — which is how this guard shipped circumventable twice.
+    const names = AXES.map(([n]) => n);
+    for (const axis of ['lowercase', 'filename case', 'directory case', 'duplicate separator', 'percent-encoded']) {
+      expect(names).toContain(axis);
+    }
   });
+});
 
+describe('QF-20260728-458: forward cover — spellings nobody has tried yet', () => {
+  it.each(FORWARD_COVER)('blocks %s', (_label, path) => {
+    expect(isRetiredSessionView(path)).toBe(true);
+  });
+});
+
+describe('QF-20260728-458: the retirement stays FILE-scoped', () => {
   it.each(MUST_PASS_THROUGH)('does NOT match %s (%s)', (path) => {
-    expect(RE.test(path)).toBe(false);
+    expect(isRetiredSessionView(path)).toBe(false);
+  });
+});
+
+describe('QF-20260728-458: the normaliser does the work, by construction', () => {
+  // These replace the previous source-text pins on RE.flags/RE.source, which asserted the regex
+  // carried `i` and `\/+` — properties this design deliberately REMOVES, because the normaliser now
+  // owns case and separators. Pinning behaviour instead of spelling keeps the same regressions
+  // caught without re-coupling the suite to one implementation.
+  it('case-folds', () => {
+    expect(normalizeRequestPath('/FLEET-UI/Session-View.HTML')).toBe('/fleet-ui/session-view.html');
   });
 
-  it('is case-insensitive and slash-tolerant by construction, not by accident', () => {
-    // Pin the two axes on the flags/source themselves, so a future edit that drops either one
-    // fails here even if someone also edits the case list above.
-    expect(RE.flags).toContain('i');
-    expect(RE.source).toContain('\\/+');
+  it('collapses duplicate separators', () => {
+    expect(normalizeRequestPath('/fleet-ui///session-view.html')).toBe('/fleet-ui/session-view.html');
+  });
+
+  it('percent-decodes — the axis that defeated the previous fix', () => {
+    expect(normalizeRequestPath('/fleet-ui/session%2Dview.html')).toBe('/fleet-ui/session-view.html');
+  });
+
+  it('decodes ONCE, matching what express.static does', () => {
+    // Not a loop. %252D is a request for a file literally named %2D, which static will not resolve
+    // to '-', so decoding further would retire a path the file server never serves.
+    expect(normalizeRequestPath('/fleet-ui/session%252Dview.html')).toBe('/fleet-ui/session%2dview.html');
+  });
+
+  it('decodes BEFORE collapsing, so the step order cannot be swapped unnoticed', () => {
+    // If collapse ran before decode, %2F would still be encoded at collapse time and the '%2F/'
+    // pair would survive as two separators.
+    expect(normalizeRequestPath('/fleet-ui%2F/session-view.html')).toBe('/fleet-ui/session-view.html');
+  });
+
+  it('never throws on a malformed escape — a guard must not turn a weird URL into a 500', () => {
+    for (const bad of ['/fleet-ui/%ZZ.html', '/fleet-ui/%', '/fleet-ui/session-view.html%']) {
+      expect(() => normalizeRequestPath(bad)).not.toThrow();
+      expect(() => isRetiredSessionView(bad)).not.toThrow();
+    }
   });
 
   it('a global-flag regex would be stateful across calls — guard against that regression', () => {
-    // A `g` flag on a matcher used per-request makes lastIndex persist between requests, so
-    // alternating calls would silently return false. Express would then serve the retired page.
+    // `g` makes lastIndex persist between requests, so alternating calls silently return false and
+    // Express serves the retired page every other hit.
     expect(RE.flags).not.toContain('g');
   });
 });


### PR DESCRIPTION
## Summary

QF-20260725-096 was marked completed, but the retired `/fleet-ui` session view was **still served on three of four access paths**. This closes the remaining axes by normalising the request path instead of enumerating another literal.

**Measured live before touching anything** (localhost:3000, server running pre-`8bdb6eccd0b`):

| path | status | |
|---|---|---|
| `/fleet-ui/session-view.html` | 410 | the axis that held |
| `/FLEET-UI/session-view.html` | 200 | STILL SERVED |
| `/fleet-ui/SESSION-VIEW.HTML` | 200 | STILL SERVED |
| `/fleet-ui//session-view.html` | 200 | STILL SERVED |
| `/fleet-ui/session%2Dview.html` | 200 | STILL SERVED |

## Root cause (measured, not reasoned)

Express does **not** percent-decode the pathname before route matching; `express.static` **does** decode before resolving on disk. The guard and the file server were matching different strings — which is why every alternate spelling walked past a matcher that looked correct.

## Why this is the third fix and should be the last

- v1: exact literal → defeated by casing and repeated separators
- v2 (`8bdb6eccd0b`): added `i` and `\/+` → defeated by percent-encoding
- v3 (this): normalise once — decode, unify separators, collapse, case-fold — then match one exact pattern

Enumeration does not terminate; normalisation does. Decoding is deliberately **single, not a loop**, because the normaliser models `express.static`, and static decodes once — `%252Dview` requests a file literally named `%2Dview`, which static never resolves to `-view`.

## Structural change this forced

The guard could not remain `app.all(<regex>)`: Express matches a route regex against the **raw** pathname, so normalise-then-match isn't expressible as a route pattern. It is now middleware, registered at the same point, still ahead of the static mount.

## Acceptance

Asserted **per axis** with a stated denominator, never aggregated — an aggregate ratio hides a wholly-failing axis behind passing ones, which is how this guard shipped circumventable twice. Five axes at `blocked/attempted == 1`, plus six forward-cover spellings nobody has tried (encoded separator, backslash, mixed case-and-encoding).

## Verified by mutation, both directions

| mutation | result |
|---|---|
| remove the percent-decode | 6 red, incl. the axis that defeated v2 |
| widen matcher to a substring test | 5 red on the file-scope pins |

One earlier mutation produced an invalid regex and vitest reported "no tests" — a broken control, not a result. Redone rather than counted.

End-to-end on an ephemeral app reproducing `server/index.js`'s middleware+static order with the real files: **8/8 blocked**, siblings unaffected (`fleet-panel` 200; `vision` and nested 404 — reaching static, not intercepted).

## Test plan

- `tests/unit/server/` — 81 passed (30 in this file)

## Still owed

The shared server was **not** restarted to re-probe live: its `node_modules` is mid-restore under the coordinator's NODE_MODULES_LOCK (SDK still missing), so killing it risked leaving a shared service down during an active repair. The live re-probe after deploy is recorded as outstanding in `runtime_observation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)