### PR TITLE
fix(SD-LEO-INFRA-STALENESS-GUARD-THREE-DEFECTS-001): the guard measured the wrong thing, said so precisely, and went quiet when it broke

### DIFF
--- a/lib/coordinator/checkout-staleness.cjs
+++ b/lib/coordinator/checkout-staleness.cjs
@@ -56,13 +56,49 @@ const SEND_PATHS = Object.freeze([
 
 const BASE_REF = 'origin/main';
 
-/** Default runner: argv-array, never a shell string, so a pathspec cannot be re-parsed. */
+/**
+ * Default runner: argv-array, never a shell string, so a pathspec cannot be re-parsed.
+ *
+ * stderr is PIPED, not ignored, and that is a deliberate reversal of the inherited setting.
+ * With stderr ignored, a failed execFileSync throws an Error whose message is ONLY the echoed
+ * argv — git's actual diagnostic never reaches Node. That made the "origin/main not available
+ * locally" branch below unreachable: it tested for git's vocabulary in text that could never
+ * contain it. A guard whose most actionable message cannot fire is the same defect class this
+ * SD exists to remove, one level down. (Found by SECURITY review, reproduced directly.)
+ *
+ * Piping stderr is safe HERE specifically: `rev-list --count` performs no network or remote-auth
+ * operation, so no credential-bearing remote URL can appear in its diagnostics. That is a
+ * property of this command, not a general licence — see classifyGitFailure, which never
+ * interpolates git's text into output regardless.
+ */
 function defaultRunner(args) {
   return execFileSync('git', args, {
     encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'ignore'],
+    stdio: ['ignore', 'pipe', 'pipe'],
     timeout: 5000,
   });
+}
+
+/**
+ * Map a git failure to a fixed, human-actionable reason.
+ *
+ * *** NO GIT-SUPPLIED TEXT IS EVER INTERPOLATED INTO THE RETURNED STRING. *** Every reason
+ * below is a literal owned by this module. git's stderr is READ to classify, never echoed —
+ * so even if this runner is later repointed at a command that does touch the network, a
+ * credential-bearing remote URL cannot reach an operator's terminal through here. The earlier
+ * version interpolated `msg.split('\n')[0]`, which would have leaked whatever git said.
+ */
+function classifyGitFailure(err) {
+  if (err && (err.killed || err.signal === 'SIGTERM')) return 'git timed out';
+  // err.killed is undefined on some Windows/Node builds, so the SIGTERM check above is
+  // load-bearing rather than redundant — verified on this host.
+  const text = `${(err && err.stderr) || ''}\n${(err && err.message) || err || ''}`;
+  if (/unknown revision|bad revision|ambiguous argument|unknown ref/i.test(text)) {
+    return `${BASE_REF} not available locally — fetch it`;
+  }
+  if (/ENOENT|not recognized|command not found/i.test(text)) return 'git unavailable';
+  if (/not a git repository/i.test(text)) return 'not a git repository';
+  return 'git failed';
 }
 
 /**
@@ -80,15 +116,9 @@ function measureBehind(execImpl, paths) {
   try {
     raw = execImpl(['rev-list', '--count', `HEAD..${BASE_REF}`, '--', ...paths]);
   } catch (err) {
-    // The old code stopped here and returned nothing at all. Which failure occurred is
-    // exactly what the reader needs, so it survives into the message.
-    const msg = String(err && err.message ? err.message : err);
-    if (err && (err.killed || err.signal === 'SIGTERM')) return { ok: false, reason: 'git timed out' };
-    if (/unknown revision|bad revision|ambiguous argument/i.test(msg)) {
-      return { ok: false, reason: `${BASE_REF} not available locally — fetch it` };
-    }
-    if (/ENOENT|not found/i.test(msg)) return { ok: false, reason: 'git unavailable' };
-    return { ok: false, reason: `git error (${msg.split('\n')[0].slice(0, 80)})` };
+    // The old code stopped here and returned nothing at all. WHICH failure occurred is exactly
+    // what the reader needs, so it is classified into one of a fixed set of owned strings.
+    return { ok: false, reason: classifyGitFailure(err) };
   }
   const behind = Number.parseInt(String(raw).trim(), 10);
   // An unparseable count is NOT zero. Collapsing it would reintroduce D3 through the happy
@@ -127,4 +157,4 @@ function warnIfCheckoutStale(label, execImpl = defaultRunner, paths = SEND_PATHS
   // measured against origin/main and are current, not that the check fell over.
 }
 
-module.exports = { warnIfCheckoutStale, measureBehind, SEND_PATHS, BASE_REF };
+module.exports = { warnIfCheckoutStale, measureBehind, classifyGitFailure, SEND_PATHS, BASE_REF };

--- a/lib/coordinator/checkout-staleness.cjs
+++ b/lib/coordinator/checkout-staleness.cjs
@@ -4,24 +4,127 @@
 // 1h43m because the checkout was 18 commits behind origin/main, with no signal.
 // Deliberately: WARN only, never auto-pull (main checkout is chronically dirty —
 // mutating auto-pull is unsafe) and never a hard gate (too aggressive for a warn-class
-// issue). Non-fatal on any git error (detached HEAD, no upstream, git unavailable).
-const { execSync } = require('child_process');
+// issue).
+//
+// SD-LEO-INFRA-STALENESS-GUARD-THREE-DEFECTS-001 — three defects, fixed together.
+//
+// D1 REPO-WIDE SCOPE. The count carried no pathspec while the message claimed to be about
+//    THIS SEND. Those decouple the moment anyone merges anything unrelated, i.e. constantly.
+// D2 WRONG REFERENT. It measured @{u} and said "origin/main". On a pushed feature branch
+//    @{u} is that branch's OWN remote, so the number described a different ref than the one
+//    it named — a wrong number stated precisely.
+// D3 FAIL-OPEN SILENCE. A bare `catch {}` swallowed every git failure, so "up to date" and
+//    "the check crashed" were indistinguishable to the reader. With no upstream configured
+//    the old command exited 128 and this guard said NOTHING — on exactly the topology where
+//    staleness is most likely, since a fresh branch has no upstream until its first push and
+//    workers branch constantly. THE PREVIOUS HEADER DOCUMENTED THAT AS INTENDED ("Non-fatal
+//    on any git error"). It is no longer intended: non-fatal yes, silent no.
+//
+// *** WHY D1 AND D2 HAD TO SHIP IN ONE COMMIT — the part that is easy to get wrong. ***
+// They point in OPPOSITE directions. Measured on the authoring checkout: HEAD..@{u}=0,
+// HEAD..origin/main=34, and HEAD..origin/main scoped to these paths=0. Fixing only the
+// referent makes the guard shout "34 commits behind" at a checkout whose send-path code is
+// completely current — a false positive strictly WORSE than the silence it replaced, because
+// this warning had already been demoted to noise once. Fixing only the pathspec changes
+// nothing (still 0 against @{u}, still silent). Only both together are correct.
+const { execFileSync } = require('child_process');
 
-function warnIfCheckoutStale(label, execImpl = execSync) {
-  try {
-    const behind = execImpl('git rev-list --count HEAD..@{u}', {
-      encoding: 'utf8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).trim();
-    const count = parseInt(behind, 10);
-    if (count > 0) {
-      process.stderr.write(
-        `⚠️  WARN: ${label} checkout is ${count} commit(s) behind origin/main — this send may run pre-fix code. Consider a git pull before continuing.\n`
-      );
-    }
-  } catch {
-    // No upstream configured, detached HEAD, or git unavailable — never block the send.
-  }
+/**
+ * The code whose staleness actually matters to a send.
+ *
+ * EXPLICIT, NOT DERIVED — a real decision, not laziness. Deriving the scope from
+ * require.cache at call time was considered and rejected: all three callers invoke this at
+ * the TOP of main(), BEFORE subcommand parsing, so a derived scope would only ever see the
+ * statically-required modules. Any lazy require inside a subcommand body would be silently
+ * omitted, narrowing coverage exactly the way D1 already did — the same defect one layer
+ * down, and invisible.
+ *
+ * The cost of explicit is that this list can go stale. That cost is paid down by the
+ * path-existence test: a listed path that no longer exists FAILS LOUDLY rather than quietly
+ * shrinking what the guard watches.
+ */
+const SEND_PATHS = Object.freeze([
+  'scripts/worker-signal.cjs',
+  'scripts/adam-advisory.cjs',
+  'scripts/solomon-advisory.cjs',
+  'lib/coordinator',
+  'lib/coordination',
+  'lib/fleet/worker-status.cjs',
+  'lib/shared/body-cap.cjs',
+  'lib/governance/fw3-framing-router.cjs',
+]);
+
+const BASE_REF = 'origin/main';
+
+/** Default runner: argv-array, never a shell string, so a pathspec cannot be re-parsed. */
+function defaultRunner(args) {
+  return execFileSync('git', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'ignore'],
+    timeout: 5000,
+  });
 }
 
-module.exports = { warnIfCheckoutStale };
+/**
+ * Measure how far the send paths are behind origin/main.
+ *
+ * Returns { ok: true, behind: N } or { ok: false, reason } — NEVER a bare 0 standing in for
+ * "could not tell". Every abnormal path carries its own name so the caller can report which
+ * one happened. Modelled on lib/fleet/tree-currency.cjs, which already refuses to collapse
+ * unknown states into a number.
+ *
+ * @returns {{ok: true, behind: number} | {ok: false, reason: string}}
+ */
+function measureBehind(execImpl, paths) {
+  let raw;
+  try {
+    raw = execImpl(['rev-list', '--count', `HEAD..${BASE_REF}`, '--', ...paths]);
+  } catch (err) {
+    // The old code stopped here and returned nothing at all. Which failure occurred is
+    // exactly what the reader needs, so it survives into the message.
+    const msg = String(err && err.message ? err.message : err);
+    if (err && (err.killed || err.signal === 'SIGTERM')) return { ok: false, reason: 'git timed out' };
+    if (/unknown revision|bad revision|ambiguous argument/i.test(msg)) {
+      return { ok: false, reason: `${BASE_REF} not available locally — fetch it` };
+    }
+    if (/ENOENT|not found/i.test(msg)) return { ok: false, reason: 'git unavailable' };
+    return { ok: false, reason: `git error (${msg.split('\n')[0].slice(0, 80)})` };
+  }
+  const behind = Number.parseInt(String(raw).trim(), 10);
+  // An unparseable count is NOT zero. Collapsing it would reintroduce D3 through the happy
+  // path: the guard would fall silent on a malformed answer and read as up-to-date.
+  if (!Number.isFinite(behind) || behind < 0) {
+    return { ok: false, reason: 'unparseable commit count' };
+  }
+  return { ok: true, behind };
+}
+
+/**
+ * WARN if the code this send actually depends on is behind origin/main.
+ *
+ * The signature is unchanged for the three production callers, which pass only a label
+ * (worker-signal.cjs:598, adam-advisory.cjs:895, solomon-advisory.cjs:779).
+ */
+function warnIfCheckoutStale(label, execImpl = defaultRunner, paths = SEND_PATHS) {
+  const result = measureBehind(execImpl, paths);
+
+  if (!result.ok) {
+    // NOT silent, and deliberately NOT dressed as a staleness warning — the honest statement
+    // is that we do not know. Distinct wording so it can never be misread as a behind-by-N
+    // result, and so that seeing nothing at all now means the check ran and passed.
+    process.stderr.write(
+      `⚠️  NOTICE: ${label} could not determine checkout staleness (${result.reason}) — this send may be running pre-fix code, unverified.\n`
+    );
+    return;
+  }
+
+  if (result.behind > 0) {
+    process.stderr.write(
+      `⚠️  WARN: ${label} send-path code is ${result.behind} commit(s) behind ${BASE_REF} — this send may run pre-fix code. Consider a git pull before continuing.\n`
+    );
+  }
+  // behind === 0 → silent, and that silence is now EARNED: it means the send paths were
+  // measured against origin/main and are current, not that the check fell over.
+}
+
+module.exports = { warnIfCheckoutStale, measureBehind, SEND_PATHS, BASE_REF };

--- a/lib/coordinator/checkout-staleness.cjs
+++ b/lib/coordinator/checkout-staleness.cjs
@@ -89,16 +89,31 @@ function defaultRunner(args) {
  * version interpolated `msg.split('\n')[0]`, which would have leaked whatever git said.
  */
 function classifyGitFailure(err) {
-  if (err && (err.killed || err.signal === 'SIGTERM')) return 'git timed out';
-  // err.killed is undefined on some Windows/Node builds, so the SIGTERM check above is
-  // load-bearing rather than redundant — verified on this host.
-  const text = `${(err && err.stderr) || ''}\n${(err && err.message) || err || ''}`;
-  if (/unknown revision|bad revision|ambiguous argument|unknown ref/i.test(text)) {
-    return `${BASE_REF} not available locally — fetch it`;
+  // *** THE WHOLE BODY IS GUARDED BECAUSE "NEVER THROWS" IS AN INVARIANT THIS MODULE STATES
+  // ABOUT ITSELF, AND STATING IT IS NOT ENFORCING IT. *** Reading .stderr/.message can throw
+  // if they are accessor properties, and a raw Symbol thrown as `err` makes template-literal
+  // coercion throw. Neither is reachable through defaultRunner — real execFileSync errors carry
+  // plain string properties, verified against live git — but execImpl is a PUBLIC injectable
+  // seam, so the invariant has to hold for whatever a caller passes, not just for what git
+  // happens to produce. (Gap found by TESTING fuzzing the seam; it was not reachable in
+  // practice, and it was still a real hole in a promise the file makes in its own docblock.)
+  try {
+    if (err && (err.killed || err.signal === 'SIGTERM')) return 'git timed out';
+    // err.killed is undefined on some Windows/Node builds, so the SIGTERM check above is
+    // load-bearing rather than redundant — verified on this host.
+    const text = `${(err && err.stderr) || ''}\n${(err && err.message) || err || ''}`;
+    if (/unknown revision|bad revision|ambiguous argument|unknown ref/i.test(text)) {
+      return `${BASE_REF} not available locally — fetch it`;
+    }
+    if (/ENOENT|not recognized|command not found/i.test(text)) return 'git unavailable';
+    if (/not a git repository/i.test(text)) return 'not a git repository';
+    return 'git failed';
+  } catch {
+    // Deliberately distinct from 'git failed': the git call failed AND we could not read why.
+    // Still a cannot-determine outcome, so the caller still speaks up — the one thing that
+    // must never happen here is falling back to silence.
+    return 'git failed (unreadable error)';
   }
-  if (/ENOENT|not recognized|command not found/i.test(text)) return 'git unavailable';
-  if (/not a git repository/i.test(text)) return 'not a git repository';
-  return 'git failed';
 }
 
 /**

--- a/tests/unit/coordinator/checkout-staleness.test.js
+++ b/tests/unit/coordinator/checkout-staleness.test.js
@@ -1,8 +1,30 @@
 /**
  * QF-20260707-875: preventive staleness WARN for routing-critical comms CLIs.
+ * SD-LEO-INFRA-STALENESS-GUARD-THREE-DEFECTS-001: three defects fixed together.
+ *
+ * *** THESE TESTS ARE WRITTEN TO FAIL AGAINST THE *PLAUSIBLE WRONG FIX*, NOT MERELY AGAINST
+ * THE OLD CODE. *** The obvious repair — swap @{u} for origin/main and leave the scope
+ * repo-wide — makes the guard shout "34 commits behind" at a checkout whose send-path code
+ * is fully current. That false positive is strictly worse than the silence it replaced. A
+ * test asserting only "warns when behind" PASSES that wrong fix, so there is no such test
+ * here; every case below names the mutation that must break it.
+ *
+ * ONE THING THAT DROVE THE DESIGN: a value-only assertion CANNOT catch a reverted referent.
+ * On this repo HEAD..@{u}=0 and the correctly-scoped HEAD..origin/main=0 — both render
+ * silent, so the outcome is identical either way. The referent has to be asserted on the
+ * captured ARGV. That is why the runner seam is an argv array rather than a shell string.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { warnIfCheckoutStale } from '../../../lib/coordinator/checkout-staleness.cjs';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  warnIfCheckoutStale,
+  measureBehind,
+  SEND_PATHS,
+  BASE_REF,
+} from '../../../lib/coordinator/checkout-staleness.cjs';
+
+const REPO_ROOT = join(import.meta.dirname, '..', '..', '..');
 
 describe('warnIfCheckoutStale', () => {
   let stderrSpy;
@@ -11,25 +33,149 @@ describe('warnIfCheckoutStale', () => {
   });
   afterEach(() => stderrSpy.mockRestore());
 
-  it('does NOT warn when up to date (0 commits behind)', () => {
-    const fakeExec = vi.fn().mockReturnValue('0\n');
-    warnIfCheckoutStale('test-cli', fakeExec);
+  it('is SILENT when the send paths are current, even if the repo is far behind overall', () => {
+    // The exact situation measured on the authoring checkout: 34 commits behind origin/main
+    // repo-wide, 0 on the send paths. This fake answers like real git — it returns the
+    // repo-wide number when NO pathspec was supplied, and the scoped number when one was.
+    const fakeExec = vi.fn().mockImplementation((args) => {
+      const hasPathspec = args.includes('--') && args.indexOf('--') < args.length - 1;
+      return hasPathspec ? '0\n' : '34\n';
+    });
+
+    warnIfCheckoutStale('worker-signal.cjs', fakeExec);
+
     expect(stderrSpy).not.toHaveBeenCalled();
+
+    // MUTATION THAT MUST BREAK THIS: drop the pathspec while keeping origin/main — the
+    // naive fix. The fake then returns 34, the guard warns, and this fails. This is the
+    // single most important test in the file.
   });
 
-  it('WARNs with the commit count when behind origin', () => {
-    const fakeExec = vi.fn().mockReturnValue('18\n');
+  it('measures origin/main and NOT @{u} — asserted on the argv, because the values coincide', () => {
+    const fakeExec = vi.fn().mockReturnValue('0\n');
+    warnIfCheckoutStale('worker-signal.cjs', fakeExec);
+
+    const args = fakeExec.mock.calls[0][0];
+    expect(args).toContain(`HEAD..${BASE_REF}`);
+    expect(args.join(' ')).not.toContain('@{u}');
+
+    // MUTATION THAT MUST BREAK THIS: revert the referent to @{u}. Note a value-based
+    // assertion could NOT catch that mutation here — both refs return 0 on this repo — so
+    // this test deliberately ignores the return value and inspects the command instead.
+  });
+
+  it('passes the send paths as a pathspec after a -- separator', () => {
+    const fakeExec = vi.fn().mockReturnValue('0\n');
+    warnIfCheckoutStale('worker-signal.cjs', fakeExec);
+
+    const args = fakeExec.mock.calls[0][0];
+    const sep = args.indexOf('--');
+    expect(sep).toBeGreaterThan(-1);
+    expect(args.slice(sep + 1)).toEqual([...SEND_PATHS]);
+
+    // MUTATION: remove the pathspec entirely -> no separator, fails.
+  });
+
+  it('WARNs with the SCOPED count when a send path is genuinely behind', () => {
+    const fakeExec = vi.fn().mockImplementation((args) => (args.includes('--') ? '7\n' : '34\n'));
+
     warnIfCheckoutStale('adam-advisory.cjs', fakeExec);
+
     expect(stderrSpy).toHaveBeenCalledTimes(1);
     const message = stderrSpy.mock.calls[0][0];
-    expect(message).toContain('18');
+    expect(message).toContain('7');
+    expect(message).not.toContain('34'); // never the repo-wide number
     expect(message).toContain('adam-advisory.cjs');
+    expect(message).toContain(BASE_REF);
     expect(message).toContain('WARN');
+
+    // MUTATION: report the repo-wide count -> '34' appears, fails.
   });
 
-  it('never throws and never warns when git errors (detached HEAD / no upstream)', () => {
-    const fakeExec = vi.fn().mockImplementation(() => { throw new Error('no upstream configured'); });
+  /**
+   * *** DELIBERATE REVERSAL OF A DOCUMENTED DESIGN DECISION — NOT A STALE ASSERTION. ***
+   * This case previously read "never throws and never warns when git errors" and asserted
+   * `expect(stderrSpy).not.toHaveBeenCalled()`. That was defect 3 written down as intended
+   * behaviour, and the module header stated the same in prose ("Non-fatal on any git
+   * error"). Both have been changed together, on purpose: non-fatal is still required, but
+   * silent is not. A guard that is quiet because it is correct and one that is quiet
+   * because it crashed must not look the same to a reader — and the crash case fires on
+   * fresh unpushed branches, precisely when a worker is most likely running stale code.
+   * The not-throwing half of the original assertion is preserved unchanged.
+   */
+  it('EMITS a distinct cannot-determine notice when git fails, and still never throws', () => {
+    const fakeExec = vi.fn().mockImplementation(() => {
+      throw new Error('fatal: no upstream configured for branch');
+    });
+
+    expect(() => warnIfCheckoutStale('worker-signal.cjs', fakeExec)).not.toThrow();
+
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    const message = stderrSpy.mock.calls[0][0];
+    expect(message).toContain('could not determine');
+    expect(message).toContain('worker-signal.cjs');
+    // Must NOT masquerade as a staleness measurement.
+    expect(message).not.toContain('behind');
+
+    // MUTATION THAT MUST BREAK THIS: restore the bare `catch {}`. Silence returns and this
+    // fails — which is the whole point of reversing the original assertion.
+  });
+
+  it('treats an unparseable count as cannot-determine, never as zero', () => {
+    const fakeExec = vi.fn().mockReturnValue('not-a-number\n');
+
+    warnIfCheckoutStale('solomon-advisory.cjs', fakeExec);
+
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    expect(stderrSpy.mock.calls[0][0]).toContain('could not determine');
+
+    // MUTATION: collapse an unparseable count to 0 -> silence, fails. Without this the
+    // guard could go quiet on a malformed answer and read as up-to-date — defect 3
+    // re-entering through the happy path rather than the catch block.
+  });
+
+  it('does not throw and stays silent when the send paths are current', () => {
+    const fakeExec = vi.fn().mockReturnValue('0\n');
     expect(() => warnIfCheckoutStale('worker-signal.cjs', fakeExec)).not.toThrow();
     expect(stderrSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('measureBehind', () => {
+  it('reports a named reason rather than collapsing failures into a number', () => {
+    const timedOut = Object.assign(new Error('killed'), { killed: true });
+    expect(measureBehind(() => { throw timedOut; }, SEND_PATHS)).toEqual({ ok: false, reason: 'git timed out' });
+
+    expect(measureBehind(() => { throw new Error('fatal: bad revision origin/main'); }, SEND_PATHS))
+      .toEqual({ ok: false, reason: `${BASE_REF} not available locally — fetch it` });
+
+    expect(measureBehind(() => { throw new Error('spawn git ENOENT'); }, SEND_PATHS))
+      .toEqual({ ok: false, reason: 'git unavailable' });
+
+    // MUTATION: return a bare 0 (or undefined) from any of these branches -> the caller can
+    // no longer distinguish them and these fail.
+  });
+
+  it('returns the parsed count on success', () => {
+    expect(measureBehind(() => '12\n', SEND_PATHS)).toEqual({ ok: true, behind: 12 });
+  });
+});
+
+describe('SEND_PATHS', () => {
+  /**
+   * The explicit-list design's one weakness is that it can go stale as the tree moves, which
+   * would silently narrow what the guard watches — the same class of defect this SD exists
+   * to remove. This test is the counterweight: a path that no longer exists fails loudly
+   * instead of quietly reducing coverage.
+   */
+  it('every listed path exists on disk', () => {
+    const missing = SEND_PATHS.filter((p) => !existsSync(join(REPO_ROOT, p)));
+    expect(missing).toEqual([]);
+  });
+
+  it('includes all three production callers', () => {
+    expect(SEND_PATHS).toContain('scripts/worker-signal.cjs');
+    expect(SEND_PATHS).toContain('scripts/adam-advisory.cjs');
+    expect(SEND_PATHS).toContain('scripts/solomon-advisory.cjs');
   });
 });

--- a/tests/unit/coordinator/checkout-staleness.test.js
+++ b/tests/unit/coordinator/checkout-staleness.test.js
@@ -20,6 +20,7 @@ import { join } from 'node:path';
 import {
   warnIfCheckoutStale,
   measureBehind,
+  classifyGitFailure,
   SEND_PATHS,
   BASE_REF,
 } from '../../../lib/coordinator/checkout-staleness.cjs';
@@ -158,6 +159,74 @@ describe('measureBehind', () => {
 
   it('returns the parsed count on success', () => {
     expect(measureBehind(() => '12\n', SEND_PATHS)).toEqual({ ok: true, behind: 12 });
+  });
+});
+
+describe('classifyGitFailure', () => {
+  /**
+   * *** THIS WHOLE BLOCK EXISTS BECAUSE THE FIRST IMPLEMENTATION HAD A BRANCH THAT COULD
+   * NEVER RUN. *** The runner originally used stdio ['ignore','pipe','ignore'], so a failed
+   * execFileSync threw an Error whose message was ONLY the echoed argv — git's diagnostic
+   * never reached Node. The "origin/main not available locally" branch tested for git's
+   * vocabulary in text that could not contain it, so the most actionable message the guard
+   * had was unreachable. Found in SECURITY review and reproduced directly against real git.
+   * stderr is now piped and the classification reads it.
+   */
+  it('reads git stderr — the channel that was previously discarded — to name the failure', () => {
+    const err = Object.assign(new Error('Command failed: git rev-list --count HEAD..origin/main'), {
+      stderr: "fatal: ambiguous argument 'HEAD..origin/main': unknown revision or path not in the working tree.",
+    });
+    expect(classifyGitFailure(err)).toBe(`${BASE_REF} not available locally — fetch it`);
+
+    // MUTATION THAT MUST BREAK THIS: read only err.message (the pre-fix behaviour). The
+    // message alone carries no git vocabulary, so this falls through to 'git failed'.
+  });
+
+  it('NEVER interpolates git-supplied text into the reason', () => {
+    // The earlier version returned `git error (${msg.split('\n')[0]})`, which would echo
+    // whatever git said. If this runner is ever repointed at a command that touches the
+    // network, git's stderr can carry a remote URL — and those can embed credentials.
+    const err = Object.assign(new Error('Command failed'), {
+      stderr: 'fatal: unable to access https://user:s3cr3t-token@github.com/org/repo.git/',
+    });
+    const reason = classifyGitFailure(err);
+    expect(reason).not.toContain('s3cr3t-token');
+    expect(reason).not.toContain('https://');
+    expect(reason).toBe('git failed');
+
+    // MUTATION: interpolate the git text back into the reason -> the token appears, fails.
+  });
+
+  it('classifies a timeout via signal, not only via killed', () => {
+    // err.killed is undefined on some Windows/Node builds — verified on this host — so the
+    // SIGTERM check is load-bearing rather than belt-and-braces.
+    expect(classifyGitFailure({ signal: 'SIGTERM' })).toBe('git timed out');
+    expect(classifyGitFailure({ killed: true })).toBe('git timed out');
+  });
+
+  it('classifies a missing git binary and a non-repo distinctly', () => {
+    expect(classifyGitFailure(new Error('spawn git ENOENT'))).toBe('git unavailable');
+    expect(classifyGitFailure(Object.assign(new Error('x'), { stderr: 'fatal: not a git repository' })))
+      .toBe('not a git repository');
+  });
+});
+
+describe('detached HEAD', () => {
+  /**
+   * FR-2 AC3 anticipated detached HEAD as a cannot-determine case. It no longer is, and that
+   * is the fix working rather than a gap: the referent is now the literal `origin/main`, so
+   * the measurement does not depend on HEAD having an upstream at all. Detached HEAD now
+   * MEASURES CORRECTLY and stays silent when current. Recording the real behaviour here so
+   * the AC's superseded expectation cannot be mistaken for missing coverage later.
+   * (Surfaced by TESTING, which verified it in a scratch clone.)
+   */
+  it('measures normally when HEAD is detached, because the referent no longer depends on @{u}', () => {
+    const fakeExec = vi.fn().mockReturnValue('0\n');
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    warnIfCheckoutStale('worker-signal.cjs', fakeExec);
+    expect(fakeExec.mock.calls[0][0]).toContain(`HEAD..${BASE_REF}`);
+    expect(stderrSpy).not.toHaveBeenCalled();
+    stderrSpy.mockRestore();
   });
 });
 

--- a/tests/unit/coordinator/checkout-staleness.test.js
+++ b/tests/unit/coordinator/checkout-staleness.test.js
@@ -204,6 +204,36 @@ describe('classifyGitFailure', () => {
     expect(classifyGitFailure({ killed: true })).toBe('git timed out');
   });
 
+  /**
+   * "Never throws" is an invariant this module asserts about itself in its own docblock, and
+   * asserting it is not the same as enforcing it. Reading .stderr/.message can throw when they
+   * are accessor properties, and a raw Symbol makes template-literal coercion throw. Neither is
+   * reachable through defaultRunner — real execFileSync errors carry plain string properties —
+   * but execImpl is a PUBLIC seam, so the invariant must hold for anything a caller injects.
+   * (Gap found by TESTING fuzzing the seam after the classifier landed.)
+   */
+  it('never throws, even for adversarial error shapes that cannot come from real git', () => {
+    const throwingGetter = {};
+    Object.defineProperty(throwingGetter, 'stderr', { get() { throw new Error('boom'); } });
+    expect(() => classifyGitFailure(throwingGetter)).not.toThrow();
+    expect(classifyGitFailure(throwingGetter)).toBe('git failed (unreadable error)');
+
+    expect(() => classifyGitFailure(Symbol('nope'))).not.toThrow();
+    expect(classifyGitFailure(Symbol('nope'))).toBe('git failed (unreadable error)');
+
+    // And the invariant that actually matters — the guard itself must still SPEAK, not fall
+    // silent, when it cannot even read why git failed.
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    expect(() => warnIfCheckoutStale('worker-signal.cjs', () => { throw Symbol('nope'); })).not.toThrow();
+    expect(stderrSpy).toHaveBeenCalledTimes(1);
+    expect(stderrSpy.mock.calls[0][0]).toContain('could not determine');
+    stderrSpy.mockRestore();
+
+    // MUTATION THAT MUST BREAK THIS: remove the try/catch around the classification body.
+    // Both the throwing-getter case and the Symbol case then propagate out of
+    // warnIfCheckoutStale, breaking the module's stated never-throw contract.
+  });
+
   it('classifies a missing git binary and a non-repo distinctly', () => {
     expect(classifyGitFailure(new Error('spawn git ENOENT'))).toBe('git unavailable');
     expect(classifyGitFailure(Object.assign(new Error('x'), { stderr: 'fatal: not a git repository' })))


### PR DESCRIPTION
`lib/coordinator/checkout-staleness.cjs` runs on **every** `/signal` and every advisory send. It had three defects, and they had to be fixed together.

| | Defect | Effect |
|---|---|---|
| **D1** | Count carried no pathspec, while the message claimed to be about *this send* | Decouples the moment anyone merges anything unrelated — i.e. constantly |
| **D2** | Measured `@{u}`, printed "behind origin/main" | On a pushed feature branch `@{u}` is that branch's *own* remote — a wrong number, stated precisely |
| **D3** | Bare `catch {}` swallowed every git failure | "Up to date" and "the check crashed" looked identical |

D3 mattered most: with no upstream the old command exits 128 and the guard said **nothing** — on exactly the topology where staleness is most likely, since a fresh branch has no upstream until its first push and workers branch constantly. A guard that's quiet because it's correct and one that's quiet because it fell over must not look the same.

## Why D1 and D2 ship in one commit

**They point in opposite directions.** Measured on the authoring checkout: `HEAD..@{u}`=0, `HEAD..origin/main`=**34**, and `HEAD..origin/main` scoped to the send paths=**0**.

- Fix only the referent → the guard shouts "34 commits behind" at a checkout whose send-path code is completely current. That false positive is **strictly worse** than the silence it replaced — this warning had already been demoted to noise once.
- Fix only the pathspec → still 0, still silent. No change.
- Both → correctly silent, for the right reason, and loud the moment a send path actually moves.

Mutation (a) below exists to make the naive fix unshippable.

## Scope list is explicit, not derived

Deriving from `require.cache` was considered and rejected: all three callers invoke at the top of `main()` **before** subcommand parsing, so a derived scope would only see statically-required modules and would silently omit anything lazily required inside a subcommand — the same defect one layer down, and invisible. Explicit can go stale, so a test asserts every listed path still exists; a dead entry fails loudly rather than quietly shrinking what the guard watches.

## A test asserted the defect, and is deliberately reversed

`checkout-staleness.test.js` previously read *"never throws and never warns when git errors"* — D3 written down as intended behaviour, matching the module header's "Non-fatal on any git error". Both are changed together, on purpose. Non-fatal is still required and the not-throwing assertion is **preserved unchanged**; silent is no longer intended.

## Every mutation applied, observed failing, reverted — not asserted

| Mutation | Result |
|---|---|
| (a) drop the pathspec, keep origin/main — **the naive fix** | **3 tests fail** |
| (b) revert the referent to `@{u}` | 1 test fails |
| (c) restore the bare `catch {}` | 2 tests fail |
| (d) collapse an unparseable count to 0 | 1 test fails |

(b) is asserted on the captured **argv**, not the outcome — a value-only test *cannot* catch it here, because `HEAD..@{u}` and the correctly-scoped `HEAD..origin/main` both return 0 on this repo and both render silent. That's why the runner seam is an argv array rather than a shell string.

## Verification

- Live: send paths current → silent (earned, real git); unmeasurable ref → emits the distinct cannot-determine NOTICE.
- All three callers (`worker-signal.cjs:598`, `adam-advisory.cjs:895`, `solomon-advisory.cjs:779`) load and run unchanged — no call-site signature change.
- Lint clean. `tests/unit/coordinator`: **953 tests across 87 files, all passing**. 297 LOC, under threshold.

## Out of scope, deliberately — this PR does not restore the alarm fleet-wide

The guard's output is **discarded** on three call paths: `pre-tool-enforce.cjs:1239` and `BaseExecutor.js:570` spawn with `stdio: "ignore"`, and `adam-quiet-tick.mjs:104` destructures only `{ stdout }`. Adam's 5-minute inbox cron therefore *already* fires this guard where nobody can hear it. This change makes the guard **correct on every path and audible on roughly half**; repointing stdio on two hot enforcement paths is a separate blast radius and belongs in its own row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)