### PR TITLE
feat(QF-20260727-962): claim-burn gauge, split by WHO burned the claims

### DIFF
--- a/lib/coordinator/claim-burn-gauge.cjs
+++ b/lib/coordinator/claim-burn-gauge.cjs
@@ -1,0 +1,125 @@
+/**
+ * @wire-check-exempt: loaded via a lazy require() inside scripts/fleet-dashboard.cjs's
+ * printClaimBurnGauge() — mirrors this file's sibling gauge modules (strand-age-gauge.cjs,
+ * relay-drop-gauge.cjs, chairman-directive-gauge.cjs), none of which are traced as reachable
+ * either because fleet-dashboard.cjs has no package.json script entry point.
+ *
+ * Claim-burn gauge: how many claim events an SD consumes, split by WHO consumed them.
+ * QF-20260727-962 (coordinator KPI-0 committed action).
+ *
+ * WHY A SINGLE COUNT WOULD BE WORSE THAN NO GAUGE. claim_history length conflates two defects
+ * that need opposite fixes:
+ *   - ONE session retaking ONE item        -> claim/resume IDEMPOTENCY failure
+ *   - MANY distinct sessions bouncing off  -> a dependency or spec WALL
+ * Measured on the live table: SD-LEO-INFRA-WORKER-INBOX-DRAIN-SUBSET-001 carries 13 claim events
+ * under exactly ONE distinct holder. A length-only gauge scores that identically to 13 different
+ * workers hitting a wall and sends the fix the wrong way. So the two are emitted as SEPARATE
+ * signals and never summed into one headline.
+ *
+ * WHICH WAY THE LIVE DATA ACTUALLY POINTS (measured 2026-07-28, whole table, paginated):
+ * 5449 SDs, 1254 carrying claim_history, 2109 claim events. Of the SDs with more than one event,
+ * REPEAT-HOLDER burn (189) EXCEEDS DISTINCT-HOLDER burn (117), with 108 mixed — and 539 repeat
+ * events would be invisible to a length-only gauge. The dominant defect is idempotency, not walls,
+ * which is the opposite of the intuition the aggregate invites.
+ *
+ * THE WINDOW IS PART OF THE SIGNAL. The commissioning row quoted 3.30 claim events per shipped
+ * item; measured table-wide lifetime it is 0.50 — 6.6x apart, and BOTH are correct for their scope
+ * (that figure was a recent cohort). A burn ratio without its denominator stated is a number nobody
+ * can reproduce or falsify, so windowLabel rides on every emission.
+ *
+ * SUSTAINED BURN ONLY. 840 of 1254 SDs carrying history have exactly one claim; a gauge that fired
+ * on a single re-claim would flag normal life and be muted within a week.
+ *
+ * Read-only: never writes strategic_directives_v2 and never touches claiming_session_id.
+ */
+'use strict';
+
+/** Sustained, not incidental: 2 claims is ordinary, 3+ is a pattern worth a name. */
+const DEFAULT_MIN_EVENTS = 3;
+
+/** PURE. Split one SD's claim_history into the two independent burn signals. */
+function classifyClaimBurn(claimHistory) {
+  const list = Array.isArray(claimHistory) ? claimHistory : [];
+  const ids = list
+    .map((e) => (e && typeof e === 'object' ? e.session_id : null))
+    .filter((v) => typeof v === 'string' && v.length > 0);
+  const events = list.length;
+  const distinctHolders = new Set(ids).size;
+  // Entries with no readable session_id cannot be attributed, so they are counted as events but
+  // never inflate distinctHolders. Clamping at 0 keeps a malformed row from reporting negative burn.
+  const repeatEvents = Math.max(0, events - distinctHolders);
+  let shape = 'none';
+  if (events > 1) {
+    if (distinctHolders <= 1) shape = 'repeat_holder';
+    else if (repeatEvents === 0) shape = 'distinct_holders';
+    else shape = 'mixed';
+  }
+  return { events, distinctHolders, repeatEvents, shape };
+}
+
+/** Read-only scan. Fails OPEN (empty gauge) so a query fault never breaks the dashboard tick. */
+async function planClaimBurnGauge(supabase, opts = {}) {
+  const minEvents = Number.isFinite(opts.minEvents) ? opts.minEvents : DEFAULT_MIN_EVENTS;
+  const windowLabel = opts.windowLabel || 'lifetime (all SD rows)';
+
+  let rows = null;
+  try {
+    const { fetchAllPaginated } = await import('../db/fetch-all-paginated.mjs');
+    rows = await fetchAllPaginated(() => supabase
+      .from('strategic_directives_v2')
+      .select('sd_key, status, metadata')
+      .order('sd_key'));           // unique-key tiebreaker for stable pagination
+  } catch { rows = null; }
+  if (!Array.isArray(rows)) return emptyGauge(windowLabel, minEvents);
+
+  const scored = [];
+  let totalEvents = 0;
+  let completed = 0;
+  for (const sd of rows) {
+    if (sd && sd.status === 'completed') completed += 1;
+    const burn = classifyClaimBurn(sd && sd.metadata && sd.metadata.claim_history);
+    totalEvents += burn.events;
+    if (burn.events >= minEvents) scored.push({ sd_key: sd.sd_key, status: sd.status, ...burn });
+  }
+
+  const by = (shape) => scored.filter((r) => r.shape === shape);
+  return {
+    windowLabel,
+    minEvents,
+    population: rows.length,
+    totalEvents,
+    completed,
+    // Declared alongside its denominator, never bare — see the module docblock.
+    eventsPerCompletion: completed > 0 ? totalEvents / completed : null,
+    repeatHolder: by('repeat_holder').sort((a, b) => b.repeatEvents - a.repeatEvents),
+    distinctHolders: by('distinct_holders').sort((a, b) => b.distinctHolders - a.distinctHolders),
+    mixed: by('mixed').sort((a, b) => b.events - a.events),
+  };
+}
+
+function emptyGauge(windowLabel, minEvents) {
+  return {
+    windowLabel, minEvents, population: 0, totalEvents: 0, completed: 0,
+    eventsPerCompletion: null, repeatHolder: [], distinctHolders: [], mixed: [],
+  };
+}
+
+/**
+ * One line, emitted UNCONDITIONALLY including every zero. A counter that appears only when non-zero
+ * renders measured-and-clean identically to not-measured — the ambiguity the sibling gauges exist to
+ * remove. The window is inside the string so a pasted figure carries its own denominator.
+ */
+function formatClaimBurnSummary(gauge) {
+  const ratio = gauge.eventsPerCompletion === null ? 'n/a' : gauge.eventsPerCompletion.toFixed(2);
+  return `CLAIM BURN (${gauge.windowLabel}, >=${gauge.minEvents} events): `
+    + `repeat_holder=${gauge.repeatHolder.length} distinct_holders=${gauge.distinctHolders.length} `
+    + `mixed=${gauge.mixed.length} | ${gauge.totalEvents} events / ${gauge.completed} completed `
+    + `= ${ratio} per completion`;
+}
+
+module.exports = {
+  classifyClaimBurn,
+  planClaimBurnGauge,
+  formatClaimBurnSummary,
+  DEFAULT_MIN_EVENTS,
+};

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -2212,6 +2212,33 @@ async function printStrandAgeGauge() {
   console.log('');
 }
 
+// QF-20260727-962: surface claim burn, split by WHO burned it. The two shapes are printed as
+// SEPARATE lines on purpose — one seat retaking one item is an idempotency failure, many seats
+// bouncing off is a dependency wall, and a single combined count sends the fix the wrong way.
+async function printClaimBurnGauge() {
+  const { planClaimBurnGauge, formatClaimBurnSummary } = require('../lib/coordinator/claim-burn-gauge.cjs');
+
+  console.log('CLAIM-BURN GAUGE');
+  console.log('─'.repeat(72));
+
+  const gauge = await planClaimBurnGauge(supabase);
+  console.log('  ' + formatClaimBurnSummary(gauge));
+
+  const section = (label, rows, detail) => {
+    console.log('  ' + label + ': ' + rows.length);
+    for (const r of rows.slice(0, 5)) console.log('    • ' + r.sd_key + ' — ' + detail(r) + ' [' + r.status + ']');
+  };
+  // Idempotency first: it is the larger half on the live table (189 vs 117 SDs measured 2026-07-28)
+  // and is the one an aggregate hides, since a single holder looks like a single claim.
+  section('REPEAT-HOLDER (one seat retaking — idempotency/resume)', gauge.repeatHolder,
+    (r) => r.events + ' events, ' + r.repeatEvents + ' repeats, 1 holder');
+  section('DISTINCT-HOLDER (seats bouncing off — dependency/spec wall)', gauge.distinctHolders,
+    (r) => r.events + ' events across ' + r.distinctHolders + ' holders');
+  section('MIXED', gauge.mixed,
+    (r) => r.events + ' events, ' + r.distinctHolders + ' holders, ' + r.repeatEvents + ' repeats');
+  console.log('');
+}
+
 // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-3: surface the
 // relay/decision/review drop gauge — mirrors printUndeliveredOutbound()'s shape. Read-only
 // + fail-open (planRelayDrops never throws).
@@ -2483,6 +2510,7 @@ async function main() {
     predictions:   async () => await printPredictions(d),
     drain:         () => printDrainAgents(d),
     strand:        async () => await printStrandAgeGauge(), // SD-LEO-INFRA-ADOPTED-RESUME-FINAL-001 (FR-2)
+    'claim-burn':  async () => await printClaimBurnGauge(), // QF-20260727-962
     inbox:         async () => {
       // SD-LEO-FIX-FLEET-WORKER-DIRECTIVE-001: the coordinator view is no longer the
       // unconditional default — a worker invoking the fallback gets ITS OWN inbox.

--- a/tests/unit/coordinator/claim-burn-gauge.test.js
+++ b/tests/unit/coordinator/claim-burn-gauge.test.js
@@ -1,0 +1,128 @@
+/**
+ * QF-20260727-962 — claim burn, split by WHO burned it.
+ *
+ * THE WHOLE POINT IS THE DISCRIMINATION. A claim_history-length gauge scores "one seat retaking one
+ * item thirteen times" identically to "thirteen workers bouncing off a dependency wall". Those are
+ * different defects with opposite fixes, so every assertion here is paired against its twin: same
+ * event count, different holder shape, different verdict.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const {
+  classifyClaimBurn, planClaimBurnGauge, formatClaimBurnSummary, DEFAULT_MIN_EVENTS,
+} = createRequire(import.meta.url)('../../../lib/coordinator/claim-burn-gauge.cjs');
+
+const ev = (id) => ({ claimed_at: '2026-07-25T19:17:09.241Z', session_id: id, identity_source: 'env' });
+const repeat = (n, id = 'sess-a') => Array.from({ length: n }, () => ev(id));
+const distinct = (n) => Array.from({ length: n }, (_, i) => ev(`sess-${i}`));
+
+describe('the two burn shapes are never collapsed', () => {
+  it('THE LIVE SPECIMEN — 13 events under ONE holder is repeat_holder, not a wall', () => {
+    // SD-LEO-INFRA-WORKER-INBOX-DRAIN-SUBSET-001 carries exactly this shape on the live table.
+    const r = classifyClaimBurn(repeat(13));
+    expect(r).toMatchObject({ events: 13, distinctHolders: 1, repeatEvents: 12, shape: 'repeat_holder' });
+  });
+
+  it('THE DISCRIMINATOR — the SAME event count with 13 distinct holders reports the other shape', () => {
+    // Identical length, opposite diagnosis. A length-only gauge cannot tell these apart, and this
+    // pair is what proves the split is real rather than decorative.
+    const wall = classifyClaimBurn(distinct(13));
+    const idem = classifyClaimBurn(repeat(13));
+    expect(wall).toMatchObject({ events: 13, distinctHolders: 13, repeatEvents: 0, shape: 'distinct_holders' });
+    expect(wall.events).toBe(idem.events);
+    expect(wall.shape).not.toBe(idem.shape);
+  });
+
+  it('a mix of both is named mixed rather than forced into one bucket', () => {
+    const r = classifyClaimBurn([...distinct(3), ev('sess-0'), ev('sess-0')]);
+    expect(r).toMatchObject({ events: 5, distinctHolders: 3, repeatEvents: 2, shape: 'mixed' });
+  });
+
+  it('degenerate input never reports negative burn and never throws', () => {
+    for (const bad of [null, undefined, 'x', [null, 3, {}], [{}, { session_id: '' }]]) {
+      const r = classifyClaimBurn(bad);
+      expect(r.repeatEvents).toBeGreaterThanOrEqual(0);
+      expect(r.distinctHolders).toBeGreaterThanOrEqual(0);
+    }
+    // Unattributable entries count as events but must not inflate the holder count.
+    expect(classifyClaimBurn([{}, {}])).toMatchObject({ events: 2, distinctHolders: 0, repeatEvents: 2 });
+  });
+});
+
+describe('SUSTAINED burn only — a single re-claim is ordinary life', () => {
+  it('one claim is not burn', () => {
+    expect(classifyClaimBurn(repeat(1)).shape).toBe('none');
+  });
+
+  it('NEGATIVE CONTROL — 840 of 1254 live SDs have exactly one claim, so the floor must exclude them', () => {
+    // Without a floor this gauge fires on the majority of the corpus and gets muted within a week,
+    // which is the failure mode the sibling gauges document.
+    expect(DEFAULT_MIN_EVENTS).toBeGreaterThan(2);
+    const twoClaims = classifyClaimBurn(repeat(2));
+    expect(twoClaims.shape).toBe('repeat_holder');       // classified…
+    expect(twoClaims.events).toBeLessThan(DEFAULT_MIN_EVENTS); // …but below the reporting floor
+  });
+});
+
+function fakeSb(rows) {
+  const builder = {
+    select: () => builder,
+    order: () => builder,
+    range: () => Promise.resolve({ data: rows, error: null }),
+    then: (res, rej) => Promise.resolve({ data: rows, error: null }).then(res, rej),
+  };
+  return { from: () => builder };
+}
+const sd = (key, status, history) => ({ sd_key: key, status, metadata: { claim_history: history } });
+
+describe('the gauge separates the signals and always declares its window', () => {
+  it('emits repeat and distinct as SEPARATE buckets, never one total', async () => {
+    const g = await planClaimBurnGauge(fakeSb([
+      sd('SD-IDEM-001', 'completed', repeat(13)),
+      sd('SD-WALL-001', 'in_progress', distinct(4)),
+      sd('SD-MIXED-001', 'completed', [...distinct(3), ev('sess-0')]),
+      sd('SD-QUIET-001', 'completed', repeat(1)),
+    ]), { minEvents: 3 });
+
+    expect(g.repeatHolder.map((r) => r.sd_key)).toEqual(['SD-IDEM-001']);
+    expect(g.distinctHolders.map((r) => r.sd_key)).toEqual(['SD-WALL-001']);
+    expect(g.mixed.map((r) => r.sd_key)).toEqual(['SD-MIXED-001']);
+    expect(g.population).toBe(4);
+    // The single-claim SD is counted in the totals but never reported as burn.
+    expect(g.totalEvents).toBe(13 + 4 + 4 + 1);
+  });
+
+  it('THE WINDOW RIDES ON THE SIGNAL — a bare ratio is unreproducible', async () => {
+    // The commissioning row quoted 3.30 events/completion; table-wide lifetime measures 0.50, and
+    // both are correct for their scope. A figure without its denominator cannot be falsified.
+    const g = await planClaimBurnGauge(fakeSb([sd('SD-A', 'completed', repeat(4))]), { minEvents: 3, windowLabel: '7d cohort' });
+    expect(g.windowLabel).toBe('7d cohort');
+    expect(g.eventsPerCompletion).toBe(4);
+    const line = formatClaimBurnSummary(g);
+    expect(line).toContain('7d cohort');
+    expect(line).toMatch(/4 events \/ 1 completed = 4\.00 per completion/);
+  });
+
+  it('counts print unconditionally, zeros included', async () => {
+    const g = await planClaimBurnGauge(fakeSb([sd('SD-A', 'completed', repeat(1))]), { minEvents: 3 });
+    const line = formatClaimBurnSummary(g);
+    expect(line).toContain('repeat_holder=0');
+    expect(line).toContain('distinct_holders=0');
+    expect(line).toContain('mixed=0');
+  });
+
+  it('no completions yields n/a rather than a fabricated ratio', async () => {
+    const g = await planClaimBurnGauge(fakeSb([sd('SD-A', 'in_progress', repeat(5))]), { minEvents: 3 });
+    expect(g.eventsPerCompletion).toBeNull();
+    expect(formatClaimBurnSummary(g)).toContain('= n/a per completion');
+  });
+
+  it('fails OPEN on a query fault — an empty gauge, never a thrown dashboard tick', async () => {
+    const broken = { from: () => { throw new Error('db down'); } };
+    const g = await planClaimBurnGauge(broken, { minEvents: 3 });
+    expect(g.population).toBe(0);
+    expect(g.repeatHolder).toEqual([]);
+    expect(formatClaimBurnSummary(g)).toContain('repeat_holder=0');
+  });
+});


### PR DESCRIPTION
## Summary

Claim burn was counted nowhere, so a few items each consuming many claims stayed invisible behind a healthy aggregate conversion rate.

**The split is the whole point.** A `claim_history`-length gauge scores *"one seat retaking one item thirteen times"* identically to *"thirteen workers bouncing off a dependency wall"*. Different defects, opposite fixes. So repeat-holder and distinct-holder burn are emitted as **separate signals**, never summed into one headline.

## Measured on the live table before building

Paginated, because the implicit PostgREST cap is 1000 and a single page would under-report the very population being measured:

| | |
|---|---|
| SD rows | 5449 |
| carrying `claim_history` | 1254 |
| claim events | 2109 |
| **REPEAT-HOLDER burn** | **189 SDs** |
| **DISTINCT-HOLDER burn** | **117 SDs** |
| mixed | 108 |
| repeat events invisible to a length-only gauge | **539** |

**The dominant defect is idempotency, not dependency walls** — the opposite of what the aggregate invites, and exactly what the commissioning row predicted a naive gauge would get wrong. The specimen is `SD-LEO-INFRA-WORKER-INBOX-DRAIN-SUBSET-001`: 13 events, **one** holder.

## The window rides on the signal

The commissioning row quoted **3.30** events per shipped item; table-wide lifetime measures **0.50** — 6.6x apart, and *both are correct for their scope* (that figure was a recent cohort). A burn ratio without its denominator stated is a number nobody can reproduce or falsify, so `windowLabel` is emitted inside the summary string itself.

**Sustained burn only:** 840 of 1254 SDs carrying history have exactly one claim. A gauge that fired on a single re-claim would flag ordinary life and be muted within a week.

## Wired to a consumer

`node scripts/fleet-dashboard.cjs claim-burn` prints the summary plus both shapes as separate sections — not a module nobody reads. Verified end-to-end against the live table: it reproduces the hand measurement exactly (2109 events / 4255 completed = 0.50), and `mixed=108` is identical at both the >1 and >=3 floors, which is a useful internal consistency check since a mixed row structurally requires at least 3 events.

## Test plan

11 tests, lint clean, 618 coordinator tests green (no regression).

**Mutation-verified**, each mutation confirmed on disk before its run:

| Mutation | Result |
|---|---|
| the two shapes collapse into one | KILLED (3 tests) |
| `repeatEvents = events` (holder count ignored) | KILLED (4) |
| sustained floor dropped to 1 | KILLED (1) |
| window dropped from the emitted summary | KILLED (1) |
| fabricates a `0` ratio instead of `n/a` | KILLED (1) |
| comment-only control | SURVIVED (as required) |

One further mutation (`rows = null` to `rows = []` on the fail-open path) also survived, and it is a genuine **equivalent mutant** rather than a coverage gap: both paths produce byte-identical output, so no test could distinguish them. Stated rather than papered over.

## Scope note — flagged, not hidden

This is **90 non-comment source lines against a Tier 2 ceiling of 75**.

I did **not** trim the dashboard wiring to fit. A gauge with no consumer is the exact defect class this campaign has been removing, and the SESSIONS-PAGE re-tier ruling was explicit that scope must not be dropped to fit a tier. Flagged here for the compliance rubric to rule on rather than resolved unilaterally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
