### PR TITLE
fix(QF-20260727-884): exclude gitignored scratch/ from the vitest unit tier

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -89,6 +89,22 @@ const SHARED_EXCLUDE = [
   '**/.cursor/worktrees/**',
   '**/.claude/worktrees/**',
   '**/PATH/**',
+  // QF-20260727-884: scratch/ holds PRESERVED WORKTREE COPIES and is gitignored
+  // (.gitignore '/scratch/'), so `git ls-files scratch` returns ZERO test files and CI never sees
+  // them — while a local run collected them as live tests. MEASURED in the shared root at
+  // origin/main: 887 scratch/preserved-* directories holding exactly 14 test files, and a local
+  // unit run reporting exactly 14 failures. A 14-for-14 match.
+  //
+  // WHY THIS ONE MATTERED MORE THAN ITS SIZE: CI stayed green and local read red, both correctly,
+  // and the contradiction was unresolvable without reading the failing file paths. At least one
+  // worker read it as "main is broken" and it cost coordinator time to reconcile. A signal that
+  // means different things on two surfaces is worse than a signal that is simply wrong on both.
+  // It also blocked ship-preflight, which runs the local suite.
+  //
+  // Both forms are listed deliberately: the anchored one is the real rule, and the unanchored one
+  // also covers a preserved copy that lands outside the top-level scratch/ root.
+  'scratch/**',
+  '**/scratch/**',
 ];
 
 // Inherently DB-dependent test locations — routed to the opt-in `db` project


### PR DESCRIPTION
## Summary

The unit project had **no exclude for `scratch/`**, so it collected preserved worktree copies under `scratch/preserved-*/` as live tests. `scratch/` is gitignored and `git ls-files scratch` returns **zero** test files — so CI never saw them.

**Measured** in the shared root at `origin/main`: **887** `scratch/preserved-*` directories holding **exactly 14** test files, against a local unit run reporting **exactly 14** failures. A 14-for-14 match.

**Why this mattered more than its size:** CI read green and local read red, and *both were correct*. The contradiction was unresolvable without reading the failing file paths, at least one worker read it as "main is broken", and it cost coordinator time to reconcile. A signal that means different things on two surfaces is worse than one that is simply wrong on both — the disagreement itself looks like evidence. It also blocked `ship-preflight`, which runs the local suite.

I can confirm the cost first-hand: earlier today I investigated `scratch/preserved-from-hotfix-smoke/tests/unit/fleet/tree-currency.test.js` failures on an unrelated SD, A/B-tested them with my changes stashed to prove they weren't mine, and reported them as pre-existing **without knowing why they existed**. This is why.

## Test plan

Verified in three steps rather than by reading the glob:
1. A deliberately failing test placed **under** `scratch/` → `No test files found` (not collected).
2. **Negative control:** the byte-identical failing test **outside** `scratch/` → collected and failed, proving the exclude isn't simply breaking collection.
3. All **14 real offenders** copied into a clean worktree at their real paths → **zero** failing paths under `scratch/`, and total collected files unchanged at **2743**.

Both glob forms are listed deliberately: `scratch/**` is the real anchored rule; `**/scratch/**` also covers a preserved copy landing outside the top-level `scratch/` root.

## Not fixed here

**887 preserved directories is itself a housekeeping problem.** The QF explicitly flags it as worth raising rather than folding in, so it's filed separately rather than silently expanding this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)