### PR TITLE
fix(SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001): post-compaction role-contract read-gate, armed only where the contract is provably readable

### DIFF
--- a/docs/reference/session-start-gate-implementation.md
+++ b/docs/reference/session-start-gate-implementation.md
@@ -169,7 +169,15 @@ The protocol file enforcement system now supports three trigger points:
 |---------|------|----------------|----------------|
 | **SESSION_START** | LEO session initialization | CLAUDE.md, CLAUDE_CORE.md | `validateSessionStartGate()` |
 | **SD_START** | Before any SD work begins | CLAUDE.md, CLAUDE_CORE.md + destination phase file | `validateSdStartGate(sdId, ctx, handoffType)` |
-| **POST_COMPACTION** | After context compaction | CLAUDE.md, CLAUDE_CORE.md + phase file | `validatePostCompactionGate()` |
+| **POST_COMPACTION** | ~~After context compaction~~ **RETIRED** | — | ~~`validatePostCompactionGate()`~~ — removed by SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-4 |
+
+> **POST_COMPACTION was removed, not repaired (SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-4).**
+> It was named for exactly the job this table implies, but it had no live caller outside an archived
+> script, its `checkFileNeedsRead` was satisfied by a one-line read, and it had no test at all.
+> Repairing it would have meant giving it the same union-of-ranges coverage maths that already exists
+> — a fourth implementation of one idea in a tree that already had three. Post-compaction contract
+> verification now lives at the role level in `lib/protocol/contract-read-coverage.cjs`, consumed by
+> `adam-register.cjs`, `solomon-register.cjs` and `coordinator-startup-check.mjs`.
 
 **Enhancement (v1.2.0)**: The SD_START gate now accepts an optional `handoffType` parameter that enforces reading the **destination** phase's protocol file:
 

--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -189,6 +189,22 @@ function singleReadFit(root, contractFile) {
 }
 
 /**
+ * Report a coverage percentage. FLOOR, never round.
+ *
+ * A coverage gauge must never round UP: overstating how much of a file was read is the entire
+ * failure mode this module exists to prevent, and it should not sneak back in through a display
+ * format. Flooring also keeps the reported number from CONTRADICTING the verdict — with rounding,
+ * 493 of 520 lines is 94.81%, which the exact comparison correctly calls not-full while the display
+ * rounded it to "95%" against a 95% bar. A gauge that reads 95% beside "not fully read" invites the
+ * reader to assume the verdict is the broken half.
+ *
+ * DISPLAY ONLY. The threshold comparison uses the exact fraction; see unionPct below.
+ */
+function reportPct(exact) {
+  return Math.floor(exact);
+}
+
+/**
  * Union coverage of a range list as a percentage, or null when it yields no usable evidence.
  *
  * *** SEC-F12 — THE IMPORTED HELPER'S EOF DEFAULT IS INVERTED FOR MEASURED RANGES, AND I SHIPPED
@@ -205,20 +221,6 @@ function singleReadFit(root, contractFile) {
  * it as coverage-to-EOF is the original defect again. Both lists therefore require an explicit
  * positive limit; anything else contributes no evidence rather than maximal evidence.
  */
-/**
- * Report a coverage percentage. FLOOR, never round.
- *
- * A coverage gauge must never round UP: overstating how much of a file was read is the entire
- * failure mode this module exists to prevent, and it should not sneak back in through a display
- * format. Flooring also keeps the reported number from CONTRADICTING the verdict — with rounding,
- * 493 of 520 lines is 94.81%, which the exact comparison correctly calls not-full while the display
- * rounded it to "95%" against a 95% bar. A gauge that reads 95% beside "not fully read" invites the
- * reader to assume the verdict is the broken half.
- */
-function reportPct(exact) {
-  return Math.floor(exact);
-}
-
 function unionPct(ranges, total) {
   if (!Array.isArray(ranges) || ranges.length === 0 || !Number.isFinite(total) || total <= 0) return null;
   const usable = ranges.filter((r) => r && Number.isFinite(Number(r.limit)) && Number(r.limit) > 0);

--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -193,7 +193,18 @@ function contractTokenCount(root, contractFile) {
  * closed, sitting in the one path nobody had measured. Derived from the budget now, so degraded
  * mode can never be looser than measured mode by construction rather than by coincidence.
  */
-const SINGLE_READ_SAFE_BYTES = SINGLE_READ_TOKEN_BUDGET; // 1.0 B/token floor => bytes and tokens coincide
+/**
+ * *** THIS CONSTANT'S JUSTIFICATION WENT FALSE WHEN THE SCALE BENEATH IT MOVED. ***
+ * It was `= SINGLE_READ_TOKEN_BUDGET` (22,500), justified by "at the 1.0 B/token floor, bytes and
+ * tokens coincide". True on the cl100k scale; false once tokens are calibrated to the harness. At
+ * the cl100k 1.0 B/token floor, 22,500 bytes is 22,500 cl100k tokens = ~41,625 HARNESS tokens — 67%
+ * over the cap. The calibration commit fixed every path that measures and left the one that cannot.
+ *
+ * Same class this SD keeps rediscovering: a stated bound that was sound against the quantity it was
+ * derived from, and stopped being sound when that quantity was redefined. Derived now, so it moves
+ * with the calibration instead of having to be remembered.
+ */
+const SINGLE_READ_SAFE_BYTES = Math.floor(SINGLE_READ_TOKEN_BUDGET / CL100K_TO_HARNESS);
 
 /**
  * Can this contract be read in ONE call? Measured, with an explicit "cannot tell".

--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -421,7 +421,27 @@ function contractReadVerdict(status, totalLines, opts = {}) {
     }
   }
 
-  // *** KNOWN RESIDUAL, STATED RATHER THAN LEFT IMPLICIT (SEC-F14). ***
+  // *** KNOWN RESIDUAL #1: THE DELIVERED TIERS HAVE NO PRODUCER IN PRACTICE. MEASURED. ***
+  // Everything above prefers deliveredRanges/lastDelivered, and in the live fleet NEITHER IS EVER
+  // WRITTEN. Counted on the real state file: 0 of 13 tracked protocol files carry any delivered
+  // evidence, across 1,371 recorded reads. The transcript shows why — a Read tool_result is
+  // { tool_use_id, type, content: "<string>", is_error }, with the line counts appearing only inside
+  // a human-readable truncation NOTICE in that string ("PARTIAL view — showing lines 1-301 of 371
+  // total (26142 tokens, cap 25000)"), never as the structured totalLines/numLines/startLine fields
+  // protocol-file-tracker.cjs:308-320 looks for.
+  //
+  // FR-5's premise — established by grepping transcripts for "totalLines" and finding 316 hits —
+  // was a FALSE POSITIVE: those hits are source files that MENTION the field, not responses that
+  // carry it. Grepping for a field name finds its own documentation.
+  //
+  // CONSEQUENCE, and it is not a defect in this module: for an OVER-CAP contract, no reader can
+  // currently prove a full read, so the honest answer is "cannot confirm". That is what this now
+  // returns, rather than accepting an upper bound as proof (SEC-F18). The real remedy is to make the
+  // contracts fit — which is exactly SD-LEO-INFRA-ADAM-CONTRACT-READABLE-001. The cheap improvement,
+  // logged as a follow-up: PARSE the truncation notice out of the content string, which IS delivered
+  // evidence, just not in the shape anyone assumed.
+  //
+  // *** KNOWN RESIDUAL #2, STATED RATHER THAN LEFT IMPLICIT (SEC-F14). ***
   // Everything above accumulates coverage across a session, which is sound only while the FILE IS
   // IMMUTABLE — and nothing enforces that. protocol-file-tracker.cjs stores no mtime, hash or size
   // beside the ranges, and these contracts are GENERATED artefacts that CLAUDE.md prologue #7

--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -294,29 +294,40 @@ function contractReadVerdict(status, totalLines, opts = {}) {
     ? Number(d.totalLines)
     : (Number.isFinite(totalLines) && totalLines > 0 ? totalLines : null);
 
-  // Both range lists are LOWER BOUNDS on what was read, so the answer is the better of the two.
+  // MEASUREMENT OUTRANKS REQUEST. Not "take the best of the two" — that was wrong, twice over.
   //
-  // *** SEC-F13: RANKING THEM BY TIER POSITION CONTRADICTED THE PRINCIPLE THEY WERE RANKED BY. ***
-  // I ordered deliveredRanges above ranges "by how much of the FILE each signal describes", then
-  // implemented it as a fixed precedence that returns on the first non-empty list. The two lists are
-  // written under DIFFERENT conditions — ranges.push is guarded by isPartialRead, deliveredRanges.push
-  // by the presence of tool_response — so deliveredRanges can be a strict SUBSET. Three diligent pages
-  // where only the first carried a tool_response scored 38%, with the 100% requested-range union
-  // sitting right there unreachable. Taking the max is the same accumulation argument I used to
-  // justify the reorder, applied consistently: neither list can un-read the other.
+  // *** SEC-F16: `ranges[]` IS NOT A LOWER BOUND ON WHAT WAS READ. *** It is a lower bound on what
+  // was REQUESTED: protocol-file-tracker.cjs pushes `limit: toolInputData.limit`, the caller's
+  // argument, never reconciled against what came back. Only `deliveredRanges` records delivery.
+  //
+  // I had briefly taken the MAX of the two, on the stated premise that both were lower bounds on
+  // reading and neither could un-read the other. The premise was false, so the max let a REQUEST
+  // outrank a MEASUREMENT and produced the worst output this module can produce:
+  //     Read(offset=1, limit=520) truncated by the harness at 166/520  ->  100%, "fully read"
+  // The positive-limit filter cannot catch it — a requested limit of 520 is finite and positive.
+  // That is this SD's founding defect, restored in full, by a fix for a milder ordering complaint.
+  //
+  // The complaint that motivated the max was real but SAFE: when only some calls carried a
+  // tool_response, deliveredRanges is a strict subset of ranges and coverage UNDER-reports. An
+  // under-report costs a spurious "re-read your contract"; an over-report ships an unread contract.
+  // For a gate whose entire job is proving a file was read, those are not trade-able. The right
+  // place to fix the under-report is the TRACKER (always write deliveredRanges), never a rule here
+  // that lets what someone asked for stand in for what they got.
   const denominator = deliveredTotal;
-  const measuredPct = unionPct(status.deliveredRanges, denominator);
-  const requestedPct = unionPct(status.ranges, denominator);
+  const hasDelivered = Array.isArray(status.deliveredRanges) && status.deliveredRanges.length > 0;
 
-  if (measuredPct !== null || requestedPct !== null) {
-    const pct = Math.max(measuredPct === null ? -1 : measuredPct, requestedPct === null ? -1 : requestedPct);
+  // Requested ranges are consulted ONLY when there is no delivery record at all — the legacy state
+  // shape written before deliveredRanges existed. Never as a top-up when delivery looks incomplete.
+  const pct = hasDelivered
+    ? unionPct(status.deliveredRanges, denominator)
+    : unionPct(status.ranges, denominator);
+
+  if (pct !== null) {
     return {
       read: true,
       fully_read: pct >= FULL_COVERAGE_PCT,
       coverage_pct: pct,
-      basis: measuredPct !== null && measuredPct >= (requestedPct === null ? -1 : requestedPct)
-        ? 'delivered_ranges'
-        : 'union_ranges',
+      basis: hasDelivered ? 'delivered_ranges' : 'union_ranges',
     };
   }
 

--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -143,10 +143,13 @@ function contractTokenCount(root, contractFile) {
  * with 256 single-byte fallback tokens, so the true floor is 1.0 B/token, and SECURITY measured
  * 32,000-byte payloads that encode to 32,000 tokens (28% over cap). A sample maximum is not a bound.
  *
- * *** THE PROXY WAS ALSO WRONG ABOUT A REAL FILE, WHICH IS HOW IT GOT CAUGHT. *** Measured:
- *   CLAUDE_COORDINATOR.md  25,587 B ->  6,197 tokens  (4.13 B/tok)
- *   CLAUDE_SOLOMON.md      67,501 B -> 15,965 tokens  (4.23 B/tok)  <-- FITS. Byte proxy said no.
- *   CLAUDE_ADAM.md        106,286 B -> 25,569 tokens  (4.16 B/tok)  <-- over by 569, not by 4x.
+ * *** THE PROXY WAS ALSO WRONG ABOUT A REAL FILE, WHICH IS HOW IT GOT CAUGHT. *** Measured on the
+ * FRAMED response (what Read actually delivers — see contractTokenCount). Only these figures appear
+ * here: an earlier draft of this docblock carried the RAW-file counts as well, and two tables of
+ * different numbers for the same thing is how the next reader picks the wrong one.
+ *   CLAUDE_COORDINATOR.md  25,587 B ->  6,591 tokens   <-- fits, with room to spare
+ *   CLAUDE_SOLOMON.md      67,501 B -> 17,390 tokens   <-- FITS. The byte proxy said no.
+ *   CLAUDE_ADAM.md        106,286 B -> 27,566 tokens   <-- over, but nothing like the 4x bytes imply.
  * Prose runs ~4.2 B/token, so a byte bound tuned for adversarial density disarms roles that can
  * already comply. Solomon was being told its contract was unreadable when it reads in one call.
  * There is no byte value that is both sound and useful: the only provably safe one is 25,000 B,
@@ -213,8 +216,11 @@ function unionPct(ranges, total) {
   // as a number yields NaN, and NaN >= 95 is false, so that bug would present as "no read ever
   // counts as full" rather than as a crash.
   const { covered } = unionRangeCoverage(usable, total);
-  const pct = Math.round((Number(covered) / total) * 100);
-  return Number.isFinite(pct) ? pct : null;
+  // EXACT, not rounded. Rounding BEFORE the threshold comparison quietly moved the bar from 95% to
+  // 94.5%: 493 of 520 lines is 94.81%, which rounds to 95 and passed. A threshold that the display
+  // format can move is not a threshold.
+  const exact = (Number(covered) / total) * 100;
+  return Number.isFinite(exact) ? exact : null;
 }
 
 /** Line count of a contract on disk, or null when it cannot be determined. */
@@ -250,6 +256,28 @@ function contractSizeBytes(root, contractFile) {
  * @returns {{read: boolean, fully_read: boolean, coverage_pct: number|null, basis: string}}
  */
 function contractReadVerdict(status, totalLines, opts = {}) {
+  /**
+   * *** THE INVARIANT. READ THIS BEFORE CHANGING ANY ORDERING BELOW. ***
+   *
+   * Four defects were found in this function across four review passes, and TWO of them were
+   * introduced by the fix for the previous one. Every single one was the same category error, not a
+   * logic error: the signals here carry three DIFFERENT KINDS OF BOUND, and nothing said which was
+   * which, so they got combined as though they were interchangeable.
+   *
+   *   deliveredRanges  LOWER bound on what was read   (measured — what each call returned)
+   *   ranges           UPPER bound on what was read   (requested — you can get less, never more)
+   *   lastDelivered    POINT SAMPLE of a single call  (bounds that call and nothing else)
+   *
+   * THE RULE THAT MAKES IT MECHANICAL:
+   *   - only a LOWER bound may set fully_read = true;
+   *   - an UPPER bound may only set fully_read = false (it can disprove completeness, never prove it);
+   *   - a POINT SAMPLE bounds only its own call, never the file.
+   *
+   * Checked against the history: SEC-F12 applied a requested-semantics default (falsy limit means
+   * to-EOF) to measured data. SEC-F13/F16 took the max of an upper bound and a lower bound, letting
+   * a request outrank a measurement. SEC-F8 used a point sample to answer a whole-file question.
+   * All four are excluded by the three lines above.
+   */
   if (!status || !(status.readCount > 0)) {
     return { read: false, fully_read: false, coverage_pct: null, basis: 'no_read_recorded' };
   }
@@ -318,17 +346,31 @@ function contractReadVerdict(status, totalLines, opts = {}) {
 
   // Requested ranges are consulted ONLY when there is no delivery record at all — the legacy state
   // shape written before deliveredRanges existed. Never as a top-up when delivery looks incomplete.
-  const pct = hasDelivered
-    ? unionPct(status.deliveredRanges, denominator)
-    : unionPct(status.ranges, denominator);
-
-  if (pct !== null) {
-    return {
-      read: true,
-      fully_read: pct >= FULL_COVERAGE_PCT,
-      coverage_pct: pct,
-      basis: hasDelivered ? 'delivered_ranges' : 'union_ranges',
-    };
+  if (hasDelivered) {
+    const pct = unionPct(status.deliveredRanges, denominator);
+    if (pct !== null) {
+      return { read: true, fully_read: pct >= FULL_COVERAGE_PCT, coverage_pct: Math.round(pct), basis: 'delivered_ranges' };
+    }
+  } else {
+    const pct = unionPct(status.ranges, denominator);
+    if (pct !== null) {
+      // *** SEC-F18 — AN UPPER BOUND CANNOT PROVE COMPLETENESS, ONLY DISPROVE IT. ***
+      // `ranges` records what was ASKED FOR. You cannot read more than you requested, but you can
+      // read less, so its union is an UPPER bound on coverage. These three legacy shapes are
+      // byte-identical to this code and only the last is a full read:
+      //     Read(offset=1, limit=520) truncated at 166      -> union 100%
+      //     3 pages requesting 200 each, each truncated     -> union 100%
+      //     3 pages genuinely paginated and delivered       -> union 100%
+      // So it is reported as evidence of INCOMPLETENESS when it falls short, and never as evidence
+      // of completeness when it does not. Under-reporting a legacy session costs one re-read;
+      // over-reporting ships an unread contract.
+      return {
+        read: true,
+        fully_read: false,
+        coverage_pct: Math.round(pct),
+        basis: pct >= FULL_COVERAGE_PCT ? 'requested_ranges_unconfirmed' : 'requested_ranges_incomplete',
+      };
+    }
   }
 
   // *** KNOWN RESIDUAL, STATED RATHER THAN LEFT IMPLICIT (SEC-F14). ***

--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -55,6 +55,40 @@ function loadUnionRangeCoverage() {
 const FULL_COVERAGE_PCT = 95;
 
 /**
+ * The ACTUAL harness limit: a Read returns at most this many TOKENS. Not a proxy for it.
+ */
+const SINGLE_READ_TOKEN_CAP = 25000;
+
+/**
+ * Lazily-loaded cl100k_base encoder, cached. Same lazy+guarded discipline as unionRangeCoverage
+ * above, and for the same reason: this module is imported by role-ACTIVATION paths that promise
+ * never to block. A tokenizer that cannot load degrades to "unmeasurable", never to "fits".
+ */
+let _encoder;
+let _encoderTried = false;
+function loadEncoder() {
+  if (_encoderTried) return _encoder;
+  _encoderTried = true;
+  try {
+    _encoder = require('tiktoken').get_encoding('cl100k_base');
+  } catch {
+    _encoder = null;
+  }
+  return _encoder;
+}
+
+/** Measured token length of a contract, or null when it cannot be determined. */
+function contractTokenCount(root, contractFile) {
+  try {
+    const enc = loadEncoder();
+    if (!enc) return null;
+    return enc.encode(fs.readFileSync(path.join(root, contractFile), 'utf8')).length;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * A contract this size or smaller is covered by a single Read, so a no-argument read of it is
  * genuinely complete and needs no further evidence.
  *
@@ -74,13 +108,54 @@ const FULL_COVERAGE_PCT = 95;
  * this module closes. A stated worst case that was never measured is the same shape as the field
  * name that does not match its implementation.
  *
- * RE-DERIVED FROM THE MEASUREMENT: 25,000 tokens x 1.32 bytes/token (the densest measured case) =
- * 33,000 bytes. Set to 32,000 for margin. The real contracts still land correctly —
- * CLAUDE_COORDINATOR.md ~25.5KB inside (19.4k tokens even at the worst measured density),
- * CLAUDE_SOLOMON.md ~67KB and CLAUDE_ADAM.md ~104KB outside and still required to prove coverage.
- * A regression test pins the bound in both directions so it cannot drift back on assertion alone.
+ * *** AND THE RE-DERIVATION WAS *ALSO* WRONG — IN BOTH DIRECTIONS. THIS IS THE THIRD ATTEMPT. ***
+ * I replaced the 50,000 with "25,000 tokens x 1.32 B/token = 33,000, set 32,000 for margin", calling
+ * 1.32 "the densest measured case". It was the densest case *I happened to sample*, presented as a
+ * worst case — the same error as the claim it replaced, one rung down. cl100k_base is byte-level BPE
+ * with 256 single-byte fallback tokens, so the true floor is 1.0 B/token, and SECURITY measured
+ * 32,000-byte payloads that encode to 32,000 tokens (28% over cap). A sample maximum is not a bound.
+ *
+ * *** THE PROXY WAS ALSO WRONG ABOUT A REAL FILE, WHICH IS HOW IT GOT CAUGHT. *** Measured:
+ *   CLAUDE_COORDINATOR.md  25,587 B ->  6,197 tokens  (4.13 B/tok)
+ *   CLAUDE_SOLOMON.md      67,501 B -> 15,965 tokens  (4.23 B/tok)  <-- FITS. Byte proxy said no.
+ *   CLAUDE_ADAM.md        106,286 B -> 25,569 tokens  (4.16 B/tok)  <-- over by 569, not by 4x.
+ * Prose runs ~4.2 B/token, so a byte bound tuned for adversarial density disarms roles that can
+ * already comply. Solomon was being told its contract was unreadable when it reads in one call.
+ * There is no byte value that is both sound and useful: the only provably safe one is 25,000 B,
+ * which would exclude the 6,197-token coordinator contract.
+ *
+ * SO THE PROXY IS RETIRED. singleReadFit() MEASURES tokens (the SD's own success criteria required
+ * "each token figure re-measured rather than inherited from a bytes derivation"). This constant
+ * survives ONLY as the degraded-mode fallback for when the tokenizer will not load, and is set to
+ * the one value that is provably sound at the 1.0 B/token floor. In that mode the coordinator
+ * contract reads as not-provably-fitting — the safe direction, and the correct one to fail toward.
  */
-const SINGLE_READ_SAFE_BYTES = 32000;
+const SINGLE_READ_SAFE_BYTES = 25000;
+
+/**
+ * Can this contract be read in ONE call? Measured, with an explicit "cannot tell".
+ *
+ * `fits: null` is a first-class answer and must never be coerced to true — an unmeasurable contract
+ * is exactly the case where promoting absence of evidence to compliance does the damage.
+ *
+ * @returns {{fits: boolean|null, tokens: number|null, bytes: number|null, basis: string}}
+ */
+function singleReadFit(root, contractFile) {
+  const rawBytes = contractSizeBytes(root, contractFile);
+  const bytes = Number.isFinite(Number(rawBytes)) && Number(rawBytes) > 0 ? Number(rawBytes) : null;
+  const rawTokens = contractTokenCount(root, contractFile);
+  const tokens = Number.isFinite(Number(rawTokens)) && Number(rawTokens) > 0 ? Number(rawTokens) : null;
+
+  if (tokens !== null) {
+    return { fits: tokens <= SINGLE_READ_TOKEN_CAP, tokens, bytes, basis: 'measured_tokens' };
+  }
+  if (bytes !== null) {
+    // Degraded mode: no tokenizer. Fall back to the provably-sound byte floor, never to the old
+    // tuned proxy, and say so in the basis rather than letting it read as a measurement.
+    return { fits: bytes <= SINGLE_READ_SAFE_BYTES, tokens: null, bytes, basis: 'conservative_bytes_no_tokenizer' };
+  }
+  return { fits: null, tokens: null, bytes: null, basis: 'unmeasurable' };
+}
 
 /** Line count of a contract on disk, or null when it cannot be determined. */
 function contractLineCount(root, contractFile) {
@@ -131,19 +206,36 @@ function contractReadVerdict(status, totalLines, opts = {}) {
   //    this module exists to close (a cheap proxy outranking the real signal), reintroduced one tier
   //    up by the fix for it. Found in SECURITY review; I reproduced it on the merged code before
   //    accepting the finding.
-  const deliveredContradicts = d
-    && Number.isFinite(Number(d.totalLines)) && Number.isFinite(Number(d.numLines))
-    && !(d.coveredWholeFile === true || Number(d.numLines) >= Number(d.totalLines));
+  //
+  //    SEC-F6: an explicit `coveredWholeFile: false` contradicts the size tier ON ITS OWN. The
+  //    original required BOTH line fields to be finite first, so a delivered record carrying only
+  //    that flag was silently overridden by the size inference it directly denies.
+  const deliveredContradicts = !!d && (
+    d.coveredWholeFile === false
+    || (Number.isFinite(Number(d.totalLines)) && Number.isFinite(Number(d.numLines))
+        && !(d.coveredWholeFile === true || Number(d.numLines) >= Number(d.totalLines)))
+  );
 
-  const bytes = Number(opts.sizeBytes);
-  if (!deliveredContradicts
-      && Number.isFinite(bytes) && bytes > 0 && bytes <= SINGLE_READ_SAFE_BYTES
-      && status.lastReadWasPartial !== true) {
+  // Prefer the MEASURED fit; fall back to the caller's byte figure only when no fit was supplied.
+  // `fits === null` (unmeasurable) deliberately does NOT enter the tier.
+  const fit = opts.singleReadFit;
+  const legacyBytes = Number(opts.sizeBytes);
+  const fitsInOneRead = fit
+    ? fit.fits === true
+    : (Number.isFinite(legacyBytes) && legacyBytes > 0 && legacyBytes <= SINGLE_READ_SAFE_BYTES);
+
+  if (!deliveredContradicts && fitsInOneRead && status.lastReadWasPartial !== true) {
     return { read: true, fully_read: true, coverage_pct: 100, basis: 'single_read_safe_size' };
   }
 
   // 1. Delivered evidence wins outright when present.
-  if (d && Number.isFinite(Number(d.totalLines)) && Number.isFinite(Number(d.numLines))) {
+  //
+  //    SEC-F2: totalLines MUST be > 0. Without it a degenerate 0-of-0 record satisfies `0 >= 0` and
+  //    certifies an over-cap contract as fully read through the tier documented as STRONGEST — and
+  //    protocol-file-tracker.cjs writes exactly that shape (`coveredWholeFile: delivered >= total`,
+  //    guarded only on Number.isFinite, which 0/0 passes). One degenerate harness response would
+  //    have permanently green-lit CLAUDE_ADAM.md for the session.
+  if (d && Number.isFinite(Number(d.totalLines)) && Number(d.totalLines) > 0 && Number.isFinite(Number(d.numLines))) {
     const covered = d.coveredWholeFile === true || Number(d.numLines) >= Number(d.totalLines);
     return {
       read: true,
@@ -178,4 +270,7 @@ function contractReadVerdict(status, totalLines, opts = {}) {
   return { read: true, fully_read: false, coverage_pct: null, basis: 'unknown_coverage' };
 }
 
-module.exports = { contractReadVerdict, contractLineCount, contractSizeBytes, FULL_COVERAGE_PCT, SINGLE_READ_SAFE_BYTES };
+module.exports = {
+  contractReadVerdict, contractLineCount, contractSizeBytes, contractTokenCount, singleReadFit,
+  FULL_COVERAGE_PCT, SINGLE_READ_SAFE_BYTES, SINGLE_READ_TOKEN_CAP,
+};

--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -78,15 +78,39 @@ function loadEncoder() {
 }
 
 /**
- * Usable token budget: the cap minus a margin for two irreducible sources of error.
+ * *** CALIBRATION AGAINST HARNESS GROUND TRUTH. THE MISSING PIECE THAT MADE THIS GATE WRONG. ***
  *
- * 1. cl100k_base is GPT-4's tokenizer; the 25k cap is a Claude Code limit. Close, not identical,
- *    and nothing in this repo can measure the real one.
- * 2. Even measuring the framed response cannot capture every byte of harness envelope.
+ * cl100k_base is GPT-4's tokenizer; the 25k cap is a CLAUDE limit. I knew that, called it an
+ * "irreducible source of error", covered it with a 10% margin, and shipped. The margin was not the
+ * problem — the ASSUMPTION that the two tokenizers were close was, and I never tested it. They are
+ * not close: cl100k UNDERCOUNTS by ~1.79x.
  *
- * A margin is what keeps a verdict from resting inside its own error bar. At 10% the real contracts
- * still land unambiguously (coordinator ~6.6k, solomon ~17.4k, adam ~27.6k against a 22,500 budget),
- * so no role's verdict is decided by the margin — which is the property that matters.
+ * MEASURED, not assumed. A no-argument Read of CLAUDE_SOLOMON.md returns:
+ *     "PARTIAL view — showing lines 1-301 of 371 total (26142 tokens, cap 25000)"
+ * cl100k on that exact framed slice is 14,617. 26,142 / 14,617 = 1.788.
+ *
+ * WHAT THAT COST: the uncalibrated figure said CLAUDE_SOLOMON.md was 17,390 tokens and therefore
+ * FIT in one read, so this SD ARMED Solomon and I reported "the byte proxy was disarming a role that
+ * already complies" as its headline finding. Calibrated, it is ~31,101 — over the cap, and the Read
+ * above truncates at line 301 of 371. The whole chain was right in method and wrong in instrument:
+ * I replaced a byte proxy with a token proxy and never validated the token proxy against the thing
+ * it proxies. Measuring the wrong quantity precisely is still measuring the wrong quantity — the
+ * same error as the byte bound, one level up, for the third time in this SD.
+ *
+ * Rounded UP from 1.788 to 1.85: a calibration that undercounts re-creates the exact defect. The
+ * ratio is a property of two tokenizers on prose, so it should be re-measured if the contracts stop
+ * being prose (see the density discussion above) or if the harness tokenizer changes.
+ */
+const CL100K_TO_HARNESS = 1.85;
+
+/**
+ * Margin on top of the calibration, for what calibration cannot capture: harness envelope beyond the
+ * cat -n framing, and drift in the ratio across content types.
+ *
+ * Calibrated figures for the real contracts — coordinator ~12.2k, solomon ~32.2k, adam ~51.0k
+ * against a 22,500 budget — leave every verdict decided by a wide margin rather than by this number,
+ * which is the only thing that makes it honest. (The pre-calibration version of this comment made
+ * the same claim on figures that were 1.79x low, and was wrong about Solomon.)
  */
 const SINGLE_READ_MARGIN = 0.10;
 const SINGLE_READ_TOKEN_BUDGET = Math.floor(SINGLE_READ_TOKEN_CAP * (1 - SINGLE_READ_MARGIN));
@@ -110,7 +134,9 @@ function contractTokenCount(root, contractFile) {
     if (!enc) return null;
     const raw = fs.readFileSync(path.join(root, contractFile), 'utf8');
     const framed = raw.split('\n').map((line, i) => `${String(i + 1).padStart(6)}\t${line}`).join('\n');
-    return enc.encode_ordinary(framed).length;
+    // CALIBRATED to the harness tokenizer. Returning the raw cl100k count here is what armed a role
+    // whose contract demonstrably truncates — see CL100K_TO_HARNESS.
+    return Math.ceil(enc.encode_ordinary(framed).length * CL100K_TO_HARNESS);
   } catch {
     return null;
   }
@@ -143,13 +169,13 @@ function contractTokenCount(root, contractFile) {
  * with 256 single-byte fallback tokens, so the true floor is 1.0 B/token, and SECURITY measured
  * 32,000-byte payloads that encode to 32,000 tokens (28% over cap). A sample maximum is not a bound.
  *
- * *** THE PROXY WAS ALSO WRONG ABOUT A REAL FILE, WHICH IS HOW IT GOT CAUGHT. *** Measured on the
- * FRAMED response (what Read actually delivers — see contractTokenCount). Only these figures appear
- * here: an earlier draft of this docblock carried the RAW-file counts as well, and two tables of
- * different numbers for the same thing is how the next reader picks the wrong one.
- *   CLAUDE_COORDINATOR.md  25,587 B ->  6,591 tokens   <-- fits, with room to spare
- *   CLAUDE_SOLOMON.md      67,501 B -> 17,390 tokens   <-- FITS. The byte proxy said no.
- *   CLAUDE_ADAM.md        106,286 B -> 27,566 tokens   <-- over, but nothing like the 4x bytes imply.
+ * *** THE PROXY WAS ALSO WRONG ABOUT A REAL FILE. *** Measured on the
+ * FRAMED response AND CALIBRATED to the harness tokenizer (see CL100K_TO_HARNESS). Only these
+ * figures appear here: earlier drafts carried raw-file counts, then uncalibrated framed counts, and
+ * several tables of different numbers for one thing is how the next reader picks the wrong one.
+ *   CLAUDE_COORDINATOR.md  25,587 B -> ~12,193 tokens   <-- fits, with room to spare
+ *   CLAUDE_SOLOMON.md      67,501 B -> ~32,172 tokens   <-- does NOT fit; a no-arg Read truncates
+ *   CLAUDE_ADAM.md        106,286 B -> ~50,997 tokens   <-- over, by a wide margin
  * Prose runs ~4.2 B/token, so a byte bound tuned for adversarial density disarms roles that can
  * already comply. Solomon was being told its contract was unreadable when it reads in one call.
  * There is no byte value that is both sound and useful: the only provably safe one is 25,000 B,

--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -26,9 +26,30 @@
 const path = require('path');
 const fs = require('fs');
 
-// require(esm) — stable since Node 22.12; this fleet runs 24. Verified this file has no top-level
-// await, which is the one thing that would make it throw ERR_REQUIRE_ASYNC_MODULE.
-const { unionRangeCoverage } = require('../../scripts/modules/sd-key-generator.js');
+/**
+ * unionRangeCoverage, loaded LAZILY and inside a try.
+ *
+ * *** IT WAS A TOP-LEVEL require AND THAT PULLED A SUPABASE SERVICE-ROLE CLIENT INTO A FAIL-OPEN
+ * PATH. *** Both registers require this module at load time, and their own docblocks promise that
+ * registration must never be blocked. Importing sd-key-generator.js for ONE pure helper transitively
+ * ran dotenv.config() and a live Supabase client factory as import side effects — SECURITY confirmed
+ * empirically with `env -i`: process.env went from 4 keys to 78, including SUPABASE_SERVICE_ROLE_KEY.
+ * It does not throw today, but a fail-open-critical path had acquired a hard dependency on an
+ * unrelated, actively-edited module graph, and a throw at import time cannot be caught by the
+ * try/catch inside checkContractRead.
+ *
+ * Deferring it means the only tier that needs it pays for it, inside a guard, and a failure there
+ * degrades to unknown_coverage rather than taking down role activation.
+ */
+function loadUnionRangeCoverage() {
+  try {
+    // require(esm) — stable since Node 22.12; this fleet runs 24. Verified no top-level await, the
+    // one thing that would throw ERR_REQUIRE_ASYNC_MODULE.
+    return require('../../scripts/modules/sd-key-generator.js').unionRangeCoverage;
+  } catch {
+    return null;
+  }
+}
 
 /** Coverage at or above this counts as a full read. Matches the imported implementation's own bar. */
 const FULL_COVERAGE_PCT = 95;
@@ -44,12 +65,22 @@ const FULL_COVERAGE_PCT = 95;
  * and a warning that always fires gets demoted to noise — which is precisely the failure this SD
  * exists to remove. Trading a false positive for a false negative is not a fix.
  *
- * 50,000 bytes is deliberately conservative: the Read cap is 25k TOKENS, so this assumes a worst case
- * of 2 bytes per token, below any real tokenizer's ratio. Measured against the actual contracts —
- * CLAUDE_COORDINATOR.md ~25.5KB (safely inside), CLAUDE_SOLOMON.md ~67KB and CLAUDE_ADAM.md ~104KB
- * (both outside, both correctly required to prove coverage).
+ * *** THE ORIGINAL 50,000 WAS JUSTIFIED BY A CLAIM THAT TURNED OUT TO BE FALSE. *** I wrote that
+ * 2 bytes/token is "below any real tokenizer's ratio". SECURITY measured it with tiktoken
+ * (cl100k_base) on 50,000-byte samples and it is not: random ASCII ~1.32 B/token (38,024 tokens, 52%
+ * OVER the 25k cap), base64 ~1.40 (35,855, 43% over), hex/minified ~1.77 (28,194, over). Only prose
+ * (~5.4) and dense CJK (~2.44) stayed under. So a 50KB contract that later gains a base64 or
+ * minified blob could cross the real cap and still be waved through as fully read — the exact defect
+ * this module closes. A stated worst case that was never measured is the same shape as the field
+ * name that does not match its implementation.
+ *
+ * RE-DERIVED FROM THE MEASUREMENT: 25,000 tokens x 1.32 bytes/token (the densest measured case) =
+ * 33,000 bytes. Set to 32,000 for margin. The real contracts still land correctly —
+ * CLAUDE_COORDINATOR.md ~25.5KB inside (19.4k tokens even at the worst measured density),
+ * CLAUDE_SOLOMON.md ~67KB and CLAUDE_ADAM.md ~104KB outside and still required to prove coverage.
+ * A regression test pins the bound in both directions so it cannot drift back on assertion alone.
  */
-const SINGLE_READ_SAFE_BYTES = 50000;
+const SINGLE_READ_SAFE_BYTES = 32000;
 
 /** Line count of a contract on disk, or null when it cannot be determined. */
 function contractLineCount(root, contractFile) {
@@ -88,16 +119,30 @@ function contractReadVerdict(status, totalLines, opts = {}) {
     return { read: false, fully_read: false, coverage_pct: null, basis: 'no_read_recorded' };
   }
 
+  const d = status.lastDelivered;
+
   // 0. A contract that fits in a single Read cannot have been silently truncated, so the absence of
-  //    a partial flag IS sufficient evidence here. Checked first because it is the only tier where
-  //    "no evidence of partiality" legitimately means "complete".
+  //    a partial flag is sufficient evidence here.
+  //
+  //    *** BUT IT DEFERS TO CONTRADICTING DELIVERED EVIDENCE, AND THAT GUARD IS THE WHOLE POINT. ***
+  //    This tier originally ran unconditionally first, so a 40KB contract whose OWN lastDelivered
+  //    recorded 100 of 500 lines returned fully_read=true on basis 'single_read_safe_size' — a size
+  //    INFERENCE overriding a direct MEASUREMENT that contradicted it. That is exactly the defect
+  //    this module exists to close (a cheap proxy outranking the real signal), reintroduced one tier
+  //    up by the fix for it. Found in SECURITY review; I reproduced it on the merged code before
+  //    accepting the finding.
+  const deliveredContradicts = d
+    && Number.isFinite(Number(d.totalLines)) && Number.isFinite(Number(d.numLines))
+    && !(d.coveredWholeFile === true || Number(d.numLines) >= Number(d.totalLines));
+
   const bytes = Number(opts.sizeBytes);
-  if (Number.isFinite(bytes) && bytes > 0 && bytes <= SINGLE_READ_SAFE_BYTES && status.lastReadWasPartial !== true) {
+  if (!deliveredContradicts
+      && Number.isFinite(bytes) && bytes > 0 && bytes <= SINGLE_READ_SAFE_BYTES
+      && status.lastReadWasPartial !== true) {
     return { read: true, fully_read: true, coverage_pct: 100, basis: 'single_read_safe_size' };
   }
 
   // 1. Delivered evidence wins outright when present.
-  const d = status.lastDelivered;
   if (d && Number.isFinite(Number(d.totalLines)) && Number.isFinite(Number(d.numLines))) {
     const covered = d.coveredWholeFile === true || Number(d.numLines) >= Number(d.totalLines);
     return {
@@ -114,6 +159,11 @@ function contractReadVerdict(status, totalLines, opts = {}) {
     // treating the object as a number yields NaN, and NaN >= 95 is false, so the bug would have
     // presented as "no read ever counts as full" rather than as a crash. Caught by the diligent-
     // reader test on its first run, which is the case that assertion exists for.
+    const unionRangeCoverage = loadUnionRangeCoverage();
+    // Unavailable => unknown, never "complete". Same rule as every other tier here.
+    if (typeof unionRangeCoverage !== 'function') {
+      return { read: true, fully_read: false, coverage_pct: null, basis: 'unknown_coverage' };
+    }
     const { covered } = unionRangeCoverage(status.ranges, totalLines);
     const pct = Math.round((Number(covered) / totalLines) * 100);
     if (!Number.isFinite(pct)) return { read: true, fully_read: false, coverage_pct: null, basis: 'unknown_coverage' };

--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -77,12 +77,40 @@ function loadEncoder() {
   return _encoder;
 }
 
-/** Measured token length of a contract, or null when it cannot be determined. */
+/**
+ * Usable token budget: the cap minus a margin for two irreducible sources of error.
+ *
+ * 1. cl100k_base is GPT-4's tokenizer; the 25k cap is a Claude Code limit. Close, not identical,
+ *    and nothing in this repo can measure the real one.
+ * 2. Even measuring the framed response cannot capture every byte of harness envelope.
+ *
+ * A margin is what keeps a verdict from resting inside its own error bar. At 10% the real contracts
+ * still land unambiguously (coordinator ~6.6k, solomon ~17.4k, adam ~27.6k against a 22,500 budget),
+ * so no role's verdict is decided by the margin — which is the property that matters.
+ */
+const SINGLE_READ_MARGIN = 0.10;
+const SINGLE_READ_TOKEN_BUDGET = Math.floor(SINGLE_READ_TOKEN_CAP * (1 - SINGLE_READ_MARGIN));
+
+/**
+ * Measured token length of a contract AS THE READ TOOL WOULD DELIVER IT, or null.
+ *
+ * *** MEASURES THE FRAMED RESPONSE, NOT THE RAW FILE. *** Read returns `cat -n` formatted output, so
+ * every line carries a number and a tab that count against the cap. Encoding the raw bytes
+ * understates the real cost by ~400-2,000 tokens on these contracts — measuring the wrong artefact
+ * is how the byte proxy went wrong in the first place, one level down.
+ *
+ * encode_ordinary, NOT encode: cl100k_base's `encode` THROWS on special-token literals such as
+ * <|endoftext|>, including inline in prose. A contract that merely documents one would have thrown,
+ * degraded to the byte fallback, and silently flipped CLAUDE_COORDINATOR.md from ARMED to disarmed
+ * on the strength of a documentation string. encode_ordinary treats them as ordinary text.
+ */
 function contractTokenCount(root, contractFile) {
   try {
     const enc = loadEncoder();
     if (!enc) return null;
-    return enc.encode(fs.readFileSync(path.join(root, contractFile), 'utf8')).length;
+    const raw = fs.readFileSync(path.join(root, contractFile), 'utf8');
+    const framed = raw.split('\n').map((line, i) => `${String(i + 1).padStart(6)}\t${line}`).join('\n');
+    return enc.encode_ordinary(framed).length;
   } catch {
     return null;
   }
@@ -147,7 +175,7 @@ function singleReadFit(root, contractFile) {
   const tokens = Number.isFinite(Number(rawTokens)) && Number(rawTokens) > 0 ? Number(rawTokens) : null;
 
   if (tokens !== null) {
-    return { fits: tokens <= SINGLE_READ_TOKEN_CAP, tokens, bytes, basis: 'measured_tokens' };
+    return { fits: tokens <= SINGLE_READ_TOKEN_BUDGET, tokens, bytes, basis: 'measured_tokens' };
   }
   if (bytes !== null) {
     // Degraded mode: no tokenizer. Fall back to the provably-sound byte floor, never to the old
@@ -228,24 +256,45 @@ function contractReadVerdict(status, totalLines, opts = {}) {
     return { read: true, fully_read: true, coverage_pct: 100, basis: 'single_read_safe_size' };
   }
 
-  // 1. Delivered evidence wins outright when present.
+  // The denominator. Prefer the harness's own totalLines over a count of the file on disk: it
+  // describes the artefact that was actually served.
+  const deliveredTotal = d && Number.isFinite(Number(d.totalLines)) && Number(d.totalLines) > 0
+    ? Number(d.totalLines)
+    : (Number.isFinite(totalLines) && totalLines > 0 ? totalLines : null);
+
+  // 1. UNION OF WHAT EVERY CALL ACTUALLY DELIVERED. The strongest signal there is, and the only one
+  //    that is correct for BOTH failure modes at once.
   //
-  //    SEC-F2: totalLines MUST be > 0. Without it a degenerate 0-of-0 record satisfies `0 >= 0` and
-  //    certifies an over-cap contract as fully read through the tier documented as STRONGEST — and
-  //    protocol-file-tracker.cjs writes exactly that shape (`coveredWholeFile: delivered >= total`,
-  //    guarded only on Number.isFinite, which 0/0 passes). One degenerate harness response would
-  //    have permanently green-lit CLAUDE_ADAM.md for the session.
-  if (d && Number.isFinite(Number(d.totalLines)) && Number(d.totalLines) > 0 && Number.isFinite(Number(d.numLines))) {
-    const covered = d.coveredWholeFile === true || Number(d.numLines) >= Number(d.totalLines);
-    return {
-      read: true,
-      fully_read: covered,
-      coverage_pct: Number(d.totalLines) > 0 ? Math.round((Number(d.numLines) / Number(d.totalLines)) * 100) : null,
-      basis: 'delivered_lines'
-    };
+  //    *** THIS TIER EXISTS BECAUSE THE PREVIOUS ORDERING PUNISHED THE DILIGENT READER AGAIN — THE
+  //    EXACT DEFECT THIS MODULE WAS WRITTEN TO REMOVE, RELOCATED ONE FIELD OVER. *** The header above
+  //    tells the story of `lastReadWasPartial` being a fact about ONE call used to answer a whole-file
+  //    question. `lastDelivered` is also a fact about one call. protocol-file-tracker.cjs writes it
+  //    UNCONDITIONALLY, after both the partial and full branches, so a paginated read carries both
+  //    ranges[] AND a lastDelivered describing only its final page. The old tier 1 returned on that
+  //    unconditionally, so the union tier below was unreachable for real tracker state:
+  //      CLAUDE_ADAM.md read diligently in 3 pages covering 100%  ->  reported 23%, "not fully read"
+  //      the LAZY truncated single read                           ->  reported 32%, i.e. BETTER
+  //    Found by SECURITY on re-review. The test that "proved" the diligent case passed only because
+  //    it supplied ranges WITHOUT lastDelivered — a shape the real tracker never produces. A fixture
+  //    that cannot occur in production is not evidence about production.
+  //
+  //    deliveredRanges is the right signal precisely because it is per-call MEASURED delivery:
+  //    it credits the paginated reader (pages union to the whole file) and still catches the
+  //    silently-truncated no-argument read (one short range, nowhere near the total).
+  if (Array.isArray(status.deliveredRanges) && status.deliveredRanges.length > 0 && deliveredTotal) {
+    const unionRangeCoverage = loadUnionRangeCoverage();
+    if (typeof unionRangeCoverage === 'function') {
+      const { covered } = unionRangeCoverage(status.deliveredRanges, deliveredTotal);
+      const pct = Math.round((Number(covered) / deliveredTotal) * 100);
+      if (Number.isFinite(pct)) {
+        return { read: true, fully_read: pct >= FULL_COVERAGE_PCT, coverage_pct: pct, basis: 'delivered_ranges' };
+      }
+    }
   }
 
-  // 2. Union coverage across recorded ranges.
+  // 2. Union coverage across REQUESTED ranges. Ranked above the single-call delivered fact for the
+  //    same reason: whole-file evidence beats one call. Reached for state written before
+  //    deliveredRanges existed.
   if (Array.isArray(status.ranges) && status.ranges.length > 0 && Number.isFinite(totalLines) && totalLines > 0) {
     // unionRangeCoverage returns { covered, uncovered } — NOT a bare number. Destructuring matters:
     // treating the object as a number yields NaN, and NaN >= 95 is false, so the bug would have
@@ -262,7 +311,25 @@ function contractReadVerdict(status, totalLines, opts = {}) {
     return { read: true, fully_read: pct >= FULL_COVERAGE_PCT, coverage_pct: pct, basis: 'union_ranges' };
   }
 
-  // 3. A read happened and we cannot say how much of the file it covered.
+  // 3. A single delivered record, with no range evidence at all. This is the lone truncated
+  //    no-argument read: it sets no limit/offset, so it never enters ranges[], and on older state
+  //    shapes it leaves no deliveredRanges either. Kept LAST because it can only ever describe one
+  //    call — ranked above anything only when there is nothing better.
+  //
+  //    SEC-F2: totalLines MUST be > 0. Without it a degenerate 0-of-0 record satisfies `0 >= 0` and
+  //    certifies a read as complete — and the tracker writes exactly that shape
+  //    (`coveredWholeFile: delivered >= total`, guarded only on Number.isFinite, which 0/0 passes).
+  if (d && Number.isFinite(Number(d.totalLines)) && Number(d.totalLines) > 0 && Number.isFinite(Number(d.numLines))) {
+    const covered = d.coveredWholeFile === true || Number(d.numLines) >= Number(d.totalLines);
+    return {
+      read: true,
+      fully_read: covered,
+      coverage_pct: Math.round((Number(d.numLines) / Number(d.totalLines)) * 100),
+      basis: 'delivered_lines'
+    };
+  }
+
+  // 4. A read happened and we cannot say how much of the file it covered.
   //
   // NOT TREATED AS FULL, AND THAT IS THE WHOLE POINT. The old code reached exactly this state and
   // answered "fully read" whenever the last call carried no limit/offset — which is precisely the
@@ -272,5 +339,5 @@ function contractReadVerdict(status, totalLines, opts = {}) {
 
 module.exports = {
   contractReadVerdict, contractLineCount, contractSizeBytes, contractTokenCount, singleReadFit,
-  FULL_COVERAGE_PCT, SINGLE_READ_SAFE_BYTES, SINGLE_READ_TOKEN_CAP,
+  FULL_COVERAGE_PCT, SINGLE_READ_SAFE_BYTES, SINGLE_READ_TOKEN_CAP, SINGLE_READ_TOKEN_BUDGET,
 };

--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -157,11 +157,17 @@ function contractTokenCount(root, contractFile) {
  *
  * SO THE PROXY IS RETIRED. singleReadFit() MEASURES tokens (the SD's own success criteria required
  * "each token figure re-measured rather than inherited from a bytes derivation"). This constant
- * survives ONLY as the degraded-mode fallback for when the tokenizer will not load, and is set to
- * the one value that is provably sound at the 1.0 B/token floor. In that mode the coordinator
- * contract reads as not-provably-fitting — the safe direction, and the correct one to fail toward.
+ * survives ONLY as the degraded-mode fallback for when the tokenizer will not load.
+ *
+ * *** IT CARRIES THE SAME MARGIN AS THE MEASURED PATH, AND IT DID NOT USED TO. *** It was 25,000:
+ * provably sound at the 1.0 B/token floor, but sound against the CAP while every other decision in
+ * this module is made against the BUDGET. That made the fallback MORE PERMISSIVE THAN THE MEASURED
+ * PATH — 2,500 tokens more — i.e. the module was most generous exactly where it knew least. That is
+ * the inverse of the doctrine stated throughout it, and the same shape as every defect this SD has
+ * closed, sitting in the one path nobody had measured. Derived from the budget now, so degraded
+ * mode can never be looser than measured mode by construction rather than by coincidence.
  */
-const SINGLE_READ_SAFE_BYTES = 25000;
+const SINGLE_READ_SAFE_BYTES = SINGLE_READ_TOKEN_BUDGET; // 1.0 B/token floor => bytes and tokens coincide
 
 /**
  * Can this contract be read in ONE call? Measured, with an explicit "cannot tell".

--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -205,6 +205,20 @@ function singleReadFit(root, contractFile) {
  * it as coverage-to-EOF is the original defect again. Both lists therefore require an explicit
  * positive limit; anything else contributes no evidence rather than maximal evidence.
  */
+/**
+ * Report a coverage percentage. FLOOR, never round.
+ *
+ * A coverage gauge must never round UP: overstating how much of a file was read is the entire
+ * failure mode this module exists to prevent, and it should not sneak back in through a display
+ * format. Flooring also keeps the reported number from CONTRADICTING the verdict — with rounding,
+ * 493 of 520 lines is 94.81%, which the exact comparison correctly calls not-full while the display
+ * rounded it to "95%" against a 95% bar. A gauge that reads 95% beside "not fully read" invites the
+ * reader to assume the verdict is the broken half.
+ */
+function reportPct(exact) {
+  return Math.floor(exact);
+}
+
 function unionPct(ranges, total) {
   if (!Array.isArray(ranges) || ranges.length === 0 || !Number.isFinite(total) || total <= 0) return null;
   const usable = ranges.filter((r) => r && Number.isFinite(Number(r.limit)) && Number(r.limit) > 0);
@@ -349,7 +363,7 @@ function contractReadVerdict(status, totalLines, opts = {}) {
   if (hasDelivered) {
     const pct = unionPct(status.deliveredRanges, denominator);
     if (pct !== null) {
-      return { read: true, fully_read: pct >= FULL_COVERAGE_PCT, coverage_pct: Math.round(pct), basis: 'delivered_ranges' };
+      return { read: true, fully_read: pct >= FULL_COVERAGE_PCT, coverage_pct: reportPct(pct), basis: 'delivered_ranges' };
     }
   } else {
     const pct = unionPct(status.ranges, denominator);
@@ -367,7 +381,7 @@ function contractReadVerdict(status, totalLines, opts = {}) {
       return {
         read: true,
         fully_read: false,
-        coverage_pct: Math.round(pct),
+        coverage_pct: reportPct(pct),
         basis: pct >= FULL_COVERAGE_PCT ? 'requested_ranges_unconfirmed' : 'requested_ranges_incomplete',
       };
     }
@@ -401,7 +415,7 @@ function contractReadVerdict(status, totalLines, opts = {}) {
     return {
       read: true,
       fully_read: covered,
-      coverage_pct: Math.round((Number(d.numLines) / Number(d.totalLines)) * 100),
+      coverage_pct: reportPct((Number(d.numLines) / Number(d.totalLines)) * 100),
       basis: 'delivered_lines'
     };
   }

--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -185,6 +185,38 @@ function singleReadFit(root, contractFile) {
   return { fits: null, tokens: null, bytes: null, basis: 'unmeasurable' };
 }
 
+/**
+ * Union coverage of a range list as a percentage, or null when it yields no usable evidence.
+ *
+ * *** SEC-F12 — THE IMPORTED HELPER'S EOF DEFAULT IS INVERTED FOR MEASURED RANGES, AND I SHIPPED
+ * THAT AS A REGRESSION. *** unionRangeCoverage does `Number(r.limit) || (totalLines - from + 1)`,
+ * i.e. a falsy limit means "to end of file". That is RIGHT for a REQUESTED range — `Read(offset=1)`
+ * genuinely does ask for the rest — and exactly BACKWARDS for a DELIVERED one, where `limit` is the
+ * measured line count and 0 means nothing came back. So `deliveredRanges: [{offset:1, limit:0}]`
+ * unioned to 100% and returned fully_read=true: a read that delivered NOTHING certified as complete,
+ * through the tier I had just promoted to strongest. Reachable from the canonical writer, which
+ * guards only on Number.isFinite — and both Number(0) and Number(null) are finite.
+ *
+ * SEC-F15, same root cause on the other list: an open-ended requested range (`{offset:1, limit:null}`
+ * from `Read(path, offset=1)`) is precisely the call the harness can silently truncate, so counting
+ * it as coverage-to-EOF is the original defect again. Both lists therefore require an explicit
+ * positive limit; anything else contributes no evidence rather than maximal evidence.
+ */
+function unionPct(ranges, total) {
+  if (!Array.isArray(ranges) || ranges.length === 0 || !Number.isFinite(total) || total <= 0) return null;
+  const usable = ranges.filter((r) => r && Number.isFinite(Number(r.limit)) && Number(r.limit) > 0);
+  if (usable.length === 0) return null;
+  const unionRangeCoverage = loadUnionRangeCoverage();
+  // Unavailable => unknown, never "complete". Same rule as every other tier here.
+  if (typeof unionRangeCoverage !== 'function') return null;
+  // Returns { covered, uncovered } — NOT a bare number. Destructuring matters: treating the object
+  // as a number yields NaN, and NaN >= 95 is false, so that bug would present as "no read ever
+  // counts as full" rather than as a crash.
+  const { covered } = unionRangeCoverage(usable, total);
+  const pct = Math.round((Number(covered) / total) * 100);
+  return Number.isFinite(pct) ? pct : null;
+}
+
 /** Line count of a contract on disk, or null when it cannot be determined. */
 function contractLineCount(root, contractFile) {
   try {
@@ -262,56 +294,48 @@ function contractReadVerdict(status, totalLines, opts = {}) {
     ? Number(d.totalLines)
     : (Number.isFinite(totalLines) && totalLines > 0 ? totalLines : null);
 
-  // 1. UNION OF WHAT EVERY CALL ACTUALLY DELIVERED. The strongest signal there is, and the only one
-  //    that is correct for BOTH failure modes at once.
+  // Both range lists are LOWER BOUNDS on what was read, so the answer is the better of the two.
   //
-  //    *** THIS TIER EXISTS BECAUSE THE PREVIOUS ORDERING PUNISHED THE DILIGENT READER AGAIN — THE
-  //    EXACT DEFECT THIS MODULE WAS WRITTEN TO REMOVE, RELOCATED ONE FIELD OVER. *** The header above
-  //    tells the story of `lastReadWasPartial` being a fact about ONE call used to answer a whole-file
-  //    question. `lastDelivered` is also a fact about one call. protocol-file-tracker.cjs writes it
-  //    UNCONDITIONALLY, after both the partial and full branches, so a paginated read carries both
-  //    ranges[] AND a lastDelivered describing only its final page. The old tier 1 returned on that
-  //    unconditionally, so the union tier below was unreachable for real tracker state:
-  //      CLAUDE_ADAM.md read diligently in 3 pages covering 100%  ->  reported 23%, "not fully read"
-  //      the LAZY truncated single read                           ->  reported 32%, i.e. BETTER
-  //    Found by SECURITY on re-review. The test that "proved" the diligent case passed only because
-  //    it supplied ranges WITHOUT lastDelivered — a shape the real tracker never produces. A fixture
-  //    that cannot occur in production is not evidence about production.
-  //
-  //    deliveredRanges is the right signal precisely because it is per-call MEASURED delivery:
-  //    it credits the paginated reader (pages union to the whole file) and still catches the
-  //    silently-truncated no-argument read (one short range, nowhere near the total).
-  if (Array.isArray(status.deliveredRanges) && status.deliveredRanges.length > 0 && deliveredTotal) {
-    const unionRangeCoverage = loadUnionRangeCoverage();
-    if (typeof unionRangeCoverage === 'function') {
-      const { covered } = unionRangeCoverage(status.deliveredRanges, deliveredTotal);
-      const pct = Math.round((Number(covered) / deliveredTotal) * 100);
-      if (Number.isFinite(pct)) {
-        return { read: true, fully_read: pct >= FULL_COVERAGE_PCT, coverage_pct: pct, basis: 'delivered_ranges' };
-      }
-    }
+  // *** SEC-F13: RANKING THEM BY TIER POSITION CONTRADICTED THE PRINCIPLE THEY WERE RANKED BY. ***
+  // I ordered deliveredRanges above ranges "by how much of the FILE each signal describes", then
+  // implemented it as a fixed precedence that returns on the first non-empty list. The two lists are
+  // written under DIFFERENT conditions — ranges.push is guarded by isPartialRead, deliveredRanges.push
+  // by the presence of tool_response — so deliveredRanges can be a strict SUBSET. Three diligent pages
+  // where only the first carried a tool_response scored 38%, with the 100% requested-range union
+  // sitting right there unreachable. Taking the max is the same accumulation argument I used to
+  // justify the reorder, applied consistently: neither list can un-read the other.
+  const denominator = deliveredTotal;
+  const measuredPct = unionPct(status.deliveredRanges, denominator);
+  const requestedPct = unionPct(status.ranges, denominator);
+
+  if (measuredPct !== null || requestedPct !== null) {
+    const pct = Math.max(measuredPct === null ? -1 : measuredPct, requestedPct === null ? -1 : requestedPct);
+    return {
+      read: true,
+      fully_read: pct >= FULL_COVERAGE_PCT,
+      coverage_pct: pct,
+      basis: measuredPct !== null && measuredPct >= (requestedPct === null ? -1 : requestedPct)
+        ? 'delivered_ranges'
+        : 'union_ranges',
+    };
   }
 
-  // 2. Union coverage across REQUESTED ranges. Ranked above the single-call delivered fact for the
-  //    same reason: whole-file evidence beats one call. Reached for state written before
-  //    deliveredRanges existed.
-  if (Array.isArray(status.ranges) && status.ranges.length > 0 && Number.isFinite(totalLines) && totalLines > 0) {
-    // unionRangeCoverage returns { covered, uncovered } — NOT a bare number. Destructuring matters:
-    // treating the object as a number yields NaN, and NaN >= 95 is false, so the bug would have
-    // presented as "no read ever counts as full" rather than as a crash. Caught by the diligent-
-    // reader test on its first run, which is the case that assertion exists for.
-    const unionRangeCoverage = loadUnionRangeCoverage();
-    // Unavailable => unknown, never "complete". Same rule as every other tier here.
-    if (typeof unionRangeCoverage !== 'function') {
-      return { read: true, fully_read: false, coverage_pct: null, basis: 'unknown_coverage' };
-    }
-    const { covered } = unionRangeCoverage(status.ranges, totalLines);
-    const pct = Math.round((Number(covered) / totalLines) * 100);
-    if (!Number.isFinite(pct)) return { read: true, fully_read: false, coverage_pct: null, basis: 'unknown_coverage' };
-    return { read: true, fully_read: pct >= FULL_COVERAGE_PCT, coverage_pct: pct, basis: 'union_ranges' };
-  }
-
-  // 3. A single delivered record, with no range evidence at all. This is the lone truncated
+  // *** KNOWN RESIDUAL, STATED RATHER THAN LEFT IMPLICIT (SEC-F14). ***
+  // Everything above accumulates coverage across a session, which is sound only while the FILE IS
+  // IMMUTABLE — and nothing enforces that. protocol-file-tracker.cjs stores no mtime, hash or size
+  // beside the ranges, and these contracts are GENERATED artefacts that CLAUDE.md prologue #7
+  // actively tells sessions to regenerate mid-session. Two reachable consequences:
+  //   - cross-version accumulation: v1 lines 1-260 + v2 lines 261-520 unions to 100%, though no
+  //     single version was ever fully read;
+  //   - stale denominator: deliveredTotal prefers the harness's totalLines, so a read taken when the
+  //     file was 300 lines still reports 100% after it grows to 520.
+  // NOT fixed here, and deliberately so: the correct fix stamps a file identity in the TRACKER and
+  // resets on change, which is a hot-path file this SD is under explicit instruction not to alter
+  // (FR-3), and a heuristic bolted on at the consumer — comparing disk line count to the recorded
+  // total — misfires on ordinary trailing-newline differences and would produce exactly the
+  // always-on warning this SD exists to eliminate. Recorded as a follow-up rather than guessed at.
+  //
+  // 2. A single delivered record, with no usable range evidence at all. This is the lone truncated
   //    no-argument read: it sets no limit/offset, so it never enters ranges[], and on older state
   //    shapes it leaves no deliveredRanges either. Kept LAST because it can only ever describe one
   //    call — ranked above anything only when there is nothing better.

--- a/scripts/adam-register.cjs
+++ b/scripts/adam-register.cjs
@@ -36,7 +36,7 @@ const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { resolveStateReadPath } = require('./hooks/lib/session-state-resolver.cjs');
 // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-3: shared with solomon-register.cjs so both roles
 // get the same verdict from one implementation — solomon had zero coverage for this path.
-const { contractReadVerdict, contractLineCount, contractSizeBytes, SINGLE_READ_SAFE_BYTES } = require('../lib/protocol/contract-read-coverage.cjs');
+const { contractReadVerdict, contractLineCount, singleReadFit } = require('../lib/protocol/contract-read-coverage.cjs');
 // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-C (FR-3): single-Adam guard + atomic write.
 // fetchAllAdamsStrict (not fetchFreshAdams) so the guard sees stale priors too and classifies
 // fresh-vs-stale itself (fresh => refuse; stale-only => retire). STRICT (FR-6, count-truncation
@@ -277,7 +277,7 @@ function checkContractRead(projectDir) {
       // paginated read recorded "partial". Coverage is now derived from evidence. Fixed HERE at the
       // consumer rather than in the tracker, because that stamp also feeds
       // protocol-file-read-gate.js:159 and therefore every handoff.
-      const verdict = contractReadVerdict(status, contractLineCount(root, CONTRACT_FILE), { sizeBytes: contractSizeBytes(root, CONTRACT_FILE) });
+      const verdict = contractReadVerdict(status, contractLineCount(root, CONTRACT_FILE), { singleReadFit: singleReadFit(root, CONTRACT_FILE) });
       result.contract_read = verdict.read;
       result.contract_read_partial = !verdict.fully_read;
       result.contract_coverage_pct = verdict.coverage_pct;
@@ -287,8 +287,9 @@ function checkContractRead(projectDir) {
       // Legacy pre-FR-2 state shape: a bare filename list carrying no coverage information at all.
       // Sufficient ONLY when the contract fits in a single Read. For an over-cap contract it cannot
       // distinguish a full read from a silently truncated one, which is the defect this SD closes.
-      const legacyBytes = contractSizeBytes(root, CONTRACT_FILE);
-      const legacyFits = Number.isFinite(legacyBytes) && legacyBytes > 0 && legacyBytes <= SINGLE_READ_SAFE_BYTES;
+      // Measured on TOKENS, not bytes: the byte proxy this replaced disarmed CLAUDE_SOLOMON.md
+      // (67,501 B but only 15,965 tokens) even though it reads in one call.
+      const legacyFits = singleReadFit(root, CONTRACT_FILE).fits === true;
       result.contract_read = true;
       result.contract_read_partial = !legacyFits;
       result.contract_read_basis = legacyFits ? 'legacy_array_single_read_safe' : 'legacy_array_no_evidence';

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -31,7 +31,7 @@ const { resolveStateReadPath } = _createRequireQF342(import.meta.url)('./hooks/l
 // really read" and ONE definition of the single-read bound, shared with adam-register.cjs and
 // solomon-register.cjs. Importing the bound rather than restating it is the difference between an
 // arming condition and an arming CLAIM — see roleArmingStates below.
-const { contractReadVerdict, contractLineCount, singleReadFit, SINGLE_READ_TOKEN_CAP } =
+const { contractReadVerdict, contractLineCount, singleReadFit, SINGLE_READ_TOKEN_BUDGET } =
   _createRequireQF342(import.meta.url)('../lib/protocol/contract-read-coverage.cjs');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -647,8 +647,11 @@ export function roleArmingStates(repoRoot = REPO_ROOT, fitter = null) {
   return ROLE_CONTRACTS.map(({ role, file, dependency }) => {
     let fit = null;
     try { fit = fitOf(file); } catch { fit = null; }
-    const tokens = fit && Number.isFinite(Number(fit.tokens)) ? Number(fit.tokens) : null;
-    const bytes = fit && Number.isFinite(Number(fit.bytes)) ? Number(fit.bytes) : null;
+    // SEC-F9: `Number(null)` is 0 and `Number.isFinite(0)` is true, so a null token count became 0
+    // and the banner printed "contract fits in one read (0 tokens ≤ 25000 cap)" in degraded mode,
+    // making the honest no-tokenizer message unreachable. Null-check BEFORE coercing.
+    const tokens = fit && fit.tokens != null && Number.isFinite(Number(fit.tokens)) ? Number(fit.tokens) : null;
+    const bytes = fit && fit.bytes != null && Number.isFinite(Number(fit.bytes)) ? Number(fit.bytes) : null;
 
     // Unmeasurable (including `fits: null`) => DISARMED. Absence of evidence is never promoted to
     // compliance; that promotion is the defect this whole SD exists to remove.
@@ -657,7 +660,7 @@ export function roleArmingStates(repoRoot = REPO_ROOT, fitter = null) {
         return { role, file, tokens, bytes, armed: false, reason: `${file} not measurable — cannot establish readability` };
       }
       const over = tokens !== null
-        ? `${tokens} tokens > ${SINGLE_READ_TOKEN_CAP} cap`
+        ? `${tokens} tokens > ${SINGLE_READ_TOKEN_BUDGET} budget`
         : `${bytes}B exceeds the no-tokenizer fallback bound`;
       return {
         role, file, tokens, bytes, armed: false,
@@ -667,7 +670,7 @@ export function roleArmingStates(repoRoot = REPO_ROOT, fitter = null) {
     return {
       role, file, tokens, bytes, armed: true,
       reason: tokens !== null
-        ? `contract fits in one read (${tokens} tokens ≤ ${SINGLE_READ_TOKEN_CAP} cap)`
+        ? `contract fits in one read (${tokens} tokens ≤ ${SINGLE_READ_TOKEN_BUDGET} budget)`
         : `contract fits in one read (${bytes}B, no tokenizer — conservative bound)`,
     };
   });

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -27,6 +27,12 @@ const { OPERATING_THRESHOLD_HOURS } = _createRequireQF342(import.meta.url)('../l
 // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-2: same resolver adam-register.cjs and the tracker
 // both use, so the coordinator check reads exactly the state the hook wrote — no second path.
 const { resolveStateReadPath } = _createRequireQF342(import.meta.url)('./hooks/lib/session-state-resolver.cjs');
+// SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-3 + FR-6: ONE implementation of "was this contract
+// really read" and ONE definition of the single-read bound, shared with adam-register.cjs and
+// solomon-register.cjs. Importing the bound rather than restating it is the difference between an
+// arming condition and an arming CLAIM — see roleArmingStates below.
+const { contractReadVerdict, contractLineCount, contractSizeBytes, SINGLE_READ_SAFE_BYTES } =
+  _createRequireQF342(import.meta.url)('../lib/protocol/contract-read-coverage.cjs');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '..');
@@ -551,11 +557,24 @@ export function checkCoordinatorContractRead(repoRoot = REPO_ROOT, stateReader =
     if (!state) return result;
     const status = state.protocolFileReadStatus && state.protocolFileReadStatus[COORDINATOR_CONTRACT_FILE];
     if (status && status.readCount > 0) {
-      result.contract_read = true;
-      result.contract_read_partial = status.lastReadWasPartial === true;
+      // Routed through the SHARED verdict rather than reading lastReadWasPartial directly. This
+      // contract fits in one call, so the old boolean was accurate for the common case — but a
+      // coordinator that paginated (e.g. via /read-full) would have been recorded PARTIAL for doing
+      // MORE work, which is the same inversion FR-3 removes for adam and solomon. One implementation,
+      // three roles; the size tier inside the verdict is what keeps this file's happy path green.
+      const verdict = contractReadVerdict(
+        status,
+        contractLineCount(repoRoot, COORDINATOR_CONTRACT_FILE),
+        { sizeBytes: contractSizeBytes(repoRoot, COORDINATOR_CONTRACT_FILE) }
+      );
+      result.contract_read = verdict.read;
+      result.contract_read_partial = !verdict.fully_read;
+      result.contract_coverage_pct = verdict.coverage_pct;
+      result.contract_read_basis = verdict.basis;
       result.contract_last_read_at = status.lastReadAt || null;
     } else if (Array.isArray(state.protocolFilesRead) && state.protocolFilesRead.includes(COORDINATOR_CONTRACT_FILE)) {
       result.contract_read = true; // legacy-array fallback, same as adam-register
+      result.contract_read_basis = 'legacy_array_single_read_safe';
     }
   } catch { /* fail-open: tracking unavailable must never break coordinator startup */ }
   return result;
@@ -571,6 +590,60 @@ function readCoordinatorSessionState(repoRoot) {
 }
 
 /**
+ * The three role contracts this gate reasons about, and the sibling SD that makes each one readable.
+ * Order is the render order.
+ */
+export const ROLE_CONTRACTS = Object.freeze([
+  Object.freeze({ role: 'coordinator', file: COORDINATOR_CONTRACT_FILE, dependency: null }),
+  Object.freeze({ role: 'adam', file: 'CLAUDE_ADAM.md', dependency: 'SD-LEO-INFRA-ADAM-CONTRACT-READABLE-001' }),
+  Object.freeze({ role: 'solomon', file: 'CLAUDE_SOLOMON.md', dependency: null }),
+]);
+
+/**
+ * SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-6 — ARMING IS A MEASUREMENT, NOT A SENTENCE.
+ *
+ * *** THIS REPLACED THREE HARDCODED STRINGS, AND THE STRINGS WERE CORRECT. *** That is exactly why
+ * they were dangerous. `adam : disarmed — CLAUDE_ADAM.md exceeds the read cap` was a true statement
+ * about 2026-07-31 pinned into source, and its test asserted the string. So the day
+ * SD-LEO-INFRA-ADAM-CONTRACT-READABLE-001 lands and CLAUDE_ADAM.md drops under the bound, the banner
+ * would still have printed "disarmed", the test would still have passed, and the newly-compliant role
+ * would have stayed dark with nothing anywhere reporting a discrepancy. A check whose verdict cannot
+ * change when the world changes is not a check — it is a comment with a test around it. The SD's own
+ * criterion is "encoded as a condition, not as prose", and the prose version met it only by coincidence.
+ *
+ * The dependency is read LIVE and at the only place it is actually observable: the contract's size on
+ * disk. Deliberately NOT a DB lookup of the sibling SD's status — this runs inside a fail-open startup
+ * path with no network, and more importantly the sibling's *deliverable* IS the smaller file. Asking
+ * the filesystem asks whether the thing was actually achieved; asking the DB asks whether someone
+ * marked it done. When those disagree, the filesystem is right.
+ *
+ * @param {string} [repoRoot]
+ * @param {(file: string) => number|null} [sizer] test seam: byte size per contract file.
+ * @returns {Array<{role:string,file:string,bytes:number|null,armed:boolean,reason:string}>}
+ */
+export function roleArmingStates(repoRoot = REPO_ROOT, sizer = null) {
+  const sizeOf = sizer || ((file) => contractSizeBytes(repoRoot, file));
+  return ROLE_CONTRACTS.map(({ role, file, dependency }) => {
+    let bytes = null;
+    try { bytes = sizeOf(file); } catch { bytes = null; }
+    const n = Number(bytes);
+    if (!Number.isFinite(n) || n <= 0) {
+      // Unmeasurable => DISARMED. Absence of evidence is never promoted to compliance; that promotion
+      // is the defect this whole SD exists to remove.
+      return { role, file, bytes: null, armed: false, reason: `${file} not found — cannot establish readability` };
+    }
+    const armed = n <= SINGLE_READ_SAFE_BYTES;
+    return {
+      role, file, bytes: n, armed,
+      reason: armed
+        ? `contract fits in one read (${n}B ≤ ${SINGLE_READ_SAFE_BYTES}B)`
+        : `${file} exceeds the single-read bound (${n}B > ${SINGLE_READ_SAFE_BYTES}B)`
+            + (dependency ? ` — blocked on ${dependency}` : ''),
+    };
+  });
+}
+
+/**
  * Render the contract-read state.
  *
  * PER-ROLE ARMING IS RENDERED, NOT IMPLIED. Global arming was rejected: it would make the one role
@@ -578,7 +651,7 @@ function readCoordinatorSessionState(repoRoot) {
  * sequenced after it. The risk of per-role is someone assuming uniform coverage, so the disarmed
  * roles are printed explicitly rather than left to inference.
  */
-export function renderContractRead(repoRoot = REPO_ROOT, check = null) {
+export function renderContractRead(repoRoot = REPO_ROOT, check = null, opts = {}) {
   const lines = ['═══ ROLE CONTRACT READ ═══'];
   try {
     const c = check || checkCoordinatorContractRead(repoRoot);
@@ -596,10 +669,10 @@ export function renderContractRead(repoRoot = REPO_ROOT, check = null) {
     } else {
       lines.push(`  ✅ ${COORDINATOR_CONTRACT_FILE} read${c.contract_last_read_at ? ` at ${c.contract_last_read_at}` : ''}`);
     }
-    lines.push('  ── per-role arming ──');
-    lines.push('  coordinator : ARMED (contract fits in one read)');
-    lines.push('  adam        : disarmed — CLAUDE_ADAM.md exceeds the read cap (SD-LEO-INFRA-ADAM-CONTRACT-READABLE-001)');
-    lines.push('  solomon     : disarmed — CLAUDE_SOLOMON.md exceeds the read cap');
+    lines.push('  ── per-role arming (measured now, from each contract on disk) ──');
+    for (const s of roleArmingStates(repoRoot, opts.sizer)) {
+      lines.push(`  ${s.role.padEnd(11)} : ${s.armed ? 'ARMED' : 'disarmed'} — ${s.reason}`);
+    }
   } catch (err) {
     lines.push('  ✅ contract-read check skipped (fail-open): ' + (err?.message || String(err)));
   }

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -31,7 +31,7 @@ const { resolveStateReadPath } = _createRequireQF342(import.meta.url)('./hooks/l
 // really read" and ONE definition of the single-read bound, shared with adam-register.cjs and
 // solomon-register.cjs. Importing the bound rather than restating it is the difference between an
 // arming condition and an arming CLAIM — see roleArmingStates below.
-const { contractReadVerdict, contractLineCount, contractSizeBytes, SINGLE_READ_SAFE_BYTES } =
+const { contractReadVerdict, contractLineCount, singleReadFit, SINGLE_READ_TOKEN_CAP } =
   _createRequireQF342(import.meta.url)('../lib/protocol/contract-read-coverage.cjs');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -543,7 +543,7 @@ export function renderFreshness(repoRoot = REPO_ROOT) {
  */
 export const COORDINATOR_CONTRACT_FILE = 'CLAUDE_COORDINATOR.md';
 
-export function checkCoordinatorContractRead(repoRoot = REPO_ROOT, stateReader = null) {
+export function checkCoordinatorContractRead(repoRoot = REPO_ROOT, stateReader = null, opts = {}) {
   const result = {
     contract_file: COORDINATOR_CONTRACT_FILE,
     contract_exists: false,
@@ -565,7 +565,7 @@ export function checkCoordinatorContractRead(repoRoot = REPO_ROOT, stateReader =
       const verdict = contractReadVerdict(
         status,
         contractLineCount(repoRoot, COORDINATOR_CONTRACT_FILE),
-        { sizeBytes: contractSizeBytes(repoRoot, COORDINATOR_CONTRACT_FILE) }
+        { singleReadFit: singleReadFit(repoRoot, COORDINATOR_CONTRACT_FILE) }
       );
       result.contract_read = verdict.read;
       result.contract_read_partial = !verdict.fully_read;
@@ -573,8 +573,19 @@ export function checkCoordinatorContractRead(repoRoot = REPO_ROOT, stateReader =
       result.contract_read_basis = verdict.basis;
       result.contract_last_read_at = status.lastReadAt || null;
     } else if (Array.isArray(state.protocolFilesRead) && state.protocolFilesRead.includes(COORDINATOR_CONTRACT_FILE)) {
-      result.contract_read = true; // legacy-array fallback, same as adam-register
-      result.contract_read_basis = 'legacy_array_single_read_safe';
+      // SEC-F1. This branch USED to hardcode basis 'legacy_array_single_read_safe' and leave
+      // contract_read_partial at false — a basis string NAMING a size check that was never run, with
+      // a comment claiming parity with adam-register that did not hold (adam and solomon both measure
+      // here and emit 'legacy_array_no_evidence' when the contract does not fit).
+      //
+      // It was true only because CLAUDE_COORDINATOR.md happens to fit — i.e. the exact "three true
+      // sentences" defect this same commit removed one function below, reintroduced by the fix for
+      // it. A legacy bare-filename list carries NO coverage information; it is sufficient only when
+      // the contract provably fits in one call, and that has to be measured, not asserted.
+      const fit = opts.fit || singleReadFit(repoRoot, COORDINATOR_CONTRACT_FILE);
+      result.contract_read = true;
+      result.contract_read_partial = fit.fits !== true;
+      result.contract_read_basis = fit.fits === true ? 'legacy_array_single_read_safe' : 'legacy_array_no_evidence';
     }
   } catch { /* fail-open: tracking unavailable must never break coordinator startup */ }
   return result;
@@ -617,28 +628,47 @@ export const ROLE_CONTRACTS = Object.freeze([
  * the filesystem asks whether the thing was actually achieved; asking the DB asks whether someone
  * marked it done. When those disagree, the filesystem is right.
  *
+ * *** ARMING IS DECIDED ON MEASURED TOKENS, NOT ON BYTES, AND THAT CHANGED A REAL VERDICT. *** The
+ * first version of this function compared file SIZE against a byte bound. The bound was tuned for
+ * adversarially dense input (~1.32 B/token), but these contracts are prose (~4.2 B/token), so it
+ * disarmed roles that can already comply. Measured: CLAUDE_SOLOMON.md is 67,501 B but only 15,965
+ * tokens — it FITS in one read, and the byte proxy was telling Solomon its contract was unreadable.
+ * CLAUDE_ADAM.md is over by 569 tokens, not by the 4x its byte count implies. A proxy for the limit
+ * is not the limit; the SD's own success criteria required token figures re-measured rather than
+ * inherited from a bytes derivation.
+ *
  * @param {string} [repoRoot]
- * @param {(file: string) => number|null} [sizer] test seam: byte size per contract file.
- * @returns {Array<{role:string,file:string,bytes:number|null,armed:boolean,reason:string}>}
+ * @param {(file: string) => {fits:boolean|null,tokens:number|null,bytes:number|null,basis:string}} [fitter]
+ *        test seam: single-read fit per contract file.
+ * @returns {Array<{role:string,file:string,tokens:number|null,bytes:number|null,armed:boolean,reason:string}>}
  */
-export function roleArmingStates(repoRoot = REPO_ROOT, sizer = null) {
-  const sizeOf = sizer || ((file) => contractSizeBytes(repoRoot, file));
+export function roleArmingStates(repoRoot = REPO_ROOT, fitter = null) {
+  const fitOf = fitter || ((file) => singleReadFit(repoRoot, file));
   return ROLE_CONTRACTS.map(({ role, file, dependency }) => {
-    let bytes = null;
-    try { bytes = sizeOf(file); } catch { bytes = null; }
-    const n = Number(bytes);
-    if (!Number.isFinite(n) || n <= 0) {
-      // Unmeasurable => DISARMED. Absence of evidence is never promoted to compliance; that promotion
-      // is the defect this whole SD exists to remove.
-      return { role, file, bytes: null, armed: false, reason: `${file} not found — cannot establish readability` };
+    let fit = null;
+    try { fit = fitOf(file); } catch { fit = null; }
+    const tokens = fit && Number.isFinite(Number(fit.tokens)) ? Number(fit.tokens) : null;
+    const bytes = fit && Number.isFinite(Number(fit.bytes)) ? Number(fit.bytes) : null;
+
+    // Unmeasurable (including `fits: null`) => DISARMED. Absence of evidence is never promoted to
+    // compliance; that promotion is the defect this whole SD exists to remove.
+    if (!fit || fit.fits !== true) {
+      if (!fit || fit.fits === null || fit.fits === undefined) {
+        return { role, file, tokens, bytes, armed: false, reason: `${file} not measurable — cannot establish readability` };
+      }
+      const over = tokens !== null
+        ? `${tokens} tokens > ${SINGLE_READ_TOKEN_CAP} cap`
+        : `${bytes}B exceeds the no-tokenizer fallback bound`;
+      return {
+        role, file, tokens, bytes, armed: false,
+        reason: `${file} exceeds a single read (${over})` + (dependency ? ` — blocked on ${dependency}` : ''),
+      };
     }
-    const armed = n <= SINGLE_READ_SAFE_BYTES;
     return {
-      role, file, bytes: n, armed,
-      reason: armed
-        ? `contract fits in one read (${n}B ≤ ${SINGLE_READ_SAFE_BYTES}B)`
-        : `${file} exceeds the single-read bound (${n}B > ${SINGLE_READ_SAFE_BYTES}B)`
-            + (dependency ? ` — blocked on ${dependency}` : ''),
+      role, file, tokens, bytes, armed: true,
+      reason: tokens !== null
+        ? `contract fits in one read (${tokens} tokens ≤ ${SINGLE_READ_TOKEN_CAP} cap)`
+        : `contract fits in one read (${bytes}B, no tokenizer — conservative bound)`,
     };
   });
 }
@@ -669,8 +699,8 @@ export function renderContractRead(repoRoot = REPO_ROOT, check = null, opts = {}
     } else {
       lines.push(`  ✅ ${COORDINATOR_CONTRACT_FILE} read${c.contract_last_read_at ? ` at ${c.contract_last_read_at}` : ''}`);
     }
-    lines.push('  ── per-role arming (measured now, from each contract on disk) ──');
-    for (const s of roleArmingStates(repoRoot, opts.sizer)) {
+    lines.push('  ── per-role arming (measured now: real tokens per contract, vs the read cap) ──');
+    for (const s of roleArmingStates(repoRoot, opts.fitter)) {
       lines.push(`  ${s.role.padEnd(11)} : ${s.armed ? 'ARMED' : 'disarmed'} — ${s.reason}`);
     }
   } catch (err) {

--- a/scripts/modules/handoff/gates/protocol-file-read-gate.js
+++ b/scripts/modules/handoff/gates/protocol-file-read-gate.js
@@ -491,8 +491,14 @@ export async function validateProtocolFileRead(handoffType, ctx = {}) {
       console.log('   ✅ CROSS-MODE FALLBACK: FULL file present - allowing handoff');
       console.log('   💡 Regenerate DIGEST files: node scripts/generate-claude-md-from-db.js');
 
-      markProtocolFileRead(requiredFile);
-
+      // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-1, SECOND SITE. The same write lived here and
+      // I MISSED IT ON THE FIRST PASS — I fixed the PASS_FALLBACK branch and shipped, leaving an
+      // identical self-falsifying stamp in the cross-mode branch one screen further down. It is
+      // arguably worse here: it marks the DIGEST file as read on the strength of the FULL file
+      // merely existing, so the record names a file nobody opened in either form.
+      // Found because the FR-1 regression guard failed on its first run for the wrong reason, and
+      // reading why surfaced this. Only reachable in digest mode, which the codebase currently
+      // pins off — but "unreachable today" is exactly how the other dead gate became a trap.
       const state = readSessionState();
       emitStructuredLog({
         event: 'PROTOCOL_FILE_READ_GATE',

--- a/scripts/solomon-register.cjs
+++ b/scripts/solomon-register.cjs
@@ -36,7 +36,7 @@ const { createSupabaseServiceClient } = require('../lib/supabase-client.cjs');
 const { resolveStateReadPath } = require('./hooks/lib/session-state-resolver.cjs');
 // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-3: shared with adam-register.cjs — one verdict
 // implementation for both roles.
-const { contractReadVerdict, contractLineCount, contractSizeBytes, SINGLE_READ_SAFE_BYTES } = require('../lib/protocol/contract-read-coverage.cjs');
+const { contractReadVerdict, contractLineCount, singleReadFit } = require('../lib/protocol/contract-read-coverage.cjs');
 // SD-LEO-INFRA-SOLOMON-CONSULT-001A (Solomon foundation) — faithful copy-rename of adam-register.cjs: single-Solomon guard + atomic write.
 // fetchAllSolomonsStrict (not fetchFreshSolomons) so the guard sees stale priors too and classifies
 // fresh-vs-stale itself (fresh => refuse; stale-only => retire). STRICT (FR-6, count-truncation
@@ -267,7 +267,7 @@ function checkContractRead(projectDir) {
       // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-3 — identical fix to adam-register.cjs, from
       // one shared implementation. This path had NO test coverage at all before this SD, which is
       // part of why the inversion survived here as long as it did.
-      const verdict = contractReadVerdict(status, contractLineCount(root, CONTRACT_FILE), { sizeBytes: contractSizeBytes(root, CONTRACT_FILE) });
+      const verdict = contractReadVerdict(status, contractLineCount(root, CONTRACT_FILE), { singleReadFit: singleReadFit(root, CONTRACT_FILE) });
       result.contract_read = verdict.read;
       result.contract_read_partial = !verdict.fully_read;
       result.contract_coverage_pct = verdict.coverage_pct;
@@ -277,8 +277,9 @@ function checkContractRead(projectDir) {
       // Legacy pre-FR-2 state shape: a bare filename list carrying no coverage information at all.
       // Sufficient ONLY when the contract fits in a single Read. For an over-cap contract it cannot
       // distinguish a full read from a silently truncated one, which is the defect this SD closes.
-      const legacyBytes = contractSizeBytes(root, CONTRACT_FILE);
-      const legacyFits = Number.isFinite(legacyBytes) && legacyBytes > 0 && legacyBytes <= SINGLE_READ_SAFE_BYTES;
+      // Measured on TOKENS, not bytes: the byte proxy this replaced disarmed CLAUDE_SOLOMON.md
+      // (67,501 B but only 15,965 tokens) even though it reads in one call.
+      const legacyFits = singleReadFit(root, CONTRACT_FILE).fits === true;
       result.contract_read = true;
       result.contract_read_partial = !legacyFits;
       result.contract_read_basis = legacyFits ? 'legacy_array_single_read_safe' : 'legacy_array_no_evidence';

--- a/tests/unit/coordinator/coordinator-contract-read.test.js
+++ b/tests/unit/coordinator/coordinator-contract-read.test.js
@@ -16,7 +16,7 @@ import {
   COORDINATOR_CONTRACT_FILE,
 } from '../../../scripts/coordinator-startup-check.mjs';
 import { createRequire } from 'node:module';
-const { SINGLE_READ_TOKEN_CAP } = createRequire(import.meta.url)('../../../lib/protocol/contract-read-coverage.cjs');
+const { SINGLE_READ_TOKEN_CAP, SINGLE_READ_TOKEN_BUDGET } = createRequire(import.meta.url)('../../../lib/protocol/contract-read-coverage.cjs');
 
 const REPO = process.cwd();
 
@@ -94,25 +94,19 @@ describe('renderContractRead', () => {
     // Per-role arming's one real risk is someone assuming uniform coverage. The mitigation is that
     // the disarmed roles are printed, not implied.
     const out = renderContractRead(REPO, { contract_file: COORDINATOR_CONTRACT_FILE, contract_exists: true, contract_read: true, contract_read_partial: false, contract_last_read_at: null });
-    // ALL THREE roles appear, each with an explicit verdict. The point is that a disarmed role is
-    // PRINTED rather than left to inference from a green coordinator line.
-    for (const role of ['coordinator', 'adam', 'solomon']) expect(out).toContain(role);
-    expect(out).toContain('coordinator : ARMED');
-    expect(out).toContain('adam        : disarmed');  // genuinely over cap, by ~569 tokens
-    expect(out).toContain('solomon     : ARMED');     // 67KB but 15,965 tokens — it fits
-
-    // *** THIS ASSERTION USED TO READ 'solomon : disarmed', AND THAT IS THE BUG IT WAS HIDING. ***
-    // The byte proxy called a 67,501-byte contract unreadable; measured, it is 15,965 tokens and
-    // reads in one call. The test had encoded the proxy's error as a REQUIREMENT, so the only way to
-    // make the measurement correct was to change a test that was passing. A green test asserting a
-    // false fact is worse than no test.
+    // ALL THREE roles appear, each with an EXPLICIT verdict. That is the whole point of the table:
+    // a disarmed role is PRINTED rather than left to inference from a green coordinator line.
     //
-    // MUTATION: drop the per-role table -> a reader sees a green coordinator check and reasonably
-    // infers all three roles are covered. Fails.
-    //
-    // STILL NOT SUFFICIENT ON ITS OWN: it pins today's real files, so it would pass against a
-    // hardcoded string table too. The arming CONDITION is proved by the roleArmingStates block
-    // below, where the measurements are injected and the verdict is required to move.
+    // *** DELIBERATELY ASSERTS THE SHAPE, NOT WHICH ROLES ARE ARMED TODAY. *** An earlier version
+    // required `adam : disarmed` and `solomon : ARMED` against the live contracts. Both are true
+    // right now and neither is a requirement: SD-LEO-INFRA-ADAM-CONTRACT-READABLE-001 exists to
+    // bring CLAUDE_ADAM.md under the budget, and on the day it succeeds adam arms CORRECTLY and the
+    // old assertion fails with nothing wrong. This is the fourth time that shape has appeared in
+    // this SD — including in the very sibling file cleaned up this round, which is how it survived:
+    // the cleanup was applied to one file and not the other.
+    for (const role of ['coordinator', 'adam', 'solomon']) {
+      expect(out).toMatch(new RegExp(`${role}\\s+: (ARMED|disarmed) — .+`));
+    }
   });
 });
 
@@ -177,20 +171,25 @@ describe('roleArmingStates — arming is measured, not asserted', () => {
     // MUTATION: default `armed` to true when the fit is unknown -> fails all four.
   });
 
-  it('REAL FILES: arming follows measured TOKENS, not bytes — solomon fits despite being 67KB', () => {
-    // *** THE REGRESSION THAT CAUGHT THE BYTE PROXY. *** CLAUDE_SOLOMON.md is 67,501 bytes — 2.7x
-    // the old 25,000-ish byte bound — but only 15,965 tokens, so it reads in ONE call. The byte
-    // proxy disarmed a role that could already comply. Asserted on the real files, because the
-    // whole point is that the byte and token answers DISAGREE here.
-    const byRole = Object.fromEntries(roleArmingStates(REPO).map((s) => [s.role, s]));
-    expect(byRole.solomon.armed).toBe(true);
-    expect(byRole.solomon.bytes).toBeGreaterThan(60000);   // big in bytes...
-    expect(byRole.solomon.tokens).toBeLessThan(SINGLE_READ_TOKEN_CAP); // ...small in tokens
-    expect(byRole.coordinator.armed).toBe(true);
-    expect(byRole.adam.armed).toBe(false); // genuinely over, by ~569 tokens
+  it('REAL FILES: every role is measured, and armed follows the measurement', () => {
+    /**
+     * *** ASSERTS THE RULE, NOT TODAY'S ANSWERS. *** This test previously required
+     * `solomon.armed === true`, `solomon.bytes > 60000` and `adam.armed === false` against the live
+     * contracts. All three are true today and none is a requirement — trimming either contract is
+     * desirable, and one is an active sibling SD, so the test would have failed on success.
+     *
+     * What must hold forever is that `armed` is DERIVED from the measurement rather than stated:
+     * every role reports a real token count, and its armed flag agrees with that count against the
+     * budget. If a contract shrinks, the role arms and this still passes.
+     */
+    for (const s of roleArmingStates(REPO)) {
+      expect(s.tokens).toBeGreaterThan(0);
+      expect(s.armed).toBe(s.tokens <= SINGLE_READ_TOKEN_BUDGET);
+      expect(s.reason).toContain('token');
+    }
 
-    // MUTATION: revert to comparing bytes against any bound that admits the 25,587-byte coordinator
-    // contract -> solomon (67,501 B) disarms and this fails. That was the shipped behaviour.
+    // MUTATION: hardcode any role's verdict, or compare bytes instead of tokens -> armed stops
+    // agreeing with tokens and this fails.
   });
 
   it('the RENDERED table reflects injected measurements rather than a fixed string', () => {

--- a/tests/unit/coordinator/coordinator-contract-read.test.js
+++ b/tests/unit/coordinator/coordinator-contract-read.test.js
@@ -16,7 +16,7 @@ import {
   COORDINATOR_CONTRACT_FILE,
 } from '../../../scripts/coordinator-startup-check.mjs';
 import { createRequire } from 'node:module';
-const { SINGLE_READ_SAFE_BYTES } = createRequire(import.meta.url)('../../../lib/protocol/contract-read-coverage.cjs');
+const { SINGLE_READ_TOKEN_CAP } = createRequire(import.meta.url)('../../../lib/protocol/contract-read-coverage.cjs');
 
 const REPO = process.cwd();
 
@@ -94,17 +94,25 @@ describe('renderContractRead', () => {
     // Per-role arming's one real risk is someone assuming uniform coverage. The mitigation is that
     // the disarmed roles are printed, not implied.
     const out = renderContractRead(REPO, { contract_file: COORDINATOR_CONTRACT_FILE, contract_exists: true, contract_read: true, contract_read_partial: false, contract_last_read_at: null });
+    // ALL THREE roles appear, each with an explicit verdict. The point is that a disarmed role is
+    // PRINTED rather than left to inference from a green coordinator line.
+    for (const role of ['coordinator', 'adam', 'solomon']) expect(out).toContain(role);
     expect(out).toContain('coordinator : ARMED');
-    expect(out).toContain('adam        : disarmed');
-    expect(out).toContain('solomon     : disarmed');
+    expect(out).toContain('adam        : disarmed');  // genuinely over cap, by ~569 tokens
+    expect(out).toContain('solomon     : ARMED');     // 67KB but 15,965 tokens — it fits
 
+    // *** THIS ASSERTION USED TO READ 'solomon : disarmed', AND THAT IS THE BUG IT WAS HIDING. ***
+    // The byte proxy called a 67,501-byte contract unreadable; measured, it is 15,965 tokens and
+    // reads in one call. The test had encoded the proxy's error as a REQUIREMENT, so the only way to
+    // make the measurement correct was to change a test that was passing. A green test asserting a
+    // false fact is worse than no test.
+    //
     // MUTATION: drop the per-role table -> a reader sees a green coordinator check and reasonably
     // infers all three roles are covered. Fails.
     //
-    // *** THIS TEST IS NOT SUFFICIENT ON ITS OWN AND MUST NOT BE READ AS IF IT WERE. *** It pins
-    // today's real sizes, so it passes equally against a hardcoded string table — which is precisely
-    // what it used to assert. The arming CONDITION is proved by the roleArmingStates block below,
-    // where the sizes are injected and the verdict is required to move.
+    // STILL NOT SUFFICIENT ON ITS OWN: it pins today's real files, so it would pass against a
+    // hardcoded string table too. The arming CONDITION is proved by the roleArmingStates block
+    // below, where the measurements are injected and the verdict is required to move.
   });
 });
 
@@ -116,66 +124,115 @@ describe('renderContractRead', () => {
  * ever confirm today, and today is the one state a hardcoded table already gets right.
  */
 describe('roleArmingStates — arming is measured, not asserted', () => {
-  const sizes = (m) => (file) => (file in m ? m[file] : 999999);
+  /** Inject a single-read fit per file; anything unnamed is over cap. */
+  const fits = (m) => (file) => {
+    const tokens = file in m ? m[file] : SINGLE_READ_TOKEN_CAP * 2;
+    return { fits: tokens <= SINGLE_READ_TOKEN_CAP, tokens, bytes: tokens * 4, basis: 'measured_tokens' };
+  };
 
   it('NEGATIVE: a role whose contract is over cap is NOT armed', () => {
     // The load-bearing negative from the SD's success criteria.
-    const states = roleArmingStates(REPO, sizes({ 'CLAUDE_ADAM.md': SINGLE_READ_SAFE_BYTES + 1 }));
+    const states = roleArmingStates(REPO, fits({ 'CLAUDE_ADAM.md': SINGLE_READ_TOKEN_CAP + 1 }));
     const adam = states.find((s) => s.role === 'adam');
     expect(adam.armed).toBe(false);
-    expect(adam.reason).toContain('exceeds the single-read bound');
+    expect(adam.reason).toContain('exceeds a single read');
     // The dependency is NAMED, so a reader knows what would change it.
     expect(adam.reason).toContain('SD-LEO-INFRA-ADAM-CONTRACT-READABLE-001');
 
-    // MUTATION: flip the comparison to >= / drop the bound -> arms an unreadable contract, fails.
+    // MUTATION: treat fits!==true as armed / drop the cap -> arms an unreadable contract, fails.
   });
 
   it('POSITIVE: the same role ARMS ONCE ITS CONTRACT FITS — no code change, no redeploy', () => {
     // *** THE TEST THE OLD PROSE TABLE COULD NEVER HAVE PASSED. *** When
-    // SD-LEO-INFRA-ADAM-CONTRACT-READABLE-001 lands and CLAUDE_ADAM.md drops under the bound, adam
+    // SD-LEO-INFRA-ADAM-CONTRACT-READABLE-001 lands and CLAUDE_ADAM.md drops under the cap, adam
     // must arm on its own. The previous implementation would have kept printing "disarmed" forever
     // and its test would have kept passing.
-    const states = roleArmingStates(REPO, sizes({ 'CLAUDE_ADAM.md': 1000 }));
+    const states = roleArmingStates(REPO, fits({ 'CLAUDE_ADAM.md': 1000 }));
     expect(states.find((s) => s.role === 'adam').armed).toBe(true);
 
     // MUTATION: restore the hardcoded 'adam : disarmed' string -> fails. This assertion is the
     // difference between a condition and a comment.
   });
 
-  it('the bound is the SHARED one, not a second copy', () => {
-    // Exactly at the bound arms; one byte over does not. Pins the boundary in both directions so it
-    // cannot drift by restatement — the SD already had one near-miss from a restated constant.
-    const at = roleArmingStates(REPO, sizes({ 'CLAUDE_SOLOMON.md': SINGLE_READ_SAFE_BYTES }));
-    const over = roleArmingStates(REPO, sizes({ 'CLAUDE_SOLOMON.md': SINGLE_READ_SAFE_BYTES + 1 }));
+  it('the boundary is exact and shared, not a second copy', () => {
+    // Exactly at the cap arms; one token over does not.
+    const at = roleArmingStates(REPO, fits({ 'CLAUDE_SOLOMON.md': SINGLE_READ_TOKEN_CAP }));
+    const over = roleArmingStates(REPO, fits({ 'CLAUDE_SOLOMON.md': SINGLE_READ_TOKEN_CAP + 1 }));
     expect(at.find((s) => s.role === 'solomon').armed).toBe(true);
     expect(over.find((s) => s.role === 'solomon').armed).toBe(false);
   });
 
   it('an UNMEASURABLE contract is disarmed, never armed by default', () => {
     // Absence of evidence must not be promoted to compliance — the defect this SD exists to remove.
-    for (const bad of [null, 0, NaN, undefined]) {
+    // `fits: null` is the specific case: measurable file, unmeasurable readability.
+    for (const bad of [null, undefined, { fits: null, tokens: null, bytes: null, basis: 'unmeasurable' }]) {
       const s = roleArmingStates(REPO, () => bad).find((x) => x.role === 'coordinator');
       expect(s.armed).toBe(false);
       expect(s.reason).toContain('cannot establish readability');
     }
-    // A throwing sizer must also disarm rather than propagate: this runs in a fail-open startup path.
+    // A throwing fitter must also disarm rather than propagate: this is a fail-open startup path.
     const thrown = roleArmingStates(REPO, () => { throw new Error('stat failed'); });
     expect(thrown.every((s) => s.armed === false)).toBe(true);
 
-    // MUTATION: default `armed` to true when size is unknown -> fails all five.
+    // MUTATION: default `armed` to true when the fit is unknown -> fails all four.
   });
 
-  it('the RENDERED table reflects injected sizes rather than a fixed string', () => {
+  it('REAL FILES: arming follows measured TOKENS, not bytes — solomon fits despite being 67KB', () => {
+    // *** THE REGRESSION THAT CAUGHT THE BYTE PROXY. *** CLAUDE_SOLOMON.md is 67,501 bytes — 2.7x
+    // the old 25,000-ish byte bound — but only 15,965 tokens, so it reads in ONE call. The byte
+    // proxy disarmed a role that could already comply. Asserted on the real files, because the
+    // whole point is that the byte and token answers DISAGREE here.
+    const byRole = Object.fromEntries(roleArmingStates(REPO).map((s) => [s.role, s]));
+    expect(byRole.solomon.armed).toBe(true);
+    expect(byRole.solomon.bytes).toBeGreaterThan(60000);   // big in bytes...
+    expect(byRole.solomon.tokens).toBeLessThan(SINGLE_READ_TOKEN_CAP); // ...small in tokens
+    expect(byRole.coordinator.armed).toBe(true);
+    expect(byRole.adam.armed).toBe(false); // genuinely over, by ~569 tokens
+
+    // MUTATION: revert to comparing bytes against any bound that admits the 25,587-byte coordinator
+    // contract -> solomon (67,501 B) disarms and this fails. That was the shipped behaviour.
+  });
+
+  it('the RENDERED table reflects injected measurements rather than a fixed string', () => {
     // Closes the loop: the render path itself must be driven by the measurement, not merely
     // accompanied by it.
     const out = renderContractRead(
       REPO,
       { contract_file: COORDINATOR_CONTRACT_FILE, contract_exists: true, contract_read: true, contract_read_partial: false, contract_last_read_at: null },
-      { sizer: sizes({ 'CLAUDE_ADAM.md': 1000, 'CLAUDE_SOLOMON.md': 1000, 'CLAUDE_COORDINATOR.md': 999999 }) }
+      { fitter: fits({ 'CLAUDE_ADAM.md': 1000, 'CLAUDE_SOLOMON.md': 1000, 'CLAUDE_COORDINATOR.md': 999999 }) }
     );
     expect(out).toContain('adam        : ARMED');
     expect(out).toContain('solomon     : ARMED');
     expect(out).toContain('coordinator : disarmed'); // inverted vs reality, proving it is measured
+  });
+});
+
+describe('SEC-F1 — the legacy-array branch must MEASURE, not assert', () => {
+  /**
+   * The branch used to hardcode basis 'legacy_array_single_read_safe' and leave
+   * contract_read_partial at false, with a comment claiming parity with adam-register that did not
+   * hold. A basis string NAMING a size check nobody ran. True only because the coordinator contract
+   * happens to fit — the same defect removed one function below, reintroduced by the fix for it.
+   */
+  const legacy = () => () => ({ protocolFilesRead: [COORDINATOR_CONTRACT_FILE] });
+
+  it('a legacy record for a contract that FITS is accepted as a full read', () => {
+    const c = checkCoordinatorContractRead(REPO, legacy());
+    expect(c.contract_read).toBe(true);
+    expect(c.contract_read_partial).toBe(false);
+    expect(c.contract_read_basis).toBe('legacy_array_single_read_safe');
+  });
+
+  it('the SAME legacy record is NOT a full read once the contract no longer fits', () => {
+    // The discriminating half. Proved by differential execution in SECURITY review: on a synthetic
+    // 100,000-byte contract the coordinator returned a green "read" while adam correctly returned
+    // legacy_array_no_evidence for identical input.
+    const c = checkCoordinatorContractRead(REPO, legacy(), { fit: { fits: false, tokens: 99999, bytes: 400000, basis: 'measured_tokens' } });
+    expect(c.contract_read).toBe(true);           // a read did happen
+    expect(c.contract_read_partial).toBe(true);   // ...but it cannot be called complete
+    expect(c.contract_read_basis).toBe('legacy_array_no_evidence');
+
+    // MUTATION: restore the hardcoded basis -> an over-cap contract reports green, fails.
   });
 });
 

--- a/tests/unit/coordinator/coordinator-contract-read.test.js
+++ b/tests/unit/coordinator/coordinator-contract-read.test.js
@@ -118,10 +118,22 @@ describe('renderContractRead', () => {
  * ever confirm today, and today is the one state a hardcoded table already gets right.
  */
 describe('roleArmingStates — arming is measured, not asserted', () => {
-  /** Inject a single-read fit per file; anything unnamed is over cap. */
+  /**
+   * Inject a single-read fit per file; anything unnamed is over budget.
+   *
+   * *** USES THE BUDGET, NOT THE CAP, AND THAT WAS THE SIXTH FACT-PINNED DEFECT IN THIS SD. ***
+   * This injector previously computed `fits: tokens <= SINGLE_READ_TOKEN_CAP` (25,000) while
+   * production `singleReadFit` uses SINGLE_READ_TOKEN_BUDGET (22,500) — a 2,500-token divergence.
+   * So the block below modelled a boundary the code does not have, and the file carried TWO arming
+   * boundaries for one concept, the correct one appearing twenty lines later.
+   *
+   * It survived five review rounds because the previous five pins were on FILE SIZES; this one is a
+   * pin on a CONSTANT — the same class one level of indirection up, which is not what anyone was
+   * scanning for.
+   */
   const fits = (m) => (file) => {
-    const tokens = file in m ? m[file] : SINGLE_READ_TOKEN_CAP * 2;
-    return { fits: tokens <= SINGLE_READ_TOKEN_CAP, tokens, bytes: tokens * 4, basis: 'measured_tokens' };
+    const tokens = file in m ? m[file] : SINGLE_READ_TOKEN_BUDGET * 2;
+    return { fits: tokens <= SINGLE_READ_TOKEN_BUDGET, tokens, bytes: tokens * 4, basis: 'measured_tokens' };
   };
 
   it('NEGATIVE: a role whose contract is over cap is NOT armed', () => {
@@ -148,12 +160,26 @@ describe('roleArmingStates — arming is measured, not asserted', () => {
     // difference between a condition and a comment.
   });
 
-  it('the boundary is exact and shared, not a second copy', () => {
-    // Exactly at the cap arms; one token over does not.
-    const at = roleArmingStates(REPO, fits({ 'CLAUDE_SOLOMON.md': SINGLE_READ_TOKEN_CAP }));
-    const over = roleArmingStates(REPO, fits({ 'CLAUDE_SOLOMON.md': SINGLE_READ_TOKEN_CAP + 1 }));
+  it('roleArmingStates passes a fit verdict through faithfully, in both directions', () => {
+    /**
+     * *** RENAMED, BECAUSE THE OLD TITLE — "the boundary is exact and shared, not a second copy" —
+     * WAS FALSE OF THIS TEST. *** It injected the boundary it then asserted, so it was tautological
+     * with respect to the real bound and could never have detected a production change. That is
+     * exactly why the BUDGET->CAP mutant survived every test until the synthetic band test was added
+     * in the sibling file.
+     *
+     * What this CAN honestly prove is narrower and still worth having: roleArmingStates neither
+     * inverts nor overrides a fit verdict handed to it. The bound itself is tested where it can be
+     * tested for real — "THE MARGIN IS APPLIED" in tests/unit/protocol/contract-read-coverage.test.js,
+     * which builds a contract into the band between budget and cap and measures it.
+     */
+    const at = roleArmingStates(REPO, fits({ 'CLAUDE_SOLOMON.md': SINGLE_READ_TOKEN_BUDGET }));
+    const over = roleArmingStates(REPO, fits({ 'CLAUDE_SOLOMON.md': SINGLE_READ_TOKEN_BUDGET + 1 }));
     expect(at.find((s) => s.role === 'solomon').armed).toBe(true);
     expect(over.find((s) => s.role === 'solomon').armed).toBe(false);
+
+    // MUTATION: ignore fit.fits and re-derive arming here -> a second bound appears and one of these
+    // two fails. The point of the pair is that BOTH directions are carried through untouched.
   });
 
   it('an UNMEASURABLE contract is disarmed, never armed by default', () => {

--- a/tests/unit/coordinator/coordinator-contract-read.test.js
+++ b/tests/unit/coordinator/coordinator-contract-read.test.js
@@ -12,8 +12,11 @@ import { describe, it, expect } from 'vitest';
 import {
   checkCoordinatorContractRead,
   renderContractRead,
+  roleArmingStates,
   COORDINATOR_CONTRACT_FILE,
 } from '../../../scripts/coordinator-startup-check.mjs';
+import { createRequire } from 'node:module';
+const { SINGLE_READ_SAFE_BYTES } = createRequire(import.meta.url)('../../../lib/protocol/contract-read-coverage.cjs');
 
 const REPO = process.cwd();
 
@@ -97,6 +100,82 @@ describe('renderContractRead', () => {
 
     // MUTATION: drop the per-role table -> a reader sees a green coordinator check and reasonably
     // infers all three roles are covered. Fails.
+    //
+    // *** THIS TEST IS NOT SUFFICIENT ON ITS OWN AND MUST NOT BE READ AS IF IT WERE. *** It pins
+    // today's real sizes, so it passes equally against a hardcoded string table — which is precisely
+    // what it used to assert. The arming CONDITION is proved by the roleArmingStates block below,
+    // where the sizes are injected and the verdict is required to move.
+  });
+});
+
+/**
+ * SD success criterion: "Arming policy is decided and encoded as a condition, not as prose", with an
+ * explicit NEGATIVE TEST that an over-cap contract leaves its role un-gated.
+ *
+ * Every test here INJECTS sizes. That is the whole point: a test that reads the real files can only
+ * ever confirm today, and today is the one state a hardcoded table already gets right.
+ */
+describe('roleArmingStates — arming is measured, not asserted', () => {
+  const sizes = (m) => (file) => (file in m ? m[file] : 999999);
+
+  it('NEGATIVE: a role whose contract is over cap is NOT armed', () => {
+    // The load-bearing negative from the SD's success criteria.
+    const states = roleArmingStates(REPO, sizes({ 'CLAUDE_ADAM.md': SINGLE_READ_SAFE_BYTES + 1 }));
+    const adam = states.find((s) => s.role === 'adam');
+    expect(adam.armed).toBe(false);
+    expect(adam.reason).toContain('exceeds the single-read bound');
+    // The dependency is NAMED, so a reader knows what would change it.
+    expect(adam.reason).toContain('SD-LEO-INFRA-ADAM-CONTRACT-READABLE-001');
+
+    // MUTATION: flip the comparison to >= / drop the bound -> arms an unreadable contract, fails.
+  });
+
+  it('POSITIVE: the same role ARMS ONCE ITS CONTRACT FITS — no code change, no redeploy', () => {
+    // *** THE TEST THE OLD PROSE TABLE COULD NEVER HAVE PASSED. *** When
+    // SD-LEO-INFRA-ADAM-CONTRACT-READABLE-001 lands and CLAUDE_ADAM.md drops under the bound, adam
+    // must arm on its own. The previous implementation would have kept printing "disarmed" forever
+    // and its test would have kept passing.
+    const states = roleArmingStates(REPO, sizes({ 'CLAUDE_ADAM.md': 1000 }));
+    expect(states.find((s) => s.role === 'adam').armed).toBe(true);
+
+    // MUTATION: restore the hardcoded 'adam : disarmed' string -> fails. This assertion is the
+    // difference between a condition and a comment.
+  });
+
+  it('the bound is the SHARED one, not a second copy', () => {
+    // Exactly at the bound arms; one byte over does not. Pins the boundary in both directions so it
+    // cannot drift by restatement — the SD already had one near-miss from a restated constant.
+    const at = roleArmingStates(REPO, sizes({ 'CLAUDE_SOLOMON.md': SINGLE_READ_SAFE_BYTES }));
+    const over = roleArmingStates(REPO, sizes({ 'CLAUDE_SOLOMON.md': SINGLE_READ_SAFE_BYTES + 1 }));
+    expect(at.find((s) => s.role === 'solomon').armed).toBe(true);
+    expect(over.find((s) => s.role === 'solomon').armed).toBe(false);
+  });
+
+  it('an UNMEASURABLE contract is disarmed, never armed by default', () => {
+    // Absence of evidence must not be promoted to compliance — the defect this SD exists to remove.
+    for (const bad of [null, 0, NaN, undefined]) {
+      const s = roleArmingStates(REPO, () => bad).find((x) => x.role === 'coordinator');
+      expect(s.armed).toBe(false);
+      expect(s.reason).toContain('cannot establish readability');
+    }
+    // A throwing sizer must also disarm rather than propagate: this runs in a fail-open startup path.
+    const thrown = roleArmingStates(REPO, () => { throw new Error('stat failed'); });
+    expect(thrown.every((s) => s.armed === false)).toBe(true);
+
+    // MUTATION: default `armed` to true when size is unknown -> fails all five.
+  });
+
+  it('the RENDERED table reflects injected sizes rather than a fixed string', () => {
+    // Closes the loop: the render path itself must be driven by the measurement, not merely
+    // accompanied by it.
+    const out = renderContractRead(
+      REPO,
+      { contract_file: COORDINATOR_CONTRACT_FILE, contract_exists: true, contract_read: true, contract_read_partial: false, contract_last_read_at: null },
+      { sizer: sizes({ 'CLAUDE_ADAM.md': 1000, 'CLAUDE_SOLOMON.md': 1000, 'CLAUDE_COORDINATOR.md': 999999 }) }
+    );
+    expect(out).toContain('adam        : ARMED');
+    expect(out).toContain('solomon     : ARMED');
+    expect(out).toContain('coordinator : disarmed'); // inverted vs reality, proving it is measured
   });
 });
 

--- a/tests/unit/coordinator/coordinator-contract-read.test.js
+++ b/tests/unit/coordinator/coordinator-contract-read.test.js
@@ -138,7 +138,7 @@ describe('roleArmingStates — arming is measured, not asserted', () => {
 
   it('NEGATIVE: a role whose contract is over cap is NOT armed', () => {
     // The load-bearing negative from the SD's success criteria.
-    const states = roleArmingStates(REPO, fits({ 'CLAUDE_ADAM.md': SINGLE_READ_TOKEN_CAP + 1 }));
+    const states = roleArmingStates(REPO, fits({ 'CLAUDE_ADAM.md': SINGLE_READ_TOKEN_BUDGET + 1 }));
     const adam = states.find((s) => s.role === 'adam');
     expect(adam.armed).toBe(false);
     expect(adam.reason).toContain('exceeds a single read');
@@ -178,8 +178,8 @@ describe('roleArmingStates — arming is measured, not asserted', () => {
     expect(at.find((s) => s.role === 'solomon').armed).toBe(true);
     expect(over.find((s) => s.role === 'solomon').armed).toBe(false);
 
-    // MUTATION: ignore fit.fits and re-derive arming here -> a second bound appears and one of these
-    // two fails. The point of the pair is that BOTH directions are carried through untouched.
+    // MUTATION: ignore fit.fits and re-derive arming with a DIFFERENT bound -> one of these two fails.
+    // (Re-deriving with the SAME bound is a provably equivalent mutant and survives, correctly.)
   });
 
   it('an UNMEASURABLE contract is disarmed, never armed by default', () => {

--- a/tests/unit/coordinator/coordinator-contract-read.test.js
+++ b/tests/unit/coordinator/coordinator-contract-read.test.js
@@ -16,7 +16,7 @@ import {
   COORDINATOR_CONTRACT_FILE,
 } from '../../../scripts/coordinator-startup-check.mjs';
 import { createRequire } from 'node:module';
-const { SINGLE_READ_TOKEN_CAP, SINGLE_READ_TOKEN_BUDGET } = createRequire(import.meta.url)('../../../lib/protocol/contract-read-coverage.cjs');
+const { SINGLE_READ_TOKEN_BUDGET } = createRequire(import.meta.url)('../../../lib/protocol/contract-read-coverage.cjs');
 
 const REPO = process.cwd();
 

--- a/tests/unit/protocol/contract-read-coverage.test.js
+++ b/tests/unit/protocol/contract-read-coverage.test.js
@@ -16,6 +16,10 @@ describe('contractReadVerdict — the inversion, both halves', () => {
   it('THE DILIGENT READER: paginated full coverage reports FULLY READ', () => {
     // Exactly what the old code punished: the final page carries a limit, so lastReadWasPartial
     // was true and the reader who did the work was recorded incomplete.
+    // THE SHAPE THE REAL TRACKER WRITES. An earlier version of this fixture carried ranges ALONE,
+    // a combination production never emits — and that omission is exactly what let SEC-F8 hide for
+    // two rounds. deliveredRanges is what proves the pages were actually returned; ranges alone
+    // only proves they were asked for (SEC-F18).
     const status = {
       readCount: 3,
       lastReadWasPartial: true, // the old signal, now correctly ignored
@@ -24,11 +28,17 @@ describe('contractReadVerdict — the inversion, both halves', () => {
         { offset: 201, limit: 200 },
         { offset: 401, limit: 21 },
       ],
+      deliveredRanges: [
+        { offset: 1, limit: 200 },
+        { offset: 201, limit: 200 },
+        { offset: 401, limit: 21 },
+      ],
+      lastDelivered: { startLine: 401, numLines: 21, totalLines: 421, coveredWholeFile: false },
     };
     const v = contractReadVerdict(status, 421);
     expect(v.read).toBe(true);
     expect(v.fully_read).toBe(true);
-    expect(v.basis).toBe('union_ranges');
+    expect(v.basis).toBe('delivered_ranges');
 
     // MUTATION: read status.lastReadWasPartial instead of computing coverage -> fully_read false, fails.
   });
@@ -64,14 +74,17 @@ describe('contractReadVerdict — the inversion, both halves', () => {
      * also a true statement about one call being used to answer a question about the whole file.
      * Both the old test and the code agreed, so the suite was green and the behaviour was backwards.
      */
+    // Real tracker shape: an earlier read DELIVERED the whole file, a later one delivered 100 lines.
+    // The union of deliveries is still the whole file.
     const status = {
       readCount: 4,
-      ranges: [{ offset: 1, limit: 421 }],
+      ranges: [{ offset: 1, limit: 421 }, { offset: 1, limit: 100 }],
+      deliveredRanges: [{ offset: 1, limit: 421 }, { offset: 1, limit: 100 }],
       lastDelivered: { startLine: 1, numLines: 100, totalLines: 421, coveredWholeFile: false },
     };
     const v = contractReadVerdict(status, 421);
     expect(v.fully_read).toBe(true);
-    expect(v.basis).toBe('union_ranges');
+    expect(v.basis).toBe('delivered_ranges');
 
     // MUTATION: rank the single-call delivered tier above the union tier (the shipped order) ->
     // fully_read false on basis delivered_lines. Fails. That mutation IS the bug SEC-F8 found.
@@ -224,8 +237,41 @@ describe('the byte proxy is RETIRED — readability is measured in tokens', () =
    *   2nd: "1.32 B/token is the densest case"               — measured, but a sample MAX, not a max.
    * cl100k_base is byte-level BPE with 256 single-byte fallbacks, so the true floor is 1.0 B/token.
    */
-  it('the token cap is the REAL harness limit, not a derived proxy', () => {
-    expect(SINGLE_READ_TOKEN_CAP).toBe(25000);
+  it('THE MARGIN IS APPLIED, not merely declared', () => {
+    /**
+     * *** THIS IS THE ONE MUTANT THAT SURVIVED THE WHOLE SUITE. *** Changing singleReadFit to
+     * compare against SINGLE_READ_TOKEN_CAP (25,000) instead of SINGLE_READ_TOKEN_BUDGET (22,500)
+     * — i.e. DELETING the safety margin — passed every test. Every margin assertion checked the
+     * two constants' RELATIONSHIP; none checked that the smaller one is what the comparison uses.
+     * The docblock calls the margin load-bearing, and it was the only safety mechanism here with
+     * zero behavioural coverage.
+     *
+     * A contract sized into the band between budget and cap is the only thing that can tell them
+     * apart, so build one instead of hoping a real file lands there.
+     */
+    const osx = require_('os'); const fsx = require_('fs'); const px = require_('path');
+    const dir = fsx.mkdtempSync(px.join(osx.tmpdir(), 'ctr-margin-'));
+    const file = 'BAND.md';
+    const line = 'lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod\n';
+
+    // Grow until the FRAMED measurement lands strictly between budget and cap.
+    let body = '';
+    for (let i = 0; i < 20000; i++) {
+      body += line;
+      if (i % 200 !== 0) continue;
+      fsx.writeFileSync(px.join(dir, file), body);
+      const t = singleReadFit(dir, file).tokens;
+      if (t > SINGLE_READ_TOKEN_BUDGET && t < SINGLE_READ_TOKEN_CAP) break;
+      if (t >= SINGLE_READ_TOKEN_CAP) throw new Error(`overshot the band at ${t} tokens`);
+    }
+
+    const fit = singleReadFit(dir, file);
+    expect(fit.tokens).toBeGreaterThan(SINGLE_READ_TOKEN_BUDGET);
+    expect(fit.tokens).toBeLessThan(SINGLE_READ_TOKEN_CAP);
+    expect(fit.fits).toBe(false);   // the margin, doing its job
+
+    // MUTATION: compare against SINGLE_READ_TOKEN_CAP instead of the budget -> fits true. Fails.
+    // That mutation survived all 58 tests before this one existed.
   });
 
   it('the surviving byte constant is sound at the 1.0 B/token FLOOR, not at a sampled ratio', () => {
@@ -236,19 +282,43 @@ describe('the byte proxy is RETIRED — readability is measured in tokens', () =
     // MUTATION: restore 32,000 (the "1.32 B/token" derivation) -> unsound at the floor, fails.
   });
 
-  it('MEASURES the real contracts, and disagrees with the byte proxy on Solomon', () => {
-    // The load-bearing regression. Byte-wise Solomon looks 2.7x over; token-wise it fits.
+  it('MEASURES rather than infers — a file can be over the byte bound and still fit', () => {
+    /**
+     * *** DELIBERATELY NOT PINNED TO TODAY'S CONTRACT SIZES. *** The first version of this test
+     * asserted `sol.bytes > SINGLE_READ_SAFE_BYTES` and `coord.fits === true` against the live
+     * files — i.e. it required Solomon's contract to stay over 25 KB and the coordinator's to stay
+     * small. Trimming either (both desirable, and one is an active sibling SD) would have failed a
+     * test with nothing wrong. That is the same defect as the arming table this SD replaced, just
+     * pointed at a different fact.
+     *
+     * The BEHAVIOUR is what matters: bytes and tokens can disagree, and tokens decide. Built from
+     * a synthetic file so it stays true whatever happens to the real contracts.
+     */
+    const osx = require_('os'); const fsx = require_('fs'); const px = require_('path');
+    const dir = fsx.mkdtempSync(px.join(osx.tmpdir(), 'ctr-prose-'));
+    // Prose runs ~4.2 bytes/token, so this is far over the byte bound and far under the token one.
+    fsx.writeFileSync(px.join(dir, 'P.md'), 'the quick brown fox jumps over the lazy dog\n'.repeat(1200));
+
+    const fit = singleReadFit(dir, 'P.md');
+    expect(fit.basis).toBe('measured_tokens');
+    expect(fit.bytes).toBeGreaterThan(SINGLE_READ_SAFE_BYTES);  // the byte proxy would disarm it
+    expect(fit.tokens).toBeLessThan(SINGLE_READ_TOKEN_BUDGET);
+    expect(fit.fits).toBe(true);                                // ...measurement says otherwise
+
+    // MUTATION: compare bytes instead of tokens -> fits false. Fails.
+  });
+
+  it('the real contracts are measured by the same rule (reported, not required)', () => {
+    // Sanity only, and deliberately asserts nothing about SIZE — just that each real contract is
+    // genuinely measured and that fits/tokens agree with each other. Whatever the sibling SD does
+    // to CLAUDE_ADAM.md, this keeps passing and the arming table keeps telling the truth.
     const root = process.cwd();
-    const sol = singleReadFit(root, 'CLAUDE_SOLOMON.md');
-    const coord = singleReadFit(root, 'CLAUDE_COORDINATOR.md');
-
-    expect(sol.basis).toBe('measured_tokens');
-    expect(sol.bytes).toBeGreaterThan(SINGLE_READ_SAFE_BYTES); // the proxy would have disarmed it
-    expect(sol.tokens).toBeLessThan(SINGLE_READ_TOKEN_CAP);
-    expect(sol.fits).toBe(true);                               // ...but it genuinely fits
-
-    expect(coord.fits).toBe(true);
-    expect(coord.tokens).toBeLessThan(SINGLE_READ_TOKEN_CAP);
+    for (const f of ['CLAUDE_COORDINATOR.md', 'CLAUDE_SOLOMON.md', 'CLAUDE_ADAM.md']) {
+      const fit = singleReadFit(root, f);
+      expect(fit.basis).toBe('measured_tokens');
+      expect(fit.tokens).toBeGreaterThan(0);
+      expect(fit.fits).toBe(fit.tokens <= SINGLE_READ_TOKEN_BUDGET);
+    }
   });
 
   it('WITHOUT a tokenizer it degrades to disarmed — never to "fits"', () => {
@@ -446,15 +516,35 @@ describe('SEC-F16 — a REQUEST must never stand in for a MEASUREMENT', () => {
     expect(v.basis).toBe('delivered_ranges');
   });
 
-  it('requested ranges ARE used when there is no delivery record at all (legacy state)', () => {
-    // The fallback must still work, or every pre-deliveredRanges session reports unknown forever.
-    const v = contractReadVerdict(
+  it('SEC-F18: legacy requested-ranges coverage can DISPROVE completeness but never prove it', () => {
+    /**
+     * `ranges` is an UPPER bound — you cannot read more than you asked for, but you can read less.
+     * These three legacy shapes are byte-identical to this code and only the last is a full read:
+     *     Read(offset=1, limit=520) truncated at 166   -> union 100%
+     *     3 pages requesting 200 each, each truncated  -> union 100%
+     *     3 pages genuinely paginated and delivered    -> union 100%
+     * So a full-looking requested union reports UNCONFIRMED, not complete.
+     */
+    const full = contractReadVerdict(
       { readCount: 3, lastReadWasPartial: true, ranges: [{ offset: 1, limit: 200 }, { offset: 201, limit: 200 }, { offset: 401, limit: 120 }] },
       T,
       { singleReadFit: overCap }
     );
-    expect(v.fully_read).toBe(true);
-    expect(v.basis).toBe('union_ranges');
+    expect(full.coverage_pct).toBe(100);            // the request did span the file...
+    expect(full.fully_read).toBe(false);            // ...which is not evidence it was delivered
+    expect(full.basis).toBe('requested_ranges_unconfirmed');
+
+    // MUTATION: let the requested union set fully_read -> a truncated legacy read passes. Fails.
+
+    // And the direction it CAN speak to: falling short proves incompleteness.
+    const short = contractReadVerdict(
+      { readCount: 1, lastReadWasPartial: true, ranges: [{ offset: 1, limit: 100 }] },
+      T,
+      { singleReadFit: overCap }
+    );
+    expect(short.fully_read).toBe(false);
+    expect(short.basis).toBe('requested_ranges_incomplete');
+    expect(short.coverage_pct).toBe(19);
   });
 
   it('an EMPTY-after-filter delivery record does not fall back to requested ranges', () => {
@@ -503,17 +593,25 @@ describe('SEC-F10/F11 — measuring the right artefact, with the right encoder',
     expect(framed).toBeGreaterThan(rawTokens);
   });
 
-  it('the budget leaves margin under the cap, and no real verdict sits inside it', () => {
+  it('the budget leaves a real margin under the cap', () => {
     expect(SINGLE_READ_TOKEN_BUDGET).toBeLessThan(SINGLE_READ_TOKEN_CAP);
-    // The margin exists because cl100k_base is GPT-4's tokenizer and the cap is a Claude limit. It
-    // is only honest if no role's answer is DECIDED by it — assert each real contract clears the
-    // budget (or misses it) by more than the margin itself.
-    const root = process.cwd();
-    const margin = SINGLE_READ_TOKEN_CAP - SINGLE_READ_TOKEN_BUDGET;
-    for (const f of ['CLAUDE_COORDINATOR.md', 'CLAUDE_SOLOMON.md', 'CLAUDE_ADAM.md']) {
-      const { tokens } = singleReadFit(root, f);
-      expect(Math.abs(tokens - SINGLE_READ_TOKEN_BUDGET)).toBeGreaterThan(margin);
-    }
+    expect(SINGLE_READ_TOKEN_BUDGET).toBeGreaterThan(0);
+
+    /**
+     * *** THE ASSERTION THAT USED TO LIVE HERE WOULD HAVE BROKEN WHEN THE SIBLING SD SUCCEEDED. ***
+     * It required every real contract to sit further from the budget than the margin itself, to
+     * show no verdict was decided by the margin. True today — but CLAUDE_ADAM.md is 27,566 tokens
+     * and SD-LEO-INFRA-ADAM-CONTRACT-READABLE-001 exists to bring it under 22,500. Any landing in
+     * 20,000-25,000 arms the role CORRECTLY and would have failed this test, silently imposing a
+     * stricter bar than the arming condition itself.
+     *
+     * That is the mirror of the defect this SD was written to fix. The old arming table could not
+     * change when the world changed; this assertion would have broken when the world changed FOR
+     * THE BETTER. Both are a fact about today pinned as a requirement forever.
+     *
+     * The margin's real property — that it is APPLIED — is asserted above against a synthetic
+     * contract built into the band, which no contract trim can invalidate.
+     */
   });
 });
 

--- a/tests/unit/protocol/contract-read-coverage.test.js
+++ b/tests/unit/protocol/contract-read-coverage.test.js
@@ -176,6 +176,52 @@ describe('single-read-safe size — the tier a CI failure forced me to add', () 
   });
 });
 
+describe('the 95% bar is exact — rounding must not move it, and a gauge must not round UP', () => {
+  /**
+   * *** THE FIX FOR THIS SHIPPED WITH A COMMENT INSTEAD OF AN ASSERTION, AND BOTH REVIEWERS CAUGHT
+   * IT INDEPENDENTLY. *** The previous commit corrected `Math.round` running BEFORE the threshold
+   * comparison — which had quietly moved the bar from 95% to 94.5% — and wrote a paragraph about it.
+   * Nothing tested it: restoring the rounding passed all 59 tests. That is the identical gap the
+   * margin had one round earlier. A safety mechanism defended only by a comment is undefended, and
+   * this SD has now produced that shape twice, so it is worth naming as a pattern rather than an
+   * incident: when a fix is subtle enough to need a paragraph, it is subtle enough to need a test.
+   */
+  const T = 520;
+  const overCap = { fits: false, tokens: 27566, bytes: 106286, basis: 'measured_tokens' };
+  const withDelivered = (limit) => ({
+    readCount: 1, lastReadWasPartial: true,
+    deliveredRanges: [{ offset: 1, limit }],
+    lastDelivered: { startLine: 1, numLines: limit, totalLines: T, coveredWholeFile: false },
+  });
+
+  it('493 of 520 lines (94.81%) is NOT a full read', () => {
+    // The exact payload the round-first mutant certifies: 94.8077% rounds to 95, and 95 >= 95.
+    // 5.2% of the contract never delivered, reported complete.
+    const v = contractReadVerdict(withDelivered(493), T, { singleReadFit: overCap });
+    expect(v.fully_read).toBe(false);
+
+    // MUTATION: round before comparing to FULL_COVERAGE_PCT -> fully_read true. Fails.
+  });
+
+  it('494 of 520 lines (95.0%) IS a full read', () => {
+    // The discriminating half: the bar must still be reachable, or the fix would just be "nothing
+    // ever passes" — which no single-sided test could distinguish.
+    const v = contractReadVerdict(withDelivered(494), T, { singleReadFit: overCap });
+    expect(v.fully_read).toBe(true);
+  });
+
+  it('the REPORTED percentage never contradicts the verdict, and never rounds up', () => {
+    // At 493/520 a rounding report would print "95%" beside "not fully read" against a 95% bar,
+    // inviting the reader to assume the verdict is the broken half. Flooring also means the gauge
+    // can never overstate coverage — the failure mode this whole module exists to prevent.
+    const near = contractReadVerdict(withDelivered(493), T, { singleReadFit: overCap });
+    expect(near.coverage_pct).toBeLessThan(FULL_COVERAGE_PCT);
+    expect(near.coverage_pct).toBe(94);
+
+    // MUTATION: report Math.round -> 95, contradicting fully_read:false. Fails.
+  });
+});
+
 describe('coverage threshold', () => {
   it('partial union coverage below the bar is not a full read', () => {
     const v = contractReadVerdict({ readCount: 1, ranges: [{ offset: 1, limit: 200 }] }, 421);
@@ -258,7 +304,7 @@ describe('the byte proxy is RETIRED — readability is measured in tokens', () =
     let body = '';
     for (let i = 0; i < 20000; i++) {
       body += line;
-      if (i % 200 !== 0) continue;
+      if (i % 20 !== 0) continue;   // stride 20, not 200: the band is 2,500 wide and a 3,600-token step can leap clean over it
       fsx.writeFileSync(px.join(dir, file), body);
       const t = singleReadFit(dir, file).tokens;
       if (t > SINGLE_READ_TOKEN_BUDGET && t < SINGLE_READ_TOKEN_CAP) break;
@@ -380,7 +426,7 @@ describe('SEC-F8 — the diligent reader, on the state shape the REAL tracker wr
     // The half that stops the fix from becoming "everything passes".
     const v = contractReadVerdict(lazy, TOTAL, { singleReadFit: overCap });
     expect(v.fully_read).toBe(false);
-    expect(v.coverage_pct).toBe(32);
+    expect(v.coverage_pct).toBe(31);   // 166/520 = 31.92%, FLOORED — a coverage gauge never rounds up
   });
 
   it('AND THE ORDERING IS RIGHT: the diligent reader outscores the lazy one', () => {
@@ -475,7 +521,7 @@ describe('SEC-F16 — a REQUEST must never stand in for a MEASUREMENT', () => {
       { singleReadFit: overCap }
     );
     expect(v.fully_read).toBe(false);
-    expect(v.coverage_pct).toBe(32);
+    expect(v.coverage_pct).toBe(31);   // 166/520 = 31.92%, FLOORED — a coverage gauge never rounds up
     expect(v.basis).toBe('delivered_ranges');
 
     // MUTATION: take the max of the two unions -> 100% fully_read on basis union_ranges. Fails.
@@ -495,7 +541,7 @@ describe('SEC-F16 — a REQUEST must never stand in for a MEASUREMENT', () => {
       { singleReadFit: overCap }
     );
     expect(v.fully_read).toBe(false);
-    expect(v.coverage_pct).toBe(35);
+    expect(v.coverage_pct).toBe(34);   // 180/520 = 34.6%, floored
   });
 
   it('UNDER-reporting is accepted as the safe direction when delivery is partly unrecorded', () => {

--- a/tests/unit/protocol/contract-read-coverage.test.js
+++ b/tests/unit/protocol/contract-read-coverage.test.js
@@ -371,49 +371,107 @@ describe('SEC-F12 — a falsy limit means "nothing delivered", never "to end of 
   });
 });
 
-describe('SEC-F13 — the two range lists are both lower bounds, so take the better one', () => {
+describe('SEC-F16 — a REQUEST must never stand in for a MEASUREMENT', () => {
   /**
-   * I ranked deliveredRanges above ranges "by how much of the FILE each signal describes", then
-   * implemented it as a fixed precedence that returned on the first non-empty list. The lists are
-   * written under DIFFERENT conditions (ranges.push guarded by isPartialRead; deliveredRanges.push
-   * by the presence of tool_response), so deliveredRanges can be a strict SUBSET — and then the
-   * ordering contradicted the very principle it was justified by.
+   * *** THIS BLOCK REPLACED ONE THAT ASSERTED THE FOUNDING DEFECT AS A REQUIREMENT. ***
+   *
+   * Briefly, this module took the MAX of the two range unions, on the premise that both were lower
+   * bounds on what was READ and neither could un-read the other. The premise is false:
+   * protocol-file-tracker.cjs pushes `limit: toolInputData.limit` into ranges[] — the caller's
+   * ARGUMENT, never reconciled against what came back. ranges[] bounds what was REQUESTED.
+   *
+   * So the max let a request outrank a measurement, and a no-limit-honoured truncated read reported
+   * 100% fully read — this SD's founding defect, restored in full by a fix for a milder complaint.
+   * The test that went with it asserted `fully_read: true` from a requested-range union, mutation
+   * note and all: the second green test in this SD to encode a false fact as a requirement.
+   *
+   * The under-report it was trying to fix (deliveredRanges a strict subset when only some calls
+   * carried a tool_response) is SAFE — it costs a spurious re-read. The over-report ships an unread
+   * contract. For a gate that exists to prove a file was read, those do not trade.
    */
   const T = 520;
   const overCap = { fits: false, tokens: 27566, bytes: 106286, basis: 'measured_tokens' };
 
-  it('three diligent pages where only the first carried a tool_response still reports 100%', () => {
+  it('a read that REQUESTED the whole file but was truncated is NOT fully read', () => {
+    // The load-bearing case. Requested 520, harness delivered 166.
+    const v = contractReadVerdict(
+      {
+        readCount: 1, lastReadWasPartial: true,
+        ranges: [{ offset: 1, limit: 520 }],
+        deliveredRanges: [{ offset: 1, limit: 166 }],
+        lastDelivered: { startLine: 1, numLines: 166, totalLines: T, coveredWholeFile: false },
+      },
+      T,
+      { singleReadFit: overCap }
+    );
+    expect(v.fully_read).toBe(false);
+    expect(v.coverage_pct).toBe(32);
+    expect(v.basis).toBe('delivered_ranges');
+
+    // MUTATION: take the max of the two unions -> 100% fully_read on basis union_ranges. Fails.
+    // A finite positive requested limit sails through the positive-limit filter, so ONLY the
+    // delivered-preferred rule catches this.
+  });
+
+  it('pages that requested 200 each but delivered 60 each are NOT fully read', () => {
+    const v = contractReadVerdict(
+      {
+        readCount: 3, lastReadWasPartial: true,
+        ranges: [{ offset: 1, limit: 200 }, { offset: 201, limit: 200 }, { offset: 401, limit: 200 }],
+        deliveredRanges: [{ offset: 1, limit: 60 }, { offset: 201, limit: 60 }, { offset: 401, limit: 60 }],
+        lastDelivered: { startLine: 401, numLines: 60, totalLines: T, coveredWholeFile: false },
+      },
+      T,
+      { singleReadFit: overCap }
+    );
+    expect(v.fully_read).toBe(false);
+    expect(v.coverage_pct).toBe(35);
+  });
+
+  it('UNDER-reporting is accepted as the safe direction when delivery is partly unrecorded', () => {
+    // The mixed-subset case, stated as a deliberate trade rather than left to look like an oversight.
+    // Only page 1 carried a tool_response, so delivery is recorded for 200 of 520 even though all
+    // three pages were read. 38% is WRONG but SAFE; the correct fix is in the tracker.
     const v = contractReadVerdict(
       {
         readCount: 3, lastReadWasPartial: true,
         ranges: [{ offset: 1, limit: 200 }, { offset: 201, limit: 200 }, { offset: 401, limit: 120 }],
-        deliveredRanges: [{ offset: 1, limit: 200 }],   // strict subset — only page 1 had a response
+        deliveredRanges: [{ offset: 1, limit: 200 }],
         lastDelivered: { startLine: 1, numLines: 200, totalLines: T, coveredWholeFile: false },
       },
       T,
       { singleReadFit: overCap }
     );
-    expect(v.fully_read).toBe(true);
-    expect(v.coverage_pct).toBe(100);
-
-    // MUTATION: return on deliveredRanges whenever it is non-empty (the shipped order) -> 38%,
-    // not fully read. Fails. Neither list can un-read the other.
+    expect(v.fully_read).toBe(false);
+    expect(v.basis).toBe('delivered_ranges');
   });
 
-  it('and the measured list still wins when it is the larger one', () => {
-    // The other direction — "take the max" must not collapse into "always prefer requested".
+  it('requested ranges ARE used when there is no delivery record at all (legacy state)', () => {
+    // The fallback must still work, or every pre-deliveredRanges session reports unknown forever.
+    const v = contractReadVerdict(
+      { readCount: 3, lastReadWasPartial: true, ranges: [{ offset: 1, limit: 200 }, { offset: 201, limit: 200 }, { offset: 401, limit: 120 }] },
+      T,
+      { singleReadFit: overCap }
+    );
+    expect(v.fully_read).toBe(true);
+    expect(v.basis).toBe('union_ranges');
+  });
+
+  it('an EMPTY-after-filter delivery record does not fall back to requested ranges', () => {
+    // The subtle half: "no usable delivery" must not be treated as "no delivery record", or a
+    // zero-delivery read would borrow the request's coverage and pass.
     const v = contractReadVerdict(
       {
-        readCount: 2,
-        ranges: [{ offset: 1, limit: 100 }],
-        deliveredRanges: [{ offset: 1, limit: 100 }, { offset: 101, limit: 420 }],
-        lastDelivered: { startLine: 101, numLines: 420, totalLines: T, coveredWholeFile: false },
+        readCount: 1,
+        ranges: [{ offset: 1, limit: 520 }],
+        deliveredRanges: [{ offset: 1, limit: 0 }],
+        lastDelivered: { startLine: 1, numLines: 0, totalLines: T, coveredWholeFile: false },
       },
       T,
       { singleReadFit: overCap }
     );
-    expect(v.coverage_pct).toBe(100);
-    expect(v.basis).toBe('delivered_ranges');
+    expect(v.fully_read).toBe(false);
+    expect(v.coverage_pct).not.toBe(100);
   });
 });
 

--- a/tests/unit/protocol/contract-read-coverage.test.js
+++ b/tests/unit/protocol/contract-read-coverage.test.js
@@ -10,7 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 const require_ = createRequire(import.meta.url);
-const { contractReadVerdict, singleReadFit, FULL_COVERAGE_PCT, SINGLE_READ_SAFE_BYTES, SINGLE_READ_TOKEN_CAP } = require_('../../../lib/protocol/contract-read-coverage.cjs');
+const { contractReadVerdict, singleReadFit, FULL_COVERAGE_PCT, SINGLE_READ_SAFE_BYTES, SINGLE_READ_TOKEN_CAP, SINGLE_READ_TOKEN_BUDGET } = require_('../../../lib/protocol/contract-read-coverage.cjs');
 
 describe('contractReadVerdict — the inversion, both halves', () => {
   it('THE DILIGENT READER: paginated full coverage reports FULLY READ', () => {
@@ -52,19 +52,29 @@ describe('contractReadVerdict — the inversion, both halves', () => {
     // could NOT have made pass.
   });
 
-  it('delivered evidence OUTRANKS ranges when both are present', () => {
-    // A file can have historical paginated ranges AND a recent truncated read. The truncated read is
-    // the more recent fact about what this session actually has in hand.
+  it('COVERAGE IS CUMULATIVE: a later partial read does not erase an earlier full one', () => {
+    /**
+     * *** THIS ASSERTION WAS INVERTED, AND IT IS WHAT KEPT SEC-F8 ALIVE. *** It used to require
+     * fully_read=false here, on the rationale that "the truncated read is the more recent fact about
+     * what this session has in hand". That rationale is wrong: reading MORE of a file cannot un-read
+     * the part already read. Coverage accumulates over a session; it does not track the last call.
+     *
+     * Ranking a single-call fact above whole-file coverage to honour that idea is precisely the
+     * defect this module was built to remove — the same mistake as `lastReadWasPartial`, which was
+     * also a true statement about one call being used to answer a question about the whole file.
+     * Both the old test and the code agreed, so the suite was green and the behaviour was backwards.
+     */
     const status = {
       readCount: 4,
       ranges: [{ offset: 1, limit: 421 }],
       lastDelivered: { startLine: 1, numLines: 100, totalLines: 421, coveredWholeFile: false },
     };
     const v = contractReadVerdict(status, 421);
-    expect(v.fully_read).toBe(false);
-    expect(v.basis).toBe('delivered_lines');
+    expect(v.fully_read).toBe(true);
+    expect(v.basis).toBe('union_ranges');
 
-    // MUTATION: check ranges before lastDelivered -> stale full coverage wins, fully_read true, fails.
+    // MUTATION: rank the single-call delivered tier above the union tier (the shipped order) ->
+    // fully_read false on basis delivered_lines. Fails. That mutation IS the bug SEC-F8 found.
   });
 
   it('a genuinely complete delivered read reports FULLY READ', () => {
@@ -249,6 +259,121 @@ describe('the byte proxy is RETIRED — readability is measured in tokens', () =
     expect(v.basis).toBe('unknown_coverage');
 
     // MUTATION: treat fits!==false as fitting -> an unmeasurable contract reports complete, fails.
+  });
+});
+
+describe('SEC-F8 — the diligent reader, on the state shape the REAL tracker writes', () => {
+  /**
+   * *** THE FOUNDING DEFECT, FOUND AGAIN ONE FIELD OVER, AFTER I HAD DECLARED IT FIXED. ***
+   *
+   * protocol-file-tracker.cjs writes `lastDelivered` UNCONDITIONALLY — after both the partial and
+   * the full branch — so a paginated read carries ranges[] AND a lastDelivered describing only its
+   * FINAL PAGE. The old tier order returned on that single-call fact before the union tier could
+   * run, so a 100%-covered 3-page read of CLAUDE_ADAM.md reported 23% "not fully read", while the
+   * lazy truncated single read reported 32% — BETTER. Exactly the inversion this module exists to
+   * remove, in a different field.
+   *
+   * *** AND THE TEST THAT "PROVED" THE DILIGENT CASE COULD NOT HAVE CAUGHT IT: *** it supplied
+   * ranges WITHOUT lastDelivered, a combination the real tracker never emits. A fixture that cannot
+   * occur in production is not evidence about production. Every fixture below carries all three
+   * fields together, because that is what is actually on disk.
+   */
+  const TOTAL = 520;
+  const overCap = { fits: false, tokens: 27566, bytes: 106286, basis: 'measured_tokens' };
+
+  /** 3 pages covering all 520 lines — ranges, deliveredRanges AND a last-page lastDelivered. */
+  const diligent = {
+    readCount: 3, lastReadWasPartial: true,
+    ranges: [{ offset: 1, limit: 200 }, { offset: 201, limit: 200 }, { offset: 401, limit: 120 }],
+    deliveredRanges: [{ offset: 1, limit: 200 }, { offset: 201, limit: 200 }, { offset: 401, limit: 120 }],
+    lastDelivered: { startLine: 401, numLines: 120, totalLines: TOTAL, coveredWholeFile: false },
+  };
+
+  /** One no-argument read the harness silently truncated at 166 of 520. No ranges — that is the point. */
+  const lazy = {
+    readCount: 1, lastReadWasPartial: false,
+    deliveredRanges: [{ offset: 1, limit: 166 }],
+    lastDelivered: { startLine: 1, numLines: 166, totalLines: TOTAL, coveredWholeFile: false },
+  };
+
+  it('a paginated FULL read reports fully read', () => {
+    const v = contractReadVerdict(diligent, TOTAL, { singleReadFit: overCap });
+    expect(v.fully_read).toBe(true);
+    expect(v.coverage_pct).toBe(100);
+    expect(v.basis).toBe('delivered_ranges');
+
+    // MUTATION: rank the single-call delivered tier above the union tier (the shipped order) ->
+    // returns 23% / not fully read. Fails.
+  });
+
+  it('a truncated no-arg read still does NOT report fully read', () => {
+    // The half that stops the fix from becoming "everything passes".
+    const v = contractReadVerdict(lazy, TOTAL, { singleReadFit: overCap });
+    expect(v.fully_read).toBe(false);
+    expect(v.coverage_pct).toBe(32);
+  });
+
+  it('AND THE ORDERING IS RIGHT: the diligent reader outscores the lazy one', () => {
+    // The invariant in one line. Stated as a comparison because the defect was never about an
+    // absolute number — it was about which of the two came out ahead.
+    const d = contractReadVerdict(diligent, TOTAL, { singleReadFit: overCap });
+    const l = contractReadVerdict(lazy, TOTAL, { singleReadFit: overCap });
+    expect(d.coverage_pct).toBeGreaterThan(l.coverage_pct);
+    expect(d.fully_read && !l.fully_read).toBe(true);
+  });
+
+  it('partial pagination is still partial — union, not "any ranges means done"', () => {
+    const partial = {
+      readCount: 1, lastReadWasPartial: true,
+      ranges: [{ offset: 1, limit: 100 }],
+      deliveredRanges: [{ offset: 1, limit: 100 }],
+      lastDelivered: { startLine: 1, numLines: 100, totalLines: TOTAL, coveredWholeFile: false },
+    };
+    const v = contractReadVerdict(partial, TOTAL, { singleReadFit: overCap });
+    expect(v.fully_read).toBe(false);
+    expect(v.coverage_pct).toBe(19);
+  });
+});
+
+describe('SEC-F10/F11 — measuring the right artefact, with the right encoder', () => {
+  it('a contract mentioning a special-token literal does not silently degrade', () => {
+    // cl100k_base `encode` THROWS on <|endoftext|> even inline in prose. That throw would fall
+    // through to the byte fallback and flip a 25,587-byte contract from ARMED to disarmed on the
+    // strength of a documentation string. encode_ordinary treats it as text.
+    const os = require_('os'); const fsx = require_('fs'); const p = require_('path');
+    const dir = fsx.mkdtempSync(p.join(os.tmpdir(), 'ctr-special-'));
+    fsx.writeFileSync(p.join(dir, 'X.md'), '# doc\nmentions <|endoftext|> inline\n'.repeat(50));
+
+    const fit = singleReadFit(dir, 'X.md');
+    expect(fit.basis).toBe('measured_tokens');   // NOT the byte fallback
+    expect(fit.tokens).toBeGreaterThan(0);
+
+    // MUTATION: swap encode_ordinary back to encode -> throws, basis becomes
+    // conservative_bytes_no_tokenizer, fails.
+  });
+
+  it('counts the FRAMED response, not the raw file', () => {
+    // Read returns cat -n output; the line numbers and tabs count against the cap. Measuring raw
+    // bytes understates the real cost — measuring the wrong artefact is the same error the byte
+    // proxy made, one level down.
+    const root = process.cwd();
+    const framed = singleReadFit(root, 'CLAUDE_COORDINATOR.md').tokens;
+    const rawTokens = require_('tiktoken').get_encoding('cl100k_base')
+      .encode_ordinary(require_('fs').readFileSync(require_('path').join(root, 'CLAUDE_COORDINATOR.md'), 'utf8')).length;
+    expect(framed).toBeGreaterThan(rawTokens);
+  });
+
+  it('the budget leaves margin under the cap, and no real verdict sits inside it', () => {
+    expect(SINGLE_READ_TOKEN_BUDGET).toBeLessThan(SINGLE_READ_TOKEN_CAP);
+    // The margin exists because cl100k_base is GPT-4's tokenizer and the cap is a Claude limit. It
+    // is only honest if no role's answer is DECIDED by it — assert each real contract clears the
+    // budget (or misses it) by more than the margin itself.
+    const root = process.cwd();
+    const margin = SINGLE_READ_TOKEN_CAP - SINGLE_READ_TOKEN_BUDGET;
+    for (const f of ['CLAUDE_COORDINATOR.md', 'CLAUDE_SOLOMON.md', 'CLAUDE_ADAM.md']) {
+      const { tokens } = singleReadFit(root, f);
+      expect(Math.abs(tokens - SINGLE_READ_TOKEN_BUDGET)).toBeGreaterThan(margin);
+    }
   });
 });
 

--- a/tests/unit/protocol/contract-read-coverage.test.js
+++ b/tests/unit/protocol/contract-read-coverage.test.js
@@ -347,7 +347,10 @@ describe('the byte proxy is RETIRED — readability is measured in tokens', () =
     const osx = require_('os'); const fsx = require_('fs'); const px = require_('path');
     const dir = fsx.mkdtempSync(px.join(osx.tmpdir(), 'ctr-prose-'));
     // Prose runs ~4.2 bytes/token, so this is far over the byte bound and far under the token one.
-    fsx.writeFileSync(px.join(dir, 'P.md'), 'the quick brown fox jumps over the lazy dog\n'.repeat(1200));
+    // 700 lines: ~30.8KB, comfortably over the byte bound, and ~17k CALIBRATED tokens — under the
+    // budget. Sized against the calibrated scale; at 1200 it was 29,242 calibrated tokens and the
+    // premise of the test (over on bytes, under on tokens) no longer held.
+    fsx.writeFileSync(px.join(dir, 'P.md'), 'the quick brown fox jumps over the lazy dog\n'.repeat(700));
 
     const fit = singleReadFit(dir, 'P.md');
     expect(fit.basis).toBe('measured_tokens');
@@ -641,6 +644,48 @@ describe('SEC-F10/F11 — measuring the right artefact, with the right encoder',
     const rawTokens = require_('tiktoken').get_encoding('cl100k_base')
       .encode_ordinary(require_('fs').readFileSync(require_('path').join(root, 'CLAUDE_COORDINATOR.md'), 'utf8')).length;
     expect(framed).toBeGreaterThan(rawTokens);
+  });
+
+  it('IS CALIBRATED TO THE HARNESS TOKENIZER, against a recorded ground-truth observation', () => {
+    /**
+     * *** THE GATE SHIPPED WRONG BECAUSE THIS ASSERTION DID NOT EXIST. ***
+     *
+     * cl100k_base is GPT-4's tokenizer; the 25k cap is a CLAUDE limit. I knew that, called it an
+     * irreducible error source, covered it with a 10% margin and shipped — never testing whether the
+     * two were actually close. They are not: cl100k UNDERCOUNTS by ~1.79x.
+     *
+     * GROUND TRUTH, recorded from an actual no-argument Read of CLAUDE_SOLOMON.md:
+     *     "PARTIAL view — showing lines 1-301 of 371 total (26142 tokens, cap 25000)"
+     * cl100k on that exact framed slice: 14,617. Ratio 26,142 / 14,617 = 1.788.
+     *
+     * Uncalibrated, CLAUDE_SOLOMON.md measured 17,390 and this SD ARMED Solomon, reporting "the byte
+     * proxy was disarming a role that already complies" as its headline finding. It was the opposite:
+     * the contract truncates. I had replaced a byte proxy with a token proxy and never validated the
+     * token proxy against the thing it proxies.
+     *
+     * This test re-derives the ratio from the file the observation was taken on, so it fails if the
+     * calibration is removed OR if the contract changes enough to invalidate the recorded datum.
+     */
+    const fsx = require_('fs'); const px = require_('path');
+    const root = process.cwd();
+    const HARNESS_TOKENS_LINES_1_TO_301 = 26142;   // observed, not computed
+    const OBSERVED_LINES = 301;
+
+    const raw = fsx.readFileSync(px.join(root, 'CLAUDE_SOLOMON.md'), 'utf8');
+    const slice = raw.split('\n').slice(0, OBSERVED_LINES).join('\n');
+    const framed = slice.split('\n').map((l, i) => `${String(i + 1).padStart(6)}\t${l}`).join('\n');
+    const cl100k = require_('tiktoken').get_encoding('cl100k_base').encode_ordinary(framed).length;
+
+    const observedRatio = HARNESS_TOKENS_LINES_1_TO_301 / cl100k;
+    // The shipped constant must not UNDERSTATE the measured ratio — understating re-creates the bug.
+    expect(SINGLE_READ_TOKEN_BUDGET).toBeGreaterThan(0);
+    expect(observedRatio).toBeGreaterThan(1.5);   // the two tokenizers are NOT close; that is the point
+
+    // And the consequence that matters: Solomon's contract must NOT be reported as fitting.
+    expect(singleReadFit(root, 'CLAUDE_SOLOMON.md').fits).toBe(false);
+
+    // MUTATION: drop the CL100K_TO_HARNESS multiplier from contractTokenCount -> Solomon reports
+    // fits:true and this fails. That mutation IS the state this SD shipped in for six commits.
   });
 
   it('DEGRADED MODE IS NEVER MORE PERMISSIVE THAN MEASURED MODE', () => {

--- a/tests/unit/protocol/contract-read-coverage.test.js
+++ b/tests/unit/protocol/contract-read-coverage.test.js
@@ -10,7 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 const require_ = createRequire(import.meta.url);
-const { contractReadVerdict, FULL_COVERAGE_PCT } = require_('../../../lib/protocol/contract-read-coverage.cjs');
+const { contractReadVerdict, FULL_COVERAGE_PCT, SINGLE_READ_SAFE_BYTES } = require_('../../../lib/protocol/contract-read-coverage.cjs');
 
 describe('contractReadVerdict — the inversion, both halves', () => {
   it('THE DILIGENT READER: paginated full coverage reports FULLY READ', () => {
@@ -166,5 +166,62 @@ describe('coverage threshold', () => {
     expect(v.coverage_pct).toBe(50);
 
     // MUTATION: sum the limits instead of unioning -> 100%, fully_read true, fails.
+  });
+});
+
+describe('size tier DEFERS to contradicting delivered evidence', () => {
+  /**
+   * *** THIS TIER ORIGINALLY OVERRODE A DIRECT MEASUREMENT WITH A SIZE INFERENCE. ***
+   * A 40KB contract whose own lastDelivered recorded 100 of 500 lines returned fully_read=true on
+   * basis 'single_read_safe_size'. That is a cheap proxy outranking the real signal — the same
+   * defect class this whole module exists to close, reintroduced one tier up by the fix for it.
+   * Found in SECURITY review and reproduced on the merged code before the fix.
+   */
+  it('a small contract with lastDelivered showing partial coverage is NOT fully read', () => {
+    const v = contractReadVerdict(
+      { readCount: 1, lastReadWasPartial: false, lastDelivered: { numLines: 100, totalLines: 500, coveredWholeFile: false } },
+      500,
+      { sizeBytes: 30000 }
+    );
+    expect(v.fully_read).toBe(false);
+    expect(v.basis).toBe('delivered_lines');
+    expect(v.coverage_pct).toBe(20);
+
+    // MUTATION THAT MUST BREAK THIS: run the size tier before checking lastDelivered (the shipped
+    // state). Returns fully_read true on basis single_read_safe_size.
+  });
+
+  it('a small contract with lastDelivered showing FULL coverage is still fully read', () => {
+    // The other half — the guard must not turn into "any lastDelivered blocks the tier".
+    const v = contractReadVerdict(
+      { readCount: 1, lastReadWasPartial: false, lastDelivered: { numLines: 99, totalLines: 99, coveredWholeFile: true } },
+      99,
+      { sizeBytes: 30000 }
+    );
+    expect(v.fully_read).toBe(true);
+  });
+});
+
+describe('SINGLE_READ_SAFE_BYTES is derived from a MEASUREMENT, not an assertion', () => {
+  /**
+   * The original 50,000 was justified by "2 bytes/token is below any real tokenizer's ratio". That
+   * claim was FALSE — measured with tiktoken cl100k_base on 50,000-byte samples: random ASCII ~1.32
+   * B/token (52% over the 25k cap), base64 ~1.40 (43% over), hex/minified ~1.77 (over). Re-derived
+   * as 25,000 tokens x 1.32 = 33,000, set to 32,000 for margin. Pinned here so it cannot drift back
+   * to a number justified by assertion.
+   */
+  it('is bounded by the densest measured tokenization, not by a guessed ratio', () => {
+    const WORST_MEASURED_BYTES_PER_TOKEN = 1.32;
+    const READ_CAP_TOKENS = 25000;
+    expect(SINGLE_READ_SAFE_BYTES).toBeLessThanOrEqual(READ_CAP_TOKENS * WORST_MEASURED_BYTES_PER_TOKEN);
+
+    // MUTATION: raise it back to 50000 -> exceeds 33,000 and fails.
+  });
+
+  it('still admits the coordinator contract and still excludes the over-cap ones', () => {
+    // The bound is only useful if it lands correctly on the real files it governs.
+    expect(25587).toBeLessThanOrEqual(SINGLE_READ_SAFE_BYTES);  // CLAUDE_COORDINATOR.md
+    expect(67501).toBeGreaterThan(SINGLE_READ_SAFE_BYTES);      // CLAUDE_SOLOMON.md
+    expect(104280).toBeGreaterThan(SINGLE_READ_SAFE_BYTES);     // CLAUDE_ADAM.md
   });
 });

--- a/tests/unit/protocol/contract-read-coverage.test.js
+++ b/tests/unit/protocol/contract-read-coverage.test.js
@@ -10,7 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 const require_ = createRequire(import.meta.url);
-const { contractReadVerdict, FULL_COVERAGE_PCT, SINGLE_READ_SAFE_BYTES } = require_('../../../lib/protocol/contract-read-coverage.cjs');
+const { contractReadVerdict, singleReadFit, FULL_COVERAGE_PCT, SINGLE_READ_SAFE_BYTES, SINGLE_READ_TOKEN_CAP } = require_('../../../lib/protocol/contract-read-coverage.cjs');
 
 describe('contractReadVerdict — the inversion, both halves', () => {
   it('THE DILIGENT READER: paginated full coverage reports FULLY READ', () => {
@@ -202,26 +202,137 @@ describe('size tier DEFERS to contradicting delivered evidence', () => {
   });
 });
 
-describe('SINGLE_READ_SAFE_BYTES is derived from a MEASUREMENT, not an assertion', () => {
+describe('the byte proxy is RETIRED — readability is measured in tokens', () => {
   /**
-   * The original 50,000 was justified by "2 bytes/token is below any real tokenizer's ratio". That
-   * claim was FALSE — measured with tiktoken cl100k_base on 50,000-byte samples: random ASCII ~1.32
-   * B/token (52% over the 25k cap), base64 ~1.40 (43% over), hex/minified ~1.77 (over). Re-derived
-   * as 25,000 tokens x 1.32 = 33,000, set to 32,000 for margin. Pinned here so it cannot drift back
-   * to a number justified by assertion.
+   * *** THIS BLOCK REPLACED ONE THAT ASSERTED A FALSE FACT. *** It previously pinned
+   * `expect(67501).toBeGreaterThan(SINGLE_READ_SAFE_BYTES)` — i.e. it required CLAUDE_SOLOMON.md to
+   * be over the bound. Solomon's contract is 67,501 BYTES but 15,965 TOKENS: it reads in one call.
+   * The test was encoding the proxy's error as a requirement, which is how a wrong bound survives.
+   *
+   * Two separate mistakes, both the same shape (a sample presented as a bound):
+   *   1st: "2 B/token is below any real tokenizer's ratio"  — never measured, false.
+   *   2nd: "1.32 B/token is the densest case"               — measured, but a sample MAX, not a max.
+   * cl100k_base is byte-level BPE with 256 single-byte fallbacks, so the true floor is 1.0 B/token.
    */
-  it('is bounded by the densest measured tokenization, not by a guessed ratio', () => {
-    const WORST_MEASURED_BYTES_PER_TOKEN = 1.32;
-    const READ_CAP_TOKENS = 25000;
-    expect(SINGLE_READ_SAFE_BYTES).toBeLessThanOrEqual(READ_CAP_TOKENS * WORST_MEASURED_BYTES_PER_TOKEN);
-
-    // MUTATION: raise it back to 50000 -> exceeds 33,000 and fails.
+  it('the token cap is the REAL harness limit, not a derived proxy', () => {
+    expect(SINGLE_READ_TOKEN_CAP).toBe(25000);
   });
 
-  it('still admits the coordinator contract and still excludes the over-cap ones', () => {
-    // The bound is only useful if it lands correctly on the real files it governs.
-    expect(25587).toBeLessThanOrEqual(SINGLE_READ_SAFE_BYTES);  // CLAUDE_COORDINATOR.md
-    expect(67501).toBeGreaterThan(SINGLE_READ_SAFE_BYTES);      // CLAUDE_SOLOMON.md
-    expect(104280).toBeGreaterThan(SINGLE_READ_SAFE_BYTES);     // CLAUDE_ADAM.md
+  it('the surviving byte constant is sound at the 1.0 B/token FLOOR, not at a sampled ratio', () => {
+    // It is now only the no-tokenizer fallback, so it must hold even for input that encodes at one
+    // token per byte. Anything above 25,000 is unsound at that floor.
+    expect(SINGLE_READ_SAFE_BYTES).toBeLessThanOrEqual(SINGLE_READ_TOKEN_CAP * 1.0);
+
+    // MUTATION: restore 32,000 (the "1.32 B/token" derivation) -> unsound at the floor, fails.
+  });
+
+  it('MEASURES the real contracts, and disagrees with the byte proxy on Solomon', () => {
+    // The load-bearing regression. Byte-wise Solomon looks 2.7x over; token-wise it fits.
+    const root = process.cwd();
+    const sol = singleReadFit(root, 'CLAUDE_SOLOMON.md');
+    const coord = singleReadFit(root, 'CLAUDE_COORDINATOR.md');
+
+    expect(sol.basis).toBe('measured_tokens');
+    expect(sol.bytes).toBeGreaterThan(SINGLE_READ_SAFE_BYTES); // the proxy would have disarmed it
+    expect(sol.tokens).toBeLessThan(SINGLE_READ_TOKEN_CAP);
+    expect(sol.fits).toBe(true);                               // ...but it genuinely fits
+
+    expect(coord.fits).toBe(true);
+    expect(coord.tokens).toBeLessThan(SINGLE_READ_TOKEN_CAP);
+  });
+
+  it('WITHOUT a tokenizer it degrades to disarmed — never to "fits"', () => {
+    // The safe direction. A missing tokenizer must not become a licence to wave contracts through.
+    const fit = { fits: null, tokens: null, bytes: null, basis: 'unmeasurable' };
+    const v = contractReadVerdict({ readCount: 1, lastReadWasPartial: false }, 99, { singleReadFit: fit });
+    expect(v.fully_read).toBe(false);
+    expect(v.basis).toBe('unknown_coverage');
+
+    // MUTATION: treat fits!==false as fitting -> an unmeasurable contract reports complete, fails.
+  });
+});
+
+describe('IMPORT PURITY — the fail-open promise depends on this module having no deps', () => {
+  /**
+   * *** NOTHING PINNED THIS, AND EVERYTHING RESTED ON IT. *** All three consumers
+   * (adam-register.cjs, solomon-register.cjs, coordinator-startup-check.mjs) `require` this module
+   * at TOP LEVEL, outside any try/catch, and all three promise never to block role activation —
+   * coordinator-startup-check.mjs states "Exit code is ALWAYS 0". A throw at import time cannot be
+   * caught by the try/catch inside the check functions, so those promises hold ONLY while this
+   * module imports nothing that can throw.
+   *
+   * That invariant has already been broken once: an earlier revision top-level-required
+   * sd-key-generator.js for one pure helper and transitively ran dotenv.config() plus a Supabase
+   * service-role client factory as import side effects (SECURITY measured process.env going 4 -> 78
+   * keys under `env -i`). It was fixed by deferring the require. This test is what stops it
+   * regressing silently the next time someone needs "just one helper".
+   */
+  it('imports nothing beyond node builtins — no supabase, no dotenv, no tokenizer', () => {
+    const path = require_('path');
+    const modPath = require_.resolve('../../../lib/protocol/contract-read-coverage.cjs');
+    // Load in a pristine child so this test's own imports cannot mask a violation.
+    const { execFileSync } = require_('child_process');
+    const probe = `
+      const before = Object.keys(process.env).length;
+      require(${JSON.stringify(modPath)});
+      const after = Object.keys(process.env).length;
+      const bad = Object.keys(require.cache).filter(k => /supabase|dotenv|tiktoken/i.test(k));
+      console.log(JSON.stringify({ envDelta: after - before, bad: bad.map(f => require('path').basename(f)) }));
+    `;
+    const out = JSON.parse(execFileSync(process.execPath, ['-e', probe], { encoding: 'utf8' }).trim());
+
+    expect(out.envDelta).toBe(0);   // no dotenv side effect
+    expect(out.bad).toEqual([]);    // no credential client, and the tokenizer stays LAZY
+
+    // MUTATION: move the tiktoken or unionRangeCoverage require to top level -> `bad` is non-empty
+    // and this fails. That is exactly the regression that broke fail-open once already.
+    expect(path.basename(modPath)).toBe('contract-read-coverage.cjs');
+  });
+});
+
+describe('SEC-F2 — a degenerate 0-of-0 delivered record must not certify a full read', () => {
+  /**
+   * `covered = numLines >= totalLines` is satisfied by `0 >= 0`, so a 0-of-0 record returned
+   * fully_read=true through the tier documented as STRONGEST evidence — and
+   * protocol-file-tracker.cjs writes exactly that shape. One degenerate harness response would have
+   * permanently green-lit the 25,569-token CLAUDE_ADAM.md for the whole session.
+   */
+  it('0 of 0 delivered lines is NOT a full read of a real file', () => {
+    const v = contractReadVerdict(
+      { readCount: 1, lastReadWasPartial: false, lastDelivered: { numLines: 0, totalLines: 0, coveredWholeFile: true } },
+      520,
+      { singleReadFit: { fits: false, tokens: 25569, bytes: 106286, basis: 'measured_tokens' } }
+    );
+    expect(v.fully_read).toBe(false);
+    expect(v.basis).not.toBe('delivered_lines');
+
+    // MUTATION: drop the `totalLines > 0` guard -> 0>=0 certifies it, fails.
+  });
+
+  it('a genuine 1-of-1 delivered record still IS a full read', () => {
+    // The other half — the guard must reject degenerate records, not all small ones.
+    const v = contractReadVerdict(
+      { readCount: 1, lastDelivered: { numLines: 1, totalLines: 1, coveredWholeFile: true } },
+      1,
+      { singleReadFit: { fits: false, tokens: 99999, bytes: 400000, basis: 'measured_tokens' } }
+    );
+    expect(v.fully_read).toBe(true);
+    expect(v.basis).toBe('delivered_lines');
+  });
+});
+
+describe('SEC-F6 — a bare coveredWholeFile:false contradicts the size tier on its own', () => {
+  it('an explicit not-covered flag is not overridden by the fits-in-one-read inference', () => {
+    // Previously `deliveredContradicts` required BOTH line fields to be finite, so a delivered
+    // record carrying only this flag was overridden by the very inference it denies.
+    const v = contractReadVerdict(
+      { readCount: 1, lastReadWasPartial: false, lastDelivered: { coveredWholeFile: false } },
+      99,
+      { singleReadFit: { fits: true, tokens: 6197, bytes: 25587, basis: 'measured_tokens' } }
+    );
+    expect(v.fully_read).toBe(false);
+    expect(v.basis).not.toBe('single_read_safe_size');
+
+    // MUTATION: require both line fields finite again -> the size tier wins, fully_read true, fails.
   });
 });

--- a/tests/unit/protocol/contract-read-coverage.test.js
+++ b/tests/unit/protocol/contract-read-coverage.test.js
@@ -138,8 +138,12 @@ describe('single-read-safe size — the tier a CI failure forced me to add', () 
    * so trading a false positive for a false negative is not a fix. CI caught it; two tests in
    * tests/unit/adam/ that I had not run locally were asserting the correct behaviour all along.
    */
-  const SAFE = 25_000;   // ~CLAUDE_COORDINATOR.md
-  const OVER = 104_000;  // ~CLAUDE_ADAM.md
+  // SHARED, not restated. This was `const SAFE = 25_000` — a literal copy of a bound the file
+  // already imports, with a comment calling it '~CLAUDE_COORDINATOR.md'. The coordinator contract
+  // is 25,587 bytes and would FAIL that tier, so the label was wrong too. Same class as the
+  // sixth fact-pin: a bound restated instead of shared.
+  const SAFE = SINGLE_READ_SAFE_BYTES;
+  const OVER = 104_000;  // ~CLAUDE_ADAM.md, comfortably over any bound this module uses
 
   it('a small contract read without a partial flag IS fully read, with no further evidence', () => {
     const v = contractReadVerdict({ readCount: 1, lastReadWasPartial: false }, 99, { sizeBytes: SAFE });
@@ -637,6 +641,27 @@ describe('SEC-F10/F11 — measuring the right artefact, with the right encoder',
     const rawTokens = require_('tiktoken').get_encoding('cl100k_base')
       .encode_ordinary(require_('fs').readFileSync(require_('path').join(root, 'CLAUDE_COORDINATOR.md'), 'utf8')).length;
     expect(framed).toBeGreaterThan(rawTokens);
+  });
+
+  it('DEGRADED MODE IS NEVER MORE PERMISSIVE THAN MEASURED MODE', () => {
+    /**
+     * *** THE SEVENTH FINDING, AND IT WAS IN PRODUCTION CODE — WHICH IS WHY FIVE TEST-FOCUSED
+     * SWEEPS MISSED IT. *** The measured path admitted <= 22,500 tokens (a 10% margin under the
+     * cap) while the no-tokenizer byte fallback admitted <= 25,000 bytes — which at the module's own
+     * documented 1.0 B/token floor is 25,000 tokens, i.e. exactly the cap and 2,500 tokens BEYOND
+     * what the measured path allows.
+     *
+     * So the module was most generous exactly where it knew least: it relaxed its bound at the
+     * moment it lost the ability to measure. That is the inverse of the doctrine stated in every
+     * other tier here ("absence of evidence is never promoted to compliance") and the same shape as
+     * every defect this SD has closed.
+     *
+     * Pinned as a RELATIONSHIP rather than as two literals, so it holds if either constant moves.
+     */
+    expect(SINGLE_READ_SAFE_BYTES).toBeLessThanOrEqual(SINGLE_READ_TOKEN_BUDGET);
+
+    // MUTATION: restore SINGLE_READ_SAFE_BYTES = 25000 -> the fallback outruns the measured path
+    // by 2,500 tokens and this fails.
   });
 
   it('the budget leaves a real margin under the cap', () => {

--- a/tests/unit/protocol/contract-read-coverage.test.js
+++ b/tests/unit/protocol/contract-read-coverage.test.js
@@ -335,6 +335,88 @@ describe('SEC-F8 — the diligent reader, on the state shape the REAL tracker wr
   });
 });
 
+describe('SEC-F12 — a falsy limit means "nothing delivered", never "to end of file"', () => {
+  /**
+   * *** A REGRESSION I INTRODUCED WHILE FIXING SEC-F8, CAUGHT BEFORE IT SHIPPED. ***
+   * unionRangeCoverage does `Number(r.limit) || (totalLines - from + 1)` — a falsy limit means
+   * to-EOF. Correct for a REQUESTED range (Read(offset=1) does ask for the rest); exactly backwards
+   * for a DELIVERED one, where limit is the measured line count and 0 means nothing came back.
+   * So a read that delivered NOTHING unioned to 100% and certified as complete, through the tier I
+   * had just promoted to strongest. The tracker guards only on Number.isFinite, and both Number(0)
+   * and Number(null) are finite, so this is reachable from the canonical writer.
+   */
+  const T = 520;
+  const overCap = { fits: false, tokens: 27566, bytes: 106286, basis: 'measured_tokens' };
+
+  for (const [label, limit] of [['zero', 0], ['null', null], ['undefined', undefined], ['negative', -5]]) {
+    it(`a delivered range with a ${label} limit is not coverage`, () => {
+      const v = contractReadVerdict(
+        { readCount: 1, deliveredRanges: [{ offset: 1, limit }], lastDelivered: { startLine: 1, numLines: 0, totalLines: T, coveredWholeFile: false } },
+        T,
+        { singleReadFit: overCap }
+      );
+      expect(v.fully_read).toBe(false);
+      expect(v.coverage_pct).not.toBe(100);
+
+      // MUTATION: drop the positive-limit filter -> unions to 100%, fully_read true. Fails.
+    });
+  }
+
+  it('SEC-F15: an OPEN-ENDED requested range is not full coverage either', () => {
+    // `Read(path, offset=1)` records {offset:1, limit:null}. That is precisely the call the harness
+    // can silently truncate, so reading it as coverage-to-EOF is the original defect again.
+    const v = contractReadVerdict({ readCount: 1, ranges: [{ offset: 1, limit: null }] }, T, { singleReadFit: overCap });
+    expect(v.fully_read).toBe(false);
+    expect(v.basis).toBe('unknown_coverage');
+  });
+});
+
+describe('SEC-F13 — the two range lists are both lower bounds, so take the better one', () => {
+  /**
+   * I ranked deliveredRanges above ranges "by how much of the FILE each signal describes", then
+   * implemented it as a fixed precedence that returned on the first non-empty list. The lists are
+   * written under DIFFERENT conditions (ranges.push guarded by isPartialRead; deliveredRanges.push
+   * by the presence of tool_response), so deliveredRanges can be a strict SUBSET — and then the
+   * ordering contradicted the very principle it was justified by.
+   */
+  const T = 520;
+  const overCap = { fits: false, tokens: 27566, bytes: 106286, basis: 'measured_tokens' };
+
+  it('three diligent pages where only the first carried a tool_response still reports 100%', () => {
+    const v = contractReadVerdict(
+      {
+        readCount: 3, lastReadWasPartial: true,
+        ranges: [{ offset: 1, limit: 200 }, { offset: 201, limit: 200 }, { offset: 401, limit: 120 }],
+        deliveredRanges: [{ offset: 1, limit: 200 }],   // strict subset — only page 1 had a response
+        lastDelivered: { startLine: 1, numLines: 200, totalLines: T, coveredWholeFile: false },
+      },
+      T,
+      { singleReadFit: overCap }
+    );
+    expect(v.fully_read).toBe(true);
+    expect(v.coverage_pct).toBe(100);
+
+    // MUTATION: return on deliveredRanges whenever it is non-empty (the shipped order) -> 38%,
+    // not fully read. Fails. Neither list can un-read the other.
+  });
+
+  it('and the measured list still wins when it is the larger one', () => {
+    // The other direction — "take the max" must not collapse into "always prefer requested".
+    const v = contractReadVerdict(
+      {
+        readCount: 2,
+        ranges: [{ offset: 1, limit: 100 }],
+        deliveredRanges: [{ offset: 1, limit: 100 }, { offset: 101, limit: 420 }],
+        lastDelivered: { startLine: 101, numLines: 420, totalLines: T, coveredWholeFile: false },
+      },
+      T,
+      { singleReadFit: overCap }
+    );
+    expect(v.coverage_pct).toBe(100);
+    expect(v.basis).toBe('delivered_ranges');
+  });
+});
+
 describe('SEC-F10/F11 — measuring the right artefact, with the right encoder', () => {
   it('a contract mentioning a special-token literal does not silently degrade', () => {
     // cl100k_base `encode` THROWS on <|endoftext|> even inline in prose. That throw would fall

--- a/tests/unit/protocol/fallback-must-not-write-read-record.test.js
+++ b/tests/unit/protocol/fallback-must-not-write-read-record.test.js
@@ -1,0 +1,98 @@
+/**
+ * SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 — FR-1 regression guard.
+ *
+ * *** THIS FILE EXISTS BECAUSE THE HIGHEST-SEVERITY FIX IN THE SD HAD NO TEST THAT COULD CATCH ITS
+ * REGRESSION. *** TESTING re-ran my mutations independently and found that restoring
+ * markProtocolFileRead() in the PASS_FALLBACK branch — reintroducing the exact self-falsifying defect
+ * FR-1 fixes — produced ZERO failures across every reachable test. Two compounding reasons:
+ *
+ *   1. tests/unit/protocol-file-read-gate.test.js is QUARANTINED (order-dependent flake, unrelated to
+ *      this SD) and skips SILENTLY even when named directly on the CLI — `vitest run <that file>`
+ *      reports "No test files found". A regression net that cannot run is not a net.
+ *   2. Its closest case ("fallback-pass then tracked-pass") calls markProtocolFileRead ITSELF before
+ *      asserting, so it cannot distinguish the gate writing the record from the test writing it.
+ *
+ * WHAT THIS TEST IS, STATED PLAINLY: a source-level assertion, not a behavioural one. That is weaker
+ * than driving the gate, and it is deliberate — the behavioural path is quarantined and this file
+ * lives outside that manifest so it actually executes. It catches the specific regression that
+ * matters: someone re-adding the write to the fallback branch. It would NOT catch a semantically
+ * equivalent write introduced by another name, and I am not claiming otherwise.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const GATE = new URL('../../../scripts/modules/handoff/gates/protocol-file-read-gate.js', import.meta.url);
+const src = readFileSync(GATE, 'utf8');
+
+/**
+ * Strip comments before checking for a call.
+ *
+ * *** THE FIRST VERSION OF THIS GUARD FAILED ON ITS OWN FIX. *** It matched the COMMENT explaining
+ * that markProtocolFileRead used to be called here — decoration, not code. A check that cannot tell
+ * an explanation from an invocation is not a check. That false failure was still useful: reading why
+ * it fired surfaced a SECOND site with the identical real defect, in the cross-mode branch.
+ */
+function stripComments(s) {
+  return s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/\/\/[^\n]*/g, '');
+}
+
+/** The PASS_FALLBACK branch: from the fileExists check to the cross-mode section. */
+function fallbackBranch() {
+  const start = src.indexOf('if (fileExists) {');
+  expect(start, 'PASS_FALLBACK branch not found — this guard is anchored to it').toBeGreaterThan(-1);
+  const end = src.indexOf('// SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-030', start);
+  expect(end, 'end of PASS_FALLBACK branch not found').toBeGreaterThan(start);
+  return stripComments(src.slice(start, end));
+}
+
+/** The cross-mode DIGEST fallback — the second site, missed on the first pass. */
+function crossModeBranch() {
+  const start = src.indexOf('if (fullFileExists) {');
+  expect(start, 'cross-mode fallback not found').toBeGreaterThan(-1);
+  const end = src.indexOf('PASS_CROSS_MODE_FALLBACK', start);
+  return stripComments(src.slice(start, end + 400));
+}
+
+describe('FR-1: the fallback must not write a read record it never observed', () => {
+  it('PASS_FALLBACK does NOT call markProtocolFileRead', () => {
+    // The defect: a file that was never read got stamped as read, so every later handoff passed
+    // legitimately on evidence the gate had manufactured — and the failure could not be reproduced,
+    // because the first run destroyed its own precondition.
+    expect(fallbackBranch()).not.toContain('markProtocolFileRead');
+
+    // MUTATION THAT MUST BREAK THIS: re-add markProtocolFileRead(requiredFile) inside the
+    // `if (fileExists)` branch. TESTING verified that mutation is caught by nothing else.
+  });
+
+  it('the fallback still records that no read was observed', () => {
+    const branch = fallbackBranch();
+    // Passing without a read is acceptable; passing SILENTLY, or recording a read, is not.
+    expect(branch).toContain('read_observed: false');
+    expect(branch).toContain('session_state_written: false');
+    expect(branch).toMatch(/NO READ OBSERVED/);
+
+    // MUTATION: drop the read_observed flag -> a log consumer can no longer separate "passed on a
+    // read" from "passed without one", which is the whole point of leaving the pass in place.
+  });
+
+  it('markProtocolFileRead still exists and is still used elsewhere', () => {
+    // Guards against the lazy fix: deleting the function entirely rather than removing this one
+    // call. It is legitimately used on the real read path.
+    expect(src).toContain('markProtocolFileRead');
+  });
+});
+
+describe('FR-1 SECOND SITE: the cross-mode DIGEST fallback had the identical defect', () => {
+  /**
+   * Missed on the first pass. I fixed PASS_FALLBACK and shipped, leaving the same self-falsifying
+   * stamp one screen down in the cross-mode branch — arguably worse there, because it marks the
+   * DIGEST file as read on the strength of the FULL file merely existing, so the record names a file
+   * nobody opened in either form. Surfaced only because the guard above failed for the WRONG reason
+   * and I read why instead of adjusting the anchor.
+   */
+  it('PASS_CROSS_MODE_FALLBACK does NOT call markProtocolFileRead', () => {
+    expect(crossModeBranch()).not.toContain('markProtocolFileRead');
+
+    // MUTATION: re-add markProtocolFileRead(requiredFile) to the fullFileExists branch -> fails.
+  });
+});


### PR DESCRIPTION
## What this closes

A role contract larger than the 25k-token Read cap is silently truncated by a no-argument Read. The old check answered "was the contract read?" from `lastReadWasPartial` — a fact about the MOST RECENT call — which inverts on exactly those files:

- a no-offset Read truncates and records `lastReadWasPartial=false` → **"read"**
- a diligent paginated full read records `true` on its last page → **"partial"**

The reader who did the least was recorded complete. Filed as feedback `39c3d27d` on 2026-07-19 and mis-titled as a capability gap, which is why it sat: the capability was already there.

## Approach

Fixed at the **consumer**, deliberately. The same stamp feeds `protocol-file-read-gate.js:159`, which is wired into all four handoff executors, so redefining it at the tracker would change handoff gating for CLAUDE_LEAD/PLAN/EXEC.md fleet-wide to fix a defect affecting two role contracts.

`lib/protocol/contract-read-coverage.cjs` decides from evidence, ranked by **bound direction** — the invariant that retired a whole defect class:

| signal | bound | may set `fully_read` |
|---|---|---|
| `deliveredRanges` | LOWER (measured) | true or false |
| `ranges` | UPPER (requested) | false only |
| `lastDelivered` | POINT SAMPLE | its own call only |

Per-role arming is **measured at runtime**, not stated: coordinator ARMED (~12.2k tokens), adam and solomon disarmed (~51.0k, ~32.2k) against a 22,500 budget.

## The correction worth reading

Arming was calibrated against `cl100k_base` — GPT-4's tokenizer — while the cap is a **Claude** limit. That assumption was written down, covered with a 10% margin, and never tested. It undercounts by **1.788x**.

Uncalibrated, CLAUDE_SOLOMON.md measured 17,390 tokens, so this SD **armed Solomon** and reported "the byte proxy was disarming a role that already complies" as its headline finding. A real no-arg Read truncates at line 301 of 371. Caught only because the VALIDATION sub-agent was asked to verify the load-bearing criterion by *performing the Read* rather than trusting the count. Now calibrated and pinned by a test that re-derives the ratio from the observation.

That was the fifth instance of one root error: every bound in this SD was first justified against a proxy for the limit rather than the limit.

## Verification

- Full unit suite **33,420 passing**; 12 failures across 8 files are pre-existing, none touching these modules (the flake pool rotates — compared by membership, not count).
- Sub-agents: SECURITY **PASS**, VALIDATION **PASS**, REGRESSION CONDITIONAL_PASS, TESTING CONDITIONAL_PASS, RETRO **PASS**. Both conditional verdicts are non-blocking coverage gaps, stated below.
- Handoffs: EXEC→PLAN 90, PLAN→LEAD 96.
- Every safety mechanism verified by mutation, controls falsified before use.

## Stated residuals (not silently carried)

- **The delivered-evidence tier has no producer.** 0 of 13 tracked files carry it across ~1,373 reads; FR-5's founding evidence was a transcript grep for `totalLines` that matched source files mentioning the field. Behaviour is honest — an over-cap contract reports cannot-confirm rather than accepting an upper bound as proof. Logged `e385fbc2`.
- **Session-accumulated coverage assumes an immutable file** (no mtime/hash stamp). Logged `e623c296`.
- **All three behavioural test files for `protocol-file-read-gate.js` are quarantined**, so the modified branch has no live behavioural net; safety verified by code-trace and a source-text guard instead. Pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)