### PR TITLE
feat(GSB-A): one belt-depth implementation, two named readings

### DIFF
--- a/lib/fleet/belt-depth.cjs
+++ b/lib/fleet/belt-depth.cjs
@@ -20,6 +20,9 @@
  * belt_ranked_claimable=8 with belt_claimable_at_my_tier=0 continuously for ~2.5h.
  */
 const { classifyDispatchIneligibility, draftDepsSatisfied } = require('./claim-eligibility.cjs');
+// The QF claimability predicate is OWNED by the coordinator's supply module. Imported, never
+// restated — see countClaimableQuickFixes below for why a local copy would be a gate failure.
+const { applyClaimableQfFilter } = require('../coordinator/qf-supply-predicate.cjs');
 
 // The columns classifyDispatchIneligibility's axes actually read. Kept explicit (not select('*'))
 // so a schema change that drops one fails loudly here rather than silently un-gating a row.
@@ -81,4 +84,53 @@ async function countDispatchableBacklog(supabase) {
   return { dispatchable, raw: (rows || []).length, ineligible };
 }
 
-module.exports = { countDispatchableBacklog, ELIGIBILITY_COLUMNS };
+/**
+ * QF-side depth: quick_fixes that a worker could claim right now.
+ *
+ * WHY IT LIVES HERE AND NOT IN THE CALLER. This module's whole premise (see the header) is that two
+ * consumers each owning a copy of the query is how they drift. The QF side had exactly that shape:
+ * scripts/coordinator-capacity-forecast.mjs:252 head-counted `status='open'` while ignoring
+ * claiming_session_id — so it counted 148 where 145 are actually claimable — and its SD term two
+ * dozen lines later DOES skip claimed rows. One surface, two claimability rules.
+ *
+ * IT REUSES applyClaimableQfFilter RATHER THAN RESTATING THE PREDICATE. lib/coordinator/qf-supply-
+ * predicate.cjs already owns "unclaimed and in a claimable status" and is what the coordinator's own
+ * supply reads use. Restating it here would make this the twelfth independent depth derivation in a
+ * module written to abolish the second — the sibling SD's acceptance criterion names a further
+ * implementation as a gate failure rather than a style choice.
+ *
+ * DELIBERATELY SEPARATE FROM countDispatchableBacklog, NOT FOLDED INTO IT. Widening that function to
+ * include quick_fixes would break scripts/adam-coordinator-health.mjs:223, which asserts EXACT
+ * equality against an SD-only count and whose asymmetric tolerance was retired at :209-222 — so
+ * integrity_ok would read false on every run. Two NAMED readings sharing one implementation is the
+ * invariant this module actually asserts; one number everywhere is not.
+ *
+ * FAIL-LOUD, matching countDispatchableBacklog's contract: a gauge that silently reports 0 when it
+ * cannot read is indistinguishable from an empty belt, and an empty belt is an alarm condition.
+ * A caller that genuinely wants fail-open must say so at its own call site, in the open.
+ *
+ * @param {object} supabase
+ * @returns {Promise<number>} count of unclaimed, claimable-status quick_fixes
+ */
+async function countClaimableQuickFixes(supabase) {
+  const { count, error } = await applyClaimableQfFilter(
+    supabase.from('quick_fixes').select('id', { count: 'exact', head: true }));
+  if (error) throw error;
+  return typeof count === 'number' ? count : 0;
+}
+
+/**
+ * Both readings together, for a caller that legitimately wants claimable WORK rather than claimable
+ * SDs. `total` is the sum and is NOT interchangeable with sdDepth — a consumer that swaps one for
+ * the other moves whatever threshold it feeds.
+ *
+ * @param {object} supabase
+ * @returns {Promise<{sdDepth:number, qfDepth:number, total:number, raw:number, ineligible:object}>}
+ */
+async function countBeltDepth(supabase) {
+  const sd = await countDispatchableBacklog(supabase);
+  const qfDepth = await countClaimableQuickFixes(supabase);
+  return { sdDepth: sd.dispatchable, qfDepth, total: sd.dispatchable + qfDepth, raw: sd.raw, ineligible: sd.ineligible };
+}
+
+module.exports = { countDispatchableBacklog, countClaimableQuickFixes, countBeltDepth, ELIGIBILITY_COLUMNS };

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -39,6 +39,8 @@ import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 // predicate the worker resolver uses — else RHA-held / co_author_pending SDs inflate belt depth and the
 // forecaster emits false belt-low DEFICITs (the exact masked-starvation symptom this SD targets).
 import { classifyDispatchIneligibility } from '../lib/fleet/claim-eligibility.cjs';
+// SD-LEO-INFRA-GATE-SIDE-BELT-001: the QF term is no longer derived here. See the call site.
+import { countClaimableQuickFixes } from '../lib/fleet/belt-depth.cjs';
 // SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001 (FR-3): per-tier claimable depth (not a single aggregate).
 import { tierClaimableBreakdown } from '../lib/fleet/tier-claimable.cjs';
 import { isTieringActive } from '../lib/fleet/tier-ladder.cjs';
@@ -210,7 +212,7 @@ export async function computePhaseMinsFromActuals(supabase) {
 
 async function main() {
   const liveCutoff = new Date(Date.now() - HEARTBEAT_LIVE_MS).toISOString();
-  const [sessions, sds, { count: openQfCountRaw }] = await Promise.all([
+  const [sessions, sds, openQfCountRaw] = await Promise.all([
     // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 9: claude_sessions is a growing
     // table and this read feeds worker-count/capacity math directly (filtered + iterated
     // below) — paginate to completion. Preserve the prior fail-open policy (undefined `data`
@@ -247,13 +249,23 @@ async function main() {
       .order('sd_key', { ascending: true })) // unique tiebreaker (FR-6)
       .catch(() => []),
     // Open QFs are claimable belt too (a worker can claim a QF) — counting only SDs
-    // under-reports belt depth and over-reports deficit (workers self-claim QFs). This is a
-    // gauge (only the count is used) — exact head-count avoids the 1000-row cap misreading
-    // belt depth (SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 9).
-    sb.from('quick_fixes').select('id', { count: 'exact', head: true }).eq('status', 'open'),
+    // under-reports belt depth and over-reports deficit (workers self-claim QFs).
+    //
+    // SD-LEO-INFRA-GATE-SIDE-BELT-001: this was a local head-count on `status='open'` that IGNORED
+    // claiming_session_id, while the SD term ~20 lines below skips claimed rows — one surface, two
+    // claimability rules, over-reporting by 3 (148 counted, 145 actually claimable). It now shares
+    // the coordinator's QF supply predicate through lib/fleet/belt-depth.cjs, so this number and the
+    // coordinator's own supply reads cannot disagree again.
+    //
+    // FAIL-OPEN IS PRESERVED DELIBERATELY, AND SAID OUT LOUD. countClaimableQuickFixes is fail-LOUD
+    // by contract, because a gauge that reports 0 when it cannot read is indistinguishable from an
+    // empty belt. THIS surface has always fallen back to a 0 QF contribution rather than aborting the
+    // whole forecast, so the catch keeps that behaviour at the call site where a reader can see it,
+    // instead of weakening the shared gauge for every other consumer.
+    countClaimableQuickFixes(sb).catch(() => null),
   ]);
   const openQfCountRendered = renderCount(openQfCountRaw);
-  const openQfCount = typeof openQfCountRendered === 'number' ? openQfCountRendered : 0; // fail-open: unavailable → 0 belt contribution, same as prior [] fallback
+  const openQfCount = typeof openQfCountRendered === 'number' ? openQfCountRendered : 0; // fail-open: unreadable → 0 belt contribution, unchanged from the prior fallback
 
   // ── resolve dependency statuses → claimable belt ──
   // parseSdDependencies handles the live shape mix ([{sd_id}], [{sd_key}], raw strings) AND drops the

--- a/scripts/coordinator-self-review.mjs
+++ b/scripts/coordinator-self-review.mjs
@@ -16,6 +16,8 @@ const { insertCoordinationRow, isFullUuid } = createRequire(import.meta.url)('..
 import { guardMutation, resolveOwnSessionId } from '../lib/coordinator-mutation-guard.mjs';
 // SD-LEO-INFRA-ROLE-RUBRIC-SCORE-001 FR-2: graded coordinator self-score (shared role-agnostic core).
 import { COORDINATOR_CONFIG } from '../lib/coordinator/self-score-config.mjs';
+// SD-LEO-INFRA-GATE-SIDE-BELT-001: belt depth is read through the ONE eligibility-gated gauge.
+import { countDispatchableBacklog } from '../lib/fleet/belt-depth.cjs';
 import { stampLastFired } from '../lib/periodic-liveness/stamp-last-fired.js';
 const roleScoreCore = createRequire(import.meta.url)('../lib/governance/role-self-score.cjs');
 
@@ -196,7 +198,18 @@ export async function selfReviewMain() {
   // with the common tri-party score schema, idempotent on review_key. FAIL-OPEN.
   if (process.env.COORD_SELF_SCORE_V1 === 'on') {
     try {
-      const { count: beltDepth } = await db.from('strategic_directives_v2').select('id', { count: 'exact', head: true }).eq('status', 'draft').is('claiming_session_id', null);
+      // SD-LEO-INFRA-GATE-SIDE-BELT-001: this was the raw
+      //   .eq('status','draft').is('claiming_session_id', null)
+      // head-count — VERBATIM the query lib/fleet/belt-depth.cjs:4-6 records itself as replacing,
+      // still live here and feeding a governance SELF-SCORE via lib/coordinator/self-score-config.mjs.
+      // It read 41 where the eligibility-gated gauge reads 22: the 19-row gap is human_action_required
+      // holds, orchestrator parents, a needs-review row and a test fixture — none of them dispatchable.
+      // Scoring proactive_sourcing against the raw number rewards a belt that only LOOKS full, which is
+      // the precise defect QF-20260725-089 created the shared gauge to abolish; it converted two of the
+      // four consumers and this one was missed.
+      //
+      // `dispatchable`, NOT `raw`: raw is the pre-eligibility count and would reproduce the old value.
+      const { dispatchable: beltDepth } = await countDispatchableBacklog(db);
       // Reuse the SAME `workers` set the solicitation loop above already computed (partitionParticipants
       // + isFullUuid filter) rather than re-deriving from `sess` -- keeps this signal consistent with
       // that loop's own Adam-exclusion behavior (adversarial review catch, 2026-07-04): when

--- a/tests/unit/fleet/belt-depth-qf.test.js
+++ b/tests/unit/fleet/belt-depth-qf.test.js
@@ -1,0 +1,107 @@
+// GSB-A — the QF-side reading and the invariant that keeps the SD reading unchanged.
+// SD-LEO-INFRA-GATE-SIDE-BELT-001, TS-1/TS-2/TS-3.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const { countDispatchableBacklog, countClaimableQuickFixes, countBeltDepth } = require('../../../lib/fleet/belt-depth.cjs');
+const { CLAIMABLE_QF_STATUSES } = require('../../../lib/coordinator/qf-supply-predicate.cjs');
+
+/**
+ * TABLE-AWARE fake. tests/helpers/supabase-chain-mock.js is deliberately NOT used: it is eager and
+ * table-blind — one shared result for every table and filter — so the SD reading and the QF reading
+ * would return identical rows and TS-2 could not fail. A fake that cannot distinguish the two
+ * readings cannot test a change whose entire point is that they are different.
+ *
+ * It also RECORDS every table requested, which is what TS-1 asserts on.
+ */
+function fakeClient({ sds = [], qfs = [] } = {}) {
+  const tablesSeen = [];
+  const qfFilters = [];
+  const make = (table) => {
+    const rows = table === 'quick_fixes' ? qfs : sds;
+    let filtered = rows;
+    const builder = {
+      select(_cols, opts = {}) {
+        builder._head = !!opts.head;
+        return builder;
+      },
+      eq(col, val) { filtered = filtered.filter((r) => r[col] === val); return builder; },
+      is(col, val) { qfFilters.push(`is:${col}`); filtered = filtered.filter((r) => (val === null ? r[col] == null : r[col] === val)); return builder; },
+      in(col, vals) { qfFilters.push(`in:${col}`); filtered = filtered.filter((r) => vals.includes(r[col])); return builder; },
+      not() { return builder; },
+      order() { return builder; },
+      range(from, to) { filtered = filtered.slice(from, to + 1); return builder; },
+      then(resolve, reject) {
+        return Promise.resolve({ data: builder._head ? null : filtered, count: filtered.length, error: null })
+          .then(resolve, reject);
+      },
+    };
+    return builder;
+  };
+  return {
+    from(table) { tablesSeen.push(table); return make(table); },
+    _tablesSeen: tablesSeen,
+    _qfFilters: qfFilters,
+  };
+}
+
+const openUnclaimed = (n) => Array.from({ length: n }, (_, i) => ({ id: `qf-open-${i}`, status: CLAIMABLE_QF_STATUSES[0], claiming_session_id: null }));
+const openClaimed = (n) => Array.from({ length: n }, (_, i) => ({ id: `qf-claimed-${i}`, status: CLAIMABLE_QF_STATUSES[0], claiming_session_id: `sess-${i}` }));
+
+describe('TS-1 — countDispatchableBacklog never reads quick_fixes', () => {
+  // BEHAVIOURAL, NOT A PINNED COUNT. The first draft of this asserted dispatchable===23; it had
+  // already drifted to 22 before EXEC began, because a draft left the belt — normal movement, not a
+  // regression. A test pinned to a live number fails for reasons that are not the thing it names.
+  // What must never change is WHICH TABLE the gauge reads: widening it to quick_fixes would break
+  // the exact-equality integrity check at scripts/adam-coordinator-health.mjs:223.
+  it('requests strategic_directives_v2 and never quick_fixes', async () => {
+    const client = fakeClient({ sds: [], qfs: openUnclaimed(5) });
+    await countDispatchableBacklog(client);
+    expect(client._tablesSeen).toContain('strategic_directives_v2');
+    expect(client._tablesSeen).not.toContain('quick_fixes');
+  });
+});
+
+describe('TS-3 — the QF reading excludes rows carrying a claiming_session_id', () => {
+  it('counts unclaimed only, so a claimed row is not belt depth', async () => {
+    const client = fakeClient({ qfs: [...openUnclaimed(4), ...openClaimed(3)] });
+    expect(await countClaimableQuickFixes(client)).toBe(4);
+  });
+
+  it('applies BOTH the unclaimed filter and the status filter — via the shared predicate', async () => {
+    // The predicate is owned by lib/coordinator/qf-supply-predicate.cjs. If a future edit restates
+    // it locally and drops one half, this fails.
+    const client = fakeClient({ qfs: openUnclaimed(2) });
+    await countClaimableQuickFixes(client);
+    expect(client._qfFilters).toContain('is:claiming_session_id');
+    expect(client._qfFilters).toContain('in:status');
+  });
+
+  it('does NOT count a row whose status is outside CLAIMABLE_QF_STATUSES', async () => {
+    const client = fakeClient({ qfs: [{ id: 'x', status: '__not_a_claimable_status__', claiming_session_id: null }] });
+    expect(await countClaimableQuickFixes(client)).toBe(0);
+  });
+});
+
+describe('TS-2 — the two readings are DIFFERENT numbers', () => {
+  // A suite where both arms expect the same value is satisfied by an implementation that returns one
+  // number twice. This scenario exists to make that implementation fail.
+  it('sdDepth and qfDepth disagree on one fixture, and total is their sum', async () => {
+    const sds = [
+      { id: 's1', sd_key: 'SD-A', status: 'draft', sd_type: 'infrastructure', metadata: {}, target_application: 'EHG_Engineer', dependencies: null },
+      { id: 's2', sd_key: 'SD-B', status: 'draft', sd_type: 'infrastructure', metadata: {}, target_application: 'EHG_Engineer', dependencies: null },
+    ];
+    const client = fakeClient({ sds, qfs: openUnclaimed(7) });
+    const depth = await countBeltDepth(client);
+    expect(depth.qfDepth).toBe(7);
+    expect(depth.sdDepth).not.toBe(depth.qfDepth);
+    expect(depth.total).toBe(depth.sdDepth + depth.qfDepth);
+  });
+});
+
+describe('the QF gauge is FAIL-LOUD, so an unreadable belt cannot masquerade as an empty one', () => {
+  it('propagates the error rather than returning 0', async () => {
+    const erroring = { from: () => ({ select: () => ({ is: () => ({ in: () => Promise.resolve({ count: null, error: { code: 'PGRST205' } }) }) }) }) };
+    await expect(countClaimableQuickFixes(erroring)).rejects.toBeTruthy();
+  });
+});


### PR DESCRIPTION
## GSB-A — one belt-depth implementation, two named readings

First and **blocking** part of SD-LEO-INFRA-GATE-SIDE-BELT-001. GSB-B (gating the QF minters) cannot ship without this: `measureDemand`'s default gauge is `countDispatchableBacklog`, which reads `strategic_directives_v2` only — so gating quick-fix minting on it today would gate production on a number that structurally cannot see a quick fix.

### What changed

| Surface | Before | After |
|---|---|---|
| `lib/fleet/belt-depth.cjs` | SD reading only | `+ countClaimableQuickFixes`, `+ countBeltDepth` composite |
| `coordinator-capacity-forecast.mjs:252` | head-count on `status='open'`, **ignoring** `claiming_session_id` | shares the predicate — **148 → 145** |
| `coordinator-self-review.mjs:199` | the raw `.eq('status','draft').is('claiming_session_id',null)` query | the eligibility-gated gauge — **41 → 21** |

The QF predicate is **imported** from `lib/coordinator/qf-supply-predicate.cjs`, never restated. Eleven independent depth derivations already exist; the sibling SD's acceptance criterion names a further implementation as a gate failure rather than a style choice.

`coordinator-self-review.mjs:199` ran **verbatim** the query `belt-depth.cjs:4-6` records itself as replacing — still live, and feeding a governance **self-score**. It read 41 where the gated gauge reads 21; the 19-row gap is human-action holds, orchestrator parents, a needs-review row and a test fixture, none of them dispatchable. QF-20260725-089 converted two of four consumers; this is the one nobody had named.

### What deliberately did *not* change

`countDispatchableBacklog`'s return value. Widening it would break `adam-coordinator-health.mjs:223`, which asserts **exact equality** against an SD-only count and whose asymmetric tolerance was retired at `:209-222` — `integrity_ok` would read false every run, and with 145 open QFs against floor 3 both SD minters would go permanently dark.

Each surface keeps its own semantics: the shared gauge is **fail-loud** (a gauge reporting 0 when it cannot read is indistinguishable from an empty belt, which is an alarm condition), while capacity-forecast's long-standing fail-open-to-0 now sits at *its* call site where a reader can see it.

### TS-1 is a table spy, not a pinned count

The first draft asserted `dispatchable === 23`. It read 22 when EXEC started and **21** at commit time — with the ineligible breakdown identical (15/2/1/1) throughout. Drafts simply left the belt. A test pinned to a live number fails for reasons that are not the regression it names, so what's asserted is *which table the gauge reads*.

### Mutation-proven — four mutants, each verified to have **applied**

| mutation | result |
|---|---|
| `countDispatchableBacklog` also reads `quick_fixes` | **1 failed** |
| drop the unclaimed half of the shared predicate | **2 failed** |
| composite returns the SD number twice | **1 failed** |
| QF gauge swallows the error, returns 0 | **1 failed** |
| restored | 6/6 |

The fourth **first read as a survivor and was not one**: the file is CRLF and the multi-line `\n` pattern silently matched nothing, so the mutation never applied. An unapplied mutation is indistinguishable from a surviving mutant — the retry asserts the source actually changed and aborts if it didn't.

**Live after:** dispatchable 21 / raw 40, QF 145 vs raw open 148, composite total 166.

### Not covered, stated rather than implied
- `capacity-forecast:252`'s fail-open path becoming a crash under a different error shape
- One global `BELT_DEMAND_FLOOR` will serve four producers across gauges differing ~6× (GSB-B decides the floor)
- The self-review block sits behind default-OFF `COORD_SELF_SCORE_V1`, so it is dead code today — the fix is correct but unexercised in production until that flag flips

🤖 Generated with [Claude Code](https://claude.com/claude-code)
