### PR TITLE
SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A: TRUE HIDE backend — SW_HIDE/SW_SHOW, durable visibility truth, refusal guards

### DIFF
--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -48,7 +48,8 @@ import {
   loadLiveSessionIdentity,
 } from './session-registry-adapter.js';
 import { resolveSpawnDecisions } from './spawn-executor-core.cjs';
-import { captureNewWindowHandle, enumerateWindows, focusWindow } from './window-handle.js';
+import { captureNewWindowHandle, enumerateWindows, focusWindow, setWindowVisibility } from './window-handle.js';
+import { classifyHideRefusal, readWindowOwner, setWindowVisible } from './window-visibility-writer.js';
 import { evaluateClaimBoundary } from './claim-boundary-probe.cjs';
 
 
@@ -574,6 +575,61 @@ export async function attach(target, opts = {}) {
   const focused = await focusWindow(handle, opts);
   await emitVerbEvent(supabase, { verb: 'attach', session_id, outcome: focused ? 'ok' : 'stale_handle' });
   return { ok: focused, reason: focused ? null : 'stale_handle', session_id };
+}
+
+/**
+ * SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A FR-4 — hide/show a session's window.
+ *
+ * NOT MODELLED ON attach() ABOVE, deliberately. attach reports ok from focusWindow, which returns
+ * true whenever the PowerShell process resolves — it never inspects SetForegroundWindow's return.
+ * That is tolerable for focus (a no-op if it fails) and NOT tolerable for hide: a wrongly-reported
+ * hide leaves an invisible window with no affordance to recover it except the FR-7 sweep. So this
+ * verb believes only `achieved`, which setWindowVisibility derives from an IsWindowVisible reading
+ * taken AFTER the act.
+ *
+ * REFUSE BEFORE ACTING. classifyHideRefusal enumerates the three handle-less shapes plus an
+ * incomplete owner identity; any of them refuses with a named reason and writes NOTHING. Hiding what
+ * cannot be proven restorable is the one outcome with no cheap undo.
+ *
+ * PERSIST ONLY WHAT HAPPENED. window_visible is written after a verified flip, never before it, so
+ * the row cannot claim a hide that did not occur — which is the operator-truth defect this SD exists
+ * to close, in its most embarrassing form.
+ */
+export async function setSessionWindowVisibility(target, opts = {}) {
+  const supabase = opts.supabaseClient;
+  const show = Boolean(opts.show);
+  const verb = show ? 'window_show' : 'window_hide';
+  const by = opts.by || 'callsign';
+  const resolution = await resolveLiveSession(supabase, { by, value: target });
+  if (!resolution.resolved) {
+    await emitVerbEvent(supabase, { verb, outcome: `not_resolved:${resolution.reason}` });
+    return { ok: false, reason: resolution.reason };
+  }
+  const { session_id } = resolution.identity;
+  const { data: row } = await supabase.from('claude_sessions').select('metadata').eq('session_id', session_id).maybeSingle();
+  const metadata = (row && row.metadata) || {};
+
+  // Hiding needs proof of restorability; showing does not (it can only make things visible), but a
+  // show still needs a handle and an owner to target, so both go through the same classifier.
+  const refusal = classifyHideRefusal(metadata);
+  if (refusal) {
+    await emitVerbEvent(supabase, { verb, session_id, outcome: `refused:${refusal}` });
+    return { ok: false, refused: true, reason: refusal, session_id };
+  }
+
+  const result = await setWindowVisibility(metadata.window_handle, {
+    show,
+    owner: readWindowOwner(metadata),
+    ...(opts.execFn ? { execFn: opts.execFn } : {}),
+  });
+  if (!result.achieved) {
+    await emitVerbEvent(supabase, { verb, session_id, outcome: `not_achieved:${result.reason || 'unverified'}` });
+    return { ok: false, refused: Boolean(result.refused), reason: result.reason || 'not_achieved', session_id };
+  }
+
+  const written = await setWindowVisible(session_id, { visible: show, by: opts.actor || 'fleet-api' }, opts);
+  await emitVerbEvent(supabase, { verb, session_id, outcome: written.written ? 'ok' : 'ok_unpersisted' });
+  return { ok: true, session_id, visible: show, persisted: Boolean(written.written) };
 }
 
 /**

--- a/lib/fleet/spawn-control.js
+++ b/lib/fleet/spawn-control.js
@@ -487,6 +487,25 @@ export async function spawn({ role, callsign, accountProfile } = {}, opts = {}) 
               ...(current.metadata || {}),
               window_handle: handleResult.handle,
               handle_capture_failed: handleResult.handleCaptureFailed,
+              // SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A FR-2 — PERSIST OWNER IDENTITY AT CAPTURE.
+              //
+              // WITHOUT THIS THE WHOLE HIDE FEATURE IS INERT, and inert in a way unit tests cannot
+              // see: classifyHideRefusal refuses with window_owner_identity_incomplete whenever the
+              // owner is missing, so every hide against every real session would have been refused
+              // while 60/60 tests passed. Caught by TESTING and SECURITY independently at EXEC —
+              // setWindowOwner had zero production callers. A mechanism with no producer is the
+              // same defect class as one with no consumer, and a test IS a consumer, which is
+              // exactly why the suite stayed green.
+              //
+              // window_owner_pid IS NEVER A KILL TARGET — it is the SHARED WindowsTerminal host
+              // (measured: 9 seats, ONE owning pid), so taskkill on it is a nine-seat outage. The
+              // per-seat process is claude_sessions.pid. See lib/fleet/window-visibility-writer.js.
+              ...(handleResult.owner ? {
+                window_owner_pid: handleResult.owner.pid,
+                window_owner_proc: handleResult.owner.procName,
+                window_owner_start_ticks: handleResult.owner.startTicks,
+                window_owner_captured_at: new Date().toISOString(),
+              } : {}),
               // FR-4: persist the DIAGNOSIS on failure so the one permitted live run yields an answer
               // (nothing opened / filtered everything out / too many opened) instead of a bare retry.
               ...(handleResult.handleCaptureFailed && handleResult.diagnostics

--- a/lib/fleet/window-handle.js
+++ b/lib/fleet/window-handle.js
@@ -316,6 +316,14 @@ export function buildFocusCommand(handle) {
 /**
  * Focus a previously-captured window handle (FR-3 attach). Never throws -- a stale/invalid handle
  * (window closed) returns false so the caller reports a clear degraded state instead of guessing.
+ *
+ * READ THIS BEFORE COPYING IT FOR HIDE/SHOW -- IT IS WEAKER THAN IT LOOKS, and
+ * SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A's spine originally leaned on it as a safety precedent.
+ * `true` here means "the PowerShell process did not throw", NOT "the window was focused":
+ * buildFocusCommand never inspects SetForegroundWindow's boolean return, and against a stale HWND
+ * that call returns FALSE without throwing, so this resolves and reports success. The one test
+ * covering it injects a mock rejection, which proves the process-failure path and never real Win32
+ * behaviour. setWindowVisibility below deliberately does NOT follow this pattern.
  */
 export async function focusWindow(handle, opts = {}) {
   const { execFn = defaultExec } = opts;
@@ -326,4 +334,114 @@ export async function focusWindow(handle, opts = {}) {
   } catch {
     return false;
   }
+}
+
+/** ShowWindow nCmdShow codes. Only the two we use -- SW_MINIMIZE is the control, never a target. */
+export const SW_HIDE = 0;
+export const SW_SHOW = 5;
+
+/** Parsed from the single invocation below. `RESULT|<status>|<reason>|<visibleAfter>`. */
+export const VISIBILITY_RESULT_PREFIX = 'RESULT|';
+
+/**
+ * Build the verify-AND-act visibility command -- SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A FR-1/FR-2.
+ *
+ * ONE INVOCATION, AND THAT IS THE SAFETY PROPERTY. Validating the owner in one execFile and calling
+ * ShowWindow in a second leaves a TOCTOU window of PowerShell startup plus Add-Type C# compilation
+ * -- measured in this repo at ~4.9s. Inside one invocation it is microseconds. Atomicity dominates
+ * the CONTENT of the check, so the check and the act must never be split for readability.
+ *
+ * THREE CONJUNCTS, because owning-pid alone has ZERO discriminating power here. Measured on this
+ * host: all 9 visible WindowsTerminal windows share EXACTLY ONE owning pid, while 9 cmd windows had
+ * 9 distinct pids -- the shared host is a terminal-architecture property, not a general Windows one.
+ * A pid-equality guard therefore PASSES in precisely the recycled-handle case it exists to catch.
+ * Process START TIME is what defeats pid recycling; name and pid alone do not.
+ *
+ * IsWindow(h) IS DELIBERATELY NOT USED. It returns TRUE for a recycled handle, so it passes in
+ * exactly the case the guard exists to catch -- and it is the primitive a builder reaches for first.
+ *
+ * SW_HIDE IS DESTRUCTIVE IN A WAY SW_SHOW AND FOCUS ARE NOT: a wrongly-hidden window belonging to
+ * the operator has no affordance anywhere to bring it back except the unfiltered restore sweep.
+ * Hence refuse-by-default: any conjunct that cannot be positively confirmed refuses.
+ */
+export function buildSetVisibilityCommand({ handle, show, ownerPid, ownerProcName, ownerStartTicks }) {
+  const h = Number(handle);
+  if (!Number.isFinite(h) || h === 0) throw new Error(`buildSetVisibilityCommand: invalid handle: ${JSON.stringify(handle)}`);
+  const pid = Number(ownerPid);
+  if (!Number.isInteger(pid) || pid <= 0) throw new Error(`buildSetVisibilityCommand: invalid ownerPid: ${JSON.stringify(ownerPid)}`);
+  const ticks = String(ownerStartTicks ?? '');
+  if (!/^\d+$/.test(ticks)) throw new Error(`buildSetVisibilityCommand: invalid ownerStartTicks: ${JSON.stringify(ownerStartTicks)}`);
+  const name = String(ownerProcName ?? '');
+  // Process names are [A-Za-z0-9._-]; anything else is refused here rather than interpolated, so the
+  // command keeps the zero-injection-surface property the enumeration command documents above.
+  if (!/^[\w.-]+$/.test(name)) throw new Error(`buildSetVisibilityCommand: invalid ownerProcName: ${JSON.stringify(ownerProcName)}`);
+  const sw = show ? SW_SHOW : SW_HIDE;
+
+  const typeDef = 'using System;using System.Runtime.InteropServices;public class FleetVis{'
+    + '[DllImport("user32.dll")]public static extern bool ShowWindow(IntPtr h,int c);'
+    + '[DllImport("user32.dll")]public static extern bool IsWindowVisible(IntPtr h);'
+    + '[DllImport("user32.dll")]public static extern uint GetWindowThreadProcessId(IntPtr h,out uint p);'
+    + 'public static uint Owner(IntPtr h){uint p;GetWindowThreadProcessId(h,out p);return p;}}';
+
+  const script = [
+    `Add-Type -TypeDefinition '${typeDef}'`,
+    `$h=[IntPtr]${h}`,
+    '$op=[FleetVis]::Owner($h)',
+    // Owner 0 means the handle no longer resolves to a window at all.
+    `if($op -eq 0){Write-Output '${VISIBILITY_RESULT_PREFIX}refused|handle_not_a_window|'; exit 0}`,
+    `if($op -ne ${pid}){Write-Output '${VISIBILITY_RESULT_PREFIX}refused|owner_pid_mismatch|'; exit 0}`,
+    '$p=Get-Process -Id $op -ErrorAction SilentlyContinue',
+    `if(-not $p){Write-Output '${VISIBILITY_RESULT_PREFIX}refused|owner_process_gone|'; exit 0}`,
+    `if($p.ProcessName -ne '${name}'){Write-Output '${VISIBILITY_RESULT_PREFIX}refused|owner_proc_name_mismatch|'; exit 0}`,
+    // START TIME is the conjunct that actually defeats pid recycling.
+    `if([string]$p.StartTime.Ticks -ne '${ticks}'){Write-Output '${VISIBILITY_RESULT_PREFIX}refused|owner_start_time_mismatch|'; exit 0}`,
+    `[void][FleetVis]::ShowWindow($h,${sw})`,
+    // The OUTCOME is read from the world AFTER the act -- never inferred from "no exception".
+    '$vis=[FleetVis]::IsWindowVisible($h)',
+    `Write-Output ('${VISIBILITY_RESULT_PREFIX}ok||' + $vis)`,
+  ].join('; ');
+
+  return { program: 'powershell', args: ['-NoProfile', '-NonInteractive', '-Command', script] };
+}
+
+/** Parse the single RESULT line. Pure, so the contract is testable without PowerShell. */
+export function parseVisibilityResult(stdout) {
+  const line = String(stdout || '').split(/\r?\n/).find((l) => l.startsWith(VISIBILITY_RESULT_PREFIX));
+  if (!line) return { ok: false, refused: false, reason: 'unparseable_output', visibleAfter: null };
+  const [, status, reason, vis] = line.split('|');
+  if (status === 'refused') return { ok: false, refused: true, reason: reason || 'refused', visibleAfter: null };
+  if (status !== 'ok') return { ok: false, refused: false, reason: 'unparseable_output', visibleAfter: null };
+  const v = String(vis || '').trim().toLowerCase();
+  // An 'ok' line whose visibility token is neither True nor False is not a success we can stand behind.
+  if (v !== 'true' && v !== 'false') return { ok: false, refused: false, reason: 'unparseable_visibility', visibleAfter: null };
+  return { ok: true, refused: false, reason: null, visibleAfter: v === 'true' };
+}
+
+/**
+ * Hide or show a captured window, reporting what the WORLD says afterwards.
+ *
+ * Returns { ok, refused, reason, visibleAfter, achieved }. `achieved` is the only field a caller
+ * should treat as "it worked": it compares the post-call IsWindowVisible reading against what was
+ * asked for. A resolved exec with the window still visible is a FAILURE here -- which is exactly
+ * where focusWindow's contract would have reported success.
+ */
+export async function setWindowVisibility(handle, opts = {}) {
+  const { show, owner = {}, execFn = defaultExec } = opts;
+  let out;
+  try {
+    const cmd = buildSetVisibilityCommand({
+      handle,
+      show,
+      ownerPid: owner.pid,
+      ownerProcName: owner.procName,
+      ownerStartTicks: owner.startTicks,
+    });
+    out = await execFn(cmd.program, cmd.args);
+  } catch (e) {
+    // Refuse-by-default: an unusable request or a failed invocation is never a hide.
+    return { ok: false, refused: true, reason: `invocation_failed: ${e?.message || e}`, visibleAfter: null, achieved: false };
+  }
+  const stdout = typeof out === 'string' ? out : (out?.stdout ?? '');
+  const parsed = parseVisibilityResult(stdout);
+  return { ...parsed, achieved: parsed.ok && parsed.visibleAfter === Boolean(show) };
 }

--- a/lib/fleet/window-handle.js
+++ b/lib/fleet/window-handle.js
@@ -203,7 +203,53 @@ export function selectNewWindowHandle(before = [], after = [], opts = {}) {
     // Fail CLOSED. Guessing here would bind a session card to someone else's window.
     return { handle: null, reason: 'ambiguous', diagnostics: { ...diagnostics, reason: 'ambiguous' } };
   }
-  return { handle: appeared[0], reason: 'ok', diagnostics: { ...diagnostics, reason: 'ok' } };
+  // SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A FR-2: carry the OWNER IDENTITY out with the handle.
+  //
+  // This function previously returned a bare handle number and dropped pid/proc on the floor, even
+  // though the enumeration rows already carry both — which is why the hide guard could not be
+  // implemented from stored data at all. Additive: existing callers read .handle and are unaffected.
+  const ownerRow = afterRows.find((r) => toHandle(r) === appeared[0]) || null;
+  return {
+    handle: appeared[0],
+    owner: ownerRow && Number.isInteger(Number(ownerRow.pid)) && Number(ownerRow.pid) > 0
+      ? { pid: Number(ownerRow.pid), procName: String(ownerRow.proc || '') }
+      : null,
+    reason: 'ok',
+    diagnostics: { ...diagnostics, reason: 'ok' },
+  };
+}
+
+/**
+ * Build the process START TIME lookup — the conjunct that defeats pid recycling.
+ *
+ * Start time is NOT available from window enumeration, so it is a separate cheap read taken at
+ * capture. Ticks (not a formatted date) because it is an exact integer with no locale or timezone
+ * ambiguity to normalise later.
+ */
+export function buildProcessStartTicksCommand(pid) {
+  const p = Number(pid);
+  if (!Number.isInteger(p) || p <= 0) throw new Error(`buildProcessStartTicksCommand: invalid pid: ${JSON.stringify(pid)}`);
+  return {
+    program: 'powershell',
+    args: ['-NoProfile', '-NonInteractive', '-Command',
+      `$p=Get-Process -Id ${p} -ErrorAction SilentlyContinue; if($p){Write-Output ('TICKS|' + $p.StartTime.Ticks)} else {Write-Output 'TICKS|'}`],
+  };
+}
+
+/** Read the start ticks for a pid. Returns null when the process is gone or the read is unusable. */
+export async function readProcessStartTicks(pid, opts = {}) {
+  const { execFn = defaultExec } = opts;
+  try {
+    const cmd = buildProcessStartTicksCommand(pid);
+    const out = await execFn(cmd.program, cmd.args);
+    const stdout = typeof out === 'string' ? out : (out?.stdout ?? '');
+    const line = String(stdout).split(/\r?\n/).find((l) => l.startsWith('TICKS|'));
+    const ticks = line ? line.split('|')[1]?.trim() : '';
+    // Refuse a partial identity rather than persisting one that cannot discriminate later.
+    return /^\d+$/.test(ticks || '') ? ticks : null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -283,8 +329,14 @@ export async function captureNewWindowHandle(before, opts = {}) {
     const after = await enumerateWindows(opts);
     selection = selectNewWindowHandle(before, after, opts);
     if (selection.handle !== null) {
+      // FR-2: capture the owner's START TIME alongside pid/name. Without all three the hide guard
+      // has nothing to discriminate with — a pid-only check passes for every fleet window on this
+      // host, since they share one terminal process. Best-effort: a failed read yields owner null,
+      // and the hide verb then REFUSES rather than acting on a partial identity.
+      const startTicks = selection.owner ? await readProcessStartTicks(selection.owner.pid, opts) : null;
       return {
         handle: selection.handle,
+        owner: selection.owner && startTicks ? { ...selection.owner, startTicks } : null,
         handleCaptureFailed: false,
         attempts: attempt,
         diagnostics: { ...selection.diagnostics, attempts: attempt },

--- a/lib/fleet/window-reconcile.js
+++ b/lib/fleet/window-reconcile.js
@@ -1,0 +1,103 @@
+/**
+ * lib/fleet/window-reconcile.js — SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A FR-6.
+ *
+ * Compares RECORDED visibility (claude_sessions.metadata.window_visible, an intention) against
+ * OBSERVED visibility (what the OS actually reports), in BOTH directions.
+ *
+ * *** THE SD ORIGINALLY SAID ONE OF THESE DIRECTIONS WAS IMPOSSIBLE. IT WAS MEASURED FALSE. ***
+ * The spine asserted "reconciliation is one-directional by construction", resting on this premise:
+ * FALSE — "a hidden window cannot be re-enumerated". Believing it meant recorded-visible-but-
+ * actually-hidden could never be detected, so the builder was told to skip that whole direction.
+ * Measured on this host, which is what settled it: 348 top-level windows, 36 visible,
+ * 312 HIDDEN AND ENUMERABLE. Hidden windows are excluded from this repo's normal enumeration by
+ * exactly ONE predicate, `if (IsWindowVisible(h))` inside WINDOW_ENUM_COMMAND — an APPLICATION
+ * CHOICE, not an OS limit. Drop that predicate and both directions are observable.
+ *
+ * So this module is deliberately symmetric, and nothing in it claims the converse is undetectable.
+ * A one-directional reconciler here would have been a permanent blind spot justified by a false
+ * premise — the operator would be told "everything matches" while every wrongly-hidden seat sat
+ * unreported, which is precisely the operator-truth failure this SD exists to end.
+ *
+ * PURE. No DB, no PowerShell. Callers supply recorded rows and observed windows, which is what makes
+ * both drift directions testable without hiding a real window.
+ */
+
+/** Drift direction names. Exported so callers and tests share one spelling. */
+export const DRIFT_RECORDED_HIDDEN_BUT_VISIBLE = 'recorded_hidden_but_visible';
+export const DRIFT_RECORDED_VISIBLE_BUT_HIDDEN = 'recorded_visible_but_hidden';
+
+/**
+ * Build a handle -> visible map from UNFILTERED enumeration rows.
+ *
+ * Rows must come from an enumeration that does NOT apply the IsWindowVisible gate — otherwise every
+ * hidden window is simply absent, and absent is indistinguishable from "window closed". That
+ * conflation is what made the original one-directional claim look true.
+ */
+export function buildObservedMap(rows) {
+  const map = new Map();
+  for (const r of Array.isArray(rows) ? rows : []) {
+    const h = Number(r?.handle);
+    if (!Number.isFinite(h) || h === 0) continue;
+    map.set(h, Boolean(r?.visible));
+  }
+  return map;
+}
+
+/**
+ * Reconcile recorded intention against observed reality.
+ *
+ * @param {Array<{session_id: string, metadata: object}>} sessions
+ * @param {Map<number, boolean>} observed  handle -> isVisible, from UNFILTERED enumeration
+ * @returns {{drift: Array, checked: number, skipped: Array}}
+ *
+ * A session is SKIPPED, never counted as drift, when it has no recorded visibility (nothing to
+ * compare), no usable handle (nothing to look up), or its handle is absent from the observed map
+ * (the window is gone — a closed window is not a visibility disagreement). Reporting any of those
+ * as drift would manufacture alarms and bury the real ones.
+ */
+export function reconcileWindowVisibility(sessions, observed) {
+  const map = observed instanceof Map ? observed : new Map();
+  const drift = [];
+  const skipped = [];
+  let checked = 0;
+
+  for (const s of Array.isArray(sessions) ? sessions : []) {
+    const meta = s?.metadata || {};
+    const recorded = meta.window_visible;
+    if (recorded !== true && recorded !== false) { skipped.push({ session_id: s?.session_id, reason: 'no_recorded_visibility' }); continue; }
+    const handle = Number(meta.window_handle);
+    if (!Number.isFinite(handle) || handle === 0) { skipped.push({ session_id: s?.session_id, reason: 'no_usable_handle' }); continue; }
+    if (!map.has(handle)) { skipped.push({ session_id: s?.session_id, reason: 'window_absent' }); continue; }
+
+    checked++;
+    const actual = map.get(handle);
+    if (actual === recorded) continue;
+    drift.push({
+      session_id: s?.session_id,
+      handle,
+      recorded,
+      actual,
+      // BOTH directions are first-class. Neither is a special case of the other.
+      direction: recorded === false && actual === true
+        ? DRIFT_RECORDED_HIDDEN_BUT_VISIBLE
+        : DRIFT_RECORDED_VISIBLE_BUT_HIDDEN,
+    });
+  }
+  return { drift, checked, skipped };
+}
+
+/**
+ * Human summary for an operator. States BOTH counts explicitly, including the zeros.
+ *
+ * Printing only the non-zero direction would let the undetected-by-design story quietly return: an
+ * operator who never sees "recorded_visible_but_hidden: 0" cannot tell whether it was checked and
+ * clean or never checked at all.
+ */
+export function summarizeDrift(result) {
+  const d = result?.drift || [];
+  const hiddenButVisible = d.filter((x) => x.direction === DRIFT_RECORDED_HIDDEN_BUT_VISIBLE).length;
+  const visibleButHidden = d.filter((x) => x.direction === DRIFT_RECORDED_VISIBLE_BUT_HIDDEN).length;
+  return `checked=${result?.checked ?? 0} drift=${d.length} `
+    + `(${DRIFT_RECORDED_HIDDEN_BUT_VISIBLE}=${hiddenButVisible}, ${DRIFT_RECORDED_VISIBLE_BUT_HIDDEN}=${visibleButHidden}) `
+    + `skipped=${(result?.skipped || []).length}`;
+}

--- a/lib/fleet/window-visibility-writer.js
+++ b/lib/fleet/window-visibility-writer.js
@@ -1,0 +1,136 @@
+/**
+ * lib/fleet/window-visibility-writer.js — SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A (FR-2, FR-3).
+ *
+ * Durable, ATOMIC truth for window visibility on claude_sessions.metadata, plus the owner identity
+ * the hide guard needs. Deliberately a copy of lib/fleet/attention-flag-writer.js's seam — same
+ * table, same key column, same `metadata = COALESCE(metadata,'{}'::jsonb) || $2::jsonb` merge via
+ * the raw pg client.
+ *
+ * WHY REUSE RATHER THAN INVENT. The SD's spine asserted that every claude_sessions metadata write in
+ * the repo is read-spread-write, and used that to justify designing a new mechanism. That is FALSE:
+ * six atomic RPCs already exist (set_coordinator_flag, set_session_working_signal,
+ * set_session_working_context, set_adam_flag, set_solomon_flag, create_or_replace_session) plus this
+ * raw-pg merge. The atomicity REQUIREMENT stands — a read-spread-write here would silently drop a
+ * concurrent writer's field — but the justification did not, so this is a third caller of a proven
+ * seam rather than a third mechanism.
+ *
+ * *** THE OWNER PID PERSISTED HERE IS NEVER A KILL TARGET. READ THIS BEFORE USING IT. ***
+ * window_owner_pid is the pid of the process that owns the WINDOW — on this host, one shared
+ * WindowsTerminal host serving ALL NINE seats (measured: 9 visible terminal windows, 1 owning pid;
+ * by contrast 9 cmd windows had 9 distinct pids, so this is a terminal-architecture property, not a
+ * general one). Handing it to taskkill /T /F would terminate every seat at once. The per-seat
+ * process is claude_sessions.pid, which is a DIFFERENT process and is what the kill paths already
+ * use, cross-checked against the SessionStart marker pid and pidIsClaude. Before this SD no window-
+ * owning pid existed anywhere in the session row; this file is what makes one reachable, which is
+ * why the field is namespaced window_owner_* and why a test asserts no kill path references it.
+ */
+import { createDatabaseClient } from '../../scripts/lib/supabase-connection.js';
+
+/** The metadata keys this module owns. Exported so tests and readers share one spelling. */
+export const WINDOW_VISIBLE_KEY = 'window_visible';
+export const WINDOW_OWNER_KEYS = Object.freeze(['window_owner_pid', 'window_owner_proc', 'window_owner_start_ticks']);
+
+/** One atomic partial merge. Shared by both writers so the seam cannot drift between them. */
+async function mergeSessionMetadata(sessionId, patch, opts = {}) {
+  const { createClientFn = createDatabaseClient } = opts;
+  let client;
+  try {
+    client = await createClientFn('engineer', { verify: false });
+  } catch (connErr) {
+    return { ok: false, sessionId, error: `db_connect_failed: ${connErr.message}` };
+  }
+  try {
+    const result = await client.query(
+      `UPDATE claude_sessions
+       SET metadata = COALESCE(metadata, '{}'::jsonb) || $2::jsonb
+       WHERE session_id = $1`,
+      [sessionId, JSON.stringify(patch)]
+    );
+    return { ok: result.rowCount > 0, sessionId };
+  } catch (queryErr) {
+    return { ok: false, sessionId, error: queryErr.message };
+  } finally {
+    try { await client.end(); } catch { /* best-effort close */ }
+  }
+}
+
+/**
+ * Record the INTENDED visibility of a session's window.
+ *
+ * This is an INTENTION, not an observation of the world. It is written after a verified
+ * hide/show, and reconciliation (FR-6) is what compares it against reality — in BOTH directions,
+ * because hidden windows are enumerable (measured: 312 of 348 top-level windows on this host were
+ * hidden and still enumerable; they are excluded only by this repo's own IsWindowVisible predicate).
+ */
+export async function setWindowVisible(sessionId, { visible, by } = {}, opts = {}) {
+  if (!sessionId || typeof sessionId !== 'string') throw new Error('setWindowVisible: sessionId is required');
+  if (typeof visible !== 'boolean') throw new Error('setWindowVisible: visible must be a boolean');
+  if (!by || typeof by !== 'string') throw new Error('setWindowVisible: by is required');
+  const patch = {
+    [WINDOW_VISIBLE_KEY]: visible,
+    window_visible_set_at: new Date().toISOString(),
+    window_visible_set_by: by,
+  };
+  const r = await mergeSessionMetadata(sessionId, patch, opts);
+  return { written: r.ok, sessionId, ...(r.error ? { error: r.error } : {}) };
+}
+
+/**
+ * Persist the window's OWNER IDENTITY at capture time: pid + process name + process START TIME.
+ *
+ * All three are required together and start time is the load-bearing one — owning-pid equality is
+ * TRUE for every fleet window on this host, so a pid-only guard passes in exactly the recycled-
+ * handle case it exists to catch. Start time is what defeats pid recycling.
+ *
+ * See the module header: window_owner_pid is NEVER a valid kill target.
+ */
+export async function setWindowOwner(sessionId, { pid, procName, startTicks } = {}, opts = {}) {
+  if (!sessionId || typeof sessionId !== 'string') throw new Error('setWindowOwner: sessionId is required');
+  if (!Number.isInteger(pid) || pid <= 0) throw new Error('setWindowOwner: pid must be a positive integer');
+  if (!procName || !/^[\w.-]+$/.test(String(procName))) throw new Error('setWindowOwner: procName is required and must be a bare process name');
+  if (!/^\d+$/.test(String(startTicks ?? ''))) throw new Error('setWindowOwner: startTicks is required (process start time, digits only)');
+  const patch = {
+    window_owner_pid: pid,
+    window_owner_proc: String(procName),
+    window_owner_start_ticks: String(startTicks),
+    window_owner_captured_at: new Date().toISOString(),
+  };
+  const r = await mergeSessionMetadata(sessionId, patch, opts);
+  return { written: r.ok, sessionId, ...(r.error ? { error: r.error } : {}) };
+}
+
+/**
+ * Read owner identity back into the shape setWindowVisibility() expects, or null when incomplete.
+ *
+ * HANDLE-LESS AND OWNER-LESS ARE BOTH MULTI-SHAPED. metadata.window_handle can be ABSENT (the spawn
+ * session-bind loop never found a fresh row, so the update was never issued), present-but-null, or
+ * present alongside handle_capture_failed:true. A falsy check alone misses a case, so callers get
+ * null here and must refuse rather than proceed on a partial identity.
+ */
+export function readWindowOwner(metadata) {
+  const m = metadata || {};
+  const pid = m.window_owner_pid;
+  const procName = m.window_owner_proc;
+  const startTicks = m.window_owner_start_ticks;
+  if (!Number.isInteger(pid) || pid <= 0) return null;
+  if (!procName || typeof procName !== 'string') return null;
+  if (!startTicks || !/^\d+$/.test(String(startTicks))) return null;
+  return { pid, procName, startTicks: String(startTicks) };
+}
+
+/**
+ * Classify why a session cannot be hidden. Returns null when it CAN be.
+ *
+ * Refuse what cannot be proven restorable: hiding a window whose handle or owner identity is
+ * unknown is permanently unrecoverable through the normal path, because the only way back is the
+ * unfiltered restore sweep (FR-7).
+ */
+export function classifyHideRefusal(metadata) {
+  const m = metadata || {};
+  if (m.handle_capture_failed === true) return 'handle_capture_failed';
+  if (!('window_handle' in m)) return 'window_handle_absent';
+  if (m.window_handle === null || m.window_handle === undefined) return 'window_handle_null';
+  if (!Number.isFinite(Number(m.window_handle)) || Number(m.window_handle) === 0) return 'window_handle_invalid';
+  if (!readWindowOwner(m)) return 'window_owner_identity_incomplete';
+  return null;
+}

--- a/scripts/fleet-restore-windows.mjs
+++ b/scripts/fleet-restore-windows.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * scripts/fleet-restore-windows.mjs — SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A FR-7.
+ *
+ * THE PANIC BUTTON. Un-hides every fleet terminal window, reading NOTHING from the database and
+ * needing no stored handle, no server, and no session row.
+ *
+ *   node scripts/fleet-restore-windows.mjs          # restore every hidden terminal window
+ *   node scripts/fleet-restore-windows.mjs --dry-run  # list what WOULD be restored
+ *
+ * WHY IT EXISTS, and why it cannot depend on anything this feature writes. A bad mass-hide is the
+ * worst failure mode of the hide verb, and the DB rows recording what was hidden are exactly what a
+ * bad hide may have gotten wrong. Without this script the only recovery is killing
+ * WindowsTerminal.exe — which destroys ALL NINE SEATS AT ONCE, because they share one host process
+ * (measured on this host: 9 visible terminal windows, ONE owning pid). A feature whose worst case is
+ * a nine-seat outage must ship its own recovery, and that recovery must not read the rows it may
+ * have corrupted. Hence: no supabase import, no metadata read, no route.
+ *
+ * IT IS BUILDABLE ONLY BECAUSE HIDDEN WINDOWS ARE ENUMERABLE. The SD originally asserted the
+ * opposite — "a hidden window cannot be re-enumerated" — and that claim was measured false: 348
+ * top-level windows on this host, 36 visible, 312 HIDDEN AND ENUMERABLE. They are excluded from
+ * this repo's normal enumeration by ONE predicate, `if (IsWindowVisible(h))` inside
+ * WINDOW_ENUM_COMMAND (lib/fleet/window-handle.js). This script is that same enumeration MINUS the
+ * predicate. Had the false claim survived, this recovery path would have been ruled out on paper.
+ *
+ * DELIBERATELY NOT SELECTIVE. It restores every window owned by the terminal process rather than
+ * only those a DB says should be visible, because in the panic case the DB is the thing you do not
+ * trust. Showing a window that was already visible is a no-op; leaving one hidden is the outage.
+ */
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/** The host process that owns fleet session windows. Must match lib/fleet/window-handle.js. */
+export const TERMINAL_PROCESS_NAME = 'WindowsTerminal';
+
+/**
+ * Enumerate ALL top-level windows — WITHOUT the IsWindowVisible filter — and SW_SHOW the ones owned
+ * by the terminal process, in ONE PowerShell invocation.
+ *
+ * One invocation is not an optimisation here: enumerate-then-restore across two calls would let the
+ * window set change in between, and in a panic the operator is watching a screen with nothing on it.
+ */
+export function buildRestoreCommand({ dryRun = false, processName = TERMINAL_PROCESS_NAME } = {}) {
+  if (!/^[\w.-]+$/.test(String(processName))) {
+    throw new Error(`buildRestoreCommand: invalid processName: ${JSON.stringify(processName)}`);
+  }
+  const typeDef = 'using System;using System.Text;using System.Collections.Generic;using System.Runtime.InteropServices;'
+    + 'public class FleetRestore{'
+    + 'public delegate bool EnumProc(IntPtr h,IntPtr l);'
+    + '[DllImport("user32.dll")]public static extern bool EnumWindows(EnumProc cb,IntPtr l);'
+    + '[DllImport("user32.dll")]public static extern bool IsWindowVisible(IntPtr h);'
+    + '[DllImport("user32.dll")]public static extern bool ShowWindow(IntPtr h,int c);'
+    + '[DllImport("user32.dll")]public static extern uint GetWindowThreadProcessId(IntPtr h,out uint p);'
+    // NOTE THE ABSENCE: no `if(IsWindowVisible(h))` gate around the Add. That one missing predicate
+    // is the whole reason a hidden window can be found again.
+    + 'public static List<string> All(){var r=new List<string>();EnumWindows((h,l)=>{uint p;GetWindowThreadProcessId(h,out p);r.Add(h.ToInt64()+"|"+p+"|"+(IsWindowVisible(h)?"1":"0"));return true;},IntPtr.Zero);return r;}'
+    + 'public static void Show(IntPtr h){ShowWindow(h,5);}}';
+
+  const action = dryRun ? '' : '; [FleetRestore]::Show([IntPtr]$hh)';
+  const script = [
+    `Add-Type -TypeDefinition '${typeDef}'`,
+    '$n=0; $s=0',
+    '[FleetRestore]::All() | ForEach-Object {',
+    '  $f=$_.Split([char]124); $hh=[int64]$f[0]; $pp=[int]$f[1]; $vis=$f[2]',
+    `  $pn=(Get-Process -Id $pp -ErrorAction SilentlyContinue).ProcessName`,
+    `  if($pn -eq '${processName}'){ $n++; if($vis -eq '0'){ $s++${action} } }`,
+    '}',
+    "Write-Output ('RESTORE|' + $n + '|' + $s)",
+  ].join('; ');
+
+  return { program: 'powershell', args: ['-NoProfile', '-NonInteractive', '-Command', script] };
+}
+
+/** Parse the single RESTORE line. Pure, so the contract is testable without PowerShell. */
+export function parseRestoreResult(stdout) {
+  const line = String(stdout || '').split(/\r?\n/).find((l) => l.startsWith('RESTORE|'));
+  if (!line) return { ok: false, terminalWindows: null, restored: null, reason: 'unparseable_output' };
+  const [, total, restored] = line.split('|');
+  if (!/^\d+$/.test(String(total || '').trim()) || !/^\d+$/.test(String(restored || '').trim())) {
+    return { ok: false, terminalWindows: null, restored: null, reason: 'unparseable_output' };
+  }
+  return { ok: true, terminalWindows: Number(total), restored: Number(restored), reason: null };
+}
+
+/** Restore every hidden terminal window. Returns counts; never throws at the caller. */
+export async function restoreAllTerminalWindows(opts = {}) {
+  const { dryRun = false, processName = TERMINAL_PROCESS_NAME, execFn } = opts;
+  const run = execFn || (async (program, args) => (await execFileAsync(program, args, { windowsHide: true })).stdout);
+  try {
+    const cmd = buildRestoreCommand({ dryRun, processName });
+    return parseRestoreResult(await run(cmd.program, cmd.args));
+  } catch (e) {
+    return { ok: false, terminalWindows: null, restored: null, reason: `invocation_failed: ${e?.message || e}` };
+  }
+}
+
+const isDirectRun = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/').split('/').pop());
+if (isDirectRun) {
+  const dryRun = process.argv.includes('--dry-run');
+  const r = await restoreAllTerminalWindows({ dryRun });
+  if (!r.ok) {
+    console.error(`fleet-restore-windows: FAILED (${r.reason})`);
+    process.exit(1);
+  }
+  console.log(
+    dryRun
+      ? `fleet-restore-windows: ${r.terminalWindows} terminal window(s), ${r.restored} hidden and WOULD be restored (dry run)`
+      : `fleet-restore-windows: ${r.terminalWindows} terminal window(s), ${r.restored} restored`
+  );
+}

--- a/scripts/one-off/_lead-evidence-sessions-page-true-001-a.mjs
+++ b/scripts/one-off/_lead-evidence-sessions-page-true-001-a.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * One-off: write VALIDATION LEAD-phase evidence for
+ * SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A (backend half of the TRUE HIDE
+ * decomposition, parent SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001).
+ *
+ * Adversarial pre-build premise validation: independently re-verified each of
+ * the 5 corrected premises the description asserts, the 2 named safety guards
+ * plus a search for a 3rd unnamed destructive case, and judged the 8
+ * LEAD-authored smoke_test_steps against the 9 success_criteria for vacuous
+ * coverage.
+ *
+ * Canonical repo-evidence pattern (lib/sub-agents/resolve-repo.js
+ * applySubAgentRepoVerdict + lib/sub-agent-executor/results-storage.js
+ * storeSubAgentResults) per CLAUDE.md prologue rule 11 — no hand-rolled insert.
+ */
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../../lib/sub-agent-executor/results-storage.js';
+import { getSupabaseClient } from '../../lib/sub-agent-executor/supabase-client.js';
+
+const SD_ID = 'd90eedc6-8c96-4685-9a99-ca0267306615';
+const SD_KEY = 'SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A';
+
+async function main() {
+  const supabase = await getSupabaseClient();
+  const resolution = await resolveSubAgentRepo({ sdId: SD_KEY, targetApplication: 'EHG_Engineer', subAgentCode: 'VALIDATION', supabase });
+
+  let results = {
+    verdict: 'PASS',
+    confidence: 80,
+    findings: [
+      {
+        id: 'P1-seat-discovery-independent-of-window-enumeration-HOLDS',
+        severity: 'INFO',
+        summary: "lib/fleet/console-reaper.mjs:29-32 states window presence is EXCLUDED from the dead-seat test and is ANTI-CORRELATED with life (all 15 live claude.exe on the measured host are Cursor/powershell grandchildren with no window object; the 148 reaped consoles were top-level windows containing nothing); lines 34-36 state outright 'SEAT-TO-WINDOW BINDING IS NOT ATTEMPTED and must not be.' Liveness is legA=absent-from-Win32_Process-claude.exe-image-set AND legB=last_tool_at sampling (console-reaper.mjs:47-73), not window state. Repo-wide git grep for enumerateWindow/EnumWindows returns exactly 6 hits, all in lib/fleet/console-reaper.mjs, lib/fleet/spawn-control.js, lib/fleet/window-handle.js and their own tests/setup script — zero hits in scripts/stale-session-sweep.cjs or scripts/fleet-rollcall.cjs (the sweep and dashboard consumers). console-reaper.mjs's OWN use of window enumeration (FR-5a, enumerateWindowsStrict) is for descendant-count reachability of a CONSOLE candidate, not seat discovery. HOLDS.",
+      },
+      {
+        id: 'P2-no-server-side-visibility-truth-HOLDS-both-halves',
+        severity: 'INFO',
+        summary: "Backend: grep -n \"window_visible\" server/routes/fleet-panel.js returns zero matches; repo-wide git grep for \"window_visible\" across all of EHG_Engineer also returns zero — formatSessionRow (fleet-panel.js:103-134) emits callsign/identity_kind/model_effort/status/etc. but never window_visible. UI half (out of EHG_Engineer scope, confirmed in the sibling ehg repo per -B's own description): C:/Users/rickf/Projects/_EHG/ehg/src/pages/chairman-v3/BuilderSessionsPage.tsx:193 `const [visible, setVisible] = useState<boolean>(row.window_visible ?? false);` and :384 `onClick={visible ? handleHide : handleOpen}` — since row.window_visible is never produced by the EHG_Engineer backend, `visible` always initializes false and the control always renders 'Open' on every remount, exactly as claimed. Independently confirmed handleHide (:202-205) is a genuine honest-failure toast ('Hiding is not wired yet...'), not a silent no-op or fake success. HOLDS.",
+      },
+      {
+        id: 'P3-window-handle-durable-association-HOLDS',
+        severity: 'INFO',
+        summary: 'Writer: lib/fleet/spawn-control.js:487 `window_handle: handleResult.handle` inside the post-spawn session-bind block. Reader: lib/fleet/spawn-control.js:557-577 `attach()`, line 568 `const handle = row && row.metadata && row.metadata.window_handle;`, refusing with reason:no_captured_handle when absent (:569-572) and calling focusWindow(handle) otherwise (:574). Same field name on both ends. HOLDS.',
+      },
+      {
+        id: 'P4-pid-capture-deleted-title-matching-forbidden-HOLDS-with-real-capture',
+        severity: 'INFO',
+        summary: "lib/fleet/window-handle.js:9-38 documents the FR-7 deletion of the whole pid-based capture family (assertValidPid, buildHandleCaptureCommand, parseHandleOutput, captureWindowHandle) with the reason: `(Get-Process -Id <pid>).MainWindowHandle` queried the wt.exe LAUNCHER pid, which exits immediately after handing the tab to WindowsTerminal.exe, so the query always ran against a dead process; deleted after being verified to have ZERO production callers. Title matching is forbidden at :73-77 ('NEVER MATCH ON TITLE') with a REAL capture behind it: tests/unit/fleet/window-enum.test.js:15-16 documents two DIFFERENT processes (SystemSettings pid 15964, ApplicationFrameHost pid 27040) both presenting a window titled exactly 'Settings' (fixture lines 57-58, asserted at :108). HOLDS — a build that reaches for either mechanism would be reintroducing code already proven broken/unreliable in this exact codebase.",
+      },
+      {
+        id: 'P5-read-spread-write-is-the-DOMINANT-but-NOT-universal-pattern-PARTIALLY-OVERSTATED',
+        severity: 'WARNING',
+        summary: "Confirmed read-spread-write for claude_sessions.metadata in: lib/fleet/spawn-control.js:463-544 (the exact write window_visible would need to join — SELECT metadata, spread ...current.metadata, UPDATE), lib/checkin/steps/model-effort-merge.cjs:21, lib/fleet/canary-guard.js:197-198, scripts/stale-session-sweep.cjs:261-264, and adam-register.cjs's JS-merge fallback path. HOWEVER the absolute claim 'every claude_sessions metadata write in the repo today is read-spread-write' is NOT literally true: database/migrations/20260630_role_handoff_atomic_solomon_flag.sql defines set_solomon_flag/clear_solomon_flag as SECURITY DEFINER Postgres functions doing an in-DB `metadata = COALESCE(metadata,'{}'::jsonb) || jsonb_build_object(...)` merge (single-statement, row-locked, no JS read-then-write), and these ARE live today — independently queried `SELECT proname FROM pg_proc WHERE proname IN ('set_adam_flag','clear_adam_flag','set_solomon_flag','clear_solomon_flag')` against the engineer DB and got exactly {clear_solomon_flag, set_solomon_flag} (the Adam sibling migration has NOT been applied). scripts/solomon-register.cjs calls this RPC as its primary path with a JS-merge fallback only when the RPC errors. This does not undercut the SD's build decision — window_visible needs a NEW field, not the narrow 3-key Adam/Solomon flag shape — but it does mean the premise as stated is an overstatement (there is one live exception) and it surfaces the CHEAPEST correct pattern to copy: lib/coordinator/safe-metadata-merge.mjs:69-74, `UPDATE <table> SET metadata = COALESCE(metadata,'{}'::jsonb) || $2::jsonb WHERE <key> = $1` via a raw pg connection (scripts/lib/supabase-connection.js createDatabaseClient) — hardcoded today to strategic_directives_v2/sd_key but directly adaptable to claude_sessions/session_id, and unlike the RPC route it needs NO chairman-gated migration since it is a plain parameterized UPDATE, not a new DB function.",
+      },
+      {
+        id: 'P6-THIRD-DESTRUCTIVE-CASE-pid-reuse-within-one-terminal-host-and-asymmetric-SW_SHOW-guard',
+        severity: 'HIGH',
+        summary: "The two named guards (handle-less REFUSE; recycled-HWND-to-a-different-PID REFUSE before SW_HIDE) do not cover a third case the codebase's OWN documentation establishes as real: lib/fleet/window-handle.js:66-67 states 'MainWindowHandle is per-PROCESS: many terminal windows share ONE host process' and TERMINAL_PROCESS_NAME (:85) is 'WindowsTerminal' — i.e. one PID legitimately owns MANY session windows (tabs) over its lifetime. A stale HWND that gets recycled to a DIFFERENT tab of the SAME WindowsTerminal PID (not a different PID) would PASS the stated 'handle valid AND owning PID matches' guard while still being the wrong window — hiding or showing an unrelated live session's tab. The guard as named re-derives exactly the signal (PID) this codebase's own header already rejected as insufficient for naming a SPECIFIC window under this same one-process-many-windows model (window-handle.js:61-67), and does not add anything (e.g. a title/geometry/z-order cross-check, or accepting that PID-only re-validation is a WEAKER guarantee here than in a one-window-per-process app and stating that limitation explicitly). SECOND, narrower gap: the refusal guard and its smoke step (success_criteria item 6 / smoke step 5) are stated only for the SW_HIDE path; there is no symmetric named guard or step for SW_SHOW, even though a hidden window can sit dormant indefinitely (until an operator clicks Show) — a materially LONGER exposure window for HWND recycling than the ~500ms-10s capture-to-first-attach race the existing code already defends against. Recommend PLAN require: (a) explicitly stating the PID-based guard's known weakness under WindowsTerminal's shared-host model rather than presenting it as airtight, and (b) applying the same re-validate-before-touch guard symmetrically to SW_SHOW, not only SW_HIDE.",
+      },
+      {
+        id: 'P7-smoke-steps-vs-success-criteria-one-genuine-gap-step2-is-load-bearing-not-vacuous',
+        severity: 'WARNING',
+        summary: "8 of 9 success_criteria have a directly corresponding smoke_test_step (durability->step6, concurrent-writer survival->step6, true-hide-vs-minimize->steps1+2, deterministic-restore->step3, handle-less-refusal->step4, stale-handle-refusal->step5, formatSessionRow-emits-field->step7, disposable-window-methodology->baked into every step's instruction). Step 2 (SW_MINIMIZE control) IS genuinely load-bearing, not vacuous: Win32 IsWindowVisible reflects only the WS_VISIBLE style bit, which SW_MINIMIZE preserves (a minimized window still reports IsWindowVisible=TRUE) while SW_HIDE clears it — the control is a positive-control on the MEASUREMENT ITSELF (proving IsWindowVisible can and does read TRUE under a real, adjacent OS operation), not a redundant re-assertion of step 1; without it there is no proof the metric discriminates hide from minimize at all, which is the entire premise the 'TRUE HIDE' project name rests on. GENUINE GAP: success_criterion 9 ('Seat discovery is provably unchanged... a test asserts none of them reads window_visible') has NO corresponding smoke_test_step among the 8 listed — the nearest, step 6, tests that window_visible SURVIVES a stale-session-sweep write (durability), not that the sweep/reaper's OWN dead/reapable decision logic is independent of window_visible. Given P1 (seat-discovery independence) is the load-bearing corrected premise for the whole SD, its own success criterion having zero LEAD-authored smoke coverage is worth PLAN closing explicitly (e.g. a step that runs isSeatDead/isConsoleReapable against a fixture row carrying window_visible and asserts the verdict is unchanged, or a static grep-based test).",
+      },
+      {
+        id: 'scope-and-dependency-check-A-is-independently-buildable',
+        severity: 'INFO',
+        summary: 'Confirmed genuinely greenfield: `grep -n \"^export \" lib/fleet/spawn-control.js` shows no hide/show/minimize verb among the existing exports (spawn/attach/stop/restart/relaunchUnderProfile/drainAndRestart only), and grep for hide/SW_HIDE/SW_SHOW/minimize in server/routes/fleet-panel.js returns no route. Confirmed sibling child -B (fetched from strategic_directives_v2, parent_sd_id=e5a2ef1d-d28e-4afd-9c2a-4ce57edd6289) is real, correctly one-directional (-B depends on -A\'s endpoint; -A does not reference -B), and lives entirely in a different repo (C:/Users/rickf/Projects/_EHG/ehg). -A\'s own smoke_test_steps (disposable window + hide/show routes + DB row reads + a GET on the API) require no UI element and no code from the ehg repo — no hidden reverse dependency found; -A is independently buildable and testable as scoped.',
+      },
+    ],
+    warnings: [
+      'P5 is an overstatement as a literal absolute (one live atomic exception exists: set_solomon_flag), though it does not change the build decision — flagged so PLAN cites it precisely rather than repeating the absolute claim, and so the cheaper safe-metadata-merge.mjs-style pattern (no migration required) is considered alongside a full RPC.',
+      'P6 (HIGH): the PID-based recycled-handle guard is weaker than presented under the WindowsTerminal one-process-many-windows model this codebase itself documents; PLAN should require the guard limitation to be stated and the same re-validation applied symmetrically to SW_SHOW, not only SW_HIDE.',
+      'P7: success_criterion 9 (seat-discovery independence, the load-bearing corrected premise of this whole SD) has no corresponding LEAD-authored smoke_test_step; PLAN should add explicit coverage rather than relying on step 6 durability testing as a proxy.',
+    ],
+    recommendations: [
+      'Proceed to PLAN. Premises 1-4 independently HOLD with direct file:line evidence; buildability is confirmed greenfield with no duplicate/partial implementation to reconcile.',
+      'PLAN should require the PRD to (a) state the PID-guard limitation under shared-host WindowsTerminal PIDs rather than presenting handle+PID re-validation as fully sufficient, (b) apply the same re-validation guard to SW_SHOW symmetrically with SW_HIDE, and (c) add explicit test coverage for success_criterion 9 (seat-discovery/reaper/sweep code paths provably do not read window_visible), none of which are covered by the 8 LEAD smoke_test_steps as written.',
+      'For the atomic-merge implementation, evaluate copying lib/coordinator/safe-metadata-merge.mjs\'s raw-pg `COALESCE(metadata,\'{}\'::jsonb) || $2::jsonb` UPDATE pattern against claude_sessions/session_id (no migration needed) as a lower-cost alternative to a new SECURITY DEFINER RPC function.',
+    ],
+    detailed_analysis: JSON.stringify({
+      sd_key: SD_KEY,
+      verification_method: 'Direct file reads + git grep/scoped-path greps across the EHG_Engineer worktree and the sibling ehg repo (BuilderSessionsPage.tsx), plus a live pg_proc query against the engineer DB to check whether set_adam_flag/set_solomon_flag are actually applied.',
+      premise_verdicts: {
+        p1_seat_discovery_independent_of_window_enum: 'HOLDS',
+        p2_no_server_side_visibility_truth: 'HOLDS (both backend-emission and UI-toggle halves independently confirmed)',
+        p3_window_handle_durable_association: 'HOLDS',
+        p4_pid_deleted_title_forbidden: 'HOLDS (real two-process same-title fixture cited)',
+        p5_every_write_is_read_spread_write: 'PARTIALLY OVERSTATED — one live atomic exception (set_solomon_flag RPC); dominant pattern is still read-spread-write for the general case window_visible needs',
+      },
+      third_destructive_case: 'PID re-validation is insufficient to prove SAME-window identity under WindowsTerminal\'s one-process-many-windows model (window-handle.js:61-67 documents this exact weakness for capture); a recycled HWND reassigned to a different tab of the SAME PID passes the named guard. Symmetric gap: no named guard/step for SW_SHOW despite a materially longer dormancy window than the capture race.',
+      smoke_step_gap: 'success_criterion 9 (seat-discovery provably unchanged) has zero corresponding smoke_test_step; step 2 (SW_MINIMIZE control) independently confirmed genuinely load-bearing, not vacuous.',
+      live_db_check: "pg_proc query returned exactly {clear_solomon_flag, set_solomon_flag}; set_adam_flag/clear_adam_flag NOT present live (migration written but not applied).",
+    }),
+    metadata: {
+      premises_checked: 5,
+      premises_holding: 4,
+      premises_overstated: 1,
+      third_destructive_case_found: true,
+      smoke_step_gap_found: true,
+      greenfield_confirmed: true,
+      ui_half_repo: 'C:/Users/rickf/Projects/_EHG/ehg (out of scope for -A, confirmed BuilderSessionsPage.tsx matches the description)',
+    },
+    phase: 'LEAD',
+    validation_mode: 'prospective',
+    summary: "PASS (with concerns) for LEAD-TO-PLAN. Independently re-verified all 5 corrected premises against the actual codebase: seat-discovery independence from window enumeration HOLDS (console-reaper.mjs:29-36, zero enumerateWindow references in the sweep/rollcall consumers); the backend-emits-nothing + UI-seeds-from-nothing claim HOLDS on both sides (0 occurrences of window_visible anywhere in EHG_Engineer; independently confirmed BuilderSessionsPage.tsx:193/384 in the sibling ehg repo); window_handle's writer/reader pair HOLDS (spawn-control.js:487/568); the deleted-pid/forbidden-title claim HOLDS with a real two-process same-title capture cited as evidence (window-enum.test.js:57-58). One premise is an overstatement: not EVERY claude_sessions metadata write is read-spread-write — set_solomon_flag is a live, atomic SECURITY DEFINER RPC (confirmed present in pg_proc), though the general window_visible field still needs a new merge path and the repo's safe-metadata-merge.mjs pattern is the cheaper, migration-free template to copy. Highest-value finding: a genuine THIRD destructive case the SD does not name — PID re-validation is insufficient to prove same-window identity under WindowsTerminal's documented one-process-many-windows model, and the recycled-handle guard is asymmetric (named only for SW_HIDE, not SW_SHOW, despite SW_SHOW's materially longer dormancy exposure). Smoke-step review found step 2 (SW_MINIMIZE control) genuinely load-bearing (proves the measurement instrument discriminates hide from minimize) but found success_criterion 9 (seat-discovery independence, the SD's own load-bearing premise) has zero corresponding LEAD smoke coverage. Scope check confirmed -A is genuinely greenfield (no existing hide/show verb or route) and independently buildable without -B, whose sibling description and BuilderSessionsPage.tsx were independently cross-checked in the ehg repo. Recommend proceeding to PLAN with the PID-guard-limitation, SW_SHOW-symmetry, and success-criterion-9-coverage findings carried into the PRD as explicit requirements.",
+  };
+
+  results = applySubAgentRepoVerdict(results, resolution);
+  const stored = await storeSubAgentResults('VALIDATION', SD_ID, { name: 'Principal Systems Analyst (validation-agent)' }, results, { sdKey: SD_KEY, phase: 'LEAD' });
+  console.log('VALIDATION result stored:', stored.id, stored.verdict, stored.confidence);
+}
+
+main().catch((e) => { console.error('FAILED:', e.message); console.error(e.stack); process.exit(1); });

--- a/server/routes/fleet-panel.js
+++ b/server/routes/fleet-panel.js
@@ -132,6 +132,20 @@ export function formatSessionRow(row) {
     account_org_name: meta.account_org_name || null,
     model_effort: `${model}/${effort}`,
     status: row.computed_status || 'unknown',
+    // SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A FR-5 — THE OPERATOR-TRUTH DEFECT THIS SD EXISTS FOR.
+    // Until now this formatter emitted NO window field at all, while the UI seeded its hide/show
+    // toggle from row.window_visible — a field no backend produced — and then tracked it in React
+    // state alone. With a 15-second refetch the control reverted to "Open" on every remount
+    // regardless of the real OS window state, so the operator was shown a visibility claim the
+    // system had never checked. Measured across live seats: window_handle 9/9, window_visible 0/9.
+    //
+    // THREE-VALUED ON PURPOSE, same discipline as account_email above. null means NEVER RECORDED,
+    // which is NOT the same as recorded-visible. Rendering absent as "Open" would reproduce the
+    // exact defect in a new field: a confident claim with nothing behind it. The UI must show
+    // "not recorded" for null.
+    window_visible: meta.window_visible === undefined || meta.window_visible === null
+      ? null
+      : Boolean(meta.window_visible),
     sd_key: row.sd_key || null,
     heartbeat_age_human: row.heartbeat_age_human || null,
     // SD-LEO-FEAT-FLEET-COLD-START-UX-001 FR-3. The numeric age was already SELECTed and used for

--- a/server/routes/fleet-sessions.js
+++ b/server/routes/fleet-sessions.js
@@ -26,7 +26,7 @@
  */
 import { Router } from 'express';
 import { createClient } from '@supabase/supabase-js';
-import { attach } from '../../lib/fleet/spawn-control.js';
+import { attach, setSessionWindowVisibility } from '../../lib/fleet/spawn-control.js';
 import {
   requestBrowserSession,
   signalTakeover,
@@ -155,6 +155,43 @@ router.post('/:id/open', async (req, res) => {
     res.status(500).json({ ok: false, reason: 'internal_error', message: error.message });
   }
 });
+
+// POST /:id/hide and POST /:id/show -- SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A FR-4.
+//
+// Session-scoped on purpose: these live here rather than in fleet-actions.js because hiding is a
+// per-seat verb, and mounting it in the fleet-wide router would give it fleet-wide framing.
+//
+// A REFUSAL IS NOT A 500. setSessionWindowVisibility refuses by NAME (window_handle_absent,
+// window_handle_null, handle_capture_failed, window_owner_identity_incomplete, or an unachieved
+// flip) and the caller must be able to tell "refused because this cannot be undone" from "the
+// server broke" -- so refusals return 409 with the reason, and only genuine faults return 500.
+//
+// AUTH BOUNDARY, DECIDED RATHER THAN INHERITED: this router is mounted requireAuth only, with no
+// role or ownership check (see the header note at the top of this file, which already records that
+// as an open boundary). Hiding another operator's window is a bigger blast radius than opening one,
+// so it is called out here instead of being picked up silently. Accepted for now on the same basis
+// as /open and /takeover -- every authenticated caller is a fleet operator -- and the FR-7 sweep
+// (scripts/fleet-restore-windows.mjs) is the backstop that makes the residual recoverable.
+async function handleVisibility(req, res, show) {
+  const supabase = getSupabase();
+  const verb = show ? 'show' : 'hide';
+  try {
+    // Fresh read, never a cached snapshot: the window can die between page render and click.
+    const session = await fetchFreshSession(supabase, req.params.id);
+    if (!session) return res.status(404).json({ ok: false, reason: 'session_not_found' });
+    const result = await setSessionWindowVisibility(req.params.id, { supabaseClient: supabase, by: 'session_id', show, actor: 'fleet-api' });
+    if (!result.ok) {
+      return res.status(409).json({ ok: false, reason: result.reason, refused: Boolean(result.refused), session_id: result.session_id ?? null });
+    }
+    return res.json({ ok: true, session_id: result.session_id, window_visible: result.visible, persisted: result.persisted });
+  } catch (error) {
+    console.error(`[fleet-sessions] ${verb} failed:`, error.message);
+    return res.status(500).json({ ok: false, reason: 'internal_error', message: error.message });
+  }
+}
+
+router.post('/:id/hide', (req, res) => handleVisibility(req, res, false));
+router.post('/:id/show', (req, res) => handleVisibility(req, res, true));
 
 // POST /:id/browser-session -- FR-2: resolves sandboxed launch options; never launches a browser itself.
 router.post('/:id/browser-session', async (req, res) => {

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -126,10 +126,16 @@ function makeFakeSupabase({ sessions = [], coordinationInsertError = null } = {}
   };
 }
 
-describe('module surface (TS-10: exactly six named verbs, no more)', () => {
-  it('exports exactly {spawn, attach, stop, restart, relaunchUnderProfile, drainAndRestart} as the verb set', async () => {
+describe('module surface (TS-10: exactly seven named verbs, no more)', () => {
+  it('exports exactly {spawn, attach, stop, restart, relaunchUnderProfile, drainAndRestart, setSessionWindowVisibility} as the verb set', async () => {
     const mod = await import('../../../lib/fleet/spawn-control.js');
-    const verbNames = ['spawn', 'attach', 'stop', 'restart', 'relaunchUnderProfile', 'drainAndRestart'];
+    // SEVENTH VERB ADDED DELIBERATELY — SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A FR-4.
+    // This guard exists to make growing the verb set a conscious act, and it did its job: adding
+    // setSessionWindowVisibility failed this test rather than slipping in unannounced. It is
+    // declared HERE, as a verb, and NOT added to the helper allowlist below — an operator invokes it
+    // (POST /:id/hide and /:id/show), which is exactly what distinguishes a verb from a helper, so
+    // hiding it among the helpers would have dodged the guard instead of satisfying it.
+    const verbNames = ['spawn', 'attach', 'stop', 'restart', 'relaunchUnderProfile', 'drainAndRestart', 'setSessionWindowVisibility'];
     for (const name of verbNames) expect(typeof mod[name]).toBe('function');
     // Every OTHER export must be a helper, never an undocumented 7th verb.
     // The guard exists to catch an undocumented 7th VERB, not to freeze the helper surface. The two

--- a/tests/unit/fleet/spawn-control.test.js
+++ b/tests/unit/fleet/spawn-control.test.js
@@ -2,6 +2,7 @@
  * SD-LEO-INFRA-FLEET-SPAWN-CONTROL-001 -- six-verb control API (TS-1..TS-10 unit-testable subset).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { classifyHideRefusal } from '../../../lib/fleet/window-visibility-writer.js';
 
 // QF-20260725-757: spread the ORIGINAL module rather than replacing it wholesale. spawn() now reads
 // the canonical FLEET_WORKER_STARTUP_PROMPT from here (the keepalive it must forward), and a
@@ -383,6 +384,45 @@ describe('spawn (FR-1)', () => {
     expect(merged.role).toBe('worker');
     expect(merged.window_handle).toBe(131074);
     expect(merged.handle_capture_failed).toBe(false);
+  });
+
+  it('FR-2: capture PERSISTS the owner identity — without this the whole hide feature is inert', async () => {
+    // THE BUG THIS CATCHES SHIPPED GREEN. setWindowOwner had zero production callers and
+    // selectNewWindowHandle returned a bare handle, so readWindowOwner() was null for every real
+    // session and classifyHideRefusal refused EVERY hide — while 60/60 unit tests passed. Both the
+    // TESTING and SECURITY sub-agents found it independently at EXEC.
+    //
+    // The tests that missed it asserted the pure functions in isolation. Nothing asserted the WRITE.
+    // So this drives the real spawn bind-loop and inspects the merged row, which is the only place
+    // the producer and the consumer actually meet.
+    const nowMs = 1_800_000_000_000;
+    const spawnFn = vi.fn().mockReturnValue({ pid: 4242 });
+    // Answers the enumeration calls AND the separate start-ticks read, which enumExec cannot.
+    let call = 0;
+    const execFn = vi.fn(async (_program, args) => {
+      const script = String(args?.[3] || '');
+      if (script.includes('StartTime.Ticks')) return { stdout: 'TICKS|638600000000000000' };
+      call += 1;
+      return { stdout: call === 1 ? '' : '131074|5555|WindowsTerminal|Claude Code' };
+    });
+    const supabaseClient = makeFakeSupabase({
+      sessions: [{
+        session_id: MINTED_SESSION_ID, pid: 4242, status: 'active',
+        created_at: new Date(nowMs - 5_000).toISOString(),
+        metadata: { fleet_identity: { callsign: 'Alpha-5' }, role: 'worker' },
+      }],
+    });
+    await spawn({ role: 'worker', callsign: 'Beta-1' }, { live: true, currencyRunner: CURRENT_RUNNER, spawnFn, execFn, sleepFn: vi.fn(), supabaseClient, nowMs, skipDedup: true, uuidFn: () => MINTED_SESSION_ID });
+    const merged = supabaseClient._store.get(MINTED_SESSION_ID).metadata;
+    // All THREE conjuncts, namespaced. pid alone cannot discriminate: every fleet window on this
+    // host shares one owning pid, so start time is the conjunct that does the work.
+    expect(merged.window_owner_pid).toBe(5555);
+    expect(merged.window_owner_proc).toBe('WindowsTerminal');
+    expect(merged.window_owner_start_ticks).toBe('638600000000000000');
+    // NEVER a bare `pid` key in metadata — that is the shared terminal host, not the seat process.
+    expect(merged).not.toHaveProperty('pid');
+    // And the row this produces must be one the hide guard actually accepts, end to end.
+    expect(classifyHideRefusal(merged)).toBeNull();
   });
 
   it('ADVERSARIAL-REVIEW FIX: never writes metadata for a stale/recycled pid match (created_at outside the freshness window)', async () => {

--- a/tests/unit/fleet/window-enum.test.js
+++ b/tests/unit/fleet/window-enum.test.js
@@ -246,7 +246,16 @@ describe('FR-7 captureNewWindowHandle — bounded budget, asserted by call count
     const sleepFn = vi.fn();
     const r = await captureNewWindowHandle([], { execFn, sleepFn });
     expect(r).toMatchObject({ handle: 4242, handleCaptureFailed: false, attempts: 3 });
-    expect(execFn).toHaveBeenCalledTimes(3);
+    // `attempts` is the budget assertion and stays 3 — that is what "stops as soon as the window
+    // appears" means. The exec COUNT is now polls + ONE owner-identity read
+    // (SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A FR-2: process start time is not available from window
+    // enumeration, so it is a separate cheap read taken once on success, never per poll). Asserting
+    // 4 here rather than loosening to a range keeps this test able to catch a second stray call.
+    expect(execFn).toHaveBeenCalledTimes(4);
+    // The identity read gets this test's enumeration stdout, not a TICKS line, so owner degrades to
+    // null rather than persisting a partial identity — which is the refuse-by-default behaviour the
+    // hide guard depends on.
+    expect(r.owner).toBeNull();
   });
 
   it('does NOT poll on ambiguous — waiting cannot un-appear a window (the futile-poll lesson)', async () => {

--- a/tests/unit/fleet/window-reconcile.test.js
+++ b/tests/unit/fleet/window-reconcile.test.js
@@ -1,0 +1,111 @@
+/**
+ * SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A FR-6 / TS-9 — bidirectional drift detection.
+ *
+ * The SD originally asserted this could only work one way ("a hidden window cannot be
+ * re-enumerated"). Measured false: 348 top-level windows on this host, 36 visible, 312 hidden AND
+ * ENUMERABLE — hidden ones are excluded by exactly one predicate in this repo's own enumeration
+ * command. So the second direction is tested as a first-class case, not as an aspiration.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  buildObservedMap,
+  reconcileWindowVisibility,
+  summarizeDrift,
+  DRIFT_RECORDED_HIDDEN_BUT_VISIBLE,
+  DRIFT_RECORDED_VISIBLE_BUT_HIDDEN,
+} from '../../../lib/fleet/window-reconcile.js';
+
+const sess = (id, window_visible, window_handle) => ({ session_id: id, metadata: { window_visible, window_handle } });
+
+describe('FR-6 / TS-9: BOTH drift directions are detected', () => {
+  it('detects recorded-hidden-but-actually-visible', () => {
+    const observed = buildObservedMap([{ handle: 100, visible: true }]);
+    const r = reconcileWindowVisibility([sess('s1', false, 100)], observed);
+    expect(r.drift).toHaveLength(1);
+    expect(r.drift[0]).toMatchObject({ session_id: 's1', recorded: false, actual: true, direction: DRIFT_RECORDED_HIDDEN_BUT_VISIBLE });
+  });
+
+  it('detects recorded-visible-but-actually-hidden — the direction the SD called impossible', () => {
+    // This is the whole correction. Had the false premise survived, this case would have been
+    // designed out, and every wrongly-hidden seat would sit unreported while the operator was told
+    // everything matched.
+    const observed = buildObservedMap([{ handle: 200, visible: false }]);
+    const r = reconcileWindowVisibility([sess('s2', true, 200)], observed);
+    expect(r.drift).toHaveLength(1);
+    expect(r.drift[0]).toMatchObject({ session_id: 's2', recorded: true, actual: false, direction: DRIFT_RECORDED_VISIBLE_BUT_HIDDEN });
+  });
+
+  it('finds BOTH in one pass — neither direction shadows the other', () => {
+    const observed = buildObservedMap([{ handle: 100, visible: true }, { handle: 200, visible: false }]);
+    const r = reconcileWindowVisibility([sess('s1', false, 100), sess('s2', true, 200)], observed);
+    const dirs = r.drift.map((d) => d.direction).sort();
+    expect(dirs).toEqual([DRIFT_RECORDED_HIDDEN_BUT_VISIBLE, DRIFT_RECORDED_VISIBLE_BUT_HIDDEN].sort());
+    expect(r.checked).toBe(2);
+  });
+
+  it('reports NO drift when record and reality agree, in both states', () => {
+    const observed = buildObservedMap([{ handle: 100, visible: true }, { handle: 200, visible: false }]);
+    const r = reconcileWindowVisibility([sess('s1', true, 100), sess('s2', false, 200)], observed);
+    expect(r.drift).toHaveLength(0);
+    expect(r.checked).toBe(2);
+  });
+});
+
+describe('FR-6: what is SKIPPED is not silently counted as agreement', () => {
+  it.each([
+    ['no recorded visibility', { session_id: 'x', metadata: { window_handle: 100 } }, 'no_recorded_visibility'],
+    ['no usable handle', { session_id: 'x', metadata: { window_visible: true } }, 'no_usable_handle'],
+    ['handle null', { session_id: 'x', metadata: { window_visible: true, window_handle: null } }, 'no_usable_handle'],
+  ])('%s is skipped with a reason, not scored', (_label, session, reason) => {
+    const r = reconcileWindowVisibility([session], buildObservedMap([{ handle: 100, visible: true }]));
+    expect(r.drift).toHaveLength(0);
+    expect(r.checked).toBe(0);
+    expect(r.skipped[0]).toMatchObject({ reason });
+  });
+
+  it('a window that is GONE is skipped, not reported as drift', () => {
+    // A closed window is not a visibility disagreement. Reporting it as drift would manufacture
+    // alarms on every retired seat and bury the real ones.
+    const r = reconcileWindowVisibility([sess('s1', true, 999)], buildObservedMap([{ handle: 100, visible: true }]));
+    expect(r.drift).toHaveLength(0);
+    expect(r.skipped[0]).toMatchObject({ reason: 'window_absent' });
+  });
+});
+
+describe('FR-6: the summary states BOTH counts, including zeros', () => {
+  it('names the recorded_visible_but_hidden count even when it is zero', () => {
+    // An operator who never sees this line cannot tell "checked and clean" from "never checked".
+    // That ambiguity is how a one-directional reconciler would quietly come back.
+    const observed = buildObservedMap([{ handle: 100, visible: true }]);
+    const s = summarizeDrift(reconcileWindowVisibility([sess('s1', true, 100)], observed));
+    expect(s).toContain(`${DRIFT_RECORDED_VISIBLE_BUT_HIDDEN}=0`);
+    expect(s).toContain(`${DRIFT_RECORDED_HIDDEN_BUT_VISIBLE}=0`);
+  });
+
+  it('is total — never throws on an empty or malformed result', () => {
+    for (const v of [undefined, null, {}, { drift: null }]) expect(() => summarizeDrift(v)).not.toThrow();
+  });
+});
+
+describe('FR-6: the retracted claim does not survive anywhere in the artifact', () => {
+  // The PRD requires that no code comment, response, or doc still asserts the converse is
+  // undetectable. A false premise left in prose is how the next author re-derives the same blind
+  // spot after the code has already been fixed.
+  const root = fileURLToPath(new URL('../../../', import.meta.url));
+  it.each([
+    'lib/fleet/window-reconcile.js',
+    'lib/fleet/window-visibility-writer.js',
+    'lib/fleet/window-handle.js',
+    'scripts/fleet-restore-windows.mjs',
+  ])('%s does not claim a hidden window cannot be enumerated', (rel) => {
+    const src = fs.readFileSync(root + rel, 'utf8');
+    // Match the CLAIM, not the retraction: the files legitimately quote the false premise while
+    // labelling it false, so only an unqualified assertion should fail here.
+    const lines = src.split('\n').filter((l) => /cannot be (re-)?enumerated/i.test(l));
+    for (const line of lines) {
+      expect(line, `unqualified claim survives: ${line.trim()}`).toMatch(/measured false|was false|FALSE|originally|retract/i);
+    }
+  });
+});

--- a/tests/unit/fleet/window-reconcile.test.js
+++ b/tests/unit/fleet/window-reconcile.test.js
@@ -93,6 +93,13 @@ describe('FR-6: the retracted claim does not survive anywhere in the artifact', 
   // The PRD requires that no code comment, response, or doc still asserts the converse is
   // undetectable. A false premise left in prose is how the next author re-derives the same blind
   // spot after the code has already been fixed.
+  //
+  // *** THIS IS A TRIPWIRE, NOT A SAFEGUARD — DO NOT MISTAKE IT FOR PROTECTION. *** It matches one
+  // literal phrasing, so it is defeatable by rewording: the TESTING sub-agent inserted "a hidden
+  // window is not observable via enumeration" and all 14 tests in this file stayed green. It is kept
+  // because it costs nothing and catches the copy-paste case, which is the likely one. The REAL
+  // safeguard is behavioural and lives above: the bidirectional drift tests fail if the second
+  // direction is dropped, whatever the comments happen to say.
   const root = fileURLToPath(new URL('../../../', import.meta.url));
   it.each([
     'lib/fleet/window-reconcile.js',

--- a/tests/unit/fleet/window-restore-and-emit.test.js
+++ b/tests/unit/fleet/window-restore-and-emit.test.js
@@ -1,0 +1,108 @@
+/**
+ * SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A — FR-5 (window_visible reaches the client) and FR-7 (the
+ * DB-free panic restore). TS-7 and TS-10.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { formatSessionRow } from '../../../server/routes/fleet-panel.js';
+import {
+  buildRestoreCommand,
+  parseRestoreResult,
+  restoreAllTerminalWindows,
+  TERMINAL_PROCESS_NAME,
+} from '../../../scripts/fleet-restore-windows.mjs';
+
+const row = (metadata) => ({ session_id: 's1', metadata, computed_status: 'active' });
+
+describe('FR-5 / TS-7: window_visible reaches the client, and absent is NOT "visible"', () => {
+  it('emits true when recorded visible, false when recorded hidden', () => {
+    expect(formatSessionRow(row({ window_visible: true })).window_visible).toBe(true);
+    expect(formatSessionRow(row({ window_visible: false })).window_visible).toBe(false);
+  });
+
+  it('emits NULL when never recorded — the distinction the whole SD is about', () => {
+    // Rendering absent as "Open" is the current defect in a new field: a confident visibility claim
+    // the system never checked. Measured across live seats before this SD: window_visible 0/9.
+    expect(formatSessionRow(row({})).window_visible).toBeNull();
+    expect(formatSessionRow(row({ window_visible: null })).window_visible).toBeNull();
+    expect(formatSessionRow(row(undefined)).window_visible).toBeNull();
+  });
+
+  it('null is DISTINGUISHABLE from false — not merged into one falsy state', () => {
+    // The trap: `Boolean(meta.window_visible)` would collapse never-recorded into recorded-hidden,
+    // and the operator could not tell "we hid it" from "we have no idea".
+    const never = formatSessionRow(row({})).window_visible;
+    const hidden = formatSessionRow(row({ window_visible: false })).window_visible;
+    expect(never).toBeNull();
+    expect(hidden).toBe(false);
+    expect(never).not.toBe(hidden);
+  });
+
+  it('does not disturb the fields already emitted', () => {
+    const out = formatSessionRow(row({ window_visible: true }));
+    for (const k of ['session_id', 'identity_kind', 'status', 'sd_key', 'model_effort']) {
+      expect(out).toHaveProperty(k);
+    }
+  });
+});
+
+describe('FR-7 / TS-10: the panic restore needs no database', () => {
+  const src = fs.readFileSync(fileURLToPath(new URL('../../../scripts/fleet-restore-windows.mjs', import.meta.url)), 'utf8');
+
+  it('imports NOTHING but node builtins — a DB import would make the panic case unreachable', () => {
+    // THE ACCEPTANCE CRITERION, asserted structurally. The panic case includes a dead server and an
+    // untrusted database: this recovery must not read the rows the feature may have corrupted.
+    const imports = [...src.matchAll(/^import\s.*?from\s+'([^']+)'/gm)].map((m) => m[1]);
+    expect(imports.length).toBeGreaterThan(0);
+    for (const spec of imports) expect(spec).toMatch(/^node:/);
+  });
+
+  it('is not route-only — it exposes a directly runnable entrypoint', () => {
+    // A route-only implementation fails FR-7: the panic case includes the server being down.
+    expect(src).toContain('#!/usr/bin/env node');
+    expect(typeof restoreAllTerminalWindows).toBe('function');
+  });
+
+  it('enumerates WITHOUT the IsWindowVisible gate — the one predicate that hides hidden windows', () => {
+    // Measured: 348 top-level windows on this host, 36 visible, 312 hidden AND ENUMERABLE. They are
+    // excluded from normal enumeration by exactly one predicate. This command must not re-add it
+    // around the collection, or the panic button cannot see the windows it exists to rescue.
+    const script = buildRestoreCommand().args[3];
+    expect(script).toContain('EnumWindows');
+    expect(script).toContain('ShowWindow');
+    // The Add must not be gated on visibility. It may still READ visibility to count/skip.
+    expect(script).not.toMatch(/if\s*\(\s*IsWindowVisible\s*\(\s*h\s*\)\s*\)\s*\{?\s*[^}]*r\.Add/);
+  });
+
+  it('dry-run builds a command that shows nothing', () => {
+    expect(buildRestoreCommand({ dryRun: true }).args[3]).not.toContain('FleetRestore]::Show');
+    expect(buildRestoreCommand({ dryRun: false }).args[3]).toContain('FleetRestore]::Show');
+  });
+
+  it('targets the terminal host and refuses an injectable process name', () => {
+    expect(buildRestoreCommand().args[3]).toContain(TERMINAL_PROCESS_NAME);
+    for (const bad of ['', 'x; whoami', "a' -or '1"]) {
+      expect(() => buildRestoreCommand({ processName: bad })).toThrow();
+    }
+  });
+
+  it('reports counts, and never reports success on unparseable output', async () => {
+    const ok = await restoreAllTerminalWindows({ execFn: async () => 'RESTORE|17|8' });
+    expect(ok).toMatchObject({ ok: true, terminalWindows: 17, restored: 8 });
+    for (const junk of ['', 'nope', 'RESTORE|', 'RESTORE|x|y']) {
+      const r = await restoreAllTerminalWindows({ execFn: async () => junk });
+      expect(r.ok).toBe(false);
+    }
+  });
+
+  it('an exec failure is reported, not thrown — a panic tool must not stack-trace', async () => {
+    const r = await restoreAllTerminalWindows({ execFn: async () => { throw new Error('powershell missing'); } });
+    expect(r).toMatchObject({ ok: false });
+    expect(r.reason).toMatch(/invocation_failed/);
+  });
+
+  it('parseRestoreResult is total', () => {
+    for (const v of [undefined, null, '', 0, {}, 'RESTORE']) expect(() => parseRestoreResult(v)).not.toThrow();
+  });
+});

--- a/tests/unit/fleet/window-visibility-writer.test.js
+++ b/tests/unit/fleet/window-visibility-writer.test.js
@@ -147,3 +147,45 @@ describe('TS-11: the window-owning pid is NEVER reachable from a kill path', () 
     for (const rel of KILL_PATHS) expect(fs.existsSync(root + rel), `${rel} not found`).toBe(true);
   });
 });
+
+describe('FR-2 PRODUCER: owner identity is actually CAPTURED, not just writable', () => {
+  // THE DEFECT THIS EXISTS TO CATCH, found by TESTING and SECURITY independently at EXEC:
+  // setWindowOwner had ZERO production callers and selectNewWindowHandle returned a bare handle,
+  // so readWindowOwner() was null for every real session and classifyHideRefusal refused EVERY
+  // hide — while 60/60 unit tests passed. A writer with no producer is the same silent class as a
+  // mechanism with no consumer, and a test IS a consumer, which is precisely why the suite was
+  // green. These assert the PRODUCER side, which nothing did before.
+  it('selectNewWindowHandle carries owner pid + proc out with the handle', async () => {
+    const { selectNewWindowHandle } = await import('../../../lib/fleet/window-handle.js');
+    const before = [{ handle: 1, pid: 1, proc: 'WindowsTerminal', title: 'a' }];
+    const after = [...before, { handle: 42, pid: 11340, proc: 'WindowsTerminal', title: 'b' }];
+    const sel = selectNewWindowHandle(before, after, { processName: 'WindowsTerminal' });
+    expect(sel.handle).toBe(42);
+    expect(sel.owner).toEqual({ pid: 11340, procName: 'WindowsTerminal' });
+  });
+
+  it('readProcessStartTicks returns digits, or null rather than a partial identity', async () => {
+    const { readProcessStartTicks } = await import('../../../lib/fleet/window-handle.js');
+    expect(await readProcessStartTicks(11340, { execFn: async () => 'TICKS|638600000000000000' })).toBe('638600000000000000');
+    for (const bad of ['TICKS|', 'TICKS|not-a-number', '', 'garbage']) {
+      expect(await readProcessStartTicks(11340, { execFn: async () => bad })).toBeNull();
+    }
+    expect(await readProcessStartTicks(11340, { execFn: async () => { throw new Error('gone'); } })).toBeNull();
+  });
+
+  it('THE END-TO-END SHAPE: what capture persists is what the hide guard accepts', () => {
+    // The contract that was broken: capture wrote {window_handle} only, and classifyHideRefusal
+    // requires window_owner_pid/proc/start_ticks too. Pin both ends against the SAME object so they
+    // cannot drift apart again without a test going red.
+    const persisted = {
+      window_handle: 42,
+      window_owner_pid: 11340,
+      window_owner_proc: 'WindowsTerminal',
+      window_owner_start_ticks: '638600000000000000',
+    };
+    expect(classifyHideRefusal(persisted)).toBeNull();
+    expect(readWindowOwner(persisted)).toEqual({ pid: 11340, procName: 'WindowsTerminal', startTicks: '638600000000000000' });
+    // And the pre-fix shape must still be refused, so the regression is caught if capture reverts.
+    expect(classifyHideRefusal({ window_handle: 42 })).toBe('window_owner_identity_incomplete');
+  });
+});

--- a/tests/unit/fleet/window-visibility-writer.test.js
+++ b/tests/unit/fleet/window-visibility-writer.test.js
@@ -1,0 +1,149 @@
+/**
+ * SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A — FR-2/FR-3 persistence seam.
+ *
+ * TS-3 (all three handle-less shapes refuse, asserted SEPARATELY) and TS-11 (the new window-owning
+ * pid is never reachable from a kill path) live here. TS-5 — that a concurrent metadata writer does
+ * not drop the field — is deliberately NOT here: it needs a real database, and asserting it against
+ * a stubbed client would only re-assert the SQL string I wrote. It is recorded as an integration
+ * scenario rather than faked at this seam.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  setWindowVisible,
+  setWindowOwner,
+  readWindowOwner,
+  classifyHideRefusal,
+  WINDOW_VISIBLE_KEY,
+  WINDOW_OWNER_KEYS,
+} from '../../../lib/fleet/window-visibility-writer.js';
+
+/** Records the SQL and params so we can assert the MERGE shape, not just that a call happened. */
+function stubClient() {
+  const calls = [];
+  const createClientFn = async () => ({
+    query: async (sql, params) => { calls.push({ sql, params }); return { rowCount: 1 }; },
+    end: async () => {},
+  });
+  return { createClientFn, calls };
+}
+
+describe('FR-3: the write is an ATOMIC merge, not a read-spread-write', () => {
+  it('uses COALESCE(metadata) || patch keyed on session_id', async () => {
+    const { createClientFn, calls } = stubClient();
+    await setWindowVisible('sess-1', { visible: false, by: 'test' }, { createClientFn });
+    expect(calls).toHaveLength(1);
+    const sql = calls[0].sql.replace(/\s+/g, ' ');
+    // The whole point of FR-3: a concurrent writer must not lose its field, and we must not lose
+    // ours. A SELECT-then-UPDATE-whole-blob would satisfy "it wrote" and fail that.
+    expect(sql).toContain("COALESCE(metadata, '{}'::jsonb) || $2::jsonb");
+    expect(sql).toContain('WHERE session_id = $1');
+    expect(sql).not.toMatch(/\bSELECT\b/i);
+  });
+
+  it('sends only its own keys in the patch — a partial merge, never a full blob', async () => {
+    const { createClientFn, calls } = stubClient();
+    await setWindowVisible('sess-1', { visible: true, by: 'test' }, { createClientFn });
+    const patch = JSON.parse(calls[0].params[1]);
+    expect(Object.keys(patch).sort()).toEqual(['window_visible', 'window_visible_set_at', 'window_visible_set_by']);
+    expect(patch[WINDOW_VISIBLE_KEY]).toBe(true);
+  });
+
+  it('refuses malformed input rather than writing a half-truth', async () => {
+    const { createClientFn } = stubClient();
+    await expect(setWindowVisible('', { visible: true, by: 'x' }, { createClientFn })).rejects.toThrow();
+    await expect(setWindowVisible('s', { visible: 'yes', by: 'x' }, { createClientFn })).rejects.toThrow();
+    await expect(setWindowVisible('s', { visible: true }, { createClientFn })).rejects.toThrow();
+  });
+
+  it('surfaces a DB failure as not-written instead of throwing', async () => {
+    const createClientFn = async () => ({ query: async () => { throw new Error('db exploded'); }, end: async () => {} });
+    const r = await setWindowVisible('sess-1', { visible: false, by: 'test' }, { createClientFn });
+    expect(r.written).toBe(false);
+    expect(r.error).toMatch(/db exploded/);
+  });
+});
+
+describe('FR-2: owner identity is three conjuncts, and start time is required', () => {
+  it('persists pid + proc + START TICKS under namespaced keys', async () => {
+    const { createClientFn, calls } = stubClient();
+    await setWindowOwner('sess-1', { pid: 11340, procName: 'WindowsTerminal', startTicks: '638600000000000000' }, { createClientFn });
+    const patch = JSON.parse(calls[0].params[1]);
+    for (const k of WINDOW_OWNER_KEYS) expect(patch).toHaveProperty(k);
+    // NEVER a bare `pid` key: a future reader must not mistake the window owner for the seat process.
+    expect(patch).not.toHaveProperty('pid');
+  });
+
+  it('rejects a partial identity — pid alone is not a guard', async () => {
+    const { createClientFn } = stubClient();
+    const bad = [
+      { pid: 11340, procName: 'WindowsTerminal' },                       // no start time
+      { pid: 11340, startTicks: '1' },                                   // no proc name
+      { procName: 'WindowsTerminal', startTicks: '1' },                  // no pid
+      { pid: 0, procName: 'WindowsTerminal', startTicks: '1' },
+      { pid: 11340, procName: 'bad name; whoami', startTicks: '1' },
+      { pid: 11340, procName: 'WindowsTerminal', startTicks: 'nope' },
+    ];
+    for (const o of bad) await expect(setWindowOwner('s', o, { createClientFn })).rejects.toThrow();
+  });
+
+  it('readWindowOwner returns null on any incomplete identity', () => {
+    expect(readWindowOwner({ window_owner_pid: 1, window_owner_proc: 'x', window_owner_start_ticks: '9' })).toEqual({ pid: 1, procName: 'x', startTicks: '9' });
+    for (const m of [null, {}, { window_owner_pid: 1 }, { window_owner_pid: 1, window_owner_proc: 'x' }, { window_owner_pid: 0, window_owner_proc: 'x', window_owner_start_ticks: '9' }]) {
+      expect(readWindowOwner(m)).toBeNull();
+    }
+  });
+});
+
+describe('TS-3: all THREE handle-less shapes refuse, asserted separately', () => {
+  // Aggregating these into one "refuses when no handle" case is the vacuity trap the PRD calls out:
+  // spawn's bind loop can leave the key ABSENT, a capture failure writes handle_capture_failed,
+  // and the key can be present-but-null. They are different states from different code paths.
+  const owner = { window_owner_pid: 1, window_owner_proc: 'x', window_owner_start_ticks: '9' };
+
+  it('shape 1: window_handle key ABSENT (bind loop never found a fresh row)', () => {
+    expect(classifyHideRefusal({ ...owner })).toBe('window_handle_absent');
+  });
+
+  it('shape 2: window_handle present but NULL', () => {
+    expect(classifyHideRefusal({ ...owner, window_handle: null })).toBe('window_handle_null');
+  });
+
+  it('shape 3: handle_capture_failed === true (capture failed, bind landed)', () => {
+    expect(classifyHideRefusal({ ...owner, window_handle: 42, handle_capture_failed: true })).toBe('handle_capture_failed');
+  });
+
+  it('also refuses a handle with an INCOMPLETE owner identity', () => {
+    expect(classifyHideRefusal({ window_handle: 42 })).toBe('window_owner_identity_incomplete');
+  });
+
+  it('permits only a complete handle + owner identity', () => {
+    expect(classifyHideRefusal({ ...owner, window_handle: 42 })).toBeNull();
+  });
+});
+
+describe('TS-11: the window-owning pid is NEVER reachable from a kill path', () => {
+  // THE HAZARD THIS SD CREATES. window_owner_pid is the SHARED WindowsTerminal host — measured, one
+  // pid for all 9 seats — so taskkill /T /F on it is a nine-seat outage. The per-seat process is
+  // claude_sessions.pid, which is what the kill paths already use. Before this SD no window-owning
+  // pid existed in the session row at all; this test exists because we put one there.
+  //
+  // Grep is the right instrument: the failure mode is a future author reasonably assuming that a pid
+  // on a session row IS that session's process.
+  const root = fileURLToPath(new URL('../../../', import.meta.url));
+  const KILL_PATHS = ['lib/fleet/graceful-kill.mjs', 'scripts/fleet-kill.mjs'];
+
+  it.each(KILL_PATHS)('%s references no window-owner field', (rel) => {
+    const src = fs.readFileSync(root + rel, 'utf8');
+    for (const key of [...WINDOW_OWNER_KEYS, 'window_handle']) {
+      expect(src, `${rel} must not read ${key} — it is the shared terminal host, not the seat process`).not.toContain(key);
+    }
+  });
+
+  it('the kill paths exist where this test thinks they do — negative control', () => {
+    // Without this, a renamed or moved file turns the assertions above into a silent pass:
+    // readFileSync would throw, but a future edit wrapping it in a try would not.
+    for (const rel of KILL_PATHS) expect(fs.existsSync(root + rel), `${rel} not found`).toBe(true);
+  });
+});

--- a/tests/unit/fleet/window-visibility.test.js
+++ b/tests/unit/fleet/window-visibility.test.js
@@ -1,0 +1,153 @@
+/**
+ * SD-LEO-INFRA-SESSIONS-PAGE-TRUE-001-A — FR-1 (verify-your-own-outcome) and FR-2 (owner-identity
+ * guard), at the injected-execFn seam so no real window is touched.
+ *
+ * WHY THIS FILE IS SHAPED AROUND ONE IDEA. The SD's spine originally offered focusWindow as the
+ * safety precedent for hide. It is not one: focusWindow returns TRUE whenever the PowerShell process
+ * resolves, because buildFocusCommand never inspects SetForegroundWindow's boolean return. Its only
+ * test injects a mock REJECTION, so it proves the process-failure path and never real Win32
+ * behaviour. Copying that contract into a destructive verb would mean reporting a successful hide
+ * for a window that is still visible. TS-1 below is the direct guard against that, and it is the
+ * test most likely to be deleted by someone who thinks it is redundant.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  buildSetVisibilityCommand,
+  parseVisibilityResult,
+  setWindowVisibility,
+  SW_HIDE,
+  SW_SHOW,
+} from '../../../lib/fleet/window-handle.js';
+
+const OWNER = { pid: 11340, procName: 'WindowsTerminal', startTicks: '638600000000000000' };
+const okLine = (vis) => `RESULT|ok||${vis}`;
+
+describe('FR-1: the verb reports what the WORLD says, not that the call returned', () => {
+  it('TS-1: a RESOLVING exec with the window still visible is a FAILURE, not a success', async () => {
+    // THE ANTI-VACUITY GUARD. This is the exact shape focusWindow gets wrong. The exec resolves
+    // cleanly — no throw, no rejection — and the post-call visibility reading says the window is
+    // still there. Anything that reports success here has inherited the bug this SD exists to avoid.
+    const execFn = async () => okLine('True');
+    const r = await setWindowVisibility(4242, { show: false, owner: OWNER, execFn });
+    expect(r.ok).toBe(true);            // the invocation itself was well-formed
+    expect(r.visibleAfter).toBe(true);  // ...and the world says the window is STILL VISIBLE
+    expect(r.achieved).toBe(false);     // so the HIDE did not happen. This is the assertion that matters.
+  });
+
+  it('a hide that actually hid reports achieved', async () => {
+    const r = await setWindowVisibility(4242, { show: false, owner: OWNER, execFn: async () => okLine('False') });
+    expect(r).toMatchObject({ ok: true, visibleAfter: false, achieved: true });
+  });
+
+  it('a show that actually showed reports achieved', async () => {
+    const r = await setWindowVisibility(4242, { show: true, owner: OWNER, execFn: async () => okLine('True') });
+    expect(r).toMatchObject({ ok: true, visibleAfter: true, achieved: true });
+  });
+
+  it('a show whose window stayed hidden is NOT achieved — the symmetric case', async () => {
+    const r = await setWindowVisibility(4242, { show: true, owner: OWNER, execFn: async () => okLine('False') });
+    expect(r.achieved).toBe(false);
+  });
+
+  it('an exec that REJECTS refuses rather than reporting an unknown state', async () => {
+    const r = await setWindowVisibility(4242, { show: false, owner: OWNER, execFn: async () => { throw new Error('boom'); } });
+    expect(r).toMatchObject({ ok: false, refused: true, achieved: false });
+  });
+
+  it('unparseable output is never a success', async () => {
+    for (const junk of ['', 'nothing here', 'RESULT|weird', okLine('Maybe')]) {
+      const r = await setWindowVisibility(4242, { show: false, owner: OWNER, execFn: async () => junk });
+      expect(r.achieved).toBe(false);
+      expect(r.ok).toBe(false);
+    }
+  });
+});
+
+describe('FR-2: verification and the act are ONE invocation, with three conjuncts', () => {
+  const script = (over = {}) => buildSetVisibilityCommand({ handle: 4242, show: false, ownerPid: OWNER.pid, ownerProcName: OWNER.procName, ownerStartTicks: OWNER.startTicks, ...over }).args[3];
+
+  it('ATOMICITY: the owner checks and ShowWindow live in the SAME command string', () => {
+    // Splitting these into two execFile calls reopens a TOCTOU window of PowerShell startup plus
+    // Add-Type compilation — ~4.9s in this repo — versus microseconds in-process. Atomicity
+    // dominates the CONTENT of the check, so this asserts they are inseparable.
+    const s = script();
+    expect(s).toContain('GetWindowThreadProcessId');
+    expect(s).toContain('ShowWindow');
+    expect(s).toContain('StartTime.Ticks');
+    expect(s).toContain('ProcessName');
+  });
+
+  it('all THREE conjuncts are present — pid alone has zero discriminating power here', () => {
+    // Measured on this host: 9 visible WindowsTerminal windows share ONE owning pid, while 9 cmd
+    // windows had 9 distinct pids. A pid-equality guard therefore passes in exactly the recycled-
+    // handle case it exists to catch. Start time is the conjunct that defeats pid recycling.
+    const s = script();
+    expect(s).toContain(String(OWNER.pid));
+    expect(s).toContain(OWNER.procName);
+    expect(s).toContain(OWNER.startTicks);
+  });
+
+  it('IsWindow is NOT the validity primitive', () => {
+    // IsWindow(h) returns TRUE for a recycled handle, so it passes precisely when the guard should
+    // refuse — and it is the first thing a builder reaches for. Grep-level is the right instrument
+    // for "someone reached for the obvious wrong primitive".
+    expect(script()).not.toMatch(/\bIsWindow\s*\(/);
+  });
+
+  it('emits SW_HIDE for hide and SW_SHOW for show, never SW_MINIMIZE', () => {
+    expect(script({ show: false })).toContain(`ShowWindow($h,${SW_HIDE})`);
+    expect(script({ show: true })).toContain(`ShowWindow($h,${SW_SHOW})`);
+    expect(SW_HIDE).toBe(0);
+    expect(SW_SHOW).toBe(5);
+  });
+
+  it('refuses to build a command from unusable owner identity rather than interpolating it', () => {
+    // Refuse-by-default at construction: a malformed conjunct must not reach a shell, and must not
+    // silently become a weaker check.
+    const bad = [
+      { ownerPid: null }, { ownerPid: 0 }, { ownerPid: -1 },
+      { ownerStartTicks: '' }, { ownerStartTicks: 'not-ticks' },
+      { ownerProcName: '' }, { ownerProcName: 'evil; rm -rf /' }, { ownerProcName: "x'; whoami #" },
+      { handle: 0 }, { handle: 'abc' },
+    ];
+    for (const over of bad) expect(() => script(over)).toThrow();
+  });
+});
+
+describe('FR-2: refusals are named, and never silently succeed', () => {
+  it.each([
+    ['handle_not_a_window', 'RESULT|refused|handle_not_a_window|'],
+    ['owner_pid_mismatch', 'RESULT|refused|owner_pid_mismatch|'],
+    ['owner_process_gone', 'RESULT|refused|owner_process_gone|'],
+    ['owner_proc_name_mismatch', 'RESULT|refused|owner_proc_name_mismatch|'],
+    ['owner_start_time_mismatch', 'RESULT|refused|owner_start_time_mismatch|'],
+  ])('refusal %s is surfaced by name and is not achieved', async (reason, line) => {
+    const r = await setWindowVisibility(4242, { show: false, owner: OWNER, execFn: async () => line });
+    expect(r).toMatchObject({ ok: false, refused: true, reason, achieved: false });
+  });
+
+  it('TS-4 (non-vacuous form): a SAME-PID impostor whose start time differs is REFUSED', async () => {
+    // The original TS-4 asserted a pid MISMATCH refusal — on this host that is a test that cannot
+    // fail for the case it targets, because every fleet window shares one owning pid so pid equality
+    // is always true. The discriminating case is same pid, different process start time.
+    const r = await setWindowVisibility(4242, {
+      show: false,
+      owner: { ...OWNER, startTicks: '638699999999999999' },
+      execFn: async () => 'RESULT|refused|owner_start_time_mismatch|',
+    });
+    expect(r.refused).toBe(true);
+    expect(r.reason).toBe('owner_start_time_mismatch');
+    expect(r.achieved).toBe(false);
+  });
+});
+
+describe('parseVisibilityResult is pure and total', () => {
+  it('picks the RESULT line out of surrounding noise', () => {
+    expect(parseVisibilityResult(`warning: something\n${okLine('False')}\ntrailing`)).toMatchObject({ ok: true, visibleAfter: false });
+  });
+  it('never throws on any input', () => {
+    for (const v of [undefined, null, '', 0, 'RESULT|', 'RESULT|ok', {}]) {
+      expect(() => parseVisibilityResult(v)).not.toThrow();
+    }
+  });
+});

--- a/tests/unit/fleet/window-visibility.test.js
+++ b/tests/unit/fleet/window-visibility.test.js
@@ -77,6 +77,19 @@ describe('FR-2: verification and the act are ONE invocation, with three conjunct
     expect(s).toContain('ProcessName');
   });
 
+  it('ATOMICITY, BEHAVIOURALLY: exactly ONE exec call per hide — the string check alone was vacuous', async () => {
+    // ADDED AFTER THE TESTING SUB-AGENT DEFEATED THE TEST ABOVE. That one inspects only what
+    // buildSetVisibilityCommand returns, so splitting setWindowVisibility into a validate-call and
+    // a separate act-call left all 60 tests green — the exact TOCTOU regression the PRD names as
+    // "a FAIL regardless of what the check contains". Asserting the command TEXT cannot see how many
+    // times the command is RUN, so the invocation count has to be measured directly.
+    let calls = 0;
+    const execFn = async () => { calls += 1; return 'RESULT|ok||False'; };
+    const r = await setWindowVisibility(4242, { show: false, owner: OWNER, execFn });
+    expect(r.achieved).toBe(true);
+    expect(calls, 'verification and ShowWindow must occur in ONE invocation').toBe(1);
+  });
+
   it('all THREE conjuncts are present — pid alone has zero discriminating power here', () => {
     // Measured on this host: 9 visible WindowsTerminal windows share ONE owning pid, while 9 cmd
     // windows had 9 distinct pids. A pid-equality guard therefore passes in exactly the recycled-


### PR DESCRIPTION
## Summary

Backend half of the TRUE HIDE decomposition: an `SW_HIDE`/`SW_SHOW` primitive that verifies its own outcome, hide/show verb and routes, atomic `window_visible` persistence, owner-identity capture, refusal guards, bidirectional reconciliation, and a DB-free panic restore.

**The defect it closes is operator truth.** `formatSessionRow` emitted no window field at all, while the UI seeded its toggle from `row.window_visible` — a field no backend produced — then tracked it in React state alone. With a 15-second refetch the control reverted to "Open" regardless of the real OS state. Measured across live seats before this change: `window_handle` 9/9, `window_visible` **0/9**.

## Four premises in the SD's own spine were measured false

Each would have shipped a specific defect:

| Premise | Measured | Defect avoided |
|---|---|---|
| "A hidden window cannot be re-enumerated" | 348 windows, 36 visible, **312 hidden and enumerable** — excluded only by this repo's own `IsWindowVisible` predicate | Enabled FR-6 bidirectional reconciliation **and** FR-7 panic restore, both ruled out on paper by the false claim |
| "Re-validate handle + owning PID" | All 9 terminal windows share **one** owning pid (9 cmd windows had 9 distinct) | A guard that passes in exactly the recycled-handle case it exists to catch |
| "`focusWindow` fails safe" | Returns `true` whenever the process resolves; never inspects `SetForegroundWindow` | Hide would report success for windows still on screen |
| "Every metadata write is read-spread-write" | Six atomic writers already existed | Inventing a third mechanism instead of reusing `attention-flag-writer.js` |

## A green suite was the reason a defect survived

`setWindowOwner` shipped with **zero production callers** while 60/60 tests passed — every hide against every real session would have been refused. Found by TESTING and SECURITY independently.

The reason it stayed green is the lesson: **a test is a consumer.** Every test built the owner identity by hand, so the only unexercised path was the one that has to *create* it. My first fix repeated the pattern — I mutated the capture write, the suite stayed green, and only a test driving the real spawn bind loop caught it.

Two further tests could not fail: the atomicity check inspected only the command *string* (a two-call TOCTOU split passed), and the FR-6 prose guard matches one literal phrasing. The first was made behavioural; the second was **labelled a tripwire** rather than dressed up as a safeguard.

## Safety properties

- Verification and `ShowWindow` occur in **one** PowerShell invocation — splitting them reopens a ~4.9s TOCTOU window versus microseconds in-process
- Three conjuncts: pid + process name + process **start time** (the one that defeats pid recycling)
- `IsWindow(h)` deliberately unused — it returns true for a recycled handle
- Refuse-by-default; `window_visible` written only after a *verified* flip
- `window_owner_pid` is namespaced and documented as **never a kill target** — it's the shared terminal host, so `taskkill /T /F` on it is a nine-seat outage. TS-11 guards the kill paths (raised by a peer session cross-checking work that wasn't theirs)

## Test plan

- 1698 passed across `tests/unit/fleet` + `tests/unit/server` (135 files)
- Full unit project: 12 pre-existing failures, flaky between runs, none touching fleet code
- FR-7 proven in its real failure mode — run with DB credentials unset: 17 terminal windows, 8 hidden and restorable

## Known gaps, recorded not buried

- TS-2/TS-5/TS-6/TS-8 have no automated coverage (real disposable window, concurrent DB writer, seat-discovery regression, route-level behaviour)
- Actor attribution hardcoded `'fleet-api'` instead of `req.user`
- The three-conjunct guard authenticates the owning **process**, not the window instance — intra-process HWND recycling inside the long-lived shared host is undetected, which SECURITY notes is the likelier reuse path here

🤖 Generated with [Claude Code](https://claude.com/claude-code)