### PR TITLE
chore(SD-LEO-INFRA-ACCOUNT-QUOTA-STRIP-001): add @approved-by header to account_usage_snapshots migration

### DIFF
--- a/.claude/.protocol-sync
+++ b/.claude/.protocol-sync
@@ -1,1 +1,1 @@
-{"timestamp":"2026-06-11T11:41:09.870Z","pid":48148,"stateFile":"C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.claude\\unified-session-state.json"}
+{"timestamp":"2026-07-27T15:29:46.348Z","pid":68020,"stateFile":"C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.claude\\unified-session-state.json"}

--- a/.claude/session-state.md
+++ b/.claude/session-state.md
@@ -1,20 +1,49 @@
 # LEO Protocol Session State
-**Last Updated**: 2026-03-24T00:00:00Z
-**Session Focus**: Worktree Cleanup (27 remaining)
+**Last Updated**: 2026-07-26 ~12:40 ET (Adam session, pre-compaction #2)
+**Session Focus**: LEO `/builder/sessions` UI — SHIPPED, awaiting the chairman's personal review
 
 ---
 
-## Current Task
-Worktree cleanup — 27 remaining worktrees need investigation before removal.
-See memory: `project_worktree_cleanup_2026-03-24.md` for full list.
+## CHAIRMAN'S GOALS (standing, his words)
+1. **"I want that Leo app done. That's my main focus."** — the Sessions UI, reviewed by him.
+2. **"I want to be able to transition out of cursor."** — now the top remaining goal.
+3. **Governance**: *"you have governance and oversight over the coordinator, and it's also your goal to drive progress."*
+4. He is impatient with back-and-forth and token burn. Ultracode is ON — be exhaustive and RIGHT, not fast.
 
-## Immediate Next Steps
-1. Run `git worktree prune` to clean 2 prunable worktrees
-2. For each remaining worktree, check if unpushed commits are superseded on main
-3. Remove safe ones, flag any with unique unmerged work
+## STATUS: THE UI SHIPPED — HE STILL CANNOT SEE IT
+- **ehg PR #774** merged 16:00:17Z + **EHG_Engineer PR #6519** merged 15:59:42Z. Backend-first, deliberately (frontend-first would render element 5 "not captured" for every row).
+- `BuilderSessionsPage.tsx` on `origin/main`: **467 lines** (was 252). I verified **all 11 elements present**; 2 declared PARTIAL by the author (element 11's *hide* has no backend route; it reports "not wired" rather than silently failing).
+- **BLOCKER**: Vite on :8080 (pid 19520, cwd `_EHG\ehg`) serves the **ehg main tree**, which is checked out on `chore/untrack-auth-storage-state` = **PR #773**. So :8080 renders the OLD 252-line page.
+- **I DECIDED PR #773 LANDS** (routed to me): real security fix — tracked `.auth/user.json` holds a **live Supabase refresh token**; checks SUCCESS; open 4h+. Execution routed to the coordinator's ship path (CONST-002: I don't hand-merge).
+- **Hazard measured, not assumed**: coordinator + Golf both refused to switch that tree citing a live-session branch. I queried all 9 active sessions — **every `current_branch` reads `main`, none on that branch** — and ran the control (field populated 9/9, so the negative is real). Zero of the 4 modified files collide with the incoming diff. The switch is safe.
+- **TRAP**: `git pull` in that tree says *"Already up to date"* — true and misleading; it tracks the feature branch.
 
-## Key Context
-- All 27 remaining worktrees have SDs marked completed/cancelled in DB
-- Each has either unpushed commits or non-metadata uncommitted changes
-- Work was likely shipped via direct-to-main commits but worktree branches never cleaned
-- 20 worktrees already removed this session (6 clean + 14 metadata-only)
+## THE REVIEW GATE — DO NOT LET ANYONE CLOSE IT
+QF-20260726-642: `uat_verified=false`, gate in `verification_notes`. **Only his personal review of the rendered page closes it.** Tests, CI, merged PRs, and my element count are all explicitly insufficient — the first build passed every mechanical check and shipped 3 of 11.
+
+## THE SPEC — DO NOT RE-DERIVE
+`docs/design/leo-sessions-artifact-2026-07-26.png` — **UNTRACKED, not in git**. Durable copies: `Projects/_EHG/_design-backup/` and the scratchpad (md5 519a2155c81f7115b6090f9586fec20e, 144455 bytes). Full 11-element spec is in QF-642's description, along with the element-5 source pin and the not-captured render requirement.
+
+## MY BIGGEST ERROR TODAY — the lesson, not the incident
+I **verified a symptom first-hand and then RELAYED the mechanism** from Solomon without re-deriving it. The coordinator built on my relay, I told the chairman, an SD was filed on it. A 10-agent adversarial verification **refuted the mechanism entirely** (orphan tickers: 0, not 15; the "15" was a coincidence of two unrelated counts; re-parenting is impossible by construction).
+**Real cause**: `lib/fleet/session-liveness.cjs:59-64` parses `terminal_id` as `win-cc-{port}-{pid}`; live sessions write a bare UUID. `hasPidAlive` TRUE for **0 of 22** sessions — **dead since 2026-04-04**. Working resolver already exists at `stale-session-sweep.cjs:526-563`, never migrated.
+**Use `process_alive_at`** as the discriminator — the only column that separated dead from live with no overlap. `heartbeat_at` has 12+ writers; `is_alive` actively promotes corpses.
+SD-LEO-INFRA-PID-LIVENESS-DURABLE-VENUE-001 scope carries the full refutation (readback confirmed). **Foxtrot is building it.**
+
+## OPEN THREADS
+- **Cursor exit**: `SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001` and `-001-E` — both now claim-free after the dead-seat clearing. **Push these to live seats; this is his #2 goal.**
+- **Pending, needs a written response not an ack**: `review_request` id `796f7e73` — 8-SD bidirectional Coordinator↔Adam review.
+- Deferred by his sole-focus directive: solomon-health + plan-check adherence runs (~45h overdue); six MATERIALISE sourcing items.
+- **The LEO app is NOT on the roadmap** — `plan-check-status.mjs` returns Wave-1 items only, so his main focus isn't tracked by the plan-of-record tooling. Worth fixing.
+
+## FLEET STATE
+Shared root `EHG_Engineer` **behind=0** (the fast-forward landed — that one command cleared reap/sync/restart/relaunch/claims). Fleet **6 live, 0 dead** by PID. My own session has `pid=null`, so PID checks cannot evaluate it.
+
+## STANDING GOTCHAS (each cost a real error)
+- **Verify the mechanism, not just the symptom.** Separate evidence; say which is which.
+- **Run a control before believing a negative** — a field that is never populated returns the same empty answer.
+- **`heartbeat_at` / `is_alive` are NOT liveness.** PID is, when the resolver works.
+- Bash `/tmp` ≠ Node `/tmp` on Windows (Node resolves `C:\tmp`) — use the scratchpad path.
+- `adam-advisory` caps at **4096 chars**; CONST-010 blocks the words urgent/immediately/critical **even when quoting them**; the 2-hypothesis bar fires on model-cutoff-shaped claims — clear it with a real handoff check, then `--alarm-verified`.
+- `quick_fixes` has no `metadata` column (use `uat_verified`/`verification_notes`); QF key is `id`; `sms_relay_staging` uses `body_raw`/`received_at`/`drained_at`.
+- Check the **right repo** (ehg vs EHG_Engineer) and the **right tree** (working copy vs `origin/main`).

--- a/.workflow-patterns.json
+++ b/.workflow-patterns.json
@@ -4,5 +4,5 @@
   "form_validation": [],
   "loading_patterns": [],
   "navigation": [],
-  "last_scan": "2026-07-01T23:16:44.644Z"
+  "last_scan": "2026-07-25T21:54:14.498Z"
 }

--- a/database/migrations/20260728_account_usage_snapshots.sql
+++ b/database/migrations/20260728_account_usage_snapshots.sql
@@ -1,6 +1,24 @@
 -- Account quota snapshots — retain the last-known reading per account.
 -- SD-LEO-INFRA-ACCOUNT-QUOTA-STRIP-001 (FR-4/FR-6).
 --
+-- @approved-by: codestreetlabs@gmail.com
+--
+-- PROVENANCE OF THAT HEADER, so the artifact carries the truth rather than just the token:
+-- the approval is the chairman's, given verbally 2026-07-28 ~17:26 ET in TWO parts (the table,
+-- then the GRANT/REVOKE permission changes) and recorded at chairman_decisions
+-- 642965c4-6ca9-42e1-8713-dd431eb6a435 (decision_type=ddl_approval, status=approved), then
+-- reaffirmed live at the keyboard 2026-07-29 ("I approve the migration"). The LINE was typed by
+-- adam:39b3e4f6 at his explicit direction after the guard rejected on the approver factor; Adam
+-- declined to add it unprompted and did so only when asked directly. The email is
+-- codestreetlabs@gmail.com because the guard matches this header against the INVOKER's
+-- `git config --get user.email`, not against the approver's personal address.
+--
+-- NOTE FOR WHOEVER AUDITS THIS: the approval record pins sha256
+-- 5a2c897a2da3d537fabd8c40644d6baedf7e38d7825b754a04f3e50730aeabea, computed BEFORE this header
+-- existed. That artifact could never have passed its own approver guard, so the recorded hash is
+-- necessarily stale the moment the migration becomes appliable. The hash must be re-pinned after
+-- this edit; a chairman-gated approval that pins an unappliable hash is a real gap, not a typo.
+--
 -- WHY THIS TABLE EXISTS. The sessions-page quota strip discards a reading the moment an account
 -- stops being readable, so an EXHAUSTED account collapses to "Unavailable" and the final value —
 -- the one that matters most, 100% across the board just before reset — is erased. No usage-snapshot

--- a/docs/04_features/account-quota-usage-strip.md
+++ b/docs/04_features/account-quota-usage-strip.md
@@ -1,6 +1,16 @@
 # Per-account quota usage strip
 
-**SD-LEO-FEAT-ACCOUNT-USAGE-STRIP-001** · backend `lib/fleet/account-usage-reader.cjs` · UI `ehg:src/components/chairman-v3/AccountUsageStrip.tsx`
+**SD-LEO-FEAT-ACCOUNT-USAGE-STRIP-001**, extended by **SD-LEO-INFRA-ACCOUNT-QUOTA-STRIP-001** · backend `lib/fleet/account-usage-reader.cjs`, `lib/fleet/account-usage-snapshot-writer.cjs` · UI `ehg:src/components/chairman-v3/AccountUsageStrip.tsx`
+
+<!--
+Category: Feature
+Status: Approved
+Version: 2.0.0
+Author: EXEC (Alpha-2)
+Last Updated: 2026-07-28
+Tags: fleet, quota, accounts, observability
+-->
+
 
 Renders each Max account's **weekly** quota use at the top of `/builder/sessions`.
 
@@ -24,7 +34,17 @@ Response fields consumed: `seven_day.utilization`, `five_hour.utilization`, and 
 
 ## Fail visibly — the load-bearing rule
 
-Every failure resolves to `{state:'unavailable', reason}` where `reason` is a **closed** enum: `not_configured | unauthorized | unexpected_shape | timeout | unreachable`.
+Every failure resolves to `{state:'unavailable', reason}` where `reason` is a **closed** enum: `not_configured | unauthorized | unexpected_shape | timeout | unreachable | exhausted | duplicate_identity`.
+
+### `exhausted` is not `unreachable` (SD-LEO-INFRA-ACCOUNT-QUOTA-STRIP-001)
+
+An account that is **out of quota answered** — it is the fact that explains why the fleet stopped. An unreachable one told us nothing. Until this SD a 429 fell through the `!res.ok` branch into `unreachable`, so "exhausted" was not merely un-rendered, it was **unrepresentable**: the reader had no way to say it and the strip had no way to show it. The 429 check therefore sits **before** the catch-all, and the strip renders *"Quota spent"* (rose) distinctly from *"Unavailable"* (amber).
+
+### `duplicate_identity` — refusing to attribute
+
+A duplicate is only visible **across** slots: one account read in isolation looks perfectly healthy, which is exactly why the defect reached the chairman's screen instead of a log. When two registry slots resolve to the same account we cannot say whose usage a number belongs to, so the honest output is **no figure at all** — never a number under a label we cannot vouch for. That refusal is enforced in three places (reader, `withLastKnown`, and the component), because the number could otherwise re-enter through the retained-value path.
+
+**This fires on the live fleet today**: `Code Street Labs` and `Rick Felix 2000` currently resolve to the same account, and `Deep Soul Sessions` is `not_configured` — so the strip has **zero** readable accounts. That is the detector working, not failing; it is a provisioning fault, routed to the coordinator.
 
 On `unavailable` the percentage **key is absent, not null**. A nullable percentage is what produces the forbidden dash — see `buildNamedAccountChips` → `{wkPct: null}` → `fleet-panel-format.js` rendering `wk --% used`.
 
@@ -63,9 +83,48 @@ The reader caches for **60s** so the page's 15s poll cannot hammer an undocument
 
 `GET /api/fleet-panel?refreshUsage=1` bypasses the cache. That backs the strip's **Refresh** control — the cache is there to stop polling pressure, not to block a deliberate re-read after an operator fixes an account.
 
+## Retained history — the last known reading
+
+*(SD-LEO-INFRA-ACCOUNT-QUOTA-STRIP-001 · `lib/fleet/account-usage-snapshot-writer.cjs`)*
+
+When an account stops being readable, its **final** reading — the number that explains why the fleet stopped — used to vanish with it. Successful reads are now appended to `account_usage_snapshots`, and an unavailable account renders `Last known 92% · 3h ago` beneath its state.
+
+Three rules make this safe rather than dangerous:
+
+- **History is added, never substituted.** The live `state`/`reason` are preserved exactly and history arrives under separate `lastKnown*` keys. Overwriting the live state with a stored one would make a stale value indistinguishable from a current reading — the failure this feature exists to *end*, not relocate.
+- **The age is relative, never a bare clock.** `formatClock` renders hour:minute with no date, so a value retained three days ago read exactly like one from this morning. `formatAge` carries its own staleness (`3d ago`) and cannot be misread.
+- **"Last KNOWN" means the last row that actually carried a number.** The lookup filters on `weekly_pct`/`five_hour_pct` being non-null and runs **one query per account**. Both are load-bearing: the route persists the current reading *before* reading history back, so an exhausted account's just-written NULL row would otherwise shadow the very number being recovered; and a row budget shared across accounts let the busy accounts crowd an exhausted one out of the window within about half an hour, while exhaustion lasts *hours*.
+
+Persistence is **wholly fail-soft** — no client, no table, transport error and malformed reading all resolve to a counted skip. It is a side effect of rendering the strip and must never break it.
+
+> **The migration is TIER-2 chairman-gated, so this makes history *possible*, not *present*.** Nothing is retained until `database/migrations/20260728_account_usage_snapshots.sql` is applied. Until then `pending_migration: true` appears in the write log — an expected state, not an alarm.
+
+### Operating it
+
+| Concern | Where |
+|---|---|
+| Cadence | `scripts/cron/account-usage-sample.mjs`, every 15 min, registered `standard_loop:account-usage-sample` |
+| Retention | `lib/retention/policies.js` → `account_usage_snapshots`, 90-day archive on `created_at` |
+| Table | `account_usage_snapshots` — name, percentages, reset times, `fetched_at`, state, `account_uuid8` |
+
+**Why a cron and not the page.** Snapshot writes began as a side effect of rendering the panel, which meant history existed only while somebody was watching — and the fleet going down is precisely when nobody is. The record would have been thinnest in exactly the window that needed it. It is hosted locally rather than in GitHub Actions because the meters need credentials that live in this host's config directories; a GHA runner would report the whole fleet `not_configured` — a green cron manufacturing a false record.
+
+## `FLEET_ACCOUNT_IDENTITY_MAP` (optional, currently unset)
+
+JSON mapping `accountUuid8 → display name`, letting a slot be labelled from its **credentials** rather than its directory. Malformed config never breaks the strip (it falls back to registry names), and control characters are stripped — the value reaches both the API response and a log line.
+
+Two collision rules, because a display name is not merely cosmetic: it is the key `account_usage_snapshots` stores under, so two slots sharing a name would share a history row-space and could show each other's numbers.
+
+- Two accounts mapped to the **same** label → the label is not applied; both slots keep their own names and fail as `duplicate_identity`.
+- A label equal to a **different** slot's own registry name → same treatment. Self-mapping (a slot's own account mapped to its own name) is legitimate and contests nothing.
+
 ## Boundary
 
-The bearer token is **request-local**: never returned, cached, logged or persisted. No config directory, profile name or file path appears in any browser-bound field. Only the closed enum values reach the client, so a raw upstream body or transport error cannot escape through `reason`.
+The bearer token is **request-local**: never returned, cached, logged or persisted. No config directory, profile name or file path appears in any browser-bound field. Only the closed enum values reach the client, so a raw upstream body or transport error cannot escape through `reason`. The credentialed request sets `redirect: 'error'` — undici happens to strip `Authorization` cross-origin, but a same-origin 302 *does* forward it, so refusing outright keeps the guarantee local to the code holding the token.
+
+**The email is a resolution input only.** It is never a stored column, log line, error message or API field — `toSnapshotRow` is a fixed 8-key literal with no spread, and a unit test asserts the exact key set as a whitelist so a future field cannot slip in. `account_usage_snapshots` has RLS enabled with a service-role-only policy plus `REVOKE ALL FROM anon, authenticated`; the REVOKE is load-bearing, since `pg_default_acl` auto-grants public-schema tables to anon and authenticated.
+
+> Note: `/api/fleet-panel` already emits `account_email` from `claude_sessions.metadata` via a **different, pre-existing** field (QF-20260726-642). This SD's table stays email-free; if "no email in fleet surfaces" is meant to be a global invariant, that field is where to look next.
 
 The containing control on `/api/fleet-panel` is the **loopback bind** in `server/index.js`, *not* the operator JWT — the route uses `optionalAuth`, and `requireAuth` accepts any valid JWT from the shared Supabase project with no role check. The payload is therefore safe on its own terms rather than relying on who can call it.
 

--- a/templates/session-prologue.md
+++ b/templates/session-prologue.md
@@ -1,15 +1,6 @@
-# Session Prologue - LEO Protocol v4.4.1
+# Session Prologue - LEO Protocol v4.3.3 - UI Parity Governance 4.4.1
 *Copy-paste this at session start to align Claude with EHG_Engineer practices*
-*Generated: 2025-12-03T23:21:50.817Z*
-
-## Operating Mode
-
-At SessionStart, `scripts/hooks/session-role-orient.cjs` emits a `[ROLE]` block naming your role and channel:
-- **SOLO** — no active coordinator. Canonical pause points apply. Fall through to `/leo assist` Phase 1 when `/leo next` returns no workable SD under AUTO-PROCEED=ON.
-- **WORKER** — under coordinator. `/signal <type> "<body>"` when recurrence (gate 2×, RCA 2×, tool 3×) | bypass intent | spec/PRD friction | harness-bug recognized | memory-trend match.
-- **COORDINATOR** — drain worker signals via `/coordinator inbox`. 3+ matching signals within 60min auto-promote to feedback (category=harness_backlog).
-
-If you don't see a `[ROLE]` line at session start, the hook is unregistered or failed silently — check `.claude/settings.json` and run `echo '{"session_id":"<uuid>"}' | node scripts/hooks/session-role-orient.cjs` to probe.
+*Generated: 2026-07-25T02:25:44.849Z*
 
 ## Core Directives
 


### PR DESCRIPTION
Adds the `-- @approved-by: codestreetlabs@gmail.com` header the three-factor prod-deploy guard requires, plus a provenance comment recording where the approval came from.

## Why this exists

The chairman approved this migration verbally on 2026-07-28 (`chairman_decisions 642965c4`, `decision_type=ddl_approval`, two parts: the table, then the GRANT/REVOKE). **The approved artifact could never have passed its own approver guard** — `scripts/lib/migration-guards.js` requires a `-- @approved-by: <email>` header matching the invoker's `git config user.email`, and the file had none.

The dry-run does not check any guard factor, so it verified clean for a full day on an artifact that would fail three separate gates. Four rejections were hit in sequence before the apply succeeded: approver header, shell state, `git_committed`, and pre-commit branch policy.

## Status: already applied to production

```
[MIGRATION_APPLY_PROD_PASS]
account_usage_snapshots        EXISTS
schema_migrations_applied      applied_at 2026-07-29T11:49:07  sha 0ca74a072f68
token                          issued 11:32:41 -> consumed 11:49:07
chairman_decisions 642965c4    consumed_at 2026-07-29T11:49:07 (hash re-pinned)
```

**This PR must land so the file matches the applied artifact.** The audit record pins `0ca74a07…`, which is the *post-header* hash. Discarding this commit would leave the file on disk no longer matching what is recorded as applied.

## Note on scope

The commit contains four unrelated files (`.claude/.protocol-sync`, `.claude/session-state.md`, `.workflow-patterns.json`, `templates/session-prologue.md`) that were already staged in the shared root's index when the commit was made. They are session bookkeeping, no secrets. `.claude/settings.json` is **not** among them — verified explicitly, since a staged `bypassPermissions` line had been removed earlier that morning.

## Unblocks

The shared root has been parked on this branch, leaving it 34 behind `origin/main`, which blocks worktree reclaim (pool 23/28, unreaped 9+ ticks). Merging lets the root return to `main`. The reaper's `FLEET_TREE_CURRENCY_BYPASS_REASON` escape should **not** be used — `worktree-manager.js` and `worktree-provision.js` both differ from `origin/main`, so bypassing would reap using stale provisioning code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XPC4v8MowS4eMrNeAkv2pn
