### PR TITLE
fix(SD-LEO-INFRA-USER-STORY-QUALITY-001): the LLM story path threw on every call for 172 days and reported success anyway

### DIFF
--- a/lib/integrations/eva-chat-service.js
+++ b/lib/integrations/eva-chat-service.js
@@ -14,6 +14,15 @@
 import { createSupabaseServiceClient } from '../supabase-client.js';
 import 'dotenv/config';
 import { getClaudeModel } from '../config/model-config.js';
+// SD-LEO-INFRA-USER-STORY-QUALITY-001 (FR-3): BOTH LLM call sites in this file destructured
+// `createLLMClient` from a DYNAMIC import of client-factory.js — a symbol that module does not
+// export. The destructure therefore yielded `undefined` and the call threw
+// "createLLMClient is not a function" on EVERY invocation, live via generateEVAResponse (chat) and
+// streamMessage (streaming chat). That is a hard fail rather than the silent fallback the stories
+// module had, so it was visible to whoever hit it — but it means EVA chat has been dead on both
+// paths, not degraded. Static import so the symbol is resolved at load time and a future rename
+// breaks the build instead of one request.
+import { getLLMClient } from '../llm/client-factory.js';
 import { isMainModule } from '../utils/is-main-module.js';
 import { getSectionPrompt } from '../eva/friday-chat-prompt.js';
 
@@ -114,9 +123,7 @@ const EVA_SYSTEM_PROMPT = EVA_BASE_PROMPT;
  */
 async function generateEVAResponse(conversationMessages, systemPrompt = null) {
   // Dynamic import to handle ESM
-  const { createLLMClient } = await import('../llm/client-factory.js');
-
-  const client = await createLLMClient('sonnet');
+  const client = await getLLMClient({ purpose: 'eva-chat', subAgent: 'EVA_CHAT' });
 
   const messages = conversationMessages.map(m => ({
     role: m.role,
@@ -311,6 +318,16 @@ export async function streamMessage(conversationId, userContent, _userId, callba
   }));
 
   try {
+    // *** DELIBERATELY NOT REPAIRED IN SD-LEO-INFRA-USER-STORY-QUALITY-001 — SEE BELOW. ***
+    // This site has the same dead `createLLMClient` destructure as generateEVAResponse above, but
+    // repairing it is NOT the same one-line change, because it needs `.messages.stream()` with
+    // incremental token events and THE ADAPTER LAYER HAS NO STREAMING AT ALL — every adapter
+    // exposes only the non-incremental `.complete()`. The FR-4 compat layer deliberately provides
+    // `.messages.create` and NOT `.messages.stream`: a `.stream()` that resolved `.complete()` and
+    // emitted the whole response as one 'text' event would satisfy this call site while making the
+    // word "stream" false, which is the defect class this SD exists to remove, not a fix for it.
+    // Real streaming support in the adapter layer is separate work with a different blast radius.
+    // Left failing loudly (TypeError on call) rather than silently faked.
     const { createLLMClient } = await import('../llm/client-factory.js');
     const client = await createLLMClient('sonnet');
 

--- a/lib/skunkworks/proposal-agent.js
+++ b/lib/skunkworks/proposal-agent.js
@@ -41,7 +41,10 @@ export async function generateProposals(deps, signals) {
 
 async function generateWithLLM(deps, signals) {
   const { logger = console } = deps;
-  const client = getLLMClient('haiku');
+  // SD-LEO-INFRA-USER-STORY-QUALITY-001 (FR-3): getLLMClient takes an OPTIONS OBJECT, not a bare
+  // tier string — `getLLMClient('haiku')` silently landed on defaults because a string has no
+  // .purpose/.subAgent keys, so the routing config never saw an intent to honour.
+  const client = await getLLMClient({ purpose: 'skunkworks-proposals', subAgent: 'SKUNKWORKS' });
 
   const signalSummary = signals.map((s, i) =>
     `${i + 1}. [${s.type}] ${s.title} (priority: ${Math.round(s.priority)})\n   Evidence: ${JSON.stringify(s.evidence)}`
@@ -63,8 +66,11 @@ For each proposal, output valid JSON (array of objects). Each object must have:
 Group related signals into single proposals where appropriate. Aim for 3-7 proposals total.
 Output ONLY the JSON array, no surrounding text.`;
 
+  // FR-3: `client._model` does not exist on ANY adapter — the surface is .model/.defaultModel — so
+  // this override was permanently undefined and always fell through to the hardcoded default.
+  // `.messages.create` itself now resolves via the FR-4 compat layer; before that it threw.
   const response = await client.messages.create({
-    model: client._model || getClaudeModel('fast'),
+    model: client.defaultModel || client.model || getClaudeModel('fast'),
     max_tokens: 2000,
     messages: [{ role: 'user', content: prompt }],
   });

--- a/lib/sub-agents/modules/stories/execute.js
+++ b/lib/sub-agents/modules/stories/execute.js
@@ -31,6 +31,46 @@ const __dirname = dirname(__filename);
 dotenv.config({ path: join(__dirname, '../../../../.env') });
 
 /**
+ * SD-LEO-INFRA-USER-STORY-QUALITY-001 (FR-5) — turn ONE functional requirement into the text a
+ * story is generated from, without ever emitting "[object Object]".
+ *
+ * *** THE OLD LINE WAS `fr.title || fr.description || String(fr)` AND IT SHIPPED CORRUPTION. ***
+ * The canonical FR contract also allows `requirement`, so an FR carrying only that field fell
+ * through every branch to String(fr) — which, for a plain object, is the literal string
+ * "[object Object]". Measured on 2026-07-31: 66 stories have "[object Object]" in the TITLE and 74
+ * have "[object" in user_want. The downstream templater then conjugates whatever it is handed into
+ * a verb, producing acceptance criteria like "The the feature is [object object]ed successfully".
+ *
+ * ALL 66 OF THOSE STORIES HAVE validation_status='validated'. The validator does not reject a
+ * primary field that is literally the string "[object Object]", so nothing downstream flagged it.
+ *
+ * Independently root-caused in feedback 5554c0d1-0c4e-4007-804f-83178d8f0ddf (filed 2026-07-11).
+ *
+ * ADDING `requirement` TO THE CHAIN IS NOT THE FIX ON ITS OWN — it only closes the path we found.
+ * The guard is the fix: anything non-string reaching the templater produces the same corruption, so
+ * the fallback is an identifiable placeholder rather than a stringified object.
+ *
+ * @param {*} fr - A functional requirement; expected to be an object, but explicitly not trusted.
+ * @param {number} index - Position, used to make the placeholder traceable to a specific FR.
+ * @returns {string} Non-empty criterion text, never "[object Object]".
+ */
+export function criterionFromFR(fr, index = 0) {
+  if (typeof fr === 'string') return fr.trim() || `Unnamed requirement #${index + 1}`;
+  if (!fr || typeof fr !== 'object') return `Unnamed requirement #${index + 1}`;
+
+  // `requirement` is part of the canonical FR contract and was the field the old chain omitted.
+  for (const key of ['title', 'description', 'requirement', 'name', 'summary']) {
+    const value = fr[key];
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+
+  // Traceable placeholder — an FR id is far more useful to whoever finds it than "[object Object]",
+  // and unlike a stringified object it is greppable.
+  const id = typeof fr.id === 'string' && fr.id.trim() ? fr.id.trim() : `#${index + 1}`;
+  return `Unnamed requirement ${id} (no title, description or requirement text)`;
+}
+
+/**
  * Execute User Story Context Engineering
  * @param {string} sdId - Strategic Directive ID
  * @param {Object} subAgent - Sub-agent configuration
@@ -234,6 +274,10 @@ async function createStoriesFromPRD(supabase, sdId, sdKey, options, results) {
     return null;
   }
 
+  // SD-LEO-INFRA-USER-STORY-QUALITY-001 (FR-5) — see criterionFromFR below; the previous
+  // `fr.title || fr.description || String(fr)` put the literal '[object Object]' into 66 story
+  // titles, and every one of those 66 has validation_status='validated'.
+  //
   // QF-20260703-894: derive story-source criteria from functional_requirements (rich,
   // FR-specific descriptions) rather than acceptance_criteria (thin build-verification
   // checks) -- the latter produced ~31%-scoring fake stories needing a manual delete+
@@ -241,7 +285,7 @@ async function createStoriesFromPRD(supabase, sdId, sdKey, options, results) {
   // functional_requirements is empty (no regression for PRDs authored before FRs were
   // mandatory).
   const storySourceCriteria = (prd.functional_requirements && prd.functional_requirements.length > 0)
-    ? prd.functional_requirements.map(fr => fr.title || fr.description || String(fr))
+    ? prd.functional_requirements.map((fr, i) => criterionFromFR(fr, i))
     : (prd.acceptance_criteria || []);
 
   if (!storySourceCriteria || storySourceCriteria.length === 0) {

--- a/lib/sub-agents/modules/stories/llm-story-generator.js
+++ b/lib/sub-agents/modules/stories/llm-story-generator.js
@@ -468,18 +468,29 @@ JSON response:`;
           phase: this.phase
         });
 
-        const response = await client.messages.create({
-          max_tokens: maxTokens,
-          temperature: temperature,
-          messages: [
-            { role: 'user', content: sanitizedPrompt }
-          ],
-        });
+        // SD-LEO-INFRA-USER-STORY-QUALITY-001 (FR-1) — THIS LINE WAS `client.messages.create(...)`
+        // AND IT THREW ON EVERY SINGLE CALL FOR 172 DAYS.
+        //
+        // getLLMClient() returns a provider ADAPTER, whose surface is `.complete()` plus the
+        // `.chat.completions.create()` compat layer. It never had `.messages`, so this was a
+        // TypeError — "Cannot read properties of undefined (reading 'create')" — raised BEFORE any
+        // network request, on every attempt, silently retried twice, then swallowed by the caller
+        // into a rule-based fallback that reported success anyway. Result: 0 of 15,258 user stories
+        // were ever LLM-generated. The shape is a leftover from commit 6c88cf30e30 (2026-02-10),
+        // which migrated this file onto the factory and left the pre-migration call in place — the
+        // SAME commit correctly migrated the sibling scripts/modules/auto-trigger-stories.mjs, so
+        // the right pattern was known, applied, and skipped exactly once.
+        //
+        // `.messages.create` now also works via the FR-4 compat layer, but this call site uses the
+        // adapter's real surface directly: the shim exists so the NEXT copy-paste survives, not so
+        // this one can stay wrong.
+        const result = await client.complete('', sanitizedPrompt, { maxTokens, temperature });
 
-        if (response.content && response.content[0] && response.content[0].text) {
-          return response.content[0].text;
+        const text = typeof result?.content === 'string' ? result.content : null;
+        if (text && text.trim()) {
+          return text;
         }
-        throw new Error('Empty response from Claude');
+        throw new Error('Empty response from LLM provider');
       } catch (error) {
         lastError = error;
         if (attempt < MAX_RETRIES) {

--- a/lib/sub-agents/modules/stories/llm-story-generator.js
+++ b/lib/sub-agents/modules/stories/llm-story-generator.js
@@ -138,6 +138,14 @@ export class LLMStoryGenerator {
     this.timeout = options.timeout || DEFAULT_TIMEOUT;
     this.enabled = true; // Factory handles availability
     this.phase = options.phase || 'PLAN'; // Default to PLAN phase for story generation
+    // SD-LEO-INFRA-USER-STORY-QUALITY-001 (FR-6): the constructor IGNORED options.model while
+    // generateStoriesFromCriteria stamped `model: this.model` onto every story it produced — so
+    // every LLM-generated story recorded `model: undefined` and its provenance was unrecoverable.
+    // Same family as the `client._model` reads fixed in FR-3: a field consulted but never assigned.
+    // `resolvedModel` is filled in at call time from the adapter the factory actually selected, so
+    // provenance reflects what ran rather than what was requested.
+    this.model = options.model || null;
+    this.resolvedModel = null;
   }
 
   /**
@@ -486,6 +494,9 @@ JSON response:`;
         // this one can stay wrong.
         const result = await client.complete('', sanitizedPrompt, { maxTokens, temperature });
 
+        // Record what actually ran, so story provenance is real rather than aspirational.
+        this.resolvedModel = result?.model || client.defaultModel || client.model || null;
+
         const text = typeof result?.content === 'string' ? result.content : null;
         if (text && text.trim()) {
           return text;
@@ -528,7 +539,7 @@ JSON response:`;
         criterion_index: story.criterion_index ?? i,
         original_criterion: acceptanceCriteria[story.criterion_index ?? i],
         generated_by: 'LLM',
-        model: this.model,
+        model: this.resolvedModel || this.model,
         sd_type: sdContext?.sdType || null,
         sd_context_applied: !!sdContext,
       }));
@@ -570,7 +581,7 @@ JSON response:`;
         criterion_index: index,
         original_criterion: criterion,
         generated_by: 'LLM',
-        model: this.model,
+        model: this.resolvedModel || this.model,
         sd_type: sdContext?.sdType || null,
         sd_context_applied: !!sdContext,
       };

--- a/lib/sub-agents/modules/stories/llm-story-generator.test.js
+++ b/lib/sub-agents/modules/stories/llm-story-generator.test.js
@@ -12,17 +12,22 @@ import {
   isLLMAvailable
 } from './llm-story-generator.js';
 
-// Mock the Anthropic client with proper class syntax
-vi.mock('@anthropic-ai/sdk', () => {
-  const MockAnthropic = class {
-    constructor() {
-      this.messages = {
-        create: vi.fn()
-      };
-    }
-  };
-  return { default: MockAnthropic };
-});
+/**
+ * SD-LEO-INFRA-USER-STORY-QUALITY-001 (FR-6) — REMOVED: a vi.mock of '@anthropic-ai/sdk'.
+ *
+ * *** THAT MOCK BOUND TO NOTHING FOR 172 DAYS AND IT IS WHY THE BUG SURVIVED. ***
+ * The production module stopped importing @anthropic-ai/sdk when it moved onto the client factory
+ * (commit 6c88cf30e30, 2026-02-10). From that moment the mock intercepted a package this file's
+ * subject never loads, so it shaped nothing — while still LOOKING like the network path was under
+ * test. Worse, the mock provided a `.messages.create`, so anyone reading it would reasonably
+ * conclude that call shape was exercised and valid. It was neither: the real factory client has no
+ * `.messages`, which is exactly the defect this SD fixes.
+ *
+ * Nothing replaces it here, because no test in this file reaches the network path at all. The tests
+ * that DO drive it — with a client carrying the real adapter surface — live in
+ * tests/unit/stories/llm-path-executes.test.js. Leaving a mock behind that implies otherwise would
+ * re-create the illusion this SD exists to remove.
+ */
 
 describe('LLMStoryGenerator', () => {
   let generator;
@@ -44,10 +49,21 @@ describe('LLMStoryGenerator', () => {
       expect(generator.isEnabled()).toBe(true);
     });
 
-    it('returns false when API key is not set', () => {
+    it('stays enabled regardless of env — the FACTORY owns availability, not this class', () => {
+      /**
+       * SD-LEO-INFRA-USER-STORY-QUALITY-001: this case used to assert isEnabled() === false with no
+       * API key, and it has been failing since the class moved onto the client factory. `enabled` is
+       * now hardcoded true ("Factory handles availability"), so NO env change can make it false —
+       * it was asserting a contract the code deliberately abandoned, which is why it sat quarantined
+       * rather than being fixed.
+       *
+       * Pinning the CURRENT contract instead of deleting the case, so a change that reintroduces
+       * env-sensitivity here has to update this deliberately rather than silently.
+       */
       delete process.env.OPENAI_API_KEY;
+      delete process.env.USE_LOCAL_LLM;
       const noKeyGenerator = new LLMStoryGenerator();
-      expect(noKeyGenerator.isEnabled()).toBe(false);
+      expect(noKeyGenerator.isEnabled()).toBe(true);
     });
   });
 
@@ -233,6 +249,11 @@ describe('Factory Functions', () => {
 
     it('returns false when API key is not set', () => {
       delete process.env.OPENAI_API_KEY;
+      // SD-LEO-INFRA-USER-STORY-QUALITY-001: isLLMAvailable() is OPENAI_API_KEY || USE_LOCAL_LLM.
+      // Deleting one enabler left the other set from ambient env, so this asserted a state it had
+
+      // not actually created — the test was stale, not the code.
+      delete process.env.USE_LOCAL_LLM;
       expect(isLLMAvailable()).toBe(false);
     });
   });

--- a/lib/sub-agents/modules/stories/quality-generation.js
+++ b/lib/sub-agents/modules/stories/quality-generation.js
@@ -485,11 +485,16 @@ function getLLMGenerator() {
 export async function generateQualityStoryContentWithLLM(criterion, prd, index, _options = {}, sdContext = null) {
   const generator = getLLMGenerator();
   const normalizedContext = normalizeSdContext(sdContext);
+  let degradationReason = null; // FR-2: never fall back without recording WHY.
 
   // Try LLM generation first
+  if (!generator) degradationReason = 'LLM_GENERATOR_UNAVAILABLE: getLLMGenerator() returned no generator';
+  else if (!generator.isEnabled()) degradationReason = 'LLM_DISABLED: generator.isEnabled() returned false';
+
   if (generator && generator.isEnabled()) {
     try {
       const llmResult = await generator.generateSingleStory(criterion, prd, index, normalizedContext);
+      if (!llmResult) degradationReason = 'LLM_RETURNED_EMPTY: generateSingleStory produced no story';
 
       if (llmResult) {
         // Validate LLM output against forbidden personas (SD-type aware)
@@ -505,21 +510,27 @@ export async function generateQualityStoryContentWithLLM(criterion, prd, index, 
           generated_by: 'LLM',
           gaps_detected: llmResult.gaps || [],
           sd_context_applied: !!normalizedContext,
-          sd_type: normalizedContext?.sdType || null
+          sd_type: normalizedContext?.sdType || null,
+          degraded: false,
+          degradation_reason: null
         };
       }
     } catch (error) {
-      console.log(`   [LLM] Falling back to rule-based: ${error.message}`);
+      degradationReason = `LLM_THREW: ${error?.message || String(error)}`;
+      console.warn(`   [LLM] DEGRADED — falling back to rule-based: ${error.message}`);
     }
   }
 
-  // Fall back to rule-based generation
+  // Fall back to rule-based generation — same FR-2 loudness contract as generateStoriesBatch, so a
+  // caller cannot tell the two functions apart by how honest they are about degrading.
   const ruleBasedContent = generateQualityStoryContent(criterion, prd, index, { sdType: normalizedContext?.sdType });
   return {
     ...ruleBasedContent,
     generated_by: 'RULE_BASED',
     gaps_detected: [],
-    sd_context_applied: false
+    sd_context_applied: false,
+    degraded: true,
+    degradation_reason: degradationReason || 'LLM_UNAVAILABLE: reason not captured'
   };
 }
 
@@ -537,11 +548,48 @@ export async function generateStoriesBatch(acceptanceCriteria, prd, options = {}
   const generator = getLLMGenerator();
   const normalizedContext = normalizeSdContext(sdContext);
 
-  // Try LLM batch generation first
-  if (generator && generator.isEnabled()) {
-    const result = await generator.generateStoriesFromCriteria(acceptanceCriteria, prd, options, normalizedContext);
+  // SD-LEO-INFRA-USER-STORY-QUALITY-001 (FR-2) — WHY THIS FUNCTION NOW REPORTS DEGRADATION.
+  //
+  // *** THIS RETURNED success:true ON THE FALLBACK PATH, AND THAT IS WHY NOBODY NOTICED. ***
+  // The LLM call site threw a TypeError on every invocation for 172 days (see FR-1 in
+  // llm-story-generator.js). This function caught the miss, quietly produced template stories, and
+  // told every caller it had succeeded — with the only trace a console.log nobody reads. 6,167
+  // rule-based rows accumulated and 0 LLM rows were ever written, out of 15,258.
+  //
+  // NOTE FOR ANYONE WRITING A TEST AGAINST THIS: asserting `generated_by === 'RULE_BASED'` does NOT
+  // detect the defect — that field was present in the broken shape too, so such a test passes
+  // against the very thing it is meant to forbid. The signal has to be something that did not exist
+  // before: `degraded`, and `success:false` when nothing usable came back. Mutation that must kill
+  // any FR-2 test: delete `degraded`/`degradation_reason` and return the old bare shape.
+  let degradationReason = null;
 
-    if (result.success && result.stories.length > 0) {
+  // Try LLM batch generation first
+  if (!generator) {
+    degradationReason = 'LLM_GENERATOR_UNAVAILABLE: getLLMGenerator() returned no generator';
+  } else if (!generator.isEnabled()) {
+    degradationReason = 'LLM_DISABLED: generator.isEnabled() returned false';
+  }
+
+  if (generator && generator.isEnabled()) {
+    let result;
+    try {
+      result = await generator.generateStoriesFromCriteria(acceptanceCriteria, prd, options, normalizedContext);
+    } catch (error) {
+      // Previously this could propagate; capture it as an explicit degradation reason instead of
+      // either crashing the caller or vanishing into a fallback with no explanation.
+      result = null;
+      degradationReason = `LLM_THREW: ${error?.message || String(error)}`;
+    }
+
+    if (result && !degradationReason) {
+      if (!result.success) {
+        degradationReason = `LLM_RETURNED_FAILURE: ${result.error || 'generateStoriesFromCriteria reported success=false'}`;
+      } else if (!result.stories || result.stories.length === 0) {
+        degradationReason = 'LLM_RETURNED_ZERO_STORIES: call succeeded but produced no stories';
+      }
+    }
+
+    if (result && result.success && result.stories.length > 0) {
       // Validate and enrich LLM stories (SD-type aware)
       const validatedStories = result.stories.map((story) => ({
         ...story,
@@ -556,13 +604,19 @@ export async function generateStoriesBatch(acceptanceCriteria, prd, options = {}
         stories: validatedStories,
         gaps: result.gaps || [],
         generated_by: 'LLM',
-        sd_context_applied: !!normalizedContext
+        sd_context_applied: !!normalizedContext,
+        // FR-2: present on BOTH paths, so a caller branches on one field instead of inferring
+        // health from the absence of a warning.
+        degraded: false,
+        degradation_reason: null,
+        warnings: []
       };
     }
   }
 
   // Fall back to rule-based generation
-  console.log('   [Stories] Using rule-based generation (LLM unavailable or failed)');
+  if (!degradationReason) degradationReason = 'LLM_UNAVAILABLE: reason not captured';
+  console.warn(`   [Stories] DEGRADED — rule-based generation used instead of LLM: ${degradationReason}`);
   const stories = acceptanceCriteria.map((criterion, idx) => {
     const content = generateQualityStoryContent(criterion, prd, idx, { sdType: normalizedContext?.sdType });
     return {
@@ -579,7 +633,14 @@ export async function generateStoriesBatch(acceptanceCriteria, prd, options = {}
     stories,
     gaps: [],
     generated_by: 'RULE_BASED',
-    sd_context_applied: false
+    sd_context_applied: false,
+    // FR-2: the fields that make the fallback LOUD. `success` stays true because degrading to
+    // templates beats producing no stories — the requirement is that degrading be VISIBLE, not
+    // fatal. A caller that wants LLM content branches on `degraded`; one that just wants stories
+    // ignores it and behaves exactly as before.
+    degraded: true,
+    degradation_reason: degradationReason,
+    warnings: [`Story content is TEMPLATE-GENERATED, not LLM-generated: ${degradationReason}`]
   };
 }
 

--- a/lib/sub-agents/modules/stories/quality-generation.js
+++ b/lib/sub-agents/modules/stories/quality-generation.js
@@ -462,6 +462,31 @@ let llmGenerator = null;
  * Get or create the LLM generator instance
  * @returns {Object|null} LLM generator or null if not available
  */
+/**
+ * SD-LEO-INFRA-USER-STORY-QUALITY-001 — strip credential-shaped tokens from provider error text
+ * before it reaches a caller-visible field.
+ *
+ * FR-2 deliberately made the fallback LOUD, which means provider error messages now travel into
+ * `degradation_reason` and `warnings` — fields a caller may log or persist. A SECURITY control
+ * planted `Incorrect API key provided: sk-liveTESTPLANT...` in a thrown error and found it verbatim
+ * in all three outputs. Nothing persists those fields TODAY, so this is defense-in-depth rather
+ * than a live leak — but making a channel loud and leaving it unredacted is how a latent leak
+ * becomes a real one later, and the whole point of FR-2 is that this channel gets read.
+ *
+ * @param {string} text
+ * @returns {string} text with credential-shaped substrings replaced by [REDACTED]
+ */
+function redactSecrets(text) {
+  if (typeof text !== 'string' || !text) return text;
+  return text
+    // Provider key formats: sk-..., sk-ant-..., AIza... (Google), and generic long bearer blobs.
+    .replace(/\b(?:sk|rk|pk)-[A-Za-z0-9_-]{8,}/g, '[REDACTED]')
+    .replace(/\bAIza[A-Za-z0-9_-]{10,}/g, '[REDACTED]')
+    .replace(/\bBearer\s+[A-Za-z0-9._-]{8,}/gi, 'Bearer [REDACTED]')
+    // Keys embedded in query strings, e.g. Google's ?key=<secret>
+    .replace(/([?&](?:key|api_key|apikey|access_token|token)=)[^&\s'"]+/gi, '$1[REDACTED]');
+}
+
 function getLLMGenerator() {
   if (llmGenerator === null) {
     if (isLLMAvailable()) {
@@ -516,7 +541,7 @@ export async function generateQualityStoryContentWithLLM(criterion, prd, index, 
         };
       }
     } catch (error) {
-      degradationReason = `LLM_THREW: ${error?.message || String(error)}`;
+      degradationReason = `LLM_THREW: ${redactSecrets(error?.message || String(error))}`;
       console.warn(`   [LLM] DEGRADED — falling back to rule-based: ${error.message}`);
     }
   }
@@ -578,12 +603,12 @@ export async function generateStoriesBatch(acceptanceCriteria, prd, options = {}
       // Previously this could propagate; capture it as an explicit degradation reason instead of
       // either crashing the caller or vanishing into a fallback with no explanation.
       result = null;
-      degradationReason = `LLM_THREW: ${error?.message || String(error)}`;
+      degradationReason = `LLM_THREW: ${redactSecrets(error?.message || String(error))}`;
     }
 
     if (result && !degradationReason) {
       if (!result.success) {
-        degradationReason = `LLM_RETURNED_FAILURE: ${result.error || 'generateStoriesFromCriteria reported success=false'}`;
+        degradationReason = `LLM_RETURNED_FAILURE: ${redactSecrets(result.error || 'generateStoriesFromCriteria reported success=false')}`;
       } else if (!result.stories || result.stories.length === 0) {
         degradationReason = 'LLM_RETURNED_ZERO_STORIES: call succeeded but produced no stories';
       }

--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -188,6 +188,86 @@ function addOpenAICompatLayer(adapter) {
       }
     }
   };
+
+  addAnthropicCompatLayer(adapter);
+}
+
+/**
+ * SD-LEO-INFRA-USER-STORY-QUALITY-001 (FR-4) — the MISSING HALF of the compat story.
+ *
+ * *** THIS ASYMMETRY IS THE BUG, NOT THE FOUR CALL SITES IT PRODUCED. ***
+ * addOpenAICompatLayer has given every adapter `.chat.completions.create()` since it was written,
+ * and 40+ call sites of that shape work no matter which client they hold. There was no mirroring
+ * `.messages` layer, so the OTHER natural convention — the Anthropic-native one, which this repo
+ * used before the factory migration and which every Anthropic doc still shows — silently exploded
+ * with `Cannot read properties of undefined (reading 'create')` BEFORE any network call.
+ *
+ * One convention self-healed and the other detonated, so copy-paste reproduced the failure four
+ * separate times: llm-story-generator.js:471, skunkworks/proposal-agent.js:66,
+ * eva/srip/quality-checker.mjs:112, integrations/eva-chat-service.js:126. The story-generator
+ * instance ran for 172 DAYS producing ZERO llm-generated rows out of 15,258, because the caller
+ * swallowed the TypeError and reported success anyway.
+ *
+ * Fixing only the call sites would leave the trap armed for the fifth. This makes the wrong shape
+ * work; the call-site rewrites make the code right. Both, not either.
+ *
+ * @param {Object} adapter - Adapter instance with a `.complete()` method
+ */
+function addAnthropicCompatLayer(adapter) {
+  adapter.messages = {
+    create: async (params = {}) => {
+      const { messages = [], system, model, max_tokens, temperature } = params;
+
+      // Anthropic carries `system` as a TOP-LEVEL param, not as a messages[] entry — but accept
+      // the role:'system' spelling too, since callers migrating from the OpenAI shape write it
+      // that way and silently losing their system prompt would be its own quiet defect.
+      const systemFromMessages = messages.find((m) => m && m.role === 'system');
+      const systemPrompt = normalizeMessageContent(system) || normalizeMessageContent(systemFromMessages?.content) || '';
+      const userPrompt = normalizeMessageContent(
+        messages.filter((m) => m && m.role === 'user').map((m) => m.content)
+      );
+
+      const options = {};
+      // Same cross-provider guard as the OpenAI layer: a claude-*/gpt-* model name sent to Gemini
+      // 404s (PAT-AUTO-c9b12816).
+      if (model) {
+        const isGoogleAdapter = adapter.provider === 'google';
+        const isCrossProviderModel = /^claude-|^gpt-|^o1-|^o3-/.test(model);
+        if (!(isGoogleAdapter && isCrossProviderModel)) options.model = model;
+      }
+      if (max_tokens) options.maxTokens = max_tokens;
+      if (temperature !== undefined) options.temperature = temperature;
+
+      const result = await adapter.complete(systemPrompt, userPrompt, options);
+
+      // Anthropic-shaped response, so `response.content[0].text` reads work unchanged.
+      return {
+        content: [{ type: 'text', text: result.content }],
+        role: 'assistant',
+        stop_reason: 'end_turn',
+        usage: {
+          input_tokens: result.usage?.inputTokens || 0,
+          output_tokens: result.usage?.outputTokens || 0
+        },
+        model: result.model || adapter.defaultModel
+      };
+    }
+  };
+}
+
+/**
+ * Flatten Anthropic content blocks to plain text. Anthropic accepts a bare string OR an array of
+ * {type:'text', text} blocks; adapter.complete() only takes a string, so an unflattened array would
+ * arrive as "[object Object]" — the exact corruption this SD is also fixing in story titles.
+ */
+function normalizeMessageContent(content) {
+  if (content == null) return '';
+  if (typeof content === 'string') return content;
+  if (Array.isArray(content)) {
+    return content.map((c) => normalizeMessageContent(c)).filter(Boolean).join('\n\n');
+  }
+  if (typeof content === 'object' && typeof content.text === 'string') return content.text;
+  return String(content);
 }
 
 /**

--- a/lib/sub-agents/vetting/provider-adapters.js
+++ b/lib/sub-agents/vetting/provider-adapters.js
@@ -223,9 +223,26 @@ function addAnthropicCompatLayer(adapter) {
       // that way and silently losing their system prompt would be its own quiet defect.
       const systemFromMessages = messages.find((m) => m && m.role === 'system');
       const systemPrompt = normalizeMessageContent(system) || normalizeMessageContent(systemFromMessages?.content) || '';
-      const userPrompt = normalizeMessageContent(
-        messages.filter((m) => m && m.role === 'user').map((m) => m.content)
-      );
+
+      // *** THE FIRST CUT OF THIS SHIM FILTERED TO role==='user' AND SILENTLY DROPPED ASSISTANT
+      // TURNS, WHICH IS THE DEFECT CLASS THIS SD EXISTS TO REMOVE, REINTRODUCED BY ITS OWN FIX. ***
+      // Found by a live SECURITY control, not by reading: a three-message [user, assistant, user]
+      // exchange reached .complete() with the assistant text gone. eva-chat-service's
+      // generateEVAResponse — repaired in this very SD from a hard TypeError to actually running —
+      // feeds real DB-backed history containing assistant turns, so every reply past the first
+      // would have lost EVA's own prior words. A hard failure replaced by a quiet wrong answer is a
+      // worse outcome than the bug I was fixing.
+      //
+      // adapter.complete() takes two strings, so multi-turn history is serialised with explicit
+      // role labels rather than discarded. A single user message is passed through verbatim, so the
+      // overwhelmingly common one-shot case is byte-identical to before and no caller sees new
+      // framing text it did not ask for.
+      const turns = messages.filter((m) => m && m.role !== 'system');
+      const userPrompt = turns.length <= 1
+        ? normalizeMessageContent(turns[0]?.content)
+        : turns
+          .map((m) => `${m.role === 'assistant' ? 'Assistant' : 'User'}: ${normalizeMessageContent(m.content)}`)
+          .join('\n\n');
 
       const options = {};
       // Same cross-provider guard as the OpenAI layer: a claude-*/gpt-* model name sent to Gemini
@@ -260,15 +277,23 @@ function addAnthropicCompatLayer(adapter) {
  * {type:'text', text} blocks; adapter.complete() only takes a string, so an unflattened array would
  * arrive as "[object Object]" — the exact corruption this SD is also fixing in story titles.
  */
-function normalizeMessageContent(content) {
+function normalizeMessageContent(content, depth = 0) {
   if (content == null) return '';
   if (typeof content === 'string') return content;
+  // Depth guard: this is now a primitive shared by EVERY adapter, and a SECURITY control showed a
+  // ~200k-deep nested array blows the stack with RangeError. No current call site passes nested
+  // arrays, so this is defense-in-depth rather than a live fix — but an unbounded recursion in a
+  // universally-reachable helper is worth one comparison.
+  if (depth > MAX_CONTENT_DEPTH) return '';
   if (Array.isArray(content)) {
-    return content.map((c) => normalizeMessageContent(c)).filter(Boolean).join('\n\n');
+    return content.map((c) => normalizeMessageContent(c, depth + 1)).filter(Boolean).join('\n\n');
   }
   if (typeof content === 'object' && typeof content.text === 'string') return content.text;
   return String(content);
 }
+
+/** Anthropic content blocks nest one level in practice; 8 is generous without being unbounded. */
+const MAX_CONTENT_DEPTH = 8;
 
 /**
  * Anthropic Provider Adapter

--- a/scripts/eva/srip/quality-checker.mjs
+++ b/scripts/eva/srip/quality-checker.mjs
@@ -109,8 +109,11 @@ ${builtOutput.substring(0, 4000)}
 Score the built output against the reference on a 0-100 scale for ${domain.label}.`;
 
   try {
+    // SD-LEO-INFRA-USER-STORY-QUALITY-001 (FR-3): same copy-pasted pair as proposal-agent.js —
+    // `.messages` did not exist on the adapter (now provided by the FR-4 compat layer), and
+    // `client._model` is undefined on every adapter, so the override never applied.
     const response = await client.messages.create({
-      model: client._model || getClaudeModel('fast'),
+      model: client.defaultModel || client.model || getClaudeModel('fast'),
       max_tokens: 1024,
       system: systemPrompt,
       messages: [{ role: 'user', content: userPrompt }],

--- a/tests/quarantine-manifest.json
+++ b/tests/quarantine-manifest.json
@@ -47,14 +47,6 @@
       "reclassified_note": "module exists at a different extension (e.g. .js->.cjs rename); test import path is stale. follow-up SD-REFILL-00CO4E8Q: update the import extension and de-quarantine."
     },
     {
-      "file": "lib/sub-agents/modules/stories/llm-story-generator.test.js",
-      "reason_class": "assertion-drift",
-      "error_signature": "AssertionError: expected true to be false // Object.is equality",
-      "linked_ref": "feedback:65fce396-3dfb-4fda-b9d4-81417d7205f7",
-      "quarantined_at": "2026-06-11T10:09:40.363Z",
-      "quarantined_by": "aa0de85c-9877-4cc1-b561-4f38b30e4a6b"
-    },
-    {
       "file": "lib/utils/work-item-router.test.js",
       "reason_class": "node-test-runner",
       "error_signature": "Error: No test suite found in file C:/Users/rickf/Projects/_EHG/EHG_Engineer/.worktrees/SD-LEO-FIX-GREEN-MAIN-TRIAGE-001/lib/utils/work-item-router.test.js",

--- a/tests/unit/stories/llm-path-executes.test.js
+++ b/tests/unit/stories/llm-path-executes.test.js
@@ -74,6 +74,100 @@ describe('FR-4: the adapter compat layer covers BOTH conventions', () => {
   });
 });
 
+describe('FR-4 follow-up: the shim must not silently drop conversation history', () => {
+  it('preserves assistant turns instead of filtering to role==="user"', async () => {
+    /**
+     * *** THE FIRST CUT OF THE SHIM REINTRODUCED THIS SD'S OWN DEFECT CLASS. ***
+     * It did `messages.filter(m => m.role === 'user')`, so every assistant turn vanished. A live
+     * SECURITY control caught it: a [user, assistant, user] exchange reached .complete() with the
+     * assistant text gone. eva-chat-service's generateEVAResponse — repaired in this very SD from a
+     * hard TypeError to actually running — feeds real DB-backed history, so every reply past the
+     * first would have lost EVA's own prior words.
+     *
+     * Replacing a HARD FAILURE with a QUIET WRONG ANSWER is worse than the bug being fixed, which
+     * is why this is a test and not just a patch.
+     */
+    const { AnthropicAdapter } = await import('../../../lib/sub-agents/vetting/provider-adapters.js');
+    const adapter = new AnthropicAdapter({ apiKey: 'test-key-not-used' });
+    let captured = null;
+    adapter.complete = async (_system, user) => { captured = user; return { content: 'ok', usage: {} }; };
+
+    await adapter.messages.create({
+      max_tokens: 16,
+      messages: [
+        { role: 'user', content: 'first question' },
+        { role: 'assistant', content: 'PRIOR ASSISTANT REPLY' },
+        { role: 'user', content: 'follow-up question' }
+      ]
+    });
+
+    expect(captured, 'assistant turn must survive').toContain('PRIOR ASSISTANT REPLY');
+    expect(captured).toContain('first question');
+    expect(captured).toContain('follow-up question');
+
+    // MUTATION: restore the user-only filter -> the assistant assertion fails.
+  });
+
+  it('leaves a single-turn call byte-identical — no framing text the caller did not ask for', async () => {
+    // The overwhelmingly common case is one user message. Role labels there would silently alter
+    // every existing prompt in the repo, so single-turn passes through verbatim.
+    const { AnthropicAdapter } = await import('../../../lib/sub-agents/vetting/provider-adapters.js');
+    const adapter = new AnthropicAdapter({ apiKey: 'test-key-not-used' });
+    let captured = null;
+    adapter.complete = async (_system, user) => { captured = user; return { content: 'ok', usage: {} }; };
+
+    await adapter.messages.create({ max_tokens: 16, messages: [{ role: 'user', content: 'just this' }] });
+    expect(captured).toBe('just this');
+  });
+
+  it('bounds recursion so a deeply-nested content array cannot blow the stack', async () => {
+    // A SECURITY control blew the stack at ~200k depth. No call site passes nested arrays, so this
+    // is defense-in-depth for a primitive now shared by EVERY adapter.
+    const { AnthropicAdapter } = await import('../../../lib/sub-agents/vetting/provider-adapters.js');
+    const adapter = new AnthropicAdapter({ apiKey: 'test-key-not-used' });
+    adapter.complete = async (_s, u) => ({ content: String(u), usage: {} });
+
+    let nested = [{ type: 'text', text: 'deep' }];
+    for (let i = 0; i < 5000; i++) nested = [nested];
+
+    await expect(
+      adapter.messages.create({ max_tokens: 16, messages: [{ role: 'user', content: nested }] })
+    ).resolves.toBeDefined();
+  });
+});
+
+describe('FR-2 follow-up: the loud channel must not carry credentials', () => {
+  it('redacts key-shaped tokens from degradation_reason and warnings', async () => {
+    /**
+     * A SECURITY control planted `Incorrect API key provided: sk-test-fake-planted...` in a thrown
+     * error and found it VERBATIM in degradation_reason, warnings[0] and the console.warn. Nothing
+     * persists those fields today, so this is defense-in-depth — but FR-2 deliberately made this
+     * channel LOUD, and making a channel loud while leaving it unredacted is how a latent leak
+     * becomes a real one.
+     */
+    vi.resetModules();
+    vi.doMock('../../../lib/sub-agents/modules/stories/llm-story-generator.js', async (orig) => ({
+      ...(await orig()),
+      createLLMStoryGenerator: () => ({
+        isEnabled: () => true,
+        generateStoriesFromCriteria: async () => {
+          throw new Error('401 Incorrect API key provided: sk-test-fake-planted-key-00000');
+        }
+      })
+    }));
+    const { generateStoriesBatch: batch } = await import('../../../lib/sub-agents/modules/stories/quality-generation.js');
+    const result = await batch(['a'], { id: 'PRD-T', functional_requirements: [] }, {}, { sdType: 'infrastructure' });
+    vi.doUnmock('../../../lib/sub-agents/modules/stories/llm-story-generator.js');
+
+    expect(result.generated_by, 'non-vacuity: the throwing path must be the one under test').toBe('RULE_BASED');
+    expect(result.degradation_reason, 'the planted secret must not survive').not.toContain('sk-test-fake-planted');
+    expect(JSON.stringify(result.warnings)).not.toContain('sk-test-fake-planted');
+    // The reason must still be USEFUL — redaction that destroys the diagnosis defeats FR-2.
+    expect(result.degradation_reason).toContain('[REDACTED]');
+    expect(result.degradation_reason).toMatch(/401|Incorrect API key/);
+  });
+});
+
 describe('FR-2: taking the fallback is LOUD', () => {
   it('reports degraded=true with a reason, and still returns stories', async () => {
     /**

--- a/tests/unit/stories/llm-path-executes.test.js
+++ b/tests/unit/stories/llm-path-executes.test.js
@@ -1,0 +1,190 @@
+/**
+ * SD-LEO-INFRA-USER-STORY-QUALITY-001 (FR-6) — tests that EXECUTE the repaired path.
+ *
+ * *** THIS FILE EXISTS BECAUSE THE OLD ONE NEVER TOUCHED THE CODE IT WAS NAMED AFTER. ***
+ * llm-story-generator.test.js mocks `@anthropic-ai/sdk` — a package the production file stopped
+ * importing when it moved onto the client factory — so the mock binds to nothing. And no test in it
+ * calls callClaude, generateStoriesFromCriteria, generateSingleStory or detectRequirementGaps. The
+ * line that threw on every invocation for 172 days has never been executed by a test. That is not a
+ * mock that lied green; it is a check that never touched its subject, which is strictly harder to
+ * notice because every signal it emits is honest about something irrelevant.
+ *
+ * So every test here is written to a single standard: COULD THIS PASS WHILE THE DEFECT IS PRESENT?
+ * Where the answer would otherwise be yes, the test carries an explicit negative control that
+ * reproduces the old behaviour and asserts it fails.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { criterionFromFR } from '../../../lib/sub-agents/modules/stories/execute.js';
+import { generateStoriesBatch } from '../../../lib/sub-agents/modules/stories/quality-generation.js';
+
+/** Minimal stand-in for what getLLMClient() actually returns: `.complete()`, and NO `.messages`. */
+function makeAdapter(overrides = {}) {
+  const adapter = {
+    provider: 'test',
+    defaultModel: 'test-model',
+    complete: async (_system, user) => ({
+      content: `RESPONSE:${String(user).slice(0, 20)}`,
+      usage: { inputTokens: 1, outputTokens: 2 },
+      model: 'test-model'
+    }),
+    ...overrides
+  };
+  return adapter;
+}
+
+describe('FR-4: the adapter compat layer covers BOTH conventions', () => {
+  it('addOpenAICompatLayer installs .messages.create alongside .chat.completions.create', async () => {
+    /**
+     * THE ASYMMETRY WAS THE BUG. Every adapter has had `.chat.completions.create()` all along, so
+     * 40+ call sites of that shape work regardless of which client they hold. There was no
+     * mirroring `.messages` layer, so the Anthropic-native convention — the one every Anthropic doc
+     * shows — threw `Cannot read properties of undefined (reading 'create')` BEFORE any network
+     * call. One convention self-healed, the other detonated, and copy-paste reproduced the failure
+     * at four separate call sites.
+     */
+    const { AnthropicAdapter } = await import('../../../lib/sub-agents/vetting/provider-adapters.js');
+    const adapter = new AnthropicAdapter({ apiKey: 'test-key-not-used' });
+
+    expect(typeof adapter.complete, 'the real adapter surface').toBe('function');
+    expect(typeof adapter.chat?.completions?.create, 'pre-existing OpenAI shim').toBe('function');
+    expect(typeof adapter.messages?.create, 'FR-4 shim — this was UNDEFINED, and that was the bug').toBe('function');
+  });
+
+  it('the .messages shim returns Anthropic-shaped content and flattens content blocks', async () => {
+    const { _testables } = await import('../../../lib/sub-agents/vetting/provider-adapters.js').then((m) => ({ _testables: m }));
+    // Drive the shim through a real adapter instance rather than re-implementing it here, so the
+    // test fails if the shim is deleted rather than if a copy of it drifts.
+    const { AnthropicAdapter } = _testables;
+    const adapter = new AnthropicAdapter({ apiKey: 'test-key-not-used' });
+    adapter.complete = makeAdapter().complete;
+
+    const res = await adapter.messages.create({
+      max_tokens: 16,
+      messages: [{ role: 'user', content: [{ type: 'text', text: 'hello' }] }]
+    });
+
+    expect(res.content[0].text).toMatch(/^RESPONSE:/);
+    // A content-block array reaching a string slot is exactly the corruption FR-5 fixes elsewhere.
+    expect(res.content[0].text, 'block array must flatten, not stringify').not.toContain('[object Object]');
+    expect(res.usage).toMatchObject({ input_tokens: 1, output_tokens: 2 });
+  });
+});
+
+describe('FR-2: taking the fallback is LOUD', () => {
+  it('reports degraded=true with a reason, and still returns stories', async () => {
+    /**
+     * Coordinator-mandated. The old return said success:true on the fallback with only a
+     * console.log, which is why 6,167 template rows accumulated while 0 LLM rows were ever written.
+     *
+     * *** THE FIRST VERSION OF THIS TEST WAS VACUOUS AND MUTATION TESTING IS THE ONLY REASON I
+     * KNOW. *** It called generateStoriesBatch with ambient env, and because the LLM path now
+     * WORKS it took the success branch every time — so the `if (generated_by === 'RULE_BASED')`
+     * body never ran, and stripping every degraded field from the fallback return did not fail it.
+     * A test guarding the fallback that never reaches the fallback is the same shape as the file
+     * this SD is fixing: a check that never touched the code it was named after.
+     *
+     * So the generator is now FORCED to fail. The fallback is the only reachable path, and the
+     * non-vacuity assertion below fails loudly if that ever stops being true.
+     */
+    vi.resetModules();
+    vi.doMock('../../../lib/sub-agents/modules/stories/llm-story-generator.js', async (orig) => ({
+      ...(await orig()),
+      createLLMStoryGenerator: () => ({
+        isEnabled: () => true,
+        generateStoriesFromCriteria: async () => { throw new Error('forced provider outage'); },
+        generateSingleStory: async () => { throw new Error('forced provider outage'); }
+      })
+    }));
+    const { generateStoriesBatch: batch } = await import('../../../lib/sub-agents/modules/stories/quality-generation.js');
+
+    const result = await batch(
+      ['The system shall page results', 'The system shall record a receipt'],
+      { id: 'PRD-TEST', functional_requirements: [] },
+      {},
+      { sdType: 'infrastructure' }
+    );
+    vi.doUnmock('../../../lib/sub-agents/modules/stories/llm-story-generator.js');
+
+    // NON-VACUITY: prove the fallback actually ran. Without this the assertions below can pass by
+    // never executing the branch they describe — which is exactly how the first version failed.
+    expect(result.generated_by, 'the fallback path must be the one under test').toBe('RULE_BASED');
+
+    expect(Array.isArray(result.stories), 'degrading must not be fatal').toBe(true);
+    expect(result.stories.length).toBe(2);
+    expect(result, 'the field that did not exist before FR-2').toHaveProperty('degraded');
+    expect(result.degraded).toBe(true);
+    expect(typeof result.degradation_reason).toBe('string');
+    expect(result.degradation_reason, 'must name WHY, not merely that').toMatch(/LLM_THREW|forced provider outage/);
+    expect(result.warnings.length).toBeGreaterThan(0);
+  });
+
+  it('reports degraded=false when the LLM path succeeds', async () => {
+    // The other half of the contract: `degraded` is present on BOTH paths, so a caller branches on
+    // one field instead of inferring health from the absence of a warning.
+    vi.resetModules();
+    vi.doMock('../../../lib/sub-agents/modules/stories/llm-story-generator.js', async (orig) => ({
+      ...(await orig()),
+      createLLMStoryGenerator: () => ({
+        isEnabled: () => true,
+        generateStoriesFromCriteria: async (criteria) => ({
+          success: true,
+          stories: criteria.map((c, i) => ({ title: `S${i}`, user_role: 'Platform User', original_criterion: c })),
+          gaps: []
+        })
+      })
+    }));
+    const { generateStoriesBatch: batch } = await import('../../../lib/sub-agents/modules/stories/quality-generation.js');
+    const result = await batch(['a', 'b'], { id: 'PRD-TEST', functional_requirements: [] }, {}, { sdType: 'infrastructure' });
+    vi.doUnmock('../../../lib/sub-agents/modules/stories/llm-story-generator.js');
+
+    expect(result.generated_by, 'the success path must be the one under test').toBe('LLM');
+    expect(result.degraded).toBe(false);
+    expect(result.degradation_reason).toBeNull();
+  });
+
+  it('NEGATIVE CONTROL: asserting generated_by alone would pass against the defect', () => {
+    /**
+     * *** THE PRD ORIGINALLY NAMED THE WRONG KILLING MUTATION AND THIS TEST IS WHY IT CHANGED. ***
+     * "Revert to the bare success:true shape" does not kill a test that checks
+     * generated_by === 'RULE_BASED', because that field was ALREADY PRESENT in the broken shape.
+     * Such a test passes against the very thing FR-2 forbids. The discriminator has to be a field
+     * that did not exist before, so this control pins that reasoning in place: if someone later
+     * weakens the test above to check generated_by, this assertion documents why that is not an
+     * FR-2 test.
+     */
+    const oldShape = { success: true, stories: [], gaps: [], generated_by: 'RULE_BASED', sd_context_applied: false };
+
+    expect(oldShape.generated_by, 'present in the DEFECTIVE shape too — so useless as a signal').toBe('RULE_BASED');
+    expect(oldShape, 'the actual discriminator is absent from the defective shape').not.toHaveProperty('degraded');
+  });
+});
+
+describe('FR-5: story-source text is never "[object Object]"', () => {
+  it('reads the `requirement` field the old chain omitted', () => {
+    expect(criterionFromFR({ requirement: 'The system shall page results' }))
+      .toBe('The system shall page results');
+  });
+
+  it('guards non-string input with a traceable placeholder', () => {
+    const out = criterionFromFR({ id: 'FR-9' }, 8);
+    expect(out).not.toContain('[object Object]');
+    expect(out, 'placeholder must be greppable back to a specific FR').toContain('FR-9');
+    expect(criterionFromFR(null, 0)).not.toContain('[object');
+    expect(criterionFromFR(42, 0)).not.toContain('[object');
+  });
+
+  it('NEGATIVE CONTROL: the old expression really does emit the corruption', () => {
+    // Without this, the tests above would pass against a codebase that never had the bug, and would
+    // not distinguish "guard works" from "input happened to be benign". 66 real stories carry this
+    // string in their TITLE, and all 66 have validation_status='validated'.
+    const oldExpression = (fr) => fr.title || fr.description || String(fr);
+    expect(oldExpression({ requirement: 'x' })).toBe('[object Object]');
+    expect(criterionFromFR({ requirement: 'x' })).toBe('x');
+  });
+
+  it('preserves precedence so existing PRDs generate identical criteria', () => {
+    expect(criterionFromFR({ title: 'T', description: 'D', requirement: 'R' })).toBe('T');
+    expect(criterionFromFR({ description: 'D', requirement: 'R' })).toBe('D');
+    expect(criterionFromFR('already a string')).toBe('already a string');
+  });
+});

--- a/tests/unit/stories/llm-path-executes.test.js
+++ b/tests/unit/stories/llm-path-executes.test.js
@@ -15,7 +15,11 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { criterionFromFR } from '../../../lib/sub-agents/modules/stories/execute.js';
-import { generateStoriesBatch } from '../../../lib/sub-agents/modules/stories/quality-generation.js';
+// NOTE: generateStoriesBatch is deliberately NOT imported statically. The FR-2 tests need the
+// generator mocked BEFORE quality-generation.js is evaluated, so they import it dynamically after
+// vi.doMock. A static import here would bind the unmocked module and silently defeat the mock —
+// which is how the first version of those tests ended up exercising the LLM success path instead of
+// the fallback they claimed to guard.
 
 /** Minimal stand-in for what getLLMClient() actually returns: `.complete()`, and NO `.messages`. */
 function makeAdapter(overrides = {}) {

--- a/tests/unit/stories/llm-path-executes.test.js
+++ b/tests/unit/stories/llm-path-executes.test.js
@@ -148,6 +148,7 @@ describe('FR-2 follow-up: the loud channel must not carry credentials', () => {
     vi.resetModules();
     vi.doMock('../../../lib/sub-agents/modules/stories/llm-story-generator.js', async (orig) => ({
       ...(await orig()),
+      isLLMAvailable: () => true,
       createLLMStoryGenerator: () => ({
         isEnabled: () => true,
         generateStoriesFromCriteria: async () => {
@@ -187,6 +188,7 @@ describe('FR-2: taking the fallback is LOUD', () => {
     vi.resetModules();
     vi.doMock('../../../lib/sub-agents/modules/stories/llm-story-generator.js', async (orig) => ({
       ...(await orig()),
+      isLLMAvailable: () => true,
       createLLMStoryGenerator: () => ({
         isEnabled: () => true,
         generateStoriesFromCriteria: async () => { throw new Error('forced provider outage'); },
@@ -222,6 +224,7 @@ describe('FR-2: taking the fallback is LOUD', () => {
     vi.resetModules();
     vi.doMock('../../../lib/sub-agents/modules/stories/llm-story-generator.js', async (orig) => ({
       ...(await orig()),
+      isLLMAvailable: () => true,
       createLLMStoryGenerator: () => ({
         isEnabled: () => true,
         generateStoriesFromCriteria: async (criteria) => ({

--- a/tests/unit/sub-agents/stories-execute-fr-source.test.js
+++ b/tests/unit/sub-agents/stories-execute-fr-source.test.js
@@ -16,9 +16,34 @@ describe('QF-20260703-894: createStoriesFromPRD derives criteria from functional
   const code = fs.readFileSync(SRC, 'utf8');
 
   it('defines storySourceCriteria preferring functional_requirements, falling back to acceptance_criteria', () => {
+    /**
+     * *** THIS TEST WAS PINNING THE BUG IN PLACE. ***
+     * It asserted the source contained the LITERAL expression
+     * `fr.title || fr.description || String(fr)` — which is exactly the defect
+     * SD-LEO-INFRA-USER-STORY-QUALITY-001/FR-5 fixed. That chain omits `requirement` from the
+     * canonical FR contract, so such an FR fell through to String(fr) and became the literal
+     * "[object Object]": 66 stories carry it in the TITLE, and all 66 have
+     * validation_status='validated'.
+     *
+     * So anyone fixing the corruption met a RED TEST demanding they put it back. A source-pin test
+     * does not just break on legitimate change — it can actively defend a defect, and the more
+     * precisely it pins, the harder it defends.
+     *
+     * The INTENT was right and is preserved: criteria come from functional_requirements when
+     * present, else acceptance_criteria. Only the pinned spelling changed — plus a negative
+     * assertion below so the old expression can never come back silently.
+     */
     expect(code).toMatch(/const storySourceCriteria = \(prd\.functional_requirements && prd\.functional_requirements\.length > 0\)/);
-    expect(code).toMatch(/\?\s*prd\.functional_requirements\.map\(fr => fr\.title \|\| fr\.description \|\| String\(fr\)\)/);
+    expect(code).toMatch(/\?\s*prd\.functional_requirements\.map\(\(fr, i\) => criterionFromFR\(fr, i\)\)/);
     expect(code).toMatch(/:\s*\(prd\.acceptance_criteria \|\| \[\]\)/);
+
+    // REGRESSION GUARD: the unguarded chain must never return as the MAP BODY. It is the
+    // "[object Object]" source. Scoped to `.map(fr => ...)` rather than the bare expression,
+    // because execute.js's own docblock QUOTES the old chain to explain why it was removed — and a
+    // naive text match flagged that comment, i.e. the guard fired on the documentation of the fix.
+    // A source-pin assertion matches prose as readily as code; it has to name the shape it forbids.
+    expect(code, 'the pre-FR-5 map body emits "[object Object]" for requirement-only FRs')
+      .not.toMatch(/\.map\(fr => fr\.title \|\| fr\.description \|\| String\(fr\)\)/);
   });
 
   it('the batch generation call and the story-build loop both use storySourceCriteria, not the raw PRD field', () => {


### PR DESCRIPTION
`llm-story-generator.js:471` called `client.messages.create()` on a provider **adapter** whose surface is `.complete()` plus a `.chat.completions.create()` compat layer. It never had `.messages`, so this was a `TypeError` raised **before any network request**, on every attempt, retried twice against the same broken shape, then swallowed by a caller that returned `success: true` regardless.

**0 of 15,258 user stories were ever LLM-generated.** The file documents itself as *"LLM-powered generation with rule-based fallback"*. In production it was fallback-only.

Introduced by `6c88cf30e30` (2026-02-10), which migrated this file onto the factory and left the pre-migration call in place. **The same commit correctly migrated the sibling** `auto-trigger-stories.mjs` — the right pattern was known, applied, and skipped once.

## The asymmetry is the bug; the four call sites are its evidence

`addOpenAICompatLayer` has given every adapter `.chat.completions.create()` all along — 40+ call sites of that shape work regardless of which client they hold. There was **no mirroring `.messages` layer**, so the Anthropic-native convention silently exploded. One convention self-healed, the other detonated, and copy-paste reproduced the failure four times.

FR-4 adds the mirror so the fifth survives; the call-site rewrites make these right. Both, not either.

## What shipped

| FR | Change |
|---|---|
| **FR-1** | Call site rewritten to the adapter's real surface. **Verified live**: `generated_by = LLM`, 2 stories, 4 gaps, via a real Gemini adapter. |
| **FR-2** | Fallback is now **loud** — `degraded` + `degradation_reason` on every path, naming the cause. `success` stays true: degrading beats producing no stories; the requirement is that it be *visible*, not fatal. |
| **FR-3** | Three sibling sites: `proposal-agent.js` (bare string where an options object belongs, plus `client._model` which no adapter defines), `quality-checker.mjs` (same copy-pasted typo), `eva-chat-service.js` (destructured `createLLMClient` from a dynamic import of a module that doesn't export it — EVA chat has been **dead**, not degraded). |
| **FR-4** | `.messages.create` shim on every adapter, with content-block flattening and the same cross-provider model guard. |
| **FR-5** | `fr.title \|\| fr.description \|\| String(fr)` omitted `requirement`, so such an FR became the literal `[object Object]`. 66 stories carry it in the **title**; all 66 have `validation_status='validated'`. The guard is the fix, not the added field. |
| **FR-6** | Tests that execute the line, un-quarantining, and a real bug the quarantine was hiding. |

## Mutation-verified — and the first version failed that check

| mutant | result |
|---|---|
| remove the FR-4 shim call | **2 tests fail** |
| revert `criterionFromFR` | **3 tests fail** |
| strip `degraded` from the fallback | **1 test fails** |

That last one **survived at first**, and the reason is the whole point of this SD. My FR-2 test called `generateStoriesBatch` with ambient env — and because the LLM path now *works*, it took the success branch every time. The `RULE_BASED` body never ran, so deleting every degraded field didn't fail it. **A test guarding the fallback that never reaches the fallback is the same shape as the file this SD is fixing.** The generator is now forced to throw, with a non-vacuity assertion.

Two earlier mutation attempts were themselves invalid and would have produced a false *"the test is weak"*: one defeated by CRLF, one hit the wrong function via a non-global replace, one produced a syntax error. **A mutation that doesn't apply is indistinguishable from one the test survived**, so each was verified to have actually changed the file and still parse.

## Two decisions worth flagging

**The streaming site is deliberately left broken.** `eva-chat-service.js` has *two* dead call sites, not one — the sweep keyed on `.messages.create(` and missed `.messages.stream(`. Repairing it needs incremental token events and **the adapter layer has no streaming at all**. The shim deliberately provides `.create` and not `.stream`: a `.stream()` that resolved `.complete()` and emitted one `'text'` event would satisfy the call site while making the word "stream" false. That's the defect class this SD removes, not a fix for it. Left failing loudly rather than silently faked.

**A real bug the quarantine was hiding.** The constructor ignored `options.model` while `generateStoriesFromCriteria` stamped `model: this.model` onto every story — so every LLM story recorded `model: undefined`. Same family as `client._model`: a field consulted but never assigned. Un-quarantining was required, not cosmetic — `vitest.config.js` builds its exclude list from the manifest *by file path*, so repairing content alone ships tests that never run.

## Not in this PR

- **TS-5** static lint sweep for `.messages.create(`/`._model` on factory-held clients (needs the 3-part class-guard pattern; base eslint isn't run on `lib/` by any workflow).
- **TS-8** recurring canary that fails if the trailing-window LLM fraction returns to 0% — the only mechanism that would catch a *future* silent regression rather than today's instance.
- The 11 threshold-tuning recommendations remain **untouched**, per the SD and the coordinator's ruling. Seven of seven cells still fall below the line after the proposed cut.

26 tests pass across both files; all six touched modules import cleanly. The two remaining `no-unused-vars` errors in `proposal-agent.js` are pre-existing and byte-identical to `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)