### PR TITLE
feat(SD-FDBK-INFRA-LIVE-PROBE-DDL-001): FR-6 LF-normalised hash; FR-4 needs no new probe

### DIFF
--- a/scripts/lib/approved-artifact-hash.js
+++ b/scripts/lib/approved-artifact-hash.js
@@ -1,0 +1,48 @@
+/**
+ * approved-artifact-hash — LF-normalised digest for comparing an approved migration artifact
+ * against what is live. SD-FDBK-INFRA-LIVE-PROBE-DDL-001 FR-6 (parent FR-5).
+ *
+ * Parent FR-5 AC-1: "Hash comparison normalises CRLF to LF before digesting."
+ * Parent FR-5 AC-2: "A byte-identical file differing only in line endings compares EQUAL."
+ *
+ * WHY THIS IS DERIVED RATHER THAN IMPORTED — parent FR-5 AC-3 requires stating the honest
+ * reason, and records it: computePlanContentHash (lib/sd-creation/source-adapters/plan.js:32-36)
+ * DOES exist and IS CRLF-equivalence tested. It is not imported because it ALSO strips trailing
+ * whitespace per line and drags in Supabase wiring — not because nothing exists.
+ *
+ * Both of those matter here specifically:
+ *   - Trailing-whitespace stripping is WRONG for this use. SQL bodies round-tripped through
+ *     pg_get_functiondef / pg_get_constraintdef carry pg's own formatting; silently rewriting
+ *     it would make a real divergence compare EQUAL, which is the exact false-APPLIED direction
+ *     docs/reference/ddl-approval-record-definition.md forbids.
+ *   - Supabase wiring in a pure hash helper would make it unusable from a probe path that
+ *     already holds a pg client and needs no second dependency.
+ *
+ * Normalises CRLF and lone CR to LF. Nothing else. A digest that "helpfully" normalised more
+ * would hide divergence, which is the failure this SD exists to end.
+ */
+import crypto from 'crypto';
+
+/** Normalise line endings to LF. CRLF and lone CR both become LF; no other rewriting. */
+export function normaliseLineEndings(text) {
+  return String(text ?? '').replace(/\r\n/g, '\n').replace(/\r/g, '\n');
+}
+
+/**
+ * SHA-256 of the LF-normalised content.
+ * @param {string} content
+ * @returns {string} hex digest
+ */
+export function approvedArtifactHash(content) {
+  return crypto.createHash('sha256').update(normaliseLineEndings(content), 'utf8').digest('hex');
+}
+
+/**
+ * Compare two artifacts on the LF-normalised digest.
+ * @returns {{equal: boolean, approvedHash: string, liveHash: string}}
+ */
+export function compareArtifacts(approvedContent, liveContent) {
+  const approvedHash = approvedArtifactHash(approvedContent);
+  const liveHash = approvedArtifactHash(liveContent);
+  return { equal: approvedHash === liveHash, approvedHash, liveHash };
+}

--- a/scripts/lib/migration-verification.js
+++ b/scripts/lib/migration-verification.js
@@ -9,6 +9,27 @@
  * SD: SD-LEO-INFRA-CANONICAL-SCRIPTS-APPLY-001
  */
 
+/**
+ * FR-4 (SD-FDBK-INFRA-LIVE-PROBE-DDL-001) — NO SEPARATE proconfig CAPTURE IS NEEDED, and the
+ * reason is measured rather than assumed.
+ *
+ * Parent FR-4 AC-3 reads "Function items compare pg_proc.prosrc/proconfig, so a search_path
+ * change is visible." The AC names columns; its stated PURPOSE is visibility of a search_path
+ * change. pg_get_functiondef already reconstructs the SET clauses from proconfig, so that
+ * purpose is met by the capture below. Verified live against this database, not inferred:
+ * all 3 public functions carrying a non-null proconfig (reset_eva_circuit,
+ * update_leo_settings_timestamp, update_feedback_updated_at) emit a matching
+ * "SET search_path" line in pg_get_functiondef output.
+ *
+ * SCOPE OF THAT CHECK, stated so nobody over-reads it: search_path specifically was verified.
+ * proconfig can carry other GUCs (e.g. statement_timeout); pg_get_functiondef emits SET clauses
+ * generally, but only the search_path case was measured.
+ *
+ * THE STANDING REQUIREMENT this creates: the returned definition must be passed through
+ * VERBATIM. Any future normalisation/trimming that strips SET lines would silently break AC-3
+ * while every existing test still passed. tests/unit/lib/migration-verification-access-control.js
+ * pins that.
+ */
 async function captureFunctionDef(client, schema, name) {
   const r = await client.query(
     `SELECT pg_get_functiondef(p.oid) AS def

--- a/tests/unit/lib/approved-artifact-hash.test.js
+++ b/tests/unit/lib/approved-artifact-hash.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { approvedArtifactHash, normaliseLineEndings, compareArtifacts } from '../../../scripts/lib/approved-artifact-hash.js';
+
+// SD-FDBK-INFRA-LIVE-PROBE-DDL-001 FR-6 / parent FR-5.
+describe('FR-6 LF-normalised artifact hash', () => {
+  const sql = 'CREATE POLICY p ON t\nUSING (true);\n';
+
+  // Parent FR-5 AC-2, verbatim: "A byte-identical file differing only in line endings compares
+  // EQUAL, asserted by test." This is the case schema_migrations_applied.migration_sha256 gets
+  // wrong, since it digests raw bytes.
+  it('AC-2: CRLF and LF versions of the same content hash EQUAL', () => {
+    const crlf = sql.replace(/\n/g, '\r\n');
+    expect(crlf).not.toBe(sql);                       // genuinely different bytes
+    expect(approvedArtifactHash(crlf)).toBe(approvedArtifactHash(sql));
+  });
+
+  it('lone CR is normalised too', () => {
+    expect(approvedArtifactHash(sql.replace(/\n/g, '\r'))).toBe(approvedArtifactHash(sql));
+  });
+
+  // The guard that keeps this honest. A digest that normalised MORE would hide real divergence —
+  // the false-APPLIED direction docs/reference/ddl-approval-record-definition.md forbids, and the
+  // specific reason computePlanContentHash was not imported (it strips trailing whitespace).
+  it('does NOT normalise anything else — trailing whitespace still changes the hash', () => {
+    expect(approvedArtifactHash('SELECT 1;  \n')).not.toBe(approvedArtifactHash('SELECT 1;\n'));
+  });
+
+  it('a real body difference still diverges', () => {
+    expect(approvedArtifactHash('USING (true)')).not.toBe(approvedArtifactHash('USING (false)'));
+  });
+
+  it('normaliseLineEndings handles null/undefined without throwing', () => {
+    expect(normaliseLineEndings(null)).toBe('');
+    expect(normaliseLineEndings(undefined)).toBe('');
+  });
+
+  it('compareArtifacts reports equal across line-ending differences and surfaces both digests', () => {
+    const r = compareArtifacts(sql, sql.replace(/\n/g, '\r\n'));
+    expect(r.equal).toBe(true);
+    expect(r.approvedHash).toBe(r.liveHash);
+    expect(r.approvedHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('compareArtifacts reports unequal on a genuine difference', () => {
+    expect(compareArtifacts('USING (true)', 'USING (false)').equal).toBe(false);
+  });
+});

--- a/tests/unit/lib/migration-verification-access-control.test.js
+++ b/tests/unit/lib/migration-verification-access-control.test.js
@@ -85,6 +85,33 @@ describe('FR-3 CONSTRAINT capture (parent FR-4 AC-2)', () => {
   });
 });
 
+// FR-4 (parent FR-4 AC-3): "Function items compare pg_proc.prosrc/proconfig, so a search_path
+// change is visible." Verified live that pg_get_functiondef already emits SET search_path for
+// every public function carrying a proconfig, so no separate proconfig capture is needed. What
+// MUST hold from here on is that the definition survives VERBATIM — a future normalisation that
+// trimmed or rewrote the definition would strip the SET line and silently break AC-3 while every
+// other test still passed.
+describe('FR-4 function definition passes through verbatim (AC-3 depends on it)', () => {
+  const fakeClient = (def) => ({ query: async () => ({ rows: [{ def }] }) });
+
+  it('a SET search_path line in the definition is preserved exactly', async () => {
+    const { captureObjectDefinitions } = await import('../../../scripts/lib/migration-verification.js');
+    const def = 'CREATE OR REPLACE FUNCTION public.f()\n RETURNS void\n LANGUAGE plpgsql\n SECURITY DEFINER\n SET search_path TO \'public\'\nAS $function$ BEGIN END $function$\n';
+    const [row] = await captureObjectDefinitions(fakeClient(def), [{ kind: 'FUNCTION', schema: 'public', name: 'f' }]);
+    expect(row.definition).toBe(def);                      // byte-identical, not trimmed
+    expect(row.definition).toContain("SET search_path TO 'public'");
+  });
+
+  it('two definitions differing ONLY in search_path are not equal', async () => {
+    const { captureObjectDefinitions } = await import('../../../scripts/lib/migration-verification.js');
+    const mk = (sp) => `CREATE OR REPLACE FUNCTION public.f()\n SET search_path TO '${sp}'\nAS $function$ BEGIN END $function$\n`;
+    const obj = [{ kind: 'FUNCTION', schema: 'public', name: 'f' }];
+    const [a] = await captureObjectDefinitions(fakeClient(mk('public')), obj);
+    const [b] = await captureObjectDefinitions(fakeClient(mk('public, extensions')), obj);
+    expect(a.definition).not.toBe(b.definition);
+  });
+});
+
 describe('no regression to the pre-existing kinds', () => {
   it('an unknown kind still yields definition=null rather than throwing', async () => {
     const client = fakeClient(() => ({ rows: [] }));


### PR DESCRIPTION
Stacked on #6688 (FR-2/FR-3) — retarget to `main` once that merges.

## FR-4 — measured, not assumed, and the answer is "no code needed"

Parent FR-4 AC-3 reads *"Function items compare `pg_proc.prosrc/proconfig`, so a search_path
change is visible."* The AC names **columns**; its stated **purpose** is visibility.

I probed the live database rather than reasoning from the AC text. All 3 public functions carrying
a non-null `proconfig` (`reset_eva_circuit`, `update_leo_settings_timestamp`,
`update_feedback_updated_at`) **already emit a matching `SET search_path` line** in
`pg_get_functiondef` output. The existing `captureFunctionDef` therefore already satisfies AC-3's
purpose. Adding a separate proconfig capture would be redundant code justified by a literal reading
of column names rather than the property they exist to guarantee.

**What that creates instead is a standing requirement:** the definition must pass through
**verbatim**. A future normalisation or trim would strip the `SET` line and silently break AC-3
while every other test still passed. Two tests now pin byte-identical passthrough and
search_path-sensitivity.

Scope of the measurement is stated in the code rather than overclaimed: `search_path` specifically
was verified; `proconfig` can carry other GUCs.

## FR-6 — LF-normalised digest (parent FR-5 AC-1/AC-2)

Derived, not imported — and AC-3 requires stating the honest reason. `computePlanContentHash`
**does** exist and **is** CRLF-tested; it isn't imported because it *also* strips trailing
whitespace and drags in Supabase wiring.

Both matter here. **Trailing-whitespace stripping is actively wrong for this use**: SQL
round-tripped through `pg_get_functiondef` carries pg's own formatting, and rewriting it would make
a real divergence compare **EQUAL** — the exact false-`APPLIED` direction FR-1 forbids. So this
normalises line endings and **nothing else**, and a test asserts trailing whitespace still changes
the hash.

## Evidence

**Falsified, not observed green:** removing normalisation fails **3 of the 7** FR-6 tests; restored,
all pass. **348 tests pass across 31 files.** 143 insertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
