### PR TITLE
feat(SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001): archive-first orphan sweep with guards that can see content

### DIFF
--- a/lib/worktree-quota.js
+++ b/lib/worktree-quota.js
@@ -32,6 +32,10 @@ import path from 'node:path';
 // SD-LEO-INFRA-WORKTREE-CONTENTION-CLEANUP-001 (FR-4): shared reapability predicate,
 // used to exclude owned/dirty/unpushed dirs from the ORPHAN_DETECTED count.
 import { isReapable, WORKTREE_CONTAINER_DIRS } from './worktree-reapability.js';
+// SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-3/FR-3b): pure content verdict. The walk itself is
+// injected by the caller (opts.probe) so this module adds NO filesystem I/O to the worktree-quota
+// hot path, which reaches classifyOrphanDirs on every `git worktree add`.
+import { classifyContent } from './worktree-reaper/orphan-content-probe.mjs';
 // SD-FDBK-INFRA-DISK-FULL-RECURS-001: reuse the canonical free-space reader (statfs-based, returns
 // undefined when unreadable) so the disk-floor guard and the node_modules-isolation decision share one
 // SSOT. No import cycle: worktree-provision.js does not import this module.
@@ -228,8 +232,9 @@ export function countFilesystemWorktreeDirs(worktreesDir) {
  * @returns {{reapable: number, reapableDirs: Array<{dir:string, full:string}>, excluded: Array<{dir:string, reason:string}>, total: number}}
  */
 export function classifyOrphanDirs(worktreesDir, registered = [], opts = {}) {
-  const { liveOwners = new Set(), gitRunner, minAgeMs = 0, now = Date.now() } = opts;
-  const empty = { reapable: 0, reapableDirs: [], excluded: [], total: 0 };
+  const { liveOwners = new Set(), gitRunner, minAgeMs = 0, now = Date.now(), probe } = opts;
+  const empty = { reapable: 0, reapableDirs: [], excluded: [], refused: [], total: 0 };
+  const refused = [];
   if (!worktreesDir || !fs.existsSync(worktreesDir)) return { ...empty };
   // SD-LEO-INFRA-ORPHAN-WORKTREE-SWEEP-001 (review HIGH): on Windows the filesystem is
   // case-INSENSITIVE, so the registered-worktree exclusion must compare case-insensitively
@@ -257,22 +262,69 @@ export function classifyOrphanDirs(worktreesDir, registered = [], opts = {}) {
     // does not — so compare case-insensitively too, else the live-owner guard is silently defeated
     // by path-casing drift across the module boundary and a live-claimed dir could be reaped.
     if (liveOwners.has(normFull) || liveOwners.has(normFull.toLowerCase())) { excluded.push({ dir: entry, reason: 'live_owner' }); continue; }
-    // FR-3 recent-dir guard: never reap a dir created within minAgeMs (could be a
-    // worktree mid-`git worktree add` not yet registered). minAgeMs=0 → no-op.
+
+    // SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-2/FR-3/FR-3b): content probe, OPT-IN.
+    //
+    // WHY OPT-IN AND NOT UNCONDITIONAL — this is the load-bearing decision in this function.
+    // emitOrphanWarningIfAny() below calls classifyOrphanDirs with NO minAgeMs and no probe, and
+    // enforceWorktreeQuota reaches that on EVERY `git worktree add`. Today that path performs ZERO
+    // per-dir I/O (the recency block is gated on minAgeMs > 0). Probing unconditionally would add a
+    // directory walk where none runs, on the worktree-creation hot path, against a .worktrees that
+    // currently holds a 45,877-file directory whose naive walk already exceeded a ten-minute budget.
+    // With no `probe` supplied every branch below is byte-identical to the pre-fix behaviour.
+    //
+    // Scoped to the NO-.git branch: that is exactly FR-3's population, and it keeps the probe off
+    // dirs that isReapable already interrogates via their own git state.
+    const hasGit = fs.existsSync(path.join(full, '.git'));
+    let probed = null;
+    if (!hasGit && typeof probe === 'function') {
+      probed = probe(full);
+      // FR-3b: an UNMEASURABLE dir is not an EMPTY one. A failed walk is the single case where we
+      // know least about the contents, so it refuses rather than falling through to reapable.
+      // Silently continuing here is the exact shape that let safeRecursiveCp truncate an archive
+      // while reporting success.
+      if (!probed || probed.ok !== true) {
+        refused.push({ dir: entry, full, reason: probed?.reason || 'walk_error', files: null, newestMtimeMs: null });
+        continue;
+      }
+    }
+
+    // FR-2 recent-dir guard. When probed, use the newest DESCENDANT mtime: the top-level directory
+    // inode only advances on entry add/remove/rename, so a tree whose nested files were edited
+    // minutes ago reads as ancient — that blindness is what let a 3.5h-old tree be reaped.
+    // Unprobed callers keep the legacy top-level stat, unchanged.
     if (minAgeMs > 0) {
       let mtimeMs = 0;
-      try { mtimeMs = fs.statSync(full).mtimeMs; } catch { mtimeMs = now; }
+      if (probed) mtimeMs = probed.newestMtimeMs;
+      else { try { mtimeMs = fs.statSync(full).mtimeMs; } catch { mtimeMs = now; } }
       if (now - mtimeMs < minAgeMs) { excluded.push({ dir: entry, reason: 'too_recent' }); continue; }
     }
+
     // A plain leftover dir (no .git) cannot carry its OWN uncommitted/unpushed
     // state — git status from it would report the ENCLOSING repo — so it is a
     // genuine reapable orphan. Only worktree-root dirs get the dirty/unpushed predicate.
-    if (!fs.existsSync(path.join(full, '.git'))) { reapableDirs.push({ dir: entry, full }); continue; }
+    if (!hasGit) {
+      // FR-3: ...UNLESS it holds substantial content. The original rationale inverted on exactly
+      // the incident case: the property that made the dir dangerous to delete (unregistered,
+      // unattributed, contents never examined) was the property that made it unconditionally
+      // reapable. REFUSED is a THIRD bucket, deliberately not folded into `excluded`, so the quota
+      // warning below still counts the biggest orphans instead of hiding them from the gauge that
+      // watches orphan accumulation.
+      if (probed) {
+        const verdictContent = classifyContent(probed);
+        if (verdictContent.refuse) {
+          refused.push({ dir: entry, full, reason: verdictContent.reason, files: probed.files, newestMtimeMs: probed.newestMtimeMs });
+          continue;
+        }
+      }
+      reapableDirs.push({ dir: entry, full });
+      continue;
+    }
     const verdict = isReapable(full, { liveOwner: false, gitRunner });
     if (verdict.reapable) reapableDirs.push({ dir: entry, full });
     else excluded.push({ dir: entry, reason: verdict.reason });
   }
-  return { reapable: reapableDirs.length, reapableDirs, excluded, total };
+  return { reapable: reapableDirs.length, reapableDirs, excluded, refused, total };
 }
 
 /**

--- a/lib/worktree-quota.js
+++ b/lib/worktree-quota.js
@@ -294,9 +294,21 @@ export function classifyOrphanDirs(worktreesDir, registered = [], opts = {}) {
     // minutes ago reads as ancient — that blindness is what let a 3.5h-old tree be reaped.
     // Unprobed callers keep the legacy top-level stat, unchanged.
     if (minAgeMs > 0) {
-      let mtimeMs = 0;
-      if (probed) mtimeMs = probed.newestMtimeMs;
-      else { try { mtimeMs = fs.statSync(full).mtimeMs; } catch { mtimeMs = now; } }
+      let containerMtimeMs = 0;
+      try { containerMtimeMs = fs.statSync(full).mtimeMs; } catch { containerMtimeMs = now; }
+      // Take the LATER of the container and its newest descendant.
+      //
+      // Descendant-alone is wrong in the empty-directory case and regressed the guard's ORIGINAL
+      // purpose: probeContent returns newestMtimeMs=0 for a tree with no files, so `now - 0` is
+      // ~57 years and the recency check never fires. A directory created seconds ago by a
+      // half-finished `git worktree add` — precisely what this guard was written for — became
+      // reapable. Measured before the fix: WITH probe -> reapable, LEGACY -> too_recent.
+      //
+      // Container-alone is the original blindness: the inode does not advance on nested-file
+      // modification, which is how a tree edited 3.5h earlier read as ancient and was deleted.
+      // max() is correct for both — an empty dir has no signal but its own mtime, and a dir with
+      // fresh contents is recent no matter how stale the container looks.
+      const mtimeMs = probed ? Math.max(containerMtimeMs, probed.newestMtimeMs) : containerMtimeMs;
       if (now - mtimeMs < minAgeMs) { excluded.push({ dir: entry, reason: 'too_recent' }); continue; }
     }
 
@@ -321,8 +333,34 @@ export function classifyOrphanDirs(worktreesDir, registered = [], opts = {}) {
       continue;
     }
     const verdict = isReapable(full, { liveOwner: false, gitRunner });
-    if (verdict.reapable) reapableDirs.push({ dir: entry, full });
-    else excluded.push({ dir: entry, reason: verdict.reason });
+    if (!verdict.reapable) { excluded.push({ dir: entry, reason: verdict.reason }); continue; }
+
+    // FR-3 (gap closed after security review): CONTENT-CHECK ANY DIRECTORY ABOUT TO BE REAPED,
+    // not only the .git-less ones.
+    //
+    // The original scoping said the probe could skip dirs "that isReapable already interrogates".
+    // That rationale is false precisely where the interrogation FAILS. Measured: two trees with
+    // identical content (8 nested files, freshly written, container force-aged 6h) — the copy with
+    // no .git was caught, while a copy carrying a .git file that points at a NONEXISTENT gitdir was
+    // classified REAPABLE. isReapable cannot read git state it cannot reach, so it returns a
+    // clean-orphan verdict; the probe was gated off by hasGit; and recency fell back to the blind
+    // container stat. All three guards abstained on the same directory.
+    //
+    // Probing here costs a walk only for dirs already destined for reclamation — the small set,
+    // and the one moment where being wrong is expensive.
+    if (typeof probe === 'function') {
+      const late = probe(full);
+      if (!late || late.ok !== true) {
+        refused.push({ dir: entry, full, reason: late?.reason || 'walk_error', files: null, newestMtimeMs: null });
+        continue;
+      }
+      const lateVerdict = classifyContent(late);
+      if (lateVerdict.refuse) {
+        refused.push({ dir: entry, full, reason: lateVerdict.reason, files: late.files, newestMtimeMs: late.newestMtimeMs });
+        continue;
+      }
+    }
+    reapableDirs.push({ dir: entry, full });
   }
   return { reapable: reapableDirs.length, reapableDirs, excluded, refused, total };
 }

--- a/lib/worktree-reaper/orphan-content-probe.mjs
+++ b/lib/worktree-reaper/orphan-content-probe.mjs
@@ -1,0 +1,147 @@
+/**
+ * Bounded content probe for orphan classification.
+ * SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-2 / FR-3 / FR-3b).
+ *
+ * WHY THIS EXISTS: on 2026-08-01 the orphan sweep hard-deleted 601,021,494 bytes / 42,162 files
+ * that two agents had refused to remove. Two guards were inapplicable BY CONSTRUCTION:
+ *
+ *   1. The recency guard stat'd the TOP-LEVEL directory inode (worktree-quota.js:265). Directory
+ *      mtime advances on entry add/remove/rename only — never on nested-file modification — so a
+ *      tree edited 3.5h earlier read as ancient. Structural blindness, not mis-tuning: no
+ *      threshold fixes a measurement that cannot see the thing it measures.
+ *   2. A missing .git short-circuited straight to reapable (worktree-quota.js:270), skipping the
+ *      predicate entirely. The property that made the directory DANGEROUS to delete — unregistered,
+ *      unattributed, contents never examined — was the property that made it unconditionally
+ *      reapable. Absence of signal read as signal of absence.
+ *
+ * THE BOUND IS NOT A NICETY. dirSizeBytes (orphan-sweep.js:109-126) has no cap and no deadline,
+ * and reclaimOrphans calls it BEFORE the dry-run short-circuit, so even a dry run walks the full
+ * tree of every reapable orphan. A naive walk of the 45,877-file directory presently in .worktrees
+ * exceeded a ten-minute budget and was killed. This repo's own prior answer to that exact class was
+ * architectural avoidance, not a better walker: scripts/maintenance/Prune-WorktreeArchive.ps1 says
+ * it never recursively walks to size a tree ("40M files = the thing that hung").
+ *
+ * FR-3b — THE FAILURE MODE THIS MODULE MUST NOT HAVE. FR-3 is itself an absence-read-as-signal
+ * fix, and PAT-CONFLATION-RECURSES-ONE-LAYER-UP-001 predicts that such a fix reproduces the
+ * conflation one layer out, authored by whoever just diagnosed it one layer down. The specific way
+ * that happens here is treating an UNMEASURABLE directory as an EMPTY one. So every failure —
+ * timeout, cap, unreadable dir, stat error — returns ok:false and the caller must REFUSE. A
+ * directory whose walk we could not finish is the directory we know least about.
+ *
+ * PURITY: classifyContent() is pure. probeContent() is the only function that touches the
+ * filesystem, and it takes fsImpl + a clock so both polarities are testable from fixtures without
+ * locking files (locking is the mechanism that MANUFACTURES these orphans — never simulate it).
+ */
+
+/**
+ * Content thresholds above which a .git-less directory is REFUSED rather than reaped.
+ *
+ * CHOSEN AGAINST THE ACTUAL FIXTURES, not by taste. The existing suites write:
+ *   - tests/unit/worktree-reaper/orphan-sweep.test.js mkLeftover: 1 file of EXACTLY 100 bytes
+ *   - tests/unit/worktree-quota-orphan-classify.test.js: an empty 'plain-leftover'
+ *   - lib/worktree-quota.test.js addOrphanDirectory: 1 file of 6 bytes
+ * A `> 1 file AND > 100 bytes` rule clears all three with ZERO MARGIN on both dimensions — one
+ * extra byte in mkLeftover would flip four assertions in a suite nobody was editing. These values
+ * keep real margin while still refusing anything resembling live work.
+ */
+export const CONTENT_REFUSE_MIN_FILES = 3;
+export const CONTENT_REFUSE_MIN_BYTES = 4096;
+
+/** Hard bounds. Exported so tests can assert a fixture sits BELOW the cap — see below. */
+export const PROBE_MAX_FILES = 5000;
+export const PROBE_MAX_MS = 4000;
+
+/** Verdict reasons. Distinct strings by design — see classifyContent(). */
+export const REASON = Object.freeze({
+  HIGH_CONTENT: 'high_content',
+  WALK_TIMEOUT: 'walk_timeout',
+  WALK_ERROR: 'walk_error',
+  CAP_EXCEEDED: 'cap_exceeded',
+});
+
+/**
+ * Decide whether a probe result means REFUSE, and why. PURE — no fs, no clock, no I/O.
+ *
+ * The reason strings for a content refusal and for a failed walk are DELIBERATELY DIFFERENT.
+ * If a failed walk also refused as 'high_content', a test asserting reason==='high_content'
+ * would be satisfied by the failure path and could no longer prove the content branch ran at
+ * all. Distinct reasons keep those two claims independently checkable.
+ *
+ * @param {{ok:boolean, files?:number, bytes?:number, truncated?:boolean, reason?:string}} probe
+ * @returns {{refuse:boolean, reason:string|null}}
+ */
+export function classifyContent(probe) {
+  if (!probe || probe.ok !== true) {
+    // FR-3b: unmeasurable is NOT empty. Refuse, carrying the failure's own reason.
+    return { refuse: true, reason: probe?.reason || REASON.WALK_ERROR };
+  }
+  if (probe.truncated === true) return { refuse: true, reason: REASON.CAP_EXCEEDED };
+  const files = probe.files || 0;
+  const bytes = probe.bytes || 0;
+  if (files >= CONTENT_REFUSE_MIN_FILES || bytes > CONTENT_REFUSE_MIN_BYTES) {
+    return { refuse: true, reason: REASON.HIGH_CONTENT };
+  }
+  return { refuse: false, reason: null };
+}
+
+/**
+ * Walk `dir` under a hard file-count cap and deadline, collecting file count, byte total and the
+ * newest DESCENDANT mtime.
+ *
+ * Never traverses a symlink or junction: a link counts as 0 files / 0 bytes. That mirrors
+ * dirSizeBytes:116 and is load-bearing — following a node_modules junction would walk (and could
+ * later delete through) the shared store.
+ *
+ * @param {string} dir
+ * @param {{fsImpl?:object, pathImpl?:object, maxFiles?:number, maxMs?:number, now?:function}} [opts]
+ * @returns {{ok:true, files:number, bytes:number, newestMtimeMs:number, truncated:boolean}
+ *          |{ok:false, reason:string, files:number}}
+ */
+export function probeContent(dir, opts = {}) {
+  const {
+    fsImpl,
+    pathImpl,
+    maxFiles = PROBE_MAX_FILES,
+    maxMs = PROBE_MAX_MS,
+    now = Date.now,
+  } = opts;
+  if (!fsImpl || !pathImpl) throw new Error('probeContent requires fsImpl and pathImpl (injection seam)');
+
+  const deadline = now() + maxMs;
+  let files = 0;
+  let bytes = 0;
+  let newestMtimeMs = 0;
+  const stack = [dir];
+
+  while (stack.length) {
+    if (now() > deadline) return { ok: false, reason: REASON.WALK_TIMEOUT, files };
+    const cur = stack.pop();
+    let st;
+    try {
+      st = fsImpl.lstatSync(cur);
+    } catch {
+      // A node we cannot stat. Skipping it silently is exactly how safeRecursiveCp truncates an
+      // archive while reporting success — so this is a HARD FAILURE, not a continue.
+      return { ok: false, reason: REASON.WALK_ERROR, files };
+    }
+    if (st.isSymbolicLink()) continue; // 0 files, 0 bytes, never traversed
+    if (st.isDirectory()) {
+      let entries;
+      try {
+        entries = fsImpl.readdirSync(cur);
+      } catch {
+        return { ok: false, reason: REASON.WALK_ERROR, files };
+      }
+      for (const e of entries) stack.push(pathImpl.join(cur, e));
+      continue;
+    }
+    files += 1;
+    bytes += st.size || 0;
+    if (st.mtimeMs > newestMtimeMs) newestMtimeMs = st.mtimeMs;
+    if (files > maxFiles) {
+      // Cap hit. Report truncated rather than a partial count the caller might trust as complete.
+      return { ok: true, files, bytes, newestMtimeMs, truncated: true };
+    }
+  }
+  return { ok: true, files, bytes, newestMtimeMs, truncated: false };
+}

--- a/lib/worktree-reaper/orphan-content-probe.mjs
+++ b/lib/worktree-reaper/orphan-content-probe.mjs
@@ -138,8 +138,12 @@ export function probeContent(dir, opts = {}) {
     files += 1;
     bytes += st.size || 0;
     if (st.mtimeMs > newestMtimeMs) newestMtimeMs = st.mtimeMs;
-    if (files > maxFiles) {
+    if (files >= maxFiles) {
       // Cap hit. Report truncated rather than a partial count the caller might trust as complete.
+      // `>=` not `>`: the contract is "never walk more than maxFiles", and `>` let one extra file
+      // through. The original test asserted `files <= maxFiles + 1`, which ACCOMMODATED the
+      // off-by-one instead of pinning the contract — an assertion written around the behaviour
+      // rather than around the requirement.
       return { ok: true, files, bytes, newestMtimeMs, truncated: true };
     }
   }

--- a/lib/worktree-reaper/orphan-sweep.js
+++ b/lib/worktree-reaper/orphan-sweep.js
@@ -249,7 +249,24 @@ export function reclaimOrphans(reapableDirs = [], opts = {}) {
     execute = false,
     repoRoot,
     remove = defaultRemoveOrphan,
-    sizeOf = (full) => dirSizeBytes(full),
+    // SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-2): size via the BOUNDED probe, not the unbounded
+    // dirSizeBytes.
+    //
+    // This call sits ABOVE the `if (!execute)` short-circuit below, so it runs on every DRY RUN —
+    // the default posture, hourly. dirSizeBytes has no file cap and no deadline, so a dry run
+    // walked the full byte-tree of every reapable orphan; that is the walk that exceeded a
+    // ten-minute budget on the 45,877-file directory and had to be killed. FR-2 bounded the
+    // classifier's walk and left this one, which meant the hazard survived in the path that runs
+    // most often.
+    //
+    // A truncated probe yields a LOWER BOUND on bytes rather than an exact total. That is the
+    // correct trade for a summary field: an approximate number that always returns beats an exact
+    // one that hangs the reaper. archived_bytes is reported alongside disk_freed_bytes: 0, so
+    // nothing downstream treats it as a reclamation figure.
+    sizeOf = (full) => {
+      const p = probeContent(full, { fsImpl: fs, pathImpl: path });
+      return p.ok ? p.bytes : 0;
+    },
     logger = () => {},
   } = opts;
   const reclaimed = [];

--- a/lib/worktree-reaper/orphan-sweep.js
+++ b/lib/worktree-reaper/orphan-sweep.js
@@ -11,20 +11,25 @@
  * junction-unlink logic:
  *   • selection  → lib/worktree-quota.js::classifyOrphanDirs (orphan set + isReapable guard
  *                  + the FR-3 recent-dir guard), enumerating registered via listActiveWorktrees.
- *   • reclamation → the same junction-safe path the reaper uses (removeWorktreeViaGit, which
- *                  pre-unlinks the node_modules junction, then safeRecursiveRm as fallback).
+ *   • reclamation → SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-1): ARCHIVE-FIRST. The orphan path
+ *                  MOVES the directory into `_archive` by rename and REFUSES if the rename
+ *                  fails. It no longer deletes anything.
  *
  * CARDINAL SAFETY INVARIANT: NEVER raw-rm an orphan. A raw recursive delete can FOLLOW the
  * orphan's node_modules junction and gut the shared node_modules fleet-wide (ERR_MODULE_NOT_FOUND).
- * All removal goes through safeRecursiveRm, which unlinks every junction/symlink descendant
- * BEFORE fs.rmSync.
+ * As of FR-1 this path performs NO deletion at all, which satisfies the invariant by construction:
+ * rename() never dereferences a reparse point, so a junction moves as a junction and the shared
+ * store is untouched. The removal-time pre-unlink in safeRecursiveRm remains intact and is still
+ * the guard for the Stage-1/2 reaper paths, which DO delete (TR-2) — do not weaken it there.
  */
 
 import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
 import { classifyOrphanDirs, listActiveWorktrees, WORKTREE_QUOTA_HELPERS } from '../worktree-quota.js';
-import { safeRecursiveRm } from '../worktree-manager.js';
+// SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-2/FR-3): the bounded content probe, supplied to
+// classifyOrphanDirs on the SWEEP path only (it is opt-in there — see the note at its call site).
+import { probeContent } from './orphan-content-probe.mjs';
 
 // FR-3: never reap a dir created within this window (could be a worktree mid-`git worktree add`).
 export const DEFAULT_ORPHAN_MIN_AGE_MS = 30 * 60 * 1000; // 30 min
@@ -49,6 +54,13 @@ export function resolveMinAgeMs(env = process.env) {
 // dir left behind when `git worktree remove` hits a Windows lock) are caught. `_archive` is
 // deliberately NOT scanned: it is the reaper's preserve destination, not abandoned work.
 const TYPED_SUBDIRS = ['qf', 'sd', 'adhoc'];
+// SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-1/FR-5): the archive destination, and the name that must
+// never appear in scanRoots above. FR-1 makes this directory the SOLE custodian of everything the
+// sweep preserves, so the value behind that one exclusion just went up sharply — hence the
+// regression test asserting _archive is never scanned. Note isReapable's container guard matches
+// path.basename only, so it protects a dir NAMED _archive but not its children
+// (.worktrees/_archive/SD-FOO has basename SD-FOO); the exclusion here is what actually covers them.
+export const ARCHIVE_DIR_NAME = '_archive';
 
 /**
  * PURE-over-IO: select the reapable orphan directories across BOTH the flat legacy layout
@@ -73,11 +85,20 @@ export function selectReapableOrphans(opts = {}) {
     listRegistered = listActiveWorktrees,
   } = opts;
   const registered = opts.registered || (repoRoot ? listRegistered(repoRoot) : []);
-  const cfg = { liveOwners, gitRunner, minAgeMs, now };
+  // SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-2/FR-3): supply the bounded content probe HERE, on the
+  // sweep path only. classifyOrphanDirs treats it as opt-in precisely so the worktree-quota hot
+  // path — which reaches that function on every `git worktree add` and performs zero per-dir I/O
+  // today — does not inherit a directory walk. Injectable for tests.
+  const probe = opts.probe || ((dir) => probeContent(dir, { fsImpl: fs, pathImpl: path }));
+  const cfg = { liveOwners, gitRunner, minAgeMs, now, probe };
 
   // Scan the top level (flat layout) plus each typed subdir (one level down).
+  // FR-5: `_archive` appears in NEITHER list — not as a scan root here, and skipped as a top-level
+  // entry by WORKTREE_QUOTA_HELPERS inside classifyOrphanDirs. Both layers matter, because
+  // isReapable's container guard matches path.basename only: `_archive/SD-FOO` has basename
+  // `SD-FOO`, so an archived tree would look like an ordinary orphan if it were ever scanned.
   const scanRoots = [worktreesDir, ...TYPED_SUBDIRS.map((s) => path.join(worktreesDir, s))];
-  const merged = { reapable: 0, reapableDirs: [], excluded: [], total: 0 };
+  const merged = { reapable: 0, reapableDirs: [], excluded: [], refused: [], total: 0 };
   const seen = new Set();
   for (const rootDir of scanRoots) {
     let exists = false;
@@ -92,6 +113,12 @@ export function selectReapableOrphans(opts = {}) {
       merged.reapableDirs.push({ dir: prefix + d.dir, full: d.full });
     }
     for (const e of r.excluded) merged.excluded.push({ dir: prefix + e.dir, reason: e.reason });
+    // FR-4: refusals MUST flow through to the report. Dropping them here would leave FR-3
+    // technically implemented and operationally invisible — the directory would be spared, but
+    // nobody would learn it needs a human decision, which is the whole reason it was spared.
+    for (const x of r.refused || []) {
+      merged.refused.push({ dir: prefix + x.dir, full: x.full, reason: x.reason, files: x.files, newestMtimeMs: x.newestMtimeMs });
+    }
     merged.total += r.total;
   }
   merged.reapable = merged.reapableDirs.length;
@@ -126,12 +153,12 @@ export function dirSizeBytes(dir, { fsImpl = fs } = {}) {
 }
 
 /**
- * Default junction-safe orphan remover. Orphans are UNREGISTERED by construction (the selection
- * excludes everything in `git worktree list`), so we go STRAIGHT to safeRecursiveRm — which
- * recursively unlinks EVERY junction/symlink descendant (not just the top-level node_modules)
- * BEFORE fs.rmSync. This is strictly safer than trying `git worktree remove --force` first,
- * whose pre-unlink only covers the top-level node_modules and could follow a NESTED junction
- * (review MEDIUM). A best-effort `git worktree prune` afterward clears any stale registration
+ * Default orphan RECLAIMER — archive-first as of FR-1; it no longer removes anything.
+ * Orphans are UNREGISTERED by construction (the selection excludes everything in
+ * `git worktree list`), so the directory is moved wholesale into `_archive` by a single rename.
+ * A rename that fails REFUSES and leaves the source in place — see the long note in the body for
+ * why there is deliberately no copy-then-delete fallback.
+ * A best-effort `git worktree prune` afterward clears any stale registration
  * for a prunable leftover. NEVER a raw fs.rmSync. Returns {ok, method, error?}.
  *
  * @param {string} full
@@ -139,19 +166,60 @@ export function dirSizeBytes(dir, { fsImpl = fs } = {}) {
  * @param {{rm?: function, runGit?: function}} [deps] - injectable for tests
  * @returns {{ok: boolean, method: string, error?: string}}
  */
-export function defaultRemoveOrphan(full, repoRoot, { rm = safeRecursiveRm, runGit } = {}) {
+export function defaultRemoveOrphan(full, repoRoot, { runGit, renameImpl, fsImpl = fs, now } = {}) {
+  // SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-1): ARCHIVE-FIRST, RENAME-ONLY, REFUSE ON FAILURE.
+  //
+  // This function used to call safeRecursiveRm directly. On 2026-08-01 that hard-deleted 42,162
+  // files / 601,021,494 bytes with no archived copy — content a peer had inspected and refused to
+  // remove and the coordinator had declined to authorise. The whole class becomes recoverable by
+  // moving instead of deleting.
+  //
+  // WHY RENAME-ONLY, AND WHY NO COPY FALLBACK — this is the subtle part, and getting it wrong
+  // would reproduce the incident wearing a fix's paint. _archiveWorktreeDir falls back to
+  // safeRecursiveCp + rm when rename throws, and safeRecursiveCp wraps its per-child lstat in a
+  // catch whose body is a bare `continue` (worktree-manager.js:1438-1442) — it SILENTLY SKIPS any
+  // child it cannot stat, then reports success, and the caller then deletes the source. These dirs
+  // are orphans precisely BECAUSE a prior removal hit a Windows lock (3 of 4 candidates in the
+  // incident failed on EPERM), so the locked-tree case is the LIKELY branch here, not an edge case.
+  // Copy-then-delete on a locked tree yields a TRUNCATED archive with a success verdict. So: a
+  // rename that fails REFUSES and leaves the source untouched. Nothing is ever deleted here.
+  //
+  // JUNCTION SAFETY: rename() / MoveFileEx is a directory-entry operation that never dereferences
+  // a reparse point, so a node_modules junction moves as a junction and still points at the shared
+  // store. That is an OS guarantee, not application code — no pre-unlink is needed on this path,
+  // and the removal-time pre-unlink in safeRecursiveRm stays intact for the Stage-1/2 paths (TR-2).
+  //
+  // NO POST-MOVE VERIFICATION WALK: rename completeness is likewise an OS guarantee. Walking the
+  // destination to "confirm" it would re-import the unbounded-walk hazard FR-2 exists to remove —
+  // on the very trees most likely to be huge.
   const abs = path.resolve(full);
+  const rename = renameImpl || ((a, b) => fsImpl.renameSync(a, b));
   try {
-    if (!fs.existsSync(abs)) return { ok: true, method: 'already-gone' };
-    rm(abs); // safeRecursiveRm: unlinks ALL junctions/symlinks BEFORE fs.rmSync — never raw-rm
+    if (!fsImpl.existsSync(abs)) return { ok: true, method: 'already-gone' };
+
+    const archiveDir = path.join(path.dirname(abs), ARCHIVE_DIR_NAME);
+    fsImpl.mkdirSync(archiveDir, { recursive: true });
+    // Same timestamped convention as the Stage-1/2 archive path.
+    const stamp = new Date(typeof now === 'number' ? now : Date.now()).toISOString().replace(/[:.]/g, '-');
+    let dest = path.join(archiveDir, `${path.basename(abs)}-${stamp}`);
+    // The Stage-1/2 archiver has NO collision check; millisecond stamps make it rare, not
+    // impossible, and a collision there surfaces as a generic rename throw. Refuse explicitly
+    // rather than letting a name clash read as a locked tree.
+    if (fsImpl.existsSync(dest)) {
+      return { ok: false, method: 'refused', error: `archive destination already exists: ${dest}` };
+    }
+
+    rename(abs, dest);
+
     // Best-effort: clear a stale git registration for a prunable leftover. Never throws.
     try {
       if (runGit) runGit(['worktree', 'prune'], { cwd: repoRoot });
       else if (repoRoot) execSync('git worktree prune', { cwd: repoRoot, stdio: 'pipe' });
     } catch { /* prune is best-effort */ }
-    return { ok: true, method: 'safe-recursive-rm' };
+    return { ok: true, method: 'archived', archivePath: dest };
   } catch (e) {
-    return { ok: false, method: 'failed', error: String(e?.message || e) };
+    // REFUSED, not failed-then-deleted. The source is still on disk and still inspectable.
+    return { ok: false, method: 'refused', error: String(e?.message || e) };
   }
 }
 
@@ -221,6 +289,15 @@ export function buildOrphanSummary(sel, rec, { now = Date.now() } = {}) {
     reclaimed_bytes: rec.reclaimed_bytes,
     failed_count: rec.failed.length,
     dry_run: rec.dry_run,
+    // SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-4): refusals are ENUMERATED, not just counted.
+    // The incident summary recorded excluded_count=0 and reclaimed_count=1 — technically true and
+    // operationally useless: it named no directory, so nothing in the durable record said WHAT had
+    // been deleted or WHAT still needed a human. A refused dir that nobody can identify is spared
+    // and then forgotten, which is how a 707MB tree sat unattributed for two days.
+    refused_count: (sel.refused || []).length,
+    refused: (sel.refused || []).map((r) => ({
+      dir: r.dir, reason: r.reason, files: r.files, newest_mtime_ms: r.newestMtimeMs,
+    })),
   };
 }
 

--- a/lib/worktree-reaper/orphan-sweep.js
+++ b/lib/worktree-reaper/orphan-sweep.js
@@ -197,7 +197,17 @@ export function defaultRemoveOrphan(full, repoRoot, { runGit, renameImpl, fsImpl
   try {
     if (!fsImpl.existsSync(abs)) return { ok: true, method: 'already-gone' };
 
-    const archiveDir = path.join(path.dirname(abs), ARCHIVE_DIR_NAME);
+    // Resolve the ONE archive root, not a per-layout sibling.
+    //
+    // dirname(abs) alone sends a typed orphan (.worktrees/qf/QF-X) to .worktrees/qf/_archive.
+    // scripts/maintenance/Prune-WorktreeArchive.ps1 only ever visits .worktrees/_archive, so that
+    // split would leave "the dominant real orphan case" (per this module's own docstring)
+    // accumulating in a directory nothing prunes — trading a delete-everything bug for a
+    // never-collect-anything one. Walk up past a known typed subdir so every archive lands in the
+    // single root the pruner and the scan-root exclusion both already know about.
+    let archiveParent = path.dirname(abs);
+    if (TYPED_SUBDIRS.includes(path.basename(archiveParent))) archiveParent = path.dirname(archiveParent);
+    const archiveDir = path.join(archiveParent, ARCHIVE_DIR_NAME);
     fsImpl.mkdirSync(archiveDir, { recursive: true });
     // Same timestamped convention as the Stage-1/2 archive path.
     const stamp = new Date(typeof now === 'number' ? now : Date.now()).toISOString().replace(/[:.]/g, '-');
@@ -231,7 +241,8 @@ export function defaultRemoveOrphan(full, repoRoot, { runGit, renameImpl, fsImpl
  * @param {{execute?: boolean, repoRoot: string, remove?: function, sizeOf?: function,
  *          logger?: function}} [opts]
  * @returns {{reclaimed: Array<{dir, bytes, method}>, failed: Array<{dir, error}>,
- *            reclaimed_count: number, reclaimed_bytes: number, dry_run: boolean}}
+ *            reclaimed_count: number, archived_bytes: number, disk_freed_bytes: number,
+ *            dry_run: boolean}}
  */
 export function reclaimOrphans(reapableDirs = [], opts = {}) {
   const {
@@ -261,12 +272,20 @@ export function reclaimOrphans(reapableDirs = [], opts = {}) {
       logger(`[orphan-sweep] ERROR reclaiming ${dir}: ${String(e?.message || e)}`);
     }
   }
-  const reclaimed_bytes = reclaimed.reduce((s, r) => s + (r.bytes || 0), 0);
+  // SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-1): name what actually happened.
+  //
+  // These bytes were MOVED into _archive, not reclaimed — a rename frees no disk at all. Keeping
+  // the old `reclaimed_bytes` name would have the summary assert a disk saving that did not occur,
+  // in the very SD whose FR-4 exists because the incident's record was "correct and operationally
+  // useless". `disk_freed_bytes` is stated explicitly as 0 rather than omitted, so a reader is
+  // told the number rather than left to infer it from a missing field.
+  const archived_bytes = reclaimed.reduce((s, r) => s + (r.bytes || 0), 0);
   return {
     reclaimed,
     failed,
     reclaimed_count: reclaimed.length,
-    reclaimed_bytes,
+    archived_bytes,
+    disk_freed_bytes: 0,
     dry_run: !execute,
   };
 }
@@ -279,14 +298,17 @@ export function reclaimOrphans(reapableDirs = [], opts = {}) {
  */
 export function buildOrphanSummary(sel, rec, { now = Date.now() } = {}) {
   return {
-    schema_version: 1,
+    // v2: reclaimed_bytes -> archived_bytes + explicit disk_freed_bytes, and refused[] added.
+    // Bumped rather than silently redefining a field, so a consumer reading v1 semantics can tell.
+    schema_version: 2,
     timestamp: new Date(now).toISOString(),
     event: 'orphan_sweep',
     scanned: sel.total,
     reapable: sel.reapable,
     excluded_count: sel.excluded.length,
     reclaimed_count: rec.reclaimed_count,
-    reclaimed_bytes: rec.reclaimed_bytes,
+    archived_bytes: rec.archived_bytes ?? 0,
+    disk_freed_bytes: rec.disk_freed_bytes ?? 0,
     failed_count: rec.failed.length,
     dry_run: rec.dry_run,
     // SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-4): refusals are ENUMERATED, not just counted.

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -167,10 +167,12 @@ function parseArgs(argv) {
     // (standalone, for manual inspection); --no-orphan-sweep = skip the sweep that is
     // otherwise folded into the normal flow (so the hourly tick includes it).
     orphanSweep: args.includes('--orphan-sweep'),
-    // SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-1b): the CLI opt-out above is unreachable from BOTH
-    // automated invokers, so the gate must also be readable from the environment. See
-    // resolveOrphanSweepDisabled() for why it lives here and not in buildReaperArgs.
-    noOrphanSweep: args.includes('--no-orphan-sweep') || resolveOrphanSweepDisabled().disabled,
+    // SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-1b): CLI flag only HERE. The env half is evaluated at
+    // the call site instead — parseArgs runs at :1242 but loadDotenv() does not run until :1266,
+    // so reading process.env here would consult the environment BEFORE .env is loaded and
+    // WORKTREE_ORPHAN_SWEEP in a .env file would have had ZERO effect. The gate would have looked
+    // wired and done nothing, which is the same class of defect this SD exists to remove.
+    noOrphanSweep: args.includes('--no-orphan-sweep'),
     // SD-LEO-INFRA-WORKTREE-REAPER-MULTIREPO-001: reap EVERY registered pool (spawns a per-pool
     // --repo child so each pool keeps the full single-repo safety), not just the current repo.
     allPools: args.includes('--all-pools'),
@@ -1146,17 +1148,26 @@ async function runAndReportOrphanSweep({ repoRoot, worktreesDir, supabase, execu
   const s = sweep.summary || {};
   console.log(
     `🧹 Orphan sweep: scanned=${s.scanned ?? '?'} reapable=${s.reapable ?? '?'} ` +
-    `reclaimed=${s.reclaimed_count ?? 0} bytes=${s.reclaimed_bytes ?? 0} ` +
+    `archived=${s.reclaimed_count ?? 0} archived_bytes=${s.archived_bytes ?? 0} disk_freed=0 refused=${s.refused_count ?? 0} ` +
     `excluded=${s.excluded_count ?? 0} failed=${s.failed_count ?? 0}${s.dry_run ? ' (dry-run)' : ''}`
   );
-  // FR-4 durable summary: best-effort audit_log row when an EXECUTE run actually acted. Fail-soft.
-  if (sweep.ok && supabase && effectiveExecute && ((s.reclaimed_count || 0) > 0 || (s.failed_count || 0) > 0)) {
+  // FR-4 durable summary: best-effort audit_log row when an EXECUTE run acted OR REFUSED. Fail-soft.
+  //
+  // refused_count is in this gate deliberately. Without it, the one outcome that most needs a
+  // durable record — the sweep declining to touch a directory because it holds real content, which
+  // means a HUMAN has to decide — is the exact case that writes no row at all. A refuse-5/archive-0
+  // run would leave nothing behind but a console line on a cron nobody reads, which is how the
+  // 707MB directory sat unattributed for two days. FR-4 exists because the incident's record was
+  // correct and useless; a missing record is strictly worse than a useless one.
+  const actedOrRefused = (s.reclaimed_count || 0) > 0 || (s.failed_count || 0) > 0 || (s.refused_count || 0) > 0;
+  if (sweep.ok && supabase && effectiveExecute && actedOrRefused) {
     try {
       await supabase.from('audit_log').insert({
         event_type: 'worktree_orphan_sweep',
         entity_type: 'worktree',
         entity_id: 'orphan_sweep',
-        severity: (s.failed_count || 0) > 0 ? 'warning' : 'info',
+        // A refusal is not routine: it is an unresolved decision sitting on disk.
+        severity: ((s.failed_count || 0) > 0 || (s.refused_count || 0) > 0) ? 'warning' : 'info',
         created_by: 'worktree-reaper',
         metadata: s,
       });
@@ -1297,8 +1308,21 @@ export async function main(argv = process.argv) {
   // worktree-reaper-tick.cjs spawn includes it with NO separate cron. Runs BEFORE the
   // registered-worktree stage scan (and its early returns), is dry-run unless --execute,
   // and is fully fail-soft so it can never abort the reaper. Opt out with --no-orphan-sweep.
-  if (!opts.noOrphanSweep) {
+  // SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-1b): the env half of the gate is resolved HERE, after
+  // loadDotenv() has run at :1266. Reading it inside parseArgs (:1242) consulted process.env
+  // before .env was loaded, so a WORKTREE_ORPHAN_SWEEP entry in .env had no effect whatsoever —
+  // a gate that reads as wired and does nothing. Verified by the ordering of those two lines.
+  const orphanGate = resolveOrphanSweepDisabled();
+  if (!opts.noOrphanSweep && !orphanGate.disabled) {
     await runAndReportOrphanSweep({ repoRoot, worktreesDir, supabase, execute: opts.execute });
+  } else {
+    // Announce a deliberate zero rather than emitting nothing. A silent skip is indistinguishable
+    // from a sweep that ran and found nothing, which is how a disabled census goes unnoticed.
+    console.warn(JSON.stringify({
+      event: 'orphan_sweep_skipped',
+      reason: opts.noOrphanSweep ? 'cli_flag' : orphanGate.reason,
+      env_raw: orphanGate.raw ?? null,
+    }));
   }
 
   // Load reference data (best-effort — reaper is useful even with empty maps).

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -112,6 +112,48 @@ const PRESERVE_EXEMPT_RE = /^(tmp-|scratch-|\.claude[\\/]|\.workflow-patterns|\.
 
 // ── CLI parsing ────────────────────────────────────────────────────────
 
+/**
+ * SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-1b) — environment gate for the orphan leg.
+ *
+ * WHY AN ENV VAR AND NOT A CLI FLAG. `--no-orphan-sweep` is a real opt-out that NEITHER automated
+ * invoker can pass:
+ *   1. scripts/fleet/worktree-reaper-tick.cjs buildReaperArgs (:189-195) emits only --execute,
+ *      --stage2 --yes and --all-pools; the string 'no-orphan-sweep' does not appear in that file.
+ *   2. .github/workflows/worktree-reaper-cadence.yml runs `npm run worktree:reap:execute` on a
+ *      daily schedule, invoking THIS script directly with no path through the tick at all — it
+ *      cannot pass a flag under any wiring.
+ * An opt-out nothing can invoke is not an opt-out. Reading it HERE is the only seam both honour;
+ * threading a flag through buildReaperArgs alone would leave the cron ungated.
+ *
+ * FAIL DIRECTION IS DELIBERATE, and it is the opposite of the mistake next door. resolveMinAgeMs
+ * (lib/worktree-reaper/orphan-sweep.js:38-43) falls back to its 30-minute DEFAULT on every
+ * corruption — a value typo, a key typo, an empty string, a negative number — and accepts an
+ * explicit 0 that disables the guard entirely. Its docstring calls that "fail-safe toward MORE
+ * conservatism", which is true against a 30-minute baseline and FALSE once the same knob is used
+ * as a 10-year kill switch: every corruption RE-ARMS the destructive path. Measured, 2026-08-03.
+ *
+ * So here: UNSET means enabled (existing behaviour, byte-identical). A recognised off-value means
+ * disabled. Anything else that is SET BUT UNRECOGNISED means disabled AND WARNS — a typo must
+ * never silently leave a directory-deleting job armed, and it must never fail silently either.
+ * Accumulating orphans is a disk-space problem; deleting 601MB of deferred content is not.
+ *
+ * @param {NodeJS.ProcessEnv} [env=process.env]
+ * @returns {{disabled: boolean, reason: string|null, raw: string|undefined}}
+ */
+export function resolveOrphanSweepDisabled(env = process.env) {
+  const raw = env?.WORKTREE_ORPHAN_SWEEP;
+  if (raw == null || raw === '') return { disabled: false, reason: null, raw };
+  const v = String(raw).trim().toLowerCase();
+  if (['on', 'true', '1', 'yes', 'enabled'].includes(v)) return { disabled: false, reason: 'explicit_on', raw };
+  if (['off', 'false', '0', 'no', 'disabled'].includes(v)) return { disabled: true, reason: 'explicit_off', raw };
+  console.warn(
+    `⚠️  WORKTREE_ORPHAN_SWEEP is set to an unrecognised value ${JSON.stringify(raw)} — ` +
+    'treating the orphan sweep as DISABLED. This is deliberate: an unreadable setting must not ' +
+    'leave a directory-deleting job armed. Set it to on/off explicitly.'
+  );
+  return { disabled: true, reason: 'unrecognised_value', raw };
+}
+
 function parseArgs(argv) {
   const args = argv.slice(2);
   const opts = {
@@ -125,7 +167,10 @@ function parseArgs(argv) {
     // (standalone, for manual inspection); --no-orphan-sweep = skip the sweep that is
     // otherwise folded into the normal flow (so the hourly tick includes it).
     orphanSweep: args.includes('--orphan-sweep'),
-    noOrphanSweep: args.includes('--no-orphan-sweep'),
+    // SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-1b): the CLI opt-out above is unreachable from BOTH
+    // automated invokers, so the gate must also be readable from the environment. See
+    // resolveOrphanSweepDisabled() for why it lives here and not in buildReaperArgs.
+    noOrphanSweep: args.includes('--no-orphan-sweep') || resolveOrphanSweepDisabled().disabled,
     // SD-LEO-INFRA-WORKTREE-REAPER-MULTIREPO-001: reap EVERY registered pool (spawns a per-pool
     // --repo child so each pool keeps the full single-repo safety), not just the current repo.
     allPools: args.includes('--all-pools'),

--- a/tests/unit/worktree-reaper/orphan-content-probe.test.js
+++ b/tests/unit/worktree-reaper/orphan-content-probe.test.js
@@ -1,0 +1,215 @@
+/**
+ * SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 — bounded content probe (FR-2 / FR-3 / FR-3b).
+ *
+ * THE FAILURE BEING PINNED: the orphan sweep hard-deleted 601MB/42,162 files because the recency
+ * guard stat'd the top-level inode (blind to nested edits) and a missing .git short-circuited to
+ * reapable without any content check.
+ *
+ * THE FAILURE THIS SUITE IS ITSELF GUARDING AGAINST: FR-3 is an absence-read-as-signal fix, and
+ * PAT-CONFLATION-RECURSES-ONE-LAYER-UP-001 predicts such fixes reproduce the conflation one layer
+ * out. Here that means treating an UNMEASURABLE directory as an EMPTY one. Every failed-walk test
+ * below exists for that specific recurrence.
+ *
+ * Fixtures use a real mkdtemp sandbox (no vi.mock of node:fs) for the succeeding path, and an
+ * injected fsImpl for the failure paths. Locking a file to simulate failure is DELIBERATELY not
+ * used: a lock is the mechanism that manufactures these orphans, and a test whose cleanup fails
+ * would create one.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  probeContent, classifyContent,
+  CONTENT_REFUSE_MIN_FILES, CONTENT_REFUSE_MIN_BYTES,
+  PROBE_MAX_FILES, REASON,
+} from '../../../lib/worktree-reaper/orphan-content-probe.mjs';
+
+let sandbox;
+beforeAll(() => {
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'orphan-probe-'));
+});
+afterAll(() => {
+  try { fs.rmSync(sandbox, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+const mk = (name, files) => {
+  const root = path.join(sandbox, name);
+  fs.mkdirSync(root, { recursive: true });
+  for (const [rel, content] of files) {
+    const p = path.join(root, rel);
+    fs.mkdirSync(path.dirname(p), { recursive: true });
+    fs.writeFileSync(p, content);
+  }
+  return root;
+};
+
+describe('the probe measures CONTENT, not the container', () => {
+  it('counts nested files at depth, which the old top-level stat could not see', () => {
+    const root = mk('nested', [['a.txt', 'x'], ['d1/b.txt', 'yy'], ['d1/d2/c.txt', 'zzz']]);
+    const r = probeContent(root, { fsImpl: fs, pathImpl: path });
+    expect(r.ok).toBe(true);
+    expect(r.files).toBe(3);
+    expect(r.bytes).toBe(6);
+    expect(r.truncated).toBe(false);
+  });
+
+  it('reports the newest DESCENDANT mtime, not the directory mtime', () => {
+    const root = mk('mtimes', [['old.txt', 'a'], ['deep/new.txt', 'b']]);
+    const target = path.join(root, 'deep/new.txt');
+    const future = new Date(Date.now() + 60_000);
+    fs.utimesSync(target, future, future);
+    const r = probeContent(root, { fsImpl: fs, pathImpl: path });
+    expect(r.ok).toBe(true);
+    // The nested file is the newest thing in the tree; a top-level stat would never see it.
+    expect(r.newestMtimeMs).toBeGreaterThan(fs.statSync(root).mtimeMs);
+  });
+
+  it('CONTROL: the succeeding path runs against a REAL filesystem', () => {
+    // Without this, the probe would only ever be proven against an injected fake.
+    const root = mk('control', [['only.txt', 'hello']]);
+    const r = probeContent(root, { fsImpl: fs, pathImpl: path });
+    expect(r.ok).toBe(true);
+    expect(r.files).toBe(1);
+    expect(r.bytes).toBe(5);
+  });
+});
+
+describe('junctions and symlinks are never traversed', () => {
+  it('a link counts as zero files and zero bytes', () => {
+    const target = mk('link-target', [['big1.txt', 'x'.repeat(50)], ['big2.txt', 'y'.repeat(50)]]);
+    const root = mk('with-link', [['real.txt', 'z']]);
+    let linked = false;
+    try {
+      fs.symlinkSync(target, path.join(root, 'node_modules'), 'junction');
+      linked = true;
+    } catch { /* junction creation unavailable — assertion below is then vacuous, so skip */ }
+    if (!linked) return;
+    const r = probeContent(root, { fsImpl: fs, pathImpl: path });
+    expect(r.ok).toBe(true);
+    // 1 real file only. Following the junction would have counted the target's 2 files / 100 bytes.
+    expect(r.files).toBe(1);
+    expect(r.bytes).toBe(1);
+  });
+});
+
+describe('FR-3b — an UNMEASURABLE directory is never treated as an EMPTY one', () => {
+  const throwingFs = (on) => ({
+    lstatSync: (p) => { if (on === 'lstat') throw new Error('EPERM'); return fs.lstatSync(p); },
+    readdirSync: (p) => { if (on === 'readdir') throw new Error('EPERM'); return fs.readdirSync(p); },
+  });
+
+  it('a stat failure returns ok:false, not an empty measurement', () => {
+    const root = mk('stat-fail', [['a.txt', 'x']]);
+    const r = probeContent(root, { fsImpl: throwingFs('lstat'), pathImpl: path });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe(REASON.WALK_ERROR);
+  });
+
+  it('a readdir failure returns ok:false, not an empty measurement', () => {
+    const root = mk('readdir-fail', [['a.txt', 'x']]);
+    const r = probeContent(root, { fsImpl: throwingFs('readdir'), pathImpl: path });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe(REASON.WALK_ERROR);
+  });
+
+  it('a timeout returns ok:false with its own reason', () => {
+    const root = mk('timeout', [['a.txt', 'x'], ['b/c.txt', 'y']]);
+    let t = 1000;
+    const r = probeContent(root, { fsImpl: fs, pathImpl: path, maxMs: 5, now: () => (t += 10) });
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe(REASON.WALK_TIMEOUT);
+  });
+
+  it('EVERY failure mode classifies as REFUSE — this is the whole point of FR-3b', () => {
+    for (const probe of [
+      { ok: false, reason: REASON.WALK_ERROR },
+      { ok: false, reason: REASON.WALK_TIMEOUT },
+      null,
+      undefined,
+    ]) {
+      expect(classifyContent(probe).refuse).toBe(true);
+    }
+  });
+
+  it('a failed walk does NOT reuse the high_content reason', () => {
+    // If it did, a test asserting reason==='high_content' would be satisfied by the failure path
+    // and could no longer prove the content branch ran. Distinct strings keep the two claims
+    // independently checkable.
+    expect(classifyContent({ ok: false, reason: REASON.WALK_ERROR }).reason).not.toBe(REASON.HIGH_CONTENT);
+    expect(classifyContent({ ok: false, reason: REASON.WALK_TIMEOUT }).reason).not.toBe(REASON.HIGH_CONTENT);
+    expect(REASON.WALK_ERROR).not.toBe(REASON.HIGH_CONTENT);
+    expect(REASON.WALK_TIMEOUT).not.toBe(REASON.HIGH_CONTENT);
+    expect(REASON.CAP_EXCEEDED).not.toBe(REASON.HIGH_CONTENT);
+  });
+});
+
+describe('the bound is real — a cap hit is truncated, not a trusted partial count', () => {
+  it('stops at the cap and reports truncated', () => {
+    const files = Array.from({ length: 12 }, (_, i) => [`f${i}.txt`, 'x']);
+    const root = mk('capped', files);
+    const r = probeContent(root, { fsImpl: fs, pathImpl: path, maxFiles: 5 });
+    expect(r.truncated).toBe(true);
+    expect(r.files).toBeLessThanOrEqual(6);
+  });
+
+  it('a truncated probe REFUSES rather than judging on a partial count', () => {
+    const c = classifyContent({ ok: true, files: 2, bytes: 10, truncated: true });
+    expect(c.refuse).toBe(true);
+    expect(c.reason).toBe(REASON.CAP_EXCEEDED);
+  });
+
+  it('an untruncated probe under the thresholds does NOT refuse', () => {
+    // Opposite polarity: if everything refused, the sweep would stop working entirely.
+    const c = classifyContent({ ok: true, files: 1, bytes: 100, truncated: false });
+    expect(c.refuse).toBe(false);
+    expect(c.reason).toBeNull();
+  });
+});
+
+describe('thresholds keep real margin against the EXISTING fixtures', () => {
+  it('the 100-byte / 1-file fixture used by orphan-sweep.test.js does NOT refuse', () => {
+    // mkLeftover (:29-35) writes exactly one 100-byte file into every fixture. A
+    // `>1 file AND >100 bytes` rule would clear it with ZERO margin on both dimensions —
+    // one extra byte there would flip four assertions in a suite nobody was editing.
+    expect(classifyContent({ ok: true, files: 1, bytes: 100, truncated: false }).refuse).toBe(false);
+  });
+
+  it('the 6-byte README fixture used by lib/worktree-quota.test.js does NOT refuse', () => {
+    expect(classifyContent({ ok: true, files: 1, bytes: 6, truncated: false }).refuse).toBe(false);
+  });
+
+  it('the empty plain-leftover fixture does NOT refuse', () => {
+    expect(classifyContent({ ok: true, files: 0, bytes: 0, truncated: false }).refuse).toBe(false);
+  });
+
+  it('boundary pair: at-threshold refuses, one-under does not', () => {
+    expect(classifyContent({ ok: true, files: CONTENT_REFUSE_MIN_FILES, bytes: 0, truncated: false }).refuse).toBe(true);
+    expect(classifyContent({ ok: true, files: CONTENT_REFUSE_MIN_FILES - 1, bytes: 0, truncated: false }).refuse).toBe(false);
+    expect(classifyContent({ ok: true, files: 0, bytes: CONTENT_REFUSE_MIN_BYTES + 1, truncated: false }).refuse).toBe(true);
+    expect(classifyContent({ ok: true, files: 0, bytes: CONTENT_REFUSE_MIN_BYTES, truncated: false }).refuse).toBe(false);
+  });
+
+  it('a tree the size of the incident refuses on content', () => {
+    const c = classifyContent({ ok: true, files: 42162, bytes: 601021494, truncated: false });
+    expect(c.refuse).toBe(true);
+    expect(c.reason).toBe(REASON.HIGH_CONTENT);
+  });
+
+  it('thresholds and caps are exported constants, not inline literals', () => {
+    // So a test can assert a fixture sits BELOW the cap and remove the bound as a possible
+    // cause of a refusal — otherwise a content refusal and a cap refusal are indistinguishable.
+    expect(typeof CONTENT_REFUSE_MIN_FILES).toBe('number');
+    expect(typeof CONTENT_REFUSE_MIN_BYTES).toBe('number');
+    expect(PROBE_MAX_FILES).toBeGreaterThan(CONTENT_REFUSE_MIN_FILES);
+  });
+});
+
+describe('the injection seam is mandatory', () => {
+  it('refuses to run without fsImpl — no silent module-scope fs fallback', () => {
+    // A default fs would make the failure paths untestable and let a caller walk the real tree
+    // by accident. TR-3: no test may point this at a path under the real repo root.
+    expect(() => probeContent('/anywhere', {})).toThrow(/injection seam/);
+    expect(() => probeContent('/anywhere', { fsImpl: fs })).toThrow(/injection seam/);
+  });
+});

--- a/tests/unit/worktree-reaper/orphan-content-probe.test.js
+++ b/tests/unit/worktree-reaper/orphan-content-probe.test.js
@@ -150,7 +150,10 @@ describe('the bound is real — a cap hit is truncated, not a trusted partial co
     const root = mk('capped', files);
     const r = probeContent(root, { fsImpl: fs, pathImpl: path, maxFiles: 5 });
     expect(r.truncated).toBe(true);
-    expect(r.files).toBeLessThanOrEqual(6);
+    // Assert the CONTRACT ("never walk more than maxFiles"), not the observed behaviour.
+    // This previously read `toBeLessThanOrEqual(6)` with maxFiles=5 — an assertion shaped around
+    // an off-by-one rather than around the requirement, so it passed while the bound was wrong.
+    expect(r.files).toBe(5);
   });
 
   it('a truncated probe REFUSES rather than judging on a partial count', () => {

--- a/tests/unit/worktree-reaper/orphan-leg-env-gate.test.js
+++ b/tests/unit/worktree-reaper/orphan-leg-env-gate.test.js
@@ -1,0 +1,118 @@
+/**
+ * SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-1b) — the orphan leg must be gateable by BOTH invokers.
+ *
+ * THE DEFECT: `--no-orphan-sweep` is a real, documented opt-out on the reaper CLI that NEITHER
+ * automated caller can pass.
+ *   1. scripts/fleet/worktree-reaper-tick.cjs buildReaperArgs emits only --execute,
+ *      --stage2 --yes, --all-pools. The string 'no-orphan-sweep' appears ZERO times in that file.
+ *   2. .github/workflows/worktree-reaper-cadence.yml runs `npm run worktree:reap:execute` daily,
+ *      invoking scripts/worktree-reaper.mjs DIRECTLY — no tick, no arg builder, so no flag is
+ *      passable under any wiring.
+ * An opt-out nothing can invoke is not an opt-out.
+ *
+ * WHY THESE TESTS ASSERT AT worktree-reaper.mjs AND NOT AT buildReaperArgs: a gate threaded
+ * through the arg builder would satisfy invoker 1 and leave invoker 2 — the one that runs with
+ * --execute on a schedule, unattended — completely ungated. Asserting at the arg builder would
+ * therefore be a green test for a fix that does not cover the dangerous path.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { resolveOrphanSweepDisabled } from '../../../scripts/worktree-reaper.mjs';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+afterEach(() => { vi.restoreAllMocks(); });
+
+describe('the env gate is readable where BOTH invokers pass through', () => {
+  it('unset leaves the leg ENABLED — existing behaviour is byte-identical', () => {
+    expect(resolveOrphanSweepDisabled({}).disabled).toBe(false);
+    expect(resolveOrphanSweepDisabled({ WORKTREE_ORPHAN_SWEEP: '' }).disabled).toBe(false);
+  });
+
+  it('recognised off-values DISABLE the leg', () => {
+    for (const v of ['off', 'OFF', 'false', '0', 'no', 'disabled', ' Off ']) {
+      const r = resolveOrphanSweepDisabled({ WORKTREE_ORPHAN_SWEEP: v });
+      expect(r.disabled, `value ${JSON.stringify(v)}`).toBe(true);
+      expect(r.reason).toBe('explicit_off');
+    }
+  });
+
+  it('recognised on-values keep it ENABLED', () => {
+    for (const v of ['on', 'true', '1', 'yes', 'enabled']) {
+      expect(resolveOrphanSweepDisabled({ WORKTREE_ORPHAN_SWEEP: v }).disabled, v).toBe(false);
+    }
+  });
+});
+
+describe('FAIL DIRECTION — a corrupted setting must not leave a deleting job armed', () => {
+  it('an unrecognised value DISABLES rather than re-arming', () => {
+    // This is the inverse of the mistake in resolveMinAgeMs, where every corruption mode falls
+    // back to the 30-minute default and thereby RE-ARMS the destructive path. Measured 2026-08-03:
+    // a value typo, a key typo, empty and negative all resolve to 30 minutes there, and an
+    // explicit 0 disables that guard entirely.
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    for (const v of ['offf', 'no-orphan-sweep', 'TRUE!', '2', 'null', 'undefined']) {
+      const r = resolveOrphanSweepDisabled({ WORKTREE_ORPHAN_SWEEP: v });
+      expect(r.disabled, `value ${JSON.stringify(v)}`).toBe(true);
+      expect(r.reason).toBe('unrecognised_value');
+    }
+  });
+
+  it('and it WARNS — failing safe silently is its own defect', () => {
+    // mockClear() is load-bearing: vi.spyOn on an already-spied method returns the SAME mock, so
+    // without it this assertion counts the previous test's calls too and measures accumulated
+    // state rather than this test's behaviour. It failed 7-vs-1 on first run, which is how I know.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    warn.mockClear();
+    resolveOrphanSweepDisabled({ WORKTREE_ORPHAN_SWEEP: 'offf' });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(String(warn.mock.calls[0][0])).toMatch(/unrecognised value/i);
+  });
+
+  it('a RECOGNISED value never warns — the warning must stay meaningful', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    warn.mockClear();
+    resolveOrphanSweepDisabled({ WORKTREE_ORPHAN_SWEEP: 'off' });
+    resolveOrphanSweepDisabled({ WORKTREE_ORPHAN_SWEEP: 'on' });
+    resolveOrphanSweepDisabled({});
+    expect(warn).not.toHaveBeenCalled();
+  });
+});
+
+describe('the gate is wired at the seam both invokers reach', () => {
+  const SRC = readFileSync(resolve(REPO_ROOT, 'scripts/worktree-reaper.mjs'), 'utf8');
+  const CODE = SRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+  it('noOrphanSweep consults the env gate, not only the CLI flag', () => {
+    expect(CODE).toMatch(/noOrphanSweep:[^\n]*resolveOrphanSweepDisabled\(\)/);
+  });
+
+  it('the orphan leg call site still honours opts.noOrphanSweep', () => {
+    expect(CODE).toMatch(/if \(!opts\.noOrphanSweep\)/);
+  });
+
+  it('CONTROL: the stripper did not empty the source', () => {
+    expect(CODE).toMatch(/function parseArgs/);
+    expect(CODE.length).toBeGreaterThan(5000);
+  });
+});
+
+describe('the tick cannot pass the flag — which is WHY the env gate exists', () => {
+  const TICK = readFileSync(resolve(REPO_ROOT, 'scripts/fleet/worktree-reaper-tick.cjs'), 'utf8');
+
+  it('buildReaperArgs still emits no orphan-sweep flag', () => {
+    // Pins the premise. If someone later adds the flag here, this test failing is the signal to
+    // re-read FR-1b rather than assume the env gate became redundant — the cron path still
+    // cannot pass a flag, so the env gate remains load-bearing either way.
+    expect(TICK).not.toMatch(/no-orphan-sweep/);
+  });
+
+  it('the cron workflow invokes the reaper directly, with no tick in between', () => {
+    const wf = readFileSync(resolve(REPO_ROOT, '.github/workflows/worktree-reaper-cadence.yml'), 'utf8');
+    expect(wf).toMatch(/schedule:/);
+    expect(wf).toMatch(/worktree:reap/);
+    expect(wf).not.toMatch(/worktree-reaper-tick/);
+  });
+});

--- a/tests/unit/worktree-reaper/orphan-leg-env-gate.test.js
+++ b/tests/unit/worktree-reaper/orphan-leg-env-gate.test.js
@@ -85,12 +85,43 @@ describe('the gate is wired at the seam both invokers reach', () => {
   const SRC = readFileSync(resolve(REPO_ROOT, 'scripts/worktree-reaper.mjs'), 'utf8');
   const CODE = SRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
 
-  it('noOrphanSweep consults the env gate, not only the CLI flag', () => {
-    expect(CODE).toMatch(/noOrphanSweep:[^\n]*resolveOrphanSweepDisabled\(\)/);
+  it('the orphan leg honours BOTH the CLI flag and the env gate', () => {
+    expect(CODE).toMatch(/if \(!opts\.noOrphanSweep && !orphanGate\.disabled\)/);
   });
 
-  it('the orphan leg call site still honours opts.noOrphanSweep', () => {
-    expect(CODE).toMatch(/if \(!opts\.noOrphanSweep\)/);
+  it('THE ORDERING — the env gate is resolved AFTER loadDotenv(), not inside parseArgs', () => {
+    // THE DEFECT THIS PINS, found in review: the gate was originally evaluated inside parseArgs
+    // (:1242) while loadDotenv() does not run until :1266. It therefore read process.env BEFORE
+    // .env was loaded, so WORKTREE_ORPHAN_SWEEP in a .env file had ZERO effect. The gate looked
+    // wired, tested green against injected env objects, and did nothing in the deployment that
+    // matters. Position is the requirement here — a substring match alone cannot see it.
+    const parseArgsPos = CODE.indexOf('function parseArgs');
+    const dotenvPos = CODE.lastIndexOf('loadDotenv()');
+    const gateCallPos = CODE.indexOf('const orphanGate = resolveOrphanSweepDisabled()');
+    expect(gateCallPos).toBeGreaterThan(-1);
+    expect(dotenvPos).toBeGreaterThan(-1);
+    expect(gateCallPos).toBeGreaterThan(dotenvPos);      // resolved after .env is loaded
+    // And it is NOT evaluated inside parseArgs' returned object literal any more.
+    expect(CODE).not.toMatch(/noOrphanSweep:[^\n]*resolveOrphanSweepDisabled/);
+    expect(parseArgsPos).toBeGreaterThan(-1);            // control: the anchor still exists
+  });
+
+  it('the audit_log gate includes refused_count — a refusal must leave a record', () => {
+    // FOUND IN SECURITY REVIEW: the insert was gated on reclaimed_count/failed_count only, so a
+    // refuse-5/archive-0 run wrote NO row. That is the outcome most needing a durable trace — the
+    // sweep declined to act and a human now has to decide — and it was the one case that vanished.
+    expect(CODE).toMatch(/const actedOrRefused = [^\n]*refused_count/);
+    expect(CODE).toMatch(/effectiveExecute && actedOrRefused/);
+  });
+
+  it('a refusal raises severity above info — it is an unresolved decision, not routine', () => {
+    expect(CODE).toMatch(/severity:[\s\S]{0,120}refused_count[^\n]*'warning'/);
+  });
+
+  it('a skipped sweep is ANNOUNCED, not silent', () => {
+    // A silent skip is indistinguishable from a sweep that ran and found nothing, which is how a
+    // disabled census goes unnoticed for weeks.
+    expect(CODE).toMatch(/orphan_sweep_skipped/);
   });
 
   it('CONTROL: the stripper did not empty the source', () => {

--- a/tests/unit/worktree-reaper/orphan-refuse-high-content.test.js
+++ b/tests/unit/worktree-reaper/orphan-refuse-high-content.test.js
@@ -32,9 +32,14 @@
  */
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import fs from 'node:fs';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import { classifyOrphanDirs } from '../../../lib/worktree-quota.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 import {
   probeContent, PROBE_MAX_FILES, REASON,
   CONTENT_REFUSE_MIN_FILES,
@@ -254,15 +259,42 @@ describe('a BROKEN .git must not exempt a directory from the content check', () 
 });
 
 describe('the probe never runs on the worktree-creation hot path', () => {
-  it('classifyOrphanDirs performs ZERO probe calls when no probe is supplied', () => {
-    // enforceWorktreeQuota reaches this with no minAgeMs and no probe on every `git worktree add`.
-    // A probe there would walk the live .worktrees — which currently holds a 45,877-file tree whose
-    // naive walk exceeded ten minutes.
-    let calls = 0;
-    const counting = (d) => { calls += 1; return realProbe(d); };
-    classifyOrphanDirs(worktreesDir, [], {});                       // the hot-path shape
-    expect(calls).toBe(0);
-    classifyOrphanDirs(worktreesDir, [], { probe: counting });      // the sweep shape
-    expect(calls).toBeGreaterThan(0);
+  // WHY THIS IS A SOURCE ASSERTION AND NOT A CALL COUNT.
+  //
+  // This was originally written as a counting test: increment on each probe call, invoke
+  // classifyOrphanDirs with no probe, assert the counter is 0. That assertion was TAUTOLOGICAL —
+  // the counting function was never passed to that invocation, so the counter was 0 by
+  // construction and no implementation could have made it fail. A mutant that walked on every
+  // call survived it.
+  //
+  // A better counter does not exist either: classifyOrphanDirs never imports probeContent, it
+  // only receives one, so "did it call probeContent" is trivially no regardless of behaviour.
+  // The claim that actually matters lives one level up — whether the QUOTA CALL SITE passes a
+  // probe — and that is a property of the call site, so the call site is what gets asserted.
+  const QUOTA_SRC = readFileSync(resolve(REPO_ROOT, 'lib/worktree-quota.js'), 'utf8')
+    .replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+  it('the quota warning path calls classifyOrphanDirs WITHOUT a probe', () => {
+    // enforceWorktreeQuota reaches this on every `git worktree add`, against the live .worktrees
+    // — which currently holds a 45,877-file tree whose naive walk exceeded a ten-minute budget.
+    const call = QUOTA_SRC.match(/classifyOrphanDirs\(worktreesDir, registered, \{[^}]*\}\)/);
+    expect(call, 'quota call site not found — the anchor moved').not.toBeNull();
+    expect(call[0]).not.toMatch(/probe/);
+  });
+
+  it('and the probe branch is gated on the probe being a function', () => {
+    // So an absent probe cannot fall through to a default that walks.
+    expect(QUOTA_SRC).toMatch(/typeof probe === 'function'/);
+    expect(QUOTA_SRC).not.toMatch(/probe = \(dir\) =>/);   // no module-scope default in the classifier
+  });
+
+  it('BEHAVIOURAL: with no probe supplied, nothing can land in refused', () => {
+    // The half of the original test that was never tautological, kept and named honestly.
+    const dir = path.join(worktreesDir, 'heavy-but-unprobed');
+    fs.mkdirSync(dir, { recursive: true });
+    for (let i = 0; i < 10; i++) fs.writeFileSync(path.join(dir, `f${i}.txt`), 'x'.repeat(600));
+    const r = classifyOrphanDirs(worktreesDir, [], { minAgeMs: 0 });
+    expect(r.refused).toEqual([]);
+    expect(r.reapableDirs.find((x) => x.dir === 'heavy-but-unprobed')).toBeDefined();
   });
 });

--- a/tests/unit/worktree-reaper/orphan-refuse-high-content.test.js
+++ b/tests/unit/worktree-reaper/orphan-refuse-high-content.test.js
@@ -110,6 +110,56 @@ describe('FR-3 — a .git-less directory holding real content is REFUSED, not re
   });
 });
 
+describe('FR-2 — the recency guard reads CONTENT age, proven by a discriminating fixture', () => {
+  // ADDED AFTER REVIEW. Every other recency fixture here ages the container AND its contents
+  // together, so none of them can tell which mtime the consumer actually reads: replacing
+  // `Math.max(container, newestDescendant)` with the legacy container-only stat left all 257
+  // tests green. probeContent was proven to REPORT the newest descendant mtime; nothing proved
+  // classifyOrphanDirs USED it. This is the shape that discriminates — and it is the incident's
+  // own shape: a container that looks ancient wrapped around contents edited minutes ago.
+  it('a dir whose CONTAINER is aged but whose CONTENTS are fresh is NOT reaped', () => {
+    const dir = path.join(worktreesDir, 'stale-shell-fresh-guts');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'edited-just-now.txt'), 'x');   // descendant: seconds old
+    const ancient = new Date(Date.now() - AGED);
+    fs.utimesSync(dir, ancient, ancient);                            // container: 38.2h old
+
+    const r = classifyOrphanDirs(worktreesDir, [], { minAgeMs: THIRTY_MIN, probe: realProbe });
+
+    // Under the pre-fix top-level stat this read as 38.2h old and was REAPABLE — that is exactly
+    // how a tree edited 3.5h before the incident was classified as ancient and deleted.
+    expect(r.reapableDirs.find((x) => x.dir === 'stale-shell-fresh-guts')).toBeUndefined();
+    const ex = r.excluded.find((x) => x.dir === 'stale-shell-fresh-guts');
+    expect(ex).toBeDefined();
+    expect(ex.reason).toBe('too_recent');
+  });
+
+  it('an EMPTY dir created seconds ago is still too_recent — the guard\'s original purpose', () => {
+    // REGRESSION FOUND IN REVIEW: probeContent returns newestMtimeMs=0 for a tree with no files,
+    // so descendant-alone made `now - 0` ~57 years and a brand-new empty directory became
+    // REAPABLE. That population — a dir created by a half-finished `git worktree add` — is the
+    // case this guard was originally written for. Measured before the fix:
+    // WITH probe -> reapable, LEGACY -> too_recent.
+    fs.mkdirSync(path.join(worktreesDir, 'brand-new-empty'), { recursive: true });
+    const r = classifyOrphanDirs(worktreesDir, [], { minAgeMs: THIRTY_MIN, probe: realProbe });
+    const ex = r.excluded.find((x) => x.dir === 'brand-new-empty');
+    expect(ex).toBeDefined();
+    expect(ex.reason).toBe('too_recent');
+    expect(r.reapableDirs.find((x) => x.dir === 'brand-new-empty')).toBeUndefined();
+  });
+
+  it('and an AGED empty dir is still reapable — max() did not just disable the guard', () => {
+    // Opposite polarity for the same fix: if Math.max had been written so the container always
+    // wins, or the probe branch dropped entirely, empty orphans would stop being collected.
+    const dir = path.join(worktreesDir, 'aged-empty-shell');
+    fs.mkdirSync(dir, { recursive: true });
+    const ancient = new Date(Date.now() - AGED);
+    fs.utimesSync(dir, ancient, ancient);
+    const r = classifyOrphanDirs(worktreesDir, [], { minAgeMs: THIRTY_MIN, probe: realProbe });
+    expect(r.reapableDirs.find((x) => x.dir === 'aged-empty-shell')).toBeDefined();
+  });
+});
+
 describe('opposite polarity — the sweep must still do its job', () => {
   it('an EMPTY .git-less dir of the same age is still REAPABLE', () => {
     // If everything became refused, the orphan sweep would stop working and the fix would be
@@ -159,6 +209,47 @@ describe('FR-3b — an unmeasurable directory refuses with a DISTINCT reason', (
     expect(hit).toBeDefined();
     expect(hit.reason).toBe(REASON.WALK_TIMEOUT);
     expect(r.reapableDirs.find((x) => x.dir === 'aged-empty')).toBeUndefined();
+  });
+});
+
+describe('a BROKEN .git must not exempt a directory from the content check', () => {
+  // FOUND IN SECURITY REVIEW, reproduced before fixing. Two trees with identical content: the
+  // no-.git copy was caught, and a copy carrying a `.git` file pointing at a NONEXISTENT gitdir
+  // was classified REAPABLE. Three guards abstained on the same directory at once — isReapable
+  // cannot read git state it cannot reach and returns a clean-orphan verdict, the probe was gated
+  // off by hasGit, and recency fell back to the blind container stat. The original scoping
+  // rationale ("skip dirs isReapable already interrogates") is false exactly where that
+  // interrogation fails, which is the population most likely to be an abandoned real worktree.
+  const mkBroken = (name) => {
+    const dir = path.join(worktreesDir, name);
+    fs.mkdirSync(path.join(dir, 'nested'), { recursive: true });
+    for (let i = 0; i < 8; i++) fs.writeFileSync(path.join(dir, 'nested', `f${i}.txt`), 'x'.repeat(600));
+    fs.writeFileSync(path.join(dir, '.git'), 'gitdir: /nonexistent/path/that/does/not/exist');
+    const old = new Date(Date.now() - 6 * 60 * 60 * 1000);
+    fs.utimesSync(dir, old, old);           // container aged; contents deliberately left fresh
+    return dir;
+  };
+
+  it('a .git pointing at a nonexistent gitdir is REFUSED on content, not reaped', () => {
+    mkBroken('broken-git-heavy');
+    const r = classifyOrphanDirs(worktreesDir, [], { minAgeMs: THIRTY_MIN, probe: realProbe });
+    expect(r.reapableDirs.find((x) => x.dir === 'broken-git-heavy')).toBeUndefined();
+    const hit = r.refused.find((x) => x.dir === 'broken-git-heavy');
+    expect(hit).toBeDefined();
+    expect(hit.reason).toBe(REASON.HIGH_CONTENT);
+  });
+
+  it('but an EMPTY dir with a broken .git is still reapable — the check is content, not .git shape', () => {
+    // Opposite polarity: the fix must not make every .git-bearing dir unreapable, or the sweep
+    // stops collecting the leftovers it exists to collect.
+    const dir = path.join(worktreesDir, 'broken-git-empty');
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, '.git'), 'gitdir: /nonexistent');
+    const old = new Date(Date.now() - AGED);
+    fs.utimesSync(path.join(dir, '.git'), old, old);
+    fs.utimesSync(dir, old, old);
+    const r = classifyOrphanDirs(worktreesDir, [], { minAgeMs: THIRTY_MIN, probe: realProbe });
+    expect(r.reapableDirs.find((x) => x.dir === 'broken-git-empty')).toBeDefined();
   });
 });
 

--- a/tests/unit/worktree-reaper/orphan-refuse-high-content.test.js
+++ b/tests/unit/worktree-reaper/orphan-refuse-high-content.test.js
@@ -1,0 +1,177 @@
+/**
+ * SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 — ACTIVATION TEST for FR-3.
+ *
+ * THE INCIDENT: on 2026-08-01T16:01:49Z the orphan sweep ran execute=true and hard-deleted
+ * .worktrees/SD-FDBK-INFRA-CLAUDE-SOLOMON-EXCEEDS-001 — 42,162 files / 601,021,494 bytes — which
+ * one agent had inspected and refused to remove and the coordinator had explicitly declined to
+ * authorise ~34 minutes earlier. reclaimed_count=1, excluded_count=0, no archived copy.
+ * (audit_log 0c9875ad, written by the reaper itself.)
+ *
+ * WHY THIS FILE EXISTS SEPARATELY FROM THE HAPPY-PATH REPLAY — this is the whole point:
+ * the originally-stated acceptance replayed the incident with "nested mtimes FRESH". FR-2's
+ * recency guard excludes that on its own, so FR-3 never fires and the suite goes green with the
+ * FR-3 branch DELETED. A replay that cannot fail when the requirement is removed measures nothing.
+ *
+ * Four ways this suite could still have false-passed, and what closes each:
+ *   A. FR-2's file-count cap and "high file count" are the same dimension — a fixture built to
+ *      mirror the incident trips the CAP first and FR-3 is never consulted.
+ *      CLOSED BY: fixture sits provably below PROBE_MAX_FILES (asserted), and truncated===false.
+ *   B. Bucket folding — asserting on `excluded` passes even if `refused` never ships.
+ *      CLOSED BY: asserting refused contains it AND excluded/reapableDirs do not.
+ *   C. An outer-layer size/age belt refuses while classifyOrphanDirs still says reapable.
+ *      CLOSED BY: driving classifyOrphanDirs directly.
+ *   D. Reason-string collision with FR-3b — a failed walk also refusing as 'high_content' would
+ *      satisfy the assertion without the content branch running.
+ *      CLOSED BY: asserting the failure reason DIFFERS from the content reason.
+ *
+ * THE DECIDING ASSERTION is the minAgeMs:0 rerun. With the recency guard fully disabled it
+ * provably cannot be what refuses the directory, so a refusal there can only come from FR-3.
+ *
+ * MUTATION RECORD (required by the PRD, run 2026-08-03): commenting out the FR-3 content-refusal
+ * branch in lib/worktree-quota.js turns this file RED. Failing titles recorded in the handoff.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { classifyOrphanDirs } from '../../../lib/worktree-quota.js';
+import {
+  probeContent, PROBE_MAX_FILES, REASON,
+  CONTENT_REFUSE_MIN_FILES,
+} from '../../../lib/worktree-reaper/orphan-content-probe.mjs';
+
+/** The real probe, bound to the real fs. Never pointed at anything outside the sandbox (TR-3). */
+const realProbe = (dir) => probeContent(dir, { fsImpl: fs, pathImpl: path });
+
+let sandbox;
+let worktreesDir;
+beforeAll(() => {
+  sandbox = fs.mkdtempSync(path.join(os.tmpdir(), 'orphan-fr3-'));
+  worktreesDir = path.join(sandbox, '.worktrees');
+  fs.mkdirSync(worktreesDir, { recursive: true });
+});
+afterAll(() => {
+  try { fs.rmSync(sandbox, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+/** Unregistered, no .git — the incident's shape. `age` ages EVERY descendant. */
+const mkOrphan = (name, fileCount, bytesEach = 1, ageMs = 0) => {
+  const root = path.join(worktreesDir, name);
+  fs.mkdirSync(root, { recursive: true });
+  for (let i = 0; i < fileCount; i++) {
+    fs.writeFileSync(path.join(root, `f${i}.txt`), 'x'.repeat(bytesEach));
+  }
+  if (ageMs > 0) {
+    const when = new Date(Date.now() - ageMs);
+    for (const f of fs.readdirSync(root)) fs.utimesSync(path.join(root, f), when, when);
+    fs.utimesSync(root, when, when);
+  }
+  return root;
+};
+
+const THIRTY_MIN = 30 * 60 * 1000;
+const AGED = 38.2 * 60 * 60 * 1000; // the live exposure's actual age
+
+describe('FR-3 — a .git-less directory holding real content is REFUSED, not reaped', () => {
+  it('the AGED high-content shape is refused with reason=high_content', () => {
+    // THE SHAPE THE ORIGINAL ACCEPTANCE MISSED. Content is 38.2h old — far past any defensible
+    // recency window — so FR-2 cannot save it. This is the live 707MB exposure's exact shape.
+    mkOrphan('aged-heavy', 10, 600, AGED);
+    const r = classifyOrphanDirs(worktreesDir, [], { minAgeMs: THIRTY_MIN, probe: realProbe });
+
+    const hit = r.refused.find((x) => x.dir === 'aged-heavy');
+    expect(hit).toBeDefined();
+    expect(hit.reason).toBe(REASON.HIGH_CONTENT);          // toBe, not toMatch — vector D
+    expect(hit.files).toBe(10);
+    // Vector B: it must be in `refused`, and in NEITHER other bucket.
+    expect(r.reapableDirs.find((x) => x.dir === 'aged-heavy')).toBeUndefined();
+    expect(r.excluded.find((x) => x.dir === 'aged-heavy')).toBeUndefined();
+  });
+
+  it('THE DECIDING ASSERTION — still refused with minAgeMs:0, so recency cannot be the decider', () => {
+    // With the recency guard fully disabled, a refusal can only come from the FR-3 content branch.
+    // Without this, vector A stands: a big fixture could be refused by FR-2's bound and this file
+    // would stay green with FR-3 deleted.
+    const r = classifyOrphanDirs(worktreesDir, [], { minAgeMs: 0, probe: realProbe });
+    const hit = r.refused.find((x) => x.dir === 'aged-heavy');
+    expect(hit).toBeDefined();
+    expect(hit.reason).toBe(REASON.HIGH_CONTENT);
+    expect(r.excluded.find((x) => x.dir === 'aged-heavy')).toBeUndefined();
+  });
+
+  it('CONTROL — the fixture sits BELOW the probe cap, so the bound cannot be the cause', () => {
+    // Removes vector A conclusively: a cap-driven refusal reports CAP_EXCEEDED, not HIGH_CONTENT,
+    // and this fixture never reaches the cap at all.
+    const p = realProbe(path.join(worktreesDir, 'aged-heavy'));
+    expect(p.ok).toBe(true);
+    expect(p.truncated).toBe(false);
+    expect(p.files).toBeLessThan(PROBE_MAX_FILES);
+    expect(p.files).toBeGreaterThanOrEqual(CONTENT_REFUSE_MIN_FILES);
+  });
+});
+
+describe('opposite polarity — the sweep must still do its job', () => {
+  it('an EMPTY .git-less dir of the same age is still REAPABLE', () => {
+    // If everything became refused, the orphan sweep would stop working and the fix would be
+    // indistinguishable from disabling it.
+    mkOrphan('aged-empty', 0, 0, AGED);
+    const r = classifyOrphanDirs(worktreesDir, [], { minAgeMs: THIRTY_MIN, probe: realProbe });
+    expect(r.reapableDirs.find((x) => x.dir === 'aged-empty')).toBeDefined();
+    expect(r.refused.find((x) => x.dir === 'aged-empty')).toBeUndefined();
+  });
+
+  it('a FRESH high-content dir is excluded by RECENCY, not by content — FR-2 still owns that case', () => {
+    // Pins the evaluation order: recency runs before content refusal. If FR-3 were evaluated
+    // first this flips to refused and this assertion fails.
+    mkOrphan('fresh-heavy', 10, 600, 0);
+    const r = classifyOrphanDirs(worktreesDir, [], { minAgeMs: THIRTY_MIN, probe: realProbe });
+    const ex = r.excluded.find((x) => x.dir === 'fresh-heavy');
+    expect(ex).toBeDefined();
+    expect(ex.reason).toBe('too_recent');
+    expect(r.refused.find((x) => x.dir === 'fresh-heavy')).toBeUndefined();
+  });
+
+  it('the legacy no-probe path is unchanged — no refused bucket populated', () => {
+    // Byte-identical behaviour for every existing caller, including the worktree-quota hot path
+    // that runs on every `git worktree add`.
+    const r = classifyOrphanDirs(worktreesDir, [], { minAgeMs: THIRTY_MIN });
+    expect(r.refused).toEqual([]);
+    expect(r.reapableDirs.find((x) => x.dir === 'aged-heavy')).toBeDefined();
+  });
+});
+
+describe('FR-3b — an unmeasurable directory refuses with a DISTINCT reason', () => {
+  it('a failing probe refuses, and not as high_content', () => {
+    // Vector D: if the failure path reused 'high_content', the assertions above could be
+    // satisfied without the content branch ever running.
+    const failingProbe = () => ({ ok: false, reason: REASON.WALK_ERROR });
+    const r = classifyOrphanDirs(worktreesDir, [], { minAgeMs: THIRTY_MIN, probe: failingProbe });
+    const hit = r.refused.find((x) => x.dir === 'aged-heavy');
+    expect(hit).toBeDefined();
+    expect(hit.reason).toBe(REASON.WALK_ERROR);
+    expect(hit.reason).not.toBe(REASON.HIGH_CONTENT);
+  });
+
+  it('even an EMPTY dir refuses when its walk fails — unmeasurable is not empty', () => {
+    const failingProbe = () => ({ ok: false, reason: REASON.WALK_TIMEOUT });
+    const r = classifyOrphanDirs(worktreesDir, [], { minAgeMs: THIRTY_MIN, probe: failingProbe });
+    const hit = r.refused.find((x) => x.dir === 'aged-empty');
+    expect(hit).toBeDefined();
+    expect(hit.reason).toBe(REASON.WALK_TIMEOUT);
+    expect(r.reapableDirs.find((x) => x.dir === 'aged-empty')).toBeUndefined();
+  });
+});
+
+describe('the probe never runs on the worktree-creation hot path', () => {
+  it('classifyOrphanDirs performs ZERO probe calls when no probe is supplied', () => {
+    // enforceWorktreeQuota reaches this with no minAgeMs and no probe on every `git worktree add`.
+    // A probe there would walk the live .worktrees — which currently holds a 45,877-file tree whose
+    // naive walk exceeded ten minutes.
+    let calls = 0;
+    const counting = (d) => { calls += 1; return realProbe(d); };
+    classifyOrphanDirs(worktreesDir, [], {});                       // the hot-path shape
+    expect(calls).toBe(0);
+    classifyOrphanDirs(worktreesDir, [], { probe: counting });      // the sweep shape
+    expect(calls).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/worktree-reaper/orphan-report-and-scan-roots.test.js
+++ b/tests/unit/worktree-reaper/orphan-report-and-scan-roots.test.js
@@ -22,7 +22,12 @@ import {
   selectReapableOrphans, buildOrphanSummary, ARCHIVE_DIR_NAME,
 } from '../../../lib/worktree-reaper/orphan-sweep.js';
 import { WORKTREE_QUOTA_HELPERS } from '../../../lib/worktree-quota.js';
-import { REASON } from '../../../lib/worktree-reaper/orphan-content-probe.mjs';
+import { REASON, probeContent } from '../../../lib/worktree-reaper/orphan-content-probe.mjs';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
 
 let root, worktreesDir;
 
@@ -88,6 +93,34 @@ describe('FR-4 — refusals survive the merge and reach the report', () => {
     const summary = buildOrphanSummary(sel, { reclaimed_count: 0, reclaimed_bytes: 0, failed: [], dry_run: true });
     expect(summary.refused_count).toBe(0);
     expect(summary.refused).toEqual([]);
+  });
+});
+
+describe('FR-2 — the DRY-RUN path is bounded too', () => {
+  it('sizing goes through the bounded probe, not the unbounded walker', () => {
+    // reclaimOrphans calls sizeOf ABOVE the `if (!execute)` short-circuit, so it runs on every dry
+    // run — the default posture, hourly. dirSizeBytes has no cap and no deadline, so that walk is
+    // exactly the one that exceeded ten minutes on the 45,877-file directory. Bounding the
+    // classifier's walk while leaving this one meant the hazard survived in the path that runs
+    // most often.
+    const SRC = readFileSync(resolve(REPO_ROOT, 'lib/worktree-reaper/orphan-sweep.js'), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    expect(SRC).toMatch(/sizeOf = \(full\) => \{[\s\S]{0,200}probeContent\(/);
+    expect(SRC).not.toMatch(/sizeOf = \(full\) => dirSizeBytes\(full\)/);
+  });
+
+  it('a tree far over the cap still returns promptly with a lower-bound size', () => {
+    // Behavioural: the probe truncates rather than walking forever. The number is a lower bound,
+    // which is the right trade for a summary field — an approximate figure that always returns
+    // beats an exact one that hangs the reaper.
+    const big = path.join(worktreesDir, 'oversized');
+    fs.mkdirSync(big, { recursive: true });
+    for (let i = 0; i < 40; i++) fs.writeFileSync(path.join(big, `f${i}.txt`), 'x'.repeat(100));
+    const started = Date.now();
+    const p = probeContent(big, { fsImpl: fs, pathImpl: path, maxFiles: 10 });
+    expect(p.truncated).toBe(true);
+    expect(p.files).toBe(10);
+    expect(Date.now() - started).toBeLessThan(2000);
   });
 });
 

--- a/tests/unit/worktree-reaper/orphan-report-and-scan-roots.test.js
+++ b/tests/unit/worktree-reaper/orphan-report-and-scan-roots.test.js
@@ -1,0 +1,136 @@
+/**
+ * SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 — FR-4 (report enumerates the population) + FR-5 (_archive is
+ * never a scan root).
+ *
+ * FR-4's motivation is the incident's own summary row (audit_log 0c9875ad):
+ *   {scanned:4, reapable:4, excluded_count:0, reclaimed_count:1, reclaimed_bytes:601021494, failed_count:3}
+ * Every number is correct and the record is still operationally useless — it names no directory.
+ * Nothing in it says WHAT was deleted or WHAT still needs a human, which is how a 707MB tree sat
+ * unattributed for two days afterwards. Counting is not enumerating.
+ *
+ * WHY THE END-TO-END TEST BELOW EXISTS: while wiring this I found that selectReapableOrphans built
+ * its merged result with no `refused` key and never copied r.refused, so refusals from
+ * classifyOrphanDirs were silently DROPPED before reaching the sweep. FR-3 was implemented and
+ * operationally inert — the directory would have been spared, and nobody would ever have learned
+ * it needed a decision. A unit test on classifyOrphanDirs alone cannot see that seam.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import {
+  selectReapableOrphans, buildOrphanSummary, ARCHIVE_DIR_NAME,
+} from '../../../lib/worktree-reaper/orphan-sweep.js';
+import { WORKTREE_QUOTA_HELPERS } from '../../../lib/worktree-quota.js';
+import { REASON } from '../../../lib/worktree-reaper/orphan-content-probe.mjs';
+
+let root, worktreesDir;
+
+const mkDir = (rel, files = []) => {
+  const dir = path.join(worktreesDir, rel);
+  fs.mkdirSync(dir, { recursive: true });
+  for (const [n, c] of files) fs.writeFileSync(path.join(dir, n), c);
+  return dir;
+};
+
+beforeEach(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'orphan-report-'));
+  worktreesDir = path.join(root, '.worktrees');
+  fs.mkdirSync(worktreesDir, { recursive: true });
+});
+afterEach(() => {
+  try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe('FR-4 — refusals survive the merge and reach the report', () => {
+  it('END-TO-END: a high-content orphan is refused AND named in the selection', () => {
+    // The seam that was broken: classifyOrphanDirs refused it, selectReapableOrphans dropped it.
+    mkDir('heavy', [['a.txt', 'x'.repeat(50)], ['b.txt', 'y'.repeat(50)], ['c.txt', 'z'.repeat(50)]]);
+    const sel = selectReapableOrphans({ worktreesDir, registered: [], minAgeMs: 0 });
+
+    const hit = (sel.refused || []).find((r) => r.dir === 'heavy');
+    expect(hit).toBeDefined();
+    expect(hit.reason).toBe(REASON.HIGH_CONTENT);
+    expect(hit.files).toBe(3);
+    expect(sel.reapableDirs.find((d) => d.dir === 'heavy')).toBeUndefined();
+  });
+
+  it('the summary ENUMERATES refusals, not just a count', () => {
+    mkDir('heavy', [['a.txt', 'x'.repeat(50)], ['b.txt', 'y'.repeat(50)], ['c.txt', 'z'.repeat(50)]]);
+    const sel = selectReapableOrphans({ worktreesDir, registered: [], minAgeMs: 0 });
+    const summary = buildOrphanSummary(sel, { reclaimed_count: 0, reclaimed_bytes: 0, failed: [], dry_run: true });
+
+    expect(summary.refused_count).toBe(1);
+    // A count alone reproduces the incident summary's defect: correct and unactionable.
+    expect(summary.refused[0].dir).toBe('heavy');
+    expect(summary.refused[0].reason).toBe(REASON.HIGH_CONTENT);
+    expect(summary.refused[0].files).toBe(3);
+    expect(summary.refused[0]).toHaveProperty('newest_mtime_ms');
+  });
+
+  it('an empty orphan is still reaped and NOT refused — the population is real, not blanket', () => {
+    mkDir('empty-one');
+    const sel = selectReapableOrphans({ worktreesDir, registered: [], minAgeMs: 0 });
+    expect(sel.reapableDirs.find((d) => d.dir === 'empty-one')).toBeDefined();
+    expect((sel.refused || []).find((r) => r.dir === 'empty-one')).toBeUndefined();
+  });
+
+  it('typed-subdir refusals carry their prefix so the report is unambiguous', () => {
+    mkDir('qf/heavy-qf', [['a.txt', 'x'.repeat(50)], ['b.txt', 'y'.repeat(50)], ['c.txt', 'z'.repeat(50)]]);
+    const sel = selectReapableOrphans({ worktreesDir, registered: [], minAgeMs: 0 });
+    const hit = (sel.refused || []).find((r) => r.dir === 'qf/heavy-qf');
+    expect(hit).toBeDefined();
+    expect(hit.reason).toBe(REASON.HIGH_CONTENT);
+  });
+
+  it('a summary with no refusals reports 0 and an empty list, never undefined', () => {
+    const sel = selectReapableOrphans({ worktreesDir, registered: [], minAgeMs: 0 });
+    const summary = buildOrphanSummary(sel, { reclaimed_count: 0, reclaimed_bytes: 0, failed: [], dry_run: true });
+    expect(summary.refused_count).toBe(0);
+    expect(summary.refused).toEqual([]);
+  });
+});
+
+describe('FR-5 — _archive is never scanned, by two independent layers', () => {
+  it('layer 1: _archive is skipped as a TOP-LEVEL entry', () => {
+    expect(WORKTREE_QUOTA_HELPERS.has(ARCHIVE_DIR_NAME)).toBe(true);
+  });
+
+  it('layer 2: _archive is not a scan root — BEHAVIOURAL, not a constant check', () => {
+    // The one that matters. isReapable's container guard matches path.basename ONLY, so an
+    // archived tree at _archive/<name>-<ts> has basename <name>-<ts> and would look like an
+    // ordinary orphan if _archive ever became a scan root. FR-1 makes _archive the sole custodian
+    // of everything the sweep preserves, so this is now load-bearing in a way it was not before.
+    const archived = path.join(worktreesDir, ARCHIVE_DIR_NAME, 'SD-PRESERVED-2026-08-03T00-00-00-000Z');
+    fs.mkdirSync(archived, { recursive: true });
+    fs.writeFileSync(path.join(archived, 'precious.txt'), 'x'.repeat(9000));
+
+    const sel = selectReapableOrphans({ worktreesDir, registered: [], minAgeMs: 0 });
+
+    const names = [
+      ...sel.reapableDirs.map((d) => d.dir),
+      ...sel.excluded.map((e) => e.dir),
+      ...(sel.refused || []).map((r) => r.dir),
+    ];
+    // It must not appear in ANY bucket — not reapable, and not merely "refused" either. A refused
+    // verdict would still mean the sweep walked into the archive.
+    expect(names.some((n) => n.includes('SD-PRESERVED'))).toBe(false);
+    expect(names.some((n) => n.includes(ARCHIVE_DIR_NAME))).toBe(false);
+    expect(fs.existsSync(path.join(archived, 'precious.txt'))).toBe(true);
+  });
+
+  it('CONTROL: the same tree placed OUTSIDE _archive IS seen — proving the scan works at all', () => {
+    // Without this, the assertion above passes on a scan that finds nothing anywhere.
+    const loose = path.join(worktreesDir, 'SD-PRESERVED-loose');
+    fs.mkdirSync(loose, { recursive: true });
+    fs.writeFileSync(path.join(loose, 'precious.txt'), 'x'.repeat(9000));
+
+    const sel = selectReapableOrphans({ worktreesDir, registered: [], minAgeMs: 0 });
+    const names = [
+      ...sel.reapableDirs.map((d) => d.dir),
+      ...sel.excluded.map((e) => e.dir),
+      ...(sel.refused || []).map((r) => r.dir),
+    ];
+    expect(names.some((n) => n.includes('SD-PRESERVED-loose'))).toBe(true);
+  });
+});

--- a/tests/unit/worktree-reaper/orphan-sweep.test.js
+++ b/tests/unit/worktree-reaper/orphan-sweep.test.js
@@ -34,6 +34,30 @@ function mkLeftover(name, { withGit = false } = {}) {
   return dir;
 }
 
+/**
+ * Age a leftover tree — DIRECTORY AND CONTENTS.
+ *
+ * SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-2): these fixtures previously called
+ * `fs.utimesSync(dir, old, old)` and aged the CONTAINER ONLY, leaving the file inside freshly
+ * written. Under the old guard — which stat'd the top-level directory inode — that read as two
+ * hours old and the tests passed. Under FR-2, which reads the newest DESCENDANT mtime, the same
+ * fixture correctly reads as SECONDS old and is excluded as too_recent.
+ *
+ * The tests were not wrong about intent; their fixture encoded the very blindness FR-2 removes.
+ * A directory whose contents were written moments ago IS recent, and the incident is precisely
+ * what that confusion costs: a tree edited 3.5h earlier read as ancient because only the container
+ * was consulted. So the fixtures are corrected to age the whole tree — the guard is not weakened
+ * to accommodate them.
+ */
+function ageTree(dir, ms) {
+  const when = new Date(Date.now() - ms);
+  for (const e of fs.readdirSync(dir)) {
+    const p = path.join(dir, e);
+    try { if (!fs.lstatSync(p).isSymbolicLink()) fs.utimesSync(p, when, when); } catch { /* skip */ }
+  }
+  fs.utimesSync(dir, when, when);
+}
+
 // Junction (Windows) / dir-symlink (POSIX) from <dir>/node_modules to the shared store.
 function linkNodeModules(dir) {
   const nm = path.join(dir, 'node_modules');
@@ -53,12 +77,20 @@ beforeEach(() => {
 
 afterEach(() => {
   // Defensive teardown: unlink any junctions first so the test cleanup never follows them.
-  try {
-    for (const e of fs.readdirSync(worktreesDir)) {
-      const nm = path.join(worktreesDir, e, 'node_modules');
+  // SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-1): archived orphans now live one level deeper, at
+  // _archive/<name>-<ts>/node_modules. Without descending into _archive the teardown's recursive
+  // rmSync below is no longer junction-guarded and could follow a junction into the shared store —
+  // the exact harm the CANARY test exists to detect, caused by the cleanup rather than the code.
+  const unlinkJunctionsIn = (dir) => {
+    let entries = [];
+    try { entries = fs.readdirSync(dir); } catch { return; }
+    for (const e of entries) {
+      const nm = path.join(dir, e, 'node_modules');
       try { if (fs.lstatSync(nm).isSymbolicLink()) fs.unlinkSync(nm); } catch { /* none */ }
     }
-  } catch { /* worktreesDir gone */ }
+  };
+  unlinkJunctionsIn(worktreesDir);
+  unlinkJunctionsIn(path.join(worktreesDir, '_archive'));
   try { fs.rmSync(root, { recursive: true, force: true }); } catch { /* best-effort */ }
 });
 
@@ -69,10 +101,11 @@ describe('selectReapableOrphans (FR-1/FR-3)', () => {
     const recent = mkLeftover('fresh-dir');
     fs.mkdirSync(path.join(worktreesDir, '_archive'), { recursive: true }); // helper, never an orphan
 
-    // Age the old orphan well past the threshold; leave 'fresh-dir' new.
+    // Age the old orphan well past the threshold — CONTENTS INCLUDED (see ageTree); leave
+    // 'fresh-dir' new. FR-2 reads the newest DESCENDANT mtime, so ageing only the container
+    // would leave this tree correctly classified as seconds old.
     const now = Date.now();
-    const old = new Date(now - 2 * 60 * 60 * 1000);
-    fs.utimesSync(oldOrphan, old, old);
+    ageTree(oldOrphan, 2 * 60 * 60 * 1000);
 
     const sel = selectReapableOrphans({
       worktreesDir,
@@ -100,8 +133,7 @@ describe('selectReapableOrphans (FR-1/FR-3)', () => {
     fs.mkdirSync(path.join(worktreesDir, '_archive', 'preserved-from-x'), { recursive: true });
 
     const now = Date.now();
-    const old = new Date(now - 2 * 60 * 60 * 1000);
-    fs.utimesSync(qfOrphan, old, old);
+    ageTree(qfOrphan, 2 * 60 * 60 * 1000);
 
     const sel = selectReapableOrphans({
       worktreesDir,
@@ -128,19 +160,99 @@ describe('reclaimOrphans dry-run (FR-3)', () => {
 
 describe('reclaimOrphans junction safety — CANARY survives (FR-2)', () => {
   it('reclaims an orphan that junctions to shared node_modules without gutting the store', () => {
+    // SD-LEO-INFRA-ORPHAN-SWEEP-HARD-001 (FR-1) REPAIR — READ THIS BEFORE EDITING.
+    //
+    // This test was the repo's ONLY behavioural proof that orphan reclamation does not follow a
+    // node_modules junction and gut the shared store. It proved it by DELETING a junctioned tree
+    // and checking the canary survived.
+    //
+    // FR-1 made reclamation rename-only. The two original assertions then became TRUE FOR THE
+    // WRONG REASONS and the test went on passing while measuring nothing:
+    //   existsSync(orphan)===false  — still true, because a rename MOVES the source away.
+    //   existsSync(canary)===true   — now TRIVIALLY true, because nothing deletes any more.
+    // A test whose failure mode has been removed is indistinguishable from a healthy one.
+    // (PAT-TEST-PINS-FACT-NOT-BEHAVIOUR-001.)
+    //
+    // The destination assertions below are what restore its teeth: they check the junction moved
+    // AS A LINK, still resolves to the shared store, and that the store was never traversed.
     const orphan = mkLeftover('orphan-junctioned');
     linkNodeModules(orphan);
     expect(fs.existsSync(canary)).toBe(true);
+    const storeEntriesBefore = fs.readdirSync(sharedStore).length;
 
     const res = reclaimOrphans([{ dir: 'orphan-junctioned', full: orphan }], {
       execute: true,
-      repoRoot: root, // not a git repo → removeWorktreeViaGit fails → safeRecursiveRm fallback
+      repoRoot: root, // not a git repo → the best-effort `git worktree prune` is skipped
     });
 
     expect(res.reclaimed_count).toBe(1);
     expect(res.failed.length).toBe(0);
-    expect(fs.existsSync(orphan)).toBe(false);  // orphan removed
-    expect(fs.existsSync(canary)).toBe(true);   // shared store CANARY survived (junction not followed)
+    expect(fs.existsSync(orphan)).toBe(false);  // source path vacated (moved, not deleted)
+    expect(fs.existsSync(canary)).toBe(true);   // shared store CANARY survived
+
+    // --- FR-1 destination assertions: the archive actually holds the content ---
+    const archiveRoot = path.join(worktreesDir, '_archive');
+    const archived = fs.readdirSync(archiveRoot).filter((d) => d.startsWith('orphan-junctioned-'));
+    expect(archived).toHaveLength(1);
+    const dest = path.join(archiveRoot, archived[0]);
+
+    // The real file moved with it — proves this was a move, not a delete-and-forget.
+    expect(fs.readFileSync(path.join(dest, 'file.txt'), 'utf8')).toHaveLength(100);
+
+    // The junction moved AS A JUNCTION and still points at the shared store. If rename had
+    // dereferenced it, this would be a real directory containing a copy of the store.
+    const destNm = path.join(dest, 'node_modules');
+    expect(fs.lstatSync(destNm).isSymbolicLink()).toBe(true);
+    expect(fs.readFileSync(path.join(destNm, 'CANARY.txt'), 'utf8')).toBe('do-not-delete');
+
+    // The store itself was never walked into or added to.
+    expect(fs.readdirSync(sharedStore).length).toBe(storeEntriesBefore);
+  });
+
+  it('REFUSES rather than truncating when the move fails — source left intact', () => {
+    // The failure this SD exists to prevent, in its post-fix form: a locked child makes the
+    // parent rename throw EPERM. The old code would fall back to copy-then-delete, and
+    // safeRecursiveCp silently skips children it cannot stat — a truncated archive reporting
+    // success, then the source deleted. Rename-only means the only honest answer is REFUSAL.
+    const orphan = mkLeftover('orphan-locked');
+    linkNodeModules(orphan);
+    const boom = () => { const e = new Error('EPERM: operation not permitted'); e.code = 'EPERM'; throw e; };
+
+    const r = defaultRemoveOrphan(orphan, root, { renameImpl: boom });
+
+    expect(r.ok).toBe(false);
+    expect(r.method).toBe('refused');
+    expect(fs.existsSync(path.join(orphan, 'file.txt'))).toBe(true); // source intact, still inspectable
+    expect(fs.existsSync(canary)).toBe(true);
+    // And no partial destination left behind for someone to mistake for a complete archive.
+    const archiveRoot = path.join(worktreesDir, '_archive');
+    const leftovers = fs.existsSync(archiveRoot)
+      ? fs.readdirSync(archiveRoot).filter((d) => d.startsWith('orphan-locked-'))
+      : [];
+    expect(leftovers).toHaveLength(0);
+  });
+
+  it('REFUSES when the archive destination already exists — never overwrites a prior preserve', () => {
+    // Found by a surviving mutant: removing the collision guard changed nothing observable, which
+    // meant the guard was untested. It matters because FR-1 makes _archive the SOLE custodian of
+    // everything the sweep preserves — silently landing on an existing entry would destroy an
+    // earlier preserved tree, which is this SD's own failure mode relocated one directory over.
+    // The Stage-1/2 archiver has no such check; millisecond stamps make a clash rare, not absent.
+    const orphan = mkLeftover('orphan-clash');
+    const fixedNow = Date.parse('2026-08-03T00:00:00.000Z');
+    const stamp = new Date(fixedNow).toISOString().replace(/[:.]/g, '-');
+    const archiveRoot = path.join(worktreesDir, '_archive');
+    fs.mkdirSync(path.join(archiveRoot, `orphan-clash-${stamp}`), { recursive: true });
+    fs.writeFileSync(path.join(archiveRoot, `orphan-clash-${stamp}`, 'PRIOR.txt'), 'earlier-preserve');
+
+    const r = defaultRemoveOrphan(orphan, root, { now: fixedNow });
+
+    expect(r.ok).toBe(false);
+    expect(r.method).toBe('refused');
+    expect(String(r.error)).toMatch(/already exists/);
+    // The earlier preserve is untouched and the source is still there to retry.
+    expect(fs.readFileSync(path.join(archiveRoot, `orphan-clash-${stamp}`, 'PRIOR.txt'), 'utf8')).toBe('earlier-preserve');
+    expect(fs.existsSync(path.join(orphan, 'file.txt'))).toBe(true);
   });
 });
 

--- a/tests/unit/worktree-reaper/orphan-sweep.test.js
+++ b/tests/unit/worktree-reaper/orphan-sweep.test.js
@@ -98,7 +98,7 @@ describe('selectReapableOrphans (FR-1/FR-3)', () => {
   it('selects orphans = fs dirs minus registered + recent + helpers', () => {
     const oldOrphan = mkLeftover('old-orphan');
     const registered = mkLeftover('registered-wt', { withGit: true });
-    const recent = mkLeftover('fresh-dir');
+    mkLeftover('fresh-dir'); // created for its side effect; asserted by name below
     fs.mkdirSync(path.join(worktreesDir, '_archive'), { recursive: true }); // helper, never an orphan
 
     // Age the old orphan well past the threshold — CONTENTS INCLUDED (see ageTree); leave


### PR DESCRIPTION
## The incident

`2026-08-01T16:01:49Z` — the orphan sweep ran `execute=true` and hard-deleted `.worktrees/SD-FDBK-INFRA-CLAUDE-SOLOMON-EXCEEDS-001`: **42,162 files / 601,021,494 bytes**, which one agent had inspected and refused to remove and the coordinator had explicitly declined to authorise ~34 minutes earlier. No archived copy. Machine-attested by the reaper itself (`audit_log 0c9875ad`).

Two guards were **inapplicable by construction**, not mis-tuned:

- the recency guard stat'd the **top-level directory inode**, which advances only on entry add/remove/rename — so a tree whose nested files were edited 3.5h earlier read as ancient;
- a missing `.git` **short-circuited straight to reapable**, skipping the predicate entirely. The property that made the directory dangerous to delete became the property that made it unconditionally reapable.

## What changed

| FR | Change |
|---|---|
| **FR-1** | Reclamation moves into `_archive` by **rename only** and REFUSES on failure. No copy-then-delete fallback. |
| **FR-1b** | Env gate read in `worktree-reaper.mjs`, so **both** automated invokers honour it. |
| **FR-2** | Newest **descendant** mtime under a hard file-count cap AND deadline, failing toward exclude. |
| **FR-3** | Missing `.git` + content ⇒ **REFUSED**, in a third bucket. |
| **FR-3b** | A **failed walk** is never read as empty. |
| **FR-4** | The report **enumerates** refusals — dir, reason, file count, newest mtime. |
| **FR-5** | `_archive` is never a scan root, asserted behaviourally. |

### Why rename-only, with no copy fallback

`safeRecursiveCp` swallows a per-child `lstat` failure with a bare `continue`. These directories are orphans **because** a prior removal hit a Windows lock — 3 of 4 incident candidates failed on EPERM — so the locked-tree case is the *likely* branch. A copy fallback would silently truncate the archive, report success, then delete the source: the incident again, wearing a fix's paint. Junction safety is by construction, since `rename` never dereferences a reparse point.

### Why the env gate, and its fail direction

`--no-orphan-sweep` is a real opt-out that **neither** automated invoker can pass — `buildReaperArgs` emits only `--execute`/`--stage2`/`--all-pools`, and the daily GitHub Actions cron invokes the script directly with no tick in between. An opt-out nothing can invoke is not an opt-out.

Its fail direction deliberately inverts the bug next door: `resolveMinAgeMs` falls back to its 30-minute default on *every* corruption mode — value typo, key typo, empty, negative — and accepts an explicit `0` that disables the guard entirely, so each corruption **re-arms** the destructive path. Here an unrecognised value **disables** the leg and warns.

### Why FR-3b exists

`PAT-CONFLATION-RECURSES-ONE-LAYER-UP-001` predicts that a fix for *"absence read as signal of absence"* reproduces the conflation one layer out, authored by whoever just diagnosed it one layer down. FR-3 **is** such a fix, and the specific recurrence is treating an **unmeasurable** directory as an **empty** one. Timeout, cap and stat failure all refuse, with reason strings deliberately distinct from `high_content` so neither claim can satisfy the other's assertion.

## Verification

**257 pass / 0 fail** (baseline 208/0). Every FR mutation-verified:

| mutant | tests killed |
|---|---|
| `refused` dropped in the merge | 4 |
| probe not supplied (FR-3 disconnected) | 3 |
| FR-3 branch unreachable | 2 — incl. the deciding `minAgeMs:0` assertion |
| rename becomes a no-op reporting success | 2 — incl. the repaired CANARY |
| walk failure reusing `high_content` | 2 |
| probe made unconditional (hot-path) | 2 |
| fail-direction flipped to re-arm | 1 |
| `_archive` as a scan root | 1 |
| count without enumeration | 1 |
| collision guard removed | 1 |

## Two things found while building this

**A test was hollowed by my own fix.** The CANARY junction-safety test proved orphan removal doesn't gut the shared `node_modules` store — by *deleting* a junctioned tree and checking the canary survived. Once reclamation became rename-only, `existsSync(orphan)===false` still passed (rename moves the source) and `existsSync(canary)===true` became **trivially** true. The repo's only behavioural junction-safety proof for this path went on passing while measuring nothing. Repaired with destination assertions.

**FR-3 was operationally inert.** `selectReapableOrphans` built its merged result with no `refused` key and never copied `r.refused`, so refusals were dropped before reaching the sweep — the directory would be spared and nobody would learn it needed a decision. Only the end-to-end test sees that seam.

## Fixtures corrected, guards not weakened

Two existing tests aged the **container** (`fs.utimesSync(dir, ...)`) while leaving their file freshly written. That passed under the old top-level stat and correctly fails under FR-2. The fixtures encoded the very blindness this SD removes, so they now age the whole tree. Relaxing the guard to make them green would have restored the incident's mechanism.

## Not done here

The `.env` interim disarm **stays in place**. Its revert condition is corrected in `.env:194` and SD metadata to require **FR-3 landed AND a green enumeration** — not FR-1. FR-1 only makes a loss recoverable, and FR-2 cannot reach the live 707 MB exposure whose content is 38.2h old. Only FR-3 does.

Scope: **131 non-comment production lines** across three modules — above the 100 target, inside the 400 max, justified by six FRs on a data-loss path and by the gate needing to sit where both invokers pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
