### PR TITLE
feat(SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001): FR-1 — wire the ADVISORY lane of the receipt contract

### DIFF
--- a/lib/coordinator/adam-advisory-store.cjs
+++ b/lib/coordinator/adam-advisory-store.cjs
@@ -14,6 +14,9 @@
 'use strict';
 
 const { groupMultiPartAdvisories } = require('./multi-part-reply.cjs');
+// FR-1: the receipt ledger. Safe as a top-level require — receipt-ledger.cjs imports nothing, so it
+// cannot pull a client or config into this module's load path.
+const { recordReceipt, LANES, STATES, DISPOSITIONS } = require('../coordination/receipt-ledger.cjs');
 
 const ADAM_ADVISORY_KIND = 'adam_advisory';
 const BROADCAST_COORDINATOR = 'broadcast-coordinator';
@@ -82,7 +85,12 @@ function isActionRequiredAdvisory(row) {
 async function fetchAdvisory(supabase, advisoryId) {
   const { data, error } = await supabase
     .from('session_coordination')
-    .select('id, sender_session, target_session, subject, payload, read_at')
+    // created_at is REQUIRED, not incidental: stampActioned writes a receipt whose source_age_ms
+    // (time-to-answer) can only be computed at the transition, because the source row is deleted at
+    // created+24h. Omitting it here silently produced a receipt with a null age — the ledger's one
+    // load-bearing field, absent, with nothing failing. The other two selects in this file already
+    // carry it; this was the odd one out.
+    .select('id, sender_session, target_session, subject, payload, read_at, created_at')
     .eq('id', advisoryId)
     .maybeSingle();
   return { row: data || null, error: error || null };
@@ -171,6 +179,39 @@ async function stampActioned(supabase, advisoryRow, nowIso) {
     .from('session_coordination')
     .update({ payload: mergedPayload })
     .eq('id', advisoryRow.id);
+
+  // SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-1) — the ADVISORY lane of the one receipt contract.
+  //
+  // The ledger shipped with four lanes enumerated and exactly ONE wired (signal, via
+  // coordinator-ack-signal.cjs). Measured before this change: 4 receipts, all lane='signal'. So the
+  // contract that exists precisely to stop a remedy from covering one lane was itself covering one
+  // lane — the answered-rate for advisories read as zero because nothing ever wrote a receipt, which
+  // is indistinguishable from advisories never being actioned.
+  //
+  // THIS is the right seam: stampActioned's own docblock says payload.actioned_at is the ONLY thing
+  // that retires an advisory, and stampActionedGroup routes every multi-part member through here, so
+  // a receipt per member follows the same never-retire-half-a-series rule.
+  //
+  // Non-fatal and AFTER the stamp, matching the signal lane: the advisory is retired either way. A
+  // measurement outage must not become an operational one, and a lost receipt under-counts answers,
+  // which is the safe direction.
+  if (!error) {
+    const receipt = await recordReceipt(supabase, {
+      coordinationId: advisoryRow.id,
+      lane: LANES.ADVISORY,
+      state: STATES.DISPOSED,
+      disposition: DISPOSITIONS.ACTIONED,
+      actorSession: process.env.CLAUDE_SESSION_ID || null,
+      actorRole: 'coordinator',
+      isRetention: false,
+      sourceCreatedAt: advisoryRow.created_at,
+      nowMs: Date.parse(nowIso),
+      metadata: { advisory_kind: (advisoryRow.payload && advisoryRow.payload.kind) || null, via: 'adam-advisory-store.stampActioned' },
+    });
+    if (!receipt.ok) {
+      console.error('NOTE: advisory receipt skipped (' + (receipt.error || receipt.skipped) + ') — actioned_at still stands.');
+    }
+  }
   return { error: error || null };
 }
 

--- a/tests/unit/coordinator/advisory-receipt-lane.test.js
+++ b/tests/unit/coordinator/advisory-receipt-lane.test.js
@@ -1,0 +1,103 @@
+/**
+ * SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-1) — the ADVISORY lane of the one receipt contract.
+ *
+ * *** THE CONTRACT THAT EXISTS TO PREVENT SINGLE-LANE REMEDIES WAS ITSELF SINGLE-LANE. ***
+ * receipt-ledger.cjs enumerates four lanes (signal, work_assignment, advisory, resolves_files)
+ * precisely so "a remedy scoped to one lane cannot silently leave the others open" — its own words.
+ * It shipped with exactly ONE writer (coordinator-ack-signal.cjs). Measured on the live ledger
+ * before this change: 4 rows, every one lane='signal'. An advisory answered-rate of zero was
+ * indistinguishable from advisories never being actioned, because nothing wrote a receipt either way.
+ *
+ * These tests drive the REAL stampActioned against a fake client, so they assert behaviour rather
+ * than the presence of a call.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require_ = createRequire(import.meta.url);
+const { stampActioned, stampActionedGroup } = require_('../../../lib/coordinator/adam-advisory-store.cjs');
+
+/** Minimal PostgREST-shaped fake. Records every insert so we can assert on the receipt. */
+function fakeClient({ updateError = null, insertError = null } = {}) {
+  const inserts = [];
+  return {
+    inserts,
+    from(table) {
+      return {
+        update() { return { eq: async () => ({ error: updateError }) }; },
+        async insert(row) { inserts.push({ table, row }); return { error: insertError }; },
+      };
+    },
+  };
+}
+
+const ROW = {
+  id: 'adv-1',
+  created_at: '2026-07-31T10:00:00Z',
+  payload: { kind: 'adam_advisory', action_required: true },
+};
+const NOW = '2026-07-31T10:05:00Z';
+
+describe('FR-1: retiring an advisory writes an ADVISORY-lane receipt', () => {
+  it('writes exactly one receipt, on the advisory lane, disposed/actioned', async () => {
+    const c = fakeClient();
+    const { error } = await stampActioned(c, ROW, NOW);
+    expect(error).toBeNull();
+
+    const receipts = c.inserts.filter((i) => i.table === 'coordination_receipts');
+    expect(receipts).toHaveLength(1);
+    expect(receipts[0].row).toMatchObject({
+      coordination_id: 'adv-1',
+      lane: 'advisory',
+      state: 'disposed',
+      disposition: 'actioned',
+      is_retention: false,
+    });
+
+    // MUTATION: drop the recordReceipt call -> zero receipts, fails. That was the shipped state.
+  });
+
+  it('captures time-to-answer, which cannot be recovered later', async () => {
+    // The source row is deleted at created+24h, so source_age_ms is unrecoverable unless captured
+    // at the transition. 10:00 -> 10:05 is five minutes.
+    const c = fakeClient();
+    await stampActioned(c, ROW, NOW);
+    const receipt = c.inserts.find((i) => i.table === 'coordination_receipts').row;
+    expect(receipt.source_age_ms).toBe(5 * 60 * 1000);
+
+    // MUTATION: stop passing sourceCreatedAt (or drop created_at from fetchAdvisory's select) ->
+    // source_age_ms becomes null and this fails. That omission was live in one of the three
+    // selects in adam-advisory-store.cjs and would have written a null age with nothing erroring.
+  });
+
+  it('a LEDGER failure does not break the retirement — measurement never blocks operation', async () => {
+    // The advisory is retired by payload.actioned_at. If the ledger write fails, the retirement
+    // must still stand; a lost receipt under-counts answers, which is the safe direction.
+    const c = fakeClient({ insertError: { message: 'ledger down' } });
+    const { error } = await stampActioned(c, ROW, NOW);
+    expect(error).toBeNull();
+
+    // MUTATION: make the receipt failure fatal -> a measurement outage becomes an operational one.
+  });
+
+  it('does NOT write a receipt when the stamp itself failed', async () => {
+    // A receipt claims a transition happened. If actioned_at never landed, there was no transition,
+    // and recording one would inflate the answered-rate — the exact direction this SD exists to stop.
+    const c = fakeClient({ updateError: { message: 'update failed' } });
+    const { error } = await stampActioned(c, ROW, NOW);
+    expect(error).toBeTruthy();
+    expect(c.inserts.filter((i) => i.table === 'coordination_receipts')).toHaveLength(0);
+
+    // MUTATION: write the receipt unconditionally -> a failed stamp reports as an answer. Fails.
+  });
+
+  it('a multi-part series gets a receipt PER MEMBER, never half a series', async () => {
+    // stampActionedGroup routes every member through stampActioned, so the never-retire-half-a-
+    // series rule (SD-LEO-FIX-SOLOMON-MULTI-PART-001 FR-3) extends to receipts for free. Asserted
+    // rather than assumed, because "for free" is how a lane goes unwired in the first place.
+    const c = fakeClient();
+    const group = { rows: [{ ...ROW, id: 'p1' }, { ...ROW, id: 'p2' }, { ...ROW, id: 'p3' }] };
+    await stampActionedGroup(c, group, NOW);
+    const ids = c.inserts.filter((i) => i.table === 'coordination_receipts').map((i) => i.row.coordination_id);
+    expect(ids).toEqual(['p1', 'p2', 'p3']);
+  });
+});


### PR DESCRIPTION
## The contract that forbids single-lane remedies was itself single-lane

`receipt-ledger.cjs` enumerates four lanes — `signal`, `work_assignment`, `advisory`, `resolves_files` — and says in its own header that it does so *"so a remedy scoped to one lane cannot silently leave the others open."*

It shipped with exactly **one** writer.

Measured on the live ledger before this change: **4 receipts, every one `lane='signal'`**, all from a single coordinator session. So the advisory answered-rate read as zero — and a zero that nothing ever writes to is indistinguishable from advisories never being actioned. That is the same unmeasured-vs-unanswered conflation this SD was opened to remove, reproduced inside the instrument built to remove it.

## What this wires

The `advisory` lane, at `stampActioned` — which its own docblock calls the **only** thing that retires an advisory. `stampActionedGroup` routes every multi-part member through it, so the never-retire-half-a-series rule (`SD-LEO-FIX-SOLOMON-MULTI-PART-001` FR-3) extends to receipts without a second code path. Asserted rather than assumed, because "for free" is how a lane goes unwired in the first place.

**Also fixed, and it would have written a null silently:** `fetchAdvisory`'s select omitted `created_at` while the other two selects in the same file carry it. `source_age_ms` (time-to-answer) can only be computed at the transition, because the source row is deleted at `created+24h`. A receipt written through that path would have recorded the ledger's one load-bearing field as `null`, with nothing erroring.

## Design choices, stated

- **Non-fatal, after the stamp** — matching the signal lane. The advisory is retired either way; a lost receipt under-counts answers, which is the safe direction. Over-counting would let a broken lane read as healthy.
- **Written only when the stamp succeeded.** A receipt asserts a transition happened, so writing one after a failed update would inflate the answered-rate in precisely the direction this SD exists to prevent.

## Verification

Mutation-tested in both directions against the real `stampActioned` with a fake client:

| mutation | result |
|---|---|
| disable the write (the shipped state) | **kills 3** |
| write unconditionally, ignoring stamp failure | **kills 1** (the discriminating test) |

Full unit suite: **33,547 passing**. 16 failures across 8 files, all pre-existing, none touching `advisory-store` or the ledger.

⚠️ **Unrelated finding for whoever owns it:** `tests/unit/governance/self-score-contract-content.test.js` (5 failures) is **not a flake** — it fails identically in isolation and with this branch's changes stashed, i.e. on `origin/main` content. Flagging rather than fixing.

## Remaining for FR-1

`work_assignment` and `resolves_files` lanes are still unwired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)