### PR TITLE
fix(QF-20260802-742): scope schema-reference-lint to the PR's own NEW drift

### DIFF
--- a/.github/workflows/schema-reference-lint.yml
+++ b/.github/workflows/schema-reference-lint.yml
@@ -59,7 +59,13 @@ jobs:
         env:
           SCHEMA_LINT_BASE: origin/${{ github.base_ref }}
         run: |
-          git fetch origin ${{ github.base_ref }} --depth=1 || true
+          # QF-20260802-742: do NOT re-shallow the base ref. checkout@v4 above already fetched
+          # FULL history (fetch-depth: 0); `--depth=1` here truncated that ref back to a single
+          # commit and wrote a .git/shallow boundary, which cripples `git merge-base` — the base
+          # of the PR becomes uncomputable and the diff widens to include main's own commits.
+          # That is the "merge-commit widening" half of this QF, and it was self-inflicted one
+          # line after the full fetch that would have prevented it.
+          git fetch origin ${{ github.base_ref }} || true
           node scripts/lint/schema-reference-lint.mjs --diff | tee lint-output.txt
           exit_code=${PIPESTATUS[0]}
           {

--- a/scripts/lint/schema-lint-scope.mjs
+++ b/scripts/lint/schema-lint-scope.mjs
@@ -1,0 +1,62 @@
+/**
+ * Pure scope/baseline helpers for the schema-reference lint.
+ * QF-20260802-742.
+ *
+ * THE FAILURE THIS ENCODES: the lint blocked PR #6738 on 33 violations with ZERO in its own
+ * 12-file diff, and its scan scope drifted 79 -> 140 files across two runs 24 minutes apart with
+ * the violation count pinned. Two independent mechanisms, both of which produce violations the
+ * PR did not introduce:
+ *
+ *   1. SCOPE INFLATION — the file set unioned staged + working-tree + untracked files on the
+ *      stated assumption that "the latter two are empty in CI". They are not: CI checkout
+ *      renormalises line endings, so every CRLF-affected file appears as an unstaged
+ *      modification and joins the PR's scope (measured: a 5-file diff -> a 33-file checked set).
+ *
+ *   2. BACKLOG INHERITANCE — violations were counted per FILE. main carries ~378 violations in
+ *      --all mode, so any PR touching an affected file inherited that file's old violations as
+ *      its own. The class fires on BRANCH AGE and on which files you happened to touch, not on
+ *      anything the author did.
+ *
+ * partitionViolations() fixes (2) and, as a side effect, disarms (1): a merely renormalised file
+ * has byte-identical violations at both ends, so every one of them classifies as pre-existing.
+ *
+ * Kept pure (no fs, no git, no DB) so both polarities are testable from fixtures — the lint's own
+ * exit helper (schema-lint-exit.mjs) established this shape.
+ */
+
+/**
+ * Identity of a violation for baseline comparison.
+ *
+ * DELIBERATELY EXCLUDES `line`. A violation that merely shifted because unrelated code was
+ * inserted above it is the SAME violation. Keying on line would re-classify every pre-existing
+ * violation as new the moment a PR touches the file — which is precisely the punish-the-toucher
+ * behaviour this QF removes, reintroduced through the back door.
+ *
+ * @param {{file:string,type:string,table:string,column?:string,kind:string}} v
+ * @returns {string}
+ */
+export function violationKey(v) {
+  return `${v.file}|${v.type}|${v.table}|${v.column || ''}|${v.kind}`;
+}
+
+/**
+ * Split violations found at HEAD into NEW drift (blocks) and pre-existing (reports only).
+ *
+ * @param {Array<object>} violations — violations found in the current working copy
+ * @param {Set<string>|null} baselineKeys — violationKey()s present at the merge base.
+ *        `null` means NO BASELINE IS AVAILABLE (an --all sweep, or a degraded --diff whose base
+ *        could not be resolved). In that case nothing can be proven pre-existing, so every
+ *        violation is returned as new and the caller's existing degraded/advisory rules decide
+ *        whether that blocks. Treating an absent baseline as "everything is pre-existing" would
+ *        silently disable the lint on exactly the runs that already lost their footing.
+ * @returns {{newViolations:Array<object>, preExisting:Array<object>}}
+ */
+export function partitionViolations(violations, baselineKeys) {
+  const newViolations = [];
+  const preExisting = [];
+  for (const v of violations || []) {
+    if (baselineKeys && baselineKeys.has(violationKey(v))) preExisting.push(v);
+    else newViolations.push(v);
+  }
+  return { newViolations, preExisting };
+}

--- a/scripts/lint/schema-reference-lint.mjs
+++ b/scripts/lint/schema-reference-lint.mjs
@@ -28,6 +28,8 @@ import { extractReferences, findViolations } from './schema-reference-extract.mj
 // SD-LEO-INFRA-SCHEMA-LINT-DEGRADED-FAILOPEN-001: a degraded --diff run (unresolvable base ->
 // whole-repo fallback) is ADVISORY and must not block; the pure helper encodes that exit rule.
 import { computeExitCode } from './schema-lint-exit.mjs';
+// QF-20260802-742: the new-vs-pre-existing split, kept pure so both polarities are fixture-testable.
+import { violationKey, partitionViolations } from './schema-lint-scope.mjs';
 
 const SNAPSHOT_PATH = 'database/schema-reference-snapshot.json';
 const ALLOWLIST_PATH = 'scripts/lint/schema-reference-allowlist.json';
@@ -47,6 +49,14 @@ const alertOnDrift = args.includes('--alert');
 // A full sweep re-surfaces the pre-existing phantom backlog (not NEW drift), so we must NOT fire a
 // critical schema-drift alert on it (adversarial-review finding) — only a genuine diff-scoped result is.
 let degradedFallback = false;
+// QF-20260802-742: the merge-base SHA a --diff run scoped itself to. Printed in every report so a
+// disputed scan scope is auditable, and used as the baseline for the new-vs-pre-existing split.
+let mergeBase = null;
+// QF-20260802-742: in CI the working tree is not a developer's — it is a fresh checkout whose only
+// "local modifications" are line-ending renormalisations. Scope to COMMITTED changes there.
+// --committed-only forces it anywhere; --include-worktree opts back in for debugging a CI run.
+const committedOnly = args.includes('--committed-only')
+  || (!!process.env.CI && !args.includes('--include-worktree'));
 
 function loadJson(p, fallback) {
   try { return JSON.parse(readFileSync(p, 'utf8')); } catch { return fallback; }
@@ -73,14 +83,37 @@ function candidateFiles() {
   if (mode === 'diff') {
     try {
       const base = process.env.SCHEMA_LINT_BASE || 'origin/main';
-      // Committed changes vs the merge base + staged + working-tree changes —
-      // the latter two are empty in CI but make local pre-push linting correct.
-      const out = [
-        execSync(`git diff --name-only --diff-filter=ACMR ${base}...HEAD`, { encoding: 'utf8', timeout: 30000 }),
-        execSync('git diff --name-only --diff-filter=ACMR --cached', { encoding: 'utf8', timeout: 30000 }),
-        execSync('git diff --name-only --diff-filter=ACMR', { encoding: 'utf8', timeout: 30000 }),
-        execSync('git ls-files --others --exclude-standard', { encoding: 'utf8', timeout: 30000 }),
-      ].join('\n');
+      // QF-20260802-742: resolve the merge base EXPLICITLY instead of leaning on the `...`
+      // shorthand. The SHA becomes printable, so two runs whose scope is disputed can be
+      // compared directly — on PR #6738 the checked set drifted 79 -> 140 files across 24
+      // minutes with the violation count pinned, and there was no way to tell which run was
+      // right. An explicit two-dot diff from that SHA also cannot widen if origin/main
+      // advances between the fetch and the diff.
+      mergeBase = execSync(`git merge-base ${base} HEAD`, { encoding: 'utf8', timeout: 30000 }).trim();
+      // QF-20260802-742: git merge-base exits 1 with no common ancestor (verified against a
+      // deliberately shallowed clone), so the throw above normally covers it. This guard closes
+      // the exit-0-but-empty case explicitly: a falsy mergeBase would make every baseline lookup
+      // return null, and EVERY pre-existing violation would then read as new — the original bug,
+      // silently restored. Routed into the same catch so it degrades to advisory, never blocks.
+      if (!mergeBase) throw new Error(`merge-base ${base}..HEAD resolved empty (shallow clone?)`);
+      const sources = [
+        execSync(`git diff --name-only --diff-filter=ACMR ${mergeBase}..HEAD`, { encoding: 'utf8', timeout: 30000 }),
+      ];
+      // QF-20260802-742: the previous code ALWAYS unioned staged + working-tree + untracked
+      // files, on the stated assumption that "the latter two are empty in CI". They are not.
+      // CI checkout renormalises line endings, so every CRLF-affected file surfaces as an
+      // unstaged modification and joins this PR's scope — the measured 5-file -> 33-file
+      // inflation that blocked #6738 on 33 violations with ZERO in its own 12-file diff.
+      // Locally they are genuinely wanted for pre-push linting, so they are dropped only
+      // where the working tree is not the developer's: CI.
+      if (!committedOnly) {
+        sources.push(
+          execSync('git diff --name-only --diff-filter=ACMR --cached', { encoding: 'utf8', timeout: 30000 }),
+          execSync('git diff --name-only --diff-filter=ACMR', { encoding: 'utf8', timeout: 30000 }),
+          execSync('git ls-files --others --exclude-standard', { encoding: 'utf8', timeout: 30000 }),
+        );
+      }
+      const out = sources.join('\n');
       return [...new Set(out.split('\n').map(s => s.trim()).filter(Boolean))]
         .filter(f => CODE_RE.test(f))
         .filter(f => RUNTIME_DIRS.includes(f.split('/')[0]))
@@ -112,8 +145,27 @@ function candidateFilesAll() {
   return out;
 }
 
+/** Violations already present in `file` at the merge base. null when there is no baseline. */
+function baselineViolationKeys(file) {
+  if (!mergeBase) return null; // --all sweep or degraded fallback: nothing to compare against
+  let prev;
+  try {
+    prev = execSync(`git show ${mergeBase}:${file}`, {
+      encoding: 'utf8', timeout: 30000, maxBuffer: 32 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    return new Set(); // file did not exist at the merge base -> every violation in it is genuinely new
+  }
+  return new Set(
+    findViolations(extractReferences(prev, file), snapshot)
+      .filter(v => !allowedTables.has(v.table))
+      .map(violationKey)
+  );
+}
+
 const files = candidateFiles();
-const allViolations = [];
+const allViolations = [];   // NEW drift — blocks
+const preExisting = [];     // present at the merge base — reported, never blocks
 for (const file of files) {
   if (allowedFiles.has(file)) continue;
   let text;
@@ -121,7 +173,15 @@ for (const file of files) {
   const refs = extractReferences(text, file);
   const violations = findViolations(refs, snapshot)
     .filter(v => !allowedTables.has(v.table));
-  allViolations.push(...violations);
+  if (violations.length === 0) continue;
+  // QF-20260802-742: split per VIOLATION, not per file. A PR that legitimately touches a file
+  // carrying old violations must not inherit them — that is how main's ~378-violation backlog
+  // became individual PRs' problem. This also disarms the CRLF mechanism on its own: a merely
+  // renormalised file has byte-identical violations at both ends, so all of them classify as
+  // pre-existing and none block.
+  const split = partitionViolations(violations, baselineViolationKeys(file));
+  allViolations.push(...split.newViolations);
+  preExisting.push(...split.preExisting);
 }
 
 // FR-C1: opt-in breakage surfacing — emit ONE schema-drift system_alerts row ONLY for a genuine
@@ -139,10 +199,18 @@ if (alertOnDrift && allViolations.length > 0 && mode === 'diff' && !degradedFall
   });
 }
 
+// QF-20260802-742: the scan scope, stated on every run. Two runs of the same head+base must
+// report the same merge_base and the same files_checked; when they do not, this line is the
+// evidence. Without it the 79-vs-140 drift on #6738 was unfalsifiable from the logs alone.
+const scope = `scope: merge_base=${mergeBase ? mergeBase.slice(0, 8) : 'none'} files=${files.length} committed_only=${committedOnly}`;
+
 if (asJson) {
-  console.log(JSON.stringify({ mode, files_checked: files.length, violations: allViolations }, null, 1));
+  console.log(JSON.stringify({
+    mode, files_checked: files.length, merge_base: mergeBase, committed_only: committedOnly,
+    violations: allViolations, pre_existing: preExisting,
+  }, null, 1));
 } else if (allViolations.length === 0) {
-  console.log(`✅ schema-reference-lint (${mode}): ${files.length} file(s) checked, 0 violations`);
+  console.log(`✅ schema-reference-lint (${mode}): ${files.length} file(s) checked, 0 new violations  [${scope}]`);
 } else if (degradedFallback) {
   // Degraded full-repo sweep (the --diff base was unresolvable): these are the pre-existing
   // backlog, NOT new drift, and the check is NON-BLOCKING (advisory). Print as a warning.
@@ -169,6 +237,21 @@ if (asJson) {
   );
 }
 
+// QF-20260802-742: the pre-existing backlog gets its own NON-BLOCKING report. main is red at
+// ~378 violations in --all mode, so before this split the workflow header's promise that the
+// phantom backlog "never blocks a PR" was false in practice for any PR touching an affected file.
+// Reported (not silenced) so the backlog stays visible and someone can still choose to clear it.
+if (preExisting.length > 0 && !asJson) {
+  console.warn(
+    `\nℹ️  ${preExisting.length} PRE-EXISTING violation(s) in touched files — present at merge base ` +
+    `${mergeBase ? mergeBase.slice(0, 8) : '?'}, NOT introduced by this change, NOT blocking:`
+  );
+  for (const v of preExisting) console.warn(`   ${v.file}:${v.line}  missing ${v.missing}  (${v.kind})`);
+  console.warn(`   To clear the backlog: npm run schema:snapshot:lint (commit the result) or update ${ALLOWLIST_PATH}.`);
+}
+
 // FR-1: a degraded --diff run (unresolvable base) is advisory and exits 0; a resolvable-base run
 // keeps full diff-scoped blocking. An explicit --all run keeps degradedFallback=false -> unchanged.
+// QF-20260802-742: `allViolations` now counts NEW drift only — pre-existing violations are in
+// `preExisting` and are deliberately absent from this decision.
 process.exitCode = computeExitCode({ violations: allViolations.length, degradedFallback });

--- a/tests/unit/lint/schema-lint-scope.test.js
+++ b/tests/unit/lint/schema-lint-scope.test.js
@@ -1,0 +1,158 @@
+/**
+ * QF-20260802-742 — the schema-reference lint must scope to the PR's OWN new drift.
+ *
+ * MEASURED FAILURE THIS PINS (A/B run against origin/main on an identical working tree):
+ *   a PR that appended ONE COMMENT to lib/validation/validation-gate-enforcer.js
+ *     old script: EXIT 1, "8 violation(s) in 3 file(s) checked"
+ *     new script: EXIT 0, 0 new violations, 8 reported as pre-existing
+ *   and with a genuinely new bad reference added to the same file
+ *     new script: EXIT 1, naming ONLY the 1 new violation — not the 8 old ones
+ *
+ * Both polarities matter. A lint that stops blocking is trivially achievable by never firing,
+ * which is the same defect wearing the opposite sign.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { violationKey, partitionViolations } from '../../../scripts/lint/schema-lint-scope.mjs';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+/** Shape produced by findViolations() in schema-reference-extract.mjs. */
+const v = (over = {}) => ({
+  file: 'lib/validation/validation-gate-enforcer.js',
+  type: 'column',
+  table: 'product_requirements_v2',
+  column: 'validation_status',
+  kind: 'update',
+  line: 278,
+  missing: 'product_requirements_v2.validation_status',
+  ...over,
+});
+
+describe('the backlog must not become the toucher\'s problem', () => {
+  it('a violation present at the merge base is PRE-EXISTING, not new', () => {
+    const head = [v()];
+    const baseline = new Set([violationKey(v())]);
+    const { newViolations, preExisting } = partitionViolations(head, baseline);
+    expect(newViolations).toHaveLength(0);
+    expect(preExisting).toHaveLength(1);
+  });
+
+  it('a violation ABSENT from the merge base still BLOCKS', () => {
+    // The polarity that stops this fix from being "disable the lint".
+    const head = [v({ table: 'table_that_does_not_exist_qf742', column: undefined, type: 'table', kind: 'from' })];
+    const baseline = new Set([violationKey(v())]);
+    const { newViolations, preExisting } = partitionViolations(head, baseline);
+    expect(newViolations).toHaveLength(1);
+    expect(preExisting).toHaveLength(0);
+  });
+
+  it('separates them in the SAME file — the reproduced #6738 shape', () => {
+    const old1 = v();
+    const old2 = v({ column: 'validation_blocker', missing: 'product_requirements_v2.validation_blocker' });
+    const fresh = v({ table: 'brand_new_typo_table', column: undefined, type: 'table', kind: 'from', line: 415 });
+    const baseline = new Set([violationKey(old1), violationKey(old2)]);
+    const { newViolations, preExisting } = partitionViolations([old1, old2, fresh], baseline);
+    expect(newViolations.map(x => x.table)).toEqual(['brand_new_typo_table']);
+    expect(preExisting).toHaveLength(2);
+  });
+});
+
+describe('line numbers must not resurrect a pre-existing violation', () => {
+  it('the SAME violation shifted to a new line is still pre-existing', () => {
+    // THE CRLF/refactor case: inserting code above a violation moves its line. If the key
+    // included `line`, every old violation in a touched file would read as new — exactly the
+    // bug, reintroduced through the back door.
+    const baseline = new Set([violationKey(v({ line: 278 }))]);
+    const { newViolations, preExisting } = partitionViolations([v({ line: 999 })], baseline);
+    expect(newViolations).toHaveLength(0);
+    expect(preExisting).toHaveLength(1);
+  });
+
+  it('violationKey does not contain the line number', () => {
+    expect(violationKey(v({ line: 278 }))).toBe(violationKey(v({ line: 4242 })));
+    expect(violationKey(v())).not.toMatch(/278/);
+  });
+
+  it('but a DIFFERENT column at the same line is a different violation', () => {
+    // Opposite polarity: the key must still discriminate, or everything collapses to
+    // pre-existing and the lint silently dies.
+    expect(violationKey(v({ column: 'a' }))).not.toBe(violationKey(v({ column: 'b' })));
+    expect(violationKey(v({ table: 'x' }))).not.toBe(violationKey(v({ table: 'y' })));
+    expect(violationKey(v({ kind: 'select' }))).not.toBe(violationKey(v({ kind: 'update' })));
+    expect(violationKey(v({ file: 'a.js' }))).not.toBe(violationKey(v({ file: 'b.js' })));
+  });
+});
+
+describe('a MISSING baseline must not silently disable the lint', () => {
+  it('null baseline treats every violation as new', () => {
+    // --all sweeps and degraded --diff runs have no baseline. Treating absent-baseline as
+    // "all pre-existing" would disable the check on precisely the runs that already lost
+    // their footing. The caller's degraded/advisory rules decide whether that blocks.
+    const { newViolations, preExisting } = partitionViolations([v(), v({ column: 'other' })], null);
+    expect(newViolations).toHaveLength(2);
+    expect(preExisting).toHaveLength(0);
+  });
+
+  it('an EMPTY baseline set is not the same as a null baseline', () => {
+    // Empty = "the file existed and was clean" -> violations are new.
+    const { newViolations } = partitionViolations([v()], new Set());
+    expect(newViolations).toHaveLength(1);
+  });
+
+  it('handles an empty/absent violation list without throwing', () => {
+    expect(partitionViolations([], new Set()).newViolations).toHaveLength(0);
+    expect(partitionViolations(undefined, null).newViolations).toHaveLength(0);
+  });
+});
+
+describe('the CI scope pin is wired in the lint itself', () => {
+  // Asserted on the AST-adjacent source with comments stripped: this fix's own comments quote
+  // the removed assumption ("the latter two are empty in CI") verbatim, so a raw-text match
+  // would pass on its own explanation.
+  const SRC = readFileSync(resolve(REPO_ROOT, 'scripts/lint/schema-reference-lint.mjs'), 'utf8');
+  const CODE = SRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+  it('resolves an explicit merge-base rather than relying on the ... shorthand', () => {
+    expect(CODE).toMatch(/git merge-base/);
+    expect(CODE).toMatch(/\$\{mergeBase\}\.\.HEAD/);
+  });
+
+  it('gates the working-tree sources behind committedOnly', () => {
+    // The CRLF inflation vector: staged/unstaged/untracked must NOT be unconditional.
+    expect(CODE).toMatch(/if \(!committedOnly\)/);
+    const idx = CODE.indexOf('if (!committedOnly)');
+    const cached = CODE.indexOf('--cached');
+    expect(cached).toBeGreaterThan(idx); // the working-tree reads live INSIDE the guard
+  });
+
+  it('defaults to committed-only under CI', () => {
+    expect(CODE).toMatch(/process\.env\.CI/);
+  });
+
+  it('the exit decision counts NEW violations only', () => {
+    expect(CODE).toMatch(/computeExitCode\(\{\s*violations:\s*allViolations\.length/);
+    // preExisting must never reach the exit decision.
+    expect(CODE).not.toMatch(/computeExitCode\([^)]*preExisting/);
+  });
+
+  it('an empty merge-base degrades instead of blocking', () => {
+    // Measured on a deliberately shallowed clone: `git fetch <base> --depth=1` writes
+    // .git/shallow, drops the base to 1 visible commit, and merge-base returns EMPTY (exit 1).
+    // A falsy mergeBase would null every baseline lookup and re-block the whole backlog.
+    expect(CODE).toMatch(/if \(!mergeBase\) throw/);
+  });
+
+  it('the workflow does not re-shallow the base ref it just fetched in full', () => {
+    const wf = readFileSync(resolve(REPO_ROOT, '.github/workflows/schema-reference-lint.yml'), 'utf8');
+    expect(wf).toMatch(/fetch-depth:\s*0/);          // full history at checkout
+    expect(wf).not.toMatch(/git fetch origin \S+ --depth=1/); // and not undone one line later
+  });
+
+  it('CONTROL: the stripper did not empty the source', () => {
+    expect(CODE).toMatch(/candidateFiles/);
+    expect(CODE.length).toBeGreaterThan(2000);
+  });
+});


### PR DESCRIPTION
Unblocks **4+ PRs across 2 seats**, including the TERMINAL-RITUAL stack (#6741/2/3) and #6738.

## What was happening

PR #6738 was blocked on **33 violations with ZERO in its own 12-file diff**, and the scan scope drifted **79 → 140 files** across two runs 24 minutes apart with the violation count pinned. The class fires on **branch age** and on which files you happened to touch — not on anything the author did.

Three causes, all fixed here.

### 1. Backlog inheritance

Violations were counted **per file**. `main` carries ~378 violations in `--all` mode, so any PR touching an affected file inherited that file's old violations as its own.

Now split **per violation** against the merge base. Pre-existing violations are **reported, not silenced**, and never block; only new drift blocks. The comparison key deliberately excludes `line` — a violation that merely shifted because code was inserted above it is the same violation, and keying on line would reintroduce the bug through the back door.

### 2. Scope inflation (the CRLF mechanism)

The file set unconditionally unioned staged + working-tree + untracked files, on this stated assumption:

> Committed changes vs the merge base + staged + working-tree changes — **the latter two are empty in CI** but make local pre-push linting correct.

They are not empty in CI. Checkout renormalises line endings, so every CRLF-affected file appears as an unstaged modification and joins the PR's scope — the measured **5-file → 33-file** expansion. Those sources are now gated behind `committedOnly` (default ON under CI, still ON locally for pre-push ergonomics).

### 3. The workflow re-shallowed its own base ref

`checkout@v4` fetches full history (`fetch-depth: 0`) and the very next line ran:

```
git fetch origin ${{ github.base_ref }} --depth=1
```

That writes `.git/shallow` and truncates the ref. **Verified on a synthetic clone:**

| state | base commits visible | `git merge-base` |
|---|---|---|
| full history | 6 | resolves |
| after `--depth=1` | **1** | **empty (exit 1)** |

With no computable base the diff widens to include main's own commits. This is the "merge-commit widening" half — self-inflicted one line after the full fetch that would have prevented it.

## Measured A/B

Identical working tree; a PR appending **one comment** to `lib/validation/validation-gate-enforcer.js` (8 pre-existing violations):

| script | exit | result |
|---|---|---|
| `origin/main` | **1** | "8 violation(s) in 3 file(s) checked" |
| this PR | **0** | 0 new, 8 reported pre-existing |

And with a genuinely bad reference added to the same file:

| script | exit | result |
|---|---|---|
| this PR | **1** | names **only** the 1 new violation |

Both polarities matter. A lint that stops blocking is trivially achievable by never firing — the same defect wearing the opposite sign.

## Fail-safe preserved

An unresolvable base still degrades to **advisory (exit 0)** rather than blocking, per `SD-LEO-INFRA-SCHEMA-LINT-DEGRADED-FAILOPEN-001`. A guard also rejects an **empty-but-exit-0** merge-base, which would otherwise null every baseline lookup and silently restore the original bug.

Every run now prints its scope (`merge_base`, `files`, `committed_only`) so a disputed scan scope is auditable — the 79-vs-140 drift was unfalsifiable from the logs alone.

## Verification

16 tests, **verified by mutation** — 4 mutants, each killed by a distinct test:

| mutant | tests killed |
|---|---|
| baseline always matches (lint never blocks) | 4 |
| `violationKey` includes `line` | 2 |
| working-tree union made unconditional | 1 |
| null baseline treated as all-pre-existing | 1 |

Adjacent suite: `tests/unit/lint` 10 files / 114 tests pass. Scope: **66 non-comment production lines.**

Evidence: feedback `56fddb7c` (Alpha false-positive scoping, Charlie `venture-scope.js:162` mis-attribution, Bravo #6734 self-resolved widening and #6738 blocked); Delta CRLF measurement; escalation `4183955a`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
