### PR TITLE
feat(SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001): FR-2 receipt writer — capture the answer at the transition

### DIFF
--- a/lib/coordination/receipt-ledger.cjs
+++ b/lib/coordination/receipt-ledger.cjs
@@ -1,0 +1,107 @@
+/**
+ * SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-2) — write receipts to the durable ledger.
+ *
+ * WHY A SEPARATE TABLE AT ALL. The answered-rate cannot be computed from session_coordination:
+ * cleanup_expired_coordination() deletes ACKED rows at created+24h while UNACKED rows persist, so
+ * the denominator is curated by the exact state being measured. Measured 2026-07-31: 0 of 31 acked
+ * rows survived past 24h against 1,930 unacked that did; to DISPLAY 60% on the survivor table the
+ * true rate would have to be 98.6%. Receipts written here outlive the row they describe, which is
+ * the whole point — so a receipt MUST NOT be derived by reading session_coordination later.
+ *
+ * ONE RECEIPT CONTRACT ACROSS ALL LANES (binding coordinator directive). Friction signals,
+ * WORK_ASSIGNMENT fulfilment, Adam advisories and resolution-by-work_assignment each half-
+ * implemented their own notion of "handled" — acknowledged_at here, payload.actioned_at there,
+ * nothing at all for a fulfilled assignment. LANES enumerates them so a remedy scoped to one lane
+ * cannot silently leave the others open.
+ *
+ * CommonJS to match lib/coordinator/*.cjs and be require()-able from the CLI scripts that stamp.
+ */
+
+'use strict';
+
+/** The lanes a receipt can belong to. One contract, not a signal-lane patch. */
+const LANES = Object.freeze({
+  SIGNAL: 'signal',                 // worker friction signal
+  WORK_ASSIGNMENT: 'work_assignment', // coordinator -> worker assignment, incl. fulfilment
+  ADVISORY: 'advisory',             // Adam advisory
+  RESOLVES_FILES: 'resolves_files', // block resolved via a work_assignment carrying resolves_files
+});
+
+/**
+ * The three states. They are DISTINCT and independently queryable on purpose: conflating delivery
+ * with disposition is the root defect of this SD (read_at meant "rendered on a screen" and was read
+ * as "answered").
+ */
+const STATES = Object.freeze({
+  DELIVERED: 'delivered', // transport succeeded
+  SEEN: 'seen',           // a consumer actually surfaced it to a decider
+  DISPOSED: 'disposed',   // an outcome was recorded
+});
+
+/** Only meaningful when state === disposed. */
+const DISPOSITIONS = Object.freeze({
+  ACTIONED: 'actioned',
+  DECLINED: 'declined',
+  SUPERSEDED: 'superseded',
+});
+
+/**
+ * PURE/TOTAL. Build the ledger row. Exported so the shape is testable without a database.
+ *
+ * source_age_ms is computed HERE, at transition time, because it cannot be recovered later — the
+ * source row is deleted at 24h, so time-to-answer is unrecoverable unless captured now.
+ *
+ * @returns {object|null} the row, or null if required fields are missing (caller fails open)
+ */
+function buildReceipt(input = {}) {
+  const { coordinationId, lane, state, disposition, actorSession, actorRole, isRetention, sourceCreatedAt, nowMs, metadata } = input;
+  if (!coordinationId || !lane || !state) return null;
+  if (!Object.values(STATES).includes(state)) return null;
+  if (!Object.values(LANES).includes(lane)) return null;
+  // A disposition without DISPOSED is incoherent; DISPOSED without one is merely unspecified.
+  if (disposition && state !== STATES.DISPOSED) return null;
+  if (disposition && !Object.values(DISPOSITIONS).includes(disposition)) return null;
+
+  const now = Number.isFinite(nowMs) ? nowMs : Date.now();
+  const createdMs = sourceCreatedAt ? Date.parse(/Z$|[+-]\d{2}:?\d{2}$/.test(String(sourceCreatedAt)) ? sourceCreatedAt : sourceCreatedAt + 'Z') : NaN;
+  const ageMs = Number.isFinite(createdMs) ? Math.max(0, now - createdMs) : null;
+
+  return {
+    coordination_id: coordinationId,
+    lane,
+    state,
+    disposition: disposition || null,
+    actor_session: actorSession || null,
+    actor_role: actorRole || null,
+    is_retention: isRetention === true,
+    source_age_ms: ageMs,
+    metadata: metadata && typeof metadata === 'object' ? metadata : {},
+  };
+}
+
+/**
+ * Write one receipt. FAIL-OPEN AND NON-FATAL BY DESIGN.
+ *
+ * Recording a receipt must never block, delay or fail the act it describes: if the ledger write
+ * throws, the ack still happened and the caller must proceed. A measurement outage must not become
+ * an operational outage — that is the same discipline the FR-4 instrumentation already follows.
+ *
+ * The tradeoff is stated rather than hidden: a failed write means that receipt is lost, so the
+ * metric UNDER-counts answers. That is the safe direction. Over-counting would let a broken lane
+ * read as healthy, which is the failure this SD exists to eliminate.
+ *
+ * @returns {Promise<{ok: boolean, skipped?: string, error?: string}>}
+ */
+async function recordReceipt(client, input = {}) {
+  const row = buildReceipt(input);
+  if (!row) return { ok: false, skipped: 'invalid_input' };
+  if (!client) return { ok: false, skipped: 'no_client' };
+  try {
+    const { error } = await client.from('coordination_receipts').insert(row);
+    return error ? { ok: false, error: error.message } : { ok: true };
+  } catch (e) {
+    return { ok: false, error: (e && e.message) || String(e) };
+  }
+}
+
+module.exports = { LANES, STATES, DISPOSITIONS, buildReceipt, recordReceipt };

--- a/scripts/coordinator-ack-signal.cjs
+++ b/scripts/coordinator-ack-signal.cjs
@@ -26,6 +26,9 @@ const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { isTwoWayV2Enabled } = require('../lib/coordinator/resolve.cjs');
 const { isFullUuid } = require('../lib/coordinator/dispatch.cjs');
 const { sendCoordinatorReply } = require('./coordinator-reply.cjs');
+// FR-2: durable receipt ledger — the answered-rate cannot be recovered from session_coordination,
+// whose cleanup deletes ACKED rows at created+24h while unacked rows persist.
+const { recordReceipt, LANES, STATES, DISPOSITIONS } = require('../lib/coordination/receipt-ledger.cjs');
 
 function parseArgs(argv) {
   const args = argv.slice(2);
@@ -65,7 +68,7 @@ async function main() {
 
   const { data: sig, error: fErr } = await supabase
     .from('session_coordination')
-    .select('id, sender_session, payload, acknowledged_at')
+    .select('id, sender_session, payload, acknowledged_at, created_at')
     .eq('id', signalId)
     .maybeSingle();
   if (fErr) { console.error('ERROR: signal lookup failed:', fErr.message); process.exit(1); }
@@ -79,6 +82,29 @@ async function main() {
       .update({ acknowledged_at: nowIso })
       .eq('id', signalId);
     if (sErr) { console.error('ERROR: failed to stamp acknowledged_at:', sErr.message); process.exit(1); }
+
+    // SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-2): record the disposal in the DURABLE ledger.
+    // This row is deleted by cleanup_expired_coordination() at created+24h — and it is deleted
+    // BECAUSE it is now acked, while unacked rows persist. So the answered-rate cannot be recovered
+    // from session_coordination afterwards at any later time; it has to be captured HERE, at the
+    // moment of the transition, or it is gone. source_created_at is passed so time-to-answer
+    // survives the deletion too.
+    //
+    // Deliberately NON-FATAL and after the stamp: the ack has already happened and must stand even
+    // if the ledger write fails. A measurement outage must never become an operational one.
+    const receipt = await recordReceipt(supabase, {
+      coordinationId: signalId,
+      lane: LANES.SIGNAL,
+      state: STATES.DISPOSED,
+      disposition: DISPOSITIONS.ACTIONED,
+      actorSession: process.env.CLAUDE_SESSION_ID || null,
+      actorRole: 'coordinator',
+      isRetention: false,
+      sourceCreatedAt: sig.created_at,
+      nowMs: Date.parse(nowIso),
+      metadata: { signal_type: (sig.payload && sig.payload.signal_type) || null, via: 'coordinator-ack-signal.cjs' },
+    });
+    if (!receipt.ok) console.error('NOTE: receipt ledger write skipped (' + (receipt.error || receipt.skipped) + ') — ack still stands.');
   }
   console.log('✓ Signal acknowledged (retired from inbox)');
   console.log('  signal_id:', signalId);

--- a/tests/unit/receipt-ledger.test.js
+++ b/tests/unit/receipt-ledger.test.js
@@ -1,0 +1,93 @@
+/**
+ * SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 FR-2 — durable receipt ledger writer.
+ *
+ * The ledger exists because the answered-rate cannot be computed from session_coordination: its
+ * cleanup deletes ACKED rows at created+24h while UNACKED rows persist, so the denominator is
+ * curated by the exact state being measured. A receipt therefore has to be captured AT the
+ * transition — it cannot be reconstructed afterwards.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { buildReceipt, recordReceipt, LANES, STATES, DISPOSITIONS } = require('../../lib/coordination/receipt-ledger.cjs');
+
+const NOW = 1_750_000_000_000;
+const minsAgo = (m) => new Date(NOW - m * 60_000).toISOString();
+
+describe('buildReceipt', () => {
+  it('captures time-to-answer at transition time, because it is unrecoverable later', () => {
+    const r = buildReceipt({
+      coordinationId: 'c-1', lane: LANES.SIGNAL, state: STATES.DISPOSED,
+      disposition: DISPOSITIONS.ACTIONED, sourceCreatedAt: minsAgo(45), nowMs: NOW,
+    });
+    expect(r.source_age_ms).toBe(45 * 60_000);
+  });
+
+  it('handles a naive (no-timezone) timestamp as UTC rather than silently producing null', () => {
+    // PostgREST returns naive strings; treating them as local would skew age by the TZ offset —
+    // the same class of defect SD-LEO-INFRA-NAIVE-TIMESTAMP-SKEW-001 reports, which skews "in the
+    // direction that suppresses alerts".
+    const naive = new Date(NOW - 30 * 60_000).toISOString().replace('Z', '');
+    expect(buildReceipt({ coordinationId: 'c', lane: LANES.SIGNAL, state: STATES.SEEN, sourceCreatedAt: naive, nowMs: NOW }).source_age_ms)
+      .toBe(30 * 60_000);
+  });
+
+  it('leaves age null (never 0) when the source timestamp is absent — unknown is not instant', () => {
+    expect(buildReceipt({ coordinationId: 'c', lane: LANES.SIGNAL, state: STATES.SEEN, nowMs: NOW }).source_age_ms).toBe(null);
+  });
+
+  it('rejects incoherent input rather than writing a misleading row', () => {
+    expect(buildReceipt({})).toBe(null);
+    expect(buildReceipt({ coordinationId: 'c', lane: LANES.SIGNAL, state: 'invented' })).toBe(null);
+    expect(buildReceipt({ coordinationId: 'c', lane: 'invented', state: STATES.SEEN })).toBe(null);
+    // a disposition only means something on DISPOSED
+    expect(buildReceipt({ coordinationId: 'c', lane: LANES.SIGNAL, state: STATES.SEEN, disposition: DISPOSITIONS.ACTIONED })).toBe(null);
+    expect(buildReceipt({ coordinationId: 'c', lane: LANES.SIGNAL, state: STATES.DISPOSED, disposition: 'invented' })).toBe(null);
+  });
+
+  it('keeps the three states distinct — delivery is not disposition', () => {
+    const delivered = buildReceipt({ coordinationId: 'c', lane: LANES.SIGNAL, state: STATES.DELIVERED, nowMs: NOW });
+    expect(delivered.state).toBe('delivered');
+    expect(delivered.disposition).toBe(null);
+    expect(buildReceipt({ coordinationId: 'c', lane: LANES.SIGNAL, state: STATES.SEEN, nowMs: NOW }).state).toBe('seen');
+  });
+
+  it('defaults is_retention to false and only accepts an exact true', () => {
+    expect(buildReceipt({ coordinationId: 'c', lane: LANES.SIGNAL, state: STATES.SEEN, nowMs: NOW }).is_retention).toBe(false);
+    expect(buildReceipt({ coordinationId: 'c', lane: LANES.SIGNAL, state: STATES.SEEN, isRetention: 'yes', nowMs: NOW }).is_retention).toBe(false);
+    expect(buildReceipt({ coordinationId: 'c', lane: LANES.SIGNAL, state: STATES.SEEN, isRetention: true, nowMs: NOW }).is_retention).toBe(true);
+  });
+
+  it('covers all four lanes, so no lane is left to invent its own contract', () => {
+    for (const lane of Object.values(LANES)) {
+      expect(buildReceipt({ coordinationId: 'c', lane, state: STATES.SEEN, nowMs: NOW }).lane).toBe(lane);
+    }
+  });
+});
+
+describe('recordReceipt is fail-open — measurement must never break the act it measures', () => {
+  const valid = { coordinationId: 'c-1', lane: LANES.SIGNAL, state: STATES.DISPOSED, disposition: DISPOSITIONS.ACTIONED, nowMs: NOW };
+
+  it('writes the row on the happy path', async () => {
+    const seen = [];
+    const client = { from: () => ({ insert: async (row) => { seen.push(row); return { error: null }; } }) };
+    expect(await recordReceipt(client, valid)).toEqual({ ok: true });
+    expect(seen[0].lane).toBe('signal');
+    expect(seen[0].state).toBe('disposed');
+  });
+
+  it('a DB error is reported, not thrown — the caller proceeds', async () => {
+    const client = { from: () => ({ insert: async () => ({ error: { message: 'db down' } }) }) };
+    expect(await recordReceipt(client, valid)).toEqual({ ok: false, error: 'db down' });
+  });
+
+  it('a THROWING client is swallowed — the ack it describes has already happened', async () => {
+    const client = { from: () => { throw new Error('boom'); } };
+    expect(await recordReceipt(client, valid)).toEqual({ ok: false, error: 'boom' });
+  });
+
+  it('missing client or invalid input skips without throwing', async () => {
+    expect(await recordReceipt(null, valid)).toEqual({ ok: false, skipped: 'no_client' });
+    expect(await recordReceipt({}, {})).toEqual({ ok: false, skipped: 'invalid_input' });
+  });
+});


### PR DESCRIPTION
Wires the chairman-authorized `coordination_receipts` table (live 14:52Z, `MIGRATION_APPLY_PROD_PASS`, audit row in `adam_delegated_apply_ledger`).

## Why the write must happen at the transition

`cleanup_expired_coordination()` deletes **acked** rows at `created+24h` while **unacked** rows persist. The row is deleted *because* it was answered.

So the answered-rate cannot be reconstructed from `session_coordination` at any later time — not by a smarter query, not by a longer window. Measured: **0 of 31** acked rows survived 24h against **1,930** unacked that did; to *display* 60% on the survivor table, the true rate would have to be **98.6%**.

`source_age_ms` is captured for the same reason — time-to-answer dies with the row.

## One receipt contract, not a signal-lane patch

Per the coordinator's binding directive, `LANES` enumerates all four — `signal`, `work_assignment`, `advisory`, `resolves_files` — so the three lanes that each half-implement their own notion of "handled" have one place to converge.

`STATES` keeps **delivered / seen / disposed** independently queryable, because conflating delivery with disposition is this SD's root defect: `read_at` meant "rendered on a screen" and was read as "answered".

## Fail-open, with the tradeoff stated

A ledger write must never block, delay or fail the ack it describes, so a throwing client is swallowed and the caller proceeds.

The cost: a failed write **under-counts** answers. That's the safe direction — over-counting would let a broken lane read as healthy, which is the exact failure this SD exists to eliminate.

## One defect caught by wiring it rather than assuming

`coordinator-ack-signal.cjs` did **not** select `created_at`, so `sourceCreatedAt` would have been `undefined` and `source_age_ms` silently `null` on every receipt — time-to-answer lost forever, with nothing failing. An omitted select column is invisible until the data is already gone.

## Verified at the consumer

Not only in unit tests. Inserted a synthetic coordination row aged 42 minutes (deliberately carrying **no** `payload.signal_type`, so it could never be counted as a friction signal while it existed), acked it through the real CLI, and read the receipt back:

```
lane=signal  state=disposed  disposition=actioned
actor_session=<captured>  actor_role=coordinator  is_retention=false
source_age_ms=2536588  (~42.3 min — matches)
```

Both probe rows deleted afterwards; `coordination_receipts` back to 0 rows.

11/11 unit tests, including naive-timestamp handling (age must not skew by the TZ offset — the SD-LEO-INFRA-NAIVE-TIMESTAMP-SKEW-001 class, which skews *in the direction that suppresses alerts*) and unknown-age staying `null` rather than `0`, because unknown is not instant.

## Scope

This is the **writer** half of FR-2 on the ack path. Remaining: the other three lanes' call sites, and the acceptance query reading the ledger. FR-4 stays held behind the 48h window; FR-5 awaits a route decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)