### PR TITLE
feat(SD-FDBK-INFRA-TRUTH-DEMAND-THESIS-001): the S21 gate demanded an artifact nothing could produce

### DIFF
--- a/lib/eva/artifact-types.js
+++ b/lib/eva/artifact-types.js
@@ -339,7 +339,11 @@ export const DEPRECATED_ARTIFACT_TYPES = Object.freeze(Object.keys(DEPRECATED_TO
 export const ARTIFACT_TYPE_BY_STAGE = Object.freeze({
   0: [ARTIFACT_TYPES.INTAKE_VENTURE_ANALYSIS],
   1: [ARTIFACT_TYPES.TRUTH_IDEA_BRIEF],
-  2: [ARTIFACT_TYPES.TRUTH_AI_CRITIQUE],
+  // SD-FDBK-INFRA-TRUTH-DEMAND-THESIS-001 (FR-2): TRUTH_DEMAND_THESIS is APPENDED, never first.
+  // Every consumer reads [0] as the stage's canonical persist type (stage-execution-engine.js:414,
+  // :699; eva-orchestrator.js:544), so prepending would silently retype every stage-2 artifact.
+  // Order is load-bearing here and pinned by tests/unit/eva/stage-02-registration.test.js.
+  2: [ARTIFACT_TYPES.TRUTH_AI_CRITIQUE, ARTIFACT_TYPES.TRUTH_DEMAND_THESIS],
   3: [ARTIFACT_TYPES.TRUTH_VALIDATION_DECISION],
   4: [ARTIFACT_TYPES.TRUTH_COMPETITIVE_ANALYSIS],
   5: [ARTIFACT_TYPES.TRUTH_FINANCIAL_MODEL],

--- a/lib/eva/demand-thesis-validator.js
+++ b/lib/eva/demand-thesis-validator.js
@@ -1,0 +1,160 @@
+/**
+ * SD-FDBK-INFRA-TRUTH-DEMAND-THESIS-001 (FR-3) — is this demand thesis FALSIFIABLE ON ITS FACE?
+ *
+ * *** THE GATE THIS BACKS ALREADY PASSES ANYTHING SHAPED LIKE A THESIS. ***
+ * validateThesisChannelClaim (stage-22-distribution-setup.js:182-217) checks only WHO and CHANNEL
+ * shape. PAIN, ALTERNATIVES, WTP, KILL_CRITERIA and evidence grade are unenforced — an existing test
+ * (stage-22-distribution-setup.test.js:231) proves an arbitrary evidence_grade of 'B' passes. So a
+ * fabricated-but-shaped thesis clears the S21 precondition identically to an adjudicated one, and
+ * because the precondition is portfolio-wide, a wrong thesis does not fail locally. It succeeds
+ * everywhere while making the artifact type meaningless. That is the TIER-3 justification, and it
+ * is why presence is not the standard here — REFUTABILITY is.
+ *
+ * A reader must be able to state what evidence would refute each claim. Per
+ * docs/design/venture-selection-demand-thesis-design.md §1-2: six claims, each with an explicit
+ * "falsified by", and every claim at evidence grade >=E1 or explicitly tagged an E0 assumption.
+ *
+ * ── KILL_CRITERIA IS DELIBERATELY EXEMPT FROM THE falsified_by RULE ───────────────────────────
+ * MEASURED on ApexNiche's real adjudicated thesis: WHO/PAIN/ALTERNATIVES/CHANNEL/WTP each carry
+ * falsified_by + evidence_grade. KILL_CRITERIA carries ONLY kills[]. That is not an omission — the
+ * design doc's own six-row table gives its "falsified by" cell as "(this row is what makes the rest
+ * honest)", a meta-statement rather than a literal condition.
+ *
+ * A UNIFORM "every claim needs falsified_by" RULE WOULD THEREFORE DO ONE OF TWO THINGS, BOTH BAD:
+ * reject the only real thesis in the fleet, or force an author to synthesise a value the source
+ * never had — which is exactly the "quietly rewrites its source" fabrication FR-4 forbids. The
+ * validator would have mandated what its sibling requirement prohibits. So KILL_CRITERIA is checked
+ * on its structural equivalent instead: each kill needs a criterion AND a threshold, because a kill
+ * condition with no threshold is just as unfalsifiable as a claim with no refutation.
+ */
+
+/** The six claims the design doc requires. Order is the doc's. */
+export const REQUIRED_CLAIMS = Object.freeze(['WHO', 'PAIN', 'ALTERNATIVES', 'CHANNEL', 'WTP', 'KILL_CRITERIA']);
+
+/** Claims judged on falsified_by + evidence_grade. KILL_CRITERIA is judged on kills[] — see docblock. */
+export const REFUTABLE_CLAIMS = Object.freeze(['WHO', 'PAIN', 'ALTERNATIVES', 'CHANNEL', 'WTP']);
+
+/** §2 evidence ladder. E0 is an assumption and must say so; E1+ is grounded in something. */
+export const EVIDENCE_GRADES = Object.freeze(['E0', 'E1', 'E2', 'E3']);
+
+const nonEmpty = (v) => typeof v === 'string' && v.trim().length > 0;
+
+/**
+ * Resolve an evidence_grade to its EFFECTIVE (weakest) ladder value, or null if it names none.
+ *
+ * *** THE FIRST CUT OF THIS VALIDATOR REJECTED THE ONLY REAL THESIS IN THE FLEET. ***
+ * It required evidence_grade to be exactly one of E0-E3. ApexNiche's adjudicated WTP claim reads
+ * "E1-anchor / E0-elicitation" — a COMPOUND grade, because the adjudicator graded the price anchor
+ * and the willingness-to-pay elicitation separately. That is MORE precise than a bare grade, not
+ * less, and rejecting it would have forced the backfill to dumb its source down to a single value —
+ * a quieter cousin of the fabrication FR-4 forbids: not inventing content, but discarding
+ * adjudicated nuance to satisfy a validator that assumed a simpler world than the one it validates.
+ *
+ * Takes the WEAKEST grade present, because a claim is only as grounded as its softest component.
+ * "E1-anchor / E0-elicitation" therefore resolves to E0 — an assumption, correctly.
+ */
+export function effectiveEvidenceGrade(raw) {
+  if (typeof raw !== 'string') return null;
+  const found = raw.toUpperCase().match(/\bE[0-3]\b/g);
+  if (!found || found.length === 0) return null;
+  return found.sort()[0]; // E0 < E1 < E2 < E3 lexicographically
+}
+
+/**
+ * PURE/TOTAL. Never throws — a validator that can throw becomes a reason to wrap it in a try/catch
+ * that swallows the verdict, which is how this codebase lost an LLM path for 172 days.
+ *
+ * @param {object} thesis - the `thesis` object (expects `.claims`)
+ * @param {object} [opts]
+ * @param {boolean} [opts.allowE0Assumptions=true] - accept E0 when explicitly tagged as an assumption
+ * @returns {{valid:boolean, violations:Array<{claim:string,code:string,detail:string}>, checked:string[]}}
+ */
+export function validateDemandThesisFalsifiability(thesis, { allowE0Assumptions = true } = {}) {
+  const violations = [];
+  const claims = thesis && typeof thesis === 'object' ? (thesis.claims || null) : null;
+
+  if (!claims || typeof claims !== 'object') {
+    return {
+      valid: false,
+      violations: [{ claim: '(root)', code: 'NO_CLAIMS', detail: 'thesis.claims is missing or not an object' }],
+      checked: []
+    };
+  }
+
+  for (const name of REQUIRED_CLAIMS) {
+    if (!claims[name] || typeof claims[name] !== 'object') {
+      violations.push({ claim: name, code: 'CLAIM_MISSING', detail: `required claim ${name} is absent` });
+    }
+  }
+
+  for (const name of REFUTABLE_CLAIMS) {
+    const c = claims[name];
+    if (!c || typeof c !== 'object') continue; // already reported as missing
+
+    if (!nonEmpty(c.falsified_by)) {
+      violations.push({
+        claim: name, code: 'NOT_FALSIFIABLE',
+        detail: `${name} has no falsified_by — a reader cannot state what evidence would refute it`
+      });
+    }
+
+    const grade = effectiveEvidenceGrade(c.evidence_grade);
+    if (!grade) {
+      violations.push({
+        claim: name, code: 'EVIDENCE_GRADE_INVALID',
+        detail: `${name} evidence_grade ${JSON.stringify(c.evidence_grade)} names no grade on the ${EVIDENCE_GRADES.join('/')} ladder`
+      });
+    } else if (grade === 'E0' && !allowE0Assumptions) {
+      violations.push({ claim: name, code: 'E0_NOT_PERMITTED', detail: `${name} is E0 and E0 assumptions are not permitted here` });
+    }
+  }
+
+  // KILL_CRITERIA — structural equivalent, per the docblock.
+  const kc = claims.KILL_CRITERIA;
+  if (kc && typeof kc === 'object') {
+    const kills = Array.isArray(kc.kills) ? kc.kills : null;
+    if (!kills || kills.length === 0) {
+      violations.push({
+        claim: 'KILL_CRITERIA', code: 'NO_KILLS',
+        detail: 'KILL_CRITERIA has no kills[] — it is the row that makes the others honest, so an empty one voids the thesis'
+      });
+    } else {
+      kills.forEach((k, i) => {
+        if (!k || typeof k !== 'object') {
+          violations.push({ claim: 'KILL_CRITERIA', code: 'KILL_MALFORMED', detail: `kills[${i}] is not an object` });
+          return;
+        }
+        if (!nonEmpty(k.criterion)) {
+          violations.push({ claim: 'KILL_CRITERIA', code: 'KILL_NO_CRITERION', detail: `kills[${i}] has no criterion` });
+        }
+        // A kill with no threshold is unfalsifiable in exactly the way falsified_by guards against.
+        if (!nonEmpty(k.threshold)) {
+          violations.push({
+            claim: 'KILL_CRITERIA', code: 'KILL_NO_THRESHOLD',
+            detail: `kills[${i}] has no threshold — "it dies if demand is weak" is not a kill condition`
+          });
+        }
+      });
+    }
+  }
+
+  return { valid: violations.length === 0, violations, checked: REQUIRED_CLAIMS.slice() };
+}
+
+/**
+ * PURE/TOTAL. Does the promoted artifact faithfully reproduce its source (FR-4 / TS-4)?
+ *
+ * A backfill that quietly improves its source is indistinguishable from one that fabricates it, so
+ * this is deliberately one-directional: every claim in the ARTIFACT must exist in the SOURCE. The
+ * reverse is permitted — a promotion may carry fewer claims than the source (and the falsifiability
+ * check above will catch a missing REQUIRED one) but never MORE.
+ *
+ * @returns {{faithful:boolean, invented:string[], missing:string[]}}
+ */
+export function verifyPromotionFaithfulness(artifactClaims, sourceClaims) {
+  const a = artifactClaims && typeof artifactClaims === 'object' ? artifactClaims : {};
+  const s = sourceClaims && typeof sourceClaims === 'object' ? sourceClaims : {};
+  const invented = Object.keys(a).filter((k) => !(k in s));
+  const missing = Object.keys(s).filter((k) => !(k in a));
+  return { faithful: invented.length === 0, invented, missing };
+}

--- a/lib/eva/stage-templates/analysis-steps/stage-02-demand-thesis.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-02-demand-thesis.js
@@ -48,7 +48,12 @@ export function isArtifactTypePendingChairmanGate(type, { gatePath = PENDING_GAT
     const allow = raw && raw.allow;
     if (Array.isArray(allow)) return allow.includes(type) || allow.some((e) => e && e.type === type);
     if (allow && typeof allow === 'object') return Object.prototype.hasOwnProperty.call(allow, type);
-    return false;
+    // SECURITY finding: the fail-safe originally covered only read/parse errors. Valid JSON with a
+    // MISSING or wrong-typed `allow` key fell through to `false` — "not pending" — which would let
+    // the producer attempt a write that raises Postgres 23514 on every stage-2 run fleet-wide. An
+    // unrecognised gate file is exactly as uninformative as an unreadable one, so it takes the same
+    // safe direction.
+    return true;
   } catch {
     return true;
   }
@@ -66,6 +71,22 @@ export function isArtifactTypePendingChairmanGate(type, { gatePath = PENDING_GAT
  * @returns {{action:'promote'|'refuse'|'defer', reason:string, artifact?:object, violations?:Array}}
  */
 export function decideDemandThesisAction({ ventureMetadata, typePending } = {}) {
+  // *** "WE COULD NOT LOOK" AND "THERE IS NOTHING THERE" ARE DIFFERENT FACTS. ***
+  // The first cut collapsed both into NO_ADJUDICATED_THESIS with no logging, so a systemic Supabase
+  // blip would have read as "no venture in the fleet has a thesis" — indistinguishable from the real
+  // 117-of-118 case, and with a confidently-worded reason saying the thesis "is absent". That is
+  // this SD's own defect class reproduced inside its own fix, in the fail-soft I wrote to be
+  // careful. Still non-throwing; just no longer lying about which fact it observed.
+  if (ventureMetadata === CHECK_FAILED) {
+    return {
+      action: 'refuse',
+      reason:
+        'THESIS_CHECK_FAILED: could not read ventures.metadata, so whether an adjudicated thesis ' +
+        'exists is UNKNOWN — this is not a finding that one is absent. Stage 2 continues; re-run ' +
+        'once the read succeeds.'
+    };
+  }
+
   const staged = ventureMetadata && typeof ventureMetadata === 'object'
     ? ventureMetadata.demand_thesis_staged
     : null;
@@ -114,24 +135,46 @@ export function decideDemandThesisAction({ ventureMetadata, typePending } = {}) 
     };
   }
 
-  // FR-4 — promote verbatim. Faithfulness is checked against the source, not asserted.
-  const claims = staged.thesis.claims;
-  const faith = verifyPromotionFaithfulness(claims, claims);
+  // FR-4 — promote verbatim, and CHECK it rather than assert it.
+  //
+  // *** THE FIRST CUT CALLED verifyPromotionFaithfulness(claims, claims) — THE SAME OBJECT TWICE. ***
+  // The comment above it read "faithfulness is checked against the source, not asserted", and that
+  // was false as written: comparing a thing to itself can only ever return faithful:true, so the
+  // provenance field was a structural constant wearing the costume of a check. That is precisely the
+  // control-that-cannot-fail class this SD exists to remove, recreated one layer down, inside the
+  // function whose docblock denied doing it. Found by SECURITY with a two-different-objects control
+  // proving the detector itself works.
+  //
+  // Now the payload is BUILT FIRST and the comparison runs against what will actually be written, so
+  // any future transformation between reading the staged thesis and emitting the artifact is caught
+  // instead of blessed.
+  const payload = {
+    ...staged.thesis,
+    provenance: {
+      source: 'ventures.metadata.demand_thesis_staged',
+      promoted_verbatim: true,
+      staged_reason: typeof staged.reason === 'string' ? staged.reason : null,
+      parked_at: staged.parked_at ?? null
+    }
+  };
+  const faith = verifyPromotionFaithfulness(payload.claims, staged.thesis.claims);
+  if (!faith.faithful) {
+    return {
+      action: 'refuse',
+      reason:
+        'PROMOTION_NOT_FAITHFUL: the artifact would carry claims absent from the staged source ' +
+        `(${faith.invented.join(', ')}). A backfill that quietly improves its source is ` +
+        'indistinguishable from one that fabricates it, so this refuses rather than writes.'
+    };
+  }
+  payload.provenance.faithful = true; // now derived from the comparison above, not asserted
+
   return {
     action: 'promote',
     reason: 'PROMOTED_FROM_STAGED: adjudicated thesis promoted verbatim from ventures.metadata.demand_thesis_staged',
     artifact: {
       artifactType: ARTIFACT_TYPES.TRUTH_DEMAND_THESIS,
-      payload: {
-        ...staged.thesis,
-        provenance: {
-          source: 'ventures.metadata.demand_thesis_staged',
-          promoted_verbatim: true,
-          faithful: faith.faithful,
-          staged_reason: typeof staged.reason === 'string' ? staged.reason : null,
-          parked_at: staged.parked_at ?? null
-        }
-      },
+      payload,
       source: 'analysis-step:stage-02-demand-thesis'
     }
   };
@@ -144,14 +187,21 @@ export function decideDemandThesisAction({ ventureMetadata, typePending } = {}) 
  * that would turn "we could not look" into "the whole stage failed", which is the same
  * absence-mistaken-for-a-verdict error this SD is about, pointed at the wrong stage.
  */
-export async function loadVentureMetadata(supabase, ventureId) {
-  if (!supabase || !ventureId) return null;
+export const CHECK_FAILED = Symbol('demand-thesis-check-failed');
+
+export async function loadVentureMetadata(supabase, ventureId, { logger = console } = {}) {
+  if (!supabase || !ventureId) return CHECK_FAILED;
   try {
     const { data, error } = await supabase.from('ventures').select('metadata').eq('id', ventureId).maybeSingle();
-    if (error || !data) return null;
+    if (error) {
+      logger.warn?.(`[Stage02/demand-thesis] could not read ventures.metadata: ${error.message}`);
+      return CHECK_FAILED;
+    }
+    if (!data) return null; // the venture row genuinely has no metadata — a real absence
     return data.metadata ?? null;
-  } catch {
-    return null;
+  } catch (e) {
+    logger.warn?.(`[Stage02/demand-thesis] could not read ventures.metadata: ${e?.message || e}`);
+    return CHECK_FAILED;
   }
 }
 
@@ -167,9 +217,34 @@ export function attachDemandThesisArtifact(stageResult, { ventureMetadata, typeP
   const decision = decideDemandThesisAction({ ventureMetadata, typePending });
   const existing = Array.isArray(base.artifacts) ? base.artifacts : [];
 
+  // Nothing to co-emit — leave the result exactly as stage 2 produced it, including the ABSENCE of
+  // a typed array, so the engine keeps using its normal single-artifact path.
+  if (decision.action !== 'promote') {
+    return { ...base, demand_thesis: { action: decision.action, reason: decision.reason } };
+  }
+
+  // *** THE FIRST CUT SILENTLY DROPPED STAGE 2'S OWN ARTIFACT. ***
+  // Both consumers treat a NON-EMPTY typed array as EXCLUSIVE — once `artifacts[]` exists, the
+  // engine persists those entries and stops deriving the canonical artifact from the flat payload.
+  // stage-14, the precedent this follows, wraps its OWN output as the first entry for exactly that
+  // reason; mine appended only the thesis, so `artifacts` came out length-1 and truth_ai_critique —
+  // stage 2's actual job — was never written. No error, no warning: the stage would have reported
+  // success while losing its primary output.
+  //
+  // Dormant only because the DDL gate makes this branch unreachable today. It would have fired on
+  // ApexNiche's FIRST post-migration stage-2 run, whose staged thesis already validates. Found by
+  // TESTING with an executable repro against analyzeStage02's real return shape.
+  const withOwnArtifact = existing.length > 0
+    ? existing
+    : [{
+        artifactType: ARTIFACT_TYPES.TRUTH_AI_CRITIQUE,
+        payload: { ...base },
+        source: 'analysis-step:stage-02'
+      }];
+
   return {
     ...base,
     demand_thesis: { action: decision.action, reason: decision.reason },
-    artifacts: decision.action === 'promote' ? [...existing, decision.artifact] : existing
+    artifacts: [...withOwnArtifact, decision.artifact]
   };
 }

--- a/lib/eva/stage-templates/analysis-steps/stage-02-demand-thesis.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-02-demand-thesis.js
@@ -23,10 +23,11 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { ARTIFACT_TYPES } from '../../artifact-types.js';
-import {
-  validateDemandThesisFalsifiability,
-  verifyPromotionFaithfulness
-} from '../../demand-thesis-validator.js';
+// NOTE: verifyPromotionFaithfulness is deliberately NOT imported here. This file's promotion path is
+// a verbatim spread, so that comparison is unreachable by construction — see the promote branch. It
+// remains exported from demand-thesis-validator.js and unit-tested there, for any future non-verbatim
+// path. Importing it without calling it would re-suggest a guarantee this file does not make.
+import { validateDemandThesisFalsifiability } from '../../demand-thesis-validator.js';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const PENDING_GATE = join(HERE, '../../../../database/artifact-type-parity-pending-chairman-gate.json');

--- a/lib/eva/stage-templates/analysis-steps/stage-02-demand-thesis.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-02-demand-thesis.js
@@ -1,0 +1,157 @@
+/**
+ * SD-FDBK-INFRA-TRUTH-DEMAND-THESIS-001 (FR-1, FR-4, FR-5) — the missing producer for
+ * truth_demand_thesis.
+ *
+ * The type has been declared since before 2026-07-16 and gate-enforced at S21, with NOTHING able to
+ * write it: repo-wide, the symbol appeared only in its own definition and in the consumer. Zero rows
+ * among 2,161. Every venture reaching S21 blocked identically; ApexNiche was just the first arrival.
+ *
+ * ── THIS PRODUCER REFUSES MORE OFTEN THAN IT PRODUCES, AND THAT IS THE DESIGN ─────────────────
+ * MEASURED: of 118 ventures at stage >= 2, ONE has a staged thesis and 117 DO NOT. So the dominant
+ * case is "no evidence exists yet", and the obvious implementation — a single LLM completion that
+ * writes a plausible six-claim thesis — would satisfy the S21 gate portfolio-wide while fabricating
+ * the evidence. That passes the structural check, unblocks every venture, and makes the artifact
+ * type meaningless: this SD's own defect, arriving one venture later and much harder to see.
+ *
+ * Producing a real thesis needs the design doc's author-not-adjudicator protocol (a drafter plus a
+ * separate adversarial adjudicator), which the doc scopes as its own child. So this producer does
+ * exactly two things: PROMOTE an already-adjudicated thesis, or REFUSE and name what is missing.
+ * It never authors one.
+ */
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { ARTIFACT_TYPES } from '../../artifact-types.js';
+import {
+  validateDemandThesisFalsifiability,
+  verifyPromotionFaithfulness
+} from '../../demand-thesis-validator.js';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PENDING_GATE = join(HERE, '../../../../database/artifact-type-parity-pending-chairman-gate.json');
+
+/**
+ * Is the artifact type still waiting on the chairman-gated CHECK-constraint widening?
+ *
+ * Reads the repo's own record rather than probing the constraint, so this shares ONE source of
+ * truth with TS-1 and with artifact-type-db-parity.test.js. Attempting the insert instead would
+ * raise Postgres 23514 on EVERY stage-2 run fleet-wide — a loud failure in the wrong place, breaking
+ * 117 ventures' stage 2 to report a condition we already know.
+ *
+ * Fail-safe direction: if the file cannot be read, assume PENDING. A wrong "permitted" guess costs a
+ * broken stage 2; a wrong "pending" guess costs a deferred artifact that the next run picks up.
+ */
+export function isArtifactTypePendingChairmanGate(type, { gatePath = PENDING_GATE } = {}) {
+  try {
+    const raw = JSON.parse(readFileSync(gatePath, 'utf8'));
+    const allow = raw && raw.allow;
+    if (Array.isArray(allow)) return allow.includes(type) || allow.some((e) => e && e.type === type);
+    if (allow && typeof allow === 'object') return Object.prototype.hasOwnProperty.call(allow, type);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
+/**
+ * PURE/TOTAL. Decide what stage 2 should do about the demand thesis for one venture.
+ *
+ * Never throws and never authors content — every branch either promotes an existing adjudicated
+ * thesis verbatim or refuses with a reason a human can act on.
+ *
+ * @param {object} input
+ * @param {object|null} input.ventureMetadata - the `ventures.metadata` object
+ * @param {boolean} [input.typePending] - override the chairman-gate check (tests)
+ * @returns {{action:'promote'|'refuse'|'defer', reason:string, artifact?:object, violations?:Array}}
+ */
+export function decideDemandThesisAction({ ventureMetadata, typePending } = {}) {
+  const staged = ventureMetadata && typeof ventureMetadata === 'object'
+    ? ventureMetadata.demand_thesis_staged
+    : null;
+
+  // TS-6 — the 117-of-118 case. Refusing is the whole point; naming WHAT is missing is what makes
+  // the refusal actionable rather than merely negative.
+  if (!staged || !staged.thesis || typeof staged.thesis !== 'object') {
+    return {
+      action: 'refuse',
+      reason:
+        'NO_ADJUDICATED_THESIS: ventures.metadata.demand_thesis_staged is absent, so there is no ' +
+        'adjudicated demand thesis to promote. This producer does not author one — a six-claim ' +
+        'thesis written to satisfy the S21 gate would pass every structural check while fabricating ' +
+        'the evidence. Required: a drafted thesis adjudicated by a separate reviewer per the ' +
+        'author-not-adjudicator protocol in docs/design/venture-selection-demand-thesis-design.md.'
+    };
+  }
+
+  // FR-3 — falsifiable on its face, or escalate. Explicitly NOT "improve it and continue": a
+  // backfill that quietly repairs its source is indistinguishable from one that fabricates it.
+  const verdict = validateDemandThesisFalsifiability(staged.thesis);
+  if (!verdict.valid) {
+    return {
+      action: 'refuse',
+      reason:
+        'STAGED_THESIS_NOT_FALSIFIABLE: the staged thesis exists but does not meet the falsifiability ' +
+        'bar, and this producer will not silently repair it. Escalate to whoever adjudicated it. ' +
+        `Violations: ${verdict.violations.map((v) => `${v.claim}/${v.code}`).join(', ')}`,
+      violations: verdict.violations
+    };
+  }
+
+  // FR-5 — the write cannot succeed yet, and pretending otherwise breaks stage 2 for everyone.
+  const pending = typeof typePending === 'boolean'
+    ? typePending
+    : isArtifactTypePendingChairmanGate(ARTIFACT_TYPES.TRUTH_DEMAND_THESIS);
+  if (pending) {
+    return {
+      action: 'defer',
+      reason:
+        'DDL_PENDING: venture_artifacts_artifact_type_check does not yet permit ' +
+        `${ARTIFACT_TYPES.TRUTH_DEMAND_THESIS}. The widening migration ` +
+        '(database/migrations/20260716_add_truth_demand_thesis_artifact_type.sql) is chairman-gated ' +
+        'and unapplied, so an insert would raise Postgres 23514 on every stage-2 run. The thesis is ' +
+        'VALID and ready to promote the moment the gate clears — this is a deferral, not a failure.'
+    };
+  }
+
+  // FR-4 — promote verbatim. Faithfulness is checked against the source, not asserted.
+  const claims = staged.thesis.claims;
+  const faith = verifyPromotionFaithfulness(claims, claims);
+  return {
+    action: 'promote',
+    reason: 'PROMOTED_FROM_STAGED: adjudicated thesis promoted verbatim from ventures.metadata.demand_thesis_staged',
+    artifact: {
+      artifactType: ARTIFACT_TYPES.TRUTH_DEMAND_THESIS,
+      payload: {
+        ...staged.thesis,
+        provenance: {
+          source: 'ventures.metadata.demand_thesis_staged',
+          promoted_verbatim: true,
+          faithful: faith.faithful,
+          staged_reason: typeof staged.reason === 'string' ? staged.reason : null,
+          parked_at: staged.parked_at ?? null
+        }
+      },
+      source: 'analysis-step:stage-02-demand-thesis'
+    }
+  };
+}
+
+/**
+ * Co-emit the demand thesis alongside stage 2's existing output, using the typed-array contract the
+ * engine already detects (`Array.isArray(result.artifacts)`), per stage-14's precedent.
+ *
+ * Refusals and deferrals are recorded on the payload rather than thrown, so a venture with no thesis
+ * still completes stage 2 — and the reason is visible instead of inferred from an absence.
+ */
+export function attachDemandThesisArtifact(stageResult, { ventureMetadata, typePending } = {}) {
+  const base = stageResult && typeof stageResult === 'object' ? stageResult : {};
+  const decision = decideDemandThesisAction({ ventureMetadata, typePending });
+  const existing = Array.isArray(base.artifacts) ? base.artifacts : [];
+
+  return {
+    ...base,
+    demand_thesis: { action: decision.action, reason: decision.reason },
+    artifacts: decision.action === 'promote' ? [...existing, decision.artifact] : existing
+  };
+}

--- a/lib/eva/stage-templates/analysis-steps/stage-02-demand-thesis.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-02-demand-thesis.js
@@ -157,17 +157,29 @@ export function decideDemandThesisAction({ ventureMetadata, typePending } = {}) 
       parked_at: staged.parked_at ?? null
     }
   };
-  const faith = verifyPromotionFaithfulness(payload.claims, staged.thesis.claims);
-  if (!faith.faithful) {
-    return {
-      action: 'refuse',
-      reason:
-        'PROMOTION_NOT_FAITHFUL: the artifact would carry claims absent from the staged source ' +
-        `(${faith.invented.join(', ')}). A backfill that quietly improves its source is ` +
-        'indistinguishable from one that fabricates it, so this refuses rather than writes.'
-    };
-  }
-  payload.provenance.faithful = true; // now derived from the comparison above, not asserted
+  // *** THERE IS NO FAITHFULNESS CHECK HERE, AND SAYING SO IS THE FIX. ***
+  // I shipped this claim three times and it was false every time.
+  //   v1: verifyPromotionFaithfulness(claims, claims) — the same object twice.
+  //   v2: "fixed" to (payload.claims, staged.thesis.claims) — but `payload` is a SHALLOW SPREAD, so
+  //       those are the SAME REFERENCE. Textually different, behaviourally identical. VALIDATION
+  //       proved it by reverting to the literal v1 bug and watching all 13 tests stay green.
+  //   v3: an identity check with a `faithful_basis` string — which my own mutation defeated by
+  //       hardcoding the string the test asserted.
+  //
+  // The real conclusion, which two rewrites were avoiding: through this function the payload is
+  // ALWAYS a verbatim spread of the source, so the claims are always the same object and
+  // verifyPromotionFaithfulness (a KEY-SET comparison) can never fail. The branch is unreachable by
+  // construction. No test can force it, because no input exists that would.
+  //
+  // A guarantee that cannot fail is not a weak guarantee — it is a decoration, and shipping one
+  // labelled `faithful: true` is worse than shipping nothing, because a downstream reader will trust
+  // it. So the computed-looking field is GONE. What remains is a statement about HOW the artifact
+  // was built, which is verifiable by reading these six lines rather than by believing a boolean.
+  //
+  // verifyPromotionFaithfulness stays exported and unit-tested on its own (see
+  // demand-thesis-validator.test.js) for any future path that does NOT carry verbatim. The moment
+  // such a path exists, it must call the check and this comment must change with it.
+  payload.provenance.promotion_method = 'verbatim_spread';
 
   return {
     action: 'promote',

--- a/lib/eva/stage-templates/analysis-steps/stage-02-demand-thesis.js
+++ b/lib/eva/stage-templates/analysis-steps/stage-02-demand-thesis.js
@@ -138,6 +138,24 @@ export function decideDemandThesisAction({ ventureMetadata, typePending } = {}) 
 }
 
 /**
+ * Load `ventures.metadata` for the thesis lookup. FAIL-SOFT BY DESIGN: a failed read returns null,
+ * which routes to the NO_ADJUDICATED_THESIS refusal rather than throwing. Stage 2 has a real job of
+ * its own (truth_ai_critique) and must not break because a secondary artifact could not be checked —
+ * that would turn "we could not look" into "the whole stage failed", which is the same
+ * absence-mistaken-for-a-verdict error this SD is about, pointed at the wrong stage.
+ */
+export async function loadVentureMetadata(supabase, ventureId) {
+  if (!supabase || !ventureId) return null;
+  try {
+    const { data, error } = await supabase.from('ventures').select('metadata').eq('id', ventureId).maybeSingle();
+    if (error || !data) return null;
+    return data.metadata ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Co-emit the demand thesis alongside stage 2's existing output, using the typed-array contract the
  * engine already detects (`Array.isArray(result.artifacts)`), per stage-14's precedent.
  *

--- a/lib/eva/stage-templates/stage-02.js
+++ b/lib/eva/stage-templates/stage-02.js
@@ -16,6 +16,7 @@
 import { validateString, validateInteger, validateCrossStageContract } from './validation.js';
 import { extractOutputSchema, ensureOutputSchema } from './output-schema-extractor.js';
 import { analyzeStage02 } from './analysis-steps/stage-02-multi-persona.js';
+import { attachDemandThesisArtifact, loadVentureMetadata } from './analysis-steps/stage-02-demand-thesis.js';
 
 const METRIC_NAMES = [
   'marketFit', 'customerNeed', 'momentum',
@@ -155,7 +156,28 @@ const TEMPLATE = {
 };
 
 TEMPLATE.outputSchema = extractOutputSchema(TEMPLATE.schema);
-TEMPLATE.analysisStep = analyzeStage02;
+
+/**
+ * SD-FDBK-INFRA-TRUTH-DEMAND-THESIS-001 (FR-2) — REGISTERED HERE, AND ONLY HERE.
+ *
+ * This assignment is the live dispatch path: both the manual engine (stage-execution-engine.js) and
+ * the daemon (eva-orchestrator.js) resolve stage templates by glob discovery over stage-NN.js and
+ * call TEMPLATE.analysisStep. `analysis-steps/index.js` getAnalysisStep() is a SECOND registry that
+ * is NOT what runs in production — its stage-21 mapping is provably not the S21 producer, and it has
+ * zero callers outside its own file. Registering the thesis producer there instead would ship a
+ * producer that exists and never runs, which is precisely the name-without-implementation defect
+ * this SD exists to end. Verified in both directions by
+ * tests/unit/eva/stage-02-registration.test.js.
+ *
+ * Wrapped rather than replaced: stage 2's real job is truth_ai_critique, and the thesis is
+ * CO-EMITTED via the typed-array contract the engine already detects.
+ */
+TEMPLATE.analysisStep = async (ctx = {}) => {
+  const base = await analyzeStage02(ctx);
+  const ventureMetadata = await loadVentureMetadata(ctx.supabase, ctx.ventureId);
+  return attachDemandThesisArtifact(base, { ventureMetadata });
+};
+
 ensureOutputSchema(TEMPLATE);
 
 export { METRIC_NAMES };

--- a/tests/unit/eva/artifact-type-producer-parity.test.js
+++ b/tests/unit/eva/artifact-type-producer-parity.test.js
@@ -1,0 +1,134 @@
+/**
+ * SD-FDBK-INFRA-TRUTH-DEMAND-THESIS-001 (TS-7) — no declared artifact type may sit gate-enforced
+ * with nothing able to produce it.
+ *
+ * *** THE EXISTING PARITY TEST STAYED GREEN THROUGH THIS ENTIRE OUTAGE. ***
+ * tests/unit/eva/artifact-type-db-parity.test.js enforces registry-vs-CHECK-constraint parity and
+ * never registry-vs-PRODUCER parity, so `truth_demand_thesis` — declared, gate-enforced at S21, and
+ * writable by nothing — passed CI continuously while every venture reaching S21 blocked on it. That
+ * is the control for this file: a green suite was fully compatible with the defect.
+ *
+ * ── WHY THE OBVIOUS PREDICATE IS WRONG, MEASURED BEFORE CHOOSING ──────────────────────────────
+ * The natural check is "the type's stage-NN.js names it". MEASURED: that fails 67 of 78 mapped
+ * types, because stage templates delegate to analysis steps and the engine resolves the type from
+ * ARTIFACT_TYPE_BY_STAGE — the stage file has no reason to name it. Shipping that would have
+ * wedged 86% of the population on day one, and a check that bricks the codebase gets switched off
+ * permanently, which buys nothing. Same reasoning the mechanism-claim gate applied to its own
+ * rollout.
+ *
+ * The predicate that actually discriminates: a type must be REACHABLE BY A WRITER — mapped in
+ * ARTIFACT_TYPE_BY_STAGE (the engine persists stage output under that mapping), or deprecated, or
+ * explicitly listed below as name-only with a reason.
+ *
+ * ── THE ALLOWLIST IS A DEBT REGISTER, NOT AN EXEMPTION ────────────────────────────────────────
+ * MEASURED 2026-08-01 against 102 declared types and 2,161 live rows: 21 are unmapped. SEVEN of
+ * those have rows (produced via non-stage paths, so they are fine). FOURTEEN have NO MAPPING AND
+ * ZERO ROWS — the exact state of truth_demand_thesis.
+ *
+ * SO THIS SD'S DEFECT IS ONE OF FOURTEEN. truth_demand_thesis is simply the one that happens to be
+ * gate-enforced, which is why it blocked a venture and the other thirteen did not. They are latent:
+ * declared names waiting for someone to gate on them. Seeding them here makes that debt countable
+ * and makes the check BLOCKING for any NEW type from day one.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  ARTIFACT_TYPES,
+  ARTIFACT_TYPE_BY_STAGE,
+  DEPRECATED_ARTIFACT_TYPES
+} from '../../../lib/eva/artifact-types.js';
+
+/**
+ * Types declared but not reachable through the stage mapping. Each needs a reason; entries with
+ * rows are producible by another path, entries without are genuine name-only debt.
+ * MEASURED 2026-08-01. Remove an entry when it gains a mapping or a producer — never add one to
+ * make this test pass without saying why.
+ */
+export const NAME_ONLY_OR_NON_STAGE_PRODUCED = Object.freeze({
+  // Produced via non-stage paths — MEASURED to have live rows, so reachable.
+  blueprint_token_manifest: 'produced outside the stage mapping; live rows measured 2026-08-01',
+  stage_17_analysis: 'produced outside the stage mapping; live rows measured 2026-08-01',
+  system_devils_advocate_review: 'produced outside the stage mapping; live rows measured 2026-08-01',
+  value_multiplier_assessment: 'produced outside the stage mapping; live rows measured 2026-08-01',
+  lifecycle_sd_bridge: 'produced outside the stage mapping; live rows measured 2026-08-01',
+  build_deviation_record: 'produced outside the stage mapping; live rows measured 2026-08-01',
+  distribution_block_marker: 'produced by stage-22-distribution-setup blockDistribution; live rows measured 2026-08-01',
+
+  // NAME-ONLY DEBT — declared, unmapped, ZERO rows. Same state as truth_demand_thesis was.
+  truth_problem_statement: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
+  truth_target_market_analysis: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
+  truth_value_proposition: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
+  truth_demand_thesis:
+    'NAME-ONLY, AND THE ONLY ONE OF THE FOURTEEN THAT IS GATE-ENFORCED — which is why it blocked ' +
+    'ApexNiche at S21 while the other thirteen sat latent. REMOVE THIS ENTRY when FR-1 lands the ' +
+    'S2 producer and ARTIFACT_TYPE_BY_STAGE[2] includes it; leaving it here after that would ' +
+    'silence the check for the one type this SD exists to fix.',
+  blueprint_risk_register: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
+  blueprint_project_plan: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
+  build_system_prompt: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
+  build_cicd_config: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
+  build_test_coverage_report: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
+  s17_variant_scores: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
+  stitch_project: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
+  stitch_curation: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
+  economic_lens: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
+  post_lifecycle_decision: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01'
+});
+
+const mappedTypes = () => new Set(Object.values(ARTIFACT_TYPE_BY_STAGE).flat());
+
+describe('TS-7: every declared artifact type is reachable by a writer', () => {
+  it('no type is declared without a mapping, a deprecation, or a documented exemption', () => {
+    const mapped = mappedTypes();
+    const deprecated = new Set(DEPRECATED_ARTIFACT_TYPES);
+    const orphans = Object.values(ARTIFACT_TYPES).filter(
+      (t) => !mapped.has(t) && !deprecated.has(t) && !(t in NAME_ONLY_OR_NON_STAGE_PRODUCED)
+    );
+
+    expect(
+      orphans,
+      'A NEW artifact type was declared with no way to produce it. That is the defect this SD exists ' +
+      'to end — a type that exists in name only, which a gate can then enforce and block a venture on ' +
+      'forever. Either map it in ARTIFACT_TYPE_BY_STAGE, or add it to NAME_ONLY_OR_NON_STAGE_PRODUCED ' +
+      'WITH A REASON so the debt is countable.'
+    ).toEqual([]);
+  });
+
+  it('every exemption carries a non-empty reason — an allowlist without reasons is just a mute button', () => {
+    for (const [type, reason] of Object.entries(NAME_ONLY_OR_NON_STAGE_PRODUCED)) {
+      expect(typeof reason, `${type} exemption reason`).toBe('string');
+      expect(reason.trim().length, `${type} exemption reason is empty`).toBeGreaterThan(20);
+    }
+  });
+
+  it('no exemption is stale — every listed type is still declared', () => {
+    // A stale entry silently widens the allowlist for a name that no longer exists, and hides the
+    // day a real type reclaims it.
+    const declared = new Set(Object.values(ARTIFACT_TYPES));
+    const stale = Object.keys(NAME_ONLY_OR_NON_STAGE_PRODUCED).filter((t) => !declared.has(t));
+    expect(stale, 'exemptions for types no longer in ARTIFACT_TYPES').toEqual([]);
+  });
+
+  it('NEGATIVE CONTROL: the check actually catches an unreachable type', () => {
+    // Without this, the suite above passes trivially on a codebase where nothing is wrong, and
+    // could keep passing if the predicate were accidentally inverted — which is precisely how the
+    // existing db-parity test stayed green for the entire outage.
+    const mapped = mappedTypes();
+    const deprecated = new Set(DEPRECATED_ARTIFACT_TYPES);
+    const planted = 'truth_planted_unreachable_type';
+    const orphans = [...Object.values(ARTIFACT_TYPES), planted].filter(
+      (t) => !mapped.has(t) && !deprecated.has(t) && !(t in NAME_ONLY_OR_NON_STAGE_PRODUCED)
+    );
+    expect(orphans).toEqual([planted]);
+  });
+
+  it('records that truth_demand_thesis is currently unreachable — and must stop being so', () => {
+    // Pins this SD's own premise as an executable fact rather than prose. When FR-1 lands, this
+    // expectation flips and the exemption comes off; both halves change together or the test fails.
+    const mapped = mappedTypes();
+    const isExempt = 'truth_demand_thesis' in NAME_ONLY_OR_NON_STAGE_PRODUCED;
+    expect(
+      mapped.has('truth_demand_thesis') || isExempt,
+      'truth_demand_thesis must be either mapped (producer landed) or exempt (producer pending)'
+    ).toBe(true);
+  });
+});

--- a/tests/unit/eva/artifact-type-producer-parity.test.js
+++ b/tests/unit/eva/artifact-type-producer-parity.test.js
@@ -57,11 +57,6 @@ export const NAME_ONLY_OR_NON_STAGE_PRODUCED = Object.freeze({
   truth_problem_statement: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
   truth_target_market_analysis: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
   truth_value_proposition: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
-  truth_demand_thesis:
-    'NAME-ONLY, AND THE ONLY ONE OF THE FOURTEEN THAT IS GATE-ENFORCED — which is why it blocked ' +
-    'ApexNiche at S21 while the other thirteen sat latent. REMOVE THIS ENTRY when FR-1 lands the ' +
-    'S2 producer and ARTIFACT_TYPE_BY_STAGE[2] includes it; leaving it here after that would ' +
-    'silence the check for the one type this SD exists to fix.',
   blueprint_risk_register: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
   blueprint_project_plan: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',
   build_system_prompt: 'NAME-ONLY: declared, unmapped, zero rows as of 2026-08-01',

--- a/tests/unit/eva/demand-thesis-validator.test.js
+++ b/tests/unit/eva/demand-thesis-validator.test.js
@@ -1,0 +1,150 @@
+/**
+ * SD-FDBK-INFRA-TRUTH-DEMAND-THESIS-001 (TS-3, TS-4) — falsifiability and promotion faithfulness.
+ *
+ * The standard for every case here: COULD THIS PASS WHILE THE DEFECT IS PRESENT? The defect in
+ * question is a thesis that is SHAPED correctly and REFUTABLE nowhere, which is what the existing
+ * S21 gate already accepts — so a test asserting the six claims merely EXIST would pass against
+ * exactly the thing this validator was built to reject.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  validateDemandThesisFalsifiability,
+  verifyPromotionFaithfulness,
+  REQUIRED_CLAIMS,
+  effectiveEvidenceGrade
+} from '../../../lib/eva/demand-thesis-validator.js';
+
+/** Shaped on ApexNiche's real adjudicated thesis, including KILL_CRITERIA's kills-only form. */
+function realisticThesis(overrides = {}) {
+  const claims = {
+    WHO: { statement: 'Niche Content Solopreneur', falsified_by: 'No solopreneur signs up in 14 days', evidence_grade: 'E1' },
+    PAIN: { statement: 'Manual niche research is slow', falsified_by: 'Users report research is already fast', evidence_grade: 'E1' },
+    ALTERNATIVES: { statement: 'Spreadsheets and manual search', falsified_by: 'A dominant incumbent already solves this', evidence_grade: 'E2' },
+    CHANNEL: { channels: ['SEO'], falsified_by: 'Zero qualified traffic from any tested channel', evidence_grade: 'E1' },
+    WTP: { price_point: '$29/mo', falsified_by: 'Nobody converts at any tested price', evidence_grade: 'E0' },
+    KILL_CRITERIA: {
+      kills: [{ kind: 'demand', criterion: 'Dies below 10 qualified signups', threshold: '< 10 qualified signups / 14 probe-days' }]
+    },
+    ...(overrides.claims || {})
+  };
+  return { claims };
+}
+
+describe('TS-3: falsifiability is enforced, not merely shape', () => {
+  it('accepts a thesis modelled on the real adjudicated one', () => {
+    const r = validateDemandThesisFalsifiability(realisticThesis());
+    expect(r.violations).toEqual([]);
+    expect(r.valid).toBe(true);
+    expect(r.checked).toEqual([...REQUIRED_CLAIMS]);
+  });
+
+  it('REJECTS a claim with no falsified_by — the killing mutation', () => {
+    const t = realisticThesis();
+    delete t.claims.PAIN.falsified_by;
+    const r = validateDemandThesisFalsifiability(t);
+    expect(r.valid).toBe(false);
+    expect(r.violations.map((v) => v.code)).toContain('NOT_FALSIFIABLE');
+    expect(r.violations.find((v) => v.code === 'NOT_FALSIFIABLE').claim).toBe('PAIN');
+  });
+
+  it('REJECTS an evidence_grade outside the E0-E3 ladder', () => {
+    // The existing gate accepts an arbitrary grade of 'B' — proven by
+    // stage-22-distribution-setup.test.js:231. That is the hole this closes.
+    const t = realisticThesis();
+    t.claims.WHO.evidence_grade = 'B';
+    const r = validateDemandThesisFalsifiability(t);
+    expect(r.valid).toBe(false);
+    expect(r.violations.map((v) => v.code)).toContain('EVIDENCE_GRADE_INVALID');
+  });
+
+  it('DOES NOT demand falsified_by on KILL_CRITERIA — a uniform rule would force fabrication', () => {
+    /**
+     * *** THIS TEST EXISTS BECAUSE THE OBVIOUS IMPLEMENTATION IS WRONG. ***
+     * ApexNiche's real KILL_CRITERIA carries kills[] and nothing else — by design, since the design
+     * doc gives its "falsified by" cell as "(this row is what makes the rest honest)". A uniform
+     * "every claim needs falsified_by" validator would either reject the only real thesis in the
+     * fleet, or force an author to synthesise a value the source never had — the exact
+     * quietly-rewrites-its-source fabrication FR-4 forbids. The validator would have mandated what
+     * its sibling requirement prohibits.
+     */
+    const t = realisticThesis();
+    expect(t.claims.KILL_CRITERIA.falsified_by).toBeUndefined();
+    expect(t.claims.KILL_CRITERIA.evidence_grade).toBeUndefined();
+    expect(validateDemandThesisFalsifiability(t).valid).toBe(true);
+  });
+
+  it('but DOES reject a kill with no threshold — unfalsifiable in the same way', () => {
+    const t = realisticThesis();
+    delete t.claims.KILL_CRITERIA.kills[0].threshold;
+    const r = validateDemandThesisFalsifiability(t);
+    expect(r.valid).toBe(false);
+    expect(r.violations.map((v) => v.code)).toContain('KILL_NO_THRESHOLD');
+  });
+
+  it('rejects an empty kills[] — the row that makes the others honest cannot be empty', () => {
+    const t = realisticThesis();
+    t.claims.KILL_CRITERIA.kills = [];
+    expect(validateDemandThesisFalsifiability(t).violations.map((v) => v.code)).toContain('NO_KILLS');
+  });
+
+  it('accepts a COMPOUND evidence_grade, resolving to the weakest component', () => {
+    /**
+     * *** THE FIRST CUT REJECTED THE ONLY REAL THESIS IN THE FLEET ON EXACTLY THIS. ***
+     * ApexNiche's adjudicated WTP claim reads "E1-anchor / E0-elicitation" — the adjudicator graded
+     * the price anchor and the elicitation separately. Demanding a bare E0-E3 would have forced the
+     * backfill to flatten that to a single value: not inventing content, but DISCARDING ADJUDICATED
+     * NUANCE to satisfy a validator that assumed a simpler world than the one it validates.
+     * Resolves to the WEAKEST component, because a claim is only as grounded as its softest part.
+     */
+    const t = realisticThesis();
+    t.claims.WTP.evidence_grade = 'E1-anchor / E0-elicitation';
+    expect(validateDemandThesisFalsifiability(t).valid).toBe(true);
+    expect(effectiveEvidenceGrade('E1-anchor / E0-elicitation')).toBe('E0');
+    expect(effectiveEvidenceGrade('E2')).toBe('E2');
+
+    // Still rejects a grade naming nothing on the ladder — the widening must not become a hole.
+    expect(effectiveEvidenceGrade('B')).toBeNull();
+    expect(effectiveEvidenceGrade('strong evidence')).toBeNull();
+    t.claims.WTP.evidence_grade = 'anchor / elicitation';
+    expect(validateDemandThesisFalsifiability(t).valid).toBe(false);
+  });
+
+  it('NEGATIVE CONTROL: a fully-shaped but unrefutable thesis is REJECTED', () => {
+    // Every required key present, every claim hollow. This is precisely what the existing S21 gate
+    // accepts today, so a validator that passes it would add nothing.
+    const hollow = { claims: Object.fromEntries(REQUIRED_CLAIMS.map((k) => [k, { statement: 'something' }])) };
+    const r = validateDemandThesisFalsifiability(hollow);
+    expect(r.valid).toBe(false);
+    expect(r.violations.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it('is TOTAL — never throws on malformed input', () => {
+    for (const bad of [null, undefined, 42, 'thesis', {}, { claims: null }, { claims: 'x' }]) {
+      expect(() => validateDemandThesisFalsifiability(bad)).not.toThrow();
+      expect(validateDemandThesisFalsifiability(bad).valid).toBe(false);
+    }
+  });
+});
+
+describe('TS-4: a promotion cites its source, it does not improve it', () => {
+  it('flags a claim present in the artifact but absent from the source', () => {
+    const source = { WHO: {}, PAIN: {} };
+    const artifact = { WHO: {}, PAIN: {}, WTP: {} };
+    const r = verifyPromotionFaithfulness(artifact, source);
+    expect(r.faithful).toBe(false);
+    expect(r.invented).toEqual(['WTP']);
+  });
+
+  it('permits FEWER claims than the source — the falsifiability check catches a missing required one', () => {
+    // Deliberately one-directional. Dropping is visible and separately caught; INVENTING is the
+    // failure that looks like diligence.
+    const r = verifyPromotionFaithfulness({ WHO: {} }, { WHO: {}, PAIN: {} });
+    expect(r.faithful).toBe(true);
+    expect(r.missing).toEqual(['PAIN']);
+  });
+
+  it('is TOTAL on malformed input', () => {
+    expect(() => verifyPromotionFaithfulness(null, undefined)).not.toThrow();
+    expect(verifyPromotionFaithfulness(null, undefined).faithful).toBe(true);
+  });
+});

--- a/tests/unit/eva/stage-02-demand-thesis.test.js
+++ b/tests/unit/eva/stage-02-demand-thesis.test.js
@@ -1,0 +1,117 @@
+/**
+ * SD-FDBK-INFRA-TRUTH-DEMAND-THESIS-001 (TS-6, FR-4, FR-5) — the producer refuses more often than it
+ * produces, and the refusals are the part under test.
+ *
+ * MEASURED: of 118 ventures at stage >= 2, ONE has a staged thesis and 117 do not. So "no evidence
+ * yet" is the DOMINANT path, and the failure that matters is not a crash — it is a plausible
+ * six-claim thesis written to satisfy the S21 gate, which passes every structural check while
+ * fabricating the evidence. These cases exist to make that outcome impossible to reach by accident.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  decideDemandThesisAction,
+  attachDemandThesisArtifact
+} from '../../../lib/eva/stage-templates/analysis-steps/stage-02-demand-thesis.js';
+
+function validThesis() {
+  return {
+    claims: {
+      WHO: { statement: 'Solopreneur', falsified_by: 'nobody signs up', evidence_grade: 'E1' },
+      PAIN: { statement: 'research is slow', falsified_by: 'users say it is fast', evidence_grade: 'E1' },
+      ALTERNATIVES: { statement: 'spreadsheets', falsified_by: 'an incumbent already solves it', evidence_grade: 'E2' },
+      CHANNEL: { channels: ['SEO'], falsified_by: 'no qualified traffic', evidence_grade: 'E1' },
+      WTP: { price_point: '$29', falsified_by: 'nobody converts', evidence_grade: 'E1-anchor / E0-elicitation' },
+      KILL_CRITERIA: { kills: [{ criterion: 'dies below 10 signups', threshold: '< 10 / 14 days' }] }
+    }
+  };
+}
+const staged = (thesis = validThesis()) => ({ demand_thesis_staged: { thesis, reason: 'promote verbatim' } });
+
+describe('TS-6: no staged thesis -> REFUSE, never author one', () => {
+  it('refuses and NAMES the missing evidence', () => {
+    const d = decideDemandThesisAction({ ventureMetadata: {}, typePending: false });
+    expect(d.action).toBe('refuse');
+    expect(d.reason).toContain('NO_ADJUDICATED_THESIS');
+    // A refusal that does not say what would satisfy it is just a failure.
+    expect(d.reason).toMatch(/author-not-adjudicator|adjudicated by a separate reviewer/);
+    expect(d.artifact).toBeUndefined();
+  });
+
+  it('emits NO artifact — the killing mutation is any branch that fabricates one', () => {
+    const out = attachDemandThesisArtifact({ analysis: 'x' }, { ventureMetadata: null, typePending: false });
+    expect(out.artifacts).toEqual([]);
+    expect(out.demand_thesis.action).toBe('refuse');
+    // Stage 2 still completes — a venture without a thesis is not a broken venture.
+    expect(out.analysis).toBe('x');
+  });
+
+  it('is TOTAL across malformed metadata', () => {
+    for (const md of [null, undefined, 42, 'x', {}, { demand_thesis_staged: null }, { demand_thesis_staged: {} }]) {
+      expect(() => decideDemandThesisAction({ ventureMetadata: md, typePending: false })).not.toThrow();
+      expect(decideDemandThesisAction({ ventureMetadata: md, typePending: false }).action).toBe('refuse');
+    }
+  });
+});
+
+describe('FR-3: a staged thesis that fails the bar is ESCALATED, not repaired', () => {
+  it('refuses and lists the violations rather than filling the gap', () => {
+    const bad = validThesis();
+    delete bad.claims.PAIN.falsified_by;
+    const d = decideDemandThesisAction({ ventureMetadata: staged(bad), typePending: false });
+    expect(d.action).toBe('refuse');
+    expect(d.reason).toContain('STAGED_THESIS_NOT_FALSIFIABLE');
+    expect(d.violations.map((v) => v.code)).toContain('NOT_FALSIFIABLE');
+    // The point: it did NOT promote a repaired version. Quietly improving a source is
+    // indistinguishable from fabricating it.
+    expect(d.artifact).toBeUndefined();
+  });
+});
+
+describe('FR-5: the write cannot succeed yet, so DEFER rather than break stage 2', () => {
+  it('defers with the migration named, and does not emit', () => {
+    const d = decideDemandThesisAction({ ventureMetadata: staged(), typePending: true });
+    expect(d.action).toBe('defer');
+    expect(d.reason).toContain('DDL_PENDING');
+    expect(d.reason).toContain('20260716_add_truth_demand_thesis_artifact_type.sql');
+    // Deferral is not failure — says so explicitly, because a reader seeing "not produced" would
+    // otherwise assume the thesis was rejected.
+    expect(d.reason).toMatch(/deferral, not a failure/);
+  });
+
+  it('a deferral would otherwise raise 23514 on EVERY stage-2 run — 117 ventures, not one', () => {
+    const out = attachDemandThesisArtifact({ analysis: 'x' }, { ventureMetadata: staged(), typePending: true });
+    expect(out.artifacts).toEqual([]);
+    expect(out.demand_thesis.action).toBe('defer');
+  });
+});
+
+describe('FR-4: promotion is verbatim, with provenance', () => {
+  it('promotes once the gate clears, carrying the source on the payload', () => {
+    const d = decideDemandThesisAction({ ventureMetadata: staged(), typePending: false });
+    expect(d.action).toBe('promote');
+    expect(d.artifact.artifactType).toBe('truth_demand_thesis');
+    expect(d.artifact.payload.claims).toEqual(validThesis().claims);
+    expect(d.artifact.payload.provenance).toMatchObject({
+      source: 'ventures.metadata.demand_thesis_staged',
+      promoted_verbatim: true,
+      faithful: true
+    });
+  });
+
+  it('co-emits via the typed-array contract the engine already detects', () => {
+    const out = attachDemandThesisArtifact(
+      { analysis: 'x', artifacts: [{ artifactType: 'truth_ai_critique', payload: {}, source: 'analysis-step:stage-02' }] },
+      { ventureMetadata: staged(), typePending: false }
+    );
+    expect(out.artifacts).toHaveLength(2);
+    expect(out.artifacts.map((a) => a.artifactType)).toEqual(['truth_ai_critique', 'truth_demand_thesis']);
+    // Stage 2's existing output is untouched — co-emission, not replacement.
+    expect(out.artifacts[0].payload).toEqual({});
+  });
+
+  it('NEGATIVE CONTROL: promote is reachable, so the refusals above are choices not dead ends', () => {
+    // Without this, every assertion in this file could be satisfied by a producer that refuses
+    // unconditionally — which would pass while delivering nothing.
+    expect(decideDemandThesisAction({ ventureMetadata: staged(), typePending: false }).action).toBe('promote');
+  });
+});

--- a/tests/unit/eva/stage-02-demand-thesis.test.js
+++ b/tests/unit/eva/stage-02-demand-thesis.test.js
@@ -39,7 +39,10 @@ describe('TS-6: no staged thesis -> REFUSE, never author one', () => {
 
   it('emits NO artifact — the killing mutation is any branch that fabricates one', () => {
     const out = attachDemandThesisArtifact({ analysis: 'x' }, { ventureMetadata: null, typePending: false });
-    expect(out.artifacts).toEqual([]);
+    // No typed artifacts[] is emitted at all on a non-promote path, so the engine keeps its normal
+    // single-artifact route for truth_ai_critique. Emitting an empty array would be harmless today
+    // (consumers check length > 0) but would signal an intent to co-emit that does not exist.
+    expect(out.artifacts).toBeUndefined();
     expect(out.demand_thesis.action).toBe('refuse');
     // Stage 2 still completes — a venture without a thesis is not a broken venture.
     expect(out.analysis).toBe('x');
@@ -50,6 +53,62 @@ describe('TS-6: no staged thesis -> REFUSE, never author one', () => {
       expect(() => decideDemandThesisAction({ ventureMetadata: md, typePending: false })).not.toThrow();
       expect(decideDemandThesisAction({ ventureMetadata: md, typePending: false }).action).toBe('refuse');
     }
+  });
+});
+
+describe('the four defects the EXEC sub-agents found in this producer', () => {
+  it('CHECK_FAILED is distinguished from GENUINELY ABSENT', async () => {
+    // A systemic DB blip must not read as "no venture in the fleet has a thesis". Same
+    // absence-mistaken-for-a-verdict error this SD is about, which I reproduced in my own fail-soft.
+    const { CHECK_FAILED } = await import('../../../lib/eva/stage-templates/analysis-steps/stage-02-demand-thesis.js');
+    const d = decideDemandThesisAction({ ventureMetadata: CHECK_FAILED, typePending: false });
+    expect(d.action).toBe('refuse');
+    expect(d.reason).toContain('THESIS_CHECK_FAILED');
+    expect(d.reason).toMatch(/UNKNOWN/);
+    // And it must NOT claim absence.
+    expect(d.reason).not.toContain('NO_ADJUDICATED_THESIS');
+  });
+
+  it('co-emission does NOT drop stage 2 own artifact', () => {
+    /**
+     * *** THIS WAS SILENT DATA LOSS. *** Both consumers treat a non-empty typed artifacts[] as
+     * EXCLUSIVE, so appending only the thesis meant truth_ai_critique — stage 2's actual job — was
+     * never written. The stage would have reported success while losing its primary output. Dormant
+     * only because the DDL gate makes promote unreachable; it fires on the first post-migration run.
+     */
+    const out = attachDemandThesisArtifact(
+      { critiques: ['a'], compositeScore: 7 },
+      { ventureMetadata: staged(), typePending: false }
+    );
+    expect(out.artifacts.map((a) => a.artifactType))
+      .toEqual(['truth_ai_critique', 'truth_demand_thesis']);
+    expect(out.artifacts[0].payload.compositeScore).toBe(7);
+  });
+
+  it('faithfulness is DERIVED from a comparison, not asserted', () => {
+    // The first cut compared the source to ITSELF, so `faithful` could only ever be true — a
+    // structural constant wearing the costume of a check.
+    const d = decideDemandThesisAction({ ventureMetadata: staged(), typePending: false });
+    expect(d.artifact.payload.provenance.faithful).toBe(true);
+    // The comparison now runs against the built payload, so a divergence is reachable.
+    expect(d.artifact.payload.claims).toEqual(validThesis().claims);
+  });
+
+  it('an unrecognised gate-file shape is treated as PENDING, not permitted', async () => {
+    const { isArtifactTypePendingChairmanGate } = await import('../../../lib/eva/stage-templates/analysis-steps/stage-02-demand-thesis.js');
+    // Valid JSON, no `allow` key — previously fell through to "not pending" and would have attempted
+    // a write that raises 23514 fleet-wide.
+    const { writeFileSync, mkdtempSync } = await import('node:fs');
+    const { tmpdir } = await import('node:os');
+    const { join } = await import('node:path');
+    const dir = mkdtempSync(join(tmpdir(), 'gate-'));
+    const p = join(dir, 'g.json');
+    writeFileSync(p, JSON.stringify({ _doc: 'no allow key here' }));
+    expect(isArtifactTypePendingChairmanGate('truth_demand_thesis', { gatePath: p })).toBe(true);
+    writeFileSync(p, JSON.stringify({ allow: { truth_demand_thesis: 'x' } }));
+    expect(isArtifactTypePendingChairmanGate('truth_demand_thesis', { gatePath: p })).toBe(true);
+    writeFileSync(p, JSON.stringify({ allow: {} }));
+    expect(isArtifactTypePendingChairmanGate('truth_demand_thesis', { gatePath: p })).toBe(false);
   });
 });
 
@@ -80,7 +139,10 @@ describe('FR-5: the write cannot succeed yet, so DEFER rather than break stage 2
 
   it('a deferral would otherwise raise 23514 on EVERY stage-2 run — 117 ventures, not one', () => {
     const out = attachDemandThesisArtifact({ analysis: 'x' }, { ventureMetadata: staged(), typePending: true });
-    expect(out.artifacts).toEqual([]);
+    // No typed artifacts[] is emitted at all on a non-promote path, so the engine keeps its normal
+    // single-artifact route for truth_ai_critique. Emitting an empty array would be harmless today
+    // (consumers check length > 0) but would signal an intent to co-emit that does not exist.
+    expect(out.artifacts).toBeUndefined();
     expect(out.demand_thesis.action).toBe('defer');
   });
 });

--- a/tests/unit/eva/stage-02-demand-thesis.test.js
+++ b/tests/unit/eva/stage-02-demand-thesis.test.js
@@ -85,13 +85,28 @@ describe('the four defects the EXEC sub-agents found in this producer', () => {
     expect(out.artifacts[0].payload.compositeScore).toBe(7);
   });
 
-  it('faithfulness is DERIVED from a comparison, not asserted', () => {
-    // The first cut compared the source to ITSELF, so `faithful` could only ever be true — a
-    // structural constant wearing the costume of a check.
-    const d = decideDemandThesisAction({ ventureMetadata: staged(), typePending: false });
-    expect(d.artifact.payload.provenance.faithful).toBe(true);
-    // The comparison now runs against the built payload, so a divergence is reachable.
-    expect(d.artifact.payload.claims).toEqual(validThesis().claims);
+  it('claims no faithfulness guarantee it cannot compute — the field is GONE', () => {
+    /**
+     * *** I SHIPPED A FALSE 'faithful: true' THREE TIMES BEFORE DELETING IT. ***
+     * v1 compared the source to itself. v2 compared a shallow-spread payload to the source — the
+     * SAME REFERENCE. v3 added a basis string my own mutation defeated by hardcoding it. Each
+     * rewrite made the claim look more computed while remaining exactly as vacuous.
+     *
+     * Through this function the payload is ALWAYS a verbatim spread, so a key-set comparison can
+     * never fail: the branch is unreachable by construction and no test can force it. So the
+     * computed-looking boolean is gone, replaced by a statement about HOW the artifact was built —
+     * verifiable by reading the code rather than by trusting a flag.
+     */
+    const md = staged();
+    const d = decideDemandThesisAction({ ventureMetadata: md, typePending: false });
+    expect(d.action).toBe('promote');
+    // No fabricated guarantee.
+    expect(d.artifact.payload.provenance.faithful).toBeUndefined();
+    expect(d.artifact.payload.provenance.faithful_basis).toBeUndefined();
+    // An honest, checkable statement instead.
+    expect(d.artifact.payload.provenance.promotion_method).toBe('verbatim_spread');
+    // And the thing that claim asserts is TRUE: the promoted claims are the adjudicated object.
+    expect(d.artifact.payload.claims).toBe(md.demand_thesis_staged.thesis.claims);
   });
 
   it('an unrecognised gate-file shape is treated as PENDING, not permitted', async () => {
@@ -156,7 +171,7 @@ describe('FR-4: promotion is verbatim, with provenance', () => {
     expect(d.artifact.payload.provenance).toMatchObject({
       source: 'ventures.metadata.demand_thesis_staged',
       promoted_verbatim: true,
-      faithful: true
+      promotion_method: 'verbatim_spread'
     });
   });
 

--- a/tests/unit/eva/stage-02-registration.test.js
+++ b/tests/unit/eva/stage-02-registration.test.js
@@ -1,0 +1,71 @@
+/**
+ * SD-FDBK-INFRA-TRUTH-DEMAND-THESIS-001 (TS-2) — the producer is registered where dispatch ACTUALLY
+ * happens, and the decoy registry is proven to be a decoy.
+ *
+ * *** REGISTERING IN THE WRONG PLACE WOULD SHIP A PRODUCER THAT EXISTS AND NEVER RUNS — WHICH IS
+ * EXACTLY THE DEFECT THIS SD EXISTS TO END, REPRODUCED BY ITS OWN FIX. ***
+ * There are two registries. `TEMPLATE.analysisStep` in stage-templates/stage-NN.js is resolved by
+ * glob discovery and called by both the manual engine and the daemon. `analysis-steps/index.js`
+ * getAnalysisStep() is the other one, and it has ZERO callers outside its own definition file — its
+ * stage-21 mapping is provably not the S21 producer that runs in production.
+ *
+ * So this file asserts BOTH directions. Asserting only that the real one works would pass equally
+ * well on a codebase where someone had *also* wired the decoy and believed it did something.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import TEMPLATE from '../../../lib/eva/stage-templates/stage-02.js';
+import { ARTIFACT_TYPE_BY_STAGE, ARTIFACT_TYPES } from '../../../lib/eva/artifact-types.js';
+
+describe('TS-2: registration is on the live dispatch path', () => {
+  it('stage-02 TEMPLATE.analysisStep is a function — the path the engine actually calls', () => {
+    expect(typeof TEMPLATE.analysisStep).toBe('function');
+  });
+
+  it('analysisStep is WRAPPED, not the bare stage-2 function — the wiring is what is under test', async () => {
+    /**
+     * *** THE FIRST VERSION OF THIS TEST CALLED THE REAL TEMPLATE AND TIMED OUT AT 60 SECONDS,
+     * BECAUSE analyzeStage02 MAKES A LIVE LLM CALL. *** A unit test doing network I/O is slow,
+     * flaky, and — worse — its failure mode is indistinguishable from a provider outage, so a real
+     * regression here would have been dismissed as "the LLM was down".
+     *
+     * The wiring claim does not need the network. It is: stage-02's analysisStep is NOT the bare
+     * analyzeStage02, and the wrapper composes it with the thesis attachment. Comparing identity
+     * against the unwrapped import proves exactly that, and fails the moment someone reverts
+     * `TEMPLATE.analysisStep = analyzeStage02`. The co-emission BEHAVIOUR is covered without a
+     * network in stage-02-demand-thesis.test.js.
+     */
+    const { analyzeStage02 } = await import('../../../lib/eva/stage-templates/analysis-steps/stage-02-multi-persona.js');
+    expect(TEMPLATE.analysisStep).not.toBe(analyzeStage02);
+
+    const src = readFileSync('lib/eva/stage-templates/stage-02.js', 'utf8');
+    expect(src).toContain('attachDemandThesisArtifact');
+    expect(src).toContain('analyzeStage02(ctx)');
+  });
+
+  it('NEGATIVE CONTROL: the decoy registry has no callers, so registering there would be inert', () => {
+    // Text-level, deliberately: the claim is about REACHABILITY, and the cheapest honest evidence is
+    // that nothing outside the file names getAnalysisStep. If that ever changes, this test should be
+    // revisited rather than silently trusted.
+    const decoy = readFileSync('lib/eva/stage-templates/analysis-steps/index.js', 'utf8');
+    expect(decoy).toContain('getAnalysisStep');
+    // The thesis producer must NOT be registered there — if someone adds it, this fails and they
+    // are pointed at stage-02.js instead.
+    expect(decoy).not.toMatch(/stage-02-demand-thesis|attachDemandThesisArtifact/);
+  });
+});
+
+describe('TS-2: ARTIFACT_TYPE_BY_STAGE[2] ordering is load-bearing', () => {
+  it('includes the thesis type, so the type is reachable by a writer', () => {
+    expect(ARTIFACT_TYPE_BY_STAGE[2]).toContain(ARTIFACT_TYPES.TRUTH_DEMAND_THESIS);
+  });
+
+  it('keeps TRUTH_AI_CRITIQUE FIRST — [0] is the stage canonical persist type', () => {
+    /**
+     * Every consumer reads [0]: stage-execution-engine.js:414 and :699, eva-orchestrator.js:544.
+     * Prepending the thesis would silently retype EVERY stage-2 artifact to truth_demand_thesis —
+     * a data-corrupting change with no error, produced by an edit that looks like reordering a list.
+     */
+    expect(ARTIFACT_TYPE_BY_STAGE[2][0]).toBe(ARTIFACT_TYPES.TRUTH_AI_CRITIQUE);
+  });
+});


### PR DESCRIPTION
`truth_demand_thesis` was declared in `artifact-types.js`, gate-enforced at S21, and **writable by nothing** — the symbol appeared repo-wide only in its own definition and in the consumer. **Zero rows among 2,161.** Every venture reaching S21 blocked identically; ApexNiche was just the first arrival.

## The defect is one of fourteen

Measured across 102 declared types and 2,161 live rows: 21 unmapped, **7** produced via non-stage paths, **14 with no mapping and zero rows**. `truth_demand_thesis` isn't special — it's *the one that happens to be gate-enforced*, which is why it blocked a venture while the other thirteen sat latent. TS-7 turns that into a countable debt register.

The existing `artifact-type-db-parity.test.js` **stayed green through the entire outage**, because it checks registry↔constraint parity and never registry↔producer parity.

## What shipped

| | |
|---|---|
| **Producer** | Promotes an adjudicated thesis or **refuses**. Never authors. 117 of 118 ventures have no staged thesis, so the natural implementation — one LLM completion — would unblock the portfolio while inventing evidence. |
| **Validator** | Falsifiability, with a `KILL_CRITERIA` carve-out and compound evidence grades. |
| **Registration** | `TEMPLATE.analysisStep`, *not* the decoy registry that has zero callers. |
| **Parity check** | No declared type may sit gate-enforced with nothing able to produce it. |

## Three spine corrections, recorded in metadata

1. **"No migration is in scope" is false** — the CHECK constraint doesn't permit the type; proven by `pg_get_constraintdef` and a rolled-back insert failing **23514** with a positive control. The widening migration is merged as code but **DDL unapplied and chairman-gated**.
2. **The stated acceptance points at the wrong reader** — `checkStageArtifactPrecondition` never reads the thesis; it's consumed one hop upstream.
3. The storage half of the ruling was **correct** and is retained as not-to-be-re-litigated.

## The review found four defects in my own code

The EXEC sub-agents were adversarial and right:

- **Silent data loss.** Co-emission appended only the thesis; consumers treat a non-empty typed array as *exclusive*, so `truth_ai_critique` — stage 2's actual job — would never have been written. stage-14, the precedent I cited, wraps its own output first. I copied half the pattern.
- **`provenance.faithful` was a structural constant** — `verifyPromotionFaithfulness(claims, claims)`, the same object twice, under a comment claiming it was checked. The control-that-cannot-fail class this SD exists to remove, one layer down.
- **The fail-soft collapsed "could not look" into "nothing there."**
- **The DDL fail-safe missed valid-JSON-with-no-`allow`-key.**

All four fixed with tests pinned to each.

## Still blocked

The backfill **insert** needs the chairman-gated DDL. TS-1 (the must-fail 23514 probe) and TS-5 (two clean polls) are not implemented for that reason — disclosed, not omitted.

`ventures.metadata` write access verified service_role-only, with a positive control proving the query method isn't blind. 6,869 eva tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)