### PR TITLE
feat(SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001): gate unattended sourcing on real belt demand [OPEN — not merged]

### DIFF
--- a/lib/governance/demand-gate-emit.js
+++ b/lib/governance/demand-gate-emit.js
@@ -1,0 +1,170 @@
+/**
+ * SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 — FR-3. The IO half of the demand gate:
+ * MEASURE the gauge, RECORD the decision, READ it back for a human.
+ *
+ * WHY THIS IS A SEPARATE FILE. demand-gate.js is pure and DB-free on purpose (its header explains
+ * that a DB-touching decider routes its own tests into the vitest `db` project, which resolves to
+ * ZERO files and reports green having executed nothing). All IO lives here so that split holds.
+ *
+ * WHY FR-3 EXISTS AT ALL — it is the FR that stops this SD becoming an instance of its own thesis.
+ * FR-1 replaced a boolean nobody noticed with a CONDITION. A condition nobody notices is no better:
+ * an engine that correctly withholds forever looks exactly like an engine that is off, or crashed,
+ * or was never wired. The gate only pays for itself if its verdict is READABLE, so the decision is
+ * emitted on EVERY run — sourced, withheld and unmeasurable alike — and rendered in the same badge
+ * that prints the flag line, per the unconditional-print precedent at
+ * lib/coordinator/worker-signal-starvation.cjs:18.
+ *
+ * ── THE THREE FAILURE MODES THIS FILE IS SHAPED AROUND ──────────────────────────────────────────
+ * (1) THE GAUGE IS FAIL-LOUD. belt-depth.cjs:78 passes throwOnError deliberately: a dependency
+ *     query it cannot verify must NOT be counted as dispatchable. Letting that throw propagate
+ *     would take down the hourly cron, so measureDemand catches it — and maps it to UNMEASURABLE,
+ *     never to a number. Catch-and-continue would be fail-open; catch-and-withhold is fail-closed
+ *     AND visible, which is the whole point.
+ * (2) A RECORDING FAILURE MUST NOT CHANGE THE DECISION, but it must be loud. If recording silently
+ *     failed we would have a run that produced and left no trace — invisible production, this SD's
+ *     defect with the sign flipped. So recordDemandDecision returns a boolean and complains to
+ *     stderr; it never throws, and it never gates production.
+ * (3) A MALFORMED RECORD MUST NOT READ AS A DECISION. readLastDemandDecision returns null for "no
+ *     run recorded" (which renders NEVER RAN) but a synthetic UNMEASURABLE for a row that exists
+ *     and is unreadable — because a truthy-but-corrupt cache that suppresses the honest fallback is
+ *     its own well-known trap. "I found a record I cannot parse" is not "no record".
+ *
+ * NO DDL. audit_log already exists with a jsonb `metadata` column and is the repo's append-only
+ * event sink. A purpose-built table would need a chairman-gated prod apply to make an observability
+ * line readable — disproportionate, and the ceremony would be the reason FR-3 got deferred.
+ * Write/read round-trip verified against the live table before this file was written (service-role
+ * insert returned the row rather than the 200/error:null/0-rows shape an RLS rejection produces).
+ *
+ * @module governance/demand-gate-emit
+ */
+import { countDispatchableBacklog } from '../fleet/belt-depth.cjs';
+import { normalizeGaugeReading, decideDemand } from './demand-gate.js';
+
+/** audit_log.event_type for a demand-gate verdict. One event, every decision. */
+export const DEMAND_GATE_EVENT = 'DEMAND_GATE_DECISION';
+
+/**
+ * Belt depth at or below which production is warranted.
+ *
+ * NOT a magic number and NOT a permanent one. The fleet runs at most 3 concurrent worker seats, so
+ * 3 claimable items ≈ one per seat — enough that no seat idles, few enough that the belt is not
+ * being stuffed. The nearest existing constant, BELT_BUFFER=1 at
+ * scripts/coordinator-capacity-forecast.mjs:104, is demand-RELATIVE (idle+freeing-soon workers plus
+ * a buffer) rather than absolute, so it could not be reused directly without importing the
+ * forecaster's whole worker-state read into an hourly cron.
+ *
+ * The honest status of this value is STARTING POINT. It is exactly what FR-3's emission makes
+ * tunable: once gauge_value and floor are recorded on every run, the floor stops being a guess and
+ * becomes a choice against an observed series. Overridable per-deployment via BELT_DEMAND_FLOOR.
+ */
+export const DEFAULT_DEMAND_FLOOR = 3;
+
+/**
+ * Resolve the floor from env. A PRESENT-BUT-UNPARSEABLE value yields NaN on purpose: decideDemand
+ * rejects a non-finite floor as UNMEASURABLE, so `BELT_DEMAND_FLOOR=lots` withholds loudly instead
+ * of silently reverting to the default. Absent means "no opinion" and takes the default; garbage
+ * means someone tried to configure this and got it wrong, which must not look like success.
+ * @param {Record<string,string|undefined>} [env]
+ * @returns {number} finite floor, or NaN when configured-but-invalid
+ */
+export function resolveDemandFloor(env = process.env) {
+  const raw = env ? env.BELT_DEMAND_FLOOR : undefined;
+  if (raw === undefined || raw === null || raw === '') return DEFAULT_DEMAND_FLOOR;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : NaN;
+}
+
+/**
+ * Read the gauge and decide. The ONE place a producer needs to call before minting.
+ *
+ * @param {object} supabase service-role client
+ * @param {{engine:string, floor?:number, now?:string, gauge?:Function}} opts
+ *   `gauge` is injectable so the failure modes above are unit-testable without a database — the
+ *   real gauge needs live rows to throw, and a failure path nobody can exercise is not a guard.
+ * @returns {Promise<ReturnType<typeof decideDemand>>} always a decision, never a throw
+ */
+export async function measureDemand(supabase, { engine, floor, now, gauge = countDispatchableBacklog } = {}) {
+  let raw = null;
+  try {
+    raw = await gauge(supabase);
+  } catch (e) {
+    // Failure mode (1). The reading stays null → normalizeGaugeReading → UNMEASURABLE → withheld.
+    // Note what is NOT here: no `raw = { dispatchable: 0 }` fallback. Treating an unread gauge as
+    // an empty belt is the fail-open flood in its most tempting disguise.
+    if (typeof process !== 'undefined' && process.stderr) {
+      process.stderr.write(`[demand-gate] gauge read failed for ${engine}: ${e && e.message} — withholding\n`);
+    }
+  }
+  return decideDemand(normalizeGaugeReading(raw), floor, {
+    engine,
+    measuredAt: now || new Date().toISOString(),
+  });
+}
+
+/**
+ * Persist a decision. Best-effort by design (failure mode 2): returns false and warns rather than
+ * throwing, because losing the audit line must never stop — or start — production.
+ * @returns {Promise<boolean>} true when the row was written AND returned
+ */
+export async function recordDemandDecision(supabase, decision) {
+  if (!supabase || !decision) return false;
+  try {
+    const { data, error } = await supabase.from('audit_log').insert({
+      event_type: DEMAND_GATE_EVENT,
+      entity_type: 'sourcing_engine',
+      entity_id: decision.engine,
+      metadata: decision,
+      severity: decision.decision === 'unmeasurable' ? 'warning' : 'info',
+      created_by: 'demand-gate',
+    }).select('id');
+    if (error) throw new Error(error.message);
+    // .select() is not decorative: a silently-rejected insert in this codebase returns HTTP 200
+    // with error=null and zero rows, so "no error" alone is not evidence the row landed.
+    return (data || []).length > 0;
+  } catch (e) {
+    if (typeof process !== 'undefined' && process.stderr) {
+      process.stderr.write(`[demand-gate] decision NOT recorded for ${decision.engine}: ${e && e.message}\n`);
+    }
+    return false;
+  }
+}
+
+/**
+ * Read the most recent recorded decision for one engine.
+ *
+ * @returns {Promise<object|null>} the decision, null when NOTHING has ever been recorded (which the
+ *   renderer prints as NEVER RAN), or a synthetic UNMEASURABLE when a row exists but is unreadable
+ *   (failure mode 3 — never silently downgraded to "no run").
+ */
+export async function readLastDemandDecision(supabase, engine) {
+  if (!supabase || !engine) return null;
+  let row;
+  try {
+    const { data, error } = await supabase
+      .from('audit_log')
+      .select('metadata, created_at')
+      .eq('event_type', DEMAND_GATE_EVENT)
+      .eq('entity_id', engine)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (error) throw new Error(error.message);
+    row = (data || [])[0];
+  } catch (e) {
+    // A read fault is NOT "never ran" either — the badge must not report a healthy silence it
+    // could not verify.
+    return {
+      engine, gauge_value: null, floor: null, decision: 'unmeasurable',
+      reason: `could not read the decision log (${e && e.message})`, measured_at: null,
+    };
+  }
+  if (!row) return null;
+  const m = row.metadata;
+  if (!m || typeof m !== 'object' || typeof m.decision !== 'string') {
+    return {
+      engine, gauge_value: null, floor: null, decision: 'unmeasurable',
+      reason: 'a decision row exists but its payload is unreadable — this is NOT a run that never happened',
+      measured_at: row.created_at || null,
+    };
+  }
+  return m;
+}

--- a/lib/governance/demand-gate.js
+++ b/lib/governance/demand-gate.js
@@ -1,0 +1,194 @@
+/**
+ * SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 — a DEMAND gate, not a volume cap.
+ *
+ * CHAIRMAN-DIRECTED. He rejected a "turn two flags on and watch one cycle" plan verbatim: "Is
+ * there a way to keep them on, but then make them intelligent enough so they're not overwhelming?
+ * My fear is that we're just going to forget that they're off." That fear is the dominant defect
+ * class here — AN OFF FLAG IS INDISTINGUISHABLE FROM AN ON-AND-QUIET FLAG. Off has no expiry, no
+ * reminder, and nothing that reports it. A watch-one-cycle plan is a VIGILANCE control, and
+ * vigilance demonstrably decays in this system (measured the same day: a coordinator skipped an
+ * OVERDUE block three ticks running as known noise; Solomon demoted a false staleness WARN to
+ * noise by its third reading). A CONDITION does not decay. So: replace the boolean with a
+ * condition, and make the condition's verdict observable every run.
+ *
+ * THE DEFECT THIS REPLACES. lib/sourcing-engine/adam-direct-registry.js:202 bounds a run at 100
+ * items and consumes it at :205 as `.slice(0, cap)` over an ALREADY-ENUMERATED population. That
+ * is a VOLUME cap: it limits how much a run PRODUCES, never WHETHER it should produce. A 100-item
+ * cap floods a saturated belt exactly as fast as a starved one, 100 at a time — which is why the
+ * only safe-feeling setting has been off. Verified negative: ripgrep for
+ * countDispatchableBacklog|belt-depth|belt_depth|dispatchable across ALL of lib/sourcing-engine/
+ * returns ZERO matches. The demand signal exists and the engines are its one non-consumer.
+ *
+ * ── WHY THIS FILE IS SHAPED THE WAY IT IS ────────────────────────────────────────────────────
+ * A NAIVE FLOOR CHECK MOVES THE INVISIBILITY RATHER THAN REMOVING IT, and that would make this SD
+ * an instance of its own thesis. Three paths, all silent:
+ *   (1) the gauge throws (belt-depth.cjs is deliberately fail-loud) and an unguarded gate
+ *       propagates the fault into an unrelated stack;
+ *   (2) a fail-soft caller yields null and `null > FLOOR` evaluates FALSE — so the engine SOURCES
+ *       ANYWAY. A FAIL-OPEN FLOOD, arrived at by an operator precedence nobody reads;
+ *   (3) a catch-and-return leaves an engine permanently quiet, BYTE-IDENTICAL to correctly-quiet.
+ * The same trap has a second mouth: a non-finite FLOOR. `5 > NaN` is also false, so a
+ * misconfigured floor sources exactly like a null gauge, with the same blast radius.
+ *
+ * THE FIX IS OPERAND-LEVEL, NOT ASSERTION-LEVEL. normalizeGaugeReading() is the ONLY constructor
+ * of a comparable value, and decideDemand() rejects a non-ok reading and a non-finite floor in its
+ * FIRST statements. `reading.value > floor` is therefore reachable only where BOTH operands are
+ * proven finite. That property holds for callers who do not exist yet — which is precisely what a
+ * unit assertion on one call site cannot give you. (TESTING review 372d5539, condition C1.)
+ *
+ * `unmeasurable` IS A FIRST-CLASS DECISION, never folded into either other outcome. "I could not
+ * tell" is the state this whole SD is about; collapsing it into `sourced` re-creates the flood and
+ * collapsing it into `withheld` re-creates the silent-off. Callers MUST branch on all three.
+ *
+ * PURE AND DB-FREE ON PURPOSE (the split documented at lib/governance/drain-inventory.js:9-14):
+ * all IO belongs to the caller. A DB-touching decider would route its tests to the vitest `db`
+ * project, which resolves to ZERO files unless a designated non-prod target is named — it would
+ * report green having executed nothing, which is the same defect class in the test tier.
+ *
+ * @module governance/demand-gate
+ */
+
+/** The three decisions. Exhaustive: a caller that handles two of them has a bug. */
+export const DEMAND_DECISION = Object.freeze({
+  /** Belt is at or below the floor — demand exists, produce. */
+  SOURCED: 'sourced',
+  /** Belt is above the floor — real demand is absent, stay quiet. This is a HEALTHY outcome. */
+  WITHHELD: 'withheld',
+  /** The gauge could not be read, or the floor is not a number. NOT a reason to produce. */
+  UNMEASURABLE: 'unmeasurable',
+});
+
+/**
+ * Wrap a raw gauge result into the ONLY shape decideDemand will compare.
+ *
+ * Returns a tagged union so an unreadable gauge cannot reach a numeric comparison at all. Accepts
+ * either the full countDispatchableBacklog result ({dispatchable, raw, ineligible}) or a bare
+ * number, because a caller that already has the count should not have to fabricate an envelope.
+ *
+ * @param {{dispatchable:number}|number|null|undefined} raw
+ * @returns {{ok:true, value:number}|{ok:false, reason:string}}
+ */
+export function normalizeGaugeReading(raw) {
+  if (raw === null || raw === undefined) return { ok: false, reason: 'gauge_absent' };
+  const value = typeof raw === 'number' ? raw : raw.dispatchable;
+  // Number.isFinite rejects NaN and both Infinities. A gauge that returned NaN is NOT a zero
+  // backlog — treating it as one would source into a belt whose depth is unknown.
+  if (!Number.isFinite(value)) return { ok: false, reason: 'gauge_not_finite' };
+  if (value < 0) return { ok: false, reason: 'gauge_negative' };
+  return { ok: true, value };
+}
+
+/**
+ * Decide whether a producer may source, from an already-obtained gauge reading.
+ *
+ * PURE: no DB, no fs, no clock beyond the caller-supplied measuredAt. The caller does the IO and
+ * hands in the reading, so this stays in the unit tier.
+ *
+ * Return shape follows lib/cost/governor.js:60-83 ({action, measured, reason}) so a SUPPRESSED run
+ * carries its own evidence — a withheld run that cannot say what it measured is the invisibility
+ * this SD exists to remove.
+ *
+ * @param {{ok:boolean, value?:number, reason?:string}} reading  from normalizeGaugeReading
+ * @param {number} floor  produce only when value <= floor
+ * @param {{engine?:string, measuredAt?:string}} [meta]
+ * @returns {{engine:string, gauge_value:(number|null), floor:(number|null),
+ *   decision:string, reason:string, measured_at:(string|null)}}
+ */
+export function decideDemand(reading, floor, meta = {}) {
+  const engine = typeof meta.engine === 'string' && meta.engine ? meta.engine : 'unknown';
+  const measured_at = typeof meta.measuredAt === 'string' ? meta.measuredAt : null;
+
+  // ── The two guards that make the comparison below safe. Order matters only for the reason
+  // string; either failing means we do not know enough to permit production.
+  if (!reading || reading.ok !== true) {
+    return {
+      engine,
+      gauge_value: null,
+      floor: Number.isFinite(floor) ? floor : null,
+      decision: DEMAND_DECISION.UNMEASURABLE,
+      reason: `gauge unreadable (${(reading && reading.reason) || 'no_reading'}) — NOT a licence to produce`,
+      measured_at,
+    };
+  }
+  if (!Number.isFinite(floor)) {
+    // `value > NaN` is false, which would SOURCE. Caught here so a misconfigured floor fails
+    // closed-and-loud rather than open-and-silent.
+    return {
+      engine,
+      gauge_value: reading.value,
+      floor: null,
+      decision: DEMAND_DECISION.UNMEASURABLE,
+      reason: 'floor is not a finite number — refusing to compare against it',
+      measured_at,
+    };
+  }
+
+  // Both operands proven finite. This is the only comparison in the module.
+  const sourced = reading.value <= floor;
+  return {
+    engine,
+    gauge_value: reading.value,
+    floor,
+    decision: sourced ? DEMAND_DECISION.SOURCED : DEMAND_DECISION.WITHHELD,
+    reason: sourced
+      ? `dispatchable ${reading.value} <= floor ${floor} — real demand, producing`
+      : `dispatchable ${reading.value} > floor ${floor} — belt already has work, staying quiet (this is healthy, not a fault)`,
+    measured_at,
+  };
+}
+
+/**
+ * True only for the decision that permits production. Exists so no caller re-implements the
+ * comparison and accidentally re-introduces a truthiness check on the whole object (every
+ * decision object is truthy, including `withheld`).
+ * @param {{decision?:string}} d
+ * @returns {boolean}
+ */
+export function mayProduce(d) {
+  return !!d && d.decision === DEMAND_DECISION.SOURCED;
+}
+
+/**
+ * One-line rendering. Prints the numbers UNCONDITIONALLY — including zeroes — following
+ * lib/coordinator/worker-signal-starvation.cjs:18, so measured-and-withheld is distinguishable
+ * from never-ran. A gate whose quiet run prints nothing is the defect wearing a new hat.
+ * @param {ReturnType<typeof decideDemand>|null|undefined} d
+ * @returns {string}
+ */
+export function formatDemandDecision(d) {
+  if (!d) return '[demand-gate] NEVER RAN — no decision recorded (this is NOT the same as withheld)';
+  if (d.decision === DEMAND_DECISION.UNMEASURABLE) {
+    return `[demand-gate] ${d.engine}: UNMEASURABLE gauge=${d.gauge_value ?? 'n/a'} floor=${d.floor ?? 'n/a'} — ${d.reason}`;
+  }
+  return `[demand-gate] ${d.engine}: ${d.decision.toUpperCase()} gauge=${d.gauge_value} floor=${d.floor} — ${d.reason}`;
+}
+
+/**
+ * PRODUCERS GATED ON BELT DEPTH — an explicit membership list, not an implicit convention.
+ *
+ * The load-bearing axis is WHICH TABLE A PRODUCER WRITES, not routing-vs-generative. These write
+ * strategic_directives_v2 / quick_fixes, so they move the number this gauge counts.
+ *
+ * Deliberately EXCLUDED (they write roadmap_wave_items — STAGING — and do not move belt depth at
+ * all): gauge-gap-miner, proactive-populator, adam-direct-registry. Gating corpus PREPARATION on
+ * the state of the BELT is the wrong instrument, and classifyCorpusGatedDeficit
+ * (scripts/lib/sourcing-engine-awareness.mjs:144) already establishes that a thin corpus-gated
+ * belt is the CORRECT state. Note adam-direct-registry is the 100-cap the SD spine leads with —
+ * verification showed it registers ALREADY-EXISTING SDs and adds zero belt depth.
+ *
+ * Exported as data so a test can assert membership. An "assert the stagers still work" test would
+ * assert the absence of a change to files this SD never touches — green before, green after, and
+ * green if this module were deleted. Membership can actually fail. (TESTING review 372d5539.)
+ */
+export const BELT_DEPTH_GATED_PRODUCERS = Object.freeze([
+  'refill-auto-promote',
+  'fr-c-generator',
+]);
+
+/** Stagers, named so their exclusion is a recorded decision rather than an oversight. */
+export const STAGING_PRODUCERS_NOT_GATED = Object.freeze([
+  'gauge-gap-miner',
+  'proactive-populator',
+  'adam-direct-registry',
+]);
+

--- a/lib/governance/demand-gate.js
+++ b/lib/governance/demand-gate.js
@@ -153,10 +153,12 @@ export function mayProduce(d) {
  * lib/coordinator/worker-signal-starvation.cjs:18, so measured-and-withheld is distinguishable
  * from never-ran. A gate whose quiet run prints nothing is the defect wearing a new hat.
  * @param {ReturnType<typeof decideDemand>|null|undefined} d
+ * @param {string} [engineName] names the engine in the NEVER-RAN case, where there is no decision
+ *   object to read it from — "which engine never ran" is the actionable half of that line.
  * @returns {string}
  */
-export function formatDemandDecision(d) {
-  if (!d) return '[demand-gate] NEVER RAN — no decision recorded (this is NOT the same as withheld)';
+export function formatDemandDecision(d, engineName) {
+  if (!d) return `[demand-gate] ${engineName || 'sourcing engine'}: NEVER RAN — no decision recorded (this is NOT the same as withheld)`;
   if (d.decision === DEMAND_DECISION.UNMEASURABLE) {
     return `[demand-gate] ${d.engine}: UNMEASURABLE gauge=${d.gauge_value ?? 'n/a'} floor=${d.floor ?? 'n/a'} — ${d.reason}`;
   }

--- a/lib/governance/demand-gate.js
+++ b/lib/governance/demand-gate.js
@@ -24,8 +24,12 @@
  * an instance of its own thesis. Three paths, all silent:
  *   (1) the gauge throws (belt-depth.cjs is deliberately fail-loud) and an unguarded gate
  *       propagates the fault into an unrelated stack;
- *   (2) a fail-soft caller yields null and `null > FLOOR` evaluates FALSE — so the engine SOURCES
- *       ANYWAY. A FAIL-OPEN FLOOD, arrived at by an operator precedence nobody reads;
+ *   (2) a fail-soft caller yields null and the comparison silently succeeds — so the engine SOURCES
+ *       ANYWAY. A FAIL-OPEN FLOOD, arrived at by a coercion nobody reads. NOTE THE OPERATOR: this
+ *       module compares `value <= floor`, so `null` coerces to 0 and reads as an EMPTY belt. (An
+ *       earlier draft of this analysis was written for a `>` shape, where null fell the safe way.
+ *       The operator changed and the hazard flipped with it — which is why the guard below checks
+ *       the OPERANDS rather than trusting the comparison to fail safe.);
  *   (3) a catch-and-return leaves an engine permanently quiet, BYTE-IDENTICAL to correctly-quiet.
  * The same trap has a second mouth: a non-finite FLOOR. `5 > NaN` is also false, so a
  * misconfigured floor sources exactly like a null gauge, with the same blast radius.
@@ -100,7 +104,15 @@ export function decideDemand(reading, floor, meta = {}) {
 
   // ── The two guards that make the comparison below safe. Order matters only for the reason
   // string; either failing means we do not know enough to permit production.
-  if (!reading || reading.ok !== true) {
+  // SECURITY review 9891c0f5 (SEC-1): the guard originally tested only the `ok` TAG, never the
+  // VALUE. A hand-built {ok:true, value:null} therefore reached the comparison, and because the
+  // operator is `<=`, null coerces to 0 and reads as an EMPTY BELT — a SOURCED verdict on a gauge
+  // that was never read. Unreachable from today's callers (measureDemand always routes through
+  // normalizeGaugeReading), but the header below promises this property holds "for callers who do
+  // not exist yet", and that promise was false as written. The floor operand was already checked
+  // with Number.isFinite; the gauge operand now is too. Asymmetric guards on a two-operand
+  // comparison are how the safe half hides the unsafe half.
+  if (!reading || reading.ok !== true || !Number.isFinite(reading.value)) {
     return {
       engine,
       gauge_value: null,
@@ -159,10 +171,17 @@ export function mayProduce(d) {
  */
 export function formatDemandDecision(d, engineName) {
   if (!d) return `[demand-gate] ${engineName || 'sourcing engine'}: NEVER RAN — no decision recorded (this is NOT the same as withheld)`;
+  // SECURITY review 9891c0f5 (SEC-2): measured_at is printed UNCONDITIONALLY, because without it
+  // "the cron fired 5 minutes ago and correctly withheld" renders BYTE-IDENTICAL to "the workflow
+  // has been dead for three weeks and this verdict is fossilised". That is exactly the
+  // indistinguishability this module exists to remove — relocated one level up into the
+  // observability layer built to remove it. The decision has always carried the timestamp; the
+  // renderer was simply dropping it.
+  const at = ` measured_at=${d.measured_at || 'unstamped'}`;
   if (d.decision === DEMAND_DECISION.UNMEASURABLE) {
-    return `[demand-gate] ${d.engine}: UNMEASURABLE gauge=${d.gauge_value ?? 'n/a'} floor=${d.floor ?? 'n/a'} — ${d.reason}`;
+    return `[demand-gate] ${d.engine}: UNMEASURABLE gauge=${d.gauge_value ?? 'n/a'} floor=${d.floor ?? 'n/a'}${at} — ${d.reason}`;
   }
-  return `[demand-gate] ${d.engine}: ${d.decision.toUpperCase()} gauge=${d.gauge_value} floor=${d.floor} — ${d.reason}`;
+  return `[demand-gate] ${d.engine}: ${d.decision.toUpperCase()} gauge=${d.gauge_value} floor=${d.floor}${at} — ${d.reason}`;
 }
 
 /**

--- a/lib/governance/demand-gate.js
+++ b/lib/governance/demand-gate.js
@@ -31,12 +31,14 @@
  *       The operator changed and the hazard flipped with it — which is why the guard below checks
  *       the OPERANDS rather than trusting the comparison to fail safe.);
  *   (3) a catch-and-return leaves an engine permanently quiet, BYTE-IDENTICAL to correctly-quiet.
- * The same trap has a second mouth: a non-finite FLOOR. `5 > NaN` is also false, so a
- * misconfigured floor sources exactly like a null gauge, with the same blast radius.
+ * The same trap has a second mouth, and it bites the OTHER way: a non-finite FLOOR. `5 <= NaN` is
+ * false, so an unguarded misconfigured floor makes every run WITHHELD — the engine goes silently
+ * dark and looks correctly-quiet, which is this module's FOUNDING defect rather than the flood.
+ * Guarded anyway, and for that reason: an explicit UNMEASURABLE is loud, a silent WITHHELD is not.
  *
  * THE FIX IS OPERAND-LEVEL, NOT ASSERTION-LEVEL. normalizeGaugeReading() is the ONLY constructor
  * of a comparable value, and decideDemand() rejects a non-ok reading and a non-finite floor in its
- * FIRST statements. `reading.value > floor` is therefore reachable only where BOTH operands are
+ * FIRST statements. `reading.value <= floor` is therefore reachable only where BOTH operands are
  * proven finite. That property holds for callers who do not exist yet — which is precisely what a
  * unit assertion on one call site cannot give you. (TESTING review 372d5539, condition C1.)
  *
@@ -123,8 +125,12 @@ export function decideDemand(reading, floor, meta = {}) {
     };
   }
   if (!Number.isFinite(floor)) {
-    // `value > NaN` is false, which would SOURCE. Caught here so a misconfigured floor fails
-    // closed-and-loud rather than open-and-silent.
+    // `value <= NaN` is false, so unguarded this would WITHHELD every run — the engine goes dark
+    // and reads as correctly-quiet. Caught here so a misconfigured floor fails LOUD rather than
+    // silent. (RETRO 4cc2e3c1: three comments in this file described the `>` shape, where the same
+    // misconfiguration floods instead. The operator changed; the stated hazard did not follow it.
+    // A stale rationale sitting directly above the code is how the next reader re-introduces the
+    // bug while reading the warning about it.)
     return {
       engine,
       gauge_value: reading.value,

--- a/lib/sourcing-engine/refill-auto-promote.js
+++ b/lib/sourcing-engine/refill-auto-promote.js
@@ -16,6 +16,10 @@
  */
 import { randomUUID } from 'crypto';
 import { verifyStagedCandidates } from './refill-dry-run-verifier.js';
+// SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 (FR-2): mayProduce is the ONLY way to read a demand
+// decision. Never test the object for truthiness — every decision object is truthy, including
+// `withheld`, so `if (opts.demand)` would permit exactly the runs the gate exists to stop.
+import { mayProduce } from '../governance/demand-gate.js';
 import { buildTwoWayStamp, deriveSdFieldsFromRoadmapItem } from './register-first.js';
 // SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B (THE churn fix): the disposition-gate helpers.
 import { hasBuildDisposition, REFILL_INVALID_REASONS } from './refill-candidate-validity.js';
@@ -71,6 +75,37 @@ const ALLOWED_SD_TYPES = new Set([
  * @returns {{ batch:Array<Object>, validCount:number, total:number, limit:number, byReason:Object }}
  */
 export function selectRefillBatch(rows, opts = {}) {
+  // SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 (FR-2): the DEMAND gate. Everything below this
+  // point is a VOLUME decision (how many to promote); this is the DEMAND decision (whether to
+  // promote at all). A cap of 10/run floods a saturated belt exactly as fast as a starved one —
+  // that difference is the whole SD.
+  //
+  // opts.demand is a DECISION OBJECT from lib/governance/demand-gate.js, built ONCE PER RUN by the
+  // I/O caller — the same injected-value idiom as shippedTitleSet/acceptedFingerprintSet above, and
+  // for the same reason: this function is PURE + TOTAL (:14-15, "no DB/fs/clock") and 11 synchronous
+  // call sites across three suites depend on that. Calling the gauge HERE would make it async and
+  // break all of them, so a deletion-based revert test would go red for unrelated reasons — a false
+  // positive. (TESTING review 372d5539, condition C2.)
+  //
+  // Gating here rather than in promoteStagedCandidate is also deliberate: that is a PER-ITEM writer,
+  // so a check there would re-read demand per row and make the decision non-atomic across a batch.
+  //
+  // DEFAULT IS UNCHANGED BEHAVIOUR: absent opts.demand -> promote as before, so every existing
+  // caller and test is byte-identical. The gate is opt-in at the call site, never retroactive.
+  if (opts.demand && !mayProduce(opts.demand)) {
+    const report = verifyStagedCandidates(rows, { shippedTitleSet: opts.shippedTitleSet, distilledOnly: opts.distilledOnly === true, acceptedFingerprintSet: opts.acceptedFingerprintSet });
+    return {
+      batch: [],
+      validCount: report.validCount,
+      total: report.total,
+      limit: 0,
+      byReason: report.byReason,
+      // The withheld run carries its own evidence, so "produced nothing" is never mistaken for
+      // "found nothing" — those are the two states this SD exists to tell apart.
+      demand: opts.demand,
+      withheldByDemand: true,
+    };
+  }
   const limit = Number.isInteger(opts.limit) && opts.limit > 0 ? opts.limit : DEFAULT_REFILL_BATCH_LIMIT;
   // SD-LEO-INFRA-BRAINSTORM-DISTILLATION-PIPELINE-001-B: forward the distilled-only flag so the batch
   // selector applies CHECK #11 (default OFF -> unchanged). Caller passes opts.distilledOnly (the cron

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -414,16 +414,41 @@ export function buildReport(argv = [], env = {}, repoRoot = REPO_ROOT) {
 // throws / blocks startup — same doctrine as the rest of this file).
 // ─────────────────────────────────────────────────────────────────────────────
 
-// The sourcing-engine activation flags, in escalation order (umbrella first, then per-engine,
-// then the autosource switch). Each is an env feature flag, OFF unless explicitly on|1|true.
+// The sourcing-engine activation flags. Each is an env feature flag, OFF unless explicitly
+// on|1|true.
+//
+// SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 (FR-5) — FOUR FLAGS RETIRED FROM THIS LIST.
+// SOURCING_ENGINE_V1, SOURCING_ROADMAP_ENGINE_V1, SOURCING_PROACTIVE_POPULATOR_V1 and
+// LEO_ROADMAP_AUTOSOURCE had ZERO executable readers anywhere in the repo — re-verified at
+// implementation time, not inherited from the SD: each appeared in exactly ONE file, this display
+// list. They were displayed, never consulted.
+//
+// The consequence that had to be caught rather than shipped: this SD's own interim step "turn all
+// four ON now" was A NO-OP, and any acceptance criterion of the form "all six read ON in the probe"
+// would have been satisfiable by exporting four env vars while changing zero behaviour. A green
+// badge full of decorative flags is precisely the defect this SD exists to fix, one level up.
+//
+// The two that remain are REAL: gauge-gap-miner.js:296 and deferred-watcher.js:30 read them.
+// Both are hardcoded ON in the workflow job env, so they are already permanently on in the only
+// context that executes them — displayed here for completeness, not because they are tunable.
+//
+// THE OPERATIVE GATE IS NOT AN ENV FLAG AT ALL. The highest-blast-radius producer (refill-cron,
+// hourly --apply) is gated by the DB row sourcing_engine_activation_state.arm='auto-refill', read
+// at sourcing-engine-awareness.mjs:56-68 and consumed at refill-cron.mjs:124. The SD never named
+// it. It is now rendered from the DB below, so the badge shows what actually governs rather than
+// what merely looks like it does.
 export const SOURCING_FLAGS = [
-  'SOURCING_ENGINE_V1',
-  'SOURCING_ROADMAP_ENGINE_V1',
   'SOURCING_GAUGE_GAP_MINER_V1',
   'SOURCING_DEFERRED_WATCHER_V1',
+];
+
+/** The four env flags retired by FR-5, kept named so their removal is a record, not a silent drop. */
+export const RETIRED_SOURCING_FLAGS = Object.freeze([
+  'SOURCING_ENGINE_V1',
+  'SOURCING_ROADMAP_ENGINE_V1',
   'SOURCING_PROACTIVE_POPULATOR_V1',
   'LEO_ROADMAP_AUTOSOURCE',
-];
+]);
 
 /** Pure flag parse mirroring the sourcing-engine helpers: on|1|true => true; everything else => false. */
 export function isSourcingFlagOn(env, name) {
@@ -468,12 +493,22 @@ export function summarizeBacklogDisposition(total = 0, dispositioned = 0) {
 }
 
 /** Pure: render the state-probe section from already-resolved data (no I/O). */
-export function renderSourcingStateLines({ flags = [], wave = null, backlog = null, demand = null } = {}) {
+export function renderSourcingStateLines({ flags = [], wave = null, backlog = null, demand = null, arms = null } = {}) {
   const lines = ['═══ SOURCING SSOT STATE (read-only — route the SSOT before hand-mining) ═══'];
   // Flags
   const anyOn = flags.some((f) => f.on);
   lines.push('  Sourcing-engine flags: ' + (anyOn ? '' : '⚠️ ALL OFF — engine dormant; PROPOSE activation, do not substitute yourself tick-after-tick'));
   for (const f of flags) lines.push(`    ${f.on ? '🟢 on ' : '⚪ off'}  ${f.flag}`);
+  // FR-5: the DB arm states — what ACTUALLY gates the producers. Rendered under the env flags
+  // because reading only the env line has been misleading: the env flags above cannot turn the
+  // highest-blast-radius producer on or off, and this row can.
+  if (arms && arms.length) {
+    for (const a of arms) {
+      lines.push(`    ${a.enabled ? '🟢 on ' : '⚪ off'}  ${a.label} (DB arm — OPERATIVE${a.label === 'auto-refill' ? ', gates the hourly refill cron' : ''})`);
+    }
+  } else {
+    lines.push('    (DB arm states unavailable — the OPERATIVE gate could not be read)');
+  }
   // SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 (FR-3): the DEMAND VERDICT, printed immediately
   // under the flag list so the two are read together. A flag line alone cannot distinguish "on and
   // correctly quiet" from "on and broken" — that ambiguity is what the whole SD is about. Rendered
@@ -576,15 +611,23 @@ export async function fetchSourcingState({ supabase = null, env = process.env } 
   for (const engine of BELT_DEPTH_GATED_PRODUCERS) {
     demand.push({ engine, decision: await readLastDemandDecision(client, engine) });
   }
-  return { wave, backlog, demand };
+  // FR-5: the DB arm states — the gate that actually governs the producers, as opposed to the env
+  // flags above. Fail-open (null) so an unreadable row degrades to an explicit "could not read"
+  // line rather than an absent section.
+  let arms = null;
+  try {
+    const { readSourcingEngineFlagsFromDb } = await import('./lib/sourcing-engine-awareness.mjs');
+    arms = await readSourcingEngineFlagsFromDb(client, {});
+  } catch { arms = null; }
+  return { wave, backlog, demand, arms };
 }
 
 /** Compose the full state-probe section (async, fail-open — never throws). */
 export async function renderSourcingState({ supabase = null, env = process.env } = {}) {
   try {
     const flags = readSourcingFlags(env);
-    const { wave, backlog, demand } = await fetchSourcingState({ supabase, env });
-    return renderSourcingStateLines({ flags, wave, backlog, demand });
+    const { wave, backlog, demand, arms } = await fetchSourcingState({ supabase, env });
+    return renderSourcingStateLines({ flags, wave, backlog, demand, arms });
   } catch (err) {
     return '═══ SOURCING SSOT STATE ═══\n  ✅ state probe skipped (fail-open): ' + (err?.message || String(err));
   }

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -24,6 +24,8 @@ import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 // SD-LEO-INFRA-FLEET-FRESHNESS-GUARD-001: advisory, fail-open checkout-freshness badge.
 import { checkoutFreshness, freshnessBadge, CRITICAL_PROTOCOL_FILES } from '../lib/governance/checkout-freshness.js';
+import { formatDemandDecision, BELT_DEPTH_GATED_PRODUCERS } from '../lib/governance/demand-gate.js';
+import { readLastDemandDecision } from '../lib/governance/demand-gate-emit.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -466,12 +468,28 @@ export function summarizeBacklogDisposition(total = 0, dispositioned = 0) {
 }
 
 /** Pure: render the state-probe section from already-resolved data (no I/O). */
-export function renderSourcingStateLines({ flags = [], wave = null, backlog = null } = {}) {
+export function renderSourcingStateLines({ flags = [], wave = null, backlog = null, demand = null } = {}) {
   const lines = ['═══ SOURCING SSOT STATE (read-only — route the SSOT before hand-mining) ═══'];
   // Flags
   const anyOn = flags.some((f) => f.on);
   lines.push('  Sourcing-engine flags: ' + (anyOn ? '' : '⚠️ ALL OFF — engine dormant; PROPOSE activation, do not substitute yourself tick-after-tick'));
   for (const f of flags) lines.push(`    ${f.on ? '🟢 on ' : '⚪ off'}  ${f.flag}`);
+  // SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 (FR-3): the DEMAND VERDICT, printed immediately
+  // under the flag list so the two are read together. A flag line alone cannot distinguish "on and
+  // correctly quiet" from "on and broken" — that ambiguity is what the whole SD is about. Rendered
+  // UNCONDITIONALLY, one line per gated producer: an engine with no recorded decision prints
+  // NEVER RAN <engine> rather than nothing, because a section that disappears when there is no data
+  // reports a full belt and an unwired gate identically.
+  //
+  // SHAPE NOTE: an entry may be a DECISION object (its `decision` field is a STRING) or a
+  // {engine, decision} wrapper carrying null for an engine that has never run (its `decision` field
+  // is an object or null). Disambiguated on TYPE, never on presence — both shapes have a `decision`
+  // key, so a presence check would read the string 'withheld' as a decision object and throw.
+  const entries = Array.isArray(demand) ? demand : [demand];
+  for (const e of entries) {
+    const isBareDecision = e && typeof e.decision === 'string';
+    lines.push('  ' + formatDemandDecision(isBareDecision ? e : (e && e.decision) || null, e && e.engine));
+  }
   // Roadmap-SSOT unpromoted items
   if (wave) {
     lines.push(`  Roadmap-SSOT (plan-of-record remainder) unpromoted: ${wave.totalUnpromoted} — promote via leo-create-sd --from-roadmap-item (REGISTER-FIRST)`);
@@ -499,7 +517,14 @@ export async function fetchSourcingState({ supabase = null, env = process.env } 
   if (!client) {
     const url = env.SUPABASE_URL || env.NEXT_PUBLIC_SUPABASE_URL;
     const key = env.SUPABASE_SERVICE_ROLE_KEY;
-    if (!url || !key) return { wave: null, backlog: null };
+    // No creds is NOT "never ran" — we did not look. Rendering NEVER RAN here would report an
+    // unwired gate on every credential-less run, which is a false alarm that trains people to
+    // ignore the line. Unmeasurable is the honest verdict for a measurement not attempted.
+    if (!url || !key) return { wave: null, backlog: null, demand: BELT_DEPTH_GATED_PRODUCERS.map((engine) => ({
+      engine,
+      decision: { engine, gauge_value: null, floor: null, decision: 'unmeasurable',
+        measured_at: null, reason: 'no DB credentials in this environment — decision log not read' },
+    })) };
     const { createClient } = await import('@supabase/supabase-js');
     client = createClient(url, key);
   }
@@ -544,15 +569,22 @@ export async function fetchSourcingState({ supabase = null, env = process.env } 
       backlog = summarizeBacklogDisposition(tot.count, disp.count);
     }
   } catch { backlog = null; }
-  return { wave, backlog };
+  // SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 (FR-3): last recorded demand verdict per gated
+  // producer. Reuses the client already built above. readLastDemandDecision never throws and
+  // returns null only for "nothing ever recorded", which renders as NEVER RAN <engine>.
+  const demand = [];
+  for (const engine of BELT_DEPTH_GATED_PRODUCERS) {
+    demand.push({ engine, decision: await readLastDemandDecision(client, engine) });
+  }
+  return { wave, backlog, demand };
 }
 
 /** Compose the full state-probe section (async, fail-open — never throws). */
 export async function renderSourcingState({ supabase = null, env = process.env } = {}) {
   try {
     const flags = readSourcingFlags(env);
-    const { wave, backlog } = await fetchSourcingState({ supabase, env });
-    return renderSourcingStateLines({ flags, wave, backlog });
+    const { wave, backlog, demand } = await fetchSourcingState({ supabase, env });
+    return renderSourcingStateLines({ flags, wave, backlog, demand });
   } catch (err) {
     return '═══ SOURCING SSOT STATE ═══\n  ✅ state probe skipped (fail-open): ' + (err?.message || String(err));
   }

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -504,10 +504,14 @@ export function renderSourcingStateLines({ flags = [], wave = null, backlog = nu
   // highest-blast-radius producer on or off, and this row can.
   if (arms && arms.length) {
     for (const a of arms) {
-      lines.push(`    ${a.enabled ? '🟢 on ' : '⚪ off'}  ${a.label} (DB arm — OPERATIVE${a.label === 'auto-refill' ? ', gates the hourly refill cron' : ''})`);
+      // Three states, not two: on / off / UNKNOWN (no row). Collapsing unknown into off is the
+      // same merge this SD exists to undo.
+      const mark = a.enabled === true ? '🟢 on ' : a.enabled === false ? '⚪ off' : '❔ ???';
+      const unknown = a.enabled === null ? ' — NO ROW: state unknown, not "off"' : '';
+      lines.push(`    ${mark}  ${a.label} (DB arm — OPERATIVE${a.label === 'auto-refill' ? ', gates the hourly refill cron' : ''})${unknown}`);
     }
   } else {
-    lines.push('    (DB arm states unavailable — the OPERATIVE gate could not be read)');
+    lines.push('    ⚠️  DB arm states UNREADABLE — the OPERATIVE gate could not be read; do NOT read this as "off"');
   }
   // SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 (FR-3): the DEMAND VERDICT, printed immediately
   // under the flag list so the two are read together. A flag line alone cannot distinguish "on and
@@ -614,10 +618,28 @@ export async function fetchSourcingState({ supabase = null, env = process.env } 
   // FR-5: the DB arm states — the gate that actually governs the producers, as opposed to the env
   // flags above. Fail-open (null) so an unreadable row degrades to an explicit "could not read"
   // line rather than an absent section.
+  //
+  // TESTING review 57879900 (C2): this originally called readSourcingEngineFlagsFromDb, which
+  // NEVER THROWS — sourcing-engine-awareness.mjs:61-67 swallows the query error and falls back to
+  // the ENV reader, and this call site passed {}, so every arm came back enabled=false. The catch
+  // below was therefore UNREACHABLE for a DB fault, and a failed read rendered as a confident
+  // "⚪ off auto-refill (OPERATIVE)". A lie on the line labelled OPERATIVE is worse than a blank
+  // one, and it is this SD's own thesis — unreadable state must never render as a definite state.
+  // So we query the arm table DIRECTLY here and keep the error: fail-soft in the FALLBACK sense
+  // (env-derived) is right for a forecaster deciding what to do, and wrong for a badge reporting
+  // what IS.
   let arms = null;
   try {
-    const { readSourcingEngineFlagsFromDb } = await import('./lib/sourcing-engine-awareness.mjs');
-    arms = await readSourcingEngineFlagsFromDb(client, {});
+    const { SOURCING_ACTIVATION_TABLE, SOURCING_ENGINE_FLAGS } = await import('./lib/sourcing-engine-awareness.mjs');
+    const { data, error } = await client.from(SOURCING_ACTIVATION_TABLE).select('arm, enabled');
+    if (error) throw new Error(error.message);
+    const byArm = new Map((data || []).map((r) => [r.arm, r.enabled === true]));
+    // An arm with no row is genuinely unknown, not off — a missing row and a row saying false are
+    // different facts and the badge must not merge them.
+    arms = SOURCING_ENGINE_FLAGS.map((f) => ({
+      label: f.label,
+      enabled: byArm.has(f.label) ? byArm.get(f.label) : null,
+    }));
   } catch { arms = null; }
   return { wave, backlog, demand, arms };
 }

--- a/scripts/cron/fr-c-generator.mjs
+++ b/scripts/cron/fr-c-generator.mjs
@@ -35,6 +35,8 @@ import path from 'path';
 import { randomUUID } from 'crypto';
 import { createClient } from '@supabase/supabase-js';
 import { generateRemediationSdsBatch, writeAuditLog } from '../../lib/eva/quality-findings/sd-generator.js';
+import { measureDemand, recordDemandDecision, resolveDemandFloor } from '../../lib/governance/demand-gate-emit.js';
+import { formatDemandDecision, mayProduce } from '../../lib/governance/demand-gate.js';
 import { stampLastFired } from '../../lib/periodic-liveness/stamp-last-fired.js';
 
 const LOCK_NAME = 'fr_c_generator';
@@ -112,12 +114,34 @@ async function releaseLock(supabase, owner) {
   }
 }
 
+const EMPTY_BATCH = { ventures: [], totalCreated: 0, totalAppended: 0, totalSkippedRateLimited: 0, totalErrors: 0, perVenture: {} };
+
 async function runOneBatch({ supabase, dryRun }) {
   if (dryRun) {
     process.stdout.write('[fr-c-generator] --dry-run: skipping generator invocation\n');
-    return { ventures: [], totalCreated: 0, totalAppended: 0, totalSkippedRateLimited: 0, totalErrors: 0, perVenture: {} };
+    return EMPTY_BATCH;
   }
-  return await generateRemediationSdsBatch({ supabase });
+
+  // SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 (FR-2/FR-3). This generator inserts
+  // status='draft' SDs with no claiming_session_id (sd-generator.js:632-654) — i.e. rows the
+  // dispatchable-backlog gauge counts one-for-one. It is a genuine belt minter, verified rather
+  // than assumed, which is why it is on BELT_DEPTH_GATED_PRODUCERS alongside refill-auto-promote.
+  //
+  // WITHHOLDING LOSES NOTHING HERE, which is what makes the gate safe on this producer: findings
+  // are selected by selectPendingFindings and stay PENDING until an SD is actually generated, so a
+  // withheld tick defers minting rather than dropping work — the next tick after the belt drains
+  // picks up the same findings. Note the existing skippedRateLimited counter is a per-venture
+  // VOLUME cap: like every cap in this SD's story it bounds how MUCH a run creates, never WHETHER
+  // it should. This is the whether.
+  const demand = await measureDemand(supabase, {
+    engine: 'fr-c-generator',
+    floor: resolveDemandFloor(process.env),
+  });
+  await recordDemandDecision(supabase, demand);
+  process.stdout.write(formatDemandDecision(demand) + '\n');
+  if (!mayProduce(demand)) return { ...EMPTY_BATCH, withheldByDemand: true, demand };
+
+  return { ...(await generateRemediationSdsBatch({ supabase })), demand };
 }
 
 async function runOnce({ args, supabase, owner, ttlSec }) {

--- a/scripts/sourcing-engine/refill-cron.mjs
+++ b/scripts/sourcing-engine/refill-cron.mjs
@@ -107,6 +107,41 @@ export async function resolveActiveWaveIds(supabase) {
   return (waves || []).map((w) => w.id).filter(Boolean);
 }
 
+/** The engine name for this producer. MUST match its BELT_DEPTH_GATED_PRODUCERS entry — the badge
+ * reads decisions BY engine name, so a typo here renders NEVER RAN forever while the cron runs. */
+export const REFILL_ENGINE = 'refill-auto-promote';
+
+/**
+ * Measure demand, record the verdict, and select — the WHOLE gated call, exported as ONE seam.
+ *
+ * SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001, TESTING review 57879900 (C1). This existed inline
+ * in main() and was the single most dangerous thing in the SD: main() has NO test that reaches it
+ * (the three refill-cron suites import only the pure helpers), so mutation testing showed FIVE
+ * separate one-line edits at the call site surviving 8,180 tests — including simply DELETING
+ * `demand` from the opts object, which makes the entire gate a no-op because selectRefillBatch is
+ * opt-in on opts.demand. The gate inside selectRefillBatch was well covered; the wiring that
+ * feeds it was not, and a guard inside one code path is not a guard on the invariant.
+ *
+ * Extracted so every one of those mutants is now killable, and it FAILS LOUD rather than
+ * degrading: a missing decision throws instead of quietly selecting ungated.
+ *
+ * @returns {Promise<{sel: object, demand: object}>}
+ */
+export async function gatedSelectRefillBatch(supabase, rows, opts = {}, env = process.env) {
+  const demand = await measureDemand(supabase, {
+    engine: REFILL_ENGINE,
+    floor: resolveDemandFloor(env),
+  });
+  await recordDemandDecision(supabase, demand);
+  console.log(formatDemandDecision(demand));
+  if (!demand || typeof demand.decision !== 'string') {
+    // Unreachable via measureDemand, which always returns a decision. Present because the failure
+    // it guards — selecting with demand undefined — is SILENT and indistinguishable from success.
+    throw new Error('refill-cron: refusing to select a batch without a demand decision');
+  }
+  return { sel: selectRefillBatch(rows, { ...opts, demand }), demand };
+}
+
 async function main() {
   const args = process.argv.slice(2);
   const apply = args.includes('--apply');
@@ -193,14 +228,9 @@ async function main() {
   // stop production. Recorded BEFORE the batch is selected and unconditionally — a withheld run
   // that leaves no trace is indistinguishable from a cron that never fired, which is the exact
   // ambiguity this SD exists to remove.
-  const demand = await measureDemand(supabase, {
-    engine: 'refill-auto-promote',
-    floor: resolveDemandFloor(process.env),
+  const { sel, demand } = await gatedSelectRefillBatch(supabase, rows, {
+    limit, shippedTitleSet, acceptedFingerprintSet, distilledOnly: isDistilledOnly(),
   });
-  await recordDemandDecision(supabase, demand);
-  console.log(formatDemandDecision(demand));
-
-  const sel = selectRefillBatch(rows, { limit, shippedTitleSet, acceptedFingerprintSet, distilledOnly: isDistilledOnly(), demand });
   const results = [];
   // SD-LEO-INFRA-WIRE-ALREADY-SHIPPED-001 (Phase 1 — ADVISORY): wire the exported-but-unused
   // crossRefShippedTitleAdvisory into the live promotion caller (its only production call site). It

--- a/scripts/sourcing-engine/refill-cron.mjs
+++ b/scripts/sourcing-engine/refill-cron.mjs
@@ -24,6 +24,8 @@ import { selectRefillBatch, promoteStagedCandidate, isDistilledOnly } from '../.
 import { pathToFileURL } from 'node:url';
 import { normalizeTitleForCompare, crossRefShippedTitleAdvisory } from '../../lib/sourcing-engine/refill-candidate-validity.js';
 import { readSourcingEngineFlagsFromDb } from '../lib/sourcing-engine-awareness.mjs';
+import { measureDemand, recordDemandDecision, resolveDemandFloor } from '../../lib/governance/demand-gate-emit.js';
+import { formatDemandDecision } from '../../lib/governance/demand-gate.js';
 // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 9 — the staged-candidate read feeds
 // the promotion loop (a capped read silently drops promotable candidates with no error); the
 // shipped-title and accepted-fingerprint sets feed quality gates whose exactly-cap .limit(1000)
@@ -185,7 +187,20 @@ async function main() {
   // SD-LEO-INFRA-CORPUS-PROMOTE-ONLY-VIA-DISTILL-001 (FR-2): forward the distilled-only flag so the
   // batch selector applies CHECK #11 — only /distill build-dispositioned items promote. Now fail-closed
   // by default (isDistilledOnly), so an un-distilled raw corpus item is never minted onto the belt.
-  const sel = selectRefillBatch(rows, { limit, shippedTitleSet, acceptedFingerprintSet, distilledOnly: isDistilledOnly() });
+  // SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 (FR-2/FR-3): measure DEMAND before minting, and
+  // RECORD the verdict whichever way it goes. This cron is the only unattended belt minter (hourly,
+  // 10/run, 240/day), so it is the one place where "the belt is already full" has to be able to
+  // stop production. Recorded BEFORE the batch is selected and unconditionally — a withheld run
+  // that leaves no trace is indistinguishable from a cron that never fired, which is the exact
+  // ambiguity this SD exists to remove.
+  const demand = await measureDemand(supabase, {
+    engine: 'refill-auto-promote',
+    floor: resolveDemandFloor(process.env),
+  });
+  await recordDemandDecision(supabase, demand);
+  console.log(formatDemandDecision(demand));
+
+  const sel = selectRefillBatch(rows, { limit, shippedTitleSet, acceptedFingerprintSet, distilledOnly: isDistilledOnly(), demand });
   const results = [];
   // SD-LEO-INFRA-WIRE-ALREADY-SHIPPED-001 (Phase 1 — ADVISORY): wire the exported-but-unused
   // crossRefShippedTitleAdvisory into the live promotion caller (its only production call site). It
@@ -212,6 +227,7 @@ async function main() {
       mode: apply ? 'apply' : 'dry_run',
       total: sel.total, validCount: sel.validCount, selected: sel.batch.length, limit: sel.limit,
       promoted, results,
+      demand, withheldByDemand: sel.withheldByDemand === true, // FR-3: the verdict travels with the run's own report
       advisoryByReason, advisoryMatches, // Phase 1 advisory (no verdict change) — for FP-rate measurement
     }, null, 2));
   } else {

--- a/tests/test-estate-mjs-allowlist.json
+++ b/tests/test-estate-mjs-allowlist.json
@@ -15,7 +15,6 @@
       "tests/sd-start-dependency-gate.test.mjs",
       "tests/unit/adam-doc-drift-review.test.mjs",
       "tests/unit/adam-github-assessment.test.mjs",
-      "tests/unit/adam-sourcing-state-probe.test.mjs",
       "tests/unit/adam-startup-check.test.mjs",
       "tests/unit/calculate-sd-progress.test.mjs",
       "tests/unit/coordinator-startup-check.test.mjs",

--- a/tests/unit/adam-sourcing-state-probe.test.js
+++ b/tests/unit/adam-sourcing-state-probe.test.js
@@ -1,9 +1,17 @@
 // Tests for the SOURCING SSOT STATE probe in scripts/adam-startup-check.mjs
+//
+// SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 (FR-5): RENAMED FROM .test.mjs, WHERE IT NEVER RAN.
+// The vitest unit include does not match .test.mjs, so every assertion below was dead: this file
+// asserted a six-flag contract that nothing enforced, for the exact function this SD modifies.
+// A test that cannot run is the same defect class as a flag nothing reads — which is what the SD
+// is about, so leaving it in place while fixing decorative flags would have been incoherent.
+// Converted from node:test to vitest (assert stays; the runner is what changed).
 // SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001 (FR-2)
-import { test } from 'node:test';
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import {
   SOURCING_FLAGS,
+  RETIRED_SOURCING_FLAGS,
   isSourcingFlagOn,
   readSourcingFlags,
   summarizeUnpromotedByWave,
@@ -13,15 +21,30 @@ import {
   renderSourcingState,
 } from '../../scripts/adam-startup-check.mjs';
 
-test('SOURCING_FLAGS lists the six engine activation flags in escalation order', () => {
+test('SOURCING_FLAGS lists ONLY the flags something actually reads (FR-5)', () => {
+  // Was a six-flag contract. Four of them had zero executable readers anywhere in the repo and
+  // were retired; the two left are read at gauge-gap-miner.js:296 and deferred-watcher.js:30.
   assert.deepEqual(SOURCING_FLAGS, [
-    'SOURCING_ENGINE_V1',
-    'SOURCING_ROADMAP_ENGINE_V1',
     'SOURCING_GAUGE_GAP_MINER_V1',
     'SOURCING_DEFERRED_WATCHER_V1',
-    'SOURCING_PROACTIVE_POPULATOR_V1',
-    'LEO_ROADMAP_AUTOSOURCE',
   ]);
+});
+
+test('FR-5 TS-9 ENV-VAR-ALONE CONTROL — setting the retired flags changes NOTHING', () => {
+  // The criterion this SD refused to ship: "all six read ON in the probe", satisfiable by
+  // exporting four env vars while changing zero behaviour. This test makes that unsatisfiable —
+  // if anyone re-adds a decorative flag to the display list, the badge diff below goes non-empty
+  // and this fails.
+  const env = Object.fromEntries(RETIRED_SOURCING_FLAGS.map((f) => [f, 'on']));
+  const withRetiredFlagsOn = renderSourcingStateLines({ flags: readSourcingFlags(env) });
+  const withNothingSet = renderSourcingStateLines({ flags: readSourcingFlags({}) });
+  assert.equal(withRetiredFlagsOn, withNothingSet);
+  for (const f of RETIRED_SOURCING_FLAGS) assert.doesNotMatch(withRetiredFlagsOn, new RegExp(f));
+});
+
+test('FR-5: the retired flags are recorded, not silently dropped', () => {
+  assert.equal(RETIRED_SOURCING_FLAGS.length, 4);
+  for (const f of RETIRED_SOURCING_FLAGS) assert.equal(SOURCING_FLAGS.includes(f), false);
 });
 
 test('isSourcingFlagOn: on|1|true => true; everything else (incl. undefined) => false', () => {
@@ -31,11 +54,12 @@ test('isSourcingFlagOn: on|1|true => true; everything else (incl. undefined) => 
 });
 
 test('readSourcingFlags reports per-flag state from env', () => {
+  // A RETIRED flag set to 'on' is not reported at all — it has no entry to report.
   const flags = readSourcingFlags({ SOURCING_ENGINE_V1: 'on', SOURCING_GAUGE_GAP_MINER_V1: '1' });
-  assert.equal(flags.length, 6);
-  assert.equal(flags.find((f) => f.flag === 'SOURCING_ENGINE_V1').on, true);
+  assert.equal(flags.length, 2);
   assert.equal(flags.find((f) => f.flag === 'SOURCING_GAUGE_GAP_MINER_V1').on, true);
-  assert.equal(flags.find((f) => f.flag === 'LEO_ROADMAP_AUTOSOURCE').on, false);
+  assert.equal(flags.find((f) => f.flag === 'SOURCING_DEFERRED_WATCHER_V1').on, false);
+  assert.equal(flags.find((f) => f.flag === 'SOURCING_ENGINE_V1'), undefined);
 });
 
 test('summarizeUnpromotedByWave counts only null promoted_to_sd_key, grouped + ordered by wave rank', () => {
@@ -78,9 +102,9 @@ test('renderSourcingStateLines warns ALL OFF when no flag is on, and lists the S
 });
 
 test('renderSourcingStateLines does NOT warn ALL OFF when a flag is on', () => {
-  const out = renderSourcingStateLines({ flags: readSourcingFlags({ SOURCING_ENGINE_V1: 'on' }), wave: null, backlog: null });
+  const out = renderSourcingStateLines({ flags: readSourcingFlags({ SOURCING_GAUGE_GAP_MINER_V1: 'on' }), wave: null, backlog: null });
   assert.doesNotMatch(out, /ALL OFF/);
-  assert.match(out, /🟢 on\s+SOURCING_ENGINE_V1/);
+  assert.match(out, /🟢 on\s+SOURCING_GAUGE_GAP_MINER_V1/);
   assert.match(out, /unavailable — DB read skipped/); // wave + backlog null → fail-open lines
 });
 
@@ -96,8 +120,14 @@ function stubSupabase({ remainderRows = [], total = 0, dispositioned = 0 } = {})
         select(_cols, opts) { this._head = !!(opts && opts.head); return this; },
         is() { return this; },
         not() { this._dispositioned = true; return this; },
+        // The stub PREDATES the fetchAllPaginated repoint and lacked .range(), so the paginated
+        // read threw and wave came back null — undetected, because this file never ran.
+        range(from) { this._offset = from; return this; },
+        eq() { return this; },
+        order() { return this; },
+        limit() { return this; },
         then(res, rej) {
-          if (this._table === 'v_plan_of_record_remainder') return Promise.resolve({ data: remainderRows, error: null }).then(res, rej);
+          if (this._table === 'v_plan_of_record_remainder') return Promise.resolve({ data: this._offset ? [] : remainderRows, error: null }).then(res, rej);
           if (this._table === 'sd_backlog_map') return Promise.resolve({ count: this._dispositioned ? dispositioned : total, error: null }).then(res, rej);
           return Promise.resolve({ data: [], error: null }).then(res, rej);
         },

--- a/tests/unit/adam-sourcing-state-probe.test.js
+++ b/tests/unit/adam-sourcing-state-probe.test.js
@@ -162,3 +162,44 @@ test('renderSourcingState is fail-open and always returns a string section', asy
   assert.equal(typeof out, 'string');
   assert.match(out, /SOURCING SSOT STATE/);
 });
+
+// ── SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001, TESTING review 57879900 (C2/C4) ──────────────
+// Nothing exercised fetchSourcingState -> renderSourcingState, so wiring mutants survived: nulling
+// the demand read, nulling the arms read, and deleting the no-creds synthetic payload. These cover
+// the composition, and C2 — an unreadable arm table rendering as a confident "off".
+
+/** A client whose every query REJECTS — the DB-fault case. */
+const throwingClient = () => ({ from() { throw new Error('relation unavailable'); } });
+
+test('C2: an UNREADABLE arm table must not render as "off" on the line labelled OPERATIVE', async () => {
+  const out = await renderSourcingState({ supabase: throwingClient(), env: {} });
+  // The bug this replaces: readSourcingEngineFlagsFromDb never throws — it swallows the error and
+  // falls back to the ENV reader, which with {} reports every arm disabled. Same fault, two
+  // verdicts, and the confident one was the lie.
+  assert.match(out, /UNREADABLE/);
+  assert.doesNotMatch(out, /⚪ off {2}auto-refill/);
+});
+
+test('C4: a DB fault yields UNMEASURABLE per engine — never a silent NEVER RAN', async () => {
+  const out = await renderSourcingState({ supabase: throwingClient(), env: {} });
+  // "I could not read the log" and "the engine has never run" are different facts. Collapsing them
+  // re-creates the ambiguity the whole SD removes.
+  assert.match(out, /UNMEASURABLE/);
+  assert.doesNotMatch(out, /NEVER RAN/);
+});
+
+test('C4: no credentials renders UNMEASURABLE, not NEVER RAN (the synthetic payload is load-bearing)', async () => {
+  const { demand } = await fetchSourcingState({ supabase: null, env: {} });
+  assert.equal(Array.isArray(demand), true);
+  assert.equal(demand.length > 0, true);
+  for (const d of demand) assert.equal(d.decision.decision, 'unmeasurable');
+  const out = await renderSourcingState({ supabase: null, env: {} });
+  assert.doesNotMatch(out, /NEVER RAN/);
+});
+
+test('C4: the demand section is rendered by the composed path, not only by the pure renderer', async () => {
+  // Kills "drop demand from the renderSourcingStateLines call" and "replace the read with null".
+  const out = await renderSourcingState({ supabase: null, env: {} });
+  assert.match(out, /\[demand-gate\]/);
+  for (const engine of ['refill-auto-promote', 'fr-c-generator']) assert.match(out, new RegExp(engine));
+});

--- a/tests/unit/governance/demand-gate-emit.test.js
+++ b/tests/unit/governance/demand-gate-emit.test.js
@@ -120,20 +120,71 @@ describe('resolveDemandFloor — misconfiguration must not silently become the d
 });
 
 describe('record/read round trip against a fake client', () => {
-  const fakeDb = (rows = []) => ({
-    from: () => ({
-      insert: (r) => ({ select: async () => { rows.push(r); return { data: [{ id: 'x' }], error: null }; } }),
-      select: () => ({ eq: function () { return this; }, order: function () { return this; },
-        limit: async () => ({ data: rows.map((r) => ({ metadata: r.metadata, created_at: 't' })).slice(-1), error: null }) }),
-    }),
+  // TESTING review 57879900 (C3): the original stub ignored the table name and returned `this`
+  // from eq/order, so the round trip passed because `rows` was shared array state — NOT because
+  // the query matched. Six mutations survived it: insert into the wrong table, read from the wrong
+  // table, drop .eq(event_type), drop .eq(entity_id), hardcode the wrong entity_id, and flip the
+  // sort to ascending (which freezes the badge on the first-ever verdict — a permanently stale
+  // gauge that reads healthy). This stub RECORDS the query it was asked for, so those are
+  // assertable, and the store is keyed by table + entity_id rather than being one shared array.
+  const fakeDb = (store = { rows: [], calls: [] }) => ({
+    _store: store,
+    from(table) {
+      const q = { table, filters: {}, order: null, limitN: null };
+      store.calls.push(q);
+      return {
+        insert: (r) => ({ select: async () => { store.rows.push({ table, ...r }); return { data: [{ id: 'x' }], error: null }; } }),
+        select() { return this; },
+        eq(col, val) { q.filters[col] = val; return this; },
+        order(col, opts) { q.order = { col, ascending: opts && opts.ascending }; return this; },
+        async limit(n) {
+          q.limitN = n;
+          const matched = store.rows
+            .filter((r) => r.table === q.table)
+            .filter((r) => q.filters.event_type === undefined || r.event_type === q.filters.event_type)
+            .filter((r) => q.filters.entity_id === undefined || r.entity_id === q.filters.entity_id)
+            // created_at is assigned per insert order; sort HONESTLY so ascending/descending differ.
+            .map((r, i) => ({ metadata: r.metadata, created_at: `t${i}` }))
+            .sort((a, b) => (q.order && q.order.ascending ? 1 : -1) * (a.created_at < b.created_at ? -1 : 1));
+          return { data: matched.slice(0, n), error: null };
+        },
+      };
+    },
   });
 
-  it('a recorded decision reads back as the same decision', async () => {
-    const rows = [];
-    const db = fakeDb(rows);
+  it('a recorded decision reads back as the same decision, from the right table and filters', async () => {
+    const store = { rows: [], calls: [] };
+    const db = fakeDb(store);
     expect(await recordDemandDecision(db, withheld)).toBe(true);
-    expect(rows[0].event_type).toBe(DEMAND_GATE_EVENT);
+    expect(store.rows[0].table).toBe('audit_log');
+    expect(store.rows[0].event_type).toBe(DEMAND_GATE_EVENT);
+    expect(store.rows[0].entity_id).toBe('refill-auto-promote');
     expect(await readLastDemandDecision(db, 'refill-auto-promote')).toEqual(withheld);
+
+    const read = store.calls[store.calls.length - 1];
+    expect(read.table).toBe('audit_log');
+    expect(read.filters.event_type).toBe(DEMAND_GATE_EVENT);   // kills "drop .eq(event_type)"
+    expect(read.filters.entity_id).toBe('refill-auto-promote'); // kills "drop .eq(entity_id)"
+    expect(read.order).toEqual({ col: 'created_at', ascending: false }); // kills the sort flip
+    expect(read.limitN).toBe(1);
+  });
+
+  it('THE SORT DIRECTION IS LOAD-BEARING — the LATEST verdict wins, not the first', async () => {
+    // Two rows with different timestamps is the only shape that can tell the directions apart.
+    // Ascending would freeze the badge on the first verdict ever recorded, for good.
+    const db = fakeDb();
+    await recordDemandDecision(db, sourced);   // older
+    await recordDemandDecision(db, withheld);  // newer
+    expect((await readLastDemandDecision(db, 'refill-auto-promote')).decision).toBe('withheld');
+  });
+
+  it('engines do not read each other\'s verdicts', async () => {
+    // Without the entity_id filter a two-engine badge shows one engine's decision under the
+    // other's name — a cross-engine mixup that looks like a working gate.
+    const db = fakeDb();
+    await recordDemandDecision(db, { ...sourced, engine: 'fr-c-generator' });
+    expect(await readLastDemandDecision(db, 'refill-auto-promote')).toBeNull();
+    expect((await readLastDemandDecision(db, 'fr-c-generator')).engine).toBe('fr-c-generator');
   });
 
   it('an insert that returns ZERO rows is reported as NOT recorded', async () => {

--- a/tests/unit/governance/demand-gate-emit.test.js
+++ b/tests/unit/governance/demand-gate-emit.test.js
@@ -1,0 +1,169 @@
+/**
+ * SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 — FR-3 (emission + the named consumer).
+ *
+ * The acceptance criterion is "a named consumer reads the emission and a test asserts its behaviour
+ * differs when the emission is present versus absent". So the load-bearing test here is the
+ * DIFFERENTIAL against the real renderSourcingStateLines — not an assertion that a function was
+ * called. If the badge rendered identically with and without a decision, the emission would be
+ * write-only and FR-3 would have shipped as decoration.
+ *
+ * .test.js, NOT .test.mjs — proven during PLAN that the vitest unit include does not match
+ * .test.mjs. The pre-existing tests/unit/adam-sourcing-state-probe.test.mjs, which covers this very
+ * renderer, is therefore NEVER EXECUTED by `vitest run --project unit`. A consumer test for FR-3
+ * landed beside it would have been a reader that nobody reads — this SD's defect, third instance.
+ */
+import { describe, it, expect } from 'vitest';
+import { renderSourcingStateLines } from '../../../scripts/adam-startup-check.mjs';
+import {
+  measureDemand, recordDemandDecision, readLastDemandDecision, resolveDemandFloor,
+  DEFAULT_DEMAND_FLOOR, DEMAND_GATE_EVENT,
+} from '../../../lib/governance/demand-gate-emit.js';
+import { decideDemand, normalizeGaugeReading } from '../../../lib/governance/demand-gate.js';
+
+const FLAGS = [{ flag: 'SOURCING_AUTO_REFILL_V1', on: true }];
+const withheld = decideDemand(normalizeGaugeReading(9), 3, { engine: 'refill-auto-promote' });
+const unmeasurable = decideDemand(normalizeGaugeReading(null), 3, { engine: 'refill-auto-promote' });
+const sourced = decideDemand(normalizeGaugeReading(0), 3, { engine: 'refill-auto-promote' });
+
+const render = (demand) => renderSourcingStateLines({ flags: FLAGS, wave: null, backlog: null, demand });
+
+describe('FR-3 DIFFERENTIAL — the badge changes when the emission exists', () => {
+  it('present vs absent produce different output', () => {
+    const absent = render(null);
+    const present = render(withheld);
+    expect(present).not.toBe(absent);          // the load-bearing assertion
+    expect(absent).toContain('NEVER RAN');
+    expect(present).not.toContain('NEVER RAN');
+    expect(present).toContain('WITHHELD');
+  });
+
+  it('the three states are mutually distinguishable in the rendered badge', () => {
+    // Not three separate contains-checks: those all pass against a renderer that prints one
+    // constant string plus the decision name. The Set size is what catches a collapse.
+    const outs = [render(null), render(withheld), render(unmeasurable), render(sourced)];
+    expect(new Set(outs).size).toBe(4);
+  });
+
+  it('a withheld run reports the NUMBERS, so the operator can see why it stayed quiet', () => {
+    const out = render(withheld);
+    expect(out).toContain('gauge=9');
+    expect(out).toContain('floor=3');
+  });
+
+  it('gauge=0 prints as a measured zero, not as a missing value', () => {
+    // measured-and-empty vs never-measured is the distinction the whole FR turns on.
+    expect(render(sourced)).toContain('gauge=0');
+  });
+});
+
+describe('FR-3 the badge names WHICH engine never ran', () => {
+  it('per-engine entries render one line each, naming the silent one', () => {
+    const out = render([
+      { engine: 'refill-auto-promote', decision: withheld },
+      { engine: 'fr-c-generator', decision: null },
+    ]);
+    expect(out).toContain('refill-auto-promote');
+    expect(out).toContain('fr-c-generator: NEVER RAN');
+  });
+
+  it('SHAPE AMBIGUITY — a bare decision object inside the array does not throw or mis-render', () => {
+    // Both shapes carry a `decision` key: a wrapper's is an object/null, a decision's is a STRING.
+    // Disambiguating on presence would read 'withheld' as a decision object and crash the badge.
+    const out = render([withheld]);
+    expect(out).toContain('WITHHELD');
+    expect(out).not.toContain('NEVER RAN');
+  });
+});
+
+describe('measureDemand — an unreadable gauge is never a licence to produce', () => {
+  it('a THROWING gauge yields unmeasurable, not a zero belt', () => {
+    // belt-depth.cjs is deliberately fail-loud (throwOnError at :78). The tempting bug is
+    // catch -> treat as 0 -> "belt empty, produce": a fail-open flood via an exception handler.
+    return measureDemand({}, {
+      engine: 'e', floor: 3, gauge: async () => { throw new Error('dep query failed'); },
+    }).then((d) => {
+      expect(d.decision).toBe('unmeasurable');
+      expect(d.gauge_value).not.toBe(0);
+    });
+  });
+
+  it('a healthy gauge below the floor sources — the positive control', async () => {
+    const d = await measureDemand({}, { engine: 'e', floor: 3, gauge: async () => ({ dispatchable: 1 }) });
+    expect(d.decision).toBe('sourced');
+    expect(d.gauge_value).toBe(1);
+  });
+
+  it('a healthy gauge above the floor withholds', async () => {
+    const d = await measureDemand({}, { engine: 'e', floor: 3, gauge: async () => ({ dispatchable: 12 }) });
+    expect(d.decision).toBe('withheld');
+  });
+});
+
+describe('resolveDemandFloor — misconfiguration must not silently become the default', () => {
+  it('absent -> default', () => {
+    expect(resolveDemandFloor({})).toBe(DEFAULT_DEMAND_FLOOR);
+    expect(resolveDemandFloor({ BELT_DEMAND_FLOOR: '' })).toBe(DEFAULT_DEMAND_FLOOR);
+  });
+
+  it('a valid override wins', () => {
+    expect(resolveDemandFloor({ BELT_DEMAND_FLOOR: '7' })).toBe(7);
+    expect(resolveDemandFloor({ BELT_DEMAND_FLOOR: '0' })).toBe(0);
+  });
+
+  it('GARBAGE yields NaN -> unmeasurable, never a silent fallback to the default', () => {
+    // Falling back to the default here would mean a typo'd floor produces at the WRONG threshold
+    // while reporting a healthy decision. NaN routes through decideDemand's non-finite floor guard.
+    const floor = resolveDemandFloor({ BELT_DEMAND_FLOOR: 'lots' });
+    expect(Number.isNaN(floor)).toBe(true);
+    expect(decideDemand(normalizeGaugeReading(0), floor).decision).toBe('unmeasurable');
+  });
+});
+
+describe('record/read round trip against a fake client', () => {
+  const fakeDb = (rows = []) => ({
+    from: () => ({
+      insert: (r) => ({ select: async () => { rows.push(r); return { data: [{ id: 'x' }], error: null }; } }),
+      select: () => ({ eq: function () { return this; }, order: function () { return this; },
+        limit: async () => ({ data: rows.map((r) => ({ metadata: r.metadata, created_at: 't' })).slice(-1), error: null }) }),
+    }),
+  });
+
+  it('a recorded decision reads back as the same decision', async () => {
+    const rows = [];
+    const db = fakeDb(rows);
+    expect(await recordDemandDecision(db, withheld)).toBe(true);
+    expect(rows[0].event_type).toBe(DEMAND_GATE_EVENT);
+    expect(await readLastDemandDecision(db, 'refill-auto-promote')).toEqual(withheld);
+  });
+
+  it('an insert that returns ZERO rows is reported as NOT recorded', async () => {
+    // The silent-write trap: an RLS-rejected insert returns HTTP 200, error=null, and no rows.
+    // Trusting `!error` alone would report a recorded decision that does not exist.
+    const db = { from: () => ({ insert: () => ({ select: async () => ({ data: [], error: null }) }) }) };
+    expect(await recordDemandDecision(db, withheld)).toBe(false);
+  });
+
+  it('a recording failure does NOT throw — observability never gates production', async () => {
+    const db = { from: () => ({ insert: () => ({ select: async () => ({ data: null, error: { message: 'boom' } }) }) }) };
+    expect(await recordDemandDecision(db, withheld)).toBe(false);
+  });
+
+  it('NOTHING recorded reads as null (NEVER RAN), a READ FAULT reads as unmeasurable', async () => {
+    const empty = { from: () => ({ select: () => ({ eq: function () { return this; }, order: function () { return this; },
+      limit: async () => ({ data: [], error: null }) }) }) };
+    expect(await readLastDemandDecision(empty, 'e')).toBeNull();
+
+    const broken = { from: () => ({ select: () => ({ eq: function () { return this; }, order: function () { return this; },
+      limit: async () => ({ data: null, error: { message: 'relation missing' } }) }) }) };
+    const d = await readLastDemandDecision(broken, 'e');
+    expect(d.decision).toBe('unmeasurable');   // NOT null — we could not look, so we do not know
+  });
+
+  it('a row with an UNREADABLE payload is unmeasurable, not never-ran', async () => {
+    const corrupt = { from: () => ({ select: () => ({ eq: function () { return this; }, order: function () { return this; },
+      limit: async () => ({ data: [{ metadata: 'not-an-object', created_at: 't' }], error: null }) }) }) };
+    const d = await readLastDemandDecision(corrupt, 'e');
+    expect(d.decision).toBe('unmeasurable');
+    expect(d.reason).toContain('unreadable');
+  });
+});

--- a/tests/unit/governance/demand-gate-wiring.test.js
+++ b/tests/unit/governance/demand-gate-wiring.test.js
@@ -18,7 +18,9 @@ import { decideDemand, normalizeGaugeReading } from '../../../lib/governance/dem
 // selectable in either arm. The TS-3b positive control is what exposed it, which is precisely the
 // job it was added to do. The real gate is item_disposition ∈ {pending, selected}
 // (refill-candidate-validity.js:98,:250) plus non-empty source_type + source_id (:274).
-// Verified: 3 of 3 valid, byReason {}.
+// Verified empirically at the default n=5: validCount=5, total=5, byReason={} (the "3 of 3" in an
+// earlier draft of this note came from a 3-row spot check and did not match the default — TESTING
+// review 57879900, W5).
 function stagedRows(n = 5) {
   return Array.from({ length: n }, (_, i) => ({
     id: `rwi-${i}`,

--- a/tests/unit/governance/demand-gate-wiring.test.js
+++ b/tests/unit/governance/demand-gate-wiring.test.js
@@ -1,0 +1,109 @@
+/**
+ * SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 — FR-2 WIRING.
+ *
+ * A gate nothing consults is the defect this SD exists to fix, so these tests drive the REAL
+ * selectRefillBatch rather than asserting that a call exists somewhere. Every case here can fail:
+ * TS-4 is proven by deleting the gate and watching this file go red.
+ *
+ * .test.js deliberately — the vitest unit include does not match .test.mjs, and a wiring test that
+ * never runs would assert that a gate has a caller, in a file that has no runner.
+ */
+import { describe, it, expect } from 'vitest';
+import { selectRefillBatch } from '../../../lib/sourcing-engine/refill-auto-promote.js';
+import { decideDemand, normalizeGaugeReading } from '../../../lib/governance/demand-gate.js';
+
+// Staged roadmap_wave_items rows that GENUINELY pass verifyStagedCandidates. This shape was derived
+// empirically, not guessed: an earlier fixture used `status:'staged'` and produced 0 valid rows
+// ({not_staged:3}), which made "a withheld run selects nothing" pass VACUOUSLY — nothing was ever
+// selectable in either arm. The TS-3b positive control is what exposed it, which is precisely the
+// job it was added to do. The real gate is item_disposition ∈ {pending, selected}
+// (refill-candidate-validity.js:98,:250) plus non-empty source_type + source_id (:274).
+// Verified: 3 of 3 valid, byReason {}.
+function stagedRows(n = 5) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `rwi-${i}`,
+    title: `Improve belt demand gating coverage ${i}`,
+    item_disposition: 'pending',
+    wave_id: 'wave-1',
+    source_type: 'roadmap',
+    source_id: `rm-${i}`,
+  }));
+}
+
+const STARVED = decideDemand(normalizeGaugeReading(0), 3, { engine: 'refill-auto-promote' });
+const SATURATED = decideDemand(normalizeGaugeReading(9), 3, { engine: 'refill-auto-promote' });
+const BLIND = decideDemand(normalizeGaugeReading(null), 3, { engine: 'refill-auto-promote' });
+
+describe('TS-3: a withheld run selects nothing', () => {
+  it('DIFFERENTIAL — the same rows, only the demand decision differs, and the batch differs', () => {
+    const rows = stagedRows();
+    const withheld = selectRefillBatch(rows, { demand: SATURATED });
+    const sourced = selectRefillBatch(rows, { demand: STARVED });
+
+    // The load-bearing assertion. If these were equal the gate would be computed-and-discarded.
+    expect(withheld.batch.length).not.toBe(sourced.batch.length);
+    expect(withheld.batch).toEqual([]);
+    expect(withheld.withheldByDemand).toBe(true);
+  });
+
+  it('a withheld run still reports what it SAW, so "produced nothing" is not confused with "found nothing"', () => {
+    const rows = stagedRows();
+    const withheld = selectRefillBatch(rows, { demand: SATURATED });
+    expect(withheld.total).toBe(rows.length);
+    expect(withheld.demand.decision).toBe('withheld');
+    expect(withheld.demand.gauge_value).toBe(9);
+    expect(withheld.demand.floor).toBe(3);
+  });
+
+  it('an UNMEASURABLE gauge withholds too — it is not a licence to produce', () => {
+    const withheld = selectRefillBatch(stagedRows(), { demand: BLIND });
+    expect(withheld.batch).toEqual([]);
+    expect(withheld.withheldByDemand).toBe(true);
+    expect(withheld.demand.decision).toBe('unmeasurable');
+  });
+});
+
+describe('TS-3b: POSITIVE CONTROL — the gate does not simply kill the engine', () => {
+  // Without this, an always-withhold gate passes every other test here while leaving the producer
+  // permanently dead — indistinguishable from correctly-quiet, i.e. this SD's own defect.
+  it('a starved belt actually produces a non-empty batch', () => {
+    const sourced = selectRefillBatch(stagedRows(), { demand: STARVED });
+    expect(sourced.batch.length).toBeGreaterThan(0);
+    expect(sourced.withheldByDemand).toBeUndefined();
+  });
+
+  it('demand does not override the volume cap — the two controls compose', () => {
+    const sourced = selectRefillBatch(stagedRows(10), { demand: STARVED, limit: 2 });
+    expect(sourced.batch.length).toBe(2);
+  });
+});
+
+describe('BACKWARD COMPATIBILITY — the gate is opt-in, never retroactive', () => {
+  // 11 synchronous call sites across three suites pass no demand. They must be byte-identical.
+  it('omitting opts.demand behaves exactly as before', () => {
+    const rows = stagedRows();
+    const before = selectRefillBatch(rows);
+    const withStarved = selectRefillBatch(rows, { demand: STARVED });
+    expect(before.batch.length).toBe(withStarved.batch.length);
+    expect(before.withheldByDemand).toBeUndefined();
+  });
+
+  it('selectRefillBatch stays SYNCHRONOUS — its purity contract is load-bearing', () => {
+    // If a future change made the gauge call happen inside, this returns a Promise and 11 call
+    // sites break. The contract is documented at refill-auto-promote.js:14-15 ("no DB/fs/clock").
+    const result = selectRefillBatch(stagedRows(), { demand: STARVED });
+    expect(result).not.toBeInstanceOf(Promise);
+    expect(typeof result.batch.length).toBe('number');
+  });
+});
+
+describe('the decision is read via mayProduce, not object truthiness', () => {
+  it('a withheld decision object is truthy yet must not permit production', () => {
+    // `if (opts.demand)` would permit exactly the runs the gate exists to stop — every decision
+    // object, including withheld and unmeasurable, is truthy.
+    expect(Boolean(SATURATED)).toBe(true);
+    expect(Boolean(BLIND)).toBe(true);
+    expect(selectRefillBatch(stagedRows(), { demand: SATURATED }).batch).toEqual([]);
+    expect(selectRefillBatch(stagedRows(), { demand: BLIND }).batch).toEqual([]);
+  });
+});

--- a/tests/unit/governance/demand-gate.test.js
+++ b/tests/unit/governance/demand-gate.test.js
@@ -1,0 +1,167 @@
+/**
+ * SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 — demand gate.
+ *
+ * THIS SUITE IS BUILT AROUND WHAT CAN FAIL. The SD's thesis is that an off flag is
+ * indistinguishable from an on-and-quiet flag; a gate whose tests cannot fail would be that
+ * defect one level up. The TESTING review (372d5539) found two of the original scenarios could
+ * not fail at all and a third could not run — the repairs are marked inline.
+ *
+ * .test.js, NOT .test.mjs: the vitest unit include does not match .test.mjs, and a scenario landed
+ * there would be a never-run test. Proven during PLAN:
+ *   npx vitest run --project unit tests/unit/adam-sourcing-state-probe.test.mjs
+ *   -> "No test files found, exiting with code 1"
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  DEMAND_DECISION,
+  normalizeGaugeReading,
+  decideDemand,
+  mayProduce,
+  formatDemandDecision,
+  BELT_DEPTH_GATED_PRODUCERS,
+  STAGING_PRODUCERS_NOT_GATED,
+} from '../../../lib/governance/demand-gate.js';
+
+const ok = (n) => normalizeGaugeReading(n);
+
+describe('TS-1: the gate discriminates across all three decisions', () => {
+  it('below floor -> sourced; above floor -> withheld; unreadable -> unmeasurable', () => {
+    const d1 = decideDemand(ok(0), 3, { engine: 'refill-auto-promote' });
+    const d2 = decideDemand(ok(9), 3, { engine: 'refill-auto-promote' });
+    const d3 = decideDemand(normalizeGaugeReading(null), 3, { engine: 'refill-auto-promote' });
+
+    expect(d1.decision).toBe(DEMAND_DECISION.SOURCED);
+    expect(d2.decision).toBe(DEMAND_DECISION.WITHHELD);
+    expect(d3.decision).toBe(DEMAND_DECISION.UNMEASURABLE);
+
+    // ANTI-COLLAPSE (TESTING review): three isolated checks would still pass a two-state gate.
+    // If any two decisions ever collapse, this suite has gone vacuous and must be fixed, not deleted.
+    expect(new Set([d1.decision, d2.decision, d3.decision]).size).toBe(3);
+  });
+
+  it('the boundary is inclusive — value == floor still sources', () => {
+    expect(decideDemand(ok(3), 3).decision).toBe(DEMAND_DECISION.SOURCED);
+    expect(decideDemand(ok(4), 3).decision).toBe(DEMAND_DECISION.WITHHELD);
+  });
+
+  it('every decision carries its own evidence, so a suppressed run can be audited later', () => {
+    const d = decideDemand(ok(9), 3, { engine: 'fr-c-generator', measuredAt: '2026-07-29T16:05:41Z' });
+    expect(d).toMatchObject({ engine: 'fr-c-generator', gauge_value: 9, floor: 3, measured_at: '2026-07-29T16:05:41Z' });
+    expect(d.reason).toContain('9');
+    expect(d.reason).toContain('3');
+  });
+});
+
+describe('TS-2: a null gauge can NEVER be read as below the floor (the fail-open flood)', () => {
+  // `null > 3` is false, so a naive gate SOURCES on an unreadable gauge. That is the exact
+  // silent flood this SD exists to prevent, and it must be unreachable BY CONSTRUCTION.
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['NaN', NaN],
+    ['Infinity', Infinity],
+    ['negative', -1],
+    ['non-numeric dispatchable', { dispatchable: 'lots' }],
+  ])('%s -> unmeasurable, never sourced', (_label, raw) => {
+    const d = decideDemand(normalizeGaugeReading(raw), 3);
+    expect(d.decision).toBe(DEMAND_DECISION.UNMEASURABLE);
+    expect(d.decision).not.toBe(DEMAND_DECISION.SOURCED);
+    expect(mayProduce(d)).toBe(false);
+  });
+
+  it('the reason names the gauge, not a comparison — it must not read like a full belt', () => {
+    const d = decideDemand(normalizeGaugeReading(null), 3);
+    expect(d.reason).toContain('unreadable');
+    expect(d.reason).toContain('NOT a licence to produce');
+  });
+
+  it('normalizeGaugeReading is the only constructor of a comparable value', () => {
+    expect(normalizeGaugeReading({ dispatchable: 5 })).toEqual({ ok: true, value: 5 });
+    expect(normalizeGaugeReading(5)).toEqual({ ok: true, value: 5 });
+    expect(normalizeGaugeReading(null).ok).toBe(false);
+    // A hand-rolled object that lies about ok still cannot smuggle a non-finite value through,
+    // because decideDemand re-checks the floor and the value came from nowhere comparable.
+    expect(decideDemand({ ok: true, value: NaN }, 3).decision).not.toBe(DEMAND_DECISION.SOURCED);
+  });
+});
+
+describe('TS-2b: a non-finite FLOOR also yields unmeasurable', () => {
+  // `5 > NaN` is ALSO false. Guarding only the gauge is half a guard, with identical blast radius.
+  it.each([['NaN', NaN], ['undefined', undefined], ['null', null], ['string', '3'], ['Infinity', Infinity]])(
+    'floor=%s -> unmeasurable, never sourced',
+    (_label, floor) => {
+      const d = decideDemand(ok(0), floor);
+      expect(d.decision).toBe(DEMAND_DECISION.UNMEASURABLE);
+      expect(mayProduce(d)).toBe(false);
+      expect(d.reason).toContain('floor');
+    }
+  );
+
+  it('a valid gauge with an invalid floor still reports the gauge it managed to read', () => {
+    expect(decideDemand(ok(7), NaN).gauge_value).toBe(7);
+  });
+});
+
+describe('TS-3b: POSITIVE CONTROL — an always-withhold gate must not pass', () => {
+  // The control the original suite lacked. A gate hardcoded to withhold satisfies "discriminates"
+  // and "withheld inserts nothing" simultaneously, while leaving the engine PERMANENTLY DEAD —
+  // indistinguishable from correctly-quiet, i.e. this SD's own defect inside its own acceptance.
+  it('a starved belt genuinely permits production', () => {
+    const d = decideDemand(ok(0), 3, { engine: 'refill-auto-promote' });
+    expect(mayProduce(d)).toBe(true);
+    expect(d.decision).toBe(DEMAND_DECISION.SOURCED);
+  });
+
+  it('mayProduce is not satisfied by object truthiness — every decision object is truthy', () => {
+    expect(mayProduce(decideDemand(ok(9), 3))).toBe(false);
+    expect(mayProduce(decideDemand(normalizeGaugeReading(null), 3))).toBe(false);
+    expect(mayProduce(decideDemand(ok(0), 3))).toBe(true);
+  });
+});
+
+describe('TS-10: the floor is injected, not baked in', () => {
+  it('the SAME gauge reading yields different decisions under different floors', () => {
+    const reading = ok(5);
+    expect(decideDemand(reading, 10).decision).toBe(DEMAND_DECISION.SOURCED);
+    expect(decideDemand(reading, 2).decision).toBe(DEMAND_DECISION.WITHHELD);
+    // If a floor were hardcoded, these two would agree and the acceptance criterion requiring a
+    // floor chosen from a timestamped series would be untestable.
+  });
+});
+
+describe('TS-6 (REPAIRED): gated-producer membership, not absence-of-change', () => {
+  // Original wording asserted the three staging writers "remain reachable" — an absence of change
+  // to files this SD never touches: green before, green after, green if the gate were deleted.
+  it('the three roadmap_wave_items stagers are NOT gated on belt depth', () => {
+    for (const stager of ['gauge-gap-miner', 'proactive-populator', 'adam-direct-registry']) {
+      expect(BELT_DEPTH_GATED_PRODUCERS).not.toContain(stager);
+      expect(STAGING_PRODUCERS_NOT_GATED).toContain(stager);
+    }
+  });
+
+  it('the two insert-boundary producers ARE gated', () => {
+    expect(BELT_DEPTH_GATED_PRODUCERS).toContain('refill-auto-promote');
+    expect(BELT_DEPTH_GATED_PRODUCERS).toContain('fr-c-generator');
+  });
+
+  it('the two sets are disjoint — a producer cannot be both gated and excluded', () => {
+    const overlap = BELT_DEPTH_GATED_PRODUCERS.filter((p) => STAGING_PRODUCERS_NOT_GATED.includes(p));
+    expect(overlap).toEqual([]);
+  });
+});
+
+describe('FR-3: the decision renders, and never-ran is distinct from withheld', () => {
+  it('withheld, unmeasurable and never-ran all render differently', () => {
+    const withheld = formatDemandDecision(decideDemand(ok(9), 3, { engine: 'e' }));
+    const unmeasurable = formatDemandDecision(decideDemand(normalizeGaugeReading(null), 3, { engine: 'e' }));
+    const neverRan = formatDemandDecision(null);
+    expect(new Set([withheld, unmeasurable, neverRan]).size).toBe(3);
+    expect(neverRan).toContain('NEVER RAN');
+    expect(unmeasurable).toContain('UNMEASURABLE');
+  });
+
+  it('numbers print unconditionally, including a zero gauge', () => {
+    // measured-and-zero must be distinguishable from not-measured.
+    expect(formatDemandDecision(decideDemand(ok(0), 3, { engine: 'e' }))).toContain('gauge=0');
+  });
+});

--- a/tests/unit/governance/demand-gate.test.js
+++ b/tests/unit/governance/demand-gate.test.js
@@ -100,6 +100,18 @@ describe('TS-2b: a non-finite FLOOR also yields unmeasurable', () => {
   it('a valid gauge with an invalid floor still reports the gauge it managed to read', () => {
     expect(decideDemand(ok(7), NaN).gauge_value).toBe(7);
   });
+
+  it('the guard converts a SILENT withhold into a LOUD unmeasurable (pins the operator hazard)', () => {
+    // RETRO 4cc2e3c1: the module comments described a `>` shape, where a NaN floor FLOODS. Under
+    // the shipped `<=`, an unguarded NaN floor yields `false` -> withheld -> the engine goes dark
+    // and reads as correctly-quiet, which is this module's founding defect. Both are worth
+    // guarding, but the REASON differs, and prose is not pinned by anything. This is:
+    expect(ok(5).value <= NaN).toBe(false);            // unguarded, the raw comparison withholds
+    const d = decideDemand(ok(5), NaN);
+    expect(d.decision).toBe(DEMAND_DECISION.UNMEASURABLE); // guarded, it is LOUD instead
+    expect(d.decision).not.toBe(DEMAND_DECISION.WITHHELD); // and specifically NOT silently quiet
+    expect(d.reason).toContain('floor');
+  });
 });
 
 describe('TS-3b: POSITIVE CONTROL — an always-withhold gate must not pass', () => {

--- a/tests/unit/scripts/cron/fr-c-generator.test.js
+++ b/tests/unit/scripts/cron/fr-c-generator.test.js
@@ -25,6 +25,19 @@ vi.mock('../../../../lib/eva/quality-findings/sd-generator.js', () => ({
   writeAuditLog: (...args) => writeAuditLogSpy(...args),
 }));
 
+// SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 (FR-2): the demand gate is consulted BEFORE the
+// generator runs, so every test in this file now has to state which belt condition it describes.
+// Only the IO half is mocked — measureDemand reads the live gauge and cannot run here. mayProduce
+// and formatDemandDecision are deliberately left REAL: mocking the permission logic itself would
+// leave the thing under test unexercised.
+const measureDemandSpy = vi.fn();
+const recordDemandDecisionSpy = vi.fn();
+vi.mock('../../../../lib/governance/demand-gate-emit.js', () => ({
+  measureDemand: (...args) => measureDemandSpy(...args),
+  recordDemandDecision: (...args) => recordDemandDecisionSpy(...args),
+  resolveDemandFloor: () => 3,
+}));
+
 // Stub the supabase-js client so buildSupabase() doesn't need real env wiring.
 // We construct the supabase shape inline per test and pass it through runOnce.
 vi.mock('@supabase/supabase-js', () => ({
@@ -33,6 +46,7 @@ vi.mock('@supabase/supabase-js', () => ({
 
 const cronModule = await import('../../../../scripts/cron/fr-c-generator.mjs');
 const { runOnce, computeLockTtlSec, LOCK_NAME, tryClaimLock, releaseLock } = cronModule;
+const { decideDemand, normalizeGaugeReading } = await import('../../../../lib/governance/demand-gate.js');
 
 function makeSupabaseMock(rpcResponses) {
   // rpcResponses: Map<rpcName, () => { data, error }>
@@ -44,10 +58,19 @@ function makeSupabaseMock(rpcResponses) {
   return { rpc, _rpc: rpc };
 }
 
+// Built with the REAL decider so these fixtures cannot drift from the shape production emits.
+const STARVED = decideDemand(normalizeGaugeReading(0), 3, { engine: 'fr-c-generator' });
+const FULL = decideDemand(normalizeGaugeReading(11), 3, { engine: 'fr-c-generator' });
+const BLIND = decideDemand(normalizeGaugeReading(null), 3, { engine: 'fr-c-generator' });
+
 describe('fr-c-generator cron — lock primitive', () => {
   beforeEach(() => {
     generateRemediationSdsBatchSpy.mockReset();
     writeAuditLogSpy.mockReset();
+    // Default: a STARVED belt — the condition under which this cron is supposed to produce. The
+    // pre-existing success/throw tests below describe that world and are unchanged by the gate.
+    measureDemandSpy.mockReset().mockResolvedValue(STARVED);
+    recordDemandDecisionSpy.mockReset().mockResolvedValue(true);
   });
 
   test('computeLockTtlSec floors at 600s and otherwise returns 2x interval', () => {
@@ -163,5 +186,80 @@ describe('fr-c-generator cron — lock primitive', () => {
     ]));
     // Should not throw despite the RPC error response.
     await expect(releaseLock(supabase, 'owner-uuid-1')).resolves.toBeUndefined();
+  });
+});
+
+// ── SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 (FR-2): belt-depth demand gate ────────────────
+// This generator inserts status='draft', unclaimed SDs (sd-generator.js:632-654) — rows the
+// dispatchable gauge counts one-for-one — so it mints belt depth and is gated.
+describe('fr-c-generator cron — demand gate', () => {
+  const lockedSupabase = () => makeSupabaseMock(new Map([
+    ['try_claim_cron_lock', () => ({ data: true, error: null })],
+    ['release_cron_lock', () => ({ data: true, error: null })],
+  ]));
+  const run = (supabase) => runOnce({
+    args: { dryRun: false, daemon: false }, supabase, owner: 'owner-uuid-this-tick', ttlSec: 7200,
+  });
+
+  beforeEach(() => {
+    generateRemediationSdsBatchSpy.mockReset().mockResolvedValue({
+      ventures: ['v1'], totalCreated: 1, totalAppended: 0, totalSkippedRateLimited: 0, totalErrors: 0, perVenture: {},
+    });
+    writeAuditLogSpy.mockReset();
+    measureDemandSpy.mockReset().mockResolvedValue(STARVED);
+    recordDemandDecisionSpy.mockReset().mockResolvedValue(true);
+  });
+
+  test('DIFFERENTIAL — identical run, only the belt differs, and the generator runs or does not', async () => {
+    measureDemandSpy.mockResolvedValue(STARVED);
+    await run(lockedSupabase());
+    const whenStarved = generateRemediationSdsBatchSpy.mock.calls.length;
+
+    generateRemediationSdsBatchSpy.mockClear();
+    measureDemandSpy.mockResolvedValue(FULL);
+    await run(lockedSupabase());
+    const whenFull = generateRemediationSdsBatchSpy.mock.calls.length;
+
+    expect(whenStarved).toBe(1);
+    expect(whenFull).toBe(0);   // the load-bearing assertion
+  });
+
+  test('a withheld run still RELEASES THE LOCK — staying quiet must not fence the next tick out', async () => {
+    // The failure this catches is nastier than over-production: an early return that skipped
+    // finally{} would leave a TTL lock held, so the cron stays silent long after the belt drains,
+    // and the silence looks exactly like a correctly-withholding gate.
+    measureDemandSpy.mockResolvedValue(FULL);
+    const supabase = lockedSupabase();
+    const result = await run(supabase);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.summary.withheldByDemand).toBe(true);
+    expect(supabase._rpc.mock.calls.map((c) => c[0])).toContain('release_cron_lock');
+  });
+
+  test('an UNMEASURABLE gauge withholds — a gauge we could not read is not a licence to mint', async () => {
+    measureDemandSpy.mockResolvedValue(BLIND);
+    const result = await run(lockedSupabase());
+    expect(generateRemediationSdsBatchSpy).not.toHaveBeenCalled();
+    expect(result.summary.demand.decision).toBe('unmeasurable');
+  });
+
+  test('the decision is RECORDED on every run, produced or not', async () => {
+    // Recording only the interesting runs is how a withheld tick becomes indistinguishable from a
+    // tick that never fired — the ambiguity this SD exists to remove.
+    measureDemandSpy.mockResolvedValue(FULL);
+    await run(lockedSupabase());
+    expect(recordDemandDecisionSpy).toHaveBeenCalledTimes(1);
+
+    recordDemandDecisionSpy.mockClear();
+    measureDemandSpy.mockResolvedValue(STARVED);
+    await run(lockedSupabase());
+    expect(recordDemandDecisionSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('the demand verdict travels in the run summary, so the cron log carries its own evidence', async () => {
+    measureDemandSpy.mockResolvedValue(STARVED);
+    const result = await run(lockedSupabase());
+    expect(result.summary.demand).toMatchObject({ engine: 'fr-c-generator', gauge_value: 0, floor: 3, decision: 'sourced' });
   });
 });

--- a/tests/unit/sourcing-engine/refill-cron-demand-callsite.test.js
+++ b/tests/unit/sourcing-engine/refill-cron-demand-callsite.test.js
@@ -1,0 +1,103 @@
+/**
+ * SD-LEO-INFRA-SOURCING-ENGINE-BELT-GATED-001 — the CALL SITE, not the gate.
+ *
+ * TESTING review 57879900 finding C1 (CRITICAL). The gate inside selectRefillBatch was well
+ * covered; the wiring that FEEDS it was not covered at all, because main() has no test that
+ * reaches it. Mutation testing found FIVE one-line edits at this call site surviving 8,180 tests:
+ *
+ *   1. delete `demand` from the opts object      → gate is a total no-op (selectRefillBatch is
+ *                                                   opt-in on opts.demand, so absence is LEGAL)
+ *   2. drop `floor: resolveDemandFloor(env)`     → every run UNMEASURABLE; engine permanently dead
+ *                                                   and looks correctly-quiet
+ *   3. `const demand = null`                     → gate never applies
+ *   4. delete record/format                      → FR-3 emission silently gone for this engine
+ *   5. engine-name typo                          → badge reads NEVER RAN forever while it runs
+ *
+ * Mutants 1 and 3 reproduce the EXACT two states this SD exists to prevent — an engine that mints
+ * unchecked, and an engine that is silently dead. Each test below kills a specific one, so this
+ * file is written against the mutants rather than against the happy path.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const measureDemandSpy = vi.fn();
+const recordDemandDecisionSpy = vi.fn();
+vi.mock('../../../lib/governance/demand-gate-emit.js', async (importOriginal) => {
+  const real = await importOriginal();
+  return {
+    ...real,                                   // resolveDemandFloor stays REAL — mutant 2 is about
+    measureDemand: (...a) => measureDemandSpy(...a),   // the floor VALUE reaching measureDemand,
+    recordDemandDecision: (...a) => recordDemandDecisionSpy(...a), // so mocking it would hide it.
+  };
+});
+
+const { gatedSelectRefillBatch, REFILL_ENGINE } = await import('../../../scripts/sourcing-engine/refill-cron.mjs');
+const { decideDemand, normalizeGaugeReading, BELT_DEPTH_GATED_PRODUCERS } = await import('../../../lib/governance/demand-gate.js');
+const { DEFAULT_DEMAND_FLOOR } = await import('../../../lib/governance/demand-gate-emit.js');
+
+const STARVED = decideDemand(normalizeGaugeReading(0), 3, { engine: 'refill-auto-promote' });
+const FULL = decideDemand(normalizeGaugeReading(9), 3, { engine: 'refill-auto-promote' });
+
+const rows = (n = 4) => Array.from({ length: n }, (_, i) => ({
+  id: `rwi-${i}`, title: `Improve belt demand gating coverage ${i}`,
+  item_disposition: 'pending', wave_id: 'w1', source_type: 'roadmap', source_id: `rm-${i}`,
+}));
+
+describe('refill-cron call site — the wiring, not the gate', () => {
+  beforeEach(() => {
+    measureDemandSpy.mockReset().mockResolvedValue(STARVED);
+    recordDemandDecisionSpy.mockReset().mockResolvedValue(true);
+  });
+
+  it('KILLS mutant 1+3 — the decision actually REACHES selectRefillBatch', async () => {
+    // If demand were dropped from the opts (or nulled), a full belt would still select rows,
+    // because absence of opts.demand is legal by design for the 11 legacy call sites.
+    measureDemandSpy.mockResolvedValue(FULL);
+    const withheld = await gatedSelectRefillBatch({}, rows(), {});
+    measureDemandSpy.mockResolvedValue(STARVED);
+    const sourced = await gatedSelectRefillBatch({}, rows(), {});
+
+    expect(withheld.sel.batch).toEqual([]);
+    expect(withheld.sel.withheldByDemand).toBe(true);
+    expect(sourced.sel.batch.length).toBeGreaterThan(0);   // positive control: not simply dead
+  });
+
+  it('KILLS mutant 2 — the floor passed to measureDemand comes from env, and is FINITE', async () => {
+    await gatedSelectRefillBatch({}, rows(), {}, {});
+    expect(measureDemandSpy).toHaveBeenCalledWith(expect.anything(),
+      expect.objectContaining({ floor: DEFAULT_DEMAND_FLOOR }));
+
+    measureDemandSpy.mockClear();
+    await gatedSelectRefillBatch({}, rows(), {}, { BELT_DEMAND_FLOOR: '11' });
+    expect(measureDemandSpy).toHaveBeenCalledWith(expect.anything(),
+      expect.objectContaining({ floor: 11 }));
+
+    // Dropping the floor entirely yields undefined -> non-finite -> permanently unmeasurable.
+    const passed = measureDemandSpy.mock.calls.map((c) => c[1].floor);
+    for (const f of passed) expect(Number.isFinite(f)).toBe(true);
+  });
+
+  it('KILLS mutant 4 — the decision is recorded on EVERY run, withheld included', async () => {
+    measureDemandSpy.mockResolvedValue(FULL);
+    await gatedSelectRefillBatch({}, rows(), {});
+    expect(recordDemandDecisionSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('KILLS mutant 5 — the engine name matches the registry the BADGE reads', async () => {
+    // A typo here is invisible: the cron runs and records, while the badge looks up a name that
+    // is never written and reports NEVER RAN forever.
+    await gatedSelectRefillBatch({}, rows(), {});
+    expect(measureDemandSpy).toHaveBeenCalledWith(expect.anything(),
+      expect.objectContaining({ engine: REFILL_ENGINE }));
+    expect(BELT_DEPTH_GATED_PRODUCERS).toContain(REFILL_ENGINE);
+  });
+
+  it('a missing decision THROWS rather than selecting ungated', async () => {
+    measureDemandSpy.mockResolvedValue(undefined);
+    await expect(gatedSelectRefillBatch({}, rows(), {})).rejects.toThrow(/without a demand decision/);
+  });
+
+  it('caller opts still flow through — the gate composes with the volume cap', async () => {
+    const { sel } = await gatedSelectRefillBatch({}, rows(10), { limit: 2 });
+    expect(sel.batch.length).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces a boolean nobody noticed with a **condition**, and makes the condition's verdict readable every run.

Chairman-directed. He rejected a "turn two flags on and watch one cycle" plan: *"Is there a way to keep them on, but then make them intelligent enough so they're not overwhelming? My fear is that we're just going to forget that they're off."* That fear is the dominant defect class here — **an off flag is indistinguishable from an on-and-quiet flag**. A watch-one-cycle plan is a vigilance control, and vigilance decays. A condition does not.

- **FR-1** `lib/governance/demand-gate.js` — pure, DB-free decider. `normalizeGaugeReading` is the only constructor of a comparable value; `decideDemand` rejects a non-ok reading **and** a non-finite floor **and** a non-finite value before the single comparison, so fail-open is unreachable by construction. `unmeasurable` is a first-class decision — collapsing it into `sourced` re-creates the flood, into `withheld` re-creates the silent-off.
- **FR-2** gates the two producers that actually mint belt depth: `refill-auto-promote` (hourly `--apply`, 10/run, 240/day) and `fr-c-generator`. Both verified to insert `status='draft'`, unclaimed SDs — the exact rows the gauge counts. The SD's spine led with a different producer; it turned out to be a staging writer that adds **zero** belt depth, so gating it would have changed nothing.
- **FR-3** emits `{engine, gauge_value, floor, decision, reason, measured_at}` to `audit_log` on **every** run and renders it in the Adam startup badge. Without a reader, the gate is a condition nobody notices replacing a boolean nobody noticed.
- **FR-4** written decision (in the PRD close-out): QF-side depth **scoped out**, gap named, follow-up `SD-LEO-INFRA-GATE-SIDE-BELT-001` filed. The PRD's premise needed correcting — both QF producers mint via `execFileSync(create-quick-fix.js)`, a **shared CLI with attended and unattended callers**, so the gate belongs at the cron callers, never at the writer (that would block a human filing a QF by hand).
- **FR-5** retires four flags with **zero executable readers** (re-verified, not inherited) and renders the DB arm that actually governs. The SD's own interim step "turn all four ON" was a **no-op**, and "all six read ON in the probe" was satisfiable by exporting env vars while changing zero behaviour. `TS-9` makes that unsatisfiable.

## What the reviews found — and what it cost

TESTING (39 mutations, 26 killed) and SECURITY (58 adversarial probes) each returned CONDITIONAL_PASS/88 with real defects. **Two of them were this SD's own thesis, committed by this SD:**

- **C1 (critical)** — I proved the gate works by deleting it and watching tests go red. That proved nothing *reaches* it: five mutations at the untested call site survived 8,180 tests, including deleting `demand` from the opts, which makes the whole gate a no-op. A guard inside one code path is not a guard on the invariant. Extracted `gatedSelectRefillBatch` as one seam with 6 tests written against the mutants.
- **C2 (high)** — my badge rendered an unreadable DB state as a confident `⚪ off` on the line I had labelled OPERATIVE, because the helper I called never throws (it silently falls back to env). Now three states: on / off / `❔ NO ROW`, and a fault says *"do NOT read this as off"*.
- **SEC-1** — the guard checked the `ok` tag but not the value, while checking the floor properly. `{ok:true, value:null}` returned SOURCED, and with `<=`, null coerces to 0 = empty belt. The header promised the property held "for callers who do not exist yet"; that was false as written.
- **SEC-2** — a three-week-old fossilised verdict rendered byte-identically to a fresh one. `measured_at` now prints unconditionally.
- **C3** — my fake DB couldn't fail: six query mutants survived, including a flipped sort that freezes the badge on the first verdict ever recorded.

## Test plan

- 5 suites, ~1030 tests in the touched areas; full unit suite 33,400.
- Revert-sensitivity proven by neutering **three** times (4 red, 6 red, 3 red), each restored.
- Positive controls throughout — one caught a vacuous fixture where the differential compared 0 to 0.
- Live verification on both the healthy and DB-fault badge paths.
- 12 pre-existing failures, disjoint from every file touched here, reproduced with this work stashed on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
