### PR TITLE
feat(SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001): FR-2 acceptance half — wire the first reader, and it exposed two defects immediately

### DIFF
--- a/lib/coordination/answered-rate.cjs
+++ b/lib/coordination/answered-rate.cjs
@@ -107,7 +107,14 @@ function answeredBySeat(input = {}) {
   );
   const bySeat = new Map();
   for (const s of signals || []) {
-    const seat = (s && s.sender_callsign) || 'unknown';
+    // READS BOTH SHAPES, because the docblock above and the code disagreed and the DATA sides with
+    // the docblock. Live session_coordination rows carry sender_callsign INSIDE payload — there is
+    // no top-level column of that name (verified: "column session_coordination.sender_callsign does
+    // not exist"). So a caller passing raw DB rows bucketed EVERY seat as 'unknown', collapsing the
+    // per-seat breakdown to one row and making "NO SEAT AT ZERO" unfalsifiable — while still
+    // returning a confident-looking number. Found while wiring the first production reader; it could
+    // not surface earlier because the only caller was a test supplying the flattened shape.
+    const seat = (s && (s.sender_callsign ?? (s.payload && s.payload.sender_callsign))) || 'unknown';
     const cur = bySeat.get(seat) || { seat, sent: 0, answered: 0 };
     cur.sent += 1;
     if (answeredIds.has(s && s.id)) cur.answered += 1;

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -712,6 +712,83 @@ export function renderContractRead(repoRoot = REPO_ROOT, check = null, opts = {}
   return lines.join('\n');
 }
 
+/**
+ * SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-2, acceptance half) — THE FIRST PRODUCTION READER
+ * OF THE RECEIPT LEDGER.
+ *
+ * *** THE SD SHIPPED THE WRITE HALF OF ITS OWN THESIS AND NEARLY CALLED IT DONE. *** Three lanes
+ * wrote receipts and NOTHING read them: answered-rate.cjs had zero production callers, so the state
+ * was recorded and unobservable. The SD's stated goal is "a signal must produce a return state THE
+ * SENDING WORKER CAN OBSERVE". Found by VALIDATION at PLAN_VERIFICATION; coordinator ruled WIRE,
+ * not defer, partly because deferring it would have made FR-4's unhold trigger — which depends on
+ * the answered-rate being computable — permanently unreachable.
+ *
+ * WHY HERE: the coordinator is the party whose conduct this rate measures AND the one who can act
+ * on it, and this script already has a proven invocation point (coordinator.md Step 4). Scope is
+ * deliberately ONE reader per the ruling — not a dashboard, not a gauge family.
+ *
+ * FAIL-OPEN like everything else in this file, and UNKNOWN is never rendered as a healthy zero:
+ * computeAnsweredRate returns rate=null with a verdict when coverage cannot be established, and
+ * that is printed as UNKNOWN. An absence displayed as 0% is the exact defect this module exists to
+ * prevent — a deployment gap would otherwise read as "nobody answered anything".
+ */
+export async function renderAnsweredRate(sb = null, nowMs = Date.now()) {
+  const lines = ['═══ SIGNAL ANSWERED-RATE (durable ledger) ═══'];
+  try {
+    const client = sb || (await import('../lib/supabase-client.js')).lazyServiceClient();
+    const req = _createRequireQF342(import.meta.url);
+    const { computeAnsweredRate, answeredBySeat } = req('../lib/coordination/answered-rate.cjs');
+
+    const sinceIso = new Date(nowMs - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+    /**
+     * PAGES. PostgREST caps an unranged select at 1000 rows and returns them WITHOUT ERROR.
+     *
+     * The first cut of this reader printed "1.3% (13 answered / 1000 signals)" — and 1000 is not a
+     * measurement, it is the cap. The denominator was a truncated page, so the rate was computed
+     * over a sample while being rendered as the population. That is the same defect this SD exists
+     * to remove, and the third time this specific cap has bitten in one day; it is silent every
+     * time, because a full page looks exactly like a complete result.
+     */
+    const fetchAll = async (build) => {
+      const PAGE = 1000;
+      const out = [];
+      for (let from = 0; ; from += PAGE) {
+        const { data, error } = await build().range(from, from + PAGE - 1);
+        if (error) throw error;
+        const rows = data || [];
+        out.push(...rows);
+        if (rows.length < PAGE) return out;
+      }
+    };
+
+    // The CANONICAL friction-signal predicate, reused rather than re-derived: detectors.cjs:142
+    // establishes that only rows carrying payload.signal_type are friction signals (roll-call rows
+    // deliberately omit it so they are not miscounted).
+    const [signals, receipts] = await Promise.all([
+      fetchAll(() => client.from('session_coordination').select('id, created_at, payload')
+        .not('payload->>signal_type', 'is', null).gte('created_at', sinceIso).order('created_at')),
+      fetchAll(() => client.from('coordination_receipts').select('coordination_id, lane, state, is_retention, created_at')
+        .eq('lane', 'signal').gte('created_at', sinceIso).order('created_at')),
+    ]);
+
+    const input = { receipts: receipts || [], signals: signals || [] };
+    const r = computeAnsweredRate(input);
+    if (r.rate === null) {
+      lines.push(`  UNKNOWN — ${r.verdict} (${r.total} signal(s) in window). NOT reported as 0%.`);
+    } else {
+      lines.push(`  ${(r.rate * 100).toFixed(1)}%  (${r.answered} answered / ${r.total} signals, 7d)`);
+      const { seats } = answeredBySeat(input);
+      const zero = seats.filter((s) => s.sent >= 5 && s.answered === 0);
+      if (zero.length) lines.push(`  ⚠ seat(s) at ZERO with >=5 sent: ${zero.map((s) => `${s.seat}(${s.sent})`).join(', ')}`);
+    }
+    if (r.excluded) lines.push(`  ${r.excluded} signal(s) excluded as uncoverable (writer not deployed).`);
+  } catch (err) {
+    lines.push('  ✅ answered-rate skipped (fail-open): ' + (err?.message || String(err)));
+  }
+  return lines.join('\n');
+}
+
 export function buildReport(argv = [], env = {}, repoRoot = REPO_ROOT) {
   const armed = parseArmedSet(argv, env);
   return [renderResponsibilities(repoRoot), '', renderAdamLane(), '', renderLoops(armed), '', renderContractRead(repoRoot), '', renderFreshness(repoRoot)].join('\n');
@@ -748,6 +825,11 @@ function main() {
   renderColdRecovery(process.argv.slice(2), process.env)
     .then(async (out) => {
       console.log(out);
+      // FR-2 acceptance half: PRINT the answered-rate. Building renderAnsweredRate and not calling
+      // it here would ship a second unread mechanism inside the SD whose entire subject is unread
+      // mechanisms. It rides this already-async leg because it needs a DB round trip, and it is
+      // fail-open on its own (never throws) so it cannot affect the startup contract.
+      try { console.log('\n' + await renderAnsweredRate()); } catch { /* fail-open */ }
       // SD-FDBK-ENH-CENTRAL-LIVENESS-STAMPER-001 (FR-3): stamp on every successful
       // startup-check tick (the report + cold-recovery leg are fail-open by design).
       try {

--- a/tests/unit/coordinator/answered-rate-reader.test.js
+++ b/tests/unit/coordinator/answered-rate-reader.test.js
@@ -1,0 +1,110 @@
+/**
+ * SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-2, acceptance half) — the first PRODUCTION READER
+ * of the receipt ledger, plus the two defects wiring it exposed.
+ *
+ * The SD shipped three lanes WRITING receipts and nothing reading them, so the state was recorded
+ * and unobservable — the write half of its own thesis. Coordinator ruled WIRE rather than defer,
+ * partly because deferring would have made FR-4's unhold trigger (which needs the answered-rate to
+ * be computable) permanently unreachable.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require_ = createRequire(import.meta.url);
+const { answeredBySeat } = require_('../../../lib/coordination/answered-rate.cjs');
+import { renderAnsweredRate } from '../../../scripts/coordinator-startup-check.mjs';
+
+describe('answeredBySeat reads the callsign where it actually lives', () => {
+  it('groups by payload.sender_callsign, not just a top-level field', () => {
+    /**
+     * The module's own docblock says "Grouped by payload.sender_callsign" and the code read
+     * `s.sender_callsign`. Live rows carry it INSIDE payload — there is no top-level column of that
+     * name ("column session_coordination.sender_callsign does not exist"). So a caller passing raw
+     * DB rows bucketed EVERY seat as 'unknown', collapsing the breakdown to one row and making
+     * "NO SEAT AT ZERO" unfalsifiable — while still returning a confident-looking number.
+     *
+     * It could not surface before now because the only caller was a test supplying the flat shape.
+     */
+    const signals = [
+      { id: 'a', created_at: '2026-07-31T10:00:00Z', payload: { sender_callsign: 'Echo' } },
+      { id: 'b', created_at: '2026-07-31T10:01:00Z', payload: { sender_callsign: 'Echo' } },
+      { id: 'c', created_at: '2026-07-31T10:02:00Z', payload: { sender_callsign: 'Foxtrot' } },
+    ];
+    const receipts = [{ coordination_id: 'a', lane: 'signal', state: 'disposed', is_retention: false }];
+    const { seats } = answeredBySeat({ signals, receipts });
+    const byName = Object.fromEntries(seats.map((s) => [s.seat, s]));
+
+    expect(Object.keys(byName).sort()).toEqual(['Echo', 'Foxtrot']);
+    expect(byName.Echo).toMatchObject({ sent: 2, answered: 1 });
+    expect(byName.Foxtrot).toMatchObject({ sent: 1, answered: 0 });
+
+    // MUTATION: read only s.sender_callsign -> every seat collapses to 'unknown' and this fails.
+    // That state produced a real number with a meaningless seat breakdown.
+  });
+
+  it('still honours a flat sender_callsign, so the pre-existing shape keeps working', () => {
+    const { seats } = answeredBySeat({
+      signals: [{ id: 'a', sender_callsign: 'Alpha-3' }],
+      receipts: [],
+    });
+    expect(seats[0].seat).toBe('Alpha-3');
+  });
+});
+
+describe('the reader pages past the 1000-row cap', () => {
+  it('does not compute a rate over a truncated page', async () => {
+    /**
+     * *** THE FIRST CUT OF THIS READER PRINTED "1.3% (13 answered / 1000 signals)". ***
+     * 1000 is not a measurement, it is PostgREST's default cap, returned WITHOUT error. The
+     * denominator was a truncated page rendered as the population. Live truth once paged: 2015
+     * signals, cross-checked against an independent head:true count of 2015.
+     *
+     * It was also FALSELY ACCUSING SEATS: two seats appeared "at zero with >=5 sent" under the cap
+     * and dropped off once the full window was read. A silent truncation does not just understate a
+     * total — it manufactures specific, nameable, wrong conclusions about individuals.
+     */
+    const PAGE = 1000;
+    const TOTAL = 2015;
+    const signals = Array.from({ length: TOTAL }, (_, i) => ({
+      id: `s${i}`, created_at: '2026-07-31T10:00:00Z', payload: { sender_callsign: 'Echo' },
+    }));
+
+    // Fake client that enforces the real cap: it serves at most PAGE rows per .range() call.
+    const paged = (rows) => ({
+      select() { return this; }, not() { return this; }, eq() { return this; },
+      gte() { return this; }, order() { return this; },
+      range: async (from, to) => ({ data: rows.slice(from, Math.min(to + 1, from + PAGE)), error: null }),
+    });
+    const sb = {
+      from(table) {
+        return table === 'session_coordination' ? paged(signals) : paged([]);
+      },
+    };
+
+    const out = await renderAnsweredRate(sb);
+    expect(out).toContain(String(TOTAL));
+    expect(out, 'a rate computed over the cap would report 1000').not.toContain('/ 1000 signals');
+
+    // MUTATION: drop the fetchAll pagination loop -> only the first 1000 rows are read and this
+    // fails on both assertions.
+  });
+
+  it('renders UNKNOWN rather than a healthy-looking 0% when nothing is measurable', async () => {
+    // An absence displayed as 0% is the defect answered-rate.cjs exists to prevent: a window where
+    // the writer was not deployed is indistinguishable, to a naive query, from a window where
+    // nobody answered.
+    const empty = {
+      select() { return this; }, not() { return this; }, eq() { return this; },
+      gte() { return this; }, order() { return this; },
+      range: async () => ({ data: [], error: null }),
+    };
+    const out = await renderAnsweredRate({ from: () => empty });
+    expect(out).toMatch(/UNKNOWN/);
+    expect(out).not.toMatch(/\b0\.0%/);
+  });
+
+  it('is FAIL-OPEN — a broken query can never break coordinator startup', async () => {
+    const boom = { from() { throw new Error('db down'); } };
+    const out = await renderAnsweredRate(boom);
+    expect(out).toContain('fail-open');
+  });
+});


### PR DESCRIPTION
Coordinator ruled **wire, not defer**. Three lanes were writing receipts and nothing read them — the SD shipping the write half of its own thesis. Deferring would also have deadlocked FR-4, whose unhold trigger depends on the answered-rate being computable.

Scope is **one** reader per the ruling: `renderAnsweredRate()` on the coordinator startup surface, which has a proven invocation point. The coordinator is both the party whose conduct this rate measures and the one who can act on it. It is **printed from main** — building the renderer and not calling it would ship a second unread mechanism inside the SD about unread mechanisms.

## Wiring it immediately exposed two defects that could only surface at a real caller

**1. `answered-rate.cjs` read the callsign from the wrong place.** Its docblock says *"Grouped by `payload.sender_callsign`"*; the code read `s.sender_callsign`. Live rows carry it **inside** payload — there is no top-level column of that name (`column session_coordination.sender_callsign does not exist`). So a caller passing raw DB rows bucketed **every** seat as `'unknown'`, collapsing the breakdown to one row and making "NO SEAT AT ZERO" unfalsifiable — while still returning a confident-looking number. Invisible until now because the only caller was a test supplying the flattened shape.

**2. My own reader computed the rate over a truncated page.** First cut printed `1.3% (13 answered / 1000 signals)`. **1000 is not a measurement** — it's PostgREST's default cap, returned without error.

| | signals | answered | rate |
|---|---|---|---|
| capped (first cut) | 1000 | 13 | 1.3% |
| **paged (correct)** | **2015** | **41** | **2.0%** |

Cross-checked against an independent `head:true` count of exactly 2015. Both numerator and denominator were wrong.

**The sharper half:** the capped read was *falsely accusing seats*. Two seats appeared "at zero with ≥5 sent" and dropped off once the full window was read. A silent truncation doesn't merely understate a total — it manufactures specific, nameable, wrong conclusions about individuals, which is worse than an obviously-missing number because it's actionable.

This is the third time this cap has bitten in a single day, and it's silent every time: a full page looks exactly like a complete result.

## Verification

| mutation | result |
|---|---|
| drop the pagination loop | **kills** the truncation test |
| revert the module to top-level-only callsign | **kills** the callsign test |

Also covered: `UNKNOWN` renders as UNKNOWN rather than a healthy-looking 0% (an absence displayed as a value is precisely what `answered-rate.cjs` exists to prevent), and the reader is fail-open so a broken query can never break coordinator startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)