### PR TITLE
fix(SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-B): close the fail-open reaper guards on the occupancy invariant

### DIFF
--- a/lib/cleanup/filesystem-provider.js
+++ b/lib/cleanup/filesystem-provider.js
@@ -10,13 +10,36 @@
  */
 
 import { existsSync, rmSync } from 'fs';
-import { resolve, normalize } from 'path';
+import { resolve, normalize, sep } from 'path';
 
-// Directories that are safe to search for venture workspaces
+/**
+ * SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-B (FR-4): `.worktrees` was REMOVED from this
+ * allowlist.
+ *
+ * Every other worktree deleter in this repo routes through a guarded chokepoint that asks
+ * whether the tree is live-claimed or occupied. This one did not: it accepted any path
+ * under `.worktrees` and called a RAW rmSync — no claim guard, no residency guard, no
+ * isReapable, and not even safeRecursiveRm, so it could follow a `node_modules` junction
+ * out of the worktree and into the shared store. The guards child cannot claim "a venue
+ * with a live occupant is not reapable, by any addressing scheme" while a path exists that
+ * consults none of them.
+ *
+ * HONEST SEVERITY, because the original framing overstated it: this was LATENT, not live.
+ * cleanupFilesystem does no auto-discovery (see targetPaths below), its only caller is
+ * lib/cleanup/index.js, and the venture-delete path that reaches it passes no
+ * `filesystemPaths` — so the rmSync was unreachable in production. It is closed because it
+ * is a loaded gun in a subsystem that has had this class of accident repeatedly, not
+ * because it was firing.
+ *
+ * Venture workspace cleanup under `tmp` is unaffected. Anything genuinely needing to remove
+ * a worktree should go through the reaper or worktree-manager, which consult the guards.
+ */
 const ALLOWED_ROOTS = [
-  resolve(process.cwd(), '.worktrees'),
   resolve(process.cwd(), 'tmp'),
 ];
+
+/** Refused explicitly (rather than merely falling off the allowlist) so the reason is legible. */
+const WORKTREE_ROOT = resolve(process.cwd(), '.worktrees');
 
 // Never delete these regardless of matching
 const PROTECTED_PATHS = new Set([
@@ -39,12 +62,32 @@ function validatePath(targetPath) {
     return { safe: false, reason: 'Protected path' };
   }
 
-  const isUnderAllowed = ALLOWED_ROOTS.some(root => normalized.startsWith(root));
+  // FR-4: named refusal. Worktree removal must go through a guarded path that can ask
+  // whether the tree is claimed or occupied; this provider cannot ask either question.
+  if (isUnder(normalized, WORKTREE_ROOT)) {
+    return { safe: false, reason: 'Worktree paths must be removed via the guarded reaper/worktree-manager, not the cleanup provider' };
+  }
+
+  const isUnderAllowed = ALLOWED_ROOTS.some((root) => isUnder(normalized, root));
   if (!isUnderAllowed) {
     return { safe: false, reason: `Path not under allowed roots: ${ALLOWED_ROOTS.join(', ')}` };
   }
 
   return { safe: true };
+}
+
+/**
+ * Containment WITH a separator boundary.
+ *
+ * The previous check was a bare `normalized.startsWith(root)`, so a sibling directory
+ * whose name merely began with an allowed root — `tmp-restore`, `tmpfoo` — validated as
+ * being inside `tmp` and became deletable. Same defect family as the rest of this SD: a
+ * guard whose predicate is looser than the thing it claims to enforce.
+ */
+function isUnder(candidate, root) {
+  if (candidate === root) return true;
+  const prefix = root.endsWith(sep) ? root : root + sep;
+  return candidate.startsWith(prefix);
 }
 
 /**

--- a/lib/cleanup/filesystem-provider.js
+++ b/lib/cleanup/filesystem-provider.js
@@ -9,7 +9,7 @@
  * Part of SD-LEO-INFRA-VENTURE-CLEANUP-ORCHESTRATOR-001-B
  */
 
-import { existsSync, rmSync } from 'fs';
+import { existsSync, rmSync, realpathSync } from 'fs';
 import { resolve, normalize, sep } from 'path';
 
 /**
@@ -18,11 +18,19 @@ import { resolve, normalize, sep } from 'path';
  *
  * Every other worktree deleter in this repo routes through a guarded chokepoint that asks
  * whether the tree is live-claimed or occupied. This one did not: it accepted any path
- * under `.worktrees` and called a RAW rmSync — no claim guard, no residency guard, no
- * isReapable, and not even safeRecursiveRm, so it could follow a `node_modules` junction
- * out of the worktree and into the shared store. The guards child cannot claim "a venue
- * with a live occupant is not reapable, by any addressing scheme" while a path exists that
- * consults none of them.
+ * under `.worktrees` and deleted it having asked neither question. The guards child cannot
+ * claim "a venue with a live occupant is not reapable, by any addressing scheme" while a
+ * path exists that consults none of them.
+ *
+ * CORRECTION TO THIS FILE'S EARLIER RATIONALE (SEC-08). An earlier version of this comment
+ * — and the FR-5 guard, and worktree-manager.js:1179-1191 — justified the control by
+ * claiming a recursive rmSync follows a nested `node_modules` junction out of the tree.
+ * SECURITY could NOT reproduce that on Node v24.12.0: the nested junction was unlinked and
+ * the link target survived intact. The false premise mattered, because it pointed at a
+ * safe route and concealed the one that is real — a junction in an INTERMEDIATE path
+ * segment, which escapes lexical containment entirely (see validatePath). The control is
+ * still correct; its justification is that this provider cannot ask the claim or residency
+ * question, not a junction-following behaviour that does not occur.
  *
  * HONEST SEVERITY, because the original framing overstated it: this was LATENT, not live.
  * cleanupFilesystem does no auto-discovery (see targetPaths below), its only caller is
@@ -34,12 +42,14 @@ import { resolve, normalize, sep } from 'path';
  * Venture workspace cleanup under `tmp` is unaffected. Anything genuinely needing to remove
  * a worktree should go through the reaper or worktree-manager, which consult the guards.
  */
+const realOrSelf = (p) => { try { return realpathSync.native(p); } catch { return p; } };
+
 const ALLOWED_ROOTS = [
-  resolve(process.cwd(), 'tmp'),
+  realOrSelf(resolve(process.cwd(), 'tmp')),
 ];
 
 /** Refused explicitly (rather than merely falling off the allowlist) so the reason is legible. */
-const WORKTREE_ROOT = resolve(process.cwd(), '.worktrees');
+const WORKTREE_ROOT = realOrSelf(resolve(process.cwd(), '.worktrees'));
 
 // Never delete these regardless of matching
 const PROTECTED_PATHS = new Set([
@@ -56,7 +66,22 @@ const PROTECTED_PATHS = new Set([
  * @returns {{safe: boolean, reason?: string}}
  */
 function validatePath(targetPath) {
-  const normalized = normalize(resolve(targetPath));
+  // SEC-01: resolve()/normalize() collapse `..` but do NOT resolve links, so the checks
+  // below were purely LEXICAL. A junction in an INTERMEDIATE path segment escaped both the
+  // worktree refusal and the tmp allowlist — SECURITY reproduced this destroying a real
+  // file under .worktrees via `tmp/portal/VICTIM` where tmp/portal was a junction.
+  // realpath is what makes containment a statement about the filesystem rather than about
+  // the string. Note safeRecursiveRm does NOT fix this route: it lstats only the final
+  // component, so it walks the intermediate junction too.
+  //
+  // A path that does not exist yet cannot be realpath'd; fall back to the lexical form,
+  // which is safe because a non-existent path is also nothing to delete.
+  let normalized;
+  try {
+    normalized = normalize(realpathSync.native(resolve(targetPath)));
+  } catch {
+    normalized = normalize(resolve(targetPath));
+  }
 
   if (PROTECTED_PATHS.has(normalized)) {
     return { safe: false, reason: 'Protected path' };
@@ -73,7 +98,11 @@ function validatePath(targetPath) {
     return { safe: false, reason: `Path not under allowed roots: ${ALLOWED_ROOTS.join(', ')}` };
   }
 
-  return { safe: true };
+  // The RESOLVED path is returned so the caller deletes the thing that was validated.
+  // Validating a realpath and then deleting the lexical path would traverse the very
+  // junction the realpath was computed to see through — the check would be real and the
+  // deletion would still escape.
+  return { safe: true, resolvedPath: normalized };
 }
 
 /**
@@ -118,7 +147,10 @@ export async function cleanupFilesystem(ventureId, options = {}) {
       continue;
     }
 
-    if (!existsSync(absolutePath)) {
+    // Delete what was VALIDATED, not what was requested (SEC-01).
+    const deletePath = validation.resolvedPath || absolutePath;
+
+    if (!existsSync(deletePath)) {
       continue; // Already gone, not an error
     }
 
@@ -128,7 +160,7 @@ export async function cleanupFilesystem(ventureId, options = {}) {
     }
 
     try {
-      rmSync(absolutePath, { recursive: true, force: true });
+      rmSync(deletePath, { recursive: true, force: true });
       result.cleaned.push(absolutePath);
     } catch (err) {
       result.errors.push({ path: absolutePath, error: err.message });

--- a/lib/worktree-reapability.js
+++ b/lib/worktree-reapability.js
@@ -28,6 +28,10 @@ export const REAP_REASONS = Object.freeze({
   DIRTY_TREE: 'dirty_tree',
   UNPUSHED: 'unpushed',
   ORPHAN_CLEAN: 'orphan_clean',
+  // SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-B FR-7: the probes could not answer.
+  // Distinct from ORPHAN_CLEAN on purpose — "I looked and found nothing" and "I could
+  // not look" had the same return value here, which is the whole defect.
+  UNVERIFIABLE: 'unverifiable',
 });
 
 /** Resolve + forward-slash + lowercase, for cross-platform path-key comparison. */
@@ -67,7 +71,13 @@ export function collectDirtyStatus(wtPath, { gitRunner = runGit } = {}) {
   }
   try {
     const res = gitRunner(['status', '--porcelain', '--untracked-files=all'], wtPath);
-    if (res.code !== 0) return { dirtyCount: 0, untracked: [], modified: [], exists: true };
+    // FR-7: a non-zero exit means the question was NOT ANSWERED. Reporting dirtyCount:0
+    // here told isReapable "clean" and it returned reapable:true — a locked index, a
+    // corrupt or pruned gitdir, or a Windows permission error was enough to license
+    // deletion of a tree that might be full of uncommitted work. `unknown` is additive:
+    // dirtyCount/untracked/modified/exists keep their existing values and meaning, so
+    // consumers that do not read it are byte-identical to before.
+    if (res.code !== 0) return { dirtyCount: 0, untracked: [], modified: [], exists: true, unknown: true };
     const lines = (res.stdout || '').split('\n').filter(Boolean);
     const untracked = [];
     const modified = [];
@@ -83,18 +93,39 @@ export function collectDirtyStatus(wtPath, { gitRunner = runGit } = {}) {
       if (p.startsWith('"') && p.endsWith('"')) p = p.slice(1, -1); // git quotes special chars
       if (p) modified.push(p);
     }
-    return { dirtyCount: dirty, untracked, modified, exists: true };
-  } catch { return { dirtyCount: 0, untracked: [], modified: [], exists: true }; }
+    return { dirtyCount: dirty, untracked, modified, exists: true, unknown: false };
+  } catch { return { dirtyCount: 0, untracked: [], modified: [], exists: true, unknown: true }; }
 }
 
 /** Count commits on HEAD not yet pushed to the upstream (default origin/main). */
-export function countUnpushedCommits(wtPath, { gitRunner = runGit, upstream = 'origin/main' } = {}) {
-  if (!wtPath || !fs.existsSync(wtPath)) return 0;
+export function countUnpushedCommits(wtPath, opts = {}) {
+  return countUnpushedCommitsResult(wtPath, opts).count;
+}
+
+/**
+ * FR-7 sibling of countUnpushedCommits that can say "I could not answer".
+ *
+ * The plain counter returns 0 on a git failure, which isReapable read as "nothing
+ * unpushed" — the same conflation of not-found with could-not-look that
+ * collectDirtyStatus had. countUnpushedCommits stays a number-returning wrapper so
+ * every existing caller and test is unaffected; only isReapable consults `unknown`.
+ *
+ * NAMING, RECORDED SO IT IS NOT MISTAKEN FOR A MEASUREMENT BUG: `git cherry origin/main
+ * HEAD` counts commits NOT PATCH-PRESENT IN origin/main, which is NOT the same as
+ * unpushed — a branch pushed to its own remote with an open PR reports non-zero. The
+ * error direction is OVER-reporting, and non-zero means NOT reapable, so it
+ * OVER-PROTECTS. Making it "accurate" would REMOVE protection from every branch with an
+ * open PR. The rename belongs to sibling -C; the semantics deliberately do not change.
+ *
+ * @returns {{count: number, unknown: boolean}}
+ */
+export function countUnpushedCommitsResult(wtPath, { gitRunner = runGit, upstream = 'origin/main' } = {}) {
+  if (!wtPath || !fs.existsSync(wtPath)) return { count: 0, unknown: false };
   try {
     const res = gitRunner(['cherry', upstream, 'HEAD'], wtPath);
-    if (res.code !== 0) return 0;
-    return (res.stdout || '').split('\n').filter((l) => l.startsWith('+')).length;
-  } catch { return 0; }
+    if (res.code !== 0) return { count: 0, unknown: true };
+    return { count: (res.stdout || '').split('\n').filter((l) => l.startsWith('+')).length, unknown: false };
+  } catch { return { count: 0, unknown: true }; }
 }
 
 /**
@@ -115,12 +146,17 @@ export function countUnpushedCommits(wtPath, { gitRunner = runGit, upstream = 'o
 export function isReapable(worktreePath, opts = {}) {
   const { liveOwner = false, gitRunner = runGit, upstream = 'origin/main' } = opts;
   if (liveOwner) return { reapable: false, reason: REAP_REASONS.LIVE_OWNER };
-  if (collectDirtyStatus(worktreePath, { gitRunner }).dirtyCount > 0) {
-    return { reapable: false, reason: REAP_REASONS.DIRTY_TREE };
-  }
-  if (countUnpushedCommits(worktreePath, { gitRunner, upstream }) > 0) {
-    return { reapable: false, reason: REAP_REASONS.UNPUSHED };
-  }
+
+  const dirty = collectDirtyStatus(worktreePath, { gitRunner });
+  if (dirty.dirtyCount > 0) return { reapable: false, reason: REAP_REASONS.DIRTY_TREE };
+  // FR-7: could-not-look is not proof-of-clean. Ordered AFTER the positive dirty check so
+  // a tree that answered "dirty" keeps its more specific reason.
+  if (dirty.unknown) return { reapable: false, reason: REAP_REASONS.UNVERIFIABLE };
+
+  const ahead = countUnpushedCommitsResult(worktreePath, { gitRunner, upstream });
+  if (ahead.count > 0) return { reapable: false, reason: REAP_REASONS.UNPUSHED };
+  if (ahead.unknown) return { reapable: false, reason: REAP_REASONS.UNVERIFIABLE };
+
   return { reapable: true, reason: REAP_REASONS.ORPHAN_CLEAN };
 }
 

--- a/lib/worktree-reapability.js
+++ b/lib/worktree-reapability.js
@@ -65,6 +65,33 @@ export function runGit(args, cwd = process.cwd()) {
  * working-tree file to preserve. PURE: status comes from the injected gitRunner only.
  * Existing fields (dirtyCount/untracked/exists) are unchanged for back-compat.
  */
+/**
+ * Does `wtPath` own the git state that `git` commands run there would report?
+ *
+ * Three outcomes, and conflating any two of them causes a real defect:
+ *   - git cannot answer at all (no repo anywhere above)  => ownsGitState:false, definitive
+ *   - git answers about an ANCESTOR (the walk-up)        => ownsGitState:false, definitive
+ *   - git answers about THIS tree                        => ownsGitState:true
+ *
+ * Only the third case makes a subsequent `status`/`cherry` failure genuinely UNKNOWN.
+ * Separator- and case-tolerant because Windows `--show-toplevel` returns forward slashes
+ * while path.resolve returns backslashes — a naive === reports every real worktree as
+ * not-its-own, which silently disables the guard.
+ */
+function resolveWorktreeRoot(wtPath, gitRunner) {
+  try {
+    const res = gitRunner(['rev-parse', '--show-toplevel'], wtPath);
+    if (!res || res.code !== 0) return { ownsGitState: false, toplevel: null };
+    const toplevel = String(res.stdout || '').trim();
+    if (!toplevel) return { ownsGitState: false, toplevel: null };
+    return { ownsGitState: normalizePath(toplevel) === normalizePath(wtPath), toplevel };
+  } catch {
+    // A THROWN runner is an unknown, not a definitive "no git here" — say so by
+    // claiming ownership, which routes the caller into its unknown handling.
+    return { ownsGitState: true, toplevel: null, probeThrew: true };
+  }
+}
+
 export function collectDirtyStatus(wtPath, { gitRunner = runGit } = {}) {
   if (!wtPath || !fs.existsSync(wtPath)) {
     return { dirtyCount: 0, untracked: [], modified: [], exists: false };
@@ -149,13 +176,31 @@ export function isReapable(worktreePath, opts = {}) {
 
   const dirty = collectDirtyStatus(worktreePath, { gitRunner });
   if (dirty.dirtyCount > 0) return { reapable: false, reason: REAP_REASONS.DIRTY_TREE };
-  // FR-7: could-not-look is not proof-of-clean. Ordered AFTER the positive dirty check so
-  // a tree that answered "dirty" keeps its more specific reason.
-  if (dirty.unknown) return { reapable: false, reason: REAP_REASONS.UNVERIFIABLE };
 
   const ahead = countUnpushedCommitsResult(worktreePath, { gitRunner, upstream });
   if (ahead.count > 0) return { reapable: false, reason: REAP_REASONS.UNPUSHED };
-  if (ahead.unknown) return { reapable: false, reason: REAP_REASONS.UNVERIFIABLE };
+
+  // FR-7: could-not-look is not proof-of-clean — ordered AFTER both positive checks so a
+  // tree that actually answered keeps its more specific reason.
+  //
+  // BUT (TESTING F1/F3) "git could not answer" splits in two, and collapsing them created a
+  // NEW stranding: a PRUNED or .git-less directory makes every git command fail, which the
+  // first cut of this read as unverifiable and refused FOREVER — precisely the orphan shape
+  // this SD family exists to unstick, re-created one layer down. It also broke
+  // cleanup-pending-sweep, whose fixtures are bare mkdtemp dirs.
+  //
+  // So: only ask WHOSE git state this is once a probe has already failed. A directory that
+  // owns none is definitively clean (it holds no commits and no uncommitted work of its
+  // own); a directory that owns its git state and still failed is genuinely unknown. The
+  // probe is deliberately NOT hoisted into collectDirtyStatus/countUnpushedCommitsResult —
+  // that would add a git call to every call site and break existing injected-runner
+  // fixtures that never anticipated a rev-parse.
+  if (dirty.unknown || ahead.unknown) {
+    if (!resolveWorktreeRoot(worktreePath, gitRunner).ownsGitState) {
+      return { reapable: true, reason: REAP_REASONS.ORPHAN_CLEAN };
+    }
+    return { reapable: false, reason: REAP_REASONS.UNVERIFIABLE };
+  }
 
   return { reapable: true, reason: REAP_REASONS.ORPHAN_CLEAN };
 }

--- a/lib/worktree-reaper/live-claim-guard.js
+++ b/lib/worktree-reaper/live-claim-guard.js
@@ -65,7 +65,27 @@ export async function liveClaimBlocksRemoval(supabase, wtPath, opts = {}) {
   const { isSessionAliveFn = isSessionAlive, logger = null } = opts;
 
   const parsed = keyFromWorktreePath(wtPath);
-  if (!parsed) return { blocked: false, reason: 'no_work_key_in_path' };
+  if (!parsed) {
+    // SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001 (FR-1). This branch used to return
+    // {blocked:false, reason:'no_work_key_in_path'} — the SOLE fail-open in a module whose
+    // every other branch fails closed. An unparseable basename does not mean "no claim
+    // exists"; it means THIS GUARD COULD NOT VERIFY, and absence of evidence was being
+    // read as evidence of absence. On 2026-07-31 that read deleted two in-use ceremony
+    // trees (.worktrees/scribe-privesc-20260731 and .worktrees/changelog-privesc) whose
+    // basenames match neither ^SD- nor ^QF-.
+    //
+    // KNOWN TRADEOFF, accepted deliberately: an ad-hoc worktree whose name carries no
+    // work key is now never removed by this path, so such trees accumulate against the
+    // pool cap. That is the correct side to err on — over-refusal is visible and
+    // recoverable (quota pressure, loudly logged), under-refusal destroys work that is
+    // still being written. Do NOT "fix" pool pressure by restoring the fail-open; the
+    // operator remedy is a .reap-eligible marker (validated per FR-3) or explicit removal.
+    //
+    // NOT to be confused with the 'no_live_claim' exit below, which also returns
+    // blocked:false but only AFTER a successful lookup positively found no claimant.
+    // That one is a VERIFIED clear, and it stays.
+    return { blocked: true, reason: 'work_key_unresolvable', detail: { worktree_path: wtPath } };
+  }
   if (!supabase) {
     // No DB access = cannot verify = refuse (fail-closed).
     return { blocked: true, reason: 'unverifiable_no_supabase', detail: parsed };

--- a/lib/worktree-reaper/reap-eligible-marker.js
+++ b/lib/worktree-reaper/reap-eligible-marker.js
@@ -139,7 +139,13 @@ export function isReapEligibleMarkerValid(wtPath, options = {}) {
   const markedAt = Date.parse(marker.marked_at || '');
   if (!Number.isFinite(markedAt)) return { valid: false, reason: 'marker_no_timestamp' };
 
-  const ageMs = nowMs - markedAt;
+  // SEC-06 / RC-2: clamp a FUTURE marked_at to now, mirroring the identical clamp in
+  // residency-guard. COND-4 named both files and only one was closed; a marker stamped
+  // ahead of the clock (skew, restored archive, crafted value) otherwise produces a
+  // negative age and NEVER expires — an authorisation with no end date. Bounded in blast
+  // radius because the sd_key must still match, so it cannot license deleting another
+  // tree; but "never expires" is exactly the property this FR exists to remove.
+  const ageMs = Math.max(0, nowMs - markedAt);
   if (ageMs > ttlMin * 60 * 1000) {
     return { valid: false, reason: 'marker_expired_age', detail: { age_ms: ageMs, ttl_min: ttlMin } };
   }

--- a/lib/worktree-reaper/reap-eligible-marker.js
+++ b/lib/worktree-reaper/reap-eligible-marker.js
@@ -58,4 +58,112 @@ export function hasReapEligibleMarker(wtPath) {
   return fs.existsSync(path.join(wtPath, MARKER_FILENAME));
 }
 
-export default { MARKER_FILENAME, writeReapEligibleMarker, readReapEligibleMarker, hasReapEligibleMarker };
+/**
+ * MARKER REVALIDATION (SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-B, FR-3).
+ *
+ * THE INCIDENT. At 2026-07-31T21:34:48Z the reaper removed the RLS posture ceremony tree
+ * on the authority of a marker written 5.5 HOURS EARLIER by a DIFFERENT session, recording
+ * a DIFFERENT SD (SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001) than the branch it ended up
+ * deleting (scribe/rls-receipts-20260731). An affirmative "this tree is disposable"
+ * decision, correct when made about one piece of work, silently licensed the deletion of
+ * unrelated work that appeared in that tree hours later.
+ *
+ * WHY IT WAS POSSIBLE. hasReapEligibleMarker is existsSync ONLY. classifyWorktree pushed
+ * the reap-eligible category on PRESENCE alone and called readReapEligibleMarker purely to
+ * populate an evidence field that NO PREDICATE CONSULTS. So sd_key and marked_at were
+ * parsed, recorded, and ignored: the two fields needed to expire the marker were already
+ * in hand and nothing read them. Same shape as the live-claim fail-open — an input the
+ * guard does not validate is treated as permission.
+ *
+ * hasReapEligibleMarker deliberately KEEPS its pure-presence contract; validation lives in
+ * a separate predicate rather than being folded in. Existing callers and tests that ask
+ * "is there a marker?" are unaffected.
+ *
+ * THE MISMATCH RULE IS NARROWER THAN IT FIRST LOOKS, and getting it wrong causes the exact
+ * false-expiry it exists to prevent. Three of the four marker producers do NOT write a
+ * canonical SD key: worktree-merge.js writes a relative PATH, post-merge-worktree-cleanup
+ * falls back to a basename, and the field defaults to null. A path-shaped value reduces to
+ * a real key and MATCHES — refusing it would reject legitimate markers. So: declare a
+ * mismatch ONLY when BOTH sides resolve to a canonical ^(SD|QF)- key AND they differ.
+ * Everything else is CANNOT-VALIDATE, which does not authorise (consistent with FR-1: the
+ * inability to verify is not permission), but is reported distinctly from a real mismatch
+ * so the two are never conflated in a log.
+ */
+export const DEFAULT_MARKER_TTL_MIN = 120;
+
+/**
+ * Reduce a recorded value to a canonical work key, or null when it is not one.
+ * Tolerates the PATH shape that worktree-merge.js actually writes.
+ */
+export function canonicalWorkKey(value) {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim().replace(/[\\/]+$/, '');
+  if (!trimmed) return null;
+  const base = trimmed.split(/[\\/]/).pop();
+  const m = /^(sd|qf)-(.+)$/i.exec(base || '');
+  return m ? `${m[1].toUpperCase()}-${m[2]}` : null;
+}
+
+function resolveTtlMin(explicit) {
+  if (Number.isFinite(explicit) && explicit > 0) return explicit;
+  const env = Number(process.env.REAP_ELIGIBLE_TTL_MIN);
+  return Number.isFinite(env) && env > 0 ? env : DEFAULT_MARKER_TTL_MIN;
+}
+
+/**
+ * Does the marker still carry authority to license removal of THIS tree, NOW?
+ *
+ * nowMs and ttlMin default INTERNALLY on purpose: the reaper's classification context does
+ * not supply them, and a destructure-and-assume signature would make every existing caller
+ * silently pass undefined.
+ *
+ * @param {string} wtPath
+ * @param {{ nowMs?: number, treeKey?: string|null, ttlMin?: number }} [options]
+ *   treeKey — the work key the CALLER resolved for this tree (it owns keyFromWorktree;
+ *   resolving it here would drag a script-level dependency into lib).
+ * @returns {{ valid: boolean, reason: string|null, detail?: object }}
+ */
+export function isReapEligibleMarkerValid(wtPath, options = {}) {
+  const { nowMs = Date.now(), treeKey = null } = options;
+  const ttlMin = resolveTtlMin(options.ttlMin);
+
+  if (!hasReapEligibleMarker(wtPath)) return { valid: false, reason: 'marker_absent' };
+
+  const marker = readReapEligibleMarker(wtPath);
+  if (!marker) return { valid: false, reason: 'marker_unreadable' }; // corrupt/unparseable
+
+  const markedAt = Date.parse(marker.marked_at || '');
+  if (!Number.isFinite(markedAt)) return { valid: false, reason: 'marker_no_timestamp' };
+
+  const ageMs = nowMs - markedAt;
+  if (ageMs > ttlMin * 60 * 1000) {
+    return { valid: false, reason: 'marker_expired_age', detail: { age_ms: ageMs, ttl_min: ttlMin } };
+  }
+
+  const markerKey = canonicalWorkKey(marker.sd_key);
+  const treeCanon = canonicalWorkKey(treeKey);
+  if (markerKey && treeCanon) {
+    if (markerKey !== treeCanon) {
+      return { valid: false, reason: 'marker_sd_key_mismatch', detail: { marker_key: markerKey, tree_key: treeCanon } };
+    }
+    return { valid: true, reason: null, detail: { age_ms: ageMs, matched_key: markerKey } };
+  }
+
+  // One or both sides do not resolve to a work key — we cannot confirm the marker is
+  // ABOUT this tree, so it does not authorise. Distinct from a positive mismatch.
+  return {
+    valid: false,
+    reason: 'marker_key_unverifiable',
+    detail: { marker_sd_key: marker.sd_key ?? null, tree_key: treeKey ?? null },
+  };
+}
+
+export default {
+  MARKER_FILENAME,
+  DEFAULT_MARKER_TTL_MIN,
+  writeReapEligibleMarker,
+  readReapEligibleMarker,
+  hasReapEligibleMarker,
+  isReapEligibleMarkerValid,
+  canonicalWorkKey,
+};

--- a/lib/worktree-reaper/reap-eligible-marker.js
+++ b/lib/worktree-reaper/reap-eligible-marker.js
@@ -101,7 +101,11 @@ export function canonicalWorkKey(value) {
   if (!trimmed) return null;
   const base = trimmed.split(/[\\/]/).pop();
   const m = /^(sd|qf)-(.+)$/i.exec(base || '');
-  return m ? `${m[1].toUpperCase()}-${m[2]}` : null;
+  // SEC-07: uppercase the WHOLE key, not just the prefix. Casing only the prefix made
+  // `sd-victim-001` and `SD-VICTIM-001` compare UNEQUAL, producing marker_sd_key_mismatch
+  // — the loudest reason, reserved for the actual incident shape — for what is the same
+  // key. live-claim-guard.js normalizes case, so the two modules disagreed.
+  return m ? `${m[1]}-${m[2]}`.toUpperCase() : null;
 }
 
 function resolveTtlMin(explicit) {

--- a/lib/worktree-reaper/removal-decision.js
+++ b/lib/worktree-reaper/removal-decision.js
@@ -1,0 +1,95 @@
+/**
+ * The removal decision (SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-B, FR-1b).
+ *
+ * WHY THIS EXISTS AS A FUNCTION AT ALL. The reaper's removal gate lived inline inside
+ * main()'s loop, so the composition of the guards — the thing that actually decides
+ * whether a directory is deleted — could not be tested without a real filesystem and a
+ * real Supabase. classifyWorktree and stageForCategories are exported and well covered;
+ * the gate that acts on them was not.
+ *
+ * WHAT IT CHANGES. Previously every guard was an absolute veto, AND-composed, claim guard
+ * first: `if (claimGuard.blocked) { ...; continue; }`. That `continue` returns to the top
+ * of the loop, so residency was never consulted once the claim guard had spoken.
+ *
+ * That was fine while the claim guard only blocked on real claims. FR-1 made it also block
+ * on `work_key_unresolvable` — an honest admission that it CANNOT VERIFY a tree whose
+ * basename resolves to no work key. Left as a veto, that admission would mean such a tree
+ * is never reaped again, converting silent data-loss into permanent pool backlog. The
+ * coordinator predicted exactly this before FR-1 landed, and it landed anyway.
+ *
+ * THE FIX IS A DEMAND, NOT A DOWNGRADE. `work_key_unresolvable` no longer short-circuits;
+ * it requires residency to AFFIRMATIVELY clear before removal proceeds. So:
+ *
+ *     unresolvable + resident            => blocked   (the ceremony trees survive)
+ *     unresolvable + untouched past N    => removed   (dead ad-hoc trees still drain)
+ *
+ * This is the invariant itself rather than a proxy for it: a venue with a live occupant is
+ * not reapable, BY ANY ADDRESSING SCHEME. For a tree with no derivable key, occupancy is
+ * not one predicate among several — it is the only one available, because keyFromWorktree
+ * reads the branch but only for feat|qf|fix|chore|hotfix, so a ceremony branch resolves
+ * under neither branch nor basename.
+ *
+ * THE GUARD ITSELF STAYS HONEST. liveClaimBlocksRemoval keeps returning blocked:true with
+ * an accurate reason — it genuinely cannot answer the occupancy question. The policy lives
+ * here, at the composition layer. A guard that lies about its own confidence to produce a
+ * convenient answer is the failure mode this whole SD exists to close.
+ *
+ * EVERY OTHER BLOCKED REASON REMAINS AN ABSOLUTE VETO. live_claimed, the three
+ * unverifiable_* lookup errors, unverifiable_no_supabase, live_session_pointing — those are
+ * either positive evidence of a claim or a failure to reach the DB, and residency clearing
+ * says nothing about either. Only the unresolvable-KEY case is a statement about addressing.
+ */
+
+/** The one claim-guard reason that is a demand rather than a veto. */
+export const WORK_KEY_UNRESOLVABLE = 'work_key_unresolvable';
+
+/** Removal was permitted despite an unresolvable key, because residency cleared. */
+export const UNRESOLVABLE_KEY_RESIDENCY_CLEARED = 'unresolvable_key_residency_cleared';
+
+/** A guard result that is absent or malformed cannot be trusted to mean "clear". */
+function isMalformed(guard) {
+  return !guard || typeof guard.blocked !== 'boolean';
+}
+
+/**
+ * Decide whether a candidate worktree may be removed.
+ *
+ * Pure and synchronous by design: callers do the I/O, this decides. Any guard may be
+ * omitted ONLY by passing an explicit non-blocking result; a missing or malformed guard
+ * fails CLOSED, so a caller that forgets to wire one up refuses rather than deletes.
+ *
+ * @param {object} input
+ * @param {{blocked: boolean, reason?: string}} input.claimGuard
+ * @param {{blocked: boolean, reason?: string}} input.treeResidency
+ * @param {{blocked: boolean, reason?: string}} input.heartbeatResidency
+ * @returns {{remove: boolean, reason: string|null, source: string|null}}
+ */
+export function decideRemoval({ claimGuard, treeResidency, heartbeatResidency } = {}) {
+  for (const [name, guard] of [
+    ['claim', claimGuard],
+    ['tree_residency', treeResidency],
+    ['heartbeat_residency', heartbeatResidency],
+  ]) {
+    if (isMalformed(guard)) {
+      return { remove: false, reason: `guard_result_missing:${name}`, source: name };
+    }
+  }
+
+  const residencyBlock = treeResidency.blocked
+    ? { remove: false, reason: treeResidency.reason ?? null, source: 'tree_residency' }
+    : heartbeatResidency.blocked
+      ? { remove: false, reason: heartbeatResidency.reason ?? null, source: 'heartbeat_residency' }
+      : null;
+
+  if (claimGuard.blocked) {
+    if (claimGuard.reason !== WORK_KEY_UNRESOLVABLE) {
+      return { remove: false, reason: claimGuard.reason ?? null, source: 'claim' };
+    }
+    // Demand: the claim guard abstains, residency must affirmatively clear.
+    return residencyBlock ?? { remove: true, reason: UNRESOLVABLE_KEY_RESIDENCY_CLEARED, source: null };
+  }
+
+  return residencyBlock ?? { remove: true, reason: null, source: null };
+}
+
+export default { decideRemoval, WORK_KEY_UNRESOLVABLE, UNRESOLVABLE_KEY_RESIDENCY_CLEARED };

--- a/lib/worktree-reaper/residency-guard.js
+++ b/lib/worktree-reaper/residency-guard.js
@@ -20,6 +20,8 @@
  * delete path, so a false-positive storm must be operationally recoverable.
  */
 import path from 'path';
+import fs from 'fs';
+import { execFileSync } from 'child_process';
 import { createRequire } from 'module';
 // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 8 (GUARD): this scans EVERY session with a
 // worktree_path to block reaping a resident worktree. claude_sessions grows, so a silent 1000-row cap
@@ -127,4 +129,137 @@ export async function heartbeatResidencyBlocksRemoval(supabase, wtPath, options 
   }
 }
 
-export default { cwdResidencyBlocks, heartbeatResidencyBlocksRemoval, REAP_BLOCKED_RESIDENT, REAP_RESIDENCY_UNKNOWN };
+/**
+ * TREE residency (SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-B, FR-2).
+ *
+ * WHY A THIRD RESIDENCY PREDICATE. The two above answer "is a session standing here?" by
+ * ADDRESS — cwd, or claude_sessions.worktree_path. That column holds ONE path per session,
+ * so a worker occupying a SECONDARY ad-hoc worktree while its session row still points at
+ * its primary venue is STRUCTURALLY INVISIBLE to both. On 2026-07-31 two ceremony trees were
+ * reaped through exactly that hole. And for a tree whose basename resolves to no work key,
+ * NO addressing scheme can answer at all: keyFromWorktree (worktree-reaper.mjs:379-383) reads
+ * the branch but only for feat|qf|fix|chore|hotfix, so `scribe/rls-receipts-20260731` resolves
+ * under neither branch nor basename. Occupancy is therefore not one predicate among several —
+ * it is the ONLY one available to that class, which is why this asks the filesystem directly
+ * and needs no DB row to agree with reality.
+ *
+ * This is fix option (3) from the QF-20260725-821 incident report, whose own note in
+ * reap-protected-marker.js called residency "the general operator fix" and deferred it.
+ *
+ * SEPARATE FUNCTION, NOT FOLDED INTO heartbeatResidencyBlocksRemoval, for two reasons: folding
+ * would break three existing assertions that build mkdtemp fixtures whose mtime is NOW, and it
+ * would merge two refusal reasons that must stay separately greppable.
+ *
+ * TWO MEASURED TRAPS, both of which produce a WRONG answer rather than a noisy one:
+ *
+ *  (1) WALK-UP. `git log -1 --format=%ct` run with cwd set to a .git-LESS directory returns the
+ *      PARENT repo's HEAD time — git repo discovery walks up and .gitignore does not stop it.
+ *      Unguarded, every orphan reads as "resident because the parent just committed" and is
+ *      blocked FOREVER, which would cement precisely the stranding class this SD family exists
+ *      to unstick. So the HEAD probe runs ONLY after --show-toplevel confirms wtPath IS the
+ *      worktree root. mtime needs no such guard: fs.statSync cannot walk up.
+ *
+ *  (2) PATH SHAPE. On Windows `--show-toplevel` returns FORWARD slashes while path.resolve
+ *      returns BACKslashes, so a naive `toplevel === wtPath` is FALSE for a GENUINE worktree.
+ *      That failure is the mirror image of the first: the guard would silently degenerate to
+ *      ALWAYS-CLEAR and pass any suite that only tested the orphan case. Hence sameDir(), built
+ *      on the norm() this module already uses for exactly this reason.
+ *
+ * Polarity note: unlike its siblings this predicate does NOT fail closed on a git error. A git
+ * failure here means "no HEAD signal", not "unknown residency" — mtime still answers, and
+ * treating a pruned or corrupt gitdir as permanently resident would re-create trap (1) by
+ * another route. A THROW (not a non-zero exit) is still fail-closed.
+ */
+export const REAP_BLOCKED_TREE_RESIDENT = 'REAP_BLOCKED_TREE_RESIDENT';
+export const DEFAULT_RESIDENCY_WINDOW_MIN = 30;
+
+/** Same directory, tolerant of separator direction and Windows case. */
+function sameDir(a, b) {
+  return pathInside(a, b) && pathInside(b, a);
+}
+
+function defaultGitRunner(args, cwd) {
+  try {
+    const out = execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    return { code: 0, stdout: out };
+  } catch (e) {
+    return { code: typeof e?.status === 'number' ? e.status : 1, stdout: '' };
+  }
+}
+
+function resolveWindowMin(explicit) {
+  if (Number.isFinite(explicit) && explicit > 0) return explicit;
+  const env = Number(process.env.WORKTREE_RESIDENCY_WINDOW_MIN);
+  return Number.isFinite(env) && env > 0 ? env : DEFAULT_RESIDENCY_WINDOW_MIN;
+}
+
+/**
+ * Has this tree been touched recently enough to count as occupied?
+ *
+ * @param {string} wtPath
+ * @param {{ nowMs?: number, windowMin?: number, statFn?: function, gitRunner?: function, logger?: function }} [options]
+ * @returns {{ blocked: boolean, reason: string|null, detail?: object }}
+ */
+export function treeResidencyBlocksRemoval(wtPath, options = {}) {
+  const {
+    nowMs = Date.now(),
+    windowMin,
+    statFn = fs.statSync,
+    gitRunner = defaultGitRunner,
+    logger = console.warn,
+  } = options;
+
+  if (killSwitchOff()) {
+    logger(`[residency-guard] WORKTREE_RESIDENCY_GUARD=off — BYPASSING tree residency check for ${wtPath}`);
+    return { blocked: false, reason: null, bypassed: true };
+  }
+
+  const windowMs = resolveWindowMin(windowMin) * 60 * 1000;
+
+  try {
+    // mtime: immune to walk-up by construction.
+    let mtimeMs = 0;
+    try { mtimeMs = Number(statFn(wtPath)?.mtimeMs) || 0; } catch { mtimeMs = 0; }
+
+    // HEAD: only meaningful when wtPath IS the worktree root (trap 1), and only
+    // detectable as such with separator/case-tolerant comparison (trap 2).
+    let headMs = 0;
+    let isWorktreeRoot = false;
+    const top = gitRunner(['rev-parse', '--show-toplevel'], wtPath);
+    if (top?.code === 0) {
+      const toplevel = String(top.stdout || '').trim();
+      if (toplevel && sameDir(toplevel, wtPath)) {
+        isWorktreeRoot = true;
+        const head = gitRunner(['log', '-1', '--format=%ct'], wtPath);
+        if (head?.code === 0) {
+          const secs = Number(String(head.stdout || '').trim());
+          if (Number.isFinite(secs) && secs > 0) headMs = secs * 1000;
+        }
+      }
+    }
+
+    const lastActivityMs = Math.max(mtimeMs, headMs);
+    const ageMs = lastActivityMs > 0 ? nowMs - lastActivityMs : Infinity;
+    if (ageMs <= windowMs) {
+      return {
+        blocked: true,
+        reason: REAP_BLOCKED_TREE_RESIDENT,
+        detail: { age_ms: ageMs, window_ms: windowMs, mtime_ms: mtimeMs, head_ms: headMs, is_worktree_root: isWorktreeRoot },
+      };
+    }
+    return { blocked: false, reason: null, detail: { age_ms: ageMs, window_ms: windowMs, is_worktree_root: isWorktreeRoot } };
+  } catch (e) {
+    logger(`[residency-guard] tree residency check failed for ${wtPath} (${e?.message}) — failing CLOSED`);
+    return { blocked: true, reason: REAP_RESIDENCY_UNKNOWN, detail: { error: e?.message } };
+  }
+}
+
+export default {
+  cwdResidencyBlocks,
+  heartbeatResidencyBlocksRemoval,
+  treeResidencyBlocksRemoval,
+  REAP_BLOCKED_RESIDENT,
+  REAP_RESIDENCY_UNKNOWN,
+  REAP_BLOCKED_TREE_RESIDENT,
+  DEFAULT_RESIDENCY_WINDOW_MIN,
+};

--- a/lib/worktree-reaper/residency-guard.js
+++ b/lib/worktree-reaper/residency-guard.js
@@ -218,8 +218,23 @@ export function treeResidencyBlocksRemoval(wtPath, options = {}) {
 
   try {
     // mtime: immune to walk-up by construction.
+    //
+    // SEC-03: a stat FAILURE is not evidence of absence. This previously swallowed every
+    // error to mtimeMs=0, which reads as "ancient" and clears the guard. The sharp edge is
+    // Windows-specific and points the wrong way: a directory held open by a live process
+    // yields EPERM/EBUSY, so the error most CORRELATED WITH OCCUPANCY was converted into
+    // evidence that nobody was there. ENOENT is different — an absent directory is a real
+    // answer, and nothing is occupying a path that does not exist.
     let mtimeMs = 0;
-    try { mtimeMs = Number(statFn(wtPath)?.mtimeMs) || 0; } catch { mtimeMs = 0; }
+    try {
+      mtimeMs = Number(statFn(wtPath)?.mtimeMs) || 0;
+    } catch (e) {
+      if (e?.code !== 'ENOENT') {
+        logger(`[residency-guard] stat failed for ${wtPath} (${e?.code || e?.message}) — failing CLOSED`);
+        return { blocked: true, reason: REAP_RESIDENCY_UNKNOWN, detail: { stat_error: e?.code || String(e?.message) } };
+      }
+      mtimeMs = 0;
+    }
 
     // HEAD: only meaningful when wtPath IS the worktree root (trap 1), and only
     // detectable as such with separator/case-tolerant comparison (trap 2).
@@ -238,7 +253,15 @@ export function treeResidencyBlocksRemoval(wtPath, options = {}) {
       }
     }
 
-    const lastActivityMs = Math.max(mtimeMs, headMs);
+    // SEC-05: clamp FUTURE timestamps to "now" rather than letting them produce a negative
+    // age. A tree stamped in 2030 — by a skewed clock, a crafted GIT_COMMITTER_DATE, or a
+    // restored archive — otherwise reads as resident FOREVER and can never be reaped. That
+    // is the permanent-backlog failure this SD's own FR-1b argues against, reachable by
+    // anyone who can set a file mtime. Clamping keeps it resident for one window, which is
+    // the conservative reading of "we cannot tell when this was last touched", and then
+    // lets it age out normally.
+    const rawActivityMs = Math.max(mtimeMs, headMs);
+    const lastActivityMs = rawActivityMs > nowMs ? nowMs : rawActivityMs;
     const ageMs = lastActivityMs > 0 ? nowMs - lastActivityMs : Infinity;
     if (ageMs <= windowMs) {
       return {

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -65,7 +65,7 @@ import { runOrphanSweep } from '../lib/worktree-reaper/orphan-sweep.js';
 // reaped regardless of commit count (Alpha-2 incident: zero-commit mid-PLAN reap).
 import { liveClaimBlocksRemoval } from '../lib/worktree-reaper/live-claim-guard.js';
 import { heartbeatResidencyBlocksRemoval, treeResidencyBlocksRemoval } from '../lib/worktree-reaper/residency-guard.js';
-import { hasReapEligibleMarker, readReapEligibleMarker } from '../lib/worktree-reaper/reap-eligible-marker.js';
+import { hasReapEligibleMarker, readReapEligibleMarker, isReapEligibleMarkerValid } from '../lib/worktree-reaper/reap-eligible-marker.js';
 import { decideRemoval, UNRESOLVABLE_KEY_RESIDENCY_CLEARED } from '../lib/worktree-reaper/removal-decision.js';
 // QF-20260725-821: the opt-OUT marker. .reap-eligible.json is opt-IN TO REAPING; before this
 // there was no way to say "do not reap me", so any operator/drill/ops worktree without an
@@ -621,9 +621,26 @@ async function classifyWorktree(wt, ctx) {
   // marker is the out-of-band handoff from a post-merge flow that refused to
   // self-delete — collect it promptly, ahead of age-based classification. The
   // removal gate (live-claim + residency guards) still decides WHEN it is safe.
+  // SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-B (FR-3): the marker must still HOLD
+  // authority, not merely exist. Presence alone let a 5.5-hour-old marker naming a
+  // different SD license deleting the RLS ceremony tree at 21:34:48Z. The gate lands
+  // here — by not pushing the category — rather than in stageForCategories, which is a
+  // pure function of `categories` pinned by 14 assertions and is the wrong layer.
   if (hasReapEligibleMarker(wt.path)) {
-    categories.push('reap-eligible');
-    reasons['reap-eligible'] = { matched: true, reason: 'marker', evidence: readReapEligibleMarker(wt.path) || {} };
+    const validity = isReapEligibleMarkerValid(wt.path, { treeKey: keyFromWorktree(wt) });
+    if (validity.valid) {
+      categories.push('reap-eligible');
+      reasons['reap-eligible'] = { matched: true, reason: 'marker', evidence: readReapEligibleMarker(wt.path) || {} };
+    } else {
+      // Recorded, not silent: an expired marker is a decision someone made and it should
+      // be visible that it was declined rather than never seen.
+      reasons['reap-eligible-expired'] = {
+        matched: false,
+        reason: validity.reason,
+        detail: validity.detail || null,
+        evidence: readReapEligibleMarker(wt.path) || {},
+      };
+    }
   }
 
   const nested = isNested(wt);

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -64,8 +64,9 @@ import { runOrphanSweep } from '../lib/worktree-reaper/orphan-sweep.js';
 // QF-20260710-432: last-line live-claim guard — a live-claimed worktree is never
 // reaped regardless of commit count (Alpha-2 incident: zero-commit mid-PLAN reap).
 import { liveClaimBlocksRemoval } from '../lib/worktree-reaper/live-claim-guard.js';
-import { heartbeatResidencyBlocksRemoval } from '../lib/worktree-reaper/residency-guard.js';
+import { heartbeatResidencyBlocksRemoval, treeResidencyBlocksRemoval } from '../lib/worktree-reaper/residency-guard.js';
 import { hasReapEligibleMarker, readReapEligibleMarker } from '../lib/worktree-reaper/reap-eligible-marker.js';
+import { decideRemoval, UNRESOLVABLE_KEY_RESIDENCY_CLEARED } from '../lib/worktree-reaper/removal-decision.js';
 // QF-20260725-821: the opt-OUT marker. .reap-eligible.json is opt-IN TO REAPING; before this
 // there was no way to say "do not reap me", so any operator/drill/ops worktree without an
 // sd_key basename and a DB claim was auto-removed at stage 2 (live incident: the chairman's
@@ -1394,19 +1395,14 @@ export async function main(argv = process.argv) {
         logger: (m) => process.stderr.write(`  ${m}
 `),
       });
-      if (claimGuard.blocked) {
-        console.log(`  ⛔ ${path.basename(wtPath)} live-claim guard: ${claimGuard.reason} — skipping`);
-        emitJsonLine({
-          schema_version: SCHEMA_VERSION,
-          timestamp: new Date().toISOString(),
-          event: 'removal_blocked_live_claim',
-          worktree_path: wtPath,
-          reason: claimGuard.reason,
-          detail: claimGuard.detail || null,
-        });
-        aborted++;
-        continue;
-      }
+      // SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-B (FR-2): tree residency —
+      // occupancy asked of the FILESYSTEM, needing no DB row to agree with reality.
+      // This is the only predicate that can answer for a worktree whose basename
+      // resolves to no work key, since keyFromWorktree reads the branch but only for
+      // feat|qf|fix|chore|hotfix. Claim-independent and session-independent.
+      const treeResidency = treeResidencyBlocksRemoval(wtPath, {
+        logger: (m) => process.stderr.write(`  ${m}\n`),
+      });
 
       // SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001 (FR-4): residency guard —
       // a FRESH-heartbeat session whose worktree_path references this target
@@ -1415,20 +1411,38 @@ export async function main(argv = process.argv) {
       const residency = await heartbeatResidencyBlocksRemoval(supabase, wtPath, {
         logger: (m) => process.stderr.write(`  ${m}\n`),
       });
-      if (residency.blocked) {
-        console.log(`  ⛔ ${path.basename(wtPath)} residency guard: ${residency.reason} — skipping`);
+
+      // FR-1b: compose. Every guard is still a veto EXCEPT the claim guard's
+      // work_key_unresolvable, which is an admission that it cannot verify — that one
+      // becomes a DEMAND that residency affirmatively clear. Without this, FR-1's
+      // honest refusal would mean an unresolvable basename is never reaped again.
+      const decision = decideRemoval({ claimGuard, treeResidency, heartbeatResidency: residency });
+      if (!decision.remove) {
+        console.log(`  ⛔ ${path.basename(wtPath)} removal gate (${decision.source}): ${decision.reason} — skipping`);
         emitJsonLine({
           schema_version: SCHEMA_VERSION,
           timestamp: new Date().toISOString(),
-          event: 'removal_blocked_resident',
+          // Historical event names kept verbatim — the emitted JSON is a consumed schema
+          // and this FR is about the decision, not the reporting vocabulary.
+          event: decision.source === 'claim' ? 'removal_blocked_live_claim' : 'removal_blocked_resident',
           worktree_path: wtPath,
-          reason: residency.reason,
-          detail: residency.detail || null,
+          reason: decision.reason,
+          source: decision.source,
+          detail: (decision.source === 'claim' ? claimGuard.detail : treeResidency.detail) || null,
         });
         aborted++;
         continue;
       }
-
+      if (decision.reason === UNRESOLVABLE_KEY_RESIDENCY_CLEARED) {
+        emitJsonLine({
+          schema_version: SCHEMA_VERSION,
+          timestamp: new Date().toISOString(),
+          event: 'removal_permitted_unresolvable_key',
+          worktree_path: wtPath,
+          reason: decision.reason,
+          detail: treeResidency.detail || null,
+        });
+      }
       // SD-LEO-FEAT-DATA-LOSS-HIGH-001 (FR-2): preserve BOTH untracked AND modified-tracked files
       // before the force-remove. Uncommitted edits to tracked files (the ~56-LOC data-loss class)
       // were previously destroyed because only `untracked` was copied. Dedupe defensively. The

--- a/tests/unit/cleanup/filesystem-provider-worktree-refusal.test.js
+++ b/tests/unit/cleanup/filesystem-provider-worktree-refusal.test.js
@@ -1,0 +1,95 @@
+/**
+ * SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-B FR-4 — the cleanup provider no longer
+ * deletes worktrees, and its containment check now has a separator boundary.
+ *
+ * The provider accepted any path under .worktrees and called a RAW rmSync: no claim guard,
+ * no residency guard, no isReapable, and not safeRecursiveRm, so it could follow a
+ * node_modules junction into the shared store. Latent rather than live (nothing passes it
+ * filesystemPaths today), but the guards child cannot claim an invariant while a path
+ * exists that consults none of the guards.
+ *
+ * The POSITIVE case matters as much as the refusal: the pre-existing suite asserted only
+ * an empty-paths case and an /etc rejection, so a blanket disablement would have passed it.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { cleanupFilesystem } from '../../../lib/cleanup/filesystem-provider.js';
+
+const CWD = process.cwd();
+const mk = (p) => { fs.mkdirSync(p, { recursive: true }); fs.writeFileSync(path.join(p, 'f.txt'), 'x'); return p; };
+const made = [];
+
+afterEach(() => {
+  for (const p of made.splice(0)) { try { fs.rmSync(p, { recursive: true, force: true }); } catch { /* best effort */ } }
+});
+
+describe('FR-4 — worktree paths are refused', () => {
+  test('a path under .worktrees is NOT deleted, and says why', async () => {
+    const target = path.join(CWD, '.worktrees', '__fr4_probe__');
+    made.push(target);
+    mk(target);
+    const r = await cleanupFilesystem('venture-1', { paths: [target] });
+    expect(r.cleaned).toEqual([]);
+    expect(r.errors[0].error).toMatch(/guarded reaper|worktree-manager/i);
+    expect(fs.existsSync(target)).toBe(true); // ARMING: it really is still on disk
+  });
+
+  test('refusal holds in dryRun too — it is a validation refusal, not a delete-time one', async () => {
+    const target = path.join(CWD, '.worktrees', '__fr4_probe2__');
+    made.push(target);
+    mk(target);
+    const r = await cleanupFilesystem('v', { paths: [target], dryRun: true });
+    expect(r.cleaned).toEqual([]);
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('FR-4 — OPPOSITE POLARITY: the provider still does its actual job', () => {
+  test('a path under tmp IS still deleted', async () => {
+    // Without this, a blanket disablement would satisfy every refusal test above.
+    const target = path.join(CWD, 'tmp', '__fr4_ok__');
+    made.push(target);
+    mk(target);
+    const r = await cleanupFilesystem('v', { paths: [target] });
+    expect(r.cleaned).toEqual([target]);
+    expect(r.success).toBe(true);
+    expect(fs.existsSync(target)).toBe(false);
+  });
+
+  test('dryRun under tmp reports without deleting', async () => {
+    const target = path.join(CWD, 'tmp', '__fr4_dry__');
+    made.push(target);
+    mk(target);
+    const r = await cleanupFilesystem('v', { paths: [target], dryRun: true });
+    expect(r.cleaned).toEqual([target]);
+    expect(fs.existsSync(target)).toBe(true);
+  });
+});
+
+describe('FR-4 — the containment check has a separator boundary', () => {
+  test('a SIBLING whose name merely starts with an allowed root is refused', async () => {
+    // Previously `normalized.startsWith(root)` made tmp-restore look like it was inside tmp.
+    const target = path.join(CWD, 'tmp-fr4-sibling');
+    made.push(target);
+    mk(target);
+    const r = await cleanupFilesystem('v', { paths: [target] });
+    expect(r.cleaned).toEqual([]);
+    expect(fs.existsSync(target)).toBe(true);
+  });
+
+  test('a sibling of .worktrees is refused by the allowlist, not mislabelled as a worktree', async () => {
+    const target = path.join(CWD, 'tmp', '__fr4_nested__', 'deep');
+    made.push(path.join(CWD, 'tmp', '__fr4_nested__'));
+    mk(target);
+    // genuinely nested under tmp -> allowed, proving the boundary check did not over-tighten
+    const r = await cleanupFilesystem('v', { paths: [target] });
+    expect(r.cleaned).toEqual([target]);
+  });
+
+  test('paths outside every root are still refused', async () => {
+    const r = await cleanupFilesystem('v', { paths: ['/etc/passwd'] });
+    expect(r.cleaned).toEqual([]);
+    expect(r.errors[0].error).toMatch(/not under allowed roots/i);
+  });
+});

--- a/tests/unit/live-claim-guard-qf432.test.js
+++ b/tests/unit/live-claim-guard-qf432.test.js
@@ -87,8 +87,35 @@ describe('liveClaimBlocksRemoval — the Alpha-2 regression fixture', () => {
     expect(r.reason).toBe('unverifiable_guard_exception');
   });
 
-  test('non-work directories are not the guard\'s business', async () => {
+  // SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001 (FR-1) REVERSES this case. The old test
+  // was named "non-work directories are not the guard's business" and pinned
+  // {blocked:false, reason:'no_work_key_in_path'}. That doctrine deleted two in-use
+  // ceremony trees on 2026-07-31. A directory the guard cannot resolve is now precisely
+  // the guard's business, because it is the case it cannot verify.
+  test('an unresolvable directory name fails CLOSED — cannot verify is not "no claim"', async () => {
     const r = await liveClaimBlocksRemoval(null, 'C:/repo/.worktrees/_archive');
-    expect(r).toEqual({ blocked: false, reason: 'no_work_key_in_path' });
+    expect(r.blocked).toBe(true);
+    expect(r.reason).toBe('work_key_unresolvable');
+    expect(r.detail).toEqual({ worktree_path: 'C:/repo/.worktrees/_archive' });
+  });
+
+  // The two REAL basenames from the 2026-07-31 incident, verbatim. Regression pins.
+  test.each([
+    '.worktrees/scribe-privesc-20260731',
+    '.worktrees/changelog-privesc',
+  ])('incident basename %s is refused, not reaped', async (rel) => {
+    const r = await liveClaimBlocksRemoval(null, `C:/repo/${rel}`);
+    expect(r.blocked).toBe(true);
+    expect(r.reason).toBe('work_key_unresolvable');
+  });
+
+  // OPPOSITE POLARITY — the control. Without this, a change that simply blocked
+  // everything would pass every assertion above while breaking the reaper entirely.
+  // A resolvable key with no claimant must still clear, via the VERIFIED path.
+  test('a resolvable key with no claimant still clears (fail-closed is not block-everything)', async () => {
+    const supabase = mockSupabase({ claimant: null, pointingSession: null });
+    const r = await liveClaimBlocksRemoval(supabase, 'C:/repo/.worktrees/SD-SOME-THING-001', { isSessionAliveFn: deadFn });
+    expect(r.blocked).toBe(false);
+    expect(r.reason).toBe('no_live_claim');
   });
 });

--- a/tests/unit/worktree-delete-primitive-static-guard.test.js
+++ b/tests/unit/worktree-delete-primitive-static-guard.test.js
@@ -75,9 +75,16 @@ describe('worktree delete primitive is chokepoint-only (FR-5)', () => {
    * `git worktree remove`, so EVERY rmSync / safeRecursiveRm deleter was structurally
    * invisible to it. The header of this file records that per-site patching is why the
    * class recurred five times; the mechanism built to end that recurrence covered one of
-   * the two delete primitives. A worktree removed with a RAW recursive rmSync can also
-   * follow a node_modules junction out of the tree and into the shared store, which the
-   * junction-safe helpers exist to prevent.
+   * the two delete primitives.
+   *
+   * WHY, CORRECTED (SEC-08): the original justification here claimed a raw recursive
+   * rmSync follows a nested node_modules junction out of the tree. SECURITY could NOT
+   * reproduce that on Node v24.12.0 — the nested junction was unlinked and its target
+   * survived. The real reason to route through the junction-safe helpers is that they
+   * unlink links deliberately and are the single place that behaviour is maintained; a
+   * raw rmSync is an unreviewed second implementation of a delete policy. Keeping a false
+   * threat premise in a control's rationale is its own hazard: it points readers at a safe
+   * route and away from the real one (intermediate-segment junctions, see SEC-01).
    *
    * Scope is deliberately narrow so the guard does not land permanently red: a bare
    * `recursive: true` pattern matches 226 files. This flags a raw recursive rmSync only in
@@ -89,13 +96,13 @@ describe('worktree delete primitive is chokepoint-only (FR-5)', () => {
       ['lib/worktree-manager.js',
         'IS the junction-safe primitive — safeRecursiveRm/WithRetry are defined here and this is their implementation.'],
       ['lib/cleanup/filesystem-provider.js',
-        'FR-4 removed .worktrees from its allowlist; it now refuses worktree paths outright and deletes only under tmp. It mentions .worktrees solely to name that refusal.'],
+        'FR-4 removed .worktrees from its allowlist and it refuses worktree paths outright. SECURITY disproved the first version of this reason by escaping the LEXICAL containment check via an intermediate-segment junction; containment is now realpath-based and the resolved path is what gets deleted, so the claim holds as restated.'],
       ['scripts/audit/worktree-reparse-audit.mjs',
         'Removes its own mkdtemp scratch dir, not a worktree.'],
       ['scripts/hooks/concurrent-session-worktree.cjs',
-        'RESIDUAL RISK, RECORDED NOT RESOLVED: this DOES rmSync a worktree path. Already allowlisted above for the git primitive because a sync CJS hook cannot import the ESM chokepoint. It is guarded by fs-marker + active-claim + dirty + unpushed + merged-to-main checks, but the raw rmSync means it is not junction-safe. Converting it needs its own change.'],
+        'CORRECTED BY SECURITY: it DOES rmSync a worktree path, but it is NOT unsafe — :610 calls _unlinkNestedLinks(wtPath) inside the retry loop immediately before every rmSync at :612, mirroring the canonical _unlinkLinksRecursive (worktree-manager.js:1334). My earlier reason here said it was not junction-safe; that was wrong. The real (minor) issue is DUPLICATION of the primitive rather than reuse, which is a drift risk, not a wipe risk.'],
       ['scripts/maintenance/sweep-worker-scratch.mjs',
-        'Sweeps worker scratch paths. Not re-verified as worktree-free in this SD — allowlisted to keep the guard green, flagged for follow-up.'],
+        'CORRECTED BY SECURITY: verifiably safe, not merely unverified — :57 lists .worktrees/ in its never-walk EXCLUDE set. My earlier reason was weaker than the truth and would have sent a future reader chasing a non-hazard.'],
     ]);
 
     // Comments are BLANKED IN PLACE rather than removed: stripping them shifts every
@@ -122,7 +129,12 @@ describe('worktree delete primitive is chokepoint-only (FR-5)', () => {
     };
 
     // Word-boundary, so it catches the BARE destructured `rmSync(` as well as `fs.rmSync(`.
+    // SECURITY found the first version evadable: it required `rmSync(` and `recursive` on
+    // the SAME line, and Prettier splits a long call across lines — the reformatted call
+    // sailed through a guard whose entire purpose is ending a five-time recurrence. The
+    // options object is now searched in a small forward WINDOW instead.
     const RAW_RM_RE = /\brmSync\s*\(/;
+    const WINDOW = 4;
     const violations = [];
     for (const dir of SCAN_DIRS) {
       for (const fp of walk(path.join(repoRoot, dir))) {
@@ -130,10 +142,11 @@ describe('worktree delete primitive is chokepoint-only (FR-5)', () => {
         if (FS_ALLOWLIST.has(rel)) continue;
         const blanked = blankComments(fs.readFileSync(fp, 'utf8'));
         if (!blanked.includes('.worktrees')) continue; // not a worktree-handling file
-        for (const [i, line] of blanked.split('\n').entries()) {
-          if (RAW_RM_RE.test(line) && line.includes('recursive')) {
-            violations.push(`${rel}:${i + 1}`);
-          }
+        const lines = blanked.split('\n');
+        for (const [i, line] of lines.entries()) {
+          if (!RAW_RM_RE.test(line)) continue;
+          const window = lines.slice(i, i + WINDOW).join('\n');
+          if (window.includes('recursive')) violations.push(`${rel}:${i + 1}`);
         }
       }
     }

--- a/tests/unit/worktree-delete-primitive-static-guard.test.js
+++ b/tests/unit/worktree-delete-primitive-static-guard.test.js
@@ -70,6 +70,90 @@ describe('worktree delete primitive is chokepoint-only (FR-5)', () => {
     expect(violations, `direct 'git worktree remove' outside the guarded chokepoint:\n  ${violations.join('\n  ')}`).toEqual([]);
   });
 
+  /**
+   * SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-B (FR-5) — the guard above greps only
+   * `git worktree remove`, so EVERY rmSync / safeRecursiveRm deleter was structurally
+   * invisible to it. The header of this file records that per-site patching is why the
+   * class recurred five times; the mechanism built to end that recurrence covered one of
+   * the two delete primitives. A worktree removed with a RAW recursive rmSync can also
+   * follow a node_modules junction out of the tree and into the shared store, which the
+   * junction-safe helpers exist to prevent.
+   *
+   * Scope is deliberately narrow so the guard does not land permanently red: a bare
+   * `recursive: true` pattern matches 226 files. This flags a raw recursive rmSync only in
+   * files that actually deal with worktree paths.
+   */
+  it('no non-allowlisted worktree-handling file deletes with a raw recursive rmSync (FR-5)', () => {
+    // Each entry states WHY, so the next reader can re-judge it rather than inherit it.
+    const FS_ALLOWLIST = new Map([
+      ['lib/worktree-manager.js',
+        'IS the junction-safe primitive — safeRecursiveRm/WithRetry are defined here and this is their implementation.'],
+      ['lib/cleanup/filesystem-provider.js',
+        'FR-4 removed .worktrees from its allowlist; it now refuses worktree paths outright and deletes only under tmp. It mentions .worktrees solely to name that refusal.'],
+      ['scripts/audit/worktree-reparse-audit.mjs',
+        'Removes its own mkdtemp scratch dir, not a worktree.'],
+      ['scripts/hooks/concurrent-session-worktree.cjs',
+        'RESIDUAL RISK, RECORDED NOT RESOLVED: this DOES rmSync a worktree path. Already allowlisted above for the git primitive because a sync CJS hook cannot import the ESM chokepoint. It is guarded by fs-marker + active-claim + dirty + unpushed + merged-to-main checks, but the raw rmSync means it is not junction-safe. Converting it needs its own change.'],
+      ['scripts/maintenance/sweep-worker-scratch.mjs',
+        'Sweeps worker scratch paths. Not re-verified as worktree-free in this SD — allowlisted to keep the guard green, flagged for follow-up.'],
+    ]);
+
+    // Comments are BLANKED IN PLACE rather than removed: stripping them shifts every
+    // subsequent line number, so reported violations point at the wrong code. (Learned
+    // the hard way while sizing this guard.) An unstripped scan is also wrong — the
+    // reaper mentions rmSync only in a comment and would self-report a false violation.
+    const blankComments = (src) => {
+      let out = ''; let state = null;
+      for (let i = 0; i < src.length;) {
+        const two = src.slice(i, i + 2);
+        if (state === null) {
+          if (two === '/*') { state = 'block'; out += '  '; i += 2; continue; }
+          if (two === '//') { state = 'line'; out += '  '; i += 2; continue; }
+          out += src[i]; i += 1;
+        } else if (state === 'block') {
+          if (two === '*/') { state = null; out += '  '; i += 2; continue; }
+          out += src[i] === '\n' ? '\n' : ' '; i += 1;
+        } else {
+          if (src[i] === '\n') { state = null; out += '\n'; i += 1; continue; }
+          out += ' '; i += 1;
+        }
+      }
+      return out;
+    };
+
+    // Word-boundary, so it catches the BARE destructured `rmSync(` as well as `fs.rmSync(`.
+    const RAW_RM_RE = /\brmSync\s*\(/;
+    const violations = [];
+    for (const dir of SCAN_DIRS) {
+      for (const fp of walk(path.join(repoRoot, dir))) {
+        const rel = path.relative(repoRoot, fp).replace(/\\/g, '/');
+        if (FS_ALLOWLIST.has(rel)) continue;
+        const blanked = blankComments(fs.readFileSync(fp, 'utf8'));
+        if (!blanked.includes('.worktrees')) continue; // not a worktree-handling file
+        for (const [i, line] of blanked.split('\n').entries()) {
+          if (RAW_RM_RE.test(line) && line.includes('recursive')) {
+            violations.push(`${rel}:${i + 1}`);
+          }
+        }
+      }
+    }
+    expect(violations, `raw recursive rmSync in worktree-handling files (use safeRecursiveRm):\n  ${violations.join('\n  ')}`).toEqual([]);
+  });
+
+  it('FR-5 guard is not vacuous — it detects a synthetic violation', () => {
+    // Without this, the guard passes identically whether its predicate works or not.
+    const synthetic = [
+      'const dir = resolve(cwd, ".worktrees", name);',
+      'fs.rmSync(dir, { recursive: true, force: true });',
+    ].join('\n');
+    const RAW_RM_RE = /\brmSync\s*\(/;
+    const hit = synthetic.split('\n').some((l) => RAW_RM_RE.test(l) && l.includes('recursive'));
+    expect(hit).toBe(true);
+    // …and a comment-only mention must NOT trip it, which is why blanking exists.
+    const commented = '// fs.rmSync(dir, { recursive: true });';
+    expect(commented.trim().startsWith('//')).toBe(true);
+  });
+
   it('the warn-and-proceed CWD branch is gone from post-merge cleanup (FR-2)', () => {
     const src = fs.readFileSync(path.join(repoRoot, 'scripts/modules/shipping/post-merge-worktree-cleanup.js'), 'utf8');
     // The old branch returned a warning AND still deleted; the refusal path

--- a/tests/unit/worktree-delete-primitive-static-guard.test.js
+++ b/tests/unit/worktree-delete-primitive-static-guard.test.js
@@ -33,6 +33,59 @@ const SCAN_DIRS = ['lib', 'scripts'];
 const EXT_RE = /\.(m?c?js)$/;
 const PRIMITIVE_RE = /git\s+worktree\s+remove/;
 
+// ── FR-5 predicate, at MODULE scope so the self-test below can drive THE REAL ONE ──
+//
+// RETRO-F1: the previous self-test re-declared this regex inside its own `it()` and ran it
+// against a string literal, because every helper lived inside the scan `it()` and was out of
+// scope. It therefore passed no matter what the guard did — WINDOW could go back to 1,
+// blankComments could be deleted, the allowlist could swallow every file. That is the
+// correct-but-not-wired failure this SD spent a commit fixing elsewhere, re-committed inside
+// the fix for the line-number bug, in a commit whose message claimed verification by planted
+// violation. The manual planted runs were real; what got committed was not them.
+
+/** Blank comment BODIES in place, preserving newlines so line numbers stay accurate. */
+function blankComments(src) {
+  const NL = String.fromCharCode(10);
+  let out = ''; let state = null;
+  for (let i = 0; i < src.length;) {
+    const two = src.slice(i, i + 2);
+    if (state === null) {
+      if (two === '/*') { state = 'block'; out += '  '; i += 2; continue; }
+      if (two === '//') { state = 'line'; out += '  '; i += 2; continue; }
+      out += src[i]; i += 1;
+    } else if (state === 'block') {
+      if (two === '*/') { state = null; out += '  '; i += 2; continue; }
+      out += src[i] === NL ? NL : ' '; i += 1;
+    } else {
+      if (src[i] === NL) { state = null; out += NL; i += 1; continue; }
+      out += ' '; i += 1;
+    }
+  }
+  return out;
+}
+
+// Word-boundary, so the BARE destructured `rmSync(` is caught alongside `fs.rmSync(`.
+const RAW_RM_RE = /\brmSync\s*\(/;
+// SECURITY: the first version required `rmSync(` and `recursive` on the SAME line, and
+// Prettier splits a long call — the reformatted call sailed through a guard whose entire
+// purpose is ending a five-time recurrence. The options object is searched in a window.
+const RM_WINDOW = 4;
+
+/**
+ * Line numbers (1-based) of raw recursive rmSync calls in `src`.
+ * THE single implementation — the scan and its non-vacuity test both call this.
+ */
+function findRawRecursiveRmSync(src) {
+  const NL = String.fromCharCode(10);
+  const lines = blankComments(src).split(NL);
+  const hits = [];
+  for (const [i, line] of lines.entries()) {
+    if (!RAW_RM_RE.test(line)) continue;
+    if (lines.slice(i, i + RM_WINDOW).join(NL).includes('recursive')) hits.push(i + 1);
+  }
+  return hits;
+}
+
 function* walk(dir) {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const fp = path.join(dir, entry.name);
@@ -105,68 +158,51 @@ describe('worktree delete primitive is chokepoint-only (FR-5)', () => {
         'CORRECTED BY SECURITY: verifiably safe, not merely unverified — :57 lists .worktrees/ in its never-walk EXCLUDE set. My earlier reason was weaker than the truth and would have sent a future reader chasing a non-hazard.'],
     ]);
 
-    // Comments are BLANKED IN PLACE rather than removed: stripping them shifts every
-    // subsequent line number, so reported violations point at the wrong code. (Learned
-    // the hard way while sizing this guard.) An unstripped scan is also wrong — the
-    // reaper mentions rmSync only in a comment and would self-report a false violation.
-    const blankComments = (src) => {
-      let out = ''; let state = null;
-      for (let i = 0; i < src.length;) {
-        const two = src.slice(i, i + 2);
-        if (state === null) {
-          if (two === '/*') { state = 'block'; out += '  '; i += 2; continue; }
-          if (two === '//') { state = 'line'; out += '  '; i += 2; continue; }
-          out += src[i]; i += 1;
-        } else if (state === 'block') {
-          if (two === '*/') { state = null; out += '  '; i += 2; continue; }
-          out += src[i] === '\n' ? '\n' : ' '; i += 1;
-        } else {
-          if (src[i] === '\n') { state = null; out += '\n'; i += 1; continue; }
-          out += ' '; i += 1;
-        }
-      }
-      return out;
-    };
-
-    // Word-boundary, so it catches the BARE destructured `rmSync(` as well as `fs.rmSync(`.
-    // SECURITY found the first version evadable: it required `rmSync(` and `recursive` on
-    // the SAME line, and Prettier splits a long call across lines — the reformatted call
-    // sailed through a guard whose entire purpose is ending a five-time recurrence. The
-    // options object is now searched in a small forward WINDOW instead.
-    const RAW_RM_RE = /\brmSync\s*\(/;
-    const WINDOW = 4;
     const violations = [];
     for (const dir of SCAN_DIRS) {
       for (const fp of walk(path.join(repoRoot, dir))) {
         const rel = path.relative(repoRoot, fp).replace(/\\/g, '/');
         if (FS_ALLOWLIST.has(rel)) continue;
-        const blanked = blankComments(fs.readFileSync(fp, 'utf8'));
-        if (!blanked.includes('.worktrees')) continue; // not a worktree-handling file
-        const lines = blanked.split('\n');
-        for (const [i, line] of lines.entries()) {
-          if (!RAW_RM_RE.test(line)) continue;
-          const window = lines.slice(i, i + WINDOW).join('\n');
-          if (window.includes('recursive')) violations.push(`${rel}:${i + 1}`);
-        }
+        const src = fs.readFileSync(fp, 'utf8');
+        if (!blankComments(src).includes('.worktrees')) continue; // not a worktree-handling file
+        for (const line of findRawRecursiveRmSync(src)) violations.push(`${rel}:${line}`);
       }
     }
     expect(violations, `raw recursive rmSync in worktree-handling files (use safeRecursiveRm):\n  ${violations.join('\n  ')}`).toEqual([]);
   });
 
-  it('FR-5 guard is not vacuous — it detects a synthetic violation', () => {
-    // Without this, the guard passes identically whether its predicate works or not.
-    const synthetic = [
+  it('FR-5 predicate is not vacuous — it detects BOTH call shapes and ignores comments', () => {
+    // Drives findRawRecursiveRmSync itself. Acceptance for RETRO-F1: setting RM_WINDOW
+    // back to 1 must turn this RED, which is impossible if the test re-implements it.
+    const NL = String.fromCharCode(10);
+    const singleLine = [
       'const dir = resolve(cwd, ".worktrees", name);',
       'fs.rmSync(dir, { recursive: true, force: true });',
-    ].join('\n');
-    const RAW_RM_RE = /\brmSync\s*\(/;
-    const hit = synthetic.split('\n').some((l) => RAW_RM_RE.test(l) && l.includes('recursive'));
-    expect(hit).toBe(true);
-    // …and a comment-only mention must NOT trip it, which is why blanking exists.
-    const commented = '// fs.rmSync(dir, { recursive: true });';
-    expect(commented.trim().startsWith('//')).toBe(true);
-  });
+    ].join(NL);
+    expect(findRawRecursiveRmSync(singleLine)).toEqual([2]);
 
+    // The multi-line form Prettier emits — the shape that evaded the first version.
+    const multiLine = [
+      'const dir = resolve(cwd, ".worktrees", name);',
+      'fs.rmSync(dir, {',
+      '  recursive: true,',
+      '  force: true,',
+      '});',
+    ].join(NL);
+    expect(findRawRecursiveRmSync(multiLine)).toEqual([2]);
+
+    // The bare destructured call, not just the dotted form.
+    expect(findRawRecursiveRmSync('rmSync(p, { recursive: true });')).toEqual([1]);
+
+    // A comment-only mention must NOT trip it — this is what blankComments buys, and it
+    // is asserted THROUGH the predicate rather than by re-checking the string.
+    expect(findRawRecursiveRmSync('// fs.rmSync(dir, { recursive: true });')).toEqual([]);
+    const blockComment = ['/*', ' fs.rmSync(dir, {', ' recursive: true,', ' });', '*/'].join(NL);
+    expect(findRawRecursiveRmSync(blockComment)).toEqual([]);
+
+    // A non-recursive rmSync is out of scope and must not be flagged.
+    expect(findRawRecursiveRmSync('fs.rmSync(file);')).toEqual([]);
+  });
   it('the warn-and-proceed CWD branch is gone from post-merge cleanup (FR-2)', () => {
     const src = fs.readFileSync(path.join(repoRoot, 'scripts/modules/shipping/post-merge-worktree-cleanup.js'), 'utf8');
     // The old branch returned a warning AND still deleted; the refusal path

--- a/tests/unit/worktree-reapability-unverifiable.test.js
+++ b/tests/unit/worktree-reapability-unverifiable.test.js
@@ -1,0 +1,99 @@
+/**
+ * SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-B FR-7 — the SSOT stops reading
+ * "I could not look" as "I looked and found nothing".
+ *
+ * lib/worktree-reapability.js declares itself the single source of truth for "is this
+ * worktree safe to remove?" and gates four removal paths. It failed open four ways:
+ * collectDirtyStatus returned dirtyCount:0 on non-zero git exit AND on throw, and
+ * countUnpushedCommits returned 0 in both cases. Composed through isReapable, a tree
+ * whose git commands merely FAILED — locked index, corrupt or pruned gitdir, Windows
+ * permission error — reported clean AND fully pushed and came back reapable:true.
+ *
+ * The guards child cannot claim "a venue with a live occupant is not reapable" while the
+ * module four removal paths consult answers reapable:true for a tree it never managed to
+ * inspect. Moved here from sibling -C by coordinator ruling: a merge conflict is a merge
+ * problem, shipping an invariant that is already false is a correctness problem.
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  collectDirtyStatus,
+  countUnpushedCommits,
+  countUnpushedCommitsResult,
+  isReapable,
+  REAP_REASONS,
+} from '../../lib/worktree-reapability.js';
+
+// A real path, so the fs.existsSync pre-checks pass and the git runner is genuinely reached.
+const REAL = process.cwd();
+
+const failing = () => ({ code: 128, stdout: '', stderr: 'fatal: index file corrupt' });
+const throwing = () => { throw new Error('EPERM: operation not permitted'); };
+const clean = (args) => (args[0] === 'status' ? { code: 0, stdout: '' } : { code: 0, stdout: '' });
+
+describe('FR-7 — could-not-look is not proof-of-clean', () => {
+  test('THE DEFECT, at the level where it caused harm: a git failure no longer yields reapable:true', () => {
+    const r = isReapable(REAL, { gitRunner: failing });
+    expect(r.reapable).toBe(false);
+    expect(r.reason).toBe(REAP_REASONS.UNVERIFIABLE);
+  });
+
+  test('a THROWING git runner is equally unverifiable, not clean', () => {
+    const r = isReapable(REAL, { gitRunner: throwing });
+    expect(r.reapable).toBe(false);
+    expect(r.reason).toBe(REAP_REASONS.UNVERIFIABLE);
+  });
+
+  test('OPPOSITE POLARITY: a tree that genuinely answers clean is STILL reapable', () => {
+    // Without this, "fail closed" degenerates into "never reap", the pool fills,
+    // and the fleet stalls — the exact over-correction this SD is trying to avoid.
+    const r = isReapable(REAL, { gitRunner: clean });
+    expect(r.reapable).toBe(true);
+    expect(r.reason).toBe(REAP_REASONS.ORPHAN_CLEAN);
+  });
+
+  test('a POSITIVE dirty answer keeps its specific reason rather than being masked as unverifiable', () => {
+    const dirty = (args) => (args[0] === 'status'
+      ? { code: 0, stdout: ' M src/a.js\n?? b.txt\n' }
+      : { code: 0, stdout: '' });
+    expect(isReapable(REAL, { gitRunner: dirty }).reason).toBe(REAP_REASONS.DIRTY_TREE);
+  });
+
+  test('a positive unpushed answer likewise keeps UNPUSHED', () => {
+    const ahead = (args) => (args[0] === 'status'
+      ? { code: 0, stdout: '' }
+      : { code: 0, stdout: '+ abc123 subject\n' });
+    expect(isReapable(REAL, { gitRunner: ahead }).reason).toBe(REAP_REASONS.UNPUSHED);
+  });
+
+  test('unpushed-probe failure alone is unverifiable, even when the dirty probe succeeded', () => {
+    const mixed = (args) => (args[0] === 'status' ? { code: 0, stdout: '' } : { code: 128, stdout: '' });
+    expect(isReapable(REAL, { gitRunner: mixed }).reason).toBe(REAP_REASONS.UNVERIFIABLE);
+  });
+});
+
+describe('FR-7 — back-compatibility of the probe contracts', () => {
+  test('collectDirtyStatus keeps every existing field and only ADDS unknown', () => {
+    const ok = collectDirtyStatus(REAL, { gitRunner: clean });
+    expect(ok).toMatchObject({ dirtyCount: 0, untracked: [], modified: [], exists: true, unknown: false });
+    const bad = collectDirtyStatus(REAL, { gitRunner: failing });
+    expect(bad).toMatchObject({ dirtyCount: 0, untracked: [], modified: [], exists: true, unknown: true });
+  });
+
+  test('countUnpushedCommits still returns a plain NUMBER for its existing callers', () => {
+    // The wrapper must stay number-returning: changing its shape would break every
+    // existing consumer for the sake of a signal only isReapable needs.
+    expect(countUnpushedCommits(REAL, { gitRunner: failing })).toBe(0);
+    expect(typeof countUnpushedCommits(REAL, { gitRunner: clean })).toBe('number');
+  });
+
+  test('countUnpushedCommitsResult exposes the distinction the wrapper cannot', () => {
+    expect(countUnpushedCommitsResult(REAL, { gitRunner: failing })).toEqual({ count: 0, unknown: true });
+    expect(countUnpushedCommitsResult(REAL, { gitRunner: clean })).toEqual({ count: 0, unknown: false });
+    // Same count, opposite meaning — which is precisely why 0 was not safe to act on.
+  });
+
+  test('a non-existent path is NOT unverifiable — absent is a real answer', () => {
+    expect(countUnpushedCommitsResult('C:/no/such/path/at/all', { gitRunner: throwing }))
+      .toEqual({ count: 0, unknown: false });
+  });
+});

--- a/tests/unit/worktree-reapability-unverifiable.test.js
+++ b/tests/unit/worktree-reapability-unverifiable.test.js
@@ -26,9 +26,11 @@ import {
 // A real path, so the fs.existsSync pre-checks pass and the git runner is genuinely reached.
 const REAL = process.cwd();
 
-const failing = () => ({ code: 128, stdout: '', stderr: 'fatal: index file corrupt' });
+// rev-parse SUCCEEDS (this dir owns its git state) so a status/cherry failure is a genuine
+// UNKNOWN rather than the definitive "no git here" answer.
+const failing = (args) => (args[0] === 'rev-parse' ? { code: 0, stdout: REAL } : { code: 128, stdout: '', stderr: 'fatal: index file corrupt' });
 const throwing = () => { throw new Error('EPERM: operation not permitted'); };
-const clean = (args) => (args[0] === 'status' ? { code: 0, stdout: '' } : { code: 0, stdout: '' });
+const clean = (args) => (args[0] === 'rev-parse' ? { code: 0, stdout: REAL } : { code: 0, stdout: '' });
 
 describe('FR-7 — could-not-look is not proof-of-clean', () => {
   test('THE DEFECT, at the level where it caused harm: a git failure no longer yields reapable:true', () => {
@@ -52,21 +54,34 @@ describe('FR-7 — could-not-look is not proof-of-clean', () => {
   });
 
   test('a POSITIVE dirty answer keeps its specific reason rather than being masked as unverifiable', () => {
-    const dirty = (args) => (args[0] === 'status'
-      ? { code: 0, stdout: ' M src/a.js\n?? b.txt\n' }
-      : { code: 0, stdout: '' });
+    const dirty = (args) => (args[0] === 'rev-parse'
+      ? { code: 0, stdout: REAL }
+      : args[0] === 'status' ? { code: 0, stdout: ' M src/a.js\n?? b.txt\n' } : { code: 0, stdout: '' });
     expect(isReapable(REAL, { gitRunner: dirty }).reason).toBe(REAP_REASONS.DIRTY_TREE);
   });
 
   test('a positive unpushed answer likewise keeps UNPUSHED', () => {
-    const ahead = (args) => (args[0] === 'status'
-      ? { code: 0, stdout: '' }
-      : { code: 0, stdout: '+ abc123 subject\n' });
+    const ahead = (args) => (args[0] === 'rev-parse'
+      ? { code: 0, stdout: REAL }
+      : args[0] === 'status' ? { code: 0, stdout: '' } : { code: 0, stdout: '+ abc123 subject\n' });
     expect(isReapable(REAL, { gitRunner: ahead }).reason).toBe(REAP_REASONS.UNPUSHED);
   });
 
+  // F4 (TESTING): the MIRROR of the case below. Without it, the `dirty.unknown` guard can
+  // be deleted entirely and stay green, because the `ahead.unknown` guard masks it — the
+  // exact "testing them only in combination lets a half-implementation pass" failure this
+  // SD warns about for FR-3, committed in FR-7.
+  test('dirty-probe failure alone is unverifiable, even when the unpushed probe succeeded', () => {
+    const dirtyFailsOnly = (args) => (args[0] === 'rev-parse'
+      ? { code: 0, stdout: REAL }
+      : args[0] === 'status' ? { code: 128, stdout: '' } : { code: 0, stdout: '' });
+    expect(isReapable(REAL, { gitRunner: dirtyFailsOnly }).reason).toBe(REAP_REASONS.UNVERIFIABLE);
+  });
+
   test('unpushed-probe failure alone is unverifiable, even when the dirty probe succeeded', () => {
-    const mixed = (args) => (args[0] === 'status' ? { code: 0, stdout: '' } : { code: 128, stdout: '' });
+    const mixed = (args) => (args[0] === 'rev-parse'
+      ? { code: 0, stdout: REAL }
+      : args[0] === 'status' ? { code: 0, stdout: '' } : { code: 128, stdout: '' });
     expect(isReapable(REAL, { gitRunner: mixed }).reason).toBe(REAP_REASONS.UNVERIFIABLE);
   });
 });

--- a/tests/unit/worktree-reaper/exec-review-fixes.test.js
+++ b/tests/unit/worktree-reaper/exec-review-fixes.test.js
@@ -1,0 +1,118 @@
+/**
+ * Regressions for the four defects TESTING and SECURITY found in the -B implementation at
+ * EXEC-TO-PLAN. Each was REPRODUCED before being fixed; these pin the fixes.
+ *
+ *  F3/F1  — a pruned or .git-less tree was made permanently unreapable by FR-7, which is
+ *           the stranding shape this SD family exists to unstick, re-created one layer
+ *           down. It also broke cleanup-pending-sweep (bare mkdtemp fixtures).
+ *  SEC-01 — a junction in an INTERMEDIATE path segment escaped the cleanup provider's
+ *           containment check; SECURITY destroyed a real file under .worktrees through it.
+ *  SEC-03 — a stat error became evidence of absence, and on Windows the errors most
+ *           correlated with occupancy (EPERM/EBUSY) are exactly the ones that cleared it.
+ *  SEC-05 — a future timestamp produced a negative age and blocked FOREVER.
+ */
+import { describe, test, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import { isReapable, REAP_REASONS } from '../../../lib/worktree-reapability.js';
+import {
+  treeResidencyBlocksRemoval,
+  REAP_BLOCKED_TREE_RESIDENT,
+  REAP_RESIDENCY_UNKNOWN,
+} from '../../../lib/worktree-reaper/residency-guard.js';
+import { cleanupFilesystem } from '../../../lib/cleanup/filesystem-provider.js';
+
+const git = (a, c) => execFileSync('git', a, { cwd: c, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+const cleanups = [];
+afterEach(() => { for (const fn of cleanups.splice(0)) { try { fn(); } catch { /* best effort */ } } });
+
+describe('F3/F1 — "no git state here" is definitive, not unknown', () => {
+  test('a PRUNED worktree is reapable again (it was permanently stranded)', () => {
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'f3-'));
+    cleanups.push(() => fs.rmSync(root, { recursive: true, force: true }));
+    git(['init', '-q', '-b', 'main'], root);
+    git(['config', 'user.email', 'a@b.c'], root);
+    git(['config', 'user.name', 't'], root);
+    fs.writeFileSync(path.join(root, 's.txt'), 's');
+    git(['add', '-A'], root); git(['commit', '-q', '-m', 's'], root);
+    const wt = path.join(root, '.worktrees', 'SD-PRUNE-001');
+    git(['worktree', 'add', '-q', '-b', 'feat/SD-PRUNE-001', wt], root);
+    fs.rmSync(path.join(root, '.git', 'worktrees', 'SD-PRUNE-001'), { recursive: true, force: true });
+
+    // ARMING: every git command in that tree really does fail now.
+    let rawExit = 0;
+    try { git(['status', '--porcelain'], wt); } catch (e) { rawExit = e.status; }
+    expect(rawExit).toBe(128);
+
+    expect(isReapable(wt)).toEqual({ reapable: true, reason: REAP_REASONS.ORPHAN_CLEAN });
+  });
+
+  test('OPPOSITE POLARITY: a tree that OWNS its git state and still fails stays unverifiable', () => {
+    // Without this, the F3 fix would degrade into "any git failure means reapable",
+    // which is the original FR-7 defect restored.
+    const owned = (a) => (a[0] === 'rev-parse' ? { code: 0, stdout: process.cwd() } : { code: 128, stdout: '' });
+    expect(isReapable(process.cwd(), { gitRunner: owned }).reason).toBe(REAP_REASONS.UNVERIFIABLE);
+  });
+});
+
+describe('SEC-01 — containment is a filesystem fact, not a string fact', () => {
+  test('a junction in an intermediate segment cannot smuggle a worktree path past the refusal', () => {
+    const cwd = process.cwd();
+    const victimDir = path.join(cwd, '.worktrees', '__sec01_regression__');
+    const victimFile = path.join(victimDir, 'work.js');
+    const portal = path.join(cwd, 'tmp', '__sec01_portal__');
+    fs.mkdirSync(victimDir, { recursive: true });
+    fs.writeFileSync(victimFile, 'precious');
+    fs.mkdirSync(path.join(cwd, 'tmp'), { recursive: true });
+    cleanups.push(() => fs.rmSync(victimDir, { recursive: true, force: true }));
+    try {
+      fs.symlinkSync(path.join(cwd, '.worktrees'), portal, 'junction');
+    } catch {
+      return; // link creation unavailable in this environment — nothing to assert
+    }
+    cleanups.push(() => fs.rmSync(portal, { recursive: true, force: true }));
+
+    return cleanupFilesystem('v', { paths: [path.join(portal, '__sec01_regression__')] }).then((r) => {
+      expect(r.cleaned).toEqual([]);
+      expect(r.errors[0].error).toMatch(/guarded reaper|worktree-manager/i);
+      expect(fs.existsSync(victimFile)).toBe(true);
+    });
+  });
+});
+
+describe('SEC-03 — a stat error is not evidence of absence', () => {
+  const quiet = () => {};
+  test.each(['EPERM', 'EBUSY', 'EACCES', 'EIO'])('%s fails CLOSED (on Windows these correlate with occupancy)', (code) => {
+    const boom = () => { const e = new Error(code); e.code = code; throw e; };
+    const r = treeResidencyBlocksRemoval(process.cwd(), {
+      nowMs: Date.now(), statFn: boom, gitRunner: () => ({ code: 128, stdout: '' }), logger: quiet,
+    });
+    expect(r.blocked).toBe(true);
+    expect(r.reason).toBe(REAP_RESIDENCY_UNKNOWN);
+  });
+
+  test('ENOENT is a REAL answer — nothing occupies a path that does not exist', () => {
+    const gone = () => { const e = new Error('ENOENT'); e.code = 'ENOENT'; throw e; };
+    const r = treeResidencyBlocksRemoval(process.cwd(), {
+      nowMs: Date.now(), statFn: gone, gitRunner: () => ({ code: 128, stdout: '' }), logger: quiet,
+    });
+    expect(r.blocked).toBe(false);
+  });
+});
+
+describe('SEC-05 — a future timestamp cannot block forever', () => {
+  const quiet = () => {};
+  const now = 1_800_000_000_000;
+  const YEAR = 365 * 24 * 60 * 60 * 1000;
+
+  test('a tree stamped years in the future is resident for ONE window, not forever', () => {
+    const future = { nowMs: now, statFn: () => ({ mtimeMs: now + 3 * YEAR }), gitRunner: () => ({ code: 128, stdout: '' }), logger: quiet };
+    expect(treeResidencyBlocksRemoval(process.cwd(), future).reason).toBe(REAP_BLOCKED_TREE_RESIDENT);
+
+    // Evaluated well past the window it is no longer resident — the clamp lets it age out.
+    const later = { ...future, nowMs: now + 3 * YEAR + 60 * 60 * 1000, statFn: () => ({ mtimeMs: now + 3 * YEAR }) };
+    expect(treeResidencyBlocksRemoval(process.cwd(), later).blocked).toBe(false);
+  });
+});

--- a/tests/unit/worktree-reaper/production-wiring.test.js
+++ b/tests/unit/worktree-reaper/production-wiring.test.js
@@ -1,0 +1,112 @@
+/**
+ * F2 (TESTING, EXEC-TO-PLAN) — the guards must be WIRED, not merely correct.
+ *
+ * TESTING mutated `scripts/worktree-reaper.mjs` three ways and every mutant SURVIVED:
+ * replacing decideRemoval with the old claim-guard veto, passing a hard-coded
+ * `treeResidency:{blocked:false}`, and stubbing isReapEligibleMarkerValid to `{valid:true}`.
+ * Each unwires an FR from production entirely, and CI stayed green — because every test
+ * drove the extracted functions directly and nothing asserted the call sites.
+ *
+ * PRD FR-1b AC-4 asks for exercise "through the reaper's real removal loop". That loop is
+ * inline in main() and needs a live Supabase, so it is split here by what each half can
+ * honestly prove:
+ *
+ *   FR-3  -> BEHAVIOURAL. classifyWorktree is exported, so its use of the marker validator
+ *            is driven for real against a temp tree. This kills the stub-it-to-valid mutant
+ *            on behaviour, not on source text.
+ *
+ *   FR-1b, FR-2 -> SOURCE ASSERTION, and labelled as such. These pin a FACT (the call
+ *            exists at the site) rather than a BEHAVIOUR, which is a weaker guarantee —
+ *            see PAT-TEST-PINS-FACT-NOT-BEHAVIOUR-001. It is the right tool for "is this
+ *            wired", and the wrong tool for "does this work"; the behaviour is covered by
+ *            removal-decision.test.js and tree-residency-guard.test.js. Stated plainly so
+ *            nobody mistakes this for end-to-end coverage.
+ */
+import { describe, test, expect, vi, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+vi.mock('../../../lib/worktree-reaper/detectors.js', () => ({
+  isNested: vi.fn(() => ({ matched: false })),
+  isZombieOnMain: vi.fn(() => ({ matched: false })),
+  hasOrphanSD: vi.fn(() => ({ matched: false })),
+  isPatchEquivalentToMain: vi.fn(async () => ({ matched: false, reason: 'skipped', evidence: {} })),
+  isIdle: vi.fn(() => ({ matched: false })),
+}));
+
+import { classifyWorktree } from '../../../scripts/worktree-reaper.mjs';
+import { writeReapEligibleMarker } from '../../../lib/worktree-reaper/reap-eligible-marker.js';
+
+const ctx = () => ({
+  repoRoot: '/repo',
+  claimMap: new Map(),
+  sdMap: new Set(),
+  qfMap: new Set(),
+  activeSdSet: new Set(),
+  activeQfSet: new Set(),
+  idleThresholdMs: 7 * 24 * 60 * 60 * 1000,
+});
+
+let dir;
+beforeAll(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'wiring-')); });
+afterAll(() => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+/** Write a marker and force its age, bypassing the writer's own clock. */
+function marker({ hoursAgo, sd_key }) {
+  writeReapEligibleMarker(dir, { sd_key });
+  const p = path.join(dir, '.reap-eligible.json');
+  const payload = JSON.parse(fs.readFileSync(p, 'utf8'));
+  payload.marked_at = new Date(Date.now() - hoursAgo * 3600 * 1000).toISOString();
+  fs.writeFileSync(p, JSON.stringify(payload, null, 2));
+}
+
+describe('FR-3 is wired into classifyWorktree (behavioural)', () => {
+  test('a STALE foreign marker does not make the tree reap-eligible', async () => {
+    marker({ hoursAgo: 5.5, sd_key: 'SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001' });
+    const wt = { path: dir, branch: 'feat/SD-OTHER-001' };
+    const { categories, reasons } = await classifyWorktree(wt, ctx());
+    expect(categories).not.toContain('reap-eligible');
+    expect(reasons['reap-eligible-expired']).toBeDefined();
+  });
+
+  test('OPPOSITE POLARITY: a fresh MATCHING marker still does', async () => {
+    // Without this, stubbing the validator to always-INVALID would also pass above.
+    marker({ hoursAgo: 0.1, sd_key: 'SD-OTHER-001' });
+    const wt = { path: dir, branch: 'feat/SD-OTHER-001' };
+    const { categories } = await classifyWorktree(wt, ctx());
+    expect(categories).toContain('reap-eligible');
+  });
+});
+
+describe('FR-1b and FR-2 are wired into the removal loop (source assertion)', () => {
+  // Weaker than behavioural, and deliberately so — see the header. This exists because
+  // three production-unwiring mutants survived a fully green suite.
+  const src = fs.readFileSync(
+    path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..', 'scripts', 'worktree-reaper.mjs'),
+    'utf8',
+  );
+
+  test('the removal gate calls decideRemoval with all three guard results', () => {
+    expect(src).toMatch(/decideRemoval\(\s*\{[^}]*claimGuard[^}]*treeResidency[^}]*heartbeatResidency[^}]*\}\s*\)/s);
+    expect(src).toMatch(/if\s*\(\s*!decision\.remove\s*\)/);
+  });
+
+  test('tree residency is actually computed for the candidate, not passed a constant', () => {
+    expect(src).toMatch(/treeResidencyBlocksRemoval\(\s*wtPath/);
+    // A hard-coded literal would unwire FR-2 while leaving the decideRemoval call intact.
+    expect(src).not.toMatch(/treeResidency:\s*\{\s*blocked:\s*(false|true)\s*\}/);
+  });
+
+  test('the OLD standalone claim-guard veto is gone from the removal loop', () => {
+    // Its return is what made work_key_unresolvable an absolute veto and would silently
+    // re-strand every unresolvable basename.
+    expect(src).not.toMatch(/if\s*\(\s*claimGuard\.blocked\s*\)\s*\{/);
+  });
+
+  test('marker validation is called at the classification site', () => {
+    expect(src).toMatch(/isReapEligibleMarkerValid\(\s*wt\.path/);
+    expect(src).not.toMatch(/isReapEligibleMarkerValid[^\n]*=>\s*\(\{\s*valid:\s*true/);
+  });
+});

--- a/tests/unit/worktree-reaper/reap-eligible-marker-validity.test.js
+++ b/tests/unit/worktree-reaper/reap-eligible-marker-validity.test.js
@@ -125,7 +125,12 @@ describe('FR-3 — contract details that break callers if wrong', () => {
   });
 
   test('canonicalWorkKey normalizes case and path shape, and rejects non-keys', () => {
-    expect(canonicalWorkKey('sd-foo-001')).toBe('SD-foo-001');
+    // SEC-07: the WHOLE key is uppercased, not just the prefix. Casing only the prefix
+    // made `sd-victim-001` and `SD-VICTIM-001` compare unequal and report
+    // marker_sd_key_mismatch — the loudest reason, reserved for the real incident shape —
+    // for what is the same key. live-claim-guard.js normalizes case; these now agree.
+    expect(canonicalWorkKey('sd-foo-001')).toBe('SD-FOO-001');
+    expect(canonicalWorkKey('SD-FOO-001')).toBe(canonicalWorkKey('sd-foo-001'));
     expect(canonicalWorkKey('.worktrees/qf/QF-20260710-432')).toBe('QF-20260710-432');
     expect(canonicalWorkKey('wt-abc')).toBeNull();
     expect(canonicalWorkKey(null)).toBeNull();

--- a/tests/unit/worktree-reaper/reap-eligible-marker-validity.test.js
+++ b/tests/unit/worktree-reaper/reap-eligible-marker-validity.test.js
@@ -1,0 +1,134 @@
+/**
+ * SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-B FR-3 — a marker must still HOLD authority.
+ *
+ * The two expiry predicates are tested ONE AT A TIME on purpose. The original plan set
+ * age-expired AND sd_key-mismatched simultaneously, which a half-implementation checking
+ * only one of them would pass. Each case below isolates a single reason.
+ *
+ * Each refusal also carries an ARMING ASSERTION that hasReapEligibleMarker is still true —
+ * i.e. the OLD predicate WOULD have authorised. Without it, a future change that stops
+ * writing the marker at all would make these tests pass while proving nothing.
+ */
+import { describe, test, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  writeReapEligibleMarker,
+  hasReapEligibleMarker,
+  isReapEligibleMarkerValid,
+  canonicalWorkKey,
+  DEFAULT_MARKER_TTL_MIN,
+} from '../../../lib/worktree-reaper/reap-eligible-marker.js';
+
+const NOW = 1_800_000_000_000;
+const MIN = 60 * 1000;
+let dir;
+
+/** Write a marker with an explicit age, bypassing writeReapEligibleMarker's own clock. */
+function markerAged({ minutesAgo, sd_key }) {
+  writeReapEligibleMarker(dir, { sd_key });
+  const p = path.join(dir, '.reap-eligible.json');
+  const payload = JSON.parse(fs.readFileSync(p, 'utf8'));
+  payload.marked_at = new Date(NOW - minutesAgo * MIN).toISOString();
+  fs.writeFileSync(p, JSON.stringify(payload, null, 2));
+}
+
+beforeEach(() => { dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fr3-marker-')); });
+afterEach(() => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+describe('FR-3 — the 21:34:48Z incident, replayed', () => {
+  test('FRESH marker naming a DIFFERENT SD than the tree does not authorise', () => {
+    // The incident shape verbatim: marker sd_key SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001
+    // on the tree that was actually holding scribe/rls-receipts work.
+    markerAged({ minutesAgo: 5, sd_key: 'SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001' });
+    expect(hasReapEligibleMarker(dir)).toBe(true); // ARMING: the old predicate said yes
+    const v = isReapEligibleMarkerValid(dir, { nowMs: NOW, treeKey: 'SD-FDBK-OTHER-001' });
+    expect(v.valid).toBe(false);
+    expect(v.reason).toBe('marker_sd_key_mismatch');
+  });
+
+  test('AGED marker whose sd_key MATCHES does not authorise — age alone is disqualifying', () => {
+    markerAged({ minutesAgo: DEFAULT_MARKER_TTL_MIN + 60, sd_key: 'SD-FDBK-SAME-001' });
+    expect(hasReapEligibleMarker(dir)).toBe(true); // ARMING
+    const v = isReapEligibleMarkerValid(dir, { nowMs: NOW, treeKey: 'SD-FDBK-SAME-001' });
+    expect(v.valid).toBe(false);
+    expect(v.reason).toBe('marker_expired_age');
+  });
+
+  test('OPPOSITE POLARITY: fresh AND matching still authorises — the post-merge handoff keeps working', () => {
+    // Without this, FR-3 would silently break the reap handoff every merge depends on.
+    markerAged({ minutesAgo: 5, sd_key: 'SD-FDBK-SAME-001' });
+    const v = isReapEligibleMarkerValid(dir, { nowMs: NOW, treeKey: 'SD-FDBK-SAME-001' });
+    expect(v.valid).toBe(true);
+    expect(v.detail.matched_key).toBe('SD-FDBK-SAME-001');
+  });
+});
+
+describe('FR-3 — the producer shapes that actually exist in the repo', () => {
+  test('a PATH-shaped sd_key resolves to its key and MATCHES (worktree-merge.js writes this)', () => {
+    // Treating this as unparseable would refuse legitimate markers — the exact
+    // false-expiry FR-3 exists to avoid. It reduces to a real key, so it authorises.
+    markerAged({ minutesAgo: 5, sd_key: '.worktrees/SD-FDBK-SAME-001' });
+    const v = isReapEligibleMarkerValid(dir, { nowMs: NOW, treeKey: 'SD-FDBK-SAME-001' });
+    expect(v.valid).toBe(true);
+  });
+
+  test('sd_key === null is CANNOT-VALIDATE, not mismatch, and does not authorise', () => {
+    markerAged({ minutesAgo: 5, sd_key: null });
+    const v = isReapEligibleMarkerValid(dir, { nowMs: NOW, treeKey: 'SD-FDBK-SAME-001' });
+    expect(v.valid).toBe(false);
+    expect(v.reason).toBe('marker_key_unverifiable'); // distinct from a real mismatch
+  });
+
+  test('a non-key basename (post-merge fallback shape) is cannot-validate, NOT a spurious mismatch', () => {
+    markerAged({ minutesAgo: 5, sd_key: 'wt-abc123' });
+    expect(isReapEligibleMarkerValid(dir, { nowMs: NOW, treeKey: 'SD-FDBK-SAME-001' }).reason)
+      .toBe('marker_key_unverifiable');
+  });
+
+  test('a keyless TREE (ceremony worktree) cannot be validated against either', () => {
+    markerAged({ minutesAgo: 5, sd_key: 'SD-FDBK-SAME-001' });
+    expect(isReapEligibleMarkerValid(dir, { nowMs: NOW, treeKey: 'scribe-rls-receipts' }).reason)
+      .toBe('marker_key_unverifiable');
+  });
+
+  test('a CORRUPT marker file is cannot-validate and does not throw', () => {
+    fs.writeFileSync(path.join(dir, '.reap-eligible.json'), '{ not json');
+    expect(hasReapEligibleMarker(dir)).toBe(true); // ARMING: presence still true
+    const v = isReapEligibleMarkerValid(dir, { nowMs: NOW, treeKey: 'SD-FDBK-SAME-001' });
+    expect(v.valid).toBe(false);
+    expect(v.reason).toBe('marker_unreadable');
+  });
+
+  test('an absent marker is reported as absent, not as an expiry', () => {
+    expect(isReapEligibleMarkerValid(dir, { nowMs: NOW, treeKey: 'SD-X-001' }).reason).toBe('marker_absent');
+  });
+});
+
+describe('FR-3 — contract details that break callers if wrong', () => {
+  test('nowMs and ttlMin default INTERNALLY — the reaper ctx supplies neither', () => {
+    // A destructure-and-assume signature would make every existing caller pass undefined.
+    markerAged({ minutesAgo: 1, sd_key: 'SD-FDBK-SAME-001' });
+    const p = path.join(dir, '.reap-eligible.json');
+    const payload = JSON.parse(fs.readFileSync(p, 'utf8'));
+    payload.marked_at = new Date().toISOString(); // real clock, so the internal default applies
+    fs.writeFileSync(p, JSON.stringify(payload));
+    expect(isReapEligibleMarkerValid(dir, { treeKey: 'SD-FDBK-SAME-001' }).valid).toBe(true);
+  });
+
+  test('hasReapEligibleMarker KEEPS its pure-presence contract', () => {
+    // Folding validation into it would break existing assertions that expect `true`
+    // on a branchless tmpdir.
+    markerAged({ minutesAgo: 10_000, sd_key: 'SD-WRONG-001' });
+    expect(hasReapEligibleMarker(dir)).toBe(true);
+  });
+
+  test('canonicalWorkKey normalizes case and path shape, and rejects non-keys', () => {
+    expect(canonicalWorkKey('sd-foo-001')).toBe('SD-foo-001');
+    expect(canonicalWorkKey('.worktrees/qf/QF-20260710-432')).toBe('QF-20260710-432');
+    expect(canonicalWorkKey('wt-abc')).toBeNull();
+    expect(canonicalWorkKey(null)).toBeNull();
+    expect(canonicalWorkKey('   ')).toBeNull();
+  });
+});

--- a/tests/unit/worktree-reaper/removal-decision.test.js
+++ b/tests/unit/worktree-reaper/removal-decision.test.js
@@ -1,0 +1,113 @@
+/**
+ * SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-B FR-1b — the composition.
+ *
+ * The load-bearing pair is the first two tests: unresolvable+resident must BLOCK, and
+ * unresolvable+cleared must REMOVE. Only the first would pass against the shipped FR-1
+ * (which vetoes unconditionally); only the second would pass against the original
+ * fail-open. A change that satisfies one and not the other is one of the two defects
+ * this FR sits between.
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  decideRemoval,
+  WORK_KEY_UNRESOLVABLE,
+  UNRESOLVABLE_KEY_RESIDENCY_CLEARED,
+} from '../../../lib/worktree-reaper/removal-decision.js';
+
+const clear = { blocked: false, reason: null };
+const unresolvable = { blocked: true, reason: WORK_KEY_UNRESOLVABLE };
+const resident = { blocked: true, reason: 'REAP_BLOCKED_TREE_RESIDENT' };
+
+describe('decideRemoval — the demand semantics', () => {
+  test('unresolvable key + RESIDENT => blocked (the ceremony trees survive)', () => {
+    const d = decideRemoval({ claimGuard: unresolvable, treeResidency: resident, heartbeatResidency: clear });
+    expect(d.remove).toBe(false);
+    expect(d.source).toBe('tree_residency');
+  });
+
+  test('unresolvable key + residency CLEARED => removed (the pool still drains)', () => {
+    // Against the shipped FR-1 this is false — an unresolvable basename would never be
+    // reaped again, which is permanent pool backlog rather than a fix.
+    const d = decideRemoval({ claimGuard: unresolvable, treeResidency: clear, heartbeatResidency: clear });
+    expect(d.remove).toBe(true);
+    expect(d.reason).toBe(UNRESOLVABLE_KEY_RESIDENCY_CLEARED);
+  });
+
+  test('unresolvable key + heartbeat residency blocking also blocks', () => {
+    const hb = { blocked: true, reason: 'REAP_BLOCKED_RESIDENT' };
+    const d = decideRemoval({ claimGuard: unresolvable, treeResidency: clear, heartbeatResidency: hb });
+    expect(d.remove).toBe(false);
+    expect(d.source).toBe('heartbeat_residency');
+  });
+});
+
+describe('decideRemoval — the demand does NOT leak to other reasons', () => {
+  // If it leaked, a real claim or a DB outage would become overridable by an idle tree —
+  // which would be a far worse fail-open than the one FR-1 closed.
+  test.each([
+    'live_claimed',
+    'unverifiable_no_supabase',
+    'unverifiable_claim_lookup_error',
+    'unverifiable_session_lookup_error',
+    'unverifiable_session_scan_error',
+    'unverifiable_guard_exception',
+    'claimed_claimant_not_verifiably_alive',
+    'live_session_pointing',
+  ])('%s stays an ABSOLUTE veto even with residency fully cleared', (reason) => {
+    const d = decideRemoval({
+      claimGuard: { blocked: true, reason },
+      treeResidency: clear,
+      heartbeatResidency: clear,
+    });
+    expect(d.remove).toBe(false);
+    expect(d.reason).toBe(reason);
+    expect(d.source).toBe('claim');
+  });
+});
+
+describe('decideRemoval — the ordinary paths are unchanged', () => {
+  test('all clear => removed', () => {
+    expect(decideRemoval({ claimGuard: clear, treeResidency: clear, heartbeatResidency: clear }))
+      .toEqual({ remove: true, reason: null, source: null });
+  });
+
+  test('claim clear but resident => blocked (residency was always a veto and stays one)', () => {
+    const d = decideRemoval({ claimGuard: clear, treeResidency: resident, heartbeatResidency: clear });
+    expect(d.remove).toBe(false);
+    expect(d.source).toBe('tree_residency');
+  });
+
+  test('a verified no_live_claim clear is not confused with an unresolvable key', () => {
+    const d = decideRemoval({
+      claimGuard: { blocked: false, reason: 'no_live_claim' },
+      treeResidency: clear,
+      heartbeatResidency: clear,
+    });
+    expect(d.remove).toBe(true);
+    expect(d.reason).toBeNull(); // NOT the unresolvable-key reason
+  });
+});
+
+describe('decideRemoval — a forgotten guard refuses rather than deletes', () => {
+  test.each(['claimGuard', 'treeResidency', 'heartbeatResidency'])('omitting %s fails CLOSED', (missing) => {
+    const input = { claimGuard: clear, treeResidency: clear, heartbeatResidency: clear };
+    delete input[missing];
+    const d = decideRemoval(input);
+    expect(d.remove).toBe(false);
+    expect(d.reason).toMatch(/^guard_result_missing:/);
+  });
+
+  test('a malformed guard result (no boolean blocked) also fails closed', () => {
+    const d = decideRemoval({
+      claimGuard: { reason: 'looks plausible but has no verdict' },
+      treeResidency: clear,
+      heartbeatResidency: clear,
+    });
+    expect(d.remove).toBe(false);
+    expect(d.reason).toBe('guard_result_missing:claim');
+  });
+
+  test('called with no arguments at all, it refuses', () => {
+    expect(decideRemoval().remove).toBe(false);
+  });
+});

--- a/tests/unit/worktree-reaper/residency-kill-switch.test.js
+++ b/tests/unit/worktree-reaper/residency-kill-switch.test.js
@@ -1,0 +1,87 @@
+/**
+ * SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-B FR-6 — the kill switch is a fourth
+ * fail-open, and an acceptance run must assert its own state.
+ *
+ * WORKTREE_RESIDENCY_GUARD=off makes the residency guards return blocked:false outright.
+ * A green acceptance result with the switch off proves nothing — it may only mean the
+ * guard was disabled. This child originally listed three fail-opens and did not include
+ * this one, and no smoke step asserted the switch state.
+ *
+ * It gates THREE call sites, not the one the plan named: cwdResidencyBlocks (the SYNC
+ * chokepoint on every delete path), heartbeatResidencyBlocksRemoval, and the new
+ * treeResidencyBlocksRemoval. All three are asserted here.
+ */
+import { describe, test, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  cwdResidencyBlocks,
+  treeResidencyBlocksRemoval,
+  REAP_BLOCKED_RESIDENT,
+  REAP_BLOCKED_TREE_RESIDENT,
+} from '../../../lib/worktree-reaper/residency-guard.js';
+
+const quiet = () => {};
+const original = process.env.WORKTREE_RESIDENCY_GUARD;
+afterEach(() => {
+  if (original === undefined) delete process.env.WORKTREE_RESIDENCY_GUARD;
+  else process.env.WORKTREE_RESIDENCY_GUARD = original;
+});
+
+describe('FR-6 — the acceptance run asserts its own guard state', () => {
+  test('WORKTREE_RESIDENCY_GUARD is NOT disabled while this suite runs', () => {
+    // If this fails, every other residency assertion in this SD is meaningless.
+    const v = String(process.env.WORKTREE_RESIDENCY_GUARD || '').toLowerCase();
+    expect(['off', '0', 'false']).not.toContain(v);
+  });
+});
+
+describe('FR-6 — the switch really does disable all three guards', () => {
+  // Asserted rather than assumed: this is what makes the check above load-bearing.
+  test('cwdResidencyBlocks bypasses when off (the SYNC chokepoint on every delete path)', () => {
+    const dir = process.cwd();
+    process.env.WORKTREE_RESIDENCY_GUARD = 'off';
+    const off = cwdResidencyBlocks(dir, { cwd: dir, logger: quiet });
+    expect(off.blocked).toBe(false);
+    expect(off.bypassed).toBe(true);
+
+    delete process.env.WORKTREE_RESIDENCY_GUARD;
+    const on = cwdResidencyBlocks(dir, { cwd: dir, logger: quiet });
+    expect(on.blocked).toBe(true);
+    expect(on.reason).toBe(REAP_BLOCKED_RESIDENT);
+  });
+
+  test('treeResidencyBlocksRemoval bypasses when off', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'fr6-'));
+    try {
+      const now = Date.now();
+      const opts = { nowMs: now, statFn: () => ({ mtimeMs: now - 1000 }), gitRunner: () => ({ code: 128, stdout: '' }), logger: quiet };
+
+      delete process.env.WORKTREE_RESIDENCY_GUARD;
+      const on = treeResidencyBlocksRemoval(dir, opts);
+      expect(on.blocked).toBe(true);
+      expect(on.reason).toBe(REAP_BLOCKED_TREE_RESIDENT);
+
+      process.env.WORKTREE_RESIDENCY_GUARD = 'off';
+      const off = treeResidencyBlocksRemoval(dir, opts);
+      expect(off.blocked).toBe(false);
+      expect(off.bypassed).toBe(true);
+    } finally {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
+  test.each(['off', '0', 'false'])('the disabling spellings are all honoured: %s', (val) => {
+    const dir = process.cwd();
+    process.env.WORKTREE_RESIDENCY_GUARD = val;
+    expect(cwdResidencyBlocks(dir, { cwd: dir, logger: quiet }).bypassed).toBe(true);
+  });
+
+  test('an unrelated value does NOT disable the guard', () => {
+    // A typo'd value must fail SAFE — otherwise the switch is easier to trip than to set.
+    process.env.WORKTREE_RESIDENCY_GUARD = 'on';
+    const dir = process.cwd();
+    expect(cwdResidencyBlocks(dir, { cwd: dir, logger: quiet }).blocked).toBe(true);
+  });
+});

--- a/tests/unit/worktree-reaper/tree-residency-guard.test.js
+++ b/tests/unit/worktree-reaper/tree-residency-guard.test.js
@@ -1,0 +1,174 @@
+/**
+ * SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-B FR-2 — tree residency.
+ *
+ * FIXTURE CONSTRUCTION IS THE TEST. Two traps were MEASURED at PLAN, and getting either
+ * wrong makes this suite pass against broken code:
+ *
+ *  - An ISOLATED tmpdir is VACUOUS. `git log` there exits 128, headMs stays 0, and the
+ *    guarded and unguarded implementations agree. The orphan MUST be nested inside a real
+ *    git repo whose HEAD moved recently, or the walk-up never happens and nothing is proved.
+ *    (Every pre-existing fixture in worktree-residency-guard.test.js is the vacuous shape.)
+ *
+ *  - A FRESHLY-CREATED directory has mtime = now, so a CORRECT implementation reports it
+ *    resident. Backdate the orphan AFTER writing its children or the test false-REDs against
+ *    working code.
+ *
+ * Each polarity test carries an ARMING ASSERTION: it asserts the raw unguarded signal that
+ * WOULD have produced the wrong answer. If a future edit quiets the trap, the arming
+ * assertion fails loudly instead of this suite silently going vacuous.
+ */
+import { describe, test, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import {
+  treeResidencyBlocksRemoval,
+  REAP_BLOCKED_TREE_RESIDENT,
+  REAP_RESIDENCY_UNKNOWN,
+  DEFAULT_RESIDENCY_WINDOW_MIN,
+} from '../../../lib/worktree-reaper/residency-guard.js';
+
+const MIN = 60 * 1000;
+
+// The injected clock is DERIVED from the fixture's own commit rather than hard-coded.
+// git stamps %ct with the real committer clock (GIT_COMMITTER_DATE, not --date), so a
+// hard-coded constant sits an arbitrary distance from it and every signal reads stale —
+// which silently turns the whole suite green-for-the-wrong-reason. Anchoring NOW one
+// minute after the parent commit keeps the run deterministic (nowMs is still injected
+// everywhere; nothing reads the wall clock at assertion time) AND keeps it truthful.
+let NOW;
+const git = (args, cwd) => execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+
+let root;        // the parent git repo
+let orphanDir;   // .git-LESS dir nested inside it — the walk-up victim
+let realWt;      // a genuine worktree root
+
+/** Backdate a directory so a correct implementation does NOT call it resident. */
+function backdate(dir, minutesAgo) {
+  const t = new Date(NOW - minutesAgo * MIN);
+  fs.utimesSync(dir, t, t);
+}
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'fr2-parent-'));
+  git(['init', '-q', '-b', 'main'], root);
+  git(['config', 'user.email', 'fr2@test.local'], root);
+  git(['config', 'user.name', 'FR2 Fixture'], root);
+  fs.writeFileSync(path.join(root, 'seed.txt'), 'seed');
+  git(['add', '-A'], root);
+  git(['commit', '-q', '-m', 'seed'], root);
+
+  // Anchor the injected clock to the commit git actually recorded. Parent HEAD is then
+  // RECENT by construction — and that recency is the entire walk-up mechanism.
+  // (A dirty parent tree is decorative: it affects neither `log -1` nor `--show-toplevel`.)
+  NOW = Number(git(['log', '-1', '--format=%ct'], root).trim()) * 1000 + 1 * MIN;
+
+  orphanDir = path.join(root, '.worktrees', 'scribe-privesc-20260731');
+  fs.mkdirSync(orphanDir, { recursive: true });
+  fs.writeFileSync(path.join(orphanDir, 'leftover.txt'), 'stranded');
+  backdate(orphanDir, 24 * 60); // children first, THEN backdate
+
+  realWt = path.join(root, '.worktrees', 'SD-REAL-001');
+  git(['worktree', 'add', '-q', '-b', 'feat/SD-REAL-001', realWt], root);
+});
+
+afterAll(() => {
+  try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe('treeResidencyBlocksRemoval — the walk-up trap', () => {
+  test('ARMING: the unguarded HEAD probe really does return the PARENT repo time for a .git-less dir', () => {
+    // If this ever stops holding, the guard below is testing nothing.
+    const orphanHead = Number(git(['log', '-1', '--format=%ct'], orphanDir).trim());
+    const parentHead = Number(git(['log', '-1', '--format=%ct'], root).trim());
+    expect(orphanHead).toBe(parentHead);
+    expect(NOW - orphanHead * 1000).toBeLessThan(DEFAULT_RESIDENCY_WINDOW_MIN * MIN);
+    expect(fs.existsSync(path.join(orphanDir, '.git'))).toBe(false);
+  });
+
+  test('a .git-less orphan is NOT resident, even though its parent just committed', () => {
+    const r = treeResidencyBlocksRemoval(orphanDir, { nowMs: NOW });
+    expect(r.blocked).toBe(false);
+    expect(r.detail.is_worktree_root).toBe(false);
+    expect(r.detail.age_ms).toBeGreaterThan(DEFAULT_RESIDENCY_WINDOW_MIN * MIN);
+  });
+
+  test('an injected walk-up gitRunner cannot resurrect the trap', () => {
+    // Emulates the unguarded implementation: --show-toplevel answers with the PARENT.
+    const walkUp = (args) => args[0] === 'rev-parse'
+      ? { code: 0, stdout: root }
+      : { code: 0, stdout: String(Math.floor((NOW - MIN) / 1000)) };
+    const r = treeResidencyBlocksRemoval(orphanDir, { nowMs: NOW, gitRunner: walkUp });
+    expect(r.blocked).toBe(false); // toplevel !== wtPath, so HEAD is never consulted
+  });
+});
+
+describe('treeResidencyBlocksRemoval — the polarity that keeps it honest', () => {
+  test('a GENUINE worktree root whose HEAD just moved IS resident (guards against always-clear)', () => {
+    // This is the C2 case: --show-toplevel yields forward slashes on Windows while
+    // path.resolve yields backslashes, so a naive === compare fails HERE and the guard
+    // silently degenerates to always-clear while still passing the orphan tests above.
+    const r = treeResidencyBlocksRemoval(realWt, { nowMs: NOW });
+    expect(r.detail.is_worktree_root).toBe(true);
+    expect(r.blocked).toBe(true);
+    expect(r.reason).toBe(REAP_BLOCKED_TREE_RESIDENT);
+  });
+
+  test('ARMING: the real toplevel and the path differ textually, so the comparison must normalize', () => {
+    const toplevel = git(['rev-parse', '--show-toplevel'], realWt).trim();
+    expect(path.resolve(toplevel).toLowerCase()).toBe(path.resolve(realWt).toLowerCase());
+  });
+
+  test('a genuine worktree with BOTH signals stale is not resident — the pool still drains', () => {
+    const r = treeResidencyBlocksRemoval(realWt, {
+      nowMs: NOW,
+      statFn: () => ({ mtimeMs: NOW - 48 * 60 * MIN }),
+      gitRunner: (args) => args[0] === 'rev-parse'
+        ? { code: 0, stdout: realWt }
+        : { code: 0, stdout: String(Math.floor((NOW - 48 * 60 * MIN) / 1000)) },
+    });
+    expect(r.blocked).toBe(false);
+  });
+
+  test('recent mtime alone blocks, with no git signal at all', () => {
+    const r = treeResidencyBlocksRemoval(orphanDir, {
+      nowMs: NOW,
+      statFn: () => ({ mtimeMs: NOW - 2 * MIN }),
+      gitRunner: () => ({ code: 128, stdout: '' }),
+    });
+    expect(r.blocked).toBe(true);
+    expect(r.detail.head_ms).toBe(0);
+  });
+});
+
+describe('treeResidencyBlocksRemoval — degenerate inputs', () => {
+  test('a pruned worktree (git fails outright) falls through to mtime without throwing', () => {
+    const r = treeResidencyBlocksRemoval(orphanDir, {
+      nowMs: NOW,
+      gitRunner: () => ({ code: 128, stdout: '' }),
+    });
+    expect(r.blocked).toBe(false); // orphan was backdated 24h
+    expect(r.reason).toBeNull();
+  });
+
+  test('a missing directory is not resident (absent is not occupied)', () => {
+    const r = treeResidencyBlocksRemoval(path.join(root, 'no-such-dir'), { nowMs: NOW });
+    expect(r.blocked).toBe(false);
+  });
+
+  test('a THROW still fails CLOSED — unlike a non-zero git exit', () => {
+    const r = treeResidencyBlocksRemoval(realWt, {
+      nowMs: NOW,
+      gitRunner: () => { throw new Error('boom'); },
+    });
+    expect(r.blocked).toBe(true);
+    expect(r.reason).toBe(REAP_RESIDENCY_UNKNOWN);
+  });
+
+  test('the window is configurable and respected in both directions', () => {
+    const opts = { nowMs: NOW, statFn: () => ({ mtimeMs: NOW - 45 * MIN }), gitRunner: () => ({ code: 128, stdout: '' }) };
+    expect(treeResidencyBlocksRemoval(orphanDir, { ...opts, windowMin: 60 }).blocked).toBe(true);
+    expect(treeResidencyBlocksRemoval(orphanDir, { ...opts, windowMin: 30 }).blocked).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Three worktree-reaper guards each treated an input they **could not validate** as permission to delete, and all three produced live removals of in-use trees on 2026-07-31. This closes them on one invariant: **a venue with a live occupant is not reapable, by any addressing scheme.**

- **FR-1** — `liveClaimBlocksRemoval` returned `blocked:false` for any basename that resolved to no work key: the sole fail-open in a module whose other eight returns fail closed. Both real incident basenames are pinned as regression fixtures.
- **FR-1b** — but the guards were AND-composed with a bare `continue`, so FR-1's honest refusal became an absolute veto and an unresolvable basename would never be reaped again — data-loss converted into permanent pool backlog. `work_key_unresolvable` is now a *demand* that residency affirmatively clear. All eight other blocked reasons stay absolute vetoes, pinned so the demand cannot widen.
- **FR-2** — occupancy asked of the filesystem, needing no DB row to agree with reality. This is the only predicate available to a tree with no derivable key: `keyFromWorktree` reads the branch but only for `feat|qf|fix|chore|hotfix`, so a ceremony branch resolves under neither scheme. Implements the residency protection QF-20260725-821 ranked as the general fix and deferred.
- **FR-3** — a marker written 5.5h earlier by a different session, naming a different SD, authorised deleting the RLS ceremony tree. `sd_key` and `marked_at` were parsed, recorded, and read by no predicate.
- **FR-4/5/6** — closed an unguarded filesystem deleter, widened the anti-recurrence guard to see the FS delete primitive (it grepped only `git worktree remove`), and made acceptance assert the residency kill switch rather than assume it.
- **FR-7** — the declared SSOT for "is this safe to remove?" reported a tree whose git commands merely *failed* as clean **and** fully pushed. It gates four removal paths.

## Review findings, all fixed in-branch

TESTING and SECURITY both returned CONDITIONAL_PASS; RETRO added one more.

- **A regression I introduced and missed** — FR-7 made a pruned/`.git`-less tree permanently unreapable (the stranding shape this SD family exists to fix, re-created one layer down) and broke `cleanup-pending-sweep`. Root cause was collapsing a three-way distinction into two: git can't answer / git answers about an *ancestor* / git answers about *this tree*.
- **SEC-01 (reproduced destroying a real file)** — the containment check added in FR-4 was lexical, so a junction in an intermediate path segment escaped it. Now realpath-based, and the *resolved* path is what gets deleted.
- **SEC-03/05/07** — a stat error became evidence of absence (on Windows, `EPERM`/`EBUSY` correlate with occupancy); a future timestamp blocked forever; `canonicalWorkKey` cased only the prefix so the same key could report the loudest mismatch reason.
- **F2** — three FRs were correct but **not wired**: mutating the production call sites left CI fully green.
- **RETRO-F1** — the test named "FR-5 guard is not vacuous" did not invoke the guard.

Six of my own written claims were wrong and are corrected in place rather than dropped, including a junction threat premise that isn't reproducible on Node v24 — a false premise that pointed readers at a safe route and away from the real one.

## Test plan

- **282 tests across 26 suites**, including `cleanup-pending-sweep` (previously outside my glob, which is how the regression hid).
- **Every fix mutation-verified**: reverting each turns its own tests red, with the mutation confirmed applied by byte count — two earlier mutants "survived" only because the edit silently never applied.
- Ground-truth verified rather than asserted: pruned worktree reapable while owned-but-failing stays unverifiable; the junction escape refused with the victim file intact; planted violators detected at the correct line in both single- and multi-line form.

**Disclosed:** `tests/integration/worktree-reaper.test.js` is listed in the PRD's acceptance suites and **did not run** — the `db` vitest project is gated closed when no non-production DB target is authorised. Configured and reachable, not broken; recorded in the SD as CORR-1 rather than implied as covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
