### PR TITLE
feat(SD-FDBK-INFRA-LIVE-PROBE-DDL-001): FR-5a — parse POLICY/CONSTRAINT, stop collapsing per-table names

### DIFF
--- a/scripts/lib/migration-object-parser.js
+++ b/scripts/lib/migration-object-parser.js
@@ -58,11 +58,27 @@ function parseQualifiedName(raw) {
   return { schema: DEFAULT_SCHEMA, name: trimmed };
 }
 
+/**
+ * SD-FDBK-INFRA-LIVE-PROBE-DDL-001 FR-5a — the key now includes `table` when the object has one.
+ *
+ * WHY THIS CHANGED, because it is a behaviour change and not a rename: POLICY, CONSTRAINT,
+ * TRIGGER and INDEX names are unique per TABLE, not per schema. Keying on kind::schema::name
+ * silently COLLAPSED two genuinely different objects into one and dropped the second — and for
+ * policies that is the common case, not an edge case (a schema where many tables each carry a
+ * policy named "select_own" declared exactly one). A dropped declared object is a silent miss,
+ * which is the failure class this SD exists to end; it would have meant probing one table and
+ * reporting the other as verified.
+ *
+ * The change only makes dedupe LESS aggressive — objects that differ solely by table are now
+ * both retained. FUNCTION and VIEW carry no table and are unaffected.
+ */
 function uniqByKindSchemaName(objs) {
   const seen = new Set();
   const out = [];
   for (const o of objs) {
-    const k = `${o.kind}::${o.schema}::${o.name}`;
+    const k = o.table
+      ? `${o.kind}::${o.schema}::${o.table}::${o.name}`
+      : `${o.kind}::${o.schema}::${o.name}`;
     if (seen.has(k)) continue;
     seen.add(k);
     out.push(o);
@@ -98,6 +114,23 @@ export function parseDeclaredObjects(sql) {
     const idx = parseQualifiedName(m[1]);
     const table = parseQualifiedName(m[2]);
     objs.push({ kind: 'INDEX', schema: table.schema, name: idx.name, table: table.name });
+  }
+
+  // SD-FDBK-INFRA-LIVE-PROBE-DDL-001 FR-5a: POLICY and CONSTRAINT. Without these the live
+  // probes added in FR-2/FR-3 have nothing to probe — a migration that changes access-control
+  // DDL declares ZERO objects today, so the sweep cannot even know an object was touched.
+  const policyRe = /\b(?:CREATE|ALTER)\s+POLICY\s+("?[\w]+"?)\s+ON\s+(?:TABLE\s+)?("?[\w]+"?(?:\.[\w"]+)?)/gi;
+  while ((m = policyRe.exec(cleaned)) !== null) {
+    const pol = parseQualifiedName(m[1]);
+    const table = parseQualifiedName(m[2]);
+    objs.push({ kind: 'POLICY', schema: table.schema, name: pol.name, table: table.name });
+  }
+
+  const conRe = /\bALTER\s+TABLE\s+(?:(?:IF\s+EXISTS|ONLY)\s+)*("?[\w]+"?(?:\.[\w"]+)?)[\s\S]*?\bADD\s+CONSTRAINT\s+("?[\w]+"?)/gi;
+  while ((m = conRe.exec(cleaned)) !== null) {
+    const table = parseQualifiedName(m[1]);
+    const con = parseQualifiedName(m[2]);
+    objs.push({ kind: 'CONSTRAINT', schema: table.schema, name: con.name, table: table.name });
   }
 
   return uniqByKindSchemaName(objs);

--- a/tests/unit/lib/migration-object-parser-access-control.test.js
+++ b/tests/unit/lib/migration-object-parser-access-control.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { parseDeclaredObjects } from '../../../scripts/lib/migration-object-parser.js';
+
+// SD-FDBK-INFRA-LIVE-PROBE-DDL-001 FR-5a. Without POLICY/CONSTRAINT parsing, a migration that
+// changes access-control DDL declares ZERO objects, so the FR-2/FR-3 live probes have nothing to
+// probe and the sweep cannot know an object was touched at all.
+describe('FR-5a POLICY parsing', () => {
+  it('CREATE POLICY ... ON table yields a POLICY carrying its table', () => {
+    const objs = parseDeclaredObjects('CREATE POLICY p_read ON public.ventures FOR SELECT USING (true);');
+    expect(objs).toContainEqual({ kind: 'POLICY', schema: 'public', name: 'p_read', table: 'ventures' });
+  });
+
+  it('ALTER POLICY is captured too — a policy can diverge by being altered, not only created', () => {
+    const objs = parseDeclaredObjects('ALTER POLICY p_read ON ventures USING (false);');
+    expect(objs).toContainEqual({ kind: 'POLICY', schema: 'public', name: 'p_read', table: 'ventures' });
+  });
+
+  // THE DEDUPE FIX, and the reason it matters. Policy names are unique per TABLE. The old key
+  // (kind::schema::name) collapsed these two into one and dropped the second — meaning the sweep
+  // would probe one table and report the other as verified. That is a silent miss.
+  it('two same-named policies on DIFFERENT tables are BOTH retained', () => {
+    const objs = parseDeclaredObjects(
+      'CREATE POLICY select_own ON public.ventures FOR SELECT USING (true);\n'
+      + 'CREATE POLICY select_own ON public.companies FOR SELECT USING (true);'
+    );
+    const policies = objs.filter((o) => o.kind === 'POLICY');
+    expect(policies).toHaveLength(2);
+    expect(policies.map((p) => p.table).sort()).toEqual(['companies', 'ventures']);
+  });
+
+  it('a genuinely duplicate declaration is still deduped', () => {
+    const objs = parseDeclaredObjects(
+      'CREATE POLICY p ON public.t USING (true);\nCREATE POLICY p ON public.t USING (true);'
+    );
+    expect(objs.filter((o) => o.kind === 'POLICY')).toHaveLength(1);
+  });
+});
+
+describe('FR-5a CONSTRAINT parsing', () => {
+  it('ALTER TABLE ... ADD CONSTRAINT yields a CONSTRAINT carrying its table', () => {
+    const objs = parseDeclaredObjects("ALTER TABLE public.ventures ADD CONSTRAINT ck_status CHECK (status <> '');");
+    expect(objs).toContainEqual({ kind: 'CONSTRAINT', schema: 'public', name: 'ck_status', table: 'ventures' });
+  });
+
+  it('handles ALTER TABLE IF EXISTS / ONLY forms', () => {
+    const objs = parseDeclaredObjects('ALTER TABLE IF EXISTS ONLY public.t ADD CONSTRAINT c1 UNIQUE (a);');
+    expect(objs).toContainEqual({ kind: 'CONSTRAINT', schema: 'public', name: 'c1', table: 't' });
+  });
+
+  it('same constraint name on different tables: both retained', () => {
+    const objs = parseDeclaredObjects(
+      'ALTER TABLE public.a ADD CONSTRAINT ck_x CHECK (1=1);\nALTER TABLE public.b ADD CONSTRAINT ck_x CHECK (1=1);'
+    );
+    expect(objs.filter((o) => o.kind === 'CONSTRAINT')).toHaveLength(2);
+  });
+});
+
+describe('FR-5a no regression to existing kinds', () => {
+  it('FUNCTION and VIEW (no table) still parse and dedupe by kind::schema::name', () => {
+    const objs = parseDeclaredObjects(
+      'CREATE OR REPLACE FUNCTION public.f() RETURNS void AS $$ BEGIN END $$ LANGUAGE plpgsql;\n'
+      + 'CREATE OR REPLACE VIEW public.v AS SELECT 1;\n'
+      + 'CREATE OR REPLACE FUNCTION public.f() RETURNS void AS $$ BEGIN END $$ LANGUAGE plpgsql;'
+    );
+    expect(objs.filter((o) => o.kind === 'FUNCTION')).toHaveLength(1);
+    expect(objs.filter((o) => o.kind === 'VIEW')).toHaveLength(1);
+  });
+
+  it('a migration mixing all kinds declares each one', () => {
+    const objs = parseDeclaredObjects(
+      'CREATE OR REPLACE FUNCTION public.f() RETURNS trigger AS $$ BEGIN RETURN NEW; END $$ LANGUAGE plpgsql;\n'
+      + 'CREATE TRIGGER t1 AFTER INSERT ON public.ventures FOR EACH ROW EXECUTE FUNCTION public.f();\n'
+      + 'CREATE INDEX ix1 ON public.ventures (id);\n'
+      + 'CREATE POLICY p1 ON public.ventures USING (true);\n'
+      + 'ALTER TABLE public.ventures ADD CONSTRAINT ck1 CHECK (id IS NOT NULL);'
+    );
+    expect(objs.map((o) => o.kind).sort()).toEqual(['CONSTRAINT', 'FUNCTION', 'INDEX', 'POLICY', 'TRIGGER']);
+  });
+});


### PR DESCRIPTION
## Why this is a prerequisite for FR-5

The FR-2/FR-3 live probes shipped (#6688), but **nothing feeds them**.
`migration-object-parser.js:5` scopes the MVP to FUNCTION/TRIGGER/VIEW/INDEX, so a migration that
changes access-control DDL declares **zero objects** — the sweep cannot know an object was touched
at all, let alone compare it.

Adds `CREATE/ALTER POLICY … ON <table>` and `ALTER TABLE … ADD CONSTRAINT`, both emitting the
**table** alongside the name — which the FR-2/FR-3 captures need to disambiguate. Without it they
correctly return `null` and the item degrades to `UNVERIFIABLE`.

## The latent bug found alongside it, which is worse than the missing kinds

`uniqByKindSchemaName` keyed on `kind::schema::name`. **POLICY, CONSTRAINT, TRIGGER and INDEX names
are unique per TABLE, not per schema** — so two genuinely different objects collapsed into one and
the second was **silently dropped**.

For policies this is the *common* case, not an edge case: a schema where many tables each carry a
policy named `select_own` declared exactly one of them. The consequence is precise — **the sweep
would probe one table and report the other as verified.**

A dropped declared object is a silent miss: the exact failure class this SD exists to end, sitting
in the input path of the verifier being built to end it.

The key now includes `table` when present. This only makes dedupe **less** aggressive — genuine
duplicates still collapse, `FUNCTION`/`VIEW` carry no table and are unaffected, and the same latent
collapse is fixed for TRIGGER and INDEX, which were already exposed to it.

## Evidence

**Falsified, not observed green:** dropping `table` from the key fails both "both retained" tests;
restored, they pass. **411 tests pass across 37 files**, including the parser's pre-existing suites.

113 insertions, 1 deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
