### PR TITLE
feat(SD-LEO-INFRA-SHIP-AUTO-HANDOFF-001): the fence and the merge path now know about each other

### DIFF
--- a/scripts/post-merge-handoff-orchestrator.js
+++ b/scripts/post-merge-handoff-orchestrator.js
@@ -14,6 +14,14 @@ import { spawnSync } from 'child_process';
 import { appendFileSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
+
+// SD-LEO-INFRA-SHIP-AUTO-HANDOFF-001 (FR-3): the hold SSOT lives in a CommonJS module, so it is
+// pulled in via createRequire rather than re-implemented on this side of the boundary. Re-stating
+// the hold vocabulary here is exactly the second fence-reader FR-3 forbids — a copy drifts the
+// first time either side learns a new hold key, and the drift is silent because both halves keep
+// returning plausible answers.
+const { resolveHoldProvenance, formatHoldProvenance } = createRequire(import.meta.url)('../lib/fleet/claim-eligibility.cjs');
 
 const LOG_FILE = join(process.cwd(), '.claude', 'post-merge-orchestrator.log');
 const HANDOFF_CHAIN = ['EXEC-TO-PLAN', 'PLAN-TO-LEAD', 'LEAD-FINAL-APPROVAL'];
@@ -29,9 +37,39 @@ function logEvent(event) {
 }
 
 // Classify SD state for routing. Pure function — no side effects.
-export function classifyState({ status, current_phase }) {
+//
+// SD-LEO-INFRA-SHIP-AUTO-HANDOFF-001 (FR-1): `metadata` is now read so a RECORDED HOLD can refuse
+// the chain. Previously this function could not see holds at all, so /ship step 6.5 would drive an
+// SD that TESTING and VALIDATION had deliberately fenced at LEAD_FINAL straight through to
+// completed — and NO GATE WOULD HAVE FAILED, because each handoff is legitimately satisfied on its
+// own terms. The SD simply ARRIVES at completed with the work undelivered, and `completed` is
+// affirmatively excluded from every sweep, so nothing downstream can ever detect it.
+//
+// The only thing that previously prevented this was a worker happening to know
+// LEO_AUTOHANDOFF_ENABLED=false exists. Safety that depends on the operator already knowing the
+// escape hatch is not safety, so the default is inverted: held SDs are refused unless something
+// says otherwise, rather than advanced unless someone opts out.
+//
+// Stays PURE — metadata is passed in by the caller that already fetched the row, and
+// resolveHoldProvenance is itself pure over metadata. That purity is what keeps FR-4's regression
+// test a plain unit test with no database, no merge and no spawn.
+export function classifyState({ status, current_phase, metadata }) {
   if (status === 'completed' || current_phase === 'LEAD-FINAL-APPROVAL') {
     return { action: 'idempotent_skip', reason: 'already_completed_no_op' };
+  }
+  // Checked BEFORE the advance decision and after the no-op check: an already-completed SD has
+  // nothing to refuse, but everything still in flight must be tested for a hold first so the
+  // refusal reason is the informative one rather than a generic phase skip.
+  //
+  // FR-3: resolveHoldProvenance is reused verbatim — it is described in its own source as "the SSOT
+  // coalescer for the ad-hoc hold-reason keys". Deliberately NOT classifyDispatchIneligibility:
+  // that answers "may a worker CLAIM this?", a different question. claim-eligibility.cjs:187
+  // records that metadata.exec_boundary_hold is claim-ALLOWING by design, so the claim verdict is
+  // blind to at least one real hold, and axes like orchestrator_parent say nothing about whether a
+  // built SD should be completed. Aliasing it would import the wrong question.
+  const hold = resolveHoldProvenance(metadata);
+  if (hold && hold.reason) {
+    return { action: 'refuse_held', reason: 'sd_on_hold', hold };
   }
   if (current_phase === 'LEAD' && status === 'draft') {
     return { action: 'warn_skip', reason: 'no_exec_work_to_advance' };
@@ -125,7 +163,10 @@ export async function runOrchestrator({ sdKey, supabase, runner = defaultRunner,
 
   const { data: sd, error: lookupErr } = await supabase
     .from('strategic_directives_v2')
-    .select('status, current_phase, sd_key')
+    // FR-1: metadata is REQUIRED here — classifyState cannot see a hold that was never fetched,
+    // and an unselected column arrives as undefined rather than as an error, so omitting it would
+    // silently restore the old advance-everything behaviour with every test still green.
+    .select('status, current_phase, sd_key, metadata')
     .eq('sd_key', sdKey)
     .maybeSingle();
   if (lookupErr || !sd) {
@@ -134,6 +175,29 @@ export async function runOrchestrator({ sdKey, supabase, runner = defaultRunner,
   }
 
   const decision = classifyState(sd);
+
+  // SD-LEO-INFRA-SHIP-AUTO-HANDOFF-001 (FR-2): a refusal is NOT an idempotent skip and must not be
+  // reported as one. Every non-advance action previously logged 'idempotent_skip' and returned
+  // exitCode 0 — so a fenced SD would have been recorded as a routine no-op and reported success to
+  // /ship. A refusal gets its own event and its own exit code precisely so the caller can tell
+  // "refused because held" from "nothing to do" and from "the chain broke".
+  //
+  // It RENDERS the holder and the release condition rather than failing silently: a silent no-op
+  // teaches the operator nothing and is indistinguishable from a bug, which is how the escape-hatch
+  // flag came to be the only thing anyone knew about.
+  if (decision.action === 'refuse_held') {
+    const h = decision.hold || {};
+    logEvent({
+      event: 'refused_held', sd_key: sdKey, reason: decision.reason,
+      hold_reason: h.reason, hold_set_by: h.set_by, hold_source_key: h.source_key,
+    });
+    console.error(`⛔ REFUSED: ${sdKey} carries a recorded hold — auto-handoff will not advance it.`);
+    console.error(`   ${typeof formatHoldProvenance === 'function' ? formatHoldProvenance(h) : h.reason}`);
+    console.error('   The hold must be released by the party that set it; this is not a bug and');
+    console.error('   LEO_AUTOHANDOFF_ENABLED=false is not the remedy — the fence is doing its job.');
+    return { exitCode: 5, action: decision.action, reason: decision.reason, hold: h };
+  }
+
   if (decision.action !== 'advance') {
     logEvent({ event: 'idempotent_skip', sd_key: sdKey, reason: decision.reason, action: decision.action });
     return { exitCode: 0, action: decision.action, reason: decision.reason };

--- a/tests/unit/ship-auto-handoff-hold-refusal.test.js
+++ b/tests/unit/ship-auto-handoff-hold-refusal.test.js
@@ -1,0 +1,123 @@
+// SD-LEO-INFRA-SHIP-AUTO-HANDOFF-001 — the fence and the merge path now know about each other.
+//
+// THE WITNESSED NEAR-MISS: TESTING and VALIDATION had both fenced an SD at LEAD_FINAL pending human
+// delivery of FR-5. /ship step 6.5 auto-fires post-merge-handoff-orchestrator.js, which runs
+// EXEC-TO-PLAN -> PLAN-TO-LEAD -> LEAD-FINAL-APPROVAL and drives the SD to completed. Merging by the
+// DEFAULT path would have driven it straight through that fence and NO GATE WOULD HAVE FAILED —
+// each handoff is legitimately satisfied on its own terms. The SD would simply have ARRIVED at
+// completed with the work undelivered.
+//
+// WHY THAT IS UNALARMABLE, and why these tests assert what they assert: `completed` is affirmatively
+// excluded from every sweep. After the fact, a false completion is invisible — and so is a
+// legitimate non-completion. They are the same observation. So a test asserting "the SD did not
+// reach completed" passes when the fence works, when the chain crashes, AND when the orchestrator
+// never ran. Only a POSITIVE observable — a refusal naming its holder — separates the fixed state
+// from those failure modes.
+import { describe, it, expect } from 'vitest';
+import { classifyState } from '../../scripts/post-merge-handoff-orchestrator.js';
+
+// A phase/status pair that WOULD advance, so every hold test below is proving the hold caused the
+// refusal rather than the phase doing it anyway.
+const ADVANCING = { status: 'active', current_phase: 'EXEC' };
+const HELD = {
+  requires_human_action_reason: 'FR-5 must be applied by a human before completion',
+  requires_human_action_by: 'VALIDATION',
+  requires_human_action_at: '2026-08-01T12:00:00Z',
+};
+
+describe('FR-1: a recorded hold refuses the auto-handoff', () => {
+  // THE DECIDING SCENARIO — the witnessed shape, on the path a worker takes by default.
+  it('refuses an SD that carries a hold, instead of advancing it', () => {
+    const d = classifyState({ ...ADVANCING, metadata: HELD });
+    expect(d.action).toBe('refuse_held');
+    expect(d.action).not.toBe('advance');
+  });
+
+  // CONTROL — NOT optional coverage. A refusal that fires unconditionally satisfies every other
+  // assertion in this file and blocks every merge in the fleet. A check that cannot tell held from
+  // unheld is not a check.
+  it('CONTROL: an SD with no hold still advances', () => {
+    expect(classifyState({ ...ADVANCING, metadata: {} }).action).toBe('advance');
+    expect(classifyState({ ...ADVANCING, metadata: null }).action).toBe('advance');
+    expect(classifyState({ ...ADVANCING }).action).toBe('advance');
+  });
+
+  // The refusal must beat the advance decision, not follow it: refusing after the chain started
+  // would leave the SD advanced partway, which is a worse state than either outcome.
+  it('refuses across every phase that would otherwise advance', () => {
+    for (const phase of ['EXEC', 'PLAN_PRD', 'PLAN', 'PLAN_VERIFICATION']) {
+      expect(classifyState({ status: 'active', current_phase: phase, metadata: HELD }).action).toBe('refuse_held');
+      expect(classifyState({ status: 'active', current_phase: phase, metadata: {} }).action).toBe('advance');
+    }
+  });
+
+  // An already-completed SD has nothing to refuse — the no-op answer stays the more accurate one.
+  it('does not relabel an already-completed SD as held', () => {
+    expect(classifyState({ status: 'completed', current_phase: 'EXEC', metadata: HELD }).action).toBe('idempotent_skip');
+  });
+});
+
+describe('FR-2: the refusal names the holding party and the release condition', () => {
+  it('carries the hold reason and who set it', () => {
+    const d = classifyState({ ...ADVANCING, metadata: HELD });
+    expect(d.hold).toBeTruthy();
+    expect(d.hold.reason).toBe('FR-5 must be applied by a human before completion');
+    expect(d.hold.set_by).toBe('VALIDATION');
+    expect(d.hold.source_key).toBe('requires_human_action_reason');
+  });
+
+  // A refusal saying only "held" sends the operator back into the code to find out why — the silent
+  // no-op in a thinner disguise, and the failure this SD exists to remove.
+  it('is not a bare flag — the reason is present and non-empty', () => {
+    const d = classifyState({ ...ADVANCING, metadata: HELD });
+    expect(typeof d.hold.reason).toBe('string');
+    expect(d.hold.reason.length).toBeGreaterThan(0);
+  });
+});
+
+describe('FR-3: the hold vocabulary is the shared SSOT, not a local copy', () => {
+  // resolveHoldProvenance coalesces several ad-hoc hold-reason keys. If this file had re-implemented
+  // the vocabulary, only the key it happened to know would refuse — and the drift would be silent,
+  // because both halves keep returning plausible answers. Exercising a DIFFERENT key than the one
+  // above proves the shared reader is doing the work.
+  it('recognises a hold recorded under a different key', () => {
+    const d = classifyState({
+      ...ADVANCING,
+      metadata: { not_worker_claimable_reason: 'chairman ratification pending', deferred_by: 'coordinator' },
+    });
+    expect(d.action).toBe('refuse_held');
+    expect(d.hold.reason).toBe('chairman ratification pending');
+    expect(d.hold.source_key).toBe('not_worker_claimable_reason');
+  });
+});
+
+describe('FR-4/TR-1: pre-existing behaviour is unchanged for metadata-free callers', () => {
+  // Pinned so the signature widening is provably inert: a later failure is then attributable to the
+  // hold branch rather than to the refactor that preceded it.
+  it('keeps every original branch and reason', () => {
+    expect(classifyState({ status: 'completed', current_phase: 'EXEC' }))
+      .toEqual({ action: 'idempotent_skip', reason: 'already_completed_no_op' });
+    expect(classifyState({ status: 'active', current_phase: 'LEAD-FINAL-APPROVAL' }))
+      .toEqual({ action: 'idempotent_skip', reason: 'already_completed_no_op' });
+    expect(classifyState({ status: 'draft', current_phase: 'LEAD' }))
+      .toEqual({ action: 'warn_skip', reason: 'no_exec_work_to_advance' });
+    expect(classifyState({ status: 'active', current_phase: 'EXEC' }))
+      .toEqual({ action: 'advance', reason: 'ready_for_handoff_chain' });
+    expect(classifyState({ status: 'active', current_phase: 'WEIRD' }))
+      .toEqual({ action: 'warn_skip', reason: 'unexpected_phase_WEIRD_status_active' });
+  });
+
+  // TS-4: the protection must hold on the DEFAULT path. The defect was that safety depended on the
+  // operator knowing LEO_AUTOHANDOFF_ENABLED existed — so a refusal that only works when someone
+  // sets a flag would demonstrate the opposite of the fix.
+  it('refuses without reference to LEO_AUTOHANDOFF_ENABLED', () => {
+    const prior = process.env.LEO_AUTOHANDOFF_ENABLED;
+    delete process.env.LEO_AUTOHANDOFF_ENABLED;
+    try {
+      expect(classifyState({ ...ADVANCING, metadata: HELD }).action).toBe('refuse_held');
+    } finally {
+      if (prior === undefined) delete process.env.LEO_AUTOHANDOFF_ENABLED;
+      else process.env.LEO_AUTOHANDOFF_ENABLED = prior;
+    }
+  });
+});


### PR DESCRIPTION
## The near-miss

`/ship` step 6.5 auto-fires `post-merge-handoff-orchestrator.js`, which runs `EXEC-TO-PLAN → PLAN-TO-LEAD → LEAD-FINAL-APPROVAL` and drives the SD to `completed`.

`gh-merge-safe.mjs:39` skips it **only** when `LEO_AUTOHANDOFF_ENABLED === 'false'` — so **unset means run**. It is opt-*out*.

An SD that TESTING and VALIDATION had deliberately fenced at LEAD_FINAL would have been driven straight through it. **No gate would have failed** — each handoff is legitimately satisfied on its own terms. The SD simply *arrives* at `completed` with the work undelivered.

And `completed` is affirmatively excluded from every sweep, so **nothing downstream could ever detect it**. That is why the fix has to be a refusal at the moment of transition rather than a detector after it — there is no "after" that can see this.

The only thing that prevented it was a worker happening to know the flag existed. Safety that depends on the operator already knowing the escape hatch is not safety.

## The fix is composition, not construction

`classifyState` was already **pure, exported, and already had a refusal path**. `resolveHoldProvenance` — which calls itself *"the SSOT coalescer for the ad-hoc hold-reason keys"* — is also pure. So the whole change is composing two pure functions at a decision point that already existed.

| FR | Change |
|---|---|
| **FR-1** | `classifyState` receives `metadata` and refuses **before** the chain runs — refusing later leaves the SD advanced partway, worse than either outcome |
| **FR-2** | A refusal is **not** an idempotent skip. Previously *every* non-advance action logged `idempotent_skip` and returned `exitCode 0` — a fenced SD would have been recorded as a routine no-op and reported **success** to `/ship`. Now: own event, exit code 5, and it renders the holder + release condition |
| **FR-3** | Reuses `resolveHoldProvenance` verbatim. Deliberately **not** `classifyDispatchIneligibility` — that answers *"may a worker claim this?"*, a different question. `claim-eligibility.cjs:187` records that `exec_boundary_hold` is claim-**allowing** by design, so the claim verdict is blind to at least one real hold |

A test exercises a **second** hold key to prove the shared reader is doing the work, not a local copy that would drift silently.

## The `metadata` select

`:129` selected only `status, current_phase, sd_key`. An unselected column arrives as `undefined` rather than as an error, so omitting it would have **silently restored advance-everything with every test still green**. Same trap as `cancel-sd.js` earlier today.

## Seeded-defect check

Disabling the hold branch fails **6 of 9**. The 3 that stay green are exactly the ones that should — the unheld control, the already-completed case, and the pre-existing-branch pins — because they test the other direction. A suite that passes proves nothing until it can fail.

Two assertions carry the suite:
- **Assert the refusal, never the absence of completion.** "Did not reach completed" also passes when the chain crashes and when the orchestrator never ran.
- **TS-4 runs with `LEO_AUTOHANDOFF_ENABLED` unset.** Passing with it set to `false` would demonstrate the escape hatch works — the opposite of the fix.

9 tests pass. No DDL, no schema change, no chairman gate.