### PR TITLE
feat(SD-LEO-FIX-UNOWNED-PARENT-SLICE-001): retire the fleet-ui panel, and make the fence testable

### DIFF
--- a/docs/reference/fleet-launcher-respawn-architecture.md
+++ b/docs/reference/fleet-launcher-respawn-architecture.md
@@ -127,6 +127,42 @@ internal-only, not customer-facing product UI.
 
 ## Fleet panel graphical render (SD-LEO-INFRA-LEO-APP-RENDERED-001-A)
 
+> **RETIRED 2026-07-28 — SD-LEO-FIX-UNOWNED-PARENT-SLICE-001.**
+> `server/public/fleet-ui/fleet-panel.*` now returns **410 Gone**. The section
+> below is kept as the historical design record; the page is no longer served.
+>
+> **Where the capability lives now:** the Builder Sessions page in EHG
+> (`/builder/sessions`), which is authenticated and already renders the
+> manifest table, the account column and `AccountUsageStrip` (a strict
+> superset of this page's 2-field `accountChips` — 7 fields vs 2).
+>
+> **Why it was retired rather than fixed:** the page was served by plain
+> `express.static` with **no auth**, while every verb it called is
+> `requireAuth` — so all four buttons returned 401 for the page's entire life.
+> The obvious repair is forbidden: `requireAuth`'s only non-bearer option is
+> `x-internal-api-key`, a secret shared across ~15 route groups, so soliciting
+> it into an unauthenticated page converts any origin XSS into an app-wide
+> bypass. Removing the surface needs no credential at all.
+>
+> **What was NOT ported, and the condition to revisit it:** respawn-fleet,
+> relaunch-under-profile and snapshot-manifest. They are not dead capability —
+> every live consumer imports `lib/fleet/spawn-control.js` **directly**
+> (`canary-guard.js:25`, `session-watchdog.js:30`, `u4-drill-runner.js:26`).
+> The orphan was the HTTP route, not the verb. Note the usage count alone
+> proves nothing: no credentialed caller *could* exist while the only surface
+> 401'd. **Re-open condition:** an operator needing these from a browser
+> without CLI access. `add-session` already works authenticated from EHG
+> (`ehg/src/hooks/useFleetSessions.ts:420`).
+>
+> **Still open, deliberately:** `GET /api/fleet-panel` remains `optionalAuth`
+> and still serves this whole payload anonymously — the page was the proxy,
+> the endpoint is the payload. And NTFS 8.3 short names (`FLEET-~1.HTM`)
+> still serve the retired files, because a filesystem alias is not a spelling
+> and no path normaliser can see it; closing that needs `fs.realpathSync.native`
+> or an allow-list at the mount, **not** a sixth spelling. Both tracked
+> separately. `fleet-panel-format.js` is intentionally still served as the
+> canary for a dot-dropped matcher.
+
 The mockup-1 counterpart to the Session View pane above: renders
 `server/routes/fleet-panel.js`'s `GET /api/fleet-panel` (manifest table, 3
 named-account capacity chips, attention strip) and drives the 4

--- a/server/index.js
+++ b/server/index.js
@@ -44,7 +44,7 @@ import {
 import { loadState, dashboardState } from './state.js';
 // QF-20260725-096: retired-route matchers, kept in their own side-effect-free module so the scope
 // pins can import the real pattern without booting the server.
-import { isRetiredSessionView } from './retired-routes.js';
+import { installFleetUiSurface } from './retired-routes.js';
 
 // Import WebSocket handler
 import { initializeWebSocket, broadcastUpdate } from './websocket.js';
@@ -215,43 +215,19 @@ app.use(express.json());
 // the normalisation has to happen before the decision. That is the whole reason three spellings
 // kept getting served: the guard was matching a different string than the file server resolved.
 // Registered here, still ahead of the /fleet-ui static mount below, so the retirement wins.
-app.use((req, res, next) => {
-  if (!isRetiredSessionView(req.path)) return next();
-  return retiredSessionViewHandler(req, res);
-});
-
-function retiredSessionViewHandler(req, res) {
-  // QF-20260727-484 — WITHOUT THIS LINE THE SOAK CANNOT PRODUCE EVIDENCE. The retirement above
-  // is dispositioned by a seven-day soak in which SILENCE IS THE EVIDENCE, but this server has no
-  // request logging of any kind (no morgan — it is not even a dependency), so a 410 hit wrote
-  // nothing anywhere. Silence was therefore GUARANTEED: at day 7 nobody could distinguish "nobody
-  // hit it" from "we could never have seen it". QF-20260725-096 already carried the warning that
-  // a zero from a file that could not be opened is not a zero — but pinned it on locked browser
-  // history. The real blind spot was server-side and total.
-  //
-  // Scoped to THIS handler on purpose: general request logging on /fleet-ui or on the app is a
-  // different change with a different justification (volume, privacy, noise) and is NOT in scope.
-  // stdout is durable here — scripts/leo-stack.ps1:171 runs the server as `node server.js >
-  // .logs/engineer-<timestamp>.log 2>&1` — so the soak reader has exactly one command:
-  //   grep fleet-ui-410 .logs/engineer-*.log
-  // An empty result now means genuinely unhit, which is the whole point.
-  console.log(
-    `[fleet-ui-410] ${new Date().toISOString()} ${req.method} ${req.originalUrl} ` +
-    `referer=${req.get('referer') || '-'}`
-  );
-  res.status(410).type('text/plain').send(
-    'Gone — the standalone fleet-ui session view was retired on 2026-07-27 (QF-20260725-096).\n\n' +
-    'Session list: the Builder Sessions page in EHG.\n' +
-    'Session detail (TTY, narration, agent-browser, takeover/hand-back): use the terminal.\n\n' +
-    'This capability is knowingly unavailable from the web surface. If you needed this page,\n' +
-    'that is a signal worth raising — the retirement is reversible.\n'
-  );
-}
-
+// SD-LEO-FIX-UNOWNED-PARENT-SLICE-001: the retirement guards AND the static mount are installed
+// together by one function, because THE ORDER IS THE SECURITY PROPERTY. A 410 registered after
+// express.static is shadowed, unreachable, and still reads as correct in review. While both
+// registrations lived inline here, nothing could assert the guard was even MOUNTED — deleting the
+// app.use line left every matcher unit test green while the retired page went straight back to
+// being served, because index.js calls startServer() at import so no test can import it. Behind
+// the seam, tests/unit/server/fleet-ui-410-scope.test.js builds a bare express app, calls this
+// same function, and issues real requests: ordering is EXERCISED, not asserted.
+//
 // Fleet-launcher operator UI static assets (SD-LEO-INFRA-LEO-LAUNCHER-SHELL-001-B): the
 // Session View pane fragment, mountable into the parent shell. See the ARCH-007 exception
 // note at the top of this file.
-app.use('/fleet-ui', express.static(path.join(PROJECT_ROOT, 'server', 'public', 'fleet-ui')));
+installFleetUiSurface(app, { root: path.join(PROJECT_ROOT, 'server', 'public', 'fleet-ui') });
 
 // NOTE: /api/webhooks/github-ci-status (api/webhooks/github-ci-status.js) is
 // intentionally NOT mounted here. Its ESM/CJS crash and an unauthenticated

--- a/server/retired-routes.js
+++ b/server/retired-routes.js
@@ -7,7 +7,12 @@
  * guard's test flaky, and a flaky guard test is one CI-quarantine away from being no guard at all.
  *
  * QF-20260725-096.
+ *
+ * express is imported for installFleetUiSurface() below. It is a module import only — nothing here
+ * binds a port or opens a connection, so the "testable without booting the server" property above
+ * still holds.
  */
+import express from 'express';
 
 /**
  * NORMALISE, THEN MATCH — QF-20260728-458.
@@ -78,4 +83,109 @@ export const RETIRED_SESSION_VIEW_RE = /^\/fleet-ui\/session-view\.[^/]*$/;
  */
 export function isRetiredSessionView(rawPath) {
   return RETIRED_SESSION_VIEW_RE.test(normalizeRequestPath(rawPath));
+}
+
+/**
+ * The retired fleet panel — SD-LEO-FIX-UNOWNED-PARENT-SLICE-001.
+ *
+ * WHY IT IS RETIRED RATHER THAN FIXED. The page was served by plain express.static with no auth,
+ * while every action it called is requireAuth — so all four buttons returned 401 for the page's
+ * entire life. server/public/fleet-ui/fleet-panel.js:1-20 records that as a DISCLOSED, ACCEPTED
+ * gap found by adversarial PR review. The obvious repair (put a credential in the page) is
+ * FORBIDDEN: requireAuth's only non-bearer option is x-internal-api-key, a secret shared across
+ * ~15 route groups, so soliciting it into an unauthenticated page converts any origin XSS into an
+ * app-wide auth bypass — strictly worse than the 401. Removing the surface needs no credential.
+ *
+ * WHY NOTHING WAS PORTED FIRST. Three actions had no credentialed caller (respawn-fleet,
+ * relaunch-under-profile, snapshot-manifest), but they are NOT unused capability: every live
+ * consumer imports lib/fleet/spawn-control.js DIRECTLY (canary-guard.js:25, session-watchdog.js:30,
+ * u4-drill-runner.js:26). The orphan is the HTTP route, not the verb. Note the usage count alone
+ * proves nothing — no credentialed caller COULD exist while the only surface 401'd — so the
+ * decision rests on the direct-import evidence. Re-open condition: an operator needing these from
+ * a browser without CLI access. The fourth action, add-session, already works authenticated from
+ * EHG (ehg/src/hooks/useFleetSessions.ts:420).
+ *
+ * SCOPE. Same normalise-then-match design as the session view, for the same measured reason. The
+ * literal `\.` is load-bearing TWICE: it keeps the extensionless path out, and it keeps
+ * fleet-panel-format.js OUT — that file stays servable on purpose as the canary for a
+ * dot-dropped widening, so a matcher that starts swallowing it fails the scope pins.
+ */
+export const RETIRED_FLEET_PANEL_RE = /^\/fleet-ui\/fleet-panel\.[^/]*$/;
+
+/**
+ * Is this request for the retired fleet panel page?
+ * @param {string} rawPath a request pathname, e.g. req.path
+ */
+export function isRetiredFleetPanel(rawPath) {
+  return RETIRED_FLEET_PANEL_RE.test(normalizeRequestPath(rawPath));
+}
+
+/**
+ * Every retirement on the /fleet-ui mount, in one table so adding the next one cannot forget the
+ * guard-before-static ordering.
+ */
+const FLEET_UI_RETIREMENTS = Object.freeze([
+  {
+    name: 'session-view',
+    matches: isRetiredSessionView,
+    body:
+      'Gone — the standalone fleet-ui session view was retired on 2026-07-27 (QF-20260725-096).\n\n' +
+      'Session list: the Builder Sessions page in EHG.\n' +
+      'Session detail (TTY, narration, agent-browser, takeover/hand-back): use the terminal.\n\n' +
+      'This capability is knowingly unavailable from the web surface. If you needed this page,\n' +
+      'that is a signal worth raising — the retirement is reversible.\n',
+  },
+  {
+    name: 'fleet-panel',
+    matches: isRetiredFleetPanel,
+    body:
+      'Gone — the fleet-ui panel was retired on 2026-07-28 (SD-LEO-FIX-UNOWNED-PARENT-SLICE-001).\n\n' +
+      'Fleet manifest, account usage and spawn control: the Builder Sessions page in EHG\n' +
+      '(/builder/sessions), which is authenticated and where these already work.\n\n' +
+      'Its action buttons never worked from this page — they returned 401 for its entire life,\n' +
+      'because the page was unauthenticated and the actions were not. respawn-fleet,\n' +
+      'relaunch-under-profile and snapshot-manifest were NOT ported: every live consumer calls\n' +
+      'lib/fleet/spawn-control.js directly. If you needed one of them FROM A BROWSER, that is the\n' +
+      'stated re-open condition — say so and the port gets built.\n',
+  },
+]);
+
+/**
+ * Install the /fleet-ui surface: retirement guards FIRST, then the static mount.
+ *
+ * WHY THIS IS A FUNCTION AND NOT TWO CALLS IN index.js. The ordering IS the security property —
+ * a 410 registered after express.static is shadowed, unreachable, and still looks correct in
+ * review. While the registration lived inline in server/index.js it could not be tested at all,
+ * because index.js calls startServer() at import time (no main-module guard), so importing it to
+ * check a route would open DB connections and bind a port. Nothing therefore asserted the guard
+ * was MOUNTED: deleting the app.use line left every matcher unit test green while the retired
+ * page went back to being served. Behind this seam a test builds a bare express app, calls this,
+ * and issues real requests — so ordering is EXERCISED rather than asserted, and registering the
+ * static mount first makes the 410 assertions fail instead of quietly passing.
+ *
+ * The test uses the SAME express as production — a harness that supplied its own would only prove
+ * that its own copy behaves, which is the mistake this module's header already warns about.
+ *
+ * @param {import('express').Express} app
+ * @param {{ root: string }} opts  root = the fleet-ui static directory
+ */
+export function installFleetUiSurface(app, { root }) {
+  app.use((req, res, next) => {
+    const hit = FLEET_UI_RETIREMENTS.find((r) => r.matches(req.path));
+    if (!hit) return next();
+    // QF-20260727-484 — WITHOUT THIS LINE THE SOAK CANNOT PRODUCE EVIDENCE. These retirements are
+    // dispositioned by a soak in which SILENCE IS THE EVIDENCE, but this server has no request
+    // logging of any kind (no morgan — not even a dependency), so a 410 hit wrote nothing anywhere
+    // and silence was GUARANTEED. The tag is unchanged so the documented reader still works:
+    //   grep fleet-ui-410 .logs/engineer-*.log
+    // Scoped to this handler on purpose: general request logging is a different change with a
+    // different justification (volume, privacy, noise) and is NOT in scope.
+    console.log(
+      `[fleet-ui-410] ${new Date().toISOString()} ${hit.name} ${req.method} ${req.originalUrl} ` +
+      `referer=${req.get('referer') || '-'}`
+    );
+    return res.status(410).type('text/plain').send(hit.body);
+  });
+
+  app.use('/fleet-ui', express.static(root));
 }

--- a/tests/unit/server/fleet-actions-route.test.js
+++ b/tests/unit/server/fleet-actions-route.test.js
@@ -250,3 +250,39 @@ describe('GET /api/fleet-actions/snapshot-manifest', () => {
     expect(typeof payload.snapshot_at).toBe('string');
   });
 });
+
+/**
+ * SD-LEO-FIX-UNOWNED-PARENT-SLICE-001 — pin that these routes are actually AUTH-GATED.
+ *
+ * Every test above calls the exported handlers DIRECTLY with mock req/res, which is the right
+ * shape for testing composition logic but means all of them bypass requireAuth by design. So the
+ * property the fleet panel's retirement decision leans on -- "leaving these three routes in place
+ * is fine BECAUSE they are auth-gated" -- was asserted by exactly one line in server/index.js that
+ * nothing pinned. Flipping it to optionalAuth would fail no test. That is precisely how the panel
+ * itself came to be unauthenticated for its entire life.
+ *
+ * These are not read-only routes: respawn-fleet and relaunch-under-profile invoke spawn() and
+ * relaunchUnderProfile(), i.e. process execution under an account profile. requireAuth is only
+ * AUTHENTICATION -- no role check, no allowlist, no ownership check -- and EHG_Engineer and EHG
+ * share one Supabase project, so any EHG-app JWT passes here. The present bound is that EHG has
+ * no public signup surface, which is an incidental property, NOT a control.
+ *
+ * THIS IS A SOURCE-TEXT PROXY, deliberately labelled as one. server/index.js calls startServer()
+ * at import time (no main-module guard), so it cannot be imported to inspect its router. The pin
+ * therefore reads the mount line as text. It will need re-anchoring if that line is reformatted --
+ * accepted, because the regression it catches (a silent swap to optionalAuth) is the one that
+ * matters and is otherwise invisible.
+ */
+describe('SD-LEO-FIX-UNOWNED-PARENT-SLICE-001: /api/fleet-actions stays behind requireAuth', () => {
+  it('is mounted with requireAuth, not optionalAuth', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    const src = fs.readFileSync(
+      path.join(process.cwd(), 'server', 'index.js'), 'utf8'
+    );
+    const mount = src.split('\n').find((l) => l.includes("app.use('/api/fleet-actions'"));
+    expect(mount, 'the fleet-actions mount line was not found -- re-anchor this pin').toBeTruthy();
+    expect(mount).toContain('requireAuth');
+    expect(mount).not.toContain('optionalAuth');
+  });
+});

--- a/tests/unit/server/fleet-ui-410-scope.test.js
+++ b/tests/unit/server/fleet-ui-410-scope.test.js
@@ -32,8 +32,13 @@
  * server/retired-routes.js rather than server/index.js because the latter calls startServer() at
  * import time, so asserting a matcher would otherwise open DB connections and bind a port.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import express from 'express';
+import path from 'node:path';
+import fs from 'node:fs';
 import {
+  installFleetUiSurface,
+  isRetiredFleetPanel,
   isRetiredSessionView,
   normalizeRequestPath,
   RETIRED_SESSION_VIEW_RE as RE,
@@ -91,10 +96,15 @@ const FORWARD_COVER = [
  * is pinned at least as hard as the bypasses.
  */
 const MUST_PASS_THROUGH = [
-  ['/fleet-ui/fleet-panel.html', 'sibling page, live'],
+  // NB these two are RETIRED as of SD-LEO-FIX-UNOWNED-PARENT-SLICE-001 — but by the FLEET-PANEL
+  // matcher, not this one. They stay here because what they pin is cross-matcher scope: the
+  // session-view matcher must not claim them. Relabelled rather than duplicated: a path carrying
+  // both a green "passes through" and a green "is retired" lets a reader trust whichever they
+  // read first, so the label has to say WHICH matcher it is about.
+  ['/fleet-ui/fleet-panel.html', 'retired by the fleet-panel matcher — the session-view matcher must NOT claim it'],
+  ['/FLEET-UI/FLEET-PANEL.HTML', 'same, upper — case-folding must not widen THIS match across files'],
   ['/fleet-ui/vision.html', 'sibling page, live'],
-  ['/fleet-ui/fleet-panel-format.js', 'sibling asset'],
-  ['/FLEET-UI/FLEET-PANEL.HTML', 'sibling page upper — case-folding must not widen the match'],
+  ['/fleet-ui/fleet-panel-format.js', 'sibling asset, live — see the fleet-panel scope pins'],
   ['/fleet-ui/sub/session-view.html', 'nested path — [^/] must not cross a segment'],
   ['/fleet-ui//sub//session-view.html', 'nested with duplicated separators — still nested after collapse'],
   ['/fleet-ui/session-view', 'no extension — the dot is required'],
@@ -174,5 +184,126 @@ describe('QF-20260728-458: the normaliser does the work, by construction', () =>
     // `g` makes lastIndex persist between requests, so alternating calls silently return false and
     // Express serves the retired page every other hit.
     expect(RE.flags).not.toContain('g');
+  });
+});
+
+/**
+ * SD-LEO-FIX-UNOWNED-PARENT-SLICE-001 — the fleet panel is retired on the SAME mount.
+ *
+ * Reuses the session view's axis list verbatim rather than inventing a fresh one: these are the
+ * spellings MEASURED to defeat this guard three times, and a second retirement on the same mount
+ * gets them for free only if it is asserted for them explicitly.
+ */
+const FLEET_PANEL_AXES = [
+  ['lowercase', ['/fleet-ui/fleet-panel.html', '/fleet-ui/fleet-panel.js', '/fleet-ui/fleet-panel.css']],
+  ['filename case', ['/fleet-ui/Fleet-Panel.html', '/fleet-ui/FLEET-PANEL.HTML']],
+  ['directory case', ['/FLEET-UI/fleet-panel.html', '/Fleet-UI/fleet-panel.html']],
+  ['duplicate separator', ['/fleet-ui//fleet-panel.html', '//fleet-ui/fleet-panel.html']],
+  ['percent-encoded', ['/fleet-ui/fleet%2Dpanel.html', '/fleet-ui/fleet%2dpanel.html', '/fleet-ui/fleet-panel%2Ehtml']],
+];
+
+/**
+ * THE CANARY LIST. fleet-panel-format.js is deliberately NOT retired, and it is the reason the
+ * literal dot in the matcher is load-bearing: drop the dot and this file gets swallowed while
+ * every "is it retired" assertion still passes green. Keep it here permanently.
+ */
+const FLEET_PANEL_MUST_PASS_THROUGH = [
+  ['/fleet-ui/fleet-panel-format.js', 'THE CANARY — a dot-dropped matcher swallows this first'],
+  ['/fleet-ui/vision.html', 'sibling page on the same mount, live'],
+  ['/fleet-ui/session-view.html', 'retired by the OTHER matcher — this one must not claim it'],
+  ['/fleet-ui/fleet-panel', 'no extension — the dot is required'],
+  ['/fleet-ui/sub/fleet-panel.html', 'nested — [^/] must not cross a segment'],
+  ['/fleet-ui/fleet-panel-notes.html', 'longer filename sharing the prefix'],
+];
+
+describe('SD-LEO-FIX-UNOWNED-PARENT-SLICE-001: the fleet panel is retired — per axis', () => {
+  it.each(FLEET_PANEL_AXES)('axis "%s": blocked/attempted === 1', (_axis, spellings) => {
+    const attempted = spellings.length;
+    const blocked = spellings.filter((p) => isRetiredFleetPanel(p)).length;
+    expect(attempted).toBeGreaterThan(0);
+    expect(`${blocked}/${attempted}`).toBe(`${attempted}/${attempted}`);
+  });
+
+  it.each(FLEET_PANEL_MUST_PASS_THROUGH)('does NOT match %s (%s)', (path) => {
+    expect(isRetiredFleetPanel(path)).toBe(false);
+  });
+});
+
+/**
+ * THE BEHAVIOURAL BLOCK — the half that no amount of matcher testing can replace.
+ *
+ * Every assertion above proves a FUNCTION behaves. None of them proves the function is WIRED.
+ * Before installFleetUiSurface() existed, deleting the app.use line in server/index.js left this
+ * entire file green while the retired pages went back to being served — the guard's own test
+ * inherited the guard's blind spot, which is the failure mode this suite's header already
+ * describes for the matcher. index.js cannot be imported to check (it calls startServer() at
+ * import), so the registration was extracted behind a seam and is exercised here for real:
+ * same express, same static directory, real requests, real status codes.
+ *
+ * Ordering is EXERCISED, not asserted. Registering express.static before the guards inside
+ * installFleetUiSurface turns these assertions red — no private router-stack introspection
+ * (app._router) and no source-order pin, both of which break on unrelated edits.
+ */
+describe('SD-LEO-FIX-UNOWNED-PARENT-SLICE-001: the surface is actually mounted', () => {
+  let server;
+  let base;
+
+  beforeAll(async () => {
+    const app = express();
+    installFleetUiSurface(app, {
+      root: path.join(process.cwd(), 'server', 'public', 'fleet-ui'),
+    });
+    server = app.listen(0);
+    await new Promise((resolve) => server.once('listening', resolve));
+    base = `http://127.0.0.1:${server.address().port}`;
+  });
+
+  afterAll(() => server?.close());
+
+  const RETIRED_REQUESTS = [
+    ['/fleet-ui/fleet-panel.html', 'the retired panel'],
+    ['/fleet-ui/fleet%2Dpanel.html', 'encoded hyphen — the axis that defeated a previous fix'],
+    ['/fleet-ui/session-view.html', 'the previously retired session view, still retired'],
+    ['/fleet-ui/session%2Dview.html', 'encoded, same'],
+  ];
+
+  // DERIVED FROM THE DIRECTORY, NOT INVENTED. The first draft of this control asserted
+  // /fleet-ui/vision.html — a file that DOES NOT EXIST on this mount. It 404s, so it could never
+  // distinguish an intact fence from a mount-wide one: a vacuous control that would have passed
+  // review as a negative control. The claim came from the module header's "vision.*, session-view.*
+  // and fleet-panel.* share one mount" and was propagated through the PRD without anyone listing
+  // the directory. Reading the mount is what makes the control real, so read the mount.
+  const FLEET_UI_ROOT = path.join(process.cwd(), 'server', 'public', 'fleet-ui');
+  const RETIRED_PREFIXES = ['fleet-panel.', 'session-view.'];
+  const LIVE_FILES = fs.readdirSync(FLEET_UI_ROOT)
+    .filter((f) => !RETIRED_PREFIXES.some((p) => f.toLowerCase().startsWith(p)));
+
+  it('the derived pass-through list is non-empty — otherwise this control proves nothing', () => {
+    // A zero-length list would make the it.each below vacuously green, which is exactly the
+    // failure the vision.html draft had.
+    expect(LIVE_FILES.length).toBeGreaterThan(0);
+  });
+
+  it.each(LIVE_FILES.map((f) => [f]))('GET /fleet-ui/%s still returns 200', async (file) => {
+    const res = await fetch(`${base}/fleet-ui/${file}`, { redirect: 'manual' });
+    expect(res.status).toBe(200);
+  });
+
+  it.each(RETIRED_REQUESTS)('GET %s returns 410 (%s)', async (p) => {
+    const res = await fetch(base + p, { redirect: 'manual' });
+    expect(res.status).toBe(410);
+  });
+
+  it('the panel 410 names where the capability actually lives', async () => {
+    // A 410 that does not say where to go is a dead end. The operator needs the replacement
+    // surface, not just a refusal.
+    const res = await fetch(base + '/fleet-ui/fleet-panel.html');
+    expect(await res.text()).toContain('/builder/sessions');
+  });
+
+  it('HEAD is fenced too, not just GET', async () => {
+    // The guard is method-agnostic middleware; a route-scoped fix could easily miss this.
+    const res = await fetch(base + '/fleet-ui/fleet-panel.html', { method: 'HEAD' });
+    expect(res.status).toBe(410);
   });
 });

--- a/tests/unit/server/fleet-ui-410-scope.test.js
+++ b/tests/unit/server/fleet-ui-410-scope.test.js
@@ -2,6 +2,14 @@
  * QF-20260728-458 — the retired /fleet-ui session view must be blocked on EVERY spelling of the
  * path, not on an enumerated list of them.
  *
+ * >>> THAT HEADLINE IS NOT TRUE TODAY. READ THE "KNOWN-OPEN" BLOCK AT THE BOTTOM OF THIS FILE
+ * >>> BEFORE TRUSTING ANY GREEN RUN. NTFS 8.3 short names (FLEET-~1.HTM, SESSIO~1.HTM) serve BOTH
+ * >>> retired pages verbatim while every test here passes. 8.3 is a filesystem ALIAS resolved
+ * >>> below the path string, so no normaliser can close it — the fix is structural. Measured and
+ * >>> reproduced three times; raised separately. Bounded here (SD-LEO-FIX-UNOWNED-PARENT-SLICE-001)
+ * >>> because a green UNIVERSAL claim is worse than no claim, and this one has now been falsified
+ * >>> a fourth time by an axis the design said could not exist.
+ *
  * WHY THIS FILE EXISTS, and why it has now been rewritten twice. The matcher has been circumvented
  * three times, each by a spelling the previous fix did not enumerate:
  *   v1  exact literal                     → defeated by filename case, directory case, repeated separators
@@ -32,10 +40,13 @@
  * server/retired-routes.js rather than server/index.js because the latter calls startServer() at
  * import time, so asserting a matcher would otherwise open DB connections and bind a port.
  */
-import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import express from 'express';
 import path from 'node:path';
 import fs from 'node:fs';
+import crypto from 'node:crypto';
+
+const FLEET_UI_ROOT_FOR_HASH = path.join(process.cwd(), 'server', 'public', 'fleet-ui');
 import {
   installFleetUiSurface,
   isRetiredFleetPanel,
@@ -79,6 +90,12 @@ const AXES = [
  * that spellings nobody has tried yet are already closed. If any of these ever needs its own case
  * added to the matcher, the normalise-then-match design has failed and a fourth enumeration pass
  * has begun.
+ *
+ * SCOPE CORRECTION (SD-LEO-FIX-UNOWNED-PARENT-SLICE-001): "already closed" holds only for axes
+ * that are SPELLINGS OF THE PATH STRING, which is all this list contains. It does NOT hold
+ * generally — NTFS 8.3 aliases resolve BELOW the string and defeat the fence today (see the
+ * KNOWN-OPEN block at the bottom). The design premise was not wrong so much as
+ * mis-scoped: normalisation terminates the spelling axis; it never addressed the aliasing axis.
  */
 const FORWARD_COVER = [
   ['encoded separator', '/fleet-ui%2Fsession-view.html'],
@@ -94,6 +111,15 @@ const FORWARD_COVER = [
  * fleet-panel.* and vision.* share the same /fleet-ui static mount, so an over-broad matcher takes
  * live sibling pages down. Normalising makes over-matching EASIER to do by accident, so this half
  * is pinned at least as hard as the bypasses.
+ *
+ * TRACKED IS NOT DEPLOYED — a correction worth keeping, because I got it wrong in both directions
+ * on the same day. The DEPLOYED mount serves 13 files; git tracks 8. vision.html, mockup.html and
+ * two icons exist and serve 200 in production but are UNTRACKED, so they are absent from a fresh
+ * worktree. I listed a worktree, found no vision.html, and concluded "that file does not exist" —
+ * generalising from a sample selected by a mechanism (git tracking) correlated with exactly what I
+ * was measuring. The original defect was real: the behavioural control WAS vacuous where it runs,
+ * because in CI the derived live-file population is n=1. Both halves matter — the control is weak
+ * in CI, and the mount is richer in production than any test here can see.
  */
 const MUST_PASS_THROUGH = [
   // NB these two are RETIRED as of SD-LEO-FIX-UNOWNED-PARENT-SLICE-001 — but by the FLEET-PANEL
@@ -275,7 +301,11 @@ describe('SD-LEO-FIX-UNOWNED-PARENT-SLICE-001: the surface is actually mounted',
   // the directory. Reading the mount is what makes the control real, so read the mount.
   const FLEET_UI_ROOT = path.join(process.cwd(), 'server', 'public', 'fleet-ui');
   const RETIRED_PREFIXES = ['fleet-panel.', 'session-view.'];
-  const LIVE_FILES = fs.readdirSync(FLEET_UI_ROOT)
+  // withFileTypes: without it a SUBDIRECTORY enumerates as a file and express.static answers 301,
+  // producing a red test that looks like a fence bug and invites loosening the assertion.
+  const LIVE_FILES = fs.readdirSync(FLEET_UI_ROOT, { withFileTypes: true })
+    .filter((d) => d.isFile())
+    .map((d) => d.name)
     .filter((f) => !RETIRED_PREFIXES.some((p) => f.toLowerCase().startsWith(p)));
 
   it('the derived pass-through list is non-empty — otherwise this control proves nothing', () => {
@@ -305,5 +335,106 @@ describe('SD-LEO-FIX-UNOWNED-PARENT-SLICE-001: the surface is actually mounted',
     // The guard is method-agnostic middleware; a route-scoped fix could easily miss this.
     const res = await fetch(base + '/fleet-ui/fleet-panel.html', { method: 'HEAD' });
     expect(res.status).toBe(410);
+  });
+
+  it('a 410 emits the soak log line — QF-20260727-484 says silence IS the evidence', async () => {
+    // That console.log is LOAD-BEARING and was unpinned: deleting it left the suite fully green
+    // while destroying the disposition mechanism for BOTH retirements, and renaming the tag
+    // silently breaks the one documented reader (grep fleet-ui-410 .logs/engineer-*.log).
+    // A routine "drop console.log from middleware" cleanup would have shipped green.
+    const seen = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...a) => seen.push(a.join(' ')));
+    try {
+      await fetch(base + '/fleet-ui/fleet-panel.html');
+    } finally {
+      spy.mockRestore();
+    }
+    expect(seen.join('\n')).toContain('[fleet-ui-410]');
+  });
+});
+
+/**
+ * KNOWN-OPEN AXIS — NTFS 8.3 SHORT NAMES DEFEAT BOTH RETIREMENTS. Do not delete these tests to
+ * make the suite look better; they are the honest half of it.
+ *
+ * MEASURED, reproduced independently three times (two sub-agents plus a direct check), against
+ * both this app and the running server on 127.0.0.1:3000:
+ *
+ *   GET /fleet-ui/fleet-panel.html   410     the canonical spelling
+ *   GET /fleet-ui/FLEET-~1.HTM       200     THE SAME FILE, sha256-identical to the on-disk bytes
+ *   GET /fleet-ui/SESSIO~1.HTM       200     ditto, for the ALREADY-SHIPPED session-view retirement
+ *
+ * It is BROWSER-REACHABLE: the WHATWG URL parser leaves that pathname untouched, so a browser
+ * sends it verbatim. No tooling required.
+ *
+ * WHY NO NORMALISER CAN CLOSE IT, and why this file must stop claiming otherwise. 8.3 is a
+ * FILESYSTEM ALIAS resolved BELOW the path string, not another spelling of it. This module's
+ * governing thesis — "reduce the path ONCE to the form the filesystem will actually resolve,
+ * enumeration does not terminate but normalisation does" — is FALSE for this axis, and the
+ * suite's own FORWARD_COVER block above claims "spellings nobody has tried yet are already
+ * closed" while 68 tests pass green and the page is served. That green universal claim is worse
+ * than no claim, so it is bounded here rather than left to be discovered a fourth time.
+ *
+ * NOT FIXED IN THIS SD, deliberately: the real fix is structural — allow-list the mount or move
+ * retired files out of the served root — and it needs its own decision, because the deployed mount
+ * also serves untracked files (vision.html, mockup.html, icons) that a tracked-file allow-list
+ * would take down. Raised to the coordinator at high severity as its own item.
+ *
+ * These tests assert the bypass STILL EXISTS. When it is fixed they go red — which is the point:
+ * whoever closes it is told exactly which claims they may now restore.
+ */
+describe('KNOWN-OPEN: NTFS 8.3 aliases bypass the fence (asserted as OPEN, not as fixed)', () => {
+  let server;
+  let base;
+
+  beforeAll(async () => {
+    const app = express();
+    installFleetUiSurface(app, {
+      root: path.join(process.cwd(), 'server', 'public', 'fleet-ui'),
+    });
+    server = app.listen(0);
+    await new Promise((resolve) => server.once('listening', resolve));
+    base = `http://127.0.0.1:${server.address().port}`;
+  });
+
+  afterAll(() => server?.close());
+
+  it('the matcher does not see the 8.3 alias — a string normaliser structurally cannot', () => {
+    expect(isRetiredFleetPanel('/fleet-ui/FLEET-~1.HTM')).toBe(false);
+    expect(isRetiredSessionView('/fleet-ui/SESSIO~1.HTM')).toBe(false);
+  });
+
+  it('DOCUMENTS THE GAP: the 8.3 alias still serves the retired page (410 canonically, 200 aliased)', async () => {
+    // Guard first: on a volume with 8dot3 disabled the alias 404s and this axis is moot there.
+    // Skipping on 404 keeps the test honest rather than red for the wrong reason.
+    const aliased = await fetch(`${base}/fleet-ui/FLEET-~1.HTM`, { redirect: 'manual' });
+    if (aliased.status === 404) return;   // 8dot3 disabled on this volume — nothing to document
+
+    const canonical = await fetch(`${base}/fleet-ui/fleet-panel.html`, { redirect: 'manual' });
+    expect(canonical.status).toBe(410);
+    expect(aliased.status).toBe(200);
+
+    // PAYLOAD, not proxy: a 200 alone could be an error page. Compare the bytes.
+    const served = crypto.createHash('sha256')
+      .update(Buffer.from(await aliased.arrayBuffer())).digest('hex');
+    const onDisk = crypto.createHash('sha256')
+      .update(fs.readFileSync(path.join(FLEET_UI_ROOT_FOR_HASH, 'fleet-panel.html'))).digest('hex');
+    expect(served).toBe(onDisk);
+  });
+
+  it('DOCUMENTS THE GAP: the bypass emits NO soak log line, so silence cannot mean unhit', async () => {
+    const aliased0 = await fetch(`${base}/fleet-ui/FLEET-~1.HTM`, { redirect: 'manual' });
+    if (aliased0.status === 404) return;
+
+    const seen = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...a) => seen.push(a.join(' ')));
+    try {
+      await fetch(`${base}/fleet-ui/FLEET-~1.HTM`);
+    } finally {
+      spy.mockRestore();
+    }
+    // This is the compounding failure: the soak's disposition is "silence is the evidence", and
+    // the one axis that defeats the fence is exactly the axis the instrument cannot see.
+    expect(seen.join('\n')).not.toContain('[fleet-ui-410]');
   });
 });

--- a/tests/unit/server/fleet-ui-410-scope.test.js
+++ b/tests/unit/server/fleet-ui-410-scope.test.js
@@ -448,9 +448,16 @@ describe('KNOWN-OPEN: NTFS 8.3 aliases bypass the fence (asserted as OPEN, not a
     return (await fetch(base + ALIAS_CANARY, { redirect: 'manual' })).status === 200;
   }
 
-  it.each(ALIASED_RETIRED)(
-    'DOCUMENTS THE GAP: %s still serves %s verbatim (RED when closed, skipped when 8.3 is off)',
-    async (aliasPath, realFile, ctx) => {
+  // DELIBERATELY NOT it.each. Measured on vitest 4.1.4: `it.each` passes ONLY the row values —
+  // the TestContext is never appended, for array rows and object rows alike — so `ctx.skip()`
+  // below threw TypeError instead of skipping. It threw ONLY on Linux, because this branch is
+  // unreachable wherever 8.3 aliases DO resolve: the guard added to make vacuity visible was
+  // itself never executed on the platform it was written on, and CI caught what the local run
+  // structurally could not. A plain `it` does receive the context (the soak-log test below is
+  // the in-suite control — it is the one test that skipped cleanly on ubuntu). The loop keeps
+  // one distinctly-named test per axis, which the first test in this describe pins.
+  for (const [aliasPath, realFile] of ALIASED_RETIRED) {
+    it(`DOCUMENTS THE GAP: ${aliasPath} still serves ${realFile} verbatim (RED when closed, skipped when 8.3 is off)`, async (ctx) => {
       if (!(await aliasesResolveHere())) {
         ctx.skip();   // visible as skipped, never a silent green
         return;
@@ -473,8 +480,8 @@ describe('KNOWN-OPEN: NTFS 8.3 aliases bypass the fence (asserted as OPEN, not a
       const onDisk = crypto.createHash('sha256')
         .update(fs.readFileSync(path.join(FLEET_UI_ROOT_FOR_HASH, realFile))).digest('hex');
       expect(served).toBe(onDisk);
-    }
-  );
+    });
+  }
 
   it('DOCUMENTS THE GAP: the bypass emits NO soak log line, so silence cannot mean unhit', async (ctx) => {
     if (!(await aliasesResolveHere())) {

--- a/tests/unit/server/fleet-ui-410-scope.test.js
+++ b/tests/unit/server/fleet-ui-410-scope.test.js
@@ -357,12 +357,22 @@ describe('SD-LEO-FIX-UNOWNED-PARENT-SLICE-001: the surface is actually mounted',
  * KNOWN-OPEN AXIS — NTFS 8.3 SHORT NAMES DEFEAT BOTH RETIREMENTS. Do not delete these tests to
  * make the suite look better; they are the honest half of it.
  *
- * MEASURED, reproduced independently three times (two sub-agents plus a direct check), against
- * both this app and the running server on 127.0.0.1:3000:
+ * MEASURED, reproduced independently three times (two sub-agents plus a direct check). The two
+ * environments are listed SEPARATELY on purpose — an earlier draft presented one merged table
+ * "measured against both", which was false for its own first row, since this SD is not deployed
+ * and fleet-panel.html still returns 200 in production. That is the same generalise-across-
+ * environments error this file apologises for elsewhere, so it does not get to appear here.
  *
- *   GET /fleet-ui/fleet-panel.html   410     the canonical spelling
- *   GET /fleet-ui/FLEET-~1.HTM       200     THE SAME FILE, sha256-identical to the on-disk bytes
- *   GET /fleet-ui/SESSIO~1.HTM       200     ditto, for the ALREADY-SHIPPED session-view retirement
+ *   MEASURED IN PRODUCTION (127.0.0.1:3000, main) — proves the gap is LIVE, not theoretical:
+ *     GET /fleet-ui/session-view.html   410   the ALREADY-SHIPPED retirement
+ *     GET /fleet-ui/SESSIO~1.HTM        200   THE SAME FILE, sha256-identical to disk
+ *
+ *   MEASURED IN THIS APP (installFleetUiSurface at this commit):
+ *     GET /fleet-ui/fleet-panel.html    410   the canonical spelling
+ *     GET /fleet-ui/FLEET-~1.HTM        200   THE SAME FILE, sha256-identical to disk
+ *
+ * Every retired extension is affected, not just .HTM — .JS and .CSS alias identically, and
+ * SESSIO~2.JS exposes session-view.test.js, a test file living in a public static root.
  *
  * It is BROWSER-REACHABLE: the WHATWG URL parser leaves that pathname untouched, so a browser
  * sends it verbatim. No tooling required.
@@ -404,28 +414,73 @@ describe('KNOWN-OPEN: NTFS 8.3 aliases bypass the fence (asserted as OPEN, not a
     expect(isRetiredSessionView('/fleet-ui/SESSIO~1.HTM')).toBe(false);
   });
 
-  it('DOCUMENTS THE GAP: the 8.3 alias still serves the retired page (410 canonically, 200 aliased)', async () => {
-    // Guard first: on a volume with 8dot3 disabled the alias 404s and this axis is moot there.
-    // Skipping on 404 keeps the test honest rather than red for the wrong reason.
-    const aliased = await fetch(`${base}/fleet-ui/FLEET-~1.HTM`, { redirect: 'manual' });
-    if (aliased.status === 404) return;   // 8dot3 disabled on this volume — nothing to document
+  /**
+   * THE 8DOT3 PROBE — and why a bare 404 check was not one.
+   *
+   * v1 of this block did `if (alias.status === 404) return;`, which conflates two OPPOSITE
+   * states: "this volume has 8dot3 disabled, nothing to document" and "the alias is unresolvable
+   * BECAUSE SOMEONE FIXED IT". Measured consequence: of the three ways to close this gap, the
+   * block detected only the one the header argues AGAINST (teach the matcher the alias) and was
+   * blind to BOTH it recommends — allow-list the mount, or move retired files out of the root —
+   * each of which left it 53/53 green. And CI runs ubuntu-latest, where no 8.3 alias exists, so
+   * a bare `return` PASSED rather than skipped: in the tier that gates merges the honest half of
+   * this suite was three green tests executing no assertion. That is the vacuous-control shape
+   * the previous commit corrected, reproduced one level up.
+   *
+   * The discriminator is the CANARY'S OWN ALIAS. fleet-panel-format.js must stay live whatever
+   * the fix, so its alias answers "do 8.3 aliases resolve here at all?" independently of the
+   * retirement. Then:
+   *   canary alias 404  -> aliases unavailable (Linux CI, 8dot3 off). Genuinely skip, visibly.
+   *   canary 200, retired alias 200 -> the gap is still open. Assert it, by payload.
+   *   canary 200, retired alias 404/410 -> CLOSED. Go RED and say so.
+   * Nothing here hardcodes a single ~N spelling as the availability signal, which also survives
+   * 8.3 ordinals shifting on a fresh checkout.
+   */
+  const ALIAS_CANARY = '/fleet-ui/FLEET-~1.JS';        // -> fleet-panel-format.js, must stay live
+  const ALIASED_RETIRED = [
+    ['/fleet-ui/FLEET-~1.HTM', 'fleet-panel.html'],
+    ['/fleet-ui/FLEET-~1.CSS', 'fleet-panel.css'],
+    ['/fleet-ui/SESSIO~1.HTM', 'session-view.html'],
+    ['/fleet-ui/SESSIO~1.CSS', 'session-view.css'],
+  ];
 
-    const canonical = await fetch(`${base}/fleet-ui/fleet-panel.html`, { redirect: 'manual' });
-    expect(canonical.status).toBe(410);
-    expect(aliased.status).toBe(200);
+  async function aliasesResolveHere() {
+    return (await fetch(base + ALIAS_CANARY, { redirect: 'manual' })).status === 200;
+  }
 
-    // PAYLOAD, not proxy: a 200 alone could be an error page. Compare the bytes.
-    const served = crypto.createHash('sha256')
-      .update(Buffer.from(await aliased.arrayBuffer())).digest('hex');
-    const onDisk = crypto.createHash('sha256')
-      .update(fs.readFileSync(path.join(FLEET_UI_ROOT_FOR_HASH, 'fleet-panel.html'))).digest('hex');
-    expect(served).toBe(onDisk);
-  });
+  it.each(ALIASED_RETIRED)(
+    'DOCUMENTS THE GAP: %s still serves %s verbatim (RED when closed, skipped when 8.3 is off)',
+    async (aliasPath, realFile, ctx) => {
+      if (!(await aliasesResolveHere())) {
+        ctx.skip();   // visible as skipped, never a silent green
+        return;
+      }
+      const canonical = await fetch(`${base}/fleet-ui/${realFile}`, { redirect: 'manual' });
+      expect(canonical.status).toBe(410);
 
-  it('DOCUMENTS THE GAP: the bypass emits NO soak log line, so silence cannot mean unhit', async () => {
-    const aliased0 = await fetch(`${base}/fleet-ui/FLEET-~1.HTM`, { redirect: 'manual' });
-    if (aliased0.status === 404) return;
+      const aliased = await fetch(base + aliasPath, { redirect: 'manual' });
+      // Aliases DO resolve here, so a non-200 means the gap was CLOSED, not that 8.3 is absent.
+      // Failing loudly is the point: whoever closed it is told to restore the bounded claims.
+      expect(
+        aliased.status,
+        `8.3 aliases resolve on this volume but ${aliasPath} no longer serves. If you CLOSED this ` +
+        'gap: restore the universal claims in the file header and FORWARD_COVER, and delete this block.'
+      ).toBe(200);
 
+      // PAYLOAD, not proxy: a 200 alone could be an error page or a directory listing.
+      const served = crypto.createHash('sha256')
+        .update(Buffer.from(await aliased.arrayBuffer())).digest('hex');
+      const onDisk = crypto.createHash('sha256')
+        .update(fs.readFileSync(path.join(FLEET_UI_ROOT_FOR_HASH, realFile))).digest('hex');
+      expect(served).toBe(onDisk);
+    }
+  );
+
+  it('DOCUMENTS THE GAP: the bypass emits NO soak log line, so silence cannot mean unhit', async (ctx) => {
+    if (!(await aliasesResolveHere())) {
+      ctx.skip();
+      return;
+    }
     const seen = [];
     const spy = vi.spyOn(console, 'log').mockImplementation((...a) => seen.push(a.join(' ')));
     try {
@@ -433,8 +488,8 @@ describe('KNOWN-OPEN: NTFS 8.3 aliases bypass the fence (asserted as OPEN, not a
     } finally {
       spy.mockRestore();
     }
-    // This is the compounding failure: the soak's disposition is "silence is the evidence", and
-    // the one axis that defeats the fence is exactly the axis the instrument cannot see.
+    // The compounding failure: the soak's disposition is "silence is the evidence", and the one
+    // axis that defeats the fence is exactly the axis the instrument cannot see.
     expect(seen.join('\n')).not.toContain('[fleet-ui-410]');
   });
 });


### PR DESCRIPTION
## Summary

Retires the unauthenticated `/fleet-ui` panel page behind a file-scoped 410, and — the larger half — makes the fence **testable**.

The panel was served by plain `express.static` with no auth while every action it called is `requireAuth`, so all four buttons returned 401 for the page's entire life. Putting a credential in the page is forbidden: `requireAuth`'s only non-bearer option is a secret shared across ~15 route groups, so soliciting it into an unauthenticated page converts any origin XSS into an app-wide bypass. Removing the surface needs no credential.

**Nothing was ported first.** Three actions had no credentialed caller, but they are not unused capability — every live consumer imports `lib/fleet/spawn-control.js` **directly** (`canary-guard.js:25`, `session-watchdog.js:30`, `u4-drill-runner.js:26`). The orphan is the HTTP route, not the verb. Note the usage count alone proves nothing: no credentialed caller *could* exist while the only surface 401'd, so the decision rests on the direct-import evidence, and the re-open condition is recorded on the SD.

## The order is the security property

Both guards and the static mount are now installed by one `installFleetUiSurface()`. A 410 registered *after* `express.static` is shadowed, unreachable, and still reads as correct in review. While both registrations lived inline in `index.js`, nothing could assert the guard was even **mounted** — deleting the `app.use` line left every matcher test green while the retired page went back to being served, because `index.js` calls `startServer()` at import and cannot be imported by a test. Behind the seam the suite builds a real app and issues real requests, so ordering is **exercised**, not asserted.

## Two things the tests caught that reasoning did not

**The negative control was vacuous.** It asserted `/fleet-ui/vision.html` still returns 200. That file **does not exist** on this mount — it 404s either way, so it could never distinguish an intact fence from a mount-wide one. The claim came from a module comment and was propagated into the PRD without anyone listing the directory. The pass-through list is now derived from `readdirSync`, with a non-empty assertion so it cannot go vacuously green again.

**A sub-agent's "measured" bypass finding was wrong, and I amplified it.** I signalled a live percent-encoding bypass of the shipped session-view 410. There is none — QF-20260728-458 fixed it at 10:03, *before* the measurement. The agent had reconstructed the old `app.all(RE)` shape itself and measured its own reconstruction. Retracted with scope stated. The subtlety worth keeping: after that fix the regex is *deliberately weaker in isolation* (no `i` flag, no multi-slash class) because the strength moved into the normaliser — so testing that component against raw paths makes a correct fix look like a regression.

## Test plan

Falsification drill — the suite must go **red** under each breakage, or "tests pass" means nothing:

| # | Breakage | Result |
|---|----------|--------|
| 1 | Widen the regex (drop the literal dot) | **RED** — 4 failed / 45 passed |
| 2 | Delete the guard registration (unmounted) | **RED** — 6 failed / 43 passed |
| 3 | Register `express.static` before the guards | **RED** — 6 failed / 43 passed |
| 4 | Remove the percent-decode | **RED** — 11 failed / 38 passed |

Mutations 2 and 3 first reported `ANCHOR NOT FOUND` rather than passing — the file is CRLF and the anchors were written with `\n`. A mutation that fails to apply is indistinguishable from one the suite failed to catch, so the drill asserts anchor uniqueness before trusting a result.

- `tests/unit/server/` — 101 passed (6 files)
- `fleet-ui-410-scope.test.js` — 49 passed
- The `requireAuth` mount pin was independently falsified: flipping it to `optionalAuth` turns it red.

## Not claimed

**The unauthenticated surface is not gone.** `GET /api/fleet-panel` is `optionalAuth` (`server/index.js:293`) and still serves the full manifest, accountChips and attentionStrip anonymously. The page was the proxy; the endpoint is the payload. Containment is the loopback bind, the CORS allowlist and CSP `scriptSrc: 'self'` — none of which this change touches or may take credit for. Routed to the durable feedback channel, along with the fact that the bound on the dormant process-spawning routes is the *absence of a public signup surface* — an incidental property, not a control.

`fleet-panel-format.js` stays servable on purpose: it is the canary for a dot-dropped matcher, and drill mutation 1 fails through it.

**Size:** 292 insertions / 39 deletions, above the 100 LOC target. The bulk is the test suite (139) and the reasoning comments; the behavioural harness and the drill are the substance of this SD rather than incidental to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
