### PR TITLE
fix(SD-LEO-INFRA-STATUS-VOCABULARY-SCHISM-001): the normalizer overwrote the executors for three months under a comment saying it matched them

### DIFF
--- a/lib/eva/bridge/venture-build-consumer.js
+++ b/lib/eva/bridge/venture-build-consumer.js
@@ -55,7 +55,21 @@ import { resolveRepoPathDbFirst, normalizeAppName, ENGINEER_ROOT } from '../../r
 import { observeLeafMergeWitness } from './venture-build-merge-witness.js';
 
 export const S19 = 19;
-export const NON_TERMINAL = ['draft', 'active'];
+// The statuses the handoff pipeline actually produces for an SD that is still being worked.
+// SD-LEO-INFRA-STATUS-VOCABULARY-SCHISM-001 added 'in_progress' and 'pending_approval':
+// POST_HANDOFF_SD_STATE force-normalized every handoff outcome to 'in_progress' from
+// 2026-04-24, and 'in_progress' was in NEITHER this list nor TERMINAL, so an SD that had
+// passed ANY handoff became invisible to leaf selection. That bit twice in legacyWorkableLeaves,
+// which reads this constant with OPPOSITE senses: an in-flight SD was not SELECTED as a leaf,
+// and — worse — its parent stopped counting it as a working descendant, so the PARENT looked
+// like a workable leaf instead of the child.
+//
+// ENUMERATION IS DELIBERATE HERE; DO NOT INVERT IT. QF-20260727-846 inverted isTreeComplete to
+// test TERMINAL membership so an unknown status counts as NOT complete — safe there, because the
+// worst case is a venture needing a nudge. The direction is OPPOSITE for selection: inverting
+// here would make an unknown status WORKABLE and drive an SD that should not be driven. So the
+// fix is to complete the enumeration, not to flip the test.
+export const NON_TERMINAL = ['draft', 'active', 'in_progress', 'pending_approval'];
 export const TERMINAL = ['completed', 'cancelled', 'archived'];
 const VENTURE_DEAD = ['killed', 'retired', 'cancelled', 'archived'];
 

--- a/scripts/modules/handoff/cli/execution-helpers.js
+++ b/scripts/modules/handoff/cli/execution-helpers.js
@@ -22,13 +22,31 @@ import { resolveAutoProceed } from '../auto-proceed-resolver.js';
  * helper re-queries the SD and force-updates status/phase when drift is
  * detected. Fail-soft: any error is logged but does not fail the handoff.
  *
- * Expected post-handoff SD state per handoff type (matches the DB writes
- * in each executor's state-transitions.js):
+ * Expected post-handoff SD state per handoff type. Each entry MUST equal what that
+ * handoff's authoritative setter actually writes — this table does not decide the
+ * vocabulary, it mirrors it.
+ *
+ * *** THIS COMMENT USED TO SAY THE TABLE MATCHED THE EXECUTORS. IT DID NOT. ***
+ * SD-LEO-INFRA-STATUS-VOCABULARY-SCHISM-001. From the 2026-04-24 reconciler commit
+ * (0af429eaf52) until this fix, PLAN-TO-EXEC and EXEC-TO-PLAN were listed here as
+ * 'in_progress' while their setters write 'active' — plan-to-exec/state-transitions.js:133
+ * and fn_atomic_exec_to_plan_transition. The drift branch below therefore fired on EVERY
+ * one of those handoffs and overwrote the setter milliseconds later in the same process,
+ * so 'active' stopped being written at all: the audit pre_active series ran 2026-04:125,
+ * 05:5, 06:12, 07:ZERO, with the collapse landing exactly on that commit.
+ *
+ * The false comment is why it survived three months of review — the file asserted its own
+ * correctness, so anyone checking read the claim instead of the executors. If you change a
+ * value here, change it because you read the setter, not because this comment says so.
+ *
+ * VERIFY AT THE CITED LINE: plan-to-exec/state-transitions.js has an EARLIER status write
+ * at :87 setting 'in_progress'. A grep that stops at the first hit reads the file as
+ * agreeing with this table and concludes there is no schism.
  */
 const POST_HANDOFF_SD_STATE = {
-  'LEAD-TO-PLAN': { status: 'in_progress', current_phase: 'PLAN_PRD' },
-  'PLAN-TO-EXEC': { status: 'in_progress', current_phase: 'EXEC' },
-  'EXEC-TO-PLAN': { status: 'in_progress', current_phase: 'PLAN_VERIFICATION' },
+  'LEAD-TO-PLAN': { status: 'in_progress', current_phase: 'PLAN_PRD' },       // lead-to-plan/state-transitions.js:104
+  'PLAN-TO-EXEC': { status: 'active', current_phase: 'EXEC' },                // plan-to-exec/state-transitions.js:133
+  'EXEC-TO-PLAN': { status: 'active', current_phase: 'PLAN_VERIFICATION' },   // fn_atomic_exec_to_plan_transition
   'PLAN-TO-LEAD': { status: 'pending_approval', current_phase: 'LEAD_FINAL' },
   'LEAD-FINAL-APPROVAL': { status: 'completed', current_phase: 'COMPLETED' },
 };

--- a/tests/unit/eva/bridge/venture-build-consumer.test.js
+++ b/tests/unit/eva/bridge/venture-build-consumer.test.js
@@ -162,6 +162,56 @@ describe('venture-build-consumer — introspection', () => {
     // Degenerate case: no descendants is vacuously complete (unchanged by the inversion).
     expect(isTreeComplete([])).toBe(true);
   });
+
+  // SD-LEO-INFRA-STATUS-VOCABULARY-SCHISM-001 (FR-3). Pins the QF-20260727-846 direction for the
+  // OTHER status the pipeline produces. PLAN-TO-LEAD writes 'pending_approval', which — like
+  // 'in_progress' before it — is in neither list, so it must block completion for the same reason.
+  // Landed BEFORE the NON_TERMINAL edit below, because that edit touches the same constant family
+  // and this is the behaviour it must not regress.
+  it('isTreeComplete blocks on pending_approval (PLAN-TO-LEAD output), not just in_progress', () => {
+    const sds = nestedTree({ children: 1, grandkidsEach: 2 }).filter((s) => s.id !== 'orch-top');
+    sds.forEach((s) => { s.status = 'completed'; });
+    sds[0].status = 'pending_approval';
+    expect(isTreeComplete(sds)).toBe(false);
+  });
+
+  // SD-LEO-INFRA-STATUS-VOCABULARY-SCHISM-001 (FR-2). THE STARVATION HALF.
+  //
+  // legacyWorkableLeaves reads NON_TERMINAL with two OPPOSITE senses in one function: it SELECTS
+  // leaves whose own status is non-terminal, and it EXCLUDES a node that still has a non-terminal
+  // DESCENDANT. Leaving 'in_progress' out of the list therefore broke it twice — the in-flight SD
+  // was not selected, AND its parent stopped seeing it as working, so the parent surfaced as a
+  // leaf in its place. Both directions are asserted here.
+  it('computeWorkableLeaves selects in_progress and pending_approval SDs, and their parents do not shadow them', () => {
+    const sds = nestedTree({ children: 1, grandkidsEach: 2 }).filter((s) => s.id !== 'orch-top');
+    const leaves = sds.filter((s) => s.sd_type === 'feature');
+
+    // The exact reported defect: an SD past any handoff is still workable.
+    leaves.forEach((l) => { l.status = 'in_progress'; });
+    let picked = computeWorkableLeaves(sds);
+    expect(picked.map((p) => p.id).sort()).toEqual(leaves.map((l) => l.id).sort());
+
+    // PLAN-TO-LEAD's status is workable too.
+    leaves.forEach((l) => { l.status = 'pending_approval'; });
+    picked = computeWorkableLeaves(sds);
+    expect(picked.length).toBe(leaves.length);
+
+    // THE SHADOWING DIRECTION: with a working child, the child-orchestrator parent must NOT be
+    // offered as a leaf itself. Before the fix an in_progress child was invisible, so the parent
+    // looked childless-and-workable and the wrong node got driven.
+    expect(picked.some((p) => p.sd_type === 'orchestrator')).toBe(false);
+  });
+
+  // The enumeration must stay an enumeration: an unknown status is NOT workable. This is the
+  // opposite safe direction from isTreeComplete on purpose — inverting here would drive an SD
+  // nobody classified. Asserted alongside the completion direction so the two cannot drift apart.
+  it('an unknown status is NOT workable and NOT complete — opposite safe directions, one scenario', () => {
+    const sds = nestedTree({ children: 1, grandkidsEach: 2 }).filter((s) => s.id !== 'orch-top');
+    sds.forEach((s) => { s.status = 'some_future_status_nobody_enumerated'; });
+
+    expect(computeWorkableLeaves(sds)).toHaveLength(0);
+    expect(isTreeComplete(sds)).toBe(false);
+  });
 });
 
 describe('TS-1 — nested-tree drive (keystone)', () => {


### PR DESCRIPTION
## The schism

`POST_HANDOFF_SD_STATE` listed PLAN-TO-EXEC and EXEC-TO-PLAN as `in_progress` while their setters write `active` (`plan-to-exec/state-transitions.js:133`, `fn_atomic_exec_to_plan_transition`). The drift branch fired on **every** one of those handoffs and overwrote the setter milliseconds later **in the same process** — so `active` stopped being written at all:

| month | `pre_active` writes |
|---|---|
| 2026-04 | 125 |
| 2026-05 | 5 |
| 2026-06 | 12 |
| 2026-07 | **0** |

The collapse lands exactly on reconciler commit `0af429eaf52`. (`post_state` is deliberately not cited — hardcoded literal, zero variance across 1756 rows.)

**Why it survived three months of review:** the comment claimed the table *"matches the DB writes in each executor."* It didn't, for exactly the two types writing `active`. The file certified its own correctness, so checking it meant reading the claim instead of the setters.

## Two things the SD got wrong, corrected here

**1. Its stated severity driver was already fixed.** "The venture completion check can no longer fail" is no longer true — QF-20260727-846 changed `isTreeComplete` to test TERMINAL membership. **Not rebuilt.**

**2. The live severity is the opposite failure direction, and it bites twice.** `in_progress` was in *neither* `NON_TERMINAL` nor `TERMINAL`. `legacyWorkableLeaves` reads `NON_TERMINAL` with **opposite senses in one function** — to *select* leaves, and to detect a working *descendant*. So an in-flight SD wasn't selected **and** its parent stopped counting it as working, surfacing the **parent** as a leaf in the child's place. The SD described only the first half.

## Enumeration, not inversion — stated in-source

QF-20260727-846's inversion is safe for **completion** (unknown = not complete; worst case a venture needs a nudge). The direction is **opposite** for **selection** — inverting would make an unknown status *workable* and drive an SD nobody classified. So the fix completes the enumeration and says why.

## Falsified, not assumed

Reverting `NON_TERMINAL` to `['draft','active']` makes the new selection test **fail** (1 failed / 37 passed). With the fix: **38/38 pass**. The test discriminates.

FR-3 pins cover `pending_approval` (PLAN-TO-LEAD's output), which the QF pins did not, and the unknown-status scenario asserts **both** predicates together so the two safe directions can't drift apart.

## Verification trap, for the next reader

`plan-to-exec/state-transitions.js` has an **earlier** status write at `:87` setting `in_progress`. A grep stopping at the first hit reads the file as *agreeing* with the table and concludes there's no bug. I hit that at LEAD; it's now documented in-source.

## Out of scope, flagged not fixed

`scripts/cron/leo-build-starter.mjs:39` declares its **own** `NON_TERMINAL = ['draft','active']`, used in a DB query filter at `:182` — a third copy of the same vocabulary, still blind to `in_progress`. Not in this PRD's scope; reported separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
