### PR TITLE
feat(SD-LEO-INFRA-SURVEY-EVERY-PERMISSION-001): SURVEY-5 — a probe template that FAILS if it cannot discriminate

### DIFF
--- a/lib/security/rls-probe-template.cjs
+++ b/lib/security/rls-probe-template.cjs
@@ -1,0 +1,166 @@
+'use strict';
+/**
+ * CANONICAL RLS / PERMISSION PROBE TEMPLATE — SD-LEO-INFRA-SURVEY-EVERY-PERMISSION-001 (FR-5).
+ *
+ * WHY THIS IS A TEMPLATE AND NOT A CAUTION. The constraint-ordering caution WAS written into the
+ * anchor SD at sourcing; the worker DID read it and restated it in his own words; and he hit the trap
+ * three times anyway. Prose is read once, at the start. An order-of-operations trap fires later,
+ * during execution. The two occupy different moments and comprehension does not bridge them — the
+ * remedy has to be PRESENT AT THE FAILING MOMENT, which a template is because you are writing inside
+ * it. That is the timing test for when guidance must become scaffolding: does the failure it prevents
+ * occur while you are READING, or later, inside a procedure?
+ *
+ * WHAT IT DEFENDS AGAINST, measured 2026-08-03 against public.feedback:
+ *   anon .insert().select()  -> 42501, row ABSENT   (looks refused)
+ *   anon .insert()  (no RETURNING, same row) -> error null, ROW LANDS   (is wide open)
+ * So an error code cannot prove refusal — and NEITHER CAN AN ABSENT ROW, because absence only
+ * discriminates when the write was attempted in the shape a REAL WRITER uses. A denied nonsense
+ * control returns the SAME SQLSTATE **and the same message string**, so message matching is unsound
+ * too. RLS WITH CHECK evaluates BEFORE NOT NULL, so column constraints do not mask the policy verdict.
+ *
+ * COMPOSES WITH, does not replace, scripts/db-validate/rls-validator.js — that reads pg_policies and
+ * checks policy SHAPE; this probes BEHAVIOUR. Shape and behaviour are different questions and this SD
+ * exists because the second one was being answered with the first one's evidence.
+ *
+ * @module lib/security/rls-probe-template
+ */
+
+/** Verdicts. OPEN and REFUSED are conclusions; INCONCLUSIVE is the honest default and never an alarm. */
+const VERDICT = Object.freeze({ OPEN: 'OPEN', REFUSED: 'REFUSED', INCONCLUSIVE: 'INCONCLUSIVE' });
+
+/** How leg 2 confirmed absence. Both are valid; SURVEY-1 found a live probe using deletion-count. */
+const CONFIRM = Object.freeze({ ABSENCE: 'absence-readback', DELETION_COUNT: 'deletion-count' });
+
+class ProbeTemplateError extends Error {}
+
+/**
+ * Build a probe plan. The NONSENSE CONTROL IS A REQUIRED SLOT — omitting it THROWS.
+ *
+ * It is a slot rather than a documented discipline on purpose: three layers of identical rejection
+ * look exactly like a working guard until something proves the probe can still discriminate, and
+ * nobody thinks to add that proof while staring at a rejection they already believe. A remembered
+ * control is absent exactly when the result is most convincing.
+ *
+ * @param {{table:string, validRow:object, fieldUnderTest:string, nonsenseControl:object,
+ *          command?:'INSERT'|'UPDATE', markerColumn?:string, confirmBy?:string}} spec
+ */
+function buildProbePlan(spec) {
+  const { table, validRow, fieldUnderTest, nonsenseControl, command = 'INSERT',
+    markerColumn = 'subject', confirmBy = CONFIRM.ABSENCE } = spec || {};
+  if (!table) throw new ProbeTemplateError('table is required');
+  if (!validRow || typeof validRow !== 'object') {
+    throw new ProbeTemplateError('validRow is required: construct an OTHERWISE-VALID row so every column constraint is satisfied, then vary ONLY the field under test. A row that trips NOT NULL or a CHECK tells you nothing about the policy.');
+  }
+  if (!fieldUnderTest) throw new ProbeTemplateError('fieldUnderTest is required — vary exactly one thing');
+  if (!nonsenseControl || typeof nonsenseControl !== 'object') {
+    throw new ProbeTemplateError('nonsenseControl is REQUIRED and must be a row expected to be genuinely DENIED. Without it a probe cannot demonstrate it is still capable of failing, and an always-refused reading is indistinguishable from a working guard.');
+  }
+  if (command !== 'INSERT' && command !== 'UPDATE') {
+    throw new ProbeTemplateError(`command must be INSERT or UPDATE (got ${command})`);
+  }
+  return Object.freeze({ table, validRow, fieldUnderTest, nonsenseControl, command, markerColumn, confirmBy });
+}
+
+/**
+ * PURE three-leg classifier. Same logic shipped and merged as the SURVEY-2 canary exemplar
+ * (lib/breakage/active-canary-probes.cjs classifyRlsProbe) — one representation of the rule, two
+ * consumers.
+ *
+ * @param {{withReturning?:{error?:object|null,data?:Array|null}|null,
+ *          readbackAfterReturning?:{rows?:Array|null, deleted?:number}|null,
+ *          bareInsert?:{error?:object|null}|null,
+ *          readbackAfterBare?:{rows?:Array|null, deleted?:number}|null,
+ *          confirmBy?:string}} evidence
+ */
+function classifyProbeEvidence(evidence) {
+  const e = evidence || {};
+  const wr = e.withReturning || {};
+  const code = (wr.error && (wr.error.code || '')) || '';
+  const confirmBy = e.confirmBy || CONFIRM.ABSENCE;
+
+  const present = (leg) => {
+    if (!leg) return false;
+    if (confirmBy === CONFIRM.DELETION_COUNT) return Number(leg.deleted || 0) > 0;
+    return Array.isArray(leg.rows) && leg.rows.length > 0;
+  };
+  const observed = (leg) => {
+    if (!leg) return false;
+    return confirmBy === CONFIRM.DELETION_COUNT
+      ? Object.prototype.hasOwnProperty.call(leg, 'deleted')
+      : Array.isArray(leg.rows);
+  };
+
+  // A row that exists after EITHER attempt means the write got through. Readback is the authority;
+  // RETURNING's data is only a hint and is absent by construction on a bare insert.
+  if (present(e.readbackAfterBare) || present(e.readbackAfterReturning) || (Array.isArray(wr.data) && wr.data.length > 0)) {
+    return {
+      verdict: VERDICT.OPEN,
+      reason: 'the write LANDED — a row is present on service-role confirmation, so the permission is NOT enforced for this shape',
+      detail: { landed_via: present(e.readbackAfterBare) ? 'bare-write' : 'with-returning', confirmBy },
+    };
+  }
+
+  // REFUSED requires leg 3. Absence after a RETURNING attempt alone is the FALSE ALL-CLEAR.
+  const bareAttempted = Object.prototype.hasOwnProperty.call(e, 'bareInsert') && observed(e.readbackAfterBare);
+  if (observed(e.readbackAfterReturning) && bareAttempted) {
+    return {
+      verdict: VERDICT.REFUSED,
+      reason: 'refused — absent after the RETURNING attempt AND after an identical write with NO RETURNING (three legs confirmed)',
+      detail: { legs: 3, code: code || null, confirmBy },
+    };
+  }
+  return {
+    verdict: VERDICT.INCONCLUSIVE,
+    reason: observed(e.readbackAfterReturning)
+      ? 'leg 3 missing — absence after a RETURNING attempt CANNOT distinguish refusal from a write that would land without RETURNING'
+      : 'no service-role confirmation — an error code alone proves only that the CALLER saw a failure',
+    detail: { legs: observed(e.readbackAfterReturning) ? 2 : 1, code: code || null, confirmBy },
+  };
+}
+
+/**
+ * Run a probe. `assertPrecondition` is REQUIRED for live runs and must THROW on fixture drift —
+ * never skip. A fixture that has drifted toward "everything is open" makes an always-OPEN template
+ * pass silently, which is the failure this whole SD is about, reproduced in the instrument.
+ *
+ * @param {{anon:object, service:object, plan:object, assertPrecondition:Function}} io
+ */
+async function runProbe({ anon, service, plan, assertPrecondition }) {
+  if (typeof assertPrecondition !== 'function') {
+    throw new ProbeTemplateError('assertPrecondition is REQUIRED and must throw on fixture drift — a probe whose fixture moved reports a verdict about a table that no longer exists as described');
+  }
+  await assertPrecondition();     // throws on drift; must never downgrade to a skip
+
+  const marker = plan.validRow[plan.markerColumn];
+  if (!marker) throw new ProbeTemplateError(`validRow must carry a unique value in markerColumn "${plan.markerColumn}" so the row can be found and removed`);
+
+  const confirm = async () => {
+    try {
+      const { data } = await service.from(plan.table).select('id').eq(plan.markerColumn, marker);
+      return { rows: Array.isArray(data) ? data : [] };
+    } catch { return null; }      // failed confirmation is ABSENT EVIDENCE, not evidence of absence
+  };
+
+  const evidence = { confirmBy: plan.confirmBy };
+  try { evidence.withReturning = await anon.from(plan.table).insert(plan.validRow).select('id'); }
+  catch (err) { evidence.withReturning = { error: { code: err.code, message: err.message }, data: null }; }
+  evidence.readbackAfterReturning = await confirm();
+
+  const looksRefused = evidence.readbackAfterReturning && evidence.readbackAfterReturning.rows.length === 0
+    && !(Array.isArray(evidence.withReturning.data) && evidence.withReturning.data.length > 0);
+  if (looksRefused) {
+    try { evidence.bareInsert = await anon.from(plan.table).insert(plan.validRow); }
+    catch (err) { evidence.bareInsert = { error: { code: err.code, message: err.message } }; }
+    evidence.readbackAfterBare = await confirm();
+  }
+
+  const result = classifyProbeEvidence(evidence);
+  try {
+    await service.from(plan.table).delete().eq(plan.markerColumn, marker);
+    const after = await confirm();
+    if (after && after.rows.length > 0) result.detail = { ...(result.detail || {}), cleanup_residue: after.rows.length, marker };
+  } catch { /* row is clearly marked for a human sweep */ }
+  return result;
+}
+
+module.exports = { VERDICT, CONFIRM, ProbeTemplateError, buildProbePlan, classifyProbeEvidence, runProbe };

--- a/tests/unit/security/rls-probe-template.test.js
+++ b/tests/unit/security/rls-probe-template.test.js
@@ -1,0 +1,166 @@
+// SELF-TEST for the canonical RLS probe template — SD-LEO-INFRA-SURVEY-EVERY-PERMISSION-001 FR-5 / TS-1,2,7.
+//
+// The point of this file is NOT that the template runs. It is that the template DISCRIMINATES: a
+// version that returned OPEN unconditionally, or REFUSED unconditionally, must FAIL here. Both arms
+// are asserted in the same scenario because a suite whose every arm expects the same verdict is
+// satisfied by a constant function — that exact vacuity was caught in this SD's own PRD draft.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const {
+  VERDICT, CONFIRM, ProbeTemplateError, buildProbePlan, classifyProbeEvidence, runProbe,
+} = require('../../../lib/security/rls-probe-template.cjs');
+
+const validRow = { subject: '__PROBE_MARKER__', source_type: 'auto_capture', feedback_type: 'user_bug', description: 'probe' };
+const nonsense = { subject: '__PROBE_MARKER__', source_type: 'auto_capture', feedback_type: 'sentry_error', description: 'control' };
+const plan = () => buildProbePlan({ table: 'feedback', validRow, fieldUnderTest: 'feedback_type', nonsenseControl: nonsense });
+
+// LAZY like the real supabase-js builder: the request fires on AWAIT, not at insert(). An eager fake
+// mutated state during .insert() and made the leg-2 readback see the bare row, misreporting WHICH leg
+// found it — a fake-fidelity bug that produced a confident wrong answer about ORDER.
+function fakeAnon({ landsWithReturning = false, landsOnBare = false, store = null }) {
+  return {
+    from: () => ({
+      insert: () => ({
+        then(resolve) {
+          if (landsOnBare && store) store.rows = [{ id: 'landed-bare' }];
+          return Promise.resolve(landsOnBare ? { error: null } : { error: { code: '42501' } }).then(resolve);
+        },
+        select() {
+          if (landsWithReturning && store) store.rows = [{ id: 'landed-ret' }];
+          return Promise.resolve(landsWithReturning
+            ? { data: [{ id: 'landed-ret' }], error: null }
+            : { data: null, error: { code: '42501', message: 'new row violates row-level security policy for table "feedback"' } });
+        },
+      }),
+    }),
+  };
+}
+function fakeService(store) {
+  return {
+    from: () => ({
+      select: () => ({ eq: () => Promise.resolve({ data: store.rows, error: null }) }),
+      delete: () => ({ eq: () => { store.rows = []; return Promise.resolve({ error: null }); } }),
+    }),
+  };
+}
+const ok = async () => {};
+
+describe('FR-5 — the nonsense control is a SLOT, not a discipline', () => {
+  it('THROWS when the control is omitted (a remembered control is absent when it matters most)', () => {
+    expect(() => buildProbePlan({ table: 'feedback', validRow, fieldUnderTest: 'feedback_type' }))
+      .toThrow(ProbeTemplateError);
+  });
+  it('THROWS without an otherwise-valid row — a constraint trip says nothing about the policy', () => {
+    expect(() => buildProbePlan({ table: 'feedback', fieldUnderTest: 'x', nonsenseControl: nonsense }))
+      .toThrow(/OTHERWISE-VALID/);
+  });
+  it('accepts a complete plan', () => {
+    expect(plan().nonsenseControl).toBeTruthy();
+  });
+});
+
+describe('FR-5 — the template DISCRIMINATES (both arms, one scenario)', () => {
+  it('OPEN when the bare write lands, REFUSED for the control — in the SAME run', async () => {
+    const openStore = { rows: [] };
+    const openVerdict = await runProbe({
+      anon: fakeAnon({ landsOnBare: true, store: openStore }),
+      service: fakeService(openStore), plan: plan(), assertPrecondition: ok,
+    });
+
+    const refusedStore = { rows: [] };
+    const refusedVerdict = await runProbe({
+      anon: fakeAnon({ landsOnBare: false, store: refusedStore }),
+      service: fakeService(refusedStore), plan: plan(), assertPrecondition: ok,
+    });
+
+    // A constant-OPEN template fails the second; a constant-REFUSED template fails the first.
+    expect(openVerdict.verdict).toBe(VERDICT.OPEN);
+    expect(openVerdict.detail.landed_via).toBe('bare-write');
+    expect(refusedVerdict.verdict).toBe(VERDICT.REFUSED);
+    expect(refusedVerdict.detail.legs).toBe(3);
+    expect(openVerdict.verdict).not.toBe(refusedVerdict.verdict);
+  });
+
+  it('OPEN when the RETURNING attempt itself succeeds', async () => {
+    const store = { rows: [] };
+    const v = await runProbe({
+      anon: fakeAnon({ landsWithReturning: true, store }),
+      service: fakeService(store), plan: plan(), assertPrecondition: ok,
+    });
+    expect(v.verdict).toBe(VERDICT.OPEN);
+    expect(v.detail.landed_via).toBe('with-returning');
+  });
+});
+
+describe('FR-5 — absence-readback ALONE is INCONCLUSIVE, never REFUSED', () => {
+  it('two legs is not enough — this is the false all-clear the SD was built on', () => {
+    const v = classifyProbeEvidence({
+      withReturning: { data: null, error: { code: '42501' } },
+      readbackAfterReturning: { rows: [] },
+    });
+    expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(v.detail.legs).toBe(2);
+  });
+  it('an error code with no confirmation at all is one leg', () => {
+    const v = classifyProbeEvidence({ withReturning: { data: null, error: { code: '42501' } } });
+    expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(v.detail.legs).toBe(1);
+  });
+  it('a failed readback is ABSENT EVIDENCE, not evidence of absence', () => {
+    const v = classifyProbeEvidence({
+      withReturning: { data: null, error: { code: '42501' } },
+      readbackAfterReturning: null,
+      bareInsert: { error: { code: '42501' } },
+      readbackAfterBare: null,
+    });
+    expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+  });
+});
+
+describe('FR-5 — deletion-count is a valid leg-2 variant (found live in SURVEY-1)', () => {
+  it('REFUSED when both legs deleted zero rows', () => {
+    const v = classifyProbeEvidence({
+      confirmBy: CONFIRM.DELETION_COUNT,
+      withReturning: { data: null, error: { code: '42501' } },
+      readbackAfterReturning: { deleted: 0 },
+      bareInsert: { error: { code: '42501' } },
+      readbackAfterBare: { deleted: 0 },
+    });
+    expect(v.verdict).toBe(VERDICT.REFUSED);
+  });
+  it('OPEN when a deletion removed a row that should never have existed', () => {
+    const v = classifyProbeEvidence({
+      confirmBy: CONFIRM.DELETION_COUNT,
+      withReturning: { data: null, error: { code: '42501' } },
+      readbackAfterReturning: { deleted: 0 },
+      bareInsert: { error: null },
+      readbackAfterBare: { deleted: 1 },
+    });
+    expect(v.verdict).toBe(VERDICT.OPEN);
+  });
+});
+
+describe('FR-5 / TS-7 — fixture drift HARD-ERRORS, never skips', () => {
+  it('refuses to run without a precondition assert', async () => {
+    const store = { rows: [] };
+    await expect(runProbe({ anon: fakeAnon({ store }), service: fakeService(store), plan: plan() }))
+      .rejects.toThrow(/assertPrecondition is REQUIRED/);
+  });
+  it('propagates a drift throw rather than degrading to a verdict', async () => {
+    const store = { rows: [] };
+    await expect(runProbe({
+      anon: fakeAnon({ store }), service: fakeService(store), plan: plan(),
+      assertPrecondition: async () => { throw new Error('policy set drifted: anon_feedback_ingress_bounds missing'); },
+    })).rejects.toThrow(/drifted/);
+  });
+});
+
+describe('FR-5 — never branch on message TEXT', () => {
+  // Measured: a genuinely-denied control returns the SAME code AND the same message string as the
+  // ambiguous case, so the template must decide on state and never on wording.
+  it('the template source contains no error-message branching', () => {
+    const src = require('node:fs').readFileSync(require.resolve('../../../lib/security/rls-probe-template.cjs'), 'utf8');
+    expect(src).not.toMatch(/error\.message\s*[.=~]|message\s*\.\s*(includes|match)/);
+  });
+});


### PR DESCRIPTION
## Why a template and not a caution

The caution **already existed**. It was written into the anchor SD at sourcing, the worker read it, restated it in his own words — and hit the trap **three times anyway**.

Prose is read once, at the start. An order-of-operations trap fires later, during execution. The two occupy different moments and comprehension does not bridge them. The remedy has to be *present at the failing moment*, which a template is because you are writing inside it.

## What it encodes — measured, not asserted

| attempt | result |
|---|---|
| anon `.insert().select()` on allow-INSERT / deny-read | **42501, row ABSENT** |
| the *identical row* via bare `.insert()` | **`error:null`, row LANDS** |

So an error code cannot prove refusal — **and neither can an absent row**, because absence only discriminates when the write was attempted in the shape a real writer uses. `REFUSED` requires three legs; two legs is `INCONCLUSIVE`, which is the false all-clear this SD was founded on.

## The nonsense control is a required slot

Omitting it **throws**. Not a documented discipline: three layers of identical rejection look exactly like a working guard, and nobody thinks to add a proof-of-discrimination while staring at a rejection they already believe. A remembered control is absent exactly when the result is most convincing.

## The self-test is mutation-proven

That's the only reason to trust it:

| mutant | result |
|---|---|
| always OPEN | **killed** — 6 failures |
| always REFUSED | **killed** — 6 failures |
| accept two legs as REFUSED *(the exact regression this SD prevents)* | **killed** — 1 failure |
| revert | 13/13 green |

Both verdict arms are asserted in the **same scenario**, because a suite whose every arm expects one verdict is satisfied by a constant function. That exact vacuity was caught in this SD's own PRD draft and would have shipped a template that always said OPEN.

## Also encoded

- **Fixture drift hard-errors** and can never degrade to a skip — `public.feedback` gained a RESTRICTIVE policy on 2026-08-02 and the anchor SD still has chairman-gated DDL pending. A drifted fixture makes an always-OPEN template pass silently.
- **Deletion-count** permitted as a leg-2 variant, found live during SURVEY-1.
- A **failed readback is absent evidence**, not evidence of absence.
- A static assertion forbids branching on `error.message` — a genuinely-denied control returns the same SQLSTATE *and the same message string* as the ambiguous case.

## Composition

Composes with, does not replace, `scripts/db-validate/rls-validator.js` — that reads `pg_policies` and checks policy **shape**; this probes **behaviour**. This SD exists because the second question kept being answered with the first one's evidence. The classifier is the same logic already merged as the SURVEY-2 canary exemplar: one representation, two consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)