### PR TITLE
feat(SD-FDBK-INFRA-LIVE-PROBE-DDL-001): FR-5b — approval artifact resolver with real provenance

### DIFF
--- a/lib/audits/approval-artifact-resolver.js
+++ b/lib/audits/approval-artifact-resolver.js
@@ -1,0 +1,93 @@
+/**
+ * approval-artifact-resolver — resolve a chairman approval to the ARTIFACT a live probe can be
+ * compared against. SD-FDBK-INFRA-LIVE-PROBE-DDL-001 FR-5.
+ *
+ * Implements the contract decided in docs/reference/ddl-approval-record-definition.md (FR-1):
+ *
+ *   - Approval IDENTITY comes from the approval record (chairman_decisions, or the SD/QF/feedback
+ *     metadata the sweep already collects). That is the caller's input here.
+ *   - Approved CONTENT comes from the migration FILE on disk — a genuinely DIFFERENT origin.
+ *   - Object IDENTITY comes from PARSING that file, never from regex-scraping approval prose.
+ *     Prose scraping is what fabricated a nonexistent filename twice
+ *     (chairman-apply-sweep.js:333-345, chairman-apply-collectors.js:42-48).
+ *
+ * WHY THE TWO-ORIGIN RULE IS LOAD-BEARING, not bookkeeping: chairman-apply-collectors.js:199-205
+ * hardcodes provenanceIndependent:false and warns, verbatim, that "21 rows would reach hasApproval
+ * with provenance never established the moment a live prober lands" — because the approval text and
+ * the artifact path are extracted from THE SAME STRING. Comparing those is a string compared
+ * against itself, reported as verification. This module only reports provenanceIndependent when the
+ * content actually came from the filesystem, which is the second origin that claim requires.
+ *
+ * FAIL DIRECTION: every unresolvable case returns resolved:false with a reason, so the caller keeps
+ * the item UNVERIFIABLE. It never returns a partial or inferred artifact. Every existing fail-open
+ * in this area errs toward APPLIED; repeating that would make the sweep confidently wrong where it
+ * is currently honestly silent.
+ */
+import path from 'path';
+import fs from 'fs';
+import { parseDeclaredObjects } from '../../scripts/lib/migration-object-parser.js';
+import { approvedArtifactHash } from '../../scripts/lib/approved-artifact-hash.js';
+
+/** Reasons a resolution can fail. Each maps to UNVERIFIABLE, never to APPLIED. */
+export const UNRESOLVED = Object.freeze({
+  NO_PATH: 'no_artifact_path_in_approval',
+  OUTSIDE_REPO: 'artifact_path_escapes_repo_root',
+  MISSING: 'artifact_file_not_found',
+  UNREADABLE: 'artifact_file_unreadable',
+  NO_OBJECTS: 'artifact_declares_no_objects',
+});
+
+/**
+ * @param {object} opts
+ * @param {string|null} opts.artifactPath - path named by the approval (may be absolute or relative)
+ * @param {string} opts.repoRoot - repository root; the artifact must resolve inside it
+ * @param {object} [deps] - injectable fs for tests
+ * @returns {{resolved: boolean, reason?: string, path?: string, content?: string,
+ *            contentHash?: string, objects?: Array, provenanceIndependent?: boolean}}
+ */
+export function resolveApprovedArtifact({ artifactPath, repoRoot }, deps = {}) {
+  const io = deps.fs || fs;
+  if (!artifactPath || typeof artifactPath !== 'string') {
+    return { resolved: false, reason: UNRESOLVED.NO_PATH };
+  }
+
+  // The approval names a path we did not author. Resolve it and confirm it stays inside the repo:
+  // an approval is not authorisation to read arbitrary filesystem locations.
+  const abs = path.resolve(repoRoot, artifactPath);
+  const rootAbs = path.resolve(repoRoot);
+  const rel = path.relative(rootAbs, abs);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    return { resolved: false, reason: UNRESOLVED.OUTSIDE_REPO, path: abs };
+  }
+
+  if (!io.existsSync(abs)) {
+    // A named-but-absent artifact is the case that historically got fabricated. Absent is a real,
+    // reportable answer — the approval references something this checkout does not have.
+    return { resolved: false, reason: UNRESOLVED.MISSING, path: abs };
+  }
+
+  let content;
+  try {
+    content = io.readFileSync(abs, 'utf8');
+  } catch {
+    return { resolved: false, reason: UNRESOLVED.UNREADABLE, path: abs };
+  }
+
+  const objects = parseDeclaredObjects(content);
+  if (!objects.length) {
+    // The file exists but declares nothing this system can probe. Honest UNVERIFIABLE, not APPLIED.
+    return { resolved: false, reason: UNRESOLVED.NO_OBJECTS, path: abs, content };
+  }
+
+  return {
+    resolved: true,
+    path: abs,
+    content,
+    contentHash: approvedArtifactHash(content),
+    objects,
+    // TRUE only here: the content was read from the FILESYSTEM, a different origin from the
+    // approval prose that named it. That is precisely what collectors:199-205 requires before a
+    // comparison counts as verification rather than self-comparison.
+    provenanceIndependent: true,
+  };
+}

--- a/tests/unit/audits/approval-artifact-resolver.test.js
+++ b/tests/unit/audits/approval-artifact-resolver.test.js
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { resolveApprovedArtifact, UNRESOLVED } from '../../../lib/audits/approval-artifact-resolver.js';
+
+// SD-FDBK-INFRA-LIVE-PROBE-DDL-001 FR-5. Implements the FR-1 contract
+// (docs/reference/ddl-approval-record-definition.md): approval identity from the approval record,
+// approved CONTENT from the file on disk, object identity from PARSING that file.
+const REPO = process.platform === 'win32' ? 'C:\\repo' : '/repo';
+
+/** @param {Record<string,string>} files */
+const fakeFs = (files) => ({
+  existsSync: (p) => Object.prototype.hasOwnProperty.call(files, p),
+  readFileSync: (p) => {
+    if (!Object.prototype.hasOwnProperty.call(files, p)) throw new Error('ENOENT');
+    if (files[p] === null) throw new Error('EACCES');
+    return files[p];
+  },
+});
+
+const POLICY_SQL = 'CREATE POLICY p_read ON public.ventures FOR SELECT USING (true);\n';
+const abs = (rel) => (process.platform === 'win32' ? `${REPO}\\${rel.replace(/\//g, '\\')}` : `${REPO}/${rel}`);
+
+describe('FR-5 approval artifact resolution', () => {
+  it('resolves a real artifact and reports provenanceIndependent', () => {
+    const p = 'database/migrations/20260101_policy.sql';
+    const r = resolveApprovedArtifact({ artifactPath: p, repoRoot: REPO }, { fs: fakeFs({ [abs(p)]: POLICY_SQL }) });
+    expect(r.resolved).toBe(true);
+    expect(r.objects).toContainEqual({ kind: 'POLICY', schema: 'public', name: 'p_read', table: 'ventures' });
+    expect(r.contentHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(r.provenanceIndependent).toBe(true);
+  });
+
+  // THE POINT OF THE WHOLE MODULE. collectors:199-205 warns that 21 rows would reach hasApproval
+  // with provenance never established once a prober lands, because the approval text and artifact
+  // path share one origin. provenanceIndependent may be asserted ONLY when content came from the
+  // filesystem — a second origin. It must never be true on a failed resolution.
+  it('NEVER claims provenanceIndependent when resolution failed', () => {
+    const cases = [
+      { artifactPath: null },
+      { artifactPath: 'database/migrations/absent.sql' },
+      { artifactPath: '../../etc/passwd' },
+    ];
+    for (const c of cases) {
+      const r = resolveApprovedArtifact({ ...c, repoRoot: REPO }, { fs: fakeFs({}) });
+      expect(r.resolved).toBe(false);
+      expect(r.provenanceIndependent).toBeUndefined();
+    }
+  });
+
+  it('no path in the approval -> NO_PATH, not a guess', () => {
+    const r = resolveApprovedArtifact({ artifactPath: null, repoRoot: REPO }, { fs: fakeFs({}) });
+    expect(r.reason).toBe(UNRESOLVED.NO_PATH);
+  });
+
+  // The historically-fabricated case: an approval naming a file that does not exist. "Absent" is a
+  // real, reportable answer; inventing content for it is how the earlier bugs happened.
+  it('named-but-absent artifact -> MISSING, no content invented', () => {
+    const r = resolveApprovedArtifact({ artifactPath: 'database/migrations/nope.sql', repoRoot: REPO }, { fs: fakeFs({}) });
+    expect(r.reason).toBe(UNRESOLVED.MISSING);
+    expect(r.content).toBeUndefined();
+    expect(r.objects).toBeUndefined();
+  });
+
+  it('a path escaping the repo root is REFUSED — an approval is not arbitrary read authority', () => {
+    const r = resolveApprovedArtifact({ artifactPath: '../../../etc/passwd', repoRoot: REPO }, { fs: fakeFs({}) });
+    expect(r.reason).toBe(UNRESOLVED.OUTSIDE_REPO);
+  });
+
+  it('unreadable file -> UNREADABLE rather than throwing into the sweep', () => {
+    const p = 'database/migrations/locked.sql';
+    const r = resolveApprovedArtifact({ artifactPath: p, repoRoot: REPO }, { fs: fakeFs({ [abs(p)]: null }) });
+    expect(r.reason).toBe(UNRESOLVED.UNREADABLE);
+  });
+
+  it('a file declaring nothing probeable -> NO_OBJECTS, never APPLIED-by-default', () => {
+    const p = 'database/migrations/comment-only.sql';
+    const r = resolveApprovedArtifact({ artifactPath: p, repoRoot: REPO }, { fs: fakeFs({ [abs(p)]: '-- just a comment\nSELECT 1;\n' }) });
+    expect(r.reason).toBe(UNRESOLVED.NO_OBJECTS);
+    expect(r.resolved).toBe(false);
+  });
+
+  // FR-6 interlock: the digest is LF-normalised, so a CRLF checkout of the same approved file must
+  // not read as a different artifact.
+  it('CRLF and LF copies of one artifact produce the SAME contentHash', () => {
+    const p = 'database/migrations/x.sql';
+    const lf = resolveApprovedArtifact({ artifactPath: p, repoRoot: REPO }, { fs: fakeFs({ [abs(p)]: POLICY_SQL }) });
+    const crlf = resolveApprovedArtifact({ artifactPath: p, repoRoot: REPO }, { fs: fakeFs({ [abs(p)]: POLICY_SQL.replace(/\n/g, '\r\n') }) });
+    expect(crlf.contentHash).toBe(lf.contentHash);
+  });
+});


### PR DESCRIPTION
Implements the FR-1 contract **in code** rather than leaving it in a document (#6685).

- Approval **identity** → the approval record (caller's input)
- Approved **content** → the migration **file on disk**
- Object **identity** → **parsing** that file, never regex-scraping approval prose (which fabricated
  a nonexistent filename twice: `chairman-apply-sweep.js:333-345`, `collectors:42-48`)

## The two-origin rule is the point, not bookkeeping

`collectors:199-205` hardcodes `provenanceIndependent:false` and warns, verbatim, that *"21 rows
would reach hasApproval with provenance never established the moment a live prober lands"* — because
the approval text and the artifact path are pulled from **the same string**. Comparing those is a
string compared against itself, reported as verification.

This module reports `provenanceIndependent` **only** when content actually came from the filesystem
— the second origin that claim requires — and a test asserts it is **never** set on a failed
resolution.

## Fail direction held throughout

Five distinct unresolvable cases — no path, escapes repo root, missing, unreadable, declares no
objects — each return `resolved:false` with a reason so the caller keeps the item `UNVERIFIABLE`.
Nothing returns a partial or inferred artifact.

Every existing fail-open in this area errs toward `APPLIED`; repeating that would make the sweep
confidently wrong where it is currently honestly silent.

Path containment is deliberate: an approval names a path we did not author, so it resolves against
`repoRoot` and is refused if it escapes. **An approval is not authority to read arbitrary filesystem
locations.**

## Interlocks with FR-6

`contentHash` is the LF-normalised digest, so a CRLF checkout of the same approved file does not read
as a different artifact. Asserted by test.

## Evidence

**Falsified:** setting `provenanceIndependent` on the MISSING branch fails the guard test; restored,
it passes. **519 tests pass across 40 files.** 182 insertions, new files only — no existing behaviour
changed, and `live.probed` is still **not** flipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
