### PR TITLE
fix(QF-20260801-998): re-guard what the walk-up fix accidentally un-guarded

### DIFF
--- a/lib/worktree-quota.js
+++ b/lib/worktree-quota.js
@@ -31,7 +31,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 // SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 (FR-4): shared reapability predicate,
 // used to exclude owned/dirty/unpushed dirs from the ORPHAN_DETECTED count.
-import { isReapable } from './worktree-reapability.js';
+import { isReapable, WORKTREE_CONTAINER_DIRS } from './worktree-reapability.js';
 // SD-FDBK-INFRA-DISK-FULL-RECURS-001: reuse the canonical free-space reader (statfs-based, returns
 // undefined when unreadable) so the disk-floor guard and the node_modules-isolation decision share one
 // SSOT. No import cycle: worktree-provision.js does not import this module.
@@ -85,7 +85,12 @@ export function createDiskPressureError(freeBytes, floorBytes) {
  * by these names. The new counter does not need this list because helper dirs
  * are never registered worktrees, but the export stays for backward-compat.
  */
-export const WORKTREE_QUOTA_HELPERS = new Set(['_archive', 'qf', 'sd', 'adhoc']);
+// QF-20260801-998: re-exported, no longer redefined. isReapable needs the same list
+// (it is the SSOT four removal paths consult) and this module imports that one, so the
+// definition moved down to lib/worktree-reapability.js to avoid an import cycle. Two
+// copies would have drifted the moment either was edited — and only one of them guards
+// deletion.
+export const WORKTREE_QUOTA_HELPERS = WORKTREE_CONTAINER_DIRS;
 
 /**
  * Normalize a filesystem path for comparison. Converts backslashes to forward

--- a/lib/worktree-reapability.js
+++ b/lib/worktree-reapability.js
@@ -32,7 +32,27 @@ export const REAP_REASONS = Object.freeze({
   // Distinct from ORPHAN_CLEAN on purpose — "I looked and found nothing" and "I could
   // not look" had the same return value here, which is the whole defect.
   UNVERIFIABLE: 'unverifiable',
+  // QF-20260801-998: a CONTAINER under .worktrees/ — not a worktree at all.
+  CONTAINER_DIR: 'container_dir',
 });
+
+/**
+ * Directory names living under `.worktrees/` that are CONTAINERS, not worktrees.
+ *
+ * QF-20260801-998 — this list used to exist only in lib/worktree-quota.js, where
+ * classifyOrphanDirs skips these entries. isReapable had no equivalent, and isReapable
+ * is the SSOT that FOUR removal paths consult (worktree-manager.js, worktree-quota.js,
+ * cleanup-pending-sweep.mjs, safe-worktree-remove.mjs). These directories hold no .git
+ * of their own, so once the walk-up was closed they began reporting orphan_clean —
+ * `.worktrees/_archive` alone holds 40 archived worktrees, and it was protected before
+ * only by the false inherited dirt that SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-C
+ * removed. Protection by a bug is not protection; this makes it explicit.
+ *
+ * Defined HERE rather than in worktree-quota.js because quota imports this module
+ * (worktree-quota.js:34) — importing back would be a cycle. Quota re-exports it as
+ * WORKTREE_QUOTA_HELPERS so there stays exactly ONE definition.
+ */
+export const WORKTREE_CONTAINER_DIRS = Object.freeze(new Set(['_archive', 'qf', 'sd', 'adhoc']));
 
 /** Resolve + forward-slash + lowercase, for cross-platform path-key comparison. */
 export function normalizePath(p) {
@@ -78,13 +98,27 @@ export function runGit(args, cwd = process.cwd()) {
  * while path.resolve returns backslashes — a naive === reports every real worktree as
  * not-its-own, which silently disables the guard.
  */
+/**
+ * QF-20260801-998: `path.resolve` does NOT resolve junctions, symlinks or 8.3 short
+ * names; git's `--show-toplevel` returns the REAL path. So a genuinely-owned worktree
+ * reached through an alias compares unequal and reads as a walk-up — the guard failing
+ * in the UNDER-PROTECTIVE direction, licensing deletion of a tree holding uncommitted
+ * work. Latent rather than live (the current layout has no alias), but the DB-persisted
+ * path at cleanup-pending-sweep.mjs:245 originates from sd-start.js and is the way one
+ * would enter. realpath both sides before comparing; fall back to the given path when
+ * it cannot be resolved, so a missing directory still compares as before.
+ */
+function realPathOrSelf(p) {
+  try { return fs.realpathSync.native(p); } catch { return p; }
+}
+
 function resolveWorktreeRoot(wtPath, gitRunner) {
   try {
     const res = gitRunner(['rev-parse', '--show-toplevel'], wtPath);
     if (!res || res.code !== 0) return { ownsGitState: false, toplevel: null };
     const toplevel = String(res.stdout || '').trim();
     if (!toplevel) return { ownsGitState: false, toplevel: null };
-    return { ownsGitState: normalizePath(toplevel) === normalizePath(wtPath), toplevel };
+    return { ownsGitState: normalizePath(realPathOrSelf(toplevel)) === normalizePath(realPathOrSelf(wtPath)), toplevel };
   } catch {
     // A THROWN runner is an unknown, not a definitive "no git here" — say so by
     // claiming ownership, which routes the caller into its unknown handling.
@@ -217,6 +251,16 @@ export function countUnpushedCommitsResult(wtPath, { gitRunner = runGit, upstrea
  */
 export function isReapable(worktreePath, opts = {}) {
   const { liveOwner = false, gitRunner = runGit, upstream = 'origin/main' } = opts;
+
+  // QF-20260801-998: checked FIRST, ahead of even live_owner, because this is a
+  // STRUCTURAL fact about the path rather than an observation of mutable state — no
+  // reading of ownership, dirt or heartbeats can make a container safe to delete.
+  // Reason precedence for the other three (live_owner > dirty_tree > unpushed) is
+  // unchanged.
+  if (WORKTREE_CONTAINER_DIRS.has(path.basename(String(worktreePath || '')))) {
+    return { reapable: false, reason: REAP_REASONS.CONTAINER_DIR };
+  }
+
   if (liveOwner) return { reapable: false, reason: REAP_REASONS.LIVE_OWNER };
 
   const dirty = collectDirtyStatus(worktreePath, { gitRunner });

--- a/scripts/coordinator-charter-audit.mjs
+++ b/scripts/coordinator-charter-audit.mjs
@@ -20,6 +20,7 @@
 import 'dotenv/config';
 import { createRequire } from 'node:module';
 import { join } from 'node:path';
+import { existsSync } from 'node:fs'; // QF-20260801-998: DUTY-8b stranded-worktree probe
 import { createClient } from '@supabase/supabase-js';
 import { getDbNowMs } from '../lib/fleet/db-clock.mjs';
 import { isProcessRunning } from '../lib/heartbeat-manager.mjs';
@@ -36,6 +37,11 @@ import {
   detectAutoRefillBacklog,
   // SD-REFILL-00R7REXL: DUTY-3b — in_progress + unclaimed orphans (invisible to DUTY-2/3/4/5/7/8/9).
   detectInProgressOrphans,
+  // QF-20260801-998: DUTY-8b — stranded workers. Shipped unwired by
+  // SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-C: the detector was unit-tested but
+  // never imported here, so it never ran. Unit-testing a detector proves it BEHAVES;
+  // only the call site proves it is ASKED.
+  detectStrandedWorker,
 } from '../lib/coordinator/charter-audit-detectors.mjs';
 // SD-LEO-INFRA-AUTO-REFILL-SELECTION-GATE-001-E: the -B dry-run verifier supplies the promotable count.
 import { verifyStagedCandidates } from '../lib/sourcing-engine/refill-dry-run-verifier.js';
@@ -305,6 +311,20 @@ async function main() {
     // the full `live` set (heartbeat|armed-silence|PID) NOT liveWorkers, so a long-Task worker whose claim
     // was transiently hard-cap-released (still heartbeating its sd_key) is never mis-flagged (c1df435f).
     orphan: detectInProgressOrphans({ sds, liveSessions: live, classifyIneligibility: classifyDispatchIneligibility, nowMs, minAgeMs: ORPHAN_MIN_AGE_MS }),
+    // QF-20260801-998: DUTY-8b — a worker whose worktree is missing or is not a worktree
+    // root. Invisible to DUTY-8 above, which reads liveness: a stranded worker is ALIVE
+    // with a green heartbeat, which is exactly why its SD flatlines unnoticed. The fs
+    // probe is injected (never called inside the detector) so the detector stays pure
+    // and its fixtures keep running against injected state rather than this machine.
+    stranded: detectStrandedWorker({
+      liveSessions: liveWorkers, nowMs, isWithinArmedSilence: isWithinArmedSilenceWindow,
+      probeWorktree: (p) => ({
+        exists: existsSync(p),
+        // A real worktree carries a `.git` FILE (a `gitdir:` pointer); a stranded
+        // leftover carries none. Absence of .git is the stranding, not an error.
+        isWorktreeRoot: existsSync(join(p, '.git')),
+      }),
+    }),
   };
 
   const flag = (r) => (r.remediation ? '  ⚠ ' + r.remediation : '');
@@ -321,6 +341,7 @@ async function main() {
   console.log('  DUTY-8 PROGRESS-STALL: ' + D.progress.detail + flag(D.progress)); // PROGRESS-STALL-DETECTION-001
   console.log('  DUTY-9 LEAD-AGING    : ' + D.leadAging.detail + flag(D.leadAging)); // ADAM-VISION-SD-FLOW-001
   console.log('  DUTY-3b IN-PROG ORPHAN: ' + D.orphan.detail + flag(D.orphan)); // SD-REFILL-00R7REXL
+  console.log('  DUTY-8b STRANDED WKR : ' + D.stranded.detail + flag(D.stranded)); // QF-20260801-998
   // SD-LEO-INFRA-GOVERNANCE-ROLE-ADHERENCE-DBVALIDATION-001 (FR-3) — coordinator mirror adherence.
   if (D.srcCap) console.log('  SOURCE-TO-CAPACITY   : ' + D.srcCap.detail + flag(D.srcCap));
   if (D.d3lean) console.log('  D3-LEAN (coord/Adam) : ' + D.d3lean.detail + flag(D.d3lean));

--- a/tests/unit/worktree-reaper/container-and-alias-guards.test.js
+++ b/tests/unit/worktree-reaper/container-and-alias-guards.test.js
@@ -11,7 +11,6 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { execFileSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import {

--- a/tests/unit/worktree-reaper/container-and-alias-guards.test.js
+++ b/tests/unit/worktree-reaper/container-and-alias-guards.test.js
@@ -1,0 +1,141 @@
+/**
+ * QF-20260801-998 — three defects found AFTER SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-C
+ * merged (PR #6719). Each one is a guard that stopped guarding, or never started.
+ *
+ * The unifying lesson: closing the walk-up removed a bug that had been ACCIDENTALLY
+ * providing protection. `.worktrees/_archive` was never safe to delete; it was merely
+ * reported dirty because the walk-up attributed the parent's dirt to it. Protection by
+ * a bug is not protection, and removing the bug exposes everything that leaned on it.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import {
+  isReapable,
+  REAP_REASONS,
+  WORKTREE_CONTAINER_DIRS,
+} from '../../../lib/worktree-reapability.js';
+import { WORKTREE_QUOTA_HELPERS } from '../../../lib/worktree-quota.js';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '../../..');
+
+describe('FIX 1 — container dirs under .worktrees/ are never reapable', () => {
+  let root;
+  beforeAll(() => {
+    root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'qf998-')));
+  });
+  afterAll(() => { try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+  it('_archive is refused, and the refusal does NOT depend on git saying anything', () => {
+    const archive = path.join(root, '_archive');
+    fs.mkdirSync(archive);
+    fs.writeFileSync(path.join(archive, 'old-worktree-contents.txt'), 'forty of these\n');
+
+    // A runner that would otherwise report the dir spotlessly clean and reapable. The
+    // guard must win anyway: it is a structural fact about the path, not an observation.
+    const cleanRunner = () => ({ code: 0, stdout: '', stderr: '' });
+    const r = isReapable(archive, { liveOwner: false, gitRunner: cleanRunner });
+    expect(r.reapable).toBe(false);
+    expect(r.reason).toBe(REAP_REASONS.CONTAINER_DIR);
+  });
+
+  it('every container name is refused — not just the one that was found on disk', () => {
+    for (const name of WORKTREE_CONTAINER_DIRS) {
+      const d = path.join(root, name);
+      fs.mkdirSync(d, { recursive: true });
+      const r = isReapable(d, { liveOwner: false, gitRunner: () => ({ code: 0, stdout: '', stderr: '' }) });
+      expect(r.reason, `container "${name}" must be refused`).toBe(REAP_REASONS.CONTAINER_DIR);
+    }
+  });
+
+  it('OPPOSITE POLARITY: an ordinary orphan is still reapable — the guard is narrow', () => {
+    const ordinary = path.join(root, 'SD-SOME-ORDINARY-ORPHAN-001');
+    fs.mkdirSync(ordinary, { recursive: true });
+    const r = isReapable(ordinary, { liveOwner: false, gitRunner: () => ({ code: 0, stdout: '', stderr: '' }) });
+    expect(r.reapable).toBe(true);
+    expect(r.reason).toBe(REAP_REASONS.ORPHAN_CLEAN);
+  });
+
+  it('ONE definition, not two — quota re-exports rather than redefining', () => {
+    // Two copies would drift the moment either was edited, and only one of them guards
+    // deletion. Identity, not deep-equality: a duplicated literal passes toEqual.
+    expect(WORKTREE_QUOTA_HELPERS).toBe(WORKTREE_CONTAINER_DIRS);
+  });
+});
+
+describe('FIX 2 — a path alias must not defeat the ownership probe', () => {
+  let root;
+  beforeAll(() => { root = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), 'qf998-alias-'))); });
+  afterAll(() => { try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* ignore */ } });
+
+  it('a DIRTY worktree reached through an alias is still protected', () => {
+    // The real directory owns its git state and is genuinely dirty.
+    const real = path.join(root, 'real-worktree');
+    fs.mkdirSync(real);
+    fs.writeFileSync(path.join(real, '.git'), 'gitdir: /somewhere\n');
+
+    // The alias: a second path that resolves to the SAME directory. git answers with the
+    // REAL path, while path.resolve leaves the alias spelling intact — which is exactly
+    // how a genuinely-owned tree came to read as a walk-up and got licensed for deletion.
+    const alias = path.join(root, 'alias-worktree');
+    let aliased = false;
+    try { fs.symlinkSync(real, alias, 'junction'); aliased = fs.existsSync(alias); } catch { aliased = false; }
+    if (!aliased) return; // unprivileged CI cannot create links; FIX 1/3 still cover the QF
+
+    const runner = (args) => {
+      if (args[0] === 'status') return { code: 0, stdout: ' M inflight.js\n', stderr: '' };
+      if (args[0] === 'rev-parse') return { code: 0, stdout: real, stderr: '' }; // git returns the REAL path
+      return { code: 0, stdout: '', stderr: '' };
+    };
+
+    const r = isReapable(alias, { liveOwner: false, gitRunner: runner });
+    expect(r.reapable).toBe(false);
+    expect(r.reason).toBe(REAP_REASONS.DIRTY_TREE);
+  });
+
+  it('OPPOSITE POLARITY: realpathing does not resurrect the walk-up it was meant to catch', () => {
+    const orphan = path.join(root, 'genuine-orphan');
+    fs.mkdirSync(orphan, { recursive: true });
+    const runner = (args) => {
+      if (args[0] === 'status') return { code: 0, stdout: ' M parent.js\n?? junk.txt\n', stderr: '' };
+      if (args[0] === 'rev-parse') return { code: 0, stdout: root, stderr: '' }; // the ANCESTOR
+      return { code: 0, stdout: '', stderr: '' };
+    };
+    const r = isReapable(orphan, { liveOwner: false, gitRunner: runner });
+    expect(r.reapable).toBe(true);
+    expect(r.reason).toBe(REAP_REASONS.ORPHAN_CLEAN);
+  });
+});
+
+describe('FIX 3 — the stranded-worker detector is actually WIRED', () => {
+  // SD-...-001-C unit-tested detectStrandedWorker thoroughly and shipped it importing
+  // nowhere, so DUTY-8b never ran. Behaviour tests prove a detector BEHAVES; only the
+  // call site proves it is ASKED. This asserts the call site, by name, in the consumer.
+  const audit = readFileSync(path.join(REPO, 'scripts/coordinator-charter-audit.mjs'), 'utf8');
+
+  it('is imported by the charter audit', () => {
+    expect(audit).toMatch(/detectStrandedWorker,?\s*\n?\s*\}?\s*from '\.\.\/lib\/coordinator\/charter-audit-detectors\.mjs'|detectStrandedWorker/);
+    const importBlock = audit.slice(0, audit.indexOf("from '../lib/coordinator/charter-audit-detectors.mjs'"));
+    expect(importBlock).toContain('detectStrandedWorker');
+  });
+
+  it('is INVOKED, not merely imported — an unused import is still dead code', () => {
+    expect(audit).toMatch(/stranded:\s*detectStrandedWorker\(/);
+  });
+
+  it('is invoked with a real fs probe and the live worker set', () => {
+    const call = audit.slice(audit.indexOf('stranded: detectStrandedWorker('));
+    expect(call.slice(0, 600)).toContain('liveSessions: liveWorkers');
+    expect(call.slice(0, 600)).toContain('probeWorktree');
+    expect(call.slice(0, 600)).toMatch(/existsSync/);
+  });
+
+  it('its finding reaches the operator — a detector nobody prints is nobody informed', () => {
+    expect(audit).toMatch(/DUTY-8b[^\n]*D\.stranded\.detail/);
+  });
+});


### PR DESCRIPTION
Follow-up to **PR #6719** (`SD-FDBK-INFRA-ORPHAN-WORKTREE-STRANDING-001-C`). Three defects found by TESTING and SECURITY sub-agents that returned **after** that PR merged. Two I verified myself against the merged code before writing a line.

## The unifying cause

Closing the walk-up removed a bug that had been **accidentally providing protection**. `.worktrees/_archive` was never safe to delete — it was merely *reported dirty* because the walk-up attributed the parent's dirt to it. **Protection by a bug is not protection**, and removing the bug exposes everything that was leaning on it.

## 1. Container dirs — verified data-loss exposure

`isReapable` is the SSOT that **four** removal paths consult, and it had no equivalent of `classifyOrphanDirs`' helper-name skip. Measured against the merged code:

```
_archive collectDirtyStatus: {"dirtyCount":0,"ownsGitState":false,"unknown":false}
_archive isReapable        : {"reapable":true,"reason":"orphan_clean"}
```

That container holds **40 archived worktrees**. Requires a caller to explicitly target it, so it is a defense-in-depth regression rather than an imminent deletion — stating that precisely so it isn't over- or under-read.

Checked **first**, ahead of `live_owner`, because it is a *structural fact about the path* rather than an observation of mutable state — no reading of ownership, dirt, or heartbeats can make a container safe to delete. Precedence among the other three is unchanged.

The list moved **down** to `worktree-reapability.js` (quota imports that module, so importing back would cycle) and quota now re-exports it. One definition, asserted by identity rather than deep-equality — two copies would drift the moment either was edited, and only one of them guards deletion.

## 2. Path aliases — the guard failing OPEN

`resolveWorktreeRoot:87` compared `path.resolve`d paths while git's `--show-toplevel` returns the **real** path. A junction-aliased **live, dirty** worktree therefore read as a walk-up and became `orphan_clean` — licensing deletion of a tree holding uncommitted work. Latent in the current layout; the DB-persisted path at `cleanup-pending-sweep.mjs:245` is how an alias would enter.

Worth naming: **the -C suite structurally could not see this**, because it wraps its fixtures in `realpathSync` and so pre-compensates for the exact flaw. A test that normalises away the hazard it should be probing is a test that cannot fail.

## 3. Dead detector — I reported FR-3 delivered and it never ran

`detectStrandedWorker` shipped with **zero non-test references**. `coordinator-charter-audit.mjs:32` imports `detectProgressStall` and wires it at `:303`; the stranded detector appeared nowhere. DUTY-8b never executed.

-C unit-tested that detector thoroughly and never verified it was *invoked*. **Behaviour tests prove a detector BEHAVES; only the call site proves it is ASKED.** Now wired with an injected fs probe, printed as `DUTY-8b`, and verified live:

```
DUTY-8b STRANDED WKR : none (live claims have attachable worktrees, or worktree_path was not measured)
```

The wiring itself is asserted — imported, **invoked**, given the live worker set and a real probe, and printed — so it cannot silently come loose again.

## Verification

Per-site mutation, each edit confirmed applied by byte-delta before the suite ran:

| Site | Applied | Killed |
|---|---|---|
| FIX-1 container guard | −65 bytes | ✅ 2 red |
| FIX-2 realpath compare | −32 bytes | ✅ 1 red |
| FIX-3 detector wiring | +48 bytes | ✅ 2 red |

FIX-2's kill confirms the junction fixture was actually created rather than silently skipped. **474 tests green across 45 adjacent suites.** Both polarities covered throughout: an ordinary orphan is still reapable, and realpathing does not resurrect the walk-up it was meant to catch.

## Still outstanding, deliberately not in this PR

SECURITY established that preserve-before-delete is **structurally blind** to gitignored / `.git`-less worktrees, and that this **predates -C** — live since `109734815d36` (2026-06-16). It also found the pre-change behaviour emitted a *false preservation receipt*, copying pristine ancestor-relative files nobody edited while omitting every file somebody did. That belongs at the delete chokepoint, ~60–120 LOC across 5 files plus junction review. Filed separately so it is not misfiled as a regression of this work and fixed in the wrong module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
