### PR TITLE
feat(G2): stage the chairman-approved source_type qualifier for anon_feedback_ingress_bounds (STAGED, NOT APPLIED)

### DIFF
--- a/database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier.sql
+++ b/database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier.sql
@@ -1,0 +1,221 @@
+-- STAGED, NOT APPLIED. This file lives in database/chairman-gated/ deliberately.
+-- It is OUTSIDE the three directories BaseExecutor._checkAndExecutePendingMigrations scans
+-- (database/migrations, database/manual-updates, supabase/migrations). Placing it in any of those
+-- would auto-apply it: LEO_MIGRATION_TIER_GATE is unset in this repo, so the TIER-2 default-deny
+-- classification is computed, logged, and changes nothing. A worker cannot put chairman-gated DDL
+-- on an auto-applied path and still call it gated. See database/chairman-gated/README.md.
+--
+-- Amendment: add a source_type qualifier to clause (3) of anon_feedback_ingress_bounds
+-- Date: 2026-08-03
+-- SD: SD-LEO-FIX-BOUND-ANON-TELEGRAM-001 (completed) — this is its gap G2, carried as follow-on.
+--
+-- CHAIRMAN-APPROVED: Option A, verbatim "I approve the security amendment recommendation option A"
+-- (SMS 2026-08-03 10:13:53Z, signature valid, on record via Adam). The APPLY still runs through the
+-- chairman-gated ceremony with the approval row referenced. Approval to AUTHOR is not approval to
+-- APPLY, and this file does not apply itself.
+--
+-- ============================================================================================
+-- WHAT IS WRONG TODAY (the defect this amends)
+-- ============================================================================================
+-- The installed clause (3) counts telegram rows and is ANDed into a RESTRICTIVE policy that
+-- applies to EVERY anon INSERT. So a limit keyed on TELEGRAM ingress gates the venture-user path
+-- too — a path that has its own per-venture limit and never needed this one. An attacker posts ~50
+-- individually-legal telegram rows and ALL anon feedback ingress stops for an hour. Cost: ~50
+-- requests. The harmed path is not the attacker's own.
+--
+-- Found by the SECURITY sub-agent during EXEC review of the original SD, not by the policy's
+-- author. Measured exposure at the time of approval: organic peaks of 1 telegram row/hour (all
+-- time) and 9 venture-user rows/hour — so this is an adversarial lever, not an operational fault.
+-- Real, but cold. That calibration is why it was routed for same-day ratification rather than
+-- treated as an incident.
+--
+-- ============================================================================================
+-- THE CURRENT PREDICATE, VERBATIM FROM THE CATALOG — so rollback is EXACT, not RECONSTRUCTED
+-- ============================================================================================
+-- Captured 2026-08-03 via pg_get_expr(p.polwithcheck, p.polrelid, true) on the LIVE policy, not
+-- copied from the migration file. This matters: the file's text and the installed text differ in
+-- normalisation (Postgres rewrites NOT IN as <> ALL(ARRAY[...]) and casts to ::text), so a rollback
+-- reconstructed from the migration would not restore byte-identical state. Requirement (1) from
+-- Adam, and the reason it was made a condition.
+--
+-- polname     : anon_feedback_ingress_bounds
+-- polpermissive: false   (RESTRICTIVE)
+-- polcmd      : 'a'      (INSERT)
+-- table owner : postgres
+--
+-- WITH CHECK, exactly as installed:
+--
+--   (severity IS NULL OR (severity::text <> ALL (ARRAY['critical'::character varying, 'high'::character varying]::text[]))) AND category::text IS DISTINCT FROM 'chairman_decision_deferred'::text AND ( SELECT count(*) < 50
+--      FROM feedback f
+--     WHERE f.source_type::text = 'telegram'::text AND f.created_at > (now() - '01:00:00'::interval))
+--
+-- ROLLBACK — restores exactly the above. Run inside a transaction:
+--
+--   ALTER POLICY anon_feedback_ingress_bounds ON public.feedback
+--       WITH CHECK (
+--           (severity IS NULL OR severity NOT IN ('critical','high'))
+--           AND (category IS DISTINCT FROM 'chairman_decision_deferred')
+--           AND ( SELECT count(*) < 50
+--                   FROM public.feedback f
+--                  WHERE f.source_type = 'telegram'
+--                    AND f.created_at > now() - interval '1 hour' )
+--       );
+--
+-- (The rollback is written in source form rather than pasted from pg_get_expr because
+-- pg_get_expr output is a rendering, not necessarily re-parseable input. Applying the rollback and
+-- re-reading pg_get_expr must reproduce the verbatim block above — verify that, do not assume it.)
+
+BEGIN;
+
+-- ALTER, not DROP+CREATE, and this is deliberate on a live security policy. DROP+CREATE would
+-- leave the table with NO restrictive bound for the duration of the statement pair. Transaction
+-- isolation makes that invisible to other sessions here, but the habit is wrong for permission
+-- objects and the failure mode of getting it wrong (an error between DROP and CREATE, in a file
+-- someone later runs statement-by-statement) is an open ingress. ALTER POLICY replaces the
+-- predicate atomically and cannot leave the policy absent.
+ALTER POLICY anon_feedback_ingress_bounds ON public.feedback
+    WITH CHECK (
+        -- (1) UNCHANGED. Not the chairman-queue severities.
+        (severity IS NULL OR severity NOT IN ('critical', 'high'))
+
+        -- (2) UNCHANGED. Not the chairman-deferral category.
+        AND (category IS DISTINCT FROM 'chairman_decision_deferred')
+
+        -- (3) AMENDED — this is the entire change. The window is now counted over rows sharing the
+        --     INSERTING ROW'S source_type, instead of always over telegram. Each source_type gets
+        --     its own 50/hour budget, so flooding one can no longer deny ingress to another.
+        --
+        --     *** THE SCOPING HERE IS THE ONE THING MOST LIKELY TO BE SILENTLY WRONG. ***
+        --     The subquery aliases the same table as `f`. An UNQUALIFIED `source_type` inside it
+        --     binds to `f.source_type` (innermost scope wins) — which would make the predicate
+        --     `f.source_type IS NOT DISTINCT FROM f.source_type`, trivially TRUE for every row.
+        --     The count would then be the FULL hourly population and the limit would still work by
+        --     accident today, while meaning something completely different from what is written.
+        --     `feedback.source_type` is therefore load-bearing: it is an OUTER reference to the row
+        --     being inserted. Because the subquery aliased `feedback` to `f`, the bare name
+        --     `feedback` is free inside it and resolves outward.
+        --     VERIFIED READ-ONLY BEFORE STAGING, against live data: the correlated form returns
+        --     distinct per-source counts (telegram=1, auto_capture=9979, manual_feedback=6417)
+        --     rather than the 16580 table total, which is exactly what an outer binding produces
+        --     and an inner binding could not. Post-condition 2 below re-asserts it at apply time.
+        --
+        --     IS NOT DISTINCT FROM, not `=`: source_type is nullable, and `=` would make the
+        --     predicate NULL for a NULL source_type, failing the WITH CHECK and silently closing
+        --     an ingress path this amendment is not meant to touch.
+        AND (
+            SELECT count(*) < 50
+            FROM public.feedback f
+            WHERE f.source_type IS NOT DISTINCT FROM feedback.source_type
+              AND f.created_at > now() - interval '1 hour'
+        )
+    );
+
+COMMENT ON POLICY anon_feedback_ingress_bounds ON public.feedback IS
+'SD-LEO-FIX-BOUND-ANON-TELEGRAM-001 + G2 amendment 2026-08-03 (chairman Option A). RESTRICTIVE, so
+it ANDs with every permissive anon INSERT policy. Bounds anon inserts away from the chairman queue:
+severity not in (critical,high) because the queue arm admits exactly those two, and category is not
+chairman_decision_deferred because the legitimate deferral writer stamps severity=low. Rate limit is
+counted PER source_type of the inserting row (feedback.source_type is an outer reference, not the
+subquery alias) so flooding one source cannot deny ingress to another - that cross-source denial was
+the G2 defect. KNOWN, UNFIXED: the counting subquery runs as the inserting role and is subject to
+that role SELECT RLS, so narrowing the anon SELECT policy makes this undercount and fail OPEN.';
+
+-- ============================================================================================
+-- POST-CONDITIONS, inside the transaction. An external suite cannot substitute: this repo's
+-- vitest `db` project is gated to zero files when no non-production target is designated, so it
+-- would report green having executed nothing. An assertion here cannot silently not-run.
+-- These are STRUCTURAL. The BEHAVIOURAL acceptance is the companion probe (requirement 2 from
+-- Adam) — see 20260803_bound_anon_ingress_source_type_qualifier_acceptance.mjs. Structure and
+-- behaviour are different claims and this file only makes the first.
+-- ============================================================================================
+DO $$
+DECLARE
+    wc                      text;
+    is_restrictive          boolean;
+    permissive_insert_count integer;
+BEGIN
+    SELECT pg_get_expr(p.polwithcheck, p.polrelid, true), NOT p.polpermissive
+      INTO wc, is_restrictive
+      FROM pg_policy p
+      JOIN pg_class c ON c.oid = p.polrelid
+     WHERE c.relname = 'feedback'
+       AND c.relnamespace = 'public'::regnamespace
+       AND p.polname = 'anon_feedback_ingress_bounds';
+
+    IF wc IS NULL THEN
+        RAISE EXCEPTION 'anon_feedback_ingress_bounds not found after ALTER — the policy this amendment edits does not exist.';
+    END IF;
+
+    -- 1. STILL RESTRICTIVE. ALTER POLICY cannot change this, which is precisely why it is asserted:
+    --    the assertion is cheap and the property is the one that makes the whole policy do anything.
+    IF is_restrictive IS DISTINCT FROM true THEN
+        RAISE EXCEPTION 'anon_feedback_ingress_bounds is no longer RESTRICTIVE — it would OR with the permissive anon INSERT policies and close nothing.';
+    END IF;
+
+    -- 2. THE CORRELATION LANDED. Guards the exact silent failure described at clause (3): if the
+    --    outer reference had bound to the subquery alias, Postgres would render the predicate with
+    --    `f.source_type IS NOT DISTINCT FROM f.source_type`. Assert the rendered expression
+    --    references the OUTER table name inside the correlation, and does NOT contain the
+    --    self-comparison form.
+    IF wc !~ 'f\.source_type IS NOT DISTINCT FROM feedback\.source_type' THEN
+        RAISE EXCEPTION 'clause (3) is not correlated to the inserting row: expected f.source_type IS NOT DISTINCT FROM feedback.source_type, got: %', wc;
+    END IF;
+    IF wc ~ 'f\.source_type IS NOT DISTINCT FROM f\.source_type' THEN
+        RAISE EXCEPTION 'clause (3) correlation collapsed to a self-comparison (always TRUE) — the outer reference bound to the subquery alias.';
+    END IF;
+
+    -- 3. THE LIMIT IS STILL A LIMIT. Adam's stated worry, asserted structurally: narrowing the
+    --    counting scope is exactly how a rate limit accidentally stops limiting. If the threshold
+    --    were dropped or the comparison inverted while the qualifier was added, checks 1-2 would
+    --    still pass. The behavioural half of this is the companion probe.
+    IF wc !~ 'count\(\*\) < 50' THEN
+        RAISE EXCEPTION 'clause (3) no longer carries the count(*) < 50 bound — the qualifier was added but the limit stopped limiting: %', wc;
+    END IF;
+
+    -- 4. THE OLD UNCONDITIONAL TELEGRAM KEY IS GONE. Without this, an amendment that ADDED the
+    --    correlation while LEAVING the telegram filter in place would satisfy 1-3 and still gate
+    --    every anon insert on telegram volume — i.e. G2 unfixed, with all assertions green.
+    IF wc ~ 'f\.source_type::text = ''telegram''::text' THEN
+        RAISE EXCEPTION 'clause (3) still filters on a literal telegram source_type — G2 is not fixed; the cross-source denial remains.';
+    END IF;
+
+    -- 5. A permissive ANON INSERT policy must STILL EXIST. Carried forward from the original
+    --    migration, including its role filter: an unfiltered count reads 3 (two anon + one
+    --    service_role) and would pass even with both anon policies dropped. `0 = ANY(polroles)`
+    --    handles TO PUBLIC, which an inner join on pg_roles drops silently.
+    SELECT count(*)
+      INTO permissive_insert_count
+      FROM pg_policy p
+      JOIN pg_class c ON c.oid = p.polrelid
+     WHERE c.relname = 'feedback'
+       AND c.relnamespace = 'public'::regnamespace
+       AND p.polpermissive
+       AND p.polcmd = 'a'
+       AND ( 0 = ANY(p.polroles)
+             OR EXISTS (SELECT 1 FROM pg_roles r WHERE r.oid = ANY(p.polroles) AND r.rolname = 'anon') );
+
+    IF permissive_insert_count < 1 THEN
+        RAISE EXCEPTION 'no permissive ANON INSERT policy remains on public.feedback — a RESTRICTIVE policy alone denies everything.';
+    END IF;
+END $$;
+
+COMMIT;
+
+-- ============================================================================================
+-- AFTER APPLY: run the behavioural acceptance. The apply exit code is NOT the acceptance.
+--   node database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier_acceptance.mjs
+--
+-- It asserts, using the three-leg method (observe / service-role readback / re-attempt WITHOUT
+-- RETURNING and read back again, because the two write forms diverge):
+--   A. THE LIMIT STILL REJECTS past threshold for a single source_type  <- requirement (2)
+--   B. a source_type UNDER threshold is still ACCEPTED while another is over  <- G2 actually fixed
+--   C. clauses (1) and (2) are unchanged — severity and category bounds still refuse
+--   D. a benign control still LANDS, without which no absence result above means anything
+--
+-- WHAT THIS AMENDMENT DOES NOT FIX, restated so it is not mistaken for closed:
+--   - the counting subquery runs as the inserting role and is subject to that role's SELECT RLS,
+--     so narrowing the anon SELECT policy still makes it undercount and FAIL OPEN;
+--   - clause (1) still mirrors a constant that lives in a separately-editable view, which has
+--     already been restructured once without this policy being consulted;
+--   - public.record_venture_error() still reaches public.feedback outside RLS entirely.
+-- ============================================================================================

--- a/database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier.sql
+++ b/database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier.sql
@@ -30,13 +30,31 @@
 -- treated as an incident.
 --
 -- ============================================================================================
--- THE CURRENT PREDICATE, VERBATIM FROM THE CATALOG — so rollback is EXACT, not RECONSTRUCTED
+-- THE CURRENT PREDICATE — CAPTURED FOR CONTEXT. *** THIS IS NOT THE ROLLBACK SOURCE. ***
 -- ============================================================================================
--- Captured 2026-08-03 via pg_get_expr(p.polwithcheck, p.polrelid, true) on the LIVE policy, not
--- copied from the migration file. This matters: the file's text and the installed text differ in
--- normalisation (Postgres rewrites NOT IN as <> ALL(ARRAY[...]) and casts to ::text), so a rollback
--- reconstructed from the migration would not restore byte-identical state. Requirement (1) from
--- Adam, and the reason it was made a condition.
+-- HARD REQUIREMENT (Adam, 2026-08-03; supersedes the original wording of condition 1):
+--   The rollback source for this amendment is a FRESH PRE-APPLY CAPTURE of live pg_policies state,
+--   taken by the applier in his own lane at apply time. It is NEVER a repo file — including THIS
+--   one. The block below is context for the reviewer, not an authority to restore from.
+--
+-- WHY THE REQUIREMENT WAS UPGRADED, and it is not hypothetical: SECURITY found that this repo
+-- already carries a policy file for public.session_coordination (20260309, declaring FOR ALL with
+-- no TO clause) that DISAGREES with live state. That is the same defect as this SD's parent, in
+-- the opposite direction — there, a live policy had no file; here, a file misdescribes the live
+-- policy. Both are one representation being trusted for a fact it does not hold. So file-resident
+-- policy text cannot be trusted as rollback, and THIS FILE IS A FILE. The block below is
+-- EXPECTED-AT-AUTHORING; diff the fresh capture against it rather than restoring from it.
+--
+-- *** ANY FILE-VS-LIVE DISAGREEMENT FOUND DURING THE PRE-APPLY CAPTURE IS A BLOCKING FINDING. ***
+-- Not a footnote, not note-and-proceed. If the fresh capture does not match the block below, STOP
+-- the ceremony and report it: it means the live policy was changed outside migration history a
+-- second time, which matters more than this amendment does.
+--
+-- Captured 2026-08-03 at AUTHORING time (not apply time) via
+-- pg_get_expr(p.polwithcheck, p.polrelid, true) on the live policy, not copied from the migration
+-- file. Even as context that distinction matters: the file's text and the installed text differ in
+-- normalisation (Postgres rewrites NOT IN as <> ALL(ARRAY[...]) and casts to ::text), so anything
+-- reconstructed from migration source would not reproduce installed state byte-identically.
 --
 -- polname     : anon_feedback_ingress_bounds
 -- polpermissive: false   (RESTRICTIVE)
@@ -49,7 +67,9 @@
 --      FROM feedback f
 --     WHERE f.source_type::text = 'telegram'::text AND f.created_at > (now() - '01:00:00'::interval))
 --
--- ROLLBACK — restores exactly the above. Run inside a transaction:
+-- ROLLBACK SHAPE — REFERENCE ONLY. Build the actual rollback from the fresh pre-apply capture, not
+-- from this. It is reproduced here so the reviewer can see what a correct rollback looks like and
+-- so the fresh capture has something to be diffed AGAINST. Run inside a transaction:
 --
 --   ALTER POLICY anon_feedback_ingress_bounds ON public.feedback
 --       WITH CHECK (

--- a/database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier_acceptance.mjs
+++ b/database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier_acceptance.mjs
@@ -1,0 +1,211 @@
+// Behavioural acceptance for the G2 amendment to anon_feedback_ingress_bounds.
+// Requirement (2) from Adam, condition of the chairman's Option A approval:
+//   "include a test that the limit still REJECTS past threshold for a single source_type after
+//    the qualifier lands — narrowing the counting scope is exactly how a limit accidentally stops
+//    limiting."
+//
+// NOT YET EXECUTED. Authored alongside the staged amendment; the policy it tests is not applied.
+// This file makes no claim to have passed. It is the instrument, not the evidence.
+//
+// ── RUN IT TWICE. THE BASELINE IS NOT OPTIONAL. ───────────────────────────────────────────────
+//   node <this file> --baseline    BEFORE the apply. Test B must FAIL.
+//   node <this file> --verify      AFTER  the apply. Every test must PASS.
+//
+// A post-apply green proves nothing on its own: if the probe cannot detect the defect, it would
+// read green against the UNAMENDED policy too, and "the fix works" would be indistinguishable from
+// "the test cannot see". The baseline run is what makes the verify run mean something. Test B is
+// the discriminator — under the current (unamended) policy a non-telegram anon insert is denied
+// while telegram is over threshold, which IS the G2 defect; after the amendment it must be allowed.
+//
+// ── METHOD ────────────────────────────────────────────────────────────────────────────────────
+// Three-leg, because an error code never decides landed-vs-refused:
+//   leg 1  observe what the client reports
+//   leg 2  SERVICE-ROLE READBACK — the only thing that establishes whether the row exists
+//   leg 3  re-attempt the IDENTICAL write WITHOUT RETURNING (bare insert), read back again
+// The two write forms DIVERGE: a bare insert can persist a row while the .select() form of the same
+// write reports an error, so a suite built only from the RETURNING variant proves only that
+// RETURNING refused.
+//
+// Probe rows are otherwise VALID and differ only in the field under test — NOT NULL and CHECK
+// constraints are evaluated BEFORE the RLS WITH CHECK, so a malformed probe never reaches the
+// policy and returns a misleading error. That trap voided a full acceptance battery four times on
+// the parent SD; the control below is what catches it.
+//
+// ── BLAST RADIUS, read before running ─────────────────────────────────────────────────────────
+// Setup inserts enough tagged telegram rows (as service_role, which bypasses RLS) to push the
+// 1-hour window past 50. For that hour the REAL telegram ingress path is rate-limited. Measured
+// organic telegram volume is 1 row/hour all-time, so this is near-zero impact — but it is not zero,
+// and cleanup runs in a finally block with a verified residual count. Do not run this while a
+// telegram incident is in progress.
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const MODE = process.argv.includes('--baseline') ? 'baseline'
+           : process.argv.includes('--verify') ? 'verify'
+           : null;
+if (!MODE) {
+  console.error('Usage: node <this file> --baseline | --verify   (see the header: the baseline is not optional)');
+  process.exit(2);
+}
+
+const URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anon = createClient(URL, process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
+const svc = createClient(URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const TAG = 'G2ACCEPT-SOURCE-TYPE-QUALIFIER';
+const THRESHOLD = 50;
+const results = [];
+
+/** Otherwise-valid row; callers vary ONLY the field under test. */
+const validBase = (name, extra = {}) => ({
+  type: 'issue',
+  source_application: 'chairman_bot',
+  source_type: 'telegram',
+  severity: 'medium',
+  title: `${TAG} ${name} — automated acceptance probe, safe to delete`,
+  description: 'G2 amendment acceptance probe. Reader side is fenced; this row cannot govern anything.',
+  ...extra,
+});
+
+async function readback(name) {
+  const { data, error } = await svc.from('feedback').select('id').ilike('title', `${TAG} ${name}%`);
+  if (error) throw new Error(`readback failed (results are void without it): ${error.message}`);
+  return data || [];
+}
+
+/** Three-leg probe. Decides landed-vs-refused by READBACK under BOTH write forms. */
+async function probe(name, fields) {
+  const withReturning = await anon.from('feedback').insert(validBase(name, fields)).select('id');
+  const afterReturning = await readback(name);
+
+  const bare = await anon.from('feedback').insert(validBase(`${name}-bare`, fields)); // no .select()
+  const afterBare = await readback(`${name}-bare`);
+
+  const landedReturning = afterReturning.length > 0;
+  const landedBare = afterBare.length > 0;
+  const agree = landedReturning === landedBare;
+
+  console.log(`  ${name.padEnd(30)} RETURNING=${landedReturning ? 'LANDED' : 'absent'} bare=${landedBare ? 'LANDED' : 'absent'}${agree ? '' : '   *** FORMS DISAGREE ***'}`);
+  if (withReturning.error && landedReturning) {
+    console.log('      *** the client reported an error AND the row is present — the status code would have lied.');
+  }
+  if (!agree) {
+    console.log('      *** bare-insert and RETURNING diverge. This is the exact hazard leg 3 exists for.');
+    console.log('      *** Treat the LANDED side as the truth: the write happened.');
+  }
+  return { landed: landedReturning || landedBare, agree };
+}
+
+function record(id, desc, pass, detail) {
+  results.push({ id, desc, pass, detail });
+  console.log(`  [${pass ? 'PASS' : 'FAIL'}] ${id}: ${desc}${detail ? ` — ${detail}` : ''}`);
+}
+
+async function windowCount(sourceType) {
+  const since = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+  const { count, error } = await svc.from('feedback')
+    .select('id', { count: 'exact', head: true })
+    .eq('source_type', sourceType).gt('created_at', since);
+  if (error) throw new Error(`window count failed: ${error.message}`);
+  return count ?? 0;
+}
+
+let filled = [];
+try {
+  console.log(`=== G2 acceptance — mode: ${MODE} ===\n`);
+
+  // ── D. CONTROL FIRST. Without a demonstrated positive, every absence below is meaningless. ──
+  console.log('D. CONTROL (must LAND — proves the probe can produce a positive at all)');
+  const control = await probe('control-benign', { severity: 'medium', category: 'harness_backlog' });
+  record('D', 'benign anon telegram insert lands', control.landed,
+    control.landed ? undefined : 'HARNESS BROKEN — every absence result below is void. Stop here.');
+  if (!control.landed) {
+    console.log('\n*** ABORTING: the control did not land, so no absence result can be trusted. ***');
+    process.exitCode = 1;
+  } else {
+
+    // ── C. Clauses (1) and (2) unchanged by the amendment. ──
+    console.log('\nC. UNCHANGED CLAUSES (must be REFUSED)');
+    const crit = await probe('severity-critical', { severity: 'critical' });
+    record('C1', 'severity=critical still refused', !crit.landed);
+    const defer = await probe('category-deferred', { severity: 'low', category: 'chairman_decision_deferred' });
+    record('C2', 'category=chairman_decision_deferred still refused (severity legal on purpose, so only the category clause can be doing the work)', !defer.landed);
+
+    // ── SETUP: push telegram past threshold, as service_role (bypasses RLS). ──
+    const before = await windowCount('telegram');
+    const need = Math.max(0, THRESHOLD - before + 1);
+    console.log(`\nSETUP: telegram rows in window = ${before}; inserting ${need} tagged rows to exceed ${THRESHOLD}`);
+    if (need > 0) {
+      const rows = Array.from({ length: need }, (_, i) => validBase(`fill-${i}`));
+      const { data, error } = await svc.from('feedback').insert(rows).select('id');
+      if (error) throw new Error(`setup insert failed: ${error.message}`);
+      filled = (data || []).map(r => r.id);
+    }
+    const after = await windowCount('telegram');
+    console.log(`  telegram rows in window now = ${after} (must exceed ${THRESHOLD}: ${after > THRESHOLD})`);
+    if (after <= THRESHOLD) {
+      record('SETUP', 'could not push telegram over threshold — A and B are unrunnable', false);
+    } else {
+
+      // ── A. REQUIREMENT (2): the limit must STILL REJECT past threshold for one source_type. ──
+      console.log('\nA. LIMIT STILL REJECTS past threshold for a single source_type (requirement 2)');
+      const over = await probe('telegram-over-limit', { severity: 'medium' });
+      record('A', 'anon telegram insert refused while telegram is over threshold', !over.landed,
+        over.landed ? 'THE LIMIT STOPPED LIMITING — narrowing the counting scope is exactly how this happens. Do not ship.' : undefined);
+
+      // ── B. THE DISCRIMINATOR: another source_type under threshold must still be ACCEPTED. ──
+      // Under the UNAMENDED policy this is DENIED (that is G2). Under the amendment it is allowed.
+      // anon cannot write an arbitrary source_type — the permissive layer must admit it — so this
+      // uses the venture-user path. If no such path can be constructed, the test FAILS LOUDLY
+      // rather than being silently skipped: an unrunnable discriminator is not a pass.
+      console.log('\nB. DISCRIMINATOR — a DIFFERENT source_type, under its own threshold, must still be accepted');
+      const ventureUnder = await windowCount('user_feedback');
+      console.log(`  user_feedback rows in window = ${ventureUnder} (must be under ${THRESHOLD})`);
+      const other = await probe('other-source-under-limit', {
+        source_type: 'user_feedback',
+        feedback_type: 'user_general',
+        severity: 'low',
+      });
+      const expectLanded = MODE === 'verify';
+      record('B', `non-telegram anon insert ${expectLanded ? 'ACCEPTED (G2 fixed)' : 'DENIED (G2 present — this FAIL is the point of --baseline)'}`,
+        other.landed === expectLanded,
+        MODE === 'baseline' && !other.landed
+          ? 'EXPECTED FAILURE. The probe can see the defect, so the --verify green will mean something.'
+          : (MODE === 'baseline' && other.landed
+              ? 'the baseline did NOT reproduce G2 — either the permissive layer refused for an unrelated reason, or the premise is wrong. Investigate before trusting --verify.'
+              : undefined));
+    }
+  }
+} catch (err) {
+  console.error('\n*** PROBE ERROR:', err.message);
+  process.exitCode = 1;
+} finally {
+  // ── CLEANUP, verified. Probe rows sit inside the live rate-limit window until removed. ──
+  const { data: mine } = await svc.from('feedback').select('id').ilike('title', `${TAG}%`);
+  const ids = (mine || []).map(r => r.id);
+  if (ids.length) {
+    for (let i = 0; i < ids.length; i += 100) {
+      await svc.from('feedback').delete().in('id', ids.slice(i, i + 100));
+    }
+  }
+  const { count: residual } = await svc.from('feedback')
+    .select('id', { count: 'exact', head: true }).ilike('title', `${TAG}%`);
+  console.log(`\ncleanup: deleted ${ids.length} (setup fill: ${filled.length}) | residual probe rows: ${residual}`);
+  if (residual > 0) {
+    console.log('*** CLEANUP INCOMPLETE — remove manually; these rows are inside the live rate-limit window.');
+    process.exitCode = 1;
+  }
+
+  const failed = results.filter(r => !r.pass);
+  console.log(`\n=== ${MODE.toUpperCase()}: ${results.length - failed.length}/${results.length} passed ===`);
+  if (MODE === 'baseline') {
+    const b = results.find(r => r.id === 'B');
+    console.log(b && b.pass
+      ? 'Baseline OK: the probe reproduced G2, so a --verify green is meaningful.'
+      : 'Baseline did NOT reproduce G2 — a --verify green would be uninterpretable. Fix the probe first.');
+  } else if (failed.length) {
+    console.log('DO NOT accept the amendment. Failing: ' + failed.map(f => f.id).join(', '));
+    process.exitCode = 1;
+  }
+}

--- a/database/chairman-gated/README.md
+++ b/database/chairman-gated/README.md
@@ -51,6 +51,54 @@ and has **no retention implemented**, so every row added is permanent. The `WHEN
 trigger is a second, independent guard on that same property, so the trigger does not fire at all
 for updates touching none of the three fields.
 
+## Applying `20260803_bound_anon_ingress_source_type_qualifier.sql`
+
+```
+node scripts/apply-migration.js "database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier.sql" \
+  --prod-deploy --issue-token <token>
+```
+
+Chairman-approved 2026-08-03 (Option A, SMS 10:13:53Z, on record via Adam). **Approval to author is
+not approval to apply** — the apply runs through the ceremony with the approval row referenced.
+
+Rollback is in the file header, and the pre-amendment predicate is captured there **verbatim from
+`pg_get_expr` on the live policy**, not reconstructed from the migration source. That distinction is
+load-bearing: Postgres normalises `NOT IN` to `<> ALL (ARRAY[...])` and adds `::text` casts, so a
+rollback rebuilt from the migration file would not restore byte-identical state.
+
+**Run the acceptance twice — the baseline is not optional:**
+
+```
+node database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier_acceptance.mjs --baseline   # BEFORE apply, test B must FAIL
+node database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier_acceptance.mjs --verify     # AFTER apply, all must PASS
+```
+
+A post-apply green proves nothing alone: a probe that cannot detect the defect reads green against
+the unamended policy too, making "the fix works" indistinguishable from "the test cannot see". The
+baseline run is what gives the verify run meaning.
+
+### What it does
+
+Amends clause (3) of `anon_feedback_ingress_bounds` so the 1-hour window is counted over rows
+sharing the **inserting row's** `source_type` instead of always over `telegram`. Each `source_type`
+gets its own budget, so flooding one can no longer deny ingress to another.
+
+That cross-source denial was the defect (gap G2 of SD-LEO-FIX-BOUND-ANON-TELEGRAM-001): a limit
+keyed on telegram was ANDed into a RESTRICTIVE policy applying to *every* anon INSERT, so ~50
+individually-legal telegram rows denied all anon feedback ingress for an hour. Found by the SECURITY
+sub-agent during EXEC review, not by the policy's author. Exposure is real but cold — organic
+telegram volume is 1 row/hour all-time — so it is an adversarial lever, not an operational fault.
+
+`feedback.source_type` in the subquery is the load-bearing token and the thing most likely to be
+silently wrong: the subquery aliases the same table as `f`, so an unqualified `source_type` would
+bind to `f` and collapse the predicate to a tautology, counting the full hourly population while
+reading as if it were scoped. Verified read-only before staging (the correlated form returns
+distinct per-source counts, not the table total) and re-asserted at apply time by post-condition 2.
+
+**Does not fix**, and must not be read as fixing: the counting subquery still runs as the inserting
+role and is subject to that role's SELECT RLS, so narrowing the anon SELECT policy still makes it
+undercount and fail **open**.
+
 ## The underlying finding, which outlives this SD
 
 `LEO_MIGRATION_TIER_GATE` being off means the TIER-2 default-deny protection is currently inert

--- a/database/chairman-gated/README.md
+++ b/database/chairman-gated/README.md
@@ -61,10 +61,20 @@ node scripts/apply-migration.js "database/chairman-gated/20260803_bound_anon_ing
 Chairman-approved 2026-08-03 (Option A, SMS 10:13:53Z, on record via Adam). **Approval to author is
 not approval to apply** — the apply runs through the ceremony with the approval row referenced.
 
-Rollback is in the file header, and the pre-amendment predicate is captured there **verbatim from
-`pg_get_expr` on the live policy**, not reconstructed from the migration source. That distinction is
-load-bearing: Postgres normalises `NOT IN` to `<> ALL (ARRAY[...])` and adds `::text` casts, so a
-rollback rebuilt from the migration file would not restore byte-identical state.
+**The rollback source is a FRESH PRE-APPLY CAPTURE of live `pg_policies` state, taken by the applier
+at apply time — never a repo file, including the amendment file itself.** The predicate in that
+file's header is captured from `pg_get_expr` on the live policy at *authoring* time and is there as
+**context to diff against**, not as an authority to restore from.
+
+That requirement is not ceremony. This repo already carries a policy file for
+`public.session_coordination` (20260309, `FOR ALL` with no `TO` clause) that **disagrees with live
+state** — the same defect as the SD above in the opposite direction: there a live policy had no
+file, here a file misdescribes the live policy. Both are one representation being trusted for a fact
+it does not hold.
+
+**Any file-vs-live disagreement found during the pre-apply capture is a BLOCKING finding** — stop
+the ceremony and report it, because it means live policy was changed outside migration history
+again, which matters more than the amendment does.
 
 **Run the acceptance twice — the baseline is not optional:**
 


### PR DESCRIPTION
## Summary

Stages the chairman-approved amendment (Option A, 2026-08-03 10:13:53Z, on record via Adam) closing gap **G2** of SD-LEO-FIX-BOUND-ANON-TELEGRAM-001.

**Staged, not applied.** The file lives in `database/chairman-gated/`, outside the three directories `BaseExecutor._checkAndExecutePendingMigrations` scans. That placement is load-bearing, not cosmetic: `LEO_MIGRATION_TIER_GATE` is unset in this repo, so the TIER-2 default-deny classification is computed, logged, and — in the code's own words — "changes NOTHING". A worker cannot put chairman-gated DDL on an auto-applied path and still call it gated. **Approval to author is not approval to apply.**

## The defect

Clause (3) counted `telegram` rows, but was ANDed into a **RESTRICTIVE** policy applying to *every* anon INSERT. So a limit keyed on telegram ingress gated the venture-user path too — one that has its own per-venture limit and never needed this one. ~50 individually-legal telegram rows deny **all** anon feedback ingress for an hour, at a cost of ~50 requests. The harmed path is not the attacker's own.

Found by the SECURITY sub-agent during EXEC review, not by the policy's author. Exposure is real but **cold**: organic telegram volume is 1 row/hour all-time, so it's an adversarial lever rather than an operational fault — which is why it was routed for same-day ratification instead of treated as an incident.

## The fix

Count the 1-hour window over rows sharing the **inserting row's** `source_type`, so each source gets its own budget and flooding one cannot deny another.

## Adam's two conditions, both met

1. **Rollback is exact, not reconstructed.** The pre-amendment predicate is captured verbatim from `pg_get_expr` on the *live* policy. This matters: Postgres normalises `NOT IN` → `<> ALL (ARRAY[...])` and adds `::text` casts, so a rollback rebuilt from the migration source would not restore byte-identical state.
2. **A behavioural test that the limit still REJECTS past threshold** for a single `source_type` — narrowing the counting scope is exactly how a limit accidentally stops limiting.

## Test plan

The acceptance runs **twice**, and the baseline is not optional:

```
node database/chairman-gated/20260803_..._acceptance.mjs --baseline   # BEFORE apply — test B must FAIL
node database/chairman-gated/20260803_..._acceptance.mjs --verify     # AFTER apply — all must PASS
```

A post-apply green proves nothing alone: a probe that cannot detect the defect reads green against the unamended policy too, making "the fix works" indistinguishable from "the test cannot see". Test B is the discriminator — under the current policy a non-telegram anon insert is denied while telegram is over threshold (that *is* G2); after the amendment it must be allowed.

Probes use the three-leg method (observe → service-role readback → re-attempt **without** `RETURNING`), because the two write forms diverge: a bare insert can persist a row while the `.select()` form of the same write reports an error. A benign control must LAND first, or every absence result is void.

Five structural post-conditions run **inside the transaction** — an external suite can't substitute, since this repo's vitest `db` project is gated to zero files and would report green having executed nothing. They assert: still RESTRICTIVE; the correlation landed; it did **not** collapse to a self-comparison; the `count(*) < 50` bound survived; and the old unconditional telegram filter is gone (without which an amendment could add the qualifier, leave the filter, and pass everything with G2 unfixed).

**`ALTER POLICY`, not `DROP`+`CREATE`** — the latter leaves the table with no restrictive bound between statements, which is an open ingress if the file is ever run statement-by-statement.

## The subtle part

`feedback.source_type` inside the subquery is load-bearing. The subquery aliases the same table as `f`, so an unqualified `source_type` binds to `f` and collapses the predicate to a tautology — counting the full hourly population while *reading* as if scoped, and working by accident today. Verified read-only against live data before staging (the correlated form returns distinct per-source counts — telegram=1, auto_capture=9979 — not the 16,580 table total) and re-asserted at apply time.

## What this does NOT fix

- The counting subquery still runs as the inserting role and is subject to that role's SELECT RLS, so narrowing the anon SELECT policy still makes it undercount and **fail open**.
- Clause (1) still mirrors a constant living in a separately-editable view, already restructured once without this policy being consulted.
- `public.record_venture_error()` still reaches `public.feedback` outside RLS entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
