### PR TITLE
fix(QF-20260727-251): dependency relation scopes the refusal instead of blocking the claim

### DIFF
--- a/lib/claim/gates/dependency-gate.cjs
+++ b/lib/claim/gates/dependency-gate.cjs
@@ -48,6 +48,51 @@ function extractDependencyRefs(sd) {
 }
 
 /**
+ * QF-20260727-251 — RELATION SCOPES THE REFUSAL.
+ *
+ * dependencies entries carry relation semantics and the gate read none of them, so a dependency
+ * that blocks ONE strategic objective refused the WHOLE claim. Measured on
+ * SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001: four refs, relations blocks_objective_0,
+ * sequence_after_for_FR4, land_before_FR5, overlaps_FR4 — not one of which blocks the SD — and
+ * metadata.claim_history recorded SEVEN sessions claiming and releasing that row in a single day
+ * with zero completions. A partial block presented to every arriving worker as a total block.
+ *
+ * AN ABSENT OR UNRECOGNISED RELATION STAYS CLAIM-BLOCKING, and that direction is the whole design.
+ * Defaulting unknown relations to non-blocking would make this gate permissive on input it does not
+ * understand — the exact defect SD-LEO-INFRA-PURE-GUARD-UNWIRED-001 shipped detectors for, where a
+ * check that cannot see its subject returns the permissive answer and the permissive answer is
+ * indistinguishable from a passing one. Only relations explicitly recognised as scope-constraining
+ * may downgrade; everything else refuses exactly as it does today, so legacy plain-string refs and
+ * every other fold (metadata.blocked_on_sd, blocked_by_sd_key, depends_on) are untouched.
+ *
+ * Recognised scope-constraining forms, taken from live rows rather than invented:
+ *   blocks_objective_N     — blocks strategic_objectives[N], not the claim
+ *   sequence_after_for_X   — ordering constraint on one FR
+ *   land_before_X          — ordering constraint on one FR
+ *   overlaps_X             — shared surface needing coordination, not a block
+ */
+const SCOPE_CONSTRAINING_RELATION = /^(?:blocks_objective_\d+|sequence_after_for_\S+|land_before_\S+|overlaps_\S+)$/;
+
+/** 'scope' when the relation constrains part of the work; 'claim' (refuse) for everything else. */
+function classifyDependencyRelation(relation) {
+  return typeof relation === 'string' && SCOPE_CONSTRAINING_RELATION.test(relation.trim())
+    ? 'scope'
+    : 'claim';
+}
+
+/** ref -> relation, read ONLY from the structured top-level dependencies array (other folds carry none). */
+function relationsByRef(dependencies) {
+  const out = {};
+  if (!Array.isArray(dependencies)) return out;
+  for (const dep of dependencies) {
+    if (!dep || typeof dep !== 'object') continue;
+    const ref = dep.sd_id || dep.sd_key || dep.id;
+    if (typeof ref === 'string' && ref) out[ref] = dep.relation;
+  }
+  return out;
+}
+
+/**
  * Resolve + classify an SD's declared dependencies.
  *
  * @param {object} supabase - service client
@@ -84,7 +129,7 @@ function extractDependencyRefs(sd) {
  * split of responsibility — it was two callers disagreeing about a blind spot.
  */
 async function evaluateClaimDependencyGate(supabase, sd) {
-  const empty = { blocking: [], unresolved: [], satisfied: [], resolved: [], queryError: null };
+  const empty = { blocking: [], scopeConstrained: [], unresolved: [], satisfied: [], resolved: [], queryError: null };
   const row = sd || {};
   let deps = row.dependencies;
   try {
@@ -150,9 +195,25 @@ async function evaluateClaimDependencyGate(supabase, sd) {
       }
     }
 
-    const resolved = refs.map((k) => ({ sd_id: k, status: statusByRef[k] || null }));
+    // QF-20260727-251: carry the relation onto every resolved entry so BOTH callers partition from
+    // one classification instead of each re-deriving it (the divergence this module exists to end).
+    const relByRef = relationsByRef(deps);
+    const resolved = refs.map((k) => {
+      const relation = relByRef[k];
+      return {
+        sd_id: k,
+        status: statusByRef[k] || null,
+        relation: relation === undefined ? null : relation,
+        claimBlocking: classifyDependencyRelation(relation) === 'claim',
+      };
+    });
+    const incomplete = resolved.filter((d) => d.status && d.status !== 'completed');
     return {
-      blocking: resolved.filter((d) => d.status && d.status !== 'completed'),
+      blocking: incomplete.filter((d) => d.claimBlocking),
+      // Incomplete, but its relation constrains PART of the work rather than the claim. Surfaced as
+      // its own axis, never silently dropped: an unexplained permit is the same ambiguity as an
+      // unexplained refusal, one level down.
+      scopeConstrained: incomplete.filter((d) => !d.claimBlocking),
       unresolved: resolved.filter((d) => !d.status),
       satisfied: resolved.filter((d) => d.status === 'completed'),
       resolved,
@@ -176,4 +237,9 @@ function depsSatisfiedFromVerdict(verdict) {
   return verdict.blocking.length === 0 && verdict.unresolved.length === 0;
 }
 
-module.exports = { evaluateClaimDependencyGate, depsSatisfiedFromVerdict, extractDependencyRefs };
+module.exports = {
+  evaluateClaimDependencyGate,
+  depsSatisfiedFromVerdict,
+  extractDependencyRefs,
+  classifyDependencyRelation,
+};

--- a/lib/sd-start/dependency-gate.mjs
+++ b/lib/sd-start/dependency-gate.mjs
@@ -29,18 +29,43 @@ export function evaluateDependencyGate(resolved, opts = {}) {
   const force = Boolean(opts.force);
 
   // Confirmed-incomplete dependencies: resolved to a real, non-completed status.
-  const blocking = list.filter(d => d && d.status && d.status !== SATISFIED_STATUS);
+  const incomplete = list.filter(d => d && d.status && d.status !== SATISFIED_STATUS);
+  // QF-20260727-251: an incomplete dependency whose RELATION constrains part of the work
+  // (blocks_objective_N, sequence_after_for_X, land_before_X, overlaps_X) does not block the
+  // CLAIM. Classified upstream in lib/claim/gates/dependency-gate.cjs so both callers partition
+  // from one source. `!== false` is deliberate: an entry without the field — an older caller, a
+  // hand-built fixture — keeps today's blocking behaviour, so the permissive path is reachable
+  // only by an explicit, recognised classification.
+  const blocking = incomplete.filter(d => d.claimBlocking !== false);
+  const scopeConstrained = incomplete.filter(d => d.claimBlocking === false);
   // Unresolvable references (deleted / typo'd): surfaced as a warning, never a
   // hard block — blocking on a bad reference would strand the SD forever.
   const unresolved = list.filter(d => d && !d.status);
 
   if (blocking.length === 0) {
-    return { verdict: 'proceed', blocking, unresolved, warn: unresolved.length > 0 };
+    // A scope-constrained dep permits the claim but must never do so SILENTLY: an unexplained
+    // permit is the same ambiguity as an unexplained refusal, one level down.
+    return {
+      verdict: 'proceed', blocking, scopeConstrained, unresolved,
+      warn: unresolved.length > 0 || scopeConstrained.length > 0,
+    };
   }
   if (force) {
-    return { verdict: 'proceed', blocking, unresolved, warn: true };
+    return { verdict: 'proceed', blocking, scopeConstrained, unresolved, warn: true };
   }
-  return { verdict: 'refuse', blocking, unresolved, warn: false };
+  return { verdict: 'refuse', blocking, scopeConstrained, unresolved, warn: false };
+}
+
+/**
+ * Human-readable body for dependencies that constrain PART of the work but permit the claim.
+ * Names the relation so the reader knows what is constrained, not merely that something is.
+ * @param {Array<{sd_id: string, status: string|null, relation: string|null}>} scopeConstrained
+ * @returns {string}
+ */
+export function formatScopeConstraints(scopeConstrained = []) {
+  return scopeConstrained
+    .map(d => `  • ${d.sd_id} — status='${d.status}', relation='${d.relation}' (constrains this scope, does NOT block the claim)`)
+    .join('\n');
 }
 
 /**

--- a/scripts/sd-start.js
+++ b/scripts/sd-start.js
@@ -81,7 +81,7 @@ import { existsSync } from 'node:fs';
 import { validateTargetApplication, formatCrosscheckResult } from './modules/sd-validation/target-application-crosscheck.js';
 import { shouldShowVenturePipelinePointer, VENTURE_PIPELINE_POINTER } from '../lib/leo/venture-pipeline-pointer.js';
 // SD-FDBK-INFRA-DEPENDENCY-BLOCKS-ADVISORY-001: enforce declared dependencies at claim time.
-import { evaluateDependencyGate, formatDependencyRefusal } from '../lib/sd-start/dependency-gate.mjs';
+import { evaluateDependencyGate, formatDependencyRefusal, formatScopeConstraints } from '../lib/sd-start/dependency-gate.mjs';
 // SD-LEO-INFRA-WORKER-CLAIM-TIME-001 (FR-3): claim-time fitness fail-fast (repo-match + premise +
 // preconditions). CJS module imported as default (Node CJS interop) for its named export.
 import sdFit from '../lib/fleet/sd-executable-here.cjs';
@@ -165,6 +165,15 @@ async function enforceDependencyGate(sd, effectiveId) {
     const why = force && result.blocking.length ? '--force override' : 'unresolved reference(s)';
     console.log(`\n${colors.yellow}⚠️  Proceeding despite unmet dependencies (${why}) for ${effectiveId}:${colors.reset}`);
     console.log(`${colors.yellow}${formatDependencyRefusal(result.blocking, result.unresolved)}${colors.reset}`);
+  }
+
+  // QF-20260727-251: a dependency that constrains PART of the work permits the claim — but it is
+  // announced, never silent. The worker needs to know which objective or FR is constrained before
+  // starting, and a permit nobody can see is the same ambiguity as a refusal nobody can explain.
+  if (result.scopeConstrained?.length) {
+    console.log(`\n${colors.yellow}⚠️  Claim permitted, scope constrained for ${effectiveId}:${colors.reset}`);
+    console.log(`${colors.yellow}${formatScopeConstraints(result.scopeConstrained)}${colors.reset}`);
+    console.log(`   ${colors.dim}These relations bound part of the work, not the claim. Honour them while building.${colors.reset}`);
   }
 }
 

--- a/tests/unit/claim/gates/dependency-gate.test.js
+++ b/tests/unit/claim/gates/dependency-gate.test.js
@@ -9,7 +9,7 @@ import { readFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, resolve } from 'path';
 import { createRequire } from 'module';
-import { evaluateDependencyGate, formatDependencyRefusal } from '../../../../lib/sd-start/dependency-gate.mjs';
+import { evaluateDependencyGate, formatDependencyRefusal, formatScopeConstraints } from '../../../../lib/sd-start/dependency-gate.mjs';
 
 const require = createRequire(import.meta.url);
 const {
@@ -294,5 +294,90 @@ describe('module purity (FR-2 AC — D5 audit ownership + no CLI side effects)',
     expect(src).not.toMatch(/console\./);
     expect(src).not.toMatch(/process\.argv/);
     expect(src).not.toMatch(/audit_log/); // DEPENDENCY_GATE_REFUSED stays in the sd-start caller
+  });
+});
+
+/**
+ * QF-20260727-251 — RELATION SCOPES THE REFUSAL.
+ *
+ * The gate read no relation at all, so a dependency blocking ONE strategic objective refused the
+ * WHOLE claim. Measured on SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001: four refs, relations
+ * blocks_objective_0 / sequence_after_for_FR4 / land_before_FR5 / overlaps_FR4, not one of which
+ * blocks the SD, and claim_history recorded SEVEN sessions claiming and releasing that row in one
+ * day with zero completions.
+ *
+ * The direction is the design: only EXPLICITLY recognised scope relations may downgrade. Absent or
+ * unrecognised stays claim-blocking, because a gate that turns permissive on input it does not
+ * understand is the defect class, not the fix.
+ */
+describe('QF-20260727-251 — relation scopes the refusal', () => {
+  const { classifyDependencyRelation } = require('../../../../lib/claim/gates/dependency-gate.cjs');
+
+  it('classifies the four live relation forms as scope-constraining', () => {
+    for (const rel of ['blocks_objective_0', 'blocks_objective_12', 'sequence_after_for_FR4', 'land_before_FR5', 'overlaps_FR4']) {
+      expect(classifyDependencyRelation(rel), rel).toBe('scope');
+    }
+  });
+
+  it('NEGATIVE CONTROL — absent or unrecognised relations stay CLAIM-BLOCKING', () => {
+    // Load-bearing: without it, "everything downgrades" would satisfy the assertion above while
+    // silently disabling the gate for every legacy plain-string ref in the corpus.
+    for (const rel of [undefined, null, '', 'blocks', 'depends_on', 'blocked_by', 'blocks_objective_', 'BLOCKS_OBJECTIVE_0', 42, {}]) {
+      expect(classifyDependencyRelation(rel), String(rel)).toBe('claim');
+    }
+  });
+
+  it('THE LIVE FIXTURE — four scope relations permit the claim and are reported, not dropped', async () => {
+    const sb = makeSb({ rows: [
+      { id: 'u-a', sd_key: 'SD-COLD-START-001', status: 'in_progress' },
+      { id: 'u-b', sd_key: 'SD-OTHER-001', status: 'in_progress' },
+    ] });
+    const verdict = await evaluateClaimDependencyGate(sb, sdWith([
+      { sd_key: 'SD-COLD-START-001', relation: 'sequence_after_for_FR4' },
+      { sd_key: 'SD-OTHER-001', relation: 'blocks_objective_0' },
+    ]));
+    expect(verdict.blocking).toEqual([]);
+    expect(verdict.scopeConstrained.map(d => d.sd_id)).toEqual(['SD-COLD-START-001', 'SD-OTHER-001']);
+    // The relation rides along so the caller can NAME what is constrained.
+    expect(verdict.scopeConstrained[0].relation).toBe('sequence_after_for_FR4');
+
+    // sd-start's polarity: proceed, and WARN — a silent permit would be the same ambiguity as a
+    // silent refusal, one level down.
+    const result = evaluateDependencyGate(verdict.resolved, {});
+    expect(result.verdict).toBe('proceed');
+    expect(result.warn).toBe(true);
+    expect(formatScopeConstraints(result.scopeConstrained)).toMatch(/does NOT block the claim/);
+  });
+
+  it('a claim-blocking relation still REFUSES, alongside scope-constrained ones', async () => {
+    const sb = makeSb({ rows: [
+      { id: 'u-a', sd_key: 'SD-HARD-001', status: 'in_progress' },
+      { id: 'u-b', sd_key: 'SD-SOFT-001', status: 'in_progress' },
+    ] });
+    const verdict = await evaluateClaimDependencyGate(sb, sdWith([
+      { sd_key: 'SD-HARD-001', relation: 'blocked_by' },
+      { sd_key: 'SD-SOFT-001', relation: 'overlaps_FR4' },
+    ]));
+    expect(verdict.blocking.map(d => d.sd_id)).toEqual(['SD-HARD-001']);
+    expect(verdict.scopeConstrained.map(d => d.sd_id)).toEqual(['SD-SOFT-001']);
+    expect(evaluateDependencyGate(verdict.resolved, {}).verdict).toBe('refuse');
+  });
+
+  it('worker-checkin FAIL-CLOSED polarity is preserved on the narrowed axis', async () => {
+    // A scope-constrained dep no longer skips the candidate — that is the point — but an
+    // unresolved ref or a genuinely blocking relation still does.
+    const sb = makeSb({ rows: [{ id: 'u-b', sd_key: 'SD-SOFT-001', status: 'in_progress' }] });
+    const scoped = await evaluateClaimDependencyGate(sb, sdWith([{ sd_key: 'SD-SOFT-001', relation: 'land_before_FR5' }]));
+    expect(depsSatisfiedFromVerdict(scoped)).toBe(true);
+
+    const sb2 = makeSb({ rows: [{ id: 'u-c', sd_key: 'SD-HARD-001', status: 'in_progress' }] });
+    const hard = await evaluateClaimDependencyGate(sb2, sdWith([{ sd_key: 'SD-HARD-001', relation: 'blocks' }]));
+    expect(depsSatisfiedFromVerdict(hard)).toBe(false);
+  });
+
+  it('an entry with NO claimBlocking field keeps today behaviour (older callers, hand-built fixtures)', () => {
+    const result = evaluateDependencyGate([{ sd_id: 'SD-A-001', status: 'in_progress' }], {});
+    expect(result.verdict).toBe('refuse');
+    expect(result.scopeConstrained).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

`strategic_directives_v2.dependencies` entries carry **relation semantics** and the claim gate read none of them, so a dependency blocking **one strategic objective** refused the **whole claim**.

Measured on SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001: four refs with relations `blocks_objective_0`, `sequence_after_for_FR4`, `land_before_FR5`, `overlaps_FR4` — not one of which blocks the SD — while `metadata.claim_history` recorded **seven sessions** claiming and releasing that row in a single day with zero completions. A partial block presented to every arriving worker as a total block.

- `lib/claim/gates/dependency-gate.cjs` — classifies each relation and attaches `relation` + `claimBlocking` to every resolved entry, so both callers partition from **one** classification rather than each re-deriving it (the divergence that module exists to end). New `scopeConstrained` axis.
- `lib/sd-start/dependency-gate.mjs` — refuses on the narrowed `blocking` axis; new `formatScopeConstraints`.
- `scripts/sd-start.js` — prints it. A scope-constrained dep **permits** the claim but never *silently*: an unexplained permit is the same ambiguity as an unexplained refusal, one level down.

## The polarity is the design

**An absent or unrecognised relation stays CLAIM-BLOCKING.** Defaulting unknown relations to non-blocking would make the gate permissive on input it does not understand — exactly the defect SD-LEO-INFRA-PURE-GUARD-UNWIRED-001 just shipped detectors for. Only explicitly recognised scope relations downgrade, so legacy plain-string refs and every other fold (`blocked_on_sd`, `blocked_by_sd_key`, `depends_on`) behave as before. The consumer uses `claimBlocking !== false` for the same reason: an entry without the field keeps today's blocking behaviour.

Both caller polarities preserved and tested: worker-checkin still fails closed on unresolved refs and genuinely blocking relations; sd-start still warns-and-proceeds.

## Premise verified before writing code

The queue warns items may already be fixed. Two parts of the report **were** already resolved and are not re-fixed here: the cited SD is now `status=completed`, and its `metadata.needs_enrichment` is already `[]`. A suspicious `dependencies: []` call at `sd-start.js:239` was checked and **cleared** — it is the deliberate `blocked_on_sd` fold, not a gate that cannot see its subject.

## Test plan

- 29 tests pass (23 pre-existing + 6 added), lint clean.
- **Mutation-verified**, each mutation confirmed on disk before its run: inverting the classifier default to permissive killed 9 tests; an always-scope classifier killed 9; dropping the relation, emptying the `scopeConstrained` bucket, treating a missing `claimBlocking` as non-blocking, and silencing the warn all died. A comment-only control **survived**, so the suite discriminates rather than merely being red.
- 5 failures in `scratch/preserved-from-hotfix-smoke/tests/unit/fleet/tree-currency.test.js` are pre-existing and unrelated — verified by re-running with these changes stashed: identical 5 failures, and that file has zero references to anything changed here.
- 56 non-comment source lines (Tier 2 band, 31–75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)