### PR TITLE
fix(QF-20260802-245): run-stage.js never exited after a successful real-mode run

### DIFF
--- a/scripts/eva/run-stage.js
+++ b/scripts/eva/run-stage.js
@@ -84,7 +84,7 @@ const inlineMode = args.includes('--inline');
 const persistJson = getArg('--persist');
 
 if (!ventureId || !stageNumber) {
-  console.error('Usage: node scripts/eva/run-stage.js --venture-id <UUID> --stage <N> [--dry-run] [--inline] [--persist <JSON>] [--check]');
+  console.error('Usage: node scripts/eva/run-stage.js --venture-id <UUID> --stage <N> [--dry-run] [--inline] [--persist <JSON>] [--check] [--verbose]');
   process.exit(1);
 }
 
@@ -130,7 +130,15 @@ console.log('');
 
   // 2. Execute stage
   console.log('⚡ Step 2: Stage Execution');
-  const silentLogger = { log: () => {}, warn: console.warn, error: console.error };
+  // QF-20260802-245: --verbose surfaces the engine's own progress lines. They were unconditionally
+  // discarded (log: () => {}), which is WHY the 10-minute block was unlabeled: executeStage logs
+  // onBeforeAnalysis, the chairman-gate outcome, post-contract validation, EVA keys, persist and
+  // stage-work sync — every one of which would have located the stall immediately. Kept OFF by
+  // default so existing callers' output is byte-identical; opt in when diagnosing.
+  const verbose = args.includes('--verbose');
+  const silentLogger = verbose
+    ? { log: console.log, warn: console.warn, error: console.error }
+    : { log: () => {}, warn: console.warn, error: console.error };
   const result = await executeStage({ stageNumber, ventureId, dryRun, logger: silentLogger });
 
   console.log(`   Template: ${result.template}`);
@@ -155,6 +163,26 @@ console.log('');
   }
 
   console.log('');
+
+  // QF-20260802-245: EXIT EXPLICITLY. Without this the async IIFE resolves and the process
+  // survives until Node's event loop drains — which it never does, because real mode opens
+  // Supabase connections dry-run skips (resolveEvaKeys, persistArtifact, syncStageWork,
+  // processLifecycleTerminal are all !dryRun-guarded) and their undici keep-alive sockets hold
+  // the loop open.
+  //
+  // MEASURED, NOT INFERRED: a real-mode stage-5 run completed in 28.3s with validation PASS,
+  // updated venture_artifacts 5f1d42f5 and venture_stage_work in place — and then sat until a
+  // 150s timeout killed it. The operator who filed this saw a ">10 minute silent block with zero
+  // rows written" and reasonably concluded the stage was hanging pre-persist. IT HAD ALREADY
+  // FINISHED. The rows looked absent because this path UPDATES existing artifacts (the is_current
+  // dedup at artifact-persistence-service.js:97-120 returns the existing id), so created_at and
+  // new-row counts are correctly unchanged while the write genuinely lands.
+  //
+  // CLAUDE.md documents this identical pattern for add-prd-to-database
+  // (SD-LEO-INFRA-ADD-PRD-EXIT-CODE-SUCCESS-001): lingering supabase/undici handles hold the loop
+  // until Bash SIGTERMs the process (exit 143) AFTER the writes landed, so callers mis-read a
+  // success as a failure. Same fix, same reason.
+  process.exit(0);
 })().catch(err => {
   console.error(`\n❌ Stage execution failed: ${err.message}`);
   process.exit(1);

--- a/tests/unit/eva/run-stage-exit.test.js
+++ b/tests/unit/eva/run-stage-exit.test.js
@@ -1,0 +1,96 @@
+/**
+ * QF-20260802-245 — run-stage.js must EXIT after a successful run, and must be able to say what
+ * it is doing.
+ *
+ * THE FAILURE THIS PINS: a real-mode stage-5 run for venture 50763b6a completed in 28.3s with
+ * validation PASS and wrote its artifact + venture_stage_work in place — then sat until a shell
+ * timeout killed it. The operator saw ">10 minutes, zero rows written" and reasonably concluded
+ * the stage was hanging pre-persist. It had already finished. Two independent causes:
+ *
+ *   1. NO process.exit(0) on the success path. Real mode opens Supabase connections dry-run skips
+ *      (resolveEvaKeys / persistArtifact / syncStageWork / processLifecycleTerminal are all
+ *      !dryRun-guarded); their undici keep-alive handles hold the event loop open forever.
+ *      Measured: EXIT=124 (killed at 150s) before, EXIT=0 (clean at ~29s) after.
+ *
+ *   2. The engine's logger was hard-silenced (log: () => {}), so the one line that contained the
+ *      whole answer — "[stage-work-sync] venture_stage_work synced for stage 5 (status: blocked,
+ *      advisory_data: 28 keys)" — was discarded. A check that CAN distinguish the hypotheses is
+ *      worthless if its output is thrown away for tidiness.
+ *
+ * Asserted on CODE with comments stripped: this file's own comments quote the removed
+ * `log: () => {}` verbatim, so a raw-text match would pass on its own explanation. That mistake
+ * was made twice earlier in this session.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const SRC = readFileSync(resolve(REPO_ROOT, 'scripts/eva/run-stage.js'), 'utf8');
+const CODE = SRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+describe('the process must exit after a successful run', () => {
+  it('calls process.exit(0) on the success path', () => {
+    expect(CODE).toMatch(/process\.exit\(0\)/);
+  });
+
+  it('the success exit is INSIDE the async IIFE, not after it', () => {
+    // If it sat outside, it would fire before the awaited work finished and truncate the run.
+    const iifeStart = CODE.indexOf('(async () => {');
+    const catchStart = CODE.indexOf('})().catch');
+    const exitZero = CODE.indexOf('process.exit(0)', iifeStart);
+    expect(iifeStart).toBeGreaterThan(-1);
+    expect(catchStart).toBeGreaterThan(iifeStart);
+    expect(exitZero).toBeGreaterThan(iifeStart);
+    expect(exitZero).toBeLessThan(catchStart);
+  });
+
+  it('still exits non-zero on failure — the error path is unchanged', () => {
+    expect(CODE).toMatch(/Stage execution failed[\s\S]{0,120}process\.exit\(1\)/);
+  });
+
+  it('CONTROL: the stripper did not empty the file', () => {
+    // Without this, every assertion above could pass vacuously on an empty string.
+    expect(CODE).toMatch(/executeStage\(/);
+    expect(CODE.length).toBeGreaterThan(500);
+  });
+});
+
+describe('a block must never again be unlabeled', () => {
+  it('--verbose surfaces the engine progress lines that were being discarded', () => {
+    expect(CODE).toMatch(/--verbose/);
+    expect(CODE).toMatch(/verbose[\s\S]{0,120}log:\s*console\.log/);
+  });
+
+  it('default output is unchanged — verbose is OPT-IN', () => {
+    // Existing callers must see byte-identical output; diagnosability is not worth a surprise
+    // regression in anything parsing this script's stdout.
+    expect(CODE).toMatch(/log:\s*\(\)\s*=>\s*\{\}/);
+  });
+
+  it('--verbose is documented in the usage line', () => {
+    expect(CODE).toMatch(/Usage:[\s\S]{0,200}--verbose/);
+  });
+});
+
+describe('SCOPE: the chairman-gate question is NOT decided here', () => {
+  it('this change does not add an onBeforeAnalysis to stage-05', () => {
+    // The venture stays stage_status=blocked because stage-05 defines no onBeforeAnalysis, so no
+    // chairman_decisions row is ever created and the gate branch at stage-execution-engine.js:576
+    // is skipped entirely. Whether stage 5 SHOULD be a gate stage is a governance decision, not a
+    // bug fix — deliberately left to the coordinator. This test exists so a later reader does not
+    // mistake this QF for having resolved it.
+    const stage05 = readFileSync(
+      resolve(REPO_ROOT, 'lib/eva/stage-templates/analysis-steps/stage-05-financial-model.js'), 'utf8');
+    expect(stage05).not.toMatch(/onBeforeAnalysis/);
+  });
+
+  it('the engine gate branch is untouched by this QF', () => {
+    const engine = readFileSync(resolve(REPO_ROOT, 'lib/eva/stage-execution-engine.js'), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    // Still guarded on a decision id, still bounded — neither was the cause and neither changed.
+    expect(engine).toMatch(/if \(beforeAnalysisContext\.chairmanDecisionId && output\)/);
+    expect(engine).toMatch(/timeoutMs:\s*5000/);
+  });
+});


### PR DESCRIPTION
## What broke

A real-mode stage-5 run for venture `50763b6a` (Image Alt Text Generator, W2-E critical path) finished in **28.3s** with `Validation: ✅ PASS` and wrote both `venture_artifacts` (`5f1d42f5`) and `venture_stage_work` — then sat until the shell timed out and SIGTERMed it. The filed symptom was ">10 minutes, zero rows written," read as a pre-persist hang. **It had already finished.**

## Two independent causes, both fixed

**1. No `process.exit(0)` on the success path.** Real mode opens Supabase connections that dry-run skips (`resolveEvaKeys` / `persistArtifact` / `syncStageWork` / `processLifecycleTerminal` are all `!dryRun`-guarded); their undici keep-alive handles hold the event loop open indefinitely.

| | exit code | wall clock |
|---|---|---|
| before | **124** (killed at 150s) | never returns |
| after | **0** | ~29s |

Same failure and same fix as `SD-LEO-INFRA-ADD-PRD-EXIT-CODE-SUCCESS-001` for `add-prd-to-database`.

**2. The engine logger was hard-silenced** (`log: () => {}`), discarding the one line that contained the whole answer:

```
[stage-work-sync] venture_stage_work synced for stage 5 (status: blocked, advisory_data: 28 keys)
```

`--verbose` now surfaces it. **OFF by default** so existing callers' stdout is byte-identical.

## On the "zero rows written" reading

That was itself a measurement artifact. This path **UPDATEs** via the `is_current` dedup at `artifact-persistence-service.js:97-120`, so `created_at` and new-row counts are correctly unchanged while the write genuinely lands. `updated_at` is the discriminating column — it read 7 minutes old at the time the rows were being called absent.

## Deliberately NOT fixed here

The venture stays `stage_status=blocked` because `stage-05-financial-model.js` defines **no `onBeforeAnalysis`** (only stages 01, 10, 16, 18 do), so no `chairman_decisions` row is created, the gate branch at `stage-execution-engine.js` is skipped, and `_gateApproved` is false.

Whether stage 5 *should* be a gate stage is a governance decision, not a bug fix — left to the coordinator. Both original QF suspects were refuted: the gate branch is guarded by `chairmanDecisionId` and `waitForDecision` is bounded at `timeoutMs: 5000` in a try/catch; `syncStageWork` did run and did write.

A test pins that boundary so a later reader does not mistake this QF for having resolved it.

## Verification

9 tests, **verified by mutation** — each mutant kills a distinct test:

| mutant | result |
|---|---|
| remove the success-path `process.exit(0)` | ✅ kills the IIFE-position test |
| disable the `--verbose` branch | ✅ kills the `--verbose` test |

Assertions run against comment-stripped source: the file's own comments quote the removed `log: () => {}` verbatim, so a raw-text match would pass on its own explanation.

Scope: **6 non-comment production lines.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
