### PR TITLE
feat(SD-FDBK-INFRA-LIVE-PROBE-DDL-001): FR-2/FR-3 — probe POLICY and CONSTRAINT from live catalogs

### DIFF
--- a/scripts/lib/migration-verification.js
+++ b/scripts/lib/migration-verification.js
@@ -57,6 +57,64 @@ async function captureIndexDef(client, schema, name) {
   return r.rows.length ? r.rows[0].indexdef : null;
 }
 
+/**
+ * POLICY capture — SD-FDBK-INFRA-LIVE-PROBE-DDL-001 FR-2 (parent FR-4 AC-1:
+ * "RLS/policy items are verdicted from pg_policies and relrowsecurity directly").
+ *
+ * Returns a stable, comparable definition string built from the live catalog, plus the
+ * table's relrowsecurity — AC-4 requires citing relrowsecurity=FALSE with zero policies,
+ * so the RLS-enabled flag must survive into the captured value, not just the policy body.
+ *
+ * AMBIGUITY RETURNS NULL. A policy name is unique per (table, policy), not per schema, so a
+ * name-only lookup can match rows on several tables. Returning null makes the item
+ * UNVERIFIABLE rather than picking one arbitrarily — per the FR-1 decision
+ * (docs/reference/ddl-approval-record-definition.md), the fail direction is UNVERIFIABLE,
+ * never a false APPLIED. Pass obj.table to disambiguate.
+ */
+async function capturePolicyDef(client, schema, name, table) {
+  const params = table ? [schema, name, table] : [schema, name];
+  const r = await client.query(
+    `SELECT p.tablename, p.policyname, p.permissive, p.roles::text AS roles, p.cmd,
+            COALESCE(p.qual, '') AS qual, COALESCE(p.with_check, '') AS with_check,
+            c.relrowsecurity
+       FROM pg_policies p
+       JOIN pg_class c ON c.relname = p.tablename
+       JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = p.schemaname
+      WHERE p.schemaname = $1 AND p.policyname = $2
+        ${table ? 'AND p.tablename = $3' : ''}`,
+    params
+  );
+  if (r.rows.length !== 1) return null; // 0 = absent, >1 = ambiguous -> UNVERIFIABLE
+  const p = r.rows[0];
+  return `POLICY ${p.policyname} ON ${schema}.${p.tablename} `
+    + `PERMISSIVE=${p.permissive} ROLES=${p.roles} CMD=${p.cmd} `
+    + `USING=(${p.qual}) WITH_CHECK=(${p.with_check}) RLS_ENABLED=${p.relrowsecurity}`;
+}
+
+/**
+ * CONSTRAINT capture — FR-3 (parent FR-4 AC-2: "Constraint items compare
+ * pg_get_constraintdef() BODY, never conname alone").
+ *
+ * The BODY is the point. scripts/verify-migration-apply-state.mjs:358-366 matches on conname
+ * only, so a same-named CHECK with a different body reads APPLIED — that fail-open is exactly
+ * what this closes. Same ambiguity rule as policies: conname is unique per table, not per
+ * schema, so >1 match returns null rather than guessing.
+ */
+async function captureConstraintDef(client, schema, name, table) {
+  const params = table ? [schema, name, table] : [schema, name];
+  const r = await client.query(
+    `SELECT pg_get_constraintdef(con.oid) AS def, rel.relname AS tablename
+       FROM pg_constraint con
+       JOIN pg_namespace n ON n.oid = con.connamespace
+       LEFT JOIN pg_class rel ON rel.oid = con.conrelid
+      WHERE n.nspname = $1 AND con.conname = $2
+        ${table ? 'AND rel.relname = $3' : ''}`,
+    params
+  );
+  if (r.rows.length !== 1) return null; // 0 = absent, >1 = ambiguous -> UNVERIFIABLE
+  return `CONSTRAINT ${name} ON ${schema}.${r.rows[0].tablename} ${r.rows[0].def}`;
+}
+
 export async function captureObjectDefinitions(client, declaredObjects) {
   const out = [];
   for (const obj of declaredObjects) {
@@ -65,7 +123,13 @@ export async function captureObjectDefinitions(client, declaredObjects) {
     else if (obj.kind === 'TRIGGER') definition = await captureTriggerDef(client, obj.schema, obj.name);
     else if (obj.kind === 'VIEW') definition = await captureViewDef(client, obj.schema, obj.name);
     else if (obj.kind === 'INDEX') definition = await captureIndexDef(client, obj.schema, obj.name);
-    out.push({ kind: obj.kind, schema: obj.schema, name: obj.name, definition });
+    // FR-2/FR-3 (SD-FDBK-INFRA-LIVE-PROBE-DDL-001): POLICY and CONSTRAINT were the declared
+    // gap — migration-object-parser.js:5 scopes the MVP to FUNCTION/TRIGGER/VIEW/INDEX, which
+    // is precisely why access-control DDL has never been verifiable. obj.table is optional and
+    // disambiguates; without it an ambiguous match returns null (-> UNVERIFIABLE, never APPLIED).
+    else if (obj.kind === 'POLICY') definition = await capturePolicyDef(client, obj.schema, obj.name, obj.table);
+    else if (obj.kind === 'CONSTRAINT') definition = await captureConstraintDef(client, obj.schema, obj.name, obj.table);
+    out.push({ kind: obj.kind, schema: obj.schema, name: obj.name, ...(obj.table ? { table: obj.table } : {}), definition });
   }
   return out;
 }

--- a/tests/unit/lib/migration-verification-access-control.test.js
+++ b/tests/unit/lib/migration-verification-access-control.test.js
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+
+// SD-FDBK-INFRA-LIVE-PROBE-DDL-001 FR-2/FR-3. Parent FR-4 AC-1 (policies verdicted from
+// pg_policies + relrowsecurity directly) and AC-2 (constraints compare pg_get_constraintdef
+// BODY, never conname alone). A fake client is used so these run without a live DB; the SQL
+// shape itself is exercised against the real database by the SD's smoke steps.
+const { captureObjectDefinitions } = await import('../../../scripts/lib/migration-verification.js');
+
+/** @param {(sql: string, params: any[]) => {rows: any[]}} handler */
+const fakeClient = (handler) => ({ query: async (sql, params) => handler(sql, params) });
+
+describe('FR-2 POLICY capture (parent FR-4 AC-1)', () => {
+  it('captures policy body AND relrowsecurity, since AC-4 must cite RLS_ENABLED', async () => {
+    const client = fakeClient(() => ({
+      rows: [{
+        tablename: 'ventures', policyname: 'p_read', permissive: 'PERMISSIVE',
+        roles: '{authenticated}', cmd: 'SELECT', qual: 'true', with_check: '',
+        relrowsecurity: true,
+      }],
+    }));
+    const [row] = await captureObjectDefinitions(client, [{ kind: 'POLICY', schema: 'public', name: 'p_read', table: 'ventures' }]);
+    expect(row.definition).toContain('POLICY p_read ON public.ventures');
+    expect(row.definition).toContain('CMD=SELECT');
+    expect(row.definition).toContain('RLS_ENABLED=true');
+  });
+
+  // AC-4 is "relrowsecurity=FALSE with zero policies cited" — the disabled case must be
+  // representable, not collapse to the same value as the enabled one.
+  it('a disabled-RLS table is distinguishable from an enabled one', async () => {
+    const client = fakeClient(() => ({
+      rows: [{
+        tablename: 'ventures', policyname: 'p_read', permissive: 'PERMISSIVE',
+        roles: '{authenticated}', cmd: 'SELECT', qual: 'true', with_check: '',
+        relrowsecurity: false,
+      }],
+    }));
+    const [row] = await captureObjectDefinitions(client, [{ kind: 'POLICY', schema: 'public', name: 'p_read', table: 'ventures' }]);
+    expect(row.definition).toContain('RLS_ENABLED=false');
+  });
+
+  it('absent policy -> null (UNVERIFIABLE), not a fabricated definition', async () => {
+    const client = fakeClient(() => ({ rows: [] }));
+    const [row] = await captureObjectDefinitions(client, [{ kind: 'POLICY', schema: 'public', name: 'missing' }]);
+    expect(row.definition).toBeNull();
+  });
+
+  // THE FAIL-DIRECTION RULE from docs/reference/ddl-approval-record-definition.md: ambiguity
+  // must degrade to UNVERIFIABLE, never resolve to an arbitrary match that could read APPLIED.
+  it('AMBIGUOUS policy name across tables -> null, never an arbitrary pick', async () => {
+    const client = fakeClient(() => ({
+      rows: [
+        { tablename: 'ventures', policyname: 'p_read', permissive: 'PERMISSIVE', roles: '{}', cmd: 'SELECT', qual: 'true', with_check: '', relrowsecurity: true },
+        { tablename: 'companies', policyname: 'p_read', permissive: 'PERMISSIVE', roles: '{}', cmd: 'SELECT', qual: 'false', with_check: '', relrowsecurity: true },
+      ],
+    }));
+    const [row] = await captureObjectDefinitions(client, [{ kind: 'POLICY', schema: 'public', name: 'p_read' }]);
+    expect(row.definition).toBeNull();
+  });
+});
+
+describe('FR-3 CONSTRAINT capture (parent FR-4 AC-2)', () => {
+  it('captures the pg_get_constraintdef BODY', async () => {
+    const client = fakeClient(() => ({ rows: [{ def: 'CHECK ((status = ANY (ARRAY[\'a\'::text])))', tablename: 'ventures' }] }));
+    const [row] = await captureObjectDefinitions(client, [{ kind: 'CONSTRAINT', schema: 'public', name: 'ck_status', table: 'ventures' }]);
+    expect(row.definition).toContain('CHECK ((status = ANY');
+    expect(row.definition).toContain('ON public.ventures');
+  });
+
+  // The whole point of AC-2. verify-migration-apply-state.mjs:358-366 matches conname only, so
+  // a same-named CHECK with a different body reads APPLIED. Same name MUST NOT compare equal.
+  it('same conname, DIFFERENT body produces a different definition (the AC-2 fail-open)', async () => {
+    const mk = (def) => fakeClient(() => ({ rows: [{ def, tablename: 'ventures' }] }));
+    const obj = [{ kind: 'CONSTRAINT', schema: 'public', name: 'ck_status', table: 'ventures' }];
+    const [a] = await captureObjectDefinitions(mk('CHECK ((status = ANY (ARRAY[\'a\'::text])))'), obj);
+    const [b] = await captureObjectDefinitions(mk('CHECK ((status = ANY (ARRAY[\'a\'::text, \'b\'::text])))'), obj);
+    expect(a.definition).not.toBe(b.definition);
+  });
+
+  it('AMBIGUOUS constraint name across tables -> null', async () => {
+    const client = fakeClient(() => ({ rows: [{ def: 'CHECK (x)', tablename: 't1' }, { def: 'CHECK (y)', tablename: 't2' }] }));
+    const [row] = await captureObjectDefinitions(client, [{ kind: 'CONSTRAINT', schema: 'public', name: 'ck_dup' }]);
+    expect(row.definition).toBeNull();
+  });
+});
+
+describe('no regression to the pre-existing kinds', () => {
+  it('an unknown kind still yields definition=null rather than throwing', async () => {
+    const client = fakeClient(() => ({ rows: [] }));
+    const [row] = await captureObjectDefinitions(client, [{ kind: 'SEQUENCE', schema: 'public', name: 's1' }]);
+    expect(row).toMatchObject({ kind: 'SEQUENCE', definition: null });
+  });
+});


### PR DESCRIPTION
## The gap

`scripts/lib/migration-object-parser.js:5` scopes the MVP to FUNCTION/TRIGGER/VIEW/INDEX, and
`migration-verification.js` matched it. **POLICY and CONSTRAINT — the two access-control classes —
have never been capturable**, which is why nothing has ever verified access-control DDL against a
chairman approval.

## FR-2 (parent FR-4 AC-1)

`capturePolicyDef` reads `pg_policies` **and** `pg_class.relrowsecurity`. The RLS flag has to
survive into the captured value because AC-4 requires citing `relrowsecurity=FALSE` *with zero
policies* — a policy-body-only capture cannot express the disabled case at all.

## FR-3 (parent FR-4 AC-2)

`captureConstraintDef` compares the `pg_get_constraintdef` **body**.
`verify-migration-apply-state.mjs:358-366` matches `conname` alone, so a same-named CHECK with a
different body reads `APPLIED` — that's the fail-open this closes, and a test asserts the two bodies
do **not** compare equal.

## Ambiguity returns null, and that is the point

Policy and constraint names are unique per **table**, not per schema, so a name-only lookup can
match several rows. Both functions return `null` on `>1` match rather than picking one — degrading
the item to `UNVERIFIABLE` instead of risking a false `APPLIED`.

This is the fail direction fixed in FR-1 (`docs/reference/ddl-approval-record-definition.md`): every
existing fail-open in this area errs toward `APPLIED`, and repeating that would make the sweep
**confidently wrong where it is currently honestly silent**. Optional `obj.table` disambiguates.

## Evidence

Tests **falsified, not merely observed green**: relaxing the guard from `!== 1` to `=== 0` makes
**both** ambiguity tests fail; they pass with it restored. **339 tests pass across 30 affected
files.**

Additive only — existing kinds and the `captureObjectDefinitions` return shape are unchanged for
callers that pass no `table`. 159 insertions.

Depends on #6685 (FR-1) for the fail-direction rationale; no code dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
