### PR TITLE
fix(SD-LEARN-FIX-ADDRESS-SAL-VISION-001): VISION_FIDELITY should not block on whole-company vision pillars

### DIFF
--- a/lib/sub-agents/vision-fidelity/__tests__/vision-level-scope.test.js
+++ b/lib/sub-agents/vision-fidelity/__tests__/vision-level-scope.test.js
@@ -1,0 +1,93 @@
+/**
+ * L1 portfolio-scope branch — SD-LEARN-FIX-ADDRESS-SAL-VISION-001.
+ *
+ * WHY A SEPARATE FILE. policy.test.js pins the sd_type matrix across 17 cases and is deliberately
+ * left byte-untouched: the new parameter is optional, so if any of those 17 needed editing to stay
+ * green, that would itself be evidence the change was not additive. Keeping the new cases here makes
+ * that separation checkable rather than asserted.
+ *
+ * WHAT IS BEING GUARDED. Every SD lacking a bespoke vision is gap-filled to the whole-company
+ * document at creation (pipeline.js DEFAULT_VISION_KEY = VISION-EHG-L1-001). Its dimensions are
+ * constitutional pillars — automation_by_default, chairman_governance_model — that no single SD can
+ * deliver, UI-producing or not. All 5 SDs in the observed FAIL population were scored against it.
+ */
+import { describe, it, expect } from 'vitest';
+import { classifyOutcome } from '../severity-policy.js';
+
+describe('L1 portfolio-scope branch (SD-LEARN-FIX-ADDRESS-SAL-VISION-001)', () => {
+  // TS-1. Both arms in ONE test on purpose: asserting only the L1 arm would pass just as well if the
+  // module had been made permissive outright. The pair is what shows the parameter is what changed.
+  it('L1 does not block where the identical call without a level still FAILS', () => {
+    const args = { sdType: 'feature', criticalMissing: 11, nonCriticalMissing: 0 };
+
+    const withoutLevel = classifyOutcome(args);
+    expect(withoutLevel.verdict).toBe('FAIL');
+    expect(withoutLevel.passed).toBe(false);
+
+    const withL1 = classifyOutcome({ ...args, visionLevel: 'L1' });
+    expect(withL1.passed).toBe(true);
+    expect(withL1.verdict).not.toBe('FAIL');
+    expect(withL1.reason).toBe('vision_level_l1_portfolio_scope');
+  });
+
+  it('reports WARNING rather than PASS when L1 elements are missing', () => {
+    // Non-blocking must not mean silent. An operator reading the gate needs to see that elements
+    // were missing AND that the level is why it did not block — otherwise "PASS" would teach them
+    // the SD satisfied a vision it was never measured against.
+    const o = classifyOutcome({ sdType: 'bugfix', criticalMissing: 7, nonCriticalMissing: 2, visionLevel: 'L1' });
+    expect(o.verdict).toBe('WARNING');
+    expect(o.mode).toBe('warn');
+    expect(o.reason).toMatch(/l1/i);
+  });
+
+  it('L1 with nothing missing is a clean PASS carrying no reason', () => {
+    const o = classifyOutcome({ sdType: 'feature', criticalMissing: 0, nonCriticalMissing: 0, visionLevel: 'L1' });
+    expect(o.verdict).toBe('PASS');
+    expect(o.reason).toBeNull();
+  });
+
+  // TS-1 second arm. L2 is a SCOPED vision — blocking on it is legitimate and must be preserved,
+  // otherwise the change is indistinguishable from disabling the gate.
+  it('L2 still FAILS exactly as before for every block-mode sd_type', () => {
+    for (const sdType of ['feature', 'bugfix']) {
+      const o = classifyOutcome({ sdType, criticalMissing: 3, nonCriticalMissing: 0, visionLevel: 'L2' });
+      expect(o.verdict, `${sdType} @ L2`).toBe('FAIL');
+      expect(o.passed, `${sdType} @ L2`).toBe(false);
+    }
+    for (const sdType of ['database', 'security']) {
+      const o = classifyOutcome({ sdType, criticalMissing: 2, nonCriticalMissing: 0, visionLevel: 'L2' });
+      expect(o.verdict, `${sdType} @ L2`).toBe('FAIL');
+    }
+  });
+
+  // TS-4 / TS-7. THE CONTROL THAT MATTERS. The s18 case-study fixture — the real-incident negative
+  // control proving this gate still bites — is an inline mock carrying NO level field. Under an
+  // allowlist its undefined level falls through to the strict path. Under a denylist
+  // (`visionLevel !== 'L2'`) it would satisfy "is not L2", flip non-blocking, and delete the only
+  // evidence that this change did not simply switch the gate off. This test is what makes the
+  // allowlist load-bearing rather than a stylistic note in a comment.
+  it('an ABSENT level falls through to the strict path — the s18-shaped case still FAILS', () => {
+    const s18Shaped = { sdType: 'feature', criticalMissing: 5, nonCriticalMissing: 3 };
+
+    expect(classifyOutcome(s18Shaped).verdict).toBe('FAIL');
+    expect(classifyOutcome({ ...s18Shaped, visionLevel: undefined }).verdict).toBe('FAIL');
+    expect(classifyOutcome({ ...s18Shaped, visionLevel: null }).verdict).toBe('FAIL');
+  });
+
+  it('an UNRECOGNISED level fails safe toward blocking, not toward silence', () => {
+    // A level the schema does not yet have (L3, a typo, a renamed tier) must not silently disable
+    // blocking. Fail-safe direction is the stricter existing behaviour.
+    for (const lvl of ['L3', 'l1', 'PORTFOLIO', '']) {
+      const o = classifyOutcome({ sdType: 'feature', criticalMissing: 3, nonCriticalMissing: 0, visionLevel: lvl });
+      expect(o.verdict, `level=${JSON.stringify(lvl)}`).toBe('FAIL');
+    }
+  });
+
+  it('skip-mode sd_types are unaffected by level — skip still wins', () => {
+    // Ordering check: the skip branch is evaluated before the L1 branch, so a documentation SD
+    // scored against L1 is skipped (its existing reason), not re-labelled as a portfolio warning.
+    const o = classifyOutcome({ sdType: 'documentation', criticalMissing: 9, visionLevel: 'L1' });
+    expect(o.skipped).toBe(true);
+    expect(o.reason).toMatch(/does not produce UI/);
+  });
+});

--- a/lib/sub-agents/vision-fidelity/index.js
+++ b/lib/sub-agents/vision-fidelity/index.js
@@ -135,7 +135,12 @@ export async function executeVisionFidelity(args = {}) {
   const criticalMissing = missing_elements.filter(el => el.severity === 'critical' || el.critical === true).length;
   const nonCriticalMissing = missing_elements.length - criticalMissing;
 
-  const outcome = classifyOutcome({ sdType, criticalMissing, nonCriticalMissing });
+  const outcome = classifyOutcome({
+    sdType,
+    criticalMissing,
+    nonCriticalMissing,
+    visionLevel: visionDoc.level
+  });
 
   const totalElements = delivered_elements.length + partial_elements.length + missing_elements.length;
   const visionCoveragePct = computeCoveragePct(delivered_elements.length, totalElements);
@@ -210,7 +215,10 @@ async function loadSD(supabase, sdId) {
 async function loadVisionDocument(supabase, visionKey) {
   const { data } = await supabase
     .from('eva_vision_documents')
-    .select('vision_key, version, content, extracted_dimensions, status')
+    // `level` (SD-LEARN-FIX-ADDRESS-SAL-VISION-001): read from the column, never parsed out of
+    // vision_key. It drives the L1 portfolio-scope branch in classifyOutcome, and omitting it here
+    // would leave that branch permanently undefined — the fix would look implemented and do nothing.
+    .select('vision_key, version, content, extracted_dimensions, status, level')
     .eq('vision_key', visionKey)
     .maybeSingle();
   return data;

--- a/lib/sub-agents/vision-fidelity/severity-policy.js
+++ b/lib/sub-agents/vision-fidelity/severity-policy.js
@@ -31,9 +31,17 @@ export function getPolicyForSdType(sdType) {
  * @param {number} input.nonCriticalMissing - count of missing_elements with severity!=critical
  * @param {number} [input.totalElements] - delivered + partial + missing (for coverage_pct)
  * @param {number} [input.deliveredCount]
+ * @param {string} [input.visionLevel] - eva_vision_documents.level of the doc being compared
+ *   against ('L1' | 'L2'). Optional: omitting it reproduces the pre-SD-LEARN-FIX behaviour
+ *   exactly, which is what keeps the existing sd_type matrix and its tests untouched.
  * @returns {{verdict: string, passed: boolean, mode: string, skipped: boolean, reason: string|null}}
  */
-export function classifyOutcome({ sdType, criticalMissing = 0, nonCriticalMissing = 0 } = {}) {
+export function classifyOutcome({
+  sdType,
+  criticalMissing = 0,
+  nonCriticalMissing = 0,
+  visionLevel
+} = {}) {
   const policy = getPolicyForSdType(sdType);
 
   if (policy.mode === 'skip') {
@@ -41,6 +49,28 @@ export function classifyOutcome({ sdType, criticalMissing = 0, nonCriticalMissin
   }
 
   const noMisses = criticalMissing === 0 && nonCriticalMissing === 0;
+
+  // SD-LEARN-FIX-ADDRESS-SAL-VISION-001. An L1 document is the WHOLE-COMPANY vision, and every SD
+  // that lacks a bespoke one is gap-filled to it at creation (pipeline.js DEFAULT_VISION_KEY). Its
+  // dimensions are constitutional pillars — automation_by_default, chairman_governance_model — that
+  // no single SD can deliver. Not because the SD ships no UI: a UI-producing SD cannot deliver the
+  // chairman governance model either. Blocking on it measures an SD against a document that was
+  // never about that SD, which is why 5 of 5 observed FAIL verdicts were L1.
+  //
+  // *** ALLOWLIST, DELIBERATELY — NEVER REWRITE AS `visionLevel !== 'L2'`. ***
+  // The s18 case-study fixture, which is the negative control proving this gate still bites, carries
+  // NO level field at all. Under a denylist its undefined level would satisfy "is not L2", flip it
+  // non-blocking, and silently delete the only evidence that this change did not just switch the
+  // gate off. An unknown level must fall through to the stricter existing behaviour.
+  if (visionLevel === 'L1') {
+    return {
+      verdict: noMisses ? 'PASS' : 'WARNING',
+      passed: true,
+      mode: 'warn',
+      skipped: false,
+      reason: noMisses ? null : 'vision_level_l1_portfolio_scope'
+    };
+  }
 
   if (policy.mode === 'warn') {
     return {


### PR DESCRIPTION
## Summary

VISION_FIDELITY was failing SDs for "missing" elements like `automation_by_default` and `chairman_governance_model`. Those aren't defects in the SDs — they're constitutional pillars of the **entire company**, and every SD without a bespoke vision is gap-filled to the L1 company document at creation (`pipeline.js DEFAULT_VISION_KEY`). A single PR was being measured against a document that was never about it.

## The discriminant is the vision document's own `level` column

Not `sd_type`, and not UI-ness. `eva_vision_documents.level` is first-class: **3 rows L1, 302 L2**. L1 is the portfolio vision; L2 is a scoped one.

- **L2 → still blocks**, exactly as today. Blocking on a scoped vision is legitimate.
- **L1 → warns.** No single SD can deliver "the chairman governance model" — *including a UI-producing one*. That last point is why this isn't the "backend SDs ship no UI" fix it first looked like; I started with that framing and it was refuted.

## Coverage is the whole observed population

All 5 SDs that ever produced a FAIL carry `level=L1` **and** sit in block mode:

| SD | type | note |
|---|---|---|
| `SCOPE-REPLACE-WORKTREE-001` | feature | 7 of the 11 FAIL rows — a `node_modules` junction-topology change |
| `EXTRACT-SEC-OUT-001` | bugfix | |
| `SESSIONS-PAGE-TRUE-001` | orchestrator | |
| `FOLD-LEO-INTO-EHG-001` | feature | |
| `LEO-COMPLETION-001` | orchestrator | |

197 SDs carry the L1 default; **58** are in block mode and move to warn (orchestrator 14 via `DEFAULT_POLICY`, feature 25, bugfix 16, database 2, security 1). The 137 infrastructure SDs already warned.

## ⚠️ The allowlist is load-bearing — do not "tidy" it later

The branch tests `visionLevel === 'L1'`. It must **never** be rewritten as `visionLevel !== 'L2'`.

The s18 case study — the real-incident negative control proving this gate still bites — is an inline fixture carrying **no `level` field**. Under a denylist its `undefined` level satisfies "is not L2", flips it non-blocking, and deletes the only evidence the gate wasn't simply switched off.

**Verified by mutation, not by reasoning:** rewriting the branch as a denylist makes s18 stop failing and trips the absent-level guard. Restored → 31/31.

## The other way this could have shipped inert

`loadVisionDocument()` didn't select `level`. Without adding it the read returns `undefined` forever and the fix looks implemented while doing nothing.

## Test plan

31 pass across 4 files (was 24 across 3). New cases live in their own file because `policy.test.js` pins the `sd_type` matrix across 17 cases and is deliberately byte-untouched — if any had needed editing, that would itself be evidence the change wasn't additive.

**Honest about which new tests prove what:** reverting the policy fails **2 of the 7** new cases — the two asserting L1 non-blocking. The other 5 pass before and after *by design*; they assert behaviour that must **not** change (L2 still fails, absent level still fails, unknown level fails safe, skip still wins). They're regression guards, not proof of the fix, and are labelled as such rather than left looking like evidence they aren't.

## Out of scope, recorded rather than quietly folded in

The comparison is an **unseeded LLM call** (`index.js:113-119`, no temperature set, in-process-only cache), so verdicts genuinely re-sample — one SD logged FAIL then PASS 18s apart with no scope change, reproduced in a second SD. Fixing that means touching `lib/llm/client-factory.js`, which every LLM sub-agent shares. It needs its own row.

Also unfixed: `index.js:267` describes an element as a wireframe unit while the data compared is constitutional pillars. Making L1 non-blocking removes the harm without pretending the prompt is coherent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
