### PR TITLE
fix(SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001): FR-3 — the starvation gauge treated "rendered on a screen" as "answered"

### DIFF
--- a/lib/coordinator/detectors.cjs
+++ b/lib/coordinator/detectors.cjs
@@ -146,7 +146,20 @@ function detectReplyStarvation(data) {
     const answered = !!sig.acknowledged_at || !!(sig.payload && sig.payload.routed_to_feedback_id)
       || hasCorrelatedReply(sig, allSignals);
     if (answered) continue;
-    if (sig.read_at) continue; // read counts as a soft answer here (no separate reply table)
+    // SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-3): `if (sig.read_at) continue` USED TO LIVE
+    // HERE, treating a read-stamp as a soft answer. MEASURED: read_at is set on 1,962 of 1,965
+    // friction signals (99.85%), so this one line excluded almost the entire population from the
+    // only wired starvation gauge — which is why 1,963 unanswered signals never raised an alarm.
+    //
+    // read_at DOES NOT MEAN ANSWERED, and two SDs already shipped that contract on 2026-07-10:
+    // COORDINATOR-WAKE-ON-DIRECTIVE-001 and ADAM-INBOX-SURFACE-NOT-STAMP-001 both established that
+    // a read-stamp means SURFACED, never RENDERED — and scripts/fleet-dashboard.cjs stamps read_at
+    // on render (two sites). So a signal nobody acted on was marked read by the act of drawing it
+    // on a screen, and then silently dropped from the gauge that exists to notice it.
+    //
+    // THE PRODUCERS ARE DELIBERATELY LEFT ALONE. read_at is the legitimate DELIVERED stamp and the
+    // receipt contract (FR-1) requires DELIVERED to stay independently queryable; deleting the
+    // stamp would break that. The defect was always the CONSUMER reading delivery as disposition.
     const ageMs = now - toMs(sig.created_at);
     if (ageMs > thresholdMs) {
       starved.push({ id: sig.id, sender: sig.sender_session, age_ms: ageMs });

--- a/tests/unit/coordinator/detectors.test.js
+++ b/tests/unit/coordinator/detectors.test.js
@@ -62,16 +62,32 @@ describe('detectReplyStarvation', () => {
     expect(r.matched).toBe(true);
     expect(r.evidence.starved_count).toBe(1);
   });
-  it('does not match answered / read / non-worker / recent signals', () => {
+  it('does not match answered / non-worker / recent signals', () => {
+    // SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 FR-3: the read-but-unanswered row was REMOVED from
+    // this fixture and promoted to its own test below. It used to sit here asserting that a read
+    // signal is not starved, which locked in the defect: read_at is set on 99.85% of friction
+    // signals, so treating read as answered made this gauge structurally unable to see its own
+    // population.
     const base = { sender_type: 'worker', sender_session: 'w', created_at: minsAgo(45), acknowledged_at: null, read_at: null, payload: { signal_type: 'stuck' } };
     const signals = [
       { ...base, id: 'a', acknowledged_at: minsAgo(40) },                 // acknowledged
       { ...base, id: 'b', payload: { signal_type: 'stuck', routed_to_feedback_id: 'fb-1' } },   // routed (stampRouted)
-      { ...base, id: 'c', read_at: minsAgo(40) },                          // read
       { ...base, id: 'd', sender_type: 'coordinator' },                   // not a worker ask
       { ...base, id: 'e', created_at: minsAgo(5) },                        // too recent
     ];
     expect(detectReplyStarvation({ signals, now: NOW, thresholdMs: 30 * 60_000 }).matched).toBe(false);
+  });
+
+  it('DOES match a signal that was read but never answered (FR-3 — read is delivery, not disposition)', () => {
+    // read_at means DELIVERED and, per COORDINATOR-WAKE-ON-DIRECTIVE-001 and
+    // ADAM-INBOX-SURFACE-NOT-STAMP-001 (both 2026-07-10), a read-stamp means SURFACED — never
+    // RENDERED. fleet-dashboard.cjs stamps read_at on render, so counting read as answered let a
+    // signal be silenced by the act of drawing it on a screen.
+    const base = { sender_type: 'worker', sender_session: 'w', created_at: minsAgo(45), acknowledged_at: null, read_at: null, payload: { signal_type: 'stuck' } };
+    const readButUnanswered = [{ ...base, id: 'c', read_at: minsAgo(40) }];
+    const res = detectReplyStarvation({ signals: readButUnanswered, now: NOW, thresholdMs: 30 * 60_000 });
+    expect(res.matched).toBe(true);
+    expect(res.evidence.starved_count).toBe(1);
   });
 
   it('SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001: a correlated reply row excludes the original from starvation', () => {

--- a/tests/unit/coordinator/worker-signal-starvation.test.js
+++ b/tests/unit/coordinator/worker-signal-starvation.test.js
@@ -62,16 +62,27 @@ describe('reportWorkerSignalStarvation', () => {
     expect(lines.filter((l) => l.includes('WORKER_SIGNAL_UNANSWERED')).length).toBe(2);
   });
 
-  it('does NOT count signals that are answered, read, routed, or under threshold, or non-worker senders', async () => {
+  it('does NOT count signals that are answered, routed, under threshold, or from non-worker senders', async () => {
+    // SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 FR-3: row 'b' (read but never answered) was removed
+    // from this fixture and promoted to its own test below. Asserting starved===0 over a set that
+    // included a read-but-unanswered row locked in the defect that blinded this gauge to 99.85% of
+    // its population.
     const { log } = capture();
     const r = await reportWorkerSignalStarvation(fakeSupabase([
       { id: 'a', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(90), acknowledged_at: minsAgo(5), payload: { signal_type: 'stuck' } },
-      { id: 'b', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(90), read_at: minsAgo(5), payload: { signal_type: 'stuck' } },
       { id: 'c', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(90), payload: { signal_type: 'stuck', routed_to_feedback_id: 'f-1' } },
       { id: 'd', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(10), payload: { signal_type: 'stuck' } },   // too young
       { id: 'e', sender_session: 'adam', sender_type: 'adam', created_at: minsAgo(90), payload: { signal_type: 'stuck' } },  // not a worker
     ]), { now: NOW, log, env: {} });
     expect(r.starved).toBe(0);
+  });
+
+  it('DOES count a read-but-unanswered signal (FR-3 — read_at is delivery, not disposition)', async () => {
+    const { log } = capture();
+    const r = await reportWorkerSignalStarvation(fakeSupabase([
+      { id: 'b', sender_session: 'w', sender_type: 'worker', created_at: minsAgo(90), read_at: minsAgo(5), payload: { signal_type: 'stuck' } },
+    ]), { now: NOW, log, env: {} });
+    expect(r.starved).toBe(1);
   });
 
   // QF-20260727-683: every /checkin emits a fresh payload.kind='roll_call' availability


### PR DESCRIPTION
**PR 2 of 4** for SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001. One line removed from `lib/coordinator/detectors.cjs`: `if (sig.read_at) continue`.

## The defect

`read_at` is set on **1,962 of 1,965** friction signals (99.85%). `detectReplyStarvation` is the *only* wired gauge for unanswered worker signals, and that one line excluded 99.85% of its own population.

That is why 1,963 unanswered signals never raised an alarm. The gauge wasn't missing — it was blind, and blind by a single line.

## This is a regression against an already-shipped contract

SD-LEO-INFRA-COORDINATOR-WAKE-ON-DIRECTIVE-001 and SD-LEO-INFRA-ADAM-INBOX-SURFACE-NOT-STAMP-001 (both 2026-07-10) established that a read-stamp means **SURFACED**, never **RENDERED**. `scripts/fleet-dashboard.cjs` stamps `read_at` on render, so a signal nobody acted on was marked read by the act of drawing it on a screen — and then dropped from the gauge that exists to notice it.

Worth an RCA on why that shipped contract didn't propagate to the dashboard.

## Producers deliberately untouched

The LEAD framing of this FR said to stop the render-stamp. That was **corrected at PLAN** because it contradicts FR-1: `read_at` is the legitimate DELIVERED stamp (it says so in source at `fleet-dashboard.cjs:1478-1480` and `:1827-1830`), and the receipt contract requires DELIVERED to stay independently queryable.

The defect was always the **consumer** reading delivery as disposition. Fixing only the consumer also avoids the untested blast radius in `lib/adam/inbound-backlog.js isBreaching`, which would otherwise have silently migrated rows between breach branches — changing the Adam alarm threshold with nothing going red.

## Two tests locked in the defect

Both asserted "not starved" over a multi-row fixture that *included* a read-but-unanswered row, so the bug was pinned by a negative assertion where it was easy to miss. In each file that row is promoted to its own **positive** test naming the behaviour: a read-but-unanswered signal **is** starved.

Corrected, not deleted.

## Verification

73/73 across `detectors.test.js`, `worker-signal-starvation.test.js`, `session-coordination-consumption-census.test.js` (the silent-half-fix canary that only breaks if both `read_at` stamps are removed), and the FR-6 drain-gate suite.

## Sequencing

Ships **after** FR-6 (#6677, merged) and deliberately **before** the human rung. The PRD mandates a 48h observation window after this PR: un-blinding the gauge moves it from ~0 to ~1,900 items in one step against ~280 signals/day, of which ~85% are informational feedback rather than blockers. Wiring that volume to a live chairman SMS transport without first calibrating it would reproduce the flood class already fixed by CHAIRMAN-DECISION-EMAIL-001 and RESURFACE-DIGEST-BATCHING-001.

🤖 Generated with [Claude Code](https://claude.com/claude-code)