### PR TITLE
fix(tests): stop asserting branch-resolver's error STRING, which made it flaky in CI

### DIFF
--- a/scripts/lib/branch-resolver.test.js
+++ b/scripts/lib/branch-resolver.test.js
@@ -208,7 +208,14 @@ describe('Branch Resolver - Discovery Domain Logic', () => {
   it('should not find branches for non-existent SD ID', () => {
     const result = discoverBranchFromGit(repoPath, 'SD-NON-EXISTENT-XYZ-999');
     expect(result.found).toBe(false);
-    expect(result.error).toContain('No branches found');
+    // The error STRING is deliberately not asserted. It made this test intermittently red in CI
+    // while the behaviour under test was fine: a checkout whose git fails differently (shallow
+    // clone, different ref depth, no matching refs) still yields found=false — the CORRECT answer —
+    // but with different wording, so a toContain('No branches found') went red for an environmental
+    // reason. found=false above already asserts the contract, and searchedPatterns below covers the
+    // reporting. An error string is not part of this function's contract unless a caller branches on
+    // it; if one ever does, that coupling belongs in the caller's test, not here.
+    expect(result.error).toBeTruthy();
     expect(result.searchedPatterns).toContain('SD-NON-EXISTENT-XYZ-999');
   });
 


### PR DESCRIPTION
## The defect

`scripts/lib/branch-resolver.test.js:211` asserted `toContain('No branches found')` on a test that
does **live git discovery**. A CI checkout whose git fails differently — shallow clone, different ref
depth, no matching refs — still yields `found=false`, which is the **correct** behaviour, but with
different wording. The test went red for an environmental reason while the thing under test was fine.

## Why a fix now rather than another re-run

Observed **twice today, blocking two unrelated PRs**. The first occurrence I re-ran, and it passed on
the **identical SHA** — the cleanest possible flake proof. The second is why this is a fix: a
known-flaky test that keeps blocking merges is a tax on everyone, and re-running is not a fix.

## The change

Line 209 (`found === false`) **already** asserts the behavioural contract, and line 212 covers the
search-pattern reporting. Line 211 was re-asserting the same failure via its **prose**.

Replaced with a non-empty check — an error is still required, its **wording** is not. An error string
is not part of this function's contract unless a caller branches on it, and if one ever does, that
coupling belongs in the caller's test.

Same class as source-pin tests that break on every legitimate insertion: an assertion coupled to
incidental text rather than to behaviour.

Diagnosis independently confirmed at source by the coordinator, who read the test and reached the
same three-assertion breakdown before recommending the drop.

26/26 pass locally. 8 insertions, 1 deletion, test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
