### PR TITLE
feat(SD-LEO-INFRA-AUDIT-LOG-MUTATION-BLIND-001): mutation auditing, and the writers that were quietly losing it

### DIFF
--- a/database/chairman-gated/20260802_sd_mutation_audit_trigger.sql
+++ b/database/chairman-gated/20260802_sd_mutation_audit_trigger.sql
@@ -1,0 +1,100 @@
+-- SD-LEO-INFRA-AUDIT-LOG-MUTATION-BLIND-001 (FR-1)
+-- Mutation auditing for strategic_directives_v2: status, current_phase, claiming_session_id.
+--
+-- WHY THIS EXISTS
+-- audit_log holds 232,811 rows and is actively written, but old_value — the column that
+-- distinguishes a MUTATION record from a creation advisory — is populated in 388 of them
+-- (0.167%), against new_value at 97.1%. The table was BUILT for mutations (it has old_value and
+-- new_value) and has only ever been used for creation provenance, plus two fields that happened to
+-- get purpose-built governance triggers. Measured consequence: twelve consequential state changes
+-- in one night left no trace, reconstructible only because an operator voluntarily wrote priors
+-- into metadata — an authorial habit, not a control.
+--
+-- WHY IT IS FIELD-SCOPED, WHICH IS THE WHOLE DESIGN
+-- update_strategic_directives_v2_updated_at (database/schema/001_initial_schema.sql:121) fires on
+-- EVERY write to this table, so an unfiltered AFTER UPDATE audit trigger would emit a row per
+-- touch. audit_log already carries a 214,099-row advisory flood the SD calls unreadable, and it
+-- has NO retention implemented (no pruning machinery exists for this table anywhere in the repo;
+-- 20260124_aegis_phase5_rules.sql documents audit_logs=365d as a minimum that nothing enforces).
+-- So every row added here is permanent, and a blanket trigger would make the ledger LESS readable
+-- while claiming to fix it. The WHEN clause below is the load-bearing part of this migration.
+--
+-- SHAPE
+-- Follows the writer that already works — 20260202_sd_type_change_governance_fixed.sql:115 —
+-- jsonb_build_object of OLD and NEW into old_value/new_value, entity_type 'strategic_directive',
+-- entity_id = sd_key. That keeps the new rows queryable alongside the 388 existing mutation rows
+-- rather than starting a second, differently-shaped record.
+--
+-- Rollback:
+--   DROP TRIGGER IF EXISTS trg_sd_mutation_audit ON strategic_directives_v2;
+--   DROP FUNCTION IF EXISTS log_sd_mutation_audit();
+
+CREATE OR REPLACE FUNCTION log_sd_mutation_audit()
+RETURNS TRIGGER AS $$
+DECLARE
+  changed TEXT;
+  old_j JSONB;
+  new_j JSONB;
+BEGIN
+  -- One row per CHANGED FIELD rather than one row per UPDATE carrying a diff: a reader asking
+  -- "when did this SD's claim change" should not have to parse a blob that also contains a phase
+  -- change. Matches how the existing sd_type writer records a single field.
+  IF NEW.status IS DISTINCT FROM OLD.status THEN
+    changed := 'status';
+    old_j := jsonb_build_object('status', OLD.status);
+    new_j := jsonb_build_object('status', NEW.status);
+    INSERT INTO audit_log (event_type, entity_type, entity_id, old_value, new_value, metadata, severity, created_by)
+    VALUES ('sd_status_change', 'strategic_directive', NEW.sd_key, old_j, new_j,
+            jsonb_build_object('field', changed, 'trigger', 'trg_sd_mutation_audit', 'sd_id', NEW.id),
+            'info', COALESCE(current_setting('app.actor', true), session_user));
+  END IF;
+
+  IF NEW.current_phase IS DISTINCT FROM OLD.current_phase THEN
+    changed := 'current_phase';
+    old_j := jsonb_build_object('current_phase', OLD.current_phase);
+    new_j := jsonb_build_object('current_phase', NEW.current_phase);
+    INSERT INTO audit_log (event_type, entity_type, entity_id, old_value, new_value, metadata, severity, created_by)
+    VALUES ('sd_phase_transition', 'strategic_directive', NEW.sd_key, old_j, new_j,
+            jsonb_build_object('field', changed, 'trigger', 'trg_sd_mutation_audit', 'sd_id', NEW.id),
+            'info', COALESCE(current_setting('app.actor', true), session_user));
+  END IF;
+
+  -- Claim ACQUIRE and RELEASE are both recorded. Release is the direction that matters
+  -- operationally: the untraced mutations that motivated this SD included a stale
+  -- claiming_session_id clear, and a claim that vanished with no record is the shape that makes a
+  -- stranded SD impossible to attribute afterwards.
+  IF NEW.claiming_session_id IS DISTINCT FROM OLD.claiming_session_id THEN
+    changed := 'claiming_session_id';
+    old_j := jsonb_build_object('claiming_session_id', OLD.claiming_session_id);
+    new_j := jsonb_build_object('claiming_session_id', NEW.claiming_session_id);
+    INSERT INTO audit_log (event_type, entity_type, entity_id, old_value, new_value, metadata, severity, created_by)
+    VALUES (
+      CASE WHEN NEW.claiming_session_id IS NULL THEN 'sd_claim_released' ELSE 'sd_claim_acquired' END,
+      'strategic_directive', NEW.sd_key, old_j, new_j,
+      jsonb_build_object('field', changed, 'trigger', 'trg_sd_mutation_audit', 'sd_id', NEW.id),
+      'info', COALESCE(current_setting('app.actor', true), session_user));
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION log_sd_mutation_audit() IS
+'SD-LEO-INFRA-AUDIT-LOG-MUTATION-BLIND-001 FR-1: writes an audit_log row per changed governed field '
+'(status, current_phase, claiming_session_id) with old_value/new_value populated. Deliberately does '
+'NOT log other columns — updated_at is touched on every write, so a blanket log would out-volume the '
+'existing advisory traffic on a table with no retention.';
+
+-- The WHEN clause is a second, independent guard on the same invariant the IF blocks enforce: even
+-- if a future edit adds a field to the body, the trigger still does not FIRE for updates that touch
+-- none of the three. Belt and braces on the one property that keeps this from becoming a flood.
+DROP TRIGGER IF EXISTS trg_sd_mutation_audit ON strategic_directives_v2;
+CREATE TRIGGER trg_sd_mutation_audit
+  AFTER UPDATE ON strategic_directives_v2
+  FOR EACH ROW
+  WHEN (
+    OLD.status IS DISTINCT FROM NEW.status
+    OR OLD.current_phase IS DISTINCT FROM NEW.current_phase
+    OR OLD.claiming_session_id IS DISTINCT FROM NEW.claiming_session_id
+  )
+  EXECUTE FUNCTION log_sd_mutation_audit();

--- a/database/chairman-gated/README.md
+++ b/database/chairman-gated/README.md
@@ -1,0 +1,59 @@
+# `database/chairman-gated/` — DDL that must NOT be auto-applied
+
+Created by SD-LEO-INFRA-AUDIT-LOG-MUTATION-BLIND-001 (FR-1).
+
+## Why this directory exists
+
+The handoff pipeline auto-applies pending migrations. `BaseExecutor._checkAndExecutePendingMigrations`
+runs with `autoExecute: options.autoExecuteMigrations !== false` — i.e. **true by default** — and
+scans exactly three directories (`pending-migrations-check.js:778`):
+
+```
+database/migrations   database/manual-updates   supabase/migrations
+```
+
+There *is* a tier gate meant to stop this for risky DDL: files that are not provably additive
+classify as **TIER-2 (default-deny)** and defer to the 3-factor chairman gate. But it is controlled
+by `LEO_MIGRATION_TIER_GATE`, which is **unset in this repo**, and `tierGateEnabled()` returns true
+only for the literal string `on`. With the gate off the classification is computed and logged but,
+in the code's own words, "changes NOTHING".
+
+So a `CREATE TRIGGER` / `CREATE OR REPLACE FUNCTION` migration dropped into `database/migrations/`
+would be picked up and executed automatically — self-applying DDL that is supposed to require a
+chairman's `--issue-token`. **A worker cannot place chairman-gated DDL in an auto-applied path and
+still call it gated.** This directory is outside all three scanned paths, so the file waits here
+until a human applies it deliberately.
+
+## Applying `20260802_sd_mutation_audit_trigger.sql`
+
+```
+node scripts/apply-migration.js "database/chairman-gated/20260802_sd_mutation_audit_trigger.sql" \
+  --prod-deploy --issue-token <token>
+```
+
+Rollback is in the file header:
+
+```sql
+DROP TRIGGER IF EXISTS trg_sd_mutation_audit ON strategic_directives_v2;
+DROP FUNCTION IF EXISTS log_sd_mutation_audit();
+```
+
+## What it does
+
+Adds `AFTER UPDATE` mutation auditing to `strategic_directives_v2` for three governed fields —
+`status`, `current_phase`, `claiming_session_id` — writing one `audit_log` row per changed field
+with `old_value` and `new_value` populated, in the same shape as the existing sd_type_change writer.
+
+It is **field-scoped on purpose**, and that is the load-bearing part of the design:
+`update_strategic_directives_v2_updated_at` fires on every write to the table, so an unfiltered
+audit trigger would emit a row per touch. `audit_log` already carries a 214,099-row advisory flood
+and has **no retention implemented**, so every row added is permanent. The `WHEN` clause on the
+trigger is a second, independent guard on that same property, so the trigger does not fire at all
+for updates touching none of the three fields.
+
+## The underlying finding, which outlives this SD
+
+`LEO_MIGRATION_TIER_GATE` being off means the TIER-2 default-deny protection is currently inert
+repo-wide. Any worker adding non-additive DDL to `database/migrations/` today gets it auto-applied,
+gate or no gate. That is worth deciding on its own merits — either turn the gate on, or stop
+describing TIER-2 as deferred — and it is out of scope for this SD.

--- a/database/schema/enforce_sd_type_change_explanation.sql
+++ b/database/schema/enforce_sd_type_change_explanation.sql
@@ -1,3 +1,44 @@
+-- ============================================================================
+-- SUPERSEDED — DO NOT APPLY. This file is kept for history only.
+-- SD-LEO-INFRA-AUDIT-LOG-MUTATION-BLIND-001 (FR-2)
+--
+-- THE LIVE DEFINITION IS:
+--   database/migrations/20260202_sd_type_change_governance_fixed.sql
+--
+-- Both files define enforce_sd_type_change_explanation() and
+-- trg_enforce_sd_type_change_explanation, but they DIFFER in one way that
+-- matters: the migration writes sd_type mutations to audit_log with old_value
+-- and new_value populated (:115-129, :158, :188); THIS FILE WRITES NOTHING.
+-- Those writes are 172 of the 388 rows in the whole table that carry an
+-- old_value — 0.167% of audit_log is the entire mutation record, and this
+-- function's live twin produces a large share of it.
+--
+-- So applying this file would CREATE OR REPLACE the live function with a
+-- non-auditing one, silently ending sd_type mutation auditing. Nothing would
+-- detect it: no test asserts the trigger writes, and the rows simply stop
+-- appearing. database/schema/ is not scanned by the pending-migration checker
+-- (it reads database/migrations, database/manual-updates, supabase/migrations),
+-- so this file is applied only by a human copying it — which is exactly the
+-- path a guard has to cover.
+--
+-- The guard below makes that mistake loud instead of silent. Remove it only
+-- together with the duplicate definition itself.
+-- ============================================================================
+DO $supersede$
+BEGIN
+  RAISE EXCEPTION USING
+    MESSAGE = 'SUPERSEDED FILE — applying this would disable sd_type audit logging.',
+    DETAIL  = 'enforce_sd_type_change_explanation() is defined here WITHOUT the audit_log writes '
+              || 'that the live version has. Replacing the live function would silently stop '
+              || 'recording sd_type mutations (old_value/new_value), and nothing detects the loss.',
+    HINT    = 'Apply database/migrations/20260202_sd_type_change_governance_fixed.sql instead.';
+END
+$supersede$;
+
+-- ---------------------------------------------------------------------------
+-- Historical content below this line. Unreachable: the guard above aborts.
+-- ---------------------------------------------------------------------------
+
 -- Enforce SD Type Change Explanation Requirement
 -- Created: 2025-12-30
 -- Purpose: Requires governance_metadata.type_reclassification when sd_type is changed

--- a/scripts/audit-log-coverage.mjs
+++ b/scripts/audit-log-coverage.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-AUDIT-LOG-MUTATION-BLIND-001 — FR-4 (amplification) and FR-5 (coverage).
+ *
+ * Two questions about audit_log that nobody could answer without reading 232k rows:
+ *
+ *   COVERAGE (FR-5)      how much of the table records a state MUTATION rather than a creation?
+ *                        old_value is the discriminator — a creation advisory has no prior value.
+ *                        Baseline at 2026-08-02: 388 of 232,811 rows = 0.167%.
+ *
+ *   AMPLIFICATION (FR-4) how many advisory rows does one entity generate? The trigger is
+ *                        AFTER INSERT, so the honest ratio is ~1 per created SD. Measured: 5,519
+ *                        SDs against 214,099 advisories = 38.8 each, and ONE key with 9,728 rows
+ *                        that has ZERO rows in strategic_directives_v2.
+ *
+ * DELIBERATELY REPORT-ONLY. This does not delete, dedupe or quieten anything. The advisory is
+ * correctly reporting real, repeated, provenance-less inserts; muting it would destroy the evidence
+ * of an active defect while leaving the defect running (see TR-4 — the Stage-20 producer already
+ * has four downstream workarounds and no fix).
+ *
+ * Usage: node scripts/audit-log-coverage.mjs [--top N]
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const TOP = (() => {
+  const i = process.argv.indexOf('--top');
+  const n = i > -1 ? Number(process.argv[i + 1]) : NaN;
+  return Number.isFinite(n) && n > 0 ? Math.min(n, 50) : 10;
+})();
+
+const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const head = { count: 'exact', head: true };
+const pct = (n, d) => (d ? ((n / d) * 100).toFixed(3) : '0.000');
+
+/** Exact count — never a select().length, which silently caps at the PostgREST 1000-row limit. */
+async function count(filterFn) {
+  const q = filterFn(sb.from('audit_log').select('*', head));
+  const { count: c, error } = await q;
+  if (error) throw new Error(`count failed: ${error.message}`); // must DIE, never default to 0
+  return c;
+}
+
+const total = await count((q) => q);
+const withOld = await count((q) => q.not('old_value', 'is', null));
+const withNew = await count((q) => q.not('new_value', 'is', null));
+
+console.log('audit_log coverage');
+console.log('  total rows          ' + total);
+console.log('  old_value populated ' + withOld + '  (' + pct(withOld, total) + '%)   <- the MUTATION record');
+console.log('  new_value populated ' + withNew + '  (' + pct(withNew, total) + '%)');
+
+// CONTROL: a filter that returns 0 because it is wrong looks identical to one that returns 0
+// because the population is empty. metadata is populated on every row, so a non-zero here proves
+// .not(is,null) actually filters and the zero-ish old_value number above is a measurement.
+const withMeta = await count((q) => q.not('metadata', 'is', null));
+console.log('  [control] metadata  ' + withMeta + '  (proves the null-filter discriminates)');
+
+console.log('\nmutation events present');
+const { data: muts, error: mErr } = await sb
+  .from('audit_log').select('event_type').not('old_value', 'is', null).limit(1000);
+if (mErr) throw new Error(mErr.message);
+const byType = {};
+for (const r of muts || []) byType[r.event_type] = (byType[r.event_type] || 0) + 1;
+const types = Object.entries(byType).sort((a, b) => b[1] - a[1]);
+if (!types.length) console.log('  (none — no row in the table carries a prior value)');
+for (const [t, n] of types) console.log('  ' + String(n).padStart(6) + '  ' + t);
+if ((muts || []).length === 1000) console.log('  (sampled the newest 1000 mutation rows — counts above are of that sample)');
+
+console.log('\nadvisory amplification (rows per entity)');
+const { count: sdCount } = await sb.from('strategic_directives_v2').select('*', head);
+const advisory = await count((q) => q.eq('event_type', 'sd_creation_source_missing'));
+console.log('  strategic_directives_v2 rows ' + sdCount);
+console.log('  sd_creation_source_missing   ' + advisory);
+console.log('  ratio                        ' + (sdCount ? (advisory / sdCount).toFixed(1) : 'n/a')
+  + ' advisory rows per SD   (an AFTER INSERT trigger should give ~1)');
+
+// Sample the newest window rather than the whole table: the point is to name the loudest current
+// offenders, and a full group-by would need a view this SD deliberately does not create.
+const { data: recent } = await sb
+  .from('audit_log').select('entity_id')
+  .eq('event_type', 'sd_creation_source_missing')
+  .order('created_at', { ascending: false }).limit(1000);
+const perEntity = {};
+for (const r of recent || []) perEntity[r.entity_id] = (perEntity[r.entity_id] || 0) + 1;
+const ranked = Object.entries(perEntity).sort((a, b) => b[1] - a[1]).slice(0, TOP);
+console.log('  newest 1000 advisory rows span ' + Object.keys(perEntity).length + ' distinct entities');
+
+for (const [entity, n] of ranked) {
+  const { count: liveRows } = await sb
+    .from('strategic_directives_v2').select('*', head).eq('sd_key', entity);
+  const lifetime = await count((q) => q.eq('entity_id', entity).eq('event_type', 'sd_creation_source_missing'));
+  // A key with advisory rows and NO live SD row is the decisive shape: the trigger fires only on
+  // INSERT, so those rows are inserts of something that does not survive — a loop, not a backlog.
+  const flag = liveRows === 0 ? '  <- NO live SD row: repeated inserts of a row that never persists' : '';
+  console.log('  ' + String(n).padStart(4) + ' in window · ' + String(lifetime).padStart(6) + ' lifetime · '
+    + entity + flag);
+}
+
+console.log('\nThis report changes nothing. Advisory volume is expected to stay flat until the');
+console.log('producer behind the amplification is fixed under its own SD.');

--- a/scripts/cancel-sd.js
+++ b/scripts/cancel-sd.js
@@ -210,6 +210,32 @@ export function verifyShippedOnOriginMain({ pr, evidenceFiles = [] } = {}, { run
  * @param {{runGit: Function, runGh: Function, repoRoot?: string}} runners
  * @returns {{refuse: boolean, reasons: string[]}}
  */
+/**
+ * SD-LEO-INFRA-AUDIT-LOG-MUTATION-BLIND-001 (FR-3): build the metadata patch recording that an
+ * audit_log write FAILED, so an unaudited cancellation is discoverable later instead of living in
+ * a console line nobody reads.
+ *
+ * PURE and exported for the same reason the helpers above are: the hazard here is not the happy
+ * path, it is the MERGE. `existing` must be the metadata read fresh from the row — passing a
+ * partial or undefined object would drop every key the SD already carries, turning an
+ * observability fix into silent data loss. That is the case the test pins.
+ *
+ * @param {object|null|undefined} existing - metadata as currently stored on the row
+ * @param {{event_type:string, error:string, source:string, at:string}} failure
+ * @returns {object} the full metadata object to write back
+ */
+export function buildAuditFailureMarker(existing, failure) {
+  return {
+    ...(existing && typeof existing === 'object' ? existing : {}),
+    audit_write_failed: {
+      event_type: failure.event_type,
+      at: failure.at,
+      error: failure.error,
+      source: failure.source,
+    },
+  };
+}
+
 export function decideCancelRefusal(reason, evidence, runners) {
   if (!classifyShipReason(reason)) return { refuse: false, reasons: [] };
   const { verified, reasons } = verifyShippedOnOriginMain(evidence, runners);
@@ -327,7 +353,47 @@ async function cancelSD(sd, reason) {
       created_by: 'cancel-sd.js',
     });
   if (auditErr) {
+    // SD-LEO-INFRA-AUDIT-LOG-MUTATION-BLIND-001 (FR-3): the non-fatal choice above is right — the
+    // SD is already cancelled and blocking on the audit write would mask a completed action. But
+    // "surfaced loudly" meant console.warn, and a console line in a script that ran hours ago is
+    // not an observation anyone can make later: a cancellation whose audit write FAILED was
+    // indistinguishable from one that was never audited, which is the exact blindness this SD
+    // exists to remove.
+    //
+    // So the failure is stamped on the ENTITY whose mutation went untraced. It is durable,
+    // queryable by a sweep, and cannot fail for the reason the audit_log write just did (different
+    // table, and the SD update on this path already succeeded). Best-effort in turn — if this also
+    // fails there is nothing further to write to, and the console line remains as the last resort.
     console.warn(`⚠️  audit_log write for ${sd.sd_key} failed (non-fatal):`, auditErr.message);
+    try {
+      // Re-READ metadata rather than spreading `sd.metadata`: the fetch at :247 selects seven
+      // columns and metadata is NOT one of them, so `sd.metadata` is undefined here and merging
+      // from it would write the marker over the WHOLE object, silently destroying every existing
+      // key. Fetching it fresh is also more correct — this runs after the cancellation update, so
+      // an in-memory copy could be stale regardless.
+      const { data: cur } = await supabase
+        .from('strategic_directives_v2')
+        .select('metadata')
+        .eq('id', sd.id)
+        .single();
+      const marker = buildAuditFailureMarker(cur && cur.metadata, {
+        event_type: 'sd_cancelled',
+        at: new Date().toISOString(),
+        error: auditErr.message,
+        source: 'cancel-sd.js',
+      });
+      const { error: markErr } = await supabase
+        .from('strategic_directives_v2')
+        .update({ metadata: marker })
+        .eq('id', sd.id);
+      if (markErr) {
+        console.warn(`⚠️  audit-failure marker for ${sd.sd_key} also failed:`, markErr.message);
+      } else {
+        console.warn(`   ↳ recorded metadata.audit_write_failed on ${sd.sd_key} — this cancellation is UNAUDITED`);
+      }
+    } catch (e) {
+      console.warn(`⚠️  audit-failure marker for ${sd.sd_key} threw:`, e?.message || e);
+    }
   } else {
     console.log(`✓ audit_log: sd_cancelled recorded for ${sd.sd_key}`);
   }

--- a/tests/unit/audit-log-mutation-coverage.test.js
+++ b/tests/unit/audit-log-mutation-coverage.test.js
@@ -61,6 +61,52 @@ describe('FR-2: one trigger definition, and it audits', () => {
   });
 });
 
+describe('FR-1/FR-5: the mutation trigger covers the named transitions and nothing else', () => {
+  const MIGRATION = 'database/chairman-gated/20260802_sd_mutation_audit_trigger.sql';
+
+  it('CONTROL: the migration exists outside every auto-applied directory', () => {
+    expect(existsSync(join(REPO, MIGRATION)), `${MIGRATION} missing — the assertions below would pass vacuously`).toBe(true);
+    // pending-migrations-check.js:778 scans exactly these three, with autoExecute defaulting TRUE.
+    // Chairman-gated DDL sitting in any of them would be self-applied, so its ABSENCE from them is
+    // part of the deliverable, not an accident of where the file landed.
+    for (const scanned of ['database/migrations', 'database/manual-updates', 'supabase/migrations']) {
+      expect(existsSync(join(REPO, scanned, '20260802_sd_mutation_audit_trigger.sql'))).toBe(false);
+    }
+  });
+
+  it('audits exactly the three governed fields, each with old_value and new_value', () => {
+    const sql = read(MIGRATION);
+    for (const field of ['status', 'current_phase', 'claiming_session_id']) {
+      expect(sql).toContain(`NEW.${field} IS DISTINCT FROM OLD.${field}`);
+    }
+    expect(sql).toMatch(/INSERT INTO audit_log/);
+    expect(sql).toMatch(/old_value/);
+    expect(sql).toMatch(/new_value/);
+    // Claim release is the direction that matters operationally and is easy to omit.
+    expect(sql).toContain('sd_claim_released');
+    expect(sql).toContain('sd_claim_acquired');
+  });
+
+  // THE GUARD THAT KEEPS THE FIX FROM BECOMING THE NEXT FLOOD. updated_at is touched on every
+  // write, so a trigger without a WHEN clause fires on every UPDATE — on a table with NO retention,
+  // where every row is permanent, that would out-volume the 214k advisory traffic it must be
+  // readable against. The WHEN clause is a second guard independent of the function body.
+  it('is field-scoped at the TRIGGER level, not only inside the function', () => {
+    const sql = read(MIGRATION);
+    const when = sql.slice(sql.indexOf('CREATE TRIGGER trg_sd_mutation_audit'));
+    expect(when).toMatch(/WHEN\s*\(/);
+    expect(when).toContain('OLD.status IS DISTINCT FROM NEW.status');
+    expect(when).toContain('OLD.current_phase IS DISTINCT FROM NEW.current_phase');
+    expect(when).toContain('OLD.claiming_session_id IS DISTINCT FROM NEW.claiming_session_id');
+  });
+
+  it('ships a rollback, because a trigger applied by hand must be removable by hand', () => {
+    const sql = read(MIGRATION);
+    expect(sql).toContain('DROP TRIGGER IF EXISTS trg_sd_mutation_audit');
+    expect(sql).toContain('DROP FUNCTION IF EXISTS log_sd_mutation_audit');
+  });
+});
+
 describe('FR-3: a failed cancellation audit write is recorded, not swallowed', () => {
   const failure = { event_type: 'sd_cancelled', at: '2026-08-02T23:59:00.000Z', error: 'permission denied', source: 'cancel-sd.js' };
 

--- a/tests/unit/audit-log-mutation-coverage.test.js
+++ b/tests/unit/audit-log-mutation-coverage.test.js
@@ -1,0 +1,108 @@
+// SD-LEO-INFRA-AUDIT-LOG-MUTATION-BLIND-001 — FR-2 and FR-3.
+//
+// audit_log holds 232,811 rows but old_value — the column that distinguishes a MUTATION record
+// from a creation advisory — is populated in 388 of them (0.167%). Of those 388, 172 come from the
+// sd_type_change writer and 214 from cancel-sd.js. Both of those writers are defective in ways that
+// would quietly reduce that number further, and neither defect had a test:
+//
+//   FR-2  trg_enforce_sd_type_change_explanation is defined TWICE. The live definition
+//         (database/migrations/20260202_...) writes audit_log; the one in database/schema/ does not.
+//         Applying the schema copy would CREATE OR REPLACE the live function with a non-auditing
+//         one and silently end sd_type auditing.
+//   FR-3  cancel-sd.js swallowed a failed audit write with console.warn, so a cancellation whose
+//         audit row never landed was indistinguishable from one that was never audited.
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildAuditFailureMarker } from '../../scripts/cancel-sd.js';
+
+const REPO = join(fileURLToPath(new URL('.', import.meta.url)), '..', '..');
+const SCHEMA_COPY = 'database/schema/enforce_sd_type_change_explanation.sql';
+const LIVE_MIGRATION = 'database/migrations/20260202_sd_type_change_governance_fixed.sql';
+const read = (p) => readFileSync(join(REPO, p), 'utf8');
+
+describe('FR-2: one trigger definition, and it audits', () => {
+  // CONTROL FIRST. Both assertions below are about file CONTENT, so a wrong path yields an
+  // empty string and every "does not contain" check passes vacuously. Prove the files exist
+  // and that the positive case is actually detectable before trusting any negative one.
+  it('CONTROL: both files exist and the live migration really does write audit_log', () => {
+    expect(existsSync(join(REPO, SCHEMA_COPY)), `${SCHEMA_COPY} missing — the rest of this suite would pass vacuously`).toBe(true);
+    expect(existsSync(join(REPO, LIVE_MIGRATION))).toBe(true);
+    const live = read(LIVE_MIGRATION);
+    expect(live).toMatch(/INSERT INTO audit_log/);
+    expect(live).toMatch(/old_value/);
+    expect(live).toMatch(/new_value/);
+  });
+
+  // THE DECIDING SCENARIO. The schema copy still defines the function (history is preserved), so
+  // "it has no definition" is not the property to assert. The property is that it cannot be
+  // applied silently: it must abort loudly and name what applying it would destroy.
+  it('the superseded copy cannot be applied silently — it aborts and names the live definition', () => {
+    const copy = read(SCHEMA_COPY);
+    expect(copy).toMatch(/RAISE EXCEPTION/);
+    expect(copy).toMatch(/SUPERSEDED/);
+    expect(copy).toContain('20260202_sd_type_change_governance_fixed.sql');
+  });
+
+  it('the guard precedes the duplicate definition, so it cannot be reached', () => {
+    const copy = read(SCHEMA_COPY);
+    const guardAt = copy.indexOf('RAISE EXCEPTION');
+    const defAt = copy.indexOf('CREATE OR REPLACE FUNCTION enforce_sd_type_change_explanation');
+    expect(guardAt).toBeGreaterThan(-1);
+    expect(defAt).toBeGreaterThan(-1);
+    // A guard placed AFTER the CREATE OR REPLACE would let the damage land before it fired —
+    // the function would already be replaced by the time the exception aborted the transaction.
+    expect(guardAt).toBeLessThan(defAt);
+  });
+
+  it('the superseded copy still does not write audit_log — the reason the guard exists', () => {
+    expect(read(SCHEMA_COPY)).not.toMatch(/INSERT INTO audit_log/);
+  });
+});
+
+describe('FR-3: a failed cancellation audit write is recorded, not swallowed', () => {
+  const failure = { event_type: 'sd_cancelled', at: '2026-08-02T23:59:00.000Z', error: 'permission denied', source: 'cancel-sd.js' };
+
+  it('records the failure against the entity whose mutation went untraced', () => {
+    const m = buildAuditFailureMarker({}, failure);
+    expect(m.audit_write_failed).toMatchObject({ event_type: 'sd_cancelled', error: 'permission denied', source: 'cancel-sd.js' });
+    expect(m.audit_write_failed.at).toBe('2026-08-02T23:59:00.000Z');
+  });
+
+  // THE BUG THIS TEST EXISTS FOR, and it was live in my first implementation. The call site
+  // originally merged from `sd.metadata` — but the SD is fetched with an explicit seven-column
+  // select that does NOT include metadata, so that value is undefined and the write would have
+  // replaced the entire object with just the marker. An observability fix that destroys data is
+  // worse than the silence it replaced.
+  it('PRESERVES every existing metadata key — the marker extends, never replaces', () => {
+    const existing = {
+      strand_repair: { by: 'coordinator', at: '2026-08-01T00:00:00Z' },
+      requires_human_action: true,
+      not_before: '2026-09-01T00:00:00Z',
+      nested: { keep: ['a', 'b'] },
+    };
+    const m = buildAuditFailureMarker(existing, failure);
+    expect(m.strand_repair).toEqual(existing.strand_repair);
+    expect(m.requires_human_action).toBe(true);
+    expect(m.not_before).toBe('2026-09-01T00:00:00Z');
+    expect(m.nested).toEqual({ keep: ['a', 'b'] });
+    expect(Object.keys(m).sort()).toEqual(['audit_write_failed', 'nested', 'not_before', 'requires_human_action', 'strand_repair']);
+  });
+
+  // Absent metadata must not throw and must not fabricate structure — the marker alone is correct
+  // when the row genuinely has none.
+  it('handles null/undefined/non-object metadata without throwing or inventing keys', () => {
+    for (const bad of [null, undefined, 'not-an-object', 42]) {
+      const m = buildAuditFailureMarker(bad, failure);
+      expect(Object.keys(m)).toEqual(['audit_write_failed']);
+    }
+  });
+
+  it('does not mutate the object it was given', () => {
+    const existing = { keep: 1 };
+    buildAuditFailureMarker(existing, failure);
+    expect(existing).toEqual({ keep: 1 });
+    expect(existing.audit_write_failed).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## The gap, measured at the schema rather than the event names

`audit_log` holds 232,896 rows and is actively written. It was **built** for mutations — it has `old_value` and `new_value` columns — but:

| | rows | share |
|---|---|---|
| `new_value` populated | 226,208 | 97.128% |
| **`old_value` populated** | **388** | **0.167%** |
| *(control)* `metadata` | 232,896 | proves the null-filter discriminates |

`old_value` is what separates a mutation record from a creation advisory. **0.167% is the mutation coverage.**

## Three corrections to the SD, made before planning

1. **"NOT ONE event_type describes a state mutation"** — false. Five do: `sd_cancelled` (214), `sd_type_change` (92), `sd_type_change_override` (80), `sd_cancel_reverted`, `UPDATE`.
2. **The four cited triggers ARE clean**, as the SD says. I claimed otherwise last pass and retract it — I matched a trigger *name* and read a different file that defines it.
3. **The real writers are weaker than either account**: one fail-open script, one duplicate-defined trigger. Both are repaired here.

## Changes

**FR-1** — `AFTER UPDATE` auditing for `status`, `current_phase`, `claiming_session_id`; one row per changed field, `old_value`/`new_value` populated, matching the existing `sd_type_change` shape. Claim **release** is recorded as well as acquire.

**Field-scoped on purpose.** `update_strategic_directives_v2_updated_at` fires on *every* write, so an unfiltered trigger emits a row per touch — and this table has **no retention implemented**, so every row is permanent. The `WHEN` clause guards that property independently of the function body.

**The migration is NOT in `database/migrations/`, deliberately.** `_checkAndExecutePendingMigrations` runs `autoExecute: true` over `database/migrations`, `manual-updates`, `supabase/migrations`. The TIER-2 default-deny that should hold risky DDL is gated on `LEO_MIGRATION_TIER_GATE`, which is **unset** — with it off the classification is logged and "changes NOTHING". Committing a `CREATE TRIGGER` there would have self-applied DDL requiring a chairman `--issue-token`. It waits in `database/chairman-gated/` with apply recipe and rollback.

**FR-2** — `trg_enforce_sd_type_change_explanation` is defined **twice**; the live migration writes `audit_log`, the `database/schema/` copy does not. Applying the copy would silently end sd_type auditing — 172 of the 388 `old_value` rows. That directory isn't scanned, so the hazard is a human copying it. The file now opens with a `RAISE EXCEPTION` naming the live definition.

**FR-3** — `cancel-sd.js` swallowed a failed audit write with `console.warn`. Non-fatal is right; *silent* isn't. It now stamps `metadata.audit_write_failed` on the entity. My first version merged from `sd.metadata`, which the seven-column fetch doesn't select — it would have destroyed every existing key. Re-reads fresh; the extracted pure helper is tested against exactly that.

**FR-4/FR-5** — a report (no DDL) and 12 assertions. Every content assertion carries a control, because a wrong path makes "does not contain" pass vacuously.

## What the report found

```
5,519 SDs vs 214,139 advisories = 38.8 per SD   (AFTER INSERT should give ~1)
newest 1000 advisory rows span THREE entities, ALL with no live SD row:
   9,750 lifetime  SD-LEO-FIX-REMEDIATION-UNIT-TEST-007
   5,012 lifetime  SD-LEO-FIX-REMEDIATION-LINT-MEDIUM-006
```

Current advisory traffic is essentially **all** this defect, still growing (9,728 → 9,750 within the hour). The producer is the Stage-20 quality loop, which already has **four** downstream workarounds and no fix (TR-4).

**So the advisory volume is deliberately unchanged.** It is correctly reporting real provenance-less inserts; muting it would be the fifth workaround and the first to destroy the evidence.

12 tests pass.