### PR TITLE
feat(SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001): FR-2 answered-rate query — UNMEASURED is not UNANSWERED

### DIFF
--- a/lib/coordination/answered-rate.cjs
+++ b/lib/coordination/answered-rate.cjs
@@ -1,0 +1,148 @@
+/**
+ * SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-2, acceptance half) — compute the answered rate
+ * from the DURABLE ledger, and refuse to report a number the data cannot support.
+ *
+ * READ THE LEDGER, NEVER session_coordination. cleanup_expired_coordination() deletes ACKED rows at
+ * created+24h while UNACKED rows persist, so a survivor-table rate measures the deletion policy
+ * rather than anyone's conduct. Measured 2026-07-31: 0 of 31 acked rows survived 24h against 1,930
+ * unacked that did; to DISPLAY 60% there the true rate would have to be 98.6%.
+ *
+ * ── THE DISTINCTION THIS MODULE EXISTS TO PROTECT ──────────────────────────────────────────────
+ * UNMEASURED IS NOT UNANSWERED. A window in which the writer was not deployed produces zero
+ * receipts — identical, to a naive query, to a window in which nobody answered anything. Reporting
+ * the first as the second manufactures a damning number out of a deployment gap.
+ *
+ * This is not hypothetical. The receipt writer merged to origin/main as d00db0c974e while the
+ * coordinator's root was still behind it and a live .git/index.lock blocked the pull, so THIRTEEN
+ * acks between 15:27:44Z and 15:46:51Z on 2026-07-31 ran pre-fix code and wrote no receipt. Those
+ * acks happened. The answers were real. Only the recording was missing.
+ *
+ * It is also the same shape as the two other measurement defects this SD already fixed: a head:true
+ * count against a missing table returns null and reads as an empty table; a read-stamp on render
+ * read as an answer. In every case an absence was silently rendered as a value. So this module
+ * returns UNKNOWN rather than 0 whenever coverage cannot be established, exactly as
+ * countFailedRuns does for CI.
+ *
+ * CommonJS to match lib/coordination/receipt-ledger.cjs.
+ */
+
+'use strict';
+
+/**
+ * PURE/TOTAL. Compute the answered rate over receipts, excluding retention stamps and any window
+ * the writer was not deployed for.
+ *
+ * @param {object} input
+ * @param {Array<object>} input.receipts  ledger rows: { coordination_id, lane, state, is_retention, created_at }
+ * @param {Array<object>} input.signals   the population that SHOULD have receipts: { id, created_at, severity }
+ * @param {Array<{from:string,to:string,reason:string}>} [input.coverageGaps] windows with no writer deployed
+ * @returns {{answered:number|null, total:number, rate:number|null, excluded:number, gaps:Array, verdict:string}}
+ *
+ * rate is null — never 0 — when no signal in the window is measurable. `verdict` names why, so a
+ * caller cannot render UNKNOWN as a healthy zero by accident.
+ */
+function computeAnsweredRate(input = {}) {
+  const receipts = Array.isArray(input.receipts) ? input.receipts : [];
+  const signals = Array.isArray(input.signals) ? input.signals : [];
+  const gaps = Array.isArray(input.coverageGaps) ? input.coverageGaps : [];
+
+  const inGap = (iso) => {
+    if (!iso) return false;
+    const t = Date.parse(/Z$|[+-]\d{2}:?\d{2}$/.test(String(iso)) ? iso : iso + 'Z');
+    if (!Number.isFinite(t)) return false;
+    return gaps.some((g) => {
+      const from = Date.parse(g.from);
+      const to = g.to ? Date.parse(g.to) : Infinity;
+      return t >= from && t <= to;
+    });
+  };
+
+  // A signal raised inside a coverage gap is UNMEASURABLE, not unanswered — drop it from BOTH
+  // numerator and denominator rather than counting it as a miss.
+  const measurable = signals.filter((s) => !inGap(s && s.created_at));
+  const excluded = signals.length - measurable.length;
+
+  if (measurable.length === 0) {
+    return {
+      answered: null,
+      total: 0,
+      rate: null,
+      excluded,
+      gaps,
+      verdict: excluded > 0 ? 'UNKNOWN_ALL_SIGNALS_IN_COVERAGE_GAP' : 'UNKNOWN_NO_SIGNALS_IN_WINDOW',
+    };
+  }
+
+  // A retention stamp is not an answer (FR-7). Counting it would let flood control improve the very
+  // gauge that exists to notice nobody replied.
+  const answeredIds = new Set(
+    receipts
+      .filter((r) => r && r.state === 'disposed' && r.is_retention !== true)
+      .map((r) => r.coordination_id)
+  );
+  const answered = measurable.filter((s) => answeredIds.has(s && s.id)).length;
+
+  return {
+    answered,
+    total: measurable.length,
+    rate: answered / measurable.length,
+    excluded,
+    gaps,
+    verdict: 'MEASURED',
+  };
+}
+
+/**
+ * PURE/TOTAL. Per-seat answered counts, so "NO SEAT AT ZERO" is checkable.
+ *
+ * Grouped by payload.sender_callsign, NOT sender_session: sender_session is an ephemeral UUID, so
+ * grouping on it inflates the seat count (36 apparent seats vs 8 real ones) and lets a seat that
+ * sent its first signals near the window edge show a structurally-fixed zero.
+ */
+function answeredBySeat(input = {}) {
+  const { receipts = [], signals = [], coverageGaps = [] } = input;
+  const { verdict } = computeAnsweredRate({ receipts, signals, coverageGaps });
+  const answeredIds = new Set(
+    (receipts || []).filter((r) => r && r.state === 'disposed' && r.is_retention !== true).map((r) => r.coordination_id)
+  );
+  const bySeat = new Map();
+  for (const s of signals || []) {
+    const seat = (s && s.sender_callsign) || 'unknown';
+    const cur = bySeat.get(seat) || { seat, sent: 0, answered: 0 };
+    cur.sent += 1;
+    if (answeredIds.has(s && s.id)) cur.answered += 1;
+    bySeat.set(seat, cur);
+  }
+  return { seats: [...bySeat.values()].sort((a, b) => b.sent - a.sent), verdict };
+}
+
+/**
+ * PURE/TOTAL. Apply the SD's acceptance thresholds.
+ *
+ * An UNKNOWN rate FAILS rather than passes. A criterion that passes because nothing could be
+ * measured is exactly the false-green this SD exists to remove — the same reason coordinator-ack-
+ * signal.cjs running without error was rejected as evidence that signals get answered.
+ *
+ * minSent guards the seat rule: a seat with fewer than that many signals in the window has too
+ * little data for a zero to mean anything.
+ */
+function evaluateAcceptance(input = {}, { floor = 0.85, minSent = 5 } = {}) {
+  const rate = computeAnsweredRate(input);
+  const { seats } = answeredBySeat(input);
+  const zeroSeats = seats.filter((s) => s.sent >= minSent && s.answered === 0).map((s) => s.seat);
+
+  if (rate.rate === null) {
+    return { pass: false, reason: rate.verdict, rate: null, floor, zeroSeats, excluded: rate.excluded };
+  }
+  const meetsFloor = rate.rate >= floor;
+  return {
+    pass: meetsFloor && zeroSeats.length === 0,
+    reason: !meetsFloor ? 'BELOW_FLOOR' : zeroSeats.length ? 'SEAT_AT_ZERO' : 'PASS',
+    rate: rate.rate,
+    floor,
+    zeroSeats,
+    excluded: rate.excluded,
+  };
+}
+
+module.exports = { computeAnsweredRate, answeredBySeat, evaluateAcceptance };

--- a/tests/unit/answered-rate.test.js
+++ b/tests/unit/answered-rate.test.js
@@ -1,0 +1,136 @@
+/**
+ * SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 FR-2 (acceptance half).
+ *
+ * The load-bearing property is NOT that the arithmetic is right — it is that the query refuses to
+ * report a number the data cannot support. Every measurement defect this SD fixed had the same
+ * shape: an absence silently rendered as a value (a head:true count against a missing table
+ * returning null and reading as empty; a read-stamp on render reading as an answer; a survivor
+ * table whose acked rows had been deleted reading as 0.05% answered).
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { computeAnsweredRate, answeredBySeat, evaluateAcceptance } = require('../../lib/coordination/answered-rate.cjs');
+
+const sig = (id, createdAt, callsign = 'Delta') => ({ id, created_at: createdAt, sender_callsign: callsign });
+const disposed = (id, isRetention = false) => ({ coordination_id: id, lane: 'signal', state: 'disposed', is_retention: isRetention });
+
+describe('computeAnsweredRate', () => {
+  it('computes the rate over measurable signals', () => {
+    const r = computeAnsweredRate({
+      signals: [sig('a', '2026-07-31T10:00:00Z'), sig('b', '2026-07-31T10:05:00Z')],
+      receipts: [disposed('a')],
+    });
+    expect(r.rate).toBe(0.5);
+    expect(r.verdict).toBe('MEASURED');
+  });
+
+  it('a RETENTION receipt is not an answer', () => {
+    const r = computeAnsweredRate({
+      signals: [sig('a', '2026-07-31T10:00:00Z')],
+      receipts: [disposed('a', true)],
+    });
+    expect(r.answered).toBe(0);
+  });
+
+  it('a delivered/seen receipt is not an answer either — only disposed is', () => {
+    const r = computeAnsweredRate({
+      signals: [sig('a', '2026-07-31T10:00:00Z')],
+      receipts: [{ coordination_id: 'a', lane: 'signal', state: 'seen', is_retention: false }],
+    });
+    expect(r.answered).toBe(0);
+  });
+
+  // ── the reason this module exists ────────────────────────────────────────────────────────────
+  it('UNMEASURED IS NOT UNANSWERED: signals inside a coverage gap leave BOTH numerator and denominator', () => {
+    // Real incident: the receipt writer merged as d00db0c974e while the coordinator's root was
+    // behind it and a live .git/index.lock blocked the pull, so 13 acks between 15:27:44Z and
+    // 15:46:51Z ran pre-fix code and wrote no receipt. Those answers happened; only the recording
+    // was missing. A naive query would report them as 13 unanswered signals.
+    const gaps = [{ from: '2026-07-31T15:27:44Z', to: '2026-07-31T15:46:51Z', reason: 'writer not deployed' }];
+    const r = computeAnsweredRate({
+      signals: [sig('in-gap', '2026-07-31T15:30:00Z'), sig('outside', '2026-07-31T16:00:00Z')],
+      receipts: [disposed('outside')],
+      coverageGaps: gaps,
+    });
+    expect(r.total).toBe(1);        // the gap signal is not counted against the rate
+    expect(r.excluded).toBe(1);
+    expect(r.rate).toBe(1);         // NOT 0.5 — the missing receipt was never measurable
+  });
+
+  it('returns UNKNOWN (null), never 0, when every signal falls in a coverage gap', () => {
+    const r = computeAnsweredRate({
+      signals: [sig('a', '2026-07-31T15:30:00Z')],
+      receipts: [],
+      coverageGaps: [{ from: '2026-07-31T15:00:00Z', to: '2026-07-31T16:00:00Z', reason: 'writer not deployed' }],
+    });
+    expect(r.rate).toBe(null);
+    expect(r.rate).not.toBe(0);
+    expect(r.verdict).toBe('UNKNOWN_ALL_SIGNALS_IN_COVERAGE_GAP');
+  });
+
+  it('an empty window is UNKNOWN, not a perfect score', () => {
+    const r = computeAnsweredRate({ signals: [], receipts: [] });
+    expect(r.rate).toBe(null);
+    expect(r.verdict).toBe('UNKNOWN_NO_SIGNALS_IN_WINDOW');
+  });
+
+  it('is TOTAL on junk input', () => {
+    expect(computeAnsweredRate().rate).toBe(null);
+    expect(computeAnsweredRate({ signals: null, receipts: null }).rate).toBe(null);
+  });
+});
+
+describe('answeredBySeat groups by callsign, not by ephemeral session id', () => {
+  it('aggregates a seat across its many session ids', () => {
+    const { seats } = answeredBySeat({
+      signals: [sig('a', '2026-07-31T10:00:00Z', 'Delta'), sig('b', '2026-07-31T10:01:00Z', 'Delta'), sig('c', '2026-07-31T10:02:00Z', 'Bravo')],
+      receipts: [disposed('a')],
+    });
+    const delta = seats.find((s) => s.seat === 'Delta');
+    expect(delta).toEqual({ seat: 'Delta', sent: 2, answered: 1 });
+    expect(seats.find((s) => s.seat === 'Bravo').answered).toBe(0);
+  });
+});
+
+describe('evaluateAcceptance', () => {
+  const many = (n, prefix, callsign, from) =>
+    Array.from({ length: n }, (_, i) => sig(`${prefix}${i}`, from, callsign));
+
+  it('UNKNOWN FAILS — a criterion must never pass because nothing could be measured', () => {
+    const r = evaluateAcceptance({ signals: [], receipts: [] });
+    expect(r.pass).toBe(false);
+    expect(r.reason).toBe('UNKNOWN_NO_SIGNALS_IN_WINDOW');
+  });
+
+  it('fails below the floor', () => {
+    const signals = many(10, 's', 'Delta', '2026-07-31T10:00:00Z');
+    const receipts = signals.slice(0, 5).map((s) => disposed(s.id));
+    expect(evaluateAcceptance({ signals, receipts }).reason).toBe('BELOW_FLOOR');
+  });
+
+  it('fails when a seat sits at zero even if the overall floor is met', () => {
+    const delta = many(20, 'd', 'Delta', '2026-07-31T10:00:00Z');
+    const bravo = many(5, 'b', 'Bravo', '2026-07-31T10:00:00Z');
+    const receipts = delta.map((s) => disposed(s.id)); // Bravo answered zero times
+    const r = evaluateAcceptance({ signals: [...delta, ...bravo], receipts });
+    expect(r.rate).toBe(0.8);
+    expect(r.zeroSeats).toEqual(['Bravo']);
+    expect(r.pass).toBe(false);
+  });
+
+  it('ignores a seat with too few signals for a zero to mean anything', () => {
+    const delta = many(20, 'd', 'Delta', '2026-07-31T10:00:00Z');
+    const newbie = many(2, 'n', 'Echo', '2026-07-31T10:00:00Z');
+    const receipts = delta.map((s) => disposed(s.id));
+    const r = evaluateAcceptance({ signals: [...delta, ...newbie], receipts }, { floor: 0.9, minSent: 5 });
+    expect(r.zeroSeats).toEqual([]);
+  });
+
+  it('passes only when the floor is met AND no seat is at zero', () => {
+    const delta = many(10, 'd', 'Delta', '2026-07-31T10:00:00Z');
+    const bravo = many(10, 'b', 'Bravo', '2026-07-31T10:00:00Z');
+    const receipts = [...delta, ...bravo].map((s) => disposed(s.id));
+    expect(evaluateAcceptance({ signals: [...delta, ...bravo], receipts })).toMatchObject({ pass: true, reason: 'PASS', rate: 1 });
+  });
+});


### PR DESCRIPTION
FR-2 acceptance half. Reads the **durable ledger**, never `session_coordination` — whose cleanup deletes acked rows at `created+24h` while unacked rows persist, so a survivor-table rate measures the deletion policy rather than conduct.

## The property this exists to protect

Not the arithmetic. It's that the query **refuses to report a number the data cannot support.**

A window in which the writer wasn't deployed produces zero receipts — indistinguishable, to a naive query, from a window in which nobody answered. Reporting the first as the second manufactures a damning number out of a deployment gap.

## This already happened to this SD

The receipt writer merged as `d00db0c974e` while the coordinator's root was still behind it and a live `.git/index.lock` blocked the pull. **Thirteen acks between 15:27:44Z and 15:46:51Z ran pre-fix code and wrote no receipt.**

Those acks happened. The answers were real. Only the recording was missing.

`coverageGaps` drops such signals from **both** numerator and denominator rather than scoring them as misses.

## Same shape as every other defect this SD fixed

An absence silently rendered as a value:

| defect | the absence | how it read |
|---|---|---|
| `head:true` count vs missing table | table doesn't exist | empty table |
| read-stamp on render | nobody acted | answered |
| retention deletes acked rows | evidence pruned | 0.05% answered |
| writer not deployed | nothing recorded | nobody answered |

So the rate is `null` and **never 0** when coverage can't be established, and `verdict` names why.

## UNKNOWN fails acceptance

A criterion that passes because nothing could be measured is the false-green this SD exists to remove — the same reason *"`coordinator-ack-signal.cjs` runs without error"* was rejected as evidence that signals get answered.

## Seats group by callsign, not session id

`sender_session` is an ephemeral UUID: grouping on it inflates 8 real seats to 36 apparent ones, and lets a seat that first signalled near the window edge show a structurally-fixed zero. `minSent` guards that too.

## Verification

13/13, including the coverage-gap case reproducing the real 15:27:44Z–15:46:51Z incident, and an explicit assertion that the UNKNOWN rate is `null` and not `0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)