### PR TITLE
feat(SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001): FR-6 — a blocker re-assertion is unsound until you have drained your inbox

### DIFF
--- a/lib/fleet/blocker-drain-gate.mjs
+++ b/lib/fleet/blocker-drain-gate.mjs
@@ -1,0 +1,72 @@
+/**
+ * SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-6) — the inbox-drain precondition on a blocker
+ * re-assertion.
+ *
+ * WHY IT LIVES IN lib/ RATHER THAN IN THE CLI. scripts/worker-recheck-blocker.mjs carries a
+ * shebang, and vite's import analysis refuses to parse a shebang'd module, so anything exported
+ * from there is structurally untestable by the vitest `unit` project. Same doctrine as
+ * lib/adam/presend-consult-lane.cjs: all logic in the unit-tested lib, the live path keeps a tiny
+ * diff.
+ *
+ * WHY THE GATE EXISTS. Alpha-3 re-checked its own blocker correctly on every pass, exactly as the
+ * directive instructs, and still sat for ten hours — because it never re-read INBOUND while the
+ * coordinator was actively sending it the diagnosis that would have unstuck it. "Still blocked" is
+ * a sound claim only if you have looked at everything that could have unblocked you.
+ */
+
+/**
+ * Count inbound rows this session has NOT yet consumed.
+ *
+ * Undrained means `acknowledged_at IS NULL` — the predicate lib/checkin/steps/resume.cjs uses.
+ * QF-20260703-476 established that UNACKED, not unread, is the correct test: a row can be
+ * read_at-stamped and still unactioned, and (per this SD's FR-3) read_at is even stamped on mere
+ * dashboard render, so an unread-only test would let a surfaced-but-unactioned answer pass as
+ * drained.
+ *
+ * TAKES AN ALREADY-CONSTRUCTED CLIENT, NOT A FACTORY. Constructing a SECOND supabase client in this
+ * process and issuing a query from it makes the subsequent process.exit() race libuv handle
+ * teardown on Windows: the run aborts with "Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)"
+ * and exit code 127, destroying the exit-code contract this CLI exists to provide (0/2/3/4). Caller
+ * must pass the ONE client it already builds for emit-feedback. Verified: factory form exited 127,
+ * shared-client form exits 3/4 correctly.
+ *
+ * @param {string|null} sessionId
+ * @param {Function} [countFn] injectable counter so tests never touch a live database
+ * @param {object} [deps] { client } — an existing supabase client, NOT a createClient factory
+ * @returns {Promise<number|null>} count, or null when it cannot be determined
+ *
+ * FAIL-OPEN BY DESIGN: a failure to COUNT is not a failure to drain. If the query breaks we return
+ * null and the caller proceeds, because a telemetry outage must never manufacture a blocker.
+ */
+export async function countUndrainedInbound(sessionId, countFn, deps = {}) {
+  if (!sessionId) return null;
+  try {
+    if (countFn) return await countFn(sessionId);
+    const client = deps.client;
+    if (!client) return null;
+    const { count, error } = await client
+      .from('session_coordination')
+      .select('id', { count: 'exact', head: true })
+      .eq('target_session', sessionId)
+      .is('acknowledged_at', null);
+    return error ? null : count;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * PURE/TOTAL. Decide whether a re-check verdict may stand.
+ *
+ * Only STILL_BLOCKING is gated. The asymmetry is load-bearing: gating CLEARED would keep a worker
+ * blocked in order to enforce a process rule, which is precisely the harm FR-6 exists to prevent.
+ * INDETERMINATE passes through so a broken check stays distinguishable from a real block.
+ *
+ * @returns {'cleared'|'still_blocking'|'indeterminate'|'drain_required'}
+ */
+export function applyDrainGate(outcome, undrainedCount) {
+  return outcome === 'still_blocking' && Number(undrainedCount) > 0 ? 'drain_required' : outcome;
+}
+
+/** Exit code for each verdict, so a worker can branch without parsing prose. */
+export const EXIT_CODES = { cleared: 0, indeterminate: 2, still_blocking: 3, drain_required: 4 };

--- a/scripts/worker-recheck-blocker.mjs
+++ b/scripts/worker-recheck-blocker.mjs
@@ -24,12 +24,24 @@
  *   2 = INDETERMINATE  -> the check itself could not run (e.g. git fetch failed). Treated as
  *                         still-blocking for safety, but reported distinctly so a broken check is
  *                         never silently read as "still blocked" forever. Fail-safe, not fail-quiet.
+ *   4 = DRAIN_REQUIRED -> you have undrained inbound messages. You may NOT assert blocker-unchanged
+ *                         until you have read them (SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 FR-6).
+ *
+ * WHY EXIT 4 EXISTS (FR-6). Alpha-3 re-checked its own blocker correctly on every pass, exactly as
+ * the directive says to — and still sat for ten hours, because it never re-read INBOUND while the
+ * coordinator was actively sending it the diagnosis that would have unstuck it. "Still blocked" is
+ * only a truthful claim if you have looked at everything that could have unblocked you. So an
+ * undrained inbox makes the assertion UNSOUND, not merely impolite, and this check refuses to let
+ * the worker make it. Note the asymmetry: a CLEARED result is never withheld — good news is allowed
+ * through an undrained inbox, because withholding it would keep a worker blocked to enforce a
+ * process rule, which is the very harm FR-6 exists to prevent.
  */
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { createClient } from '@supabase/supabase-js';
 import fingerprintLib from '../lib/shared/content-fingerprint.cjs';
 import { emitFeedback } from '../lib/governance/emit-feedback.js';
+import { countUndrainedInbound, applyDrainGate, EXIT_CODES } from '../lib/fleet/blocker-drain-gate.mjs';
 import 'dotenv/config';
 
 const { fingerprint } = fingerprintLib;
@@ -88,6 +100,46 @@ const gateFile = arg('gate-file');
 const check = has('dirty') ? checkDirty() : checkGateFile(gateFile || 'scripts/sd-start.js');
 const label = has('dirty') ? 'peer-dirty-tree' : `gate-file:${gateFile || 'scripts/sd-start.js'}`;
 
+// FR-6 gate. Runs BEFORE the verdict is printed so the worker is never told "unchanged, stay quiet"
+// while an unread answer is sitting in its inbox.
+const sessionId = arg('session') || process.env.CLAUDE_SESSION_ID;
+// ONE client for the whole run, shared with the emit-feedback tail below. Building a second client
+// here and querying from it makes process.exit() race libuv teardown on Windows (exit 127, libuv
+// UV_HANDLE_CLOSING assertion), which would silently destroy the 0/2/3/4 exit-code contract that is
+// this CLI's entire interface. A client MUST be passed — omitting it makes the count return null
+// forever and the gate never fires, i.e. an inert mechanism, the exact failure this SD exists to fix.
+const sbUrl = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const sbKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const supabase = sbUrl && sbKey ? createClient(sbUrl, sbKey) : null;
+
+/**
+ * Exit WITHOUT racing libuv teardown.
+ *
+ * Calling process.exit() in the same tick as a just-settled supabase fetch aborts the run on
+ * Windows with "Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)" and exit code 127 —
+ * silently destroying the 0/2/3/4 contract that is this CLI's entire interface. MEASURED: the
+ * drain-count query followed by an immediate exit reproduced 127 every time.
+ *
+ * So: set exitCode and let the loop drain (clean, natural exit), with an UNREF'd timer as a
+ * backstop in case a keep-alive socket would otherwise hold the process open. Unref'd means the
+ * timer never itself keeps us alive — it only fires if something else already has.
+ */
+function finish(code) {
+  process.exitCode = code;
+  setTimeout(() => process.exit(code), 250).unref();
+}
+
+const undrained = await countUndrainedInbound(sessionId, null, { client: supabase });
+const gated = applyDrainGate(check.outcome, undrained);
+// if/ELSE, not two ifs: finish() only SETS the exit code (it must not process.exit in-tick — see
+// above), so a bare `if` would fall through and the tail's finish() would overwrite 4 with 3. That
+// exact bug shipped for one run here: the CLI printed DRAIN_REQUIRED and exited 3.
+if (gated === 'drain_required') {
+  console.log(`[recheck] ${label} -> DRAIN_REQUIRED (${undrained} unread inbound message(s); blocker looks unchanged but you have not read what arrived)`);
+  console.log('[recheck] Run /checkin and read your inbox, THEN re-assert. "Still blocked" is not a sound claim until you have.');
+  finish(4);
+} else {
+
 console.log(`[recheck] ${label} -> ${check.outcome.toUpperCase()} (${check.detail})`);
 if (check.outcome === 'cleared') console.log('[recheck] RESUME IMMEDIATELY — do not wait to be told.');
 if (check.outcome === 'still_blocking') console.log('[recheck] Unchanged: re-check silently next tick. Do NOT re-report (FR-2).');
@@ -97,12 +149,10 @@ if (check.outcome === 'still_blocking') console.log('[recheck] Unchanged: re-che
 // scripts/hooks/stop-loop-wakeup-reminder.cjs.
 if (!has('no-record')) {
   try {
-    const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
-    if (url && key) {
+    if (supabase) {
       const fp = fingerprint('blocker_recheck', `${label}::${check.detail}`);
       await emitFeedback({
-        supabase: createClient(url, key),
+        supabase,
         title: `blocker re-check: ${label} -> ${check.outcome}`,
         description: `${check.detail}. Emitted by scripts/worker-recheck-blocker.mjs per SD-LEO-INFRA-BLOCKED-WORKER-SELF-RECHECK-001 FR-4.`,
         category: 'blocker_recheck',
@@ -117,4 +167,5 @@ if (!has('no-record')) {
   } catch { /* instrumentation is never load-bearing */ }
 }
 
-process.exit(check.outcome === 'cleared' ? 0 : check.outcome === 'still_blocking' ? 3 : 2);
+finish(EXIT_CODES[check.outcome] ?? 2);
+} // end else (non-drain path)

--- a/tests/unit/worker-recheck-drain-gate.test.js
+++ b/tests/unit/worker-recheck-drain-gate.test.js
@@ -1,0 +1,59 @@
+/**
+ * SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 FR-6 — a blocker re-assertion is unsound until the
+ * worker has drained its inbox in the same pass.
+ *
+ * MEASURED MOTIVATION: Alpha-3 re-checked its own blocker correctly on every pass, exactly as the
+ * directive instructs, and still sat for ten hours — because it never re-read INBOUND while the
+ * coordinator was actively sending it the diagnosis that would have unstuck it.
+ *
+ * Named .test.js deliberately: the vitest `unit` project globs every ".test.js" file but only two
+ * narrow .mjs anchors (tests/unit/org, tests/unit/venture-email), so a ".test.mjs" here would never
+ * run in CI — the exact gap measured in QF-20260728-823 (12 of 25 .test.mjs files gate nothing).
+ */
+import { describe, it, expect } from 'vitest';
+import { applyDrainGate, countUndrainedInbound } from '../../lib/fleet/blocker-drain-gate.mjs';
+
+describe('FR-6 drain gate', () => {
+  it('REJECTS a still-blocking assertion when inbound is undrained', () => {
+    expect(applyDrainGate('still_blocking', 1)).toBe('drain_required');
+    expect(applyDrainGate('still_blocking', 74)).toBe('drain_required');
+  });
+
+  it('allows a still-blocking assertion once the inbox is drained', () => {
+    expect(applyDrainGate('still_blocking', 0)).toBe('still_blocking');
+  });
+
+  it('NEVER withholds good news — a cleared blocker passes through an undrained inbox', () => {
+    // The asymmetry is load-bearing. Gating CLEARED would keep a worker blocked in order to
+    // enforce a process rule, which is precisely the harm FR-6 exists to prevent.
+    expect(applyDrainGate('cleared', 99)).toBe('cleared');
+  });
+
+  it('does not gate INDETERMINATE — a broken check must stay distinguishable', () => {
+    expect(applyDrainGate('indeterminate', 5)).toBe('indeterminate');
+  });
+
+  it('fails OPEN when the count is unavailable, so telemetry loss cannot manufacture a blocker', () => {
+    expect(applyDrainGate('still_blocking', null)).toBe('still_blocking');
+    expect(applyDrainGate('still_blocking', undefined)).toBe('still_blocking');
+    expect(applyDrainGate('still_blocking', NaN)).toBe('still_blocking');
+  });
+
+  it('counts UNACKED inbound, not unread — a read-but-unactioned row still blocks the assertion', async () => {
+    // QF-20260703-476: acknowledged_at IS NULL is the correct predicate. read_at is stamped on mere
+    // delivery (and, per this SD, even on dashboard render), so an unread-only test would let a
+    // surfaced-but-unactioned answer pass as drained.
+    const calls = [];
+    const countFn = async (sid) => { calls.push(sid); return 3; };
+    const n = await countUndrainedInbound('session-abc', countFn);
+    expect(n).toBe(3);
+    expect(calls).toEqual(['session-abc']);
+    expect(applyDrainGate('still_blocking', n)).toBe('drain_required');
+  });
+
+  it('returns null without a session id, and swallows a throwing counter', async () => {
+    expect(await countUndrainedInbound(null, async () => 5)).toBe(null);
+    const boom = async () => { throw new Error('db down'); };
+    expect(await countUndrainedInbound('session-abc', boom)).toBe(null);
+  });
+});


### PR DESCRIPTION
**PR 1 of 4** for SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001. The PRD sequences this first because it is fully independent and the lowest-risk slice — it completes wiring an artifact that already shipped.

`scripts/worker-recheck-blocker.mjs` landed with SD-LEO-INFRA-BLOCKED-WORKER-SELF-RECHECK-001 on 2026-07-27 and has had **zero callers repo-wide** ever since: no hook, no slash command, no npm script, no workflow.

## Why the gate

Alpha-3 re-checked its own blocker correctly on every pass, exactly as the directive instructs — and still sat for ten hours, because it never re-read **inbound** while the coordinator was actively sending it the diagnosis that would have unstuck it.

"Still blocked" is a sound claim only if you have looked at everything that could have unblocked you. An undrained inbox makes the assertion **unsound**, not merely impolite. New exit code **4 = DRAIN_REQUIRED**.

## The asymmetry is load-bearing

Only `STILL_BLOCKING` is gated.

- `CLEARED` passes through an undrained inbox untouched — withholding good news would keep a worker blocked in order to enforce a process rule, which is precisely the harm this FR exists to prevent.
- `INDETERMINATE` also passes, so a broken check stays distinguishable from a real block.

## Three defects I introduced, and caught by verifying at the consumer

The lib's unit tests were green through all three. Only running the actual CLI surfaced them.

1. **Exit 127 on every run.** Injecting a `createClient` *factory* meant a second Supabase client issued a query, and the following `process.exit()` raced libuv teardown on Windows — `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)` — silently destroying the 0/2/3/4 contract that is this CLI's entire interface. A control against `origin/main` proved I caused it: the original exits 3 cleanly on both its paths. Fixed by sharing the one client the script already builds.
2. **Same-tick exit still raced.** `finish()` now sets `process.exitCode` and lets the loop drain, with an unref'd 250ms backstop in case a keep-alive socket would hold the process open.
3. **Fall-through overwrote the verdict.** Because `finish()` no longer halts execution the way `process.exit()` did, the drain branch fell through and the tail overwrote exit 4 with exit 3 — the CLI printed `DRAIN_REQUIRED` and exited `STILL_BLOCKING`. Branches are now mutually exclusive.

## Verification

At the consumer, not only in unit tests:

| case | result |
|---|---|
| undrained inbox + still-blocking | `DRAIN_REQUIRED`, **exit 4** |
| drained inbox + still-blocking | `STILL_BLOCKING`, **exit 3** |
| `CLEARED` with an undrained inbox | **exit 0** (asymmetry holds) |

Plus 7/7 unit tests.

## Two structural notes

- Logic lives in `lib/fleet/blocker-drain-gate.mjs`, not the CLI: the script carries a shebang and vite's import analysis refuses to parse a shebang'd module, so anything exported from there is structurally untestable by the vitest `unit` project. Same doctrine as `lib/adam/presend-consult-lane.cjs`.
- The test is named `.test.js` deliberately — a `.test.mjs` there would never run in CI, the gap measured in QF-20260728-823.

Counting `acknowledged_at IS NULL` (not `read_at`) per QF-20260703-476: a row can be read-stamped and still unactioned, and per this SD's FR-3 `read_at` is even stamped on dashboard render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)