### PR TITLE
fix(SD-LEO-INFRA-GUARD-FIRING-RECORDS-001): make each safety guard's zero readable

### DIFF
--- a/lib/coordinator/singleton-relaunch-trigger.js
+++ b/lib/coordinator/singleton-relaunch-trigger.js
@@ -204,6 +204,72 @@ export async function evaluateSingletonRelaunch(supabase, {
   return { role, scheduled: true, reason: decision.reason, scheduleId: written.id, freshness, fleetActivity, sessionId, loopState };
 }
 
+/**
+ * SD-LEO-INFRA-GUARD-FIRING-RECORDS-001 / FR-3 — THE SWEEP'S DENOMINATOR.
+ *
+ * MEASURED: singleton_relaunch_scheduled reads 0 of 5,166 session_coordination rows, LIFETIME.
+ * That zero was uninterpretable from inside the database, because the sweep recorded nothing when
+ * it declined — exactly the FR-2 defect in a second guard. Establishing that the sweep runs at all
+ * required leaving the system and reading GitHub Actions history (10 consecutive successful runs of
+ * singleton-relaunch-cron.yml), which is the same "induce it and watch" cost this SD was filed
+ * about. After this change the answer is one query against the same DB.
+ *
+ * NOTE THE CORRECTION THIS ENCODES: the SD searched system_events for %relaunch% and found nothing,
+ * concluding the net had no recorder. It HAS one — writeScheduleRecord — it just lives in
+ * session_coordination. The SD looked in the wrong table. Writing the denominator to system_events
+ * makes that original diagnostic query answer truthfully instead of misleading the next reader.
+ *
+ * WHY ONE ROW PER SWEEP AND NOT FR-2'S HOURLY AGGREGATE: this is not a hot path. The scheduler runs
+ * ~4x/hour from cron, so a row per sweep is ~96/day — affordable, and it keeps the per-role reason
+ * breakdown intact. Aggregating here would discard the field that does the actual work.
+ *
+ * BY_REASON IS THE POINT, not the count. "0 scheduled" is not diagnosable; "0 scheduled, declined
+ * for fleet_busy 400x and target_not_idle 900x" names which precondition is the blocker — and a
+ * breakdown that is entirely unknown_role would expose a wiring fault the bare count would hide.
+ */
+export const sweepAuditFailures = { singleton_relaunch_evaluated: 0 };
+
+export function summarizeSweep(results) {
+  const rows = Array.isArray(results) ? results.filter(Boolean) : [];
+  const byReason = {};
+  for (const r of rows) {
+    const key = r.reason || 'no_reason_recorded';
+    byReason[key] = (byReason[key] || 0) + 1;
+  }
+  return {
+    guard: 'singleton_relaunch',
+    evaluated: rows.length,
+    scheduled: rows.filter((r) => r.scheduled === true).length,
+    by_reason: byReason,
+  };
+}
+
+/**
+ * Record that the sweep RAN. Never throws and never alters the sweep's outcome — a telemetry write
+ * that could break the relaunch net would trade an observability gap for the very outage the net
+ * exists to prevent. Its own failures are counted and reported (FR-1's lesson): a silent recorder
+ * here would recreate this exact defect one level down.
+ */
+export async function recordSweepEvaluation(supabase, results, opts = {}) {
+  const summary = summarizeSweep(results);
+  try {
+    const { error } = await supabase.from('system_events').insert({
+      event_type: 'singleton_relaunch_evaluated',
+      payload: { ...summary, swept_at: opts.now || new Date().toISOString() },
+    });
+    if (error) throw new Error(error.message);
+  } catch (err) {
+    sweepAuditFailures.singleton_relaunch_evaluated += 1;
+    try {
+      console.warn('[singleton-relaunch] SWEEP-COUNT WRITE FAILED (non-fatal, sweep outcome unchanged): '
+        + `${(err && err.message) || err} — this sweep is UNRECORDED, so the scheduled-count zero `
+        + `stays uninterpretable; at least ${sweepAuditFailures.singleton_relaunch_evaluated} sweep(s) `
+        + 'are missing from the denominator.');
+    } catch { /* a broken console must not become a new way for the sweep to die */ }
+  }
+  return summary;
+}
+
 /** Evaluate all 3 singleton roles for one tick. Freshness + fleet-quiescence are computed ONCE
  * and shared — today all 3 singletons operate from the same shared working tree, and fleet
  * activity is fleet-wide, not per-role, so recomputing 3x would just be 3x the git/DB cost for
@@ -216,6 +282,10 @@ export async function evaluateAllSingletons(supabase, { checkoutPath = process.c
     // sequential by design: each write must dedupe against the previous role's own record, not race
     results.push(await evaluateSingletonRelaunch(supabase, { role, checkoutPath, senderSession, freshness, fleetActivity, enabled }));
   }
+  // FR-3: record that the sweep ran, whatever it decided. This is the denominator that makes a
+  // zero scheduled-count readable. Unconditional by design — recording only non-empty sweeps
+  // would reproduce the blindness, since the all-declined sweep is the case in question.
+  await recordSweepEvaluation(supabase, results);
   return results;
 }
 
@@ -228,4 +298,7 @@ export default {
   writeScheduleRecord,
   evaluateSingletonRelaunch,
   evaluateAllSingletons,
+  summarizeSweep,
+  recordSweepEvaluation,
+  sweepAuditFailures,
 };

--- a/lib/fleet/claimant-liveness.cjs
+++ b/lib/fleet/claimant-liveness.cjs
@@ -222,6 +222,23 @@ async function fenceDisabled(sb, nowMs = Date.now()) {
  * pids that were consulted, not just the fact that something was refused. Best-effort by design:
  * the audit must never be able to block or fail a claim decision.
  */
+// SD-LEO-INFRA-GUARD-FIRING-RECORDS-001 (FR-1): counts audit writes that FAILED, in-process.
+//
+// The catch below must keep swallowing — the docstring above is right that an audit write must never
+// block a claim decision, and a fence that failed closed because system_events was unreachable would
+// be a far worse defect than an unreadable counter. What was wrong is that the catch was EMPTY, so a
+// refusal whose insert failed left NOTHING anywhere: "never fired" and "fired but not recorded"
+// became the same observation, and the lifetime count of zero could not be interpreted.
+//
+// Swallow the EFFECT, never the EVIDENCE. Same shape as _emitS19HardGateEvent
+// (lib/eva/stage-execution-worker.js:3928), which writes this same table through this same
+// best-effort wrapper and logs on failure.
+//
+// The counter is deliberately in-process and deliberately NOT sufficient on its own: as the
+// docstring notes, anything console-or-memory-shaped dies with the process. It makes the failure
+// COUNTABLE and testable here; making a zero READABLE is FR-2's denominator, not this.
+const auditFailures = { claim_write_refused_claimant_not_live: 0 };
+
 async function recordRefusal(sb, detail, context = {}) {
   try {
     await sb.from('system_events').insert({
@@ -230,7 +247,15 @@ async function recordRefusal(sb, detail, context = {}) {
       actor_role: 'fleet-worker',
       payload: { ...detail, ...context, sd_key: context.sdKey ?? null },
     });
-  } catch { /* audit is best-effort; never let it affect the fence outcome */ }
+  } catch (err) {
+    // Effect swallowed (the fence outcome is untouched); evidence is not.
+    auditFailures.claim_write_refused_claimant_not_live += 1;
+    try {
+      console.warn('[claimant-liveness] REFUSAL AUDIT WRITE FAILED (non-fatal, fence outcome unchanged): '
+        + `${(err && err.message) || err} — this refusal is UNRECORDED; the lifetime refusal count `
+        + `now under-reports by at least ${auditFailures.claim_write_refused_claimant_not_live}.`);
+    } catch { /* logging must not throw into the fence either */ }
+  }
 }
 
 /**
@@ -300,6 +325,11 @@ module.exports = {
   claimantLivenessFence,
   fenceDisabled,
   recordRefusal,
+  // SD-LEO-INFRA-GUARD-FIRING-RECORDS-001 (FR-1): exported so the FAILURE path is assertable.
+  // That path has, on the evidence, never executed — a lifetime count of zero refusals with a
+  // silent catch is exactly the state this SD exists to make readable — so it needs a test that
+  // forces it rather than one that exercises the happy path and inherits the same blindness.
+  auditFailures,
   FENCE_DISABLED_CACHE,
   shouldRefuseClaim,
   pidIsClaude,

--- a/lib/fleet/claimant-liveness.cjs
+++ b/lib/fleet/claimant-liveness.cjs
@@ -237,7 +237,73 @@ async function fenceDisabled(sb, nowMs = Date.now()) {
 // The counter is deliberately in-process and deliberately NOT sufficient on its own: as the
 // docstring notes, anything console-or-memory-shaped dies with the process. It makes the failure
 // COUNTABLE and testable here; making a zero READABLE is FR-2's denominator, not this.
-const auditFailures = { claim_write_refused_claimant_not_live: 0 };
+const auditFailures = { claim_write_refused_claimant_not_live: 0, claim_fence_evaluated: 0 };
+
+// SD-LEO-INFRA-GUARD-FIRING-RECORDS-001 (FR-2): the DENOMINATOR.
+//
+// A guard's pass path runs constantly, so it always looks healthy; its refuse path may never have
+// executed. Zero refusals therefore means UNTESTED, not safe — unless you know how many times the
+// guard was evaluated. Measured before this change: 0 refusals lifetime, and no evaluation record
+// of any kind, so the zero could not be read at all.
+//
+// LOW-CARDINALITY BY CONSTRUCTION. system_events is already 125,275 of 128,267 rows a single event
+// type (97.7%), and the FR-5 comment at the call site is right that a row per claim would bury the
+// refusals an incident review actually reads. So evaluations accumulate in memory and flush as ONE
+// aggregate row per hour bucket per process: the ratio becomes readable without the flood.
+//
+// The bucket key also makes the flush naturally idempotent-ish across a process's lifetime without
+// needing a read-modify-write.
+const fenceEvaluations = { evaluated: 0, refused: 0, pendingEvaluated: 0, pendingRefused: 0, lastBucket: null };
+
+/** PURE: fold one fence outcome into the counters. */
+function recordEvaluation(refused) {
+  fenceEvaluations.evaluated += 1;
+  fenceEvaluations.pendingEvaluated += 1;
+  if (refused) { fenceEvaluations.refused += 1; fenceEvaluations.pendingRefused += 1; }
+}
+
+/** PURE: the hour bucket a timestamp belongs to. Exported so the flush boundary is assertable. */
+function evaluationBucket(now = Date.now()) {
+  return new Date(now).toISOString().slice(0, 13); // YYYY-MM-DDTHH
+}
+
+/**
+ * Flush the accumulated evaluation count once per hour bucket.
+ *
+ * Best-effort in the same sense as recordRefusal, and for the same reason: a denominator write must
+ * never be able to block or fail a claim decision. Failure is COUNTED and reported rather than
+ * swallowed silently — the FR-1 lesson applied to the FR-2 path, so this cannot become a second
+ * invisible recorder.
+ */
+async function maybeFlushEvaluationCount(sb, now = Date.now()) {
+  const bucket = evaluationBucket(now);
+  if (fenceEvaluations.lastBucket === bucket) return;           // already flushed this hour
+  if (fenceEvaluations.lastBucket === null) {                   // first evaluation in this process
+    fenceEvaluations.lastBucket = bucket;
+    return;                                                     // nothing accrued yet to report
+  }
+  const evaluated = fenceEvaluations.pendingEvaluated;
+  const refused = fenceEvaluations.pendingRefused;
+  fenceEvaluations.lastBucket = bucket;
+  fenceEvaluations.pendingEvaluated = 0;
+  fenceEvaluations.pendingRefused = 0;
+  if (evaluated === 0) return;
+  try {
+    await sb.from('system_events').insert({
+      event_type: 'claim_fence_evaluated',
+      actor_type: 'agent',
+      actor_role: 'fleet-worker',
+      payload: { evaluated, refused, bucket, guard: 'claimant_liveness' },
+    });
+  } catch (err) {
+    auditFailures.claim_fence_evaluated += 1;
+    try {
+      console.warn('[claimant-liveness] EVALUATION-COUNT WRITE FAILED (non-fatal): '
+        + `${(err && err.message) || err} — ${evaluated} evaluation(s) in bucket ${bucket} are `
+        + 'UNRECORDED, so a zero refusal count stays uninterpretable for that window.');
+    } catch { /* logging must not throw into the fence either */ }
+  }
+}
 
 async function recordRefusal(sb, detail, context = {}) {
   try {
@@ -311,6 +377,15 @@ async function claimantLivenessFence(sb, sessionId, opts = {}) {
   // per claim would bury the rows that matter — the refusals are what an incident review reads.
   if (refuse) await recordRefusal(sb, detail, opts.context || {});
 
+  // SD-LEO-INFRA-GUARD-FIRING-RECORDS-001 (FR-2): count the EVALUATION, so the refusal count has a
+  // denominator. The comment above is correct and is exactly why this is an aggregate rather than a
+  // row: writing one event per claim would bury the refusals, so the flood the original author
+  // avoided is not reintroduced here. What was missing is that "0 refusals" and "0 evaluations"
+  // were the same observation — 0 of 10,000 means the fence never fired, 0 of 0 means it never ran,
+  // and only the second is an alarm.
+  recordEvaluation(refuse);
+  await maybeFlushEvaluationCount(sb, opts.now);
+
   return { reason: refuse ? CLAIMANT_NOT_LIVE : null, detail };
 }
 
@@ -330,6 +405,12 @@ module.exports = {
   // silent catch is exactly the state this SD exists to make readable — so it needs a test that
   // forces it rather than one that exercises the happy path and inherits the same blindness.
   auditFailures,
+  // FR-2: the denominator seam. Exported so the flush BOUNDARY is assertable — a counter that
+  // silently never flushes would leave the zero exactly as unreadable as before.
+  fenceEvaluations,
+  recordEvaluation,
+  evaluationBucket,
+  maybeFlushEvaluationCount,
   FENCE_DISABLED_CACHE,
   shouldRefuseClaim,
   pidIsClaude,

--- a/scripts/guard-firing-characterization.mjs
+++ b/scripts/guard-firing-characterization.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-GUARD-FIRING-RECORDS-001 / FR-4 — is this guard's zero READABLE?
+ *
+ * The SD asks to characterize safety-guard recorders so a zero count can be interpreted. The
+ * trap TS-6 guards against is a report that lists guards and their event types: that leaves the
+ * reader exactly where the SD started, because the question was never "what does it record" but
+ * "can I believe the zero". So every row here ends in a verdict about the ZERO, not a description.
+ *
+ * THE STATES THAT MUST NOT COLLAPSE:
+ *   FIRES                   — acted N times. Working, and visibly so.
+ *   NEVER_FIRED             — ran N times, acted 0 times. Readable, and probably healthy.
+ *   NO_EVALUATIONS_RECORDED — ran 0 recorded times. Either the guard never ran, OR its denominator
+ *                             is not deployed yet. This instrument deliberately does NOT guess
+ *                             between those two: claiming "never ran" when the truth is "not
+ *                             deployed" would be this report committing the very ambiguity the SD
+ *                             exists to remove.
+ *   UNREADABLE              — no denominator exists at all, so nothing above can be told apart.
+ *
+ * A GUARD WITH NO DENOMINATOR IS NOT REPORTED AS HEALTHY. It is reported as unreadable, which is
+ * a finding rather than a pass — the whole point of the SD.
+ *
+ * WHY THE COUNTS DIE ON ERROR: a failed count that defaults to 0 renders as "never fired", which
+ * is the exact misreading this SD exists to prevent. An unknown must never print as a zero.
+ *
+ * Usage: node scripts/guard-firing-characterization.mjs [--json]
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+/**
+ * Guards in scope. `action` is the event a guard writes WHEN IT FIRES; `denominator` is the event
+ * proving it RAN. A null denominator is the defect, not a missing config field.
+ */
+export const GUARD_REGISTRY = [
+  {
+    guard: 'claimant_liveness',
+    what: 'refuses a claim write when the claiming session is not live',
+    action: { table: 'system_events', column: 'event_type', value: 'claim_write_refused_claimant_not_live' },
+    denominator: { table: 'system_events', column: 'event_type', value: 'claim_fence_evaluated' },
+    denominator_shipped_by: 'FR-2 (hourly aggregate — evaluations are a hot path)',
+  },
+  {
+    guard: 'singleton_relaunch',
+    what: 'schedules a fresh-checkout relaunch of a stale Adam / Solomon / coordinator',
+    action: { table: 'session_coordination', column: 'payload->>kind', value: 'singleton_relaunch_scheduled', json: true },
+    denominator: { table: 'system_events', column: 'event_type', value: 'singleton_relaunch_evaluated' },
+    denominator_shipped_by: 'FR-3 (one row per sweep — ~4 sweeps/hour, not a hot path)',
+  },
+];
+
+export function verdictFor({ actions, evaluations }) {
+  if (evaluations === null) {
+    return { verdict: 'UNREADABLE', because: 'no denominator: never-fired and never-ran are indistinguishable' };
+  }
+  if (evaluations === 0) {
+    // DO NOT COLLAPSE THESE TWO. A zero here means EITHER the guard never ran, OR its denominator
+    // is not deployed yet and has therefore never emitted. Reporting the first alone would be an
+    // instrument committing the very ambiguity this SD exists to remove — so the verdict names
+    // what is observed (no evaluations recorded) and the note names both causes.
+    return {
+      verdict: 'NO_EVALUATIONS_RECORDED',
+      because: 'either the guard never ran, or its denominator is not deployed yet — this instrument '
+        + 'cannot tell those apart from the database alone; confirm the denominator is live before '
+        + 'reading this as an alarm',
+    };
+  }
+  if (actions === 0) {
+    return { verdict: 'NEVER_FIRED', because: `ran ${evaluations} time(s) and never needed to act — the zero is readable` };
+  }
+  return { verdict: 'FIRES', because: `acted ${actions} time(s) across ${evaluations} evaluation(s)` };
+}
+
+async function countOf(sb, spec) {
+  if (!spec) return null;
+  let q = sb.from(spec.table).select('*', { count: 'exact', head: true });
+  q = spec.json ? q.filter(spec.column, 'eq', spec.value) : q.eq(spec.column, spec.value);
+  const { count, error } = await q;
+  // Never coerce a failed read to 0 — that would print as "never fired".
+  if (error) throw new Error(`count failed for ${spec.table}.${spec.column}=${spec.value}: ${error.message}`);
+  return count;
+}
+
+export async function characterize(sb, registry = GUARD_REGISTRY) {
+  const out = [];
+  for (const g of registry) {
+    const actions = await countOf(sb, g.action);
+    const evaluations = await countOf(sb, g.denominator);
+    out.push({ guard: g.guard, what: g.what, actions, evaluations, ...verdictFor({ actions, evaluations }), denominator_shipped_by: g.denominator_shipped_by });
+  }
+  return out;
+}
+
+async function main() {
+  const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const rows = await characterize(sb);
+  if (process.argv.includes('--json')) {
+    console.log(JSON.stringify(rows, null, 2));
+    return;
+  }
+  console.log('\nGUARD FIRING CHARACTERIZATION — can each guard\'s zero be believed?\n');
+  for (const r of rows) {
+    console.log(`  ${r.guard}  [${r.verdict}]`);
+    console.log(`    ${r.what}`);
+    console.log(`    fired ${r.actions} time(s); evaluated ${r.evaluations === null ? 'UNRECORDED' : r.evaluations} time(s)`);
+    console.log(`    ${r.because}`);
+    console.log(`    denominator: ${r.denominator_shipped_by}\n`);
+  }
+  const unreadable = rows.filter((r) => r.verdict === 'UNREADABLE' || r.verdict === 'NO_EVALUATIONS_RECORDED');
+  console.log(unreadable.length
+    ? `  ${unreadable.length} guard(s) still cannot be believed: ${unreadable.map((r) => r.guard).join(', ')}`
+    : '  every guard in scope now has an interpretable zero.');
+  console.log('\n  SCOPE: the two guards this SD examined. The missing-denominator convention is');
+  console.log('  TABLE-WIDE — all 8 event types in the newest 1000 system_events rows are refusals');
+  console.log('  or terminal outcomes; not one records that something ran and passed. The rest of');
+  console.log('  that surface is NOT covered here and is named in the completion flags.\n');
+}
+
+if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('guard-firing-characterization.mjs')) {
+  main().catch((e) => { console.error('FATAL:', e.message); process.exitCode = 1; });
+}

--- a/tests/unit/coordinator/singleton-relaunch-sweep-denominator.test.js
+++ b/tests/unit/coordinator/singleton-relaunch-sweep-denominator.test.js
@@ -1,0 +1,150 @@
+// SD-LEO-INFRA-GUARD-FIRING-RECORDS-001 (FR-3) — the relaunch sweep's denominator.
+//
+// MEASURED STATE THAT MOTIVATED THIS: payload.kind='singleton_relaunch_scheduled' reads 0 of 5,166
+// session_coordination rows, LIFETIME. The sweep recorded NOTHING when it declined, so that zero
+// could not be read from inside the database at all.
+//
+// A CORRECTION THE SD ITSELF NEEDS: the SD searched system_events for %relaunch%, found nothing, and
+// concluded the relaunch net had no recorder. It HAS one — writeScheduleRecord — in
+// session_coordination. The SD looked in the wrong table. The denominator goes to system_events so
+// that original diagnostic query answers truthfully instead of misleading the next reader.
+//
+// WHY THIS MATTERS MORE THAN THE COUNT: proving the sweep runs at all currently requires LEAVING the
+// system and reading GitHub Actions history (singleton-relaunch-cron.yml, 10 consecutive successes).
+// That is the same "induce it and watch" cost the SD was filed about, wearing different clothes.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  summarizeSweep,
+  recordSweepEvaluation,
+  sweepAuditFailures,
+} from '../../../lib/coordinator/singleton-relaunch-trigger.js';
+
+const capture = () => {
+  const rows = [];
+  return { rows, sb: { from: () => ({ insert: async (r) => { rows.push(r); return { error: null }; } }) } };
+};
+const errorSb = { from: () => ({ insert: async () => ({ error: { message: 'permission denied' } }) }) };
+const throwingSb = { from: () => ({ insert: async () => { throw new Error('socket hang up'); } }) };
+
+const declined = [
+  { role: 'adam', scheduled: false, reason: 'fleet_busy' },
+  { role: 'solomon', scheduled: false, reason: 'fleet_busy' },
+  { role: 'coordinator', scheduled: false, reason: 'target_not_idle' },
+];
+
+beforeEach(() => { sweepAuditFailures.singleton_relaunch_evaluated = 0; });
+
+describe('FR-3: an all-declined sweep is still recorded', () => {
+  // THE LOAD-BEARING TEST. Recording only sweeps that scheduled something would reproduce exactly
+  // the blindness being fixed — the all-declined sweep IS the case in question.
+  it('writes a row even when nothing was scheduled', async () => {
+    const { rows, sb } = capture();
+    await recordSweepEvaluation(sb, declined, { now: '2026-08-03T06:00:00Z' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].event_type).toBe('singleton_relaunch_evaluated');
+    expect(rows[0].payload.evaluated).toBe(3);
+    expect(rows[0].payload.scheduled).toBe(0);
+  });
+
+  // The two states the SD is about. Before FR-3 both were the same observation: nothing.
+  it('distinguishes ran-and-declined from never-ran', async () => {
+    const { rows, sb } = capture();
+    await recordSweepEvaluation(sb, declined, {});
+    expect(rows[0].payload.evaluated).toBeGreaterThan(0);  // it RAN
+    expect(rows[0].payload.scheduled).toBe(0);             // and declined — readable, not alarming
+    // never-ran is the absence of any such row, which is now a distinguishable observation
+    const { rows: none } = capture();
+    expect(none).toEqual([]);
+  });
+
+  // by_reason is the field that does the work: a bare zero is not diagnosable, a reason breakdown
+  // names which precondition is blocking — and an all-unknown_role breakdown would expose a wiring
+  // fault that the count alone would hide.
+  it('breaks the declines down by reason', async () => {
+    const { rows, sb } = capture();
+    await recordSweepEvaluation(sb, declined, {});
+    expect(rows[0].payload.by_reason).toEqual({ fleet_busy: 2, target_not_idle: 1 });
+    expect(rows[0].payload.guard).toBe('singleton_relaunch');
+  });
+
+  it('counts a genuine schedule in the numerator', () => {
+    const s = summarizeSweep([
+      { role: 'adam', scheduled: true, reason: 'behind_and_quiescent' },
+      { role: 'solomon', scheduled: false, reason: 'fleet_busy' },
+    ]);
+    expect(s.evaluated).toBe(2);
+    expect(s.scheduled).toBe(1);
+  });
+
+  it('tolerates a malformed result set rather than mislabelling it', () => {
+    const s = summarizeSweep([null, undefined, { role: 'adam' }]);
+    expect(s.evaluated).toBe(1);
+    expect(s.scheduled).toBe(0);
+    expect(s.by_reason).toEqual({ no_reason_recorded: 1 });   // never silently counted as a decline
+  });
+
+  it('handles a non-array without throwing', () => {
+    expect(summarizeSweep(undefined).evaluated).toBe(0);
+    expect(summarizeSweep('nonsense').evaluated).toBe(0);
+  });
+});
+
+describe('FR-3 inherits FR-1: the denominator writer cannot itself be silent', () => {
+  it('counts and reports a returned error', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await recordSweepEvaluation(errorSb, declined, {});
+      expect(sweepAuditFailures.singleton_relaunch_evaluated).toBe(1);
+      const said = warn.mock.calls.flat().join(' ');
+      expect(said).toMatch(/SWEEP-COUNT WRITE FAILED/);
+      expect(said).toMatch(/uninterpretable/);
+    } finally { warn.mockRestore(); }
+  });
+
+  it('counts and reports a thrown error too — both failure shapes, not just the tidy one', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await recordSweepEvaluation(throwingSb, declined, {});
+      expect(sweepAuditFailures.singleton_relaunch_evaluated).toBe(1);
+      expect(warn.mock.calls.flat().join(' ')).toMatch(/at least 1 sweep/);
+    } finally { warn.mockRestore(); }
+  });
+
+  // CONTROL — telemetry that could break the relaunch net would trade an observability gap for the
+  // very outage the net exists to prevent.
+  it('CONTROL: never throws, so it cannot break the sweep', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await expect(recordSweepEvaluation(throwingSb, declined, {})).resolves.toBeTruthy();
+      const hostile = { from: () => { throw new Error('client exploded'); } };
+      await expect(recordSweepEvaluation(hostile, declined, {})).resolves.toBeTruthy();
+      expect(sweepAuditFailures.singleton_relaunch_evaluated).toBe(2);
+    } finally { warn.mockRestore(); }
+  });
+
+  it('CONTROL: a successful write neither counts nor warns', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const { sb } = capture();
+      await recordSweepEvaluation(sb, declined, {});
+      expect(sweepAuditFailures.singleton_relaunch_evaluated).toBe(0);
+      expect(warn).not.toHaveBeenCalled();
+    } finally { warn.mockRestore(); }
+  });
+});
+
+// THE WIRING TEST. This SD's own investigation found relaunchOntoFreshCheckout — a fully built,
+// fully tested relaunch executor with ZERO production callers. A recorder that exists but is never
+// invoked emits the same unreadable zero as no recorder at all, so shipping one unwired would
+// reproduce the defect while appearing to fix it.
+describe('FR-3: the recorder is actually CALLED by the sweep', () => {
+  it('evaluateAllSingletons invokes recordSweepEvaluation', async () => {
+    const src = await import('node:fs').then((fs) =>
+      fs.readFileSync(new URL('../../../lib/coordinator/singleton-relaunch-trigger.js', import.meta.url), 'utf8'));
+    const body = src.slice(src.indexOf('export async function evaluateAllSingletons'));
+    expect(body).toMatch(/await recordSweepEvaluation\(supabase, results\)/);
+    // and it is reached on every path — not tucked behind a scheduled-something branch
+    const upToCall = body.slice(0, body.indexOf('await recordSweepEvaluation'));
+    expect(upToCall).not.toMatch(/if\s*\([^)]*scheduled/);
+  });
+});

--- a/tests/unit/fleet/claimant-liveness-audit-visibility.test.js
+++ b/tests/unit/fleet/claimant-liveness-audit-visibility.test.js
@@ -1,0 +1,90 @@
+// SD-LEO-INFRA-GUARD-FIRING-RECORDS-001 (FR-1) — the swallowed audit failure now leaves evidence.
+//
+// MEASURED STATE THAT MOTIVATED THIS: system_events holds 128,267 rows, and
+// event_type='claim_write_refused_claimant_not_live' has ZERO, lifetime. The control proves the
+// predicate is real — ilike '%S19_HA%' on the same column returns 125,275 — so the zero is genuine.
+//
+// The zero could not be READ, because recordRefusal's catch was EMPTY:
+//     catch { /* audit is best-effort; never let it affect the fence outcome */ }
+// A refusal whose insert failed left nothing anywhere, making "the fence never fired" and "the fence
+// fired and was not recorded" the same observation.
+//
+// THE SWALLOW IS CORRECT AND STAYS. The docstring is right that an audit write must never block a
+// claim decision; a fence failing closed because system_events is unreachable would be far worse
+// than an unreadable counter. What changes is that the catch is no longer silent.
+//
+// THESE TESTS FORCE THE FAILURE. This SD exists because a guard's refuse path may never have
+// executed while its pass path runs constantly — so a suite that exercised the happy path would
+// inherit exactly that blindness. The failure path is the subject, so it is what gets driven.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const { recordRefusal, auditFailures } = require_('../../../lib/fleet/claimant-liveness.cjs');
+
+const okDb = () => ({ from: () => ({ insert: async () => ({ error: null }) }) });
+const throwingDb = (msg = 'permission denied for table system_events') => ({
+  from: () => ({ insert: async () => { throw new Error(msg); } }),
+});
+
+const detail = { session_id: 's-1', verdict: 'DEAD', reason: 'pid not running' };
+
+beforeEach(() => { auditFailures.claim_write_refused_claimant_not_live = 0; });
+
+describe('FR-1: a failed refusal-audit write is visible instead of silent', () => {
+  // THE DECIDING SCENARIO. Before this change the same call left no trace of any kind.
+  it('counts and reports the failure when the insert throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await recordRefusal(throwingDb(), detail, { sdKey: 'SD-X' });
+      expect(auditFailures.claim_write_refused_claimant_not_live).toBe(1);
+      const said = warn.mock.calls.flat().join(' ');
+      expect(said).toMatch(/REFUSAL AUDIT WRITE FAILED/);
+      expect(said).toMatch(/UNRECORDED/);
+      // The operator must be told the direction of the error: the count UNDER-reports.
+      expect(said).toMatch(/under-report/i);
+    } finally { warn.mockRestore(); }
+  });
+
+  // TR-2 / TS-4 CONTROL — the whole point of keeping the swallow. If this regresses, an audit
+  // outage becomes a claim outage, which is strictly worse than the defect being fixed.
+  it('CONTROL: it still never throws, so the fence outcome cannot be affected', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await expect(recordRefusal(throwingDb(), detail, {})).resolves.toBeUndefined();
+      // Even a pathological client that throws on .from() must not escape.
+      const hostile = { from: () => { throw new Error('client exploded'); } };
+      await expect(recordRefusal(hostile, detail, {})).resolves.toBeUndefined();
+      expect(auditFailures.claim_write_refused_claimant_not_live).toBe(2);
+    } finally { warn.mockRestore(); }
+  });
+
+  // CONTROL in the other direction — a counter that increments on success would make the signal
+  // meaningless, and a warning on a healthy write would train readers to ignore it.
+  it('CONTROL: a successful write neither counts nor warns', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await recordRefusal(okDb(), detail, { sdKey: 'SD-Y' });
+      expect(auditFailures.claim_write_refused_claimant_not_live).toBe(0);
+      expect(warn).not.toHaveBeenCalled();
+    } finally { warn.mockRestore(); }
+  });
+
+  it('accumulates across repeated failures, so the under-report magnitude is knowable', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      for (let i = 0; i < 3; i += 1) await recordRefusal(throwingDb(), detail, {});
+      expect(auditFailures.claim_write_refused_claimant_not_live).toBe(3);
+      expect(warn.mock.calls.flat().join(' ')).toMatch(/at least 3/);
+    } finally { warn.mockRestore(); }
+  });
+
+  // Logging must not become a new way for the fence to die.
+  it('survives a console.warn that itself throws', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => { throw new Error('stdout gone'); });
+    try {
+      await expect(recordRefusal(throwingDb(), detail, {})).resolves.toBeUndefined();
+      expect(auditFailures.claim_write_refused_claimant_not_live).toBe(1);
+    } finally { warn.mockRestore(); }
+  });
+});

--- a/tests/unit/fleet/claimant-liveness-denominator.test.js
+++ b/tests/unit/fleet/claimant-liveness-denominator.test.js
@@ -1,0 +1,127 @@
+// SD-LEO-INFRA-GUARD-FIRING-RECORDS-001 (FR-2) — giving the refusal count a denominator.
+//
+// A guard's PASS path runs constantly, so it always looks healthy; its REFUSE path may never have
+// executed. So zero refusals means UNTESTED, not safe — unless you know how many times the guard was
+// evaluated. Measured before this change: 0 refusals lifetime, and NO evaluation record of any kind,
+// so 0-refusals and 0-evaluations were the same observation and the zero could not be read at all.
+//
+// WHY AN AGGREGATE AND NOT A ROW PER EVALUATION: the pre-existing comment at the call site is right —
+// "persist ONLY refusals ... writing one per claim would bury the rows that matter". system_events is
+// already 125,275 of 128,267 rows a single event type (97.7%). That correct instinct is what produced
+// the unreadable zero, so the denominator has to arrive WITHOUT reintroducing the flood.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const mod = require_('../../../lib/fleet/claimant-liveness.cjs');
+const { fenceEvaluations, recordEvaluation, evaluationBucket, maybeFlushEvaluationCount, auditFailures } = mod;
+
+const H = (iso) => Date.parse(iso);
+const capture = () => { const rows = []; return { rows, sb: { from: () => ({ insert: async (r) => { rows.push(r); return { error: null }; } }) } }; };
+const throwingSb = { from: () => ({ insert: async () => { throw new Error('permission denied'); } }) };
+
+beforeEach(() => {
+  fenceEvaluations.evaluated = 0; fenceEvaluations.refused = 0;
+  fenceEvaluations.pendingEvaluated = 0; fenceEvaluations.pendingRefused = 0;
+  fenceEvaluations.lastBucket = null;
+  auditFailures.claim_fence_evaluated = 0;
+});
+
+describe('FR-2: the evaluation count is the denominator', () => {
+  it('counts passes AND refusals — the pass is the whole point', () => {
+    recordEvaluation(false); recordEvaluation(false); recordEvaluation(true);
+    expect(fenceEvaluations.evaluated).toBe(3);
+    expect(fenceEvaluations.refused).toBe(1);
+  });
+
+  // THE ASSERTION THAT MAKES A ZERO READABLE. Without a denominator these two states are identical.
+  it('distinguishes never-fired from never-ran', () => {
+    for (let i = 0; i < 10; i += 1) recordEvaluation(false);
+    expect(fenceEvaluations.evaluated).toBeGreaterThan(0);
+    expect(fenceEvaluations.refused).toBe(0);   // ran 10 times, never fired — SAFE-ish and readable
+    // and the other state:
+    fenceEvaluations.evaluated = 0;
+    expect(fenceEvaluations.evaluated).toBe(0); // never ran — UNTESTED, and now distinguishable
+  });
+});
+
+describe('FR-2/TR-1: low cardinality — one aggregate per hour bucket, never a row per claim', () => {
+  it('writes NOTHING within a single bucket, however many evaluations occur', async () => {
+    const { rows, sb } = capture();
+    const t = H('2026-08-03T06:00:00Z');
+    await maybeFlushEvaluationCount(sb, t);           // first call in-process: arms the bucket
+    for (let i = 0; i < 500; i += 1) {
+      recordEvaluation(false);
+      await maybeFlushEvaluationCount(sb, t + i * 1000);
+    }
+    // 500 evaluations, ZERO rows — this is the property that keeps the fix from becoming the flood
+    // the original author correctly avoided.
+    expect(rows).toEqual([]);
+  });
+
+  it('flushes ONE aggregate when the bucket rolls, carrying both numerator and denominator', async () => {
+    const { rows, sb } = capture();
+    await maybeFlushEvaluationCount(sb, H('2026-08-03T06:00:00Z'));
+    for (let i = 0; i < 40; i += 1) recordEvaluation(i % 10 === 0); // 40 evaluations, 4 refusals
+    await maybeFlushEvaluationCount(sb, H('2026-08-03T07:00:01Z'));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].event_type).toBe('claim_fence_evaluated');
+    expect(rows[0].payload.evaluated).toBe(40);
+    expect(rows[0].payload.refused).toBe(4);
+    expect(rows[0].payload.guard).toBe('claimant_liveness');
+  });
+
+  it('does not emit an empty aggregate for a quiet hour', async () => {
+    const { rows, sb } = capture();
+    await maybeFlushEvaluationCount(sb, H('2026-08-03T06:00:00Z'));
+    await maybeFlushEvaluationCount(sb, H('2026-08-03T07:00:00Z')); // no evaluations accrued
+    expect(rows).toEqual([]);
+  });
+
+  it('resets the pending window after a flush, so counts are per-bucket not cumulative', async () => {
+    const { rows, sb } = capture();
+    await maybeFlushEvaluationCount(sb, H('2026-08-03T06:00:00Z'));
+    recordEvaluation(false); recordEvaluation(false);
+    await maybeFlushEvaluationCount(sb, H('2026-08-03T07:00:00Z'));
+    recordEvaluation(false);
+    await maybeFlushEvaluationCount(sb, H('2026-08-03T08:00:00Z'));
+    expect(rows.map((r) => r.payload.evaluated)).toEqual([2, 1]);
+    // lifetime totals keep accumulating even though the per-bucket windows reset
+    expect(fenceEvaluations.evaluated).toBe(3);
+  });
+
+  it('evaluationBucket is hour-granular', () => {
+    expect(evaluationBucket(H('2026-08-03T06:59:59Z'))).toBe('2026-08-03T06');
+    expect(evaluationBucket(H('2026-08-03T07:00:00Z'))).toBe('2026-08-03T07');
+  });
+});
+
+describe('FR-2 inherits the FR-1 lesson: the denominator writer cannot itself be silent', () => {
+  // A second recorder that swallows its own failure would recreate the exact defect this SD fixes,
+  // one level down — the zero would be unreadable again and nothing would say why.
+  it('counts and reports a failed flush instead of swallowing it', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await maybeFlushEvaluationCount(throwingSb, H('2026-08-03T06:00:00Z'));
+      recordEvaluation(false);
+      await maybeFlushEvaluationCount(throwingSb, H('2026-08-03T07:00:00Z'));
+      expect(auditFailures.claim_fence_evaluated).toBe(1);
+      const said = warn.mock.calls.flat().join(' ');
+      expect(said).toMatch(/EVALUATION-COUNT WRITE FAILED/);
+      expect(said).toMatch(/uninterpretable/);
+    } finally { warn.mockRestore(); }
+  });
+
+  // TR-2 CONTROL — the denominator must never be able to break a claim decision.
+  it('CONTROL: never throws, so it cannot affect the fence outcome', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      await maybeFlushEvaluationCount(throwingSb, H('2026-08-03T06:00:00Z'));
+      recordEvaluation(false);
+      await expect(maybeFlushEvaluationCount(throwingSb, H('2026-08-03T07:00:00Z'))).resolves.toBeUndefined();
+      const hostile = { from: () => { throw new Error('client exploded'); } };
+      recordEvaluation(false);
+      await expect(maybeFlushEvaluationCount(hostile, H('2026-08-03T08:00:00Z'))).resolves.toBeUndefined();
+    } finally { warn.mockRestore(); }
+  });
+});

--- a/tests/unit/fleet/guard-firing-acceptance.test.js
+++ b/tests/unit/fleet/guard-firing-acceptance.test.js
@@ -1,0 +1,119 @@
+// SD-LEO-INFRA-GUARD-FIRING-RECORDS-001 (FR-4 + FR-5) — acceptance, and it must be TWO-SIDED.
+//
+// A zero-refusal counter is trivially satisfiable by a guard that is never invoked — which is
+// precisely the state this SD suspected. So asserting only "a refusal is recorded" would accept
+// the broken system: a fence that never runs passes that test forever.
+//
+// Hence both directions are asserted together: a genuine action produces a durable record AND a
+// passing evaluation increments the denominator AND a failed audit write is visible. The third is
+// the one that has never been exercised in production, which is the whole subject of the SD.
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import { verdictFor, GUARD_REGISTRY, characterize } from '../../../scripts/guard-firing-characterization.mjs';
+import { recordSweepEvaluation, sweepAuditFailures } from '../../../lib/coordinator/singleton-relaunch-trigger.js';
+
+const require_ = createRequire(import.meta.url);
+const liveness = require_('../../../lib/fleet/claimant-liveness.cjs');
+const { recordRefusal, recordEvaluation, maybeFlushEvaluationCount, fenceEvaluations, auditFailures } = liveness;
+
+const capture = () => { const rows = []; return { rows, sb: { from: () => ({ insert: async (r) => { rows.push(r); return { error: null }; } }) } }; };
+
+beforeEach(() => {
+  fenceEvaluations.evaluated = 0; fenceEvaluations.refused = 0;
+  fenceEvaluations.pendingEvaluated = 0; fenceEvaluations.pendingRefused = 0;
+  fenceEvaluations.lastBucket = null;
+  auditFailures.claim_write_refused_claimant_not_live = 0;
+  auditFailures.claim_fence_evaluated = 0;
+  sweepAuditFailures.singleton_relaunch_evaluated = 0;
+});
+
+describe('FR-5: acceptance is two-sided — both the action AND the evaluation must be recorded', () => {
+  it('side 1: a genuine refusal produces a durable record', async () => {
+    const { rows, sb } = capture();
+    await recordRefusal(sb, { session_id: 's-1', verdict: 'DEAD', reason: 'pid not running' }, { sdKey: 'SD-X' });
+    expect(rows).toHaveLength(1);
+    expect(rows[0].event_type).toBe('claim_write_refused_claimant_not_live');
+  });
+
+  // SIDE 2 IS THE ONE THAT MAKES SIDE 1 MEAN ANYTHING. Without it, a fence that is never invoked
+  // satisfies the whole suite — the exact failure mode the SD was filed about.
+  it('side 2: a PASSING evaluation increments the denominator', async () => {
+    const { rows, sb } = capture();
+    await maybeFlushEvaluationCount(sb, Date.parse('2026-08-03T06:00:00Z'));
+    recordEvaluation(false);   // a pass — no refusal at all
+    recordEvaluation(false);
+    expect(fenceEvaluations.evaluated).toBe(2);
+    await maybeFlushEvaluationCount(sb, Date.parse('2026-08-03T07:00:00Z'));
+    expect(rows).toHaveLength(1);
+    expect(rows[0].payload.evaluated).toBe(2);
+    expect(rows[0].payload.refused).toBe(0);   // fired zero times, and that is now READABLE
+  });
+
+  it('side 3: an audit-write FAILURE is visible, not swallowed', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const bad = { from: () => ({ insert: async () => { throw new Error('permission denied'); } }) };
+      await recordRefusal(bad, { session_id: 's-1' }, {});
+      await recordSweepEvaluation(bad, [{ role: 'adam', scheduled: false, reason: 'fleet_busy' }], {});
+      expect(auditFailures.claim_write_refused_claimant_not_live).toBe(1);
+      expect(sweepAuditFailures.singleton_relaunch_evaluated).toBe(1);
+      expect(warn).toHaveBeenCalled();
+    } finally { warn.mockRestore(); }
+  });
+
+  // THE FALSIFIER, recorded so a later reader does not mistake it for success. The expected outcome
+  // of this SD is a zero becoming READABLE, not a count rising. If refusal counts start appearing
+  // once FR-1 is live, writes were failing all along and the finding is more urgent than assumed.
+  it('does NOT assert that refusals appear — the rollout signal is inverted', async () => {
+    const { rows, sb } = capture();
+    for (let i = 0; i < 50; i += 1) recordEvaluation(false);
+    await maybeFlushEvaluationCount(sb, Date.parse('2026-08-03T06:00:00Z'));
+    expect(fenceEvaluations.refused).toBe(0);   // staying at zero is the EXPECTED healthy outcome
+    expect(rows).toEqual([]);                   // and it costs no rows to know that
+  });
+});
+
+describe('FR-4: the characterization answers "can I believe this zero", not "what does it record"', () => {
+  // TS-6 — a report that merely lists guards and event types leaves the reader where the SD started.
+  it('a guard WITHOUT a denominator is UNREADABLE, never healthy', () => {
+    expect(verdictFor({ actions: 0, evaluations: null }).verdict).toBe('UNREADABLE');
+  });
+
+  it('a guard WITH a denominator that ran and never fired is readable', () => {
+    const v = verdictFor({ actions: 0, evaluations: 10_000 });
+    expect(v.verdict).toBe('NEVER_FIRED');
+    expect(v.because).toMatch(/readable/);
+  });
+
+  it('separates the two zeros that used to look identical', () => {
+    expect(verdictFor({ actions: 0, evaluations: 10_000 }).verdict).toBe('NEVER_FIRED');
+    expect(verdictFor({ actions: 0, evaluations: 0 }).verdict).toBe('NO_EVALUATIONS_RECORDED');
+  });
+
+  // THE INSTRUMENT MUST NOT COMMIT THE SD'S OWN DEFECT. Zero evaluations means either never-ran or
+  // denominator-not-deployed; asserting the first alone would be a guess dressed as a measurement.
+  it('does not claim "never ran" when "not deployed yet" is equally consistent', () => {
+    const v = verdictFor({ actions: 0, evaluations: 0 });
+    expect(v.because).toMatch(/not deployed yet/);
+    expect(v.because).toMatch(/cannot tell those apart/);
+  });
+
+  it('reports a firing guard as firing', () => {
+    expect(verdictFor({ actions: 3, evaluations: 900 }).verdict).toBe('FIRES');
+  });
+
+  it('every registered guard names both an action and a denominator', () => {
+    expect(GUARD_REGISTRY.length).toBeGreaterThanOrEqual(2);
+    for (const g of GUARD_REGISTRY) {
+      expect(g.action?.value, `${g.guard} action`).toBeTruthy();
+      expect(g.denominator?.value, `${g.guard} denominator`).toBeTruthy();
+    }
+  });
+
+  // A failed count that defaults to 0 renders as "never fired" — the exact misreading this SD
+  // exists to prevent. An unknown must never print as a zero.
+  it('a failed count DIES rather than defaulting to zero', async () => {
+    const failing = { from: () => ({ select: () => ({ eq: () => ({ count: null, error: { message: 'relation missing' } }), filter: () => ({ count: null, error: { message: 'relation missing' } }) }) }) };
+    await expect(characterize(failing, [GUARD_REGISTRY[0]])).rejects.toThrow(/count failed/);
+  });
+});


### PR DESCRIPTION
## The defect

A guard's PASS path runs constantly, so it always looks healthy; its REFUSE path may never have executed. **Zero refusals therefore means UNTESTED, not safe** — unless you know how many times the guard ran.

Measured before this change:
- `claim_write_refused_claimant_not_live` — **0 of 128,267** `system_events` rows, lifetime
- `singleton_relaunch_scheduled` — **0 of 5,166** `session_coordination` rows, lifetime

Neither zero could be read, because neither guard recorded anything when it *passed*. `0 of 10,000` means never fired; `0 of 0` means never ran — and only the second is an alarm.

## A correction to the SD's own premise

FR-3 asserted the relaunch net has **no recorder**, inferred from `system_events` `%relaunch%` returning zero. **The net has a recorder** — `writeScheduleRecord` — it writes to `session_coordination`. The SD searched the wrong table. So case 2 is not a missing-instrument case; it is the same missing-denominator defect in a second guard.

Establishing that the relaunch sweep runs *at all* required leaving the system and reading GitHub Actions history (`singleton-relaunch-cron.yml`, 10 consecutive successes, latest 2026-08-03T08:15Z). That is the "induce it and watch" cost this SD was filed about, wearing different clothes. The denominator is written to `system_events` specifically so the SD's own diagnostic query answers truthfully next time.

## What ships

| FR | Change |
|----|--------|
| FR-1 | The swallowed refusal-audit failure is counted and reported. **The swallow itself stays** — an audit write must never block a claim decision. |
| FR-2 | Claim-fence denominator as an **hourly aggregate** — the call site's existing "persist ONLY refusals, writing one per claim would bury the rows that matter" reasoning is correct, and that correct instinct is what produced the unreadable zero. |
| FR-3 | Relaunch sweep records that it ran. **One row per sweep, not aggregated** — ~4 sweeps/hour is not a hot path, and the per-role `by_reason` breakdown is the field that does the work. |
| FR-4 | `guard-firing-characterization.mjs` — every row ends in a verdict about the **zero**, not a description of the guard. |
| FR-5 | Two-sided acceptance: action durable **AND** passing evaluation counted **AND** audit failure visible. |

## Two things worth reviewing closely

**The rollout signal is inverted.** Success is a zero becoming *readable*, not a count rising. No test asserts refusals appear; one explicitly asserts staying at zero is the healthy outcome. If refusals *do* appear once FR-1 is live, writes were failing all along and the finding is more urgent than assumed.

**FR-4 nearly committed this SD's own defect.** Its first run reported both guards `NEVER_RAN` — but zero evaluations means *either* never-ran *or* denominator-not-deployed, and since these FRs aren't merged the second is the true cause. Asserting the first would have been a guess dressed as a measurement. The verdict is now `NO_EVALUATIONS_RECORDED` and names both causes.

## Incidental finding — high stakes, NOT fixed here

`relaunchOntoFreshCheckout` (`lib/singleton-relaunch.js`) — the fresh-checkout executor that would resurrect a dead Adam, Solomon or coordinator — has **zero production callers**. Referenced only by its own tests and by PRD payloads. The trigger's header documents the spawn step as human-gated, so this is a known deferral rather than a regression, but the net is **disconnected in the middle**: detection is wired and now instrumented; actuation is not reachable. Routed to completion flags.

That finding is why FR-3 ships a **wiring test** — a recorder that exists but is never invoked emits the same unreadable zero as no recorder at all.

## Falsification

Every FR was falsified with a seeded defect:

| Seed | Result |
|------|--------|
| Restore FR-1's empty catch | 4 of 5 fail |
| Remove FR-2's bucket guard (per-evaluation writes) | 1 of 9 — the 500-evaluations test, sole guardian of low cardinality |
| Record only sweeps that scheduled something | 6 of 11 |
| Leave FR-3's recorder unwired | exactly 1 — the wiring test; nothing else catches it |
| Report a denominator-less guard as healthy | 1 |
| **Kill the denominator, leave the action path intact** | **exactly 1, and it is side 2 — side 1 still passes.** That is the proof the acceptance is genuinely two-sided |

**2,968 pass across 252 fleet + coordinator suites.** 0 stray seed markers after restore.

🤖 Generated with [Claude Code](https://claude.com/claude-code)