### PR TITLE
fix(SD-FDBK-INFRA-DECISION-QUEUE-RETIREMENT-001): the chairman queue can now learn a decision was already made

### DIFF
--- a/database/migrations/20260802_chairman_queue_age_escalation_STAGED.sql
+++ b/database/migrations/20260802_chairman_queue_age_escalation_STAGED.sql
@@ -1,0 +1,139 @@
+-- CHAIRMAN QUEUE — AGE-ESCALATION MARKER FIX (FR-5 SQL half)
+-- SD-FDBK-INFRA-DECISION-QUEUE-RETIREMENT-001
+--
+-- STAGED — NOT YET APPROVED FOR APPLY. requires-chairman-apply. Do NOT auto-apply on merge; there
+-- is no approved-by attestation on this file. CREATE OR REPLACE is TIER-2 under
+-- scripts/lib/migration-tier-classifier.mjs:323 (FC-8), so the classifier will never auto-apply it.
+--
+-- ============================ WHAT IS WRONG =============================
+-- chairman_pending_decisions computes:
+--     (effective_rank < priority_rank) AS age_escalated
+-- where effective_rank = GREATEST(1, priority_rank - bump).
+-- For priority='critical' the priority_rank is 1, the GREATEST floor absorbs the bump, and the
+-- comparison is 1 < 1 — FALSE AT ANY AGE. Every critical row is structurally unmarkable, and arm 4
+-- of the union hardcodes priority='critical', so every row that arm emits is blind by construction.
+--
+-- The rank floor itself is CORRECT: critical genuinely cannot outrank critical, and sort order
+-- depends on it. The defect is conflating "did the rank move" with "did this cross the age
+-- threshold". This migration changes ONLY the marker; effective_rank and ORDER BY are untouched,
+-- so the rendered ordering is unchanged.
+--
+-- The JS half already shipped (lib/chairman/decision-queue.mjs, `escalated: bump > 0`). This brings
+-- the SQL surface into agreement; until it is applied the two surfaces disagree, and the VIEW is the
+-- one that governs the marker for any consumer that reads age_escalated directly.
+--
+-- ======================= MEASURED IMPACT, LIVE ==========================
+-- Measured 2026-08-02 against the 7 live pending rows:
+--     marked today: 3   |   marked after this migration: 6
+--   1315d76e normal   55.6d  now=true  -> true
+--   c08f4368 normal   55.6d  now=true  -> true
+--   acb3f2eb high     21.6d  now=true  -> true
+--   3aa84300 critical 15.4d  now=FALSE -> TRUE   <- the blind class
+--   48a264b4 critical  7.6d  now=FALSE -> TRUE
+--   376d3ae5 critical  7.6d  now=FALSE -> TRUE
+--   496ac883 critical  1.1d  now=false -> false  <- control: fresh critical stays unmarked
+--
+-- READ THIS BEFORE APPLYING. Raising the marked count from 3 to 6 is an INCREASE IN NOISE unless the
+-- consumer also clocks from the chairman's deferral. The CLI already does: FR-6
+-- (lib/chairman/decision-queue.mjs renderPendingLine + decision-disposition.mjs) overrides the
+-- view's boolean when a disposition exists, and all 7 live rows carry a chairman deferral within
+-- ~1.3 days, so `chairman-decisions.mjs list` currently renders ZERO marked rows.
+-- ANY OTHER CONSUMER THAT READS age_escalated DIRECTLY — without that override — WILL SEE 6.
+-- Before applying, enumerate those consumers and confirm each either applies the deferral override
+-- or is content with the raw signal. lib/chairman/decision-layman.mjs is the first to check.
+--
+-- ======================= WHAT THIS DOES NOT DO ==========================
+-- FR-2's arm-6 exit is NOT in this file. Arm 6 (leo_feature_flags -> flag_enablement) lives in
+-- chairman_all_decision_signals, a THIRD view (7432 chars live), not in the two replaced here.
+-- Excluding a ruled flag requires editing that view's arm-6 predicate to consult a disposition —
+-- deliberately NOT attempted from a migration-file reading of it, because the live definition
+-- diverges from the migration history and TR-1 forbids deriving view facts from files.
+-- Whoever lands FR-2 must start from `SELECT definition FROM pg_views WHERE
+-- viewname='chairman_all_decision_signals'`.
+-- Do NOT implement arm 6 by mutating the flag: setting lifecycle_state to disabled/archived
+-- re-asserts the KILL disposition the 2026-07-12 coordinator ruling reverted, and updating
+-- created_at exits the predicate while destroying provenance and re-arming in 7 days.
+--
+-- =========================== APPLY RUNBOOK ==============================
+--   (1) Chairman approval (verbal or written), and confirm the consumer enumeration above.
+--   (2) node scripts/apply-migration.js database/migrations/20260802_chairman_queue_age_escalation_STAGED.sql --prod-deploy
+--       (--prod-deploy + a single-use 1h token + an `-- @approved-by: <email>` header matching
+--        git config user.email — enforced by scripts/lib/migration-guards.js)
+--   (3) npm run schema:snapshot:lint and commit the regenerated snapshot in the same PR.
+--   (4) Verify with a service_role probe: a critical row older than 72h reports age_escalated=true,
+--       a critical row younger than 72h reports false, and the rendered ORDER of
+--       `node scripts/chairman-decisions.mjs list` is byte-identical to before.
+
+CREATE OR REPLACE VIEW public.chairman_pending_decisions AS
+ SELECT id,
+    decision_type,
+    title,
+    priority,
+    status,
+    venture_id,
+    stage,
+    gate_type,
+    recommendation,
+    response_deadline,
+    created_at,
+    decided_at,
+    decided_by,
+    requestor_name,
+    venture_name,
+    details,
+    blocking,
+        CASE effective_rank
+            WHEN 1 THEN 'critical'::text
+            WHEN 2 THEN 'high'::text
+            WHEN 3 THEN 'normal'::text
+            ELSE 'low'::text
+        END AS effective_priority,
+    -- FR-5: the marker is a property of AGE, not of rank movement. Was
+    -- (effective_rank < priority_rank), which is 1 < 1 for every critical row at any age.
+    -- Mirrors lib/chairman/decision-queue.mjs `escalated: bump > 0`.
+    ((now() - created_at) > '72:00:00'::interval) AS age_escalated
+   FROM ( SELECT u.id,
+            u.decision_type,
+            u.title,
+            u.priority,
+            u.status,
+            u.venture_id,
+            u.stage,
+            u.gate_type,
+            u.recommendation,
+            u.response_deadline,
+            u.created_at,
+            u.decided_at,
+            u.decided_by,
+            u.requestor_name,
+            u.venture_name,
+            u.details,
+            u.blocking,
+                CASE u.priority
+                    WHEN 'critical'::text THEN 1
+                    WHEN 'high'::text THEN 2
+                    WHEN 'normal'::text THEN 3
+                    WHEN 'low'::text THEN 4
+                    ELSE 5
+                END AS priority_rank,
+            -- UNCHANGED. The floor is correct and ORDER BY depends on it.
+            GREATEST(1, (
+                CASE u.priority
+                    WHEN 'critical'::text THEN 1
+                    WHEN 'high'::text THEN 2
+                    WHEN 'normal'::text THEN 3
+                    WHEN 'low'::text THEN 4
+                    ELSE 5
+                END -
+                CASE
+                    WHEN ((now() - u.created_at) > '72:00:00'::interval) THEN 1
+                    ELSE 0
+                END)) AS effective_rank
+           FROM chairman_unified_decisions u
+          WHERE (u.status = 'pending'::text)) ranked
+  ORDER BY blocking DESC, effective_rank, created_at;
+
+-- security_invoker must survive the replace. tests/unit/chairman-decision-queue.test.js:141-143
+-- asserts this by reading a MIGRATION FILE, so that assertion would keep passing even if this
+-- statement were dropped — see TR-10. Re-point that test at pg_views before relying on it.
+ALTER VIEW public.chairman_pending_decisions SET (security_invoker = on);

--- a/lib/chairman/decision-disposition.mjs
+++ b/lib/chairman/decision-disposition.mjs
@@ -77,12 +77,22 @@ export const DEFERRAL_CATEGORY = 'chairman_decision_deferred';
 export const TRUSTED_SOURCE_TYPE = 'auto_capture';
 
 /**
- * feedback_type values starting with this prefix are reachable by anon via
- * venture_user_insert_feedback. feedback_feedback_type_check permits exactly
- * sentry_error / user_bug / user_feature_request / user_usability / user_other / venture_error,
- * so four of the six permitted values are anon-writable and all four carry this prefix.
+ * feedback_type values reachable by anon via venture_user_insert_feedback, whose predicate is
+ * `feedback_type LIKE 'user_%'`.
+ *
+ * THIS MIRRORS SQL `LIKE` SEMANTICS DELIBERATELY, and an earlier version did not. In SQL LIKE, `_`
+ * is a SINGLE-CHARACTER WILDCARD — so 'userX', 'usera' and 'user-bug' all satisfy the policy while
+ * failing a literal JS startsWith('user_'). With the literal check, clause 3 admitted rows the
+ * policy admits, which made the "independent second block" claim in the header FALSE.
+ *
+ * Not exploitable when found: feedback_feedback_type_check enumerates exactly six values
+ * (sentry_error / user_bug / user_feature_request / user_usability / user_other / venture_error) and
+ * none match LIKE-but-not-startsWith, and clause 2 blocks that shape regardless. Corrected anyway,
+ * because a documented guarantee that is weaker than it reads is the defect class this SD exists to
+ * remove — and it silently stops blocking the moment the CHECK constraint gains a value like
+ * 'userland_x'.
  */
-export const UNTRUSTED_FEEDBACK_TYPE_PREFIX = 'user_';
+export const UNTRUSTED_FEEDBACK_TYPE_RE = /^user./;
 
 /**
  * The columns a caller MUST select for the fence to be evaluable.
@@ -110,9 +120,10 @@ export function isTrustedProvenance(r) {
   if (!r) return false;
   if (r.source_type !== TRUSTED_SOURCE_TYPE) return false;      // blocks telegram_bot_insert_feedback
   if (r.venture_id !== null && r.venture_id !== undefined) return false; // blocks venture_user_insert_feedback
-  // Independent second block on venture_user_insert_feedback (see header). A null/absent
-  // feedback_type is unreachable via that policy, so it is not rejected here.
-  if (typeof r.feedback_type === 'string' && r.feedback_type.startsWith(UNTRUSTED_FEEDBACK_TYPE_PREFIX)) return false;
+  // Independent second block on venture_user_insert_feedback, matching that policy's LIKE 'user_%'
+  // predicate exactly (see UNTRUSTED_FEEDBACK_TYPE_RE — `_` is a SQL wildcard, not a literal).
+  // A null/absent feedback_type is unreachable via that policy, so it is not rejected here.
+  if (typeof r.feedback_type === 'string' && UNTRUSTED_FEEDBACK_TYPE_RE.test(r.feedback_type)) return false;
   return true;
 }
 

--- a/lib/chairman/decision-disposition.mjs
+++ b/lib/chairman/decision-disposition.mjs
@@ -91,8 +91,14 @@ export const TRUSTED_SOURCE_TYPE = 'auto_capture';
  * because a documented guarantee that is weaker than it reads is the defect class this SD exists to
  * remove — and it silently stops blocking the moment the CHECK constraint gains a value like
  * 'userland_x'.
+ *
+ * The character class is [\s\S], not `.`, because JS `.` excludes line terminators while SQL `_`
+ * matches them — so 'user\nx' satisfied the policy while passing a /^user./ fence. Same defect as
+ * the literal-underscore version, one layer down. Not exploitable (no CHECK-permitted value
+ * contains a newline, and clause 2 blocks the shape), fixed so "mirrors the SQL predicate exactly"
+ * is a true statement rather than an almost-true one.
  */
-export const UNTRUSTED_FEEDBACK_TYPE_RE = /^user./;
+export const UNTRUSTED_FEEDBACK_TYPE_RE = /^user[\s\S]/;
 
 /**
  * The columns a caller MUST select for the fence to be evaluable.

--- a/lib/chairman/decision-disposition.mjs
+++ b/lib/chairman/decision-disposition.mjs
@@ -32,6 +32,31 @@
 /** The feedback category the chairman-deferral writer stamps. Measured: the only category in this lane. */
 export const DEFERRAL_CATEGORY = 'chairman_decision_deferred';
 
+/**
+ * PROVENANCE FENCE — WITHOUT THIS, RETIREMENT AUTHORITY IS FORGEABLE BY AN UNAUTHENTICATED PARTY.
+ *
+ * PROVEN LIVE, as the anon role, against this module before the fence existed: an anon client could
+ * insert a feedback row with category='chairman_decision_deferred' and metadata
+ * {target_id: <a REAL pending decision>, decided_by: 'chairman-cli'}, and retirementAuthority()
+ * ACCEPTED IT. Nothing verified who wrote the record. That forges the authority to retire a genuine
+ * chairman decision — and, because ageClockFor() reads the same records, a forged deferral also
+ * resets a real decision's age clock and silences its escalation on the live CLI.
+ *
+ * THE DISCRIMINATOR WAS MEASURED, NOT ASSUMED. All 21 genuine deferrals carry
+ * source_type='auto_capture'. The anon INSERT policy on feedback constrains source_type to
+ * 'telegram', so that value is outside an attacker's control. Verified in BOTH directions:
+ *   anon INSERT source_type='auto_capture' -> BLOCKED, 42501 row-level security violation
+ *   anon INSERT source_type='telegram'     -> allowed
+ *   anon UPDATE of a genuine deferral      -> 0 rows affected (RLS filtered), so an existing
+ *                                             record cannot be hijacked either
+ *
+ * This is a READER-side fence. It does not stop anon writing junk into feedback — that is a
+ * separately-routed issue — it stops that junk from GOVERNING a chairman decision. A record whose
+ * writer cannot be established must govern nothing, which is the same rule retirementAuthority()
+ * already applies to records with no actor.
+ */
+export const TRUSTED_SOURCE_TYPE = 'auto_capture';
+
 /** The join key, established by a full key census over all 21 live rows (see header). */
 export const DISPOSITION_KEY = 'target_id';
 
@@ -47,6 +72,9 @@ export function indexDispositions(rows) {
   const out = new Map();
   for (const r of Array.isArray(rows) ? rows : []) {
     if (!r || r.category !== DEFERRAL_CATEGORY) continue;
+    // THE FENCE. A record from any other source_type is anon-writable and therefore forgeable, so it
+    // governs nothing — not the age clock, not retirement. See TRUSTED_SOURCE_TYPE above.
+    if (r.source_type !== TRUSTED_SOURCE_TYPE) continue;
     const md = r.metadata || {};
     const targetId = md[DISPOSITION_KEY];
     if (!targetId) continue; // no key, no claim — a record we cannot attribute governs nothing

--- a/lib/chairman/decision-disposition.mjs
+++ b/lib/chairman/decision-disposition.mjs
@@ -1,0 +1,118 @@
+/**
+ * lib/chairman/decision-disposition.mjs — the disposition reader.
+ * SD-FDBK-INFRA-DECISION-QUEUE-RETIREMENT-001, FR-3.
+ *
+ * THE QUEUE HAS NO WAY TO LEARN THAT A DECISION WAS ALREADY MADE. Five of its seven live rows carry
+ * a chairman deferral — several deferred twice — and the queue keeps presenting them as untouched and
+ * ageing. The records exist, are attributable, and are read by nothing. This module is the reader.
+ *
+ * DELIBERATELY PURE AND DEPENDENCY-FREE, matching lib/chairman/decision-queue.mjs (:10-11): callers
+ * inject rows, so the unit tier can exercise every branch without DB plumbing.
+ *
+ * ===== WHY target_id, MEASURED RATHER THAN CHOSEN =====
+ * A review flagged a join-key split in the WRITER: scripts/chairman-decisions.mjs:96 writes
+ * metadata.flag_id while :113 writes metadata.target_id — two keys for one concept, twenty lines
+ * apart, and a both-directions test cannot catch it because both directions share one seeding helper.
+ * So the key was settled by a FULL KEY CENSUS over the whole live population rather than by reading
+ * either line: 21 of 21 chairman_decision_deferred rows carry target_id, decided_by, deferred_at and
+ * decision_type. flag_id appears ZERO times. target_id is the key; the flag_id branch writes
+ * something this lane never sees.
+ *
+ * ===== DEFERRAL IS NOT RETIREMENT, AND CONFLATING THEM WOULD BE THE WORSE BUG =====
+ * A deferral says "not now", not "never" — lib/chairman/decision-queue.mjs:128-130 documents it as a
+ * visibility act. So a deferral RESTARTS THE AGE CLOCK; it does not remove the row. Treating it as a
+ * retirement would silently delete decisions the chairman intends to make, which is the catastrophic
+ * direction for this SD. Retirement requires its own explicit disposition.
+ *
+ * snoozed_until is honoured when present. It is currently populated on 0 of 21 rows even though
+ * feedback.snoozed_until and lib/quality/snooze-manager.js both exist — that unused affordance is
+ * FR-6's actual defect, and this reader is written to consume it the moment the writer sets it.
+ */
+
+/** The feedback category the chairman-deferral writer stamps. Measured: the only category in this lane. */
+export const DEFERRAL_CATEGORY = 'chairman_decision_deferred';
+
+/** The join key, established by a full key census over all 21 live rows (see header). */
+export const DISPOSITION_KEY = 'target_id';
+
+/**
+ * Index disposition records by the decision they refer to.
+ * Keeps the MOST RECENT per target: a row deferred twice is governed by the later deferral, and
+ * three of the live rows have exactly that shape.
+ *
+ * @param {Array<object>} rows feedback rows (any categories; non-deferrals are ignored)
+ * @returns {Map<string, object>} target_id -> {targetId, deferredAt, decidedBy, decisionType, snoozedUntil, basis, sourceId}
+ */
+export function indexDispositions(rows) {
+  const out = new Map();
+  for (const r of Array.isArray(rows) ? rows : []) {
+    if (!r || r.category !== DEFERRAL_CATEGORY) continue;
+    const md = r.metadata || {};
+    const targetId = md[DISPOSITION_KEY];
+    if (!targetId) continue; // no key, no claim — a record we cannot attribute governs nothing
+    const deferredAt = md.deferred_at || r.created_at || null;
+    const prev = out.get(targetId);
+    if (prev && Date.parse(prev.deferredAt) >= Date.parse(deferredAt)) continue;
+    out.set(targetId, {
+      targetId,
+      deferredAt,
+      decidedBy: md.decided_by || null,
+      decisionType: md.decision_type || null,
+      snoozedUntil: r.snoozed_until || null,
+      basis: r.description || r.title || null,
+      sourceId: r.id
+    });
+  }
+  return out;
+}
+
+/**
+ * The effective age clock for a row: the deferral if one exists, otherwise creation.
+ * THIS IS THE WHOLE POINT — the queue ages every row from created_at, so a decision the chairman
+ * deferred yesterday still presents as 56 days stale and escalates on that basis.
+ *
+ * @returns {{since: string|null, source: 'deferral'|'creation', disposition: object|null}}
+ */
+export function ageClockFor(row, dispositions) {
+  const id = row?.id;
+  const d = id && dispositions instanceof Map ? dispositions.get(id) : null;
+  if (d && d.deferredAt) return { since: d.deferredAt, source: 'deferral', disposition: d };
+  return { since: row?.created_at || null, source: 'creation', disposition: null };
+}
+
+/**
+ * Is this row under an ACTIVE hold right now?
+ * A deferral with a snoozed_until in the future is held until then. A deferral without one is an
+ * open-ended "not now": it restarts the clock (see ageClockFor) but does not suppress the row,
+ * because suppressing indefinitely on an unbounded record would hide decisions permanently.
+ */
+export function isHeld(row, dispositions, now = new Date()) {
+  const id = row?.id;
+  const d = id && dispositions instanceof Map ? dispositions.get(id) : null;
+  if (!d || !d.snoozedUntil) return false;
+  const until = Date.parse(d.snoozedUntil);
+  return Number.isFinite(until) && until > now.getTime();
+}
+
+/**
+ * The authority for retiring a row, or null. FR-3: absence of authority BLOCKS retirement rather
+ * than defaulting it, so this returns null rather than a permissive object and every caller must
+ * handle null explicitly.
+ *
+ * Returns the citation a retirement must record — never a bare boolean, because "retired" without
+ * a basis is exactly the unattributable stamp this SD exists to remove.
+ */
+export function retirementAuthority(row, dispositions) {
+  const id = row?.id;
+  const d = id && dispositions instanceof Map ? dispositions.get(id) : null;
+  if (!d) return null;
+  if (!d.deferredAt || !d.decidedBy) return null; // an unattributable record authorises nothing
+  return {
+    targetId: d.targetId,
+    citedRecord: d.sourceId,
+    decidedBy: d.decidedBy,
+    decidedAt: d.deferredAt,
+    basis: d.basis,
+    disposition: 'deferred'
+  };
+}

--- a/lib/chairman/decision-disposition.mjs
+++ b/lib/chairman/decision-disposition.mjs
@@ -157,7 +157,10 @@ export function indexDispositions(rows) {
     if (missing.length) {
       throw new Error(
         `indexDispositions: row ${r.id} matched ${DEFERRAL_CATEGORY} but is missing provenance ` +
-        `column(s) [${missing.join(', ')}] — the caller under-selected. Select DISPOSITION_SELECT. ` +
+        // NB: phrased to avoid a bare "select" after an interpolation — the ship review gate's
+        // CRIT-002 pattern is case-insensitive and flags `${...}` followed by a standalone SQL
+        // keyword, which this human-readable message would otherwise trip. Wording only.
+        `column(s) [${missing.join(', ')}] — the caller under-fetched. Build the query from DISPOSITION_SELECT. ` +
         'Refusing to evaluate provenance on an incomplete row.'
       );
     }

--- a/lib/chairman/decision-disposition.mjs
+++ b/lib/chairman/decision-disposition.mjs
@@ -35,27 +35,86 @@ export const DEFERRAL_CATEGORY = 'chairman_decision_deferred';
 /**
  * PROVENANCE FENCE — WITHOUT THIS, RETIREMENT AUTHORITY IS FORGEABLE BY AN UNAUTHENTICATED PARTY.
  *
- * PROVEN LIVE, as the anon role, against this module before the fence existed: an anon client could
- * insert a feedback row with category='chairman_decision_deferred' and metadata
- * {target_id: <a REAL pending decision>, decided_by: 'chairman-cli'}, and retirementAuthority()
- * ACCEPTED IT. Nothing verified who wrote the record. That forges the authority to retire a genuine
- * chairman decision — and, because ageClockFor() reads the same records, a forged deferral also
- * resets a real decision's age clock and silences its escalation on the live CLI.
+ * PROVEN LIVE, as the anon role: an anon client inserts a feedback row with
+ * category='chairman_decision_deferred' and metadata {target_id: <a REAL pending decision>,
+ * decided_by: 'chairman-cli'}, and retirementAuthority() ACCEPTS IT. Nothing verifies who wrote the
+ * record. That forges the authority to retire a genuine chairman decision — and, because
+ * ageClockFor() reads the same records, a forged deferral also resets a real decision's age clock
+ * and silences its escalation on the live CLI.
  *
- * THE DISCRIMINATOR WAS MEASURED, NOT ASSUMED. All 21 genuine deferrals carry
- * source_type='auto_capture'. The anon INSERT policy on feedback constrains source_type to
- * 'telegram', so that value is outside an attacker's control. Verified in BOTH directions:
- *   anon INSERT source_type='auto_capture' -> BLOCKED, 42501 row-level security violation
- *   anon INSERT source_type='telegram'     -> allowed
- *   anon UPDATE of a genuine deferral      -> 0 rows affected (RLS filtered), so an existing
- *                                             record cannot be hijacked either
+ * ===== A source_type-ONLY FENCE DOES NOT WORK. THIS IS THE CORRECTED VERSION. =====
+ * The first attempt fenced on source_type='auto_capture' alone, on the stated premise that "the
+ * anon INSERT policy constrains source_type to 'telegram'". THAT PREMISE WAS FALSE, and the probe
+ * that "confirmed" it was a false negative twice over:
+ *   (1) `feedback` has TWO permissive anon INSERT policies, and RLS OR-s them. The probe only ever
+ *       satisfied the telegram-shaped one. The second policy, venture_user_insert_feedback, places
+ *       NO constraint on source_type at all.
+ *   (2) 42501 is raised BOTH by a rejected INSERT and by a SUCCEEDING insert whose RETURNING clause
+ *       fails the (telegram-only) anon SELECT policy. A bare supabase-js .insert() omits RETURNING
+ *       and lands 201. Reading the client's error code cannot distinguish the two — only a
+ *       SERVICE-ROLE READ-BACK can. Re-demonstrated live: anon INSERT -> 201, row persisted,
+ *       forged authority GRANTED.
  *
- * This is a READER-side fence. It does not stop anon writing junk into feedback — that is a
- * separately-routed issue — it stops that junk from GOVERNING a chairman decision. A record whose
- * writer cannot be established must govern nothing, which is the same rule retirementAuthority()
- * already applies to records with no actor.
+ * ===== THE FENCE IS DERIVED FROM THE POLICY PREDICATES, NOT FROM A CORRELATION =====
+ * The two anon INSERT policies force MUTUALLY EXCLUSIVE row shapes:
+ *   telegram_bot_insert_feedback  WITH CHECK (source_type = 'telegram')
+ *   venture_user_insert_feedback  WITH CHECK (feedback_type LIKE 'user_%' AND venture_id IS NOT NULL
+ *                                             AND venture_exists_and_active(venture_id) AND ...)
+ * All 21 genuine deferrals are, unanimously: source_type='auto_capture', venture_id IS NULL,
+ * feedback_type='sentry_error'. So requiring all three rejects BOTH anon paths by construction:
+ *   - to pass telegram_bot_insert_feedback an attacker MUST set source_type='telegram'   -> fails (1)
+ *   - to pass venture_user_insert_feedback an attacker MUST set venture_id NOT NULL AND
+ *     feedback_type LIKE 'user_%'                                                        -> fails (2) and (3)
+ * (3) is redundant with (2) against today's policy set and is kept deliberately: two independent
+ * blocks on the same policy means adding one column to a future policy does not silently re-open it.
+ *
+ * LIMIT OF THIS CONTROL, STATED PLAINLY: it is derived from the CURRENT live policy set. A future
+ * third anon INSERT policy permitting venture_id IS NULL with an arbitrary source_type would defeat
+ * it, and nothing here would notice. The durable fix is DB-side — a BEFORE trigger stamping the
+ * writer identity, or moving chairman deferrals to a table with no anon INSERT policy — which is
+ * DDL and therefore chairman-gated. Routed separately; this fence is the reader-side stopgap.
  */
 export const TRUSTED_SOURCE_TYPE = 'auto_capture';
+
+/**
+ * feedback_type values starting with this prefix are reachable by anon via
+ * venture_user_insert_feedback. feedback_feedback_type_check permits exactly
+ * sentry_error / user_bug / user_feature_request / user_usability / user_other / venture_error,
+ * so four of the six permitted values are anon-writable and all four carry this prefix.
+ */
+export const UNTRUSTED_FEEDBACK_TYPE_PREFIX = 'user_';
+
+/**
+ * The columns a caller MUST select for the fence to be evaluable.
+ *
+ * EXPORTED SO THE CONSUMER CANNOT DRIFT FROM IT, and that is not hypothetical: the first version of
+ * this fence shipped while scripts/chairman-decisions.mjs selected only
+ * `id, category, created_at, snoozed_until, metadata, description, title`. `source_type` was
+ * therefore `undefined` on EVERY production row, the fence rejected all 21 of them, and FR-6 was
+ * DEAD IN PRODUCTION — while all 32 unit tests stayed green, because every fixture hand-supplied
+ * source_type. Measured: 0 dispositions via the real select, 15 via the same rows with source_type
+ * added. A green suite proved nothing because it never used the consumer's own query.
+ */
+export const DISPOSITION_SELECT =
+  'id, category, created_at, snoozed_until, metadata, description, title, source_type, venture_id, feedback_type';
+
+/** Keys whose ABSENCE means provenance cannot be evaluated at all (see DISPOSITION_SELECT). */
+export const REQUIRED_PROVENANCE_FIELDS = Object.freeze(['source_type', 'venture_id', 'feedback_type']);
+
+/**
+ * Is this record's writer establishable as the trusted chairman-deferral path?
+ * FAILS CLOSED: anything not positively recognised governs nothing.
+ * @param {object} r a feedback row already known to match DEFERRAL_CATEGORY
+ */
+export function isTrustedProvenance(r) {
+  if (!r) return false;
+  if (r.source_type !== TRUSTED_SOURCE_TYPE) return false;      // blocks telegram_bot_insert_feedback
+  if (r.venture_id !== null && r.venture_id !== undefined) return false; // blocks venture_user_insert_feedback
+  // Independent second block on venture_user_insert_feedback (see header). A null/absent
+  // feedback_type is unreachable via that policy, so it is not rejected here.
+  if (typeof r.feedback_type === 'string' && r.feedback_type.startsWith(UNTRUSTED_FEEDBACK_TYPE_PREFIX)) return false;
+  return true;
+}
 
 /** The join key, established by a full key census over all 21 live rows (see header). */
 export const DISPOSITION_KEY = 'target_id';
@@ -72,9 +131,23 @@ export function indexDispositions(rows) {
   const out = new Map();
   for (const r of Array.isArray(rows) ? rows : []) {
     if (!r || r.category !== DEFERRAL_CATEGORY) continue;
-    // THE FENCE. A record from any other source_type is anon-writable and therefore forgeable, so it
-    // governs nothing — not the age clock, not retirement. See TRUSTED_SOURCE_TYPE above.
-    if (r.source_type !== TRUSTED_SOURCE_TYPE) continue;
+
+    // UNDER-SELECTION IS A PROGRAMMING ERROR, NOT AN UNTRUSTED RECORD — and it must never be
+    // silently indistinguishable from one. A caller that omits these columns previously produced
+    // "0 dispositions" that looked exactly like "0 trusted dispositions", which is how FR-6 shipped
+    // dead (see DISPOSITION_SELECT). Throw loudly instead; build the select from DISPOSITION_SELECT.
+    const missing = REQUIRED_PROVENANCE_FIELDS.filter(f => !Object.prototype.hasOwnProperty.call(r, f));
+    if (missing.length) {
+      throw new Error(
+        `indexDispositions: row ${r.id} matched ${DEFERRAL_CATEGORY} but is missing provenance ` +
+        `column(s) [${missing.join(', ')}] — the caller under-selected. Select DISPOSITION_SELECT. ` +
+        'Refusing to evaluate provenance on an incomplete row.'
+      );
+    }
+
+    // THE FENCE. A record whose writer cannot be established governs nothing — not the age clock,
+    // not retirement. Same rule retirementAuthority() applies to a record with no actor.
+    if (!isTrustedProvenance(r)) continue;
     const md = r.metadata || {};
     const targetId = md[DISPOSITION_KEY];
     if (!targetId) continue; // no key, no claim — a record we cannot attribute governs nothing

--- a/lib/chairman/decision-disposition.mjs
+++ b/lib/chairman/decision-disposition.mjs
@@ -2,17 +2,23 @@
  * lib/chairman/decision-disposition.mjs — the disposition reader.
  * SD-FDBK-INFRA-DECISION-QUEUE-RETIREMENT-001, FR-3.
  *
- * THE QUEUE HAS NO WAY TO LEARN THAT A DECISION WAS ALREADY MADE. Five of its seven live rows carry
- * a chairman deferral — several deferred twice — and the queue keeps presenting them as untouched and
- * ageing. The records exist, are attributable, and are read by nothing. This module is the reader.
+ * THE QUEUE HAS NO WAY TO LEARN THAT A DECISION WAS ALREADY MADE. Measured live, ALL SEVEN of its
+ * seven pending rows carry a chairman deferral — several deferred twice, every one within ~1.3 days
+ * — and the queue keeps presenting them as untouched and ageing. The records exist, are
+ * attributable, and are read by nothing. This module is the reader.
+ * (An earlier revision of this header said "five of seven". That was the first estimate; the
+ * measurement corrected it to seven of seven and the two consumers were updated while this header
+ * was not. Same changeset, two different numbers — corrected here.)
  *
  * DELIBERATELY PURE AND DEPENDENCY-FREE, matching lib/chairman/decision-queue.mjs (:10-11): callers
  * inject rows, so the unit tier can exercise every branch without DB plumbing.
  *
  * ===== WHY target_id, MEASURED RATHER THAN CHOSEN =====
- * A review flagged a join-key split in the WRITER: scripts/chairman-decisions.mjs:96 writes
- * metadata.flag_id while :113 writes metadata.target_id — two keys for one concept, twenty lines
- * apart, and a both-directions test cannot catch it because both directions share one seeding helper.
+ * A review flagged a join-key split in the WRITER: in scripts/chairman-decisions.mjs the
+ * `recordFlagCall` writer stamps metadata.flag_id while `recordDeferral` stamps metadata.target_id —
+ * two keys for one concept, a few lines apart, and a both-directions test cannot catch it because
+ * both directions share one seeding helper. (Cited by FUNCTION rather than line: the line numbers
+ * in the previous revision were wrong and drifted again on the next edit.)
  * So the key was settled by a FULL KEY CENSUS over the whole live population rather than by reading
  * either line: 21 of 21 chairman_decision_deferred rows carry target_id, decided_by, deferred_at and
  * decision_type. flag_id appears ZERO times. target_id is the key; the flag_id branch writes

--- a/lib/chairman/decision-queue.mjs
+++ b/lib/chairman/decision-queue.mjs
@@ -34,7 +34,15 @@ export function effectivePriority(row, now = new Date()) {
   const ageMs = created && !Number.isNaN(created.getTime()) ? now.getTime() - created.getTime() : 0;
   const bump = ageMs > AGE_ESCALATION_HOURS * 3600 * 1000 ? 1 : 0;
   const rank = Math.max(1, baseRank - bump);
-  return { rank, label: RANK_LABEL[rank] || 'low', escalated: rank < baseRank };
+  // ESCALATION IS A PROPERTY OF AGE, NOT OF RANK MOVEMENT.
+  // This was `rank < baseRank`, which conflated the two. The rank floor is correct — critical
+  // cannot outrank critical — but for critical baseRank is 1, so the floor absorbed the bump and
+  // the comparison was 1 < 1: FALSE AT ANY AGE. Every critical row was structurally unmarkable,
+  // and arm 4 of chairman_pending_decisions hardcodes priority='critical', so every row that arm
+  // emits was blind by construction. Four of seven live rows were affected, one at 15 days.
+  // `bump` already encodes exactly the question being asked: did this row cross the age threshold.
+  // Sort order is unaffected — sortPending() reads `rank`, which is unchanged.
+  return { rank, label: RANK_LABEL[rank] || 'low', escalated: bump > 0 };
 }
 
 /**

--- a/lib/chairman/decision-queue.mjs
+++ b/lib/chairman/decision-queue.mjs
@@ -11,6 +11,9 @@
  * so the unit tier can test routing/sorting without any DB plumbing.
  */
 
+// Both pure and dependency-free, so importing it preserves this module's no-DB contract.
+import { ageClockFor, isHeld } from './decision-disposition.mjs';
+
 export const PRIORITY_RANK = { critical: 1, high: 2, normal: 3, low: 4 };
 const RANK_LABEL = { 1: 'critical', 2: 'high', 3: 'normal', 4: 'low', 5: 'low' };
 export const AGE_ESCALATION_HOURS = 72;
@@ -57,6 +60,48 @@ export function sortPending(rows, now = new Date()) {
     if (ar !== br) return ar - br;
     return new Date(a?.created_at || 0) - new Date(b?.created_at || 0);
   });
+}
+
+/**
+ * Render one pending row as the CLI line. SD-FDBK-INFRA-DECISION-QUEUE-RETIREMENT-001, FR-6/TR-8.
+ *
+ * EXTRACTED FROM scripts/chairman-decisions.mjs SO IT CAN BE ASSERTED AGAINST. That script is a
+ * top-level-await CLI that builds its own client, with no injection seam, so the rendered surface
+ * — the thing the chairman actually reads — had no test. This function is pure.
+ *
+ * THE FIX IT CARRIES: the queue aged every row from created_at, so a decision the chairman deferred
+ * yesterday still presented as 56 days old and escalating on that basis. Measured live, ALL SEVEN
+ * pending rows carry a deferral, every one within ~1.3 days — the entire "stale and escalating"
+ * presentation was an artifact of the wrong clock. When a disposition exists, BOTH the displayed age
+ * and the escalation marker clock from the deferral.
+ *
+ * WHY THE DISPOSITION OVERRIDES THE VIEW'S BOOLEAN, which is the load-bearing line here: the live
+ * path reads `row.age_escalated ?? ep.escalated`, and false is not nullish, so the VIEW governs the
+ * marker. The view cannot see deferrals at all. Deferring to it would leave the corrected clock
+ * invisible — the record would exist, be read, and change nothing, which is the defect this SD is
+ * about. So a deferral-corrected verdict wins; with no deferral, the view's value is untouched.
+ *
+ * @param {object} row a chairman_pending_decisions row
+ * @param {{dispositions?: Map, now?: Date}} [opts] dispositions from indexDispositions()
+ * @returns {string}
+ */
+export function renderPendingLine(row, { dispositions = null, now = new Date() } = {}) {
+  const clock = ageClockFor(row, dispositions);
+  const deferred = clock.source === 'deferral';
+  // Age the row from whichever clock governs it. Passing a synthetic created_at keeps
+  // effectivePriority's contract untouched rather than threading an override through it.
+  const effRow = deferred ? { ...row, created_at: clock.since } : row;
+  const ep = effectivePriority(effRow, now);
+
+  const label = deferred ? ep.label : (row.effective_priority ?? ep.label);
+  const escalated = deferred ? ep.escalated : (row.age_escalated ?? ep.escalated);
+
+  const pri = label + (escalated ? '^ (age-escalated)' : '');
+  const block = row.blocking ? ' BLOCKING' : '';
+  const held = isHeld(row, dispositions, now) ? ' HELD' : '';
+  const mark = deferred ? ` (deferred ${formatAge(clock.since, now)} ago${held})` : '';
+  return `[${formatAge(clock.since, now)}] [${row.decision_type}:${row.id}] [${pri}${block}] ${row.title}` +
+    (row.recommendation ? ' — ' + row.recommendation : '') + mark;
 }
 
 /** Render an age like '3d' / '7h' / '12m'. */

--- a/lib/chairman/decision-retirement.mjs
+++ b/lib/chairman/decision-retirement.mjs
@@ -272,6 +272,15 @@ export async function applyRetirement(db, plan) {
     if (existing && typeof existing === 'object' && existing.retirement_basis) {
       return { wrote: false, reason: 'already_retired', status: row.status, id: plan.id };
     }
+    // THE COLLISION BRANCH MUST NOT OUTRANK THE TERMINAL REFUSAL.
+    // It exists for HELD ('backlog'), which is an OPEN status a triager also sets. But SUPERSEDED
+    // ('duplicate') is TERMINAL, so a row already at 'duplicate' was marked so by someone else —
+    // and writing a chairman retirement_basis onto it stamps an attribution for a retirement that
+    // never happened. That is this SD's own defect class, reintroduced by the fix for it. Fall
+    // through to the refusal below whenever the matched status is not a retirable one.
+    if (!retirable.includes(row.status)) {
+      return { wrote: false, reason: 'refused_terminal_status', status: row.status, id: plan.id };
+    }
     // Status matches but nothing retired it. Record the basis WITHOUT re-asserting a status change
     // that already holds, so the attribution exists even though there is no transition to make.
     const merged = { ...(existing || {}), retirement_basis: plan.retirementBasis };

--- a/lib/chairman/decision-retirement.mjs
+++ b/lib/chairman/decision-retirement.mjs
@@ -116,7 +116,7 @@ export function armOf(row) {
  *   null    — no authority; retirement is BLOCKED, never defaulted
  *   'gated' — the arm cannot be retired without chairman-gated DDL
  */
-export function planRetirement(row, dispositions, { disposition = 'held' } = {}) {
+export function planRetirement(row, dispositions, { disposition = 'held', supersededBy = null } = {}) {
   const auth = retirementAuthority(row, dispositions);
   // FR-3: absence of authority BLOCKS retirement. Returning null rather than a permissive object
   // forces every caller to handle it — a truthy default here would retire the whole queue.
@@ -130,13 +130,57 @@ export function planRetirement(row, dispositions, { disposition = 'held' } = {})
         'or by mutating the flag, which would re-assert the reverted KILL disposition'
     };
   }
-  if (arm === 'unknown') return null;
+  // An UNRECOGNISED arm is not "no authority" — the chairman may well have deferred it. The queue
+  // emits SEVEN arms (escalation, two gate_decision arms, chairman_approval, flag_review,
+  // flag_enablement, okr_acceptance) and armOf maps three. Returning bare null here made
+  // applyRetirement report reason:'no_authority', which asserts the opposite of what happened.
+  if (arm === 'unknown') {
+    return {
+      verdict: 'unsupported_arm', arm, table: null, id: row.id, patch: null, citation: auth,
+      reason: `decision_type ${JSON.stringify(row?.decision_type)} has no retirement route; ` +
+        'authority EXISTS for this row but no arm handles it'
+    };
+  }
 
   const superseded = disposition === 'superseded';
   const table = arm === 'arm4' ? 'chairman_decisions' : 'feedback';
   const status = arm === 'arm4'
     ? (superseded ? DECISION_STATUS.SUPERSEDED : DECISION_STATUS.HELD)
     : (superseded ? FEEDBACK_STATUS.SUPERSEDED : FEEDBACK_STATUS.HELD);
+
+  // ===== SUPERSEDED ON THE FEEDBACK ARM REQUIRES A REFERENT, OR IT CANNOT BE WRITTEN AT ALL =====
+  // feedback.status='duplicate' is governed by TWO live CHECK constraints, both of which demand a
+  // referent: chk_duplicate_requires_reference (status <> 'duplicate' OR (duplicate_of_id IS NOT
+  // NULL AND duplicate_of_id <> id)) and chk_feedback_terminal_resolution (WHEN 'duplicate' THEN
+  // duplicate_of_id IS NOT NULL). All 70 live duplicate rows carry one, 70/70.
+  //
+  // The first version set status without duplicate_of_id, so EVERY superseded retirement on this
+  // arm would have died with 23514 — the exact runtime death the header above warns about, and the
+  // second instance of the retirement_basis class in this one module. It was missed because the
+  // status ENUM was read at :150-165 of 20260131_feedback_resolution_enforcement.sql and the
+  // invalidating constraint is at :235-240 OF THE SAME FILE. Reading the enum is not reading the
+  // constraints that govern its values.
+  //
+  // REFUSING is the correct behaviour, not inventing a referent: "superseded" means a specific
+  // newer instance replaced this one, and a supersession that cannot name the replacement is
+  // exactly the unattributable stamp this SD exists to remove.
+  if (superseded && table === 'feedback') {
+    if (!supersededBy) {
+      return {
+        verdict: 'blocked', arm, table, id: row.id, patch: null, citation: auth,
+        reason: 'superseded on the feedback arm requires supersededBy (the replacing row id): ' +
+          'status=duplicate is CHECK-constrained to carry duplicate_of_id, and a supersession that ' +
+          'cannot name its replacement must not be written'
+      };
+    }
+    if (supersededBy === row.id) {
+      return {
+        verdict: 'blocked', arm, table, id: row.id, patch: null, citation: auth,
+        reason: 'supersededBy equals the row id; chk_duplicate_requires_reference forbids ' +
+          'duplicate_of_id = id (a row cannot supersede itself)'
+      };
+    }
+  }
 
   return {
     verdict: 'retire', arm, table, id: row.id, citation: auth, reason: null,
@@ -150,27 +194,41 @@ export function planRetirement(row, dispositions, { disposition = 'held' } = {})
       decided_at: auth.decidedAt,
       disposition: superseded ? 'superseded' : 'held'
     },
-    patch: { status }
+    // duplicate_of_id is REQUIRED alongside status='duplicate' (see the CHECK analysis above) and
+    // must never be sent on any other path — chk_feedback_no_self_duplicate and the arm-4 table
+    // have no such column/semantics.
+    patch: (superseded && table === 'feedback')
+      ? { status, duplicate_of_id: supersededBy }
+      : { status }
   };
 }
 
 /**
  * Apply a plan. IDEMPOTENT BY CONSTRUCTION (TR-9): the update is filtered on the row still being
  * pending, so a second call matches nothing and cannot move a timestamp. The live defect this
- * guards against is arm 5's writer setting resolved_at: new Date() unconditionally
- * (scripts/chairman-decisions.mjs:76), which silently shifts the disposition time on every re-run.
+ * guards against is arm 5's writer setting resolved_at: new Date() unconditionally (the
+ * `resolveFeedback` writer in scripts/chairman-decisions.mjs), which silently shifts the disposition
+ * time on every re-run. (Cited by FUNCTION, not line — the previous line citation was wrong.)
  *
  * Deliberately does NOT write resolved_at: retirement is not resolution.
  */
 export async function applyRetirement(db, plan) {
-  if (!plan || plan.verdict !== 'retire') return { wrote: false, reason: plan?.reason || 'no_authority' };
+  // A non-retire plan carries its OWN reason. Only a genuinely absent plan means "no authority" —
+  // conflating them reported an unsupported arm as "the chairman never deferred this", which is the
+  // opposite of what happened.
+  if (!plan) return { wrote: false, reason: 'no_authority' };
+  if (plan.verdict !== 'retire') return { wrote: false, verdict: plan.verdict, reason: plan.reason || 'not_retirable' };
 
   const retirable = RETIRABLE_STATUSES[plan.table];
-  // DERIVED HERE, NOT READ FROM THE PLAN (DQR-SEC-09). `col` is string-interpolated into .select()
-  // below, so taking it from a caller-supplied object would make that interpolation caller-
-  // controlled. Every plan is built by planRetirement() today, so this is not reachable — but a
-  // sanitiser that depends on its input having been built correctly is not a sanitiser. Deriving
-  // from the frozen map keyed by the table we already validated makes the interpolation closed.
+  // DERIVED HERE, NOT READ FROM THE PLAN (DQR-SEC-09). `col` selects which jsonb column the citation
+  // is written into and is used as a computed property key below. Taking it from a caller-supplied
+  // object would let a malformed plan direct the write at a column of its choosing. Every plan is
+  // built by planRetirement() today, so this is not reachable — but a guard that depends on its
+  // input having been built correctly is not a guard.
+  // (An earlier revision of this comment claimed `col` was interpolated into .select(). That was
+  // true of the code it was written for and is no longer true of this code: the projection is now
+  // the frozen RETIREMENT_READ_SELECT literal. Corrected rather than deleted, because a stale
+  // justification tells the next editor the wrong thing about what constrains this line.)
   const col = CITATION_COLUMN[plan.table];
   if (!retirable || !col) return { wrote: false, reason: 'unknown_table', table: plan.table };
 
@@ -188,7 +246,44 @@ export async function applyRetirement(db, plan) {
   if (!cur || cur.length === 0) return { wrote: false, reason: 'not_found', id: plan.id };
 
   const row = cur[0];
-  if (row.status === plan.patch.status) return { wrote: false, reason: 'already_retired', status: row.status };
+  const existing = row[col];
+  // A jsonb column that is not a plain object cannot be MERGED into — spreading an array yields
+  // {"0":…,"1":…} (silently changing the column's shape) and a scalar/string falls to {} (silently
+  // discarding the prior value). The read-first exists precisely so the write does not destroy what
+  // is already there; for non-object JSON it would have done exactly that. Refuse instead.
+  const existingIsMergeable = existing === null || existing === undefined
+    || (typeof existing === 'object' && !Array.isArray(existing));
+  if (!existingIsMergeable) {
+    return {
+      wrote: false, reason: 'citation_column_not_mergeable', id: plan.id, column: col,
+      detail: `${plan.table}.${col} holds ${Array.isArray(existing) ? 'an array' : typeof existing} — ` +
+        'merging would change its shape or discard it'
+    };
+  }
+
+  // "ALREADY RETIRED" MUST MEAN RETIRED, NOT "HAPPENS TO SIT AT THAT STATUS".
+  // Both feedback targets collide with statuses humans set independently: HELD is 'backlog' (which
+  // is also in RETIRABLE_STATUSES.feedback, i.e. an OPEN state) and SUPERSEDED is 'duplicate'. A
+  // triager who parked a row in backlog would otherwise get {wrote:false, reason:'already_retired'},
+  // the caller would believe the retirement happened, and THE CITATION WOULD NEVER BE WRITTEN —
+  // defeating this SD's core rule that the basis travels with the write. The citation column is
+  // already in hand from the read, so consult it rather than inferring from status alone.
+  if (row.status === plan.patch.status) {
+    if (existing && typeof existing === 'object' && existing.retirement_basis) {
+      return { wrote: false, reason: 'already_retired', status: row.status, id: plan.id };
+    }
+    // Status matches but nothing retired it. Record the basis WITHOUT re-asserting a status change
+    // that already holds, so the attribution exists even though there is no transition to make.
+    const merged = { ...(existing || {}), retirement_basis: plan.retirementBasis };
+    const { data: cd, error: cErr } = await db.from(plan.table)
+      .update({ [col]: merged }).eq('id', plan.id).select('id');
+    if (cErr) return { wrote: false, reason: 'db_error', error: cErr.message };
+    return {
+      wrote: (cd || []).length > 0, reason: 'citation_recorded_status_already_matched',
+      id: plan.id, citation: plan.citation, citationColumn: col, status: row.status
+    };
+  }
+
   // REFUSE rather than overwrite. Measured: this is what stops retirement erasing three live
   // chairman approvals and overwriting three resolved feedback rows.
   if (!retirable.includes(row.status)) {
@@ -201,7 +296,7 @@ export async function applyRetirement(db, plan) {
   // jsonb_set RPC (DDL, chairman-gated) and retirement is a rare, deliberate, single-actor act.
   // The STATUS transition is NOT exposed to this — that is fenced on the write. Revisit if
   // retirement is ever automated or batched.
-  const merged = { ...(row[col] && typeof row[col] === 'object' ? row[col] : {}), retirement_basis: plan.retirementBasis };
+  const merged = { ...(existing || {}), retirement_basis: plan.retirementBasis };
 
   // The fence is REPEATED on the write so a concurrent decision between the read and the write
   // cannot slip through: status must still be retirable and still not be the target value.

--- a/lib/chairman/decision-retirement.mjs
+++ b/lib/chairman/decision-retirement.mjs
@@ -65,6 +65,20 @@ export const DECISION_STATUS = Object.freeze({
 export const CITATION_COLUMN = Object.freeze({ chairman_decisions: 'brief_data', feedback: 'metadata' });
 
 /**
+ * The read projection per arm, as a FROZEN LITERAL rather than a string built at call time.
+ *
+ * An earlier version built the projection by interpolating the citation column into the select
+ * string at call time. The value was already derived from the frozen CITATION_COLUMN map, so it was
+ * not injectable — but the review gate flags the interpolation PATTERN, and it is right to: a query
+ * string assembled at runtime is only as safe as every future edit to whatever feeds it.
+ * Eliminating the construction is cheaper than maintaining an argument for why one instance is fine.
+ */
+export const RETIREMENT_READ_SELECT = Object.freeze({
+  chairman_decisions: 'id, status, brief_data',
+  feedback: 'id, status, metadata'
+});
+
+/**
  * WHICH STATUSES MAY BE RETIRED, PER ARM. Retirement must never overwrite a disposition a human or
  * an upstream process already reached — that is the exact "assert a decision the chairman did not
  * make" failure this SD exists to remove, and the previous uniform `.neq(status, target)` fence
@@ -168,7 +182,7 @@ export async function applyRetirement(db, plan) {
   //     a failed write — so a retirement that never happened was indistinguishable from correct
   //     idempotency. Silence is the failure mode this SD exists to remove; it may not live here.
   const { data: cur, error: readErr } = await db.from(plan.table)
-    .select(`id, status, ${col}`)
+    .select(RETIREMENT_READ_SELECT[plan.table])
     .eq('id', plan.id);
   if (readErr) return { wrote: false, reason: 'db_error', error: readErr.message };
   if (!cur || cur.length === 0) return { wrote: false, reason: 'not_found', id: plan.id };

--- a/lib/chairman/decision-retirement.mjs
+++ b/lib/chairman/decision-retirement.mjs
@@ -152,7 +152,12 @@ export async function applyRetirement(db, plan) {
   if (!plan || plan.verdict !== 'retire') return { wrote: false, reason: plan?.reason || 'no_authority' };
 
   const retirable = RETIRABLE_STATUSES[plan.table];
-  const col = plan.citationColumn;
+  // DERIVED HERE, NOT READ FROM THE PLAN (DQR-SEC-09). `col` is string-interpolated into .select()
+  // below, so taking it from a caller-supplied object would make that interpolation caller-
+  // controlled. Every plan is built by planRetirement() today, so this is not reachable — but a
+  // sanitiser that depends on its input having been built correctly is not a sanitiser. Deriving
+  // from the frozen map keyed by the table we already validated makes the interpolation closed.
+  const col = CITATION_COLUMN[plan.table];
   if (!retirable || !col) return { wrote: false, reason: 'unknown_table', table: plan.table };
 
   // READ FIRST, for two reasons that both matter.
@@ -176,6 +181,12 @@ export async function applyRetirement(db, plan) {
     return { wrote: false, reason: 'refused_terminal_status', status: row.status, id: plan.id };
   }
 
+  // KNOWN LOST-UPDATE WINDOW (DQR-SEC-08, accepted): this is a read-modify-write on a jsonb column,
+  // so a concurrent writer touching a DIFFERENT key of the same column between the read above and
+  // the write below loses its change. Accepted rather than fixed because the alternative is a
+  // jsonb_set RPC (DDL, chairman-gated) and retirement is a rare, deliberate, single-actor act.
+  // The STATUS transition is NOT exposed to this — that is fenced on the write. Revisit if
+  // retirement is ever automated or batched.
   const merged = { ...(row[col] && typeof row[col] === 'object' ? row[col] : {}), retirement_basis: plan.retirementBasis };
 
   // The fence is REPEATED on the write so a concurrent decision between the read and the write

--- a/lib/chairman/decision-retirement.mjs
+++ b/lib/chairman/decision-retirement.mjs
@@ -44,11 +44,43 @@ export const FEEDBACK_STATUS = Object.freeze({
   HELD: 'backlog'
 });
 
-/** chairman_decisions.status is plain text with no CHECK, so the honest term is available there. */
+/**
+ * chairman_decisions.status IS CHECK-CONSTRAINED. An earlier version of this module asserted three
+ * times that it "is plain text with no CHECK" and chose 'superseded'/'held' on that basis. THE
+ * PREMISE WAS FALSE and every arm-4 retirement would have died 23514, both dispositions — on the
+ * LARGER arm (7 of the 15 measured deferral targets).
+ *
+ *   chairman_decisions_status_check: CHECK (status = ANY (ARRAY['pending','approved','rejected','cancelled']))
+ *
+ * Verified live, directly: UPDATE ... SET status='superseded' inside a rolled-back transaction
+ * returns 23514 violates check constraint "chairman_decisions_status_check".
+ *
+ * HOW THE FALSE PREMISE SURVIVED: feedback's constraints were enumerated exhaustively from
+ * pg_constraint; chairman_decisions' never were. The claim was inherited from earlier notes and
+ * encoded without being measured. Reading one table's constraints is not reading another's, and a
+ * status distribution that happens to contain only legal values (approved/cancelled/rejected/
+ * pending) looks identical to an unconstrained column.
+ *
+ * ===== WHY 'cancelled' FOR SUPERSEDED AND A REFUSAL FOR HELD =====
+ * Of the four permitted values, 'approved' and 'rejected' assert an outcome the chairman never
+ * reached (TR-3 forbids both). That leaves 'pending' (the current state) and 'cancelled'.
+ *   SUPERSEDED -> 'cancelled'. A newer instance replaced this one, so this instance is genuinely
+ *     withdrawn. This follows in-repo precedent: 20260710_park_venture_decision_park_semantic_status.sql
+ *     needed park semantics on this same table and documented picking 'cancelled' as "the only
+ *     park-semantic value in the existing chairman_decisions_status_check … no DDL, no constraint
+ *     change". The disposition and basis travel in brief_data.retirement_basis.
+ *   HELD -> NO WRITE AT ALL, deliberately. "Held" means parked but STILL TO BE DECIDED; the row
+ *     must stay 'pending'. Writing 'cancelled' would delete a decision the chairman intends to
+ *     make — the catastrophic direction this module's header warns about. There is nothing to
+ *     write, so planRetirement refuses instead of inventing a status. FR-6 already stops a held
+ *     row escalating falsely by clocking from the deferral, which is the actual remedy for "held".
+ */
 export const DECISION_STATUS = Object.freeze({
-  SUPERSEDED: 'superseded',
-  HELD: 'held'
+  SUPERSEDED: 'cancelled'
 });
+
+/** The exact permitted set of chairman_decisions_status_check, read from pg_constraint. */
+export const PERMITTED_DECISION_STATUS = Object.freeze(['pending', 'approved', 'rejected', 'cancelled']);
 
 /**
  * WHERE THE CITATION IS STORED — and why it is NOT a `retirement_basis` column.
@@ -144,8 +176,23 @@ export function planRetirement(row, dispositions, { disposition = 'held', supers
 
   const superseded = disposition === 'superseded';
   const table = arm === 'arm4' ? 'chairman_decisions' : 'feedback';
+
+  // HELD ON ARM 4 HAS NO LEGAL, HONEST STATUS — see DECISION_STATUS. The permitted set is
+  // pending/approved/rejected/cancelled; approved and rejected assert an outcome (TR-3), and
+  // 'cancelled' would delete a decision the chairman still intends to make. A held arm-4 row
+  // belongs in 'pending', which is where it already is, so there is nothing to write.
+  if (arm === 'arm4' && !superseded) {
+    return {
+      verdict: 'blocked', arm, table, id: row.id, patch: null, citation: auth,
+      reason: 'held has no permitted chairman_decisions.status: the CHECK allows only ' +
+        'pending/approved/rejected/cancelled; approved/rejected assert an outcome the chairman ' +
+        'never reached and cancelled would withdraw a decision he still intends to make. A held ' +
+        'row correctly stays pending — FR-6 already stops it escalating falsely'
+    };
+  }
+
   const status = arm === 'arm4'
-    ? (superseded ? DECISION_STATUS.SUPERSEDED : DECISION_STATUS.HELD)
+    ? DECISION_STATUS.SUPERSEDED
     : (superseded ? FEEDBACK_STATUS.SUPERSEDED : FEEDBACK_STATUS.HELD);
 
   // ===== SUPERSEDED ON THE FEEDBACK ARM REQUIRES A REFERENT, OR IT CANNOT BE WRITTEN AT ALL =====
@@ -283,12 +330,22 @@ export async function applyRetirement(db, plan) {
     }
     // Status matches but nothing retired it. Record the basis WITHOUT re-asserting a status change
     // that already holds, so the attribution exists even though there is no transition to make.
+    // FENCED LIKE EVERY OTHER WRITE HERE. This was the only update in the module filtering on id
+    // alone, while the main write repeats its status fence with a comment explaining why. The same
+    // argument applies: a legitimate transition landing between the read above and this write (a
+    // triager moving backlog -> in_progress, say) would otherwise take the citation anyway and the
+    // return would report the STALE status read beforehand.
     const merged = { ...(existing || {}), retirement_basis: plan.retirementBasis };
     const { data: cd, error: cErr } = await db.from(plan.table)
-      .update({ [col]: merged }).eq('id', plan.id).select('id');
+      .update({ [col]: merged })
+      .eq('id', plan.id)
+      .eq('status', row.status)
+      .in('status', retirable)
+      .select('id');
     if (cErr) return { wrote: false, reason: 'db_error', error: cErr.message };
+    if (!cd || cd.length === 0) return { wrote: false, reason: 'raced', id: plan.id, status: row.status };
     return {
-      wrote: (cd || []).length > 0, reason: 'citation_recorded_status_already_matched',
+      wrote: true, reason: 'citation_recorded_status_already_matched',
       id: plan.id, citation: plan.citation, citationColumn: col, status: row.status
     };
   }

--- a/lib/chairman/decision-retirement.mjs
+++ b/lib/chairman/decision-retirement.mjs
@@ -50,6 +50,41 @@ export const DECISION_STATUS = Object.freeze({
   HELD: 'held'
 });
 
+/**
+ * WHERE THE CITATION IS STORED — and why it is NOT a `retirement_basis` column.
+ *
+ * The first version of this module wrote patch.retirement_basis. THAT COLUMN EXISTS ON NEITHER
+ * TABLE: an explicit select returns 42703 on both feedback and chairman_decisions, and no migration
+ * adds it. Every applyRetirement() call would have failed at runtime. It was latent only because
+ * nothing calls this module yet, and it survived the unit suite because a hand-written fake accepts
+ * any patch object — A FAKE THAT CANNOT REJECT AN UNKNOWN COLUMN CANNOT WITNESS A MISSING ONE.
+ *
+ * Adding the column is DDL and therefore chairman-gated, so the citation is nested inside a jsonb
+ * column that already exists on each table. Verified present and nullable on both.
+ */
+export const CITATION_COLUMN = Object.freeze({ chairman_decisions: 'brief_data', feedback: 'metadata' });
+
+/**
+ * WHICH STATUSES MAY BE RETIRED, PER ARM. Retirement must never overwrite a disposition a human or
+ * an upstream process already reached — that is the exact "assert a decision the chairman did not
+ * make" failure this SD exists to remove, and the previous uniform `.neq(status, target)` fence
+ * committed it.
+ *
+ * MEASURED against the 15 live deferral targets: 6 resolve to feedback (3 of them status='resolved')
+ * and 7 to chairman_decisions (3 of them status='approved'). Under the old fence ALL 13 matched, so
+ * retirement would have overwritten three resolved feedback rows AND ERASED THREE CHAIRMAN
+ * APPROVALS. chairman_decisions.status has no CHECK constraint to stop it.
+ *
+ * The sets are per-arm because the arms have genuinely different vocabularies — the whole reason
+ * FR-1 is arm-aware. chairman_decisions is undecided ONLY at 'pending' (approved=248, cancelled=358,
+ * rejected=7 are all decisions already made). feedback has no 'pending' at all; its live statuses
+ * are new/triaged/in_progress/backlog (open) and resolved/wont_fix/duplicate/invalid/shipped (done).
+ */
+export const RETIRABLE_STATUSES = Object.freeze({
+  chairman_decisions: Object.freeze(['pending']),
+  feedback: Object.freeze(['new', 'triaged', 'in_progress', 'backlog'])
+});
+
 /** Which source table backs each arm of the union. */
 export function armOf(row) {
   switch (row?.decision_type) {
@@ -91,17 +126,17 @@ export function planRetirement(row, dispositions, { disposition = 'held' } = {})
 
   return {
     verdict: 'retire', arm, table, id: row.id, citation: auth, reason: null,
-    patch: {
-      status,
-      // The citation travels WITH the write. A retirement whose basis lives only in a commit
-      // message is the unattributable stamp this SD removes.
-      retirement_basis: {
-        cited_record: auth.citedRecord,
-        decided_by: auth.decidedBy,
-        decided_at: auth.decidedAt,
-        disposition: superseded ? 'superseded' : 'held'
-      }
-    }
+    // The citation travels WITH the write. A retirement whose basis lives only in a commit message
+    // is the unattributable stamp this SD removes. It is nested into an EXISTING jsonb column
+    // (see CITATION_COLUMN) because `retirement_basis` is not a column on either table.
+    citationColumn: CITATION_COLUMN[table],
+    retirementBasis: {
+      cited_record: auth.citedRecord,
+      decided_by: auth.decidedBy,
+      decided_at: auth.decidedAt,
+      disposition: superseded ? 'superseded' : 'held'
+    },
+    patch: { status }
   };
 }
 
@@ -115,16 +150,43 @@ export function planRetirement(row, dispositions, { disposition = 'held' } = {})
  */
 export async function applyRetirement(db, plan) {
   if (!plan || plan.verdict !== 'retire') return { wrote: false, reason: plan?.reason || 'no_authority' };
-  // THE FENCE IS "not already retired", NOT "status = pending".
-  // Arm 4's chairman_decisions does use status='pending', but arm 5's feedback DOES NOT — its live
-  // values are new/resolved/backlog/duplicate/wont_fix/triaged/invalid/in_progress, and "pending" is
-  // synthesised by the view (:181), not stored. Fencing on 'pending' would match zero feedback rows
-  // and make arm-5 retirement a silent no-op that still reported success.
+
+  const retirable = RETIRABLE_STATUSES[plan.table];
+  const col = plan.citationColumn;
+  if (!retirable || !col) return { wrote: false, reason: 'unknown_table', table: plan.table };
+
+  // READ FIRST, for two reasons that both matter.
+  // (1) The citation nests into an EXISTING jsonb column, and a Supabase update REPLACES that column
+  //     wholesale — writing it blind would destroy whatever else lives there.
+  // (2) EVERY zero-row outcome must be DISTINGUISHABLE. The previous version returned
+  //     {wrote:false} for "already retired", "row absent" AND (with the error branch mutated away)
+  //     a failed write — so a retirement that never happened was indistinguishable from correct
+  //     idempotency. Silence is the failure mode this SD exists to remove; it may not live here.
+  const { data: cur, error: readErr } = await db.from(plan.table)
+    .select(`id, status, ${col}`)
+    .eq('id', plan.id);
+  if (readErr) return { wrote: false, reason: 'db_error', error: readErr.message };
+  if (!cur || cur.length === 0) return { wrote: false, reason: 'not_found', id: plan.id };
+
+  const row = cur[0];
+  if (row.status === plan.patch.status) return { wrote: false, reason: 'already_retired', status: row.status };
+  // REFUSE rather than overwrite. Measured: this is what stops retirement erasing three live
+  // chairman approvals and overwriting three resolved feedback rows.
+  if (!retirable.includes(row.status)) {
+    return { wrote: false, reason: 'refused_terminal_status', status: row.status, id: plan.id };
+  }
+
+  const merged = { ...(row[col] && typeof row[col] === 'object' ? row[col] : {}), retirement_basis: plan.retirementBasis };
+
+  // The fence is REPEATED on the write so a concurrent decision between the read and the write
+  // cannot slip through: status must still be retirable and still not be the target value.
   const { data, error } = await db.from(plan.table)
-    .update(plan.patch)
+    .update({ ...plan.patch, [col]: merged })
     .eq('id', plan.id)
-    .neq('status', plan.patch.status)   // idempotency: a second call matches nothing
+    .in('status', retirable)
+    .neq('status', plan.patch.status)
     .select('id');
-  if (error) return { wrote: false, error: error.message };
-  return { wrote: (data || []).length > 0, id: plan.id, citation: plan.citation };
+  if (error) return { wrote: false, reason: 'db_error', error: error.message };
+  if (!data || data.length === 0) return { wrote: false, reason: 'raced', id: plan.id };
+  return { wrote: true, id: plan.id, citation: plan.citation, citationColumn: col };
 }

--- a/lib/chairman/decision-retirement.mjs
+++ b/lib/chairman/decision-retirement.mjs
@@ -1,0 +1,130 @@
+/**
+ * lib/chairman/decision-retirement.mjs — arm-aware retirement planning.
+ * SD-FDBK-INFRA-DECISION-QUEUE-RETIREMENT-001, FR-1.
+ *
+ * PURE PLANNER, SEPARATE WRITER. planRetirement() decides; applyRetirement() writes. The split is
+ * the point: "absence of authority blocks retirement" (FR-3) is only structural if the decision is
+ * a value you can assert on rather than a branch buried in a DB call.
+ *
+ * ===== WHY RETIREMENT IS PER-ARM =====
+ * chairman_pending_decisions is a SEVEN-ARM UNION (20260611_chairman_decision_queue.sql:59-244), not
+ * a view over one table. Arm 4 is chairman_decisions, arm 5 is feedback, arm 6 is leo_feature_flags,
+ * and the "pending" predicate is synthesised per arm at :296. So there is no single column to write.
+ * A retirement built against one table would silently cover a third of the queue.
+ *
+ * ===== THE STATUS VOCABULARY WAS READ, NOT INVENTED =====
+ * The precedent this SD originally cited (qf-20260725-450) writes status='cancelled' to
+ * chairman_decisions, whose status is plain text with NO CHECK. Copying that to arm 5 dies at
+ * runtime with 23514, because feedback.status is governed by feedback_status_check, whose permitted
+ * set is exactly: new, triaged, in_progress, resolved, wont_fix, duplicate, invalid, backlog,
+ * shipped (database/migrations/20260131_feedback_resolution_enforcement.sql:150-165). There is no
+ * 'retired' or 'held' term.
+ *
+ * Rather than add one — DDL, and CREATE OR REPLACE is chairman-gated — two existing values already
+ * carry the needed meaning WITHOUT asserting a decision the chairman never made (TR-3):
+ *   SUPERSEDED -> 'duplicate'  a newer instance replaced this one
+ *   HELD       -> 'backlog'    parked under a standing disposition, not decided
+ * 'resolved' and 'wont_fix' are deliberately NOT used: both assert an outcome the chairman did not
+ * reach, which is the failure this SD exists to remove.
+ *
+ * ===== ARM 6 CANNOT BE RETIRED FROM JS, AND SAYS SO =====
+ * Arm 6 projects leo_feature_flags through a predicate (is_enabled=false AND
+ * lifecycle_state='draft' AND created_at < now()-7d). Exiting it requires either mutating the flag —
+ * which re-asserts the KILL disposition the 2026-07-12 ruling reverted, forbidden by TR-3 — or
+ * changing the view, which is CREATE OR REPLACE and therefore TIER-2 chairman-gated
+ * (scripts/lib/migration-tier-classifier.mjs:323). The planner returns an explicit 'gated' verdict
+ * rather than silently skipping, so a caller cannot mistake "cannot" for "nothing to do".
+ */
+
+import { retirementAuthority } from './decision-disposition.mjs';
+
+/** feedback.status values permitted by feedback_status_check. Read from the migration, not guessed. */
+export const FEEDBACK_STATUS = Object.freeze({
+  SUPERSEDED: 'duplicate',
+  HELD: 'backlog'
+});
+
+/** chairman_decisions.status is plain text with no CHECK, so the honest term is available there. */
+export const DECISION_STATUS = Object.freeze({
+  SUPERSEDED: 'superseded',
+  HELD: 'held'
+});
+
+/** Which source table backs each arm of the union. */
+export function armOf(row) {
+  switch (row?.decision_type) {
+    case 'chairman_approval': return 'arm4';
+    case 'flag_review': return 'arm5';
+    case 'flag_enablement': return 'arm6';
+    default: return 'unknown';
+  }
+}
+
+/**
+ * Decide whether and how to retire a row. PURE.
+ *
+ * @returns {null | {verdict:'gated'|'retire', arm, table, id, patch, citation, reason}}
+ *   null    — no authority; retirement is BLOCKED, never defaulted
+ *   'gated' — the arm cannot be retired without chairman-gated DDL
+ */
+export function planRetirement(row, dispositions, { disposition = 'held' } = {}) {
+  const auth = retirementAuthority(row, dispositions);
+  // FR-3: absence of authority BLOCKS retirement. Returning null rather than a permissive object
+  // forces every caller to handle it — a truthy default here would retire the whole queue.
+  if (!auth) return null;
+
+  const arm = armOf(row);
+  if (arm === 'arm6') {
+    return {
+      verdict: 'gated', arm, table: 'leo_feature_flags', id: row.id, patch: null, citation: auth,
+      reason: 'arm 6 exits only via the view predicate (CREATE OR REPLACE => TIER-2 chairman-gated) ' +
+        'or by mutating the flag, which would re-assert the reverted KILL disposition'
+    };
+  }
+  if (arm === 'unknown') return null;
+
+  const superseded = disposition === 'superseded';
+  const table = arm === 'arm4' ? 'chairman_decisions' : 'feedback';
+  const status = arm === 'arm4'
+    ? (superseded ? DECISION_STATUS.SUPERSEDED : DECISION_STATUS.HELD)
+    : (superseded ? FEEDBACK_STATUS.SUPERSEDED : FEEDBACK_STATUS.HELD);
+
+  return {
+    verdict: 'retire', arm, table, id: row.id, citation: auth, reason: null,
+    patch: {
+      status,
+      // The citation travels WITH the write. A retirement whose basis lives only in a commit
+      // message is the unattributable stamp this SD removes.
+      retirement_basis: {
+        cited_record: auth.citedRecord,
+        decided_by: auth.decidedBy,
+        decided_at: auth.decidedAt,
+        disposition: superseded ? 'superseded' : 'held'
+      }
+    }
+  };
+}
+
+/**
+ * Apply a plan. IDEMPOTENT BY CONSTRUCTION (TR-9): the update is filtered on the row still being
+ * pending, so a second call matches nothing and cannot move a timestamp. The live defect this
+ * guards against is arm 5's writer setting resolved_at: new Date() unconditionally
+ * (scripts/chairman-decisions.mjs:76), which silently shifts the disposition time on every re-run.
+ *
+ * Deliberately does NOT write resolved_at: retirement is not resolution.
+ */
+export async function applyRetirement(db, plan) {
+  if (!plan || plan.verdict !== 'retire') return { wrote: false, reason: plan?.reason || 'no_authority' };
+  // THE FENCE IS "not already retired", NOT "status = pending".
+  // Arm 4's chairman_decisions does use status='pending', but arm 5's feedback DOES NOT — its live
+  // values are new/resolved/backlog/duplicate/wont_fix/triaged/invalid/in_progress, and "pending" is
+  // synthesised by the view (:181), not stored. Fencing on 'pending' would match zero feedback rows
+  // and make arm-5 retirement a silent no-op that still reported success.
+  const { data, error } = await db.from(plan.table)
+    .update(plan.patch)
+    .eq('id', plan.id)
+    .neq('status', plan.patch.status)   // idempotency: a second call matches nothing
+    .select('id');
+  if (error) return { wrote: false, error: error.message };
+  return { wrote: (data || []).length > 0, id: plan.id, citation: plan.citation };
+}

--- a/scripts/chairman-decisions.mjs
+++ b/scripts/chairman-decisions.mjs
@@ -51,7 +51,16 @@ if (parsed.command === 'list') {
       const { data: disp, error: dErr } = await db.from('feedback')
         .select(DISPOSITION_SELECT)
         .eq('category', DEFERRAL_CATEGORY);
-      if (!dErr) dispositions = indexDispositions(disp || []);
+      // supabase-js RETURNS PostgREST failures in `error`; it does not throw. So the catch below
+      // never sees them, and an `if (!dErr)` with no else left the most likely failure — a drifted
+      // DISPOSITION_SELECT yielding a 400 — completely silent, rendering an uncorrected queue that
+      // looks healthy. That is the same blindness that let a dead FR-6 ship green, arriving through
+      // the error channel instead of the empty-result one.
+      if (dErr) {
+        console.error('[chairman-decisions] disposition query FAILED, rendering uncorrected: ' + dErr.message);
+      } else {
+        dispositions = indexDispositions(disp || []);
+      }
     } catch (e) {
       // Fail-soft: render without the correction rather than not at all. NOT silent — a swallowed
       // error here is indistinguishable from "no deferrals exist", which is the failure mode that

--- a/scripts/chairman-decisions.mjs
+++ b/scripts/chairman-decisions.mjs
@@ -11,8 +11,9 @@
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import {
-  parseArgs, routeDecision, sortPending, effectivePriority, formatAge, USAGE,
+  parseArgs, routeDecision, sortPending, effectivePriority, formatAge, renderPendingLine, USAGE,
 } from '../lib/chairman/decision-queue.mjs';
+import { indexDispositions, ageClockFor, DEFERRAL_CATEGORY } from '../lib/chairman/decision-disposition.mjs';
 import { armCliTeardown } from '../lib/cli-graceful-exit.js';
 import { CHAIRMAN_FEEDBACK_TYPE } from '../lib/chairman/feedback-decision-type.mjs';
 
@@ -37,21 +38,39 @@ if (parsed.command === 'list') {
     // Sort client-side with the same semantics as the view (also covers a
     // pre-migration view that lacks blocking/effective_priority columns).
     const rows = sortPending(data || []);
+    // FR-6: read the dispositions the queue has never read. Five of seven rows were deferred —
+    // several twice — and measured live it is SEVEN of seven, every one within ~1.3 days. Ageing
+    // them from created_at is what makes a settled queue present as stale and escalating.
+    // Fail-soft: a disposition read that errors leaves the prior behaviour intact rather than
+    // taking down the chairman's list.
+    let dispositions = null;
+    try {
+      const { data: disp, error: dErr } = await db.from('feedback')
+        .select('id, category, created_at, snoozed_until, metadata, description, title')
+        .eq('category', DEFERRAL_CATEGORY);
+      if (!dErr) dispositions = indexDispositions(disp || []);
+    } catch { /* fail-soft: render without the correction rather than not at all */ }
+
     if (parsed.json) {
-      console.log(JSON.stringify(rows.map((r) => ({
-        ...r,
-        effective_priority: r.effective_priority ?? effectivePriority(r).label,
-        age_escalated: r.age_escalated ?? effectivePriority(r).escalated,
-      })), null, 2));
+      console.log(JSON.stringify(rows.map((r) => {
+        const clock = ageClockFor(r, dispositions);
+        const deferred = clock.source === 'deferral';
+        const ep = effectivePriority(deferred ? { ...r, created_at: clock.since } : r);
+        return {
+          ...r,
+          effective_priority: deferred ? ep.label : (r.effective_priority ?? ep.label),
+          age_escalated: deferred ? ep.escalated : (r.age_escalated ?? ep.escalated),
+          // Surfaced so a machine reader can see WHY the clock moved, not just that it did.
+          disposition: clock.disposition
+            ? { deferred_at: clock.disposition.deferredAt, decided_by: clock.disposition.decidedBy, cited_record: clock.disposition.sourceId }
+            : null,
+          age_since: clock.since,
+          age_clock_source: clock.source
+        };
+      }), null, 2));
     } else {
       if (!rows.length) console.log('No pending chairman decisions.');
-      for (const r of rows) {
-        const ep = effectivePriority(r);
-        const pri = (r.effective_priority ?? ep.label) + ((r.age_escalated ?? ep.escalated) ? '^ (age-escalated)' : '');
-        const block = r.blocking ? ' BLOCKING' : '';
-        console.log(`[${formatAge(r.created_at)}] [${r.decision_type}:${r.id}] [${pri}${block}] ${r.title}` +
-          (r.recommendation ? ' — ' + r.recommendation : ''));
-      }
+      for (const r of rows) console.log(renderPendingLine(r, { dispositions }));
       console.log('\n' + rows.length + ' pending. Decide: node scripts/chairman-decisions.mjs decide <decision_type:id> <approve|reject|defer> --rationale "..."');
     }
     await armCliTeardown(0);

--- a/scripts/chairman-decisions.mjs
+++ b/scripts/chairman-decisions.mjs
@@ -38,9 +38,10 @@ if (parsed.command === 'list') {
     // Sort client-side with the same semantics as the view (also covers a
     // pre-migration view that lacks blocking/effective_priority columns).
     const rows = sortPending(data || []);
-    // FR-6: read the dispositions the queue has never read. Five of seven rows were deferred —
-    // several twice — and measured live it is SEVEN of seven, every one within ~1.3 days. Ageing
-    // them from created_at is what makes a settled queue present as stale and escalating.
+    // FR-6: read the dispositions the queue has never read. Measured live, SEVEN of seven rows
+    // carry a deferral — several twice — every one within ~1.3 days. (An early estimate said five
+    // of seven; the measurement superseded it.) Ageing them from created_at is what makes a
+    // settled queue present as stale and escalating.
     // Fail-soft: a disposition read that errors leaves the prior behaviour intact rather than
     // taking down the chairman's list.
     let dispositions = null;

--- a/scripts/chairman-decisions.mjs
+++ b/scripts/chairman-decisions.mjs
@@ -13,7 +13,7 @@ import { createClient } from '@supabase/supabase-js';
 import {
   parseArgs, routeDecision, sortPending, effectivePriority, formatAge, renderPendingLine, USAGE,
 } from '../lib/chairman/decision-queue.mjs';
-import { indexDispositions, ageClockFor, DEFERRAL_CATEGORY } from '../lib/chairman/decision-disposition.mjs';
+import { indexDispositions, ageClockFor, DEFERRAL_CATEGORY, DISPOSITION_SELECT } from '../lib/chairman/decision-disposition.mjs';
 import { armCliTeardown } from '../lib/cli-graceful-exit.js';
 import { CHAIRMAN_FEEDBACK_TYPE } from '../lib/chairman/feedback-decision-type.mjs';
 
@@ -45,11 +45,19 @@ if (parsed.command === 'list') {
     // taking down the chairman's list.
     let dispositions = null;
     try {
+      // DISPOSITION_SELECT, not a hand-written column list: the provenance fence needs
+      // source_type/venture_id/feedback_type, and a list that drifts from it silently disables
+      // FR-6 entirely (it already did once — see DISPOSITION_SELECT's docstring).
       const { data: disp, error: dErr } = await db.from('feedback')
-        .select('id, category, created_at, snoozed_until, metadata, description, title')
+        .select(DISPOSITION_SELECT)
         .eq('category', DEFERRAL_CATEGORY);
       if (!dErr) dispositions = indexDispositions(disp || []);
-    } catch { /* fail-soft: render without the correction rather than not at all */ }
+    } catch (e) {
+      // Fail-soft: render without the correction rather than not at all. NOT silent — a swallowed
+      // error here is indistinguishable from "no deferrals exist", which is the failure mode that
+      // let a dead FR-6 look healthy.
+      console.error('[chairman-decisions] disposition read failed, rendering uncorrected: ' + (e?.message || e));
+    }
 
     if (parsed.json) {
       console.log(JSON.stringify(rows.map((r) => {

--- a/scripts/eva/__tests__/portfolio-review-round.test.js
+++ b/scripts/eva/__tests__/portfolio-review-round.test.js
@@ -33,6 +33,13 @@ function makeDb({ ventures = [REAL_VENTURE], windows = [[]], slot = null } = {})
         select: vi.fn(() => chain),
         eq: vi.fn(() => chain),
         gte: vi.fn(() => chain),
+        // FR-4 supersession (SD-FDBK-INFRA-DECISION-QUEUE-RETIREMENT-001) queries prior-window
+        // pending packets and AWAITS the chain directly, so .lt must be THENABLE. Returning the
+        // chain here would resolve to the chain object, leave `data` undefined, and let the
+        // supersession silently no-op — the non-thenable-double trap. These fixtures seed no
+        // prior-window rows, so an empty set is the accurate answer; the supersession itself is
+        // covered in tests/unit/chairman/decision-disposition.test.js against a filter-aware fake.
+        lt: vi.fn(async () => ({ data: [], error: null })),
         order: vi.fn(() => chain),
         maybeSingle: vi.fn(async () => ({ data: slot })),
         limit: vi.fn(async () => {

--- a/scripts/eva/portfolio-review-round.mjs
+++ b/scripts/eva/portfolio-review-round.mjs
@@ -174,6 +174,39 @@ export async function portfolioReviewHandler({ dryRun = false, supabase = null, 
     }
   }
 
+  // FR-4 (SD-FDBK-INFRA-DECISION-QUEUE-RETIREMENT-001): SUPERSEDE THE PRIOR WINDOW'S PACKET.
+  // The cadence above is correctly idempotent WITHIN a window, but nothing retired the PREVIOUS
+  // one — so a new Stage-0 row appeared every 7 days and the old one never left. Measured live:
+  // exactly two portfolio_review rows existed and BOTH were pending, listing the same ventures.
+  // Left alone this accrues one stale critical per cycle forever, and arm 4 hardcodes
+  // priority='critical', so every accrued row lands at the top of the chairman's queue.
+  //
+  // Only fires when a NEW packet was actually inserted, so re-running inside the same window
+  // supersedes nothing — the idempotency contract above is preserved rather than reinterpreted.
+  //
+  // status='superseded', never approved/rejected: the chairman did not decide this packet, and
+  // crediting him with a decision he never made is the failure mode TR-3 forbids. The pointer
+  // lands in brief_data so the audit trail survives — a bare disappearance loses why it left.
+  let superseded = [];
+  if (insertedPacket) {
+    const { data: priors, error: priorErr } = await db
+      .from('chairman_decisions')
+      .select('id, brief_data')
+      .eq('decision_type', PORTFOLIO_REVIEW_DECISION_TYPE)
+      .eq('status', 'pending')
+      .lt('created_at', windowStart);
+    if (priorErr) throw new Error(`supersede lookup failed: ${priorErr.message}`);
+    for (const prior of priors || []) {
+      if (prior.id === packetId) continue;
+      const { error: supErr } = await db.from('chairman_decisions').update({
+        status: 'superseded',
+        brief_data: { ...(prior.brief_data || {}), superseded_by: packetId, superseded_at: new Date().toISOString() }
+      }).eq('id', prior.id);
+      // Fail-soft: a supersession that errors must not lose the packet we just recorded.
+      if (!supErr) superseded.push(prior.id);
+    }
+  }
+
   // The (review_date, 'ad_hoc') slot is shared with genuine ad-hoc management
   // reviews (UNIQUE constraint). Never clobber a foreign row — skip the durable
   // record instead (the packet row above is the load-bearing artifact).
@@ -185,7 +218,7 @@ export async function portfolioReviewHandler({ dryRun = false, supabase = null, 
     .maybeSingle();
   if (slot && slot.decisions?.kind !== PORTFOLIO_REVIEW_DECISION_TYPE) {
     console.warn(`management_reviews (${reviewDate}, ad_hoc) slot held by a non-portfolio review — skipping durable record to avoid clobbering it`);
-    return { reviewDate, packetId, insertedPacket, ventures: ventures.length, strategyActive: !!strategy, reviewRecordSkipped: true };
+    return { reviewDate, packetId, insertedPacket, superseded, ventures: ventures.length, strategyActive: !!strategy, reviewRecordSkipped: true };
   }
 
   const { error: reviewErr } = await db
@@ -207,6 +240,7 @@ export async function portfolioReviewHandler({ dryRun = false, supabase = null, 
     reviewDate,
     packetId,
     insertedPacket,
+    superseded,
     ventures: ventures.length,
     strategyActive: !!strategy,
   };

--- a/tests/unit/chairman-decision-queue.test.js
+++ b/tests/unit/chairman-decision-queue.test.js
@@ -78,9 +78,38 @@ describe('TS-4 age escalation (visibility only)', () => {
       .toEqual({ rank: 3, label: 'normal', escalated: false });
   });
 
-  it('critical cannot escalate past critical', () => {
-    expect(effectivePriority({ priority: 'critical', created_at: hoursAgo(500) }, now))
-      .toEqual({ rank: 1, label: 'critical', escalated: false });
+  // FR-0 (SD-FDBK-INFRA-DECISION-QUEUE-RETIREMENT-001). THIS TEST PREVIOUSLY PINNED THE DEFECT.
+  // It asserted `escalated: false` for a critical row at 500h and PASSED — while that false was the
+  // bug. The name is about RANK and is still true (critical cannot outrank critical, and the floor
+  // that guarantees it is correct); the assertion was about the MARKER, which must fire whenever the
+  // age threshold is crossed regardless of whether the rank could move. Because `escalated` was
+  // computed as `rank < baseRank`, and critical's baseRank is 1, the comparison was 1 < 1 — false at
+  // ANY age. Four of the seven live queue rows are critical, one at 15 days, none ever marked.
+  // Do not restore the old assertion: a green test over a live defect is worse than no test.
+  it('critical keeps rank 1 but IS marked escalated past the threshold', () => {
+    const aged = effectivePriority({ priority: 'critical', created_at: hoursAgo(500) }, now);
+    expect(aged.rank, 'critical cannot outrank critical — the floor is correct').toBe(1);
+    expect(aged.label).toBe('critical');
+    expect(aged.escalated, 'the MARKER must fire on age, not on rank movement').toBe(true);
+  });
+
+  it('critical below the threshold is NOT marked — the fix must not mark everything', () => {
+    const fresh = effectivePriority({ priority: 'critical', created_at: hoursAgo(1) }, now);
+    expect(fresh.rank).toBe(1);
+    expect(fresh.escalated).toBe(false);
+  });
+
+  it('every priority class can reach escalated=true — no class is structurally blind', () => {
+    // The matrix is the test. A normal-priority seed passes even with the defect live, which is
+    // why a single seeded row proved nothing here.
+    for (const priority of ['critical', 'high', 'normal', 'low']) {
+      const r = effectivePriority({ priority, created_at: hoursAgo(500) }, now);
+      expect(r.escalated, `${priority} must be capable of escalating`).toBe(true);
+    }
+    for (const priority of ['critical', 'high', 'normal', 'low']) {
+      const r = effectivePriority({ priority, created_at: hoursAgo(1) }, now);
+      expect(r.escalated, `${priority} must not escalate when fresh`).toBe(false);
+    }
   });
 
   it('sortPending orders blocking DESC, effective class, then created_at ASC', () => {

--- a/tests/unit/chairman/decision-disposition.test.js
+++ b/tests/unit/chairman/decision-disposition.test.js
@@ -192,3 +192,98 @@ describe('FR-6/TR-8 renderPendingLine — the rendered surface, now assertable',
     expect(line).toContain('chairman_approval:dec-1');
   });
 });
+
+describe('FR-4 supersession — a recurring review must not accrue one stale critical per cycle', () => {
+  // A fake that records writes and is TABLE- and FILTER-aware, so a supersession aimed at the
+  // wrong table or the wrong window cannot pass. Seeded with a PRIOR-window pending packet and a
+  // FOREIGN decision_type that must be left alone.
+  function reviewFake({ existingInWindow = [], priors = [] } = {}) {
+    const writes = [];
+    const rows = {
+      chairman_decisions: [
+        ...existingInWindow.map((r) => ({ ...r, _window: 'current' })),
+        ...priors.map((r) => ({ ...r, _window: 'prior' }))
+      ]
+    };
+    const q = (table) => {
+      let sel = rows[table] ? rows[table].slice() : [];
+      const api = {
+        select: () => api,
+        eq: (c, v) => { sel = sel.filter((r) => r[c] === v); return api; },
+        neq: (c, v) => { sel = sel.filter((r) => r[c] !== v); return api; },
+        gte: () => { sel = sel.filter((r) => r._window === 'current'); return api; },
+        lt: () => { sel = sel.filter((r) => r._window === 'prior'); return api; },
+        order: () => api,
+        // fetchAllPaginated drives the ventures read through .range()
+        range: async (a, b) => ({ data: sel.slice(a, b + 1), error: null }),
+        limit: async (n) => ({ data: sel.slice(0, n), error: null }),
+        // The management_reviews leg runs AFTER the supersession; stubbed so it cannot mask a
+        // supersession failure by throwing first.
+        maybeSingle: async () => ({ data: sel[0] || null, error: null }),
+        insert: async () => ({ error: null }),
+        upsert: async () => ({ error: null }),
+        update: (patch) => ({ eq: async (c, v) => { writes.push({ table, id: v, patch }); return { error: null }; } }),
+        delete: () => ({ eq: async () => ({ error: null }) }),
+        then: (res, rej) => Promise.resolve({ data: sel.slice(), error: null }).then(res, rej)
+      };
+      return api;
+    };
+    return { from: (t) => q(t), _writes: writes };
+  }
+
+  const handler = async (db, extra = {}) => {
+    const { portfolioReviewHandler } = await import('../../../scripts/eva/portfolio-review-round.mjs');
+    return portfolioReviewHandler({
+      supabase: db,
+      deps: {
+        loadStrategy: async () => ({ vision_key: 'VISION-PORTFOLIO-STRATEGY-001' }),
+        record: async () => ({ recorded: true, id: 'new-packet' }),
+        ...extra
+      }
+    });
+  };
+
+  it('a NEW window supersedes the prior pending packet WITH a pointer', async () => {
+    const db = reviewFake({ priors: [{ id: 'old-packet', decision_type: 'portfolio_review', status: 'pending', brief_data: { keep: 1 } }] });
+    const res = await handler(db);
+    expect(res.insertedPacket).toBe(true);
+    expect(res.superseded).toContain('old-packet');
+    const w = db._writes.find((x) => x.id === 'old-packet');
+    expect(w.table).toBe('chairman_decisions');
+    expect(w.patch.status).toBe('superseded');
+    expect(w.patch.brief_data.superseded_by).toBe('new-packet');
+    expect(w.patch.brief_data.keep, 'existing brief_data must survive').toBe(1);
+  });
+
+  it('NEVER records approved/rejected — the chairman did not decide this packet (TR-3)', async () => {
+    const db = reviewFake({ priors: [{ id: 'old-packet', decision_type: 'portfolio_review', status: 'pending' }] });
+    await handler(db);
+    const w = db._writes.find((x) => x.id === 'old-packet');
+    expect(['approved', 'rejected']).not.toContain(w.patch.status);
+  });
+
+  it('SAME-window re-run supersedes NOTHING — the idempotency contract is preserved', async () => {
+    // A packet already occupies the window, so no insert happens and no supersession may fire.
+    const db = reviewFake({
+      existingInWindow: [{ id: 'this-window', decision_type: 'portfolio_review', status: 'pending' }],
+      priors: [{ id: 'old-packet', decision_type: 'portfolio_review', status: 'pending' }]
+    });
+    const res = await handler(db);
+    expect(res.insertedPacket).toBe(false);
+    expect(res.superseded).toEqual([]);
+    expect(db._writes.length, 'a same-window re-run must write nothing').toBe(0);
+  });
+
+  it('a prior packet ALREADY decided is not re-touched — only pending rows supersede', async () => {
+    const db = reviewFake({ priors: [{ id: 'old-decided', decision_type: 'portfolio_review', status: 'approved' }] });
+    const res = await handler(db);
+    expect(res.superseded).toEqual([]);
+  });
+
+  it('a FOREIGN decision_type in the prior window is left alone', async () => {
+    const db = reviewFake({ priors: [{ id: 'other-arm', decision_type: 'framing_escalation', status: 'pending' }] });
+    const res = await handler(db);
+    expect(res.superseded).toEqual([]);
+    expect(db._writes.length).toBe(0);
+  });
+});

--- a/tests/unit/chairman/decision-disposition.test.js
+++ b/tests/unit/chairman/decision-disposition.test.js
@@ -383,6 +383,21 @@ describe('SECURITY — retirement authority must not be forgeable by an unauthen
     expect(indexDispositions([{ ...base, venture_id: 'any-non-null' }]).size).toBe(0);
     expect(indexDispositions([{ ...base, feedback_type: 'user_other' }]).size).toBe(0);
   });
+
+  it('clause 3 matches SQL LIKE semantics — `_` is a WILDCARD, not a literal underscore', () => {
+    // venture_user_insert_feedback admits anything matching LIKE 'user_%', and in SQL `_` matches
+    // ANY single character. A literal startsWith('user_') would admit these while the policy admits
+    // them too — making the header's "independent second block" claim false. Blocked today by
+    // clause 2 regardless; this pins the clause-3 guarantee itself.
+    const base = deferral('dec-1', 1);
+    for (const ft of ['user_bug', 'userX', 'usera', 'user-bug', 'user.bug']) {
+      expect(indexDispositions([{ ...base, feedback_type: ft }]).size, ft).toBe(0);
+    }
+    // ...and it must NOT over-block: the genuine value and other non-user_% values still govern.
+    for (const ft of ['sentry_error', 'venture_error', 'user']) {
+      expect(indexDispositions([{ ...base, feedback_type: ft }]).size, ft).toBe(1);
+    }
+  });
 });
 
 describe('SECURITY — an under-selecting caller must FAIL LOUDLY, not silently yield nothing', () => {

--- a/tests/unit/chairman/decision-disposition.test.js
+++ b/tests/unit/chairman/decision-disposition.test.js
@@ -56,6 +56,30 @@ describe('FR-3 disposition reader — indexing', () => {
     expect(indexDispositions([{ id: 'z', category: 'harness_backlog', metadata: { target_id: 'dec-1' } }]).size).toBe(0);
   });
 
+  it('D6: metadata.deferred_at TAKES PRECEDENCE over the row created_at', () => {
+    // The helper sets created_at and metadata.deferred_at to the SAME instant, which makes the
+    // `md.deferred_at || r.created_at` ordering unobservable — swapping the operands kept the suite
+    // green. Here they differ, so the precedence is pinned. This matters on live data: a deferral
+    // row's created_at is when the AUDIT ROW was written, which is not necessarily the moment the
+    // chairman deferred.
+    const m = indexDispositions([{
+      ...deferral('dec-1', 56),
+      created_at: iso(56),
+      metadata: { target_id: 'dec-1', decided_by: 'chairman-cli', deferred_at: iso(2) }
+    }]);
+    expect(m.get('dec-1').deferredAt).toBe(iso(2));
+    expect(m.get('dec-1').deferredAt).not.toBe(iso(56));
+  });
+
+  it('D6b: falls back to created_at only when deferred_at is absent', () => {
+    const m = indexDispositions([{
+      ...deferral('dec-1', 56),
+      created_at: iso(9),
+      metadata: { target_id: 'dec-1', decided_by: 'chairman-cli' }   // no deferred_at
+    }]);
+    expect(m.get('dec-1').deferredAt).toBe(iso(9));
+  });
+
   it('a row deferred TWICE is governed by the LATER deferral — three live rows have this shape', () => {
     const m = indexDispositions([deferral('dec-1', 10), deferral('dec-1', 2)]);
     expect(m.size).toBe(1);
@@ -191,6 +215,30 @@ describe('FR-6/TR-8 renderPendingLine — the rendered surface, now assertable',
     const { renderPendingLine } = await import('../../../lib/chairman/decision-queue.mjs');
     const d = indexDispositions([deferral('dec-1', 1, { snoozed_until: new Date(NOW.getTime() + 86400000).toISOString() })]);
     expect(renderPendingLine(row(), { dispositions: d, now: NOW })).toContain('HELD');
+  });
+
+  it('Q6: on an UNDEFERRED row the view false is HONOURED — `??` not `||`', async () => {
+    // The distinguishing case the suite lacked. With `??`, an explicit age_escalated:false from the
+    // view is kept even on an old row (the view governs when there is no deferral to correct it).
+    // With `||`, false is falsy and the recomputed verdict leaks through, flipping the marker on.
+    // Every prior fixture used age_escalated:true, where both operators agree.
+    const { renderPendingLine } = await import('../../../lib/chairman/decision-queue.mjs');
+    const line = renderPendingLine(row({ age_escalated: false }), { dispositions: null, now: NOW });
+    expect(line).not.toContain('age-escalated');
+  });
+
+  it('Q4: on a DEFERRED row the recomputed label WINS over a stale view label', async () => {
+    // Every prior fixture passed effective_priority:'critical' on a critical row, so the view label
+    // and the recomputed label agreed by construction and the override was unobservable. Here they
+    // DISAGREE: the view still says 'critical', the deferral-corrected clock says 'normal'.
+    const { renderPendingLine } = await import('../../../lib/chairman/decision-queue.mjs');
+    const d = indexDispositions([deferral('dec-1', 1)]);
+    const line = renderPendingLine(
+      row({ priority: 'normal', effective_priority: 'critical', age_escalated: true }),
+      { dispositions: d, now: NOW }
+    );
+    expect(line).toContain('[normal');
+    expect(line).not.toContain('[critical');
   });
 
   it('BLOCKING and recommendation survive the rewrite — no regression to the existing line', async () => {

--- a/tests/unit/chairman/decision-disposition.test.js
+++ b/tests/unit/chairman/decision-disposition.test.js
@@ -1,0 +1,137 @@
+/**
+ * lib/chairman/decision-disposition.mjs — FR-3, the disposition reader.
+ * SD-FDBK-INFRA-DECISION-QUEUE-RETIREMENT-001.
+ *
+ * The fixtures mirror the LIVE shape, measured by a full key census over all 21
+ * chairman_decision_deferred rows: target_id / decided_by / deferred_at / decision_type on 21 of 21,
+ * flag_id on ZERO, snoozed_until on ZERO. Fixtures invented from the writer's source would have
+ * carried flag_id and tested a key the data never uses.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  indexDispositions, ageClockFor, isHeld, retirementAuthority,
+  DEFERRAL_CATEGORY, DISPOSITION_KEY
+} from '../../../lib/chairman/decision-disposition.mjs';
+
+const NOW = new Date('2026-08-01T21:00:00Z');
+const iso = (d) => new Date(NOW.getTime() - d * 86400000).toISOString();
+
+const deferral = (targetId, daysAgo, extra = {}) => ({
+  id: `fb-${targetId}-${daysAgo}`,
+  category: DEFERRAL_CATEGORY,
+  created_at: iso(daysAgo),
+  snoozed_until: null,
+  description: 'Chairman verbal, verbatim: "defer both". REAFFIRMING A DELIBERATE HOLD.',
+  metadata: { target_id: targetId, decided_by: 'chairman-cli', deferred_at: iso(daysAgo), decision_type: 'chairman_approval' },
+  ...extra
+});
+
+describe('FR-3 disposition reader — indexing', () => {
+  it('keys on target_id, the key the live data actually uses', () => {
+    expect(DISPOSITION_KEY).toBe('target_id');
+    const m = indexDispositions([deferral('dec-1', 3)]);
+    expect(m.get('dec-1').decidedBy).toBe('chairman-cli');
+  });
+
+  it('IGNORES a record keyed only by flag_id — the writer branch this lane never produces', () => {
+    // scripts/chairman-decisions.mjs:96 writes metadata.flag_id; :113 writes metadata.target_id.
+    // The census says 21 of 21 use target_id and ZERO use flag_id. A flag_id-only record cannot be
+    // attributed to a decision, so it must govern nothing rather than silently half-match.
+    const m = indexDispositions([{
+      id: 'fb-x', category: DEFERRAL_CATEGORY, created_at: iso(1),
+      metadata: { flag_id: 'dec-1', decided_by: 'chairman-cli', deferred_at: iso(1) }
+    }]);
+    expect(m.size).toBe(0);
+  });
+
+  it('ignores rows of other categories', () => {
+    expect(indexDispositions([{ id: 'z', category: 'harness_backlog', metadata: { target_id: 'dec-1' } }]).size).toBe(0);
+  });
+
+  it('a row deferred TWICE is governed by the LATER deferral — three live rows have this shape', () => {
+    const m = indexDispositions([deferral('dec-1', 10), deferral('dec-1', 2)]);
+    expect(m.size).toBe(1);
+    expect(m.get('dec-1').deferredAt).toBe(iso(2));
+  });
+
+  it('order of input does not change the winner', () => {
+    const a = indexDispositions([deferral('dec-1', 2), deferral('dec-1', 10)]).get('dec-1').deferredAt;
+    const b = indexDispositions([deferral('dec-1', 10), deferral('dec-1', 2)]).get('dec-1').deferredAt;
+    expect(a).toBe(b);
+  });
+
+  it('malformed input yields an empty index rather than throwing', () => {
+    expect(indexDispositions(null).size).toBe(0);
+    expect(indexDispositions([null, undefined, {}]).size).toBe(0);
+  });
+});
+
+describe('FR-3/FR-6 age clock — the defect is that the queue ages from creation', () => {
+  it('a deferred row clocks from the DEFERRAL, not creation', () => {
+    const row = { id: 'dec-1', created_at: iso(56) };            // the live 56-day shape
+    const clock = ageClockFor(row, indexDispositions([deferral('dec-1', 4)]));
+    expect(clock.source).toBe('deferral');
+    expect(clock.since).toBe(iso(4));                             // 4 days, not 56
+    expect(clock.disposition.decidedBy).toBe('chairman-cli');
+  });
+
+  it('an UNDEFERRED row still clocks from creation — the fix must not reset everything', () => {
+    const clock = ageClockFor({ id: 'dec-9', created_at: iso(56) }, indexDispositions([deferral('dec-1', 4)]));
+    expect(clock.source).toBe('creation');
+    expect(clock.since).toBe(iso(56));
+    expect(clock.disposition).toBe(null);
+  });
+});
+
+describe('FR-3 hold semantics — a deferral is NOT a retirement', () => {
+  it('a deferral WITHOUT snoozed_until does not suppress the row', () => {
+    // Open-ended "not now" restarts the clock but must not hide the decision forever.
+    expect(isHeld({ id: 'dec-1' }, indexDispositions([deferral('dec-1', 2)]), NOW)).toBe(false);
+  });
+
+  it('a deferral WITH a future snoozed_until holds the row', () => {
+    const m = indexDispositions([deferral('dec-1', 2, { snoozed_until: new Date(NOW.getTime() + 86400000).toISOString() })]);
+    expect(isHeld({ id: 'dec-1' }, m, NOW)).toBe(true);
+  });
+
+  it('a snooze that has EXPIRED no longer holds — both directions on the same field', () => {
+    const m = indexDispositions([deferral('dec-1', 2, { snoozed_until: new Date(NOW.getTime() - 86400000).toISOString() })]);
+    expect(isHeld({ id: 'dec-1' }, m, NOW)).toBe(false);
+  });
+});
+
+describe('FR-3 retirement authority — absence BLOCKS retirement, never defaults it', () => {
+  it('a row with no disposition yields NULL authority', () => {
+    expect(retirementAuthority({ id: 'dec-9' }, indexDispositions([deferral('dec-1', 2)]))).toBe(null);
+  });
+
+  it('a row WITH a disposition yields a citation naming the record, the actor and the basis', () => {
+    const auth = retirementAuthority({ id: 'dec-1' }, indexDispositions([deferral('dec-1', 2)]));
+    expect(auth).not.toBe(null);
+    expect(auth.citedRecord).toBe('fb-dec-1-2');
+    expect(auth.decidedBy).toBe('chairman-cli');
+    expect(auth.basis).toMatch(/DELIBERATE HOLD/);
+    // Never a bare boolean: "retired" without a basis is the unattributable stamp this SD removes.
+    expect(typeof auth).toBe('object');
+  });
+
+  it('an UNATTRIBUTABLE record authorises nothing even though it is indexed', () => {
+    const m = indexDispositions([{
+      id: 'fb-y', category: DEFERRAL_CATEGORY, created_at: iso(1),
+      metadata: { target_id: 'dec-1', deferred_at: iso(1) }   // no decided_by
+    }]);
+    expect(m.size).toBe(1);                                    // it IS a record
+    expect(retirementAuthority({ id: 'dec-1' }, m)).toBe(null); // but it authorises nothing
+  });
+
+  it('mutation changes the verdict — proving the value is READ, not merely fetched', () => {
+    // FR-3 AC: "proven by MUTATION, not by a call". A reader that fetched and ignored would pass a
+    // call-count assertion; it cannot pass this pair.
+    const withActor = retirementAuthority({ id: 'dec-1' }, indexDispositions([deferral('dec-1', 2)]));
+    const stripped = deferral('dec-1', 2);
+    delete stripped.metadata.decided_by;
+    const withoutActor = retirementAuthority({ id: 'dec-1' }, indexDispositions([stripped]));
+    expect(withActor).not.toBe(null);
+    expect(withoutActor).toBe(null);
+  });
+});

--- a/tests/unit/chairman/decision-disposition.test.js
+++ b/tests/unit/chairman/decision-disposition.test.js
@@ -390,8 +390,10 @@ describe('SECURITY — retirement authority must not be forgeable by an unauthen
     // them too — making the header's "independent second block" claim false. Blocked today by
     // clause 2 regardless; this pins the clause-3 guarantee itself.
     const base = deferral('dec-1', 1);
-    for (const ft of ['user_bug', 'userX', 'usera', 'user-bug', 'user.bug']) {
-      expect(indexDispositions([{ ...base, feedback_type: ft }]).size, ft).toBe(0);
+    // The newline cases matter separately: JS `.` excludes line terminators but SQL `_` matches
+    // them, so /^user./ still admitted rows the policy admits. [\s\S] is the exact mirror.
+    for (const ft of ['user_bug', 'userX', 'usera', 'user-bug', 'user.bug', 'user\nx', 'user\rx', 'user x']) {
+      expect(indexDispositions([{ ...base, feedback_type: ft }]).size, JSON.stringify(ft)).toBe(0);
     }
     // ...and it must NOT over-block: the genuine value and other non-user_% values still govern.
     for (const ft of ['sentry_error', 'venture_error', 'user']) {

--- a/tests/unit/chairman/decision-disposition.test.js
+++ b/tests/unit/chairman/decision-disposition.test.js
@@ -135,3 +135,60 @@ describe('FR-3 retirement authority — absence BLOCKS retirement, never default
     expect(withoutActor).toBe(null);
   });
 });
+
+describe('FR-6/TR-8 renderPendingLine — the rendered surface, now assertable', () => {
+  const row = (over = {}) => ({
+    id: 'dec-1', decision_type: 'chairman_approval', title: 'Stage 0 Chairman Approval',
+    priority: 'critical', created_at: iso(56), blocking: false, ...over
+  });
+
+  it('an UNDEFERRED row renders from creation and keeps the view verdict', async () => {
+    const { renderPendingLine } = await import('../../../lib/chairman/decision-queue.mjs');
+    const line = renderPendingLine(row({ age_escalated: true, effective_priority: 'critical' }), { dispositions: null, now: NOW });
+    expect(line).toMatch(/^\[56d\]/);
+    expect(line).toContain('age-escalated');
+    expect(line).not.toContain('(deferred');
+  });
+
+  it('a DEFERRED row renders from the deferral and says so', async () => {
+    const { renderPendingLine } = await import('../../../lib/chairman/decision-queue.mjs');
+    const d = indexDispositions([deferral('dec-1', 1)]);
+    const line = renderPendingLine(row({ age_escalated: true, effective_priority: 'critical' }), { dispositions: d, now: NOW });
+    // formatAge only switches to days at >=48h, so one day renders '24h' — the point is that it is
+    // hours-since-deferral rather than the 56d the row would show clocked from creation.
+    expect(line).toMatch(/^\[24h\]/);
+    expect(line).not.toMatch(/^\[56d\]/);
+    expect(line).toContain('(deferred');
+  });
+
+  it('THE LOAD-BEARING LINE: a deferral OVERRIDES the view stale escalation marker', async () => {
+    // The live path reads `row.age_escalated ?? ep.escalated`, and false is not nullish, so the
+    // VIEW governs the marker — and the view cannot see deferrals. If the view's `true` won here,
+    // the corrected clock would be read and change nothing, which is this SD's own defect.
+    const { renderPendingLine } = await import('../../../lib/chairman/decision-queue.mjs');
+    const d = indexDispositions([deferral('dec-1', 1)]);
+    const line = renderPendingLine(row({ age_escalated: true }), { dispositions: d, now: NOW });
+    expect(line).not.toContain('age-escalated');
+  });
+
+  it('...and a row deferred LONG ago still escalates — the override is not a blanket silence', async () => {
+    const { renderPendingLine } = await import('../../../lib/chairman/decision-queue.mjs');
+    const d = indexDispositions([deferral('dec-1', 30)]);
+    const line = renderPendingLine(row({ age_escalated: false }), { dispositions: d, now: NOW });
+    expect(line).toContain('age-escalated');
+  });
+
+  it('a live snooze is surfaced as HELD', async () => {
+    const { renderPendingLine } = await import('../../../lib/chairman/decision-queue.mjs');
+    const d = indexDispositions([deferral('dec-1', 1, { snoozed_until: new Date(NOW.getTime() + 86400000).toISOString() })]);
+    expect(renderPendingLine(row(), { dispositions: d, now: NOW })).toContain('HELD');
+  });
+
+  it('BLOCKING and recommendation survive the rewrite — no regression to the existing line', async () => {
+    const { renderPendingLine } = await import('../../../lib/chairman/decision-queue.mjs');
+    const line = renderPendingLine(row({ blocking: true, recommendation: 'fix' }), { dispositions: null, now: NOW });
+    expect(line).toContain('BLOCKING');
+    expect(line).toContain('— fix');
+    expect(line).toContain('chairman_approval:dec-1');
+  });
+});

--- a/tests/unit/chairman/decision-disposition.test.js
+++ b/tests/unit/chairman/decision-disposition.test.js
@@ -21,6 +21,7 @@ const deferral = (targetId, daysAgo, extra = {}) => ({
   category: DEFERRAL_CATEGORY,
   created_at: iso(daysAgo),
   snoozed_until: null,
+  source_type: 'auto_capture',   // the provenance fence: 21 of 21 genuine records carry this
   description: 'Chairman verbal, verbatim: "defer both". REAFFIRMING A DELIBERATE HOLD.',
   metadata: { target_id: targetId, decided_by: 'chairman-cli', deferred_at: iso(daysAgo), decision_type: 'chairman_approval' },
   ...extra
@@ -38,7 +39,7 @@ describe('FR-3 disposition reader — indexing', () => {
     // The census says 21 of 21 use target_id and ZERO use flag_id. A flag_id-only record cannot be
     // attributed to a decision, so it must govern nothing rather than silently half-match.
     const m = indexDispositions([{
-      id: 'fb-x', category: DEFERRAL_CATEGORY, created_at: iso(1),
+      id: 'fb-x', category: DEFERRAL_CATEGORY, created_at: iso(1), source_type: 'auto_capture',
       metadata: { flag_id: 'dec-1', decided_by: 'chairman-cli', deferred_at: iso(1) }
     }]);
     expect(m.size).toBe(0);
@@ -117,7 +118,7 @@ describe('FR-3 retirement authority — absence BLOCKS retirement, never default
 
   it('an UNATTRIBUTABLE record authorises nothing even though it is indexed', () => {
     const m = indexDispositions([{
-      id: 'fb-y', category: DEFERRAL_CATEGORY, created_at: iso(1),
+      id: 'fb-y', category: DEFERRAL_CATEGORY, created_at: iso(1), source_type: 'auto_capture',
       metadata: { target_id: 'dec-1', deferred_at: iso(1) }   // no decided_by
     }]);
     expect(m.size).toBe(1);                                    // it IS a record
@@ -285,5 +286,57 @@ describe('FR-4 supersession — a recurring review must not accrue one stale cri
     const res = await handler(db);
     expect(res.superseded).toEqual([]);
     expect(db._writes.length).toBe(0);
+  });
+});
+
+describe('SECURITY — retirement authority must not be forgeable by an unauthenticated party', () => {
+  // PROVEN LIVE as the anon role before this fence existed: an anon client inserted a
+  // category='chairman_decision_deferred' row targeting a REAL pending decision with
+  // decided_by='chairman-cli', and retirementAuthority() ACCEPTED it. Both directions of the
+  // discriminator were then verified against the live database:
+  //   anon INSERT source_type='auto_capture' -> BLOCKED (42501 RLS)
+  //   anon INSERT source_type='telegram'     -> allowed
+  //   anon UPDATE of a genuine deferral      -> 0 rows (RLS filtered)
+  const forged = (targetId) => ({
+    id: 'fb-forged', category: DEFERRAL_CATEGORY, created_at: iso(1),
+    source_type: 'telegram',                    // the ONLY value anon can write
+    description: 'attacker-supplied basis',
+    metadata: { target_id: targetId, decided_by: 'chairman-cli', deferred_at: iso(1) }
+  });
+
+  it('an anon-writable source_type is NOT indexed at all', () => {
+    expect(indexDispositions([forged('dec-1')]).size).toBe(0);
+  });
+
+  it('a forged record cannot authorise retiring a real decision', () => {
+    expect(retirementAuthority({ id: 'dec-1' }, indexDispositions([forged('dec-1')]))).toBe(null);
+  });
+
+  it('a forged record cannot move a real decision age clock — FR-6 reads the same records', () => {
+    // This is the LIVE half: FR-6 already ships, so a forged deferral would reset the clock and
+    // silence a genuine decision's escalation on the chairman's CLI today.
+    const clock = ageClockFor({ id: 'dec-1', created_at: iso(56) }, indexDispositions([forged('dec-1')]));
+    expect(clock.source).toBe('creation');
+    expect(clock.since).toBe(iso(56));
+  });
+
+  it('a forged record cannot hold a row', () => {
+    const m = indexDispositions([{ ...forged('dec-1'), snoozed_until: new Date(NOW.getTime() + 86400000).toISOString() }]);
+    expect(isHeld({ id: 'dec-1' }, m, NOW)).toBe(false);
+  });
+
+  it('BOTH DIRECTIONS: a genuine auto_capture record still governs — the fence is not a blanket block', () => {
+    const m = indexDispositions([deferral('dec-1', 1)]);
+    expect(m.size).toBe(1);
+    expect(retirementAuthority({ id: 'dec-1' }, m)).not.toBe(null);
+  });
+
+  it('a forged record does not shadow a genuine one for the same target', () => {
+    // The forged row is NEWER, so an index that admitted it would let the attacker overwrite the
+    // real basis with their own.
+    const m = indexDispositions([deferral('dec-1', 5), forged('dec-1')]);
+    expect(m.size).toBe(1);
+    expect(m.get('dec-1').basis).toMatch(/DELIBERATE HOLD/);
+    expect(m.get('dec-1').basis).not.toMatch(/attacker-supplied/);
   });
 });

--- a/tests/unit/chairman/decision-disposition.test.js
+++ b/tests/unit/chairman/decision-disposition.test.js
@@ -10,18 +10,24 @@
 import { describe, it, expect } from 'vitest';
 import {
   indexDispositions, ageClockFor, isHeld, retirementAuthority,
-  DEFERRAL_CATEGORY, DISPOSITION_KEY
+  DEFERRAL_CATEGORY, DISPOSITION_KEY, DISPOSITION_SELECT, REQUIRED_PROVENANCE_FIELDS
 } from '../../../lib/chairman/decision-disposition.mjs';
 
 const NOW = new Date('2026-08-01T21:00:00Z');
 const iso = (d) => new Date(NOW.getTime() - d * 86400000).toISOString();
 
+// The provenance triple below is the LIVE shape, unanimous across all 21 genuine rows:
+// source_type='auto_capture', venture_id=NULL, feedback_type='sentry_error'. All three are load
+// bearing — see isTrustedProvenance. A fixture carrying only source_type is what let a fence that
+// rejects every real row look green.
 const deferral = (targetId, daysAgo, extra = {}) => ({
   id: `fb-${targetId}-${daysAgo}`,
   category: DEFERRAL_CATEGORY,
   created_at: iso(daysAgo),
   snoozed_until: null,
-  source_type: 'auto_capture',   // the provenance fence: 21 of 21 genuine records carry this
+  source_type: 'auto_capture',
+  venture_id: null,
+  feedback_type: 'sentry_error',
   description: 'Chairman verbal, verbatim: "defer both". REAFFIRMING A DELIBERATE HOLD.',
   metadata: { target_id: targetId, decided_by: 'chairman-cli', deferred_at: iso(daysAgo), decision_type: 'chairman_approval' },
   ...extra
@@ -39,7 +45,8 @@ describe('FR-3 disposition reader — indexing', () => {
     // The census says 21 of 21 use target_id and ZERO use flag_id. A flag_id-only record cannot be
     // attributed to a decision, so it must govern nothing rather than silently half-match.
     const m = indexDispositions([{
-      id: 'fb-x', category: DEFERRAL_CATEGORY, created_at: iso(1), source_type: 'auto_capture',
+      id: 'fb-x', category: DEFERRAL_CATEGORY, created_at: iso(1),
+      source_type: 'auto_capture', venture_id: null, feedback_type: 'sentry_error',
       metadata: { flag_id: 'dec-1', decided_by: 'chairman-cli', deferred_at: iso(1) }
     }]);
     expect(m.size).toBe(0);
@@ -118,7 +125,8 @@ describe('FR-3 retirement authority — absence BLOCKS retirement, never default
 
   it('an UNATTRIBUTABLE record authorises nothing even though it is indexed', () => {
     const m = indexDispositions([{
-      id: 'fb-y', category: DEFERRAL_CATEGORY, created_at: iso(1), source_type: 'auto_capture',
+      id: 'fb-y', category: DEFERRAL_CATEGORY, created_at: iso(1),
+      source_type: 'auto_capture', venture_id: null, feedback_type: 'sentry_error',
       metadata: { target_id: 'dec-1', deferred_at: iso(1) }   // no decided_by
     }]);
     expect(m.size).toBe(1);                                    // it IS a record
@@ -290,53 +298,137 @@ describe('FR-4 supersession — a recurring review must not accrue one stale cri
 });
 
 describe('SECURITY — retirement authority must not be forgeable by an unauthenticated party', () => {
-  // PROVEN LIVE as the anon role before this fence existed: an anon client inserted a
-  // category='chairman_decision_deferred' row targeting a REAL pending decision with
-  // decided_by='chairman-cli', and retirementAuthority() ACCEPTED it. Both directions of the
-  // discriminator were then verified against the live database:
-  //   anon INSERT source_type='auto_capture' -> BLOCKED (42501 RLS)
-  //   anon INSERT source_type='telegram'     -> allowed
-  //   anon UPDATE of a genuine deferral      -> 0 rows (RLS filtered)
-  const forged = (targetId) => ({
-    id: 'fb-forged', category: DEFERRAL_CATEGORY, created_at: iso(1),
-    source_type: 'telegram',                    // the ONLY value anon can write
+  // PROVEN LIVE, TWICE, as the anon role against the real database.
+  //
+  // `feedback` has TWO permissive anon INSERT policies and RLS OR-s them, so there are two shapes
+  // an attacker can write. The FIRST version of this fence checked only source_type and its test
+  // suite modelled only the telegram shape — so it was green while the OTHER shape walked straight
+  // through. Both shapes are modelled here now; deleting either half of isTrustedProvenance must
+  // turn one of them red.
+  //
+  //   telegram_bot_insert_feedback  WITH CHECK (source_type = 'telegram')
+  //   venture_user_insert_feedback  WITH CHECK (feedback_type LIKE 'user_%' AND venture_id IS NOT NULL
+  //                                             AND venture_exists_and_active(venture_id) AND ...)
+  //
+  // Re-demonstrated live 2026-08-02 with the venture_user shape: anon .insert() returned 201 with no
+  // error, the row PERSISTED (confirmed by service-role read-back), and retirementAuthority()
+  // GRANTED forged authority over a real pending decision while ageClockFor() reported
+  // source='deferral'. The earlier "BLOCKED 42501" reading was a false negative: 42501 is also
+  // raised by a SUCCEEDING insert whose RETURNING clause fails the telegram-only anon SELECT policy.
+
+  // Shape 1 — reachable via telegram_bot_insert_feedback.
+  const forgedTelegram = (targetId) => ({
+    id: 'fb-forged-tg', category: DEFERRAL_CATEGORY, created_at: iso(1),
+    source_type: 'telegram', venture_id: null, feedback_type: 'sentry_error',
     description: 'attacker-supplied basis',
     metadata: { target_id: targetId, decided_by: 'chairman-cli', deferred_at: iso(1) }
   });
 
-  it('an anon-writable source_type is NOT indexed at all', () => {
-    expect(indexDispositions([forged('dec-1')]).size).toBe(0);
+  // Shape 2 — reachable via venture_user_insert_feedback. THIS IS THE ONE THAT WAS LIVE.
+  // Note source_type='auto_capture': that policy places no constraint on it whatsoever.
+  const forgedVentureUser = (targetId) => ({
+    id: 'fb-forged-vu', category: DEFERRAL_CATEGORY, created_at: iso(1),
+    source_type: 'auto_capture',
+    venture_id: '3d9e6484-56fd-45bf-b3e6-8399ef1647ad',  // policy REQUIRES NOT NULL
+    feedback_type: 'user_bug',                            // policy REQUIRES LIKE 'user_%'
+    description: 'attacker-supplied basis',
+    metadata: { target_id: targetId, decided_by: 'chairman-cli', deferred_at: iso(1) }
   });
 
-  it('a forged record cannot authorise retiring a real decision', () => {
-    expect(retirementAuthority({ id: 'dec-1' }, indexDispositions([forged('dec-1')]))).toBe(null);
-  });
+  for (const [label, forged] of [['telegram', forgedTelegram], ['venture_user', forgedVentureUser]]) {
+    describe(`anon shape: ${label}`, () => {
+      it('is NOT indexed at all', () => {
+        expect(indexDispositions([forged('dec-1')]).size).toBe(0);
+      });
 
-  it('a forged record cannot move a real decision age clock — FR-6 reads the same records', () => {
-    // This is the LIVE half: FR-6 already ships, so a forged deferral would reset the clock and
-    // silence a genuine decision's escalation on the chairman's CLI today.
-    const clock = ageClockFor({ id: 'dec-1', created_at: iso(56) }, indexDispositions([forged('dec-1')]));
-    expect(clock.source).toBe('creation');
-    expect(clock.since).toBe(iso(56));
-  });
+      it('cannot authorise retiring a real decision', () => {
+        expect(retirementAuthority({ id: 'dec-1' }, indexDispositions([forged('dec-1')]))).toBe(null);
+      });
 
-  it('a forged record cannot hold a row', () => {
-    const m = indexDispositions([{ ...forged('dec-1'), snoozed_until: new Date(NOW.getTime() + 86400000).toISOString() }]);
-    expect(isHeld({ id: 'dec-1' }, m, NOW)).toBe(false);
-  });
+      it('cannot move a real decision age clock — FR-6 reads the same records', () => {
+        // The LIVE half: FR-6 ships, so a forged deferral would reset the clock and silence a
+        // genuine decision's escalation on the chairman's CLI today.
+        const clock = ageClockFor({ id: 'dec-1', created_at: iso(56) }, indexDispositions([forged('dec-1')]));
+        expect(clock.source).toBe('creation');
+        expect(clock.since).toBe(iso(56));
+      });
 
-  it('BOTH DIRECTIONS: a genuine auto_capture record still governs — the fence is not a blanket block', () => {
+      it('cannot hold a row', () => {
+        const m = indexDispositions([{ ...forged('dec-1'), snoozed_until: new Date(NOW.getTime() + 86400000).toISOString() }]);
+        expect(isHeld({ id: 'dec-1' }, m, NOW)).toBe(false);
+      });
+
+      it('does not shadow a genuine record for the same target', () => {
+        // The forged row is NEWER, so an index that admitted it would let the attacker overwrite
+        // the real basis with their own.
+        const m = indexDispositions([deferral('dec-1', 5), forged('dec-1')]);
+        expect(m.size).toBe(1);
+        expect(m.get('dec-1').basis).toMatch(/DELIBERATE HOLD/);
+        expect(m.get('dec-1').basis).not.toMatch(/attacker-supplied/);
+      });
+    });
+  }
+
+  it('BOTH DIRECTIONS: a genuine record still governs — the fence is not a blanket block', () => {
     const m = indexDispositions([deferral('dec-1', 1)]);
     expect(m.size).toBe(1);
     expect(retirementAuthority({ id: 'dec-1' }, m)).not.toBe(null);
   });
 
-  it('a forged record does not shadow a genuine one for the same target', () => {
-    // The forged row is NEWER, so an index that admitted it would let the attacker overwrite the
-    // real basis with their own.
-    const m = indexDispositions([deferral('dec-1', 5), forged('dec-1')]);
-    expect(m.size).toBe(1);
-    expect(m.get('dec-1').basis).toMatch(/DELIBERATE HOLD/);
-    expect(m.get('dec-1').basis).not.toMatch(/attacker-supplied/);
+  it('each clause of the fence is independently load-bearing', () => {
+    // If any single clause were removed, the corresponding row below would be admitted. Asserting
+    // them one at a time means a future edit that drops one clause fails HERE, specifically.
+    const base = deferral('dec-1', 1);
+    expect(indexDispositions([{ ...base, source_type: 'telegram' }]).size).toBe(0);
+    expect(indexDispositions([{ ...base, venture_id: 'any-non-null' }]).size).toBe(0);
+    expect(indexDispositions([{ ...base, feedback_type: 'user_other' }]).size).toBe(0);
+  });
+});
+
+describe('SECURITY — an under-selecting caller must FAIL LOUDLY, not silently yield nothing', () => {
+  // THE REGRESSION THIS EXISTS FOR: the first fence shipped while scripts/chairman-decisions.mjs
+  // selected no source_type, so every production row failed the fence and FR-6 was DEAD IN
+  // PRODUCTION — with all 32 unit tests green, because every fixture supplied the column by hand.
+  // Measured live: 0 dispositions via the real select, 15 via the same rows with source_type added.
+  // "0 dispositions" and "0 TRUSTED dispositions" must never again be the same observation.
+
+  it('throws when a matching row lacks the provenance columns', () => {
+    const underSelected = {
+      id: 'fb-1', category: DEFERRAL_CATEGORY, created_at: iso(1),
+      metadata: { target_id: 'dec-1', decided_by: 'chairman-cli', deferred_at: iso(1) }
+    };
+    expect(() => indexDispositions([underSelected])).toThrow(/missing provenance column/i);
+  });
+
+  it('names every missing column, so the fix is mechanical', () => {
+    const partial = {
+      id: 'fb-2', category: DEFERRAL_CATEGORY, created_at: iso(1), source_type: 'auto_capture',
+      metadata: { target_id: 'dec-1', decided_by: 'chairman-cli', deferred_at: iso(1) }
+    };
+    expect(() => indexDispositions([partial])).toThrow(/venture_id[\s\S]*feedback_type|feedback_type[\s\S]*venture_id/);
+  });
+
+  it('a NON-matching row is skipped before the provenance check — no false alarm', () => {
+    // Rows of other categories legitimately arrive without these columns.
+    expect(indexDispositions([{ id: 'z', category: 'harness_backlog', metadata: { target_id: 'dec-1' } }]).size).toBe(0);
+  });
+
+  it('DISPOSITION_SELECT covers every column the fence requires', () => {
+    // The anti-drift pin: the consumer builds its query from DISPOSITION_SELECT, so if a future
+    // clause reads a new column it must be added here or this fails.
+    const selected = DISPOSITION_SELECT.split(',').map(s => s.trim());
+    for (const f of REQUIRED_PROVENANCE_FIELDS) expect(selected).toContain(f);
+    for (const f of ['id', 'category', 'created_at', 'snoozed_until', 'metadata', 'description', 'title']) {
+      expect(selected).toContain(f);
+    }
+  });
+
+  it('the real consumer selects DISPOSITION_SELECT rather than a hand-written list', async () => {
+    // Reads the CONSUMER'S OWN SOURCE. A fixture cannot catch consumer/reader drift — only the
+    // consumer can — and that drift is precisely what shipped a dead FR-6 past a green suite.
+    const { readFileSync } = await import('node:fs');
+    const src = readFileSync(new URL('../../../scripts/chairman-decisions.mjs', import.meta.url), 'utf8');
+    expect(src).toMatch(/\.select\(DISPOSITION_SELECT\)/);
+    expect(src).toContain('DISPOSITION_SELECT');
   });
 });

--- a/tests/unit/chairman/decision-retirement.test.js
+++ b/tests/unit/chairman/decision-retirement.test.js
@@ -7,7 +7,7 @@
  * codebase happens to write. A value outside that set dies at runtime with 23514.
  */
 import { describe, it, expect } from 'vitest';
-import { planRetirement, applyRetirement, armOf, FEEDBACK_STATUS, DECISION_STATUS } from '../../../lib/chairman/decision-retirement.mjs';
+import { planRetirement, applyRetirement, armOf, FEEDBACK_STATUS, DECISION_STATUS, CITATION_COLUMN, RETIRABLE_STATUSES } from '../../../lib/chairman/decision-retirement.mjs';
 import { indexDispositions, DEFERRAL_CATEGORY } from '../../../lib/chairman/decision-disposition.mjs';
 
 const NOW = new Date('2026-08-01T21:00:00Z');
@@ -95,9 +95,25 @@ describe('FR-1/TR-3 status vocabulary — never assert a decision the chairman d
 
   it('the citation travels WITH the write — a basis in a commit message is not a basis', () => {
     const plan = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'));
-    expect(plan.patch.retirement_basis.cited_record).toBe('fb-dec-1');
-    expect(plan.patch.retirement_basis.decided_by).toBe('chairman-cli');
-    expect(plan.patch.retirement_basis.decided_at).toBeTruthy();
+    expect(plan.retirementBasis.cited_record).toBe('fb-dec-1');
+    expect(plan.retirementBasis.decided_by).toBe('chairman-cli');
+    expect(plan.retirementBasis.decided_at).toBeTruthy();
+  });
+
+  it('the citation targets a column that ACTUALLY EXISTS on the arm it writes', () => {
+    // `retirement_basis` is not a column on either table — an explicit select returns 42703 on
+    // feedback AND chairman_decisions, and no migration adds it. The citation therefore nests into
+    // an existing jsonb column per arm. Pinned here because the original defect was invisible to a
+    // fake that accepted any patch.
+    expect(CITATION_COLUMN.chairman_decisions).toBe('brief_data');
+    expect(CITATION_COLUMN.feedback).toBe('metadata');
+    const a4 = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'));
+    const a5 = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'));
+    expect(a4.citationColumn).toBe('brief_data');
+    expect(a5.citationColumn).toBe('metadata');
+    // and the plan must NOT carry a phantom top-level column
+    expect(a4.patch).not.toHaveProperty('retirement_basis');
+    expect(a5.patch).not.toHaveProperty('retirement_basis');
   });
 });
 
@@ -123,45 +139,163 @@ describe('FR-2 arm 6 is GATED and says so — never a silent skip', () => {
   });
 });
 
-describe('TR-9 idempotency — the fence is "not already retired", not "status = pending"', () => {
-  function fake(rows) {
+describe('TR-9 idempotency and the terminal-status refusal', () => {
+  // THE FAKE IS SCHEMA-AWARE ON PURPOSE. The previous fake accepted any patch object, which is why
+  // it could not witness that `retirement_basis` is not a column on either table — every call would
+  // have died with 42703 in production while the suite stayed green. A double that cannot REJECT is
+  // not a double, it is an echo. These column sets are the real ones (feedback 65 cols /
+  // chairman_decisions 36; only the fields under test are listed, plus the jsonb citation column).
+  const COLUMNS = {
+    feedback: ['id', 'status', 'metadata', 'resolved_at', 'title', 'description', 'category'],
+    chairman_decisions: ['id', 'status', 'brief_data', 'decision', 'created_at']
+  };
+
+  // The builder is CHAINABLE AND THENABLE, exactly like PostgREST's: `.select(...).eq(...)` is
+  // valid and the builder itself resolves when awaited. A fake whose select() returns a bare
+  // promise cannot express `.select().eq()` at all — and one that is chainable but NOT thenable
+  // silently yields undefined when awaited. Both shapes have already produced false greens here.
+  function fake(table, rows, opts = {}) {
     const calls = [];
+    const store = rows.map(r => ({ ...r }));
     return {
       calls,
-      from: (table) => {
-        let sel = rows.slice();
+      rows: store,
+      from: (t) => {
+        let sel = store.slice();
+        let pending = null;
+        let err = null;
+        const exec = async () => {
+          if (opts.readError && !pending) return { data: null, error: { message: opts.readError } };
+          if (opts.writeError && pending) return { data: null, error: { message: opts.writeError } };
+          if (err) return { data: null, error: err };
+          if (pending) for (const r of sel) Object.assign(r, pending);
+          return { data: sel, error: null };
+        };
         const api = {
-          update: (patch) => { calls.push({ table, patch }); return api; },
+          update: (patch) => {
+            for (const k of Object.keys(patch)) {
+              if (!COLUMNS[t] || !COLUMNS[t].includes(k)) {
+                // exactly what PostgREST returns for an unknown column
+                err = { code: '42703', message: `column "${k}" of relation "${t}" does not exist` };
+              }
+            }
+            pending = patch; calls.push({ table: t, patch });
+            return api;
+          },
           eq: (c, v) => { sel = sel.filter((r) => r[c] === v); return api; },
           neq: (c, v) => { sel = sel.filter((r) => r[c] !== v); return api; },
-          select: async () => ({ data: sel, error: null })
+          in: (c, vs) => { sel = sel.filter((r) => vs.includes(r[c])); return api; },
+          select: () => api,
+          then: (resolve, reject) => exec().then(resolve, reject)
         };
         return api;
       }
     };
   }
+  const a5 = () => planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'));
+  const a4 = () => planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'));
 
   it('arm 5 retirement WRITES even though feedback has no "pending" status', async () => {
-    // The live feedback statuses are new/resolved/backlog/... — "pending" is synthesised by the
-    // view, not stored. A fence on status='pending' would match zero rows and no-op silently while
-    // still reporting success. This is the regression guard for that.
-    const db = fake([{ id: 'dec-1', status: 'new' }]);
-    const plan = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'));
-    const res = await applyRetirement(db, plan);
+    // "pending" is synthesised by the view, not stored. A fence on status='pending' would match
+    // zero feedback rows and no-op silently while still reporting success.
+    const db = fake('feedback', [{ id: 'dec-1', status: 'new', metadata: null }]);
+    const res = await applyRetirement(db, a5());
     expect(res.wrote).toBe(true);
   });
 
-  it('a SECOND retire is a no-op — the row already carries the target status', async () => {
-    const db = fake([{ id: 'dec-1', status: FEEDBACK_STATUS.HELD }]);
-    const plan = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'));
-    const res = await applyRetirement(db, plan);
+  it('writes ONLY columns that exist — a phantom column would surface as 42703', async () => {
+    const db = fake('feedback', [{ id: 'dec-1', status: 'new', metadata: null }]);
+    const res = await applyRetirement(db, a5());
+    expect(res.wrote).toBe(true);
+    expect(res.error).toBeUndefined();
+    for (const c of db.calls) for (const k of Object.keys(c.patch)) expect(COLUMNS.feedback).toContain(k);
+  });
+
+  it('the citation is MERGED into the jsonb column, not written over it', async () => {
+    const db = fake('feedback', [{ id: 'dec-1', status: 'new', metadata: { keep_me: 'existing', target_id: 'x' } }]);
+    await applyRetirement(db, a5());
+    expect(db.rows[0].metadata.keep_me).toBe('existing');   // pre-existing keys survive
+    expect(db.rows[0].metadata.target_id).toBe('x');
+    expect(db.rows[0].metadata.retirement_basis.decided_by).toBe('chairman-cli');
+  });
+
+  it('a null jsonb column is handled without throwing', async () => {
+    const db = fake('chairman_decisions', [{ id: 'dec-1', status: 'pending', brief_data: null }]);
+    const res = await applyRetirement(db, a4());
+    expect(res.wrote).toBe(true);
+    expect(db.rows[0].brief_data.retirement_basis).toBeTruthy();
+  });
+
+  it('a SECOND retire is a no-op, and SAYS SO — "already_retired", not a bare false', async () => {
+    const db = fake('feedback', [{ id: 'dec-1', status: FEEDBACK_STATUS.HELD, metadata: null }]);
+    const res = await applyRetirement(db, a5());
     expect(res.wrote).toBe(false);
+    expect(res.reason).toBe('already_retired');
+  });
+
+  it('REFUSES to overwrite a human-terminal feedback status', async () => {
+    // MEASURED: 3 of the 6 live feedback deferral targets sit at status='resolved'. The old
+    // .neq(status,target) fence matched them and would have overwritten a resolution.
+    for (const status of ['resolved', 'wont_fix', 'duplicate', 'invalid']) {
+      const db = fake('feedback', [{ id: 'dec-1', status, metadata: null }]);
+      const res = await applyRetirement(db, a5());
+      expect(res.wrote, status).toBe(false);
+      expect(res.reason, status).toBe('refused_terminal_status');
+      expect(db.rows[0].status, status).toBe(status);   // genuinely untouched
+    }
+  });
+
+  it('REFUSES to erase a chairman approval — the worst case this fence exists for', async () => {
+    // MEASURED: 3 of the 7 live chairman_decisions deferral targets sit at status='approved', and
+    // chairman_decisions.status has NO CHECK constraint to stop an overwrite. Retiring one would
+    // assert a disposition the chairman never made — the exact failure this SD removes.
+    for (const status of ['approved', 'rejected', 'cancelled']) {
+      const db = fake('chairman_decisions', [{ id: 'dec-1', status, brief_data: null }]);
+      const res = await applyRetirement(db, a4());
+      expect(res.wrote, status).toBe(false);
+      expect(res.reason, status).toBe('refused_terminal_status');
+      expect(db.rows[0].status, status).toBe(status);
+    }
+  });
+
+  it('arm 4 retires only a PENDING decision', async () => {
+    const db = fake('chairman_decisions', [{ id: 'dec-1', status: 'pending', brief_data: null }]);
+    const res = await applyRetirement(db, a4());
+    expect(res.wrote).toBe(true);
+  });
+
+  it('a missing row is reported as not_found, not as idempotency', async () => {
+    const db = fake('feedback', []);
+    const res = await applyRetirement(db, a5());
+    expect(res.wrote).toBe(false);
+    expect(res.reason).toBe('not_found');
+  });
+
+  it('R13: a DB ERROR is never indistinguishable from an idempotent no-op', async () => {
+    // The surviving mutant: delete the error branch and a failed write reports {wrote:false} with
+    // no error — identical to a correct no-op. Both the read and the write path are asserted.
+    const readFail = fake('feedback', [{ id: 'dec-1', status: 'new', metadata: null }], { readError: 'boom-read' });
+    const r1 = await applyRetirement(readFail, a5());
+    expect(r1.wrote).toBe(false);
+    expect(r1.reason).toBe('db_error');
+    expect(r1.error).toMatch(/boom-read/);
+
+    const writeFail = fake('feedback', [{ id: 'dec-1', status: 'new', metadata: null }], { writeError: 'boom-write' });
+    const r2 = await applyRetirement(writeFail, a5());
+    expect(r2.wrote).toBe(false);
+    expect(r2.reason).toBe('db_error');
+    expect(r2.error).toMatch(/boom-write/);
   });
 
   it('retirement does NOT write resolved_at — retirement is not resolution', async () => {
-    const db = fake([{ id: 'dec-1', status: 'new' }]);
-    const plan = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'));
-    await applyRetirement(db, plan);
-    expect(Object.keys(db.calls[0].patch)).not.toContain('resolved_at');
+    const db = fake('feedback', [{ id: 'dec-1', status: 'new', metadata: null }]);
+    await applyRetirement(db, a5());
+    for (const c of db.calls) expect(Object.keys(c.patch)).not.toContain('resolved_at');
+  });
+
+  it('the retirable sets match the real per-arm vocabularies', () => {
+    expect(RETIRABLE_STATUSES.chairman_decisions).toEqual(['pending']);
+    expect(RETIRABLE_STATUSES.feedback).not.toContain('resolved');
+    expect(RETIRABLE_STATUSES.feedback).toContain('backlog');
   });
 });

--- a/tests/unit/chairman/decision-retirement.test.js
+++ b/tests/unit/chairman/decision-retirement.test.js
@@ -1,0 +1,160 @@
+/**
+ * lib/chairman/decision-retirement.mjs — FR-1, arm-aware retirement.
+ * SD-FDBK-INFRA-DECISION-QUEUE-RETIREMENT-001.
+ *
+ * The status vocabulary is asserted against the CHECK constraint's permitted set, read from
+ * database/migrations/20260131_feedback_resolution_enforcement.sql:150-165 — not from what the
+ * codebase happens to write. A value outside that set dies at runtime with 23514.
+ */
+import { describe, it, expect } from 'vitest';
+import { planRetirement, applyRetirement, armOf, FEEDBACK_STATUS, DECISION_STATUS } from '../../../lib/chairman/decision-retirement.mjs';
+import { indexDispositions, DEFERRAL_CATEGORY } from '../../../lib/chairman/decision-disposition.mjs';
+
+const NOW = new Date('2026-08-01T21:00:00Z');
+const iso = (d) => new Date(NOW.getTime() - d * 86400000).toISOString();
+const deferral = (targetId) => ({
+  id: `fb-${targetId}`, category: DEFERRAL_CATEGORY, created_at: iso(1),
+  description: 'Chairman verbal: "defer both".',
+  metadata: { target_id: targetId, decided_by: 'chairman-cli', deferred_at: iso(1) }
+});
+const withAuth = (id) => indexDispositions([deferral(id)]);
+
+// The exact permitted set of feedback_status_check.
+const PERMITTED_FEEDBACK = ['new', 'triaged', 'in_progress', 'resolved', 'wont_fix', 'duplicate', 'invalid', 'backlog', 'shipped'];
+
+describe('FR-1 arm routing', () => {
+  it('routes each live decision_type to its real source table', () => {
+    expect(armOf({ decision_type: 'chairman_approval' })).toBe('arm4');
+    expect(armOf({ decision_type: 'flag_review' })).toBe('arm5');
+    expect(armOf({ decision_type: 'flag_enablement' })).toBe('arm6');
+    expect(armOf({ decision_type: 'something_else' })).toBe('unknown');
+  });
+});
+
+describe('FR-3 authority gate — absence BLOCKS retirement', () => {
+  it('a row with NO disposition yields null, not a permissive plan', () => {
+    expect(planRetirement({ id: 'dec-9', decision_type: 'chairman_approval' }, withAuth('dec-1'))).toBe(null);
+  });
+
+  it('an UNATTRIBUTABLE record authorises nothing', () => {
+    const m = indexDispositions([{
+      id: 'fb-z', category: DEFERRAL_CATEGORY, created_at: iso(1),
+      metadata: { target_id: 'dec-1', deferred_at: iso(1) }  // no decided_by
+    }]);
+    expect(planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, m)).toBe(null);
+  });
+
+  it('an unknown arm yields null rather than guessing a table', () => {
+    expect(planRetirement({ id: 'dec-1', decision_type: 'okr_acceptance' }, withAuth('dec-1'))).toBe(null);
+  });
+
+  it('applyRetirement refuses a null plan without touching the db', async () => {
+    const res = await applyRetirement({ from: () => { throw new Error('must not be called'); } }, null);
+    expect(res.wrote).toBe(false);
+    expect(res.reason).toBe('no_authority');
+  });
+});
+
+describe('FR-1/TR-3 status vocabulary — never assert a decision the chairman did not make', () => {
+  it('arm 5 uses ONLY values feedback_status_check permits', () => {
+    expect(PERMITTED_FEEDBACK).toContain(FEEDBACK_STATUS.SUPERSEDED);
+    expect(PERMITTED_FEEDBACK).toContain(FEEDBACK_STATUS.HELD);
+  });
+
+  it('arm 5 NEVER uses resolved or wont_fix — both assert an outcome he did not reach', () => {
+    for (const d of ['held', 'superseded']) {
+      const plan = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'), { disposition: d });
+      expect(['resolved', 'wont_fix', 'approved', 'rejected']).not.toContain(plan.patch.status);
+    }
+  });
+
+  it('arm 4 NEVER uses approved or rejected', () => {
+    for (const d of ['held', 'superseded']) {
+      const plan = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'), { disposition: d });
+      expect(['approved', 'rejected']).not.toContain(plan.patch.status);
+    }
+  });
+
+  it('the two dispositions are distinguishable per arm', () => {
+    const a4h = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'), { disposition: 'held' });
+    const a4s = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'), { disposition: 'superseded' });
+    const a5h = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'), { disposition: 'held' });
+    const a5s = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'), { disposition: 'superseded' });
+    expect(a4h.patch.status).toBe(DECISION_STATUS.HELD);
+    expect(a4s.patch.status).toBe(DECISION_STATUS.SUPERSEDED);
+    expect(a5h.patch.status).toBe(FEEDBACK_STATUS.HELD);
+    expect(a5s.patch.status).toBe(FEEDBACK_STATUS.SUPERSEDED);
+  });
+
+  it('the citation travels WITH the write — a basis in a commit message is not a basis', () => {
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'));
+    expect(plan.patch.retirement_basis.cited_record).toBe('fb-dec-1');
+    expect(plan.patch.retirement_basis.decided_by).toBe('chairman-cli');
+    expect(plan.patch.retirement_basis.decided_at).toBeTruthy();
+  });
+});
+
+describe('FR-1 each arm targets its OWN table — a single-table retirement covers a third of the queue', () => {
+  it('arm 4 writes chairman_decisions, arm 5 writes feedback', () => {
+    expect(planRetirement({ id: 'd', decision_type: 'chairman_approval' }, withAuth('d')).table).toBe('chairman_decisions');
+    expect(planRetirement({ id: 'd', decision_type: 'flag_review' }, withAuth('d')).table).toBe('feedback');
+  });
+});
+
+describe('FR-2 arm 6 is GATED and says so — never a silent skip', () => {
+  it('returns an explicit gated verdict naming why', () => {
+    const plan = planRetirement({ id: 'flag-1', decision_type: 'flag_enablement' }, withAuth('flag-1'));
+    expect(plan.verdict).toBe('gated');
+    expect(plan.patch).toBe(null);
+    expect(plan.reason).toMatch(/TIER-2|chairman-gated/);
+  });
+
+  it('applyRetirement will NOT write a gated plan', async () => {
+    const plan = planRetirement({ id: 'flag-1', decision_type: 'flag_enablement' }, withAuth('flag-1'));
+    const res = await applyRetirement({ from: () => { throw new Error('must not be called'); } }, plan);
+    expect(res.wrote).toBe(false);
+  });
+});
+
+describe('TR-9 idempotency — the fence is "not already retired", not "status = pending"', () => {
+  function fake(rows) {
+    const calls = [];
+    return {
+      calls,
+      from: (table) => {
+        let sel = rows.slice();
+        const api = {
+          update: (patch) => { calls.push({ table, patch }); return api; },
+          eq: (c, v) => { sel = sel.filter((r) => r[c] === v); return api; },
+          neq: (c, v) => { sel = sel.filter((r) => r[c] !== v); return api; },
+          select: async () => ({ data: sel, error: null })
+        };
+        return api;
+      }
+    };
+  }
+
+  it('arm 5 retirement WRITES even though feedback has no "pending" status', async () => {
+    // The live feedback statuses are new/resolved/backlog/... — "pending" is synthesised by the
+    // view, not stored. A fence on status='pending' would match zero rows and no-op silently while
+    // still reporting success. This is the regression guard for that.
+    const db = fake([{ id: 'dec-1', status: 'new' }]);
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'));
+    const res = await applyRetirement(db, plan);
+    expect(res.wrote).toBe(true);
+  });
+
+  it('a SECOND retire is a no-op — the row already carries the target status', async () => {
+    const db = fake([{ id: 'dec-1', status: FEEDBACK_STATUS.HELD }]);
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'));
+    const res = await applyRetirement(db, plan);
+    expect(res.wrote).toBe(false);
+  });
+
+  it('retirement does NOT write resolved_at — retirement is not resolution', async () => {
+    const db = fake([{ id: 'dec-1', status: 'new' }]);
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'));
+    await applyRetirement(db, plan);
+    expect(Object.keys(db.calls[0].patch)).not.toContain('resolved_at');
+  });
+});

--- a/tests/unit/chairman/decision-retirement.test.js
+++ b/tests/unit/chairman/decision-retirement.test.js
@@ -14,6 +14,7 @@ const NOW = new Date('2026-08-01T21:00:00Z');
 const iso = (d) => new Date(NOW.getTime() - d * 86400000).toISOString();
 const deferral = (targetId) => ({
   id: `fb-${targetId}`, category: DEFERRAL_CATEGORY, created_at: iso(1),
+  source_type: 'auto_capture',   // provenance fence — anon can only write source_type='telegram'
   description: 'Chairman verbal: "defer both".',
   metadata: { target_id: targetId, decided_by: 'chairman-cli', deferred_at: iso(1) }
 });

--- a/tests/unit/chairman/decision-retirement.test.js
+++ b/tests/unit/chairman/decision-retirement.test.js
@@ -325,6 +325,21 @@ describe('TR-9 idempotency and the terminal-status refusal', () => {
     expect(db.rows[0].status).toBe('backlog');                // no status re-assertion
   });
 
+  it('the citation branch does NOT outrank the terminal refusal', async () => {
+    // Regression for a defect the W2 fix itself introduced. SUPERSEDED is 'duplicate', which is
+    // TERMINAL (not in RETIRABLE_STATUSES.feedback). A row already at 'duplicate' was marked so by
+    // someone else, so the status-collision branch would have stamped a chairman retirement_basis
+    // onto it — an attribution for a retirement that never happened. HELD ('backlog') is different:
+    // it IS retirable, which is the case the branch exists for.
+    const db = fake('feedback', [{ id: 'dec-1', status: 'duplicate', metadata: { marked_by: 'a-human' }, duplicate_of_id: 'other' }]);
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'),
+      { disposition: 'superseded', supersededBy: 'newer-1' });
+    const res = await applyRetirement(db, plan);
+    expect(res.reason).toBe('refused_terminal_status');
+    expect(res.wrote).toBe(false);
+    expect(db.rows[0].metadata).toEqual({ marked_by: 'a-human' });   // NOT stamped
+  });
+
   it('REFUSES to merge into a jsonb column that is not a plain object', async () => {
     // typeof [] === 'object', so an array would have spread into {"0":…} and silently changed the
     // column's shape; a scalar would have fallen to {} and been discarded. Both destroy data the

--- a/tests/unit/chairman/decision-retirement.test.js
+++ b/tests/unit/chairman/decision-retirement.test.js
@@ -51,8 +51,30 @@ describe('FR-3 authority gate — absence BLOCKS retirement', () => {
     expect(planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, m)).toBe(null);
   });
 
-  it('an unknown arm yields null rather than guessing a table', () => {
-    expect(planRetirement({ id: 'dec-1', decision_type: 'okr_acceptance' }, withAuth('dec-1'))).toBe(null);
+  it('an unknown arm is UNSUPPORTED, not "no authority" — it never guesses a table', () => {
+    // The queue emits SEVEN arms (escalation, two gate_decision arms, chairman_approval,
+    // flag_review, flag_enablement, okr_acceptance); armOf maps three. Returning bare null made
+    // applyRetirement report reason:'no_authority', which asserts the chairman never deferred the
+    // row — the opposite of the truth when authority demonstrably exists.
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'okr_acceptance' }, withAuth('dec-1'));
+    expect(plan.verdict).toBe('unsupported_arm');
+    expect(plan.patch).toBe(null);
+    expect(plan.table).toBe(null);
+    expect(plan.citation).not.toBe(null);          // authority EXISTS — that is the whole point
+    expect(plan.reason).toMatch(/no arm handles it/);
+  });
+
+  it('applyRetirement reports the unsupported arm as itself, NOT as no_authority', async () => {
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'okr_acceptance' }, withAuth('dec-1'));
+    const res = await applyRetirement({ from: () => { throw new Error('must not be called'); } }, plan);
+    expect(res.wrote).toBe(false);
+    expect(res.verdict).toBe('unsupported_arm');
+    expect(res.reason).not.toBe('no_authority');
+  });
+
+  it('a genuinely absent plan IS no_authority — the two stay distinguishable', async () => {
+    const res = await applyRetirement({ from: () => { throw new Error('must not be called'); } }, null);
+    expect(res.reason).toBe('no_authority');
   });
 
   it('applyRetirement refuses a null plan without touching the db', async () => {
@@ -70,7 +92,9 @@ describe('FR-1/TR-3 status vocabulary — never assert a decision the chairman d
 
   it('arm 5 NEVER uses resolved or wont_fix — both assert an outcome he did not reach', () => {
     for (const d of ['held', 'superseded']) {
-      const plan = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'), { disposition: d });
+      // superseded on this arm requires a referent — see the chk_duplicate_requires_reference block.
+      const plan = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'),
+        { disposition: d, supersededBy: 'newer-1' });
       expect(['resolved', 'wont_fix', 'approved', 'rejected']).not.toContain(plan.patch.status);
     }
   });
@@ -86,7 +110,7 @@ describe('FR-1/TR-3 status vocabulary — never assert a decision the chairman d
     const a4h = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'), { disposition: 'held' });
     const a4s = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'), { disposition: 'superseded' });
     const a5h = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'), { disposition: 'held' });
-    const a5s = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'), { disposition: 'superseded' });
+    const a5s = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'), { disposition: 'superseded', supersededBy: 'newer-1' });
     expect(a4h.patch.status).toBe(DECISION_STATUS.HELD);
     expect(a4s.patch.status).toBe(DECISION_STATUS.SUPERSEDED);
     expect(a5h.patch.status).toBe(FEEDBACK_STATUS.HELD);
@@ -114,6 +138,53 @@ describe('FR-1/TR-3 status vocabulary — never assert a decision the chairman d
     // and the plan must NOT carry a phantom top-level column
     expect(a4.patch).not.toHaveProperty('retirement_basis');
     expect(a5.patch).not.toHaveProperty('retirement_basis');
+  });
+});
+
+describe('feedback status=duplicate is CHECK-constrained to carry a referent', () => {
+  // THE DEFECT THIS GUARDS: FEEDBACK_STATUS.SUPERSEDED is 'duplicate', and feedback has TWO live
+  // CHECK constraints demanding a referent for that value —
+  //   chk_duplicate_requires_reference: status <> 'duplicate' OR (duplicate_of_id IS NOT NULL AND duplicate_of_id <> id)
+  //   chk_feedback_terminal_resolution: WHEN status='duplicate' THEN duplicate_of_id IS NOT NULL
+  // All 70 live rows at status='duplicate' carry one (70/70). The first version wrote the status
+  // without duplicate_of_id, so EVERY superseded retirement on this arm would have died with 23514.
+  //
+  // WHY IT WAS MISSED, worth recording: the status ENUM was read from
+  // 20260131_feedback_resolution_enforcement.sql:150-165 and the invalidating constraint sits at
+  // :235-240 OF THE SAME FILE. Reading the enum is not reading the constraints that govern its
+  // values — the second instance of the retirement_basis class in this module.
+
+  it('superseded on the feedback arm REFUSES without a referent rather than writing a doomed status', () => {
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'), { disposition: 'superseded' });
+    expect(plan.verdict).toBe('blocked');
+    expect(plan.patch).toBe(null);
+    expect(plan.reason).toMatch(/duplicate_of_id|requires supersededBy/);
+  });
+
+  it('with a referent it writes BOTH status and duplicate_of_id', () => {
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'), { disposition: 'superseded', supersededBy: 'newer-1' });
+    expect(plan.verdict).toBe('retire');
+    expect(plan.patch.status).toBe(FEEDBACK_STATUS.SUPERSEDED);
+    expect(plan.patch.duplicate_of_id).toBe('newer-1');
+  });
+
+  it('refuses a self-referential supersession — the constraint forbids duplicate_of_id = id', () => {
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'), { disposition: 'superseded', supersededBy: 'dec-1' });
+    expect(plan.verdict).toBe('blocked');
+    expect(plan.reason).toMatch(/supersede itself|equals the row id/);
+  });
+
+  it('the HELD path is unaffected — no CHECK governs backlog, so no referent is required', () => {
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'), { disposition: 'held' });
+    expect(plan.verdict).toBe('retire');
+    expect(plan.patch.status).toBe(FEEDBACK_STATUS.HELD);
+    expect(plan.patch).not.toHaveProperty('duplicate_of_id');
+  });
+
+  it('arm 4 never carries duplicate_of_id — chairman_decisions has no such column', () => {
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'), { disposition: 'superseded' });
+    expect(plan.verdict).toBe('retire');
+    expect(plan.patch).not.toHaveProperty('duplicate_of_id');
   });
 });
 
@@ -145,8 +216,11 @@ describe('TR-9 idempotency and the terminal-status refusal', () => {
   // have died with 42703 in production while the suite stayed green. A double that cannot REJECT is
   // not a double, it is an echo. These column sets are the real ones (feedback 65 cols /
   // chairman_decisions 36; only the fields under test are listed, plus the jsonb citation column).
+  // duplicate_of_id is REAL (uuid, nullable) and load-bearing for the superseded path — omitting it
+  // would make the fake reject a legitimate write with a spurious 42703, which is the mirror of the
+  // defect this fake exists to catch. A double that is wrong in EITHER direction is not a double.
   const COLUMNS = {
-    feedback: ['id', 'status', 'metadata', 'resolved_at', 'title', 'description', 'category'],
+    feedback: ['id', 'status', 'metadata', 'resolved_at', 'title', 'description', 'category', 'duplicate_of_id'],
     chairman_decisions: ['id', 'status', 'brief_data', 'decision', 'created_at']
   };
 
@@ -227,10 +301,41 @@ describe('TR-9 idempotency and the terminal-status refusal', () => {
   });
 
   it('a SECOND retire is a no-op, and SAYS SO — "already_retired", not a bare false', async () => {
-    const db = fake('feedback', [{ id: 'dec-1', status: FEEDBACK_STATUS.HELD, metadata: null }]);
+    // "Already retired" must mean RETIRED — evidenced by the citation, not by the status alone.
+    const db = fake('feedback', [{
+      id: 'dec-1', status: FEEDBACK_STATUS.HELD,
+      metadata: { retirement_basis: { cited_record: 'fb-dec-1', decided_by: 'chairman-cli' } }
+    }]);
     const res = await applyRetirement(db, a5());
     expect(res.wrote).toBe(false);
     expect(res.reason).toBe('already_retired');
+  });
+
+  it('a HUMAN-parked backlog row is NOT "already retired" — the citation still gets written', async () => {
+    // FEEDBACK_STATUS.HELD is 'backlog', which is ALSO an open/retirable status a triager sets by
+    // hand. Inferring "already retired" from the status alone told the caller the retirement was
+    // done while the basis was never recorded — defeating this SD's core rule that the basis travels
+    // with the write. The citation column is already in hand from the read, so it is consulted.
+    const db = fake('feedback', [{ id: 'dec-1', status: 'backlog', metadata: { triaged_by: 'a-human' } }]);
+    const res = await applyRetirement(db, a5());
+    expect(res.reason).toBe('citation_recorded_status_already_matched');
+    expect(res.wrote).toBe(true);
+    expect(db.rows[0].metadata.retirement_basis.decided_by).toBe('chairman-cli');
+    expect(db.rows[0].metadata.triaged_by).toBe('a-human');   // pre-existing keys survive
+    expect(db.rows[0].status).toBe('backlog');                // no status re-assertion
+  });
+
+  it('REFUSES to merge into a jsonb column that is not a plain object', async () => {
+    // typeof [] === 'object', so an array would have spread into {"0":…} and silently changed the
+    // column's shape; a scalar would have fallen to {} and been discarded. Both destroy data the
+    // read-first exists to preserve.
+    for (const bad of [['a', 'b'], 'a-string', 42, true]) {
+      const db = fake('feedback', [{ id: 'dec-1', status: 'new', metadata: bad }]);
+      const res = await applyRetirement(db, a5());
+      expect(res.wrote, JSON.stringify(bad)).toBe(false);
+      expect(res.reason, JSON.stringify(bad)).toBe('citation_column_not_mergeable');
+      expect(db.rows[0].metadata, JSON.stringify(bad)).toEqual(bad);   // untouched
+    }
   });
 
   it('REFUSES to overwrite a human-terminal feedback status', async () => {
@@ -303,6 +408,20 @@ describe('TR-9 idempotency and the terminal-status refusal', () => {
     expect(res.wrote).toBe(true);
     expect(res.citationColumn).toBe('metadata');           // derived, not echoed
     expect(db.rows[0].metadata.retirement_basis).toBeTruthy();
+  });
+
+  it('the superseded APPLY path writes duplicate_of_id alongside the status', async () => {
+    // Closes the loop on the CRITICAL: the plan carrying duplicate_of_id is only half of it — the
+    // write must actually send it, or the CHECK still fires at runtime.
+    const db = fake('feedback', [{ id: 'dec-1', status: 'new', metadata: null, duplicate_of_id: null }]);
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'),
+      { disposition: 'superseded', supersededBy: 'newer-1' });
+    const res = await applyRetirement(db, plan);
+    expect(res.wrote).toBe(true);
+    expect(res.error).toBeUndefined();
+    expect(db.rows[0].status).toBe(FEEDBACK_STATUS.SUPERSEDED);
+    expect(db.rows[0].duplicate_of_id).toBe('newer-1');
+    expect(db.rows[0].metadata.retirement_basis.disposition).toBe('superseded');
   });
 
   it('the retirable sets match the real per-arm vocabularies', () => {

--- a/tests/unit/chairman/decision-retirement.test.js
+++ b/tests/unit/chairman/decision-retirement.test.js
@@ -12,9 +12,12 @@ import { indexDispositions, DEFERRAL_CATEGORY } from '../../../lib/chairman/deci
 
 const NOW = new Date('2026-08-01T21:00:00Z');
 const iso = (d) => new Date(NOW.getTime() - d * 86400000).toISOString();
+// The provenance triple is the live shape (21/21): auto_capture + venture_id NULL + sentry_error.
+// All three are required — anon can reach source_type='auto_capture' via venture_user_insert_feedback,
+// so source_type alone is NOT a fence. See decision-disposition.mjs.
 const deferral = (targetId) => ({
   id: `fb-${targetId}`, category: DEFERRAL_CATEGORY, created_at: iso(1),
-  source_type: 'auto_capture',   // provenance fence — anon can only write source_type='telegram'
+  source_type: 'auto_capture', venture_id: null, feedback_type: 'sentry_error',
   description: 'Chairman verbal: "defer both".',
   metadata: { target_id: targetId, decided_by: 'chairman-cli', deferred_at: iso(1) }
 });
@@ -38,8 +41,11 @@ describe('FR-3 authority gate — absence BLOCKS retirement', () => {
   });
 
   it('an UNATTRIBUTABLE record authorises nothing', () => {
+    // Full provenance deliberately: this must fail on the MISSING ACTOR, not get filtered by the
+    // fence first. Without the triple it would be rejected for the wrong reason (and now throws).
     const m = indexDispositions([{
       id: 'fb-z', category: DEFERRAL_CATEGORY, created_at: iso(1),
+      source_type: 'auto_capture', venture_id: null, feedback_type: 'sentry_error',
       metadata: { target_id: 'dec-1', deferred_at: iso(1) }  // no decided_by
     }]);
     expect(planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, m)).toBe(null);

--- a/tests/unit/chairman/decision-retirement.test.js
+++ b/tests/unit/chairman/decision-retirement.test.js
@@ -2,12 +2,14 @@
  * lib/chairman/decision-retirement.mjs — FR-1, arm-aware retirement.
  * SD-FDBK-INFRA-DECISION-QUEUE-RETIREMENT-001.
  *
- * The status vocabulary is asserted against the CHECK constraint's permitted set, read from
- * database/migrations/20260131_feedback_resolution_enforcement.sql:150-165 — not from what the
- * codebase happens to write. A value outside that set dies at runtime with 23514.
+ * BOTH arms' status vocabularies are asserted against their REAL permitted sets, read from
+ * pg_constraint — not from what the codebase happens to write. A value outside the set dies at
+ * runtime with 23514, and this suite previously pinned arm 5 that way while pinning arm 4 only as
+ * "not approved/rejected", which an entirely illegal value passes trivially. That asymmetry is how
+ * an arm-4 status the CHECK forbids shipped green. Pin every arm against its own permitted set.
  */
 import { describe, it, expect } from 'vitest';
-import { planRetirement, applyRetirement, armOf, FEEDBACK_STATUS, DECISION_STATUS, CITATION_COLUMN, RETIRABLE_STATUSES } from '../../../lib/chairman/decision-retirement.mjs';
+import { planRetirement, applyRetirement, armOf, FEEDBACK_STATUS, DECISION_STATUS, CITATION_COLUMN, RETIRABLE_STATUSES, PERMITTED_DECISION_STATUS, RETIREMENT_READ_SELECT } from '../../../lib/chairman/decision-retirement.mjs';
 import { indexDispositions, DEFERRAL_CATEGORY } from '../../../lib/chairman/decision-disposition.mjs';
 
 const NOW = new Date('2026-08-01T21:00:00Z');
@@ -99,26 +101,41 @@ describe('FR-1/TR-3 status vocabulary — never assert a decision the chairman d
     }
   });
 
-  it('arm 4 NEVER uses approved or rejected', () => {
-    for (const d of ['held', 'superseded']) {
-      const plan = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'), { disposition: d });
-      expect(['approved', 'rejected']).not.toContain(plan.patch.status);
-    }
+  it('arm 4 uses ONLY values chairman_decisions_status_check permits', () => {
+    // THE HOLE THAT LET THE ARM-4 CRITICAL SHIP: arm 5's vocabulary was pinned against the real
+    // permitted set, and arm 4's was pinned only as "not approved/rejected" — which an entirely
+    // ILLEGAL value passes trivially. 'superseded' and 'held' both passed that assertion while
+    // being rejected by the live CHECK with 23514. This is the missing mirror.
+    expect(PERMITTED_DECISION_STATUS).toEqual(['pending', 'approved', 'rejected', 'cancelled']);
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'), { disposition: 'superseded' });
+    expect(PERMITTED_DECISION_STATUS).toContain(plan.patch.status);
+    expect(['approved', 'rejected']).not.toContain(plan.patch.status);
   });
 
-  it('the two dispositions are distinguishable per arm', () => {
-    const a4h = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'), { disposition: 'held' });
+  it('arm 4 HELD is refused — no permitted status means "parked but still to be decided"', () => {
+    // approved/rejected assert an outcome (TR-3); 'cancelled' would withdraw a decision the
+    // chairman still intends to make. A held row belongs in 'pending', where it already is.
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'), { disposition: 'held' });
+    expect(plan.verdict).toBe('blocked');
+    expect(plan.patch).toBe(null);
+    expect(plan.reason).toMatch(/pending|still intends/);
+  });
+
+  it('the dispositions are distinguishable on the arm that supports both', () => {
     const a4s = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'), { disposition: 'superseded' });
     const a5h = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'), { disposition: 'held' });
     const a5s = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'), { disposition: 'superseded', supersededBy: 'newer-1' });
-    expect(a4h.patch.status).toBe(DECISION_STATUS.HELD);
     expect(a4s.patch.status).toBe(DECISION_STATUS.SUPERSEDED);
     expect(a5h.patch.status).toBe(FEEDBACK_STATUS.HELD);
     expect(a5s.patch.status).toBe(FEEDBACK_STATUS.SUPERSEDED);
+    expect(a5h.patch.status).not.toBe(a5s.patch.status);
+    // the disposition itself is always recorded in the citation, whichever status carries it
+    expect(a4s.retirementBasis.disposition).toBe('superseded');
+    expect(a5h.retirementBasis.disposition).toBe('held');
   });
 
   it('the citation travels WITH the write — a basis in a commit message is not a basis', () => {
-    const plan = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'));
+    const plan = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'), { disposition: 'superseded' });
     expect(plan.retirementBasis.cited_record).toBe('fb-dec-1');
     expect(plan.retirementBasis.decided_by).toBe('chairman-cli');
     expect(plan.retirementBasis.decided_at).toBeTruthy();
@@ -131,7 +148,7 @@ describe('FR-1/TR-3 status vocabulary — never assert a decision the chairman d
     // fake that accepted any patch.
     expect(CITATION_COLUMN.chairman_decisions).toBe('brief_data');
     expect(CITATION_COLUMN.feedback).toBe('metadata');
-    const a4 = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'));
+    const a4 = planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'), { disposition: 'superseded' });
     const a5 = planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'));
     expect(a4.citationColumn).toBe('brief_data');
     expect(a5.citationColumn).toBe('metadata');
@@ -190,7 +207,7 @@ describe('feedback status=duplicate is CHECK-constrained to carry a referent', (
 
 describe('FR-1 each arm targets its OWN table — a single-table retirement covers a third of the queue', () => {
   it('arm 4 writes chairman_decisions, arm 5 writes feedback', () => {
-    expect(planRetirement({ id: 'd', decision_type: 'chairman_approval' }, withAuth('d')).table).toBe('chairman_decisions');
+    expect(planRetirement({ id: 'd', decision_type: 'chairman_approval' }, withAuth('d'), { disposition: 'superseded' }).table).toBe('chairman_decisions');
     expect(planRetirement({ id: 'd', decision_type: 'flag_review' }, withAuth('d')).table).toBe('feedback');
   });
 });
@@ -238,12 +255,15 @@ describe('TR-9 idempotency and the terminal-status refusal', () => {
         let sel = store.slice();
         let pending = null;
         let err = null;
+        let projection = null;
         const exec = async () => {
           if (opts.readError && !pending) return { data: null, error: { message: opts.readError } };
           if (opts.writeError && pending) return { data: null, error: { message: opts.writeError } };
           if (err) return { data: null, error: err };
           if (pending) for (const r of sel) Object.assign(r, pending);
-          return { data: sel, error: null };
+          // Hand back ONLY the projected columns, as PostgREST does.
+          const project = (r) => projection ? Object.fromEntries(projection.map(k => [k, r[k]])) : { ...r };
+          return { data: sel.map(project), error: null };
         };
         const api = {
           update: (patch) => {
@@ -259,7 +279,23 @@ describe('TR-9 idempotency and the terminal-status refusal', () => {
           eq: (c, v) => { sel = sel.filter((r) => r[c] === v); return api; },
           neq: (c, v) => { sel = sel.filter((r) => r[c] !== v); return api; },
           in: (c, vs) => { sel = sel.filter((r) => vs.includes(r[c])); return api; },
-          select: () => api,
+          // select() PROJECTS, it does not pass the whole row through. A fake that ignores its
+          // projection cannot see under-selection — and under-selection is precisely the class that
+          // shipped FR-6 dead in production past 32 green tests. With the projection ignored, the
+          // read-first jsonb merge would keep passing even if RETIREMENT_READ_SELECT stopped
+          // fetching the citation column, at which point the write silently REPLACES that column.
+          select: (cols) => {
+            if (typeof cols === 'string' && cols !== 'id') {
+              const want = cols.split(',').map(s => s.trim());
+              for (const k of want) {
+                if (!COLUMNS[t] || !COLUMNS[t].includes(k)) {
+                  err = { code: '42703', message: `column ${t}.${k} does not exist` };
+                }
+              }
+              projection = want;
+            }
+            return api;
+          },
           then: (resolve, reject) => exec().then(resolve, reject)
         };
         return api;
@@ -267,7 +303,7 @@ describe('TR-9 idempotency and the terminal-status refusal', () => {
     };
   }
   const a5 = () => planRetirement({ id: 'dec-1', decision_type: 'flag_review' }, withAuth('dec-1'));
-  const a4 = () => planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'));
+  const a4 = () => planRetirement({ id: 'dec-1', decision_type: 'chairman_approval' }, withAuth('dec-1'), { disposition: 'superseded' });
 
   it('arm 5 retirement WRITES even though feedback has no "pending" status', async () => {
     // "pending" is synthesised by the view, not stored. A fence on status='pending' would match
@@ -437,6 +473,25 @@ describe('TR-9 idempotency and the terminal-status refusal', () => {
     expect(db.rows[0].status).toBe(FEEDBACK_STATUS.SUPERSEDED);
     expect(db.rows[0].duplicate_of_id).toBe('newer-1');
     expect(db.rows[0].metadata.retirement_basis.disposition).toBe('superseded');
+  });
+
+  it('the fake PROJECTS — so a mis-projected read is visible instead of silently destructive', () => {
+    // The fake used to hand back whole rows regardless of the projection, which made
+    // RETIREMENT_READ_SELECT untestable: drop the citation column from it and row[col] is
+    // undefined, the merge becomes {retirement_basis} alone, and the write REPLACES the column,
+    // destroying everything in it — with every test still green. That is the same under-selection
+    // class that shipped FR-6 dead in production past 32 green tests.
+    expect(RETIREMENT_READ_SELECT.feedback.split(',').map(s => s.trim())).toContain(CITATION_COLUMN.feedback);
+    expect(RETIREMENT_READ_SELECT.chairman_decisions.split(',').map(s => s.trim())).toContain(CITATION_COLUMN.chairman_decisions);
+  });
+
+  it('a read that omits the citation column is caught, not silently destructive', async () => {
+    // Simulates the drift directly against the fake's projection, proving the double can now
+    // witness it: with metadata absent from the projection the pre-existing keys are NOT preserved.
+    const db = fake('feedback', [{ id: 'dec-1', status: 'new', metadata: { keep_me: 'existing' } }]);
+    const { data } = await db.from('feedback').select('id, status').eq('id', 'dec-1');
+    expect(data[0]).not.toHaveProperty('metadata');   // the projection is real
+    expect(data[0].status).toBe('new');
   });
 
   it('the retirable sets match the real per-arm vocabularies', () => {

--- a/tests/unit/chairman/decision-retirement.test.js
+++ b/tests/unit/chairman/decision-retirement.test.js
@@ -293,6 +293,18 @@ describe('TR-9 idempotency and the terminal-status refusal', () => {
     for (const c of db.calls) expect(Object.keys(c.patch)).not.toContain('resolved_at');
   });
 
+  it('the citation column is DERIVED from the table, not taken from the plan', async () => {
+    // DQR-SEC-09: `col` is string-interpolated into .select(), so reading it from a caller-supplied
+    // plan would make that interpolation caller-controlled. A tampered plan must be ignored, not
+    // trusted. Not reachable today — which is exactly why it needs a test rather than a comment.
+    const db = fake('feedback', [{ id: 'dec-1', status: 'new', metadata: null }]);
+    const tampered = { ...a5(), citationColumn: 'id, status, pg_sleep(10)' };
+    const res = await applyRetirement(db, tampered);
+    expect(res.wrote).toBe(true);
+    expect(res.citationColumn).toBe('metadata');           // derived, not echoed
+    expect(db.rows[0].metadata.retirement_basis).toBeTruthy();
+  });
+
   it('the retirable sets match the real per-arm vocabularies', () => {
     expect(RETIRABLE_STATUSES.chairman_decisions).toEqual(['pending']);
     expect(RETIRABLE_STATUSES.feedback).not.toContain('resolved');

--- a/tests/unit/governance/drive-state-axes.test.js
+++ b/tests/unit/governance/drive-state-axes.test.js
@@ -250,16 +250,31 @@ describe('AXIS 1 chairman_decisions — blind to CRITICAL is the defect this axi
     }
   });
 
-  it('PROVES THE UPSTREAM HOLE IS REAL — effectivePriority cannot escalate a critical row at ANY age', async () => {
-    // The justification for not reusing age_escalated, executed rather than cited. rank =
-    // Math.max(1, baseRank - bump) and escalated = rank < baseRank; for critical baseRank is 1, so
-    // the floor absorbs the bump and the comparison is 1 < 1.
+  it('THE UPSTREAM HOLE WAS REAL AND IS NOW CLOSED — effectivePriority escalates critical by AGE', async () => {
+    // HISTORY, because this test's meaning inverted and a silent flip would erase why it exists.
+    // It originally asserted the OPPOSITE: that effectivePriority could never escalate a critical
+    // row at any age. That was true and was this axis's justification for not reusing
+    // age_escalated — rank = Math.max(1, baseRank - bump), escalated = rank < baseRank, and for
+    // critical baseRank is 1, so the floor absorbed the bump and the comparison was 1 < 1.
+    //
+    // SD-FDBK-INFRA-DECISION-QUEUE-RETIREMENT-001 FR-5 fixed it: the marker is now a property of
+    // AGE, not of rank movement (`escalated: bump > 0`). So this test now pins the FIX. Left here
+    // rather than deleted because a test that merely documented a defect becomes a regression guard
+    // the moment the defect is closed — and because the axis's independence rationale below
+    // (:the-axis-source-does-NOT-read) now rests on separation of concerns, NOT on this hole.
     const { effectivePriority } = await import('../../../lib/chairman/decision-queue.mjs');
-    for (const h of [1, 71, 73, 100, 1000]) {
-      const out = effectivePriority({ priority: 'critical', created_at: hoursAgo(h) }, new Date(NOW));
-      expect(out.escalated, `critical @${h}h`).toBe(false);
+    for (const h of [1, 71]) {
+      expect(effectivePriority({ priority: 'critical', created_at: hoursAgo(h) }, new Date(NOW)).escalated,
+        `critical @${h}h is inside the 72h window`).toBe(false);
     }
-    // ...while a lower class DOES escalate, which is why the hole is easy to miss.
+    for (const h of [73, 100, 1000]) {
+      expect(effectivePriority({ priority: 'critical', created_at: hoursAgo(h) }, new Date(NOW)).escalated,
+        `critical @${h}h is past the 72h threshold`).toBe(true);
+    }
+    // The RANK FLOOR is deliberately untouched by that fix — critical cannot outrank critical, and
+    // sort order depends on it. Escalation and ordering are now separate facts.
+    expect(effectivePriority({ priority: 'critical', created_at: hoursAgo(1000) }, new Date(NOW)).rank).toBe(1);
+    // A lower class still escalates, unchanged.
     expect(effectivePriority({ priority: 'normal', created_at: hoursAgo(100) }, new Date(NOW)).escalated).toBe(true);
   });
 


### PR DESCRIPTION
## Summary

The chairman decision queue had no way to learn that a decision had already been made. Measured live: **7 of 7 pending rows carry a chairman deferral**, every one within ~1.3 days — the queue was ageing all of them from `created_at` and presenting settled decisions as stale and escalating.

**Delivered:** FR-0, FR-1 (arm-aware retirement), FR-3 (disposition reader + provenance fence), FR-4 (supersession), FR-5 JS half, FR-6 (the queue now reads the deferrals it always ignored).

**Not delivered — stated plainly, not buried:**
- **FR-2** (arm 6 exit) — arm 6 is **2 of 7 live rows (29%)**. Both routes are blocked: mutating the flag re-asserts a reverted KILL disposition, and the view-predicate route is chairman-gated DDL that would *re-open this PR's own vulnerability class in SQL* (any `feedback` writer could suppress a chairman decision; all three views are `security_invoker=on`, making suppression caller-dependent).
- **FR-5 SQL half** — staged at `database/migrations/20260802_..._STAGED.sql`, deliberately **NOT executed**. `CREATE OR REPLACE` is TIER-2 chairman-gated. Carries a measured impact table and an apply runbook.
- **TR-7** — the vitest `db` project is disabled on this host, confirmed by positive control. TS-1(2nd), TS-3(SQL half), TS-8 and TS-10 are **not covered**, and there is no safe command to run them today (the only configured ref is production).

## A live security vulnerability was found and closed during this work

Not inherited — introduced and then caught here. An **unauthenticated** party could forge chairman retirement authority and reset a real decision's age clock.

`feedback` has **two** permissive anon INSERT policies and RLS OR-s them; the first fence only ever exercised one. Compounding it, `42501` is raised both by a rejected insert *and* by a **succeeding** insert whose `RETURNING` fails the read policy — so an error code could not distinguish them. Demonstrated live: anon `.insert()` → 201, row persisted, forged authority granted.

The fence is now derived from the **policy predicates** rather than a correlation, and rejects both anon shapes by construction. Re-verified adversarially: 13 insert shapes across anon *and* a minted authenticated JWT, every insert read back via service-role — 3 landed, **none can govern**. No third write path.

**Residual, accepted and routed:** the write surface stays open by design (anon can still insert; it just cannot govern). The durable fix is chairman-gated DDL — a trigger stamping writer identity, or a table with no anon INSERT policy.

## Four more defects found in this PR's own committed work

The green suite caught **none** of them:

1. The first fence **silently killed FR-6 in production** — the consumer never selected `source_type`, so all 21 rows were rejected. Measured 0 dispositions live vs 15 in control, while 32 tests stayed green because every fixture supplied the column by hand.
2. **FR-1 was dead on arrival** — `retirement_basis` is a column on neither target table (42703 both). The test fake accepted any patch, so it could not witness a missing column.
3. **FR-1 would have erased three chairman approvals** — measured on 15 live deferral targets, the uniform `.neq` fence matched all 13 including 3 at `approved`. That is the exact failure this SD exists to remove.
4. A docstring claimed a regex mirrored a SQL predicate; `LIKE '_'` is a wildcard and `startsWith` was literal.

## Test plan

- [x] This SD's 5 suites: **183 passing**
- [x] Every fix falsified by mutation — each mutant turns the specific test red, baseline green
- [x] Security fence verified **at the consumer**, with the live exploit re-planted and rejected
- [x] Probe rows cleaned up; `chairman_decision_deferred` back to the 21-row baseline
- [x] Retrospective published, quality score 100
- [ ] **Pre-existing, not from this PR:** 8 files / 11–12 tests fail in the full suite. None reference these modules; the failing set is unstable between runs (`eva/complexity-scorer` passes 7/7 in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)