### PR TITLE
fix(SD-LEO-INFRA-DECISION-RESURFACE-GUARDS-001): refuse to re-surface chairman decisions when there is no durable sink

### DIFF
--- a/lib/chairman/sms-outbound-worker.js
+++ b/lib/chairman/sms-outbound-worker.js
@@ -57,7 +57,13 @@
  * known table confirmed the probe works. So this path is LIVE, not inert, and has been for
  * some time. The fail-soft branch remains as a defensive measure; the claim that it is the
  * normal case does not. (SD-LEO-INFRA-DECISION-RESURFACE-GUARDS-001 FR-3 — the same false
- * claim sat in five places, so correcting one door left four serving stale.)
+ * claim was spread across MORE files than the first sweep found — correcting one door left the
+ * others serving stale, and the second sweep's own count was also short. Non-test files that have
+ * asserted it: this file, chairman-sms-gate/index.js (x2), chairman-morning-review-sweep.mjs,
+ * sms-outbound-reconcile-sweep.mjs, adam-decision-scheduler-tick.mjs (:9 and :34 — the PRODUCTION
+ * RUNNER, missed by the second sweep), api/webhooks/twilio-sms.js:114, sms-bridge.js:209,
+ * sms-outbound-worker.js:175 and :301, sms-channel-health.js:6. Grep the CLAIM, not the file you
+ * were sent to — and do not state a count you have not just re-counted.)
  */
 import twilioProvider from '../messaging/providers/twilio-provider.js';
 import { smsOutboundObligationsLive } from './sms-bridge.js';

--- a/lib/chairman/sms-outbound-worker.js
+++ b/lib/chairman/sms-outbound-worker.js
@@ -48,9 +48,16 @@
  * it, so a late callback for the ORIGINAL send still resolves against this row instead of
  * silently no-op'ing — the exact mechanism behind the live 7-duplicate incident this SD fixes.
  *
- * FAIL-SOFT: while the STAGED sms_outbound_obligations migration is unapplied the table is
- * absent; the liveness probe short-circuits and reconcileOutboundSms returns a no-op summary
- * (never throws), so this is inert pre-apply.
+ * FAIL-SOFT (mechanism, still correct): if the table is absent the liveness probe
+ * short-circuits and reconcileOutboundSms returns a no-op summary rather than throwing.
+ *
+ * BUT THE TABLE IS NOT ABSENT. This header previously asserted "while the STAGED
+ * sms_outbound_obligations migration is unapplied … this is inert pre-apply". MEASURED
+ * 2026-08-02: to_regclass resolves, 17 columns, 395 rows — and a to_regclass control on a
+ * known table confirmed the probe works. So this path is LIVE, not inert, and has been for
+ * some time. The fail-soft branch remains as a defensive measure; the claim that it is the
+ * normal case does not. (SD-LEO-INFRA-DECISION-RESURFACE-GUARDS-001 FR-3 — the same false
+ * claim sat in five places, so correcting one door left four serving stale.)
  */
 import twilioProvider from '../messaging/providers/twilio-provider.js';
 import { smsOutboundObligationsLive } from './sms-bridge.js';

--- a/lib/comms/adam-outbound/away-bridge/index.js
+++ b/lib/comms/adam-outbound/away-bridge/index.js
@@ -64,6 +64,34 @@ export async function processOwedDecisions(context = {}, opts = {}) {
     // Present -> do nothing (never text mid-read). Governs decisions only; presence never
     // touches heartbeats (they are not in the owed-decision set at all).
     if (!isAway(context)) { results.push({ owedId: o.owedId, action: 'skipped_present' }); continue; }
+    // SD-LEO-INFRA-DECISION-RESURFACE-GUARDS-001: NO DURABLE SINK -> REFUSE TO SEND.
+    //
+    // POSITION IS LOAD-BEARING, though NOT for the reason first written here. The original
+    // comment claimed a check placed below the next two guards would be "unreachable".
+    // That is false, and my own mutation harness disproved it: those branches only
+    // `continue` when they FIRE, and with the hardcoded permissive inputs they never do,
+    // so execution falls through and a lower placement still refuses. Moving the block
+    // below them did not fail the suite.
+    //
+    // What ordering actually protects is THE TRUTHFULNESS OF THE REPORTED REASON. When a
+    // guard input is present but untrustworthy -- resurfacedThisWindow true, or
+    // resurfaceCount at K, on a store with no column behind either -- a lower placement
+    // reports skipped_idempotent or escalated_email, asserting a fact the store
+    // demonstrably cannot know. Same non-send; a completely different claim in the log,
+    // and worse for escalated_email, which would send a real email on a fabricated count.
+    // The log is what a human reads when deciding whether the brakes work.
+    //
+    // FAIL CLOSED, deliberately, and note this is the opposite posture from the advisory
+    // surfaces elsewhere in this codebase: an informational reader that fails closed takes
+    // down a command, whereas a SEND path that fails open texts a person repeatedly. The
+    // consequence of being wrong picks the posture, not a general preference for strictness.
+    //
+    // Distinct action string on purpose: collapsing this into skipped_present would make
+    // "no brakes at all" indistinguishable from "the chairman is looking at the screen".
+    if (o.durabilityUnavailable) {
+      results.push({ owedId: o.owedId, action: 'skipped_no_durable_sink' });
+      continue;
+    }
     // Idempotent: already re-surfaced this window -> no double-apply.
     if (o.resurfacedThisWindow) { results.push({ owedId: o.owedId, action: 'skipped_idempotent' }); continue; }
     // K reached -> escalate to email, not another text.

--- a/lib/comms/adam-outbound/away-bridge/index.js
+++ b/lib/comms/adam-outbound/away-bridge/index.js
@@ -94,7 +94,11 @@ export async function processOwedDecisions(context = {}, opts = {}) {
     }
     // Idempotent: already re-surfaced this window -> no double-apply.
     if (o.resurfacedThisWindow) { results.push({ owedId: o.owedId, action: 'skipped_idempotent' }); continue; }
-    // K reached -> escalate to email, not another text.
+    // K reached -> escalate. NOT "email instead of a text": escalateChairmanDecision sends the
+    // email AND then calls gatedSms (lib/chairman/record-pending-decision.mjs:217), so this branch
+    // also attempts another chairman SMS. It is bounded per-decision by a durable CAS marker
+    // (brief_data.escalation_email_sent_at) so it cannot loop — but a reader evaluating the brakes
+    // was previously told the opposite by this very line.
     if ((o.resurfaceCount || 0) >= K) {
       if (typeof escalateEmail === 'function') await escalateEmail(o);
       results.push({ owedId: o.owedId, action: 'escalated_email' });

--- a/lib/comms/adam-outbound/chairman-sms-gate/index.js
+++ b/lib/comms/adam-outbound/chairman-sms-gate/index.js
@@ -59,8 +59,11 @@ function makeDefaultSender() {
     // without Supabase config. Credential isolation is preserved: no raw Twilio client is exposed.
     //
     // TRANSPORT fail-SOFT (distinct from the gate's RUBRIC fail-CLOSED): a rubric PASS has already
-    // been earned before send() is called; if the durable enqueue is unavailable (the STAGED
-    // sms_outbound_obligations migration is not applied pre-go-live), we DO NOT throw. Returns the
+    // been earned before send() is called; if the durable enqueue is unavailable we DO NOT throw.
+    // (This previously cited "the STAGED sms_outbound_obligations migration is not applied
+    // pre-go-live" as the reason it would be unavailable. That is FALSE — measured 2026-08-02:
+    // 17 columns, 395 rows. The fail-soft branch stands as a defensive path; the stated cause
+    // does not. SD-LEO-INFRA-DECISION-RESURFACE-GUARDS-001 FR-3.) Returns the
     // enqueue outcome so sendChairmanSMS (the caller) can report the truth and fire a real
     // fallback (QF-20260719-509 — this send() previously claimed 'the email fallback has already
     // fired' when NO fallback existed anywhere in the call path; the caller now owns that).
@@ -97,8 +100,11 @@ function makeDefaultSender() {
         // idempotent and serialized (claim predicate `WHERE status='owed' AND claimed_at IS NULL`),
         // so calling it here cannot double-send and cannot race the cron sweep. Verification reads
         // the row back rather than trusting the sweep's aggregate counts — per the sweep's own
-        // header it runs FAIL-SOFT while the STAGED obligations migration is unapplied, so its
-        // counters are not authoritative for a specific message.
+        // header the sweep has a FAIL-SOFT branch, so its aggregate counters are not authoritative
+        // for a specific message. (That header used to attribute the fail-soft to the obligations
+        // migration being unapplied; the table is in fact live — 395 rows, measured 2026-08-02 —
+        // so the sweep does real work. Reading the row back remains correct regardless: an
+        // aggregate count was never evidence about one message.)
         //
         // status='sent' is the honest bar: the worker stamps it only after Twilio accepts the
         // message (provider_message_id set). 'delivered' is callback-only and NOT required here —

--- a/lib/comms/adam-outbound/decision-scheduler/index.js
+++ b/lib/comms/adam-outbound/decision-scheduler/index.js
@@ -8,10 +8,24 @@
  * the existing chairman decision-email escalation path. away-bridge itself is NOT
  * modified (TR-1) -- this module is purely the wiring layer.
  *
- * FAIL-SOFT (TR-2): sms_outbound_obligations is a STAGED migration, not yet applied to
- * the live DB. getOwedDecisions() returns [] (never throws) while the table is absent,
- * reusing the existing smsOutboundObligationsLive() liveness probe. Once applied, the
- * SAME code path reads real rows -- but see the column-mapping caveat below.
+ * FAIL-SOFT (TR-2): getOwedDecisions() returns [] (never throws) when the table is
+ * absent, reusing the existing smsOutboundObligationsLive() liveness probe.
+ *
+ * *** THE TABLE IS APPLIED. Corrected by SD-LEO-INFRA-DECISION-RESURFACE-GUARDS-001. ***
+ * This header previously stated that sms_outbound_obligations "is a STAGED migration, not
+ * yet applied to the live DB". Measured 2026-08-01: 377 rows, 24 kind='decision_question',
+ * 6 of those with decision_id NOT NULL. The comment had been false for some time, and it
+ * is worth naming why that mattered rather than just deleting it: a comment sitting three
+ * lines above the code is trusted in proportion to its PROXIMITY and validated in inverse
+ * proportion -- it reads as documentation of the thing you are looking at, so each reader
+ * re-ratified the fail-soft rationale instead of querying the table.
+ *
+ * WHAT IS STILL MISSING (this part remains true): the table has NO answered,
+ * resurface_count or resurfaced_this_window columns -- each returns Postgres 42703,
+ * confirmed against a control query on id/kind/decision_id that returned cleanly in the
+ * same session. So the rate guards have no state to read, and buildOwedStore now marks
+ * that explicitly (durabilityUnavailable) so away-bridge REFUSES to re-surface instead of
+ * re-surfacing unbounded. See the caveat at the mapping site for the full reasoning.
  *
  * COLUMN-MAPPING CAVEAT (real, documented, not a silent gap): sms_outbound_obligations
  * has NO `answered`, `resurfaceCount`, or `resurfacedThisWindow` columns -- `status`
@@ -72,6 +86,29 @@ export function buildOwedStore(supabase) {
         // real owed decision), resurfaceCount=0 / resurfacedThisWindow=false (never
         // silently skip -- correct behavior is deferred to the chairman-apply follow-up,
         // not faked here).
+        //
+        // SD-LEO-INFRA-DECISION-RESURFACE-GUARDS-001 -- THOSE DEFAULTS ARE NOT SAFE, THEY
+        // ARE PERMISSIVE. resurfaceCount=0 and resurfacedThisWindow=false do not let the
+        // policy "run safely"; they make it UNABLE TO FIRE. away-bridge:68 tests
+        // resurfacedThisWindow (always false, so the window-skip never skips) and :70
+        // compares resurfaceCount (always 0) against K (so the K-cap never trips). With
+        // markResurfaced a no-op, nothing persists between ticks either. Both brakes are
+        // disconnected on a path whose side effect is an SMS to the chairman, and the
+        // only thing that has prevented repeat sends is the isAway presence check
+        // happening to read "present" because fleet heartbeats keep it fresh -- an
+        // accident of fleet liveness, not a control, and one that dissolves the moment
+        // dead-session heartbeat hygiene is fixed.
+        //
+        // A GUARD THAT CANNOT READ ITS STATE MUST NOT ACT. So this store now DECLARES the
+        // gap instead of papering over it: durabilityUnavailable marks that there is no
+        // durable sink behind resurfaceCount/resurfacedThisWindow, and away-bridge refuses
+        // to re-surface rather than re-surfacing unbounded. The flag is set HERE, where the
+        // absence is discovered -- not re-derived at the bridge, because two places
+        // deciding the same fact is how policy lists drift apart.
+        //
+        // It flips to false (or disappears) when the chairman-apply migration lands the
+        // three columns and markResurfaced gets a real sink. Other owed-store
+        // implementations that DO have durability simply omit the flag and are unaffected.
         return data.map((row) => ({
           owedId: row.id,
           decisionId: row.decision_id,
@@ -79,6 +116,7 @@ export function buildOwedStore(supabase) {
           answered: false,
           resurfaceCount: 0,
           resurfacedThisWindow: false,
+          durabilityUnavailable: true,
         }));
       } catch {
         return [];

--- a/scripts/cron/adam-decision-scheduler-tick.mjs
+++ b/scripts/cron/adam-decision-scheduler-tick.mjs
@@ -6,11 +6,23 @@
  *
  * SD: SD-LEO-INFRA-ADAM-DECISION-SCHEDULER-001 (FR-2)
  *
- * FAIL-SOFT: sms_outbound_obligations is a STAGED migration, not yet applied live. While
- * absent, runDecisionSchedulerTick() returns {ran:true, results:[]} (owedStore.getOwedDecisions
- * returns [] fail-soft) and this sweep exits 0. Once the migration is applied, the SAME code
- * path processes real owed decision rows -- see the decision-scheduler module header for the
- * documented column-mapping caveat (no answered/resurfaceCount/resurfacedThisWindow columns).
+ * THE MIGRATION IS APPLIED. THIS RUNNER DOES REAL WORK ON EVERY TICK.
+ * This header previously said "sms_outbound_obligations is a STAGED migration, not yet applied
+ * live … this sweep exits 0", which invited every reader of the ENTRY POINT to conclude the whole
+ * path was inert. MEASURED 2026-08-02T00:47Z: the table resolves, 395 rows, 17 columns, and NINE
+ * rows match getOwedDecisions' predicate. This workflow runs ~15x/day.
+ *
+ * FAIL-SOFT (mechanism, still correct): were the table absent, runDecisionSchedulerTick() would
+ * return {ran:true, results:[]} and this sweep would exit 0. That branch is defensive, not the
+ * normal case.
+ *
+ * WHAT ACTUALLY RESTRAINS THIS PATH is the durability refusal in away-bridge, NOT absence of the
+ * table: sms_outbound_obligations has no answered/resurface_count/resurfaced_this_window columns
+ * (42703 each, against a clean control on id/kind/decision_id), so the window-skip and K-cap
+ * cannot fire, and buildOwedStore stamps durabilityUnavailable so the bridge refuses to send.
+ * Without that refusal the loop is SELF-AMPLIFYING, not merely repetitive: each re-surface
+ * enqueues a row that itself matches the unfiltered predicate (9 -> 18 -> 36 per tick).
+ * SD-LEO-INFRA-DECISION-RESURFACE-GUARDS-001 FR-3.
  *
  * Liveness: registers ARMED machinery once (periodic_process_registry, named activation
  * trigger = this cron workflow) and stamps last_fired_at on every real run, mirroring

--- a/scripts/cron/chairman-morning-review-sweep.mjs
+++ b/scripts/cron/chairman-morning-review-sweep.mjs
@@ -17,9 +17,14 @@
  * is 5), so exactly one of the two fires maps to 05:45 ET per season and does work — the other
  * exits inert. The per-ET-date dedupeKey is the idempotency backstop against a double-fire.
  *
- * FAIL-SOFT: while the STAGED sms_outbound_obligations table is unapplied, enqueueChairmanSms
- * returns {enqueued:false, reason:'table_absent...'} without throwing and this sweep logs inert
- * + exits 0 (no crash, no direct provider.send fallback).
+ * FAIL-SOFT (mechanism, still correct): if the table were absent, enqueueChairmanSms returns
+ * {enqueued:false, reason:'table_absent...'} without throwing and this sweep logs inert + exits 0
+ * (no crash, no direct provider.send fallback).
+ *
+ * THE TABLE IS PRESENT. This header previously said it "is unapplied". MEASURED 2026-08-02:
+ * 17 columns, 395 rows, to_regclass resolves (control query on a known table confirms the probe
+ * works). This sweep enqueues for real — do not reason about it as inert.
+ * SD-LEO-INFRA-DECISION-RESURFACE-GUARDS-001 FR-3.
  *
  * Usage:
  *   node scripts/cron/chairman-morning-review-sweep.mjs --once

--- a/scripts/cron/sms-outbound-reconcile-sweep.mjs
+++ b/scripts/cron/sms-outbound-reconcile-sweep.mjs
@@ -9,8 +9,13 @@
  * mid-send (the F1 failure mode). reconcileOutboundSms itself is claim-serialized + idempotent,
  * so overlapping invocations are safe.
  *
- * FAIL-SOFT: while the STAGED sms_outbound_obligations migration is unapplied, reconcileOutboundSms
- * returns {ran:false, reason:'table_absent'} and this sweep exits 0 (nothing to do).
+ * FAIL-SOFT (mechanism, still correct): if the table were absent, reconcileOutboundSms returns
+ * {ran:false, reason:'table_absent'} and this sweep exits 0.
+ *
+ * THE TABLE IS PRESENT. This header previously said the STAGED migration "is unapplied".
+ * MEASURED 2026-08-02: 17 columns, 395 rows, to_regclass resolves (control query on a known
+ * table confirms the probe works). This sweep therefore does REAL work; treating it as inert
+ * is wrong. SD-LEO-INFRA-DECISION-RESURFACE-GUARDS-001 FR-3.
  *
  * Usage:
  *   node scripts/cron/sms-outbound-reconcile-sweep.mjs --once       # one reconcile pass

--- a/tests/unit/decision-resurface-durability-guard.test.js
+++ b/tests/unit/decision-resurface-durability-guard.test.js
@@ -228,6 +228,35 @@ describe('THE REAL STORE marks the gap — not just the test fixture', () => {
     expect(owedDecisions.length).toBeGreaterThan(0);
     for (const o of owedDecisions) {
       expect(o.durabilityUnavailable, `owed ${o.owedId}`).toBe(true);
+
+      // ===== answered:false IS LOAD-BEARING, AND ITS ABSENCE HERE WAS A LIVE SURVIVOR =====
+      // Mutating the adapter's `answered: false` to `true` left ALL 12 tests green. It is not a
+      // cosmetic field: away-bridge's answered-drop (:63) runs BEFORE the durability refusal
+      // (:91), so an always-answered store makes THIS SD'S GUARD UNREACHABLE — every owed
+      // decision exits as 'dropped_answered', which reads in the log like a legitimate drop
+      // rather than a disabled brake. A one-line adapter change silently removes the feature.
+      //
+      // The comment above ("if the store stops marking … nothing would notice") was written for
+      // exactly this hazard and then closed it for ONE field. Pinning every mapped field is the
+      // general form: a stubbed writer is only witnessed for the values you actually assert.
+      expect(o.answered, `owed ${o.owedId} answered`).toBe(false);
+      expect(o.resurfaceCount, `owed ${o.owedId} resurfaceCount`).toBe(0);
+      expect(o.resurfacedThisWindow, `owed ${o.owedId} resurfacedThisWindow`).toBe(false);
+      expect(o.owedId, 'owedId must be mapped').toBeTruthy();
+      expect(o.message, 'message must be mapped').toBeTruthy();
     }
+  });
+
+  it('an always-answered store would make the refusal UNREACHABLE — the drop precedes it', async () => {
+    // Proves the consequence the assertion above guards against, at the bridge level: with
+    // answered:true the refusal never runs, so the outcome is 'dropped_answered' and NOT
+    // 'skipped_no_durable_sink'. Ordering is the whole point — the drop is upstream of the guard.
+    const answeredStore = {
+      getOwedDecisions: async () => [{ ...owed(), answered: true, durabilityUnavailable: true }],
+      markResurfaced: async () => {},
+    };
+    const results = await run(AWAY, answeredStore);
+    expect(results.map((r) => r.action)).toEqual(['dropped_answered']);
+    expect(results.map((r) => r.action)).not.toContain('skipped_no_durable_sink');
   });
 });

--- a/tests/unit/decision-resurface-durability-guard.test.js
+++ b/tests/unit/decision-resurface-durability-guard.test.js
@@ -1,0 +1,233 @@
+/**
+ * SD-LEO-INFRA-DECISION-RESURFACE-GUARDS-001 — fail closed when there is no durable sink.
+ *
+ * THE DEFECT: sms_outbound_obligations has no answered / resurface_count /
+ * resurfaced_this_window columns (Postgres 42703 on each, confirmed against a control
+ * query on id/kind/decision_id that returned cleanly in the same session). buildOwedStore
+ * therefore hardcoded all three guard inputs to the PERMISSIVE value, which does not make
+ * the policy "run safely" — it makes it UNABLE TO FIRE. away-bridge tests
+ * resurfacedThisWindow (always false → never skips) and compares resurfaceCount (always 0)
+ * against K (→ never trips). markResurfaced is a no-op, so nothing persists between the
+ * hourly ticks either.
+ *
+ * WHY NOTHING HAS BEEN SENT: the only remaining brake is the isAway presence check, and
+ * presence reads MAX(claude_sessions.heartbeat_at), which fleet workers keep fresh. That
+ * is an accident of fleet liveness, not a control — so EVERY rate-guard scenario below
+ * runs with isAway TRUE. If any of them passed because the chairman looked present, this
+ * suite would be re-creating today's accidental containment inside its own fixtures and
+ * proving nothing about the guards.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { processOwedDecisions, isAway } from '../../lib/comms/adam-outbound/away-bridge/index.js';
+import { buildOwedStore } from '../../lib/comms/adam-outbound/decision-scheduler/index.js';
+
+const NOW = Date.UTC(2026, 7, 1, 18, 0, 0);
+/** isAway TRUE — every rate-guard scenario uses this. */
+const AWAY = { now: NOW, lastInputAt: NOW - 6 * 60 * 60 * 1000 };
+/** isAway FALSE — used ONCE, and never as evidence the guards work. */
+const PRESENT = { now: NOW, lastInputAt: NOW - 1000 };
+
+const owed = (over = {}) => ({
+  owedId: 'owed-1',
+  decisionId: 'dec-1',
+  message: { body: 'Still pending: choose A or B', decisionId: 'dec-1' },
+  answered: false,
+  resurfaceCount: 0,
+  resurfacedThisWindow: false,
+  ...over,
+});
+
+/** Store whose durability is ABSENT — today's real production state. */
+const noSinkStore = (entries) => ({
+  getOwedDecisions: async () => entries.map((e) => ({ ...e, durabilityUnavailable: true })),
+  markResurfaced: vi.fn(async () => {}),
+});
+
+/** Store WITH a working sink — what exists once the migration lands the three columns. */
+const durableStore = (entries, marked) => ({
+  getOwedDecisions: async () => entries,
+  markResurfaced: marked,
+});
+
+const run = (context, store, opts = {}) => processOwedDecisions(context, {
+  owedStore: store,
+  sender: opts.sender ?? vi.fn(async () => {}),
+  escalateEmail: opts.escalateEmail ?? vi.fn(async () => {}),
+  K: opts.K ?? 2,
+});
+
+describe('the fixtures actually exercise the intended presence state', () => {
+  // Control. If AWAY did not make isAway true, every "guard held" assertion below would be
+  // satisfied by skipped_present instead — the exact substitution this SD exists to stop.
+  it('AWAY is away and PRESENT is present', () => {
+    expect(isAway(AWAY)).toBe(true);
+    expect(isAway(PRESENT)).toBe(false);
+  });
+});
+
+describe('FR-1: no durable sink → REFUSE to send', () => {
+  it('TWO consecutive ticks produce ZERO sends and a distinct refusal', async () => {
+    // TWO ticks is the point. One tick cannot distinguish "sent once, correctly" from
+    // "will send every hour forever", and the second is what the defect actually causes.
+    const sender = vi.fn(async () => {});
+    const store = noSinkStore([owed()]);
+
+    const first = await run(AWAY, store, { sender });
+    const second = await run(AWAY, store, { sender });
+
+    expect(sender).not.toHaveBeenCalled();
+    expect(first[0].action).toBe('skipped_no_durable_sink');
+    expect(second[0].action).toBe('skipped_no_durable_sink');
+  });
+
+  it('the refusal is distinguishable from skipped_present', async () => {
+    // Collapsing these would make "no brakes at all" look identical to "the chairman is
+    // reading the screen" — the most misleading conflation available on this path.
+    const away = await run(AWAY, noSinkStore([owed()]));
+    const present = await run(PRESENT, noSinkStore([owed()]));
+    expect(away[0].action).toBe('skipped_no_durable_sink');
+    expect(present[0].action).toBe('skipped_present');
+  });
+});
+
+describe('FR-1 ordering: the refusal must precede guards that cannot fire', () => {
+  it('refuses even when the two dead guards would have passed', async () => {
+    // resurfacedThisWindow=false and resurfaceCount=0 are precisely the inputs that make
+    // the window-skip and K-cap unreachable. A durability check placed BELOW them would
+    // never run — it would read as a fix and change nothing. Asserting the ACTION proves
+    // position rather than assuming it.
+    const sender = vi.fn(async () => {});
+    const results = await run(AWAY, noSinkStore([owed({ resurfacedThisWindow: false, resurfaceCount: 0 })]), { sender });
+    expect(results[0].action).toBe('skipped_no_durable_sink');
+    expect(sender).not.toHaveBeenCalled();
+  });
+
+  it('an ANSWERED decision is still dropped first — the refusal does not mask a real drop', async () => {
+    const results = await run(AWAY, noSinkStore([owed({ answered: true })]));
+    expect(results[0].action).toBe('dropped_answered');
+  });
+});
+
+describe('FR-2 OPPOSITE POLARITY: with a working sink the feature still works', () => {
+  // A fix that refuses in BOTH directions is a permanent mute — silent, unreported, and
+  // worse than the defect, because the defect at least sends something.
+  it('sends when the sink is available, and marks it', async () => {
+    const sender = vi.fn(async () => {});
+    const marked = vi.fn(async () => {});
+    const results = await run(AWAY, durableStore([owed()], marked), { sender });
+    expect(results[0].action).not.toBe('skipped_no_durable_sink');
+    expect(sender).toHaveBeenCalledTimes(1);
+    // markResurfaced must actually be CALLED. It is a no-op today, so a fix that leaves it
+    // uncalled would regress silently the moment the columns land.
+    expect(marked).toHaveBeenCalled();
+  });
+
+  it('the window-skip suppresses a second re-surface', async () => {
+    const sender = vi.fn(async () => {});
+    const results = await run(AWAY, durableStore([owed({ resurfacedThisWindow: true })], vi.fn()), { sender });
+    expect(results[0].action).toBe('skipped_idempotent');
+    expect(sender).not.toHaveBeenCalled();
+  });
+
+  it('the K-cap ESCALATES to email rather than muting', async () => {
+    const sender = vi.fn(async () => {});
+    const escalateEmail = vi.fn(async () => {});
+    const results = await run(AWAY, durableStore([owed({ resurfaceCount: 2 })], vi.fn()), { sender, escalateEmail, K: 2 });
+    expect(results[0].action).toBe('escalated_email');
+    expect(escalateEmail).toHaveBeenCalledTimes(1);
+    expect(sender).not.toHaveBeenCalled();
+  });
+});
+
+describe('FR-4: presence is not carrying the guards', () => {
+  it('the refusals above happened with isAway TRUE — presence never suppressed them', async () => {
+    // If this suite relied on skipped_present to reach zero sends, a green run would prove
+    // only that the chairman looked present. Assert that negative directly.
+    const results = await run(AWAY, noSinkStore([owed(), owed({ owedId: 'owed-2' })]));
+    expect(results.map((r) => r.action)).toEqual(['skipped_no_durable_sink', 'skipped_no_durable_sink']);
+    expect(results.some((r) => r.action === 'skipped_present')).toBe(false);
+  });
+});
+
+describe('ORDERING — the refusal must outrank a guard that WOULD fire', () => {
+  // MY OWN MUTATION HARNESS CORRECTED ME HERE. I had claimed a refusal placed below the
+  // window-skip and K-cap would be "unreachable". That is wrong: those branches only
+  // `continue` when they FIRE, and with permissive hardcoded inputs they never do, so
+  // execution falls through and the refusal still runs. Moving it below therefore did NOT
+  // fail the suite.
+  //
+  // What ordering actually protects is the TRUTHFULNESS OF THE REPORTED REASON. When a
+  // guard input is present-but-untrustworthy, the lower placement reports skipped_idempotent
+  // — asserting an idempotency the store demonstrably cannot know, because there is no
+  // column behind it. Same non-send either way; completely different claim in the log,
+  // and the log is what a human reads when deciding whether the brakes work.
+  it('durability absent AND resurfacedThisWindow true -> reports NO-DURABLE-SINK, not idempotent', async () => {
+    const sender = vi.fn(async () => {});
+    const store = {
+      getOwedDecisions: async () => [owed({ resurfacedThisWindow: true, durabilityUnavailable: true })],
+      markResurfaced: vi.fn(async () => {}),
+    };
+    const results = await run(AWAY, store, { sender });
+    expect(results[0].action).toBe('skipped_no_durable_sink');
+    expect(results[0].action).not.toBe('skipped_idempotent');
+    expect(sender).not.toHaveBeenCalled();
+  });
+
+  it('durability absent AND resurfaceCount at K -> refuses rather than claiming escalation', async () => {
+    const escalateEmail = vi.fn(async () => {});
+    const store = {
+      getOwedDecisions: async () => [owed({ resurfaceCount: 5, durabilityUnavailable: true })],
+      markResurfaced: vi.fn(async () => {}),
+    };
+    const results = await run(AWAY, store, { escalateEmail, K: 2 });
+    expect(results[0].action).toBe('skipped_no_durable_sink');
+    // Escalating on a count read from nothing would send a real email on a fabricated number.
+    expect(escalateEmail).not.toHaveBeenCalled();
+  });
+});
+
+describe('THE REAL STORE marks the gap — not just the test fixture', () => {
+  // SECOND SURVIVOR MY HARNESS FOUND: renaming durabilityUnavailable in the production
+  // store killed nothing, because every scenario above builds its own fixture that sets
+  // the flag itself. The bridge was tested; the STORE never was. That is stubbed-writer
+  // blindness — the same shape as the FR-4 constant-only gap a reviewer found on the
+  // previous SD, reproduced by me one module over, in the SD whose subject is guards that
+  // report without measuring.
+  it('buildOwedStore stamps durabilityUnavailable on every owed decision it returns', async () => {
+    const rows = [
+      { id: 'o1', decision_id: 'd1', body: 'Still pending: A or B', status: 'queued' },
+      { id: 'o2', decision_id: 'd2', body: 'Still pending: C or D', status: 'queued' },
+    ];
+    // getOwedDecisions goes through fetchAllPaginated, which paginates with .range() —
+    // the store's own comment notes the PostgREST 1000-row cap would otherwise silently
+    // drop owed decisions. So .order() must stay CHAINABLE and .range() is what resolves;
+    // a mock that resolves at .order() returns nothing and the test fails for the wrong
+    // reason. (I got this wrong first — the cap that comment warns about is the same one
+    // that made a capped sample look like a clean result twice for me today.)
+    let page = 0;
+    const builder = {
+      select() { return builder; },
+      eq() { return builder; },
+      not() { return builder; },
+      order() { return builder; },
+      // smsOutboundObligationsLive probes .select('id').limit(1) and treats ANY error as
+      // "table absent" -> the store fail-softs to []. Omitting limit() here made the mock
+      // throw, the probe report dead, and the assertion fail for a reason that had nothing
+      // to do with the behaviour under test.
+      limit() { return Promise.resolve({ data: [], error: null }); },
+      range() { return Promise.resolve({ data: page++ === 0 ? rows : [], error: null }); },
+      then(res) { return Promise.resolve({ data: rows, error: null }).then(res); },
+    };
+    const supabase = { from: () => builder };
+
+    const store = buildOwedStore(supabase);
+    const owedDecisions = await store.getOwedDecisions();
+
+    // If the store stops marking, the bridge silently reverts to the unbounded path and
+    // nothing in the bridge-level tests would notice.
+    expect(owedDecisions.length).toBeGreaterThan(0);
+    for (const o of owedDecisions) {
+      expect(o.durabilityUnavailable, `owed ${o.owedId}`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Both rate guards on the chairman SMS decision re-surface path were **structurally dead**, and the only thing preventing repeat sends was an accident that ordinary maintenance would remove.

## The defect

`sms_outbound_obligations` has no `answered` / `resurface_count` / `resurfaced_this_window` columns — Postgres **42703** on each, confirmed against a control query on `id/kind/decision_id` that returned cleanly in the same session. So `buildOwedStore` hardcoded all three guard inputs to the **permissive** value.

That doesn't let the policy "run safely" as the old comment claimed — it makes the policy **unable to fire**:

| guard | input | outcome |
|---|---|---|
| window-skip (`:68`) | `resurfacedThisWindow` always `false` | never skips |
| K-cap (`:70`) | `resurfaceCount` always `0` | never trips |
| `markResurfaced` | no-op | nothing persists between ticks |

The GHA cron fires ~15×/day, and every fire re-evaluated the same decisions with both brakes disconnected.

## It was self-amplifying, not merely repetitive

SECURITY measured this more precisely than the SD originally framed it. A re-surface **enqueues a row that itself matches** `getOwedDecisions`' unfiltered predicate (`dedupe_key` NULL, and 230 null-keyed rows prove NULLs don't conflict) — so the owed set grows **9 → 18 → 36 per tick**.

## Why nothing had fired

The only remaining brake was the `isAway` presence check, and presence reads `MAX(claude_sessions.heartbeat_at)` — kept fresh by fleet workers and leaked session daemons. That's **fleet liveness, not a control**. It dissolves the moment someone fixes dead-session heartbeat hygiene, which is ordinary cleanup nobody would connect to an outbound SMS path.

## The fix

**A guard that cannot read its state must not act.** The store now declares the gap (`durabilityUnavailable`) where the absence is *discovered*, and the bridge refuses rather than re-surfacing unbounded — with a distinct action string, so "no brakes at all" can't be mistaken for "the chairman is reading the screen."

**Fail closed**, deliberately the opposite posture from the advisory surfaces elsewhere in this codebase: an informational reader that fails closed takes down a command; a *send* path that fails open texts a person repeatedly. The consequence of being wrong picks the posture.

**No DDL** — adding the three columns is chairman-gated and remains the real fix.

## Defects found in this work, by review and by mutation

**The guard could be disabled from another file with a green suite.** Mutating the adapter's `answered: false` → `true` left all 12 tests passing. The answered-drop (`:63`) runs *before* the durability refusal (`:91`), so an always-answered store makes the entire guard unreachable — and every decision exits as `dropped_answered`, which reads like a legitimate drop. The store test asserted only `durabilityUnavailable`; its own comment named that exact hazard and then closed it for one field. **A stubbed writer is only witnessed for the values you actually assert.** Now pins every mapped field plus a bridge-level consequence test.

**The FR-3 correction landed on one door.** The stale "table is a STAGED migration" claim was live in ~10 other places, including `scripts/cron/adam-decision-scheduler-tick.mjs` — the production cron entry point, the first file a human opens to ask whether this does anything. Rule: **grep the claim, not the file you were sent to.**

**A comment on a brake told the opposite of the truth.** `away-bridge:97` said the K-cap "escalates to email, not another text" — `escalateChairmanDecision` sends the email *and* calls `gatedSms`. Bounded by a durable CAS marker so it cannot loop, but it misled exactly the reader evaluating whether the brakes work.

**And an overclaim of mine, disproved by my own harness.** I wrote that a refusal placed below the guards would be "unreachable." False — those branches only `continue` when they *fire*, and with permissive inputs they never do. Ordering actually protects the *truthfulness of the reported reason*: a lower placement reports `escalated_email` on a fabricated count, which sends a real email. Comment corrected, case pinned.

## Verification

Per-site mutation 3/3 killed on my sites, 24/25 then 25/25 after the survivor was closed — every edit **content-verified** (both files are 100% CRLF; bare-`\n` anchors matched zero and aborted a run). 80+ tests green across the adjacent suites. No live row mutated, no message sent: 377 rows / 0 sent before and after.

SD: SD-LEO-INFRA-DECISION-RESURFACE-GUARDS-001 · built with Alpha-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)
