### PR TITLE
feat(SD-LEO-INFRA-ROLE-SESSIONS-FORCED-001): reconnect 639 stranded role learnings to /learn (FR-1..FR-3)

### DIFF
--- a/lib/learning/role-learning-promoter.js
+++ b/lib/learning/role-learning-promoter.js
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-ROLE-SESSIONS-FORCED-001 (FR-1..FR-3) — RECONNECT ROLE LEARNINGS TO /learn.
+ *
+ * WHY THIS EXISTS. Role sessions were believed to have no retrospective capture at all; the
+ * sourcing measured that by grepping role scripts for the word "retrospective" (adam-* 0,
+ * coordinator-* 0, solomon-* 1). That grep reproduces exactly — and it measured a TOKEN, not a
+ * CAPABILITY. The machinery is named self-review / self-adherence-review, and it is prolific:
+ * 639 rows across feedback.category IN (coordinator_review, coordinator_adam_review), median
+ * description 1,401 chars, 83% over 1,000 chars. Long-form prose, not telemetry.
+ *
+ * THE ACTUAL DEFECT IS PROMOTION, NOT CAPTURE. issue_patterns holds 1,662 rows and
+ * source='feedback_cluster' holds ZERO. The /learn noise filter (scripts/modules/learning/
+ * filter.mjs:77-84) admits only source IN ('retrospective','feedback_cluster'), so with that lane
+ * empty every admitted pattern is necessarily worker-originated — exactly why a live /learn run
+ * returned "Lessons: 5, every one carrying a Source SD id". The roles are not filtered out at the
+ * gate; THEY NEVER ARRIVE AT IT.
+ *
+ * WHY NOT ROUTE THROUGH lib/learning/feedback-clusterer.js — TWO INDEPENDENT BLOCKS, MEASURED:
+ *   (1) Its query filters .not('error_hash','is',null) (:56-62). ALL 639 role rows have
+ *       error_hash NULL. Control: 2,133 rows table-wide DO carry one, so the column is live and
+ *       the zero is specific to this lane.
+ *   (2) THRESHOLDS.MIN_OCCURRENCES=5 within 14 days — it promotes an error that RECURS five
+ *       times. Role learnings are unique one-off prose. They would never cluster.
+ * The clusterer is an ERROR-DEDUPLICATION instrument and this content is the opposite shape. It
+ * is NOT dead code (shebang, process.argv, isMainModule guard at :466 — it is CLI-executable);
+ * it is simply the wrong instrument.
+ *
+ * SHAPE COPIED FROM THE WORKING PRECEDENT, lib/eva/traversal-reflection-emitter.js:
+ *   - write DIRECTLY to issue_patterns with source='retrospective' (already admitted by the
+ *     filter, so filter.mjs is NOT modified — FR-2)
+ *   - distinguish origin via metadata.emission_type rather than a new source value. That is not
+ *     stylistic: issue_patterns_source_check is a CHECK enum on source, so a value like
+ *     'role_review' would FAIL THE WRITE OUTRIGHT (same class as system_settings.valid_setting_keys,
+ *     which refuted a store choice earlier in this same session)
+ *   - a quality floor that SKIPS the write, so promotion cannot pollute issue_patterns
+ *   - an explicit idempotency pre-check (FR-3) — but NOT on dedup_fingerprint, which the database
+ *     overwrites; see roleLearningDedupKey below for the measurement that forced that change
+ *
+ * ONE DELIBERATE DEPARTURE FROM THE PRECEDENT: it uses category='learning_reflection', which has
+ * ZERO live rows — an unproven value. This uses 'process' (297 live rows, proven accepted) and
+ * leans on metadata.emission_type for distinguishability, which is what the precedent's own header
+ * argues for anyway.
+ *
+ * WHAT THIS DOES NOT DO: it does not FORCE a role to capture anything. That is FR-4..FR-6 and a
+ * separate mechanism. Existing capture is opportunistic — it happens when a seat chooses to write
+ * a review — and a role that freezes mid-iteration contributes whatever it had already written.
+ * This module reconnects what is already being written; it does not make writing unavoidable.
+ */
+import { scoreLessonQuality } from '../eva/lesson-quality-guard.js';
+
+/** feedback.category values populated by the role self-review scripts. */
+export const ROLE_FEEDBACK_CATEGORIES = Object.freeze([
+  'coordinator_review', 'coordinator_adam_review', 'adam_adherence_drift', 'fleet_retro',
+]);
+
+/** Marks a promoted row's origin. The source column cannot carry this (CHECK enum). */
+export const EMISSION_TYPE = 'role_review';
+
+/** Proven-accepted category. See the header note on 'learning_reflection'. */
+export const ISSUE_PATTERNS_CATEGORY = 'process';
+
+const RECENT_LESSON_LOOKBACK = 5;
+
+/**
+ * IDEMPOTENCY KEY — metadata.source_feedback_id, NOT dedup_fingerprint.
+ *
+ * MEASURED THE HARD WAY: supplying dedup_fingerprint='role_review:<uuid>' and reading it back
+ * live returned '44352f420731cbcb659fc1008977d42b' — a computed 32-char hash. Something on the
+ * DB side (trigger/default) OVERWRITES whatever the client supplies, so a pre-check keyed on it
+ * matches NOTHING and every re-run would insert a duplicate. The unit-test double accepted the
+ * supplied value verbatim, so 18 green tests said the idempotency worked while it did not — the
+ * same permissive-mock failure that refuted a store choice earlier in this session.
+ *
+ * metadata.source_feedback_id survives the write intact (verified on the same live row), so the
+ * provenance field doubles as the dedup key. This module therefore does NOT supply
+ * dedup_fingerprint at all: writing a value the database silently replaces is a lie in the record.
+ */
+export function roleLearningDedupKey(row) {
+  return row && row.id ? String(row.id) : null;
+}
+
+/**
+ * Recent role-originated lessons, for the quality guard's repetition check.
+ * Fail-soft: on error the guard simply sees no history.
+ */
+async function fetchRecentRoleLessons(supabase, logger) {
+  try {
+    const { data, error } = await supabase.from('issue_patterns')
+      .select('issue_summary')
+      .eq('metadata->>emission_type', EMISSION_TYPE)
+      .order('created_at', { ascending: false })
+      .limit(RECENT_LESSON_LOOKBACK);
+    if (error) { logger.warn(`[RolePromoter] recent-lesson lookup failed: ${error.message}`); return []; }
+    return (data || []).map((r) => r.issue_summary).filter(Boolean);
+  } catch (e) {
+    logger.warn(`[RolePromoter] recent-lesson lookup threw: ${e.message}`);
+    return [];
+  }
+}
+
+/**
+ * Promote ONE role-originated feedback row into issue_patterns.
+ * Never throws — a promotion failure must never abort the caller's operating tick.
+ *
+ * @returns {Promise<{promoted:boolean, skipped?:string, patternId?:string, error?:string, reasons?:string[]}>}
+ */
+export async function promoteOne(supabase, row, deps = {}) {
+  const logger = deps.logger || console;
+  if (!supabase || !row || !row.id) return { promoted: false, skipped: 'missing supabase/row' };
+
+  const lessonText = String(row.description || '').trim();
+  if (!lessonText) return { promoted: false, skipped: 'empty_description' };
+
+  try {
+    const dedupKey = roleLearningDedupKey(row);
+
+    // IDEMPOTENCY BY EXPLICIT PRE-CHECK on a field the database PRESERVES (see roleLearningDedupKey).
+    // Fail CLOSED: an unreadable dedup state must not fall through into a duplicate insert.
+    const { data: existing, error: existErr } = await supabase.from('issue_patterns')
+      .select('pattern_id').eq('metadata->>source_feedback_id', dedupKey).limit(1);
+    if (existErr) return { promoted: false, error: `dedup check failed: ${existErr.message}` };
+    if (existing && existing.length) return { promoted: false, skipped: 'already_promoted' };
+
+    const recentLessons = deps.recentLessons || await fetchRecentRoleLessons(supabase, logger);
+    const { score, reasons } = scoreLessonQuality(lessonText, { recentLessons });
+    if (score === 0) {
+      // The precedent SKIPS rather than downgrades, precisely so promotion cannot inflate the
+      // pattern corpus with low-signal rows. 639 promoted unfiltered would grow a 1,662-row
+      // corpus by ~38%.
+      return { promoted: false, skipped: 'quality_floor', reasons };
+    }
+
+    const patternId = `PAT-ROLE-${fingerprintSuffix(row.id)}`;
+    const { error } = await supabase.from('issue_patterns').insert({
+      pattern_id: patternId,
+      category: ISSUE_PATTERNS_CATEGORY,
+      severity: row.severity === 'critical' || row.severity === 'high' ? 'medium' : 'low',
+      issue_summary: lessonText,
+      occurrence_count: 1,
+      status: 'active',
+      source: 'retrospective',
+      metadata: {
+        emission_type: EMISSION_TYPE,
+        source_feedback_id: row.id,          // FR-3 provenance: traceable to the originating row
+        source_feedback_category: row.category,
+        source_feedback_created_at: row.created_at,
+        promoted_at: new Date().toISOString(),
+      },
+    });
+    if (error) {
+      logger.warn(`[RolePromoter] insert failed for feedback ${row.id}: ${error.message}`);
+      return { promoted: false, error: error.message };
+    }
+    return { promoted: true, patternId };
+  } catch (err) {
+    logger.warn(`[RolePromoter] unexpected failure for feedback ${row.id}: ${err.message}`);
+    return { promoted: false, error: err.message };
+  }
+}
+
+function fingerprintSuffix(id) {
+  return String(id).replace(/-/g, '').slice(0, 12);
+}
+
+/**
+ * Promote a batch of role-originated feedback rows.
+ *
+ * NOTE ON STATUS: rows are NOT filtered by feedback.status. 308 of the 639 are already
+ * 'resolved', but that records the FEEDBACK ITEM being actioned — it says nothing about whether
+ * the LEARNING inside it is still valid. Filtering on it would discard half the corpus for a
+ * reason unrelated to learning value. The quality floor is the filter that matters.
+ *
+ * @returns {Promise<{scanned:number, promoted:number, skipped:object, errors:number}>}
+ */
+export async function promoteRoleLearnings(supabase, opts = {}) {
+  const { limit = 100, categories = ROLE_FEEDBACK_CATEGORIES, logger = console } = opts;
+  const summary = { scanned: 0, promoted: 0, skipped: {}, errors: 0 };
+  if (!supabase) return summary;
+
+  const { data, error } = await supabase.from('feedback')
+    .select('id, category, description, severity, created_at')
+    .in('category', categories)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+  if (error) { logger.warn(`[RolePromoter] feedback query failed: ${error.message}`); summary.errors += 1; return summary; }
+
+  const recentLessons = await fetchRecentRoleLessons(supabase, logger);
+  for (const row of data || []) {
+    summary.scanned += 1;
+    const r = await promoteOne(supabase, row, { logger, recentLessons });
+    if (r.promoted) summary.promoted += 1;
+    else if (r.error) summary.errors += 1;
+    else summary.skipped[r.skipped] = (summary.skipped[r.skipped] || 0) + 1;
+  }
+  return summary;
+}
+
+export default {
+  promoteOne, promoteRoleLearnings, roleLearningDedupKey,
+  ROLE_FEEDBACK_CATEGORIES, EMISSION_TYPE, ISSUE_PATTERNS_CATEGORY,
+};

--- a/lib/learning/role-learning-promoter.test.js
+++ b/lib/learning/role-learning-promoter.test.js
@@ -1,0 +1,229 @@
+/**
+ * SD-LEO-INFRA-ROLE-SESSIONS-FORCED-001 (FR-1..FR-3) — tests for the role-learning promoter.
+ *
+ * THE DOUBLE MODELS THE REAL TABLE AND CAN REFUSE. A permissive mock is what kept 27 tests and 4
+ * killed mutants green earlier in this same session while the designed store was rejecting every
+ * write on a CHECK constraint. So this one enforces the two constraints that actually bind here:
+ * source must be an admitted enum value, and a duplicate dedup_fingerprint must be visible to the
+ * pre-check. A double that cannot refuse cannot falsify.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  promoteOne, promoteRoleLearnings, roleLearningDedupKey,
+  ROLE_FEEDBACK_CATEGORIES, EMISSION_TYPE, ISSUE_PATTERNS_CATEGORY,
+} from './role-learning-promoter.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const io_read = (rel) => readFileSync(resolve(REPO_ROOT, rel), 'utf8');
+
+/** The real issue_patterns.source CHECK enum — a write outside it FAILS. */
+const ALLOWED_SOURCES = ['auto_rca', 'retrospective', 'narrative-knowledge-audit', 'manual', 'feedback_cluster'];
+
+function makeDb({ patterns = [], feedback = [], insertError = null, dedupError = null } = {}) {
+  const inserted = [];
+  return {
+    get inserted() { return inserted; },
+    from(table) {
+      if (table === 'issue_patterns') {
+        return {
+          select() {
+            return {
+              eq(col, val) {
+                // dedup pre-check: .select().eq('dedup_fingerprint', fp).limit(1)
+                if (col === 'metadata->>source_feedback_id') {
+                  const hit = [...patterns, ...inserted].filter((p) => p.metadata?.source_feedback_id === val);
+                  return { limit: async () => (dedupError ? { data: null, error: { message: dedupError } } : { data: hit, error: null }) };
+                }
+                // recent lessons: .select().eq('metadata->>emission_type', X).order().limit()
+                return { order: () => ({ limit: async () => ({ data: patterns.filter((p) => p.metadata?.emission_type === val), error: null }) }) };
+              },
+            };
+          },
+          insert: async (row) => {
+            if (insertError) return { error: { message: insertError } };
+            // ENFORCE THE REAL CONSTRAINT — this is the refusal a permissive mock would skip.
+            if (!ALLOWED_SOURCES.includes(row.source)) {
+              return { error: { message: `new row violates check constraint "issue_patterns_source_check" (source=${row.source})` } };
+            }
+            inserted.push(row);
+            return { error: null };
+          },
+        };
+      }
+      // feedback: .select().in().order().limit()
+      return { select: () => ({ in: () => ({ order: () => ({ limit: async () => ({ data: feedback, error: null }) }) }) }) };
+    },
+  };
+}
+
+const GOOD = {
+  id: 'fb-1', category: 'coordinator_review', severity: 'low', created_at: '2026-08-02T10:00:00Z',
+  description: 'DORMANCY REPORT: scripts/adam-quiet-tick.mjs kept heartbeating while last_tool_at went stale for 80 minutes, so the liveness watcher in periodic-liveness-watcher.mjs reported the seat healthy and never fired.',
+};
+
+describe('FR-1 promotion reaches the admitted lane', () => {
+  it('writes to issue_patterns with source=retrospective', async () => {
+    const db = makeDb();
+    const r = await promoteOne(db, GOOD);
+    expect(r.promoted).toBe(true);
+    expect(db.inserted).toHaveLength(1);
+    expect(db.inserted[0].source).toBe('retrospective');
+  });
+
+  it('uses an ADMITTED source value — an invented one would fail the CHECK enum', () => {
+    // The precedent's header documents issue_patterns_source_check explicitly. Pinned so a later
+    // edit to something descriptive-but-invalid (e.g. 'role_review') cannot ship silently.
+    expect(ALLOWED_SOURCES).toContain('retrospective');
+    expect(ALLOWED_SOURCES).not.toContain(EMISSION_TYPE);
+  });
+
+  it('distinguishes origin via metadata.emission_type, not via source', async () => {
+    const db = makeDb();
+    await promoteOne(db, GOOD);
+    expect(db.inserted[0].metadata.emission_type).toBe('role_review');
+  });
+
+  it('uses a category with proven live acceptance', () => {
+    // 'learning_reflection' (the precedent's choice) has ZERO live rows; 'process' has 297.
+    expect(ISSUE_PATTERNS_CATEGORY).toBe('process');
+  });
+
+  it('covers every role feedback category the self-review scripts write', () => {
+    expect(ROLE_FEEDBACK_CATEGORIES).toContain('coordinator_review');
+    expect(ROLE_FEEDBACK_CATEGORIES).toContain('coordinator_adam_review');
+    expect(ROLE_FEEDBACK_CATEGORIES).toContain('adam_adherence_drift');
+    expect(ROLE_FEEDBACK_CATEGORIES).toContain('fleet_retro');
+  });
+});
+
+describe('FR-2 the noise filter is NOT modified', () => {
+  it('filter.mjs still admits only retrospective + feedback_cluster, unchanged by this SD', () => {
+    const filter = readFileSync(resolve(REPO_ROOT, 'scripts/modules/learning/filter.mjs'), 'utf8');
+    expect(filter).toContain('LOW_SIGNAL_SOURCE');
+    // The fix delivers rows the EXISTING filter accepts; widening it would admit a 9,323-row
+    // auto_capture population and rebuild the noise the filter exists to remove.
+    expect(filter).not.toContain('role_review');
+  });
+});
+
+describe('FR-3 idempotency and provenance', () => {
+  it('a second promotion of the same row is skipped, not duplicated', async () => {
+    const db = makeDb();
+    const first = await promoteOne(db, GOOD);
+    const second = await promoteOne(db, GOOD);
+    expect(first.promoted).toBe(true);
+    expect(second.promoted).toBe(false);
+    expect(second.skipped).toBe('already_promoted');
+    expect(db.inserted).toHaveLength(1);
+  });
+
+  it('the dedup key is the SOURCE ROW id, on a field the DB preserves', () => {
+    // NOT dedup_fingerprint: supplying that and reading it back live returned a computed hash,
+    // so a pre-check keyed on it matched nothing and every re-run would have duplicated.
+    expect(roleLearningDedupKey({ id: 'fb-1' })).toBe('fb-1');
+    expect(roleLearningDedupKey({ id: 'fb-2' })).not.toBe(roleLearningDedupKey({ id: 'fb-1' }));
+    expect(roleLearningDedupKey(null)).toBeNull();
+  });
+
+  it('does NOT supply dedup_fingerprint — the DB overwrites it, so writing one would be a lie', () => {
+    const src = io_read('lib/learning/role-learning-promoter.js');
+    const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    expect(code).not.toMatch(/dedup_fingerprint\s*:/);
+  });
+
+  it('carries provenance back to the originating feedback row', async () => {
+    const db = makeDb();
+    await promoteOne(db, GOOD);
+    const md = db.inserted[0].metadata;
+    expect(md.source_feedback_id).toBe('fb-1');
+    expect(md.source_feedback_category).toBe('coordinator_review');
+    expect(md.source_feedback_created_at).toBe('2026-08-02T10:00:00Z');
+  });
+
+  it('a failed dedup check does NOT fall through to an insert', async () => {
+    // Fail-closed on the idempotency probe: an unreadable dedup state must not become a duplicate.
+    const db = makeDb({ dedupError: 'boom' });
+    const r = await promoteOne(db, GOOD);
+    expect(r.promoted).toBe(false);
+    expect(r.error).toMatch(/dedup check failed/);
+    expect(db.inserted).toHaveLength(0);
+  });
+});
+
+describe('THE QUALITY FLOOR — promotion must not pollute the corpus', () => {
+  it('skips a row with no concrete referent', async () => {
+    const db = makeDb();
+    const r = await promoteOne(db, { ...GOOD, description: 'Things went reasonably well today and the team made good progress on several fronts overall.' });
+    expect(r.promoted).toBe(false);
+    expect(r.skipped).toBe('quality_floor');
+    expect(db.inserted).toHaveLength(0);
+  });
+
+  it('skips a too-short row', async () => {
+    const db = makeDb();
+    const r = await promoteOne(db, { ...GOOD, description: 'ok' });
+    expect(r.promoted).toBe(false);
+    expect(db.inserted).toHaveLength(0);
+  });
+
+  it('skips an empty description without calling the store', async () => {
+    const db = makeDb();
+    const r = await promoteOne(db, { ...GOOD, description: '   ' });
+    expect(r.skipped).toBe('empty_description');
+    expect(db.inserted).toHaveLength(0);
+  });
+});
+
+describe('FAIL-SOFT — a promotion failure never aborts the caller', () => {
+  it('an insert error is returned, not thrown', async () => {
+    const db = makeDb({ insertError: 'connection reset' });
+    const r = await promoteOne(db, GOOD);
+    expect(r.promoted).toBe(false);
+    expect(r.error).toBe('connection reset');
+  });
+
+  it('a missing client is handled rather than throwing', async () => {
+    await expect(promoteOne(null, GOOD)).resolves.toMatchObject({ promoted: false });
+  });
+
+  it('batch promotion reports a summary and never throws', async () => {
+    const db = makeDb({ feedback: [GOOD, { ...GOOD, id: 'fb-2' }, { ...GOOD, id: 'fb-3', description: 'nope' }] });
+    const s = await promoteRoleLearnings(db, { logger: { warn() {}, log() {} } });
+    expect(s.scanned).toBe(3);
+    expect(s.promoted).toBe(2);
+    expect(s.skipped.quality_floor).toBe(1);
+  });
+});
+
+describe('NO RIVAL WRITER — the existing capture scripts are untouched', () => {
+  it('this SD does not modify the three role self-review scripts', () => {
+    // The whole point is that capture already works; adding a second writer alongside 639 existing
+    // rows is the drift this SD warns about elsewhere.
+    for (const f of ['scripts/coordinator-self-review.mjs', 'scripts/solomon-self-adherence-review.mjs', 'scripts/adam-self-adherence-review.mjs']) {
+      const src = readFileSync(resolve(REPO_ROOT, f), 'utf8');
+      expect(src).not.toContain('role-learning-promoter');
+    }
+  });
+
+  it('does not route through the feedback clusterer', async () => {
+    const src = readFileSync(resolve(REPO_ROOT, 'lib/learning/role-learning-promoter.js'), 'utf8');
+    // The clusterer filters .not(error_hash,is,null) and requires MIN_OCCURRENCES=5 recurrence —
+    // both structurally exclude unique one-off role prose.
+    //
+    // ASSERT ON CODE, NOT ON TEXT. The header documents WHY the clusterer is unusable and quotes
+    // its filter verbatim, so BOTH a substring check and a regex over the raw file match the
+    // module's own explanation. Two successive versions of this test failed that way. Strip
+    // comments first — the question is what the code DOES, and prose is not code.
+    const code = src
+      .replace(/\/\*[\s\S]*?\*\//g, '')   // block comments
+      .replace(/^\s*\/\/.*$/gm, '');      // line comments
+    expect(code).not.toMatch(/feedback-clusterer/);
+    expect(code).not.toMatch(/error_hash/);
+    expect(code).not.toMatch(/MIN_OCCURRENCES/);
+    // Control: the stripper must not have emptied the file, or these assertions prove nothing.
+    expect(code).toMatch(/export async function promoteOne/);
+  });
+});


### PR DESCRIPTION
## What this closes

The chairman asked for role sessions (Adam, Solomon, coordinator) to be force-gated on retrospectives the way workers are. **The SD's conclusion is right and every stated cause is wrong** — which matters, because building against the stated cause produces a fix that tests green and changes nothing.

## What the sourcing got wrong, re-measured 2026-08-02

**"Role sessions have NO retrospective capture machinery"** — refuted. All three role scripts contain `insert()` calls, and `feedback` holds **518 `coordinator_review` + 121 `coordinator_adam_review`** rows. The sourcing measured absence by grepping role scripts for the word *"retrospective"* (0/0/1). That grep reproduces exactly — I ran it — but the machinery is named `self-review` / `self-adherence-review`. **It measured a token, not a capability.**

**"Role sessions contribute NOTHING to /learn"** — true, for a different reason. `issue_patterns` holds 1,662 rows and `source='feedback_cluster'` holds **zero**. The noise filter admits only `retrospective` and `feedback_cluster`, so with that lane empty every admitted pattern is necessarily worker-originated. **The roles aren't filtered out at the gate; they never arrive at it.**

The stranded content is substantive — measured across all 639 rows, not sampled: median **1,401 chars**, p25 1,128, p75 1,894, **83% over 1,000 chars**, 3% under 200. Long-form prose. One row is a role self-diagnosis whose author was measured wedged at 319 minutes the same day.

## Why not the clusterer (which the PRD originally specified)

Two independent structural blocks:
- Its query filters `.not('error_hash','is',null)` — **all 639 role rows have `error_hash` NULL** (control: 2,133 rows table-wide *do* carry one).
- `MIN_OCCURRENCES=5` promotes an error that **recurs**; role learnings are unique one-off prose.

It's an error-deduplication instrument pointed at the opposite shape of data. It is **not** dead code — shebang, `process.argv`, `isMainModule` guard at `:466`. The zero-importer search suggesting otherwise is exactly what `pattern-detection-engine.js:312-319` warns about.

## Shape copied from an existing precedent

`lib/eva/traversal-reflection-emitter.js` already solved this: write directly to `issue_patterns` with `source='retrospective'` (so **`filter.mjs` is not modified**), distinguish origin via `metadata.emission_type`, skip on a quality floor. Its header also names `issue_patterns_source_check` — a CHECK enum on `source` — so an invented value like `'role_review'` would fail the write outright. That warning saved a defect.

## The defect only a live write could catch

I supplied `dedup_fingerprint='role_review:<uuid>'` for idempotency. The database returned `44352f420731cbcb659fc1008977d42b`. Something server-side overwrites that column, so the pre-check matched nothing and **every re-run would have inserted a duplicate — while 18 green unit tests asserted idempotency worked**, because the double accepted the supplied value verbatim.

Idempotency now keys on `metadata.source_feedback_id`, verified to survive the write. The module no longer supplies `dedup_fingerprint` at all: writing a value the database silently replaces is a lie in the record.

## Verification

| Check | Result |
|---|---|
| Unit tests | 19 passed |
| Mutation | **6/7 dead** — source enum, quality floor, idempotency, fail-closed dedup, provenance, origin marker |
| Live end-to-end | promotes once → second call `already_promoted` → exactly one row → `source=retrospective` / `category=process` / `emission_type=role_review` → corpus restored to 0 |
| Regression | 603 tests / 45 files green (`lib/learning`, `lib/eva`) |

**M7 survived and is left unkilled deliberately.** Converting the insert-error return into a `throw` kills no test because the insert sits inside the `try` and the outer `catch` returns the identical shape — an equivalent mutant, not a coverage gap. Writing a test to "kill" it would game the count rather than measure anything.

## Scope — read this before approving

This is **FR-1..FR-3 only**. It reconnects capture that already happens; it does **not** force a role to capture anything. That is FR-4..FR-6, split to a child SD at the boundary the PRD names, because this change is already 431 LOC against a 400 ceiling.

The design constraint for that child is recorded and load-bearing: **it must not be a session-end / Stop-hook gate.** Four seats were measured wedged mid-iteration today — one a role seat at 386 minutes — and a wedged session never reaches turn-end, so a terminal-boundary gate would pass its tests on clean exits and capture nothing from the observed death mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
