### PR TITLE
fix(QF-20260803-882): the freeze remedy had a path where the alarm does not fire

### DIFF
--- a/scripts/fleet-down-alert.mjs
+++ b/scripts/fleet-down-alert.mjs
@@ -244,6 +244,59 @@ export async function checkDeadCoordinator(db, DRY, sendChairmanSMSFn = null, no
   console.log('[dead-coordinator-alert] sendChairmanSMS result:', JSON.stringify(r));
 }
 
+/**
+ * QF-20260803-882: run one notification arm in isolation, so no arm can suppress another.
+ *
+ * THE DEFECT THIS REPLACES: main() ran the arms as two bare awaits with nothing between them, and
+ * the EMAIL arm ran FIRST. A throw from Resend — an outage, a rate limit, a malformed address —
+ * aborted main() before the chairman pager ever fired. So the fleet-down pager, shipped as the
+ * freeze remedy, had a path where the alarm simply does not go off, and that path was SILENT: a
+ * failed run and a clean run were indistinguishable in the logs and in the exit code.
+ *
+ * A pager whose reliability depends on an unrelated third-party email call is not a pager.
+ *
+ * PURE-ish and exported for test: the two-sided acceptance (email throws → pager still fires; pager
+ * throws → email still sends AND the failure is visible) cannot be asserted against a main() that
+ * takes no seams.
+ *
+ * @param {string} name arm label used in the log line
+ * @param {() => Promise<any>} fn the arm
+ * @param {{log?:Function, error?:Function}} [io]
+ * @returns {Promise<{name:string, ok:boolean, error?:string}>} never throws
+ */
+export async function runAlertArm(name, fn, io = {}) {
+  const err = io.error || ((m) => console.error(m));
+  try {
+    await fn();
+    return { name, ok: true };
+  } catch (e) {
+    // LOUD, not swallowed. A caught-and-ignored arm failure would recreate the silence this fixes.
+    err(`[fleet-down-alert] ARM FAILED: ${name}: ${(e && e.message) || e}`);
+    return { name, ok: false, error: (e && e.message) || String(e) };
+  }
+}
+
+/**
+ * QF-20260803-882: run every arm independently and report partial delivery.
+ *
+ * ORDER IS DELIBERATE — the chairman pager goes FIRST. Both arms are now isolated, so ordering can
+ * no longer cause suppression; but if the process is killed mid-run (workflow timeout, runner
+ * eviction) the arm that already fired should be the one that reaches a human.
+ *
+ * @returns {Promise<{results:Array, failed:Array}>}
+ */
+export async function runAlertArms(arms, io = {}) {
+  const results = [];
+  for (const [name, fn] of arms) results.push(await runAlertArm(name, fn, io));
+  const failed = results.filter((r) => !r.ok);
+  if (failed.length) {
+    const err = io.error || ((m) => console.error(m));
+    err(`[fleet-down-alert] PARTIAL DELIVERY: ${failed.length} of ${results.length} arm(s) failed `
+      + `(${failed.map((f) => f.name).join(', ')}) — this alert did NOT fully fire.`);
+  }
+  return { results, failed };
+}
+
 async function main() {
   enforceCliSendGuard({ scriptName: 'scripts/fleet-down-alert.mjs', flags: [{ name: '--dry-run' }] });
   const DRY = !!process.env.FLEET_DOWN_ALERT_DRYRUN || process.argv.includes('--dry-run');
@@ -255,8 +308,15 @@ async function main() {
   }
   const db = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
 
-  await checkWorkerFleetDown(db, DRY);
-  await checkDeadCoordinator(db, DRY);
+  // QF-20260803-882: isolated arms, pager first. Previously two bare awaits — an email throw
+  // suppressed the pager entirely and the run still looked clean.
+  const { failed } = await runAlertArms([
+    ['dead-coordinator-pager', () => checkDeadCoordinator(db, DRY)],
+    ['worker-fleet-email', () => checkWorkerFleetDown(db, DRY)],
+  ]);
+  // A half-delivered alert must not exit 0. The workflow treating a partial page as success is the
+  // same silence one layer up.
+  if (failed.length) process.exitCode = 1;
 }
 
 // Run main() only as a CLI (guarded so tests can import the pure helper).

--- a/tests/unit/fleet-down-alert-arm-isolation.test.js
+++ b/tests/unit/fleet-down-alert-arm-isolation.test.js
@@ -1,0 +1,107 @@
+// QF-20260803-882 — the freeze remedy had a path where the alarm does not fire.
+//
+// fleet-down-alert main() ran its two notification arms as bare awaits with nothing between them,
+// and the EMAIL arm ran FIRST. A throw from Resend — provider outage, rate limit, malformed address
+// — aborted main() before the chairman pager arm ever ran. So the fleet-down pager, shipped as the
+// remedy for worker freezes, could silently not fire at all: a suppressed run and a clean run were
+// indistinguishable in both the log and the exit code.
+//
+// The acceptance is TWO-SIDED on purpose, and the QF says why: "a control must not become silent in
+// either direction". Isolating the arms so the pager survives an email failure is only half of it —
+// if the pager arm fails, email must still send AND the failure must be visible. A fix that made
+// failures quiet in the other direction would pass a one-sided test and reintroduce the defect
+// wearing the opposite mask.
+import { describe, it, expect } from 'vitest';
+import { runAlertArm, runAlertArms } from '../../scripts/fleet-down-alert.mjs';
+
+const io = () => {
+  const errs = [];
+  return { io: { error: (m) => errs.push(String(m)) }, errs };
+};
+
+describe('QF-20260803-882: neither arm can suppress the other', () => {
+  // (a) THE WITNESSED PATH. Email throws; the pager must still fire.
+  it('an email-arm throw does NOT suppress the coordinator pager', async () => {
+    const fired = [];
+    const { io: i } = io();
+    const { failed } = await runAlertArms([
+      ['dead-coordinator-pager', async () => { fired.push('pager'); }],
+      ['worker-fleet-email', async () => { throw new Error('resend 429'); }],
+    ], i);
+    expect(fired).toContain('pager');
+    expect(failed.map((f) => f.name)).toEqual(['worker-fleet-email']);
+  });
+
+  // (b) THE OTHER DIRECTION, which the QF names explicitly. A control must not go silent either way.
+  it('a pager-arm throw does NOT suppress email, and the failure is LOGGED not swallowed', async () => {
+    const fired = [];
+    const { io: i, errs } = io();
+    const { failed } = await runAlertArms([
+      ['dead-coordinator-pager', async () => { throw new Error('sms gateway down'); }],
+      ['worker-fleet-email', async () => { fired.push('email'); }],
+    ], i);
+    expect(fired).toContain('email');
+    expect(failed.map((f) => f.name)).toEqual(['dead-coordinator-pager']);
+    // Swallowing is the failure mode being fixed — the arm failure must be visible.
+    expect(errs.join('\n')).toMatch(/ARM FAILED: dead-coordinator-pager/);
+    expect(errs.join('\n')).toMatch(/sms gateway down/);
+  });
+
+  // A half-delivered alert must be distinguishable from a clean run. Without this, the workflow
+  // treats a partial page as success — the same silence one layer up.
+  it('reports PARTIAL DELIVERY when any arm fails', async () => {
+    const { io: i, errs } = io();
+    await runAlertArms([
+      ['dead-coordinator-pager', async () => {}],
+      ['worker-fleet-email', async () => { throw new Error('boom'); }],
+    ], i);
+    expect(errs.join('\n')).toMatch(/PARTIAL DELIVERY: 1 of 2/);
+    expect(errs.join('\n')).toMatch(/did NOT fully fire/);
+  });
+
+  // CONTROL — the guard must not report failure on a healthy run, or the signal means nothing.
+  it('CONTROL: a clean run reports no failures and logs nothing', async () => {
+    const { io: i, errs } = io();
+    const { results, failed } = await runAlertArms([
+      ['dead-coordinator-pager', async () => {}],
+      ['worker-fleet-email', async () => {}],
+    ], i);
+    expect(failed).toEqual([]);
+    expect(results.every((r) => r.ok)).toBe(true);
+    expect(errs).toEqual([]);
+  });
+
+  // BOTH arms failing must still be survivable and fully reported — the worst case is exactly when
+  // the operator most needs to know the alert did not reach them.
+  it('survives BOTH arms throwing and names both', async () => {
+    const { io: i, errs } = io();
+    const { failed } = await runAlertArms([
+      ['dead-coordinator-pager', async () => { throw new Error('a'); }],
+      ['worker-fleet-email', async () => { throw new Error('b'); }],
+    ], i);
+    expect(failed.map((f) => f.name).sort()).toEqual(['dead-coordinator-pager', 'worker-fleet-email']);
+    expect(errs.join('\n')).toMatch(/PARTIAL DELIVERY: 2 of 2/);
+  });
+
+  it('runAlertArm never throws, whatever the arm does', async () => {
+    const { io: i } = io();
+    for (const thrower of [() => { throw new Error('x'); }, async () => { throw 'not-an-error'; }]) {
+      await expect(runAlertArm('t', thrower, i)).resolves.toMatchObject({ ok: false });
+    }
+  });
+});
+
+describe('the pager arm is ordered FIRST', () => {
+  // Isolation already prevents suppression, so ordering is belt-and-braces: if the process is
+  // killed mid-run (workflow timeout, runner eviction), the arm that already fired should be the
+  // one that reaches a human.
+  it('runs arms in the order given, pager before email', async () => {
+    const order = [];
+    const { io: i } = io();
+    await runAlertArms([
+      ['dead-coordinator-pager', async () => { order.push('pager'); }],
+      ['worker-fleet-email', async () => { order.push('email'); }],
+    ], i);
+    expect(order).toEqual(['pager', 'email']);
+  });
+});


### PR DESCRIPTION
## A pager that depends on an email provider is not a pager

`fleet-down-alert` `main()` ran its two notification arms as bare `await`s with nothing between them — and the **email arm ran first**:

```js
await checkWorkerFleetDown(db, DRY);   // Resend
await checkDeadCoordinator(db, DRY);   // chairman pager
```

A throw from Resend — provider outage, rate limit, malformed address — aborted `main()` **before the pager arm ever ran**. So the fleet-down pager, shipped tonight as the remedy for worker freezes, had a path where the alarm simply does not go off.

And that path was **silent**: a suppressed run and a clean run were indistinguishable in the log *and* in the exit code.

## The fix

- Each arm runs isolated via `runAlertArm`, which **never throws** and logs its own failure loudly.
- `runAlertArms` reports `PARTIAL DELIVERY` naming the failed arms.
- `main()` sets a **non-zero exit code** on any arm failure — a half-delivered alert must not look like a clean run to the workflow, which would be the same silence one layer up.
- **The pager arm is ordered first.** Isolation already prevents suppression, so this is belt-and-braces: if the process is killed mid-run (workflow timeout, runner eviction), the arm that already fired should be the one that reaches a human.

## Acceptance is two-sided, as the QF requires

The QF is explicit: *"a control must not become silent in either direction."*

| direction | assertion |
|---|---|
| email throws | pager **still fires** |
| pager throws | email **still sends**, and the failure is **logged, not swallowed** |

A fix that quietened failures in the second direction would pass a one-sided test and reintroduce the defect wearing the opposite mask. Also covered: both arms failing is survivable and both are named; and a **control** — a clean run reports no failures and logs nothing, so the signal keeps meaning something.

**Seeded-defect check:** restoring the propagating throw fails **5 of 7**. The 2 survivors are the clean-run control and the ordering test — neither involves a throwing arm, so neither should detect it.

28 tests pass across this suite and the existing `fleet-down-alert` suite. ~45 LOC.

Provenance: Echo's FLEET-DOWN-PAGER-001 completion flags, routed by the coordinator 2026-08-03.