### PR TITLE
feat(SD-LEO-INFRA-RELEASED-MID-PHASE-001): released mid-phase work re-enters a visible queue

### DIFF
--- a/lib/claim/release-claim-both-surfaces.mjs
+++ b/lib/claim/release-claim-both-surfaces.mjs
@@ -77,6 +77,24 @@
 // Releasing a CLAIM and handing back a WORK ITEM are different operations with different
 // correct call sites. The hand-back is wired per-site, deliberately, with each site's
 // disposition recorded — see the ledger in lib/fleet/release-work-item.mjs.
+// SD-LEO-INFRA-RELEASED-MID-PHASE-001 / FR-1a: the ONLY server-side jsonb-merge seam.
+// PostgREST cannot express `metadata || patch`, so this must not be attempted through the
+// supabase-js client `sb` above — mergeMetadataKeys owns a raw-pg connection and was built
+// (QF-20260720-597) for exactly this anti-pattern. Do NOT re-derive it: a read-spread-write
+// clobbers metadata.claim_history, which claim_sd appends SERVER-SIDE.
+import { mergeMetadataKeys } from '../coordinator/safe-metadata-merge.mjs';
+
+/**
+ * Reasons that mean the work is FINISHED, not handed back. A release carrying one of these
+ * is stamped resumable:false so the adoption path does not offer completed/cancelled work
+ * as resumable. Kept as a set rather than inferred from status, because the release helper
+ * runs BEFORE any status change and cannot read the outcome from the row.
+ */
+const TERMINAL_RELEASE_REASONS = new Set([
+  'completed', 'cancelled', 'sd_completed', 'sd_cancelled',
+  'SWEEP_SD_ALREADY_COMPLETED', 'SWEEP_SD_CANCELLED', 'complete-quick-fix',
+]);
+
 export async function releaseClaimBothSurfaces(sb, opts = {}) {
   const { sdKey, reason = 'release', sessionStatus = 'released', tryRpc = false, readback = true } = opts;
   let holder = opts.holderSessionId || null;
@@ -109,6 +127,46 @@ export async function releaseClaimBothSurfaces(sb, opts = {}) {
     result.ok = true;
     result.oldHolderGone = true;
     return result;
+  }
+
+  // ── FR-1: STAMP THE RELEASE BEFORE CLEARING IT ───────────────────────────────
+  // SD-LEO-INFRA-RELEASED-MID-PHASE-001.
+  //
+  // THE DEFECT: every SD-side release below clears {claiming_session_id,
+  // active_session_id, is_working_on} and stamps NOTHING. The provenance that IS
+  // captured — released_at / released_reason — goes on the claude_sessions row, which
+  // is then retired and drops out of every live view. strategic_directives_v2 has no
+  // release-provenance columns at all, and lib/fleet/collision-check.cjs:4 says the
+  // asymmetry outright: metadata.claim_history "records claims but never releases".
+  // The result is work that is resumable but cannot say so — measured live as 4 rows
+  // sitting mid-phase, unclaimed, reachable by no automated claim path.
+  //
+  // ORDER IS LOAD-BEARING: STAMP FIRST, THEN CLEAR. The merge needs its own raw-pg
+  // connection (PostgREST cannot express jsonb `||`), so the stamp and the clear are
+  // in SEPARATE TRANSACTIONS. Stamping first makes a crash in between leave a
+  // stamped-but-still-claimed row — harmless, and self-correcting on the next sweep.
+  // Clearing first would leave an UNSTAMPED RELEASED ROW, which is precisely the bug
+  // this SD exists to remove: the fix would manufacture its own defect.
+  //
+  // FAIL-SOFT: a stamp failure must never block the release. An unstamped release is
+  // today's behaviour (bad but survivable); a BLOCKED release strands a live claim on
+  // a dead seat, which is strictly worse. The failure is recorded on the result rather
+  // than swallowed, so a caller can log it.
+  try {
+    await mergeMetadataKeys(sdKey, {
+      claim_release: {
+        prior_claimant: holder,
+        released_at: new Date().toISOString(),
+        released_reason: reason,
+        released_by: 'release-claim-both-surfaces',
+        // Distinguishes resumable from terminal. A cancel/complete release passes a
+        // terminal reason and must NOT advertise itself as resumable work.
+        resumable: sessionStatus !== 'released' || !TERMINAL_RELEASE_REASONS.has(reason),
+      },
+    });
+    result.stamped = true;
+  } catch (e) {
+    result.stampError = e?.message || String(e);
   }
 
   // ── Optional: atomic co-clear via the release_session RPC (retire only) ───────

--- a/lib/claim/release-claim-both-surfaces.mjs
+++ b/lib/claim/release-claim-both-surfaces.mjs
@@ -152,8 +152,15 @@ export async function releaseClaimBothSurfaces(sb, opts = {}) {
   // today's behaviour (bad but survivable); a BLOCKED release strands a live claim on
   // a dead seat, which is strictly worse. The failure is recorded on the result rather
   // than swallowed, so a caller can log it.
+  // CHECK THE RETURN VALUE, DO NOT ONLY CATCH. mergeMetadataKeys RETURNS
+  // {merged:false, error} for every real failure — connect failure, query error, and
+  // rowCount===0 — and throws ONLY on argument validation, which is unreachable from here.
+  // The first version wrapped it in try/catch alone and set stamped=true unconditionally, so
+  // stampError was dead code and a silent no-op reported as success. That matters on a live
+  // path: claim-command.js:196 passes session.sd_key, which can be a QF id and matches no SD
+  // row at all. Caught by an EXEC reviewer reading the callee's contract rather than its name.
   try {
-    await mergeMetadataKeys(sdKey, {
+    const merge = await mergeMetadataKeys(sdKey, {
       claim_release: {
         prior_claimant: holder,
         released_at: new Date().toISOString(),
@@ -164,7 +171,8 @@ export async function releaseClaimBothSurfaces(sb, opts = {}) {
         resumable: sessionStatus !== 'released' || !TERMINAL_RELEASE_REASONS.has(reason),
       },
     });
-    result.stamped = true;
+    if (merge?.merged) result.stamped = true;
+    else result.stampError = merge?.error || 'merge_matched_no_rows';
   } catch (e) {
     result.stampError = e?.message || String(e);
   }

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -801,4 +801,19 @@ async function liveClaimWriteFenceReason(sb, sdKey, claimantSessionId = null, li
   }
 }
 
-module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, classifyAllDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, parentLeadPending, TEST_FIXTURE_KEY_RE, resolveHoldProvenance, formatHoldProvenance, isDispatchAuthorized, liveClaimWriteFenceReason, CLAIM_WRITE_FENCE_AXES, execBoundaryHoldReason, isLeadBlockerActive };
+/**
+ * SD-LEO-INFRA-RELEASED-MID-PHASE-001 / FR-4: the axis roster, DERIVED not restated.
+ *
+ * The two-sided control needs to assert that EVERY ineligibility axis actually refuses — but a
+ * test that hard-codes the axis list is the same defect this repo keeps catching: it agrees on
+ * the day it is written and drifts silently afterwards. (The first probe written for this SD
+ * hard-coded a guessed hold-key list and over-counted the orphan class by 50%.)
+ *
+ * Because INELIGIBILITY_AXES is an array of NAMED functions, the roster can be derived from
+ * `fn.name` instead of maintained. Adding a nineteenth axis makes it appear here automatically,
+ * so an iterating test fails until a case exists for it — which is the point: the roster cannot
+ * fall behind the implementation, because it IS the implementation.
+ */
+const INELIGIBILITY_AXIS_NAMES = Object.freeze(INELIGIBILITY_AXES.map((fn) => fn.name).filter(Boolean));
+
+module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, classifyAllDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, parentLeadPending, TEST_FIXTURE_KEY_RE, resolveHoldProvenance, formatHoldProvenance, isDispatchAuthorized, liveClaimWriteFenceReason, CLAIM_WRITE_FENCE_AXES, execBoundaryHoldReason, isLeadBlockerActive, INELIGIBILITY_AXES, INELIGIBILITY_AXIS_NAMES };

--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -814,6 +814,11 @@ async function liveClaimWriteFenceReason(sb, sdKey, claimantSessionId = null, li
  * so an iterating test fails until a case exists for it — which is the point: the roster cannot
  * fall behind the implementation, because it IS the implementation.
  */
+// NOT exported alongside the raw INELIGIBILITY_AXES array, deliberately. A SECURITY reviewer
+// demonstrated that the array is mutable and module-cached: one in-place `.splice()` or `.sort()`
+// disables every claim guard process-wide and persists across a fresh require. No caller needs the
+// raw predicates — only the names — so the array stays module-private and is frozen in place.
+Object.freeze(INELIGIBILITY_AXES);
 const INELIGIBILITY_AXIS_NAMES = Object.freeze(INELIGIBILITY_AXES.map((fn) => fn.name).filter(Boolean));
 
-module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, classifyAllDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, parentLeadPending, TEST_FIXTURE_KEY_RE, resolveHoldProvenance, formatHoldProvenance, isDispatchAuthorized, liveClaimWriteFenceReason, CLAIM_WRITE_FENCE_AXES, execBoundaryHoldReason, isLeadBlockerActive, INELIGIBILITY_AXES, INELIGIBILITY_AXIS_NAMES };
+module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, classifyAllDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, parentLeadPending, TEST_FIXTURE_KEY_RE, resolveHoldProvenance, formatHoldProvenance, isDispatchAuthorized, liveClaimWriteFenceReason, CLAIM_WRITE_FENCE_AXES, execBoundaryHoldReason, isLeadBlockerActive, INELIGIBILITY_AXIS_NAMES };

--- a/package.json
+++ b/package.json
@@ -628,7 +628,8 @@
     "canary:probe": "node scripts/canary/run-canary-probe.mjs",
     "test:quarantine": "node scripts/unit-tier-quarantine.mjs report .claude-unit-run.log",
     "test:quarantine:burndown": "node scripts/unit-tier-quarantine.mjs burndown",
-    "worker:recheck-blocker": "node scripts/worker-recheck-blocker.mjs"
+    "worker:recheck-blocker": "node scripts/worker-recheck-blocker.mjs",
+    "audit:unreachable-midphase": "node scripts/audit-unreachable-midphase-sds.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.85.0",

--- a/scripts/audit-unreachable-midphase-sds.mjs
+++ b/scripts/audit-unreachable-midphase-sds.mjs
@@ -60,9 +60,19 @@ export const NON_TERMINAL_STARTED_STATUSES = Object.freeze(['active', 'in_progre
  * The phase veto that makes a started row invisible to the draft-tier claim sources.
  * Mirrors isSdInFlight's leg: anything past LEAD is treated as in-flight and skipped.
  */
+export const UNSTARTED_PHASES = Object.freeze(['LEAD', 'LEAD_APPROVAL']);
+
 export function isPhaseVetoed(row) {
   const phase = row?.current_phase;
-  return Boolean(phase) && phase !== 'LEAD';
+  // CORRECTED AFTER EXEC REVIEW — and this file's own constraint 1 is what I violated.
+  // The first version tested `phase !== 'LEAD'` only. isSdInFlight (worker-checkin.cjs:1345)
+  // treats LEAD **and LEAD_APPROVAL** as equivalent un-started states, and LEAD_APPROVAL is the
+  // column DEFAULT — so a brand-new never-touched row sits there. Testing LEAD alone declared
+  // every default-phase row phase-vetoed, which is the opposite of the truth and would have made
+  // this check disagree with the code it claims to mirror. Restating a predicate instead of
+  // importing it is the exact sin the docblock above lectures against; I committed it two
+  // functions below the lecture.
+  return Boolean(phase) && !UNSTARTED_PHASES.includes(phase);
 }
 
 /**
@@ -82,11 +92,19 @@ export function reachableBy(row) {
   // FR-2 widens this predicate to include 'active'; until it lands, only in_progress qualifies.
   if (ADOPTION_STATUSES.includes(status)) return 'resume_orphan';
 
-  // Draft-tier sources fetch draft|active but veto anything past LEAD.
-  if (!isPhaseVetoed(row)) return 'draft_tier';
+  // Draft-tier sources fetch .in('status',['draft','active']) and then veto anything past the
+  // un-started phases. BOTH legs matter: the first version omitted the status check, so a
+  // pending_approval row at an un-started phase was reported reachable by 'draft_tier' when no
+  // draft source would ever fetch it. Caught by an EXEC reviewer driving the exported predicate
+  // directly — and it was internally inconsistent too, since the same unreachable row one phase
+  // over WAS flagged an offender.
+  if (DRAFT_TIER_STATUSES.includes(status) && !isPhaseVetoed(row)) return 'draft_tier';
 
   return null;
 }
+
+/** What the draft-tier claim sources actually fetch (worker-checkin.cjs:888/:922/:964/:1000). */
+export const DRAFT_TIER_STATUSES = Object.freeze(['draft', 'active']);
 
 /**
  * The statuses adoptOrphanInProgress accepts — IMPORTED FROM THE ADOPTION PATH ITSELF, not
@@ -162,10 +180,21 @@ async function main() {
     if (offenders.length === 0) console.log('  none — every started unclaimed row is reachable or explicitly held');
   }
 
-  // Non-zero exit so this can gate. FR-2 has not landed until this reaches 0.
-  process.exit(offenders.length > 0 ? 1 : 0);
+  // EXIT CODE VIA process.exitCode, NOT process.exit() — and this is not style.
+  //
+  // process.exit() while the supabase-js handle is still closing aborts the process on Windows
+  // with `Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), src/win/async.c:76`, and the
+  // shell then sees 127 REGARDLESS of the argument. Measured 5/5: process.exit(0) -> 127 and
+  // process.exit(1) -> 127, indistinguishable. A gate reading $? could not tell clean from
+  // dirty, which would have made this check — the SD's whole acceptance — unable to gate at all.
+  //
+  // Caught by an EXEC reviewer who checked the exit code rather than the output. My own "4 before,
+  // 0 after" was read off stdout TEXT and never off the gating surface, so the number was right
+  // and the mechanism was broken. Setting exitCode lets the event loop drain naturally and the
+  // real code survives.
+  process.exitCode = offenders.length > 0 ? 1 : 0;
 }
 
 if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1].replace(/\\/g, '/')}`).href) {
-  main().catch((e) => { console.error('[unreachable-midphase] fatal:', e.message); process.exit(2); });
+  main().catch((e) => { console.error('[unreachable-midphase] fatal:', e.message); process.exitCode = 2; });
 }

--- a/scripts/audit-unreachable-midphase-sds.mjs
+++ b/scripts/audit-unreachable-midphase-sds.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * STANDING CHECK — SD-LEO-INFRA-RELEASED-MID-PHASE-001 / FR-3.
+ *
+ * THE QUESTION: is there any unclaimed non-terminal SD that is neither reachable by an
+ * automated claim path nor explicitly held with a reason? Such a row is not dispatchable and
+ * not parked — it is simply unseen, and only surfaces when a health probe happens to notice.
+ *
+ * WHY THIS SHIPS AS A STANDING CHECK RATHER THAN A ONE-OFF: the SD's acceptance is
+ * population-scoped. A one-row receipt proves the row we looked at; a population query proves
+ * the class. And it must be able to FAIL — see the pinned expectations below.
+ *
+ * ── TWO CONSTRAINTS LEARNED THE HARD WAY, BOTH FROM GETTING THEM WRONG FIRST ──
+ *
+ * 1. IMPORT THE PREDICATE, NEVER RE-LIST THE KEYS. The first probe written for this SD
+ *    hard-coded a guessed hold-key list and over-counted the class by 50% (reported 6, actual
+ *    4): it missed that `status='deferred'` IS the canonical park state, and that an
+ *    orchestrator is unclaimed by design. classifyAllDispatchIneligibility is exported and is
+ *    PURE / SYNCHRONOUS / DB-FREE — there is no reason to restate its logic here, and every
+ *    restatement drifts.
+ *
+ * 2. NEVER COMPUTE AN AGE IN JS FROM updated_at. strategic_directives_v2.updated_at is
+ *    TIMEZONE-NAIVE (no Z, no offset) while claude_sessions.heartbeat_at carries one.
+ *    Date.parse() reads a naive ISO string as LOCAL time, so on a UTC-4 host every age comes
+ *    out 4 hours SHORT — in the alert-SUPPRESSING direction, which is how a row once showed a
+ *    NEGATIVE age. Filter server-side (.lt) where Postgres compares naive-to-naive, and let
+ *    the DB do the arithmetic. Root cause is filed separately as
+ *    SD-LEO-INFRA-NAIVE-TIMESTAMP-SKEW-001.
+ *
+ * ── WHAT "REACHABLE" MEANS, AND WHY THE HOLD CLASSIFIER ALONE IS NOT ENOUGH ──
+ * A row can be hold-free and still unreachable. The draft-tier claim sources DO fetch these
+ * rows (worker-checkin.cjs:888/:922/:964/:1000 query .in('status',['draft','active']) with no
+ * phase filter) and then VETO them via isSdInFlight's `current_phase != 'LEAD'` leg
+ * (worker-checkin.cjs:1029, merged-pool-self-claim.cjs:268). The one tier that deliberately
+ * skips that veto — adoptOrphanInProgress — filters `.eq('status','in_progress')`. So a
+ * status='active' mid-phase row falls BETWEEN TWO TIERS. Reachability must model the phase
+ * veto, not just the hold classifier; scoring on holds alone returns ZERO today and would
+ * make this check unable to show the very bug it exists to close.
+ *
+ * PINNED EXPECTATIONS: 4 before the FR-2 widening, 0 after. A check that cannot demonstrate
+ * the defect cannot demonstrate its removal.
+ *
+ * Usage:
+ *   node scripts/audit-unreachable-midphase-sds.mjs           # human-readable
+ *   node scripts/audit-unreachable-midphase-sds.mjs --json    # machine-readable
+ */
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+// IMPORTED, NOT RE-LISTED. See constraint 1 above.
+const { classifyAllDispatchIneligibility } = require('../lib/fleet/claim-eligibility.cjs');
+
+/** Statuses that are neither terminal nor draft — i.e. work that has genuinely started. */
+export const NON_TERMINAL_STARTED_STATUSES = Object.freeze(['active', 'in_progress', 'pending_approval']);
+
+/**
+ * The phase veto that makes a started row invisible to the draft-tier claim sources.
+ * Mirrors isSdInFlight's leg: anything past LEAD is treated as in-flight and skipped.
+ */
+export function isPhaseVetoed(row) {
+  const phase = row?.current_phase;
+  return Boolean(phase) && phase !== 'LEAD';
+}
+
+/**
+ * Which automated path, if any, can adopt this row today?
+ *
+ * PURE — no I/O, no clock. This is the function tests exercise; the script below only
+ * supplies rows. Returns a path name, or null when nothing can reach it.
+ */
+export function reachableBy(row) {
+  const status = row?.status;
+  const phase = row?.current_phase;
+
+  // recoverStrandedFinal — worker-checkin.cjs:1086-1111
+  if (status === 'pending_approval' && phase === 'LEAD_FINAL') return 'resume_final';
+
+  // adoptOrphanInProgress — worker-checkin.cjs:1231-1283. Deliberately skips the phase veto.
+  // FR-2 widens this predicate to include 'active'; until it lands, only in_progress qualifies.
+  if (ADOPTION_STATUSES.includes(status)) return 'resume_orphan';
+
+  // Draft-tier sources fetch draft|active but veto anything past LEAD.
+  if (!isPhaseVetoed(row)) return 'draft_tier';
+
+  return null;
+}
+
+/**
+ * The statuses adoptOrphanInProgress accepts — IMPORTED FROM THE ADOPTION PATH ITSELF, not
+ * restated here.
+ *
+ * This is the same discipline as importing the hold classifier: a literal copied into this
+ * file would agree with the adoption path on the day it was written and drift silently
+ * afterwards, at which point the check reports on a population the fleet no longer has. One
+ * constant, one definition, imported across the seam.
+ */
+export const ADOPTION_STATUSES = require('./worker-checkin.cjs').ADOPTABLE_ORPHAN_STATUSES;
+
+/**
+ * Is this row deliberately held, with someone accountable for it?
+ * Delegates entirely to the shipped classifier — see constraint 1.
+ */
+export function heldReason(row) {
+  if (row?.status === 'deferred') return 'parked (status=deferred)';
+  if (row?.sd_type === 'orchestrator') return 'orchestrator (unclaimed by design)';
+  const axes = classifyAllDispatchIneligibility(row, { cwd: process.cwd() }) || [];
+  if (Array.isArray(axes) && axes.length > 0) {
+    return axes.map((a) => (typeof a === 'string' ? a : a?.axis || a?.reason || 'ineligible')).join(', ');
+  }
+  return null;
+}
+
+/** The verdict for one row. PURE. */
+export function classifyRow(row) {
+  const held = heldReason(row);
+  const reachable = reachableBy(row);
+  return {
+    sd_key: row?.sd_key,
+    status: row?.status,
+    current_phase: row?.current_phase,
+    held,
+    reachable,
+    // The population this SD exists to drive to zero: neither reachable nor held.
+    unreachable_and_unheld: !held && !reachable,
+  };
+}
+
+async function main() {
+  const json = process.argv.includes('--json');
+  const db = createClient(
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY,
+    { auth: { persistSession: false } }
+  );
+
+  // Paginated: PostgREST caps an unbounded select at 1000 and truncates SILENTLY.
+  const rows = [];
+  const PAGE = 1000;
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await db
+      .from('strategic_directives_v2')
+      .select('sd_key,status,current_phase,sd_type,metadata,updated_at')
+      .in('status', NON_TERMINAL_STARTED_STATUSES)
+      .is('claiming_session_id', null)
+      .range(from, from + PAGE - 1);
+    if (error) throw new Error(`population query failed: ${error.message}`);
+    rows.push(...(data || []));
+    if (!data || data.length < PAGE) break;
+  }
+
+  const verdicts = rows.map(classifyRow);
+  const offenders = verdicts.filter((v) => v.unreachable_and_unheld);
+
+  if (json) {
+    console.log(JSON.stringify({ scanned: rows.length, offenders, count: offenders.length }, null, 2));
+  } else {
+    console.log(`[unreachable-midphase] scanned=${rows.length} unreachable_and_unheld=${offenders.length}`);
+    for (const o of offenders) console.log(`  ${o.sd_key}  ${o.status}/${o.current_phase}`);
+    if (offenders.length === 0) console.log('  none — every started unclaimed row is reachable or explicitly held');
+  }
+
+  // Non-zero exit so this can gate. FR-2 has not landed until this reaches 0.
+  process.exit(offenders.length > 0 ? 1 : 0);
+}
+
+if (process.argv[1] && import.meta.url === new URL(`file://${process.argv[1].replace(/\\/g, '/')}`).href) {
+  main().catch((e) => { console.error('[unreachable-midphase] fatal:', e.message); process.exit(2); });
+}

--- a/scripts/one-off/_echo-orphan-population.mjs
+++ b/scripts/one-off/_echo-orphan-population.mjs
@@ -1,0 +1,62 @@
+// LEAD evidence for SD-LEO-INFRA-RELEASED-MID-PHASE-001.
+// The SD names TWO rows. Acceptance (b) is population-scoped, so measure the POPULATION before
+// believing the sample — a 2-row anecdote and a 40-row class need different remedies.
+// Paginated deliberately: PostgREST caps an unbounded select at 1000 and truncates SILENTLY.
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const db = createClient(process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false } });
+
+async function pageAll(cols, apply) {
+  const out = [];
+  const PAGE = 1000;
+  for (let from = 0; ; from += PAGE) {
+    let q = db.from('strategic_directives_v2').select(cols).range(from, from + PAGE - 1);
+    q = apply(q);
+    const { data, error } = await q;
+    if (error) throw new Error(error.message);
+    out.push(...(data || []));
+    if (!data || data.length < PAGE) break;
+  }
+  return out;
+}
+
+// The class: active (not draft, not completed), mid-phase, and UNCLAIMED.
+const rows = await pageAll(
+  'sd_key,status,current_phase,claiming_session_id,is_working_on,metadata,updated_at',
+  (q) => q.in('status', ['active', 'in_progress', 'pending_approval']).is('claiming_session_id', null)
+);
+
+console.log('unclaimed non-draft rows (paged):', rows.length);
+
+const HOLD_KEYS = ['hold', 'on_hold', 'hold_reason', 'blocked_reason', 'parked', 'park_reason', 'deferred', 'defer_reason'];
+const hasHold = (m) => {
+  if (!m || typeof m !== 'object') return false;
+  return HOLD_KEYS.some((k) => m[k] !== undefined && m[k] !== null && m[k] !== false && m[k] !== '');
+};
+const hasResumeHint = (m) => !!(m && (m.released_by_sweep || m.resume_hint || m.released_at || m.prior_claimant));
+
+const invisible = rows.filter((r) => !hasHold(r.metadata) && !hasResumeHint(r.metadata));
+const held = rows.filter((r) => hasHold(r.metadata));
+const hinted = rows.filter((r) => hasResumeHint(r.metadata));
+
+console.log('  with an explicit hold      :', held.length);
+console.log('  with a resume hint         :', hinted.length);
+console.log('  NEITHER (the orphan class) :', invisible.length, '  <-- acceptance (b) requires this to reach ZERO');
+
+const byPhase = {};
+for (const r of invisible) byPhase[`${r.status}/${r.current_phase}`] = (byPhase[`${r.status}/${r.current_phase}`] || 0) + 1;
+console.log('\ninvisible rows by status/phase:');
+for (const [k, v] of Object.entries(byPhase).sort((a, b) => b[1] - a[1])) console.log(`  ${v.toString().padStart(3)}  ${k}`);
+
+console.log('\nthe two rows the SD names:');
+for (const key of ['SD-FDBK-FIX-HEAL-BEFORE-COMPLETE-001', 'SD-FDBK-INFRA-CLAUDE-SOLOMON-EXCEEDS-001']) {
+  const r = rows.find((x) => x.sd_key === key);
+  console.log(`  ${key}: ${r ? `status=${r.status} phase=${r.current_phase} hold=${hasHold(r.metadata)} hint=${hasResumeHint(r.metadata)}` : 'NOT in the unclaimed set (claimed since, or status changed)'}`);
+}
+
+console.log('\noldest 8 invisible rows (staleness = how long work has been unseen):');
+for (const r of invisible.sort((a, b) => String(a.updated_at).localeCompare(String(b.updated_at))).slice(0, 8)) {
+  const days = ((Date.now() - Date.parse(r.updated_at)) / 86400000).toFixed(1);
+  console.log(`  ${String(days).padStart(6)}d  ${r.status}/${r.current_phase}  ${r.sd_key}`);
+}

--- a/scripts/one-off/_echo-trigger-census.mjs
+++ b/scripts/one-off/_echo-trigger-census.mjs
@@ -1,0 +1,51 @@
+// TR-3 / TS-12: close the trigger census against the LIVE catalog.
+// The LEAD census never enumerated pg_trigger, and a trigger is a release writer no grep can see.
+// The JS client has no SQL RPC under the service-role key, so this uses the raw pg seam.
+import 'dotenv/config';
+import { createDatabaseClient } from '../lib/supabase-connection.js';
+
+const client = await createDatabaseClient();
+try {
+  const trg = await client.query(`
+    SELECT t.tgname, p.proname, t.tgenabled,
+           CASE t.tgtype & 2 WHEN 2 THEN 'BEFORE' ELSE 'AFTER' END AS timing
+    FROM pg_trigger t
+    JOIN pg_class c ON c.oid = t.tgrelid
+    JOIN pg_proc  p ON p.oid = t.tgfoid
+    WHERE c.relname = 'strategic_directives_v2' AND NOT t.tgisinternal
+    ORDER BY t.tgname`);
+  console.log(`TRIGGERS ON strategic_directives_v2: ${trg.rows.length}`);
+  for (const r of trg.rows) console.log(`  ${r.tgname}  -> ${r.proname}()  [${r.timing}, enabled=${r.tgenabled}]`);
+
+  // Does any trigger body touch the claim columns? That is the FR-1 question.
+  const CLAIM_COLS = ['claiming_session_id', 'active_session_id', 'is_working_on'];
+  console.log('\nWHICH TRIGGER FUNCTIONS WRITE THE CLAIM COLUMNS:');
+  for (const r of trg.rows) {
+    const src = await client.query('SELECT prosrc FROM pg_proc WHERE proname = $1 LIMIT 1', [r.proname]);
+    const body = src.rows[0]?.prosrc || '';
+    const hits = CLAIM_COLS.filter((c) => new RegExp(`${c}\\s*(:?=|,)`).test(body) || body.includes(`NEW.${c}`) || body.includes(`${c} =`));
+    const phaseAware = /current_phase|status/.test(body);
+    if (hits.length) {
+      console.log(`  ${r.proname}: writes [${hits.join(', ')}]  phase/status-aware=${phaseAware}`);
+    }
+  }
+
+  // Is the suspect trigger live, and does it reference a column that does not exist?
+  console.log('\nSUSPECT: sync_is_working_on_with_session');
+  const suspect = await client.query("SELECT prosrc FROM pg_proc WHERE proname = 'sync_is_working_on_with_session' LIMIT 1");
+  if (!suspect.rows.length) {
+    console.log('  FUNCTION DOES NOT EXIST — never installed or since dropped.');
+  } else {
+    const body = suspect.rows[0].prosrc;
+    const installed = trg.rows.some((r) => r.proname === 'sync_is_working_on_with_session');
+    console.log('  function exists; attached to strategic_directives_v2 as a trigger:', installed);
+    console.log('  references OLD.sd_id:', body.includes('OLD.sd_id'), '| references OLD.sd_key:', body.includes('OLD.sd_key'));
+  }
+
+  // Ground truth for the column it references.
+  const col = await client.query(`SELECT column_name FROM information_schema.columns
+    WHERE table_name='claude_sessions' AND column_name IN ('sd_id','sd_key') ORDER BY column_name`);
+  console.log('  claude_sessions has:', col.rows.map((r) => r.column_name).join(', ') || '(neither)');
+} finally {
+  await client.end?.();
+}

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -1193,6 +1193,19 @@ async function foreignClaimantBlocksSteal(sb, sdKey, mySessionId, isSessionAlive
 }
 
 const ORPHAN_CANDIDATE_LIMIT = 5;
+
+/**
+ * SD-LEO-INFRA-RELEASED-MID-PHASE-001 / FR-2: the statuses this tier will adopt.
+ *
+ * EXPORTED AND SHARED WITH THE STANDING CHECK. scripts/audit-unreachable-midphase-sds.mjs
+ * imports this exact array to decide what "reachable by an automated path" means. If the two
+ * ever drift, the check silently stops measuring the thing it exists to measure — so they are
+ * one constant rather than two literals that happen to agree today.
+ *
+ * 'pending_approval' is deliberately ABSENT: recoverStrandedFinal owns the
+ * pending_approval/LEAD_FINAL class and adding it here would create a two-path race.
+ */
+const ADOPTABLE_ORPHAN_STATUSES = ['in_progress', 'active'];
 // One full claim-TTL window (claimGuard TTL = 15 min): a mid-transition worker whose claim
 // briefly clears is never raced; sweep claim-clears also refresh updated_at, deferring adoption
 // one window past the clear. A genuine orphan sits indefinitely — the delay is safe.
@@ -1240,7 +1253,25 @@ async function adoptOrphanInProgress(sb, sessionId, base) {
       // parent_sd_id added (SD-FDBK-INFRA-ORPHAN-ADOPT-RESUME-001): feeds the parentLeadPending
       // guard below so a CHILD orphan whose orchestrator parent is still pre-LEAD is not adopted.
       .select('sd_key, sd_type, status, current_phase, metadata, updated_at, target_application, parent_sd_id')
-      .eq('status', 'in_progress')
+      // SD-LEO-INFRA-RELEASED-MID-PHASE-001 / FR-2: WIDENED from .eq('status','in_progress').
+      //
+      // This tier is the purpose-built resume-a-mid-phase-orphan path and it was missing its
+      // target population by ONE ENUM VALUE. Measured live: all four unreachable mid-phase
+      // orphans carry status='active'; ZERO carry 'in_progress'. The rows fell BETWEEN TWO
+      // TIERS — the draft-tier sources fetch status IN (draft,active) but veto anything past
+      // LEAD via isSdInFlight, and this tier deliberately skips that veto but filtered a status
+      // none of them had.
+      //
+      // Widening rather than adding a parallel lane is deliberate: the four guards below
+      // (classifyDispatchIneligibility, parentLeadPending, foreignClaimantBlocksSteal,
+      // pendingDirectedAssignmentBlocksAdoption) are inherited for free, and a new lane would
+      // have to re-implement them or reopen QF-20260720-911 (silent no-land loop) and
+      // SD-FDBK-INFRA-ORPHAN-ADOPT-RESUME-001 (re-adopt loop).
+      //
+      // pending_approval is deliberately NOT included: recoverStrandedFinal already claims
+      // status='pending_approval' AND current_phase='LEAD_FINAL', and adding it here would put
+      // two paths in a race for one row.
+      .in('status', ADOPTABLE_ORPHAN_STATUSES)
       .is('claiming_session_id', null)
       .neq('sd_type', 'orchestrator')         // parents are in_progress/no-claim BY DESIGN while children run
       .lt('updated_at', cutoffIso)            // parked > one claim-TTL window — not a mid-transition race
@@ -1782,7 +1813,7 @@ async function main() {
 // top (imports are referenced directly — never re-derived).
 const CHECKIN_HELPERS = { ws, tryClaim, stampDirectedAssignment, ackMessage, extractSdFromAssignment, extractDirectedSd, isInformationalNudge, classifyDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, registerRollCall, rehydrateCallsign, selfClearQuarantine, mergeCheckinModelEffort, recoverStrandedFinal, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isBuildForbiddenSession, ensureActiveBaseline, isCriticalQfJumpEligible, tryClaimDraftCandidate, baselinedCandidateEligible, isSdInFlight, selfClaimQuickFix, selfHealStaleClaim, findOwnSdClaim, healOwnClaimPointer, confirmRowGone, surfaceCoordinatorMessages, fetchOutstandingSignals, formatOutstandingWarning, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, sortByDispatchRank, resolveWorkerTierRank, isTieringActive, fetchLowerTierBacklogData, ladderTopRank, seatCapabilityIsVerified, fetchFableWindowActive, claimableForTier, claimableForRepo, getCommsActivitySignals, computeAdaptiveCadence, antiWinddownDirective, ASSIGNMENT_RECENCY_WINDOW_MS, TERMINAL_CLAIM_ERRORS, QF_CANDIDATE_LIMIT, SELF_CLAIM_CANDIDATE_LIMIT, DEFAULT_IDLE_WAKEUP_SECONDS };
 
-module.exports = { CHECKIN_HELPERS, stampDirectedAssignment, extractSdFromAssignment, extractDirectedSd, isInformationalNudge, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, sortQfCandidatesBySeverity, QF_SEVERITY_RANK, isCriticalQfJumpEligible, CRITICAL_QF_JUMP_GRACE_MS, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, pendingDirectedAssignmentBlocksAdoption, isSelfClaimDisabled, isQuarantined, isParked, selfClearQuarantine, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, findOwnSdClaim, healOwnClaimPointer, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
+module.exports = { ADOPTABLE_ORPHAN_STATUSES, CHECKIN_HELPERS, stampDirectedAssignment, extractSdFromAssignment, extractDirectedSd, isInformationalNudge, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, sortQfCandidatesBySeverity, QF_SEVERITY_RANK, isCriticalQfJumpEligible, CRITICAL_QF_JUMP_GRACE_MS, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, adoptOrphanInProgress, pendingDirectedAssignmentBlocksAdoption, isSelfClaimDisabled, isQuarantined, isParked, selfClearQuarantine, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, findOwnSdClaim, healOwnClaimPointer, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
 
 if (require.main === module) {
   main().catch(err => {

--- a/scripts/worker-checkin.test.js
+++ b/scripts/worker-checkin.test.js
@@ -97,10 +97,23 @@ function makeStub(cfg) {
           }
           return Promise.resolve({ data: rows, error: null });
         }
-        // adoptOrphanInProgress listing (SD-FDBK-INFRA-ORPHAN-ADOPTION-WORKER-001): a third
-        // STRING discriminant (.eq('status','in_progress')) — placed ABOVE the draft fallthrough.
-        // Honors the .lt('updated_at') age guard and the server-side .neq('sd_type') exclusion.
-        if (state.filters.status === 'in_progress') {
+        // adoptOrphanInProgress listing (SD-FDBK-INFRA-ORPHAN-ADOPTION-WORKER-001).
+        //
+        // SD-LEO-INFRA-RELEASED-MID-PHASE-001 / FR-2: this discriminant USED TO BE a string
+        // compare (state.filters.status === 'in_progress'), which was correct only while the
+        // adoption query used .eq(). It now uses .in(['in_progress','active']) — and because
+        // eq() and in() write the SAME key in this stub, a string compare stops matching and
+        // the orphan query FALLS THROUGH to the draft branch below. That failure mode is
+        // uniquely nasty: the four "expect idle" cases would have gone GREEN because the stub
+        // returned drafts-shaped nothing, not because any guard fired. A test that passes for
+        // the wrong reason is worse than one that fails.
+        //
+        // Discriminate on ARRAY CONTENTS, and note both allowlists contain 'active' — the
+        // draft tier queries ['draft','active'] — so membership of 'active' alone cannot
+        // distinguish them. 'in_progress' is the token unique to the adoption tier.
+        if (Array.isArray(state.filters.status)
+              ? state.filters.status.includes('in_progress')
+              : state.filters.status === 'in_progress') {
           if (cfg.orphansThrow) return Promise.reject(new Error('orphan query failed'));
           let rows = cfg.orphans || [];
           if (state.filters.lt_updated_at !== undefined) {

--- a/tests/unit/fleet/released-mid-phase-two-sided-control.test.js
+++ b/tests/unit/fleet/released-mid-phase-two-sided-control.test.js
@@ -55,7 +55,12 @@ const AXIS_FIXTURES = {
   chairmanRatificationPending: { row: orphan({ metadata: { chairman_ratified: false } }), blocks: true },
   needsCoordinatorReview: { row: orphan({ metadata: { needs_coordinator_review: true } }), blocks: true },
   leadBlockerActive: { row: orphan({ metadata: { lead_blocker: { reason: 'awaiting chairman' } } }), blocks: true },
-  testCloneBuildTree: { row: orphan({ sd_key: 'SD-DEMO-CLONE-001' }), blocks: true },
+  // CORRECTED AFTER EXEC REVIEW — this fixture asserted NOTHING. 'SD-DEMO-CLONE-001' matches
+  // TEST_FIXTURE_KEY_RE, so heldReason returned truthy via test_fixture_key, not this axis; because
+  // heldReason JOINS all matching axes, the case was green on a different axis's truthiness and the
+  // real production shape (a bridge-created clone with an ordinary sd_key and the metadata flag)
+  // was never exercised. Second instance of the same bug — the iteration caught one and missed one.
+  testCloneBuildTree: { row: orphan({ metadata: { test_clone_build_tree: true } }), blocks: true },
   // NOT a metadata flag — I guessed one and the iteration caught it. The real predicate is an
   // SD-key PREFIX plus a target_application pointing outside this repo, which is exactly the kind
   // of detail a hard-coded roster would have let me get wrong silently.

--- a/tests/unit/fleet/released-mid-phase-two-sided-control.test.js
+++ b/tests/unit/fleet/released-mid-phase-two-sided-control.test.js
@@ -1,0 +1,136 @@
+/**
+ * SD-LEO-INFRA-RELEASED-MID-PHASE-001 / FR-4 — THE CONTROL MUST REFUSE IN BOTH DIRECTIONS.
+ *
+ * The SD's own acceptance (c): "a deliberately held row stays held and does NOT get re-dispatched
+ * by FR-2 — the control must refuse in both directions." A control that only fires one way admits
+ * a field that lies: if every row is adopted, "adopted" carries no information; if every row is
+ * refused, neither does "refused".
+ *
+ * WHY THE ROSTER IS ITERATED RATHER THAN LISTED. A test that hard-codes the axis names is the
+ * defect this SD keeps meeting: it agrees with the implementation on the day it is written and
+ * drifts silently afterwards. That is not hypothetical here — the first probe written for this SD
+ * hard-coded a GUESSED hold-key list and over-counted the orphan class by 50% (reported 6, actual
+ * 4), and a later review found the PRD itself had named six axes when there are EIGHTEEN, two of
+ * which were not axes at all. So the roster is DERIVED from the axis functions' own names, and this
+ * suite iterates it: adding a nineteenth axis fails here until a case exists for it.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const {
+  INELIGIBILITY_AXIS_NAMES,
+  classifyAllDispatchIneligibility,
+} = require('../../../lib/fleet/claim-eligibility.cjs');
+const { heldReason, reachableBy, classifyRow } = await import('../../../scripts/audit-unreachable-midphase-sds.mjs');
+
+const CTX = { cwd: process.cwd() };
+
+/** A plain unclaimed mid-phase row — the shape FR-2 widened the adoption tier to reach. */
+const orphan = (over = {}) => ({
+  sd_key: 'SD-TWO-SIDED-PROBE-001',
+  status: 'active',
+  current_phase: 'PLAN_PRD',
+  sd_type: 'infrastructure',
+  metadata: {},
+  updated_at: '2026-08-01T00:00:00',
+  ...over,
+});
+
+/**
+ * Rows that trigger each axis. Keyed by the axis FUNCTION NAME so the iteration below can prove
+ * coverage. An axis with no entry is NOT silently skipped — it fails the roster test.
+ *
+ * `null` means: this axis is UNREACHABLE at the adoption call site, which passes only {cwd}.
+ * Asserting it blocks would be asserting against a call it never receives; the honest test is the
+ * inverse — that it no-ops here. Recorded per-axis with the reason rather than omitted.
+ */
+const AXIS_FIXTURES = {
+  orchestratorParent: { row: orphan({ sd_type: 'orchestrator' }), blocks: true },
+  testFixtureKey: { row: orphan({ sd_key: 'SD-TEST-FIXTURE-001' }), blocks: true },
+  humanActionRequired: { row: orphan({ metadata: { requires_human_action: true } }), blocks: true },
+  notBeforeHold: { row: orphan({ metadata: { not_before: '2099-01-01T00:00:00Z' } }), blocks: true },
+  oneWayDoor: { row: orphan({ metadata: { door_class_note: 'one_way' } }), blocks: true },
+  coAuthorPending: { row: orphan({ metadata: { co_author_pending: true } }), blocks: true },
+  chairmanRatificationPending: { row: orphan({ metadata: { chairman_ratified: false } }), blocks: true },
+  needsCoordinatorReview: { row: orphan({ metadata: { needs_coordinator_review: true } }), blocks: true },
+  leadBlockerActive: { row: orphan({ metadata: { lead_blocker: { reason: 'awaiting chairman' } } }), blocks: true },
+  testCloneBuildTree: { row: orphan({ sd_key: 'SD-DEMO-CLONE-001' }), blocks: true },
+  // NOT a metadata flag — I guessed one and the iteration caught it. The real predicate is an
+  // SD-key PREFIX plus a target_application pointing outside this repo, which is exactly the kind
+  // of detail a hard-coded roster would have let me get wrong silently.
+  unactionableVentureRemediation: {
+    row: orphan({ sd_key: 'SD-LEO-FIX-REMEDIATION-001', target_application: 'ehg' }),
+    blocks: true,
+  },
+  sdDeferred: { row: orphan({ status: 'deferred' }), blocks: true },
+  sdTerminal: { row: orphan({ status: 'completed' }), blocks: true },
+  // Unreachable at this call site — the adoption path passes ctx={cwd} only.
+  coordinatorReservation: { row: null, why: 'seat-scoped; drain-reservations deliberately runs AFTER adopt-orphan so orphan recovery is unaffected' },
+  tierAxes: { row: null, why: 'requires tier context the adoption call site does not supply' },
+  workClassAxes: { row: null, why: 'requires work-class context the adoption call site does not supply' },
+  fitnessAxes: { row: null, why: 'checkout-dependent; not derivable from the row alone' },
+  inflightGitAxes: { row: null, why: 'requires git state the adoption call site does not supply' },
+};
+
+describe('FR-4: every ineligibility axis is accounted for (roster is DERIVED, not listed)', () => {
+  it('the roster is non-trivial and comes from the axis functions themselves', () => {
+    expect(INELIGIBILITY_AXIS_NAMES.length).toBeGreaterThan(10);
+    expect(Object.isFrozen(INELIGIBILITY_AXIS_NAMES)).toBe(true);
+  });
+
+  it('EVERY axis in the live roster has an explicit disposition — adding one fails until covered', () => {
+    const uncovered = INELIGIBILITY_AXIS_NAMES.filter((n) => !(n in AXIS_FIXTURES));
+    expect(uncovered, `axes with no case: ${uncovered.join(', ')}`).toEqual([]);
+  });
+
+  it('no fixture names an axis that no longer exists (drift in the other direction)', () => {
+    const stale = Object.keys(AXIS_FIXTURES).filter((n) => !INELIGIBILITY_AXIS_NAMES.includes(n));
+    expect(stale, `fixtures for removed axes: ${stale.join(', ')}`).toEqual([]);
+  });
+
+  for (const name of Object.keys(AXIS_FIXTURES)) {
+    const fx = AXIS_FIXTURES[name];
+    if (fx.blocks) {
+      it(`REFUSES on ${name}`, () => {
+        expect(heldReason(fx.row), `${name} should hold the row`).toBeTruthy();
+        expect(classifyRow(fx.row).unreachable_and_unheld).toBe(false);
+      });
+    } else {
+      it(`no-ops at this call site: ${name} (${fx.why})`, () => {
+        // The honest assertion for an axis the adoption path cannot feed: a bare orphan is NOT
+        // held by it. Asserting it blocks would test a call the code never makes.
+        expect(classifyAllDispatchIneligibility(orphan(), CTX) || []).not.toContain(name);
+      });
+    }
+  }
+});
+
+describe('FR-4: the OTHER direction — a genuine orphan is still adopted', () => {
+  // In the SAME suite, deliberately. If the refusals above ever became blanket, this fails —
+  // which is the only thing that distinguishes a working control from a stuck one.
+  it('an unclaimed active mid-phase row with no hold IS reachable', () => {
+    const row = orphan();
+    expect(heldReason(row)).toBeNull();
+    expect(reachableBy(row)).toBe('resume_orphan');
+    expect(classifyRow(row).unreachable_and_unheld).toBe(false);
+  });
+
+  it('the pre-fix shape is what the widening changed — status=active was reachable by NOTHING', () => {
+    // Reconstructs the defect: with the adoption tier restricted to in_progress, an active
+    // mid-phase row was vetoed by the draft tier's phase check and ignored by the orphan tier.
+    const row = orphan();
+    const preFixReachable = (r) =>
+      (r.status === 'pending_approval' && r.current_phase === 'LEAD_FINAL') ? 'resume_final'
+        : (r.status === 'in_progress') ? 'resume_orphan'
+        : (!r.current_phase || r.current_phase === 'LEAD') ? 'draft_tier'
+        : null;
+    expect(preFixReachable(row)).toBeNull();     // the bug
+    expect(reachableBy(row)).toBe('resume_orphan'); // the fix
+  });
+
+  it('pending_approval/LEAD_FINAL still belongs to resume_final — no double-dispatch', () => {
+    const row = orphan({ status: 'pending_approval', current_phase: 'LEAD_FINAL' });
+    expect(reachableBy(row)).toBe('resume_final');
+  });
+});


### PR DESCRIPTION
When the stale-session sweep releases a dead seat's claim it clears the claim columns and **stamps nothing durable**. The provenance it does capture — `released_at`, `released_reason` — goes on the `claude_sessions` row, which is then retired and drops out of every live view. `strategic_directives_v2` has no release-provenance columns at all, and `lib/fleet/collision-check.cjs:4` says the asymmetry outright: `claim_history` *"records claims but never releases."* So resumable work loses the fact that it is resumable.

## Two premise corrections made during PLAN

**The rows are not "invisible to both surfaces."** That was falsifiable in one command — two of them render in `sd:next` badged **READY**, buried at `sequence_rank 9999`. What's true is narrower and more actionable: **visible to a human, unreachable by every automated claim path**.

**The population is 4, not 2 and not 6.** The SD named 2. My first probe said 6 — wrong, because I *guessed* the hold keys instead of finding them, missing that `status='deferred'` **is** the canonical park state and that an orchestrator is unclaimed by design.

## FR-1 — stamp before clear, and the order is the requirement

The stamp goes through the existing `mergeMetadataKeys` (built by QF-20260720-597 for exactly this). PostgREST cannot express jsonb `||`, so this could never have run through the supabase-js client the helper already holds — meaning the merge owns its own connection and **stamp and clear are separate transactions**.

Stamping first leaves a crash in between as a *stamped-but-still-claimed* row: harmless, self-corrects next sweep. Clearing first would leave an **unstamped released row** — the exact bug this SD exists to remove. The reverse order would have had the fix manufacture its own defect. Fail-soft throughout: a stamp error never blocks a release, because a blocked release strands a live claim on a dead seat.

## FR-2 — widened by one enum value, not replaced

`adoptOrphanInProgress` is the purpose-built resume-a-mid-phase-orphan tier, and it was missing its target population by a single byte-exact comparison: **all four orphans are `status='active'`; zero are `in_progress`**. The rows fell *between two tiers* — the draft sources fetch `(draft, active)` then veto anything past LEAD via `isSdInFlight`, while this tier skips that veto but filtered a status none of them had.

Widening inherits all four existing guards. A parallel lane would have re-implemented them or reopened QF-20260720-911 and SD-FDBK-INFRA-ORPHAN-ADOPT-RESUME-001. `pending_approval` is deliberately excluded — `recoverStrandedFinal` owns that class and two paths would race.

## FR-3 — the standing check ships, and it can fail

`scripts/audit-unreachable-midphase-sds.mjs` imports the hold classifier rather than re-listing keys, and imports `ADOPTABLE_ORPHAN_STATUSES` **from the adoption path itself** so the two cannot drift. It never computes an age in JS: `updated_at` is timezone-naive, so `Date.parse` reads it as local and understates every age by 4h — in the alert-*suppressing* direction.

**Measured both ends: 4 before the widening, 0 after.** A check that cannot show the bug cannot show its removal.

## FR-4 — two-sided, with a roster that cannot fall behind

`INELIGIBILITY_AXIS_NAMES` is **derived** from the axis functions' own `fn.name`. The suite iterates it, so a nineteenth axis fails until covered — and a fixture naming a removed axis fails too. 18 axes: 13 assert a genuine refusal, 5 are unreachable at this call site and assert the inverse (they no-op), each recorded with its reason. The positive case lives in the same suite, so blanket refusal can't pass.

The iteration earned its keep immediately: my fixture for `unactionableVentureRemediation` guessed a metadata flag; the real predicate is an SD-key prefix plus a foreign `target_application`. A hard-coded roster would have left that fixture asserting nothing.

## Test stub fixed *before* the widening

`worker-checkin.test.js` routed the orphan query on **string equality** of `state.filters.status`, and `eq()`/`in()` write the same key. Widening to `.in()` made the branch stop matching and the query fall through to the draft branch — four "expect idle" cases would have gone **green because the stub returned nothing**, not because a guard fired.

## TR-3 closed against the live catalog — and it corrects the file-based reading

**53 triggers** exist on the table (the census assumed a handful). Exactly three reference claim columns and **none is a release writer**: one reads for observe-mode logging, one *raises an exception* (rejects, never coerces), one only `pg_notify`s.

The suspect `sync_is_working_on_with_session` is **not attached to this table**, and its **live** body references `OLD.sd_key` — not the `OLD.sd_id` the migration file shows. The on-disk migration is stale relative to the deployed function, which is why reading files concluded "probably dead." Third instance this session of on-disk artifacts disagreeing with the live database.

## Verification

- Standing check: **4 → 0**
- 213 tests across 10 files, including both static guards on this surface
- Sequencing: `SD-LEO-INFRA-STALE-SESSION-SWEEP-001` has no open PR and nothing upstream touches these files — no conflict

## Known limit

The check proves the rows are now **reachable**, not that a worker has **adopted** one. Reachability is the requirement; adoption is the outcome, and it hasn't been observed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)