### PR TITLE
fix(QF-20260727-395): nothing measured whether the COORDINATOR was answering

### DIFF
--- a/lib/checkin/steps/idle.cjs
+++ b/lib/checkin/steps/idle.cjs
@@ -59,6 +59,32 @@ module.exports = {
       }
     } catch { /* fail-open: keep the baseline recommendation */ }
 
+    // QF-20260727-395: every fleet instrument measures whether WORKERS are talking; nothing
+    // measured whether the COORDINATOR is answering. Measured 2026-07-27T20:38Z: 21 ranked, 0
+    // claimable, none tier-blocked — 10 held on needs_coordinator_review — while the silent-holder
+    // audit, unanswered_over_30m and unranked-claimable-leaves all read green, because a fully
+    // COORDINATOR-FENCED belt is indistinguishable from a healthy one on every existing gauge.
+    // This is the wiring, not just the emit: an unread signal is the defect this row sits inside.
+    // Dynamic import because this file is CJS and the assessor is ESM; the whole block is
+    // fail-open so a gauge fault can never break a check-in.
+    let beltBlockNote = '';
+    try {
+      const { assessCoordinatorBeltBlock, formatCoordinatorBeltBlock } =
+        await import('../../governance/coordinator-belt-block.js');
+      const belt = assessCoordinatorBeltBlock({
+        claimableDepth: claimableAtTier,
+        ineligibilityBreakdown: ctx.base.belt_ineligibility_breakdown,
+      });
+      // Surfaced on ctx.base so a consumer other than this message can read the structured verdict.
+      ctx.base.belt_block = belt;
+      if (belt.blocked) {
+        beltBlockNote =
+          ` ⚠️  BELT BLOCKED ON THE COORDINATOR: ${belt.reason}. This is NOT "work ran out" —` +
+          ` the largest bucket is a fence only the coordinator can clear. Holding a fence for a` +
+          ` stated reason is correct; not NOTICING is the defect. ${formatCoordinatorBeltBlock(belt)}`;
+      }
+    } catch { /* fail-open: an unavailable gauge must not block the idle path */ }
+
     // SD-LEO-INFRA-WORK-CLASS-CLAIM-001 (FR-3, the recurrence fix): a restricted-capability
     // (fable) session that found NO fable-fit work must idle-and-propose — the fence above
     // already made general work invisible; this terminal makes the empty-lane state explicit
@@ -81,7 +107,7 @@ module.exports = {
       ...ctx.base,
       action: 'idle',
       recommended_wakeup_seconds: idleWakeupSeconds,
-      message: `No assignment and nothing claimable. IDLE.${tierNote} The /checkin skill must now call ScheduleWakeup(~${idleWakeupSeconds}s)${adaptiveCadenceNote} and proceed — never wait on a human.`,
+      message: `No assignment and nothing claimable. IDLE.${tierNote}${beltBlockNote} The /checkin skill must now call ScheduleWakeup(~${idleWakeupSeconds}s)${adaptiveCadenceNote} and proceed — never wait on a human.`,
     };
   },
 };

--- a/lib/governance/coordinator-belt-block.js
+++ b/lib/governance/coordinator-belt-block.js
@@ -1,0 +1,140 @@
+/**
+ * QF-20260727-395 — measure the OTHER side of the conversation.
+ *
+ * EVERY FLEET INSTRUMENT MEASURES WHETHER WORKERS ARE TALKING. NOTHING MEASURED WHETHER THE
+ * COORDINATOR IS ANSWERING. Measured by Charlie at 2026-07-27T20:38Z: 21 SDs ranked, ZERO
+ * claimable, none of them tier-blocked — 10 held on needs_coordinator_review, 9 on
+ * human_action_required. A worker sat idle with capacity while the single largest bucket
+ * blocking the whole belt was decisions only the coordinator could make.
+ *
+ * THREE GREEN GAUGES, ZERO CLAIMABLE WORK. None of them is broken; each measures the wrong side:
+ *   1. the silent-holder audit keys on WORKER signal age and work product — every worker WAS
+ *      talking, so it correctly reported zero silent holders;
+ *   2. unanswered_over_30m excludes any signal with read_at set (lib/coordinator/detectors.cjs
+ *      treats read as a soft answer), so a coordinator who READS and does not RULE is
+ *      indistinguishable from one who answered;
+ *   3. unranked-claimable-leaves reports 0 when every leaf is correctly ranked AND correctly
+ *      fenced — a fully-fenced belt is indistinguishable from a healthy one.
+ *
+ * THE DISCRIMINATOR THIS ADDS, and it is the whole point: claimable depth reaching zero is not
+ * itself a defect — the belt legitimately empties when work runs out. The alarm therefore fires
+ * only when depth is zero AND the largest blocking bucket is COORDINATOR-OWNED. That second
+ * clause is what separates "the belt is empty because work ran out" from "the belt is empty
+ * because I have not ruled", which today look identical from every surface.
+ *
+ * WHAT THIS DELIBERATELY IS NOT. It does not auto-clear fences and it is not a nag. A fence held
+ * for a stated reason is CORRECT BEHAVIOUR and several are currently held for good ones. The
+ * defect is INVISIBILITY, not the holding — the coordinator should be unable to not-notice, and
+ * must not be pushed into premature rulings.
+ *
+ * PURE AND DB-FREE ON PURPOSE (mirrors lib/governance/drain-inventory.js's split): all IO lives
+ * in the caller. A DB-touching detector would route to the vitest `db` project, which resolves to
+ * ZERO files unless a designated non-prod target is named — it would report green having executed
+ * nothing, which is the same class of defect this row exists to fix.
+ *
+ * @module governance/coordinator-belt-block
+ */
+
+/**
+ * Ineligibility reasons that only the COORDINATOR can clear. Keys are the reasons emitted by
+ * lib/fleet/claim-eligibility.cjs::classifyDispatchIneligibility, which is the SSOT — this list
+ * names a SUBSET of them and must never be widened to reasons a coordinator cannot act on.
+ * human_action_required is deliberately EXCLUDED: it is the chairman's to clear, not the
+ * coordinator's, and folding it in here would blame the coordinator for someone else's queue.
+ */
+export const COORDINATOR_OWNED_REASONS = Object.freeze(['needs_coordinator_review']);
+
+/** Verdicts. NOT_MEASURED is a first-class outcome, never collapsed into OK. */
+export const BELT_VERDICT = Object.freeze({
+  OK: 'OK',
+  BLOCKED_ON_COORDINATOR: 'BLOCKED_ON_COORDINATOR',
+  NOT_MEASURED: 'NOT_MEASURED',
+});
+
+/**
+ * Assess whether the belt is blocked on coordinator-owned fences.
+ *
+ * @param {object} input
+ * @param {number|null|undefined} input.claimableDepth  ranked+claimable count (belt_claimable_at_my_tier
+ *   or the agnostic belt_ranked_claimable). Missing => NOT_MEASURED, never OK.
+ * @param {Record<string, number>|null|undefined} input.ineligibilityBreakdown  reason -> count, as
+ *   tallied in lib/checkin/steps/merged-pool-self-claim.cjs. Missing => NOT_MEASURED.
+ * @param {string[]} [input.coordinatorOwnedReasons]  override for tests.
+ * @returns {{verdict:string, blocked:boolean, claimableDepth:(number|null),
+ *   coordinatorOwnedCount:number, largestBucket:(string|null), largestBucketCount:number,
+ *   totalIneligible:number, reason:string}}
+ */
+export function assessCoordinatorBeltBlock({
+  claimableDepth,
+  ineligibilityBreakdown,
+  coordinatorOwnedReasons = COORDINATOR_OWNED_REASONS,
+} = {}) {
+  // NOT_MEASURED is the load-bearing branch. If the inputs were never supplied, saying OK would
+  // make an unwired gauge indistinguishable from a healthy belt — the exact defect being fixed.
+  const depthMissing = typeof claimableDepth !== 'number' || Number.isNaN(claimableDepth);
+  const breakdownMissing =
+    !ineligibilityBreakdown || typeof ineligibilityBreakdown !== 'object' || Array.isArray(ineligibilityBreakdown);
+  if (depthMissing || breakdownMissing) {
+    const missing = [depthMissing && 'claimableDepth', breakdownMissing && 'ineligibilityBreakdown']
+      .filter(Boolean)
+      .join(', ');
+    return {
+      verdict: BELT_VERDICT.NOT_MEASURED,
+      blocked: false,
+      claimableDepth: depthMissing ? null : claimableDepth,
+      coordinatorOwnedCount: 0,
+      largestBucket: null,
+      largestBucketCount: 0,
+      totalIneligible: 0,
+      reason: `not measured: missing ${missing}`,
+    };
+  }
+
+  const entries = Object.entries(ineligibilityBreakdown).filter(([, n]) => Number(n) > 0);
+  const totalIneligible = entries.reduce((acc, [, n]) => acc + Number(n), 0);
+
+  // Deterministic largest bucket: count DESC, then reason name ASC so a tie never flickers.
+  const sorted = [...entries].sort((a, b) => Number(b[1]) - Number(a[1]) || String(a[0]).localeCompare(String(b[0])));
+  const largestBucket = sorted.length ? sorted[0][0] : null;
+  const largestBucketCount = sorted.length ? Number(sorted[0][1]) : 0;
+
+  const owned = new Set(coordinatorOwnedReasons);
+  const coordinatorOwnedCount = entries
+    .filter(([reason]) => owned.has(reason))
+    .reduce((acc, [, n]) => acc + Number(n), 0);
+
+  const blocked = claimableDepth === 0 && largestBucket !== null && owned.has(largestBucket);
+
+  return {
+    verdict: blocked ? BELT_VERDICT.BLOCKED_ON_COORDINATOR : BELT_VERDICT.OK,
+    blocked,
+    claimableDepth,
+    coordinatorOwnedCount,
+    largestBucket,
+    largestBucketCount,
+    totalIneligible,
+    reason: blocked
+      ? `claimable depth 0 and the largest blocking bucket is coordinator-owned (${largestBucket}=${largestBucketCount} of ${totalIneligible} ineligible)`
+      : claimableDepth === 0
+        ? `claimable depth 0, but the largest blocking bucket is ${largestBucket ?? 'none'} which is not coordinator-owned — the belt ran out of work, it is not waiting on a ruling`
+        : `claimable depth ${claimableDepth}`,
+  };
+}
+
+/**
+ * One-line summary for the coordinator surface. Prints the counts UNCONDITIONALLY — including the
+ * zeroes — following lib/coordinator/worker-signal-starvation.cjs:18, so measured-and-zero is
+ * distinguishable from not-measured-at-all.
+ * @param {ReturnType<typeof assessCoordinatorBeltBlock>} a
+ * @returns {string}
+ */
+export function formatCoordinatorBeltBlock(a) {
+  if (a.verdict === BELT_VERDICT.NOT_MEASURED) {
+    return `[belt-block] NOT_MEASURED — ${a.reason}. This is NOT a healthy belt; it is an unread one.`;
+  }
+  const head = a.blocked ? 'BLOCKED_ON_COORDINATOR' : 'OK';
+  return (
+    `[belt-block] ${head} claimable=${a.claimableDepth} coordinator_owned=${a.coordinatorOwnedCount} ` +
+    `largest_bucket=${a.largestBucket ?? 'none'}(${a.largestBucketCount}) total_ineligible=${a.totalIneligible} — ${a.reason}`
+  );
+}

--- a/tests/unit/governance/coordinator-belt-block-wiring.test.js
+++ b/tests/unit/governance/coordinator-belt-block-wiring.test.js
@@ -1,0 +1,94 @@
+/**
+ * QF-20260727-395 — WIRING test, differential.
+ *
+ * The row's whole complaint is that a correct instrument can be attached to the wrong side of the
+ * conversation and nobody notices. A test that merely asserted "idle.cjs imports the assessor"
+ * would be the same defect: an import proves the symbol resolves, not that the verdict is READ.
+ *
+ * So this drives the real idle step TWICE with inputs that differ in ONE field, and requires the
+ * consumer's OBSERVABLE OUTPUT to differ. If both runs produced the same message, the signal is
+ * computed-and-discarded and this test fails — which is the only outcome that would tell us the
+ * wiring is decorative.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const idleStep = require('../../../lib/checkin/steps/idle.cjs');
+
+// Minimal ctx: the idle step's other dependencies are stubbed to their no-op shapes so the only
+// thing varying between runs is the belt input under test.
+function makeCtx(base) {
+  return {
+    sb: {},
+    sessionId: 'test-session',
+    sessionMetadata: {},              // no model => not a Fable seat => the plain 'idle' return
+    helpers: {
+      // Force the adaptive-cadence block down its fail-open path so it cannot vary the message.
+      getCommsActivitySignals: async () => { throw new Error('stubbed'); },
+      computeAdaptiveCadence: () => ({ tight: false, intervalMs: 0, reason: '' }),
+      DEFAULT_IDLE_WAKEUP_SECONDS: 1200,
+    },
+    base,
+  };
+}
+
+// Charlie's 20:38Z measurement: 0 claimable, coordinator-owned bucket largest.
+const BLOCKED_BASE = {
+  belt_ranked_claimable: 21,
+  belt_claimable_at_my_tier: 0,
+  belt_ineligibility_breakdown: { needs_coordinator_review: 10, human_action_required: 9 },
+};
+// ONE field different: the largest bucket is now the chairman's queue, not the coordinator's.
+const NOT_BLOCKED_BASE = {
+  belt_ranked_claimable: 21,
+  belt_claimable_at_my_tier: 0,
+  belt_ineligibility_breakdown: { needs_coordinator_review: 2, human_action_required: 17 },
+};
+
+describe('QF-20260727-395 wiring: the idle step CONSUMES the belt-block verdict', () => {
+  it('DIFFERENTIAL: the same step, one field different, produces DIFFERENT observable output', async () => {
+    const blocked = await idleStep.run(makeCtx({ ...BLOCKED_BASE }));
+    const notBlocked = await idleStep.run(makeCtx({ ...NOT_BLOCKED_BASE }));
+
+    // The load-bearing assertion. Identical messages here would mean the verdict is computed and
+    // thrown away -- an emit with no consumer, which this QF exists to prevent.
+    expect(blocked.message).not.toBe(notBlocked.message);
+    expect(blocked.message).toContain('BELT BLOCKED ON THE COORDINATOR');
+    expect(notBlocked.message).not.toContain('BELT BLOCKED ON THE COORDINATOR');
+  });
+
+  it('names the bucket and the count, so the coordinator does not have to go hunting', async () => {
+    const blocked = await idleStep.run(makeCtx({ ...BLOCKED_BASE }));
+    expect(blocked.message).toContain('needs_coordinator_review');
+    expect(blocked.message).toContain('10');
+  });
+
+  it('distinguishes "blocked on a ruling" from "work ran out" in the text itself', async () => {
+    const blocked = await idleStep.run(makeCtx({ ...BLOCKED_BASE }));
+    // The row is explicit that these two states look identical from every surface today.
+    expect(blocked.message).toContain('NOT "work ran out"');
+  });
+
+  it('does NOT nag: holding a fence is named as correct behaviour, the invisibility is the defect', async () => {
+    const blocked = await idleStep.run(makeCtx({ ...BLOCKED_BASE }));
+    expect(blocked.message).toContain('correct');
+    expect(blocked.message).toContain('not NOTICING is the defect');
+  });
+
+  it('exposes the structured verdict on ctx.base for consumers other than the message', async () => {
+    const ctx = makeCtx({ ...BLOCKED_BASE });
+    const out = await idleStep.run(ctx);
+    expect(out.belt_block).toBeTruthy();
+    expect(out.belt_block.verdict).toBe('BLOCKED_ON_COORDINATOR');
+    expect(out.belt_block.largestBucket).toBe('needs_coordinator_review');
+  });
+
+  it('FAIL-OPEN: a missing breakdown yields NOT_MEASURED and still returns a normal idle', async () => {
+    // An unwired upstream must not fabricate a healthy verdict, and must not break the check-in.
+    const out = await idleStep.run(makeCtx({ belt_ranked_claimable: 0 }));
+    expect(out.action).toBe('idle');
+    expect(out.message).not.toContain('BELT BLOCKED ON THE COORDINATOR');
+    expect(out.belt_block.verdict).toBe('NOT_MEASURED');
+  });
+});

--- a/tests/unit/governance/coordinator-belt-block.test.js
+++ b/tests/unit/governance/coordinator-belt-block.test.js
@@ -1,0 +1,143 @@
+/**
+ * QF-20260727-395 — the gauge that measures whether the COORDINATOR is answering.
+ *
+ * THIS SUITE IS BUILT AROUND ITS NEGATIVE CONTROLS, not around its positive case. The row exists
+ * because three gauges reported green while the belt was fully fenced; a fourth gauge that can
+ * only ever report one verdict would be the same defect wearing a new name. So every assertion
+ * below has a partner that must produce the OPPOSITE verdict from a minimally-different input.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  assessCoordinatorBeltBlock,
+  formatCoordinatorBeltBlock,
+  BELT_VERDICT,
+  COORDINATOR_OWNED_REASONS,
+} from '../../../lib/governance/coordinator-belt-block.js';
+
+// Charlie's measurement, 2026-07-27T20:38Z: 21 ranked, 0 claimable, 10 coordinator / 9 human.
+const CHARLIE_2038Z = { needs_coordinator_review: 10, human_action_required: 9 };
+
+describe('QF-20260727-395: belt blocked on coordinator-owned fences', () => {
+  it('THE CASE: depth 0 and the largest bucket is coordinator-owned -> BLOCKED_ON_COORDINATOR', () => {
+    const a = assessCoordinatorBeltBlock({ claimableDepth: 0, ineligibilityBreakdown: CHARLIE_2038Z });
+    expect(a.verdict).toBe(BELT_VERDICT.BLOCKED_ON_COORDINATOR);
+    expect(a.blocked).toBe(true);
+    expect(a.largestBucket).toBe('needs_coordinator_review');
+    expect(a.coordinatorOwnedCount).toBe(10);
+    // The reason must NAME the bucket -- a bare "blocked" would send the coordinator hunting.
+    expect(a.reason).toContain('needs_coordinator_review');
+  });
+
+  it('NEGATIVE CONTROL 1 (the load-bearing one): depth 0 but the largest bucket is NOT coordinator-owned -> OK', () => {
+    // Same zero depth, ONE field different. If this also returned BLOCKED, the gauge would be
+    // measuring "belt is empty" -- which is not a defect -- and would fire every time work ran out.
+    const a = assessCoordinatorBeltBlock({
+      claimableDepth: 0,
+      ineligibilityBreakdown: { needs_coordinator_review: 2, human_action_required: 11 },
+    });
+    expect(a.verdict).toBe(BELT_VERDICT.OK);
+    expect(a.blocked).toBe(false);
+    expect(a.largestBucket).toBe('human_action_required');
+    // It still REPORTS the coordinator-owned count, unconditionally, even when not blocking.
+    expect(a.coordinatorOwnedCount).toBe(2);
+    expect(a.reason).toContain('not coordinator-owned');
+  });
+
+  it('NEGATIVE CONTROL 2: coordinator-owned bucket is largest but work IS claimable -> OK', () => {
+    // Fences held while workers still have work is correct behaviour, not an alarm. A fence held
+    // for a stated reason is fine; the row is explicit that this must not become a nag.
+    const a = assessCoordinatorBeltBlock({ claimableDepth: 7, ineligibilityBreakdown: CHARLIE_2038Z });
+    expect(a.verdict).toBe(BELT_VERDICT.OK);
+    expect(a.blocked).toBe(false);
+    expect(a.coordinatorOwnedCount).toBe(10);
+  });
+
+  it('the two controls differ from the positive case by ONE field each, so the gauge is proven to discriminate', () => {
+    const positive = assessCoordinatorBeltBlock({ claimableDepth: 0, ineligibilityBreakdown: CHARLIE_2038Z });
+    const depthDiffers = assessCoordinatorBeltBlock({ claimableDepth: 1, ineligibilityBreakdown: CHARLIE_2038Z });
+    const bucketDiffers = assessCoordinatorBeltBlock({
+      claimableDepth: 0,
+      ineligibilityBreakdown: { needs_coordinator_review: 1, human_action_required: 9 },
+    });
+    // If any of these three collapse to the same verdict the suite has gone vacuous.
+    expect(new Set([positive.verdict, depthDiffers.verdict, bucketDiffers.verdict]).size).toBe(2);
+    expect(positive.verdict).not.toBe(depthDiffers.verdict);
+    expect(positive.verdict).not.toBe(bucketDiffers.verdict);
+  });
+});
+
+describe('NOT_MEASURED is never collapsed into OK', () => {
+  it('missing claimableDepth -> NOT_MEASURED, not OK', () => {
+    const a = assessCoordinatorBeltBlock({ ineligibilityBreakdown: CHARLIE_2038Z });
+    expect(a.verdict).toBe(BELT_VERDICT.NOT_MEASURED);
+    expect(a.reason).toContain('claimableDepth');
+  });
+
+  it('missing ineligibilityBreakdown -> NOT_MEASURED, not OK', () => {
+    const a = assessCoordinatorBeltBlock({ claimableDepth: 0 });
+    expect(a.verdict).toBe(BELT_VERDICT.NOT_MEASURED);
+    expect(a.reason).toContain('ineligibilityBreakdown');
+  });
+
+  it('called with NO arguments at all -> NOT_MEASURED', () => {
+    // The unwired-caller case. An unwired gauge must not read as a healthy belt -- this is the
+    // whole class QF-20260727-395 sits inside.
+    expect(assessCoordinatorBeltBlock().verdict).toBe(BELT_VERDICT.NOT_MEASURED);
+    expect(assessCoordinatorBeltBlock({}).verdict).toBe(BELT_VERDICT.NOT_MEASURED);
+  });
+
+  it('an array is not a breakdown object -> NOT_MEASURED', () => {
+    const a = assessCoordinatorBeltBlock({ claimableDepth: 0, ineligibilityBreakdown: [] });
+    expect(a.verdict).toBe(BELT_VERDICT.NOT_MEASURED);
+  });
+
+  it('a genuinely EMPTY breakdown with claimable work is OK, not NOT_MEASURED', () => {
+    // measured-and-empty vs not-measured: the distinction the row is about.
+    const a = assessCoordinatorBeltBlock({ claimableDepth: 5, ineligibilityBreakdown: {} });
+    expect(a.verdict).toBe(BELT_VERDICT.OK);
+    expect(a.totalIneligible).toBe(0);
+    expect(a.largestBucket).toBeNull();
+  });
+});
+
+describe('mechanics', () => {
+  it('human_action_required is NOT counted as coordinator-owned', () => {
+    // It is the chairman's queue. Folding it in would blame the coordinator for someone else's.
+    expect(COORDINATOR_OWNED_REASONS).not.toContain('human_action_required');
+    const a = assessCoordinatorBeltBlock({
+      claimableDepth: 0,
+      ineligibilityBreakdown: { human_action_required: 11 },
+    });
+    expect(a.coordinatorOwnedCount).toBe(0);
+    expect(a.blocked).toBe(false);
+  });
+
+  it('zero-count buckets are ignored so an empty tally cannot win the largest-bucket contest', () => {
+    const a = assessCoordinatorBeltBlock({
+      claimableDepth: 0,
+      ineligibilityBreakdown: { needs_coordinator_review: 0, human_action_required: 3 },
+    });
+    expect(a.largestBucket).toBe('human_action_required');
+    expect(a.blocked).toBe(false);
+  });
+
+  it('ties break deterministically by reason name so the verdict cannot flicker between runs', () => {
+    const input = { claimableDepth: 0, ineligibilityBreakdown: { needs_coordinator_review: 4, human_action_required: 4 } };
+    const first = assessCoordinatorBeltBlock(input);
+    const second = assessCoordinatorBeltBlock({ ...input, ineligibilityBreakdown: { human_action_required: 4, needs_coordinator_review: 4 } });
+    expect(first.largestBucket).toBe(second.largestBucket);
+    expect(first.verdict).toBe(second.verdict);
+  });
+
+  it('formats counts UNCONDITIONALLY, including zeroes, so measured-zero reads differently from unmeasured', () => {
+    const measuredZero = formatCoordinatorBeltBlock(
+      assessCoordinatorBeltBlock({ claimableDepth: 3, ineligibilityBreakdown: {} })
+    );
+    const unmeasured = formatCoordinatorBeltBlock(assessCoordinatorBeltBlock());
+    expect(measuredZero).toContain('coordinator_owned=0');
+    expect(measuredZero).toContain('total_ineligible=0');
+    expect(unmeasured).toContain('NOT_MEASURED');
+    expect(unmeasured).not.toContain('coordinator_owned=0');
+    expect(measuredZero).not.toBe(unmeasured);
+  });
+});


### PR DESCRIPTION
## Summary

Measured by Charlie at 2026-07-27T20:38Z: **21 SDs ranked, ZERO claimable, none tier-blocked** — 10 held on `needs_coordinator_review`, 9 on `human_action_required`. The largest bucket blocking the whole belt was decisions only the coordinator could make, while a worker sat idle with capacity.

**Three green gauges, zero claimable work.** None was broken; each measures the wrong side of the conversation:
1. the silent-holder audit keys on **worker** signal age — every worker *was* talking;
2. `unanswered_over_30m` excludes signals with `read_at` set, so a coordinator who **reads and does not rule** looks identical to one who answered;
3. `unranked-claimable-leaves` reports 0 when every leaf is correctly ranked **and** correctly fenced — a fully-fenced belt is indistinguishable from a healthy one.

Second occurrence: the coordinator had already written this exact diagnosis onto QF-20260726-996 and it recurred within hours. Diagnosing a defect in prose does not fix it; only changing the instrument does.

## The discriminator

Claimable depth reaching zero is **not** a defect — the belt legitimately empties. The alarm fires only when depth is zero **AND** the largest blocking bucket is coordinator-owned. That clause separates *"work ran out"* from *"I have not ruled"*, which look identical from every surface today.

`human_action_required` is deliberately **excluded** — it's the chairman's queue, and folding it in would blame the coordinator for someone else's backlog.

## Not a nag

No auto-clearing of fences. A fence held for a stated reason is correct behaviour and the message says so. The defect is **invisibility**, not the holding.

## Wired, not just emitted

This lands during SD-LEO-INFRA-PURE-GUARD-UNWIRED-001, whose thesis is that a guard with an unwired caller is indistinguishable from a passing one — so a gauge nothing reads would *be* that defect. `idle.cjs` consumes the verdict (it already held both inputs), proven **differentially**: same step, one field different, observable output must differ.

## Test plan
- [x] 19/19 green across 2 test files (asserted non-zero — the db vitest project resolves to zero files and would report green having executed nothing)
- [x] **Revert-sensitivity proven**: neutering only the *consumption* — verdict still computed, dropped from the message — turns 3 tests RED including the differential. Restored: green.
- [x] `NOT_MEASURED` never collapses into OK (missing depth, missing breakdown, array, or no arguments at all)
- [x] Measured-and-empty is distinguishable from not-measured
- [x] Ties break deterministically so the verdict cannot flicker
- [x] Full `tests/unit/governance/` suite: 63 files, 951 tests, all passing

Related, not duplicated: QF-20260727-190 (`read_at` as soft answer), QF-20260727-714.

🤖 Generated with [Claude Code](https://claude.com/claude-code)