### PR TITLE
fix(SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001): a rung-level value stored on a per-wave row, and the tests that defended it

### DIFF
--- a/lib/chairman/daily-review/gantt-renderer.js
+++ b/lib/chairman/daily-review/gantt-renderer.js
@@ -31,22 +31,30 @@ function truncateTitle(title) {
 // QF-20260719-275 (Solomon correction 08bde2ed): roadmap_waves.progress_pct is one shared V1
 // rung gauge repeated across every wave, not a per-wave value — rendering bars from it made
 // W0-W2 show an identical 71% and W5 show 0% while 78/213 items were actually complete. Child
-// A's per-wave item_counts {total, promoted} are the real per-wave signal; fall back to
-// progress_pct only when item_counts is absent (older/malformed wave shape).
+// A's per-wave item_counts {total, promoted} are the real per-wave signal.
+//
+// SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001 (FR-2): that correction kept progress_pct as a
+// FALLBACK, and the fallback is what kept firing — three of seven approved waves took it,
+// drawing a 75% bar over ZERO items in the artifact delivered to the chairman on 2026-07-22.
+// A fallback to a rung-level value is not a degraded per-wave answer; it is a different
+// measurement wearing this one's units. There is no honest per-wave number for a wave with no
+// items, so return null and render no percentage at all — never a plausible one.
 function computeWavePct(wave) {
   const counts = wave.item_counts;
   if (counts && Number.isFinite(counts.total) && counts.total > 0) {
     const promoted = Number(counts.promoted) || 0;
     return Math.max(0, Math.min(100, Math.round((promoted / counts.total) * 100)));
   }
-  return Math.max(0, Math.min(100, Number(wave.progress_pct) || 0));
+  return null;
 }
 
 /**
  * Pure function: builds a well-formed SVG string for a Gantt-style bar chart, one row per
- * wave, bar width scaled by per-wave item_counts (falls back to progress_pct when absent). No
- * I/O, no external assets/fonts, no network call.
- * @param {Array<{wave_id?:string, title:string, status?:string, progress_pct?:number|null, item_counts?:{total:number,promoted:number}}>} waves
+ * wave, bar width scaled by per-wave item_counts. A wave with no items renders an empty track
+ * labelled "not yet scoped" — never a percentage. No I/O, no external assets/fonts, no network
+ * call. progress_pct is deliberately NOT in the accepted shape: it is a rung-level value and
+ * this renderer is per-wave (SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001).
+ * @param {Array<{wave_id?:string, title:string, status?:string, item_counts?:{total:number,promoted:number}}>} waves
  * @returns {string} SVG markup
  */
 export function buildGanttSvg(waves) {
@@ -55,14 +63,17 @@ export function buildGanttSvg(waves) {
 
   const bars = rows.map((wave, i) => {
     const y = TOP_MARGIN + i * ROW_HEIGHT;
+    // FR-2: a wave with no items has no per-wave percentage. Draw an empty track and say so,
+    // rather than a filled bar and an N% label that no measurement backs.
     const pct = computeWavePct(wave);
-    const barWidth = (pct / 100) * BAR_MAX_WIDTH;
+    const barWidth = pct == null ? 0 : (pct / 100) * BAR_MAX_WIDTH;
+    const pctLabel = pct == null ? 'not yet scoped' : `${pct}%`;
     const label = escapeXml(truncateTitle(wave.title || `Wave ${i + 1}`));
     return [
       `<text x="10" y="${y + 20}" font-family="sans-serif" font-size="14" fill="#222">${label}</text>`,
       `<rect x="${BAR_X}" y="${y + 8}" width="${BAR_MAX_WIDTH}" height="18" fill="#e0e0e0" />`,
       `<rect x="${BAR_X}" y="${y + 8}" width="${barWidth}" height="18" fill="#3b82f6" />`,
-      `<text x="${BAR_X + BAR_MAX_WIDTH + 8}" y="${y + 20}" font-family="sans-serif" font-size="12" fill="#555">${pct}%</text>`,
+      `<text x="${BAR_X + BAR_MAX_WIDTH + 8}" y="${y + 20}" font-family="sans-serif" font-size="12" fill="#555">${escapeXml(pctLabel)}</text>`,
     ].join('');
   }).join('');
 

--- a/lib/chairman/daily-review/roadmap-status-doc.js
+++ b/lib/chairman/daily-review/roadmap-status-doc.js
@@ -229,7 +229,7 @@ async function buildPlanOfRecordSection(supabase, { velocityLookbackDays }) {
 
     const { data: waves, error: wavesErr } = await supabase
       .from('roadmap_waves')
-      .select('id, title, sequence_rank, status, progress_pct, confidence_score')
+      .select('id, title, sequence_rank, status, confidence_score')
       .eq('roadmap_id', roadmap.id)
       .in('status', RATIFIED_WAVE_STATUSES)
       .order('sequence_rank', { ascending: true });
@@ -266,7 +266,6 @@ async function buildPlanOfRecordSection(supabase, { velocityLookbackDays }) {
       wave_id: w.id,
       title: w.title,
       status: w.status,
-      progress_pct: w.progress_pct,
       calibrated_probability: w.confidence_score,
       item_counts: countsByWave.get(w.id) || { total: 0, promoted: 0 },
     }));
@@ -292,9 +291,15 @@ async function buildPlanOfRecordSection(supabase, { velocityLookbackDays }) {
     lines.push(`  Roadmap: ${data.roadmap_title || data.roadmap_id}`);
     lines.push(`  Overall: ${data.overall_pct != null ? `${data.overall_pct}%` : 'n/a'}`);
     for (const w of data.waves) {
+      // SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001 (FR-2): the "progress N%" clause is REMOVED.
+      // It read roadmap_waves.progress_pct unconditionally — no item_counts preference, no
+      // fallback gate — so it printed a rung-level figure as this wave's progress and could
+      // contradict the item count in its own line. The delivered 2026-07-22 body read
+      // "0/0 items (probability 0%, progress 75%)". The item counts beside it are the honest
+      // per-wave signal and stay.
       lines.push(
         `  - ${w.title}: ${w.item_counts.promoted}/${w.item_counts.total} items ` +
-        `(probability ${formatProbability(w.calibrated_probability)}, progress ${w.progress_pct ?? 'n/a'}%)`
+        `(probability ${formatProbability(w.calibrated_probability)})`
       );
     }
     if (forecast.confidence === 'insufficient_data') {

--- a/lib/fleet/exec-email-rung-rollup.js
+++ b/lib/fleet/exec-email-rung-rollup.js
@@ -20,24 +20,42 @@ const RUNG_ORDER = ['V1', 'V2', 'V3'];
  * Aggregate runRollup rows into one progress % per rung. PURE.
  * A rung's % is the rounded mean of its waves' non-null progress_pct; null when no wave under that rung
  * is measurable (honest-null, never fabricated 0).
+ *
+ * SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001 (FR-3): THE MEAN IS USUALLY INERT, AND `measured` OVERSTATES
+ * WHAT WAS MEASURED. Every row under one rung normally carries the SAME value — runRollup assigns one
+ * computeBuildGauge to every wave of a build rung, and one KR aggregate to every wave of an outcome
+ * rung — so the mean of N identical numbers returns that number unchanged. `measured: 4` then reads as
+ * four independent measurements agreeing, when it is one measurement counted four times, which is the
+ * strongest-looking evidence shape there is and entirely spurious. `pct` is left exactly as it was
+ * (numerically identical either way); `distinct` is added so a reader can tell agreement from
+ * duplication. distinct === 1 with measured > 1 means ONE measurement, not a consensus.
+ *
+ * These rows come from runRollup(..., { apply: false }) IN MEMORY — this function never reads the
+ * stored roadmap_waves.progress_pct column, so it is unaffected by that column's retirement.
  * @param {Array<{rung_key:?string, progress_pct:?number}>} rows
- * @returns {Object<string, {pct:?number, waves:number, measured:number}>} keyed by rung_key
+ * @returns {Object<string, {pct:?number, waves:number, measured:number, distinct:number}>} keyed by rung_key
  */
 export function aggregateRungProgress(rows) {
   const byRung = {};
   for (const r of Array.isArray(rows) ? rows : []) {
     const key = r && r.rung_key;
     if (!key) continue; // unmappable waves are excluded, not zero-counted
-    const slot = byRung[key] || (byRung[key] = { sum: 0, measured: 0, waves: 0 });
+    const slot = byRung[key] || (byRung[key] = { sum: 0, measured: 0, waves: 0, values: new Set() });
     slot.waves += 1;
     if (typeof r.progress_pct === 'number' && Number.isFinite(r.progress_pct)) {
       slot.sum += r.progress_pct;
       slot.measured += 1;
+      slot.values.add(r.progress_pct);
     }
   }
   const out = {};
   for (const [key, s] of Object.entries(byRung)) {
-    out[key] = { pct: s.measured > 0 ? Math.round(s.sum / s.measured) : null, waves: s.waves, measured: s.measured };
+    out[key] = {
+      pct: s.measured > 0 ? Math.round(s.sum / s.measured) : null,
+      waves: s.waves,
+      measured: s.measured,
+      distinct: s.values.size,
+    };
   }
   return out;
 }

--- a/lib/integrations/baseline-manager.js
+++ b/lib/integrations/baseline-manager.js
@@ -31,7 +31,7 @@ export async function createBaseline(supabase, roadmapId, options = {}) {
   // Fetch all waves with items
   const { data: waves, error: wErr } = await supabase
     .from('roadmap_waves')
-    .select('id, sequence_rank, title, description, status, confidence_score, progress_pct')
+    .select('id, sequence_rank, title, description, status, confidence_score')
     .eq('roadmap_id', roadmapId)
     .order('sequence_rank', { ascending: true });
 
@@ -56,8 +56,12 @@ export async function createBaseline(supabase, roadmapId, options = {}) {
       title: wave.title,
       description: wave.description,
       status: wave.status,
+      // SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001 (FR-4): progress_pct is NOT snapshotted. It is a
+      // rung-level value stored on a wave row, so persisting it froze one shared figure into a
+      // durable governance artifact as though it were per-wave. roadmap-manager.js:160 writes the
+      // same roadmap_baseline_snapshots.wave_sequence artifact and never carried this field, so
+      // removing it aligns the two writers rather than dropping information the baseline needs.
       confidence_score: wave.confidence_score,
-      progress_pct: wave.progress_pct,
       items: items || [],
     });
   }

--- a/lib/roadmap/plan-check-status.js
+++ b/lib/roadmap/plan-check-status.js
@@ -131,7 +131,10 @@ export async function computePlanCheckStatus(supabase, { windowHours = 48 } = {}
 
   const [wavesRes, forwardListRes] = await Promise.all([
     supabase.from('roadmap_waves')
-      .select('id, title, sequence_rank, status, progress_pct')
+      // SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001 (FR-4): progress_pct dropped from the select. It
+      // was fetched and never read — a dead fetch, and a loaded gun for the next reader of this
+      // query, in the very surface the SD records as having misreported wave bookkeeping.
+      .select('id, title, sequence_rank, status')
       .eq('roadmap_id', canonicalRoadmap.id)
       .in('status', RATIFIED_WAVE_STATUSES)
       .order('sequence_rank', { ascending: true }),

--- a/lib/vision/rung-progress-rollup.mjs
+++ b/lib/vision/rung-progress-rollup.mjs
@@ -102,7 +102,10 @@ export function rollupWaves(waves, ctx = {}) {
 
 /**
  * IO runner. FAIL-SOFT: a read error degrades to an empty/unknown result rather than throwing.
- * DRY-RUN by default; pass { apply:true } to persist progress_pct (only for rows with a non-null %).
+ * READ-ONLY. This function no longer persists anything (SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001
+ * FR-1): its values are rung-level and roadmap_waves is keyed by wave, so writing them fanned one
+ * measurement across many rows. `apply` is retained in the signature and the log for callers, but
+ * `written` is now always 0. Consumers read `rows` from the returned object.
  *
  * @param {object} opts
  *   supabase       - REQUIRED supabase client
@@ -169,7 +172,7 @@ export async function runRollup(opts = {}) {
       try {
         const w = await supabase
           .from('roadmap_waves')
-          .select('id,title,time_horizon,okr_objective_ids,metadata,progress_pct')
+          .select('id,title,time_horizon,okr_objective_ids,metadata')
           .eq('roadmap_id', roadmapScope.id);
         if (w && !w.error && Array.isArray(w.data)) waves = w.data;
       } catch { waves = []; }
@@ -177,16 +180,24 @@ export async function runRollup(opts = {}) {
 
     const rows = rollupWaves(waves, { activeRungKey, gaugeBuildPct, krAggByObjective });
 
-    let written = 0;
-    if (apply) {
-      for (const row of rows) {
-        if (row.progress_pct == null) continue; // never write a fabricated 0
-        try {
-          const u = await supabase.from('roadmap_waves').update({ progress_pct: row.progress_pct }).eq('id', row.wave_id);
-          if (!u || !u.error) written += 1;
-        } catch { /* fail-soft per-row; keep going */ }
-      }
-    }
+    // SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001 (FR-1): THE WRITE-BACK IS REMOVED.
+    //
+    // Every value this function produces is RUNG-level. A build rung reuses one computeBuildGauge
+    // for all its waves (:83, reason "reuse build gauge"); an outcome rung reuses one per-objective
+    // KR aggregate. roadmap_waves is keyed by WAVE, so persisting either one fanned a single
+    // measurement across many rows: 23 waves held just three distinct values ({0 x17, 20 x2,
+    // 71 x4}) and the six non-zero ones carried the same-second updated_at from one pass. Wave 1B
+    // stored 71 while its items were 17/17 complete.
+    //
+    // The honest-null rule above ("never write a fabricated 0") was the right instinct applied one
+    // level too shallow: a rung figure is not a per-wave value that happens to be imprecise, it is
+    // a different measurement, so there is no threshold at which writing it to a wave row is
+    // truthful. Nothing replaces it because nothing needed it — the two live consumers of this
+    // rollup (the exec email via formatRungRollupLine, and needle-priority) both read `rows` from
+    // the returned object IN MEMORY and never the stored column.
+    //
+    // `written` stays in the return shape, always 0, so existing callers and logs keep working.
+    const written = 0;
 
     log(`[rung-rollup] ${apply ? 'APPLY' : 'DRY-RUN'} activeRung=${activeRungKey} gaugeBuildPct=${gaugeBuildPct} roadmapScope=${roadmapScope ? roadmapScope.id : (scopeNote || 'none')} waves=${rows.length} writable=${rows.filter((r) => r.progress_pct != null).length} written=${written}`);
     return { ok: true, apply, activeRungKey, gaugeBuildPct, rows, written, roadmapScope: roadmapScope ? roadmapScope.id : null, scopeNote };

--- a/scripts/cron/chairman-morning-review-sweep.mjs
+++ b/scripts/cron/chairman-morning-review-sweep.mjs
@@ -130,13 +130,22 @@ export async function gatherWaves(supabase) {
   }
   if (!rm) return { state: 'none', waveCount: 0, doneWaves: 0, avgPct: null };
   try {
-    const { data: waves, error } = await supabase.from('roadmap_waves').select('status, progress_pct').eq('roadmap_id', rm.id);
+    // SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001 (FR-2): progress_pct is no longer read here.
+    //
+    // This was the THIRD chairman-facing consumer and the least honest of them. progress_pct is a
+    // RUNG-level value stored on a per-wave row, so `avgPct` averaged copies of one measurement —
+    // and `Number(w.progress_pct || 0)` coerced NULL to 0, which is precisely the fabrication the
+    // rollup's own contract forbids ("never fabricated as 0%"). An unmeasured wave therefore
+    // dragged the chairman's headline build % downward as though it had been measured at zero.
+    //
+    // doneWaves now keys on the wave's own status, which is a genuine per-wave fact. No average is
+    // computed: there is no honest roadmap-level percentage to derive from a rung-level column.
+    const { data: waves, error } = await supabase.from('roadmap_waves').select('status').eq('roadmap_id', rm.id);
     if (error) throw new Error(error.message);
     const ws = waves || [];
     const waveCount = ws.length;
-    const doneWaves = ws.filter((w) => Number(w.progress_pct || 0) >= 100 || w.status === 'completed').length;
-    const avgPct = waveCount ? Math.round(ws.reduce((s, w) => s + Number(w.progress_pct || 0), 0) / waveCount) : null;
-    return { state: 'resolved', roadmapId: rm.id, waveCount, doneWaves, avgPct };
+    const doneWaves = ws.filter((w) => w.status === 'completed').length;
+    return { state: 'resolved', roadmapId: rm.id, waveCount, doneWaves, avgPct: null };
   } catch {
     return { state: 'unavailable', waveCount: 0, doneWaves: 0, avgPct: null };
   }
@@ -151,8 +160,12 @@ export async function gatherWaves(supabase) {
 export function formatRoadmapLine(waves) {
   switch (waves?.state) {
     case 'resolved':
+      // FR-2 (SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001): the "N% build" clause is gone with the
+      // column it came from. Rendering '?%' instead would keep asserting that a roadmap-level
+      // percentage exists and is merely unavailable; it does not exist. The wave counts beside it
+      // are real, and the four states stay pairwise distinct without it.
       return waves.waveCount
-        ? `Roadmap: ${waves.avgPct == null ? '?' : waves.avgPct}% build, waves ${waves.doneWaves}/${waves.waveCount} done`
+        ? `Roadmap: waves ${waves.doneWaves}/${waves.waveCount} done`
         : 'Roadmap: active roadmap has no waves yet';
     case 'ambiguous':
       return `Roadmap: AMBIGUOUS — ${waves.activeCount ?? 'multiple'} active roadmaps, numbers withheld until resolved`;

--- a/scripts/roadmap-status.js
+++ b/scripts/roadmap-status.js
@@ -47,7 +47,7 @@ async function main() {
     // Fetch waves
     const { data: waves, error: wErr } = await supabase
       .from('roadmap_waves')
-      .select('id, sequence_rank, title, status, progress_pct, confidence_score')
+      .select('id, sequence_rank, title, status, confidence_score')
       .eq('roadmap_id', rm.id)
       .order('sequence_rank', { ascending: true });
 
@@ -86,12 +86,15 @@ async function main() {
       }
       const dispStr = Object.entries(dispositions).map(([k, v]) => `${k}:${v}`).join(' ');
 
+      // SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001 (FR-4): the per-wave "Progress: N%" is removed.
+      // It printed roadmap_waves.progress_pct — a RUNG-level value shared across every wave of a
+      // rung — as this wave's progress, with null coerced to 0. The Items/Promoted line printed
+      // immediately below is the honest per-wave signal and is unchanged.
       const statusLabel = WAVE_STATUS_LABELS[wave.status] || wave.status;
-      const progress = Number(wave.progress_pct || 0).toFixed(0);
       const conf = Number(wave.confidence_score || 0).toFixed(2);
 
       console.log(`    [${wave.sequence_rank}] ${wave.title}`);
-      console.log(`        Status: ${statusLabel} | Progress: ${progress}% | Confidence: ${conf}`);
+      console.log(`        Status: ${statusLabel} | Confidence: ${conf}`);
       console.log(`        Items: ${count || 0} | Promoted: ${promoted.count || 0}${dispStr ? ' | ' + dispStr : ''}`);
     }
   }

--- a/tests/test-estate-mjs-allowlist.json
+++ b/tests/test-estate-mjs-allowlist.json
@@ -25,7 +25,6 @@
       "tests/unit/sd-key-generator-coverage.test.mjs",
       "tests/unit/session-tick-patch-failure-telemetry.test.mjs",
       "tests/unit/v-sd-next-candidates-fixture-exclusion.test.mjs",
-      "tests/unit/vision/rung-progress-rollup.test.mjs",
       "tests/unit/worktree-stale-base-guard.test.mjs"
     ]
   }

--- a/tests/unit/chairman/daily-review-gantt-renderer.test.js
+++ b/tests/unit/chairman/daily-review-gantt-renderer.test.js
@@ -13,13 +13,20 @@ const waves = [
 ];
 
 describe('buildGanttSvg (FR-1)', () => {
-  it('returns well-formed SVG containing each wave title (falls back to progress_pct when item_counts absent)', () => {
+  // SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001 (FR-2): this test previously ASSERTED the fallback —
+  // it required '71%' and '20%' to appear for waves that carry no item_counts. QF-20260719-275
+  // removed the fallback from the primary path but left it as a fallback AND pinned it here, so
+  // the surviving half of the defect was defended by the suite: anyone deleting it was told they
+  // had broken something. The rung-level values it asserts (71, 20) are the very numbers the live
+  // table still holds across four and two waves respectively. Now inverted.
+  it('renders each wave title and emits NO percentage when item_counts is absent', () => {
     const svg = buildGanttSvg(waves);
     expect(svg.startsWith('<svg')).toBe(true);
     expect(svg).toContain('Wave 1: Foundation');
     expect(svg).toContain('Wave 2: Revenue rails');
-    expect(svg).toContain('71%');
-    expect(svg).toContain('20%');
+    expect(svg).not.toContain('71%');
+    expect(svg).not.toContain('20%');
+    expect(svg).toContain('not yet scoped');
   });
 
   it('handles an empty waves array without throwing', () => {
@@ -48,9 +55,15 @@ describe('buildGanttSvg (FR-1)', () => {
     expect(svg).not.toContain('>0%<');
   });
 
-  it('treats item_counts.total === 0 as no signal and falls back to progress_pct', () => {
+  // THE REGRESSION FIXTURE, in miniature. The artifact delivered to the chairman on 2026-07-22
+  // (chairman-daily-review/2026-07-22.png) drew a 75% filled bar over a wave with ZERO items,
+  // because total === 0 fell back to the rung value. A zero-item wave has no per-wave progress:
+  // the honest render is an empty track, not a plausible number.
+  it('emits NO percentage for a wave with zero items — not a fallback, no number at all', () => {
     const svg = buildGanttSvg([{ title: 'Empty wave', progress_pct: 45, item_counts: { total: 0, promoted: 0 } }]);
-    expect(svg).toContain('45%');
+    expect(svg).not.toContain('45%');
+    expect(svg).not.toMatch(/>\d+%</);
+    expect(svg).toContain('not yet scoped');
   });
 
   // QF-20260719-275: long titles overflowed under the bar area into the right-edge pct labels.

--- a/tests/unit/chairman/daily-review-roadmap-status-doc.test.js
+++ b/tests/unit/chairman/daily-review-roadmap-status-doc.test.js
@@ -156,9 +156,12 @@ describe('buildRoadmapStatusDoc — plan_of_record section', () => {
     expect(por.data.waves[0]).toMatchObject({
       wave_id: 'w1',
       calibrated_probability: 0.8,
-      progress_pct: 50,
       item_counts: { total: 2, promoted: 1 },
     });
+    // SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001 (FR-2): progress_pct is no longer carried into the
+    // wave summary at all. toMatchObject ignores extra keys, so asserting its ABSENCE explicitly
+    // is what keeps this test able to fail if the field is reintroduced.
+    expect(por.data.waves[0]).not.toHaveProperty('progress_pct');
     expect(por.data.overall_pct).toBeCloseTo(33.3, 1); // 1 promoted of 3 total
   });
 

--- a/tests/unit/fleet/exec-email-rung-rollup.test.js
+++ b/tests/unit/fleet/exec-email-rung-rollup.test.js
@@ -13,9 +13,27 @@ describe('aggregateRungProgress', () => {
       { rung_key: 'V2', progress_pct: null },
       { rung_key: null, progress_pct: 50 }, // unmappable -> excluded
     ]);
-    expect(agg.V1).toEqual({ pct: 88, waves: 2, measured: 2 }); // (80+96)/2
-    expect(agg.V2).toEqual({ pct: null, waves: 1, measured: 0 }); // honest-null, never 0
+    expect(agg.V1).toEqual({ pct: 88, waves: 2, measured: 2, distinct: 2 }); // (80+96)/2
+    expect(agg.V2).toEqual({ pct: null, waves: 1, measured: 0, distinct: 0 }); // honest-null, never 0
     expect(agg.null).toBeUndefined();
+  });
+
+  // SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001 (FR-3): distinct === 1 with measured > 1 is the LIVE
+  // shape, not a curiosity — runRollup gives every wave of a build rung the same computeBuildGauge,
+  // which is why the real table held one value across four waves. Without `distinct`, `measured: 4`
+  // reads as four independent measurements agreeing: the most persuasive evidence shape there is,
+  // and entirely spurious. The mean of identical copies also returns the copy, so `pct` cannot
+  // reveal the duplication either.
+  it('distinguishes agreement from duplication when a rung shares one measurement', () => {
+    const agg = aggregateRungProgress([
+      { rung_key: 'V1', progress_pct: 71 },
+      { rung_key: 'V1', progress_pct: 71 },
+      { rung_key: 'V1', progress_pct: 71 },
+      { rung_key: 'V1', progress_pct: 71 },
+    ]);
+    expect(agg.V1.pct).toBe(71);
+    expect(agg.V1.measured).toBe(4);
+    expect(agg.V1.distinct).toBe(1); // ONE measurement counted four times
   });
 
   it('handles empty / non-array input', () => {

--- a/tests/unit/roadmap-waves-progress-census.test.js
+++ b/tests/unit/roadmap-waves-progress-census.test.js
@@ -1,0 +1,80 @@
+// SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001 — the field must stay unreadable, not merely be unread today.
+//
+// roadmap_waves.progress_pct is a RUNG-level value stored on a PER-WAVE row: rung-progress-rollup
+// assigned one computeBuildGauge to every wave of a build rung, so 23 waves held three distinct
+// values ({0 x17, 20 x2, 71 x4}) and the six non-zero ones were stamped in a single pass. Consumers
+// then read it as per-wave — correctly, as the column name promises, and wrongly, as the data means.
+//
+// THIS WAS CORRECTED ONCE BEFORE AND CAME BACK. QF-20260719-275 fixed one caller and left the field
+// standing; ten days later new consumers were reading it again. The SD is explicit that an acceptance
+// test which passes while the field is still readable HAS NOT closed this — so these assertions are
+// about what a FUTURE reader can do, not about today's callers being clean.
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const REPO = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..');
+const SCAN_DIRS = ['lib', 'scripts'];
+const CODE_RE = /\.(js|mjs|cjs)$/;
+const SKIP_RE = /(^|[\\/])(node_modules|\.git|dist|build|coverage)([\\/]|$)/;
+
+// The ONE legitimate mention: the rollup computes rung-level values into in-memory rows whose field
+// happens to be named progress_pct. It is the derivation path the SD acceptance carves out — but it
+// must not touch the STORED column, which the read/write assertions below enforce independently.
+const DERIVATION_PATH = 'lib/vision/rung-progress-rollup.mjs';
+
+function walk(dir, out = []) {
+  let entries;
+  try { entries = readdirSync(dir); } catch { return out; }
+  for (const e of entries) {
+    const p = join(dir, e);
+    if (SKIP_RE.test(p)) continue;
+    let st;
+    try { st = statSync(p); } catch { continue; }
+    if (st.isDirectory()) walk(p, out);
+    else if (CODE_RE.test(p)) out.push(p);
+  }
+  return out;
+}
+
+const FILES = SCAN_DIRS.flatMap((d) => walk(join(REPO, d))).map((p) => ({
+  rel: relative(REPO, p).replace(/\\/g, '/'),
+  src: (() => { try { return readFileSync(p, 'utf8'); } catch { return ''; } })(),
+}));
+
+/** Files that query roadmap_waves AND name `field` inside a .select(...) string. */
+function selectsFieldFromWaves(field) {
+  const re = new RegExp(`\\.select\\(\\s*['"\`][^'"\`]*\\b${field}\\b[^'"\`]*['"\`]`);
+  return FILES.filter((f) => f.src.includes("from('roadmap_waves')") && re.test(f.src)).map((f) => f.rel);
+}
+
+describe('roadmap_waves.progress_pct is not readable as a per-wave measure', () => {
+  // THE SCAN IS ONLY MEANINGFUL IF IT CAN FIND THINGS. A zero result from a broken or mis-scoped
+  // walker is indistinguishable from a clean tree, so prove the instrument works on the same
+  // predicate, over the same files, before trusting any zero it reports.
+  it('CONTROL: the scanner finds files and finds OTHER roadmap_waves fields being selected', () => {
+    expect(FILES.length).toBeGreaterThan(500);
+    const wavesReaders = FILES.filter((f) => f.src.includes("from('roadmap_waves')"));
+    expect(wavesReaders.length).toBeGreaterThan(3);
+    // The identical predicate, a different column — if this is empty the detector is broken.
+    expect(selectsFieldFromWaves('sequence_rank').length).toBeGreaterThan(0);
+  });
+
+  // Acceptance (i). This is the assertion that outlives the current callers.
+  it('no file SELECTs progress_pct from roadmap_waves', () => {
+    expect(selectsFieldFromWaves('progress_pct')).toEqual([]);
+  });
+
+  it('no file WRITES progress_pct back to roadmap_waves', () => {
+    const writers = FILES.filter((f) => /update\(\s*\{\s*progress_pct/.test(f.src)).map((f) => f.rel);
+    expect(writers).toEqual([]);
+  });
+
+  it('even the derivation path does not touch the stored column', () => {
+    const f = FILES.find((x) => x.rel === DERIVATION_PATH);
+    expect(f, `${DERIVATION_PATH} must exist — if it moved, this whole file is scanning nothing`).toBeTruthy();
+    expect(/\.select\(\s*['"`][^'"`]*progress_pct/.test(f.src)).toBe(false);
+    expect(/update\(\s*\{\s*progress_pct/.test(f.src)).toBe(false);
+  });
+});

--- a/tests/unit/roadmap/canonical-scoping.test.js
+++ b/tests/unit/roadmap/canonical-scoping.test.js
@@ -118,13 +118,30 @@ describe('FR-2 / TS-2, TS-3, TS-11: the four states are PAIRWISE DISTINCT', () =
   });
 });
 
-describe('TS-11: avgPct is asserted, not just waveCount', () => {
-  it('averages progress across the ACTIVE roadmap only', async () => {
-    // 3 waves at 100 + 5 at 50 = 550/8 = 68.75 -> 69. Under the pre-fix reader this would be
-    // the archived roadmap's 0, so the number itself discriminates.
+describe('TS-11: the counts discriminate the ACTIVE roadmap, not just waveCount', () => {
+  // This test asserted avgPct === 69 (3 waves at 100 + 5 at 50 = 550/8) BECAUSE the number
+  // discriminated: the pre-fix unscoped reader would have returned the archived roadmap's 0.
+  //
+  // SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001 (FR-2) removed avgPct — it averaged a RUNG-level
+  // progress_pct across waves and coerced NULL to 0, so an unmeasured wave counted as measured-
+  // at-zero in the chairman's headline. The SCOPING PROPERTY this test exists to prove is
+  // untouched by that, and must not be lost with the vehicle that carried it.
+  //
+  // The fixture still discriminates, now on two independent signals rather than one: the active
+  // roadmap has 8 waves of which 3 are completed; the archived-newest roadmap that a broken
+  // `order(created_at).limit(1)` reader would select has 4 waves and none completed. Reading the
+  // wrong roadmap therefore fails BOTH assertions, not merely one.
+  it('counts waves from the ACTIVE roadmap only', async () => {
     const r = await gatherWaves(makeDb());
-    expect(r.avgPct).toBe(69);
-    expect(r.doneWaves).toBe(3);
+    expect(r.waveCount).toBe(8); // archived-newest would give 4
+    expect(r.doneWaves).toBe(3); // archived-newest would give 0
+  });
+
+  // The removed field must stay removed: null here is the fix holding, not a missing value.
+  it('reports no roadmap-level average, because none can be honestly derived', async () => {
+    const r = await gatherWaves(makeDb());
+    expect(r.avgPct).toBeNull();
+    expect(formatRoadmapLine(r)).not.toMatch(/%/);
   });
 });
 

--- a/tests/unit/vision/rung-progress-rollup.test.js
+++ b/tests/unit/vision/rung-progress-rollup.test.js
@@ -1,6 +1,15 @@
 // Tests for lib/vision/rung-progress-rollup.mjs
 // SD-LEO-INFRA-PROGRESS-ROLLUP-NEEDLE-PRIORITIZATION-001-B (FR-1)
-import { test } from 'node:test';
+//
+// SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001: THESE 17 TESTS HAD NEVER RUN. The file was named
+// `.test.mjs` and used node:test, but the vitest unit project includes `**/*.test.js` plus
+// `.test.mjs` ONLY under tests/unit/org/ and tests/unit/venture-email/ — so this path matched
+// nothing and the runner silently skipped it. Two of its assertions had ALREADY been broken by
+// SD-LEO-INFRA-ROADMAP-REGENERATION-DUPLICATES-001 FR-8, which added canonical-roadmap scoping to
+// runRollup without teaching this stub about strategic_roadmaps; res.rows came back empty and
+// nobody heard. Switched to the vitest runner (assert still works) and renamed to .test.js so the
+// module at the centre of this SD is actually covered.
+import { test } from 'vitest';
 import assert from 'node:assert/strict';
 import {
   RUNG_BY_HORIZON,
@@ -108,19 +117,33 @@ test('rollupWaves maps all waves', () => {
 });
 
 // ── runRollup IO with an injected supabase stub ──
-function stubSupabase({ activeRung = { rung_key: 'V1' }, krs = [], waves = [], captureUpdates } = {}) {
+// The `roadmaps` default models ONE active canonical roadmap. Without it resolveCanonicalRoadmap
+// (added by REGENERATION-DUPLICATES FR-8) resolves nothing, runRollup fails closed to zero waves,
+// and every row assertion below fails on an empty array — which is exactly what was happening,
+// unobserved, for as long as this file has been unrunnable.
+function stubSupabase({ activeRung = { rung_key: 'V1' }, krs = [], waves = [], captureUpdates,
+  roadmaps = [{ id: 'rm-1', status: 'active', created_at: '2026-01-01T00:00:00Z' }] } = {}) {
   return {
     from(table) {
       const chain = {
         _table: table, _filters: {},
         select() { return chain; },
         eq(col, val) { chain._filters[col] = val; return chain; },
+        in() { return chain; },
+        order() { return chain; },
+        limit() { return chain; },
         maybeSingle() {
           if (table === 'vision_ladder_rungs') return Promise.resolve({ data: activeRung, error: null });
+          if (table === 'strategic_roadmaps') return Promise.resolve({ data: roadmaps[0] || null, error: null });
+          return Promise.resolve({ data: null, error: null });
+        },
+        single() {
+          if (table === 'strategic_roadmaps') return Promise.resolve({ data: roadmaps[0] || null, error: null });
           return Promise.resolve({ data: null, error: null });
         },
         update(payload) { chain._payload = payload; return chain; },
         then(res, rej) {
+          if (table === 'strategic_roadmaps') return Promise.resolve({ data: roadmaps, error: null }).then(res, rej);
           if (table === 'key_results') return Promise.resolve({ data: krs, error: null }).then(res, rej);
           if (table === 'roadmap_waves') {
             if (chain._payload) { // an update().eq() resolution
@@ -160,23 +183,30 @@ test('runRollup dry-run: computes rows, writes nothing', async () => {
   assert.equal(byId.wx.progress_pct, null); // skip
 });
 
-test('runRollup apply: persists only non-null rows', async () => {
+// SD-LEO-INFRA-ROADMAP-WAVES-PROGRESS-001 (FR-1): INVERTED. This asserted that apply:true wrote
+// progress_pct back to two wave rows — w1 taking the build gauge (60) and w3 a KR aggregate (50).
+// Both are RUNG-level figures, and roadmap_waves is keyed by wave, so those writes are precisely
+// how one measurement came to sit on four rows at once. apply:true is now inert: the values are
+// still computed and returned in `rows` for the in-memory consumers, and nothing is persisted.
+test('runRollup apply: computes rows but persists NOTHING', async () => {
   const updates = [];
   const supabase = stubSupabase({
     krs: [{ objective_id: 'obj-a', baseline_value: 0, current_value: 5, target_value: 10, direction: 'increase' }],
     waves: [
       { id: 'w1', time_horizon: 'now' },
       { id: 'w3', time_horizon: 'next', okr_objective_ids: ['obj-a'] },
-      { id: 'wx', time_horizon: null }, // skip → must NOT be written
+      { id: 'wx', time_horizon: null },
     ],
     captureUpdates: (u) => updates.push(u),
   });
   const res = await runRollup({ supabase, computeGaugeFn: async () => ({ available: true, build_pct: 60 }), apply: true, log: () => {} });
-  assert.equal(res.written, 2);
-  assert.equal(updates.length, 2);
-  assert.deepEqual(updates.map((u) => u.id).sort(), ['w1', 'w3']);
-  assert.equal(updates.find((u) => u.id === 'w1').payload.progress_pct, 60);
-  assert.equal(updates.find((u) => u.id === 'w3').payload.progress_pct, 50);
+  assert.equal(res.written, 0);
+  assert.equal(updates.length, 0, 'apply:true must not write roadmap_waves.progress_pct');
+  // The computation itself is unchanged — the values still reach the in-memory consumers.
+  const byId = Object.fromEntries(res.rows.map((r) => [r.wave_id, r]));
+  assert.equal(byId.w1.progress_pct, 60);
+  assert.equal(byId.w3.progress_pct, 50);
+  assert.equal(byId.wx.progress_pct, null);
 });
 
 test('runRollup fail-soft: gauge throw → build rungs null, no throw', async () => {


### PR DESCRIPTION
## The defect is granularity, not arithmetic

`roadmap_waves.progress_pct` is a **rung-level value stored on a per-wave row**. `rung-progress-rollup.mjs:83` assigns one `computeBuildGauge()` to every wave of a build rung — deliberately, `reason: "reuse build gauge"` — and `:159` wrote it back per wave.

Measured at the table: 23 waves, **three distinct values** `{0 ×17, 20 ×2, 71 ×4}`, and all six non-zero waves stamped **within one second**. Wave 1B stored 71 while its items were 17/17 complete. Consumers read it as per-wave because a column named `progress_pct` on a wave-keyed row says exactly that.

## The census undercounted: 5 claimed, 9 found

Two were chairman-delivered and named in the SD. **Three more were not:**

| Consumer | What it did |
|---|---|
| `chairman-morning-review-sweep.mjs:138` | Averaged it into the chairman's headline `N% build`, with `Number(w.progress_pct \|\| 0)` coercing **NULL to 0** — the fabrication the rollup's own contract forbids |
| `baseline-manager.js:60` | **Persisted** it into `roadmap_baseline_snapshots` |
| `roadmap-status.js:90` | Printed it per wave, null coerced to 0 |
| `plan-check-status.js:134` | Fetched, never read |

`roadmap-manager.js:160` writes the *same* baseline artifact and never carried the field — so removing it aligns two writers rather than dropping information.

## The tests were defending the defect

QF-20260719-275 fixed one caller ten days ago and pinned the surviving fallback in two cases literally named **"falls back to progress_pct"**, asserting the exact `71%`/`20%` the live table still holds. Deleting the fallback failed the suite. The field wasn't merely left standing — it was protected. Both are now inverted to assert *no percentage is emitted*.

## Changes

- **FR-1** — remove the write-back. Every value is rung-level, so no threshold makes persisting it to a wave row truthful. Nothing replaces it: both live consumers read `rows` in memory, never the column.
- **FR-2/FR-4** — remove all nine reads.
- **FR-3** — `pct` unchanged (numerically identical); adds `distinct`. Averaging N copies returns the copy while reporting `measured: 4` — four independent measurements agreeing, which is spurious.
- **FR-5** — census assertion with a control on the same predicate. **It found the last two consumers immediately** — my own grep had missed them behind a `head -30`.

## Scope

**No DDL.** `DROP COLUMN` is chairman-gated; the SD's acceptance asks for zero reads *outside the derivation path*, which a surviving column satisfies. The drop is a clean follow-on once reads are zero.

**ehg residue named, not dropped:** `usePortfolioRoadmap.ts:292` (dead fetch) and `activeFilter.test.ts:85-87` (fixtures pinning 75/20/20). Separate repo and CI; recorded in TR-2.

70 tests pass across the 5 affected suites.