### PR TITLE
fix(QF-20260728-823): CI health gauge counted feedback rows, so a dead recorder read as a green CI

### DIFF
--- a/.github/workflows/unit-tier.yml
+++ b/.github/workflows/unit-tier.yml
@@ -46,6 +46,15 @@ jobs:
         # first-tick fixes under a real spawned child process.
         run: npm run test:session-tick
 
+      - name: Run adam-github-assessment node:test suite (QF-20260728-823)
+        # Same gap as the session-tick step above, found again: this suite uses
+        # node:test/node:assert, and `--project unit` includes **/*.test.js plus ONLY the
+        # tests/unit/org and tests/unit/venture-email .mjs anchors — so this file has never
+        # gated a PR since it was written. Wiring it here means the D2 regression tests
+        # (failed-run count measured from the runs API; UNKNOWN never reported as 0)
+        # actually run in CI instead of only on the author's machine.
+        run: npm run test:adam-github-assessment
+
       - name: Quarantine burn-down summary
         if: always()
         # SD-LEO-FIX-UNIT-TIER-STARTUP-001: block scalar (run: |) so the embedded

--- a/lib/adam/presend-consult-lane.cjs
+++ b/lib/adam/presend-consult-lane.cjs
@@ -13,7 +13,7 @@
  *
  * WHY IT IS NON-BLOCKING (FR-1). There is NO safe blocking value. The consult gate runs BEFORE
  * insertCoordinationRow writes the advisory, and an outer 60s execFileSync wrapper
- * (adam-github-assessment.mjs:135) kills the process first — so a longer wait converts today's
+ * (adam-github-assessment.mjs sendAdvisory) kills the process first — so a longer wait converts today's
  * degraded-proceed into TOTAL SEND LOSS, strictly worse. Meanwhile the measured MINIMUM verdict
  * latency is 135s (p50 245-324s). The wait is therefore removed, not enlarged: the lane emits a
  * durable reply-needed consult and returns immediately, and a late verdict is reconciled

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "test:smoke": "vitest run tests/smoke.test.js",
     "test:session-tick": "node --test tests/unit/session-tick-heartbeat.test.mjs tests/unit/session-tick-marker-pid-refresh.test.mjs tests/unit/session-tick-patch-failure-telemetry.test.mjs tests/unit/session-tick-release-on-exit.test.mjs tests/unit/session-tick-spawn-observe.test.mjs",
     "test:sd-key-generator-gate": "node --test tests/unit/sd-key-generator-coverage.test.mjs",
+    "test:adam-github-assessment": "node --test tests/unit/adam-github-assessment.test.mjs",
     "test:unit": "vitest run --project unit",
     "test:db": "vitest run --project db",
     "test:db-guards": "node scripts/audit-db-test-guards.mjs",

--- a/scripts/adam-github-assessment.mjs
+++ b/scripts/adam-github-assessment.mjs
@@ -5,7 +5,7 @@
  * Read-only assessor that AGGREGATES existing GitHub-health producers into ONE ranked advisory for the
  * coordinator (it computes nothing new except the dependabot/code-scanning alert reads). Producers:
  *   (1) CI red on main      — codebase_health_snapshots latest dimension='ci_test_failure_count'
- *   (2) failed runs (3d)    — feedback rows category='ci_failure' (gh-failure-monitor.cjs)
+ *   (2) failed runs (3d)    — gh Actions runs API, conclusion=failure, PAGED TO EXHAUSTION
  *   (3) PR hygiene          — gh pr list --json: open / stale(>14d) / oversized(>400 LOC) / conflicts
  *   (4) merge conflicts     — derived from the same gh pr list (mergeable=CONFLICTING)
  *   (5) security alerts     — gh api open dependabot + code-scanning alerts (the one genuinely-new read)
@@ -38,6 +38,30 @@ function ghJson(args) {
   } catch { return null; }
 }
 
+/** Run a gh command, returning raw stdout (or null on any failure — fail-soft). */
+function ghRaw(args) {
+  try {
+    return execFileSync('gh', args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 120_000 });
+  } catch { return null; }
+}
+
+/**
+ * PURE/TOTAL: count failed workflow runs from the stdout of
+ * `gh api ... --paginate -q '.workflow_runs[].conclusion'` — one conclusion per line, pages
+ * concatenated (so exhaustion is counted, never a bare first page).
+ *
+ * QF-20260728-823 D2: a NON-STRING stdout (the gh read failed) returns null = UNKNOWN, NEVER 0.
+ * The old gauge counted `feedback` rows written by gh-failure-monitor.cjs, so a dead recorder was
+ * indistinguishable from a green CI — silence read as health. Unmeasurable must never read as clean.
+ */
+export function countFailedRuns(stdout) {
+  if (typeof stdout !== 'string') return null;
+  return stdout.split('\n')
+    .map((s) => s.trim().replace(/^"|"$/g, ''))
+    .filter((c) => c === 'failure')
+    .length;
+}
+
 /**
  * PURE/TOTAL: derive PR-hygiene counts from a `gh pr list` JSON array. Drafts are excluded from the
  * actionable counts. nowMs injected for deterministic tests.
@@ -59,7 +83,9 @@ export function summarizePrs(prs, { nowMs = Date.now(), staleDays = STALE_PR_DAY
 /**
  * PURE/TOTAL: rank the assembled facts into severity-ordered findings + a one-line summary. Returns
  * { findings:[{area,severity,detail}], summary, clean:boolean }. `clean` => the caller stays SILENT.
- * Unknown/unmeasured facts (null) are simply omitted (never a fabricated alarm).
+ * Unknown/unmeasured facts (null) are simply omitted (never a fabricated alarm) — with ONE
+ * deliberate exception: a null `failedRuns` alarms, because an unreadable CI must not render as
+ * "all clear" (QF-20260728-823 D2).
  */
 export function rankGithubHealth(facts = {}) {
   const f = facts || {};
@@ -71,6 +97,10 @@ export function rankGithubHealth(facts = {}) {
   if (Number(f.alertsCodeScanning) > 0) push('security', 'high', `${f.alertsCodeScanning} open code-scanning alert(s)`);
   if (Number(f.prConflicts) > 0) push('pr', 'medium', `${f.prConflicts} PR(s) with merge conflicts`);
   if (Number(f.failedRuns) > 0) push('ci', 'medium', `${f.failedRuns} failed CI run(s) in ${f.windowDays || WINDOW_DAYS}d`);
+  // Load-bearing half of QF-20260728-823 D2: UNKNOWN is a finding, not a silence. `undefined`
+  // (fact never supplied, e.g. pure-function callers) stays omitted; only an explicit null —
+  // meaning we TRIED to measure and could not — alarms.
+  if (f.failedRuns === null) push('ci', 'medium', 'failed CI run count UNKNOWN (Actions runs API unreadable) — NOT 0');
   if (Number(f.prStale) > 0) push('pr', 'low', `${f.prStale} stale PR(s) (>${STALE_PR_DAYS}d)`);
   if (Number(f.prOversized) > 0) push('pr', 'low', `${f.prOversized} oversized PR(s) (>${OVERSIZED_PR_LOC} LOC)`);
   const rank = { high: 0, medium: 1, low: 2 };
@@ -106,12 +136,14 @@ export async function resolveGithubHealth(supabase, { windowDays = WINDOW_DAYS, 
     facts.openRedMergeQfs = (rmRows || []).filter((qf) => !isFixtureQf(qf)).length;
   } catch { /* null */ }
 
-  // (2) failed CI runs in window.
-  try {
-    const { count } = await supabase.from('feedback')
-      .select('id', { count: 'exact', head: true }).eq('category', 'ci_failure').gte('created_at', since);
-    if (Number.isFinite(count)) facts.failedRuns = count;
-  } catch { /* null */ }
+  // (2) failed CI runs in window — counted from the Actions runs API itself, paged to exhaustion.
+  // NOT from feedback rows: that measured a different population (gh-failure-monitor's recordings)
+  // under the same label, and a stopped recorder reported ZERO failures = a perfectly green CI.
+  facts.failedRuns = countFailedRuns(ghRaw([
+    'api', '-X', 'GET', `repos/${REPO}/actions/runs`,
+    '-f', 'status=failure', '-f', `created=>=${since}`, '-F', 'per_page=100',
+    '--paginate', '-q', '.workflow_runs[].conclusion',
+  ]));
 
   // (3)+(4) PR hygiene + conflicts via one gh pr list.
   const prs = ghJson(['pr', 'list', '--repo', REPO, '--state', 'open', '--limit', '100', '--json', 'number,createdAt,additions,deletions,mergeable,isDraft']);

--- a/tests/unit/adam-github-assessment.test.mjs
+++ b/tests/unit/adam-github-assessment.test.mjs
@@ -5,7 +5,7 @@
  */
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { summarizePrs, rankGithubHealth } from '../../scripts/adam-github-assessment.mjs';
+import { summarizePrs, rankGithubHealth, countFailedRuns } from '../../scripts/adam-github-assessment.mjs';
 
 const NOW = new Date('2026-06-21T00:00:00Z').getTime();
 const daysAgo = (d) => new Date(NOW - d * 24 * 60 * 60 * 1000).toISOString();
@@ -38,6 +38,35 @@ test('rankGithubHealth: null facts are omitted (no fabricated alarm)', () => {
   const r = rankGithubHealth({});
   assert.equal(r.clean, true);
   assert.equal(r.findings.length, 0);
+});
+
+// ── QF-20260728-823 D2: the failed-run gauge must measure runs, and must never read UNKNOWN as 0 ──
+
+test('countFailedRuns: reported/actual == 1 across concatenated pages (exhaustion, not first page)', () => {
+  // 2 pages of `-q .workflow_runs[].conclusion` output, 120 failures total — more than one
+  // per_page=100 page, so a first-page-only count would report 100 and the ratio would be 0.83.
+  const actual = 120;
+  const stdout = Array.from({ length: actual }, () => 'failure').join('\n') + '\n';
+  assert.equal(countFailedRuns(stdout) / actual, 1);
+});
+
+test('countFailedRuns: counts only failure conclusions, tolerates quotes/blank lines', () => {
+  assert.equal(countFailedRuns('failure\n"failure"\nsuccess\ncancelled\n\n  failure  \n'), 3);
+  assert.equal(countFailedRuns(''), 0);   // measured, genuinely zero failures
+});
+
+test('countFailedRuns: an unreadable runs API is UNKNOWN (null), never 0', () => {
+  assert.equal(countFailedRuns(null), null);
+  assert.equal(countFailedRuns(undefined), null);
+  assert.notEqual(countFailedRuns(null), 0);
+});
+
+test('rankGithubHealth: UNKNOWN failed-run count alarms — silence must not read as all clear', () => {
+  const r = rankGithubHealth({ ciRedOnMain: 0, prStale: 0, failedRuns: null });
+  assert.equal(r.clean, false, 'an unreadable CI must NOT render as clean');
+  assert.match(r.summary, /UNKNOWN/);
+  // a measured zero stays silent — the alarm is about unmeasurability, not about zero
+  assert.equal(rankGithubHealth({ ciRedOnMain: 0, prStale: 0, failedRuns: 0 }).clean, true);
 });
 
 test('rankGithubHealth: severity-orders findings (high before low) and summarizes', () => {


### PR DESCRIPTION
## Correction first: Defect 1 of this QF is not real

The QF reports that `safe-root-resync`'s dependency repair fails non-fatally on CI, so jobs proceed without `node_modules` and die with errors that look like test failures. **That reading is wrong**, and I did not fix it because there is nothing there to fix.

Pulling the log of the exact run the QF cites (`30315385287`):

- The `[safe-root-resync]` lines are **stderr from the passing unit suite** `tests/unit/scripts/safe-root-resync.test.js` — 15/15 green, the PASS marker is the very next line.
- All of them land inside **30 ms** (`23:50:21.88`–`23:50:21.91`), and one announces a lock held by `other-session-xyz` — a fixture value.
- **No workflow invokes `safe-root-resync`.** Full-tree grep of `origin/main` finds only `npm run resync:safe` in `package.json`, plus docs and tests.
- Its loud non-zero exit for `repair_failed` has shipped since **2026-06-15** (`5858783da18`), six weeks before this QF was written.

The "5 of 5 runs, identical counts (probe FAILED ×4, missing-env ×1)" uniformity that the scope-bound-lift read as proof of a systematic environmental fault is exactly what a deterministic test suite printing fixed fixture output produces every run.

That run's real failure was **1 suite of 2696** — `complete-quick-fix-exits-on-success.test.js`, `Hook timed out in 10000ms`. **Trunk is green now**: the last 12 Unit Tier runs on `main` all passed. So the premise "trunk red for 3 days" no longer holds either, and I did not manufacture work to match the ticket.

## What this PR actually fixes: Defect 2 (real, load-bearing)

`resolveGithubHealth` measured `failedRuns` as `feedback` rows with `category='ci_failure'` — the *recordings* of `gh-failure-monitor.cjs`, not CI runs. Measured live over the same 3-day window:

| gauge | count |
|---|---|
| old proxy (feedback rows) | **11** |
| Actions runs API (truth) | **66** |

A 6× undercount — and the undercount is not the dangerous part. The recorder's most recent row **of any age** is `2026-07-29T19:40Z`, so it is already going stale and the gauge decays toward `0`, which rendered as *"all clear"*. Silence from the recorder was indistinguishable from a healthy CI.

**The fix:** count from the runs API directly (`status=failure`, `--paginate` to exhaustion, never a bare limit), and make an unreadable API yield `null` = UNKNOWN that **alarms** instead of being omitted. That second half is load-bearing — had UNKNOWN stayed silent, an unreadable CI would still have read as clean, reproducing the same failure mode one layer over.

## Verification at the consumer, not just in unit tests

- Live `--dry-run` → `66 failed CI run(s) in 3d` — matches the API count exactly (ratio = 1).
- Forced-unreadable (`ADAM_GH_REPO=<nonexistent>`) → `failed CI run count UNKNOWN (Actions runs API unreadable) — NOT 0`.
- 9/9 unit tests pass, including reported/actual == 1 across concatenated pages and `countFailedRuns(null) !== 0`.
- `tests/unit/adam-advisory-presend-consult-body.test.js` 9/9 (touched only by a stale line-number comment, repointed to the function name).

## Acceptance mapping

- **D2 ratio == 1 over a window where actual > 0** — met (66/66 live; unit test asserts the ratio across pages).
- **D2 stale/absent recorder yields UNKNOWN, never 0** — met, and proven end-to-end, not only in a unit test.
- **D1 exits non-zero on failed repair** — already shipped 2026-06-15; the premise it was meant to fix does not reproduce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)