### PR TITLE
feat(SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001): FR-5 — supply the prior-phase feed (lands INERT)

### DIFF
--- a/lib/coordinator/prior-phases.cjs
+++ b/lib/coordinator/prior-phases.cjs
@@ -1,0 +1,95 @@
+/**
+ * SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-5) — supply detectStuckWorker with the phase each
+ * claim held at the START of the staleness window, so "alive but not moving" can be distinguished
+ * from "alive and progressing".
+ *
+ * WHY THIS EXISTS. detectStuckWorker already implements the phase-unchanged guard
+ * (detectors.cjs: `if (priorPhases && c.sd_key in priorPhases && priorPhases[c.sd_key] !== c.current_phase) continue;`)
+ * and runDetectors already threads `priorPhases: opts.priorPhases` straight through. The predicate
+ * was never broken — NO PRODUCTION CALLER EVER SUPPLIED THE DATA. Alpha-3 emitted ~40 heartbeats
+ * over 19 hours with its phase frozen and every gauge read healthy, because liveness was
+ * instrumented and progress was not. This module is the missing data feed, not a new detector.
+ *
+ * WHY sd_phase_handoffs AND NOT A SNAPSHOT TABLE. A naive implementation stores "phase at previous
+ * tick" somewhere and diffs it, which needs new storage — and new storage is chairman-gated DDL.
+ * But the transitions are ALREADY durably recorded: a phase change writes an sd_phase_handoffs row.
+ * So the phase at the start of the window is derivable from history rather than remembered, which
+ * also makes it correct across sweep restarts, host changes and missed ticks — a snapshot table
+ * would silently lose its memory on any of those and report a moving claim as frozen.
+ *
+ * INERT ON ARRIVAL. runAndLogDetectors returns [] unless COORD_DETECTORS_V2 is truthy, and that flag
+ * is absent from .env. Landing this now is a pure data-supply change; the ungate is a SEPARATE
+ * deliberate step owned by the coordinator after the FR-3 observation window closes. Measured
+ * reason for the split: runDetectors fires THIRTEEN detectors including two critical-severity ones,
+ * and the flag is all-or-nothing by construction, so there is no way to activate this predicate
+ * alone today.
+ *
+ * CommonJS to match lib/coordinator/*.cjs.
+ */
+
+'use strict';
+
+/**
+ * PURE/TOTAL. Given the claims bundle and the handoff rows written inside the window, return the
+ * phase each claim held at the START of the window.
+ *
+ * SEMANTICS, stated because the detector's use of the map is easy to invert:
+ *   - a claim WITH a transition in the window   -> map to the EARLIEST from_phase seen, which
+ *     differs from current_phase, so the detector SKIPS it. Progress happened; not stuck.
+ *   - a claim with NO transition in the window  -> map to its CURRENT phase, i.e. unchanged, so the
+ *     detector proceeds to its staleness check. This is the alive-but-not-moving case.
+ *
+ * A claim is deliberately never OMITTED from the map: `sd_key in priorPhases` is what gates the
+ * guard, so omitting a claim would silently disable the phase check for it and fall back to
+ * pure staleness — the pre-existing behaviour this FR exists to improve on.
+ *
+ * @param {Array<object>} claims  bundle.claims — each { sd_key, sd_id?, current_phase }
+ * @param {Array<object>} handoffs rows from sd_phase_handoffs created inside the window
+ * @returns {Record<string,string|null>} sd_key -> phase at window start
+ */
+function buildPriorPhases(claims, handoffs) {
+  const list = Array.isArray(claims) ? claims : [];
+  const rows = Array.isArray(handoffs) ? handoffs : [];
+
+  // Earliest transition per sd_id — its from_phase is the phase held at window start.
+  const earliestBySdId = new Map();
+  for (const h of rows) {
+    if (!h || !h.sd_id) continue;
+    const prev = earliestBySdId.get(h.sd_id);
+    if (!prev || String(h.created_at) < String(prev.created_at)) earliestBySdId.set(h.sd_id, h);
+  }
+
+  const out = {};
+  for (const c of list) {
+    if (!c || !c.sd_key) continue;
+    const moved = c.sd_id ? earliestBySdId.get(c.sd_id) : undefined;
+    // from_phase may legitimately be null on a first transition; null !== current_phase still reads
+    // as "moved", which is the correct verdict.
+    out[c.sd_key] = moved ? (moved.from_phase ?? null) : (c.current_phase ?? null);
+  }
+  return out;
+}
+
+/**
+ * IO seam. Fetch the window's handoffs and build the map. FAIL-OPEN: on any error return null so
+ * the caller passes no priorPhases and the detector behaves exactly as it does today. A failure to
+ * read history must never manufacture a stuck-worker alarm.
+ *
+ * @returns {Promise<Record<string,string|null>|null>}
+ */
+async function fetchPriorPhases(supabase, claims, { windowMs = 60 * 60 * 1000, nowMs = Date.now() } = {}) {
+  try {
+    if (!supabase || !Array.isArray(claims) || claims.length === 0) return null;
+    const since = new Date(nowMs - windowMs).toISOString();
+    const { data, error } = await supabase
+      .from('sd_phase_handoffs')
+      .select('sd_id, from_phase, created_at')
+      .gte('created_at', since);
+    if (error) return null;
+    return buildPriorPhases(claims, data || []);
+  } catch {
+    return null;
+  }
+}
+
+module.exports = { buildPriorPhases, fetchPriorPhases };

--- a/lib/sweep/legacy-fallback.cjs
+++ b/lib/sweep/legacy-fallback.cjs
@@ -25,6 +25,7 @@ const DECONFLICTION_ENABLED = process.env.CROSS_SESSION_DECONFLICTION === 'true'
 const INTENT_WINDOW_MIN = Number(process.env.CROSS_SESSION_INTENT_WINDOW_MIN) || 24 * 60;
 const signalRouterModule = require('../coordinator/signal-router.cjs');
 const coordEventsModule = require('../coordinator/coordination-events.cjs');
+const priorPhasesModule = require('../coordinator/prior-phases.cjs'); // FR-5
 const workerSignalStarvationModule = require('../coordinator/worker-signal-starvation.cjs');
 
 // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 8 (GUARD) — runDeadLetterLegacy fetches the
@@ -125,7 +126,15 @@ async function runCoordinationDetectorsLegacy(ctx) {
   try {
     if (coordEventsModule.coordDetectorsEnabled()) {
       const coordInputs = await coordEventsModule.gatherDetectorInputs(supabase, {});
-      const coordMatches = await coordEventsModule.runAndLogDetectors(supabase, coordInputs);
+            // SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-5): supply the phase each claim held at the
+      // start of the staleness window. detectStuckWorker has always implemented the phase-unchanged
+      // guard and runDetectors has always threaded priorPhases — no production caller ever supplied
+      // the data, so 'alive but not moving' could not be distinguished from 'alive and progressing'.
+      // Derived from sd_phase_handoffs (already durable) rather than a snapshot table, so it survives
+      // sweep restarts and missed ticks. Fail-open: null => detector behaves exactly as before.
+      // INERT until COORD_DETECTORS_V2 is ungated, which is a separate deliberate step.
+      const priorPhases = await priorPhasesModule.fetchPriorPhases(supabase, coordInputs.claims);
+      const coordMatches = await coordEventsModule.runAndLogDetectors(supabase, coordInputs, { priorPhases });
       for (const m of coordMatches) {
         console.log('  COORD_DETECTOR: ' + m.event_type + ' [' + m.severity + '] ' + m.reason + (m.logged ? '' : ' (event-log-failed)'));
       }

--- a/lib/sweep/passes/coordination-detectors.cjs
+++ b/lib/sweep/passes/coordination-detectors.cjs
@@ -10,6 +10,7 @@
 
 const signalRouterModule = require('../../coordinator/signal-router.cjs');
 const coordEventsModule = require('../../coordinator/coordination-events.cjs');
+const priorPhasesModule = require('../../coordinator/prior-phases.cjs'); // FR-5
 const workerSignalStarvationModule = require('../../coordinator/worker-signal-starvation.cjs');
 
 async function run(ctx) {
@@ -40,7 +41,15 @@ async function run(ctx) {
   try {
     if (coordEventsModule.coordDetectorsEnabled()) {
       const coordInputs = await coordEventsModule.gatherDetectorInputs(supabase, {});
-      const coordMatches = await coordEventsModule.runAndLogDetectors(supabase, coordInputs);
+            // SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-5): supply the phase each claim held at the
+      // start of the staleness window. detectStuckWorker has always implemented the phase-unchanged
+      // guard and runDetectors has always threaded priorPhases — no production caller ever supplied
+      // the data, so 'alive but not moving' could not be distinguished from 'alive and progressing'.
+      // Derived from sd_phase_handoffs (already durable) rather than a snapshot table, so it survives
+      // sweep restarts and missed ticks. Fail-open: null => detector behaves exactly as before.
+      // INERT until COORD_DETECTORS_V2 is ungated, which is a separate deliberate step.
+      const priorPhases = await priorPhasesModule.fetchPriorPhases(supabase, coordInputs.claims);
+      const coordMatches = await coordEventsModule.runAndLogDetectors(supabase, coordInputs, { priorPhases });
       for (const m of coordMatches) {
         console.log('  COORD_DETECTOR: ' + m.event_type + ' [' + m.severity + '] ' + m.reason + (m.logged ? '' : ' (event-log-failed)'));
       }

--- a/tests/unit/prior-phases.test.js
+++ b/tests/unit/prior-phases.test.js
@@ -1,0 +1,78 @@
+/**
+ * SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 FR-5 — the prior-phase feed for detectStuckWorker.
+ *
+ * The detector always had the phase-unchanged guard and runDetectors always threaded priorPhases;
+ * no production caller ever supplied the data. Alpha-3 emitted ~40 heartbeats over 19 hours with
+ * its phase frozen while every gauge read healthy — liveness was instrumented, progress was not.
+ *
+ * These tests pin the SEMANTICS, which are easy to invert: the detector SKIPS a claim whose prior
+ * phase differs from its current one.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { buildPriorPhases } = require('../../lib/coordinator/prior-phases.cjs');
+const { detectStuckWorker } = require('../../lib/coordinator/detectors.cjs');
+
+describe('buildPriorPhases', () => {
+  it('a claim that MOVED maps to its earlier phase, so the detector skips it', () => {
+    const claims = [{ sd_key: 'SD-A', sd_id: 'u1', current_phase: 'EXEC' }];
+    const handoffs = [{ sd_id: 'u1', from_phase: 'PLAN', created_at: '2026-07-31T10:00:00Z' }];
+    expect(buildPriorPhases(claims, handoffs)['SD-A']).toBe('PLAN');
+  });
+
+  it('a claim that did NOT move maps to its CURRENT phase — the alive-but-not-moving case', () => {
+    const claims = [{ sd_key: 'SD-B', sd_id: 'u2', current_phase: 'EXEC' }];
+    expect(buildPriorPhases(claims, [])['SD-B']).toBe('EXEC');
+  });
+
+  it('uses the EARLIEST transition in the window, not the latest', () => {
+    // Two hops inside one window: the phase at window START is the first from_phase.
+    const claims = [{ sd_key: 'SD-C', sd_id: 'u3', current_phase: 'EXEC' }];
+    const handoffs = [
+      { sd_id: 'u3', from_phase: 'PLAN', created_at: '2026-07-31T11:00:00Z' },
+      { sd_id: 'u3', from_phase: 'LEAD', created_at: '2026-07-31T09:00:00Z' },
+    ];
+    expect(buildPriorPhases(claims, handoffs)['SD-C']).toBe('LEAD');
+  });
+
+  it('NEVER omits a claim — omission would silently disable the guard for it', () => {
+    // `sd_key in priorPhases` is what gates the check, so a missing key falls back to pure
+    // staleness, i.e. the exact pre-FR-5 behaviour.
+    const claims = [
+      { sd_key: 'SD-D', sd_id: 'u4', current_phase: 'EXEC' },
+      { sd_key: 'SD-E', sd_id: 'u5', current_phase: null },
+    ];
+    const map = buildPriorPhases(claims, []);
+    expect('SD-D' in map).toBe(true);
+    expect('SD-E' in map).toBe(true);
+  });
+
+  it('is TOTAL on junk input', () => {
+    expect(buildPriorPhases(null, null)).toEqual({});
+    expect(buildPriorPhases([{ no_key: 1 }], [{ no_sd_id: 1 }])).toEqual({});
+  });
+});
+
+describe('coupling — the feed actually changes detectStuckWorker verdicts', () => {
+  const NOW = Date.parse('2026-07-31T12:00:00Z');
+  const stale = new Date(NOW - 5 * 60 * 60 * 1000).toISOString(); // 5h idle
+  const claims = [{ sd_key: 'SD-A', sd_id: 'u1', session_id: 's1', current_phase: 'EXEC', heartbeat_at: stale, sd_updated_at: stale }];
+
+  it('WITHOUT the feed, a frozen claim is flagged on staleness alone (pre-FR-5 behaviour)', () => {
+    const r = detectStuckWorker({ claims, now: NOW, thresholdMs: 60 * 60 * 1000 });
+    expect(r.matched).toBe(true);
+  });
+
+  it('WITH the feed, a claim that MOVED is no longer flagged', () => {
+    const priorPhases = buildPriorPhases(claims, [{ sd_id: 'u1', from_phase: 'PLAN', created_at: '2026-07-31T11:30:00Z' }]);
+    const r = detectStuckWorker({ claims, now: NOW, thresholdMs: 60 * 60 * 1000, priorPhases });
+    expect(r.matched).toBe(false);
+  });
+
+  it('WITH the feed, a claim that did NOT move is still flagged — this is the Alpha-3 shape', () => {
+    const priorPhases = buildPriorPhases(claims, []);
+    const r = detectStuckWorker({ claims, now: NOW, thresholdMs: 60 * 60 * 1000, priorPhases });
+    expect(r.matched).toBe(true);
+  });
+});


### PR DESCRIPTION
**FR-5, built as B-split** on the coordinator's ruling: land the wiring **inert** behind the existing flag now; the ungate is a separate deliberate step they own after the FR-3 observation window closes.

## Why the split — measured, not assumed

`runDetectors` fires **thirteen** detectors, including two critical-severity ones (`SPLIT_BRAIN`, `MULTIPLE_ADAMS`), and the gate is all-or-nothing by construction: `coordination-events.cjs:48` reads a single `COORD_DETECTORS_V2` with no per-detector granularity.

So there is no version of this that activates only `STUCK_WORKER` today. Ungating to get one predicate would be a **13-for-1 activation**, in the same session that already un-blinded the starvation gauge. That's what makes the split necessary rather than merely cautious.

Route A (writing from the charter audit) was rejected: that file declares itself read-only in its own header, and a doctrine header that's been quietly falsified is worse than none — the next reader trusts it and is wrong.

## The detector was never broken — nobody ever fed it

`detectStuckWorker` has always implemented the phase-unchanged guard, and `runDetectors` has always threaded `priorPhases` through. No production caller supplied the data, so *alive but not moving* couldn't be told from *alive and progressing*.

Alpha-3 emitted ~40 heartbeats over 19 hours with its phase frozen while every gauge read healthy: liveness was instrumented, progress was not.

This is a caller-side data feed — which is why it reviews as a pure data-supply diff.

## Derived from history, not remembered

The naive shape stores "phase at previous tick" and diffs it, which needs new storage — and new storage is chairman-gated DDL. But transitions are **already** durably recorded in `sd_phase_handoffs`.

That's not just cheaper. A snapshot table silently loses its memory across sweep restarts, host changes and missed ticks, and would then report a *moving* claim as frozen. History has no such failure mode.

## Semantics pinned by test, because they invert easily

| case | maps to | detector |
|---|---|---|
| claim **moved** in window | its earlier phase | **skips** it |
| claim did **not** move | its current phase | proceeds to staleness check |

A claim is **never omitted** from the map — `sd_key in priorPhases` is what gates the guard, so omitting one would silently disable the check for it and fall back to pre-FR-5 behaviour.

## Inertness proven, not asserted

With `COORD_DETECTORS_V2` absent from `.env`: `coordDetectorsEnabled()` is `false`, and `runAndLogDetectors` returns `[]` with **zero write attempts** even when `priorPhases` is passed.

Fail-open too — `fetchPriorPhases` returns `null` on any read error, so a failure to read history can never manufacture a stuck-worker alarm.

## Verification

90/90 across the new suite — including three **coupling** tests proving the feed actually flips `detectStuckWorker` verdicts rather than merely being accepted — plus detectors, worker-signal-starvation, receipt-ledger and retention-ack-marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)