### PR TITLE
fix(SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001): FR-7 — a retention stamp was indistinguishable from a real answer

### DIFF
--- a/lib/coordinator/detectors.cjs
+++ b/lib/coordinator/detectors.cjs
@@ -37,6 +37,7 @@
 
 const { hasCorrelatedReply } = require('./reply-correlation.cjs');
 const { hasSignalType } = require('./signal-router.cjs');
+const { isGenuinelyAcknowledged } = require('../retention/retention-ack-marker.cjs'); // FR-7
 
 /** Default freshness window (ms) for "is this session a live coordinator". */
 const DEFAULT_COORDINATOR_FRESH_MS = 10 * 60 * 1000;
@@ -143,7 +144,15 @@ function detectReplyStarvation(data) {
     if (!hasSignalType(sig)) continue;
     // SD-LEO-INFRA-ACKSTAMP-FALSE-METRICS-C6-001 (closure map class C6): a reply
     // routinely arrives as a fresh correlated row, not an update to acknowledged_at.
-    const answered = !!sig.acknowledged_at || !!(sig.payload && sig.payload.routed_to_feedback_id)
+    //
+    // SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-7): isGenuinelyAcknowledged, NOT a bare
+    // !!acknowledged_at. Retention stamps that acknowledged_at without anyone answering — the
+    // STUCK-drain in stale-session-sweep.cjs and convergeAckTTL — now carry payload.auto_acked, and
+    // counting those as answers would let flood-control silently retire a signal AND make this
+    // gauge report the lane as healthy because the row was deleted-in-waiting. Marking a stamp
+    // without teaching the consumer to skip it would be an inert mechanism; this is the consumer.
+    // Same predicate lib/adam/inbound-backlog.js already applies on its own lane.
+    const answered = isGenuinelyAcknowledged(sig) || !!(sig.payload && sig.payload.routed_to_feedback_id)
       || hasCorrelatedReply(sig, allSignals);
     if (answered) continue;
     // SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-3): `if (sig.read_at) continue` USED TO LIVE

--- a/lib/retention/retention-ack-marker.cjs
+++ b/lib/retention/retention-ack-marker.cjs
@@ -1,0 +1,84 @@
+/**
+ * SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-7) — tell a RETENTION stamp apart from a real answer.
+ *
+ * THE DEFECT. Two paths stamp acknowledged_at with no answer behind them:
+ *   - convergeAckTTL (lib/retention/session-coordination-ack-convergence.js) sets
+ *     payload.auto_acked = true, so its stamps ARE identifiable.
+ *   - the STUCK-signal drain in scripts/stale-session-sweep.cjs mass-stamps in batches of 50 and
+ *     set NO marker at all — making a retention stamp permanently indistinguishable from a genuine
+ *     coordinator ack. Once written, no later reader can undo that ambiguity.
+ *
+ * WHY IT MATTERS BEYOND TIDINESS. acknowledged_at is the substrate of the answered-rate metric this
+ * SD exists to fix. An unmarked retention stamp does not merely lose information — it INFLATES the
+ * very number used to judge whether the escalation lane is healthy, in the direction that makes a
+ * broken lane look answered.
+ *
+ * THE PRIOR ART IS ALREADY IN THE REPO: lib/adam/inbound-backlog.js:225-233 deliberately queries
+ * `.or('acknowledged_at.is.null,payload->>auto_acked.eq.true')` rather than a bare null-filter,
+ * precisely so retention convergence cannot silently retire Adam's backlog. The WORKER lane had no
+ * equivalent protection. This module is that protection, shared so the two lanes cannot drift.
+ *
+ * CommonJS to match lib/coordinator/*.cjs and be require()-able from scripts/stale-session-sweep.cjs.
+ */
+
+'use strict';
+
+/** Marks a stamp as written by retention/flood-control rather than by an answering agent. */
+const RETENTION_ACK_SOURCE = 'stale_session_sweep_stuck_drain';
+
+/**
+ * PURE. Build the payload to write alongside a retention acknowledged_at stamp.
+ *
+ * Preserves every existing key — the payload carries signal_type, severity and sender_callsign that
+ * downstream readers depend on, so this MERGES rather than replaces. Records WHY the row was
+ * drained (dead_sender vs aged_out), which the sweep already reports separately in its log line
+ * (QF-20260727-190) but never persisted.
+ *
+ * @param {object|null} payload existing row payload
+ * @param {'dead_sender'|'aged_out'} reason
+ * @returns {object} merged payload carrying the retention marker
+ */
+function buildRetentionAckPayload(payload, reason) {
+  return {
+    ...(payload && typeof payload === 'object' ? payload : {}),
+    auto_acked: true,
+    auto_ack_source: RETENTION_ACK_SOURCE,
+    auto_ack_reason: reason,
+  };
+}
+
+/**
+ * PURE/TOTAL. Was this row's acknowledged_at written by retention rather than by an answer?
+ *
+ * Keyed on payload.auto_acked, the convention convergeAckTTL already established, so a row retired
+ * by EITHER retention path is recognised by one predicate. Total on junk input: anything that is
+ * not explicitly marked is treated as a genuine ack, which is the conservative direction — a real
+ * answer must never be discarded because its payload was malformed.
+ *
+ * @param {object|null} row a session_coordination row
+ * @returns {boolean}
+ */
+function isRetentionAck(row) {
+  return !!(row && row.payload && row.payload.auto_acked === true);
+}
+
+/**
+ * PURE/TOTAL. Does this row count as ANSWERED for metric purposes?
+ *
+ * An acknowledged_at that carries a retention marker is NOT an answer. This is the load-bearing
+ * half of FR-7: adding a marker that no consumer reads would leave the metric exactly as wrong as
+ * before, and would be an inert mechanism of precisely the kind this SD exists to eliminate.
+ *
+ * @param {object|null} row
+ * @returns {boolean}
+ */
+function isGenuinelyAcknowledged(row) {
+  return !!(row && row.acknowledged_at) && !isRetentionAck(row);
+}
+
+module.exports = {
+  RETENTION_ACK_SOURCE,
+  buildRetentionAckPayload,
+  isRetentionAck,
+  isGenuinelyAcknowledged,
+};

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -30,6 +30,7 @@ const { PLAN_CONTENT_MARKER } = require('../lib/sd-enrichment-markers.cjs');
 // dispatch choke point this file's WORK_ASSIGNMENT insert deliberately bypasses.
 const { describeUnreadableAssignment } = require('../lib/fleet/assignment-target.cjs');
 const { parseSdDependencies } = require('../lib/utils/parse-sd-dependencies.cjs'); // QF-20260525-542
+const { buildRetentionAckPayload } = require('../lib/retention/retention-ack-marker.cjs'); // FR-7
 // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate (same one the
 // worker self_claim path uses) so CLAIM_FIX never re-affirms an orchestrator PARENT / dep-blocked SD.
 const { evaluateDispatchEligibility, classifyDispatchIneligibility, TEST_FIXTURE_KEY_RE } = require('../lib/fleet/claim-eligibility.cjs');
@@ -3373,9 +3374,26 @@ async function main() {
       return s.created_at < stuckAgeCutoff;                   // live + routine — age-drain as before
     });
     const drainStuckIds = drainRows.map(s => s.id);
-    for (let i = 0; i < drainStuckIds.length; i += 50) {
-      const batch = drainStuckIds.slice(i, i + 50);
-      await supabase.from('session_coordination').update({ acknowledged_at: now.toISOString() }).in('id', batch);
+    // SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-7): this drain used to stamp a BARE
+    // acknowledged_at via `.in('id', batch)`, which made a flood-control retirement permanently
+    // indistinguishable from a genuine coordinator answer — and acknowledged_at is the substrate of
+    // the answered-rate metric, so an unmarked stamp INFLATES exactly the number used to judge
+    // whether this lane is healthy. Every stamp now carries payload.auto_acked (the convention
+    // convergeAckTTL already established) plus WHY it drained, which the log line below has always
+    // reported but never persisted.
+    //
+    // Per-row rather than `.in()` because payload is JSONB and must be MERGED — the row's
+    // signal_type / severity / sender_callsign are load-bearing downstream and a blanket write
+    // would erase them. Concurrency stays bounded at the same 50 the batching already used.
+    for (let i = 0; i < drainRows.length; i += 50) {
+      const batch = drainRows.slice(i, i + 50);
+      await Promise.all(batch.map((s) => supabase
+        .from('session_coordination')
+        .update({
+          acknowledged_at: now.toISOString(),
+          payload: buildRetentionAckPayload(s.payload, senderIsDead(s) ? 'dead_sender' : 'aged_out'),
+        })
+        .eq('id', s.id)));
     }
     if (drainStuckIds.length > 0) {
       // QF-20260727-190: the old line read "drained N stale/dead-sender STUCK signal(s)" — ONE
@@ -3388,7 +3406,7 @@ async function main() {
       const parts = [];
       if (deadCount > 0) parts.push(deadCount + ' dead-sender');
       if (ageCount > 0) parts.push(ageCount + ' aged-out (live sender, severity below high)');
-      actions.push('CLEANUP: drained ' + drainStuckIds.length + ' STUCK signal(s) — ' + parts.join(' + ') + ' (acknowledged_at stamped)');
+      actions.push('CLEANUP: drained ' + drainStuckIds.length + ' STUCK signal(s) — ' + parts.join(' + ') + ' (acknowledged_at stamped, payload.auto_acked=true — NOT an answer)');
     }
     // Report what was deliberately NOT drained, so a held signal is visible rather than merely
     // un-retired. Without this the fix would be silent in exactly the way the bug was.

--- a/tests/unit/retention-ack-marker.test.js
+++ b/tests/unit/retention-ack-marker.test.js
@@ -1,0 +1,88 @@
+/**
+ * SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 FR-7 — a retention stamp must never be mistaken for an
+ * answer.
+ *
+ * Two paths stamp acknowledged_at with nobody answering: convergeAckTTL (which already marks
+ * payload.auto_acked) and the STUCK-signal drain in stale-session-sweep.cjs (which marked nothing,
+ * so its stamps were permanently indistinguishable from a genuine coordinator ack). Since
+ * acknowledged_at is the substrate of this SD's answered-rate metric, an unmarked stamp inflates
+ * the exact number used to judge whether the escalation lane is healthy.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const {
+  buildRetentionAckPayload,
+  isRetentionAck,
+  isGenuinelyAcknowledged,
+  RETENTION_ACK_SOURCE,
+} = require('../../lib/retention/retention-ack-marker.cjs');
+const { detectReplyStarvation } = require('../../lib/coordinator/detectors.cjs');
+
+const NOW = 1_750_000_000_000;
+const minsAgo = (m) => new Date(NOW - m * 60_000).toISOString();
+
+describe('buildRetentionAckPayload', () => {
+  it('PRESERVES existing payload keys — they are load-bearing downstream', () => {
+    const p = buildRetentionAckPayload({ signal_type: 'stuck', severity: 'high', sender_callsign: 'Delta' }, 'aged_out');
+    expect(p.signal_type).toBe('stuck');
+    expect(p.severity).toBe('high');
+    expect(p.sender_callsign).toBe('Delta');
+  });
+
+  it('records the marker and WHY the row drained', () => {
+    expect(buildRetentionAckPayload({}, 'dead_sender')).toMatchObject({
+      auto_acked: true, auto_ack_source: RETENTION_ACK_SOURCE, auto_ack_reason: 'dead_sender',
+    });
+    expect(buildRetentionAckPayload({}, 'aged_out').auto_ack_reason).toBe('aged_out');
+  });
+
+  it('is TOTAL on a null/garbage payload', () => {
+    expect(buildRetentionAckPayload(null, 'aged_out').auto_acked).toBe(true);
+    expect(buildRetentionAckPayload('nonsense', 'aged_out').auto_acked).toBe(true);
+  });
+});
+
+describe('isGenuinelyAcknowledged', () => {
+  it('a real coordinator ack counts', () => {
+    expect(isGenuinelyAcknowledged({ acknowledged_at: minsAgo(5), payload: { signal_type: 'stuck' } })).toBe(true);
+  });
+
+  it('a RETENTION stamp does NOT count as an answer', () => {
+    const row = { acknowledged_at: minsAgo(5), payload: buildRetentionAckPayload({ signal_type: 'stuck' }, 'aged_out') };
+    expect(isRetentionAck(row)).toBe(true);
+    expect(isGenuinelyAcknowledged(row)).toBe(false);
+  });
+
+  it('an unacked row is not acknowledged, and junk defaults to genuine (never discard a real answer)', () => {
+    expect(isGenuinelyAcknowledged({ acknowledged_at: null, payload: {} })).toBe(false);
+    expect(isGenuinelyAcknowledged(null)).toBe(false);
+    // auto_acked must be exactly true — a truthy string must not silently retire a real ack
+    expect(isGenuinelyAcknowledged({ acknowledged_at: minsAgo(5), payload: { auto_acked: 'yes' } })).toBe(true);
+  });
+});
+
+describe('FR-7 consumer coupling — the marker is READ, not merely written', () => {
+  // A marker no consumer reads would be an inert mechanism: the metric would stay exactly as wrong
+  // as before. This test fails if detectReplyStarvation ever reverts to a bare !!acknowledged_at.
+  const base = {
+    id: 'sig-1', sender_type: 'worker', sender_session: 'w1',
+    created_at: minsAgo(45), read_at: null, payload: { signal_type: 'stuck' },
+  };
+
+  it('a signal retired by the retention drain is STILL counted as starved', () => {
+    const drained = {
+      ...base,
+      acknowledged_at: minsAgo(5),
+      payload: buildRetentionAckPayload({ signal_type: 'stuck' }, 'aged_out'),
+    };
+    const r = detectReplyStarvation({ signals: [drained], now: NOW, thresholdMs: 30 * 60_000 });
+    expect(r.matched).toBe(true);
+    expect(r.evidence.starved_count).toBe(1);
+  });
+
+  it('a signal answered by a real ack is NOT counted as starved (genuine case preserved)', () => {
+    const answered = { ...base, acknowledged_at: minsAgo(5) };
+    expect(detectReplyStarvation({ signals: [answered], now: NOW, thresholdMs: 30 * 60_000 }).matched).toBe(false);
+  });
+});


### PR DESCRIPTION
**PR 3 of 4** for SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001. Taken on the coordinator's ruling: the sweep SD that shares this file is draft/LEAD, unclaimed and on a `needs_coordinator_review` hold, so the collision costs nothing — only one of the two is in flight.

## The defect

Two paths stamp `acknowledged_at` with nobody answering:

- `convergeAckTTL` sets `payload.auto_acked`, so its stamps **are** identifiable.
- The STUCK-signal drain in `stale-session-sweep.cjs` mass-stamped in batches of 50 and set **no marker at all**.

Once written, no later reader could tell a flood-control retirement from a genuine coordinator ack. The ambiguity is permanent.

## Why this isn't cosmetic

`acknowledged_at` is the substrate of this SD's answered-rate metric. An unmarked retention stamp doesn't merely lose information — it **inflates the exact number used to judge whether the escalation lane is healthy**, in the direction that makes a broken lane look answered.

A signal could be silently retired by flood control *and simultaneously improve the gauge that exists to notice it was never answered.*

## Both halves, because the marker alone would be inert

**Producer** — the drain writes `auto_acked` + `auto_ack_source` + `auto_ack_reason` (`dead_sender` vs `aged_out`, a distinction the log line has always reported per QF-20260727-190 but never persisted). Per-row rather than `.in()` because `payload` is JSONB and must be **merged**: `signal_type`, `severity` and `sender_callsign` are load-bearing downstream and a blanket write would erase them. Concurrency stays bounded at the same 50 the batching already used.

**Consumer** — `detectReplyStarvation` now calls `isGenuinelyAcknowledged` instead of a bare `!!acknowledged_at`. Adding a marker no consumer reads would leave the metric exactly as wrong as before — an inert mechanism of precisely the kind this SD exists to eliminate.

## Shared, not re-derived

`lib/adam/inbound-backlog.js:225-233` **already** applies this protection on Adam's lane, querying `auto_acked` rather than a bare null-filter. The worker lane simply never got it. The predicate now lives in one module so the two cannot drift.

`isGenuinelyAcknowledged` is deliberately conservative on junk: anything not explicitly `auto_acked === true` counts as a real answer, so a malformed payload can never discard a genuine ack.

## Verification

104/104 — the new suite (including a coupling test that **fails if the consumer ever reverts** to a bare `!!acknowledged_at`), `detectors`, `worker-signal-starvation`, the consumption census, and all five `stale-session-sweep` suites.

FR-4 remains held behind the mandated 48h observation window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)