### PR TITLE
feat(SD-LEO-INFRA-PURE-GUARD-UNWIRED-001): a guard that cannot see its subject returns the permissive answer

### DIFF
--- a/lib/adam/rationale-bar.js
+++ b/lib/adam/rationale-bar.js
@@ -281,14 +281,27 @@ export function waveAlignmentTerm(candidate, waveAlignment) {
 export function capabilityGapTerm(candidate, capabilityGap) {
   const gaps = capabilityGap && capabilityGap.gaps;
   const cap = candidate && candidate.capability;
-  if (!gaps || !cap || !Object.prototype.hasOwnProperty.call(gaps, cap)) {
-    return { active: false, multiplier: 1.0, buildPct: null };
+  // SD-LEO-INFRA-PURE-GUARD-UNWIRED-001 FR-4 (AC-4): SAY WHY IT IS INACTIVE, like the sibling term
+  // twenty lines up. Without this, the three no-data branches below were indistinguishable from
+  // "evaluated and found no gap" — and the distinction matters most here, because `capability` is
+  // never set by ANY producer, so this term has been permanently inactive for a reason no reader
+  // could see. The sibling has said why since SD-LEO-INFRA-ADAM-WORK-SELECTION-001; this one did
+  // not, in the same file.
+  if (!gaps) {
+    return { active: false, multiplier: 1.0, buildPct: null, inactive_reason: 'no_gaps_supplied' };
+  }
+  if (!cap) {
+    // The live case: no producer sets candidate.capability, so this fires on every candidate.
+    return { active: false, multiplier: 1.0, buildPct: null, inactive_reason: 'candidate_has_no_capability' };
+  }
+  if (!Object.prototype.hasOwnProperty.call(gaps, cap)) {
+    return { active: false, multiplier: 1.0, buildPct: null, inactive_reason: 'capability_absent_from_gap_map' };
   }
   // Defense-in-depth: require a real number. Number(null|''|false) all coerce to 0 (a phantom
   // max-boost); reject non-numbers so a malformed caller map can never invent a 0% gap.
   const buildPct = gaps[cap];
   if (typeof buildPct !== 'number' || !Number.isFinite(buildPct)) {
-    return { active: false, multiplier: 1.0, buildPct: null };
+    return { active: false, multiplier: 1.0, buildPct: null, inactive_reason: 'gap_value_not_a_number' };
   }
   // Lower build% => higher multiplier (bounded by CLAMP_HI). Linear: 100%->1.0, 0%->CLAMP_HI.
   const frac = Math.max(0, Math.min(1, 1 - buildPct / 100));

--- a/lib/adam/rationale-bar.js
+++ b/lib/adam/rationale-bar.js
@@ -18,6 +18,11 @@ import {
   getKRStatusMultipliers,
 } from '../eva/okr-priority-integrator.js';
 import { clamp, CLAMP_HI, candidatePreferenceClass } from './preference-model.js';
+// SD-LEO-INFRA-PURE-GUARD-UNWIRED-001 FR-4. Both terms below already NAMED their inactive reason
+// and nothing read it, which is why FR-4 was demoted to last: an emit with no behavioural consumer
+// changes no one's detectability. These two imports are that consumer, on the production path.
+import { foldTermResults } from '../governance/inactive-reason-consumer.js';
+import { assessGuards } from '../governance/guard-sustained-zero.js';
 
 /**
  * CARDINAL INVARIANT (the whole point of this SD): a preference/Q2 weight must
@@ -411,9 +416,30 @@ export function selectAdvisory(candidates, opts = {}) {
     const e = evaluateCandidate(c, opts);
     return { candidate: c, ...e };
   });
+
+  // FR-4: one bucket per self-gating term, filled as the terms actually run below.
+  const termObservations = { waveAlignmentTerm: [], capabilityGapTerm: [] };
+  /**
+   * Fold what the terms DID this pass into an operator-readable health line.
+   *
+   * This is the consumer FR-4 requires, and the loop is what makes it one: it reads each term's
+   * `inactive_reason` and names the absent input, so a pass where every term self-gated reports
+   * WHICH data never arrived instead of reporting nothing at all. The `cleared === 0` path calls it
+   * too, and that is the case that matters most — the ledger recorded 21 consecutive
+   * `ADAM_OK cleared=0` while waveAlignmentTerm was failing closed on an empty linkage table, and
+   * the two were indistinguishable from outside. Now they are not.
+   */
+  const guardHealth = () => assessGuards(
+    Object.entries(termObservations).map(([name, results]) => foldTermResults(name, results)),
+    'this advisory pass',
+  );
+
   const cleared = evaluated.filter((x) => x.clears);
   if (cleared.length === 0) {
-    return { surfaced: null, verdict: 'ADAM_OK', cleared: 0, evaluated, trace: [] };
+    // The terms never ran, so the fold reports OBSERVED-0 / UNKNOWN rather than health — the
+    // distinction between "nothing cleared the bar" and "the terms could not judge" is the whole
+    // point, and collapsing it is what hid instance 3 for 21 passes.
+    return { surfaced: null, verdict: 'ADAM_OK', cleared: 0, evaluated, trace: [], guard_health: guardHealth() };
   }
 
   // Annotate each cleared candidate with its status tier, bounded weight + effective score.
@@ -422,6 +448,11 @@ export function selectAdvisory(candidates, opts = {}) {
     const prefW = clamp(prefWeights[cls] ?? 1.0); // bounded; missing -> identity 1.0
     const wave = waveAlignmentTerm(x.candidate, opts.waveAlignment); // 1.0 when inactive
     const capGap = capabilityGapTerm(x.candidate, opts.capabilityGap); // FR-2: 1.0 when inactive
+    // FR-4: record what each term actually did, INCLUDING its inactive_reason. The scoring path
+    // below reads only `.multiplier` and drops the reason on the next line — which is precisely how
+    // a correct emit stayed unread.
+    termObservations.waveAlignmentTerm.push(wave);
+    termObservations.capabilityGapTerm.push(capGap);
     x._class = cls;
     x._prefW = prefW;
     x._waveMul = wave.multiplier;
@@ -473,6 +504,7 @@ export function selectAdvisory(candidates, opts = {}) {
     cleared: cleared.length,
     evaluated,
     trace,
+    guard_health: guardHealth(),
   };
 }
 

--- a/lib/adam/rationale-bar.js
+++ b/lib/adam/rationale-bar.js
@@ -362,7 +362,12 @@ export function evaluateCandidate(candidate, opts = {}) {
   const waveUnaligned = wave.active && q1Pass && wave.aligned === false && !urgent;
   if (waveUnaligned) reasons.push('Q2 wave-unaligned (routed to backlog)');
 
-  return { clears: reasons.length === 0, score, reasons, waveUnaligned };
+  // FR-4: hand the term's own verdict back, INCLUDING its inactive_reason. This is where the wave
+  // term actually runs — once per candidate, cleared or not — so it is the only place that sees the
+  // full population. Collecting it in selectAdvisory instead would have observed only the CLEARED
+  // candidates, and in the 21-pass instance NOTHING cleared: the observation set would have been
+  // empty in exactly the case the alarm exists to explain.
+  return { clears: reasons.length === 0, score, reasons, waveUnaligned, waveTerm: wave };
 }
 
 /**
@@ -417,8 +422,13 @@ export function selectAdvisory(candidates, opts = {}) {
     return { candidate: c, ...e };
   });
 
-  // FR-4: one bucket per self-gating term, filled as the terms actually run below.
-  const termObservations = { waveAlignmentTerm: [], capabilityGapTerm: [] };
+  // FR-4: one bucket per self-gating term. The wave term already ran once per candidate inside
+  // evaluateCandidate — including for candidates it ROUTED TO BACKLOG, which is the whole population
+  // in the instance this exists to expose.
+  const termObservations = {
+    waveAlignmentTerm: evaluated.map((x) => x.waveTerm).filter(Boolean),
+    capabilityGapTerm: [],
+  };
   /**
    * Fold what the terms DID this pass into an operator-readable health line.
    *
@@ -448,10 +458,10 @@ export function selectAdvisory(candidates, opts = {}) {
     const prefW = clamp(prefWeights[cls] ?? 1.0); // bounded; missing -> identity 1.0
     const wave = waveAlignmentTerm(x.candidate, opts.waveAlignment); // 1.0 when inactive
     const capGap = capabilityGapTerm(x.candidate, opts.capabilityGap); // FR-2: 1.0 when inactive
-    // FR-4: record what each term actually did, INCLUDING its inactive_reason. The scoring path
+    // FR-4: record what the term actually did, INCLUDING its inactive_reason. The scoring path
     // below reads only `.multiplier` and drops the reason on the next line — which is precisely how
-    // a correct emit stayed unread.
-    termObservations.waveAlignmentTerm.push(wave);
+    // a correct emit stayed unread. (The wave term is collected above, from evaluateCandidate,
+    // because it runs for every candidate rather than only the cleared ones.)
     termObservations.capabilityGapTerm.push(capGap);
     x._class = cls;
     x._prefW = prefW;

--- a/lib/governance/guard-sustained-zero.js
+++ b/lib/governance/guard-sustained-zero.js
@@ -1,0 +1,122 @@
+/**
+ * The sustained-zero alarm: A GATE THAT HAS NEVER BLOCKED ANYTHING IS NOT A PASSING GATE,
+ * IT IS AN UNPLUGGED ONE.
+ * SD-LEO-INFRA-PURE-GUARD-UNWIRED-001 FR-2 — the load-bearing deliverable.
+ *
+ * WHY FR-1 IS NOT ENOUGH. The wiring test answers "does a caller supply the input". Two live
+ * instances slip straight past it because they are wired AND supplied AND still inert:
+ *   - a predicate that was wired, was fed data, and was ITSELF broken — a shell-mangled regex that
+ *     compiled to a backspace character. It reported 0/3 for 27 consecutive passes across a window
+ *     in which the underlying state demonstrably changed. Nothing was missing; the answer was.
+ *   - waveAlignmentTerm, wired and supplied, but 0 of 261 roadmap_wave_items carry the linkage it
+ *     reads, so it silently fails CLOSED.
+ * Neither is visible to a static check. Only the RECORD OF WHAT THE GUARD ACTUALLY DID over time
+ * separates "evaluated and passed, repeatedly" from "never evaluated anything".
+ *
+ * THREE STATES, NOT TWO — and this is the design constraint the FR itself names as its known
+ * failure mode. A sustained-zero alarm that cannot SEE the blocking events reports diligence as
+ * neglect: a guard nobody observed and a guard that observed nothing both present as zero, and
+ * flagging both manufactures false alarms that get muted, which recreates the silence it exists to
+ * break. So:
+ *   HEALTHY   — blocked at least once in the window. It demonstrably can.
+ *   SUSPECT   — OBSERVED, and blocked zero times. This is the alarm.
+ *   UNKNOWN   — no observations at all. NOT an alarm and NOT health: we cannot tell.
+ *
+ * The count is emitted UNCONDITIONALLY, including zero — reusing the shape of
+ * lib/coordinator/worker-signal-starvation.cjs, whose docblock records why: a counter that appears
+ * only when non-zero renders measured-and-empty identically to not-measured, which is the same
+ * family of defect one level up.
+ *
+ * Pure: no DB, no clock, no fs. Observations are injected so the judgment is testable without a
+ * live corpus — and so a caller cannot accidentally make it score an empty read as health.
+ */
+'use strict';
+
+export const GUARD_HEALTH = Object.freeze({
+  HEALTHY: 'healthy',
+  SUSPECT: 'suspect',
+  UNKNOWN: 'unknown',
+});
+
+/**
+ * Classify one guard from its observation record over a window.
+ *
+ * @param {object} record
+ * @param {string} record.guard                 guard name
+ * @param {number|null} record.observations     times the guard RAN in the window (null = unmeasured)
+ * @param {number|null} record.blocked          times it took its BLOCKING branch (null = unmeasured)
+ * @param {number} [record.permissiveNoData]    times it took the no-data permissive branch
+ * @param {string|null} [record.missingInput]   which input was absent on that branch (AC-4)
+ * @param {string} windowLabel                  human-readable window, e.g. '7d'
+ */
+export function classifyGuard(record = {}, windowLabel = 'window') {
+  const guard = record.guard || '(unnamed)';
+  const observations = numOrNull(record.observations);
+  const blocked = numOrNull(record.blocked);
+
+  // UNKNOWN FIRST. Deciding health before establishing that anything was observed is precisely how
+  // a gauge reports diligence as neglect — or worse, reports an unobserved guard as healthy.
+  if (observations === null || blocked === null || observations === 0) {
+    return {
+      guard,
+      state: GUARD_HEALTH.UNKNOWN,
+      observations: observations ?? 0,
+      blocked: blocked ?? 0,
+      window: windowLabel,
+      missingInput: record.missingInput ?? null,
+      detail: observations === 0
+        ? `${guard}: OBSERVED 0 times in ${windowLabel} — the guard did not run, so nothing can be concluded about it (this is NOT health)`
+        : `${guard}: NOT MEASURED in ${windowLabel} — no observation record exists (this is NOT health)`,
+    };
+  }
+
+  if (blocked > 0) {
+    return {
+      guard,
+      state: GUARD_HEALTH.HEALTHY,
+      observations,
+      blocked,
+      window: windowLabel,
+      missingInput: record.missingInput ?? null,
+      detail: `${guard}: blocked ${blocked}/${observations} in ${windowLabel} — demonstrably able to block`,
+    };
+  }
+
+  // Observed, ran, never blocked. The alarm.
+  const missing = record.missingInput ? ` Missing input on the permissive branch: '${record.missingInput}'.` : '';
+  const noData = Number.isFinite(record.permissiveNoData) ? ` no-data branch taken ${record.permissiveNoData}x.` : '';
+  return {
+    guard,
+    state: GUARD_HEALTH.SUSPECT,
+    observations,
+    blocked: 0,
+    window: windowLabel,
+    missingInput: record.missingInput ?? null,
+    detail: `${guard}: SUSPECT — ran ${observations}x in ${windowLabel} and blocked 0 times. `
+      + `A gate that has never blocked anything is not a passing gate, it is an unplugged one.${noData}${missing}`,
+  };
+}
+
+function numOrNull(v) {
+  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+}
+
+/**
+ * Classify a whole population and render a report line per guard.
+ * Every guard appears in the output — including the zero ones. Omitting a zero is how the count
+ * that "appears only when non-zero" reproduces the ambiguity this module exists to remove.
+ */
+export function assessGuards(records = [], windowLabel = 'window') {
+  const results = (Array.isArray(records) ? records : []).map((r) => classifyGuard(r, windowLabel));
+  const by = (s) => results.filter((r) => r.state === s);
+  return {
+    window: windowLabel,
+    results,
+    suspect: by(GUARD_HEALTH.SUSPECT),
+    unknown: by(GUARD_HEALTH.UNKNOWN),
+    healthy: by(GUARD_HEALTH.HEALTHY),
+    // Unconditional counts, zeros included — see the module docblock.
+    summary: `GUARD SUSTAINED-ZERO (${windowLabel}): healthy=${by(GUARD_HEALTH.HEALTHY).length} `
+      + `suspect=${by(GUARD_HEALTH.SUSPECT).length} unknown=${by(GUARD_HEALTH.UNKNOWN).length}`,
+  };
+}

--- a/lib/governance/guard-sustained-zero.js
+++ b/lib/governance/guard-sustained-zero.js
@@ -54,7 +54,14 @@ export const GUARD_HEALTH = Object.freeze({
  * @param {string|null} [record.missingInput]   which input was absent on that branch (AC-4)
  * @param {string} windowLabel                  human-readable window, e.g. '7d'
  */
-export function classifyGuard(record = {}, windowLabel = 'window') {
+export function classifyGuard(recordArg = {}, windowLabelArg = 'window') {
+  const record = recordArg;
+  // windowLabel is interpolated into `detail` and into the summary that reaches the durable ledger,
+  // and it was the ONE interpolation left unsanitised and unbounded — a newline injects a fabricated
+  // "demonstrably able to block" line, and a 5000-character label defeats the per-row size bound
+  // that holds everywhere else. Production passes the literal 'this advisory pass'; that is a reason
+  // it has not bitten, not a reason it cannot.
+  const windowLabel = safeLabel(windowLabelArg) || 'window';
   const guard = safeLabel(own(record, 'guard')) || '(unnamed)';
   const observations = numOrNull(own(record, 'observations'));
   const blocked = numOrNull(own(record, 'blocked'));
@@ -64,7 +71,7 @@ export function classifyGuard(record = {}, windowLabel = 'window') {
 
   // UNKNOWN FIRST. Deciding health before establishing that anything was observed is precisely how
   // a gauge reports diligence as neglect — or worse, reports an unobserved guard as healthy.
-  if (observations === null || blocked === null || observations === 0) {
+  if (observations === null || blocked === null || observations === 0 || !coherent(observations, blocked)) {
     return {
       guard,
       state: GUARD_HEALTH.UNKNOWN,
@@ -142,10 +149,17 @@ const own = (o, k) => {
 /**
  * A NEGATIVE count is not a small count. `{observations: -5, blocked: 3}` is incoherent, and
  * reading it as HEALTHY would let a malformed feed manufacture the one verdict that ends enquiry.
- * Unmeasured is the only safe reading of nonsense.
+ * Unmeasured is the only safe reading of nonsense — and counts are integers, so a fractional
+ * `blocked` of 1e-323 was rounding up to "it demonstrably blocked" on a value that is not a count
+ * at all. Every one of these degrades toward UNKNOWN, never toward health.
  */
 function numOrNull(v) {
-  return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? v : null;
+  return Number.isInteger(v) && v >= 0 ? v : null;
+}
+
+/** More blocks than observations is not a strong signal, it is a broken feed. */
+function coherent(observations, blocked) {
+  return observations !== null && blocked !== null && blocked <= observations;
 }
 
 /**

--- a/lib/governance/guard-sustained-zero.js
+++ b/lib/governance/guard-sustained-zero.js
@@ -36,6 +36,11 @@ export const GUARD_HEALTH = Object.freeze({
   HEALTHY: 'healthy',
   SUSPECT: 'suspect',
   UNKNOWN: 'unknown',
+  // FR-3 pairing (AC-4): a sustained zero from a predicate PROVEN unable to produce its blocking
+  // verdict is not the same finding as a sustained zero from one that simply had nothing to block.
+  // The first is broken; the second may be a quiet week. Reporting both as SUSPECT would send an
+  // operator hunting for a cause in the wrong half of the cases, which is how an alarm loses trust.
+  INERT: 'inert',
 });
 
 /**
@@ -82,9 +87,27 @@ export function classifyGuard(record = {}, windowLabel = 'window') {
     };
   }
 
-  // Observed, ran, never blocked. The alarm.
+  // Observed, ran, never blocked. The alarm — but WHICH alarm depends on FR-3.
   const missing = record.missingInput ? ` Missing input on the permissive branch: '${record.missingInput}'.` : '';
   const noData = Number.isFinite(record.permissiveNoData) ? ` no-data branch taken ${record.permissiveNoData}x.` : '';
+
+  // AC-4: if a self-test has PROVEN the predicate cannot produce its blocking verdict, the zero is
+  // explained — the guard is inert, not quiet. Saying so turns "go investigate why this never
+  // fired" into "this cannot fire; fix the predicate", which is a different and much shorter job.
+  if (record.selfTest && record.selfTest.capable === false) {
+    return {
+      guard,
+      state: GUARD_HEALTH.INERT,
+      observations,
+      blocked: 0,
+      window: windowLabel,
+      missingInput: record.missingInput ?? null,
+      detail: `${guard}: INERT — ran ${observations}x in ${windowLabel}, blocked 0 times, AND its self-test `
+        + `shows it cannot produce its blocking verdict (${record.selfTest.missingVerdict ?? 'unknown'}). `
+        + `The zero is explained: this guard could not have blocked.${noData}${missing}`,
+    };
+  }
+
   return {
     guard,
     state: GUARD_HEALTH.SUSPECT,
@@ -115,8 +138,10 @@ export function assessGuards(records = [], windowLabel = 'window') {
     suspect: by(GUARD_HEALTH.SUSPECT),
     unknown: by(GUARD_HEALTH.UNKNOWN),
     healthy: by(GUARD_HEALTH.HEALTHY),
+    inert: by(GUARD_HEALTH.INERT),
     // Unconditional counts, zeros included — see the module docblock.
     summary: `GUARD SUSTAINED-ZERO (${windowLabel}): healthy=${by(GUARD_HEALTH.HEALTHY).length} `
-      + `suspect=${by(GUARD_HEALTH.SUSPECT).length} unknown=${by(GUARD_HEALTH.UNKNOWN).length}`,
+      + `suspect=${by(GUARD_HEALTH.SUSPECT).length} inert=${by(GUARD_HEALTH.INERT).length} `
+      + `unknown=${by(GUARD_HEALTH.UNKNOWN).length}`,
   };
 }

--- a/lib/governance/guard-sustained-zero.js
+++ b/lib/governance/guard-sustained-zero.js
@@ -55,9 +55,12 @@ export const GUARD_HEALTH = Object.freeze({
  * @param {string} windowLabel                  human-readable window, e.g. '7d'
  */
 export function classifyGuard(record = {}, windowLabel = 'window') {
-  const guard = record.guard || '(unnamed)';
-  const observations = numOrNull(record.observations);
-  const blocked = numOrNull(record.blocked);
+  const guard = safeLabel(own(record, 'guard')) || '(unnamed)';
+  const observations = numOrNull(own(record, 'observations'));
+  const blocked = numOrNull(own(record, 'blocked'));
+  const missingInput = safeLabel(own(record, 'missingInput')) || null;
+  const selfTest = own(record, 'selfTest');
+  const permissiveNoData = own(record, 'permissiveNoData');
 
   // UNKNOWN FIRST. Deciding health before establishing that anything was observed is precisely how
   // a gauge reports diligence as neglect — or worse, reports an unobserved guard as healthy.
@@ -68,7 +71,7 @@ export function classifyGuard(record = {}, windowLabel = 'window') {
       observations: observations ?? 0,
       blocked: blocked ?? 0,
       window: windowLabel,
-      missingInput: record.missingInput ?? null,
+      missingInput,
       detail: observations === 0
         ? `${guard}: OBSERVED 0 times in ${windowLabel} — the guard did not run, so nothing can be concluded about it (this is NOT health)`
         : `${guard}: NOT MEASURED in ${windowLabel} — no observation record exists (this is NOT health)`,
@@ -82,28 +85,28 @@ export function classifyGuard(record = {}, windowLabel = 'window') {
       observations,
       blocked,
       window: windowLabel,
-      missingInput: record.missingInput ?? null,
+      missingInput,
       detail: `${guard}: blocked ${blocked}/${observations} in ${windowLabel} — demonstrably able to block`,
     };
   }
 
   // Observed, ran, never blocked. The alarm — but WHICH alarm depends on FR-3.
-  const missing = record.missingInput ? ` Missing input on the permissive branch: '${record.missingInput}'.` : '';
-  const noData = Number.isFinite(record.permissiveNoData) ? ` no-data branch taken ${record.permissiveNoData}x.` : '';
+  const missing = missingInput ? ` Missing input on the permissive branch: '${missingInput}'.` : '';
+  const noData = Number.isFinite(permissiveNoData) ? ` no-data branch taken ${permissiveNoData}x.` : '';
 
   // AC-4: if a self-test has PROVEN the predicate cannot produce its blocking verdict, the zero is
   // explained — the guard is inert, not quiet. Saying so turns "go investigate why this never
   // fired" into "this cannot fire; fix the predicate", which is a different and much shorter job.
-  if (record.selfTest && record.selfTest.capable === false) {
+  if (own(selfTest, 'capable') === false) {
     return {
       guard,
       state: GUARD_HEALTH.INERT,
       observations,
       blocked: 0,
       window: windowLabel,
-      missingInput: record.missingInput ?? null,
+      missingInput,
       detail: `${guard}: INERT — ran ${observations}x in ${windowLabel}, blocked 0 times, AND its self-test `
-        + `shows it cannot produce its blocking verdict (${record.selfTest.missingVerdict ?? 'unknown'}). `
+        + `shows it cannot produce its blocking verdict (${safeLabel(own(selfTest, 'missingVerdict')) || 'unknown'}). `
         + `The zero is explained: this guard could not have blocked.${noData}${missing}`,
     };
   }
@@ -114,14 +117,52 @@ export function classifyGuard(record = {}, windowLabel = 'window') {
     observations,
     blocked: 0,
     window: windowLabel,
-    missingInput: record.missingInput ?? null,
+    missingInput,
     detail: `${guard}: SUSPECT — ran ${observations}x in ${windowLabel} and blocked 0 times. `
       + `A gate that has never blocked anything is not a passing gate, it is an unplugged one.${noData}${missing}`,
   };
 }
 
+/**
+ * Own-property read. Every field above comes from a caller-supplied record, and an INHERITED
+ * property reads identically to a supplied one — so `Object.prototype.observations = 40` plus
+ * `Object.prototype.blocked = 3` makes classifyGuard report a guard nobody ever observed as
+ * "blocked 3/40 — demonstrably able to block". The forged direction is always HEALTHY, i.e. the
+ * permissive answer, which is precisely what this module exists to make impossible to fake.
+ */
+const own = (o, k) => {
+  // The read is wrapped because a throwing getter would escape a function documented as total.
+  try {
+    return o != null && typeof o === 'object' && Object.hasOwn(o, k) ? o[k] : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * A NEGATIVE count is not a small count. `{observations: -5, blocked: 3}` is incoherent, and
+ * reading it as HEALTHY would let a malformed feed manufacture the one verdict that ends enquiry.
+ * Unmeasured is the only safe reading of nonsense.
+ */
 function numOrNull(v) {
-  return typeof v === 'number' && Number.isFinite(v) ? v : null;
+  return typeof v === 'number' && Number.isFinite(v) && v >= 0 ? v : null;
+}
+
+/**
+ * `detail` is the operator-facing sentence, and `guard`/`missingInput` are interpolated into it.
+ * A newline in a guard name injects a whole fabricated line — "…demonstrably able to block" —
+ * into a report a human reads to decide whether to investigate. Collapse control characters and
+ * bound the length so a record can describe itself but never author the surrounding narrative.
+ */
+function safeLabel(v) {
+  if (typeof v !== 'string') return '';
+  // Explicit \u escapes, NOT raw control bytes. This SD's founding instance was a regex whose
+  // intended \b became a literal BACKSPACE; typing a control-character class as literal bytes is
+  // the same trap one level out — it survives review and silently matches the wrong range. My
+  // first attempt at this line did exactly that: the bytes landed raw and git reported the file
+  // as binary.
+  const flat = v.replace(/[\u0000-\u001F\u007F]+/g, ' ').trim();
+  return flat.length > 120 ? `${flat.slice(0, 117)}...` : flat;
 }
 
 /**

--- a/lib/governance/guard-wiring-registry.js
+++ b/lib/governance/guard-wiring-registry.js
@@ -28,22 +28,46 @@
  * function by name, and they are what made enforceSweepBudget look wired for months.
  */
 export const NON_PRODUCTION_PATTERNS = Object.freeze([
-  /\.test\.(?:js|cjs|mjs|ts)$/i,        // tests
-  /[\\/]tests?[\\/]/i,                   // test trees
+  /\.test\.(?:js|cjs|mjs|ts|tsx|mts|cts)$/i,   // tests
+  /\.spec\.(?:js|cjs|mjs|ts|tsx|mts|cts)$/i,   // …under either naming convention
+  /[\\/]tests?[\\/]/i,                          // test trees
   /[\\/]__tests__[\\/]/i,
-  /\.md$/i,                              // docs
+  /[\\/]__mocks__[\\/]/i,
+  /[\\/]test-helpers?[\\/]/i,                   // harness code that MENTIONS guards but never gates
+  /[\\/]testing[\\/]/i,
+  /[\\/]mocks?[\\/]/i,
+  /[\\/]fixtures?[\\/]/i,
+  /\.md$/i,                                     // docs
   /[\\/]docs[\\/]/i,
-  /[\\/]\.claude[\\/]/i,                 // skills / commands / prompts
+  /[\\/]\.claude[\\/]/i,                        // skills / commands / prompts
   /[\\/]archive[\\/]/i,
   /[\\/]_deprecated[\\/]/i,
   /[\\/]node_modules[\\/]/i,
 ]);
 
-/** A reference only counts as wiring if it lives in executable production code. */
+/**
+ * A reference only counts as wiring if it lives in executable production code.
+ *
+ * BOTH DIRECTIONS OF ERROR MATTER, which is why the exclusion list above grew: a false NEGATIVE
+ * hides a guard's only real caller and reports a wired guard as unwired, while a false POSITIVE
+ * counts a mock or fixture as wiring and reports an unwired guard as healthy. The second is the
+ * permissive direction and 111 files in this tree hit it before these patterns were added
+ * (lib/mock, lib/test-helpers, lib/testing, and any nested fixtures directory) — all of them files
+ * whose entire job is to MENTION production functions.
+ *
+ * KNOWN LIMIT, stated rather than papered over: this is a path-level judgment and the call-site
+ * scan that consumes it is text-level, so neither can tell a call inside a STRING LITERAL from a
+ * real one. scripts/solomon-startup-check.mjs — the SD's own motivating example — is a production
+ * file whose reference is a prompt string, and it is excluded here only because that prompt happens
+ * not to also contain the gated input. suppliesGatedInput is what carries that case, and a prompt
+ * that quoted a full call would defeat both. Closing it needs a parser, not another regex.
+ */
 export function isProductionCallSite(filePath) {
   const p = String(filePath || '');
   if (!p) return false;
-  if (!/\.(?:js|cjs|mjs)$/i.test(p)) return false;   // a prompt string in a .md can never be a caller
+  // TypeScript is production too — omitting it made 25 files in this tree invisible to the scan,
+  // and invisible resolves to "no caller found", which is the permissive answer.
+  if (!/\.(?:js|cjs|mjs|ts|tsx|mts|cts)$/i.test(p)) return false;  // a prompt string in a .md can never be a caller
   return !NON_PRODUCTION_PATTERNS.some((re) => re.test(p));
 }
 
@@ -62,8 +86,22 @@ export function suppliesGatedInput(callText, gatedInput) {
   if (!callText || !gatedInput) return false;
   if (isStubbedInput(callText, gatedInput)) return false;   // supplied-but-inert is not wired
   // Match `spent`, `spent:`, `spent =`, `...spent`, or a shorthand inside an object literal.
-  const re = new RegExp(`(^|[^\\w.])${gatedInput}\\s*(?::|,|\\}|\\)|=[^=])`, 'm');
+  const re = new RegExp(`(^|[^\\w.])${escapeForRegExp(gatedInput)}\\s*(?::|,|\\}|\\)|=[^=])`, 'm');
   return re.test(callText);
+}
+
+/**
+ * The gated input is DATA interpolated into a pattern, so it must be escaped as data.
+ *
+ * Unescaped, a registry entry with `gatedInput: '.*'` reports EVERY call site as supplying it —
+ * `suppliesGatedInput('enforceSweepBudget({}) // no data at all', '.*')` returned true — which
+ * turns the whole registry green with one plausible-looking typo. `'('` threw a SyntaxError, and a
+ * pathological value backtracked exponentially (n=26 took 487ms, and an unbounded probe never
+ * returned). All three failures land on "this guard looks wired", which is the answer that ends
+ * enquiry.
+ */
+function escapeForRegExp(s) {
+  return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
 /**
@@ -85,7 +123,7 @@ export function isStubbedInput(callText, gatedInput) {
   if (!callText || !gatedInput) return false;
   // `getForecast: () => undefined`, `: () => null`, `: () => false`, `: () => ({})`, `: null`
   const stub = new RegExp(
-    `(^|[^\\w.])${gatedInput}\\s*:\\s*(?:` +
+    `(^|[^\\w.])${escapeForRegExp(gatedInput)}\\s*:\\s*(?:` +
     '\\(\\s*\\)\\s*=>\\s*(?:undefined|null|false|\\{\\s*\\}|\\(\\s*\\{\\s*\\}\\s*\\)|\\[\\s*\\])' +
     '|undefined|null' +
     ')',
@@ -103,7 +141,26 @@ export function isStubbedInput(callText, gatedInput) {
  * which is how a loud signal becomes a quiet one. Removing an entry from the unwired set and
  * watching the test go red is the proof that it bites.
  */
-export const GUARD_REGISTRY = Object.freeze([
+export const GUARD_REGISTRY = deepFreeze([
+  {
+    // THE ONE WIRED ENTRY, and it is load-bearing for the test rather than decorative. With all six
+    // entries below marked expectedWired:false, the "baseline must never grow" test `continue`d on
+    // every single one and never called the corpus scanner at all — replacing the scanner's body
+    // with `return []` left the whole suite green. A wiring test that no source change can redden
+    // is exactly the unfireable guard this SD is about, so the fix was to actually wire one: FR-4's
+    // consumer is called from selectAdvisory, this entry asserts it, and gutting the scanner now
+    // fails here first.
+    name: 'foldTermResults',
+    module: 'lib/governance/inactive-reason-consumer.js',
+    definedAt: 'lib/governance/inactive-reason-consumer.js:113',
+    gatedInput: 'results',
+    permissiveMeans: 'observations:0 — the term batch is unread, so FR-2 reports UNKNOWN rather than naming the missing input',
+    expectedWired: true,
+    note: 'FR-4\'s named consumer. Wired at lib/adam/rationale-bar.js in selectAdvisory, which is '
+      + 'reached in production from scripts/adam-opportunity-scan.cjs:266. Before that wiring it was '
+      + 'imported by nothing but its own test — the emit-with-no-consumer this FR exists to reject, '
+      + 'reproduced one indirection deeper inside the FR\'s own deliverable.',
+  },
   {
     name: 'enforceSweepBudget',
     module: 'scripts/solomon-advisory.cjs',
@@ -166,6 +223,24 @@ export const GUARD_REGISTRY = Object.freeze([
       + 'The caller is wired; the data is not.',
   },
 ]);
+
+/**
+ * Object.freeze is SHALLOW, so freezing the array left every entry writable: setting
+ * `GUARD_REGISTRY[0].expectedWired = true` silently shrank the known-unwired baseline, and setting
+ * `gatedInput = '.*'` produced a false WIRED verdict. This registry is the baseline the wiring test
+ * compares against — if it can be edited at runtime, the comparison is against whatever the last
+ * writer wanted it to say.
+ */
+function deepFreeze(value) {
+  if (value && (typeof value === 'object' || typeof value === 'function') && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const key of Reflect.ownKeys(value)) {
+      const desc = Object.getOwnPropertyDescriptor(value, key);
+      if (desc && 'value' in desc) deepFreeze(desc.value);
+    }
+  }
+  return value;
+}
 
 /** Guards currently known to be unwired — the baseline that may shrink and must never grow. */
 export function knownUnwired(registry = GUARD_REGISTRY) {

--- a/lib/governance/guard-wiring-registry.js
+++ b/lib/governance/guard-wiring-registry.js
@@ -143,28 +143,9 @@ export function isStubbedInput(callText, gatedInput) {
  */
 export const GUARD_REGISTRY = deepFreeze([
   {
-    // THE ONE WIRED ENTRY, and it is load-bearing for the test rather than decorative. With all six
-    // entries below marked expectedWired:false, the "baseline must never grow" test `continue`d on
-    // every single one and never called the corpus scanner at all — replacing the scanner's body
-    // with `return []` left the whole suite green. A wiring test that no source change can redden
-    // is exactly the unfireable guard this SD is about, so the fix was to actually wire one: FR-4's
-    // consumer is called from selectAdvisory, this entry asserts it, and gutting the scanner now
-    // fails here first.
-    name: 'foldTermResults',
-    module: 'lib/governance/inactive-reason-consumer.js',
-    definedAt: 'lib/governance/inactive-reason-consumer.js:113',
-    gatedInput: 'results',
-    permissiveMeans: 'observations:0 — the term batch is unread, so FR-2 reports UNKNOWN rather than naming the missing input',
-    expectedWired: true,
-    note: 'FR-4\'s named consumer. Wired at lib/adam/rationale-bar.js in selectAdvisory, which is '
-      + 'reached in production from scripts/adam-opportunity-scan.cjs:266. Before that wiring it was '
-      + 'imported by nothing but its own test — the emit-with-no-consumer this FR exists to reject, '
-      + 'reproduced one indirection deeper inside the FR\'s own deliverable.',
-  },
-  {
     name: 'enforceSweepBudget',
     module: 'scripts/solomon-advisory.cjs',
-    definedAt: 'scripts/solomon-advisory.cjs:263',
+    definedAt: 'scripts/solomon-advisory.cjs:262',
     gatedInput: 'spent',
     permissiveMeans: 'withinBudget:true — the per-sweep cost ceiling does not apply',
     expectedWired: false,
@@ -177,7 +158,7 @@ export const GUARD_REGISTRY = deepFreeze([
   {
     name: 'createRegistryNarrowedTrustGate',
     module: 'lib/ship/auto-merge.mjs',
-    definedAt: 'lib/ship/auto-merge.mjs:76',
+    definedAt: 'lib/ship/auto-merge.mjs:73',
     gatedInput: 'registry',
     permissiveMeans: 'the trust gate cannot REVOKE auto-merge for a mis-tagged platform repo',
     expectedWired: false,
@@ -198,7 +179,7 @@ export const GUARD_REGISTRY = deepFreeze([
   {
     name: 'enforceGuardrail',
     module: 'lib/eva/guardrail-enforcement-engine.js',
-    definedAt: 'lib/eva/guardrail-enforcement-engine.js:49',
+    definedAt: 'lib/eva/guardrail-enforcement-engine.js:45',
     gatedInput: 'guardrails',
     permissiveMeans: 'no guardrail is enforced',
     expectedWired: false,
@@ -206,7 +187,7 @@ export const GUARD_REGISTRY = deepFreeze([
   {
     name: 'auditSourcingGateConflict',
     module: 'lib/governance/adam-contract-audit.js',
-    definedAt: 'lib/governance/adam-contract-audit.js:40',
+    definedAt: 'lib/governance/adam-contract-audit.js:39',
     gatedInput: 'gates',
     permissiveMeans: 'a sourcing-gate conflict goes unreported',
     expectedWired: false,
@@ -214,7 +195,7 @@ export const GUARD_REGISTRY = deepFreeze([
   {
     name: 'capabilityGapTerm',
     module: 'lib/adam/rationale-bar.js',
-    definedAt: 'lib/adam/rationale-bar.js:284',
+    definedAt: 'lib/adam/rationale-bar.js:286',
     gatedInput: 'capability',
     permissiveMeans: 'the capability-gap term contributes nothing to the rationale bar',
     expectedWired: false,

--- a/lib/governance/guard-wiring-registry.js
+++ b/lib/governance/guard-wiring-registry.js
@@ -1,0 +1,173 @@
+/**
+ * The registry of self-gating guards, and what each one needs its caller to supply.
+ * SD-LEO-INFRA-PURE-GUARD-UNWIRED-001 FR-1.
+ *
+ * THE DEFECT CLASS. A pure, correct, well-documented guard that self-gates to PERMISSIVE when its
+ * caller supplies no data is indistinguishable from a guard that evaluated and passed. Every one of
+ * these documents its no-op as deliberate safety, and each is individually defensible — inverting
+ * them to fail closed would trade a silent permit for a silent outage. The defect is not the
+ * permissive branch. It is that nothing tells you which branch you got.
+ *
+ * WHAT THIS REGISTRY IS FOR. Not to re-derive that judgment per guard, but to answer one mechanical
+ * question the codebase could not previously answer at all: DOES A PRODUCTION CALLER ACTUALLY
+ * SUPPLY THE INPUT THIS GUARD GATES ON? enforceSweepBudget would have failed that on day one — it
+ * is Solomon's own per-sweep cost ceiling, it has ten repo-wide occurrences, ZERO executable
+ * production callers, and the only thing that looks like one is a PROMPT STRING.
+ *
+ * A PROMPT STRING IS NOT A CALL SITE. Neither is a test, a doc, or a comment. That distinction is
+ * the whole point: a guard referenced only in prose reads as wired to a grep and to a reviewer, and
+ * is unreachable at runtime. isProductionCallSite below is where that rule lives.
+ *
+ * Pure data + pure predicates: no fs, no DB. The test does the reading so this stays inspectable.
+ */
+'use strict';
+
+/**
+ * Paths that can never constitute production wiring.
+ * Prompts are listed FIRST because they are the trap: they are executable-adjacent, they mention the
+ * function by name, and they are what made enforceSweepBudget look wired for months.
+ */
+export const NON_PRODUCTION_PATTERNS = Object.freeze([
+  /\.test\.(?:js|cjs|mjs|ts)$/i,        // tests
+  /[\\/]tests?[\\/]/i,                   // test trees
+  /[\\/]__tests__[\\/]/i,
+  /\.md$/i,                              // docs
+  /[\\/]docs[\\/]/i,
+  /[\\/]\.claude[\\/]/i,                 // skills / commands / prompts
+  /[\\/]archive[\\/]/i,
+  /[\\/]_deprecated[\\/]/i,
+  /[\\/]node_modules[\\/]/i,
+]);
+
+/** A reference only counts as wiring if it lives in executable production code. */
+export function isProductionCallSite(filePath) {
+  const p = String(filePath || '');
+  if (!p) return false;
+  if (!/\.(?:js|cjs|mjs)$/i.test(p)) return false;   // a prompt string in a .md can never be a caller
+  return !NON_PRODUCTION_PATTERNS.some((re) => re.test(p));
+}
+
+/**
+ * Does this call site actually SUPPLY the gated input?
+ *
+ * Deliberately narrow: it looks for the input name appearing in the same call expression, which is
+ * a heuristic and is documented as one. The alternative — "the function is mentioned somewhere in a
+ * production file" — is precisely the check that let these six through, because it cannot tell
+ * `enforceSweepBudget({ spent })` from `enforceSweepBudget({})`.
+ *
+ * @param {string} callText the source text of the call expression
+ * @param {string} gatedInput the property the guard self-gates on
+ */
+export function suppliesGatedInput(callText, gatedInput) {
+  if (!callText || !gatedInput) return false;
+  if (isStubbedInput(callText, gatedInput)) return false;   // supplied-but-inert is not wired
+  // Match `spent`, `spent:`, `spent =`, `...spent`, or a shorthand inside an object literal.
+  const re = new RegExp(`(^|[^\\w.])${gatedInput}\\s*(?::|,|\\}|\\)|=[^=])`, 'm');
+  return re.test(callText);
+}
+
+/**
+ * Is the input supplied as a HARD-CODED NO-OP — present to a syntactic check, useless at runtime?
+ *
+ * THE THIRD SHAPE, and it defeated this detector on its first real run. The class has three forms,
+ * not one:
+ *   1. NO CALLER AT ALL                  — enforceSweepBudget
+ *   2. CALLER WIRED, DATA NEVER PRODUCED — capabilityGapTerm (nothing ever sets candidate.capability)
+ *   3. INPUT SUPPLIED AS A STUB          — runPreShipGate, called in the PRODUCTION entrypoint as
+ *      `runPreShipGate(brief, { getForecast: () => undefined })`, beneath a comment reading
+ *      "Real runs inject the Solomon forecast accessor" — which this run is.
+ *
+ * Shape 3 is the most deceptive: it passes a grep, passes review, and passes any check that asks
+ * only "is the input supplied". Treating it as wired would have made this very test report the
+ * guard as healthy — a detector for guards that cannot see their subject, unable to see its own.
+ */
+export function isStubbedInput(callText, gatedInput) {
+  if (!callText || !gatedInput) return false;
+  // `getForecast: () => undefined`, `: () => null`, `: () => false`, `: () => ({})`, `: null`
+  const stub = new RegExp(
+    `(^|[^\\w.])${gatedInput}\\s*:\\s*(?:` +
+    '\\(\\s*\\)\\s*=>\\s*(?:undefined|null|false|\\{\\s*\\}|\\(\\s*\\{\\s*\\}\\s*\\)|\\[\\s*\\])' +
+    '|undefined|null' +
+    ')',
+    'm',
+  );
+  return stub.test(callText);
+}
+
+/**
+ * Every guard is listed with the input it gates on and WHAT THE PERMISSIVE BRANCH MEANS, because
+ * a reader deciding whether an unwired entry matters needs the consequence, not just the name.
+ *
+ * `expectedWired: false` records a guard KNOWN to be unwired today. The wiring test asserts that
+ * set can SHRINK but never GROW — a permanently red suite would block every merge and get muted,
+ * which is how a loud signal becomes a quiet one. Removing an entry from the unwired set and
+ * watching the test go red is the proof that it bites.
+ */
+export const GUARD_REGISTRY = Object.freeze([
+  {
+    name: 'enforceSweepBudget',
+    module: 'scripts/solomon-advisory.cjs',
+    definedAt: 'scripts/solomon-advisory.cjs:263',
+    gatedInput: 'spent',
+    permissiveMeans: 'withinBudget:true — the per-sweep cost ceiling does not apply',
+    expectedWired: false,
+    note: 'Solomon\'s own cost ceiling. Ten repo-wide occurrences, ZERO executable production callers; '
+      + 'the only caller-shaped reference is a PROMPT STRING at scripts/solomon-startup-check.mjs:187. '
+      + 'It has never been able to fire. Two shipped docs assert that it runs — .claude/commands/solomon.md:18 '
+      + 'and docs/protocol/coordinator-solomon-comms.md:43 — which makes it active false assurance rather than '
+      + 'merely a gap.',
+  },
+  {
+    name: 'createRegistryNarrowedTrustGate',
+    module: 'lib/ship/auto-merge.mjs',
+    definedAt: 'lib/ship/auto-merge.mjs:76',
+    gatedInput: 'registry',
+    permissiveMeans: 'the trust gate cannot REVOKE auto-merge for a mis-tagged platform repo',
+    expectedWired: false,
+    note: 'The only code able to revoke auto-merge on a mis-tagged repo. Its permissive branch is the '
+      + 'one that ships an unreviewed merge, so "could not evaluate" and "evaluated and allowed" '
+      + 'differ by the entire value of the gate.',
+  },
+  {
+    name: 'runPreShipGate',
+    module: 'lib/daily-review/artifact-preship-gate.js',
+    definedAt: 'lib/daily-review/artifact-preship-gate.js:27',
+    gatedInput: 'getForecast',
+    permissiveMeans: 'the pre-ship artifact check passes without a forecast',
+    expectedWired: false,
+    note: 'The sole caller hard-codes getForecast to return undefined, so the guard is reached but '
+      + 'permanently blind — worse than uncalled, because the call site LOOKS like wiring.',
+  },
+  {
+    name: 'enforceGuardrail',
+    module: 'lib/eva/guardrail-enforcement-engine.js',
+    definedAt: 'lib/eva/guardrail-enforcement-engine.js:49',
+    gatedInput: 'guardrails',
+    permissiveMeans: 'no guardrail is enforced',
+    expectedWired: false,
+  },
+  {
+    name: 'auditSourcingGateConflict',
+    module: 'lib/governance/adam-contract-audit.js',
+    definedAt: 'lib/governance/adam-contract-audit.js:40',
+    gatedInput: 'gates',
+    permissiveMeans: 'a sourcing-gate conflict goes unreported',
+    expectedWired: false,
+  },
+  {
+    name: 'capabilityGapTerm',
+    module: 'lib/adam/rationale-bar.js',
+    definedAt: 'lib/adam/rationale-bar.js:284',
+    gatedInput: 'capability',
+    permissiveMeans: 'the capability-gap term contributes nothing to the rationale bar',
+    expectedWired: false,
+    note: 'A subtler shape than the others: gaps ARE injected, but NO PRODUCER ever sets '
+      + 'candidate.capability, so the term self-gates on data that structurally never arrives. '
+      + 'The caller is wired; the data is not.',
+  },
+]);
+
+/** Guards currently known to be unwired — the baseline that may shrink and must never grow. */
+export function knownUnwired(registry = GUARD_REGISTRY) {
+  return registry.filter((g) => g.expectedWired === false).map((g) => g.name).sort();
+}

--- a/lib/governance/inactive-reason-consumer.js
+++ b/lib/governance/inactive-reason-consumer.js
@@ -130,7 +130,11 @@ export function foldTermResults(guard, results = []) {
   for (const r of list) {
     if (!r || typeof r !== 'object') continue;
     if (own(r, 'active') === true) { blocked += 1; continue; }  // an ACTIVE term is one that did something
-    const reason = typeof own(r, 'inactive_reason') === 'string' ? r.inactive_reason : null;
+    // Read ONCE, then type-check the value read. Type-checking one read and using a second is the
+    // same TOCTOU closed in predicate-self-test: a getter can pass the check and then hand back an
+    // object, which would travel on as `missingInput`.
+    const raw = own(r, 'inactive_reason');
+    const reason = typeof raw === 'string' ? raw : null;
     if (!reason) continue;
     reasons.set(reason, (reasons.get(reason) || 0) + 1);
     const cls = classifyReason(reason);

--- a/lib/governance/inactive-reason-consumer.js
+++ b/lib/governance/inactive-reason-consumer.js
@@ -1,0 +1,81 @@
+/**
+ * THE NAMED CONSUMER of inactive_reason. SD-LEO-INFRA-PURE-GUARD-UNWIRED-001 FR-4.
+ *
+ * WHY THIS FILE IS THE POINT OF FR-4, and why FR-4 was demoted from first to last. Instance 3
+ * ALREADY emits inactive_reason — shipped by SD-LEO-INFRA-ADAM-WORK-SELECTION-001, three distinct
+ * reasons at rationale-bar.js:214/:230/:252 — and detectability did not change at all, because
+ * nothing read them. The emit was correct and insufficient. The SD's own counterfactual is exactly
+ * this: six months on, the emits exist, no consumer reads them, and the codebase has three more log
+ * lines and the same blindness.
+ *
+ * So the deliverable is NOT another emit. It is a reader that CHANGES ITS ANSWER because the signal
+ * is there. This converts a term's self-reported reason into the observation record FR-2's alarm
+ * consumes, which is what turns "0 blocks this week" into either "quiet" or "structurally unable".
+ *
+ * Pure: no fs, no DB, no clock.
+ */
+'use strict';
+
+/**
+ * Reasons that mean THE GUARD NEVER GOT ITS DATA, as opposed to reasons that mean it evaluated
+ * and found nothing. The two are different findings and must not collapse:
+ *   - no-data      → the guard could not have blocked; chasing "why didn't it fire" is wasted work
+ *   - evaluated    → the guard ran on real input and legitimately found nothing
+ */
+export const NO_DATA_REASONS = Object.freeze(new Set([
+  'zero_waves_or_no_alignment',
+  'no_gaps_supplied',
+  'candidate_has_no_capability',
+  'capability_absent_from_gap_map',
+  'gap_value_not_a_number',
+]));
+
+/** Reasons that mean the guard DID have data and still declined to act. */
+export const EVALUATED_REASONS = Object.freeze(new Set([
+  'empty_aligned_set',
+  'id_space_mismatch',
+]));
+
+/**
+ * Fold a batch of term results into the observation record FR-2's alarm consumes.
+ *
+ * THE BEHAVIOURAL CHANGE FR-4 REQUIRES (AC-3): the presence of inactive_reason alters the output.
+ * Without it a batch of inactive terms yields observations>0 and no explanation, so FR-2 reports
+ * SUSPECT and an operator goes looking for a cause. With it, the same batch reports WHICH input was
+ * absent and how often — turning an investigation into a fix.
+ *
+ * @param {string} guard
+ * @param {Array<{active?:boolean, inactive_reason?:string}>} results one entry per evaluation
+ * @returns {{guard, observations, blocked, permissiveNoData, missingInput, reasons}}
+ */
+export function foldTermResults(guard, results = []) {
+  const list = Array.isArray(results) ? results : [];
+  const reasons = new Map();
+  let permissiveNoData = 0;
+  let blocked = 0;
+
+  for (const r of list) {
+    if (!r || typeof r !== 'object') continue;
+    if (r.active === true) { blocked += 1; continue; }   // an ACTIVE term is one that did something
+    const reason = typeof r.inactive_reason === 'string' ? r.inactive_reason : null;
+    if (reason) reasons.set(reason, (reasons.get(reason) || 0) + 1);
+    if (reason && NO_DATA_REASONS.has(reason)) permissiveNoData += 1;
+  }
+
+  // The dominant no-data reason IS the missing input, named. This is the whole value of the emit:
+  // a consumer that had to re-derive it would be doing the work the signal exists to save.
+  let missingInput = null;
+  let top = 0;
+  for (const [reason, n] of reasons) {
+    if (NO_DATA_REASONS.has(reason) && n > top) { top = n; missingInput = reason; }
+  }
+
+  return {
+    guard,
+    observations: list.length,
+    blocked,
+    permissiveNoData,
+    missingInput,
+    reasons: Object.fromEntries(reasons),
+  };
+}

--- a/lib/governance/inactive-reason-consumer.js
+++ b/lib/governance/inactive-reason-consumer.js
@@ -11,30 +11,102 @@
  * So the deliverable is NOT another emit. It is a reader that CHANGES ITS ANSWER because the signal
  * is there. This converts a term's self-reported reason into the observation record FR-2's alarm
  * consumes, which is what turns "0 blocks this week" into either "quiet" or "structurally unable".
+ * It is called from lib/adam/rationale-bar.js selectAdvisory — a production path — because a
+ * consumer imported only by its own test is the very thing FR-1 exists to catch, and shipping one
+ * would have been this SD failing its own thesis one indirection deeper.
  *
  * Pure: no fs, no DB, no clock.
  */
 'use strict';
 
 /**
- * Reasons that mean THE GUARD NEVER GOT ITS DATA, as opposed to reasons that mean it evaluated
- * and found nothing. The two are different findings and must not collapse:
- *   - no-data      → the guard could not have blocked; chasing "why didn't it fire" is wasted work
- *   - evaluated    → the guard ran on real input and legitimately found nothing
+ * Own-property read. Everything below reads caller-supplied objects, and an INHERITED property is
+ * indistinguishable from a supplied one on a normal read — so `Object.prototype.active = true`
+ * would make every empty result count as a block and drive the alarm to HEALTHY. Every failure
+ * direction there is permissive, which is this module's entire subject pointed at itself.
  */
-export const NO_DATA_REASONS = Object.freeze(new Set([
+const own = (o, k) => {
+  // The read is wrapped because a throwing getter would escape an otherwise total fold.
+  try {
+    return o != null && typeof o === 'object' && Object.hasOwn(o, k) ? o[k] : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
+ * Reasons meaning THE GUARD NEVER GOT ITS DATA — it could not have blocked, so "why didn't it
+ * fire" is answered, not open.
+ *
+ * ALL SEVEN LIVE REASONS ARE NO-DATA, and I had two of them filed as the opposite. The first
+ * version of this module put `empty_aligned_set` and `id_space_mismatch` under EVALUATED, on the
+ * reasoning that waves existed so the guard "had its data". The file that emits them says the
+ * opposite, twenty lines from the emit: rationale-bar.js:221 "Waves exist but NOTHING is linked =>
+ * this term cannot judge alignment", and :248 "Wholly disjoint id spaces mean this term cannot
+ * judge alignment, and a term that cannot judge must not judge — the same doctrine as the empty-set
+ * case above." Cannot-judge IS no-data.
+ *
+ * The consequence was measured, not theorised, on the SD's own flagship instance — 8 waves, 0 of
+ * 261 roadmap_wave_items carrying linkages, 27 evaluations: the fold reported permissiveNoData: 0
+ * and missingInput: null while the no-data branch had fired all 27 times, so FR-2 emitted "no-data
+ * branch taken 0x" and named nothing. The alarm built to catch instance 3 was blind to instance 3,
+ * in the permissive direction, because of a classification I asserted instead of read. Recorded
+ * rather than quietly corrected: this is FR-5's failure mode (an artifact of the SD propagating a
+ * claim the SD's own evidence refutes) committed inside the SD itself.
+ */
+export const NO_DATA_REASONS = Object.freeze([
+  // waveAlignmentTerm — all three are "cannot judge" per the emitting file's own docblocks.
   'zero_waves_or_no_alignment',
+  'empty_aligned_set',
+  'id_space_mismatch',
+  // capabilityGapTerm
   'no_gaps_supplied',
   'candidate_has_no_capability',
   'capability_absent_from_gap_map',
   'gap_value_not_a_number',
-]));
+]);
 
-/** Reasons that mean the guard DID have data and still declined to act. */
-export const EVALUATED_REASONS = Object.freeze(new Set([
-  'empty_aligned_set',
-  'id_space_mismatch',
-]));
+/**
+ * Reasons meaning the guard HAD its data and still declined to act. EMPTY, and deliberately kept.
+ *
+ * No producer in this repo emits one today: a term that can judge and finds nothing returns
+ * `active: true` with a 1.0 multiplier, carrying no reason at all. This is the empty set, not an
+ * unpopulated registry — the distinction is real and a future evaluated-and-declined reason must
+ * land here rather than inflating the no-data count. Naming it costs one line and stops the next
+ * reader from re-deriving the classification from scratch, which is how the inversion above
+ * happened.
+ */
+export const EVALUATED_REASONS = Object.freeze([]);
+
+// Frozen ARRAYS above, private Sets here. `Object.freeze(new Set([...]))` reports isFrozen === true
+// while .add/.delete/.clear all still work — a false immutability guarantee, and clearing the set
+// would silently collapse permissiveNoData to 0 and suppress the AC-4 explanation. The lookup
+// structures are therefore not reachable from outside this module at all.
+const NO_DATA = new Set(NO_DATA_REASONS);
+const EVALUATED = new Set(EVALUATED_REASONS);
+
+export const REASON_CLASS = Object.freeze({
+  NO_DATA: 'no_data',
+  EVALUATED: 'evaluated',
+  UNCLASSIFIED: 'unclassified',
+});
+
+/**
+ * Classify one reason string.
+ *
+ * AN UNKNOWN REASON COUNTS AS NO-DATA, and the direction is the whole decision. Treating it as
+ * "not no-data" would mean a newly-added emit silently stops contributing to the count — the
+ * permissive answer, arriving quietly, which is the defect class this SD exists to remove.
+ * Treating it as no-data can at worst over-report a guard as unable, which is loud and gets fixed.
+ * It is also surfaced separately by the fold so an unrecognised reason is visible rather than
+ * absorbed into a number that looks deliberate.
+ */
+export function classifyReason(reason) {
+  if (typeof reason !== 'string' || reason.length === 0) return null;
+  if (EVALUATED.has(reason)) return REASON_CLASS.EVALUATED;
+  if (NO_DATA.has(reason)) return REASON_CLASS.NO_DATA;
+  return REASON_CLASS.UNCLASSIFIED;
+}
 
 /**
  * Fold a batch of term results into the observation record FR-2's alarm consumes.
@@ -46,20 +118,24 @@ export const EVALUATED_REASONS = Object.freeze(new Set([
  *
  * @param {string} guard
  * @param {Array<{active?:boolean, inactive_reason?:string}>} results one entry per evaluation
- * @returns {{guard, observations, blocked, permissiveNoData, missingInput, reasons}}
+ * @returns {{guard, observations, blocked, permissiveNoData, unclassified, missingInput, reasons}}
  */
 export function foldTermResults(guard, results = []) {
   const list = Array.isArray(results) ? results : [];
   const reasons = new Map();
   let permissiveNoData = 0;
+  let unclassified = 0;
   let blocked = 0;
 
   for (const r of list) {
     if (!r || typeof r !== 'object') continue;
-    if (r.active === true) { blocked += 1; continue; }   // an ACTIVE term is one that did something
-    const reason = typeof r.inactive_reason === 'string' ? r.inactive_reason : null;
-    if (reason) reasons.set(reason, (reasons.get(reason) || 0) + 1);
-    if (reason && NO_DATA_REASONS.has(reason)) permissiveNoData += 1;
+    if (own(r, 'active') === true) { blocked += 1; continue; }  // an ACTIVE term is one that did something
+    const reason = typeof own(r, 'inactive_reason') === 'string' ? r.inactive_reason : null;
+    if (!reason) continue;
+    reasons.set(reason, (reasons.get(reason) || 0) + 1);
+    const cls = classifyReason(reason);
+    if (cls === REASON_CLASS.NO_DATA) permissiveNoData += 1;
+    else if (cls === REASON_CLASS.UNCLASSIFIED) { permissiveNoData += 1; unclassified += 1; }
   }
 
   // The dominant no-data reason IS the missing input, named. This is the whole value of the emit:
@@ -67,7 +143,8 @@ export function foldTermResults(guard, results = []) {
   let missingInput = null;
   let top = 0;
   for (const [reason, n] of reasons) {
-    if (NO_DATA_REASONS.has(reason) && n > top) { top = n; missingInput = reason; }
+    if (classifyReason(reason) === REASON_CLASS.EVALUATED) continue;
+    if (n > top) { top = n; missingInput = reason; }
   }
 
   return {
@@ -75,7 +152,10 @@ export function foldTermResults(guard, results = []) {
     observations: list.length,
     blocked,
     permissiveNoData,
+    unclassified,
     missingInput,
-    reasons: Object.fromEntries(reasons),
+    // Null-prototype: the keys are caller-supplied strings, and a `__proto__` or `constructor`
+    // key on an ordinary object literal is a foothold this record does not need to offer.
+    reasons: Object.assign(Object.create(null), Object.fromEntries(reasons)),
   };
 }

--- a/lib/governance/inactive-reason-consumer.js
+++ b/lib/governance/inactive-reason-consumer.js
@@ -3,8 +3,12 @@
  *
  * WHY THIS FILE IS THE POINT OF FR-4, and why FR-4 was demoted from first to last. Instance 3
  * ALREADY emits inactive_reason — shipped by SD-LEO-INFRA-ADAM-WORK-SELECTION-001, three distinct
- * reasons at rationale-bar.js:214/:230/:252 — and detectability did not change at all, because
- * nothing read them. The emit was correct and insufficient. The SD's own counterfactual is exactly
+ * reasons on waveAlignmentTerm's no-data branches in lib/adam/rationale-bar.js — and detectability
+ * did not change at all, because nothing read them. (Cited by SYMBOL, not by line: the four
+ * file:line citations this SD first wrote were stale within the SD itself, invalidated by its own
+ * edits. A stale reference that reads as evidence is this SD's subject; line numbers survive only
+ * in GUARD_REGISTRY.definedAt, where a test resolves them against the file.)
+ * The emit was correct and insufficient. The SD's own counterfactual is exactly
  * this: six months on, the emits exist, no consumer reads them, and the codebase has three more log
  * lines and the same blindness.
  *
@@ -41,10 +45,10 @@ const own = (o, k) => {
  * ALL SEVEN LIVE REASONS ARE NO-DATA, and I had two of them filed as the opposite. The first
  * version of this module put `empty_aligned_set` and `id_space_mismatch` under EVALUATED, on the
  * reasoning that waves existed so the guard "had its data". The file that emits them says the
- * opposite, twenty lines from the emit: rationale-bar.js:221 "Waves exist but NOTHING is linked =>
- * this term cannot judge alignment", and :248 "Wholly disjoint id spaces mean this term cannot
- * judge alignment, and a term that cannot judge must not judge — the same doctrine as the empty-set
- * case above." Cannot-judge IS no-data.
+ * opposite, in the comment directly above each emit: "Waves exist but NOTHING is linked => this
+ * term cannot judge alignment", and, at the id-space guard, "Wholly disjoint id spaces mean this
+ * term cannot judge alignment, and a term that cannot judge must not judge — the same doctrine as
+ * the empty-set case above." Cannot-judge IS no-data.
  *
  * The consequence was measured, not theorised, on the SD's own flagship instance — 8 waves, 0 of
  * 261 roadmap_wave_items carrying linkages, 27 evaluations: the fold reported permissiveNoData: 0

--- a/lib/governance/predicate-self-test.js
+++ b/lib/governance/predicate-self-test.js
@@ -1,0 +1,115 @@
+/**
+ * A CHECK THAT HAS NEVER BEEN SHOWN TO FAIL CANNOT BE CITED.
+ * SD-LEO-INFRA-PURE-GUARD-UNWIRED-001 FR-3.
+ *
+ * WHERE THIS COMES FROM. A predicate was wired, was fed real data, and reported 0/3 for 27
+ * consecutive passes across a window in which the underlying state demonstrably changed. Nothing
+ * was missing. The predicate itself was inert: a shell-mangled regex that had compiled to a
+ * BACKSPACE CHARACTER and could never match anything. Every pass was honest and every pass was
+ * meaningless, and because "no matches" is the permissive answer, it read as health for 27 passes.
+ *
+ * ONE TEST WOULD HAVE CAUGHT IT: run the predicate against a string KNOWN to match. That is all
+ * this module is. It generalises the codebase's own repeated lesson — "a check that compares a
+ * value to itself cannot fail" — one step outward: a check that has never been DEMONSTRATED to
+ * return its blocking verdict has not been shown to be a check at all.
+ *
+ * DELIBERATELY SCOPED to predicates feeding gates, alarms and handoff evidence. Applying it to
+ * every boolean in the tree would be noise, and noise is what gets a signal muted.
+ *
+ * Pure and total: it never throws. A predicate that throws on a known input is itself a finding,
+ * and swallowing that into a pass would be the exact defect this module exists to remove.
+ */
+'use strict';
+
+export const VERDICT_KIND = Object.freeze({ BLOCKING: 'blocking', PASSING: 'passing' });
+
+/** Default reading of "this result is the blocking verdict". */
+function defaultIsBlocking(result) {
+  if (result === true) return true;
+  if (result && typeof result === 'object') {
+    if (result.blocked === true) return true;
+    if (result.ok === false) return true;
+    if (result.verdict === 'fail' || result.verdict === 'block') return true;
+  }
+  return false;
+}
+
+/**
+ * Demonstrate that a predicate can produce BOTH of its verdicts against known inputs.
+ *
+ * @param {object} spec
+ * @param {string} spec.name
+ * @param {Function} spec.predicate          the predicate under test
+ * @param {*} spec.blockingInput             an input that MUST produce the blocking verdict
+ * @param {*} spec.passingInput              an input that MUST produce the passing verdict
+ * @param {(r:*)=>boolean} [spec.isBlocking] how to read the result
+ * @returns {{name, capable, produced, missingVerdict, threw, detail}} never throws
+ */
+export function selfTestPredicate(specArg = {}) {
+  // `= {}` only defaults on undefined, so an explicit null still reaches the body and throws on
+  // property access. Caught by the never-throws test, which is exactly what it is there for.
+  const spec = specArg && typeof specArg === 'object' ? specArg : {};
+  const name = spec.name || '(unnamed predicate)';
+  const isBlocking = typeof spec.isBlocking === 'function' ? spec.isBlocking : defaultIsBlocking;
+  const out = { name, capable: false, produced: { blocking: false, passing: false }, missingVerdict: null, threw: null, detail: '' };
+
+  if (typeof spec.predicate !== 'function') {
+    out.missingVerdict = 'both';
+    out.detail = `${name}: no predicate supplied — nothing was demonstrated, which is NOT the same as passing`;
+    return out;
+  }
+
+  const run = (input, label) => {
+    try {
+      return { ok: true, blocking: isBlocking(spec.predicate(input)) };
+    } catch (err) {
+      // A throw is a finding, not a pass. Recorded and surfaced rather than absorbed.
+      out.threw = `${label}: ${err?.message || String(err)}`;
+      return { ok: false, blocking: false };
+    }
+  };
+
+  const b = run(spec.blockingInput, 'blockingInput');
+  const p = run(spec.passingInput, 'passingInput');
+  out.produced.blocking = b.ok && b.blocking === true;
+  out.produced.passing = p.ok && p.blocking === false;
+
+  if (out.threw) {
+    out.detail = `${name}: THREW during the self-test (${out.threw}) — a predicate that cannot run cannot be cited`;
+    return out;
+  }
+  if (!out.produced.blocking && !out.produced.passing) {
+    out.missingVerdict = 'both';
+    out.detail = `${name}: produced NEITHER verdict against known inputs — it is not discriminating at all`;
+    return out;
+  }
+  if (!out.produced.blocking) {
+    // The instance-5 shape: it can say "fine" and has never been shown able to say anything else.
+    out.missingVerdict = VERDICT_KIND.BLOCKING;
+    out.detail = `${name}: could NOT produce its BLOCKING verdict against an input known to trigger it — `
+      + 'it can only ever return the permissive answer, so its zeros mean nothing';
+    return out;
+  }
+  if (!out.produced.passing) {
+    out.missingVerdict = VERDICT_KIND.PASSING;
+    out.detail = `${name}: could NOT produce its PASSING verdict against an input known to be clean — `
+      + 'it blocks unconditionally, so its blocks mean nothing';
+    return out;
+  }
+
+  out.capable = true;
+  out.detail = `${name}: demonstrated BOTH verdicts against known inputs`;
+  return out;
+}
+
+/** Run a suite of predicate self-tests; returns the incapable ones first — they are the finding. */
+export function selfTestAll(specs = []) {
+  const results = (Array.isArray(specs) ? specs : []).map((s) => selfTestPredicate(s));
+  const incapable = results.filter((r) => !r.capable);
+  return {
+    results,
+    incapable,
+    // Unconditional counts, zeros included — same reasoning as the sustained-zero report.
+    summary: `PREDICATE SELF-TEST: capable=${results.length - incapable.length} incapable=${incapable.length}`,
+  };
+}

--- a/lib/governance/predicate-self-test.js
+++ b/lib/governance/predicate-self-test.js
@@ -23,15 +23,60 @@
 
 export const VERDICT_KIND = Object.freeze({ BLOCKING: 'blocking', PASSING: 'passing' });
 
-/** Default reading of "this result is the blocking verdict". */
+/**
+ * Own-property read — an inherited property is indistinguishable from a supplied one, and
+ * `Object.prototype.predicate = () => …` would let selfTestPredicate({name:'missing'}) report
+ * capable:true, i.e. manufacture the citation this module exists to withhold.
+ */
+const own = (o, k) => {
+  // The READ itself is wrapped: `{ get name() { throw … } }` throws at property access, and these
+  // accesses happen BEFORE the try/catch around the predicate run — so a hostile spec escaped a
+  // function whose docblock promises it never throws. A field that cannot be read is a field that
+  // was not supplied.
+  try {
+    return o != null && typeof o === 'object' && Object.hasOwn(o, k) ? o[k] : undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+/** Describe a thrown value without ever throwing again — `String(Object.create(null))` throws. */
+function describeThrown(err) {
+  try {
+    if (err instanceof Error && typeof err.message === 'string') return err.message;
+    if (typeof err === 'string') return err;
+    const m = own(err, 'message');
+    if (typeof m === 'string') return m;
+    return Object.prototype.toString.call(err);
+  } catch {
+    return '(unrepresentable thrown value)';
+  }
+}
+
+/**
+ * Default reading of "this result is the blocking verdict".
+ *
+ * THE OBJECT ARM IS THE LIVE ONE. This module is scoped to predicates feeding gates, alarms and
+ * handoff evidence, and in this codebase those return VERDICT OBJECTS, not bare booleans. If the
+ * object shapes were dropped, a real gate predicate returning `{blocked:true}` would read as
+ * PASSING, and the self-test would declare a working guard incapable of blocking — a false alarm,
+ * which FR-2's own docblock identifies as the failure that gets an alarm muted.
+ */
 function defaultIsBlocking(result) {
   if (result === true) return true;
   if (result && typeof result === 'object') {
-    if (result.blocked === true) return true;
-    if (result.ok === false) return true;
-    if (result.verdict === 'fail' || result.verdict === 'block') return true;
+    if (own(result, 'blocked') === true) return true;
+    if (own(result, 'ok') === false) return true;
+    const verdict = own(result, 'verdict');
+    if (verdict === 'fail' || verdict === 'block') return true;
   }
   return false;
+}
+
+/** A thenable result cannot be judged synchronously — see the run() comment below. */
+function isThenable(v) {
+  if (v == null || (typeof v !== 'object' && typeof v !== 'function')) return false;
+  try { return typeof v.then === 'function'; } catch { return false; }
 }
 
 /**
@@ -49,11 +94,21 @@ export function selfTestPredicate(specArg = {}) {
   // `= {}` only defaults on undefined, so an explicit null still reaches the body and throws on
   // property access. Caught by the never-throws test, which is exactly what it is there for.
   const spec = specArg && typeof specArg === 'object' ? specArg : {};
-  const name = spec.name || '(unnamed predicate)';
-  const isBlocking = typeof spec.isBlocking === 'function' ? spec.isBlocking : defaultIsBlocking;
-  const out = { name, capable: false, produced: { blocking: false, passing: false }, missingVerdict: null, threw: null, detail: '' };
+  // EVERY field is read EXACTLY ONCE, up front. `spec.predicate` was previously read three times
+  // (once to type-check, once per run), so a getter could return a blocking-only predicate and then
+  // a passing-only one and the pair would be certified as having "demonstrated BOTH verdicts" —
+  // a citation assembled from two different functions, neither of which can discriminate. Reading
+  // once turns a time-of-check/time-of-use gap into no gap.
+  const nameRaw = own(spec, 'name');
+  const name = (typeof nameRaw === 'string' && nameRaw) || '(unnamed predicate)';
+  const isBlockingRaw = own(spec, 'isBlocking');
+  const isBlocking = typeof isBlockingRaw === 'function' ? isBlockingRaw : defaultIsBlocking;
+  const predicate = own(spec, 'predicate');
+  const blockingInput = own(spec, 'blockingInput');
+  const passingInput = own(spec, 'passingInput');
+  const out = { name, capable: false, produced: { blocking: false, passing: false }, missingVerdict: null, threw: null, asyncResult: false, detail: '' };
 
-  if (typeof spec.predicate !== 'function') {
+  if (typeof predicate !== 'function') {
     out.missingVerdict = 'both';
     out.detail = `${name}: no predicate supplied — nothing was demonstrated, which is NOT the same as passing`;
     return out;
@@ -61,19 +116,38 @@ export function selfTestPredicate(specArg = {}) {
 
   const run = (input, label) => {
     try {
-      return { ok: true, blocking: isBlocking(spec.predicate(input)) };
+      const result = predicate(input);
+      // AN ASYNC PREDICATE CANNOT BE SELF-TESTED HERE, and silently trying was the worse of the two
+      // failures available. A returned Promise is an object without `.blocked`, so it read as the
+      // PASSING verdict; and when it later rejected, nothing was attached to catch it, so an
+      // async-throwing predicate returned a clean `{capable:false, threw:null}` and then killed the
+      // process at the microtask checkpoint — the throw neither recorded nor surfaced, in a module
+      // whose docblock promises it never throws. Swallow the rejection, and report the shape as the
+      // finding it is.
+      if (isThenable(result)) {
+        try { Promise.resolve(result).catch(() => {}); } catch { /* not a real promise; nothing to settle */ }
+        out.asyncResult = true;
+        out.threw = `${label}: predicate returned a thenable — this self-test is synchronous and cannot judge it`;
+        return { ok: false, blocking: false };
+      }
+      return { ok: true, blocking: isBlocking(result) === true };
     } catch (err) {
       // A throw is a finding, not a pass. Recorded and surfaced rather than absorbed.
-      out.threw = `${label}: ${err?.message || String(err)}`;
+      out.threw = `${label}: ${describeThrown(err)}`;
       return { ok: false, blocking: false };
     }
   };
 
-  const b = run(spec.blockingInput, 'blockingInput');
-  const p = run(spec.passingInput, 'passingInput');
+  const b = run(blockingInput, 'blockingInput');
+  const p = run(passingInput, 'passingInput');
   out.produced.blocking = b.ok && b.blocking === true;
   out.produced.passing = p.ok && p.blocking === false;
 
+  if (out.asyncResult) {
+    out.detail = `${name}: returned a PROMISE, which this synchronous self-test cannot judge (${out.threw}) — `
+      + 'undemonstrated is not the same as passing, so it still cannot be cited';
+    return out;
+  }
   if (out.threw) {
     out.detail = `${name}: THREW during the self-test (${out.threw}) — a predicate that cannot run cannot be cited`;
     return out;

--- a/scripts/adam-opportunity-scan.cjs
+++ b/scripts/adam-opportunity-scan.cjs
@@ -211,12 +211,17 @@ function adamOkLine(scope, result) {
  * is not exported and is therefore unreachable from any unit test. Collapsing them into ONE call
  * shrinks that surface to a single hop, and every decision it makes is tested here.
  *
- * The residual is real and is stated rather than papered over: `scanOutcome(...)` is still invoked
- * from main(), and a mutation that passed it a null result would produce no unit-test signal. That
- * last hop cannot be closed by unit tests at all — it needs a process-level test that actually runs
- * the CLI, which this scan cannot have cheaply because it reads the database first. Recording the
- * boundary precisely is the honest move; claiming the hop is covered would be the third repetition
- * of the exact defect this SD exists to remove.
+ * The residual, stated precisely. `scanOutcome(...)` is invoked from main(), and nothing executes
+ * main() in a test, so the hop cannot be closed BEHAVIOURALLY — a static check cannot prove the
+ * value passed is the right one. It needs a process-level test running the CLI, which is not cheap
+ * here because the scan reads the database first.
+ *
+ * I first wrote that it "cannot be closed by unit tests at all", and that was too strong — review
+ * caught it, and the correction matters more than the code: this SD is about claims outliving their
+ * evidence, and "we established this cannot be tested" is exactly the sentence that gets inherited
+ * and stops the next person looking. It IS statically checkable that the call supplies the input,
+ * by this SD's own FR-1 machinery, and tests/unit/governance/guard-wiring.test.js now does so —
+ * catching deletion, omission and null-stubbing, which is the whole class the mutations exercised.
  */
 function scanOutcome({ result, scope, flagEnabled }) {
   const surfaced = result && result.surfaced;

--- a/scripts/adam-opportunity-scan.cjs
+++ b/scripts/adam-opportunity-scan.cjs
@@ -117,7 +117,7 @@ function appendLedger(entry) {
   return entry;
 }
 
-function buildLedgerEntry({ scope, verdict, cleared = 0, flagEnabled, detail = null, trace = null }) {
+function buildLedgerEntry({ scope, verdict, cleared = 0, flagEnabled, detail = null, trace = null, guardHealth = null }) {
   return {
     ts: new Date().toISOString(),
     scope: scope ? scope.scope_key : 'none',
@@ -127,7 +127,31 @@ function buildLedgerEntry({ scope, verdict, cleared = 0, flagEnabled, detail = n
     ...(detail ? { detail } : {}),
     // SD-LEO-INFRA-ADAM-PRIORITY-ANCHORING-001: audit the rank perturbations.
     ...(Array.isArray(trace) && trace.length ? { trace } : {}),
+    // SD-LEO-INFRA-PURE-GUARD-UNWIRED-001 FR-4. THE READ THAT MAKES THE EMIT A SIGNAL.
+    //
+    // The ledger recorded 21 consecutive `ADAM_OK cleared=0` rows while waveAlignmentTerm was
+    // failing closed on an empty linkage table — every row byte-identical, so "nothing qualified"
+    // and "the term could not judge" were the same observation from outside. Computing the health
+    // and not writing it down would leave pass 22 identical to the 21 before it, which is this
+    // SD's own defect wearing the remedy's clothes; adversarial review caught exactly that here.
+    ...(guardHealth ? { guard_health: guardHealth } : {}),
   };
+}
+
+/**
+ * Render the guard-health line for stdout — the operator-facing half of the same read.
+ *
+ * Emitted UNCONDITIONALLY when health was computed, zeros included. A line that appears only when
+ * something is wrong makes "measured and fine" indistinguishable from "not measured", which is the
+ * ambiguity this whole SD is about, one level up.
+ */
+function formatGuardHealth(health) {
+  if (!health || !health.summary) return '';
+  const named = (health.results || [])
+    .filter((r) => r.missingInput)
+    .map((r) => ` ${r.guard} could not judge: '${r.missingInput}'.`)
+    .join('');
+  return `\n  ${health.summary}${named}`;
 }
 
 // NOTE: lib/adam/* and lib/eva/* are ESM; this CommonJS CLI loads them via
@@ -266,8 +290,13 @@ async function main() {
     const result = selectAdvisory(guarded.kept, selectOpts);
 
     if (!result.surfaced) {
-      const entry = appendLedger(buildLedgerEntry({ scope, verdict: 'ADAM_OK', cleared: 0, flagEnabled: gateEnabled }));
-      process.stdout.write(`ADAM_OK scope=${scope.scope_key} (nothing cleared the bar)\n`);
+      // The 21-pass path. `guard_health` is what separates "nothing qualified" from "the terms
+      // could not judge" — without it these two rows are byte-identical.
+      const entry = appendLedger(buildLedgerEntry({
+        scope, verdict: 'ADAM_OK', cleared: 0, flagEnabled: gateEnabled,
+        guardHealth: result.guard_health ? result.guard_health.summary : null,
+      }));
+      process.stdout.write(`ADAM_OK scope=${scope.scope_key} (nothing cleared the bar)${formatGuardHealth(result.guard_health)}\n`);
       process.stdout.write(JSON.stringify(entry) + '\n');
       process.exit(0);
     }
@@ -282,7 +311,7 @@ async function main() {
     }
 
     // gate ON (env AND registry): emit exactly ONE advisory via the existing lane.
-    appendLedger(buildLedgerEntry({ scope, verdict: 'SURFACED', cleared: result.cleared, flagEnabled: gateEnabled, detail: result.surfaced.dedup_key || null, trace: result.trace }));
+    appendLedger(buildLedgerEntry({ scope, verdict: 'SURFACED', cleared: result.cleared, flagEnabled: gateEnabled, detail: result.surfaced.dedup_key || null, trace: result.trace, guardHealth: result.guard_health ? result.guard_health.summary : null }));
     const r = spawnSync('node', [ADVISORY_CLI, 'send', body], { stdio: 'inherit' });
     process.exit(r.status == null ? 0 : r.status);
   } catch (e) {
@@ -292,7 +321,7 @@ async function main() {
   }
 }
 
-module.exports = { isFlagEnabled, resolveGovernanceFlagGate, parseArgs, buildLedgerEntry, usage, LEDGER_PATH };
+module.exports = { isFlagEnabled, resolveGovernanceFlagGate, parseArgs, buildLedgerEntry, formatGuardHealth, usage, LEDGER_PATH };
 
 if (require.main === module) {
   main();

--- a/scripts/adam-opportunity-scan.cjs
+++ b/scripts/adam-opportunity-scan.cjs
@@ -154,6 +154,94 @@ function formatGuardHealth(health) {
   return `\n  ${health.summary}${named}`;
 }
 
+/**
+ * THE DURABLE FORM of guard health — counts AND names.
+ *
+ * Writing only `summary` made the ledger row distinguishable but not ACTIONABLE: it said
+ * "suspect=1" and named neither the term nor the absent input, so the one artifact an auditor reads
+ * months later still required re-deriving what FR-2 AC-4 exists to state. The 21-pass evidence came
+ * out of this ledger; stdout is ephemeral and is not where that reconstruction happens.
+ */
+function guardHealthForLedger(health) {
+  if (!health || !health.summary) return null;
+  return {
+    summary: health.summary,
+    // Always present, empty included — a field that appears only when non-empty makes
+    // "measured, nothing missing" and "not measured" the same row again.
+    missing: (health.results || [])
+      .filter((r) => r.missingInput)
+      .map((r) => ({ guard: r.guard, missing_input: r.missingInput, observations: r.observations })),
+  };
+}
+
+/**
+ * Build the ledger entry FROM A REAL selectAdvisory RESULT.
+ *
+ * Extracted from main() because main() is not exported and therefore not reachable from any test:
+ * both ENDS of this read were well covered — buildLedgerEntry with a literal, formatGuardHealth
+ * with a literal — while the WIRE between them was not, so deleting the argument that carries
+ * `result.guard_health` into the ledger restored the byte-identical row and produced no test
+ * signal at all. Third round running, the final hop was the unguarded one. Putting the logic in an
+ * exported pure function leaves main() with nothing worth mutating.
+ */
+function advisoryLedgerEntry({ result, scope, verdict, flagEnabled, detail = null, trace = null }) {
+  return buildLedgerEntry({
+    scope,
+    verdict,
+    cleared: verdict === 'ADAM_OK' ? 0 : ((result && result.cleared) || 0),
+    flagEnabled,
+    detail,
+    trace,
+    guardHealth: guardHealthForLedger(result && result.guard_health),
+  });
+}
+
+/** The ADAM_OK stdout line, likewise extracted so the interpolation is reachable from a test. */
+function adamOkLine(scope, result) {
+  const key = scope ? scope.scope_key : 'none';
+  return `ADAM_OK scope=${key} (nothing cleared the bar)${formatGuardHealth(result && result.guard_health)}`;
+}
+
+/**
+ * Decide the whole outcome of a scan — verdict, ledger entry and stdout — from a selectAdvisory
+ * result. main() then performs side effects and holds no branching of its own.
+ *
+ * WHY THIS SHAPE, and what it does NOT close. Mutation testing found the three call sites that
+ * passed `result` into the ledger builder still surviving, because they lived inside main(), which
+ * is not exported and is therefore unreachable from any unit test. Collapsing them into ONE call
+ * shrinks that surface to a single hop, and every decision it makes is tested here.
+ *
+ * The residual is real and is stated rather than papered over: `scanOutcome(...)` is still invoked
+ * from main(), and a mutation that passed it a null result would produce no unit-test signal. That
+ * last hop cannot be closed by unit tests at all — it needs a process-level test that actually runs
+ * the CLI, which this scan cannot have cheaply because it reads the database first. Recording the
+ * boundary precisely is the honest move; claiming the hop is covered would be the third repetition
+ * of the exact defect this SD exists to remove.
+ */
+function scanOutcome({ result, scope, flagEnabled }) {
+  const surfaced = result && result.surfaced;
+  if (!surfaced) {
+    return {
+      verdict: 'ADAM_OK',
+      entry: advisoryLedgerEntry({ result, scope, verdict: 'ADAM_OK', flagEnabled }),
+      stdout: adamOkLine(scope, result),
+    };
+  }
+  const detail = surfaced.dedup_key || null;
+  if (!flagEnabled) {
+    return {
+      verdict: 'SUPPRESSED_FLAG_OFF',
+      entry: advisoryLedgerEntry({ result, scope, verdict: 'SUPPRESSED_FLAG_OFF', flagEnabled, detail }),
+      stdout: null,   // main() renders this one; it needs the gate source, which is not a scan input
+    };
+  }
+  return {
+    verdict: 'SURFACED',
+    entry: advisoryLedgerEntry({ result, scope, verdict: 'SURFACED', flagEnabled, detail, trace: result.trace }),
+    stdout: null,     // the advisory body is shelled out to the advisory lane
+  };
+}
+
 // NOTE: lib/adam/* and lib/eva/* are ESM; this CommonJS CLI loads them via
 // dynamic import() with STRING-LITERAL relative specifiers — both Windows-safe
 // at runtime and traceable by the WIRE_CHECK static call-graph (a computed
@@ -289,29 +377,29 @@ async function main() {
 
     const result = selectAdvisory(guarded.kept, selectOpts);
 
-    if (!result.surfaced) {
+    // ONE seam. Every verdict, ledger entry and stdout line is decided by the exported, tested
+    // scanOutcome(); what remains below is side effects. See its docblock for the one hop this
+    // still cannot cover and why.
+    const outcome = scanOutcome({ result, scope, flagEnabled: gateEnabled });
+    const entry = appendLedger(outcome.entry);
+
+    if (outcome.verdict === 'ADAM_OK') {
       // The 21-pass path. `guard_health` is what separates "nothing qualified" from "the terms
       // could not judge" — without it these two rows are byte-identical.
-      const entry = appendLedger(buildLedgerEntry({
-        scope, verdict: 'ADAM_OK', cleared: 0, flagEnabled: gateEnabled,
-        guardHealth: result.guard_health ? result.guard_health.summary : null,
-      }));
-      process.stdout.write(`ADAM_OK scope=${scope.scope_key} (nothing cleared the bar)${formatGuardHealth(result.guard_health)}\n`);
+      process.stdout.write(outcome.stdout + '\n');
       process.stdout.write(JSON.stringify(entry) + '\n');
       process.exit(0);
     }
 
     const body = formatAdvisoryBody(result.surfaced);
-    if (!gateEnabled) {
+    if (outcome.verdict === 'SUPPRESSED_FLAG_OFF') {
       // Cleared the bar, but the surfacing path is inert until the gate clears
       // (env off, or QF-20260610-863: the authoritative registry killed it).
-      appendLedger(buildLedgerEntry({ scope, verdict: 'SUPPRESSED_FLAG_OFF', cleared: result.cleared, flagEnabled: gateEnabled, detail: result.surfaced.dedup_key || null }));
       process.stdout.write(`SUPPRESSED_FLAG_OFF scope=${scope.scope_key} (1 cleared; ADAM_GOVERNANCE_HEARTBEAT_V1 gate off: ${gate.source})\n`);
       process.exit(0);
     }
 
     // gate ON (env AND registry): emit exactly ONE advisory via the existing lane.
-    appendLedger(buildLedgerEntry({ scope, verdict: 'SURFACED', cleared: result.cleared, flagEnabled: gateEnabled, detail: result.surfaced.dedup_key || null, trace: result.trace, guardHealth: result.guard_health ? result.guard_health.summary : null }));
     const r = spawnSync('node', [ADVISORY_CLI, 'send', body], { stdio: 'inherit' });
     process.exit(r.status == null ? 0 : r.status);
   } catch (e) {
@@ -321,7 +409,7 @@ async function main() {
   }
 }
 
-module.exports = { isFlagEnabled, resolveGovernanceFlagGate, parseArgs, buildLedgerEntry, formatGuardHealth, usage, LEDGER_PATH };
+module.exports = { isFlagEnabled, resolveGovernanceFlagGate, parseArgs, buildLedgerEntry, formatGuardHealth, guardHealthForLedger, advisoryLedgerEntry, adamOkLine, scanOutcome, usage, LEDGER_PATH };
 
 if (require.main === module) {
   main();

--- a/tests/unit/adam/rationale-bar-capability-gap.test.js
+++ b/tests/unit/adam/rationale-bar-capability-gap.test.js
@@ -31,9 +31,26 @@ const base = (over = {}) => ({
 
 describe('FR-2: capabilityGapTerm — pure, self-gating, bounded (mirrors waveAlignmentTerm)', () => {
   it('1.0 no-op when no data, no candidate.capability, or an unknown/excluded capability', () => {
-    expect(capabilityGapTerm(base({ capability: 'X' }), undefined)).toEqual({ active: false, multiplier: 1.0, buildPct: null });
-    expect(capabilityGapTerm(base(), { gaps: { X: 0 } })).toEqual({ active: false, multiplier: 1.0, buildPct: null }); // candidate has no capability
-    expect(capabilityGapTerm(base({ capability: 'NotMeasured' }), { gaps: { X: 0 } })).toEqual({ active: false, multiplier: 1.0, buildPct: null }); // capability excluded (unknown)
+    // SD-LEO-INFRA-PURE-GUARD-UNWIRED-001 FR-4 (AC-4) widened the no-op return with an
+    // `inactive_reason`, so this assertion moved from toEqual to an explicit two-part check:
+    // the SCORING contract must be byte-identical (unchanged 1.0 no-op — the property this test
+    // was written to protect), and the new field must name WHICH input was absent. Relaxing to a
+    // bare toMatchObject would have let a future change bury a real scoring regression under an
+    // additive key, so the scoring keys are still pinned exactly.
+    const noop = (r) => ({ active: r.active, multiplier: r.multiplier, buildPct: r.buildPct });
+    const NOOP = { active: false, multiplier: 1.0, buildPct: null };
+
+    const noGaps = capabilityGapTerm(base({ capability: 'X' }), undefined);
+    expect(noop(noGaps)).toEqual(NOOP);
+    expect(noGaps.inactive_reason).toBe('no_gaps_supplied');
+
+    const noCapability = capabilityGapTerm(base(), { gaps: { X: 0 } }); // candidate has no capability
+    expect(noop(noCapability)).toEqual(NOOP);
+    expect(noCapability.inactive_reason).toBe('candidate_has_no_capability');
+
+    const excluded = capabilityGapTerm(base({ capability: 'NotMeasured' }), { gaps: { X: 0 } }); // unknown/excluded
+    expect(noop(excluded)).toEqual(NOOP);
+    expect(excluded.inactive_reason).toBe('capability_absent_from_gap_map');
   });
 
   it('lower build% => higher multiplier, bounded by CLAMP_HI (built=1.0, unbuilt=CLAMP_HI, partial=midpoint)', () => {

--- a/tests/unit/governance/guard-sustained-zero.test.js
+++ b/tests/unit/governance/guard-sustained-zero.test.js
@@ -161,8 +161,8 @@ describe('the alarm cannot be talked into health it did not establish', () => {
     // `Object.prototype.observations = 40; Object.prototype.blocked = 3` made classifyGuard report
     // a guard nobody ever watched as "blocked 3/40 — demonstrably able to block", and assessGuards
     // print healthy=3 for three empty records.
-    Object.prototype.observations = 40;   // eslint-disable-line no-extend-native
-    Object.prototype.blocked = 3;         // eslint-disable-line no-extend-native
+    Object.prototype.observations = 40;
+    Object.prototype.blocked = 3;
     try {
       expect(classifyGuard({ guard: 'unobserved' }, '7d').state).toBe(GUARD_HEALTH.UNKNOWN);
       expect(assessGuards([{ guard: 'a' }, { guard: 'b' }], '7d').summary).toContain('healthy=0');

--- a/tests/unit/governance/guard-sustained-zero.test.js
+++ b/tests/unit/governance/guard-sustained-zero.test.js
@@ -1,0 +1,125 @@
+/**
+ * FR-2 — a gate that has never blocked anything is not a passing gate, it is an unplugged one.
+ * SD-LEO-INFRA-PURE-GUARD-UNWIRED-001.
+ *
+ * THE ALARM MUST DISCRIMINATE, and that is most of what these tests are about. An alarm that fires
+ * on everything is muted within a week, and a muted alarm is the silence it was built to break. So
+ * every firing case here is paired with a case that must NOT fire.
+ *
+ * THE THIRD STATE IS THE SUBTLE PART. The FR names its own known failure mode: an alarm that cannot
+ * SEE blocking events reports diligence as neglect. A guard nobody observed and a guard that
+ * observed nothing both present as zero. Collapsing them produces false alarms; so UNKNOWN is a
+ * first-class verdict that is neither health nor alarm.
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyGuard, assessGuards, GUARD_HEALTH } from '../../../lib/governance/guard-sustained-zero.js';
+
+describe('SUSPECT — observed, ran, never blocked', () => {
+  it('a guard that ran and blocked zero times is SUSPECT, not healthy', () => {
+    // AC-1. This is the whole thesis: it ran 27 times, nothing was missing, and it never once
+    // blocked — the shape of a predicate whose regex compiled to a backspace character.
+    const r = classifyGuard({ guard: 'staleCheck', observations: 27, blocked: 0 }, '7d');
+    expect(r.state).toBe(GUARD_HEALTH.SUSPECT);
+    expect(r.detail).toContain('staleCheck');
+    expect(r.detail).toContain('7d');
+    expect(r.detail).toMatch(/unplugged/);
+  });
+
+  it('names WHICH input was missing so a consumer need not re-derive it', () => {
+    // AC-4. "Something is wrong with waveAlignmentTerm" is not actionable; "it took the no-data
+    // branch 12x because `waves` was absent" is.
+    const r = classifyGuard({
+      guard: 'waveAlignmentTerm', observations: 12, blocked: 0,
+      permissiveNoData: 12, missingInput: 'waves',
+    }, '7d');
+    expect(r.state).toBe(GUARD_HEALTH.SUSPECT);
+    expect(r.missingInput).toBe('waves');
+    expect(r.detail).toContain("'waves'");
+    expect(r.detail).toContain('12x');
+  });
+});
+
+describe('HEALTHY — the negative control, so the alarm is proven to discriminate', () => {
+  it('a guard that HAS blocked in the window is healthy', () => {
+    // AC-2, and load-bearing: without it, "everything is suspect" would satisfy every assertion
+    // above while making the alarm worthless.
+    const r = classifyGuard({ guard: 'realGate', observations: 40, blocked: 3 }, '7d');
+    expect(r.state).toBe(GUARD_HEALTH.HEALTHY);
+    expect(r.detail).toContain('3/40');
+  });
+
+  it('a single block in a large window is still healthy — it demonstrably CAN block', () => {
+    // The claim is about capability, not frequency. A rarely-triggered gate is not a broken one.
+    expect(classifyGuard({ guard: 'g', observations: 1000, blocked: 1 }).state).toBe(GUARD_HEALTH.HEALTHY);
+  });
+});
+
+describe('UNKNOWN — the state that stops diligence being reported as neglect', () => {
+  it('no observation record is UNKNOWN, not suspect and not healthy', () => {
+    // AC-3. If this collapsed into SUSPECT, every unmeasured guard would raise a false alarm and
+    // the whole report would be muted. If it collapsed into HEALTHY, the silence returns.
+    for (const rec of [{ guard: 'g' }, { guard: 'g', observations: null, blocked: null }]) {
+      const r = classifyGuard(rec, '7d');
+      expect(r.state).toBe(GUARD_HEALTH.UNKNOWN);
+      expect(r.detail).toMatch(/NOT MEASURED/);
+      expect(r.detail).toMatch(/NOT health/);
+    }
+  });
+
+  it('OBSERVED-ZERO-TIMES is UNKNOWN and says so distinctly from never-measured', () => {
+    // AC-3's sharp edge: "we watched and it never ran" is a different fact from "we never watched",
+    // and both differ from "it ran and never blocked". Three facts, three renderings.
+    const r = classifyGuard({ guard: 'g', observations: 0, blocked: 0 }, '7d');
+    expect(r.state).toBe(GUARD_HEALTH.UNKNOWN);
+    expect(r.detail).toMatch(/OBSERVED 0 times/);
+    expect(r.detail).not.toMatch(/NOT MEASURED/);
+  });
+
+  it('THE DISCRIMINATION — measured-zero-blocks and unmeasured render differently', () => {
+    const suspect = classifyGuard({ guard: 'g', observations: 5, blocked: 0 }, '7d');
+    const unknown = classifyGuard({ guard: 'g', observations: null, blocked: null }, '7d');
+    expect(suspect.state).not.toBe(unknown.state);
+    expect(suspect.detail).not.toBe(unknown.detail);
+  });
+});
+
+describe('the report emits every guard, zeros included', () => {
+  it('counts are unconditional — a counter that appears only when non-zero recreates the ambiguity', () => {
+    // The lesson carried from worker-signal-starvation.cjs: `promoted=0` omitted reads identically
+    // to "nothing needs attention", which is how the original starvation stayed invisible.
+    const a = assessGuards([
+      { guard: 'healthy1', observations: 10, blocked: 2 },
+      { guard: 'suspect1', observations: 10, blocked: 0 },
+      { guard: 'unknown1' },
+    ], '7d');
+    expect(a.summary).toBe('GUARD SUSTAINED-ZERO (7d): healthy=1 suspect=1 unknown=1');
+    expect(a.results).toHaveLength(3);
+  });
+
+  it('an all-healthy population still prints its zeros', () => {
+    const a = assessGuards([{ guard: 'g', observations: 5, blocked: 1 }], '7d');
+    expect(a.summary).toContain('suspect=0');
+    expect(a.summary).toContain('unknown=0');
+  });
+
+  it('an empty population is not an error and not a pass', () => {
+    const a = assessGuards([], '7d');
+    expect(a.results).toEqual([]);
+    expect(a.summary).toContain('healthy=0');
+  });
+});
+
+describe('malformed input degrades to UNKNOWN rather than to health', () => {
+  it('non-numeric counts are unmeasured, never optimistic', () => {
+    // The direction matters: coercing junk to 0 would make a broken feed indistinguishable from a
+    // guard that ran and passed — the permissive answer, which is this SD's entire subject.
+    for (const bad of ['5', NaN, {}, [], true, -0.5 / 0]) {
+      expect(classifyGuard({ guard: 'g', observations: bad, blocked: 0 }).state).toBe(GUARD_HEALTH.UNKNOWN);
+      expect(classifyGuard({ guard: 'g', observations: 5, blocked: bad }).state).toBe(GUARD_HEALTH.UNKNOWN);
+    }
+  });
+
+  it('a guard with no name still reports rather than vanishing', () => {
+    expect(classifyGuard({ observations: 5, blocked: 0 }).guard).toBe('(unnamed)');
+  });
+});

--- a/tests/unit/governance/guard-sustained-zero.test.js
+++ b/tests/unit/governance/guard-sustained-zero.test.js
@@ -26,15 +26,22 @@ describe('SUSPECT — observed, ran, never blocked', () => {
   });
 
   it('names WHICH input was missing so a consumer need not re-derive it', () => {
-    // AC-4. "Something is wrong with waveAlignmentTerm" is not actionable; "it took the no-data
-    // branch 12x because `waves` was absent" is.
+    // "Something is wrong with this guard" is not actionable; "it took the no-data branch 12x
+    // because `spent` was absent" is.
+    //
+    // FR-5 COMPLIANCE, and I had to fix this fixture: it originally used waveAlignmentTerm with
+    // missingInput:'waves', which silently re-asserts the REFUTED claim that its caller never
+    // supplies waves. That caller has been wired since 1650f8e8cf9 (2026-06-15) and is
+    // flag-enabled live; the real mechanism is an empty okr_linkages table producing a silent
+    // fail-CLOSED. Carrying the old attribution into a test fixture is exactly how a corrected
+    // claim propagates anyway — this SD's own defect, one level out.
     const r = classifyGuard({
-      guard: 'waveAlignmentTerm', observations: 12, blocked: 0,
-      permissiveNoData: 12, missingInput: 'waves',
+      guard: 'enforceSweepBudget', observations: 12, blocked: 0,
+      permissiveNoData: 12, missingInput: 'spent',
     }, '7d');
     expect(r.state).toBe(GUARD_HEALTH.SUSPECT);
-    expect(r.missingInput).toBe('waves');
-    expect(r.detail).toContain("'waves'");
+    expect(r.missingInput).toBe('spent');
+    expect(r.detail).toContain("'spent'");
     expect(r.detail).toContain('12x');
   });
 });

--- a/tests/unit/governance/guard-sustained-zero.test.js
+++ b/tests/unit/governance/guard-sustained-zero.test.js
@@ -152,6 +152,63 @@ describe('the report emits every guard, zeros included', () => {
   });
 });
 
+describe('the alarm cannot be talked into health it did not establish', () => {
+  // Every finding below was reachable in the permissive direction, i.e. each one forged HEALTHY or
+  // suppressed an explanation. That asymmetry is the point: a bug that makes this module shout is
+  // noisy, a bug that makes it reassure is the defect it exists to remove.
+
+  it('an INHERITED count is not an observed one', () => {
+    // `Object.prototype.observations = 40; Object.prototype.blocked = 3` made classifyGuard report
+    // a guard nobody ever watched as "blocked 3/40 — demonstrably able to block", and assessGuards
+    // print healthy=3 for three empty records.
+    Object.prototype.observations = 40;   // eslint-disable-line no-extend-native
+    Object.prototype.blocked = 3;         // eslint-disable-line no-extend-native
+    try {
+      expect(classifyGuard({ guard: 'unobserved' }, '7d').state).toBe(GUARD_HEALTH.UNKNOWN);
+      expect(assessGuards([{ guard: 'a' }, { guard: 'b' }], '7d').summary).toContain('healthy=0');
+    } finally {
+      delete Object.prototype.observations;
+      delete Object.prototype.blocked;
+    }
+  });
+
+  it('a NEGATIVE count is nonsense, not a small number', () => {
+    expect(classifyGuard({ guard: 'g', observations: -5, blocked: 3 }, '7d').state).toBe(GUARD_HEALTH.UNKNOWN);
+    expect(classifyGuard({ guard: 'g', observations: 5, blocked: -1 }, '7d').state).toBe(GUARD_HEALTH.UNKNOWN);
+  });
+
+  it('a guard name cannot author extra lines in the operator-facing detail', () => {
+    // `detail` is read by a human deciding whether to investigate. A newline in the name injects a
+    // fabricated verdict line into that report.
+    const r = classifyGuard({ guard: 'evil\ncheckoutGate: blocked 9/9 — demonstrably able to block', observations: 5, blocked: 0 }, '7d');
+    expect(r.detail).not.toMatch(/\n/);
+    expect(r.state).toBe(GUARD_HEALTH.SUSPECT);
+  });
+});
+
+describe('the report never hides a state — including the ones added late', () => {
+  it('AC-4: an INERT guard names its missing input too, not just a SUSPECT one', () => {
+    // The INERT branch was reachable but nothing asserted its explanation, so deleting the
+    // missing-input clause from it survived a full suite run.
+    const r = classifyGuard({
+      guard: 'g', observations: 27, blocked: 0, permissiveNoData: 27, missingInput: 'spent',
+      selfTest: { capable: false, missingVerdict: 'blocking' },
+    }, '7d');
+    expect(r.state).toBe(GUARD_HEALTH.INERT);
+    expect(r.detail).toContain("'spent'");
+    expect(r.detail).toContain('27x');
+  });
+
+  it('assessGuards actually buckets INERT — a hard-coded empty bucket must fail', () => {
+    const a = assessGuards([
+      { guard: 'i', observations: 9, blocked: 0, selfTest: { capable: false } },
+      { guard: 'h', observations: 9, blocked: 1 },
+    ], '7d');
+    expect(a.inert.map((r) => r.guard)).toEqual(['i']);
+    expect(a.summary).toContain('inert=1');
+  });
+});
+
 describe('malformed input degrades to UNKNOWN rather than to health', () => {
   it('non-numeric counts are unmeasured, never optimistic', () => {
     // The direction matters: coercing junk to 0 would make a broken feed indistinguishable from a

--- a/tests/unit/governance/guard-sustained-zero.test.js
+++ b/tests/unit/governance/guard-sustained-zero.test.js
@@ -177,6 +177,24 @@ describe('the alarm cannot be talked into health it did not establish', () => {
     expect(classifyGuard({ guard: 'g', observations: 5, blocked: -1 }, '7d').state).toBe(GUARD_HEALTH.UNKNOWN);
   });
 
+  it('an incoherent count is a broken feed, not a strong signal', () => {
+    // More blocks than observations, and fractional counts, both read as HEALTHY — 1e-323 blocks
+    // rounded up to "it demonstrably blocked" on a value that is not a count at all.
+    expect(classifyGuard({ guard: 'g', observations: 1, blocked: 999 }, '7d').state).toBe(GUARD_HEALTH.UNKNOWN);
+    expect(classifyGuard({ guard: 'g', observations: 10, blocked: 0.5 }, '7d').state).toBe(GUARD_HEALTH.UNKNOWN);
+    expect(classifyGuard({ guard: 'g', observations: 10, blocked: 1e-323 }, '7d').state).toBe(GUARD_HEALTH.UNKNOWN);
+    expect(classifyGuard({ guard: 'g', observations: 10, blocked: 3 }, '7d').state).toBe(GUARD_HEALTH.HEALTHY); // control
+  });
+
+  it('the WINDOW LABEL cannot author lines either — the last unsanitised interpolation', () => {
+    // It reaches the durable ledger summary, and it was the one interpolation with neither
+    // sanitisation nor a length bound.
+    const r = classifyGuard({ guard: 'g', observations: 5, blocked: 0 }, '7d\nfakeGuard: blocked 9/9 — demonstrably able to block');
+    expect(r.detail).not.toMatch(/\n/);
+    const long = classifyGuard({ guard: 'g', observations: 5, blocked: 0 }, 'x'.repeat(5000));
+    expect(long.detail.length).toBeLessThan(600);
+  });
+
   it('a guard name cannot author extra lines in the operator-facing detail', () => {
     // `detail` is read by a human deciding whether to investigate. A newline in the name injects a
     // fabricated verdict line into that report.

--- a/tests/unit/governance/guard-sustained-zero.test.js
+++ b/tests/unit/governance/guard-sustained-zero.test.js
@@ -83,6 +83,42 @@ describe('UNKNOWN — the state that stops diligence being reported as neglect',
   });
 });
 
+describe('AC-4 — FR-2 consumes FR-3: an INERT zero is not a QUIET zero', () => {
+  it('a zero from a predicate PROVEN unable to block reports INERT, not SUSPECT', () => {
+    // The distinction changes what an operator does. SUSPECT means "go find out why this never
+    // fired". INERT means "it could not have fired; fix the predicate" — a different, shorter job.
+    const r = classifyGuard({
+      guard: 'blockPattern', observations: 27, blocked: 0,
+      selfTest: { capable: false, missingVerdict: 'blocking' },
+    }, '7d');
+    expect(r.state).toBe(GUARD_HEALTH.INERT);
+    expect(r.detail).toMatch(/cannot produce its blocking verdict/);
+    expect(r.detail).toMatch(/could not have blocked/);
+  });
+
+  it('NEGATIVE CONTROL — the same zero with a CAPABLE predicate stays SUSPECT', () => {
+    // Without this, everything with a selfTest field would read as INERT and the pairing would
+    // explain away every genuine sustained zero — worse than not pairing at all.
+    const r = classifyGuard({
+      guard: 'blockPattern', observations: 27, blocked: 0,
+      selfTest: { capable: true, missingVerdict: null },
+    }, '7d');
+    expect(r.state).toBe(GUARD_HEALTH.SUSPECT);
+  });
+
+  it('no self-test at all leaves the verdict SUSPECT — absence is not exoneration', () => {
+    const r = classifyGuard({ guard: 'g', observations: 27, blocked: 0 }, '7d');
+    expect(r.state).toBe(GUARD_HEALTH.SUSPECT);
+  });
+
+  it('a capable predicate that DID block is still healthy — the self-test does not override facts', () => {
+    const r = classifyGuard({
+      guard: 'g', observations: 10, blocked: 2, selfTest: { capable: false },
+    }, '7d');
+    expect(r.state).toBe(GUARD_HEALTH.HEALTHY);
+  });
+});
+
 describe('the report emits every guard, zeros included', () => {
   it('counts are unconditional — a counter that appears only when non-zero recreates the ambiguity', () => {
     // The lesson carried from worker-signal-starvation.cjs: `promoted=0` omitted reads identically
@@ -92,7 +128,7 @@ describe('the report emits every guard, zeros included', () => {
       { guard: 'suspect1', observations: 10, blocked: 0 },
       { guard: 'unknown1' },
     ], '7d');
-    expect(a.summary).toBe('GUARD SUSTAINED-ZERO (7d): healthy=1 suspect=1 unknown=1');
+    expect(a.summary).toBe('GUARD SUSTAINED-ZERO (7d): healthy=1 suspect=1 inert=0 unknown=1');
     expect(a.results).toHaveLength(3);
   });
 

--- a/tests/unit/governance/guard-wiring.test.js
+++ b/tests/unit/governance/guard-wiring.test.js
@@ -89,6 +89,37 @@ describe('the registry is well-formed enough to act on', () => {
   it('scans a real corpus — a zero-file scan would make every assertion below vacuous', () => {
     expect(FILES.length).toBeGreaterThan(500);
   });
+
+  it('THE SCANNER ITSELF IS EXERCISED — a corpus walk nothing asserts on is not a check', () => {
+    // The gap this closes was found by adversarial review, and it is this SD's own defect class
+    // aimed at this SD's own test: replacing the body of wiredCallSites() with `return []` left the
+    // ENTIRE suite green. Every assertion below either tested the pure predicates (suppliesGatedInput,
+    // isStubbedInput) or asserted that the scanner found NOTHING — and "found nothing" is exactly
+    // what a scanner that never opens a file returns. The stated control and the delivered control
+    // were at different layers, and the uncovered layer was the one doing the work.
+    //
+    // A POSITIVE control fixes it: assert the scanner finds a call site that really exists.
+    const wired = GUARD_REGISTRY.filter((g) => g.expectedWired === true);
+    expect(wired.length, 'no wired guard is registered, so nothing forces the scanner to find anything').toBeGreaterThan(0);
+    for (const g of wired) {
+      const sites = wiredCallSites(g.name, g.gatedInput, g.module);
+      expect(sites.length, `${g.name} is registered as WIRED but the scanner found no caller supplying '${g.gatedInput}'`).toBeGreaterThan(0);
+    }
+  });
+
+  it('every required root is actually walked — narrowing SCAN_DIRS must not pass silently', () => {
+    // Paired with the above: a scanner can also be defeated by shrinking WHERE it looks. Dropping
+    // 'scripts' from SCAN_DIRS is invisible to a "did it find files" check (lib alone clears 500),
+    // and scripts/ is where enforceSweepBudget — the SD's motivating guard — is defined.
+    //
+    // Asserted against a HARD-CODED list, deliberately NOT against SCAN_DIRS: a check that compares
+    // the config to itself cannot fail, which is the codebase's own recorded lesson.
+    const REQUIRED_ROOTS = ['lib', 'scripts'];
+    for (const root of REQUIRED_ROOTS) {
+      const n = FILES.filter((f) => path.relative(repoRoot, f).replace(/\\/g, '/').startsWith(`${root}/`)).length;
+      expect(n, `no files scanned under ${root}/ — the corpus walk does not cover it`).toBeGreaterThan(0);
+    }
+  });
 });
 
 describe('A PROMPT STRING IS NOT A CALL SITE', () => {
@@ -163,6 +194,49 @@ describe('THE THIRD SHAPE — an input supplied as a stub is not wiring', () => 
     expect(isStubbedInput('{ getForecast: solomonForecast }', 'getForecast')).toBe(false);
     expect(suppliesGatedInput('{ getForecast: solomonForecast }', 'getForecast')).toBe(true);
     expect(suppliesGatedInput('{ getForecast: () => fetchReal() }', 'getForecast')).toBe(true);
+  });
+});
+
+describe('the registry and its patterns cannot be edited into agreement', () => {
+  it('the gated input is escaped as DATA — a regex metacharacter must not match everything', () => {
+    // `gatedInput: '.*'` reported EVERY call site as supplying it, turning the whole registry green
+    // on one plausible typo; `'('` threw a SyntaxError; a pathological value backtracked
+    // exponentially. All three land on "this guard looks wired", the answer that ends enquiry.
+    expect(suppliesGatedInput('enforceSweepBudget({}) // no data at all', '.*')).toBe(false);
+    expect(() => suppliesGatedInput('anything', '(')).not.toThrow();
+    // An escaped '.' matches a literal dot and nothing else. My first version of this assertion
+    // expected `{ a.b: 1 }` NOT to match 'a.b', which is backwards — escaping is what MAKES it
+    // match there, and match only there.
+    expect(suppliesGatedInput('{ a.b: 1 }', 'a.b')).toBe(true);
+    expect(suppliesGatedInput('{ axb: 1 }', 'a.b')).toBe(false);
+    expect(suppliesGatedInput('{ spent, budget }', 'spent')).toBe(true);   // control: still works
+  });
+
+  it('the registry is frozen DEEPLY — a shallow freeze leaves the baseline writable', () => {
+    // Object.freeze on the array left every entry mutable, so `expectedWired = true` silently shrank
+    // the known-unwired baseline this test compares against.
+    expect(Object.isFrozen(GUARD_REGISTRY)).toBe(true);
+    expect(Object.isFrozen(GUARD_REGISTRY[0])).toBe(true);
+    const before = knownUnwired().length;
+    expect(() => { GUARD_REGISTRY[0].expectedWired = !GUARD_REGISTRY[0].expectedWired; }).toThrow();
+    expect(knownUnwired().length).toBe(before);
+  });
+
+  it('mocks, fixtures and harness code are not production wiring', () => {
+    // 111 files in this tree classified as production before these patterns existed — every one a
+    // file whose entire job is to MENTION production functions. A false POSITIVE here reports an
+    // unwired guard as healthy, which is the permissive direction.
+    for (const p of [
+      'lib/mock/firewall.js', 'lib/test-helpers/build.js', 'lib/testing/harness.js',
+      'lib/apa/fixtures/sample.mjs', 'src/thing.spec.ts', 'lib/x/__mocks__/y.js',
+    ]) {
+      expect(isProductionCallSite(p), p).toBe(false);
+    }
+    // …and TypeScript IS production: excluding it made 25 files invisible, and invisible resolves
+    // to "no caller found".
+    expect(isProductionCallSite('src/app/gate.ts')).toBe(true);
+    expect(isProductionCallSite('src/app/Gate.tsx')).toBe(true);
+    expect(isProductionCallSite('lib/real/module.js')).toBe(true);
   });
 });
 

--- a/tests/unit/governance/guard-wiring.test.js
+++ b/tests/unit/governance/guard-wiring.test.js
@@ -268,6 +268,37 @@ describe('the registry and its patterns cannot be edited into agreement', () => 
   });
 });
 
+describe('FR-1 TURNED ON THIS SD\'S OWN LAST HOP', () => {
+  it('main() actually supplies the scan result to the outcome builder', () => {
+    // The unclaimed win. I had written that main()'s single remaining call could not be covered by
+    // unit tests "at all", and review corrected it: the mutation class I demonstrated — deleting the
+    // argument, omitting it, stubbing it to null — is a STATIC property of the call text, and
+    // deciding exactly that is what suppliesGatedInput was built for. FR-1 asks "does a production
+    // caller actually supply the input this thing needs"; the last hop of this SD was that question,
+    // unanswered, in a file this SD wrote, with the answer sitting in a module this SD shipped.
+    //
+    // What this does NOT do, so the next reader does not over-read it: it cannot prove the value
+    // passed is the RIGHT one — that needs a process-level test running the CLI, which is not cheap
+    // because the scan reads the database first. It converts "no signal whatsoever" into "signal for
+    // deletion, omission and null-stubbing".
+    const src = fs.readFileSync(path.join(repoRoot, 'scripts/adam-opportunity-scan.cjs'), 'utf8');
+    // `outcome.entry`, not `outcome`: suppliesGatedInput matches an identifier followed by a
+    // supply token (`:` `,` `}` `)` `=`), and a member access puts a `.` there instead. Naming the
+    // whole expression is the correct input here — and it only works because gatedInput is escaped
+    // as data, which is the C5 fix earning its keep one file over.
+    for (const [callee, input] of [['scanOutcome', 'result'], ['appendLedger', 'outcome.entry']]) {
+      // The call inside main(), not the definition — skip the `function <name>(` declaration.
+      const calls = [...src.matchAll(new RegExp(`(?<!function )\\b${callee}\\s*\\(([\\s\\S]{0,300})`, 'g'))]
+        .map((m) => m[1]);
+      expect(calls.length, `no call to ${callee} found`).toBeGreaterThan(0);
+      expect(
+        calls.some((text) => suppliesGatedInput(text, input)),
+        `no call to ${callee} supplies '${input}' — the last hop is unwired`,
+      ).toBe(true);
+    }
+  });
+});
+
 describe('the detector can actually see wiring — not just its absence', () => {
   it('NEGATIVE CONTROL: a synthetic wired guard is detected', () => {
     // Without this, every assertion above would also pass on a detector that finds NOTHING, which

--- a/tests/unit/governance/guard-wiring.test.js
+++ b/tests/unit/governance/guard-wiring.test.js
@@ -1,0 +1,178 @@
+/**
+ * FR-1 — every self-gating guard must have a PRODUCTION caller that supplies the input it gates on.
+ * SD-LEO-INFRA-PURE-GUARD-UNWIRED-001.
+ *
+ * Generalises PAT-PROCESS-PRODUCER-CONSUMER-INVARIANT-001 (tests/unit/cron/*-wiring.test.js) from
+ * "this cron names its dispatcher" to "this guard names a caller that actually feeds it".
+ *
+ * THE QUESTION IT ANSWERS that no existing check could: not "is this function referenced" — grep
+ * answers that, and grep is what made enforceSweepBudget look wired for months — but "does anything
+ * executable pass it the data it self-gates on". A PROMPT STRING mentioning the function by name
+ * satisfies the first and not the second, and that gap is the entire defect class.
+ *
+ * Static only: reads source text, runs nothing, touches no DB.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  GUARD_REGISTRY, knownUnwired, isProductionCallSite, suppliesGatedInput, isStubbedInput,
+} from '../../../lib/governance/guard-wiring-registry.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const SCAN_DIRS = ['lib', 'scripts', 'server', 'src'];
+
+/** Every production source file, once. */
+function productionFiles() {
+  const out = [];
+  const walk = (dir) => {
+    let entries = [];
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      if (e.name === 'node_modules' || e.name === '.git' || e.name === '.worktrees') continue;
+      const full = path.join(dir, e.name);
+      if (e.isDirectory()) { walk(full); continue; }
+      if (isProductionCallSite(full)) out.push(full);
+    }
+  };
+  for (const d of SCAN_DIRS) walk(path.join(repoRoot, d));
+  return out;
+}
+
+const FILES = productionFiles();
+
+/**
+ * The registry is DATA ABOUT guards, never a caller of them — and it must be excluded explicitly.
+ *
+ * It caught itself on the first run: a docblock example written to explain the check —
+ * "it cannot tell enforceSweepBudget({ spent }) from enforceSweepBudget({})" — was counted as a
+ * real wired call site. That is this SD's own defect class, in the detector built to find it: a
+ * reference that LOOKS like wiring and executes nothing. Left as a comment rather than quietly
+ * patched, because the next person writing a scanner will reach for the same shape.
+ */
+const REGISTRY_MODULE = 'lib/governance/guard-wiring-registry.js';
+
+/** Call sites of `name` that also supply `gatedInput`, excluding the file that defines it. */
+function wiredCallSites(name, gatedInput, defModule) {
+  const hits = [];
+  // A FIXED WINDOW after the opening paren — deliberately NOT `[\s\S]{0,400}?\)`, which is lazy and
+  // stops at the FIRST close paren. For `runPreShipGate(brief, { getForecast: () => undefined })`
+  // that first paren belongs to the ARROW FUNCTION, so the captured text was `brief, { getForecast: (`
+  // — the stub was truncated away and the call read as wired. Silent truncation producing the
+  // permissive answer, in the detector for guards that produce the permissive answer.
+  const callRe = new RegExp(`\\b${name}\\s*\\(([\\s\\S]{0,400})`, 'g');
+  for (const file of FILES) {
+    const rel = path.relative(repoRoot, file).replace(/\\/g, '/');
+    if (rel === defModule || rel === REGISTRY_MODULE) continue;   // definition and registry are not callers
+    let src = '';
+    try { src = fs.readFileSync(file, 'utf8'); } catch { continue; }
+    if (!src.includes(name)) continue;
+    for (const m of src.matchAll(callRe)) {
+      if (suppliesGatedInput(m[1], gatedInput)) { hits.push(rel); break; }
+    }
+  }
+  return hits;
+}
+
+describe('the registry is well-formed enough to act on', () => {
+  it('every guard names a file:line and the exact input it gates on', () => {
+    // AC-4. Without the gated input, the check degrades to "is it mentioned" — which is the check
+    // that already existed and already failed.
+    for (const g of GUARD_REGISTRY) {
+      expect(g.definedAt, `${g.name} has no file:line`).toMatch(/:\d+$/);
+      expect(g.gatedInput, `${g.name} does not say what it gates on`).toBeTruthy();
+      expect(g.permissiveMeans, `${g.name} does not say what its permissive branch MEANS`).toBeTruthy();
+    }
+  });
+
+  it('scans a real corpus — a zero-file scan would make every assertion below vacuous', () => {
+    expect(FILES.length).toBeGreaterThan(500);
+  });
+});
+
+describe('A PROMPT STRING IS NOT A CALL SITE', () => {
+  it('rejects prompts, docs, tests and archives as wiring', () => {
+    // AC-3. This is the distinction the whole SD turns on: enforceSweepBudget's only caller-shaped
+    // reference is a prompt string, and two shipped docs assert it runs.
+    expect(isProductionCallSite('.claude/commands/solomon.md')).toBe(false);
+    expect(isProductionCallSite('scripts/solomon-startup-check.mjs')).toBe(true); // the FILE is production…
+    expect(isProductionCallSite('docs/protocol/coordinator-solomon-comms.md')).toBe(false);
+    expect(isProductionCallSite('tests/unit/foo.test.js')).toBe(false);
+    expect(isProductionCallSite('lib/foo/bar.test.js')).toBe(false);
+    expect(isProductionCallSite('scripts/archive/old.js')).toBe(false);
+    expect(isProductionCallSite('lib/real/module.js')).toBe(true);
+  });
+
+  it('…but a mention inside a production file still does not count unless it FEEDS the guard', () => {
+    // The subtle half: solomon-startup-check.mjs IS production, yet its reference is a prompt
+    // string. suppliesGatedInput is what separates "names it" from "passes it the data".
+    expect(suppliesGatedInput('enforceSweepBudget mentioned in a prompt', 'spent')).toBe(false);
+    expect(suppliesGatedInput('{ budget, tasks }', 'spent')).toBe(false);
+    expect(suppliesGatedInput('{ spent, budget }', 'spent')).toBe(true);
+    expect(suppliesGatedInput('{ spent: total }', 'spent')).toBe(true);
+  });
+});
+
+describe('THE BASELINE — it may shrink, it must never grow', () => {
+  it('no guard outside the known-unwired set has lost its wiring', () => {
+    // A permanently red suite blocks every merge and gets muted, which is how a loud signal becomes
+    // a quiet one. So the KNOWN unwired guards are recorded as a baseline; anything NEW failing is
+    // a regression and fails here.
+    const baseline = new Set(knownUnwired());
+    const regressions = [];
+    for (const g of GUARD_REGISTRY) {
+      if (baseline.has(g.name)) continue;
+      const sites = wiredCallSites(g.name, g.gatedInput, g.module);
+      if (sites.length === 0) regressions.push(`${g.name} (needs '${g.gatedInput}') — permissive means: ${g.permissiveMeans}`);
+    }
+    expect(regressions, `guards lost their wiring:\n  ${regressions.join('\n  ')}`).toEqual([]);
+  });
+
+  it('reports the known-unwired population, naming the MISSING INPUT and the consequence', () => {
+    // AC-1: the failure must name the missing input, not just the guard. This test does not fail —
+    // it is the loud inventory the SD asks for. Shrinking this list is the work; the test above is
+    // what stops it growing.
+    const unwired = GUARD_REGISTRY.filter((g) => g.expectedWired === false);
+    expect(unwired.length).toBeGreaterThan(0);
+    for (const g of unwired) {
+      const sites = wiredCallSites(g.name, g.gatedInput, g.module);
+      // If one of these acquires a real caller, remove it from the baseline — that is the win.
+      expect(sites, `${g.name} now HAS a wired caller (${sites.join(', ')}) — remove expectedWired:false from the registry`).toEqual([]);
+    }
+  });
+});
+
+describe('THE THIRD SHAPE — an input supplied as a stub is not wiring', () => {
+  it('a hard-coded no-op accessor does not count as supplying the input', () => {
+    // Found live, and it defeated this detector on its first real run: the PRODUCTION entrypoint
+    // scripts/daily-review-drive-doc.js:45 calls
+    //   runPreShipGate(brief, { getForecast: () => undefined })
+    // beneath a comment reading "Real runs inject the Solomon forecast accessor" — which that run
+    // IS. A check asking only "is the input supplied" reports this guard as healthy forever.
+    expect(isStubbedInput('brief, { getForecast: () => undefined }', 'getForecast')).toBe(true);
+    expect(suppliesGatedInput('brief, { getForecast: () => undefined }', 'getForecast')).toBe(false);
+    for (const stub of ['{ x: () => null }', '{ x: () => false }', '{ x: () => ({}) }', '{ x: null }', '{ x: undefined }']) {
+      expect(isStubbedInput(stub, 'x'), stub).toBe(true);
+    }
+  });
+
+  it('NEGATIVE CONTROL — a REAL accessor still counts as wiring', () => {
+    // Without this, "everything is a stub" would satisfy the assertion above and report the whole
+    // codebase unwired — the mirror failure, and just as believable.
+    expect(isStubbedInput('{ getForecast: solomonForecast }', 'getForecast')).toBe(false);
+    expect(suppliesGatedInput('{ getForecast: solomonForecast }', 'getForecast')).toBe(true);
+    expect(suppliesGatedInput('{ getForecast: () => fetchReal() }', 'getForecast')).toBe(true);
+  });
+});
+
+describe('the detector can actually see wiring — not just its absence', () => {
+  it('NEGATIVE CONTROL: a synthetic wired guard is detected', () => {
+    // Without this, every assertion above would also pass on a detector that finds NOTHING, which
+    // would report the whole codebase as unwired and be believed. A check that can only return one
+    // answer is the defect this SD exists to remove.
+    const call = 'runPreShipGate({ getForecast, artifacts })';
+    expect(suppliesGatedInput(call, 'getForecast')).toBe(true);
+    expect(suppliesGatedInput(call, 'spent')).toBe(false);
+  });
+});

--- a/tests/unit/governance/guard-wiring.test.js
+++ b/tests/unit/governance/guard-wiring.test.js
@@ -86,25 +86,53 @@ describe('the registry is well-formed enough to act on', () => {
     }
   });
 
+  it('…and the file:line RESOLVES — a format check is not a check on the content', () => {
+    // Adversarial review found 6 of 7 line numbers wrong, including one I had just added. The
+    // assertion above only matched /:\d+$/, so every wrong number passed: a check that validates
+    // the SHAPE of an answer and never the answer is this SD's own subject, aimed at this SD's own
+    // inventory. Resolve them instead.
+    const defRe = (n) => new RegExp(
+      `^\\s*(?:export\\s+)?(?:async\\s+)?function\\s+${n}\\b`
+      + `|^\\s*(?:export\\s+)?(?:const|let|var)\\s+${n}\\s*=`
+      + `|^\\s*${n}\\s*[:(]`,
+    );
+    for (const g of GUARD_REGISTRY) {
+      const [rel, lineStr] = g.definedAt.split(/:(?=\d+$)/);
+      const abs = path.join(repoRoot, rel);
+      expect(fs.existsSync(abs), `${g.name}: ${rel} does not exist`).toBe(true);
+      const lines = fs.readFileSync(abs, 'utf8').split(/\r?\n/);
+      const re = defRe(g.name);
+      const actual = lines.findIndex((l) => re.test(l)) + 1;
+      expect(actual, `${g.name} is not defined anywhere in ${rel}`).toBeGreaterThan(0);
+      expect(Number(lineStr), `${g.name}: definedAt says :${lineStr}, actual definition is at :${actual}`).toBe(actual);
+    }
+  });
+
   it('scans a real corpus — a zero-file scan would make every assertion below vacuous', () => {
     expect(FILES.length).toBeGreaterThan(500);
   });
 
-  it('THE SCANNER ITSELF IS EXERCISED — a corpus walk nothing asserts on is not a check', () => {
+  it('THE SCANNER MUST PRODUCE BOTH VERDICTS — FR-3\'s doctrine applied to FR-1\'s own scanner', () => {
     // The gap this closes was found by adversarial review, and it is this SD's own defect class
     // aimed at this SD's own test: replacing the body of wiredCallSites() with `return []` left the
-    // ENTIRE suite green. Every assertion below either tested the pure predicates (suppliesGatedInput,
-    // isStubbedInput) or asserted that the scanner found NOTHING — and "found nothing" is exactly
-    // what a scanner that never opens a file returns. The stated control and the delivered control
-    // were at different layers, and the uncovered layer was the one doing the work.
+    // ENTIRE suite green. Every other assertion here either tested the pure predicates
+    // (suppliesGatedInput, isStubbedInput) or asserted the scanner found NOTHING — and "found
+    // nothing" is exactly what a scanner that never opens a file returns. The stated control and
+    // the delivered control were at different layers, and the uncovered layer did the work.
     //
-    // A POSITIVE control fixes it: assert the scanner finds a call site that really exists.
-    const wired = GUARD_REGISTRY.filter((g) => g.expectedWired === true);
-    expect(wired.length, 'no wired guard is registered, so nothing forces the scanner to find anything').toBeGreaterThan(0);
-    for (const g of wired) {
-      const sites = wiredCallSites(g.name, g.gatedInput, g.module);
-      expect(sites.length, `${g.name} is registered as WIRED but the scanner found no caller supplying '${g.gatedInput}'`).toBeGreaterThan(0);
-    }
+    // The fix is FR-3's rule turned on FR-1: a check never shown to produce BOTH of its verdicts
+    // cannot be cited. So the scanner is required to FIND a call site that genuinely exists, and to
+    // NOT find one for an input that is genuinely absent from that same call. Anchored on a real
+    // production wiring rather than on registry membership — my first attempt registered FR-4's
+    // consumer as a guard purely so this test would have something to find, which reviewers
+    // correctly called a category error: it is a pure fold, its starved branch reports UNKNOWN, and
+    // UNKNOWN is explicitly not the permissive answer this registry enumerates.
+    const found = wiredCallSites('foldTermResults', 'results', 'lib/governance/inactive-reason-consumer.js');
+    expect(found.length, 'the scanner found NO caller for a call site that demonstrably exists').toBeGreaterThan(0);
+    expect(found).toContain('lib/adam/rationale-bar.js');
+
+    const notFound = wiredCallSites('foldTermResults', 'spent', 'lib/governance/inactive-reason-consumer.js');
+    expect(notFound, 'the scanner reported wiring for an input that call never supplies').toEqual([]);
   });
 
   it('every required root is actually walked — narrowing SCAN_DIRS must not pass silently', () => {
@@ -218,7 +246,7 @@ describe('the registry and its patterns cannot be edited into agreement', () => 
     expect(Object.isFrozen(GUARD_REGISTRY)).toBe(true);
     expect(Object.isFrozen(GUARD_REGISTRY[0])).toBe(true);
     const before = knownUnwired().length;
-    expect(() => { GUARD_REGISTRY[0].expectedWired = !GUARD_REGISTRY[0].expectedWired; }).toThrow();
+    expect(() => { GUARD_REGISTRY[0].expectedWired = true; }).toThrow();
     expect(knownUnwired().length).toBe(before);
   });
 

--- a/tests/unit/governance/guard-wiring.test.js
+++ b/tests/unit/governance/guard-wiring.test.js
@@ -62,13 +62,24 @@ function wiredCallSites(name, gatedInput, defModule) {
   // — the stub was truncated away and the call read as wired. Silent truncation producing the
   // permissive answer, in the detector for guards that produce the permissive answer.
   const callRe = new RegExp(`\\b${name}\\s*\\(([\\s\\S]{0,400})`, 'g');
+  // The DEFINITION is not a caller — but the rest of the defining file may be, and skipping the
+  // whole file was a blind spot review caught: capabilityGapTerm is genuinely called from
+  // lib/adam/rationale-bar.js, the same file that defines it, so its "unwired" verdict was reached
+  // WITHOUT ever evaluating its one real call site. The verdict happened to be right (that call
+  // supplies the candidate, not `capability`), which is exactly how a blind spot survives review —
+  // it agrees with you. Skip the declaration line only.
+  const defRe = new RegExp(`^\\s*(?:export\\s+)?(?:async\\s+)?function\\s+${name}\\b|^\\s*(?:export\\s+)?(?:const|let|var)\\s+${name}\\s*=`);
   for (const file of FILES) {
     const rel = path.relative(repoRoot, file).replace(/\\/g, '/');
-    if (rel === defModule || rel === REGISTRY_MODULE) continue;   // definition and registry are not callers
+    if (rel === REGISTRY_MODULE) continue;   // the registry is data ABOUT guards, never a caller
     let src = '';
     try { src = fs.readFileSync(file, 'utf8'); } catch { continue; }
     if (!src.includes(name)) continue;
     for (const m of src.matchAll(callRe)) {
+      // Exclude the declaration itself, whichever file it lives in.
+      const lineStart = src.lastIndexOf('\n', m.index) + 1;
+      const line = src.slice(lineStart, src.indexOf('\n', m.index) === -1 ? undefined : src.indexOf('\n', m.index));
+      if (rel === defModule && defRe.test(line)) continue;
       if (suppliesGatedInput(m[1], gatedInput)) { hits.push(rel); break; }
     }
   }
@@ -192,8 +203,24 @@ describe('THE BASELINE — it may shrink, it must never grow', () => {
     // AC-1: the failure must name the missing input, not just the guard. This test does not fail —
     // it is the loud inventory the SD asks for. Shrinking this list is the work; the test above is
     // what stops it growing.
+    //
+    // AND IT MUST ACTUALLY PRINT. Review found the second half of AC-1 unmet: the inventory was
+    // "loud" only in a failure message, on a branch that by construction cannot fail, so it emitted
+    // nothing at all. A signal that appears only on failure, in a test that cannot fail, is FR-2's
+    // defect one level up and inside FR-1 — the very shape this SD exists to remove.
+    //
+    // WRITTEN TO stderr, NOT console.warn, and this was measured rather than assumed. My first fix
+    // used console.warn to match two sibling guards in this directory — and it emitted nothing,
+    // because tests/setup.unit.js replaces global.console with vi.fn() stubs "to reduce noise". So
+    // those siblings do not print either; their inventories have been silent all along. I nearly
+    // shipped "it is loud now" on the strength of having written a log line, which is the same
+    // unchecked claim in the same SD for the third time. A probe test confirmed stderr survives.
     const unwired = GUARD_REGISTRY.filter((g) => g.expectedWired === false);
     expect(unwired.length).toBeGreaterThan(0);
+    process.stderr.write(`[FR-1 INVENTORY] ${unwired.length} self-gating guard(s) with NO production caller supplying their gated input:\n`);
+    for (const g of unwired) {
+      process.stderr.write(`    - ${g.name} (${g.definedAt}) needs '${g.gatedInput}' — permissive means: ${g.permissiveMeans}\n`);
+    }
     for (const g of unwired) {
       const sites = wiredCallSites(g.name, g.gatedInput, g.module);
       // If one of these acquires a real caller, remove it from the baseline — that is the win.

--- a/tests/unit/governance/inactive-reason-consumer.test.js
+++ b/tests/unit/governance/inactive-reason-consumer.test.js
@@ -11,7 +11,7 @@
 import { describe, it, expect } from 'vitest';
 import { foldTermResults, NO_DATA_REASONS } from '../../../lib/governance/inactive-reason-consumer.js';
 import { classifyGuard, GUARD_HEALTH } from '../../../lib/governance/guard-sustained-zero.js';
-import { capabilityGapTerm } from '../../../lib/adam/rationale-bar.js';
+import { capabilityGapTerm, waveAlignmentTerm, selectAdvisory } from '../../../lib/adam/rationale-bar.js';
 
 describe('AC-4 — capabilityGapTerm now says why, like its sibling', () => {
   // Signature is capabilityGapTerm(candidate, capabilityGap) — the CANDIDATE carries `capability`,
@@ -77,17 +77,74 @@ describe('AC-3 — the consumer CHANGES BEHAVIOUR when the signal is present', (
 });
 
 describe('a no-data reason and an evaluated-and-declined reason are not the same finding', () => {
-  it('only no-data reasons count as permissive-no-data', () => {
-    // empty_aligned_set means the guard HAD its data and found nothing — chasing "why didn't it
-    // fire" there is wasted work, so it must not inflate the no-data count.
+  it('CANNOT-JUDGE IS NO-DATA — the classification I got backwards, and what it cost', () => {
+    // The first version of this test asserted the opposite: that `empty_aligned_set` meant "the
+    // guard HAD its data and found nothing", so it must NOT inflate the no-data count. That is
+    // refuted by the file that emits it, twenty lines from the emit — rationale-bar.js:221 "Waves
+    // exist but NOTHING is linked => this term cannot judge alignment", and :248 "a term that
+    // cannot judge must not judge — the same doctrine as the empty-set case above."
+    //
+    // The cost was measured on this SD's own flagship instance, not argued: with 8 waves, 0 of 261
+    // roadmap_wave_items linked, and 27 evaluations, the fold reported permissiveNoData: 0 and
+    // missingInput: null while the no-data branch had fired all 27 times. FR-2 then printed
+    // "no-data branch taken 0x" and named nothing — the alarm built to catch instance 3 was blind
+    // to instance 3, in the permissive direction, because I asserted a classification instead of
+    // reading one. Kept as the test's headline rather than quietly corrected, because it is FR-5's
+    // exact failure mode committed inside FR-5's own SD.
     const folded = foldTermResults('waveAlignmentTerm', [
       { active: false, inactive_reason: 'empty_aligned_set' },
       { active: false, inactive_reason: 'zero_waves_or_no_alignment' },
     ]);
-    expect(folded.permissiveNoData).toBe(1);
-    expect(folded.missingInput).toBe('zero_waves_or_no_alignment');
+    expect(folded.permissiveNoData).toBe(2);
     expect(folded.reasons.empty_aligned_set).toBe(1);
-    expect(NO_DATA_REASONS.has('empty_aligned_set')).toBe(false);
+    expect(NO_DATA_REASONS).toContain('empty_aligned_set');
+    expect(NO_DATA_REASONS).toContain('id_space_mismatch');
+  });
+
+  it('THE FLAGSHIP INSTANCE — 27 empty-linkage passes now name the missing input', () => {
+    // The end-to-end shape the correction exists for: what the live roadmap actually produces.
+    const results = Array.from({ length: 27 }, () => waveAlignmentTerm({}, { waves: [{ okr_ids: [] }] }));
+    expect(results[0].inactive_reason).toBe('empty_aligned_set');
+
+    const verdict = classifyGuard(foldTermResults('waveAlignmentTerm', results), '7d');
+    expect(verdict.state).toBe(GUARD_HEALTH.SUSPECT);
+    expect(verdict.detail).toContain('no-data branch taken 27x');   // was "0x" before the fix
+    expect(verdict.missingInput).toBe('empty_aligned_set');
+  });
+
+  it('an UNRECOGNISED reason counts as no-data and is surfaced, never silently dropped', () => {
+    // The direction is the decision. If a new emit defaulted to "not no-data" it would silently
+    // stop contributing — the permissive answer arriving quietly, which is the defect class itself.
+    // Counting it can at worst over-report, which is loud and gets fixed.
+    const folded = foldTermResults('newTerm', [{ active: false, inactive_reason: 'some_future_reason' }]);
+    expect(folded.permissiveNoData).toBe(1);
+    expect(folded.unclassified).toBe(1);
+    expect(folded.missingInput).toBe('some_future_reason');
+  });
+
+  it('an inherited property is not a supplied one — no forged blocks', () => {
+    // `active` is a generic name; a polluted Object.prototype would make every empty result count
+    // as a block and drive the alarm to HEALTHY, forging the one verdict that ends enquiry.
+    Object.prototype.active = true;      // eslint-disable-line no-extend-native
+    try {
+      const folded = foldTermResults('g', [{}, {}, {}]);
+      expect(folded.blocked).toBe(0);
+      expect(classifyGuard(folded, '7d').state).not.toBe(GUARD_HEALTH.HEALTHY);
+    } finally {
+      delete Object.prototype.active;
+    }
+  });
+
+  it('the reason lists cannot be emptied from outside — Object.freeze on a Set is not immutability', () => {
+    // `Object.freeze(new Set([...]))` reports isFrozen true while .add/.delete/.clear all still
+    // work. Clearing it would collapse permissiveNoData to 0 and suppress the AC-4 explanation —
+    // turning this SD's remedy into this SD's defect. Frozen ARRAYS are exported instead; the Sets
+    // are private.
+    expect(Array.isArray(NO_DATA_REASONS)).toBe(true);
+    expect(Object.isFrozen(NO_DATA_REASONS)).toBe(true);
+    expect(() => { NO_DATA_REASONS.push('x'); }).toThrow();
+    const folded = foldTermResults('g', [{ active: false, inactive_reason: 'no_gaps_supplied' }]);
+    expect(folded.permissiveNoData).toBe(1);
   });
 
   it('an ACTIVE term counts as the guard doing something', () => {
@@ -95,6 +152,50 @@ describe('a no-data reason and an evaluated-and-declined reason are not the same
     expect(folded.observations).toBe(2);
     expect(folded.blocked).toBe(1);
     expect(classifyGuard(folded, '7d').state).toBe(GUARD_HEALTH.HEALTHY);
+  });
+
+  it('AC-2 — the consumer is reached from PRODUCTION, not only from this test', () => {
+    // The finding that forced this: `foldTermResults` had zero production references. Its link to
+    // rationale-bar.js:214/:230/:252 was a DOCBLOCK COMMENT — a reference that looks like wiring and
+    // executes nothing, which is the precise trap FR-1 was written to catch. FR-4's own thesis is
+    // "an emit with no behavioural consumer does not satisfy this FR"; shipping a consumer nothing
+    // imports would have reproduced that thesis one indirection deeper, and a test asserting the
+    // consumer in isolation would have passed the whole time.
+    //
+    // So the assertion is made through selectAdvisory — the real scoring entrypoint, reached in
+    // production from scripts/adam-opportunity-scan.cjs:266.
+    const out = selectAdvisory([], {});
+    expect(out.guard_health).toBeTruthy();
+    expect(out.guard_health.summary).toMatch(/^GUARD SUSTAINED-ZERO/);
+
+    // cleared=0 is the case that hid instance 3 for 21 consecutive passes: the terms never ran, so
+    // the honest verdict is UNKNOWN — explicitly NOT health.
+    const wave = out.guard_health.results.find((r) => r.guard === 'waveAlignmentTerm');
+    expect(wave.state).toBe(GUARD_HEALTH.UNKNOWN);
+    expect(wave.detail).toMatch(/OBSERVED 0 times/);
+    expect(wave.detail).toMatch(/NOT health/);
+  });
+
+  it('…and when candidates DO clear, the health line reports what the terms actually did', () => {
+    // NEGATIVE CONTROL for the above: if guard_health were hard-coded to the UNKNOWN shape, the
+    // previous test would still pass. Here the terms genuinely run, so observations must be > 0.
+    const candidate = {
+      scope_key: 'harness',
+      opportunity: 'op', evidence: 'ev', rationale: 'ra', risk: 'ri', counterfactual: 'cf',
+      objective_kr: { objective: 'O-GOV', kr: 'KR', kr_status: 'off_track', off_track_delta: 10 },
+      contribution_type: 'enabling',
+      confidence: 0.5,
+      okr_score: 30,
+    };
+    // The gap map IS injected in production (gauge-lens readCapabilityGaps); what never arrives is
+    // candidate.capability. Passing gaps here mirrors the live call — without it the fixture would
+    // exercise a branch production never takes and report a different missing input.
+    const out = selectAdvisory([candidate], { capabilityGap: { gaps: { api: 40 } } });
+    expect(out.cleared).toBeGreaterThan(0);
+    const cap = out.guard_health.results.find((r) => r.guard === 'capabilityGapTerm');
+    expect(cap.observations).toBe(out.cleared);
+    // No producer sets candidate.capability, so the live reason is named rather than left blank.
+    expect(cap.missingInput).toBe('candidate_has_no_capability');
   });
 
   it('degenerate input does not throw and does not invent health', () => {

--- a/tests/unit/governance/inactive-reason-consumer.test.js
+++ b/tests/unit/governance/inactive-reason-consumer.test.js
@@ -12,6 +12,10 @@ import { describe, it, expect } from 'vitest';
 import { foldTermResults, NO_DATA_REASONS } from '../../../lib/governance/inactive-reason-consumer.js';
 import { classifyGuard, GUARD_HEALTH } from '../../../lib/governance/guard-sustained-zero.js';
 import { capabilityGapTerm, waveAlignmentTerm, selectAdvisory } from '../../../lib/adam/rationale-bar.js';
+// The live consumer of guard_health — a CommonJS CLI, hence createRequire.
+import { createRequire } from 'node:module';
+
+const { buildLedgerEntry, formatGuardHealth } = createRequire(import.meta.url)('../../../scripts/adam-opportunity-scan.cjs');
 
 describe('AC-4 — capabilityGapTerm now says why, like its sibling', () => {
   // Signature is capabilityGapTerm(candidate, capabilityGap) — the CANDIDATE carries `capability`,
@@ -196,6 +200,68 @@ describe('a no-data reason and an evaluated-and-declined reason are not the same
     expect(cap.observations).toBe(out.cleared);
     // No producer sets candidate.capability, so the live reason is named rather than left blank.
     expect(cap.missingInput).toBe('candidate_has_no_capability');
+  });
+
+  it('THE 21-PASS CASE — the wave term is observed for every candidate, even when NOTHING clears', () => {
+    // Found by mutation, not by reading: deleting `waveTerm` from evaluateCandidate's return left
+    // the whole suite green, so the collection point I had just added to fix a coverage gap was
+    // itself uncovered. The remedy unguarded, one more time.
+    //
+    // The scenario is the real one. Every candidate below fails the bar (no counterfactual), so
+    // cleared === 0 — which is precisely the state that produced 21 identical ADAM_OK rows. The
+    // wave term still RAN 27 times inside evaluateCandidate, and that is what must be reported: if
+    // observations were collected only from cleared candidates, the count would be 0 in exactly the
+    // case the alarm exists to explain.
+    const waveAlignment = { waves: Array.from({ length: 8 }, () => ({ okr_ids: [] })) };  // 8 waves, 0 linked
+    const candidates = Array.from({ length: 27 }, (_, i) => ({
+      scope_key: 'governance',
+      opportunity: `op${i}`, evidence: 'ev', rationale: 'ra', risk: 'ri',   // counterfactual MISSING
+      objective_kr: { objective: 'O-GOV', kr: 'KR', kr_status: 'on_track', off_track_delta: null },
+      contribution_type: 'enabling', confidence: 0.5, okr_score: 30,
+    }));
+
+    const out = selectAdvisory(candidates, { waveAlignment });
+    expect(out.cleared).toBe(0);
+    expect(out.verdict).toBe('ADAM_OK');
+
+    const wave = out.guard_health.results.find((r) => r.guard === 'waveAlignmentTerm');
+    expect(wave.observations, 'the wave term ran 27x but was not observed').toBe(27);
+    expect(wave.state).toBe(GUARD_HEALTH.SUSPECT);
+    expect(wave.missingInput).toBe('empty_aligned_set');
+    expect(wave.detail).toContain('27x');
+  });
+
+  it('…and the operator STDOUT line names it too, not just the ledger JSON', () => {
+    // formatGuardHealth is the human-facing half. Emitted unconditionally when health exists:
+    // a line that appears only when something is wrong makes "measured and fine" and "not measured"
+    // the same observation again.
+    const line = formatGuardHealth({
+      summary: 'GUARD SUSTAINED-ZERO (this advisory pass): healthy=0 suspect=1 inert=0 unknown=1',
+      results: [{ guard: 'waveAlignmentTerm', missingInput: 'empty_aligned_set' }, { guard: 'capabilityGapTerm', missingInput: null }],
+    });
+    expect(line).toContain('suspect=1');
+    expect(line).toContain("waveAlignmentTerm could not judge: 'empty_aligned_set'");
+    expect(line).not.toContain('capabilityGapTerm could not judge');   // no missingInput, nothing to name
+    expect(formatGuardHealth(null)).toBe('');                          // degrades silently, never throws
+  });
+
+  it('AC-3 AT THE OPERATOR — the LEDGER ROW differs, not just an internal field', () => {
+    // The correction that matters most in this SD. I wired the consumer into selectAdvisory, wrote
+    // "the two were indistinguishable from outside — now they are not", and it was FALSE: nothing
+    // read `result.guard_health`, so the ledger row and stdout of pass 22 were byte-identical to the
+    // 21 before it. Computed-and-discarded is what the emit already did; moving it one level up and
+    // calling it consumed is the same defect wearing the remedy's clothes.
+    //
+    // So the assertion is on the artifact a human actually sees.
+    const health = { summary: 'GUARD SUSTAINED-ZERO (this advisory pass): healthy=0 suspect=1 inert=0 unknown=1' };
+    const withHealth = buildLedgerEntry({ scope: { scope_key: 'governance' }, verdict: 'ADAM_OK', cleared: 0, flagEnabled: true, guardHealth: health.summary });
+    const without = buildLedgerEntry({ scope: { scope_key: 'governance' }, verdict: 'ADAM_OK', cleared: 0, flagEnabled: true });
+
+    expect(withHealth.guard_health).toContain('suspect=1');
+    expect(without.guard_health).toBeUndefined();
+    // The two rows must not be mistakable for one another once the ts is set aside.
+    const strip = ({ ts, ...rest }) => rest;   // eslint-disable-line no-unused-vars
+    expect(strip(withHealth)).not.toEqual(strip(without));
   });
 
   it('degenerate input does not throw and does not invent health', () => {

--- a/tests/unit/governance/inactive-reason-consumer.test.js
+++ b/tests/unit/governance/inactive-reason-consumer.test.js
@@ -1,0 +1,107 @@
+/**
+ * FR-4 — an emit with no behavioural consumer does NOT satisfy this FR.
+ * SD-LEO-INFRA-PURE-GUARD-UNWIRED-001.
+ *
+ * FR-4 was demoted from first to last on this SD's own evidence: instance 3 already emitted
+ * inactive_reason and detectability did not change, because nothing read it. So the tests that
+ * matter here are the ones proving the consumer's OUTPUT DIFFERS when the signal is present. A test
+ * that only asserted "the reason is carried through" would pass on a pure pass-through and satisfy
+ * the letter of the FR while leaving the blindness exactly where it was.
+ */
+import { describe, it, expect } from 'vitest';
+import { foldTermResults, NO_DATA_REASONS } from '../../../lib/governance/inactive-reason-consumer.js';
+import { classifyGuard, GUARD_HEALTH } from '../../../lib/governance/guard-sustained-zero.js';
+import { capabilityGapTerm } from '../../../lib/adam/rationale-bar.js';
+
+describe('AC-4 — capabilityGapTerm now says why, like its sibling', () => {
+  // Signature is capabilityGapTerm(candidate, capabilityGap) — the CANDIDATE carries `capability`,
+  // the gap map arrives as capabilityGap.gaps. I had these backwards on the first write and the
+  // tests said so immediately, which is the argument for exercising the real function rather than
+  // asserting against a remembered shape.
+  it('emits a distinct inactive_reason on each no-data branch', () => {
+    // Four branches, four reasons. A single generic "inactive" would be no better than silence,
+    // because the point is to name WHICH input was absent.
+    expect(capabilityGapTerm({}, null).inactive_reason).toBe('no_gaps_supplied');
+    expect(capabilityGapTerm({}, { gaps: { api: 40 } }).inactive_reason).toBe('candidate_has_no_capability');
+    expect(capabilityGapTerm({ capability: 'y' }, { gaps: { api: 40 } }).inactive_reason).toBe('capability_absent_from_gap_map');
+    expect(capabilityGapTerm({ capability: 'y' }, { gaps: { y: 'nope' } }).inactive_reason).toBe('gap_value_not_a_number');
+  });
+
+  it('THE LIVE CASE — no producer sets candidate.capability, so this is what actually fires', () => {
+    // The term is permanently inactive for a reason no reader could previously see.
+    const r = capabilityGapTerm({ sd_key: 'SD-X' }, { gaps: { api: 40 } });
+    expect(r.active).toBe(false);
+    expect(r.inactive_reason).toBe('candidate_has_no_capability');
+  });
+
+  it('NEGATIVE CONTROL — a real gap still activates, with no inactive_reason', () => {
+    // Without this, "always inactive with a reason" would satisfy everything above while breaking
+    // the term outright.
+    const r = capabilityGapTerm({ capability: 'api' }, { gaps: { api: 40 } });
+    expect(r.active).toBe(true);
+    expect(r.multiplier).toBeGreaterThan(1.0);
+    expect(r.inactive_reason).toBeUndefined();
+  });
+});
+
+describe('AC-3 — the consumer CHANGES BEHAVIOUR when the signal is present', () => {
+  // Real term output, not a hand-built fixture — a fixture would keep passing if the emit regressed.
+  const twelveInactive = Array.from({ length: 12 }, () =>
+    capabilityGapTerm({ sd_key: 'SD-X' }, { gaps: { api: 40 } }));
+
+  it('with the signal, the alarm names the missing input instead of just flagging a zero', () => {
+    const folded = foldTermResults('capabilityGapTerm', twelveInactive);
+    expect(folded.permissiveNoData).toBe(12);
+    expect(folded.missingInput).toBe('candidate_has_no_capability');
+
+    const verdict = classifyGuard(folded, '7d');
+    expect(verdict.state).toBe(GUARD_HEALTH.SUSPECT);
+    expect(verdict.detail).toContain('candidate_has_no_capability');
+    expect(verdict.detail).toContain('12x');
+  });
+
+  it('THE DISCRIMINATOR — strip the signal and the SAME batch yields a less actionable verdict', () => {
+    // This is the assertion that makes FR-4 more than a log line. Identical inputs, identical
+    // counts; the only difference is whether inactive_reason was present, and the operator-facing
+    // output changes because of it. A pass-through consumer would fail here.
+    const stripped = twelveInactive.map((r) => { const c = { ...r }; delete c.inactive_reason; return c; });
+    const withSignal = classifyGuard(foldTermResults('g', twelveInactive), '7d');
+    const without = classifyGuard(foldTermResults('g', stripped), '7d');
+
+    expect(withSignal.state).toBe(without.state);            // same verdict…
+    expect(withSignal.detail).not.toBe(without.detail);      // …different actionability
+    expect(withSignal.missingInput).toBe('candidate_has_no_capability');
+    expect(without.missingInput).toBeNull();
+    expect(without.detail).not.toMatch(/Missing input/);
+  });
+});
+
+describe('a no-data reason and an evaluated-and-declined reason are not the same finding', () => {
+  it('only no-data reasons count as permissive-no-data', () => {
+    // empty_aligned_set means the guard HAD its data and found nothing — chasing "why didn't it
+    // fire" there is wasted work, so it must not inflate the no-data count.
+    const folded = foldTermResults('waveAlignmentTerm', [
+      { active: false, inactive_reason: 'empty_aligned_set' },
+      { active: false, inactive_reason: 'zero_waves_or_no_alignment' },
+    ]);
+    expect(folded.permissiveNoData).toBe(1);
+    expect(folded.missingInput).toBe('zero_waves_or_no_alignment');
+    expect(folded.reasons.empty_aligned_set).toBe(1);
+    expect(NO_DATA_REASONS.has('empty_aligned_set')).toBe(false);
+  });
+
+  it('an ACTIVE term counts as the guard doing something', () => {
+    const folded = foldTermResults('g', [{ active: true }, { active: false, inactive_reason: 'no_gaps_supplied' }]);
+    expect(folded.observations).toBe(2);
+    expect(folded.blocked).toBe(1);
+    expect(classifyGuard(folded, '7d').state).toBe(GUARD_HEALTH.HEALTHY);
+  });
+
+  it('degenerate input does not throw and does not invent health', () => {
+    for (const bad of [null, undefined, 'x', [null, 3, {}]]) {
+      const f = foldTermResults('g', bad);
+      expect(() => classifyGuard(f, '7d')).not.toThrow();
+    }
+    expect(classifyGuard(foldTermResults('g', []), '7d').state).toBe(GUARD_HEALTH.UNKNOWN);
+  });
+});

--- a/tests/unit/governance/inactive-reason-consumer.test.js
+++ b/tests/unit/governance/inactive-reason-consumer.test.js
@@ -15,7 +15,19 @@ import { capabilityGapTerm, waveAlignmentTerm, selectAdvisory } from '../../../l
 // The live consumer of guard_health — a CommonJS CLI, hence createRequire.
 import { createRequire } from 'node:module';
 
-const { buildLedgerEntry, formatGuardHealth } = createRequire(import.meta.url)('../../../scripts/adam-opportunity-scan.cjs');
+const {
+  buildLedgerEntry, formatGuardHealth, guardHealthForLedger, advisoryLedgerEntry, adamOkLine,
+  scanOutcome,
+} = createRequire(import.meta.url)('../../../scripts/adam-opportunity-scan.cjs');
+
+/** The live instance-3 shape: 8 waves exist, ZERO carry linkages. */
+const EMPTY_LINKAGE_ROADMAP = { waves: Array.from({ length: 8 }, () => ({ okr_ids: [] })) };
+const barredCandidates = (n) => Array.from({ length: n }, (_, i) => ({
+  scope_key: 'governance',
+  opportunity: `op${i}`, evidence: 'ev', rationale: 'ra', risk: 'ri',   // counterfactual MISSING => never clears
+  objective_kr: { objective: 'O-GOV', kr: 'KR', kr_status: 'on_track', off_track_delta: null },
+  contribution_type: 'enabling', confidence: 0.5, okr_score: 30,
+}));
 
 describe('AC-4 — capabilityGapTerm now says why, like its sibling', () => {
   // Signature is capabilityGapTerm(candidate, capabilityGap) — the CANDIDATE carries `capability`,
@@ -129,7 +141,7 @@ describe('a no-data reason and an evaluated-and-declined reason are not the same
   it('an inherited property is not a supplied one — no forged blocks', () => {
     // `active` is a generic name; a polluted Object.prototype would make every empty result count
     // as a block and drive the alarm to HEALTHY, forging the one verdict that ends enquiry.
-    Object.prototype.active = true;      // eslint-disable-line no-extend-native
+    Object.prototype.active = true;
     try {
       const folded = foldTermResults('g', [{}, {}, {}]);
       expect(folded.blocked).toBe(0);
@@ -245,6 +257,80 @@ describe('a no-data reason and an evaluated-and-declined reason are not the same
     expect(formatGuardHealth(null)).toBe('');                          // degrades silently, never throws
   });
 
+  it('THE WIRE, not just the two ends — a real selectAdvisory result reaches the ledger', () => {
+    // Both ENDS were well covered and the CONNECTION was not: the tests called buildLedgerEntry and
+    // formatGuardHealth with hand-written literals, while the call sites that pass
+    // `result.guard_health` into them lived inside an unexported main(). Deleting those arguments
+    // restored the byte-identical row and produced no test signal whatsoever.
+    //
+    // Third round in a row that the final hop was the unguarded one — the consumer didn't exist,
+    // then the caller didn't read it, then the read wasn't tested. So the entry construction is now
+    // an exported pure function driven here by a REAL selectAdvisory return, and main() holds no
+    // logic left to mutate.
+    const result = selectAdvisory(barredCandidates(27), { waveAlignment: EMPTY_LINKAGE_ROADMAP });
+    expect(result.surfaced).toBeNull();
+
+    const entry = advisoryLedgerEntry({ result, scope: { scope_key: 'governance' }, verdict: 'ADAM_OK', flagEnabled: true });
+    expect(entry.guard_health).toBeTruthy();
+    expect(entry.guard_health.summary).toContain('suspect=');
+    // ACTIONABLE, not merely distinguishable: the durable row NAMES the term and the absent input.
+    // Writing only the summary left "suspect=1" in the ledger — an auditor months later would still
+    // have to re-derive exactly what FR-2 AC-4 exists to state.
+    expect(entry.guard_health.missing).toContainEqual(
+      expect.objectContaining({ guard: 'waveAlignmentTerm', missing_input: 'empty_aligned_set', observations: 27 }),
+    );
+
+    // …and the stdout line, from the same real result.
+    expect(adamOkLine({ scope_key: 'governance' }, result)).toContain("waveAlignmentTerm could not judge: 'empty_aligned_set'");
+  });
+
+  it('ONE SEAM — every verdict decision is made by an exported function, from a real result', () => {
+    // Mutation found the three main() call sites still surviving after the builder was extracted:
+    // main() is not exported, so nothing that happens inside it is reachable from a unit test.
+    // Collapsing the branching into scanOutcome() moves every DECISION under test and leaves main()
+    // with a single call.
+    //
+    // WHAT THIS STILL DOES NOT COVER, stated rather than implied: that one remaining call. A
+    // mutation passing scanOutcome a null result would produce no unit-test signal, and no unit
+    // test can close it — that needs a process-level test running the CLI, which is not cheap here
+    // because the scan reads the database first. Bounded and named, not claimed closed.
+    const barred = selectAdvisory(barredCandidates(27), { waveAlignment: EMPTY_LINKAGE_ROADMAP });
+    const ok = scanOutcome({ result: barred, scope: { scope_key: 'governance' }, flagEnabled: true });
+    expect(ok.verdict).toBe('ADAM_OK');
+    expect(ok.entry.guard_health.missing[0]).toMatchObject({ guard: 'waveAlignmentTerm', missing_input: 'empty_aligned_set' });
+    expect(ok.stdout).toContain("could not judge: 'empty_aligned_set'");
+
+    // A result that DID surface routes by the flag, and carries health either way.
+    const surfacedResult = { surfaced: { dedup_key: 'k' }, cleared: 2, trace: [], guard_health: barred.guard_health };
+    const gateOff = scanOutcome({ result: surfacedResult, scope: { scope_key: 'governance' }, flagEnabled: false });
+    const gateOn = scanOutcome({ result: surfacedResult, scope: { scope_key: 'governance' }, flagEnabled: true });
+    expect(gateOff.verdict).toBe('SUPPRESSED_FLAG_OFF');
+    expect(gateOn.verdict).toBe('SURFACED');
+    for (const o of [gateOff, gateOn]) {
+      expect(o.entry.guard_health).toBeTruthy();
+      expect(o.entry.cleared).toBe(2);
+      expect(o.entry.detail).toBe('k');
+    }
+  });
+
+  it('EVERY verdict path records it — including the one where the terms ran but the gate was off', () => {
+    // SUPPRESSED_FLAG_OFF is reached when something DID clear, so the terms ran and their health is
+    // real; omitting it there discarded the one reading that path could offer.
+    const result = selectAdvisory(barredCandidates(3), { waveAlignment: EMPTY_LINKAGE_ROADMAP });
+    for (const verdict of ['ADAM_OK', 'SURFACED', 'SUPPRESSED_FLAG_OFF']) {
+      const e = advisoryLedgerEntry({ result, scope: { scope_key: 'governance' }, verdict, flagEnabled: false });
+      expect(e.guard_health, `${verdict} dropped guard_health`).toBeTruthy();
+    }
+  });
+
+  it('the durable form degrades honestly rather than inventing a shape', () => {
+    expect(guardHealthForLedger(null)).toBeNull();
+    expect(guardHealthForLedger({})).toBeNull();
+    // `missing` is always present — a field that appears only when non-empty makes
+    // "measured, nothing absent" and "not measured" the same row again.
+    expect(guardHealthForLedger({ summary: 's', results: [] })).toEqual({ summary: 's', missing: [] });
+  });
+
   it('AC-3 AT THE OPERATOR — the LEDGER ROW differs, not just an internal field', () => {
     // The correction that matters most in this SD. I wired the consumer into selectAdvisory, wrote
     // "the two were indistinguishable from outside — now they are not", and it was FALSE: nothing
@@ -259,8 +345,8 @@ describe('a no-data reason and an evaluated-and-declined reason are not the same
 
     expect(withHealth.guard_health).toContain('suspect=1');
     expect(without.guard_health).toBeUndefined();
-    // The two rows must not be mistakable for one another once the ts is set aside.
-    const strip = ({ ts, ...rest }) => rest;   // eslint-disable-line no-unused-vars
+    // The two rows must not be mistakable for one another once the timestamp is set aside.
+    const strip = (row) => { const c = { ...row }; delete c.ts; return c; };
     expect(strip(withHealth)).not.toEqual(strip(without));
   });
 

--- a/tests/unit/governance/inactive-reason-consumer.test.js
+++ b/tests/unit/governance/inactive-reason-consumer.test.js
@@ -96,9 +96,9 @@ describe('a no-data reason and an evaluated-and-declined reason are not the same
   it('CANNOT-JUDGE IS NO-DATA — the classification I got backwards, and what it cost', () => {
     // The first version of this test asserted the opposite: that `empty_aligned_set` meant "the
     // guard HAD its data and found nothing", so it must NOT inflate the no-data count. That is
-    // refuted by the file that emits it, twenty lines from the emit — rationale-bar.js:221 "Waves
-    // exist but NOTHING is linked => this term cannot judge alignment", and :248 "a term that
-    // cannot judge must not judge — the same doctrine as the empty-set case above."
+    // refuted by the file that emits it, in the comment directly above the emit — "Waves exist but
+    // NOTHING is linked => this term cannot judge alignment" — and again at the id-space guard:
+    // "a term that cannot judge must not judge — the same doctrine as the empty-set case above."
     //
     // The cost was measured on this SD's own flagship instance, not argued: with 8 waves, 0 of 261
     // roadmap_wave_items linked, and 27 evaluations, the fold reported permissiveNoData: 0 and
@@ -172,14 +172,14 @@ describe('a no-data reason and an evaluated-and-declined reason are not the same
 
   it('AC-2 — the consumer is reached from PRODUCTION, not only from this test', () => {
     // The finding that forced this: `foldTermResults` had zero production references. Its link to
-    // rationale-bar.js:214/:230/:252 was a DOCBLOCK COMMENT — a reference that looks like wiring and
+    // waveAlignmentTerm's no-data branches was a DOCBLOCK COMMENT — a reference that looks like wiring and
     // executes nothing, which is the precise trap FR-1 was written to catch. FR-4's own thesis is
     // "an emit with no behavioural consumer does not satisfy this FR"; shipping a consumer nothing
     // imports would have reproduced that thesis one indirection deeper, and a test asserting the
     // consumer in isolation would have passed the whole time.
     //
     // So the assertion is made through selectAdvisory — the real scoring entrypoint, reached in
-    // production from scripts/adam-opportunity-scan.cjs:266.
+    // production from the --scan path of scripts/adam-opportunity-scan.cjs.
     const out = selectAdvisory([], {});
     expect(out.guard_health).toBeTruthy();
     expect(out.guard_health.summary).toMatch(/^GUARD SUSTAINED-ZERO/);

--- a/tests/unit/governance/predicate-self-test.test.js
+++ b/tests/unit/governance/predicate-self-test.test.js
@@ -123,7 +123,7 @@ describe('THE OBJECT ARM — the shape real gate predicates actually return', ()
 
   it('an INHERITED blocked flag does not count as a produced verdict', () => {
     // Otherwise a polluted prototype certifies any predicate as discriminating.
-    Object.prototype.blocked = true;   // eslint-disable-line no-extend-native
+    Object.prototype.blocked = true;
     try {
       const r = selfTestPredicate({ name: 'p', predicate: () => ({}), blockingInput: 'x', passingInput: 'y' });
       expect(r.capable).toBe(false);
@@ -136,7 +136,7 @@ describe('THE OBJECT ARM — the shape real gate predicates actually return', ()
 
 describe('it really never throws, and never quietly certifies', () => {
   it('an INHERITED predicate is not a supplied one', () => {
-    Object.prototype.predicate = (s) => s === 'x';   // eslint-disable-line no-extend-native
+    Object.prototype.predicate = (s) => s === 'x';
     try {
       const r = selfTestPredicate({ name: 'missing' });
       expect(r.capable).toBe(false);

--- a/tests/unit/governance/predicate-self-test.test.js
+++ b/tests/unit/governance/predicate-self-test.test.js
@@ -1,0 +1,114 @@
+/**
+ * FR-3 — a check that has never been shown to fail cannot be cited.
+ * SD-LEO-INFRA-PURE-GUARD-UNWIRED-001.
+ *
+ * THE FIXTURE IS THE POINT. AC-1 asks for a DELIBERATELY INERT predicate, so the inert case here
+ * is the real thing rather than a stand-in: a regex mangled to a BACKSPACE character, exactly as it
+ * happened. It ran, it never threw, it answered honestly, and it reported 0/3 for 27 consecutive
+ * passes while the underlying state changed — because "no match" is the permissive answer and the
+ * permissive answer reads as health.
+ */
+import { describe, it, expect } from 'vitest';
+import { selfTestPredicate, selfTestAll, VERDICT_KIND } from '../../../lib/governance/predicate-self-test.js';
+
+/** The actual defect: a pattern intended as \b that became a literal backspace (\x08). */
+const MANGLED = new RegExp('\x08lock\x08');
+const inertPredicate = (s) => MANGLED.test(String(s));
+
+/** What it was meant to be. */
+const healthyPredicate = (s) => /\block\b/.test(String(s));
+
+describe('AC-1 — a predicate that cannot block is REJECTED', () => {
+  it('the mangled-regex predicate fails the self-test', () => {
+    const r = selfTestPredicate({
+      name: 'blockPattern',
+      predicate: inertPredicate,
+      blockingInput: 'this line contains lock and must match',
+      passingInput: 'nothing here',
+    });
+    expect(r.capable).toBe(false);
+    expect(r.missingVerdict).toBe(VERDICT_KIND.BLOCKING);
+  });
+
+  it('AC-3 — the message says WHICH verdict could not be produced', () => {
+    const r = selfTestPredicate({
+      name: 'blockPattern', predicate: inertPredicate,
+      blockingInput: 'contains lock', passingInput: 'clean',
+    });
+    expect(r.detail).toMatch(/BLOCKING verdict/);
+    expect(r.detail).toContain('blockPattern');
+    expect(r.detail).toMatch(/permissive answer/);
+  });
+});
+
+describe('AC-2 — a healthy predicate passes unmodified', () => {
+  it('the intended regex demonstrates both verdicts', () => {
+    // Load-bearing: without it, "everything is incapable" would satisfy AC-1 while rejecting every
+    // working predicate in the codebase — the mirror failure, and just as useless.
+    const r = selfTestPredicate({
+      name: 'blockPattern', predicate: healthyPredicate,
+      blockingInput: 'this line contains lock and must match',
+      passingInput: 'nothing here',
+    });
+    expect(r.capable).toBe(true);
+    expect(r.produced).toEqual({ blocking: true, passing: true });
+  });
+});
+
+describe('the other ways a predicate can be uncitable', () => {
+  it('one that blocks EVERYTHING is rejected too', () => {
+    // The mirror of instance 5. Its blocks are as meaningless as the other's passes.
+    const r = selfTestPredicate({ name: 'always', predicate: () => true, blockingInput: 'x', passingInput: 'y' });
+    expect(r.capable).toBe(false);
+    expect(r.missingVerdict).toBe(VERDICT_KIND.PASSING);
+    expect(r.detail).toMatch(/blocks unconditionally/);
+  });
+
+  it('one that answers the SAME thing to everything is rejected', () => {
+    // My first expectation here was 'both', and it was wrong: a constant non-boolean reads as
+    // "not blocking" under the default reader, so the verdict it cannot produce is BLOCKING —
+    // the same finding as instance 5, arrived at a different way.
+    const r = selfTestPredicate({ name: 'mush', predicate: () => 'maybe', blockingInput: 'x', passingInput: 'y' });
+    expect(r.capable).toBe(false);
+    expect(r.missingVerdict).toBe(VERDICT_KIND.BLOCKING);
+  });
+
+  it('a THROWING predicate is a finding, not a pass', () => {
+    // Absorbing the throw into a pass would be this SD's defect inside its own remedy.
+    const r = selfTestPredicate({
+      name: 'boom', predicate: () => { throw new Error('bad input'); },
+      blockingInput: 'x', passingInput: 'y',
+    });
+    expect(r.capable).toBe(false);
+    expect(r.threw).toMatch(/bad input/);
+    expect(r.detail).toMatch(/THREW/);
+  });
+
+  it('NO predicate at all is not a pass', () => {
+    const r = selfTestPredicate({ name: 'missing' });
+    expect(r.capable).toBe(false);
+    expect(r.detail).toMatch(/NOT the same as passing/);
+  });
+
+  it('never throws, whatever it is handed', () => {
+    for (const bad of [undefined, null, {}, { predicate: 42 }, { predicate: () => undefined }]) {
+      expect(() => selfTestPredicate(bad)).not.toThrow();
+    }
+  });
+});
+
+describe('the suite reports unconditionally', () => {
+  it('counts capable and incapable, zeros included', () => {
+    const a = selfTestAll([
+      { name: 'good', predicate: healthyPredicate, blockingInput: 'has lock', passingInput: 'clean' },
+      { name: 'bad', predicate: inertPredicate, blockingInput: 'has lock', passingInput: 'clean' },
+    ]);
+    expect(a.summary).toBe('PREDICATE SELF-TEST: capable=1 incapable=1');
+    expect(a.incapable.map((r) => r.name)).toEqual(['bad']);
+  });
+
+  it('an all-healthy suite still prints incapable=0', () => {
+    const a = selfTestAll([{ name: 'good', predicate: healthyPredicate, blockingInput: 'has lock', passingInput: 'clean' }]);
+    expect(a.summary).toContain('incapable=0');
+  });
+});

--- a/tests/unit/governance/predicate-self-test.test.js
+++ b/tests/unit/governance/predicate-self-test.test.js
@@ -97,6 +97,101 @@ describe('the other ways a predicate can be uncitable', () => {
   });
 });
 
+describe('THE OBJECT ARM — the shape real gate predicates actually return', () => {
+  // Every fixture above uses a bare boolean or a string, so deleting the entire object-reading arm
+  // of the default reader survived the suite. That arm is the LIVE one: this module is scoped to
+  // predicates feeding gates, alarms and handoff evidence, and those return verdict objects. Losing
+  // it would read `{blocked:true}` as PASSING and declare a working gate incapable of blocking —
+  // a false alarm, which is how an alarm gets muted.
+  const cases = [
+    ['blocked flag', { blocked: true }, { blocked: false }],
+    ['ok flag', { ok: false }, { ok: true }],
+    ['verdict string', { verdict: 'fail' }, { verdict: 'pass' }],
+    ['verdict block', { verdict: 'block' }, { verdict: 'allow' }],
+  ];
+  for (const [label, blockingResult, passingResult] of cases) {
+    it(`reads a ${label} verdict object as blocking`, () => {
+      const r = selfTestPredicate({
+        name: label,
+        predicate: (s) => (s === 'bad' ? blockingResult : passingResult),
+        blockingInput: 'bad', passingInput: 'good',
+      });
+      expect(r.capable).toBe(true);
+      expect(r.produced).toEqual({ blocking: true, passing: true });
+    });
+  }
+
+  it('an INHERITED blocked flag does not count as a produced verdict', () => {
+    // Otherwise a polluted prototype certifies any predicate as discriminating.
+    Object.prototype.blocked = true;   // eslint-disable-line no-extend-native
+    try {
+      const r = selfTestPredicate({ name: 'p', predicate: () => ({}), blockingInput: 'x', passingInput: 'y' });
+      expect(r.capable).toBe(false);
+      expect(r.missingVerdict).toBe(VERDICT_KIND.BLOCKING);
+    } finally {
+      delete Object.prototype.blocked;
+    }
+  });
+});
+
+describe('it really never throws, and never quietly certifies', () => {
+  it('an INHERITED predicate is not a supplied one', () => {
+    Object.prototype.predicate = (s) => s === 'x';   // eslint-disable-line no-extend-native
+    try {
+      const r = selfTestPredicate({ name: 'missing' });
+      expect(r.capable).toBe(false);
+      expect(r.detail).toMatch(/NOT the same as passing/);
+    } finally {
+      delete Object.prototype.predicate;
+    }
+  });
+
+  it('a throw that is not an Error still reports, rather than escaping', () => {
+    // `String(Object.create(null))` itself throws, so the error-formatting path was the escape.
+    for (const thrown of [Object.create(null), { get message() { throw new Error('nested'); } }, 'plain string', 42, null]) {
+      const r = selfTestPredicate({
+        name: 'boom', predicate: () => { throw thrown; }, blockingInput: 'x', passingInput: 'y',
+      });
+      expect(r.capable).toBe(false);
+      expect(typeof r.threw).toBe('string');
+    }
+  });
+
+  it('a spec whose fields are booby-trapped getters cannot escape', () => {
+    const hostile = { get name() { throw new Error('name'); }, predicate: () => true };
+    expect(() => selfTestPredicate(hostile)).not.toThrow();
+  });
+
+  it('an ASYNC predicate is reported as unjudgeable — not as passing, and without killing the run', () => {
+    // The worst of the set: a returned Promise is an object with no `.blocked`, so it read as the
+    // PASSING verdict; and with nothing attached to catch it, an async-throwing predicate returned
+    // {capable:false, threw:null} and then took the whole process down at the microtask checkpoint
+    // — inside a module whose docblock promises it never throws.
+    const r = selfTestPredicate({
+      name: 'asyncGate',
+      predicate: async () => { throw new Error('boom'); },
+      blockingInput: 'x', passingInput: 'y',
+    });
+    expect(r.capable).toBe(false);
+    expect(r.asyncResult).toBe(true);
+    expect(r.produced.passing).toBe(false);   // an unjudged result is NOT the passing verdict
+    expect(r.detail).toMatch(/PROMISE/);
+  });
+
+  it('a getter-swapped predicate cannot assemble a citation from two different functions', () => {
+    // TOCTOU: spec.predicate was read three times, so a getter could hand over a blocking-only
+    // predicate and then a passing-only one and the PAIR would certify as "demonstrated BOTH".
+    let n = 0;
+    const spec = {
+      name: 'swapper',
+      get predicate() { n += 1; return n >= 2 ? () => false : () => true; },
+      blockingInput: 'x', passingInput: 'y',
+    };
+    const r = selfTestPredicate(spec);
+    expect(r.capable).toBe(false);
+  });
+});
+
 describe('the suite reports unconditionally', () => {
   it('counts capable and incapable, zeros included', () => {
     const a = selfTestAll([


### PR DESCRIPTION
## Summary

A pure guard whose caller never supplies its gated input is indistinguishable from a guard that evaluated and passed. This SD builds four detectors for that class — and the notable part is that every one of them was found exhibiting the class **inside itself** before it was fixed.

- **FR-1 `guard-wiring-registry.js`** — a guard must name a production call site that actually *feeds* it. Three shapes: no caller, caller-wired-but-data-never-produced, and input-supplied-as-a-stub. Six live guards registered with the consequence of each permissive branch, printed as a loud inventory on every run.
- **FR-2 `guard-sustained-zero.js`** — a gate that has never blocked is not a passing gate. Four states, because a guard nobody *observed* and a guard that observed nothing both present as zero, and collapsing them reports diligence as neglect.
- **FR-3 `predicate-self-test.js`** — a predicate never shown to produce *both* verdicts cannot be cited. The inert fixture is the real defect: a regex mangled to a backspace character that answered honestly and meaninglessly for 27 passes.
- **FR-4 `inactive-reason-consumer.js`** — deliberately demoted from first to last on this SD's own evidence: the emit already existed and changed nothing because nothing read it. So the deliverable is a **reader whose output differs**, wired into `selectAdvisory` and read by the scan CLI into the durable ledger.
- **FR-5** — self-audit. Two founding claims were corrected at LEAD by verification rather than inherited.

## What adversarial review found that the author did not

Four review rounds (TESTING, SECURITY, VALIDATION, REGRESSION) found the load-bearing defects. Every one is fixed here, and the commits record them rather than smoothing them over:

- **FR-4 had no production consumer.** Its link to the emit sites was a docblock comment — a reference that looks like wiring and executes nothing, which is exactly what FR-1 exists to catch.
- **FR-1's scanner could not redden.** Gutting `wiredCallSites()` to `return []` left the whole suite green; the stated control tested the pure predicate, not the corpus walk.
- **The reason classification was backwards.** `empty_aligned_set`/`id_space_mismatch` were filed as evaluated-and-declined; the emitting file says "cannot judge" directly above each emit. Measured on the flagship instance, the alarm reported `no-data branch taken 0x` while that branch had fired all 27 times — blind to the very instance it was built for, in the permissive direction.
- **The ledger row was unchanged.** `guard_health` was computed and discarded, so pass 22 was byte-identical to the 21 before it.
- **The "loud inventory" printed nothing** — `tests/setup.unit.js` stubs `global.console`, so the two sibling guards it copied are silent too.
- **Security:** prototype-chain reads forged HEALTHY in all three modules; `Object.freeze(new Set())` is not immutability; async predicates were read as PASSING and then killed the process; `gatedInput` was unescaped; the registry was shallow-frozen.

**The recurring shape, which is the more durable finding than any single fix:** *both ends tested, the wire between them not.* It recurred four times, one hop further out each time, and every intermediate state passed a green suite. The rule taken from it — assert on the terminal artifact a human reads, not on the last function written — is in the retrospective.

## Test plan

- `npx vitest run tests/unit/governance/ tests/unit/adam/` — 1429 passing across 96 files (77 tests added).
- **Mutation-verified**, with every mutation confirmed on disk before its run (two mutations silently no-opped earlier in this work and reported green). Every mutation reviewers found *surviving* now dies; comment-only and whitespace-only controls survive, so the suite discriminates rather than merely being red.
- **No behavioural regression**, established empirically rather than by inspection: a differential harness drove 4000 randomized passes / 13,359 candidate evaluations against the `origin/main` baseline of `rationale-bar.js` — `selDiff=0 evalDiff=0 capDiff=0 waveDiff=0 rankDiff=0`, with the added fields exercised on essentially every call. The CARDINAL INVARIANT (KR-status tier dominates) is untouched.
- Unit-tier failures elsewhere are pre-existing: no failing file imports a module this branch touches, none is modified by it, and re-running with this branch's entire test contribution excluded reproduces the identical failures. Deliberately reported causally rather than as a count — the tier is flaky (7, 8 and 9 failing files measured across runs of one tree).

## Known limits, stated rather than implied

- `scanOutcome(...)` is invoked from an unexported `main()`, so that final hop cannot be closed *behaviourally* without a process-level test running the CLI. It **is** statically guarded by FR-1's own `suppliesGatedInput`, which catches deletion, omission and null-stubbing. An earlier draft claimed it "cannot be tested at all"; that was too strong and was corrected.
- FR-1 AC-1 is met in substance, not as literally written: the wiring test does not fail today and is designed not to (a permanently red suite gets muted).
- FR-1 AC-2 is structurally unprovable right now — 0 of 6 registered guards has a wired call site, so there is nothing to delete from the baseline.
- TS-8/TS-9/TS-10 are undelivered, and the PRD contradicts itself on cardinality (`implementation_approach` says "the NINE verified instances" while FR-1 enumerates six).
- `predicate-self-test.js` has no production importer, so `GUARD_HEALTH.INERT` is unreachable live. FR-3's ACs do not require a consumer, but by this SD's own thesis that is worth naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
