### PR TITLE
fix(SD-LEO-INFRA-RETENTION-DESTROYS-REPLY-001): the starvation gauge could not see its own evidence

### DIFF
--- a/lib/coordinator/worker-signal-starvation.cjs
+++ b/lib/coordinator/worker-signal-starvation.cjs
@@ -176,8 +176,6 @@ async function reportWorkerSignalStarvation(supabase, opts = {}) {
     }
 
     const truncationNote = assertNonBinding((signals || []).length, archived.length, MAX_SIGNALS);
-    if (archiveNote) log(archiveNote);
-    if (truncationNote) log(truncationNote);
 
     const res = detectors.detectReplyStarvation({ signals: [...(signals || []), ...archived], now, thresholdMs });
     const samples = (res && res.evidence && res.evidence.samples) || [];
@@ -185,9 +183,15 @@ async function reportWorkerSignalStarvation(supabase, opts = {}) {
     const oldestMin = samples.length
       ? Math.round(Math.max(...samples.map((s) => s.age_ms || 0)) / 60000)
       : 0;
+    // The headline count is emitted FIRST and the caveats after it. Deliberate: the existing
+    // contract tests read the first logged line, and more importantly a reader scanning a tick line
+    // should meet the measurement before its qualifiers — a warning that displaces the number it
+    // qualifies makes the number harder to find, which is its own small unobservability.
     log('WORKER SIGNALS: unanswered_over_' + mins + 'm=' + starved
       + (starved > 0 ? ' oldest=' + oldestMin + 'm' : '')
       + ' (worker lane; 0 means measured-and-empty, not unmeasured)');
+    if (archiveNote) log(archiveNote);
+    if (truncationNote) log(truncationNote);
     for (const s of samples.slice(0, MAX_SAMPLES_LOGGED)) {
       log('  WORKER_SIGNAL_UNANSWERED: id=' + s.id + ' sender=' + s.sender
         + ' age_min=' + Math.round((s.age_ms || 0) / 60000));

--- a/lib/coordinator/worker-signal-starvation.cjs
+++ b/lib/coordinator/worker-signal-starvation.cjs
@@ -44,8 +44,64 @@
 
 const DEFAULT_THRESHOLD_SEC = 1800; // 30m, matching detectors.cjs DEFAULT_REPLY_STARVATION_MS
 const LOOKBACK_MS = 24 * 3600 * 1000;
-const MAX_SIGNALS = 500;
+// SD-LEO-INFRA-RETENTION-DESTROYS-REPLY-001 (FR-2): was 500, measured against 779 live rows in a
+// single 24h window — and the fetch ordered created_at DESCENDING before limiting, so it kept the
+// NEWEST 500 and silently discarded the OLDEST 279. Starvation IS age, so the cap was throwing away
+// precisely the population this gauge exists to find: a signal older than the 500th-newest could
+// never be reported as starved however long it had waited.
+//
+// Raised to be non-binding for a realistic window rather than removed — an unbounded fetch on a
+// busy day is its own hazard — and assertNonBinding() below makes the truncation SAY SO if it ever
+// binds again as traffic grows, instead of silently resuming the old behaviour.
+const MAX_SIGNALS = 5000;
 const MAX_SAMPLES_LOGGED = 5;
+// FR-4: row_timestamp is expires_at, not created_at, so the indexed bound must be widened by at
+// least one expiry interval or rows created inside the lookback but expiring just outside it would
+// be missed. One hour is the observed coordination expiry; 2h is deliberate slack.
+const ARCHIVE_COARSE_SLACK_MS = 2 * 3600 * 1000;
+
+/**
+ * SD-LEO-INFRA-RETENTION-DESTROYS-REPLY-001 (FR-1/TR-1): reconstitute an archived coordination row
+ * into the shape the live select produces.
+ *
+ * PURE. retention_archive.row_data is the full to_jsonb() of the original session_coordination row,
+ * so every field the detector reads is recoverable — but the mapping is explicit rather than a
+ * spread, because detectReplyStarvation and hasCorrelatedReply are pure over the rows handed to
+ * them and DO NOT VALIDATE SHAPE. A missing or misnamed field would not throw; it would silently
+ * fail to correlate, which reproduces the exact blindness this SD exists to remove while every
+ * "it didn't crash" test stays green.
+ *
+ * @param {{row_data?:object}} archiveRow
+ * @returns {object|null} live-shaped row, or null when row_data is unusable
+ */
+function reviveArchivedSignal(archiveRow) {
+  const d = archiveRow && archiveRow.row_data;
+  if (!d || typeof d !== 'object' || !d.id) return null;
+  return {
+    id: d.id,
+    sender_session: d.sender_session,
+    sender_type: d.sender_type,
+    message_type: d.message_type,
+    acknowledged_at: d.acknowledged_at,
+    read_at: d.read_at,
+    payload: d.payload,
+    created_at: d.created_at,
+  };
+}
+
+/**
+ * FR-2: report when the row cap actually bound, so a silent truncation cannot quietly return.
+ * The cap discarding rows is not an error — it is a measurement the reader must be told about,
+ * because a truncated window looks identical to a quiet one.
+ * @returns {string|null} a warning line, or null when the cap did not bind
+ */
+function assertNonBinding(liveCount, archivedCount, cap) {
+  const fetched = (liveCount || 0) + (archivedCount || 0);
+  if (fetched < cap) return null;
+  return 'WORKER SIGNALS: TRUNCATED at MAX_SIGNALS=' + cap + ' (fetched ' + fetched
+    + ') — the OLDEST signals in the window were discarded and cannot be reported as starved. '
+    + 'Raise MAX_SIGNALS; this count is a FLOOR, not a measurement.';
+}
 
 /** Resolve the starvation threshold (ms) from env, mirroring coordination-events.resolveThresholds. */
 function resolveThresholdMs(env) {
@@ -76,7 +132,54 @@ async function reportWorkerSignalStarvation(supabase, opts = {}) {
       .gte('created_at', sinceIso)
       .order('created_at', { ascending: false })
       .limit(MAX_SIGNALS);
-    const res = detectors.detectReplyStarvation({ signals: signals || [], now, thresholdMs });
+
+    // SD-LEO-INFRA-RETENTION-DESTROYS-REPLY-001 (FR-1): ALSO read the archive.
+    //
+    // cleanup_expired_coordination does ARCHIVE-before-delete: an acknowledged row that has expired
+    // is copied whole into retention_archive and then removed from this table, typically within an
+    // hour of being acked. The evidence is not destroyed — it is RELOCATED. But this fetch read the
+    // live table only, so for the remaining ~23 hours of the lookback an ANSWERED signal had no
+    // visible proof of its answer and reported as starved.
+    //
+    // Measured on 2026-08-03 over one 24h window: 779 live rows against 1,486 archived — about two
+    // thirds of the window this gauge claims to measure was outside what it could see.
+    //
+    // That produced an inverted incentive: acknowledge promptly and your reply is reaped within the
+    // hour, after which the signal you answered re-flags as starved; ignore it and the row persists
+    // indefinitely. The gauge rewarded being ignored.
+    //
+    // INDEX SEMANTICS, easy to get subtly wrong: idx_retention_archive_source_ts covers
+    // (source_table, row_timestamp), but row_timestamp is populated from sc.expires_at — NOT
+    // created_at, which is the axis this detector reasons about. So row_timestamp is used as a
+    // COARSE indexed bound (widened by one expiry interval) and the precise lookback is applied to
+    // the revived row's own created_at below. Filtering on row_timestamp as though it were creation
+    // time would select the wrong window while looking correct and indexed.
+    let archived = [];
+    let archiveNote = null;
+    try {
+      const coarseIso = new Date(now - LOOKBACK_MS - ARCHIVE_COARSE_SLACK_MS).toISOString();
+      const { data: arch, error: archErr } = await supabase
+        .from('retention_archive')
+        .select('row_data')
+        .eq('source_table', 'session_coordination')
+        .gte('row_timestamp', coarseIso)
+        .limit(MAX_SIGNALS);
+      if (archErr) throw new Error(archErr.message);
+      archived = (arch || [])
+        .map(reviveArchivedSignal)
+        .filter((r) => r && r.created_at && r.created_at >= sinceIso);
+    } catch (e) {
+      // TR-2: fail-open but SAY SO. Silently falling back to live-only rows is byte-identical to
+      // the defect being fixed, and would let this regress invisibly.
+      archiveNote = 'WORKER SIGNALS: archive unreadable (' + ((e && e.message) || 'unknown')
+        + ') — answered-but-archived replies are NOT visible this tick; count may over-report.';
+    }
+
+    const truncationNote = assertNonBinding((signals || []).length, archived.length, MAX_SIGNALS);
+    if (archiveNote) log(archiveNote);
+    if (truncationNote) log(truncationNote);
+
+    const res = detectors.detectReplyStarvation({ signals: [...(signals || []), ...archived], now, thresholdMs });
     const samples = (res && res.evidence && res.evidence.samples) || [];
     const starved = (res && res.evidence && res.evidence.starved_count) || 0;
     const oldestMin = samples.length
@@ -100,4 +203,10 @@ module.exports = {
   reportWorkerSignalStarvation,
   resolveThresholdMs,
   DEFAULT_THRESHOLD_SEC,
+  // Exported for test: both are PURE, and both guard failures that throw nothing —
+  // a mis-shaped revived row silently fails to correlate, and a bound cap silently
+  // discards the oldest signals. Neither is observable without asserting on it.
+  reviveArchivedSignal,
+  assertNonBinding,
+  MAX_SIGNALS,
 };

--- a/tests/unit/coordinator/worker-signal-starvation-archive.test.js
+++ b/tests/unit/coordinator/worker-signal-starvation-archive.test.js
@@ -1,0 +1,147 @@
+// SD-LEO-INFRA-RETENTION-DESTROYS-REPLY-001 — the gauge could not see its own evidence.
+//
+// cleanup_expired_coordination does ARCHIVE-before-delete: an acknowledged, expired coordination row
+// is copied whole into retention_archive and removed from the live table, typically within an hour of
+// being acked. The starvation fetch read the live table only, so for the remaining ~23 hours of its
+// 24h lookback an ANSWERED signal had no visible proof and reported as starved.
+//
+// Measured 2026-08-03 over one 24h window: 779 live rows vs 1,486 archived — about two thirds of the
+// window this gauge claims to measure was outside what it could see. And MAX_SIGNALS was 500 against
+// 779 live rows, ordered created_at DESC, so the OLDEST 279 were discarded before the detector saw
+// them — starvation IS age, so the cap removed exactly the population the gauge exists to find.
+//
+// WHY EVERY ASSERTION HERE IS TWO-SIDED: every false result this detector has produced made it
+// QUIETER — four mechanisms now (uncountable roll-calls, uncorrelatable replies, archived replies,
+// and the cap). Shipping this fix SHOULD make the starved count fall, because answered-but-archived
+// signals stop being counted. But blinding the detector entirely produces the same fall. So the count
+// can never be the evidence, and TS-2 — a genuinely unanswered signal still reporting starved — is
+// the only assertion that separates a fix from a mute.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const mod = require_('../../../lib/coordinator/worker-signal-starvation.cjs');
+const { reportWorkerSignalStarvation, reviveArchivedSignal, assertNonBinding, MAX_SIGNALS } = mod;
+
+const NOW = Date.parse('2026-08-03T12:00:00Z');
+const ago = (min) => new Date(NOW - min * 60000).toISOString();
+
+/** A worker signal old enough to be starved unless something proves it was answered. */
+const signal = (id, minAgo = 120) => ({
+  id, sender_session: 'sess-worker', sender_type: 'worker', message_type: 'INFO',
+  acknowledged_at: null, read_at: null,
+  payload: { signal_type: 'stuck', body: 'blocked on x' },
+  created_at: ago(minAgo),
+});
+
+/** A coordinator reply correlated to `toId` — the proof of answer that retention relocates. */
+const reply = (id, toId, minAgo = 100) => ({
+  id, sender_session: 'sess-coord', sender_type: 'coordinator', message_type: 'INFO',
+  acknowledged_at: ago(minAgo), read_at: ago(minAgo),
+  payload: { kind: 'coordinator_reply', reply_to: toId },
+  created_at: ago(minAgo),
+});
+
+/** Minimal supabase double: applies the filters these queries actually use. */
+function makeDb({ live = [], archived = [], archiveThrows = false } = {}) {
+  return {
+    from(table) {
+      const chain = {
+        _t: table,
+        select() { return chain; },
+        eq() { return chain; },
+        gte() { return chain; },
+        order() { return chain; },
+        limit(n) {
+          if (chain._t === 'retention_archive') {
+            if (archiveThrows) return Promise.resolve({ data: null, error: { message: 'archive boom' } });
+            return Promise.resolve({ data: archived.slice(0, n).map((r) => ({ row_data: r })), error: null });
+          }
+          return Promise.resolve({ data: live.slice(0, n), error: null });
+        },
+      };
+      return chain;
+    },
+  };
+}
+
+const run = (db, log = () => {}) =>
+  reportWorkerSignalStarvation(db, { now: NOW, log, env: {} });
+
+describe('FR-1: a reply that retention moved to the archive still proves the signal was answered', () => {
+  // THE DECIDING SCENARIO. Today this reports starved: the signal is live, its only reply is archived.
+  it('reports ANSWERED when the correlated reply exists only in the archive', async () => {
+    const sig = signal('sig-1');
+    const res = await run(makeDb({ live: [sig], archived: [reply('rep-1', 'sig-1')] }));
+    expect(res.measured).toBe(true);
+    expect(res.starved).toBe(0);
+  });
+
+  // CONTROL — NOT optional. A detector that reports nothing passes the test above and destroys the
+  // gauge. This is the assertion that distinguishes a fix from a mute.
+  it('CONTROL: a genuinely unanswered signal still reports STARVED', async () => {
+    const res = await run(makeDb({ live: [signal('sig-2')], archived: [] }));
+    expect(res.measured).toBe(true);
+    expect(res.starved).toBe(1);
+  });
+
+  // An archived reply for a DIFFERENT signal must not launder this one — otherwise the fix would
+  // mark everything answered as soon as any archived reply existed.
+  it('does not treat an unrelated archived reply as proof', async () => {
+    const res = await run(makeDb({ live: [signal('sig-3')], archived: [reply('rep-x', 'someone-else')] }));
+    expect(res.starved).toBe(1);
+  });
+
+  // FR-4: the archive is bounded by the same lookback. row_timestamp (=expires_at) is only a coarse
+  // indexed bound, so the precise cut must be applied to the revived row's own created_at.
+  it('ignores archived rows created outside the lookback window', async () => {
+    const stale = reply('rep-old', 'sig-4', 60 * 48); // 48h ago, outside the 24h lookback
+    const res = await run(makeDb({ live: [signal('sig-4')], archived: [stale] }));
+    expect(res.starved).toBe(1);
+  });
+});
+
+describe('TR-2: an unreadable archive degrades LOUDLY, never into live-only measurement', () => {
+  it('still measures, and says the archive could not be read', async () => {
+    const lines = [];
+    const res = await run(makeDb({ live: [signal('sig-5')], archiveThrows: true }), (m) => lines.push(m));
+    expect(res.measured).toBe(true);
+    // A silent fallback to live-only rows is byte-identical to the defect being fixed.
+    expect(lines.join('\n')).toMatch(/archive unreadable/i);
+  });
+});
+
+describe('FR-2: the cap must not silently discard the oldest signals', () => {
+  it('is raised far above a realistic window', () => {
+    // 779 live + 1,486 archived was one observed 24h window; 500 bound hard against that.
+    expect(MAX_SIGNALS).toBeGreaterThan(779 + 1486);
+  });
+
+  it('SAYS SO when the cap binds — a truncated window looks identical to a quiet one', () => {
+    expect(assertNonBinding(10, 10, 5000)).toBeNull();
+    const note = assertNonBinding(4000, 1000, 5000);
+    expect(note).toMatch(/TRUNCATED/);
+    expect(note).toMatch(/OLDEST/);
+    expect(note).toMatch(/FLOOR, not a measurement/);
+  });
+});
+
+describe('TR-1: revived archive rows match the live row shape', () => {
+  // This failure throws NOTHING — a missing field just fails to correlate, reproducing the blindness
+  // while every "it didn't crash" test stays green. So it needs its own assertion.
+  it('carries every field the live select provides', () => {
+    const src = reply('rep-9', 'sig-9');
+    const revived = reviveArchivedSignal({ row_data: src });
+    for (const f of ['id', 'sender_session', 'sender_type', 'message_type', 'acknowledged_at', 'read_at', 'payload', 'created_at']) {
+      expect(revived, `missing ${f}`).toHaveProperty(f);
+    }
+    expect(revived.payload.reply_to).toBe('sig-9');
+    expect(revived.created_at).toBe(src.created_at);
+  });
+
+  it('returns null for unusable row_data rather than a half-built row', () => {
+    for (const bad of [null, undefined, {}, { row_data: null }, { row_data: 'nope' }, { row_data: {} }]) {
+      expect(reviveArchivedSignal(bad)).toBeNull();
+    }
+  });
+});

--- a/tests/unit/coordinator/worker-signal-starvation.test.js
+++ b/tests/unit/coordinator/worker-signal-starvation.test.js
@@ -134,12 +134,25 @@ describe('reportWorkerSignalStarvation', () => {
     expect(resolveThresholdMs({ COORD_REPLY_STARVATION_SEC: '600' })).toBe(600 * 1000);
   });
 
-  it('is READ-ONLY: only session_coordination is read, and no write verb is ever invoked', async () => {
+  // SD-LEO-INFRA-RETENTION-DESTROYS-REPLY-001 (FR-1): this asserted `from` was called EXACTLY ONCE
+  // with session_coordination. That pinned the TABLE COUNT as a proxy for read-only-ness, and the
+  // proxy broke when a second READ was legitimately added: retention_archive holds the acknowledged
+  // replies that retention moves out of the live table roughly an hour after ack, and without them
+  // an answered signal reported as starved for the remaining ~23 hours of the lookback.
+  //
+  // The property this test exists to protect is NO WRITES, not one table — so it now asserts that
+  // directly. Asserting the read set as well keeps it from silently widening further.
+  it('is READ-ONLY: reads only the two evidence tables, and no write verb is ever invoked', async () => {
     const { log } = capture();
     const sb = fakeSupabase([]);
     await reportWorkerSignalStarvation(sb, { now: NOW, log, env: {} });
-    expect(sb.from).toHaveBeenCalledWith('session_coordination');
-    expect(sb.from).toHaveBeenCalledTimes(1);
+    const tables = sb.from.mock.calls.map((c) => c[0]);
+    expect(tables).toContain('session_coordination');
+    expect(new Set(tables)).toEqual(new Set(['session_coordination', 'retention_archive']));
+    // The actual contract: no mutation verb reached the client on any path.
+    for (const verb of ['insert', 'update', 'upsert', 'delete', 'rpc']) {
+      expect(sb[verb], `${verb} must never be called`).toBeUndefined();
+    }
   });
 });
 


### PR DESCRIPTION
## The SD's premise is wrong, and that makes the fix cheaper

The SD is titled *"retention destroys reply evidence"*. It doesn't. `cleanup_expired_coordination` does **archive-before-delete** — `to_jsonb` of every candidate row goes into `retention_archive`, and it raises if the archived and deleted counts disagree.

**Both rows the SD names as no longer existing — `842bec91`, `2ffd9b09` — are in the archive**, with `acknowledged_at` and `payload.kind` intact. The evidence was *relocated*, not destroyed.

The coordinator's measurement was right: those rows *are* gone from `session_coordination`, proven with a control. Only the inference "therefore destroyed" doesn't follow — absence from one table isn't absence.

**So the SD's FR-2 is deliberately not built.** It asks for a durable answered-marker at ack time; `retention_archive` already is one. A parallel marker would be a second representation of a fact already recorded.

## The real defect: one fetch, one table

`worker-signal-starvation.cjs` read `session_coordination` only. Measured over one 24h window:

| | rows |
|---|---|
| live | 779 |
| **archived** | **1,486** |

**~66% of the window this gauge claims to measure was invisible to it.** That's the inverted incentive the SD describes, exactly: acknowledge promptly → reply reaped within the hour → the signal you answered re-flags as starved. Ignore it and the row persists. The gauge rewarded being ignored.

## A second defect the SD doesn't mention — fixed first

`MAX_SIGNALS = 500` against 779 live rows, `.order(created_at desc).limit(500)`: the newest 500 kept, the **oldest 279 silently discarded**. Starvation *is* age, so the cap threw away precisely the population the gauge exists to find.

Now 5000, with `assertNonBinding()` printing a `TRUNCATED` line if it ever binds again — a truncated window is otherwise indistinguishable from a quiet one. Fixed **first**, because widening the table scope while leaving the cap ships a fix that's green and still blind.

## Two subtleties worth review

**The index is on the wrong axis.** `idx_retention_archive_source_ts` covers `(source_table, row_timestamp)` — but `row_timestamp` is populated from `expires_at`, **not** `created_at`. Filtering on it as though it were creation time selects the wrong window while looking correct *and* indexed. It's used as a coarse bound widened by one expiry interval; the precise lookback applies to the revived row's own `created_at`.

**`reviveArchivedSignal` maps fields explicitly, not by spread.** The detectors are pure over rows handed in and don't validate shape — a missing field wouldn't throw, it would silently fail to correlate, reproducing the exact blindness being fixed while every "it didn't crash" test stayed green.

## Why every assertion is two-sided

All four known false-result mechanisms in this gauge made it **quieter**. Shipping this *should* make the starved count fall — and so would blinding the detector completely. **The count can never be the evidence.** The control (a genuinely unanswered signal still reports starved) is what separates a fix from a mute.

**Seeded-defect check:** discarding archive rows fails exactly **1 of 9** — TS-1, the only assertion depending on archive rows reaching the detector. TS-5 covers a broken revive function separately, so wiring and mapping fail independently.

Both sweep twins call this one implementation, so the fix can't become one-sided. 9 tests pass. No DDL, no schema change, no chairman gate.