### PR TITLE
feat(SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001): record intended audience, so the RLS audit is decidable without guessing

### DIFF
--- a/database/migrations/20260728_anon_authenticated_audience_and_narrowing_STAGED.sql
+++ b/database/migrations/20260728_anon_authenticated_audience_and_narrowing_STAGED.sql
@@ -1,0 +1,97 @@
+-- SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001 — recorded audience + the third narrowing.
+--
+-- *** TIER-2. CHAIRMAN-GATED APPLY. DO NOT AUTO-APPLY. ***
+-- Contains DROP POLICY (a TIER-2 forbidden top-level verb per scripts/lib/migration-tier-classifier.mjs)
+-- and COMMENT ON TABLE (also TIER-2 — only COMMENT ON COLUMN is TIER-1-eligible). Both require the
+-- 3-factor chairman ceremony:
+--     node scripts/apply-migration.js <this-file> --prod-deploy
+-- after --issue-token, with an `-- @approved-by: <email>` attestation line appended by the ceremony.
+-- Do NOT route through scripts/run-sql-migration.js — that would execute it while bypassing the gate
+-- for an access-control change. isDelegatableForApply() refuses this file at code level regardless.
+--
+-- ── WHY THIS FILE EXISTS ──────────────────────────────────────────────────────────────────────
+-- Three tables carry a SELECT policy admitting a principal broader than service_role with no
+-- row-level predicate narrowing it to an intended audience. Two of them (switchon_auto_actions,
+-- switchon_decision_audit) are already handled by a SEPARATE, EARLIER staged file —
+--     database/migrations/20260718_switchon_rls_narrow_authenticated_read_STAGED.sql
+-- which narrows both to fn_is_chairman(). THIS FILE DOES NOT DUPLICATE IT. Verified at PLAN and
+-- again at EXEC: that file's DROP targets are still present live and still qual=true, so it will
+-- bite rather than silently no-op when applied.
+--
+-- What remains here is the THIRD instance plus the recorded-audience requirement for all three.
+--
+-- ── THE CRITERION, so this is decidable by whoever reads it next ──────────────────────────────
+-- Does the policy admit a principal broader than service_role WITHOUT a row-level predicate that
+-- narrows it to an intended audience?
+--   fn_is_chairman()                    -> narrows. A real predicate about the caller.
+--   auth.role() = 'authenticated'       -> DOES NOT narrow. It re-states the role the policy
+--                                          already grants to, which is a tautology wearing the
+--                                          shape of a check.
+--
+-- ── WHY research_intelligence_reference IS NOT SIMPLY REVOKED ─────────────────────────────────
+-- Its authenticated read is INTENTIONAL. It is a standing landscape reference — the versioned data
+-- product RESEARCH_INTELLIGENCE_OPERATOR maintains, whose entry_type discriminates rows consumed by
+-- Child B/C/D. Revoking authenticated read would break deliberate consumers. Narrowing it to
+-- fn_is_chairman(), as its two siblings get, would break them just as thoroughly.
+--
+-- So the fix is NOT to narrow the PRINCIPAL — for this table the broad principal is correct — but to
+--   (a) narrow the ROWS to the ones the audience actually needs, and
+--   (b) RECORD that the broad principal is intentional, so the next auditor does not have to infer
+--       it from the word "reference" in the table's name. Inferring audience from a name is the
+--       exact move that produced a wrong classification on this finding and was withdrawn.
+--
+-- ROW NARROWING CHOSEN: is_current = true. The table is versioned (version, is_current,
+-- superseded_by); consumers read the CURRENT landscape. Superseded revisions are history and have no
+-- audience beyond service_role. If a consumer is later found to need superseded rows, the audience
+-- statement below is where that decision gets recorded and this predicate revisited — that is the
+-- point of recording it rather than leaving it implicit.
+
+BEGIN;
+
+-- ── 1. The third instance: replace the role-restatement with a real row predicate ─────────────
+-- Old: USING (auth.role() = 'authenticated' OR auth.role() = 'service_role') on roles={public}.
+-- That admits every authenticated principal to every row INCLUDING superseded revisions, and its
+-- qual answers a question it already knew the answer to.
+DROP POLICY IF EXISTS research_intel_ref_read ON public.research_intelligence_reference;
+CREATE POLICY research_intel_ref_read ON public.research_intelligence_reference
+  FOR SELECT TO authenticated, service_role
+  USING (is_current = true OR auth.role() = 'service_role');
+
+-- ── 2. Recorded intended audience (FR-1) ──────────────────────────────────────────────────────
+-- Structured "Audience:" line appended to the existing prose. The convention: one line beginning
+-- `Audience:` naming WHO may read and WHY, so the audit is decidable without reading the policy or
+-- guessing from the table name. Machine-readable by the FR-4 verification query.
+COMMENT ON TABLE public.research_intelligence_reference IS
+  'Standing landscape reference (SD-LEO-INFRA-RESEARCH-INTELLIGENCE-OPERATOR-001-A): the versioned '
+  'data product the RESEARCH_INTELLIGENCE_OPERATOR maintains. entry_type discriminates tech/model-'
+  'landscape rows (Child B) from the rows consumed by Children C and D. '
+  'Audience: all authenticated fleet principals, CURRENT revisions only — this is a shared reference '
+  'data product and the broad read is INTENTIONAL, not an omitted REVOKE. Superseded revisions are '
+  'history and are service_role-only. Recorded per SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001 FR-1 '
+  'so this exemption is stated rather than inferred from the word "reference" in the table name.';
+
+COMMENT ON TABLE public.switchon_auto_actions IS
+  'PC-5 rate/soak log for op-co switch-on auto-proceeds (SD-LEO-INFRA-INTELLIGENT-SWITCH-AUTOMATION-001-C). '
+  'One row per auto-proceed decision; read by checkRateSoak() to enforce a per-component rate cap and '
+  'minimum soak spacing. '
+  'Audience: chairman only. Internal governance/automation history with no tenant or customer data and '
+  'no consumer outside the service role and chairman review. Narrowed to fn_is_chairman() by '
+  'database/migrations/20260718_switchon_rls_narrow_authenticated_read_STAGED.sql. Recorded per '
+  'SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001 FR-1.';
+
+COMMENT ON TABLE public.switchon_decision_audit IS
+  'CONST-003 audit stamp for every op-co switch-on decision (SD-LEO-INFRA-INTELLIGENT-SWITCH-AUTOMATION-001-C, '
+  'PC-7): actor, policy_version (chairman_switchon_policy state at decision time), and a full '
+  'evidence_snapshot. '
+  'Audience: chairman only. An audit trail of governance decisions; broad read would expose the '
+  'decision history of every component to any logged-in principal. Narrowed to fn_is_chairman() by '
+  'database/migrations/20260718_switchon_rls_narrow_authenticated_read_STAGED.sql. Recorded per '
+  'SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001 FR-1.';
+
+COMMIT;
+
+-- ── VERIFICATION, to be run AFTER the chairman applies this ───────────────────────────────────
+--   node scripts/audit/broad-policy-audience-audit.mjs
+-- Before apply it reports three tables lacking a narrowing predicate; after, zero. That query is the
+-- only way this SD's outcome becomes checkable, since the SD itself is forbidden from applying
+-- anything — see SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001 TR-1.

--- a/database/migrations/20260728_anon_authenticated_audience_and_narrowing_STAGED.sql
+++ b/database/migrations/20260728_anon_authenticated_audience_and_narrowing_STAGED.sql
@@ -45,6 +45,18 @@
 -- audience beyond service_role. If a consumer is later found to need superseded rows, the audience
 -- statement below is where that decision gets recorded and this predicate revisited — that is the
 -- point of recording it rather than leaving it implicit.
+--
+-- *** HONEST SCOPE OF WHAT THIS NARROWING BUYS (corrected after SECURITY review f3cdce33). ***
+-- This is DEFENCE IN DEPTH, not the closing of an active leak, and it should not be claimed as one:
+--   • Both real consumers ALREADY self-filter is_current=true at the application layer regardless
+--     of RLS — lib/eva/stage-zero/data-feed.js:79 and lib/eva/stage-zero/modeling.js:104.
+--   • The "Child D reads superseded rows" consumer described in the earlier draft of this comment
+--     DOES NOT EXIST IN CODE. lib/eva/cross-venture-learning.js:698-760 grades forecasts against
+--     actuals and never queries this table. I inferred that consumer rather than verifying it,
+--     which is the same move — reasoning about intent instead of measuring it — that this SD was
+--     written to stop. Removed rather than left standing.
+-- So the value here is that the boundary now holds in the DATABASE rather than only by the good
+-- behaviour of two callers. That is worth having; it is not an incident being closed.
 
 BEGIN;
 

--- a/lib/db/broad-policy-classifier.mjs
+++ b/lib/db/broad-policy-classifier.mjs
@@ -1,0 +1,104 @@
+/**
+ * broad-policy-classifier.mjs — SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001 (FR-3/FR-4).
+ *
+ * ONE classification function, shared by BOTH the migration-text lint (FR-3) and the live-database
+ * audit query (FR-4). They ask the same question of different inputs, so authoring two classifiers
+ * would let them drift — and the drift would be invisible, because each would look correct on its
+ * own. That is the failure this SD's sibling work keeps finding, so it is designed out here rather
+ * than warned about.
+ *
+ * THE CRITERION IS EXPOSURE SHAPE, NOT TABLE NAMING:
+ *   does the policy admit a principal broader than service_role WITHOUT a row-level predicate that
+ *   narrows it to an intended audience?
+ *
+ *   fn_is_chairman()                  -> NARROWS. A real predicate about the caller.
+ *   auth.uid() = user_id              -> NARROWS. Binds the row to the caller's identity.
+ *   is_current = true                 -> NARROWS. A row predicate, even though it says nothing
+ *                                        about the caller — it reduces what the audience can reach.
+ *   true                              -> DOES NOT narrow.
+ *   auth.role() = 'authenticated'     -> DOES NOT narrow. It RE-STATES the role the policy already
+ *                                        grants to: a tautology wearing the shape of a check. This
+ *                                        is the third shape, and the one the existing lint misses
+ *                                        because there is no tenant column whose binding to check.
+ *
+ * WHY THE RESTATEMENT CASE NEEDS CARE: matching on the substring `auth.role()` alone would flag a
+ * COMPOUND predicate like `auth.role() = 'authenticated' AND auth.uid() = user_id`, which genuinely
+ * narrows. The classifier must therefore decide whether ANY narrowing conjunct survives once the
+ * role-restatement terms are removed — not whether the string appears.
+ */
+
+/**
+ * Terms that re-state the granted role and therefore narrow nothing.
+ *
+ * THE `::text` CAST IS LOAD-BEARING, and it was found by a calibration check rather than by
+ * reasoning. pg_policies renders the live qual as `auth.role() = 'authenticated'::text`, not
+ * `auth.role() = 'authenticated'`. Without the optional cast in this pattern the role term was
+ * stripped but its trailing `::text` survived, that residue read as "a real predicate", and the
+ * classifier reported the one shape it was built to catch as SAFE.
+ *
+ * The instrument looked healthy while doing so — 472 findings, all four negative controls passing —
+ * which is exactly why the positive control (does it flag the KNOWN instance?) is not optional. A
+ * detector that only ever gets checked against things it should ignore cannot be shown to work.
+ */
+const ROLE_RESTATEMENT = /auth\.role\(\)\s*=\s*'(?:authenticated|anon|service_role)'(?:::text)?/gi;
+
+/**
+ * Does this qual contain a predicate that genuinely narrows what the audience can reach?
+ * Strips role-restatement terms first, then asks whether anything of substance remains.
+ * @param {string|null|undefined} qual the policy's USING expression
+ * @returns {boolean}
+ */
+export function hasNarrowingPredicate(qual) {
+  if (qual === null || qual === undefined) return false;
+  const raw = String(qual).trim();
+  if (raw === '' || raw.toLowerCase() === 'true') return false;
+
+  // Remove the tautological role terms, then the boolean scaffolding they were joined by.
+  let residue = raw.replace(ROLE_RESTATEMENT, ' ');
+  residue = residue.replace(/\b(?:OR|AND|NOT)\b/gi, ' ')
+    .replace(/\btrue\b/gi, ' ')
+    .replace(/[()\s]/g, '');
+
+  // Anything left is a real predicate: a function call, a column comparison, a literal test.
+  return residue.length > 0;
+}
+
+/**
+ * Classify one policy. Roles are compared as a set so `{public}` — which PostgREST resolves to
+ * anon+authenticated — is treated as broad, not as a name to be trusted.
+ * @param {{roles?: string|string[], cmd?: string, qual?: string|null}} policy
+ * @returns {{ broad: boolean, narrowed: boolean, violation: boolean, reason: string }}
+ */
+export function classifyPolicy(policy = {}) {
+  const roles = Array.isArray(policy.roles)
+    ? policy.roles
+    : String(policy.roles || '').replace(/[{}]/g, '').split(',').map(r => r.trim()).filter(Boolean);
+
+  const readCmd = ['SELECT', 'ALL'].includes(String(policy.cmd || 'SELECT').toUpperCase());
+  // service_role and postgres alone are not broad; anything else reaching rows is.
+  const broad = readCmd && roles.some(r => !['service_role', 'postgres'].includes(r));
+  const narrowed = hasNarrowingPredicate(policy.qual);
+
+  if (!readCmd) return { broad: false, narrowed, violation: false, reason: 'not a read policy' };
+  if (!broad) return { broad: false, narrowed, violation: false, reason: 'service_role/postgres only' };
+  if (narrowed) return { broad: true, narrowed: true, violation: false, reason: 'broad principal, but rows are narrowed' };
+  return {
+    broad: true, narrowed: false, violation: true,
+    reason: String(policy.qual || '').trim().toLowerCase() === 'true' || !policy.qual
+      ? 'admits a broad principal with no predicate at all (qual=true)'
+      : 'admits a broad principal; the qual only RE-STATES the granted role and narrows nothing',
+  };
+}
+
+/**
+ * Is an intended audience recorded for this table? FR-1's convention is a line beginning
+ * `Audience:` inside COMMENT ON TABLE — chosen because COMMENT ON TABLE is an existing habit here
+ * (~487 instances) rather than a new artifact class.
+ * @param {string|null|undefined} tableComment
+ * @returns {boolean}
+ */
+export function hasRecordedAudience(tableComment) {
+  return /(^|\s)Audience:\s*\S/.test(String(tableComment || ''));
+}
+
+export default { classifyPolicy, hasNarrowingPredicate, hasRecordedAudience };

--- a/lib/db/broad-policy-classifier.mjs
+++ b/lib/db/broad-policy-classifier.mjs
@@ -40,18 +40,62 @@
  * which is exactly why the positive control (does it flag the KNOWN instance?) is not optional. A
  * detector that only ever gets checked against things it should ignore cannot be shown to work.
  */
-const ROLE_RESTATEMENT = /auth\.role\(\)\s*=\s*'(?:authenticated|anon|service_role)'(?:::text)?/gi;
+// Cast suffix is GENERIC, not just ::text. SECURITY f3cdce33 showed that hardcoding ::text left
+// `auth.role() = 'authenticated'::name` (or any other cast) classified as narrowed — the same bug
+// as the original ::text miss, one cast away.
+const ROLE_RESTATEMENT = /auth\.role\(\)\s*=\s*'(?:authenticated|anon|service_role)'(?:::\w+)?/gi;
+
+/**
+ * Tautologies: expressions that are always true and therefore narrow nothing, but which survive
+ * naive residue-counting because they contain "real-looking" tokens.
+ *
+ * SECURITY f3cdce33 verified all of these against the SHIPPED function and every one was
+ * MISCLASSIFIED AS NARROWED: `1=1`, `'a'='a'`, `NOT false`, and `true OR fn_is_chairman()` — the
+ * last being the nastiest, because the disjunct makes the whole expression true while the
+ * fn_is_chairman() token makes it LOOK like the most narrowed policy in the schema.
+ *
+ * A FALSE NEGATIVE IS THE DANGEROUS DIRECTION HERE. This classifier's job is to prove policies are
+ * narrowed; marking a broad one "safe" removes it from the audit silently, which is the same
+ * failure mode as the defect the audit exists to find.
+ */
+const TAUTOLOGY = [
+  /^\s*\(*\s*true\s*\)*\s*$/i,                                  // true, (true), (((true)))
+  /^\s*\(*\s*NOT\s+false\s*\)*\s*$/i,                           // NOT false
+  /(\b\d+\s*=\s*\1\b)/,                                         // 1=1, 42=42
+  /'([^']*)'(?:::\w+)?\s*=\s*'\1'(?:::\w+)?/,                   // 'a'='a'
+];
+
+/** Strip SQL comments so a `--` inside a USING clause cannot hide a tautology (SECURITY f3cdce33). */
+function stripSqlComments(text) {
+  return String(text)
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/--[^\n]*/g, ' ');
+}
 
 /**
  * Does this qual contain a predicate that genuinely narrows what the audience can reach?
- * Strips role-restatement terms first, then asks whether anything of substance remains.
+ *
+ * Strategy: strip comments, reject outright tautologies, remove role-restatement terms, then ask
+ * whether anything of substance remains. Deliberately CONSERVATIVE — when in doubt it reports NOT
+ * narrowed, because over-reporting costs a reviewer a glance while under-reporting hides a broad
+ * policy from the audit entirely.
+ *
  * @param {string|null|undefined} qual the policy's USING expression
  * @returns {boolean}
  */
 export function hasNarrowingPredicate(qual) {
   if (qual === null || qual === undefined) return false;
-  const raw = String(qual).trim();
-  if (raw === '' || raw.toLowerCase() === 'true') return false;
+  const raw = stripSqlComments(String(qual)).trim();
+  if (raw === '') return false;
+
+  // Whole-expression tautologies narrow nothing regardless of what tokens they contain.
+  if (TAUTOLOGY.some(re => re.test(raw))) return false;
+
+  // A top-level `true OR <anything>` is true for every row: the other disjunct is decoration.
+  // Checked BEFORE residue-counting, because that disjunct is usually a real-looking function
+  // call and would otherwise be counted as the narrowing this expression does not do.
+  const unwrapped = raw.replace(/^\s*\(+|\)+\s*$/g, '');
+  if (/(^|\bOR\s+)\(*\s*true\s*\)*(\s+OR\b|$)/i.test(unwrapped)) return false;
 
   // Remove the tautological role terms, then the boolean scaffolding they were joined by.
   let residue = raw.replace(ROLE_RESTATEMENT, ' ');

--- a/scripts/audit/broad-policy-audience-audit.mjs
+++ b/scripts/audit/broad-policy-audience-audit.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+/**
+ * broad-policy-audience-audit.mjs — SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001 (FR-4).
+ *
+ * READ-ONLY. Enumerates every table whose policies admit a principal broader than service_role
+ * WITHOUT a row-level narrowing predicate, and reports whether each carries a recorded audience.
+ *
+ * This is what makes FR-1's rule decidable by whoever reads it next, rather than by whoever
+ * remembers the convention. It is ALSO the only way this SD's outcome becomes checkable at all:
+ * the SD is forbidden from applying anything (chairman-only, non-delegable per TR-1), so the
+ * proof that the fix worked is this query returning zero AFTER the chairman applies the staged
+ * migrations — not anything the SD itself can demonstrate.
+ *
+ * Classification is delegated to lib/db/broad-policy-classifier.mjs, shared with the FR-3 lint, so
+ * the two instruments cannot drift apart while each continues to look correct alone.
+ *
+ *   node scripts/audit/broad-policy-audience-audit.mjs           # report
+ *   node scripts/audit/broad-policy-audience-audit.mjs --json    # machine-readable
+ */
+import 'dotenv/config';
+import pg from 'pg';
+import { classifyPolicy, hasRecordedAudience } from '../../lib/db/broad-policy-classifier.mjs';
+
+export async function auditBroadPolicies(client) {
+  const { rows: policies } = await client.query(`
+    SELECT p.tablename, p.policyname, p.roles::text AS roles, p.cmd, p.qual,
+           obj_description(('public.'||p.tablename)::regclass) AS table_comment
+      FROM pg_policies p
+     WHERE p.schemaname = 'public'
+     ORDER BY p.tablename, p.policyname
+  `);
+
+  const findings = [];
+  for (const p of policies) {
+    const verdict = classifyPolicy(p);
+    if (!verdict.violation) continue;
+    findings.push({
+      table: p.tablename,
+      policy: p.policyname,
+      roles: p.roles,
+      cmd: p.cmd,
+      qual: p.qual === null ? 'TRUE' : p.qual,
+      reason: verdict.reason,
+      has_recorded_audience: hasRecordedAudience(p.table_comment),
+    });
+  }
+  return findings;
+}
+
+async function main() {
+  const json = process.argv.includes('--json');
+  const client = new pg.Client({
+    connectionString: process.env.SUPABASE_POOLER_URL || process.env.DATABASE_URL || process.env.SUPABASE_DB_URL,
+    ssl: { rejectUnauthorized: false },
+  });
+  await client.connect();
+  const findings = await auditBroadPolicies(client);
+  await client.end();
+
+  if (json) { console.log(JSON.stringify({ count: findings.length, findings }, null, 2)); return; }
+
+  console.log(`[BROAD-POLICY-AUDIT] ${findings.length} policy/policies admit a principal broader than service_role with no narrowing predicate.`);
+  if (!findings.length) {
+    console.log('  None. Every broad read policy narrows its rows, or is service_role-only.');
+    return;
+  }
+  // Two separable columns on purpose: the exposure shape and whether the intent was RECORDED are
+  // different facts. A table can legitimately have a broad audience — what it cannot have is an
+  // UNSTATED one, because an unstated exception is how a convention erodes one case at a time.
+  for (const f of findings) {
+    console.log(`   • ${f.table}.${f.policy}  roles=${f.roles} cmd=${f.cmd}`);
+    console.log(`       qual: ${String(f.qual).slice(0, 100)}`);
+    console.log(`       why:  ${f.reason}`);
+    console.log(`       audience recorded: ${f.has_recorded_audience ? 'YES' : 'NO  <-- undecidable without guessing intent'}`);
+  }
+  const unrecorded = findings.filter(f => !f.has_recorded_audience).length;
+  console.log('');
+  console.log(`  ${unrecorded} of ${findings.length} lack a recorded audience. That count is the gauge — if it grows, the convention is eroding.`);
+}
+
+if (process.argv[1] && /broad-policy-audience-audit\.mjs$/.test(process.argv[1].replace(/\\/g, '/'))) {
+  main().catch(e => { console.error('audit failed:', e.message); process.exit(1); });
+}

--- a/scripts/lint/rls-anon-tenant-predicate-lint.mjs
+++ b/scripts/lint/rls-anon-tenant-predicate-lint.mjs
@@ -45,6 +45,10 @@ import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
 import { fileURLToPath, pathToFileURL } from 'url';
+// SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001 FR-3: ONE classifier, shared with the FR-4 live
+// audit (scripts/audit/broad-policy-audience-audit.mjs). Two separately-authored predicate
+// classifiers would drift, and the drift would be invisible because each would look correct alone.
+import { hasNarrowingPredicate } from '../../lib/db/broad-policy-classifier.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -170,6 +174,18 @@ export function classifyViolation(policy) {
   if (!policy.using) return null;
   if (BLANKET_TRUE_RE.test(policy.using)) return 'unconditional_anon_select';
   if (TENANT_COLUMN_RE.test(policy.using) && !IDENTITY_BOUND_RE.test(policy.using)) return 'unbound_tenant_predicate';
+  // SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001 FR-3 — THE THIRD SHAPE.
+  //
+  // A qual that merely RE-STATES the role it already grants to:
+  //     USING (auth.role() = 'authenticated' OR auth.role() = 'service_role')
+  // narrows nothing — it is a tautology wearing the shape of a check. Neither branch above sees
+  // it: it is not literally `true`, and there is no tenant column whose binding could be tested.
+  // Live instance: research_intelligence_reference.
+  //
+  // Delegated to lib/db/broad-policy-classifier.mjs, which the FR-4 live-database audit also
+  // uses. Two separately-authored classifiers would drift, and the drift would be INVISIBLE
+  // because each would look correct on its own — so there is deliberately only one.
+  if (!hasNarrowingPredicate(policy.using)) return 'role_restatement_no_predicate';
   return null;
 }
 
@@ -182,6 +198,9 @@ const scopedRoleLabel = (p) => {
 };
 
 const VIOLATION_MESSAGES = {
+  role_restatement_no_predicate: (p) =>
+    `${scopedRoleLabel(p)}-role SELECT policy '${p.name}' ON ${p.table} has a USING clause that only RE-STATES the role it already grants to (e.g. auth.role() = 'authenticated') -- a tautology, not a narrowing predicate, so any matching-role caller can read ALL rows. Narrow the rows, or record the intended audience per SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001 FR-1. Live instance: research_intelligence_reference.`,
+
   unconditional_anon_select: (p) =>
     `${scopedRoleLabel(p)}-role SELECT policy '${p.name}' ON ${p.table} has an unconditional USING (true) -- any ${scopedRoleLabel(p) === 'anon' ? 'anon-key holder' : 'matching-role caller'} can read ALL rows. See SD-LEO-GEN-SCOPE-ANON-KEY-001 (companies table) and SD-FDBK-FIX-FEEDBACK-SELECT-FEEDBACK-001 (feedback table, authenticated) for prior real instances of this class.`,
   unbound_tenant_predicate: (p) =>

--- a/tests/unit/db/broad-policy-classifier.test.js
+++ b/tests/unit/db/broad-policy-classifier.test.js
@@ -94,3 +94,38 @@ describe('hasRecordedAudience — FR-1s convention', () => {
     expect(hasRecordedAudience(null)).toBe(false);
   });
 });
+
+describe('SECURITY f3cdce33 attack suite — false negatives are the DANGEROUS direction', () => {
+  // Every one of these was verified LIVE against the shipped function and MISCLASSIFIED AS
+  // NARROWED. A false negative marks a broad policy "safe" and removes it from the audit
+  // silently -- the same failure mode as the defect the audit exists to find.
+  const attacks = [
+    ['1=1', 'numeric tautology'],
+    ["'a'='a'", 'string tautology'],
+    ['NOT false', 'negated-false tautology'],
+    ['true OR fn_is_chairman()', 'true-disjunct wearing a narrowing token'],
+    ["auth.role() = 'authenticated'::name", 'a cast other than ::text'],
+    ["auth.role() = 'authenticated' -- fn_is_chairman()", 'SQL comment hiding the tautology'],
+    ['/* fn_is_chairman() */ true', 'block comment hiding the tautology'],
+  ];
+  for (const [qual, label] of attacks) {
+    it(`does NOT accept ${label} as narrowing`, () => {
+      expect(hasNarrowingPredicate(qual)).toBe(false);
+    });
+  }
+
+  // The other half. A classifier that rejects everything would pass every test above and be
+  // useless -- these are what prove it still discriminates after the hardening.
+  const genuine = [
+    ['fn_is_chairman()', 'a real caller predicate'],
+    ['auth.uid() = user_id', 'identity binding'],
+    ['is_current = true', 'a row predicate'],
+    ["auth.role() = 'authenticated' AND auth.uid() = user_id", 'compound with a real conjunct'],
+    ['tenant_id = auth.uid() OR fn_is_chairman()', 'disjunction of two real predicates'],
+  ];
+  for (const [qual, label] of genuine) {
+    it(`still accepts ${label}`, () => {
+      expect(hasNarrowingPredicate(qual)).toBe(true);
+    });
+  }
+});

--- a/tests/unit/db/broad-policy-classifier.test.js
+++ b/tests/unit/db/broad-policy-classifier.test.js
@@ -1,0 +1,96 @@
+/**
+ * SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001 — the shared classifier (FR-3 + FR-4).
+ *
+ * ONE classifier serves both the migration-text lint and the live-database audit, so this suite is
+ * where the shared contract is pinned. Two separately-authored classifiers would drift, and the
+ * drift would be invisible because each would look correct alone.
+ *
+ * THE ::text CASE IS NOT DECORATION. It is a regression pin for a bug this SD actually shipped and
+ * then caught: pg_policies renders the live qual as `auth.role() = 'authenticated'::text`, my first
+ * pattern omitted the optional cast, the role term got stripped while its trailing `::text`
+ * survived, and that residue read as "a real predicate" — so the classifier reported the ONE SHAPE
+ * IT WAS BUILT TO CATCH as safe. It looked healthy doing it: 472 findings, all four negative
+ * controls passing. Only the POSITIVE control exposed it.
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyPolicy, hasNarrowingPredicate, hasRecordedAudience } from '../../../lib/db/broad-policy-classifier.mjs';
+
+describe('hasNarrowingPredicate — does the qual actually reduce what the audience reaches?', () => {
+  it('NO for the shapes that narrow nothing', () => {
+    expect(hasNarrowingPredicate('true')).toBe(false);
+    expect(hasNarrowingPredicate('TRUE')).toBe(false);
+    expect(hasNarrowingPredicate(null)).toBe(false);
+    expect(hasNarrowingPredicate('')).toBe(false);
+    expect(hasNarrowingPredicate("auth.role() = 'authenticated'")).toBe(false);
+    expect(hasNarrowingPredicate("auth.role() = 'authenticated' OR auth.role() = 'service_role'")).toBe(false);
+  });
+
+  it('NO for the ::text-cast rendering — the regression pin', () => {
+    // This is verbatim what pg_policies returns for research_intelligence_reference. The version
+    // WITHOUT the cast already passed above; only this one caught the bug.
+    expect(hasNarrowingPredicate("((auth.role() = 'authenticated'::text) OR (auth.role() = 'service_role'::text))")).toBe(false);
+  });
+
+  it('YES for predicates that genuinely narrow', () => {
+    expect(hasNarrowingPredicate('fn_is_chairman()')).toBe(true);
+    expect(hasNarrowingPredicate('auth.uid() = user_id')).toBe(true);
+    expect(hasNarrowingPredicate('is_current = true')).toBe(true);
+  });
+
+  it('YES for a COMPOUND predicate that also mentions the role', () => {
+    // The control that a substring match on auth.role() fails. Stripping the role term must leave
+    // the real conjunct behind, not swallow it.
+    expect(hasNarrowingPredicate("auth.role() = 'authenticated' AND auth.uid() = user_id")).toBe(true);
+    expect(hasNarrowingPredicate("(auth.role() = 'authenticated'::text) AND (is_current = true)")).toBe(true);
+  });
+});
+
+describe('classifyPolicy — broad principal AND no narrowing = violation', () => {
+  const p = (over = {}) => ({ roles: '{authenticated}', cmd: 'SELECT', qual: 'true', ...over });
+
+  it('flags a broad read with no predicate', () => {
+    expect(classifyPolicy(p()).violation).toBe(true);
+  });
+
+  it('flags the role-restatement shape and NAMES it distinctly from qual=true', () => {
+    const v = classifyPolicy(p({ qual: "auth.role() = 'authenticated'::text" }));
+    expect(v.violation).toBe(true);
+    // The two diagnoses are different and collapsing them would lose the distinction that makes
+    // this shape worth a separate lint branch.
+    expect(v.reason).toMatch(/RE-STATES/);
+    expect(classifyPolicy(p()).reason).toMatch(/no predicate at all/);
+  });
+
+  it('does NOT flag a service_role-only policy', () => {
+    expect(classifyPolicy(p({ roles: '{service_role}' })).violation).toBe(false);
+  });
+
+  it('does NOT flag a broad principal whose rows ARE narrowed', () => {
+    expect(classifyPolicy(p({ qual: 'fn_is_chairman()' })).violation).toBe(false);
+    expect(classifyPolicy(p({ qual: 'is_current = true' })).violation).toBe(false);
+  });
+
+  it('treats {public} as broad — the role name is not to be trusted', () => {
+    // PostgREST resolves public to anon+authenticated; taking the label at face value is the
+    // same class of error as inferring a table's audience from its name.
+    expect(classifyPolicy(p({ roles: '{public}' })).violation).toBe(true);
+  });
+
+  it('ignores write-only policies — this is a read-confidentiality check', () => {
+    expect(classifyPolicy(p({ cmd: 'INSERT' })).violation).toBe(false);
+  });
+});
+
+describe('hasRecordedAudience — FR-1s convention', () => {
+  it('detects the structured Audience: line', () => {
+    expect(hasRecordedAudience('Some prose. Audience: chairman only. More prose.')).toBe(true);
+  });
+
+  it('is NOT satisfied by prose that merely discusses an audience', () => {
+    // The point of a structured line is that it can be found mechanically. Prose about who reads
+    // the table is exactly the informal state this SD is replacing.
+    expect(hasRecordedAudience('Read by checkRateSoak() to enforce a rate cap.')).toBe(false);
+    expect(hasRecordedAudience('Audience:')).toBe(false); // present but empty states nothing
+    expect(hasRecordedAudience(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
## What this is

Three tables carry a SELECT policy admitting any authenticated principal to every row with no narrowing predicate. **All three hold zero rows** — latent, not a live leak, and the cheapest possible moment to fix: the policy is wrong before the data arrives.

> **Nothing here is applied.** Permission changes are chairman-only and non-delegable; `isDelegatableForApply()` refuses these files at code level. This PR ends at **staged, dry-run-clean migrations plus a verification query**.

## The deliverable is a rule, not a classification

The ask was *not* "classify these three tables." Intended audience is recorded nowhere — not in the migration, not in a comment, not in the SD that created the table — so any classification would be someone **guessing intent**. That guess already failed twice on this finding, in opposite directions: one reader inferred "reference means public" from a table's *name*, and thirty authors omitted a REVOKE.

So every table with a broader-than-`service_role` policy must carry a **recorded audience statement**. Then the audit is decidable by anyone, and no exception can be silent.

## Three instances, three different answers

| table | treatment |
|---|---|
| `switchon_auto_actions`, `switchon_decision_audit` | **already authored** — an unapplied staged file exists; referenced, not duplicated |
| `research_intelligence_reference` | **narrowed by row, not principal** — its authenticated read is intentional |

That last one matters. Revoking it, or narrowing it to `fn_is_chairman()` like its siblings, would break deliberate consumers. For that table the broad principal is *correct*; what was wrong is that it reached superseded revisions through a qual that only restated the role it already granted to.

## Two defects of mine, found by review

**My classifier reported the one shape it was built to catch as safe.** `pg_policies` renders the qual with a `::text` cast my pattern didn't strip. It looked healthy doing it — 472 findings, all four negative controls passing. Only the *positive* control found it. A detector checked solely against things it should ignore cannot be shown to work.

**Then SECURITY got through six more ways**: `1=1`, `'a'='a'`, `NOT false`, `true OR fn_is_chairman()`, a `::name` cast, and a `--` comment hiding the tautology. All verified live; all misclassified as narrowed. The `::name` one stings — I'd just fixed `::text` and hardcoded the single cast I'd seen. All six are now pinned as tests, alongside five genuine-narrowing cases, because a classifier that rejected everything would pass all six and be useless.

**I also withdrew an overclaim.** My migration comment cited a consumer that doesn't exist in code. I inferred it rather than measuring it — the same move this SD exists to stop. The comment now states the honest scope: both real consumers already self-filter at the app layer, so this is **defence in depth, not an incident being closed**.

## Verification

154/154 green. The audit is calibrated in **both** directions — the three known instances present, four properly-gated tables absent (and confirmed to genuinely exist, not merely be missing from the result). The staged migration was dry-run parsed inside `BEGIN…ROLLBACK` and confirmed **not applied**: the old qual is still live.

FR-3's lint and FR-4's audit share **one** classifier, because two would drift while each looked correct alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)