### PR TITLE
fix(SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001): one CJS normalizer for naive timestamps + a TZ-pinned test that can fail

### DIFF
--- a/lib/time/pg-timestamp.cjs
+++ b/lib/time/pg-timestamp.cjs
@@ -1,0 +1,103 @@
+/**
+ * SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001 FR-1 — the canonical timezone normalizer.
+ *
+ * THE BUG THIS CLOSES. Several columns on quick_fixes and strategic_directives_v2 are
+ * `timestamp without time zone`, so PostgREST returns them with NO designator:
+ * "2026-07-29T05:25:20.028". JavaScript parses a naive string as LOCAL time, so any
+ * client-side row-vs-NOW age is shifted by the host's UTC offset. On a UTC-4 host every
+ * age reads four hours younger, and anything younger than four hours reads NEGATIVE. No
+ * error is thrown — `if (error)` cannot catch it — so the wrong number renders as fact.
+ *
+ * WHY THIS FILE IS .cjs, WHICH IS THE ONLY DESIGN DECISION HERE.
+ * The class was fixed four times without ever reaching the claim path, and the recorded
+ * belief for why is that CJS cannot require ESM. THAT BELIEF IS FALSE — require(esm) has
+ * been stable since Node 22.12 and this fleet runs 24; requiring the existing ESM
+ * parseAsUTC from a .cjs works today. It was tested, not assumed.
+ *
+ * The real constraint is narrower: require() of ESM fails with ERR_REQUIRE_ASYNC_MODULE
+ * against any module carrying a TOP-LEVEL AWAIT, and one file in this repo
+ * (scripts/hooks/stop-subagent-enforcement.js:99) genuinely has one. So an ESM home for
+ * the canonical helper would impose a permanent, invisible "never add a top-level await
+ * to this file" constraint on every future editor — a constraint nothing in the code
+ * would state and no test would catch. A CJS home removes it: ESM can `import` CJS
+ * unconditionally, with no equivalent restriction.
+ *
+ * Corroborating, and the reason this is not a coin flip: at least seven CJS files had
+ * already reinvented this same append-Z logic privately under local names (toMs, tsMs)
+ * rather than reuse anything. The demand on the CJS side is demonstrated, not predicted.
+ *
+ * DO NOT restate "CJS cannot require ESM" in a comment or commit message. It is refuted,
+ * and repeating it is what produced four incomplete passes and one documented verbatim
+ * copy (scripts/worker-checkin.cjs:585-587).
+ *
+ * SCOPE — read this before reaching for it.
+ *   USE IT for ROW-vs-NOW: comparing a naive DB timestamp against Date.now().
+ *   DO NOT USE IT for ROW-vs-ROW: two naive timestamps compared to each other both shift
+ *     identically, so the ordering is already correct. Normalizing them changes nothing
+ *     and risks a ranking regression for no defect closed.
+ *   DO NOT USE IT on tz-aware columns. quick_fixes.not_before,
+ *     strategic_directives_v2.completion_date and .quality_checked_at are TIMESTAMPTZ
+ *     (verified against information_schema, not inferred from migrations) and already
+ *     parse correctly. Passing them through here is harmless — see the hasTZ guard — but
+ *     touching those call sites is churn.
+ *   SERVER-SIDE FILTERS ARE NOT AFFECTED. A .gte('updated_at', isoString) is evaluated by
+ *     Postgres, where the naive column's digits already equal UTC, so it compares
+ *     correctly. Only client-side arithmetic on a returned string is broken.
+ */
+
+/**
+ * Interpret a PostgREST timestamp as UTC.
+ *
+ * Already-tz-aware inputs (trailing Z, or a +HH:MM / +HHMM offset) are passed through
+ * untouched — appending Z to those would corrupt them, which is how a naive "just add Z"
+ * fix creates the very churn this SD forbids.
+ *
+ * @param {string|Date|null|undefined} ts
+ * @returns {Date|null} null for null/undefined/empty; an Invalid Date is returned as-is so
+ *   callers keep their existing Number.isFinite / isNaN guards rather than silently
+ *   receiving a plausible wrong instant.
+ */
+function parsePgTimestamp(ts) {
+  if (!ts) return null;
+  if (ts instanceof Date) return ts;
+  if (typeof ts !== 'string') return null;
+  const hasTZ = /Z$|[+-]\d{2}:?\d{2}$/.test(ts);
+  return new Date(hasTZ ? ts : `${ts}Z`);
+}
+
+/**
+ * Epoch milliseconds for a PostgREST timestamp, or NaN.
+ *
+ * The ms form exists because nearly every defect site does `nowMs - parsed` arithmetic and
+ * would otherwise write `.getTime()` at each call — a small per-site step that is exactly
+ * where the previous copies diverged from each other.
+ *
+ * @param {string|Date|null|undefined} ts
+ * @returns {number} epoch ms, or NaN when unparseable/absent. NaN (not 0, not null) so an
+ *   existing `Number.isFinite(x)` guard keeps working and a missing timestamp can never be
+ *   mistaken for 1970.
+ */
+function pgTimestampMs(ts) {
+  const d = parsePgTimestamp(ts);
+  return d ? d.getTime() : NaN;
+}
+
+/**
+ * Age in milliseconds of a naive PostgREST timestamp relative to now.
+ *
+ * @param {string|Date|null|undefined} ts
+ * @param {number} [nowMs=Date.now()] injectable clock — REQUIRED for the TZ regression test
+ *   and for any pure predicate that already takes a now parameter.
+ * @returns {number} age in ms, or NaN when the timestamp is absent/unparseable.
+ *
+ * A NEGATIVE RETURN IS THE SIGNATURE OF THIS BUG, so callers should not clamp it. A
+ * Math.max(0, ...) on this value at scripts/fleet-dashboard.cjs:760 printed "0h" for every
+ * impossible age and hid the defect for an entire night — the clamp that made the display
+ * look sane suppressed the only self-evident symptom.
+ */
+function pgTimestampAgeMs(ts, nowMs = Date.now()) {
+  const ms = pgTimestampMs(ts);
+  return Number.isFinite(ms) ? nowMs - ms : NaN;
+}
+
+module.exports = { parsePgTimestamp, pgTimestampMs, pgTimestampAgeMs };

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -4,6 +4,8 @@
 const os = require('os');
 const fs = require('fs');
 const path = require('path');
+// SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001: naive PostgREST timestamps must not be parsed as local.
+const { pgTimestampAgeMs } = require('../lib/time/pg-timestamp.cjs');
 const crypto = require('crypto');
 const util = require('util');
 const { spawnSync } = require('child_process');
@@ -757,7 +759,18 @@ function printQuickFixes(d) {
   const now = Date.now();
   console.log('  ' + pad('ID', 18) + pad('Status', 12) + pad('Age', 6) + pad('Holder', 10) + 'Title');
   for (const qf of qfs) {
-    const ageH = qf.created_at ? Math.max(0, Math.round((now - Date.parse(qf.created_at)) / 3600000)) + 'h' : '?';
+    // SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001 FR-5. This line previously read:
+    //     Math.max(0, Math.round((now - Date.parse(qf.created_at)) / 3600000)) + 'h'
+    // Two defects in one expression. The bare Date.parse read the naive created_at as LOCAL,
+    // so on a UTC-4 host every QF younger than 4h computed a NEGATIVE age — and the
+    // Math.max(0, ...) then printed that impossible value as a perfectly plausible "0h".
+    // THE CLAMP IS WHY THIS SURVIVED: a negative age was the only self-evident symptom this
+    // bug class ever produces, and the clamp deleted it. The coordinator read this column all
+    // night without seeing anything wrong.
+    // The parse is now correct, so ages are truthful; the clamp is gone rather than merely
+    // unnecessary, and a negative would print loudly if this ever regresses.
+    const ageMs = qf.created_at ? pgTimestampAgeMs(qf.created_at, now) : NaN;
+    const ageH = Number.isFinite(ageMs) ? Math.round(ageMs / 3600000) + 'h' : '?';
     const holder = qf.claiming_session_id ? String(qf.claiming_session_id).substring(0, 8) : '—';
     // SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001: gated rows are NOT claimable open work —
     // badge them here so the primary list agrees with the worker-lane exclusion.

--- a/scripts/modules/sd-next/display/quick-fixes.js
+++ b/scripts/modules/sd-next/display/quick-fixes.js
@@ -7,6 +7,11 @@
 import { colors } from '../colors.js';
 import { analyzeClaimRelationship } from '../claim-analysis.js';
 import { getStaleThresholdSeconds } from '../../../../lib/claim/stale-threshold.js';
+// SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001: the canonical normalizer is CJS, and ESM imports CJS
+// unconditionally — this import is the ESM half of the proof that one home serves both module
+// systems. The CJS half is the require() in scripts/worker-checkin.cjs.
+import pgTimestamp from '../../../../lib/time/pg-timestamp.cjs';
+const { pgTimestampAgeMs } = pgTimestamp;
 
 const MAX_DISPLAY = 10;
 
@@ -274,7 +279,14 @@ function inferTier(estimatedLoc) {
  */
 function ageDays(createdAt) {
   if (!createdAt) return 0;
-  return Math.floor((Date.now() - new Date(createdAt).getTime()) / (1000 * 60 * 60 * 24));
+  // SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001. quick_fixes.created_at is `timestamp without time
+  // zone`, so PostgREST returns it with no designator and new Date() reads it as LOCAL —
+  // shifting this age by the host's UTC offset. This site was INVISIBLE to the repo scan that
+  // sized this SD, because the column is renamed to camelCase `createdAt` and so the literal
+  // string `created_at` never shares a line with Date.now(). It carries the identical defect to
+  // scripts/worker-checkin.cjs:isAutoStartableQF, independently — the two are separate
+  // implementations of the same predicate.
+  return Math.floor(pgTimestampAgeMs(createdAt) / (1000 * 60 * 60 * 24));
 }
 
 /**

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -45,6 +45,11 @@ const ws = require('../lib/fleet/worker-status.cjs');
 // a guard built on it would silently never run. Pinned by tests/unit/fleet/assignment-target.test.js.
 const { resolveAssignmentTargetKey } = require('../lib/fleet/assignment-target.cjs');
 const { stampClaim } = require('../lib/fleet/claim-stamp.cjs');
+// SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001: quick_fixes.created_at is `timestamp without time zone`,
+// so PostgREST returns it with no designator and Date.parse reads it as LOCAL — shifting every
+// age below by the host's UTC offset. Canonical normalizer, deliberately CJS so this file can
+// require it directly.
+const { pgTimestampMs } = require('../lib/time/pg-timestamp.cjs');
 // SD-FDBK-FIX-SELF-ONLY-AUTHORIZATION-001: acquisition-time guard so a propose-only
 // (non_fleet/role=adam) session never self-claims a build SD — the shared predicate
 // the ESM claim-validity gate also uses (one source; no asymmetry).
@@ -194,7 +199,12 @@ const CRITICAL_QF_JUMP_GRACE_MS = 10 * 60 * 1000;
 function isCriticalQfJumpEligible(qf, nowMs) {
   if (!isAutoStartableQF(qf, nowMs)) return false;
   if (qf.severity !== 'critical') return false;
-  const created = Date.parse(qf.created_at);
+  // SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001 (absorbs QF-20260729-352). A bare Date.parse here read
+  // the naive created_at as LOCAL, putting it 4h in the FUTURE on a UTC-4 host — so the age went
+  // NEGATIVE for any QF younger than 4h and this 10-minute grace could not be satisfied until the
+  // row was 4h10m old in wall clock. Measured: 250 minutes to clear a 10-minute gate. The
+  // pre-emption was dead for exactly the window it exists to serve.
+  const created = pgTimestampMs(qf.created_at);
   if (!Number.isFinite(created)) return false;
   return (nowMs - created) >= CRITICAL_QF_JUMP_GRACE_MS;
 }
@@ -585,6 +595,23 @@ async function rehydrateCallsign(sb, sessionId, currentMeta) {
  * scripts/modules/sd-next/display/quick-fixes.js. Re-implemented INLINE because
  * worker-checkin.cjs is CommonJS and that module is ESM (package.json
  * type:module), so it cannot be require()d here. SD-LEO-INFRA-MAKE-OPEN-QFS-001.
+ *
+ * *** CORRECTION (SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001). THE REASON ABOVE IS FALSE, AND
+ * BELIEVING IT COST FOUR INCOMPLETE FIXES. *** CJS can require ESM: it has been stable
+ * since Node 22.12 and this fleet runs 24. It was tested, not assumed — requiring the ESM
+ * parseAsUTC from a .cjs returns a working function. The retained text above is left
+ * visible rather than deleted because it is the primary evidence for WHY the timezone bug
+ * class survived four separate fixes without ever reaching this file: each pass read this
+ * docblock, believed reuse was impossible here, and stopped.
+ *
+ * The one real limit is narrower: require() fails with ERR_REQUIRE_ASYNC_MODULE against a
+ * module carrying a TOP-LEVEL AWAIT. That is why the canonical normalizer now lives at
+ * lib/time/pg-timestamp.cjs — a CJS home carries no such constraint, and ESM can import
+ * CJS unconditionally.
+ *
+ * THE DUPLICATION ITSELF IS STILL REAL and is NOT resolved by this SD: this predicate and
+ * scripts/modules/sd-next/display/quick-fixes.js:275 remain independent implementations
+ * that both carried the identical timezone defect. Consolidating them is follow-on work.
  */
 function isAutoStartableQF(qf, nowMs) {
   if (!qf || qf.status !== 'open') return false;
@@ -618,7 +645,8 @@ function isAutoStartableQF(qf, nowMs) {
   // Stays status='open' but is false open work for a worker: exclude until released via
   // scripts/release-chairman-gated-qf.js. Visible on the coordinator surface, never lost.
   if (isChairmanGatedQF(qf)) return false;
-  const created = qf.created_at ? Date.parse(qf.created_at) : NaN;
+  // SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001: naive created_at, see the require at the top of this file.
+  const created = qf.created_at ? pgTimestampMs(qf.created_at) : NaN;
   if (!Number.isFinite(created)) return false;
   const ageDays = (nowMs - created) / (24 * 60 * 60 * 1000);
   return ageDays < STALE_QF_DAYS;                       // exclude stale/verify-first QFs

--- a/tests/unit/time/pg-timestamp-tz.test.js
+++ b/tests/unit/time/pg-timestamp-tz.test.js
@@ -1,0 +1,123 @@
+/**
+ * SD-LEO-INFRA-REPO-WIDE-TIMEZONE-001 FR-3 — the regression test that CANNOT pass on a UTC runner.
+ *
+ * WHY THE TIMEZONE IS PINNED IN-FILE RATHER THAN BY A `TZ=... vitest` PREFIX.
+ * The shell form is a NO-OP for Windows developers: cross-env is not installed and npm
+ * scripts run through cmd.exe, which does not support `TZ=x cmd` syntax. It would work in
+ * CI (ubuntu/bash) and silently do nothing locally — a guard that protects only half the
+ * people running it, which is the worst available shape for a test whose entire subject is
+ * checks that cannot fail. Mutating process.env.TZ in beforeAll was verified to take effect
+ * inside vitest's forks pool without a process restart.
+ *
+ * AND WHY PINNING MATTERS EVEN THOUGH THIS DEV HOST IS ALREADY UTC-4.
+ * The ambient zone here happens to be America/New_York, so an unpinned test could pass for
+ * the wrong reason locally and then be meaningless in CI, which runs ubuntu at ambient UTC.
+ * The pin is what makes both environments produce the same verdict.
+ *
+ * THE DEFECT IS INVISIBLE ON A UTC RUNNER. It is a shift by the host's UTC offset; at
+ * offset zero there is nothing to see. So a green suite on a UTC box is not evidence for
+ * this class, and the FIXED_OFFSET assertions below are what make these tests real.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { parsePgTimestamp, pgTimestampMs, pgTimestampAgeMs } = require('../../../lib/time/pg-timestamp.cjs');
+
+const TZ = 'America/New_York';
+const OFFSET_HOURS = 4; // EDT. The fixtures below sit in July, so DST is in effect.
+const NAIVE = '2026-07-29T05:25:20.028';       // as PostgREST returns it: no designator
+const TRUE_INSTANT = Date.parse(NAIVE + 'Z');  // what it actually means
+
+let originalTZ;
+beforeAll(() => {
+  originalTZ = process.env.TZ;
+  process.env.TZ = TZ;
+});
+afterAll(() => {
+  if (originalTZ === undefined) delete process.env.TZ;
+  else process.env.TZ = originalTZ;
+});
+
+describe('pg-timestamp normalizer under a pinned non-UTC timezone', () => {
+  it('the pin is actually in effect — otherwise every assertion below is vacuous', () => {
+    // THIS TEST GUARDS THE OTHER TESTS. If the TZ pin silently failed to apply, the naive
+    // string would parse as UTC, this expectation would fail, and the suite would tell us
+    // the harness is broken rather than quietly reporting a meaningless pass.
+    const localParsed = Date.parse(NAIVE);
+    const shiftHours = (localParsed - TRUE_INSTANT) / 3600000;
+    expect(shiftHours).toBe(OFFSET_HOURS);
+  });
+
+  it('normalizes a naive timestamp to the correct instant', () => {
+    expect(pgTimestampMs(NAIVE)).toBe(TRUE_INSTANT);
+    expect(parsePgTimestamp(NAIVE).toISOString()).toBe('2026-07-29T05:25:20.028Z');
+  });
+
+  it('bare Date.parse gets it WRONG by exactly the host offset — the defect, pinned', () => {
+    // Asserting the broken behaviour explicitly. If this ever stops being wrong, the bug
+    // was fixed somewhere upstream and this whole SD's premise needs rechecking.
+    expect(Date.parse(NAIVE)).not.toBe(TRUE_INSTANT);
+    expect(Date.parse(NAIVE) - TRUE_INSTANT).toBe(OFFSET_HOURS * 3600000);
+  });
+
+  it('produces a POSITIVE age where bare Date.parse produces a negative one', () => {
+    // The live failure shape: a critical QF aged 20 real minutes was ineligible for a
+    // 10-minute grace because its computed age was about -220 minutes.
+    const nowMs = TRUE_INSTANT + 20 * 60000;
+
+    const brokenAgeMin = (nowMs - Date.parse(NAIVE)) / 60000;
+    const fixedAgeMin = pgTimestampAgeMs(NAIVE, nowMs) / 60000;
+
+    expect(brokenAgeMin).toBeCloseTo(-220, 5);
+    expect(brokenAgeMin).toBeLessThan(0);
+    expect(fixedAgeMin).toBeCloseTo(20, 5);
+
+    // A 10-minute grace: broken fails it, fixed clears it.
+    expect(brokenAgeMin >= 10).toBe(false);
+    expect(fixedAgeMin >= 10).toBe(true);
+  });
+
+  it('does NOT corrupt already-tz-aware input (Z and +HH:MM and +HHMM)', () => {
+    // A "just append Z" fix would corrupt these. quick_fixes.not_before,
+    // completion_date and quality_checked_at are all TIMESTAMPTZ, so a normalizer that
+    // mangled them would create the exact churn this SD forbids.
+    expect(pgTimestampMs('2026-07-29T05:25:20.028Z')).toBe(TRUE_INSTANT);
+    expect(pgTimestampMs('2026-07-29T01:25:20.028-04:00')).toBe(TRUE_INSTANT);
+    expect(pgTimestampMs('2026-07-29T01:25:20.028-0400')).toBe(TRUE_INSTANT);
+  });
+
+  it('returns NaN — never 0 — for absent or unparseable input', () => {
+    // 0 would be 1970 and would read as an enormous age; NaN keeps existing
+    // Number.isFinite guards working instead of inventing a plausible wrong number.
+    expect(pgTimestampMs(null)).toBeNaN();
+    expect(pgTimestampMs(undefined)).toBeNaN();
+    expect(pgTimestampMs('')).toBeNaN();
+    expect(pgTimestampAgeMs(null, Date.now())).toBeNaN();
+    expect(parsePgTimestamp(null)).toBeNull();
+  });
+
+  it('is reachable from CJS via require — the claim four prior passes believed impossible', () => {
+    // Executable proof of FR-1's reachability, not an argument about it. The belief that
+    // CJS could not reuse the helper is what produced a verbatim duplicate at
+    // worker-checkin.cjs:585-587.
+    const direct = require('../../../lib/time/pg-timestamp.cjs');
+    expect(typeof direct.pgTimestampMs).toBe('function');
+    expect(direct.pgTimestampMs(NAIVE)).toBe(TRUE_INSTANT);
+  });
+});
+
+describe('row-vs-row comparisons are shift-invariant and must not be normalized', () => {
+  it('two naive timestamps sort identically before and after normalization', () => {
+    // The SD forbids churning these. This test states WHY as an executable fact, so a
+    // future sweep that "fixes" a sort has a failing test explaining the mistake.
+    const a = '2026-07-29T05:25:20.028';
+    const b = '2026-07-29T07:10:00.000';
+
+    const naiveOrder = Math.sign(Date.parse(a) - Date.parse(b));
+    const normalizedOrder = Math.sign(pgTimestampMs(a) - pgTimestampMs(b));
+
+    expect(naiveOrder).toBe(normalizedOrder);
+    expect(naiveOrder).toBe(-1);
+  });
+});

--- a/tests/unit/time/pg-timestamp-tz.test.js
+++ b/tests/unit/time/pg-timestamp-tz.test.js
@@ -44,6 +44,17 @@ describe('pg-timestamp normalizer under a pinned non-UTC timezone', () => {
     // THIS TEST GUARDS THE OTHER TESTS. If the TZ pin silently failed to apply, the naive
     // string would parse as UTC, this expectation would fail, and the suite would tell us
     // the harness is broken rather than quietly reporting a meaningless pass.
+    //
+    // *** KNOWN LIMIT OF THIS GUARD — IT IS HOST-DEPENDENT, AND IT WAS MEASURED. ***
+    // Deleting the process.env.TZ assignment above and re-running:
+    //   ambient TZ=UTC (i.e. CI, ubuntu)          -> this test FAILS (0 vs 4), as intended
+    //   ambient already America/New_York (dev box) -> ALL 8 STILL PASS, guard silent
+    // The guard cannot distinguish "pin executed" from "pin absent, ambient happens to
+    // match". It is therefore REAL IN CI, where it matters, and DECORATIVE on an EDT/EST
+    // developer machine. So a green local run on such a host is not evidence the pin ran —
+    // only CI, or an explicit `TZ=UTC` prefix locally, actually exercises it.
+    // Recorded rather than quietly relied upon: a guard whose effectiveness depends on the
+    // environment is exactly the kind of half-check this SD exists to stop.
     const localParsed = Date.parse(NAIVE);
     const shiftHours = (localParsed - TRUE_INSTANT) / 3600000;
     expect(shiftHours).toBe(OFFSET_HOURS);


### PR DESCRIPTION
## Summary

`quick_fixes` and `strategic_directives_v2` carry `timestamp without time zone`, so PostgREST returns them with **no designator** and JavaScript parses them as **local**. Every client-side row-vs-now age is shifted by the host UTC offset — 4h young here, and **negative** for anything under 4h old. Nothing throws, so the wrong number renders as fact.

## The premise this SD was built on is false — and that's why it kept recurring

The class was fixed **four times** without reaching the claim path. The recorded reason, written verbatim in `worker-checkin.cjs`'s own docblock, is that CJS cannot require ESM.

It can. Stable since Node 22.12; this fleet runs 24. I tested it rather than reasoning about it — requiring the existing ESM `parseAsUTC` from a `.cjs` returns a working function. Each prior pass read that docblock, believed reuse was impossible, and stopped.

**I corrected the docblock in place rather than deleting it**, because it's the primary evidence for how a wrong belief survived four fixes.

### The real constraint is narrower, and it decided the home

`require(esm)` fails with `ERR_REQUIRE_ASYNC_MODULE` against a module with a **top-level await** — and one file here genuinely has one (`stop-subagent-enforcement.js:99`). An ESM home would impose a permanent, invisible *"never add a top-level await to this file"* rule that nothing states and no test catches. `lib/time/pg-timestamp.cjs` is CJS, so that constraint doesn't exist; ESM imports CJS unconditionally.

Corroborating: at least **seven CJS files had already reinvented this append-Z logic privately**, so demand on that side is demonstrated, not predicted.

Verified reachable from both systems executably — `worker-checkin.cjs` requires it, `quick-fixes.js` (ESM) imports it, both return the same correct instant.

## The test can fail, which is the whole point here

The defect is **invisible on a UTC runner** — a shift by an offset of zero is nothing — so a green suite proves nothing for this class.

- The timezone is pinned **in-file** via `process.env.TZ`, **not** a `TZ=... vitest` shell prefix. The shell form is a no-op for Windows devs (`cmd.exe`, no `cross-env`) while working in CI: a guard that protects only half the people running it.
- One test asserts **the pin is actually in effect**, so a silently-unapplied pin fails loudly instead of reporting a meaningless pass.
- **Negative control:** removing the append-Z fails **3 of 8**. The other 5 pass either way *by design* — they assert the broken `Date.parse` behaviour, tz-aware passthrough, NaN handling, and row-vs-row invariance, none of which depend on the fix. Stating that split rather than implying 8/8 is evidence.

## Sites fixed (4 of 13 confirmed; rest are follow-on)

| Site | Note |
|---|---|
| `worker-checkin.cjs` `isCriticalQfJumpEligible` | **Absorbs QF-20260729-352.** A 10-minute grace needed **250 minutes** of wall clock — critical pre-emption was dead for exactly the window it exists to serve |
| `worker-checkin.cjs` `isAutoStartableQF` | |
| `sd-next/display/quick-fixes.js` `ageDays` | The ESM twin carrying the **identical defect independently** — invisible to the scan that sized this SD, because the column is renamed to camelCase so `created_at` never shares a line with `Date.now()` |
| `fleet-dashboard.cjs` QF age | see below |

## FR-5 — the clamp that hid this

That line wrapped the age in `Math.max(0, ...)`, printing a plausible **"0h"** for every impossible negative value. A negative age is the *only* self-evident symptom this class produces, and the clamp deleted it — the coordinator read that column all night without seeing anything wrong. Removed, not merely made unnecessary.

## Deliberately not touched

Row-vs-row comparisons (both sides shift identically, so ordering is already correct — a test pins this), tz-aware columns (`not_before`, `completion_date`, `quality_checked_at` are TIMESTAMPTZ per `information_schema`, **not** per migration inference — two sites were one inference away from being wrongly "fixed"), and server-side `.gte` filters (evaluated in Postgres, where naive digits already equal UTC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
