### PR TITLE
fix(SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001): red-merge detection has never worked, and the ledger could not say 'nobody answered'

### DIFF
--- a/.github/workflows/solomon-judgment-expiry.yml
+++ b/.github/workflows/solomon-judgment-expiry.yml
@@ -1,0 +1,62 @@
+# SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-2
+#
+# Ages out advice whose ADOPTION judgment was never answered. Before this, the ledger could say
+# accepted, rejected and still-waiting, but had no way to say NOBODY EVER ANSWERED — so 566 of ~1100
+# rows sat at 'pending' forever and an unanswered question was indistinguishable from work in
+# progress.
+#
+# SHIPS WITH THE WRITE PATH OFF, in two independent ways, because aging is not reversible in the
+# sense that matters: once a row records that nobody answered, judging it later cannot un-record it.
+#   1. `schedule:` is commented out — this workflow only runs on manual dispatch until someone
+#      deliberately enables the cadence.
+#   2. Even when dispatched, the runner refuses to write unless LEO_JUDGMENT_EXPIRY_ENABLED=1 AND
+#      --apply is passed. The default dispatch is a DRY RUN that prints the candidate set.
+#
+# The dry run is the point: seeing exactly which rows would be stamped is how an operator decides
+# whether the first real run is safe. Measured at authoring time, 0 pending rows exceeded 5 days and
+# the oldest was 4.8, so a 7d threshold expires nothing on day one and what it eventually expires is
+# genuinely abandoned rather than merely recent.
+#
+# WHY THIS FILE EXISTS AT ALL: the first version of FR-2 shipped a pure selector with no runner and
+# no entry, and I described it as "ships disabled". Retro review pointed out that is not a disabled
+# mechanism, it is an ABSENT one — the exact failure mode this SD documents, where five prior
+# mechanisms shipped into this table and all five run at zero.
+
+name: Solomon Judgment Expiry
+
+on:
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Actually stamp rows (default: dry run, prints candidates only)'
+        type: boolean
+        default: false
+  # Deliberately commented out. Uncomment ONLY after a dry run has been reviewed.
+  # schedule:
+  #   - cron: '17 4 * * *'   # daily, offset off the hour to avoid the cron thundering herd
+
+permissions:
+  contents: read
+
+jobs:
+  expire:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci --ignore-scripts
+      - name: Age out unanswered judgments
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          # The second gate. Absent this, the runner prints "disabled" and exits 0 regardless of
+          # --apply, so an accidental dispatch cannot write.
+          LEO_JUDGMENT_EXPIRY_ENABLED: '1'
+        run: |
+          if [ "${{ inputs.apply }}" = "true" ]; then
+            node scripts/solomon-judgment-expiry-run.mjs --apply
+          else
+            node scripts/solomon-judgment-expiry-run.mjs
+          fi

--- a/database/migrations/20260729_solomon_ledger_judgment_expiry.sql
+++ b/database/migrations/20260729_solomon_ledger_judgment_expiry.sql
@@ -63,4 +63,4 @@ COMMENT ON COLUMN solomon_advice_outcome_ledger.judgment_expired_at IS
   'When the adoption judgment aged out unanswered. INDEPENDENT of decision, which stays ''pending'' -- a row can be both never-judged and still-pending, and that is the truth. Deliberately NOT a decision value: routing expiry through decision would move drain-inventory.mjs:88 and :91 together and inflate the accuracy denominator at fleet-dashboard.cjs:1959. SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-1.';
 
 COMMENT ON COLUMN solomon_advice_outcome_ledger.judgment_expired_by IS
-  'Identifier of the aging process that stamped judgment_expired_at. Constraint-required so a hand-written row cannot pass for a mechanism that ran. SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-2/TS-10.';
+  'Identifier of the aging process that stamped judgment_expired_at. Constraint-required so a stamp can never be ANONYMOUS -- it does NOT establish WHO stamped it, because the actor value is a public constant and every writer shares one service-role identity. TS-10 (did the mechanism actually RUN) needs a witness the database cannot supply. SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-2.';

--- a/database/migrations/20260729_solomon_ledger_judgment_expiry.sql
+++ b/database/migrations/20260729_solomon_ledger_judgment_expiry.sql
@@ -39,11 +39,20 @@ CREATE INDEX IF NOT EXISTS idx_solomon_ledger_judgment_expired
   ON solomon_advice_outcome_ledger (judgment_expired_at)
   WHERE judgment_expired_at IS NOT NULL;
 
--- Attribution is REQUIRED when expiry is stamped. Without it a hand-written row is
--- indistinguishable from one the aging job produced, and TS-10 -- which asserts the mechanism
--- actually RAN rather than merely shipping green -- would be satisfiable by hand. Five mechanisms
--- have already shipped into this table and all five run at zero; that is the failure mode this
--- constraint is aimed at.
+-- Attribution is REQUIRED when expiry is stamped: a stamped row must say WHAT stamped it.
+--
+-- CLAIM NARROWED AFTER SECURITY REVIEW, because the first version of this comment overstated it. I
+-- wrote that this makes a hand-written row unable to "pass for a mechanism that actually ran". It
+-- does not, and no CHECK could: it constrains neither the VALUE (EXPIRY_ACTOR is a public exported
+-- constant anyone can copy) nor the WRITER (every writer authenticates as the same service role, so
+-- Postgres cannot tell them apart). What it actually guarantees is narrower and still worth having:
+-- an expiry stamp can never be ANONYMOUS, so a row missing attribution is a schema violation rather
+-- than a silent gap.
+--
+-- TS-10 -- "the mechanism actually RAN rather than merely shipping green" -- therefore CANNOT rest
+-- on this constraint. Five mechanisms have already shipped into this table and all five run at zero;
+-- distinguishing "ran" from "shipped" needs a witness the DB cannot provide, and that is recorded as
+-- an open gap rather than papered over with a constraint that reads like it closes it.
 ALTER TABLE solomon_advice_outcome_ledger
   DROP CONSTRAINT IF EXISTS solomon_ledger_judgment_expiry_attributed;
 ALTER TABLE solomon_advice_outcome_ledger

--- a/database/migrations/20260729_solomon_ledger_judgment_expiry.sql
+++ b/database/migrations/20260729_solomon_ledger_judgment_expiry.sql
@@ -1,0 +1,57 @@
+-- SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-1 — judgment expiry as its OWN column.
+--
+-- CHAIRMAN-APPLY-GATED. Authored, not applied.
+--
+-- WHY A COLUMN RATHER THAN A NEW `decision` VALUE, which is what this SD originally specified.
+-- The first design added `expired_unjudged` to decision. Review dismantled it on three counts and
+-- the reversal is the safer design, not merely the cheaper one:
+--
+--   1. It would have moved BOTH scripts/drain-inventory.mjs:88 and :91 at once — emptying the
+--      undrained population while simultaneously inflating closingPathUses. One action moving two
+--      counters the right way for the wrong reason is exactly the silent-retirement risk this SD
+--      exists to prevent, so the original plan caused the harm it was written to stop and then
+--      spent a whole FR repairing it.
+--   2. scripts/fleet-dashboard.cjs:1959 partitions the accuracy DENOMINATOR by negation of
+--      'pending' while :1980 uses a positive allow-list for the numerator, so any new terminal
+--      decision value lands in the denominator and can never reach the numerator. Simulated on live
+--      data: aging every pending row would have dropped accuracy from 16% to 6% with no change in
+--      the world.
+--   3. The SD's own FR told EXEC to add the value to VALID_DISPOSITIONS while its own test asserted
+--      the judging path could NOT write it — a self-contradiction inside one PRD.
+--
+-- Expiry and adoption are independent facts. Keeping them in separate columns means a row can be
+-- both "never judged by a human" and "still pending", which is the truth, and it answers the
+-- six-months-out question better than collapsing them ever could. It also turns CHECK-altering DDL
+-- into a plain ADD COLUMN.
+--
+-- MEASURED BEFORE WRITING (2026-07-29): 1100 rows; outcome unknown on 1047; ZERO negatives ever;
+-- decision pending on 566. Zero pending rows exceed 5 days, 176 exceed 72h, max age 4.8 days —
+-- which is why the aging threshold is pinned at 7d in the job rather than left to a fixture, and
+-- why the job ships disabled. A shorter threshold would only stamp rows history says were about to
+-- be judged.
+
+ALTER TABLE solomon_advice_outcome_ledger
+  ADD COLUMN IF NOT EXISTS judgment_expired_at timestamptz,
+  ADD COLUMN IF NOT EXISTS judgment_expired_by text;
+
+-- Partial index: the aging job and every consumer ask "which rows expired", never "which did not".
+CREATE INDEX IF NOT EXISTS idx_solomon_ledger_judgment_expired
+  ON solomon_advice_outcome_ledger (judgment_expired_at)
+  WHERE judgment_expired_at IS NOT NULL;
+
+-- Attribution is REQUIRED when expiry is stamped. Without it a hand-written row is
+-- indistinguishable from one the aging job produced, and TS-10 -- which asserts the mechanism
+-- actually RAN rather than merely shipping green -- would be satisfiable by hand. Five mechanisms
+-- have already shipped into this table and all five run at zero; that is the failure mode this
+-- constraint is aimed at.
+ALTER TABLE solomon_advice_outcome_ledger
+  DROP CONSTRAINT IF EXISTS solomon_ledger_judgment_expiry_attributed;
+ALTER TABLE solomon_advice_outcome_ledger
+  ADD CONSTRAINT solomon_ledger_judgment_expiry_attributed
+  CHECK (judgment_expired_at IS NULL OR judgment_expired_by IS NOT NULL);
+
+COMMENT ON COLUMN solomon_advice_outcome_ledger.judgment_expired_at IS
+  'When the adoption judgment aged out unanswered. INDEPENDENT of decision, which stays ''pending'' -- a row can be both never-judged and still-pending, and that is the truth. Deliberately NOT a decision value: routing expiry through decision would move drain-inventory.mjs:88 and :91 together and inflate the accuracy denominator at fleet-dashboard.cjs:1959. SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-1.';
+
+COMMENT ON COLUMN solomon_advice_outcome_ledger.judgment_expired_by IS
+  'Identifier of the aging process that stamped judgment_expired_at. Constraint-required so a hand-written row cannot pass for a mechanism that ran. SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-2/TS-10.';

--- a/lib/solomon/conduct-probes.js
+++ b/lib/solomon/conduct-probes.js
@@ -82,13 +82,27 @@ export async function resolveSolomonConductFacts(supabase, { staleDays = DEFAULT
     return { staleOpenAdviceCount: null, staleDays };
   }
   try {
-    const { data, error } = await supabase
+    // SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-3 — SERVER-SIDE EXACT COUNT, not a row fetch.
+    //
+    // This was `.select('id')` followed by `data.length`, which PostgREST silently clamps at 1000.
+    // The ledger passed 1000 rows some time ago (1100 at time of writing), so the probe was one
+    // busy week away from under-reporting its own backlog — and it reads true TODAY only because the
+    // `created_at` cutoff happens to shrink the set below the cap, not because the population is
+    // small. A watchdog that silently saturates is worse than no watchdog: it reports a stable
+    // number while the thing it measures grows.
+    //
+    // `head: true` asks the server for the count and transfers no rows, so there is nothing to
+    // truncate. Note this deliberately still counts rows whose judgment has EXPIRED: expiry lives
+    // in its own column (FR-1) and leaves `decision` at 'pending', so an aged-out row remains
+    // unjudged here. That is the point — the drain must not be able to retire the backlog signal by
+    // aging it.
+    const { count, error } = await supabase
       .from('solomon_advice_outcome_ledger')
-      .select('id')
+      .select('id', { count: 'exact', head: true })
       .eq('decision', 'pending')
       .lt('created_at', cutoff);
-    if (error || !Array.isArray(data)) return { staleOpenAdviceCount: null, staleDays };
-    return { staleOpenAdviceCount: data.length, staleDays };
+    if (error || typeof count !== 'number') return { staleOpenAdviceCount: null, staleDays };
+    return { staleOpenAdviceCount: count, staleDays };
   } catch {
     return { staleOpenAdviceCount: null, staleDays };
   }

--- a/lib/solomon/conduct-probes.test.js
+++ b/lib/solomon/conduct-probes.test.js
@@ -29,7 +29,9 @@ const brokenDb = { from: () => { throw new Error('connection reset'); } };
 
 describe('THE THREE ARMS — the same resolver, three states of the world', () => {
   it('BREACH: stale undecided advice resolves to fail', async () => {
-    const facts = await resolveSolomonConductFacts(db({ data: [{ id: 1 }, { id: 2 }], error: null }));
+    // FR-3: the probe now asks the server for an exact count (head:true) instead of fetching rows
+    // and measuring .length, which PostgREST clamps at 1000. Same intent: 2 stale rows.
+    const facts = await resolveSolomonConductFacts(db({ data: null, count: 2, error: null }));
     expect(facts.staleOpenAdviceCount).toBe(2);
     const [v] = runSolomonConductProbes(facts);
     expect(v.verdict).toBe(VERDICT.FAIL);
@@ -39,7 +41,8 @@ describe('THE THREE ARMS — the same resolver, three states of the world', () =
   it('CLEAN: nothing stale resolves to PASS — not unknown', async () => {
     // The load-bearing arm. Without a demonstrated pass, "returns fail on a breach" is satisfied by
     // a probe hardcoded to fail, which would see nothing at all.
-    const facts = await resolveSolomonConductFacts(db({ data: [], error: null }));
+    // FR-3: same shape change. Same intent: zero stale rows.
+    const facts = await resolveSolomonConductFacts(db({ data: null, count: 0, error: null }));
     expect(facts.staleOpenAdviceCount).toBe(0);
     const [v] = runSolomonConductProbes(facts);
     expect(v.verdict).toBe(VERDICT.PASS);

--- a/lib/solomon/judgment-expiry.js
+++ b/lib/solomon/judgment-expiry.js
@@ -1,0 +1,70 @@
+/**
+ * SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-2 — age out advice whose adoption judgment never came.
+ *
+ * The ledger could say "accepted", "rejected" and "still waiting", but had no way to say NOBODY EVER
+ * ANSWERED. Every unanswered row sat at `pending` forever, so the backlog looked like work in
+ * progress rather than a question that had gone unanswered — and 566 of 1100 rows were in that
+ * state.
+ *
+ * THE THRESHOLD IS PINNED HERE, ON PURPOSE. Left to a fixture, any test passes for whatever value
+ * the fixture chose. Measured on live data 2026-07-29: ZERO pending rows exceed 5 days, 176 exceed
+ * 72h, and the oldest is 4.8 days. So a >=5d threshold is unsatisfiable at ship time, while a <=4d
+ * threshold is satisfiable only by stamping rows the history says were about to be judged. 7d is
+ * chosen to be clear of both: it expires nothing today, and what it eventually expires is genuinely
+ * abandoned rather than merely recent.
+ *
+ * SHIPS DISABLED. The first real run must be a decision, not a side effect of merging — see
+ * ENABLED_BY_DEFAULT. Aging is not reversible in any meaningful sense: once a row is stamped, the
+ * fact that a human never answered is recorded forever, and re-judging it later cannot un-record it.
+ */
+
+/** Days a pending judgment may go unanswered before it is recorded as expired. */
+export const EXPIRY_DAYS = 7;
+
+/** Identifier stamped into judgment_expired_by. The DB CHECK requires it to be non-null. */
+export const EXPIRY_ACTOR = 'solomon-judgment-expiry';
+
+/**
+ * Off until switched on deliberately. A scheduler entry that exists but is disabled still satisfies
+ * "a scheduler references it", which is why the test asserts this flag rather than the entry.
+ */
+export const ENABLED_BY_DEFAULT = false;
+
+/**
+ * PURE — decide which rows have aged out. Extracted so the rule is testable with no DB, no clock
+ * injection games, and no credentials. The db vitest project is DISABLED in this repo, so anything
+ * gated on real credentials would skip silently and green.
+ *
+ * @param {Array<{id:string, decision:string, created_at:string, judgment_expired_at?:string|null}>} rows
+ * @param {{nowMs:number, expiryDays?:number}} opts
+ * @returns {Array<{id:string, ageDays:number}>} rows to stamp, oldest first
+ */
+export function selectExpiredJudgments(rows = [], { nowMs, expiryDays = EXPIRY_DAYS } = {}) {
+  if (!Number.isFinite(nowMs)) return [];            // no usable clock -> stamp nothing
+  const cutoffMs = expiryDays * 24 * 60 * 60 * 1000;
+  const out = [];
+  for (const r of rows) {
+    if (!r || r.judgment_expired_at) continue;       // already stamped — never re-stamp
+    // ONLY unanswered judgments expire. An accepted/rejected/partial/deferred row HAS an answer,
+    // and stamping it would assert something false about a question that was actually resolved.
+    if (r.decision !== 'pending') continue;
+    const createdMs = r.created_at ? new Date(r.created_at).getTime() : NaN;
+    if (!Number.isFinite(createdMs)) continue;       // unusable timestamp -> skip, never guess
+    const ageMs = nowMs - createdMs;
+    if (ageMs <= cutoffMs) continue;                 // strictly past the threshold, not at it
+    out.push({ id: r.id, ageDays: ageMs / 86_400_000 });
+  }
+  return out.sort((a, b) => b.ageDays - a.ageDays);
+}
+
+/**
+ * The patch written for an expired row. NOTE WHAT IS ABSENT: `decision` is untouched.
+ *
+ * Routing expiry through `decision` was the original design and would have moved
+ * drain-inventory.mjs:88 and :91 together while inflating the accuracy denominator at
+ * fleet-dashboard.cjs:1959 — breaking the very instruments that justified the SD. Expiry and
+ * adoption are independent facts and stay in independent columns.
+ */
+export function expiryPatch({ nowIso, actor = EXPIRY_ACTOR } = {}) {
+  return { judgment_expired_at: nowIso, judgment_expired_by: actor };
+}

--- a/scripts/ci/red-merge-detector.mjs
+++ b/scripts/ci/red-merge-detector.mjs
@@ -270,7 +270,9 @@ async function main() {
     if (rot.rotted && !dryRun) {
       try {
         await db.from('audit_log').insert({
-          event: 'BASELINE_ROT_DETECTED',
+          // FR-0: same defect, same silent no-op.
+          event_type: 'BASELINE_ROT_DETECTED',
+          severity: 'medium',
           metadata: { rule: rot.rule, latest: rot.latest, prev: rot.prev, ceiling: rot.ceiling, recentMedian: rot.recentMedian, olderMedian: rot.olderMedian, reason: rot.reason },
         });
       } catch { /* best effort — never blocks */ }
@@ -344,7 +346,14 @@ async function main() {
   // Audit row — best-effort, never blocks.
   try {
     await db.from('audit_log').insert({
-      event: 'RED_MERGE_DETECTED',
+      // SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-0: the column is `event_type`. Written as
+      // `event` this insert threw 42703 inside the best-effort catch below, so it silently
+      // no-opped on every red merge ever detected. entity_type/entity_id are populated too so
+      // the row is attributable rather than metadata-only.
+      event_type: 'RED_MERGE_DETECTED',
+      entity_type: 'commit',
+      entity_id: verdict.sha ?? null,
+      severity: 'high',
       metadata: { signature: verdict.signature, sha: verdict.sha, prev_failed: verdict.prevFailed, new_failed: verdict.newFailed, qf_output: out.slice(0, 500) },
     });
   } catch { /* best effort */ }

--- a/scripts/coordinator-ack-adam.cjs
+++ b/scripts/coordinator-ack-adam.cjs
@@ -104,35 +104,36 @@ function isNoArtifactRef(ref) {
  * @param {string} ref
  * @returns {boolean}
  */
-/**
- * Single-token PLACEHOLDERS. Whitespace-free, so the token rule waves them through — and they are
- * STRICTLY WORSE than the NO_ARTIFACT sentinel, which is why they need naming explicitly.
- * selectNegativeBackprop SKIPS a NO_ARTIFACT ref (it knows there is nothing to track), but it
- * carries 'n/a' as a genuine link that can never match. Review found the error message itself steers
- * people here: it says "supply the identifier, or --no-artifact", so an operator with neither types
- * 'n/a'. Fixing only the sentence case would have narrowed the starvation to single tokens rather
- * than closing it.
- */
-const PLACEHOLDER_REFS = Object.freeze(new Set([
-  'n/a', 'na', 'n.a.', 'none', 'nil', 'null', 'nothing', 'tbd', 'tba', 'todo', 'unknown', 'unclear',
-  'moot', 'done', 'merged', 'various', 'multiple', 'verbal', 'pending', 'n/a.', '-', '--', '...',
-]));
-
 function isMatchableRef(ref) {
   if (typeof ref !== 'string') return false;
   const s = ref.trim();
   if (!s || /\s/.test(s)) return false;              // an identifier has no spaces; a sentence does
-  // A bare number IS a legitimate artifact id — pr_number is one of the matcher's harvest keys, and
-  // rejecting '#7' was a false rejection review caught. Length floors must not swallow it.
-  if (/^#?\d{1,7}$/.test(s)) return true;
-  if (s.length < 3 || s.length > 500) return false;  // 200 rejected a real signed CI-run URL (220 chars)
-  if (PLACEHOLDER_REFS.has(s.toLowerCase())) return false;
+  if (s.length > 500) return false;                  // 200 rejected a real signed CI-run URL (220 chars)
+
   // A NEAR-MISS SPELLING OF THE SENTINEL IS THE WORST CASE OF ALL: 'no_artifact' lowercase or
   // 'NO-ARTIFACT' hyphenated fails isNoArtifactRef, so the operator believes they recorded "nothing
-  // to track" while the row is billed as a real, permanently unmatchable link that the back-prop
-  // will NOT skip. Reject so they are told to use the exact sentinel.
-  if (/^no[-_. ]?artifact/i.test(s) && !isNoArtifactRef(s)) return false;
-  return /[A-Za-z0-9]/.test(s);
+  // to track" while the row is billed as a real, permanently unmatchable link the back-prop will NOT
+  // skip. END-ANCHORED — my first version was a bare prefix rule and wrongly rejected
+  // 'no-artifact-handling-001', which is a false rejection, the mode I keep calling worse than the
+  // defect. Only the near-misses themselves are caught now.
+  if (/^no[-_. ]?artifact$/i.test(s) && !isNoArtifactRef(s)) return false;
+
+  // THE STRUCTURAL DISCRIMINANT — a digit, or a URL.
+  //
+  // My previous attempt was a PLACEHOLDER_REFS enumeration, and review correctly identified it as
+  // the same failure mode as my v1 scheme allow-list, pointed the other way: 'already-merged',
+  // 'see-adam-note' and ~24 unlisted words sailed through, and one trailing character defeated it
+  // ('n/a' blocked, 'na.' not). An enumeration of what to reject rots exactly like an enumeration of
+  // what to accept.
+  //
+  // The structural fact is that an artifact identifier CARRIES A NUMBER — a sha, an SD/QF key, a PR
+  // or issue number, a uuid, a versioned URL — while a placeholder is words. Verified against the
+  // live corpus: all 5 currently-accepted refs satisfy it, and every placeholder review supplied
+  // fails it. It cannot be defeated by a word nobody thought to enumerate.
+  //
+  // All-zeros is the one numeric placeholder ('0', '#00'), so it is excluded explicitly.
+  if (/^#?0+$/.test(s)) return false;
+  return /\d/.test(s) || /^https?:\/\/\S+$/i.test(s);
 }
 
 function resolveOutcomeRef(disposition, { outcomeRef = null, noArtifact = null } = {}) {
@@ -238,7 +239,8 @@ async function recordLedgerDecision(supabase, { correlationId, disposition, deci
     //     NOT LIVE THERE (2 of 5453 rows carry a QF- key, and those are anomalies). A QF artifact
     //     would write a key that never resolves, so the row is re-selected by every scheduled batch
     //     forever, burning a slot and logging a skip line each time. Measured: 13 of the 31 existing
-    //     outcome_sd_key values already fail to resolve, 4 of them QF keys.
+    //     outcome_sd_key values already fail to resolve. Settled by direct count: 6 DISTINCT QF
+    //     keys across 8 ROWS (an earlier "4" came from a truncated sample read as a population).
     //   - /i: sd_key is stored uppercase, so a lowercased ref derives a key that never matches.
     // A key that cannot resolve is worse than no key: the forward path stays dead AND the batch is
     // permanently polluted.

--- a/scripts/coordinator-ack-adam.cjs
+++ b/scripts/coordinator-ack-adam.cjs
@@ -192,6 +192,23 @@ async function recordLedgerDecision(supabase, { correlationId, disposition, deci
       decision_at: decisionAt,
     };
     if (resolvedOutcomeRef) row.outcome_ref = resolvedOutcomeRef;
+    // SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-6 — ALSO populate outcome_sd_key when the artifact
+    // IS an SD/QF key.
+    //
+    // This column is not decoration: it drives the FORWARD reconciliation path.
+    // solomon-ledger-reconcile.cjs:64 skips every row without it ("no outcome_sd_key") and :70 looks
+    // the SD up by it to derive the outcome via mapSdStatusToOutcome. It had NO production writer —
+    // the 47 populated rows came from one-off scripts — so it is NULL on 1062 of 1109 rows, and that
+    // is the reason the reconciler is inert on ~95% of the ledger.
+    //
+    // Same starvation as FR-5, on the other leg: the negative path was starved of matchable refs,
+    // the forward path is starved of this key. Both were built and neither was fed.
+    //
+    // Derived rather than separately supplied, deliberately: a second hand-entered field would drift
+    // from outcome_ref, and then two columns would disagree about which artifact a decision tracked.
+    if (resolvedOutcomeRef && !isNoArtifactRef(resolvedOutcomeRef) && /^(SD|QF)-[A-Z0-9-]+$/i.test(resolvedOutcomeRef)) {
+      row.outcome_sd_key = resolvedOutcomeRef;
+    }
     if (disposition === 'deferred') row.defer_trigger = deferTrigger;
     const { error } = await supabase
       .from('solomon_advice_outcome_ledger') // schema-lint-disable-line — new table (this PR's migration), chairman-apply-gated, not yet in the live snapshot

--- a/scripts/coordinator-ack-adam.cjs
+++ b/scripts/coordinator-ack-adam.cjs
@@ -75,8 +75,56 @@ function isNoArtifactRef(ref) {
  * Returns { ref } (string|null) on success, or { error } when linkage is mandatory and missing.
  * Exported for tests.
  */
+/**
+ * SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-5 — is this ref one the matcher could ever match?
+ *
+ * THE STARVATION THIS CLOSES. The FR-4 negative back-propagation attributes ONLY through exact
+ * equality against identifiers harvested from audit metadata (NEGATIVE_REF_KEYS in
+ * solomon-ledger-reconcile.cjs: sha, commit_sha, sd_key, sd_id, ref, outcome_ref, pr, pr_url,
+ * pr_number, signature). This function's caller accepted ANY non-empty string, and the CLI's
+ * `--outcome-ref <artifact-id>` was only a hint — so operators typed sentences. Measured 2026-07-29:
+ * 158 of 170 populated refs are free English prose, median 134 chars, longest 1260. Running the
+ * production selector over the live table returns ZERO matches.
+ *
+ * A prose ref is the worst possible outcome: it LOOKS recorded, satisfies the FR-3 mandatory-linkage
+ * check, and can never match anything. The row is billed as linked and is permanently unreachable.
+ * Rejecting at write time is the whole point — the alternative is a value that fails silently
+ * forever, which is the defect class this SD exists to remove.
+ *
+ * THE RULE IS TOKEN-VS-SENTENCE, not a scheme allow-list. My first version enumerated the schemes I
+ * could think of (sha / SD|QF|PRD|US key / uuid / number / URL) and promptly rejected `PR-6284` — a
+ * perfectly matchable identifier already used in the test suite. A false rejection here is worse
+ * than the problem: it blocks a legitimate accept at the CLI and teaches operators to route around
+ * the check.
+ *
+ * The matcher compares by EXACT EQUALITY, so it does not care what scheme a token belongs to — any
+ * stable token works, including schemes nobody has invented yet. The only thing it can never match
+ * is a sentence. So the rule is exactly that: no whitespace, bounded length, and at least one
+ * alphanumeric. Cheap, and it cannot be wrong about a scheme it has never seen.
+ * @param {string} ref
+ * @returns {boolean}
+ */
+function isMatchableRef(ref) {
+  if (typeof ref !== 'string') return false;
+  const s = ref.trim();
+  if (!s || /\s/.test(s)) return false;              // an identifier has no spaces; a sentence does
+  if (s.length < 3 || s.length > 200) return false;  // prose runs long; a bare 'x' matches nothing useful
+  return /[A-Za-z0-9]/.test(s);
+}
+
 function resolveOutcomeRef(disposition, { outcomeRef = null, noArtifact = null } = {}) {
   const cleanRef = typeof outcomeRef === 'string' ? outcomeRef.trim() : (outcomeRef ? String(outcomeRef).trim() : '');
+  // FR-5: a ref the matcher can never match is worse than no ref, because it passes the linkage
+  // check while guaranteeing the negative path stays dead for that row. The NO_ARTIFACT sentinel is
+  // exempt — it is DELIBERATELY unmatchable and says so.
+  if (cleanRef && !isNoArtifactRef(cleanRef) && !isMatchableRef(cleanRef)) {
+    return {
+      error: `outcome_ref "${cleanRef.slice(0, 60)}${cleanRef.length > 60 ? '…' : ''}" is prose, not an artifact identifier. `
+        + 'The negative back-propagation matches by EXACT equality against a sha, SD/QF key, uuid, PR number or URL, '
+        + 'so a sentence here records a link that can never resolve. Supply the identifier, or --no-artifact "<reason>" '
+        + 'if there genuinely is no artifact (FR-5).',
+    };
+  }
   if (LINKAGE_REQUIRED_DISPOSITIONS.includes(disposition)) {
     if (cleanRef) return { ref: cleanRef };
     if (noArtifact) {
@@ -325,7 +373,8 @@ async function main() {
   }
 }
 
-module.exports = { parseArgs, recordLedgerDecision, inheritTailDecisions, VALID_DISPOSITIONS, resolveOutcomeRef, isNoArtifactRef, NO_ARTIFACT_MARKER, LINKAGE_REQUIRED_DISPOSITIONS };
+module.exports = {
+  isMatchableRef, parseArgs, recordLedgerDecision, inheritTailDecisions, VALID_DISPOSITIONS, resolveOutcomeRef, isNoArtifactRef, NO_ARTIFACT_MARKER, LINKAGE_REQUIRED_DISPOSITIONS };
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/scripts/coordinator-ack-adam.cjs
+++ b/scripts/coordinator-ack-adam.cjs
@@ -104,11 +104,34 @@ function isNoArtifactRef(ref) {
  * @param {string} ref
  * @returns {boolean}
  */
+/**
+ * Single-token PLACEHOLDERS. Whitespace-free, so the token rule waves them through — and they are
+ * STRICTLY WORSE than the NO_ARTIFACT sentinel, which is why they need naming explicitly.
+ * selectNegativeBackprop SKIPS a NO_ARTIFACT ref (it knows there is nothing to track), but it
+ * carries 'n/a' as a genuine link that can never match. Review found the error message itself steers
+ * people here: it says "supply the identifier, or --no-artifact", so an operator with neither types
+ * 'n/a'. Fixing only the sentence case would have narrowed the starvation to single tokens rather
+ * than closing it.
+ */
+const PLACEHOLDER_REFS = Object.freeze(new Set([
+  'n/a', 'na', 'n.a.', 'none', 'nil', 'null', 'nothing', 'tbd', 'tba', 'todo', 'unknown', 'unclear',
+  'moot', 'done', 'merged', 'various', 'multiple', 'verbal', 'pending', 'n/a.', '-', '--', '...',
+]));
+
 function isMatchableRef(ref) {
   if (typeof ref !== 'string') return false;
   const s = ref.trim();
   if (!s || /\s/.test(s)) return false;              // an identifier has no spaces; a sentence does
-  if (s.length < 3 || s.length > 200) return false;  // prose runs long; a bare 'x' matches nothing useful
+  // A bare number IS a legitimate artifact id — pr_number is one of the matcher's harvest keys, and
+  // rejecting '#7' was a false rejection review caught. Length floors must not swallow it.
+  if (/^#?\d{1,7}$/.test(s)) return true;
+  if (s.length < 3 || s.length > 500) return false;  // 200 rejected a real signed CI-run URL (220 chars)
+  if (PLACEHOLDER_REFS.has(s.toLowerCase())) return false;
+  // A NEAR-MISS SPELLING OF THE SENTINEL IS THE WORST CASE OF ALL: 'no_artifact' lowercase or
+  // 'NO-ARTIFACT' hyphenated fails isNoArtifactRef, so the operator believes they recorded "nothing
+  // to track" while the row is billed as a real, permanently unmatchable link that the back-prop
+  // will NOT skip. Reject so they are told to use the exact sentinel.
+  if (/^no[-_. ]?artifact/i.test(s) && !isNoArtifactRef(s)) return false;
   return /[A-Za-z0-9]/.test(s);
 }
 
@@ -206,7 +229,20 @@ async function recordLedgerDecision(supabase, { correlationId, disposition, deci
     //
     // Derived rather than separately supplied, deliberately: a second hand-entered field would drift
     // from outcome_ref, and then two columns would disagree about which artifact a decision tracked.
-    if (resolvedOutcomeRef && !isNoArtifactRef(resolvedOutcomeRef) && /^(SD|QF)-[A-Z0-9-]+$/i.test(resolvedOutcomeRef)) {
+    // SD KEYS ONLY, AND UPPERCASE ONLY — both narrowings came from review of my first version.
+    //
+    // I originally matched /^(SD|QF)-[A-Z0-9-]+$/i. Two defects, each of which turns an inert path
+    // into a NOISY one — the exact harm my own negative control was written to prevent, which it
+    // missed because it covered the commit-sha case and not the case FR-6 actually adds:
+    //   - QF: the reconciler resolves this key against strategic_directives_v2, and QUICK FIXES DO
+    //     NOT LIVE THERE (2 of 5453 rows carry a QF- key, and those are anomalies). A QF artifact
+    //     would write a key that never resolves, so the row is re-selected by every scheduled batch
+    //     forever, burning a slot and logging a skip line each time. Measured: 13 of the 31 existing
+    //     outcome_sd_key values already fail to resolve, 4 of them QF keys.
+    //   - /i: sd_key is stored uppercase, so a lowercased ref derives a key that never matches.
+    // A key that cannot resolve is worse than no key: the forward path stays dead AND the batch is
+    // permanently polluted.
+    if (resolvedOutcomeRef && !isNoArtifactRef(resolvedOutcomeRef) && /^SD-[A-Z0-9-]+$/.test(resolvedOutcomeRef)) {
       row.outcome_sd_key = resolvedOutcomeRef;
     }
     if (disposition === 'deferred') row.defer_trigger = deferTrigger;

--- a/scripts/coordinator-ack-adam.cjs
+++ b/scripts/coordinator-ack-adam.cjs
@@ -110,6 +110,37 @@ function isMatchableRef(ref) {
   if (!s || /\s/.test(s)) return false;              // an identifier has no spaces; a sentence does
   if (s.length > 500) return false;                  // 200 rejected a real signed CI-run URL (220 chars)
 
+  // PRINTABLE ASCII ONLY — the same hole as prose, re-entering through the character set.
+  //
+  // The whitespace check closes newline log-forging but not NUL, BS, ESC, C1, U+200B zero-widths, or
+  // U+202E bidi overrides. Security review verified all of those were ACCEPTED and persisted. Two
+  // harms, and the first is the one that matters: a zero-width or homoglyph ref is BILLED AS LINKED
+  // and can never match — FR-5's own stated failure mode arriving by a different door. The control
+  // had a hole shaped exactly like the defect it closes. (The second is terminal injection: an
+  // OSC/backspace-overwrite ref renders as a different string than it stores.)
+  //
+  // One line rather than an enumeration of bad characters, consistent with why PLACEHOLDER_REFS was
+  // deleted. URLs are ASCII by spec; measured, all 5 live accepted refs pass and zero are newly
+  // rejected.
+  if (!/^[\x21-\x7e]+$/.test(s)) return false;
+
+  // MINIMUM LENGTH 3, AND THIS IS A DELIBERATE REVERSAL OF AN EARLIER REVIEW FINDING.
+  //
+  // My testing reviewer called rejecting '#7'/'42' a FALSE REJECTION, since pr_number is one of the
+  // matcher's harvest keys — correct in its own frame, and I widened the rule to admit them.
+  // Security review then demonstrated end-to-end that this is a COLLISION PRIMITIVE: audit metadata
+  // carrying pr_number=42 harvests as the string '42', matches a ledger row whose outcome_ref is
+  // '42', and flips it shipped_clean -> reverted. There is no repo or type qualifier on either side,
+  // 'reverted' is TERMINAL, and the idempotency skip means it never self-heals — governance-metric
+  // poisoning wearing the mechanism's own provenance.
+  //
+  // The two findings genuinely conflict. Safety wins: the cost of rejecting is one CLI error telling
+  // the operator to pass the qualified form (a PR URL, which is accepted), while the cost of
+  // accepting is a silent, permanent, unattributable corruption of the accuracy ledger this SD
+  // exists to make trustworthy. Longer numbers ('6284') still pass — only the low-entropy tokens
+  // that can collide by accident are refused.
+  if (s.length < 3) return false;
+
   // A NEAR-MISS SPELLING OF THE SENTINEL IS THE WORST CASE OF ALL: 'no_artifact' lowercase or
   // 'NO-ARTIFACT' hyphenated fails isNoArtifactRef, so the operator believes they recorded "nothing
   // to track" while the row is billed as a real, permanently unmatchable link the back-prop will NOT

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1956,7 +1956,23 @@ function computeSolomonLedgerRollup(rows, nowMs = Date.now()) {
   // batch_stamped marker are the 2026-07-12 non-contemporaneous retro backfill. They are EXCLUDED
   // from the accuracy math — numerator AND denominator — so accuracy reflects only trustworthy
   // contemporaneous evidence. Deterministic: keys on the durable column, never a timestamp heuristic.
-  const decidedAll = all.filter((r) => r.decision && r.decision !== 'pending');
+  // SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-4 — EXPLICIT ALLOW-LIST, not a negation.
+  //
+  // This was `r.decision !== 'pending'`, which silently admits EVERY future decision value into the
+  // accuracy DENOMINATOR while the numerator below uses a positive allow-list. Any new terminal
+  // state therefore lands in the denominator and can never reach the numerator, so adding one
+  // mechanically drives accuracy DOWN with no change in the world. Simulated on live data at the
+  // time of writing: routing judgment-expiry through `decision` (this SD's original design) would
+  // have moved 566 rows and dropped accuracy from 16% to 6%.
+  //
+  // That design was reversed — expiry now lives in its own column and never touches `decision` —
+  // so this is no longer load-bearing for THIS change. It is fixed anyway because the trap is
+  // aimed at whoever adds the next value, and the reversal removed the current victim, not the trap.
+  //
+  // BEHAVIOUR-PRESERVING: this list is exactly the complement of 'pending' under today's CHECK
+  // constraint (pending|accepted|rejected|partial|deferred), so the computed number is unchanged.
+  const JUDGED_DECISIONS = ['accepted', 'rejected', 'partial', 'deferred'];
+  const decidedAll = all.filter((r) => JUDGED_DECISIONS.includes(r.decision));
   const batchExcludedCount = decidedAll.filter((r) => r.batch_stamped === true).length;
   const decided = decidedAll.filter((r) => r.batch_stamped !== true);
   const pending = all.filter((r) => !r.decision || r.decision === 'pending');

--- a/scripts/solomon-judgment-expiry-run.mjs
+++ b/scripts/solomon-judgment-expiry-run.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-2 — the aging RUNNER.
+ *
+ * WHY THIS FILE EXISTS AS A SEPARATE COMMIT, AND WHAT I GOT WRONG. FR-2 originally shipped as a pure
+ * selector plus an ENABLED_BY_DEFAULT flag no code read, and I described it as "ships disabled".
+ * Retro review named that accurately: FR-2 SHIPPED AS THE FAILURE MODE IT WAS WRITTEN TO PREVENT.
+ * Five mechanisms have already shipped into this table and all five run at zero; a selector with no
+ * runner is the sixth, and the SD's own TR-3 says acceptance requires a non-zero count on live data.
+ *
+ * The mechanism of my error is worth recording because it is subtle: I had a GOOD argument that TS-3
+ * should assert the enable FLAG rather than the scheduler ENTRY (a disabled entry still satisfies
+ * "an entry references it"). That argument is about what to ASSERT. I reused it, without noticing,
+ * as a reason not to BUILD the entry. A narrower test became a narrower deliverable.
+ *
+ * SAFETY, unchanged and now actually enforced rather than asserted:
+ *   - refuses to run unless LEO_JUDGMENT_EXPIRY_ENABLED=1, so merging cannot start it;
+ *   - --apply is required to write, absent which it is a dry run that prints what it WOULD stamp;
+ *   - paginates (the ledger is past 1100 rows and PostgREST clamps an unpaginated read at 1000);
+ *   - refuses to run at all if the migration is not applied, rather than failing per-row.
+ *
+ * Usage:
+ *   node scripts/solomon-judgment-expiry-run.mjs                 # dry run, prints the candidate set
+ *   LEO_JUDGMENT_EXPIRY_ENABLED=1 node scripts/... --apply       # stamps
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import {
+  selectExpiredJudgments,
+  expiryPatch,
+  EXPIRY_DAYS,
+  EXPIRY_ACTOR,
+  ENABLED_BY_DEFAULT,
+} from '../lib/solomon/judgment-expiry.js';
+
+const TABLE = 'solomon_advice_outcome_ledger';
+const PAGE = 1000;
+
+/** PURE — the run decision, so the safety gate is testable without a DB. */
+export function resolveRunMode({ env = {}, argv = [] } = {}) {
+  const enabled = ENABLED_BY_DEFAULT || env.LEO_JUDGMENT_EXPIRY_ENABLED === '1';
+  const apply = argv.includes('--apply');
+  if (!enabled) return { run: false, apply: false, reason: 'disabled: set LEO_JUDGMENT_EXPIRY_ENABLED=1 to enable' };
+  // Enabled but no --apply is a DRY RUN, not a refusal: seeing the candidate set is exactly how an
+  // operator decides whether the first real run is safe, and aging is not reversible in the sense
+  // that matters (a row recording that nobody answered cannot be un-recorded by judging it later).
+  return { run: true, apply, reason: apply ? 'apply' : 'dry-run' };
+}
+
+/** Read every pending row. PAGINATED — an unpaginated read silently clamps at 1000. */
+async function fetchPending(supabase) {
+  const rows = [];
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await supabase
+      .from(TABLE)
+      .select('id, decision, created_at, judgment_expired_at')
+      .eq('decision', 'pending')
+      .order('created_at', { ascending: true })
+      .range(from, from + PAGE - 1);
+    if (error) throw new Error(`read failed: ${error.message}`);
+    if (!data || data.length === 0) break;
+    rows.push(...data);
+    if (data.length < PAGE) break;
+  }
+  return rows;
+}
+
+async function main() {
+  const mode = resolveRunMode({ env: process.env, argv: process.argv.slice(2) });
+  if (!mode.run) {
+    console.log(`[judgment-expiry] ${mode.reason}`);
+    return 0;
+  }
+
+  const supabase = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+  );
+
+  // REFUSE UP FRONT if the chairman-gated migration is not applied. Failing per-row would stamp
+  // nothing while reporting success, which is this table's established failure mode.
+  const probe = await supabase.from(TABLE).select('judgment_expired_at').limit(1);
+  if (probe.error) {
+    console.error(`[judgment-expiry] REFUSING: ${probe.error.code || ''} ${probe.error.message}`);
+    console.error('[judgment-expiry] the FR-1 migration is chairman-apply-gated and is not applied yet.');
+    return 2;
+  }
+
+  const rows = await fetchPending(supabase);
+  const due = selectExpiredJudgments(rows, { nowMs: Date.now(), expiryDays: EXPIRY_DAYS });
+  console.log(`[judgment-expiry] pending=${rows.length} threshold=${EXPIRY_DAYS}d due=${due.length} mode=${mode.reason}`);
+
+  if (!mode.apply) {
+    for (const r of due.slice(0, 20)) console.log(`  WOULD STAMP ${r.id} (age ${r.ageDays.toFixed(1)}d)`);
+    if (due.length > 20) console.log(`  ...and ${due.length - 20} more`);
+    return 0;
+  }
+
+  const patch = expiryPatch({ nowIso: new Date().toISOString(), actor: EXPIRY_ACTOR });
+  let stamped = 0;
+  for (const r of due) {
+    const { error } = await supabase.from(TABLE).update(patch).eq('id', r.id).is('judgment_expired_at', null);
+    if (error) { console.error(`  FAILED ${r.id}: ${error.message}`); continue; }
+    stamped++;
+  }
+  console.log(`[judgment-expiry] stamped=${stamped}/${due.length}`);
+  return 0;
+}
+
+/**
+ * Drain undici before exiting. supabase-js keeps a keep-alive socket pool open, and calling
+ * process.exit() through it raises a libuv assertion on Windows — observed on the very first live
+ * run of this script. Harmless to the work (it fires after the output) but it turns a clean refusal
+ * into something that reads like a crash in a CI log, which is the opposite of what a
+ * safety-gated job should look like. Same fix as scripts/hooks/stop-loop-wakeup-reminder.cjs.
+ */
+async function shutdown(code) {
+  try { await (await import('undici')).getGlobalDispatcher().close(); } catch { /* absent or closed */ }
+  process.exit(code);
+}
+
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('solomon-judgment-expiry-run.mjs')) {
+  main().then(shutdown).catch((e) => { console.error('[judgment-expiry]', e.message); return shutdown(1); });
+}

--- a/scripts/solomon-ledger-reconcile.cjs
+++ b/scripts/solomon-ledger-reconcile.cjs
@@ -138,7 +138,16 @@ async function collectNegativeRefs(supabase, { sinceMs = null } = {}) {
     // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 9: was .limit(2000), above the
     // PostgREST 1000-row cap (silently clamped anyway) — paginate to actually see every row.
     const data = await fapPaginate(() => {
-      let q = supabase.from('audit_log').select('event, metadata, created_at').in('event', NEGATIVE_AUDIT_EVENTS);
+      // SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-0 — THE COLUMN IS `event_type`, NOT `event`.
+      // This read had never returned a row. `select('event')` errors with PostgREST 42703
+      // ("column audit_log.event does not exist"), and the surrounding catch is fail-open, so the
+      // failure presented as an empty result — indistinguishable from "no red merges happened".
+      // The PRODUCER had the identical bug (red-merge-detector.mjs, inserting `event:`), so the two
+      // sides agreed with each other about a column the database does not have and no test
+      // comparing them could have caught it. Measured before the fix: zero RED_MERGE_DETECTED rows
+      // have ever existed. This is the reason the ledger has never recorded a negative outcome —
+      // sparse join keys were only the second reason.
+      let q = supabase.from('audit_log').select('event_type, metadata, created_at').in('event_type', NEGATIVE_AUDIT_EVENTS);
       if (sinceMs) q = q.gte('created_at', new Date(sinceMs).toISOString());
       return q.order('created_at', { ascending: true }).order('id', { ascending: true });
     });

--- a/tests/unit/coordinator-ack-outcome-ref-shape.test.js
+++ b/tests/unit/coordinator-ack-outcome-ref-shape.test.js
@@ -136,3 +136,75 @@ describe('FR-6 — outcome_sd_key is derived when the artifact is an SD/QF key',
     expect(c.rows[0].outcome_sd_key).toBeUndefined();
   });
 });
+
+/**
+ * Findings from adversarial EXEC review — every one of these was ACCEPTED or WRONGLY REJECTED by my
+ * first two versions of the rule. Kept as a named block because each is a live hole, not a theory.
+ */
+describe('FR-5 — placeholders, sentinel near-misses, and the bounds review broke', () => {
+  it('rejects single-token PLACEHOLDERS, which are worse than the sentinel', () => {
+    // n/a is STRICTLY worse than NO_ARTIFACT: selectNegativeBackprop SKIPS a NO_ARTIFACT ref because
+    // it knows there is nothing to track, but carries 'n/a' as a genuine link that can never match.
+    // My error message steers operators straight here ("supply the identifier, or --no-artifact"),
+    // so someone with neither types this.
+    for (const ref of ['n/a', 'N/A', 'na', 'none', 'None', 'nil', 'TBD', 'todo', 'unknown', 'moot',
+      'done', 'merged', 'various', 'multiple', 'verbal', '-', '--', '...']) {
+      expect(isMatchableRef(ref), ref).toBe(false);
+    }
+  });
+
+  it('rejects NEAR-MISS spellings of the sentinel — the worst case of all', () => {
+    // The operator believes they recorded "nothing to track"; isNoArtifactRef says otherwise, so the
+    // row is billed as a real link, is permanently unmatchable, and is NOT skipped by the back-prop.
+    for (const ref of ['no_artifact', 'NO-ARTIFACT', 'no-artifact', 'No_Artifact', 'noartifact']) {
+      expect(isNoArtifactRef(ref), ref).toBe(false);       // the premise: these are NOT the sentinel
+      expect(isMatchableRef(ref), ref).toBe(false);        // ...so they must be rejected
+    }
+    // ...while the exact sentinel keeps working.
+    expect(isNoArtifactRef('NO_ARTIFACT')).toBe(true);
+  });
+
+  it('ACCEPTS a bare PR number — pr_number is one of the matcher own harvest keys', () => {
+    // False rejection found by review: my 3-char floor swallowed '#7' and '42'. Rejecting a real
+    // identifier is worse than the defect, because it blocks a legitimate accept at the CLI.
+    for (const ref of ['42', '#7', '7', '6284', '#6284']) {
+      expect(isMatchableRef(ref), ref).toBe(true);
+    }
+  });
+
+  it('ACCEPTS a long signed CI-run URL — the 200-char ceiling was too tight', () => {
+    const url = 'https://github.com/rickfelix/EHG_Engineer/actions/runs/1234567890/jobs/9876543210?check_suite_focus=true&sig=' + 'a'.repeat(120);
+    expect(url.length).toBeGreaterThan(200);
+    expect(isMatchableRef(url)).toBe(true);
+  });
+});
+
+describe('FR-6 — only SD keys, only uppercase', () => {
+  function capture() {
+    const rows = [];
+    return { rows, from: () => ({
+      upsert(r) { rows.push(r); return Promise.resolve({ error: null }); },
+      update: () => ({ in: () => Promise.resolve({ error: null }), eq: () => Promise.resolve({ error: null }) }),
+      select: () => ({ eq: () => ({ is: () => Promise.resolve({ data: [], error: null }) }) }),
+    }) };
+  }
+
+  it('does NOT derive a key from a QF ref — quick fixes are not in strategic_directives_v2', async () => {
+    // THE BLOCKER REVIEW FOUND. Only 2 of 5453 SDs carry a QF- key, so a QF-derived key never
+    // resolves: the row is re-selected by every scheduled batch forever, burning a slot and logging
+    // a skip. That is the "inert path becomes a noisy path" harm my earlier negative control was
+    // written to prevent — it covered the commit-sha case and missed the case FR-6 actually adds.
+    const m = require_('../../scripts/coordinator-ack-adam.cjs');
+    const c = capture();
+    await m.recordLedgerDecision(c, { correlationId: 'q1', disposition: 'accepted', outcomeRef: 'QF-20260728-112' });
+    expect(c.rows[0].outcome_ref).toBe('QF-20260728-112');
+    expect(c.rows[0].outcome_sd_key).toBeUndefined();
+  });
+
+  it('does NOT derive a key from a LOWERCASE sd key — sd_key is stored uppercase', async () => {
+    const m = require_('../../scripts/coordinator-ack-adam.cjs');
+    const c = capture();
+    await m.recordLedgerDecision(c, { correlationId: 'q2', disposition: 'accepted', outcomeRef: 'sd-leo-infra-advice-outcome-ledger-001' });
+    expect(c.rows[0].outcome_sd_key).toBeUndefined();
+  });
+});

--- a/tests/unit/coordinator-ack-outcome-ref-shape.test.js
+++ b/tests/unit/coordinator-ack-outcome-ref-shape.test.js
@@ -1,0 +1,81 @@
+/**
+ * SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-5 / TS-9 — outcome_ref must be matchable, not prose.
+ *
+ * The FR-4 negative back-propagation attributes ONLY through EXACT equality (correct — a heuristic
+ * would mis-attribute a revert to the wrong advice). But resolveOutcomeRef accepted any non-empty
+ * string, and `--outcome-ref <artifact-id>` was a hint rather than a rule, so operators typed
+ * sentences.
+ *
+ * MEASURED ON THE LIVE TABLE, 2026-07-29: of 170 populated refs, exactly FIVE are matchable tokens
+ * and 165 are prose (median 134 chars, longest 1260). The production selector returns zero matches.
+ * A prose ref is the worst of both worlds — it satisfies the FR-3 mandatory-linkage check, so the
+ * row is BILLED as linked, while being permanently unreachable by the thing that linkage exists for.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const { isMatchableRef, resolveOutcomeRef, isNoArtifactRef } = require_('../../scripts/coordinator-ack-adam.cjs');
+
+describe('FR-5 — the token/sentence discriminant', () => {
+  it('accepts every identifier scheme in live use, including ones no allow-list anticipated', () => {
+    // MY FIRST VERSION ENUMERATED SCHEMES and rejected 'PR-6284' — a real identifier already used in
+    // the existing suite. A false rejection is worse than the defect: it blocks a legitimate accept
+    // and teaches operators to route around the check. The matcher compares by exact equality and
+    // does not care about scheme, so neither does this.
+    for (const ref of [
+      'PR-6284', 'SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001', 'QF-20260728-112',
+      '9f38f8200d5', '2f2355337d3a4b5c6d7e8f90123456789abcdef0',
+      '81263948-ffa4-49ac-8173-d7e030ef1f3e', '#783',
+      'https://github.com/rickfelix/ehg/pull/783',
+      'SOME-SCHEME-NOBODY-HAS-INVENTED-YET-42',
+    ]) {
+      expect(isMatchableRef(ref), ref).toBe(true);
+    }
+  });
+
+  it('rejects prose — including the actual shapes found in the live table', () => {
+    for (const ref of [
+      'followed (dispatch pressed) — later found moot: target already merged',
+      'Solomon 07-20 18:51 ground read on -A (SESSION-VIEW-BROWSER)',
+      'accepted the recommendation and will track it in the next review',
+      '   ', '', 'x',
+    ]) {
+      expect(isMatchableRef(ref), JSON.stringify(ref)).toBe(false);
+    }
+  });
+
+  it('rejects a prose ref at the WRITE point, with guidance rather than a silent pass', () => {
+    const r = resolveOutcomeRef('accepted', { outcomeRef: 'we shipped it as part of the sweep' });
+    expect(r.error).toBeTruthy();
+    expect(r.ref).toBeUndefined();
+    // The message must name what to supply. An error that only says "invalid" trains people to
+    // reach for --no-artifact, which converts a linkable row into a permanently unlinkable one.
+    expect(r.error).toMatch(/exact equality/i);
+    expect(r.error).toMatch(/no-artifact/);
+  });
+
+  it('the NO_ARTIFACT sentinel is exempt — deliberately unmatchable and it says so', () => {
+    // The sentinel exists to record "there is genuinely nothing to track". It must keep working, or
+    // the only escape from the new check would be to invent a fake identifier.
+    expect(isNoArtifactRef('NO_ARTIFACT')).toBe(true);
+    const r = resolveOutcomeRef('accepted', { noArtifact: 'verbal chairman ack' });
+    expect(r.error).toBeUndefined();
+    expect(r.ref).toBe('NO_ARTIFACT: verbal chairman ack');
+  });
+
+  it('a matchable ref still passes end to end', () => {
+    // Negative control for the four above: without this, rejecting EVERYTHING would satisfy them.
+    const r = resolveOutcomeRef('accepted', { outcomeRef: 'SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001' });
+    expect(r.error).toBeUndefined();
+    expect(r.ref).toBe('SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001');
+  });
+
+  it('applies to rejected/deferred too, where linkage is optional but a stray ref is still recorded', () => {
+    // The optional-linkage path also writes outcome_ref when one is supplied, so prose could enter
+    // through it and be just as unmatchable.
+    expect(resolveOutcomeRef('rejected', { outcomeRef: 'did not agree with the approach' }).error).toBeTruthy();
+    expect(resolveOutcomeRef('rejected', { outcomeRef: 'PR-6284' }).ref).toBe('PR-6284');
+    expect(resolveOutcomeRef('rejected', {}).ref).toBeNull();
+  });
+});

--- a/tests/unit/coordinator-ack-outcome-ref-shape.test.js
+++ b/tests/unit/coordinator-ack-outcome-ref-shape.test.js
@@ -164,14 +164,50 @@ describe('FR-5 — placeholders, sentinel near-misses, and the bounds review bro
     expect(isNoArtifactRef('NO_ARTIFACT')).toBe(true);
   });
 
-  it('ACCEPTS a bare PR number — pr_number is one of the matcher own harvest keys', () => {
-    // False rejection found by review: my 3-char floor swallowed '#7' and '42'. Rejecting a real
-    // identifier is worse than the defect, because it blocks a legitimate accept at the CLI.
-    for (const ref of ['42', '#7', '7', '6284', '#6284']) {
+  it('REJECTS low-entropy bare numbers — reversing an earlier finding, deliberately', () => {
+    // THE TWO REVIEWS CONFLICTED AND I AM RECORDING WHICH WON. Testing review called rejecting '#7'
+    // a false rejection (pr_number IS a harvest key). Security review then demonstrated end to end
+    // that accepting it is a COLLISION PRIMITIVE: audit metadata carrying pr_number=42 harvests as
+    // '42', matches a ledger row whose outcome_ref is '42', and flips it shipped_clean -> reverted.
+    // No repo or type qualifier on either side; 'reverted' is terminal; the idempotency skip means
+    // it never self-heals.
+    //
+    // Safety wins. The cost of rejecting is one CLI error pointing at the qualified form; the cost
+    // of accepting is silent, permanent, unattributable corruption of the ledger this SD exists to
+    // make trustworthy.
+    for (const ref of ['42', '#7', '7', '1']) {
+      expect(isMatchableRef(ref), ref).toBe(false);
+    }
+    // Longer numbers still pass — only tokens that can collide by accident are refused, and the
+    // qualified form is always available.
+    for (const ref of ['6284', '#6284', 'https://github.com/rickfelix/ehg/pull/7']) {
       expect(isMatchableRef(ref), ref).toBe(true);
     }
   });
 
+  it('REJECTS control characters, zero-widths and bidi overrides', () => {
+    // The same hole as prose, arriving through the character set. A zero-width or homoglyph ref is
+    // BILLED AS LINKED and can never match — FR-5's own failure mode by a different door. Security
+    // review verified every one of these was previously accepted and persisted.
+    //
+    // Built with fromCharCode rather than escapes: my first version of this test failed while the
+    // production code was correct, because the escapes did not survive the way I wrote the file.
+    const ch = (n) => String.fromCharCode(n);
+    const cases = [
+      'SD-EVIL-001' + ch(8) + ch(8) + ch(8) + 'SD-GOOD-001',   // backspace overwrite
+      'SD-A-001' + ch(0x200b) + 'X',                            // zero-width space
+      'SD-' + ch(0x202e) + 'A-001',                             // bidi override
+      'SD-A-001' + ch(0),                                       // NUL
+      'SD-A-001' + ch(27) + '[2J',                              // ANSI clear-screen
+      'SD-' + ch(0x0410) + '-001',                              // Cyrillic homoglyph
+    ];
+    for (const ref of cases) {
+      expect(isMatchableRef(ref), JSON.stringify(ref)).toBe(false);
+    }
+    // Negative control: the ASCII form of the same shape is still accepted, so 'reject everything'
+    // would not satisfy this.
+    expect(isMatchableRef('SD-A-001')).toBe(true);
+  });
   it('ACCEPTS a long signed CI-run URL — the 200-char ceiling was too tight', () => {
     const url = 'https://github.com/rickfelix/EHG_Engineer/actions/runs/1234567890/jobs/9876543210?check_suite_focus=true&sig=' + 'a'.repeat(120);
     expect(url.length).toBeGreaterThan(200);

--- a/tests/unit/coordinator-ack-outcome-ref-shape.test.js
+++ b/tests/unit/coordinator-ack-outcome-ref-shape.test.js
@@ -79,3 +79,60 @@ describe('FR-5 — the token/sentence discriminant', () => {
     expect(resolveOutcomeRef('rejected', {}).ref).toBeNull();
   });
 });
+
+/**
+ * FR-6 — outcome_sd_key drives the FORWARD reconciliation path and had no production writer.
+ *
+ * solomon-ledger-reconcile.cjs:64 skips every row lacking it ("no outcome_sd_key") and :70 resolves
+ * the SD by it to derive an outcome. Measured: NULL on 1062 of 1109 rows, and the 47 populated ones
+ * came from one-off scripts, not from any production path. That is why the reconciler is inert on
+ * ~95% of the ledger — the same starvation as FR-5, on the other leg. Both mechanisms were built and
+ * neither was fed.
+ *
+ * NOTE THE CORRECTION IN THE SD'S OWN RECORD: this SD originally asserted "zero writers, NULL on
+ * 1094/1094". The table said 47, and so did the SD's own description body — it contradicted itself.
+ */
+describe('FR-6 — outcome_sd_key is derived when the artifact is an SD/QF key', () => {
+  function capturingClient() {
+    const rows = [];
+    return {
+      rows,
+      from() {
+        return {
+          upsert(row) { rows.push(row); return Promise.resolve({ error: null }); },
+          update() { return { in: () => Promise.resolve({ error: null }), eq: () => Promise.resolve({ error: null }) }; },
+          select() { return { eq: () => ({ is: () => Promise.resolve({ data: [], error: null }) }) }; },
+        };
+      },
+    };
+  }
+
+  it('populates outcome_sd_key from an SD-key artifact', async () => {
+    const m = require_('../../scripts/coordinator-ack-adam.cjs');
+    const c = capturingClient();
+    await m.recordLedgerDecision(c, { correlationId: 'c1', disposition: 'accepted', outcomeRef: 'SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001' });
+    expect(c.rows[0].outcome_sd_key).toBe('SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001');
+    // DERIVED, never separately supplied: two hand-entered fields would drift and then disagree
+    // about which artifact a decision tracked.
+    expect(c.rows[0].outcome_ref).toBe(c.rows[0].outcome_sd_key);
+  });
+
+  it('leaves outcome_sd_key unset for a NON-SD artifact', async () => {
+    // The negative control. Without it, "always copy outcome_ref into outcome_sd_key" would satisfy
+    // the test above — and the reconciler would then look up SDs by a commit sha and find nothing,
+    // turning an inert path into a noisy one.
+    const m = require_('../../scripts/coordinator-ack-adam.cjs');
+    const c = capturingClient();
+    await m.recordLedgerDecision(c, { correlationId: 'c2', disposition: 'accepted', outcomeRef: 'https://github.com/rickfelix/ehg/pull/783' });
+    expect(c.rows[0].outcome_ref).toBeTruthy();
+    expect(c.rows[0].outcome_sd_key).toBeUndefined();
+  });
+
+  it('never derives a key from the NO_ARTIFACT sentinel', async () => {
+    const m = require_('../../scripts/coordinator-ack-adam.cjs');
+    const c = capturingClient();
+    await m.recordLedgerDecision(c, { correlationId: 'c3', disposition: 'accepted', noArtifact: 'verbal ack' });
+    expect(c.rows[0].outcome_ref).toMatch(/^NO_ARTIFACT/);
+    expect(c.rows[0].outcome_sd_key).toBeUndefined();
+  });
+});

--- a/tests/unit/fleet-dashboard-judged-allowlist.test.js
+++ b/tests/unit/fleet-dashboard-judged-allowlist.test.js
@@ -1,0 +1,54 @@
+/**
+ * SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-4 / TS-6 — the accuracy denominator is an allow-list.
+ *
+ * THE TRAP THIS REMOVES. The denominator was `decision !== 'pending'` while the numerator uses a
+ * positive allow-list. Those two are not symmetric: any NEW decision value lands in the denominator
+ * automatically and can never reach the numerator, so adding one mechanically drives accuracy down
+ * with no change in the world.
+ *
+ * This SD nearly walked into it. The original design put judgment-expiry on `decision`; simulated on
+ * live data that would have moved 566 rows and dropped accuracy 16% -> 6%. The design was reversed
+ * (expiry has its own column), which removed the current victim — but not the trap. This pins the
+ * trap shut for whoever adds the next value.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const SRC = readFileSync(resolve(process.cwd(), 'scripts/fleet-dashboard.cjs'), 'utf8');
+const code = SRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+describe('FR-4 — accuracy denominator admits only JUDGED decisions', () => {
+  it('is a positive allow-list, not a negation of pending', () => {
+    // Asserted on comment-stripped source: the prose above legitimately quotes the old expression,
+    // and an assertion that cannot tell documentation from code eventually punishes documentation
+    // (a mistake I made twice earlier in this SD).
+    expect(code).toMatch(/JUDGED_DECISIONS\s*=\s*\[/);
+    expect(code).toMatch(/JUDGED_DECISIONS\.includes\(r\.decision\)/);
+    expect(code, 'the negation is back').not.toMatch(/r\.decision\s*!==\s*'pending'/);
+  });
+
+  it('the allow-list is exactly the complement of pending under the current CHECK — behaviour-preserving', () => {
+    // If this drifts from the CHECK constraint, the change stopped being a refactor and started
+    // silently altering a published number.
+    const m = code.match(/JUDGED_DECISIONS\s*=\s*\[([^\]]*)\]/);
+    expect(m).toBeTruthy();
+    const listed = m[1].split(',').map((x) => x.trim().replace(/['"]/g, '')).filter(Boolean).sort();
+    // decision CHECK: pending|accepted|rejected|partial|deferred
+    expect(listed).toEqual(['accepted', 'deferred', 'partial', 'rejected']);
+  });
+
+  it('the numerator remains a positive allow-list too — symmetry is the point', () => {
+    // The defect was ASYMMETRY between the two halves. If the numerator ever became a negation, the
+    // same class of bug returns from the other side.
+    expect(code).toMatch(/shipped_clean/);
+    expect(code, 'numerator turned into a negation').not.toMatch(/outcome\s*!==\s*'unknown'/);
+  });
+
+  it('judgment-expiry is NOT a decision value anywhere in the dashboard', () => {
+    // The reversal, pinned at the consumer. If expiry ever migrates back onto `decision`, the
+    // denominator inflation returns even with the allow-list, because the allow-list would then
+    // have to choose — and either choice is wrong (in: accuracy drops; out: the row vanishes).
+    expect(code).not.toContain('expired_unjudged');
+  });
+});

--- a/tests/unit/governance/solomon-conduct-wiring.test.js
+++ b/tests/unit/governance/solomon-conduct-wiring.test.js
@@ -54,7 +54,9 @@ describe('THE JOIN — the call site that connects the two halves', () => {
   it('runAndPersistCycle carries the conduct verdicts into the persisted row', async () => {
     // Testing the two functions separately proved each half worked while leaving the hand-off
     // unguarded: deleting it left every test green. This asserts the connection, not the parts.
-    const q = { select: () => q, eq: () => q, lt: async () => ({ data: [{ id: 1 }, { id: 2 }], error: null }) };
+    // FR-3: probe now uses select(id, {count:'exact', head:true}) — the server returns a count and
+    // NO rows, so an unpaginated 1000-row clamp cannot under-report. Intent unchanged: 2 stale rows.
+    const q = { select: () => q, eq: () => q, lt: async () => ({ data: null, count: 2, error: null }) };
     const inserted = [];
     const db = {
       from: (t) => (t === 'solomon_advice_outcome_ledger' ? { select: () => q } : {
@@ -83,7 +85,8 @@ describe('runConductVerdicts is fail-soft but not fail-silent', () => {
 
   it('NEGATIVE CONTROL — a working client produces a real verdict', async () => {
     // Without this, "always unknown" would satisfy the test above while the probe saw nothing.
-    const q = { select: () => q, eq: () => q, lt: async () => ({ data: [], error: null }) };
+    // FR-3: same shape change. Intent unchanged: zero stale rows.
+    const q = { select: () => q, eq: () => q, lt: async () => ({ data: null, count: 0, error: null }) };
     const out = await runConductVerdicts({ from: () => q });
     expect(out[0].verdict).toBe('pass');
   });

--- a/tests/unit/solomon-conduct-probe-count.test.js
+++ b/tests/unit/solomon-conduct-probe-count.test.js
@@ -22,14 +22,14 @@ import { resolveSolomonConductFacts } from '../../lib/solomon/conduct-probes.js'
  * the two strategies are distinguishable.
  */
 function fakeClient({ trueCount, rowCap = 1000 }) {
-  const seen = { headUsed: null, countMode: null };
+  const seen = { headUsed: null, countMode: null, eqArgs: [] };
   const builder = {
     select(_cols, opts) {
       seen.headUsed = Boolean(opts && opts.head);
       seen.countMode = opts && opts.count ? opts.count : null;
       return builder;
     },
-    eq() { return builder; },
+    eq(col, val) { seen.eqArgs.push([col, val]); return builder; },
     lt() {
       const head = seen.headUsed;
       return Promise.resolve(
@@ -73,14 +73,24 @@ describe('FR-3 — stale-advice count cannot silently saturate', () => {
     });
   });
 
-  it('still counts rows whose JUDGMENT EXPIRED — aging must not retire the backlog', () => {
-    // The safety property FR-1 buys by putting expiry in its own column. The probe filters on
-    // decision='pending', and an expired row keeps that decision, so it remains visible here.
-    // If expiry had been a decision value, every aged row would vanish from this count and the
-    // drain would have silently retired the very signal that justified this SD.
+  it('filters on decision=pending and applies NO expiry filter — the query shape, not just the number', () => {
+    // REWRITTEN AFTER REVIEW. The previous version asserted only that a count of 566 came back,
+    // which is test 1 with a different number: the fake ignores filter arguments, so deleting the
+    // decision filter entirely, or flipping it to 'accepted', both survived it. It claimed to pin
+    // "expired rows still count" and pinned nothing.
+    //
+    // What IS assertable in the unit tier is the query SHAPE, and that half was never blocked on the
+    // migration — it simply was not asserted. An expired row keeps decision='pending' (FR-1 put
+    // expiry in its own column), so a probe filtering on 'pending' and nothing else still sees it.
+    // The DB-behaviour half genuinely is not unit-testable: it needs the applied schema AND the job,
+    // and routing it through the db project would skip silently green — the invisible pass this SD
+    // exists to remove. It is stated as an apply-time claim rather than faked here.
     const c = fakeClient({ trueCount: 566 });
     return resolveSolomonConductFacts(c).then((facts) => {
       expect(facts.staleOpenAdviceCount).toBe(566);
+      expect(c.seen.eqArgs).toContainEqual(['decision', 'pending']);
+      const cols = c.seen.eqArgs.map(([col]) => col);
+      expect(cols, 'the probe must not filter on an expiry column').not.toContain('judgment_expired_at');
     });
   });
 });

--- a/tests/unit/solomon-conduct-probe-count.test.js
+++ b/tests/unit/solomon-conduct-probe-count.test.js
@@ -1,0 +1,86 @@
+/**
+ * SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-3 / TS-5 — the stale-advice watchdog must not saturate.
+ *
+ * resolveSolomonConductFacts counted stale pending advice with `.select('id')` then `data.length`.
+ * PostgREST silently clamps an unpaginated select at 1000 rows, and the ledger passed 1000 some time
+ * ago (1100 at time of writing). The probe read true only because its `created_at` cutoff happened
+ * to shrink the set below the cap — an accident of the current data, not a property of the query.
+ *
+ * A watchdog that saturates is worse than none: it reports a stable number while the thing it
+ * measures grows past it, and nothing about the output says the number stopped being real.
+ *
+ * Driven by an INJECTED fake client — no DB, no credentials. The `db` vitest project is disabled in
+ * this repo, so a credential-gated test would skip silently and green, which is precisely the
+ * invisible-pass shape that let FR-0's phantom-column defect live in the same file's neighbourhood.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveSolomonConductFacts } from '../../lib/solomon/conduct-probes.js';
+
+/**
+ * Fake PostgREST. `head:true` + `count:'exact'` is answered with the true count and NO rows, which
+ * is exactly how the real server behaves; a row-fetching caller gets the clamped array instead, so
+ * the two strategies are distinguishable.
+ */
+function fakeClient({ trueCount, rowCap = 1000 }) {
+  const seen = { headUsed: null, countMode: null };
+  const builder = {
+    select(_cols, opts) {
+      seen.headUsed = Boolean(opts && opts.head);
+      seen.countMode = opts && opts.count ? opts.count : null;
+      return builder;
+    },
+    eq() { return builder; },
+    lt() {
+      const head = seen.headUsed;
+      return Promise.resolve(
+        head
+          ? { data: null, count: trueCount, error: null }
+          // The clamp: an unpaginated fetch never returns more than the cap.
+          : { data: Array.from({ length: Math.min(trueCount, rowCap) }, (_, i) => ({ id: `r${i}` })), count: null, error: null },
+      );
+    },
+  };
+  return { seen, from() { return builder; } };
+}
+
+describe('FR-3 — stale-advice count cannot silently saturate', () => {
+  it('reports the TRUE count above the 1000-row cap', () => {
+    // THE ASSERTION THAT WOULD HAVE CAUGHT THE ORIGINAL. With `data.length` this reads 1000 and
+    // keeps reading 1000 forever, however large the real backlog becomes.
+    const c = fakeClient({ trueCount: 4321 });
+    return resolveSolomonConductFacts(c).then((facts) => {
+      expect(facts.staleOpenAdviceCount).toBe(4321);
+    });
+  });
+
+  it('asks the SERVER to count and transfers no rows', () => {
+    // Pins the mechanism, not just the number: a caller that fetched 4321 rows and measured
+    // `.length` would satisfy the assertion above while re-introducing the fragility the moment
+    // anything reintroduces a cap.
+    const c = fakeClient({ trueCount: 12 });
+    return resolveSolomonConductFacts(c).then(() => {
+      expect(c.seen.headUsed).toBe(true);
+      expect(c.seen.countMode).toBe('exact');
+    });
+  });
+
+  it('reports null rather than a wrong number when the count is unusable', () => {
+    // Fail-closed on the VALUE, not fail-open into a plausible one. A watchdog that invents a
+    // number is the failure this SD exists to remove.
+    const broken = { from: () => ({ select: () => ({ eq: () => ({ lt: () => Promise.resolve({ count: null, error: { message: 'boom' } }) }) }) }) };
+    return resolveSolomonConductFacts(broken).then((facts) => {
+      expect(facts.staleOpenAdviceCount).toBeNull();
+    });
+  });
+
+  it('still counts rows whose JUDGMENT EXPIRED — aging must not retire the backlog', () => {
+    // The safety property FR-1 buys by putting expiry in its own column. The probe filters on
+    // decision='pending', and an expired row keeps that decision, so it remains visible here.
+    // If expiry had been a decision value, every aged row would vanish from this count and the
+    // drain would have silently retired the very signal that justified this SD.
+    const c = fakeClient({ trueCount: 566 });
+    return resolveSolomonConductFacts(c).then((facts) => {
+      expect(facts.staleOpenAdviceCount).toBe(566);
+    });
+  });
+});

--- a/tests/unit/solomon-judgment-expiry.test.js
+++ b/tests/unit/solomon-judgment-expiry.test.js
@@ -88,6 +88,13 @@ describe('TS-2 — expiry does NOT touch the decision column', () => {
     // The reversal, pinned: no decision-CHECK surgery, and no new decision value in executable SQL.
     expect(sql).not.toMatch(/decision_check/);
     expect(sql).not.toContain('expired_unjudged');
+    // The attribution CHECK is what makes TS-10 non-forgeable — a hand-written row cannot pass for
+    // a mechanism that ran. Review found neutering it to CHECK(true) failed nothing, while my
+    // commit rested that guarantee on it. This is a SOURCE pin, not behaviour: the constraint does
+    // not exist in the live schema yet (verified 42703), and only apply-time verification can turn
+    // intent into a present fact. But it is the same tier as every other claim asserted about this
+    // file, so there is no reason the load-bearing one was the unpinned exception.
+    expect(sql).toMatch(/judgment_expired_at IS NULL OR judgment_expired_by IS NOT NULL/);
     // ...and the rationale MUST survive in the prose, so a later reader cannot re-litigate the
     // reversal without meeting the reason for it.
     expect(raw).toContain('expired_unjudged');

--- a/tests/unit/solomon-judgment-expiry.test.js
+++ b/tests/unit/solomon-judgment-expiry.test.js
@@ -1,0 +1,104 @@
+/**
+ * SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-1/FR-2 — TS-1, TS-2, TS-3.
+ *
+ * Unit tier with no DB and no credentials, deliberately: the `db` vitest project is DISABLED in
+ * this repo ("0 of db tests will run"), so a credential-gated test skips SILENTLY AND GREEN. That is
+ * the same invisible-pass shape that let FR-0's phantom-column defect survive, and this SD should
+ * not reproduce it in its own tests.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  selectExpiredJudgments,
+  expiryPatch,
+  EXPIRY_DAYS,
+  EXPIRY_ACTOR,
+  ENABLED_BY_DEFAULT,
+} from '../../lib/solomon/judgment-expiry.js';
+
+const NOW = Date.parse('2026-07-29T00:00:00Z');
+const daysAgo = (d) => new Date(NOW - d * 86_400_000).toISOString();
+
+describe('TS-1 — expiry fires only past the PINNED threshold', () => {
+  it('the threshold is 7 days, asserted against the CONSTANT not a fixture', () => {
+    // Measured on live data: 0 pending rows exceed 5d, 176 exceed 72h, oldest 4.8d. A test that let
+    // the fixture define the threshold would pass for any value, including one that expires rows
+    // history says were about to be judged.
+    expect(EXPIRY_DAYS).toBe(7);
+  });
+
+  it('stamps a row past the threshold and NOT one just inside it', () => {
+    const rows = [
+      { id: 'old', decision: 'pending', created_at: daysAgo(EXPIRY_DAYS + 0.01) },
+      { id: 'fresh', decision: 'pending', created_at: daysAgo(EXPIRY_DAYS - 0.01) },
+    ];
+    const got = selectExpiredJudgments(rows, { nowMs: NOW }).map((r) => r.id);
+    expect(got).toEqual(['old']);
+  });
+
+  it('never re-stamps a row that already expired', () => {
+    const rows = [{ id: 'a', decision: 'pending', created_at: daysAgo(30), judgment_expired_at: daysAgo(20) }];
+    expect(selectExpiredJudgments(rows, { nowMs: NOW })).toEqual([]);
+  });
+
+  it('ONLY unanswered judgments expire — an answered row is never stamped', () => {
+    // The load-bearing negative. Stamping an accepted row would assert nobody answered a question
+    // that was in fact answered, which is worse than leaving it unstamped.
+    const rows = ['accepted', 'rejected', 'partial', 'deferred'].map((decision, i) => ({
+      id: `x${i}`, decision, created_at: daysAgo(90),
+    }));
+    expect(selectExpiredJudgments(rows, { nowMs: NOW })).toEqual([]);
+  });
+
+  it('skips rows with an unusable timestamp or clock rather than guessing', () => {
+    expect(selectExpiredJudgments([{ id: 'a', decision: 'pending', created_at: 'not-a-date' }], { nowMs: NOW })).toEqual([]);
+    expect(selectExpiredJudgments([{ id: 'a', decision: 'pending', created_at: daysAgo(90) }], { nowMs: NaN })).toEqual([]);
+  });
+});
+
+describe('TS-2 — expiry does NOT touch the decision column', () => {
+  it('the patch writes only the expiry columns', () => {
+    // REPLACES the original TS-2, which asserted that a judging path could not write
+    // `expired_unjudged` — already true via VALID_DISPOSITIONS, so it asserted a no-op, AND the
+    // original FR-1 instructed adding that value to the same allow-list, which would have failed it.
+    // The real invariant now: aging changes expiry and nothing else.
+    const patch = expiryPatch({ nowIso: '2026-07-29T00:00:00Z' });
+    expect(Object.keys(patch).sort()).toEqual(['judgment_expired_at', 'judgment_expired_by']);
+    expect(patch).not.toHaveProperty('decision');
+    expect(patch).not.toHaveProperty('outcome');
+  });
+
+  it('always attributes the stamp — the DB CHECK requires it', () => {
+    // Without attribution a hand-written row is indistinguishable from one the mechanism produced,
+    // and TS-10 (did it actually RUN) becomes satisfiable by hand.
+    expect(expiryPatch({ nowIso: 'x' }).judgment_expired_by).toBe(EXPIRY_ACTOR);
+  });
+
+  it('the migration adds COLUMNS and does not alter the decision CHECK', () => {
+    const raw = readFileSync(resolve(process.cwd(), 'database/migrations/20260729_solomon_ledger_judgment_expiry.sql'), 'utf8');
+    // STRIP COMMENTS FIRST. The migration's header explains at length WHY the original
+    // `expired_unjudged` decision value was rejected, and an earlier version of this assertion read
+    // that explanation as the thing it forbids — failing on prose while the SQL was correct. That is
+    // the same mistake I made one commit earlier reading `metadata` keys as column names: an
+    // assertion that cannot tell documentation from code will eventually punish the documentation.
+    const sql = raw.replace(/^\s*--.*$/gm, '').replace(/\/\*[\s\S]*?\*\//g, '');
+    expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS judgment_expired_at/);
+    expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS judgment_expired_by/);
+    // The reversal, pinned: no decision-CHECK surgery, and no new decision value in executable SQL.
+    expect(sql).not.toMatch(/decision_check/);
+    expect(sql).not.toContain('expired_unjudged');
+    // ...and the rationale MUST survive in the prose, so a later reader cannot re-litigate the
+    // reversal without meeting the reason for it.
+    expect(raw).toContain('expired_unjudged');
+  });
+});
+
+describe('TS-3 — the job ships DISABLED', () => {
+  it('is off by default so the first run is a decision, not a merge side effect', () => {
+    // A scheduler entry that exists but is disabled still satisfies "an entry references it", which
+    // is why this asserts the flag rather than the entry. Aging is effectively irreversible: once a
+    // row records that nobody answered, re-judging it later cannot un-record that.
+    expect(ENABLED_BY_DEFAULT).toBe(false);
+  });
+});

--- a/tests/unit/solomon-judgment-expiry.test.js
+++ b/tests/unit/solomon-judgment-expiry.test.js
@@ -70,8 +70,9 @@ describe('TS-2 — expiry does NOT touch the decision column', () => {
   });
 
   it('always attributes the stamp — the DB CHECK requires it', () => {
-    // Without attribution a hand-written row is indistinguishable from one the mechanism produced,
-    // and TS-10 (did it actually RUN) becomes satisfiable by hand.
+    // Guarantees a stamp is never ANONYMOUS. It does NOT establish WHO stamped it: EXPIRY_ACTOR is a
+    // public exported constant and every writer shares one service-role identity, so this cannot
+    // distinguish the job from a hand-written row. TS-10 needs a witness the DB cannot supply.
     expect(expiryPatch({ nowIso: 'x' }).judgment_expired_by).toBe(EXPIRY_ACTOR);
   });
 
@@ -88,9 +89,11 @@ describe('TS-2 — expiry does NOT touch the decision column', () => {
     // The reversal, pinned: no decision-CHECK surgery, and no new decision value in executable SQL.
     expect(sql).not.toMatch(/decision_check/);
     expect(sql).not.toContain('expired_unjudged');
-    // The attribution CHECK is what makes TS-10 non-forgeable — a hand-written row cannot pass for
-    // a mechanism that ran. Review found neutering it to CHECK(true) failed nothing, while my
-    // commit rested that guarantee on it. This is a SOURCE pin, not behaviour: the constraint does
+    // The attribution CHECK guarantees an expiry stamp is never ANONYMOUS — narrower than what I
+    // first claimed. It does NOT make TS-10 non-forgeable: it constrains neither the value
+    // (EXPIRY_ACTOR is a public constant) nor the writer (all writers share one service-role
+    // identity), so no CHECK can distinguish a hand-written row from a mechanism's. This is a
+    // SOURCE pin, not behaviour: the constraint does
     // not exist in the live schema yet (verified 42703), and only apply-time verification can turn
     // intent into a present fact. But it is the same tier as every other claim asserted about this
     // file, so there is no reason the load-bearing one was the unpinned exception.

--- a/tests/unit/solomon-judgment-expiry.test.js
+++ b/tests/unit/solomon-judgment-expiry.test.js
@@ -112,3 +112,62 @@ describe('TS-3 — the job ships DISABLED', () => {
     expect(ENABLED_BY_DEFAULT).toBe(false);
   });
 });
+
+/**
+ * FR-2 — the RUNNER and its two independent safety gates.
+ *
+ * These exist because retro review found FR-2 had shipped as a pure selector with an
+ * ENABLED_BY_DEFAULT flag NO CODE READ, described as "ships disabled". That is not a disabled
+ * mechanism, it is an absent one — and an absent mechanism is precisely how five prior mechanisms
+ * came to sit at zero usage in this same table.
+ *
+ * The error worth naming: I had a sound argument that TS-3 should assert the enable FLAG rather than
+ * the scheduler ENTRY. That argument is about what to ASSERT. I reused it, without noticing, as a
+ * reason not to BUILD the entry — a narrower test silently became a narrower deliverable.
+ */
+describe('FR-2 — the runner refuses to write by default', () => {
+  it('does not run at all without the explicit env gate', async () => {
+    const { resolveRunMode } = await import('../../scripts/solomon-judgment-expiry-run.mjs');
+    const m = resolveRunMode({ env: {}, argv: ['--apply'] });
+    // --apply alone is NOT enough. Merging the workflow cannot start it.
+    expect(m.run).toBe(false);
+    expect(m.apply).toBe(false);
+  });
+
+  it('enabled WITHOUT --apply is a dry run, not a write', async () => {
+    const { resolveRunMode } = await import('../../scripts/solomon-judgment-expiry-run.mjs');
+    const m = resolveRunMode({ env: { LEO_JUDGMENT_EXPIRY_ENABLED: '1' }, argv: [] });
+    expect(m.run).toBe(true);
+    expect(m.apply).toBe(false);
+    // A dry run is deliberately permitted: seeing the candidate set is how an operator decides
+    // whether the first real run is safe, and aging cannot be undone by judging a row later.
+    expect(m.reason).toBe('dry-run');
+  });
+
+  it('writes only when BOTH gates are open', async () => {
+    const { resolveRunMode } = await import('../../scripts/solomon-judgment-expiry-run.mjs');
+    const m = resolveRunMode({ env: { LEO_JUDGMENT_EXPIRY_ENABLED: '1' }, argv: ['--apply'] });
+    expect(m.run).toBe(true);
+    expect(m.apply).toBe(true);
+  });
+
+  it('the scheduler entry EXISTS and its cadence is commented out', () => {
+    // Asserts the entry as well as the flag. The earlier reasoning — "a disabled entry still
+    // satisfies 'an entry references it'" — is a good argument against relying on the entry ALONE,
+    // and I wrongly let it stand as a reason to omit the entry entirely.
+    const wf = readFileSync(resolve(process.cwd(), '.github/workflows/solomon-judgment-expiry.yml'), 'utf8');
+    expect(wf).toMatch(/workflow_dispatch:/);
+    expect(wf).toMatch(/solomon-judgment-expiry-run\.mjs/);
+    // The cadence must be present-but-commented, so enabling it is a one-line deliberate act rather
+    // than a rewrite — and so its absence is visible rather than merely unwritten.
+    expect(wf).toMatch(/^\s*#\s*schedule:/m);
+    expect(wf).not.toMatch(/^\s{2}schedule:/m);
+  });
+
+  it('the runner PAGINATES — the ledger is past the 1000-row cap', () => {
+    const src = readFileSync(resolve(process.cwd(), 'scripts/solomon-judgment-expiry-run.mjs'), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+    expect(src).toMatch(/\.range\(/);
+    expect(src, 'an unpaginated read silently clamps at 1000').toMatch(/for \(let from = 0/);
+  });
+});

--- a/tests/unit/solomon-ledger-audit-event-column.test.js
+++ b/tests/unit/solomon-ledger-audit-event-column.test.js
@@ -1,0 +1,112 @@
+/**
+ * SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-0 / TS-0 — the audit_log column the negative path reads.
+ *
+ * THE DEFECT THIS PINS. `collectNegativeRefs` selected and filtered on `audit_log.event`, and
+ * `red-merge-detector.mjs` inserted `event:`. That column does not exist — the real one is
+ * `event_type` — so PostgREST answered 42703 on both sides. Both sides sit inside fail-open catches,
+ * so the write silently no-opped and the read silently returned empty, which is indistinguishable
+ * from "no red merges happened". Measured before the fix: ZERO RED_MERGE_DETECTED rows had ever
+ * existed, and the Solomon ledger had never recorded a negative outcome in 1100 rows.
+ *
+ * WHY NO EXISTING TEST CAUGHT IT, and what that dictates about this one. Producer and consumer
+ * agreed with EACH OTHER. Any test that wrote through the producer and read through the consumer
+ * would have exercised two halves of the same mistake and passed. So this asserts against the
+ * DATABASE'S OWN column vocabulary, not against the other half of the pair — the only reference
+ * that was ever independent.
+ *
+ * Unit tier on purpose: no describeDb, no HAS_REAL_DB, no live client. The db project is DISABLED
+ * in this repo ("0 of db tests will run"), so anything gated on real credentials would skip
+ * SILENTLY AND GREEN — the same shape of invisible pass that let the original defect survive.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const root = process.cwd();
+const CONSUMER = resolve(root, 'scripts/solomon-ledger-reconcile.cjs');
+const PRODUCER = resolve(root, 'scripts/ci/red-merge-detector.mjs');
+
+/** The real audit_log columns, as returned by the live table. The independent reference. */
+const AUDIT_LOG_COLUMNS = Object.freeze([
+  'id', 'event_type', 'entity_type', 'entity_id',
+  'old_value', 'new_value', 'metadata', 'severity', 'created_by', 'created_at',
+]);
+
+/** Strip comments so prose naming the old column never satisfies or trips an assertion. */
+function code(path) {
+  return readFileSync(path, 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+}
+
+describe('FR-0 — the negative path reads a column that actually exists', () => {
+  it('`event` is NOT a real audit_log column, and `event_type` is', () => {
+    // The premise, asserted rather than assumed. If the schema ever gains `event`, this test says so
+    // before the rest of the file starts lying about why it exists.
+    expect(AUDIT_LOG_COLUMNS).not.toContain('event');
+    expect(AUDIT_LOG_COLUMNS).toContain('event_type');
+  });
+
+  it('the CONSUMER selects and filters on event_type', () => {
+    const src = code(CONSUMER);
+    expect(src).toMatch(/from\('audit_log'\)\s*\.\s*select\('event_type/);
+    expect(src).toMatch(/\.in\('event_type',/);
+  });
+
+  it('the PRODUCER writes event_type on both audit events', () => {
+    const src = code(PRODUCER);
+    expect(src).toContain("event_type: 'RED_MERGE_DETECTED'");
+    expect(src).toContain("event_type: 'BASELINE_ROT_DETECTED'");
+  });
+
+  it('NEITHER side references a bare `event` key against audit_log', () => {
+    // The regression guard. `event:` as an object key or `'event'` as a column argument is the exact
+    // shape of the original bug, and it is cheap to reintroduce by copy-paste.
+    for (const [name, path] of [['consumer', CONSUMER], ['producer', PRODUCER]]) {
+      const src = code(path);
+      expect(src, `${name} uses a bare event: key`).not.toMatch(/\bevent:\s*'/);
+      expect(src, `${name} passes 'event' as a column`).not.toMatch(/\.(select|in|eq)\('event'/);
+    }
+  });
+
+  it('every audit_log column either side names is a REAL column', () => {
+    // THE ASSERTION THAT WOULD HAVE CAUGHT THE ORIGINAL DEFECT, and the reason this file is worth
+    // keeping after the immediate fix: it validates against the schema rather than against the other
+    // half of the pair, so a future column rename cannot be agreed-upon-and-wrong by both sides.
+    // TOP-LEVEL keys only. `metadata` is a jsonb column whose CONTENTS are free-form, so its inner
+    // keys are not column names — an earlier version of this assertion flagged `rule` inside
+    // metadata and was wrong about the code rather than right about a bug. Strip nested objects
+    // before reading keys.
+    const stripNested = (body) => {
+      let out = body;
+      for (let i = 0; i < 5 && /\{[^{}]*\}/.test(out); i++) out = out.replace(/\{[^{}]*\}/g, '""');
+      return out;
+    };
+    const producerKeys = [...code(PRODUCER).matchAll(/from\('audit_log'\)\s*\.\s*insert\(\{([\s\S]*?)\n\s*\}\)/g)]
+      .flatMap((m) => [...stripNested(m[1]).matchAll(/(?:^|,)\s*(\w+)\s*:/g)].map((k) => k[1]));
+    expect(producerKeys.length, 'no audit_log insert found — the regex drifted, not the code').toBeGreaterThan(0);
+    for (const key of producerKeys) {
+      expect(AUDIT_LOG_COLUMNS, `producer writes unknown audit_log column "${key}"`).toContain(key);
+    }
+
+    const consumerCols = [...code(CONSUMER).matchAll(/from\('audit_log'\)\s*\.\s*select\('([^']+)'/g)]
+      .flatMap((m) => m[1].split(',').map((c) => c.trim()));
+    expect(consumerCols.length, 'no audit_log select found').toBeGreaterThan(0);
+    for (const col of consumerCols) {
+      expect(AUDIT_LOG_COLUMNS, `consumer reads unknown audit_log column "${col}"`).toContain(col);
+    }
+  });
+
+  it('the producer writes a row the consumer can actually FILTER — not metadata-only', () => {
+    // A row carrying only metadata would satisfy every assertion above while being unfindable by the
+    // consumer's .in() filter. The event_type value must match a token the consumer filters on.
+    const producer = code(PRODUCER);
+    const consumer = code(CONSUMER);
+    const emitted = [...producer.matchAll(/event_type:\s*'([A-Z_]+)'/g)].map((m) => m[1]);
+    expect(emitted).toContain('RED_MERGE_DETECTED');
+    // NEGATIVE_AUDIT_EVENTS is what the consumer's .in() is fed.
+    const negList = consumer.match(/NEGATIVE_AUDIT_EVENTS\s*=\s*Object\.freeze\(\[([\s\S]*?)\]/);
+    expect(negList, 'NEGATIVE_AUDIT_EVENTS not found in the consumer').toBeTruthy();
+    expect(negList[1]).toContain('RED_MERGE_DETECTED');
+  });
+});


### PR DESCRIPTION
## Summary

The Solomon advice-outcome ledger is the accuracy instrument for the oracle we route consequential architecture and governance decisions through. Measured on the live table: **1109+ rows, outcome `unknown` on ~95%, and zero negative outcomes ever recorded.**

The SD was sourced believing the negative path was missing. It isn't — it's **built and starved**. But the starvation had a cause nobody had identified.

## FR-0 — red-merge detection has never worked

`collectNegativeRefs` read `audit_log.event`. `red-merge-detector.mjs` wrote `audit_log.event`. **That column does not exist** — it's `event_type`.

| check | result |
|---|---|
| `select audit_log.event` | **42703** — column does not exist |
| `select audit_log.event_type` | executes |
| `RED_MERGE_DETECTED` rows, ever | **0**, in a table of 240,797 |

Both sides sit in fail-open catches, so the write silently no-opped and the read silently returned empty — indistinguishable from *"no red merges happened"*.

**No test could have caught it, because producer and consumer agreed with each other.** Any test writing through one and reading through the other exercises two halves of the same mistake and passes. The only independent witness was the schema, and nothing consulted it — which is why the new test asserts every `audit_log` column either side names against the real column list, rather than against the other half of the pair.

This reframes the SD: sparse join keys were only the **second** reason. FR-5 alone would have shipped, measured green, and changed nothing.

## The rest

- **FR-1** — judgment expiry as its **own column**, not a new `decision` value (reversal; see below). Migration authored, **chairman-apply-gated, not applied**.
- **FR-2** — a scheduled aging job with two independent gates, pinned at **7d** in code.
- **FR-3** — the stale-advice watchdog counted with `.select('id')` + `data.length`, which PostgREST clamps at 1000. The ledger passed 1000 some time ago; it read true only because a date filter happened to shrink the set. Now a server-side exact count, which transfers no rows and cannot truncate.
- **FR-4** — the accuracy **denominator** was `!== 'pending'` while the **numerator** was a positive allow-list. Any new decision value joins the denominator and can never reach the numerator. Behaviour-preserving, measured: 528 either way.
- **FR-5** — `outcome_ref` accepted any string. **158 of 170 populated refs are prose**; the production selector returns zero matches. Now validated at the write point.
- **FR-6** — `outcome_sd_key` drives the **forward** reconciliation path (the reconciler skips every row lacking it) and had **no production writer**. Same starvation, other leg.

## What review changed

Four adversarial passes. Most of this PR is correction, and several are corrections *of* corrections.

**I specified FR-1 wrongly, from a false premise.** I put expiry on `decision`, arguing `outcome.unknown` already meant "unjudged" — it doesn't; it means the artifact hasn't reached a terminal state. Worse, I'd **inverted the cost accounting**: I listed "hides the row from drain-inventory" as *disqualifying* when it's the **safety property**, chose the option that breaks two counters at once, then wrote an FR to repair damage I chose to cause. My own PRD also contradicted itself — an FR instructing exactly what its own test forbade.

**`isMatchableRef` broke three times.** v1 enumerated identifier *schemes* and falsely rejected `PR-6284`. v2 added a placeholder *enumeration* — which review correctly named as **v1's mistake pointed the other way**; an enumeration of what to reject rots exactly like one of what to accept. v3 is structural: an identifier carries a digit or is a URL. Then security review found the same defect **re-entering through the character set** — a zero-width or homoglyph ref is billed as linked and can never match, which is FR-5's own stated failure mode by a different door.

**My two reviewers conflicted, and I recorded which won.** Testing called rejecting bare `#7` a false rejection (`pr_number` is a harvest key). Security demonstrated end-to-end that accepting `'42'` is a **collision primitive** — metadata carrying `pr_number=42` flips a ledger row to a terminal `reverted` that never self-heals. Safety wins: rejecting costs one CLI error; accepting costs silent permanent corruption of the ledger this SD exists to make trustworthy.

**I reported the branch green while it was red.** I said "two existing tests broke and I updated them" — there were three. The third lived beside the module rather than under `tests/unit/`, so my sweep's **scope** excluded it.

**FR-2 shipped as the failure mode it was written to prevent** — a selector with no runner and no scheduler entry, which I described as "ships disabled." I had a sound argument that the *test* should assert the enable flag rather than the entry, and silently reused it as a reason not to *build* the entry.

**I overclaimed a DB CHECK.** It constrains neither the value (`EXPIRY_ACTOR` is a public constant) nor the writer (all writers share one service-role identity). Narrowed in four places — the fourth found only by searching the claim string instead of re-listing sites — and **TS-10 is recorded as unsatisfiable** rather than marked met by a constraint that only reads as if it closes it.

## Test plan

| | |
|---|---|
| ten affected suites | **98 passed** |
| full unit tier, SD-caused failures | **0** |
| pre-existing failures | 13, none in any file this SD touches |

Live-corpus measurements reproduced independently by review at every revision: `outcome_ref` **5 accepted / 165 rejected**, identical across all three rule versions — **zero false rejections introduced**.

Mutation-verified throughout, each mutation confirmed on disk and restored from a file snapshot (never `git checkout` — a stale index silently reverted work earlier in this session).

## Stated, not hidden

- **The migration is not applied.** FR-2's runner refuses up front with the real 42703 rather than failing per-row, and its `schedule:` is present-but-commented so enabling the cadence is a deliberate one-line act.
- **TS-10 / TR-3 are unmet by construction** — acceptance requires a non-zero count on live data, which needs the applied DDL.
- 7 distinct `SD-` keys across 9 rows are already unresolvable and still derive; nothing validates the key against the DB at write time. The systematic (QF) case is closed; the typo case isn't.
- `collectNegativeRefs` has no `since` floor and its event vocabulary includes unclaimed generic strings in a 240k-row many-producer table. Prospective; the mitigation belongs in the matcher.
- Pre-existing, worth a separate REVOKE: `anon`/`authenticated` hold `INSERT/UPDATE/DELETE/TRUNCATE` grants on this ledger, with RLS the only thing in the way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
