### PR TITLE
fix(SD-LEO-INFRA-FULL-UTILISATION-RECOVERY-001): FR-1 — a honoured release was undone by resume on the same tick

### DIFF
--- a/lib/checkin/steps/release-request.cjs
+++ b/lib/checkin/steps/release-request.cjs
@@ -68,6 +68,16 @@ module.exports = {
         } catch { /* audit is best-effort; the release itself already happened */ }
         if (!ctx.base.release_requests_honored) ctx.base.release_requests_honored = [];
         ctx.base.release_requests_honored.push({ sd: row.sd_key, released: rel.released, requested_by: honored.requested_by || null });
+        // FR-1 (SD-LEO-INFRA-FULL-UTILISATION-RECOVERY-001): ctx.mySd is a ONE-SHOT snapshot,
+        // read once in scripts/worker-checkin.cjs (mySd = data.sd_key) BEFORE the ladder runs.
+        // Clearing the DB claim above does NOT update it, and release_sd leaves
+        // strategic_directives_v2.status untouched, so resume's terminal-check still passes.
+        // Without this line the very next step (resume) sees a held claim and returns
+        // action='resume' for the SD we just released — silently defeating this file's own
+        // closing comment and the contract in index.cjs ("BEFORE resume, so a released SD is
+        // not re-attached this same tick"). Only clear on a CONFIRMED release: if
+        // bestEffortReleaseSd failed, the claim may still be held and resume must still see it.
+        if (rel.released && ctx.mySd === row.sd_key) ctx.mySd = null;
       }
     } catch { /* fail-open: a fault here never blocks the checkin ladder */ }
     // Never returns a terminal result — the ladder continues (resume will no longer see the

--- a/tests/unit/fleet/release-request.test.js
+++ b/tests/unit/fleet/release-request.test.js
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { releaseRequestState } from '../../../lib/checkin/steps/release-request.cjs';
+import releaseRequestStep from '../../../lib/checkin/steps/release-request.cjs';
+
+const released = vi.hoisted(() => ({ value: true }));
+vi.mock('../../../lib/fleet/best-effort-release.mjs', () => ({
+  bestEffortReleaseSd: async () => ({ released: released.value, error: null }),
+}));
 
 describe('TS-5 releaseRequestState (pure part of the release-request step)', () => {
   const now = Date.parse('2026-07-16T12:00:00Z');
@@ -14,5 +20,55 @@ describe('TS-5 releaseRequestState (pure part of the release-request step)', () 
     expect(releaseRequestState(rr(31, 30), now)).toBe('expired');
     expect(releaseRequestState(rr(9999, undefined), now)).toBe('live');
     expect(releaseRequestState(rr(9999, -5), now)).toBe('live');
+  });
+});
+
+// FR-1 (SD-LEO-INFRA-FULL-UTILISATION-RECOVERY-001). ctx.mySd is a one-shot snapshot taken in
+// worker-checkin.cjs BEFORE the ladder runs, so honouring a release did NOT stop the very next
+// step (resume) from re-attaching the SD just released — defeating the contract index.cjs states
+// ("BEFORE resume, so a released SD is not re-attached this same tick").
+describe('FR-1 release-request clears the stale ctx.mySd snapshot', () => {
+  const SESSION = 'sess-1';
+  const SD_KEY = 'SD-TEST-RELEASE-001';
+
+  function fakeSb() {
+    return {
+      from(table) {
+        if (table === 'system_events') return { insert: async () => ({}) };
+        return {
+          select: () => ({
+            eq: () => ({
+              limit: async () => ({
+                data: [{
+                  id: 'row-1',
+                  sd_key: SD_KEY,
+                  metadata: { release_request: { requested_at: new Date().toISOString(), reason: 'test' } },
+                }],
+              }),
+            }),
+          }),
+          // conditional-clear chain: update().eq().eq().select('id')
+          update: () => ({ eq: () => ({ eq: () => ({ select: async () => ({ data: [{ id: 'row-1' }], error: null }) }) }) }),
+        };
+      },
+    };
+  }
+
+  const ctxFor = () => ({ sb: fakeSb(), sessionId: SESSION, mySd: SD_KEY, base: {} });
+
+  it('nulls ctx.mySd after a confirmed release, so resume falls through instead of re-attaching', async () => {
+    released.value = true;
+    const ctx = ctxFor();
+    await releaseRequestStep.run(ctx);
+    expect(ctx.base.release_requests_honored?.[0]?.sd).toBe(SD_KEY);
+    expect(ctx.mySd).toBeNull();
+  });
+
+  it('PRESERVES ctx.mySd when the release did not actually happen', async () => {
+    released.value = false;
+    const ctx = ctxFor();
+    await releaseRequestStep.run(ctx);
+    // The claim may still be held — resume must still see it. Clearing here would strand the SD.
+    expect(ctx.mySd).toBe(SD_KEY);
   });
 });


### PR DESCRIPTION
## The defect

`lib/checkin/steps/index.cjs` promises release-request runs *"strictly after roll-call and
BEFORE resume, so a released SD is not re-attached this same tick"*. `release-request.cjs`'s own
closing comment repeats it: *"resume will no longer see the released SD"*. **Neither held.**

`ctx.mySd` is a **one-shot snapshot**, read once in `scripts/worker-checkin.cjs`
(`mySd = data.sd_key`) *before* the ladder runs. Honouring a release clears
`claude_sessions.sd_key` and the SD's claim columns, but nothing updates that snapshot — and
`release_sd` deliberately leaves `strategic_directives_v2.status` untouched, so `resume`'s
terminal-check still passes. The release succeeded in the database, and `resume` immediately
returned `action='resume'` for the SD just released.

## Why this is FR-1 and not a tidy-up

The remedy chosen for this SD is option **(d)** — a directed assignment to a busy seat produces a
**scheduled release** instead of a text notice. That rests entirely on release-request being an
effective lever. A scheduled release that `resume` undoes on the same tick is not a lever. So this
lands first, and it ships independently of everything else in the SD.

## Only on a confirmed release

If `bestEffortReleaseSd` failed, the claim may still be held — clearing the snapshot there would
strand the SD, the exact harm rule 7a exists to prevent. The guard is `rel.released && ...`, and
the second test pins that direction explicitly.

## The test was falsified, not just observed green

With the fix reverted, the positive case **fails**; restored, it passes. A test that passes with
and without the change would have been worthless here.

## No test amendment required

The coordinator flagged that current behaviour is test-locked and budgeted deliberate amendments.
**FR-1 needs none.** `tests/unit/checkin-pipeline.test.js` (17-step order) and
`tests/unit/worker-checkin-assignment-surfacing.test.js` (`:103` held-claim surfacing, `:210`
byte-identical no-regression) both still pass — **49/49** — because this does not touch the resume
short-circuit for the normal case. It only makes an *explicit* release take effect, which is what
the codebase already documents.

Scope: 67 insertions, 1 deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
