### PR TITLE
fix(SD-LEO-INFRA-REAPER-GH-SHELL-INJECTION-001): a branch name is not a command — close shell injection in both gh runners

### DIFF
--- a/lib/claim/wip-detector.cjs
+++ b/lib/claim/wip-detector.cjs
@@ -30,6 +30,31 @@ function defaultRunGit(args, opts = {}) {
   return { stdout: res.stdout || '', stderr: res.stderr || '', code: res.status == null ? 1 : res.status };
 }
 
+/**
+ * SD-LEO-INFRA-REAPER-GH-SHELL-INJECTION-001 (FR-2) — the SECOND live instance.
+ *
+ * `shell: process.platform === 'win32'` USED TO BE HERE too. hasOpenPr below puts a raw
+ * BRANCH NAME into this argv, so on Windows a branch name was a command, exactly as in the
+ * reaper. The docblock above says this file "mirrors scripts/worktree-reaper.mjs's
+ * runGit/runGh" — it mirrored the defect as well.
+ *
+ * IT WAS ALREADY KNOWN AND STILL SHIPPED, which is the part worth recording:
+ * lib/fleet/inflight-git-state.cjs documents this exact line as defective and says the
+ * claim that this module "already satisfies SR-1" is false on this platform. That prose
+ * sat in another file while the defect stayed live, because no gate reads prose — there is
+ * no lint covering shell:true anywhere in scripts/lint/, despite 20+ bespoke allowlist
+ * lints there. It was only fixed once someone scoped it into an SD.
+ *
+ * The fail DIRECTION here is inverted from the reaper's and stays that way: a JSON parse
+ * failure below returns has-WIP=true, so corrupt output blocks a claim steal rather than
+ * permitting a reap. That makes the consequence a claim-takeover DoS rather than deletion
+ * — but the command execution was identical, and that is what this change closes.
+ *
+ * No shell is needed: gh is a native .exe and resolves fine without one (measured on this
+ * fleet; several callers here already do it). Note this runner returns a code rather than
+ * throwing — unlike the reaper's — so a missing binary surfaces as a non-zero code and is
+ * handled by the existing fail-safe path.
+ */
 function defaultRunGh(args, opts = {}) {
   const { spawnSync } = require('child_process');
   const res = spawnSync('gh', args, {
@@ -37,7 +62,6 @@ function defaultRunGh(args, opts = {}) {
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
     windowsHide: true,
-    shell: process.platform === 'win32',
     timeout: opts.timeout || 10000,
   });
   return { stdout: res.stdout || '', stderr: res.stderr || '', code: res.status == null ? 1 : res.status };
@@ -116,4 +140,8 @@ function hasWip(worktreePath, branch, repo, deps = {}) {
   return { hasWip: reasons.length > 0, reasons };
 }
 
-module.exports = { hasWip, hasUnpushedCommits, hasOpenPr };
+// defaultRunGh/defaultRunGit are exported for TESTING ONLY (FR-2/FR-3). They are the
+// DEFAULT runners, so a test that asserts their spawn options is asserting production
+// behaviour; a seam-injected fake cannot, because the seam replaces the code that
+// decides those options. Production callers should keep using hasWip/hasOpenPr.
+module.exports = { hasWip, hasUnpushedCommits, hasOpenPr, defaultRunGh, defaultRunGit };

--- a/lib/claim/wip-detector.cjs
+++ b/lib/claim/wip-detector.cjs
@@ -78,7 +78,11 @@ function defaultRunGh(args, opts = {}) {
 function hasUnpushedCommits(branch, opts, runGit) {
   if (!branch) return false;
   try {
-    const res = runGit(['cherry', 'origin/main', branch], { cwd: opts.cwd });
+    // `--` separates options from the ref: check-ref-format PERMITS a leading dash, so a
+    // branch named `-v` or `--abbrev=7` would otherwise be consumed by git as a FLAG and the
+    // positional would silently vanish. Removing the shell stops a branch being a command;
+    // it does not stop a branch being an option. Same fix as detectors.js, same reason.
+    const res = runGit(['cherry', 'origin/main', '--', branch], { cwd: opts.cwd });
     if (res.code !== 0) return true; // fail-safe: unknown -> assume WIP
     return (res.stdout || '').split('\n').some((l) => l.trim().startsWith('+'));
   } catch {

--- a/lib/worktree-reaper/detectors.js
+++ b/lib/worktree-reaper/detectors.js
@@ -282,6 +282,22 @@ export async function isPatchEquivalentToMain(wt, ctx) {
       { cwd: ctx.repoRoot },
     );
   } catch (err) {
+    // SD-LEO-INFRA-REAPER-GH-SHELL-INJECTION-001 (FR-6): THIS BRANCH WAS DEAD CODE ON
+    // WINDOWS AND IS NOW REACHABLE AGAIN. Under the old `shell: win32` in runGh, a missing
+    // gh returned status 1 with res.error UNSET, so runGh never threw and this catch never
+    // fired. Removing the shell re-arms it. Recorded here rather than only at the runner,
+    // because this is where a reader of the changed behaviour looks.
+    //
+    // It does NOT widen removal authority — measured, not argued: the evidence below
+    // carries no merged_pr_count, so decideShippedStaleAction's `?? 0` takes the same
+    // zero-branch a gh returning [] would take. Identical routing, identical action.
+    //
+    // But be precise about what "safe" means here, because the first version of this SD's
+    // prose said "degrades to a recorded advisory, never to silence" and that was WRONG: an
+    // unknown key degrades to advisory-only, while a TERMINAL-status key reaches STAGE-1
+    // REMOVE AUTHORITY through that same zero-branch. What is actually lost on a host where
+    // gh cannot spawn is the GitHub cross-check this function's own docblock promises —
+    // fleet-wide, silently — while terminal-key removals proceed on cherry evidence alone.
     return {
       matched: true,
       reason: 'patch_equivalent_gh_unavailable',

--- a/lib/worktree-reaper/detectors.js
+++ b/lib/worktree-reaper/detectors.js
@@ -229,10 +229,24 @@ export async function isPatchEquivalentToMain(wt, ctx) {
     throw new Error('isPatchEquivalentToMain requires ctx.runGit and ctx.runGh');
   }
 
-  // cherry -v origin/main <branch>
+  // cherry -v origin/main -- <branch>
+  //
+  // SD-LEO-INFRA-REAPER-GH-SHELL-INJECTION-001: the `--` is load-bearing and is the ARGUMENT
+  // injection this SD's shell fix does NOT address. Removing a shell stops a branch being a
+  // COMMAND; it does not stop a branch being an OPTION. git check-ref-format PERMITS a
+  // leading dash, and SECURITY measured the consequence: with branch `--abbrev=7` or `-v`,
+  // git consumes it as a flag, the positional vanishes, and cherry silently compares
+  // repoRoot's HEAD (main) against origin/main — returning rc=0 with empty stdout, which
+  // reads as allAbsorbed=true. A branch that was never examined is reported "fully
+  // absorbed", and with a terminal-status key that reaches stage1_remove.
+  //
+  // Latent rather than remotely triggerable: `git worktree add <path> refs/heads/--x` yields
+  // a DETACHED worktree (short-circuited as branch_unresolved) and `worktree add -b '--x'`
+  // fails, so attaching one needs local .git write. Closed anyway because the cost is one
+  // token and the failure mode is a silent false "absorbed" verdict on a delete path.
   let cherry;
   try {
-    cherry = ctx.runGit(['cherry', '-v', 'origin/main', branch], { cwd: ctx.repoRoot });
+    cherry = ctx.runGit(['cherry', '-v', 'origin/main', '--', branch], { cwd: ctx.repoRoot });
   } catch (err) {
     return {
       matched: false,

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -604,10 +604,19 @@ function runGit(args, opts = {}) {
  * carries `shell: false, // SR-1 — do not remove` plus measured live timings.
  *
  * RESIDUAL, left as an assertion rather than an assumption: the refutation holds because
- * gh is a .exe. A .cmd/.bat shim (scoop/winget) would ENOENT under shell:false — but that
- * surfaces as res.error, which throws below, which detectors.js turns into the DOCUMENTED
- * patch_equivalent_gh_unavailable advisory. Worst case degrades to a recorded advisory,
- * never to silence.
+ * gh is a .exe. A .cmd/.bat shim (scoop/winget) would ENOENT under shell:false — that
+ * surfaces as res.error, throws below, and detectors.js turns it into the documented
+ * patch_equivalent_gh_unavailable path.
+ *
+ * CORRECTED BY SECURITY, because the first version of this comment said "worst case
+ * degrades to a recorded advisory, never to silence" and that is WRONG. Measured: an
+ * unknown key does degrade to advisory-only, but a TERMINAL-status key reaches STAGE-1
+ * REMOVE AUTHORITY, because the fail-open returns evidence with no merged_pr_count and the
+ * `?? 0` at the terminal override treats that as zero. It is NOT a widening — a gh that
+ * returns [] decides identically, so the security delta is nil — but what is lost on a
+ * .cmd-only host is the GitHub cross-check itself, fleet-wide, while terminal-key removals
+ * proceed on cherry evidence alone. Stating that accurately matters more than the comfort
+ * of the shorter sentence.
  *
  * DO NOT "simplify" the throw below into a returned error: detectors.js depends on the
  * throw and tests/unit/worktree-reaper/detectors.test.js pins it. Exported so a test can

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -577,13 +577,49 @@ function runGit(args, opts = {}) {
   };
 }
 
-function runGh(args, opts = {}) {
+/**
+ * SD-LEO-INFRA-REAPER-GH-SHELL-INJECTION-001 (FR-1).
+ *
+ * `shell: process.platform === 'win32'` USED TO BE HERE, and it made this an arbitrary
+ * command execution primitive inside an unattended scheduled process. With a shell, Node
+ * does not pass argv as discrete arguments — it CONCATENATES them into a command string,
+ * which Node itself warns about (DEP0190). detectors.js interpolates a BRANCH NAME into
+ * these args, so a branch name was a command.
+ *
+ * Reproduced independently by three parties: branch `feat/x& echo MARKER` produced stdout
+ * `MARKER --state merged --json ...` — the injected command ran, ate the remaining
+ * arguments, and exited 0.
+ *
+ * WHY THE SEVERITY IS NOT MERELY "SOMETHING EXECUTES": the attacker also controls stdout.
+ * A payload emitting VALID merged-PR JSON yields merged_pr_count >= 1, which
+ * decideShippedStaleAction routes to 'merged-pr-backed' and stageForCategories turns into
+ * stage1_remove — the path labelled "auto-safe" in this file. Forged merge evidence drives
+ * deletion. (The MALFORMED case is fail-safe: JSON.parse fails, prs=[], advisory-only.)
+ *
+ * THE FLAG WAS NOT LOAD-BEARING, and that was MEASURED rather than assumed, because the
+ * plausible objection is that Windows needs a shell to resolve `gh`. It does not: gh is a
+ * native .exe, libuv appends the extension, and both `gh --version` and the real
+ * classification argv return status 0 under shell:false on this fleet. Seven callers in
+ * this repo already invoke gh with no shell — see lib/fleet/inflight-git-state.cjs, which
+ * carries `shell: false, // SR-1 — do not remove` plus measured live timings.
+ *
+ * RESIDUAL, left as an assertion rather than an assumption: the refutation holds because
+ * gh is a .exe. A .cmd/.bat shim (scoop/winget) would ENOENT under shell:false — but that
+ * surfaces as res.error, which throws below, which detectors.js turns into the DOCUMENTED
+ * patch_equivalent_gh_unavailable advisory. Worst case degrades to a recorded advisory,
+ * never to silence.
+ *
+ * DO NOT "simplify" the throw below into a returned error: detectors.js depends on the
+ * throw and tests/unit/worktree-reaper/detectors.test.js pins it. Exported so a test can
+ * observe the REAL spawn options — a seam-injected fake cannot, because the seam replaces
+ * the very code that decides them.
+ */
+export function runGh(args, opts = {}) {
   const res = spawnSync('gh', args, {
     cwd: opts.cwd || process.cwd(),
     encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
     windowsHide: true,
-    shell: process.platform === 'win32',
   });
   if (res.error) throw res.error;
   return {

--- a/tests/unit/worktree-reaper/gh-shell-injection.test.js
+++ b/tests/unit/worktree-reaper/gh-shell-injection.test.js
@@ -1,0 +1,216 @@
+/**
+ * SD-LEO-INFRA-REAPER-GH-SHELL-INJECTION-001 — a branch name must not be a command.
+ *
+ * WHY THIS TEST IS SHAPED THE WAY IT IS. The obvious test — grep the source for
+ * `shell:` — pins a FACT, not a BEHAVIOUR, and this repo has already paid for that:
+ * tests/unit/fleet/inflight-git-state.test.js records THREE unsafe refactors that passed a
+ * source-grep-only version, including hoisting `const IS_WIN` out and writing
+ * `shell: IS_WIN` — the exact shape lib/claim/wip-detector.cjs contained until this SD.
+ *
+ * A seam-injected fake is equally useless here: it replaces the very code that decides the
+ * spawn options, so it can never observe them. Every existing test in detectors.test.js
+ * injects runGh and therefore cannot see this defect at all.
+ *
+ * So these drive the REAL default runners against a REAL child process and assert what
+ * actually arrived. `runGh` is exported for exactly this reason.
+ */
+import { describe, test, expect, beforeAll, afterAll, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { spawnSync } from 'child_process';
+
+// Spy on the module the REAL runners spawn through, so the assertions below observe the
+// options `runGh` actually passes rather than options a test constructed for itself.
+//
+// THE FIRST DRAFT OF THIS FILE DID NOT DO THIS AND WAS VACUOUS. It spawned a probe with
+// hand-written option objects and asserted argv survived — which proves a fact about Node,
+// not a fact about runGh. Re-introducing `shell: process.platform === 'win32'` at the real
+// call site left all five tests GREEN (mutation verified applied, +42 bytes). Caught only
+// by running the mutation. This is the same correct-but-not-wired failure the sibling SD
+// spent a commit fixing; the lesson did not transfer on its own.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...actual, spawnSync: vi.fn(actual.spawnSync) };
+});
+
+const { spawnSync: spiedSpawnSync } = await import('node:child_process');
+const { runGh } = await import('../../../scripts/worktree-reaper.mjs');
+
+// A branch name git itself accepts: check-ref-format forbids space, ~, ^, :, ?, *, [ and
+// backslash, but PERMITS & — which is all cmd.exe needs to chain a command.
+const HOSTILE_BRANCH = 'feat/x&echo PWNED';
+
+let dir, argvProbe, sentinel;
+
+beforeAll(() => {
+  dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ghinj-'));
+  // Stand-in for `gh`: reports the argv it actually received.
+  argvProbe = path.join(dir, 'argv-probe.cjs');
+  fs.writeFileSync(argvProbe, 'process.stdout.write(JSON.stringify(process.argv.slice(2)));\n');
+  sentinel = path.join(dir, 'PWNED.txt');
+});
+
+afterAll(() => { try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ } });
+
+/** Run the probe through node with the SAME options the fixed runners use. */
+const runProbeNoShell = (args) => spawnSync(process.execPath, [argvProbe, ...args], {
+  encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true,
+});
+
+/** The OLD options, kept only so the assertions below have something to discriminate against. */
+const runProbeWithShell = (args) => spawnSync(process.execPath, [argvProbe, ...args], {
+  encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true,
+  shell: process.platform === 'win32',
+});
+
+const classificationArgs = (branch) => [
+  'pr', 'list', '--search', `head:${branch}`, '--state', 'merged', '--json', 'number,state,mergedAt',
+];
+
+describe('argv integrity — a hostile branch arrives as ONE element', () => {
+  test('no-shell spawn delivers the branch byte-identically, trailing args intact', () => {
+    const args = classificationArgs(HOSTILE_BRANCH);
+    const res = runProbeNoShell(args);
+    expect(res.status).toBe(0);
+    expect(JSON.parse(res.stdout)).toEqual(args);
+  });
+
+  test('ARMING: the same call WITH a shell executes the payload — proving this suite discriminates', () => {
+    // If this ever stops holding, the assertion above is no longer evidence of anything.
+    if (process.platform !== 'win32') return; // shell:false on POSIX — nothing to contrast
+    const stdout = runProbeWithShell(classificationArgs(HOSTILE_BRANCH)).stdout || '';
+    // Deliberately NOT JSON.parse'd. The first draft of this test parsed it and threw,
+    // which is the finding stated more sharply than the assertion was: with a shell the
+    // injected `echo` does not merely REORDER argv, it REPLACES the process output — the
+    // probe's JSON never reaches stdout at all. Assert on the raw bytes.
+    expect(stdout).toContain('PWNED');
+    expect(stdout.trimStart().startsWith('[')).toBe(false);
+  });
+});
+
+describe('negative canary — absence of EXECUTION, not absence of a string', () => {
+  test('a payload that would create a sentinel file does not run', () => {
+    const payload = `feat/x&type nul > "${sentinel}"`;
+    runProbeNoShell(classificationArgs(payload));
+    expect(fs.existsSync(sentinel)).toBe(false);
+  });
+
+  test('ARMING: the same payload DOES create the sentinel when a shell is present', () => {
+    if (process.platform !== 'win32') return;
+    const withShell = path.join(dir, 'SHELL_PROOF.txt');
+    runProbeWithShell(classificationArgs(`feat/x&type nul > "${withShell}"`));
+    // Proves the canary above is capable of failing — otherwise it asserts nothing.
+    expect(fs.existsSync(withShell)).toBe(true);
+    try { fs.rmSync(withShell, { force: true }); } catch { /* best effort */ }
+  });
+});
+
+describe('THE LOAD-BEARING ASSERTION — the real runners spawn without a shell', () => {
+  // Everything above demonstrates WHY a shell is dangerous. Only these observe what the
+  // production code actually does, which is the only thing a regression can break.
+
+  test('runGh passes NO shell option to spawnSync', () => {
+    spiedSpawnSync.mockClear();
+    try { runGh(['--version']); } catch { /* spawn failure is irrelevant to the options */ }
+    expect(spiedSpawnSync).toHaveBeenCalled();
+    const [bin, args, opts] = spiedSpawnSync.mock.calls.at(-1);
+    expect(bin).toBe('gh');
+    expect(Array.isArray(args)).toBe(true);
+    expect(opts.shell).toBeFalsy(); // absent or false — never platform-conditional
+  });
+
+  test('runGh forwards a hostile branch as a discrete argv element, not a command string', () => {
+    spiedSpawnSync.mockClear();
+    const args = classificationArgs(HOSTILE_BRANCH);
+    try { runGh(args); } catch { /* ignore */ }
+    const [, delivered, opts] = spiedSpawnSync.mock.calls.at(-1);
+    expect(delivered).toEqual(args);
+    expect(opts.shell).toBeFalsy();
+  });
+
+  test('wip-detector defaultRunGh also spawns without a shell (the second site)', async () => {
+    // ASSERTED BY PATH INJECTION, NOT BY MOCKING. hasOpenPr takes runGh as a required
+    // parameter, so driving it through hasOpenPr observes only the runner the test
+    // supplied — the seam problem again. And this file is CJS (`require('child_process')`),
+    // a different specifier from the reaper's `node:child_process`, so an ESM module mock
+    // does not reliably intercept it.
+    //
+    // So: put a REAL fake `gh` on PATH and let the real runner spawn it. No mocking, no
+    // seam — if defaultRunGh ever regains a shell, the payload executes and the argv the
+    // fake reports changes. This is the strongest available assertion and it is immune to
+    // both failure modes above.
+    const binDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fakegh-'));
+    const canary = path.join(binDir, 'WIP_PWNED.txt');
+    const report = path.join(binDir, 'argv.json');
+    try {
+      const js = path.join(binDir, 'gh-impl.cjs');
+      fs.writeFileSync(js, `require('fs').writeFileSync(${JSON.stringify(report)}, JSON.stringify(process.argv.slice(2)));\n`);
+      if (process.platform === 'win32') {
+        fs.writeFileSync(path.join(binDir, 'gh.cmd'), `@echo off\r\n"${process.execPath}" "${js}" %*\r\n`);
+      } else {
+        const sh = path.join(binDir, 'gh');
+        fs.writeFileSync(sh, `#!/bin/sh\nexec "${process.execPath}" "${js}" "$@"\n`);
+        fs.chmodSync(sh, 0o755);
+      }
+
+      const prevPath = process.env.PATH;
+      process.env.PATH = `${binDir}${path.delimiter}${prevPath}`;
+      try {
+        const { defaultRunGh } = await import('../../../lib/claim/wip-detector.cjs');
+        const payloadBranch = `feat/x&type nul > "${canary}"`;
+        const args = ['pr', 'list', '--state', 'open', '--head', payloadBranch, '--json', 'number'];
+        defaultRunGh(args);
+
+        // THE PAYLOAD DID NOT EXECUTE. This is the assertion that matters and it holds on
+        // every platform.
+        expect(fs.existsSync(canary)).toBe(false);
+
+        if (process.platform === 'win32') {
+          // ON WINDOWS THE NON-RESOLUTION *IS* THE PROOF, and this is a sharper
+          // discriminator than argv inspection. The fake above is a `.cmd`, and a `.cmd`
+          // is reachable ONLY through a shell — libuv appends `.exe`, and Node refuses
+          // `.cmd` without a shell post-CVE-2024-27980. So:
+          //   shell present -> gh.cmd resolves -> the fake runs -> report written
+          //   shell absent  -> gh.cmd unreachable -> no report
+          // A missing report therefore proves no shell was used. (It also confirms, at
+          // ground truth, the residual documented at both runners: a .cmd/.bat gh shim
+          // would ENOENT under shell:false — which is why that residual is written down
+          // rather than assumed away.)
+          expect(fs.existsSync(report)).toBe(false);
+
+          // ARMING: the same fake IS reachable with a shell, so the check above is
+          // capable of failing rather than passing because nothing ever happens.
+          spawnSync('gh', args, { encoding: 'utf8', windowsHide: true, shell: true });
+          expect(fs.existsSync(report)).toBe(true);
+          const delivered = JSON.parse(fs.readFileSync(report, 'utf8'));
+          expect(delivered).not.toEqual(args); // and the shell mangled it
+        } else {
+          // POSIX: the extensionless fake is directly executable, so assert argv integrity.
+          expect(fs.existsSync(report)).toBe(true);
+          expect(JSON.parse(fs.readFileSync(report, 'utf8'))).toEqual(args);
+        }
+      } finally {
+        process.env.PATH = prevPath;
+      }
+    } finally {
+      try { fs.rmSync(binDir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+});
+
+describe('the fix did not trade an RCE for a silent capability loss', () => {
+  test('the REAL default runGh still resolves gh and returns a usable result', () => {
+    // The hazard that motivated shell:true was that Windows needs a shell to find gh.
+    // That was refuted by measurement; this asserts it rather than assuming it.
+    let res;
+    try {
+      res = runGh(['--version']);
+    } catch (e) {
+      // ENOENT here is the .cmd-shim residual, not a silent pass. Fail LOUDLY with the cause.
+      throw new Error(`default runGh could not spawn gh (${e?.code || e?.message}). If gh is installed as a .cmd/.bat shim on this host, that is the documented residual — it must be handled, not ignored.`);
+    }
+    expect(res.code).toBe(0);
+    expect(res.stdout).toMatch(/^gh version/);
+  });
+});

--- a/tests/unit/worktree-reaper/gh-shell-injection.test.js
+++ b/tests/unit/worktree-reaper/gh-shell-injection.test.js
@@ -139,6 +139,41 @@ describe('THE LOAD-BEARING ASSERTION — the real runners spawn without a shell'
     expect(opts).not.toHaveProperty('shell');
   });
 
+  test('SITE 2 shape assertion — defaultRunGh passes NO shell option (platform-independent)', async () => {
+    // RETRO C1. The PATH-injection test below is win32-shaped and asserts nothing about
+    // the option on the platform CI actually runs. Reinstating
+    // `shell: process.platform === 'win32'` at wip-detector was therefore UNDETECTABLE on
+    // ubuntu — the same defect I had just fixed for site 1 and applied as a find-and-replace
+    // over the two lines that happened to contain toBeFalsy(), rather than as a property of
+    // the suite.
+    //
+    // The tell was in my own commit message: the win32 mutation turned THREE tests red
+    // (2 reaper + 1 wip-detector) and I wrote "turns 2 RED" after the change. 3 -> 2 IS this
+    // gap, printed in my own numbers and uncommented. "N went red" is not the check;
+    // "every site I claim to have closed contributed at least one red, under the ENFORCING
+    // platform's evaluation semantics" is.
+    //
+    // CJS require() returns the cached module object, and defaultRunGh re-requires inside
+    // the function, so spying on that object is observed by the real runner.
+    const { createRequire } = await import('node:module');
+    const req = createRequire(import.meta.url);
+    const cp = req('child_process');
+    const spy = vi.spyOn(cp, 'spawnSync').mockReturnValue({ stdout: '[]', stderr: '', status: 0 });
+    try {
+      const { defaultRunGh, defaultRunGit } = req('../../../lib/claim/wip-detector.cjs');
+      defaultRunGh(['pr', 'list', '--head', HOSTILE_BRANCH, '--json', 'number']);
+      defaultRunGit(['cherry', 'origin/main', '--', HOSTILE_BRANCH]);
+      expect(spy).toHaveBeenCalledTimes(2);
+      for (const [bin, args, opts] of spy.mock.calls) {
+        expect(['gh', 'git']).toContain(bin);
+        expect(opts).not.toHaveProperty('shell'); // ABSENT — falsy would pass on ubuntu
+        expect(args).toContain(HOSTILE_BRANCH);   // discrete element, never concatenated
+      }
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   test('wip-detector defaultRunGh also spawns without a shell (the second site)', async () => {
     // ASSERTED BY PATH INJECTION, NOT BY MOCKING. hasOpenPr takes runGh as a required
     // parameter, so driving it through hasOpenPr observes only the runner the test

--- a/tests/unit/worktree-reaper/gh-shell-injection.test.js
+++ b/tests/unit/worktree-reaper/gh-shell-injection.test.js
@@ -117,7 +117,17 @@ describe('THE LOAD-BEARING ASSERTION — the real runners spawn without a shell'
     const [bin, args, opts] = spiedSpawnSync.mock.calls.at(-1);
     expect(bin).toBe('gh');
     expect(Array.isArray(args)).toBe(true);
-    expect(opts.shell).toBeFalsy(); // absent or false — never platform-conditional
+    // ABSENCE, not falsiness. `toBeFalsy()` looked equivalent and was not: CI runs on
+    // ubuntu, where `shell: process.platform === 'win32'` evaluates to FALSE — so a
+    // reinstated platform-conditional flag is falsy there and the assertion passes. TESTING
+    // proved it by injecting `shell: process.platform === 'darwin'` at both sites and
+    // watching all 8 tests stay green. The only platform CI runs this on was the one
+    // platform on which it could not fail.
+    //
+    // Do NOT "improve" this by stubbing process.platform instead: a hoisted
+    // `const IS_WIN` is evaluated at module load, before any stub, which is the exact
+    // shape this file's docblock records as having defeated three prior refactors.
+    expect(opts).not.toHaveProperty('shell');
   });
 
   test('runGh forwards a hostile branch as a discrete argv element, not a command string', () => {
@@ -126,7 +136,7 @@ describe('THE LOAD-BEARING ASSERTION — the real runners spawn without a shell'
     try { runGh(args); } catch { /* ignore */ }
     const [, delivered, opts] = spiedSpawnSync.mock.calls.at(-1);
     expect(delivered).toEqual(args);
-    expect(opts.shell).toBeFalsy();
+    expect(opts).not.toHaveProperty('shell');
   });
 
   test('wip-detector defaultRunGh also spawns without a shell (the second site)', async () => {


### PR DESCRIPTION
## Summary

`shell: process.platform === 'win32'` plus a branch name interpolated into `gh` argv made this an **arbitrary command execution primitive in an unattended scheduled process**. With a shell, Node concatenates argv into a command string rather than passing it discretely — Node's own `DEP0190` says so. Reproduced independently three times: branch `feat/x&whoami` executes.

Closed at **both** sites. The second — `lib/claim/wip-detector.cjs` — was already documented as defective in another module's docblock and stayed live for weeks, because no gate reads prose and no lint covers `shell:true`.

**The severity driver is forged evidence, not the execution.** The attacker also controls stdout, so a payload emitting *valid* merged-PR JSON reaches `merged_pr_count>=1` → `merged-pr-backed` → `stage1_remove`, a path the reaper labels "auto-safe". (The malformed case is fail-safe — I initially had this backwards.)

Also closes **argument injection**, which the shell fix does *not* address: `check-ref-format` permits a leading dash, so branch `--abbrev=7` is eaten by git as a flag, the positional vanishes, and `git cherry` reports a never-examined branch as "fully absorbed". Fixed with `--` at both call sites.

## Verification

- **SECURITY, measured not read**: 22 metacharacter families × 2 sites = **44/44 argv byte-identical**, execution canary empty. Mutation control corrupted 24/44 and wrote a file to disk from a branch name.
- **Mutation-verified per site**, with each mutation confirmed applied by byte delta.
- 171/171 across the reaper suite; full-project failures identical to merge-base by test name.

## Three things I got wrong, corrected in-branch

- **My Windows hazard was refuted.** I recorded that dropping the flag might silently stop classification on Windows. Two agents measured otherwise — `gh` is a native `.exe` and seven in-repo callers already run shell-free. Left standing, it would have sent PLAN to design a gh-resolution subsystem for a non-problem.
- **My test could not fail on the platform that runs it.** `toBeFalsy()` passes on ubuntu, where `shell: process.platform === 'win32'` *is* falsy. Then I fixed only the two lines containing that token, leaving site 2 undetectable — and the tell was in my own commit message ("turns 2 RED" when the mutation had turned 3).
- **My in-code safety claim was wrong.** The `.cmd`-shim residual does not "degrade to a recorded advisory" — a terminal-status key reaches stage-1 removal authority. Not a widening, but the cross-check is lost fleet-wide on such a host.

## Deliberately out of scope, recorded not implied

`.env` key adoption can redirect `gh` via `GH_REPO` and reproduce the forged-PR chain with no shell at all (pre-existing, own SD); no lint covers `shell:true`; ~11 other shell sites, three of them measured by SECURITY, including one on the reaper's own delete path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
