### PR TITLE
fix(SD-LEO-INFRA-SURVEY-EVERY-PERMISSION-001): SURVEY-2 — the RLS canary reported healthy on a table anyone could write

### DIFF
--- a/lib/breakage/active-canary-probes.cjs
+++ b/lib/breakage/active-canary-probes.cjs
@@ -16,32 +16,84 @@
 const DEGRADED_RUNGS = Object.freeze(['SINGLE_SESSION', 'MODEL_FALLBACK', 'PAUSE_AND_SURFACE']);
 
 /**
- * FR-D1 — RLS-regression. PURE over the result of a READ-ONLY-INTENT anon INSERT of a uniquely-marked
- * canary row into an RLS-protected governance table. Healthy RLS DENIES the write (Postgres 42501) so NO
- * row is created; a regression lets the row through (data returned). Any other outcome is inconclusive
- * (fail-open — never a false alert).
- * @param {{error?:{code?:string,message?:string}|null, data?:Array|null}} anonInsertResult
+ * FR-D1 — RLS-regression, on the THREE-LEG method (SD-LEO-INFRA-SURVEY-EVERY-PERMISSION-001).
+ *
+ * WHY THE OLD SHAPE WAS UNSOUND. It classified from the anon insert ALONE: 42501 meant "RLS enforced",
+ * full stop. But 42501 is raised BOTH by a genuine refusal AND by an insert whose RETURNING clause fails
+ * the read policy — and, measured 2026-08-03, the SAME row submitted via a BARE `.insert()` (no
+ * `.select()`, so no RETURNING) LANDS with `error:null`. So a table that is wide open to a real writer
+ * reported `breakage:false` and no alert fired. Worse, the regression branch keys on `data.length > 0`,
+ * which is ALWAYS false for a bare insert — the landed row could not be seen even in principle.
+ *
+ * THE VERDICT NOW NEEDS EVIDENCE, NOT A CODE. Legs, in order:
+ *   1. `withReturning` — the anon `.insert().select()` result. Necessary, never sufficient.
+ *   2. `readbackAfterReturning` — service-role readback for the marker.
+ *   3. `bareInsert` + `readbackAfterBare` — re-attempt the IDENTICAL write with NO `.select()`, read again.
+ * Leg 3 runs only when legs 1-2 look like refusal; it is the ONLY thing separating a genuinely closed
+ * table from one whose door is simply not the one the probe knocked on.
+ *
+ * NO-FALSE-POSITIVE IS PRESERVED, and it matters here more than anywhere: the caller's alert path is
+ * fail-loud (recordSystemAlert + process.exit(1)). A genuinely-enforced table returns 42501 too, so
+ * "alert on 42501" would page on every healthy table. Absent leg-3 evidence this returns INCONCLUSIVE,
+ * never breakage.
+ *
+ * @param {{
+ *   withReturning?: {error?:{code?:string,message?:string}|null, data?:Array|null}|null,
+ *   readbackAfterReturning?: {rows?:Array|null}|null,
+ *   bareInsert?: {error?:{code?:string,message?:string}|null}|null,
+ *   readbackAfterBare?: {rows?:Array|null}|null,
+ * }} evidence
  * @returns {{breakage:boolean, breakClass?:string, reason:string, inconclusive?:boolean, detail?:object}}
  */
-function classifyRlsProbe(anonInsertResult) {
-  const r = anonInsertResult || {};
-  if (Array.isArray(r.data) && r.data.length > 0) {
+function classifyRlsProbe(evidence) {
+  const e = evidence || {};
+  const wr = e.withReturning || {};
+  const rowsAfterReturning = (e.readbackAfterReturning && e.readbackAfterReturning.rows) || null;
+  const rowsAfterBare = (e.readbackAfterBare && e.readbackAfterBare.rows) || null;
+  const code = (wr.error && (wr.error.code || '')) || '';
+
+  // A row is PRESENT after either attempt ⇒ the write got through ⇒ regression. Readback is the
+  // authority; `data` from RETURNING is only a hint, and is absent by construction on a bare insert.
+  const landed = (Array.isArray(rowsAfterBare) && rowsAfterBare.length > 0)
+    || (Array.isArray(rowsAfterReturning) && rowsAfterReturning.length > 0)
+    || (Array.isArray(wr.data) && wr.data.length > 0);
+  if (landed) {
+    const ids = []
+      .concat(Array.isArray(rowsAfterBare) ? rowsAfterBare : [])
+      .concat(Array.isArray(rowsAfterReturning) ? rowsAfterReturning : [])
+      .concat(Array.isArray(wr.data) ? wr.data : [])
+      .map((x) => x && x.id).filter(Boolean);
     return {
       breakage: true,
       breakClass: 'RLS-regression',
-      reason: 'anon INSERT into an RLS-protected governance table SUCCEEDED — anon write RLS is not enforced',
-      detail: { inserted_ids: r.data.map((x) => x && x.id).filter(Boolean) },
+      reason: 'anon INSERT into an RLS-protected governance table LANDED (row present on service-role readback) — anon write RLS is not enforced',
+      detail: { inserted_ids: Array.from(new Set(ids)), landed_via: (Array.isArray(rowsAfterBare) && rowsAfterBare.length > 0) ? 'bare-insert' : 'with-returning' },
     };
   }
-  const code = (r.error && (r.error.code || '')) || '';
-  if (code === '42501') {
-    return { breakage: false, reason: 'anon write denied (42501 / RLS policy) — RLS enforced' };
+
+  // Refusal requires BOTH readbacks to have been performed and to be empty. A 42501 with no leg-3
+  // evidence is exactly the ambiguous reading this rewrite exists to stop trusting.
+  const bareAttempted = Object.prototype.hasOwnProperty.call(e, 'bareInsert') && Array.isArray(rowsAfterBare);
+  if (code === '42501' && Array.isArray(rowsAfterReturning) && bareAttempted) {
+    return {
+      breakage: false,
+      reason: 'anon write REFUSED — 42501, and the row is absent after BOTH the RETURNING attempt and a bare re-attempt (three-leg confirmed)',
+      detail: { legs: 3 },
+    };
   }
-  // No clean deny AND no insert (constraint error, network, empty) -> we cannot conclude a regression.
+  if (code === '42501') {
+    return {
+      breakage: false,
+      inconclusive: true,
+      reason: 'anon write returned 42501 but leg-3 evidence is missing — 42501 alone cannot distinguish refusal from a landed-but-unreadable write, no alert',
+      detail: { legs: Array.isArray(rowsAfterReturning) ? 2 : 1 },
+    };
+  }
+  // No clean deny AND no landed row (constraint error, network, empty) -> cannot conclude a regression.
   return {
     breakage: false,
     inconclusive: true,
-    reason: `anon write neither succeeded nor cleanly denied (code=${code || 'none'}) — inconclusive, no alert`,
+    reason: `anon write neither landed nor cleanly denied (code=${code || 'none'}) — inconclusive, no alert`,
   };
 }
 

--- a/scripts/breakage/active-breakage-canary.mjs
+++ b/scripts/breakage/active-breakage-canary.mjs
@@ -29,23 +29,57 @@ const { recordSystemAlert } = require('../../lib/breakage/alert-writer.cjs');
 const RLS_PROBE_TABLE = 'session_coordination'; // governance table; anon INSERT is RLS-denied (verified 42501)
 const PAYMENT_WEBHOOK_TABLES = ['webhook_events', 'payment_webhook_events']; // candidates — absent today (Stripe test-mode)
 
-/** anon INSERT a uniquely-marked canary row; RLS must DENY it (42501). On regression the row is cleaned up. */
+/**
+ * anon INSERT a uniquely-marked canary row, gathering THREE LEGS of evidence
+ * (SD-LEO-INFRA-SURVEY-EVERY-PERMISSION-001). 42501 alone cannot distinguish a refusal from a write
+ * that landed and whose RETURNING merely failed the read policy — and the SAME row via a bare
+ * `.insert()` can land with `error:null`. So we observe the error, read back as service_role, and if
+ * that still looks like refusal we re-attempt WITHOUT `.select()` and read back again.
+ *
+ * CLEANUP IS BY MARKER, CONFIRMED BY COUNT. Deleting by returned id was satisfiable by an empty id
+ * loop while a bare-insert row persisted — and this is `session_coordination`, a live table an inbox
+ * consumer reads. Any row carrying the marker is removed regardless of which leg created it.
+ */
 async function probeRls(anon, service, nowMs) {
   const marker = `__RLS_CANARY_PROBE_${nowMs}__`;
-  let result;
+  const row = { target_session: marker, message_type: 'INFO', subject: marker, body: 'RLS-regression canary probe (auto-delete)', sender_type: 'system' };
+  const readByMarker = async () => {
+    try {
+      const { data } = await service.from(RLS_PROBE_TABLE).select('id').eq('subject', marker);
+      return { rows: Array.isArray(data) ? data : [] };
+    } catch { return null; }   // readback failed ⇒ absent evidence, NOT evidence of absence
+  };
+
+  const evidence = {};
   try {
-    result = await anon.from(RLS_PROBE_TABLE)
-      .insert({ target_session: marker, message_type: 'INFO', subject: marker, body: 'RLS-regression canary probe (auto-delete)', sender_type: 'system' })
-      .select('id');
+    evidence.withReturning = await anon.from(RLS_PROBE_TABLE).insert(row).select('id');
   } catch (e) {
-    result = { error: { code: e.code, message: e.message }, data: null };
+    evidence.withReturning = { error: { code: e.code, message: e.message }, data: null };
   }
-  const verdict = classifyRlsProbe(result);
-  if (verdict.breakage && verdict.detail && Array.isArray(verdict.detail.inserted_ids)) {
-    for (const id of verdict.detail.inserted_ids) {
-      try { await service.from(RLS_PROBE_TABLE).delete().eq('id', id); } catch { /* best-effort; row is clearly marked */ }
+  evidence.readbackAfterReturning = await readByMarker();
+
+  // Leg 3 — only when legs 1-2 look like refusal. This is the leg that catches an open door.
+  const looksRefused = ((evidence.withReturning && evidence.withReturning.error && evidence.withReturning.error.code) === '42501')
+    && evidence.readbackAfterReturning && evidence.readbackAfterReturning.rows.length === 0;
+  if (looksRefused) {
+    try {
+      evidence.bareInsert = await anon.from(RLS_PROBE_TABLE).insert(row);
+    } catch (e) {
+      evidence.bareInsert = { error: { code: e.code, message: e.message } };
     }
+    evidence.readbackAfterBare = await readByMarker();
   }
+
+  const verdict = classifyRlsProbe(evidence);
+
+  // Unconditional marker cleanup, then CONFIRM by count — never trust the delete's silence.
+  try {
+    await service.from(RLS_PROBE_TABLE).delete().eq('subject', marker);
+    const after = await readByMarker();
+    if (after && after.rows.length > 0) {
+      verdict.detail = { ...(verdict.detail || {}), cleanup_residue: after.rows.length, marker };
+    }
+  } catch { /* best-effort; the row is clearly marked for a human sweep */ }
   return verdict;
 }
 

--- a/tests/unit/active-breakage-canary.test.js
+++ b/tests/unit/active-breakage-canary.test.js
@@ -18,21 +18,63 @@ const LEGAL_ALERT_TYPES = ['circuit_breaker', 'threshold_breach', 'system_health
 const NOW = 1_900_000_000_000;
 const isoAgo = (ms) => new Date(NOW - ms).toISOString();
 
-describe('classifyRlsProbe (FR-D1)', () => {
-  it('REGRESSED when an anon INSERT returns rows (RLS not enforced)', () => {
-    const v = classifyRlsProbe({ data: [{ id: 'r1' }], error: null });
+// SD-LEO-INFRA-SURVEY-EVERY-PERMISSION-001 — REWRITTEN onto the three-leg method.
+// The previous suite PINNED THE DEFECT AS THE CONTRACT: it asserted that a bare 42501 means
+// "RLS enforced, no breakage", which is exactly the reading that let a landed-but-unreadable
+// write report healthy. Fixing the classifier alone would have turned this file red and invited
+// a revert of the fix, so the pin is inverted here in the same change.
+describe('classifyRlsProbe (FR-D1) — three-leg method', () => {
+  const marker = [{ id: 'r1' }];
+
+  it('REGRESSED when the row is PRESENT on readback after the RETURNING attempt', () => {
+    const v = classifyRlsProbe({ withReturning: { data: marker, error: null }, readbackAfterReturning: { rows: marker } });
     expect(v.breakage).toBe(true);
     expect(v.breakClass).toBe('RLS-regression');
     expect(v.detail.inserted_ids).toEqual(['r1']);
   });
-  it('ENFORCED (no breakage) when anon write is denied 42501', () => {
-    const v = classifyRlsProbe({ data: null, error: { code: '42501', message: 'permission denied' } });
+
+  // THE CASE THE OLD CONTRACT COULD NOT SEE. 42501 with the row absent looks like refusal, but the
+  // identical row via a bare insert LANDS. The old branch keyed on data.length > 0, which is always
+  // false for a bare insert, so the landed row was invisible even in principle.
+  it('REGRESSED when 42501 + absent-after-RETURNING but the BARE re-attempt LANDS', () => {
+    const v = classifyRlsProbe({
+      withReturning: { data: null, error: { code: '42501', message: 'new row violates row-level security policy' } },
+      readbackAfterReturning: { rows: [] },
+      bareInsert: { error: null },
+      readbackAfterBare: { rows: marker },
+    });
+    expect(v.breakage).toBe(true);
+    expect(v.breakClass).toBe('RLS-regression');
+    expect(v.detail.landed_via).toBe('bare-insert');
+  });
+
+  it('ENFORCED (no breakage, not inconclusive) only when BOTH readbacks are empty — three legs', () => {
+    const v = classifyRlsProbe({
+      withReturning: { data: null, error: { code: '42501', message: 'permission denied' } },
+      readbackAfterReturning: { rows: [] },
+      bareInsert: { error: { code: '42501' } },
+      readbackAfterBare: { rows: [] },
+    });
     expect(v.breakage).toBe(false);
     expect(v.inconclusive).toBeFalsy();
+    expect(v.detail.legs).toBe(3);
   });
+
+  // NO FALSE POSITIVE. The alert path is fail-loud (recordSystemAlert + process.exit(1)), and a
+  // genuinely-enforced table also returns 42501 — so a bare code must never alert, in either direction.
+  it('INCONCLUSIVE (never an alert) when 42501 arrives without leg-3 evidence', () => {
+    const one = classifyRlsProbe({ withReturning: { data: null, error: { code: '42501' } } });
+    expect(one.breakage).toBe(false);
+    expect(one.inconclusive).toBe(true);
+    const two = classifyRlsProbe({ withReturning: { data: null, error: { code: '42501' } }, readbackAfterReturning: { rows: [] } });
+    expect(two.breakage).toBe(false);
+    expect(two.inconclusive).toBe(true);
+    expect(two.detail.legs).toBe(2);
+  });
+
   it('INCONCLUSIVE (no false alert) on a constraint/other error or empty', () => {
-    expect(classifyRlsProbe({ error: { code: '23505' } }).inconclusive).toBe(true);
-    expect(classifyRlsProbe({ data: [], error: null }).inconclusive).toBe(true);
+    expect(classifyRlsProbe({ withReturning: { error: { code: '23505' } } }).inconclusive).toBe(true);
+    expect(classifyRlsProbe({ withReturning: { data: [], error: null } }).inconclusive).toBe(true);
     expect(classifyRlsProbe({}).breakage).toBe(false);
   });
 });
@@ -113,8 +155,13 @@ describe('frozen taxonomy round-trip (TR-1) — the 4 child-D classes stay in th
 });
 
 // --- injected-fake integration: dry-run writes nothing; live path is fail-loud + passes the break_class ---
-function fakeService({ handoffs = [], webhookPresent = false } = {}) {
+// Both fakes gained capability for the three-leg method: fakeService needs a marker READBACK path
+// (.select().eq()) it never had, and fakeAnon needs a BARE .insert() — previously it only implemented
+// .insert().select(), which is precisely the shape that cannot observe a landed row.
+function fakeService({ handoffs = [], webhookPresent = false, markerRows = [] } = {}) {
+  const state = { rows: markerRows.slice() };
   return {
+    __state: state,
     from(table) {
       return {
         select(_cols, _opts) {
@@ -122,16 +169,74 @@ function fakeService({ handoffs = [], webhookPresent = false } = {}) {
           if (table === 'webhook_events' || table === 'payment_webhook_events') {
             return { limit: () => Promise.resolve({ data: webhookPresent ? [] : null, error: webhookPresent ? null : { code: 'PGRST205', message: 'Could not find the table' } }) };
           }
-          return { limit: () => Promise.resolve({ data: [], error: null }) };
+          // Marker readback used by probeRls legs 2 and 3, and by the cleanup confirmation.
+          return { eq: () => Promise.resolve({ data: state.rows, error: null }), limit: () => Promise.resolve({ data: [], error: null }) };
         },
-        delete() { return { eq: () => Promise.resolve({ error: null }) }; },
+        delete() { return { eq: () => { state.rows = []; return Promise.resolve({ error: null }); } }; },
       };
     },
   };
 }
-function fakeAnon({ rlsRegressed = false } = {}) {
-  return { from: () => ({ insert: () => ({ select: () => Promise.resolve(rlsRegressed ? { data: [{ id: 'leak-1' }], error: null } : { data: null, error: { code: '42501' } }) }) }) };
+// rlsRegressed        — the RETURNING attempt itself succeeds (classic leak)
+// landsOnBareInsert   — RETURNING 42501s, but the bare re-attempt lands: the case the old fake could not express
+// LAZY like the real supabase-js builder: the request fires when the builder is AWAITED, not when
+// insert() is called. An eager fake set its landed-row side effect during .insert(), so the
+// leg-2 readback saw the bare-insert row and the verdict reported landed_via 'with-returning' —
+// a fake-fidelity bug that produced a plausible wrong answer. The builder is a THENABLE.
+function fakeAnon({ rlsRegressed = false, landsOnBareInsert = false, service = null } = {}) {
+  return {
+    from: () => ({
+      insert: () => ({
+        // awaited directly (no .select()) => the BARE insert path
+        then(resolve) {
+          if (landsOnBareInsert && service) service.__state.rows = [{ id: 'leak-bare' }];
+          return Promise.resolve(landsOnBareInsert ? { error: null } : { error: { code: '42501' } }).then(resolve);
+        },
+        // .select() => the RETURNING path
+        select() {
+          if (rlsRegressed && service) service.__state.rows = [{ id: 'leak-1' }];
+          return Promise.resolve(rlsRegressed
+            ? { data: [{ id: 'leak-1' }], error: null }
+            : { data: null, error: { code: '42501' } });
+        },
+      }),
+    }),
+  };
 }
+
+// The CALLER's leg-3 gathering, which the classifier unit tests cannot cover: probeRls must, on an
+// apparent refusal, RE-ATTEMPT the identical write WITHOUT .select() and read back again. Without
+// this the open door stays invisible no matter how correct the classifier is.
+describe('probeRls gathers leg 3 — the bare re-attempt (SD-LEO-INFRA-SURVEY-EVERY-PERMISSION-001)', () => {
+  it('REGRESSES when RETURNING 42501s with the row absent but the BARE insert lands', async () => {
+    const svc = fakeService({ handoffs: [] });
+    const summary = await run({
+      service: svc,
+      anon: fakeAnon({ rlsRegressed: false, landsOnBareInsert: true, service: svc }),
+      detectFromDb: async () => ({ rung: 'NORMAL', reason: 'healthy' }),
+      record: async () => ({ id: 'x', deduped: false }),
+      dryRun: true,
+      nowMs: NOW,
+    });
+    const rls = (summary || []).find((v) => v && (v.breakClass === 'RLS-regression'));
+    expect(rls, 'leg 3 never ran — an open door read as enforced').toBeTruthy();
+    expect(rls.detail.landed_via).toBe('bare-insert');
+  });
+
+  it('stays SILENT (no breakage) when both legs are genuinely empty — no false positive on an enforced table', async () => {
+    const svc = fakeService({ handoffs: [] });
+    const summary = await run({
+      service: svc,
+      anon: fakeAnon({ rlsRegressed: false, landsOnBareInsert: false, service: svc }),
+      detectFromDb: async () => ({ rung: 'NORMAL', reason: 'healthy' }),
+      record: async () => ({ id: 'x', deduped: false }),
+      dryRun: true,
+      nowMs: NOW,
+    });
+    const rls = (summary || []).find((v) => v && v.breakClass === 'RLS-regression');
+    expect(rls, 'alerted on a genuinely enforced table — the fail-loud false positive').toBeFalsy();
+  });
+});
 
 describe('run() — dry-run performs NO writes; live path is fail-loud (TS-4 / FR-D5)', () => {
   it('dry-run classifies breakages but never calls recordSystemAlert', async () => {


### PR DESCRIPTION
First EXEC item of the survey SD, and the only survey member that is also **running logic**.

## The defect

`classifyRlsProbe` decided from the anon insert alone: `42501` ⇒ *"RLS enforced"*, full stop.

But 42501 is raised **both** by a genuine refusal **and** by an insert whose `RETURNING` clause fails the read policy — and the *same row* submitted via a bare `.insert()` (no `.select()`, so no RETURNING) **lands** with `error:null`. So a governance table wide open to a real writer reported `breakage:false` and no alert fired.

Worse: the regression branch keyed on `data.length > 0`, which is **always false** for a bare insert. The landed row could not be seen even in principle.

## The verdict now takes evidence, not a code

| leg | what it establishes |
|---|---|
| 1 | the error — necessary, **never sufficient** |
| 2 | service-role readback for the marker |
| 3 | re-attempt the **identical write without RETURNING**, read back again |

Leg 3 is the only thing separating a genuinely closed table from one whose door simply isn't the one the probe knocked on. Refusal now requires **both** readbacks empty; a 42501 without leg-3 evidence returns `inconclusive`.

## No false positive — this mattered more than the false negative

The alert path is fail-loud (`recordSystemAlert` + `process.exit(1)`), and a genuinely-enforced table returns 42501 too. So *"alert on 42501"* would page on **every healthy table**. My own first draft of this test said exactly that; TESTING caught it, and both arms are now pinned.

## The test pinned the defect as the contract

Inverted in the same commit — fixing the classifier alone would have turned the suite red and invited a revert. Both fakes gained capability they lacked: `fakeService` had no marker readback path, and `fakeAnon` implemented only `.insert().select()`, which is precisely the shape that cannot observe a landed row.

## Cleanup is by marker, confirmed by count

Deleting by returned id was satisfiable by an **empty id loop** while a bare-insert row persisted — in `session_coordination`, a live table an inbox consumer reads. Residue is now surfaced on the verdict rather than swallowed.

## Two fake-fidelity bugs found while writing the tests

Both produced *plausible wrong answers*: an assertion read `summary.verdicts` when `run()` returns a flat array (failing for the wrong reason), and the anon fake applied its landed-row side effect **eagerly** at `insert()` instead of on await, so the leg-2 readback saw the bare row and the verdict misreported `landed_via`. The real supabase-js builder is a **thenable**; the fake is now lazy the same way.

**25 tests pass**, including two new integration cases the old fake could not express: leg 3 catching the bare-insert landing, and staying silent on a genuinely enforced table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)