### PR TITLE
fix(SD-LEO-FIX-EXTRACT-SEC-OUT-001): extract SEC-3 + SEC-6 from PR #6528, leave the enqueue path gated

### DIFF
--- a/lib/eva/stage-zero/nursery-reeval-invoker.js
+++ b/lib/eva/stage-zero/nursery-reeval-invoker.js
@@ -1,0 +1,166 @@
+/**
+ * SD-EHG-IDEATION-PIPELINE-SEAMS-001 (FR-6) — the scheduled invoker.
+ *
+ * FR-6 is BREAK 3's measured root cause: nothing repeats the promotion path without a human.
+ * venture-monitor.js:267 registers a job literally named `nursery_reevaluation`, but
+ * _nurseryReEvaluation queries eva_ventures and never touches venture_nursery, and its only
+ * entry point is archived and referenced by nothing. The single wired traversal is a manual UI
+ * dialog. So the nursery has had a scheduler-shaped hole with a scheduler-shaped name in it.
+ *
+ * THIS MODULE DECIDES NOTHING ITSELF, WHICH IS THE POINT. Eligibility comes from FR-1's
+ * applyPendingNurseryPredicate and the row shape comes from FR-5's buildNurseryReevalRequest.
+ * A scheduler that re-derived "which rows are due" would become the FOURTH disagreeing predicate
+ * — the exact defect FR-1 existed to remove. It composes; it does not reimplement.
+ *
+ * ATTRIBUTION IS NOT A PARAMETER. The principal is read from the registry rather than accepted
+ * from the caller, so there is no argument a scheduler could pass that attributes a witness row
+ * to a human.
+ *
+ * CORRECTION (security review SEC-3, HIGH-VALUE CATCH). An earlier version of this comment
+ * claimed buildNurseryReevalRequest enforces AC-10 "independently — a second lock on the same
+ * door". THAT WAS FALSE and is retracted rather than quietly deleted. Both this module and the
+ * builder validate against whatever `registeredPrincipals` is INJECTED, so they are one lock
+ * with one key: a single dep injection defeats AC-9 and AC-10 together. The seam exists for
+ * tests and no production caller uses it (scripts/nursery-reeval-invoker.mjs passes {supabase}
+ * alone), so enforcement here is genuinely CODE-REVIEW-ONLY. Saying so plainly is the point —
+ * a safety claim that overstates its own guarantee is worse than no claim, because the next
+ * reader stops looking. The durable fix is a BEFORE INSERT trigger requiring a registered
+ * principal for headless strategies; that is DB work and is not in this module's gift.
+ */
+
+import {
+  NURSERY_PENDING_COLUMNS,
+  applyPendingNurseryPredicate,
+} from './venture-nursery.js';
+import {
+  buildNurseryReevalRequest,
+  REGISTERED_SERVICE_PRINCIPALS,
+  NURSERY_REEVAL_STRATEGY,
+} from './nursery-reeval-request.js';
+
+/**
+ * Statuses that mean "this request is still going to be acted on".
+ *
+ * PROBED AGAINST THE LIVE ENUM, NOT ASSUMED — and the first version of this line was WRONG.
+ * It read ['pending','processing'] and Postgres rejected the query outright: invalid input
+ * value for enum stage_zero_status: "processing". The unit tests did not catch it because they
+ * mock the .in() call, so they validated my assumption rather than the database; only running
+ * the real CLI against the real schema surfaced it. Probing each candidate individually,
+ * stage_zero_status admits: pending, claimed, in_progress, completed, dismissed, failed —
+ * 'processing' and 'running' are not members. The three below are the not-yet-terminal ones.
+ */
+export const OPEN_REQUEST_STATUSES = Object.freeze(['pending', 'claimed', 'in_progress']);
+
+/**
+ * Is there already an open nursery_reeval request for this candidate?
+ *
+ * WHY THIS EXISTS AND WHY IT IS NOT OPTIONAL. The processor polls every 30s and the invoker is
+ * scheduled; without this the invoker enqueues a fresh duplicate on EVERY tick for as long as the
+ * candidate stays unpromoted, because enqueueing does not itself change next_evaluation_at. That
+ * is an unbounded queue of identical work whose first symptom is a bill, not an error. The
+ * dedupe key is (strategy, nursery_id) rather than nursery_id alone so an unrelated path holding
+ * a request for the same candidate does not suppress ours.
+ */
+export function hasOpenRequestFor(rows, nurseryId) {
+  return (rows || []).some((r) => {
+    const m = r && r.metadata ? r.metadata : {};
+    return m.strategy === NURSERY_REEVAL_STRATEGY && m.nursery_id === nurseryId;
+  });
+}
+
+/**
+ * Select the next due nursery candidate and enqueue one correctly-shaped Stage-0 request.
+ *
+ * Returns a verdict object rather than throwing on the ordinary "nothing to do" paths, because a
+ * scheduler that exits non-zero on an empty queue trains its operator to ignore it.
+ *
+ * @param {object}  [opts]
+ * @param {Date|string} [opts.now] injectable clock, threaded to the FR-1 predicate
+ * @param {boolean} [opts.dryRun=false] resolve + build + validate, but do NOT insert
+ * @param {object}  deps
+ * @param {object}  deps.supabase
+ * @param {string[]} [deps.registeredPrincipals] test seam ONLY; production reads the registry
+ * @returns {Promise<{enqueued:boolean, reason:string, nurseryId?:string, request?:object}>}
+ */
+export async function invokeNurseryReeval(opts = {}, deps = {}) {
+  const {
+    supabase,
+    registeredPrincipals = REGISTERED_SERVICE_PRINCIPALS,
+    logger = console,
+  } = deps;
+  const { now, dryRun = false } = opts;
+
+  if (!supabase) throw new Error('supabase client is required');
+
+  // Fail BEFORE reading the nursery. A registry with no principal means this scheduler has no
+  // honest author, and discovering that after selecting a candidate would log a candidate we
+  // were never able to act on — which reads like a selection bug rather than a config gap.
+  const principal = registeredPrincipals[0];
+  if (!principal) {
+    return { enqueued: false, reason: 'no_registered_service_principal' };
+  }
+
+  const { data: due, error: dueErr } = await applyPendingNurseryPredicate(
+    supabase.from('venture_nursery').select(NURSERY_PENDING_COLUMNS),
+    { now },
+  ).limit(1);
+  if (dueErr) throw new Error(`nursery selection failed: ${dueErr.message}`);
+  if (!due || due.length === 0) {
+    return { enqueued: false, reason: 'no_due_candidates' };
+  }
+
+  const candidate = due[0];
+
+  // SCOPED SERVER-SIDE (security review SEC-6). This previously fetched EVERY open request and
+  // filtered in JS, which meant the PostgREST 1000-row cap could silently truncate the result —
+  // and a truncated dedupe read returns "no duplicate" for a duplicate that exists, reviving the
+  // unbounded queue this check is the only guard against. Filtering on the two metadata keys
+  // that define the dedupe identity makes the result set at most a handful of rows, so the cap
+  // is unreachable rather than merely unlikely. .limit(1) because existence is the whole question.
+  const { data: open, error: openErr } = await supabase
+    .from('stage_zero_requests')
+    .select('id, metadata, status')
+    .in('status', OPEN_REQUEST_STATUSES)
+    .eq('metadata->>strategy', NURSERY_REEVAL_STRATEGY)
+    .eq('metadata->>nursery_id', candidate.id)
+    .limit(1);
+  // A failed dedupe read must NOT fall through to enqueueing. "I could not tell whether a
+  // duplicate exists" is not "no duplicate exists", and the failure mode of guessing is the
+  // unbounded queue this check exists to prevent.
+  if (openErr) throw new Error(`open-request read failed: ${openErr.message}`);
+  // Re-checked in JS as well as in the query. Belt-and-braces is cheap here and keeps the dedupe
+  // SEMANTIC in one testable place, so a future change to the server-side filter cannot silently
+  // widen what counts as a duplicate without this predicate disagreeing.
+  if (hasOpenRequestFor(open, candidate.id)) {
+    return { enqueued: false, reason: 'already_queued', nurseryId: candidate.id };
+  }
+
+  // RESIDUAL, STATED RATHER THAN PAPERED OVER (SEC-6): this is read-then-insert, so two invokers
+  // racing can both read zero and both insert. The workflow `concurrency` group serialises
+  // Actions runs but NOT a concurrent manual CLI run, and no unique index backs it. Closing it
+  // properly needs a partial unique index on (metadata->>'nursery_id') WHERE status IN
+  // (open statuses) — a migration, and migrations here are chairman-gated, so it is recorded
+  // rather than smuggled in. Blast radius of the residual is a duplicate request, not a
+  // duplicate promotion: the queue processor claims rows before draining them.
+
+  // Throws UnregisteredPrincipalError if the registry ever drifts — AC-10's own guard, kept in
+  // the path rather than trusted to have been checked above.
+  const request = buildNurseryReevalRequest(
+    { requestedBy: principal, nurseryId: candidate.id },
+    { registeredPrincipals },
+  );
+
+  if (dryRun) {
+    return { enqueued: false, reason: 'dry_run', nurseryId: candidate.id, request };
+  }
+
+  const { data: inserted, error: insErr } = await supabase
+    .from('stage_zero_requests')
+    .insert(request)
+    .select('id')
+    .single();
+  if (insErr) throw new Error(`enqueue failed: ${insErr.message}`);
+
+  logger.log?.(`[nursery-reeval-invoker] enqueued ${inserted.id} for nursery ${candidate.id}`);
+  return { enqueued: true, reason: 'enqueued', nurseryId: candidate.id, requestId: inserted.id, request };
+}

--- a/lib/eva/stage-zero/nursery-reeval-request.js
+++ b/lib/eva/stage-zero/nursery-reeval-request.js
@@ -72,8 +72,11 @@ export function buildNurseryReevalRequest({
   candidateCount = 1,
   constraints = {},
 } = {}, { registeredPrincipals = REGISTERED_SERVICE_PRINCIPALS } = {}) {
-  if (!registeredPrincipals.includes(requestedBy)) {
-    throw new UnregisteredPrincipalError(requestedBy, registeredPrincipals);
+  // Array.isArray FIRST (security review SEC-3): String.prototype.includes does SUBSTRING
+  // matching, so a caller passing a string registry would let any substring of it through —
+  // an allowlist that silently degrades into a fuzzy match is worse than no allowlist.
+  if (!Array.isArray(registeredPrincipals) || !registeredPrincipals.includes(requestedBy)) {
+    throw new UnregisteredPrincipalError(requestedBy, registeredPrincipals || []);
   }
   if (!nurseryId || !UUID_RE.test(nurseryId)) {
     // FR-5 names its target by UUID because five nursery rows tie at score 90 and one of

--- a/tests/unit/eva/stage-zero/nursery-reeval-invoker.test.js
+++ b/tests/unit/eva/stage-zero/nursery-reeval-invoker.test.js
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import {
+  invokeNurseryReeval,
+  hasOpenRequestFor,
+  OPEN_REQUEST_STATUSES,
+} from '../../../../lib/eva/stage-zero/nursery-reeval-invoker.js';
+import { NURSERY_REEVAL_STRATEGY } from '../../../../lib/eva/stage-zero/nursery-reeval-request.js';
+
+const HEADLINE_TRANSFORMER = '3d95f7ea-7d6e-4ffd-ba14-2d915b65fda1';
+const SERVICE_PRINCIPAL = '27e0e91e-35f7-4617-bbb9-932408db80f1';
+const CHAIRMAN_HUMAN_UID = '69c8aa7a-7661-48ed-9779-746fa6290873';
+
+/**
+ * Minimal supabase double. The nursery query must survive the FR-1 predicate's real chain
+ * (.is/.or/.order x3/.limit), so the builder returns itself until it is awaited — if the
+ * invoker ever stops routing through applyPendingNurseryPredicate this double stops matching
+ * and the test fails, which is the point.
+ */
+function makeSupabase({ due = [], open = [], insertResult = { id: 'req-1' }, openError = null, dueError = null } = {}) {
+  const calls = { inserted: null, predicateOps: [], dedupeFilters: [], dedupeStatuses: null };
+  const nurseryQuery = {
+    is(...a) { calls.predicateOps.push('is'); return this; },
+    or(...a) { calls.predicateOps.push('or'); return this; },
+    order(...a) { calls.predicateOps.push('order'); return this; },
+    limit() { return Promise.resolve({ data: due, error: dueError }); },
+  };
+  return {
+    calls,
+    from(table) {
+      if (table === 'venture_nursery') return { select: () => nurseryQuery };
+      if (table === 'stage_zero_requests') {
+        return {
+          select: () => {
+            // SEC-6: the dedupe read is now scoped SERVER-SIDE. Record the filters so a
+            // regression to "fetch every open request and filter in JS" fails here rather
+            // than silently reintroducing the 1000-row truncation.
+            const q = {
+              in(_col, statuses) { calls.dedupeStatuses = statuses; return this; },
+              eq(col, val) { calls.dedupeFilters.push([col, val]); return this; },
+              limit() { return Promise.resolve({ data: open, error: openError }); },
+            };
+            return q;
+          },
+          insert: (row) => {
+            calls.inserted = row;
+            return { select: () => ({ single: () => Promise.resolve({ data: insertResult, error: null }) }) };
+          },
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  };
+}
+
+const withPrincipal = { registeredPrincipals: [SERVICE_PRINCIPAL] };
+const candidate = { id: HEADLINE_TRANSFORMER, name: 'Headline Transformer', current_score: 90 };
+
+describe('invokeNurseryReeval — FR-6 scheduled invoker', () => {
+  it('enqueues a correctly-shaped request with NO human in the loop', async () => {
+    const sb = makeSupabase({ due: [candidate] });
+    const out = await invokeNurseryReeval({}, { supabase: sb, ...withPrincipal, logger: { log() {} } });
+
+    expect(out.enqueued).toBe(true);
+    expect(out.nurseryId).toBe(HEADLINE_TRANSFORMER);
+    // The shape the queue processor dispatches on. path is what it actually reads (it defaults
+    // to blueprint_browse), so a missing path silently runs the wrong path entirely.
+    expect(sb.calls.inserted.metadata.strategy).toBe(NURSERY_REEVAL_STRATEGY);
+    expect(sb.calls.inserted.metadata.path).toBe('discovery_mode');
+    expect(sb.calls.inserted.metadata.nursery_id).toBe(HEADLINE_TRANSFORMER);
+    expect(sb.calls.inserted.requested_by).toBe(SERVICE_PRINCIPAL);
+    expect(sb.calls.inserted.requested_by).not.toBe(CHAIRMAN_HUMAN_UID);
+  });
+
+  it('routes through the FR-1 predicate rather than re-deriving eligibility', async () => {
+    // A fourth disagreeing predicate is the defect FR-1 removed. Assert the authoritative one
+    // actually ran: it contributes .is (unpromoted), .or (null-or-due) and three .order calls.
+    const sb = makeSupabase({ due: [candidate] });
+    await invokeNurseryReeval({}, { supabase: sb, ...withPrincipal, logger: { log() {} } });
+    expect(sb.calls.predicateOps.filter((o) => o === 'is')).toHaveLength(1);
+    expect(sb.calls.predicateOps.filter((o) => o === 'or')).toHaveLength(1);
+    expect(sb.calls.predicateOps.filter((o) => o === 'order')).toHaveLength(3);
+  });
+
+  it('does NOT enqueue a duplicate while one is already open', async () => {
+    // Without this the invoker enqueues a fresh copy every scheduled tick, because enqueueing
+    // does not advance next_evaluation_at. Unbounded identical work whose first symptom is cost.
+    const sb = makeSupabase({
+      due: [candidate],
+      open: [{ id: 'r0', status: 'pending', metadata: { strategy: NURSERY_REEVAL_STRATEGY, nursery_id: HEADLINE_TRANSFORMER } }],
+    });
+    const out = await invokeNurseryReeval({}, { supabase: sb, ...withPrincipal });
+    expect(out.enqueued).toBe(false);
+    expect(out.reason).toBe('already_queued');
+    expect(sb.calls.inserted).toBeNull();
+  });
+
+  it('a FAILED dedupe read refuses to enqueue rather than guessing', async () => {
+    // "I could not tell whether a duplicate exists" is not "no duplicate exists". Fail toward
+    // NOT flooding the queue.
+    const sb = makeSupabase({ due: [candidate], openError: { message: 'read failed' } });
+    await expect(invokeNurseryReeval({}, { supabase: sb, ...withPrincipal })).rejects.toThrow(/open-request read failed/);
+    expect(sb.calls.inserted).toBeNull();
+  });
+
+  it('refuses before touching the nursery when no principal is registered', async () => {
+    // Ordering matters: discovering this AFTER selecting a candidate would log a candidate we
+    // could never act on, which reads as a selection bug rather than a config gap.
+    const sb = makeSupabase({ due: [candidate] });
+    const out = await invokeNurseryReeval({}, { supabase: sb, registeredPrincipals: [] });
+    expect(out).toEqual({ enqueued: false, reason: 'no_registered_service_principal' });
+    expect(sb.calls.predicateOps).toHaveLength(0); // nursery was never queried
+  });
+
+  it('reports no_due_candidates without enqueuing when the selector is empty', async () => {
+    const sb = makeSupabase({ due: [] });
+    const out = await invokeNurseryReeval({}, { supabase: sb, ...withPrincipal });
+    expect(out).toEqual({ enqueued: false, reason: 'no_due_candidates' });
+    expect(sb.calls.inserted).toBeNull();
+  });
+
+  it('scopes the dedupe read SERVER-SIDE so the 1000-row cap is unreachable', async () => {
+    // SEC-6: this previously fetched EVERY open request and filtered in JS. A truncated read
+    // reports "no duplicate" for a duplicate that exists, which revives the unbounded queue the
+    // check is the only guard against. Assert the narrowing filters are actually applied.
+    const sb = makeSupabase({ due: [candidate] });
+    await invokeNurseryReeval({}, { supabase: sb, ...withPrincipal, logger: { log() {} } });
+    expect(sb.calls.dedupeStatuses).toEqual(['pending', 'claimed', 'in_progress']);
+    expect(sb.calls.dedupeFilters).toEqual([
+      ['metadata->>strategy', NURSERY_REEVAL_STRATEGY],
+      ['metadata->>nursery_id', HEADLINE_TRANSFORMER],
+    ]);
+  });
+
+  it('dryRun builds and validates the row but writes nothing', async () => {
+    const sb = makeSupabase({ due: [candidate] });
+    const out = await invokeNurseryReeval({ dryRun: true }, { supabase: sb, ...withPrincipal });
+    expect(out.enqueued).toBe(false);
+    expect(out.reason).toBe('dry_run');
+    expect(out.request.metadata.nursery_id).toBe(HEADLINE_TRANSFORMER);
+    expect(sb.calls.inserted).toBeNull();
+  });
+});
+
+describe('hasOpenRequestFor — dedupe key', () => {
+  it('keys on strategy AND nursery_id, not nursery_id alone', () => {
+    const otherPath = [{ metadata: { strategy: 'trend_scanner', nursery_id: HEADLINE_TRANSFORMER } }];
+    // An unrelated path holding a request for the same candidate must not suppress ours.
+    expect(hasOpenRequestFor(otherPath, HEADLINE_TRANSFORMER)).toBe(false);
+    const ours = [{ metadata: { strategy: NURSERY_REEVAL_STRATEGY, nursery_id: HEADLINE_TRANSFORMER } }];
+    expect(hasOpenRequestFor(ours, HEADLINE_TRANSFORMER)).toBe(true);
+  });
+
+  it('tolerates rows with absent metadata', () => {
+    expect(hasOpenRequestFor([{}, { metadata: null }], HEADLINE_TRANSFORMER)).toBe(false);
+    expect(hasOpenRequestFor(null, HEADLINE_TRANSFORMER)).toBe(false);
+  });
+
+  it('uses only REAL stage_zero_status enum members', () => {
+    // This assertion previously read ['pending','processing'] and passed, while Postgres
+    // rejected the query with: invalid input value for enum stage_zero_status: "processing".
+    // The suite mocks .in(), so it could only ever confirm the constant matched itself — a
+    // mocked seam cannot see a schema constraint. Caught by running the real CLI, not here.
+    // Probed live: the enum admits pending, claimed, in_progress, completed, dismissed,
+    // failed. 'processing' and 'running' are NOT members.
+    const REAL_ENUM = ['pending', 'claimed', 'in_progress', 'completed', 'dismissed', 'failed'];
+    for (const s of OPEN_REQUEST_STATUSES) expect(REAL_ENUM).toContain(s);
+    // and it must cover every non-terminal one, or a live request stops suppressing duplicates
+    expect([...OPEN_REQUEST_STATUSES].sort()).toEqual(['claimed', 'in_progress', 'pending']);
+  });
+});

--- a/tests/unit/eva/stage-zero/nursery-reeval-production-registry.test.js
+++ b/tests/unit/eva/stage-zero/nursery-reeval-production-registry.test.js
@@ -24,10 +24,28 @@ function makeRecordingSupabase() {
     inserts,
     from(table) {
       if (table === 'venture_nursery') {
-        // Deliberately non-empty: if the guard ever regressed, a candidate WOULD be available,
-        // so this fixture cannot mask a failure by having nothing to select.
+        // Deliberately non-empty: if the early return ever regressed, a candidate WOULD be
+        // available, so this fixture cannot mask the regression by having nothing to select.
+        //
+        // The is/or/order chain is not decoration. applyPendingNurseryPredicate() calls all
+        // three unconditionally (venture-nursery.js:457-465), so a double lacking them aborts a
+        // regressed run with "query.is is not a function" before it reaches anything meaningful.
+        // The test would still fail — but for the wrong reason, and the assertion meant to catch
+        // the regression would never be evaluated. A fixture that fails by accident is not
+        // testing what its name says it tests.
+        //
+        // WHAT ACTUALLY STOPS A REGRESSED RUN, stated precisely because the tempting one-line
+        // version of this comment is wrong: there are TWO guards, not one. Disabling the early
+        // return at invoker.js:99 does NOT produce an insert — execution proceeds to AC-10's
+        // in-path check, where buildNurseryReevalRequest is called with the empty registry and
+        // throws UnregisteredPrincipalError. The module keeps that second check deliberately
+        // ("kept in the path rather than trusted to have been checked above"). So `inserts`
+        // staying empty is defence in depth, and this fixture is what lets the run travel far
+        // enough to prove the second guard is really there rather than assumed.
         const q = {
-          select: () => q,
+          is: () => q,
+          or: () => q,
+          order: () => q,
           limit: () => Promise.resolve({
             data: [{ id: '3d95f7ea-7d6e-4ffd-ba14-2d915b65fda1', next_evaluation_at: null }],
             error: null,
@@ -36,10 +54,13 @@ function makeRecordingSupabase() {
         return { select: () => q };
       }
       if (table === 'stage_zero_requests') {
+        // Chainable through the REAL dedupe shape — .select().in().eq().eq().limit(1). A double
+        // that resolves early instead of chaining would abort a regressed run with a TypeError
+        // before it could reach .insert(), which is the only thing `inserts` can observe.
         const q = {
           select: () => q,
           eq: () => q,
-          in: () => Promise.resolve({ data: [], error: null }),
+          in: () => q,
           limit: () => Promise.resolve({ data: [], error: null }),
           insert: (row) => {
             inserts.push(row);

--- a/tests/unit/eva/stage-zero/nursery-reeval-production-registry.test.js
+++ b/tests/unit/eva/stage-zero/nursery-reeval-production-registry.test.js
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { invokeNurseryReeval } from '../../../../lib/eva/stage-zero/nursery-reeval-invoker.js';
+import { REGISTERED_SERVICE_PRINCIPALS } from '../../../../lib/eva/stage-zero/nursery-reeval-request.js';
+
+/**
+ * WHY THIS FILE EXISTS AS A SEPARATE FILE.
+ *
+ * nursery-reeval-invoker.test.js is carried VERBATIM from the source branch so that when the
+ * gated enqueue PR eventually lands it produces no merge conflict. But every one of its
+ * invokeNurseryReeval call sites INJECTS `registeredPrincipals` through the test seam, so
+ * nothing there ever exercises the module resolving the REAL production registry through its
+ * own default parameter — which is precisely the path that matters for the claim "this cannot
+ * enqueue". Closing that gap by editing the verbatim file would trade a real guarantee for a
+ * test, so the coverage lives here instead.
+ *
+ * WHAT IT PINS. The scheduler is safe on main because the production allowlist is EMPTY, not
+ * because a config flag says so. That is a property of the code, and this asserts it directly.
+ */
+
+/** Minimal Supabase double that RECORDS whether anything was written. */
+function makeRecordingSupabase() {
+  const inserts = [];
+  return {
+    inserts,
+    from(table) {
+      if (table === 'venture_nursery') {
+        // Deliberately non-empty: if the guard ever regressed, a candidate WOULD be available,
+        // so this fixture cannot mask a failure by having nothing to select.
+        const q = {
+          select: () => q,
+          limit: () => Promise.resolve({
+            data: [{ id: '3d95f7ea-7d6e-4ffd-ba14-2d915b65fda1', next_evaluation_at: null }],
+            error: null,
+          }),
+        };
+        return { select: () => q };
+      }
+      if (table === 'stage_zero_requests') {
+        const q = {
+          select: () => q,
+          eq: () => q,
+          in: () => Promise.resolve({ data: [], error: null }),
+          limit: () => Promise.resolve({ data: [], error: null }),
+          insert: (row) => {
+            inserts.push(row);
+            return { select: () => ({ single: () => Promise.resolve({ data: { id: 'req-1' }, error: null }) }) };
+          },
+        };
+        return q;
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+  };
+}
+
+describe('nursery re-eval against the PRODUCTION registry (no injected seam)', () => {
+  it('has an EMPTY production registry — the property every other assertion here rests on', () => {
+    expect(REGISTERED_SERVICE_PRINCIPALS).toHaveLength(0);
+    expect(Object.isFrozen(REGISTERED_SERVICE_PRINCIPALS)).toBe(true);
+  });
+
+  it('refuses to enqueue, and writes NOTHING, when no principal is registered', async () => {
+    const sb = makeRecordingSupabase();
+
+    // No `registeredPrincipals` key: the module falls back to REGISTERED_SERVICE_PRINCIPALS.
+    const out = await invokeNurseryReeval({}, { supabase: sb });
+
+    // It RETURNS a verdict rather than throwing — invoker.js reads registeredPrincipals[0],
+    // finds undefined, and returns early. Asserting a throw here would fail against correct code.
+    expect(out).toEqual({ enqueued: false, reason: 'no_registered_service_principal' });
+
+    // The assertion that actually matters: no row reached stage_zero_requests. A returned
+    // `enqueued: false` is a claim about the outcome; this is the outcome.
+    expect(sb.inserts).toHaveLength(0);
+  });
+
+  it('refuses BEFORE reading the nursery, so no candidate is selected it could not act on', async () => {
+    let nurseryRead = false;
+    const sb = makeRecordingSupabase();
+    const inner = sb.from.bind(sb);
+    sb.from = (table) => {
+      if (table === 'venture_nursery') nurseryRead = true;
+      return inner(table);
+    };
+
+    await invokeNurseryReeval({}, { supabase: sb });
+
+    // Ordering is a deliberate design choice the module documents: discovering the config gap
+    // after selecting a candidate would log a row it was never able to act on, which reads as
+    // a selection bug rather than the config gap it is.
+    expect(nurseryRead).toBe(false);
+  });
+
+  it('still refuses when dryRun is set — dry-run is not the control here', async () => {
+    // The excluded cron workflow carries a dry-run input whose expression resolves to LIVE on
+    // scheduled runs. Pinning that dryRun is irrelevant to this refusal: the empty registry
+    // stops the call in either mode, so safety does not depend on that flag being read correctly.
+    const sb = makeRecordingSupabase();
+    const out = await invokeNurseryReeval({ dryRun: true }, { supabase: sb });
+    expect(out).toEqual({ enqueued: false, reason: 'no_registered_service_principal' });
+    expect(sb.inserts).toHaveLength(0);
+  });
+});

--- a/tests/unit/eva/stage-zero/nursery-reeval-request.test.js
+++ b/tests/unit/eva/stage-zero/nursery-reeval-request.test.js
@@ -29,6 +29,39 @@ describe('buildNurseryReevalRequest — AC-9 attribution guard', () => {
     ).toThrow(UnregisteredPrincipalError);
   });
 
+  // SEC-3 (security review of PR #6528). The guard being tested is the Array.isArray check,
+  // and it is worth stating why a type check earns a test: `registeredPrincipals` reaches an
+  // allowlist test via String.prototype.includes, which does SUBSTRING matching. A string
+  // registry therefore does not fail — it silently DEGRADES the allowlist into a fuzzy match,
+  // admitting any caller whose uid happens to appear as a substring. Verified against the
+  // pre-fix code: this exact call SUCCEEDED and returned a fully-shaped insert row.
+  it('refuses a STRING registry that contains the uid, rather than substring-matching it', () => {
+    const stringRegistry = `allowed: ${FAKE_PRINCIPAL}, and some other text`;
+    expect(stringRegistry.includes(FAKE_PRINCIPAL)).toBe(true); // the trap, made explicit
+
+    expect(() =>
+      buildNurseryReevalRequest(
+        { requestedBy: FAKE_PRINCIPAL, nurseryId: HEADLINE_TRANSFORMER },
+        { registeredPrincipals: stringRegistry }
+      )
+    ).toThrow(UnregisteredPrincipalError);
+  });
+
+  it('reports a non-array registry as empty rather than crashing the error itself', () => {
+    // The throw passes `registeredPrincipals || []`. Without it the error constructor would
+    // receive the offending non-array and a diagnostic path could fail while reporting a
+    // security refusal — turning a clean refusal into an unrelated crash.
+    try {
+      buildNurseryReevalRequest(
+        { requestedBy: FAKE_PRINCIPAL, nurseryId: HEADLINE_TRANSFORMER },
+        { registeredPrincipals: null }
+      );
+      throw new Error('expected UnregisteredPrincipalError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(UnregisteredPrincipalError);
+    }
+  });
+
   it('refuses the chairman human account even when other principals are registered', () => {
     expect(() =>
       buildNurseryReevalRequest(


### PR DESCRIPTION
## Summary

PR #6528 carries four security fixes behind a chairman gate it must not cross. This extracts the ones that can stand alone, so the hardening is not held hostage to a decision it does not need. **#6528 stays open and still holds the enqueue path behind the gate.**

## The named scope was "SEC-1/2/3/6" — two of those are not extractable code

The SD invited this check ("PLAN should identify the actual hunks rather than trusting that inference"). The *set* turned out to be the problem, not the hunk locations.

| | Disposition |
|---|---|
| **SEC-1** | **Satisfied by exclusion, not dropped.** It is the single line `if: vars.NURSERY_REEVAL_ENABLED == 'true'` at `cron.yml:68` — a job-level kill switch inside the one file the constraint forbids. Extracting it is not blocked so much as *incoherent*: a kill switch for a job that is not shipping has nothing to kill. Shipping no workflow is **strictly stronger** than shipping one with an off switch. |
| **SEC-2** | **Already live.** Zero code hunks anywhere in the PR — `grep -c banned` across the whole diff returns 0. It was a live database action (banning the auth principal), still in effect (`banned_until 2126-07-02`, verified). Nothing to extract. |
| **SEC-3** | **Ships.** The `Array.isArray` guard. |
| **SEC-6** | **Ships.** Server-side dedupe scoping, in the invoker. |
| **SEC-7** | **Deliberately excluded.** Its entire content is the claim the registry is "no longer EMPTY" — true only if the gated feature hunk ships. Carrying it would put a false safety claim into the very file whose SEC-3 fix exists to *retract* a false safety claim. |

## The extraction is hunk-level, and that is the point

A first pass concluded the four files could be copied wholesale. An Explore sweep refuted it: `nursery-reeval-request.js` also carries the FR-5/AC-10 deliverable, flipping `REGISTERED_SERVICE_PRINCIPALS` from `Object.freeze([])` to a populated live UUID.

On main the empty registry is **load-bearing** — main's own comment: *"while it is empty this module refuses to build ANY request — that is the intended behaviour, not a gap"*. Copying the file would have silently re-armed the production allowlist this change exists to leave behind. Here the registry is byte-identical to main, asserted by a test rather than by eye.

## SEC-3 is a real fix, reproduced before it was trusted

Against the unguarded code, passing `registeredPrincipals` as a **string** containing the caller uid as a substring **succeeds** and returns a fully-shaped insert row — `String.prototype.includes` does substring matching, so a string registry does not fail, it silently *degrades the allowlist into a fuzzy match*.

Negative control run both ways: without the guard exactly the two new tests fail; with it, 12/12 pass.

## Test plan

- `nursery-reeval-request.test.js` — 12/12 (main's 10 kept, incl. its `toHaveLength(0)` assertion, + 2 new)
- `nursery-reeval-invoker.test.js` — carried verbatim
- `nursery-reeval-production-registry.test.js` — **new adjunct file.** All eight `invokeNurseryReeval` call sites in the copied test inject their principals, so nothing exercised the module resolving the *real* registry through its own default — the one path backing "this cannot enqueue". The copied file stays verbatim so a later #6528 merge produces no conflict, so the coverage lands separately.
- **27/27 across the three files.**

## Cannot arm an enqueue — verified by constructing the false state

- No workflow file, no schedule trigger
- Drain worker `stage-zero-queue-processor.js` untouched
- The single write site has **no caller in the merged tree** — `invokeNurseryReeval` lands **inert** (exported, called by nothing). That is the acceptance criterion satisfied, not an oversight.
- **Fail-closed by construction:** `invoker.js:98` reads `registeredPrincipals[0]`, undefined against the empty registry, and returns early *before reading the nursery* — so it never selects a candidate it could not act on.

## Two things a reviewer should know

**No live exposure today**, stated so nobody inherits a false urgency: `invoker.js` is absent from main, and `request.js` has zero production importers with a registry that already refuses every call. The value is that the hardening is in place *before* the feature activates.

**Size: 477 insertions, above the 400 guideline.** 336 of those are verbatim copies of already security-reviewed code (`invoker.js` 166 + its test 170), kept byte-identical so #6528 merges without conflict. Net newly-authored: ~143 lines (7 guard, 33 request tests, 103 adjunct).

`invoker.js:24` references `scripts/nursery-reeval-invoker.mjs`, which this PR does not carry. Shipped verbatim anyway as a recorded decision: editing it would conflict with #6528 for a prose-only inaccuracy, and the sentence ("no production caller uses it") is *more* true without the CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
