### PR TITLE
fix(QF-20260731-222): surface spawn refusals as {ok:false, reason} instead of bare 422

### DIFF
--- a/server/routes/fleet-actions.js
+++ b/server/routes/fleet-actions.js
@@ -239,10 +239,21 @@ export async function addSession(req, res) {
   // FR-1: spread CONDITIONALLY. resolveRoleSpawnOpts returns {} for 'worker' so the key is ABSENT,
   // which is what makes spawn() fall through to callsign-namespace selection. Passing
   // `startupPrompt: undefined` would make the key present and suppress the pointer entirely.
-  const result = await spawn(
-    { role, callsign: resolvedCallsign, accountProfile },
-    { supabaseClient: supabase, ...resolveRoleSpawnOpts(role) },
-  );
+  let result;
+  try {
+    result = await spawn(
+      { role, callsign: resolvedCallsign, accountProfile },
+      { supabaseClient: supabase, ...resolveRoleSpawnOpts(role) },
+    );
+  } catch (err) {
+    // Quick-fix QF-20260731-222: spawn()'s guards throw refusals whose messages carry the remedy
+    // (tree-currency names `git pull --ff-only`; the launch contract names its violations). Letting
+    // them fall through to the EVA error handler flattens them to a bare 422 with no reason field,
+    // while the sessions page already renders {ok:false, reason} verbatim — so answer in that shape
+    // and the operator sees the refusal instead of a status code.
+    res.status(422).json({ ok: false, reason: (err && err.message) || String(err) });
+    return;
+  }
   // callsign LAST and authoritative: the UI must report the name that was actually spawned, not the
   // (now absent) one the operator typed.
   res.json({ live: isLiveEnabled(), ...result, callsign: resolvedCallsign, callsign_minted: !supplied });

--- a/tests/unit/server/fleet-actions-route.test.js
+++ b/tests/unit/server/fleet-actions-route.test.js
@@ -131,6 +131,21 @@ describe('POST /api/fleet-actions/add-session', () => {
     expect(res.status).toHaveBeenCalledWith(400);
   });
 
+  // Quick-fix QF-20260731-222: a refusal thrown inside spawn() (tree-currency, launch contract)
+  // must answer {ok:false, reason} — not fall through to the EVA error handler, which flattens it
+  // to a bare 422 the sessions page can only render as "Spawn failed: 422".
+  it('answers a spawn() throw as {ok:false, reason} so the UI can render the refusal', async () => {
+    spawn.mockRejectedValueOnce(new Error('[tree-currency] REFUSED: 36 commit(s) behind origin/main'));
+    const req = mockReq({ role: 'worker', callsign: 'Hotel-1' });
+    const res = mockRes();
+    await addSession(req, res);
+
+    expect(res.status).toHaveBeenCalledWith(422);
+    const payload = res.json.mock.calls.at(-1)[0];
+    expect(payload.ok).toBe(false);
+    expect(payload.reason).toContain('[tree-currency] REFUSED');
+  });
+
   // SD-LEO-FEAT-FLEET-COLD-START-UX-001. The suite above asserts opts as expect.anything(), which
   // is exactly why the key-presence defect was invisible — these assert opts itself.
   describe('role -> startup prompt (FR-1/FR-2)', () => {


### PR DESCRIPTION
## Summary
- `POST /api/fleet-actions/add-session` let errors thrown inside `spawn()` fall through to the EVA error handler, which flattens unrecognized errors into a bare `422` with no `reason` field — the sessions page could only render "Spawn failed: 422" while the actionable refusal text sat in the server log.
- Wrap the `spawn()` call in try/catch and answer `{ok:false, reason: err.message}` — the shape `classifySpawn` in the EHG app already renders verbatim, so guard refusals (tree-currency remedy, launch-contract violations) now reach the operator.
- Adds one unit test pinning the behavior; the rest of the route suite is untouched and green (39/39).

## Root cause (observed live)
Coordinator spawn from the sessions page was refused by the tree-currency guard (36 commits behind origin/main, auto-fast-forward blocked by a dirty tree). The guard's message names the exact remedy — the operator saw only "422".

🤖 Generated with [Claude Code](https://claude.com/claude-code)