### PR TITLE
feat(SD-FDBK-INFRA-LIVE-PROBE-DDL-001): FR-5c — live-probe enrichment, default-off

### DIFF
--- a/lib/audits/live-probe-enrichment.js
+++ b/lib/audits/live-probe-enrichment.js
@@ -1,0 +1,90 @@
+/**
+ * live-probe-enrichment — turn buildEvidence's hardcoded `live: {probed:false}` into a REAL
+ * reading. SD-FDBK-INFRA-LIVE-PROBE-DDL-001 FR-5.
+ *
+ * WHY THIS IS A SEPARATE PASS RATHER THAN AN EDIT TO buildEvidence: buildEvidence is synchronous
+ * and is called inside a population.map() in the sweep CLI. Live probing needs a database round
+ * trip. Rewriting buildEvidence async would ripple through every caller, so enrichment runs as an
+ * explicit second step over the evidence objects. buildEvidence keeps reporting probed:false, which
+ * stays the correct answer whenever enrichment does not run.
+ *
+ * DEFAULT-OFF BY CONSTRUCTION. With no client this is a no-op that returns the evidence unchanged,
+ * so the sweep's behaviour is byte-identical until a caller opts in. That matters because flipping
+ * live.probed activates three verdict branches (APPLIED, APPLIED-BUT-DIVERGENT,
+ * NOT-APPLIED-BUT-COMPLETED) that have never executed in production, and doing it on partial
+ * evidence would make the sweep confidently wrong where it is currently honestly silent.
+ *
+ * BOTH FLAGS ARE SET HONESTLY OR NEITHER IS. chairman-apply-collectors.js:199-205 warns that 21
+ * rows would reach hasApproval with provenance never established the moment a prober lands, because
+ * the approval text and artifact path share one origin. provenanceIndependent is therefore taken
+ * from the RESOLVER (true only when content came off the filesystem), never assumed here.
+ */
+import { resolveApprovedArtifact } from './approval-artifact-resolver.js';
+
+/**
+ * Probe one evidence object. Pure except for the injected probe/resolver.
+ *
+ * @param {object} evidence - output of buildEvidence(item)
+ * @param {object} opts
+ * @param {object|null} opts.client        - pg client; null/absent => no-op (default OFF)
+ * @param {string}      opts.repoRoot
+ * @param {Function}    opts.captureObjectDefinitions - (client, objects) => Promise<Array>
+ * @param {Function}   [opts.resolve]      - injectable resolver (tests)
+ * @returns {Promise<object>} a NEW evidence object; the input is not mutated
+ */
+export async function enrichEvidenceWithLiveProbe(evidence, opts = {}) {
+  const { client, repoRoot, captureObjectDefinitions, resolve = resolveApprovedArtifact } = opts;
+  if (!client || typeof captureObjectDefinitions !== 'function') return evidence;
+
+  const artifactPath = evidence?.artifact?.path || null;
+  const resolution = resolve({ artifactPath, repoRoot });
+
+  if (!resolution.resolved) {
+    // Unresolvable stays UNVERIFIABLE. Reporting WHY is the difference between an honest
+    // "we could not check" and today's undifferentiated silence.
+    return {
+      ...evidence,
+      live: { probed: false, unresolved_reason: resolution.reason },
+    };
+  }
+
+  let captured;
+  try {
+    captured = await captureObjectDefinitions(client, resolution.objects);
+  } catch (e) {
+    // A probe that ERRORED did not observe anything. Saying probed:true here would assert an
+    // observation we never made — the precise shape of every fail-open in this area.
+    return {
+      ...evidence,
+      live: { probed: false, probe_error: String((e && e.message) || e).slice(0, 200) },
+    };
+  }
+
+  // An object the approval declares but the database does not have is the NOT-APPLIED signal.
+  // Distinguish it from "we could not look", which is the distinction the sweep has never had.
+  const absent = captured.filter((c) => c.definition == null);
+
+  return {
+    ...evidence,
+    approval: { ...evidence.approval, provenanceIndependent: resolution.provenanceIndependent === true },
+    live: {
+      probed: true,
+      artifact_path: resolution.path,
+      artifact_hash: resolution.contentHash,
+      declared: resolution.objects.length,
+      observed: captured.length - absent.length,
+      absent: absent.map((a) => `${a.kind}:${a.schema}.${a.table ? `${a.table}.` : ''}${a.name}`),
+      definitions: captured,
+    },
+  };
+}
+
+/**
+ * Enrich a list. Sequential on purpose: these are database round trips against a shared pooler,
+ * and a sweep is not latency-critical. Failing one item never aborts the rest.
+ */
+export async function enrichAllWithLiveProbe(evidences, opts = {}) {
+  const out = [];
+  for (const e of evidences) out.push(await enrichEvidenceWithLiveProbe(e, opts));
+  return out;
+}

--- a/tests/unit/audits/live-probe-enrichment.test.js
+++ b/tests/unit/audits/live-probe-enrichment.test.js
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { enrichEvidenceWithLiveProbe, enrichAllWithLiveProbe } from '../../../lib/audits/live-probe-enrichment.js';
+
+// SD-FDBK-INFRA-LIVE-PROBE-DDL-001 FR-5. Turns buildEvidence's hardcoded live:{probed:false} into
+// a real reading — without ever asserting an observation that was not made.
+const baseEvidence = (path = 'database/migrations/x.sql') => ({
+  approval: { namesObjects: true, identifiers: ['p_read'], provenanceIndependent: false },
+  artifact: { present: Boolean(path), path },
+  live: { probed: false },
+  secondaryArtifactSearchDone: false,
+  secondaryArtifactFound: false,
+});
+
+const OBJECTS = [{ kind: 'POLICY', schema: 'public', name: 'p_read', table: 'ventures' }];
+const okResolve = () => ({
+  resolved: true, path: '/repo/database/migrations/x.sql', content: 'sql',
+  contentHash: 'a'.repeat(64), objects: OBJECTS, provenanceIndependent: true,
+});
+
+describe('FR-5 live probe enrichment', () => {
+  // DEFAULT-OFF is a safety property, not a convenience: flipping live.probed activates three
+  // verdict branches that have never executed in production.
+  it('no client -> exact no-op, evidence returned unchanged', async () => {
+    const e = baseEvidence();
+    const out = await enrichEvidenceWithLiveProbe(e, { repoRoot: '/repo' });
+    expect(out).toBe(e);
+    expect(out.live.probed).toBe(false);
+  });
+
+  it('client but no capture function -> still a no-op', async () => {
+    const e = baseEvidence();
+    expect(await enrichEvidenceWithLiveProbe(e, { client: {}, repoRoot: '/repo' })).toBe(e);
+  });
+
+  it('probes and reports observed objects when resolution succeeds', async () => {
+    const out = await enrichEvidenceWithLiveProbe(baseEvidence(), {
+      client: {}, repoRoot: '/repo', resolve: okResolve,
+      captureObjectDefinitions: async () => [{ ...OBJECTS[0], definition: 'POLICY p_read ON public.ventures ...' }],
+    });
+    expect(out.live.probed).toBe(true);
+    expect(out.live.declared).toBe(1);
+    expect(out.live.observed).toBe(1);
+    expect(out.live.absent).toEqual([]);
+    expect(out.approval.provenanceIndependent).toBe(true);
+  });
+
+  // The NOT-APPLIED signal: declared by the approval, absent from the database. Distinguishing
+  // this from "we could not look" is the distinction the sweep has never had.
+  it('an object the approval declares but the DB lacks is reported ABSENT, still probed', async () => {
+    const out = await enrichEvidenceWithLiveProbe(baseEvidence(), {
+      client: {}, repoRoot: '/repo', resolve: okResolve,
+      captureObjectDefinitions: async () => [{ ...OBJECTS[0], definition: null }],
+    });
+    expect(out.live.probed).toBe(true);
+    expect(out.live.observed).toBe(0);
+    expect(out.live.absent).toEqual(['POLICY:public.ventures.p_read']);
+  });
+
+  it('unresolvable artifact -> probed STAYS false, with the reason reported', async () => {
+    const out = await enrichEvidenceWithLiveProbe(baseEvidence(null), {
+      client: {}, repoRoot: '/repo',
+      resolve: () => ({ resolved: false, reason: 'artifact_file_not_found' }),
+      captureObjectDefinitions: async () => { throw new Error('must not be called'); },
+    });
+    expect(out.live.probed).toBe(false);
+    expect(out.live.unresolved_reason).toBe('artifact_file_not_found');
+  });
+
+  // A probe that THREW observed nothing. Reporting probed:true here would assert an observation
+  // never made — the precise shape of every fail-open in this area.
+  it('a probe that throws does NOT claim probed:true', async () => {
+    const out = await enrichEvidenceWithLiveProbe(baseEvidence(), {
+      client: {}, repoRoot: '/repo', resolve: okResolve,
+      captureObjectDefinitions: async () => { throw new Error('connection reset'); },
+    });
+    expect(out.live.probed).toBe(false);
+    expect(out.live.probe_error).toContain('connection reset');
+  });
+
+  // provenanceIndependent must come from the RESOLVER, never be assumed by the prober —
+  // collectors:199-205 warns 21 rows would otherwise pass with provenance never established.
+  it('never upgrades provenanceIndependent on its own', async () => {
+    const out = await enrichEvidenceWithLiveProbe(baseEvidence(), {
+      client: {}, repoRoot: '/repo',
+      resolve: () => ({ ...okResolve(), provenanceIndependent: false }),
+      captureObjectDefinitions: async () => [{ ...OBJECTS[0], definition: 'x' }],
+    });
+    expect(out.approval.provenanceIndependent).toBe(false);
+  });
+
+  it('does not mutate the input evidence', async () => {
+    const e = baseEvidence();
+    await enrichEvidenceWithLiveProbe(e, {
+      client: {}, repoRoot: '/repo', resolve: okResolve,
+      captureObjectDefinitions: async () => [{ ...OBJECTS[0], definition: 'x' }],
+    });
+    expect(e.live.probed).toBe(false);
+    expect(e.approval.provenanceIndependent).toBe(false);
+  });
+
+  it('enrichAllWithLiveProbe processes every item', async () => {
+    const out = await enrichAllWithLiveProbe([baseEvidence(), baseEvidence()], {
+      client: {}, repoRoot: '/repo', resolve: okResolve,
+      captureObjectDefinitions: async () => [{ ...OBJECTS[0], definition: 'x' }],
+    });
+    expect(out).toHaveLength(2);
+    expect(out.every((o) => o.live.probed === true)).toBe(true);
+  });
+});


### PR DESCRIPTION
Stacked on #6691 (FR-5b resolver) — it imports `resolveApprovedArtifact`. Retarget to `main` once
that merges.

## What it does

Turns `buildEvidence`'s hardcoded `live: {probed:false}` into a **real reading**.

**Why a separate pass rather than editing `buildEvidence`:** that function is synchronous and runs
inside a `population.map()` in the sweep CLI, while probing needs a database round trip. Making it
async would ripple through every caller. So enrichment is an explicit second step over the evidence
objects, and `buildEvidence` keeps reporting `probed:false` — which stays the correct answer whenever
enrichment doesn't run.

## Default-off by construction — a safety property, not a convenience

With no client, the function returns the input object **unchanged** (asserted by identity, not
deep-equality), so the sweep is byte-identical until a caller opts in.

Flipping `live.probed` activates three verdict branches — `APPLIED`, `APPLIED-BUT-DIVERGENT`,
`NOT-APPLIED-BUT-COMPLETED` — that have **never executed in production**. Doing that on partial
evidence would make the sweep confidently wrong where it is currently honestly silent.

## A probe that did not observe never claims it did

Three distinct paths keep `probed:false` while reporting **why**: unresolvable artifact (with the
resolver's reason), a probe that threw (with the error), and no client at all.

Saying `probed:true` on a thrown probe would assert an observation never made — the precise shape of
every fail-open in this area.

## Both flags or neither

`provenanceIndependent` is taken from the **resolver**, never assumed here — `collectors:199-205`
warns 21 rows would otherwise reach `hasApproval` with provenance never established. A test pins
that enrichment cannot upgrade it on its own.

It also distinguishes **declared-but-absent** (the NOT-APPLIED signal) from "could not look" — the
distinction the sweep has never had.

## Evidence

**Falsified:** making the thrown-probe path report `probed:true` fails that guard test; restored, it
passes. **474 tests pass across 36 files.** New files only — no existing behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
