### PR TITLE
feat(SD-LEO-INFRA-PERSIST-MONITOR-OBSERVED-001): guarantee claude_sessions.metadata is merged, never replaced

### DIFF
--- a/lib/fleet/metadata-write-audit.cjs
+++ b/lib/fleet/metadata-write-audit.cjs
@@ -28,6 +28,39 @@
  * ship. So the question this module asks is never "which verb" but "CAN THIS WRITE REPLACE".
  */
 
+/**
+ * ─── WHAT THIS MODULE CANNOT SEE ────────────────────────────────────────────────────────────────
+ * READ THIS BEFORE WIRING IT INTO ANYTHING. Two independent sub-agent reviews (TESTING 7343de5c,
+ * SECURITY fad2af85) enumerated these; they are stated here rather than in a commit message because
+ * the person who wires this up will read the module, not the history.
+ *
+ * DO NOT wire classifyFile into a gate, or use it to support a "the tree is clean" claim, until the
+ * misses below are closed. Zero findings from this module means NOT PARSED at least as often as it
+ * means CLEAN, and a clean-looking gauge that cannot see is precisely the defect this SD exists to
+ * eliminate. Reporting it as coverage would reproduce that defect one level up.
+ *
+ * KNOWN MISSES, each verified against a real file rather than hypothesised:
+ *   1. HOISTED PAYLOAD — `const body = JSON.stringify({metadata});` … `fetch(url, {body})`. The
+ *      payload check scans forward from the call, so a payload built earlier is invisible.
+ *   2. TABLE BEHIND A CONST — session-telemetry-writer.cjs:27 binds TELEMETRY_TABLE='claude_sessions'
+ *      and PATCHes at :139/:218. No literal near the write, so no proximity match.
+ *   3. PROXIMITY_LINES=40 IS TOO NARROW FOR SOME REAL FILES — capture-session-id.cjs has its URL at
+ *      :357 and the write at :423, a 66-line gap. Both 1 and 3 apply to that file, which is why it
+ *      returns zero findings DESPITE being named at the top of this module as the reason it exists.
+ *      That contradiction is left visible on purpose: it is the honest state of the tool.
+ *   4. RAW SQL — `UPDATE claude_sessions SET metadata = …` matches no REPLACING_FORM, so this module
+ *      can distinguish neither a raw clobber nor a raw merge. The compliant writers use exactly this
+ *      channel, which is why they show zero findings rather than a MERGE verdict.
+ *   5. `/*` inside a string literal blanks source to the next close-comment.
+ *
+ * DELIBERATE GENEROSITY, documented so it is not mistaken for an oversight: a payload that carries a
+ * variable forward is called read_then_write whenever the surrounding context reads metadata at all.
+ * That can under-report a replace. It is the right direction to err — read_then_write is still
+ * REPORTED, and a guard that accuses the canonical safe helper gets switched off wholesale, taking
+ * its true findings with it.
+ * ────────────────────────────────────────────────────────────────────────────────────────────────
+ */
+
 'use strict';
 
 /** The write forms that can replace a JSONB column outright. */
@@ -55,7 +88,14 @@ const REPLACING_FORMS = [
  * cast, which cannot appear in a JS expression) or a SET clause. JS `||` cannot satisfy either.
  */
 const MERGE_FORMS = [
-  { form: 'jsonb_concat_merge', re: /\|\|[^\n]*::jsonb|::jsonb[^\n]*\|\||SET[^\n]*metadata[^\n]*\|\|/i },
+  // THIRD ALTERNATIVE REMOVED, and its removal is the same lesson twice.
+  // It was `SET[^\n]*metadata[^\n]*\|\|/i` — case-insensitive, so it matched ordinary JavaScript:
+  // `const setMetadata = (row) => row.metadata || {}` satisfies SET…metadata…||. That is the exact
+  // false-green class the regression test below already pins; I closed two alternatives and left a
+  // third open in the same literal. A live instance exists at attention-flag-writer.js:111.
+  // Only `::jsonb` survives as a discriminator: it is a Postgres cast and cannot appear in a JS
+  // expression, so it cannot be produced by accident.
+  { form: 'jsonb_concat_merge', re: /\|\|[^\n]*::jsonb|::jsonb[^\n]*\|\|/ },
   { form: 'jsonb_set', re: /jsonb_set\s*\(/i },
 ];
 
@@ -85,7 +125,17 @@ const READS_EXISTING_RE = /\.select\s*\(\s*['"`][^'"`]*metadata|readSessionMetad
 function stripComments(source) {
   return source
     .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))   // keep line numbering intact
-    .replace(/^\s*(?:\/\/|\*|#)[^\n]*$/gm, (m) => ' '.repeat(m.length));
+    // `[^\S\r\n]*` is "horizontal whitespace only". It was `\s*`, and THAT DELETED LINES:
+    // with /m, \s matches \n, so the leading class ate the preceding newline(s) and
+    // ' '.repeat() replaced them with spaces. 172 lines vanished from session-manager.mjs and 195
+    // from capture-session-id.cjs. Two consequences, both fatal to a guard whose only product is a
+    // citation: EVERY reported file:line was wrong (session-manager.mjs:398 reported as :321), and
+    // capture-session-id.cjs fell out of the proximity window entirely — so the guard returned ZERO
+    // findings for the file this module's own header names as its reason for existing.
+    // THE TELL WAS AN INTERNAL CONTRADICTION I SHOULD HAVE CAUGHT: the header hand-cites :398/:422
+    // while the tool emitted :321/:343. When a tool disagrees with its own documentation about the
+    // same file, one of them is wrong and it is worth ten seconds to find out which.
+    .replace(/^[^\S\r\n]*(?:\/\/|\*|#)[^\n]*$/gm, (m) => ' '.repeat(m.length));
 }
 
 const TABLE_RE = /claude_sessions/;
@@ -158,7 +208,14 @@ function classifyFile(rawSource, filePath) {
         .join('\n');
 
       let verdict = VERDICT.REPLACE;
-      if (MERGE_FORMS.some((m) => m.re.test(context))) {
+      // MERGE IS JUDGED ON THE STATEMENT, NOT THE NEIGHBOURHOOD.
+      // This tested `context` (±40 lines). One correct `|| $2::jsonb` anywhere nearby therefore
+      // relabelled every blind replace within an ~80-line blast radius as compliant — reproduced by
+      // adding a blind .update() just below the correct merge in attention-flag-writer.js. That is
+      // the likeliest real regression path there is: a new writer added next to the right one.
+      // read_then_write still judges on `context`, because reading IS a file-level property; a
+      // merge is a property of the single statement performing it.
+      if (MERGE_FORMS.some((m) => m.re.test(window))) {
         verdict = VERDICT.MERGE;
       } else if (CARRIES_FORWARD_RE.test(window) && READS_EXISTING_RE.test(context)) {
         // Spreads something it actually read. Preserves the keys it saw; still loses a write that

--- a/lib/fleet/metadata-write-audit.cjs
+++ b/lib/fleet/metadata-write-audit.cjs
@@ -1,0 +1,208 @@
+/**
+ * Does this write REPLACE claude_sessions.metadata, or MERGE into it?
+ * SD-LEO-INFRA-PERSIST-MONITOR-OBSERVED-001 (re-scoped) — pure classifier.
+ *
+ * THE HAZARD. metadata is a JSONB column and a PostgREST write REPLACES it wholesale. A writer
+ * that carries only the keys it cares about silently deletes every key it did not carry.
+ *
+ * WHY THAT IS WORSE THAN A WRONG VALUE, which is the whole reason this file exists. Drop
+ * fleet_identity.callsign and sessionIdentityKind() returns null (server/routes/fleet-panel.js:54-79),
+ * and :204 filters the row OUT of the Sessions page. Every other defect in this family reports a
+ * wrong value; this one produces an ABSENT ROW. An absent row does not read as an error — it reads
+ * as nothing-wrong, because nobody counts the rows they cannot see. The seat most likely to be lost
+ * this way is a stuck one, which is the seat we most need to find.
+ *
+ * IT HAS ALREADY BITTEN SIX TIMES, and every one of those authors wrote a warning comment:
+ *   scripts/hooks/lib/session-telemetry-writer.cjs:241  lib/session-writer.cjs:88
+ *   lib/checkin/steps/model-effort-merge.cjs:16          lib/fleet/spawn-control.js:465
+ *   lib/session-manager.mjs:365                          scripts/hooks/capture-session-id.cjs:359
+ * Six comments did not stop the seventh writer. A WARNING COMMENT IS NOT A GUARD. Enforcement is
+ * the only thing that has not been tried, which is what this module is for.
+ *
+ * CLASSIFY BY CAPABILITY, NOT BY VERB — the correction that makes this guard worth having.
+ * The obvious rule is "fail on .update()". Prospective testing (evidence 9b5c3844) showed the two
+ * HIGHEST-VOLUME replacing writers are neither .update() nor PATCH:
+ *   - scripts/hooks/capture-session-id.cjs:418  POST + Prefer: resolution=merge-duplicates
+ *   - lib/session-manager.mjs:398/:422          .upsert({...}, {onConflict:'session_id'})
+ * Both replace the whole column. A verb-based guard reports clean while the two worst offenders
+ * ship. So the question this module asks is never "which verb" but "CAN THIS WRITE REPLACE".
+ */
+
+'use strict';
+
+/** The write forms that can replace a JSONB column outright. */
+const REPLACING_FORMS = [
+  { form: 'update', re: /\.update\s*\(/ },
+  { form: 'upsert', re: /\.upsert\s*\(/ },
+  { form: 'post_merge_duplicates', re: /resolution\s*=\s*merge-duplicates/ },
+  { form: 'raw_patch', re: /method\s*:\s*['"]PATCH['"]/ },
+];
+
+/**
+ * Forms that merge server-side and therefore cannot destroy siblings.
+ * `||` is the jsonb concat operator: the existing object wins nothing, but every existing key
+ * survives unless explicitly overwritten. jsonb_set is listed for completeness; note it currently
+ * has ZERO live callers against this column, so `||` is the only form actually in use.
+ */
+/*
+ * THE `||` HERE IS THE SQL JSONB CONCAT OPERATOR, NOT JAVASCRIPT'S LOGICAL OR — and conflating the
+ * two produced a FALSE GREEN, which is the one failure this guard must never have.
+ * The first version matched bare `metadata ||`. In JS, `metadata || {}` is the ordinary defensive
+ * null-coalesce idiom and appears all over these writers, so a blind-replacing writer that happened
+ * to contain it was classified MERGE and reported compliant. A guard that calls a replace a merge is
+ * worse than no guard: it adds false assurance on top of the original defect.
+ * Both patterns below therefore require an unambiguously SQL-side token — `::jsonb` (a Postgres
+ * cast, which cannot appear in a JS expression) or a SET clause. JS `||` cannot satisfy either.
+ */
+const MERGE_FORMS = [
+  { form: 'jsonb_concat_merge', re: /\|\|[^\n]*::jsonb|::jsonb[^\n]*\|\||SET[^\n]*metadata[^\n]*\|\|/i },
+  { form: 'jsonb_set', re: /jsonb_set\s*\(/i },
+];
+
+/**
+ * A payload that carries an existing object forward preserves whatever that object held.
+ * TWO SHAPES, and missing the second one flagged the canonical SAFE helper as a defect:
+ *   metadata: { ...existing, k: v }   ← spread, obvious
+ *   metadata: mergedMetadata          ← a variable built from a read, equally safe and far commoner
+ * TESTING (evidence 9b5c3844) named this: the dominant shape is `.update({ metadata })` with an
+ * identifier, so safety is a property of HOW THE VARIABLE WAS BUILT, not of the call site. Full
+ * dataflow is beyond a static guard; the tractable proxy is whether this file reads existing
+ * metadata at all. That is deliberately generous — it can call a replace a read-then-write if the
+ * file happens to read elsewhere. Erring that way is correct here: read_then_write is still
+ * REPORTED, just not failed, so a generous boundary loses a warning rather than manufacturing a
+ * false green, and a guard that cries wolf on the safe helper gets disabled wholesale.
+ */
+const CARRIES_FORWARD_RE = /metadata\s*:\s*\{\s*\.\.\.|metadata\s*:\s*\w*[Mm]erged\w*|metadata\s*:\s*\w*[Ff]resh\w*|metadata\s*[,}]/;
+/** ...but only if this file actually READS existing metadata somewhere. */
+const READS_EXISTING_RE = /\.select\s*\(\s*['"`][^'"`]*metadata|readSessionMetadata|getSessionMetadata|existingMetadata|currentMetadata|\bmetadata\s*=\s*(?:data|row|existing)/i;
+
+/**
+ * Comments quoting the hazard are not the hazard.
+ * Six files carry warning comments containing literal `.update({ metadata: ... })` examples, and
+ * flagging those made the guard report its own documentation as a defect — noise that gets a guard
+ * switched off, which is the TR-3 failure mode. Strip comments before classifying.
+ */
+function stripComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))   // keep line numbering intact
+    .replace(/^\s*(?:\/\/|\*|#)[^\n]*$/gm, (m) => ' '.repeat(m.length));
+}
+
+const TABLE_RE = /claude_sessions/;
+/** A payload that carries metadata at all. Without this, a write to other columns is irrelevant. */
+const CARRIES_METADATA_RE = /metadata\s*[:=]/;
+
+/**
+ * How far from a `claude_sessions` mention a write form still counts as being ABOUT that table.
+ * Deliberately generous: PostgREST fetch calls put the table in the URL many lines above the body.
+ */
+const PROXIMITY_LINES = 40;
+
+/**
+ * Sibling keys observed live on claude_sessions.metadata across active worker seats.
+ *
+ * THIS IS A CENSUS, NOT A COMPUTED DESTRUCTION LIST — and the distinction is load-bearing.
+ * For `{...metadataVar, k: v}` the set actually destroyed is a RUNTIME fact: nothing if the spread
+ * is fresh, everything if it is stale. Emitting a "computed" list this module did not compute would
+ * be a name making a claim the implementation cannot support — the same defect class as the false
+ * QF-20260727-488 citation this SD struck. So the guard reports what is AT RISK, and says so.
+ */
+const AT_RISK_KEY_CENSUS = [
+  'fleet_identity', 'model', 'effort', 'tier_rank', 'model_family', 'model_source', 'effort_source',
+  'role', 'is_coordinator', 'auto_proceed', 'chain_orchestrators', 'wind_down', 'launch_cwd',
+  'wake_armed_at', 'expected_wake_at', 'window_handle', 'window_owner_pid',
+];
+
+/** Verdicts, ordered by how much they should worry you. */
+const VERDICT = {
+  MERGE: 'merge',                    // server-side merge; cannot destroy siblings
+  READ_THEN_WRITE: 'read_then_write', // preserves keys it saw; still races a concurrent writer
+  REPLACE: 'replace',                 // destroys every key not carried — the defect
+};
+
+/**
+ * Classify one source file's writes to claude_sessions.metadata.
+ *
+ * Pure: source text in, findings out. No filesystem, no DB, no cwd — so the tests that exercise it
+ * cannot pass or fail for an ambient reason, which is how three sibling tests in this repo ended up
+ * reading real session state instead of their own fixtures.
+ *
+ * @param {string} source   file contents
+ * @param {string} filePath repo-relative path, used only for reporting
+ * @returns {Array<{file:string, line:number, form:string, verdict:string, at_risk_keys:string[], evidence:string}>}
+ */
+function classifyFile(rawSource, filePath) {
+  if (typeof rawSource !== 'string' || !TABLE_RE.test(rawSource)) return [];
+
+  const source = stripComments(rawSource);
+  const lines = source.split('\n');
+  const tableLines = [];
+  lines.forEach((l, i) => { if (TABLE_RE.test(l)) tableLines.push(i); });
+  if (tableLines.length === 0) return [];
+
+  const findings = [];
+
+  for (const { form, re } of REPLACING_FORMS) {
+    lines.forEach((line, i) => {
+      if (!re.test(line)) return;
+      // Is this write about claude_sessions at all?
+      if (!tableLines.some((t) => Math.abs(t - i) <= PROXIMITY_LINES)) return;
+
+      // Does the payload carry metadata? Look at the call and the lines that follow it, because
+      // the payload is usually an object spanning several lines.
+      const window = lines.slice(i, Math.min(i + PROXIMITY_LINES, lines.length)).join('\n');
+      if (!CARRIES_METADATA_RE.test(window)) return;
+
+      const context = lines
+        .slice(Math.max(0, i - PROXIMITY_LINES), Math.min(i + PROXIMITY_LINES, lines.length))
+        .join('\n');
+
+      let verdict = VERDICT.REPLACE;
+      if (MERGE_FORMS.some((m) => m.re.test(context))) {
+        verdict = VERDICT.MERGE;
+      } else if (CARRIES_FORWARD_RE.test(window) && READS_EXISTING_RE.test(context)) {
+        // Spreads something it actually read. Preserves the keys it saw; still loses a write that
+        // landed between the read and the write (the 3c40949b incident, 9 minutes).
+        verdict = VERDICT.READ_THEN_WRITE;
+      }
+
+      findings.push({
+        file: filePath,
+        line: i + 1,
+        form,
+        verdict,
+        at_risk_keys: verdict === VERDICT.REPLACE ? [...AT_RISK_KEY_CENSUS] : [],
+        evidence: line.trim().slice(0, 160),
+      });
+    });
+  }
+
+  return findings;
+}
+
+/**
+ * Human-readable failure text. Names the writer AND what is at risk, because "violation found"
+ * tells the next reader nothing about why they should care.
+ */
+function formatFinding(f) {
+  if (f.verdict !== VERDICT.REPLACE) return `${f.file}:${f.line} [${f.form}] ${f.verdict}`;
+  return [
+    `${f.file}:${f.line} — ${f.form} REPLACES claude_sessions.metadata`,
+    `    ${f.evidence}`,
+    `    AT RISK (live key census, not a computed destruction list): ${f.at_risk_keys.join(', ')}`,
+    '    Losing fleet_identity.callsign removes the row from the Sessions page entirely',
+    '    (server/routes/fleet-panel.js:204 filters on identity_kind !== null).',
+    '    FIX: merge server-side — see lib/fleet/attention-flag-writer.js:45',
+    "         metadata = COALESCE(metadata,'{}'::jsonb) || $2::jsonb",
+  ].join('\n');
+}
+
+module.exports = {
+  classifyFile,
+  formatFinding,
+  VERDICT,
+  AT_RISK_KEY_CENSUS,
+  REPLACING_FORMS,
+  MERGE_FORMS,
+  PROXIMITY_LINES,
+};

--- a/tests/unit/fleet/session-metadata-merge-guard.test.js
+++ b/tests/unit/fleet/session-metadata-merge-guard.test.js
@@ -183,13 +183,38 @@ describe('classifier: does this write REPLACE the column?', () => {
 describe('live tree', () => {
   const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
 
-  it('the three live compliant merge sites are not flagged', () => {
-    for (const rel of [
-      'lib/fleet/attention-flag-writer.js',
-      'lib/fleet/window-visibility-writer.js',
-    ]) {
+  it('the live compliant merge sites are not flagged', () => {
+    // WAS VACUOUS, AND SAID "THREE" WHILE ITERATING TWO. Both files write via raw SQL, which no
+    // REPLACING_FORM matches, so they return ZERO findings of any verdict — `filter(REPLACE)` was
+    // satisfied by the empty set and the assertion would have passed identically with MERGE_FORMS
+    // deleted. Part 1 of this file is careful about unfalsifiable assertions; Part 3 was not.
+    // A test that cannot fail is not evidence, which is the thesis of the SD it belongs to.
+    // The honest assertion is therefore about ABSENCE OF A FALSE ACCUSATION, stated as such, plus a
+    // positive check that the classifier can see a merge at all when one is in a shape it parses.
+    for (const rel of ['lib/fleet/attention-flag-writer.js', 'lib/fleet/window-visibility-writer.js']) {
       const f = classifyFile(read(rel), rel);
       expect(f.filter((x) => x.verdict === VERDICT.REPLACE)).toEqual([]);
+    }
+    // The non-vacuous half: a merge the classifier DOES parse is classified as one.
+    const parsed = classifyFile(
+      'await sb.from(\'claude_sessions\').update({ metadata: patch }); // sql: metadata || $2::jsonb',
+      'fixture.js',
+    );
+    expect(parsed.length).toBeGreaterThan(0);
+    expect(parsed.some((x) => x.verdict === VERDICT.MERGE)).toBe(true);
+  });
+
+  it('REGRESSION: stripComments must not delete lines, or every citation is wrong', () => {
+    // `^\s*` with /m ate newlines and ' '.repeat() replaced them with spaces: 172 lines vanished
+    // from session-manager.mjs, 195 from capture-session-id.cjs. Reported line numbers were off by
+    // up to 159, and capture-session-id.cjs fell out of the proximity window entirely — so the
+    // guard returned ZERO findings for the file its own header names as its reason for existing.
+    for (const rel of ['lib/session-manager.mjs', 'scripts/hooks/capture-session-id.cjs']) {
+      const src = read(rel);
+      const findings = classifyFile(src, rel);
+      const maxLine = findings.reduce((n, f) => Math.max(n, f.line), 0);
+      // A citation past the end of the file is impossible unless stripping changed the numbering.
+      expect(maxLine).toBeLessThanOrEqual(src.split('\n').length);
     }
   });
 

--- a/tests/unit/fleet/session-metadata-merge-guard.test.js
+++ b/tests/unit/fleet/session-metadata-merge-guard.test.js
@@ -1,0 +1,213 @@
+/**
+ * claude_sessions.metadata must be MERGED, never replaced.
+ * SD-LEO-INFRA-PERSIST-MONITOR-OBSERVED-001 (re-scoped by coordinator ruling).
+ *
+ * THE DEFECT. A PostgREST write REPLACES a JSONB column. A writer carrying only its own keys
+ * silently deletes the rest. Drop fleet_identity.callsign and sessionIdentityKind() returns null
+ * (server/routes/fleet-panel.js:54-79), so :204 filters the row out and THE SEAT DISAPPEARS FROM
+ * THE SESSIONS PAGE. Not a wrong value — an ABSENT ROW, which reads as nothing-wrong rather than as
+ * an error, because nobody counts the rows they cannot see.
+ *
+ * SIX AUTHORS ALREADY DOCUMENTED THIS IN COMMENTS after being burned, and the hazard survived all
+ * six. A warning comment is not a guard. That is why this is a test.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+
+const require = createRequire(import.meta.url);
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const { classifyFile, VERDICT, AT_RISK_KEY_CENSUS } = require(path.join(ROOT, 'lib/fleet/metadata-write-audit.cjs'));
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// PART 1 — THE CONSUMER. This is the part that matters most, and the part I got wrong first.
+//
+// sessionIdentityKind is an ORDERED FALLBACK CHAIN. My first draft asserted that a clobbered row
+// goes ABSENT, and prospective testing (evidence 9b5c3844) showed it does not: `model` is a
+// non-null identity source one branch BELOW fleet_identity.callsign, so the real incident payload
+// {model, effort} degrades the row to 'unstamped' and it STAYS PRESENT with callsign null.
+// The regression is worker -> unstamped, NOT present -> absent. A test asserting ABSENT would have
+// gone green on a fixture that strips everything while never touching the incident that happened.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Mirror of server/routes/fleet-panel.js sessionIdentityKind (:54-79) — the ordered fallback.
+ * Replicated rather than imported because that module pulls the express route graph; the ORDER is
+ * the thing under test and is pinned by the cases below.
+ */
+function sessionIdentityKind(meta) {
+  if (!meta || typeof meta !== 'object') return null;
+  if (meta.is_coordinator) return 'coordinator';
+  if (meta.role) return String(meta.role);
+  if (meta.fleet_identity && meta.fleet_identity.callsign) return 'worker';
+  if (meta.model) return 'unstamped';
+  return null;
+}
+
+/** The :204 filter: allRows.filter(r => r.identity_kind !== null). */
+const isOnSessionsPage = (meta) => sessionIdentityKind(meta) !== null;
+/** fleet-panel.js:117 emits null callsign for anything that is not a stamped worker. */
+const renderedCallsign = (meta) =>
+  (sessionIdentityKind(meta) === 'worker' ? meta.fleet_identity.callsign : null);
+
+describe('CONSUMER: a metadata write must not cost a seat its identity', () => {
+  // Only identity source is fleet_identity.callsign. No model, no role — so nothing can satisfy
+  // the assertion via a fallback branch and quietly make the negative cases unfalsifiable.
+  const STAMPED = { fleet_identity: { callsign: 'Alpha-2', color: 'purple' }, tier_rank: 4 };
+
+  it('a compliant merge keeps the seat a stamped worker', () => {
+    const after = { ...STAMPED, last_git_metric_at_ms: 1785534896469 };
+    // Asserted as a PAIR. `identity_kind !== null` is too weak — it passes on the degradation below,
+    // which is the actual incident.
+    expect(sessionIdentityKind(after)).toBe('worker');
+    expect(renderedCallsign(after)).toBe('Alpha-2');
+    expect(isOnSessionsPage(after)).toBe(true);
+  });
+
+  it('THE REAL INCIDENT (3c40949b): a blind write degrades worker -> unstamped, and the row STAYS', () => {
+    // Exactly what lib/checkin/steps/model-effort-merge.cjs writes back. Worker 3c40949b lost its
+    // Charlie/purple identity to a concurrent write inside NINE MINUTES.
+    const after = { model: 'opus', effort: 'xhigh' };
+    expect(sessionIdentityKind(after)).toBe('unstamped');
+    expect(renderedCallsign(after)).toBeNull();
+    // PRESENT, not absent. This is the assertion my first draft got backwards.
+    expect(isOnSessionsPage(after)).toBe(true);
+  });
+
+  it('the DISAPPEARANCE mode: a write leaving no identity key removes the row entirely', () => {
+    const after = { last_git_metric_at_ms: 1785534896469 };
+    expect(sessionIdentityKind(after)).toBeNull();
+    expect(isOnSessionsPage(after)).toBe(false);
+  });
+
+  it('CONTROL: the fallback ORDER is what makes the degradation possible', () => {
+    // If callsign ever stopped out-ranking model, the first test would pass for the wrong reason.
+    expect(sessionIdentityKind({ fleet_identity: { callsign: 'X' }, model: 'opus' })).toBe('worker');
+    expect(sessionIdentityKind({ model: 'opus' })).toBe('unstamped');
+    // And a bare non-identity payload must not be rescued by some other branch.
+    expect(sessionIdentityKind({ wind_down: { reason: 'x' } })).toBeNull();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// PART 2 — THE CLASSIFIER. Capability, not verb.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+describe('classifier: does this write REPLACE the column?', () => {
+  it('catches upsert, which no verb-based guard would', () => {
+    const src = `
+      await sb.from('claude_sessions')
+        .upsert({ session_id, metadata: { model, effort } }, { onConflict: 'session_id' });
+    `;
+    const f = classifyFile(src, 'fixture.js');
+    expect(f.length).toBeGreaterThan(0);
+    expect(f[0].verdict).toBe(VERDICT.REPLACE);
+    expect(f[0].form).toBe('upsert');
+  });
+
+  it('catches POST + resolution=merge-duplicates, the highest-volume replacing writer', () => {
+    const src = `
+      await fetch(url + '/claude_sessions', {
+        method: 'POST',
+        headers: { Prefer: 'resolution=merge-duplicates' },
+        body: JSON.stringify({ session_id, metadata: { model } }),
+      });
+    `;
+    const f = classifyFile(src, 'fixture.js');
+    expect(f.some((x) => x.verdict === VERDICT.REPLACE)).toBe(true);
+  });
+
+  it('does NOT call a server-side jsonb merge a replace', () => {
+    const src = `
+      await client.query(
+        "UPDATE claude_sessions SET metadata = COALESCE(metadata,'{}'::jsonb) || $2::jsonb WHERE session_id = $1",
+        [id, patch]
+      );
+    `;
+    const f = classifyFile(src, 'fixture.js');
+    expect(f.every((x) => x.verdict !== VERDICT.REPLACE)).toBe(true);
+  });
+
+  it('REGRESSION: JavaScript `metadata || {}` is NOT the SQL jsonb concat', () => {
+    // The first version matched a bare `||` and classified this replace as a MERGE — a FALSE GREEN,
+    // the one outcome a guard must never produce. `||` is overloaded across the two languages;
+    // the SQL form is disambiguated by ::jsonb or a SET clause, which JS cannot produce.
+    const src = `
+      const meta = metadata || {};
+      await sb.from('claude_sessions').update({ metadata: { model: meta.model } }).eq('session_id', id);
+    `;
+    const f = classifyFile(src, 'fixture.js');
+    expect(f.some((x) => x.verdict === VERDICT.REPLACE)).toBe(true);
+  });
+
+  it('does not report a comment describing the hazard as the hazard', () => {
+    // Six files carry warning comments containing literal replacing examples. Flagging those is how
+    // a guard becomes noise and gets switched off — the TR-3 failure mode.
+    const src = `
+      // WRONG: .update({ metadata: { non_fleet: true } }) on claude_sessions REPLACES the column
+      /* Historical: an .upsert({ metadata }) here destroyed fleet_identity. */
+      const x = 1;
+    `;
+    expect(classifyFile(src, 'fixture.js')).toEqual([]);
+  });
+
+  it('ignores writes that do not carry metadata at all', () => {
+    const src = 'await sb.from(\'claude_sessions\').update({ heartbeat_at: now }).eq(\'session_id\', id);';
+    expect(classifyFile(src, 'fixture.js')).toEqual([]);
+  });
+
+  it('ignores other tables', () => {
+    const src = 'await sb.from(\'session_coordination\').update({ metadata: { a: 1 } }).eq(\'id\', id);';
+    expect(classifyFile(src, 'fixture.js')).toEqual([]);
+  });
+
+  it('reports an AT-RISK CENSUS, never a computed destruction list', () => {
+    // The destroyed set is a RUNTIME fact for a spread payload. Claiming to have computed it would
+    // be a name making a claim the implementation cannot support — the same defect class as the
+    // false QF-20260727-488 citation this SD struck.
+    const src = 'await sb.from(\'claude_sessions\').upsert({ session_id, metadata: { model } });';
+    const f = classifyFile(src, 'fixture.js').find((x) => x.verdict === VERDICT.REPLACE);
+    expect(f.at_risk_keys).toEqual(AT_RISK_KEY_CENSUS);
+    expect(f.at_risk_keys).toContain('fleet_identity');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// PART 3 — THE LIVE TREE. Scoped honestly: this pins the writers we KNOW about rather than
+// claiming a clean bill of health for 357 call sites the classifier has not adjudicated.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+describe('live tree', () => {
+  const read = (rel) => fs.readFileSync(path.join(ROOT, rel), 'utf8');
+
+  it('the three live compliant merge sites are not flagged', () => {
+    for (const rel of [
+      'lib/fleet/attention-flag-writer.js',
+      'lib/fleet/window-visibility-writer.js',
+    ]) {
+      const f = classifyFile(read(rel), rel);
+      expect(f.filter((x) => x.verdict === VERDICT.REPLACE)).toEqual([]);
+    }
+  });
+
+  it('the canonical merge-preserving helpers are not reported as defects', () => {
+    // These read before writing. They still RACE — that is why they are reported as
+    // read_then_write rather than silently blessed — but they are not the blind-replace defect,
+    // and a guard that fails on them gets disabled wholesale.
+    for (const rel of ['lib/session-writer.cjs', 'lib/checkin/steps/model-effort-merge.cjs']) {
+      const f = classifyFile(read(rel), rel);
+      expect(f.filter((x) => x.verdict === VERDICT.REPLACE)).toEqual([]);
+    }
+  });
+
+  it('KNOWN REPLACING WRITERS are still detected — a silent drop here is the regression', () => {
+    // lib/session-manager.mjs is the documented wipe-on-reinit site. If this ever returns zero, the
+    // classifier has stopped seeing the thing it exists to see, and everything else here is theatre.
+    const rel = 'lib/session-manager.mjs';
+    const f = classifyFile(read(rel), rel).filter((x) => x.verdict === VERDICT.REPLACE);
+    expect(f.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary

A PostgREST write REPLACES a JSONB column. A writer to `claude_sessions.metadata` carrying only its own keys silently deletes the rest. Drop `fleet_identity.callsign` and `sessionIdentityKind()` returns null (`server/routes/fleet-panel.js:54-79`), so `:204` filters the row out and **the seat disappears from the Sessions page**. An absent row reads as nothing-wrong rather than as an error.

Six files already carry warning comments written after the hazard bit their authors. Worker `3c40949b` lost its Charlie/purple identity to a concurrent write inside nine minutes. **A warning comment is not a guard** — this ships enforcement.

## What's here

- `lib/fleet/metadata-write-audit.cjs` — pure classifier (no fs/DB/cwd). Asks *can this write REPLACE*, never *which verb*: the two highest-volume replacing writers are `upsert onConflict` and `POST + Prefer: resolution=merge-duplicates`, neither of which a verb-based guard sees.
- `tests/unit/fleet/session-metadata-merge-guard.test.js` — 15 tests. The consumer assertions are the centerpiece.

## Three things I got wrong, all caught by measuring

1. **A false green.** My merge detector matched a bare `||` — which is the SQL jsonb concat *and* JavaScript's null-coalesce idiom. A blind-replacing writer containing `metadata || {}` was classified compliant. Now requires a token JS cannot produce (`::jsonb` or a SET clause). Pinned by a regression test.
2. **It flagged the canonical safe helper.** Safety is a property of how the payload variable was *built*, not of the call site.
3. **It reported its own documentation as the hazard** — comments are now stripped before classification.

## The consumer assertions, corrected

My first draft asserted a clobbered row goes ABSENT. It does not. `sessionIdentityKind` is an ordered fallback and `model` sits one branch below `fleet_identity.callsign`, so the real incident payload `{model, effort}` degrades the row to `unstamped` and it **stays present** with a null callsign. The regression is worker→unstamped, not present→absent. Now asserted as a pair, with both modes covered.

## Falsification

Three mutants, each asserting the mutation landed before its red was believed:

| mutant | result |
|---|---|
| `false-green` (revert the SQL-context fix) | 1 failed / 14 passed |
| `fallback-order` (swap model above callsign) | 1 failed / 14 passed |
| `blind-to-upsert` | 2 failed / 13 passed |
| restored | 15 passed |

## Scope note

The live-tree assertions pin the writers we know about. They do **not** claim a clean bill of health for all 357 `claude_sessions` call sites — static classification cannot deliver that, and asserting it would be the same overclaim this SD exists to prevent.

Full unit tier: 6 failed files / 10 failed tests vs a pre-existing baseline of 8 / 11. No regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)