### PR TITLE
fix(SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001): chairman morning brief was reading an ARCHIVED roadmap

### DIFF
--- a/lib/governance/plan-drift-detectors.js
+++ b/lib/governance/plan-drift-detectors.js
@@ -24,6 +24,7 @@ import { isMetaSd } from '../fleet/exec-email-alignment.mjs';
 // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6: whole-corpus reads paginate past the
 // PostgREST 1000-row cap (strategic_directives_v2 alone exceeds it).
 import { fetchAllPaginated } from '../db/fetch-all-paginated.mjs';
+import { resolveCanonicalWaveIds } from '../roadmap/canonical-roadmap.js';
 
 /** Coverage floor: SD-LEO-INFRA-ROADMAP-FOLD-SEAM-001's own acceptance criterion. */
 export const COVERAGE_FLOOR_PCT = 80;
@@ -68,9 +69,24 @@ export async function computeStampCoverage(supabase) {
   if (error) throw new Error('computeStampCoverage: computeClaimableLeaves failed: ' + error.message);
   // FR-6: paginated past the PostgREST 1000-row cap. The prior destructure silently ignored
   // query errors (data null → []); .catch(() => []) preserves that exact fail-open policy.
-  const [waveItems, waves] = await Promise.all([
-    fetchAllPaginated(() => supabase.from('roadmap_wave_items').select('promoted_to_sd_key, wave_id').not('promoted_to_sd_key', 'is', null).order('promoted_to_sd_key')).catch(() => []),
-    fetchAllPaginated(() => supabase.from('roadmap_waves').select('id, time_horizon, metadata').order('id')).catch(() => []),
+  // SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-4: scope both sides to the canonical
+  // roadmap. Unscoped, sdRungMap attributed rungs to SDs from waves belonging to ARCHIVED
+  // roadmaps. Measured live 2026-07-29: 114 such links exist, 99 of them for SD keys that appear
+  // in NO canonical wave item at all.
+  //
+  // resolveCanonicalWaveIds returns null (not []) when the roadmap is unresolvable, because
+  // `.in('wave_id', [])` matches nothing and would read as a genuinely empty roadmap. Here the
+  // surrounding policy is deliberately fail-open (see the .catch(() => []) below), so an
+  // unresolvable roadmap degrades to empty inputs rather than throwing — but it does so because
+  // that is this function's stated policy, not by accident of an empty id list.
+  let canonicalWaveIds = null;
+  try {
+    canonicalWaveIds = await resolveCanonicalWaveIds(supabase);
+  } catch { canonicalWaveIds = null; }
+
+  const [waveItems, waves] = canonicalWaveIds === null ? [[], []] : await Promise.all([
+    fetchAllPaginated(() => supabase.from('roadmap_wave_items').select('promoted_to_sd_key, wave_id').in('wave_id', canonicalWaveIds).not('promoted_to_sd_key', 'is', null).order('promoted_to_sd_key')).catch(() => []),
+    fetchAllPaginated(() => supabase.from('roadmap_waves').select('id, time_horizon, metadata').in('id', canonicalWaveIds).order('id')).catch(() => []),
   ]);
   const wavesById = Object.fromEntries((waves || []).map((w) => [w.id, w]));
   const sdRungMap = buildSdRungMap(waveItems, wavesById);

--- a/lib/roadmap/canonical-roadmap.js
+++ b/lib/roadmap/canonical-roadmap.js
@@ -36,4 +36,28 @@ export async function resolveCanonicalRoadmap(supabase) {
   return rows[0];
 }
 
-export default { resolveCanonicalRoadmap };
+/**
+ * The wave ids belonging to the canonical roadmap — SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001.
+ *
+ * Exists so that readers of roadmap_wave_items have ONE scoping primitive to depend on instead of
+ * each hand-rolling `resolve → select waves → map ids`. The defective readers this SD fixes were
+ * precisely the ones that hand-rolled their own selection, so adding a fourth open-coded variant
+ * would fix the instances and leave the class intact.
+ *
+ * Returns null (NOT an empty array) when the canonical roadmap cannot be determined. The
+ * distinction is load-bearing: `[]` passed to `.in('wave_id', [])` matches nothing and silently
+ * reads as "no items", which is indistinguishable from a genuinely empty roadmap. null forces the
+ * caller to decide explicitly — degrade to unknown if it only reads, refuse if it writes.
+ *
+ * @returns {Promise<string[]|null>}
+ * @throws {Error} propagates the >1-active ambiguity throw from resolveCanonicalRoadmap.
+ */
+export async function resolveCanonicalWaveIds(supabase) {
+  const roadmap = await resolveCanonicalRoadmap(supabase);
+  if (!roadmap) return null;
+  const { data, error } = await supabase.from('roadmap_waves').select('id').eq('roadmap_id', roadmap.id);
+  if (error) throw new Error(`resolveCanonicalWaveIds: wave query failed: ${error.message}`);
+  return (data || []).map((w) => w.id);
+}
+
+export default { resolveCanonicalRoadmap, resolveCanonicalWaveIds };

--- a/lib/roadmap/full-create-guard.js
+++ b/lib/roadmap/full-create-guard.js
@@ -1,0 +1,51 @@
+/**
+ * --full roadmap-creation guard — SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-5.
+ *
+ * Extracted from scripts/roadmap-generate.js main() because that file invokes main() at module
+ * load, so the guard could not be imported without executing the generator. It therefore had NO
+ * unit coverage and survived mutation twice in the EXEC adversarial review. A guard nothing can
+ * test is a guard nothing protects.
+ *
+ * PREDICATE IS "any NON-ARCHIVED roadmap", not "any ACTIVE roadmap". createRoadmap() inserts
+ * status:'draft' and only roadmap-manager.js approveSequence flips it to 'active', so --full has
+ * never been able to fork a second ACTIVE roadmap — and the historical incident was two duplicate
+ * DRAFT rows (a89b078b, 8ffa7fdf, 2026-07-17). An active-only guard would not have caught the very
+ * thing it was written for.
+ */
+
+export const REFUSE_EXISTING = 'existing_non_archived_roadmap';
+export const REFUSE_REASON_REQUIRED = 'replace_active_requires_reason';
+
+/**
+ * Decide whether `--full` may create a roadmap.
+ *
+ * @param {Array<{id:string,title?:string,status:string}>} liveRoadmaps  non-archived roadmaps
+ * @param {{replaceActive?: boolean, replaceReason?: string}} flags
+ * @returns {{allow: boolean, refusal?: string, existing?: Array, override?: boolean}}
+ */
+export function evaluateFullCreate(liveRoadmaps, flags = {}) {
+  const live = Array.isArray(liveRoadmaps) ? liveRoadmaps : [];
+  // Bootstrap: nothing live, nothing to fork. This is --full's legitimate purpose.
+  if (live.length === 0) return { allow: true };
+
+  if (!flags.replaceActive) return { allow: false, refusal: REFUSE_EXISTING, existing: live };
+
+  // An override without a stated reason is an unaudited override. Refuse rather than log "".
+  const reason = typeof flags.replaceReason === 'string' ? flags.replaceReason.trim() : '';
+  if (!reason) return { allow: false, refusal: REFUSE_REASON_REQUIRED, existing: live };
+
+  return { allow: true, override: true, existing: live };
+}
+
+/**
+ * The ids an override must archive before creating. Returns ALL non-archived roadmaps, not just
+ * the first: leaving any behind reproduces the exact duplicate state this guard exists to prevent,
+ * so "replace" that replaces only one of two is not a replacement.
+ * @param {Array<{id:string}>} liveRoadmaps
+ * @returns {string[]}
+ */
+export function roadmapsToArchive(liveRoadmaps) {
+  return (Array.isArray(liveRoadmaps) ? liveRoadmaps : []).map((r) => r.id).filter(Boolean);
+}
+
+export default { evaluateFullCreate, roadmapsToArchive, REFUSE_EXISTING, REFUSE_REASON_REQUIRED };

--- a/lib/roadmap/full-create-guard.js
+++ b/lib/roadmap/full-create-guard.js
@@ -17,6 +17,16 @@ export const REFUSE_EXISTING = 'existing_non_archived_roadmap';
 export const REFUSE_REASON_REQUIRED = 'replace_active_requires_reason';
 
 /**
+ * audit_log.severity is CHECK-constrained to exactly these values. Probed live 2026-07-29:
+ * 'high' / 'low' / 'medium' / 'HIGH' are all REJECTED (23514). I shipped severity:'high' and it
+ * failed silently — supabase-js RETURNS {error}, it does not throw, so the try/catch around the
+ * insert was dead code and the override wrote no audit row at all while telling the operator it
+ * had. Exported so the value is asserted by a test rather than re-guessed.
+ */
+export const AUDIT_SEVERITY = 'critical';
+export const VALID_AUDIT_SEVERITIES = Object.freeze(['critical', 'warning', 'info', 'error']);
+
+/**
  * Decide whether `--full` may create a roadmap.
  *
  * @param {Array<{id:string,title?:string,status:string}>} liveRoadmaps  non-archived roadmaps
@@ -31,7 +41,11 @@ export function evaluateFullCreate(liveRoadmaps, flags = {}) {
   if (!flags.replaceActive) return { allow: false, refusal: REFUSE_EXISTING, existing: live };
 
   // An override without a stated reason is an unaudited override. Refuse rather than log "".
-  const reason = typeof flags.replaceReason === 'string' ? flags.replaceReason.trim() : '';
+  // A bare `--reason` also swallows the NEXT flag as its value (`--reason --force-reassign` gave
+  // reason="--force-reassign", which passed a plain trim check), so a value that looks like a
+  // flag is treated as a missing reason rather than an accepted one.
+  const raw = typeof flags.replaceReason === 'string' ? flags.replaceReason.trim() : '';
+  const reason = raw.startsWith('--') ? '' : raw;
   if (!reason) return { allow: false, refusal: REFUSE_REASON_REQUIRED, existing: live };
 
   return { allow: true, override: true, existing: live };

--- a/lib/roadmap/wave-linkage-coverage.js
+++ b/lib/roadmap/wave-linkage-coverage.js
@@ -13,6 +13,7 @@ import { createRequire } from 'node:module';
 // capped read on either side would silently skew the coverage % (false starvation OR
 // masked real starvation) rather than a merely-stale display number.
 import { fetchAllPaginated } from '../db/fetch-all-paginated.mjs';
+import { resolveCanonicalWaveIds } from './canonical-roadmap.js';
 
 export const COVERAGE_THRESHOLD = 0.8;
 export const STARVATION_NAME = 'WAVE_LINKAGE_STARVATION';
@@ -51,11 +52,31 @@ export async function computeWaveLinkageCoverage(supabase) {
     throw new Error(`wave-linkage-coverage: SD query failed: ${error.message}`);
   }
 
+  // SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-4: scope to the canonical roadmap.
+  // This was UNSCOPED, so promoted_to_sd_key values belonging to ARCHIVED roadmaps landed in
+  // promotedKeys and an SD linked only from an archived plan counted as linked. Measured live
+  // 2026-07-29: 114 orphan links, of which 99 SD keys appear ONLY in archived-roadmap items —
+  // 28.7% of the promoted universe, all of them from ed12bf74 (March 2026).
+  //
+  // Note ed12bf74 is NOT one of the duplicates this SD cleans up, which is the point: removing
+  // this SD's duplicate rows would not have corrected this reader by even one link. Only the
+  // predicate fixes it.
+  let canonicalWaveIds;
+  try {
+    canonicalWaveIds = await resolveCanonicalWaveIds(supabase);
+  } catch (rErr) {
+    throw new Error(`wave-linkage-coverage: canonical roadmap unresolvable: ${rErr.message}`);
+  }
+  if (canonicalWaveIds === null) {
+    throw new Error('wave-linkage-coverage: no active roadmap — refusing to compute coverage over an unscoped corpus');
+  }
+
   let items;
   try {
     items = await fetchAllPaginated(() => supabase
       .from('roadmap_wave_items')
       .select('promoted_to_sd_key')
+      .in('wave_id', canonicalWaveIds)
       .not('promoted_to_sd_key', 'is', null)
       .order('id', { ascending: true })); // unique tiebreaker: stable page boundaries (FR-6)
   } catch (iErr) {

--- a/lib/roadmap/wave-linkage-coverage.js
+++ b/lib/roadmap/wave-linkage-coverage.js
@@ -15,6 +15,21 @@ import { createRequire } from 'node:module';
 import { fetchAllPaginated } from '../db/fetch-all-paginated.mjs';
 import { resolveCanonicalWaveIds } from './canonical-roadmap.js';
 
+/**
+ * Thrown when no canonical roadmap exists, so coverage CANNOT be computed over a defined corpus.
+ *
+ * *** THIS IS A REPORTABLE STATE, NOT A CRASH. *** Zero active roadmaps is the normal
+ * post-condition of a successful `--full --replace-active` (old archived, new draft) and of plain
+ * bootstrap, and it persists until chairman approval. The refresher cron
+ * (.github/workflows/wave-progress-refresher.yml, every 6h with --apply) calls this, and its
+ * consumer caught EVERY error into one `console.error` WARN — so in that window the named
+ * WAVE_LINKAGE_STARVATION signal and the FR-3 retro time-series row were both silently skipped
+ * while the job exited green. Tagging the error is what lets the consumer report the state
+ * instead of swallowing it. (SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001, EXEC security
+ * review SEC-3, upgraded LATENT -> LIVE on re-verification.)
+ */
+export const ERR_NO_CANONICAL_ROADMAP = 'NO_CANONICAL_ROADMAP';
+
 export const COVERAGE_THRESHOLD = 0.8;
 export const STARVATION_NAME = 'WAVE_LINKAGE_STARVATION';
 
@@ -68,7 +83,12 @@ export async function computeWaveLinkageCoverage(supabase) {
     throw new Error(`wave-linkage-coverage: canonical roadmap unresolvable: ${rErr.message}`);
   }
   if (canonicalWaveIds === null) {
-    throw new Error('wave-linkage-coverage: no active roadmap — refusing to compute coverage over an unscoped corpus');
+    // Tagged so callers can tell "there is no canonical roadmap right now" (a real, REPORTABLE
+    // state) apart from "the coverage computation broke" (a bug). Untagged, the only consumer
+    // collapsed both into one swallowed WARN line — see ERR_NO_CANONICAL_ROADMAP's note.
+    const err = new Error('wave-linkage-coverage: no active roadmap — refusing to compute coverage over an unscoped corpus');
+    err.code = ERR_NO_CANONICAL_ROADMAP;
+    throw err;
   }
 
   let items;

--- a/lib/vision/rung-progress-rollup.mjs
+++ b/lib/vision/rung-progress-rollup.mjs
@@ -15,6 +15,7 @@
  *
  * @module lib/vision/rung-progress-rollup
  */
+import { resolveCanonicalRoadmap } from '../roadmap/canonical-roadmap.js';
 
 /** Advisory time-horizon → vision rung mapping (SD-LEO-INFRA-VISION-LADDER-ROADMAP-COHERENCE-001). */
 export const RUNG_BY_HORIZON = Object.freeze({ now: 'V1', next: 'V2', later: 'V3' });
@@ -142,12 +143,37 @@ export async function runRollup(opts = {}) {
       }
     } catch { /* leave empty → outcome rungs report unknown */ }
 
-    // waves
+    // waves — SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-8.
+    //
+    // This select was UNSCOPED and the loop below WRITES progress_pct back (:159), so this
+    // function was mutating waves belonging to ARCHIVED roadmaps on every apply run — the nine
+    // orphan waves left behind when SD-LEO-INFRA-ROADMAP-DUPLICATE-CLEANUP-001 archived the
+    // parent rows without cascading. That is why the "these readers are harmless because the
+    // orphan waves carry zero links" argument did not hold here: a vacancy argument protects
+    // readers, never a writer, because the writer is precisely what fills the vacancy.
+    //
+    // FAIL CLOSED. For a reader, an unresolvable canonical roadmap can degrade to "unknown".
+    // For a WRITER it cannot: writing to an unknown scope is strictly worse than not writing.
+    // So an absent or ambiguous canonical roadmap yields zero waves, hence zero rows and zero
+    // writes, and says so in the log rather than silently rolling up everything.
     let waves = [];
+    let scopeNote = null;
+    let roadmapScope = null;
     try {
-      const w = await supabase.from('roadmap_waves').select('id,title,time_horizon,okr_objective_ids,metadata,progress_pct');
-      if (w && !w.error && Array.isArray(w.data)) waves = w.data;
-    } catch { waves = []; }
+      roadmapScope = await resolveCanonicalRoadmap(supabase);
+    } catch (err) {
+      scopeNote = `ambiguous-canonical-roadmap (${err && err.message ? err.message : String(err)})`;
+    }
+    if (!scopeNote && !roadmapScope) scopeNote = 'no-active-roadmap';
+    if (!scopeNote) {
+      try {
+        const w = await supabase
+          .from('roadmap_waves')
+          .select('id,title,time_horizon,okr_objective_ids,metadata,progress_pct')
+          .eq('roadmap_id', roadmapScope.id);
+        if (w && !w.error && Array.isArray(w.data)) waves = w.data;
+      } catch { waves = []; }
+    }
 
     const rows = rollupWaves(waves, { activeRungKey, gaugeBuildPct, krAggByObjective });
 
@@ -162,8 +188,8 @@ export async function runRollup(opts = {}) {
       }
     }
 
-    log(`[rung-rollup] ${apply ? 'APPLY' : 'DRY-RUN'} activeRung=${activeRungKey} gaugeBuildPct=${gaugeBuildPct} waves=${rows.length} writable=${rows.filter((r) => r.progress_pct != null).length} written=${written}`);
-    return { ok: true, apply, activeRungKey, gaugeBuildPct, rows, written };
+    log(`[rung-rollup] ${apply ? 'APPLY' : 'DRY-RUN'} activeRung=${activeRungKey} gaugeBuildPct=${gaugeBuildPct} roadmapScope=${roadmapScope ? roadmapScope.id : (scopeNote || 'none')} waves=${rows.length} writable=${rows.filter((r) => r.progress_pct != null).length} written=${written}`);
+    return { ok: true, apply, activeRungKey, gaugeBuildPct, rows, written, roadmapScope: roadmapScope ? roadmapScope.id : null, scopeNote };
   } catch (err) {
     return { ok: false, apply, activeRungKey: null, gaugeBuildPct: null, rows: [], written: 0, error: err && err.message ? err.message : String(err) };
   }

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -41,6 +41,7 @@ import { isFixtureSd, isBareShell, bareShellLastCompare, isStartedSd, stripDispa
 // handling both the [{sd_id}]/[{sd_key}] object and raw-string shapes the old hand-rolled
 // resolver coerced, while correctly dropping the sentinel the hand-rolled one mis-counted.
 import { parseSdDependencies } from '../lib/utils/parse-sd-dependencies.cjs';
+import { resolveCanonicalWaveIds } from '../lib/roadmap/canonical-roadmap.js';
 // SD-LEO-INFRA-ADAM-WORK-SELECTION-001 FR-2/FR-3: ONE roadmap-marker predicate, imported rather
 // than re-declared. A hardcoded copy here had already drifted from the reader's list by 326 SDs.
 import { isPlanLinked } from '../lib/adam/work-selection-gate.js';
@@ -449,10 +450,17 @@ async function main() {
       activeRungKey = roll.activeRungKey || null;
       progByKey = rungProgressByKey(roll.rows);
     }
-    const [{ data: waveItems }, { data: waves }] = await Promise.all([
-      sb.from('roadmap_wave_items').select('promoted_to_sd_key, wave_id').not('promoted_to_sd_key', 'is', null),
-      sb.from('roadmap_waves').select('id, time_horizon, metadata'),
-    ]);
+    // SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-4 follow-up — same correction as
+    // gauge-runner.mjs. runRollup() above is scoped; these two queries were a separate unscoped
+    // read feeding buildSdRungMap, which drives needleScore and therefore backlog ORDER. I had
+    // wrongly recorded this call site as fixed transitively.
+    const canonicalWaveIds = await resolveCanonicalWaveIds(sb);
+    const [{ data: waveItems }, { data: waves }] = canonicalWaveIds === null
+      ? [{ data: [] }, { data: [] }]
+      : await Promise.all([
+        sb.from('roadmap_wave_items').select('promoted_to_sd_key, wave_id').in('wave_id', canonicalWaveIds).not('promoted_to_sd_key', 'is', null),
+        sb.from('roadmap_waves').select('id, time_horizon, metadata').in('id', canonicalWaveIds),
+      ]);
     const wavesById = Object.fromEntries((waves || []).map((w) => [w.id, w]));
     sdRungMap = buildSdRungMap(waveItems, wavesById);
     console.log(`[BACKLOG-RANK] needle context: activeRung=${activeRungKey} rungs=${Object.keys(progByKey).join(',') || 'none'} sd↦rung=${Object.keys(sdRungMap).length}`);

--- a/scripts/cron/chairman-morning-review-sweep.mjs
+++ b/scripts/cron/chairman-morning-review-sweep.mjs
@@ -35,6 +35,7 @@ import { enqueueChairmanSms } from '../../lib/chairman/sms-bridge.js';
 import { computeForecast, formatForecastLine } from '../../lib/vision/build-completion-forecast.mjs';
 import { etLocalHour, etDateStr, et6amIso, etPrior545Iso } from '../../lib/time/chairman-et-wall-clock.js';
 import { fetchAllPaginated } from '../../lib/db/fetch-all-paginated.mjs';
+import { resolveCanonicalRoadmap } from '../../lib/roadmap/canonical-roadmap.js';
 import { buildRoadmapStatusDoc } from '../../lib/chairman/daily-review/roadmap-status-doc.js';
 import { renderGanttPng } from '../../lib/chairman/daily-review/gantt-renderer.js';
 import { uploadPrivateAndSign } from '../../lib/storage/private-signed-upload.js';
@@ -93,18 +94,69 @@ async function gatherForecastInputs(supabase, nowMs, windowDays = 14) {
   return { buildPct: null, buildableRemaining, velocityPerDay, sourcingPerDay, queueDepth };
 }
 
-async function gatherWaves(supabase) {
+/**
+ * SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-1/FR-2.
+ *
+ * This previously did `.order('created_at', desc).limit(1)` — it SELECTED status and never
+ * FILTERED on it, so it returned whichever roadmap was newest. Measured live on 2026-07-29:
+ * that was 8ffa7fdf, an ARCHIVED duplicate (4 waves, 503 items, 0 dispositioned), while the
+ * plan of record 3aa2f3e2 (8 waves, 261 items) is older and was never chosen. The chairman's
+ * morning brief was reporting wave/progress numbers off an orphan roadmap.
+ *
+ * Deliberately NOT fixed by deleting the duplicate rows: that would have made this query
+ * return the right answer BY ACCIDENT while leaving the broken predicate to pick the next
+ * wrong roadmap as soon as another row existed.
+ *
+ * Returns a TAGGED state rather than bare counts. resolveCanonicalRoadmap is deliberately
+ * fail-loud (it THROWS on >1 active), and the old bare try/catch collapsed every failure into
+ * `waveCount: 0`, which the caller rendered as "(no active roadmap)". That turns a loud,
+ * correct signal into a confident falsehood — the same silent-wrong shape this SD exists to
+ * remove, and it would have been reintroduced BY this fix if left unaddressed.
+ *
+ * @returns {Promise<{state:'resolved'|'none'|'ambiguous'|'unavailable', ...}>}
+ */
+export async function gatherWaves(supabase) {
+  let rm;
   try {
-    const { data: roadmaps } = await supabase.from('strategic_roadmaps').select('id, status, created_at').order('created_at', { ascending: false }).limit(1);
-    const rm = roadmaps?.[0];
-    if (!rm) return { waveCount: 0, doneWaves: 0, avgPct: null };
-    const { data: waves } = await supabase.from('roadmap_waves').select('status, progress_pct').eq('roadmap_id', rm.id);
+    rm = await resolveCanonicalRoadmap(supabase);
+  } catch (err) {
+    const n = /(\d+)\s+status='active'/.exec(err?.message || '')?.[1];
+    return { state: 'ambiguous', activeCount: n ? Number(n) : null, waveCount: 0, doneWaves: 0, avgPct: null };
+  }
+  if (!rm) return { state: 'none', waveCount: 0, doneWaves: 0, avgPct: null };
+  try {
+    const { data: waves, error } = await supabase.from('roadmap_waves').select('status, progress_pct').eq('roadmap_id', rm.id);
+    if (error) throw new Error(error.message);
     const ws = waves || [];
     const waveCount = ws.length;
     const doneWaves = ws.filter((w) => Number(w.progress_pct || 0) >= 100 || w.status === 'completed').length;
     const avgPct = waveCount ? Math.round(ws.reduce((s, w) => s + Number(w.progress_pct || 0), 0) / waveCount) : null;
-    return { waveCount, doneWaves, avgPct };
-  } catch { return { waveCount: 0, doneWaves: 0, avgPct: null }; }
+    return { state: 'resolved', roadmapId: rm.id, waveCount, doneWaves, avgPct };
+  } catch {
+    return { state: 'unavailable', waveCount: 0, doneWaves: 0, avgPct: null };
+  }
+}
+
+/**
+ * FR-2: the four states must render PAIRWISE DISTINCTLY. Before this, zero-active and
+ * two-active both produced "waves 0/N done" — provably indistinguishable to the reader.
+ * Note 'resolved' with zero waves is NOT "(no active roadmap)": an active roadmap that has
+ * no waves yet is a different fact from having no roadmap at all.
+ */
+export function formatRoadmapLine(waves) {
+  switch (waves?.state) {
+    case 'resolved':
+      return waves.waveCount
+        ? `Roadmap: ${waves.avgPct == null ? '?' : waves.avgPct}% build, waves ${waves.doneWaves}/${waves.waveCount} done`
+        : 'Roadmap: active roadmap has no waves yet';
+    case 'ambiguous':
+      return `Roadmap: AMBIGUOUS — ${waves.activeCount ?? 'multiple'} active roadmaps, numbers withheld until resolved`;
+    case 'unavailable':
+      return 'Roadmap: unavailable (roadmap query failed)';
+    case 'none':
+    default:
+      return 'Roadmap: (no active roadmap)';
+  }
 }
 
 async function gatherYesterday(supabase, priorMorningIso) {
@@ -129,9 +181,7 @@ export async function buildMorningReviewBody(supabase, { now = new Date() } = {}
   const forecastLine = formatForecastLine(computeForecast({ ...inputs, nowMs }), null);
 
   const waves = await gatherWaves(supabase);
-  const roadmapLine = waves.waveCount
-    ? `Roadmap: ${waves.avgPct == null ? '?' : waves.avgPct}% build, waves ${waves.doneWaves}/${waves.waveCount} done`
-    : 'Roadmap: (no active roadmap)';
+  const roadmapLine = formatRoadmapLine(waves);
 
   const { shipped, inFlight } = await gatherYesterday(supabase, etPrior545Iso(now));
   const yesterdayLine = `Yesterday: ${shipped} shipped, ${inFlight} in-flight`;

--- a/scripts/eva-distill-brainstorm.js
+++ b/scripts/eva-distill-brainstorm.js
@@ -28,6 +28,7 @@ import { pathToFileURL } from 'url';
 import { distillItem, toQueueCandidate } from '../lib/integrations/distill-brainstorm.js';
 import { enqueueDistilledCandidate } from '../lib/eva/consultant/distillation-queue-writer.js';
 import { fetchAllPaginated } from '../lib/db/fetch-all-paginated.mjs';
+import { resolveCanonicalRoadmap } from '../lib/roadmap/canonical-roadmap.js';
 
 dotenv.config();
 
@@ -95,13 +96,45 @@ export async function loadTopWaveItems(supabase, topN = 20) {
  * Read-only. Returns { value, status, numerator, denominator, detail }.
  */
 export async function dispositionCoverage(supabase) {
+  // SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-3. Both counts were previously
+  // UNSCOPED over the whole roadmap_wave_items table, so every item belonging to an ARCHIVED
+  // roadmap fell into this gauge. Measured live 2026-07-29: as-written 95/1864 = 5.1%, versus
+  // 20/261 = 7.7% scoped to the canonical roadmap — the gauge understated coverage by 2.6pp.
+  //
+  // NOTE THE MECHANISM, because the obvious account of it is wrong: the 1603 non-canonical
+  // items span THREE archived roadmaps and 75 of them ARE non-pending, so they inflate the
+  // numerator as well as the denominator. The dilution happens because the orphans'
+  // non-pending rate (4.7%) is LOWER than the canonical roadmap's (7.7%), not because they
+  // are numerator-free. A denominator-only fix would be wrong.
+  let roadmap;
+  try {
+    roadmap = await resolveCanonicalRoadmap(supabase);
+  } catch (err) {
+    // Fail-loud resolver, fail-soft caller. Surface the ambiguity distinctly rather than
+    // letting it read as an empty corpus — see the same rule in chairman-morning-review-sweep.
+    return { value: null, status: 'unknown', numerator: 0, denominator: 0, detail: `ambiguous canonical roadmap: ${err.message}` };
+  }
+  if (!roadmap) return { value: null, status: 'unknown', numerator: 0, denominator: 0, detail: 'no active roadmap' };
+
+  const { data: waveRows, error: wErr } = await supabase
+    .from('roadmap_waves')
+    .select('id')
+    .eq('roadmap_id', roadmap.id);
+  if (wErr) return { value: null, status: 'unknown', numerator: 0, denominator: 0, detail: `wave error: ${wErr.message}` };
+  const waveIds = (waveRows || []).map((w) => w.id);
+  if (waveIds.length === 0) {
+    return { value: null, status: 'unknown', numerator: 0, denominator: 0, detail: 'active roadmap has no waves' };
+  }
+
   const { count: denom, error: dErr } = await supabase
     .from('roadmap_wave_items')
-    .select('id', { count: 'exact', head: true });
+    .select('id', { count: 'exact', head: true })
+    .in('wave_id', waveIds);
   if (dErr) return { value: null, status: 'unknown', numerator: 0, denominator: 0, detail: `denom error: ${dErr.message}` };
   const { count: numer, error: nErr } = await supabase
     .from('roadmap_wave_items')
     .select('id', { count: 'exact', head: true })
+    .in('wave_id', waveIds)
     .neq('item_disposition', 'pending');
   if (nErr) return { value: null, status: 'unknown', numerator: 0, denominator: denom || 0, detail: `numer error: ${nErr.message}` };
   if (!denom) return { value: null, status: 'unknown', numerator: 0, denominator: 0, detail: 'empty corpus (0 items)' };

--- a/scripts/eva-intake-refine.js
+++ b/scripts/eva-intake-refine.js
@@ -99,7 +99,27 @@ async function getRoadmap() {
   // because that predicate is what created this class of bug (see its header). Routing through
   // it removes both the bad predicate and the unscoped fallback in one move.
   const roadmap = await resolveCanonicalRoadmap(supabase);
-  return roadmap || null;
+  if (roadmap) return roadmap;
+
+  // BOOTSTRAP WINDOW — restored after the EXEC adversarial review caught that removing it was a
+  // regression, not a simplification. roadmap-generate.js:88 inserts status:'draft', and the flip
+  // to 'active' happens only in roadmap-manager.js:190 approveSequence, i.e. at chairman approval.
+  // Refine runs BEFORE approval (its own closing output tells the operator to run
+  // "/distill approve --roadmap-id <id>"), so between generate and approve there is legitimately
+  // NO active roadmap. My first fix returned null there, and main() exits 0 with "No roadmap
+  // found. Run /distill first" — telling the operator to redo the step they had just done.
+  //
+  // The original fallback was not wrong to exist; it was wrong to be UNSCOPED. It ordered by
+  // created_at across every status, which is how it reached archived 8ffa7fdf. Filtering to
+  // status='draft' keeps the bootstrap path and still cannot select an archived roadmap.
+  const { data: drafts, error } = await supabase
+    .from('strategic_roadmaps')
+    .select('id, title, status, current_baseline_version')
+    .eq('status', 'draft')
+    .order('created_at', { ascending: false })
+    .limit(1);
+  if (error || !drafts || drafts.length === 0) return null;
+  return drafts[0];
 }
 
 /**

--- a/scripts/eva-intake-refine.js
+++ b/scripts/eva-intake-refine.js
@@ -30,6 +30,7 @@ import { readFileSync, writeFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { dedup, extractDedupContext } from '../lib/integrations/refine-dedup.js';
+import { resolveCanonicalRoadmap } from '../lib/roadmap/canonical-roadmap.js';
 import { reconcile, extractReconcileContext, enforceInstitutionDiscipline } from '../lib/integrations/refine-reconcile.js';
 import { score, extractScoringContext } from '../lib/integrations/refine-score.js';
 import { promote, groupForPromotion } from '../lib/integrations/refine-promote.js';
@@ -81,28 +82,24 @@ async function getRoadmap() {
     return data;
   }
 
-  // Find active baselined roadmap
-  const { data, error } = await supabase
-    .from('strategic_roadmaps')
-    .select('id, title, status, current_baseline_version')
-    .eq('status', 'active')
-    .gt('current_baseline_version', 0)
-    .order('created_at', { ascending: false })
-    .limit(1);
-
-  if (error || !data || data.length === 0) {
-    // Fall back to any draft roadmap
-    const { data: drafts } = await supabase
-      .from('strategic_roadmaps')
-      .select('id, title, status, current_baseline_version')
-      .order('created_at', { ascending: false })
-      .limit(1);
-
-    if (!drafts || drafts.length === 0) return null;
-    return drafts[0];
-  }
-
-  return data[0];
+  // SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-6. Found by the corpus-wide invariant,
+  // not by inspection — neither sub-agent examined this file.
+  //
+  // This was THE ORIGINAL ROOT CAUSE, still live in a second file. The primary query required
+  // current_baseline_version > 0, but the canonical roadmap has 0 (baselining is an
+  // approval-workflow step it never went through), so the primary returned EMPTY and control
+  // fell to a "any draft roadmap" fallback that ordered by created_at with NO status predicate.
+  //
+  // Verified live 2026-07-29: that fallback resolved to 8ffa7fdf — status=archived — because it
+  // is merely the newest row, while the actual plan of record 3aa2f3e2 was never considered.
+  // This function is used by the refine pass that backfills wave-item titles, so it was pointed
+  // at an archived roadmap's items.
+  //
+  // resolveCanonicalRoadmap deliberately does NOT filter on current_baseline_version, precisely
+  // because that predicate is what created this class of bug (see its header). Routing through
+  // it removes both the bad predicate and the unscoped fallback in one move.
+  const roadmap = await resolveCanonicalRoadmap(supabase);
+  return roadmap || null;
 }
 
 /**

--- a/scripts/gauge-runner.mjs
+++ b/scripts/gauge-runner.mjs
@@ -22,6 +22,7 @@ import { createClient } from '@supabase/supabase-js';
 import { pathToFileURL } from 'node:url';
 import { createRequire } from 'node:module';
 import { GAUGE_REGISTRY } from '../lib/governance/gauge-registry.js';
+import { resolveCanonicalWaveIds } from '../lib/roadmap/canonical-roadmap.js';
 import { computeClaimableLeaves } from './coordinator-backlog-rank.mjs';
 import { countUnrankedClaimableLeaves } from './gauge-unranked-claimable-leaves.mjs';
 import { checkoutFreshness } from '../lib/governance/checkout-freshness.js';
@@ -313,10 +314,26 @@ function buildDetectorResolvers(supabase) {
         const computeGaugeFn = () => computeBuildGauge({ io: { supabase, grep }, visionSource: true });
         const roll = await runRollup({ supabase, computeGaugeFn, apply: false, log: () => {} });
         if (roll && roll.ok) activeRungKey = roll.activeRungKey || null;
-        const [{ data: waveItems }, { data: waves }] = await Promise.all([
-          supabase.from('roadmap_wave_items').select('promoted_to_sd_key, wave_id').not('promoted_to_sd_key', 'is', null),
-          supabase.from('roadmap_waves').select('id, time_horizon, metadata'),
-        ]);
+        // SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-4 follow-up. I previously claimed
+        // this call site was fixed "transitively" because it calls runRollup(). That was WRONG,
+        // and the EXEC adversarial review caught it: runRollup is scoped, but these two queries
+        // are a SEPARATE, unscoped read feeding buildSdRungMap. Seeing the scoped call above made
+        // me stop looking.
+        //
+        // It also left this one function internally inconsistent: computeStampCoverage() at the
+        // top is canonical-scoped, while sdRungMap here was corpus-wide — two populations, one
+        // gauge, which is how a 'plan-drift-mix' value stops meaning one thing.
+        //
+        // Impact today is nil (all non-canonical waves have time_horizon=null and no
+        // metadata.rung_key, so mapWaveToRung returns null and buildSdRungMap skips them), so this
+        // is a latent correctness fix, not a live-number one. Stated rather than implied.
+        const canonicalWaveIds = await resolveCanonicalWaveIds(supabase);
+        const [{ data: waveItems }, { data: waves }] = canonicalWaveIds === null
+          ? [{ data: [] }, { data: [] }]
+          : await Promise.all([
+            supabase.from('roadmap_wave_items').select('promoted_to_sd_key, wave_id').in('wave_id', canonicalWaveIds).not('promoted_to_sd_key', 'is', null),
+            supabase.from('roadmap_waves').select('id, time_horizon, metadata').in('id', canonicalWaveIds),
+          ]);
         const wavesById = Object.fromEntries((waves || []).map((w) => [w.id, w]));
         sdRungMap = buildSdRungMap(waveItems, wavesById);
       } catch (e) {

--- a/scripts/roadmap-generate.js
+++ b/scripts/roadmap-generate.js
@@ -454,10 +454,12 @@ async function main() {
     console.log(`  OVERRIDE: --replace-active on ${existingActive.id} — reason: ${replaceReason}`);
     try {
       await supabase.from('audit_log').insert({
-        event: 'ROADMAP_FULL_REPLACE_ACTIVE',
-        details: {
+        event_type: 'ROADMAP_FULL_REPLACE_ACTIVE',
+        entity_type: 'strategic_roadmaps',
+        entity_id: existingActive.id,
+        severity: 'high',
+        metadata: {
           sd: 'SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001',
-          replaced_roadmap_id: existingActive.id,
           replaced_roadmap_title: existingActive.title,
           reason: replaceReason,
           dry_run: dryRun,

--- a/scripts/roadmap-generate.js
+++ b/scripts/roadmap-generate.js
@@ -395,6 +395,11 @@ async function main() {
   const forceReassign = args.includes('--force-reassign');
   // --respect-locks is ON by default; --force-reassign disables it
   const respectLocks = !forceReassign;
+  // SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-5: explicit override for --full when an
+  // active roadmap already exists. Requires --reason, and the override is audit-logged.
+  const replaceActive = args.includes('--replace-active');
+  const reasonFlag = args.indexOf('--reason');
+  const replaceReason = reasonFlag >= 0 ? args[reasonFlag + 1] : undefined;
 
   const title = titleFlag >= 0 ? args[titleFlag + 1] : 'EVA Intake Roadmap';
   const application = appFlag >= 0 ? args[appFlag + 1] : undefined;
@@ -417,6 +422,50 @@ async function main() {
     console.log('  No active (canonical) roadmap found. Refusing to auto-create one (single-writer invariant).');
     console.log('  To bootstrap the FIRST roadmap, run explicitly: node scripts/roadmap-generate.js --full');
     process.exit(1);
+  }
+
+  // SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-5: --full was an UNGUARDED escape hatch.
+  // The guard above covers only the !forceFull branch, so --full could still fork a second
+  // ACTIVE roadmap — and the moment two exist, resolveCanonicalRoadmap throws 'ambiguous' for
+  // every reader in the codebase, which is a strictly worse failure than refusing here. A guard
+  // inside one code path is not a guard on the invariant.
+  //
+  // --full keeps its stated purpose (bootstrap the FIRST roadmap, or recluster after the active
+  // one has been archived). What it no longer does is create a second one silently.
+  const existingActive = await resolveCanonicalRoadmap(supabase);
+  if (existingActive) {
+    if (!replaceActive) {
+      console.error(`  REFUSING: an active roadmap already exists — ${existingActive.id} ("${existingActive.title}").`);
+      console.error('  --full bootstraps the FIRST roadmap. Creating a second would leave the canonical');
+      console.error('  roadmap ambiguous, and every reader resolving through resolveCanonicalRoadmap()');
+      console.error('  would throw rather than pick one.');
+      console.error('');
+      console.error('  To recluster: archive the current roadmap first, then re-run --full.');
+      console.error('  To replace deliberately: --full --replace-active --reason "<why>"');
+      process.exit(1);
+    }
+    if (!replaceReason) {
+      console.error('  --replace-active requires --reason "<why>" — the override is audit-logged.');
+      process.exit(1);
+    }
+    // Audit BEFORE the write, so an override that then fails is still on the record.
+    // Best-effort: a missing audit_log table must not block a legitimate, explicitly-authorised
+    // bootstrap, but the console line always emits.
+    console.log(`  OVERRIDE: --replace-active on ${existingActive.id} — reason: ${replaceReason}`);
+    try {
+      await supabase.from('audit_log').insert({
+        event: 'ROADMAP_FULL_REPLACE_ACTIVE',
+        details: {
+          sd: 'SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001',
+          replaced_roadmap_id: existingActive.id,
+          replaced_roadmap_title: existingActive.title,
+          reason: replaceReason,
+          dry_run: dryRun,
+        },
+      });
+    } catch (e) {
+      console.log(`  (audit_log write failed, continuing: ${e && e.message ? e.message : e})`);
+    }
   }
 
   await runFull({ title, application, dryRun });

--- a/scripts/roadmap-generate.js
+++ b/scripts/roadmap-generate.js
@@ -33,7 +33,7 @@ import {
 // roadmap never satisfied -- the confirmed root cause of every distill run forking a
 // brand-new parallel 'EVA Intake Roadmap' instead of writing into the existing one).
 import { resolveCanonicalRoadmap } from '../lib/roadmap/canonical-roadmap.js';
-import { evaluateFullCreate, roadmapsToArchive, REFUSE_REASON_REQUIRED } from '../lib/roadmap/full-create-guard.js';
+import { evaluateFullCreate, roadmapsToArchive, REFUSE_REASON_REQUIRED, AUDIT_SEVERITY } from '../lib/roadmap/full-create-guard.js';
 
 dotenv.config();
 
@@ -473,48 +473,62 @@ async function main() {
     process.exit(1);
   }
 
+  const overrideTargets = verdict.override ? roadmapsToArchive(existing) : [];
   if (verdict.override) {
-    const targets = roadmapsToArchive(existing);
-    // Audit BEFORE the write, so an override that then fails is still on the record.
-    console.log(`  OVERRIDE: --replace-active archiving ${targets.length} roadmap(s) — reason: ${replaceReason}`);
-    try {
-      await supabase.from('audit_log').insert({
+    console.log(`  OVERRIDE: --replace-active will archive ${overrideTargets.length} roadmap(s) AFTER the new one is created — reason: ${replaceReason}`);
+  }
+
+  // *** CREATE FIRST, ARCHIVE AFTER. *** The EXEC security review found that archiving first was
+  // a data-loss path, not merely an ordering preference: runFull() calls process.exit(0) at :339
+  // when there are no classified intake items — a NORMAL state, since classification is a
+  // separate prior step. So `--full --replace-active` against an empty queue archived EVERY
+  // roadmap including the plan of record, created nothing, and exited 0. There is no transaction
+  // here, so ordering is the only atomicity available: if creation does not happen, the archive
+  // must not either.
+  await runFull({ title, application, dryRun });
+
+  if (verdict.override) {
+    if (dryRun) {
+      console.log(`  [DRY-RUN] would archive after creation: ${overrideTargets.join(', ')}`);
+    } else {
+      // *** THE AUDIT ROW GATES THE ARCHIVE. *** Previously this was best-effort in a try/catch,
+      // which was dead code twice over: supabase-js RETURNS {error} rather than throwing, and the
+      // severity value I used ('high') violates audit_log_severity_check. Net effect: the
+      // override wrote NO audit row, silently, while printing "Archived N roadmap(s)". Live probe
+      // confirms 0 rows in audit_log with entity_type='strategic_roadmaps' out of 241,139.
+      // An unauditable destructive action is worse than a failed one, so a failed audit now
+      // REFUSES rather than continuing.
+      const { error: auditErr } = await supabase.from('audit_log').insert({
         event_type: 'ROADMAP_FULL_REPLACE_ACTIVE',
         entity_type: 'strategic_roadmaps',
-        entity_id: targets[0],
-        severity: 'high',
+        entity_id: overrideTargets[0],
+        severity: AUDIT_SEVERITY,
+        created_by: `roadmap-generate:${process.env.CLAUDE_SESSION_ID || process.env.USERNAME || 'unknown'}`,
         metadata: {
           sd: 'SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001',
-          replaced_roadmap_ids: targets,
+          replaced_roadmap_ids: overrideTargets,
           reason: replaceReason,
-          dry_run: dryRun,
         },
       });
-    } catch (e) {
-      console.log(`  (audit_log write failed, continuing: ${e && e.message ? e.message : e})`);
-    }
+      if (auditErr) {
+        console.error(`  REFUSING to archive: the audit row could not be written (${auditErr.message}).`);
+        console.error('  The new roadmap HAS been created; the previous one(s) are untouched.');
+        console.error(`  Resolve the audit failure, then archive manually: ${overrideTargets.join(', ')}`);
+        process.exit(1);
+      }
 
-    // *** ACTUALLY ARCHIVE THEM. *** The EXEC adversarial review caught that --replace-active
-    // wrote nothing: it created a second roadmap and left the first one live, producing exactly
-    // the duplicate state this guard exists to prevent. An override named "replace" that does not
-    // replace is worse than no override, because the operator believes the old one is gone.
-    if (dryRun) {
-      console.log(`  [DRY-RUN] would archive: ${targets.join(', ')}`);
-    } else {
       const { error: archErr } = await supabase
         .from('strategic_roadmaps')
         .update({ status: 'archived' })
-        .in('id', targets);
+        .in('id', overrideTargets);
       if (archErr) {
-        console.error(`  REFUSING to proceed: could not archive the existing roadmap(s): ${archErr.message}`);
-        console.error('  Creating a new roadmap now would leave duplicates behind.');
+        console.error(`  Could not archive the previous roadmap(s): ${archErr.message}`);
+        console.error(`  The new roadmap exists; archive these manually: ${overrideTargets.join(', ')}`);
         process.exit(1);
       }
-      console.log(`  Archived ${targets.length} roadmap(s): ${targets.join(', ')}`);
+      console.log(`  Archived ${overrideTargets.length} roadmap(s): ${overrideTargets.join(', ')}`);
     }
   }
-
-  await runFull({ title, application, dryRun });
 }
 
 main().catch(err => {

--- a/scripts/roadmap-generate.js
+++ b/scripts/roadmap-generate.js
@@ -503,7 +503,9 @@ async function main() {
         entity_type: 'strategic_roadmaps',
         entity_id: overrideTargets[0],
         severity: AUDIT_SEVERITY,
-        created_by: `roadmap-generate:${process.env.CLAUDE_SESSION_ID || process.env.USERNAME || 'unknown'}`,
+        // USER before USERNAME: USERNAME is Windows-only, so a POSIX run without a session id
+        // recorded 'unknown' and the audit row lost its actor (SEC-5b).
+        created_by: `roadmap-generate:${process.env.CLAUDE_SESSION_ID || process.env.USER || process.env.USERNAME || 'unknown'}`,
         metadata: {
           sd: 'SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001',
           replaced_roadmap_ids: overrideTargets,

--- a/scripts/roadmap-generate.js
+++ b/scripts/roadmap-generate.js
@@ -432,13 +432,33 @@ async function main() {
   //
   // --full keeps its stated purpose (bootstrap the FIRST roadmap, or recluster after the active
   // one has been archived). What it no longer does is create a second one silently.
-  const existingActive = await resolveCanonicalRoadmap(supabase);
+  // *** CORRECTED AFTER ADVERSARIAL REVIEW: guarding on status='active' MISSED THE ACTUAL
+  // INCIDENT. *** createRoadmap() at :88 inserts status:'draft'; the flip to 'active' happens
+  // only in roadmap-manager.js:190 approveSequence, at chairman approval. So --full has never
+  // been able to fork a second ACTIVE roadmap, and a guard that only asks about active roadmaps
+  // cannot fire on the thing that actually happened here — two duplicate DRAFT rows (see
+  // scripts/one-off/archive-duplicate-roadmaps.mjs header: "2 pre-guard duplicate draft rows").
+  // Running --full twice from a bootstrap state would have reproduced a89b078b + 8ffa7fdf
+  // unimpeded through my first version of this guard.
+  //
+  // So the predicate is "does any NON-ARCHIVED roadmap already exist", which covers both the
+  // draft window and an approved plan of record.
+  const { data: liveRoadmaps, error: liveErr } = await supabase
+    .from('strategic_roadmaps')
+    .select('id, title, status')
+    .neq('status', 'archived');
+  if (liveErr) {
+    console.error(`  Could not check for existing roadmaps: ${liveErr.message}`);
+    process.exit(1);
+  }
+  const existingActive = (liveRoadmaps || [])[0];
   if (existingActive) {
     if (!replaceActive) {
-      console.error(`  REFUSING: an active roadmap already exists — ${existingActive.id} ("${existingActive.title}").`);
-      console.error('  --full bootstraps the FIRST roadmap. Creating a second would leave the canonical');
-      console.error('  roadmap ambiguous, and every reader resolving through resolveCanonicalRoadmap()');
-      console.error('  would throw rather than pick one.');
+      console.error(`  REFUSING: ${liveRoadmaps.length} non-archived roadmap(s) already exist, e.g. ${existingActive.id} ("${existingActive.title}", status=${existingActive.status}).`);
+      console.error('  --full bootstraps the FIRST roadmap. A second one forks the plan of record:');
+      console.error('  a duplicate DRAFT is exactly what happened on 2026-07-17 (a89b078b, 8ffa7fdf),');
+      console.error('  and if one is later approved you get two active rows, at which point every');
+      console.error('  reader resolving through resolveCanonicalRoadmap() throws rather than guess.');
       console.error('');
       console.error('  To recluster: archive the current roadmap first, then re-run --full.');
       console.error('  To replace deliberately: --full --replace-active --reason "<why>"');

--- a/scripts/roadmap-generate.js
+++ b/scripts/roadmap-generate.js
@@ -33,6 +33,7 @@ import {
 // roadmap never satisfied -- the confirmed root cause of every distill run forking a
 // brand-new parallel 'EVA Intake Roadmap' instead of writing into the existing one).
 import { resolveCanonicalRoadmap } from '../lib/roadmap/canonical-roadmap.js';
+import { evaluateFullCreate, roadmapsToArchive, REFUSE_REASON_REQUIRED } from '../lib/roadmap/full-create-guard.js';
 
 dotenv.config();
 
@@ -451,42 +452,65 @@ async function main() {
     console.error(`  Could not check for existing roadmaps: ${liveErr.message}`);
     process.exit(1);
   }
-  const existingActive = (liveRoadmaps || [])[0];
-  if (existingActive) {
-    if (!replaceActive) {
-      console.error(`  REFUSING: ${liveRoadmaps.length} non-archived roadmap(s) already exist, e.g. ${existingActive.id} ("${existingActive.title}", status=${existingActive.status}).`);
-      console.error('  --full bootstraps the FIRST roadmap. A second one forks the plan of record:');
-      console.error('  a duplicate DRAFT is exactly what happened on 2026-07-17 (a89b078b, 8ffa7fdf),');
-      console.error('  and if one is later approved you get two active rows, at which point every');
-      console.error('  reader resolving through resolveCanonicalRoadmap() throws rather than guess.');
-      console.error('');
-      console.error('  To recluster: archive the current roadmap first, then re-run --full.');
-      console.error('  To replace deliberately: --full --replace-active --reason "<why>"');
-      process.exit(1);
-    }
-    if (!replaceReason) {
+  // Decision lives in lib/roadmap/full-create-guard.js so it can be unit-tested; this file
+  // self-invokes main() at module load, so an inline predicate is unreachable from a test.
+  const verdict = evaluateFullCreate(liveRoadmaps, { replaceActive, replaceReason });
+  const existing = verdict.existing || [];
+  if (!verdict.allow) {
+    if (verdict.refusal === REFUSE_REASON_REQUIRED) {
       console.error('  --replace-active requires --reason "<why>" — the override is audit-logged.');
       process.exit(1);
     }
+    const first = existing[0];
+    console.error(`  REFUSING: ${existing.length} non-archived roadmap(s) already exist, e.g. ${first.id} ("${first.title}", status=${first.status}).`);
+    console.error('  --full bootstraps the FIRST roadmap. A second one forks the plan of record:');
+    console.error('  a duplicate DRAFT is exactly what happened on 2026-07-17 (a89b078b, 8ffa7fdf),');
+    console.error('  and if one is later approved you get two active rows, at which point every');
+    console.error('  reader resolving through resolveCanonicalRoadmap() throws rather than guess.');
+    console.error('');
+    console.error('  To recluster: archive the current roadmap first, then re-run --full.');
+    console.error('  To replace deliberately: --full --replace-active --reason "<why>"');
+    process.exit(1);
+  }
+
+  if (verdict.override) {
+    const targets = roadmapsToArchive(existing);
     // Audit BEFORE the write, so an override that then fails is still on the record.
-    // Best-effort: a missing audit_log table must not block a legitimate, explicitly-authorised
-    // bootstrap, but the console line always emits.
-    console.log(`  OVERRIDE: --replace-active on ${existingActive.id} — reason: ${replaceReason}`);
+    console.log(`  OVERRIDE: --replace-active archiving ${targets.length} roadmap(s) — reason: ${replaceReason}`);
     try {
       await supabase.from('audit_log').insert({
         event_type: 'ROADMAP_FULL_REPLACE_ACTIVE',
         entity_type: 'strategic_roadmaps',
-        entity_id: existingActive.id,
+        entity_id: targets[0],
         severity: 'high',
         metadata: {
           sd: 'SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001',
-          replaced_roadmap_title: existingActive.title,
+          replaced_roadmap_ids: targets,
           reason: replaceReason,
           dry_run: dryRun,
         },
       });
     } catch (e) {
       console.log(`  (audit_log write failed, continuing: ${e && e.message ? e.message : e})`);
+    }
+
+    // *** ACTUALLY ARCHIVE THEM. *** The EXEC adversarial review caught that --replace-active
+    // wrote nothing: it created a second roadmap and left the first one live, producing exactly
+    // the duplicate state this guard exists to prevent. An override named "replace" that does not
+    // replace is worse than no override, because the operator believes the old one is gone.
+    if (dryRun) {
+      console.log(`  [DRY-RUN] would archive: ${targets.join(', ')}`);
+    } else {
+      const { error: archErr } = await supabase
+        .from('strategic_roadmaps')
+        .update({ status: 'archived' })
+        .in('id', targets);
+      if (archErr) {
+        console.error(`  REFUSING to proceed: could not archive the existing roadmap(s): ${archErr.message}`);
+        console.error('  Creating a new roadmap now would leave duplicates behind.');
+        process.exit(1);
+      }
+      console.log(`  Archived ${targets.length} roadmap(s): ${targets.join(', ')}`);
     }
   }
 

--- a/scripts/vision/rung-progress-rollup.mjs
+++ b/scripts/vision/rung-progress-rollup.mjs
@@ -16,7 +16,12 @@ import { makeDefaultGrepSeam } from '../../lib/vision/vdr-grep-seam.js';
 import { runRollup } from '../../lib/vision/rung-progress-rollup.mjs';
 import { isMainModule } from '../../lib/utils/is-main-module.js';
 import { stampLastFired } from '../../lib/periodic-liveness/stamp-last-fired.js';
-import { computeWaveLinkageCoverage, COVERAGE_THRESHOLD, STARVATION_NAME } from '../../lib/roadmap/wave-linkage-coverage.js';
+import { computeWaveLinkageCoverage, COVERAGE_THRESHOLD, STARVATION_NAME, ERR_NO_CANONICAL_ROADMAP } from '../../lib/roadmap/wave-linkage-coverage.js';
+
+// SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 SEC-3: a distinct dedup_key from
+// STARVATION_NAME, because "coverage is low" and "coverage could not be computed" are different
+// facts and must not collapse into one feedback row.
+const NO_CANONICAL_ROADMAP_NAME = 'WAVE_LINKAGE_NO_CANONICAL_ROADMAP';
 import { emitFeedback } from '../../lib/governance/emit-feedback.js';
 import { buildPlanLinkageRetroPayload, PLAN_LINKAGE_RETRO_CATEGORY } from '../../lib/roadmap/plan-linkage-retro.js';
 
@@ -107,7 +112,35 @@ async function main() {
       }
     }
   } catch (covErr) {
-    console.error(`  [coverage] WARN: wave-linkage coverage computation failed: ${covErr.message}`);
+    // SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 (EXEC security review SEC-3, LIVE).
+    // This catch previously collapsed EVERY failure into one WARN line. That mattered because
+    // "no canonical roadmap" is not a bug — it is the normal state between a roadmap being
+    // created and being approved (a successful --full --replace-active ends at old=archived,
+    // new=draft, i.e. zero active), and this file runs on a 6-hourly cron with --apply. In that
+    // window the named WAVE_LINKAGE_STARVATION signal and the FR-3 retro row were both skipped
+    // and the job still exited green: a silent control failure, which is exactly the shape this
+    // SD exists to remove. So the reportable state now gets REPORTED, and only genuine
+    // computation failures stay a WARN.
+    if (covErr && covErr.code === ERR_NO_CANONICAL_ROADMAP) {
+      console.error(`  ❌ ${NO_CANONICAL_ROADMAP_NAME}: wave-linkage coverage NOT COMPUTED — ${covErr.message}`);
+      console.error('     (this is a reportable state, not a crash: expected between roadmap creation and approval)');
+      if (apply) {
+        await emitFeedback({
+          supabase,
+          title: `${NO_CANONICAL_ROADMAP_NAME}: wave-linkage coverage could not be computed`,
+          description:
+            'No status=active strategic_roadmaps row exists, so wave-linkage coverage has no defined corpus and was NOT computed. '
+            + 'This is the normal window between roadmap creation and chairman approval; it is reported rather than swallowed so that '
+            + '"not measured" is never indistinguishable from "measured and healthy". If this persists, approve the pending roadmap '
+            + '(/distill approve --roadmap-id <id>) or investigate why none is active.',
+          category: 'harness_backlog',
+          severity: 'medium',
+          dedup_key: NO_CANONICAL_ROADMAP_NAME,
+        });
+      }
+    } else {
+      console.error(`  [coverage] WARN: wave-linkage coverage computation failed: ${covErr.message}`);
+    }
   }
 
   console.log(`\n  Active build rung: ${res.activeRungKey} | build gauge: ${res.gaugeBuildPct}%`);

--- a/tests/unit/eva/distill-brainstorm-isolation.test.js
+++ b/tests/unit/eva/distill-brainstorm-isolation.test.js
@@ -84,30 +84,79 @@ describe('SD-...-001-D: distiller observability + bounds + isolation', () => {
     expect(results.length).toBe(50);
   });
 
-  it('FR-1: dispositionCoverage = (item_disposition <> pending) / total', async () => {
-    // count probe mock: head/count select; .neq() narrows the numerator
-    const sb = {
-      from() {
-        let neq = false;
-        const chain = {
-          select() { return chain; },
-          neq() { neq = true; return chain; },
-          then(resolve) { resolve({ count: neq ? 33 : 741, error: null }); },
+  // SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-3: dispositionCoverage is now scoped to
+  // the canonical roadmap, so this mock models strategic_roadmaps/roadmap_waves and APPLIES the
+  // operators it receives.
+  //
+  // The previous mock was table-blind — it returned {count: neq ? 33 : 741} for EVERY query
+  // regardless of table or filter — so a correctly-scoped implementation reproduced 33/741
+  // exactly. It could not distinguish a scoped read from an unscoped one, which is precisely
+  // the defect under test. Counts here are derived from rows, so the numbers mean something.
+  function coverageDb({ items, waves, roadmaps } = {}) {
+    const src = {
+      strategic_roadmaps: roadmaps ?? [{ id: 'rm-canon', status: 'active' }],
+      roadmap_waves: waves ?? [{ id: 'w-canon', roadmap_id: 'rm-canon' }],
+      roadmap_wave_items: items ?? [],
+    };
+    return {
+      from(table) {
+        let rows = [...(src[table] || [])];
+        let counting = false;
+        const c = {
+          select(_col, opts) { counting = Boolean(opts?.count); return c; },
+          eq(k, v) { rows = rows.filter((r) => r[k] === v); return c; },
+          in(k, vs) { rows = rows.filter((r) => vs.includes(r[k])); return c; },
+          neq(k, v) { rows = rows.filter((r) => r[k] !== v); return c; },
+          then(resolve) { resolve(counting ? { count: rows.length, error: null } : { data: rows, error: null }); },
         };
-        return chain;
+        return c;
       },
     };
-    const cov = await dispositionCoverage(sb);
+  }
+
+  const mkItems = (waveId, total, nonPending) =>
+    Array.from({ length: total }, (_, i) => ({
+      id: `${waveId}-${i}`, wave_id: waveId, item_disposition: i < nonPending ? 'promoted' : 'pending',
+    }));
+
+  it('FR-1: dispositionCoverage = (item_disposition <> pending) / total, scoped to the canonical roadmap', async () => {
+    const cov = await dispositionCoverage(coverageDb({ items: mkItems('w-canon', 741, 33) }));
     expect(cov.denominator).toBe(741);
     expect(cov.numerator).toBe(33);
     expect(cov.value).toBeCloseTo(33 / 741, 5);
     expect(cov.status).toBe('ok');
   });
 
+  it('FR-1: items under an ARCHIVED roadmap are excluded from BOTH numerator and denominator', async () => {
+    // The regression this SD exists to prevent. Measured live 2026-07-29 before the fix:
+    // 95/1864 = 5.1% unscoped versus 20/261 = 7.7% scoped. Note the orphans here are NOT all
+    // pending — 60 of them are dispositioned — because the real archived corpus is not either,
+    // so a denominator-only fix must fail this too.
+    const cov = await dispositionCoverage(coverageDb({
+      roadmaps: [{ id: 'rm-canon', status: 'active' }, { id: 'rm-old', status: 'archived' }],
+      waves: [{ id: 'w-canon', roadmap_id: 'rm-canon' }, { id: 'w-orphan', roadmap_id: 'rm-old' }],
+      items: [...mkItems('w-canon', 741, 33), ...mkItems('w-orphan', 1100, 60)],
+    }));
+    expect(cov.denominator).toBe(741);
+    expect(cov.numerator).toBe(33);
+  });
+
   it('FR-1: dispositionCoverage returns status=unknown on empty corpus', async () => {
-    const sb = { from() { const c = { select() { return c; }, neq() { return c; }, then(r) { r({ count: 0, error: null }); } }; return c; } };
-    const cov = await dispositionCoverage(sb);
+    const cov = await dispositionCoverage(coverageDb({ items: [] }));
     expect(cov.status).toBe('unknown');
     expect(cov.value).toBe(null);
+  });
+
+  it('FR-1: no active roadmap and ambiguity are distinct from an empty corpus', async () => {
+    const none = await dispositionCoverage(coverageDb({ roadmaps: [] }));
+    expect(none.status).toBe('unknown');
+    expect(none.detail).toMatch(/no active roadmap/);
+
+    const ambiguous = await dispositionCoverage(coverageDb({
+      roadmaps: [{ id: 'a', status: 'active' }, { id: 'b', status: 'active' }],
+    }));
+    expect(ambiguous.status).toBe('unknown');
+    expect(ambiguous.detail).toMatch(/ambiguous/i);
+    expect(ambiguous.detail).not.toMatch(/empty corpus/);
   });
 });

--- a/tests/unit/needle-priority.test.js
+++ b/tests/unit/needle-priority.test.js
@@ -107,10 +107,42 @@ describe('buildSdRungMap (reuses mapWaveToRung)', () => {
     expect(buildSdRungMap(items, wavesByIdMixedStatus)).toEqual({ 'SD-A': 'V1', 'SD-B': 'V2' });
   });
 
-  it('SD-LEO-INFRA-PLAN-OF-RECORD-REMAINDER-VIEW-001 regression: coordinator-backlog-rank.mjs still sources its rung-map input from unscoped roadmap_wave_items/roadmap_waves, not the approved-only v_plan_of_record_remainder view (FR-4 -- repointing this file would silently empty the map for non-approved-wave SDs)', () => {
+  it('SD-LEO-INFRA-PLAN-OF-RECORD-REMAINDER-VIEW-001 regression: coordinator-backlog-rank.mjs sources its rung-map from the base tables, never the approved-only v_plan_of_record_remainder view (repointing it would silently empty the map for non-approved-wave SDs)', () => {
+    // *** ASSERTED AS FRAGMENTS, NOT AS ONE PINNED LITERAL — SD-LEO-INFRA-ROADMAP-REGENERATION-
+    // DUPLICATES-001. *** This previously pinned the whole chained call as a single string, so
+    // adding a roadmap scope broke it even though the invariant it guards was untouched. A pin
+    // that fails on every legitimate insertion trains people to edit the assertion without
+    // reading it, which is how the real invariant eventually gets deleted by someone in a hurry.
+    // The invariant is: base tables, not the approved-only view, and no wave-STATUS filter.
     const source = readFileSync(path.join(REPO_ROOT, 'scripts/coordinator-backlog-rank.mjs'), 'utf8');
-    expect(source).toContain("sb.from('roadmap_wave_items').select('promoted_to_sd_key, wave_id').not('promoted_to_sd_key', 'is', null)");
-    expect(source).toContain("sb.from('roadmap_waves').select('id, time_horizon, metadata')");
+    expect(source).toContain("from('roadmap_wave_items')");
+    expect(source).toContain("'promoted_to_sd_key, wave_id'");
+    expect(source).toContain(".not('promoted_to_sd_key', 'is', null)");
+    expect(source).toContain("from('roadmap_waves')");
+    expect(source).toContain("'id, time_horizon, metadata'");
     expect(source).not.toContain('v_plan_of_record_remainder');
+  });
+
+  it('SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001: the rung map is scoped by ROADMAP, never by wave status', () => {
+    // The two scopings are easy to confuse and only one is safe. Scoping by roadmap_id keeps every
+    // wave of the canonical plan regardless of status (live 2026-07-29: 7 approved + 1 proposed —
+    // the proposed one MUST stay in the map). Scoping by wave status is what the original guard
+    // was written to prevent. Asserting the absence of a status filter is what stops a future
+    // "tidy-up" from converting one into the other.
+    const source = readFileSync(path.join(REPO_ROOT, 'scripts/coordinator-backlog-rank.mjs'), 'utf8');
+    expect(source).toContain('resolveCanonicalWaveIds');
+    expect(source).not.toContain("roadmap_waves').select('id, time_horizon, metadata').eq('status'");
+    expect(source).not.toContain("'approved'");
+  });
+
+  it('SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001: buildSdRungMap still maps waves of ANY status — the behaviour the source pins stand in for', () => {
+    // The pins above are proxies; this is the property itself. If someone rewrites the queries in
+    // a way the pins miss, this still fails when non-approved waves stop mapping.
+    const waves = {
+      w1: { id: 'w1', status: 'proposed', time_horizon: 'now' },
+      w2: { id: 'w2', status: 'approved', metadata: { rung_key: 'V2' } },
+    };
+    const items = [{ promoted_to_sd_key: 'SD-P', wave_id: 'w1' }, { promoted_to_sd_key: 'SD-A', wave_id: 'w2' }];
+    expect(buildSdRungMap(items, waves)).toEqual({ 'SD-P': 'V1', 'SD-A': 'V2' });
   });
 });

--- a/tests/unit/roadmap/canonical-corpus-invariant.test.js
+++ b/tests/unit/roadmap/canonical-corpus-invariant.test.js
@@ -1,0 +1,129 @@
+/**
+ * SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-6 — the corpus-wide invariant.
+ *
+ * Every individual fix in this SD removes one instance. This removes the CLASS: no reader may
+ * pick a roadmap by recency without constraining status.
+ *
+ * *** THIS GUARD EARNED ITS KEEP BEFORE IT WAS EVEN COMMITTED. *** Written to lock in the four
+ * known instances, it immediately surfaced TWO MORE that neither sub-agent had examined — and
+ * one of them, scripts/eva-intake-refine.js, was resolving to the ARCHIVED roadmap 8ffa7fdf on
+ * live data, via the SAME root cause the SD documents (a current_baseline_version > 0 predicate
+ * that excludes the real roadmap, falling through to an unscoped "any draft" fallback).
+ *
+ * WHAT IT DETECTS, deliberately narrow: a strategic_roadmaps statement that orders by created_at
+ * without any status predicate — the "newest wins" shape. That is precise enough to have almost
+ * no false positives and is exactly the shape that caused this incident. It does NOT try to
+ * police every unscoped read; a broader rule would flag legitimate listings and would be
+ * silenced within a week, which is worse than a narrow rule that holds.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = fileURLToPath(new URL('../../../', import.meta.url));
+
+/**
+ * Statements that legitimately order roadmaps by recency with no status filter.
+ * Each entry states WHY. An allowlist without reasons decays into a mute button.
+ */
+const ALLOWLIST = {
+  'scripts/roadmap-status.js':
+    'Operator status display: deliberately ENUMERATES every roadmap, archived included, newest ' +
+    'first. It reports the corpus rather than resolving a canonical one, so a status filter ' +
+    'would hide exactly what the tool exists to show.',
+  'scripts/one-off/archive-duplicate-roadmaps.mjs':
+    'The duplicate-cleanup one-off. Its whole purpose is to enumerate NON-canonical roadmaps, ' +
+    'and it is separately fenced by a hardcoded id allowlist plus a fail-closed referrer check.',
+  'scripts/archive/one-time/roadmap-baseline.js':
+    'Retired one-time script under scripts/archive/. Not on any live path; left unmodified ' +
+    'rather than touched, since editing dead code to satisfy a linter adds risk and no value.',
+};
+
+function walk(dir, acc = []) {
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return acc; }
+  for (const e of entries) {
+    if (e.name === 'node_modules' || e.name === '.git' || e.name === '.worktrees') continue;
+    const p = path.join(dir, e.name);
+    if (e.isDirectory()) walk(p, acc);
+    else if (/\.(js|mjs|cjs)$/.test(e.name)) acc.push(p);
+  }
+  return acc;
+}
+
+/** Extract each strategic_roadmaps statement with a little leading context (the chain head). */
+export function findRoadmapStatements(source) {
+  const lines = source.split('\n');
+  const out = [];
+  lines.forEach((line, i) => {
+    if (!/from\(\s*['"]strategic_roadmaps['"]\s*\)/.test(line)) return;
+    const back = lines.slice(Math.max(0, i - 3), i).join('\n');
+    let stmt = '';
+    for (let j = i; j < Math.min(i + 10, lines.length); j++) {
+      stmt += lines[j] + '\n';
+      if (/;\s*$/.test(lines[j])) break;
+    }
+    out.push({ line: i + 1, text: `${back}\n${stmt}` });
+  });
+  return out;
+}
+
+/** The defect shape: picks by recency, constrains nothing about status. */
+export function isNewestWinsWithoutStatus(text) {
+  const ordersByRecency = /\.order\(\s*['"]created_at['"]/.test(text);
+  const hasStatusPredicate = /\.(eq|in|neq)\(\s*['"]status['"]/.test(text);
+  const isWrite = /\.(update|insert|upsert|delete)\s*\(/.test(text);
+  return ordersByRecency && !hasStatusPredicate && !isWrite;
+}
+
+describe('FR-6: no roadmap reader picks by recency without constraining status', () => {
+  const files = ['lib', 'scripts', 'server'].flatMap((d) => walk(path.join(ROOT, d)));
+
+  it('scans a non-trivial corpus (guards against a vacuous pass)', () => {
+    // If the walk silently returned nothing, every assertion below would pass while checking
+    // nothing at all — the exact failure mode this SD is about.
+    const withRoadmapReads = files.filter((f) => fs.readFileSync(f, 'utf8').includes("from('strategic_roadmaps')"));
+    expect(files.length).toBeGreaterThan(200);
+    expect(withRoadmapReads.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('finds no unallowlisted newest-wins reader', () => {
+    const violations = [];
+    for (const file of files) {
+      const rel = path.relative(ROOT, file).replace(/\\/g, '/');
+      if (ALLOWLIST[rel]) continue;
+      const src = fs.readFileSync(file, 'utf8');
+      if (!src.includes("from('strategic_roadmaps')")) continue;
+      for (const stmt of findRoadmapStatements(src)) {
+        if (isNewestWinsWithoutStatus(stmt.text)) violations.push(`${rel}:${stmt.line}`);
+      }
+    }
+    expect(violations, `Roadmap readers selecting by recency with no status predicate:\n  ${violations.join('\n  ')}\n\nResolve through lib/roadmap/canonical-roadmap.js resolveCanonicalRoadmap(), or add a reasoned ALLOWLIST entry.`).toEqual([]);
+  });
+
+  it('NEGATIVE CONTROL: the detector fires on the exact shape that shipped', () => {
+    // Verbatim from chairman-morning-review-sweep.mjs before this SD. If this stops failing,
+    // the detector has been weakened and the test above is decorative.
+    const shipped = `
+      const { data: roadmaps } = await supabase.from('strategic_roadmaps')
+        .select('id, status, created_at').order('created_at', { ascending: false }).limit(1);
+    `;
+    expect(isNewestWinsWithoutStatus(shipped)).toBe(true);
+  });
+
+  it('NEGATIVE CONTROL: the detector does NOT fire on correctly-scoped or write statements', () => {
+    const scoped = 'await supabase.from(\'strategic_roadmaps\').select(\'id\').eq(\'status\', \'active\').order(\'created_at\');';
+    const write = 'await supabase.from(\'strategic_roadmaps\').update({ status: \'archived\' }).order(\'created_at\');';
+    expect(isNewestWinsWithoutStatus(scoped)).toBe(false);
+    expect(isNewestWinsWithoutStatus(write)).toBe(false);
+  });
+
+  it('every allowlist entry names a real file and gives a reason', () => {
+    // A stale allowlist entry silently re-opens the hole it was excusing.
+    for (const [rel, reason] of Object.entries(ALLOWLIST)) {
+      expect(fs.existsSync(path.join(ROOT, rel)), `allowlisted file no longer exists: ${rel}`).toBe(true);
+      expect(reason.length, `allowlist entry needs a real reason: ${rel}`).toBeGreaterThan(40);
+    }
+  });
+});

--- a/tests/unit/roadmap/canonical-scoping-writers.test.js
+++ b/tests/unit/roadmap/canonical-scoping-writers.test.js
@@ -1,0 +1,125 @@
+/**
+ * SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 — coverage for FR-4b and FR-8.
+ *
+ * *** WHY THIS FILE EXISTS: THE EXEC ADVERSARIAL REVIEW MUTATION-TESTED MY WORK AND SIX
+ * MUTATIONS SURVIVED. *** Three of the seven shipped FRs could be deleted outright without a
+ * single test failing — FR-4b (the .in() scope AND the fail-closed branch), FR-5, and FR-8 (the
+ * .eq(roadmap_id) AND the scopeNote gate). That is precisely the cannot-fail-test defect this SD
+ * spent its whole life hunting in other people's code, sitting in mine.
+ *
+ * Each test below is written against a specific surviving mutation, named in its comment, so the
+ * mutation now has something to kill.
+ *
+ * FR-5 is NOT covered here and I am not pretending otherwise: its guard is inline in
+ * roadmap-generate.js main(), which self-invokes at module load, so it cannot be imported without
+ * executing. It is verified only by live CLI runs. Extracting it to a pure predicate is the
+ * honest fix and is recorded as a follow-up rather than quietly skipped.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveCanonicalWaveIds } from '../../../lib/roadmap/canonical-roadmap.js';
+import { runRollup } from '../../../lib/vision/rung-progress-rollup.mjs';
+
+/** Applies the operators it receives — a recording-only double would make all of this vacuous. */
+function db({ roadmaps = [{ id: 'rm-canon', status: 'active' }], waves = [], items = [] } = {}) {
+  const src = { strategic_roadmaps: roadmaps, roadmap_waves: waves, roadmap_wave_items: items };
+  return {
+    from(table) {
+      let rows = [...(src[table] || [])];
+      const b = {
+        select: () => b,
+        eq: (k, v) => { rows = rows.filter((r) => r[k] === v); return b; },
+        in: (k, vs) => { rows = rows.filter((r) => vs.includes(r[k])); return b; },
+        update: () => ({ eq: async () => ({ error: null }) }),
+        then: (res) => Promise.resolve({ data: rows, error: null }).then(res),
+      };
+      return b;
+    },
+  };
+}
+
+const CANON_WAVES = [
+  { id: 'w1', roadmap_id: 'rm-canon', time_horizon: 'now', okr_objective_ids: [], metadata: {}, progress_pct: null },
+  { id: 'w2', roadmap_id: 'rm-canon', time_horizon: 'next', okr_objective_ids: [], metadata: {}, progress_pct: null },
+];
+const ORPHAN_WAVES = [
+  { id: 'o1', roadmap_id: 'rm-archived', time_horizon: 'now', okr_objective_ids: [], metadata: {}, progress_pct: null },
+];
+
+describe('FR-4b: resolveCanonicalWaveIds', () => {
+  it('returns the canonical roadmap wave ids only', async () => {
+    // Kills the mutation that drops .eq('roadmap_id', ...) from the wave query.
+    const ids = await resolveCanonicalWaveIds(db({
+      roadmaps: [{ id: 'rm-canon', status: 'active' }, { id: 'rm-archived', status: 'archived' }],
+      waves: [...CANON_WAVES, ...ORPHAN_WAVES],
+    }));
+    expect(ids.sort()).toEqual(['w1', 'w2']);
+    expect(ids).not.toContain('o1');
+  });
+
+  it('returns NULL, not [], when no roadmap is active', async () => {
+    // The distinction the 12-line comment calls load-bearing, now asserted directly rather than
+    // inferred from one downstream assertion. `[]` fed to .in('wave_id', []) matches nothing and
+    // reads as "no items" — indistinguishable from a genuinely empty roadmap.
+    const ids = await resolveCanonicalWaveIds(db({ roadmaps: [], waves: CANON_WAVES }));
+    expect(ids).toBeNull();
+    expect(ids).not.toEqual([]);
+  });
+
+  it('propagates the ambiguity throw rather than picking one', async () => {
+    await expect(resolveCanonicalWaveIds(db({
+      roadmaps: [{ id: 'a', status: 'active' }, { id: 'b', status: 'active' }],
+    }))).rejects.toThrow(/ambiguous|expected exactly 1/i);
+  });
+
+  it('returns an empty array for an active roadmap that genuinely has no waves', async () => {
+    // Distinct from the null case above — this roadmap resolved fine, it just has nothing yet.
+    const ids = await resolveCanonicalWaveIds(db({ waves: ORPHAN_WAVES }));
+    expect(ids).toEqual([]);
+  });
+});
+
+describe('FR-8: rung rollup is roadmap-scoped and FAILS CLOSED', () => {
+  const opts = { computeGaugeFn: async () => ({ build_pct: 50 }), apply: false, log: () => {} };
+
+  it('rolls up only canonical waves', async () => {
+    // Kills the mutation that drops .eq('roadmap_id', roadmapScope.id) from the wave select.
+    const r = await runRollup({
+      supabase: db({
+        roadmaps: [{ id: 'rm-canon', status: 'active' }, { id: 'rm-archived', status: 'archived' }],
+        waves: [...CANON_WAVES, ...ORPHAN_WAVES],
+      }),
+      ...opts,
+    });
+    expect(r.ok).toBe(true);
+    expect(r.roadmapScope).toBe('rm-canon');
+    expect(r.rows.map((x) => x.wave_id).sort()).toEqual(['w1', 'w2']);
+    expect(r.rows.map((x) => x.wave_id)).not.toContain('o1');
+  });
+
+  it('with NO active roadmap: zero rows, zero writes, and says why', async () => {
+    // Kills the mutation that drops the scopeNote gate. For a WRITER, an unresolvable scope must
+    // produce no writes — writing to an unknown scope is strictly worse than not writing.
+    const r = await runRollup({ supabase: db({ roadmaps: [], waves: CANON_WAVES }), ...opts, apply: true });
+    expect(r.rows).toEqual([]);
+    expect(r.written).toBe(0);
+    expect(r.roadmapScope).toBeNull();
+    expect(r.scopeNote).toBe('no-active-roadmap');
+  });
+
+  it('with an AMBIGUOUS roadmap: zero rows, zero writes, and names the ambiguity', async () => {
+    const r = await runRollup({
+      supabase: db({ roadmaps: [{ id: 'a', status: 'active' }, { id: 'b', status: 'active' }], waves: CANON_WAVES }),
+      ...opts,
+      apply: true,
+    });
+    expect(r.rows).toEqual([]);
+    expect(r.written).toBe(0);
+    expect(r.scopeNote).toMatch(/ambiguous/i);
+  });
+
+  it('scopeNote is null on the happy path — absence of a note must mean "scoped", not "unchecked"', async () => {
+    const r = await runRollup({ supabase: db({ waves: CANON_WAVES }), ...opts });
+    expect(r.scopeNote).toBeNull();
+    expect(r.roadmapScope).toBe('rm-canon');
+  });
+});

--- a/tests/unit/roadmap/canonical-scoping.test.js
+++ b/tests/unit/roadmap/canonical-scoping.test.js
@@ -1,0 +1,128 @@
+/**
+ * SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 — FR-1, FR-2, FR-6 / TS-1, TS-2, TS-3, TS-10, TS-11.
+ *
+ * *** THE FIXTURE IS THE WHOLE POINT. *** Every reader in this SD would start returning the
+ * right answer BY ACCIDENT if the duplicate roadmap rows were simply deleted, while the broken
+ * predicate survived to pick the next wrong roadmap the moment another row was created. So the
+ * fixture deliberately holds FOUR roadmaps — exactly one active, and the NEWEST one archived —
+ * which is the only shape in which an unscoped `order(created_at).limit(1)` reader actually
+ * fails. A single-roadmap fixture passes against the broken code and proves nothing.
+ *
+ * *** AND THE DOUBLE IS UNDER TEST TOO (TS-10). *** The pre-existing mock in this repo
+ * (chairman-morning-review-sweep.test.js) RECORDS .eq/.order/.limit and APPLIES NONE. Under it
+ * the polarity of these tests INVERTS: the broken code renders "waves 0/8 done" and looks
+ * correct, while the correct fix renders "AMBIGUOUS — 4 active roadmaps" and looks broken,
+ * because the resolver receives all four rows in answer to an .eq('status','active') query.
+ * A suite built on such a double does not merely miss this defect — it CERTIFIES it and
+ * PENALISES the fix. Hence makeDb() below genuinely applies .eq, and TS-10 asserts that it does.
+ */
+import { describe, it, expect } from 'vitest';
+import { gatherWaves, formatRoadmapLine } from '../../../scripts/cron/chairman-morning-review-sweep.mjs';
+
+const ROADMAPS = [
+  { id: 'arch-newest', status: 'archived', created_at: '2026-07-17T15:49:00Z' },
+  { id: 'arch-mid', status: 'archived', created_at: '2026-07-17T15:30:00Z' },
+  { id: 'active-poR', status: 'active', created_at: '2026-06-13T10:18:00Z' },
+  { id: 'arch-oldest', status: 'archived', created_at: '2026-03-08T23:12:00Z' }
+];
+const WAVES = [
+  ...Array.from({ length: 4 }, (_, i) => ({ roadmap_id: 'arch-newest', status: 'proposed', progress_pct: 0, k: i })),
+  ...Array.from({ length: 8 }, (_, i) => ({ roadmap_id: 'active-poR', status: i < 3 ? 'completed' : 'approved', progress_pct: i < 3 ? 100 : 50, k: i }))
+];
+
+/** A double that ACTUALLY APPLIES .eq — see the header note on why this is non-negotiable. */
+function makeDb({ roadmaps = ROADMAPS, waves = WAVES } = {}) {
+  const src = { strategic_roadmaps: roadmaps, roadmap_waves: waves };
+  return {
+    from(table) {
+      let rows = [...(src[table] || [])];
+      const api = {
+        select() { return api; },
+        eq(col, val) { rows = rows.filter((r) => r[col] === val); return api; },
+        order(col, { ascending = true } = {}) {
+          rows.sort((a, b) => (a[col] < b[col] ? -1 : a[col] > b[col] ? 1 : 0) * (ascending ? 1 : -1));
+          return api;
+        },
+        limit(n) { rows = rows.slice(0, n); return api; },
+        then(res) { return Promise.resolve({ data: rows, error: null }).then(res); }
+      };
+      return api;
+    }
+  };
+}
+
+describe('TS-10: the test double is itself trustworthy', () => {
+  it('APPLIES .eq rather than merely recording it', async () => {
+    // If this fails, every other assertion in this file is void — a double that records filters
+    // without applying them hands the resolver all 4 rows for an .eq('status','active') query.
+    const db = makeDb();
+    const all = await db.from('strategic_roadmaps').select('*');
+    const activeOnly = await db.from('strategic_roadmaps').select('*').eq('status', 'active');
+    expect(all.data).toHaveLength(4);
+    expect(activeOnly.data).toHaveLength(1);
+    expect(activeOnly.data[0].id).toBe('active-poR');
+  });
+});
+
+describe('TS-1: the cron selects the ACTIVE roadmap, not the newest', () => {
+  it('picks the active plan of record even though an archived roadmap is newer', async () => {
+    const r = await gatherWaves(makeDb());
+    expect(r.state).toBe('resolved');
+    expect(r.roadmapId).toBe('active-poR');
+    expect(r.waveCount).toBe(8);
+  });
+
+  it('NEGATIVE CONTROL: the pre-fix predicate picks the archived roadmap on this same fixture', async () => {
+    // The shipped query, reproduced verbatim. If this ever stops returning 'arch-newest', the
+    // fixture has lost the property that makes the test above meaningful.
+    const db = makeDb();
+    const { data } = await db.from('strategic_roadmaps').select('id, status, created_at').order('created_at', { ascending: false }).limit(1);
+    expect(data[0].id).toBe('arch-newest');
+    expect(data[0].status).toBe('archived');
+  });
+});
+
+describe('FR-2 / TS-2, TS-3, TS-11: the four states are PAIRWISE DISTINCT', () => {
+  it('renders ambiguity as ambiguity, never as absence', async () => {
+    // Pre-fix, zero-active and two-active BOTH rendered "waves 0/N done" — provably
+    // indistinguishable. This is the assertion that would have caught that.
+    const twoActive = ROADMAPS.map((r) => ({ ...r, status: 'active' }));
+    const r = await gatherWaves(makeDb({ roadmaps: twoActive }));
+    expect(r.state).toBe('ambiguous');
+    const line = formatRoadmapLine(r);
+    expect(line).toMatch(/AMBIGUOUS/);
+    expect(line).not.toMatch(/no active roadmap/);
+  });
+
+  it('renders genuine absence as absence', async () => {
+    const r = await gatherWaves(makeDb({ roadmaps: [] }));
+    expect(r.state).toBe('none');
+    expect(formatRoadmapLine(r)).toMatch(/no active roadmap/);
+  });
+
+  it('an active roadmap with zero waves is NOT "no active roadmap"', async () => {
+    const r = await gatherWaves(makeDb({ waves: [] }));
+    expect(r.state).toBe('resolved');
+    expect(formatRoadmapLine(r)).not.toMatch(/no active roadmap/);
+  });
+
+  it('all four states produce mutually different lines', async () => {
+    const lines = [
+      formatRoadmapLine(await gatherWaves(makeDb({ roadmaps: [] }))),
+      formatRoadmapLine(await gatherWaves(makeDb({ roadmaps: ROADMAPS.map((r) => ({ ...r, status: 'active' })) }))),
+      formatRoadmapLine(await gatherWaves(makeDb())),
+      formatRoadmapLine({ state: 'unavailable' })
+    ];
+    expect(new Set(lines).size).toBe(lines.length);
+  });
+});
+
+describe('TS-11: avgPct is asserted, not just waveCount', () => {
+  it('averages progress across the ACTIVE roadmap only', async () => {
+    // 3 waves at 100 + 5 at 50 = 550/8 = 68.75 -> 69. Under the pre-fix reader this would be
+    // the archived roadmap's 0, so the number itself discriminates.
+    const r = await gatherWaves(makeDb());
+    expect(r.avgPct).toBe(69);
+    expect(r.doneWaves).toBe(3);
+  });
+});

--- a/tests/unit/roadmap/canonical-scoping.test.js
+++ b/tests/unit/roadmap/canonical-scoping.test.js
@@ -18,6 +18,7 @@
  */
 import { describe, it, expect } from 'vitest';
 import { gatherWaves, formatRoadmapLine } from '../../../scripts/cron/chairman-morning-review-sweep.mjs';
+import { dispositionCoverage } from '../../../scripts/eva-distill-brainstorm.js';
 
 const ROADMAPS = [
   { id: 'arch-newest', status: 'archived', created_at: '2026-07-17T15:49:00Z' },
@@ -124,5 +125,99 @@ describe('TS-11: avgPct is asserted, not just waveCount', () => {
     const r = await gatherWaves(makeDb());
     expect(r.avgPct).toBe(69);
     expect(r.doneWaves).toBe(3);
+  });
+});
+
+/**
+ * FR-3 / TS-4, TS-5 — the disposition-coverage gauge.
+ *
+ * Needs a second double because this path uses head-count queries
+ * (`.select('id', {count:'exact', head:true})`) plus `.in()` and `.neq()`, which the roadmap
+ * double above does not model. It applies every operator it receives, same rule as TS-10.
+ */
+function makeCountDb({ roadmaps = ROADMAPS, waves = WAVES_WITH_IDS, items = ITEMS } = {}) {
+  const src = { strategic_roadmaps: roadmaps, roadmap_waves: waves, roadmap_wave_items: items };
+  return {
+    from(table) {
+      let rows = [...(src[table] || [])];
+      let counting = false;
+      const api = {
+        select(_c, opts) { counting = Boolean(opts?.count); return api; },
+        eq(col, val) { rows = rows.filter((r) => r[col] === val); return api; },
+        neq(col, val) { rows = rows.filter((r) => r[col] !== val); return api; },
+        in(col, vals) { rows = rows.filter((r) => vals.includes(r[col])); return api; },
+        then(res) {
+          return Promise.resolve(counting ? { count: rows.length, error: null } : { data: rows, error: null }).then(res);
+        }
+      };
+      return api;
+    }
+  };
+}
+
+const WAVES_WITH_IDS = [
+  ...Array.from({ length: 4 }, (_, i) => ({ id: `an-${i}`, roadmap_id: 'arch-newest', status: 'proposed', progress_pct: 0 })),
+  ...Array.from({ length: 8 }, (_, i) => ({ id: `po-${i}`, roadmap_id: 'active-poR', status: 'approved', progress_pct: 50 })),
+  ...Array.from({ length: 6 }, (_, i) => ({ id: `ao-${i}`, roadmap_id: 'arch-oldest', status: 'proposed', progress_pct: 0 }))
+];
+const ITEMS = [
+  // Canonical roadmap: 10 items, 4 dispositioned -> 4/10 = 40%
+  ...Array.from({ length: 10 }, (_, i) => ({ id: `p${i}`, wave_id: 'po-0', item_disposition: i < 4 ? 'promoted' : 'pending' })),
+  // Orphans under the NEWEST archived roadmap: all pending (the July-incident shape)
+  ...Array.from({ length: 40 }, (_, i) => ({ id: `n${i}`, wave_id: 'an-0', item_disposition: 'pending' })),
+  // Orphans under the OLDEST archived roadmap: SOME NON-PENDING (the real ed12bf74 shape).
+  // This is what makes TS-5 discriminating — a denominator-only fix survives all-pending
+  // orphans and dies here.
+  ...Array.from({ length: 50 }, (_, i) => ({ id: `o${i}`, wave_id: 'ao-0', item_disposition: i < 20 ? 'promoted' : 'pending' }))
+];
+
+describe('FR-3 / TS-4: the coverage gauge is scoped to the canonical roadmap', () => {
+  it('counts only canonical items in BOTH numerator and denominator', async () => {
+    const r = await dispositionCoverage(makeCountDb());
+    expect(r.status).toBe('ok');
+    expect(r.numerator).toBe(4);
+    expect(r.denominator).toBe(10);
+  });
+
+  it('is unmoved by adding or removing archived-roadmap items', async () => {
+    const withOrphans = await dispositionCoverage(makeCountDb());
+    const withoutOrphans = await dispositionCoverage(
+      makeCountDb({ items: ITEMS.filter((i) => i.wave_id === 'po-0') })
+    );
+    expect(withOrphans.value).toBe(withoutOrphans.value);
+  });
+
+  it('NEGATIVE CONTROL: the unscoped counts differ, so this fixture can tell fixed from broken', async () => {
+    // Pre-fix: 100 items total, 24 non-pending -> 24%. Post-fix: 4/10 -> 40%.
+    const allItems = ITEMS.length;
+    const allNonPending = ITEMS.filter((i) => i.item_disposition !== 'pending').length;
+    expect(allNonPending / allItems).not.toBe(4 / 10);
+  });
+});
+
+describe('FR-3 / TS-5: the fix is not accidentally correct', () => {
+  it('excludes NON-pending orphan items from the numerator too', async () => {
+    // 20 of the archived-roadmap items are 'promoted'. A fix that scoped only the denominator
+    // would report 24/10 here — a ratio above 1. Asserting the numerator catches that.
+    const r = await dispositionCoverage(makeCountDb());
+    expect(r.numerator).toBe(4);
+    expect(r.value).toBeLessThanOrEqual(1);
+  });
+});
+
+describe('FR-3: non-resolved states are distinct, never an empty corpus', () => {
+  it('reports no active roadmap distinctly', async () => {
+    const r = await dispositionCoverage(makeCountDb({ roadmaps: [] }));
+    expect(r.status).toBe('unknown');
+    expect(r.detail).toMatch(/no active roadmap/);
+    expect(r.detail).not.toMatch(/empty corpus/);
+  });
+
+  it('reports ambiguity distinctly rather than as an empty corpus', async () => {
+    const allActive = ROADMAPS.map((r) => ({ ...r, status: 'active' }));
+    const r = await dispositionCoverage(makeCountDb({ roadmaps: allActive }));
+    expect(r.status).toBe('unknown');
+    expect(r.detail).toMatch(/ambiguous/i);
+    expect(r.detail).not.toMatch(/empty corpus/);
   });
 });

--- a/tests/unit/roadmap/full-create-guard.test.js
+++ b/tests/unit/roadmap/full-create-guard.test.js
@@ -1,0 +1,77 @@
+/**
+ * SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-5.
+ *
+ * This guard survived mutation TWICE in the EXEC adversarial review — both the refusal and the
+ * --reason requirement could be deleted with the whole suite still green — because it lived
+ * inline in roadmap-generate.js main(), which self-invokes at module load and therefore cannot be
+ * imported by a test. Extracting the predicate is what makes these assertions possible at all.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  evaluateFullCreate,
+  roadmapsToArchive,
+  REFUSE_EXISTING,
+  REFUSE_REASON_REQUIRED,
+} from '../../../lib/roadmap/full-create-guard.js';
+
+const draft = { id: 'rm-draft', title: 'EVA Intake Roadmap', status: 'draft' };
+const active = { id: 'rm-active', title: 'LEO Roadmap', status: 'active' };
+
+describe('FR-5: --full may bootstrap, but may not fork', () => {
+  it('allows creation when nothing non-archived exists (the bootstrap case)', () => {
+    expect(evaluateFullCreate([], {})).toMatchObject({ allow: true });
+  });
+
+  it('REFUSES when a DRAFT roadmap already exists — the actual 2026-07-17 incident shape', () => {
+    // My first version of this guard asked "does an ACTIVE roadmap exist". createRoadmap()
+    // inserts status:'draft' and only approveSequence flips it to 'active', so that guard could
+    // never have fired on the duplicate DRAFT rows (a89b078b, 8ffa7fdf) it was written to prevent.
+    // If this assertion ever flips to allow:true, that regression is back.
+    const v = evaluateFullCreate([draft], {});
+    expect(v.allow).toBe(false);
+    expect(v.refusal).toBe(REFUSE_EXISTING);
+  });
+
+  it('REFUSES when an ACTIVE roadmap already exists', () => {
+    expect(evaluateFullCreate([active], {})).toMatchObject({ allow: false, refusal: REFUSE_EXISTING });
+  });
+
+  it('archived roadmaps do not block — they are not passed in, and an empty live set allows', () => {
+    // The caller filters with .neq('status','archived'); this documents the contract that the
+    // predicate sees only live rows, so archiving is genuinely the way to unblock --full.
+    expect(evaluateFullCreate([], { }).allow).toBe(true);
+  });
+});
+
+describe('FR-5: the override is explicit, reasoned, and total', () => {
+  it('--replace-active WITHOUT a reason is refused, not silently allowed', () => {
+    const v = evaluateFullCreate([active], { replaceActive: true });
+    expect(v.allow).toBe(false);
+    expect(v.refusal).toBe(REFUSE_REASON_REQUIRED);
+  });
+
+  it('a whitespace-only reason is not a reason', () => {
+    // An unaudited override that logs "" is the failure this is guarding, not a formatting nit.
+    expect(evaluateFullCreate([active], { replaceActive: true, replaceReason: '   ' }))
+      .toMatchObject({ allow: false, refusal: REFUSE_REASON_REQUIRED });
+  });
+
+  it('--replace-active WITH a reason allows, and flags itself as an override', () => {
+    const v = evaluateFullCreate([active], { replaceActive: true, replaceReason: 'reclustering after Q3 reset' });
+    expect(v).toMatchObject({ allow: true, override: true });
+    expect(v.existing).toHaveLength(1);
+  });
+
+  it('an override must archive EVERY live roadmap, not just the first', () => {
+    // Replacing one of two leaves the duplicate state the guard exists to prevent. An override
+    // named "replace" that half-replaces is worse than none, because the operator believes the
+    // old one is gone.
+    expect(roadmapsToArchive([active, draft])).toEqual(['rm-active', 'rm-draft']);
+  });
+
+  it('tolerates malformed input rather than throwing mid-create', () => {
+    expect(evaluateFullCreate(null, {}).allow).toBe(true);
+    expect(roadmapsToArchive(null)).toEqual([]);
+    expect(roadmapsToArchive([{ title: 'no id' }])).toEqual([]);
+  });
+});

--- a/tests/unit/roadmap/full-create-guard.test.js
+++ b/tests/unit/roadmap/full-create-guard.test.js
@@ -7,12 +7,19 @@
  * imported by a test. Extracting the predicate is what makes these assertions possible at all.
  */
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
   evaluateFullCreate,
   roadmapsToArchive,
   REFUSE_EXISTING,
   REFUSE_REASON_REQUIRED,
+  AUDIT_SEVERITY,
+  VALID_AUDIT_SEVERITIES,
 } from '../../../lib/roadmap/full-create-guard.js';
+
+const ROOT = fileURLToPath(new URL('../../../', import.meta.url));
 
 const draft = { id: 'rm-draft', title: 'EVA Intake Roadmap', status: 'draft' };
 const active = { id: 'rm-active', title: 'LEO Roadmap', status: 'active' };
@@ -73,5 +80,60 @@ describe('FR-5: the override is explicit, reasoned, and total', () => {
     expect(evaluateFullCreate(null, {}).allow).toBe(true);
     expect(roadmapsToArchive(null)).toEqual([]);
     expect(roadmapsToArchive([{ title: 'no id' }])).toEqual([]);
+  });
+
+  it('a bare --reason that swallowed the NEXT flag is not a reason', () => {
+    // SEC-4 from the EXEC security review: `--reason --force-reassign` set
+    // reason="--force-reassign", which sailed through a plain trim check and archived. Argv
+    // parsing cannot tell a missing value from the next flag, so the guard has to.
+    for (const swallowed of ['--force-reassign', '--dry-run', '--full']) {
+      expect(evaluateFullCreate([active], { replaceActive: true, replaceReason: swallowed }))
+        .toMatchObject({ allow: false, refusal: REFUSE_REASON_REQUIRED });
+    }
+    // A legitimate reason that merely CONTAINS a dash is still fine.
+    expect(evaluateFullCreate([active], { replaceActive: true, replaceReason: 'post-Q3 re-cluster' }).allow).toBe(true);
+  });
+});
+
+describe('FR-5: the audit severity value is CHECK-constrained — assert it, do not re-guess it', () => {
+  // *** THIS TEST EXISTS BECAUSE ITS ABSENCE LET A BROKEN DESTRUCTIVE PATH SHIP 37/37 GREEN. ***
+  // The EXEC security review's closing note was that full-create-guard.test.js covered the
+  // predicate thoroughly and asserted NOTHING about the insert payload. I had shipped
+  // severity:'high', which audit_log_severity_check REJECTS (probed live: 23514) — and because
+  // supabase-js RETURNS {error} rather than throwing, the surrounding try/catch was dead code and
+  // the override wrote no audit row at all while printing "Archived N roadmap(s)".
+  it('is one of the values the live CHECK constraint accepts', () => {
+    expect(VALID_AUDIT_SEVERITIES).toContain(AUDIT_SEVERITY);
+  });
+
+  it('is NOT one of the plausible-looking values the constraint rejects', () => {
+    // 'high' is the one I actually shipped; the others are the same mistake one keystroke away.
+    for (const bad of ['high', 'low', 'medium', 'HIGH', 'Critical', '']) {
+      expect(VALID_AUDIT_SEVERITIES).not.toContain(bad);
+    }
+  });
+
+  it('the generator imports the shared constant rather than inlining a literal severity', () => {
+    // A second copy of this value is a second chance to get it wrong, and the failure mode is
+    // silent.
+    const src = readFileSync(path.join(ROOT, 'scripts/roadmap-generate.js'), 'utf8');
+    expect(src).toContain('AUDIT_SEVERITY');
+    expect(src).not.toMatch(/severity:\s*['"]high['"]/);
+  });
+
+  it('the generator CREATES before it ARCHIVES, and gates the archive on the audit row', () => {
+    // SEC-2 was a data-loss path, not an ordering preference: runFull() calls process.exit(0)
+    // when the classified-intake queue is empty (a normal state), so archiving first destroyed
+    // the plan of record and created nothing. There is no transaction available here, so
+    // ordering IS the atomicity. Asserted on source because main() self-invokes and cannot be
+    // imported; the ordering is the property that matters and it is not otherwise observable.
+    const src = readFileSync(path.join(ROOT, 'scripts/roadmap-generate.js'), 'utf8');
+    const runFullAt = src.indexOf('await runFull(');
+    const archiveAt = src.indexOf("update({ status: 'archived' })");
+    const auditAt = src.indexOf("event_type: 'ROADMAP_FULL_REPLACE_ACTIVE'");
+    expect(runFullAt).toBeGreaterThan(-1);
+    expect(archiveAt).toBeGreaterThan(runFullAt);   // create first
+    expect(auditAt).toBeLessThan(archiveAt);        // audit gates the destructive write
+    expect(src).toContain('REFUSING to archive: the audit row could not be written');
   });
 });

--- a/tests/unit/sourcing-engine/roadmap-link-exception.test.js
+++ b/tests/unit/sourcing-engine/roadmap-link-exception.test.js
@@ -20,6 +20,20 @@ import { computePlanAdherence } from '../../../scripts/adam-coordinator-health.m
 
 const NOW = '2026-07-25T22:00:00.000Z';
 
+/**
+ * SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-4: computeWaveLinkageCoverage now resolves
+ * the canonical roadmap before reading items, so any double feeding it must answer these two
+ * tables. Exactly ONE active roadmap, because resolveCanonicalRoadmap deliberately throws on
+ * more than one and these suites are not testing that path.
+ *
+ * These fixtures are incidental to what this file asserts (exception records must be inert to
+ * the linkage gauge) — they exist only to keep the function reachable.
+ */
+const CANONICAL_ROADMAP_TABLES = {
+  strategic_roadmaps: { select: () => ({ eq: async () => ({ data: [{ id: 'rm-canon', title: 'canonical', status: 'active', current_baseline_version: 0 }], error: null }) }) },
+  roadmap_waves: { select: () => ({ eq: async () => ({ data: [{ id: 'w-canon' }], error: null }) }) },
+};
+
 describe('buildRoadmapLinkException — FR-3 (record unconditionally, operator reason kept distinct)', () => {
   it('records a supplied operator reason verbatim and flags it as supplied', () => {
     const ex = buildRoadmapLinkException('SD-X-001', '  urgent revenue false-gate, sourced in minutes  ', NOW);
@@ -106,7 +120,10 @@ describe('TS-4 — a recorded exception must NOT raise plan-linkage coverage', (
     return {
       from: (table) => ({
         strategic_directives_v2: { select: () => ({ not: () => terminal(sdRows) }) },
-        roadmap_wave_items: { select: () => ({ not: () => terminal([]) }) },
+        // SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-4: the items query is now
+        // roadmap-scoped, so the chain gains .in() ahead of .not().
+        roadmap_wave_items: { select: () => ({ in: () => ({ not: () => terminal([]) }) }) },
+        ...CANONICAL_ROADMAP_TABLES,
       })[table],
     };
   }
@@ -158,7 +175,8 @@ describe('FR-5 — computePlanAdherence surfaces the count on BOTH return branch
     }
     return {
       from: (table) => {
-        if (table === 'roadmap_wave_items') return { select: () => ({ not: () => terminal([]) }) };
+        if (CANONICAL_ROADMAP_TABLES[table]) return CANONICAL_ROADMAP_TABLES[table];
+        if (table === 'roadmap_wave_items') return { select: () => ({ in: () => ({ not: () => terminal([]) }) }) };
         if (table === 'strategic_directives_v2') {
           return {
             select: () => ({

--- a/tests/unit/wave-linkage-coverage.test.js
+++ b/tests/unit/wave-linkage-coverage.test.js
@@ -9,23 +9,33 @@ import { computeWaveLinkageCoverage, COVERAGE_THRESHOLD } from '../../lib/roadma
 // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 8: computeWaveLinkageCoverage
 // now paginates via fetchAllPaginated, so .not(...) must return a chainable builder
 // (.order() returns itself, .range() resolves the single page) rather than a bare Promise.
-function mockSupabase({ sds, items }) {
-  function terminal(data) {
-    const builder = {
-      order: () => builder,
-      range: async () => ({ data, error: null }),
-    };
-    return builder;
-  }
+// SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-4/TR-6: this double now APPLIES the
+// operators it receives instead of ignoring them. The previous version returned a fixed row set
+// from `.not()` regardless of arguments, so the roadmap scoping added by FR-4 would have been
+// invisible to it — a green suite proving nothing about the thing under test.
+//
+// Items default into the canonical wave, so the pre-existing tests keep their original meaning;
+// a test that wants an orphan item passes an explicit wave_id.
+function mockSupabase({ sds, items, roadmaps, waves } = {}) {
+  const R = roadmaps ?? [{ id: 'rm-canon', status: 'active' }];
+  const W = waves ?? [{ id: 'w-canon', roadmap_id: 'rm-canon' }];
+  const I = (items ?? []).map((i) => ({ wave_id: 'w-canon', ...i }));
+  const src = { strategic_directives_v2: sds ?? [], roadmap_wave_items: I, strategic_roadmaps: R, roadmap_waves: W };
+
   return {
-    from: (table) => ({
-      strategic_directives_v2: {
-        select: () => ({ not: () => terminal(sds) }),
-      },
-      roadmap_wave_items: {
-        select: () => ({ not: () => terminal(items) }),
-      },
-    })[table],
+    from(table) {
+      let rows = [...(src[table] || [])];
+      const b = {
+        select: () => b,
+        eq: (c, v) => { rows = rows.filter((r) => r[c] === v); return b; },
+        in: (c, vs) => { rows = rows.filter((r) => vs.includes(r[c])); return b; },
+        not: (c, _op, _v) => { rows = rows.filter((r) => r[c] != null); return b; },
+        order: () => b,
+        range: async () => ({ data: rows, error: null }),
+        then: (res) => Promise.resolve({ data: rows, error: null }).then(res),
+      };
+      return b;
+    },
   };
 }
 
@@ -96,5 +106,59 @@ describe('computeWaveLinkageCoverage', () => {
     expect(r.coverage).toBe(1);
     expect(r.starved).toBe(false);
     expect(r.unlinkedKeys).toEqual([]);
+  });
+});
+
+/**
+ * SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-4.
+ *
+ * Measured live 2026-07-29 before the fix: 114 roadmap_wave_items belonging to ARCHIVED
+ * roadmaps carried promoted_to_sd_key, and 99 SD keys were counted as linked while appearing
+ * in NO canonical wave item at all — 28.7% of the promoted universe.
+ *
+ * Those 114 links all belong to ed12bf74, a March 2026 roadmap that is NOT one of the
+ * duplicates this SD cleans up. So deleting this SD's duplicate rows would not have corrected
+ * this reader by a single link. That is the whole argument for fixing the predicate.
+ */
+describe('FR-4: linkage is scoped to the canonical roadmap', () => {
+  const twoRoadmaps = {
+    roadmaps: [{ id: 'rm-canon', status: 'active' }, { id: 'rm-old', status: 'archived' }],
+    waves: [{ id: 'w-canon', roadmap_id: 'rm-canon' }, { id: 'w-orphan', roadmap_id: 'rm-old' }],
+  };
+
+  it('does NOT count an SD linked only from an archived roadmap', async () => {
+    const supabase = mockSupabase({
+      ...twoRoadmaps,
+      sds: [sd({ id: '1', key: 'SD-A' }), sd({ id: '2', key: 'SD-ORPHANLINK' })],
+      items: [
+        { promoted_to_sd_key: 'SD-A', wave_id: 'w-canon' },
+        { promoted_to_sd_key: 'SD-ORPHANLINK', wave_id: 'w-orphan' }, // archived roadmap
+      ],
+    });
+    const r = await computeWaveLinkageCoverage(supabase);
+    expect(r.unlinkedKeys).toContain('SD-ORPHANLINK');
+    expect(r.coverage).toBe(0.5);
+  });
+
+  it('NEGATIVE CONTROL: unscoped, both would count as linked', async () => {
+    // Same fixture with the orphan item moved into the canonical wave. If this did NOT differ
+    // from the case above, the fixture could not distinguish scoped from unscoped behaviour.
+    const supabase = mockSupabase({
+      ...twoRoadmaps,
+      sds: [sd({ id: '1', key: 'SD-A' }), sd({ id: '2', key: 'SD-ORPHANLINK' })],
+      items: [
+        { promoted_to_sd_key: 'SD-A', wave_id: 'w-canon' },
+        { promoted_to_sd_key: 'SD-ORPHANLINK', wave_id: 'w-canon' },
+      ],
+    });
+    const r = await computeWaveLinkageCoverage(supabase);
+    expect(r.coverage).toBe(1);
+  });
+
+  it('refuses rather than computing over an unscoped corpus when no roadmap is active', async () => {
+    // Fail-closed: a coverage number computed over every roadmap is worse than no number,
+    // because it looks exactly like a valid one.
+    const supabase = mockSupabase({ roadmaps: [], waves: [], sds: [sd({ id: '1', key: 'SD-A' })], items: [] });
+    await expect(computeWaveLinkageCoverage(supabase)).rejects.toThrow(/no active roadmap/);
   });
 });


### PR DESCRIPTION
## Summary

`gatherWaves()` in the 05:45 ET chairman morning-review cron selected `strategic_roadmaps` ordered by `created_at desc limit 1`. It **selected** `status` and never **filtered** on it, so it returned whichever row happened to be newest.

Measured live on 2026-07-29, with all four roadmaps still present:

| | roadmap picked | rendered line |
|---|---|---|
| pre-fix | `8ffa7fdf` (**archived**, 4 waves, 0 dispositioned) | `Roadmap: 0% build, waves 0/4 done` |
| post-fix | `3aa2f3e2` (**active**, 8 waves, plan of record) | `Roadmap: 43% build, waves 0/8 done` |

The chairman has been reading **0% build** every morning. The real figure is **43%**.

## Why the fix is the predicate, not the data

This SD is chartered to remove duplicate roadmap data. Deleting those rows would have made this query return the right answer **by accident**, while leaving the unscoped predicate alive to pick the next wrong roadmap the moment another row was created — and destroying the evidence that the predicate was broken. So the duplicates stay; they are the fixture.

Routed through the existing `lib/roadmap/canonical-roadmap.js` resolver rather than adding a sixth hand-rolled status filter. The defective readers are precisely the ones that hand-rolled their own selection.

## FR-2: the fix could have reintroduced the bug it fixes

`resolveCanonicalRoadmap` is deliberately fail-loud — it **throws** when more than one roadmap is active. The old bare `try/catch` collapsed every failure into `waveCount: 0`, which the caller rendered as `"(no active roadmap)"`. Dropping a fail-loud resolver into a fail-soft call site converts a loud, correct signal into a confident falsehood.

Pre-fix, zero-active and two-active rendered **identically**. `gatherWaves` now returns a tagged state and the four cases render pairwise distinctly; an active-but-empty roadmap is no longer reported as no roadmap at all.

## The test double is under test

The pre-existing mock in this repo **records** `.eq/.order/.limit` and applies none. Under it these tests *invert* — the broken code renders `waves 0/8 done` and looks correct, while the correct fix renders `AMBIGUOUS — 4 active roadmaps` and looks broken, because the resolver receives all four rows in answer to an `.eq('status','active')` query. That mock would have produced a green suite certifying the defect and penalising the fix. `TS-10` asserts the new double actually applies filters.

## Test plan

- `tests/unit/roadmap/canonical-scoping.test.js` — 8 tests, all passing.
- Fixture holds **4 roadmaps, exactly 1 active, newest archived** — the only shape in which an unscoped reader actually fails. A single-roadmap fixture passes against broken code and proves nothing.
- **Mutation-verified**: reverting the predicate fails 4 of 8 tests. Diff confirmed applied, so this is not a no-op mutation.
- Live negative control run against the real database with duplicates present (table above).

## Scope

FR-1/FR-2 of 8. Remaining in this SD: the coverage-gauge scoping (FR-3), five further readers pending individual verification (FR-4), the `--full` guard gap (FR-5), a corpus-wide invariant (FR-6), the `rung-progress-rollup` **write** path (FR-8). FR-7 (orphan-wave cascade) is built dry-run-only pending a routed delete-vs-archive decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)