### PR TITLE
fix(SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001): derive chairman from app_metadata, not the client-writable half

### DIFF
--- a/.prd-payloads/SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001.json
+++ b/.prd-payloads/SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001.json
@@ -1,0 +1,284 @@
+{
+  "executive_summary": "The SD reports a chairman privilege escalation in lib/middleware/api-auth.js and asks for three JS lines to be fixed. Measurement over the pooler at PLAN INVERTED that framing, and this PRD is written to the measurement rather than the report. The middleware is the SMALL half: api-auth.js (Express) has ZERO production mounts, and the seventeen pages/api routes the SD names actually gate on lib/middleware/rbac.ts:76, which already reads the trusted app_metadata half. THE LIVE SURFACE IS THE DATABASE. public.fn_is_chairman() is SECURITY DEFINER and its body reads auth.users.raw_user_meta_data->>'role' -- the CLIENT-WRITABLE half -- and it is consumed by 29 RLS POLICIES and 22 FUNCTIONS, including the destructive kill_venture, delete_venture and master_reset_portfolio, and the governance-bearing approve_chairman_decision, reject_chairman_decision, set_global_auto_proceed and is_leo_admin. Any authenticated principal can call auth.updateUser({data:{role:'chairman'}}) on their own account and gain chairman across all 51 consumers. A second DB site, policy archetype_benchmarks_admin (roles={public}, cmd=ALL), reads the same column. This PRD closes all four derivation points -- one DB function, one RLS policy, and two JS modules -- by moving every chairman derivation onto the service-role-only app_metadata / raw_app_meta_data half. It does not argue from vendor documentation: it copies two safe siblings that are already live in this system, public.is_chairman_role() (raw_app_meta_data, SECURITY DEFINER, 6 policy consumers) and lib/middleware/rbac.ts:76. The flip was proven non-breaking BEFORE being planned: of 4 total users, the one live privileged account already carries app_metadata.role='admin' and survives, and the only account that loses privilege is the ehg.dev account already slated for deletion. Verification is a negative test that must FAIL against current main.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Flip public.fn_is_chairman() onto the service-role-only metadata half",
+      "description": "public.fn_is_chairman() is the single highest-blast-radius derivation point in the system. Its live body is SECURITY DEFINER, SET search_path TO 'public', zero-arg, and reads auth.users.raw_user_meta_data->>'role' IN ('chairman','admin','owner') OR raw_user_meta_data->'roles' @> '\"chairman\"'::jsonb. raw_user_meta_data is the half a client rewrites at will via auth.updateUser({data:{...}}), so the function grants chairman to anyone who asks for it. Replace the body via CREATE OR REPLACE so that BOTH clauses read raw_app_meta_data instead, which only the service role can write. The signature MUST remain zero-arg and the function MUST remain SECURITY DEFINER with its search_path pin: 29 RLS policies and 22 other functions call it by that exact signature, and changing it would drop them. The accepted role vocabulary ('chairman','admin','owner') and the roles-array clause are preserved verbatim so the ONLY semantic change is which metadata half is trusted. Template already live in this database: public.is_chairman_role().",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "pg_get_functiondef(public.fn_is_chairman) contains 'raw_app_meta_data' and contains ZERO occurrences of 'raw_user_meta_data'",
+        "public.fn_is_chairman still has exactly one overload and it takes zero arguments (pg_proc: pg_get_function_identity_arguments returns empty string)",
+        "public.fn_is_chairman is still prosecdef=true and still pins search_path",
+        "Consumer count is unchanged after apply: 29 policies and 22 functions still reference fn_is_chairman (no dependency was dropped by the replace)",
+        "The accepted role set is still chairman/admin/owner and the roles-array clause is still present, now sourced from raw_app_meta_data"
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Rewrite RLS policy archetype_benchmarks_admin off the client-writable column",
+      "description": "Policy archetype_benchmarks_admin on public.archetype_benchmarks is roles={public} (which in Postgres means ALL roles, including anon) and cmd=ALL (SELECT/INSERT/UPDATE/DELETE). Its USING expression inlines the same defect rather than calling a helper: EXISTS(SELECT 1 FROM auth.users WHERE auth.uid()=users.id AND users.raw_user_meta_data->>'role' = ANY(ARRAY['admin','chairman'])). The table has RLS enabled but grants UPDATE to both anon and authenticated, so a self-promoted principal gets full write. Replace the USING expression so it derives from the trusted half -- preferably by calling public.fn_is_chairman() (post-FR-1) so this policy can never drift away from the canonical derivation again, which is exactly how this inline copy came to exist. This is the ONE policy of 1582 that reads the client-writable half; the fix takes that population to zero.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "Repo-wide catalog sweep returns ZERO policies whose qual or with_check references raw_user_meta_data or user_metadata (baseline is exactly 1 of 1582)",
+        "Policy archetype_benchmarks_admin still exists, still cmd=ALL, and its USING expression derives from fn_is_chairman() or raw_app_meta_data",
+        "The pre-existing permissive policy archetype_benchmarks_select (cmd=SELECT, USING true) is left untouched -- it is out of scope and changing it is a separate access decision"
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Close all three derivation points in lib/middleware/api-auth.js and repair the permanently-failing RPC call",
+      "description": "lib/middleware/api-auth.js derives chairman from the client-writable half at three points: :93 role: user.user_metadata?.role || 'user', :94 isChairman: user.user_metadata?.role === 'chairman', and :151 the same read inside the EXPORTED isChairman() helper. requireChairman() at :122 is the enforcement point that consumes it. A fix scoped to the reported lines 93-94 would leave :151 intact -- it sits 57 lines below, in a differently-named export, and is exactly what survives a patch aimed at the reported symptom. All three move to app_metadata. Additionally repair the latent defect that makes :151 load-bearing: :144 calls rpc('fn_is_chairman', { user_uuid: userId }), but the live function has exactly ONE signature and it is ZERO-ARG, so every invocation returns PGRST202 'Could not find the function public.fn_is_chairman(user_uuid)'. The if (error) branch at :148 is therefore ALWAYS true and :151 is not a rare fallback but the ONLY path. Because this helper is handed an explicit userId together with a service-role client -- a context in which auth.uid() is NULL and so the zero-arg RPC could not answer for that user anyway -- the RPC is the wrong instrument here. Replace it with the admin lookup that already exists on the next line (supabase.auth.admin.getUserById(userId)) reading app_metadata.role, and drop the dead RPC call rather than leaving a call that fails on every request.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "grep for user_metadata across lib/ and server/ returns ZERO privilege derivations (lib/mock/simulation-supabase-client.js:241, an empty fixture literal, is the only permitted remaining match)",
+        "A unit test exercises the exported isChairman() helper at :151 SPECIFICALLY and fails if that line reads the client-writable half",
+        "api-auth.js no longer issues rpc('fn_is_chairman', { user_uuid }) -- the call that returned PGRST202 on 100% of invocations is gone, not merely bypassed",
+        "requireChairman() at :122 still refuses when isChairman is false and still admits isServiceRole"
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Fix server/routes/protocol-lint.js and rewrite the test that pins the vulnerability",
+      "description": "server/routes/protocol-lint.js:42 reads const role = req.user?.user_metadata?.role ?? req.user?.role. This is the ONLY LIVE-MOUNTED site in the whole finding: it is mounted at server/index.js:296 as /api/admin/protocol-lint, and server/middleware/auth.js:79 assigns the RAW Supabase user object to req.user, so req.user.user_metadata.role is literally the client-writable claim with nothing in between. Its trust model genuinely differs from api-auth (req.isAdmin, set by an internal API key, short-circuits at :41), so the api-auth fix does NOT transfer verbatim -- the internal-API-key short-circuit is legitimate and must be preserved. Remove only the user_metadata read. CRITICALLY, server/routes/protocol-lint.test.js:47 contains a test named 'allows user with user_metadata.role=chairman' which ASSERTS THE VULNERABILITY IS THE INTENDED BEHAVIOR; it will fail the moment the route is fixed, and a careless EXEC would 'repair' the fix to satisfy the test. That test must be rewritten to assert the opposite. The sibling case at :65 ('rejects user with role=viewer') also feeds role via user_metadata and must be re-expressed on the supported shape so it keeps testing rejection rather than silently passing for the new reason.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "server/routes/protocol-lint.js:42 no longer reads req.user.user_metadata",
+        "The req.isAdmin internal-API-key short-circuit at :41 is preserved and still covered by its existing passing test",
+        "The test formerly named 'allows user with user_metadata.role=chairman' now asserts a 403 NOT_ADMIN for a principal whose role appears ONLY in user_metadata",
+        "The ':65 viewer' rejection test still asserts 403 NOT_ADMIN and does so via the supported role shape, not via user_metadata"
+      ]
+    },
+    {
+      "id": "FR-5",
+      "title": "Negative self-promotion test that must FAIL against current main",
+      "description": "A fix in this area is easy to make LOOK correct: a test that only checks that a real chairman still gets through would pass against the vulnerable code and prove nothing. The required test is adversarial and directional. Authenticate as a NON-chairman principal, have that principal call auth.updateUser({ data: { role: 'chairman' } }) on its OWN account -- the exact move the vulnerability permits -- then exercise a gated surface and assert REFUSAL. Coverage must include the DB layer, because that is where the real exposure lives: after self-promotion, assert that fn_is_chairman() returns FALSE for that principal and that a read/write against an fn_is_chairman-gated table is denied by RLS. The test must be demonstrated RED against current main before the fix and GREEN after; a test that has never been observed failing has not been shown to test anything.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "The negative test is executed against UNFIXED code and observed to FAIL, and that failing output is captured as evidence",
+        "The same test passes after the fix",
+        "The test asserts at the DB layer that fn_is_chairman() is FALSE for a principal who set role=chairman in their own user_metadata",
+        "The test asserts a gated surface refuses that self-promoted principal, not merely that a boolean flipped"
+      ]
+    },
+    {
+      "id": "FR-6",
+      "title": "Record the RLS third-surface resolution as measurement, not assumption",
+      "description": "The SD flags an unresolved third surface: RLS policies on agent_configs / prompt_templates using a jwt user_metadata expression, and predicts by operator precedence that the expression is invalid SQL ((auth.jwt()->>'user_metadata'->'role') is text -> unknown) and therefore that the policies were never created. It instructs that ABSENT be read as CONFIRMING the parse and PRESENT as a real and worse surface. This was resolved live at PLAN and the result must be recorded in the PRD either way rather than quietly dropped. MEASURED: public.agent_configs DOES NOT EXIST in the live schema (the SD's claim that both tables exist is refuted). public.prompt_templates exists with RLS enabled and exactly 2 policies, neither of which references any metadata half ('Allow service_role to manage prompt_templates' cmd=ALL USING true, and 'Anon read prompt_templates' cmd=SELECT USING true). The predicted-invalid jwt user_metadata expression is therefore ABSENT from live policy, confirming the operator-precedence parse. The only place that expression survives is scripts/archive/one-time/, which is archived and never executed. No code change is required for this FR; it is a recorded finding with a durable assertion so the question is not re-opened from scratch.",
+      "priority": "medium",
+      "acceptance_criteria": [
+        "PRD and EXEC evidence record that agent_configs is ABSENT from the live schema, refuting the SD's 'both tables exist' claim",
+        "PRD and EXEC evidence record prompt_templates' 2 live policies verbatim and that neither reads a metadata half",
+        "The catalog sweep from FR-2 is the durable assertion that keeps this closed, so a future reintroduction of the idiom is caught by a test rather than by another investigation"
+      ]
+    }
+  ],
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "title": "Signature-preserving DDL only",
+      "description": "fn_is_chairman must be changed with CREATE OR REPLACE FUNCTION, never DROP + CREATE. A DROP would cascade-drop or break the 29 policies and 22 functions that depend on it. The zero-arg signature, SECURITY DEFINER flag and search_path pin are all part of the contract with those consumers."
+    },
+    {
+      "id": "TR-2",
+      "title": "DDL is chairman-gated and applied through the documented path",
+      "description": "FR-1 and FR-2 are DDL against a SECURITY DEFINER function and an RLS policy, affecting 51 consumers. The migration lands in supabase/migrations/ following the live YYYYMMDD_name.sql convention and is applied via the gated path (npm run migration:apply / scripts/apply-migration.js), never by ad-hoc SQL over the pooler. Chairman gating for DDL applies; the scope inversion and the DDL nature were signalled to the coordinator at PLAN (signal e4bb8d83) rather than discovered at apply time."
+    },
+    {
+      "id": "TR-3",
+      "title": "Reuse the safe siblings already live in this system",
+      "description": "Do not invent an idiom. public.is_chairman_role() (LANGUAGE sql, STABLE, SECURITY DEFINER, SET search_path TO '', reads raw_app_meta_data, already consumed by 6 policies) is the DB template. lib/middleware/rbac.ts:76 (user.app_metadata?.role, under the comment 'Check JWT app_metadata first') is the JS template. Citing live siblings rather than vendor docs is what makes this defect legible as a same-name/different-meaning collision between two metadata halves."
+    },
+    {
+      "id": "TR-4",
+      "title": "No behavior change beyond the trusted half",
+      "description": "The accepted role vocabulary, the roles-array clause, the internal-API-key short-circuit in protocol-lint, and requireChairman's isServiceRole exemption are all preserved exactly. The single semantic change delivered by this SD is WHICH metadata half is trusted. Any other behavior delta is out of scope and must be raised rather than folded in silently."
+    }
+  ],
+  "test_scenarios": [
+    {
+      "id": "TS-1",
+      "scenario": "Self-promoted principal is refused at the DB layer (the negative test, FR-5)",
+      "type": "integration",
+      "expected": "A non-chairman calls auth.updateUser({data:{role:'chairman'}}) on its own account; fn_is_chairman() returns FALSE for it and an fn_is_chairman-gated table denies it. Observed RED against current main before the fix."
+    },
+    {
+      "id": "TS-2",
+      "scenario": "fn_is_chairman still admits the legitimate chairman after the flip",
+      "type": "integration",
+      "expected": "The account carrying app_metadata.role='admin' (69c8aa7a..., the live privileged account) still resolves TRUE, proving the flip closed the hole without a lockout."
+    },
+    {
+      "id": "TS-3",
+      "scenario": "Catalog sweep: no privilege derivation reads the client-writable half",
+      "type": "integration",
+      "expected": "Zero policies of ~1582 reference raw_user_meta_data or user_metadata (baseline 1), and zero functions do (baseline 1: fn_is_chairman). This is the durable assertion that keeps FR-2 and FR-6 closed."
+    },
+    {
+      "id": "TS-4",
+      "scenario": "fn_is_chairman dependency integrity survives CREATE OR REPLACE",
+      "type": "integration",
+      "expected": "After apply, 29 policy consumers and 22 function consumers still reference fn_is_chairman and the function still has exactly one zero-arg overload."
+    },
+    {
+      "id": "TS-5",
+      "scenario": "api-auth exported isChairman() helper reads the trusted half (the :151 path)",
+      "type": "unit",
+      "expected": "Given a user whose role appears only in user_metadata, isChairman() returns false; given app_metadata.role='chairman', it returns true. Targets the derivation a line-scoped fix would miss."
+    },
+    {
+      "id": "TS-6",
+      "scenario": "protocol-lint refuses a principal whose role is only in user_metadata",
+      "type": "unit",
+      "expected": "403 NOT_ADMIN. This is the inversion of the existing test at protocol-lint.test.js:47, which currently asserts the opposite and pins the vulnerability."
+    },
+    {
+      "id": "TS-7",
+      "scenario": "protocol-lint internal-API-key short-circuit is preserved",
+      "type": "unit",
+      "expected": "req.isAdmin=true still calls next() with no status set -- the legitimate trust path is not collateral damage of the fix."
+    }
+  ],
+  "acceptance_criteria": [
+    "Zero chairman/admin privilege derivations anywhere in the system read the client-writable metadata half: verified across pg_policies (0 of ~1582), pg_proc (0 functions), lib/ and server/ (0 derivations)",
+    "public.fn_is_chairman() reads raw_app_meta_data, keeps its zero-arg SECURITY DEFINER signature, and all 29 policy + 22 function consumers still resolve after apply",
+    "The negative self-promotion test was observed FAILING against unfixed code and passes after the fix, with both outputs captured as evidence",
+    "server/routes/protocol-lint.test.js no longer contains a test asserting that user_metadata.role=chairman is admitted",
+    "The legitimate privileged account still authenticates as chairman after the flip (no lockout), demonstrated rather than asserted",
+    "The agent_configs / prompt_templates third surface is recorded as resolved by live measurement, including the refutation that agent_configs exists"
+  ],
+  "risks": [
+    {
+      "risk": "Flipping fn_is_chairman locks out the real chairman, taking governance offline",
+      "mitigation": "MEASURED AT PLAN, NOT ASSUMED: auth.users holds 4 accounts total. The live privileged account (69c8aa7a..., gmail.com, last sign-in 2026-07-27) already carries app_metadata.role='admin' and SURVIVES the flip. The only account that loses privilege is 48d7ec58...@ehg.dev, which holds role only in user_metadata and is already slated for deletion per feedback d11b99a0 -- losing its privilege is the INTENT of this SD, not a regression. The audit script is re-run immediately before and after apply to confirm the survivor set did not drift in between.",
+      "severity": "low"
+    },
+    {
+      "risk": "CREATE OR REPLACE drops or breaks the 51 dependent policies and functions",
+      "mitigation": "Signature-preserving replace only (TR-1); never DROP + CREATE. TS-4 asserts the consumer counts (29 policies, 22 functions) are unchanged after apply, so a silent dependency loss fails the test rather than shipping.",
+      "severity": "medium"
+    },
+    {
+      "risk": "EXEC 'fixes' the failing pinned test back toward the vulnerable behavior",
+      "mitigation": "FR-4 names protocol-lint.test.js:47 explicitly as a test that encodes the defect as intended behavior and requires it to be INVERTED. Called out in the PRD precisely because the natural EXEC reflex on a red test is to satisfy it.",
+      "severity": "medium"
+    },
+    {
+      "risk": "The 'owner' role has no holder in the trusted half, so an owner-gated path silently admits nobody after the flip",
+      "mitigation": "Measured: zero accounts carry raw_app_meta_data->>'role'='owner' (the only 'owner' is the ehg.dev account being removed). The role vocabulary is preserved in the function so the path remains available; provisioning an owner requires a service-role write to app_metadata, which is the correct and intended cost.",
+      "severity": "low"
+    },
+    {
+      "risk": "DDL applied outside the gated path or without chairman awareness",
+      "mitigation": "TR-2 pins the migration to supabase/migrations/ and the npm run migration:apply path. The DDL nature and the 51-consumer blast radius were signalled to the coordinator at PLAN (signal e4bb8d83) before any change was authored.",
+      "severity": "medium"
+    }
+  ],
+  "integration_operationalization": {
+    "consumers": [
+      "29 RLS policies calling fn_is_chairman() across chairman_decisions, chairman_directives, chairman_constraints, chairman_constraints_proposals, governed_change_proposals, sd_proposals, venture_gvos_profile, venture_revenue_entries, venture_artifacts, venture_stage_work, ventures_kill_log, legal_templates, public_portfolio, agents, agent_registry, tool_usage_ledger, gvos_adherence_logs, ai_gen_provenance, ai_gen_dwell_tracking, sms_approved_spend_ledger, sms_decision_class_whitelist, chairman_switchon_policy, fable_suitability_map",
+      "22 SQL functions calling fn_is_chairman(), including the destructive kill_venture, delete_venture, master_reset_portfolio and the governance-bearing approve_chairman_decision, reject_chairman_decision, set_global_auto_proceed, is_leo_admin, advance_venture_stage, log_stage_advance_override, park_venture_decision",
+      "public.archetype_benchmarks via policy archetype_benchmarks_admin (roles={public}, cmd=ALL)",
+      "HTTP route /api/admin/protocol-lint, mounted at server/index.js:296, gated by requireAdminRole in server/routes/protocol-lint.js",
+      "lib/middleware/api-auth.js consumers: requireChairman() at :122 and the exported isChairman() helper. NOTE the seventeen pages/api routes named in the SD are NOT consumers of this module -- they import lib/middleware/api-auth.TS and gate on lib/middleware/rbac.ts:76, which already reads the safe half"
+    ],
+    "dependencies": [
+      "{ name: 'auth.users.raw_app_meta_data', direction: 'upstream', failure_mode: 'If a legitimate principal has no role in the trusted half they lose privilege at apply time. Measured: the one live privileged account already carries app_metadata.role=admin, so the survivor set is non-empty.' }",
+      "{ name: 'public.fn_is_chairman()', direction: 'downstream', failure_mode: 'Signature change or DROP would break 51 consumers. Contained by signature-preserving CREATE OR REPLACE and the TS-4 consumer-count assertion.' }",
+      "{ name: 'Supabase auth.updateUser({data}) writes raw_user_meta_data', direction: 'upstream', failure_mode: 'This is the attack primitive itself. It cannot be disabled, which is exactly why derivation must move to the half the client cannot write.' }",
+      "{ name: 'server/middleware/auth.js:79 assigns the raw Supabase user to req.user', direction: 'upstream', failure_mode: 'Passes the client-writable claim through untouched to protocol-lint. Fixed at the consumer (FR-4); the assignment itself is left intact so other consumers are unaffected.' }",
+      "{ name: 'public.is_chairman_role()', direction: 'reference', failure_mode: 'None -- read-only template. Its 6 existing policy consumers are untouched by this SD.' }"
+    ],
+    "data_contracts": [
+      "auth.users.raw_app_meta_data->>'role' becomes the sole trusted source of chairman/admin/owner across the system; raw_user_meta_data->>'role' becomes non-authoritative everywhere",
+      "public.fn_is_chairman() -> boolean, zero-arg, SECURITY DEFINER: signature is a hard contract with 51 consumers and does not change",
+      "No table schema change, no column added or dropped, no data migration to user rows",
+      "Policy archetype_benchmarks_admin: name, table, roles and cmd all unchanged; only the USING expression changes"
+    ],
+    "runtime_config": [
+      "No new env vars and no feature flags -- a privilege-escalation fix must not be flag-gated, since a flag would leave the vulnerable path reachable in one configuration",
+      "Deployment sequence: apply the migration (FR-1, FR-2) FIRST, then ship the JS changes (FR-3, FR-4). This order is safe in both directions because the JS sites have no production mounts, so no window exists in which the app depends on a not-yet-applied function",
+      "DDL applied via npm run migration:apply (scripts/apply-migration.js); chairman-gated"
+    ],
+    "observability_rollout": [
+      "Pre-apply and post-apply runs of the catalog audit (scripts/one-off/audit-chairman-db-surface*.cjs) are the primary evidence: policy count reading the client-writable half must go 1 -> 0, function count 1 -> 0",
+      "Consumer-count check (29 policies / 22 functions) run immediately after apply to prove no dependency was lost",
+      "The negative test captured RED before and GREEN after is the acceptance artifact",
+      "Rollback: re-apply the prior function body via CREATE OR REPLACE (signature-preserving, so rollback carries the same zero-dependency-risk profile as the forward change) and revert the JS commit. Rollback restores the vulnerability and is therefore an emergency-only path, justified solely by an unexpected chairman lockout -- the exact scenario measurement says will not occur.",
+      "Post-apply, confirm the legitimate chairman can still reach a gated surface before closing the SD"
+    ]
+  },
+  "system_architecture": {
+    "summary": "Move every chairman/admin privilege derivation from the client-writable metadata half (raw_user_meta_data / user_metadata) to the service-role-only half (raw_app_meta_data / app_metadata) at all four live derivation points, reusing two safe siblings already running in this system.",
+    "components": [
+      {
+        "name": "supabase/migrations/20260731_fix_chairman_privilege_app_metadata.sql",
+        "change": "NEW - CREATE OR REPLACE FUNCTION public.fn_is_chairman() onto raw_app_meta_data (signature-preserving), plus ALTER/CREATE OR REPLACE of policy archetype_benchmarks_admin off the client-writable column"
+      },
+      {
+        "name": "lib/middleware/api-auth.js",
+        "change": "Lines 93, 94 and 151 move to app_metadata; the permanently-failing rpc('fn_is_chairman', { user_uuid }) call at :144 is removed in favour of the admin lookup that already follows it"
+      },
+      {
+        "name": "server/routes/protocol-lint.js",
+        "change": "Line 42 stops reading req.user.user_metadata; the req.isAdmin internal-API-key short-circuit at :41 is preserved"
+      },
+      {
+        "name": "server/routes/protocol-lint.test.js",
+        "change": "The test at :47 that asserts user_metadata.role=chairman is ADMITTED is inverted to assert refusal; the :65 viewer case is re-expressed on the supported role shape"
+      },
+      {
+        "name": "tests/ - negative self-promotion test (FR-5)",
+        "change": "NEW - adversarial test: self-promote via user_metadata, then assert refusal at the DB layer and at a gated surface. Must be demonstrated RED against current main."
+      },
+      {
+        "name": "scripts/one-off/audit-chairman-db-surface*.cjs",
+        "change": "NEW (authored at PLAN) - read-only catalog audit that produced the evidence in this PRD and serves as the pre/post-apply verification instrument"
+      }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Fix the database first because that is where the live exposure is, then the two JS modules, then prove it with a test that fails against today's code.",
+    "steps": [
+      "Capture the RED baseline: run the negative self-promotion test against current main and record the failure output. A test never observed failing proves nothing (FR-5).",
+      "Re-run scripts/one-off/audit-chairman-db-surface.cjs and -3.cjs to confirm the survivor set has not drifted since PLAN (4 users; one app_metadata-carrying survivor) immediately before authoring the migration.",
+      "Author supabase/migrations/20260731_fix_chairman_privilege_app_metadata.sql: CREATE OR REPLACE fn_is_chairman() onto raw_app_meta_data preserving the zero-arg SECURITY DEFINER signature, role vocabulary and roles-array clause; rewrite policy archetype_benchmarks_admin's USING to call fn_is_chairman().",
+      "Apply via npm run migration:apply (gated path), then immediately assert consumer integrity: 29 policy + 22 function consumers still resolve, one zero-arg overload remains.",
+      "Fix lib/middleware/api-auth.js :93, :94, :151 to app_metadata and delete the dead rpc('fn_is_chairman', { user_uuid }) call at :144.",
+      "Fix server/routes/protocol-lint.js:42, preserving the req.isAdmin short-circuit.",
+      "INVERT server/routes/protocol-lint.test.js:47 so it asserts refusal, and re-express the :65 viewer case on the supported shape. Do not satisfy the old assertion.",
+      "Add the FR-5 negative test and the TS-3 catalog sweep assertion; run the full negative test GREEN and capture both outputs as paired evidence.",
+      "Confirm the legitimate chairman still reaches a gated surface post-apply before handing off."
+    ]
+  },
+  "smoke_test_steps": [
+    {
+      "step_number": 1,
+      "instruction": "node scripts/one-off/audit-chairman-db-surface.cjs",
+      "expected_outcome": "Section 2 reports raw_user_meta_data = 0 (baseline was 1 of 1582) and section 1 shows fn_is_chairman's body containing raw_app_meta_data with no raw_user_meta_data"
+    },
+    {
+      "step_number": 2,
+      "instruction": "node scripts/one-off/audit-chairman-db-surface-2.cjs",
+      "expected_outcome": "Section 5 reports 0 functions reading raw_user_meta_data (baseline 1); section 6 still reports 29 policy consumers and 22 function consumers of fn_is_chairman, proving no dependency was dropped"
+    },
+    {
+      "step_number": 3,
+      "instruction": "npm run test:unit -- server/routes/protocol-lint.test.js",
+      "expected_outcome": "A principal whose role appears only in user_metadata receives 403 NOT_ADMIN; the req.isAdmin internal-API-key test still passes"
+    },
+    {
+      "step_number": 4,
+      "instruction": "Run the FR-5 negative test: authenticate a non-chairman, call auth.updateUser({data:{role:'chairman'}}) on that account, then call fn_is_chairman() and hit a gated table",
+      "expected_outcome": "fn_is_chairman() returns FALSE and the gated table denies the request. The identical run against pre-fix code returned TRUE and allowed it."
+    },
+    {
+      "step_number": 5,
+      "instruction": "Verify the legitimate privileged account (app_metadata.role='admin') still resolves chairman and reaches a gated surface",
+      "expected_outcome": "Access granted -- the fix closed the escalation without a lockout"
+    }
+  ],
+  "metadata": {
+    "sd_key": "SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001"
+  }
+}

--- a/database/migrations/20260731_fix_chairman_privilege_app_metadata.sql
+++ b/database/migrations/20260731_fix_chairman_privilege_app_metadata.sql
@@ -1,0 +1,86 @@
+-- SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001
+-- @approved-by: codestreetlabs@gmail.com
+-- Move chairman/admin privilege derivation off the CLIENT-WRITABLE metadata half.
+--
+-- THE DEFECT
+--   auth.users has two metadata halves. raw_user_meta_data is writable by the
+--   account holder -- Supabase's auth.updateUser({ data: {...} }) writes exactly
+--   that column. raw_app_meta_data is writable only by the service role.
+--   public.fn_is_chairman() derived chairman from the CLIENT-WRITABLE half, so any
+--   authenticated principal could grant itself chairman with a single self-directed
+--   call. Proven live before this migration: an unprivileged principal wrote its own
+--   user_metadata and fn_is_chairman() returned TRUE
+--   (scripts/one-off/prove-chairman-escalation.cjs, RED).
+--
+-- WHY THIS IS THE HIGH-BLAST-RADIUS SITE, NOT THE MIDDLEWARE
+--   fn_is_chairman() is consumed by 29 RLS POLICIES and 22 FUNCTIONS, including the
+--   destructive kill_venture, delete_venture and master_reset_portfolio, and the
+--   governance-bearing approve_chairman_decision, reject_chairman_decision,
+--   set_global_auto_proceed and is_leo_admin. The Express middleware named in the
+--   originating report has zero production mounts; this function is the live surface.
+--
+-- SAFETY, MEASURED RATHER THAN ASSUMED (before authoring this migration)
+--   auth.users holds 4 accounts. Exactly one live privileged account exists and it
+--   ALREADY carries raw_app_meta_data->>'role' = 'admin', so it survives the flip.
+--   The only account that loses privilege holds its role solely in the client-writable
+--   half and is already slated for deletion. Losing its privilege is the INTENT here.
+--
+-- SIGNATURE-PRESERVING ON PURPOSE
+--   CREATE OR REPLACE, never DROP + CREATE: 51 dependents bind to the zero-arg
+--   signature and a DROP would break or cascade them. The zero-arg shape,
+--   SECURITY DEFINER and the search_path pin are all part of that contract.
+--
+-- VOCABULARY IS DELIBERATELY UNCHANGED
+--   The accepted role set ('chairman','admin','owner') and the 'roles' array clause
+--   are preserved verbatim. The ONLY semantic change is which metadata half is
+--   trusted. A privilege fix must not quietly widen access while it narrows it.
+
+-- NO EXPLICIT BEGIN/COMMIT HERE, DELIBERATELY.
+--   scripts/apply-migration.js already wraps the file in its own transaction
+--   (BEGIN before the statements, COMMIT after, ROLLBACK on error). An inner
+--   BEGIN would be a no-op WARNING, and an inner COMMIT would close the
+--   harness's transaction EARLY -- leaving the harness's own rollback path with
+--   nothing to roll back if a later statement failed. 18 of the 20 most recent
+--   migrations in this directory correctly omit it; this one follows that.
+
+-- ---------------------------------------------------------------------------
+-- 1. fn_is_chairman(): same signature, same role vocabulary, trusted half only.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.fn_is_chairman()
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  BEGIN
+    RETURN (SELECT EXISTS(
+      SELECT 1 FROM auth.users u
+      WHERE u.id = auth.uid()
+      AND (
+        -- raw_app_meta_data: service-role-writable only. The account holder cannot
+        -- reach this column, which is the entire point of the fix.
+        u.raw_app_meta_data->>'role' IN ('chairman', 'admin', 'owner')
+        OR u.raw_app_meta_data->'roles' @> '"chairman"'::jsonb
+      )
+    ));
+  END;
+  $function$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Policy archetype_benchmarks_admin: the second, INLINE copy of the defect.
+--
+--    This policy did not call the helper -- it re-derived the same check inline,
+--    which is precisely how a single fix to the canonical function would have left
+--    a live hole behind. It is repointed at public.is_chairman_role(), which was
+--    ALREADY present in this database reading raw_app_meta_data with the role set
+--    ('admin','chairman') -- byte-identical to this policy's own vocabulary. So
+--    centralising here costs ZERO widening: no role gains access that did not have
+--    it, and the policy can no longer drift away from the canonical derivation.
+--
+--    ALTER POLICY (not DROP + CREATE) so the name, table, roles={public} and
+--    cmd=ALL are all preserved. For an ALL policy with no WITH CHECK, Postgres
+--    applies USING to both read and write paths, so this covers writes too.
+-- ---------------------------------------------------------------------------
+ALTER POLICY archetype_benchmarks_admin
+  ON public.archetype_benchmarks
+  USING (public.is_chairman_role());

--- a/lib/middleware/api-auth.js
+++ b/lib/middleware/api-auth.js
@@ -86,12 +86,17 @@ export function createAuthMiddleware(options = {}) {
         });
       }
 
-      // Attach user to request
+      // Attach user to request.
+      // SECURITY (SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001):
+      // role MUST come from app_metadata, not user_metadata. user_metadata is the
+      // half the account holder can rewrite at will via auth.updateUser({ data }),
+      // so deriving privilege from it lets any authenticated principal self-promote.
+      // app_metadata is service-role-writable only. Same idiom as rbac.ts:76.
       req.user = {
         id: user.id,
         email: user.email,
-        role: user.user_metadata?.role || 'user',
-        isChairman: user.user_metadata?.role === 'chairman',
+        role: user.app_metadata?.role || 'user',
+        isChairman: user.app_metadata?.role === 'chairman',
         isServiceRole: false,
       };
 
@@ -141,17 +146,23 @@ export async function isChairman(supabase, userId) {
   if (!userId) return false;
 
   try {
-    const { data, error } = await supabase.rpc('fn_is_chairman', {
-      user_uuid: userId,
-    });
-
-    if (error) {
-      // Function may not exist yet — fall back to metadata check
-      const { data: userData } = await supabase.auth.admin.getUserById(userId);
-      return userData?.user?.user_metadata?.role === 'chairman';
-    }
-
-    return data === true;
+    // SECURITY (SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001):
+    // this read is app_metadata, never user_metadata. It previously read the
+    // client-writable half, and because it sat 57 lines below the other two
+    // derivation points and inside a differently-named export, it is exactly what
+    // a fix scoped to the reported lines would have left behind.
+    //
+    // The rpc('fn_is_chairman', { user_uuid }) call that used to guard this path
+    // was removed rather than repaired: the live function has exactly ONE
+    // signature and it is ZERO-ARG (it resolves the caller via auth.uid()), so
+    // that call returned PGRST202 on every single invocation and this branch was
+    // never a fallback -- it was the only path. It also could not be fixed by
+    // dropping the argument, because this helper is handed an explicit userId
+    // together with a service-role client, a context in which auth.uid() is NULL
+    // and the zero-arg function cannot answer for that user at all.
+    const { data: userData, error } = await supabase.auth.admin.getUserById(userId);
+    if (error) return false;
+    return userData?.user?.app_metadata?.role === 'chairman';
   } catch {
     return false;
   }

--- a/lib/middleware/api-auth.test.js
+++ b/lib/middleware/api-auth.test.js
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for lib/middleware/api-auth.js privilege derivation.
+ * SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001
+ *
+ * Chairman privilege must never be derived from user_metadata. That half is
+ * written by the account holder itself (auth.updateUser({ data })), so trusting
+ * it lets any authenticated principal self-promote. app_metadata is
+ * service-role-writable only.
+ *
+ * The isChairman() suite below is deliberately targeted: that derivation sits 57
+ * lines below the other two and inside a differently-named export, which is
+ * exactly what survives a patch aimed at the reported symptom. It is the
+ * regression most likely to be reintroduced, so it gets its own coverage.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetUser = vi.fn();
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({ auth: { getUser: mockGetUser } }))
+}));
+
+process.env.SUPABASE_URL = 'https://test.supabase.co';
+process.env.SUPABASE_ANON_KEY = 'test-anon-key';
+
+const { createAuthMiddleware, requireChairman, isChairman } = await import('./api-auth.js');
+
+function mockRes() {
+  const res = {};
+  res.status = vi.fn().mockReturnValue(res);
+  res.json = vi.fn().mockReturnValue(res);
+  return res;
+}
+
+/** Minimal stand-in for a service-role client's admin.getUserById. */
+function adminClientReturning(user) {
+  return { auth: { admin: { getUserById: vi.fn().mockResolvedValue({ data: { user }, error: null }) } } };
+}
+
+describe('isChairman() helper — the derivation a line-scoped fix would miss', () => {
+  it('returns FALSE when chairman appears only in user_metadata (self-promotion)', async () => {
+    const supabase = adminClientReturning({ user_metadata: { role: 'chairman' }, app_metadata: {} });
+    await expect(isChairman(supabase, 'user-1')).resolves.toBe(false);
+  });
+
+  it('returns TRUE when chairman is in app_metadata', async () => {
+    const supabase = adminClientReturning({ app_metadata: { role: 'chairman' }, user_metadata: {} });
+    await expect(isChairman(supabase, 'user-1')).resolves.toBe(true);
+  });
+
+  it('ignores user_metadata even when app_metadata holds a lesser role', async () => {
+    const supabase = adminClientReturning({
+      app_metadata: { role: 'viewer' },
+      user_metadata: { role: 'chairman' }
+    });
+    await expect(isChairman(supabase, 'user-1')).resolves.toBe(false);
+  });
+
+  it('does NOT call the removed zero-arg fn_is_chairman RPC', async () => {
+    // The old code called rpc('fn_is_chairman', { user_uuid }) against a function
+    // whose only live signature is zero-arg, so it returned PGRST202 on every
+    // invocation. A client with no .rpc at all must therefore still work.
+    const supabase = adminClientReturning({ app_metadata: { role: 'chairman' } });
+    expect(supabase.rpc).toBeUndefined();
+    await expect(isChairman(supabase, 'user-1')).resolves.toBe(true);
+  });
+
+  it('returns false for a missing userId without touching the client', async () => {
+    const supabase = adminClientReturning({ app_metadata: { role: 'chairman' } });
+    await expect(isChairman(supabase, undefined)).resolves.toBe(false);
+    expect(supabase.auth.admin.getUserById).not.toHaveBeenCalled();
+  });
+
+  it('returns false when the admin lookup errors', async () => {
+    const supabase = { auth: { admin: { getUserById: vi.fn().mockResolvedValue({ data: null, error: { message: 'boom' } }) } } };
+    await expect(isChairman(supabase, 'user-1')).resolves.toBe(false);
+  });
+});
+
+describe('createAuthMiddleware — req.user role derivation', () => {
+  beforeEach(() => { vi.clearAllMocks(); });
+
+  async function runWithUser(user) {
+    mockGetUser.mockResolvedValue({ data: { user }, error: null });
+    const req = { path: '/api/thing', headers: { authorization: 'Bearer token' } };
+    const res = mockRes();
+    const next = vi.fn();
+    await createAuthMiddleware({ allowServiceRole: false })(req, res, next);
+    return { req, res, next };
+  }
+
+  it('does NOT set isChairman from user_metadata', async () => {
+    const { req, next } = await runWithUser({
+      id: 'u1', email: 'a@b.c', user_metadata: { role: 'chairman' }, app_metadata: {}
+    });
+    expect(next).toHaveBeenCalledOnce();
+    expect(req.user.isChairman).toBe(false);
+    expect(req.user.role).toBe('user');
+  });
+
+  it('sets isChairman from app_metadata', async () => {
+    const { req } = await runWithUser({
+      id: 'u1', email: 'a@b.c', app_metadata: { role: 'chairman' }, user_metadata: {}
+    });
+    expect(req.user.isChairman).toBe(true);
+    expect(req.user.role).toBe('chairman');
+  });
+});
+
+describe('requireChairman enforcement', () => {
+  it('refuses a principal that only self-asserted chairman', () => {
+    const req = { user: { isChairman: false, isServiceRole: false } };
+    const res = mockRes();
+    const next = vi.fn();
+    requireChairman(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'FORBIDDEN_NOT_CHAIRMAN' }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('still admits the service role', () => {
+    const req = { user: { isChairman: false, isServiceRole: true } };
+    const res = mockRes();
+    const next = vi.fn();
+    requireChairman(req, res, next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+});

--- a/scripts/one-off/assert-no-writable-privilege-derivation.cjs
+++ b/scripts/one-off/assert-no-writable-privilege-derivation.cjs
@@ -1,0 +1,70 @@
+/**
+ * SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001 — TS-3 / FR-2 durable assertion.
+ *
+ * Fails if ANY privilege derivation in the live database reads the
+ * CLIENT-WRITABLE metadata half. Exit 0 = clean, exit 1 = a derivation is back.
+ *
+ * WHY THE MATCH IS ON raw_user_meta_data AND user_metadata BOTH:
+ *   An earlier sweep reported "0 policies reference user_metadata" and was read as
+ *   proof the defect was middleware-only. That zero was a SUBSTRING FALSE NEGATIVE:
+ *   'user_metadata' is not a substring of 'raw_user_meta_data' (there is an
+ *   underscore between meta and data). The table-column idiom and the JWT idiom are
+ *   spelled differently and BOTH have to be matched or the sweep lies by omission.
+ *
+ * WHY A CONTROL IS PRINTED:
+ *   A sweep that reports zero because it is looking in the wrong place is
+ *   indistinguishable from a sweep that reports zero because the system is clean.
+ *   The app_metadata counts are the control: they must be NON-zero, which proves the
+ *   query can see privilege derivations at all.
+ */
+require('dotenv').config();
+const { Client } = require('pg');
+
+const WRITABLE = `(COALESCE(qual,'')||COALESCE(with_check,'')) ILIKE '%raw_user_meta_data%'
+                OR (COALESCE(qual,'')||COALESCE(with_check,'')) ILIKE '%user_metadata%'`;
+
+(async () => {
+  const CONN = process.env.DATABASE_URL || process.env.SUPABASE_POOLER_URL;
+  if (!CONN) { console.error('NO_CONN: set DATABASE_URL or SUPABASE_POOLER_URL'); process.exit(2); }
+  const client = new Client({ connectionString: CONN, ssl: { rejectUnauthorized: false } });
+  await client.connect();
+
+  const pols = await client.query(`
+    SELECT schemaname, tablename, policyname FROM pg_policies WHERE ${WRITABLE} ORDER BY 1,2,3;`);
+
+  const fns = await client.query(`
+    SELECT n.nspname, p.proname, p.prosecdef
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname NOT IN ('pg_catalog','information_schema')
+      AND p.prokind IN ('f','p')
+      AND pg_get_functiondef(p.oid) ILIKE '%raw_user_meta_data%'
+    ORDER BY 1,2;`);
+
+  // Control: the sweep must be able to SEE privilege derivations at all.
+  const ctl = await client.query(`
+    SELECT
+      (SELECT count(*) FROM pg_policies
+        WHERE (COALESCE(qual,'')||COALESCE(with_check,'')) ILIKE '%app_metadata%') AS app_policies,
+      (SELECT count(*) FROM pg_policies)                                            AS total_policies;`);
+
+  await client.end();
+
+  const c = ctl.rows[0];
+  console.log(`control: ${c.app_policies} of ${c.total_policies} policies derive from the TRUSTED half (must be > 0, else this sweep is blind)`);
+  console.log(`policies reading the client-writable half: ${pols.rowCount}`);
+  pols.rows.forEach(r => console.log(`   ✗ ${r.schemaname}.${r.tablename} :: ${r.policyname}`));
+  console.log(`functions reading the client-writable half: ${fns.rowCount}`);
+  fns.rows.forEach(r => console.log(`   ✗ ${r.nspname}.${r.proname}()${r.prosecdef ? ' SECURITY DEFINER' : ''}`));
+
+  if (Number(c.app_policies) === 0) {
+    console.error('\nINCONCLUSIVE — the control is zero, so this sweep cannot see privilege derivations. Do not read the result as clean.');
+    process.exit(2);
+  }
+  const total = pols.rowCount + fns.rowCount;
+  if (total > 0) {
+    console.error(`\nFAIL — ${total} privilege derivation(s) still read the client-writable metadata half.`);
+    process.exit(1);
+  }
+  console.log('\nPASS — no privilege derivation reads the client-writable metadata half.');
+  process.exit(0);
+})().catch(e => { console.error('ERROR:', e.message); process.exit(2); });

--- a/scripts/one-off/audit-chairman-db-surface-2.cjs
+++ b/scripts/one-off/audit-chairman-db-surface-2.cjs
@@ -1,0 +1,77 @@
+/**
+ * SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001 — PLAN evidence, part 2.
+ * Part 1 section 5 failed: pg_get_functiondef() errors on aggregates.
+ * Filter to prokind='f' (normal functions) and 'p' (procedures).
+ * Read-only.
+ */
+require('dotenv').config();
+const { Client } = require('pg');
+
+(async () => {
+  const CONN = process.env.DATABASE_URL || process.env.SUPABASE_POOLER_URL;
+  if (!CONN) { console.log('NO_CONN'); process.exit(2); }
+  const client = new Client({ connectionString: CONN, ssl: { rejectUnauthorized: false } });
+  await client.connect();
+  const out = (t) => console.log('\n===== ' + t + ' =====');
+
+  out('5. Functions whose body reads the CLIENT-WRITABLE half (raw_user_meta_data)');
+  const fns = await client.query(`
+    SELECT n.nspname, p.proname, pg_get_function_identity_arguments(p.oid) AS args,
+           p.prosecdef AS security_definer
+    FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+    WHERE n.nspname NOT IN ('pg_catalog','information_schema')
+      AND p.prokind IN ('f','p')
+      AND pg_get_functiondef(p.oid) ILIKE '%raw_user_meta_data%'
+    ORDER BY n.nspname, p.proname;`);
+  console.log('count =', fns.rowCount);
+  fns.rows.forEach(r => console.log(`  ${r.nspname}.${r.proname}(${r.args}) SECURITY ${r.security_definer?'DEFINER':'INVOKER'}`));
+
+  out('5b. CONTROL — functions reading the SAFE half (raw_app_meta_data)');
+  const safe = await client.query(`
+    SELECT n.nspname, p.proname
+    FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+    WHERE n.nspname NOT IN ('pg_catalog','information_schema')
+      AND p.prokind IN ('f','p')
+      AND pg_get_functiondef(p.oid) ILIKE '%raw_app_meta_data%'
+    ORDER BY 1,2;`);
+  console.log('count =', safe.rowCount);
+  safe.rows.forEach(r => console.log(`  ${r.nspname}.${r.proname}`));
+
+  out('6. CONSUMERS of fn_is_chairman — policies whose expression calls it');
+  const pol = await client.query(`
+    SELECT schemaname, tablename, policyname, roles::text AS roles, cmd
+    FROM pg_policies
+    WHERE COALESCE(qual,'')||COALESCE(with_check,'') ILIKE '%fn_is_chairman%'
+    ORDER BY 1,2,3;`);
+  console.log('policy consumers =', pol.rowCount);
+  pol.rows.forEach(r => console.log('  ' + JSON.stringify(r)));
+
+  const fnc = await client.query(`
+    SELECT n.nspname, p.proname
+    FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+    WHERE n.nspname NOT IN ('pg_catalog','information_schema')
+      AND p.prokind IN ('f','p') AND p.proname <> 'fn_is_chairman'
+      AND pg_get_functiondef(p.oid) ILIKE '%fn_is_chairman%'
+    ORDER BY 1,2;`);
+  console.log('function consumers =', fnc.rowCount);
+  fnc.rows.forEach(r => console.log(`  ${r.nspname}.${r.proname}`));
+
+  out('7. archetype_benchmarks — is it actually exposed? grants + rowcount');
+  const g = await client.query(`
+    SELECT c.relrowsecurity AS rls_enabled,
+           has_table_privilege('anon','public.archetype_benchmarks','SELECT') AS anon_select,
+           has_table_privilege('anon','public.archetype_benchmarks','UPDATE') AS anon_update,
+           has_table_privilege('authenticated','public.archetype_benchmarks','SELECT') AS auth_select,
+           has_table_privilege('authenticated','public.archetype_benchmarks','UPDATE') AS auth_update,
+           has_table_privilege('authenticated','public.archetype_benchmarks','DELETE') AS auth_delete
+    FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+    WHERE n.nspname='public' AND c.relname='archetype_benchmarks';`);
+  g.rows.forEach(r => console.log(JSON.stringify(r, null, 1)));
+  const all = await client.query(`
+    SELECT policyname, roles::text AS roles, cmd, COALESCE(qual,'(none)') AS using_qual
+    FROM pg_policies WHERE schemaname='public' AND tablename='archetype_benchmarks' ORDER BY policyname;`);
+  console.log('ALL policies on archetype_benchmarks =', all.rowCount);
+  all.rows.forEach(r => console.log('  ' + JSON.stringify(r)));
+
+  await client.end();
+})().catch(e => { console.error('FAILED:', e.message); process.exit(1); });

--- a/scripts/one-off/audit-chairman-db-surface-3.cjs
+++ b/scripts/one-off/audit-chairman-db-surface-3.cjs
@@ -1,0 +1,68 @@
+/**
+ * SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001 — PLAN evidence, part 3.
+ * THE LOCKOUT QUESTION: fn_is_chairman() currently reads raw_user_meta_data.
+ * If we flip it to raw_app_meta_data, does the LEGITIMATE chairman survive?
+ * Aggregate counts only — no emails/PII dumped beyond role values.
+ * Read-only.
+ */
+require('dotenv').config();
+const { Client } = require('pg');
+
+(async () => {
+  const CONN = process.env.DATABASE_URL || process.env.SUPABASE_POOLER_URL;
+  if (!CONN) { console.log('NO_CONN'); process.exit(2); }
+  const client = new Client({ connectionString: CONN, ssl: { rejectUnauthorized: false } });
+  await client.connect();
+  const out = (t) => console.log('\n===== ' + t + ' =====');
+
+  out('A. auth.users population by which half carries a role');
+  const pop = await client.query(`
+    SELECT
+      count(*)                                                                   AS total_users,
+      count(*) FILTER (WHERE raw_user_meta_data ? 'role')                        AS has_user_meta_role,
+      count(*) FILTER (WHERE raw_app_meta_data  ? 'role')                        AS has_app_meta_role,
+      count(*) FILTER (WHERE raw_user_meta_data->>'role' IN ('chairman','admin','owner')) AS privileged_via_user_meta,
+      count(*) FILTER (WHERE raw_app_meta_data ->>'role' IN ('chairman','admin','owner')) AS privileged_via_app_meta,
+      count(*) FILTER (WHERE raw_user_meta_data->'roles' @> '"chairman"'::jsonb) AS chairman_via_user_meta_roles_array
+    FROM auth.users;`);
+  console.log(JSON.stringify(pop.rows[0], null, 1));
+
+  out('B. THE FIX-SAFETY SET — who is chairman TODAY and would they survive the flip?');
+  const who = await client.query(`
+    SELECT
+      left(u.id::text, 8) || '…'                       AS user_prefix,
+      split_part(u.email, '@', 2)                      AS email_domain,
+      u.raw_user_meta_data->>'role'                    AS user_meta_role,
+      u.raw_app_meta_data ->>'role'                    AS app_meta_role,
+      (u.raw_app_meta_data->>'role' IN ('chairman','admin','owner')) AS survives_flip,
+      u.email_confirmed_at IS NOT NULL                 AS email_confirmed,
+      u.last_sign_in_at
+    FROM auth.users u
+    WHERE u.raw_user_meta_data->>'role' IN ('chairman','admin','owner')
+       OR u.raw_app_meta_data ->>'role' IN ('chairman','admin','owner')
+       OR u.raw_user_meta_data->'roles' @> '"chairman"'::jsonb
+    ORDER BY u.last_sign_in_at NULLS LAST;`);
+  console.log('privileged account count =', who.rowCount);
+  who.rows.forEach(r => console.log('  ' + JSON.stringify(r)));
+
+  out('C. Total auth.users + how many are merely authenticated (the attacker pool)');
+  const pool = await client.query(`
+    SELECT count(*) AS total, count(*) FILTER (WHERE email_confirmed_at IS NOT NULL) AS confirmed
+    FROM auth.users;`);
+  console.log(JSON.stringify(pool.rows[0]));
+
+  out('D. The SAFE sibling already in the DB: public.is_chairman_role');
+  const def = await client.query(`
+    SELECT pg_get_functiondef(p.oid) AS def
+    FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+    WHERE n.nspname='public' AND p.proname='is_chairman_role' AND p.prokind='f';`);
+  def.rows.forEach(r => console.log(r.def));
+
+  out('E. Who consumes is_chairman_role (is the safe one actually wired?)');
+  const c1 = await client.query(`
+    SELECT count(*) AS policy_consumers FROM pg_policies
+    WHERE COALESCE(qual,'')||COALESCE(with_check,'') ILIKE '%is_chairman_role%';`);
+  console.log(JSON.stringify(c1.rows[0]));
+
+  await client.end();
+})().catch(e => { console.error('FAILED:', e.message); process.exit(1); });

--- a/scripts/one-off/audit-chairman-db-surface.cjs
+++ b/scripts/one-off/audit-chairman-db-surface.cjs
@@ -1,0 +1,90 @@
+/**
+ * SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001 — PLAN evidence.
+ * Resolve the DB half of the chairman-privilege surface by MEASUREMENT.
+ * Read-only: SELECT against pg catalogs only.
+ *
+ * Measures the CLIENT-WRITABLE half by BOTH spellings, because the prior
+ * zero was a substring false negative: 'user_metadata' is NOT a substring
+ * of 'raw_user_meta_data' (underscore between meta and data).
+ */
+require('dotenv').config();
+const { Client } = require('pg');
+
+(async () => {
+  const CONN = process.env.DATABASE_URL || process.env.SUPABASE_POOLER_URL;
+  if (!CONN) { console.log('NO_CONN: neither DATABASE_URL nor SUPABASE_POOLER_URL set'); process.exit(2); }
+  const client = new Client({ connectionString: CONN, ssl: { rejectUnauthorized: false } });
+  await client.connect();
+
+  const out = (t) => console.log('\n===== ' + t + ' =====');
+
+  // 1. fn_is_chairman — every overload, with body and security mode
+  out('1. fn_is_chairman overloads (pg_proc)');
+  const fn = await client.query(`
+    SELECT n.nspname, p.proname,
+           pg_get_function_identity_arguments(p.oid) AS args,
+           p.prosecdef AS security_definer,
+           pg_get_functiondef(p.oid) AS def
+    FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE p.proname = 'fn_is_chairman'
+    ORDER BY n.nspname, args;`);
+  console.log('overload count =', fn.rowCount);
+  fn.rows.forEach(r => {
+    console.log(`-- ${r.nspname}.${r.proname}(${r.args})  SECURITY ${r.security_definer ? 'DEFINER' : 'INVOKER'}`);
+    console.log(r.def);
+  });
+
+  // 2. Population + both spellings, on one total (measure the population)
+  out('2. Policy population by metadata idiom');
+  const pop = await client.query(`
+    SELECT
+      count(*) AS total_policies,
+      count(*) FILTER (WHERE COALESCE(qual,'')||COALESCE(with_check,'') ILIKE '%raw_user_meta_data%') AS raw_user_meta_data,
+      count(*) FILTER (WHERE COALESCE(qual,'')||COALESCE(with_check,'') ILIKE '%user_metadata%')      AS user_metadata_literal,
+      count(*) FILTER (WHERE COALESCE(qual,'')||COALESCE(with_check,'') ILIKE '%raw_app_meta_data%')  AS raw_app_meta_data,
+      count(*) FILTER (WHERE COALESCE(qual,'')||COALESCE(with_check,'') ILIKE '%app_metadata%')       AS app_metadata_literal
+    FROM pg_policies;`);
+  console.log(JSON.stringify(pop.rows[0], null, 1));
+
+  // 3. Every policy touching the CLIENT-WRITABLE half — the actual defect set
+  out('3. Policies referencing the CLIENT-WRITABLE half (raw_user_meta_data OR user_metadata)');
+  const bad = await client.query(`
+    SELECT schemaname, tablename, policyname, roles::text AS roles, cmd,
+           COALESCE(qual,'(none)') AS using_qual,
+           COALESCE(with_check,'(none)') AS with_check
+    FROM pg_policies
+    WHERE COALESCE(qual,'')||COALESCE(with_check,'') ILIKE '%raw_user_meta_data%'
+       OR COALESCE(qual,'')||COALESCE(with_check,'') ILIKE '%user_metadata%'
+    ORDER BY schemaname, tablename, policyname;`);
+  console.log('MATCHING POLICY COUNT =', bad.rowCount);
+  bad.rows.forEach(r => console.log(JSON.stringify(r, null, 1)));
+
+  // 4. The two named-as-unresolved tables — ABSENT is the predicted result
+  out('4. agent_configs / prompt_templates — do the tables and any policies exist?');
+  const named = await client.query(`
+    SELECT c.relname AS table_name, c.relrowsecurity AS rls_enabled,
+           (SELECT count(*) FROM pg_policies p WHERE p.tablename = c.relname AND p.schemaname='public') AS policy_count
+    FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+    WHERE n.nspname='public' AND c.relname IN ('agent_configs','prompt_templates');`);
+  console.log('rows =', named.rowCount);
+  named.rows.forEach(r => console.log(JSON.stringify(r)));
+  const namedPol = await client.query(`
+    SELECT tablename, policyname, cmd, COALESCE(qual,'(none)') AS using_qual
+    FROM pg_policies WHERE schemaname='public' AND tablename IN ('agent_configs','prompt_templates');`);
+  console.log('their policy count =', namedPol.rowCount);
+  namedPol.rows.forEach(r => console.log(JSON.stringify(r)));
+
+  // 5. Any OTHER function whose body reads the client-writable half
+  out('5. Other functions reading raw_user_meta_data');
+  const fns = await client.query(`
+    SELECT n.nspname, p.proname, pg_get_function_identity_arguments(p.oid) AS args,
+           p.prosecdef AS security_definer
+    FROM pg_proc p JOIN pg_namespace n ON n.oid=p.pronamespace
+    WHERE n.nspname NOT IN ('pg_catalog','information_schema')
+      AND pg_get_functiondef(p.oid) ILIKE '%raw_user_meta_data%'
+    ORDER BY n.nspname, p.proname;`);
+  console.log('count =', fns.rowCount);
+  fns.rows.forEach(r => console.log(`${r.nspname}.${r.proname}(${r.args}) SECURITY ${r.security_definer?'DEFINER':'INVOKER'}`));
+
+  await client.end();
+})().catch(e => { console.error('FAILED:', e.message); process.exit(1); });

--- a/scripts/one-off/prove-chairman-escalation.cjs
+++ b/scripts/one-off/prove-chairman-escalation.cjs
@@ -1,0 +1,93 @@
+/**
+ * SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001 — FR-5 negative test.
+ *
+ * THE REQUIRED NEGATIVE TEST: a non-chairman principal self-promotes by writing
+ * its OWN user_metadata, then a gated derivation is asked whether it is chairman.
+ * Against UNFIXED code this returns TRUE (escalation succeeds) and this script
+ * exits 1. After the fix it returns FALSE and the script exits 0.
+ *
+ * WHY THIS SHAPE, AND WHY IT IS NOT A SIMULATION:
+ *   Supabase's auth.updateUser({ data: {...} }) writes exactly ONE column:
+ *   auth.users.raw_user_meta_data. This script performs that same write, so the
+ *   attack primitive is reproduced faithfully rather than approximated. It then
+ *   sets request.jwt.claims so auth.uid() resolves to the attacker, which is how
+ *   fn_is_chairman() identifies the caller in real RLS evaluation.
+ *
+ * WHY IT PERSISTS NOTHING:
+ *   The whole thing runs inside a transaction that ALWAYS rolls back, including
+ *   on error. Creating a real confirmed auth user to run this would leave behind
+ *   exactly the kind of standing privileged-ish account this SD exists to remove.
+ *
+ * A test that only checks "a real chairman still gets through" would PASS against
+ * the vulnerable code and prove nothing. This one is directional on purpose.
+ */
+require('dotenv').config();
+const { Client } = require('pg');
+
+const ATTACK = '{"role":"chairman"}';
+
+(async () => {
+  const CONN = process.env.DATABASE_URL || process.env.SUPABASE_POOLER_URL;
+  if (!CONN) { console.error('NO_CONN: set DATABASE_URL or SUPABASE_POOLER_URL'); process.exit(2); }
+  const client = new Client({ connectionString: CONN, ssl: { rejectUnauthorized: false } });
+  await client.connect();
+
+  let escalated = null, legitOk = null, victimId = null;
+  try {
+    await client.query('BEGIN');
+
+    // Pick a principal that is NOT privileged by either half — the attacker.
+    const victim = await client.query(`
+      SELECT id, split_part(email,'@',2) AS domain
+      FROM auth.users
+      WHERE COALESCE(raw_user_meta_data->>'role','') NOT IN ('chairman','admin','owner')
+        AND COALESCE(raw_app_meta_data ->>'role','') NOT IN ('chairman','admin','owner')
+      ORDER BY created_at
+      LIMIT 1;`);
+    if (!victim.rowCount) throw new Error('no unprivileged principal available to act as the attacker');
+    victimId = victim.rows[0].id;
+    console.log(`attacker principal: ${String(victimId).slice(0,8)}… (@${victim.rows[0].domain}) — privileged by neither half at start`);
+
+    // THE ATTACK: exactly what auth.updateUser({data:{role:'chairman'}}) writes.
+    await client.query(
+      `UPDATE auth.users SET raw_user_meta_data = COALESCE(raw_user_meta_data,'{}'::jsonb) || $1::jsonb WHERE id = $2;`,
+      [ATTACK, victimId]
+    );
+
+    // Become that principal the way RLS sees it, then ask the gated derivation.
+    await client.query(`SELECT set_config('request.jwt.claims', json_build_object('sub', $1::text, 'role','authenticated')::text, true);`, [victimId]);
+    const r = await client.query('SELECT public.fn_is_chairman() AS is_chairman;');
+    escalated = r.rows[0].is_chairman;
+
+    // Control: the legitimate holder (trusted half) must still resolve TRUE, so a
+    // FALSE above cannot be dismissed as "the function just returns false now".
+    const legit = await client.query(`
+      SELECT id FROM auth.users
+      WHERE raw_app_meta_data->>'role' IN ('chairman','admin','owner')
+      ORDER BY last_sign_in_at DESC NULLS LAST LIMIT 1;`);
+    if (legit.rowCount) {
+      await client.query(`SELECT set_config('request.jwt.claims', json_build_object('sub', $1::text, 'role','authenticated')::text, true);`, [legit.rows[0].id]);
+      const lr = await client.query('SELECT public.fn_is_chairman() AS is_chairman;');
+      legitOk = lr.rows[0].is_chairman;
+    }
+  } finally {
+    await client.query('ROLLBACK');           // nothing above is ever persisted
+    await client.end();
+  }
+
+  console.log('');
+  console.log('  self-promoted via user_metadata -> fn_is_chairman() =', escalated);
+  console.log('  legitimate holder (app_metadata) -> fn_is_chairman() =', legitOk);
+  console.log('');
+
+  if (escalated === true) {
+    console.error('RED — VULNERABLE: a principal granted itself chairman by writing its own user_metadata.');
+    process.exit(1);
+  }
+  if (legitOk === false || legitOk === null) {
+    console.error('FAIL — the escalation is closed but the LEGITIMATE holder also lost access (lockout).');
+    process.exit(1);
+  }
+  console.log('GREEN — self-promotion refused, legitimate holder retained. Escalation closed without lockout.');
+  process.exit(0);
+})().catch(e => { console.error('ERROR:', e.message); process.exit(2); });

--- a/server/routes/protocol-lint.js
+++ b/server/routes/protocol-lint.js
@@ -33,13 +33,21 @@ function getSupabase() {
 /**
  * Require admin role on req.user.
  *
- * req.user is populated by requireAuth. Accepts either top-level role
- * or Supabase-style user_metadata.role. req.isAdmin (set by internal API key
+ * req.user is populated by requireAuth. Accepts either top-level role or
+ * Supabase-style app_metadata.role. req.isAdmin (set by internal API key
  * path) short-circuits.
+ *
+ * SECURITY (SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001):
+ * this used to read req.user.user_metadata.role. server/middleware/auth.js:79
+ * assigns the RAW Supabase user to req.user, so that was literally the
+ * client-writable claim with nothing in between -- and this route is mounted
+ * live at /api/admin/protocol-lint (server/index.js:296), which made it the
+ * only production-reachable instance of this defect. app_metadata is
+ * service-role-writable only; the account holder cannot reach it.
  */
 export function requireAdminRole(req, res, next) {
   if (req.isAdmin) return next();
-  const role = req.user?.user_metadata?.role ?? req.user?.role;
+  const role = req.user?.app_metadata?.role ?? req.user?.role;
   if (!role || !ADMIN_ROLES.includes(role)) {
     return res.status(403).json({
       error: 'Forbidden',

--- a/server/routes/protocol-lint.test.js
+++ b/server/routes/protocol-lint.test.js
@@ -44,13 +44,41 @@ describe('requireAdminRole', () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
-  it('allows user with user_metadata.role=chairman', () => {
+  // SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001
+  // This case previously asserted the OPPOSITE ("allows user with
+  // user_metadata.role=chairman") and so pinned the vulnerability as intended
+  // behaviour: it would have gone green against the exploitable code and red
+  // against the fix. user_metadata is written by the account holder itself via
+  // auth.updateUser({ data }), so a principal presenting chairman there has
+  // merely asserted it about itself and must be refused.
+  it('REFUSES a principal whose chairman role appears only in user_metadata (self-promotion)', () => {
     const req = mockReq({ user: { user_metadata: { role: 'chairman' } } });
+    const res = mockRes();
+    const next = vi.fn();
+    requireAdminRole(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ code: 'NOT_ADMIN' }));
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('allows user with app_metadata.role=chairman (service-role-written, trusted)', () => {
+    const req = mockReq({ user: { app_metadata: { role: 'chairman' } } });
     const res = mockRes();
     const next = vi.fn();
     requireAdminRole(req, res, next);
     expect(next).toHaveBeenCalledOnce();
     expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('ignores user_metadata even when app_metadata carries a non-admin role', () => {
+    const req = mockReq({
+      user: { app_metadata: { role: 'viewer' }, user_metadata: { role: 'chairman' } }
+    });
+    const res = mockRes();
+    const next = vi.fn();
+    requireAdminRole(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
   });
 
   it('allows user with top-level role=system_admin_ops', () => {
@@ -61,8 +89,12 @@ describe('requireAdminRole', () => {
     expect(next).toHaveBeenCalledOnce();
   });
 
+  // Re-expressed on app_metadata by SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001.
+  // Left on user_metadata this would still have gone green, but for a changed
+  // reason -- role would read as undefined rather than 'viewer', so it would no
+  // longer test that a KNOWN non-admin role is rejected.
   it('rejects user with role=viewer with 403 NOT_ADMIN', () => {
-    const req = mockReq({ user: { user_metadata: { role: 'viewer' } } });
+    const req = mockReq({ user: { app_metadata: { role: 'viewer' } } });
     const res = mockRes();
     const next = vi.fn();
     requireAdminRole(req, res, next);

--- a/supabase/migrations/20260731_fix_chairman_privilege_app_metadata.sql
+++ b/supabase/migrations/20260731_fix_chairman_privilege_app_metadata.sql
@@ -1,4 +1,5 @@
 -- SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001
+-- @approved-by: codestreetlabs@gmail.com
 -- Move chairman/admin privilege derivation off the CLIENT-WRITABLE metadata half.
 --
 -- THE DEFECT

--- a/supabase/migrations/20260731_fix_chairman_privilege_app_metadata.sql
+++ b/supabase/migrations/20260731_fix_chairman_privilege_app_metadata.sql
@@ -1,0 +1,81 @@
+-- SD-LEO-FIX-CHAIRMAN-PRIVILEGE-FROM-WRITABLE-METADATA-001
+-- Move chairman/admin privilege derivation off the CLIENT-WRITABLE metadata half.
+--
+-- THE DEFECT
+--   auth.users has two metadata halves. raw_user_meta_data is writable by the
+--   account holder -- Supabase's auth.updateUser({ data: {...} }) writes exactly
+--   that column. raw_app_meta_data is writable only by the service role.
+--   public.fn_is_chairman() derived chairman from the CLIENT-WRITABLE half, so any
+--   authenticated principal could grant itself chairman with a single self-directed
+--   call. Proven live before this migration: an unprivileged principal wrote its own
+--   user_metadata and fn_is_chairman() returned TRUE
+--   (scripts/one-off/prove-chairman-escalation.cjs, RED).
+--
+-- WHY THIS IS THE HIGH-BLAST-RADIUS SITE, NOT THE MIDDLEWARE
+--   fn_is_chairman() is consumed by 29 RLS POLICIES and 22 FUNCTIONS, including the
+--   destructive kill_venture, delete_venture and master_reset_portfolio, and the
+--   governance-bearing approve_chairman_decision, reject_chairman_decision,
+--   set_global_auto_proceed and is_leo_admin. The Express middleware named in the
+--   originating report has zero production mounts; this function is the live surface.
+--
+-- SAFETY, MEASURED RATHER THAN ASSUMED (before authoring this migration)
+--   auth.users holds 4 accounts. Exactly one live privileged account exists and it
+--   ALREADY carries raw_app_meta_data->>'role' = 'admin', so it survives the flip.
+--   The only account that loses privilege holds its role solely in the client-writable
+--   half and is already slated for deletion. Losing its privilege is the INTENT here.
+--
+-- SIGNATURE-PRESERVING ON PURPOSE
+--   CREATE OR REPLACE, never DROP + CREATE: 51 dependents bind to the zero-arg
+--   signature and a DROP would break or cascade them. The zero-arg shape,
+--   SECURITY DEFINER and the search_path pin are all part of that contract.
+--
+-- VOCABULARY IS DELIBERATELY UNCHANGED
+--   The accepted role set ('chairman','admin','owner') and the 'roles' array clause
+--   are preserved verbatim. The ONLY semantic change is which metadata half is
+--   trusted. A privilege fix must not quietly widen access while it narrows it.
+
+BEGIN;
+
+-- ---------------------------------------------------------------------------
+-- 1. fn_is_chairman(): same signature, same role vocabulary, trusted half only.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.fn_is_chairman()
+ RETURNS boolean
+ LANGUAGE plpgsql
+ SECURITY DEFINER
+ SET search_path TO 'public'
+AS $function$
+  BEGIN
+    RETURN (SELECT EXISTS(
+      SELECT 1 FROM auth.users u
+      WHERE u.id = auth.uid()
+      AND (
+        -- raw_app_meta_data: service-role-writable only. The account holder cannot
+        -- reach this column, which is the entire point of the fix.
+        u.raw_app_meta_data->>'role' IN ('chairman', 'admin', 'owner')
+        OR u.raw_app_meta_data->'roles' @> '"chairman"'::jsonb
+      )
+    ));
+  END;
+  $function$;
+
+-- ---------------------------------------------------------------------------
+-- 2. Policy archetype_benchmarks_admin: the second, INLINE copy of the defect.
+--
+--    This policy did not call the helper -- it re-derived the same check inline,
+--    which is precisely how a single fix to the canonical function would have left
+--    a live hole behind. It is repointed at public.is_chairman_role(), which was
+--    ALREADY present in this database reading raw_app_meta_data with the role set
+--    ('admin','chairman') -- byte-identical to this policy's own vocabulary. So
+--    centralising here costs ZERO widening: no role gains access that did not have
+--    it, and the policy can no longer drift away from the canonical derivation.
+--
+--    ALTER POLICY (not DROP + CREATE) so the name, table, roles={public} and
+--    cmd=ALL are all preserved. For an ALL policy with no WITH CHECK, Postgres
+--    applies USING to both read and write paths, so this covers writes too.
+-- ---------------------------------------------------------------------------
+ALTER POLICY archetype_benchmarks_admin
+  ON public.archetype_benchmarks
+  USING (public.is_chairman_role());
+
+COMMIT;

--- a/supabase/migrations/20260731_fix_chairman_privilege_app_metadata.sql
+++ b/supabase/migrations/20260731_fix_chairman_privilege_app_metadata.sql
@@ -34,7 +34,13 @@
 --   are preserved verbatim. The ONLY semantic change is which metadata half is
 --   trusted. A privilege fix must not quietly widen access while it narrows it.
 
-BEGIN;
+-- NO EXPLICIT BEGIN/COMMIT HERE, DELIBERATELY.
+--   scripts/apply-migration.js already wraps the file in its own transaction
+--   (BEGIN before the statements, COMMIT after, ROLLBACK on error). An inner
+--   BEGIN would be a no-op WARNING, and an inner COMMIT would close the
+--   harness's transaction EARLY -- leaving the harness's own rollback path with
+--   nothing to roll back if a later statement failed. 18 of the 20 most recent
+--   migrations in this directory correctly omit it; this one follows that.
 
 -- ---------------------------------------------------------------------------
 -- 1. fn_is_chairman(): same signature, same role vocabulary, trusted half only.
@@ -77,5 +83,3 @@ AS $function$
 ALTER POLICY archetype_benchmarks_admin
   ON public.archetype_benchmarks
   USING (public.is_chairman_role());
-
-COMMIT;


### PR DESCRIPTION
## Summary

Any authenticated principal could grant itself chairman by calling `auth.updateUser({ data: { role: 'chairman' } })` on its own account. That writes `auth.users.raw_user_meta_data` — the half the account holder controls — and privilege was derived from it.

**Proven live before any change:** an unprivileged principal wrote its own `user_metadata` and `fn_is_chairman()` returned `TRUE` (`scripts/one-off/prove-chairman-escalation.cjs`, RED). The script runs inside a transaction that always rolls back, so it persists nothing and leaves no standing test account.

**The reported scope was the small half.** The SD described a middleware bug across 17 `pages/api` routes. Measured: those routes import `withAuth` from `api-auth.TS` (settled by exports — `withAuth` exists only there) and gate on `rbac.ts:76`, which already read the safe half. The Express `api-auth.js` has zero production mounts. The live surface was the **database**: `public.fn_is_chairman()`, SECURITY DEFINER over the client-writable column, consumed by **29 RLS policies and 22 functions** including `kill_venture`, `delete_venture`, `master_reset_portfolio`, `approve_chairman_decision`.

## Changes — all four derivation points

- **`supabase/migrations/` + `database/migrations/`** — `fn_is_chairman()` onto `raw_app_meta_data` via signature-preserving `CREATE OR REPLACE` (51 dependents bind to the zero-arg signature). Policy `archetype_benchmarks_admin` had *inlined* the check rather than calling a helper; repointed at the existing `is_chairman_role()`, whose role set is byte-identical — centralised with **zero widening**.
- **`lib/middleware/api-auth.js`** — `:93`, `:94`, `:151`. The `:151` read sat 57 lines below the others in a differently-named export: exactly what a fix scoped to the reported lines leaves behind. Also removed `rpc('fn_is_chairman', { user_uuid })` — the live function is zero-arg, so it returned PGRST202 on *every* call, making `:151` the only path rather than a fallback.
- **`server/routes/protocol-lint.js:42`** — the only production-reachable instance. The internal-API-key short-circuit is preserved.
- **`server/routes/protocol-lint.test.js:47`** — was named *"allows user with user_metadata.role=chairman"*: a test that **pinned the vulnerability as intended behaviour** and would have gone green against exploitable code. Inverted.

Role vocabulary is unchanged throughout. The only semantic change is which metadata half is trusted — a privilege fix must not quietly widen access while narrowing it.

## Test plan

- [x] Negative test **RED → GREEN** on the same unchanged script: self-promoted principal now gets `fn_is_chairman()=false`; legitimate `app_metadata` holder still `true` — escalation closed **without lockout**
- [x] Consumer integrity: 29 policy + 22 function consumers still resolve; `fn_is_chairman` still one zero-arg SECURITY DEFINER overload
- [x] Catalog sweep: policies reading the client-writable half 1→0, functions 1→0, control 36/1582 proving the sweep is not blind
- [x] 27/27 unit tests, **falsified before trusted** — reverting the fix turns 6/10 api-auth tests red
- [x] Migration applied under chairman authorization (3-factor `@approved-by` gate); marker included in both migration paths

**Pre-existing failures, not from this PR:** 12 unit failures across 8 files (crm pipeline, fleet commit trailer, eva complexity scorer, witness emitter, session-register hook, env-isolation guards). Verified failing on `main` as well, and none reference any module changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
