### PR TITLE
fix(SD-LEO-INFRA-SUBAGENT-VERDICT-LAUNDERED-001): stop rewriting rejecting verdicts into acceptance

### DIFF
--- a/lib/sub-agent-executor/results-storage.js
+++ b/lib/sub-agent-executor/results-storage.js
@@ -114,17 +114,46 @@ export function mapVerdict(rawVerdict) {
   // further starts mining prose for keywords, which is how the substring trap gets in.
   const REJECTING = { FAIL: 'FAIL', FAILED: 'FAIL', BLOCK: 'BLOCKED', BLOCKED: 'BLOCKED', REJECT: 'FAIL', REJECTED: 'FAIL' };
   const ACCEPTING_WITH_CAVEATS = ['PASS', 'PASSED', 'APPROVE', 'APPROVED', 'PROCEED', 'CONDITIONAL', 'CONCERN', 'CONCERNS'];
+  // NEGATION, found by review after I asked whether the scan could be defeated — it could.
+  // 'CANNOT PROCEED', 'NOT APPROVED', 'DID NOT PASS' all resolved to CONDITIONAL_PASS,
+  // because the negator is not itself a verdict token so the scan walked straight past it
+  // and landed on the accepting word behind it. Not a regression (the old `|| 'WARNING'`
+  // accepted them too) and no live row matches today — but an LLM sub-agent emitting
+  // "CANNOT PROCEED" is entirely plausible, and the exposure becomes real precisely when
+  // SUBAGENT_VERDICT_MODE=block is turned on, which is the promotion this SD exists to enable.
+  const NEGATORS = new Set(['NOT', 'NO', 'CANNOT', 'CANT', 'UNABLE', 'NEVER', 'WITHOUT', 'DENY', 'DENIED', 'FAILING']);
+  let negated = false;
+  // Still THREE tokens: every negated form observed fits ("DID NOT PASS", "SHOULD NOT
+  // PROCEED", "UNABLE TO PROCEED"). Widening to 4 to be safe would have quietly broken the
+  // bound this file documents and tests, for no case that needs it.
   for (const token of raw.split(/[^A-Z]+/).filter(Boolean).slice(0, 3)) {
+    if (NEGATORS.has(token)) { negated = true; continue; }
     if (REJECTING[token]) return REJECTING[token];
-    if (ACCEPTING_WITH_CAVEATS.includes(token)) return 'CONDITIONAL_PASS';
+    if (ACCEPTING_WITH_CAVEATS.includes(token)) {
+      // A negated pass is NOT a pass. BLOCKED rather than FAIL: the gate documents BLOCKED
+      // as "the agent could not reach a verdict. NOT a pass", which is what a negated
+      // approval actually says, and it avoids asserting an active failure we did not read.
+      // Deliberately NOT ERROR — ERROR already carries 59 live rows of real agent crashes,
+      // and adding a second meaning would dilute the one tripwire this file depends on.
+      return negated ? 'BLOCKED' : 'CONDITIONAL_PASS';
+    }
   }
 
-  // TRULY UNRECOGNISED — and now genuinely rare, which is what keeps ERROR meaningful.
-  // Of the 60 live outliers only a handful land here (e.g. 'HIGH', a severity leaked into
-  // the verdict field; 'NO_DUPLICATES_FOUND_EXTEND_EXISTING_FILES', not a verdict at all;
-  // the STRATEGY_* family). Those are exactly the rows a human should look at. Rejecting,
-  // because a value this writer cannot classify must not mean accepted; the raw input is
-  // preserved in metadata.original_verdict.
+  // TRULY UNRECOGNISED. Of the 60 live outliers only two land here — 'HIGH' (a severity
+  // leaked into the verdict column) and a findings string. Those are exactly the rows a
+  // human should look at. Rejecting, because a value this writer cannot classify must not
+  // mean accepted; the raw input is preserved in metadata.original_verdict.
+  //
+  // AMENDED AFTER REVIEW — THE TRIPWIRE IS WEAKER THAN THIS FILE FIRST CLAIMED. The
+  // original rationale was "ERROR has zero rows today, so its appearance is unambiguous".
+  // That is true of the verdict COLUMN (0 rows) but not of the input: 59 live rows carry
+  // original_verdict='ERROR' from real agent crashes, and the ERROR->ERROR identity above
+  // now routes those into verdict='ERROR' too. So going forward ERROR means EITHER "the
+  // agent crashed" (the common case) OR "this writer could not classify the verdict" (rare).
+  // Both reject, so correctness is unaffected, and metadata.original_verdict still tells
+  // the two apart — but anyone reading verdict='ERROR' as "a new value needs classifying"
+  // will be wrong most of the time. Recorded rather than quietly left standing, because
+  // this file's own design leans on that signal.
   return 'ERROR';
 }
 

--- a/lib/sub-agent-executor/results-storage.js
+++ b/lib/sub-agent-executor/results-storage.js
@@ -65,6 +65,12 @@ export const ABSENT_VERDICT = '(absent)';
  * @returns {'PASS'|'FAIL'|'BLOCKED'|'CONDITIONAL_PASS'|'WARNING'|'MANUAL_REQUIRED'|'PENDING'|'ERROR'}
  */
 export function mapVerdict(rawVerdict) {
+  // NORMALIZE FIRST. Live data carries lowercase 'pass' and 'approve-with-conditions';
+  // an exact-match-only map sends both to the fallback. Case sensitivity is safe against
+  // LAUNDERING (the fallback rejects) but not against FALSE REJECTION, and the first cut
+  // of this fix reasoned about the former and never measured the latter.
+  const raw = String(rawVerdict ?? '').trim().toUpperCase();
+
   const verdictMap = {
     PASS: 'PASS',
     FAIL: 'FAIL',
@@ -79,13 +85,47 @@ export function mapVerdict(rawVerdict) {
     // reach a verdict. NOT a pass" — and it is rejecting, which UNKNOWN should be.
     UNKNOWN: 'BLOCKED',
   };
-  // FALLBACK IS NOW REJECTING. A value the map does not model is a value this writer does
-  // not understand, and storing it as WARNING made not-understood mean accepted. The CHECK
-  // constraint forbids free text, so an unmodelled value cannot be stored verbatim — it
-  // lands on ERROR ("When execution errors occur", per the migration) with the raw input
-  // preserved in metadata.original_verdict. ERROR has zero rows today, so its appearance
-  // is an unambiguous signal that a new verdict value needs classifying.
-  return verdictMap[rawVerdict] || 'ERROR';
+  if (verdictMap[raw]) return verdictMap[raw];
+
+  // PREFIX FAMILIES — measured, not guessed. 60 live rows carry a verdict outside the map
+  // above, and ALL 60 are stored as ACCEPTING today. They are overwhelmingly SEMANTICALLY
+  // PASSING: PASS_WITH_CONCERNS x14, CONCERNS x14, PASS_WITH_CONDITIONS, APPROVE_WITH_
+  // HARDENING, PROCEED_WITH_CONCERNS, lowercase 'pass'. Sending that family straight to a
+  // rejecting fallback would turn ~30 semantically-passing rows PER MONTH into hard
+  // handoff failures the moment SUBAGENT_VERDICT_MODE=block is enabled — i.e. this SD
+  // would have broken the very promotion it exists to make possible.
+  //
+  // AND IT WOULD HAVE CONSUMED ITS OWN TRIPWIRE. The rationale for ERROR (below, and in
+  // the gate at subagent-evidence-gate.js:57-66) is that ERROR has ZERO rows, so its
+  // appearance unambiguously means "a new verdict value needs classifying". Bulk-filling
+  // ERROR with PASS_WITH_CONCERNS destroys exactly that property.
+  //
+  // A pass-with-caveats IS CONDITIONAL_PASS — the gate documents it as "a pass with
+  // caveats" (:39) and accepts it. Prefix, never `includes`: a prose FAIL verdict that
+  // merely mentions "pass" must not be read as passing, and two such rows exist (both
+  // begin "FAIL —" and are stored as accepting WARNING today, which is itself laundering
+  // this change now corrects).
+  // Scan the LEADING TOKENS, not the whole string, and take the FIRST token that carries a
+  // verdict meaning. Prefix-only matching missed STRATEGY_APPROVED_WITH_REQUIRED_ADDITIONS
+  // (a plain approval whose first word is a namespace); whole-string `includes` would read
+  // the "pass" buried inside a prose FAIL and accept it. Token order decides, so
+  // "FAIL — ... re-verified ... closed" resolves on FAIL, not on a later word.
+  // Bounded to the first 3 tokens: a verdict announces itself at the front, and scanning
+  // further starts mining prose for keywords, which is how the substring trap gets in.
+  const REJECTING = { FAIL: 'FAIL', FAILED: 'FAIL', BLOCK: 'BLOCKED', BLOCKED: 'BLOCKED', REJECT: 'FAIL', REJECTED: 'FAIL' };
+  const ACCEPTING_WITH_CAVEATS = ['PASS', 'PASSED', 'APPROVE', 'APPROVED', 'PROCEED', 'CONDITIONAL', 'CONCERN', 'CONCERNS'];
+  for (const token of raw.split(/[^A-Z]+/).filter(Boolean).slice(0, 3)) {
+    if (REJECTING[token]) return REJECTING[token];
+    if (ACCEPTING_WITH_CAVEATS.includes(token)) return 'CONDITIONAL_PASS';
+  }
+
+  // TRULY UNRECOGNISED — and now genuinely rare, which is what keeps ERROR meaningful.
+  // Of the 60 live outliers only a handful land here (e.g. 'HIGH', a severity leaked into
+  // the verdict field; 'NO_DUPLICATES_FOUND_EXTEND_EXISTING_FILES', not a verdict at all;
+  // the STRATEGY_* family). Those are exactly the rows a human should look at. Rejecting,
+  // because a value this writer cannot classify must not mean accepted; the raw input is
+  // preserved in metadata.original_verdict.
+  return 'ERROR';
 }
 
 /**

--- a/lib/sub-agent-executor/results-storage.js
+++ b/lib/sub-agent-executor/results-storage.js
@@ -27,6 +27,68 @@ import { normalizeSDId } from '../../scripts/modules/sd-id-normalizer.js';
 import { normalizePhaseToken } from './phase-token.js';
 
 /**
+ * SD-LEO-INFRA-SUBAGENT-VERDICT-LAUNDERED-001 — sentinel recorded in
+ * metadata.original_verdict when a sub-agent returns no verdict at all.
+ *
+ * Exported so tests and audit queries share ONE literal: a query hunting for absent
+ * verdicts by hard-coding the string would drift the moment this changed, and the whole
+ * point of the sentinel is that absence stays queryable.
+ */
+export const ABSENT_VERDICT = '(absent)';
+
+/**
+ * SD-LEO-INFRA-SUBAGENT-VERDICT-LAUNDERED-001.
+ *
+ * The schema allows EIGHT verdicts, not five:
+ * database/migrations/20260130_fix_sub_agent_verdict_constraint.sql widened valid_verdict
+ * to add MANUAL_REQUIRED, PENDING and ERROR, for the reason its own RCA header states —
+ * "Code emits MANUAL_REQUIRED and PENDING verdicts, but constraint only allows 5 values".
+ * Verified against the live table rather than the file: 93 MANUAL_REQUIRED and 2,330
+ * PENDING rows exist. The lossy mappings that used to live here existed only to satisfy a
+ * constraint that stopped existing in January, so each of those three is now stored AS
+ * ITSELF.
+ *
+ * WHY THE OLD MAPPING MATTERED. WARNING is an ACCEPTING verdict
+ * (subagent-evidence-gate.js:44) and the gate ALREADY classifies MANUAL_REQUIRED and
+ * PENDING as REJECT (:68). Rewriting them to WARNING upstream meant classifyVerdict was
+ * handed 'accept' and emitted NOTHING — not even the advisory warning. The gate is
+ * advisory by default (:108), so this never defeated a block that was running; it
+ * PRE-EMPTED the block someone is about to turn on. Flipping SUBAGENT_VERDICT_MODE=block
+ * today would catch none of the 141 laundered MANUAL_REQUIRED rows, and the operator
+ * would read that silence as a clean gate.
+ *
+ * Extracted as a pure function so tests can feed its OUTPUT into the gate's real
+ * classifyVerdict. Testing the mapping alone would pass while the gate stayed blind —
+ * which is the shape of the defect itself, and worth not reproducing inside its own fix.
+ *
+ * @param {string|null|undefined} rawVerdict
+ * @returns {'PASS'|'FAIL'|'BLOCKED'|'CONDITIONAL_PASS'|'WARNING'|'MANUAL_REQUIRED'|'PENDING'|'ERROR'}
+ */
+export function mapVerdict(rawVerdict) {
+  const verdictMap = {
+    PASS: 'PASS',
+    FAIL: 'FAIL',
+    BLOCKED: 'BLOCKED',
+    CONDITIONAL_PASS: 'CONDITIONAL_PASS',
+    WARNING: 'WARNING',
+    ERROR: 'ERROR',                     // was FAIL — both reject; identity is truthful
+    PENDING: 'PENDING',                 // was WARNING (accepting) — schema allows it
+    MANUAL_REQUIRED: 'MANUAL_REQUIRED', // was WARNING (accepting) — schema allows it
+    // UNKNOWN is NOT one of the eight allowed values, so it must still be translated.
+    // BLOCKED is the exact semantic match — the gate documents it as "the agent could not
+    // reach a verdict. NOT a pass" — and it is rejecting, which UNKNOWN should be.
+    UNKNOWN: 'BLOCKED',
+  };
+  // FALLBACK IS NOW REJECTING. A value the map does not model is a value this writer does
+  // not understand, and storing it as WARNING made not-understood mean accepted. The CHECK
+  // constraint forbids free text, so an unmodelled value cannot be stored verbatim — it
+  // lands on ERROR ("When execution errors occur", per the migration) with the raw input
+  // preserved in metadata.original_verdict. ERROR has zero rows today, so its appearance
+  // is an unambiguous signal that a new verdict value needs classifying.
+  return verdictMap[rawVerdict] || 'ERROR';
+}
+
+/**
  * SD-LEO-INFRA-CLAIM-TTL-LONG-SUBAGENT-TICK-001 (FR-1): refresh the owning worker's claim heartbeat
  * after a sub-agent evidence write lands. When a fleet worker session id is supplied (CLAUDE_SESSION_
  * ID — the claim owner in the fleet model), ping claude_sessions.heartbeat_at so the claim is touched
@@ -257,20 +319,11 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
     ? Math.round(results.execution_time_ms / 1000)
     : 0;
 
-  // Map verdict to database-allowed values
-  // Schema allows: PASS, FAIL, BLOCKED, CONDITIONAL_PASS, WARNING
-  const verdictMap = {
-    'PASS': 'PASS',
-    'FAIL': 'FAIL',
-    'BLOCKED': 'BLOCKED',
-    'CONDITIONAL_PASS': 'CONDITIONAL_PASS',
-    'WARNING': 'WARNING',
-    'ERROR': 'FAIL',  // Errors map to FAIL
-    'PENDING': 'WARNING',  // Pending maps to WARNING
-    'MANUAL_REQUIRED': 'WARNING',  // Manual required maps to WARNING
-    'UNKNOWN': 'WARNING'  // Unknown maps to WARNING
-  };
-  const mappedVerdict = verdictMap[results.verdict] || 'WARNING';
+  // SD-LEO-INFRA-SUBAGENT-VERDICT-LAUNDERED-001: see mapVerdict() above for the full
+  // rationale. Summary: the schema allows eight verdicts (widened 2026-01-30), the lossy
+  // MANUAL_REQUIRED/PENDING -> WARNING rewrites made rejecting verdicts ACCEPTING before
+  // the gate ever saw them, and the unmodelled fallback now rejects instead of accepting.
+  const mappedVerdict = mapVerdict(results.verdict);
 
   // Agentic Context Engineering v3.0: Compress large results
   let detailedAnalysis = results.detailed_analysis || null;
@@ -333,7 +386,17 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
 
   let metadata = {
     sub_agent_version: subAgent?.metadata?.version || '1.0.0',
-    original_verdict: results.verdict,  // Store original before mapping
+    // Store the original before mapping. SD-LEO-INFRA-SUBAGENT-VERDICT-LAUNDERED-001:
+    // ALWAYS a string, never an omitted key. When results.verdict is undefined the JSON
+    // serialiser drops the field entirely, and a MISSING key is indistinguishable from a
+    // row written by one of the other paths that never touch this writer
+    // (source=manual / validation-agent / vision-fidelity-sub-agent). That ambiguity is
+    // not academic: it produced a "45% of the table is unauditable" reading during this
+    // SD's own investigation, which was wrong by ~12,400 rows. The sentinel makes
+    // "the agent returned nothing" a queryable fact rather than an inference from silence.
+    original_verdict: (results.verdict === undefined || results.verdict === null)
+      ? ABSENT_VERDICT
+      : results.verdict,
     options: results.options || {},
     findings: results.findings || [],
     metrics: results.metrics || {},

--- a/tests/unit/subagent-verdict-absent-writer.test.js
+++ b/tests/unit/subagent-verdict-absent-writer.test.js
@@ -1,0 +1,105 @@
+/**
+ * SD-LEO-INFRA-SUBAGENT-VERDICT-LAUNDERED-001 FR-4 — the WRITER stores the sentinel.
+ *
+ * WHY THIS FILE EXISTS: review found that replacing ABSENT_VERDICT with `undefined` in
+ * results-storage.js SURVIVED the entire 37-test suite. Every FR-4 assertion there tested
+ * properties of the exported CONSTANT — that it is a string, that it is not a valid
+ * verdict — and never that storeSubAgentResults actually WRITES it. Rationale without
+ * assertion (PAT-RATIONALE-WITHOUT-ASSERTION-001).
+ *
+ * It is the same shape the sibling suite's own header warns about — "a mapper-only test
+ * passes while the gate stays blind" — reproduced one layer down: a constant-only test
+ * passes while the writer stays unwired. Two SDs earlier this same session I shipped a
+ * detector that was fully unit-tested and imported by nothing. Behaviour tests prove a
+ * value EXISTS; only the writer proves it is USED.
+ *
+ * So this drives storeSubAgentResults for real, against a stateful mock that captures the
+ * inserted row, and asserts on what LANDS.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+/** Minimal stateful Supabase double: captures inserted rows so the test asserts on the WRITE. */
+function makeMockSupabase(rows) {
+  const builder = {
+    select() { return builder; },
+    eq() { return builder; },
+    gte() { return builder; },
+    order() { return builder; },
+    limit() { return Promise.resolve({ data: [], error: null }); },
+    maybeSingle() { return Promise.resolve({ data: null, error: null }); },
+    single() { return Promise.resolve({ data: null, error: null }); },
+    insert(payload) {
+      const row = { id: `row-${rows.length + 1}`, ...payload };
+      rows.push(row);
+      return {
+        select: () => ({ single: () => Promise.resolve({ data: row, error: null }) }),
+      };
+    },
+    update() { return builder; },
+  };
+  return { from: () => builder };
+}
+
+describe('FR-4: the writer records verdict ABSENCE as a value, not an omitted key', () => {
+  let rows;
+
+  beforeEach(() => {
+    rows = [];
+    vi.doMock('../../lib/sub-agent-executor/supabase-client.js', () => ({
+      getSupabaseClient: async () => makeMockSupabase(rows),
+    }));
+    vi.doMock('../../scripts/modules/sd-id-normalizer.js', () => ({
+      normalizeSDId: async (_s, v) => v,
+    }));
+    vi.doMock('../../lib/artifact-tools.js', () => ({
+      createArtifact: async () => ({ artifact_id: 'a', token_count: 0, summary: '' }),
+    }));
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('../../lib/sub-agent-executor/supabase-client.js');
+    vi.doUnmock('../../scripts/modules/sd-id-normalizer.js');
+    vi.doUnmock('../../lib/artifact-tools.js');
+  });
+
+  it('an agent that returns NO verdict yields a row whose metadata.original_verdict is the sentinel', async () => {
+    const { storeSubAgentResults, ABSENT_VERDICT } = await import('../../lib/sub-agent-executor/results-storage.js');
+
+    await storeSubAgentResults('TESTING', 'SD-TEST-ABSENT-001', null, { confidence: 90 }, { phase: 'EXEC' });
+
+    expect(rows).toHaveLength(1);
+    const meta = rows[0].metadata;
+    // THE ASSERTION THAT WAS MISSING. Replacing ABSENT_VERDICT with `undefined` in the
+    // writer makes original_verdict vanish from the JSON — and a MISSING key is
+    // indistinguishable from a row written by one of the other paths that never touch
+    // this writer. That ambiguity produced a "45% of the table is unauditable" reading
+    // during this SD's own investigation, wrong by ~12,400 rows.
+    expect(Object.prototype.hasOwnProperty.call(meta, 'original_verdict')).toBe(true);
+    expect(meta.original_verdict).toBe(ABSENT_VERDICT);
+    expect(meta.original_verdict).not.toBeUndefined();
+  });
+
+  it('a verdict-less result still stores a REJECTING verdict — absence must not mean accepted', async () => {
+    const { storeSubAgentResults } = await import('../../lib/sub-agent-executor/results-storage.js');
+    await storeSubAgentResults('TESTING', 'SD-TEST-ABSENT-002', null, { confidence: 90 }, { phase: 'EXEC' });
+    // 15 live rows sat in exactly this state, stored as accepting WARNING.
+    expect(rows[0].verdict).toBe('ERROR');
+  });
+
+  it('OPPOSITE POLARITY: a real verdict is recorded verbatim, not overwritten by the sentinel', async () => {
+    const { storeSubAgentResults, ABSENT_VERDICT } = await import('../../lib/sub-agent-executor/results-storage.js');
+    await storeSubAgentResults('TESTING', 'SD-TEST-PRESENT-001', null, { verdict: 'PASS', confidence: 90 }, { phase: 'EXEC' });
+    expect(rows[0].metadata.original_verdict).toBe('PASS');
+    expect(rows[0].metadata.original_verdict).not.toBe(ABSENT_VERDICT);
+    expect(rows[0].verdict).toBe('PASS');
+  });
+
+  it('an UNMODELLED verdict is preserved verbatim in metadata while the column rejects', async () => {
+    const { storeSubAgentResults } = await import('../../lib/sub-agent-executor/results-storage.js');
+    await storeSubAgentResults('TESTING', 'SD-TEST-UNMODELLED-001', null, { verdict: 'HIGH', confidence: 90 }, { phase: 'EXEC' });
+    // The whole reason the defect was measurable at all is that the raw input survives.
+    expect(rows[0].metadata.original_verdict).toBe('HIGH');
+    expect(rows[0].verdict).toBe('ERROR');
+  });
+});

--- a/tests/unit/subagent-verdict-laundering.test.js
+++ b/tests/unit/subagent-verdict-laundering.test.js
@@ -179,3 +179,30 @@ describe('absence is recorded as a value, not an omitted key (FR-4)', () => {
     expect(classifyVerdict(mapVerdict(ABSENT_VERDICT))).toBe('reject');
   });
 });
+
+describe('NEGATION — a negated pass is not a pass (found by review, not by me)', () => {
+  // I asked the reviewer directly whether the token scan could be defeated. It could:
+  // the negator is not itself a verdict token, so the scan walked past it and resolved on
+  // the accepting word behind it. Every string below returned CONDITIONAL_PASS -> accept.
+  // Not a regression — the old `|| 'WARNING'` accepted them too — and no live row matches
+  // today. But an LLM sub-agent emitting "CANNOT PROCEED" is entirely plausible, and the
+  // exposure lands exactly when SUBAGENT_VERDICT_MODE=block flips on.
+  it.each([
+    'NOT A PASS', 'DID NOT PASS', 'CANNOT PROCEED', 'DO NOT PROCEED',
+    'NOT APPROVED', 'NO PASS', 'UNABLE TO PROCEED', 'SHOULD NOT PROCEED',
+  ])('%s REJECTS', (verdict) => {
+    expect(classifyVerdict(mapVerdict(verdict))).toBe('reject');
+  });
+
+  it('OPPOSITE POLARITY: the un-negated forms still ACCEPT — the guard is narrow', () => {
+    for (const v of ['A PASS', 'PASSED', 'PROCEED', 'APPROVED', 'PASS_WITH_CONCERNS']) {
+      expect(classifyVerdict(mapVerdict(v)), v).toBe('accept');
+    }
+  });
+
+  it('negation does not flip a REJECTING verdict into acceptance', () => {
+    // "NOT FAIL" is odd phrasing and rare; rejecting is the safe direction either way.
+    expect(classifyVerdict(mapVerdict('NOT FAIL'))).toBe('reject');
+    expect(classifyVerdict(mapVerdict('CANNOT BLOCK'))).toBe('reject');
+  });
+});

--- a/tests/unit/subagent-verdict-laundering.test.js
+++ b/tests/unit/subagent-verdict-laundering.test.js
@@ -69,11 +69,75 @@ describe('the unmodelled fallback no longer means "accepted" (FR-1)', () => {
     }
   });
 
-  it('is case- and whitespace-SENSITIVE, and that is safe because the fallback rejects', () => {
-    // 'pass' and 'PASS ' do not match the map. Under the old fallback they became WARNING
-    // (accepted); now they reject, so a casing bug fails loudly instead of silently passing.
-    expect(classifyVerdict(mapVerdict('pass'))).toBe('reject');
-    expect(classifyVerdict(mapVerdict('PASS '))).toBe('reject');
+  it('normalizes case and whitespace instead of rejecting on them', () => {
+    // FIRST CUT OF THIS FIX GOT THIS WRONG. It left the map case-SENSITIVE and argued the
+    // rejecting fallback made that safe. It is safe against LAUNDERING and unsafe against
+    // FALSE REJECTION — and live data carries lowercase 'pass' and 'approve-with-conditions'.
+    expect(mapVerdict('pass')).toBe('PASS');
+    expect(mapVerdict('PASS ')).toBe('PASS');
+    expect(mapVerdict('  manual_required  ')).toBe('MANUAL_REQUIRED');
+  });
+});
+
+describe('REGRESSION GUARD — the 60 live outliers must not become hard failures', () => {
+  // MEASURED, NOT IMAGINED. 60 rows carry an original_verdict outside the 9-key map and
+  // ALL 60 are stored ACCEPTING today. Sending that family to a rejecting fallback would
+  // turn ~30 semantically-passing rows/month into hard handoff failures the moment
+  // SUBAGENT_VERDICT_MODE=block is enabled — this SD would have broken the very promotion
+  // it exists to enable. Every string below is a real value from that population.
+  it.each([
+    ['PASS_WITH_CONCERNS', 14], ['CONCERNS', 14], ['PASS_WITH_CONDITIONS', 3],
+    ['CONCERNS_DISPOSITIONED', 3], ['CONCERN', 2], ['PASS_WITH_MITIGATIONS', 2],
+    ['APPROVED_WITH_CONDITIONS', 2], ['PASS_WITH_CONTRADICTIONS', 1],
+    ['PASS_WITH_FINDINGS', 1], ['APPROVE-WITH-CONDITIONS', 1], ['PROCEED_WITH_CONCERNS', 1],
+    ['PASS_WITH_RECOMMENDATIONS', 1], ['PROCEED_WITH_MITIGATION', 1],
+    ['APPROVE_WITH_HARDENING', 1], ['approve-with-conditions', 1], ['pass', 1],
+  ])('%s (x%i live) stays ACCEPTING', (verdict) => {
+    expect(classifyVerdict(mapVerdict(verdict))).toBe('accept');
+  });
+
+  it('a PROSE verdict beginning "PASS_WITH_CONCERNS —" is accepted by PREFIX, never by substring', () => {
+    const prose = 'PASS_WITH_CONCERNS — all three REQUIRED items are functionally closed and runtime-verified';
+    expect(classifyVerdict(mapVerdict(prose))).toBe('accept');
+  });
+
+  it('OPPOSITE POLARITY: a PROSE verdict beginning "FAIL —" REJECTS, even though it contains the word "pass"', () => {
+    // Two such rows exist live and are stored as accepting WARNING today — laundering this
+    // change corrects. `includes` matching would read the embedded "pass" and accept them.
+    const prose = 'FAIL — 4 of 6 prior REQUIRED items are closed and were re-verified, but the primary sd:next path is still inert';
+    expect(mapVerdict(prose)).toBe('FAIL');
+    expect(classifyVerdict(mapVerdict(prose))).toBe('reject');
+  });
+
+  it('ERROR keeps its tripwire: only genuinely unclassifiable values land there', () => {
+    // The whole rationale for ERROR — here and at subagent-evidence-gate.js:57-66 — is that
+    // it has zero rows, so its appearance means "a new value needs classifying". Bulk-filling
+    // it with PASS_WITH_CONCERNS would have destroyed that property.
+    // Both are real live values and NEITHER IS A VERDICT: 'HIGH' is a severity leaked into
+    // the column, the other is a findings string. These are precisely the rows a human
+    // should look at, so ERROR is the right destination.
+    for (const junk of ['HIGH', 'NO_DUPLICATES_FOUND_EXTEND_EXISTING_FILES']) {
+      expect(mapVerdict(junk), junk).toBe('ERROR');
+      expect(classifyVerdict(mapVerdict(junk))).toBe('reject');
+    }
+    // And the pass-family does NOT land there — that is the regression guard.
+    expect(mapVerdict('PASS_WITH_CONCERNS')).not.toBe('ERROR');
+  });
+
+  it('a namespaced verdict resolves on its MEANINGFUL token, in both directions', () => {
+    // Prefix-only matching sent both of these to ERROR because their first word is a
+    // namespace. Token order still decides, so the BLOCK one rejects and the APPROVED one
+    // does not — the same rule, not two special cases.
+    expect(mapVerdict('STRATEGY_APPROVED_WITH_REQUIRED_ADDITIONS')).toBe('CONDITIONAL_PASS');
+    expect(classifyVerdict(mapVerdict('STRATEGY_APPROVED_WITH_REQUIRED_ADDITIONS'))).toBe('accept');
+    expect(mapVerdict('STRATEGY_BLOCK_ALL_ADDITIONS_COMMITTED_TO_EXEC')).toBe('BLOCKED');
+    expect(classifyVerdict(mapVerdict('STRATEGY_BLOCK_ALL_ADDITIONS_COMMITTED_TO_EXEC'))).toBe('reject');
+  });
+
+  it('only the FIRST THREE tokens are scanned — a verdict announces itself at the front', () => {
+    // Scanning further turns classification into keyword-mining over prose, which is how a
+    // FAIL that happens to mention "passed" gets read as a pass.
+    expect(mapVerdict('SOMETHING UNRELATED ENTIRELY PASS')).toBe('ERROR');
   });
 });
 

--- a/tests/unit/subagent-verdict-laundering.test.js
+++ b/tests/unit/subagent-verdict-laundering.test.js
@@ -1,0 +1,117 @@
+/**
+ * SD-LEO-INFRA-SUBAGENT-VERDICT-LAUNDERED-001.
+ *
+ * THE DEFECT WAS THAT THE GATE WAS NEVER SHOWN THE VALUE. results-storage.js rewrote
+ * MANUAL_REQUIRED and PENDING to WARNING — an ACCEPTING verdict — and sent every
+ * unmodelled value there too via `|| 'WARNING'`. So this suite deliberately does NOT
+ * assert the mapping in isolation: it feeds the writer's OUTPUT into the gate's REAL
+ * classifyVerdict. A mapper-only test passes while the gate stays blind, which is the
+ * defect reproduced inside its own fix.
+ *
+ * MEASURED CONTEXT (all-time, live, at LEAD): 15,602 rows come from this writer;
+ * 141 are MANUAL_REQUIRED stored as WARNING; 15 had no verdict at all and were stored as
+ * WARNING. The schema has allowed eight verdicts since migration 20260130 — 93
+ * MANUAL_REQUIRED and 2,330 PENDING rows prove the widened constraint is applied.
+ */
+import { describe, it, expect } from 'vitest';
+import { mapVerdict, ABSENT_VERDICT } from '../../lib/sub-agent-executor/results-storage.js';
+import { classifyVerdict } from '../../scripts/modules/handoff/gates/subagent-evidence-gate.js';
+
+/** The eight values valid_verdict permits (migration 20260130). */
+const ALLOWED = new Set(['PASS', 'FAIL', 'BLOCKED', 'CONDITIONAL_PASS', 'WARNING', 'MANUAL_REQUIRED', 'PENDING', 'ERROR']);
+
+describe('the gate can finally SEE rejecting verdicts (FR-2)', () => {
+  it('MANUAL_REQUIRED reaches the gate as REJECT — 141 production rows were laundered here', () => {
+    // BEFORE: mapVerdict -> 'WARNING' -> classifyVerdict -> 'accept' -> no warning at all.
+    expect(mapVerdict('MANUAL_REQUIRED')).toBe('MANUAL_REQUIRED');
+    expect(classifyVerdict(mapVerdict('MANUAL_REQUIRED'))).toBe('reject');
+  });
+
+  it('PENDING reaches the gate as REJECT — tested separately because the map treated both identically', () => {
+    // Testing only MANUAL_REQUIRED and assuming PENDING followed is exactly how the second
+    // one stays broken; the old map sent both to WARNING via two distinct lines.
+    expect(mapVerdict('PENDING')).toBe('PENDING');
+    expect(classifyVerdict(mapVerdict('PENDING'))).toBe('reject');
+  });
+
+  it('ERROR is stored as itself rather than flattened to FAIL', () => {
+    // Both reject, so this is not a policy change — it is truthfulness. The old mapping
+    // discarded the distinction between "the agent rejected" and "the agent crashed".
+    expect(mapVerdict('ERROR')).toBe('ERROR');
+    expect(classifyVerdict(mapVerdict('ERROR'))).toBe('reject');
+  });
+
+  it('UNKNOWN becomes BLOCKED — not in the eight, so it must translate, and it must reject', () => {
+    expect(mapVerdict('UNKNOWN')).toBe('BLOCKED');
+    expect(classifyVerdict(mapVerdict('UNKNOWN'))).toBe('reject');
+  });
+});
+
+describe('the unmodelled fallback no longer means "accepted" (FR-1)', () => {
+  it('free text lands on a REJECTING verdict', () => {
+    // BEFORE: `|| 'WARNING'` — not-understood silently meant accepted.
+    expect(classifyVerdict(mapVerdict('NEEDS_HUMAN'))).toBe('reject');
+    expect(classifyVerdict(mapVerdict('totally-made-up'))).toBe('reject');
+  });
+
+  it('an agent that returned NOTHING lands on a REJECTING verdict — 15 production rows', () => {
+    for (const nothing of [undefined, null, '']) {
+      expect(classifyVerdict(mapVerdict(nothing)), `verdict=${JSON.stringify(nothing)}`).toBe('reject');
+    }
+  });
+
+  it('whatever the fallback produces is still a value the CHECK constraint permits', () => {
+    // The constraint forbids free text, so a fallback that passed the raw string through
+    // would fail at the database — the row would simply never be written, which is a
+    // different and worse failure than the one being fixed.
+    for (const weird of ['NEEDS_HUMAN', undefined, null, '', 'PASS ', 'pass', 42, {}]) {
+      expect(ALLOWED.has(mapVerdict(weird)), `mapVerdict(${JSON.stringify(weird)})`).toBe(true);
+    }
+  });
+
+  it('is case- and whitespace-SENSITIVE, and that is safe because the fallback rejects', () => {
+    // 'pass' and 'PASS ' do not match the map. Under the old fallback they became WARNING
+    // (accepted); now they reject, so a casing bug fails loudly instead of silently passing.
+    expect(classifyVerdict(mapVerdict('pass'))).toBe('reject');
+    expect(classifyVerdict(mapVerdict('PASS '))).toBe('reject');
+  });
+});
+
+describe('OPPOSITE POLARITY — the evidence pipeline still works (FR-3)', () => {
+  // 15,602 rows and every future handoff flow through this writer. An over-strict fix
+  // halts the fleet immediately and gets reverted under pressure, taking the real fix
+  // with it — so this block protects the fix as much as it protects the pipeline.
+  it.each([
+    ['PASS', 'PASS', 'accept'],
+    ['CONDITIONAL_PASS', 'CONDITIONAL_PASS', 'accept'],
+    ['WARNING', 'WARNING', 'accept'],
+    ['FAIL', 'FAIL', 'reject'],
+    ['BLOCKED', 'BLOCKED', 'reject'],
+  ])('%s maps to %s and the gate says %s — unchanged from before', (input, stored, verdictClass) => {
+    expect(mapVerdict(input)).toBe(stored);
+    expect(classifyVerdict(mapVerdict(input))).toBe(verdictClass);
+  });
+
+  it('a GENUINE WARNING is still accepted — it must not be swept up with the laundered ones', () => {
+    // The fix removes values that were DISGUISED as WARNING. An agent that actually
+    // returned WARNING ran to completion and reported non-blocking concerns; breaking
+    // that would reject real work.
+    expect(mapVerdict('WARNING')).toBe('WARNING');
+    expect(classifyVerdict('WARNING')).toBe('accept');
+  });
+});
+
+describe('absence is recorded as a value, not an omitted key (FR-4)', () => {
+  it('the sentinel is exported so audit queries and tests share ONE literal', () => {
+    // A query hard-coding the string would drift the moment this changed, and the entire
+    // point of the sentinel is that absence stays queryable.
+    expect(typeof ABSENT_VERDICT).toBe('string');
+    expect(ABSENT_VERDICT.length).toBeGreaterThan(0);
+  });
+
+  it('the sentinel is NOT a valid verdict, so it can never be mistaken for one', () => {
+    expect(ALLOWED.has(ABSENT_VERDICT)).toBe(false);
+    // And if it ever reached the verdict column by accident, it would reject rather than pass.
+    expect(classifyVerdict(mapVerdict(ABSENT_VERDICT))).toBe('reject');
+  });
+});


### PR DESCRIPTION
`results-storage.js` rewrote `MANUAL_REQUIRED` and `PENDING` to `WARNING` — an **accepting** verdict (`subagent-evidence-gate.js:44`) — and sent every unmodelled value there too via `|| 'WARNING'`. Rejecting verdicts arrived at the gate already laundered.

## The mappings existed to satisfy a constraint that stopped existing in January

The comment above them claimed *"Schema allows: PASS, FAIL, BLOCKED, CONDITIONAL_PASS, WARNING"* — **stale by six months**. Migration `20260130` widened `valid_verdict` to eight values, for the reason its own RCA header states: *"Code emits MANUAL_REQUIRED and PENDING verdicts, but constraint only allows 5 values."* Verified against the live table, not the file: **93 MANUAL_REQUIRED and 2,330 PENDING rows exist**.

An adjacent comment is more convincing than a remote document precisely because it reads as documentation of the code you're looking at. I encoded it as an acceptance criterion an hour before checking the migration.

## The harm is narrower than "rejections pass the gate", and worse

The gate is **advisory by default** and already classifies `MANUAL_REQUIRED`/`PENDING` as REJECT — its policy was correct all along. Laundering hands `classifyVerdict` a `WARNING`, which resolves to *accept*, so **no advisory warning fires at all**.

And because the rewrite is upstream, flipping `SUBAGENT_VERDICT_MODE=block` today would catch **none** of the 141 rows. Whoever promoted the gate would measure silence and conclude the problem was never real.

> The defect doesn't defeat a block that exists — it **pre-empts the block someone is about to turn on**.

## Verification

`mapVerdict` is extracted as a pure function so tests feed its **output into the gate's real `classifyVerdict`** — an integration assertion at the seam that matters, no mock at the boundary. Asserting the mapping alone would pass while the gate stayed blind, which is the defect reproduced inside its own fix.

**Live replay** — all 33 distinct `original_verdict` values across **15,509 rows**, shipped code vs the verbatim pre-fix mapping:

| | count |
|---|---|
| accept → reject | **146** (141 MANUAL_REQUIRED = the fix; 2 prose FAILs; 1 STRATEGY_BLOCK; 2 non-verdicts) |
| reject → accept | **0** — no laundering introduced in the other direction |

51 tests across 2 suites; 148 green across 7 adjacent suites. Per-site mutation with every edit **content-verified applied** before running.

## Three defects found in my own work, by review

**1. The first fallback would have broken the promotion this SD enables.** `|| 'ERROR'` would have flipped 60 live rows from accepting to rejecting — overwhelmingly *semantically passing* (`PASS_WITH_CONCERNS` ×14, `CONCERNS` ×14, lowercase `pass`). ~30 hard handoff failures/month under block mode. It also bulk-populated `ERROR` while my own comment justified ERROR on *"ERROR has zero rows today"* — **the fix consumed its own tripwire.**

**2. Negation defeated the token scan.** `CANNOT PROCEED`, `NOT APPROVED`, `DID NOT PASS` all resolved to *accept* — the negator isn't a verdict token, so the scan walked past it. A negated pass now maps to `BLOCKED`.

**3. FR-4 was rationale without assertion.** Replacing `ABSENT_VERDICT` with `undefined` **survived all 37 tests** — every assertion tested the exported *constant*, none tested that the writer *stores* it. New suite drives the real writer; the mutant is now killed there and still survives the old suite.

I nearly dismissed #1: my verification query returned zero because `.limit(20000)` silently capped at 1000. A capped sample and a clean bill of health are indistinguishable in the output.

## Scope discipline

Counts are scoped by `metadata.sub_agent_version` — the table has many writers and only this one passes through `verdictMap`. Table-wide counting overstates the blast radius by ~12,400 rows and produced a false "45% unauditable" reading during this SD's own investigation.

**No historical row is mutated.** Remediation is a separate decision that must not destroy its own evidence.

Filed separately: `PAT-HF-E2EMAPPED-PHANTOM-COLUMN` / `QF-20260801-425` (a gate blocking on `user_stories.e2e_mapped`, a column that returns 42703), and the `phase4-evidence.js` policy-list divergence that makes `e2e_test_path` unsatisfiable for 1,318 stories.

SD: SD-LEO-INFRA-SUBAGENT-VERDICT-LAUNDERED-001

🤖 Generated with [Claude Code](https://claude.com/claude-code)
