### PR TITLE
fix(QF-20260802-207): STOP-truncation was invisible to both guards, and the ceiling was 1000

### DIFF
--- a/lib/ai/multimodal-client.js
+++ b/lib/ai/multimodal-client.js
@@ -9,6 +9,26 @@ const fs = require('fs').promises;
 const axios = require('axios').default;
 require('dotenv').config();
 
+/**
+ * QF-20260802-207 — per-purpose output ceiling, SINGLE SOURCE with the vetting adapter.
+ *
+ * Kept byte-identical in intent to lib/sub-agents/vetting/provider-adapters.js:599:
+ *   options.maxTokens || options.max_tokens || (purpose === 'content-generation' ? 16384 : 4096)
+ * That adapter honoured the purpose; this one did not, which is the HALF-COVERAGE the QF names.
+ *
+ * WHY THE OLD DEFAULT WAS 1000 AND WHY THAT MATTERS: this client is a vision/multimodal helper whose
+ * original callers wanted short answers, so 1000 was reasonable in its first context. It became a
+ * defect when purpose-routed generation calls started landing here — venture 50763b6a's stage-5
+ * financial model truncated at outputTokens=997 against exactly this ceiling, three times, and the
+ * near-exact 997/1000 match is the corroboration that this line served that call.
+ *
+ * 4096 (not 1000) is the no-purpose floor, matching the vetting adapter: a caller that supplies no
+ * purpose still gets a workable ceiling rather than one tuned for one-line vision answers.
+ */
+function purposeOutputCeiling(purpose) {
+  return purpose === 'content-generation' ? 16384 : 4096;
+}
+
 class MultimodalClient {
   constructor(config = {}) {
     this.config = {
@@ -16,7 +36,13 @@ class MultimodalClient {
       model: config.model || process.env.AI_MODEL || 'gemini-2.5-flash',  // Cost control (2026-06-05): default to Flash; pass config.model/useCase 'high-accuracy' for Pro
       apiKey: config.apiKey || process.env.GEMINI_API_KEY || process.env.GOOGLE_AI_API_KEY || process.env.OPENAI_API_KEY,
       temperature: config.temperature || 0,
-      maxTokens: config.maxTokens || 1000,
+      // QF-20260802-207: the 1000 default is what truncated venture 50763b6a's stage-5 financial
+      // model at outputTokens=997 (three byte-identical failures since 2026-07-26). The per-purpose
+      // ceiling from SD-LEO-INFRA-LLM-PURPOSE-THREADING-TRUNCATION-001 was threaded correctly by
+      // client-factory.js:462-463 but DIED HERE, because this adapter never read options.purpose.
+      // Mapping REUSED from lib/sub-agents/vetting/provider-adapters.js:599 rather than re-derived —
+      // two ceilings for one question is how the original fix ended up half-covering.
+      maxTokens: config.maxTokens || purposeOutputCeiling(config.purpose),
       timeout: config.timeout || 30000,
       retryAttempts: config.retryAttempts || 3,
       retryDelay: config.retryDelay || 1000,

--- a/lib/eva/utils/parse-json.js
+++ b/lib/eva/utils/parse-json.js
@@ -1,3 +1,5 @@
+import { SUCCESS_FINISH, looksLikeUnterminatedJson } from '../../llm/truncation-detect.js';
+
 /**
  * Attempt to repair common LLM JSON anti-patterns before parsing.
  *
@@ -95,8 +97,34 @@ export function parseJSON(textOrResponse, options = {}) {
   // a truncation-class cause so the failure message names the real reason instead of the generic
   // "Failed to parse" misdirection. Success values (STOP/stop/end_turn/COMPLETE/empty) are NOT abnormal.
   const finishReason = isResponseObj ? textOrResponse.finishReason : undefined;
-  const SUCCESS_FINISH = new Set(['STOP', 'stop', 'end_turn', 'COMPLETE', 'complete', '']);
+  // QF-20260802-207: SUCCESS_FINISH is now imported from lib/llm/truncation-detect.js rather than
+  // redefined here. It previously existed in two places, which is exactly how the cache ban and this
+  // classifier ended up disagreeing about STOP — one treated it as success, and nothing treated it
+  // as the ceiling hit it actually was.
   const abnormalFinish = finishReason != null && finishReason !== '' && !SUCCESS_FINISH.has(finishReason);
+
+  // QF-20260802-207 — A TRUNCATION THE TRUNCATION-DETECTOR CANNOT SEE.
+  //
+  // The two checks above are both blind to the failure that stalled venture 50763b6a at stage 5 for
+  // a week: Gemini-family adapters report a hit output ceiling as finishReason='STOP', not
+  // 'MAX_TOKENS'. So `truncated` is false, and 'STOP' sits in SUCCESS_FINISH so `abnormalFinish` is
+  // false too — the call fell through to the generic "Failed to parse LLM response as JSON", which
+  // named the wrong cause three times in a row and sent every reader looking at the prompt.
+  //
+  // A SUCCESS finishReason WITH UNPARSEABLE JSON IS ITSELF THE SIGNAL. A model that genuinely
+  // finished does not emit invalid JSON when the schema says JSON; a model cut off mid-object does.
+  // Scoped deliberately: this only fires when parsing has ALREADY failed (both layers below), so a
+  // valid response is never reclassified — the flag is consumed at the throw site, not here.
+  // USES THE SHARED SHAPE PROBE, and the first version of this did not — which a PRE-EXISTING test
+  // caught (tests/unit/eva/utils/parse-json-robustness.test.js:85, "STOP (success) on unparseable
+  // => generic parse-failure, NOT abnormal"). Without looksLikeUnterminatedJson this fired on ANY
+  // STOP response, so genuinely malformed non-JSON like 'not json {' was mislabelled a truncation —
+  // trading one misdirection for another. The probe requires the body to actually OPEN a JSON
+  // document ({ or [) before a ceiling hit is suspected.
+  const stopTruncationSuspected = isResponseObj
+    && !truncated
+    && SUCCESS_FINISH.has(String(finishReason ?? ''))
+    && looksLikeUnterminatedJson(textOrResponse.content);
 
   // Strip markdown code fences if present
   const cleaned = text.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
@@ -131,6 +159,12 @@ export function parseJSON(textOrResponse, options = {}) {
     errorMsg = `LLM response truncated at token ceiling (finishReason=MAX_TOKENS) — increase maxOutputTokens / thread the call purpose (e.g. purpose:'content-generation' → 16384). ${diag} HEAD: ${head}${tail ? `\nTAIL: ${tail}` : ''}`;
   } else if (abnormalFinish) {
     errorMsg = `LLM response abnormally terminated (finishReason=${finishReason}, non-STOP) — treat as a truncation-class failure, not a JSON-robustness one. ${diag} HEAD: ${head}${tail ? `\nTAIL: ${tail}` : ''}`;
+  } else if (stopTruncationSuspected) {
+    // QF-20260802-207: this branch is the whole point. Reaching here means the adapter reported a
+    // SUCCESS finishReason and the body still would not parse after both repair layers — the
+    // signature of a Gemini-family ceiling hit, which reports STOP rather than MAX_TOKENS. Name the
+    // truncation cause instead of the generic parse failure that misdirected three investigations.
+    errorMsg = `LLM response unparseable despite finishReason=${finishReason ?? 'n/a'} — TREAT AS TRUNCATION: Gemini-family adapters report a hit output ceiling as STOP, not MAX_TOKENS, so the ceiling is the first thing to check, not the prompt. Raise maxOutputTokens / thread the call purpose (purpose:'content-generation' → 16384). ${diag} HEAD: ${head}${tail ? `\nTAIL: ${tail}` : ''}`;
   } else {
     errorMsg = `Failed to parse LLM response as JSON ${diag} HEAD: ${head}${tail ? `\nTAIL: ${tail}` : ''}`;
   }

--- a/lib/llm/client-factory.js
+++ b/lib/llm/client-factory.js
@@ -32,6 +32,9 @@ import {
 import { getOpenAIModel, getClaudeModel, getGoogleModel, getGeminiLadderModel } from '../config/model-config.js';
 import responseCache from './response-cache.js';
 import { logUsage } from './usage-logger.js';
+// QF-20260802-207: shared with the fail-loud classifier so the cache ban and the error message
+// cannot disagree about what "truncated" means.
+import { isTruncatedResponse } from './truncation-detect.js';
 
 /**
  * Check if local LLM is enabled (evaluated at call time, not module load)
@@ -467,7 +470,16 @@ export function _wrapAdapter(adapter, options = {}) {
 
     // Cache the result (skip if TTL explicitly set to 0).
     // FR-2: do NOT cache a MAX_TOKENS (truncated) response — it must never be replayed on retry.
-    if (effectiveCacheTTL !== 0 && result && result.finishReason !== 'MAX_TOKENS') {
+    //
+    // QF-20260802-207: MAX_TOKENS ALONE WAS HALF THE GUARD, AND THE MISSING HALF EXPLAINS WHY RETRY
+    // NEVER HELPED. Gemini-family adapters report a hit output ceiling as finishReason='STOP', so a
+    // truncated response passed this check, got cached, and was then REPLAYED byte-identically on
+    // every retry — which is exactly the three byte-identical stage-5 failures on venture 50763b6a
+    // (2026-07-26 onward). Retry-alone was proven useless because it was never re-asking the model.
+    //
+    // isTruncatedResponse() is the shared predicate, so the cache ban and the fail-loud classifier
+    // in lib/eva/utils/parse-json.js cannot drift apart on what counts as truncated.
+    if (effectiveCacheTTL !== 0 && result && !isTruncatedResponse(result)) {
       responseCache.set(systemPrompt, userPrompt, modelName, result, effectiveCacheTTL);
     }
 

--- a/lib/llm/truncation-detect.js
+++ b/lib/llm/truncation-detect.js
@@ -1,0 +1,78 @@
+/**
+ * QF-20260802-207 — SHARED TRUNCATION PREDICATE.
+ *
+ * WHY THIS EXISTS AS ONE FUNCTION RATHER THAN TWO CHECKS. Venture 50763b6a (Image Alt Text
+ * Generator, the ratified first-revenue venture) sat orchestrator_state=failed at stage 5 from
+ * 2026-07-26 with three BYTE-IDENTICAL failures:
+ *   Failed to parse LLM response as JSON [finishReason=STOP outputTokens=997 contentLength=3180]
+ *
+ * Two guards existed and BOTH were blind to it, because both keyed on finishReason==='MAX_TOKENS':
+ *   - the fail-loud classifier (lib/eva/utils/parse-json.js) named the wrong cause, sending three
+ *     investigations at the prompt instead of the ceiling;
+ *   - the no-cache guard (lib/llm/client-factory.js) let the truncated body into the cache, so every
+ *     "retry" replayed the same poisoned response and never re-asked the model. That is why the QF
+ *     records retry-alone as proven useless.
+ *
+ * GEMINI-FAMILY ADAPTERS REPORT A HIT OUTPUT CEILING AS 'STOP', NOT 'MAX_TOKENS'. A truncation the
+ * truncation-detector cannot see is worse than no detector, because its silence is read as health.
+ *
+ * Kept in lib/llm (not lib/eva) so the low-level client can import it without reaching upward into
+ * the EVA layer. ONE definition, two consumers — two definitions of "truncated" is precisely how the
+ * original purpose-threading fix ended up half-covering.
+ */
+
+/** finishReason values that a provider uses to mean "the model chose to stop". */
+export const SUCCESS_FINISH = Object.freeze(
+  new Set(['STOP', 'stop', 'end_turn', 'COMPLETE', 'complete', '']),
+);
+
+/** finishReason values that explicitly name a ceiling hit. */
+export const EXPLICIT_TRUNCATION_FINISH = Object.freeze(
+  new Set(['MAX_TOKENS', 'max_tokens', 'length']),
+);
+
+/**
+ * Does this body LOOK like a JSON document that was cut off?
+ *
+ * DELIBERATELY CONSERVATIVE. Returns false for prose, so a normal text completion is never
+ * mistaken for a truncation and denied the cache. It fires only when the content opens a JSON
+ * structure and then fails to parse — a model that genuinely finished does not emit a half-open
+ * object when the schema asked for JSON.
+ */
+export function looksLikeUnterminatedJson(content) {
+  if (typeof content !== 'string') return false;
+  const cleaned = content.replace(/```json\s*\n?/g, '').replace(/```\s*$/g, '').trim();
+  if (!cleaned) return false;
+  if (cleaned[0] !== '{' && cleaned[0] !== '[') return false;   // not a JSON document — leave it alone
+  try {
+    JSON.parse(cleaned);
+    return false;                                               // parsed fine: not truncated
+  } catch {
+    return true;                                                // opens JSON, will not parse
+  }
+}
+
+/**
+ * THE PREDICATE. True when the response should be treated as truncated for BOTH fail-loud
+ * classification and the cache ban.
+ *
+ * @param {{finishReason?: string, content?: string}} response adapter response object
+ * @returns {boolean}
+ */
+export function isTruncatedResponse(response) {
+  if (!response || typeof response !== 'object') return false;
+  const finishReason = String(response.finishReason ?? '');
+
+  // Explicit: the provider named the ceiling.
+  if (EXPLICIT_TRUNCATION_FINISH.has(finishReason)) return true;
+
+  // Implicit: the provider claimed success, but the body is an unterminated JSON document.
+  // This is the QF-20260802-207 case — STOP + unparseable JSON.
+  if (SUCCESS_FINISH.has(finishReason)) return looksLikeUnterminatedJson(response.content);
+
+  // Anything else (SAFETY, RECITATION, content_filter, ...) is abnormal but not truncation-by-ceiling;
+  // the parse-json classifier already names those separately and they must not be conflated here.
+  return false;
+}
+
+export default { isTruncatedResponse, looksLikeUnterminatedJson, SUCCESS_FINISH, EXPLICIT_TRUNCATION_FINISH };

--- a/lib/llm/truncation-detect.test.js
+++ b/lib/llm/truncation-detect.test.js
@@ -1,0 +1,124 @@
+/**
+ * QF-20260802-207 — tests for the shared truncation predicate and its two consumers.
+ *
+ * THE CASE THAT MATTERS IS THE ONE THAT SHIPPED BROKEN FOR A WEEK: finishReason='STOP' with an
+ * unparseable JSON body. Both existing guards keyed on 'MAX_TOKENS' and were blind to it, so
+ * venture 50763b6a sat failed at stage 5 from 2026-07-26 with three byte-identical failures.
+ *
+ * Fixtures use the REAL observed shape (finishReason STOP, ~997 output tokens, JSON cut mid-object)
+ * rather than synthetic well-formed objects — a fixture that cannot reproduce the bug cannot
+ * falsify the fix.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { isTruncatedResponse, looksLikeUnterminatedJson, SUCCESS_FINISH, EXPLICIT_TRUNCATION_FINISH } from './truncation-detect.js';
+import { parseJSON } from '../eva/utils/parse-json.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+/** The observed stage-5 failure: JSON cut off mid-object, reported as a clean STOP. */
+const STAGE5_TRUNCATED = {
+  content: '{"revenueModel": {"tiers": [{"name": "Starter", "priceUsd": 12}, {"name": "Pro", "priceUsd": 49}], "opex": {"hosting": 340, "llm',
+  finishReason: 'STOP',
+  usage: { outputTokens: 997 },
+};
+
+describe('THE REGRESSION: STOP-truncation must be visible', () => {
+  it('classifies STOP + unparseable JSON as truncated', () => {
+    expect(isTruncatedResponse(STAGE5_TRUNCATED)).toBe(true);
+  });
+
+  it('parseJSON names TRUNCATION, not the generic parse failure', () => {
+    // The old message — "Failed to parse LLM response as JSON" — sent three investigations at the
+    // prompt instead of the ceiling. Naming the cause is the deliverable.
+    expect(() => parseJSON(STAGE5_TRUNCATED)).toThrow(/TREAT AS TRUNCATION/);
+    expect(() => parseJSON(STAGE5_TRUNCATED)).toThrow(/STOP, not MAX_TOKENS/);
+  });
+
+  it('still classifies the explicit MAX_TOKENS case (no regression)', () => {
+    expect(isTruncatedResponse({ content: 'x', finishReason: 'MAX_TOKENS' })).toBe(true);
+    expect(EXPLICIT_TRUNCATION_FINISH.has('MAX_TOKENS')).toBe(true);
+  });
+});
+
+describe('OPPOSITE POLARITY — a healthy response must never be reclassified', () => {
+  it('STOP + valid JSON is not truncated', () => {
+    expect(isTruncatedResponse({ content: '{"ok": true}', finishReason: 'STOP' })).toBe(false);
+  });
+
+  it('STOP + prose is not truncated (this client also serves non-JSON callers)', () => {
+    expect(isTruncatedResponse({ content: 'The layout looks correct.', finishReason: 'STOP' })).toBe(false);
+  });
+
+  it('valid JSON still parses through parseJSON unchanged', () => {
+    expect(parseJSON({ content: '{"a": 1}', finishReason: 'STOP' })).toEqual({ a: 1 });
+  });
+
+  it('fenced JSON still parses (fence-stripping preserved)', () => {
+    expect(parseJSON({ content: '```json\n{"a": 2}\n```', finishReason: 'STOP' })).toEqual({ a: 2 });
+  });
+
+  it('a non-JSON body is left alone by the shape probe', () => {
+    expect(looksLikeUnterminatedJson('just some text')).toBe(false);
+    expect(looksLikeUnterminatedJson('')).toBe(false);
+    expect(looksLikeUnterminatedJson(null)).toBe(false);
+  });
+});
+
+describe('ABNORMAL finishReason stays its own class — do not conflate', () => {
+  it('SAFETY is not reported as a ceiling truncation', () => {
+    // parse-json already names these separately; folding them into truncation would misdirect
+    // exactly the way the generic parse message did.
+    expect(isTruncatedResponse({ content: '{"a"', finishReason: 'SAFETY' })).toBe(false);
+  });
+
+  it('parseJSON still names an abnormal finish distinctly', () => {
+    expect(() => parseJSON({ content: '{"a"', finishReason: 'SAFETY' })).toThrow(/abnormally terminated/);
+  });
+});
+
+describe('THE CACHE BAN — a truncated response must never be replayed', () => {
+  const factory = readFileSync(resolve(REPO_ROOT, 'lib/llm/client-factory.js'), 'utf8');
+  const code = factory.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+  it('the cache guard uses the shared predicate, not a bare MAX_TOKENS compare', () => {
+    // Assert on CODE, not text — the file's comments quote the old check verbatim while explaining
+    // why it was insufficient, so a raw substring match reads its own explanation. That mistake was
+    // made twice earlier in this session.
+    expect(code).toMatch(/!isTruncatedResponse\(result\)/);
+    expect(code).not.toMatch(/result\.finishReason\s*!==\s*'MAX_TOKENS'/);
+  });
+
+  it('client-factory imports the shared predicate', () => {
+    expect(code).toMatch(/import \{ isTruncatedResponse \} from '\.\/truncation-detect\.js'/);
+  });
+});
+
+describe('THE CEILING — one mapping, not two', () => {
+  const mm = readFileSync(resolve(REPO_ROOT, 'lib/ai/multimodal-client.js'), 'utf8');
+  const code = mm.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+  it('multimodal-client no longer defaults to the 1000 ceiling that truncated stage 5', () => {
+    expect(code).not.toMatch(/maxTokens:\s*config\.maxTokens\s*\|\|\s*1000/);
+    expect(code).toMatch(/purposeOutputCeiling\(config\.purpose\)/);
+  });
+
+  it('its purpose ceiling matches the vetting adapter exactly (16384 / 4096)', () => {
+    // Same numbers as lib/sub-agents/vetting/provider-adapters.js:599. Two ceilings for one question
+    // is how the original purpose-threading fix ended up half-covering.
+    expect(code).toMatch(/content-generation'\s*\?\s*16384\s*:\s*4096/);
+  });
+
+  it('SUCCESS_FINISH is single-sourced, not redefined in parse-json', () => {
+    const pj = readFileSync(resolve(REPO_ROOT, 'lib/eva/utils/parse-json.js'), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    // Assert the PROPERTY (single-sourcing), not the exact import spelling. The first version of
+    // this pinned the literal string and broke the moment a second symbol was added to the same
+    // import — a test that fails on a harmless refactor teaches people to edit tests reflexively.
+    expect(pj).toMatch(/import \{[^}]*\bSUCCESS_FINISH\b[^}]*\} from '\.\.\/\.\.\/llm\/truncation-detect\.js'/);
+    expect(pj).not.toMatch(/const SUCCESS_FINISH\s*=\s*new Set/);
+    expect(SUCCESS_FINISH.has('STOP')).toBe(true);
+  });
+});


### PR DESCRIPTION
## The failure

Venture `50763b6a` (Image Alt Text Generator — the ratified **first-revenue venture**) has sat `orchestrator_state=failed` at stage 5 since **2026-07-26**, with three byte-identical failures:

```
Failed to parse LLM response as JSON [finishReason=STOP outputTokens=997 contentLength=3180]
```

## The ceiling was 1000, not the 4096 the QF assumed

`lib/ai/multimodal-client.js:19` defaulted `maxTokens` to **1000** and passed it straight through as `maxOutputTokens` with no purpose awareness — while `lib/sub-agents/vetting/provider-adapters.js:599` *did* honour purpose (`16384` for `content-generation`, else `4096`). That's the half-coverage the QF names, now located: **`outputTokens=997` against a 1000 default is a near-exact match.**

The purpose was threaded correctly upstream (`client-factory.js:462` forwards the real purpose), so the ceiling died at the adapter, not in the wrapper.

I also checked and **disproved** a simpler theory: that `'content-generation'` was an unrecognised purpose string falling through to a default. It's recognised at `client-factory.js:517` and maps to the high tier.

## Both guards were blind — and the second explains why retry never helped

Gemini-family adapters report a hit output ceiling as `finishReason='STOP'`, not `'MAX_TOKENS'`:

- **fail-loud** (`parse-json.js`) had `STOP` in `SUCCESS_FINISH`, so the failure fell through to the generic *"Failed to parse"* message — sending three investigations at the prompt instead of the ceiling.
- **the no-cache guard** (`client-factory.js:470`) keyed on `MAX_TOKENS` alone, so the truncated body **was cached** and every retry replayed it byte-identically. The QF records retry-alone as proven useless; this is why — it was never re-asking the model.

## Fix

One shared predicate (`lib/llm/truncation-detect.js`) consumed by both, so the cache ban and the error message cannot disagree about what "truncated" means. `SUCCESS_FINISH` now lives there rather than being redefined in `parse-json` — existing in two places is precisely how the guards drifted.

## A pre-existing test caught a real defect in my own fix

Worth reading before approving. My first `stopTruncationSuspected` fired on **any** `STOP` response object, so genuinely malformed non-JSON like `'not json {'` would have been mislabelled a truncation — trading one misdirection for another.

`tests/unit/eva/utils/parse-json-robustness.test.js:85` encodes a prior SD's deliberate decision that `STOP`+unparseable → generic, and on that fixture it was right. The shared shape probe (`looksLikeUnterminatedJson`) now requires the body to actually *open* a JSON document before a ceiling hit is suspected.

I had written that probe and then not used it here — while claiming in a comment that the two consumers couldn't drift apart. They had, in the same commit.

## Verification

| Check | Result |
|---|---|
| New tests | 15 passed |
| Mutation | **6/6 dead** — cache ban, STOP-detection, shape probe, fail-loud naming, the 1000 ceiling, ceiling divergence |
| Regression | `tests/unit` is **10 failed / 6 files both with and without this change** (measured against a stashed baseline) — zero added regressions across 29,808 tests |

## Scope honesty

The QF estimated 40 LOC; this is 277, of which 124 is the test file and much of the rest is comment. **The two halves ship together deliberately** — fixing the ceiling without the detector leaves the next truncation invisible; fixing the detector without the ceiling leaves stage 5 still failing.

## What I did not prove

That stage-05 routes through `multimodal-client` **specifically**. The 997/1000 match is strong corroboration, not a traced call path. The fix sits at the adapter default, so every caller inheriting it gets the purpose ceiling without touching any of the 31 analysis-step call sites — but if stage-05 in fact routes elsewhere, that adapter needs the same treatment and the re-run will show it.

**After merge:** the factory-lane re-run of stage 5 for venture `50763b6a` is the unblock for the W2-E deployment gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
