### PR TITLE
fix(SD-LEO-INFRA-COORDINATOR-REVIVE-NEVER-001): revive printed success into a queue that has never once delivered

### DIFF
--- a/scripts/coordinator-revive.cjs
+++ b/scripts/coordinator-revive.cjs
@@ -184,6 +184,10 @@ async function main() {
       }
     }
     console.log(`\nrevive-all: ${inserted} inserted, ${skipped} skipped (already pending), ${failed} failed`);
+    // FR-1/FR-2: revive-all is the path most likely to be run unattended, which is where
+    // the silence cost the most — 21 requests expired here without anyone noticing.
+    const allWarn = formatQueueWarning(await assessQueueHealth(supabase));
+    if (allWarn) console.log(allWarn);
     if (failed > 0) process.exit(2);
     return;
   }
@@ -196,17 +200,32 @@ async function main() {
   }
 
   const r = await reviveOne(supabase, callsign, requestedBySessionId);
+  // FR-1/FR-2: read the queue's history BEFORE reporting an outcome, so "requested"
+  // is never printed as if it meant "will be acted on".
+  const health = await assessQueueHealth(supabase);
   if (r.inserted) {
-    console.log(`✓ Revival requested for ${callsign}`);
+    console.log(`✓ Revival REQUESTED for ${callsign} (row written — not yet consumed)`);
     console.log(`  row_id: ${r.row.id}`);
     console.log(`  expires_at: ${r.row.expires_at}`);
     console.log(`  broadcast: SPAWN_REQUEST emitted on session_coordination`);
     console.log(`\nA spawn-execution layer (watchdog/notification/cron) should consume the row and start a fresh CC instance.`);
     console.log(`See docs/protocol/coordinator-worker-revival.md for the contract.`);
+    const warn = formatQueueWarning(health);
+    if (warn) console.log(warn);
   } else if (r.alreadyPending) {
-    console.log(`↺ ${callsign}: already has a pending revival request.`);
-    console.log(`  No new row inserted (idempotency rule: one pending per callsign).`);
+    // FR-3: idempotency behaviour is unchanged — only how it READS. On a queue that has
+    // never delivered, the blocking pending row is evidence of the dead consumer, not of
+    // a duplicate politely suppressed.
+    if (health && health.neverConsumed) {
+      console.log(`⚠ ${callsign}: BLOCKED by an unconsumed revival request — not a benign duplicate.`);
+      console.log(`  A previous request is still pending and nothing has consumed it.`);
+    } else {
+      console.log(`↺ ${callsign}: already has a pending revival request.`);
+      console.log(`  No new row inserted (idempotency rule: one pending per callsign).`);
+    }
     console.log(`  Run: SELECT id, requested_at, expires_at FROM worker_spawn_requests WHERE requested_callsign='${callsign}' AND status='pending';`);
+    const warn = formatQueueWarning(health);
+    if (warn) console.log(warn);
   } else {
     console.error(`✗ Failed to insert revival request: ${r.error?.message || 'unknown error'}`);
     process.exit(2);
@@ -214,7 +233,81 @@ async function main() {
 }
 
 // Export internal helpers for unit testing.
-module.exports = { NATO, findIdleCallsigns, reviveOne, insertSpawnRequest, isExpiredPendingRow, reapExpiredPendingRequests };
+/**
+ * SD-LEO-INFRA-COORDINATOR-REVIVE-NEVER-001 (FR-1, FR-2).
+ *
+ * Read the queue's own history so the CALLER can tell a live queue from a dead one.
+ * Everything here is DERIVED at call time (TR-3) — never hardcoded — so the warning
+ * switches OFF by itself the moment a request is actually fulfilled. A permanent
+ * warning would get ignored as noise and re-create the unobservable failure it exists
+ * to expose.
+ *
+ * Exact head counts, never an unbounded select (TR-1): PostgREST caps a plain .select()
+ * at 1000 rows, which would silently UNDER-REPORT the stuck population — the same
+ * blind-measurement class this SD is about.
+ *
+ * @returns {Promise<{total:number, pending:number, everFulfilled:number,
+ *                    oldestPendingAt:string|null, neverConsumed:boolean}|null>}
+ */
+async function assessQueueHealth(supabase) {
+  try {
+    const head = { count: 'exact', head: true };
+    const [{ count: total }, { count: pending }, { count: everFulfilled }] = await Promise.all([
+      supabase.from('worker_spawn_requests').select('*', head),
+      supabase.from('worker_spawn_requests').select('*', head).eq('status', 'pending'),
+      supabase.from('worker_spawn_requests').select('*', head).not('fulfilled_at', 'is', null),
+    ]);
+    const { data: oldest } = await supabase
+      .from('worker_spawn_requests')
+      .select('requested_at')
+      .eq('status', 'pending')
+      .order('requested_at', { ascending: true })
+      .limit(1);
+
+    return {
+      total: total ?? 0,
+      pending: pending ?? 0,
+      everFulfilled: everFulfilled ?? 0,
+      oldestPendingAt: oldest && oldest[0] ? oldest[0].requested_at : null,
+      // The whole signal: has this queue EVER delivered? Derived, not asserted.
+      neverConsumed: (total ?? 0) > 0 && (everFulfilled ?? 0) === 0,
+    };
+  } catch {
+    // Fail-soft: an unreadable queue must not break revive. Absent health is reported
+    // as absent, never as healthy — silence is not evidence of a live consumer.
+    return null;
+  }
+}
+
+/**
+ * Render the caller-facing warning. Returns '' when the queue has ever delivered, so a
+ * working consumer produces no noise (TS-2 pins this off-switch).
+ *
+ * Counts always ship WITH their denominator (FR-2): a bare "8 pending" is the
+ * count-truncation shape this codebase keeps rediscovering.
+ */
+function formatQueueWarning(health) {
+  if (!health) return '\n  [warn] queue health unreadable — cannot confirm a consumer exists.';
+  if (!health.neverConsumed) return '';
+  const ageDays = health.oldestPendingAt
+    ? ((Date.now() - new Date(health.oldestPendingAt).getTime()) / 86400000).toFixed(1)
+    : null;
+  const lines = [
+    '',
+    '  *** THIS REQUEST MAY NEVER BE CONSUMED ***',
+    `  worker_spawn_requests has NEVER fulfilled a request: 0 of ${health.total} rows have fulfilled_at set.`,
+    `  pending: ${health.pending} of ${health.total}` + (ageDays ? `, oldest waiting ${ageDays} days.` : '.'),
+    '  The row inserted above is real; whether anything reads it is NOT established by this command.',
+    '  WHY: scripts/fleet/worker-spawn-executor.cjs is OPERATOR-GATED (its header: "Stage 2, do NOT',
+    '  enable autonomously") and .github/workflows/fleet-rollcall-cron.yml deliberately does not wire',
+    '  it — the live spawn path needs a chairman to host-validate the claude CLI invocation and register',
+    '  a LOCAL Windows Task Scheduler entry; GHA cannot host it. Until that is done, this queue is a',
+    '  write-only surface and revive cannot recover anything.',
+  ];
+  return lines.join('\n');
+}
+
+module.exports = { NATO, findIdleCallsigns, reviveOne, insertSpawnRequest, isExpiredPendingRow, reapExpiredPendingRequests, assessQueueHealth, formatQueueWarning };
 
 // Only run main() when invoked as CLI (not when require'd by tests).
 if (require.main === module) {

--- a/tests/unit/coordinator-revive-queue-health.test.js
+++ b/tests/unit/coordinator-revive-queue-health.test.js
@@ -1,0 +1,61 @@
+// SD-LEO-INFRA-COORDINATOR-REVIVE-NEVER-001 — the caller must be able to tell a live
+// queue from a dead one.
+//
+// worker_spawn_requests has 29 rows and has NEVER fulfilled one (fulfilled_at IS NOT NULL
+// returns zero, lifetime). revive still printed "✓ Revival requested" and reported duplicates
+// as benign idempotency, so a write-only surface read as success and 8 requests accumulated
+// unnoticed. These tests pin the REPORTING, which is the defect — not the insert, which
+// worked correctly all 29 times.
+//
+// Pure: no DB, no network. assessQueueHealth is exercised against the live table separately;
+// what matters here is that the WARNING is derived from the counts and can switch off.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const { formatQueueWarning } = require_('../../scripts/coordinator-revive.cjs');
+
+const DEAD = { total: 29, pending: 8, everFulfilled: 0, oldestPendingAt: '2026-06-30T10:45:49.440001+00:00', neverConsumed: true };
+const ALIVE = { total: 29, pending: 8, everFulfilled: 1, oldestPendingAt: '2026-06-30T10:45:49.440001+00:00', neverConsumed: false };
+
+describe('coordinator-revive queue health reporting', () => {
+  // TS-1 — the deciding scenario. Without this, "requested" reads as "will happen".
+  it('warns that the request may never be consumed when nothing has ever been fulfilled', () => {
+    const w = formatQueueWarning(DEAD);
+    expect(w).toContain('MAY NEVER BE CONSUMED');
+    expect(w).toContain('0 of 29');
+  });
+
+  // TS-2 — THE OFF-SWITCH, and the reason this is a measurement rather than an assertion.
+  // A warning that cannot stop firing becomes noise, gets ignored, and re-creates the very
+  // unobservability it was added to fix. It must go silent the moment a consumer works.
+  it('goes completely silent once any request has been fulfilled', () => {
+    expect(formatQueueWarning(ALIVE)).toBe('');
+  });
+
+  // TS-3 — counts always carry their denominator. A bare "8 pending" is the count-truncation
+  // shape this codebase keeps rediscovering; "8 of 29" cannot be misread as the whole story.
+  it('reports pending WITH its denominator and the oldest wait', () => {
+    const w = formatQueueWarning(DEAD);
+    expect(w).toMatch(/pending: 8 of 29/);
+    expect(w).toMatch(/oldest waiting [\d.]+ days/);
+  });
+
+  // The operator gate lives in a DIFFERENT file's comment (fleet-rollcall-cron.yml), so a
+  // reader of revive could never discover why it never completes. Surface it at the point of use.
+  it('names the operator gate as the reason, where the caller will actually meet it', () => {
+    const w = formatQueueWarning(DEAD);
+    expect(w).toContain('OPERATOR-GATED');
+    expect(w).toContain('fleet-rollcall-cron.yml');
+  });
+
+  // Absent health must never read as healthy — silence is not evidence of a live consumer.
+  it('reports unreadable health as unreadable rather than as fine', () => {
+    expect(formatQueueWarning(null)).toContain('unreadable');
+  });
+
+  // An empty table is not a dead queue: nothing has been fulfilled because nothing was asked.
+  it('does not cry wolf on an empty queue', () => {
+    expect(formatQueueWarning({ total: 0, pending: 0, everFulfilled: 0, oldestPendingAt: null, neverConsumed: false })).toBe('');
+  });
+});


### PR DESCRIPTION
## The measurement

`worker_spawn_requests`, read live with exact head counts (not a `select` that caps at 1000):

| | |
|---|---|
| total | 29 |
| fulfilled | **0** |
| expired | 21 |
| pending | 8 |
| oldest pending | **33.3 days** |

`fulfilled_at IS NOT NULL` returns **zero across the entire table**. The documented fleet recovery path has never once completed.

## The defect is the reporting, not the insert

The insert worked correctly all 29 times. What was missing: `✓ Revival requested` told the caller nothing about whether anything would *read* the row, and on a duplicate `↺ already pending (idempotency rule)` read as politeness rather than as evidence a previous request was still sitting unconsumed.

**Success was indistinguishable from failure at the call site**, so 8 requests accumulated with nobody noticing — the same shape as the index-jam detector (QF-20260801-664) and the gha_cron liveness label (QF-20260801-527).

## Derived, never hardcoded — the part that matters

A warning that cannot switch off becomes noise, gets ignored, and re-creates the unobservability it was added to fix. `neverConsumed` is computed per call from `fulfilled_at`. **Verified both directions live:**

- real queue → warning fires with `0 of 29` and `33.3 days`
- one fulfilled row → warning is **exactly `""`**

That off-switch is the deciding test. Without it, this ships a constant wearing a measurement costume.

Counts always carry their denominator — `pending: 8 of 29`, never a bare `8`.

## The gate is named where the caller meets it

The reason the queue is never drained lives in **another file's comment**: `fleet-rollcall-cron.yml` records that `worker-spawn-executor.cjs` is deliberately unwired because its own header says *"OPERATOR GATE (Stage 2, do NOT enable autonomously)"* — the live spawn path needs a chairman to host-validate the `claude` CLI invocation and register a **local Windows Task Scheduler entry**; GHA cannot host it.

A precondition documented in an adjacent file is invisible to every reader and every detector. It's now stated in the warning itself.

## Deliberately not done

The executor is **not** wired, scheduled, or invoked. The tempting fix is the forbidden one — it's a chairman action outside any worker's reach. The single reference in this diff is prose inside the warning; **zero** require/exec/spawn call sites.

6/6 tests pass, pure — no DB, no network. Idempotency behaviour is byte-identical; only its label changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
