### PR TITLE
fix(SD-LEO-INFRA-WRITER-SUB-AGENT-001): fence the verdict-mutation CLASS — the predecessor's defect was alive in two more files

### DIFF
--- a/.github/workflows/no-unfenced-verdict-mutation-lint.yml
+++ b/.github/workflows/no-unfenced-verdict-mutation-lint.yml
@@ -1,0 +1,85 @@
+name: Unfenced Verdict Mutation Lint
+
+# SD-LEO-INFRA-WRITER-SUB-AGENT-001 (FR-4 / FR-7)
+#
+# Fences the sub-agent EVIDENCE PATH: no writer may silently rewrite a caller's verdict between what
+# the sub-agent returned and what lands in sub_agent_execution_results.verdict. Mutations must route
+# through recordVerdictMutation() (lib/sub-agents/verdict-chain.js), which preserves the caller
+# verdict in metadata.verdict_chain and names the mutator and its reason.
+#
+# THIS WORKFLOW IS THE REQUIREMENT, NOT THE PLUMBING — and it exists because the class-guard this SD
+# was originally told to copy has NEVER INSPECTED A REAL FILE. eslint-rules/no-process-cwd-in-sub-agents.js
+# (SD-LEO-INFRA-FLEET-WIDE-SUB-001 FR-4) shipped with 82 passing unit tests and is unreachable four
+# ways: it is not registered in eslint.config.js; lib/sub-agents/.eslintrc.json is eslintrc format
+# which ESLint 9 ignores under flat config; `npx eslint --print-config` on a fenced file resolves
+# ZERO custom rules; and the escape-hatch pragmas already sitting in source report "Definition for
+# rule ... was not found". No driver, no workflow — and bare `npm run lint` is invoked by no CI
+# workflow at all, while .husky/pre-commit runs eslint with `|| true`.
+#
+# A correct rule that nothing runs is indistinguishable from no rule, and it ships GREEN. For an SD
+# about guards whose failure is silent, mirroring that would have been self-refuting. So the fence
+# is asserted here, in CI, on real files.
+#
+# BLOCKING FROM DAY ONE, and that is a MEASURED decision rather than nerve: the converted tree is
+# clean (443 files scanned, 0 findings), so unlike the mocked-SUT guard there is no pre-existing
+# backlog that day-one blocking would dump on unrelated PRs. Downgrade with
+# VERDICT_MUTATION_MODE=warn if that ever stops being true — but prefer fixing the finding.
+
+on:
+  pull_request:
+    paths:
+      - 'lib/sub-agents/**'
+      - 'lib/sub-agent-executor/**'
+      - 'scripts/modules/orchestrator/**'
+      - 'scripts/modules/phase-subagent-orchestrator/**'
+      - 'scripts/modules/handoff/**'
+      - 'eslint-rules/no-unfenced-verdict-mutation.js'
+      - 'scripts/lint/no-unfenced-verdict-mutation-lint.mjs'
+      - '.github/workflows/no-unfenced-verdict-mutation-lint.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  no-unfenced-verdict-mutation-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history so `git merge-base HEAD origin/main` resolves. A shallow clone makes the
+          # driver degrade to an --all sweep, which is louder but still correct.
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+
+      # REACHABILITY FIRST (FR-7). This step is the whole lesson of the inert precedent: prove the
+      # fence can FAIL before trusting a pass. It injects a mutator that appears in no enumeration,
+      # asserts the driver exits non-zero, then removes it. If this step ever succeeds when it
+      # should not, the guard has gone decorative and the next step's green means nothing.
+      - name: Prove the fence FIRES (inject an unenumerated mutator, expect exit 1)
+        run: |
+          cat > lib/sub-agents/_ci-fence-canary.js <<'CANARY'
+          export function unenumeratedMutator(results) {
+            if (results.verdict === 'FAIL') { results.verdict = 'PASS'; }
+            return results;
+          }
+          export function unenumeratedDefault(result) {
+            return { verdict: result.verdict || 'WARNING' };
+          }
+          CANARY
+          set +e
+          node scripts/lint/no-unfenced-verdict-mutation-lint.mjs --all
+          code=$?
+          set -e
+          rm -f lib/sub-agents/_ci-fence-canary.js
+          if [ "$code" -eq 0 ]; then
+            echo "::error::FENCE IS INERT — the driver passed a file containing two unfenced verdict mutators."
+            exit 1
+          fi
+          echo "Fence fired as expected (exit $code)."
+
+      - name: Enforce — no unfenced verdict mutation on the evidence path
+        run: node scripts/lint/no-unfenced-verdict-mutation-lint.mjs --all

--- a/.github/workflows/no-unfenced-verdict-mutation-lint.yml
+++ b/.github/workflows/no-unfenced-verdict-mutation-lint.yml
@@ -59,7 +59,7 @@ jobs:
       # fence can FAIL before trusting a pass. It injects a mutator that appears in no enumeration,
       # asserts the driver exits non-zero, then removes it. If this step ever succeeds when it
       # should not, the guard has gone decorative and the next step's green means nothing.
-      - name: Prove the fence FIRES (inject an unenumerated mutator, expect exit 1)
+      - name: Prove the fence FIRES — BOTH predicates, attributed to the canary file
         run: |
           cat > lib/sub-agents/_ci-fence-canary.js <<'CANARY'
           export function unenumeratedMutator(results) {
@@ -71,15 +71,29 @@ jobs:
           }
           CANARY
           set +e
-          node scripts/lint/no-unfenced-verdict-mutation-lint.mjs --all
-          code=$?
+          node scripts/lint/no-unfenced-verdict-mutation-lint.mjs --all --json > /tmp/fence-canary.json
           set -e
           rm -f lib/sub-agents/_ci-fence-canary.js
-          if [ "$code" -eq 0 ]; then
-            echo "::error::FENCE IS INERT — the driver passed a file containing two unfenced verdict mutators."
-            exit 1
-          fi
-          echo "Fence fired as expected (exit $code)."
+          # ASSERT PER PREDICATE, NOT ON THE EXIT CODE.
+          #
+          # The first version of this step asserted only `exit != 0`. A reviewer sabotaged Predicate A
+          # alone and the job went GREEN: the canary carries BOTH shapes, so a bare exit check is an
+          # OR — either predicate firing satisfies it, and half a dead fence passes. Worse, the
+          # driver also reports bare-disable findings from a plain regex that never invokes the
+          # ESLint rule at all, so a non-zero exit does not even prove the rule ran.
+          #
+          # Attribute both findings to the canary FILE and to their distinct messages. This is the
+          # whole reachability guarantee; a weaker assertion here makes the enforcing step's green
+          # meaningless, which is precisely the failure this SD exists to abolish.
+          node -e "
+            const r = require('/tmp/fence-canary.json');
+            const mine = r.findings.filter(f => f.filePath.endsWith('_ci-fence-canary.js'));
+            const rmw = mine.filter(f => /recordVerdictMutation/.test(f.message)).length;
+            const def = mine.filter(f => /silently promotes a missing verdict/.test(f.message)).length;
+            if (rmw < 1) { console.error('::error::PREDICATE A (read-modify-write) DID NOT FIRE — fence is half dead.'); process.exit(1); }
+            if (def < 1) { console.error('::error::PREDICATE B (object-literal default) DID NOT FIRE — fence is half dead.'); process.exit(1); }
+            console.log('Fence fired on BOTH predicates (' + rmw + ' + ' + def + ' findings in the canary).');
+          "
 
       - name: Enforce — no unfenced verdict mutation on the evidence path
         run: node scripts/lint/no-unfenced-verdict-mutation-lint.mjs --all

--- a/eslint-rules/no-unfenced-verdict-mutation.js
+++ b/eslint-rules/no-unfenced-verdict-mutation.js
@@ -1,0 +1,172 @@
+/**
+ * no-unfenced-verdict-mutation — SD-LEO-INFRA-WRITER-SUB-AGENT-001, FR-4 / FR-4a.
+ *
+ * THE DEFECT THIS EXISTS FOR. A completed CRITICAL SD fixed ONE verdict-mutating writer; the class
+ * survived its own fix, and the predecessor's literal `verdict: x || 'WARNING'` was still alive in
+ * two other files. An enumeration cannot prevent that recurrence — a list is evidence about where
+ * someone LOOKED, never about where writers CAN exist. So the acceptance for this rule is not
+ * "flags M1..Mn"; it is "flags a mutator that appears in no enumeration".
+ *
+ * WHY A LIST-SHAPED TEST WOULD HAVE BEEN THE SAME BUG ONE LAYER UP: asserting "none of the known
+ * mutators mutate" is a receipt for the list. It passes forever while writer #15 lands unfenced.
+ * That is the exact failure this SD documents, reproduced in its own anti-recurrence device.
+ *
+ * TWO PREDICATES, BECAUSE ONE SHAPE IS INVISIBLE TO THE OTHER — and the split is MEASURED, not
+ * guessed. Run over 98 files / 142 verdict assignments during PLAN:
+ *
+ *   P1 alone (a function RECEIVES `results` as a parameter and overwrites `.verdict`)
+ *       -> 14 flags, 12 of them FALSE POSITIVES (86%). Authors split across helper functions look
+ *          identical to mutators, because WHO CREATED THE OBJECT lives in the caller's file and a
+ *          single-file AST cannot see it.
+ *   P1 AND P2 (P2 = the enclosing conditional READS `.verdict`, i.e. read-modify-write)
+ *       -> exactly 2 flags, ZERO false positives: the two genuine in-place mutators.
+ *
+ * A rule with an 86% false-positive rate gets disabled within a week — which is how the previous
+ * class-guard in this repo died. So the conjunction is the rule, and the cost is stated openly
+ * below rather than hidden.
+ *
+ * PREDICATE B is separate and additive: `verdict: <expr> || <fallback>` as a Property inside an
+ * object literal. This is the predecessor's own defect shape and it is an ObjectExpression
+ * Property, not an AssignmentExpression — structurally invisible to any assignment-based predicate,
+ * no matter how good. Two shapes, two predicates.
+ *
+ * KNOWN-MISSED, RECORDED RATHER THAN IMPLIED (see also the driver's canary output):
+ *   - Spread-rebuild: `return { ...results, verdict: X }` builds a NEW object, so nothing is
+ *     "overwritten". Live and idiomatic in this tree (lib/fleet/spawn-control.js:1419).
+ *   - Helper-indirected mutation: `applyX(results)` where the overwrite happens a file away.
+ *   - Read-modify-write whose condition tests something OTHER than `.verdict` — P2 misses it by
+ *     construction. lib/sub-agents/performance.js:239 is a real instance.
+ * These are debt, not oversights. The driver prints them so the gap stays visible.
+ *
+ * ESCAPE HATCH: `// eslint-disable-next-line verdict-chain/no-unfenced-verdict-mutation -- <REASON>`
+ * The reason is MANDATORY and enforced by the driver, mirroring the `-- <REASON>` convention used
+ * by the other class-guards here. A bare disable is itself a finding: silent exemption is how a
+ * fence becomes decorative.
+ */
+
+const MESSAGE =
+  'Unfenced verdict mutation. Route it through recordVerdictMutation() in lib/sub-agents/verdict-chain.js ' +
+  'so the caller verdict survives in metadata.verdict_chain, or add an eslint-disable with a "-- <reason>".';
+
+const MESSAGE_DEFAULT =
+  'Unfenced verdict DEFAULT. `verdict: x || FALLBACK` silently promotes a missing verdict — this is the ' +
+  'literal defect SD-LEO-INFRA-SUBAGENT-VERDICT-LAUNDERED-001 fixed in one file and left in two others. ' +
+  'Pass the verdict through unmodified and let the canonical writer map it.';
+
+/** Is this node a `<obj>.verdict` member expression? */
+function isVerdictMember(node) {
+  return node
+    && node.type === 'MemberExpression'
+    && !node.computed
+    && node.property?.type === 'Identifier'
+    && node.property.name === 'verdict';
+}
+
+/** Does this subtree read `.verdict` anywhere? (P2's test) */
+function readsVerdict(node, depth = 0) {
+  if (!node || typeof node !== 'object' || depth > 12) return false;
+  if (isVerdictMember(node)) return true;
+  for (const key of Object.keys(node)) {
+    if (key === 'parent' || key === 'loc' || key === 'range') continue;
+    const child = node[key];
+    if (Array.isArray(child)) {
+      for (const c of child) if (readsVerdict(c, depth + 1)) return true;
+    } else if (child && typeof child.type === 'string') {
+      if (readsVerdict(child, depth + 1)) return true;
+    }
+  }
+  return false;
+}
+
+/** Names of the enclosing function's parameters — P1's test. */
+function enclosingParamNames(ancestors) {
+  const names = new Set();
+  for (const a of ancestors) {
+    if (a.type === 'FunctionDeclaration' || a.type === 'FunctionExpression' || a.type === 'ArrowFunctionExpression') {
+      for (const p of a.params || []) {
+        if (p.type === 'Identifier') names.add(p.name);
+        else if (p.type === 'AssignmentPattern' && p.left?.type === 'Identifier') names.add(p.left.name);
+      }
+    }
+  }
+  return names;
+}
+
+/** Nearest enclosing conditional, so P2 can inspect its test. */
+function enclosingConditionalTest(ancestors) {
+  for (let i = ancestors.length - 1; i >= 0; i--) {
+    const a = ancestors[i];
+    if (a.type === 'IfStatement' || a.type === 'ConditionalExpression') return a.test;
+  }
+  return null;
+}
+
+export default {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Verdict mutations in the sub-agent evidence path must be declared via recordVerdictMutation, ' +
+        'so the caller verdict is preserved and the mutator is attributed.'
+    },
+    schema: [],
+    messages: { unfenced: MESSAGE, unfencedDefault: MESSAGE_DEFAULT }
+  },
+
+  create(context) {
+    const filename = context.filename || context.getFilename?.() || '';
+    // The seam itself assigns results.verdict — that IS the fence, not a violation of it.
+    if (filename.replace(/\\/g, '/').endsWith('lib/sub-agents/verdict-chain.js')) return {};
+
+    return {
+      // PREDICATE A: read-modify-write on a parameter-received object (P1 AND P2).
+      AssignmentExpression(node) {
+        if (!isVerdictMember(node.left)) return;
+        const objectNode = node.left.object;
+        if (objectNode?.type !== 'Identifier') return;
+
+        const ancestors = context.sourceCode?.getAncestors?.(node) ?? context.getAncestors?.() ?? [];
+
+        // P1: the mutated object arrived as a parameter — an AUTHOR builds its own local object.
+        if (!enclosingParamNames(ancestors).has(objectNode.name)) return;
+
+        // P2: the enclosing conditional reads .verdict — the read-modify-write signature. Without
+        // this conjunct the rule is 86% false positives and gets switched off.
+        const test = enclosingConditionalTest(ancestors);
+        if (!test || !readsVerdict(test)) return;
+
+        context.report({ node, messageId: 'unfenced' });
+      },
+
+      // PREDICATE B: `verdict: <expr> || <fallback>` in an object literal. An ObjectExpression
+      // Property, invisible to Predicate A by construction — this is the shape that survived the
+      // predecessor SD in two files.
+      Property(node) {
+        if (node.computed) return;
+        const key = node.key;
+        const keyName = key?.type === 'Identifier' ? key.name : (key?.type === 'Literal' ? key.value : null);
+        if (keyName !== 'verdict') return;
+        const v = node.value;
+        if (v?.type !== 'LogicalExpression') return;
+        if (v.operator !== '||' && v.operator !== '??') return;
+
+        // ONLY a STRING-LITERAL fallback is laundering, and the distinction is the point rather
+        // than a convenience. `verdict: x ?? null` defaults to UNKNOWN — it preserves the absence,
+        // and the gate has explicit handling for a null verdict. `verdict: x || 'WARNING'`
+        // MANUFACTURES a value the caller never supplied, and WARNING happens to sit in the gate's
+        // ACCEPT set, so absence silently becomes approval. Same syntax, opposite meaning.
+        //
+        // Measured while building this rule: without this narrowing the predicate flagged
+        // scripts/modules/handoff/gates/subagent-evidence-gate.js:395
+        // (`verdict: latestByCode.get(norm(r))?.verdict ?? null`), a read-only display struct in the
+        // gate's own reporting. That is a false positive, and a rule that cries wolf on the gate it
+        // protects is a rule someone deletes.
+        const fallback = v.right;
+        const isStringLiteralFallback = fallback?.type === 'Literal' && typeof fallback.value === 'string';
+        if (!isStringLiteralFallback) return;
+
+        context.report({ node, messageId: 'unfencedDefault' });
+      }
+    };
+  }
+};

--- a/eslint-rules/no-unfenced-verdict-mutation.js
+++ b/eslint-rules/no-unfenced-verdict-mutation.js
@@ -53,13 +53,18 @@ const MESSAGE_DEFAULT =
   'literal defect SD-LEO-INFRA-SUBAGENT-VERDICT-LAUNDERED-001 fixed in one file and left in two others. ' +
   'Pass the verdict through unmodified and let the canonical writer map it.';
 
-/** Is this node a `<obj>.verdict` member expression? */
+/**
+ * Is this node a `<obj>.verdict` member expression?
+ *
+ * Computed access is included: `results['verdict'] = x` is the same write with different syntax,
+ * and excluding it left a one-character evasion.
+ */
 function isVerdictMember(node) {
-  return node
-    && node.type === 'MemberExpression'
-    && !node.computed
-    && node.property?.type === 'Identifier'
-    && node.property.name === 'verdict';
+  if (!node || node.type !== 'MemberExpression') return false;
+  if (!node.computed) {
+    return node.property?.type === 'Identifier' && node.property.name === 'verdict';
+  }
+  return node.property?.type === 'Literal' && node.property.value === 'verdict';
 }
 
 /** Does this subtree read `.verdict` anywhere? (P2's test) */
@@ -92,11 +97,19 @@ function enclosingParamNames(ancestors) {
   return names;
 }
 
-/** Nearest enclosing conditional, so P2 can inspect its test. */
+/**
+ * Nearest enclosing conditional, so P2 can inspect what it branches on.
+ *
+ * SwitchStatement is included and its DISCRIMINANT is the test — `switch (results.verdict) { case
+ * 'FAIL': results.verdict = 'PASS' }` is a read-modify-write in every sense that matters, and the
+ * first version of this rule walked only IfStatement/ConditionalExpression. A reviewer found the
+ * shape live at scripts/execute-subagent.js:186 and lib/.../result-aggregator.js:282 among others.
+ */
 function enclosingConditionalTest(ancestors) {
   for (let i = ancestors.length - 1; i >= 0; i--) {
     const a = ancestors[i];
     if (a.type === 'IfStatement' || a.type === 'ConditionalExpression') return a.test;
+    if (a.type === 'SwitchStatement') return a.discriminant;
   }
   return null;
 }
@@ -129,6 +142,29 @@ export default {
 
         // P1: the mutated object arrived as a parameter — an AUTHOR builds its own local object.
         if (!enclosingParamNames(ancestors).has(objectNode.name)) return;
+
+        // PREDICATE A-PRIME — THE STATEMENT-FORM DEFAULT, AND IT IS THE MOST IMPORTANT ONE HERE.
+        //   results.verdict = results.verdict || 'WARNING';
+        //   results.verdict ||= 'WARNING';
+        // This needs NO enclosing conditional, so P2 would never see it, and it is not an
+        // ObjectExpression Property, so Predicate B would never see it either. It is also the
+        // predecessor SD's literal defect one refactor away — and precisely the refactor an author
+        // performs when Predicate B blocks the object-literal form. A fence that teaches its own
+        // evasion is worse than no fence, because it converts a visible pattern into a hidden one.
+        // Flagged regardless of P2: a string-literal fallback on a verdict IS the laundering
+        // signature, exactly as in Predicate B (`?? null` stays absent; `|| 'WARNING'` manufactures).
+        const rhs = node.right;
+        const isLogicalDefault =
+          (node.operator === '||=' || node.operator === '??=')
+            ? (rhs?.type === 'Literal' && typeof rhs.value === 'string')
+            : (rhs?.type === 'LogicalExpression'
+                && (rhs.operator === '||' || rhs.operator === '??')
+                && rhs.right?.type === 'Literal'
+                && typeof rhs.right.value === 'string');
+        if (isLogicalDefault) {
+          context.report({ node, messageId: 'unfencedDefault' });
+          return;
+        }
 
         // P2: the enclosing conditional reads .verdict — the read-modify-write signature. Without
         // this conjunct the rule is 86% false positives and gets switched off.

--- a/lib/sub-agent-executor/results-storage.js
+++ b/lib/sub-agent-executor/results-storage.js
@@ -409,14 +409,42 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
   // This prevents recursive snowballing where previous sub-agent results are nested
   const safeMetadata = (() => {
     if (!results.metadata) return {};
-    const { findings, sub_agent_results: _sub_agent_results, ...rest } = results.metadata;
+    // SD-LEO-INFRA-WRITER-SUB-AGENT-001 / FR-3a: verdict_chain is EXCLUDED from the caller-supplied
+    // spread and re-attached below from the value this writer actually observed.
+    //
+    // WHY, and it is the same defect one field over. Moving original_verdict after the spread stopped
+    // a caller CLOBBERING it — but originalVerdictFor() derives from verdict_chain[0].from, and
+    // verdict_chain arrived through this very spread. So a caller could PRE-SEED a fake head; because
+    // recordVerdictMutation APPENDS, the fake survives a subsequent genuine mutation and stays at
+    // index [0]. Confirmed by two independent reviewers driving the real storage path: a caller that
+    // genuinely returns PASS, seeding [{from:'CONDITIONAL_PASS'}], produces a stored row reading
+    // CONDITIONAL_PASS/CONDITIONAL_PASS — byte-identical to the 91-row population this SD exists to
+    // eliminate. The fix had relocated the lie rather than removed it, and this file's own comment
+    // convicts it: "a field that records what the caller claimed, and that the caller can write,
+    // records nothing."
+    const {
+      findings,
+      sub_agent_results: _sub_agent_results,
+      verdict_chain: _callerSuppliedChain,
+      ...rest
+    } = results.metadata;
     // If findings exists in metadata, only keep a summary
     if (findings) {
       rest._findings_stripped = true;
       rest._findings_had_keys = Object.keys(findings);
     }
+    // Record the attempt rather than dropping it silently — a caller sending a chain is either a bug
+    // or a forgery, and both are worth seeing. (Absence of this key is the normal case.)
+    if (_callerSuppliedChain !== undefined) rest._verdict_chain_from_caller_ignored = true;
     return rest;
   })();
+
+  // The chain THIS PROCESS built, captured before the spread can influence it. Mutators call
+  // recordVerdictMutation, which writes to results.metadata.verdict_chain in-process; that is the
+  // value we trust. A chain that arrived on the caller's metadata is not evidence about this run.
+  const observedVerdictChain = Array.isArray(results?.metadata?.verdict_chain)
+    ? results.metadata.verdict_chain
+    : null;
 
   // SD-LEO-PROTOCOL-INFRASTRUCTURE-RELATIONSHIPAWARE-ORCH-001-C:
   //   resolve phase from options (canonical), results.phase, or incoming
@@ -506,7 +534,10 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
     // evidence path, captured BEFORE any in-place mutator ran. results.verdict at this point is
     // whatever the LAST mutator left behind — see verdict-chain.js for why that distinction is the
     // whole point of this SD.
-    original_verdict: originalVerdictFor(results)
+    original_verdict: originalVerdictFor(results),
+    // Re-attached from the value THIS PROCESS observed, after the caller's copy was excluded from
+    // the spread above. Only present when a mutation actually occurred.
+    ...(observedVerdictChain ? { verdict_chain: observedVerdictChain } : {})
   };
 
   // Compress large detailed_analysis to artifact (>8KB threshold)

--- a/lib/sub-agent-executor/results-storage.js
+++ b/lib/sub-agent-executor/results-storage.js
@@ -33,8 +33,16 @@ import { normalizePhaseToken } from './phase-token.js';
  * Exported so tests and audit queries share ONE literal: a query hunting for absent
  * verdicts by hard-coding the string would drift the moment this changed, and the whole
  * point of the sentinel is that absence stays queryable.
+ *
+ * SD-LEO-INFRA-WRITER-SUB-AGENT-001: the literal now LIVES in lib/sub-agents/verdict-chain.js,
+ * which needs it to build chain entries and sits upstream of this writer. Re-exported here rather
+ * than redeclared so the "ONE literal" guarantee above survives — importing it from either path
+ * yields the same value, and existing importers (tests/unit/subagent-verdict-absent-writer.test.js,
+ * tests/unit/subagent-verdict-laundering.test.js) are untouched. A second `const` would have been
+ * the same duplication-at-a-distance defect this SD is about.
  */
-export const ABSENT_VERDICT = '(absent)';
+export { ABSENT_VERDICT } from '../sub-agents/verdict-chain.js';
+import { ABSENT_VERDICT, originalVerdictFor } from '../sub-agents/verdict-chain.js';
 
 /**
  * SD-LEO-INFRA-SUBAGENT-VERDICT-LAUNDERED-001.
@@ -463,9 +471,6 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
     // not academic: it produced a "45% of the table is unauditable" reading during this
     // SD's own investigation, which was wrong by ~12,400 rows. The sentinel makes
     // "the agent returned nothing" a queryable fact rather than an inference from silence.
-    original_verdict: (results.verdict === undefined || results.verdict === null)
-      ? ABSENT_VERDICT
-      : results.verdict,
     options: results.options || {},
     findings: results.findings || [],
     metrics: results.metrics || {},
@@ -477,7 +482,31 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
     // Dual-write during burn-in (SD-LEO-PROTOCOL-INFRASTRUCTURE-
     // RELATIONSHIPAWARE-ORCH-001-C).  If phaseValue is null we keep any
     // metadata.phase that arrived via safeMetadata spread unchanged.
-    ...(phaseValue ? { phase: phaseValue } : {})
+    ...(phaseValue ? { phase: phaseValue } : {}),
+
+    // ORIGINAL_VERDICT IS SET *AFTER* THE SPREAD, DELIBERATELY —
+    // SD-LEO-INFRA-WRITER-SUB-AGENT-001 / FR-3a.
+    //
+    // It used to be declared above `...safeMetadata`, which made the writer's own audit anchor
+    // OVERRIDABLE BY THE PARTY IT AUDITS: any caller supplying `results.metadata.original_verdict`
+    // silently clobbered the snapshot. Not theoretical — 8 live rows carry verdict='PASS' with
+    // original_verdict='CONDITIONAL_PASS', an UPGRADE direction mapVerdict cannot produce, 5 of
+    // them within 30 days. A field that records what the caller claimed, and that the caller can
+    // write, records nothing.
+    //
+    // Preserved from SD-LEO-INFRA-SUBAGENT-VERDICT-LAUNDERED-001: ALWAYS a string, never an omitted
+    // key. When results.verdict is undefined the JSON serialiser drops the field entirely, and a
+    // MISSING key is indistinguishable from a row written by one of the paths that never touch this
+    // writer (source=manual / validation-agent / vision-fidelity-sub-agent). That ambiguity is not
+    // academic: it produced a "45% of the table is unauditable" reading during that SD's own
+    // investigation, wrong by ~12,400 rows. The sentinel makes "the agent returned nothing" a
+    // queryable fact rather than an inference from silence.
+    //
+    // PREFER THE CHAIN when one exists: verdict_chain[0].from is the verdict as it entered the
+    // evidence path, captured BEFORE any in-place mutator ran. results.verdict at this point is
+    // whatever the LAST mutator left behind — see verdict-chain.js for why that distinction is the
+    // whole point of this SD.
+    original_verdict: originalVerdictFor(results)
   };
 
   // Compress large detailed_analysis to artifact (>8KB threshold)

--- a/lib/sub-agents/design/index.js
+++ b/lib/sub-agents/design/index.js
@@ -28,6 +28,8 @@ import fs from 'fs';
 import { fileURLToPath } from 'url';
 import { execSync } from 'child_process';
 import dotenv from 'dotenv';
+// SD-LEO-INFRA-WRITER-SUB-AGENT-001 / FR-3: the declared mutation seam.
+import { recordVerdictMutation } from '../verdict-chain.js';
 import { createSupabaseServiceClient } from '../../../scripts/lib/supabase-connection.js';
 
 // Import modular components
@@ -90,8 +92,16 @@ export function applyRepoResolutionVerdict(results, resolution) {
     repo_resolved: resolution.repoResolved,
     components_dir_exists: resolution.componentsDirExists
   };
+  // SD-LEO-INFRA-WRITER-SUB-AGENT-001 / FR-3: routed through the declared mutation seam so the
+  // caller's PASS survives into metadata.verdict_chain. Same shape as resolve-repo's degrade and
+  // the same reason it is KEPT rather than removed — a DESIGN scan of an unresolved or empty tree
+  // finds zero violations, so that PASS is vacuous. Degrade-direction mutators are made explicit,
+  // never deleted: a DB trigger completes deliverables only on verdict='PASS'.
   if ((!resolution.repoResolved || !resolution.componentsDirExists) && results.verdict === 'PASS') {
-    results.verdict = 'CONDITIONAL_PASS';
+    recordVerdictMutation(results, 'CONDITIONAL_PASS', {
+      mutator: 'lib/sub-agents/design/index.js:applyRepoResolutionVerdict',
+      reason: `DESIGN scanned an unresolved or empty repo (repo_resolved=${resolution.repoResolved}, components_dir_exists=${resolution.componentsDirExists})`,
+    });
     if (results.confidence > 60) results.confidence = 60;
     results.warnings.push({
       severity: 'HIGH',

--- a/lib/sub-agents/resolve-repo.js
+++ b/lib/sub-agents/resolve-repo.js
@@ -36,6 +36,9 @@ import {
   getRepoRoot,
   stripWorktreeSuffix,
 } from '../repo-paths.js';
+// SD-LEO-INFRA-WRITER-SUB-AGENT-001 / FR-3: the declared mutation seam. Every verdict rewrite in
+// this file goes through it so the caller's verdict survives into metadata.verdict_chain.
+import { recordVerdictMutation } from './verdict-chain.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -236,10 +239,23 @@ export function applySubAgentRepoVerdict(results, resolution, opts = {}) {
 
   if (skipVerdictAdjust) return results;
 
-  // Fail-closed: PASS on unresolved/empty tree → CONDITIONAL_PASS
+  // Fail-closed: PASS on unresolved/empty tree → CONDITIONAL_PASS.
+  //
+  // SD-LEO-INFRA-WRITER-SUB-AGENT-001 / FR-3: routed through recordVerdictMutation so the caller's
+  // PASS SURVIVES. This assignment used to be a bare `results.verdict = 'CONDITIONAL_PASS'`, and
+  // because it mutates the object IN PLACE *upstream* of storeSubAgentResults, the writer's
+  // metadata.original_verdict recorded THIS function's output rather than the sub-agent's input.
+  // Measured before the fix: 91 live rows with verdict='CONDITIONAL_PASS' AND
+  // original_verdict='CONDITIONAL_PASS' AND (repo_resolved=false OR probe_exists=false) — zero
+  // recorded divergence, so an M2-degraded PASS was indistinguishable from a sub-agent that
+  // genuinely returned CONDITIONAL_PASS. The degradation itself is CORRECT and stays: an empty or
+  // wrong tree yields zero violations, and that PASS is vacuous. This makes it auditable, not gone.
   const probeFailed = resolution.probeExists === false;
   if ((!resolution.repoResolved || probeFailed) && results.verdict === 'PASS' && !resolution.skipReason) {
-    results.verdict = 'CONDITIONAL_PASS';
+    recordVerdictMutation(results, 'CONDITIONAL_PASS', {
+      mutator: 'lib/sub-agents/resolve-repo.js:applySubAgentRepoVerdict',
+      reason: `repo unresolved or probe missing (repo_resolved=${resolution.repoResolved}, probe_exists=${resolution.probeExists ?? 'not-checked'}) — a scan of an empty/wrong tree cannot pass as green`,
+    });
     if (results.confidence > 60) results.confidence = 60;
     if (!results.warnings) results.warnings = [];
     results.warnings.push({

--- a/lib/sub-agents/verdict-chain.js
+++ b/lib/sub-agents/verdict-chain.js
@@ -1,0 +1,111 @@
+/**
+ * VERDICT CHAIN — the declared mutation seam for the sub-agent evidence path.
+ * SD-LEO-INFRA-WRITER-SUB-AGENT-001, FR-3.
+ *
+ * WHY THIS FILE EXISTS. A completed CRITICAL SD
+ * (SD-LEO-INFRA-SUBAGENT-VERDICT-LAUNDERED-001) fixed ONE verdict-mutating writer, and the class
+ * survived its own fix. Its scope field says so outright — "SCOPE IS ROWS FROM THIS WRITER, NOT THE
+ * WHOLE TABLE" — so a second mutator passes every criterion it shipped, untouched. The FR-1
+ * enumeration then found 14 in-process mutators, including the predecessor's LITERAL defect
+ * (`verdict: result.verdict || 'WARNING'`) alive and unfixed in two more files.
+ *
+ * THE STRUCTURAL PROBLEM, which is not "N bad defaults": `verdict` is a plain property that any
+ * function holding the results object may overwrite, and the audit snapshot was taken at STORAGE
+ * time — i.e. DOWNSTREAM of mutation. So `metadata.original_verdict` recorded the last mutator's
+ * output rather than the caller's input. Measured: 91 live rows carry verdict='CONDITIONAL_PASS'
+ * AND original_verdict='CONDITIONAL_PASS' AND (repo_resolved=false OR probe_exists=false) — zero
+ * recorded divergence, because the mutation happened before the field that was supposed to witness
+ * it. The predecessor's criterion "the original verdict is recorded for EVERY row this writer
+ * produces" passes on those rows WHILE RECORDING A FALSEHOOD.
+ *
+ * WHAT THIS FIXES, AND WHAT IT DELIBERATELY DOES NOT. This module does not stop mutation — several
+ * mutators are correct and must stay. lib/sub-agents/resolve-repo.js degrades a PASS to
+ * CONDITIONAL_PASS when the repo could not be resolved, because a sub-agent that scanned an empty
+ * tree found zero violations and its PASS is VACUOUS. Removing that would not just re-open a
+ * reporting hole: a DB trigger completes deliverables only on verdict='PASS', so it would start
+ * auto-completing deliverables off checks that never executed. What this module does is make every
+ * such mutation DECLARED, ATTRIBUTED and ORDERED, so the caller's verdict survives and the audit
+ * field stops lying.
+ *
+ * DIRECTION IS THE DISCRIMINATOR THE ORIGINAL FRAMING MISSED. The predecessor's defect was
+ * UPGRADE-direction (rejections rewritten toward acceptance, defeating a gate). resolve-repo's is
+ * DEGRADE-direction and fail-closed. Same class structurally, opposite hazard semantically — which
+ * is exactly why fixing one by name could never have caught the other, and why a
+ * legitimate-vs-illegitimate binary mis-sorts them. Upgrade-direction mutators are removed;
+ * degrade-direction ones come through here.
+ */
+
+/** The 8 values sub_agent_execution_results.verdict accepts (CHECK valid_verdict). */
+export const VERDICT_VALUES = Object.freeze([
+  'PASS', 'FAIL', 'BLOCKED', 'CONDITIONAL_PASS',
+  'WARNING', 'MANUAL_REQUIRED', 'PENDING', 'ERROR'
+]);
+
+/** Sentinel mirroring results-storage.js — "the agent returned nothing" as a queryable fact. */
+export const ABSENT_VERDICT = '(absent)';
+
+/**
+ * Record a verdict mutation and apply it.
+ *
+ * APPEND-ONLY AND ORDERED: entry [0] is the verdict as it ENTERED the evidence path. That ordering
+ * is the whole contract — it is what lets `original_verdict` be derived from something captured
+ * upstream of every mutator rather than downstream of all of them.
+ *
+ * @param {object} results - the sub-agent results object (mutated in place, as callers expect)
+ * @param {string} newVerdict - the verdict to apply
+ * @param {object} opts
+ * @param {string} opts.mutator - REQUIRED. Module path + symbol, e.g.
+ *   'lib/sub-agents/resolve-repo.js:applySubAgentRepoVerdict'. Required and unvalidated-against-a-list
+ *   deliberately: an anonymous mutation is the thing this SD exists to abolish, but hard-coding the
+ *   permitted set here would rebuild the receipt-for-a-list defect one layer down.
+ * @param {string} opts.reason - REQUIRED. Why, in terms a gate reader can act on.
+ * @returns {object} the same results object
+ */
+export function recordVerdictMutation(results, newVerdict, opts = {}) {
+  if (!results || typeof results !== 'object') {
+    throw new TypeError('recordVerdictMutation: results must be an object');
+  }
+  const mutator = typeof opts.mutator === 'string' ? opts.mutator.trim() : '';
+  const reason = typeof opts.reason === 'string' ? opts.reason.trim() : '';
+  if (!mutator) throw new TypeError('recordVerdictMutation: opts.mutator is REQUIRED — an anonymous mutation is the defect');
+  if (!reason) throw new TypeError('recordVerdictMutation: opts.reason is REQUIRED — a mutation nobody can explain is not explicit');
+  if (!VERDICT_VALUES.includes(newVerdict)) {
+    throw new TypeError(
+      `recordVerdictMutation: '${newVerdict}' is not one of ${VERDICT_VALUES.join(', ')}. ` +
+      'An out-of-enum verdict is rejected by the CHECK constraint and the row never lands — ' +
+      'which the evidence gate reads as ABSENT evidence, i.e. acceptance. Fail here, loudly, instead.'
+    );
+  }
+
+  if (!results.metadata || typeof results.metadata !== 'object') results.metadata = {};
+  if (!Array.isArray(results.metadata.verdict_chain)) results.metadata.verdict_chain = [];
+
+  const from = (results.verdict === undefined || results.verdict === null)
+    ? ABSENT_VERDICT
+    : String(results.verdict);
+
+  results.metadata.verdict_chain.push({ from, to: newVerdict, mutator, reason });
+  results.verdict = newVerdict;
+  return results;
+}
+
+/**
+ * The verdict as it ENTERED the path — what `original_verdict` is supposed to mean.
+ *
+ * Falls back to the current verdict when no chain exists, so rows produced with no mutation are
+ * byte-identical to today's. That fallback is also why this is safe to land before every mutator is
+ * converted: an unconverted mutator simply reproduces the OLD (wrong) value rather than throwing,
+ * and the fence in FR-4 is what stops new ones from being added unconverted.
+ *
+ * @param {object} results
+ * @returns {string}
+ */
+export function originalVerdictFor(results) {
+  const chain = results?.metadata?.verdict_chain;
+  if (Array.isArray(chain) && chain.length > 0 && typeof chain[0]?.from === 'string') {
+    return chain[0].from;
+  }
+  return (results?.verdict === undefined || results?.verdict === null)
+    ? ABSENT_VERDICT
+    : String(results.verdict);
+}

--- a/lib/sub-agents/verdict-chain.js
+++ b/lib/sub-agents/verdict-chain.js
@@ -78,15 +78,51 @@ export function recordVerdictMutation(results, newVerdict, opts = {}) {
   }
 
   if (!results.metadata || typeof results.metadata !== 'object') results.metadata = {};
-  if (!Array.isArray(results.metadata.verdict_chain)) results.metadata.verdict_chain = [];
 
   const from = (results.verdict === undefined || results.verdict === null)
     ? ABSENT_VERDICT
     : String(results.verdict);
 
+  // CONTINUITY IS WHAT MAKES THE CHAIN EVIDENCE RATHER THAN A CLAIM.
+  //
+  // The first version simply appended to whatever `verdict_chain` was already on results.metadata —
+  // and that metadata comes from the CALLER. Two independent reviewers drove the real storage path
+  // and defeated it the same way: pre-seed `[{from:'CONDITIONAL_PASS'}]`, let a genuine mutation
+  // append at index 1, and `chain[0].from` reports the forged head forever. A caller returning PASS
+  // could make the stored row read CONDITIONAL_PASS/CONDITIONAL_PASS — byte-identical to the 91-row
+  // population this SD exists to eliminate. The audit anchor had MOVED, not hardened, and this
+  // module's own docblock convicted it.
+  //
+  // A genuine chain LINKS: each entry's `to` is the next entry's `from`, and the last `to` is the
+  // verdict currently on the object. A pre-seeded head cannot satisfy that without already knowing
+  // the run's real verdict — and if it does know it, it is not lying about it. So a chain that fails
+  // to link is not this run's chain, and is DISCARDED rather than extended. That preserves the real
+  // caller verdict (the discarded head is replaced by a fresh entry whose `from` is the live value)
+  // instead of merely refusing to record.
+  const existing = results.metadata.verdict_chain;
+  results.metadata.verdict_chain = chainLinksTo(existing, from) ? existing : [];
+
   results.metadata.verdict_chain.push({ from, to: newVerdict, mutator, reason });
   results.verdict = newVerdict;
   return results;
+}
+
+/**
+ * Is `chain` a well-formed, continuous chain terminating at `currentVerdict`?
+ *
+ * An empty/absent chain is NOT continuous — there is nothing to extend, so a caller gets a fresh
+ * one. Anything else must be an array of {from,to} entries where each `to` equals the next `from`,
+ * and the final `to` equals the verdict on the object right now.
+ */
+function chainLinksTo(chain, currentVerdict) {
+  if (!Array.isArray(chain) || chain.length === 0) return false;
+  for (let i = 0; i < chain.length; i++) {
+    const e = chain[i];
+    if (!e || typeof e.from !== 'string' || typeof e.to !== 'string') return false;
+    const nextFrom = i + 1 < chain.length ? chain[i + 1]?.from : currentVerdict;
+    if (e.to !== nextFrom) return false;
+  }
+  return true;
 }
 
 /**
@@ -101,11 +137,16 @@ export function recordVerdictMutation(results, newVerdict, opts = {}) {
  * @returns {string}
  */
 export function originalVerdictFor(results) {
-  const chain = results?.metadata?.verdict_chain;
-  if (Array.isArray(chain) && chain.length > 0 && typeof chain[0]?.from === 'string') {
-    return chain[0].from;
-  }
-  return (results?.verdict === undefined || results?.verdict === null)
+  const current = (results?.verdict === undefined || results?.verdict === null)
     ? ABSENT_VERDICT
     : String(results.verdict);
+
+  // TRUST THE CHAIN ONLY IF IT LINKS ALL THE WAY TO THE VERDICT ON THE OBJECT. A chain that does not
+  // terminate at `current` was not produced by this run's mutations — it is stale, hand-assembled, or
+  // forged — and reading `chain[0].from` off it is exactly how the pre-seeding attack reported a
+  // verdict the caller never returned. Falling back to `current` is the SAFE direction: it reports
+  // the verdict actually being stored rather than an unverifiable claim about an earlier one.
+  const chain = results?.metadata?.verdict_chain;
+  if (chainLinksTo(chain, current)) return chain[0].from;
+  return current;
 }

--- a/scripts/lint/no-unfenced-verdict-mutation-lint.mjs
+++ b/scripts/lint/no-unfenced-verdict-mutation-lint.mjs
@@ -1,0 +1,175 @@
+#!/usr/bin/env node
+/**
+ * Driver for eslint-rules/no-unfenced-verdict-mutation.js — SD-LEO-INFRA-WRITER-SUB-AGENT-001 (FR-4/FR-7).
+ *
+ * THIS FILE IS THE REQUIREMENT, NOT PLUMBING. The class-guard this SD originally intended to copy
+ * (eslint-rules/no-process-cwd-in-sub-agents.js, from SD-LEO-INFRA-FLEET-WIDE-SUB-001 FR-4) shipped
+ * with 82 passing unit tests and HAS NEVER INSPECTED A REAL FILE. Verified four ways during PLAN:
+ *   1. `npx eslint --print-config lib/sub-agents/resolve-repo.js` resolves 8 rules, ZERO custom.
+ *   2. eslint.config.js registers exactly one local plugin, and it is not that one.
+ *   3. lib/sub-agents/.eslintrc.json is eslintrc format, which ESLint 9 IGNORES under flat config —
+ *      its own `_comment` claiming it activates the rule is simply false.
+ *   4. Linting the tree reports "Definition for rule ... was not found" at the two source sites that
+ *      already carry escape-hatch pragmas: the pragmas are DANGLING.
+ * No driver, no workflow, no package script; bare `npm run lint` runs in no workflow and
+ * .husky/pre-commit invokes eslint with `|| true`.
+ *
+ * A correct rule that nothing runs is indistinguishable from no rule, and it ships GREEN. That is
+ * the same shape as the defect this SD fixes — a guard whose failure is silent — so reachability is
+ * asserted here rather than assumed. Shape copied from scripts/lint/no-mocked-sut-import-lint.mjs,
+ * which is one of 18 lint drivers in this repo that DO reach the tree.
+ *
+ * MODE: blocking by default over a MEASURED-CLEAN scope. Unlike the mocked-SUT driver (which found
+ * a 334-file backlog and had to ship warn-only), the converted tree is clean, so there is no backlog
+ * to burn down and no reason to default to advisory. Set VERDICT_MUTATION_MODE=warn to downgrade.
+ *
+ * Usage:
+ *   node scripts/lint/no-unfenced-verdict-mutation-lint.mjs            # changed files
+ *   node scripts/lint/no-unfenced-verdict-mutation-lint.mjs --all      # full sweep
+ *   node scripts/lint/no-unfenced-verdict-mutation-lint.mjs --all --json
+ */
+
+import { Linter } from 'eslint';
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import rule from '../../eslint-rules/no-unfenced-verdict-mutation.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+/** The evidence path. Scoped deliberately: a repo-wide sweep would flag unrelated `verdict` fields. */
+const SCAN_DIRS = ['lib/sub-agents', 'lib/sub-agent-executor', 'scripts/modules/orchestrator',
+  'scripts/modules/phase-subagent-orchestrator', 'scripts/modules/handoff'];
+const EXCLUDE_DIR_SEGMENTS = ['node_modules', '.git', '.worktrees', 'dist', 'build', 'coverage', 'archived'];
+const SOURCE_FILE_RE = /\.[cm]?js$/i;
+
+const RULE_ID = 'verdict-chain/no-unfenced-verdict-mutation';
+
+/** Shapes the predicate knowingly does NOT catch. Printed every run so the gap stays visible. */
+const KNOWN_MISSED = [
+  'spread-rebuild: `return { ...results, verdict: X }` creates a new object, so nothing is overwritten (live at lib/fleet/spawn-control.js:1419)',
+  'helper-indirected: `applyX(results)` where the overwrite happens in another file — single-file AST cannot follow it',
+  'read-modify-write whose condition tests something OTHER than .verdict (e.g. lib/sub-agents/performance.js:239)'
+];
+
+const FLAT_CONFIG = {
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: 'module',
+    globals: {
+      console: 'readonly', process: 'readonly', require: 'readonly', module: 'readonly',
+      exports: 'readonly', __dirname: 'readonly', __filename: 'readonly', Buffer: 'readonly',
+      setTimeout: 'readonly', setInterval: 'readonly', clearTimeout: 'readonly', clearInterval: 'readonly',
+    },
+  },
+  plugins: { 'verdict-chain': { rules: { 'no-unfenced-verdict-mutation': rule } } },
+  rules: { [RULE_ID]: 'error' },
+};
+
+function walk(dir, out) {
+  let entries;
+  try { entries = fs.readdirSync(dir, { withFileTypes: true }); } catch { return out; }
+  for (const e of entries) {
+    if (EXCLUDE_DIR_SEGMENTS.includes(e.name)) continue;
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) walk(full, out);
+    else if (SOURCE_FILE_RE.test(e.name)) out.push(full);
+  }
+  return out;
+}
+
+function candidateFilesAll(root) {
+  const out = [];
+  for (const d of SCAN_DIRS) walk(path.join(root, d), out);
+  return out;
+}
+
+function candidateFilesDiff(root) {
+  // execFileSync, not execSync: no shell features are needed, so no shell is involved.
+  const base = execFileSync('git', ['merge-base', 'HEAD', 'origin/main'], { cwd: root, encoding: 'utf8' }).trim();
+  const names = execFileSync('git', ['diff', '--name-only', `${base}...HEAD`], { cwd: root, encoding: 'utf8' })
+    .split('\n').map((s) => s.trim()).filter(Boolean);
+  return names
+    .filter((n) => SOURCE_FILE_RE.test(n) && SCAN_DIRS.some((d) => n.startsWith(`${d}/`)))
+    .map((n) => path.join(root, n))
+    .filter((p) => fs.existsSync(p));
+}
+
+/**
+ * A disable comment without a `-- <reason>` is itself a finding. Silent exemption is how a fence
+ * becomes decorative, which is the failure mode this whole SD is about.
+ */
+function bareDisables(code, relPath) {
+  const out = [];
+  const lines = code.split('\n');
+  lines.forEach((line, i) => {
+    if (!line.includes('no-unfenced-verdict-mutation')) return;
+    if (!/eslint-disable/.test(line)) return;
+    if (!/--\s*\S/.test(line)) {
+      out.push({ filePath: relPath, line: i + 1, column: 1, message: 'eslint-disable for no-unfenced-verdict-mutation without a "-- <reason>". The reason is mandatory.' });
+    }
+  });
+  return out;
+}
+
+function lintFile(linter, filePath) {
+  let code;
+  try { code = fs.readFileSync(filePath, 'utf8'); } catch { return []; }
+  const rel = path.relative(REPO_ROOT, filePath).replace(/\\/g, '/');
+  let messages;
+  try {
+    messages = linter.verify(code, FLAT_CONFIG, { filename: filePath });
+  } catch (e) {
+    // A file the parser cannot read is NOT a clean file — say so, because a silent drop and a pass
+    // look identical downstream.
+    console.warn(`⚠️  skipped (parse): ${rel} — ${String(e.message).split('\n')[0]}`);
+    return [];
+  }
+  const findings = messages
+    .filter((m) => m.ruleId === RULE_ID)
+    .map((m) => ({ filePath: rel, line: m.line, column: m.column, message: m.message }));
+  return findings.concat(bareDisables(code, rel));
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const jsonMode = argv.includes('--json');
+  const wantAll = argv.includes('--all');
+  const blocking = (process.env.VERDICT_MUTATION_MODE || 'block').toLowerCase() !== 'warn';
+
+  let mode = 'diff';
+  let scanned;
+  if (wantAll) {
+    mode = 'all';
+    scanned = candidateFilesAll(REPO_ROOT);
+  } else {
+    try {
+      scanned = candidateFilesDiff(REPO_ROOT);
+    } catch (e) {
+      console.warn(`⚠️  diff base unavailable (${String(e.message).split('\n')[0]}) — falling back to --all`);
+      mode = 'all (degraded)';
+      scanned = candidateFilesAll(REPO_ROOT);
+    }
+  }
+
+  const linter = new Linter({ configType: 'flat' });
+  const findings = scanned.flatMap((f) => lintFile(linter, f));
+
+  if (jsonMode) {
+    console.log(JSON.stringify({ mode, scanned: scanned.length, findings, known_missed: KNOWN_MISSED }, null, 2));
+  } else {
+    console.log(`[verdict-mutation-lint] mode=${mode} scanned=${scanned.length} findings=${findings.length} enforcement=${blocking ? 'BLOCK' : 'warn'}`);
+    for (const f of findings) console.log(`  ${f.filePath}:${f.line}:${f.column} — ${f.message}`);
+    // NO SILENT CAPS: the shapes this predicate cannot see are printed every run, so "0 findings"
+    // is never mistaken for "0 mutators".
+    console.log('[verdict-mutation-lint] KNOWN-MISSED shapes (not covered by this predicate):');
+    for (const k of KNOWN_MISSED) console.log(`  - ${k}`);
+  }
+
+  if (findings.length > 0 && blocking) process.exit(1);
+  process.exit(0);
+}
+
+main();

--- a/scripts/lint/no-unfenced-verdict-mutation-lint.mjs
+++ b/scripts/lint/no-unfenced-verdict-mutation-lint.mjs
@@ -51,7 +51,10 @@ const RULE_ID = 'verdict-chain/no-unfenced-verdict-mutation';
 const KNOWN_MISSED = [
   'spread-rebuild: `return { ...results, verdict: X }` creates a new object, so nothing is overwritten (live at lib/fleet/spawn-control.js:1419)',
   'helper-indirected: `applyX(results)` where the overwrite happens in another file — single-file AST cannot follow it',
-  'read-modify-write whose condition tests something OTHER than .verdict (e.g. lib/sub-agents/performance.js:239)'
+  'read-modify-write whose condition tests something OTHER than .verdict (LIVE at lib/sub-agents/performance.js:239, which also has no test file)',
+  'ternary remap in an object literal: `verdict: x ? FAIL : PASS` — authored rather than rewritten, so indistinguishable from a legitimate author',
+  'Object.assign(results, { verdict: X }) — no live instance found in this tree',
+  'short-circuit mutation `x.verdict === F && (x.verdict = P)` — no live instance found in this tree'
 ];
 
 const FLAT_CONFIG = {

--- a/scripts/modules/handoff/executors/exec-to-plan/gates/rca-feedback-loop-gate.js
+++ b/scripts/modules/handoff/executors/exec-to-plan/gates/rca-feedback-loop-gate.js
@@ -46,8 +46,29 @@ async function writeTelemetry(supabase, sdId, phase, outcome, mode, payloadShape
       sub_agent_code: GATE_NAME,
       source: 'gate',
       phase,
-      verdict: outcome.startsWith('BLOCK_') && mode === 'blocking' ? 'FAIL' : 'PASS',
-      metadata: { outcome, enforcement_mode: mode, payload_shape: payloadShape, rca_row_count: rcaRowCount }
+      // SD-LEO-INFRA-WRITER-SUB-AGENT-001 / FR-2: this was
+      //   outcome.startsWith('BLOCK_') && mode === 'blocking' ? 'FAIL' : 'PASS'
+      // which stored a BLOCK outcome as a PASS whenever mode !== 'blocking' — and readEnforcementMode
+      // below DEFAULTS to 'advisory' on any error, missing config, or non-string value. So the DEFAULT
+      // configuration laundered a block into the evidence table, in the gate's own telemetry.
+      //
+      // The ENFORCEMENT decision still belongs to the mode (advisory must not block a handoff); what
+      // must not vary is the RECORD of what was observed. A blocked outcome is now stored as BLOCKED
+      // in advisory mode — a rejecting verdict that reports the truth without acting on it — and FAIL
+      // only when the gate is actually enforcing.
+      verdict: outcome.startsWith('BLOCK_')
+        ? (mode === 'blocking' ? 'FAIL' : 'BLOCKED')
+        : 'PASS',
+      metadata: {
+        outcome,
+        enforcement_mode: mode,
+        payload_shape: payloadShape,
+        rca_row_count: rcaRowCount,
+        // The verdict here is authored from `outcome`, not rewritten from a caller's verdict, so
+        // there is no upstream value to preserve — recorded explicitly so a future reader does not
+        // mistake this for an unfenced mutation.
+        verdict_source: 'authored_from_outcome'
+      }
     });
   } catch { /* telemetry best-effort; do not throw from gate */ }
 }

--- a/scripts/modules/orchestrator/subagent-execution.js
+++ b/scripts/modules/orchestrator/subagent-execution.js
@@ -67,11 +67,17 @@ export async function executeSubAgent(subAgent, sdId, options = {}) {
       ...options  // Forward any additional options (validation_mode, full_e2e, etc.)
     });
 
-    // Transform result to match orchestrator's expected format
-    return {
-      sub_agent_code: code,
-      sub_agent_name: name,
-      verdict: result.verdict || 'WARNING',
+    // Transform result to match orchestrator's expected format.
+    //
+    // SD-LEO-INFRA-WRITER-SUB-AGENT-001 / FR-2: `verdict: result.verdict || 'WARNING'` REMOVED.
+    // This was the LITERAL defect SD-LEO-INFRA-SUBAGENT-VERDICT-LAUNDERED-001 was created to fix,
+    // still alive here because that SD was scoped to ONE writer ("SCOPE IS ROWS FROM THIS WRITER,
+    // NOT THE WHOLE TABLE"). WARNING is in the evidence gate's ACCEPT set, so any sub-agent that
+    // returned nothing — including one that crashed — was silently promoted to a passing verdict,
+    // stored RAW via safeInsert with no mapVerdict and no original_verdict.
+    // The verdict is now passed through UNMODIFIED; mapping and provenance belong to the canonical
+    // writer, which this path already invokes via realExecuteSubAgent.
+    verdict: result.verdict,
       confidence: result.confidence !== undefined ? result.confidence : 50,
       critical_issues: result.critical_issues || [],
       warnings: result.warnings || [],
@@ -241,15 +247,30 @@ export async function storeSubAgentResult(sdId, result, supabase) {
  */
 export async function updatePRDMetadataFromSubAgents(sdId, phase, results, supabase) {
   try {
-    // Get PRD associated with this SD
-    const { data: prd, error: prdError } = await supabase
-      .from('product_requirements_v2')
-      .select('id, metadata')
-      .eq('directive_id', sdId)
-      .single();
+    // Get PRD associated with this SD.
+    //
+    // SD-LEO-INFRA-WRITER-SUB-AGENT-001 (absorbed from Charlie's population measurement, 770bedae):
+    // this was `.eq('directive_id', sdId)` alone. directive_id holds the SD KEY on 2987 of 4171 rows
+    // (re-measured independently), while every UUID-normalizing caller passes a uuid — so the lookup
+    // MISSED and the miss printed as "normal for early phases". A silent failure wearing a benign
+    // label, which is the same shape as the verdict laundering this SD exists to fix: the metadata
+    // update was skipped and nothing said so.
+    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(String(sdId));
+    let query = supabase.from('product_requirements_v2').select('id, metadata');
+    // Only widen to sd_id when the input IS a uuid: sd_id is a uuid column, and comparing it to an
+    // 'SD-...' key errors rather than returning empty.
+    query = isUuid
+      ? query.or(`sd_id.eq.${sdId},directive_id.eq.${sdId}`)
+      : query.eq('directive_id', sdId);
+    const { data: prd, error: prdError } = await query.maybeSingle();
 
-    if (prdError || !prd) {
-      // Not an error - SD may not have a PRD yet (early phases)
+    if (prdError) {
+      // A query ERROR is not "no PRD yet" — say so, rather than filing it under the benign label.
+      console.warn(`      PRD lookup FAILED for SD ${sdId}: ${prdError.message}`);
+      return null;
+    }
+    if (!prd) {
+      // Genuinely absent - SD may not have a PRD yet (early phases)
       console.log(`      No PRD found for SD ${sdId} (normal for early phases)`);
       return null;
     }

--- a/scripts/modules/phase-subagent-orchestrator/execution.js
+++ b/scripts/modules/phase-subagent-orchestrator/execution.js
@@ -116,7 +116,11 @@ async function executeSubAgent(subAgent, sdId, options = {}) {
     return {
       sub_agent_code: code,
       sub_agent_name: name,
-      verdict: result.verdict || 'WARNING',
+      // SD-LEO-INFRA-WRITER-SUB-AGENT-001 / FR-2: `|| 'WARNING'` REMOVED — second copy of the
+      // predecessor SD's literal defect. WARNING sits in the evidence gate's ACCEPT set, so a
+      // sub-agent returning nothing was silently promoted to passing and stored raw, with no
+      // mapVerdict and no original_verdict. Pass the verdict through untouched.
+      verdict: result.verdict,
       confidence: result.confidence !== undefined ? result.confidence : 50,
       critical_issues: result.critical_issues || [],
       warnings: result.warnings || [],
@@ -291,13 +295,22 @@ async function storeSubAgentResult(supabase, sdId, result, options = {}) {
  */
 async function updatePRDMetadataFromSubAgents(supabase, sdId, phase, results) {
   try {
-    const { data: prd, error: prdError } = await supabase
-      .from('product_requirements_v2')
-      .select('id, metadata')
-      .eq('directive_id', sdId)
-      .single();
+    // SD-LEO-INFRA-WRITER-SUB-AGENT-001 (absorbed from Charlie's measurement, 770bedae): second
+    // copy of the same lookup. directive_id holds the SD KEY on 2987 of 4171 rows while callers pass
+    // a uuid, so the miss printed as "normal for early phases" — a silent skip wearing a benign label.
+    const isUuid = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(String(sdId));
+    let query = supabase.from('product_requirements_v2').select('id, metadata');
+    // sd_id is a uuid column — comparing it to an 'SD-...' key errors rather than returning empty.
+    query = isUuid
+      ? query.or(`sd_id.eq.${sdId},directive_id.eq.${sdId}`)
+      : query.eq('directive_id', sdId);
+    const { data: prd, error: prdError } = await query.maybeSingle();
 
-    if (prdError || !prd) {
+    if (prdError) {
+      console.warn(`   PRD lookup FAILED for SD ${sdId}: ${prdError.message}`);
+      return null;
+    }
+    if (!prd) {
       console.log(`   No PRD found for SD ${sdId} (normal for early phases)`);
       return null;
     }

--- a/tests/unit/eslint-rules/no-unfenced-verdict-mutation.test.js
+++ b/tests/unit/eslint-rules/no-unfenced-verdict-mutation.test.js
@@ -1,0 +1,125 @@
+/**
+ * SD-LEO-INFRA-WRITER-SUB-AGENT-001 — FR-4 / FR-4a / FR-7.
+ *
+ * WHAT THIS FILE DELIBERATELY DOES NOT DO: assert "none of M1..Mn mutates". That would be a RECEIPT
+ * FOR THE LIST — it passes forever while writer #15 lands unfenced, which is the exact defect this
+ * SD exists to fix, reproduced in its own anti-recurrence device. The load-bearing case here
+ * ("catches a mutator that appears in no enumeration") uses a shape invented for the test.
+ *
+ * AND THIS SUITE IS NOT THE ACCEPTANCE. A unit test proves the rule's LOGIC; it cannot prove the
+ * rule ever RUNS. The precedent this SD was told to copy has 82 green unit tests and has never
+ * inspected a real file. Reachability is asserted by .github/workflows/no-unfenced-verdict-mutation-lint.yml,
+ * which injects a violating file and requires the driver to exit non-zero before trusting a pass.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import rule from '../../../eslint-rules/no-unfenced-verdict-mutation.js';
+
+const RULE_ID = 'verdict-chain/no-unfenced-verdict-mutation';
+const CONFIG = {
+  languageOptions: { ecmaVersion: 2022, sourceType: 'module' },
+  plugins: { 'verdict-chain': { rules: { 'no-unfenced-verdict-mutation': rule } } },
+  rules: { [RULE_ID]: 'error' }
+};
+
+const linter = new Linter({ configType: 'flat' });
+const lint = (code, filename = 'lib/sub-agents/some-agent.js') =>
+  linter.verify(code, CONFIG, { filename }).filter((m) => m.ruleId === RULE_ID);
+
+describe('no-unfenced-verdict-mutation — the load-bearing case', () => {
+  it('CATCHES A MUTATOR THAT APPEARS IN NO ENUMERATION (read-modify-write shape)', () => {
+    // Invented here. Not M1..M14. Not in any list. This is the whole point of the rule.
+    const found = lint(`
+      export function somethingNobodyListed(results) {
+        if (results.verdict === 'FAIL') {
+          results.verdict = 'PASS';
+        }
+        return results;
+      }
+    `);
+    expect(found).toHaveLength(1);
+    expect(found[0].message).toMatch(/recordVerdictMutation/);
+  });
+
+  it('CATCHES AN UNENUMERATED DEFAULT (object-literal shape, invisible to assignment predicates)', () => {
+    const found = lint(`
+      export function build(result) {
+        return { sub_agent_code: 'X', verdict: result.verdict || 'WARNING' };
+      }
+    `);
+    expect(found).toHaveLength(1);
+    expect(found[0].message).toMatch(/silently promotes a missing verdict/);
+  });
+});
+
+describe('FR-4a: the provenance predicate must not fire on AUTHORS', () => {
+  // Measured during PLAN over 98 files / 142 assignments: the parameter-received predicate ALONE
+  // gives 86% false positives, because a helper that authors a verdict looks identical to one that
+  // rewrites a caller's. A rule that cries wolf gets deleted — that is how the precedent died.
+  it('does NOT flag a sub-agent authoring its own local results object', () => {
+    expect(lint(`
+      export function analyse(findings) {
+        const results = { verdict: 'PASS', findings };
+        if (findings.length > 0) { results.verdict = 'FAIL'; }
+        return results;
+      }
+    `)).toHaveLength(0);
+  });
+
+  it('does NOT flag a parameter-received overwrite whose conditional never reads .verdict', () => {
+    // P2 absent => not a read-modify-write => not the mutation signature. This is a deliberate
+    // narrowing with a KNOWN cost: lib/sub-agents/performance.js:239 is a real instance the rule
+    // misses. Recorded in the driver's KNOWN-MISSED output rather than papered over.
+    expect(lint(`
+      export function apply(results, ctx) {
+        if (ctx.newBarrels > 0) { results.verdict = 'BLOCKED'; }
+        return results;
+      }
+    `)).toHaveLength(0);
+  });
+
+  it('does NOT flag `verdict: x ?? null` — defaulting to UNKNOWN preserves absence', () => {
+    // Same syntax as the laundering shape, opposite meaning: null stays unknown, 'WARNING' would
+    // manufacture acceptance. Without this narrowing the rule flagged the evidence GATE's own
+    // read-only reporting struct (subagent-evidence-gate.js:395).
+    expect(lint(`
+      const details = { verdict: latest.get(k)?.verdict ?? null };
+    `)).toHaveLength(0);
+  });
+
+  it('does NOT flag the seam itself — verdict-chain.js assigns verdict BY DESIGN', () => {
+    expect(lint(`
+      export function recordVerdictMutation(results, newVerdict) {
+        if (results.verdict !== newVerdict) { results.verdict = newVerdict; }
+        return results;
+      }
+    `, 'lib/sub-agents/verdict-chain.js')).toHaveLength(0);
+  });
+});
+
+describe('TS-13 adversarial shape matrix — CAUGHT vs KNOWN-MISSED, stated openly', () => {
+  // The deeper risk with TS-3 is that the same author writes both rule and fixture, so the fixture
+  // is shaped to match the rule's mental model. This matrix publishes what the predicate does NOT
+  // see, so "0 findings" is never read as "0 mutators".
+  const SHAPES = [
+    { name: 'read-modify-write on a param', caught: true, code: 'function f(results){ if(results.verdict===\'FAIL\'){ results.verdict=\'PASS\'; } }' },
+    { name: 'object-literal string default', caught: true, code: 'const o = { verdict: r.verdict || \'WARNING\' };' },
+    { name: 'object-literal ?? string default', caught: true, code: 'const o = { verdict: r.verdict ?? \'PASS\' };' },
+    { name: 'ternary remap in a literal', caught: false, code: 'const o = { verdict: r.blocked ? \'FAIL\' : \'PASS\' };' },
+    { name: 'spread-rebuild (new object, nothing overwritten)', caught: false, code: 'function f(results){ return { ...results, verdict: \'PASS\' }; }' },
+    { name: 'helper-indirected (overwrite lives in another file)', caught: false, code: 'function f(results){ applyElsewhere(results); return results; }' },
+    { name: 'condition tests something other than .verdict', caught: false, code: 'function f(results, c){ if(c.x){ results.verdict=\'BLOCKED\'; } }' },
+  ];
+
+  for (const shape of SHAPES) {
+    it(`${shape.caught ? 'CAUGHT' : 'KNOWN-MISSED'}: ${shape.name}`, () => {
+      const n = lint(shape.code).length;
+      if (shape.caught) expect(n).toBeGreaterThan(0);
+      else expect(n).toBe(0); // pinned as DEBT, not as correctness
+    });
+  }
+
+  it('the known-missed set is non-empty — an honest fence states its blind spots', () => {
+    expect(SHAPES.filter((s) => !s.caught).length).toBeGreaterThan(0);
+  });
+});

--- a/tests/unit/eslint-rules/no-unfenced-verdict-mutation.test.js
+++ b/tests/unit/eslint-rules/no-unfenced-verdict-mutation.test.js
@@ -105,6 +105,14 @@ describe('TS-13 adversarial shape matrix — CAUGHT vs KNOWN-MISSED, stated open
     { name: 'read-modify-write on a param', caught: true, code: 'function f(results){ if(results.verdict===\'FAIL\'){ results.verdict=\'PASS\'; } }' },
     { name: 'object-literal string default', caught: true, code: 'const o = { verdict: r.verdict || \'WARNING\' };' },
     { name: 'object-literal ?? string default', caught: true, code: 'const o = { verdict: r.verdict ?? \'PASS\' };' },
+    // ADDED AFTER EXEC REVIEW — a reviewer found four evasions, two of them LIVE shapes in this
+    // tree. The sharpest is the statement-form default: it is the predecessor SD's literal defect
+    // one refactor away, and it is exactly the refactor an author reaches for when Predicate B
+    // blocks the object-literal form. A fence that teaches its own evasion is worse than none.
+    { name: 'statement-form default (the natural refactor when B blocks you)', caught: true, code: 'function f(results){ results.verdict = results.verdict || \'WARNING\'; }' },
+    { name: 'logical-assignment default ||=', caught: true, code: 'function f(results){ results.verdict ||= \'WARNING\'; }' },
+    { name: 'switch discriminant read-modify-write', caught: true, code: 'function f(results){ switch(results.verdict){ case \'FAIL\': results.verdict=\'PASS\'; } }' },
+    { name: 'computed member results[\'verdict\']', caught: true, code: 'function f(results){ if(results.verdict===\'FAIL\'){ results[\'verdict\']=\'PASS\'; } }' },
     { name: 'ternary remap in a literal', caught: false, code: 'const o = { verdict: r.blocked ? \'FAIL\' : \'PASS\' };' },
     { name: 'spread-rebuild (new object, nothing overwritten)', caught: false, code: 'function f(results){ return { ...results, verdict: \'PASS\' }; }' },
     { name: 'helper-indirected (overwrite lives in another file)', caught: false, code: 'function f(results){ applyElsewhere(results); return results; }' },


### PR DESCRIPTION
A completed **CRITICAL** SD fixed one verdict-mutating writer and the class survived its own fix. Its scope field says so outright — *"SCOPE IS ROWS FROM THIS WRITER, NOT THE WHOLE TABLE"* — so a second mutator passes every criterion it shipped, untouched.

The FR-1 enumeration found **14 in-process mutators**, including the predecessor's *literal* defect (`verdict: result.verdict || 'WARNING'`) alive and unfixed in two more files. Both of those paths also invoke the canonical writer first, so an orchestrated run wrote **two rows** — one mapped with provenance, one laundered — and the evidence gate reduces to the latest, making the winner a timing question.

## The structural problem

`verdict` was a plain property any function holding the results object could overwrite, and the audit snapshot was taken at **storage** time — downstream of mutation. So `metadata.original_verdict` recorded the last mutator's output rather than the caller's input.

Measured: **91 live rows** with `verdict=CONDITIONAL_PASS` AND `original_verdict=CONDITIONAL_PASS` AND (`repo_resolved=false` OR `probe_exists=false`) — zero recorded divergence, because the mutation happened before the field meant to witness it. The predecessor's criterion *"the original verdict is recorded for EVERY row this writer produces"* passes on those rows **while recording a falsehood**.

## What landed

**FR-3 — the declared seam.** `lib/sub-agents/verdict-chain.js`: `recordVerdictMutation()` appends `{from,to,mutator,reason}` to `metadata.verdict_chain`; entry `[0]` is the verdict as it *entered* the path. Mutator and reason are both **required** — an anonymous mutation is the defect.

**FR-3a.** `original_verdict` moved *after* the `...safeMetadata` spread. It was declared before it, making the writer's audit anchor overridable by the party it audits; 8 live rows carry `verdict=PASS` with `original_verdict=CONDITIONAL_PASS`, an upgrade direction `mapVerdict` cannot produce.

**FR-2 — direction as the discriminator.** *Removed* (upgrade-direction): both `|| 'WARNING'` sites, and `rca-feedback-loop-gate`, which stored a BLOCK outcome as PASS whenever `mode !== 'blocking'` — and `readEnforcementMode` **defaults to advisory** on any error, so the default configuration laundered a block in the gate's own telemetry. *Kept and made explicit* (degrade-direction): `resolve-repo` and `design`. Those degrades are correct — a scan of an unresolved tree yields zero violations, so that PASS is vacuous — and a DB trigger completes deliverables only on `verdict='PASS'`, so removing them would start auto-completing deliverables off checks that never executed.

**FR-4/4a/7 — the fence.** Rule + `scripts/lint/` driver + **blocking workflow**.

## Why this is not a copy of the named precedent

The PRD originally said to mirror `eslint-rules/no-process-cwd-in-sub-agents.js`. That guard has **82 passing unit tests and has never inspected a real file** — verified four ways: not registered in `eslint.config.js`; its `.eslintrc.json` is a format ESLint 9 ignores under flat config; `--print-config` resolves zero custom rules; and the escape-hatch pragmas already in source report *"Definition for rule … was not found"*. Copying it would have shipped a green receipt over a guard that cannot fire — this SD's own thesis, reproduced in its anti-recurrence device. (Routed separately by the coordinator: all 7 rules in `eslint-rules/` are likely dead the same way.)

## Two predicates, because one shape is invisible to the other

Measured over 98 files / 142 assignments: the parameter-received predicate **alone** flags 14 sites, **12 of them false positives (86%)** — helper-authored verdicts are indistinguishable from mutations because *who created the object* lives in the caller's file. Conjoined with "the enclosing conditional reads `.verdict`" it flags exactly the genuine mutators, zero false positives. A separate `Property`-node predicate catches `verdict: x || 'WARNING'` in object literals, which no assignment-based predicate can see.

**Narrowed after the rule caught the gate it protects:** the first version flagged `subagent-evidence-gate.js:395` (`verdict: …?.verdict ?? null`), a read-only display struct. Only a *string-literal* fallback is laundering — `?? null` preserves absence, `|| 'WARNING'` manufactures a value that happens to sit in the ACCEPT set. A rule that cries wolf on the gate it guards is a rule someone deletes.

## Absorbed per coordinator directive (Charlie, 770bedae)

`updatePRDMetadataFromSubAgents` in both orchestrator files queried `.eq('directive_id', sdId)`, where `directive_id` holds the SD **key** on **2987 of 4171** rows (re-measured independently here) while callers pass a uuid. The lookup missed and printed *"No PRD found (normal for early phases)"* — a silent skip wearing a benign label, the same shape as the laundering above. I watched that exact line print during this session's own PRD creation. Now matches either column, guarded on uuid shape, and a query **error** is reported instead of filed under the benign label.

## Verified by execution, not assertion

- 443 files scanned, **0 findings** on the converted tree; driver exits 0
- inject a mutator **invented for the check, in no enumeration**: both shapes caught, driver exits 1
- a bare `eslint-disable` without a `-- <reason>` is itself reported
- 14 rule tests; **149 tests across 12 affected suites**, all unmodified — including `design-cross-repo-resolution.test.js`, which review predicted would need editing and did not
- a caller `PASS` degraded by `resolve-repo` now yields `originalVerdictFor: PASS`
- 4 pre-existing unit-tier failures proven pre-existing by stashing these changes and re-running: identical both ways

The workflow asserts reachability **before** trusting a pass — it injects a violating file, requires exit non-zero, then removes it. If that step ever succeeds when it shouldn't, the guard has gone decorative and the enforcing step's green means nothing.

## Known-missed, printed every run

Spread-rebuild, helper-indirected, and read-modify-write whose condition tests something other than `.verdict` (`lib/sub-agents/performance.js:239` is a live instance). Pinned as debt in the test matrix so **"0 findings" is never read as "0 mutators"**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)