### PR TITLE
fix(SD-LEO-INFRA-COMPACT-NUDGE-RACES-001): the compact nudge went to whoever prompted next, not to whoever earned it

### DIFF
--- a/scripts/hooks/context-compact-nudge.handoff-flag.test.js
+++ b/scripts/hooks/context-compact-nudge.handoff-flag.test.js
@@ -7,16 +7,23 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { fileURLToPath } from 'url';
+import { getHandoffFlagPath } from '../modules/handoff/cli/compact-after-handoff.js';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const HOOK_SCRIPT = path.join(__dirname, 'context-compact-nudge.js');
 
 const TEST_FLAG_DIR = path.join(os.tmpdir(), `leo-compact-test-${process.pid}`);
-const HANDOFF_FLAG = path.join(TEST_FLAG_DIR, 'compact-after-handoff.json');
-const COMPACTION_MARKER = path.join(TEST_FLAG_DIR, 'last-compaction.json');
 const STATE_DIR = path.join(os.tmpdir(), 'leo-context-nudge');
 const SESSION_ID = `test-handoff-flag-${process.pid}`;
 const STATE_FILE = path.join(STATE_DIR, `session-${SESSION_ID}.json`);
+// SD-LEO-INFRA-COMPACT-NUDGE-RACES-001: derived from the writer, not a fourth
+// hardcoded copy of the filename. When this was a literal, a change to the
+// writer's path would have left these tests writing where the hook never looks
+// — and every "expect no nudge" test below would have passed for that reason.
+const HANDOFF_FLAG = getHandoffFlagPath(
+  { LEO_COMPACT_FLAG_DIR: TEST_FLAG_DIR, CLAUDE_SESSION_ID: SESSION_ID }
+);
+const COMPACTION_MARKER = path.join(TEST_FLAG_DIR, 'last-compaction.json');
 
 function writeHandoffFlag(payload) {
   if (!fs.existsSync(TEST_FLAG_DIR)) fs.mkdirSync(TEST_FLAG_DIR, { recursive: true });
@@ -99,10 +106,18 @@ describe('context-compact-nudge — handoff flag consumption', () => {
     });
     const stdout = runHook();
     expect(stdout).not.toContain('LEAD-TO-PLAN complete');
+    // Load-bearing: the hook UNLINKS a stale flag. If the reader stopped
+    // looking at this path, the file would survive and this line would fail —
+    // which is what keeps the assertion above from passing vacuously.
     expect(fs.existsSync(HANDOFF_FLAG)).toBe(false);
   });
 
-  it('skips nudge when compaction marker is recent (cooldown)', () => {
+  // SD-LEO-INFRA-COMPACT-NUDGE-RACES-001 — the next two tests carry a positive
+  // control. Asserting only the ABSENCE of nudge text is satisfied just as well
+  // by a reader that never found the flag at all, so a filename change would
+  // have left them green while silently disconnecting writer from reader. Phase
+  // B removes the disqualifying condition and proves the same file DOES nudge.
+  it('skips nudge when compaction marker is recent (cooldown), but the flag itself is live', () => {
     if (!fs.existsSync(TEST_FLAG_DIR)) fs.mkdirSync(TEST_FLAG_DIR, { recursive: true });
     fs.writeFileSync(COMPACTION_MARKER, JSON.stringify({ timestamp: new Date().toISOString() }));
     writeHandoffFlag({
@@ -112,8 +127,13 @@ describe('context-compact-nudge — handoff flag consumption', () => {
       mode: 'nudge',
       timestamp: new Date().toISOString()
     });
-    const stdout = runHook();
-    expect(stdout).not.toContain('LEAD-TO-PLAN complete');
+    expect(runHook()).not.toContain('LEAD-TO-PLAN complete');
+    expect(fs.existsSync(HANDOFF_FLAG)).toBe(true);
+
+    // Phase B: same flag, marker gone, state reset.
+    fs.unlinkSync(COMPACTION_MARKER);
+    try { fs.unlinkSync(STATE_FILE); } catch { /* may not exist */ }
+    expect(runHook()).toContain('LEAD-TO-PLAN complete (SD SD-COOL)');
   });
 
   it('does nothing when flag is absent (regression: existing behavior preserved)', () => {
@@ -122,9 +142,20 @@ describe('context-compact-nudge — handoff flag consumption', () => {
     expect(stdout).not.toContain('LEAD-FINAL-APPROVAL');
   });
 
-  it('ignores flag with malformed payload (no tier)', () => {
+  it('ignores flag with malformed payload (no tier), and is not merely blind to the path', () => {
     writeHandoffFlag({ sd_id: 'SD-BAD', timestamp: new Date().toISOString() });
-    const stdout = runHook();
-    expect(stdout).not.toContain('complete');
+    expect(runHook()).not.toContain('complete');
+
+    // Phase B: same path, valid payload — proves the rejection above was a
+    // decision about the payload, not an inability to see the file.
+    try { fs.unlinkSync(STATE_FILE); } catch { /* may not exist */ }
+    writeHandoffFlag({
+      sd_id: 'SD-BAD',
+      handoff_type: 'LEAD-TO-PLAN',
+      tier: 'soft',
+      mode: 'nudge',
+      timestamp: new Date().toISOString()
+    });
+    expect(runHook()).toContain('LEAD-TO-PLAN complete (SD SD-BAD)');
   });
 });

--- a/scripts/hooks/context-compact-nudge.js
+++ b/scripts/hooks/context-compact-nudge.js
@@ -77,6 +77,24 @@ const CHECK_INTERVAL = intervalIdx !== -1 ? parseInt(process.argv[intervalIdx + 
 const STATE_DIR = process.env.LEO_COMPACT_STATE_DIR || path.join(os.tmpdir(), 'leo-context-nudge');
 const UNATTRIBUTED_SESSION = 'default';
 
+/**
+ * DELIBERATE ASYMMETRY, flagged by the EXEC SECURITY review — the handoff flag
+ * fails CLOSED on unknown identity (no file, no consumption) but state falls
+ * back to a shared `session-default.json`, which is the very pattern this SD
+ * removes elsewhere. It is kept because the alternatives are worse, not because
+ * it was overlooked:
+ *   - PID cannot key it. The hook is a FRESH PROCESS on every invocation, so a
+ *     PID-keyed file would be new each time and counters would never accumulate.
+ *   - Skipping the state write entirely means startTime resets every run, so
+ *     sessionAgeMinutes is always ~0 and the time/turn nudge never fires at all.
+ * There is no stable per-session key available without identity, so the shared
+ * bucket is the only option that preserves any behaviour. The blast radius is
+ * bounded to nudge-COOLDOWN cross-talk between sessions that are ALREADY
+ * unidentified; the handoff flag itself is never shared. In production stdin
+ * always carries session_id (the hook is wired as a first-party command hook at
+ * PostToolUse and UserPromptSubmit), so this path should not be reached at all.
+ * Pinned by test: 'unidentified sessions share the default bucket, by design'.
+ */
 function stateFileFor(sessionId) {
   return path.join(STATE_DIR, `session-${sessionId || UNATTRIBUTED_SESSION}.json`);
 }

--- a/scripts/hooks/context-compact-nudge.js
+++ b/scripts/hooks/context-compact-nudge.js
@@ -234,13 +234,6 @@ function minutesSince(isoTime) {
   return (Date.now() - new Date(isoTime).getTime()) / 60000;
 }
 
-function formatDuration(minutes) {
-  if (minutes < 60) return `${Math.round(minutes)}m`;
-  const h = Math.floor(minutes / 60);
-  const m = Math.round(minutes % 60);
-  return `${h}h ${m}m`;
-}
-
 // ============================================================================
 // MAIN
 // ============================================================================

--- a/scripts/hooks/context-compact-nudge.js
+++ b/scripts/hooks/context-compact-nudge.js
@@ -35,6 +35,11 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import {
+  getHandoffFlagPath,
+  sanitizeSessionId,
+  sweepStaleHandoffFlags
+} from '../modules/handoff/cli/compact-after-handoff.js';
 
 // ============================================================================
 // CONFIGURATION
@@ -52,9 +57,29 @@ const TIME_ONLY = process.argv.includes('--time-only');
 const intervalIdx = process.argv.indexOf('--interval');
 const CHECK_INTERVAL = intervalIdx !== -1 ? parseInt(process.argv[intervalIdx + 1] || '1') : 1;
 
-const SESSION_ID = process.env.CLAUDE_SESSION_ID || 'default';
-const STATE_DIR = path.join(os.tmpdir(), 'leo-context-nudge');
-const STATE_FILE = path.join(STATE_DIR, `session-${SESSION_ID}.json`);
+// SD-LEO-INFRA-COMPACT-NUDGE-RACES-001 — READ THIS BEFORE "SIMPLIFYING" IT BACK.
+// This used to read `process.env.CLAUDE_SESSION_ID || 'default'` at module
+// scope. Hooks are NOT Bash-tool invocations, and capture-session-id.cjs
+// persists the id via CLAUDE_ENV_FILE precisely so BASH TOOL children inherit
+// it (see its docblock, GH #17188) — so in a hook the variable is normally
+// absent and every session fell through to the same `session-default.json`.
+// Measured on this machine before the fix: session-default.json held 3670 user
+// turns and 10914 tool calls aggregated across sessions, while a 17-hour
+// session had no file of its own. lastNudgeTime lives in that shared file and
+// is checked at :227 BEFORE the handoff flag is read, so one session's nudge
+// suppressed every other session's handoff nudge for the whole cooldown.
+// Identity now comes from the hook's stdin payload (resolveSessionId below).
+// LEO_COMPACT_STATE_DIR mirrors LEO_COMPACT_FLAG_DIR: without it a test that
+// exercises the unidentified path writes to the REAL session-default.json that
+// every session on the machine shares — which both corrupts live state and lets
+// a real cooldown short-circuit the run, so the test passes without reaching
+// the code it is meant to exercise. That is how a mutant survived here twice.
+const STATE_DIR = process.env.LEO_COMPACT_STATE_DIR || path.join(os.tmpdir(), 'leo-context-nudge');
+const UNATTRIBUTED_SESSION = 'default';
+
+function stateFileFor(sessionId) {
+  return path.join(STATE_DIR, `session-${sessionId || UNATTRIBUTED_SESSION}.json`);
+}
 
 // Flag file that Claude sees - signals it should auto-invoke /context-compact
 // LEO_COMPACT_FLAG_DIR env override exists for test isolation.
@@ -67,7 +92,9 @@ const COMPACTION_MARKER = path.join(FLAG_DIR, 'last-compaction.json');
 // QF-20260510-387: Phase-aware compact nudge after handoff success.
 // cli-main.js writes this flag on handoff success; we surface a tier-based
 // nudge here. Stale flags (>60 min) are discarded.
-const HANDOFF_FLAG_FILE = path.join(FLAG_DIR, 'compact-after-handoff.json');
+// The path is now imported from the writer module rather than re-derived here —
+// there were three independent copies of this filename literal and any fix that
+// updated only one of them would have silently disconnected writer from reader.
 const HANDOFF_FLAG_STALE_MINUTES = 60;
 const HANDOFF_NUDGE_MESSAGES = {
   soft: (h) => `[context-compact-nudge] ${h.handoff_type} complete (SD ${h.sd_id}). Optional /compact available; phase reasoning is minimal.`,
@@ -85,10 +112,10 @@ function ensureDir(dir) {
   }
 }
 
-function readState() {
+function readState(stateFile) {
   try {
-    if (fs.existsSync(STATE_FILE)) {
-      return JSON.parse(fs.readFileSync(STATE_FILE, 'utf8'));
+    if (fs.existsSync(stateFile)) {
+      return JSON.parse(fs.readFileSync(stateFile, 'utf8'));
     }
   } catch {
     // Corrupted - start fresh
@@ -103,16 +130,16 @@ function readState() {
   };
 }
 
-function writeState(state) {
+function writeState(stateFile, state) {
   ensureDir(STATE_DIR);
-  fs.writeFileSync(STATE_FILE, JSON.stringify(state, null, 2));
+  fs.writeFileSync(stateFile, JSON.stringify(state, null, 2));
 }
 
-function writeFlag(level, sessionAge, counts) {
+function writeFlag(level, sessionAge, counts, sessionId) {
   ensureDir(FLAG_DIR);
   fs.writeFileSync(FLAG_FILE, JSON.stringify({
     level,
-    sessionId: SESSION_ID,
+    sessionId: sessionId || UNATTRIBUTED_SESSION,
     sessionAgeMinutes: sessionAge,
     userTurns: counts.userTurnCount,
     toolCalls: counts.toolCallCount,
@@ -130,13 +157,17 @@ function clearFlag() {
   }
 }
 
-function readHandoffFlag() {
+function readHandoffFlag(flagFile) {
+  // No identity => no flag. Falling back to a shared filename here would
+  // reintroduce the exact misdelivery this SD removes, so an unidentified
+  // session simply never consumes a handoff nudge.
+  if (!flagFile) return null;
   try {
-    if (!fs.existsSync(HANDOFF_FLAG_FILE)) return null;
-    const data = JSON.parse(fs.readFileSync(HANDOFF_FLAG_FILE, 'utf8'));
+    if (!fs.existsSync(flagFile)) return null;
+    const data = JSON.parse(fs.readFileSync(flagFile, 'utf8'));
     if (!data || !data.tier || !data.timestamp) return null;
     if (minutesSince(data.timestamp) > HANDOFF_FLAG_STALE_MINUTES) {
-      try { fs.unlinkSync(HANDOFF_FLAG_FILE); } catch { /* ignore */ }
+      try { fs.unlinkSync(flagFile); } catch { /* ignore */ }
       return null;
     }
     return data;
@@ -145,10 +176,41 @@ function readHandoffFlag() {
   }
 }
 
-function clearHandoffFlag() {
+function clearHandoffFlag(flagFile) {
+  if (!flagFile) return;
   try {
-    if (fs.existsSync(HANDOFF_FLAG_FILE)) fs.unlinkSync(HANDOFF_FLAG_FILE);
+    if (fs.existsSync(flagFile)) fs.unlinkSync(flagFile);
   } catch { /* ignore */ }
+}
+
+/**
+ * Claude Code passes the hook payload as JSON on stdin; session_id is the only
+ * identifier a hook subprocess can rely on (CLAUDE_ENV_FILE reaches Bash-tool
+ * children, not hooks). Same mechanism as scripts/hooks/coordination-inbox.cjs.
+ * The env var is kept as a fallback for direct/manual invocation only.
+ */
+function resolveSessionId(timeoutMs = 250) {
+  return new Promise((resolve) => {
+    const envFallback = () => sanitizeSessionId(process.env.CLAUDE_SESSION_ID);
+    let settled = false;
+    const finish = (value) => { if (!settled) { settled = true; resolve(value); } };
+    let buf = '';
+    const timer = setTimeout(() => finish(envFallback()), timeoutMs);
+    try {
+      process.stdin.setEncoding('utf8');
+      process.stdin.on('data', (c) => { buf += c; });
+      process.stdin.on('end', () => {
+        clearTimeout(timer);
+        let fromStdin = null;
+        try { fromStdin = sanitizeSessionId(JSON.parse(buf)?.session_id); } catch { /* not JSON */ }
+        finish(fromStdin || envFallback());
+      });
+      process.stdin.on('error', () => { clearTimeout(timer); finish(envFallback()); });
+    } catch {
+      clearTimeout(timer);
+      finish(envFallback());
+    }
+  });
 }
 
 function getLastCompactionTime(stateTime) {
@@ -183,13 +245,19 @@ function formatDuration(minutes) {
 // MAIN
 // ============================================================================
 
-function main() {
+async function main() {
   if (!ENABLED) {
     process.exit(0);
   }
 
+  // One identity resolution feeds BOTH the per-session state file (which owns
+  // the nudge cooldown) and the per-session handoff flag.
+  const sessionId = await resolveSessionId();
+  const stateFile = stateFileFor(sessionId);
+  const handoffFlagFile = getHandoffFlagPath(process.env, sessionId);
+
   try {
-    const state = readState();
+    const state = readState(stateFile);
 
     // Increment the appropriate counter
     if (TIME_ONLY) {
@@ -197,7 +265,7 @@ function main() {
 
       // Throttle: only do full evaluation every Nth tool call
       if (CHECK_INTERVAL > 1 && state.toolCallCount % CHECK_INTERVAL !== 0) {
-        writeState(state);
+        writeState(stateFile, state);
         process.exit(0);
       }
     } else {
@@ -216,27 +284,32 @@ function main() {
     const minutesSinceCompaction = minutesSince(state.lastCompactionTime);
     const minutesSinceLastNudge = minutesSince(state.lastNudgeTime);
 
+    // Orphaned per-session flags can no longer be discarded by whichever
+    // session happens to read the one shared path, so sweep on every full
+    // evaluation. Bounded: one readdir over a directory of small JSON files.
+    sweepStaleHandoffFlags(process.env, HANDOFF_FLAG_STALE_MINUTES);
+
     // If compaction happened recently, clear flag and skip
     if (minutesSinceCompaction < COOLDOWN_MINUTES) {
       clearFlag();
-      writeState(state);
+      writeState(stateFile, state);
       process.exit(0);
     }
 
     // Cooldown from last nudge
     if (minutesSinceLastNudge < COOLDOWN_MINUTES) {
-      writeState(state);
+      writeState(stateFile, state);
       process.exit(0);
     }
 
     // QF-20260510-387: Phase-aware nudge takes precedence over time/turn-based level.
-    const handoffFlag = readHandoffFlag();
+    const handoffFlag = readHandoffFlag(handoffFlagFile);
     if (handoffFlag && HANDOFF_NUDGE_MESSAGES[handoffFlag.tier]) {
       console.log(HANDOFF_NUDGE_MESSAGES[handoffFlag.tier](handoffFlag));
-      clearHandoffFlag();
+      clearHandoffFlag(handoffFlagFile);
       state.lastNudgeTime = new Date().toISOString();
       state.nudgeCount = (state.nudgeCount || 0) + 1;
-      writeState(state);
+      writeState(stateFile, state);
       process.exit(0);
     }
 
@@ -280,13 +353,13 @@ function main() {
         console.log(`[context-compact-nudge] WARNING (${source}): Consider running /context-compact to reduce context size.`);
       }
 
-      writeFlag(level, Math.round(sessionAgeMinutes), state);
+      writeFlag(level, Math.round(sessionAgeMinutes), state, sessionId);
 
       state.lastNudgeTime = new Date().toISOString();
       state.nudgeCount = (state.nudgeCount || 0) + 1;
     }
 
-    writeState(state);
+    writeState(stateFile, state);
     process.exit(0);
 
   } catch (err) {
@@ -295,4 +368,8 @@ function main() {
   }
 }
 
-main();
+main().catch((err) => {
+  // Advisory hook: never block the session on our own failure.
+  console.error(`[context-compact-nudge] Error: ${err?.message || err}`);
+  process.exit(0);
+});

--- a/scripts/hooks/context-compact-nudge.session-scope.test.js
+++ b/scripts/hooks/context-compact-nudge.session-scope.test.js
@@ -1,0 +1,244 @@
+// SD-LEO-INFRA-COMPACT-NUDGE-RACES-001 — the post-handoff compact nudge must
+// reach the session that EARNED it, and only that session.
+//
+// WHY THIS FILE EXISTS SEPARATELY FROM context-compact-nudge.handoff-flag.test.js:
+// that suite's runHook() sets CLAUDE_SESSION_ID in the child environment. Real
+// hooks do not get that variable — capture-session-id.cjs persists it via
+// CLAUDE_ENV_FILE so BASH TOOL children inherit it, and a hook is not a Bash
+// tool invocation. So a "fix" that keyed the flag off process.env would have
+// passed every test in that file while changing nothing in production, because
+// the harness supplies the exact precondition production lacks.
+//
+// Every runHook() below therefore DELETES CLAUDE_SESSION_ID from the child env
+// and passes identity only the way Claude Code actually passes it: JSON on stdin.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { fileURLToPath } from 'url';
+import { getHandoffFlagPath } from '../modules/handoff/cli/compact-after-handoff.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const HOOK_SCRIPT = path.join(__dirname, 'context-compact-nudge.js');
+
+const TEST_FLAG_DIR = path.join(os.tmpdir(), `leo-compact-scope-test-${process.pid}`);
+// Isolated from the shared leo-context-nudge dir. The unidentified-session path
+// writes to session-default.json, which on a real machine is the live file every
+// session shares — pointing at it would both corrupt it and let its real
+// cooldown suppress the run before the code under test is reached.
+const STATE_DIR = path.join(os.tmpdir(), `leo-compact-scope-state-${process.pid}`);
+
+// Distinct, sanitizer-safe ids standing in for two live workers and one role session.
+const EARNER = `scope-earner-${process.pid}`;
+const BYSTANDER = `scope-bystander-${process.pid}`;
+const ROLE_SESSION = `scope-adam-${process.pid}`;
+const SECOND_EARNER = `scope-earner2-${process.pid}`;
+const ALL_SESSIONS = [EARNER, BYSTANDER, ROLE_SESSION, SECOND_EARNER];
+
+const flagFor = (sid) => getHandoffFlagPath({ LEO_COMPACT_FLAG_DIR: TEST_FLAG_DIR }, sid);
+const stateFor = (sid) => path.join(STATE_DIR, `session-${sid}.json`);
+
+/**
+ * Runs the hook the way Claude Code does: identity on stdin, and CLAUDE_SESSION_ID
+ * deliberately ABSENT. `delete` (not '') because an empty string is a different
+ * failure mode and would let an `|| 'default'` fallback look like it works.
+ */
+function runHook({ sessionId, stdin, extraArgs = [] } = {}) {
+  const env = {
+    ...process.env,
+    LEO_COMPACT_NUDGE_ENABLED: 'true',
+    LEO_COMPACT_FLAG_DIR: TEST_FLAG_DIR,
+    LEO_COMPACT_STATE_DIR: STATE_DIR
+  };
+  delete env.CLAUDE_SESSION_ID;
+
+  const payload = stdin !== undefined
+    ? stdin
+    : JSON.stringify({ session_id: sessionId, hook_event_name: 'UserPromptSubmit' });
+
+  return execFileSync('node', [HOOK_SCRIPT, ...extraArgs], {
+    env,
+    input: payload,
+    encoding: 'utf8'
+  });
+}
+
+function writeFlagFor(sessionId, overrides = {}) {
+  fs.mkdirSync(TEST_FLAG_DIR, { recursive: true });
+  const target = flagFor(sessionId);
+  fs.writeFileSync(target, JSON.stringify({
+    sd_id: `SD-FOR-${sessionId}`,
+    session_id: sessionId,
+    handoff_type: 'LEAD-FINAL-APPROVAL',
+    tier: 'strong',
+    mode: 'nudge',
+    timestamp: new Date().toISOString(),
+    ...overrides
+  }, null, 2));
+  return target;
+}
+
+function cleanup() {
+  fs.rmSync(TEST_FLAG_DIR, { recursive: true, force: true });
+  fs.rmSync(STATE_DIR, { recursive: true, force: true });
+}
+
+beforeEach(cleanup);
+afterEach(cleanup);
+
+describe('identity comes from stdin, not the environment', () => {
+  it('THE RED TEST: resolves its session from stdin with CLAUDE_SESSION_ID absent', () => {
+    writeFlagFor(EARNER);
+    const stdout = runHook({ sessionId: EARNER });
+    expect(stdout).toContain('LEAD-FINAL-APPROVAL complete');
+    expect(stdout).toContain(`SD-FOR-${EARNER}`);
+  });
+
+  it('writes its state to a file named for the stdin session, not to session-default', () => {
+    runHook({ sessionId: EARNER });
+    expect(fs.existsSync(stateFor(EARNER))).toBe(true);
+    // The pre-fix behaviour was every session aggregating into one shared file.
+    const state = JSON.parse(fs.readFileSync(stateFor(EARNER), 'utf8'));
+    expect(state.userTurnCount).toBe(1);
+  });
+
+  it('consumes only its OWN flag file, leaving another session\'s untouched', () => {
+    const mine = writeFlagFor(EARNER);
+    const theirs = writeFlagFor(BYSTANDER);
+    runHook({ sessionId: EARNER });
+    expect(fs.existsSync(mine)).toBe(false);
+    expect(fs.existsSync(theirs)).toBe(true);
+  });
+
+  it('does not consume a handoff flag at all when identity is unresolvable', () => {
+    const orphan = writeFlagFor(EARNER);
+    // Malformed stdin, no env var: the hook has no idea who it is.
+    const stdout = runHook({ stdin: 'not json' });
+    expect(stdout).not.toContain('complete');
+    // Fail-closed. Falling back to a shared name here is the original defect.
+    expect(fs.existsSync(orphan)).toBe(true);
+  });
+
+  // This test exists because a mutant survived without it. Asserting only that
+  // an unidentified session leaves the SCOPED files alone is satisfied just as
+  // well by a reader that falls back to an unscoped name no test ever creates.
+  // The distinguishing assertion has to put a flag at the shared path.
+  it('ignores a flag at the legacy shared path instead of falling back to it', () => {
+    fs.mkdirSync(TEST_FLAG_DIR, { recursive: true });
+    const legacy = path.join(TEST_FLAG_DIR, 'compact-after-handoff.json');
+    fs.writeFileSync(legacy, JSON.stringify({
+      sd_id: 'SD-LEGACY-SHARED',
+      handoff_type: 'LEAD-FINAL-APPROVAL',
+      tier: 'strong',
+      mode: 'nudge',
+      timestamp: new Date().toISOString()
+    }));
+
+    expect(runHook({ stdin: 'not json' })).not.toContain('SD-LEGACY-SHARED');
+    // An identified session must not pick it up either — the shared file is
+    // exactly what this SD removes, whoever is asking.
+    expect(runHook({ sessionId: EARNER })).not.toContain('SD-LEGACY-SHARED');
+  });
+
+  it('sweeps the stale legacy shared file so it is not left behind forever', () => {
+    fs.mkdirSync(TEST_FLAG_DIR, { recursive: true });
+    const legacy = path.join(TEST_FLAG_DIR, 'compact-after-handoff.json');
+    fs.writeFileSync(legacy, '{}');
+    const old = new Date(Date.now() - 120 * 60 * 1000);
+    fs.utimesSync(legacy, old, old);
+
+    runHook({ sessionId: EARNER });
+    // Nothing reads this path after the fix, so without the sweep it would be
+    // permanent litter on every machine that ever ran the old code.
+    expect(fs.existsSync(legacy)).toBe(false);
+  });
+});
+
+describe('PRIMARY: worker-to-worker — the majority population', () => {
+  // Measured on the live fleet while this SD was in LEAD: 7 workers to 3 role
+  // sessions. A fix that only filtered role sessions would leave all 7 racing.
+  it('a bystander worker prompting first does not steal the earner\'s nudge', () => {
+    writeFlagFor(EARNER);
+
+    const bystanderOut = runHook({ sessionId: BYSTANDER });
+    expect(bystanderOut).not.toContain('complete');
+    expect(bystanderOut).not.toContain(`SD-FOR-${EARNER}`);
+
+    const earnerOut = runHook({ sessionId: EARNER });
+    expect(earnerOut).toContain('LEAD-FINAL-APPROVAL complete');
+    expect(earnerOut).toContain(`SD-FOR-${EARNER}`);
+  });
+});
+
+describe('SECONDARY: role sessions — satisfied by construction, not by role detection', () => {
+  it('a role session never matches, because it never runs handoffs', () => {
+    writeFlagFor(EARNER);
+    expect(runHook({ sessionId: ROLE_SESSION })).not.toContain('complete');
+    expect(runHook({ sessionId: EARNER })).toContain('LEAD-FINAL-APPROVAL complete');
+  });
+});
+
+describe('two concurrent earners each receive their own nudge', () => {
+  // Pre-fix this was a single-slot writeFileSync: the second handoff overwrote
+  // the first session's pending flag, and nobody received it. Observed live on
+  // SD-LEO-INFRA-FLEET-DOWN-PAGER-001 — a flag written at 05:33 was overwritten
+  // at 05:41 and gone by 05:47, with no race involved at all.
+  it('neither flag overwrites the other', () => {
+    writeFlagFor(EARNER, { handoff_type: 'EXEC-TO-PLAN', tier: 'medium' });
+    writeFlagFor(SECOND_EARNER, { handoff_type: 'LEAD-TO-PLAN', tier: 'soft' });
+
+    const first = runHook({ sessionId: EARNER });
+    expect(first).toContain('EXEC-TO-PLAN complete');
+
+    const second = runHook({ sessionId: SECOND_EARNER });
+    expect(second).toContain('LEAD-TO-PLAN complete');
+    expect(second).toContain(`SD-FOR-${SECOND_EARNER}`);
+  });
+});
+
+describe('TS-8: one session\'s nudge no longer suppresses the whole fleet', () => {
+  // This is FR-3(a), and it is a DIFFERENT guard from the compaction cooldown.
+  // context-compact-nudge.js:227 gates on state.lastNudgeTime, which lived in
+  // the shared session-default.json; :220 gates on the compaction marker from a
+  // different file entirely. Only the first is fixed by scoping state, and the
+  // measured live suppressor at the time of writing was this one — a flag sat
+  // unconsumed for 20 minutes behind a lastNudgeTime 22 minutes old.
+  it('a bystander that just nudged does not silence the earner', () => {
+    fs.mkdirSync(STATE_DIR, { recursive: true });
+    fs.writeFileSync(stateFor(BYSTANDER), JSON.stringify({
+      userTurnCount: 5,
+      toolCallCount: 0,
+      startTime: new Date().toISOString(),
+      lastNudgeTime: new Date().toISOString(), // one minute ago, well inside cooldown
+      nudgeCount: 1,
+      lastCompactionTime: null
+    }));
+
+    writeFlagFor(EARNER);
+    const stdout = runHook({ sessionId: EARNER });
+    expect(stdout).toContain('LEAD-FINAL-APPROVAL complete');
+  });
+});
+
+describe('stale per-session flags are swept', () => {
+  // Per-session filenames removed the old self-healing: previously any session
+  // could unlink the ONE known stale path. Now a session that runs a handoff
+  // and then never prompts again (crash, session end, one-shot CLI) leaves a
+  // file whose name no other session can construct.
+  it('an orphan from a session that never came back is removed by a live session', () => {
+    const orphan = writeFlagFor(BYSTANDER);
+    const old = new Date(Date.now() - 120 * 60 * 1000);
+    fs.utimesSync(orphan, old, old);
+
+    runHook({ sessionId: EARNER });
+    expect(fs.existsSync(orphan)).toBe(false);
+  });
+
+  it('a fresh flag belonging to another live session survives the sweep', () => {
+    const theirs = writeFlagFor(BYSTANDER);
+    runHook({ sessionId: EARNER });
+    expect(fs.existsSync(theirs)).toBe(true);
+  });
+});

--- a/scripts/hooks/context-compact-nudge.session-scope.test.js
+++ b/scripts/hooks/context-compact-nudge.session-scope.test.js
@@ -35,7 +35,6 @@ const EARNER = `scope-earner-${process.pid}`;
 const BYSTANDER = `scope-bystander-${process.pid}`;
 const ROLE_SESSION = `scope-adam-${process.pid}`;
 const SECOND_EARNER = `scope-earner2-${process.pid}`;
-const ALL_SESSIONS = [EARNER, BYSTANDER, ROLE_SESSION, SECOND_EARNER];
 
 const flagFor = (sid) => getHandoffFlagPath({ LEO_COMPACT_FLAG_DIR: TEST_FLAG_DIR }, sid);
 const stateFor = (sid) => path.join(STATE_DIR, `session-${sid}.json`);

--- a/scripts/hooks/context-compact-nudge.session-scope.test.js
+++ b/scripts/hooks/context-compact-nudge.session-scope.test.js
@@ -141,6 +141,21 @@ describe('identity comes from stdin, not the environment', () => {
     expect(runHook({ sessionId: EARNER })).not.toContain('SD-LEGACY-SHARED');
   });
 
+  // Raised by the EXEC SECURITY review: state still falls back to a shared
+  // bucket while the flag fails closed. That asymmetry is deliberate (see the
+  // docblock on stateFileFor), but nothing asserted WHERE the unidentified
+  // write landed — so it read as an oversight and could have drifted silently.
+  it('unidentified sessions share the default bucket, by design', () => {
+    runHook({ stdin: 'not json' });
+    const shared = path.join(STATE_DIR, 'session-default.json');
+    expect(fs.existsSync(shared)).toBe(true);
+    // ...and crucially, they still consume no handoff flag. The fallback is
+    // scoped to state only; identity failure must never share a FLAG.
+    const someoneElses = writeFlagFor(EARNER);
+    runHook({ stdin: 'not json' });
+    expect(fs.existsSync(someoneElses)).toBe(true);
+  });
+
   it('sweeps the stale legacy shared file so it is not left behind forever', () => {
     fs.mkdirSync(TEST_FLAG_DIR, { recursive: true });
     const legacy = path.join(TEST_FLAG_DIR, 'compact-after-handoff.json');

--- a/scripts/hooks/precompact-snapshot.ps1
+++ b/scripts/hooks/precompact-snapshot.ps1
@@ -80,7 +80,16 @@ if (Test-Path $UnifiedStateFile) {
 }
 
 # Build unified state JSON
-$timestamp = Get-Date -Format "yyyy-MM-ddTHH:mm:ss.fffZ"
+# SD-LEO-INFRA-COMPACT-NUDGE-RACES-001: this was `Get-Date -Format "...fffZ"`,
+# which returns LOCAL time and treats Z as a literal character — so the value
+# claimed UTC while carrying local time. context-compact-nudge.js feeds this
+# through minutesSince() as if it were UTC. Observed on disk at UTC-4:
+# last-compaction.json said 02:19:45Z for a compaction that happened at 06:19:45Z,
+# making minutesSinceCompaction permanently ~240 so the compaction cooldown at
+# :220 never fired. East of UTC it is worse — the marker reads as the FUTURE,
+# minutesSince() goes negative, and the check at :220 short-circuits every
+# invocation, silently disabling the whole nudge hook after the first compaction.
+$timestamp = [DateTime]::UtcNow.ToString("yyyy-MM-ddTHH:mm:ss.fff'Z'")
 $state = @{
     version = "1.0.0"
     timestamp = $timestamp

--- a/scripts/modules/handoff/cli/compact-after-handoff.js
+++ b/scripts/modules/handoff/cli/compact-after-handoff.js
@@ -35,9 +35,45 @@ export function getHandoffTier(handoffType) {
   return HANDOFF_COMPACT_TIERS[key] || null;
 }
 
-export function getHandoffFlagPath(env = process.env) {
-  const dir = env.LEO_COMPACT_FLAG_DIR || path.join(os.homedir(), '.claude', 'flags');
-  return path.join(dir, 'compact-after-handoff.json');
+// SD-LEO-INFRA-COMPACT-NUDGE-RACES-001: the flag is keyed to the session that
+// EARNED it. Before this, one unscoped file meant whichever session next
+// submitted a prompt consumed the nudge — so it reached the wrong session and
+// never reached the one that ran the handoff. The session id also lands in the
+// payload so an orphaned file can be attributed without parsing its name.
+export const HANDOFF_FLAG_PREFIX = 'compact-after-handoff-';
+export const HANDOFF_FLAG_SUFFIX = '.json';
+// The pre-fix filename. Nothing reads or writes it any more, so on every
+// machine that ever ran the old code it would sit in the flags directory
+// forever unless the sweep is told to collect it.
+export const LEGACY_HANDOFF_FLAG_NAME = 'compact-after-handoff.json';
+const SESSION_ID_MAX_LENGTH = 64;
+
+/**
+ * Session ids are UUIDs, but this value reaches path.join() — anything outside
+ * [A-Za-z0-9_-] is rejected outright rather than escaped, so a crafted id can
+ * never traverse out of the flags directory.
+ * @returns {string|null} the safe id, or null when there is no usable identity
+ */
+export function sanitizeSessionId(raw) {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim();
+  if (!trimmed || !/^[A-Za-z0-9_-]+$/.test(trimmed)) return null;
+  return trimmed.slice(0, SESSION_ID_MAX_LENGTH);
+}
+
+export function getHandoffFlagDir(env = process.env) {
+  return env.LEO_COMPACT_FLAG_DIR || path.join(os.homedir(), '.claude', 'flags');
+}
+
+/**
+ * @returns {string|null} null when no session identity is available. Callers
+ *   MUST treat null as "do not write / do not read" — falling back to a shared
+ *   filename is the defect this SD exists to remove.
+ */
+export function getHandoffFlagPath(env = process.env, sessionId = undefined) {
+  const sid = sanitizeSessionId(sessionId === undefined ? env.CLAUDE_SESSION_ID : sessionId);
+  if (!sid) return null;
+  return path.join(getHandoffFlagDir(env), `${HANDOFF_FLAG_PREFIX}${sid}${HANDOFF_FLAG_SUFFIX}`);
 }
 
 export function writeCompactAfterHandoffFlag(handoffType, sdId, env = process.env) {
@@ -48,12 +84,19 @@ export function writeCompactAfterHandoffFlag(handoffType, sdId, env = process.en
     const tier = getHandoffTier(handoffType);
     if (!tier) return { written: false, reason: 'unknown_handoff_type' };
 
-    const flagPath = getHandoffFlagPath(env);
+    // The handoff CLI is a Bash-tool descendant, so it genuinely has
+    // CLAUDE_SESSION_ID (cli-main.js:755-763 pre-flights it). A miss is
+    // surfaced explicitly instead of being swallowed into a bare written:false.
+    const sessionId = sanitizeSessionId(env.CLAUDE_SESSION_ID);
+    const flagPath = getHandoffFlagPath(env, sessionId);
+    if (!flagPath) return { written: false, reason: 'no_session_id' };
+
     const flagDir = path.dirname(flagPath);
     if (!fs.existsSync(flagDir)) fs.mkdirSync(flagDir, { recursive: true });
 
     const payload = {
       sd_id: sdId || null,
+      session_id: sessionId,
       handoff_type: handoffType.toUpperCase(),
       tier,
       mode,
@@ -64,4 +107,36 @@ export function writeCompactAfterHandoffFlag(handoffType, sdId, env = process.en
   } catch (err) {
     return { written: false, reason: 'write_error', error: err.message };
   }
+}
+
+/**
+ * Per-session filenames break the old self-healing: readHandoffFlag() used to
+ * discard the ONE known stale path, so any session could clean up after any
+ * other. Now each session only ever constructs its own name, and a session that
+ * runs a handoff then never prompts again (crash, session end, one-shot CLI)
+ * leaves a file nobody knows to look for. This sweep is the replacement — it is
+ * the only thing that keeps the flags directory from growing without bound.
+ * @returns {{swept: string[], errors: number}}
+ */
+export function sweepStaleHandoffFlags(env = process.env, staleMinutes = 60, now = Date.now()) {
+  const swept = [];
+  let errors = 0;
+  try {
+    const dir = getHandoffFlagDir(env);
+    if (!fs.existsSync(dir)) return { swept, errors };
+    for (const name of fs.readdirSync(dir)) {
+      const isScoped = name.startsWith(HANDOFF_FLAG_PREFIX) && name.endsWith(HANDOFF_FLAG_SUFFIX);
+      if (!isScoped && name !== LEGACY_HANDOFF_FLAG_NAME) continue;
+      const full = path.join(dir, name);
+      try {
+        // Age comes from mtime, not the payload: a corrupt or truncated file has
+        // no readable timestamp and would otherwise be immortal.
+        if (now - fs.statSync(full).mtimeMs > staleMinutes * 60 * 1000) {
+          fs.unlinkSync(full);
+          swept.push(name);
+        }
+      } catch { errors += 1; }
+    }
+  } catch { errors += 1; }
+  return { swept, errors };
 }

--- a/scripts/modules/handoff/cli/compact-after-handoff.js
+++ b/scripts/modules/handoff/cli/compact-after-handoff.js
@@ -58,7 +58,13 @@ export function sanitizeSessionId(raw) {
   if (typeof raw !== 'string') return null;
   const trimmed = raw.trim();
   if (!trimmed || !/^[A-Za-z0-9_-]+$/.test(trimmed)) return null;
-  return trimmed.slice(0, SESSION_ID_MAX_LENGTH);
+  // Case-folded because NTFS and APFS are case-insensitive by default: two ids
+  // differing only in case would otherwise alias to ONE file, which is a
+  // cross-session leak of exactly the kind this SD removes. Real ids are
+  // lowercase UUIDs so this is unreachable today — but the guard should not
+  // depend on the caller's formatting for that. Folding here keeps writer and
+  // reader in agreement because both resolve their path through this function.
+  return trimmed.slice(0, SESSION_ID_MAX_LENGTH).toLowerCase();
 }
 
 export function getHandoffFlagDir(env = process.env) {

--- a/scripts/modules/handoff/cli/compact-after-handoff.test.js
+++ b/scripts/modules/handoff/cli/compact-after-handoff.test.js
@@ -178,6 +178,15 @@ describe('sanitizeSessionId — this value reaches path.join()', () => {
   it('caps length so a hostile id cannot blow the filename limit', () => {
     expect(sanitizeSessionId('a'.repeat(500))).toHaveLength(64);
   });
+
+  // NTFS and APFS are case-insensitive by default, so without folding, two ids
+  // differing only in case resolve to ONE file on disk — one session reading
+  // and deleting another's flag, which is the defect this SD exists to remove.
+  it('folds case so two ids differing only in case cannot alias to one file', () => {
+    expect(sanitizeSessionId('ABC123')).toBe('abc123');
+    expect(getHandoffFlagPath({ CLAUDE_SESSION_ID: 'ABC123' }))
+      .toBe(getHandoffFlagPath({ CLAUDE_SESSION_ID: 'abc123' }));
+  });
 });
 
 describe('writeCompactAfterHandoffFlag — session identity is explicit, not swallowed', () => {

--- a/scripts/modules/handoff/cli/compact-after-handoff.test.js
+++ b/scripts/modules/handoff/cli/compact-after-handoff.test.js
@@ -6,14 +6,22 @@ import path from 'path';
 import os from 'os';
 import {
   HANDOFF_COMPACT_TIERS,
+  HANDOFF_FLAG_PREFIX,
   resolveCompactAfterHandoffMode,
   getHandoffTier,
   getHandoffFlagPath,
+  sanitizeSessionId,
+  sweepStaleHandoffFlags,
   writeCompactAfterHandoffFlag
 } from './compact-after-handoff.js';
 
 const TEST_FLAG_DIR = path.join(os.tmpdir(), `leo-compact-after-handoff-test-${process.pid}`);
-const TEST_ENV = { LEO_COMPACT_FLAG_DIR: TEST_FLAG_DIR };
+const TEST_SESSION_ID = `writer-test-${process.pid}`;
+// SD-LEO-INFRA-COMPACT-NUDGE-RACES-001: CLAUDE_SESSION_ID is now part of the
+// contract, not incidental. It is set EXPLICITLY here rather than inherited —
+// the ambient process env carries a real session id under Claude Code, which
+// would make these tests pass for a reason that has nothing to do with the code.
+const TEST_ENV = { LEO_COMPACT_FLAG_DIR: TEST_FLAG_DIR, CLAUDE_SESSION_ID: TEST_SESSION_ID };
 const FLAG_PATH = getHandoffFlagPath(TEST_ENV);
 
 function clearFlag() {
@@ -124,9 +132,137 @@ describe('writeCompactAfterHandoffFlag', () => {
 });
 
 describe('getHandoffFlagPath', () => {
-  it('returns path under user home .claude/flags', () => {
-    const p = getHandoffFlagPath();
-    expect(p).toContain(path.join('.claude', 'flags', 'compact-after-handoff.json'));
-    expect(p.startsWith(os.homedir())).toBe(true);
+  it('returns a SESSION-SCOPED path under user home .claude/flags', () => {
+    const p = getHandoffFlagPath({ CLAUDE_SESSION_ID: 'abc123' });
+    expect(p).toBe(path.join(os.homedir(), '.claude', 'flags', 'compact-after-handoff-abc123.json'));
+  });
+
+  // The whole defect was one shared filename. If this ever returns a path with
+  // no session token, every session reads and deletes the same file again.
+  it('never returns an unscoped filename', () => {
+    expect(getHandoffFlagPath({ CLAUDE_SESSION_ID: 'abc123' }))
+      .not.toBe(path.join(os.homedir(), '.claude', 'flags', 'compact-after-handoff.json'));
+  });
+
+  it('returns null when there is no session identity — never a shared fallback', () => {
+    expect(getHandoffFlagPath({})).toBeNull();
+    expect(getHandoffFlagPath({ CLAUDE_SESSION_ID: '' })).toBeNull();
+    expect(getHandoffFlagPath({ CLAUDE_SESSION_ID: '   ' })).toBeNull();
+  });
+
+  it('explicit sessionId argument overrides the environment', () => {
+    const p = getHandoffFlagPath({ CLAUDE_SESSION_ID: 'from-env' }, 'from-arg');
+    expect(p).toContain('compact-after-handoff-from-arg.json');
+    expect(p).not.toContain('from-env');
+  });
+});
+
+describe('sanitizeSessionId — this value reaches path.join()', () => {
+  it('accepts uuid-shaped ids', () => {
+    expect(sanitizeSessionId('06521203-f370-4666-a40c-7801bcc192ef'))
+      .toBe('06521203-f370-4666-a40c-7801bcc192ef');
+  });
+
+  it('rejects traversal and separators outright rather than escaping them', () => {
+    for (const bad of ['../../etc/passwd', 'a/b', 'a\\b', 'a.b', 'a b', 'a:b', '..']) {
+      expect(sanitizeSessionId(bad)).toBeNull();
+    }
+  });
+
+  it('rejects non-strings and empties', () => {
+    for (const bad of [null, undefined, 42, {}, '', '   ']) {
+      expect(sanitizeSessionId(bad)).toBeNull();
+    }
+  });
+
+  it('caps length so a hostile id cannot blow the filename limit', () => {
+    expect(sanitizeSessionId('a'.repeat(500))).toHaveLength(64);
+  });
+});
+
+describe('writeCompactAfterHandoffFlag — session identity is explicit, not swallowed', () => {
+  it('stamps session_id into the payload', () => {
+    clearFlag();
+    const result = writeCompactAfterHandoffFlag('LEAD-TO-PLAN', 'SD-X-001', TEST_ENV);
+    expect(result.written).toBe(true);
+    expect(JSON.parse(fs.readFileSync(FLAG_PATH, 'utf8')).session_id).toBe(TEST_SESSION_ID);
+    clearFlag();
+  });
+
+  it('reports no_session_id rather than a bare written:false', () => {
+    const result = writeCompactAfterHandoffFlag('LEAD-TO-PLAN', 'SD-X-001', { LEO_COMPACT_FLAG_DIR: TEST_FLAG_DIR });
+    expect(result.written).toBe(false);
+    // A bare written:false would be indistinguishable from mode_off or a
+    // write error — the caller must be able to tell identity was the problem.
+    expect(result.reason).toBe('no_session_id');
+  });
+
+  it('two sessions completing handoffs do not overwrite each other', () => {
+    const envA = { LEO_COMPACT_FLAG_DIR: TEST_FLAG_DIR, CLAUDE_SESSION_ID: 'sess-A' };
+    const envB = { LEO_COMPACT_FLAG_DIR: TEST_FLAG_DIR, CLAUDE_SESSION_ID: 'sess-B' };
+    writeCompactAfterHandoffFlag('LEAD-TO-PLAN', 'SD-A', envA);
+    writeCompactAfterHandoffFlag('EXEC-TO-PLAN', 'SD-B', envB);
+
+    const a = JSON.parse(fs.readFileSync(getHandoffFlagPath(envA), 'utf8'));
+    const b = JSON.parse(fs.readFileSync(getHandoffFlagPath(envB), 'utf8'));
+    expect(a.sd_id).toBe('SD-A');
+    expect(b.sd_id).toBe('SD-B');
+
+    fs.unlinkSync(getHandoffFlagPath(envA));
+    fs.unlinkSync(getHandoffFlagPath(envB));
+  });
+});
+
+describe('sweepStaleHandoffFlags — replaces the self-healing single-path unlink', () => {
+  const sweepDir = path.join(os.tmpdir(), `leo-compact-sweep-test-${process.pid}`);
+  const sweepEnv = { LEO_COMPACT_FLAG_DIR: sweepDir };
+
+  function seed(name, ageMinutes) {
+    fs.mkdirSync(sweepDir, { recursive: true });
+    const full = path.join(sweepDir, name);
+    fs.writeFileSync(full, '{}');
+    const when = new Date(Date.now() - ageMinutes * 60 * 1000);
+    fs.utimesSync(full, when, when);
+    return full;
+  }
+
+  beforeEach(() => { fs.rmSync(sweepDir, { recursive: true, force: true }); });
+  afterEach(() => { fs.rmSync(sweepDir, { recursive: true, force: true }); });
+
+  it('sweeps an orphan left by a session that never prompted again', () => {
+    const orphan = seed(`${HANDOFF_FLAG_PREFIX}gone-forever.json`, 90);
+    const { swept } = sweepStaleHandoffFlags(sweepEnv, 60);
+    expect(swept).toContain(`${HANDOFF_FLAG_PREFIX}gone-forever.json`);
+    expect(fs.existsSync(orphan)).toBe(false);
+  });
+
+  it('leaves a fresh flag belonging to a live session alone', () => {
+    const fresh = seed(`${HANDOFF_FLAG_PREFIX}still-working.json`, 5);
+    sweepStaleHandoffFlags(sweepEnv, 60);
+    expect(fs.existsSync(fresh)).toBe(true);
+  });
+
+  it('touches nothing outside the handoff-flag namespace', () => {
+    const marker = seed('last-compaction.json', 999);
+    const needed = seed('context-compact-needed.json', 999);
+    const { swept } = sweepStaleHandoffFlags(sweepEnv, 60);
+    expect(swept).toEqual([]);
+    expect(fs.existsSync(marker)).toBe(true);
+    expect(fs.existsSync(needed)).toBe(true);
+  });
+
+  it('sweeps a corrupt flag too — mtime is the clock, not the payload', () => {
+    const corrupt = seed(`${HANDOFF_FLAG_PREFIX}corrupt.json`, 120);
+    fs.writeFileSync(corrupt, 'not json at all');
+    const when = new Date(Date.now() - 120 * 60 * 1000);
+    fs.utimesSync(corrupt, when, when);
+    sweepStaleHandoffFlags(sweepEnv, 60);
+    expect(fs.existsSync(corrupt)).toBe(false);
+  });
+
+  it('is a no-op on a missing directory rather than throwing', () => {
+    const { swept, errors } = sweepStaleHandoffFlags({ LEO_COMPACT_FLAG_DIR: path.join(sweepDir, 'nope') }, 60);
+    expect(swept).toEqual([]);
+    expect(errors).toBe(0);
   });
 });


### PR DESCRIPTION
## What was wrong

One unscoped file — `~/.claude/flags/compact-after-handoff.json` — was written by the handoff CLI and read+deleted by whichever Claude Code session next submitted a prompt. The session that ran the handoff usually got nothing.

## The SD's own prescribed fix does not work

The SD said to copy the convention eleven lines above the bug (`context-compact-nudge.js:57`, `process.env.CLAUDE_SESSION_ID || 'default'`). **That line is a second instance of the same defect, not a template.** Hooks are not Bash-tool invocations, and `capture-session-id.cjs` persists the id via `CLAUDE_ENV_FILE` precisely so Bash-tool children inherit it.

Measured on disk before the fix: `session-default.json` held **3670 user turns and 10914 tool calls** aggregated across sessions, while a 17-hour session had no file of its own. Copying that line yields `compact-after-handoff-default.json` — one shared file, race intact — and it would have **shipped green**, because the existing harness injects `CLAUDE_SESSION_ID` into the child env.

## What changed

- Identity comes from the hook's **stdin payload** (same mechanism as `coordination-inbox.cjs`), feeding **both** the flag path and the state file.
- Scoping the **state file** is what fixes fleet-wide suppression: `lastNudgeTime` lived in the shared file and is checked at `:227` **before** the flag is read, so one session's nudge silenced every other session's handoff nudge for 30 minutes. This was the live suppressor — a flag sat unconsumed for 20 minutes behind a `lastNudgeTime` 22 minutes old, while this SD was being built.
- `precompact-snapshot.ps1` stamped **local** time with a literal `Z`. At UTC-4 the compaction marker read ~4h stale so its cooldown never fired; east of UTC it reads as the **future**, `minutesSince` goes negative, and the hook short-circuits every invocation — silently disabling all nudges after the first compaction.
- A directory sweep replaces the old self-healing single-path unlink, and collects the now-orphaned legacy shared file.
- Unidentified sessions consume **nothing** rather than falling back to a shared name.

## Verified by mutation, not by reading

| mutant | failures |
|---|---|
| `env_fallback` (the SD's own prescription) | 7 |
| `unscoped_filename` | 10 |
| `no_sweep` | 2 |
| `shared_fallback_on_unknown` | 1 |

**Correction:** the commit message for `79b6feaae44` records `shared_fallback_on_unknown` as 2 failures. It is **1** — my own run printed 1 and I transcribed it wrong; the EXEC TESTING sub-agent re-ran the harness independently and caught it. The mutant is genuinely killed either way. The reason it is 1 and not 2: the killing test packs two `expect()` calls into one `it()`, so the first abort prevents the second from running — and that second assertion is not a distinct invariant under this mutant anyway (for an *identified* session the path never falls back, so it is only killable by `unscoped_filename`, which already covers it).

`shared_fallback_on_unknown` **survived twice** before it was killed: no test wrote an unscoped file, and the unidentified path was writing to the machine's **live** `session-default.json`, whose real cooldown short-circuited the run before the code under test was reached. Both fixed — a test that writes the shared path, plus `LEO_COMPACT_STATE_DIR` isolation.

Three existing tests asserted only the **absence** of nudge text and would have stayed green after a filename change (no flag found at all, rather than found-and-correctly-rejected). Each now carries a positive control.

## Independent EXEC verification (TESTING sub-agent, CONDITIONAL_PASS 82)

Re-ran both suites and all four mutants from scratch; suite numbers matched exactly, mutant counts matched except the correction above. Additionally measured:

- **stdin never closes** — the 250ms bound holds; process exits at ~303-309ms, code 0, no hang.
- **PostToolUse budget** — hook timeout is 3000ms. Throttled call ~46-56ms; full evaluation ~44-61ms; with 300 stale flags the first sweeping call ~101ms then ~50ms; absolute worst case (stdin hangs) ~303ms, roughly 10% of budget.
- **`sanitizeSessionId` fuzzed** with 16 hostile inputs (traversal in two encodings, null bytes, CR/LF/tab, shell-injection strings, a Windows reserved name, 1000 chars, non-ASCII, leading `-`) — zero escapes from the flags directory.
- **Hostile flags directory** (a subdirectory matching the scoped pattern, non-empty, old mtime) — no throw, no hang, subdirectory untouched, real flags still handled.

**Found and not fixed here:** the per-session state file has a non-atomic read-modify-write. 10 concurrent invocations for one session landed 5 of 10 `userTurnCount` increments. This is **pre-existing** and outside this SD's scope (cross-session misdelivery); impact is delayed nudge timing, not corruption or misdelivery. Logged for follow-up rather than folded in.

## Ruled explicitly out of scope

`precompact-snapshot.ps1`'s unconditional wipe of `context-compact-needed.json`, and attributing the compaction marker by `sessionId`. Both need the PowerShell PreCompact hook to acquire session identity — a different transport with no in-repo precedent. Evidence it cannot be done today: the live marker reads `"sessionId": null`, because that script reads the same `CLAUDE_SESSION_ID` the hooks don't have.

## Tests

51 targeted; 989 passing + 1 todo across `scripts/hooks` + `scripts/modules/handoff` + `tests/unit/hooks`, no regressions. ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
