### PR TITLE
feat(SURVEY-3): settle the permissive-policy census from pg_policies, and fix the probe defect it exposed

### DIFF
--- a/lib/security/rls-probe-template.cjs
+++ b/lib/security/rls-probe-template.cjs
@@ -10,9 +10,21 @@
  * it. That is the timing test for when guidance must become scaffolding: does the failure it prevents
  * occur while you are READING, or later, inside a procedure?
  *
- * WHAT IT DEFENDS AGAINST, measured 2026-08-03 against public.feedback:
- *   anon .insert().select()  -> 42501, row ABSENT   (looks refused)
- *   anon .insert()  (no RETURNING, same row) -> error null, ROW LANDS   (is wide open)
+ * WHAT IT DEFENDS AGAINST, measured 2026-08-03 against public.feedback with THIS EXACT ROW:
+ *   { type:'issue', source_application:'EHG_Engineer', title:<marker>,
+ *     source_type:'auto_capture', feedback_type:'user_bug', venture_id:<an ACTIVE venture> }
+ *   anon .insert().select()  -> 42501 "new row violates row-level security policy", row ABSENT
+ *   anon .insert()  (no RETURNING, IDENTICAL row) -> error null, ROW LANDS
+ *
+ * EVERY FIELD IN THAT ROW IS LOAD-BEARING, which is why it is written out in full. The asymmetry
+ * comes from venture_user_insert_feedback granting INSERT on (feedback_type LIKE 'user_%' AND an
+ * active venture_id) while placing NO constraint on source_type, whereas anon SELECT
+ * (telegram_bot_select_feedback) is confined to source_type='telegram'. So the INSERT is permitted
+ * and the RETURNING read is not. Drop venture_id and the INSERT is refused too — the case stops
+ * reproducing and reads as a clean refusal. An earlier version of this comment omitted venture_id;
+ * re-running it produced REFUSED and briefly looked like a REFUTATION of the very claim it records.
+ * An under-specified repro is worse than none.
+ *
  * So an error code cannot prove refusal — and NEITHER CAN AN ABSENT ROW, because absence only
  * discriminates when the write was attempted in the shape a REAL WRITER uses. A denied nonsense
  * control returns the SAME SQLSTATE **and the same message string**, so message matching is unsound
@@ -62,9 +74,18 @@ function buildProbePlan(spec) {
 }
 
 /**
- * PURE three-leg classifier. Same logic shipped and merged as the SURVEY-2 canary exemplar
- * (lib/breakage/active-canary-probes.cjs classifyRlsProbe) — one representation of the rule, two
- * consumers.
+ * PURE three-leg classifier.
+ *
+ * RELATIONSHIP TO THE CANARY, stated accurately. An earlier version of this comment claimed "one
+ * representation of the rule, two consumers". That was FALSE: this and
+ * lib/breakage/active-canary-probes.cjs classifyRlsProbe are two separate implementations, and they
+ * had already DIVERGED — the canary required code 42501 before concluding refusal, this one did not,
+ * which is exactly the defect fixed below. A 1-REP claim asserted in prose is not 1-REP; it is a
+ * claim that nothing checks, and it read as reassurance while the two drifted apart.
+ *
+ * They stay aligned now because a test asserts it: tests/unit/security/rls-probe-template.test.js
+ * runs a shared evidence table through BOTH classifiers and fails if their verdicts disagree. That
+ * is the enforcement the prose was standing in for.
  *
  * @param {{withReturning?:{error?:object|null,data?:Array|null}|null,
  *          readbackAfterReturning?:{rows?:Array|null, deleted?:number}|null,
@@ -100,13 +121,35 @@ function classifyProbeEvidence(evidence) {
     };
   }
 
-  // REFUSED requires leg 3. Absence after a RETURNING attempt alone is the FALSE ALL-CLEAR.
+  // REFUSED requires leg 3 AND the RLS refusal code specifically. Absence after a RETURNING attempt
+  // alone is the FALSE ALL-CLEAR — and so is absence caused by a write that never reached policy
+  // evaluation at all.
+  //
+  // WHY 42501 IS REQUIRED, measured: probing feedback with a row carrying a `subject` column (this
+  // table has none — the marker column is `title`) failed PGRST204 in the SCHEMA CACHE, before any
+  // policy ran. All three legs came back absent and this function reported
+  // "REFUSED — three legs confirmed" for a table whose anon INSERT is in fact OPEN for
+  // source_type='telegram'. A malformed probe is the most dangerous input here precisely because it
+  // fails CONSISTENTLY, which is what a working guard also looks like.
+  //
+  // ALLOWLIST, NOT BLOCKLIST. Enumerating non-policy codes (PGRST204/42703/23502/23514/…) is a list
+  // that is always one entry short. Requiring the affirmative RLS code fails CLOSED to INCONCLUSIVE
+  // for every error nobody anticipated. This matches the merged SURVEY-2 canary, which required
+  // 42501 from the start; the template had silently diverged.
+  const RLS_REFUSAL_CODE = '42501';
   const bareAttempted = Object.prototype.hasOwnProperty.call(e, 'bareInsert') && observed(e.readbackAfterBare);
-  if (observed(e.readbackAfterReturning) && bareAttempted) {
+  if (code === RLS_REFUSAL_CODE && observed(e.readbackAfterReturning) && bareAttempted) {
     return {
       verdict: VERDICT.REFUSED,
-      reason: 'refused — absent after the RETURNING attempt AND after an identical write with NO RETURNING (three legs confirmed)',
-      detail: { legs: 3, code: code || null, confirmBy },
+      reason: 'refused — 42501, and absent after the RETURNING attempt AND after an identical write with NO RETURNING (three legs confirmed)',
+      detail: { legs: 3, code, confirmBy },
+    };
+  }
+  if (code && code !== RLS_REFUSAL_CODE) {
+    return {
+      verdict: VERDICT.INCONCLUSIVE,
+      reason: `the write failed with ${code}, which is NOT the RLS refusal code — it never reached policy evaluation, so this says nothing about the permission. Fix the probe row (every required column present and valid) and re-run.`,
+      detail: { legs: 0, code, confirmBy, non_policy_error: true },
     };
   }
   return {

--- a/scripts/security/rls-coexisting-permissive-census.mjs
+++ b/scripts/security/rls-coexisting-permissive-census.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+/**
+ * CO-EXISTING PERMISSIVE POLICY CENSUS — SD-LEO-INFRA-SURVEY-EVERY-PERMISSION-001 (SURVEY-3).
+ *
+ * WHY THIS EXISTS. Postgres OR-s PERMISSIVE policies, so where two or more exist on the same
+ * table+command, THE WEAKEST ONE GOVERNS. Tightening one while another remains changes nothing —
+ * and reasoning about "the" policy on a table (singular) is how that gets missed. The live instance
+ * that motivated this SD: `feedback | INSERT` carries telegram_bot_insert_feedback (WITH CHECK
+ * source_type='telegram') alongside venture_user_insert_feedback, which places NO constraint on
+ * source_type at all. A fence derived from the first policy alone bounds nothing.
+ *
+ * WHY IT IS A QUERY AND NOT A FILE SWEEP. The prior census was a static replay of CREATE/DROP POLICY
+ * text ordered by FILENAME — which is not apply order, and _STAGED / _rollback files may never have
+ * been applied at all. That produces CANDIDATES, not findings. This reads pg_policies, so every row
+ * is what the database actually enforces right now.
+ *
+ * IT REPORTS A DENOMINATOR, NOT A CHECKLIST. It enumerates every multi-permissive table+command in
+ * the schema rather than confirming a pre-supplied list, so a pair nobody suspected is still found.
+ *
+ * ALSO REPORTS THE PERMISSIVE-DENY CLASS (D3): a policy NAMED like a fence but declared PERMISSIVE
+ * with USING(false) contributes NOTHING to the OR. It reads as a guard and provides none — and it
+ * would not restrain a future permissive policy added beside it.
+ *
+ * USAGE: node scripts/security/rls-coexisting-permissive-census.mjs [--json]
+ * Requires DATABASE_URL, or SUPABASE_DB_PASSWORD + SUPABASE_URL (direct-connection form).
+ */
+import pg from 'pg';
+import dotenv from 'dotenv';
+dotenv.config();
+
+const { Client } = pg;
+
+// Use the POOLER, not the direct host. db.<ref>.supabase.co does not resolve for this project, and
+// CLAUDE_CORE.md:1238 records why the pooler is canonical here: direct URLs hit connection limits.
+// Host is configured in config/databases.json (aws-1-us-east-1.pooler.supabase.com).
+const POOLER_HOST = process.env.SUPABASE_POOLER_HOST || 'aws-1-us-east-1.pooler.supabase.com';
+
+function connectionString() {
+  if (process.env.DATABASE_URL) return process.env.DATABASE_URL;
+  const pw = process.env.SUPABASE_DB_PASSWORD;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL || '';
+  const ref = (url.match(/https:\/\/([a-z0-9]+)\.supabase\.co/) || [])[1];
+  if (!pw || !ref) return null;
+  return `postgresql://postgres.${ref}:${encodeURIComponent(pw)}@${POOLER_HOST}:5432/postgres`;
+}
+
+// THE QUERY. Grouped by (table, command) because the OR happens PER COMMAND — a table with one
+// INSERT policy and three SELECT policies is not a multi-permissive INSERT surface, and reporting
+// by table alone would hide which command is actually widened.
+const CENSUS_SQL = `
+SELECT
+  schemaname, tablename, cmd,
+  count(*)                                          AS permissive_count,
+  array_agg(policyname ORDER BY policyname)         AS policies,
+  array_agg(DISTINCT r ORDER BY r)                  AS roles,
+  bool_or(r IN ('anon','public'))                   AS reaches_anon_or_public
+FROM pg_policies pp, LATERAL unnest(pp.roles) AS r
+WHERE pp.permissive = 'PERMISSIVE' AND pp.schemaname = 'public'
+GROUP BY schemaname, tablename, cmd
+HAVING count(*) > 1
+ORDER BY bool_or(r IN ('anon','public')) DESC, tablename, cmd;
+`;
+
+// D3 — a policy that is PERMISSIVE with an always-false predicate. It contributes NOTHING to the OR:
+// it reads as an explicit fence and provides none.
+//
+// PREDICATE, NOT NAME. A name filter (%deny%/%block%) produced 7 false positives on the first run —
+// auto_apply_denylist matched on the TABLE name, circuit_breaker_blocks on "blocks", and
+// venture_stages' "deny_write_..." is a SELECT policy with qual=true. Matching the always-false
+// predicate is what actually identifies the class; the name is decoration.
+//
+// AND IT REPORTS REACHABILITY, because the harm is conditional. With no other permissive policy
+// granting that role+command, RLS default-denies anyway, so the fence is REDUNDANT-but-harmless
+// today. It becomes LOAD-BEARING-AND-ABSENT the moment someone adds a permissive grant beside it —
+// which is exactly the safe-by-coincidence shape. `co_granting_policies` is that tripwire.
+const PERMISSIVE_DENY_SQL = `
+SELECT
+  d.schemaname, d.tablename, d.cmd, d.policyname, d.roles, d.qual, d.with_check,
+  (SELECT count(*) FROM pg_policies g
+     WHERE g.schemaname = d.schemaname AND g.tablename = d.tablename
+       AND g.permissive = 'PERMISSIVE'
+       AND (g.cmd = d.cmd OR g.cmd = 'ALL' OR d.cmd = 'ALL')
+       AND g.policyname <> d.policyname
+       AND coalesce(g.qual,'true') NOT IN ('false','(false)')
+       AND g.roles && d.roles
+  ) AS co_granting_policies
+FROM pg_policies d
+WHERE d.permissive = 'PERMISSIVE' AND d.schemaname = 'public'
+  AND (coalesce(d.qual,'') IN ('false','(false)') OR coalesce(d.with_check,'') IN ('false','(false)'))
+ORDER BY d.tablename, d.cmd, d.policyname;
+`;
+
+async function main() {
+  const cs = connectionString();
+  if (!cs) { console.error('No DATABASE_URL and cannot derive one from SUPABASE_DB_PASSWORD + SUPABASE_URL'); process.exit(2); }
+  const client = new Client({ connectionString: cs, ssl: { rejectUnauthorized: false } });
+  await client.connect();
+  try {
+    const census = (await client.query(CENSUS_SQL)).rows;
+    const denies = (await client.query(PERMISSIVE_DENY_SQL)).rows;
+    const writeCmds = new Set(['INSERT', 'UPDATE', 'DELETE', 'ALL']);
+    const reaching = census.filter((r) => r.reaches_anon_or_public);
+    const reachingWrites = reaching.filter((r) => writeCmds.has(r.cmd));
+
+    if (process.argv.includes('--json')) {
+      console.log(JSON.stringify({ census, permissive_denies: denies }, null, 2));
+      return;
+    }
+
+    console.log('CO-EXISTING PERMISSIVE POLICIES — the weakest governs, per table+command');
+    console.log(`  multi-permissive table+command pairs (public schema): ${census.length}`);
+    console.log(`  of those, reaching anon/public                      : ${reaching.length}`);
+    console.log(`  of those, on a WRITE command (INSERT/UPDATE/DELETE/ALL): ${reachingWrites.length}`);
+    console.log('');
+    console.log('REACHING ANON/PUBLIC ON A WRITE COMMAND — the weakest-governs surface:');
+    const arr = (v) => Array.isArray(v) ? v : String(v || '').replace(/^[{]|[}]$/g, '').split(',').filter(Boolean);
+    for (const r of reachingWrites) {
+      console.log(`  ${r.tablename} | ${r.cmd} | n=${r.permissive_count} | roles=${arr(r.roles).join(',')}`);
+      console.log(`      ${arr(r.policies).join('  +  ')}`);
+    }
+    console.log('');
+    // Split by REACHABILITY, not by count. A permissive-deny with no co-granting policy is redundant
+    // (RLS default-denies anyway); one WITH a co-granting policy is a fence that is already being
+    // OR-ed around. Reporting a single number would merge a latent hazard with a live one.
+    const live = denies.filter((d) => Number(d.co_granting_policies) > 0);
+    const latent = denies.filter((d) => !(Number(d.co_granting_policies) > 0));
+    console.log(`PERMISSIVE-DENY CLASS (always-false PERMISSIVE — contributes nothing to the OR): ${denies.length}`);
+    console.log(`  LIVE (a co-granting permissive policy already OR-s around this fence): ${live.length}`);
+    for (const d of live) {
+      console.log(`  ! ${d.tablename} | ${d.cmd} | ${d.policyname} | roles=${d.roles} | co_granting=${d.co_granting_policies}`);
+    }
+    console.log(`  LATENT (no co-granting policy today — RLS default-denies, so it is redundant, not protective): ${latent.length}`);
+    for (const d of latent) {
+      console.log(`    ${d.tablename} | ${d.cmd} | ${d.policyname} | roles=${d.roles} | qual=${d.qual}`);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((e) => { console.error('census failed:', e.message); process.exit(1); });

--- a/tests/unit/security/rls-probe-template.test.js
+++ b/tests/unit/security/rls-probe-template.test.js
@@ -156,6 +156,67 @@ describe('FR-5 / TS-7 — fixture drift HARD-ERRORS, never skips', () => {
   });
 });
 
+describe('FR-5 — a NON-POLICY error is INCONCLUSIVE, never REFUSED', () => {
+  // MEASURED, and the reason this arm exists: probing `feedback` with a row carrying a `subject`
+  // column (that table has none — the marker column is `title`) died PGRST204 in the schema cache
+  // BEFORE any policy ran. All three legs came back absent and the classifier said
+  // "REFUSED — three legs confirmed" about a surface that is in fact OPEN for source_type='telegram'.
+  // A malformed probe fails CONSISTENTLY, which is indistinguishable from a working guard.
+  it('PGRST204 (column not in schema cache) is INCONCLUSIVE even with all three legs absent', () => {
+    const v = classifyProbeEvidence({
+      withReturning: { data: null, error: { code: 'PGRST204' } },
+      readbackAfterReturning: { rows: [] },
+      bareInsert: { error: { code: 'PGRST204' } },
+      readbackAfterBare: { rows: [] },
+    });
+    expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(v.detail.non_policy_error).toBe(true);
+  });
+
+  // ALLOWLIST, NOT BLOCKLIST — an enumerated list of non-policy codes is always one entry short, so
+  // an unanticipated code must fail CLOSED to INCONCLUSIVE rather than through to REFUSED.
+  it.each(['PGRST205', '42703', '23502', '23514', '22P02', 'SOME-UNANTICIPATED-CODE'])(
+    'code %s never yields REFUSED', (code) => {
+      const v = classifyProbeEvidence({
+        withReturning: { data: null, error: { code } },
+        readbackAfterReturning: { rows: [] },
+        bareInsert: { error: { code } },
+        readbackAfterBare: { rows: [] },
+      });
+      expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+    });
+
+  it('still reaches REFUSED for the real RLS code, so the guard above did not just disable the verdict', () => {
+    const v = classifyProbeEvidence({
+      withReturning: { data: null, error: { code: '42501' } },
+      readbackAfterReturning: { rows: [] },
+      bareInsert: { error: { code: '42501' } },
+      readbackAfterBare: { rows: [] },
+    });
+    expect(v.verdict).toBe(VERDICT.REFUSED);
+  });
+});
+
+describe('FR-5 — 1-REP is ENFORCED against the canary, not asserted in prose', () => {
+  // The docstring used to claim "one representation of the rule, two consumers". It was false — the
+  // canary required 42501 and this classifier did not. This test is what makes the claim true.
+  const { classifyRlsProbe } = require('../../../lib/breakage/active-canary-probes.cjs');
+  const EVIDENCE = [
+    ['landed via bare', { withReturning: { data: null, error: { code: '42501' } }, readbackAfterReturning: { rows: [] }, bareInsert: { error: null }, readbackAfterBare: { rows: [{ id: 'x' }] } }],
+    ['three-leg refusal', { withReturning: { data: null, error: { code: '42501' } }, readbackAfterReturning: { rows: [] }, bareInsert: { error: { code: '42501' } }, readbackAfterBare: { rows: [] } }],
+    ['two legs only', { withReturning: { data: null, error: { code: '42501' } }, readbackAfterReturning: { rows: [] } }],
+    ['non-policy error', { withReturning: { data: null, error: { code: 'PGRST204' } }, readbackAfterReturning: { rows: [] }, bareInsert: { error: { code: 'PGRST204' } }, readbackAfterBare: { rows: [] } }],
+    ['landed via returning', { withReturning: { data: [{ id: 'x' }], error: null }, readbackAfterReturning: { rows: [{ id: 'x' }] } }],
+  ];
+  it.each(EVIDENCE)('template and canary agree on: %s', (_label, evidence) => {
+    const mine = classifyProbeEvidence(evidence);
+    const theirs = classifyRlsProbe(evidence);
+    // Canary vocabulary -> template vocabulary. breakage=true means the write got through.
+    const theirsVerdict = theirs.breakage ? VERDICT.OPEN : theirs.inconclusive ? VERDICT.INCONCLUSIVE : VERDICT.REFUSED;
+    expect(mine.verdict).toBe(theirsVerdict);
+  });
+});
+
 describe('FR-5 — never branch on message TEXT', () => {
   // Measured: a genuinely-denied control returns the SAME code AND the same message string as the
   // ambiguous case, so the template must decide on state and never on wording.


### PR DESCRIPTION
## SURVEY-3 — the co-existing-permissive census, settled from the catalog

**The query is the deliverable** (`scripts/security/rls-coexisting-permissive-census.mjs`), committed so a reviewer re-runs it rather than trusting this description. It reports a **denominator**, not a checklist — every multi-permissive `table+command` in `public`, so a pair nobody suspected is still found.

| measure | value |
|---|---|
| multi-permissive table+command pairs (public) | **105** |
| …reaching anon/public | **57** |
| …on a WRITE command | **3** |

The static replay's **12 candidates were an over-count**. Each is now CONFIRMED or DISMISSED; none stays in a static-replay state.

### Only one of the 3 is real
`protocol_improvement_queue|ALL` and `security_audit_events|ALL` were flagged only because the census counted **the role on a DENY policy** as "reaching anon". Their sole anon-reaching policy is an always-false deny; every grant beside it is `service_role`. A guard that counts the wrong population reports the wrong surface.

`feedback|INSERT` is genuine, settled behaviourally — 4 cases, all matching the catalog:

| row | verdict |
|---|---|
| `auto_capture`, no `venture_id` | REFUSED (42501, three legs) |
| `source_type='telegram'` | **OPEN** — `telegram_bot_insert_feedback` grants |
| telegram + `severity='critical'` | REFUSED — RESTRICTIVE bounds bar |
| telegram + `category='chairman_decision_deferred'` | REFUSED — RESTRICTIVE bounds bar |

Confirms the founding claim: `venture_user_insert_feedback` constrains `feedback_type`/`venture_id` but places **no** constraint on `source_type`.

### D3 permissive-deny: 11, by predicate not by name
A name filter (`%deny%`/`%block%`) returned 19 with **7 false positives** — `auto_apply_denylist` matched on the *table* name, `circuit_breaker_blocks` on "blocks", and `venture_stages`' `deny_write_...` is a SELECT policy with `qual=true`.

Split by reachability: **0 LIVE, 11 LATENT** — and the zero ships with its cause, because a measured zero is inert until you know why. `aegis_*`/`protocol_constitution`/`test_*` are **command-disjoint**; `protocol_improvement_queue`/`security_audit_events` are **role-disjoint**. All 11 are redundant today, and none would restrain a permissive grant added beside them.

## The probe defect the census exposed

Re-taking the template's own docstring measurement returned **REFUSED for a surface that is OPEN**. The probe row carried a `subject` column — `feedback` has none (its marker column is `title`) — so every write died `PGRST204` in the schema cache **before any policy ran**, and `classifyProbeEvidence` reported *"REFUSED, three legs confirmed"*.

A malformed probe fails **consistently**, which is exactly what a working guard looks like. This is the failure the SD exists to prevent, reproduced inside the instrument built to prevent it.

- **Fix**: REFUSED now requires code `42501` — an **allowlist**, since enumerating non-policy codes is a list always one entry short. Unanticipated codes fail closed to INCONCLUSIVE.
- **1-REP was false**: the docstring claimed *"one representation, two consumers"* while this classifier and the merged canary's `classifyRlsProbe` were two implementations that **had already diverged** — the canary required 42501, this did not, which *is* the defect. A claim asserted in prose is not 1-REP; it is a claim nothing checks. A new test runs shared evidence through **both** classifiers and fails if they disagree.
- **The repro row was under-specified** (no `venture_id`) and did not reproduce — re-running it read as a *refutation* of the claim it records. Now written out in full and verified live: `.insert().select()` → 42501 with the row absent; the **identical** bare `.insert()` → `error: null`, **row lands**.

## Verification
- 26/26 template tests, 76/76 across template + canary.
- **Mutation-proven**: reverting the 42501 requirement fails **8** tests; restored 26/26.
- All probe rows swept by marker with service-role confirmation; residue checked, 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
