### PR TITLE
fix(SURVEY): the classifiers were correct; the collectors lied to them

### DIFF
--- a/lib/security/rls-probe-template.cjs
+++ b/lib/security/rls-probe-template.cjs
@@ -177,12 +177,43 @@ async function runProbe({ anon, service, plan, assertPrecondition }) {
   const marker = plan.validRow[plan.markerColumn];
   if (!marker) throw new ProbeTemplateError(`validRow must carry a unique value in markerColumn "${plan.markerColumn}" so the row can be found and removed`);
 
+  // A FAILED CONFIRMATION IS ABSENT EVIDENCE, NOT EVIDENCE OF ABSENCE — and the obvious way to write
+  // this is wrong. postgrest-js does NOT throw by default (shouldThrowOnError=false); it RESOLVES a
+  // failed query as {data:null,error}. So `try { const {data} = await ...; return {rows:
+  // Array.isArray(data)?data:[]} } catch { return null }` has a catch that never runs, and turns every
+  // readback failure into rows:[] — "observed, and absent", which is one of the two conjuncts REFUSED
+  // requires. Measured: a select against a missing relation resolves to {data:null,code:'PGRST205'}.
+  // That produced a full REFUSED {legs:3} over a row that had LANDED. The classifier was correct the
+  // whole time; the COLLECTOR lied to it. Checking `error` explicitly is the entire fix.
   const confirm = async () => {
     try {
-      const { data } = await service.from(plan.table).select('id').eq(plan.markerColumn, marker);
-      return { rows: Array.isArray(data) ? data : [] };
-    } catch { return null; }      // failed confirmation is ABSENT EVIDENCE, not evidence of absence
+      const { data, error } = await service.from(plan.table).select('id').eq(plan.markerColumn, marker);
+      if (error) return null;                       // <- the real guard; the catch below is a backstop
+      const rows = Array.isArray(data) ? data : [];
+      if (plan.confirmBy !== CONFIRM.DELETION_COUNT) return { rows };
+      // DELETION-COUNT MODE: confirm by removing what is there and counting it. Without this the
+      // mode could never conclude — confirm() only ever emitted `rows`, while present()/observed()
+      // read only `.deleted`, so a landed write returned INCONCLUSIVE "no service-role confirmation"
+      // about a confirmation that had in fact run.
+      if (rows.length === 0) return { rows, deleted: 0 };
+      const { data: del, error: delErr } = await service.from(plan.table).delete()
+        .eq(plan.markerColumn, marker).select('id');
+      if (delErr) return null;
+      return { rows, deleted: Array.isArray(del) ? del.length : rows.length };
+    } catch { return null; }
   };
+
+  // BASELINE BEFORE ANY WRITE. Without it a row left by an earlier run carrying the same marker reads
+  // as "the write landed" and the probe reports OPEN from residue alone — on the canary path that is
+  // an alert plus a non-zero exit. A pre-existing row also means the marker is not unique, so nothing
+  // downstream can be attributed to THIS probe; that is unrecoverable, not a warning.
+  const baseline = await confirm();
+  if (baseline === null) {
+    throw new ProbeTemplateError('baseline confirmation FAILED — the service-role reader cannot see the table, so no later absence can be trusted. Refusing to report a verdict.');
+  }
+  if (baseline.rows.length > 0) {
+    throw new ProbeTemplateError(`marker "${marker}" already matches ${baseline.rows.length} row(s) before the probe ran — it is not unique, so no result could be attributed to this probe`);
+  }
 
   const evidence = { confirmBy: plan.confirmBy };
   try { evidence.withReturning = await anon.from(plan.table).insert(plan.validRow).select('id'); }
@@ -198,10 +229,50 @@ async function runProbe({ anon, service, plan, assertPrecondition }) {
   }
 
   const result = classifyProbeEvidence(evidence);
+
+  // THE NONSENSE CONTROL IS NOW EXECUTED, not merely required. Making it a mandatory SLOT stopped it
+  // being forgotten, but nothing ever RAN it — instrumentation showed zero property reads on
+  // plan.nonsenseControl during a full probe. It was present as a field and absent as a check, which
+  // is the same false comfort as the discipline it replaced: a probe cannot demonstrate it is still
+  // capable of failing by holding a control it never attempts.
+  //
+  // Only meaningful when the main verdict was REFUSED. If a row that MUST be denied is accepted, the
+  // instrument has stopped discriminating and the REFUSED reading is worthless — so it is downgraded,
+  // never reported.
+  if (result.verdict === VERDICT.REFUSED) {
+    const controlMarker = `${marker}__CONTROL__`;
+    const controlRow = { ...plan.nonsenseControl, [plan.markerColumn]: controlMarker };
+    const confirmControl = async () => {
+      try {
+        const { data, error } = await service.from(plan.table).select('id').eq(plan.markerColumn, controlMarker);
+        if (error) return null;
+        return Array.isArray(data) ? data : [];
+      } catch { return null; }
+    };
+    let controlLanded = null;
+    try {
+      await anon.from(plan.table).insert(controlRow);
+      const seen = await confirmControl();
+      controlLanded = seen === null ? null : seen.length > 0;
+    } catch { controlLanded = null; }
+    try { await service.from(plan.table).delete().eq(plan.markerColumn, controlMarker); } catch { /* swept below */ }
+
+    if (controlLanded === true) {
+      return {
+        verdict: VERDICT.INCONCLUSIVE,
+        reason: 'CONTROL FAILED — a row that must be denied was ACCEPTED, so this probe cannot currently distinguish refusal from acceptance. The REFUSED reading is withdrawn, not reported.',
+        detail: { ...(result.detail || {}), control: 'landed', withdrawn_verdict: VERDICT.REFUSED },
+      };
+    }
+    result.detail = { ...(result.detail || {}), control: controlLanded === false ? 'denied' : 'unverified' };
+  }
+
   try {
     await service.from(plan.table).delete().eq(plan.markerColumn, marker);
     const after = await confirm();
-    if (after && after.rows.length > 0) result.detail = { ...(result.detail || {}), cleanup_residue: after.rows.length, marker };
+    // after===null is a FAILED sweep-check, not a clean one — say so rather than implying clean.
+    if (after === null) result.detail = { ...(result.detail || {}), cleanup_unverified: true, marker };
+    else if (after.rows.length > 0) result.detail = { ...(result.detail || {}), cleanup_residue: after.rows.length, marker };
   } catch { /* row is clearly marked for a human sweep */ }
   return result;
 }

--- a/scripts/breakage/active-breakage-canary.mjs
+++ b/scripts/breakage/active-breakage-canary.mjs
@@ -26,7 +26,16 @@ const {
 } = require('../../lib/breakage/active-canary-probes.cjs');
 const { recordSystemAlert } = require('../../lib/breakage/alert-writer.cjs');
 
-const RLS_PROBE_TABLE = 'session_coordination'; // governance table; anon INSERT is RLS-denied (verified 42501)
+// ATTRIBUTION, corrected. This previously read "anon INSERT is RLS-denied (verified 42501)" — which
+// is this SD's own anti-pattern committed in a comment: 42501 was observed and the enforcement was
+// attributed to RLS without checking WHICH mechanism produced it. Measured 2026-08-03:
+// session_coordination has relrowsecurity=true but exactly ONE policy (service_role_full_access,
+// PERMISSIVE, cmd=SELECT), so there is NO INSERT policy at all — and anon's table grants are
+// REFERENCES/SELECT/TRIGGER, with no INSERT. A MISSING GRANT raises the SAME SQLSTATE 42501 as an RLS
+// WITH CHECK violation. So what this probe actually holds is the GRANT; `DISABLE ROW LEVEL SECURITY`
+// would not move its verdict. Naming the class 'RLS-regression' overstates what the probe can see.
+// Fixing an instrument does not fix its attribution — the two are separate claims.
+const RLS_PROBE_TABLE = 'session_coordination'; // anon INSERT denied by a MISSING GRANT (42501), not by a policy
 const PAYMENT_WEBHOOK_TABLES = ['webhook_events', 'payment_webhook_events']; // candidates — absent today (Stripe test-mode)
 
 /**
@@ -43,11 +52,16 @@ const PAYMENT_WEBHOOK_TABLES = ['webhook_events', 'payment_webhook_events']; // 
 async function probeRls(anon, service, nowMs) {
   const marker = `__RLS_CANARY_PROBE_${nowMs}__`;
   const row = { target_session: marker, message_type: 'INFO', subject: marker, body: 'RLS-regression canary probe (auto-delete)', sender_type: 'system' };
+  // readback failed ⇒ absent evidence, NOT evidence of absence. The `catch` alone did NOT achieve
+  // that: postgrest-js resolves failures as {data:null,error} instead of throwing, so the catch never
+  // ran and every failed readback became rows:[] — "observed, and absent", which is one of the two
+  // conjuncts a three-leg REFUSED requires. Checking `error` is the fix.
   const readByMarker = async () => {
     try {
-      const { data } = await service.from(RLS_PROBE_TABLE).select('id').eq('subject', marker);
+      const { data, error } = await service.from(RLS_PROBE_TABLE).select('id').eq('subject', marker);
+      if (error) return null;
       return { rows: Array.isArray(data) ? data : [] };
-    } catch { return null; }   // readback failed ⇒ absent evidence, NOT evidence of absence
+    } catch { return null; }
   };
 
   const evidence = {};

--- a/scripts/security/rls-acceptance-text-census.mjs
+++ b/scripts/security/rls-acceptance-text-census.mjs
@@ -45,6 +45,7 @@
  */
 import pg from 'pg';
 import dotenv from 'dotenv';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
 dotenv.config({ quiet: true });  // banner on stdout would corrupt --json
 
 const POOLER_HOST = process.env.SUPABASE_POOLER_HOST || 'aws-1-us-east-1.pooler.supabase.com';
@@ -163,4 +164,12 @@ async function main() {
   } finally { await client.end(); }
 }
 
-main().catch((e) => { console.error('census failed:', e.message); process.exit(1); });
+// EXPORTED SO IT CAN BE TESTED. classify() encodes the exact ABSENT / PRESENT-BUT-UNQUOTED /
+// PRESENT-AND-HALF-RIGHT distinction this SD says people mis-apply — 4 of 7 SURVEY-1 items were
+// mis-bucketed on it — and it had no tests, so its discrimination was asserted in prose next to a
+// sibling template whose docstring says a claim nothing checks is not a claim.
+export { classify, PERMISSION_TOKEN, ACCEPTANCE_FRAME, NEGATIVE_PROBE_SHAPE, MENTIONS_READBACK, PRESCRIBES_READBACK, THIRD_LEG };
+
+if (isMainModule(import.meta.url)) {
+  main().catch((e) => { console.error('census failed:', e.message); process.exit(1); });
+}

--- a/scripts/security/rls-feedback-live-probe.cjs
+++ b/scripts/security/rls-feedback-live-probe.cjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * LIVE THREE-LEG PROBE of public.feedback — SD-LEO-INFRA-SURVEY-EVERY-PERMISSION-001.
+ *
+ * WHY THIS EXISTS. Two reasons, and the second is the important one.
+ *
+ * 1. It is the FIRST PRODUCTION CONSUMER of lib/security/rls-probe-template.cjs. Until now the
+ *    template was imported only by its own unit test, so runProbe's live IO path — real supabase-js
+ *    builders, real RETURNING semantics, real cleanup — was entirely unexercised against a real
+ *    client. That is exactly how the H1 collector defect survived review: postgrest-js RESOLVES
+ *    failures as {data:null,error} rather than throwing, which no fake reproduced, so a catch-only
+ *    guard looked correct in tests and manufactured false absence in production. A template with no
+ *    real caller is a design, not an instrument.
+ *
+ * 2. It is a REGRESSION DETECTOR for the feedback policy set, and it FAILS LOUD. Each case declares
+ *    the verdict the CATALOG predicts; a mismatch exits non-zero. So if someone tightens or widens an
+ *    anon INSERT policy on feedback, this says so — including the case everyone gets wrong.
+ *
+ * THE ASYMMETRY THIS PINS, measured 2026-08-03. venture_user_insert_feedback grants anon INSERT for
+ * (feedback_type LIKE 'user_%' AND an ACTIVE venture_id) and places NO constraint on source_type,
+ * while anon SELECT (telegram_bot_select_feedback) is confined to source_type='telegram'. So a row
+ * with source_type='auto_capture' plus a valid venture_id is INSERTABLE but NOT SELECTABLE:
+ *     .insert().select() -> 42501, row ABSENT   (reads as a clean refusal)
+ *     .insert()  IDENTICAL row, no RETURNING -> error null, ROW LANDS
+ * EVERY FIELD IN THAT ROW IS LOAD-BEARING. Drop venture_id and the INSERT is refused too, the case
+ * stops reproducing, and it reads as a refusal — which is why an under-specified repro is worse than
+ * none: it reads as a REFUTATION of the claim it records.
+ *
+ * SAFETY: writes only marker-titled rows to feedback and removes them by marker with service-role
+ * confirmation. runProbe refuses to start if the marker already matches a row (no OPEN from residue)
+ * or if the baseline readback cannot be performed at all.
+ *
+ * USAGE: node scripts/security/rls-feedback-live-probe.cjs        (exit 0 = policies unchanged)
+ */
+require('dotenv').config({ quiet: true });
+const { createSupabaseServiceClient } = require('../../lib/supabase-client.cjs');
+const { buildProbePlan, runProbe, VERDICT } = require('../../lib/security/rls-probe-template.cjs');
+
+const base = (marker) => ({ type: 'issue', source_application: 'EHG_Engineer', title: marker });
+
+// Each case names the policy that decides it, so a failure points at a policy rather than a mystery.
+const CASES = [
+  { name: 'auto_capture, no venture_id',
+    because: 'telegram_bot needs source_type=telegram; venture_user needs venture_id NOT NULL — neither grants',
+    expect: VERDICT.REFUSED, needsVenture: false,
+    row: (m) => ({ ...base(m), source_type: 'auto_capture', feedback_type: 'user_bug' }) },
+  { name: "source_type='telegram'",
+    because: 'telegram_bot_insert_feedback grants it, and anon SELECT covers telegram so RETURNING works too',
+    expect: VERDICT.OPEN, needsVenture: false,
+    row: (m) => ({ ...base(m), source_type: 'telegram', feedback_type: 'user_bug' }) },
+  { name: "telegram + severity='critical'",
+    because: 'the RESTRICTIVE anon_feedback_ingress_bounds bars critical/high regardless of any grant',
+    expect: VERDICT.REFUSED, needsVenture: false,
+    row: (m) => ({ ...base(m), source_type: 'telegram', feedback_type: 'user_bug', severity: 'critical' }) },
+  { name: "telegram + category='chairman_decision_deferred'",
+    because: 'the RESTRICTIVE bounds bar that category regardless of any grant',
+    expect: VERDICT.REFUSED, needsVenture: false,
+    row: (m) => ({ ...base(m), source_type: 'telegram', feedback_type: 'user_bug', category: 'chairman_decision_deferred' }) },
+  { name: 'THE ASYMMETRIC CASE — auto_capture + ACTIVE venture_id',
+    because: 'venture_user_insert_feedback grants the INSERT and places NO constraint on source_type, while anon SELECT is confined to telegram — so RETURNING fails and the bare write lands',
+    expect: VERDICT.OPEN, needsVenture: true,
+    row: (m, v) => ({ ...base(m), source_type: 'auto_capture', feedback_type: 'user_bug', venture_id: v }) },
+];
+
+async function main() {
+  const service = createSupabaseServiceClient();
+  const { createSupabaseClient } = await import('../../lib/supabase-client.js');
+  const anon = createSupabaseClient();
+
+  // The drift guard has TEETH: it asserts the policy set these predictions are DERIVED FROM is still
+  // the policy set in force. If the policies moved, every prediction below is about a table that no
+  // longer exists as described, and reporting a verdict would be worse than reporting nothing.
+  const EXPECTED_INSERT_POLICIES = ['insert_feedback_policy', 'telegram_bot_insert_feedback', 'venture_user_insert_feedback'];
+  const assertPrecondition = async () => {
+    const { data, error } = await service.rpc('exec_sql', {
+      sql: "select policyname from pg_policies where schemaname='public' and tablename='feedback' and cmd='INSERT' and permissive='PERMISSIVE'",
+    }).then((r) => r, (e) => ({ error: e }));
+    if (error) return;                      // rpc unavailable in this env — the row-level check below still runs
+    const names = (data || []).map((r) => r.policyname).sort();
+    const missing = EXPECTED_INSERT_POLICIES.filter((p) => !names.includes(p));
+    if (missing.length) throw new Error(`policy set DRIFTED — missing INSERT policies: ${missing.join(', ')}. Predictions in this file were derived from the old set.`);
+  };
+
+  let ventureId = null;
+  const { data: ventures } = await service.from('ventures').select('id,status').eq('status', 'active').limit(1);
+  if (ventures && ventures.length) ventureId = ventures[0].id;
+
+  let failures = 0;
+  let skipped = 0;
+  for (const c of CASES) {
+    if (c.needsVenture && !ventureId) {
+      console.log(`SKIP  ${c.name} — no active venture available to build the granted row`);
+      skipped++;
+      continue;
+    }
+    const marker = `__FEEDBACK_RLS_PROBE_${Date.now()}_${process.pid}_${CASES.indexOf(c)}__`;
+    const row = c.row(marker, ventureId);
+    const plan = buildProbePlan({
+      table: 'feedback', validRow: row, fieldUnderTest: 'source_type', markerColumn: 'title',
+      // The control must be a row that CANNOT pass: the RESTRICTIVE bounds bar severity='critical'
+      // whatever any permissive policy grants. If this is ever ACCEPTED, runProbe withdraws the
+      // REFUSED verdict rather than reporting it.
+      nonsenseControl: { ...row, severity: 'critical' },
+    });
+    let verdict;
+    try { verdict = await runProbe({ anon, service, plan, assertPrecondition }); }
+    catch (err) { console.log(`ERROR ${c.name} — ${err.message}`); failures++; continue; }
+
+    const ok = verdict.verdict === c.expect;
+    if (!ok) failures++;
+    console.log(`${ok ? 'OK   ' : 'FAIL '} ${c.name}`);
+    console.log(`        expected ${c.expect}, got ${verdict.verdict}  ${JSON.stringify(verdict.detail || {})}`);
+    console.log(`        because: ${c.because}`);
+    if (!ok) console.log(`        -> ${verdict.reason}`);
+  }
+
+  console.log(`\n${failures === 0 ? 'policy set UNCHANGED' : `${failures} MISMATCH(ES) — the feedback policy set has MOVED`}${skipped ? ` (${skipped} skipped)` : ''}`);
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((e) => { console.error('live probe failed:', e.message); process.exit(1); });

--- a/tests/unit/security/rls-acceptance-text-census.test.js
+++ b/tests/unit/security/rls-acceptance-text-census.test.js
@@ -1,0 +1,69 @@
+// SELF-TEST for the SURVEY-4/6 acceptance-text classifier.
+//
+// WHY THIS FILE EXISTS. classify() encodes the exact ABSENT / PRESENT-BUT-UNQUOTED /
+// PRESENT-AND-HALF-RIGHT distinction this SD says people mis-apply — 4 of 7 SURVEY-1 items were
+// mis-bucketed on precisely that difference — and it shipped with no tests. Its discrimination was
+// asserted in a docstring, next to a sibling template whose own docstring says a claim that nothing
+// checks is not a claim. Raised by the TESTING sub-agent at EXEC-TO-PLAN.
+//
+// EVERY ARM MUST DISAGREE WITH ANOTHER. A classifier suite where each case expects the same bucket is
+// satisfied by a constant function; that vacuity was caught once already in this SD's own PRD draft.
+import { describe, it, expect } from 'vitest';
+import { classify } from '../../../scripts/security/rls-acceptance-text-census.mjs';
+
+// Realistic acceptance text, not keyword soup — the classifier is only useful on prose of this shape.
+const ABSENT_TEXT =
+  'Acceptance: anon INSERT into the table must fail with 42501 (row-level security). Verify the error code is returned.';
+const UNQUOTED_TEXT =
+  'Acceptance: anon INSERT must be denied by RLS (42501). Note that the service-role client bypasses policies, so readback behaves differently.';
+const HALF_RIGHT_TEXT =
+  'Acceptance: anon INSERT must be denied (42501, row-level security). Then verify the row is absent using the service role client.';
+const SUFFICIENT_TEXT =
+  'Acceptance: anon INSERT must be denied (42501, RLS). Verify the row is absent via the service role, then re-attempt the identical write without returning and read back again.';
+
+describe('SURVEY-6 — the provenance classifier DISCRIMINATES', () => {
+  it('ABSENT: infers enforcement from the error code, never confirms the row', () => {
+    expect(classify(ABSENT_TEXT)).toBe('ABSENT');
+  });
+  it('PRESENT-BUT-UNQUOTED: mentions readback without prescribing it as the check', () => {
+    expect(classify(UNQUOTED_TEXT)).toBe('PRESENT-BUT-UNQUOTED');
+  });
+  it('PRESENT-AND-HALF-RIGHT: prescribes a readback but stops at two legs', () => {
+    expect(classify(HALF_RIGHT_TEXT)).toBe('PRESENT-AND-HALF-RIGHT');
+  });
+  it('SUFFICIENT: reaches the third leg', () => {
+    expect(classify(SUFFICIENT_TEXT)).toBe('SUFFICIENT');
+  });
+
+  it('all four buckets are distinct in ONE assertion — a constant function fails here', () => {
+    const verdicts = [ABSENT_TEXT, UNQUOTED_TEXT, HALF_RIGHT_TEXT, SUFFICIENT_TEXT].map(classify);
+    expect(new Set(verdicts).size).toBe(4);
+  });
+});
+
+describe('SURVEY-6 — the three conjuncts each actually gate', () => {
+  // The first filter used the generic vocabulary of rejection and returned 3191 of 38165 rows against
+  // an independent measurement of 16+22. It was not finding permission claims; it was finding the
+  // word "rejected". These arms pin each conjunct so that regression cannot return silently.
+  it('no permission token -> not a finding, however rejection-flavoured the text', () => {
+    expect(classify('Acceptance: the request must fail and the submission should be rejected with an error.')).toBeNull();
+  });
+  it('no acceptance frame -> not a finding (narrative prose is not a criterion)', () => {
+    expect(classify('The 42501 permission denied incident last week was caused by a policy change.')).toBeNull();
+  });
+  it('no negative-probe shape -> not a finding (a positive RLS statement is not a probe)', () => {
+    expect(classify('Acceptance: verify the row-level security policy exists on the table.')).toBeNull();
+  });
+});
+
+describe('SURVEY-6 — HALF-RIGHT outranks UNQUOTED, and SUFFICIENT outranks both', () => {
+  // Order matters: text that PRESCRIBES a readback also MENTIONS one, and text with a third leg does
+  // both. If the checks were ordered the other way the dangerous bucket would be reported as the safe
+  // one — which is the mis-bucketing this column exists to prevent.
+  it('text that prescribes AND mentions is HALF-RIGHT, not UNQUOTED', () => {
+    expect(classify(HALF_RIGHT_TEXT)).not.toBe('PRESENT-BUT-UNQUOTED');
+  });
+  it('text with all three legs is SUFFICIENT, not HALF-RIGHT', () => {
+    expect(classify(SUFFICIENT_TEXT)).not.toBe('PRESENT-AND-HALF-RIGHT');
+  });
+});

--- a/tests/unit/security/rls-probe-template.test.js
+++ b/tests/unit/security/rls-probe-template.test.js
@@ -36,11 +36,19 @@ function fakeAnon({ landsWithReturning = false, landsOnBare = false, store = nul
     }),
   };
 }
+// delete().eq() must be awaitable AND chain .select() — deletion-count mode counts what it removed.
 function fakeService(store) {
   return {
     from: () => ({
       select: () => ({ eq: () => Promise.resolve({ data: store.rows, error: null }) }),
-      delete: () => ({ eq: () => { store.rows = []; return Promise.resolve({ error: null }); } }),
+      delete: () => ({
+        eq: () => {
+          const removed = store.rows;
+          store.rows = [];
+          const settled = Promise.resolve({ data: removed, error: null });
+          return { then: (r, j) => settled.then(r, j), select: () => settled };
+        },
+      }),
     }),
   };
 }
@@ -197,9 +205,114 @@ describe('FR-5 — a NON-POLICY error is INCONCLUSIVE, never REFUSED', () => {
   });
 });
 
+describe('FR-5 — the COLLECTOR must not manufacture absence (SECURITY H1)', () => {
+  // postgrest-js resolves failures as {data:null,error} instead of throwing, so a `catch`-only guard
+  // never runs and every failed readback became rows:[] — "observed, and absent". That is one of the
+  // two conjuncts REFUSED requires, so a landed row could be reported REFUSED {legs:3}. The
+  // classifiers were correct throughout; the collector lied to them. These fakes RESOLVE with an
+  // error exactly as the real client does.
+  const erroringService = () => ({
+    from: () => ({
+      select: () => ({ eq: () => Promise.resolve({ data: null, error: { code: 'PGRST205' } }) }),
+      delete: () => ({ eq: () => Promise.resolve({ data: null, error: { code: 'PGRST205' } }) }),
+    }),
+  });
+
+  it('a readback that RESOLVES with an error is absent evidence — never REFUSED', async () => {
+    const v = await runProbe({
+      anon: fakeAnon({ landsOnBare: true, store: { rows: [] } }),
+      service: erroringService(), plan: plan(), assertPrecondition: ok,
+    }).catch((e) => ({ verdict: 'THREW', reason: e.message }));
+    // Either it refuses to report (baseline guard) or it reports INCONCLUSIVE. What it must NEVER do
+    // is return REFUSED off a readback that failed.
+    expect(v.verdict).not.toBe(VERDICT.REFUSED);
+  });
+
+  it('refuses to report at all when the BASELINE confirmation fails', async () => {
+    await expect(runProbe({
+      anon: fakeAnon({ store: { rows: [] } }), service: erroringService(),
+      plan: plan(), assertPrecondition: ok,
+    })).rejects.toThrow(/baseline confirmation FAILED/);
+  });
+
+  it('refuses to run when the marker already matches a row — no OPEN from residue (M2)', async () => {
+    const store = { rows: [{ id: 'pre-existing' }] };
+    await expect(runProbe({
+      anon: fakeAnon({ store }), service: fakeService(store), plan: plan(), assertPrecondition: ok,
+    })).rejects.toThrow(/not unique/);
+  });
+});
+
+describe('FR-5 — the nonsense control is EXECUTED, not merely required (SECURITY M1)', () => {
+  // Instrumentation showed ZERO property reads on plan.nonsenseControl during a full probe: it was
+  // present as a field and absent as a check. A probe cannot show it is still capable of failing by
+  // holding a control it never attempts.
+  it('withdraws a REFUSED verdict when the control row is ACCEPTED', async () => {
+    const store = { rows: [] };
+    // Denies the probe row, accepts anything else — i.e. the guard has stopped discriminating.
+    const anon = {
+      from: () => ({
+        insert: (row) => {
+          const isControl = String(row[Object.keys(row).find((k) => k === 'subject')] || '').includes('__CONTROL__');
+          if (isControl) { store.rows = [{ id: 'control-landed' }]; return Promise.resolve({ error: null }); }
+          return { then: (r) => Promise.resolve({ error: { code: '42501' } }).then(r),
+            select: () => Promise.resolve({ data: null, error: { code: '42501' } }) };
+        },
+      }),
+    };
+    const service = {
+      from: () => ({
+        select: () => ({ eq: (_c, v) => Promise.resolve({
+          data: String(v).includes('__CONTROL__') ? store.rows : [], error: null }) }),
+        delete: () => ({ eq: () => { store.rows = []; return Promise.resolve({ error: null }); } }),
+      }),
+    };
+    const v = await runProbe({ anon, service, plan: plan(), assertPrecondition: ok });
+    expect(v.verdict).toBe(VERDICT.INCONCLUSIVE);
+    expect(v.detail.control).toBe('landed');
+    expect(v.detail.withdrawn_verdict).toBe(VERDICT.REFUSED);
+  });
+
+  it('a REFUSED verdict records that the control was denied', async () => {
+    const store = { rows: [] };
+    const v = await runProbe({
+      anon: fakeAnon({ landsOnBare: false, store }), service: fakeService(store),
+      plan: plan(), assertPrecondition: ok,
+    });
+    expect(v.verdict).toBe(VERDICT.REFUSED);
+    expect(v.detail.control).toBe('denied');
+  });
+});
+
+describe('FR-5 — deletion-count mode can actually CONCLUDE (SECURITY M3)', () => {
+  // confirm() only ever emitted `rows` while present()/observed() read only `.deleted`, so in
+  // deletion-count mode a LANDED write returned INCONCLUSIVE "no service-role confirmation" — about a
+  // confirmation that had run. A mode that can never reach a verdict is not a mode.
+  it('reports OPEN when the row lands, rather than INCONCLUSIVE', async () => {
+    const store = { rows: [] };
+    const dcPlan = buildProbePlan({
+      table: 'feedback', validRow, fieldUnderTest: 'feedback_type',
+      nonsenseControl: nonsense, confirmBy: CONFIRM.DELETION_COUNT,
+    });
+    const v = await runProbe({
+      anon: fakeAnon({ landsOnBare: true, store }), service: fakeService(store),
+      plan: dcPlan, assertPrecondition: ok,
+    });
+    expect(v.verdict).toBe(VERDICT.OPEN);
+  });
+});
+
 describe('FR-5 — 1-REP is ENFORCED against the canary, not asserted in prose', () => {
   // The docstring used to claim "one representation of the rule, two consumers". It was false — the
   // canary required 42501 and this classifier did not. This test is what makes the claim true.
+  //
+  // SCOPE, STATED RATHER THAN IMPLIED: every case below is ABSENCE-MODE evidence, because absence
+  // mode is the canary's ENTIRE domain — classifyRlsProbe has no confirmBy switch and reads only
+  // `rows`. So this asserts agreement across the whole surface the two actually share, and it does
+  // NOT cover deletion-count evidence, where they genuinely differ and the canary is not a consumer
+  // at all. Left uncovered deliberately: forcing agreement there would mean asserting something about
+  // a mode one side does not implement. A cross-check whose scope is unstated invites the reader to
+  // assume it covers everything — which is how the divergence it now catches got in.
   const { classifyRlsProbe } = require('../../../lib/breakage/active-canary-probes.cjs');
   const EVIDENCE = [
     ['landed via bare', { withReturning: { data: null, error: { code: '42501' } }, readbackAfterReturning: { rows: [] }, bareInsert: { error: null }, readbackAfterBare: { rows: [{ id: 'x' }] } }],


### PR DESCRIPTION
## The classifiers were correct; the collectors lied to them

Found by the **SECURITY** and **TESTING** sub-agents at EXEC-TO-PLAN, against code this SD had **already merged**. Every defect here is this SD's own thesis, committed by the instrument built to enforce it.

### H1 — a failed readback was scored as *confirmed absence*, in both implementations
"A failed readback is ABSENT EVIDENCE, not evidence of absence" was in the docstrings, stated in a test, and **violated by the collector**. The obvious way to write it is wrong:

```js
try { const { data } = await service...; return { rows: Array.isArray(data) ? data : [] }; }
catch { return null; }
```

`postgrest-js` does not throw by default — it **resolves** a failed query as `{data:null,error}`. So the `catch` is dead code, and every readback failure became `rows: []` — *"observed, and absent"* — one of the two conjuncts REFUSED requires.

Measured live: a select against a missing relation resolves to `{data:null,code:'PGRST205'}`, and a **landed** row then reported `REFUSED {legs:3}`. Checking `error` is the entire fix. Applied to **both** implementations.

The test that claimed to cover this fed `readbackAfterReturning: null` — a shape the IO layer can essentially never produce. It asserted over an unreachable population.

### H2 — the canary probes the GRANT, not RLS
`session_coordination` has `relrowsecurity=true` but exactly **one** policy (`service_role_full_access`, PERMISSIVE, **cmd=SELECT**) — no INSERT policy at all — and anon's grants are `REFERENCES/SELECT/TRIGGER`, no INSERT. **A missing GRANT raises the same SQLSTATE 42501 as an RLS `WITH CHECK` violation**, so the probe's REFUSED is evidence about the grant; `DISABLE ROW LEVEL SECURITY` would not move it.

The old comment read *"anon INSERT is RLS-denied (verified 42501)"* — 42501 observed, enforcement attributed to the wrong mechanism, in a comment, inside the SD about exactly that error. Fixing an instrument does not fix its attribution.

### M1 — the required nonsense control was never executed
Making it a mandatory **slot** stopped it being forgotten; nothing ever **ran** it. Instrumentation showed zero property reads on `plan.nonsenseControl` during a full probe — present as a field, absent as a check, the same false comfort as the discipline it replaced. It now runs on a REFUSED verdict, and if a row that must be denied is **accepted**, the verdict is **withdrawn** to INCONCLUSIVE rather than reported.

### M2, M3, M4
- **M2** — no pre-write baseline, so residue from an earlier run read as "the write landed" → OPEN (on the canary path: alert + non-zero exit). A pre-existing marker match also means the marker isn't unique, so it now throws. An unreadable baseline throws too — refusing to report beats reporting on a reader that cannot see the table.
- **M3** — deletion-count mode could never conclude: `confirm()` emitted only `rows` while `present()/observed()` read only `.deleted`, so a landed write returned INCONCLUSIVE *"no service-role confirmation"* about a confirmation that had run.
- **M4** — the 1-REP cross-check's **scope is now stated**. Its cases are all absence-mode, which is the canary's entire domain, so it covers the whole surface the two actually share — and not deletion-count, where they differ and the canary isn't a consumer. Deliberately uncovered, said out loud: a cross-check whose scope is unstated invites the reader to assume it covers everything, which is how the divergence it now catches got in.

### TESTING
`classify()` encoded the exact ABSENT / PRESENT-BUT-UNQUOTED / PRESENT-AND-HALF-RIGHT distinction this SD says people mis-apply, had **zero tests**, and wasn't exported. Now exported behind an `isMainModule` guard (so importing it doesn't run a live census), with 10 tests.

## Mutation-proven — every new guard

| mutation | result |
|---|---|
| drop the H1 error check | **2 failed** |
| never execute the control | **2 failed** |
| drop the baseline guard | **1 failed** |
| swap the bucket order | **3 failed** |
| `classify` always returns ABSENT | **4 failed** |
| restored | 32/32 and 10/10 — **67** across three files |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
