### PR TITLE
fix(SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001): a guard I added turned a malformed insert response into a false success

### DIFF
--- a/lib/coordination/receipt-ledger.cjs
+++ b/lib/coordination/receipt-ledger.cjs
@@ -161,7 +161,16 @@ async function recordReceipt(client, input = {}) {
       // Narrowing the try already removed the other three false positives; only the timeout return
       // is unavoidably downstream of the insert, because it describes the insert's outcome.
       if (res && res.__timedOut) return { ok: false, skipped: 'timeout' };
-      const { error } = res || {};
+      // REC-8: `res || {}` here silently converted a malformed insert response into {ok:true}.
+      // Pre-fix, an insert() resolving undefined/null threw and reported {ok:false}; my guard made
+      // it a FALSE SUCCESS — the over-counting direction this file's own docblock names as the
+      // unsafe one, because an over-count lets a broken lane read as healthy. The guard also bought
+      // nothing: the timeout branch resolves {__timedOut:true}, which is truthy and already handled
+      // one line above, so `|| {}` could only ever fire on a fault and only ever hide it.
+      // Not reachable through a live PostgREST client (it always resolves {data, error}); fixed
+      // because a latent false-success in the acceptance ledger is not worth carrying.
+      if (!res) return { ok: false, skipped: 'no_result' };
+      const { error } = res;
       return error ? { ok: false, error: error.message } : { ok: true };
     } finally {
       if (timer) clearTimeout(timer);

--- a/tests/unit/receipt-ledger.test.js
+++ b/tests/unit/receipt-ledger.test.js
@@ -58,7 +58,7 @@ describe('buildReceipt', () => {
     expect(buildReceipt({ coordinationId: 'c', lane: LANES.SIGNAL, state: STATES.SEEN, isRetention: true, nowMs: NOW }).is_retention).toBe(true);
   });
 
-  it('covers all four lanes, so no lane is left to invent its own contract', () => {
+  it('covers every lane with a mechanism, so no lane is left to invent its own contract', () => {
     for (const lane of Object.values(LANES)) {
       expect(buildReceipt({ coordinationId: 'c', lane, state: STATES.SEEN, nowMs: NOW }).lane).toBe(lane);
     }


### PR DESCRIPTION
SECURITY re-review (REC-8) caught a regression I introduced while fixing REC-1/REC-2. Two cases changed verdict between pre-fix and main, and **only** these two:

| case | pre-fix | after my fix |
|---|---|---|
| `insert()` → `undefined` | `{ok:false, "Cannot destructure…"}` | **`{ok:true}`** |
| `insert()` → `null` | `{ok:false, "Cannot destructure…"}` | **`{ok:true}`** |

The culprit is `const { error } = res || {}` — the `|| {}` I added to make the timeout branch safe.

That's a **false success**, which this file's own docblock names as the unsafe direction: an over-count lets a broken lane read as healthy, which is worse than an unwritten lane because it *looks* fine.

And the guard bought nothing for its apparent purpose. The timeout branch resolves `{__timedOut:true}` — truthy, and already handled one line above. So `|| {}` could only ever fire on a fault, and only ever hide it.

Not reachable through a live PostgREST client, which always resolves `{data, error}` (verified against an absent table, a malformed uuid and an unreachable host). Fixed anyway — a latent false-success in the SD's own acceptance ledger isn't worth carrying, and it costs one line.

## Also

Renames a stale test title: *"covers all four lanes"* while iterating a three-lane enum. That's precisely the argument the enum-removal PR made — a leftover marker is indistinguishable from a capability, and a test **name** is read far more often than its body.

## Verification

`undefined`/`null` → `{ok:false, skipped:'no_result'}`; `{error:null}` → `{ok:true}`; `{error}` → `{ok:false, error}`. 56 tests green across the three receipt suites; schema lint clean.

## Gate status

SECURITY is now **CONDITIONAL_PASS (93)** with one blocker, not three. SEC-2, SEC-3, REC-1 and REC-2 are re-verified closed by execution. The remaining blocker is **SEC-1** — RLS disabled on `coordination_receipts` with anon `INSERT/UPDATE/DELETE/TRUNCATE`, and no DDL in version control. Chairman-gated, routed, and deliberately left visible on the gate: PASS would remove an open world-writable, truncatable acceptance ledger from the record entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)