### PR TITLE
feat(SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001): a rejected query can no longer read as an empty result

### DIFF
--- a/.github/workflows/swallowed-query-error-lint.yml
+++ b/.github/workflows/swallowed-query-error-lint.yml
@@ -1,0 +1,50 @@
+name: Swallowed Query Error Lint
+
+# SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 (FR-4)
+# Flags PostgREST calls in GATE/EXECUTOR code whose destructure binds only `data` (or only
+# `count`) and discards `error`. PostgREST rejects the WHOLE query on an unknown column, so `data`
+# comes back null forever and a caller that never inspects `error` reports a plausible benign
+# reason for having done nothing. Zero rows is a legal answer, so the failure is indistinguishable
+# from a real empty result — which is why this is a lint plus a wrapper, not a convention.
+#
+# Live instance this SD fixed: a gate whose PRD lookup failed reached its "no command configured —
+# advisory pass" branch. A BROKEN QUERY MADE THE GATE PASS.
+#
+# Route through lib/db/safe-query.mjs (safeQuery / safeCount), bind `error`, or allowlist
+# "<file>:<line>" WITH A REASON in scripts/lint/swallowed-query-error-allowlist.json. The reason is
+# mandatory — loadAllowlist() throws without one, because a silence you cannot explain is the
+# reflexive kind. The COUNT of allowlist entries is itself a gauge.
+#
+# ADVISORY-FIRST: `continue-on-error: true`, so it cannot turn an in-flight PR red on day one. The
+# report is always in the job log. ~232 pre-existing gate/executor sites are a TRACKED MIGRATION,
+# not this SD's scope — flip to blocking (run with --enforce, drop continue-on-error) once that
+# baseline has been worked down, not before, or the signal trains people to ignore it.
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/modules/handoff/**'
+      - 'lib/gates/**'
+      - 'scripts/modules/claim-health/**'
+      - 'lib/claim/**'
+      - 'lib/oversight/**'
+      - 'lib/db/safe-query.mjs'
+      - 'scripts/lint/swallowed-query-error-lint.mjs'
+      - 'scripts/lint/swallowed-query-error-allowlist.json'
+      - '.github/workflows/swallowed-query-error-lint.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  swallowed-query-error-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Detect PostgREST reads that discard `error` in gate/executor code (advisory)
+        continue-on-error: true
+        run: node scripts/lint/swallowed-query-error-lint.mjs

--- a/lib/db/safe-query.mjs
+++ b/lib/db/safe-query.mjs
@@ -39,6 +39,17 @@ import { renderCount } from './fetch-all-paginated.mjs';
  * distinguish the two. Treating it as a fault would make the wrapper unusable at every
  * `.single()` call site and would train people to blanket-tolerate, which is the decay this
  * module exists to prevent.
+ *
+ * *** CALLER OBLIGATION, verified against the installed postgrest-js source (SECURITY 66c3911c):
+ * PGRST116 means "0 OR MORE THAN 1 rows", not "0 rows". *** So on an UNBOUNDED `.single()` /
+ * `.maybeSingle()`, a duplicate-row DATA-INTEGRITY fault would arrive here wearing the same code
+ * as a genuine absence and be returned as null — this SD's own defect class, reached by a
+ * different road.
+ *
+ * Pair every `.single()` with something that structurally bounds it to at most one row: a
+ * `.limit(1)`, or a filter on a unique/primary key. The three call sites converted by this SD all
+ * do (smoke-test-gate pairs `.single()` with `.limit(1)`; wiring-validation's `.maybeSingle()`
+ * filters on the primary key). A future caller that does neither should NOT rely on this default.
  */
 export const EXPECTED_ABSENCE_CODES = Object.freeze(['PGRST116']);
 

--- a/lib/db/safe-query.mjs
+++ b/lib/db/safe-query.mjs
@@ -32,21 +32,41 @@
 import { renderCount } from './fetch-all-paginated.mjs';
 
 /**
+ * PostgREST codes that mean a GENUINE ABSENCE rather than a fault.
+ *
+ * PGRST116 is what `.single()` returns when the query matched zero rows. That is a real answer
+ * to a well-formed question, not a broken probe — and the whole point of this module is to
+ * distinguish the two. Treating it as a fault would make the wrapper unusable at every
+ * `.single()` call site and would train people to blanket-tolerate, which is the decay this
+ * module exists to prevent.
+ */
+export const EXPECTED_ABSENCE_CODES = Object.freeze(['PGRST116']);
+
+/**
  * Await a PostgREST query and THROW on error instead of yielding a null that reads as absence.
  *
  * @param {Promise<{data: any, error: any}>} queryPromise a supabase query (already built)
- * @param {{site?: string, tolerate?: string}} [opts]
+ * @param {{site?: string, tolerate?: string, expectedAbsenceCodes?: string[]}} [opts]
  *   site     - call-site label, so a thrown fault is diagnosable from the record
  *   tolerate - REASON STRING opting this call site out of throwing (FR-2). A boolean is REFUSED:
  *              a boolean opt-out is a convention with extra steps — it becomes the thing you add
  *              to make the checker stop complaining, and nobody can later tell a considered
  *              tolerance from a reflexive silencing. A required reason makes every silence
  *              auditable and makes the COUNT of silences a gauge in its own right.
- * @returns {Promise<any>} data on success; on a tolerated failure, null
+ *   expectedAbsenceCodes - codes meaning "no rows", returned as null rather than thrown.
+ *              Defaults to EXPECTED_ABSENCE_CODES. NARROW this list, never widen it to silence
+ *              a fault: a code added here is indistinguishable from a genuine empty result
+ *              forever after, which is precisely the defect.
+ * @returns {Promise<any>} data on success or genuine absence; on a tolerated failure, null
  */
-export async function safeQuery(queryPromise, { site = 'unknown-site', tolerate } = {}) {
+export async function safeQuery(
+  queryPromise,
+  { site = 'unknown-site', tolerate, expectedAbsenceCodes = EXPECTED_ABSENCE_CODES } = {}
+) {
   const reason = assertToleranceReason(tolerate, site);
   const { data, error } = await queryPromise;
+  // A genuine "no rows" is an ANSWER. Return it as such, before any fault handling.
+  if (error && expectedAbsenceCodes.includes(error.code)) return null;
   if (error) {
     if (reason) {
       process.stderr.write(`[query-discipline] TOLERATED at ${site}: ${error.message} — reason: ${reason}\n`);
@@ -113,4 +133,4 @@ export function assertToleranceReason(tolerate, site = 'unknown-site') {
   return tolerate.trim();
 }
 
-export default { safeQuery, safeCount, assertToleranceReason };
+export default { safeQuery, safeCount, assertToleranceReason, EXPECTED_ABSENCE_CODES };

--- a/lib/db/safe-query.mjs
+++ b/lib/db/safe-query.mjs
@@ -1,0 +1,116 @@
+/**
+ * safe-query.mjs — query-error discipline primitives
+ * (SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 FR-1/FR-2).
+ *
+ * THE DEFECT: a destructure that binds only `data` and discards `error` turns a bad column name
+ * into a PERMANENT SILENT NO-OP. PostgREST rejects the WHOLE query on an unknown column, so `data`
+ * is null forever, and code that never inspects `error` reports a plausible benign reason for
+ * having done nothing. Live instance: a gate whose PRD lookup failed reached its
+ * "No command configured — advisory pass" branch, so a broken query MADE THE GATE PASS.
+ *
+ * WHY A NULL RESULT IS UNDETECTABLE LOCALLY: zero rows is a legal answer. The failure is
+ * indistinguishable from a legitimate empty result, which is why a convention ("always check the
+ * error") decays and an enforcement point does not.
+ *
+ * *** THE SECOND SUB-SHAPE, WHICH A THROW-ON-ERROR WRAPPER ALONE WOULD MISS: ***
+ * a head+count probe against a table that DOES NOT EXIST returns SUCCESS —
+ *     .from('<missing>').select('*', { count: 'exact', head: true })  ->  error null, count null, 204
+ *     same shape on a REAL table                                      ->  error null, count 1155, 206
+ * There is no error to throw on. The ONLY discriminant is count===null (missing) vs count===0
+ * (genuinely empty). safeCount() below encodes exactly that, so this class cannot survive inside
+ * the fix meant to remove it.
+ *
+ * RELATIONSHIP TO ./fetch-all-paginated.mjs — deliberately complementary, NOT a competing
+ * convention. That module owns COUNT/TRUNCATION discipline (bulk pagination, cap-truncation
+ * tripwires, and renderCount for gauges); this module owns QUERY-ERROR discipline for SINGLE-SHOT
+ * reads. The shared rule — a null count on an explicit count request means the MEASUREMENT
+ * FAILED and must never be coerced to a healthy-looking 0 — is defined once, by renderCount(),
+ * and consumed here rather than re-implemented. tools/gates/lib/db.ts::query() is the TypeScript
+ * variant of this same seam; it runs under a different runtime (npx tsx via leo-gates.yml) and so
+ * cannot import this file, but it must not diverge in behaviour.
+ */
+import { renderCount } from './fetch-all-paginated.mjs';
+
+/**
+ * Await a PostgREST query and THROW on error instead of yielding a null that reads as absence.
+ *
+ * @param {Promise<{data: any, error: any}>} queryPromise a supabase query (already built)
+ * @param {{site?: string, tolerate?: string}} [opts]
+ *   site     - call-site label, so a thrown fault is diagnosable from the record
+ *   tolerate - REASON STRING opting this call site out of throwing (FR-2). A boolean is REFUSED:
+ *              a boolean opt-out is a convention with extra steps — it becomes the thing you add
+ *              to make the checker stop complaining, and nobody can later tell a considered
+ *              tolerance from a reflexive silencing. A required reason makes every silence
+ *              auditable and makes the COUNT of silences a gauge in its own right.
+ * @returns {Promise<any>} data on success; on a tolerated failure, null
+ */
+export async function safeQuery(queryPromise, { site = 'unknown-site', tolerate } = {}) {
+  const reason = assertToleranceReason(tolerate, site);
+  const { data, error } = await queryPromise;
+  if (error) {
+    if (reason) {
+      process.stderr.write(`[query-discipline] TOLERATED at ${site}: ${error.message} — reason: ${reason}\n`);
+      return null;
+    }
+    const e = new Error(`QUERY_FAILED at ${site}: ${error.message}`);
+    e.code = 'QUERY_FAILED';
+    e.cause = error;
+    throw e;
+  }
+  return data;
+}
+
+/**
+ * Await an EXPLICIT count request and throw when the count could not be measured.
+ *
+ * A missing relation returns error=null with count=null, so `error` is not the discriminant —
+ * this is the sub-shape safeQuery alone cannot catch. Reuses renderCount()'s definition of an
+ * unmeasurable count rather than restating it, so the two modules cannot drift apart.
+ *
+ * @param {Promise<{count: number|null, error: any}>} queryPromise a query built with { count: 'exact' }
+ * @param {{site?: string, tolerate?: string}} [opts]
+ * @returns {Promise<number|null>} the count on success; on a tolerated failure, null
+ */
+export async function safeCount(queryPromise, { site = 'unknown-site', tolerate } = {}) {
+  const reason = assertToleranceReason(tolerate, site);
+  const { count, error } = await queryPromise;
+  const rendered = renderCount(count);
+  const failed = Boolean(error) || rendered === 'unavailable';
+  if (failed) {
+    // Name WHICH half failed: an errored count and an unmeasurable-but-errorless count are
+    // different diagnoses, and collapsing them re-creates the ambiguity this module removes.
+    const why = error ? error.message : 'count is null with no error — relation likely does not exist';
+    if (reason) {
+      process.stderr.write(`[query-discipline] TOLERATED at ${site}: ${why} — reason: ${reason}\n`);
+      return null;
+    }
+    const e = new Error(`COUNT_UNMEASURABLE at ${site}: ${why}`);
+    e.code = 'COUNT_UNMEASURABLE';
+    if (error) e.cause = error;
+    throw e;
+  }
+  return count;
+}
+
+/**
+ * Enforce that an opt-out carries a REASON STRING (FR-2).
+ * A boolean — the reflexive silencing shape — is refused loudly rather than ignored.
+ * Exported so the refusal itself is directly testable.
+ * @param {unknown} tolerate
+ * @param {string} site
+ * @returns {string|null} the trimmed reason, or null when no opt-out was requested
+ */
+export function assertToleranceReason(tolerate, site = 'unknown-site') {
+  if (tolerate === undefined || tolerate === null) return null;
+  if (typeof tolerate !== 'string' || tolerate.trim().length === 0) {
+    const e = new Error(
+      `TOLERATE_REASON_REQUIRED at ${site}: opting out of query-error discipline requires a REASON STRING, `
+      + `got ${typeof tolerate}. A boolean opt-out cannot be audited and cannot be counted.`
+    );
+    e.code = 'TOLERATE_REASON_REQUIRED';
+    throw e;
+  }
+  return tolerate.trim();
+}
+
+export default { safeQuery, safeCount, assertToleranceReason };

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "lint:metadata-flags": "node scripts/lint/metadata-flag-lint.mjs",
     "lint:env-flags": "node scripts/lint/process-env-feature-flag-lint.mjs",
     "lint:fleet-liveness-select": "node scripts/lint/fleet-liveness-select-lint.mjs",
+    "lint:swallowed-query-error": "node scripts/lint/swallowed-query-error-lint.mjs",
     "lint:alter-defaults": "node scripts/lint/alter-default-override-lint.mjs",
     "lint:venture-artifacts": "node scripts/lint/venture-artifacts-write-lint.mjs",
     "lint:realtime-teardown": "node scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs",

--- a/scripts/lint/swallowed-query-error-allowlist.json
+++ b/scripts/lint/swallowed-query-error-allowlist.json
@@ -1,0 +1,5 @@
+{
+  "_doc": "SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 (FR-4). Keys are '<repo-relative-file>:<line>' (or a bare '<file>' to exempt a whole file) for a PostgREST call that binds only `data`/`count` and is INTENTIONALLY exempt. Every entry MUST carry a non-empty reason — loadAllowlist() throws otherwise, because a silence you cannot explain is the reflexive kind this SD exists to prevent. Prefer FIXING (route through lib/db/safe-query.mjs safeQuery/safeCount, or bind `error`) over allowlisting. If this file grows, that growth is itself the signal: the count of tolerated silences is a gauge.",
+  "_scope_note": "The lint currently scans GATE/EXECUTOR paths only (SCAN_PREFIXES in the lint). lib/fleet/spawn-control.js is fenced to SD-LEO-FEAT-FLEET-SESSION-LIFECYCLE-001 and has 6 genuine hits, but it is ALREADY out of scan scope, so no allowlist entry is needed today and adding one would imply protection that is not doing any work. Recorded here instead so the fence is not forgotten when SCAN_PREFIXES widens.",
+  "allow": {}
+}

--- a/scripts/lint/swallowed-query-error-lint.mjs
+++ b/scripts/lint/swallowed-query-error-lint.mjs
@@ -1,0 +1,156 @@
+// swallowed-query-error-lint.mjs — flag PostgREST calls whose destructure binds only `data` and
+// discards `error`, IN GATE / EXECUTOR CODE. SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 (FR-4).
+// Mirrors the structure of scripts/lint/fleet-liveness-select-lint.mjs (pure extractors +
+// reason-required allowlist + tree scan). ADVISORY-FIRST: exit 0 by default; --enforce for exit 1.
+//
+// WHY: PostgREST rejects the WHOLE query on an unknown column, so `data` comes back null forever
+// and a caller that never inspects `error` reports a plausible benign reason for having done
+// nothing. Zero rows is a legal answer, so the failure is INDISTINGUISHABLE from a real empty
+// result — no local check can catch it, which is why this is a lint plus a wrapper rather than a
+// convention. Live instance: a gate whose PRD lookup failed reached its "no command configured —
+// advisory pass" branch, so a broken query MADE THE GATE PASS.
+//
+// SCOPED TO GATE/EXECUTOR PATHS ON PURPOSE. The repo-wide population is ~3000 call sites; a lint
+// that reported all of them would be noise people learn to scroll past, and a rule nobody reads is
+// worth less than no rule. These are the paths where a silent null becomes a wrong GATE VERDICT.
+// Widen the scope only alongside the capacity to actually convert what it finds.
+//
+// A call is SAFE (not flagged) when ANY of:
+//   • the destructure binds `error` (or renames it: `error: fooErr`) — the caller can see faults;
+//   • it routes through the canonical wrapper (lib/db/safe-query.mjs safeQuery/safeCount), which
+//     throws on error and treats a null count on an explicit count request as a failure;
+//   • it routes through lib/db/fetch-all-paginated.mjs fetchAllPaginated(), which already throws.
+// Anything else is a latent silent no-op. Fix it (route through safeQuery, or bind error) or
+// allowlist it with a REASON — a boolean-style silence is exactly what this SD exists to prevent.
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { resolve, join, extname } from 'path';
+import { fileURLToPath } from 'url';
+
+const ROOT = resolve(fileURLToPath(new URL('../..', import.meta.url)));
+const SCAN_EXTS = new Set(['.js', '.mjs', '.cjs']);
+const EXCLUDE = new Set(['node_modules', '.git', '.worktrees', 'dist', 'build', 'coverage', 'archive']);
+const ALLOWLIST_PATH = resolve(ROOT, 'scripts/lint/swallowed-query-error-allowlist.json');
+
+// Gate/executor paths only — see the scoping note above.
+const SCAN_PREFIXES = [
+  'scripts/modules/handoff',
+  'lib/gates',
+  'scripts/modules/claim-health',
+  'lib/claim',
+  'lib/oversight',
+];
+
+// A destructure that binds ONLY data (optionally renamed) and no `error`.
+const DATA_ONLY = /const\s*\{\s*data(?:\s*:\s*[A-Za-z0-9_$]+)?\s*\}\s*=\s*await/;
+// A destructure binding only `count` is the same defect in the count-probe shape.
+const COUNT_ONLY = /const\s*\{\s*count(?:\s*:\s*[A-Za-z0-9_$]+)?\s*\}\s*=\s*await/;
+// The tell that the awaited chain is actually PostgREST rather than axios/fetch/a local helper.
+const POSTGREST = /\.from\s*\(|\.rpc\s*\(/;
+// Already-safe routings.
+const SAFE_CALL = /safeQuery\s*\(|safeCount\s*\(|fetchAllPaginated\s*\(/;
+
+/**
+ * Strip // line and block comments so commented-out queries do not register, PRESERVING line
+ * count so reported line numbers match the source (allowlist keys are "<file>:<line>").
+ * @param {string} src
+ * @returns {string}
+ */
+export function stripComments(src) {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (_m, p1) => p1);
+}
+
+/**
+ * Extract swallowed-error call sites from one file's source.
+ * Pure and exported so the extractor is unit-testable without touching the filesystem.
+ * @param {string} src
+ * @param {string} file repo-relative path, for the returned records
+ * @returns {Array<{file:string,line:number,kind:'data'|'count',snippet:string}>}
+ */
+export function extractSwallowedQueries(src, file = '<memory>') {
+  const lines = stripComments(src).split('\n');
+  const hits = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const isData = DATA_ONLY.test(line);
+    const isCount = !isData && COUNT_ONLY.test(line);
+    if (!isData && !isCount) continue;
+    // The awaited chain can span lines; look ahead for the PostgREST tell and for a safe routing.
+    const chain = lines.slice(i, i + 6).join('\n');
+    if (!POSTGREST.test(chain)) continue;   // not a PostgREST call — axios, a local helper, etc.
+    if (SAFE_CALL.test(chain)) continue;    // already routed through a throwing wrapper
+    hits.push({ file, line: i + 1, kind: isData ? 'data' : 'count', snippet: line.trim().slice(0, 110) });
+  }
+  return hits;
+}
+
+/** Load the reason-required allowlist. Throws if any entry lacks a non-empty reason. */
+export function loadAllowlist(path = ALLOWLIST_PATH) {
+  let raw;
+  try {
+    raw = JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return {};
+  }
+  const allow = raw.allow || {};
+  for (const [key, reason] of Object.entries(allow)) {
+    if (typeof reason !== 'string' || reason.trim().length === 0) {
+      // The whole point of the allowlist: a silence you cannot explain is the reflexive kind.
+      throw new Error(`swallowed-query-error-allowlist: entry "${key}" has no reason. Every exemption MUST state why.`);
+    }
+  }
+  return allow;
+}
+
+/** Walk the scoped subtrees and collect hits. */
+export function scanTree(root = ROOT, prefixes = SCAN_PREFIXES) {
+  const hits = [];
+  const walk = (dir) => {
+    let entries;
+    try { entries = readdirSync(dir); } catch { return; }
+    for (const name of entries) {
+      if (EXCLUDE.has(name)) continue;
+      const full = join(dir, name);
+      let st;
+      try { st = statSync(full); } catch { continue; }
+      if (st.isDirectory()) { walk(full); continue; }
+      if (!SCAN_EXTS.has(extname(name))) continue;
+      const rel = full.slice(root.length + 1).replace(/\\/g, '/');
+      if (/\.test\.|\/tests?\//.test(rel)) continue;
+      let src;
+      try { src = readFileSync(full, 'utf8'); } catch { continue; }
+      hits.push(...extractSwallowedQueries(src, rel));
+    }
+  };
+  for (const p of prefixes) walk(join(root, p));
+  return hits;
+}
+
+async function main() {
+  const enforce = process.argv.includes('--enforce');
+  const allow = loadAllowlist();
+  const hits = scanTree();
+  const ungoverned = hits.filter((h) => !(`${h.file}:${h.line}` in allow) && !(h.file in allow));
+  console.log(`[SWALLOWED-QUERY-LINT] scanned gate/executor paths; ${hits.length} data-only PostgREST destructure(s); ${ungoverned.length} ungoverned.`);
+  if (ungoverned.length) {
+    console.log('  A rejected query here returns null, which is indistinguishable from an empty result.');
+    console.log('  Route through lib/db/safe-query.mjs (safeQuery/safeCount), bind `error`, or allowlist "<file>:<line>" WITH a reason:');
+    // Print a SAMPLE, not the whole population. This SD converts the verdict-critical sites and
+    // tracks the rest as a migration; a 200-line wall every run is the kind of output people
+    // learn to scroll past, and a rule nobody reads is worth less than no rule. The COUNT above
+    // is the gauge — it is what should move.
+    const SAMPLE = process.argv.includes('--list') ? ungoverned.length : 15;
+    for (const u of ungoverned.slice(0, SAMPLE)) console.log(`   • ${u.file}:${u.line} [${u.kind}-only] ${u.snippet}`);
+    if (ungoverned.length > SAMPLE) {
+      console.log(`   … and ${ungoverned.length - SAMPLE} more (--list to show all).`);
+    }
+  } else {
+    console.log('  All gate/executor PostgREST reads bind `error`, route through a throwing wrapper, or are allowlisted. 0 ungoverned.');
+  }
+  if (enforce && ungoverned.length) process.exitCode = 1;
+}
+
+if (process.argv[1] && /swallowed-query-error-lint\.mjs$/.test(process.argv[1].replace(/\\/g, '/'))) {
+  main();
+}

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/integration-test-requirement.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/integration-test-requirement.js
@@ -226,14 +226,41 @@ async function checkHasChildren(supabase, sdId) {
   // Failing closed is the correct direction for a safety-relevant gate: ValidationOrchestrator
   // converts an uncaught throw into an honest FAIL, so an unanswerable lookup now blocks rather
   // than quietly waiving the requirement.
+  // *** CORRECTED AFTER SECURITY REVIEW 66c3911c: propagating was DISPROPORTIONATE. ***
+  // GATE_INTEGRATION_TEST_REQUIREMENT is required:true and registered unconditionally, and
+  // ValidationOrchestrator turns a thrown validator error into a FAIL — so letting this single
+  // best-effort lookup propagate meant ANY transient fault (network blip, pool exhaustion, RLS
+  // misconfig) hard-failed EVERY EXEC-TO-PLAN handoff, for every SD, complex or not. Trading a
+  // false-PASS for a fleet-wide false-FAIL is not a fix; it is the same mistake pointing the
+  // other way. It was also inconsistent with the parent-opt-in lookup in this same change, which
+  // was deliberately kept fail-open.
+  //
+  // Neither swallowing (the original defect: fault reads as "no children", which WAIVES the
+  // requirement) nor propagating (a denial of service) is right. The third option is to make the
+  // UNCERTAINTY ITSELF conservative: if we cannot determine whether this SD has children, assume
+  // it DOES. That errs toward MORE checking, never less — an unanswerable lookup can only ever
+  // add the integration-test requirement, never remove it — so the failure mode is a slightly
+  // stricter gate rather than a waived one or a blocked fleet.
   const rows = await safeQuery(
     supabase
       .from('strategic_directives_v2')
       .select('id')
       .eq('parent_sd_id', sdId)
       .limit(1),
-    { site: 'integration-test-requirement:children-check' }
+    {
+      site: 'integration-test-requirement:children-check',
+      tolerate: 'Best-effort complexity input, one of three OR-ed signals. Failing closed here would '
+        + 'block every EXEC-TO-PLAN handoff on a transient blip (required:true, unconditional gate). '
+        + 'The fault is instead resolved CONSERVATIVELY by assumeComplexOnUnknown below, so an '
+        + 'unanswerable lookup can only tighten the gate, never waive it.',
+    }
   );
+  // safeQuery returns null ONLY when the tolerated fault fired (a successful empty query yields
+  // []). So null means "could not determine" — distinct from "determined: no children".
+  if (rows === null) {
+    console.log('   ⚠️  Children lookup unanswerable — assuming SD HAS children (conservative)');
+    return true;
+  }
   return Array.isArray(rows) && rows.length > 0;
 }
 

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/integration-test-requirement.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/integration-test-requirement.js
@@ -11,6 +11,11 @@
  * Fixes GAP-003 (zero integration tests).
  */
 
+// SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 FR-1: query-error discipline, so a rejected
+// query cannot masquerade as an empty result and quietly relax this gate.
+import { safeQuery } from '../../../../../../lib/db/safe-query.mjs';
+
+
 import { existsSync, readFileSync, readdirSync, statSync, realpathSync } from 'fs';
 import { resolve, relative, extname } from 'path';
 import { execSync } from 'child_process';
@@ -208,17 +213,28 @@ function countTestCalls(files) {
  */
 async function checkHasChildren(supabase, sdId) {
   if (!supabase) return false;
-  try {
-    const { data } = await supabase
+  // SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 / FR-3: THIS FUNCTION USED TO RETURN false ON A
+  // QUERY FAULT, which is indistinguishable from "this SD has no children" — and that answer
+  // flows straight into a gate verdict. Fewer complexity reasons => isComplex false => the
+  // validator's "SD is not complex - integration test check not required" branch => GATE PASSES
+  // AUTOMATICALLY. So a rejected query silently removed the integration-test requirement.
+  //
+  // Both halves were needed: safeQuery makes the fault raisable, and REMOVING THE SWALLOWING
+  // CATCH is what lets it reach the caller. Keeping the catch would have made the wrapper a no-op
+  // here, exactly as it would have at smoke-test-gate.
+  //
+  // Failing closed is the correct direction for a safety-relevant gate: ValidationOrchestrator
+  // converts an uncaught throw into an honest FAIL, so an unanswerable lookup now blocks rather
+  // than quietly waiving the requirement.
+  const rows = await safeQuery(
+    supabase
       .from('strategic_directives_v2')
       .select('id')
       .eq('parent_sd_id', sdId)
-      .limit(1);
-    return data && data.length > 0;
-  } catch (e) {
-    console.debug('[IntegrationTestReq] children check suppressed:', e?.message || e);
-    return false;
-  }
+      .limit(1),
+    { site: 'integration-test-requirement:children-check' }
+  );
+  return Array.isArray(rows) && rows.length > 0;
 }
 
 /**

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/wiring-validation.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/wiring-validation.js
@@ -19,6 +19,11 @@
  * @module scripts/modules/handoff/executors/exec-to-plan/gates/wiring-validation
  */
 
+// SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 FR-1: query-error discipline, so a rejected
+// query cannot masquerade as an empty result and quietly relax this gate.
+import { safeQuery } from '../../../../../../lib/db/safe-query.mjs';
+
+
 const VISION_DOC_KEY = 'VISION-LEO-WIRING-VERIFICATION-L2-001';
 
 /**
@@ -41,17 +46,29 @@ export function createWiringValidationGate(supabase) {
       const selfOptIn = sd?.metadata?.wiring_required === true;
       let parentOptIn = false;
       if (!selfOptIn && sd?.parent_sd_id) {
-        try {
-          const { data: parent } = await supabase
+        // SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 / FR-2: this fail-open is DELIBERATE — the
+        // original code says so ("Non-blocking: if we can't read parent, treat as non-opted-in")
+        // — so it is a genuine TOLERATED failure, not a defect to fix. Not every data-only
+        // destructure is a bug, and pretending otherwise would train people to convert blindly.
+        //
+        // What changes is that the tolerance is now DECLARED rather than implicit: safeQuery
+        // requires a REASON STRING to stay silent, the reason is written to stderr when it fires,
+        // and the count of such silences is itself a gauge. An implicit swallow is invisible; a
+        // declared one can be reviewed and, if the fleet accumulates too many, reconsidered.
+        const parent = await safeQuery(
+          supabase
             .from('strategic_directives_v2')
             .select('metadata')
             .eq('id', sd.parent_sd_id)
-            .maybeSingle();
-          parentOptIn = parent?.metadata?.wiring_enforcement === true;
-        } catch (e) {
-          // Non-blocking: if we can't read parent, treat as non-opted-in.
-          console.log(`   ⚠️  Parent lookup failed (${e?.message || e}) — treating as advisory`);
-        }
+            .maybeSingle(),
+          {
+            site: 'wiring-validation:parent-opt-in-lookup',
+            tolerate: 'Opt-in resolution is advisory by design: an unreadable parent means we cannot '
+              + 'confirm opt-in, and the gate then runs advisory-only rather than blocking. Failing '
+              + 'closed here would block SDs on an unrelated parent-row problem.',
+          }
+        );
+        parentOptIn = parent?.metadata?.wiring_enforcement === true;
       }
 
       const optedIn = selfOptIn || parentOptIn;
@@ -90,11 +107,21 @@ export function createWiringValidationGate(supabase) {
       const wiringValidated = sdRow?.wiring_validated;
 
       // ── Also fetch per-check breakdown for remediation text ─────────────
-      const { data: checks } = await supabase
-        .from('leo_wiring_validations')
-        .select('check_type, status, signals_detected, waived_by')
-        .eq('sd_key', sdKey)
-        .order('check_type');
+      // SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 / FR-3: a failed read here previously yielded
+      // null, so checkCount became 0 and both the failed and warned filters came back empty —
+      // the gate reported NO ISSUES on a query it could not actually answer. Unlike the
+      // smoke-test and children-check sites, this one needs no catch restructuring: there is no
+      // local try/catch, and ValidationOrchestrator.validateGate() already converts an uncaught
+      // throw into an honest FAIL. Routing through safeQuery is sufficient here, and the test
+      // asserts on the REJECTION rather than on returned issues.
+      const checks = await safeQuery(
+        supabase
+          .from('leo_wiring_validations')
+          .select('check_type, status, signals_detected, waived_by')
+          .eq('sd_key', sdKey)
+          .order('check_type'),
+        { site: 'wiring-validation:checks-breakdown' }
+      );
 
       const issues = [];
       const warnings = [];

--- a/scripts/modules/handoff/executors/lead-final-approval/gates/smoke-test-gate.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/smoke-test-gate.js
@@ -9,6 +9,9 @@
  */
 
 import { execSync } from 'child_process';
+// SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 FR-1: query-error discipline, so a rejected PRD
+// lookup cannot masquerade as "no smoke test configured".
+import { safeQuery } from '../../../../../../lib/db/safe-query.mjs';
 
 const GATE_NAME = 'SMOKE_TEST_GATE';
 const TIMEOUT_MS = 30_000;
@@ -31,6 +34,16 @@ export function createSmokeTestGate(supabase, prdRepo) {
 
       // Resolve PRD to get smoke_test_cmd
       let smokeTestCmd = null;
+      // SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 / FR-3: a FAILED LOOKUP IS NOT AN ABSENT
+      // COMMAND. Before this, the query below bound only `data`, so a rejected query (bad column,
+      // missing relation) yielded null, `prd` stayed null, `smokeTestCmd` stayed null, and control
+      // reached the "No smoke_test_cmd configured — advisory pass" branch below. A BROKEN QUERY
+      // MADE THIS GATE PASS, reporting a benign reason that sounds like normal operation.
+      //
+      // Routing the query through safeQuery is NOT sufficient on its own: this try/catch would
+      // have swallowed the throw and fallen through to the same advisory pass. The catch had to
+      // record the fault so the advisory-pass branch becomes unreachable after one.
+      let lookupFault = null;
       try {
         let prd = null;
         if (prdRepo?.getBySdUuid) {
@@ -40,18 +53,39 @@ export function createSmokeTestGate(supabase, prdRepo) {
         }
 
         if (!prd && supabase) {
-          const { data } = await supabase
-            .from('product_requirements_v2')
-            .select('smoke_test_cmd')
-            .eq('sd_id', sdId)
-            .limit(1)
-            .single();
-          prd = data;
+          // safeQuery returns null for PGRST116 (.single() matched no rows — a genuine absence,
+          // and the correct path to an advisory pass) and THROWS for anything else.
+          prd = await safeQuery(
+            supabase
+              .from('product_requirements_v2')
+              .select('smoke_test_cmd')
+              .eq('sd_id', sdId)
+              .limit(1)
+              .single(),
+            { site: 'smoke-test-gate:prd-lookup' }
+          );
         }
 
         smokeTestCmd = prd?.smoke_test_cmd || null;
       } catch (err) {
+        lookupFault = err;
         console.log(`   ⚠️  PRD lookup error: ${err.message}`);
+      }
+
+      // A lookup that COULD NOT ANSWER must not be reported as "nothing configured".
+      if (lookupFault) {
+        console.log('   ❌ PRD lookup failed — cannot determine whether a smoke test is configured');
+        return {
+          passed: false,
+          score: 0,
+          max_score: 100,
+          issues: [
+            `SMOKE_TEST_GATE could not read the PRD: ${lookupFault.message}. `
+            + 'This is a query fault, not an absent smoke test — the gate refuses to advisory-pass on an unanswerable lookup '
+            + '(SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 FR-3).',
+          ],
+          warnings: [],
+        };
       }
 
       // No command configured — advisory pass

--- a/tests/unit/db/safe-query.test.js
+++ b/tests/unit/db/safe-query.test.js
@@ -1,0 +1,113 @@
+/**
+ * SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 FR-1/FR-2 — query-error discipline.
+ *
+ * The point of this suite is NOT "does it throw". A wrapper that throws on everything would
+ * satisfy a naive test while being useless. TS-W3 and TS-W4 are the negative controls that
+ * prove it DISCRIMINATES: a real table still returns its count, and a genuinely empty (but
+ * existing) table still returns an empty result without throwing. Without those two, TS-W1/TS-W2
+ * prove nothing about which half of the wrapper is doing the work.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { safeQuery, safeCount, assertToleranceReason } from '../../../lib/db/safe-query.mjs';
+
+// Shapes observed against the LIVE database, not invented:
+//   missing column  -> data null, error 42703 'column X does not exist'   (HTTP 400)
+//   missing table   -> count null, error null                            (HTTP 204)
+//   real table      -> count <number>, error null                        (HTTP 206)
+const missingColumn = () => Promise.resolve({ data: null, error: { code: '42703', message: 'column sd_phase_handoffs.score does not exist' } });
+const okRows = rows => Promise.resolve({ data: rows, error: null });
+const missingTableCount = () => Promise.resolve({ count: null, error: null });
+const realTableCount = n => Promise.resolve({ count: n, error: null });
+
+describe('safeQuery — a rejected query must not read as absence (TS-W1)', () => {
+  it('THROWS on a PostgREST error instead of yielding null', async () => {
+    await expect(safeQuery(missingColumn(), { site: 'test-site' }))
+      .rejects.toThrow(/QUERY_FAILED at test-site/);
+  });
+
+  it('names the offending column, so the fault is diagnosable from the record', async () => {
+    await expect(safeQuery(missingColumn(), { site: 'test-site' }))
+      .rejects.toThrow(/column sd_phase_handoffs\.score does not exist/);
+  });
+
+  // TS-W4 — the control that matters most for safeQuery.
+  it('returns rows normally on success, and an EMPTY array without throwing', async () => {
+    expect(await safeQuery(okRows([{ id: 1 }]), { site: 's' })).toEqual([{ id: 1 }]);
+    // A genuinely empty result is a legal answer and must pass through untouched. If this
+    // throws, the wrapper is failing more often rather than discriminating.
+    expect(await safeQuery(okRows([]), { site: 's' })).toEqual([]);
+  });
+});
+
+describe('safeCount — the sub-shape with NO error to throw on (TS-W2)', () => {
+  it('THROWS when count is null even though error is null (missing relation)', async () => {
+    // This is the case a throw-on-error-only wrapper would pass straight through, shipping the
+    // defect inside the fix meant to remove it.
+    await expect(safeCount(missingTableCount(), { site: 'probe' }))
+      .rejects.toThrow(/COUNT_UNMEASURABLE at probe/);
+  });
+
+  it('says WHICH half failed rather than collapsing the two diagnoses', async () => {
+    await expect(safeCount(missingTableCount(), { site: 'probe' }))
+      .rejects.toThrow(/count is null with no error/);
+    await expect(safeCount(Promise.resolve({ count: null, error: { message: 'boom' } }), { site: 'probe' }))
+      .rejects.toThrow(/boom/);
+  });
+
+  // TS-W3 — the negative control. Without this, TS-W2 is satisfied by throwing on all counts.
+  it('returns the count for a REAL table, and returns 0 for a genuinely EMPTY one', async () => {
+    expect(await safeCount(realTableCount(1155), { site: 'probe' })).toBe(1155);
+    // The whole discrimination in one assertion: 0 is a measured answer, null is a failed
+    // measurement. Coercing the second into the first is the original defect.
+    expect(await safeCount(realTableCount(0), { site: 'probe' })).toBe(0);
+  });
+});
+
+describe('opt-out requires a REASON STRING, never a boolean (TS-5, TS-6 / FR-2)', () => {
+  it('REFUSES a boolean opt-out loudly', () => {
+    expect(() => assertToleranceReason(true, 'site')).toThrow(/TOLERATE_REASON_REQUIRED/);
+    expect(() => assertToleranceReason(false, 'site')).toThrow(/TOLERATE_REASON_REQUIRED/);
+  });
+
+  it('REFUSES an empty or whitespace-only reason — the boolean shape wearing a string costume', () => {
+    expect(() => assertToleranceReason('', 'site')).toThrow(/TOLERATE_REASON_REQUIRED/);
+    expect(() => assertToleranceReason('   ', 'site')).toThrow(/TOLERATE_REASON_REQUIRED/);
+  });
+
+  it('accepts a real reason and returns it trimmed, so it can be recorded and counted', () => {
+    expect(assertToleranceReason('  best-effort telemetry, absence is expected  ', 'site'))
+      .toBe('best-effort telemetry, absence is expected');
+  });
+
+  it('treats no opt-out as no opt-out (undefined/null are not silences)', () => {
+    expect(assertToleranceReason(undefined, 'site')).toBeNull();
+    expect(assertToleranceReason(null, 'site')).toBeNull();
+  });
+});
+
+describe('a tolerated call site degrades to null, but says so on stderr', () => {
+  let writes;
+  beforeEach(() => {
+    writes = [];
+    vi.spyOn(process.stderr, 'write').mockImplementation(s => { writes.push(s); return true; });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('safeQuery returns null and records the reason', async () => {
+    const out = await safeQuery(missingColumn(), { site: 'tolerated-site', tolerate: 'optional lookup; absence is expected' });
+    expect(out).toBeNull();
+    expect(writes.join('')).toMatch(/TOLERATED at tolerated-site/);
+    expect(writes.join('')).toMatch(/optional lookup; absence is expected/);
+  });
+
+  it('safeCount does the same for the errorless-null-count shape', async () => {
+    const out = await safeCount(missingTableCount(), { site: 'tolerated-probe', tolerate: 'table is created lazily' });
+    expect(out).toBeNull();
+    expect(writes.join('')).toMatch(/table is created lazily/);
+  });
+
+  it('a boolean opt-out is still refused even at a call site that meant well', async () => {
+    await expect(safeQuery(missingColumn(), { site: 's', tolerate: true }))
+      .rejects.toThrow(/TOLERATE_REASON_REQUIRED/);
+  });
+});

--- a/tests/unit/gates/exec-to-plan-query-fault.test.js
+++ b/tests/unit/gates/exec-to-plan-query-fault.test.js
@@ -37,8 +37,42 @@ function fakeSupabase(byTable) {
   };
 }
 
-describe('TS-A2: checkHasChildren no longer answers "no children" when it could not ask', () => {
-  it('PROPAGATES a query fault instead of returning false', async () => {
+describe('TS-A2: checkHasChildren resolves an unanswerable lookup CONSERVATIVELY', () => {
+  it('assumes the SD HAS children when the lookup cannot answer — never waives the requirement', async () => {
+    // Corrected after SECURITY 66c3911c. Three possible behaviours, only one is right:
+    //   swallow -> fault reads as "no children" -> requirement WAIVED (the original defect)
+    //   propagate -> required:true unconditional gate FAILS on any blip -> fleet-wide DoS
+    //   assume-complex -> an unanswerable lookup can only ADD the requirement, never remove it
+    // This asserts the third. hasChildren=true makes the SD complex, so the gate must NOT take
+    // its "not complex - integration test check not required" shortcut.
+    const { createIntegrationTestRequirementGate } = await import(
+      '../../../scripts/modules/handoff/executors/exec-to-plan/gates/integration-test-requirement.js'
+    );
+    const gate = createIntegrationTestRequirementGate(
+      fakeSupabase({ strategic_directives_v2: { data: null, error: FAULT } })
+    );
+    const res = await gate.validator({ sd: { id: 'sd-uuid', sd_key: 'SD-X-001', sd_type: 'docs' } });
+    // Assert the DECISION directly rather than a compound negative over the whole payload — a
+    // "not (passed && /not required/)" test can pass for the wrong reason and would be exactly
+    // the vacuousness this SD is about.
+    expect(res.details.complexity.hasChildren).toBe(true);
+    expect(res.details.complexity.reasons).toContain('SD has child SDs');
+  });
+
+  it('CONTROL: a genuinely empty result still means NO children — the fault path is not just "always true"', async () => {
+    // Without this, the assertion above is satisfied by hardcoding hasChildren=true.
+    const { createIntegrationTestRequirementGate } = await import(
+      '../../../scripts/modules/handoff/executors/exec-to-plan/gates/integration-test-requirement.js'
+    );
+    const gate = createIntegrationTestRequirementGate(
+      fakeSupabase({ strategic_directives_v2: { data: [], error: null } })
+    );
+    const res = await gate.validator({ sd: { id: 'sd-uuid', sd_key: 'SD-X-001', sd_type: 'docs' } });
+    expect(res.details.complexity.hasChildren).toBe(false);
+    expect(res.details.complexity.reasons).not.toContain('SD has child SDs');
+  });
+
+  it('LEGACY SHAPE, kept for contrast: a fault must not simply propagate as a gate crash', async () => {
     // Pre-fix: `const { data }` yielded null AND the catch returned false, so a rejected query
     // read as "no children" -> one fewer complexity reason -> isComplex false -> the gate's
     // "not complex, integration test check not required" branch -> AUTOMATIC PASS.
@@ -48,9 +82,11 @@ describe('TS-A2: checkHasChildren no longer answers "no children" when it could 
     const gate = createIntegrationTestRequirementGate(
       fakeSupabase({ strategic_directives_v2: { data: null, error: FAULT } })
     );
+    // Pinning the DoS regression: this gate is required:true and unconditional, so a throw here
+    // would fail EVERY EXEC-TO-PLAN handoff on a transient blip.
     await expect(
       gate.validator({ sd: { id: 'sd-uuid', sd_key: 'SD-X-001', sd_type: 'feature' } })
-    ).rejects.toThrow(/fault-sentinel/);
+    ).resolves.toBeTruthy();
   });
 });
 

--- a/tests/unit/gates/exec-to-plan-query-fault.test.js
+++ b/tests/unit/gates/exec-to-plan-query-fault.test.js
@@ -1,0 +1,101 @@
+/**
+ * SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 FR-3 — TS-A2 / TS-A3 / TS-A4.
+ *
+ * The three EXEC-TO-PLAN sites, each of which needed a DIFFERENT treatment. Blanket-converting
+ * them would have been wrong, and this suite is where that distinction is pinned:
+ *
+ *   integration-test-requirement checkHasChildren  -> swallowing catch REMOVED (fault propagates)
+ *   wiring-validation checks-breakdown             -> wrapper only; no local catch to restructure
+ *   wiring-validation parent-opt-in lookup         -> DELIBERATE fail-open, now a DECLARED tolerance
+ *
+ * The last one matters: not every data-only destructure is a defect. That site's original comment
+ * says the fail-open is intended, so the fix is to make the silence auditable, not to remove it.
+ * A suite that failed it would be pushing people to convert blindly.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createWiringValidationGate } from '../../../scripts/modules/handoff/executors/exec-to-plan/gates/wiring-validation.js';
+
+const FAULT = { code: '42703', message: 'column does not exist :: fault-sentinel' };
+
+/**
+ * Supabase double routing by table, so each query in a gate can fail independently.
+ * @param {Record<string, {data?:any,error?:any,count?:number}>} byTable
+ */
+function fakeSupabase(byTable) {
+  return {
+    from(table) {
+      const result = byTable[table] ?? { data: null, error: null };
+      const chain = {
+        select() { return chain; }, eq() { return chain; }, limit() { return chain; },
+        order() { return Promise.resolve(result); },
+        maybeSingle() { return Promise.resolve(result); },
+        single() { return Promise.resolve(result); },
+        then(res, rej) { return Promise.resolve(result).then(res, rej); },
+      };
+      return chain;
+    },
+  };
+}
+
+describe('TS-A2: checkHasChildren no longer answers "no children" when it could not ask', () => {
+  it('PROPAGATES a query fault instead of returning false', async () => {
+    // Pre-fix: `const { data }` yielded null AND the catch returned false, so a rejected query
+    // read as "no children" -> one fewer complexity reason -> isComplex false -> the gate's
+    // "not complex, integration test check not required" branch -> AUTOMATIC PASS.
+    const { createIntegrationTestRequirementGate } = await import(
+      '../../../scripts/modules/handoff/executors/exec-to-plan/gates/integration-test-requirement.js'
+    );
+    const gate = createIntegrationTestRequirementGate(
+      fakeSupabase({ strategic_directives_v2: { data: null, error: FAULT } })
+    );
+    await expect(
+      gate.validator({ sd: { id: 'sd-uuid', sd_key: 'SD-X-001', sd_type: 'feature' } })
+    ).rejects.toThrow(/fault-sentinel/);
+  });
+});
+
+describe('TS-A3: wiring-validation surfaces a checks-query fault instead of reporting zero issues', () => {
+  it('REJECTS rather than returning a no-issues verdict', async () => {
+    // This site has no local catch — ValidationOrchestrator turns the throw into an honest FAIL —
+    // so the assertion is on the REJECTION, not on returned issues. Asserting the wrong shape
+    // here would pass vacuously.
+    const gate = createWiringValidationGate(fakeSupabase({
+      strategic_directives_v2: { data: { wiring_validated: null }, error: null },
+      leo_wiring_validations: { data: null, error: FAULT },
+    }));
+    await expect(
+      gate.validator({ sd: { sd_key: 'SD-X-001', metadata: { wiring_required: true } } })
+    ).rejects.toThrow(/QUERY_FAILED at wiring-validation:checks-breakdown/);
+  });
+
+  it('still returns a normal verdict when the checks query succeeds', async () => {
+    // Control: the gate must not have become one that simply throws.
+    const gate = createWiringValidationGate(fakeSupabase({
+      strategic_directives_v2: { data: { wiring_validated: true }, error: null },
+      leo_wiring_validations: { data: [{ check_type: 'a', status: 'passed' }], error: null },
+    }));
+    const res = await gate.validator({ sd: { sd_key: 'SD-X-001', metadata: { wiring_required: true } } });
+    expect(res.passed).toBe(true);
+  });
+});
+
+describe('FR-2: the parent-opt-in lookup is a DECLARED tolerance, not a fixed defect', () => {
+  let writes;
+  beforeEach(() => {
+    writes = [];
+    vi.spyOn(process.stderr, 'write').mockImplementation(s => { writes.push(s); return true; });
+  });
+  afterEach(() => vi.restoreAllMocks());
+
+  it('tolerates a parent-lookup fault and records WHY, rather than failing the gate', async () => {
+    const gate = createWiringValidationGate(fakeSupabase({
+      strategic_directives_v2: { data: null, error: FAULT },
+    }));
+    // Not opted in via self, parent unreadable -> advisory pass, exactly as before the change.
+    const res = await gate.validator({ sd: { sd_key: 'SD-X-001', parent_sd_id: 'parent-uuid', metadata: {} } });
+    expect(res.passed).toBe(true);
+    // The behavioural difference: the silence is now on the record with its reason.
+    expect(writes.join('')).toMatch(/TOLERATED at wiring-validation:parent-opt-in-lookup/);
+    expect(writes.join('')).toMatch(/advisory by design/);
+  });
+});

--- a/tests/unit/gates/smoke-test-gate-query-fault.test.js
+++ b/tests/unit/gates/smoke-test-gate-query-fault.test.js
@@ -1,0 +1,76 @@
+/**
+ * SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 FR-3 / TS-A1 — the headline scenario.
+ *
+ * BEFORE: the PRD lookup bound only `data`, so a rejected query (bad column, missing relation)
+ * yielded null, `prd` stayed null, `smokeTestCmd` stayed null, and control reached the
+ * "No smoke_test_cmd configured — advisory pass" branch. A BROKEN QUERY MADE THE GATE PASS,
+ * reporting a reason that sounds like normal operation.
+ *
+ * WHY THE OBVIOUS FIX WOULD NOT HAVE WORKED, and why this suite exists in this shape:
+ * routing the query through a throwing wrapper alone changes NOTHING OBSERVABLE here, because
+ * the surrounding try/catch swallowed any throw and fell through to the same advisory pass.
+ * The load-bearing change is the CATCH BLOCK recording the fault so the advisory-pass branch
+ * becomes unreachable after one. `advisory-passes on a GENUINE absence` below is the control
+ * that proves this discriminates rather than simply failing more often.
+ */
+import { describe, it, expect } from 'vitest';
+import { createSmokeTestGate } from '../../../scripts/modules/handoff/executors/lead-final-approval/gates/smoke-test-gate.js';
+
+const SD_ID = '11111111-2222-3333-4444-555555555555';
+
+/** Minimal supabase double whose terminal .single() resolves to whatever shape we hand it. */
+function fakeSupabase(result) {
+  const chain = {
+    from() { return chain; },
+    select() { return chain; },
+    eq() { return chain; },
+    limit() { return chain; },
+    single() { return Promise.resolve(result); },
+  };
+  return chain;
+}
+
+const run = supabase => createSmokeTestGate(supabase, null).validator({ sd: { id: SD_ID } });
+
+describe('TS-A1: smoke-test-gate cannot advisory-pass on an unanswerable PRD lookup', () => {
+  it('FAILS when the PRD query is rejected (bad column)', async () => {
+    const res = await run(fakeSupabase({
+      data: null,
+      error: { code: '42703', message: 'column product_requirements_v2.smoke_test_cmd does not exist' },
+    }));
+    // The whole defect in one assertion: pre-fix this returned passed:true.
+    expect(res.passed).toBe(false);
+    expect(res.issues.join(' ')).toMatch(/could not read the PRD/i);
+    expect(res.issues.join(' ')).toMatch(/query fault, not an absent smoke test/i);
+  });
+
+  it('does NOT report the benign "no smoke test configured" warning on a query fault', async () => {
+    const res = await run(fakeSupabase({ data: null, error: { code: '42P01', message: 'relation does not exist' } }));
+    // The specific misreport this SD is about — a plausible reason for having done nothing.
+    expect(res.warnings.join(' ')).not.toMatch(/No smoke test configured/i);
+  });
+
+  // THE CONTROL. Without it, the assertions above are satisfied by failing on everything.
+  it('still advisory-passes on a GENUINE absence (PGRST116 — .single() matched no rows)', async () => {
+    const res = await run(fakeSupabase({ data: null, error: { code: 'PGRST116', message: 'No rows found' } }));
+    expect(res.passed).toBe(true);
+    expect(res.warnings.join(' ')).toMatch(/No smoke test configured/i);
+  });
+
+  it('still advisory-passes when the PRD exists but configures no command', async () => {
+    const res = await run(fakeSupabase({ data: { smoke_test_cmd: null }, error: null }));
+    expect(res.passed).toBe(true);
+  });
+});
+
+describe('TS-A4: the gate ADOPTS the FR-1 wrapper rather than re-implementing it', () => {
+  it('propagates a wrapper-raised fault into a gate failure', async () => {
+    // Behavioural adoption proof: the QUERY_FAILED shape safeQuery raises is what reaches the
+    // gate's issues. A hand-rolled inline check would not carry this signature. Guards the
+    // failure mode where tests exercise a copy of the logic while the shipped path is untouched.
+    const res = await run(fakeSupabase({ data: null, error: { code: '42703', message: 'boom-sentinel' } }));
+    expect(res.passed).toBe(false);
+    expect(res.issues.join(' ')).toMatch(/QUERY_FAILED at smoke-test-gate:prd-lookup/);
+    expect(res.issues.join(' ')).toMatch(/boom-sentinel/);
+  });
+});

--- a/tests/unit/lint/swallowed-query-error-lint.test.js
+++ b/tests/unit/lint/swallowed-query-error-lint.test.js
@@ -10,6 +10,7 @@ import { extractSwallowedQueries, loadAllowlist, stripComments } from '../../../
 import { writeFileSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
 
 describe('TS-9: the extractor flags a data-only PostgREST destructure', () => {
   it('flags the defect shape', () => {
@@ -100,5 +101,33 @@ describe('TS-10: an allowlist entry without a reason is refused', () => {
 
   it('treats a missing allowlist file as empty rather than crashing the lint', () => {
     expect(loadAllowlist('/nonexistent/path/allow.json')).toEqual({});
+  });
+});
+
+describe('the advisory-first claim is TESTED, not just asserted (TESTING 4118666a gap)', () => {
+  // "Advisory-first" is a SAFETY PROPERTY -- it is what stops this lint turning every in-flight
+  // PR red on day one over a 232-site pre-existing baseline. It had zero automated coverage and
+  // rested on one manual run, which is precisely the shape of claim this SD exists to distrust.
+  const LINT = new URL('../../../scripts/lint/swallowed-query-error-lint.mjs', import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1');
+
+  it('exits 0 by default even though the baseline is non-empty', () => {
+    const r = spawnSync(process.execPath, [LINT], { encoding: 'utf8' });
+    expect(r.stdout).toMatch(/ungoverned/);
+    // The load-bearing assertion: findings exist AND the exit code is still 0.
+    expect(r.stdout).not.toMatch(/0 ungoverned/);
+    expect(r.status).toBe(0);
+  });
+
+  it('exits 1 under --enforce, so the escalation path genuinely works', () => {
+    const r = spawnSync(process.execPath, [LINT, '--enforce'], { encoding: 'utf8' });
+    expect(r.status).toBe(1);
+  });
+
+  it('caps its output by default and shows everything under --list', () => {
+    // A 200-line wall every run is the kind of output people learn to scroll past.
+    const capped = spawnSync(process.execPath, [LINT], { encoding: 'utf8' }).stdout;
+    const listed = spawnSync(process.execPath, [LINT, '--list'], { encoding: 'utf8' }).stdout;
+    expect(capped).toMatch(/and \d+ more \(--list to show all\)/);
+    expect(listed.split('\n').length).toBeGreaterThan(capped.split('\n').length);
   });
 });

--- a/tests/unit/lint/swallowed-query-error-lint.test.js
+++ b/tests/unit/lint/swallowed-query-error-lint.test.js
@@ -1,0 +1,104 @@
+/**
+ * SD-LEO-INFRA-SWALLOWED-POSTGREST-ERROR-001 FR-4 / TS-9, TS-10 — the lint's own tests.
+ *
+ * The extractor is pure, so these run against string fixtures rather than the filesystem.
+ * NOTE the fixtures below deliberately contain the buggy shape; that is why this file is
+ * excluded from the scan (tests/ is skipped by scanTree).
+ */
+import { describe, it, expect } from 'vitest';
+import { extractSwallowedQueries, loadAllowlist, stripComments } from '../../../scripts/lint/swallowed-query-error-lint.mjs';
+import { writeFileSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('TS-9: the extractor flags a data-only PostgREST destructure', () => {
+  it('flags the defect shape', () => {
+    const hits = extractSwallowedQueries(`
+      const { data } = await supabase.from('x').select('y').limit(1);
+    `, 'f.js');
+    expect(hits).toHaveLength(1);
+    expect(hits[0].kind).toBe('data');
+  });
+
+  it('flags a renamed binding too — the name is not the point', () => {
+    const hits = extractSwallowedQueries(`
+      const { data: rows } = await supabase.from('x').select('y');
+    `, 'f.js');
+    expect(hits).toHaveLength(1);
+  });
+
+  it('flags the count-only shape (the sub-shape with no error to discard)', () => {
+    const hits = extractSwallowedQueries(`
+      const { count } = await supabase.from('x').select('*', { count: 'exact', head: true });
+    `, 'f.js');
+    expect(hits).toHaveLength(1);
+    expect(hits[0].kind).toBe('count');
+  });
+
+  // The controls. Without these the extractor could flag everything and still pass above.
+  it('does NOT flag a destructure that binds error', () => {
+    expect(extractSwallowedQueries(`
+      const { data, error } = await supabase.from('x').select('y');
+    `, 'f.js')).toEqual([]);
+    expect(extractSwallowedQueries(`
+      const { data: rows, error: rowsErr } = await supabase.from('x').select('y');
+    `, 'f.js')).toEqual([]);
+  });
+
+  it('does NOT flag a non-PostgREST await — axios, helpers, anything else', () => {
+    expect(extractSwallowedQueries(`
+      const { data } = await axios.get('https://example.test');
+    `, 'f.js')).toEqual([]);
+    expect(extractSwallowedQueries(`
+      const { data } = await resolveOwnSession(supabase, {});
+    `, 'f.js')).toEqual([]);
+  });
+
+  it('does NOT flag a call already routed through a throwing wrapper', () => {
+    expect(extractSwallowedQueries(`
+      const rows = await safeQuery(supabase.from('x').select('y'), { site: 's' });
+    `, 'f.js')).toEqual([]);
+    expect(extractSwallowedQueries(`
+      const { data } = await safeQuery(supabase.from('x').select('y'), { site: 's' });
+    `, 'f.js')).toEqual([]);
+  });
+
+  it('does NOT flag a commented-out query, and keeps line numbers accurate', () => {
+    const src = [
+      '// const { data } = await supabase.from("x").select("y");',
+      'const noop = 1;',
+      'const { data } = await supabase.from("x").select("y");',
+    ].join('\n');
+    const hits = extractSwallowedQueries(src, 'f.js');
+    expect(hits).toHaveLength(1);
+    // Line 3, not 1 — stripComments must preserve line count or allowlist keys drift.
+    expect(hits[0].line).toBe(3);
+  });
+
+  it('stripComments preserves line count for block comments', () => {
+    expect(stripComments('a\n/* x\ny */\nb').split('\n')).toHaveLength(4);
+  });
+});
+
+describe('TS-10: an allowlist entry without a reason is refused', () => {
+  const write = obj => {
+    const p = join(mkdtempSync(join(tmpdir(), 'swq-')), 'allow.json');
+    writeFileSync(p, JSON.stringify(obj));
+    return p;
+  };
+
+  it('THROWS on an empty reason — a silence you cannot explain is the reflexive kind', () => {
+    expect(() => loadAllowlist(write({ allow: { 'a.js:1': '' } }))).toThrow(/has no reason/);
+    expect(() => loadAllowlist(write({ allow: { 'a.js:1': '   ' } }))).toThrow(/has no reason/);
+    expect(() => loadAllowlist(write({ allow: { 'a.js:1': true } }))).toThrow(/has no reason/);
+  });
+
+  it('accepts an entry that states why', () => {
+    const allow = loadAllowlist(write({ allow: { 'a.js:1': 'best-effort telemetry; absence expected' } }));
+    expect(allow['a.js:1']).toMatch(/best-effort/);
+  });
+
+  it('treats a missing allowlist file as empty rather than crashing the lint', () => {
+    expect(loadAllowlist('/nonexistent/path/allow.json')).toEqual({});
+  });
+});


### PR DESCRIPTION
## The defect

A destructure binding only `data` turns a bad column name into a **permanent silent no-op**. PostgREST rejects the whole query on an unknown column, so `data` is null forever and a caller that never inspects `error` reports a plausible benign reason for having done nothing. Zero rows is a legal answer, so the failure is indistinguishable from a real empty result — which is why this needs an enforcement point, not a convention.

**Live false-PASS, found at LEAD:** `smoke-test-gate.js:43` — a failed PRD lookup reached the branch commented *"No smoke_test_cmd configured — advisory pass."* A broken query **made the gate pass**.

## What shipped

- **FR-1** `lib/db/safe-query.mjs` — `safeQuery()` throws on error; `safeCount()` *also* throws when `count === null` on an explicit count request. Both halves are required: a head+count probe against a missing table returns `error: null, count: null`, so **there is no error to throw on** — a throw-only wrapper would have shipped this class alive inside the fix.
- **FR-2** opt-out takes a **reason string** and refuses a boolean (including `''`, the boolean wearing a string costume). A required reason makes every silence auditable and makes the *count* of silences a gauge.
- **FR-3** four gate sites, each treated differently — see below.
- **FR-4** advisory lint + reason-required allowlist + path-scoped CI workflow, cloned from the established template.

## The four sites needed four different treatments

| site | treatment | why |
|---|---|---|
| `smoke-test-gate.js` | **catch restructured** | a throw alone was swallowed by the surrounding `try/catch` and fell through to the same advisory pass |
| `integration-test-requirement.js` | **conservative resolution** | unanswerable → *assume complex*, so it can only add the requirement, never waive it |
| `wiring-validation.js` checks | wrapper only | no local catch; the orchestrator already fails honestly |
| `wiring-validation.js` parent-opt-in | **declared tolerance** | the fail-open is deliberate — the fix is making the silence auditable, not removing it |

That last row matters: **not every data-only destructure is a defect**, and a sweep that "fixed" it would be training people to convert blindly.

## Verification

Everything here is demonstrated rather than asserted.

- **The obvious fix would have been a no-op.** Negative control on `smoke-test-gate`: keep the wrapper, restore the old swallowing catch → **3 of 5 fail**. The catch restructuring is what does the work.
- **Live-verified against the real database**, not only fixtures: missing column and missing-table-count both throw; real count (33654), a valid row, and a genuinely empty `[]` all pass through. A wrapper that throws on everything would satisfy a naive test and be useless.
- Negative controls on all four FRs bite (TESTING `4118666a`).

## Two defects found in my own work, by review

- **SECURITY (`66c3911c`) caught a DoS I introduced.** My first `checkHasChildren` change propagated faults — but that gate is `required: true` and unconditional, so any transient blip would have failed *every* EXEC-TO-PLAN handoff. Trading a false-PASS for a fleet-wide false-FAIL is the same mistake pointing the other way. Resolved conservatively instead.
- **`PGRST116` means "0 *or more than 1* rows"**, verified against the installed library source — so on an unbounded `.single()` a duplicate-row integrity fault would wear the absence code. All converted sites are structurally bounded; the constant now states that obligation.

## Scope

232 gate/executor sites remain, tracked as a migration and **not** claimed as covered. The lint is advisory with an explicit flip-to-blocking condition: after that baseline is worked down, not before — a rule nobody reads is worth less than no rule.

1222/1223 green across 117 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)