### PR TITLE
feat(SD-FDBK-INFRA-LESSONS-CONVERSION-WIRING-001): dedup gauge emissions, and make the resulting silence legible

### DIFF
--- a/lib/governance/plan-drift-detectors.js
+++ b/lib/governance/plan-drift-detectors.js
@@ -172,9 +172,13 @@ export async function hasOpenFinding(supabase, gaugeId) {
  * The OPEN statuses. Named because the set IS the trip-clear-trip contract: a finding that has
  * been cleared must leave these states, or a re-trip is indistinguishable from a re-emission and
  * a genuinely RECURRING defect collapses into a standing one.
- * NOTE `backlog` IS OPEN — it is a triage bucket, not a clear.
+ * NOTE `backlog` IS OPEN — it is a triage bucket, not a clear. So is `triaged`: my first version
+ * argued backlog-is-a-triage-bucket while silently DROPPING the status literally named 'triaged',
+ * which would have re-armed hourly amplification the moment anyone started working the backlog —
+ * i.e. on first contact with the intended use. The live feedback_status_check domain is
+ * new|triaged|in_progress|resolved|wont_fix|duplicate|invalid|backlog|shipped.
  */
-export const OPEN_FINDING_STATUSES = ['new', 'backlog', 'in_progress'];
+export const OPEN_FINDING_STATUSES = ['new', 'triaged', 'backlog', 'in_progress'];
 
 /**
  * I/O: the same dedup check as hasOpenFinding, but RETURNING THE ROW.
@@ -194,8 +198,25 @@ export async function findOpenFinding(supabase, gaugeId) {
     .from('feedback')
     .select('id, occurrence_count')
     .eq('category', 'invariant_gauge_finding')
+    // ONLY ROWS THIS RUNNER COULD HAVE WRITTEN. RLS grants anon an INSERT path constrained on
+    // source_type='telegram' ONLY — category, status and metadata are entirely caller-supplied, and
+    // the anon key is public by design. Without these two predicates, anyone could insert a
+    // lookalike finding and PERMANENTLY MUTE that invariant, because nothing ever clears a gauge
+    // finding. The primitive pre-dates this change; what this change adds is EFFECTIVENESS — while
+    // the insert was unconditional a planted row suppressed nothing. Taking dedup from 1 detector to
+    // 22 without this filter would be a material widening attributable to this PR.
+    // Both anon policies are structurally excluded: the telegram policy cannot set
+    // source_type='auto_capture', and the venture policy cannot leave feedback_type NULL.
+    .eq('source_type', 'auto_capture')
+    .is('feedback_type', null)
     .eq('metadata->>gauge_id', gaugeId)
     .in('status', OPEN_FINDING_STATUSES)
+    // DETERMINISTIC PICK. Up to 692 open rows share one gauge_id today, and .limit(1) without
+    // .order() returns an ARBITRARY one — which is then UPDATEd, writing a new heap tuple and
+    // perturbing the very ordering it depended on. Across passes the stamped row drifts, scattering
+    // occurrence_count and last_seen across hundreds of identical siblings with no authoritative
+    // row. That is dedup destroying information rather than preserving it.
+    .order('created_at', { ascending: false })
     .limit(1);
   if (error) throw new Error('findOpenFinding failed: ' + error.message);
   return Array.isArray(data) && data.length > 0 ? data[0] : null;

--- a/lib/governance/plan-drift-detectors.js
+++ b/lib/governance/plan-drift-detectors.js
@@ -198,17 +198,26 @@ export async function findOpenFinding(supabase, gaugeId) {
     .from('feedback')
     .select('id, occurrence_count')
     .eq('category', 'invariant_gauge_finding')
-    // ONLY ROWS THIS RUNNER COULD HAVE WRITTEN. RLS grants anon an INSERT path constrained on
-    // source_type='telegram' ONLY — category, status and metadata are entirely caller-supplied, and
-    // the anon key is public by design. Without these two predicates, anyone could insert a
-    // lookalike finding and PERMANENTLY MUTE that invariant, because nothing ever clears a gauge
-    // finding. The primitive pre-dates this change; what this change adds is EFFECTIVENESS — while
-    // the insert was unconditional a planted row suppressed nothing. Taking dedup from 1 detector to
-    // 22 without this filter would be a material widening attributable to this PR.
-    // Both anon policies are structurally excluded: the telegram policy cannot set
-    // source_type='auto_capture', and the venture policy cannot leave feedback_type NULL.
+    // ONLY ROWS THIS RUNNER COULD HAVE WRITTEN. The anon key is public by design and RLS grants it
+    // exactly two INSERT paths, both verified live in pg_policies (every other feedback INSERT
+    // policy is service_role):
+    //   telegram_bot_insert_feedback  WITH CHECK source_type = 'telegram'   → excluded by :source_type
+    //   venture_user_insert_feedback  WITH CHECK feedback_type LIKE 'user_%' → excluded by :feedback_type
+    // category, status and metadata are entirely caller-supplied, so without these two predicates
+    // anyone could insert a lookalike finding and PERMANENTLY MUTE that invariant, since nothing
+    // ever clears a gauge finding. The primitive pre-dates this change; what this change adds is
+    // EFFECTIVENESS — while the insert was unconditional a planted row suppressed nothing.
+    //
+    // 'sentry_error' IS THE VALUE THIS RUNNER WRITES, AND IT IS NOT A CHOICE. feedback.feedback_type
+    // is NOT NULL DEFAULT 'sentry_error'; buildFindingRow omits the column, so every row the runner
+    // writes takes that default. The first version of this filter said .is('feedback_type', null),
+    // reasoning from the RLS policy ("the venture policy cannot leave feedback_type NULL") without
+    // reading the COLUMN — which is NOT NULL, so 0 of 15,394 live rows can satisfy it. Postgres
+    // short-circuits it to `One-Time Filter: false`. That made the whole dedup inert AND regressed
+    // hasOpenFinding to always-false. Asserting a column's shape from a policy that mentions it is
+    // the same mistake as asserting a function's contract from its name.
     .eq('source_type', 'auto_capture')
-    .is('feedback_type', null)
+    .eq('feedback_type', 'sentry_error')
     // AN ARCHIVED ROW IS NOT AN OPEN ROW. Archive-not-delete is the obvious remediation for a
     // 5,382-row backlog, and without this an archived finding keeps muting its gauge forever while
     // being invisible on every surface that filters archived rows out. Its status stays in the open

--- a/lib/governance/plan-drift-detectors.js
+++ b/lib/governance/plan-drift-detectors.js
@@ -161,15 +161,44 @@ export async function fetchLastNDispatchedKeys(supabase, { limit = 20 } = {}) {
  * @returns {Promise<boolean>} true when an OPEN finding already exists (caller should skip insert)
  */
 export async function hasOpenFinding(supabase, gaugeId) {
+  // Deliberately a BOOLEAN COERCION of findOpenFinding rather than its own query.
+  // The return type is NOT widened: tests/unit/plan-drift-detectors.test.js:130,135 assert
+  // toBe(true)/toBe(false), and gauge-runner.mjs:348 feeds this straight into `skipRoute`.
+  // Widening it would silently change both.
+  return (await findOpenFinding(supabase, gaugeId)) !== null;
+}
+
+/**
+ * The OPEN statuses. Named because the set IS the trip-clear-trip contract: a finding that has
+ * been cleared must leave these states, or a re-trip is indistinguishable from a re-emission and
+ * a genuinely RECURRING defect collapses into a standing one.
+ * NOTE `backlog` IS OPEN — it is a triage bucket, not a clear.
+ */
+export const OPEN_FINDING_STATUSES = ['new', 'backlog', 'in_progress'];
+
+/**
+ * I/O: the same dedup check as hasOpenFinding, but RETURNING THE ROW.
+ *
+ * WHY THIS EXISTS RATHER THAN WIDENING hasOpenFinding: stamping a re-emission needs the row's id
+ * AND its current occurrence_count, and a boolean cannot carry either. I originally specified this
+ * work as "zero new mechanism, reuse hasOpenFinding" and that was WRONG — I asserted reuse without
+ * reading the signature. This is the smallest honest correction: one row-returning function, with
+ * the boolean re-expressed on top so the existing two callers are untouched.
+ *
+ * @param {import('@supabase/supabase-js').SupabaseClient} supabase
+ * @param {string} gaugeId
+ * @returns {Promise<{id: string, occurrence_count: (number|null)}|null>} the open row, or null
+ */
+export async function findOpenFinding(supabase, gaugeId) {
   const { data, error } = await supabase
     .from('feedback')
-    .select('id')
+    .select('id, occurrence_count')
     .eq('category', 'invariant_gauge_finding')
     .eq('metadata->>gauge_id', gaugeId)
-    .in('status', ['new', 'backlog', 'in_progress'])
+    .in('status', OPEN_FINDING_STATUSES)
     .limit(1);
-  if (error) throw new Error('hasOpenFinding failed: ' + error.message);
-  return Array.isArray(data) && data.length > 0;
+  if (error) throw new Error('findOpenFinding failed: ' + error.message);
+  return Array.isArray(data) && data.length > 0 ? data[0] : null;
 }
 
 /**

--- a/lib/governance/plan-drift-detectors.js
+++ b/lib/governance/plan-drift-detectors.js
@@ -209,6 +209,11 @@ export async function findOpenFinding(supabase, gaugeId) {
     // source_type='auto_capture', and the venture policy cannot leave feedback_type NULL.
     .eq('source_type', 'auto_capture')
     .is('feedback_type', null)
+    // AN ARCHIVED ROW IS NOT AN OPEN ROW. Archive-not-delete is the obvious remediation for a
+    // 5,382-row backlog, and without this an archived finding keeps muting its gauge forever while
+    // being invisible on every surface that filters archived rows out. Its status stays in the open
+    // set — archiving is not a status transition — so the status filter cannot catch it.
+    .is('archived_at', null)
     .eq('metadata->>gauge_id', gaugeId)
     .in('status', OPEN_FINDING_STATUSES)
     // DETERMINISTIC PICK. Up to 692 open rows share one gauge_id today, and .limit(1) without

--- a/scripts/coordinator-hourly-review.cjs
+++ b/scripts/coordinator-hourly-review.cjs
@@ -301,7 +301,7 @@ async function main() {
   try {
     const { checkGaugeRunnerLiveness } = await import('../lib/governance/gauge-runner-liveness.js');
     const { data: hb } = await sb.from('codebase_health_snapshots')
-      .select('scanned_at')
+      .select('scanned_at, findings')
       .eq('dimension', 'gauge_runner_heartbeat')
       .order('scanned_at', { ascending: false })
       .limit(1)
@@ -310,6 +310,28 @@ async function main() {
     if (liveness.alarm) {
       const ageNote = liveness.ageMs == null ? 'no heartbeat ever recorded' : Math.floor(liveness.ageMs / 60000) + 'm stale';
       console.log('\n[HOURLY-REVIEW] GAUGE-RUNNER LIVENESS ALARM — invariant gauges may be silently NOT running (' + ageNote + '). Investigate scripts/gauge-runner.mjs.');
+    }
+
+    // SD-FDBK-INFRA-LESSONS-CONVERSION-WIRING-001: SIGNAL liveness, not just PROCESS liveness.
+    // The check above proves the runner RAN. It cannot prove the gauges still SEE anything —
+    // writeHeartbeat fires unconditionally with a hardcoded score of 100 regardless of detector
+    // outcomes, so a runner that executes flawlessly while every detector returns nothing produces
+    // a perfect heartbeat. That gap became load-bearing when gauge findings started deduping:
+    // nothing in this repo ever CLEARS a gauge finding, so `inserted` is 0 from the very first run
+    // and stays there. `suppressed > 0` is the ONLY evidence the gauges are still watching.
+    // ALL-QUIET IS THE ALARM CONDITION: every counter zero means either the detectors stopped
+    // tripping or they stopped working, and those must not look identical.
+    const routing = Array.isArray(hb?.findings) ? hb.findings[0] : null;
+    if (routing && ['inserted', 'suppressed', 'skipped', 'error'].some((k) => typeof routing[k] === 'number')) {
+      const { inserted = 0, suppressed = 0, skipped = 0, error = 0 } = routing;
+      if (inserted + suppressed + skipped + error === 0) {
+        console.log('\n[HOURLY-REVIEW] GAUGE SIGNAL ALARM — the runner is alive but routed NOTHING last pass '
+          + '(inserted=0 suppressed=0 skipped=0 error=0). Either every detector stopped tripping or every '
+          + 'detector stopped working; a healthy deduped pass reports suppressed>0. Investigate before trusting the gauges.');
+      } else {
+        console.log('[HOURLY-REVIEW] gauge routing last pass: inserted=' + inserted + ' suppressed=' + suppressed
+          + ' skipped=' + skipped + ' error=' + error);
+      }
     }
   } catch (e) {
     console.log('[HOURLY-REVIEW] gauge-runner liveness check skipped (non-fatal): ' + e.message);

--- a/scripts/coordinator-hourly-review.cjs
+++ b/scripts/coordinator-hourly-review.cjs
@@ -209,10 +209,86 @@ async function resolveLiveAdam(sb, freshS) {
   return adams[0] || null;
 }
 
+/**
+ * GAUGE HEALTH — HOISTED OUT OF THE REMINDER LEGS ON PURPOSE.
+ * This lived at the tail of main(), behind three early returns: fleet-quiescent CYCLE-DOWN, no live
+ * Adam, and dry-run. So the one surface that distinguishes "gauges deduped and still watching" from
+ * "gauges silently dead" could not evaluate precisely when the fleet was idle and nobody was
+ * watching — the longest a dead gauge system would go unnoticed. It is a who-watches-the-watchmen
+ * check with no dependency on Adam, on dry-run, or on fleet activity, so it runs unconditionally
+ * and reads/logs only.
+ */
+async function reportGaugeHealth(sb) {
+// SD-LEO-INFRA-INVARIANT-GAUGES-FRAMEWORK-001 FR-4 (invariant #0, who-watches-the-watchmen):
+// an EXTERNAL check (this process is independently cron'd, separate from gauge-runner.mjs
+// itself) that the gauge-runner is observably alive. A dead runner is a worse failure than any
+// single invariant drifting (false all-clear) -- so a stale/missing heartbeat alarms here.
+try {
+  const { checkGaugeRunnerLiveness } = await import('../lib/governance/gauge-runner-liveness.js');
+  const { data: hb } = await sb.from('codebase_health_snapshots')
+    .select('scanned_at, findings')
+    .eq('dimension', 'gauge_runner_heartbeat')
+    .order('scanned_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  const liveness = checkGaugeRunnerLiveness(hb?.scanned_at, Date.now());
+  if (liveness.alarm) {
+    const ageNote = liveness.ageMs == null ? 'no heartbeat ever recorded' : Math.floor(liveness.ageMs / 60000) + 'm stale';
+    console.log('\n[HOURLY-REVIEW] GAUGE-RUNNER LIVENESS ALARM — invariant gauges may be silently NOT running (' + ageNote + '). Investigate scripts/gauge-runner.mjs.');
+  }
+
+  // SD-FDBK-INFRA-LESSONS-CONVERSION-WIRING-001: SIGNAL liveness, not just PROCESS liveness.
+  // The check above proves the runner RAN. It cannot prove the gauges still SEE anything —
+  // writeHeartbeat fires unconditionally with a hardcoded score of 100 regardless of detector
+  // outcomes, so a runner that executes flawlessly while every detector returns nothing produces
+  // a perfect heartbeat. That gap became load-bearing when gauge findings started deduping:
+  // nothing in this repo ever CLEARS a gauge finding, so `inserted` is 0 from the very first run
+  // and stays there. `suppressed > 0` is the ONLY evidence the gauges are still watching.
+  // ALL-QUIET IS THE ALARM CONDITION: every counter zero means either the detectors stopped
+  // tripping or they stopped working, and those must not look identical.
+  const routing = Array.isArray(hb?.findings) ? hb.findings[0] : null;
+  if (routing && ['inserted', 'suppressed', 'skipped', 'error'].some((k) => typeof routing[k] === 'number')) {
+    const { inserted = 0, suppressed = 0, skipped = 0, error = 0 } = routing;
+    if (inserted + suppressed + skipped + error === 0) {
+      console.log('\n[HOURLY-REVIEW] GAUGE SIGNAL ALARM — the runner is alive but routed NOTHING last pass '
+        + '(inserted=0 suppressed=0 skipped=0 error=0). Either every detector stopped tripping or every '
+        + 'detector stopped working; a healthy deduped pass reports suppressed>0. Investigate before trusting the gauges.');
+    } else if (inserted > 0 && suppressed === 0) {
+      // THE ALARM THAT WOULD HAVE CAUGHT THE DEFECT THIS PR ALMOST SHIPPED. The first version of
+      // findOpenFinding filtered on a NOT NULL column being NULL, so the lookup could never match
+      // and every pass took the INSERT branch — dedup permanently inert, amplification unchanged,
+      // and the all-quiet alarm above silent because the counters were NOT all zero. Standing
+      // trips are what this system is made of: after the first pass a working dedup ALWAYS reports
+      // suppressed>0. inserted>0 with suppressed==0, pass after pass, is the signature of a dedup
+      // that is not deduping — the exact shape 162 green unit tests failed to see.
+      console.log('\n[HOURLY-REVIEW] GAUGE DEDUP ALARM — ' + inserted + ' inserted, 0 suppressed. Every gauge '
+        + 'finding was NEW, which after the first pass means the dedup lookup is matching nothing (a filter that '
+        + 'cannot match the rows the runner itself writes). Amplification is uncontrolled. Check findOpenFinding '
+        + 'in lib/governance/plan-drift-detectors.js against the live feedback column definitions.');
+    } else if (error > 0) {
+      // Routing errors fail toward a duplicate row, so they never surface as silence — but they do
+      // mean freshness stamps are being lost, and nothing else reports them.
+      console.log('\n[HOURLY-REVIEW] GAUGE ROUTING ERRORS — ' + error + ' of '
+        + (inserted + suppressed + skipped + error) + ' gauges failed to route last pass '
+        + '(inserted=' + inserted + ' suppressed=' + suppressed + '). Stamps are being dropped.');
+    } else {
+      console.log('[HOURLY-REVIEW] gauge routing last pass: inserted=' + inserted + ' suppressed=' + suppressed
+        + ' skipped=' + skipped + ' error=' + error);
+    }
+  }
+} catch (e) {
+  console.log('[HOURLY-REVIEW] gauge-runner liveness check skipped (non-fatal): ' + e.message);
+}
+
+}
+
 async function main() {
   let sb;
   try { sb = createSupabaseServiceClient(); }
   catch (e) { console.log('[HOURLY-REVIEW] supabase unavailable (non-fatal): ' + e.message); return; }
+
+  // BEFORE the quiescence gate: a dead gauge system is most dangerous when the fleet is idle.
+  await reportGaugeHealth(sb);
 
   const activity = await assessFleetActivity(sb);
   if (activity.quiescent) {
@@ -294,48 +370,6 @@ async function main() {
     console.log('[HOURLY-REVIEW] undelivered-receipt check skipped (non-fatal): ' + e.message);
   }
 
-  // SD-LEO-INFRA-INVARIANT-GAUGES-FRAMEWORK-001 FR-4 (invariant #0, who-watches-the-watchmen):
-  // an EXTERNAL check (this process is independently cron'd, separate from gauge-runner.mjs
-  // itself) that the gauge-runner is observably alive. A dead runner is a worse failure than any
-  // single invariant drifting (false all-clear) -- so a stale/missing heartbeat alarms here.
-  try {
-    const { checkGaugeRunnerLiveness } = await import('../lib/governance/gauge-runner-liveness.js');
-    const { data: hb } = await sb.from('codebase_health_snapshots')
-      .select('scanned_at, findings')
-      .eq('dimension', 'gauge_runner_heartbeat')
-      .order('scanned_at', { ascending: false })
-      .limit(1)
-      .maybeSingle();
-    const liveness = checkGaugeRunnerLiveness(hb?.scanned_at, Date.now());
-    if (liveness.alarm) {
-      const ageNote = liveness.ageMs == null ? 'no heartbeat ever recorded' : Math.floor(liveness.ageMs / 60000) + 'm stale';
-      console.log('\n[HOURLY-REVIEW] GAUGE-RUNNER LIVENESS ALARM — invariant gauges may be silently NOT running (' + ageNote + '). Investigate scripts/gauge-runner.mjs.');
-    }
-
-    // SD-FDBK-INFRA-LESSONS-CONVERSION-WIRING-001: SIGNAL liveness, not just PROCESS liveness.
-    // The check above proves the runner RAN. It cannot prove the gauges still SEE anything —
-    // writeHeartbeat fires unconditionally with a hardcoded score of 100 regardless of detector
-    // outcomes, so a runner that executes flawlessly while every detector returns nothing produces
-    // a perfect heartbeat. That gap became load-bearing when gauge findings started deduping:
-    // nothing in this repo ever CLEARS a gauge finding, so `inserted` is 0 from the very first run
-    // and stays there. `suppressed > 0` is the ONLY evidence the gauges are still watching.
-    // ALL-QUIET IS THE ALARM CONDITION: every counter zero means either the detectors stopped
-    // tripping or they stopped working, and those must not look identical.
-    const routing = Array.isArray(hb?.findings) ? hb.findings[0] : null;
-    if (routing && ['inserted', 'suppressed', 'skipped', 'error'].some((k) => typeof routing[k] === 'number')) {
-      const { inserted = 0, suppressed = 0, skipped = 0, error = 0 } = routing;
-      if (inserted + suppressed + skipped + error === 0) {
-        console.log('\n[HOURLY-REVIEW] GAUGE SIGNAL ALARM — the runner is alive but routed NOTHING last pass '
-          + '(inserted=0 suppressed=0 skipped=0 error=0). Either every detector stopped tripping or every '
-          + 'detector stopped working; a healthy deduped pass reports suppressed>0. Investigate before trusting the gauges.');
-      } else {
-        console.log('[HOURLY-REVIEW] gauge routing last pass: inserted=' + inserted + ' suppressed=' + suppressed
-          + ' skipped=' + skipped + ' error=' + error);
-      }
-    }
-  } catch (e) {
-    console.log('[HOURLY-REVIEW] gauge-runner liveness check skipped (non-fatal): ' + e.message);
-  }
 
   // SD-LEO-INFRA-RELAY-QUEUE-CONFIRM-ON-RELAY-DELIVERY-GUARANTEE-001 / FR-3: surface the
   // relay/decision/review drop gauge. Read-only + fail-open (planRelayDrops never throws).

--- a/scripts/gauge-runner.mjs
+++ b/scripts/gauge-runner.mjs
@@ -532,7 +532,7 @@ export async function routeFinding(supabase, entry, result) {
     // Its LOOKUP at :91-95 is a NAMED ANTI-PRECEDENT (PRD TR-4): it filters on error_hash with NO
     // status filter, so it bumps counts on CLOSED rows -- live, a ci_failure row sits at
     // occurrence_count 586 with a fresh last_seen while that table holds 2,101 resolved.
-    const { error } = await supabase
+    const { data: stamped, error } = await supabase
       .from('feedback')
       .update({
         last_seen: new Date().toISOString(),
@@ -540,15 +540,28 @@ export async function routeFinding(supabase, entry, result) {
         updated_at: new Date().toISOString(),
       })
       .eq('id', open.id)
-      // RE-ASSERTED, NOT ASSUMED. The lookup already proved these, but the invariant "this runner
-      // only ever bumps its OWN open gauge rows" then lives split across two statements in two
-      // files, and the anti-precedent above is exactly what that split produces: a correct-looking
-      // UPDATE fed by a lookup that lost a predicate. Keeping them here makes the UPDATE refuse a
-      // stale or mis-scoped id on its own terms — it is a no-op when the lookup is right.
+      // RE-ASSERTED, NOT ASSUMED — and re-asserting the FULL lookup predicate, not a subset. The
+      // lookup already proved these, but the invariant "this runner only ever bumps its OWN open
+      // gauge rows" then lives split across two statements in two files, and the anti-precedent
+      // above is exactly what that split produces: a correct-looking UPDATE fed by a lookup that
+      // lost a predicate. It is a no-op whenever the lookup is right.
       .eq('category', 'invariant_gauge_finding')
-      .in('status', OPEN_FINDING_STATUSES);
+      .eq('source_type', 'auto_capture')
+      .eq('feedback_type', 'sentry_error')
+      .is('archived_at', null)
+      .in('status', OPEN_FINDING_STATUSES)
+      // ZERO ROWS MATCHED IS NOT SUCCESS. Without .select() supabase-js returns {error:null} for an
+      // UPDATE that touched NOTHING, so a row triaged or archived out of scope between the lookup
+      // and the stamp would be reported 'suppressed' with nothing written — the trip silently
+      // dropped, and counted as healthy dedup on the very tally that exists to detect silence.
+      // Reporting success for work that did not happen is the defect class this whole SD is about.
+      .select('id');
     if (error) {
       console.error(`[gauge-runner] ${entry.id}: re-emission stamp failed (non-fatal): ${error.message}`);
+      return 'error';
+    }
+    if (!Array.isArray(stamped) || stamped.length === 0) {
+      console.error(`[gauge-runner] ${entry.id}: re-emission stamp matched NO row (row ${open.id} moved out of scope between lookup and update) — reporting error, not suppressed`);
       return 'error';
     }
     return 'suppressed';

--- a/scripts/gauge-runner.mjs
+++ b/scripts/gauge-runner.mjs
@@ -68,6 +68,7 @@ import {
   isDriftBreach,
   fetchLastNDispatchedKeys,
   hasOpenFinding,
+  findOpenFinding,
 } from '../lib/governance/plan-drift-detectors.js';
 import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 import { checkGhostCeos } from '../lib/agents/ghost-ceo-gauge.js';
@@ -460,25 +461,105 @@ export function buildFindingRow(entry, result) {
   };
 }
 
-async function routeFinding(supabase, entry, result) {
-  // SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001 FR-5 (re-surface-once dedup): a detector may set
-  // result.skipRoute=true when an OPEN finding for its gauge_id already exists (or the trip is a
-  // self-gated starved short-circuit that isn't a genuine drift finding) -- skip the duplicate
-  // insert. Generic extension point: any future detector can opt in the same way.
+/** How long the dedup lookup may take before we give up and INSERT. See routeFinding. */
+export const DEDUP_LOOKUP_TIMEOUT_MS = 4000;
+
+/**
+ * Route one tripped gauge to the feedback table, deduping re-emissions.
+ *
+ * WHY THIS CHANGED (SD-FDBK-INFRA-LESSONS-CONVERSION-WIRING-001).
+ * The insert below was UNCONDITIONAL, and 12 of 13 emitting detectors never opted into skipRoute.
+ * Measured consequence: 5,374 invariant_gauge_finding rows representing ~13 distinct conditions —
+ * roughly 77x amplification — at 0% disposition, growing 200-330/day. The contrast is ci_failure,
+ * which absorbs far MORE raw events, stays at ~2,104 rows and is 99.9% dispositioned, because it
+ * collapses re-emissions onto last_seen instead of inserting.
+ *
+ * THE DEDUP IS DEFAULT-ON AND LIVES HERE, NOT IN EACH DETECTOR. Per-detector opt-in is exactly what
+ * left 12 of 13 undeduped for the life of this code; a chokepoint is the only place the default can
+ * actually hold.
+ *
+ * *** THIS CHANGE MAKES THE GAUGE SYSTEM QUIET, AND THAT IS THE DANGEROUS PART. ***
+ * Nothing in this repo ever CLEARS a gauge finding — all 5,374 rows are status='new'; every
+ * automated closer is scoped to other categories, both DB auto-close triggers key on SD/QF
+ * references gauge rows never carry, and the purpose-built drain writes to a table with zero rows
+ * ever written and no join back. So after one more pass every tripping gauge holds an open row and
+ * this function stops inserting, permanently. That is not a prediction: plan-drift-mix, the single
+ * detector that already opted in, has EXACTLY ONE ROW EVER — tripped once, silently muted since.
+ * Going from 5,374 rows at 0% disposition to ~14 at 0% disposition is a real NOISE win and ZERO
+ * OBSERVABILITY win, and it turns a loud useless signal into a quiet one. A system that is wrong
+ * and noisy gets fixed; a system that is wrong and quiet does not.
+ * THAT is why this returns a verdict and why main() must surface the counts: the suppressed count
+ * is the only thing distinguishing "deduped" from "the gauges stopped working".
+ *
+ * @returns {Promise<'inserted'|'suppressed'|'skipped'|'error'>}
+ */
+export async function routeFinding(supabase, entry, result) {
+  // SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001 FR-5: a detector may still self-suppress. Kept AHEAD of the
+  // dedup deliberately — it also covers the starved short-circuit case, which is not a re-emission
+  // at all, so folding it into the dedup branch would conflate two different reasons for silence.
   if (result?.skipRoute) {
     console.log(`[gauge-runner] ${entry.id}: routing skipped (skipRoute -- already-open finding or starved short-circuit)`);
-    return;
+    return 'skipped';
   }
-  const { error } = await supabase.from('feedback').insert(buildFindingRow(entry, result));
-  if (error) console.error(`[gauge-runner] finding-route failed for ${entry.id} (non-fatal): ${error.message}`);
+
+  // FAIL TOWARD INSERTING. A duplicate row is recoverable and visible; a suppressed genuine first
+  // emission is silent and is the failure this whole SD exists to eliminate. Both the throw path
+  // and the timeout path therefore fall through to the insert below.
+  // The timeout matters because a HANGING (not erroring) lookup across 22 gauges could exhaust the
+  // workflow budget and kill a pass mid-flight, which would read as a fleet-down alarm.
+  let open = null;
+  try {
+    open = await Promise.race([
+      findOpenFinding(supabase, entry.id),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('dedup lookup timeout')), DEDUP_LOOKUP_TIMEOUT_MS)),
+    ]);
+  } catch (e) {
+    console.error(`[gauge-runner] ${entry.id}: dedup lookup failed (${e.message}) -- INSERTING rather than suppressing`);
+    open = null;
+  }
+
+  if (open) {
+    // RE-EMISSION. Stamp freshness on the existing row rather than inserting a new one.
+    // Modelled on scripts/clockwork/gh-failure-monitor.cjs:96-110 -- THE UPDATE HALF ONLY.
+    // Its LOOKUP at :91-95 is a NAMED ANTI-PRECEDENT (PRD TR-4): it filters on error_hash with NO
+    // status filter, so it bumps counts on CLOSED rows -- live, a ci_failure row sits at
+    // occurrence_count 586 with a fresh last_seen while that table holds 2,101 resolved.
+    const { error } = await supabase
+      .from('feedback')
+      .update({
+        last_seen: new Date().toISOString(),
+        occurrence_count: (open.occurrence_count || 1) + 1,
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', open.id);
+    if (error) {
+      console.error(`[gauge-runner] ${entry.id}: re-emission stamp failed (non-fatal): ${error.message}`);
+      return 'error';
+    }
+    return 'suppressed';
+  }
+
+  // FIRST EMISSION. Stamp BOTH first_seen and last_seen: all 5,374 existing gauge rows have both
+  // NULL, so without this the freshness data the dedup branch depends on is never seeded. (My
+  // original spec claimed these columns were already populated -- that was the ci_failure
+  // population measured on the wrong set.)
+  const now = new Date().toISOString();
+  const { error } = await supabase
+    .from('feedback')
+    .insert({ ...buildFindingRow(entry, result), first_seen: now, last_seen: now });
+  if (error) {
+    console.error(`[gauge-runner] finding-route failed for ${entry.id} (non-fatal): ${error.message}`);
+    return 'error';
+  }
+  return 'inserted';
 }
 
-async function writeHeartbeat(supabase, ranCount) {
+async function writeHeartbeat(supabase, ranCount, routing) {
   const { error } = await supabase.from('codebase_health_snapshots').insert({
     dimension: HEARTBEAT_DIMENSION,
     target_application: 'EHG_Engineer',
     score: 100,
-    findings: [{ ran_count: ranCount, ran_at: new Date().toISOString() }],
+    findings: [{ ran_count: ranCount, ran_at: new Date().toISOString(), ...(routing || {}) }],
     trend_direction: 'stable',
     metadata: { source: 'gauge-runner.mjs' },
   });
@@ -492,6 +573,10 @@ async function main() {
   const supabase = createClient(url, key);
   const resolvers = buildDetectorResolvers(supabase);
 
+  // Routing tally. WITHOUT THIS THE DEDUP IS INDISTINGUISHABLE FROM THE GAUGES BREAKING:
+  // once every tripping gauge holds an open row this runner stops inserting forever, and a silent
+  // run and a healthy run look identical. suppressed>0 is the proof the system is still watching.
+  const routing = { inserted: 0, suppressed: 0, skipped: 0, error: 0 };
   const enabled = selectEnabledEntries(GAUGE_REGISTRY).slice(0, MAX_DETECTORS_PER_RUN);
   const results = [];
 
@@ -508,7 +593,8 @@ async function main() {
       console.log(`GAUGE ${entry.id}=${value}`);
       results.push({ id: entry.id, value, tripped, result });
       if (tripped) {
-        await routeFinding(supabase, entry, result);
+        const verdict = await routeFinding(supabase, entry, result);
+        routing[verdict] = (routing[verdict] || 0) + 1;
         // SD-LEO-INFRA-PLAN-DRIFT-GAUGE-001 FR-6: dual-recipient push, gauge-specific (narrow by
         // design -- no other gauge pushes to session_coordination yet) and dedup-gated (skipRoute
         // means either a starved short-circuit or an already-open finding -- never re-push).
@@ -528,7 +614,8 @@ async function main() {
     }
   }
 
-  await writeHeartbeat(supabase, results.length);
+  console.log(`GAUGE_ROUTING inserted=${routing.inserted} suppressed=${routing.suppressed} skipped=${routing.skipped} error=${routing.error}`);
+  await writeHeartbeat(supabase, results.length, routing);
 
   try {
     await stampLastFired(supabase, 'standard_loop:gauge-runner');

--- a/scripts/gauge-runner.mjs
+++ b/scripts/gauge-runner.mjs
@@ -69,6 +69,7 @@ import {
   fetchLastNDispatchedKeys,
   hasOpenFinding,
   findOpenFinding,
+  OPEN_FINDING_STATUSES,
 } from '../lib/governance/plan-drift-detectors.js';
 import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 import { checkGhostCeos } from '../lib/agents/ghost-ceo-gauge.js';
@@ -538,7 +539,14 @@ export async function routeFinding(supabase, entry, result) {
         occurrence_count: (open.occurrence_count || 1) + 1,
         updated_at: new Date().toISOString(),
       })
-      .eq('id', open.id);
+      .eq('id', open.id)
+      // RE-ASSERTED, NOT ASSUMED. The lookup already proved these, but the invariant "this runner
+      // only ever bumps its OWN open gauge rows" then lives split across two statements in two
+      // files, and the anti-precedent above is exactly what that split produces: a correct-looking
+      // UPDATE fed by a lookup that lost a predicate. Keeping them here makes the UPDATE refuse a
+      // stale or mis-scoped id on its own terms — it is a no-op when the lookup is right.
+      .eq('category', 'invariant_gauge_finding')
+      .in('status', OPEN_FINDING_STATUSES);
     if (error) {
       console.error(`[gauge-runner] ${entry.id}: re-emission stamp failed (non-fatal): ${error.message}`);
       return 'error';

--- a/scripts/gauge-runner.mjs
+++ b/scripts/gauge-runner.mjs
@@ -508,14 +508,21 @@ export async function routeFinding(supabase, entry, result) {
   // The timeout matters because a HANGING (not erroring) lookup across 22 gauges could exhaust the
   // workflow budget and kill a pass mid-flight, which would read as a fleet-down alarm.
   let open = null;
+  let timer = null;
   try {
     open = await Promise.race([
       findOpenFinding(supabase, entry.id),
-      new Promise((_, reject) => setTimeout(() => reject(new Error('dedup lookup timeout')), DEDUP_LOOKUP_TIMEOUT_MS)),
+      new Promise((_, reject) => { timer = setTimeout(() => reject(new Error('dedup lookup timeout')), DEDUP_LOOKUP_TIMEOUT_MS); }),
     ]);
   } catch (e) {
     console.error(`[gauge-runner] ${entry.id}: dedup lookup failed (${e.message}) -- INSERTING rather than suppressing`);
     open = null;
+  } finally {
+    // The timer holds the event loop for its FULL duration even when the lookup wins — measured at
+    // 4007ms for a call that resolved in 1ms. Invisible today only because main() calls
+    // process.exit(), which is a load-bearing accident rather than a design. routeFinding is
+    // EXPORTED now, so any long-lived importer would accumulate these.
+    if (timer) clearTimeout(timer);
   }
 
   if (open) {
@@ -623,7 +630,7 @@ async function main() {
     console.error(`[gauge-runner] stampLastFired failed (non-fatal): ${err.message}`);
   }
 
-  if (JSON_MODE) console.log(JSON.stringify({ ran: results.length, results }));
+  if (JSON_MODE) console.log(JSON.stringify({ ran: results.length, routing, results }));
   process.exit(0); // advisory: the runner itself never fails the tick
 }
 

--- a/tests/unit/governance/gauge-finding-dedup.test.js
+++ b/tests/unit/governance/gauge-finding-dedup.test.js
@@ -48,9 +48,20 @@ function makeSupabase({ openRow = null, selectError = null, updateError = null, 
         update(payload) { calls.updates.push({ payload }); return q; },
         async insert(row) { calls.inserts.push(row); return { error: insertError ? { message: insertError } : null }; },
       };
-      // .update(...).eq(...) resolves as a thenable
+      // The UPDATE is its OWN builder, not the select's. It was a one-shot `{ eq: async () => … }`,
+      // which broke the moment the UPDATE re-asserted category and open-status alongside the id.
+      // It now takes any number of filters, RECORDS each one, and resolves as a thenable the way
+      // postgrest-js does — so `await …update().eq().eq().in()` works and the filters are assertable.
       const origUpdate = q.update;
-      q.update = (payload) => { origUpdate(payload); return { eq: async () => ({ error: updateError ? { message: updateError } : null }) }; };
+      q.update = (payload) => {
+        origUpdate(payload);
+        const u = {
+          eq(col, val) { if (col === 'id') calls.updates.at(-1).id = val; else calls.updates.at(-1)[col] = val; return u; },
+          in(col, vals) { calls.updates.at(-1)[col] = vals; return u; },
+          then(resolve, reject) { return Promise.resolve({ error: updateError ? { message: updateError } : null }).then(resolve, reject); },
+        };
+        return u;
+      };
       return q;
     },
   };
@@ -65,6 +76,12 @@ describe('routeFinding: re-emission is stamped, not re-inserted', () => {
     expect(sb.calls.updates).toHaveLength(1);
     expect(sb.calls.updates[0].payload.occurrence_count).toBe(8);
     expect(sb.calls.updates[0].payload.last_seen).toEqual(expect.any(String));
+    // THE UPDATE RE-ASSERTS ITS OWN SCOPE. The lookup already proved category and open-status, but
+    // the named anti-precedent in this very PR (gh-failure-monitor, live-bumping a RESOLVED row to
+    // occurrence_count 586) is precisely a correct-looking UPDATE fed by a lookup that lost a
+    // predicate. Split across two files, that invariant is one careless edit from gone.
+    expect(sb.calls.updates[0].category).toBe('invariant_gauge_finding');
+    expect(sb.calls.updates[0].status).toEqual(OPEN_FINDING_STATUSES);
   });
 
   it('INSERTS a first emission and stamps BOTH first_seen and last_seen', async () => {
@@ -207,6 +224,12 @@ describe('the dedup query asks the right question', () => {
     await routeFinding(sb, ENTRY, { count: 1 });
     expect(sb.calls.selects.join('|')).toContain('source_type=auto_capture');
     expect(sb.calls.isFilters).toContainEqual({ col: 'feedback_type', val: null });
+    // The category filter is what keeps the dedup key inside this runner's own row family; without
+    // it any auto_capture row with a matching gauge_id would mute the gauge.
+    expect(sb.calls.selects.join('|')).toContain('category=invariant_gauge_finding');
+    // An archived row still holds an open STATUS — archiving is not a status transition — so only
+    // this predicate stops an archived finding from muting its gauge from behind a filtered view.
+    expect(sb.calls.isFilters).toContainEqual({ col: 'archived_at', val: null });
   });
 
   it('picks the open row DETERMINISTICALLY — .limit(1) without .order() stamps an arbitrary sibling', async () => {

--- a/tests/unit/governance/gauge-finding-dedup.test.js
+++ b/tests/unit/governance/gauge-finding-dedup.test.js
@@ -16,34 +16,70 @@
 
 import { describe, it, expect, vi } from 'vitest';
 import { routeFinding, buildFindingRow, DEDUP_LOOKUP_TIMEOUT_MS } from '../../../scripts/gauge-runner.mjs';
-import { OPEN_FINDING_STATUSES } from '../../../lib/governance/plan-drift-detectors.js';
+import { OPEN_FINDING_STATUSES, hasOpenFinding } from '../../../lib/governance/plan-drift-detectors.js';
 
 const ENTRY = { id: 'test-gauge', name: 'Test Gauge', ownerRole: 'coordinator', remediation: 'do the thing' };
+
+/** Resolve a postgrest `metadata->>key` selector against a plain fixture row. */
+function matchJsonPath(row, selector) {
+  const [col, key] = selector.split('->>');
+  const v = row[col];
+  return v && typeof v === 'object' ? v[key] : undefined;
+}
 
 /**
  * Minimal supabase double. Records what was asked for so the assertions can check the SHAPE of the
  * query, not just its outcome — a dedup that returns the right verdict off the wrong query is the
  * defect this SD is about.
  */
+/**
+ * DB DEFAULTS THE RUNNER NEVER SETS. buildFindingRow omits these three columns entirely, so every
+ * row it writes takes the column default. Verified live against information_schema.columns:
+ *   feedback_type  NOT NULL DEFAULT 'sentry_error'   (0 of 15,394 rows are NULL — they cannot be)
+ *   archived_at    NULL     DEFAULT null
+ *   occurrence_count                                  (seeded on insert by the runner)
+ * Mirrored rather than imported ON PURPOSE: this is the schema's half of the contract, and a test
+ * that reads the same source as the code under test cannot catch the code disagreeing with the DB.
+ */
+const DB_DEFAULTS = { feedback_type: 'sentry_error', archived_at: null };
+
+/** The row this runner actually writes, as the database would hold it. */
+export function realGaugeRow(overrides = {}) {
+  return { id: 'row-1', occurrence_count: 1, ...buildFindingRow(ENTRY, { count: 1 }), ...DB_DEFAULTS, ...overrides };
+}
+
 function makeSupabase({ openRow = null, selectError = null, updateError = null, insertError = null, selectDelayMs = 0 } = {}) {
   const calls = { selects: [], updates: [], inserts: [], statusFilter: null, isFilters: [], order: null };
+  // FILTERS ARE APPLIED, NOT MERELY RECORDED — and this is the whole point of the rewrite.
+  // The previous double recorded every predicate and then returned `openRow` regardless. So when
+  // findOpenFinding asked `.is('feedback_type', null)` — a predicate NO row can satisfy, because
+  // the column is NOT NULL DEFAULT 'sentry_error' — the double answered "found it" and 162 tests
+  // went green over a dedup that could never fire once. Worse, the assertion I wrote to PROVE the
+  // fix was `expect(isFilters).toContainEqual({col:'feedback_type', val:null})`: the test pinned
+  // the fatal predicate AS the acceptance criterion. Recording a filter is not applying it.
+  // Now the fixture row carries real column semantics and the predicates run against it, so a
+  // filter that cannot match what the runner writes fails HERE instead of shipping silently.
+  const preds = [];
+  const matches = (row) => preds.every((p) => p(row));
   return {
     calls,
     from() {
       const q = {
         _isSelect: false,
         select(cols) { q._isSelect = true; calls.selects.push(cols); return q; },
-        eq(col, val) { if (col === 'id') calls.updates.at(-1).id = val; else calls.selects.push(`${col}=${val}`); return q; },
-        in(col, vals) { calls.statusFilter = { col, vals }; return q; },
-        // .is() and .order() are recorded, not ignored. A double that silently swallows a filter
-        // lets the query drift out from under its own assertions — which is how a dedup that asks
-        // the WRONG question still returns the right verdict and ships green.
-        is(col, val) { calls.isFilters.push({ col, val }); return q; },
+        eq(col, val) {
+          if (col === 'id') { calls.updates.at(-1).id = val; return q; }
+          calls.selects.push(`${col}=${val}`);
+          preds.push((row) => row[col] === val || (col.includes('->>') && matchJsonPath(row, col) === val));
+          return q;
+        },
+        in(col, vals) { calls.statusFilter = { col, vals }; preds.push((row) => vals.includes(row[col])); return q; },
+        is(col, val) { calls.isFilters.push({ col, val }); preds.push((row) => (row[col] ?? null) === val); return q; },
         order(col, opts) { calls.order = { col, ...opts }; return q; },
         async limit() {
           if (selectDelayMs) await new Promise((r) => setTimeout(r, selectDelayMs));
           if (selectError) return { data: null, error: { message: selectError } };
-          return { data: openRow ? [openRow] : [], error: null };
+          return { data: openRow && matches(openRow) ? [openRow] : [], error: null };
         },
         update(payload) { calls.updates.push({ payload }); return q; },
         async insert(row) { calls.inserts.push(row); return { error: insertError ? { message: insertError } : null }; },
@@ -55,9 +91,24 @@ function makeSupabase({ openRow = null, selectError = null, updateError = null, 
       const origUpdate = q.update;
       q.update = (payload) => {
         origUpdate(payload);
+        const upreds = [];
         const u = {
-          eq(col, val) { if (col === 'id') calls.updates.at(-1).id = val; else calls.updates.at(-1)[col] = val; return u; },
-          in(col, vals) { calls.updates.at(-1)[col] = vals; return u; },
+          eq(col, val) {
+            if (col === 'id') { calls.updates.at(-1).id = val; return u; }
+            calls.updates.at(-1)[col] = val;
+            upreds.push((row) => row[col] === val);
+            return u;
+          },
+          in(col, vals) { calls.updates.at(-1)[col] = vals; upreds.push((row) => vals.includes(row[col])); return u; },
+          is(col, val) { calls.updates.at(-1)[col] = val; upreds.push((row) => (row[col] ?? null) === val); return u; },
+          // .select() makes the UPDATE return its matched rows. The double applies the same
+          // predicates to the fixture, so an update whose filters exclude the row it is stamping
+          // resolves to [] here exactly as postgrest would — which is what turns a silent
+          // zero-row 'suppressed' into a visible error.
+          select() {
+            const matched = openRow && upreds.every((p) => p(openRow)) ? [{ id: openRow.id }] : [];
+            return Promise.resolve({ data: updateError ? null : matched, error: updateError ? { message: updateError } : null });
+          },
           then(resolve, reject) { return Promise.resolve({ error: updateError ? { message: updateError } : null }).then(resolve, reject); },
         };
         return u;
@@ -67,9 +118,58 @@ function makeSupabase({ openRow = null, selectError = null, updateError = null, 
   };
 }
 
+describe('THE LOOKUP MUST MATCH A ROW THE RUNNER ACTUALLY WROTE', () => {
+  // THE REGRESSION THAT ALMOST SHIPPED. findOpenFinding first filtered .is("feedback_type", null),
+  // reasoning from an RLS policy that mentions the column instead of from the column, which is NOT
+  // NULL DEFAULT 'sentry_error'. Every predicate was individually defensible; their CONJUNCTION
+  // could not match a single one of the 15,394 live rows, so the dedup was inert AND hasOpenFinding
+  // — the one function the PR promised not to change the value of — regressed to always-false,
+  // defeating plan-drift-mix's FR-5 re-surface-once dedup and re-firing its FR-6 dual-recipient
+  // push every hour. Two reviewers found it against the live DB; 162 green tests did not.
+
+  it('finds a row built by THIS runner and stored with the DB defaults it never sets', async () => {
+    // The fixture is buildFindingRow() output plus the real column defaults. If any filter in the
+    // lookup cannot be satisfied by the row the runner itself writes, this fails — which is the
+    // whole class of defect, not just the feedback_type instance.
+    const sb = makeSupabase({ openRow: realGaugeRow() });
+    expect(await routeFinding(sb, ENTRY, { count: 1 })).toBe('suppressed');
+    expect(sb.calls.inserts).toEqual([]);
+  });
+
+  it('hasOpenFinding still sees an existing open row — value preserved, not just type', async () => {
+    // hasOpenFinding was re-expressed as a coercion of findOpenFinding and silently inherited three
+    // new filters. Its type was preserved and its VALUE was not. Its sole production caller feeds
+    // it straight into skipRoute, so always-false is a live behaviour change, invisible to a test
+    // that only checks it returns a boolean.
+    const sb = makeSupabase({ openRow: realGaugeRow({ metadata: { gauge_id: 'plan-drift-mix' } }) });
+    expect(await hasOpenFinding(sb, 'plan-drift-mix')).toBe(true);
+  });
+
+  it('a row planted through an anon INSERT policy CANNOT mute a gauge', async () => {
+    // The reason the filters exist at all. Verified live in pg_policies: anon holds exactly two
+    // INSERT paths and every other feedback INSERT policy is service_role.
+    const telegram = makeSupabase({ openRow: realGaugeRow({ source_type: 'telegram' }) });
+    expect(await routeFinding(telegram, ENTRY, { count: 1 })).toBe('inserted');
+    const venture = makeSupabase({ openRow: realGaugeRow({ feedback_type: 'user_bug' }) });
+    expect(await routeFinding(venture, ENTRY, { count: 1 })).toBe('inserted');
+  });
+
+  it('an UPDATE that matches zero rows is an ERROR, never a silent suppressed', async () => {
+    // A row triaged or archived out of scope between lookup and stamp. supabase-js returns
+    // {error:null} for an UPDATE that touched nothing, so without the .select() this trip would be
+    // dropped AND counted as healthy dedup on the tally that exists to detect silence.
+    const sb = makeSupabase({ openRow: realGaugeRow() });
+    const origFrom = sb.from.bind(sb);
+    sb.from = () => { const q = origFrom(); const origUpdate = q.update;
+      q.update = (payload) => { const u = origUpdate(payload); const origSelect = u.select;
+        u.select = () => { void origSelect; return Promise.resolve({ data: [], error: null }); }; return u; }; return q; };
+    expect(await routeFinding(sb, ENTRY, { count: 1 })).toBe('error');
+  });
+});
+
 describe('routeFinding: re-emission is stamped, not re-inserted', () => {
   it('SUPPRESSES a re-emission and stamps last_seen + occurrence_count on the existing row', async () => {
-    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 7 } });
+    const sb = makeSupabase({ openRow: realGaugeRow({ occurrence_count: 7 }) });
     const verdict = await routeFinding(sb, ENTRY, { count: 1 });
     expect(verdict).toBe('suppressed');
     expect(sb.calls.inserts).toEqual([]);           // the whole point: no new row
@@ -100,7 +200,7 @@ describe('routeFinding: re-emission is stamped, not re-inserted', () => {
   });
 
   it('treats occurrence_count NULL as 1 rather than producing NaN', async () => {
-    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: null } });
+    const sb = makeSupabase({ openRow: realGaugeRow({ occurrence_count: null }) });
     await routeFinding(sb, ENTRY, { count: 1 });
     expect(sb.calls.updates[0].payload.occurrence_count).toBe(2);
   });
@@ -139,7 +239,7 @@ describe('the dedup must not destroy recurrence information', () => {
     // The clear is modelled as wont_fix because chk_resolved_requires_reference demands
     // resolution_notes or an FK for 'resolved' — a naive clear violates a constraint a double
     // cannot see.
-    const open = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 1 } });
+    const open = makeSupabase({ openRow: realGaugeRow({ occurrence_count: 1 }) });
     expect(await routeFinding(open, ENTRY, { count: 1 })).toBe('suppressed');
 
     const cleared = makeSupabase({ openRow: null });   // wont_fix -> no longer in OPEN_FINDING_STATUSES
@@ -159,13 +259,13 @@ describe('fail direction: toward a duplicate row, never toward silence', () => {
   it('INSERTS when the dedup lookup TIMES OUT rather than hanging the pass', async () => {
     // A hanging (not erroring) lookup across 22 gauges could exhaust the workflow budget and kill
     // a pass mid-flight, which reads as a fleet-down alarm — a dedup change causing a false outage.
-    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 1 }, selectDelayMs: DEDUP_LOOKUP_TIMEOUT_MS + 200 });
+    const sb = makeSupabase({ openRow: realGaugeRow({ occurrence_count: 1 }), selectDelayMs: DEDUP_LOOKUP_TIMEOUT_MS + 200 });
     const verdict = await routeFinding(sb, ENTRY, { count: 1 });
     expect(verdict).toBe('inserted');
   }, DEDUP_LOOKUP_TIMEOUT_MS + 3000);
 
   it('reports error (not silent success) when the stamp itself fails', async () => {
-    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 1 }, updateError: 'permission denied' });
+    const sb = makeSupabase({ openRow: realGaugeRow({ occurrence_count: 1 }), updateError: 'permission denied' });
     expect(await routeFinding(sb, ENTRY, { count: 1 })).toBe('error');
   });
 
@@ -181,7 +281,7 @@ describe('OBSERVABILITY: zero-inserted must mean tolerated, never unparsed', () 
     // every gauge holds an open row, `inserted` is permanently 0 — so a run that suppressed 13
     // re-emissions and a run where every gauge silently broke both insert nothing. Only a distinct
     // 'suppressed' verdict separates them.
-    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 3 } });
+    const sb = makeSupabase({ openRow: realGaugeRow({ occurrence_count: 3 }) });
     const verdict = await routeFinding(sb, ENTRY, { count: 1 });
     expect(verdict).toBe('suppressed');
     expect(verdict).not.toBe('skipped');   // skipRoute is a DIFFERENT reason for silence
@@ -207,7 +307,7 @@ describe('the dedup query asks the right question', () => {
     // NAMED ANTI-PRECEDENT (PRD TR-4): gh-failure-monitor.cjs:91-95 looks up by hash with NO status
     // filter, and live it is incrementing a RESOLVED row to occurrence_count 586. Only its UPDATE
     // half was reused here. This asserts we did not inherit its lookup.
-    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 1 } });
+    const sb = makeSupabase({ openRow: realGaugeRow({ occurrence_count: 1 }) });
     await routeFinding(sb, ENTRY, { count: 1 });
     expect(sb.calls.statusFilter).not.toBeNull();
     expect(sb.calls.statusFilter.col).toBe('status');
@@ -220,10 +320,18 @@ describe('the dedup query asks the right question', () => {
     // planted lookalike row would PERMANENTLY mute that invariant, because nothing clears a gauge
     // finding. This diff is what makes planting effective: while the insert was unconditional a
     // planted row suppressed nothing.
-    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 1 } });
+    const sb = makeSupabase({ openRow: realGaugeRow({ occurrence_count: 1 }) });
     await routeFinding(sb, ENTRY, { count: 1 });
     expect(sb.calls.selects.join('|')).toContain('source_type=auto_capture');
-    expect(sb.calls.isFilters).toContainEqual({ col: 'feedback_type', val: null });
+    expect(sb.calls.selects.join('|')).toContain('feedback_type=sentry_error');
+    // NOT .is(feedback_type, null). That was the first version, and it was the defect: the column is
+    // NOT NULL DEFAULT 'sentry_error', so the predicate was unsatisfiable and Postgres folded the
+    // whole lookup to a One-Time Filter: false. The dedup could never fire, and this very assertion
+    // — written to prove the fix — pinned the broken predicate as the acceptance criterion. What
+    // makes it catchable now is the line above plus a double that APPLIES filters: realGaugeRow()
+    // carries feedback_type='sentry_error', so any predicate the runner's own row cannot satisfy
+    // fails here. sentry_error still excludes both anon INSERT policies (venture requires
+    // feedback_type LIKE 'user_%'), so the mute defence is intact — verified live in pg_policies.
     // The category filter is what keeps the dedup key inside this runner's own row family; without
     // it any auto_capture row with a matching gauge_id would mute the gauge.
     expect(sb.calls.selects.join('|')).toContain('category=invariant_gauge_finding');
@@ -236,7 +344,7 @@ describe('the dedup query asks the right question', () => {
     // Up to 692 open rows share one gauge_id today. An unordered limit(1) picks arbitrarily and
     // then UPDATEs, perturbing the ordering it depended on, scattering occurrence_count across
     // hundreds of identical siblings with no authoritative row.
-    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 1 } });
+    const sb = makeSupabase({ openRow: realGaugeRow({ occurrence_count: 1 }) });
     await routeFinding(sb, ENTRY, { count: 1 });
     expect(sb.calls.order).toEqual({ col: 'created_at', ascending: false });
   });

--- a/tests/unit/governance/gauge-finding-dedup.test.js
+++ b/tests/unit/governance/gauge-finding-dedup.test.js
@@ -1,0 +1,190 @@
+/**
+ * Gauge-emission dedup at the routeFinding chokepoint.
+ * SD-FDBK-INFRA-LESSONS-CONVERSION-WIRING-001 (scope-gate piece; FR-1/FR-2 held by ruling).
+ *
+ * WHAT THIS GUARDS. routeFinding's insert was unconditional and 12 of 13 emitting detectors never
+ * opted into skipRoute, producing 5,374 rows for ~13 conditions at 0% disposition. The dedup is now
+ * default-on at the chokepoint.
+ *
+ * THE DANGEROUS HALF, AND WHY HALF THIS FILE IS ABOUT OBSERVABILITY RATHER THAN DEDUP.
+ * Nothing in this repo ever CLEARS a gauge finding — all 5,374 rows are status='new'. So once every
+ * tripping gauge holds an open row, this runner stops inserting FOREVER. plan-drift-mix, the one
+ * detector that already opted in, has exactly ONE row ever: tripped once, silently muted since.
+ * A quiet run and a broken run then look identical. The routing tally is the only thing that tells
+ * them apart, which is why 'suppressed' is asserted as a positive signal and not merely as "no row".
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { routeFinding, buildFindingRow, DEDUP_LOOKUP_TIMEOUT_MS } from '../../../scripts/gauge-runner.mjs';
+import { OPEN_FINDING_STATUSES } from '../../../lib/governance/plan-drift-detectors.js';
+
+const ENTRY = { id: 'test-gauge', name: 'Test Gauge', ownerRole: 'coordinator', remediation: 'do the thing' };
+
+/**
+ * Minimal supabase double. Records what was asked for so the assertions can check the SHAPE of the
+ * query, not just its outcome — a dedup that returns the right verdict off the wrong query is the
+ * defect this SD is about.
+ */
+function makeSupabase({ openRow = null, selectError = null, updateError = null, insertError = null, selectDelayMs = 0 } = {}) {
+  const calls = { selects: [], updates: [], inserts: [], statusFilter: null };
+  return {
+    calls,
+    from() {
+      const q = {
+        _isSelect: false,
+        select(cols) { q._isSelect = true; calls.selects.push(cols); return q; },
+        eq(col, val) { if (col === 'id') calls.updates.at(-1).id = val; else calls.selects.push(`${col}=${val}`); return q; },
+        in(col, vals) { calls.statusFilter = { col, vals }; return q; },
+        async limit() {
+          if (selectDelayMs) await new Promise((r) => setTimeout(r, selectDelayMs));
+          if (selectError) return { data: null, error: { message: selectError } };
+          return { data: openRow ? [openRow] : [], error: null };
+        },
+        update(payload) { calls.updates.push({ payload }); return q; },
+        async insert(row) { calls.inserts.push(row); return { error: insertError ? { message: insertError } : null }; },
+      };
+      // .update(...).eq(...) resolves as a thenable
+      const origUpdate = q.update;
+      q.update = (payload) => { origUpdate(payload); return { eq: async () => ({ error: updateError ? { message: updateError } : null }) }; };
+      return q;
+    },
+  };
+}
+
+describe('routeFinding: re-emission is stamped, not re-inserted', () => {
+  it('SUPPRESSES a re-emission and stamps last_seen + occurrence_count on the existing row', async () => {
+    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 7 } });
+    const verdict = await routeFinding(sb, ENTRY, { count: 1 });
+    expect(verdict).toBe('suppressed');
+    expect(sb.calls.inserts).toEqual([]);           // the whole point: no new row
+    expect(sb.calls.updates).toHaveLength(1);
+    expect(sb.calls.updates[0].payload.occurrence_count).toBe(8);
+    expect(sb.calls.updates[0].payload.last_seen).toEqual(expect.any(String));
+  });
+
+  it('INSERTS a first emission and stamps BOTH first_seen and last_seen', async () => {
+    // Regression: all 5,374 existing gauge rows have first_seen AND last_seen NULL. If the insert
+    // path does not seed them, the dedup branch has nothing to advance and "freshness retained"
+    // is half-built. My original spec claimed these were already populated — that figure was the
+    // ci_failure population, measured on the wrong set.
+    const sb = makeSupabase({ openRow: null });
+    const verdict = await routeFinding(sb, ENTRY, { count: 1 });
+    expect(verdict).toBe('inserted');
+    expect(sb.calls.updates).toEqual([]);
+    expect(sb.calls.inserts).toHaveLength(1);
+    expect(sb.calls.inserts[0].first_seen).toEqual(expect.any(String));
+    expect(sb.calls.inserts[0].last_seen).toEqual(expect.any(String));
+    expect(sb.calls.inserts[0].category).toBe('invariant_gauge_finding');
+  });
+
+  it('treats occurrence_count NULL as 1 rather than producing NaN', async () => {
+    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: null } });
+    await routeFinding(sb, ENTRY, { count: 1 });
+    expect(sb.calls.updates[0].payload.occurrence_count).toBe(2);
+  });
+});
+
+describe('the dedup must not destroy recurrence information', () => {
+  it('the open-status set does NOT treat backlog as cleared', () => {
+    // TRIP-CLEAR-TRIP depends entirely on this set. If `backlog` counted as cleared, a triaged
+    // finding would start re-inserting; if `resolved` counted as open, a genuine re-trip would be
+    // suppressed forever. The set IS the contract, so it is asserted directly.
+    expect(OPEN_FINDING_STATUSES).toContain('new');
+    expect(OPEN_FINDING_STATUSES).toContain('backlog');
+    expect(OPEN_FINDING_STATUSES).toContain('in_progress');
+    expect(OPEN_FINDING_STATUSES).not.toContain('resolved');
+    expect(OPEN_FINDING_STATUSES).not.toContain('wont_fix');
+  });
+
+  it('PREDICATE ONLY — trip, CLEAR, trip yields a second row', async () => {
+    // LABELLED PREDICATE, DELIBERATELY. Nothing in production clears a gauge finding today: all
+    // 5,374 rows are status='new', every automated closer is scoped to other categories, and the
+    // purpose-built drain writes to a table with zero rows ever written. So this pins the
+    // PREDICATE, not an observable production behaviour, and calling it an end-to-end guarantee
+    // would be the overclaim this SD family keeps producing.
+    // The clear is modelled as wont_fix because chk_resolved_requires_reference demands
+    // resolution_notes or an FK for 'resolved' — a naive clear violates a constraint a double
+    // cannot see.
+    const open = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 1 } });
+    expect(await routeFinding(open, ENTRY, { count: 1 })).toBe('suppressed');
+
+    const cleared = makeSupabase({ openRow: null });   // wont_fix -> no longer in OPEN_FINDING_STATUSES
+    expect(await routeFinding(cleared, ENTRY, { count: 1 })).toBe('inserted');
+    expect(cleared.calls.inserts).toHaveLength(1);
+  });
+});
+
+describe('fail direction: toward a duplicate row, never toward silence', () => {
+  it('INSERTS when the dedup lookup ERRORS', async () => {
+    const sb = makeSupabase({ selectError: 'connection reset' });
+    const verdict = await routeFinding(sb, ENTRY, { count: 1 });
+    expect(verdict).toBe('inserted');
+    expect(sb.calls.inserts).toHaveLength(1);
+  });
+
+  it('INSERTS when the dedup lookup TIMES OUT rather than hanging the pass', async () => {
+    // A hanging (not erroring) lookup across 22 gauges could exhaust the workflow budget and kill
+    // a pass mid-flight, which reads as a fleet-down alarm — a dedup change causing a false outage.
+    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 1 }, selectDelayMs: DEDUP_LOOKUP_TIMEOUT_MS + 200 });
+    const verdict = await routeFinding(sb, ENTRY, { count: 1 });
+    expect(verdict).toBe('inserted');
+  }, DEDUP_LOOKUP_TIMEOUT_MS + 3000);
+
+  it('reports error (not silent success) when the stamp itself fails', async () => {
+    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 1 }, updateError: 'permission denied' });
+    expect(await routeFinding(sb, ENTRY, { count: 1 })).toBe('error');
+  });
+
+  it('reports error when the insert fails', async () => {
+    const sb = makeSupabase({ openRow: null, insertError: 'constraint violation' });
+    expect(await routeFinding(sb, ENTRY, { count: 1 })).toBe('error');
+  });
+});
+
+describe('OBSERVABILITY: zero-inserted must mean tolerated, never unparsed', () => {
+  it('a suppressed re-emission is reported as SUPPRESSED, not as nothing-happened', async () => {
+    // This is the acceptance criterion the coordinator ruled IS the gate. Once nothing clears and
+    // every gauge holds an open row, `inserted` is permanently 0 — so a run that suppressed 13
+    // re-emissions and a run where every gauge silently broke both insert nothing. Only a distinct
+    // 'suppressed' verdict separates them.
+    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 3 } });
+    const verdict = await routeFinding(sb, ENTRY, { count: 1 });
+    expect(verdict).toBe('suppressed');
+    expect(verdict).not.toBe('skipped');   // skipRoute is a DIFFERENT reason for silence
+  });
+
+  it('detector self-suppression stays distinguishable from dedup suppression', async () => {
+    // skipRoute also covers the starved short-circuit, which is not a re-emission at all. Folding
+    // the two into one verdict would conflate "already reported" with "not a real finding".
+    const sb = makeSupabase({ openRow: null });
+    expect(await routeFinding(sb, ENTRY, { count: 1, skipRoute: true })).toBe('skipped');
+    expect(sb.calls.inserts).toEqual([]);
+    expect(sb.calls.selects).toEqual([]);   // and it short-circuits BEFORE the lookup
+  });
+
+  it('CONTROL: the four verdicts are distinct, so the tally cannot collapse', () => {
+    const verdicts = new Set(['inserted', 'suppressed', 'skipped', 'error']);
+    expect(verdicts.size).toBe(4);
+  });
+});
+
+describe('the dedup query asks the right question', () => {
+  it('filters on the OPEN statuses — an unfiltered lookup would bump counts on closed rows', async () => {
+    // NAMED ANTI-PRECEDENT (PRD TR-4): gh-failure-monitor.cjs:91-95 looks up by hash with NO status
+    // filter, and live it is incrementing a RESOLVED row to occurrence_count 586. Only its UPDATE
+    // half was reused here. This asserts we did not inherit its lookup.
+    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 1 } });
+    await routeFinding(sb, ENTRY, { count: 1 });
+    expect(sb.calls.statusFilter).not.toBeNull();
+    expect(sb.calls.statusFilter.col).toBe('status');
+    expect(sb.calls.statusFilter.vals).toEqual(OPEN_FINDING_STATUSES);
+  });
+
+  it('keys on the gauge id, which buildFindingRow also writes', async () => {
+    const row = buildFindingRow(ENTRY, { count: 1 });
+    expect(row.metadata.gauge_id).toBe(ENTRY.id);
+    const sb = makeSupabase({ openRow: null });
+    await routeFinding(sb, ENTRY, { count: 1 });
+    expect(sb.calls.selects.join('|')).toContain(`metadata->>gauge_id=${ENTRY.id}`);
+  });
+});

--- a/tests/unit/governance/gauge-finding-dedup.test.js
+++ b/tests/unit/governance/gauge-finding-dedup.test.js
@@ -26,7 +26,7 @@ const ENTRY = { id: 'test-gauge', name: 'Test Gauge', ownerRole: 'coordinator', 
  * defect this SD is about.
  */
 function makeSupabase({ openRow = null, selectError = null, updateError = null, insertError = null, selectDelayMs = 0 } = {}) {
-  const calls = { selects: [], updates: [], inserts: [], statusFilter: null };
+  const calls = { selects: [], updates: [], inserts: [], statusFilter: null, isFilters: [], order: null };
   return {
     calls,
     from() {
@@ -35,6 +35,11 @@ function makeSupabase({ openRow = null, selectError = null, updateError = null, 
         select(cols) { q._isSelect = true; calls.selects.push(cols); return q; },
         eq(col, val) { if (col === 'id') calls.updates.at(-1).id = val; else calls.selects.push(`${col}=${val}`); return q; },
         in(col, vals) { calls.statusFilter = { col, vals }; return q; },
+        // .is() and .order() are recorded, not ignored. A double that silently swallows a filter
+        // lets the query drift out from under its own assertions — which is how a dedup that asks
+        // the WRONG question still returns the right verdict and ships green.
+        is(col, val) { calls.isFilters.push({ col, val }); return q; },
+        order(col, opts) { calls.order = { col, ...opts }; return q; },
         async limit() {
           if (selectDelayMs) await new Promise((r) => setTimeout(r, selectDelayMs));
           if (selectError) return { data: null, error: { message: selectError } };
@@ -94,6 +99,18 @@ describe('the dedup must not destroy recurrence information', () => {
     expect(OPEN_FINDING_STATUSES).toContain('in_progress');
     expect(OPEN_FINDING_STATUSES).not.toContain('resolved');
     expect(OPEN_FINDING_STATUSES).not.toContain('wont_fix');
+  });
+
+  it('is checked against the FULL live status domain, so an omission cannot hide', () => {
+    // The assertions above are not.toContain checks, which BY CONSTRUCTION cannot catch a MISSING
+    // open status. That is exactly how 'triaged' was dropped from the first version while the suite
+    // stayed green: the live feedback_status_check domain contains it, and omitting it would have
+    // re-armed hourly amplification the moment anyone started triaging the 5,382-row backlog --
+    // i.e. on first contact with the intended use. Partition the WHOLE domain instead.
+    const LIVE_STATUS_DOMAIN = ['new', 'triaged', 'in_progress', 'resolved', 'wont_fix', 'duplicate', 'invalid', 'backlog', 'shipped'];
+    const CLOSED = ['resolved', 'wont_fix', 'duplicate', 'invalid', 'shipped'];
+    const open = LIVE_STATUS_DOMAIN.filter((s) => !CLOSED.includes(s));
+    expect([...OPEN_FINDING_STATUSES].sort()).toEqual([...open].sort());
   });
 
   it('PREDICATE ONLY — trip, CLEAR, trip yields a second row', async () => {
@@ -178,6 +195,27 @@ describe('the dedup query asks the right question', () => {
     expect(sb.calls.statusFilter).not.toBeNull();
     expect(sb.calls.statusFilter.col).toBe('status');
     expect(sb.calls.statusFilter.vals).toEqual(OPEN_FINDING_STATUSES);
+  });
+
+  it('SECURITY: restricts to rows this runner could have written, so an anon row cannot mute a gauge', async () => {
+    // RLS grants anon an INSERT path constrained on source_type='telegram' ONLY — category, status
+    // and metadata are caller-supplied, and the anon key is public. Without these predicates a
+    // planted lookalike row would PERMANENTLY mute that invariant, because nothing clears a gauge
+    // finding. This diff is what makes planting effective: while the insert was unconditional a
+    // planted row suppressed nothing.
+    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 1 } });
+    await routeFinding(sb, ENTRY, { count: 1 });
+    expect(sb.calls.selects.join('|')).toContain('source_type=auto_capture');
+    expect(sb.calls.isFilters).toContainEqual({ col: 'feedback_type', val: null });
+  });
+
+  it('picks the open row DETERMINISTICALLY — .limit(1) without .order() stamps an arbitrary sibling', async () => {
+    // Up to 692 open rows share one gauge_id today. An unordered limit(1) picks arbitrarily and
+    // then UPDATEs, perturbing the ordering it depended on, scattering occurrence_count across
+    // hundreds of identical siblings with no authoritative row.
+    const sb = makeSupabase({ openRow: { id: 'row-1', occurrence_count: 1 } });
+    await routeFinding(sb, ENTRY, { count: 1 });
+    expect(sb.calls.order).toEqual({ col: 'created_at', ascending: false });
   });
 
   it('keys on the gauge id, which buildFindingRow also writes', async () => {

--- a/tests/unit/governance/gauge-registry.test.js
+++ b/tests/unit/governance/gauge-registry.test.js
@@ -420,4 +420,15 @@ describe('buildFindingRow (FR-3 alerting row shape)', () => {
     expect(row.description).toContain('gid');
     expect(row.description).toContain('do the thing');
   });
+  it('gauge ids are UNIQUE — a duplicate id is now silent cross-gauge suppression, not a cosmetic clash', () => {
+    // BEHAVIOUR CHANGED BY THE DEDUP SD. Before it, routeFinding inserted unconditionally and two
+    // registry entries sharing an id produced two rows — ugly, harmless, visible. Now the dedup key
+    // IS metadata.gauge_id, so the second entry finds the FIRST one's open row and suppresses
+    // itself forever. One gauge silently stops reporting and the routing tally counts it as a
+    // healthy 'suppressed'. Nothing else in the registry pins this.
+    const ids = GAUGE_REGISTRY.map((g) => g.id);
+    const dupes = ids.filter((id, i) => ids.indexOf(id) !== i);
+    expect(dupes).toEqual([]);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
 });

--- a/tests/unit/plan-drift-detectors.test.js
+++ b/tests/unit/plan-drift-detectors.test.js
@@ -112,18 +112,21 @@ describe('plan-drift-detectors', () => {
   });
 
   describe('hasOpenFinding (FR-5 re-surface-once dedup, TS-6)', () => {
+    // Flat chainable double rather than the previous hand-nested select→eq→eq→in→limit shape.
+    // That shape encoded the exact filter LIST, so adding a predicate to the query — here the
+    // .is('feedback_type', null) and .order() that stop an anon-planted row from muting a gauge —
+    // failed with "…is not a function" in a file that has no opinion about the filter list.
+    // These three tests assert hasOpenFinding's VERDICT (true / false / throws). The query SHAPE is
+    // asserted where it belongs, in gauge-finding-dedup.test.js, whose double RECORDS every filter
+    // — so making this one permissive drops no coverage.
     const fakeSupabase = (rows, err = null) => ({
-      from: (table) => ({
-        select: () => ({
-          eq: (col1, val1) => ({
-            eq: (col2, val2) => ({
-              in: () => ({
-                limit: () => Promise.resolve({ data: rows, error: err }),
-              }),
-            }),
-          }),
-        }),
-      }),
+      from: () => {
+        const q = {
+          select: () => q, eq: () => q, in: () => q, is: () => q, order: () => q,
+          limit: () => Promise.resolve({ data: rows, error: err }),
+        };
+        return q;
+      },
     });
 
     it('returns true when an OPEN finding already exists for the gauge_id', async () => {


### PR DESCRIPTION
## Summary

13 gauges re-emitted identical standing trips every pass: **5,374 rows for ~13 distinct conditions** (~77x amplification) at **0% disposition**, growing 200–330/day. `routeFinding`'s insert was unconditional and 12 of 13 detectors never opted into the `skipRoute` dedup that already existed.

Contrast: `ci_failure` absorbs far *more* raw events, stays at ~2,104 rows, and is 99.9% dispositioned — because it collapses re-emissions onto `last_seen`.

## The dedup is the easy half

**This change makes the gauge system quiet.** Nothing in this repo ever *clears* a gauge finding — all 5,374 rows are `status='new'`. So once every tripping gauge holds an open row, the runner stops inserting **permanently**.

That isn't a prediction: `plan-drift-mix`, the one detector already opted in, has **exactly one row, ever**. Tripped once, silently muted since — a live instance of this change already running.

5,374 rows at 0% disposition → ~14 rows at 0% disposition is a real **noise** win and **zero observability** win. A system that is wrong and noisy gets fixed; a system that is wrong and quiet does not.

So `routeFinding` now returns `inserted|suppressed|skipped|error`, `main()` accumulates, and the tally lands in the heartbeat `findings[]` that `coordinator-hourly-review` already reads. **The suppressed count is the only thing separating "deduped and still watching" from "every gauge broke."**

## Four things I specified wrong and corrected

All the same shape — each claim was *about code I had not opened*:

1. **"Zero new mechanism" was false.** `hasOpenFinding` returns a boolean and selects only `id`; it cannot supply the row and count a stamp needs. Added `findOpenFinding` (row-returning), with the boolean re-expressed on top so its two existing callers are untouched.
2. **I cited a precedent that fails my own requirement.** `gh-failure-monitor.cjs:92-128` includes a lookup at `:91-95` with **no status filter** — live, it is bumping a **resolved** row to `occurrence_count` 586. Only the UPDATE half is reused; the lookup is a named anti-precedent in the PRD.
3. **Right column, wrong population.** I claimed `first_seen`/`last_seen` were populated — that was `ci_failure`. All 5,374 gauge rows have both NULL. The insert path now seeds them.
4. Rate understated: 200–330/day, not ~184.

## Fail direction

Toward a duplicate row, never toward silence. Both the throw path and a new 4s timeout fall through to insert. The timeout exists because a *hanging* lookup across 22 gauges could exhaust the workflow budget and kill a pass — a dedup change causing a false fleet-down alarm.

## Tests

14 new. Two exist specifically so they cannot pass vacuously: trip-clear-trip is **labelled a predicate test** (nothing clears in production, so calling it end-to-end would be an overclaim), and the open-status set is asserted directly because it *is* the trip-clear-trip contract.

**Falsified**: removing the status filter trips 1 of 14; restored, 14/14. Anchor asserted before the red was believed.

## No regression — established causally, not by a count

Tier: 7 failed files / 11 tests vs a 9/12 baseline — *fewer*, which is a flakiness signal, not evidence. The real check: all 7 are the known pre-existing set, **none reference `gauge-runner`, `plan-drift-detectors`, or the new test**, and the two existing suites over the changed module are 64/64.

## Scope

FR-1/2/3/4 remain **held** pending the commissioning chain. This is the gauge-dedup piece only, authorised as independent of both the falsified premise and the unapplied migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)