### PR TITLE
fix(SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001): the read gate was inert, and the tracker rewarded the lazy read

### DIFF
--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -33,11 +33,38 @@ const { unionRangeCoverage } = require('../../scripts/modules/sd-key-generator.j
 /** Coverage at or above this counts as a full read. Matches the imported implementation's own bar. */
 const FULL_COVERAGE_PCT = 95;
 
+/**
+ * A contract this size or smaller is covered by a single Read, so a no-argument read of it is
+ * genuinely complete and needs no further evidence.
+ *
+ * *** THIS THRESHOLD EXISTS BECAUSE A CI FAILURE EXPOSED A REAL FALSE NEGATIVE IN MY OWN FIX. ***
+ * Requiring positive coverage evidence unconditionally is correct for an over-cap contract and WRONG
+ * for a small one: with no lastDelivered and no ranges, a perfectly good single read of a 25KB file
+ * would report "partial" forever. That is a permanent false alarm on every Adam and Solomon startup,
+ * and a warning that always fires gets demoted to noise — which is precisely the failure this SD
+ * exists to remove. Trading a false positive for a false negative is not a fix.
+ *
+ * 50,000 bytes is deliberately conservative: the Read cap is 25k TOKENS, so this assumes a worst case
+ * of 2 bytes per token, below any real tokenizer's ratio. Measured against the actual contracts —
+ * CLAUDE_COORDINATOR.md ~25.5KB (safely inside), CLAUDE_SOLOMON.md ~67KB and CLAUDE_ADAM.md ~104KB
+ * (both outside, both correctly required to prove coverage).
+ */
+const SINGLE_READ_SAFE_BYTES = 50000;
+
 /** Line count of a contract on disk, or null when it cannot be determined. */
 function contractLineCount(root, contractFile) {
   try {
     const raw = fs.readFileSync(path.join(root, contractFile), 'utf8');
     return raw.split('\n').length;
+  } catch {
+    return null;
+  }
+}
+
+/** Byte size of a contract on disk, or null. Decides whether one Read can cover it. */
+function contractSizeBytes(root, contractFile) {
+  try {
+    return fs.statSync(path.join(root, contractFile)).size;
   } catch {
     return null;
   }
@@ -56,9 +83,17 @@ function contractLineCount(root, contractFile) {
  *
  * @returns {{read: boolean, fully_read: boolean, coverage_pct: number|null, basis: string}}
  */
-function contractReadVerdict(status, totalLines) {
+function contractReadVerdict(status, totalLines, opts = {}) {
   if (!status || !(status.readCount > 0)) {
     return { read: false, fully_read: false, coverage_pct: null, basis: 'no_read_recorded' };
+  }
+
+  // 0. A contract that fits in a single Read cannot have been silently truncated, so the absence of
+  //    a partial flag IS sufficient evidence here. Checked first because it is the only tier where
+  //    "no evidence of partiality" legitimately means "complete".
+  const bytes = Number(opts.sizeBytes);
+  if (Number.isFinite(bytes) && bytes > 0 && bytes <= SINGLE_READ_SAFE_BYTES && status.lastReadWasPartial !== true) {
+    return { read: true, fully_read: true, coverage_pct: 100, basis: 'single_read_safe_size' };
   }
 
   // 1. Delivered evidence wins outright when present.
@@ -93,4 +128,4 @@ function contractReadVerdict(status, totalLines) {
   return { read: true, fully_read: false, coverage_pct: null, basis: 'unknown_coverage' };
 }
 
-module.exports = { contractReadVerdict, contractLineCount, FULL_COVERAGE_PCT };
+module.exports = { contractReadVerdict, contractLineCount, contractSizeBytes, FULL_COVERAGE_PCT, SINGLE_READ_SAFE_BYTES };

--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -1,0 +1,96 @@
+// SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-3 + FR-4.
+//
+// THE DEFECT THIS REPLACES WAS AN INVERSION, NOT A GAP. adam-register.cjs and solomon-register.cjs
+// answered "was the contract read?" from `status.lastReadWasPartial` — a boolean about the MOST
+// RECENT call. On a contract larger than the 25k-token Read cap that gets the answer exactly
+// backwards:
+//   a no-offset Read TRUNCATES at ~line 166 of 421 and records lastReadWasPartial=false -> "read"
+//   a diligent paginated full read records lastReadWasPartial=true on its last page  -> "partial"
+// The reader who did the least was recorded complete; the reader who did the work was recorded
+// incomplete. Filed as feedback 39c3d27d on 2026-07-19 and mis-titled as a capability gap, which is
+// why it sat for ten days: the capability was already there.
+//
+// *** THIS LIVES AT THE CONSUMER, DELIBERATELY, AND THAT IS THE MOST IMPORTANT LINE IN THE FILE. ***
+// The obvious fix is to redefine partial-ness inside protocol-file-tracker.cjs. Do not. That same
+// stamp is read by protocol-file-read-gate.js:159, which is wired into ALL FOUR handoff executors —
+// so changing its meaning would alter handoff gating for CLAUDE_LEAD/PLAN/EXEC.md fleet-wide in order
+// to fix a defect affecting two role contracts. Fixing it here contains the blast radius to the
+// roles that have the problem, and leaves the tracker's per-call stamp accurate as what it actually
+// is: a fact about ONE call. The bug was ever using it to answer a whole-file question.
+//
+// FR-4: the union-of-ranges maths is IMPORTED, not reauthored. A correct implementation already
+// existed and was wired to nothing. NOTE THE NARROW IMPORT — only unionRangeCoverage. Its sibling
+// computeCoveragePercent carries a `no_limit_final_read` fallback that reproduces the very
+// truncation bug this SD exists to close, and it ignores its caller's projectDir. "Import rather
+// than reauthor" was right in spirit and wrong if applied wholesale.
+const path = require('path');
+const fs = require('fs');
+
+// require(esm) — stable since Node 22.12; this fleet runs 24. Verified this file has no top-level
+// await, which is the one thing that would make it throw ERR_REQUIRE_ASYNC_MODULE.
+const { unionRangeCoverage } = require('../../scripts/modules/sd-key-generator.js');
+
+/** Coverage at or above this counts as a full read. Matches the imported implementation's own bar. */
+const FULL_COVERAGE_PCT = 95;
+
+/** Line count of a contract on disk, or null when it cannot be determined. */
+function contractLineCount(root, contractFile) {
+  try {
+    const raw = fs.readFileSync(path.join(root, contractFile), 'utf8');
+    return raw.split('\n').length;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decide whether a role contract was genuinely read, from evidence rather than from a stale boolean.
+ *
+ * Precedence is deliberate — strongest evidence first:
+ *   1. lastDelivered  — what the read ACTUALLY returned (FR-5). The only signal that can see a
+ *      silently-truncated no-argument read, because such a read sets no limit/offset and therefore
+ *      never enters ranges[] at all.
+ *   2. ranges[]       — union coverage across paginated reads. Catches the diligent reader the old
+ *      boolean punished.
+ *   3. readCount      — last resort, and it is EXPLICITLY NOT treated as proof of a full read.
+ *
+ * @returns {{read: boolean, fully_read: boolean, coverage_pct: number|null, basis: string}}
+ */
+function contractReadVerdict(status, totalLines) {
+  if (!status || !(status.readCount > 0)) {
+    return { read: false, fully_read: false, coverage_pct: null, basis: 'no_read_recorded' };
+  }
+
+  // 1. Delivered evidence wins outright when present.
+  const d = status.lastDelivered;
+  if (d && Number.isFinite(Number(d.totalLines)) && Number.isFinite(Number(d.numLines))) {
+    const covered = d.coveredWholeFile === true || Number(d.numLines) >= Number(d.totalLines);
+    return {
+      read: true,
+      fully_read: covered,
+      coverage_pct: Number(d.totalLines) > 0 ? Math.round((Number(d.numLines) / Number(d.totalLines)) * 100) : null,
+      basis: 'delivered_lines'
+    };
+  }
+
+  // 2. Union coverage across recorded ranges.
+  if (Array.isArray(status.ranges) && status.ranges.length > 0 && Number.isFinite(totalLines) && totalLines > 0) {
+    // unionRangeCoverage returns { covered, uncovered } — NOT a bare number. Destructuring matters:
+    // treating the object as a number yields NaN, and NaN >= 95 is false, so the bug would have
+    // presented as "no read ever counts as full" rather than as a crash. Caught by the diligent-
+    // reader test on its first run, which is the case that assertion exists for.
+    const { covered } = unionRangeCoverage(status.ranges, totalLines);
+    const pct = Math.round((Number(covered) / totalLines) * 100);
+    if (!Number.isFinite(pct)) return { read: true, fully_read: false, coverage_pct: null, basis: 'unknown_coverage' };
+    return { read: true, fully_read: pct >= FULL_COVERAGE_PCT, coverage_pct: pct, basis: 'union_ranges' };
+  }
+
+  // 3. A read happened and we cannot say how much of the file it covered.
+  //
+  // NOT TREATED AS FULL, AND THAT IS THE WHOLE POINT. The old code reached exactly this state and
+  // answered "fully read" whenever the last call carried no limit/offset — which is precisely the
+  // truncated read. Absence of evidence is reported as absence, never promoted to completeness.
+  return { read: true, fully_read: false, coverage_pct: null, basis: 'unknown_coverage' };
+}
+
+module.exports = { contractReadVerdict, contractLineCount, FULL_COVERAGE_PCT };

--- a/scripts/adam-register.cjs
+++ b/scripts/adam-register.cjs
@@ -34,6 +34,9 @@ const fs = require('fs');
 const path = require('path');
 const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { resolveStateReadPath } = require('./hooks/lib/session-state-resolver.cjs');
+// SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-3: shared with solomon-register.cjs so both roles
+// get the same verdict from one implementation — solomon had zero coverage for this path.
+const { contractReadVerdict, contractLineCount } = require('../lib/protocol/contract-read-coverage.cjs');
 // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-C (FR-3): single-Adam guard + atomic write.
 // fetchAllAdamsStrict (not fetchFreshAdams) so the guard sees stale priors too and classifies
 // fresh-vs-stale itself (fresh => refuse; stale-only => retire). STRICT (FR-6, count-truncation
@@ -268,11 +271,22 @@ function checkContractRead(projectDir) {
     const state = JSON.parse(fs.readFileSync(statePath, 'utf8').replace(/^\uFEFF/, ''));
     const status = state.protocolFileReadStatus && state.protocolFileReadStatus[CONTRACT_FILE];
     if (status && status.readCount > 0) {
-      result.contract_read = true;
-      result.contract_read_partial = status.lastReadWasPartial === true;
+      // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-3. This used to read
+      // `status.lastReadWasPartial` — a boolean about the MOST RECENT call — and it answered
+      // backwards on a file this size: a truncating no-offset Read recorded "full", while a diligent
+      // paginated read recorded "partial". Coverage is now derived from evidence. Fixed HERE at the
+      // consumer rather than in the tracker, because that stamp also feeds
+      // protocol-file-read-gate.js:159 and therefore every handoff.
+      const verdict = contractReadVerdict(status, contractLineCount(root, CONTRACT_FILE));
+      result.contract_read = verdict.read;
+      result.contract_read_partial = !verdict.fully_read;
+      result.contract_coverage_pct = verdict.coverage_pct;
+      result.contract_read_basis = verdict.basis;
       result.contract_last_read_at = status.lastReadAt || null;
     } else if (Array.isArray(state.protocolFilesRead) && state.protocolFilesRead.includes(CONTRACT_FILE)) {
       result.contract_read = true; // legacy-array fallback (pre-FR-2 state shape)
+      result.contract_read_partial = true; // legacy shape carries no coverage evidence — not a full read
+      result.contract_read_basis = 'legacy_array';
     }
   } catch { /* fail-open: tracking unavailable must never break role activation */ }
   return result;

--- a/scripts/adam-register.cjs
+++ b/scripts/adam-register.cjs
@@ -36,7 +36,7 @@ const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { resolveStateReadPath } = require('./hooks/lib/session-state-resolver.cjs');
 // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-3: shared with solomon-register.cjs so both roles
 // get the same verdict from one implementation — solomon had zero coverage for this path.
-const { contractReadVerdict, contractLineCount } = require('../lib/protocol/contract-read-coverage.cjs');
+const { contractReadVerdict, contractLineCount, contractSizeBytes, SINGLE_READ_SAFE_BYTES } = require('../lib/protocol/contract-read-coverage.cjs');
 // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-C (FR-3): single-Adam guard + atomic write.
 // fetchAllAdamsStrict (not fetchFreshAdams) so the guard sees stale priors too and classifies
 // fresh-vs-stale itself (fresh => refuse; stale-only => retire). STRICT (FR-6, count-truncation
@@ -277,16 +277,21 @@ function checkContractRead(projectDir) {
       // paginated read recorded "partial". Coverage is now derived from evidence. Fixed HERE at the
       // consumer rather than in the tracker, because that stamp also feeds
       // protocol-file-read-gate.js:159 and therefore every handoff.
-      const verdict = contractReadVerdict(status, contractLineCount(root, CONTRACT_FILE));
+      const verdict = contractReadVerdict(status, contractLineCount(root, CONTRACT_FILE), { sizeBytes: contractSizeBytes(root, CONTRACT_FILE) });
       result.contract_read = verdict.read;
       result.contract_read_partial = !verdict.fully_read;
       result.contract_coverage_pct = verdict.coverage_pct;
       result.contract_read_basis = verdict.basis;
       result.contract_last_read_at = status.lastReadAt || null;
     } else if (Array.isArray(state.protocolFilesRead) && state.protocolFilesRead.includes(CONTRACT_FILE)) {
-      result.contract_read = true; // legacy-array fallback (pre-FR-2 state shape)
-      result.contract_read_partial = true; // legacy shape carries no coverage evidence — not a full read
-      result.contract_read_basis = 'legacy_array';
+      // Legacy pre-FR-2 state shape: a bare filename list carrying no coverage information at all.
+      // Sufficient ONLY when the contract fits in a single Read. For an over-cap contract it cannot
+      // distinguish a full read from a silently truncated one, which is the defect this SD closes.
+      const legacyBytes = contractSizeBytes(root, CONTRACT_FILE);
+      const legacyFits = Number.isFinite(legacyBytes) && legacyBytes > 0 && legacyBytes <= SINGLE_READ_SAFE_BYTES;
+      result.contract_read = true;
+      result.contract_read_partial = !legacyFits;
+      result.contract_read_basis = legacyFits ? 'legacy_array_single_read_safe' : 'legacy_array_no_evidence';
     }
   } catch { /* fail-open: tracking unavailable must never break role activation */ }
   return result;

--- a/scripts/archive/one-time/protocol-gate-status.js
+++ b/scripts/archive/one-time/protocol-gate-status.js
@@ -158,8 +158,14 @@ async function checkPostCompaction(phase) {
     process.exit(1);
   }
 
-  console.log(`\nChecking Post-Compaction Gate (phase: ${phase || 'unknown'})`);
-  const result = await gateModule.validatePostCompactionGate(phase);
+  // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-4: validatePostCompactionGate was REMOVED. It was
+  // the only caller of a gate that had no live caller, hard-blocked on paper, and accepted a 1-line
+  // read as a satisfied "post-compaction re-read" — a trap for anyone later solving exactly this
+  // problem, since its name is what they would search for. Coverage now lives in
+  // lib/protocol/contract-read-coverage.cjs (union-of-ranges + delivered lines).
+  console.log(`\nPost-Compaction Gate check REMOVED (phase: ${phase || 'unknown'})`);
+  console.log('  See lib/protocol/contract-read-coverage.cjs — this archived script is no longer a gate status tool.');
+  const result = { pass: true, score: 0, max_score: 0, issues: [], warnings: ['validatePostCompactionGate removed by SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001'] };
 
   console.log('');
   console.log('Result:', result.pass ? '✅ PASS' : '❌ BLOCKED');

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -16,7 +16,7 @@
 // Exit code is ALWAYS 0 (fail-open). Model: peer of scripts/coordinator-audit.mjs.
 
 import 'dotenv/config';
-import { readFileSync } from 'fs';
+import { readFileSync, existsSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 // SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001: advisory, fail-open checkout-freshness badge.
@@ -24,6 +24,9 @@ import { checkoutFreshness, freshnessBadge, CRITICAL_PROTOCOL_FILES } from '../l
 // QF-20260725-342: single source of truth for the resurface threshold (see that module's header).
 import { createRequire as _createRequireQF342 } from 'node:module';
 const { OPERATING_THRESHOLD_HOURS } = _createRequireQF342(import.meta.url)('../lib/coordination/resurface-threshold.cjs');
+// SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-2: same resolver adam-register.cjs and the tracker
+// both use, so the coordinator check reads exactly the state the hook wrote — no second path.
+const { resolveStateReadPath } = _createRequireQF342(import.meta.url)('./hooks/lib/session-state-resolver.cjs');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -513,9 +516,99 @@ export function renderFreshness(repoRoot = REPO_ROOT) {
   }
 }
 
+/**
+ * SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-2.
+ *
+ * THE AUDIT THAT PRODUCED THIS: no role had both halves. adam and solomon have register scripts that
+ * check the contract read, but contracts too large to read in one call. The coordinator had a
+ * contract small enough to read (CLAUDE_COORDINATOR.md ~25.5KB, under the 25k-token cap for any real
+ * tokenizer — established from the byte count, not from a token ratio) and NO VERIFIER OF ANY KIND.
+ * Its priming requirement terminated in a self-attestation that nothing checked.
+ *
+ * Deliberately mirrors adam-register.cjs checkContractRead rather than inventing a shape.
+ *
+ * WHY HERE AND NOT IN A NEW coordinator-register.cjs: registration is an inline node -e in
+ * coordinator.md, and Step 4 of that same ritual already invokes THIS script at the fixed activation
+ * moment. A parallel register script would mean inventing an invocation point that does not exist.
+ *
+ * FAIL-OPEN, LIKE EVERYTHING ELSE HERE. This reports; it never blocks. A gate that stops a
+ * coordinator from starting because it has not yet read the contract it is starting in order to read
+ * is a deadlock, and the script's contract is "exit code is ALWAYS 0".
+ */
+export const COORDINATOR_CONTRACT_FILE = 'CLAUDE_COORDINATOR.md';
+
+export function checkCoordinatorContractRead(repoRoot = REPO_ROOT, stateReader = null) {
+  const result = {
+    contract_file: COORDINATOR_CONTRACT_FILE,
+    contract_exists: false,
+    contract_read: false,
+    contract_read_partial: false,
+    contract_last_read_at: null,
+  };
+  try {
+    result.contract_exists = existsSync(resolve(repoRoot, COORDINATOR_CONTRACT_FILE));
+    const state = stateReader ? stateReader() : readCoordinatorSessionState(repoRoot);
+    if (!state) return result;
+    const status = state.protocolFileReadStatus && state.protocolFileReadStatus[COORDINATOR_CONTRACT_FILE];
+    if (status && status.readCount > 0) {
+      result.contract_read = true;
+      result.contract_read_partial = status.lastReadWasPartial === true;
+      result.contract_last_read_at = status.lastReadAt || null;
+    } else if (Array.isArray(state.protocolFilesRead) && state.protocolFilesRead.includes(COORDINATOR_CONTRACT_FILE)) {
+      result.contract_read = true; // legacy-array fallback, same as adam-register
+    }
+  } catch { /* fail-open: tracking unavailable must never break coordinator startup */ }
+  return result;
+}
+
+/** Read session state without throwing. Separated so tests can inject state directly. */
+function readCoordinatorSessionState(repoRoot) {
+  try {
+    const statePath = resolveStateReadPath(repoRoot);
+    if (!statePath || !existsSync(statePath)) return null;
+    return JSON.parse(readFileSync(statePath, 'utf8').replace(/^﻿/, ''));
+  } catch { return null; }
+}
+
+/**
+ * Render the contract-read state.
+ *
+ * PER-ROLE ARMING IS RENDERED, NOT IMPLIED. Global arming was rejected: it would make the one role
+ * that can comply today wait on two that cannot, and would couple this SD to a sibling deliberately
+ * sequenced after it. The risk of per-role is someone assuming uniform coverage, so the disarmed
+ * roles are printed explicitly rather than left to inference.
+ */
+export function renderContractRead(repoRoot = REPO_ROOT, check = null) {
+  const lines = ['═══ ROLE CONTRACT READ ═══'];
+  try {
+    const c = check || checkCoordinatorContractRead(repoRoot);
+    if (!c.contract_exists) {
+      lines.push(`  ✗ ${COORDINATOR_CONTRACT_FILE} not found — regenerate: node scripts/generate-claude-md-from-db.js`);
+    } else if (!c.contract_read) {
+      lines.push(`  ✗ NO RECORD of ${COORDINATOR_CONTRACT_FILE} being read this session.`);
+      // Safe advice HERE and only here: this contract is under the read cap, so a no-offset Read
+      // genuinely covers it. The same instruction on an over-cap contract silently truncates and is
+      // then recorded as a complete read — see FR-3/FR-5.
+      lines.push(`  → Read ${COORDINATOR_CONTRACT_FILE} in full before coordinating.`);
+    } else if (c.contract_read_partial) {
+      lines.push(`  ⚠ Last read of ${COORDINATOR_CONTRACT_FILE} was PARTIAL (offset/limit used).`);
+      lines.push('  → Re-read it in full; this contract fits in one call.');
+    } else {
+      lines.push(`  ✅ ${COORDINATOR_CONTRACT_FILE} read${c.contract_last_read_at ? ` at ${c.contract_last_read_at}` : ''}`);
+    }
+    lines.push('  ── per-role arming ──');
+    lines.push('  coordinator : ARMED (contract fits in one read)');
+    lines.push('  adam        : disarmed — CLAUDE_ADAM.md exceeds the read cap (SD-LEO-INFRA-ADAM-CONTRACT-READABLE-001)');
+    lines.push('  solomon     : disarmed — CLAUDE_SOLOMON.md exceeds the read cap');
+  } catch (err) {
+    lines.push('  ✅ contract-read check skipped (fail-open): ' + (err?.message || String(err)));
+  }
+  return lines.join('\n');
+}
+
 export function buildReport(argv = [], env = {}, repoRoot = REPO_ROOT) {
   const armed = parseArmedSet(argv, env);
-  return [renderResponsibilities(repoRoot), '', renderAdamLane(), '', renderLoops(armed), '', renderFreshness(repoRoot)].join('\n');
+  return [renderResponsibilities(repoRoot), '', renderAdamLane(), '', renderLoops(armed), '', renderContractRead(repoRoot), '', renderFreshness(repoRoot)].join('\n');
 }
 
 // SD-LEO-INFRA-BOOTSTRAPPABLE-SURVIVOR-AGNOSTIC-001: coordinator-cold-recovery.cjs shipped +

--- a/scripts/hooks/protocol-file-tracker.cjs
+++ b/scripts/hooks/protocol-file-tracker.cjs
@@ -46,7 +46,14 @@ const PROTOCOL_FILES = [
   // Role contracts (no DIGEST variant, NOT a handoff-gate requirement — verified at
   // role activation instead: adam-register.cjs checks this read via session state)
   'CLAUDE_ADAM.md',
-  'CLAUDE_SOLOMON.md'  // role contract, not a handoff-gate requirement — verified at role activation
+  'CLAUDE_SOLOMON.md',  // role contract, not a handoff-gate requirement — verified at role activation
+  // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-2 prerequisite. The coordinator was the ONLY role
+  // whose contract is small enough to read in one call (CLAUDE_COORDINATOR.md is ~25.5KB, under the
+  // 25k-token cap for any real tokenizer) and the ONLY role with no verifier of any kind — its
+  // priming requirement terminated in a self-attestation nothing checked. Adding it here is the
+  // prerequisite for checking it at all: until now a coordinator READING its contract produced no
+  // session-state record, so there was nothing for a check to consult.
+  'CLAUDE_COORDINATOR.md'
 ];
 
 // SD-LEO-INFRA-OPTIMIZE-PROTOCOL-FILE-001: Equivalence mapping for gate compatibility

--- a/scripts/hooks/protocol-file-tracker.cjs
+++ b/scripts/hooks/protocol-file-tracker.cjs
@@ -196,6 +196,21 @@ function normalizeProtocolPath(filePath) {
 function processHookInput(hookInput) {
   const toolName = hookInput.tool_name || '';
   const toolInputData = hookInput.tool_input || {};
+  // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-5. ADDITIVE ONLY — this does NOT touch
+  // lastReadWasPartial, whose semantics are load-bearing for protocol-file-read-gate.js:159 and
+  // therefore for all four handoff executors. A new field cannot change an existing verdict.
+  //
+  // WHY IT IS NEEDED: partial-ness is computed from the CALLER'S ARGUMENTS, so a no-argument Read of
+  // an over-cap file — which the harness silently TRUNCATES — records lastReadWasPartial=false, i.e.
+  // "confirmed full". It also never enters ranges[], because that push sits inside the isPartialRead
+  // branch. So neither the boolean nor union-coverage can see it. The only thing that can is what the
+  // read actually DELIVERED.
+  //
+  // WHETHER THE HARNESS SUPPLIES THIS IS AN OPEN QUESTION AT TIME OF WRITING: transcripts show the
+  // Read result carrying {startLine, numLines, totalLines}, but that is the transcript, not proof of
+  // the hook payload. Captured defensively — present when the harness sends it, absent otherwise, and
+  // consumers must treat absence as "unknown" rather than as "full".
+  const toolResponse = hookInput.tool_response || null;
 
   // Only track Read tool calls
   if (toolName !== 'Read') {
@@ -277,6 +292,42 @@ function processHookInput(hookInput) {
     fileStatus.lastReadWasPartial = false;
     // Note: lastPartialRead preserved for audit (FR-2)
     console.log(`[protocol-file-tracker] ✅ Full read of ${normalizedPath}${fileStatus.lastPartialRead ? ' (clears partial read flag)' : ''}`);
+  }
+
+  // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-5: record what the read actually DELIVERED,
+  // independent of what the caller asked for. This is the only signal that can distinguish a genuine
+  // full read from a no-argument read the harness silently truncated — the boolean above says
+  // "confirmed full" for both, and ranges[] never sees the truncated one at all.
+  //
+  // ADDITIVE: a new field, read by the role-contract consumers only. lastReadWasPartial is untouched,
+  // so the handoff gate at protocol-file-read-gate.js:159 behaves exactly as before.
+  //
+  // ABSENT MEANS UNKNOWN, NOT COMPLETE. If the harness does not supply tool_response, no field is
+  // written and a consumer must not infer coverage from its absence — that inference is the original
+  // defect in another costume.
+  if (toolResponse && typeof toolResponse === 'object') {
+    const total = Number(toolResponse.totalLines);
+    const delivered = Number(toolResponse.numLines);
+    const start = Number(toolResponse.startLine);
+    if (Number.isFinite(total) && Number.isFinite(delivered)) {
+      fileStatus.lastDelivered = {
+        startLine: Number.isFinite(start) ? start : 1,
+        numLines: delivered,
+        totalLines: total,
+        // The load-bearing derived fact, computed once here where both numbers are in hand.
+        coveredWholeFile: delivered >= total,
+        readAt: now
+      };
+      if (!Array.isArray(fileStatus.deliveredRanges)) fileStatus.deliveredRanges = [];
+      fileStatus.deliveredRanges.push({
+        offset: Number.isFinite(start) ? start : 1,
+        limit: delivered,
+        readAt: now
+      });
+      if (delivered < total) {
+        console.log(`[protocol-file-tracker] ⚠️ TRUNCATED read of ${normalizedPath}: ${delivered} of ${total} lines delivered (caller passed no limit/offset, so this would otherwise record as a full read)`);
+      }
+    }
   }
 
   // Save updated status for ACTUAL file read only

--- a/scripts/modules/handoff/gates/core-protocol-gate.js
+++ b/scripts/modules/handoff/gates/core-protocol-gate.js
@@ -657,147 +657,6 @@ export async function validateSdStartGate(sdId, ctx = {}, handoffType = null) {
     full_files_loaded: fullFilesLoaded
   };
 }
-
-/**
- * Validate Post-Compaction Gate - enforces re-read after compaction
- *
- * SD-LEO-INFRA-DUAL-GENERATION-CLAUDE-001: Added DIGEST mode support
- *
- * @param {string} currentPhase - Current SD phase (LEAD, PLAN, EXEC)
- * @param {Object} ctx - Validation context
- * @param {boolean} ctx.needs_full_protocol - If true, load FULL files even in digest mode
- * @returns {Object} Validation result with protocolMode, full_loaded, full_files_loaded
- */
-export async function validatePostCompactionGate(currentPhase, ctx = {}) {
-  const protocolMode = getProtocolMode();
-  const coreRequirements = getCoreProtocolRequirements();
-  const phaseFiles = getPhaseProtocolFiles();
-
-  console.log('\n📚 GATE: Post-Compaction Protocol Enforcement');
-  console.log('-'.repeat(50));
-  console.log(`   Current Phase: ${currentPhase || 'unknown'}`);
-  console.log(`   Protocol Mode: ${protocolMode.toUpperCase()}`);
-
-  // Track if FULL files were loaded on-demand
-  let fullLoaded = false;
-  const fullFilesLoaded = [];
-
-  // PAT-ASYNC-RACE-001: Wait for sync marker before reading state
-  await waitForSyncMarker();
-
-  const state = readSessionState();
-  const lastCompaction = state.protocolGate?.lastCompactionAt;
-
-  if (!lastCompaction) {
-    console.log('   ℹ️  No compaction events recorded - gate not applicable');
-    return {
-      pass: true,
-      score: 100,
-      max_score: 100,
-      issues: [],
-      warnings: ['No compaction events in session - post-compaction gate not enforced'],
-      protocolMode,
-      full_loaded: false,
-      full_files_loaded: []
-    };
-  }
-
-  console.log(`   Last compaction: ${lastCompaction}`);
-  console.log(`   Compaction count: ${state.protocolGate?.compactionCount || 0}`);
-
-  // Determine required files based on protocol mode
-  const requiredFiles = [...coreRequirements.POST_COMPACTION];
-  if (currentPhase && phaseFiles[currentPhase]) {
-    requiredFiles.push(phaseFiles[currentPhase]);
-  }
-
-  // SD-LEO-INFRA-DUAL-GENERATION-CLAUDE-001: On-demand FULL loading
-  if (ctx.needs_full_protocol && protocolMode === 'digest') {
-    console.log('   ⚡ On-demand FULL loading triggered');
-
-    for (const digestFile of [...requiredFiles]) {
-      const fullFile = getFullFilename(digestFile);
-      if (!requiredFiles.includes(fullFile)) {
-        requiredFiles.push(fullFile);
-        fullFilesLoaded.push(fullFile);
-        fullLoaded = true;
-        console.log(`   + Adding FULL file: ${fullFile}`);
-      }
-    }
-  }
-
-  const issues = [];
-  const warnings = [];
-
-  for (const filename of requiredFiles) {
-    const check = checkFileNeedsRead(filename, 'POST_COMPACTION');
-
-    if (check.needsRead) {
-      console.log(`   ❌ ${filename} needs re-read after compaction (${check.reason})`);
-      issues.push(`Protocol file needs re-read after compaction: ${filename}`);
-    } else {
-      console.log(`   ✅ ${filename} read after compaction`);
-    }
-  }
-
-  if (issues.length > 0) {
-    console.log('');
-    console.log('   📚 REMEDIATION:');
-    console.log('   Context compaction occurred - protocol files need re-reading.');
-    console.log('');
-    console.log('   ACTION REQUIRED:');
-    requiredFiles.forEach((f, i) => console.log(`   ${i + 1}. Read the file: ${f}`));
-
-    emitStructuredLog({
-      event: 'POST_COMPACTION_GATE',
-      status: 'BLOCK',
-      currentPhase,
-      lastCompaction,
-      requiredFiles,
-      issues,
-      protocolMode,
-      timestamp: new Date().toISOString()
-    });
-
-    return {
-      pass: false,
-      score: 0,
-      max_score: 100,
-      issues,
-      warnings,
-      protocolMode,
-      full_loaded: fullLoaded,
-      full_files_loaded: fullFilesLoaded
-    };
-  }
-
-  // PAT-ASYNC-RACE-001: Clear sync marker after successful validation
-  clearSyncMarker();
-
-  emitStructuredLog({
-    event: 'POST_COMPACTION_GATE',
-    status: 'PASS',
-    currentPhase,
-    lastCompaction,
-    requiredFiles,
-    protocolMode,
-    fullLoaded,
-    fullFilesLoaded,
-    timestamp: new Date().toISOString()
-  });
-
-  return {
-    pass: true,
-    score: 100,
-    max_score: 100,
-    issues: [],
-    warnings,
-    protocolMode,
-    full_loaded: fullLoaded,
-    full_files_loaded: fullFilesLoaded
-  };
-}
-
 /**
  * Get current protocol gate state for auditing
  * @returns {Object} Current gate state
@@ -839,24 +698,6 @@ export function createSdStartGate(sdId, handoffType = null) {
     remediation: `Read ${fileList} before starting work on ${sdId}. Use: Read tool with file_path for each file.`
   };
 }
-
-/**
- * Create Post-Compaction Gate for handoff integration
- * @param {string} currentPhase - Current phase
- * @returns {Object} Gate configuration
- */
-export function createPostCompactionGate(currentPhase) {
-  return {
-    name: 'GATE_POST_COMPACTION_PROTOCOL',
-    validator: async (ctx) => {
-      return validatePostCompactionGate(currentPhase, ctx);
-    },
-    required: true,
-    blocking: true,
-    remediation: 'Re-read CLAUDE.md, CLAUDE_CORE.md, and phase protocol file after context compaction. Use: Read tool with file_path="CLAUDE.md" then file_path="CLAUDE_CORE.md"'
-  };
-}
-
 /**
  * Validate Session Start Gate - enforces CLAUDE_CORE.md at session initialization
  * This gate runs BEFORE any SD work, at the earliest point of LEO session initialization.
@@ -1036,13 +877,11 @@ export default {
 
   // Validation gates
   validateSdStartGate,
-  validatePostCompactionGate,
   validateSessionStartGate,
   getProtocolGateState,
 
   // Gate factories
   createSdStartGate,
-  createPostCompactionGate,
   createSessionStartGate,
 
   // Mode helpers (SD-LEO-INFRA-DUAL-GENERATION-CLAUDE-001)

--- a/scripts/modules/handoff/gates/protocol-file-read-gate.js
+++ b/scripts/modules/handoff/gates/protocol-file-read-gate.js
@@ -435,11 +435,20 @@ export async function validateProtocolFileRead(handoffType, ctx = {}) {
 
   if (fileExists) {
     console.log(`   ⚠️  Session state does not track ${requiredFile}, but file exists on disk`);
-    console.log('   ✅ FALLBACK PASS: File exists and has content - allowing handoff');
+    console.log('   ⚠️  FALLBACK PASS: no read was observed — passing on file existence only');
 
-    // Mark it as read now to fix session state for future handoffs
-    markProtocolFileRead(requiredFile);
-
+    // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-1: markProtocolFileRead(requiredFile) USED TO BE
+    // CALLED HERE, with the comment "Mark it as read now to fix session state for future handoffs".
+    //
+    // *** THAT MADE THE CHECK FALSIFY THE RECORD IT WAS EVALUATING. *** A file that was never read
+    // got stamped as READ, so every subsequent handoff took the top branch above and passed
+    // legitimately — on evidence this gate had manufactured. The failure could not even be
+    // reproduced by re-running, because the first run destroyed its own precondition.
+    //
+    // The fallback still PASSES: blocking here would wedge sessions whose state is genuinely
+    // missing, and that is a separate decision. But passing without a read and RECORDING a read are
+    // different acts, and only the second one corrupts the audit trail. A reader who later asks "was
+    // this file read?" now gets the truth.
     const state = readSessionState();
     emitStructuredLog({
       event: 'PROTOCOL_FILE_READ_GATE',
@@ -447,6 +456,9 @@ export async function validateProtocolFileRead(handoffType, ctx = {}) {
       handoff_type: handoffType,
       required_file: requiredFile,
       fallback_reason: 'file_exists_on_disk',
+      // Explicit so a log consumer can separate "passed on a read" from "passed without one".
+      read_observed: false,
+      session_state_written: false,
       session_id: state.sessionId || 'unknown',
       timestamp: new Date().toISOString()
     });
@@ -457,7 +469,8 @@ export async function validateProtocolFileRead(handoffType, ctx = {}) {
       max_score: 100,
       issues: [],
       warnings: [
-        `Session state did not track ${requiredFile} - fallback validation used`,
+        `NO READ OBSERVED for ${requiredFile} — passed on file existence alone, not on evidence it was read`,
+        'Session state was deliberately NOT updated: recording an unobserved read would falsify the audit trail',
         'Consider investigating session state corruption if this happens frequently'
       ]
     };

--- a/scripts/solomon-register.cjs
+++ b/scripts/solomon-register.cjs
@@ -34,6 +34,9 @@ const fs = require('fs');
 const path = require('path');
 const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { resolveStateReadPath } = require('./hooks/lib/session-state-resolver.cjs');
+// SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-3: shared with adam-register.cjs — one verdict
+// implementation for both roles.
+const { contractReadVerdict, contractLineCount } = require('../lib/protocol/contract-read-coverage.cjs');
 // SD-LEO-INFRA-SOLOMON-CONSULT-001A (Solomon foundation) — faithful copy-rename of adam-register.cjs: single-Solomon guard + atomic write.
 // fetchAllSolomonsStrict (not fetchFreshSolomons) so the guard sees stale priors too and classifies
 // fresh-vs-stale itself (fresh => refuse; stale-only => retire). STRICT (FR-6, count-truncation
@@ -261,11 +264,19 @@ function checkContractRead(projectDir) {
     const state = JSON.parse(fs.readFileSync(statePath, 'utf8').replace(/^﻿/, ''));
     const status = state.protocolFileReadStatus && state.protocolFileReadStatus[CONTRACT_FILE];
     if (status && status.readCount > 0) {
-      result.contract_read = true;
-      result.contract_read_partial = status.lastReadWasPartial === true;
+      // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-3 — identical fix to adam-register.cjs, from
+      // one shared implementation. This path had NO test coverage at all before this SD, which is
+      // part of why the inversion survived here as long as it did.
+      const verdict = contractReadVerdict(status, contractLineCount(root, CONTRACT_FILE));
+      result.contract_read = verdict.read;
+      result.contract_read_partial = !verdict.fully_read;
+      result.contract_coverage_pct = verdict.coverage_pct;
+      result.contract_read_basis = verdict.basis;
       result.contract_last_read_at = status.lastReadAt || null;
     } else if (Array.isArray(state.protocolFilesRead) && state.protocolFilesRead.includes(CONTRACT_FILE)) {
       result.contract_read = true; // legacy-array fallback (pre-FR-2 state shape)
+      result.contract_read_partial = true; // legacy shape carries no coverage evidence — not a full read
+      result.contract_read_basis = 'legacy_array';
     }
   } catch { /* fail-open: tracking unavailable must never break role activation */ }
   return result;

--- a/scripts/solomon-register.cjs
+++ b/scripts/solomon-register.cjs
@@ -36,7 +36,7 @@ const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { resolveStateReadPath } = require('./hooks/lib/session-state-resolver.cjs');
 // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-3: shared with adam-register.cjs — one verdict
 // implementation for both roles.
-const { contractReadVerdict, contractLineCount } = require('../lib/protocol/contract-read-coverage.cjs');
+const { contractReadVerdict, contractLineCount, contractSizeBytes, SINGLE_READ_SAFE_BYTES } = require('../lib/protocol/contract-read-coverage.cjs');
 // SD-LEO-INFRA-SOLOMON-CONSULT-001A (Solomon foundation) — faithful copy-rename of adam-register.cjs: single-Solomon guard + atomic write.
 // fetchAllSolomonsStrict (not fetchFreshSolomons) so the guard sees stale priors too and classifies
 // fresh-vs-stale itself (fresh => refuse; stale-only => retire). STRICT (FR-6, count-truncation
@@ -267,16 +267,21 @@ function checkContractRead(projectDir) {
       // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-3 — identical fix to adam-register.cjs, from
       // one shared implementation. This path had NO test coverage at all before this SD, which is
       // part of why the inversion survived here as long as it did.
-      const verdict = contractReadVerdict(status, contractLineCount(root, CONTRACT_FILE));
+      const verdict = contractReadVerdict(status, contractLineCount(root, CONTRACT_FILE), { sizeBytes: contractSizeBytes(root, CONTRACT_FILE) });
       result.contract_read = verdict.read;
       result.contract_read_partial = !verdict.fully_read;
       result.contract_coverage_pct = verdict.coverage_pct;
       result.contract_read_basis = verdict.basis;
       result.contract_last_read_at = status.lastReadAt || null;
     } else if (Array.isArray(state.protocolFilesRead) && state.protocolFilesRead.includes(CONTRACT_FILE)) {
-      result.contract_read = true; // legacy-array fallback (pre-FR-2 state shape)
-      result.contract_read_partial = true; // legacy shape carries no coverage evidence — not a full read
-      result.contract_read_basis = 'legacy_array';
+      // Legacy pre-FR-2 state shape: a bare filename list carrying no coverage information at all.
+      // Sufficient ONLY when the contract fits in a single Read. For an over-cap contract it cannot
+      // distinguish a full read from a silently truncated one, which is the defect this SD closes.
+      const legacyBytes = contractSizeBytes(root, CONTRACT_FILE);
+      const legacyFits = Number.isFinite(legacyBytes) && legacyBytes > 0 && legacyBytes <= SINGLE_READ_SAFE_BYTES;
+      result.contract_read = true;
+      result.contract_read_partial = !legacyFits;
+      result.contract_read_basis = legacyFits ? 'legacy_array_single_read_safe' : 'legacy_array_no_evidence';
     }
   } catch { /* fail-open: tracking unavailable must never break role activation */ }
   return result;

--- a/tests/unit/coordinator/coordinator-contract-read.test.js
+++ b/tests/unit/coordinator/coordinator-contract-read.test.js
@@ -1,0 +1,114 @@
+/**
+ * SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 — FR-2 / TS-5.
+ *
+ * The coordinator was the only role whose contract fits in one read and the only role with NO
+ * verifier of any kind; its priming requirement terminated in a self-attestation nothing checked.
+ *
+ * *** EVERY TEST HERE NAMES THE MUTATION THAT MUST BREAK IT. *** A check that can only ever report
+ * "not read" is exactly as useless as one that can only report "read", so both directions are
+ * asserted — the negative case alone would pass against a function that returns false unconditionally.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  checkCoordinatorContractRead,
+  renderContractRead,
+  COORDINATOR_CONTRACT_FILE,
+} from '../../../scripts/coordinator-startup-check.mjs';
+
+const REPO = process.cwd();
+
+/** Inject session state directly rather than touching the real state file. */
+const stateWith = (status) => () => ({ protocolFileReadStatus: { [COORDINATOR_CONTRACT_FILE]: status } });
+
+describe('checkCoordinatorContractRead', () => {
+  it('reports NOT read when session state has no record', () => {
+    const c = checkCoordinatorContractRead(REPO, () => ({ protocolFileReadStatus: {} }));
+    expect(c.contract_read).toBe(false);
+    expect(c.contract_exists).toBe(true); // the file is really on disk in this repo
+
+    // MUTATION: return contract_read true unconditionally -> fails.
+  });
+
+  it('reports READ when the tracker recorded a full read', () => {
+    const c = checkCoordinatorContractRead(REPO, stateWith({ readCount: 1, lastReadWasPartial: false, lastReadAt: '2026-07-29T00:00:00Z' }));
+    expect(c.contract_read).toBe(true);
+    expect(c.contract_read_partial).toBe(false);
+    expect(c.contract_last_read_at).toBe('2026-07-29T00:00:00Z');
+
+    // MUTATION: return contract_read false unconditionally -> fails. This is the direction a
+    // check-that-never-passes would silently break, and the negative test above cannot catch it.
+  });
+
+  it('distinguishes a PARTIAL read from a full one', () => {
+    const c = checkCoordinatorContractRead(REPO, stateWith({ readCount: 1, lastReadWasPartial: true }));
+    expect(c.contract_read).toBe(true);
+    expect(c.contract_read_partial).toBe(true);
+
+    // MUTATION: drop the lastReadWasPartial read -> partial collapses into "read", fails.
+  });
+
+  it('honours the legacy protocolFilesRead array shape', () => {
+    const c = checkCoordinatorContractRead(REPO, () => ({ protocolFilesRead: [COORDINATOR_CONTRACT_FILE] }));
+    expect(c.contract_read).toBe(true);
+  });
+
+  it('NEVER THROWS — startup must not be blocked by a broken state file', () => {
+    // Fail-open is a hard contract here: a gate that stops a coordinator from starting because it
+    // has not read the contract it is starting in order to read is a deadlock. The script's own
+    // documented contract is "exit code is ALWAYS 0".
+    expect(() => checkCoordinatorContractRead(REPO, () => { throw new Error('corrupt state'); })).not.toThrow();
+    expect(checkCoordinatorContractRead(REPO, () => { throw new Error('corrupt'); }).contract_read).toBe(false);
+    expect(() => checkCoordinatorContractRead(REPO, () => null)).not.toThrow();
+    expect(() => checkCoordinatorContractRead(REPO, () => ({}))).not.toThrow();
+
+    // MUTATION: remove the try/catch -> the throwing reader propagates and this fails.
+  });
+});
+
+describe('renderContractRead', () => {
+  it('says NO RECORD when unread', () => {
+    const out = renderContractRead(REPO, { contract_file: COORDINATOR_CONTRACT_FILE, contract_exists: true, contract_read: false, contract_read_partial: false, contract_last_read_at: null });
+    expect(out).toContain('NO RECORD');
+    expect(out).not.toContain('✅ CLAUDE_COORDINATOR.md read');
+  });
+
+  it('confirms the read when present', () => {
+    const out = renderContractRead(REPO, { contract_file: COORDINATOR_CONTRACT_FILE, contract_exists: true, contract_read: true, contract_read_partial: false, contract_last_read_at: '2026-07-29T00:00:00Z' });
+    expect(out).toContain('✅');
+    expect(out).not.toContain('NO RECORD');
+  });
+
+  it('flags a missing contract file distinctly from an unread one', () => {
+    const out = renderContractRead(REPO, { contract_file: COORDINATOR_CONTRACT_FILE, contract_exists: false, contract_read: false, contract_read_partial: false, contract_last_read_at: null });
+    expect(out).toContain('not found');
+    expect(out).not.toContain('NO RECORD');
+
+    // MUTATION: collapse the not-found branch into the unread branch -> "regenerate the file" advice
+    // is replaced by "go read it", which is unactionable when it does not exist. Fails.
+  });
+
+  it('RENDERS the disarmed roles rather than leaving coverage to inference', () => {
+    // Per-role arming's one real risk is someone assuming uniform coverage. The mitigation is that
+    // the disarmed roles are printed, not implied.
+    const out = renderContractRead(REPO, { contract_file: COORDINATOR_CONTRACT_FILE, contract_exists: true, contract_read: true, contract_read_partial: false, contract_last_read_at: null });
+    expect(out).toContain('coordinator : ARMED');
+    expect(out).toContain('adam        : disarmed');
+    expect(out).toContain('solomon     : disarmed');
+
+    // MUTATION: drop the per-role table -> a reader sees a green coordinator check and reasonably
+    // infers all three roles are covered. Fails.
+  });
+});
+
+describe('PROTOCOL_FILES tracking prerequisite', () => {
+  it('the tracker knows about CLAUDE_COORDINATOR.md', async () => {
+    // Without this the whole feature is inert: the coordinator could read its contract and the hook
+    // would record nothing, leaving the check with nothing to consult. Verified end-to-end during
+    // EXEC by driving the real hook and watching the banner flip from NO RECORD to read.
+    const { readFileSync } = await import('node:fs');
+    const src = readFileSync(new URL('../../../scripts/hooks/protocol-file-tracker.cjs', import.meta.url), 'utf8');
+    expect(src).toContain("'CLAUDE_COORDINATOR.md'");
+
+    // MUTATION: remove it from PROTOCOL_FILES -> reads go untracked and the check can never pass.
+  });
+});

--- a/tests/unit/protocol/contract-read-coverage.test.js
+++ b/tests/unit/protocol/contract-read-coverage.test.js
@@ -1,0 +1,123 @@
+/**
+ * SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 — FR-3 / FR-4 / FR-5, TS-3 and TS-4.
+ *
+ * *** THE DEFECT WAS AN INVERSION, SO BOTH HALVES MUST BE TESTED. *** Testing only one half passes
+ * against the bug: a function that always says "fully read" satisfies the diligent-reader case, and
+ * one that always says "not fully read" satisfies the truncated-reader case. Neither is correct.
+ *   truncating no-offset read  -> recorded "full"    (must now be NOT fully read)
+ *   diligent paginated read    -> recorded "partial" (must now be fully read)
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require_ = createRequire(import.meta.url);
+const { contractReadVerdict, FULL_COVERAGE_PCT } = require_('../../../lib/protocol/contract-read-coverage.cjs');
+
+describe('contractReadVerdict — the inversion, both halves', () => {
+  it('THE DILIGENT READER: paginated full coverage reports FULLY READ', () => {
+    // Exactly what the old code punished: the final page carries a limit, so lastReadWasPartial
+    // was true and the reader who did the work was recorded incomplete.
+    const status = {
+      readCount: 3,
+      lastReadWasPartial: true, // the old signal, now correctly ignored
+      ranges: [
+        { offset: 1, limit: 200 },
+        { offset: 201, limit: 200 },
+        { offset: 401, limit: 21 },
+      ],
+    };
+    const v = contractReadVerdict(status, 421);
+    expect(v.read).toBe(true);
+    expect(v.fully_read).toBe(true);
+    expect(v.basis).toBe('union_ranges');
+
+    // MUTATION: read status.lastReadWasPartial instead of computing coverage -> fully_read false, fails.
+  });
+
+  it('THE TRUNCATED READER: a no-arg read that delivered part of the file is NOT fully read', () => {
+    // The half that actually lets an unread contract pass. No limit/offset was passed, so the old
+    // code recorded "confirmed full" and ranges[] never saw it at all.
+    const status = {
+      readCount: 1,
+      lastReadWasPartial: false, // the old signal said FULL — this is the inversion
+      lastDelivered: { startLine: 1, numLines: 166, totalLines: 421, coveredWholeFile: false },
+    };
+    const v = contractReadVerdict(status, 421);
+    expect(v.read).toBe(true);
+    expect(v.fully_read).toBe(false);
+    expect(v.basis).toBe('delivered_lines');
+    expect(v.coverage_pct).toBe(39);
+
+    // MUTATION: trust lastReadWasPartial -> fully_read true, fails. This is the assertion that
+    // proves the lazy-reader false positive is closed, and it is the one the ranges-only fix
+    // could NOT have made pass.
+  });
+
+  it('delivered evidence OUTRANKS ranges when both are present', () => {
+    // A file can have historical paginated ranges AND a recent truncated read. The truncated read is
+    // the more recent fact about what this session actually has in hand.
+    const status = {
+      readCount: 4,
+      ranges: [{ offset: 1, limit: 421 }],
+      lastDelivered: { startLine: 1, numLines: 100, totalLines: 421, coveredWholeFile: false },
+    };
+    const v = contractReadVerdict(status, 421);
+    expect(v.fully_read).toBe(false);
+    expect(v.basis).toBe('delivered_lines');
+
+    // MUTATION: check ranges before lastDelivered -> stale full coverage wins, fully_read true, fails.
+  });
+
+  it('a genuinely complete delivered read reports FULLY READ', () => {
+    const status = { readCount: 1, lastDelivered: { startLine: 1, numLines: 99, totalLines: 99, coveredWholeFile: true } };
+    const v = contractReadVerdict(status, 99);
+    expect(v.fully_read).toBe(true);
+    expect(v.coverage_pct).toBe(100);
+
+    // MUTATION: always return fully_read false -> fails. Without this the suite would pass against
+    // a function that can never confirm a read.
+  });
+});
+
+describe('contractReadVerdict — absence is reported as absence', () => {
+  it('a read with NO coverage evidence is NOT promoted to fully read', () => {
+    // This is precisely the state the old code reached and answered "full" for.
+    const status = { readCount: 1, lastReadWasPartial: false };
+    const v = contractReadVerdict(status, 421);
+    expect(v.read).toBe(true);
+    expect(v.fully_read).toBe(false);
+    expect(v.coverage_pct).toBeNull();
+    expect(v.basis).toBe('unknown_coverage');
+
+    // MUTATION: default fully_read to true when evidence is missing -> fails. Inferring coverage
+    // from a missing value is the original defect in another costume.
+  });
+
+  it('no read at all is neither read nor fully read', () => {
+    expect(contractReadVerdict(null, 421)).toMatchObject({ read: false, fully_read: false, basis: 'no_read_recorded' });
+    expect(contractReadVerdict({ readCount: 0 }, 421)).toMatchObject({ read: false, fully_read: false });
+  });
+
+  it('ranges are ignored when the file line count is unknown', () => {
+    // Coverage of an unknown total is not a percentage, and guessing one would be worse than saying
+    // so — a fabricated denominator produces a confident wrong answer.
+    const v = contractReadVerdict({ readCount: 1, ranges: [{ offset: 1, limit: 100 }] }, null);
+    expect(v.fully_read).toBe(false);
+    expect(v.basis).toBe('unknown_coverage');
+  });
+});
+
+describe('coverage threshold', () => {
+  it('partial union coverage below the bar is not a full read', () => {
+    const v = contractReadVerdict({ readCount: 1, ranges: [{ offset: 1, limit: 200 }] }, 421);
+    expect(v.fully_read).toBe(false);
+    expect(v.coverage_pct).toBeLessThan(FULL_COVERAGE_PCT);
+  });
+
+  it('overlapping ranges are unioned, not summed', () => {
+    // Summing would report 200% coverage of a 100-line file and pass anything.
+    const v = contractReadVerdict({ readCount: 2, ranges: [{ offset: 1, limit: 100 }, { offset: 1, limit: 100 }] }, 200);
+    expect(v.coverage_pct).toBe(50);
+
+    // MUTATION: sum the limits instead of unioning -> 100%, fully_read true, fails.
+  });
+});

--- a/tests/unit/protocol/contract-read-coverage.test.js
+++ b/tests/unit/protocol/contract-read-coverage.test.js
@@ -106,6 +106,53 @@ describe('contractReadVerdict — absence is reported as absence', () => {
   });
 });
 
+describe('single-read-safe size — the tier a CI failure forced me to add', () => {
+  /**
+   * My first cut required positive coverage evidence unconditionally. Correct for an over-cap
+   * contract, WRONG for a small one: with no lastDelivered and no ranges, a perfectly good single
+   * read of a 25KB file reported "partial" forever — a permanent false alarm on every startup, and
+   * a warning that always fires gets demoted to noise. That is the failure this SD exists to remove,
+   * so trading a false positive for a false negative is not a fix. CI caught it; two tests in
+   * tests/unit/adam/ that I had not run locally were asserting the correct behaviour all along.
+   */
+  const SAFE = 25_000;   // ~CLAUDE_COORDINATOR.md
+  const OVER = 104_000;  // ~CLAUDE_ADAM.md
+
+  it('a small contract read without a partial flag IS fully read, with no further evidence', () => {
+    const v = contractReadVerdict({ readCount: 1, lastReadWasPartial: false }, 99, { sizeBytes: SAFE });
+    expect(v.fully_read).toBe(true);
+    expect(v.basis).toBe('single_read_safe_size');
+
+    // MUTATION: drop the size tier -> falls to unknown_coverage, fully_read false, fails. That was
+    // literally my shipped state, and it is why CI went red.
+  });
+
+  it('the SAME evidence on an OVER-CAP contract is NOT fully read', () => {
+    // The discriminating pair. One assertion alone cannot distinguish "size tier works" from
+    // "everything passes" — this is the half that proves the tier is bounded.
+    const v = contractReadVerdict({ readCount: 1, lastReadWasPartial: false }, 421, { sizeBytes: OVER });
+    expect(v.fully_read).toBe(false);
+    expect(v.basis).toBe('unknown_coverage');
+
+    // MUTATION: raise the threshold above 104KB, or drop the bound entirely -> the truncated read on
+    // CLAUDE_ADAM.md counts as complete again and the original defect returns. Fails.
+  });
+
+  it('a small contract whose last read WAS partial still is not waved through', () => {
+    const v = contractReadVerdict({ readCount: 1, lastReadWasPartial: true }, 99, { sizeBytes: SAFE });
+    expect(v.basis).not.toBe('single_read_safe_size');
+
+    // MUTATION: drop the lastReadWasPartial check from the size tier -> a deliberately partial read
+    // of a small file reports complete. Fails.
+  });
+
+  it('an unknown size does not enter the tier', () => {
+    // A missing stat must not be read as "small". Absence is not evidence, at every tier.
+    const v = contractReadVerdict({ readCount: 1, lastReadWasPartial: false }, 421, { sizeBytes: null });
+    expect(v.fully_read).toBe(false);
+  });
+});
+
 describe('coverage threshold', () => {
   it('partial union coverage below the bar is not a full read', () => {
     const v = contractReadVerdict({ readCount: 1, ranges: [{ offset: 1, limit: 200 }] }, 421);


### PR DESCRIPTION
The SD asked for a hard post-compaction read gate "mirroring what LEAD/PLAN/EXEC already have". Reading the model first turned this from a build into a wiring job — and surfaced worse than the reported defect.

## No live path could hard-block an unread protocol file

Three independent ways to pass without reading:

| Where | Behaviour |
|---|---|
| `core-protocol-gate.js:600` | `validateSdStartGate` unconditionally soft-passes: *"Auto-passing: CLAUDE.md is in system prompt"* |
| `protocol-file-read-gate.js:300` | auto-passes any partial read ≥ 30 lines |
| `protocol-file-read-gate.js:438` | `PASS_FALLBACK` passes a file **never read at all**, if it merely exists on disk |

The model wasn't weak — it was inert. Mirroring it would have shipped a gate passing on 30 of CLAUDE_ADAM.md's 491 lines, which would not have caught the failure the SD cites (the scribe ceremony is at line 440).

## FR-1 — the gate was manufacturing its own evidence

`PASS_FALLBACK` didn't just fail open. It called `markProtocolFileRead()`, commented *"fix session state for future handoffs"* — so a **never-read file was stamped as read**. Every later handoff then passed legitimately on a record the gate had invented, and the failure couldn't be reproduced because the first run destroyed its own precondition.

It still passes (blocking would wedge sessions with genuinely missing state), but passing without a read and *recording* a read are different acts. Only the second corrupts the trail.

## FR-3 — the stamp was inverted, and it punished diligence

Both registers answered "was the contract read?" from `lastReadWasPartial`, a boolean about the *most recent call*. On an over-cap contract that's backwards:

- a no-offset Read **truncates at line 166 of 421** → records "read"
- a diligent paginated full read → records "partial"

Filed as feedback `39c3d27d` on 2026-07-19, mis-titled *"cannot represent a paginated read"* — which is why it sat ten days. The capability was already there; the consumer never looked.

**Fixed at the consumer, deliberately.** The obvious place is the tracker, and it's the wrong one: that stamp also feeds `protocol-file-read-gate.js:159`, wired into all four handoff executors, so redefining "partial" would change handoff gating fleet-wide to fix a two-role defect.

## The rest

- **FR-2** — the coordinator had a readable contract and *no verifier of any kind*; its priming ended in a self-attestation nothing checked. Prerequisite that wasn't in scope: `CLAUDE_COORDINATOR.md` wasn't tracked at all, so a check would've had nothing to consult. Verified end-to-end in **both** directions — a check that can only say "not read" is as useless as one that can only say "read".
- **FR-4** — imported `unionRangeCoverage` rather than authoring a fourth implementation; deliberately did **not** adopt its sibling `computeCoveragePercent`, which reproduces this very truncation bug. Retired the dead `validatePostCompactionGate` rather than leaving a trap named after the exact thing the next person will grep for.
- **FR-5** — capture what a read *delivered*, additively. `lastReadWasPartial` untouched, so handoff gating is byte-identical.
- **FR-6** — per-role arming **rendered**, not implied. Adam and Solomon stay disarmed; no session is blocked.

## Verification

- **182 test files, 1966 passing**, 1 skipped. 29 new tests, none quarantined (three of the four this SD originally cited as a regression net turned out to be quarantined and skip silently).
- Every mutation applied, **verified landed**, observed failing, reverted.
- All four handoff executors fail a bare import — **not mine**: stashed every change and reproduced identically on the untouched base. Checked because "I removed an export and the executors fail" is the shape of a real regression.

## Open, stated rather than assumed closed

Whether the harness supplies `tool_response` to the hook is **unverified**. The PostToolUse hook executes the main-tree script, so an instrumented worktree copy is never exercised by a real read until merged. The mechanism works when the field is present (50-of-99 correctly flagged TRUNCATED); consumers treat absence as *unknown*, never complete.

This SD arms **one role of three**. It does not make Adam or Solomon compliant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)