### PR TITLE
fix(SD-LEO-INFRA-FULL-UTILISATION-RECOVERY-001): release-request could release the wrong SD

### DIFF
--- a/lib/checkin/steps/release-request.cjs
+++ b/lib/checkin/steps/release-request.cjs
@@ -55,7 +55,13 @@ module.exports = {
           .select('id');
         if (upd.error || !upd.data || upd.data.length !== 1) continue;
         const { bestEffortReleaseSd } = await import('../../fleet/best-effort-release.mjs');
-        const rel = await bestEffortReleaseSd(sb, sessionId, `release_request:${honored.reason || 'unspecified'}`);
+        // SD-SCOPED (QF-20260726-593). release_sd takes NO SD argument — it releases whatever
+        // claude_sessions.sd_key currently points at. This loop walks up to 5 SDs claimed by this
+        // session, so an unscoped call could clear the release_request flag on THIS row while
+        // releasing a DIFFERENT, live SD. expectedSdKey makes it a fail-closed no-op unless the
+        // session actually holds this row's SD.
+        const rel = await bestEffortReleaseSd(sb, sessionId, `release_request:${honored.reason || 'unspecified'}`,
+          console.error, { expectedSdKey: row.sd_key });
         // Audit trail — a cooperative release must be reconstructable (who asked, when honored).
         try {
           await sb.from('system_events').insert({

--- a/tests/unit/fleet/release-request.test.js
+++ b/tests/unit/fleet/release-request.test.js
@@ -3,8 +3,12 @@ import { releaseRequestState } from '../../../lib/checkin/steps/release-request.
 import releaseRequestStep from '../../../lib/checkin/steps/release-request.cjs';
 
 const released = vi.hoisted(() => ({ value: true }));
+const lastCall = vi.hoisted(() => ({ args: null }));
 vi.mock('../../../lib/fleet/best-effort-release.mjs', () => ({
-  bestEffortReleaseSd: async () => ({ released: released.value, error: null }),
+  bestEffortReleaseSd: async (...args) => {
+    lastCall.args = args;
+    return { released: released.value, error: null };
+  },
 }));
 
 describe('TS-5 releaseRequestState (pure part of the release-request step)', () => {
@@ -62,6 +66,18 @@ describe('FR-1 release-request clears the stale ctx.mySd snapshot', () => {
     await releaseRequestStep.run(ctx);
     expect(ctx.base.release_requests_honored?.[0]?.sd).toBe(SD_KEY);
     expect(ctx.mySd).toBeNull();
+  });
+
+  // QF-20260726-593: release_sd takes no SD argument and releases whatever the session currently
+  // holds. This loop walks up to 5 held SDs, so an unscoped call can clear THIS row's flag while
+  // releasing a DIFFERENT live SD. expectedSdKey makes it fail-closed.
+  it('passes expectedSdKey so the release is SD-scoped, not "whatever the session holds"', async () => {
+    released.value = true;
+    lastCall.args = null;
+    const ctx = ctxFor();
+    await releaseRequestStep.run(ctx);
+    expect(lastCall.args).not.toBeNull();
+    expect(lastCall.args[4]).toMatchObject({ expectedSdKey: SD_KEY });
   });
 
   it('PRESERVES ctx.mySd when the release did not actually happen', async () => {


### PR DESCRIPTION
## The hazard

`release_sd` takes **no SD argument** — it releases whatever `claude_sessions.sd_key` currently
points at (`20260502_release_clear_worktree_state.sql`). QF-20260726-593 added an `expectedSdKey`
guard to `bestEffortReleaseSd` for exactly this, fail-closed by construction, and stated the rule:
*"have every caller assert the session holds the SD it intends to release before calling."*

`release-request.cjs` wasn't passing it.

## Why this call site is worse than the generic case

The loop above it walks up to **five** SDs claimed by the session
(`select ... .eq('claiming_session_id', sessionId).limit(5)`). So a `release_request` on SD-B can:

1. clear **SD-B's** flag — the atomic conditional clear succeeds, it's keyed on `row.id` — and then
2. release **SD-A**, whichever SD the session's single scalar `sd_key` happens to hold.

The flag is consumed on one row and a different, live claim is dropped. Both halves wrong, and
silently: `bestEffortReleaseSd` never throws by contract.

Passing `{ expectedSdKey: row.sd_key }` makes it a no-op unless the session really holds this row's SD.

## Provenance

Found while implementing FR-3 (release safety) for this SD — the release path is the lever the whole
remedy depends on, so an unscoped release sitting in it is not something to leave behind.

## Test

Asserts the argument is passed. Its teeth are **structural** rather than empirically falsified: it
reads the 5th argument, which does not exist without this change.

Stacked on #6673 (FR-1); rebases cleanly if that lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
