### PR TITLE
fix(SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001): the FR-delivery gate that could not lower a score

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -14,7 +14,13 @@ import { getFilteredRetrospective } from '../../retro-filters.js';
 
 // Core Protocol Gate - SD Start Gate (SD-LEO-INFRA-ENHANCED-PROTOCOL-FILE-001)
 import { createSdStartGate } from '../../gates/core-protocol-gate.js';
-import { classifyFrDelivery, projectGateResult, isFrTraceabilityEnforced } from '../../gates/fr-delivery-classifier.js';
+import {
+  classifyFrDelivery,
+  projectGateResult,
+  isFrTraceabilityEnforced,
+  NOT_MEASURED_SCORE,
+  ERRORED_SCORE,
+} from '../../gates/fr-delivery-classifier.js';
 
 // Pipeline Flow Verifier (SD-LEO-INFRA-INTEGRATION-AWARE-PRD-001 FR-5)
 import { verifyPipelineFlow, requiresPipelineFlowVerification } from '../../../../../lib/pipeline-flow-verifier.js';
@@ -942,19 +948,24 @@ async function runFRDeliveryVerification(ctx, supabase, prdRepo) {
       .select('id')
       .eq('parent_sd_id', ctx.sd.id);
 
+    // SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001: each of the three non-measurement paths below
+    // used to emit its own unearned score (100 / 80 / 100), so "delegated to children",
+    // "there was no PRD" and "every FR verified delivered" were indistinguishable to the
+    // composite mean. They now share ONE representation — NOT_MEASURED_SCORE — and each
+    // names its own condition in the warning text.
     if (children && children.length > 0) {
-      console.log('   ℹ️  Orchestrator SD — FR verification delegated to children');
-      return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['Orchestrator SD — FR verification delegated to children'] };
+      console.log('   ℹ️  Orchestrator SD — FR verification delegated to children (not measured here)');
+      return { passed: true, score: NOT_MEASURED_SCORE, max_score: 100, issues: [], warnings: ['Orchestrator SD — FR verification delegated to children; NOT verified at this boundary'] };
     }
 
-    console.log('   ⚠️  No PRD found — skipping FR verification');
-    return { passed: true, score: 80, max_score: 100, issues: [], warnings: ['No PRD found — FR delivery verification skipped'] };
+    console.log('   ⚠️  No PRD found — FR delivery NOT verified');
+    return { passed: true, score: NOT_MEASURED_SCORE, max_score: 100, issues: [], warnings: ['No PRD found — FR delivery NOT verified (this is a non-measurement, not a pass)'] };
   }
 
   const frs = prd.functional_requirements || [];
   if (frs.length === 0) {
-    console.log('   ℹ️  No functional requirements in PRD');
-    return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['No FRs defined in PRD'] };
+    console.log('   ℹ️  No functional requirements in PRD — nothing to verify');
+    return { passed: true, score: NOT_MEASURED_SCORE, max_score: 100, issues: [], warnings: ['No FRs defined in PRD — FR delivery NOT verified'] };
   }
 
   console.log(`   📋 Checking ${frs.length} functional requirements (per-FR mapping)...`);
@@ -970,17 +981,19 @@ async function runFRDeliveryVerification(ctx, supabase, prdRepo) {
     functionalRequirements: frs,
     requesterSessionId: ctx.sessionId || ctx.session_id || null,
   });
+  const MARKS = { delivered: '✅', descoped: '🔵', unverifiable: '❓', undelivered: '❌' };
   for (const f of classification.frs) {
-    const mark = f.status === 'delivered' ? '✅' : f.status === 'descoped' ? '🔵' : '❌';
-    console.log(`   ${mark} ${f.id} [${f.status}]: ${safeTruncate(f.description || '', 56)}`);
+    console.log(`   ${MARKS[f.status] || '❌'} ${f.id} [${f.status}]: ${safeTruncate(f.description || '', 56)}`);
   }
   const enforced = isFrTraceabilityEnforced();
-  console.log(`\n   📊 FR delivery: ${classification.delivered} delivered, ${classification.descoped} descoped, ${classification.undelivered} undelivered (enforce=${enforced ? 'ON' : 'OFF/warn-only'})`);
+  console.log(`\n   📊 FR delivery: ${classification.delivered} delivered, ${classification.descoped} descoped, ${classification.undelivered} undelivered, ${classification.unverifiable} unverifiable (enforce=${enforced ? 'ON' : 'OFF/warn-only'})`);
   const result = projectGateResult(classification, { enforced, gateName: 'FR_DELIVERY_VERIFICATION' });
   if (!result.passed) {
     console.log(`   ❌ FR delivery FAILED — ${classification.undelivered}/${classification.total} undelivered`);
+  } else if (classification.unverifiable === classification.total) {
+    console.log(`   ❓ FR delivery UNVERIFIABLE — this SD does not use the FR-reference convention, so delivery was NOT observed (score ${result.score} = verified delivery only)`);
   } else if (result.warnings.length) {
-    console.log('   ⚠️  FR delivery passed (warn-only) with undelivered FRs');
+    console.log('   ⚠️  FR delivery passed (warn-only) with undelivered or unverifiable FRs');
   } else {
     console.log('   ✅ All FRs delivered or approver-descoped');
   }
@@ -1010,9 +1023,11 @@ export function createFRDeliveryVerificationGate(supabase, prdRepo) {
       } catch (err) {
         if (isFrTraceabilityEnforced()) throw err;
         console.log(`   ⚠️  FR delivery verification errored in warn-only mode (fail-open): ${err.message}`);
+        // SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001: still non-blocking, but NOT a 100. A broken
+        // instrument must not be arithmetically indistinguishable from a verified delivery.
         return {
-          passed: true, score: 100, max_score: 100, issues: [],
-          warnings: [`FR delivery verification errored (warn-only, fail-open): ${err.message}`],
+          passed: true, score: ERRORED_SCORE, max_score: 100, issues: [],
+          warnings: [`FR delivery verification ERRORED (warn-only, fail-open) — delivery NOT verified: ${err.message}`],
         };
       }
     },

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -11,6 +11,53 @@
 import BaseExecutor from '../BaseExecutor.js';
 import ResultBuilder from '../../ResultBuilder.js';
 
+/**
+ * Project the orchestrator's per-gate results into a compact, queryable shape for persistence
+ * on the LEAD-FINAL handoff row. SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001 FR-5.
+ *
+ * WHY THIS EXISTS: measured before the fix, 0 of 62 LEAD-FINAL handoff rows carried any
+ * gate_results, so FR_DELIVERY_VERIFICATION — the gate whose blindness this SD was filed
+ * about — had NO persisted execution record for any of the 60 most recent completed SDs. Its
+ * verdict was unobservable to any auditor after the run, which meant a repair to it could only
+ * ever be demonstrated in a unit test and never in production.
+ *
+ * Deliberately compact: name/score/passed/required plus the FR classification counts. The full
+ * `details` blob is NOT persisted — it can carry every FR description and would bloat the row.
+ *
+ * Pure and exported for direct unit testing (no DB, no orchestrator instance needed).
+ *
+ * @param {Object} gateResults - the ValidationOrchestrator result (uses .gateResults map)
+ * @returns {Array<Object>} one compact entry per gate, or [] when nothing is available
+ */
+export function projectGateResultsForPersistence(gateResults) {
+  const byName = gateResults && gateResults.gateResults;
+  if (!byName || typeof byName !== 'object') return [];
+  return Object.entries(byName).map(([name, r]) => {
+    const entry = {
+      name,
+      score: r && typeof r.score === 'number' ? r.score : null,
+      max_score: r && typeof r.max_score === 'number' ? r.max_score : (r && typeof r.maxScore === 'number' ? r.maxScore : null),
+      passed: !!(r && r.passed),
+      required: !!(r && r.required),
+    };
+    // FR-delivery gates carry the classification the auditor actually needs — specifically
+    // whether a shortfall was UNVERIFIABLE (blind) or UNDELIVERED (genuinely missing).
+    const d = r && r.details;
+    if (d && typeof d.total === 'number') {
+      entry.fr_classification = {
+        total: d.total,
+        delivered: d.delivered ?? null,
+        descoped: d.descoped ?? null,
+        undelivered: d.undelivered ?? null,
+        unverifiable: d.unverifiable ?? null,
+        convention_in_use: d.convention_in_use ?? null,
+        over_ceiling: d.over_ceiling ?? null,
+      };
+    }
+    return entry;
+  });
+}
+
 // Domain imports
 import { getRequiredGates } from './gates.js';
 import {
@@ -493,7 +540,13 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
             validation_details: { written_by: 'LeadFinalApprovalExecutor pre-completion canonical write' },
             accepted_at: new Date().toISOString(),
             created_by: HANDOFF_SYSTEM_TAG,
-            metadata: { canonical_pre_completion_write: true, sd_ref: 'SD-FDBK-FIX-LFA-ACCEPT-ORDERING-001' }
+            metadata: {
+              canonical_pre_completion_write: true,
+              sd_ref: 'SD-FDBK-FIX-LFA-ACCEPT-ORDERING-001',
+              // SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001 FR-5: make the per-gate verdicts
+              // auditable after the run. Previously absent on all 62 LEAD-FINAL rows.
+              gate_results: projectGateResultsForPersistence(gateResults)
+            }
           });
         if (canonErr) {
           console.log(`   ❌ Canonical LFA write failed (SD NOT completed): ${canonErr.message}`);

--- a/scripts/modules/handoff/gates/fr-delivery-classifier.js
+++ b/scripts/modules/handoff/gates/fr-delivery-classifier.js
@@ -1,6 +1,6 @@
 /**
  * FR Delivery Classifier — shared per-FR delivery status for completion gates.
- * SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001.
+ * SD-LEO-INFRA-HARDEN-LEO-COMPLETION-001, repaired by SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001.
  *
  * Single source of truth used by BOTH the LEAD-FINAL FR_DELIVERY_VERIFICATION gate
  * and the EXEC-TO-PLAN FR_DELIVERY_TRACEABILITY gate. Reads the AUTHORITATIVE FR list
@@ -11,10 +11,32 @@
  *   - DESCOPED  : the SD has an APPROVER-GATED descope record for the FR
  *                 (strategic_directives_v2.metadata.descoped_frs[].approved_by non-empty and
  *                 != the requester).
- *   - UNDELIVERED: neither of the above.
+ *   - UNVERIFIABLE: the FR-reference convention is not in use for THIS SD at all, so no
+ *                 instrument here could have observed delivery either way. Decided PER-SD,
+ *                 never per-FR — see below.
+ *   - UNDELIVERED: the convention IS in use for this SD and this FR still has no reference.
  *
- * Enforcement is gated by LEO_FR_TRACEABILITY_ENFORCE (default OFF = warn-only). The
- * classifier ALWAYS runs; the gate wrappers project status -> {passed, required} per the flag.
+ * WHY UNVERIFIABLE EXISTS (SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001, "green-where-blind").
+ * Measured on 60 recent completed SDs (55 with FRs): 45 classified at 0% satisfied and only
+ * 4 at 100%, because the healthy story-generation path never writes an FR id into story text
+ * (it lands in ~a fifth of rows only via a degenerate fallback branch). Collapsing that into
+ * UNDELIVERED asserts "we looked and it is absent" when the truth is "no instrument here could
+ * have seen it" — and the old warn-only projection then reported score 100 anyway, so the
+ * blindness was invisible. Separating the two states is what makes an UNDELIVERED verdict mean
+ * something: it is only reachable when this SD demonstrably uses the convention.
+ *
+ * REJECTED ALTERNATIVE — positional story_key linkage. story_key is minted as SDKEY:US-NNN by
+ * every generator iterating functional_requirements in array order, and the correspondence is
+ * real (49/49 SDs-with-stories have contiguous 1..N ordinals). It must NOT be used as a delivery
+ * signal: executed against the specimen it returns 6/6 DELIVERED, including the two FRs that
+ * SD's own metadata.scope_completion_annotation records as not delivered, and population-wide it
+ * flips 45/55 SDs from 0% to 100%. Its only live discriminant is whether the generator minted a
+ * story at that ordinal — decided at PLAN time, before any code exists — so it measures generator
+ * output completeness and reports it as delivery. It converts a false 0 into a false 100.
+ *
+ * Enforcement is gated by LEO_FR_TRACEABILITY_ENFORCE (default OFF = warn-only). The flag governs
+ * BLOCKING ONLY (passed / required) — it never changes the REPORTED SCORE. A gate that reports a
+ * number it did not measure is the defect this module was repaired to remove.
  */
 
 /** True when strict FR-delivery enforcement is turned on. Default OFF (warn-only). */
@@ -24,6 +46,42 @@ export function isFrTraceabilityEnforced(env = process.env) {
   const s = String(v).trim().toLowerCase();
   return s === '1' || s === 'true' || s === 'on' || s === 'yes';
 }
+
+/**
+ * Ceiling on the UNVERIFIABLE state, as a fraction (0..1) of an SD's FRs.
+ *
+ * Shipped on day one deliberately. The precedent is the WAIT verdict, which needed
+ * WAIT_MAX_ATTEMPTS and a 24h wall clock retrofitted (ValidationOrchestrator.js) after an
+ * open-ended non-failing state had already become a permanent escape hatch. An uncapped
+ * UNVERIFIABLE would just be warn-only under a new name.
+ *
+ * Default 1.0 = a fully-unverifiable SD is tolerated but always reported as such and always
+ * scored honestly. Lowering it (e.g. 0.5) is how the fleet ratchets the unmeasurable population
+ * down once story->FR linkage is actually recorded.
+ */
+export function frUnverifiableCeiling(env = process.env) {
+  const raw = env.LEO_FR_UNVERIFIABLE_CEILING;
+  if (raw == null || String(raw).trim() === '') return 1;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0 || n > 1) return 1;
+  return n;
+}
+
+/**
+ * The score a gate reports when it could not measure delivery at all (no PRD, no FRs, an
+ * orchestrator parent delegating to children, or a validator that threw). NOT 100: a
+ * non-measurement must never be arithmetically indistinguishable from a verified full delivery,
+ * because the composite handoff score is an unweighted mean that cannot tell them apart.
+ */
+export const NOT_MEASURED_SCORE = 75;
+
+/**
+ * The score a gate reports when its own validator THREW and the failure was swallowed to stay
+ * non-blocking in warn-only mode. Distinct from — and lower than — NOT_MEASURED_SCORE: "there
+ * was nothing to measure" and "the instrument broke" are different conditions and must not
+ * share a number. Previously both of these, and a verified full delivery, all reported 100.
+ */
+export const ERRORED_SCORE = 50;
 
 /** Stable FR id for an FR entry (falls back to FR-<n> by 1-based index). */
 export function frIdOf(fr, index) {
@@ -94,66 +152,147 @@ export async function classifyFrDelivery(supabase, { sdId, directiveId = null, s
     .eq('sd_id', sdId);
   const validated = (stories || []).filter(isValidatedStory);
 
-  const out = [];
+  // PASS 1 — resolve the two positive signals per FR without deciding the negative case yet.
+  // The negative case (undelivered vs unverifiable) cannot be decided per-FR: it depends on
+  // whether THIS SD uses the FR-reference convention at all, which is only knowable after
+  // every FR has been examined.
+  const resolved = [];
   for (let i = 0; i < frs.length; i++) {
     const fr = frs[i];
     const id = frIdOf(fr, i);
     const desc = (fr && (fr.requirement || fr.description || fr.title)) || '';
     const deliveredBy = validated.find((s) => frReferencesId(s, id));
-    if (deliveredBy) {
-      out.push({ id, description: desc, status: 'delivered', evidence: `Validated story ${deliveredBy.id} references ${id}` });
-      continue;
-    }
-    const descope = descopeFor(sdMetadata, id, requesterSessionId);
-    if (descope) {
-      out.push({ id, description: desc, status: 'descoped', evidence: `Descoped by ${descope.approved_by}${descope.reason ? `: ${descope.reason}` : ''}` });
-      continue;
-    }
-    out.push({ id, description: desc, status: 'undelivered', evidence: 'No validated story references this FR id and no approver-gated descope' });
+    const descope = deliveredBy ? null : descopeFor(sdMetadata, id, requesterSessionId);
+    resolved.push({ id, desc, deliveredBy, descope });
   }
 
+  // PASS 2 — is the FR-reference convention in use for this SD? One genuine reference is
+  // enough to prove the instrument works here, which is what makes a missing reference on a
+  // sibling FR real evidence of non-delivery rather than an artifact of an unused convention.
+  const conventionInUse = resolved.some((r) => r.deliveredBy);
+
+  // ...but UNVERIFIABLE requires that there was something we could have read. With ZERO
+  // validated stories there is no work product at all, so "the convention is not in use here"
+  // is not an available excuse — nothing exists that could have carried a reference. That is a
+  // genuinely suspicious state (FRs declared, nothing built or validated against them) and it
+  // stays UNDELIVERED rather than being laundered into blindness. Surfaced by an existing
+  // hard-fail test in fr-delivery-traceability-gate.test.js, which was right to object.
+  const hasWorkProduct = validated.length > 0;
+  const unmeasurable = !conventionInUse && hasWorkProduct;
+
+  const out = resolved.map(({ id, desc, deliveredBy, descope }) => {
+    if (deliveredBy) {
+      return { id, description: desc, status: 'delivered', evidence: `Validated story ${deliveredBy.id} references ${id}` };
+    }
+    if (descope) {
+      return { id, description: desc, status: 'descoped', evidence: `Descoped by ${descope.approved_by}${descope.reason ? `: ${descope.reason}` : ''}` };
+    }
+    if (unmeasurable) {
+      return {
+        id,
+        description: desc,
+        status: 'unverifiable',
+        evidence: `No FR of this SD is referenced by any of its ${validated.length} validated story/stories, so the FR-reference convention is not in use here — delivery of this FR was not observable either way`,
+      };
+    }
+    const why = hasWorkProduct
+      ? 'No validated story references this FR id and no approver-gated descope, while sibling FRs of this SD ARE referenced'
+      : 'No validated story exists for this SD at all and no approver-gated descope — nothing was built or validated against this FR';
+    return { id, description: desc, status: 'undelivered', evidence: why };
+  });
+
+  const count = (status) => out.filter((f) => f.status === status).length;
+  const total = out.length;
+  const unverifiable = count('unverifiable');
   return {
     frs: out,
-    total: out.length,
-    delivered: out.filter((f) => f.status === 'delivered').length,
-    descoped: out.filter((f) => f.status === 'descoped').length,
-    undelivered: out.filter((f) => f.status === 'undelivered').length,
+    total,
+    delivered: count('delivered'),
+    descoped: count('descoped'),
+    undelivered: count('undelivered'),
+    unverifiable,
+    convention_in_use: conventionInUse,
+    has_work_product: hasWorkProduct,
+    validated_story_count: validated.length,
+    unverifiable_ratio: total === 0 ? 0 : unverifiable / total,
   };
 }
 
 /**
- * Project a classification into a gate result, honoring the enforcement flag.
- * OFF (default): passed:true / required:false, undelivered FRs surface as WARNINGS only
- * (byte-identical pass outcome regardless of undelivered count -> zero blast radius).
- * ON: passed:false / required:true on any undelivered FR (hard-fails via gate.required!==false).
+ * Project a classification into a gate result.
+ *
+ * THE SCORE IS ALWAYS THE TRUE satisfied/total RATIO, in BOTH modes. The enforcement flag
+ * governs only `passed` and `required` — i.e. whether the gate BLOCKS — never what it REPORTS.
+ *
+ * The previous implementation pinned the warn-only score at 100 and hid the real number in
+ * details.raw_score, on the reasoning that a sub-100 score could soft-block a borderline SD.
+ * That bought "zero blast radius" by making the gate structurally unable to lower a score:
+ * measured on the specimen, 0 of 6 FRs satisfied still reported 100, so the composite could
+ * not distinguish six-of-six from zero-of-six. Honest reporting is the whole point of a gate.
+ * Measured cost of telling the truth, across 62 handoffs carrying an FR gate: mean composite
+ * delta -2.26 points, worst -10.0 on a small roster, and exactly 2 handoffs newly crossing
+ * below their type threshold. Small, bounded, and enumerable — not zero, and stated as such.
  */
-export function projectGateResult(classification, { enforced = isFrTraceabilityEnforced(), gateName = 'FR_DELIVERY' } = {}) {
-  const { frs, total, delivered, descoped, undelivered } = classification;
+export function projectGateResult(classification, {
+  enforced = isFrTraceabilityEnforced(),
+  gateName = 'FR_DELIVERY',
+  ceiling = frUnverifiableCeiling(),
+} = {}) {
+  const { frs, total, delivered, descoped, undelivered, unverifiable = 0 } = classification;
   const satisfied = delivered + descoped;
-  const score = total === 0 ? 100 : Math.round((satisfied / total) * 100);
-  const undeliveredList = frs.filter((f) => f.status === 'undelivered').map((f) => `${f.id}: ${f.description}`.trim());
+  const score = total === 0 ? NOT_MEASURED_SCORE : Math.round((satisfied / total) * 100);
+  const listOf = (status, label) => frs
+    .filter((f) => f.status === status)
+    .map((f) => `  ${label}: ${`${f.id}: ${f.description}`.trim()}`);
+  const undeliveredList = listOf('undelivered', 'Undelivered');
+  const unverifiableList = listOf('unverifiable', 'Unverifiable');
+  const ratio = total === 0 ? 0 : unverifiable / total;
+  const overCeiling = total > 0 && ratio > ceiling;
+  const details = { ...classification, ceiling, over_ceiling: overCeiling };
 
   if (total === 0) {
-    return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['No functional requirements in PRD'], required: false, details: classification };
-  }
-  if (undelivered === 0) {
-    return { passed: true, score, max_score: 100, issues: [], warnings: [], required: enforced, details: classification };
-  }
-  // There ARE undelivered FRs.
-  if (enforced) {
+    // No FRs to measure. Reported as a NON-MEASUREMENT, not as a delivery.
     return {
-      passed: false, score, max_score: 100, required: true,
-      issues: [`${gateName}: ${undelivered}/${total} FR(s) undelivered (no validated story reference and no approver-gated descope)`, ...undeliveredList.map((u) => `  Undelivered: ${u}`)],
-      warnings: [], details: classification,
+      passed: true, score: NOT_MEASURED_SCORE, max_score: 100, issues: [], required: false,
+      warnings: [`${gateName}: no functional requirements in PRD — delivery NOT verified (score ${NOT_MEASURED_SCORE} denotes not-measured, not delivered)`],
+      details,
     };
   }
-  // OFF = warn-only: pass with FULL score (100) so the averaged handoff normalizedScore is NOT
-  // diluted — a sub-100 score here could soft-block a borderline SD, which would break the
-  // promised zero-blast-radius. Undelivered detail lives only in warnings + details.raw_score.
+
+  const issues = [];
+  const warnings = [];
+
+  if (undelivered > 0) {
+    const line = `${gateName}: ${undelivered}/${total} FR(s) UNDELIVERED — this SD does use the FR-reference convention (sibling FRs are referenced), so these are genuinely missing`;
+    (enforced ? issues : warnings).push(line, ...undeliveredList);
+  }
+
+  if (unverifiable > 0) {
+    // Never silent, in either mode: an unmeasurable completion is the condition this gate was
+    // repaired to surface, so it is always stated even when it does not block.
+    warnings.push(
+      `${gateName}: ${unverifiable}/${total} FR(s) UNVERIFIABLE — no FR of this SD is referenced by any validated story, so delivery was not observable. This is BLINDNESS, not evidence of absence, and the score below reflects VERIFIED delivery only.`,
+      ...unverifiableList,
+    );
+  }
+
+  if (overCeiling) {
+    const line = `${gateName}: unverifiable ratio ${(ratio * 100).toFixed(0)}% exceeds the ceiling of ${(ceiling * 100).toFixed(0)}% (LEO_FR_UNVERIFIABLE_CEILING) — an SD may not complete this blind`;
+    (enforced ? issues : warnings).push(line);
+  }
+
+  if (!enforced && (undelivered > 0 || unverifiable > 0)) {
+    warnings.push(`${gateName} is warn-only (set LEO_FR_TRACEABILITY_ENFORCE to block); the score is the true verified-delivery ratio either way.`);
+  }
+
+  const blocking = enforced && (undelivered > 0 || overCeiling);
   return {
-    passed: true, score: 100, max_score: 100, required: false,
-    issues: [],
-    warnings: [`${gateName} (warn-only; set LEO_FR_TRACEABILITY_ENFORCE to enforce): ${undelivered}/${total} FR(s) lack a validated story reference or approver-gated descope`, ...undeliveredList.map((u) => `  Undelivered: ${u}`)],
-    details: { ...classification, raw_score: score },
+    passed: !blocking,
+    score,
+    max_score: 100,
+    required: blocking ? true : enforced,
+    issues,
+    warnings,
+    details,
   };
 }

--- a/scripts/modules/handoff/gates/fr-delivery-traceability-gate.js
+++ b/scripts/modules/handoff/gates/fr-delivery-traceability-gate.js
@@ -12,7 +12,13 @@
  * flag the exported-no-caller factory). Wired into exec-to-plan/index.js (both the
  * orchestrator-child path and the normal path) by SD-LEO-FIX-RECONCILE-DEAD-ARRIVAL-001.
  */
-import { classifyFrDelivery, projectGateResult, isFrTraceabilityEnforced } from './fr-delivery-classifier.js';
+import {
+  classifyFrDelivery,
+  projectGateResult,
+  isFrTraceabilityEnforced,
+  NOT_MEASURED_SCORE,
+  ERRORED_SCORE,
+} from './fr-delivery-classifier.js';
 
 /** The real validation body — separated so the fail-open wrapper below stays trivial. */
 async function runFrDeliveryTraceability(supabase, ctx) {
@@ -25,8 +31,11 @@ async function runFrDeliveryTraceability(supabase, ctx) {
     .select('id')
     .eq('parent_sd_id', sd.id);
   if (children && children.length > 0) {
-    console.log('   ℹ️  Orchestrator parent — FR delivery delegated to children');
-    return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['Orchestrator parent — FR delivery delegated to children'], required: false };
+    // SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001: delegation is a NON-MEASUREMENT, not a delivery.
+    // Reporting 100 here made "the children were checked" arithmetically identical to "this SD
+    // verified every FR", which the composite mean cannot distinguish.
+    console.log('   ℹ️  Orchestrator parent — FR delivery delegated to children (not measured here)');
+    return { passed: true, score: NOT_MEASURED_SCORE, max_score: 100, issues: [], warnings: ['Orchestrator parent — FR delivery delegated to children; NOT verified at this boundary'], required: false };
   }
 
   const classification = await classifyFrDelivery(supabase, {
@@ -40,15 +49,15 @@ async function runFrDeliveryTraceability(supabase, ctx) {
 
   if (classification.total === 0) {
     console.log('   ℹ️  No functional requirements in PRD (or no PRD) — nothing to verify');
-    return { passed: true, score: 100, max_score: 100, issues: [], warnings: ['No functional requirements found for FR delivery traceability'], required: false };
+    return { passed: true, score: NOT_MEASURED_SCORE, max_score: 100, issues: [], warnings: ['No functional requirements found for FR delivery traceability — NOT verified'], required: false };
   }
 
+  const MARKS = { delivered: '✅', descoped: '🔵', unverifiable: '❓', undelivered: '❌' };
   for (const f of classification.frs) {
-    const mark = f.status === 'delivered' ? '✅' : f.status === 'descoped' ? '🔵' : '❌';
-    console.log(`   ${mark} ${f.id} [${f.status}]`);
+    console.log(`   ${MARKS[f.status] || '❌'} ${f.id} [${f.status}]`);
   }
   const enforced = isFrTraceabilityEnforced();
-  console.log(`   📊 ${classification.delivered} delivered, ${classification.descoped} descoped, ${classification.undelivered} undelivered (enforce=${enforced ? 'ON' : 'OFF/warn-only'})`);
+  console.log(`   📊 ${classification.delivered} delivered, ${classification.descoped} descoped, ${classification.undelivered} undelivered, ${classification.unverifiable} unverifiable (enforce=${enforced ? 'ON' : 'OFF/warn-only'})`);
   return projectGateResult(classification, { enforced, gateName: 'FR_DELIVERY_TRACEABILITY' });
 }
 
@@ -66,9 +75,11 @@ export function createFrDeliveryTraceabilityGate(supabase) {
       } catch (err) {
         if (isFrTraceabilityEnforced()) throw err;
         console.log(`   ⚠️  FR traceability errored in warn-only mode (fail-open): ${err.message}`);
+        // SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001: still non-blocking, but NOT a 100. A broken
+        // instrument must not be arithmetically indistinguishable from a verified delivery.
         return {
-          passed: true, score: 100, max_score: 100, issues: [],
-          warnings: [`FR delivery traceability errored (warn-only, fail-open): ${err.message}`],
+          passed: true, score: ERRORED_SCORE, max_score: 100, issues: [],
+          warnings: [`FR delivery traceability ERRORED (warn-only, fail-open) — delivery NOT verified: ${err.message}`],
           required: false
         };
       }

--- a/scripts/one-off/_alpha-attestation-completion-flag-harness-001.mjs
+++ b/scripts/one-off/_alpha-attestation-completion-flag-harness-001.mjs
@@ -1,0 +1,109 @@
+/**
+ * REAL_CALLEE_ATTESTATION for SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001.
+ *
+ * Names the test that actually DRIVES each real callee this SD adds or modifies. "Driven"
+ * means the test invokes the real implementation, not a mock of it — on an SD about checks
+ * that report verdicts they did not earn, an attestation naming a mocked callee would be the
+ * same defect in miniature.
+ *
+ * Idempotent.
+ */
+import dotenv from 'dotenv';
+dotenv.config();
+import { createClient } from '@supabase/supabase-js';
+
+const s = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const SD_KEY = 'SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001';
+
+const attestation = {
+  attested_by: 'Alpha (worker session e7c92ad8)',
+  commit: '0547e5e6594',
+  note: 'Every callee below is exercised against its REAL implementation. The two suites that mock the classifier (fr-delivery-traceability-wiring, lead-final-fr-delivery-verification-fail-open) are listed as wiring/fail-open coverage only and are NOT claimed as drivers of the logic.',
+  callees: [
+    {
+      callee: 'classifyFrDelivery (scripts/modules/handoff/gates/fr-delivery-classifier.js)',
+      driven_by: 'tests/unit/handoff/gates/fr-delivery-classifier.test.js',
+      tests: [
+        'classifies delivered / descoped / undelivered per-FR',
+        'REGRESSION (the 93-scored specimen): no FR referenced anywhere -> all unverifiable, never 100',
+        'SEEDED DEFECT: convention IS in use and one named FR is missing -> UNDELIVERED and REFUSED',
+        'ZERO validated stories is UNDELIVERED, not unverifiable',
+        'unvalidated stories do not count as work product',
+        'a descope alone does not prove the convention is in use',
+      ],
+      also_driven_live_by: 'scripts/one-off/_alpha-probe-fr-classifier-specimen.mjs and _alpha-probe-fr-classifier-population.mjs — real code against real DB rows (55 SDs)',
+    },
+    {
+      callee: 'projectGateResult (same module)',
+      driven_by: 'tests/unit/handoff/gates/fr-delivery-classifier.test.js',
+      tests: [
+        'ON + undelivered -> hard fail (passed:false, required:true)',
+        'OFF + undelivered -> warn-only pass but the score is TRUE, not pinned at 100',
+        'OFF score TRACKS the undelivered count instead of being invariant',
+        'all delivered -> pass either way, score 100; required mirrors the flag',
+        'no FRs -> pass but scored as NOT-MEASURED, never 100',
+        'score 100 implies undelivered===0 AND unverifiable===0 (6 classifications x 2 modes)',
+        'exceeding the ceiling produces an OBSERVABLY DIFFERENT result, not the same pass',
+        'the ceiling never blocks in warn-only mode',
+      ],
+    },
+    {
+      callee: 'frUnverifiableCeiling (same module)',
+      driven_by: 'tests/unit/handoff/gates/fr-delivery-classifier.test.js',
+      tests: ['frUnverifiableCeiling parses env and fails safe on nonsense (default, 0.4, and 4 invalid inputs)'],
+    },
+    {
+      callee: 'projectGateResultsForPersistence (scripts/modules/handoff/executors/lead-final-approval/index.js)',
+      driven_by: 'tests/unit/handoff/lead-final-gate-results-persistence.test.js',
+      tests: [
+        'returns [] rather than throwing on missing/malformed input',
+        'projects name/score/passed/required per gate',
+        'carries the FR classification so an auditor can tell UNVERIFIABLE from UNDELIVERED',
+        'does NOT persist the per-FR descriptions (row-bloat guard)',
+        'omits fr_classification for gates that carry no classification',
+        'tolerates the maxScore spelling used by the orchestrator',
+      ],
+    },
+    {
+      callee: 'createFrDeliveryTraceabilityGate (scripts/modules/handoff/gates/fr-delivery-traceability-gate.js)',
+      driven_by: 'tests/unit/handoff/gates/fr-delivery-traceability-gate.test.js',
+      tests: [
+        'ON: undelivered FR -> hard fail',
+        'OFF (default): undelivered FR -> warn-only pass',
+        'orchestrator PARENT delegates to children (pass)',
+        'delivered FR -> pass',
+      ],
+      note: 'Real classifier, real projection — this suite does not mock the module. Its consumer exec-to-plan/index.js:56 is untouched because the exported signature is unchanged (flagged by CONSUMER_IMPACT_ADVISORY and reviewed).',
+    },
+    {
+      callee: 'runFRDeliveryVerification / createFRDeliveryVerificationGate (lead-final-approval/gates.js)',
+      driven_by: 'tests/unit/lead-final-fr-delivery-verification-fail-open.test.js',
+      tests: ['thrown validator body with enforcement OFF => passing warn result (never blocks)'],
+      note: 'HONEST LIMITATION, stated rather than glossed: this suite MOCKS the classifier module, so it drives the gate WRAPPER and its fail-open contract, not the classification logic. The logic itself is driven by the classifier suite above and by the two live probes. No test drives this wrapper against a real DB — the FR-5 gate_results persistence is likewise proven at the projection function, not end-to-end through a real LEAD-FINAL run.',
+    },
+  ],
+  mutation_evidence: {
+    method: 'Each mutant confirmed PRESENT ON DISK before running — an unapplied mutation is indistinguishable from one the tests survived. Original restored and the restore verified.',
+    results: [
+      'M1 restore the warn-only score:100 pin -> falsified, 4 tests failing',
+      'M2 collapse UNVERIFIABLE back into UNDELIVERED -> falsified, 2 tests failing',
+      'M3 decide the convention PER-FR instead of PER-SD -> falsified, 2 tests failing',
+    ],
+    deviation: 'The PRD said each mutant would fail a DISTINCT count; M2 and M3 both fail 2. Each was still independently detected, which is the property that matters. The distinct-count phrasing was over-specified by me at PLAN time.',
+  },
+};
+
+const { data: sd, error: readErr } = await s
+  .from('strategic_directives_v2').select('id, metadata').eq('sd_key', SD_KEY).single();
+if (readErr) { console.log('READ ERR:', readErr.message); process.exit(1); }
+
+if (sd.metadata?.real_callee_attestation) {
+  console.log('ALREADY PRESENT');
+  process.exit(0);
+}
+
+const { error } = await s.from('strategic_directives_v2')
+  .update({ metadata: { ...(sd.metadata || {}), real_callee_attestation: attestation } })
+  .eq('id', sd.id);
+if (error) { console.log('UPDATE ERR:', error.message); process.exit(1); }
+console.log('WROTE attestation for', attestation.callees.length, 'real callees');

--- a/scripts/one-off/_alpha-lead-evidence-completion-flag-harness-001.mjs
+++ b/scripts/one-off/_alpha-lead-evidence-completion-flag-harness-001.mjs
@@ -1,0 +1,142 @@
+/**
+ * LEAD-phase evidence for SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001.
+ *
+ * Writes (a) the Explore sub-agent row -- Explore is a read-only Claude Code built-in that
+ * cannot self-write, and `execute-subagent.js --code EXPLORE` resolves against leo_sub_agents
+ * where no Explore row exists, so the designed path is Task-tool invocation with the worker
+ * persisting the result -- and (b) mechanism_verifications on the SD.
+ *
+ * The verification record deliberately carries the claims that REFUTED my own readings. A
+ * verification record that omits what corrected it is the same failure the gate exists to catch.
+ *
+ * Idempotent on both writes.
+ */
+import dotenv from 'dotenv';
+dotenv.config();
+import { createClient } from '@supabase/supabase-js';
+
+const s = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const SD_UUID = '222e317f-926c-4d5c-99eb-b98ee8d24f53';
+const SD_KEY = 'SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001';
+// process.cwd(), never a hand-typed literal: Windows path literals get mangled by JS
+// string-escape parsing, which the reject_control_chars_in_subagent_evidence guard catches.
+const CWD = process.cwd();
+
+// ---------- (a) Explore evidence row ----------
+const existing = await s
+  .from('sub_agent_execution_results')
+  .select('id')
+  .eq('sd_id', SD_UUID)
+  .eq('sub_agent_code', 'Explore')
+  .limit(1);
+
+if (existing.data && existing.data.length) {
+  console.log('EXPLORE ROW ALREADY PRESENT:', existing.data[0].id);
+} else {
+  const { data, error } = await s
+    .from('sub_agent_execution_results')
+    .insert({
+      sd_id: SD_UUID,
+      sub_agent_code: 'Explore',
+      sub_agent_name: 'Explore (read-only search agent)',
+      verdict: 'CONDITIONAL_PASS',
+      confidence: 88,
+      phase: 'LEAD',
+      source: 'task_tool',
+      validation_mode: 'prospective',
+      executed_from_cwd: CWD,
+      justification:
+        'Exploration was thorough and load-bearing: it mapped the story-to-FR linkage question to a definite answer (no fr_id column exists on user_stories; all 40 columns and every ALTER TABLE checked), enumerated SIX further completion checks beyond the two known, and produced the exact score-aggregation arithmetic. CONDITIONAL rather than PASS because its central positive finding -- a deterministic positional story_key linkage -- was subsequently FALSIFIED as a delivery signal by a variance measurement, and because its aggregation arithmetic (~23 equal-weight gates) was later measured wrong (rosters are 29-43, mean 39.6). Exploration located the code correctly; the conclusions drawn from reading it needed measurement to correct.',
+      conditions: [
+        'Do NOT adopt the positional story_key linkage as a delivery signal -- falsified by execution: it yields 6/6 delivered on the specimen whose own metadata records 2 FRs as not delivered.',
+        'Re-measure the gate-roster size before using any per-gate blast-radius number; the ~23-gate estimate was wrong (actual 29-43, mean 39.6).',
+        'Treat the six rival completion checks as OUT of scope for this SD but record them -- three mutually-unaware representations of scope-delivered is a separate single-representation defect.',
+      ],
+      critical_issues: [
+        'user_stories has NO fr_id/fr_ref column and no join table records which FR a story implements; the only FR-id-bearing artifact is the descope path (strategic_directives_v2.metadata.descoped_frs), which fired 0 times across all 55 SDs measured.',
+        'FR ids are LLM-authored and never normalised (prd-llm-service.mjs:156-164 hands the model a literal "FR-1" example; no post-parse validation), so dialects FR-1 / FR-001 / FR-3a coexist and an exact word-boundary text match cannot span them.',
+        'SIX further completion checks can each return a passing score with no evidence: SCOPE_COMPLETION_VERIFICATION (4 pass-without-evidence paths), DELIVERABLES_COMPLETENESS (reads a status column the harness self-writes at 50% confidence), deliverable-canary (conservative by design, never false-fails), PCVP light tier (sole check is that the SD wrote its own handoff row), USER_STORIES_COMPLETE (the any-status proxy the FR classifier was built to REPLACE, still running in the same LEAD-FINAL gate list at gates.js:1363), ACCEPTANCE_CRITERIA_TRACEABILITY (keyword-matches vision markdown to test filenames).',
+      ],
+      warnings: [
+        'lib/sub-agents/modules/stories/execute.js:371 carries a comment asserting user_stories has no metadata column. That comment is factually wrong -- the column exists -- and it is why the primary story writer routes provenance into technical_notes as a JSON blob instead.',
+        'required:false excludes a gate from BLOCKING but NOT from the score average (ValidationOrchestrator.js:348-359 accumulates before :368 consults required), and SKIPPED gates also contribute their score.',
+        'SD-SD-COMPLETION-DELIVERABLE-VERIFICATION-ORCH, named in this SD as an already-shipped gate, does not exist anywhere in the tree.',
+      ],
+      recommendations: [
+        'Repair projectGateResult in place -- both consumers already call it, so a state added there propagates to both by construction; adding a gate would be the single-representation violation.',
+      ],
+      metadata: {
+        repo_path: CWD,
+        executed_from_cwd: CWD,
+        invocation: 'Task tool - Explore is read-only and cannot self-write; worker persists per established pattern',
+      },
+    })
+    .select('id,verdict');
+  if (error) { console.log('EXPLORE INSERT ERR:', error.message); process.exit(1); }
+  console.log('EXPLORE ROW WROTE:', JSON.stringify(data[0]));
+}
+
+// ---------- (b) mechanism_verifications ----------
+const { data: sd, error: readErr } = await s
+  .from('strategic_directives_v2')
+  .select('id, metadata')
+  .eq('sd_key', SD_KEY)
+  .single();
+if (readErr) { console.log('SD READ ERR:', readErr.message); process.exit(1); }
+
+if (Array.isArray(sd.metadata?.mechanism_verifications) && sd.metadata.mechanism_verifications.length) {
+  console.log('MECHANISM_VERIFICATIONS ALREADY PRESENT');
+  process.exit(0);
+}
+
+const verifications = [
+  {
+    verified_by: 'Alpha (worker session e7c92ad8)',
+    verified_at: 'scripts/modules/handoff/gates/fr-delivery-classifier.js:150-158',
+    claim: 'In warn-only mode (the default) projectGateResult returns score:100 regardless of the true delivery ratio; the real number is stashed in details.raw_score.',
+    method:
+      'Ran the real classifier against the real specimen row (SD-FDBK-INFRA-WORKER-LOOP-DIRECTIVE-001) rather than reading it: 0 delivered / 0 descoped / 6 undelivered, details.raw_score 0, gate result passed=true score=100 required=false. Executed, not inferred.',
+  },
+  {
+    verified_by: 'Alpha (worker session e7c92ad8)',
+    verified_at: 'user_stories population, 275 rows across the 60 most-recent completed SDs',
+    claim: 'isValidatedStory() is a tautology on the population the gate actually runs against -- status=completed 275/275 and validation_status=validated 275/275 -- so it discriminates nothing.',
+    method:
+      'Variance measurement over every story belonging to those SDs. CORRECTED BY VALIDATION: the tautology is NOT global (a 1000-row sample of 15,290 gives completed 814 / validated 752), it is CONDITIONAL on reaching EXEC-TO-PLAN and it is MANUFACTURED -- four bulk writers flip every story unconditionally (exec-to-plan/state-transitions.js:19-67, plan-to-lead/state-transitions.js:81-139, auto-validate-user-stories-on-exec-complete.js:238-242, RPC fn_atomic_exec_to_plan_transition). The specimen s six stories were flipped at 19:42:44, ten seconds before its PLAN-TO-LEAD row. plan-to-lead/index.js:225 flips the data BEFORE the gate that reads it. The cause is the argument; my sample was only the symptom.',
+  },
+  {
+    verified_by: 'Alpha (worker session e7c92ad8), falsified by execution',
+    verified_at: 'story_key population measurement + validation-agent re-execution',
+    claim: 'REJECTED CANDIDATE FIX: reading the positional story_key ordinal (US-00n <-> functional_requirements[n-1]) as a delivery signal.',
+    method:
+      'The linkage is real and I confirmed it in DATA, not code: 49/49 SDs-with-stories have every key matching US-NNN, ordinals contiguous 1..N, zero gaps or dupes, 46/55 count-matched. It still must NOT be adopted. Executed on the specimen it returns 6/6 DELIVERED score 100 -- including FR-5 and FR-6, which that SD s own metadata.scope_completion_annotation lists under not_delivered. Population-wide it flips 45/55 SDs from 0% to 100%. It converts a false 0 into a false 100: equally blind, opposite direction. Its only live discriminant is whether the generator minted a story at that ordinal, decided at PLAN time before any code exists, so it would measure GENERATOR OUTPUT COMPLETENESS and report it as delivery.',
+  },
+  {
+    verified_by: 'validation-agent (row 5fb913a0), correcting Alpha',
+    verified_at: 'scripts/modules/handoff/executors/... story writers; grep over user_stories.title',
+    claim: 'CORRECTION TO MY OWN CLAIM: I wrote that no writer ever emits an FR id into story text. That is false and falsifiable by grep.',
+    method:
+      '146 stories repo-wide carry an FR id in title; 21 of 123 sampled match frReferencesId; 34 FRs across 10 of 55 SDs actually classify DELIVERED on text match and 4 SDs reach 100% that way. Both generators DO interpolate the id on a degenerate fallback branch (auto-trigger-stories.mjs:1112 fr.requirement || Implement ${fr.id}; lib/sub-agents/modules/stories/execute.js:69-70). Correct statement: the healthy path never emits it, so it appears in roughly a fifth of rows by accident. UNRELIABLE, NOT DEAD.',
+  },
+  {
+    verified_by: 'validation-agent (row 5fb913a0), correcting the SD premise itself',
+    verified_at: 'sd_phase_handoffs rows for the specimen; PLAN-TO-LEAD gate roster',
+    claim: 'PREMISE CORRECTION: the SD says PLAN-TO-LEAD passed at 93 and blames FR_DELIVERY_VERIFICATION. That 29-gate PLAN-TO-LEAD roster contains NO FR gate at all.',
+    method:
+      'The fabricated 100 is real but it landed in EXEC-TO-PLAN, from FR_DELIVERY_TRACEABILITY (100/100) -- the sibling wrapper, not the LEAD-FINAL gate the SD names. Also measured: the specimen is sd_type=infrastructure (threshold 75), not the 85 I assumed. Both corrections were made before this record was written so the PRD does not inherit the wrong target.',
+  },
+  {
+    verified_by: 'validation-agent (row 5fb913a0), defect Alpha missed',
+    verified_at: 'sd_phase_handoffs, 62 LEAD-FINAL rows',
+    claim: 'SCOPE-CHANGING GAP: 0 of 62 LEAD-FINAL handoff rows contain metadata.gate_results, so FR_DELIVERY_VERIFICATION has no persisted execution record for any of the 60 most recent completed SDs.',
+    method:
+      'Enumerated the rows. The specimen s carries only sd_ref, heal_invoked, heal_invoked_at, canonical_pre_completion_write. Consequence: repairing this gate alone would fix a verdict no auditor can observe, and the seeded-defect acceptance would be demonstrable only in a unit test, never in production. LEAD-FINAL gate-result persistence must be in scope or explicitly deferred.',
+  },
+];
+
+const { error } = await s
+  .from('strategic_directives_v2')
+  .update({ metadata: { ...(sd.metadata || {}), mechanism_verifications: verifications } })
+  .eq('id', sd.id);
+if (error) { console.log('UPDATE ERR:', error.message); process.exit(1); }
+console.log('WROTE', verifications.length, 'mechanism verification(s)');

--- a/scripts/one-off/_alpha-mutants-completion-flag-harness-001.mjs
+++ b/scripts/one-off/_alpha-mutants-completion-flag-harness-001.mjs
@@ -1,0 +1,107 @@
+/**
+ * Mutation testing for SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001 (FR-6 / TS-8).
+ *
+ * "909 of 910 green" demonstrates that tests PASS. It does not demonstrate that they can
+ * DETECT. Each mutant below restores one facet of the defect this SD removes; a mutant that
+ * survives means the corresponding test coverage is decorative.
+ *
+ * Restores the original file content in a finally block, and verifies the restore.
+ */
+import { readFileSync, writeFileSync } from 'fs';
+import { execSync } from 'child_process';
+
+const CLASSIFIER = 'scripts/modules/handoff/gates/fr-delivery-classifier.js';
+const SUITES = [
+  'tests/unit/handoff/gates/fr-delivery-classifier.test.js',
+  'tests/unit/handoff/gates/fr-delivery-traceability-gate.test.js',
+  'tests/unit/handoff/lead-final-gate-results-persistence.test.js',
+];
+
+const MUTANTS = [
+  {
+    name: 'M1 restore the warn-only score:100 pin',
+    detail: 'The original defect: report a perfect score whenever not enforcing.',
+    file: CLASSIFIER,
+    find: '  const score = total === 0 ? NOT_MEASURED_SCORE : Math.round((satisfied / total) * 100);',
+    replace: '  const score = enforced ? (total === 0 ? NOT_MEASURED_SCORE : Math.round((satisfied / total) * 100)) : 100;',
+  },
+  {
+    name: 'M2 collapse UNVERIFIABLE back into UNDELIVERED',
+    detail: 'Removes the distinction between blindness and absence.',
+    file: CLASSIFIER,
+    find: '  const unmeasurable = !conventionInUse && hasWorkProduct;',
+    replace: '  const unmeasurable = false;',
+  },
+  {
+    name: 'M3 decide the convention PER-FR instead of PER-SD',
+    detail: 'Makes every unreferenced FR unverifiable, so UNDELIVERED becomes unreachable.',
+    file: CLASSIFIER,
+    find: '  const conventionInUse = resolved.some((r) => r.deliveredBy);',
+    replace: '  const conventionInUse = resolved.every((r) => r.deliveredBy);',
+  },
+];
+
+function runSuites() {
+  // Parse the summary line, NOT the exit code: vitest can exit non-zero for reasons unrelated
+  // to assertions (the repo's DB-guard preamble, unhandled warnings), and a -1 "unparsed"
+  // reading would be indistinguishable from a surviving mutant.
+  let out;
+  try {
+    out = execSync(`npx vitest run ${SUITES.join(' ')}`, {
+      encoding: 'utf8', stdio: 'pipe', maxBuffer: 40 * 1024 * 1024,
+    });
+  } catch (e) {
+    out = (e.stdout || '') + (e.stderr || '');
+  }
+  const failed = /Tests\s+(\d+)\s+failed/.exec(out);
+  const passed = /Tests\s+.*?(\d+)\s+passed/.exec(out);
+  if (failed) return { out, failed: Number(failed[1]) };
+  if (passed) return { out, failed: 0 };
+  return { out, failed: -1 };   // could not read the summary at all
+}
+
+const original = readFileSync(CLASSIFIER, 'utf8');
+const results = [];
+try {
+  console.log('=== BASELINE (unmutated) ===');
+  const base = runSuites();
+  const basePass = /Tests\s+(\d+)\s+passed/.exec(base.out);
+  console.log(`baseline: ${basePass ? basePass[1] : '?'} passed, ${base.failed} failed\n`);
+  if (base.failed !== 0) {
+    console.log('BASELINE IS NOT GREEN — mutation results would be meaningless. Aborting.');
+    process.exit(1);
+  }
+
+  for (const mut of MUTANTS) {
+    const src = readFileSync(mut.file, 'utf8');
+    if (!src.includes(mut.find)) {
+      console.log(`${mut.name}: ANCHOR NOT FOUND — mutation did not apply. Treating as INVALID.`);
+      results.push({ name: mut.name, failed: null, applied: false });
+      continue;
+    }
+    writeFileSync(mut.file, src.replace(mut.find, mut.replace));
+    // Confirm the mutation is actually on disk: an unapplied mutant is indistinguishable
+    // from one the tests survived, and would silently read as "coverage is fine".
+    const applied = readFileSync(mut.file, 'utf8').includes(mut.replace);
+    const r = runSuites();
+    console.log(`${mut.name}\n   ${mut.detail}\n   applied=${applied}  ->  ${r.failed} test(s) FAILED`);
+    results.push({ name: mut.name, failed: r.failed, applied });
+    writeFileSync(mut.file, original);
+  }
+} finally {
+  writeFileSync(CLASSIFIER, original);
+  const restored = readFileSync(CLASSIFIER, 'utf8') === original;
+  console.log(`\nrestore verified: ${restored}`);
+  if (!restored) console.log('!!! FILE NOT RESTORED — restore by hand before committing');
+}
+
+console.log('\n=== MUTANT SUMMARY ===');
+let survivors = 0;
+for (const r of results) {
+  const verdict = r.applied === false ? 'INVALID (not applied)' : r.failed > 0 ? `FALSIFIED (${r.failed} failing)` : 'SURVIVED — coverage gap';
+  if (r.applied !== false && r.failed === 0) survivors++;
+  console.log(`  ${r.name}: ${verdict}`);
+}
+console.log(survivors === 0
+  ? '\nAll mutants falsified — the suite DETECTS, it does not merely pass.'
+  : `\n${survivors} mutant(s) SURVIVED — that coverage is decorative and must be strengthened.`);

--- a/scripts/one-off/_alpha-probe-fr-classifier-population.mjs
+++ b/scripts/one-off/_alpha-probe-fr-classifier-population.mjs
@@ -1,0 +1,85 @@
+/**
+ * Population probe for SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001.
+ *
+ * The specimen classified 0/6 delivered. Before concluding anything about the FR-id
+ * linkage, measure the POPULATION: run the real classifier over recent COMPLETED SDs
+ * that have a PRD with FRs, and report the distribution of delivery ratios.
+ *
+ * This decides the fix: if delivered>0 is rare across the board, the DELIVERED test
+ * (story text must contain the FR id) does not match how stories are actually authored,
+ * and enabling enforcement today would hard-fail nearly every SD. Read-only.
+ */
+import dotenv from 'dotenv';
+dotenv.config();
+import { createClient } from '@supabase/supabase-js';
+import { classifyFrDelivery } from '../modules/handoff/gates/fr-delivery-classifier.js';
+
+const s = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const LIMIT = Number(process.argv[2] || 60);
+
+const { data: sds } = await s
+  .from('strategic_directives_v2')
+  .select('id, sd_key, metadata, updated_at')
+  .eq('status', 'completed')
+  .order('updated_at', { ascending: false })
+  .limit(LIMIT);
+
+let withPrd = 0;
+const buckets = { full: 0, partial: 0, zero: 0 };
+// SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001: the ratio alone no longer decides anything. What
+// matters now is WHY an SD is short — a genuinely missing FR (the convention is in use here)
+// versus an unmeasurable one (it is not). Only the former is a real hard-fail under enforcement.
+const kinds = { allUnverifiable: 0, someUndelivered: 0, clean: 0, mixed: 0 };
+const rows = [];
+
+for (const sd of sds || []) {
+  const c = await classifyFrDelivery(s, {
+    sdId: sd.id,
+    directiveId: sd.sd_key,
+    sdMetadata: sd.metadata || {},
+  });
+  if (c.total === 0) continue;
+  withPrd++;
+  const satisfied = c.delivered + c.descoped;
+  const pct = Math.round((satisfied / c.total) * 100);
+  if (pct === 100) buckets.full++;
+  else if (pct > 0) buckets.partial++;
+  else buckets.zero++;
+
+  const unver = c.unverifiable || 0;
+  if (c.undelivered > 0 && unver > 0) kinds.mixed++;
+  else if (c.undelivered > 0) kinds.someUndelivered++;
+  else if (unver === c.total) kinds.allUnverifiable++;
+  else kinds.clean++;
+
+  rows.push({
+    key: sd.sd_key, total: c.total, delivered: c.delivered, descoped: c.descoped,
+    undelivered: c.undelivered, unverifiable: unver, conventionInUse: c.convention_in_use, pct,
+  });
+}
+
+console.log(`Scanned ${sds.length} most-recent COMPLETED SDs; ${withPrd} had a PRD with >=1 FR.\n`);
+console.log('DISTRIBUTION OF FR-DELIVERY RATIO (as the shipped classifier computes it):');
+console.log(`  100% satisfied : ${buckets.full}`);
+console.log(`  partial (1-99%): ${buckets.partial}`);
+console.log(`  0% satisfied   : ${buckets.zero}`);
+const ratioShort = buckets.partial + buckets.zero;
+console.log(`\n  (ratio-short, the OLD hard-fail set): ${ratioShort}/${withPrd}` +
+  (withPrd ? ` (${Math.round((ratioShort / withPrd) * 100)}%)` : ''));
+
+console.log('\nWHY EACH SD IS SHORT (the distinction the repair introduces):');
+console.log(`  fully UNVERIFIABLE (convention not in use — blindness, not absence): ${kinds.allUnverifiable}`);
+console.log(`  has genuinely UNDELIVERED FR(s) (convention IS in use here)        : ${kinds.someUndelivered}`);
+console.log(`  mixed undelivered + unverifiable                                    : ${kinds.mixed}`);
+console.log(`  clean (all delivered or approver-descoped)                          : ${kinds.clean}`);
+
+const realFail = kinds.someUndelivered + kinds.mixed;
+console.log(`\nWOULD HARD-FAIL UNDER ENFORCEMENT, AFTER THE REPAIR: ${realFail}/${withPrd}` +
+  (withPrd ? ` (${Math.round((realFail / withPrd) * 100)}%)` : '') +
+  `\n  — down from ${ratioShort}/${withPrd}. The difference is SDs that were being blamed for` +
+  `\n    non-delivery when the gate simply could not see them.`);
+
+console.log('\nPer-SD detail (satisfied/total | undelivered | unverifiable | convention-in-use):');
+for (const r of rows) {
+  console.log(`  ${String(r.pct).padStart(3)}%  ${r.delivered + r.descoped}/${r.total}  undel=${r.undelivered} unver=${r.unverifiable} conv=${r.conventionInUse ? 'YES' : 'no '}  ${r.key}`);
+}

--- a/scripts/one-off/_alpha-probe-fr-classifier-specimen.mjs
+++ b/scripts/one-off/_alpha-probe-fr-classifier-specimen.mjs
@@ -1,0 +1,56 @@
+/**
+ * Ground-truth probe for SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001.
+ *
+ * Runs the REAL classifier + the REAL gate projection against the 93-scored specimen
+ * (SD-FDBK-INFRA-WORKER-LOOP-DIRECTIVE-001) so the diagnosis rests on what the code
+ * actually computes, not on reading it. Read-only: no writes anywhere.
+ */
+import dotenv from 'dotenv';
+dotenv.config();
+import { createClient } from '@supabase/supabase-js';
+import {
+  classifyFrDelivery,
+  projectGateResult,
+  isFrTraceabilityEnforced,
+} from '../modules/handoff/gates/fr-delivery-classifier.js';
+
+const s = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const KEY = 'SD-FDBK-INFRA-WORKER-LOOP-DIRECTIVE-001';
+
+const { data: sd } = await s
+  .from('strategic_directives_v2')
+  .select('id, sd_key, metadata')
+  .eq('sd_key', KEY)
+  .single();
+
+const classification = await classifyFrDelivery(s, {
+  sdId: sd.id,
+  directiveId: sd.sd_key,
+  sdMetadata: sd.metadata || {},
+});
+
+console.log('=== CLASSIFICATION (real code, real data) ===');
+console.log('total       :', classification.total);
+console.log('delivered   :', classification.delivered);
+console.log('descoped    :', classification.descoped);
+console.log('undelivered :', classification.undelivered);
+for (const f of classification.frs) {
+  console.log(`  ${f.id.padEnd(6)} ${f.status.padEnd(12)} ${f.evidence}`);
+}
+
+console.log('\n=== GATE PROJECTION ===');
+console.log('env LEO_FR_TRACEABILITY_ENFORCE =', JSON.stringify(process.env.LEO_FR_TRACEABILITY_ENFORCE));
+console.log('isFrTraceabilityEnforced()      =', isFrTraceabilityEnforced());
+
+const off = projectGateResult(classification, { enforced: false, gateName: 'FR_DELIVERY_VERIFICATION' });
+const on = projectGateResult(classification, { enforced: true, gateName: 'FR_DELIVERY_VERIFICATION' });
+
+console.log('\n-- AS SHIPPED (enforced=false, the default) --');
+console.log('passed:', off.passed, '| score:', off.score, '| required:', off.required);
+console.log('issues  :', JSON.stringify(off.issues));
+console.log('warnings:', JSON.stringify(off.warnings, null, 2));
+console.log('details.raw_score:', off.details.raw_score);
+
+console.log('\n-- IF ENFORCED (enforced=true) --');
+console.log('passed:', on.passed, '| score:', on.score, '| required:', on.required);
+console.log('issues  :', JSON.stringify(on.issues, null, 2));

--- a/scripts/one-off/_alpha-probe-story-key-linkage.mjs
+++ b/scripts/one-off/_alpha-probe-story-key-linkage.mjs
@@ -1,0 +1,88 @@
+/**
+ * Verify the POSITIONAL story_key <-> FR linkage claim against DATA, not code.
+ *
+ * Explore reported (from reading the three generators) that every story is minted as
+ * story_key = `${sdKey}:US-${String(i+1).padStart(3,'0')}` while iterating
+ * prd.functional_requirements IN ARRAY ORDER, so US-00n corresponds to FR index n-1.
+ * That claim is the entire foundation of the proposed fix, and it was derived by reading
+ * writers rather than by measuring rows. Measure it.
+ *
+ * Checks, per completed SD with a PRD:
+ *   - do story_keys actually match the US-NNN shape?
+ *   - does the story COUNT equal the FR count (required for a positional map to be total)?
+ *   - are the ordinals contiguous 1..N with no gaps/dupes?
+ * Read-only.
+ */
+import dotenv from 'dotenv';
+dotenv.config();
+import { createClient } from '@supabase/supabase-js';
+
+const s = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const LIMIT = Number(process.argv[2] || 60);
+
+const { data: sds } = await s
+  .from('strategic_directives_v2')
+  .select('id, sd_key')
+  .eq('status', 'completed')
+  .order('updated_at', { ascending: false })
+  .limit(LIMIT);
+
+const tally = {
+  scanned: 0, shapeOk: 0, shapeBad: 0, countMatch: 0, countMismatch: 0,
+  contiguous: 0, nonContiguous: 0, noStories: 0,
+};
+const shapes = new Map();
+const examples = [];
+
+for (const sd of sds || []) {
+  const { data: prd } = await s.from('product_requirements_v2')
+    .select('functional_requirements').eq('directive_id', sd.sd_key).maybeSingle();
+  const frs = (prd && prd.functional_requirements) || [];
+  if (!frs.length) continue;
+
+  const { data: stories } = await s.from('user_stories')
+    .select('story_key, status, validation_status').eq('sd_id', sd.id);
+  tally.scanned++;
+  if (!stories || !stories.length) { tally.noStories++; continue; }
+
+  const keys = stories.map((x) => x.story_key || '');
+  // record observed shape (mask digits) to see if US-NNN is really universal
+  for (const k of keys) {
+    const shape = k.replace(/\d+/g, 'N');
+    shapes.set(shape, (shapes.get(shape) || 0) + 1);
+  }
+  const ords = keys
+    .map((k) => { const m = /US-(\d+)\s*$/.exec(k); return m ? Number(m[1]) : null; })
+    .filter((n) => n != null)
+    .sort((a, b) => a - b);
+
+  const allShaped = ords.length === keys.length;
+  allShaped ? tally.shapeOk++ : tally.shapeBad++;
+
+  const countsEqual = keys.length === frs.length;
+  countsEqual ? tally.countMatch++ : tally.countMismatch++;
+
+  const contiguous = ords.length > 0 && ords.every((n, i) => n === i + 1);
+  contiguous ? tally.contiguous++ : tally.nonContiguous++;
+
+  if (examples.length < 8) {
+    examples.push({ key: sd.sd_key, frs: frs.length, stories: keys.length, ords: ords.join(','), sample: keys[0] });
+  }
+}
+
+console.log('=== POSITIONAL LINKAGE, MEASURED ===');
+console.log(`SDs with a PRD carrying >=1 FR : ${tally.scanned}`);
+console.log(`  no stories at all            : ${tally.noStories}`);
+console.log(`  ALL story_keys match US-NNN  : ${tally.shapeOk}   (some/none: ${tally.shapeBad})`);
+console.log(`  story COUNT == FR COUNT      : ${tally.countMatch}   (mismatch: ${tally.countMismatch})`);
+console.log(`  ordinals contiguous 1..N     : ${tally.contiguous}   (gapped/dupe: ${tally.nonContiguous})`);
+
+console.log('\nOBSERVED story_key SHAPES (digits masked as N):');
+for (const [shape, n] of [...shapes.entries()].sort((a, b) => b[1] - a[1]).slice(0, 12)) {
+  console.log(`  ${String(n).padStart(5)}  ${shape}`);
+}
+
+console.log('\nEXAMPLES:');
+for (const e of examples) {
+  console.log(`  ${e.key}\n     FRs=${e.frs} stories=${e.stories} ords=[${e.ords}] sample_key=${e.sample}`);
+}

--- a/scripts/one-off/_alpha-retro-completion-flag-harness-001.mjs
+++ b/scripts/one-off/_alpha-retro-completion-flag-harness-001.mjs
@@ -1,0 +1,120 @@
+/**
+ * Genuine post-implementation retrospective for SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001.
+ *
+ * WHY A NEW ROW RATHER THAN A TIMESTAMP NUDGE: an SD_COMPLETION retrospective already existed
+ * (37ff07e3), created 2026-08-01T11:06:37.265Z — 563ms before the gate's threshold, but also
+ * BEFORE the PRD existed (11:10:57) and roughly an hour before any implementation code was
+ * written. It is an artifact claiming to summarise a completion, produced before the completion.
+ * That is the same family as the defect this SD repairs, so beating the timestamp on it would
+ * have been the wrong move twice over. This row records what actually happened.
+ *
+ * Idempotent on the marker in metadata.
+ */
+import dotenv from 'dotenv';
+dotenv.config();
+import { createClient } from '@supabase/supabase-js';
+
+const s = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const SD_UUID = '222e317f-926c-4d5c-99eb-b98ee8d24f53';
+const MARKER = 'alpha_post_implementation_retro_v1';
+
+const existing = await s.from('retrospectives').select('id, metadata').eq('sd_id', SD_UUID);
+if ((existing.data || []).some((r) => r.metadata && r.metadata.marker === MARKER)) {
+  console.log('ALREADY PRESENT');
+  process.exit(0);
+}
+
+const row = {
+  sd_id: SD_UUID,
+  retro_type: 'SD_COMPLETION',
+  project_name: 'FR-Delivery Gate: Honest Scoring and the UNVERIFIABLE State',
+  title: 'SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001 Retrospective (post-implementation)',
+  description:
+    'Repaired the FR-delivery completion gate, which reported a fabricated score of 100 whenever it could not measure delivery. Written AFTER implementation, unlike the pre-work SD_COMPLETION row 37ff07e3 that this supersedes.',
+  conducted_date: new Date().toISOString(),
+  agents_involved: ['LEAD', 'PLAN', 'EXEC'],
+  sub_agents_involved: ['Explore', 'VALIDATION', 'RETRO', 'RCA', 'TESTING', 'SECURITY'],
+  human_participants: [],
+  what_went_well: [
+    'The diagnosis was EXECUTED, not read. Running the real classifier against the real specimen row turned a filed claim of "2 of 6 FRs unbuilt scored 93" into the measured fact that the gate computed 0 delivered / 6 undelivered and still reported 100.',
+    'A cheap and apparently perfect fix was found AND killed before it shipped. The positional story_key linkage is real and confirmed in data (49/49 SDs with contiguous US-NNN ordinals), but executed against the specimen it returns 6/6 DELIVERED including the two FRs that SD s own metadata records as not delivered. It would have converted a loud wrong answer into a quiet one.',
+    'The variance check generalised. status=completed 275/275 and validation_status=validated 275/275 are constants, and a variable with zero variance carries zero information — so the classifier s "validated story" precondition was a tautology, not a filter.',
+    'Adversarial validation was invited rather than avoided: the VALIDATION agent was explicitly told to argue FOR the fix I preferred to reject, and it refuted three of my claims and found a scope-changing defect I had missed (0 of 62 LEAD-FINAL rows persist gate_results).',
+    'An existing test caught a real flaw in the new design. The zero-stories hard-fail case was right to object, and it produced the has_work_product distinction: blindness needs something to be blind to.',
+    'Mutants were verified PRESENT ON DISK before being run, so a mutation that failed to apply could not be misread as one the suite survived.',
+  ],
+  what_needs_improvement: [
+    'I asserted "no writer ever emits the FR id into story text" as an absolute. Grep killed it: 146 stories carry one, 34 FRs across 10 SDs classify DELIVERED on text match. The healthy path never emits it; the accident path does, in about a fifth of rows. An absolute was the wrong shape for a claim I had sampled rather than enumerated.',
+    'My blast-radius arithmetic assumed ~23 equal-weight gates. Rosters are 29-43 (mean 39.6), so my per-gate delta was wrong, and a uniform model could not see that SMALL rosters amplify the hit to -10.0.',
+    'I accepted the SD s premise that the 93 came from PLAN-TO-LEAD. That roster contains no FR gate at all; the fabricated 100 landed in EXEC-TO-PLAN via the sibling wrapper. I should have measured which handoff emitted the number before designing against it.',
+    'I hit the backtick-in-double-quoted-bash trap I already had recorded in memory, corrupting one word of a signal body.',
+    'The PRD promised each mutant would fail a DISTINCT test count; M2 and M3 both fail 2. The criterion was over-specified at PLAN time and I reported the deviation rather than reshaping the mutants to fit it.',
+  ],
+  key_learnings: [
+    'A GATE THAT CANNOT LOWER A SCORE IS NOT A GATE. The warn-only path pinned the score at 100 and moved the truth to details.raw_score, so the composite mean could not distinguish six-of-six from zero-of-six. "Zero blast radius" was purchased by making the instrument structurally unable to report a shortfall.',
+    'TWO DEFECTS CAN CONCEAL EACH OTHER AND NEITHER IS FINDABLE ALONE. The unusable measurement is why the gate shipped OFF; the fabricated 100 is why OFF looked like a pass. Each one prevented the other from being noticed, which is why this survived long enough to become the fifth green-where-blind instance.',
+    'CHECK A SIGNAL S ATTAINABLE RANGE BEFORE TRUSTING IT. If a variable is constant across the population the check runs against, it is a no-op wearing the costume of a precondition.',
+    'A FIX THAT CONVERTS A LOUD WRONG ANSWER INTO A QUIET ONE IS A REGRESSION EVEN THOUGH EVERY NUMBER IMPROVES. Text-match failing at 45/55 is visibly broken and therefore gets filed; positional matching at uniform 100% would never have been questioned.',
+    'DECIDE THE NEGATIVE CASE AT THE RIGHT SCOPE. Whether a missing reference means UNDELIVERED or UNVERIFIABLE cannot be decided per-FR — it depends on whether the SD uses the convention at all. Deciding it per-FR makes UNDELIVERED unreachable; deciding it per-SD is what gives the verdict meaning.',
+    'AN UNBOUNDED NON-FAILING STATE BECOMES A PERMANENT ESCAPE HATCH. The WAIT verdict needed a ceiling retrofitted after it was load-bearing, so UNVERIFIABLE shipped with LEO_FR_UNVERIFIABLE_CEILING on day one.',
+    'A REPAIR TO AN UNAUDITABLE VERDICT FIXES NOTHING OBSERVABLE. 0 of 62 LEAD-FINAL rows carried gate_results, so this gate had no execution record for any recent completed SD. Persistence had to be in scope or the fix would only ever be demonstrable in a unit test.',
+    'THE FIX MUST NOT EXEMPT ITSELF. This SD s own FRs classify UNVERIFIABLE under its own repaired gate, because its stories do not use the FR-reference convention either. That is correct behaviour and worth stating rather than hiding.',
+    'MEASURE THE POPULATION BEFORE PROPOSING ENFORCEMENT. 51 of 55 recent completed SDs would have hard-failed under naive enforcement, and most of those failures would have been FALSE. Enforcing a broken measurement is worse than not enforcing it.',
+    'AN UNACTIONABLE BLOCKER IS WORSE THAN A WRONG ONE. TESTING blocked with a message naming a condition already satisfied, whose remediation was a literal no-op — and whose only real remediation the harness converts into fabricated evidence.',
+  ],
+  action_items: [
+    'P0 (outside this SD, signalled 7b6afb37): plan-to-lead/state-transitions.js:119-121 stamps e2e_test_status=passing on a TRUTHY STRING with no execution — 726 stories affected, 10 pointing at a placeholder path reading "no E2E required". Fix before anything that pressures workers to populate e2e_test_path.',
+    'P1: phase4-evidence.js:90-94 emits a T1-hardcoded label for a three-term disjunction; carry the failing term in the message and the payload. 181 of 422 BLOCKED rows across 78 SDs.',
+    'P2: leo_sub_agents.depends_on does not exist, so the orchestrator has run every sub-agent concurrently since 2026-01-29. Add a schema-contract test asserting every column the orchestrator filters on exists — that catches the class.',
+    'P3: RETRO generated an SD_COMPLETION retrospective at 11:06, before the PRD existed and an hour before implementation. A completion artifact produced before completion is the same defect family this SD repairs.',
+    'Follow-up: promote FR delivery enforcement once story->FR linkage is actually recorded; the ceiling is the ratchet.',
+    'Follow-up: the six sibling completion checks enumerated in the Explore evidence row can each pass without evidence — a separate single-representation SD.',
+  ],
+  quality_score: 90,
+  business_value_delivered: 'HIGH',
+  customer_impact: 'LOW',
+  technical_debt_addressed: true,
+  technical_debt_created: false,
+  bugs_found: 3,
+  bugs_resolved: 1,
+  tests_added: 24,
+  objectives_met: true,
+  on_schedule: true,
+  within_scope: true,
+  success_patterns: ['Execute rather than read', 'Falsify your own preferred fix', 'Adversarial validation invited', 'Mutants verified applied before trusting the result'],
+  failure_patterns: ['Absolute claims from sampled evidence', 'Arithmetic from an unmeasured roster size', 'Inheriting a filing premise without measuring it'],
+  improvement_areas: ['Measure before asserting', 'Scope every absolute', 'Re-read own memory before shell quoting'],
+  generated_by: 'MANUAL',   // authored by the EXEC worker directly, not by a sub-agent
+  trigger_event: 'PLAN_TO_LEAD_HANDOFF',
+  status: 'PUBLISHED',
+  target_application: 'EHG_Engineer',
+  // learning_category: the invented 'QUALITY_GATES' was rejected by check_learning_category and
+  // the column is NOT NULL, so a value must be chosen. TESTING_STRATEGY is the closest
+  // observed-valid value: this SD is materially about the quality of verification evidence.
+  learning_category: 'TESTING_STRATEGY',
+  applies_to_all_apps: false,
+  related_commits: ['0547e5e6594'],
+  affected_components: [
+    'scripts/modules/handoff/gates/fr-delivery-classifier.js',
+    'scripts/modules/handoff/gates/fr-delivery-traceability-gate.js',
+    'scripts/modules/handoff/executors/lead-final-approval/gates.js',
+    'scripts/modules/handoff/executors/lead-final-approval/index.js',
+  ],
+  tags: ['SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001', 'green-where-blind', 'single-representation', 'post-implementation'],
+  metadata: {
+    marker: MARKER,
+    supersedes: '37ff07e3-ebb0-48ee-9d79-b0202820cdc7',
+    supersedes_reason: 'That row is retro_type=SD_COMPLETION but was created 2026-08-01T11:06:37.265Z — before the PRD existed (11:10:57) and about an hour before any implementation. It cannot be a retrospective of this work.',
+    evidence: {
+      commit: '0547e5e6594',
+      tests_passing: 52,
+      full_unit_suite: '33956 passing, 9 pre-existing failures named',
+      mutants_falsified: 3,
+      population_effect: 'would-hard-fail set 51/55 -> 12/55',
+    },
+  },
+};
+
+const { data, error } = await s.from('retrospectives').insert(row).select('id,retro_type,created_at');
+if (error) { console.log('INSERT ERR:', error.message); process.exit(1); }
+console.log('WROTE RETRO:', JSON.stringify(data[0]));

--- a/scripts/one-off/_alpha-verify-stories-completion-flag-harness-001.mjs
+++ b/scripts/one-off/_alpha-verify-stories-completion-flag-harness-001.mjs
@@ -1,0 +1,121 @@
+/**
+ * Per-story acceptance verification for SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001.
+ *
+ * CLAUDE_EXEC.md "User Story Acceptance Criteria Verification (MANDATORY)": bulk-updating story
+ * status to clear a gate is a protocol violation. Each story below is updated INDIVIDUALLY, by
+ * id, with the concrete evidence that proves its criterion — and the evidence is stored on the
+ * row so a later reader does not have to take this script's word for it.
+ *
+ * Doing otherwise on THIS SD in particular would be self-refuting: the SD exists because a
+ * completion gate reported a verdict it had not earned.
+ *
+ * Idempotent: skips any story already marked completed.
+ */
+import dotenv from 'dotenv';
+dotenv.config();
+import { createClient } from '@supabase/supabase-js';
+
+const s = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const SD_UUID = '222e317f-926c-4d5c-99eb-b98ee8d24f53';
+const COMMIT = '0547e5e6594';
+
+const EVIDENCE = {
+  'US-001': {
+    criterion: 'Tri-state classification: UNVERIFIABLE distinct from UNDELIVERED, decided per-SD',
+    evidence: [
+      'IMPLEMENTED: fr-delivery-classifier.js classifyFrDelivery — two-pass; PASS 2 computes conventionInUse (some FR referenced) and hasWorkProduct (>=1 validated story); unmeasurable = !conventionInUse && hasWorkProduct.',
+      'EXECUTED against the real specimen SD-FDBK-INFRA-WORKER-LOOP-DIRECTIVE-001: 6/6 unverifiable, 0 undelivered, convention_in_use=false (was 6 undelivered before).',
+      'POPULATION (55 SDs with FRs): 39 fully-unverifiable vs 12 genuinely-undelivered, where previously all 51 were reported as undelivered.',
+      'TESTS: 5 passing — specimen regression, seeded defect, zero-validated-stories stays UNDELIVERED, unvalidated stories are not work product, descope alone does not prove the convention.',
+      'MUTANTS: M2 (collapse unverifiable into undelivered) falsified by 2 tests; M3 (per-FR instead of per-SD) falsified by 2 tests.',
+    ],
+  },
+  'US-002': {
+    criterion: 'Honest scoring: the enforcement flag governs blocking only, never the reported score',
+    evidence: [
+      'IMPLEMENTED: projectGateResult now computes score = round(satisfied/total*100) unconditionally; enforced only feeds passed/required. The details.raw_score workaround is deleted.',
+      'EXECUTED on the specimen: score 0 (was 100) with passed still true in warn-only mode.',
+      'TESTS: OFF+undelivered reports 50 not 100; OFF score TRACKS the undelivered count (0 and 50) while remaining non-blocking; all-delivered still scores 100 in both modes.',
+      'MUTANT: M1 (restore the warn-only score:100 pin) falsified by 4 tests.',
+    ],
+  },
+  'US-003': {
+    criterion: 'Close the three remaining score fabrications on the LEAD-FINAL path',
+    evidence: [
+      'IMPLEMENTED: lead-final-approval/gates.js orchestrator-no-PRD and no-PRD and no-FRs paths now return NOT_MEASURED_SCORE (75) instead of 100/80/100; the validator-throw path returns ERRORED_SCORE (50) instead of 100.',
+      'SIBLING CONSUMER moved in the same commit per the writer/consumer-asymmetry rule: fr-delivery-traceability-gate.js orchestrator-parent, no-FRs and throw paths carry the identical constants.',
+      'TESTS: no-FRs asserts NOT_MEASURED_SCORE and explicitly not 100; a dedicated test asserts NOT_MEASURED_SCORE, ERRORED_SCORE and 100 are three distinct values with ERRORED < NOT_MEASURED.',
+      'INVARIANT TEST: across 6 classifications x 2 enforcement modes, score===100 implies undelivered===0 AND unverifiable===0 AND total>0.',
+    ],
+  },
+  'US-004': {
+    criterion: 'Ceiling on UNVERIFIABLE so it cannot become warn-only under a new name',
+    evidence: [
+      'IMPLEMENTED: frUnverifiableCeiling(env) reads LEO_FR_UNVERIFIABLE_CEILING; projectGateResult computes over_ceiling and escalates (issue + block when enforced).',
+      'SHIPPED DAY ONE deliberately — the WAIT verdict needed WAIT_MAX_ATTEMPTS retrofitted after it was already load-bearing.',
+      'EXECUTED: ceiling 1.0 enforced -> passed=true; ceiling 0.5 enforced -> passed=false with the ceiling named in issues; warn-only never blocks even at ceiling 0.',
+      'TESTS: 4 passing, including that exceeding the ceiling yields an OBSERVABLY DIFFERENT result from staying within it, and that bad env values fail safe to 1.',
+    ],
+  },
+  'US-005': {
+    criterion: "Persist LEAD-FINAL gate results so this gate's verdict is auditable at all",
+    evidence: [
+      'IMPLEMENTED: projectGateResultsForPersistence() exported from lead-final-approval/index.js and wired into the canonical LFA row as metadata.gate_results.',
+      'MEASURED GAP IT CLOSES: 0 of 62 LEAD-FINAL handoff rows carried metadata.gate_results, so this gate had no execution record for any of the 60 most recent completed SDs.',
+      'Carries fr_classification (total/delivered/descoped/undelivered/unverifiable/convention_in_use/over_ceiling) so an auditor can tell blindness from absence WITHOUT re-running the gate.',
+      'TESTS: 6 passing in tests/unit/handoff/lead-final-gate-results-persistence.test.js, including a row-bloat guard asserting per-FR descriptions are NOT persisted.',
+    ],
+  },
+  'US-006': {
+    criterion: 'Regression and seeded-defect coverage against real fixtures, with falsified mutants',
+    evidence: [
+      'TESTS: 52 passing across 5 FR-delivery suites (classifier, traceability gate, traceability wiring, LFA fail-open, gate-results persistence).',
+      'REGRESSION CASE: the 93-scored specimen classifies all-unverifiable and the gate can no longer report 100.',
+      'SEEDED DEFECT: a fixture where the convention IS in use and one named FR is unreferenced classifies UNDELIVERED and is REFUSED (passed:false, required:true) under enforcement.',
+      'MUTANTS: 3 distinct mutants each falsified, each with the mutation CONFIRMED PRESENT ON DISK before running (an unapplied mutant is indistinguishable from a survived one) — M1 4 failing, M2 2 failing, M3 2 failing. Restore verified afterwards.',
+      'FULL SUITE: 33,956 passing; the 9 failures are pre-existing and named — none of their suites import any module changed by this SD.',
+      'HONEST DEVIATION: the PRD said each mutant would fail a DISTINCT count; M2 and M3 both fail 2. Each mutant was still independently detected, which is the property that matters; the distinct-count phrasing was over-specified.',
+    ],
+  },
+};
+
+const { data: stories, error } = await s
+  .from('user_stories')
+  .select('id, story_key, status, validation_status, metadata')
+  .eq('sd_id', SD_UUID)
+  .order('story_key');
+if (error) { console.log('READ ERR:', error.message); process.exit(1); }
+
+let updated = 0;
+for (const st of stories) {
+  const key = (st.story_key || '').split(':').pop();
+  const ev = EVIDENCE[key];
+  if (!ev) { console.log(`SKIP ${st.story_key}: no evidence entry — NOT marking complete`); continue; }
+  if (st.status === 'completed') { console.log(`ALREADY COMPLETE ${st.story_key}`); continue; }
+
+  // Individual update, by id — never a blanket .eq('sd_id', ...) sweep.
+  const { error: upErr } = await s
+    .from('user_stories')
+    .update({
+      status: 'completed',
+      validation_status: 'validated',
+      implementation_status: 'implemented',
+      completed_at: new Date().toISOString(),
+      completed_by: 'Alpha (worker session e7c92ad8)',
+      metadata: {
+        ...(st.metadata || {}),
+        acceptance_verification: {
+          verified_by: 'Alpha (worker session e7c92ad8)',
+          commit: COMMIT,
+          criterion: ev.criterion,
+          evidence: ev.evidence,
+          method: 'Each item executed or asserted first-hand this session; per-story verification per CLAUDE_EXEC.md, not a bulk status sweep.',
+        },
+      },
+    })
+    .eq('id', st.id);
+  if (upErr) { console.log(`UPDATE ERR ${st.story_key}: ${upErr.message}`); process.exit(1); }
+  console.log(`VERIFIED + COMPLETED ${st.story_key} (${ev.evidence.length} evidence items)`);
+  updated++;
+}
+console.log(`\n${updated} story/stories updated individually with cited evidence.`);

--- a/tests/unit/fr-delivery-traceability-wiring.test.js
+++ b/tests/unit/fr-delivery-traceability-wiring.test.js
@@ -38,6 +38,10 @@ describe('FR-2: fail-open contract in warn-only mode', async () => {
     classifyFrDelivery: vi.fn(),
     projectGateResult: vi.fn(() => ({ passed: true, score: 100, max_score: 100, issues: [], warnings: [] })),
     isFrTraceabilityEnforced: vi.fn(() => process.env.LEO_FR_TRACEABILITY_ENFORCE === 'true'),
+    // SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001: the gate now distinguishes a non-measurement
+    // and a broken instrument from a verified delivery, so the mock must carry both constants.
+    NOT_MEASURED_SCORE: 75,
+    ERRORED_SCORE: 50,
   }));
   const { createFrDeliveryTraceabilityGate } = await import('../../scripts/modules/handoff/gates/fr-delivery-traceability-gate.js');
 

--- a/tests/unit/handoff/gates/fr-delivery-classifier.test.js
+++ b/tests/unit/handoff/gates/fr-delivery-classifier.test.js
@@ -10,6 +10,9 @@ import {
   descopeFor,
   classifyFrDelivery,
   projectGateResult,
+  frUnverifiableCeiling,
+  NOT_MEASURED_SCORE,
+  ERRORED_SCORE,
 } from '../../../../scripts/modules/handoff/gates/fr-delivery-classifier.js';
 
 describe('FR-2: isFrTraceabilityEnforced — default OFF', () => {
@@ -118,27 +121,179 @@ describe('FR-2: projectGateResult — flag gating', () => {
     expect(r.required).toBe(true);
     expect(r.issues.join(' ')).toMatch(/undelivered/i);
   });
-  it('OFF + undelivered -> warn-only (passed:true, required:false, FULL score, warning lists FR)', () => {
+  // SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001 REPLACES the two assertions that used to live here.
+  // They asserted score===100 in warn-only mode and an invariant pass-path "regardless of
+  // undelivered count" — i.e. they PINNED the defect: the gate was required by its own tests to
+  // report a perfect score while measuring a shortfall. Measured on the real specimen, that made
+  // 0-of-6 delivered indistinguishable from 6-of-6. The contract is now inverted: the flag
+  // governs BLOCKING only and never the reported score.
+  it('OFF + undelivered -> warn-only pass but the score is TRUE, not pinned at 100', () => {
     const r = projectGateResult(undeliveredClass, { enforced: false });
     expect(r.passed).toBe(true);
     expect(r.required).toBe(false);
-    expect(r.score).toBe(100);                 // NOT diluted -> zero blast radius
+    expect(r.score).toBe(50);                  // 1 of 2 satisfied — honest, not 100
     expect(r.warnings.join(' ')).toMatch(/FR-002/);
-    expect(r.details.raw_score).toBe(50);      // real coverage preserved in details
   });
-  it('OFF pass-path is invariant regardless of undelivered count', () => {
-    const many = { frs: [], total: 5, delivered: 0, descoped: 0, undelivered: 5 };
-    const r = projectGateResult(many, { enforced: false });
-    expect(r.passed).toBe(true);
-    expect(r.score).toBe(100);
+  it('OFF score TRACKS the undelivered count instead of being invariant', () => {
+    const allBad = { frs: [], total: 5, delivered: 0, descoped: 0, undelivered: 5, unverifiable: 0 };
+    const halfBad = { frs: [], total: 4, delivered: 2, descoped: 0, undelivered: 2, unverifiable: 0 };
+    expect(projectGateResult(allBad, { enforced: false }).score).toBe(0);
+    expect(projectGateResult(halfBad, { enforced: false }).score).toBe(50);
+    // still non-blocking in warn-only mode — the rollout promise that DOES survive
+    expect(projectGateResult(allBad, { enforced: false }).passed).toBe(true);
   });
-  it('all delivered -> pass either way; required mirrors the flag', () => {
-    expect(projectGateResult(allGoodClass, { enforced: false })).toMatchObject({ passed: true, required: false });
-    expect(projectGateResult(allGoodClass, { enforced: true })).toMatchObject({ passed: true, required: true });
+  it('all delivered -> pass either way, score 100; required mirrors the flag', () => {
+    expect(projectGateResult(allGoodClass, { enforced: false })).toMatchObject({ passed: true, required: false, score: 100 });
+    expect(projectGateResult(allGoodClass, { enforced: true })).toMatchObject({ passed: true, required: true, score: 100 });
   });
-  it('no FRs -> pass, required:false', () => {
+  it('no FRs -> pass but scored as NOT-MEASURED, never 100', () => {
     const r = projectGateResult({ frs: [], total: 0, delivered: 0, descoped: 0, undelivered: 0 }, { enforced: true });
     expect(r).toMatchObject({ passed: true, required: false });
+    expect(r.score).toBe(NOT_MEASURED_SCORE);
+    expect(r.score).not.toBe(100);
+    expect(r.warnings.join(' ')).toMatch(/NOT verified|not-measured/i);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001 — the repair
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('UNVERIFIABLE: per-SD convention check distinguishes blindness from absence', () => {
+  it('REGRESSION (the 93-scored specimen): no FR referenced anywhere -> all unverifiable, never 100', async () => {
+    // Mirrors SD-FDBK-INFRA-WORKER-LOOP-DIRECTIVE-001: 6 FRs, 6 validated stories, and not one
+    // story references an FR id. Shipped behaviour was 6 undelivered reported as score 100.
+    const stories = [
+      { id: 's1', title: 'Name the classifier denial verbatim', status: 'completed' },
+      { id: 's2', title: 'State the correct shape as four actions', status: 'completed' },
+      { id: 's3', title: 'Keep the second surface in sync', status: 'completed' },
+    ];
+    const c = await classifyFrDelivery(stub({ stories }), { sdId: 'sd-spec', functionalRequirements: FRS });
+    expect(c.unverifiable).toBe(3);
+    expect(c.undelivered).toBe(0);          // NOT blamed for non-delivery
+    expect(c.convention_in_use).toBe(false);
+
+    const r = projectGateResult(c, { enforced: false });
+    expect(r.score).not.toBe(100);          // the defect, gone
+    expect(r.score).toBe(0);                // zero VERIFIED delivery — accurate
+    expect(r.warnings.join(' ')).toMatch(/UNVERIFIABLE/);
+    expect(r.warnings.join(' ')).toMatch(/BLINDNESS, not evidence of absence/);
+  });
+
+  it('SEEDED DEFECT: convention IS in use and one named FR is missing -> UNDELIVERED and REFUSED', async () => {
+    // The acceptance case. FR-001 is genuinely referenced, which proves the instrument works
+    // for this SD, so FR-002's missing reference is real evidence rather than an artifact.
+    const stories = [{ id: 's1', title: 'implement FR-001 fully', status: 'completed' }];
+    const c = await classifyFrDelivery(stub({ stories }), {
+      sdId: 'sd-seeded',
+      functionalRequirements: [{ id: 'FR-001', requirement: 'a' }, { id: 'FR-002', requirement: 'b' }],
+    });
+    expect(c.convention_in_use).toBe(true);
+    expect(c.delivered).toBe(1);
+    expect(c.undelivered).toBe(1);
+    expect(c.unverifiable).toBe(0);
+
+    const enforcedResult = projectGateResult(c, { enforced: true });
+    expect(enforcedResult.passed).toBe(false);   // REFUSED
+    expect(enforcedResult.required).toBe(true);
+    expect(enforcedResult.issues.join(' ')).toMatch(/FR-002/);
+  });
+
+  it('ZERO validated stories is UNDELIVERED, not unverifiable — blindness needs something to be blind to', async () => {
+    // The distinction that matters: "stories exist but do not use the convention" is genuine
+    // blindness; "no work product exists at all" is not an excuse, it is a finding. Without
+    // this, an SD could declare FRs, build and validate nothing, and be excused as unmeasurable.
+    const c = await classifyFrDelivery(stub({ stories: [] }), { sdId: 'sd-empty', functionalRequirements: FRS });
+    expect(c.has_work_product).toBe(false);
+    expect(c.validated_story_count).toBe(0);
+    expect(c.undelivered).toBe(3);
+    expect(c.unverifiable).toBe(0);
+    expect(c.frs[0].evidence).toMatch(/nothing was built or validated/i);
+    // and it must still hard-fail under enforcement
+    expect(projectGateResult(c, { enforced: true }).passed).toBe(false);
+  });
+
+  it('unvalidated stories do not count as work product', async () => {
+    // Stories that exist but were never validated cannot carry a delivery signal either way,
+    // so they must not flip an SD out of the honest UNDELIVERED verdict.
+    const stories = [{ id: 's1', title: 'draft work', status: 'ready' }];
+    const c = await classifyFrDelivery(stub({ stories }), { sdId: 'sd-draft', functionalRequirements: FRS });
+    expect(c.has_work_product).toBe(false);
+    expect(c.undelivered).toBe(3);
+    expect(c.unverifiable).toBe(0);
+  });
+
+  it('a descope alone does not prove the convention is in use', async () => {
+    // Work product exists (a validated story) but references no FR id, so the convention is
+    // not in use; the descope is honoured and the remaining FR is unmeasurable rather than
+    // blamed. A descope is an approval record, not evidence that the reference convention works.
+    const stories = [{ id: 's1', title: 'some unrelated work', status: 'completed' }];
+    const c = await classifyFrDelivery(stub({ stories }), {
+      sdId: 'sd-descope-only',
+      functionalRequirements: [{ id: 'FR-001', requirement: 'a' }, { id: 'FR-002', requirement: 'b' }],
+      sdMetadata: { descoped_frs: [{ fr_id: 'FR-001', approved_by: 'lead' }] },
+    });
+    expect(c.descoped).toBe(1);
+    expect(c.convention_in_use).toBe(false);
+    expect(c.unverifiable).toBe(1);   // FR-002 unmeasurable, not "undelivered"
+    expect(c.undelivered).toBe(0);
+  });
+});
+
+describe('UNVERIFIABLE ceiling (shipped day one, per the WAIT-verdict precedent)', () => {
+  const allUnver = { frs: [], total: 4, delivered: 0, descoped: 0, undelivered: 0, unverifiable: 4 };
+
+  it('default ceiling tolerates a fully-unverifiable SD but still reports it', () => {
+    const r = projectGateResult(allUnver, { enforced: true, ceiling: 1 });
+    expect(r.passed).toBe(true);
+    expect(r.details.over_ceiling).toBe(false);
+  });
+  it('exceeding the ceiling produces an OBSERVABLY DIFFERENT result, not the same pass', () => {
+    const within = projectGateResult(allUnver, { enforced: true, ceiling: 1 });
+    const over = projectGateResult(allUnver, { enforced: true, ceiling: 0.5 });
+    expect(over.passed).toBe(false);
+    expect(over.passed).not.toBe(within.passed);
+    expect(over.details.over_ceiling).toBe(true);
+    expect(over.issues.join(' ')).toMatch(/ceiling/i);
+  });
+  it('the ceiling never blocks in warn-only mode', () => {
+    expect(projectGateResult(allUnver, { enforced: false, ceiling: 0 }).passed).toBe(true);
+  });
+  it('frUnverifiableCeiling parses env and fails safe on nonsense', () => {
+    expect(frUnverifiableCeiling({})).toBe(1);
+    expect(frUnverifiableCeiling({ LEO_FR_UNVERIFIABLE_CEILING: '0.4' })).toBe(0.4);
+    for (const bad of ['nonsense', '-1', '2', '']) {
+      expect(frUnverifiableCeiling({ LEO_FR_UNVERIFIABLE_CEILING: bad })).toBe(1);
+    }
+  });
+});
+
+describe('no path reports 100 without a verified full delivery', () => {
+  it('score 100 implies undelivered===0 AND unverifiable===0', () => {
+    const cases = [
+      { frs: [], total: 3, delivered: 3, descoped: 0, undelivered: 0, unverifiable: 0 },
+      { frs: [], total: 3, delivered: 1, descoped: 2, undelivered: 0, unverifiable: 0 },
+      { frs: [], total: 3, delivered: 0, descoped: 0, undelivered: 3, unverifiable: 0 },
+      { frs: [], total: 3, delivered: 0, descoped: 0, undelivered: 0, unverifiable: 3 },
+      { frs: [], total: 3, delivered: 1, descoped: 0, undelivered: 1, unverifiable: 1 },
+      { frs: [], total: 0, delivered: 0, descoped: 0, undelivered: 0, unverifiable: 0 },
+    ];
+    for (const c of cases) {
+      for (const enforced of [true, false]) {
+        const r = projectGateResult(c, { enforced });
+        if (r.score === 100) {
+          expect(c.undelivered).toBe(0);
+          expect(c.unverifiable).toBe(0);
+          expect(c.total).toBeGreaterThan(0);
+        }
+      }
+    }
+  });
+  it('a non-measurement and a broken instrument do not share a score with each other or with 100', () => {
+    expect(NOT_MEASURED_SCORE).not.toBe(100);
+    expect(ERRORED_SCORE).not.toBe(100);
+    expect(ERRORED_SCORE).not.toBe(NOT_MEASURED_SCORE);
+    expect(ERRORED_SCORE).toBeLessThan(NOT_MEASURED_SCORE);
   });
 });
 

--- a/tests/unit/handoff/lead-final-gate-results-persistence.test.js
+++ b/tests/unit/handoff/lead-final-gate-results-persistence.test.js
@@ -1,0 +1,83 @@
+// SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001 FR-5.
+//
+// Measured before this SD: 0 of 62 LEAD-FINAL handoff rows carried metadata.gate_results, so
+// FR_DELIVERY_VERIFICATION — the gate this SD was filed about — had NO persisted execution
+// record for any of the 60 most recent completed SDs. Its verdict was unobservable to an
+// auditor after the run, which is the same green-where-blind shape one level up: the gate
+// could not be audited because it never recorded that it ran.
+//
+// These tests pin the projection shape so the verdict stays queryable.
+import { describe, it, expect } from 'vitest';
+import { projectGateResultsForPersistence } from '../../../scripts/modules/handoff/executors/lead-final-approval/index.js';
+
+describe('projectGateResultsForPersistence', () => {
+  it('returns [] rather than throwing on missing/!malformed input', () => {
+    for (const bad of [undefined, null, {}, { gateResults: null }, { gateResults: 'nope' }]) {
+      expect(projectGateResultsForPersistence(bad)).toEqual([]);
+    }
+  });
+
+  it('projects name/score/passed/required per gate', () => {
+    const out = projectGateResultsForPersistence({
+      gateResults: {
+        SMOKE_TEST: { score: 100, max_score: 100, passed: true, required: true },
+        WIRE_CHECK: { score: 40, max_score: 100, passed: false, required: false },
+      },
+    });
+    expect(out).toHaveLength(2);
+    expect(out.find((g) => g.name === 'SMOKE_TEST')).toMatchObject({ score: 100, passed: true, required: true });
+    expect(out.find((g) => g.name === 'WIRE_CHECK')).toMatchObject({ score: 40, passed: false, required: false });
+  });
+
+  it('carries the FR classification so an auditor can tell UNVERIFIABLE from UNDELIVERED', () => {
+    // This is the whole point of FR-5: after the fact, "the gate scored low" is not enough.
+    // The auditor must be able to distinguish "we looked and FRs were missing" from
+    // "we could not see anything" WITHOUT re-running the gate.
+    const [entry] = projectGateResultsForPersistence({
+      gateResults: {
+        FR_DELIVERY_VERIFICATION: {
+          score: 0, max_score: 100, passed: true, required: false,
+          details: {
+            total: 6, delivered: 0, descoped: 0, undelivered: 0, unverifiable: 6,
+            convention_in_use: false, over_ceiling: false,
+            frs: [{ id: 'FR-1', description: 'a very long description '.repeat(40), status: 'unverifiable' }],
+          },
+        },
+      },
+    });
+    expect(entry.fr_classification).toEqual({
+      total: 6, delivered: 0, descoped: 0, undelivered: 0, unverifiable: 6,
+      convention_in_use: false, over_ceiling: false,
+    });
+    // An all-unverifiable SD is distinguishable from an all-undelivered one from the row alone.
+    expect(entry.fr_classification.unverifiable).toBe(6);
+    expect(entry.fr_classification.undelivered).toBe(0);
+  });
+
+  it('does NOT persist the per-FR descriptions (row-bloat guard)', () => {
+    const [entry] = projectGateResultsForPersistence({
+      gateResults: {
+        FR_DELIVERY_VERIFICATION: {
+          score: 0, passed: true, required: false,
+          details: { total: 1, unverifiable: 1, frs: [{ id: 'FR-1', description: 'SHOULD_NOT_APPEAR', status: 'unverifiable' }] },
+        },
+      },
+    });
+    expect(JSON.stringify(entry)).not.toContain('SHOULD_NOT_APPEAR');
+    expect(entry.fr_classification.frs).toBeUndefined();
+  });
+
+  it('omits fr_classification for gates that carry no classification', () => {
+    const [entry] = projectGateResultsForPersistence({
+      gateResults: { RETROSPECTIVE_EXISTS: { score: 100, passed: true, required: true, details: { note: 'n/a' } } },
+    });
+    expect(entry.fr_classification).toBeUndefined();
+  });
+
+  it('tolerates the maxScore spelling used by the orchestrator', () => {
+    const [entry] = projectGateResultsForPersistence({
+      gateResults: { X: { score: 50, maxScore: 100, passed: true, required: false } },
+    });
+    expect(entry.max_score).toBe(100);
+  });
+});

--- a/tests/unit/lead-final-fr-delivery-verification-fail-open.test.js
+++ b/tests/unit/lead-final-fr-delivery-verification-fail-open.test.js
@@ -18,6 +18,10 @@ vi.mock('../../scripts/modules/handoff/gates/fr-delivery-classifier.js', () => (
   classifyFrDelivery: vi.fn(),
   projectGateResult: vi.fn(),
   isFrTraceabilityEnforced: vi.fn(() => process.env.LEO_FR_TRACEABILITY_ENFORCE === 'true'),
+  // SD-FDBK-FIX-COMPLETION-FLAG-HARNESS-001: the gate now distinguishes a non-measurement
+  // and a broken instrument from a verified delivery, so the mock must carry both constants.
+  NOT_MEASURED_SCORE: 75,
+  ERRORED_SCORE: 50,
 }));
 
 const { classifyFrDelivery, projectGateResult } = await import('../../scripts/modules/handoff/gates/fr-delivery-classifier.js');


### PR DESCRIPTION
## Summary

`FR_DELIVERY_VERIFICATION` reported a fabricated **100** whenever it could not measure delivery — which is almost always. Measured rather than read: running the real classifier against the real specimen (`SD-FDBK-INFRA-WORKER-LOOP-DIRECTIVE-001`) gives **0 delivered / 6 undelivered, raw_score 0** — and the gate returned `passed=true score=100`.

Two defects concealed each other:

- `projectGateResult` pinned the warn-only score at 100 and hid the truth in `details.raw_score`.
- The DELIVERED test required story text to contain the FR id, which the healthy generator path never writes.

The second made the gate unusable, so it shipped OFF by default; the first made OFF indistinguishable from a pass, so nobody could see the second.

## What changed

Repaired in place, not cloned — both consumers already share `projectGateResult`, so the change propagates by construction.

- **`UNVERIFIABLE`, decided per-SD.** If no FR of an SD is referenced by any validated story, the convention is not in use here and delivery was not observable — blindness, not absence. Where the convention *is* in use, an unreferenced FR is genuinely `UNDELIVERED`. **Zero validated stories stays `UNDELIVERED`**: blindness needs something to be blind to.
- **The enforcement flag governs blocking only, never the reported score.**
- **Three fabrications closed.** A non-measurement (no PRD / no FRs / orchestrator delegation) and a thrown validator no longer share a score with a verified delivery, or with each other.
- **The ceiling ships day one** (`LEO_FR_UNVERIFIABLE_CEILING`). The WAIT verdict needed `WAIT_MAX_ATTEMPTS` retrofitted after it was load-bearing; an uncapped non-failing state is warn-only under a new name.
- **LEAD-FINAL now persists `metadata.gate_results`.** Measured: 0 of 62 rows carried any, so this gate had no execution record for any of the 60 most recent completed SDs — the repair would have fixed a verdict no auditor could observe.

## Rejected, and recorded so it is not rediscovered

Reading the positional `story_key` ordinal as a delivery signal. The linkage is real (49/49 SDs, contiguous `US-NNN`), but executed on the specimen it returns **6/6 DELIVERED** — including the two FRs that SD's own metadata records as *not delivered*. It converts a false 0 into a false 100: equally blind, opposite direction, and far harder to notice.

## Effect

| | before | after |
|---|---|---|
| would hard-fail under enforcement | 51/55 | **12/55** |
| specimen gate score | 100 | **0** |

The 39 difference were being blamed for non-delivery when the gate simply could not see them. Enforcement becomes thinkable for the first time.

**Cost of telling the truth, stated rather than promised away:** mean composite delta **-2.26** points, worst **-10.0** on a small roster, **2 of 62** handoffs newly crossing below threshold. Default stays non-blocking.

## Verification

- 52 tests passing across 5 FR-delivery suites; coverage on changed modules **95.57% lines / 100% functions**.
- **3 mutants each falsified**, with each mutation confirmed present on disk before running (an unapplied mutant is indistinguishable from a survived one): restoring the 100 pin (4 failing), collapsing `UNVERIFIABLE` into `UNDELIVERED` (2), deciding the convention per-FR (2).
- Full unit suite **33,956 passing**; the 9 failures are pre-existing — none of their suites import any module changed here.

## Note

This SD's own FRs classify `UNVERIFIABLE` under its own repaired gate, because its stories don't use the FR-reference convention either. That is correct behaviour — the fix does not exempt itself.

`EXEC-TO-PLAN` was cleared with the documented bypass: 42 of 44 gates passed and both failures were the same TESTING verdict, which RCA established is unsatisfiable by construction for a `bugfix` SD in this repo. Details and the P0 findings that came out of it are in signals `7b6afb37` / `e18f98f9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
