### PR TITLE
feat(SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001): FR-1 — wire the WORK_ASSIGNMENT lane; the fourth lane does not exist

### DIFF
--- a/lib/checkin/steps/directed-assignment.cjs
+++ b/lib/checkin/steps/directed-assignment.cjs
@@ -1,6 +1,10 @@
 // Extracted VERBATIM from scripts/worker-checkin.cjs resolveCheckin (rung 5: pending
 // WORK_ASSIGNMENT pull, fitness/terminal/not_before gates, tryClaim + ack branches, base
 // breadcrumbs) — SD-ARCH-HOTSPOT-CHECKIN-001. Only edits: locals -> ctx.* + helper destructuring.
+// SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-1) — the WORK_ASSIGNMENT lane of the receipt
+// contract. Safe as a top-level require: receipt-ledger.cjs imports nothing.
+const { recordReceipt, LANES, STATES, DISPOSITIONS } = require('../../coordination/receipt-ledger.cjs');
+
 module.exports = {
   name: 'directed-assignment',
   async run(ctx) {
@@ -74,6 +78,41 @@ module.exports = {
     if (assignment) {
       const sdKey = extractSdFromAssignment(assignment);
       if (sdKey) {
+        /**
+         * FR-1: ack AND record, through ONE door.
+         *
+         * MEASURED BEFORE THIS CHANGE: 116 WORK_ASSIGNMENT rows in the retention window, ZERO with
+         * acknowledged_at, ZERO receipts on this lane. The coordinator's first-hand finding was that
+         * a fulfilled assignment is never stamped even when the target seat claims AND ships it — so
+         * the lane's answered-rate was not low, it was unwritten, which reads identically to
+         * "no assignment was ever answered".
+         *
+         * WRAPPING ackMessage RATHER THAN ADDING FOUR RECEIPT BLOCKS IS THE POINT. This file has four
+         * distinct ack branches (stale-purge, ineligible-purge, claimed, terminal-claim-purge) and
+         * they were added at different times by different SDs. Four copies of a receipt call is four
+         * chances to add a fifth ack branch later and forget one — which is precisely how this lane,
+         * and the contract enumerating it, ended up half-wired in the first place. One door makes
+         * "acked but unrecorded" hard to write by accident.
+         *
+         * Non-fatal and after the ack, matching the other lanes: the ack stands regardless. A lost
+         * receipt under-counts answers, the safe direction.
+         */
+        const ackWithReceipt = async (disposition, extra) => {
+          await ackMessage(sb, assignment.id, { role: sessionRole, kind: assignment.payload?.kind, messageType: assignment.message_type });
+          const r = await recordReceipt(sb, {
+            coordinationId: assignment.id,
+            lane: LANES.WORK_ASSIGNMENT,
+            state: STATES.DISPOSED,
+            disposition,
+            actorSession: sessionId,
+            actorRole: sessionRole || 'worker',
+            isRetention: false,
+            sourceCreatedAt: assignment.created_at,
+            nowMs: Date.now(),
+            metadata: { sd: sdKey, ...(extra || {}), via: 'checkin/directed-assignment' },
+          });
+          if (!r.ok) console.error('NOTE: work_assignment receipt skipped (' + (r.error || r.skipped) + ') — ack still stands.');
+        };
         // SD-LEO-FIX-CLAIM-RPC-TERMINAL-001: purge a STALE assignment whose target SD reached a
         // terminal status (completed/cancelled/deferred) AFTER the assignment was created — the
         // in_progress->terminal race. claim_sd now refuses terminal claims, but a never-ACKed
@@ -147,10 +186,10 @@ module.exports = {
           // never fall through to tryClaim on an unconfirmed target.
           ctx.base.assignment_claim_error = 'fitness_check_query_failed';
         } else if (terminalStatus) {
-          await ackMessage(sb, assignment.id, { role: sessionRole, kind: assignment.payload?.kind, messageType: assignment.message_type });
+          await ackWithReceipt(DISPOSITIONS.SUPERSEDED, { purge: 'stale_target_terminal', status: terminalStatus });
           ctx.base.stale_assignment_purged = { sd: sdKey, status: terminalStatus };
         } else if (ineligibleReason) {
-          await ackMessage(sb, assignment.id, { role: sessionRole, kind: assignment.payload?.kind, messageType: assignment.message_type });
+          await ackWithReceipt(DISPOSITIONS.DECLINED, { purge: 'ineligible', reason: ineligibleReason });
           ctx.base.assignment_ineligible_purged = { sd: sdKey, reason: ineligibleReason };
         } else if (qfDeferredUntil) {
           // No ack: transient — re-attempted next tick; claims automatically once the gate passes.
@@ -158,7 +197,7 @@ module.exports = {
         } else {
           const claimed = await tryClaim(sb, sdKey, sessionId);
           if (claimed.ok) {
-            await ackMessage(sb, assignment.id, { role: sessionRole, kind: assignment.payload?.kind, messageType: assignment.message_type });
+            await ackWithReceipt(DISPOSITIONS.ACTIONED, { fulfilled: true });
             // QF-20260727-978: this branch IS the directed-dispatch path, so it is the honest
             // site to stamp the marker the coordinator-health gauge reads (see
             // stampDirectedAssignment in scripts/worker-checkin.cjs for why it had no writer).
@@ -181,7 +220,7 @@ module.exports = {
           // assignment_ineligible_purged branches above. Distinct breadcrumb so callers can
           // tell "permanently resolved" apart from assignment_claim_error's "retryable" meaning.
           if (TERMINAL_CLAIM_ERRORS.has(claimed.error)) {
-            await ackMessage(sb, assignment.id, { role: sessionRole, kind: assignment.payload?.kind, messageType: assignment.message_type });
+            await ackWithReceipt(DISPOSITIONS.DECLINED, { purge: 'claim_terminal', error: claimed.error });
             ctx.base.assignment_claim_terminal_purged = { sd: sdKey, error: claimed.error };
           } else {
             // could not claim the assigned SD -> fall through to self-claim

--- a/tests/unit/checkin/work-assignment-receipt-lane.test.js
+++ b/tests/unit/checkin/work-assignment-receipt-lane.test.js
@@ -1,0 +1,139 @@
+/**
+ * SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-1) — the WORK_ASSIGNMENT lane of the receipt contract.
+ *
+ * MEASURED BEFORE THE CHANGE: 116 WORK_ASSIGNMENT rows in the retention window, ZERO with
+ * acknowledged_at, ZERO receipts on this lane. So the lane's answered-rate was not low — it was
+ * UNWRITTEN, which reads identically to "no assignment was ever answered". That is the
+ * unmeasured-versus-unanswered conflation this SD exists to remove, and it was the coordinator's own
+ * first-hand finding: a fulfilled assignment goes unstamped even when the target seat claims AND
+ * ships the assigned SD.
+ *
+ * These drive the REAL pipeline through resolveCheckin (same harness as
+ * directed-assignment-marker-write.test.js) rather than calling the step in isolation, so a receipt
+ * only appears if the production path actually emits one.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { resolveCheckin } = require('../../../scripts/worker-checkin.cjs');
+
+/** Records every insert so the receipt can be asserted; otherwise mirrors the sibling harness. */
+function fakeSb({ sdRow, assignedKey, inserts, insertError = null }) {
+  return {
+    rpc: () => Promise.resolve({ data: { success: true }, error: null }),
+    from(table) {
+      const filters = {};
+      return {
+        select() { return this; }, gte() { return this; },
+        order() { return this; }, limit() { return this; }, is() { return this; },
+        eq(col, val) { filters[col] = val; return this; },
+        maybeSingle() {
+          if (table === 'claude_sessions') return Promise.resolve({ data: { metadata: { role: 'worker' }, sd_key: null }, error: null });
+          if (table === 'strategic_directives_v2') {
+            if (filters.sd_key !== assignedKey || !sdRow) return Promise.resolve({ data: null, error: null });
+            return Promise.resolve({ data: structuredClone(sdRow), error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+        insert(row) {
+          inserts.push({ table, row });
+          return Promise.resolve({ error: table === 'coordination_receipts' ? insertError : null });
+        },
+        update() { return { eq() { return Promise.resolve({ error: null }); } }; },
+      };
+    },
+  };
+}
+
+async function runDirected({ sdRow, assignedKey, insertError = null }) {
+  const inserts = [];
+  const sb = fakeSb({ sdRow, assignedKey, inserts, insertError });
+  const ws = require('../../../lib/fleet/worker-status.cjs');
+  const orig = ws.getMessagesForSession;
+  ws.getMessagesForSession = async () => [
+    {
+      id: 'msg-wa-1',
+      message_type: 'WORK_ASSIGNMENT',
+      payload: { assigned_sd: assignedKey },
+      created_at: new Date(Date.now() - 60_000).toISOString(),
+    },
+  ];
+  try {
+    const res = await resolveCheckin(sb, 'sess-worker-1', { getCoordinator: async () => null });
+    return { res, receipts: inserts.filter((i) => i.table === 'coordination_receipts').map((i) => i.row) };
+  } finally {
+    ws.getMessagesForSession = orig;
+  }
+}
+
+const SD_ROW = (key, status = 'in_progress') => ({
+  status, sd_type: 'feature', sd_key: key, target_application: null, metadata: {},
+});
+
+describe('FR-1: a disposed WORK_ASSIGNMENT writes a receipt', () => {
+  let receipts;
+  beforeEach(() => { receipts = null; });
+
+  it('a FULFILLED assignment records disposition=actioned on the work_assignment lane', async () => {
+    const r = await runDirected({ assignedKey: 'SD-WA-001', sdRow: SD_ROW('SD-WA-001') });
+    expect(r.res.action).toBe('claimed_assignment');
+    expect(r.receipts).toHaveLength(1);
+    expect(r.receipts[0]).toMatchObject({
+      coordination_id: 'msg-wa-1',
+      lane: 'work_assignment',
+      state: 'disposed',
+      disposition: 'actioned',
+    });
+    expect(r.receipts[0].metadata).toMatchObject({ sd: 'SD-WA-001', fulfilled: true });
+
+    // MUTATION: revert the ack to a bare ackMessage -> zero receipts. That is the shipped state,
+    // and it is what made 116 assignments read as never-answered.
+  });
+
+  it('captures time-to-answer, which the 24h retention delete makes unrecoverable later', async () => {
+    const r = await runDirected({ assignedKey: 'SD-WA-002', sdRow: SD_ROW('SD-WA-002') });
+    expect(r.receipts[0].source_age_ms).toBeGreaterThanOrEqual(59_000);
+
+    // MUTATION: stop passing sourceCreatedAt -> null age. The row is deleted at created+24h, so
+    // this number cannot be reconstructed afterwards at any price.
+  });
+
+  it('a NON-fulfilment disposal is recorded too, and distinguishably', async () => {
+    // The helper must not be wired only on the happy path. A stale assignment whose target already
+    // reached a terminal status is still a DISPOSAL — it just is not an answer, so it is recorded
+    // as superseded rather than actioned. Collapsing these would inflate the answered-rate.
+    const r = await runDirected({ assignedKey: 'SD-WA-003', sdRow: SD_ROW('SD-WA-003', 'completed') });
+    expect(r.res.action).not.toBe('claimed_assignment');
+    expect(r.receipts).toHaveLength(1);
+    expect(r.receipts[0]).toMatchObject({ lane: 'work_assignment', state: 'disposed', disposition: 'superseded' });
+
+    // MUTATION: wire only the claimed branch -> zero receipts here, and the lane silently reports
+    // only successes, which is a worse metric than none.
+  });
+
+  it('a LEDGER failure never breaks the claim — measurement must not become an outage', async () => {
+    const r = await runDirected({
+      assignedKey: 'SD-WA-004', sdRow: SD_ROW('SD-WA-004'),
+      insertError: { message: 'ledger down' },
+    });
+    expect(r.res.action).toBe('claimed_assignment');
+
+    // MUTATION: make the receipt write fatal -> the claim fails and a worker loses real work to a
+    // bookkeeping error.
+  });
+});
+
+describe('FR-1: every ack branch in this step goes through the receipt helper', () => {
+  it('no ack bypasses the recorder', async () => {
+    // STRUCTURAL, and deliberately so. This file has four ack branches added over time by four
+    // different SDs; four copies of a receipt call is four chances for a fifth branch to forget one
+    // — which is exactly how this lane ended up half-wired. Exactly ONE raw ackMessage may exist:
+    // the one INSIDE ackWithReceipt.
+    const { readFileSync } = require('node:fs');
+    const src = readFileSync(new URL('../../../lib/checkin/steps/directed-assignment.cjs', import.meta.url), 'utf8');
+    const raw = (src.match(/await ackMessage\(sb, assignment\.id/g) || []).length;
+    expect(raw, 'a raw ackMessage outside ackWithReceipt would dispose an assignment unrecorded').toBe(1);
+    expect((src.match(/ackWithReceipt\(DISPOSITIONS\./g) || []).length).toBeGreaterThanOrEqual(4);
+  });
+});

--- a/tests/unit/checkin/work-assignment-receipt-lane.test.js
+++ b/tests/unit/checkin/work-assignment-receipt-lane.test.js
@@ -12,7 +12,7 @@
  * directed-assignment-marker-write.test.js) rather than calling the step in isolation, so a receipt
  * only appears if the production path actually emits one.
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
@@ -72,9 +72,6 @@ const SD_ROW = (key, status = 'in_progress') => ({
 });
 
 describe('FR-1: a disposed WORK_ASSIGNMENT writes a receipt', () => {
-  let receipts;
-  beforeEach(() => { receipts = null; });
-
   it('a FULFILLED assignment records disposition=actioned on the work_assignment lane', async () => {
     const r = await runDirected({ assignedKey: 'SD-WA-001', sdRow: SD_ROW('SD-WA-001') });
     expect(r.res.action).toBe('claimed_assignment');


### PR DESCRIPTION
## Measured before touching anything

**116 `WORK_ASSIGNMENT` rows** in the retention window. **Zero** with `acknowledged_at`. **Zero** receipts on the lane.

So its answered-rate was not low — it was *unwritten*, which reads identically to "no assignment was ever answered." That is the coordinator's own first-hand finding (a fulfilled assignment goes unstamped even when the target seat claims **and ships** the SD), and it is the unmeasured-versus-unanswered conflation this SD exists to remove.

## Wrapped `ackMessage` rather than adding four receipt calls

This is the substantive choice. The step has **four** ack branches — stale-target purge, ineligible purge, claimed, terminal-claim purge — added over time by four different QFs/SDs. Four copies of a receipt call is four chances for a fifth branch to be added later without one, which is exactly how this lane (and the contract enumerating it) ended up half-wired.

One door — `ackWithReceipt` — makes "acked but unrecorded" hard to write by accident, and a structural test pins that exactly **one** raw `ackMessage` may exist in the file: the one inside the helper.

Dispositions are distinguished rather than collapsed:

| branch | disposition |
|---|---|
| claimed | `actioned` |
| stale target (terminal status) | `superseded` |
| ineligible / terminal claim error | `declined` |

A purge is a disposal but not an answer. Recording them all as `actioned` would inflate the very rate this SD is trying to make honest.

## The `resolves_files` lane does not exist, and I did not fabricate a transition for it

`receipt-ledger.cjs` enumerates it, and the coordinator's directive describes it as live practice ("resolving a block via a work_assignment carrying `resolves_files`"). Neither is true in the tree:

- `resolves_files` appears **only** in the ledger's own enum — zero occurrences in `lib`, `scripts`, tests or SQL.
- The live table has **zero** rows with `payload.resolves_files`.

The lane names a mechanism nobody built. It cannot be wired because there is no transition to hook, and inventing one would mean shipping a writer for an event that never fires — a receipt lane that reads as covered while measuring nothing, which is this SD's founding defect in a new costume. Reported rather than faked.

## Verification

Mutation-tested both directions against the **real** pipeline via `resolveCheckin` (not the step in isolation), so a receipt only appears if production actually emits one:

| mutation | result |
|---|---|
| revert the fulfilled branch to a raw ack (the shipped state) | **kills 3** |
| wire only the happy path | **kills 2**, including the structural guard |

Full unit suite: **33,551 passing**. 17 failures across 9 files, none touching checkin or the ledger — the 8-file stable set, plus `tests/unit/governance/self-score-contract-content.test.js` (genuinely **red on main**, not a flake — identical in isolation and with this branch stashed) and `tests/unit/roadmap/canonical-corpus-invariant.test.js` (known rotating flake).

## FR-1 status after this

`signal` + `advisory` + `work_assignment` wired. `resolves_files` unbuildable as specified. That is every lane that has a mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)