### PR TITLE
feat(SD-LEO-INFRA-TERMINAL-RITUAL-ENFORCEMENT-001): steps A and B onto MAIN — the stacked merges never reached it

### DIFF
--- a/scripts/hooks/__tests__/stop-loop-wakeup-reminder.test.js
+++ b/scripts/hooks/__tests__/stop-loop-wakeup-reminder.test.js
@@ -225,11 +225,32 @@ describe('stop-loop-wakeup-reminder — wrapper fail-open (TS-6, spawn)', () => 
   });
 
   // A Stop hook that TIMES OUT returns NO decision — the enforcement silently disappears exactly
-  // when the machine is loaded. Registered timeout is 10s against 3-5 DB round-trips plus a 2.5s
-  // stabilisation re-read, so the hermetic path must stay well clear of it.
-  it('stays under the 6s wall-clock ceiling (10s registered timeout)', () => {
+  // when the machine is loaded.
+  //
+  // THIS THRESHOLD WAS RECALIBRATED, NOT RELAXED TO GET GREEN. At 6000ms it failed on CI at
+  // 7198ms for this same hermetic path, which measures 412ms locally — a 17x spread on a runner
+  // whose node_modules probe was failing. Most of that is node process start + module resolution,
+  // which the hook does not control and which no in-hook fix can shrink; the number therefore says
+  // more about the runner than about this code. What the hook DOES control is now bounded
+  // explicitly (HOOK_WORK_BUDGET_MS, asserted below), so this assertion is kept only as a coarse
+  // guard against the 10s cliff rather than as the real invariant.
+  //
+  // The 7198ms reading is itself a finding and was reported, not absorbed: if the CHEAPEST path
+  // costs that much on CI-class hardware, the block path would exceed the registered timeout there.
+  it('stays clear of the 10s registered timeout on the hermetic path', () => {
     const t0 = Date.now();
     runHook({ stop_hook_active: false, session_id: 'nonexistent' }, { LEO_LOOP_WAKEUP_REMINDER: 'on' });
-    expect(Date.now() - t0).toBeLessThan(6000);
+    expect(Date.now() - t0).toBeLessThan(9000);
+  });
+
+  // The environment-independent half of the same invariant, and the one that actually protects the
+  // decision: the hook's own discretionary work is capped, and the stabilisation re-read is given
+  // only what the DB round-trips left rather than a fixed 2.5s on top of them.
+  it('bounds its own work budget below the registered timeout', () => {
+    const src = require('node:fs').readFileSync(HOOK_PATH, 'utf8');
+    const budget = Number((src.match(/HOOK_WORK_BUDGET_MS\s*=\s*(\d+)/) || [])[1]);
+    expect(budget).toBeGreaterThan(0);
+    expect(budget).toBeLessThan(10000);            // the registered timeout
+    expect(src).toMatch(/deadlineMs:\s*Math\.min\(2500,\s*remainingBudgetMs\(\)\)/);
   });
 });

--- a/scripts/hooks/__tests__/stop-loop-wakeup-reminder.test.js
+++ b/scripts/hooks/__tests__/stop-loop-wakeup-reminder.test.js
@@ -251,6 +251,20 @@ describe('stop-loop-wakeup-reminder — wrapper fail-open (TS-6, spawn)', () => 
     const budget = Number((src.match(/HOOK_WORK_BUDGET_MS\s*=\s*(\d+)/) || [])[1]);
     expect(budget).toBeGreaterThan(0);
     expect(budget).toBeLessThan(10000);            // the registered timeout
-    expect(src).toMatch(/deadlineMs:\s*Math\.min\(2500,\s*remainingBudgetMs\(\)\)/);
+    expect(src).toMatch(/deadlineMs:[\s\S]{0,120}remainingBudgetMs\(\)/);
+  });
+
+  // The observational re-read must not be able to spend the budget the DECISION-CRITICAL block
+  // record needs. Racing them for one pool starved the write — measured, it got timed out, which
+  // put the step-C gate back to unreadable. Asserted on the arithmetic, not on a fixed string,
+  // so the reserve cannot be silently dropped while the expression is reshaped.
+  it('reserves telemetry budget OUT of what the stabilisation re-read may spend', () => {
+    const src = require('node:fs').readFileSync(HOOK_PATH, 'utf8');
+    const reserve = Number((src.match(/TELEMETRY_RESERVE_MS\s*=\s*(\d+)/) || [])[1]);
+    const budget = Number((src.match(/HOOK_WORK_BUDGET_MS\s*=\s*(\d+)/) || [])[1]);
+    expect(reserve).toBeGreaterThan(0);
+    expect(reserve).toBeLessThan(budget);          // a reserve that eats the whole budget is a stall
+    expect(src).toMatch(/remainingBudgetMs\(\)\s*-\s*TELEMETRY_RESERVE_MS/);
+    expect(src).toMatch(/reason: 'blocked_unarmed'/);   // the record the reserve exists for
   });
 });

--- a/scripts/hooks/__tests__/stop-loop-wakeup-reminder.test.js
+++ b/scripts/hooks/__tests__/stop-loop-wakeup-reminder.test.js
@@ -24,22 +24,64 @@ describe('stop-loop-wakeup-reminder — REMINDER text (source-pin, shipped wordi
   });
 });
 
-// SD-LEO-INFRA-LOOP-CONTINUITY-ENFORCE-001 (FR-2 allow-path): a worker that announced its
-// wind-down via /signal must NOT be blocked (false-positive guard), while an un-announced
-// premature stop STILL blocks.
-describe('stop-loop-wakeup-reminder — wind-down allow-path', () => {
-  it('does NOT block when windDownSignaled, even for an active worker', () => {
-    expect(shouldRemind({ loopState: 'active', stopHookActive: false, flagEnabled: true, windDownSignaled: true })).toBe(false);
+// SD-LEO-INFRA-TERMINAL-RITUAL-ENFORCEMENT-001 step A — REPLACES the windDownSignaled allow-path
+// (SD-LEO-INFRA-LOOP-CONTINUITY-ENFORCE-001 FR-2). That path returned false for ANY session that
+// merely SAID "winding down", which is precisely Charlie's false positive: a worker talks its way
+// out of the arm requirement without the tool ever being called. Operator safety — the reason the
+// allow-path existed — is now carried by the WORKER GATE instead, which is a claim or a live loop
+// state rather than an announcement. Announcements are no longer load-bearing anywhere.
+describe('step A — an ANNOUNCEMENT is not an arm (FR-3, Charlie\'s false positive)', () => {
+  it('BLOCKS a claim-holding worker that announced a wind-down but never called the tool', () => {
+    expect(shouldRemind({ armVerdict: 'unarmed', loopState: 'active', flagEnabled: true, hasActiveClaim: true })).toBe(true);
   });
-  it('does NOT block a claim-holder that announced wind-down (unknown state + claim)', () => {
-    expect(shouldRemind({ loopState: 'unknown', stopHookActive: false, flagEnabled: true, hasActiveClaim: true, windDownSignaled: true })).toBe(false);
+
+  // The self-report the OLD predicate trusted. post-tool-loop-state.cjs sets awaiting_tick from
+  // the worker's own claim about itself, so reading it asked the suspect for an alibi.
+  it('BLOCKS a worker whose loop_state says awaiting_tick when the transcript says unarmed', () => {
+    expect(shouldRemind({ armVerdict: 'unarmed', loopState: 'awaiting_tick', flagEnabled: true, hasActiveClaim: true })).toBe(true);
   });
-  it('STILL blocks an active worker that did NOT announce wind-down', () => {
-    expect(shouldRemind({ loopState: 'active', stopHookActive: false, flagEnabled: true, windDownSignaled: false })).toBe(true);
+
+  it('allows a worker with a REAL ScheduleWakeup tool_use in the current turn', () => {
+    expect(shouldRemind({ armVerdict: 'armed', loopState: 'active', flagEnabled: true, hasActiveClaim: true })).toBe(false);
   });
-  it('flag-off and stop_hook_active guards still win over everything', () => {
-    expect(shouldRemind({ loopState: 'active', stopHookActive: false, flagEnabled: false, windDownSignaled: false })).toBe(false);
-    expect(shouldRemind({ loopState: 'active', stopHookActive: true, flagEnabled: true, windDownSignaled: false })).toBe(false);
+});
+
+describe('step A — worker gate keeps operators safe (FR-4)', () => {
+  it('never blocks a claim-less, loop-less session even when unarmed', () => {
+    expect(shouldRemind({ armVerdict: 'unarmed', loopState: null, flagEnabled: true, hasActiveClaim: false })).toBe(false);
+    expect(shouldRemind({ armVerdict: 'unarmed', loopState: 'unknown', flagEnabled: true, hasActiveClaim: false })).toBe(false);
+  });
+
+  // The live defect FR-4 names: an operator that says "winding down" must not become blockable.
+  // Under the old allow-path this same input was ALSO false, but for the wrong reason (the
+  // announcement); it is false here because the session is not a worker.
+  it('never blocks an operator that announced a wind-down', () => {
+    expect(shouldRemind({ armVerdict: 'unarmed', loopState: null, flagEnabled: true, hasActiveClaim: false, windDownSignaled: true })).toBe(false);
+  });
+
+  it('blocks the same unarmed turn once a claim is held', () => {
+    expect(shouldRemind({ armVerdict: 'unarmed', loopState: null, flagEnabled: true, hasActiveClaim: true })).toBe(true);
+  });
+});
+
+describe('step A — guards and escapes', () => {
+  const worker = { armVerdict: 'unarmed', loopState: 'active', flagEnabled: true, hasActiveClaim: true };
+
+  it('flag-off, second-stop and loop_state=exited all win over the arm requirement', () => {
+    expect(shouldRemind({ ...worker, flagEnabled: false })).toBe(false);
+    expect(shouldRemind({ ...worker, stopHookActive: true })).toBe(false);
+    expect(shouldRemind({ ...worker, loopState: 'exited' })).toBe(false);
+  });
+
+  // FR-2: the runtime switch must be able to stop a LIVE seat enforcing, with no merge/restart.
+  it('the kill switch disables the block outright', () => {
+    expect(shouldRemind({ ...worker, enforcementDisabled: true })).toBe(false);
+  });
+
+  // Absence of evidence is not evidence of absence — an unreadable transcript must not trap.
+  it("'unknown' and a missing verdict both fail OPEN", () => {
+    expect(shouldRemind({ ...worker, armVerdict: 'unknown' })).toBe(false);
+    expect(shouldRemind({ ...worker, armVerdict: undefined })).toBe(false);
   });
 });
 
@@ -55,45 +97,55 @@ describe('loop_state coherence (FR-3, no-new-state)', () => {
   });
 });
 
+// The original TS-1..TS-9, carried forward onto the arm-evidence basis. Each case keeps its
+// ORIGINAL INTENT; only the signal standing in for "no wakeup armed" changed — from
+// loop_state='active' (a self-report) to armVerdict='unarmed' (transcript evidence).
 describe('stop-loop-wakeup-reminder — shouldRemind (pure)', () => {
-  it('TS-1: returns false when the flag is disabled, even for an active /loop worker', () => {
-    expect(shouldRemind({ loopState: 'active', stopHookActive: false, flagEnabled: false })).toBe(false);
+  const unarmedWorker = { armVerdict: 'unarmed', loopState: 'active', stopHookActive: false, flagEnabled: true };
+
+  it('TS-1: returns false when the flag is disabled, even for an unarmed /loop worker', () => {
+    expect(shouldRemind({ ...unarmedWorker, flagEnabled: false })).toBe(false);
   });
 
-  it('TS-2: returns true when enabled, loop_state=active, and first stop (no wakeup armed)', () => {
-    expect(shouldRemind({ loopState: 'active', stopHookActive: false, flagEnabled: true })).toBe(true);
+  it('TS-2: returns true when enabled, unarmed, in-loop, and first stop', () => {
+    expect(shouldRemind(unarmedWorker)).toBe(true);
   });
 
-  it('TS-3: returns false when a wakeup is already armed (loop_state=awaiting_tick)', () => {
-    expect(shouldRemind({ loopState: 'awaiting_tick', stopHookActive: false, flagEnabled: true })).toBe(false);
+  it('TS-3: returns false when a wakeup was genuinely armed this turn', () => {
+    expect(shouldRemind({ ...unarmedWorker, armVerdict: 'armed' })).toBe(false);
   });
 
   it('TS-4: returns false on the second pass (stop_hook_active true) — never block twice', () => {
-    expect(shouldRemind({ loopState: 'active', stopHookActive: true, flagEnabled: true })).toBe(false);
+    expect(shouldRemind({ ...unarmedWorker, stopHookActive: true })).toBe(false);
   });
 
-  it('TS-5: returns false for exited / null / unknown loop_state WITHOUT a claim (operator-safe)', () => {
-    expect(shouldRemind({ loopState: 'exited', stopHookActive: false, flagEnabled: true })).toBe(false);
-    expect(shouldRemind({ loopState: null, stopHookActive: false, flagEnabled: true })).toBe(false);
-    expect(shouldRemind({ loopState: undefined, stopHookActive: false, flagEnabled: true })).toBe(false);
-    expect(shouldRemind({ loopState: 'unknown', stopHookActive: false, flagEnabled: true })).toBe(false);
+  it('TS-5: returns false for exited, and for null/unknown loop_state WITHOUT a claim (operator-safe)', () => {
+    expect(shouldRemind({ ...unarmedWorker, loopState: 'exited' })).toBe(false);
+    for (const loopState of [null, undefined, 'unknown']) {
+      expect(shouldRemind({ ...unarmedWorker, loopState, hasActiveClaim: false })).toBe(false);
+    }
   });
 
   // Coverage-gap (operator 2026-06-10): a worker holding a live SD claim whose loop_state
   // never entered the machine ('unknown'/null) is still about to go silent → remind.
   it('TS-7: returns true for unknown/null loop_state WHEN the session holds an active SD claim', () => {
-    expect(shouldRemind({ loopState: 'unknown', stopHookActive: false, flagEnabled: true, hasActiveClaim: true })).toBe(true);
-    expect(shouldRemind({ loopState: null, stopHookActive: false, flagEnabled: true, hasActiveClaim: true })).toBe(true);
+    for (const loopState of ['unknown', null]) {
+      expect(shouldRemind({ ...unarmedWorker, loopState, hasActiveClaim: true })).toBe(true);
+    }
   });
 
-  it('TS-8: a claim does NOT override the awaiting_tick (wakeup armed) or exited escapes', () => {
-    expect(shouldRemind({ loopState: 'awaiting_tick', stopHookActive: false, flagEnabled: true, hasActiveClaim: true })).toBe(false);
-    expect(shouldRemind({ loopState: 'exited', stopHookActive: false, flagEnabled: true, hasActiveClaim: true })).toBe(false);
+  // CHANGED DELIBERATELY. TS-8 used to assert awaiting_tick was an escape even for a claim-holder.
+  // It is not any more: awaiting_tick is the worker's OWN self-report, and honouring it is exactly
+  // the hole step A closes. 'exited' remains an escape — it is an explicit, deliberate loop
+  // termination, not a claim about having armed.
+  it('TS-8: awaiting_tick is NO LONGER an escape; exited still is', () => {
+    expect(shouldRemind({ ...unarmedWorker, loopState: 'awaiting_tick', hasActiveClaim: true })).toBe(true);
+    expect(shouldRemind({ ...unarmedWorker, loopState: 'exited', hasActiveClaim: true })).toBe(false);
   });
 
   it('TS-9: a claim is ignored when the flag is off or already reminded this turn', () => {
-    expect(shouldRemind({ loopState: 'unknown', stopHookActive: false, flagEnabled: false, hasActiveClaim: true })).toBe(false);
-    expect(shouldRemind({ loopState: 'unknown', stopHookActive: true, flagEnabled: true, hasActiveClaim: true })).toBe(false);
+    expect(shouldRemind({ ...unarmedWorker, loopState: 'unknown', hasActiveClaim: true, flagEnabled: false })).toBe(false);
+    expect(shouldRemind({ ...unarmedWorker, loopState: 'unknown', hasActiveClaim: true, stopHookActive: true })).toBe(false);
   });
 });
 

--- a/scripts/hooks/__tests__/wakeup-arm-evidence.test.js
+++ b/scripts/hooks/__tests__/wakeup-arm-evidence.test.js
@@ -457,6 +457,32 @@ describe('step B — awaiting_tick is stamped only on real arm evidence (AC3, co
   });
 });
 
+// The step-C gate reads feedback(category='wind_down_survey'). That channel had written ZERO rows
+// since it shipped, because source_type='wind_down_survey' violates feedback_source_type_check and
+// recordWindDown swallows the throw to stderr. A dead writer reads identically to an empty
+// population — the gate would have returned 0 forever and killed step C for the wrong reason.
+describe('wind-down mirror writes through a source_type the DB actually accepts', () => {
+  const hookSrc = fs.readFileSync(HOOK_PATH, 'utf8');
+  // Mirrors CHECK feedback_source_type_check (database/schema-reference-snapshot.json:1505).
+  const ALLOWED_SOURCE_TYPES = [
+    'manual_feedback', 'auto_capture', 'uat_failure', 'error_capture', 'uncaught_exception',
+    'unhandled_rejection', 'manual_capture', 'todoist_intake', 'youtube_intake',
+    'claude_code_intake', 'telegram', 'user_feedback',
+  ];
+
+  it('every source_type this hook emits is admitted by the CHECK constraint', () => {
+    const emitted = [...hookSrc.matchAll(/source_type:\s*'([^']+)'/g)].map((m) => m[1]);
+    expect(emitted.length).toBeGreaterThan(0);
+    for (const st of emitted) expect(ALLOWED_SOURCE_TYPES).toContain(st);
+  });
+
+  // The category is the discriminator the gauge registry reads; it was never the blocker and
+  // must not drift while fixing the source_type.
+  it('still files under category wind_down_survey (what the gate and gauge query)', () => {
+    expect(hookSrc).toMatch(/category:\s*'wind_down_survey'/);
+  });
+});
+
 describe('no new hook or registry (constraint)', () => {
   it('the Stop array is unchanged — exactly 6 commands, same set', () => {
     const settings = JSON.parse(fs.readFileSync(SETTINGS, 'utf8'));

--- a/scripts/hooks/__tests__/wakeup-arm-evidence.test.js
+++ b/scripts/hooks/__tests__/wakeup-arm-evidence.test.js
@@ -413,21 +413,47 @@ describe('print-before-park — discriminators (first tests for this file)', () 
 });
 
 // ── Ship-order tripwires: these encode the BUILD ORDER itself as assertions ──
-describe('ship-order tripwires (green during step 0/A, red at step B by design)', () => {
+// STEP B LANDED. The tripwire is UPDATED, not weakened: AC3 stays countable (exactly one call
+// site) and gains the stronger claim — that call site is now UNREACHABLE unless the turn actually
+// armed. Guarding beat deleting: deleting would have stripped the true state from compliant
+// workers too, and all four consumers depend on it being present when it is EARNED.
+describe('step B — awaiting_tick is stamped only on real arm evidence (AC3, countable)', () => {
   const hookSrc = fs.readFileSync(HOOK_PATH, 'utf8');
+  const hook = require(HOOK_PATH);
 
-  // AC3 is countable, so count it. Step B deletes this call site; this test going red IS the
-  // signal that step B landed, at which point it is updated deliberately rather than by accident.
-  it('setLoopState(_, AWAITING_TICK) has EXACTLY ONE call site', () => {
+  it('setLoopState(_, AWAITING_TICK) still has EXACTLY ONE call site', () => {
     const sites = hookSrc.match(/setLoopState\(\s*sessionId\s*,\s*LOOP_STATE_AWAITING_TICK\s*\)/g) || [];
     expect(sites).toHaveLength(1);
   });
 
-  // FR-B1: parkSessionRecoverable writes TWO things. Step B kills the false arm claim and KEEPS
-  // the recoverability write — deleting both would remove the unarmed parked seat from
-  // detectDormantWorkers, losing the only current sighting of this SD's target population.
-  it('parkSessionRecoverable still writes expected_silence_until (kept at step B)', () => {
-    expect(hookSrc).toMatch(/expected_silence_until/);
+  it('that call site sits behind an armVerdict === \'armed\' guard', () => {
+    expect(hookSrc).toMatch(/if \(armVerdict === 'armed'\)[\s\S]{0,300}setLoopState\(\s*sessionId\s*,\s*LOOP_STATE_AWAITING_TICK\s*\)/);
+  });
+
+  // FR-B1: the recoverability write must SURVIVE. Deleting both would drop the seat out of
+  // charter-audit's parked check and dormancy-watchdog's :27 parse, losing the only sighting of
+  // this SD's target population.
+  it('expected_silence_until is still written UNCONDITIONALLY, outside the arm guard', () => {
+    const body = hookSrc.slice(hookSrc.indexOf('async function parkSessionRecoverable'));
+    const guardEnd = body.indexOf('}', body.indexOf('setLoopState('));
+    expect(body.slice(guardEnd).includes('expected_silence_until')).toBe(true);
+  });
+
+  // Behavioural, not just source-shaped: the write must not fire for an unarmed or unknown turn.
+  it('does not touch loop_state for unarmed / unknown / missing verdicts', async () => {
+    const tracker = require(path.resolve(__dirname, '../../lib/sessions/loop-state-tracker.cjs'));
+    const orig = tracker.setLoopState;
+    const calls = [];
+    tracker.setLoopState = async (...a) => { calls.push(a); };
+    try {
+      for (const armVerdict of ['unarmed', 'unknown', undefined]) {
+        await hook.parkSessionRecoverable('11111111-2222-4333-8444-555555555555', { armVerdict });
+      }
+      expect(calls).toHaveLength(0);
+      await hook.parkSessionRecoverable('11111111-2222-4333-8444-555555555555', { armVerdict: 'armed' });
+      expect(calls).toHaveLength(1);
+      expect(calls[0][1]).toBe('awaiting_tick');
+    } finally { tracker.setLoopState = orig; }
   });
 });
 

--- a/scripts/hooks/__tests__/wakeup-arm-evidence.test.js
+++ b/scripts/hooks/__tests__/wakeup-arm-evidence.test.js
@@ -192,11 +192,70 @@ describe('turn boundary — promptId primary, origin fallback', () => {
   });
 });
 
+// FR-3 — THE POPULATION THAT ACTUALLY FAILS. Arm compliance is ~100% on failure-shaped turns
+// (an error is salient, the worker is still "in" the task) and decays toward zero on
+// success-terminal ones, where a dense closing summary displaces the mechanical step. A suite
+// that only exercises failure paths passes while leaving the entire real failure population
+// untouched — so the specimens below are all SUCCESS-shaped.
+describe('FR-3 — success-terminal unarmed turns are the target, and they block', () => {
+  const { shouldRemind } = require(HOOK_PATH);
+  const u = (promptId) => ({ type: 'user', promptId, message: { content: [{ type: 'tool_result' }] } });
+  const worker = { loopState: 'active', flagEnabled: true, hasActiveClaim: true, stopHookActive: false };
+
+  // The exact shape of all three recorded dormancies: work done, tests green, a long closing
+  // summary written — and the wakeup never armed because the summary displaced it.
+  it('a turn that ends on a successful summary with no arm is UNARMED and blocks', () => {
+    const specimen = [u('t1'), otherTool('Bash'), otherTool('Edit'), textEntry('All 362 tests pass. Shipped as PR #6741.')];
+    const v = ev.findArmInCurrentTurn(specimen);
+    expect(v.verdict).toBe('unarmed');
+    expect(shouldRemind({ ...worker, armVerdict: v.verdict })).toBe(true);
+  });
+
+  // Charlie's false positive, reproduced deliberately: the worker SAYS it armed, in the same
+  // turn, in text. Text is not a tool call.
+  it('a turn that ANNOUNCES "wakeup armed" in text but never calls the tool still blocks', () => {
+    const specimen = [u('t1'), otherTool('Bash'), textEntry('Done. wakeup-armed +900s at 17:53.')];
+    const v = ev.findArmInCurrentTurn(specimen);
+    expect(v.verdict).toBe('unarmed');
+    expect(shouldRemind({ ...worker, armVerdict: v.verdict })).toBe(true);
+  });
+
+  // The same announcement mirrored into the DB as the worker's self-report. The OLD predicate
+  // read exactly this and allowed the stop.
+  it('the same turn still blocks even with loop_state=awaiting_tick claiming otherwise', () => {
+    const v = ev.findArmInCurrentTurn([u('t1'), textEntry('wakeup-armed +900s')]);
+    expect(shouldRemind({ ...worker, loopState: 'awaiting_tick', armVerdict: v.verdict })).toBe(true);
+  });
+
+  // STALE ARM, end to end: a real ScheduleWakeup exists in the transcript — one turn too early.
+  it('a success-shaped turn whose only arm is in the PREVIOUS turn blocks (stale arm)', () => {
+    const specimen = [u('t1'), armEntry({ delaySeconds: 900 }), textEntry('tick done'),
+      u('t2'), otherTool('Bash'), textEntry('next tick done')];
+    const v = ev.findArmInCurrentTurn(specimen);
+    expect(v.verdict).toBe('unarmed');
+    expect(v.armCount).toBe(0);
+    expect(shouldRemind({ ...worker, armVerdict: v.verdict })).toBe(true);
+  });
+
+  // The compliant shape this SD is trying to produce: arm, THEN summarise.
+  it('arming before the closing summary is compliant and does NOT block', () => {
+    const specimen = [u('t1'), otherTool('Bash'), armEntry({ delaySeconds: 900 }), textEntry('Shipped. Next tick in 15m.')];
+    const v = ev.findArmInCurrentTurn(specimen);
+    expect(v.verdict).toBe('armed');
+    expect(shouldRemind({ ...worker, armVerdict: v.verdict })).toBe(false);
+  });
+
+  it('a deliberate ScheduleWakeup({stop:true}) loop-end is not treated as a failure to arm', () => {
+    const v = ev.findArmInCurrentTurn([u('t1'), armEntry({ stop: true }), textEntry('loop complete')]);
+    expect(v.stopRequested).toBe(true);
+    expect(shouldRemind({ ...worker, armVerdict: v.verdict })).toBe(false);
+  });
+});
+
 describe('stdout decision-channel muzzle', () => {
   const hook = require(HOOK_PATH);
+  const hookSrc = fs.readFileSync(HOOK_PATH, 'utf8');
 
-  // Requiring the supabase client loads dotenv, which writes ~80 bytes of banner to STDOUT — the
-  // channel Claude Code parses as the Stop decision. Measured pre-existing at git HEAD.
   it('discards stdout writes made inside the muzzle', () => {
     const chunks = [];
     const real = process.stdout.write;
@@ -213,11 +272,28 @@ describe('stdout decision-channel muzzle', () => {
     expect(process.stdout.write).toBe(before);
   });
 
-  // A throw inside the muzzle must not leave stdout muted for the decision write that follows.
   it('restores stdout even when the callee throws', () => {
     const before = process.stdout.write;
     expect(() => hook.muzzleStdout(() => { throw new Error('boom'); })).toThrow('boom');
     expect(process.stdout.write).toBe(before);
+  });
+
+  // THE CLASS FIX, MADE COUNTABLE. A scoped muzzle around the one require I had MEASURED was an
+  // instance fix: the allow path still emitted 87 bytes from a different transitive require
+  // (park-worker / emit-feedback), caught only by an end-to-end run. The muzzle now installs at
+  // module load, so the invariant is structural — exactly one write reaches the real stdout, and
+  // it is the decision. A new `process.stdout.write(...)` anywhere else turns this red.
+  it('the real stdout has exactly ONE writer, and it is emitDecision', () => {
+    const realWrites = hookSrc.match(/REAL_STDOUT_WRITE\(/g) || [];
+    expect(realWrites).toHaveLength(1);
+    expect(hookSrc).toMatch(/function emitDecision[\s\S]{0,200}REAL_STDOUT_WRITE\(/);
+    // the muzzle is armed before any require below it can print
+    expect(hookSrc.indexOf('process.stdout.write = () => true;')).toBeLessThan(hookSrc.indexOf("require('../lib/sessions/loop-state-tracker.cjs')"));
+  });
+
+  it('the block decision is emitted through emitDecision, not a raw write', () => {
+    expect(hookSrc).toMatch(/emitDecision\(\{\s*decision:\s*'block'/);
+    expect(hookSrc).not.toMatch(/process\.stdout\.write\(JSON\.stringify/);
   });
 });
 

--- a/scripts/hooks/stop-loop-wakeup-reminder.cjs
+++ b/scripts/hooks/stop-loop-wakeup-reminder.cjs
@@ -161,17 +161,54 @@ function shouldParkRecoverable({ loopState, hasActiveClaim, windDownSignaled } =
 }
 
 /**
- * Write a RECOVERABLE park-state for the session: loop_state='awaiting_tick' + a capped
- * expected_silence_until, reusing the post-tool-loop-state.cjs writeTelemetryAwait pattern so
- * coordinator-revival / orphan-adoption deterministically re-engages the worker (no cold-exit).
+ * STEP B — write a RECOVERABLE park-state: a capped expected_silence_until ALWAYS, and
+ * loop_state='awaiting_tick' ONLY WHEN THE TURN ACTUALLY ARMED.
+ *
+ * FR-B1's requirement is "no code path stamps armed-state without an actual ScheduleWakeup tool
+ * call". This function was that path: it stamped awaiting_tick — a claim that a wakeup is pending —
+ * on every parked worker, armed or not. Now that step A produces real arm evidence, the write is
+ * GUARDED by it rather than deleted. Guarding beats deleting: a genuinely armed worker keeps the
+ * true state and all four consumers below behave exactly as before, so the change costs nothing on
+ * the compliant path and only removes the FALSE claim.
+ *
+ * THE FOUR ACTUATING CONSUMERS, and what each does once an unarmed seat stops being stamped
+ * (an unarmed /loop worker's loop_state remains 'active', which is accurate — it was looping and
+ * did not arm):
+ *   1. dormancy-watchdog.cjs isDormant:25 — gates on loop_state ∈ {awaiting_tick, active} FIRST,
+ *      then expected_silence_until. Unarmed seats stay 'active' ⇒ STILL DETECTED.
+ *      NOTE FR-B1 IS WRONG ON THE MECHANISM: it says keeping expected_silence_until preserves
+ *      visibility, but :25 short-circuits on loop_state BEFORE :26 ever reads that field. What
+ *      actually preserves visibility is 'active' already being in the set. Keeping
+ *      expected_silence_until is still required — :27 rejects an unparseable one — but it is not
+ *      sufficient on its own, and a seat whose loop_state is null/'unknown' would be invisible.
+ *      MEASURED 2026-08-02: of 4 claim-holding sessions, loop_state was {awaiting_tick:2,
+ *      active:2} and ZERO fell outside the set. That is a point-in-time sample, not a proof the
+ *      null/'unknown' population is empty in general.
+ *   2. session-watchdog.js classifyWatchdogState:48 — 'parked' ⇒ STOPPED ⇒ never restarted.
+ *      It also treats a live expected_silence_until window as parked, so behaviour is UNCHANGED
+ *      while the window is open. Once it elapses, an unarmed seat now classifies CRASHED/AUTH-LOST
+ *      and becomes ACTIONABLE. That is the point: a dead seat should be revived, not left parked
+ *      forever by a sticky flag it never earned.
+ *   3. singleton-relaunch-trigger.js SAFE_LOOP_STATES:47 — ['awaiting_tick','exited']; anything
+ *      else FAILS CLOSED (no relaunch). An unarmed singleton now reads 'active' ⇒ relaunch is NOT
+ *      scheduled. Conservative, and it removes a real contradiction: the same false stamp was
+ *      simultaneously telling consumer 2 "parked, do not restart" and consumer 3 "safe to
+ *      relaunch". Armed singletons are unaffected — they still stamp awaiting_tick, both here and
+ *      via post-tool-loop-state.cjs, which is the LEGITIMATE writer (it fires on the actual tool call).
+ *   4. charter-audit-detectors.mjs isParked:83 — awaiting_tick OR inside the armed-silence window.
+ *      expected_silence_until is still written unconditionally ⇒ UNCHANGED; parked workers are
+ *      still excluded from the neglect flag, so no false starvation alarms.
+ *
  * Best-effort / fail-open — any failure is logged and never blocks the stop.
  */
-async function parkSessionRecoverable(sessionId) {
-  try {
-    const { setLoopState } = require('../lib/sessions/loop-state-tracker.cjs');
-    await setLoopState(sessionId, LOOP_STATE_AWAITING_TICK);
-  } catch (e) {
-    process.stderr.write(`[stop-loop-wakeup-reminder] park loop-state (non-fatal): ${e.message}\n`);
+async function parkSessionRecoverable(sessionId, { armVerdict } = {}) {
+  if (armVerdict === 'armed') {
+    try {
+      const { setLoopState } = require('../lib/sessions/loop-state-tracker.cjs');
+      await setLoopState(sessionId, LOOP_STATE_AWAITING_TICK);
+    } catch (e) {
+      process.stderr.write(`[stop-loop-wakeup-reminder] park loop-state (non-fatal): ${e.message}\n`);
+    }
   }
   try {
     const { computeSilenceMinutes } = require('../park-worker.cjs');
@@ -443,7 +480,7 @@ async function main() {
     // work, PARK it recoverable (loop_state='awaiting_tick' + capped expected_silence_until) so
     // coordinator-revival / orphan-adoption re-engages it, instead of a cold-exit to zero workers.
     if (shouldParkRecoverable({ loopState, hasActiveClaim, windDownSignaled })) {
-      await parkSessionRecoverable(sessionId);
+      await parkSessionRecoverable(sessionId, { armVerdict });
       // SD-LEO-INFRA-WORKER-WINDDOWN-SURVEY-001 (a)+(c): capture WHY this worker wound down
       // (same worker-gate as the park, so no false telemetry on a non-worker operator session).
       await recordWindDown(supabase, sessionId, {

--- a/scripts/hooks/stop-loop-wakeup-reminder.cjs
+++ b/scripts/hooks/stop-loop-wakeup-reminder.cjs
@@ -32,6 +32,31 @@
  * 'active' (no wakeup armed) — exactly the attrition case it guards.
  */
 
+// ── STDOUT IS THE DECISION CHANNEL — MUZZLED BEFORE ANYTHING ELSE LOADS ──────
+// Claude Code parses this hook's stdout as the Stop decision document. Requiring the supabase
+// client loads dotenv, which writes an ~80-byte "◇ injected env …" banner to STDOUT (measured
+// 2026-08-02; PRE-EXISTING — git HEAD already required it). Worse, that banner's tip text
+// contains a literal "{", so it is not merely a preamble: it defeats find-first-brace extraction
+// and yields a SyntaxError instead of a decision. (Observed live — it broke an unrelated parse of
+// worker-checkin.cjs stdout the same day.)
+//
+// A scoped muzzle around the ONE require I had measured was the instance fix, not the class fix:
+// the allow path still emitted 87 bytes from a DIFFERENT transitive require (park-worker /
+// emit-feedback). So the muzzle is installed at module load, before any require below runs, and
+// stdout is restored ONLY to emit the decision. Everything else on this hook's stdout is dropped.
+// stderr is untouched. AC: process.stdout.write appears exactly ONCE outside these two helpers.
+const REAL_STDOUT_WRITE = process.stdout.write.bind(process.stdout);
+process.stdout.write = () => true;
+
+/** The ONLY path back onto stdout. Writes the decision document and re-muzzles. */
+function emitDecision(payload) {
+  try {
+    REAL_STDOUT_WRITE(JSON.stringify(payload));
+  } finally {
+    process.stdout.write = () => true;
+  }
+}
+
 const {
   LOOP_STATE_ACTIVE,
   LOOP_STATE_AWAITING_TICK,
@@ -64,30 +89,50 @@ async function shutdown() {
 
 /**
  * Pure decision: should the Stop hook block-and-remind this turn?
- * Block when the reminder is enabled, we have not already reminded this turn, AND the session
- * is a worker about to go silent without a wakeup armed. Two worker signals:
- *   - loop_state='active' (in a /loop, no wakeup armed), OR
- *   - the session holds an active SD claim while loop_state never entered the machine
- *     ('unknown'/null) — the coverage gap where a working worker would otherwise stop silently.
- * Operator/coordinator/Adam sessions hold no sd-start claim and never reach 'active', so they
- * are never trapped; and the block fires at most once per turn (stop_hook_active guard).
- * @param {{ loopState: string|null|undefined, stopHookActive: boolean, flagEnabled: boolean, hasActiveClaim?: boolean }} args
+ *
+ * STEP A (SD-LEO-INFRA-TERMINAL-RITUAL-ENFORCEMENT-001): the block now derives from TRANSCRIPT
+ * EVIDENCE of a ScheduleWakeup tool_use in the current turn, not from loop_state. The old
+ * predicate read a flag the worker sets about itself, so a worker that believed it had armed —
+ * or said so — satisfied it without the tool ever being called.
+ *
+ * WHAT THIS CAN AND CANNOT DO. It blocks ONCE per turn; a worker that stops again passes through
+ * (stop_hook_active, the anti-infinite-loop guard). For the dormancy this SD targets there is no
+ * later turn to re-block — the seat is gone — so step A is a one-shot NUDGE, not a compulsion.
+ * The escape is therefore COUNTED (classifyWindDownReason → 'second_stop_still_unarmed'): that
+ * number is how often a reminder was seen and ignored, and it is the evidence base for step C,
+ * which arms on the worker's behalf and is the actual enforcement.
+ *
+ * @param {{ armVerdict?: 'armed'|'unarmed'|'unknown', loopState?: string|null, stopHookActive?: boolean,
+ *           flagEnabled?: boolean, enforcementDisabled?: boolean, hasActiveClaim?: boolean }} args
  * @returns {boolean}
  */
-function shouldRemind({ loopState, stopHookActive, flagEnabled, hasActiveClaim, windDownSignaled }) {
+function shouldRemind({ armVerdict, loopState, stopHookActive, flagEnabled, enforcementDisabled, hasActiveClaim }) {
   if (!flagEnabled) return false;                       // default-OFF: no-op
+  if (enforcementDisabled) return false;                // runtime kill switch (FR-2)
   if (stopHookActive) return false;                     // never block twice — already reminded
-  // ALLOW-PATH (SD-LEO-INFRA-LOOP-CONTINUITY-ENFORCE-001, exit-mode 4c): a worker that
-  // announced its wind-down via /signal (session_coordination) is making a LEGITIMATE,
-  // coordinator-visible stop — never block it. Closes the false-positive where a worker
-  // does the handshake and then gets trapped by the reminder.
-  if (windDownSignaled) return false;
-  if (loopState === LOOP_STATE_ACTIVE) return true;     // in-loop, no wakeup armed
-  if (loopState === LOOP_STATE_AWAITING_TICK) return false; // wakeup already armed — fine
   if (loopState === LOOP_STATE_EXITED) return false;    // loop legitimately ended
-  // loop_state 'unknown'/null: remind ONLY if this session holds a live SD claim (= a worker
-  // about to abandon in-progress work). A claim-less interactive session is never reminded.
-  return Boolean(hasActiveClaim);
+
+  // WORKER GATE (FR-4). Worker-shape is a CLAIM or a live loop state — NOT an announcement.
+  // This is what keeps operators safe, and it replaces the old windDownSignaled allow-path,
+  // which returned false for ANY session that merely said "winding down". That allow-path was
+  // simultaneously too wide and too narrow: it let a worker talk its way out of the arm
+  // requirement, and (shouldParkRecoverable:112, same defect) it parked operators into
+  // awaiting_tick, where an aged-out window then blocked THEIR turn-end.
+  const isWorker = Boolean(hasActiveClaim)
+    || loopState === LOOP_STATE_ACTIVE
+    || loopState === LOOP_STATE_AWAITING_TICK;
+  if (!isWorker) return false;
+
+  // ARM EVIDENCE (FR-3). ONLY an actual ScheduleWakeup tool_use in the CURRENT turn excuses the
+  // stop. An announcement does not — not a /signal saying "wakeup armed", not loop_state, not
+  // metadata. That is Charlie's false positive, and it is the whole point of this predicate:
+  // the old one read loop_state='awaiting_tick', which post-tool-loop-state.cjs sets from the
+  // worker's own claim about itself, so the enforcement was asking the suspect for an alibi.
+  if (armVerdict === 'armed') return false;
+  if (armVerdict === 'unarmed') return true;
+  // 'unknown' — no boundary in the tail window, or no transcript. Absence of evidence is not
+  // evidence of absence: fail open rather than trap a worker on an unreadable transcript.
+  return false;
 }
 
 function isFlagEnabled() {
@@ -173,7 +218,13 @@ async function parkSessionRecoverable(sessionId) {
  * @param {{ windDownSignaled?:boolean, stopHookActive?:boolean, hasActiveClaim?:boolean, loopState?:string|null }} args
  * @returns {'signaled'|'second_stop'|'turn_end_with_claim_wakeup_scheduled'|'turn_end_wakeup_scheduled'|'turn_end_with_claim_no_wakeup'|'no_claim_idle'}
  */
-function classifyWindDownReason({ windDownSignaled, stopHookActive, hasActiveClaim, loopState } = {}) {
+function classifyWindDownReason({ windDownSignaled, stopHookActive, hasActiveClaim, loopState, armVerdict } = {}) {
+  // STEP A — THE COUNTABLE IGNORE. A worker that reached a SECOND stop while still carrying no
+  // arm evidence saw the reminder and stopped anyway. This is the population step A cannot save
+  // (the anti-infinite-loop guard lets it through) and the exact population step C exists for.
+  // Counted before 'signaled' so an announcement cannot mask it — announcing is what these
+  // workers do INSTEAD of arming, and folding them into 'signaled' would hide the whole class.
+  if (stopHookActive && armVerdict === 'unarmed' && hasActiveClaim) return 'second_stop_still_unarmed';
   if (windDownSignaled) return 'signaled';
   if (stopHookActive) return 'second_stop';
   if (loopState === LOOP_STATE_AWAITING_TICK) {
@@ -225,6 +276,10 @@ async function recordWindDown(supabase, sessionId, { reason, hadClaim } = {}) {
 }
 
 const REMINDER = [
+  'NO ScheduleWakeup tool_use found in THIS turn. This is read from the transcript, not from any',
+  'state you set: saying "wakeup armed" in a /signal, or having loop_state=awaiting_tick, does NOT',
+  'satisfy it. Only calling the tool does. If you believe you armed one, you armed it in a PREVIOUS',
+  'turn — that is the stale-arm case this check exists to catch.',
   'Worker stopping with NO ScheduleWakeup armed — you will go INCOGNITO and strand your claimed SD',
   '(the worktree then gets reaped by the claim-sweep). Run the WIND-DOWN HANDSHAKE before you stop:',
   "  1. If you hold an IN-PROGRESS SD: FINISH it or hand it off — never leave it half-done + unclaimed (orphan).",
@@ -291,15 +346,9 @@ async function main() {
     const sessionId = payload.session_id || process.env.CLAUDE_SESSION_ID || process.env.SESSION_ID || '';
     if (!sessionId) { return shutdown(); }       // can't resolve — fail-open
 
-    // STDOUT IS THE DECISION CHANNEL. Requiring the supabase client loads dotenv, which writes an
-    // 80-byte "◇ injected env …" banner to STDOUT — MEASURED 2026-08-02, and PRE-EXISTING (git HEAD
-    // already required this module at the same point). That put a non-JSON preamble in front of
-    // every block decision this hook has ever emitted; it is the only blocking Stop hook that
-    // requires supabase-client, and therefore the only one with a polluted channel. Whether Claude
-    // Code tolerates the preamble is unverified — but a decision document that MIGHT not parse, on
-    // the hook every seat traverses every turn, is exactly the silent-failure shape this SD exists
-    // to remove. Muzzled synchronously around the require; stderr is untouched.
-    const { createSupabaseServiceClient } = muzzleStdout(() => require('../../lib/supabase-client.cjs'));
+    // (stdout is muzzled at module load — see the header. This require is one of at least two
+    // that print a dotenv banner; the park path carries another.)
+    const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
     const supabase = createSupabaseServiceClient();
     const { data, error } = await supabase
       .from('claude_sessions')
@@ -361,6 +410,8 @@ async function main() {
     // add 2.5s to every operator turn-end to measure a population it is not in. Same predicate as
     // the park below, so the observation covers exactly the seats the enforcement will act on.
     const workerShaped = shouldParkRecoverable({ loopState, hasActiveClaim, windDownSignaled });
+    let armVerdict;                       // undefined ⇒ not evaluated ⇒ treated as 'unknown'
+    let armObservation = null;
     if (!enforcementDisabled && workerShaped && payload.transcript_path) {
       try {
         const fs = require('fs');
@@ -369,17 +420,22 @@ async function main() {
           if (!fs.existsSync(payload.transcript_path)) return { verdict: 'unknown', reason: 'transcript absent', armCount: 0 };
           return armEvidence.findArmInCurrentTurn(readTailEntries(payload.transcript_path));
         };
-        const obs = await armEvidence.awaitStableVerdict({ read, sleep: (ms) => new Promise((r) => setTimeout(r, ms)) });
-        process.stderr.write(armEvidence.formatPendingWake(obs, { sessionId }));
+        armObservation = await armEvidence.awaitStableVerdict({ read, sleep: (ms) => new Promise((r) => setTimeout(r, ms)) });
+        armVerdict = armObservation.stable && armObservation.stable.verdict;
+        process.stderr.write(armEvidence.formatPendingWake(armObservation, { sessionId }));
       } catch (e) {
+        // Fail-open: an unreadable transcript leaves armVerdict undefined ⇒ never blocks.
         process.stderr.write(`[stop-loop-wakeup-reminder] pending-wake observe (non-fatal): ${e.message}\n`);
       }
     }
 
-    if (shouldRemind({ loopState, stopHookActive, flagEnabled, hasActiveClaim, windDownSignaled })) {
+    if (shouldRemind({ armVerdict, loopState, stopHookActive, flagEnabled, enforcementDisabled, hasActiveClaim })) {
       // BLOCK — the worker must arm its OWN ScheduleWakeup; do not park on its behalf (parking here
       // would let it cold-exit anyway by satisfying the recoverable-state check it should set itself).
-      process.stdout.write(JSON.stringify({ decision: 'block', reason: REMINDER }));
+      // The block reason is the ONLY channel that reaches the model, so the pending-wake state
+      // rides here rather than on stderr (which the model never sees on a blocking Stop).
+      const detail = armObservation ? `\n${armEvidence.formatPendingWake(armObservation, { sessionId }).trim()}` : '';
+      emitDecision({ decision: 'block', reason: REMINDER + detail });
       return shutdown();
     }
     // ALLOW-PATH (SD-LEO-INFRA-WORKER-ENGAGEMENT-ARM-PARK-001): the stop is allowed — windDownSignaled
@@ -391,7 +447,7 @@ async function main() {
       // SD-LEO-INFRA-WORKER-WINDDOWN-SURVEY-001 (a)+(c): capture WHY this worker wound down
       // (same worker-gate as the park, so no false telemetry on a non-worker operator session).
       await recordWindDown(supabase, sessionId, {
-        reason: classifyWindDownReason({ windDownSignaled, stopHookActive, hasActiveClaim, loopState }),
+        reason: classifyWindDownReason({ windDownSignaled, stopHookActive, hasActiveClaim, loopState, armVerdict }),
         hadClaim: hasActiveClaim,
       });
     }

--- a/scripts/hooks/stop-loop-wakeup-reminder.cjs
+++ b/scripts/hooks/stop-loop-wakeup-reminder.cjs
@@ -398,6 +398,13 @@ function readStdinPayload(timeoutMs = 2000) {
 // So the hook bounds its own discretionary work instead of assuming the environment is fast: the
 // stabilisation re-read gets whatever is LEFT of the budget after the DB calls, never a fixed 2.5s.
 const HOOK_WORK_BUDGET_MS = 6000;
+// Reserved OUT of the budget for the block-telemetry write, which the stabilisation re-read may
+// not consume. Both are optional work, but they are not equally valuable: the re-read is
+// OBSERVATIONAL (it refines a verdict that is already usable), while the block record is
+// DECISION-CRITICAL — without it, second_stop_still_unarmed=0 cannot be told apart from "no block
+// ever fired", and the step-C gate reverts to meaningless. Racing them for the same budget
+// silently starved the more important one: MEASURED, the write got timed out at the cap.
+const TELEMETRY_RESERVE_MS = 2500;
 
 async function main() {
   const hookStartedAt = Date.now();
@@ -493,7 +500,9 @@ async function main() {
         armObservation = await armEvidence.awaitStableVerdict({
           read,
           sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
-          deadlineMs: Math.min(2500, remainingBudgetMs()),
+          // Whatever the DB calls left, MINUS the telemetry reserve — this observational re-read
+          // must not eat the budget the decision-critical block record needs.
+          deadlineMs: Math.max(0, Math.min(2500, remainingBudgetMs() - TELEMETRY_RESERVE_MS)),
         });
         armVerdict = armObservation.stable && armObservation.stable.verdict;
         process.stderr.write(armEvidence.formatPendingWake(armObservation, { sessionId }));
@@ -510,6 +519,25 @@ async function main() {
       // rides here rather than on stderr (which the model never sees on a blocking Stop).
       const detail = armObservation ? `\n${armEvidence.formatPendingWake(armObservation, { sessionId }).trim()}` : '';
       emitDecision({ decision: 'block', reason: REMINDER + detail });
+      // RECORD THE BLOCK. Without this the step-C gate is UNINTERPRETABLE, and I only noticed
+      // because I asked what state would silence it and whether anyone can reach that state.
+      // 'second_stop_still_unarmed' requires TWO events: (1) a block fires, then (2) the worker
+      // stops again still unarmed. Step (2) was recorded; step (1) was not. A zero therefore meant
+      // EITHER "no block has ever fired, so (2) is unreachable" OR "blocks fire and every worker
+      // complies" — opposite conclusions, indistinguishable, and I had been treating the zero as
+      // evidence for the second. Recording the block makes the ratio readable: blocks>0 with
+      // second_stop_still_unarmed=0 is genuine compliance; blocks=0 means the enforcement never
+      // engages and the gate says nothing about step C at all.
+      // Emitted AFTER the decision is already on stdout — but that ordering alone is NOT enough.
+      // A hook killed at the 10s timeout returns no decision at all, so work done after the write
+      // can still cost the decision it was meant to annotate. MEASURED: this write added ~1.9s
+      // (3260ms -> 5146ms), which fits the 6s budget locally and would NOT fit on the CI-class
+      // hardware that spent 7.2s on the cheapest path. So it is raced against whatever budget is
+      // left: telemetry may be dropped, the decision may not.
+      await Promise.race([
+        recordWindDown(supabase, sessionId, { reason: 'blocked_unarmed', hadClaim: hasActiveClaim }),
+        new Promise((r) => setTimeout(r, remainingBudgetMs())),
+      ]);
       return shutdown();
     }
     // ALLOW-PATH (SD-LEO-INFRA-WORKER-ENGAGEMENT-ARM-PARK-001): the stop is allowed — windDownSignaled

--- a/scripts/hooks/stop-loop-wakeup-reminder.cjs
+++ b/scripts/hooks/stop-loop-wakeup-reminder.cjs
@@ -302,7 +302,19 @@ async function recordWindDown(supabase, sessionId, { reason, hadClaim } = {}) {
       description: `Worker session ${sessionId} wound down: reason=${reason}, had_claim=${!!hadClaim}.`,
       category: 'wind_down_survey',
       severity: 'low',
-      source_type: 'wind_down_survey',
+      // 'wind_down_survey' is a valid CATEGORY but NOT a valid source_type: CHECK
+      // feedback_source_type_check admits only a fixed list, and machine telemetry uses
+      // 'auto_capture' (1000/1000 sampled rows). The old value threw on EVERY call, and the
+      // catch below swallowed it to stderr — so this mirror has written ZERO rows since it
+      // shipped, while reading as healthy. Measured 2026-08-02: 0 rows for the category, and a
+      // direct emitFeedback call reproduced the constraint violation; swapping this one value
+      // made the row land and the count go 0 -> 1.
+      //
+      // THIS IS LOAD-BEARING FOR THIS SD. Step A's 'second_stop_still_unarmed' — the substitute
+      // shipped INSTEAD of the debt marker, and the pre-registered gate for step C — writes
+      // through here. Left unfixed, that gate would have read 0 forever and killed step C for
+      // the wrong reason: not "the population is empty" but "the instrument was never plugged in".
+      source_type: 'auto_capture',
       metadata: { session_id: sessionId, reason, had_claim: !!hadClaim, at },
       // One row per session per minute-bucket per reason — idempotent if the hook fires twice.
       dedup_key: `wind_down::${sessionId}::${reason}::${at.slice(0, 16)}`,

--- a/scripts/hooks/stop-loop-wakeup-reminder.cjs
+++ b/scripts/hooks/stop-loop-wakeup-reminder.cjs
@@ -381,7 +381,19 @@ function readStdinPayload(timeoutMs = 2000) {
   });
 }
 
+// TOTAL WORK BUDGET. The hook is registered with a 10s timeout, and a TIMED-OUT Stop hook returns
+// NO DECISION — the enforcement silently vanishes exactly when the machine is loaded, which is the
+// failure shape this whole SD exists to remove. MEASURED on CI 2026-08-02: the cheapest path (fail
+// open, no transcript) took 7198ms against 412ms locally — a 17x spread on a runner whose
+// node_modules probe was failing. If the CHEAPEST path costs 7.2s there, the block path (this
+// budget + 3-5 DB round trips) would blow the timeout outright.
+// So the hook bounds its own discretionary work instead of assuming the environment is fast: the
+// stabilisation re-read gets whatever is LEFT of the budget after the DB calls, never a fixed 2.5s.
+const HOOK_WORK_BUDGET_MS = 6000;
+
 async function main() {
+  const hookStartedAt = Date.now();
+  const remainingBudgetMs = () => Math.max(0, HOOK_WORK_BUDGET_MS - (Date.now() - hookStartedAt));
   try {
     const flagEnabled = isFlagEnabled();
     if (!flagEnabled) { return shutdown(); }     // default-OFF fast path
@@ -469,7 +481,12 @@ async function main() {
           if (!fs.existsSync(payload.transcript_path)) return { verdict: 'unknown', reason: 'transcript absent', armCount: 0 };
           return armEvidence.findArmInCurrentTurn(readTailEntries(payload.transcript_path));
         };
-        armObservation = await armEvidence.awaitStableVerdict({ read, sleep: (ms) => new Promise((r) => setTimeout(r, ms)) });
+        // Whatever is LEFT of the budget — the DB round-trips above already spent some of it.
+        armObservation = await armEvidence.awaitStableVerdict({
+          read,
+          sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+          deadlineMs: Math.min(2500, remainingBudgetMs()),
+        });
         armVerdict = armObservation.stable && armObservation.stable.verdict;
         process.stderr.write(armEvidence.formatPendingWake(armObservation, { sessionId }));
       } catch (e) {

--- a/tests/unit/hooks/stop-loop-park-recoverable.test.js
+++ b/tests/unit/hooks/stop-loop-park-recoverable.test.js
@@ -33,18 +33,33 @@ describe('shouldParkRecoverable (SD-LEO-INFRA-WORKER-ENGAGEMENT-ARM-PARK-001)', 
   });
 });
 
+// SEPARATION OF CONCERNS (unchanged by step A): blocking and parking are independent decisions.
+// A stop that is ALLOWED through must still leave the worker parked-recoverable, or it cold-exits
+// to zero. Step A changes only what BLOCKS; every park assertion below is untouched.
 describe('shouldRemind allow-paths still allow (then the caller parks)', () => {
-  const base = { flagEnabled: true, stopHookActive: false, hasActiveClaim: true };
-  it('windDownSignaled → no block (allow-path), but the worker holds a claim → will be parked', () => {
-    expect(shouldRemind({ ...base, loopState: 'active', windDownSignaled: true })).toBe(false);
+  const base = { flagEnabled: true, stopHookActive: false, hasActiveClaim: true, armVerdict: 'unarmed' };
+
+  // REWRITTEN for step A. This case used to assert that ANNOUNCING a wind-down suppressed the
+  // block. It no longer does — that was Charlie's false positive. The worker is blocked, and is
+  // still parked recoverable, which is the invariant this file actually guards.
+  it('windDownSignaled no longer excuses an unarmed worker, but the park is unaffected', () => {
+    expect(shouldRemind({ ...base, loopState: 'active', windDownSignaled: true })).toBe(true);
     expect(shouldParkRecoverable({ loopState: 'active', hasActiveClaim: true, windDownSignaled: true })).toBe(true);
   });
+
   it('second-stop (stopHookActive) → no block (allow-path), claim-holder → parked', () => {
     expect(shouldRemind({ ...base, loopState: 'active', stopHookActive: true })).toBe(false);
     expect(shouldParkRecoverable({ loopState: 'active', hasActiveClaim: true })).toBe(true);
   });
-  it('a still-active loop worker (no wind-down, first stop) is BLOCKED (not yet an allow-path)', () => {
-    expect(shouldRemind({ flagEnabled: true, stopHookActive: false, hasActiveClaim: false, loopState: 'active', windDownSignaled: false })).toBe(true);
+
+  it('an unarmed loop worker at first stop is BLOCKED (not yet an allow-path)', () => {
+    expect(shouldRemind({ flagEnabled: true, stopHookActive: false, hasActiveClaim: false, loopState: 'active', armVerdict: 'unarmed' })).toBe(true);
+  });
+
+  // The allow-path that remains: real arm evidence. It is allowed AND parked.
+  it('a genuinely armed worker is allowed through and still parked recoverable', () => {
+    expect(shouldRemind({ ...base, loopState: 'active', armVerdict: 'armed' })).toBe(false);
+    expect(shouldParkRecoverable({ loopState: 'active', hasActiveClaim: true })).toBe(true);
   });
 });
 
@@ -124,5 +139,40 @@ describe('classifyWindDownReason (SD-LEO-INFRA-WORKER-WINDDOWN-SURVEY-001)', () 
     for (const loopState of ['active', null, 'exited', 'unknown']) {
       expect(classifyWindDownReason({ hasActiveClaim: false, loopState })).toBe('no_claim_idle');
     }
+  });
+
+  // STEP A — THE COUNTABLE IGNORE. The block fires once; a worker that stops again passes through
+  // the anti-infinite-loop guard, and for this dormancy there IS no later turn to re-block. So
+  // step A cannot compel — it can only count how often a reminder was seen and ignored, which is
+  // the evidence base for step C (auto-arm). If this value never appears, step C is unjustified;
+  // if it dominates, the nudge is insufficient and step C is the whole fix.
+  describe("'second_stop_still_unarmed' — the population step A cannot save", () => {
+    const ignored = { stopHookActive: true, armVerdict: 'unarmed', hasActiveClaim: true };
+
+    it('a claim-holder that reached a second stop still unarmed is counted distinctly', () => {
+      expect(classifyWindDownReason(ignored)).toBe('second_stop_still_unarmed');
+    });
+
+    // Announcing is what these workers do INSTEAD of arming, so 'signaled' must not absorb them.
+    it('outranks the wind-down announcement, which would otherwise mask the whole class', () => {
+      expect(classifyWindDownReason({ ...ignored, windDownSignaled: true })).toBe('second_stop_still_unarmed');
+    });
+
+    it('a second stop that DID arm is ordinary second_stop, not an ignore', () => {
+      expect(classifyWindDownReason({ ...ignored, armVerdict: 'armed' })).toBe('second_stop');
+    });
+
+    it('an unreadable transcript is not counted as an ignore', () => {
+      expect(classifyWindDownReason({ ...ignored, armVerdict: 'unknown' })).toBe('second_stop');
+      expect(classifyWindDownReason({ ...ignored, armVerdict: undefined })).toBe('second_stop');
+    });
+
+    it('a claim-less session is never counted as an ignore', () => {
+      expect(classifyWindDownReason({ ...ignored, hasActiveClaim: false })).toBe('second_stop');
+    });
+
+    it('only fires on the SECOND stop — a first stop is still a live block, not an ignore', () => {
+      expect(classifyWindDownReason({ ...ignored, stopHookActive: false, loopState: 'active' })).toBe('turn_end_with_claim_no_wakeup');
+    });
   });
 });


### PR DESCRIPTION
## The stack merged into its own base branches, not into main

#6741/#6742/#6743 all show **MERGED**, but a stacked PR merges into **its base branch**. Only #6741 had `base=main`.

| branch | armVerdict block (A) | block telemetry (B) | muzzle gating (A) | telemetry reserve (B) |
|---|:--:|:--:|:--:|:--:|
| **main** | ✗ | ✗ | ✗ | ✗ |
| step0 | ✓ | ✗ | ✓ | ✗ |
| stepA | ✓ | ✓ | ✓ | ✓ |
| **stepB (this PR)** | ✓ | ✓ | ✓ | ✓ |

`origin/main` currently has **step 0 only** — the kill-switch plumbing and the two-verdict observation, but **not the enforcement**. It still carries the old `if (windDownSignaled) return false;` allow-path that step A removed, which means a worker can still talk its way out of the arm requirement on main today.

This PR brings steps A and B to main. It is the same content already reviewed and approved in #6742 and #6743 — no new code.

## Why this needed catching before the root fast-forwards

The shared root cannot ff while my working copies differ, and the natural reconciliation is "reset the working files to main." That would have been **actively harmful**: shared-root seats currently hot-adopt my working tree (DEV-4), so they are running the full enforcement right now. Resetting to main would have silently reverted every one of them to step-0-only and removed the live block — while looking like cleanup.

## What lands

- **Step A** — block derives from a `ScheduleWakeup` tool_use in the current turn, not from `loop_state` (a flag the worker sets about itself). The `windDownSignaled` allow-path is replaced by a worker-shape gate, so an announcement is no longer load-bearing anywhere.
- **Step B** — `awaiting_tick` is stamped only on real arm evidence; `expected_silence_until` always. Four actuating consumers checked individually. Includes DEV-3 (unarmed singletons fail closed on relaunch) and the `auto_capture` fix for a mirror that had written zero rows since it shipped.
- Block telemetry (`blocked_unarmed`), `HOOK_WORK_BUDGET_MS`, `TELEMETRY_RESERVE_MS`, and the stdout muzzle gated on `require.main` so importing the hook no longer silences the importer.

Deviations DEV-1..DEV-4 are stamped in the PRD metadata with their rulings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)