### PR TITLE
security(scribe): revoke anon write grants on 7 exposed tables (applied to prod, verified)

### DIFF
--- a/database/migrations/20260801_revoke_anon_writes_burn_rate_snapshots.sql
+++ b/database/migrations/20260801_revoke_anon_writes_burn_rate_snapshots.sql
@@ -1,0 +1,67 @@
+-- requires-chairman-apply
+-- @approved-by: codestreetlabs@gmail.com
+-- @approval-provenance: chairman SMS "Approved" 2026-08-01 11:45:04Z (packet sent 11:43:47Z, dedupe anon-revoke-7th-table-20260801), Adam d5080cf3 scribing
+-- =============================================================================
+-- Migration: revoke anon WRITE grants on sd_burn_rate_snapshots (the 7th table)
+--
+-- Why a SEPARATE file: the 6-table migration in this same PR was already APPLIED
+--      to prod under the chairman's 11:16Z approval. Amending that file would
+--      retroactively change the record of what he approved. This file carries its
+--      own approval marker for its own scope.
+--
+-- HOW IT WAS MISSED (coordinator, 2026-08-01 11:15Z) — the miss IS the finding:
+--      sd_burn_rate_snapshots is one of three tables where migration 20260317 DID
+--      drop the "Allow all for anon" POLICY. Any review reading POLICY state
+--      correctly scores it as already remediated. The GRANT was never revoked.
+--      Policy and grant are independent gates. Not a systematic exclusion:
+--      sd_conflict_matrix and sd_session_activity were also policy-dropped by
+--      20260317 and DID make the batch-2 list. Plain enumeration slip in a list
+--      of seven (Adam's, at sourcing).
+--
+-- WHAT IS ACTUALLY MEASURED, and what is NOT — stated precisely because an
+-- earlier draft of this header overstated it and was corrected before apply:
+--   MEASURED (Adam, anon key, 2026-08-01 ~11:35Z): the table-level GRANT is open.
+--      anon DELETE and anon UPDATE statements are both ACCEPTED (not 42501),
+--      filtered to an impossible id so nothing could land. UPDATE used a REAL
+--      column and a REAL value — an empty payload is short-circuited by PostgREST
+--      without exercising permissions and proves nothing.
+--   NOT MEASURED: whether a write would actually AFFECT ROWS. With RLS enabled and
+--      NO permissive policy for the verb, a statement is still ACCEPTED and simply
+--      affects zero rows. That is indistinguishable, from the client, from an open
+--      grant WITH a permissive policy. So this probe proves the GRANT and cannot
+--      establish a live write path. The batch-2 file beside this one carries the
+--      same caveat and it applies here identically.
+--   THE DECIDING EVIDENCE IS UNAVAILABLE TO EITHER REVIEWER: live per-verb policy
+--      state (pg_policies for role=anon) cannot be read from the app seat —
+--      PostgREST does not expose pg_catalog, and every SQL-exec RPC referenced in
+--      this repo (exec_readonly_sql, exec_sql, exec_raw_sql, execute_sql,
+--      fn_execute_sql_admin, get_policies_for_table) is ABSENT from the deployed
+--      schema. Verified 2026-08-01 ~11:58Z.
+--
+-- CURRENT BEST READING (coordinator, derived from migration source): 20260317
+--      dropped this table's anon policy, so the open grant is most likely DORMANT
+--      — a landmine, not a live hole. Its 28 rows are probably not anon-writable
+--      today. That reading is explicitly NOT source-of-truth: this same sweep
+--      already proved source diverges from live (model_usage_log carries a
+--      never-dropped FOR ALL anon policy in source yet blocks anon reads live).
+--
+-- WHY REVOKE ANYWAY — the action is correct under BOTH readings, which is why it
+--      did not need the ambiguity resolved first. If the policy is live, this
+--      closes an open write path. If the grant is dormant, this removes a
+--      landmine that would ARM SILENTLY the instant any future policy is added to
+--      this table. Revoking a grant nothing legitimately uses costs nothing.
+--
+-- Scope: table-level WRITE grant revocation only (INSERT/UPDATE/DELETE/TRUNCATE).
+--      PostgREST requires BOTH a grant AND a policy, so this closes the write path
+--      while touching NO read path. Identical minimal shape to PR 6717 and to the
+--      6-table file beside it. Policy-level cleanup and the full anon-twin sweep
+--      ride SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001, whose scope should widen
+--      from 9 tables to ALL 24 carrying an anon policy (coordinator completeness
+--      pass, 2026-08-01: the original 9 came from grepping ONE policy NAME).
+--
+-- Verification contract: re-probe AT THE ANON KEY AFTER APPLY, not at the merge.
+--      Precedent — 20260317 dropped three anon policies, left all three DELETE
+--      grants standing, and has looked complete for four months. A green migration
+--      is not a closed grant.
+-- =============================================================================
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.sd_burn_rate_snapshots FROM anon;

--- a/database/migrations/20260801_revoke_anon_writes_forecasting_tables.sql
+++ b/database/migrations/20260801_revoke_anon_writes_forecasting_tables.sql
@@ -1,5 +1,6 @@
 -- requires-chairman-apply
--- @approved-by: <pending chairman sign-off>
+-- @approved-by: codestreetlabs@gmail.com
+-- @approval-provenance: chairman SMS "Approved" 2026-08-01 11:16:35Z (packet sent 11:13:36Z), Adam d5080cf3 scribing
 -- =============================================================================
 -- Migration: revoke anon WRITE grants on the remaining 6 exposed tables
 -- Why: PR 6717 closed claude_sessions + session_coordination, but SECURITY

--- a/database/migrations/20260801_revoke_anon_writes_forecasting_tables.sql
+++ b/database/migrations/20260801_revoke_anon_writes_forecasting_tables.sql
@@ -1,0 +1,35 @@
+-- requires-chairman-apply
+-- @approved-by: <pending chairman sign-off>
+-- =============================================================================
+-- Migration: revoke anon WRITE grants on the remaining 6 exposed tables
+-- Why: PR 6717 closed claude_sessions + session_coordination, but SECURITY
+--      (coordinator/Alpha, 2026-08-01) found that was 1 of the population, not
+--      the population. Root cause: 20260123_fix_overly_permissive_rls dropped
+--      the AUTHENTICATED policy 17x and the ANON twin ZERO times — an INVERTED
+--      remediation that removed the weaker grantee everywhere and left the
+--      UNAUTHENTICATED one standing. Adam re-verified WITH THE ANON KEY
+--      (attacker-eye, writes filtered to a nonexistent id — non-destructive):
+--      anon holds an open write grant on these 6, and on three it can both READ
+--      and DELETE the execution-baseline / forecasting substrate.
+-- Exposed set (anon DELETE grant open, confirmed live 2026-08-01):
+--   sd_execution_actuals    -- WORST: DELETE + UPDATE open, 41 real rows readable
+--   sd_baseline_items       -- DELETE open, 32,064 real rows readable
+--   sd_execution_baselines  -- DELETE open, 9 real rows readable
+--   model_usage_log         -- DELETE open, anon reads 0 (RLS blocks reads; latent)
+--   sd_conflict_matrix      -- DELETE open, empty
+--   sd_session_activity     -- DELETE open, empty
+-- Scope: table-level WRITE grant revocation only (INSERT/UPDATE/DELETE/TRUNCATE)
+--      — PostgREST needs BOTH a grant AND a policy, so revoking the grant closes
+--      the write path regardless of policy shape, touching NO read path. Same
+--      minimal shape as PR 6717. Policy-level cleanup rides
+--      SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001.
+-- Caveat (honest): a 0-row DELETE returning success proves the GRANT, not that
+--      RLS would pass a destructive delete; no destructive delete was run. The
+--      revoke closes the capability either way (defense in depth).
+-- =============================================================================
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.sd_execution_actuals FROM anon;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.sd_baseline_items FROM anon;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.sd_execution_baselines FROM anon;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.model_usage_log FROM anon;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.sd_conflict_matrix FROM anon;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE ON public.sd_session_activity FROM anon;


### PR DESCRIPTION
Closes the anon **write-grant** exposure on 7 tables. Batch 1 was PR 6717 (session tables). Chairman approvals: SMS "Approved" 11:16:35Z (6 tables) and 11:45:04Z (the 7th). Both applied to prod (`MIGRATION_APPLY_PROD_PASS`).

## What was revoked

**6-table migration** (approved 11:16Z): `sd_execution_actuals`, `sd_baseline_items`, `sd_execution_baselines`, `model_usage_log`, `sd_conflict_matrix`, `sd_session_activity`.

**7th table, separate file** (approved 11:45Z): `sd_burn_rate_snapshots`. Separate rather than amended, because the 6-table file was already applied under the earlier approval — editing it would retroactively change the record of what was approved.

## Verified post-apply, attacker-eye (anon key, impossible predicate, non-destructive)

All seven now return `42501 permission denied` on both DELETE and UPDATE. Read paths untouched.

The probe **moved** across the apply (accepted → 42501) on every table, which is the control that validates it. That matters here specifically — see the retraction below.

## Root cause

`20260123_fix_overly_permissive_rls` dropped the **authenticated** policy 17× and the **anon** twin 0× — an inverted remediation that removed the weaker grantee everywhere and left the unauthenticated one standing.

The 7th table was missed for a second, distinct reason worth recording: `20260317` DID drop its anon *policy* but never the *grant*, so any review reading policy state scores it as already remediated. Policy and grant are independent gates. Not a systematic exclusion — `sd_conflict_matrix` and `sd_session_activity` were also policy-dropped by 20260317 and did make the first list. Plain enumeration slip in a list of seven.

## Severity: what is proven, and what is NOT

**Proven:** the table-level GRANT was open on all seven, and is now closed.

**Not proven, and deliberately not claimed:** that any of these were *live* write paths. With RLS enabled and no permissive policy for the verb, a statement is still *accepted* and simply affects zero rows — indistinguishable from the client from an open grant *with* a policy. This probe proves the grant, not the write.

**Unavailable to either reviewer:** live per-verb policy state. `pg_catalog` is not exposed through PostgREST, and every SQL-exec RPC referenced in this repo (`exec_readonly_sql`, `exec_sql`, `exec_raw_sql`, `execute_sql`, `fn_execute_sql_admin`, `get_policies_for_table`) is absent from the deployed schema — verified 11:58Z.

**Current best reading** (coordinator, derived from migration source): most of these grants are dormant — landmines rather than open holes. That reading is explicitly non-authoritative, because this same sweep proved source diverges from live: `model_usage_log` carries a never-dropped `FOR ALL` anon policy in source yet blocks anon reads in production.

**Why revoke regardless:** the action is correct under both readings. If a policy is live, this closes a hole. If the grant is dormant, this removes a landmine that would arm silently the moment any future policy is added. Revoking a grant nothing legitimately uses costs nothing.

## Retraction

An earlier revision of the 6-table header called `sd_execution_actuals` "DELETE + UPDATE open." **The UPDATE half was never evidenced and is retracted.** The probe behind it used an empty payload (`{}`), which PostgREST short-circuits without exercising permissions — it returned identically before and after the fix, which is the tell. Re-probed with a real column and value: anon UPDATE returns 42501. Both verbs are genuinely closed. The retraction is about what was *proven*, not about the outcome.

Method rule earned here: **a probe whose result does not change across a known state change is measuring nothing.** Probe the verb you fear, with a payload that could actually land.

## Follow-on, not in this PR

`SD-LEO-INFRA-DEFAULT-ANON-AUTHENTICATED-001` carries the read posture and the inverted-remediation audit. Its scope should widen from 9 tables to **all 24** carrying an anon policy — the original 9 came from grepping a single policy *name*. One item needs a product decision rather than a sweep: `mental_model_applications` holds explicit anon SELECT + INSERT + UPDATE policies over 959 rows, which reads deliberate for a client app but is the one place anon can genuinely write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BgbcVquBxG3x8xwxeLMKAS
