### PR TITLE
fix(QF-20260728-894): a chairman gate written as a sentence fenced nothing

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "pattern:port-isol-persist": "node scripts/insert-pat-port-isol-001.mjs",
     "hook:rca-outcome": "node scripts/hooks/post-tool-rca-outcome.cjs",
     "audit:codeguardian-mock": "node scripts/audit/codeguardian-mock-disposition.mjs",
-    "audit:prose-gate": "node --env-file=.env scripts/audit/prose-gate-without-flag.mjs",
+    "audit:prose-gate": "node scripts/audit/prose-gate-without-flag.mjs",
     "blast-radius": "node scripts/blast-radius.js",
     "quality:aggregate": "node scripts/aggregate-quality-findings.js",
     "quality:aggregate:cron": "node scripts/cron/quality-findings-aggregator.mjs",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "pattern:port-isol-persist": "node scripts/insert-pat-port-isol-001.mjs",
     "hook:rca-outcome": "node scripts/hooks/post-tool-rca-outcome.cjs",
     "audit:codeguardian-mock": "node scripts/audit/codeguardian-mock-disposition.mjs",
+    "audit:prose-gate": "node --env-file=.env scripts/audit/prose-gate-without-flag.mjs",
     "blast-radius": "node scripts/blast-radius.js",
     "quality:aggregate": "node scripts/aggregate-quality-findings.js",
     "quality:aggregate:cron": "node scripts/cron/quality-findings-aggregator.mjs",

--- a/scripts/audit/prose-gate-without-flag.mjs
+++ b/scripts/audit/prose-gate-without-flag.mjs
@@ -1,21 +1,15 @@
 #!/usr/bin/env node
 /**
- * QF-20260728-894 — find SDs that declare a chairman gate in PROSE but carry no
- * machine-readable flag, so they sit CLAIMABLE on the open belt.
+ * QF-20260728-894 — find open SDs that declare a chairman gate in PROSE while no
+ * machine-readable flag holds them, so they sit CLAIMABLE on the belt. Exit 1 on an
+ * unconditional offender (CI-gateable). Full rationale: PR #6670.
  *
- * Origin: SD-LEO-INFRA-CLOSE-REMAINING-SECURITY-001 declared "permission changes are
- * non-delegable ... chairman 3-factor --prod-deploy path" in its description while every
- * gating key was unset. A worker self-claimed it off the belt; that claim was the proof.
+ * metadata.requires_human_action is the ONLY axis that fences a claim (see
+ * lib/fleet/claim-eligibility.cjs). requires_chairman_apply / chairman_gated /
+ * gated_ddl measured 0 live rows each — folklore.
  *
- * metadata.requires_human_action is the ONLY axis that actually fences a claim
- * (lib/fleet/claim-eligibility.cjs, INELIGIBILITY_AXES.humanActionRequired).
- * requires_chairman_apply / chairman_gated / gated_ddl are folklore — measured at 0 live rows.
- *
- * REPORT-ONLY by design: it flags rows for a human to adjudicate, it does not fence them.
- * A regex must never silently block a claim — "the coordinator STRUCTURALLY CANNOT GRANT IT"
- * is English, not SQL, and an auto-fence on that would strand a legitimate SD.
- *
- * Exit 1 when an UNCONDITIONAL declared gate is unflagged (CI-gateable); 0 otherwise.
+ * REPORT-ONLY: it never fences. "the coordinator ... STRUCTURALLY CANNOT GRANT IT"
+ * is English, not SQL — auto-fencing that match would strand a legitimate SD.
  */
 import { createClient } from '@supabase/supabase-js';
 

--- a/scripts/audit/prose-gate-without-flag.mjs
+++ b/scripts/audit/prose-gate-without-flag.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * QF-20260728-894 — find SDs that declare a chairman gate in PROSE but carry no
+ * machine-readable flag, so they sit CLAIMABLE on the open belt.
+ *
+ * Origin: SD-LEO-INFRA-CLOSE-REMAINING-SECURITY-001 declared "permission changes are
+ * non-delegable ... chairman 3-factor --prod-deploy path" in its description while every
+ * gating key was unset. A worker self-claimed it off the belt; that claim was the proof.
+ *
+ * metadata.requires_human_action is the ONLY axis that actually fences a claim
+ * (lib/fleet/claim-eligibility.cjs, INELIGIBILITY_AXES.humanActionRequired).
+ * requires_chairman_apply / chairman_gated / gated_ddl are folklore — measured at 0 live rows.
+ *
+ * REPORT-ONLY by design: it flags rows for a human to adjudicate, it does not fence them.
+ * A regex must never silently block a claim — "the coordinator STRUCTURALLY CANNOT GRANT IT"
+ * is English, not SQL, and an auto-fence on that would strand a legitimate SD.
+ *
+ * Exit 1 when an UNCONDITIONAL declared gate is unflagged (CI-gateable); 0 otherwise.
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const OPEN = ['draft', 'active', 'in_progress', 'pending_approval', 'ready'];
+const FLAG = 'requires_human_action';
+
+// A declared gate. Bare GRANT/REVOKE are deliberately absent — proven noisy in prose.
+const GATE = [
+  /chairman[- ]gated?\b/i,
+  /non-?delegable/i,
+  /prod-deploy/i,
+  /\b(?:3|three)-factor\b/i,
+  /not a worker call/i,
+  /ALTER DEFAULT PRIVILEGES/i,
+  /\b(?:GRANT|REVOKE)\s+[A-Z_, ]+\s+(?:ON|TO|FROM)\b/, // SQL only: needs an object clause
+];
+
+// "May require ... If that means DDL, it is chairman-gated" declares a CONDITIONAL gate.
+const CONDITIONAL = /\b(?:if|may|might|should it|in the event)\b[^.]{0,120}$/i;
+
+const sb = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_ANON_KEY
+);
+
+const { data, error } = await sb
+  .from('strategic_directives_v2')
+  .select('sd_key,title,description,status,metadata')
+  .in('status', OPEN);
+
+// Set exitCode and fall through rather than process.exit() — an abrupt exit while the
+// supabase client still holds handles trips a libuv UV_HANDLE_CLOSING assertion on Windows
+// and reports a bogus 127, which would make this check unusable as a CI gate.
+if (error) {
+  console.error('query failed:', error.message);
+  process.exitCode = 2;
+}
+
+const offenders = [];
+for (const row of error ? [] : data) {
+  if (row.metadata?.[FLAG] === true) continue; // already fenced
+  const text = `${row.title || ''}\n${row.description || ''}`;
+  const rx = GATE.find((r) => r.test(text));
+  if (!rx) continue;
+  const at = text.search(rx);
+  const conditional = CONDITIONAL.test(text.slice(Math.max(0, at - 120), at));
+  offenders.push({ sd_key: row.sd_key, status: row.status, conditional, phrase: text.match(rx)[0] });
+}
+
+if (!error) console.log(`[prose-gate-without-flag] scanned ${data.length} open SDs — ${offenders.length} declare a gate with ${FLAG} unset`);
+for (const o of offenders) {
+  console.log(`  ${o.conditional ? 'CONDITIONAL' : 'UNCONDITIONAL'} [${o.status}] ${o.sd_key} — matched "${o.phrase}"`);
+}
+
+const hard = offenders.filter((o) => !o.conditional);
+if (hard.length) {
+  console.error(`\n${hard.length} SD(s) declare a gate in prose that nothing enforces. Set metadata.${FLAG}=true (with a _reason and _by stamp) or reword the description.`);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## The defect

`SD-LEO-INFRA-CLOSE-REMAINING-SECURITY-001` declared in its own description that
"permission changes are non-delegable ... chairman 3-factor `--prod-deploy` path" —
and every gating key on the row was unset. A worker self-claimed it off the open belt
at 09:38Z. **That claim is the proof, not a hypothetical**: a `REVOKE`/`GRANT` +
`ALTER DEFAULT PRIVILEGES` migration against production permissions was reachable
without the chairman path ever being touched. Reported by Charlie via signal
`1b55cb2d`; the sweep was explicitly left for authorization.

## What this adds

`scripts/audit/prose-gate-without-flag.mjs` (+ `npm run audit:prose-gate`) — finds open
SDs that declare a gate in prose but are held by no machine-readable flag. Exits 1 on an
unconditional offender so it can be wired as a CI gate.

## Measurements, not assumptions

| gate key | live rows (36 open SDs) |
|---|---|
| `requires_human_action` | **13** |
| `requires_chairman_apply` | 0 |
| `chairman_gated` | 0 |
| `gated_ddl` | 0 |

`requires_human_action` is the only axis `lib/fleet/claim-eligibility.cjs` reads. The other
three are folklore — matching on them would have detected nothing.

## Why report-only, and why bare GRANT/REVOKE are excluded

`SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001` contains "the coordinator ... STRUCTURALLY
CANNOT **GRANT** IT" — English, not SQL. A naive keyword sweep flags it; an auto-fence on
that match would have stranded a legitimate SD. The SQL patterns therefore require an
`ON`/`TO`/`FROM` object clause, and the check reports rather than fences.

Conditional gates ("*If* that means DDL, it is chairman-gated") are surfaced but do not
fail the run, so the gate stays actionable instead of chronically red.

## Controls

- **Positive** — with its flag ignored, the originating SD matches 6 of 7 patterns
  (incl. a real `REVOKE EXECUTE ON FUNCTIONS FROM`): it would have been caught.
- **Negative** — "CANNOT GRANT IT" does not match.
- The run went exit 1 → exit 0 only after the live offender was fenced, so the green is falsified, not assumed.

## Live risk closed

`SD-LEO-INFRA-REGRESSION-DETECTION-SILENT-001` was sitting claimable while declaring
"CHAIRMAN-GATED DDL ... not applied inline" and "NOT A WORKER CALL". Fenced with
`requires_human_action=true`, stamped `bravo-e3610a71-QF-20260728-894`, reversible with one
update. This blocks **claim**, not authoring — staging the migration is delegable scribe
work; applying the DDL is not.

## Not done (follow-on)

No cron/CI workflow is wired yet — adding one would push this past the QF LOC budget. The
check is invokable (`npm run audit:prose-gate`) and CI-gateable today; scheduling it is a
one-file follow-on.

46 code LOC (78 raw insertions; the remainder is the rationale header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
