### PR TITLE
fix(fleet-identity): Adam and Solomon were rostered as fleet workers

### DIFF
--- a/scripts/assign-fleet-identities.cjs
+++ b/scripts/assign-fleet-identities.cjs
@@ -132,8 +132,26 @@ function nextAvailable(pool, usedSet) {
 // QF-20260508-648: writer/consumer asymmetry — lib/coordinator/resolve.cjs
 // setActiveCoordinator() writes metadata.is_coordinator=true; this consumer
 // must filter it out so coordinator sessions aren't assigned worker callsigns.
+//
+// 2026-08-02 (feedback 3372f8fb): the SAME asymmetry was open for the other two
+// ROLE sessions. adam-register.cjs / solomon-register.cjs write metadata.role +
+// metadata.non_fleet, and this consumer read neither — so Adam was rostered as a
+// fleet worker and his statusline rendered "Alpha-4 | idle" while his own
+// metadata.callsign said "Adam". Two representations of one name on one row, and
+// the statusline reads the wrong one. Operator-reported.
+//
+// The predicate here is deliberately the same shape as lib/claim/build-forbidden-session.cjs
+// isBuildForbiddenSession (non_fleet || role==='adam' || is_coordinator), which is
+// what the claim path already uses to keep these sessions propose-only per CONST-002.
+// The canonical cohort predicate is lib/fleet/session-predicates.mjs isFleetWorker;
+// it is ESM and additionally requires an sd_key, which would drop claim-free parked
+// workers out of the roster, so consolidating onto it is a separate change.
 function filterOutCoordinators(rows) {
-  return (rows || []).filter(w => w && w.metadata?.is_coordinator !== true);
+  return (rows || []).filter(w => w
+    && w.metadata?.is_coordinator !== true
+    && w.metadata?.non_fleet !== true
+    && w.metadata?.role !== 'adam'
+    && w.metadata?.role !== 'solomon');
 }
 
 // QF-20260528-581 (Bug B): filter out test/ghost sessions that consume the clean


### PR DESCRIPTION
## What

`assign-fleet-identities.cjs` filtered only `metadata.is_coordinator`. The other two **role sessions** write `metadata.role` + `metadata.non_fleet` (`adam-register.cjs`, `solomon-register.cjs`) and this consumer read neither — so Adam was assigned a NATO callsign.

## Symptom (operator-reported)

Adam's statusline read **`Alpha-4 | idle`** while his own `metadata.callsign` said `"Adam"`. Two representations of one name on one row, and the statusline renders the wrong one:

```
metadata.callsign               = "Adam"                 <- correct
metadata.fleet_identity.callsign = "Alpha-4"             <- written by this script
metadata.fleet_identity.role     = "adam"                <- it knew, and assigned anyway
```

`| idle` is the same artifact: a role session is claimless **by design** (propose-only per CONST-002), not idle.

## Why it matters beyond cosmetics

Adam inflates the worker census — the roster reported "7 workers" when there were 6 — which feeds idle-worker/dispatch logic that is supposed to see real capacity only.

## Fix

Extend the existing filter to the same shape already used by `lib/claim/build-forbidden-session.cjs` `isBuildForbiddenSession` (`non_fleet || role==='adam' || is_coordinator`), which is what the claim path uses to keep these sessions propose-only.

Same writer/consumer asymmetry as **QF-20260508-648**, which fixed it for the coordinator only.

## Verification

Predicate in isolation — role sessions dropped, real workers (including claim-free parked seats and rows with no metadata) retained:

```
KEPT: ["worker-plain","worker-claim","no-metadata"]
leaked role sessions : NONE
dropped real workers : NONE
PASS
```

**Consumer-verified**, not just the predicate — ran the script against the live fleet:

```
before: Fleet Identity Roster (7 workers ...)   incl.  Alpha-4  yellow  b22451df  idle
after : Fleet Identity Roster (6 workers ...)   Adam absent, all 6 real workers keep their callsigns
```

## Deliberately not done

Consolidating onto the canonical `lib/fleet/session-predicates.mjs` `isFleetWorker`. It is ESM and additionally requires an `sd_key`, which would drop claim-free parked workers out of the roster — a behaviour change beyond this defect. Noted in the code comment as a separate change.

## Follow-up (not in this PR)

Adam's row still carries the stale `fleet_identity` object. It will no longer be **refreshed**, but it is not **cleared** by this change, so the statusline needs that field removed once this merges.

Refs feedback `3372f8fb`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
