### PR TITLE
fix(SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-C): close the git walk-up that strands orphan worktrees

### DIFF
--- a/lib/coordinator/charter-audit-detectors.mjs
+++ b/lib/coordinator/charter-audit-detectors.mjs
@@ -335,6 +335,75 @@ export function detectProgressStall({ liveSessions = [], sds = [], nowMs, thresh
 }
 
 /**
+ * DUTY-8b STRANDED WORKER (SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-C, FR-3).
+ *
+ * A worker whose worktree is missing, or is a directory that is not a worktree root,
+ * cannot attach and cannot clear the directory through the documented removal tool. Its
+ * progress flatlines WHILE ITS HEARTBEAT STAYS GREEN — which is exactly why DUTY-8 above
+ * cannot see it. DUTY-8 reads liveness, and a stranded worker is alive. The two detectors
+ * are deliberately SEPARATE rather than one gaining a branch: they key on different
+ * evidence, and merging them would put a filesystem probe inside a predicate whose
+ * purity is load-bearing.
+ *
+ * A GUARD FAILS CLOSED; A DETECTOR FAILS QUIET. This is the opposite of the reflex the
+ * sibling SDs in this family trained, and getting it backwards is the expensive mistake
+ * here: detectProgressStall's own suite carries ELEVEN violation:false assertions and
+ * ZERO worktree_path references, so reading an ABSENT path as "missing, therefore
+ * stranded" would make all eleven start firing. AN ABSENT FIELD MEANS NOT MEASURED.
+ * Absent → skip, silently, always.
+ *
+ * The probe is INJECTED and never called raw. A bare fs call here would bypass every
+ * pure fixture and silently convert them into vacuous passes — the right answer for the
+ * wrong reason, which is indistinguishable from the wrong answer next time the code moves.
+ *
+ * @param {object} p
+ * @param {Array<object>} p.liveSessions - {session_id, sd_key, worktree_path, heartbeat_at, expected_silence_until}
+ * @param {number} p.nowMs
+ * @param {number} [p.freshMs=300000] - heartbeat freshness window; a stranded worker must be ALIVE to qualify
+ * @param {(until:any, now:number)=>boolean} [p.isWithinArmedSilence] - canonical armed-silence check
+ * @param {(path:string)=>{exists:boolean, isWorktreeRoot:boolean}} p.probeWorktree - INJECTED fs probe
+ * @returns {{violation:boolean, strandedCount:number, samples:Array, detail:string, remediation:(string|null)}}
+ */
+export function detectStrandedWorker({ liveSessions = [], nowMs, freshMs, isWithinArmedSilence, probeWorktree } = {}) {
+  if (typeof probeWorktree !== 'function' || !Array.isArray(liveSessions) || !Number.isFinite(nowMs)) {
+    return { violation: false, strandedCount: 0, samples: [], detail: 'stranded-worker not evaluable (fail-open)', remediation: null };
+  }
+  const fresh = Number.isFinite(freshMs) ? freshMs : 5 * 60 * 1000;
+  const samples = [];
+  for (const s of liveSessions) {
+    if (!s || !s.sd_key) continue;                                   // no live claim → not this detector's class
+    // THE LOAD-BEARING GUARD. Absent means NOT MEASURED, never "missing". Deleting this
+    // line makes every path-less fixture — i.e. every existing progress-stall fixture —
+    // report as stranded.
+    if (typeof s.worktree_path !== 'string' || s.worktree_path.trim() === '') continue;
+    const hb = s.heartbeat_at ? new Date(s.heartbeat_at).getTime() : NaN;
+    if (!Number.isFinite(hb) || (nowMs - hb) >= fresh) continue;     // must be ACTIVELY heartbeating — that IS the trap
+    if (isWithinArmedSilence && isWithinArmedSilence(s.expected_silence_until, nowMs)) continue; // legit parked
+    let probe;
+    try { probe = probeWorktree(s.worktree_path); }
+    catch { continue; }                                              // a throwing probe is unmeasured, not stranded
+    if (!probe || typeof probe !== 'object') continue;
+    let kind = null;
+    if (probe.exists === false) kind = 'missing';
+    else if (probe.exists === true && probe.isWorktreeRoot === false) kind = 'not_a_worktree';
+    if (!kind) continue;
+    samples.push({ sd_key: s.sd_key, session_id: s.session_id ?? null, worktree_path: s.worktree_path, kind });
+  }
+  const matched = samples.length > 0;
+  return {
+    violation: matched,
+    strandedCount: samples.length,
+    samples: samples.slice(0, 10),
+    detail: matched
+      ? `${samples.length} worker(s) heartbeat-alive but STRANDED (worktree missing or not a worktree root; cannot attach, cannot self-clear) — ${samples.slice(0, 3).map((x) => `${x.sd_key}(${x.kind})`).join(', ')}`
+      : 'none (live claims have attachable worktrees, or worktree_path was not measured)',
+    remediation: matched
+      ? 'ACTION: the named worker(s) hold a live claim on a worktree they cannot attach to — the green heartbeat is why DUTY-8 misses this. Clear the directory (worktree:remove now succeeds on the .git-less shape since SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-C) and re-attach via sd-start, or release the claim so the belt can re-route it'
+      : null,
+  };
+}
+
+/**
  * DUTY-3b (SD-REFILL-00R7REXL): in_progress SDs that are UNCLAIMED with no live worker — true orphans.
  * Refines SD-LEO-INFRA-COORDINATOR-CHARTER-SELF-AUDIT-001: DUTY-2 only inspects CLAIMED sessions,
  * DUTY-3/5/6 the draft/ready belt, DUTY-4 belt deps, DUTY-7/9 drafts, DUTY-8 CLAIMED-frozen — so an

--- a/lib/worktree-reapability.js
+++ b/lib/worktree-reapability.js
@@ -120,6 +120,33 @@ export function collectDirtyStatus(wtPath, { gitRunner = runGit } = {}) {
       if (p.startsWith('"') && p.endsWith('"')) p = p.slice(1, -1); // git quotes special chars
       if (p) modified.push(p);
     }
+    // FR-1 (SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-C) — THE WALK-UP.
+    //
+    // `git status` run with cwd=<a .git-less directory> does not fail: discovery CLIMBS
+    // OUT and answers about an ANCESTOR (.worktrees/ is gitignored, so the parent's dirt
+    // is reported as this tree's — observed at 758 files, byte-identical to the repo
+    // root). The probe SUCCEEDS WITH SOMEBODY ELSE'S ANSWER, so `unknown` stays false and
+    // isReapable returns dirty_tree at its FIRST check — which is exactly why -B's
+    // resolveWorktreeRoot guard, consulted only inside the `if (dirty.unknown || ...)`
+    // branch below, is structurally incapable of seeing this input.
+    //
+    // LAZY BY DESIGN: ownership is asked ONLY when the answer would BLOCK reaping. A
+    // clean status is verdict-identical whether or not this tree owns its git state, so
+    // probing there buys nothing and would put a rev-parse on every call site — the
+    // unconditional hoist -B tried and abandoned when it broke injected-runner fixtures.
+    //
+    // `unknown` stays FALSE on the disproved path: git ANSWERED, it just answered about
+    // somebody else. Setting unknown here would route the tree into UNVERIFIABLE below
+    // and re-strand it one layer down — the same shape this SD family exists to unstick.
+    if (dirty > 0) {
+      if (!resolveWorktreeRoot(wtPath, gitRunner).ownsGitState) {
+        return { dirtyCount: 0, untracked: [], modified: [], exists: true, unknown: false, ownsGitState: false };
+      }
+      return { dirtyCount: dirty, untracked, modified, exists: true, unknown: false, ownsGitState: true };
+    }
+    // Clean: ownership deliberately NOT measured, so the field is absent rather than
+    // guessed. Absent means NOT MEASURED — the same doctrine the stranded-worker
+    // detector applies to an absent worktree_path.
     return { dirtyCount: dirty, untracked, modified, exists: true, unknown: false };
   } catch { return { dirtyCount: 0, untracked: [], modified: [], exists: true, unknown: true }; }
 }
@@ -142,16 +169,34 @@ export function countUnpushedCommits(wtPath, opts = {}) {
  * unpushed — a branch pushed to its own remote with an open PR reports non-zero. The
  * error direction is OVER-reporting, and non-zero means NOT reapable, so it
  * OVER-PROTECTS. Making it "accurate" would REMOVE protection from every branch with an
- * open PR. The rename belongs to sibling -C; the semantics deliberately do not change.
+ * open PR. The semantics deliberately do not change.
  *
- * @returns {{count: number, unknown: boolean}}
+ * THAT FREEZE GOVERNS *WHAT IS MEASURED*, NOT *WHICH REPO IS MEASURED* — the two are
+ * separable and conflating them is what let the walk-up survive sibling -B. -C changes
+ * only the latter: the count is still "commits not patch-present in upstream", it is
+ * just no longer allowed to be an ANCESTOR's count. Nothing about the over-reporting,
+ * and therefore nothing about the over-protection, is touched.
+ *
+ * @returns {{count: number, unknown: boolean, ownsGitState?: boolean}}
  */
 export function countUnpushedCommitsResult(wtPath, { gitRunner = runGit, upstream = 'origin/main' } = {}) {
   if (!wtPath || !fs.existsSync(wtPath)) return { count: 0, unknown: false };
   try {
     const res = gitRunner(['cherry', upstream, 'HEAD'], wtPath);
     if (res.code !== 0) return { count: 0, unknown: true };
-    return { count: (res.stdout || '').split('\n').filter((l) => l.startsWith('+')).length, unknown: false };
+    const count = (res.stdout || '').split('\n').filter((l) => l.startsWith('+')).length;
+    // FR-2 — the SECOND blocking input, and closing only the first is not a partial fix
+    // but a broken one: isReapable returns UNPUSHED on count>0, so a tree fixed only in
+    // collectDirtyStatus RE-STRANDS the moment the ancestor is ahead of origin/main,
+    // which is the normal state of a busy main. Reproduced from an orphan at 42 commits
+    // and again at 2. Same lazy rule, same reasoning as FR-1 above.
+    if (count > 0) {
+      if (!resolveWorktreeRoot(wtPath, gitRunner).ownsGitState) {
+        return { count: 0, unknown: false, ownsGitState: false };
+      }
+      return { count, unknown: false, ownsGitState: true };
+    }
+    return { count, unknown: false };
   } catch { return { count: 0, unknown: true }; }
 }
 

--- a/tests/unit/stranded-worker-detector.test.js
+++ b/tests/unit/stranded-worker-detector.test.js
@@ -1,0 +1,135 @@
+/**
+ * SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-C FR-3 — detectStrandedWorker.
+ *
+ * A GUARD FAILS CLOSED; A DETECTOR FAILS QUIET. The sibling SDs in this family closed
+ * three guards fail-closed, and carrying that reflex here is the expensive mistake:
+ * detectProgressStall's own suite has eleven violation:false assertions and zero
+ * worktree_path references, so reading an ABSENT path as "missing, therefore stranded"
+ * would make all eleven start firing. The absent-path case is therefore tested FIRST and
+ * proven load-bearing by deleting the guard.
+ */
+import { describe, it, expect } from 'vitest';
+import { detectStrandedWorker } from '../../lib/coordinator/charter-audit-detectors.mjs';
+
+const NOW = Date.UTC(2026, 7, 1, 12, 0, 0);
+const fresh = (minsAgo = 1) => new Date(NOW - minsAgo * 60_000).toISOString();
+
+/** Injected probe. Never a raw fs call — a bare fs check would bypass every fixture here. */
+const probeFrom = (map) => (p) => {
+  const calls = probeFrom.calls;
+  if (calls) calls.push(p);
+  return map[p] ?? { exists: true, isWorktreeRoot: true };
+};
+
+describe('detectStrandedWorker — fires on strandings', () => {
+  it('a MISSING worktree on a live, heartbeating claim is a finding', () => {
+    const r = detectStrandedWorker({
+      liveSessions: [{ session_id: 's1', sd_key: 'SD-A', worktree_path: '/wt/gone', heartbeat_at: fresh() }],
+      nowMs: NOW,
+      probeWorktree: probeFrom({ '/wt/gone': { exists: false, isWorktreeRoot: false } }),
+    });
+    expect(r.violation).toBe(true);
+    expect(r.strandedCount).toBe(1);
+    expect(r.samples[0]).toMatchObject({ sd_key: 'SD-A', kind: 'missing' });
+    expect(r.remediation).toBeTruthy();
+  });
+
+  it('a directory that EXISTS but is not a worktree root is a DISTINCT finding', () => {
+    const r = detectStrandedWorker({
+      liveSessions: [{ session_id: 's2', sd_key: 'SD-B', worktree_path: '/wt/plain', heartbeat_at: fresh() }],
+      nowMs: NOW,
+      probeWorktree: probeFrom({ '/wt/plain': { exists: true, isWorktreeRoot: false } }),
+    });
+    expect(r.violation).toBe(true);
+    expect(r.samples[0].kind).toBe('not_a_worktree');
+    // Distinguishable from the missing case — the two need different remediation.
+    expect(r.samples[0].kind).not.toBe('missing');
+  });
+
+  it('a HEALTHY worktree on a live claim is not a finding', () => {
+    const r = detectStrandedWorker({
+      liveSessions: [{ session_id: 's3', sd_key: 'SD-C', worktree_path: '/wt/ok', heartbeat_at: fresh() }],
+      nowMs: NOW,
+      probeWorktree: probeFrom({ '/wt/ok': { exists: true, isWorktreeRoot: true } }),
+    });
+    expect(r.violation).toBe(false);
+    expect(r.strandedCount).toBe(0);
+  });
+
+  it('the green heartbeat is the whole point — a stranded worker is ALIVE, not stale', () => {
+    const sessions = [{ session_id: 's4', sd_key: 'SD-D', worktree_path: '/wt/gone', heartbeat_at: fresh(1) }];
+    const probe = probeFrom({ '/wt/gone': { exists: false, isWorktreeRoot: false } });
+    expect(detectStrandedWorker({ liveSessions: sessions, nowMs: NOW, probeWorktree: probe }).violation).toBe(true);
+    // A worker that stopped heartbeating is a different class (dead/reaped), not stranded.
+    const stale = [{ ...sessions[0], heartbeat_at: fresh(60) }];
+    expect(detectStrandedWorker({ liveSessions: stale, nowMs: NOW, probeWorktree: probe }).violation).toBe(false);
+  });
+});
+
+describe('detectStrandedWorker — stays QUIET on unmeasured data', () => {
+  it('NO worktree_path produces NO finding, and the probe is never even called', () => {
+    const calls = [];
+    probeFrom.calls = calls;
+    const r = detectStrandedWorker({
+      liveSessions: [
+        { session_id: 's5', sd_key: 'SD-E', heartbeat_at: fresh() },            // field absent
+        { session_id: 's6', sd_key: 'SD-F', worktree_path: '', heartbeat_at: fresh() },   // empty
+        { session_id: 's7', sd_key: 'SD-G', worktree_path: '   ', heartbeat_at: fresh() }, // whitespace
+      ],
+      nowMs: NOW,
+      probeWorktree: probeFrom({}),
+    });
+    probeFrom.calls = null;
+    expect(r.violation).toBe(false);
+    expect(r.strandedCount).toBe(0);
+    // "No finding" must be distinguishable from "never ran" — assert the probe was skipped
+    // deliberately rather than the detector having quietly done nothing at all.
+    expect(calls).toHaveLength(0);
+  });
+
+  it('the probe IS called when a path is present — so quietness above is a decision, not inaction', () => {
+    const calls = [];
+    probeFrom.calls = calls;
+    detectStrandedWorker({
+      liveSessions: [{ session_id: 's8', sd_key: 'SD-H', worktree_path: '/wt/ok', heartbeat_at: fresh() }],
+      nowMs: NOW,
+      probeWorktree: probeFrom({ '/wt/ok': { exists: true, isWorktreeRoot: true } }),
+    });
+    probeFrom.calls = null;
+    expect(calls).toEqual(['/wt/ok']);
+  });
+
+  it('a session with no claim is not this detector class', () => {
+    const r = detectStrandedWorker({
+      liveSessions: [{ session_id: 's9', worktree_path: '/wt/gone', heartbeat_at: fresh() }],
+      nowMs: NOW,
+      probeWorktree: probeFrom({ '/wt/gone': { exists: false, isWorktreeRoot: false } }),
+    });
+    expect(r.violation).toBe(false);
+  });
+
+  it('fails OPEN, never closed, when it cannot evaluate at all', () => {
+    // No probe injected, malformed sessions, no clock — a detector that cannot measure
+    // reports nothing. It must never manufacture a violation out of missing inputs.
+    expect(detectStrandedWorker({}).violation).toBe(false);
+    expect(detectStrandedWorker({ liveSessions: null, nowMs: NOW, probeWorktree: () => ({}) }).violation).toBe(false);
+    expect(detectStrandedWorker({ liveSessions: [], nowMs: NaN, probeWorktree: () => ({}) }).violation).toBe(false);
+    // A THROWING probe is unmeasured, not stranded.
+    const thrower = () => { throw new Error('probe exploded'); };
+    expect(detectStrandedWorker({
+      liveSessions: [{ session_id: 'sA', sd_key: 'SD-I', worktree_path: '/wt/x', heartbeat_at: fresh() }],
+      nowMs: NOW,
+      probeWorktree: thrower,
+    }).violation).toBe(false);
+  });
+
+  it('an armed-silence worker is parked, not stranded', () => {
+    const r = detectStrandedWorker({
+      liveSessions: [{ session_id: 'sB', sd_key: 'SD-J', worktree_path: '/wt/gone', heartbeat_at: fresh(), expected_silence_until: 'later' }],
+      nowMs: NOW,
+      isWithinArmedSilence: () => true,
+      probeWorktree: probeFrom({ '/wt/gone': { exists: false, isWorktreeRoot: false } }),
+    });
+    expect(r.violation).toBe(false);
+  });
+});

--- a/tests/unit/worktree-quota-orphan-classify.test.js
+++ b/tests/unit/worktree-quota-orphan-classify.test.js
@@ -26,6 +26,16 @@ function mockGit(args, cwd) {
   if (args[0] === 'cherry') {
     return { code: 0, stdout: c.includes('unpushed-orphan') ? '+ abc123 wip\n' : '', stderr: '' };
   }
+  // Since SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-C, a BLOCKING dirty/cherry answer
+  // is only honoured once the directory proves it owns its git state. This mock already
+  // modelled that distinction through the .git marker the fixtures below create — it now
+  // expresses the SAME distinction through the channel the code actually reads. A dir
+  // with no .git answers with an ANCESTOR path, which is precisely what real git does
+  // when discovery walks up out of a .git-less directory.
+  if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') {
+    const ownsGit = fs.existsSync(path.join(cwd, '.git'));
+    return { code: 0, stdout: ownsGit ? String(cwd) : path.join(os.tmpdir(), 'some-ancestor-repo'), stderr: '' };
+  }
   return { code: 0, stdout: '', stderr: '' };
 }
 

--- a/tests/unit/worktree-reapability-modified.test.js
+++ b/tests/unit/worktree-reapability-modified.test.js
@@ -13,7 +13,17 @@ import os from 'node:os';
 import path from 'node:path';
 import { collectDirtyStatus } from '../../lib/worktree-reapability.js';
 
-const git = (stdout, code = 0) => () => ({ code, stdout, stderr: '' });
+// Was args-BLIND (returned the same stdout for every call). Since -C, collectDirtyStatus
+// asserts ownership before letting a dirty answer through, so an args-blind runner hands
+// its porcelain output back as the answer to `rev-parse --show-toplevel` and the tree
+// reads as not-its-own. It now answers rev-parse with the cwd it was handed — these
+// fixtures all describe a REAL worktree reporting its OWN dirt. Only what the fixture
+// ANSWERS changed; every assertion below still claims exactly what it claimed before.
+const git = (stdout, code = 0) => (args, cwd) => (
+  args[0] === 'rev-parse' && args[1] === '--show-toplevel'
+    ? { code: 0, stdout: String(cwd), stderr: '' }
+    : { code, stdout, stderr: '' }
+);
 
 describe('collectDirtyStatus.modified (FR-1)', () => {
   let wt;

--- a/tests/unit/worktree-reapability.test.js
+++ b/tests/unit/worktree-reapability.test.js
@@ -20,14 +20,28 @@ import {
 
 // Mock git runner: (args, cwd) -> { stdout, stderr, code }. Simulates a
 // dirty/clean working tree and N unpushed commits without touching real git.
-function mockGit({ dirty = false, unpushed = 0, statusCode = 0, cherryCode = 0 } = {}) {
-  return (args) => {
+function mockGit({ dirty = false, unpushed = 0, statusCode = 0, cherryCode = 0, ownsGitState = true } = {}) {
+  return (args, cwd) => {
     if (args[0] === 'status') {
       return { code: statusCode, stdout: dirty ? ' M lib/file.js\n?? new.txt\n' : '', stderr: '' };
     }
     if (args[0] === 'cherry') {
       const lines = Array.from({ length: unpushed }, (_, i) => `+ ${i}abc123 commit ${i}`).join('\n');
       return { code: cherryCode, stdout: lines, stderr: '' };
+    }
+    // A mock standing in for a REAL worktree must be able to SAY it is one. Since -C the
+    // helpers assert ownership before letting a BLOCKING answer through, and a runner
+    // that cannot answer rev-parse is indistinguishable from a directory that owns no
+    // git state. Note what changed here and what did not: the fixture now ANSWERS a
+    // question it previously fell through on — no existing assertion was weakened.
+    // ownsGitState:false simulates THE WALK-UP by naming a DIFFERENT toplevel, which is
+    // what git really does from a .git-less directory nested in a repo.
+    if (args[0] === 'rev-parse' && args[1] === '--show-toplevel') {
+      return {
+        code: 0,
+        stdout: ownsGitState ? String(cwd) : path.join(os.tmpdir(), 'some-ancestor-repo'),
+        stderr: '',
+      };
     }
     return { code: 0, stdout: '', stderr: '' };
   };

--- a/tests/unit/worktree-reaper/orphan-walkup-attribution.test.js
+++ b/tests/unit/worktree-reaper/orphan-walkup-attribution.test.js
@@ -1,0 +1,206 @@
+/**
+ * SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-C — the walk-up, closed at BOTH inputs.
+ *
+ * THE DEFECT. `git status` run with cwd=<a .git-less directory nested in a repo> does not
+ * fail — discovery CLIMBS OUT and answers about the ANCESTOR. The probe SUCCEEDS WITH
+ * SOMEBODY ELSE'S ANSWER, so `unknown` stays false, so isReapable returns dirty_tree at
+ * its first check and never reaches the `if (dirty.unknown || ahead.unknown)` branch where
+ * sibling -B consults resolveWorktreeRoot. -B's guard cannot see this input at all.
+ *
+ * WHY THE FIRST BLOCK OF TESTS USES REAL GIT. A mock can only reproduce a walk-up that
+ * someone already understood well enough to write down; these fixtures make git itself
+ * perform the walk-up, so the test would have caught the bug without anyone knowing the
+ * mechanism. The mock-based blocks that follow then pin the properties real git cannot
+ * be asked about cheaply (call counts, thrown runners).
+ *
+ * EVERY ASSERTION IS PAIRED. An orphan reporting 0 in isolation is equally consistent
+ * with a helper that returns 0 for everything, so each orphan assertion is made in the
+ * same test as the owning directory's non-zero count.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import {
+  collectDirtyStatus,
+  countUnpushedCommitsResult,
+  countUnpushedCommits,
+  isReapable,
+  REAP_REASONS,
+} from '../../../lib/worktree-reapability.js';
+
+const git = (cwd, ...args) => execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+
+describe('the walk-up, reproduced with REAL git (FR-1, FR-2, FR-3)', () => {
+  let repoRoot;
+  let orphan;
+
+  beforeAll(() => {
+    repoRoot = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'walkup-repo-')));
+    git(repoRoot, 'init', '-q');
+    git(repoRoot, 'config', 'user.email', 'test@example.invalid');
+    git(repoRoot, 'config', 'user.name', 'Test');
+    git(repoRoot, 'config', 'commit.gpgsign', 'false');
+
+    fs.writeFileSync(path.join(repoRoot, 'base.txt'), 'base\n');
+    git(repoRoot, 'add', '-A');
+    git(repoRoot, 'commit', '-q', '-m', 'base');
+
+    // A SECOND commit so the parent is DELIBERATELY AHEAD of the ref we use as upstream.
+    // At parity the buggy and the fixed code BOTH return 0 — which is exactly how this
+    // input got missed when FR-2 was originally scoped rename-only.
+    fs.writeFileSync(path.join(repoRoot, 'ahead.txt'), 'ahead\n');
+    git(repoRoot, 'add', '-A');
+    git(repoRoot, 'commit', '-q', '-m', 'ahead');
+
+    // Make the PARENT genuinely dirty. With a clean parent the buggy and fixed code agree,
+    // so a dirty parent is required for the FR-1 assertion to mean anything.
+    fs.writeFileSync(path.join(repoRoot, 'base.txt'), 'base modified\n');
+    fs.writeFileSync(path.join(repoRoot, 'untracked.txt'), 'new\n');
+
+    // THE STRANDED SHAPE: a directory that exists, holds no .git, and is not a registered
+    // worktree — the same shape as the three real stranded dirs found on disk.
+    orphan = path.join(repoRoot, 'orphan-dir');
+    fs.mkdirSync(orphan);
+  });
+
+  afterAll(() => { try { fs.rmSync(repoRoot, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+  it('FR-1: does not attribute the ancestor dirt to the orphan, while the root keeps its own', () => {
+    const rootStatus = collectDirtyStatus(repoRoot);
+    const orphanStatus = collectDirtyStatus(orphan);
+
+    // The root owns its git state and must still report its OWN dirt — the fix must not
+    // blind the guard to real dirt.
+    expect(rootStatus.dirtyCount).toBeGreaterThan(0);
+    expect(rootStatus.ownsGitState).toBe(true);
+    expect(rootStatus.untracked).toContain('untracked.txt');
+
+    // BEFORE the fix these two were byte-identical. That equality IS the bug.
+    expect(orphanStatus.dirtyCount).toBe(0);
+    expect(orphanStatus.ownsGitState).toBe(false);
+    expect(orphanStatus.untracked).toEqual([]);
+    expect(orphanStatus.modified).toEqual([]);
+    expect(orphanStatus.dirtyCount).not.toBe(rootStatus.dirtyCount);
+
+    // DISPROVED-OWNERSHIP IS NOT COULD-NOT-LOOK. git answered; it answered about somebody
+    // else. Setting unknown here would route the tree into UNVERIFIABLE and re-strand it.
+    expect(orphanStatus.unknown).toBe(false);
+    expect(orphanStatus.exists).toBe(true);
+  });
+
+  it('FR-2: does not attribute the ancestor history to the orphan, with the parent AHEAD', () => {
+    const rootAhead = countUnpushedCommitsResult(repoRoot, { upstream: 'HEAD~1' });
+    const orphanAhead = countUnpushedCommitsResult(orphan, { upstream: 'HEAD~1' });
+
+    // The parent really is ahead — without this the assertion below is vacuous.
+    expect(rootAhead.count).toBeGreaterThan(0);
+    expect(rootAhead.ownsGitState).toBe(true);
+
+    expect(orphanAhead.count).toBe(0);
+    expect(orphanAhead.ownsGitState).toBe(false);
+    expect(orphanAhead.unknown).toBe(false);
+
+    // The plain-number wrapper delegates, so it inherits the fix with no second edit —
+    // asserted rather than assumed, because worktree-reaper.mjs:1324 calls the WRAPPER.
+    expect(countUnpushedCommits(orphan, { upstream: 'HEAD~1' })).toBe(0);
+    expect(countUnpushedCommits(repoRoot, { upstream: 'HEAD~1' })).toBeGreaterThan(0);
+  });
+
+  it('FR-3: isReapable frees the orphan at the level where the stranding actually manifests', () => {
+    // Consumers that depend on this verdict, enumerated so the coverage claim is auditable:
+    //   lib/worktree-manager.js:1498, lib/worktree-quota.js:266,
+    //   scripts/cleanup-pending-sweep.mjs:245, scripts/safe-worktree-remove.mjs (guarded default).
+    const orphanVerdict = isReapable(orphan, { liveOwner: false, upstream: 'HEAD~1' });
+    expect(orphanVerdict.reapable).toBe(true);
+    expect(orphanVerdict.reason).toBe(REAP_REASONS.ORPHAN_CLEAN);
+
+    // OPPOSITE POLARITY: the genuinely dirty owning tree is still protected. Reached via
+    // the dirty_tree early-out, i.e. the exact branch the orphan no longer trips.
+    const rootVerdict = isReapable(repoRoot, { liveOwner: false, upstream: 'HEAD~1' });
+    expect(rootVerdict.reapable).toBe(false);
+    expect(rootVerdict.reason).toBe(REAP_REASONS.DIRTY_TREE);
+
+    // And a live owner still outranks everything.
+    expect(isReapable(orphan, { liveOwner: true }).reason).toBe(REAP_REASONS.LIVE_OWNER);
+  });
+});
+
+describe('the laziness invariant — the property that bounds the blast radius', () => {
+  let wt;
+  beforeAll(() => { wt = fs.mkdtempSync(path.join(os.tmpdir(), 'walkup-lazy-')); });
+  afterAll(() => { try { fs.rmSync(wt, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+  /** Counting runner: records every subcommand it is asked for. */
+  function countingGit({ dirty = false, cherry = 0, owns = true } = {}) {
+    const calls = [];
+    const runner = (args, cwd) => {
+      calls.push(args[0] === 'rev-parse' ? 'rev-parse' : args[0]);
+      if (args[0] === 'status') return { code: 0, stdout: dirty ? ' M a.js\n?? b.js\n' : '', stderr: '' };
+      if (args[0] === 'cherry') {
+        return { code: 0, stdout: Array.from({ length: cherry }, (_, i) => `+ ${i}aaa msg`).join('\n'), stderr: '' };
+      }
+      if (args[0] === 'rev-parse') {
+        return { code: 0, stdout: owns ? String(cwd) : path.join(os.tmpdir(), 'elsewhere'), stderr: '' };
+      }
+      return { code: 0, stdout: '', stderr: '' };
+    };
+    runner.calls = calls;
+    return runner;
+  }
+
+  it('a CLEAN status asks nobody who owns the tree', () => {
+    const g = countingGit({ dirty: false });
+    const s = collectDirtyStatus(wt, { gitRunner: g });
+    expect(s.dirtyCount).toBe(0);
+    // The whole point: a clean answer is verdict-identical either way, so the probe that
+    // broke -B's unconditional hoist never fires here.
+    expect(g.calls.filter((c) => c === 'rev-parse')).toHaveLength(0);
+    // Not measured, so not claimed.
+    expect(s.ownsGitState).toBeUndefined();
+  });
+
+  it('a ZERO cherry count asks nobody who owns the tree', () => {
+    const g = countingGit({ cherry: 0 });
+    const r = countUnpushedCommitsResult(wt, { gitRunner: g });
+    expect(r.count).toBe(0);
+    expect(g.calls.filter((c) => c === 'rev-parse')).toHaveLength(0);
+    expect(r.ownsGitState).toBeUndefined();
+  });
+
+  it('a BLOCKING answer asks exactly once, on each helper', () => {
+    const gd = countingGit({ dirty: true });
+    collectDirtyStatus(wt, { gitRunner: gd });
+    expect(gd.calls.filter((c) => c === 'rev-parse')).toHaveLength(1);
+
+    const gc = countingGit({ cherry: 3 });
+    countUnpushedCommitsResult(wt, { gitRunner: gc });
+    expect(gc.calls.filter((c) => c === 'rev-parse')).toHaveLength(1);
+  });
+
+  it('OPPOSITE POLARITY: an owning tree keeps its own blocking answer', () => {
+    const s = collectDirtyStatus(wt, { gitRunner: countingGit({ dirty: true, owns: true }) });
+    expect(s.dirtyCount).toBe(2);
+    expect(s.ownsGitState).toBe(true);
+    expect(s.modified).toContain('a.js');
+
+    const r = countUnpushedCommitsResult(wt, { gitRunner: countingGit({ cherry: 3, owns: true }) });
+    expect(r.count).toBe(3);
+    expect(r.ownsGitState).toBe(true);
+  });
+
+  it('a THROWN ownership probe fails CLOSED — could-not-tell is not permission to delete', () => {
+    // resolveWorktreeRoot claims ownership when the probe throws, which routes an
+    // unanswerable case back into "keep the blocking answer". For a GUARD that is the
+    // right direction: if we cannot tell whose dirt it is, do not license deletion.
+    const throwing = (args, cwd) => {
+      if (args[0] === 'status') return { code: 0, stdout: ' M a.js\n', stderr: '' };
+      if (args[0] === 'rev-parse') throw new Error('probe exploded');
+      return { code: 0, stdout: '', stderr: '' };
+    };
+    const s = collectDirtyStatus(wt, { gitRunner: throwing });
+    expect(s.dirtyCount).toBe(1);
+    expect(s.ownsGitState).toBe(true);
+  });
+});

--- a/tests/unit/worktree-reaper/orphan-walkup-attribution.test.js
+++ b/tests/unit/worktree-reaper/orphan-walkup-attribution.test.js
@@ -194,7 +194,7 @@ describe('the laziness invariant — the property that bounds the blast radius',
     // resolveWorktreeRoot claims ownership when the probe throws, which routes an
     // unanswerable case back into "keep the blocking answer". For a GUARD that is the
     // right direction: if we cannot tell whose dirt it is, do not license deletion.
-    const throwing = (args, cwd) => {
+    const throwing = (args) => {
       if (args[0] === 'status') return { code: 0, stdout: ' M a.js\n', stderr: '' };
       if (args[0] === 'rev-parse') throw new Error('probe exploded');
       return { code: 0, stdout: '', stderr: '' };


### PR DESCRIPTION
## The defect, in one sentence

`git status` run with `cwd=<a .git-less directory nested in a repo>` **does not fail** — discovery climbs out and answers about the **ancestor**. The probe *succeeds with somebody else's answer*, so `unknown` stays false, so `isReapable` returns `dirty_tree` at its first check (`lib/worktree-reapability.js:178`) and never reaches the `if (dirty.unknown || ahead.unknown)` branch at `:198` where sibling **-B** consults `resolveWorktreeRoot`. **-B's guard is structurally incapable of seeing this input** — which is why the stranding survived it.

Observed live: three real stranded dirs reporting `dirtyCount` 758, byte-identical to the repo root.

## Both blocking inputs, not one

`isReapable` returns `UNPUSHED` on `count>0` (`:181`), so a tree fixed only in `collectDirtyStatus` **re-strands** the moment the ancestor is ahead of `origin/main` — the normal state of a busy main. Reproduced from an orphan at 42 commits, and again at 2.

## The design: a *lazy* ownership assertion

Ownership is asserted **only when the git answer would BLOCK reaping** (`dirtyCount>0`, or cherry `count>0`).

- A clean answer is verdict-identical either way, so probing there buys nothing and would put a `rev-parse` on every call site — the unconditional hoist **-B tried and abandoned**.
- `unknown` stays **false** on the disproved path: git *answered*, it just answered about somebody else. Setting it would route the tree into `UNVERIFIABLE` and re-strand it one layer down.
- `git cherry`'s over-reporting is **untouched**. That freeze governs *what is measured*; this PR changes only *which repo is measured*. The two are separable, and conflating them is what let the walk-up survive.

## End-to-end proof — `worktree:remove`, DEFAULT guarded mode, no `--force`

```
BEFORE  [reapability] {"decision":"skip","reason":"dirty_tree",...}
        ⏭️  Skipped (dirty_tree) — owned by a live session or has uncommitted/unpushed work.
        >> directory still on disk: YES (STRANDED)      ← and it exits 0, which is why automation never noticed

AFTER   ✓ Removed orphan worktree dir (junction-safe via safeRecursiveRm + pruned)
        >> directory still on disk: NO (cleared)
```

## The detector: a guard fails CLOSED, a detector fails QUIET

`detectStrandedWorker` is a **separate** export, not a branch inside `detectProgressStall`. DUTY-8 reads liveness, and a stranded worker is *alive* with a green heartbeat — that is exactly why it is invisible there.

`progress-stall-detector.test.js` carries **11** `violation:false` assertions and **zero** `worktree_path` references, so reading an absent path as "missing, therefore stranded" would make all eleven fire. **An absent field means NOT MEASURED.** That file is untouched and its 11 assertions pass byte-unmodified.

## Verification

**Per-site mutation, each edit confirmed applied by byte-delta first** (an unapplied mutation is indistinguishable from a surviving one — two mutants have already "survived" that way in this family):

| Site | Applied | Killed | Red attributable to that site |
|---|---|---|---|
| FR-1 `collectDirtyStatus` assertion | +9 bytes | ✅ 5 red | *FR-1: does not attribute the ancestor dirt to the orphan* |
| FR-2 `countUnpushedCommitsResult` assertion | +9 bytes | ✅ 4 red | *FR-2: does not attribute the ancestor history, parent AHEAD* |
| FR-3 detector absent-field guard | −63 bytes | ✅ 1 red | *NO worktree_path → NO finding, probe never called* |

My **first mutation harness reported both sites SURVIVED** — because `execFileSync('npx', …)` cannot run a `.cmd` shim under `shell:false`, so it threw, returned empty output, and the parser read "no output" as "no failures". A verifier that cannot distinguish *no failures* from *never executed* is this PR's own bug class. It now hard-fails on an unparseable summary.

- Real-git reproduction (not mocks): a temp repo, deliberately dirty and deliberately ahead, with a `.git`-less subdir. Every orphan assertion is paired with the owning directory's non-zero count in the same test — an orphan reporting 0 in isolation is equally consistent with a helper that returns 0 for everything.
- Full `unit` project: **7 files / 11 tests fail identically with *and* without this change** (order-dependent env suites, all pre-existing — baselined by stashing and re-running the same 10 files at `origin/main`).

## Fixture repairs — what changed is what they ANSWER, never what they claim

Three mocks now answer `rev-parse --show-toplevel`. `worktree-quota-orphan-classify.test.js` was **found by running the suites, not by grepping**: it reaches the helpers indirectly through `worktree-quota.js` and so sat outside the obvious glob — the same class of miss that bit **-B** (`cleanup-pending-sweep.test.js`). Its fixtures already modelled ownership via a `.git` marker; the mock now expresses that same distinction through the channel the code reads.

## Residual risk, recorded rather than buried

`.worktrees/` is gitignored, so a stranded dir's files are invisible to the parent. `preserveUntrackedFiles` (`scripts/worktree-reaper.mjs:919`) is driven by `dirty.untracked` and early-returns when it is empty (`:924`) — so a cleared stranded dir preserves **nothing**.

This is **not new to this PR**: `collectDirtyStatus:107` already returns `untracked: []` on the `unknown` branch, and `-B`'s `isReapable:198-203` (already in main) routes a *pruned* worktree to `ORPHAN_CLEAN` on exactly that path. This PR extends the shape, not the class. Filing a follow-up to enumerate a non-owning directory's own files via fs before deletion, rather than growing this PR.

SD: SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-C

🤖 Generated with [Claude Code](https://claude.com/claude-code)
