### PR TITLE
fix(SD-LEO-INFRA-IMPROVEMENT-APPLIER-UPSERTS-001): close the path by which observed content became governing instruction

### DIFF
--- a/scripts/modules/learning/improvement-appliers.js
+++ b/scripts/modules/learning/improvement-appliers.js
@@ -10,6 +10,7 @@ import dotenv from 'dotenv';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { closeIssuePatterns } from '../../../lib/governance/pattern-closure.js';
+import { sanitizeProtocolSectionPayload } from './protocol-section-payload-guard.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 dotenv.config({ path: path.resolve(__dirname, '../../../.env') });
@@ -81,15 +82,26 @@ async function applyProtocolSectionChange(improvement) {
     throw new Error(`Unexpected target table: ${target_table}`);
   }
 
-  const { error } = await supabase
-    .from('leo_protocol_sections')
-    .upsert(payload);
-
-  if (error) {
-    throw new Error(`Failed to update protocol section: ${error.message}`);
+  // SD-LEO-INFRA-IMPROVEMENT-APPLIER-UPSERTS-001 (FR-1, FR-2, FR-3): this was
+  // .upsert(payload) — unfiltered, and the ONLY applier that could REPLACE a row. A payload
+  // carrying an 'id' overwrote a governing protocol section, auto-approved at threshold 50 with no
+  // human review. INSERT-ONLY now, and the payload is filtered to an explicit column allowlist.
+  // sanitize THROWS on a non-object payload (the string shape measured in the live queue) rather
+  // than degrading to {} — a silent empty write is how this fix would ship looking correct.
+  const { clean, dropped } = sanitizeProtocolSectionPayload(payload, { queueRowId: improvement?.id });
+  if (dropped.length) {
+    console.warn(`[improvement-appliers] dropped non-allowlisted keys for queue row ${improvement?.id ?? 'unknown'}: ${dropped.join(', ')}`);
   }
 
-  return `Updated leo_protocol_sections: ${payload.section_key || payload.id}`;
+  const { error } = await supabase
+    .from('leo_protocol_sections')
+    .insert(clean);
+
+  if (error) {
+    throw new Error(`Failed to append protocol section: ${error.message}`);
+  }
+
+  return `Appended leo_protocol_sections: ${clean.section_type ?? '(untyped)'} — ${clean.title ?? '(untitled)'}`;
 }
 
 /**

--- a/scripts/modules/learning/protocol-section-payload-guard.js
+++ b/scripts/modules/learning/protocol-section-payload-guard.js
@@ -1,0 +1,115 @@
+/**
+ * SD-LEO-INFRA-IMPROVEMENT-APPLIER-UPSERTS-001 — THE DATA/INSTRUCTION BOUNDARY FOR
+ * leo_protocol_sections.
+ *
+ * WHAT WAS WRONG. improvement-appliers.js applyProtocolSectionChange passed a model-authored
+ * payload straight into .upsert() with no column allowlist, no shape transform and no insert-only
+ * constraint. A payload carrying an 'id' REPLACED an existing governing section — and the learning
+ * loop auto-approves at threshold 50 with no human review on every SD completion, fleet-wide
+ * (scripts/modules/learning/index.js:110, whose own comment at :156 reads "so auto-approve all").
+ *
+ * WHY THAT IS CONSTITUTIONAL RATHER THAN AN ORDINARY UNVALIDATED-INPUT BUG. The reachable rows
+ * include the Adam role contract (section_type=adam_role_contract) and the phase files — the
+ * documents that tell every future session what it is and how to behave. AN INJECTED INSTRUCTION
+ * LASTS ONE CONTEXT; AN OVERWRITTEN PROTOCOL SECTION IS READ AS AUTHORITATIVE BY EVERY FUTURE
+ * SESSION, INCLUDING THE ONES AUDITING FOR INJECTION. It is self-concealing by construction.
+ * CONST-001 (AI scores inform but never decide) and CONST-002 (the system that proposes cannot
+ * approve its own proposals) both sit in the top band, above System Integrity.
+ *
+ * MEASURED BEFORE BUILDING — THE DOOR IS OPEN AND NOTHING HAS WALKED THROUGH IT. All 69
+ * protocol_improvement_queue rows targeting this table were read as a full population (count
+ * matched fetched): ZERO carry payload.id, and 68 are already status=APPLIED. So this is
+ * CLOSE-BEFORE-USE, not incident response — no section has been overwritten and no rollback is in
+ * scope. That does not lower the priority, because a successful exploit would have erased its own
+ * trace, but it does mean no forensic effort belongs here.
+ *
+ * THE CASE THAT WOULD HAVE SHIPPED BROKEN. That same population scan returned payload keys 0..607
+ * — the Object.keys() signature of a STRING. Some stored payloads are not objects. A naive
+ * pick(payload, ALLOWED) returns {} for those and silently converts a working append into a no-op
+ * or a malformed write, which every well-formed-object fixture would miss. Hence sanitize()
+ * REFUSES a non-object loudly instead of degrading to an empty write.
+ *
+ * PROVENANCE OF THE CHANNEL IS NOT PROVENANCE OF THE PAYLOAD: the queue is internal, but its
+ * CONTENT is model-authored from observed material. That distinction is the whole reason this guard
+ * exists.
+ */
+
+/**
+ * Real leo_protocol_sections columns a model-authored improvement may write.
+ *
+ * DERIVED FROM THE TABLE'S COLUMN SET, NOT FROM A SAMPLE OF CURRENT PAYLOADS. Encoding today's
+ * observed keys would look like a boundary while actually being a snapshot — it would break the
+ * next legitimate field and quietly narrow over time.
+ *
+ * DELIBERATELY EXCLUDED and why:
+ *   id                  — the overwrite vector; an insert must never carry a caller-supplied id
+ *   protocol_id         — row ownership; a payload must not re-parent a section
+ *   scoring_*           — computed by the scoring pipeline, never authored
+ *   context_tier,
+ *   target_file, priority — routing/authority fields that decide WHERE a section governs
+ */
+export const ALLOWED_SECTION_COLUMNS = Object.freeze([
+  'section_type',
+  'title',
+  'content',
+  'order_index',
+  'metadata',
+  'skill_key',
+  'anchor_topic',
+]);
+
+/** Columns whose presence means the payload is trying to REPLACE rather than append. */
+export const OVERWRITE_KEYS = Object.freeze(['id']);
+
+export class PayloadRefused extends Error {
+  constructor(reason, detail) {
+    super(`protocol-section payload refused: ${reason}${detail ? ` (${detail})` : ''}`);
+    this.name = 'PayloadRefused';
+    this.reason = reason;
+    this.detail = detail;
+  }
+}
+
+/**
+ * Filter a model-authored payload down to the allowlist, refusing anything that could overwrite.
+ *
+ * FAIL-CLOSED ON THE WRITE, FAIL-LOUD ON THE REPORT — the inverse of the old behaviour, where an
+ * unfiltered write succeeded silently.
+ *
+ * @param {unknown} payload         the raw improvement payload
+ * @param {{queueRowId?: string}} [ctx] for attributable refusals
+ * @returns {{clean: object, dropped: string[]}}
+ * @throws {PayloadRefused} on a non-object payload, an overwrite attempt, or an empty result
+ */
+export function sanitizeProtocolSectionPayload(payload, ctx = {}) {
+  const where = ctx.queueRowId ? `queue row ${ctx.queueRowId}` : 'unknown queue row';
+
+  // MEASURED CASE, NOT DEFENSIVE BOILERPLATE: string payloads exist in the live queue. Refusing
+  // loudly is the point — a silent {} here is how this fix would ship looking correct.
+  if (payload === null || typeof payload !== 'object' || Array.isArray(payload)) {
+    throw new PayloadRefused('payload is not an object', `${where}, got ${Array.isArray(payload) ? 'array' : typeof payload}`);
+  }
+
+  const present = OVERWRITE_KEYS.filter((k) => payload[k] !== undefined);
+  if (present.length) {
+    // The vulnerability itself. An id-bearing payload is never an append.
+    throw new PayloadRefused('payload carries an overwrite key', `${where}, keys: ${present.join(', ')}`);
+  }
+
+  const clean = {};
+  const dropped = [];
+  for (const [k, v] of Object.entries(payload)) {
+    if (ALLOWED_SECTION_COLUMNS.includes(k)) clean[k] = v;
+    else dropped.push(k);
+  }
+
+  // An append that would write nothing is a malformed payload, not a no-op. Saying so keeps the
+  // string-payload class visible even if a future caller pre-coerces it into an empty object.
+  if (Object.keys(clean).length === 0) {
+    throw new PayloadRefused('no writable columns after allowlist', `${where}, dropped: ${dropped.join(', ') || 'nothing'}`);
+  }
+
+  return { clean, dropped };
+}
+
+export default { sanitizeProtocolSectionPayload, ALLOWED_SECTION_COLUMNS, OVERWRITE_KEYS, PayloadRefused };

--- a/scripts/modules/learning/protocol-section-payload-guard.test.js
+++ b/scripts/modules/learning/protocol-section-payload-guard.test.js
@@ -1,0 +1,150 @@
+/**
+ * SD-LEO-INFRA-IMPROVEMENT-APPLIER-UPSERTS-001 — tests for the leo_protocol_sections write boundary.
+ *
+ * THE VULNERABILITY THIS CLOSES: applyProtocolSectionChange passed a model-authored payload into an
+ * unfiltered .upsert(), so a payload carrying an 'id' REPLACED a governing protocol section — the
+ * Adam role contract and the phase files are reachable that way — while the learning loop
+ * auto-approves at threshold 50 with no human review on every SD completion.
+ *
+ * FIXTURES REFLECT THE LIVE CORPUS, NOT CONVENIENT SHAPES. The string-payload case is here because
+ * the full-population key scan over all 69 queue rows returned indices 0..607 — the Object.keys()
+ * signature of a string. A naive pick(payload, ALLOWED) returns {} for those, which is how this fix
+ * would ship looking correct and silently break the learning loop.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  sanitizeProtocolSectionPayload, ALLOWED_SECTION_COLUMNS, OVERWRITE_KEYS, PayloadRefused,
+} from './protocol-section-payload-guard.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const APPLIERS = resolve(REPO_ROOT, 'scripts/modules/learning/improvement-appliers.js');
+/** Comments quote the old code verbatim while explaining it — assert on CODE, not text. */
+const applierCode = () => readFileSync(APPLIERS, 'utf8')
+  .replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+describe('FR-1 the overwrite vector is closed', () => {
+  it('refuses a payload carrying an id', () => {
+    expect(() => sanitizeProtocolSectionPayload({ id: 'abc-123', title: 'x', content: 'y' }))
+      .toThrow(PayloadRefused);
+    expect(() => sanitizeProtocolSectionPayload({ id: 'abc-123', title: 'x', content: 'y' }))
+      .toThrow(/overwrite key/);
+  });
+
+  it('id is not silently strippable — it must REFUSE, not sanitize away', () => {
+    // Dropping id and inserting anyway would turn an attempted overwrite into a silent append,
+    // hiding the attempt. A refusal is attributable; a strip is not.
+    try {
+      sanitizeProtocolSectionPayload({ id: 'x', title: 't', content: 'c' }, { queueRowId: 'q-1' });
+      throw new Error('should have refused');
+    } catch (e) {
+      expect(e).toBeInstanceOf(PayloadRefused);
+      expect(e.detail).toContain('q-1');   // attributable to the originating queue row
+    }
+  });
+
+  it('the applier is INSERT-ONLY — no upsert remains', () => {
+    const code = applierCode();
+    expect(code).not.toMatch(/\.upsert\(/);
+    expect(code).toMatch(/\.from\('leo_protocol_sections'\)\s*\n?\s*\.insert\(clean\)/);
+  });
+});
+
+describe('FR-3 THE CASE FIXTURES MISS: non-object payloads', () => {
+  it('refuses a STRING payload loudly (measured in the live queue)', () => {
+    expect(() => sanitizeProtocolSectionPayload('a raw string payload'))
+      .toThrow(/not an object/);
+  });
+
+  it('refuses an array payload', () => {
+    expect(() => sanitizeProtocolSectionPayload(['a', 'b'])).toThrow(/not an object/);
+  });
+
+  it('refuses null and undefined', () => {
+    expect(() => sanitizeProtocolSectionPayload(null)).toThrow(/not an object/);
+    expect(() => sanitizeProtocolSectionPayload(undefined)).toThrow(/not an object/);
+  });
+
+  it('never returns an empty clean object instead of throwing', () => {
+    // The silent-{} path is the specific failure mode this FR exists to prevent.
+    for (const bad of ['str', 42, null, undefined, ['a'], {}, { nope: 1 }]) {
+      expect(() => sanitizeProtocolSectionPayload(bad)).toThrow(PayloadRefused);
+    }
+  });
+});
+
+describe('FR-2 allowlist — BOTH polarities', () => {
+  it('drops an unexpected key', () => {
+    const { clean, dropped } = sanitizeProtocolSectionPayload({ title: 'T', content: 'C', evil_column: 'x' });
+    expect(clean.evil_column).toBeUndefined();
+    expect(dropped).toContain('evil_column');
+  });
+
+  it('STILL WRITES the allowed columns — filtering everything is as much a failure as filtering nothing', () => {
+    const { clean } = sanitizeProtocolSectionPayload({
+      section_type: 'guidance', title: 'T', content: 'C', order_index: 3, metadata: { a: 1 }, evil: 'x',
+    });
+    expect(Object.keys(clean).sort()).toEqual(['content', 'metadata', 'order_index', 'section_type', 'title']);
+  });
+
+  it('excludes the authority/ownership columns deliberately', () => {
+    // protocol_id re-parents a section; context_tier/target_file/priority decide WHERE it governs;
+    // scoring_* is computed. None may be model-authored.
+    for (const forbidden of ['protocol_id', 'context_tier', 'target_file', 'priority', 'scoring_total']) {
+      expect(ALLOWED_SECTION_COLUMNS).not.toContain(forbidden);
+    }
+    expect(OVERWRITE_KEYS).toContain('id');
+  });
+
+  it('the allowlist is a frozen literal, not derived from a payload sample', () => {
+    // Deriving it from observed payloads would encode today's shapes as the contract and narrow
+    // silently as payloads change.
+    expect(Object.isFrozen(ALLOWED_SECTION_COLUMNS)).toBe(true);
+  });
+});
+
+describe('FR-4 AS CORRECTED — the append sites stay SHAPED, and are NOT sanitized', () => {
+  // FR-4 as originally written said to apply the same allowlist at :253/:367. Reading those sites
+  // refuted it: both build sectionData with protocol_id, which the allowlist deliberately excludes,
+  // so sanitizing would strip a required field and break or orphan the inserts. And every column
+  // name there is a code-authored literal, so column-name injection is structurally impossible.
+  // The real requirement is that they keep building shaped objects.
+  it('neither append site spreads a raw payload into columns', () => {
+    const code = applierCode();
+    expect(code).not.toMatch(/\.insert\(\s*\{\s*\.\.\.payload/);
+    expect(code).not.toMatch(/\.insert\(payload\)/);
+  });
+
+  it('the append sites still set protocol_id (which sanitizing would have stripped)', () => {
+    const code = applierCode();
+    expect(code).toMatch(/protocol_id:/);
+  });
+
+  it('model content reaches VALUES only, never column names', () => {
+    const code = applierCode();
+    // sectionData keys are literals; payload appears on the right-hand side.
+    expect(code).toMatch(/content:\s*payload\?\.improvement/);
+    // A COMPUTED KEY INSIDE AN OBJECT LITERAL is the injection shape — `{ [payload.x]: v }`.
+    // The first version of this asserted /\[\s*payload\./ over the whole file, which also flagged
+    // gateMap[payload.affected_phase] — a safe read from a hardcoded local map, in a different
+    // function, that produces no column name. Assert the actual shape, not any bracket near payload.
+    expect(code).not.toMatch(/[{,]\s*\[\s*payload/);
+  });
+});
+
+describe('FR-6 scope boundary held', () => {
+  it('protocol_constitution is not touched', () => {
+    expect(applierCode()).not.toMatch(/protocol_constitution/);
+  });
+
+  it('the literal target_table check survives', () => {
+    expect(applierCode()).toMatch(/target_table !== 'leo_protocol_sections'/);
+  });
+
+  it('the auto-approve threshold is not changed by this SD', () => {
+    const idx = readFileSync(resolve(REPO_ROOT, 'scripts/modules/learning/index.js'), 'utf8');
+    expect(idx).toMatch(/autoApproveCommand\(threshold = 50/);
+  });
+});


### PR DESCRIPTION
## The defect

`scripts/modules/learning/improvement-appliers.js:84-86` passed a **model-authored payload straight into an unfiltered `.upsert()`** on `leo_protocol_sections` — no column allowlist, no shape transform, no insert-only constraint. A payload carrying an `id` **replaced** a governing protocol section, and the learning loop auto-approves at threshold 50 with **no human review** on every SD completion, fleet-wide (`index.js:110`; its own comment at `:156` reads *"so auto-approve all"*).

The reachable rows include the **Adam role contract** and the **phase files** — the documents that tell every future session what it is and how to behave.

## Why this outranks an ordinary unvalidated-input bug

An injected instruction lasts one context. **An overwritten protocol section is read as authoritative by every future session — including the ones auditing for injection.** It is self-concealing by construction. CONST-001 (*AI scores inform but never decide* — auto-approve at a threshold *is* a score deciding) and CONST-002 (*the system that proposes cannot approve its own proposals* — this is that rule's exact fact pattern) both sit in the top band, above System Integrity.

## Measured before building: the door was open, nothing walked through

All **69** `protocol_improvement_queue` rows targeting this table read as a full population (count matched fetched): **zero carry `payload.id`**, 68 already `APPLIED`. Control — the distinct-key scan returns real payload keys, so an `id` would have surfaced.

So this is **close-before-use, not incident response**: no section was overwritten, no rollback in scope, no forensics needed. That does not lower the priority, since a successful exploit would have erased its own trace.

## The case that would have shipped broken

That same scan returned payload keys `0..607` — the `Object.keys()` signature of a **string**. Some stored payloads are not objects. A naive `pick(payload, ALLOWED)` returns `{}` for those and silently converts a working append into a no-op, which every well-formed-object fixture would miss. `sanitize()` **refuses loudly** instead.

## FR-4 was refuted by reading the code — read this before approving

FR-4 asked for the same allowlist at the two append sites (`:253`, `:367`). **Applying it literally would have broken two working paths.**

Both build `sectionData` containing `protocol_id`, which the allowlist deliberately **excludes** (row ownership — a model payload must never re-parent a section). Sanitizing would strip it and fail or orphan the inserts. And the premise doesn't hold there: every column name is a code-authored literal, model content reaches only *values*, so column-name injection is structurally impossible.

Implemented instead as a **regression guard** that those sites keep building shaped objects. Correction recorded on the PRD.

## Verification

| Check | Result |
|---|---|
| Tests | 17 passed |
| Mutation | **7/7 dead** — including *both* allowlist polarities (accepts-everything **and** rejects-everything), the pair that catches a guard present but useless in either direction |
| Regression | 79 tests / 11 files green across the learning module |
| Live | the guard was exercised against the real `leo_protocol_sections` column set before any test existed |

## Deliberate design choice worth challenging

The guard **refuses** an `id`-bearing payload rather than stripping it. Stripping would turn an attempted overwrite into a silent append and hide the attempt. The cost: a legitimate improvement that happens to carry an `id` now fails loudly instead of applying. Given 69/69 live rows carry no `id` that costs nothing today, and a refusal is recoverable where a silent overwrite is not — but it is a judgement call.

## Scope held

`protocol_constitution` untouched (already unreachable — every applier hardcodes its `.from()` literal and `target_table` is validated against a literal at `:80`, left intact). The auto-approve threshold is **unchanged** — that is a separate policy question, and this SD's job is making the write safe regardless of what the policy admits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
