### PR TITLE
fix(QF-20260727-731): reconcile path no longer silently drops --uat-verified and --actual-loc

### DIFF
--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -212,6 +212,44 @@ export function buildRuntimeObservation({ existing = null, observation = null, m
   };
 }
 
+/**
+ * QF-20260727-731 — the merged-reconcile path SILENTLY DROPPED --uat-verified and --actual-loc.
+ *
+ * The payload carried neither key, so both values vanished while the CLI exited success: the row
+ * read uat_verified=false, actual_loc=null, and that is INDISTINGUISHABLE from never having passed
+ * them. Reported independently from two separate closures (QF-20260726-575, QF-20260726-222), which
+ * is what makes it a pattern rather than an anecdote.
+ *
+ * THE TWO FLAGS GET DIFFERENT TREATMENT, deliberately, because they are different KINDS of thing.
+ *
+ * --actual-loc is HONOURED. It is a measurement carrying no truth claim about verification, so
+ * dropping it only lost data. Same for its source/test siblings.
+ *
+ * --uat-verified is REFUSED LOUDLY. UAT provably does not run on this path — that is the whole
+ * reason force_completed carries the completed_requires_verification CHECK here rather than
+ * fabricating uat_verified (see the rationale below). Honouring a BARE BOOLEAN would write an
+ * anonymous truth claim that UAT ran, on a path where it did not, with nobody named. --scope-accepted
+ * is the attestation mechanism on this path precisely because it names a witness; --uat-verified
+ * cannot, so it is rejected with a message that says where to go instead.
+ *
+ * Refusing is not a workaround for the drop: silence was the defect. A caller now learns
+ * immediately, instead of reading the row later and finding their input gone.
+ *
+ * @throws {Error} UAT_VERIFIED_UNSUPPORTED_ON_RECONCILE when --uat-verified is passed here
+ */
+export function assertReconcileFlagsSupported(options = {}) {
+  if (options.uatVerified === undefined) return;
+  const err = new Error(
+    '[UAT_VERIFIED_UNSUPPORTED_ON_RECONCILE] --uat-verified is not honoured on the already-MERGED ' +
+    'reconcile path: UAT does not re-run here, so the flag would assert that it did. This path sets ' +
+    'force_completed=true instead, which satisfies the completed_requires_verification CHECK without ' +
+    'claiming a UAT that never ran. To attest on this path use --scope-accepted "<who> — <why>", ' +
+    'which records a NAMED witness. Re-run without --uat-verified.'
+  );
+  err.code = 'UAT_VERIFIED_UNSUPPORTED_ON_RECONCILE';
+  throw err;
+}
+
 export function buildMergedReconcileUpdate({ qf = {}, prUrl, mergeSha = null, nowIso, scopeAcceptedBy = null, runtimeObservation = null, observationMethod = null, options = {} }) {
   // Accept the CLI options object as a FALLBACK source for the FR-1 fields, not only explicit
   // args. Two named params were declared here and the sole production call site passed NEITHER, so
@@ -281,6 +319,12 @@ export function buildMergedReconcileUpdate({ qf = {}, prUrl, mergeSha = null, no
       declaredBy: witnessNameFrom(scopeAcceptedBy),
       nowIso
     }),
+    // QF-20260727-731: honour the LOC measurements. They carry no truth claim about
+    // verification, so dropping them only lost data. Omitted keys are left absent rather than
+    // written as null, so a re-run without the flag cannot ERASE a value recorded earlier.
+    ...(options.actualLoc       !== undefined ? { actual_loc: options.actualLoc } : {}),
+    ...(options.actualSourceLoc !== undefined ? { actual_source_loc: options.actualSourceLoc } : {}),
+    ...(options.actualTestLoc   !== undefined ? { actual_test_loc: options.actualTestLoc } : {}),
     verification_notes,
     completed_at: qf.completed_at || nowIso,
     // QF-20260711-176: a completed QF has no holder. Leaving claiming_session_id set made the
@@ -400,6 +444,9 @@ export async function completeQuickFix(qfId, options = {}) {
       }
       // SD-REFILL-00QQ60BN: preserve the verification-column stamping the
       // completed_requires_verification CHECK demands, now with the SELF-DERIVED pr_url.
+      // QF-20260727-731: refuse BEFORE building, so the caller never gets a success exit with
+      // their input discarded. Silence was the defect; a loud failure is the fix.
+      assertReconcileFlagsSupported(options);
       const reconcileUpdate = buildMergedReconcileUpdate({
         qf, prUrl: probeWitness.prUrl, mergeSha, nowIso: new Date().toISOString(), scopeAcceptedBy,
         // THIS LINE WAS MISSING AND IT MATTERED. Without it a real --runtime-observation was

--- a/tests/unit/complete-quick-fix/merged-reconcile-verification.test.js
+++ b/tests/unit/complete-quick-fix/merged-reconcile-verification.test.js
@@ -8,7 +8,7 @@
 // the CHECK without fabricating uat_verified.
 
 import { describe, it, expect } from 'vitest';
-import { buildMergedReconcileUpdate, witnessNameFrom, completionModeStamp, buildRuntimeObservation, completionStampFromOptions } from '../../../scripts/modules/complete-quick-fix/orchestrator.js';
+import { buildMergedReconcileUpdate, witnessNameFrom, completionModeStamp, buildRuntimeObservation, completionStampFromOptions, assertReconcileFlagsSupported } from '../../../scripts/modules/complete-quick-fix/orchestrator.js';
 
 // Mirror of the live completed_requires_verification CHECK predicate (asserted against the DB
 // constraint def: (tests_passing AND uat_verified) OR force_completed when status='completed').
@@ -455,5 +455,60 @@ describe('buildRuntimeObservation over-cap handling (SECURITY S3)', () => {
     const o = buildRuntimeObservation({ observation: 'x'.repeat(9000), nowIso: '2026-07-28T13:00:00.000Z' });
     expect(o.declared).toBeUndefined();
     expect(o.observation).toMatch(/TRUNCATED at \d+ chars/);
+  });
+});
+
+// ── QF-20260727-731 — the reconcile path SILENTLY DROPPED --uat-verified and --actual-loc ────────
+// The payload carried neither key, so both values vanished while the CLI exited success. The row
+// then read uat_verified=false / actual_loc=null, INDISTINGUISHABLE from never having passed them.
+// Reported independently from two separate closures, which made it a pattern not an anecdote.
+describe('reconcile path no longer drops --actual-loc / --uat-verified (QF-20260727-731)', () => {
+  const base = { qf: {}, prUrl: 'https://github.com/x/y/pull/1', nowIso: '2026-07-28T15:00:00.000Z', scopeAcceptedBy: 'Alpha-4 — why' };
+
+  it('honours --actual-loc and its siblings from real parsed argv', async () => {
+    const { parseArguments } = await import('../../../scripts/modules/complete-quick-fix/cli.js');
+    const { options } = parseArguments(['QF-1', '--actual-loc', '42', '--actual-source-loc', '30', '--actual-test-loc', '12']);
+    const u = buildMergedReconcileUpdate({ ...base, options });
+    expect(u.actual_loc).toBe(42);
+    expect(u.actual_source_loc).toBe(30);
+    expect(u.actual_test_loc).toBe(12);
+  });
+
+  it('OMITS the keys entirely when not supplied, so a re-run cannot erase an earlier value', () => {
+    // Writing null instead of omitting would turn a bare re-run into silent data loss — the same
+    // shape as the drop this QF fixes, pointing the other way.
+    const u = buildMergedReconcileUpdate({ ...base, options: {} });
+    expect('actual_loc' in u).toBe(false);
+    expect('actual_source_loc' in u).toBe(false);
+  });
+
+  it('REFUSES --uat-verified loudly instead of discarding it', () => {
+    // UAT provably does not run on this path, so honouring a BARE BOOLEAN would write an anonymous
+    // claim that it did. force_completed carries the CHECK here precisely to avoid fabricating it.
+    expect(() => assertReconcileFlagsSupported({ uatVerified: true }))
+      .toThrow(/UAT_VERIFIED_UNSUPPORTED_ON_RECONCILE/);
+    // --uat-verified no is ALSO refused: the flag is unsupported here, not merely un-honoured when
+    // true. Silently accepting "no" would leave the caller believing the flag was read.
+    expect(() => assertReconcileFlagsSupported({ uatVerified: false }))
+      .toThrow(/UAT_VERIFIED_UNSUPPORTED_ON_RECONCILE/);
+  });
+
+  it('names the supported alternative in the refusal, not just the rejection', () => {
+    // A refusal that does not say what to do instead reproduces the original problem: the caller
+    // still cannot get their attestation recorded.
+    expect(() => assertReconcileFlagsSupported({ uatVerified: true })).toThrow(/--scope-accepted/);
+  });
+
+  it('passes through untouched when the flag was never given', () => {
+    expect(() => assertReconcileFlagsSupported({})).not.toThrow();
+    expect(() => assertReconcileFlagsSupported()).not.toThrow();
+  });
+
+  it('still sets force_completed — the CHECK contract must not regress', () => {
+    // Explicitly pinned because the QF warns against "fixing" this by dropping force_completed:
+    // that would either break completed_requires_verification or fabricate uat_verified.
+    const u = buildMergedReconcileUpdate({ ...base, options: { actualLoc: 42 } });
+    expect(u.force_completed).toBe(true);
+    expect(u.uat_verified).toBeUndefined();
   });
 });


### PR DESCRIPTION
The already-MERGED reconcile path built a `quick_fixes` UPDATE carrying **neither** `uat_verified` nor `actual_loc`. Both values vanished while the CLI exited success, so the row read `uat_verified=false` / `actual_loc=null` — **indistinguishable from never having passed them.** Reported independently from two separate closures (QF-20260726-575, QF-20260726-222), which is what makes it a pattern rather than an anecdote.

## The two flags get different treatment, deliberately

They are different *kinds* of thing, and the QF permits either treatment per flag.

**`--actual-loc` is honoured** (with its source/test siblings). It is a measurement carrying no truth claim about verification, so dropping it only lost data.

Keys are **omitted when not supplied**, not written as `null` — otherwise a bare re-run would *erase* a value recorded earlier, which is the same defect shape pointing the other way.

**`--uat-verified` is refused loudly.** UAT provably does not run on this path — that is exactly why `force_completed` carries the `completed_requires_verification` CHECK here rather than fabricating `uat_verified`. Honouring a **bare boolean** would write an anonymous claim that UAT ran, on a path where it did not, with nobody named. `--scope-accepted` is the attestation mechanism here precisely because it names a witness, and the error says so rather than only rejecting.

Refusing is not a workaround for the drop — **silence was the defect.** The caller now learns immediately instead of reading the row later and finding their input gone. `--uat-verified no` is refused too: the flag is unsupported here, not merely un-honoured when true.

## Explicitly unchanged

`force_completed` still set, and pinned. The QF warns that "fixing" this by dropping it would either break the CHECK or manufacture a false UAT claim.

## Pins — 6 new, mutation-verified

| mutation | result |
|---|---|
| remove the refusal (restore the silent drop) | **2 failed** |
| drop `actual_loc` from the payload again | **1 failed** |

332 passed. The LOC pin drives the **real** parser rather than a hand-made options object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)