### PR TITLE
feat(SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001): re-scoped — population guard, visible fallback, disambiguated marker

### DIFF
--- a/docs/06_deployment/multi-session-coordination-ops.md
+++ b/docs/06_deployment/multi-session-coordination-ops.md
@@ -857,9 +857,25 @@ cd .sessions/hotfix
 **Symptom**: On Windows, junction creation fails
 
 **Resolution**:
-- Ensure main repo has `node_modules` present (run `npm ci` first)
+- Ensure the main repo has `node_modules` present. **Use `npm install`, NOT `npm ci`** — see the warning below.
 - On Windows, may require administrator privileges
-- Use `--no-symlink` flag to skip symlink creation (manual `npm ci` in worktree required)
+- Use `--no-symlink` to skip symlink creation, then `npm install --ignore-scripts --no-audit --no-fund` **inside the worktree**
+
+> ⚠️ **NEVER `npm ci` at the main repo root while worktrees exist.** Its internal `rm -rf` of
+> `node_modules` follows any worktree junction and guts the **shared** store, bricking every
+> parallel session. This is not hypothetical: it is the fleet-wide wipe class this runbook exists
+> to help you recover from.
+>
+> This repo's own guard agrees. `npmCiWouldWipeSharedStore({command:'npm ci', cwd:<repo root>})`
+> returns `{wipes: true, reason: 'main_root_with_active_worktrees'}` — the instruction that used to
+> be on this line is classified as a wipe by `lib/npm-ci-junction-guard.cjs`.
+>
+> `scripts/hooks/pre-tool-enforce.cjs` blocks this for an **agent** running Bash. It does **not**
+> protect a human typing into their own terminal — and a Troubleshooting section is read by humans.
+> The protection and the exposure sit on opposite sides of that boundary, which is exactly why the
+> instruction had to be removed rather than merely guarded.
+>
+> Use `npm install` (additive) or `npm run worktree:remove` (pre-unlinks the junction first).
 
 **Issue: Branch guard blocks commit unexpectedly**
 

--- a/docs/guides/working-with-worktrees.md
+++ b/docs/guides/working-with-worktrees.md
@@ -266,14 +266,22 @@ Error: Cannot find module 'some-package'
 
 **Solution**:
 ```bash
-# Re-link node_modules
+# Additive, herd-safe, and the ONLY recommended repair:
 cd .worktrees/SD-XXX-001
-rm -rf node_modules  # Windows: rmdir /s node_modules
-npm run session:worktree:link -- --sd-key SD-XXX-001
-
-# Or run npm ci in the worktree (less efficient)
-npm ci
+npm install --ignore-scripts --no-audit --no-fund
 ```
+
+> **The previous instructions here were actively harmful and are removed.**
+> - `npm run session:worktree:link` **does not exist** — there is no such script in `package.json`.
+> - `npm ci` is **blocked by this repo's own guards** (`lib/npm-ci-junction-guard.cjs`), because its
+>   internal `rm -rf` follows a `node_modules` junction and guts the **shared** store, bricking every
+>   parallel session.
+> - `rm -rf node_modules` has the same hazard when that path is a junction. Use
+>   `npm run worktree:remove` if you need to remove a worktree; it pre-unlinks first.
+>
+> A hollow `node_modules` (one holding only `.vite` or a stray lock file and no packages) is now
+> detected and re-provisioned automatically, and `validateWorktreeSubstrate` reports it as
+> incomplete rather than healthy — it used to check presence only.
 
 ### "Worktree creation failed"
 
@@ -380,7 +388,23 @@ Worktrees solve all these issues.
 
 ### Do I need to install node_modules in each worktree?
 
-**Answer**: No. The system automatically creates a symlink/junction to the main repo's `node_modules`. This saves disk space (~300MB per worktree).
+**Answer**: No — provisioning is automatic, but **it is not always a junction**, and this page said otherwise for long enough to mis-scope an SD.
+
+Since `SD-LEO-INFRA-SMART-PER-WORKTREE-001` (PR #3825), `lib/worktree-provision.js` **decides**:
+
+| outcome | when |
+|---|---|
+| **isolated** — a real, per-worktree `npm install` | the normal case: ≥2 active sessions |
+| **junction** to the main repo's `node_modules` | ≤1 active session, `WORKTREE_ISOLATION_MODE=never`, or <3 GB free disk |
+| **junction** (`isolate_failed_fallback`) | the isolated install threw — e.g. exceeded its 180s timeout, which gets *more* likely under load |
+
+So a junction can appear at **both ends** of the concurrency curve. Check which you have — do not assume:
+
+```bash
+cat .worktrees/SD-XXX-001/.worktree-nm-mode   # e.g. isolated:auto_concurrent, junction:auto_solo
+```
+
+A value of `junction:isolate_failed_fallback` means the isolated install **failed** and the worktree silently fell back to sharing the main store. That is worth investigating, not ignoring.
 
 ### What happens to the worktree when the SD is completed?
 
@@ -410,7 +434,8 @@ ls .worktrees/  # Shows SD keys
 |---------|---------|
 | `npm run session:worktree -- --sd-key X --branch Y` | Create worktree manually |
 | `npm run session:cleanup -- --sd-key X` | Remove worktree manually |
-| `npm run session:worktree:link -- --sd-key X` | Re-link node_modules |
+| `npm install --ignore-scripts --no-audit --no-fund` | Re-provision a worktree's node_modules (run inside the worktree). Replaces the documented-but-nonexistent `session:worktree:link`. |
+| `npm run audit:worktree-reparse` | Check no worktree node_modules is a junction; self-tests its own detector first and treats 0/0 as a failure to measure |
 | `git worktree list` | List all worktrees |
 | `git worktree remove --force .worktrees/X` | Force remove worktree |
 | `git worktree prune` | Clean up stale worktree metadata |

--- a/lib/__tests__/worktree-fallback-junction-removal.test.js
+++ b/lib/__tests__/worktree-fallback-junction-removal.test.js
@@ -125,6 +125,12 @@ describe('TS-5 — a FALLBACK junction is still safe to remove (composed)', () =
     const marker = fs.readFileSync(path.join(wt, '.worktree-nm-mode'), 'utf8');
     const parsed = parseWorktreeNmMode(marker);
     expect(parsed.mode).toBe('junction');
-    expect(parsed.degraded).toBe(false); // THE distinction — both used to write a bare 'junction'
+    expect(parsed.degraded).toBe(false);
+    // THE ACTUAL DISCRIMINATOR. mode+degraded alone are ALSO true of the LEGACY bare 'junction'
+    // marker, so asserting only those left this pin GREEN when the deliberate writeMarker was
+    // reverted to bare — an un-failable pin whose NAME claimed distinguishability. Caught by the
+    // EXEC TESTING review running exactly that mutation. The reason is the thing that distinguishes.
+    expect(parsed.reason).toBe(result.reason);
+    expect(parsed.reason).toBeTruthy();
   });
 });

--- a/lib/__tests__/worktree-fallback-junction-removal.test.js
+++ b/lib/__tests__/worktree-fallback-junction-removal.test.js
@@ -1,0 +1,130 @@
+/**
+ * SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001 TS-5 — COMPOSED provision-then-delete.
+ *
+ * WHY THIS IS COMPOSED RATHER THAN A DIRECT REMOVAL TEST. My first TS-5 asserted that a provoked
+ * recursive delete leaves the shared store intact — which scripts/safe-worktree-remove.test.js
+ * ALREADY proves, against lib/worktree-manager.js code this SD does not modify. It was green
+ * before the SD and stays green if the SD is reverted entirely: a third un-failable pin. The
+ * PLAN-phase TESTING review caught it.
+ *
+ * This version traverses the code the SD actually changes. It forces the path that produces a
+ * junction UNDER LOAD — lib/worktree-provision.js's isolate_failed_fallback, taken when npm
+ * install throws (a 180s wall-clock timeout whose probability RISES with fleet concurrency) — and
+ * only then removes the worktree. That composition is what makes the invariant meaningful: the
+ * dangerous junction is the one nobody chose.
+ *
+ * LOCATION IS DELIBERATE. This first went to tests/integration/, where vitest.config.js EXCLUDES
+ * the whole tests/integration tree from the `unit` project and no integration project exists — so
+ * it would have NEVER RUN. A test that is never executed is the purest form of the un-failable pin
+ * this SD keeps tripping over. It lives in lib/__tests__/ because that path IS included.
+ *
+ * "No error occurred" is INVALID evidence here. The historical wipe was SILENT, so the assertion
+ * is an explicit before/after count of the shared store, printed as equality rather than compared
+ * against a hard-coded number that would drift on any dependency change.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execSync } from 'child_process';
+import { removeWorktreeViaGit } from '../worktree-manager.js';
+import { provisionWorktreeNodeModules, parseWorktreeNmMode } from '../worktree-provision.js';
+
+const isWin = process.platform === 'win32';
+const git = (cmd, cwd) => execSync(`git ${cmd}`, { cwd, stdio: 'pipe' });
+
+/** Sandbox whose repo root carries the shared store at repo/node_modules, with a CANARY. */
+function makeSandbox() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-fallback-'));
+  const repo = path.join(root, 'repo');
+  fs.mkdirSync(repo, { recursive: true });
+  git('init -q', repo);
+  git('config user.email t@t.t', repo);
+  git('config user.name t', repo);
+  git('config commit.gpgsign false', repo);
+  fs.writeFileSync(path.join(repo, 'README.md'), '# t');
+  git('add -A', repo);
+  git('commit -q -m init', repo);
+  // The shared store the whole fleet depends on.
+  const store = path.join(repo, 'node_modules');
+  fs.mkdirSync(path.join(store, '@supabase', 'supabase-js'), { recursive: true });
+  fs.writeFileSync(path.join(store, '@supabase', 'supabase-js', 'CANARY.txt'), 'do-not-delete');
+  fs.mkdirSync(path.join(store, 'vitest'), { recursive: true });
+  return { root, repo, store };
+}
+
+const countStore = (store) => fs.readdirSync(store).length;
+
+describe('TS-5 — a FALLBACK junction is still safe to remove (composed)', () => {
+  let sb;
+  beforeEach(() => { sb = makeSandbox(); });
+  afterEach(() => {
+    // Lifted from scripts/safe-worktree-remove.test.js: unlink leftover junctions BEFORE the
+    // recursive rm, or the teardown itself follows the link and guts what the test linked.
+    try {
+      const wtDir = path.join(sb.repo, '.worktrees');
+      for (const name of (fs.existsSync(wtDir) ? fs.readdirSync(wtDir) : [])) {
+        const nm = path.join(wtDir, name, 'node_modules');
+        try { if (fs.lstatSync(nm).isSymbolicLink()) fs.unlinkSync(nm); } catch { /* noop */ }
+      }
+    } catch { /* noop */ }
+    try { fs.rmSync(sb.root, { recursive: true, force: true }); } catch { /* noop */ }
+  });
+
+  it('isolate FAILS -> junction fallback -> removal leaves the shared store byte-identical', () => {
+    const wt = path.join(sb.repo, '.worktrees', 'SD-FALLBACK');
+    fs.mkdirSync(path.dirname(wt), { recursive: true });
+    git(`worktree add -q --detach "${wt}"`, sb.repo);
+
+    const before = countStore(sb.store);
+    expect(before).toBeGreaterThan(0); // guard: an empty store would make the assertion vacuous
+
+    // Force the ISOLATE decision (>=2 sessions), then make the install THROW so the real
+    // isolate_failed_fallback path runs. symlink/writeMarker are the REAL defaults, so an actual
+    // junction is created — the hazard is reproduced, not simulated.
+    const result = provisionWorktreeNodeModules(wt, {
+      repoRoot: sb.repo,
+      mode: 'auto',
+      activeSessionCount: 4,
+      freeDiskBytes: 500 * 1024 * 1024 * 1024,
+      deps: { runInstall: () => { throw new Error('simulated npm install timeout'); } }
+    });
+
+    expect(result.strategy).toBe('junction');
+    expect(result.reason).toBe('isolate_failed_fallback');
+
+    // FR-3: the degraded junction is self-identifying on disk.
+    const marker = fs.readFileSync(path.join(wt, '.worktree-nm-mode'), 'utf8');
+    expect(parseWorktreeNmMode(marker).degraded).toBe(true);
+
+    // It is a LIVE passthrough — so a follow-through delete WOULD gut the store.
+    const through = path.join(wt, 'node_modules', '@supabase', 'supabase-js', 'CANARY.txt');
+    expect(fs.readFileSync(through, 'utf8')).toBe('do-not-delete');
+    expect(fs.lstatSync(path.join(wt, 'node_modules')).isSymbolicLink()).toBe(true);
+
+    removeWorktreeViaGit(wt, sb.repo);
+
+    const after = countStore(sb.store);
+    expect(after).toBe(before); // equality, not a hard-coded literal
+    expect(fs.existsSync(path.join(sb.store, '@supabase', 'supabase-js', 'CANARY.txt'))).toBe(true);
+  });
+
+  it('the deliberate junction is distinguishable from this degraded one (FR-3)', () => {
+    const wt = path.join(sb.repo, '.worktrees', 'SD-DELIBERATE');
+    fs.mkdirSync(path.dirname(wt), { recursive: true });
+    git(`worktree add -q --detach "${wt}"`, sb.repo);
+
+    // Solo session => junction BY DESIGN, not by failure.
+    const result = provisionWorktreeNodeModules(wt, {
+      repoRoot: sb.repo, mode: 'auto', activeSessionCount: 1,
+      freeDiskBytes: 500 * 1024 * 1024 * 1024, deps: {}
+    });
+    expect(result.strategy).toBe('junction');
+    expect(result.reason).not.toBe('isolate_failed_fallback');
+
+    const marker = fs.readFileSync(path.join(wt, '.worktree-nm-mode'), 'utf8');
+    const parsed = parseWorktreeNmMode(marker);
+    expect(parsed.mode).toBe('junction');
+    expect(parsed.degraded).toBe(false); // THE distinction — both used to write a bare 'junction'
+  });
+});

--- a/lib/__tests__/worktree-provision.test.js
+++ b/lib/__tests__/worktree-provision.test.js
@@ -73,7 +73,8 @@ describe('provisionWorktreeNodeModules (execution)', () => {
     expect(r).toEqual({ strategy: 'isolate', reason: 'auto_concurrent' });
     expect(d.runInstall).toHaveBeenCalledWith('/wt');
     expect(d.symlink).not.toHaveBeenCalled();
-    expect(d.writeMarker).toHaveBeenCalledWith('/wt', 'isolated');
+    // SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001 FR-3: the marker now carries the REASON.
+    expect(d.writeMarker).toHaveBeenCalledWith('/wt', expect.stringMatching(/^isolated:/));
   });
 
   it('JUNCTION: symlinks (worktree, repoRoot), writes junction marker, does NOT install', () => {
@@ -83,7 +84,8 @@ describe('provisionWorktreeNodeModules (execution)', () => {
     expect(r).toEqual({ strategy: 'junction', reason: 'auto_solo' });
     expect(d.symlink).toHaveBeenCalledWith('/wt', '/repo');
     expect(d.runInstall).not.toHaveBeenCalled();
-    expect(d.writeMarker).toHaveBeenCalledWith('/wt', 'junction');
+    // FR-3: a DELIBERATE junction records WHY it was chosen.
+    expect(d.writeMarker).toHaveBeenCalledWith('/wt', expect.stringMatching(/^junction:/));
   });
 
   it('FALLBACK: isolate install failure -> clean partial -> junction (worktree always usable)', () => {
@@ -95,7 +97,11 @@ describe('provisionWorktreeNodeModules (execution)', () => {
     expect(r.reason).toBe('isolate_failed_fallback');
     expect(r.fallbackReason).toMatch(/npm boom/);
     expect(d.symlink).toHaveBeenCalledWith('/wt', '/repo'); // fell back to junction
-    expect(d.writeMarker).toHaveBeenLastCalledWith('/wt', 'junction');
+    // FR-3, THE POINT OF THE CHANGE: this junction is DEGRADED (install failed), and it must be
+    // distinguishable from the deliberate one above. Both used to write a bare 'junction', so no
+    // teardown or triage tool could tell them apart — and this SD's own LEAD phase was misled by
+    // exactly that ambiguity when it cited a marker census as evidence of topology.
+    expect(d.writeMarker).toHaveBeenLastCalledWith('/wt', 'junction:isolate_failed_fallback');
   });
 });
 

--- a/lib/node-modules-population.js
+++ b/lib/node-modules-population.js
@@ -1,0 +1,53 @@
+/**
+ * SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001 — is a node_modules populated, or merely present?
+ *
+ * ONE rule, ONE implementation. Two guards need it and they must not drift apart:
+ *   - scripts/resolve-sd-workdir.js  decides whether to PROVISION   (FR-1)
+ *   - lib/worktree-manager.js        decides whether it is HEALTHY  (FR-4)
+ * Both were existence-only, so fixing either alone would leave the silent-failure path open. A
+ * copied predicate is how they would diverge later, which is why this lives in its own module with
+ * NO imports of either caller (no cycle between worktree-manager and worktree-provision).
+ *
+ * THE DEFECT. `fs.existsSync` is TRUE for an EMPTY directory. Once anything created
+ * <wt>/node_modules/, provisioning was skipped PERMANENTLY and the health check still reported the
+ * worktree complete. Vite mkdir -p's node_modules/.vite for its optimize cache, which poisoned
+ * both. Measured on this fleet: affected worktrees held literally .vite/ and .vite-temp/ and
+ * nothing else, yet require.resolve succeeded by Node walking UP to the shared root — the coupling
+ * that makes a shared-root wipe fleet-fatal.
+ *
+ * EMPTINESS-BASED, NEVER NAME-BASED. An _archive worktree was found poisoned by only
+ * .rank-pass-trigger.lock, with no .vite at all, so "known-bad name" under-covers.
+ *
+ * NEVER READS THROUGH A JUNCTION. lib/worktree-manager.js:86-93 records why lstat was chosen over
+ * a read-through check (PR #3488 adversarial review, finding 1): a junction's target is
+ * TRANSIENTLY ABSENT during a concurrent npm install at the main repo (.staging atomic swap), so
+ * reading through would classify a HEALTHY junctioned worktree as broken and tear it down — under
+ * load, when the store is busiest. A symlink is provisioned by construction and short-circuits
+ * BEFORE any readdir. This manifests only under concurrency; a quiet test run will not surface it.
+ *
+ * @param {string} nodeModulesPath
+ * @param {{lstatSync:Function, readdirSync:Function}} fsImpl
+ * @returns {boolean} true when the path should be treated as NOT provisioned
+ */
+export function isNodeModulesUnprovisioned(nodeModulesPath, fsImpl) {
+  let stat;
+  try {
+    stat = fsImpl.lstatSync(nodeModulesPath);
+  } catch {
+    return true; // absent or unreadable => not provisioned
+  }
+  if (!stat) return true; // lstatSync({throwIfNoEntry:false}) style callers
+  if (stat.isSymbolicLink()) return false; // junction: provisioned, and MUST NOT be read through
+  if (!stat.isDirectory()) return true;    // a FILE named node_modules is not a provisioned tree
+  let entries;
+  try {
+    entries = fsImpl.readdirSync(nodeModulesPath);
+  } catch {
+    return true;
+  }
+  // Dot-entries (.vite, .vite-temp, .package-lock.json, .bin, stray locks) are caches and
+  // metadata, never packages. A provisioned tree always carries at least one package entry.
+  return !entries.some((name) => !String(name).startsWith('.'));
+}
+
+export default { isNodeModulesUnprovisioned };

--- a/lib/worktree-manager.js
+++ b/lib/worktree-manager.js
@@ -30,6 +30,7 @@
 import { execSync, spawnSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import { isNodeModulesUnprovisioned } from './node-modules-population.js';
 import os from 'os';
 import { enforceWorktreeQuota } from './worktree-quota.js';
 // SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 (FR-2): shared reapability guard.
@@ -106,8 +107,22 @@ export function validateWorktreeSubstrate(worktreePath, items = SUBSTRATE_ITEMS)
   }
   const missing = [];
   for (const item of items) {
-    const stat = fs.lstatSync(path.join(worktreePath, item), { throwIfNoEntry: false });
+    const itemPath = path.join(worktreePath, item);
+    const stat = fs.lstatSync(itemPath, { throwIfNoEntry: false });
     if (!stat) {
+      missing.push(item);
+      continue;
+    }
+    // SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001 FR-4: PRESENCE was not enough. A node_modules holding
+    // only Vite's .vite cache satisfied lstat, so a HOLLOW worktree reported healthy while every
+    // downstream tool failed module-not-found. The setup guard and this health guard were BOTH
+    // existence-only; fixing one alone left the silent path open.
+    //
+    // QUALIFIED TO NON-JUNCTIONS DELIBERATELY. The lstat-not-read-through choice above (:86-93,
+    // PR #3488 finding 1) exists because a junction's target is transiently absent during a
+    // concurrent .staging swap. isNodeModulesUnprovisioned short-circuits on a symlink before any
+    // readdir, so this cannot re-open that regression.
+    if (item === 'node_modules' && isNodeModulesUnprovisioned(itemPath, fs)) {
       missing.push(item);
     }
   }

--- a/lib/worktree-provision.js
+++ b/lib/worktree-provision.js
@@ -95,6 +95,33 @@ export function defaultEnsureHuskyHooks(worktreePath, { execSyncImpl = execSync 
 }
 
 /** Read the isolation-mode marker for teardown decisions. Returns 'isolated' | 'junction' | null. */
+/**
+ * SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001 FR-3 — split a marker into mode + reason.
+ *
+ * Both junction call sites used to write a bare 'junction', so a DELIBERATE junction (solo session,
+ * mode=never, low disk) was indistinguishable from a DEGRADED one (npm install threw and we fell
+ * back). Teardown and triage tooling could not tell them apart, and this SD's own LEAD phase was
+ * misled by exactly that ambiguity — a marker census was cited as decisive evidence of topology
+ * when the marker records INTENT AT PROVISION TIME, not outcome.
+ *
+ * The marker is now `<mode>:<reason>`. Read it through this parser rather than string-matching:
+ * a consumer doing `raw === 'junction'` would silently stop matching.
+ *
+ * Tolerates the legacy bare form so an existing on-disk marker still parses.
+ *
+ * @param {string|null} raw
+ * @returns {{mode: string|null, reason: string|null, degraded: boolean}}
+ */
+export function parseWorktreeNmMode(raw) {
+  if (typeof raw !== 'string') return { mode: null, reason: null, degraded: false };
+  const trimmed = raw.trim();
+  if (!trimmed) return { mode: null, reason: null, degraded: false };
+  const idx = trimmed.indexOf(':');
+  const mode = idx === -1 ? trimmed : trimmed.slice(0, idx);
+  const reason = idx === -1 ? null : trimmed.slice(idx + 1) || null;
+  return { mode, reason, degraded: reason === 'isolate_failed_fallback' };
+}
+
 export function readWorktreeNmMode(worktreePath, fsImpl = fs) {
   try { return fsImpl.readFileSync(path.join(worktreePath, MARKER_FILE), 'utf8').trim() || null; }
   catch { return null; }
@@ -121,7 +148,9 @@ export function provisionWorktreeNodeModules(worktreePath, options = {}) {
 
   if (decision.strategy === 'junction') {
     symlink(worktreePath, repoRoot);
-    writeMarker(worktreePath, 'junction');
+    // FR-3: carry the REASON. Both call sites used to write a bare 'junction', so a deliberate
+    // junction was indistinguishable from a failed isolation in every teardown and triage tool.
+    writeMarker(worktreePath, `junction:${decision.reason}`);
     const hooks = ensureHuskyHooks(worktreePath);
     if (!hooks.ok) log(`[worktree-provision] husky hook re-link failed (non-fatal): ${hooks.error}`);
     log(`[worktree-provision] junction (${decision.reason}): ${worktreePath}`);
@@ -131,7 +160,7 @@ export function provisionWorktreeNodeModules(worktreePath, options = {}) {
   // isolate
   try {
     runInstall(worktreePath);
-    writeMarker(worktreePath, 'isolated');
+    writeMarker(worktreePath, `isolated:${decision.reason}`);
     const hooks = ensureHuskyHooks(worktreePath);
     if (!hooks.ok) log(`[worktree-provision] husky hook re-link failed (non-fatal): ${hooks.error}`);
     log(`[worktree-provision] isolated (${decision.reason}): ${worktreePath}`);
@@ -141,7 +170,8 @@ export function provisionWorktreeNodeModules(worktreePath, options = {}) {
     try { const nm = path.join(worktreePath, 'node_modules'); if (fs.existsSync(nm)) rm(nm); } catch { /* best-effort */ }
     try {
       symlink(worktreePath, repoRoot);
-      writeMarker(worktreePath, 'junction');
+      // FR-3: the DEGRADED junction is now self-identifying.
+      writeMarker(worktreePath, 'junction:isolate_failed_fallback');
       log(`[worktree-provision] isolate FAILED (${err.message}); fell back to junction: ${worktreePath}`);
       return { strategy: 'junction', reason: 'isolate_failed_fallback', fallbackReason: err.message };
     } catch (err2) {
@@ -188,4 +218,4 @@ export async function provisionWorktreeNodeModulesAuto(worktreePath, { repoRoot,
   return provisionWorktreeNodeModules(worktreePath, { repoRoot: resolvedRoot, mode: resolvedMode, activeSessionCount, freeDiskBytes });
 }
 
-export default { decideWorktreeProvisionMode, provisionWorktreeNodeModules, provisionWorktreeNodeModulesAuto, getIsolationMode, readWorktreeNmMode, countActiveFreshSessions, getFreeDiskBytes, ISOLATION_MODES };
+export default { decideWorktreeProvisionMode, parseWorktreeNmMode, provisionWorktreeNodeModules, provisionWorktreeNodeModulesAuto, getIsolationMode, readWorktreeNmMode, countActiveFreshSessions, getFreeDiskBytes, ISOLATION_MODES };

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "audit:generate-sds": "node scripts/audit-to-sd.mjs",
     "audit:retro": "node scripts/audit-retro.mjs",
     "audit:rpc-grants": "node scripts/audit-rpc-execute-grants.mjs",
+    "audit:worktree-reparse": "node scripts/audit/worktree-reparse-audit.mjs",
+    "audit:worktree-reparse:self-test": "node scripts/audit/worktree-reparse-audit.mjs --self-test",
     "audit:orphan-prs": "node scripts/audit-orphan-prs.mjs",
     "audit:unrouted-branches": "node scripts/audit-unrouted-branches.mjs",
     "audit:shared-tables": "node scripts/audit-shared-tables-residue.cjs",

--- a/scripts/audit/worktree-reparse-audit.mjs
+++ b/scripts/audit/worktree-reparse-audit.mjs
@@ -79,7 +79,25 @@ export function classifyAudit({ total, reparse }) {
  * REPORTED, just never folded into the live denominator.
  */
 export function isArchivedWorktree(p) {
-  return String(p).split(path.sep).join('/').includes('/_archive/');
+  return toPosix(p).includes('/_archive/');
+}
+
+/**
+ * Normalise separators to POSIX. Uses an explicit backslash regex, NOT path.sep.
+ *
+ * CAUGHT BY CI, NOT BY ME. Both this and resolveMainRepoRoot used
+ * `String(p).split(path.sep).join('/')`, which is a no-op on Linux — path.sep is '/' there, so a
+ * Windows-style path keeps its backslashes and neither '/_archive/' nor '/.worktrees/' ever
+ * matches. The tests passed on my Windows box and failed on Linux CI.
+ *
+ * Worse than the bug: the test guarding it is NAMED "normalises Windows separators so the match is
+ * not platform-dependent" while the implementation was platform-DEPENDENT. The name asserted the
+ * exact property the code lacked, which is why reading it never raised a flag. A path helper must
+ * handle both separators on every platform, because the string can come from a Windows-recorded
+ * DB row while the process runs on Linux.
+ */
+function toPosix(p) {
+  return String(p).replace(/\\/g, '/');
 }
 
 /**
@@ -136,7 +154,9 @@ export function collectWorktrees(rootDir, fsImpl = fs, depth = 0) {
  * checkout, so truncating at that segment is sufficient and needs no git invocation.
  */
 export function resolveMainRepoRoot(cwd) {
-  const norm = String(cwd).split(path.sep).join('/');
+  // toPosix, NOT path.sep — see its docstring. On Linux this function silently returned the
+  // worktree path unchanged for any Windows-style input.
+  const norm = toPosix(cwd);
   const idx = norm.indexOf('/.worktrees/');
   return idx === -1 ? cwd : norm.slice(0, idx);
 }

--- a/scripts/audit/worktree-reparse-audit.mjs
+++ b/scripts/audit/worktree-reparse-audit.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+/**
+ * SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001 FR-5 — reparse regression guard.
+ *
+ * A REGRESSION GUARD, NOT AN ACCEPTANCE CRITERION. The SD was sourced with acceptance
+ * `reparse_point_worktrees / total_worktrees == 0`. Measured at LEAD: it was ALREADY 0, so as
+ * acceptance it is a permanent vacuous green that no work can move. It still has real value
+ * catching a REINTRODUCTION, which is what this is for.
+ *
+ * THE JUNCTION PATH IS NOT DEAD CODE, so this can genuinely fire. lib/worktree-provision.js
+ * junctions deliberately at <=1 active session, WORKTREE_ISOLATION_MODE=never, or <3GB free — and
+ * ALSO as an isolate_failed_fallback when npm install exceeds its 180s wall-clock timeout, whose
+ * probability RISES with fleet concurrency. Junctions can therefore appear at BOTH ENDS of the
+ * concurrency curve.
+ *
+ * THREE DISCIPLINES, each earned the hard way during this SD:
+ *
+ * 1. TR-1 — the DENOMINATOR is defined instrument-independently and RECURSIVELY. LEAD published it
+ *    wrong twice (13, then 19; authoritative was 17 = 1 main + 16 linked): once by counting
+ *    "worktrees that have a node_modules" and calling it total_worktrees, once by missing the
+ *    nested .worktrees/qf/ layout. Single-level enumeration is not enough.
+ *
+ * 2. TR-1 — the population is VOLATILE. Reapers remove worktrees continuously, so a count without
+ *    a timestamp manufactures contradictions between two readers who were both right.
+ *
+ * 3. TR-2 — 0/0 IS A FAILURE TO MEASURE, never a pass. A detector that reports zero is
+ *    indistinguishable from one that is blind, which is why --self-test exists and why an empty
+ *    denominator exits non-zero.
+ *
+ * Usage:
+ *   node scripts/audit/worktree-reparse-audit.mjs              # audit, human output
+ *   node scripts/audit/worktree-reparse-audit.mjs --json       # machine-readable
+ *   node scripts/audit/worktree-reparse-audit.mjs --self-test  # NEGATIVE CONTROL: prove it fires
+ *
+ * Exit: 0 clean · 1 reparse point found · 2 failure to measure (empty denominator) · 3 self-test failed
+ */
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+/**
+ * Pure: is this path a reparse point (junction/symlink)?
+ * lstat, never stat — stat follows the link and would report the TARGET's type.
+ */
+export function isReparsePoint(p, fsImpl = fs) {
+  try {
+    return fsImpl.lstatSync(p).isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Pure: classify an audit result. Exported so the 0/0 rule is pinned rather than asserted in prose.
+ * @param {{total:number, reparse:string[]}} counts
+ */
+export function classifyAudit({ total, reparse }) {
+  const found = (reparse || []).length;
+  if (!Number.isFinite(total) || total <= 0) {
+    return { verdict: 'FAILED_TO_MEASURE', exitCode: 2, reason: 'empty denominator — 0/0 is not a pass' };
+  }
+  if (found > 0) return { verdict: 'REGRESSION', exitCode: 1, reason: `${found} of ${total} worktree node_modules are reparse points` };
+  return { verdict: 'CLEAN', exitCode: 0, reason: `0 of ${total} worktree node_modules are reparse points` };
+}
+
+/** Recursively collect directories that contain a `.git` entry — the instrument-independent population. */
+export function collectWorktrees(rootDir, fsImpl = fs, depth = 0) {
+  const out = [];
+  if (depth > 3) return out;
+  let entries;
+  try {
+    entries = fsImpl.readdirSync(rootDir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const e of entries) {
+    if (!e.isDirectory()) continue;
+    const full = path.join(rootDir, e.name);
+    let hasGit = false;
+    try { hasGit = !!fsImpl.lstatSync(path.join(full, '.git')); } catch { hasGit = false; }
+    if (hasGit) out.push(full);
+    else out.push(...collectWorktrees(full, fsImpl, depth + 1));
+  }
+  return out;
+}
+
+/** NEGATIVE CONTROL. A zero from a blind detector reads exactly like a zero from a clean tree. */
+function selfTest() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'reparse-selftest-'));
+  const target = fs.mkdtempSync(path.join(os.tmpdir(), 'reparse-target-'));
+  const link = path.join(dir, 'node_modules');
+  try {
+    fs.symlinkSync(target, link, 'junction');
+  } catch (err) {
+    console.error(`SELF-TEST INCONCLUSIVE: could not create a junction (${err.message}). Treating as FAILURE — an unproven detector must not certify a zero.`);
+    return 3;
+  }
+  const fired = isReparsePoint(link);
+  console.log(`  self-test: deliberate junction detected = ${fired}`);
+  try { fs.unlinkSync(link); } catch { /* best-effort */ }
+  if (!fired) {
+    console.error('SELF-TEST FAILED: the detector did not fire on a real junction. Every zero it reports is meaningless.');
+    return 3;
+  }
+  console.log('  self-test PASSED — the detector demonstrably fires, so a zero below is informative.');
+  return 0;
+}
+
+function main() {
+  const json = process.argv.includes('--json');
+  const selfOnly = process.argv.includes('--self-test');
+  const repoRoot = process.cwd();
+  const worktreesDir = path.join(repoRoot, '.worktrees');
+
+  if (!json) console.log('\nWORKTREE REPARSE AUDIT (FR-5 regression guard)\n');
+  const selfCode = selfTest();
+  if (selfCode !== 0) process.exit(selfCode);
+  if (selfOnly) process.exit(0);
+
+  const worktrees = collectWorktrees(worktreesDir);
+  const reparse = worktrees.filter((w) => isReparsePoint(path.join(w, 'node_modules')));
+  const measuredAt = new Date().toISOString();
+  const result = classifyAudit({ total: worktrees.length, reparse });
+
+  if (json) {
+    console.log(JSON.stringify({ measured_at: measuredAt, total_worktrees: worktrees.length, reparse_points: reparse, ...result }, null, 2));
+  } else {
+    console.log(`\n  measured_at: ${measuredAt}   <- the population is VOLATILE; a count without this manufactures contradictions`);
+    console.log(`  total_worktrees: ${worktrees.length}  (recursive, dirs containing .git)`);
+    console.log(`  reparse_points:  ${reparse.length}`);
+    for (const r of reparse) console.log(`    ! ${r}`);
+    console.log(`\n  ${result.verdict}: ${result.reason}\n`);
+  }
+  process.exit(result.exitCode);
+}
+
+const isMain = process.argv[1] && import.meta.url === new URL(`file://${process.argv[1].replace(/\\/g, '/')}`).href;
+if (isMain) main();

--- a/scripts/audit/worktree-reparse-audit.mjs
+++ b/scripts/audit/worktree-reparse-audit.mjs
@@ -84,6 +84,16 @@ export function collectWorktrees(rootDir, fsImpl = fs, depth = 0) {
   return out;
 }
 
+/**
+ * Walk out of a worktree to the main repo root. `.worktrees/<name>` is nested INSIDE the main
+ * checkout, so truncating at that segment is sufficient and needs no git invocation.
+ */
+export function resolveMainRepoRoot(cwd) {
+  const norm = String(cwd).split(path.sep).join('/');
+  const idx = norm.indexOf('/.worktrees/');
+  return idx === -1 ? cwd : norm.slice(0, idx);
+}
+
 /** NEGATIVE CONTROL. A zero from a blind detector reads exactly like a zero from a clean tree. */
 function selfTest() {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'reparse-selftest-'));
@@ -109,7 +119,11 @@ function selfTest() {
 function main() {
   const json = process.argv.includes('--json');
   const selfOnly = process.argv.includes('--self-test');
-  const repoRoot = process.cwd();
+  // Resolve the MAIN repo root, never process.cwd(). Run from inside a worktree, cwd has no
+  // .worktrees dir, so the audit measured an empty population and correctly refused with
+  // FAILED_TO_MEASURE — right behaviour, wrong question. A guard whose answer depends on where the
+  // caller happens to stand is not instrument-independent, which is the whole point of TR-1.
+  const repoRoot = resolveMainRepoRoot(process.cwd());
   const worktreesDir = path.join(repoRoot, '.worktrees');
 
   if (!json) console.log('\nWORKTREE REPARSE AUDIT (FR-5 regression guard)\n');

--- a/scripts/audit/worktree-reparse-audit.mjs
+++ b/scripts/audit/worktree-reparse-audit.mjs
@@ -63,6 +63,53 @@ export function classifyAudit({ total, reparse }) {
   return { verdict: 'CLEAN', exitCode: 0, reason: `0 of ${total} worktree node_modules are reparse points` };
 }
 
+/**
+ * Pure: is this worktree path an ARCHIVED tree rather than a live one?
+ *
+ * ADDED AFTER THE COORDINATOR TURNED THEIR OWN WARNING ON THIS FILE. They cautioned against
+ * reading an unreaped pool as evidence — the reaper is currently REFUSING TO REAP (8 commits
+ * behind origin/main, dirty tree), so archived trees accumulate. This audit enumerated `.git`
+ * dirs recursively and swept `_archive` in with the rest, reporting a denominator of 52-53 when
+ * the LIVE population was 17 (measured 2026-07-29T00:40Z; `git worktree list` agrees: 1 main + 16
+ * linked). A ratio over a stale-inflated denominator is the same wrong-population error this SD's
+ * LEAD phase already made twice. The count is STAMPED because the population is volatile — an
+ * unstamped count of a moving population manufactures contradictions between two correct readers.
+ *
+ * Archived trees still matter — a junction in one is still a junction — so they are COUNTED and
+ * REPORTED, just never folded into the live denominator.
+ */
+export function isArchivedWorktree(p) {
+  return String(p).split(path.sep).join('/').includes('/_archive/');
+}
+
+/**
+ * Pure: split a worktree list into live and archived. Extracted so the live-only denominator is
+ * PINNABLE. Asserting `classifyAudit({total: 17})` in a test does NOT pin this — that assertion
+ * stays green no matter what main() passes in, which is the un-failable-pin shape this SD keeps
+ * finding. The rule only becomes testable once the partition is a function a test can drive.
+ */
+export function partitionWorktrees(all = []) {
+  const live = [];
+  const archived = [];
+  for (const w of all) (isArchivedWorktree(w) ? archived : live).push(w);
+  return { live, archived };
+}
+
+/**
+ * Pure: the whole audit, minus IO. `isReparse` is injectable so a test can drive the real
+ * live-vs-archived rule without creating junctions on disk.
+ *
+ * THE INVARIANT: a reparse point in an ARCHIVED tree is REPORTED but must never move the verdict
+ * or the denominator. With the reaper stalled the archive grows without bound; folding it in lets
+ * a stale pool dilute a ratio that is supposed to describe the CURRENT fleet.
+ */
+export function auditWorktrees(all, isReparse = (w) => isReparsePoint(path.join(w, 'node_modules'))) {
+  const { live, archived } = partitionWorktrees(all);
+  const liveReparse = live.filter(isReparse);
+  const archivedReparse = archived.filter(isReparse);
+  return { live, archived, liveReparse, archivedReparse, ...classifyAudit({ total: live.length, reparse: liveReparse }) };
+}
+
 /** Recursively collect directories that contain a `.git` entry — the instrument-independent population. */
 export function collectWorktrees(rootDir, fsImpl = fs, depth = 0) {
   const out = [];
@@ -138,19 +185,29 @@ function main() {
   if (selfCode !== 0) process.exit(selfCode);
   if (selfOnly) process.exit(0);
 
-  const worktrees = collectWorktrees(worktreesDir);
-  const reparse = worktrees.filter((w) => isReparsePoint(path.join(w, 'node_modules')));
+  const all = collectWorktrees(worktreesDir);
   const measuredAt = new Date().toISOString();
-  const result = classifyAudit({ total: worktrees.length, reparse });
+  // LIVE vs ARCHIVED are reported separately and NEVER summed into one denominator. The rule lives
+  // in auditWorktrees() so it is covered by a test that can actually fail; main() stays thin IO.
+  const { live, archived, liveReparse, archivedReparse, ...result } = auditWorktrees(all);
 
   if (json) {
-    console.log(JSON.stringify({ measured_at: measuredAt, total_worktrees: worktrees.length, reparse_points: reparse, ...result }, null, 2));
+    console.log(JSON.stringify({
+      measured_at: measuredAt,
+      live_worktrees: live.length, live_reparse_points: liveReparse,
+      archived_worktrees: archived.length, archived_reparse_points: archivedReparse,
+      verdict_basis: 'live only — archived trees are counted and reported but never folded into the denominator',
+      ...result
+    }, null, 2));
   } else {
     console.log(`\n  measured_at: ${measuredAt}   <- the population is VOLATILE; a count without this manufactures contradictions`);
-    console.log(`  total_worktrees: ${worktrees.length}  (recursive, dirs containing .git)`);
-    console.log(`  reparse_points:  ${reparse.length}`);
-    for (const r of reparse) console.log(`    ! ${r}`);
-    console.log(`\n  ${result.verdict}: ${result.reason}\n`);
+    console.log(`  live_worktrees:     ${live.length}  (recursive, dirs containing .git, EXCLUDING _archive)`);
+    console.log(`  reparse (live):     ${liveReparse.length}`);
+    for (const r of liveReparse) console.log(`    ! ${r}`);
+    console.log(`  archived_worktrees: ${archived.length}  (reported, NOT in the denominator — a stalled reaper inflates this)`);
+    console.log(`  reparse (archived): ${archivedReparse.length}`);
+    for (const r of archivedReparse) console.log(`    ~ ${r}`);
+    console.log(`\n  ${result.verdict}: ${result.reason}  [live fleet only]\n`);
   }
   process.exit(result.exitCode);
 }

--- a/scripts/audit/worktree-reparse-audit.mjs
+++ b/scripts/audit/worktree-reparse-audit.mjs
@@ -107,7 +107,14 @@ function selfTest() {
   }
   const fired = isReparsePoint(link);
   console.log(`  self-test: deliberate junction detected = ${fired}`);
+  // ORDER IS LOAD-BEARING: unlink the junction FIRST, then remove the directory that held it.
+  // Reversing these makes the cleanup itself follow the link into `target` — the precise
+  // follow-through delete this SD exists to prevent, committed by its own guard's self-test.
+  // Same discipline as the afterEach in lib/__tests__/worktree-fallback-junction-removal.test.js.
   try { fs.unlinkSync(link); } catch { /* best-effort */ }
+  for (const tmp of [dir, target]) {
+    try { fs.rmSync(tmp, { recursive: true, force: true }); } catch { /* best-effort */ }
+  }
   if (!fired) {
     console.error('SELF-TEST FAILED: the detector did not fire on a real junction. Every zero it reports is meaningless.');
     return 3;

--- a/scripts/one-off/_prd-testing-corrections-worktree-001.mjs
+++ b/scripts/one-off/_prd-testing-corrections-worktree-001.mjs
@@ -1,0 +1,65 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const s = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const ID = 'PRD-SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001';
+
+const { data: p, error: readErr } = await s
+  .from('product_requirements_v2')
+  .select('functional_requirements,technical_requirements,test_scenarios,metadata')
+  .eq('id', ID).maybeSingle();
+if (readErr || !p) { console.error('read failed', readErr && readErr.message); process.exit(1); }
+
+const FR3_ADD = ' || TESTING CORRECTION: the stated harm is NOT currently realized. readWorktreeNmMode has ZERO consumers (referenced only at its definition worktree-provision.js:98 and in the module export :191); the direct readers of the marker file treat the filename as non-blocking dirt and never parse contents. Backward-compat risk is therefore LOW, but FR-3 can carry only a UNIT ROUND-TRIP test, and EXEC must NOT invent a synthetic consumer to make it look integration-tested. Restated justification: FORENSIC/TRIAGE value, which is real and was load-bearing in this SD own LEAD correction, NOT unblocking an existing tool. Note that lib/__tests__/worktree-provision.test.js:89-98 currently PINS the ambiguous behaviour (writeMarker last called with the bare junction string on the failure path); FR-3 makes that assertion fail. That is the DESIRED mutation signal, so change it deliberately rather than discovering it as a surprise red.';
+
+const FR4_ADD = ' || CRITICAL TESTING CORRECTION - AS WRITTEN THIS REOPENS A CLOSED REGRESSION. lib/worktree-manager.js:86-93 documents that lstatSync rather than existsSync was chosen ON PURPOSE: for a JUNCTION-mode worktree the link target is transiently absent during a concurrent npm install at the main repo (.staging atomic swap), and reading THROUGH the link would falsely report the worktree incomplete and tear down a HEALTHY one (adversarial review of PR 3488, finding 1). Counting packages INSIDE node_modules lands in the shared store mid-swap. FR-4 MUST therefore be QUALIFIED: apply the population check ONLY when the worktree is isolated - gate on the isolated marker OR on lstat isSymbolicLink being false - and never read through a junction. This failure mode manifests ONLY under concurrency, so a quiet test run will not surface it.';
+
+const FR5_ADD = ' || TWO TESTING CORRECTIONS. (1) There is NO existing reparse audit to demote - a repo-wide grep for reparse finds only comment mentions, and the LEAD measurement was ad hoc. This FR CREATES the guard. (2) THE ACCEPTANCE AS I FIRST WROTE IT WAS VACUOUS: the original TS-5 exercised removeWorktreeViaGit and preUnlinkWorktreeNodeModules in lib/worktree-manager.js, which FR-1 through FR-4 DO NOT MODIFY. It is green today and stays green if this entire SD is reverted, so I had replaced one permanently-vacuous acceptance with another. TS-5 is now COMPOSED - see its revised text.';
+
+const fr = p.functional_requirements.map((r) => {
+  if (r.id === 'FR-3') return { ...r, description: r.description + FR3_ADD };
+  if (r.id === 'FR-4') return { ...r, description: r.description + FR4_ADD };
+  if (r.id === 'FR-5') return { ...r, title: 'CREATE a reparse CI regression guard, and prove the invariant that actually matters', description: r.description + FR5_ADD };
+  return r;
+});
+
+const tr = [...p.technical_requirements,
+  { id: 'TR-6',
+    title: 'Extract the emptiness predicate as an EXPORTED PURE function - otherwise FR-1 cannot be tested behaviourally',
+    description: 'The guard at scripts/resolve-sd-workdir.js:586 lives inside ensureWorktreeEssentials, which is NOT EXPORTED (declared :573; the exports at :236 and :857 omit it). The only existing tests for that file are static source-text pins. Without extraction, EXEC will satisfy TS-1 and TS-2 with ANOTHER source-text pin - a test that cannot fail for the reason it exists. REQUIRED: extract a predicate such as isNodeModulesUnprovisioned(dir, fsImpl) as an exported pure function, have :586 call it, and pin the PREDICATE behaviourally.' },
+  { id: 'TR-7',
+    title: 'Do not inherit the quarantined rmsync guard - but do not add a new offender either',
+    description: 'tests/unit/lib/worktree-rmsync-junction-safety.test.js is quarantined with reason_class real-finding-guard and a triage_note saying FIX the 2 files do not silence, and it is STILL RED. HOWEVER both flagged files are DETECTOR FALSE POSITIVES: concurrent-session-worktree.cjs:611 calls _unlinkNestedLinks immediately before rmSync at :612 (that IS the safety pattern, but the guard SAFE_IMPORT regex only recognises a literal isSymbolicLink within 200 chars of unlinkSync and cannot see named-helper indirection), and sweep-worker-scratch.mjs:276 matches ONLY because the worktrees path appears in its EXCLUDE deny list. Fixing the detector is separate-SD work with its own false-negative risk. THIS SD OBLIGATION IS NARROW: run the guard scoped BEFORE and AFTER the change and assert the offender list is still EXACTLY those two. ALSO NOTE: tests/unit/scripts/resolve-sd-workdir-substrate-gate.test.js is ALSO quarantined (assertion-drift) and is the wiring pin for the very substrate gate FR-4 modifies, so EXEC would otherwise edit that gate with its wiring test silently excluded from the unit tier.' }
+];
+
+const ts = [
+  { id: 'TS-1', scenario: 'A node_modules containing only .vite is CLASSIFIED unprovisioned and provisioning is INVOKED', type: 'unit',
+    expected: 'The exported predicate from TR-6 returns unprovisioned, and an INJECTED runInstall spy is called. DO NOT assert that npm actually populated anything - defaultRunInstall is a real 180s network- and cache-dependent install and is flaky in the unit tier.' },
+  { id: 'TS-2', scenario: 'A node_modules containing only a non-vite stray such as a lock file is ALSO classified unprovisioned', type: 'unit',
+    expected: 'The same predicate returns unprovisioned, proving the check is EMPTINESS-based rather than matching the string .vite. Uses the real _archive counter-example shape.' },
+  { id: 'TS-3', scenario: 'The no-op logger is GONE from the hot provisioning path', type: 'unit',
+    expected: 'scripts/resolve-sd-workdir.js:597 no longer passes a no-op log dep, pinned by its ABSENCE, and the durable emission routes through a separate injectable sink that never touches deps.log. A test that itself passes a no-op logger would prove the library behaves, NOT that the real call site is covered - a hand-wired stand-in, which this PRD implementation_approach forbids.' },
+  { id: 'TS-4', scenario: 'NEGATIVE CONTROL - a deliberately created junction is detected', type: 'unit',
+    expected: 'The detector FIRES (lstat isSymbolicLink true). Without this, any zero from the audit is meaningless.' },
+  { id: 'TS-5', scenario: 'COMPOSED provision-then-delete: force the isolate_failed_fallback junction, THEN remove the worktree', type: 'integration',
+    expected: 'Provision a sandbox worktree THROUGH provisionWorktreeNodeModules with an INJECTED THROWING runInstall (forcing the fallback junction), then run removal, then assert shared-root count before equals after. This REPLACES the earlier TS-5, which exercised removeWorktreeViaGit - code this SD does not modify - and was therefore green on full revert. The composed form traverses the FR-2 durable record and the FR-3 marker and CAN fail. Reuse makeSandbox and addWorktreeWithJunctionNM from scripts/safe-worktree-remove.test.js verbatim, INCLUDING its afterEach junction-unlink at lines 52-63, without which the test itself guts what it linked.' },
+  { id: 'TS-6', scenario: 'A hollow ISOLATED worktree fails substrate validation', type: 'unit',
+    expected: 'WORKTREE_INCOMPLETE is raised for a real-directory node_modules holding no packages.' },
+  { id: 'TS-7', scenario: 'REGRESSION GUARD - a JUNCTION-mode worktree whose target is transiently empty must NOT be reported incomplete', type: 'unit',
+    expected: 'No WORKTREE_INCOMPLETE. This is the PR-3488 finding-1 regression that FR-4 would otherwise reopen: reading through a junction during a concurrent .staging swap would tear down a healthy worktree. It manifests only under concurrency, so it must be pinned explicitly rather than assumed absent.' }
+];
+
+const metadata = { ...(p.metadata || {}), testing_review_corrections: {
+  at: new Date().toISOString(),
+  verdict: 'CONDITIONAL_PASS 88 - not blocking PLAN-TO-EXEC; all four conditions applied to this PRD before EXEC writes code.',
+  vacuous_acceptance_caught: 'My original TS-5 tested UNCHANGED code and was green on full revert - the THIRD un-failable pin I authored this session. Replaced with a composed provision-then-delete scenario that traverses the code this SD actually changes.',
+  regression_i_nearly_specified: 'FR-4 as first written would have REOPENED the PR-3488 finding-1 regression: lstat was chosen deliberately so that a transiently-absent junction target during a concurrent .staging swap does not tear down a healthy worktree. Now qualified to isolated worktrees only, with TS-7 pinning the regression.',
+  premises_corrected: 'FR-3 harm is not currently realized (readWorktreeNmMode has zero consumers), so its justification is restated as forensic/triage. FR-5 CREATES the reparse guard - there was none to demote.',
+  sandbox_limit_stated: 'The safe-worktree-remove sandbox uses a QUIESCENT shared store while the real one is concurrently written by parallel installs. A green TS-5 closes the junction-follow mechanism ONLY; a wipe with a concurrency component would stay green through it.'
+} };
+
+const { error } = await s.from('product_requirements_v2')
+  .update({ functional_requirements: fr, technical_requirements: tr, test_scenarios: ts, metadata })
+  .eq('id', ID);
+if (error) { console.error('update failed', error.message); process.exit(1); }
+console.log('PRD updated: FRs', fr.length, '| TRs', tr.length, '| scenarios', ts.length);

--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -870,4 +870,9 @@ if (isMainScript) {
 
 // isValidWorktree is exported for QF-20260726-956's binding test: the lost-pointer case is
 // only observable against a real on-disk repo, so the test builds one rather than mocking git.
-export { resolve, resolveFromDB, resolveFromScan, validateWorktreePath, resolveVentureRepoRoot, resolveExistingBranch, rejectDescendantBranch, isValidWorktree };
+// ensureWorktreeEssentials is exported for FR-1's CONSUMER pin. isNodeModulesUnprovisioned was
+// already pinned directly, but a predicate can be perfectly correct and simply not be wired to
+// anything — pinning it proves the rule, not that the rule RUNS. This is the same
+// verify-at-the-consumer-not-at-the-merge gap this SD keeps finding in other people's work, so it
+// is closed in its own.
+export { resolve, resolveFromDB, resolveFromScan, validateWorktreePath, resolveVentureRepoRoot, resolveExistingBranch, rejectDescendantBranch, isValidWorktree, ensureWorktreeEssentials };

--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -570,6 +570,55 @@ async function createWorktree(sdKey, repoRoot, opts = {}) {
  * SUBSTRATE_ITEMS membership; .env.local is opportunistic (not in the
  * substrate contract but copied if present).
  */
+/**
+ * SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001 FR-1 / TR-6 — is this node_modules unprovisioned?
+ *
+ * REPLACES a bare `!fs.existsSync(targetModules)` guard. existsSync is true for an EMPTY
+ * directory, so once anything created <wt>/node_modules/ provisioning was skipped PERMANENTLY and
+ * never retried — ensureWorktreeEssentials runs after every successful resolution and still never
+ * re-provisioned. Vite mkdir -p's node_modules/.vite for its optimize cache, which poisoned it.
+ * Measured: affected worktrees held literally .vite/ and .vite-temp/ and nothing else, yet
+ * require.resolve succeeded by Node walking UP to the shared root — the exact coupling that makes
+ * a shared-root wipe fleet-fatal.
+ *
+ * EMPTINESS-BASED, NEVER NAME-BASED. A fix scoped to "Vite creates .vite" under-covers: an
+ * _archive worktree was found poisoned by only .rank-pass-trigger.lock, with no .vite at all. The
+ * rule is therefore "holds no package entries", not "holds a known-bad name".
+ *
+ * DOES NOT READ THROUGH A JUNCTION, deliberately. lib/worktree-manager.js:86-93 records why
+ * lstat was chosen over a read-through check (adversarial review of PR #3488, finding 1): for a
+ * junction-mode worktree the link target is TRANSIENTLY ABSENT during a concurrent npm install at
+ * the main repo (.staging atomic swap), so reading through would classify a HEALTHY junctioned
+ * worktree as unprovisioned and re-provision it under load. A symlink/junction IS provisioned by
+ * construction, so it short-circuits before any readdir. This failure mode appears only under
+ * concurrency and would not surface in a quiet test run.
+ *
+ * Pure: fs is injected so the predicate is testable without touching a real tree.
+ *
+ * @param {string} nodeModulesPath
+ * @param {{lstatSync:Function, readdirSync:Function}} [fsImpl]
+ * @returns {boolean} true when provisioning should run
+ */
+export function isNodeModulesUnprovisioned(nodeModulesPath, fsImpl = fs) {
+  let stat;
+  try {
+    stat = fsImpl.lstatSync(nodeModulesPath);
+  } catch {
+    return true; // absent (or unreadable) => provision
+  }
+  if (stat.isSymbolicLink()) return false; // junction: provisioned, and must not be read through
+  if (!stat.isDirectory()) return true;    // a FILE named node_modules is not a provisioned tree
+  let entries;
+  try {
+    entries = fsImpl.readdirSync(nodeModulesPath);
+  } catch {
+    return true;
+  }
+  // Dot-entries (.vite, .vite-temp, .package-lock.json, .bin, stray locks) are caches and
+  // metadata, never packages. A provisioned tree always carries at least one package entry.
+  return !entries.some((name) => !name.startsWith('.'));
+}
+
 function ensureWorktreeEssentials(worktreePath, repoRoot, opts = {}) {
   // SD-LEO-FIX-WORKTREE-CREATION-ATOMICITY-001 US-004: Structured error return
   // instead of swallowed catches. Best-effort semantics preserved (no throw) but
@@ -583,7 +632,9 @@ function ensureWorktreeEssentials(worktreePath, repoRoot, opts = {}) {
   if (SUBSTRATE_ITEMS.includes('node_modules')) {
     const sourceModules = path.join(repoRoot, 'node_modules');
     const targetModules = path.join(worktreePath, 'node_modules');
-    if (fs.existsSync(sourceModules) && !fs.existsSync(targetModules)) {
+    // FR-1: POPULATION, not existence. An empty node_modules (Vite's .vite cache, a stray lock)
+    // used to satisfy existsSync and suppress provisioning permanently.
+    if (fs.existsSync(sourceModules) && isNodeModulesUnprovisioned(targetModules)) {
       try {
         // SD-LEO-INFRA-SMART-PER-WORKTREE-001: isolate node_modules under concurrency
         // (immune to shared-store wipes), else junction. provision handles the
@@ -594,7 +645,12 @@ function ensureWorktreeEssentials(worktreePath, repoRoot, opts = {}) {
           mode: getIsolationMode(),
           activeSessionCount: opts.activeSessionCount,
           freeDiskBytes: getFreeDiskBytes(worktreePath),
-          deps: { log: () => {} },
+          // FR-2: the no-op logger is GONE. lib/worktree-provision.js falls back to a junction
+          // when npm install throws (180s wall-clock timeout, whose probability RISES with
+          // fleet concurrency), and logs that at :145 — but this, the highest-traffic
+          // provisioning path, swallowed it. The system could silently degrade to the shared
+          // store it was built to avoid, and no operator would see it. The failure this SD
+          // exists to prevent is one nobody observed happening.
         });
       } catch (err) {
         errors.push({ step: 'provision_node_modules', message: err.message });

--- a/scripts/resolve-sd-workdir.js
+++ b/scripts/resolve-sd-workdir.js
@@ -33,6 +33,7 @@ import { enforceWorktreeQuota, MAX_WORKTREE_COUNT, WORKTREE_QUOTA_HELPERS } from
 import { resolveWorktreeBaseRef, fetchBaseRef, WorktreeBaseFetchFailedError, SUBSTRATE_ITEMS, VENTURE_SUBSTRATE_ITEMS, validateWorktreeSubstrate } from '../lib/worktree-manager.js';
 import { provisionWorktreeNodeModules, getIsolationMode, getFreeDiskBytes, countActiveFreshSessions } from '../lib/worktree-provision.js';
 import { execSync } from 'child_process';
+import { isNodeModulesUnprovisioned as isUnprovisionedShared } from '../lib/node-modules-population.js';
 import fs from 'fs';
 import path from 'path';
 import dotenv from 'dotenv';
@@ -570,53 +571,12 @@ async function createWorktree(sdKey, repoRoot, opts = {}) {
  * SUBSTRATE_ITEMS membership; .env.local is opportunistic (not in the
  * substrate contract but copied if present).
  */
-/**
- * SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001 FR-1 / TR-6 — is this node_modules unprovisioned?
- *
- * REPLACES a bare `!fs.existsSync(targetModules)` guard. existsSync is true for an EMPTY
- * directory, so once anything created <wt>/node_modules/ provisioning was skipped PERMANENTLY and
- * never retried — ensureWorktreeEssentials runs after every successful resolution and still never
- * re-provisioned. Vite mkdir -p's node_modules/.vite for its optimize cache, which poisoned it.
- * Measured: affected worktrees held literally .vite/ and .vite-temp/ and nothing else, yet
- * require.resolve succeeded by Node walking UP to the shared root — the exact coupling that makes
- * a shared-root wipe fleet-fatal.
- *
- * EMPTINESS-BASED, NEVER NAME-BASED. A fix scoped to "Vite creates .vite" under-covers: an
- * _archive worktree was found poisoned by only .rank-pass-trigger.lock, with no .vite at all. The
- * rule is therefore "holds no package entries", not "holds a known-bad name".
- *
- * DOES NOT READ THROUGH A JUNCTION, deliberately. lib/worktree-manager.js:86-93 records why
- * lstat was chosen over a read-through check (adversarial review of PR #3488, finding 1): for a
- * junction-mode worktree the link target is TRANSIENTLY ABSENT during a concurrent npm install at
- * the main repo (.staging atomic swap), so reading through would classify a HEALTHY junctioned
- * worktree as unprovisioned and re-provision it under load. A symlink/junction IS provisioned by
- * construction, so it short-circuits before any readdir. This failure mode appears only under
- * concurrency and would not surface in a quiet test run.
- *
- * Pure: fs is injected so the predicate is testable without touching a real tree.
- *
- * @param {string} nodeModulesPath
- * @param {{lstatSync:Function, readdirSync:Function}} [fsImpl]
- * @returns {boolean} true when provisioning should run
- */
+// SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001 FR-1 / TR-6. The predicate moved to
+// lib/node-modules-population.js because FR-4's health check in lib/worktree-manager.js needs
+// the SAME rule, and two copies would drift. Re-exported here so the exported surface (and its
+// pins) stay stable.
 export function isNodeModulesUnprovisioned(nodeModulesPath, fsImpl = fs) {
-  let stat;
-  try {
-    stat = fsImpl.lstatSync(nodeModulesPath);
-  } catch {
-    return true; // absent (or unreadable) => provision
-  }
-  if (stat.isSymbolicLink()) return false; // junction: provisioned, and must not be read through
-  if (!stat.isDirectory()) return true;    // a FILE named node_modules is not a provisioned tree
-  let entries;
-  try {
-    entries = fsImpl.readdirSync(nodeModulesPath);
-  } catch {
-    return true;
-  }
-  // Dot-entries (.vite, .vite-temp, .package-lock.json, .bin, stray locks) are caches and
-  // metadata, never packages. A provisioned tree always carries at least one package entry.
-  return !entries.some((name) => !name.startsWith('.'));
+  return isUnprovisionedShared(nodeModulesPath, fsImpl);
 }
 
 function ensureWorktreeEssentials(worktreePath, repoRoot, opts = {}) {

--- a/tests/unit/audit/worktree-reparse-audit.test.js
+++ b/tests/unit/audit/worktree-reparse-audit.test.js
@@ -1,0 +1,77 @@
+// SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001 FR-5 — pins for the reparse regression guard.
+//
+// The 0/0 rule is the reason this file exists. The SD shipped with acceptance
+// `reparse_point_worktrees / total_worktrees == 0`, which was ALREADY true at LEAD — a permanent
+// vacuous green. Worse, a detector that reports zero is indistinguishable from one that is blind,
+// and an EMPTY DENOMINATOR reads as a pass to anyone skimming. classifyAudit is exported precisely
+// so that rule is pinned rather than asserted in prose.
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { classifyAudit, isReparsePoint, collectWorktrees } from '../../../scripts/audit/worktree-reparse-audit.mjs';
+
+describe('classifyAudit — 0/0 is a FAILURE TO MEASURE, never a pass', () => {
+  it('refuses an empty denominator', () => {
+    expect(classifyAudit({ total: 0, reparse: [] })).toMatchObject({ verdict: 'FAILED_TO_MEASURE', exitCode: 2 });
+  });
+
+  it('refuses a non-numeric denominator rather than defaulting to clean', () => {
+    expect(classifyAudit({ total: NaN, reparse: [] }).exitCode).toBe(2);
+    expect(classifyAudit({ total: undefined, reparse: [] }).exitCode).toBe(2);
+  });
+
+  it('reports CLEAN only when the denominator is real', () => {
+    expect(classifyAudit({ total: 52, reparse: [] })).toMatchObject({ verdict: 'CLEAN', exitCode: 0 });
+  });
+
+  it('reports REGRESSION when a reparse point is found, and names the count over the denominator', () => {
+    const r = classifyAudit({ total: 52, reparse: ['/wt/a'] });
+    expect(r.verdict).toBe('REGRESSION');
+    expect(r.exitCode).toBe(1);
+    expect(r.reason).toMatch(/1 of 52/);
+  });
+});
+
+describe('isReparsePoint — lstat, never stat', () => {
+  it('detects a REAL junction', () => {
+    // NEGATIVE CONTROL as a unit test: if this cannot fire, every zero the audit prints is
+    // meaningless. The CLI runs the same check as a --self-test before it will report anything.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'reparse-unit-'));
+    const target = fs.mkdtempSync(path.join(os.tmpdir(), 'reparse-unit-target-'));
+    const link = path.join(dir, 'node_modules');
+    try {
+      fs.symlinkSync(target, link, 'junction');
+    } catch {
+      return; // environment cannot create junctions — skip rather than false-pass
+    }
+    expect(isReparsePoint(link)).toBe(true);
+    fs.unlinkSync(link);
+  });
+
+  it('does NOT flag a real directory', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'reparse-unit-real-'));
+    fs.mkdirSync(path.join(dir, 'node_modules'));
+    expect(isReparsePoint(path.join(dir, 'node_modules'))).toBe(false);
+  });
+
+  it('is false, not throwing, on an absent path', () => {
+    expect(isReparsePoint(path.join(os.tmpdir(), 'definitely-not-here-9d3f'))).toBe(false);
+  });
+});
+
+describe('collectWorktrees — the denominator is RECURSIVE (TR-1)', () => {
+  it('finds a worktree nested one level down, which single-level enumeration missed', () => {
+    // The concrete error this pins: LEAD published the denominator twice and was wrong both times,
+    // once by missing the nested .worktrees/qf/ layout entirely.
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-collect-'));
+    fs.mkdirSync(path.join(root, 'top', '.git'), { recursive: true });
+    fs.mkdirSync(path.join(root, 'qf', 'nested', '.git'), { recursive: true });
+    const found = collectWorktrees(root).map((p) => path.basename(p)).sort();
+    expect(found).toEqual(['nested', 'top']);
+  });
+
+  it('returns an empty list for an absent root rather than throwing', () => {
+    expect(collectWorktrees(path.join(os.tmpdir(), 'no-such-root-77a2'))).toEqual([]);
+  });
+});

--- a/tests/unit/audit/worktree-reparse-audit.test.js
+++ b/tests/unit/audit/worktree-reparse-audit.test.js
@@ -9,7 +9,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { classifyAudit, isReparsePoint, collectWorktrees } from '../../../scripts/audit/worktree-reparse-audit.mjs';
+import { classifyAudit, isReparsePoint, collectWorktrees, resolveMainRepoRoot } from '../../../scripts/audit/worktree-reparse-audit.mjs';
 
 describe('classifyAudit — 0/0 is a FAILURE TO MEASURE, never a pass', () => {
   it('refuses an empty denominator', () => {
@@ -75,5 +75,35 @@ describe('collectWorktrees — the denominator is RECURSIVE (TR-1)', () => {
 
   it('returns an empty list for an absent root rather than throwing', () => {
     expect(collectWorktrees(path.join(os.tmpdir(), 'no-such-root-77a2'))).toEqual([]);
+  });
+});
+
+describe('resolveMainRepoRoot — the guard must measure the FLEET, not the caller cwd', () => {
+  // ADDED AFTER A RE-REVIEW FINDING, and the finding is worth recording: this function carried the
+  // ENTIRE fix for "the audit reports FAILED_TO_MEASURE when run from inside a worktree", and
+  // NOTHING tested it. Replacing its body with `return cwd` fully reverted that fix while 896
+  // tests stayed green. I had fixed an un-failable-pin finding by adding an unpinned function.
+  it('walks OUT of a worktree to the main repo root', () => {
+    expect(resolveMainRepoRoot('C:/repo/.worktrees/SD-X-001')).toBe('C:/repo');
+  });
+
+  it('walks out of a NESTED worktree layout too', () => {
+    // .worktrees/qf/<id> is a real layout here, and a single-level assumption missed it once already.
+    expect(resolveMainRepoRoot('C:/repo/.worktrees/qf/QF-1')).toBe('C:/repo');
+  });
+
+  it('returns the repo root UNCHANGED when already at it', () => {
+    expect(resolveMainRepoRoot('C:/repo')).toBe('C:/repo');
+  });
+
+  it('normalises Windows separators so the match is not platform-dependent', () => {
+    // String.raw, deliberately: written as a normal quoted literal the \r in \repo becomes a
+    // CARRIAGE RETURN and the test silently asserts on a different string than it appears to.
+    expect(resolveMainRepoRoot(String.raw`C:\repo\.worktrees\SD-X-001`)).toBe('C:/repo');
+  });
+
+  it('does not truncate on a path that merely CONTAINS the word worktrees', () => {
+    // Guards against matching a bare substring instead of the path segment.
+    expect(resolveMainRepoRoot('C:/repo/my-worktrees-notes')).toBe('C:/repo/my-worktrees-notes');
   });
 });

--- a/tests/unit/audit/worktree-reparse-audit.test.js
+++ b/tests/unit/audit/worktree-reparse-audit.test.js
@@ -9,7 +9,7 @@ import { describe, it, expect } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { classifyAudit, isReparsePoint, collectWorktrees, resolveMainRepoRoot } from '../../../scripts/audit/worktree-reparse-audit.mjs';
+import { classifyAudit, isReparsePoint, collectWorktrees, resolveMainRepoRoot, isArchivedWorktree, auditWorktrees, partitionWorktrees } from '../../../scripts/audit/worktree-reparse-audit.mjs';
 
 describe('classifyAudit — 0/0 is a FAILURE TO MEASURE, never a pass', () => {
   it('refuses an empty denominator', () => {
@@ -105,5 +105,80 @@ describe('resolveMainRepoRoot — the guard must measure the FLEET, not the call
   it('does not truncate on a path that merely CONTAINS the word worktrees', () => {
     // Guards against matching a bare substring instead of the path segment.
     expect(resolveMainRepoRoot('C:/repo/my-worktrees-notes')).toBe('C:/repo/my-worktrees-notes');
+  });
+});
+
+describe('isArchivedWorktree — the denominator must be the LIVE fleet', () => {
+  // ADDED AFTER THE COORDINATOR TURNED THEIR OWN WARNING ON THIS FILE. They cautioned against
+  // reading an unreaped pool as evidence; the reaper is currently refusing to reap, so archived
+  // trees accumulate. This audit swept _archive into the denominator and reported 52-53 when the
+  // live population was 17 -- a ratio over a stale-inflated base, which is the same
+  // wrong-population error this SD LEAD phase made twice before.
+  it('classifies an _archive path as archived', () => {
+    expect(isArchivedWorktree('C:/repo/.worktrees/_archive/SD-OLD-001-2026-07-27T15-15-41')).toBe(true);
+  });
+
+  it('classifies a live worktree as NOT archived', () => {
+    expect(isArchivedWorktree('C:/repo/.worktrees/SD-LIVE-001')).toBe(false);
+  });
+
+  it('handles Windows separators', () => {
+    // This literal was CORRUPTED on first write and STILL PASSED. A shell heredoc ate the
+    // backslash in \repo, so the assertion ran against 'C:<CR>epo\...' and matched for a
+    // COINCIDENTAL reason -- the mangled string still contained /_archive/ after normalisation.
+    // A green test on a string that is not the string you wrote is the same class as the
+    // un-failable pins this SD keeps surfacing, so the input is now pinned FIRST.
+    const winPath = String.raw`C:\repo\.worktrees\_archive\SD-OLD-001`;
+    expect(winPath).toContain('\\repo\\');   // the input is what it appears to be
+    expect(winPath).not.toContain(String.fromCharCode(13));  // no CR smuggled in
+    expect(isArchivedWorktree(winPath)).toBe(true);
+  });
+
+  it('does NOT match a name that merely CONTAINS _archive', () => {
+    // Guards substring matching: the segment is /_archive/, not the bare token.
+    expect(isArchivedWorktree('C:/repo/.worktrees/SD-_archive-tooling-001')).toBe(false);
+  });
+});
+
+describe('auditWorktrees — archived trees are REPORTED but never move the verdict', () => {
+  // THE FIRST VERSION OF THIS BLOCK WAS UN-FAILABLE and I wrote it. It asserted
+  // `classifyAudit({total: 17})` directly, which stays green no matter what main() passes in — so
+  // it pinned nothing about the live-vs-archived rule it claimed to guard. The rule only became
+  // testable once the partition was extracted into a function a test can actually drive.
+  const isArchivedFake = (w) => w.includes('_archive');
+
+  it('a junction in an ARCHIVED tree does NOT fail the live fleet', () => {
+    const r = auditWorktrees(['/wt/a', '/wt/b', '/wt/_archive/old'], isArchivedFake);
+    expect(r.verdict).toBe('CLEAN');
+    expect(r.archivedReparse).toHaveLength(1);   // still surfaced, never hidden
+  });
+
+  it('the DENOMINATOR counts live trees only', () => {
+    // Fold the archive in and this reads "0 of 3" — the stale-pool dilution this guards against.
+    const r = auditWorktrees(['/wt/a', '/wt/b', '/wt/_archive/old'], isArchivedFake);
+    expect(r.reason).toMatch(/0 of 2/);
+    expect(r.live).toHaveLength(2);
+  });
+
+  it('a junction in a LIVE tree DOES fail — the guard still has teeth', () => {
+    const r = auditWorktrees(['/wt/a', '/wt/_archive/old'], (w) => w === '/wt/a');
+    expect(r.verdict).toBe('REGRESSION');
+    expect(r.exitCode).toBe(1);
+  });
+
+  it('an all-archived population is FAILED_TO_MEASURE, not a free pass', () => {
+    // The stalled-reaper worst case: every tree archived, live denominator 0. Reporting CLEAN here
+    // would be a vacuous green over an empty base — the exact 0/0 trap this file exists for.
+    expect(auditWorktrees(['/wt/_archive/a'], isArchivedFake).verdict).toBe('FAILED_TO_MEASURE');
+  });
+});
+
+describe('partitionWorktrees', () => {
+  it('splits without dropping or duplicating any tree', () => {
+    const all = ['/wt/a', '/wt/_archive/x', '/wt/b', '/wt/_archive/y'];
+    const { live, archived } = partitionWorktrees(all);
+    expect(live).toEqual(['/wt/a', '/wt/b']);
+    expect(archived).toEqual(['/wt/_archive/x', '/wt/_archive/y']);
+    expect(live.length + archived.length).toBe(all.length);
   });
 });

--- a/tests/unit/audit/worktree-reparse-audit.test.js
+++ b/tests/unit/audit/worktree-reparse-audit.test.js
@@ -173,6 +173,45 @@ describe('auditWorktrees — archived trees are REPORTED but never move the verd
   });
 });
 
+describe('OS-separator invariance — the CI-only defect', () => {
+  // BOTH path helpers here used `String(p).split(path.sep).join('/')`, which is a NO-OP on Linux:
+  // path.sep is '/' there, so a Windows-style path keeps its backslashes and neither '/_archive/'
+  // nor '/.worktrees/' ever matches. Green on my Windows box, two failures on Linux CI.
+  //
+  // A SOURCE assertion, deliberately, and this is the one case where that is the right instrument
+  // rather than the weak one. The behavioural pins below CANNOT fail on Windows — under the old
+  // code both separator forms returned true locally — so on the platform where the tests are
+  // usually run first, the bug is invisible to any behavioural check. The property actually being
+  // guarded is a property OF THE IMPLEMENTATION: it must not branch on path.sep. So assert that.
+  // COMMENTS STRIPPED FIRST. The first version of this pin failed instantly against correct code:
+  // its regex matched the DOCSTRING, which quotes the old `split(path.sep)` implementation
+  // verbatim to explain the bug. A source assertion that cannot tell code from prose reports the
+  // explanation as the defect — the same unanchored-match trap that produced a false refutation
+  // earlier in this SD.
+  const src = fs.readFileSync(
+    new URL('../../../scripts/audit/worktree-reparse-audit.mjs', import.meta.url), 'utf8'
+  );
+  const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+  it('the pin reads CODE, not prose — the docstring still quotes the old form', () => {
+    // Guards the stripper itself: if it ever stops working, the pin below silently goes vacuous.
+    expect(src).toContain('split(path.sep)');   // present, in the explanatory comment
+    expect(code).not.toContain('split(path.sep)'); // absent, in the code
+  });
+
+  it('normalisation goes through an explicit backslash regex', () => {
+    expect(code).toContain("replace(/\\\\/g, '/')");
+  });
+
+  it('behaviourally: both separator forms agree, on every platform', () => {
+    const B = String.fromCharCode(92);
+    expect(isArchivedWorktree(`C:${B}r${B}.worktrees${B}_archive${B}X`))
+      .toBe(isArchivedWorktree('C:/r/.worktrees/_archive/X'));
+    expect(resolveMainRepoRoot(`C:${B}r${B}.worktrees${B}SD-1`))
+      .toBe(resolveMainRepoRoot('C:/r/.worktrees/SD-1'));
+  });
+});
+
 describe('partitionWorktrees', () => {
   it('splits without dropping or duplicating any tree', () => {
     const all = ['/wt/a', '/wt/_archive/x', '/wt/b', '/wt/_archive/y'];

--- a/tests/unit/audit/worktree-reparse-audit.test.js
+++ b/tests/unit/audit/worktree-reparse-audit.test.js
@@ -34,7 +34,7 @@ describe('classifyAudit — 0/0 is a FAILURE TO MEASURE, never a pass', () => {
 });
 
 describe('isReparsePoint — lstat, never stat', () => {
-  it('detects a REAL junction', () => {
+  it('detects a REAL junction', (ctx) => {
     // NEGATIVE CONTROL as a unit test: if this cannot fire, every zero the audit prints is
     // meaningless. The CLI runs the same check as a --self-test before it will report anything.
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'reparse-unit-'));
@@ -43,7 +43,9 @@ describe('isReparsePoint — lstat, never stat', () => {
     try {
       fs.symlinkSync(target, link, 'junction');
     } catch {
-      return; // environment cannot create junctions — skip rather than false-pass
+      // ctx.skip(), NOT a bare return: vitest reports an early return as PASSED, so on a host that
+      // cannot create junctions this becomes a SILENT GREEN on the exact regression it guards.
+      ctx.skip();
     }
     expect(isReparsePoint(link)).toBe(true);
     fs.unlinkSync(link);

--- a/tests/unit/lib/worktree-manager-substrate.test.js
+++ b/tests/unit/lib/worktree-manager-substrate.test.js
@@ -23,6 +23,11 @@ function buildHealthyWorktree(root) {
       fs.mkdirSync(full, { recursive: true });
     }
   }
+  // SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001 FR-4: a HEALTHY worktree now needs a POPULATED
+  // node_modules, not merely a present one. Before FR-4 this fixture created an EMPTY directory
+  // and the presence-only check accepted it -- which is precisely the hollow-worktree state that
+  // reported healthy while every downstream tool failed module-not-found.
+  fs.mkdirSync(path.join(root, 'node_modules', 'vitest'), { recursive: true });
 }
 
 describe('SD-LEO-INFRA-LEO-INFRA-WORKTREE-001 — SUBSTRATE_ITEMS const', () => {

--- a/tests/unit/lib/worktree-substrate-population.test.js
+++ b/tests/unit/lib/worktree-substrate-population.test.js
@@ -57,7 +57,7 @@ describe('validateWorktreeSubstrate — population, not presence (FR-4)', () => 
 });
 
 describe('TS-7 — a JUNCTION must NOT be read through (PR #3488 finding 1)', () => {
-  it('accepts a symlinked node_modules whose target is EMPTY', () => {
+  it('accepts a symlinked node_modules whose target is EMPTY', (ctx) => {
     // Reading through would see an empty target and declare the worktree incomplete. Under a real
     // concurrent .staging swap that target is transiently absent, so a read-through check would
     // tear down a healthy worktree exactly when the store is busiest.
@@ -66,7 +66,9 @@ describe('TS-7 — a JUNCTION must NOT be read through (PR #3488 finding 1)', ()
     try {
       fs.symlinkSync(target, path.join(dir, 'node_modules'), 'junction');
     } catch {
-      return; // symlink/junction creation unavailable in this environment — skip rather than false-pass
+      // ctx.skip(), NOT a bare return: vitest reports an early return as PASSED, so on a host that
+      // cannot create junctions this becomes a SILENT GREEN on the exact regression it guards.
+      ctx.skip();
     }
     const res = validateWorktreeSubstrate(dir, ['node_modules']);
     expect(res.missing).not.toContain('node_modules');

--- a/tests/unit/lib/worktree-substrate-population.test.js
+++ b/tests/unit/lib/worktree-substrate-population.test.js
@@ -1,0 +1,97 @@
+// SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001 FR-4 + FR-3.
+//
+// FR-4: validateWorktreeSubstrate checked lstat PRESENCE only, and SUBSTRATE_ITEMS lists
+// 'node_modules'. A directory holding just Vite's .vite cache therefore satisfied it, no
+// WORKTREE_INCOMPLETE was raised, and the worktree reported HEALTHY while every downstream tool
+// failed module-not-found. The provisioning guard and this health guard were BOTH existence-only,
+// so fixing either alone left the silent-failure path open.
+//
+// TS-7 is the regression guard: the PLAN-phase TESTING review caught that FR-4, as originally
+// written, would have REOPENED the PR #3488 finding-1 regression. lstat was chosen over a
+// read-through check because a junction's target is transiently absent during a concurrent npm
+// install at the main repo (.staging atomic swap) — reading through would tear down a HEALTHY
+// junctioned worktree, under load, when the store is busiest. It manifests only under concurrency.
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { validateWorktreeSubstrate } from '../../../lib/worktree-manager.js';
+import { parseWorktreeNmMode } from '../../../lib/worktree-provision.js';
+
+function tmpWorktree() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-substrate-'));
+  // Minimal substrate so only node_modules is under test.
+  fs.mkdirSync(path.join(dir, 'node_modules'));
+  return dir;
+}
+
+describe('validateWorktreeSubstrate — population, not presence (FR-4)', () => {
+  it('reports a HOLLOW node_modules as missing', () => {
+    const dir = tmpWorktree();
+    fs.mkdirSync(path.join(dir, 'node_modules', '.vite'));
+    // The exact on-disk shape measured on this fleet: a cache dir and no packages.
+    expect(validateWorktreeSubstrate(dir, ['node_modules']).missing).toContain('node_modules');
+  });
+
+  it('reports a node_modules poisoned by a NON-.vite stray as missing', () => {
+    // An _archive worktree was found holding only .rank-pass-trigger.lock and no .vite at all, so
+    // a name-based fix would under-cover. This pins the emptiness rule instead.
+    const dir = tmpWorktree();
+    fs.writeFileSync(path.join(dir, 'node_modules', '.rank-pass-trigger.lock'), '');
+    expect(validateWorktreeSubstrate(dir, ['node_modules']).missing).toContain('node_modules');
+  });
+
+  it('accepts a POPULATED node_modules', () => {
+    const dir = tmpWorktree();
+    fs.mkdirSync(path.join(dir, 'node_modules', '.vite'));
+    fs.mkdirSync(path.join(dir, 'node_modules', 'vitest'));
+    const res = validateWorktreeSubstrate(dir, ['node_modules']);
+    expect(res.missing).not.toContain('node_modules');
+    expect(res.ok).toBe(true);
+  });
+
+  it('still reports a genuinely ABSENT node_modules as missing', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-substrate-none-'));
+    expect(validateWorktreeSubstrate(dir, ['node_modules']).missing).toContain('node_modules');
+  });
+});
+
+describe('TS-7 — a JUNCTION must NOT be read through (PR #3488 finding 1)', () => {
+  it('accepts a symlinked node_modules whose target is EMPTY', () => {
+    // Reading through would see an empty target and declare the worktree incomplete. Under a real
+    // concurrent .staging swap that target is transiently absent, so a read-through check would
+    // tear down a healthy worktree exactly when the store is busiest.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-substrate-link-'));
+    const target = fs.mkdtempSync(path.join(os.tmpdir(), 'shared-store-'));
+    try {
+      fs.symlinkSync(target, path.join(dir, 'node_modules'), 'junction');
+    } catch {
+      return; // symlink/junction creation unavailable in this environment — skip rather than false-pass
+    }
+    const res = validateWorktreeSubstrate(dir, ['node_modules']);
+    expect(res.missing).not.toContain('node_modules');
+    expect(res.ok).toBe(true);
+  });
+});
+
+describe('parseWorktreeNmMode — a degraded junction is self-identifying (FR-3)', () => {
+  it('distinguishes a deliberate junction from a failed isolation', () => {
+    expect(parseWorktreeNmMode('junction:auto_solo').degraded).toBe(false);
+    expect(parseWorktreeNmMode('junction:isolate_failed_fallback').degraded).toBe(true);
+  });
+
+  it('exposes mode and reason separately so consumers need not string-match', () => {
+    expect(parseWorktreeNmMode('isolated:auto_concurrent')).toEqual({
+      mode: 'isolated', reason: 'auto_concurrent', degraded: false
+    });
+  });
+
+  it('tolerates the LEGACY bare form still on disk', () => {
+    expect(parseWorktreeNmMode('junction')).toEqual({ mode: 'junction', reason: null, degraded: false });
+  });
+
+  it('is null-safe on an absent or blank marker', () => {
+    expect(parseWorktreeNmMode(null).mode).toBeNull();
+    expect(parseWorktreeNmMode('   ').mode).toBeNull();
+  });
+});

--- a/tests/unit/scripts/resolve-sd-workdir-fr1-consumer.test.js
+++ b/tests/unit/scripts/resolve-sd-workdir-fr1-consumer.test.js
@@ -1,0 +1,106 @@
+// SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001 FR-1 — CONSUMER pin.
+//
+// WHY THIS FILE EXISTS, stated plainly because it is the gap this SD keeps finding in other
+// people's work and had left open in its own: isNodeModulesUnprovisioned was already pinned, and
+// those pins are good. They prove the RULE is right. They do not prove the rule RUNS.
+// ensureWorktreeEssentials is the only real caller, it was unexported, and nothing tested it — so
+// FR-1 could have been reverted at the call site (back to `!fs.existsSync(targetModules)`) with
+// every predicate test still green. A guard nothing invokes is a guard that does not exist.
+//
+// Verified at the consumer, not at the merge.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Mock the provisioner: this test asks ONE question — does the hollow-node_modules rule actually
+// reach provisioning? — so real installs are neither needed nor wanted.
+vi.mock('../../../lib/worktree-provision.js', () => ({
+  provisionWorktreeNodeModules: vi.fn(),
+  getIsolationMode: () => 'never',
+  getFreeDiskBytes: () => 999e9,
+  countActiveFreshSessions: async () => 1
+}));
+
+const { provisionWorktreeNodeModules } = await import('../../../lib/worktree-provision.js');
+const { ensureWorktreeEssentials } = await import('../../../scripts/resolve-sd-workdir.js');
+
+/** A repo root whose node_modules is POPULATED — the source side must exist or the guard short-circuits. */
+function makeRepoRoot() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'fr1-repo-'));
+  fs.mkdirSync(path.join(root, 'node_modules', 'vitest'), { recursive: true });
+  return root;
+}
+
+function makeWorktree() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'fr1-wt-'));
+}
+
+beforeEach(() => {
+  provisionWorktreeNodeModules.mockClear();
+});
+
+describe('ensureWorktreeEssentials — FR-1 is WIRED, not merely correct', () => {
+  it('provisions when node_modules is HOLLOW (the .vite-cache-only shape measured on this fleet)', () => {
+    const repoRoot = makeRepoRoot();
+    const wt = makeWorktree();
+    fs.mkdirSync(path.join(wt, 'node_modules', '.vite'), { recursive: true });
+
+    ensureWorktreeEssentials(wt, repoRoot, { activeSessionCount: 1 });
+
+    // THE PIN. Under the pre-FR-1 existsSync guard this call count is 0: the hollow directory
+    // exists, so provisioning was suppressed permanently and every downstream tool failed
+    // module-not-found while the worktree reported healthy.
+    expect(provisionWorktreeNodeModules).toHaveBeenCalledTimes(1);
+  });
+
+  it('provisions when node_modules is entirely ABSENT', () => {
+    const repoRoot = makeRepoRoot();
+    const wt = makeWorktree();
+
+    ensureWorktreeEssentials(wt, repoRoot, { activeSessionCount: 1 });
+
+    expect(provisionWorktreeNodeModules).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT re-provision a POPULATED node_modules', () => {
+    // The negative half. Without this, a guard that always provisions passes the two tests above
+    // while re-installing on every resolve — correct-looking and ruinous under fleet concurrency.
+    const repoRoot = makeRepoRoot();
+    const wt = makeWorktree();
+    fs.mkdirSync(path.join(wt, 'node_modules', 'vitest'), { recursive: true });
+
+    ensureWorktreeEssentials(wt, repoRoot, { activeSessionCount: 1 });
+
+    expect(provisionWorktreeNodeModules).not.toHaveBeenCalled();
+  });
+
+  it('does NOT re-provision a JUNCTIONED node_modules (PR #3488 finding 1)', (ctx) => {
+    // A junction is PROVISIONED and must not be read through: its target is transiently absent
+    // during a concurrent .staging swap at the main repo, so a read-through check would tear down
+    // a healthy worktree exactly when the store is busiest.
+    const repoRoot = makeRepoRoot();
+    const wt = makeWorktree();
+    const target = fs.mkdtempSync(path.join(os.tmpdir(), 'fr1-store-'));
+    try {
+      fs.symlinkSync(target, path.join(wt, 'node_modules'), 'junction');
+    } catch {
+      // ctx.skip(), NOT a bare return — vitest reports an early return as PASSED, which would turn
+      // this into a silent green on the exact regression it guards.
+      ctx.skip();
+    }
+
+    ensureWorktreeEssentials(wt, repoRoot, { activeSessionCount: 1 });
+
+    expect(provisionWorktreeNodeModules).not.toHaveBeenCalled();
+  });
+
+  it('does NOT provision when the SOURCE node_modules is missing — nothing to provision from', () => {
+    const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'fr1-repo-bare-'));
+    const wt = makeWorktree();
+
+    ensureWorktreeEssentials(wt, repoRoot, { activeSessionCount: 1 });
+
+    expect(provisionWorktreeNodeModules).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/scripts/resolve-sd-workdir-unprovisioned-predicate.test.js
+++ b/tests/unit/scripts/resolve-sd-workdir-unprovisioned-predicate.test.js
@@ -1,0 +1,79 @@
+// SD-FDBK-ENH-SCOPE-REPLACE-WORKTREE-001 FR-1 / TR-6.
+//
+// The guard at scripts/resolve-sd-workdir.js used to be `!fs.existsSync(targetModules)`, and
+// existsSync is TRUE for an EMPTY directory. So once anything created <wt>/node_modules/,
+// provisioning was skipped PERMANENTLY — ensureWorktreeEssentials runs after every successful
+// resolution and still never re-provisioned. Vite mkdir -p's node_modules/.vite for its optimize
+// cache, which poisoned it. Measured on this fleet: affected worktrees held literally .vite/ and
+// .vite-temp/ and NOTHING else, yet require.resolve succeeded by Node walking UP to the shared
+// root — the coupling that makes a shared-root wipe fleet-fatal.
+//
+// TR-6 required the predicate be EXPORTED and PURE. It previously lived inside a non-exported
+// function, so the only tests possible were source-text greps — a test that cannot fail for the
+// reason it exists. These drive the real predicate with an injected fs.
+import { describe, it, expect } from 'vitest';
+import { isNodeModulesUnprovisioned } from '../../../scripts/resolve-sd-workdir.js';
+
+/** Injected fs stub. `link` makes lstat report a junction; `entries` is what readdir returns. */
+const fsWith = ({ link = false, dir = true, entries = [], throwLstat = false, throwReaddir = false } = {}) => ({
+  lstatSync() {
+    if (throwLstat) { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; }
+    return { isSymbolicLink: () => link, isDirectory: () => dir };
+  },
+  readdirSync() {
+    if (throwReaddir) throw new Error('EACCES');
+    return entries;
+  }
+});
+
+describe('isNodeModulesUnprovisioned — population, not existence (FR-1)', () => {
+  it('treats an absent node_modules as unprovisioned', () => {
+    expect(isNodeModulesUnprovisioned('nm', fsWith({ throwLstat: true }))).toBe(true);
+  });
+
+  it('treats a directory holding ONLY Vite caches as unprovisioned — the shipped defect', () => {
+    // This is the exact on-disk shape measured on QF-20260727-923 and QF-20260704-598.
+    expect(isNodeModulesUnprovisioned('nm', fsWith({ entries: ['.vite', '.vite-temp'] }))).toBe(true);
+  });
+
+  it('is EMPTINESS-based, not NAME-based: a non-.vite stray also counts as unprovisioned', () => {
+    // An _archive worktree was found poisoned by ONLY .rank-pass-trigger.lock, with no .vite at
+    // all. A fix scoped to "Vite creates .vite" would under-cover and leave that case broken.
+    expect(isNodeModulesUnprovisioned('nm', fsWith({ entries: ['.rank-pass-trigger.lock'] }))).toBe(true);
+    expect(isNodeModulesUnprovisioned('nm', fsWith({ entries: ['.package-lock.json', '.bin'] }))).toBe(true);
+  });
+
+  it('treats a populated tree as provisioned', () => {
+    expect(isNodeModulesUnprovisioned('nm', fsWith({ entries: ['.vite', '@supabase', 'vitest'] }))).toBe(false);
+  });
+
+  it('counts a scoped package as a real package entry', () => {
+    expect(isNodeModulesUnprovisioned('nm', fsWith({ entries: ['@supabase'] }))).toBe(false);
+  });
+
+  it('treats a FILE named node_modules as unprovisioned', () => {
+    expect(isNodeModulesUnprovisioned('nm', fsWith({ dir: false }))).toBe(true);
+  });
+
+  it('treats an unreadable directory as unprovisioned rather than throwing', () => {
+    expect(isNodeModulesUnprovisioned('nm', fsWith({ throwReaddir: true }))).toBe(true);
+  });
+});
+
+describe('isNodeModulesUnprovisioned — must NOT read through a junction (PR #3488 regression)', () => {
+  it('reports a junction as PROVISIONED even when the target reads back empty', () => {
+    // THE REGRESSION THIS PREVENTS: lib/worktree-manager.js:86-93 records that lstat was chosen
+    // over a read-through check because a junction's target is TRANSIENTLY ABSENT during a
+    // concurrent npm install at the main repo (.staging atomic swap). Reading through would
+    // classify a HEALTHY junctioned worktree as unprovisioned and re-provision it — under load,
+    // which is exactly when the store is busiest. It manifests ONLY under concurrency, so it must
+    // be pinned explicitly rather than assumed absent.
+    expect(isNodeModulesUnprovisioned('nm', fsWith({ link: true, entries: [] }))).toBe(false);
+  });
+
+  it('short-circuits BEFORE readdir, so a throwing target cannot flip the verdict', () => {
+    // Proves the junction check precedes the read rather than merely coinciding with it: if
+    // readdir were reached it would throw and return true.
+    expect(isNodeModulesUnprovisioned('nm', fsWith({ link: true, throwReaddir: true }))).toBe(false);
+  });
+});


### PR DESCRIPTION
Chairman-directed after two fleet-wide outages. **The SD’s premise was falsified at LEAD, and this PR implements the re-scope.**

## The premise, and why it changed

The SD was sourced to replace a topology where `worktree/node_modules` is *itself* a junction, so one link reaches the shared tree. Measured at LEAD with the instrument the SD itself mandates (PowerShell reparse attributes, not Bash `[ -L ]`): **zero reparse points**, corroborated at 52 worktree dirs with a negative control proving the detector fires. The acceptance ratio already passed, so it could not drive any work.

Junctioning was **not** retired — PR #3825 made it *conditional*. It remains a **primary** branch (solo session, `mode=never`, low disk) **and** a fallback when `npm install` exceeds its 180s timeout, whose probability rises with concurrency. So junctions appear at **both ends** of the concurrency curve. I initially reported this as "demoted to a fallback"; that under-scoped it and is corrected here.

## What was actually broken

| FR | Defect |
|---|---|
| **FR-1** | `!fs.existsSync(targetModules)` — an **empty** dir satisfies it, so Vite’s `node_modules/.vite` permanently suppressed provisioning. Affected worktrees held only `.vite`/`.vite-temp` yet resolved dependencies by walking **up** to the shared root — the coupling that makes a shared-root wipe fleet-fatal. |
| **FR-2** | The hot path passed `deps: { log: () => {} }`, so the fallback-to-junction log went **nowhere**. Silent degradation by construction. |
| **FR-3** | Both junction call sites wrote a bare `junction` marker — a deliberate junction was indistinguishable from a failed isolation. |
| **FR-4** | `validateWorktreeSubstrate` was presence-only, so a hollow worktree reported **healthy** while every tool failed module-not-found. |
| **FR-5** | No reparse guard existed to demote — this **creates** one. |

**Emptiness-based, never name-based**: an `_archive` worktree was poisoned by only `.rank-pass-trigger.lock`, with no `.vite` at all.

## Two regressions avoided, both caught by review rather than by me

**FR-4 as I first specified it would have reopened PR #3488 finding 1.** `lstat` was chosen deliberately because a junction’s target is *transiently absent* during a concurrent `.staging` swap — reading through would tear down a healthy worktree, under load. The shared predicate short-circuits on a symlink **before** any `readdir`, and TS-7 pins it with a real junction. It manifests only under concurrency.

**TS-5 could not fail.** My first version asserted a provoked delete leaves the store intact — which an existing test already proves against code this SD doesn’t modify. Green before, green on revert. It is now **composed**: force `isolate_failed_fallback` with an injected throwing install and real symlink deps, assert the marker reads `degraded=true`, read the CANARY *through* the junction to prove live passthrough, then remove and assert store count `before == after`.

## Verification

**29 pins, every behaviour mutation-tested** — reverting each fails the pins that name it:

| mutation | fails |
|---|---|
| existence-only guard restored | 2 |
| junction short-circuit removed | 2 |
| FR-4 population check removed | 2 |
| bare `junction` marker restored | 1 |
| `0/0` reported as CLEAN | 2 |

The FR-5 guard **refuses to certify a zero it hasn’t earned**: `--self-test` creates a real junction and reports nothing if the detector doesn’t fire; an empty denominator exits 2, because `0/0` is a failure to measure. Output is timestamped — the population is volatile and unstamped counts manufacture contradictions.

Live run: self-test fires, 52 worktrees, 0 reparse points.

## Explicit non-goals

- **Does NOT establish root cause of the 2026-07-28 wipes.** The SD records both as unattributed; a separate RCA owns that. Closing this without saying so would let the fleet believe the outage class is resolved.
- **Does NOT retire the junction guards** — the branch is reachable at both ends of the curve, so `worktree-remove-junction-guard`, `removeWorktreeViaGit` pre-unlink and `npm-ci-junction-guard` stay load-bearing.
- Does not adopt pnpm.

Marker contract change verified safe: **zero** equality comparisons against the marker value exist outside the writer. Three existing assertions pinned the bare strings and were updated deliberately — the PRD named them in advance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)