### PR TITLE
feat(SD-LEO-INFRA-TERMINAL-RITUAL-ENFORCEMENT-001): step A — block on transcript evidence, not the worker's self-report

### DIFF
--- a/scripts/hooks/__tests__/stop-loop-wakeup-reminder.test.js
+++ b/scripts/hooks/__tests__/stop-loop-wakeup-reminder.test.js
@@ -24,22 +24,64 @@ describe('stop-loop-wakeup-reminder — REMINDER text (source-pin, shipped wordi
   });
 });
 
-// SD-LEO-INFRA-LOOP-CONTINUITY-ENFORCE-001 (FR-2 allow-path): a worker that announced its
-// wind-down via /signal must NOT be blocked (false-positive guard), while an un-announced
-// premature stop STILL blocks.
-describe('stop-loop-wakeup-reminder — wind-down allow-path', () => {
-  it('does NOT block when windDownSignaled, even for an active worker', () => {
-    expect(shouldRemind({ loopState: 'active', stopHookActive: false, flagEnabled: true, windDownSignaled: true })).toBe(false);
+// SD-LEO-INFRA-TERMINAL-RITUAL-ENFORCEMENT-001 step A — REPLACES the windDownSignaled allow-path
+// (SD-LEO-INFRA-LOOP-CONTINUITY-ENFORCE-001 FR-2). That path returned false for ANY session that
+// merely SAID "winding down", which is precisely Charlie's false positive: a worker talks its way
+// out of the arm requirement without the tool ever being called. Operator safety — the reason the
+// allow-path existed — is now carried by the WORKER GATE instead, which is a claim or a live loop
+// state rather than an announcement. Announcements are no longer load-bearing anywhere.
+describe('step A — an ANNOUNCEMENT is not an arm (FR-3, Charlie\'s false positive)', () => {
+  it('BLOCKS a claim-holding worker that announced a wind-down but never called the tool', () => {
+    expect(shouldRemind({ armVerdict: 'unarmed', loopState: 'active', flagEnabled: true, hasActiveClaim: true })).toBe(true);
   });
-  it('does NOT block a claim-holder that announced wind-down (unknown state + claim)', () => {
-    expect(shouldRemind({ loopState: 'unknown', stopHookActive: false, flagEnabled: true, hasActiveClaim: true, windDownSignaled: true })).toBe(false);
+
+  // The self-report the OLD predicate trusted. post-tool-loop-state.cjs sets awaiting_tick from
+  // the worker's own claim about itself, so reading it asked the suspect for an alibi.
+  it('BLOCKS a worker whose loop_state says awaiting_tick when the transcript says unarmed', () => {
+    expect(shouldRemind({ armVerdict: 'unarmed', loopState: 'awaiting_tick', flagEnabled: true, hasActiveClaim: true })).toBe(true);
   });
-  it('STILL blocks an active worker that did NOT announce wind-down', () => {
-    expect(shouldRemind({ loopState: 'active', stopHookActive: false, flagEnabled: true, windDownSignaled: false })).toBe(true);
+
+  it('allows a worker with a REAL ScheduleWakeup tool_use in the current turn', () => {
+    expect(shouldRemind({ armVerdict: 'armed', loopState: 'active', flagEnabled: true, hasActiveClaim: true })).toBe(false);
   });
-  it('flag-off and stop_hook_active guards still win over everything', () => {
-    expect(shouldRemind({ loopState: 'active', stopHookActive: false, flagEnabled: false, windDownSignaled: false })).toBe(false);
-    expect(shouldRemind({ loopState: 'active', stopHookActive: true, flagEnabled: true, windDownSignaled: false })).toBe(false);
+});
+
+describe('step A — worker gate keeps operators safe (FR-4)', () => {
+  it('never blocks a claim-less, loop-less session even when unarmed', () => {
+    expect(shouldRemind({ armVerdict: 'unarmed', loopState: null, flagEnabled: true, hasActiveClaim: false })).toBe(false);
+    expect(shouldRemind({ armVerdict: 'unarmed', loopState: 'unknown', flagEnabled: true, hasActiveClaim: false })).toBe(false);
+  });
+
+  // The live defect FR-4 names: an operator that says "winding down" must not become blockable.
+  // Under the old allow-path this same input was ALSO false, but for the wrong reason (the
+  // announcement); it is false here because the session is not a worker.
+  it('never blocks an operator that announced a wind-down', () => {
+    expect(shouldRemind({ armVerdict: 'unarmed', loopState: null, flagEnabled: true, hasActiveClaim: false, windDownSignaled: true })).toBe(false);
+  });
+
+  it('blocks the same unarmed turn once a claim is held', () => {
+    expect(shouldRemind({ armVerdict: 'unarmed', loopState: null, flagEnabled: true, hasActiveClaim: true })).toBe(true);
+  });
+});
+
+describe('step A — guards and escapes', () => {
+  const worker = { armVerdict: 'unarmed', loopState: 'active', flagEnabled: true, hasActiveClaim: true };
+
+  it('flag-off, second-stop and loop_state=exited all win over the arm requirement', () => {
+    expect(shouldRemind({ ...worker, flagEnabled: false })).toBe(false);
+    expect(shouldRemind({ ...worker, stopHookActive: true })).toBe(false);
+    expect(shouldRemind({ ...worker, loopState: 'exited' })).toBe(false);
+  });
+
+  // FR-2: the runtime switch must be able to stop a LIVE seat enforcing, with no merge/restart.
+  it('the kill switch disables the block outright', () => {
+    expect(shouldRemind({ ...worker, enforcementDisabled: true })).toBe(false);
+  });
+
+  // Absence of evidence is not evidence of absence — an unreadable transcript must not trap.
+  it("'unknown' and a missing verdict both fail OPEN", () => {
+    expect(shouldRemind({ ...worker, armVerdict: 'unknown' })).toBe(false);
+    expect(shouldRemind({ ...worker, armVerdict: undefined })).toBe(false);
   });
 });
 
@@ -55,45 +97,55 @@ describe('loop_state coherence (FR-3, no-new-state)', () => {
   });
 });
 
+// The original TS-1..TS-9, carried forward onto the arm-evidence basis. Each case keeps its
+// ORIGINAL INTENT; only the signal standing in for "no wakeup armed" changed — from
+// loop_state='active' (a self-report) to armVerdict='unarmed' (transcript evidence).
 describe('stop-loop-wakeup-reminder — shouldRemind (pure)', () => {
-  it('TS-1: returns false when the flag is disabled, even for an active /loop worker', () => {
-    expect(shouldRemind({ loopState: 'active', stopHookActive: false, flagEnabled: false })).toBe(false);
+  const unarmedWorker = { armVerdict: 'unarmed', loopState: 'active', stopHookActive: false, flagEnabled: true };
+
+  it('TS-1: returns false when the flag is disabled, even for an unarmed /loop worker', () => {
+    expect(shouldRemind({ ...unarmedWorker, flagEnabled: false })).toBe(false);
   });
 
-  it('TS-2: returns true when enabled, loop_state=active, and first stop (no wakeup armed)', () => {
-    expect(shouldRemind({ loopState: 'active', stopHookActive: false, flagEnabled: true })).toBe(true);
+  it('TS-2: returns true when enabled, unarmed, in-loop, and first stop', () => {
+    expect(shouldRemind(unarmedWorker)).toBe(true);
   });
 
-  it('TS-3: returns false when a wakeup is already armed (loop_state=awaiting_tick)', () => {
-    expect(shouldRemind({ loopState: 'awaiting_tick', stopHookActive: false, flagEnabled: true })).toBe(false);
+  it('TS-3: returns false when a wakeup was genuinely armed this turn', () => {
+    expect(shouldRemind({ ...unarmedWorker, armVerdict: 'armed' })).toBe(false);
   });
 
   it('TS-4: returns false on the second pass (stop_hook_active true) — never block twice', () => {
-    expect(shouldRemind({ loopState: 'active', stopHookActive: true, flagEnabled: true })).toBe(false);
+    expect(shouldRemind({ ...unarmedWorker, stopHookActive: true })).toBe(false);
   });
 
-  it('TS-5: returns false for exited / null / unknown loop_state WITHOUT a claim (operator-safe)', () => {
-    expect(shouldRemind({ loopState: 'exited', stopHookActive: false, flagEnabled: true })).toBe(false);
-    expect(shouldRemind({ loopState: null, stopHookActive: false, flagEnabled: true })).toBe(false);
-    expect(shouldRemind({ loopState: undefined, stopHookActive: false, flagEnabled: true })).toBe(false);
-    expect(shouldRemind({ loopState: 'unknown', stopHookActive: false, flagEnabled: true })).toBe(false);
+  it('TS-5: returns false for exited, and for null/unknown loop_state WITHOUT a claim (operator-safe)', () => {
+    expect(shouldRemind({ ...unarmedWorker, loopState: 'exited' })).toBe(false);
+    for (const loopState of [null, undefined, 'unknown']) {
+      expect(shouldRemind({ ...unarmedWorker, loopState, hasActiveClaim: false })).toBe(false);
+    }
   });
 
   // Coverage-gap (operator 2026-06-10): a worker holding a live SD claim whose loop_state
   // never entered the machine ('unknown'/null) is still about to go silent → remind.
   it('TS-7: returns true for unknown/null loop_state WHEN the session holds an active SD claim', () => {
-    expect(shouldRemind({ loopState: 'unknown', stopHookActive: false, flagEnabled: true, hasActiveClaim: true })).toBe(true);
-    expect(shouldRemind({ loopState: null, stopHookActive: false, flagEnabled: true, hasActiveClaim: true })).toBe(true);
+    for (const loopState of ['unknown', null]) {
+      expect(shouldRemind({ ...unarmedWorker, loopState, hasActiveClaim: true })).toBe(true);
+    }
   });
 
-  it('TS-8: a claim does NOT override the awaiting_tick (wakeup armed) or exited escapes', () => {
-    expect(shouldRemind({ loopState: 'awaiting_tick', stopHookActive: false, flagEnabled: true, hasActiveClaim: true })).toBe(false);
-    expect(shouldRemind({ loopState: 'exited', stopHookActive: false, flagEnabled: true, hasActiveClaim: true })).toBe(false);
+  // CHANGED DELIBERATELY. TS-8 used to assert awaiting_tick was an escape even for a claim-holder.
+  // It is not any more: awaiting_tick is the worker's OWN self-report, and honouring it is exactly
+  // the hole step A closes. 'exited' remains an escape — it is an explicit, deliberate loop
+  // termination, not a claim about having armed.
+  it('TS-8: awaiting_tick is NO LONGER an escape; exited still is', () => {
+    expect(shouldRemind({ ...unarmedWorker, loopState: 'awaiting_tick', hasActiveClaim: true })).toBe(true);
+    expect(shouldRemind({ ...unarmedWorker, loopState: 'exited', hasActiveClaim: true })).toBe(false);
   });
 
   it('TS-9: a claim is ignored when the flag is off or already reminded this turn', () => {
-    expect(shouldRemind({ loopState: 'unknown', stopHookActive: false, flagEnabled: false, hasActiveClaim: true })).toBe(false);
-    expect(shouldRemind({ loopState: 'unknown', stopHookActive: true, flagEnabled: true, hasActiveClaim: true })).toBe(false);
+    expect(shouldRemind({ ...unarmedWorker, loopState: 'unknown', hasActiveClaim: true, flagEnabled: false })).toBe(false);
+    expect(shouldRemind({ ...unarmedWorker, loopState: 'unknown', hasActiveClaim: true, stopHookActive: true })).toBe(false);
   });
 });
 

--- a/scripts/hooks/__tests__/wakeup-arm-evidence.test.js
+++ b/scripts/hooks/__tests__/wakeup-arm-evidence.test.js
@@ -192,11 +192,70 @@ describe('turn boundary — promptId primary, origin fallback', () => {
   });
 });
 
+// FR-3 — THE POPULATION THAT ACTUALLY FAILS. Arm compliance is ~100% on failure-shaped turns
+// (an error is salient, the worker is still "in" the task) and decays toward zero on
+// success-terminal ones, where a dense closing summary displaces the mechanical step. A suite
+// that only exercises failure paths passes while leaving the entire real failure population
+// untouched — so the specimens below are all SUCCESS-shaped.
+describe('FR-3 — success-terminal unarmed turns are the target, and they block', () => {
+  const { shouldRemind } = require(HOOK_PATH);
+  const u = (promptId) => ({ type: 'user', promptId, message: { content: [{ type: 'tool_result' }] } });
+  const worker = { loopState: 'active', flagEnabled: true, hasActiveClaim: true, stopHookActive: false };
+
+  // The exact shape of all three recorded dormancies: work done, tests green, a long closing
+  // summary written — and the wakeup never armed because the summary displaced it.
+  it('a turn that ends on a successful summary with no arm is UNARMED and blocks', () => {
+    const specimen = [u('t1'), otherTool('Bash'), otherTool('Edit'), textEntry('All 362 tests pass. Shipped as PR #6741.')];
+    const v = ev.findArmInCurrentTurn(specimen);
+    expect(v.verdict).toBe('unarmed');
+    expect(shouldRemind({ ...worker, armVerdict: v.verdict })).toBe(true);
+  });
+
+  // Charlie's false positive, reproduced deliberately: the worker SAYS it armed, in the same
+  // turn, in text. Text is not a tool call.
+  it('a turn that ANNOUNCES "wakeup armed" in text but never calls the tool still blocks', () => {
+    const specimen = [u('t1'), otherTool('Bash'), textEntry('Done. wakeup-armed +900s at 17:53.')];
+    const v = ev.findArmInCurrentTurn(specimen);
+    expect(v.verdict).toBe('unarmed');
+    expect(shouldRemind({ ...worker, armVerdict: v.verdict })).toBe(true);
+  });
+
+  // The same announcement mirrored into the DB as the worker's self-report. The OLD predicate
+  // read exactly this and allowed the stop.
+  it('the same turn still blocks even with loop_state=awaiting_tick claiming otherwise', () => {
+    const v = ev.findArmInCurrentTurn([u('t1'), textEntry('wakeup-armed +900s')]);
+    expect(shouldRemind({ ...worker, loopState: 'awaiting_tick', armVerdict: v.verdict })).toBe(true);
+  });
+
+  // STALE ARM, end to end: a real ScheduleWakeup exists in the transcript — one turn too early.
+  it('a success-shaped turn whose only arm is in the PREVIOUS turn blocks (stale arm)', () => {
+    const specimen = [u('t1'), armEntry({ delaySeconds: 900 }), textEntry('tick done'),
+      u('t2'), otherTool('Bash'), textEntry('next tick done')];
+    const v = ev.findArmInCurrentTurn(specimen);
+    expect(v.verdict).toBe('unarmed');
+    expect(v.armCount).toBe(0);
+    expect(shouldRemind({ ...worker, armVerdict: v.verdict })).toBe(true);
+  });
+
+  // The compliant shape this SD is trying to produce: arm, THEN summarise.
+  it('arming before the closing summary is compliant and does NOT block', () => {
+    const specimen = [u('t1'), otherTool('Bash'), armEntry({ delaySeconds: 900 }), textEntry('Shipped. Next tick in 15m.')];
+    const v = ev.findArmInCurrentTurn(specimen);
+    expect(v.verdict).toBe('armed');
+    expect(shouldRemind({ ...worker, armVerdict: v.verdict })).toBe(false);
+  });
+
+  it('a deliberate ScheduleWakeup({stop:true}) loop-end is not treated as a failure to arm', () => {
+    const v = ev.findArmInCurrentTurn([u('t1'), armEntry({ stop: true }), textEntry('loop complete')]);
+    expect(v.stopRequested).toBe(true);
+    expect(shouldRemind({ ...worker, armVerdict: v.verdict })).toBe(false);
+  });
+});
+
 describe('stdout decision-channel muzzle', () => {
   const hook = require(HOOK_PATH);
+  const hookSrc = fs.readFileSync(HOOK_PATH, 'utf8');
 
-  // Requiring the supabase client loads dotenv, which writes ~80 bytes of banner to STDOUT — the
-  // channel Claude Code parses as the Stop decision. Measured pre-existing at git HEAD.
   it('discards stdout writes made inside the muzzle', () => {
     const chunks = [];
     const real = process.stdout.write;
@@ -213,11 +272,28 @@ describe('stdout decision-channel muzzle', () => {
     expect(process.stdout.write).toBe(before);
   });
 
-  // A throw inside the muzzle must not leave stdout muted for the decision write that follows.
   it('restores stdout even when the callee throws', () => {
     const before = process.stdout.write;
     expect(() => hook.muzzleStdout(() => { throw new Error('boom'); })).toThrow('boom');
     expect(process.stdout.write).toBe(before);
+  });
+
+  // THE CLASS FIX, MADE COUNTABLE. A scoped muzzle around the one require I had MEASURED was an
+  // instance fix: the allow path still emitted 87 bytes from a different transitive require
+  // (park-worker / emit-feedback), caught only by an end-to-end run. The muzzle now installs at
+  // module load, so the invariant is structural — exactly one write reaches the real stdout, and
+  // it is the decision. A new `process.stdout.write(...)` anywhere else turns this red.
+  it('the real stdout has exactly ONE writer, and it is emitDecision', () => {
+    const realWrites = hookSrc.match(/REAL_STDOUT_WRITE\(/g) || [];
+    expect(realWrites).toHaveLength(1);
+    expect(hookSrc).toMatch(/function emitDecision[\s\S]{0,200}REAL_STDOUT_WRITE\(/);
+    // the muzzle is armed before any require below it can print
+    expect(hookSrc.indexOf('process.stdout.write = () => true;')).toBeLessThan(hookSrc.indexOf("require('../lib/sessions/loop-state-tracker.cjs')"));
+  });
+
+  it('the block decision is emitted through emitDecision, not a raw write', () => {
+    expect(hookSrc).toMatch(/emitDecision\(\{\s*decision:\s*'block'/);
+    expect(hookSrc).not.toMatch(/process\.stdout\.write\(JSON\.stringify/);
   });
 });
 

--- a/scripts/hooks/stop-loop-wakeup-reminder.cjs
+++ b/scripts/hooks/stop-loop-wakeup-reminder.cjs
@@ -32,6 +32,31 @@
  * 'active' (no wakeup armed) — exactly the attrition case it guards.
  */
 
+// ── STDOUT IS THE DECISION CHANNEL — MUZZLED BEFORE ANYTHING ELSE LOADS ──────
+// Claude Code parses this hook's stdout as the Stop decision document. Requiring the supabase
+// client loads dotenv, which writes an ~80-byte "◇ injected env …" banner to STDOUT (measured
+// 2026-08-02; PRE-EXISTING — git HEAD already required it). Worse, that banner's tip text
+// contains a literal "{", so it is not merely a preamble: it defeats find-first-brace extraction
+// and yields a SyntaxError instead of a decision. (Observed live — it broke an unrelated parse of
+// worker-checkin.cjs stdout the same day.)
+//
+// A scoped muzzle around the ONE require I had measured was the instance fix, not the class fix:
+// the allow path still emitted 87 bytes from a DIFFERENT transitive require (park-worker /
+// emit-feedback). So the muzzle is installed at module load, before any require below runs, and
+// stdout is restored ONLY to emit the decision. Everything else on this hook's stdout is dropped.
+// stderr is untouched. AC: process.stdout.write appears exactly ONCE outside these two helpers.
+const REAL_STDOUT_WRITE = process.stdout.write.bind(process.stdout);
+process.stdout.write = () => true;
+
+/** The ONLY path back onto stdout. Writes the decision document and re-muzzles. */
+function emitDecision(payload) {
+  try {
+    REAL_STDOUT_WRITE(JSON.stringify(payload));
+  } finally {
+    process.stdout.write = () => true;
+  }
+}
+
 const {
   LOOP_STATE_ACTIVE,
   LOOP_STATE_AWAITING_TICK,
@@ -64,30 +89,50 @@ async function shutdown() {
 
 /**
  * Pure decision: should the Stop hook block-and-remind this turn?
- * Block when the reminder is enabled, we have not already reminded this turn, AND the session
- * is a worker about to go silent without a wakeup armed. Two worker signals:
- *   - loop_state='active' (in a /loop, no wakeup armed), OR
- *   - the session holds an active SD claim while loop_state never entered the machine
- *     ('unknown'/null) — the coverage gap where a working worker would otherwise stop silently.
- * Operator/coordinator/Adam sessions hold no sd-start claim and never reach 'active', so they
- * are never trapped; and the block fires at most once per turn (stop_hook_active guard).
- * @param {{ loopState: string|null|undefined, stopHookActive: boolean, flagEnabled: boolean, hasActiveClaim?: boolean }} args
+ *
+ * STEP A (SD-LEO-INFRA-TERMINAL-RITUAL-ENFORCEMENT-001): the block now derives from TRANSCRIPT
+ * EVIDENCE of a ScheduleWakeup tool_use in the current turn, not from loop_state. The old
+ * predicate read a flag the worker sets about itself, so a worker that believed it had armed —
+ * or said so — satisfied it without the tool ever being called.
+ *
+ * WHAT THIS CAN AND CANNOT DO. It blocks ONCE per turn; a worker that stops again passes through
+ * (stop_hook_active, the anti-infinite-loop guard). For the dormancy this SD targets there is no
+ * later turn to re-block — the seat is gone — so step A is a one-shot NUDGE, not a compulsion.
+ * The escape is therefore COUNTED (classifyWindDownReason → 'second_stop_still_unarmed'): that
+ * number is how often a reminder was seen and ignored, and it is the evidence base for step C,
+ * which arms on the worker's behalf and is the actual enforcement.
+ *
+ * @param {{ armVerdict?: 'armed'|'unarmed'|'unknown', loopState?: string|null, stopHookActive?: boolean,
+ *           flagEnabled?: boolean, enforcementDisabled?: boolean, hasActiveClaim?: boolean }} args
  * @returns {boolean}
  */
-function shouldRemind({ loopState, stopHookActive, flagEnabled, hasActiveClaim, windDownSignaled }) {
+function shouldRemind({ armVerdict, loopState, stopHookActive, flagEnabled, enforcementDisabled, hasActiveClaim }) {
   if (!flagEnabled) return false;                       // default-OFF: no-op
+  if (enforcementDisabled) return false;                // runtime kill switch (FR-2)
   if (stopHookActive) return false;                     // never block twice — already reminded
-  // ALLOW-PATH (SD-LEO-INFRA-LOOP-CONTINUITY-ENFORCE-001, exit-mode 4c): a worker that
-  // announced its wind-down via /signal (session_coordination) is making a LEGITIMATE,
-  // coordinator-visible stop — never block it. Closes the false-positive where a worker
-  // does the handshake and then gets trapped by the reminder.
-  if (windDownSignaled) return false;
-  if (loopState === LOOP_STATE_ACTIVE) return true;     // in-loop, no wakeup armed
-  if (loopState === LOOP_STATE_AWAITING_TICK) return false; // wakeup already armed — fine
   if (loopState === LOOP_STATE_EXITED) return false;    // loop legitimately ended
-  // loop_state 'unknown'/null: remind ONLY if this session holds a live SD claim (= a worker
-  // about to abandon in-progress work). A claim-less interactive session is never reminded.
-  return Boolean(hasActiveClaim);
+
+  // WORKER GATE (FR-4). Worker-shape is a CLAIM or a live loop state — NOT an announcement.
+  // This is what keeps operators safe, and it replaces the old windDownSignaled allow-path,
+  // which returned false for ANY session that merely said "winding down". That allow-path was
+  // simultaneously too wide and too narrow: it let a worker talk its way out of the arm
+  // requirement, and (shouldParkRecoverable:112, same defect) it parked operators into
+  // awaiting_tick, where an aged-out window then blocked THEIR turn-end.
+  const isWorker = Boolean(hasActiveClaim)
+    || loopState === LOOP_STATE_ACTIVE
+    || loopState === LOOP_STATE_AWAITING_TICK;
+  if (!isWorker) return false;
+
+  // ARM EVIDENCE (FR-3). ONLY an actual ScheduleWakeup tool_use in the CURRENT turn excuses the
+  // stop. An announcement does not — not a /signal saying "wakeup armed", not loop_state, not
+  // metadata. That is Charlie's false positive, and it is the whole point of this predicate:
+  // the old one read loop_state='awaiting_tick', which post-tool-loop-state.cjs sets from the
+  // worker's own claim about itself, so the enforcement was asking the suspect for an alibi.
+  if (armVerdict === 'armed') return false;
+  if (armVerdict === 'unarmed') return true;
+  // 'unknown' — no boundary in the tail window, or no transcript. Absence of evidence is not
+  // evidence of absence: fail open rather than trap a worker on an unreadable transcript.
+  return false;
 }
 
 function isFlagEnabled() {
@@ -173,7 +218,13 @@ async function parkSessionRecoverable(sessionId) {
  * @param {{ windDownSignaled?:boolean, stopHookActive?:boolean, hasActiveClaim?:boolean, loopState?:string|null }} args
  * @returns {'signaled'|'second_stop'|'turn_end_with_claim_wakeup_scheduled'|'turn_end_wakeup_scheduled'|'turn_end_with_claim_no_wakeup'|'no_claim_idle'}
  */
-function classifyWindDownReason({ windDownSignaled, stopHookActive, hasActiveClaim, loopState } = {}) {
+function classifyWindDownReason({ windDownSignaled, stopHookActive, hasActiveClaim, loopState, armVerdict } = {}) {
+  // STEP A — THE COUNTABLE IGNORE. A worker that reached a SECOND stop while still carrying no
+  // arm evidence saw the reminder and stopped anyway. This is the population step A cannot save
+  // (the anti-infinite-loop guard lets it through) and the exact population step C exists for.
+  // Counted before 'signaled' so an announcement cannot mask it — announcing is what these
+  // workers do INSTEAD of arming, and folding them into 'signaled' would hide the whole class.
+  if (stopHookActive && armVerdict === 'unarmed' && hasActiveClaim) return 'second_stop_still_unarmed';
   if (windDownSignaled) return 'signaled';
   if (stopHookActive) return 'second_stop';
   if (loopState === LOOP_STATE_AWAITING_TICK) {
@@ -225,6 +276,10 @@ async function recordWindDown(supabase, sessionId, { reason, hadClaim } = {}) {
 }
 
 const REMINDER = [
+  'NO ScheduleWakeup tool_use found in THIS turn. This is read from the transcript, not from any',
+  'state you set: saying "wakeup armed" in a /signal, or having loop_state=awaiting_tick, does NOT',
+  'satisfy it. Only calling the tool does. If you believe you armed one, you armed it in a PREVIOUS',
+  'turn — that is the stale-arm case this check exists to catch.',
   'Worker stopping with NO ScheduleWakeup armed — you will go INCOGNITO and strand your claimed SD',
   '(the worktree then gets reaped by the claim-sweep). Run the WIND-DOWN HANDSHAKE before you stop:',
   "  1. If you hold an IN-PROGRESS SD: FINISH it or hand it off — never leave it half-done + unclaimed (orphan).",
@@ -291,15 +346,9 @@ async function main() {
     const sessionId = payload.session_id || process.env.CLAUDE_SESSION_ID || process.env.SESSION_ID || '';
     if (!sessionId) { return shutdown(); }       // can't resolve — fail-open
 
-    // STDOUT IS THE DECISION CHANNEL. Requiring the supabase client loads dotenv, which writes an
-    // 80-byte "◇ injected env …" banner to STDOUT — MEASURED 2026-08-02, and PRE-EXISTING (git HEAD
-    // already required this module at the same point). That put a non-JSON preamble in front of
-    // every block decision this hook has ever emitted; it is the only blocking Stop hook that
-    // requires supabase-client, and therefore the only one with a polluted channel. Whether Claude
-    // Code tolerates the preamble is unverified — but a decision document that MIGHT not parse, on
-    // the hook every seat traverses every turn, is exactly the silent-failure shape this SD exists
-    // to remove. Muzzled synchronously around the require; stderr is untouched.
-    const { createSupabaseServiceClient } = muzzleStdout(() => require('../../lib/supabase-client.cjs'));
+    // (stdout is muzzled at module load — see the header. This require is one of at least two
+    // that print a dotenv banner; the park path carries another.)
+    const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
     const supabase = createSupabaseServiceClient();
     const { data, error } = await supabase
       .from('claude_sessions')
@@ -361,6 +410,8 @@ async function main() {
     // add 2.5s to every operator turn-end to measure a population it is not in. Same predicate as
     // the park below, so the observation covers exactly the seats the enforcement will act on.
     const workerShaped = shouldParkRecoverable({ loopState, hasActiveClaim, windDownSignaled });
+    let armVerdict;                       // undefined ⇒ not evaluated ⇒ treated as 'unknown'
+    let armObservation = null;
     if (!enforcementDisabled && workerShaped && payload.transcript_path) {
       try {
         const fs = require('fs');
@@ -369,17 +420,22 @@ async function main() {
           if (!fs.existsSync(payload.transcript_path)) return { verdict: 'unknown', reason: 'transcript absent', armCount: 0 };
           return armEvidence.findArmInCurrentTurn(readTailEntries(payload.transcript_path));
         };
-        const obs = await armEvidence.awaitStableVerdict({ read, sleep: (ms) => new Promise((r) => setTimeout(r, ms)) });
-        process.stderr.write(armEvidence.formatPendingWake(obs, { sessionId }));
+        armObservation = await armEvidence.awaitStableVerdict({ read, sleep: (ms) => new Promise((r) => setTimeout(r, ms)) });
+        armVerdict = armObservation.stable && armObservation.stable.verdict;
+        process.stderr.write(armEvidence.formatPendingWake(armObservation, { sessionId }));
       } catch (e) {
+        // Fail-open: an unreadable transcript leaves armVerdict undefined ⇒ never blocks.
         process.stderr.write(`[stop-loop-wakeup-reminder] pending-wake observe (non-fatal): ${e.message}\n`);
       }
     }
 
-    if (shouldRemind({ loopState, stopHookActive, flagEnabled, hasActiveClaim, windDownSignaled })) {
+    if (shouldRemind({ armVerdict, loopState, stopHookActive, flagEnabled, enforcementDisabled, hasActiveClaim })) {
       // BLOCK — the worker must arm its OWN ScheduleWakeup; do not park on its behalf (parking here
       // would let it cold-exit anyway by satisfying the recoverable-state check it should set itself).
-      process.stdout.write(JSON.stringify({ decision: 'block', reason: REMINDER }));
+      // The block reason is the ONLY channel that reaches the model, so the pending-wake state
+      // rides here rather than on stderr (which the model never sees on a blocking Stop).
+      const detail = armObservation ? `\n${armEvidence.formatPendingWake(armObservation, { sessionId }).trim()}` : '';
+      emitDecision({ decision: 'block', reason: REMINDER + detail });
       return shutdown();
     }
     // ALLOW-PATH (SD-LEO-INFRA-WORKER-ENGAGEMENT-ARM-PARK-001): the stop is allowed — windDownSignaled
@@ -391,7 +447,7 @@ async function main() {
       // SD-LEO-INFRA-WORKER-WINDDOWN-SURVEY-001 (a)+(c): capture WHY this worker wound down
       // (same worker-gate as the park, so no false telemetry on a non-worker operator session).
       await recordWindDown(supabase, sessionId, {
-        reason: classifyWindDownReason({ windDownSignaled, stopHookActive, hasActiveClaim, loopState }),
+        reason: classifyWindDownReason({ windDownSignaled, stopHookActive, hasActiveClaim, loopState, armVerdict }),
         hadClaim: hasActiveClaim,
       });
     }

--- a/tests/unit/hooks/stop-loop-park-recoverable.test.js
+++ b/tests/unit/hooks/stop-loop-park-recoverable.test.js
@@ -33,18 +33,33 @@ describe('shouldParkRecoverable (SD-LEO-INFRA-WORKER-ENGAGEMENT-ARM-PARK-001)', 
   });
 });
 
+// SEPARATION OF CONCERNS (unchanged by step A): blocking and parking are independent decisions.
+// A stop that is ALLOWED through must still leave the worker parked-recoverable, or it cold-exits
+// to zero. Step A changes only what BLOCKS; every park assertion below is untouched.
 describe('shouldRemind allow-paths still allow (then the caller parks)', () => {
-  const base = { flagEnabled: true, stopHookActive: false, hasActiveClaim: true };
-  it('windDownSignaled → no block (allow-path), but the worker holds a claim → will be parked', () => {
-    expect(shouldRemind({ ...base, loopState: 'active', windDownSignaled: true })).toBe(false);
+  const base = { flagEnabled: true, stopHookActive: false, hasActiveClaim: true, armVerdict: 'unarmed' };
+
+  // REWRITTEN for step A. This case used to assert that ANNOUNCING a wind-down suppressed the
+  // block. It no longer does — that was Charlie's false positive. The worker is blocked, and is
+  // still parked recoverable, which is the invariant this file actually guards.
+  it('windDownSignaled no longer excuses an unarmed worker, but the park is unaffected', () => {
+    expect(shouldRemind({ ...base, loopState: 'active', windDownSignaled: true })).toBe(true);
     expect(shouldParkRecoverable({ loopState: 'active', hasActiveClaim: true, windDownSignaled: true })).toBe(true);
   });
+
   it('second-stop (stopHookActive) → no block (allow-path), claim-holder → parked', () => {
     expect(shouldRemind({ ...base, loopState: 'active', stopHookActive: true })).toBe(false);
     expect(shouldParkRecoverable({ loopState: 'active', hasActiveClaim: true })).toBe(true);
   });
-  it('a still-active loop worker (no wind-down, first stop) is BLOCKED (not yet an allow-path)', () => {
-    expect(shouldRemind({ flagEnabled: true, stopHookActive: false, hasActiveClaim: false, loopState: 'active', windDownSignaled: false })).toBe(true);
+
+  it('an unarmed loop worker at first stop is BLOCKED (not yet an allow-path)', () => {
+    expect(shouldRemind({ flagEnabled: true, stopHookActive: false, hasActiveClaim: false, loopState: 'active', armVerdict: 'unarmed' })).toBe(true);
+  });
+
+  // The allow-path that remains: real arm evidence. It is allowed AND parked.
+  it('a genuinely armed worker is allowed through and still parked recoverable', () => {
+    expect(shouldRemind({ ...base, loopState: 'active', armVerdict: 'armed' })).toBe(false);
+    expect(shouldParkRecoverable({ loopState: 'active', hasActiveClaim: true })).toBe(true);
   });
 });
 
@@ -124,5 +139,40 @@ describe('classifyWindDownReason (SD-LEO-INFRA-WORKER-WINDDOWN-SURVEY-001)', () 
     for (const loopState of ['active', null, 'exited', 'unknown']) {
       expect(classifyWindDownReason({ hasActiveClaim: false, loopState })).toBe('no_claim_idle');
     }
+  });
+
+  // STEP A — THE COUNTABLE IGNORE. The block fires once; a worker that stops again passes through
+  // the anti-infinite-loop guard, and for this dormancy there IS no later turn to re-block. So
+  // step A cannot compel — it can only count how often a reminder was seen and ignored, which is
+  // the evidence base for step C (auto-arm). If this value never appears, step C is unjustified;
+  // if it dominates, the nudge is insufficient and step C is the whole fix.
+  describe("'second_stop_still_unarmed' — the population step A cannot save", () => {
+    const ignored = { stopHookActive: true, armVerdict: 'unarmed', hasActiveClaim: true };
+
+    it('a claim-holder that reached a second stop still unarmed is counted distinctly', () => {
+      expect(classifyWindDownReason(ignored)).toBe('second_stop_still_unarmed');
+    });
+
+    // Announcing is what these workers do INSTEAD of arming, so 'signaled' must not absorb them.
+    it('outranks the wind-down announcement, which would otherwise mask the whole class', () => {
+      expect(classifyWindDownReason({ ...ignored, windDownSignaled: true })).toBe('second_stop_still_unarmed');
+    });
+
+    it('a second stop that DID arm is ordinary second_stop, not an ignore', () => {
+      expect(classifyWindDownReason({ ...ignored, armVerdict: 'armed' })).toBe('second_stop');
+    });
+
+    it('an unreadable transcript is not counted as an ignore', () => {
+      expect(classifyWindDownReason({ ...ignored, armVerdict: 'unknown' })).toBe('second_stop');
+      expect(classifyWindDownReason({ ...ignored, armVerdict: undefined })).toBe('second_stop');
+    });
+
+    it('a claim-less session is never counted as an ignore', () => {
+      expect(classifyWindDownReason({ ...ignored, hasActiveClaim: false })).toBe('second_stop');
+    });
+
+    it('only fires on the SECOND stop — a first stop is still a live block, not an ignore', () => {
+      expect(classifyWindDownReason({ ...ignored, stopHookActive: false, loopState: 'active' })).toBe('turn_end_with_claim_no_wakeup');
+    });
   });
 });


### PR DESCRIPTION
**Stacked on #6741 (step 0).** Review that first — this PR's base is the step-0 branch, so the diff here is step A alone.

The block predicate moves from `loop_state` to a `ScheduleWakeup` tool_use found in the **current turn's** transcript.

## The old predicate asked the suspect for an alibi

`loop_state='awaiting_tick'` is set by `post-tool-loop-state.cjs` from the worker's *own claim about itself*. A worker that believed it had armed — or merely said so — satisfied the check without the tool ever being called. That is Charlie's false positive, now reproduced deliberately:

| specimen (all success-shaped) | verdict | blocks? |
|---|---|---|
| work done, tests green, long summary, no arm | `unarmed` | ✅ |
| text says `"wakeup-armed +900s"` | `unarmed` | ✅ |
| …and `loop_state='awaiting_tick'` agrees | `unarmed` | ✅ |
| real arm, but in the **previous** turn (stale) | `unarmed` | ✅ |
| armed **before** the summary | `armed` | allow |
| `ScheduleWakeup({stop:true})` loop-end | `armed` | allow |

Verified **end to end against the live hook**, not only in unit tests: unarmed → block, stale → block, armed → allow with stdout exactly **0 bytes**.

## The `windDownSignaled` allow-path is gone

It returned false for *any* session that said "winding down" — simultaneously **too wide** (a worker talks its way out of arming) and **too narrow** (`shouldParkRecoverable:112`, same defect, parked *operators* into `awaiting_tick`, where an aged-out window then blocked their turn-end — the live FR-4 defect). Operator safety now rests on worker **shape** (a claim or a live loop state), which an announcement cannot fake.

## What step A cannot do — stated plainly

It blocks **once**. A worker that stops again passes through the anti-infinite-loop guard, and for this dormancy **there is no later turn to re-block** — the seat is already gone. So this is a nudge, not a compulsion, and a debt marker would be dead machinery because it could never be consumed.

What ships instead is a **count**: `classifyWindDownReason` gains `second_stop_still_unarmed`, ordered *above* `signaled` so an announcement cannot mask the class. That number is how often a reminder was seen and ignored — the evidence base for step C. **If it never appears, step C is unjustified.**

## Step 0's stdout fix was an instance fix, not a class fix

I muzzled the one require I had measured. The **allow path still emitted 87 bytes** from a different transitive require (`park-worker` / `emit-feedback`) — caught only by running it end to end. The muzzle now installs at **module load** before any require, and stdout is restored solely to emit the decision. Made structural and countable: `REAL_STDOUT_WRITE` has exactly one call site, inside `emitDecision`, with a test asserting the muzzle is armed before the first require.

Pending-wake state now rides in the block **reason** — on a blocking Stop that is the only channel reaching the model.

## Test changes are deliberate, not accommodation

`TS-8` asserted `awaiting_tick` was an escape even for a claim-holder — exactly the hole this closes. The wind-down allow-path suite asserted the false positive as desired behaviour. Both rewritten with reasoning inline rather than deleted.

**782 tests pass.** One **pre-existing** failure remains in `tests/unit/hooks/session-register-created-emission.test.js` — unrelated file, unmodified in my tree, failing at HEAD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)