### PR TITLE
SD-FDBK-INFRA-STUCK-SEAT-DETECTION-001: detect the frozen seat every liveness instrument calls healthy

### DIFF
--- a/lib/fleet/stuck-seat-population.cjs
+++ b/lib/fleet/stuck-seat-population.cjs
@@ -35,6 +35,9 @@ const POPULATION_STATUSES = Object.freeze(['active', 'idle']);
  */
 const POPULATION_COLUMNS = 'session_id, status, loop_state, last_tool_at, heartbeat_at, metadata';
 
+/** PostgREST's default cap. Named so a caller can detect that it fetched exactly a full page. */
+const POPULATION_ROW_LIMIT = 1000;
+
 /**
  * Fetch the seats eligible for stuck-seat classification.
  *
@@ -42,12 +45,28 @@ const POPULATION_COLUMNS = 'session_id, status, loop_state, last_tool_at, heartb
  * @returns {Promise<Array<object>>} rows, fixture sessions already removed
  */
 async function fetchPopulation(supabase) {
+  // ROWCAP. PostgREST caps an unbounded select at 1000 rows and returns the truncation SILENTLY —
+  // no error, just fewer rows. Without .order() the retained subset is not even deterministic, so a
+  // stuck seat past the cap would vanish from the count with nothing to indicate it. That is the
+  // silent false negative this whole SD exists to remove, reproduced in its own instrumentation.
+  // Latent at today's 14 rows and fixed anyway, because "latent" is how this class always starts.
+  // .order('last_tool_at') is not cosmetic: it makes the retained page the STALEST seats, so if the
+  // cap is ever hit the rows that survive are the ones most likely to be stuck.
   const { data, error } = await supabase
     .from('claude_sessions')
     .select(POPULATION_COLUMNS)
-    .in('status', POPULATION_STATUSES);
+    .in('status', POPULATION_STATUSES)
+    .order('last_tool_at', { ascending: true, nullsFirst: true })
+    .limit(POPULATION_ROW_LIMIT);
   if (error) throw new Error('stuck-seat-population: query failed: ' + error.message);
-  return (data || []).filter((row) => !isFixtureSession(row));
+  const rows = data || [];
+  // TRUNCATION IS REPORTED, NEVER SWALLOWED. A caller that renders a count must be able to say the
+  // count was computed over a capped page — otherwise a truncated read renders as a smaller, clean
+  // number. Returning the flag rather than logging it keeps this module pure.
+  const truncated = rows.length >= POPULATION_ROW_LIMIT;
+  const seats = rows.filter((row) => !isFixtureSession(row));
+  seats.truncated = truncated;
+  return seats;
 }
 
-module.exports = { fetchPopulation, POPULATION_STATUSES, POPULATION_COLUMNS };
+module.exports = { fetchPopulation, POPULATION_STATUSES, POPULATION_COLUMNS, POPULATION_ROW_LIMIT };

--- a/lib/fleet/stuck-seat-population.cjs
+++ b/lib/fleet/stuck-seat-population.cjs
@@ -1,0 +1,53 @@
+/**
+ * STUCK-SEAT POPULATION — SD-FDBK-INFRA-STUCK-SEAT-DETECTION-001, FR-5.
+ *
+ * THE DENOMINATOR IS THE WHOLE BALLGAME, AND THIS FILE EXISTS BECAUSE I GOT IT WRONG ONCE.
+ * The first version of FR-5 pinned the population as `status IN ('active','idle')` filtered by the
+ * shipped isFleetWorker() — which requires everClaimed = (sd_key || claimed_at || worktree_path ||
+ * continuous_sds_completed > 0) at lib/fleet/genuine-worker.mjs:25. So the condition predicate
+ * correctly dropped has_live_claim and the POPULATION quietly put it back one field over. Measured
+ * live: that population returns 1 OF THIS SD'S OWN 4 STUCK SPECIMENS. Bravo, Alpha and Charlie all
+ * have everClaimed=FALSE; Delta survived only on a residual claimed_at and drops out the moment the
+ * sweep clears it. A detector cannot see a class of seat its population excludes, and it reports
+ * clean while doing so.
+ *
+ * SO: NO CLAIM-DERIVED FIELD MAY APPEAR IN THIS QUERY — not sd_key, not claimed_at, not
+ * worktree_path, not continuous_sds_completed, not everClaimed, not isFleetWorker.
+ * Synthetic fixtures are excluded by SESSION-ID SHAPE via isFixtureSession(), which inspects
+ * session_id only and fails toward "real" so a classification quirk can never drop a genuine worker.
+ *
+ * WHY status IN ('active','idle') AND NOT status='active': three of the four stuck specimens are
+ * status='idle' RIGHT NOW (Bravo, Alpha, Charlie). Restricting to 'active' would miss 75% of the
+ * target class on the same rows that motivated the SD.
+ */
+
+'use strict';
+
+const { isFixtureSession } = require('./session-predicates.mjs');
+
+/** The statuses a seat can hold while stuck. Measured: 3 of 4 stuck specimens are 'idle'. */
+const POPULATION_STATUSES = Object.freeze(['active', 'idle']);
+
+/**
+ * Column list. session_id is TEXT and is the identity; claude_sessions.id is a uuid PK and is NOT
+ * selected at all, so no downstream consumer can accidentally join on it. Querying the wrong one
+ * returns zero rows WITH NO ERROR — a silent empty indistinguishable from "no stuck seats found".
+ */
+const POPULATION_COLUMNS = 'session_id, status, loop_state, last_tool_at, heartbeat_at, metadata';
+
+/**
+ * Fetch the seats eligible for stuck-seat classification.
+ *
+ * @param {object} supabase
+ * @returns {Promise<Array<object>>} rows, fixture sessions already removed
+ */
+async function fetchPopulation(supabase) {
+  const { data, error } = await supabase
+    .from('claude_sessions')
+    .select(POPULATION_COLUMNS)
+    .in('status', POPULATION_STATUSES);
+  if (error) throw new Error('stuck-seat-population: query failed: ' + error.message);
+  return (data || []).filter((row) => !isFixtureSession(row));
+}
+
+module.exports = { fetchPopulation, POPULATION_STATUSES, POPULATION_COLUMNS };

--- a/lib/fleet/stuck-seat-population.cjs
+++ b/lib/fleet/stuck-seat-population.cjs
@@ -7,9 +7,14 @@
  * continuous_sds_completed > 0) at lib/fleet/genuine-worker.mjs:25. So the condition predicate
  * correctly dropped has_live_claim and the POPULATION quietly put it back one field over. Measured
  * live: that population returns 1 OF THIS SD'S OWN 4 STUCK SPECIMENS. Bravo, Alpha and Charlie all
- * have everClaimed=FALSE; Delta survived only on a residual claimed_at and drops out the moment the
- * sweep clears it. A detector cannot see a class of seat its population excludes, and it reports
- * clean while doing so.
+ * have everClaimed=FALSE; Delta survived only on a residual claimed_at.
+ * CORRECTED AFTER REVIEW — this sentence previously said Delta "drops out the moment the sweep
+ * clears claimed_at". The sweep NEVER clears claimed_at: there is not one `claimed_at: null` write
+ * in scripts/stale-session-sweep.cjs, whose release sites null sd_key/worktree_path/worktree_branch
+ * and set status instead. claimed_at is cleared by releaseSD in lib/session-manager.mjs — a
+ * different actor on a different trigger. The conclusion is unchanged and is independently carried
+ * by the three everClaimed=FALSE specimens, but the mechanism I named for the fourth was invented.
+ * A detector cannot see a class of seat its population excludes, and it reports clean while doing so.
  *
  * SO: NO CLAIM-DERIVED FIELD MAY APPEAR IN THIS QUERY — not sd_key, not claimed_at, not
  * worktree_path, not continuous_sds_completed, not everClaimed, not isFleetWorker.
@@ -19,6 +24,19 @@
  * WHY status IN ('active','idle') AND NOT status='active': three of the four stuck specimens are
  * status='idle' RIGHT NOW (Bravo, Alpha, Charlie). Restricting to 'active' would miss 75% of the
  * target class on the same rows that motivated the SD.
+ *
+ * KNOWN LIMITATION — SANCTIONED SILENCE IS NOT EXCLUDED, and the reason it is currently harmless is
+ * NOT the one I first gave. This query ignores expected_silence_until, so a seat parked in an
+ * authorised window is eligible to be reported STUCK. I originally justified that as "0 witnesses
+ * measured live"; a reviewer measured THREE seats in a future-dated sanctioned window at that same
+ * moment, so my basis was simply wrong. The real basis is structural: SILENCE_HARD_CAP_MIN is 30
+ * (lib/fleet/silence-cap.cjs) and post-tool-clear-telemetry nulls expected_silence_until on EVERY
+ * tool call, so a window can only ever be armed from a fresh-tool state. Across all 201 rows that
+ * have ever carried the column, the maximum the window extended past last_tool_at is 25 minutes and
+ * ZERO ever reached 120. A sanctioned seat therefore cannot reach a 120-minute cut point. Note the
+ * shape of that safety: it is accidental, exactly like the STALE_THRESHOLD_SECONDS interval this
+ * SD's seeding script documents. It goes live the moment anyone calibrates the cut below ~30m, and
+ * nothing links the two constants. Recorded rather than silently relied upon.
  */
 
 'use strict';
@@ -64,9 +82,13 @@ async function fetchPopulation(supabase) {
   // count was computed over a capped page — otherwise a truncated read renders as a smaller, clean
   // number. Returning the flag rather than logging it keeps this module pure.
   const truncated = rows.length >= POPULATION_ROW_LIMIT;
-  const seats = rows.filter((row) => !isFixtureSession(row));
-  seats.truncated = truncated;
-  return seats;
+  // RETURN AN OBJECT, NOT AN ARRAY WITH AN EXPANDO. The flag was previously a property attached to
+  // the returned Array, which .map / .filter / .slice / spread / Array.from / JSON.stringify all
+  // silently drop — and it FAILS OPEN, because undefined is falsy, so losing it makes the truncation
+  // warning vanish and the count render clean. Two reviewers independently flagged it, and the drop
+  // already existed in-repo (the falsification harness reassigns the array). That is the
+  // silent-false-negative class this SD exists to remove, reproduced in its own instrumentation.
+  return { seats: rows.filter((row) => !isFixtureSession(row)), truncated };
 }
 
 module.exports = { fetchPopulation, POPULATION_STATUSES, POPULATION_COLUMNS, POPULATION_ROW_LIMIT };

--- a/lib/fleet/stuck-seat-predicate.cjs
+++ b/lib/fleet/stuck-seat-predicate.cjs
@@ -29,15 +29,18 @@
  *
  * NOT A REPLACEMENT FOR lib/fleet/claim-boundary-probe.cjs — a SIBLING. See PRECEDENCE below.
  *
- * THIS IS A LIVENESS GAUGE, NOT A TAMPER-EVIDENT CONTROL. Both columns it reads (last_tool_at, and
- * metadata.expected_wake_at) are worker-written, and claude_sessions currently carries an
- * "Allow all for anon" RLS policy that a later remediation dropped only for the `authenticated`
- * twin — so the public anon key can write either column on any row. That is pre-existing and routed
- * separately, but it bounds what this module may be trusted to conclude. Note the direction: the
- * threat model here is an ACCIDENT (a worker wedged on an interactive prompt), and a wedged worker
- * is by definition not writing — so evading detection would require the stuck seat to keep writing,
- * i.e. to not be stuck. The real exposure is forging a VICTIM's clock to make a healthy seat look
- * frozen, which is exactly why this module stays advisory-only and drives no actuation.
+ * THIS IS A LIVENESS GAUGE, NOT A TAMPER-EVIDENT CONTROL. Both columns it reads (last_tool_at and
+ * metadata.expected_wake_at) are worker-written, so any seat holding the service-role key can write
+ * its own or another's. CORRECTED AFTER REVIEW: an earlier version of this paragraph also claimed
+ * the public ANON key could write them, because claude_sessions carries an "Allow all for anon" RLS
+ * policy a later remediation dropped only for the `authenticated` twin. PROBED: anon SELECT is
+ * allowed, but anon UPDATE and DELETE return "permission denied for table claude_sessions" — the
+ * policy is permissive while the table GRANT is absent, and RLS only filters rows a role already has
+ * privilege to touch. The stale policy is hygiene, not an exposure; it is routed separately.
+ * The direction that does matter: the threat model here is an ACCIDENT (a worker wedged on an
+ * interactive prompt), and a wedged worker is by definition not writing — so evading detection would
+ * require a stuck seat to keep writing, i.e. to not be stuck. Forging a VICTIM's clock is the real
+ * direction, which is why this module stays advisory-only and drives no actuation.
  */
 
 'use strict';

--- a/lib/fleet/stuck-seat-predicate.cjs
+++ b/lib/fleet/stuck-seat-predicate.cjs
@@ -28,6 +28,16 @@
  * that behaviourally: mutating all four claim fields must leave every verdict byte-identical.
  *
  * NOT A REPLACEMENT FOR lib/fleet/claim-boundary-probe.cjs — a SIBLING. See PRECEDENCE below.
+ *
+ * THIS IS A LIVENESS GAUGE, NOT A TAMPER-EVIDENT CONTROL. Both columns it reads (last_tool_at, and
+ * metadata.expected_wake_at) are worker-written, and claude_sessions currently carries an
+ * "Allow all for anon" RLS policy that a later remediation dropped only for the `authenticated`
+ * twin — so the public anon key can write either column on any row. That is pre-existing and routed
+ * separately, but it bounds what this module may be trusted to conclude. Note the direction: the
+ * threat model here is an ACCIDENT (a worker wedged on an interactive prompt), and a wedged worker
+ * is by definition not writing — so evading detection would require the stuck seat to keep writing,
+ * i.e. to not be stuck. The real exposure is forging a VICTIM's clock to make a healthy seat look
+ * frozen, which is exactly why this module stays advisory-only and drives no actuation.
  */
 
 'use strict';

--- a/lib/fleet/stuck-seat-predicate.cjs
+++ b/lib/fleet/stuck-seat-predicate.cjs
@@ -1,0 +1,140 @@
+/**
+ * STUCK-SEAT CONDITION PREDICATE — SD-FDBK-INFRA-STUCK-SEAT-DETECTION-001, FR-1/FR-2.
+ *
+ * A worker can freeze while every liveness instrument reports it healthy. Delta (session_id
+ * ab29dc41) sat frozen 888 minutes with heartbeat_at 0 minutes old, status=active, loop_state=active
+ * and a live process tick. Measured across the six specimens 2026-08-01T09:25:44Z:
+ *
+ *   label     truth    last_tool_at   heartbeat_at   everClaimed
+ *   ALPHA-3   healthy         0 min          0 min   true
+ *   ALPHA-2   healthy         0 min          0 min   true
+ *   CHARLIE   stuck         249 min          0 min   false
+ *   BRAVO     stuck         499 min          0 min   false
+ *   ALPHA     stuck         694 min          0 min   false
+ *   DELTA     stuck         888 min          0 min   true
+ *
+ * heartbeat_at takes a SINGLE distinct value across all six and carries zero information.
+ * last_tool_at separates them 6/6 with no overlap.
+ *
+ * WHY has_live_claim IS ABSENT, AND WHY THAT IS THE POINT.
+ * The sourced FR-5 predicate was `has_live_claim AND last_outbound_was_an_escalation AND
+ * no_wakeup_armed`. Measured against those same six rows, has_live_claim as `sd_key IS NOT NULL`
+ * agrees with ground truth 0/6 — TRUE for both healthy controls and FALSE for all four stuck seats.
+ * everClaimed (the OR of sd_key/claimed_at/worktree_path/continuous_sds_completed) agrees 1/6.
+ * That is not a weak conjunct, it is perfect anti-correlation, and the cause is structural:
+ * stale-session-sweep RELEASES a stuck seat's claim, so gating detection on holding one gates it on
+ * not-yet-having-been-swept — the detector goes blind exactly as the condition matures.
+ * NO CLAIM-DERIVED FIELD MAY ENTER THIS FILE. tests/unit/fleet/stuck-seat-predicate.test.js pins
+ * that behaviourally: mutating all four claim fields must leave every verdict byte-identical.
+ *
+ * NOT A REPLACEMENT FOR lib/fleet/claim-boundary-probe.cjs — a SIBLING. See PRECEDENCE below.
+ */
+
+'use strict';
+
+/** Closed verdict set. UNKNOWN is a first-class outcome, never folded into HEALTHY. */
+const VERDICT = Object.freeze({ STUCK: 'STUCK', HEALTHY: 'HEALTHY', UNKNOWN: 'UNKNOWN' });
+
+/** Exact reason tokens. Tests pin these strings, not their truthiness — a truthy-reason assertion
+ *  cannot tell "returned UNKNOWN from the branch under test" from "returned UNKNOWN from an earlier
+ *  guard", which is how a predicate passes its own test without reaching the code it claims to. */
+const REASON = Object.freeze({
+  NO_TOOL_CLOCK: 'last_tool_at_never_written',
+  TOOL_SILENT: 'tool_silent_past_cut_point',
+  TOOL_RECENT: 'tool_activity_within_cut_point',
+  WAKE_NOT_RECORDED: 'wake_not_recorded',
+  WAKE_OVERDUE: 'wake_armed_and_overdue',
+  WAKE_PENDING: 'wake_armed_and_pending'
+});
+
+/** Three-valued wakeup state. ABSENT IS NOT PROOF NO WAKEUP WAS ARMED: the write at
+ *  scripts/hooks/post-tool-loop-state.cjs:113 is conditional on a prior metadata read succeeding and
+ *  on a finite positive delay, so a read failure costs the deadline. expected_silence_until is NOT a
+ *  substitute — its own writer calls it a clamped do-not-sweep-me PERMISSION, useless as a deadline. */
+function classifyWakeState(session, nowMs) {
+  const raw = session && session.metadata && session.metadata.expected_wake_at;
+  if (!raw) return { state: 'not_recorded', reason: REASON.WAKE_NOT_RECORDED, overdueMinutes: null };
+  const t = Date.parse(raw);
+  if (!Number.isFinite(t)) return { state: 'not_recorded', reason: REASON.WAKE_NOT_RECORDED, overdueMinutes: null };
+  const overdueMinutes = Math.round((nowMs - t) / 60000);
+  return overdueMinutes > 0
+    ? { state: 'armed_overdue', reason: REASON.WAKE_OVERDUE, overdueMinutes }
+    : { state: 'armed_pending', reason: REASON.WAKE_PENDING, overdueMinutes };
+}
+
+/**
+ * Classify ONE session row.
+ *
+ * @param {object} session - a claude_sessions row. Identified by session_id (TEXT), NEVER id (uuid):
+ *   the two differ on every live seat and querying the wrong one returns zero rows WITH NO ERROR,
+ *   which reads as "no stuck seats found" — the exact false negative this SD exists to remove.
+ * @param {object} opts
+ * @param {number} opts.cutPointMinutes - REQUIRED, no default. See the throw below.
+ * @param {number|Date} [opts.now] - injected clock for deterministic tests.
+ * @returns {{verdict: string, reason: string, session_id: string|null, toolSilentMinutes: number|null, wake: object}}
+ */
+function classifySeat(session, opts) {
+  const cut = opts && opts.cutPointMinutes;
+  // NO DEFAULT, DELIBERATELY. The false-negative side is n=1 PER CLASS and healthy-latency data is
+  // right-censored (a live observation window structurally excludes the slowest healthy seats; both
+  // controls above read 0 min only because they were mid-work at measurement). The ORDERING is
+  // established 6/6; the CUT POINT is not. A default here would be an uncalibrated number in the one
+  // place nobody would look at again, so the module refuses to run instead.
+  if (!Number.isFinite(cut) || cut <= 0) {
+    throw new Error(
+      'stuck-seat-predicate: cutPointMinutes is REQUIRED and must be a positive finite number. ' +
+      'There is deliberately no default — see TR-4, the calibration constraint.'
+    );
+  }
+
+  const nowMs = opts.now instanceof Date ? opts.now.getTime()
+    : Number.isFinite(opts.now) ? opts.now
+    : Date.now();
+
+  const sessionId = (session && session.session_id) || null;
+  const wake = classifyWakeState(session, nowMs);
+
+  // NULL IS UNKNOWN, NEVER HEALTHY. last_tool_at has documented silent-loss paths: its sole writer
+  // swallows failures with an empty catch (scripts/hooks/post-tool-clear-telemetry.cjs), exits with
+  // no write when the session id will not resolve, and runs from the SESSION'S OWN CHECKOUT — so a
+  // seat on an older checkout may never persist the column at all. Treating that absence as health
+  // would let the blindest seats score cleanest. Discipline copied from
+  // lib/fleet/claim-boundary-probe.cjs, which returns UNKNOWN/last_tool_at_never_written.
+  const lastToolAt = session && session.last_tool_at;
+  const lastToolMs = lastToolAt instanceof Date ? lastToolAt.getTime()
+    : typeof lastToolAt === 'string' ? Date.parse(lastToolAt)
+    : NaN;
+  if (!Number.isFinite(lastToolMs)) {
+    return { verdict: VERDICT.UNKNOWN, reason: REASON.NO_TOOL_CLOCK, session_id: sessionId, toolSilentMinutes: null, wake };
+  }
+
+  const toolSilentMinutes = Math.round((nowMs - lastToolMs) / 60000);
+  return toolSilentMinutes >= cut
+    ? { verdict: VERDICT.STUCK, reason: REASON.TOOL_SILENT, session_id: sessionId, toolSilentMinutes, wake }
+    : { verdict: VERDICT.HEALTHY, reason: REASON.TOOL_RECENT, session_id: sessionId, toolSilentMinutes, wake };
+}
+
+/**
+ * PRECEDENCE against lib/fleet/claim-boundary-probe.cjs, which is a shipped stuck-seat detector on
+ * the same column and WILL disagree with this one on real rows.
+ *
+ * Run in-process against the live Delta row it returns PASS / progressed_past_boundary (its guard at
+ * :129: last_tool_at is 47 minutes past the claim anchor against a 120-second grace). Its other
+ * blinding guard, :152 outbound_comms_since_anchor, reads outbound coordination rows as PROOF OF
+ * LIFE — the exact inverse of this SD, where a final outbound escalation is EVIDENCE of stuckness.
+ * On Delta that branch is unreachable (zero outbound since the anchor), so BOTH guards matter and
+ * progressed_past_boundary is the more dangerous: it PASSes ANY seat that did work and then froze,
+ * which is the entire failure class.
+ *
+ * RULE: on disagreement, STUCK WINS FOR REPORTING and the incumbent wins for ACTUATION. This module
+ * is advisory-only — it is deliberately not wired into runDetectors and drives no release,
+ * quarantine or handback. A false positive here costs a line of dashboard text; a false positive in
+ * the incumbent costs a live worker its claim. Report loudly, actuate conservatively.
+ */
+const PRECEDENCE = Object.freeze({
+  onDisagreement: 'stuck_wins_for_reporting_incumbent_wins_for_actuation',
+  thisModuleIsAdvisoryOnly: true,
+  incumbent: 'lib/fleet/claim-boundary-probe.cjs'
+});
+
+module.exports = { classifySeat, classifyWakeState, VERDICT, REASON, PRECEDENCE };

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1674,11 +1674,15 @@ async function printAttentionStrip() {
  */
 const STUCK_SEAT_CUT_POINT_MINUTES = 120;   // operator-facing display threshold, NOT a calibration
 
-async function printStuckSeatStrip() {
+// `client` is injectable ONLY so the render path can be unit-tested; production passes nothing and
+// uses the module-scope client. Every sibling renderer here is exported "for unit testing" and this
+// one was omitted from module.exports, which is the actual reason its render was uncovered — a
+// reviewer attributed that to "no test imports fleet-dashboard", but eight test files do.
+async function printStuckSeatStrip(client) {
   try {
     const { fetchPopulation } = require('../lib/fleet/stuck-seat-population.cjs');
     const { classifySeat, VERDICT } = require('../lib/fleet/stuck-seat-predicate.cjs');
-    const { seats: population, truncated } = await fetchPopulation(supabase);
+    const { seats: population, truncated } = await fetchPopulation(client || supabase);
     const results = population.map((row) => classifySeat(row, { cutPointMinutes: STUCK_SEAT_CUT_POINT_MINUTES }));
     const stuck = results.filter((r) => r.verdict === VERDICT.STUCK);
     const unknown = results.filter((r) => r.verdict === VERDICT.UNKNOWN);
@@ -2706,7 +2710,7 @@ async function main() {
 }
 
 // Export read-only renderers for unit testing (SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001).
-module.exports = { printFeedback, reconcilePAliveWithLiveness, computeSolomonLedgerRollup, printWorkers, printChairmanEmailChannelHealth, printAvailable, printWorkerInbox, resolveInboxAudience, printAttentionStrip, printQA };
+module.exports = { printFeedback, reconcilePAliveWithLiveness, computeSolomonLedgerRollup, printWorkers, printChairmanEmailChannelHealth, printAvailable, printWorkerInbox, resolveInboxAudience, printAttentionStrip, printQA, printStuckSeatStrip };
 
 // Only run the CLI when invoked directly, so requiring this module in a test does
 // not execute main() against the live database.

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1682,13 +1682,20 @@ async function printStuckSeatStrip() {
     const results = population.map((row) => classifySeat(row, { cutPointMinutes: STUCK_SEAT_CUT_POINT_MINUTES }));
     const stuck = results.filter((r) => r.verdict === VERDICT.STUCK);
     const unknown = results.filter((r) => r.verdict === VERDICT.UNKNOWN);
-    if (stuck.length === 0 && unknown.length === 0) return;
+    // THE STRIP ALWAYS RENDERS AND ALWAYS STATES ITS DENOMINATOR. An earlier version returned early
+    // when both counts were zero; a reviewer mutated the population query and the strip then printed
+    // NOTHING AT ALL — no header, no zero, no error. Silent-empty was indistinguishable from a
+    // healthy fleet AND from the strip not being wired, which is precisely the confusion this SD
+    // exists to remove. The unknown counter alone does not cover it: population-level blindness
+    // produces zero unknowns too, so the SEATS SCANNED number is the load-bearing one.
     console.log('STUCK SEATS  (tool-silent >= ' + STUCK_SEAT_CUT_POINT_MINUTES + 'm; advisory, no action taken)');
     console.log('─'.repeat(72));
     for (const r of stuck.sort((a, b) => b.toolSilentMinutes - a.toolSilentMinutes)) {
       console.log('  ' + pad(r.session_id, 38) + pad(r.toolSilentMinutes + 'm silent', 16) + 'wake:' + r.wake.state);
     }
-    console.log('  stuck=' + stuck.length + '  unknown=' + unknown.length +
+    console.log('  seats scanned=' + population.length + '  stuck=' + stuck.length + '  unknown=' + unknown.length +
+      (population.truncated ? '  [TRUNCATED at the row cap — the count is over a partial page]' : '') +
+      (population.length === 0 ? '  <- SCANNED NOTHING. This is a blind detector, not a healthy fleet.' : '') +
       (unknown.length ? '  <- UNKNOWN means the detector could not see those seats, not that they are healthy' : ''));
     console.log('');
   } catch (e) {

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1653,6 +1653,52 @@ async function printAttentionStrip() {
   console.log('');
 }
 
+/**
+ * STUCK-SEAT STRIP — SD-FDBK-INFRA-STUCK-SEAT-DETECTION-001, FR-6.
+ *
+ * A summary line, deliberately NOT a per-row cell: fleet-dashboard's worker table renders inside a
+ * per-seat loop, so a fleet-wide count placed there would print once per seat.
+ *
+ * THE UNKNOWN COUNT IS RENDERED BESIDE THE STUCK COUNT AND THAT IS THE POINT. last_tool_at has
+ * silent-loss paths (its sole writer swallows failures with an empty catch, and hooks run from each
+ * session's own checkout), so a detector that can see nothing and a fleet that is genuinely fine
+ * both produce zero findings. Printing only "0 stuck" would make those two states identical — the
+ * exact defect class this SD exists to remove, reproduced in its own instrumentation.
+ *
+ * THE CUT POINT IS NAMED IN THE OUTPUT. The predicate ships no default and throws without one
+ * (TR-4: the ordering is established 6/6, the cut point is not — n=1 per class on the false-negative
+ * side, and healthy-latency data is right-censored). That pushes the number to the caller, so the
+ * caller states it where it is consumed rather than burying it in a render call.
+ *
+ * ADVISORY ONLY. This drives no release, quarantine or handback — see PRECEDENCE in the predicate.
+ */
+const STUCK_SEAT_CUT_POINT_MINUTES = 120;   // operator-facing display threshold, NOT a calibration
+
+async function printStuckSeatStrip() {
+  try {
+    const { fetchPopulation } = require('../lib/fleet/stuck-seat-population.cjs');
+    const { classifySeat, VERDICT } = require('../lib/fleet/stuck-seat-predicate.cjs');
+    const population = await fetchPopulation(supabase);
+    const results = population.map((row) => classifySeat(row, { cutPointMinutes: STUCK_SEAT_CUT_POINT_MINUTES }));
+    const stuck = results.filter((r) => r.verdict === VERDICT.STUCK);
+    const unknown = results.filter((r) => r.verdict === VERDICT.UNKNOWN);
+    if (stuck.length === 0 && unknown.length === 0) return;
+    console.log('STUCK SEATS  (tool-silent >= ' + STUCK_SEAT_CUT_POINT_MINUTES + 'm; advisory, no action taken)');
+    console.log('─'.repeat(72));
+    for (const r of stuck.sort((a, b) => b.toolSilentMinutes - a.toolSilentMinutes)) {
+      console.log('  ' + pad(r.session_id, 38) + pad(r.toolSilentMinutes + 'm silent', 16) + 'wake:' + r.wake.state);
+    }
+    console.log('  stuck=' + stuck.length + '  unknown=' + unknown.length +
+      (unknown.length ? '  <- UNKNOWN means the detector could not see those seats, not that they are healthy' : ''));
+    console.log('');
+  } catch (e) {
+    // Never let an advisory strip take the dashboard down — but say so, rather than rendering a
+    // silent zero that would read as "no stuck seats".
+    console.log('STUCK SEATS: check unavailable (' + e.message + ')');
+    console.log('');
+  }
+}
+
 // ── Section: Operator cockpit session actions (SD-LEO-INFRA-LEO-COMPLETION-001-E, FR-1) ──
 // Wires lib/fleet/session-detail-view.js's buildSessionDetailView() and lib/fleet/browser-control.js's
 // requestBrowserSession()/signalTakeover() into REAL production callers (G3 no-unit-mock proof: these
@@ -2525,7 +2571,7 @@ async function main() {
   const d = await loadData();
 
   const sections = {
-    workers:       async () => { printWorkers(d); await printAttentionStrip(); },
+    workers:       async () => { printWorkers(d); await printAttentionStrip(); await printStuckSeatStrip(); },
     orchestrator:  () => printOrchestrator(d),
     available:     () => printAvailable(d),
     quickfixes:    async () => { printQuickFixes(d); await printChairmanGatedQfs(); }, // QF-20260525-836 + SD-LEO-INFRA-EXCLUDE-CHAIRMAN-GATED-001
@@ -2582,6 +2628,7 @@ async function main() {
       if (d.executeTeams && d.executeTeams.length > 0) printTeam(d);
       printWorkers(d);
       await printAttentionStrip();
+      await printStuckSeatStrip();
       printDrainAgents(d);
       printOrchestrator(d);
       printAvailable(d);

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -1678,7 +1678,7 @@ async function printStuckSeatStrip() {
   try {
     const { fetchPopulation } = require('../lib/fleet/stuck-seat-population.cjs');
     const { classifySeat, VERDICT } = require('../lib/fleet/stuck-seat-predicate.cjs');
-    const population = await fetchPopulation(supabase);
+    const { seats: population, truncated } = await fetchPopulation(supabase);
     const results = population.map((row) => classifySeat(row, { cutPointMinutes: STUCK_SEAT_CUT_POINT_MINUTES }));
     const stuck = results.filter((r) => r.verdict === VERDICT.STUCK);
     const unknown = results.filter((r) => r.verdict === VERDICT.UNKNOWN);
@@ -1694,7 +1694,7 @@ async function printStuckSeatStrip() {
       console.log('  ' + pad(r.session_id, 38) + pad(r.toolSilentMinutes + 'm silent', 16) + 'wake:' + r.wake.state);
     }
     console.log('  seats scanned=' + population.length + '  stuck=' + stuck.length + '  unknown=' + unknown.length +
-      (population.truncated ? '  [TRUNCATED at the row cap — the count is over a partial page]' : '') +
+      (truncated ? '  [TRUNCATED at the row cap — the count is over a partial page]' : '') +
       (population.length === 0 ? '  <- SCANNED NOTHING. This is a blind detector, not a healthy fleet.' : '') +
       (unknown.length ? '  <- UNKNOWN means the detector could not see those seats, not that they are healthy' : ''));
     console.log('');

--- a/scripts/seeded-firing-stuck-seat.cjs
+++ b/scripts/seeded-firing-stuck-seat.cjs
@@ -30,11 +30,15 @@
  *     what capacity actually runs on. So the seed IS visible to getFleetRoster, the capacity
  *     forecaster's idleNow, coordination-events' unfiltered scan, and detectStalledLoop (it matches
  *     every guard). ACCEPTED IN-WINDOW RISK, not an exclusion.
- *   ALSO UNMENTIONED AND REAL — worktree_path NULL is read by auto-exec-checkout-sync as "this
- *     worker is in the MAIN checkout", which can hold a worker-exclusion lock for up to 15 minutes,
- *     OUTLIVING this script; and resolve-own-session's last-resort strategy picks the freshest
+ *   DIRECTION INVERTED, CORRECTED AFTER REVIEW — I wrote that worktree_path NULL "can hold a
+ *     worker-exclusion lock for 15 minutes, outliving this script". auto-exec-checkout-sync does
+ *     read NULL as "this worker is in the MAIN checkout", and MAIN_WORKER_TTL_MS is 15 minutes, but
+ *     the seed BLOCKS lock acquisition (the code aborts with reason 'live_worker_in_main') rather
+ *     than holding one — and that whole path is default-OFF behind a disabled flag. Less severe than
+ *     I claimed, and in the opposite direction; recorded rather than quietly deleted.
+ *   REAL AND UNMENTIONED — resolve-own-session's last-resort strategy picks the freshest
  *     status='active' row by heartbeat, which this seed becomes BY CONSTRUCTION, so a process
- *     falling through to it could adopt the synthetic row as its own session.
+ *     falling through to it during the window could adopt the synthetic row as its own session.
  *   TRUE — no session_coordination row is written at all. The shipped predicate does not read
  *     outbound escalation-ness (that conjunct was dropped as unproven), so there is nothing to seed
  *     and nothing for lib/coordinator/signal-router.cjs to promote into a durable feedback row.
@@ -131,7 +135,7 @@ async function main() {
     // THE DETECTOR RUNS ITS OWN PRODUCTION QUERY. The rows are NOT handed in — that is the whole
     // point of the binding criterion: a detector can score SILENT because the harness never fed it
     // anything, and that false negative is indistinguishable from a real finding.
-    let population = await fetchPopulation(sb);
+    let { seats: population, truncated } = await fetchPopulation(sb);
     if (FALSIFY) {
       population = population.filter(() => false);   // mutate the feed to select nothing
       console.log('\n[--falsify] population feed forced empty');

--- a/scripts/seeded-firing-stuck-seat.cjs
+++ b/scripts/seeded-firing-stuck-seat.cjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+/**
+ * SEEDED-FIRING VERIFICATION — SD-FDBK-INFRA-STUCK-SEAT-DETECTION-001, FR-3 (binding criterion).
+ *
+ * WHY THIS IS A STANDALONE OPERATOR SCRIPT AND NOT A VITEST INTEGRATION TEST.
+ * The PRD's TR-6 called the DB tier's empty include a blocker. Reading vitest.config.js at source
+ * corrects that: `DB_INCLUDE_GATED = DB_TARGET.allowed ? DB_INCLUDE : []` is a DELIBERATE
+ * fail-closed design whose own comment reads "fail-closed-with-nothing-to-allow is a safe end state;
+ * every DB test skips, which is strictly better than running against production." There is no
+ * designated non-prod ref, so the tier is telling me not to write to production from the test
+ * runner — and it is right. Satisfying the binding criterion by pointing the runner at production
+ * would be defeating a safety control to make a test go green, which is the exact move this SD
+ * family exists to stop. So the demonstration is an explicit, one-shot, operator-invoked script with
+ * run-id-scoped cleanup, and its CAPTURED OUTPUT is the evidence. Nothing automated runs it.
+ *
+ * WHAT THE SEED IS AND IS NOT PROTECTED FROM. MY FIRST VERSION OF THIS PARAGRAPH WAS 1-OF-3 RIGHT
+ * AND A REVIEWER PROVED IT AT SOURCE. Corrected, because a safety argument that overstates its own
+ * coverage is worse than none — it stops the next reader looking.
+ * The real stuck-seat shape is sd_key NULL / claimed_at NULL / worktree_path NULL /
+ * continuous_sds_completed 0 (three of the four live stuck specimens), and FR-3 requires the seed
+ * carry it so it traverses the same filters a real stuck seat does.
+ *   TRUE — stale-session-sweep's main candidate feed selects `.not('sd_key','is',null)`, so a
+ *     sd_key-NULL row is not swept there and runClaimBoundaryProbe cannot reach it (claimed_at NULL
+ *     would disarm that probe anyway). BUT a SECOND feed selects the inverse, `.is('sd_key', null)`,
+ *     and INSERTs a CLAIM_REMINDER. It is dead only because STALE_THRESHOLD_SECONDS defaults to 300
+ *     and the nudge needs >= 300 while aliveIdle keeps < 300 — a provably empty interval TODAY that
+ *     inverts the moment anyone raises that env var. Safe by a default, not by design.
+ *   HALF FALSE — everClaimed FALSE does exclude it from the isFleetWorker/liveFleetWorkers family,
+ *     but NOT from isDispatchableFleetMember, which deliberately does not require everClaimed and is
+ *     what capacity actually runs on. So the seed IS visible to getFleetRoster, the capacity
+ *     forecaster's idleNow, coordination-events' unfiltered scan, and detectStalledLoop (it matches
+ *     every guard). ACCEPTED IN-WINDOW RISK, not an exclusion.
+ *   ALSO UNMENTIONED AND REAL — worktree_path NULL is read by auto-exec-checkout-sync as "this
+ *     worker is in the MAIN checkout", which can hold a worker-exclusion lock for up to 15 minutes,
+ *     OUTLIVING this script; and resolve-own-session's last-resort strategy picks the freshest
+ *     status='active' row by heartbeat, which this seed becomes BY CONSTRUCTION, so a process
+ *     falling through to it could adopt the synthetic row as its own session.
+ *   TRUE — no session_coordination row is written at all. The shipped predicate does not read
+ *     outbound escalation-ness (that conjunct was dropped as unproven), so there is nothing to seed
+ *     and nothing for lib/coordinator/signal-router.cjs to promote into a durable feedback row.
+ * CONCLUSION: this is a ONE-SHOT, OPERATOR-ATTENDED script with a seconds-long window. It must never
+ * be scheduled, CI-wired or npm-scripted.
+ * The ONLY protection for claude_sessions is this script's own cleanup: the SD-TEST- fence in
+ * stale-session-sweep.cjs guards strategic_directives_v2, NOT this table, and cancelStaleTestFixtures
+ * is likewise SD-side. Cleanup is therefore scoped to the two exact session_ids generated here and
+ * runs in a finally block — never a prefix DELETE (the sweep records a TOCTOU fatal from that).
+ *
+ * Usage: node scripts/seeded-firing-stuck-seat.cjs [--falsify]
+ *   --falsify  break the population query on purpose; the positive assertion MUST then fail.
+ */
+
+'use strict';
+
+// WALK UP TO THE .env RATHER THAN COUNTING DIRECTORIES. The original hardcoded ../../../.env, which
+// is correct from a worktree (.worktrees/<SD>/scripts) and resolves to C:\Users\rickf\Projects\.env
+// — a path that does not exist — from the merged main tree. The FR-3 acceptance artifact would have
+// stopped running the moment it merged, which is the quietest possible way for an acceptance
+// criterion to stop being checked.
+(() => {
+  const path = require('node:path');
+  const fs = require('node:fs');
+  let dir = __dirname;
+  for (let i = 0; i < 6; i++) {
+    const candidate = path.join(dir, '.env');
+    if (fs.existsSync(candidate)) { require('dotenv').config({ path: candidate }); return; }
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  require('dotenv').config();   // last resort: ambient env
+})();
+const { createClient } = require('@supabase/supabase-js');
+const { randomUUID } = require('node:crypto');
+const { fetchPopulation } = require('../lib/fleet/stuck-seat-population.cjs');
+const { classifySeat, VERDICT } = require('../lib/fleet/stuck-seat-predicate.cjs');
+
+const FALSIFY = process.argv.includes('--falsify');
+const CUT_POINT_MINUTES = 120;      // for THIS demonstration only — not shipped, not a calibration
+const STALE_MINUTES = 600;
+
+async function main() {
+  const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const runId = randomUUID().slice(0, 8);
+  const now = Date.now();
+
+  // DISTINCT identifiers for the twins. Sharing one would be a claim conflict the sweep resolves by
+  // evicting one, producing a false negative in the very assertion meant to prove firing.
+  const stuckId = randomUUID();
+  const healthyId = randomUUID();
+
+  const base = {
+    status: 'active', loop_state: 'active',
+    heartbeat_at: new Date(now).toISOString(),      // FRESH — the whole point: it looks alive
+    sd_key: null, claimed_at: null, worktree_path: null, continuous_sds_completed: 0,
+    metadata: { seeded_by: 'seeded-firing-stuck-seat', run_id: runId }
+  };
+  const rows = [
+    { ...base, session_id: stuckId,   last_tool_at: new Date(now - STALE_MINUTES * 60000).toISOString() },
+    { ...base, session_id: healthyId, last_tool_at: new Date(now).toISOString() }   // MATCHED NEGATIVE
+  ];
+
+  let inserted = false;
+  // A finally block does NOT run on SIGINT/SIGTERM, and nothing in this repo reaps a claim-free
+  // status='active' row — readers without a heartbeat filter would carry an orphan forever. Ctrl-C
+  // during the seconds-long window is the realistic way that happens, so it gets a handler.
+  const emergencyCleanup = async () => {
+    try { await sb.from('claude_sessions').delete().in('session_id', [stuckId, healthyId]); } catch { /* best effort */ }
+    console.error('\nINTERRUPTED — emergency cleanup attempted for ' + stuckId + ', ' + healthyId);
+    process.exit(130);
+  };
+  process.on('SIGINT', emergencyCleanup);
+  process.on('SIGTERM', emergencyCleanup);
+
+  // Reap any orphan a previous killed run left behind, before adding more.
+  const { data: orphans } = await sb.from('claude_sessions')
+    .select('session_id').eq('metadata->>seeded_by', 'seeded-firing-stuck-seat');
+  if (orphans && orphans.length) {
+    console.log('REAPING ' + orphans.length + ' orphan(s) from a previous run: ' + orphans.map((o) => o.session_id).join(', '));
+    await sb.from('claude_sessions').delete().in('session_id', orphans.map((o) => o.session_id));
+  }
+
+  try {
+    const { error } = await sb.from('claude_sessions').insert(rows);
+    if (error) throw new Error('seed insert failed: ' + error.message);
+    inserted = true;
+    console.log('SEEDED run_id=' + runId);
+    console.log('  positive (stuck shape) : ' + stuckId + '  last_tool_at ' + STALE_MINUTES + 'm stale');
+    console.log('  matched negative       : ' + healthyId + '  last_tool_at 0m');
+    console.log('  both: sd_key NULL, claimed_at NULL, worktree_path NULL, continuous_sds_completed 0 (the REAL stuck-seat shape)');
+
+    // THE DETECTOR RUNS ITS OWN PRODUCTION QUERY. The rows are NOT handed in — that is the whole
+    // point of the binding criterion: a detector can score SILENT because the harness never fed it
+    // anything, and that false negative is indistinguishable from a real finding.
+    let population = await fetchPopulation(sb);
+    if (FALSIFY) {
+      population = population.filter(() => false);   // mutate the feed to select nothing
+      console.log('\n[--falsify] population feed forced empty');
+    }
+
+    const findings = population
+      .map((row) => classifySeat(row, { cutPointMinutes: CUT_POINT_MINUTES, now }))
+      .filter((r) => r.verdict === VERDICT.STUCK);
+    const unknowns = population
+      .map((row) => classifySeat(row, { cutPointMinutes: CUT_POINT_MINUTES, now }))
+      .filter((r) => r.verdict === VERDICT.UNKNOWN);
+
+    console.log('\nPOPULATION: ' + population.length + ' seats');
+    console.log('FINDINGS  : ' + findings.length + ' stuck, ' + unknowns.length + ' unknown');
+    findings.forEach((f) => console.log('   STUCK ' + f.session_id + '  silent ' + f.toolSilentMinutes + 'm  (' + f.reason + ')'));
+
+    const positiveFound = findings.some((f) => f.session_id === stuckId);
+    const negativeSilent = !findings.some((f) => f.session_id === healthyId);
+
+    console.log('\nASSERTIONS');
+    console.log('  seeded positive is NAMED in the output : ' + (positiveFound ? 'PASS' : 'FAIL'));
+    console.log('  matched negative stays SILENT          : ' + (negativeSilent ? 'PASS' : 'FAIL'));
+
+    const ok = positiveFound && negativeSilent;
+    console.log('\nRESULT: ' + (ok ? 'SEEDED FIRING DEMONSTRATED' : 'NOT DEMONSTRATED')
+      + (FALSIFY ? '   <- expected NOT DEMONSTRATED under --falsify' : ''));
+    process.exitCode = ok ? 0 : 1;
+  } finally {
+    if (inserted) {
+      // RUN-ID SCOPED, by exact session_id. Never a prefix DELETE. This is the ONLY protection this
+      // table has, so it runs even when the assertions throw.
+      const { error } = await sb.from('claude_sessions').delete().in('session_id', [stuckId, healthyId]);
+      // THE DELETE ERROR IS FATAL IN ITS OWN RIGHT. It previously delegated entirely to the survivor
+      // check below — so "CLEANUP: ERROR <msg>; survivors=0, exit 0" was reachable.
+      if (error) { console.error('\nCLEANUP: DELETE FAILED — ' + error.message); process.exitCode = 1; }
+      const { data: left, error: checkError } = await sb.from('claude_sessions')
+        .select('session_id').in('session_id', [stuckId, healthyId]);
+      // AND THE SURVIVOR CHECK'S OWN ERROR IS CHECKED. It was discarded: on any transient failure
+      // `left` came back undefined, the report printed survivors=0 and the guard never fired — a
+      // leaked synthetic active seat reporting clean. A check the caller can satisfy without
+      // changing the harm is not a check, which is the thesis of this entire SD.
+      if (checkError) {
+        console.error('CLEANUP: could not VERIFY removal (' + checkError.message + ') — treat as leaked: ' + stuckId + ', ' + healthyId);
+        process.exitCode = 1;
+      } else {
+        const survivors = (left || []).length;
+        console.log('\nCLEANUP: deleted; survivors=' + survivors);
+        if (survivors) process.exitCode = 1;   // a leaked synthetic active seat is a failure
+      }
+    }
+  }
+}
+
+main().catch((e) => { console.error('FATAL ' + e.message); process.exit(1); });

--- a/tests/unit/fleet/stuck-seat-predicate.test.js
+++ b/tests/unit/fleet/stuck-seat-predicate.test.js
@@ -249,7 +249,7 @@ describe('fetchPopulation BEHAVIOURALLY — the gap that let the defect through 
   ];
 
   it('returns all four CLAIM-FREE stuck seats — the regression test for returning 1 of 4', async () => {
-    const seats = await fetchPopulation(fakeSupabase(LIVE_SHAPED));
+    const { seats } = await fetchPopulation(fakeSupabase(LIVE_SHAPED));
     const ids = seats.map((s) => s.session_id);
     for (const stuck of ['ab29dc41-0382-4bdb-8d79-5306874e8dbb', 'e3610a71-688e-4184-a323-261ad135f0d3',
                          'e7c92ad8-6be0-42a6-870e-cfb5d9f73098', '06521203-f370-4666-a40c-7801bcc192ef']) {
@@ -261,7 +261,7 @@ describe('fetchPopulation BEHAVIOURALLY — the gap that let the defect through 
   });
 
   it('excludes fixtures by ID SHAPE and excludes released seats — but never by claim state', async () => {
-    const ids = (await fetchPopulation(fakeSupabase(LIVE_SHAPED))).map((s) => s.session_id);
+    const ids = (await fetchPopulation(fakeSupabase(LIVE_SHAPED))).seats.map((s) => s.session_id);
     expect(ids).not.toContain('test-session-fixture-1');          // isFixtureSession, id shape
     expect(ids).not.toContain('ffffffff-dead-dead-dead-ffffffffffff'); // status filter
     expect(ids).toContain('2bd03a3c-aaaa-bbbb-cccc-dddddddddddd');     // claim-HOLDING seat still in
@@ -288,5 +288,45 @@ describe('fetchPopulation BEHAVIOURALLY — the gap that let the defect through 
     // An empty population and a failed query render identically as "0 stuck" — the failure must be loud.
     const failing = { from: () => ({ select: () => ({ in: () => ({ order: () => ({ limit: async () => ({ data: null, error: { message: 'boom' } }) }) }) }) }) };
     await expect(fetchPopulation(failing)).rejects.toThrow(/boom/);
+  });
+});
+
+describe('the incumbent is RUN, not quoted — precedence must not rot into a frozen constant', () => {
+  /**
+   * ADDED AFTER REVIEW. The precedence test above asserts the documented rule; a reviewer pointed out
+   * it never executes lib/fleet/claim-boundary-probe.cjs, so if the incumbent's behaviour changed the
+   * assertion would keep passing while the documented rationale quietly became false. That is
+   * PAT-TEST-PINS-FACT-NOT-BEHAVIOUR-001, which has six prior occurrences in this repo, and I hit it
+   * in the one place the PRD explicitly asked for behaviour. This runs both detectors on the same row.
+   */
+  const { evaluateClaimBoundary } = require('../../../lib/fleet/claim-boundary-probe.cjs');
+
+  it('DELTA-shaped row: the incumbent PASSes and this module says STUCK', () => {
+    // Delta's real shape: it worked for a while AFTER its claim anchor, then froze. The incumbent's
+    // progressed_past_boundary guard sees the post-anchor activity and passes; it never looks at how
+    // long ago that activity was. That guard is the dangerous one — it clears ANY seat that did work
+    // and then stopped, which is the entire failure class this SD addresses.
+    const anchorMs = MEASURED_AT - 935 * 60000;          // claim anchor, ~15.5h ago
+    const lastToolAtMs = MEASURED_AT - 888 * 60000;      // last tool 47 min AFTER the anchor
+    const incumbent = evaluateClaimBoundary({ nowMs: MEASURED_AT, anchorMs, lastToolAtMs, outboundSinceAnchor: 0 });
+    const mine = classifySeat(
+      { session_id: 'delta', last_tool_at: new Date(lastToolAtMs).toISOString(), metadata: {} },
+      { cutPointMinutes: TEST_CUT, now: MEASURED_AT }
+    );
+    expect(incumbent.verdict).toBe('PASS');
+    expect(mine.verdict).toBe(VERDICT.STUCK);
+    // The disagreement is REAL and REPRODUCED, so the documented precedence has something to govern.
+    expect(PRECEDENCE.onDisagreement).toBe('stuck_wins_for_reporting_incumbent_wins_for_actuation');
+    expect(PRECEDENCE.thisModuleIsAdvisoryOnly).toBe(true);
+  });
+
+  it('names WHICH incumbent guard fired, so a change of reason is visible rather than silent', () => {
+    const anchorMs = MEASURED_AT - 935 * 60000;
+    const incumbent = evaluateClaimBoundary({
+      nowMs: MEASURED_AT, anchorMs, lastToolAtMs: MEASURED_AT - 888 * 60000, outboundSinceAnchor: 0
+    });
+    // Recorded because I documented the WRONG guard first: the PRD originally said Delta passes via
+    // outbound_comms_since_anchor, which is unreachable on Delta (zero outbound since its anchor).
+    expect(incumbent.reason).toBe('progressed_past_boundary');
   });
 });

--- a/tests/unit/fleet/stuck-seat-predicate.test.js
+++ b/tests/unit/fleet/stuck-seat-predicate.test.js
@@ -1,0 +1,189 @@
+/**
+ * Stuck-seat predicate — SD-FDBK-INFRA-STUCK-SEAT-DETECTION-001.
+ *
+ * The fixture table below is MEASURED, not narrated. Every interval was computed from two
+ * timestamps against live claude_sessions rows at 2026-08-01T09:25:44.546Z (PRD TR-4: a detection
+ * predicate calibrated against a duration someone estimated inherits that error as a THRESHOLD,
+ * where it becomes invisible).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { classifySeat, classifyWakeState, VERDICT, REASON, PRECEDENCE } from '../../../lib/fleet/stuck-seat-predicate.cjs';
+import { POPULATION_STATUSES, POPULATION_COLUMNS } from '../../../lib/fleet/stuck-seat-population.cjs';
+import { readFileSync } from 'node:fs';
+
+const MEASURED_AT = Date.parse('2026-08-01T09:25:44.546Z');
+
+/** Measured live. lta_min = minutes of tool silence at MEASURED_AT. */
+const SPECIMENS = [
+  { label: 'ALPHA-3', session_id: '2bd03a3c-healthy-control',   truth: 'healthy', lta_min: 0,   status: 'active', everClaimed: true },
+  { label: 'ALPHA-2', session_id: '8aa7b984-healthy-this-seat', truth: 'healthy', lta_min: 0,   status: 'active', everClaimed: true },
+  { label: 'CHARLIE', session_id: '06521203-stuck-stranded',    truth: 'stuck',   lta_min: 249, status: 'idle',   everClaimed: false },
+  { label: 'BRAVO',   session_id: 'e3610a71-stuck-exited',      truth: 'stuck',   lta_min: 499, status: 'idle',   everClaimed: false },
+  { label: 'ALPHA',   session_id: 'e7c92ad8-stuck-awaiting',    truth: 'stuck',   lta_min: 694, status: 'idle',   everClaimed: false },
+  { label: 'DELTA',   session_id: 'ab29dc41-stuck-frozen',      truth: 'stuck',   lta_min: 888, status: 'active', everClaimed: true }
+];
+
+/** A cut point chosen ONLY for these tests. It is NOT shipped and NOT a calibration — see TR-4. */
+const TEST_CUT = 120;
+
+function rowFor(spec, overrides = {}) {
+  return {
+    session_id: spec.session_id,
+    status: spec.status,
+    loop_state: 'active',
+    last_tool_at: new Date(MEASURED_AT - spec.lta_min * 60000).toISOString(),
+    heartbeat_at: new Date(MEASURED_AT).toISOString(),   // 0 min on ALL SIX — deliberately uninformative
+    metadata: {},
+    ...overrides
+  };
+}
+
+describe('the six measured specimens', () => {
+  it('classifies all six correctly — 4 stuck, 2 healthy', () => {
+    for (const spec of SPECIMENS) {
+      const r = classifySeat(rowFor(spec), { cutPointMinutes: TEST_CUT, now: MEASURED_AT });
+      expect(r.verdict, spec.label).toBe(spec.truth === 'stuck' ? VERDICT.STUCK : VERDICT.HEALTHY);
+    }
+  });
+
+  it('heartbeat_at is identical on all six and therefore carries NO information', () => {
+    // This is why the SD exists: four independent liveness indicators read healthy on Delta.
+    // If a future change makes the predicate consult heartbeat_at, it consults a constant.
+    const beats = new Set(SPECIMENS.map((s) => rowFor(s).heartbeat_at));
+    expect(beats.size).toBe(1);
+  });
+
+  it('last_tool_at separates the classes with NO overlap — the ordering, not a cut point', () => {
+    const healthy = SPECIMENS.filter((s) => s.truth === 'healthy').map((s) => s.lta_min);
+    const stuck = SPECIMENS.filter((s) => s.truth === 'stuck').map((s) => s.lta_min);
+    expect(Math.max(...healthy)).toBeLessThan(Math.min(...stuck));
+  });
+});
+
+describe('CLAIM STATE MUST NOT REACH THE VERDICT — the defect this SD already produced once', () => {
+  // The sourced predicate led with has_live_claim. Measured on these same six rows it agrees with
+  // ground truth 0/6 (TRUE for both healthy controls, FALSE for all four stuck seats) because the
+  // sweep releases a stuck seat's claim before it is detectably stuck. The first PRD dropped it from
+  // the predicate and then reintroduced it in the POPULATION via isFleetWorker/everClaimed, which
+  // returned 1 of 4 stuck specimens. THIS IS A BEHAVIOURAL ASSERTION AGAINST THE SHIPPED MODULE:
+  // an earlier version of this test scored a locally-defined helper, which would have stayed green
+  // if the conjunct came back.
+  const CLAIM_FIELDS = ['sd_key', 'claimed_at', 'worktree_path', 'continuous_sds_completed'];
+
+  it('mutating every claim-derived field leaves each verdict byte-identical', () => {
+    for (const spec of SPECIMENS) {
+      const base = classifySeat(rowFor(spec), { cutPointMinutes: TEST_CUT, now: MEASURED_AT });
+      const claimed = classifySeat(
+        rowFor(spec, { sd_key: 'SD-ANY-001', claimed_at: new Date(MEASURED_AT).toISOString(), worktree_path: '/tmp/wt', continuous_sds_completed: 3 }),
+        { cutPointMinutes: TEST_CUT, now: MEASURED_AT }
+      );
+      const unclaimed = classifySeat(
+        rowFor(spec, { sd_key: null, claimed_at: null, worktree_path: null, continuous_sds_completed: 0 }),
+        { cutPointMinutes: TEST_CUT, now: MEASURED_AT }
+      );
+      expect(claimed, spec.label + ' claimed').toEqual(base);
+      expect(unclaimed, spec.label + ' unclaimed').toEqual(base);
+    }
+  });
+
+  it('no claim-derived field name appears in the predicate or the population source', () => {
+    // A source-level backstop for the behavioural test above: the invariance assertion proves claim
+    // state does not change the ANSWER, this proves it is not consulted at all — including in a
+    // branch these fixtures happen not to exercise.
+    const files = ['lib/fleet/stuck-seat-predicate.cjs', 'lib/fleet/stuck-seat-population.cjs'];
+    for (const f of files) {
+      const src = readFileSync(f, 'utf8')
+        // strip comments: the rationale NECESSARILY names these fields, and a source scan that
+        // cannot tell an explanation from a use would make the honest comment unwritable.
+        .replace(/\/\*[\s\S]*?\*\//g, ' ')
+        .replace(/^[^\S\r\n]*\/\/[^\n]*$/gm, ' ');
+      for (const field of CLAIM_FIELDS.concat(['everClaimed', 'isFleetWorker'])) {
+        expect(src, f + ' must not consult ' + field).not.toContain(field);
+      }
+    }
+  });
+
+  it('the population includes idle seats — 3 of 4 stuck specimens are status=idle', () => {
+    expect(POPULATION_STATUSES).toContain('idle');
+    expect(POPULATION_STATUSES).toContain('active');
+    // and it must not select the uuid PK, so nothing downstream can join on the wrong key
+    expect(POPULATION_COLUMNS).toContain('session_id');
+    expect(POPULATION_COLUMNS.split(',').map((c) => c.trim())).not.toContain('id');
+  });
+});
+
+describe('NULL is UNKNOWN, never healthy — with EXACT reason tokens', () => {
+  it('a missing tool clock yields UNKNOWN/last_tool_at_never_written', () => {
+    const r = classifySeat(rowFor(SPECIMENS[0], { last_tool_at: null }), { cutPointMinutes: TEST_CUT, now: MEASURED_AT });
+    expect(r.verdict).toBe(VERDICT.UNKNOWN);
+    // EXACT token, not a truthy check: a truthy assertion cannot distinguish this branch from an
+    // earlier guard also returning UNKNOWN, so it would pass without ever reaching the code it names.
+    expect(r.reason).toBe(REASON.NO_TOOL_CLOCK);
+    expect(r.reason).toBe('last_tool_at_never_written');
+  });
+
+  it('an unparseable tool clock is UNKNOWN, not healthy', () => {
+    const r = classifySeat(rowFor(SPECIMENS[0], { last_tool_at: 'not-a-date' }), { cutPointMinutes: TEST_CUT, now: MEASURED_AT });
+    expect(r.verdict).toBe(VERDICT.UNKNOWN);
+    expect(r.reason).toBe('last_tool_at_never_written');
+  });
+});
+
+describe('wakeup state is THREE-valued — absent is not proof none was armed', () => {
+  it('absent expected_wake_at yields not_recorded, NOT no-wakeup-armed', () => {
+    const w = classifyWakeState({ metadata: {} }, MEASURED_AT);
+    expect(w.state).toBe('not_recorded');
+    expect(w.reason).toBe('wake_not_recorded');
+  });
+
+  it('Delta shape: an armed deadline hundreds of minutes in the past is armed_overdue', () => {
+    // Measured on the live Delta row: metadata.expected_wake_at = 2026-07-31T18:07:27.682Z.
+    const w = classifyWakeState({ metadata: { expected_wake_at: '2026-07-31T18:07:27.682Z' } }, MEASURED_AT);
+    expect(w.state).toBe('armed_overdue');
+    expect(w.overdueMinutes).toBeGreaterThan(800);
+  });
+
+  it('a future deadline is armed_pending, not overdue', () => {
+    const w = classifyWakeState({ metadata: { expected_wake_at: new Date(MEASURED_AT + 600000).toISOString() } }, MEASURED_AT);
+    expect(w.state).toBe('armed_pending');
+  });
+
+  it('an unparseable deadline degrades to not_recorded rather than throwing', () => {
+    expect(classifyWakeState({ metadata: { expected_wake_at: 'garbage' } }, MEASURED_AT).state).toBe('not_recorded');
+  });
+});
+
+describe('the module REFUSES to run without an explicit cut point', () => {
+  // TR-4: no default may exist. A default here would be an uncalibrated number in the one place
+  // nobody looks at again — the false-negative side is n=1 per class and healthy latency is
+  // right-censored, so the data cannot support a cut point yet.
+  it.each([[undefined], [null], [0], [-5], [NaN], ['120']])('throws for cutPointMinutes=%p', (cut) => {
+    expect(() => classifySeat(rowFor(SPECIMENS[0]), { cutPointMinutes: cut, now: MEASURED_AT })).toThrow(/cutPointMinutes is REQUIRED/);
+  });
+
+  it('there is no numeric default anywhere in the module source', () => {
+    const src = readFileSync('lib/fleet/stuck-seat-predicate.cjs', 'utf8');
+    expect(src).not.toMatch(/cutPointMinutes\s*=\s*\d/);
+    expect(src).not.toMatch(/DEFAULT_CUT/);
+  });
+});
+
+describe('precedence against the incumbent detector', () => {
+  it('is advisory-only and declares the disagreement rule explicitly', () => {
+    // lib/fleet/claim-boundary-probe.cjs returns PASS on Delta (progressed_past_boundary at :129 —
+    // NOT outbound_comms_since_anchor at :152, which is unreachable there because Delta has zero
+    // outbound since its claim anchor). Both guards blind it to this class; progressed_past_boundary
+    // is the more dangerous because it PASSes ANY seat that did work and then froze.
+    expect(PRECEDENCE.thisModuleIsAdvisoryOnly).toBe(true);
+    expect(PRECEDENCE.onDisagreement).toBe('stuck_wins_for_reporting_incumbent_wins_for_actuation');
+    expect(PRECEDENCE.incumbent).toBe('lib/fleet/claim-boundary-probe.cjs');
+  });
+
+  it('a Delta-shaped row that the incumbent PASSes is classified STUCK here', () => {
+    const delta = SPECIMENS.find((s) => s.label === 'DELTA');
+    const r = classifySeat(rowFor(delta), { cutPointMinutes: TEST_CUT, now: MEASURED_AT });
+    expect(r.verdict).toBe(VERDICT.STUCK);
+    expect(r.toolSilentMinutes).toBe(888);
+  });
+});

--- a/tests/unit/fleet/stuck-seat-predicate.test.js
+++ b/tests/unit/fleet/stuck-seat-predicate.test.js
@@ -9,7 +9,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { classifySeat, classifyWakeState, VERDICT, REASON, PRECEDENCE } from '../../../lib/fleet/stuck-seat-predicate.cjs';
-import { POPULATION_STATUSES, POPULATION_COLUMNS } from '../../../lib/fleet/stuck-seat-population.cjs';
+import { POPULATION_STATUSES, POPULATION_COLUMNS, POPULATION_ROW_LIMIT, fetchPopulation } from '../../../lib/fleet/stuck-seat-population.cjs';
 import { readFileSync } from 'node:fs';
 
 const MEASURED_AT = Date.parse('2026-08-01T09:25:44.546Z');
@@ -47,17 +47,36 @@ describe('the six measured specimens', () => {
     }
   });
 
-  it('heartbeat_at is identical on all six and therefore carries NO information', () => {
-    // This is why the SD exists: four independent liveness indicators read healthy on Delta.
-    // If a future change makes the predicate consult heartbeat_at, it consults a constant.
-    const beats = new Set(SPECIMENS.map((s) => rowFor(s).heartbeat_at));
-    expect(beats.size).toBe(1);
+  it('heartbeat_at cannot change any verdict — it carries no information and must not be consulted', () => {
+    // REWRITTEN AFTER REVIEW. The first version compared `rowFor()` output to itself: it asserted a
+    // constant the fixture builder had just written, stayed green under BOTH predicate mutations,
+    // and its own comment claimed it would catch "a future change that consults heartbeat_at" — which
+    // is not what it checked. This is that check: drive heartbeat_at across its whole plausible range
+    // and require every verdict to be byte-identical.
+    for (const spec of SPECIMENS) {
+      const base = classifySeat(rowFor(spec), { cutPointMinutes: TEST_CUT, now: MEASURED_AT });
+      for (const beat of [MEASURED_AT, MEASURED_AT - 3600_000, MEASURED_AT - 86_400_000, null]) {
+        const r = classifySeat(rowFor(spec, { heartbeat_at: beat === null ? null : new Date(beat).toISOString() }),
+          { cutPointMinutes: TEST_CUT, now: MEASURED_AT });
+        expect(r, spec.label + ' heartbeat=' + beat).toEqual(base);
+      }
+    }
   });
 
-  it('last_tool_at separates the classes with NO overlap — the ordering, not a cut point', () => {
-    const healthy = SPECIMENS.filter((s) => s.truth === 'healthy').map((s) => s.lta_min);
-    const stuck = SPECIMENS.filter((s) => s.truth === 'stuck').map((s) => s.lta_min);
-    expect(Math.max(...healthy)).toBeLessThan(Math.min(...stuck));
+  it('the ORDERING is a property of the code, not of the fixture literal', () => {
+    // REWRITTEN AFTER REVIEW. The first version compared numbers inside the SPECIMENS array to each
+    // other and never called the module — it could not fail for any reason involving the code.
+    // Now: run the shipped predicate over the specimens and require that no cut point anywhere in the
+    // gap produces a misclassification. That is what "separates with no overlap" actually means.
+    const healthyMax = Math.max(...SPECIMENS.filter((s) => s.truth === 'healthy').map((s) => s.lta_min));
+    const stuckMin = Math.min(...SPECIMENS.filter((s) => s.truth === 'stuck').map((s) => s.lta_min));
+    expect(healthyMax).toBeLessThan(stuckMin);
+    for (const cut of [healthyMax + 1, Math.floor((healthyMax + stuckMin) / 2), stuckMin]) {
+      for (const spec of SPECIMENS) {
+        const r = classifySeat(rowFor(spec), { cutPointMinutes: cut, now: MEASURED_AT });
+        expect(r.verdict, spec.label + ' at cut=' + cut).toBe(spec.truth === 'stuck' ? VERDICT.STUCK : VERDICT.HEALTHY);
+      }
+    }
   });
 });
 
@@ -185,5 +204,89 @@ describe('precedence against the incumbent detector', () => {
     const r = classifySeat(rowFor(delta), { cutPointMinutes: TEST_CUT, now: MEASURED_AT });
     expect(r.verdict).toBe(VERDICT.STUCK);
     expect(r.toolSilentMinutes).toBe(888);
+  });
+});
+
+describe('fetchPopulation BEHAVIOURALLY — the gap that let the defect through twice', () => {
+  /**
+   * A reviewer proved the hole: rewriting everClaimed as a computed property evaded the source scan
+   * AND passed 21/21, because NOTHING CALLED fetchPopulation. Measured blast radius under that
+   * evasion: population=0, stuck=0 — a permanently blind detector with a fully green suite. In the
+   * predicate the same evasion was caught (the invariance test still failed); the population had no
+   * equivalent. This is that equivalent.
+   *
+   * The fake APPLIES its filters instead of recording them. A double that records a predicate and
+   * then returns the fixture regardless answers "found it" to a query no row can satisfy — the exact
+   * shape that let a provably-dead predicate pass 162 tests earlier in this SD family.
+   */
+  function fakeSupabase(rows, { capture = {} } = {}) {
+    return {
+      from(table) {
+        capture.table = table;
+        let working = rows.slice();
+        const q = {
+          select(cols) { capture.columns = cols; return q; },
+          in(col, vals) { capture.statusFilter = { col, vals }; working = working.filter((r) => vals.includes(r[col])); return q; },
+          order(col, opts) { capture.order = { col, ...opts }; return q; },
+          async limit(n) { capture.limit = n; return { data: working.slice(0, n), error: null }; }
+        };
+        return q;
+      }
+    };
+  }
+
+  const LIVE_SHAPED = [
+    // The four stuck specimens: every one has NO claim state. Three are status='idle'.
+    { session_id: 'ab29dc41-0382-4bdb-8d79-5306874e8dbb', status: 'active', last_tool_at: '2026-07-31T18:38:14Z', sd_key: null, claimed_at: null, worktree_path: null, continuous_sds_completed: 0, metadata: {} },
+    { session_id: 'e3610a71-688e-4184-a323-261ad135f0d3', status: 'idle',   last_tool_at: '2026-08-01T01:02:00Z', sd_key: null, claimed_at: null, worktree_path: null, continuous_sds_completed: 0, metadata: {} },
+    { session_id: 'e7c92ad8-6be0-42a6-870e-cfb5d9f73098', status: 'idle',   last_tool_at: '2026-07-31T21:47:00Z', sd_key: null, claimed_at: null, worktree_path: null, continuous_sds_completed: 0, metadata: {} },
+    { session_id: '06521203-f370-4666-a40c-7801bcc192ef', status: 'idle',   last_tool_at: '2026-08-01T05:11:00Z', sd_key: null, claimed_at: null, worktree_path: null, continuous_sds_completed: 0, metadata: {} },
+    // A healthy claim-HOLDING seat, and a fixture that must be excluded by ID SHAPE not claim state.
+    { session_id: '2bd03a3c-aaaa-bbbb-cccc-dddddddddddd', status: 'active', last_tool_at: '2026-08-01T09:25:00Z', sd_key: 'SD-X-001', claimed_at: '2026-08-01T08:00:00Z', worktree_path: '/wt', continuous_sds_completed: 2, metadata: {} },
+    { session_id: 'test-session-fixture-1',                status: 'active', last_tool_at: '2026-08-01T09:25:00Z', sd_key: null, claimed_at: null, worktree_path: null, continuous_sds_completed: 0, metadata: {} },
+    // status='released' — outside the population entirely.
+    { session_id: 'ffffffff-dead-dead-dead-ffffffffffff', status: 'released', last_tool_at: '2026-07-01T00:00:00Z', sd_key: null, claimed_at: null, worktree_path: null, continuous_sds_completed: 0, metadata: {} }
+  ];
+
+  it('returns all four CLAIM-FREE stuck seats — the regression test for returning 1 of 4', async () => {
+    const seats = await fetchPopulation(fakeSupabase(LIVE_SHAPED));
+    const ids = seats.map((s) => s.session_id);
+    for (const stuck of ['ab29dc41-0382-4bdb-8d79-5306874e8dbb', 'e3610a71-688e-4184-a323-261ad135f0d3',
+                         'e7c92ad8-6be0-42a6-870e-cfb5d9f73098', '06521203-f370-4666-a40c-7801bcc192ef']) {
+      expect(ids, 'stuck seat must survive the population').toContain(stuck);
+    }
+    // Under the everClaimed evasion this returned ZERO. Asserting the count pins the whole class,
+    // not just the four ids: any claim-derived filter drops all four at once.
+    expect(seats.length).toBe(5);
+  });
+
+  it('excludes fixtures by ID SHAPE and excludes released seats — but never by claim state', async () => {
+    const ids = (await fetchPopulation(fakeSupabase(LIVE_SHAPED))).map((s) => s.session_id);
+    expect(ids).not.toContain('test-session-fixture-1');          // isFixtureSession, id shape
+    expect(ids).not.toContain('ffffffff-dead-dead-dead-ffffffffffff'); // status filter
+    expect(ids).toContain('2bd03a3c-aaaa-bbbb-cccc-dddddddddddd');     // claim-HOLDING seat still in
+  });
+
+  it('bounds the read and orders it stalest-first, so a row-cap truncation cannot silently hide stuck seats', async () => {
+    const capture = {};
+    await fetchPopulation(fakeSupabase(LIVE_SHAPED, { capture }));
+    expect(capture.limit).toBe(POPULATION_ROW_LIMIT);
+    expect(capture.order).toMatchObject({ col: 'last_tool_at', ascending: true });
+    expect(capture.statusFilter).toEqual({ col: 'status', vals: POPULATION_STATUSES });
+  });
+
+  it('reports truncation rather than swallowing it', async () => {
+    const many = Array.from({ length: POPULATION_ROW_LIMIT }, (_, i) => ({
+      session_id: 'aaaaaaaa-0000-0000-0000-' + String(i).padStart(12, '0'),
+      status: 'active', last_tool_at: '2026-08-01T00:00:00Z', metadata: {}
+    }));
+    expect((await fetchPopulation(fakeSupabase(many))).truncated).toBe(true);
+    expect((await fetchPopulation(fakeSupabase(LIVE_SHAPED))).truncated).toBe(false);
+  });
+
+  it('throws on a query error instead of returning an empty population', async () => {
+    // An empty population and a failed query render identically as "0 stuck" — the failure must be loud.
+    const failing = { from: () => ({ select: () => ({ in: () => ({ order: () => ({ limit: async () => ({ data: null, error: { message: 'boom' } }) }) }) }) }) };
+    await expect(fetchPopulation(failing)).rejects.toThrow(/boom/);
   });
 });

--- a/tests/unit/fleet/stuck-seat-predicate.test.js
+++ b/tests/unit/fleet/stuck-seat-predicate.test.js
@@ -330,3 +330,61 @@ describe('the incumbent is RUN, not quoted — precedence must not rot into a fr
     expect(incumbent.reason).toBe('progressed_past_boundary');
   });
 });
+
+describe('the dashboard strip RENDER path — uncovered until printStuckSeatStrip was exported', () => {
+  /**
+   * ADDED AFTER REVIEW. The strip was the only renderer in fleet-dashboard.cjs missing from
+   * module.exports, whose own comment reads "Export read-only renderers for unit testing" — so its
+   * render path had no coverage at all. These assert the behaviour that actually matters: the strip
+   * must NEVER produce a silent zero, because a detector that scanned nothing and a fleet that is
+   * genuinely fine must not render identically.
+   */
+  const { printStuckSeatStrip } = require('../../../scripts/fleet-dashboard.cjs');
+
+  function fakeClient(rows) {
+    return { from: () => { let w = rows.slice(); const q = {
+      select: () => q, in: (c, v) => { w = w.filter((r) => v.includes(r[c])); return q; },
+      order: () => q, limit: async (n) => ({ data: w.slice(0, n), error: null }) }; return q; } };
+  }
+  function capture(fn) {
+    const lines = []; const orig = console.log;
+    console.log = (...a) => lines.push(a.join(' '));
+    return fn().finally(() => { console.log = orig; }).then(() => lines.join('\n'));
+  }
+
+  const HEALTHY = { session_id: 'aaaaaaaa-1111-2222-3333-444444444444', status: 'active', last_tool_at: new Date().toISOString(), metadata: {} };
+  const STUCK = { session_id: 'bbbbbbbb-1111-2222-3333-444444444444', status: 'idle', last_tool_at: new Date(Date.now() - 600 * 60000).toISOString(), metadata: {} };
+  const BLIND = { session_id: 'cccccccc-1111-2222-3333-444444444444', status: 'active', last_tool_at: null, metadata: {} };
+
+  it('an ALL-CLEAR still states its denominator — this is the anti-silent-zero guarantee', async () => {
+    const out = await capture(() => printStuckSeatStrip(fakeClient([HEALTHY])));
+    expect(out).toContain('STUCK SEATS');
+    expect(out).toContain('seats scanned=1');
+    expect(out).toContain('stuck=0');
+  });
+
+  it('scanning NOTHING renders as a blind detector, not as a healthy fleet', async () => {
+    const out = await capture(() => printStuckSeatStrip(fakeClient([])));
+    expect(out).toContain('seats scanned=0');
+    expect(out).toMatch(/SCANNED NOTHING/);
+  });
+
+  it('a stuck seat is named with its silence and wake state', async () => {
+    const out = await capture(() => printStuckSeatStrip(fakeClient([HEALTHY, STUCK])));
+    expect(out).toContain(STUCK.session_id);
+    expect(out).toContain('stuck=1');
+  });
+
+  it('an UNKNOWN seat is counted and explained, never folded into healthy', async () => {
+    const out = await capture(() => printStuckSeatStrip(fakeClient([HEALTHY, BLIND])));
+    expect(out).toContain('unknown=1');
+    expect(out).toMatch(/could not see those seats, not that they are healthy/);
+  });
+
+  it('a DB failure says so rather than rendering a clean zero', async () => {
+    const failing = { from: () => ({ select: () => ({ in: () => ({ order: () => ({ limit: async () => ({ data: null, error: { message: 'boom' } }) }) }) }) }) };
+    const out = await capture(() => printStuckSeatStrip(failing));
+    expect(out).toContain('check unavailable');
+    expect(out).not.toContain('stuck=0');
+  });
+});


### PR DESCRIPTION
A worker can freeze while every liveness instrument reports it healthy. Delta (`session_id ab29dc41`) sat frozen **888 minutes** with `heartbeat_at` 0 minutes old, `status=active`, `loop_state=active` and a live process tick. This adds the detection half of the worker-loop directive (FR-5), left unbuilt when SD-FDBK-INFRA-WORKER-LOOP-DIRECTIVE-001 shipped 4-of-6 FRs.

Measured 2026-08-01T09:25:44Z, every interval from two timestamps:

| specimen | truth | last_tool_at | heartbeat_at |
|---|---|---|---|
| ALPHA-3 | healthy | 0m | 0m |
| ALPHA-2 | healthy | 0m | 0m |
| CHARLIE | stuck | 249m | 0m |
| BRAVO | stuck | 499m | 0m |
| ALPHA | stuck | 694m | 0m |
| DELTA | stuck | 888m | 0m |

`heartbeat_at` takes one distinct value across all six and carries zero information. `last_tool_at` separates them 6/6 with no overlap.

## The sourced predicate was inverted

FR-5 was specified as `has_live_claim AND last_outbound_was_an_escalation AND no_wakeup_armed`. `has_live_claim` agrees with ground truth **0 of 6** — TRUE for both healthy controls, FALSE for all four stuck seats — because the sweep releases a stuck seat's claim before it is detectably stuck. Gating detection on holding a claim gates it on not-yet-having-been-swept.

## Six self-inflicted instances of the defect class this SD detects

Every one caught by review, none by my own pre-handoff process. All fixed:

1. Removed `has_live_claim` from the predicate, then reintroduced it via the **population** (`isFleetWorker` → `everClaimed`) — cut the detector to 1 of 4 stuck specimens.
2. Shaped the binding acceptance seed to pass my own filter rather than to look like a stuck seat.
3. Nothing called `fetchPopulation` — a scan-evading `everClaimed` gave `population=0, stuck=0` with all 21 tests green.
4. Three false assertions in shipped headers, each citing a real `file:line`.
5. Escalated a security claim to the coordinator twice, at critical then high, without probing it. Probed since: anon `SELECT` allowed, `UPDATE`/`DELETE` denied. **Retracted and downgraded.**
6. The strip was the only renderer omitted from `module.exports`, leaving its render path uncovered.

## What it does

- **`lib/fleet/stuck-seat-predicate.cjs`** — pure, three-valued (`STUCK`/`HEALTHY`/`UNKNOWN`), exact reason tokens, **no default cut point** (throws without one). NULL is UNKNOWN, never healthy.
- **`lib/fleet/stuck-seat-population.cjs`** — `status IN (active, idle)`; fixtures excluded by **session-id shape**, never by claim state; ordered stalest-first and row-capped, with truncation returned rather than swallowed.
- **`scripts/seeded-firing-stuck-seat.cjs`** — the binding acceptance artifact. Seeds a row carrying the **real stuck-seat shape**, finds it via the detector's own production query, asserts a matched negative stays silent, cleans up run-id-scoped. `--falsify` exits 1.
- **`printStuckSeatStrip`** — always renders and always states `seats scanned=N`, so a blind detector can never look like a healthy fleet.

**Advisory only.** `claim-boundary-probe` returns PASS on Delta via `progressed_past_boundary`. On disagreement: stuck wins for reporting, the incumbent wins for actuation — a false positive here costs a line of text; one in the incumbent costs a worker its claim.

## Verification

- **33 unit tests green.** Each guard falsified separately with scan-evading mutants: reintroducing `has_live_claim` fails 6; `everClaimed` via computed property fails the population test; restoring the silent-zero early return fails exactly the two anti-silent-zero tests.
- Seeded firing re-demonstrated after every refactor; `--falsify` exits 1.
- No regression, causal: 8 failing tier files, all named, **zero** referencing the changed modules.

**Not built:** FR-6 as sourced (AWAITING-HUMAN-DECISION vs WORKING as belt/claim states) was substituted during PRD authoring for the counts strip. Recorded in `metadata.fr6_descope_record`; needs a follow-on SD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)