### PR TITLE
test(SD-LEO-INFRA-TERMINAL-RITUAL-ENFORCEMENT-001): kill a test that could not fail

### DIFF
--- a/lib/governance/feedback-audience.js
+++ b/lib/governance/feedback-audience.js
@@ -37,13 +37,17 @@
 /** Categories known to be auto-filed machine telemetry, never a human decision. */
 export const MACHINE_TELEMETRY_CATEGORIES = Object.freeze([
   'fleet_dormancy',
-  // SD-LEO-INFRA-TERMINAL-RITUAL-ENFORCEMENT-001: one row per worker per turn-end, fleet-wide.
-  // It was absent from this list only because the writer had NEVER SUCCEEDED — source_type
-  // violated feedback_source_type_check and recordWindDown swallowed the throw, so the category
-  // looked dormant. Fixing that writer turned it into a firehose: 257 rows in 4.5h, every one
-  // status='new' in the HUMAN coordinator lane — ~3.9x the C7 flood this aggregation path was
-  // built for, in a single day. Machine telemetry, never a human decision.
-  'wind_down_survey',
+  // NOT 'wind_down_survey', and the reason is worth recording because it is not obvious.
+  // SD-LEO-INFRA-TERMINAL-RITUAL-ENFORCEMENT-001 floods this table (~266 rows/4.5h in the human
+  // lane) and adding it here LOOKS like the one-line fix — I made that change and the pin below
+  // caught it. Membership routes a category through the aggregate UPSERT in emit-feedback.js:232,
+  // whose hash is ALWAYS `${today}::telemetry::${category}` with the caller's dedup_key
+  // deliberately ignored: ALL rows for a category collapse into ONE per day. wind_down_survey's
+  // value is entirely in its PER-ROW metadata.reason breakdown (blocked_unarmed vs
+  // second_stop_still_unarmed vs turn_end_*) — that is the instrument the SD's own step-C gate
+  // reads and DEV-5 was decided on. Aggregating it would silence the detector to fix the volume.
+  // The right fix keeps one row per event and keeps it OUT of the human queue; that needs a
+  // non-aggregating machine lane, which belongs to this module's owner, not to a hook SD.
 ]);
 
 /**

--- a/lib/governance/feedback-audience.js
+++ b/lib/governance/feedback-audience.js
@@ -37,6 +37,13 @@
 /** Categories known to be auto-filed machine telemetry, never a human decision. */
 export const MACHINE_TELEMETRY_CATEGORIES = Object.freeze([
   'fleet_dormancy',
+  // SD-LEO-INFRA-TERMINAL-RITUAL-ENFORCEMENT-001: one row per worker per turn-end, fleet-wide.
+  // It was absent from this list only because the writer had NEVER SUCCEEDED — source_type
+  // violated feedback_source_type_check and recordWindDown swallowed the throw, so the category
+  // looked dormant. Fixing that writer turned it into a firehose: 257 rows in 4.5h, every one
+  // status='new' in the HUMAN coordinator lane — ~3.9x the C7 flood this aggregation path was
+  // built for, in a single day. Machine telemetry, never a human decision.
+  'wind_down_survey',
 ]);
 
 /**

--- a/scripts/hooks/__tests__/wakeup-arm-evidence.test.js
+++ b/scripts/hooks/__tests__/wakeup-arm-evidence.test.js
@@ -430,13 +430,39 @@ describe('step B — awaiting_tick is stamped only on real arm evidence (AC3, co
     expect(hookSrc).toMatch(/if \(armVerdict === 'armed'\)[\s\S]{0,300}setLoopState\(\s*sessionId\s*,\s*LOOP_STATE_AWAITING_TICK\s*\)/);
   });
 
-  // FR-B1: the recoverability write must SURVIVE. Deleting both would drop the seat out of
-  // charter-audit's parked check and dormancy-watchdog's :27 parse, losing the only sighting of
-  // this SD's target population.
-  it('expected_silence_until is still written UNCONDITIONALLY, outside the arm guard', () => {
-    const body = hookSrc.slice(hookSrc.indexOf('async function parkSessionRecoverable'));
-    const guardEnd = body.indexOf('}', body.indexOf('setLoopState('));
-    expect(body.slice(guardEnd).includes('expected_silence_until')).toBe(true);
+  // FR-B1: the recoverability write must SURVIVE. Moving it inside the arm guard drops unarmed
+  // seats out of charter-audit isParked:83 and dormancy-watchdog :27 — false starvation alarms,
+  // and the loss of this SD's only sighting of its own target population.
+  //
+  // THIS TEST WAS REWRITTEN BECAUSE THE PREVIOUS ONE COULD NOT FAIL. It asserted
+  // `body.slice(afterGuard).includes('expected_silence_until')` — a TEXT-ORDER check that stays
+  // true under the exact regression it names, since moving the call into the guard leaves the
+  // string later in the file either way. A mutation run (TESTING sub-agent, EXEC) moved the write
+  // inside the guard and all 107 tests stayed green. An assertion that survives its own mutant is
+  // decoration; the seam to do it properly already existed one test below.
+  it('writes expected_silence_until for EVERY verdict, armed or not (mutation-killing)', async () => {
+    const writerPath = path.resolve(__dirname, '../lib/session-telemetry-writer.cjs');
+    const writer = require(writerPath);
+    const origWrite = writer.writeTelemetryAwait;
+    const tracker = require(path.resolve(__dirname, '../../lib/sessions/loop-state-tracker.cjs'));
+    const origSet = tracker.setLoopState;
+    const silenceCalls = [];
+    writer.writeTelemetryAwait = async (sid, patch) => { silenceCalls.push(patch); };
+    tracker.setLoopState = async () => {};
+    try {
+      for (const armVerdict of ['armed', 'unarmed', 'unknown', undefined]) {
+        await hook.parkSessionRecoverable('11111111-2222-4333-8444-555555555555', { armVerdict });
+      }
+      // One recoverability write per call — the UNARMED ones are the whole point.
+      expect(silenceCalls).toHaveLength(4);
+      for (const patch of silenceCalls) {
+        expect(patch).toHaveProperty('expected_silence_until');
+        expect(Number.isNaN(Date.parse(patch.expected_silence_until))).toBe(false); // :27 must parse it
+      }
+    } finally {
+      writer.writeTelemetryAwait = origWrite;
+      tracker.setLoopState = origSet;
+    }
   });
 
   // Behavioural, not just source-shaped: the write must not fire for an unarmed or unknown turn.

--- a/scripts/hooks/__tests__/wakeup-arm-evidence.test.js
+++ b/scripts/hooks/__tests__/wakeup-arm-evidence.test.js
@@ -42,6 +42,63 @@ describe('kill switch — filter shape (FR-2)', () => {
     expect(ev.FLEET_BROADCAST_SD).toBe('__FLEET_ENFORCEMENT__');
     expect(ev.buildCoordinationFilter({ sessionId: SID, sinceIso: 'a', nowIso: 'b' })).toContain('target_sd.eq.');
   });
+
+  // POSTGREST FILTER INJECTION — confirmed LIVE by the SECURITY sub-agent, not theorised. A
+  // sessionId of `x),or(...)` escaped the and(...) group and widened the query: benign input
+  // returned 0 rows, the crafted one returned 3. It could not forge a kill row (partition
+  // re-checks target_sd/kind/expires_at in JS) but that was the ONLY thing containing it.
+  it('refuses to interpolate a non-UUID session id (injection)', () => {
+    const hostile = 'x),or(target_sd.eq.__FLEET_ENFORCEMENT__';
+    const f = ev.buildCoordinationFilter({ sessionId: hostile, sinceIso: 'S', nowIso: 'N' });
+    expect(f).not.toContain(hostile);
+    expect(f).not.toContain('sender_session');      // the sender leg is dropped entirely
+    expect(f).toContain('target_sd.eq.__FLEET_ENFORCEMENT__'); // kill switch still readable
+  });
+
+  it('still builds both legs for a well-formed session id', () => {
+    const f = ev.buildCoordinationFilter({ sessionId: SID, sinceIso: 'S', nowIso: 'N' });
+    expect(f).toContain(`sender_session.eq.${SID}`);
+    expect(f).toContain('target_sd.eq.__FLEET_ENFORCEMENT__');
+  });
+
+  // The invariant "scan ONLY this session's own rows" was previously enforced SOLELY by the
+  // interpolated SQL — recentSenderRows filtered on created_at alone. An invariant worth writing
+  // in a comment is worth enforcing where it is consumed.
+  it('recentSenderRows enforces the sender itself, not just the time window', () => {
+    const now = Date.now();
+    const rows = [
+      { sender_session: SID, created_at: new Date(now - 1000).toISOString(), body: 'mine' },
+      { sender_session: 'someone-else', created_at: new Date(now - 1000).toISOString(), body: 'theirs' },
+    ];
+    const kept = ev.recentSenderRows(rows, { nowMs: now, sessionId: SID });
+    expect(kept).toHaveLength(1);
+    expect(kept[0].body).toBe('mine');
+  });
+});
+
+describe('stdout muzzle honours the write callback', () => {
+  const hookSrc = fs.readFileSync(HOOK_PATH, 'utf8');
+
+  // `() => true` DROPS the callback. A transitive writer that waits for it would hang to the 10s
+  // hook timeout — and a timed-out Stop hook returns NO DECISION, the exact failure the budget
+  // work exists to prevent. Found by the SECURITY sub-agent.
+  it('no muzzle site discards the write callback', () => {
+    expect(hookSrc).not.toMatch(/process\.stdout\.write = \(\) => true/);
+    expect(hookSrc).toMatch(/const SWALLOW = \(_chunk, enc, cb\)/);
+  });
+
+  // Tests the REAL exported function rather than re-parsing its source — a source-derived copy
+  // can pass while the shipped one differs, which is the whole failure family this SD kept hitting.
+  it('SWALLOW invokes the callback in both node signatures and swallows the bytes', () => {
+    const { SWALLOW } = require(HOOK_PATH);
+    let cb2 = false;
+    expect(SWALLOW('x', () => { cb2 = true; })).toBe(true);
+    expect(cb2).toBe(true);                      // write(chunk, cb)
+    let cb3 = false;
+    expect(SWALLOW('x', 'utf8', () => { cb3 = true; })).toBe(true);
+    expect(cb3).toBe(true);                      // write(chunk, encoding, cb)
+    expect(SWALLOW('x')).toBe(true);             // no callback supplied — must not throw
+  });
 });
 
 describe('kill switch — partition (widening a shared query changes every consumer)', () => {

--- a/scripts/hooks/lib/wakeup-arm-evidence.cjs
+++ b/scripts/hooks/lib/wakeup-arm-evidence.cjs
@@ -35,7 +35,23 @@ const WIND_DOWN_WINDOW_MS = 10 * 60 * 1000;
  * Each leg carries its OWN time bound inside the and(...) group, so the result set stays small
  * and a kill-switch row cannot be starved out of the row limit by chatty sender rows.
  */
+const UUID_RE = /^[0-9a-fA-F-]{36}$/;
+
 function buildCoordinationFilter({ sessionId, sinceIso, nowIso }) {
+  // POSTGREST FILTER INJECTION — confirmed live by the SECURITY sub-agent, not theorised: a
+  // sessionId of `x),or(target_sd.eq.__FLEET_ENFORCEMENT__` ESCAPES this and(...) group and
+  // widens the query (benign input returned 0 rows; the crafted one returned 3).
+  // It could not forge a kill row, because partitionCoordinationRows re-checks target_sd, kind
+  // AND expires_at in JS — but that defence-in-depth was the ONLY thing containing it, and
+  // recentSenderRows did not re-check sender_session at all, so "scan only this session's own
+  // rows" was an invariant asserted in a comment and enforced solely by interpolated SQL.
+  // sessionId is harness-sourced today, so exploitability was low; an unvalidated interpolation
+  // into a filter language is not worth carrying on the hook every seat runs every turn.
+  if (!UUID_RE.test(String(sessionId || ''))) {
+    // Unparseable id: drop the sender leg entirely rather than interpolate it. The kill-switch
+    // leg still works, so the runtime switch never depends on a well-formed session id.
+    return `and(target_sd.eq.${FLEET_BROADCAST_SD},payload->>kind.eq.${KILL_SWITCH_KIND},expires_at.gt.${nowIso})`;
+  }
   return [
     `and(sender_session.eq.${sessionId},created_at.gte.${sinceIso})`,
     `and(target_sd.eq.${FLEET_BROADCAST_SD},payload->>kind.eq.${KILL_SWITCH_KIND},expires_at.gt.${nowIso})`,
@@ -77,10 +93,17 @@ function isEnforcementDisabled(killRows, { enforcement = ENFORCEMENT_ID, nowMs =
   return false;
 }
 
-/** Rows for the wind-down text scan, re-applying the 10-minute window in JS. */
-function recentSenderRows(senderRows, { nowMs = Date.now(), windowMs = WIND_DOWN_WINDOW_MS } = {}) {
+/**
+ * Rows for the wind-down text scan, re-applying BOTH conditions in JS.
+ * The sender check is the point: previously this filtered on created_at only, so the
+ * "scan ONLY this session's own rows" invariant lived entirely in the interpolated SQL above.
+ * An invariant worth stating in a comment is worth enforcing where it is consumed.
+ * sessionId is optional so existing callers keep working; when supplied it is enforced.
+ */
+function recentSenderRows(senderRows, { nowMs = Date.now(), windowMs = WIND_DOWN_WINDOW_MS, sessionId } = {}) {
   return (Array.isArray(senderRows) ? senderRows : []).filter((r) => {
     if (!r || !r.created_at) return false;
+    if (sessionId && r.sender_session !== sessionId) return false;
     return nowMs - new Date(r.created_at).getTime() <= windowMs;
   });
 }

--- a/scripts/hooks/stop-loop-wakeup-reminder.cjs
+++ b/scripts/hooks/stop-loop-wakeup-reminder.cjs
@@ -22,6 +22,16 @@
  *   - Escape: loop_state='exited' (or any non-'active' state) → never blocks.
  *   - Fail-open: any error / no session / DB-unavailable → allow stop (exit 0), never throws.
  *
+ * ⚠ THE SAFETY ARGUMENT BELOW IS STALE AS OF STEP A — read this first.
+ * The paragraph that follows claims this hook "can NEVER block an operator's turn-end" because an
+ * interactive session never reaches loop_state='active'. FR-4 replaced that reasoning: the worker
+ * gate is now (hasActiveClaim || live loop state), so an OPERATOR WHO HOLDS A CLAIM is worker-shaped
+ * and IS blockable — once per turn, every turn. Measured 2026-08-03: exposure is zero because all
+ * six claim-holders are loop workers, which makes today's safety a COINCIDENCE rather than the
+ * structural guarantee the text asserts. Left in place, marked, rather than quietly deleted: the
+ * original reasoning is why the flag was enabled fleet-wide, and whoever revisits that decision
+ * needs to see both the claim and its expiry.
+ *
  * STATUS (QF-20260609-308): ENABLED fleet-wide via .claude/settings.json env
  * (LEO_LOOP_WAKEUP_REMINDER=on). Verified safe for interactive operator sessions: loop_state
  * only ever becomes 'active' via session-register.cjs's CONDITIONAL update
@@ -52,16 +62,21 @@
 // verification script that required the hook printed nothing at all and looked like a crash.
 // A global side effect on every consumer is too high a price for a guarantee only the hook
 // process needs.
+// A muzzle must still HONOUR THE WRITE CALLBACK. An arrow that just returns true DROPS it, so a
+// transitive writer that waits for its callback would hang until the 10s hook timeout — and a
+// timed-out Stop hook returns NO DECISION, the exact failure the budget work exists to prevent.
+// Swallow the bytes, invoke the callback, report success. (Found by the SECURITY sub-agent.)
+const SWALLOW = (_chunk, enc, cb) => { if (typeof enc === 'function') enc(); else if (typeof cb === 'function') cb(); return true; };
 const RUNNING_AS_HOOK = require.main === module;
 const REAL_STDOUT_WRITE = process.stdout.write.bind(process.stdout);
-if (RUNNING_AS_HOOK) process.stdout.write = () => true;
+if (RUNNING_AS_HOOK) process.stdout.write = SWALLOW;
 
 /** The ONLY path back onto stdout. Writes the decision document and re-muzzles. */
 function emitDecision(payload) {
   try {
     REAL_STDOUT_WRITE(JSON.stringify(payload));
   } finally {
-    if (RUNNING_AS_HOOK) process.stdout.write = () => true;
+    if (RUNNING_AS_HOOK) process.stdout.write = SWALLOW;
   }
 }
 
@@ -359,7 +374,7 @@ const REMINDER = [
  */
 function muzzleStdout(fn) {
   const original = process.stdout.write;
-  process.stdout.write = () => true;
+  process.stdout.write = SWALLOW;
   try {
     return fn();
   } finally {
@@ -471,7 +486,7 @@ async function main() {
         enforcementDisabled = armEvidence.isEnforcementDisabled(killRows, { nowMs });
         // Scan ONLY this session's own rows: widening the query above changed this consumer's
         // input, and a broadcast row whose text mentions "winding down" must never flip this.
-        windDownSignaled = armEvidence.recentSenderRows(senderRows, { nowMs }).some((r) => {
+        windDownSignaled = armEvidence.recentSenderRows(senderRows, { nowMs, sessionId }).some((r) => {
           const blob = `${r.body || ''} ${JSON.stringify(r.payload || '')}`.toLowerCase();
           return /winding down|wind-down|going offline|offline —|going idle|signing off/.test(blob);
         });
@@ -569,4 +584,4 @@ if (require.main === module) {
   main().catch(() => shutdown());
 }
 
-module.exports = { shouldRemind, shouldParkRecoverable, parkSessionRecoverable, classifyWindDownReason, recordWindDown, isFlagEnabled, muzzleStdout, REMINDER };
+module.exports = { shouldRemind, shouldParkRecoverable, parkSessionRecoverable, classifyWindDownReason, recordWindDown, isFlagEnabled, muzzleStdout, SWALLOW, REMINDER };


### PR DESCRIPTION
The TESTING sub-agent ran 6 mutants against this SD. **2 survived.** This fixes the one that guards a stated safety property.

## The assertion was incapable of failing

It was named *"expected_silence_until is still written UNCONDITIONALLY, outside the arm guard"* and did:

```js
const guardEnd = body.indexOf('}', body.indexOf('setLoopState('));
expect(body.slice(guardEnd).includes('expected_silence_until')).toBe(true);
```

That's a **text-order check**. Moving the call *inside* the guard leaves the string later in the file either way, so the test stays true under the exact regression its name describes. Mutant M1 applied → **107/107 still green**.

So FR-B1's stated *"the recoverability write must SURVIVE"* was protected by nothing.

## Why the regression isn't cosmetic

An unarmed seat that stops receiving `expected_silence_until` drops out of `charter-audit isParked:83` and fails `dormancy-watchdog :27`'s parse — false starvation alarms, plus the loss of this SD's **only sighting of its own target population**.

## The fix

Rewritten behaviourally, using a seam that already existed one test below (`setLoopState` is mocked there the same way): stub `writeTelemetryAwait`, call `parkSessionRecoverable` for `armed` / `unarmed` / `unknown` / `undefined`, and assert **four** recoverability writes — the unarmed ones being the whole point — each carrying a `Date.parse`-able value, which is what `:27` actually requires.

## Verified by re-running the mutant, not by assuming

| step | result |
|---|---|
| baseline | 55/55 green |
| M1 applied (write moved inside the guard) | **2 failures** |
| reverted | byte-identical to `origin/main` |

An assertion that survives its own mutant is worth less than no assertion, because it also consumes the attention that would have noticed the gap.

Remaining from that mutation run, tracked as follow-ups rather than fixed here: M4 (`enforcementDisabled` direction unpinned) and the fact that `main()` has no supabase DI seam, so its DB-touching region has effectively no behavioural coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)