### PR TITLE
feat(GSB-B): gate the two QF-side minters on QF depth, at the callers

### DIFF
--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 771430de96821d9f -->
+<!-- file_content_hash: 97b5f14ee44bcee0 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-08-01 8:11:44 AM
+**Generated**: 2026-08-03 8:17:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -224,7 +224,7 @@ The north-star gauges (§5e) are **SUBORDINATE diagnostics** — they inform the
 2. **Wave-0 distillation if rung-waves are empty** — groom raw backlog (`sd_backlog_map`) into waved, dispositioned candidates. Distillation precedes routing.
 3. **Check the sourcing-engine activation state BEFORE hand-feeding — and read the RIGHT switch.**
    **(a) The OPERATIVE gate is a DB ROW, not an env flag.** `sourcing_engine_activation_state.arm='auto-refill'` gates the highest-blast-radius producer (hourly `refill-cron.mjs --apply`), in three states — on / off / **`NO ROW: state unknown, not "off"`**. Only `SOURCING_GAUGE_GAP_MINER_V1` and `SOURCING_DEFERRED_WATCHER_V1` have executable readers, and both are already hardcoded ON in the only context that runs them. **RETIRED — proposing a flip of these is a NO-OP, not an activation:** `SOURCING_ENGINE_V1`, `SOURCING_ROADMAP_ENGINE_V1`, `SOURCING_PROACTIVE_POPULATOR_V1`, `LEO_ROADMAP_AUTOSOURCE` have **zero executable readers**; setting them changed nothing while *looking* like activation.
-   **(b) "On" no longer means "floods".** The two producers that mint belt depth consult a **belt-DEMAND gate** (`lib/governance/demand-gate.js`): they produce only when dispatchable depth is at or below a floor, and **an unreadable gauge is `unmeasurable` → WITHHOLD, never a licence to produce.** Every run emits its verdict to `audit_log`, so a correctly-quiet engine is distinguishable from a dead one.
+   **(b) "On" no longer means "floods".** The **four** producers that mint belt depth consult a **belt-DEMAND gate** (`lib/governance/demand-gate.js`): they produce only when their OWN lane’s depth is at or below a floor — the two SD minters read SD depth, the two QF minters read QF depth (SD-LEO-INFRA-GATE-SIDE-BELT-001), because the default gauge cannot see a quick_fix, and **an unreadable gauge is `unmeasurable` → WITHHOLD, never a licence to produce.** Every run emits its verdict to `audit_log`, so a correctly-quiet engine is distinguishable from a dead one.
    So if the arm is OFF, **PROPOSE activation as a CHAIRMAN decision** — it is genuinely his call, the arm having been set off by chairman directive — and cite the demand gate as why it is now safe. Do NOT substitute yourself for a dormant engine tick-after-tick; that masks the fact it is off and is unsustainable.
 4. **Hand-mining the VDR gauge is LAST-RESORT — and a SMELL.** Reaching for it means a layer above failed. Fix the upstream cause.
 
@@ -398,6 +398,6 @@ _Hierarchy note (chairman-ratified D-0719-ORGCHART "A", 2026-07-19): this partne
 
 ---
 
-*Generated from database: 2026-08-01*
+*Generated from database: 2026-08-03*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-01T12:11:44.491Z -->
-<!-- git_commit: f70be27d -->
-<!-- db_snapshot_hash: f40cba344ed016a6 -->
-<!-- file_content_hash: 3f184ad15999f5a3 -->
+<!-- generated_at: 2026-08-03T12:17:35.304Z -->
+<!-- git_commit: 972d12c9 -->
+<!-- db_snapshot_hash: 8c2c5d2e658539c5 -->
+<!-- file_content_hash: 09eebc7e252cbc7c -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_ADAM_MANUAL.md
+++ b/CLAUDE_ADAM_MANUAL.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: fb786c2c04998c77 -->
+<!-- file_content_hash: c0ef00343b7d36a4 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM_MANUAL.md — Adam Manual (how-to companion)
 
-**Generated**: 2026-08-01 8:11:44 AM
+**Generated**: 2026-08-03 8:17:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: How-to procedures lifted out of the role contract — SD creation field shapes, migration ceremony steps, gauge inputs
 **Load when**: At the MOMENT OF DOING the procedure — not at session start
@@ -113,6 +113,6 @@ It guards two opposed failure modes, both probed by the self-adherence review (`
 
 ---
 
-*Generated from database: 2026-08-01*
+*Generated from database: 2026-08-03*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_manual). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_PROVENANCE.md
+++ b/CLAUDE_ADAM_PROVENANCE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: f5b39f2b0de187a6 -->
+<!-- file_content_hash: 3e7a7e1190a18618 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM_PROVENANCE.md — Adam Provenance (dated rationale)
 
-**Generated**: 2026-08-01 8:11:44 AM
+**Generated**: 2026-08-03 8:17:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Why each clause exists — dated chairman verbals, live witnesses, superseded cadences
 **Load when**: When you need to know WHY a rule exists, or before proposing to change one
@@ -65,6 +65,6 @@ Do not read a missing entry as "this rule has no provenance". Coverage is roughl
 
 ---
 
-*Generated from database: 2026-08-01*
+*Generated from database: 2026-08-03*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_provenance). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_COORDINATOR.md
+++ b/CLAUDE_COORDINATOR.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 2a18ad03dadea44b -->
+<!-- file_content_hash: 94f2d627c5099db2 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_COORDINATOR.md - Coordinator Role Contract
 
-**Generated**: 2026-08-01 8:11:44 AM
+**Generated**: 2026-08-03 8:17:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical coordinator role + SRE charter — fleet supervisor session
 **Load when**: Running /coordinator, or orienting a fleet-coordinator session
@@ -94,6 +94,6 @@ _Hierarchy note (chairman-ratified D-0719-ORGCHART "A", 2026-07-19): this partne
 
 ---
 
-*Generated from database: 2026-08-01*
+*Generated from database: 2026-08-03*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=coordinator_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-01T12:11:44.491Z -->
-<!-- git_commit: f70be27d -->
-<!-- db_snapshot_hash: f40cba344ed016a6 -->
-<!-- file_content_hash: 7b72f1a4361636ea -->
+<!-- generated_at: 2026-08-03T12:17:35.304Z -->
+<!-- git_commit: 972d12c9 -->
+<!-- db_snapshot_hash: 8c2c5d2e658539c5 -->
+<!-- file_content_hash: fc6aa2cbec21075a -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 628fc50a72a4ac34 -->
+<!-- file_content_hash: 1b3a2dd5a80f4519 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-08-01 9:22:00 AM
+**Generated**: 2026-08-03 8:17:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -1591,7 +1591,7 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 |------------|----------|----------|-------|-------|--------------|
 | PAT-HF-PLANTOLEAD-27a62713 | handoff_failure | [HIGH] high | 7 | [STABLE] | N/A |
 | PAT-RETRO-PLANTOLEAD-27a62713 | session_retrospective | [HIGH] high | 7 | [STABLE] | N/A |
-| PAT-HF-LEADTOPLAN-90e39736 | handoff_failure | [HIGH] high | 6 | [STABLE] | N/A |
+| PAT-HF-PLANTOLEAD-e8842331 | handoff_failure | [HIGH] high | 6 | [STABLE] | N/A |
 | PAT-TEST-PINS-FACT-NOT-BEHAVIOUR-001 | testing | [HIGH] high | 6 | [STABLE] | Assert the RULE, not today's answer. The |
 | PAT-RETRO-PLANTOLEAD-e8842331 | session_retrospective | [HIGH] high | 6 | [STABLE] | N/A |
 
@@ -1612,8 +1612,6 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 
 | Signal Type | Workers | Severity | Title |
 |-------------|---------|----------|-------|
-| feedback | 6 | medium | online — entering autonomous loop |
-| feedback | 3 | medium | wakeup-armed +600s — idle, 0 claimable at my tier (unchanged |
 | feedback | 3 | medium | comms-check ack — read you |
 
 *Auto-updated from `feedback` table where `category='harness_backlog'` AND `metadata.contributing_workers` length ≥ 3.*
@@ -1745,7 +1743,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-08-01*
+*Generated from database: 2026-08-03*
 *Protocol Version: 4.4.1*
 *Includes: Proposals (0) + Hot Patterns (5) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-01T12:11:44.491Z -->
-<!-- git_commit: f70be27d -->
-<!-- db_snapshot_hash: f40cba344ed016a6 -->
-<!-- file_content_hash: 3b00e340966330ba -->
+<!-- generated_at: 2026-08-03T12:17:35.304Z -->
+<!-- git_commit: 972d12c9 -->
+<!-- db_snapshot_hash: 8c2c5d2e658539c5 -->
+<!-- file_content_hash: 39b4343c8cc47ce4 -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -294,5 +294,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-08-01 8:11:44 AM*
+*DIGEST generated: 2026-08-03 8:17:35 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-01T12:11:44.491Z -->
-<!-- git_commit: f70be27d -->
-<!-- db_snapshot_hash: f40cba344ed016a6 -->
-<!-- file_content_hash: 145c2727660e8751 -->
+<!-- generated_at: 2026-08-03T12:17:35.304Z -->
+<!-- git_commit: 972d12c9 -->
+<!-- db_snapshot_hash: 8c2c5d2e658539c5 -->
+<!-- file_content_hash: cdb939bdcdab6214 -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -159,5 +159,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-08-01 8:11:44 AM*
+*DIGEST generated: 2026-08-03 8:17:35 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: da922f151cef0128 -->
+<!-- file_content_hash: 1f348de3aa7d8060 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-08-01 8:11:44 AM
+**Generated**: 2026-08-03 8:17:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
@@ -2148,6 +2148,6 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 
 ---
 
-*Generated from database: 2026-08-01*
+*Generated from database: 2026-08-03*
 *Protocol Version: 4.4.1*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-01T12:11:44.491Z -->
-<!-- git_commit: f70be27d -->
-<!-- db_snapshot_hash: f40cba344ed016a6 -->
-<!-- file_content_hash: 660d291913c69986 -->
+<!-- generated_at: 2026-08-03T12:17:35.304Z -->
+<!-- git_commit: 972d12c9 -->
+<!-- db_snapshot_hash: 8c2c5d2e658539c5 -->
+<!-- file_content_hash: ee2e4989585377ed -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-08-01 8:11:44 AM*
+*DIGEST generated: 2026-08-03 8:17:35 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: b7ba040505d56297 -->
+<!-- file_content_hash: cf775e0a447447a8 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-08-01 10:05:46 AM
+**Generated**: 2026-08-03 8:17:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)
@@ -1390,6 +1390,6 @@ At LEAD-phase scope-lock, before running `add-prd-to-database.js`, invoke `testi
 
 ---
 
-*Generated from database: 2026-08-01*
+*Generated from database: 2026-08-03*
 *Protocol Version: 4.4.1*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-01T12:11:44.491Z -->
-<!-- git_commit: f70be27d -->
-<!-- db_snapshot_hash: f40cba344ed016a6 -->
-<!-- file_content_hash: 7eaae885385e9816 -->
+<!-- generated_at: 2026-08-03T12:17:35.304Z -->
+<!-- git_commit: 972d12c9 -->
+<!-- db_snapshot_hash: 8c2c5d2e658539c5 -->
+<!-- file_content_hash: 661bdfde5e6c67b7 -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-08-01 8:11:44 AM*
+*DIGEST generated: 2026-08-03 8:17:35 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD_MANUAL.md
+++ b/CLAUDE_LEAD_MANUAL.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 3dea4a27d58148f1 -->
+<!-- file_content_hash: 959da55357a233ac -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD_MANUAL.md — LEAD Manual (reference companion)
 
-**Generated**: 2026-08-01 10:05:46 AM
+**Generated**: 2026-08-03 8:17:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Long-form LEAD reference — the Q9 strategic-validation rubric, parent/child SD governance, multi-track parallel execution, directive submission review
 **Load when**: At the MOMENT OF DOING one of these procedures — not at every LEAD phase entry
@@ -209,6 +209,6 @@ npm run sd:status    # Overall progress by track
 
 ---
 
-*Generated from database: 2026-08-01*
+*Generated from database: 2026-08-03*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=parent_child_sd_governance, multi_track_parallel_execution, lead_strategic_validation_q9). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: db83158e6a9ff10c -->
+<!-- file_content_hash: 051fc5edb1dc5786 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-08-01 8:28:23 AM
+**Generated**: 2026-08-03 8:17:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)
@@ -1390,6 +1390,6 @@ For every keyword-list FR expansion, include in acceptance_criteria: "Substring-
 
 ---
 
-*Generated from database: 2026-08-01*
+*Generated from database: 2026-08-03*
 *Protocol Version: 4.4.1*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-01T12:11:44.491Z -->
-<!-- git_commit: f70be27d -->
-<!-- db_snapshot_hash: f40cba344ed016a6 -->
-<!-- file_content_hash: 6a2207cc18ddebdc -->
+<!-- generated_at: 2026-08-03T12:17:35.304Z -->
+<!-- git_commit: 972d12c9 -->
+<!-- db_snapshot_hash: 8c2c5d2e658539c5 -->
+<!-- file_content_hash: 9e2f8a591ca8de70 -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-08-01 8:11:44 AM*
+*DIGEST generated: 2026-08-03 8:17:35 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN_MANUAL.md
+++ b/CLAUDE_PLAN_MANUAL.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 5e92e8814131c76d -->
+<!-- file_content_hash: e81d796d6cc256b2 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN_MANUAL.md — PLAN Manual (reference companion)
 
-**Generated**: 2026-08-01 8:28:23 AM
+**Generated**: 2026-08-03 8:17:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Long-form PLAN reference — gate scoring tables, PRD and presentation templates, parent/child decomposition, refactor-brief guide, Explore-before-validation, runtime-audit protocol
 **Load when**: At the MOMENT OF DOING one of these procedures — not at every PLAN phase entry
@@ -1074,6 +1074,6 @@ When creating a PRD during PLAN phase, connect functional requirements to releva
 
 ---
 
-*Generated from database: 2026-08-01*
+*Generated from database: 2026-08-03*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=workflow, handoff_quality_gates, parent_child_plan, plan_refactor_brief_guide, parent_child_validation, plan_verify_explore, prd_template_scaffold, governance_kr_linkage_plan, plan_presentation_template, cascade_invalidation_plan). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_SOLOMON.md
+++ b/CLAUDE_SOLOMON.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: c788f4095e3654f1 -->
+<!-- file_content_hash: 612c9738749ee143 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_SOLOMON.md - Solomon Role Contract
 
-**Generated**: 2026-08-01 8:11:44 AM
+**Generated**: 2026-08-03 8:17:35 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Solomon oracle role contract — deep-reasoning session
 **Load when**: Running /solomon, or orienting a deep-reasoning oracle session
@@ -365,6 +365,6 @@ Solomon operates under the canonical crew-comms routing protocol: `docs/protocol
 
 ---
 
-*Generated from database: 2026-08-01*
+*Generated from database: 2026-08-03*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=solomon_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_SOLOMON_DIGEST.md
+++ b/CLAUDE_SOLOMON_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-01T12:11:44.491Z -->
-<!-- git_commit: f70be27d -->
-<!-- db_snapshot_hash: f40cba344ed016a6 -->
-<!-- file_content_hash: 64bcaa2800214e54 -->
+<!-- generated_at: 2026-08-03T12:17:35.304Z -->
+<!-- git_commit: 972d12c9 -->
+<!-- db_snapshot_hash: 8c2c5d2e658539c5 -->
+<!-- file_content_hash: b0c9025de34d7fa3 -->
 
 # CLAUDE_SOLOMON_DIGEST.md - Solomon Role (Oracle)
 

--- a/docs/sourcing-engine-activation-runbook.md
+++ b/docs/sourcing-engine-activation-runbook.md
@@ -58,11 +58,36 @@ The `/adam` startup probe prints these marked **OPERATIVE**, in three states —
 `NO ROW: state unknown, not "off"` (a missing row is unknown, and rendering it as "off" would be a
 confident lie about a state nobody read).
 
-**Belt-demand gating (why "on" no longer means "floods").** The two producers that actually mint belt
-depth — `refill-auto-promote` and `fr-c-generator` — now consult `lib/governance/demand-gate.js` before
-producing: they mint only when dispatchable belt depth is at or below a floor (`BELT_DEMAND_FLOOR`,
-default 3; a garbage value yields NaN → `unmeasurable` → withhold, never a silent revert to the
-default). An unreadable gauge is `unmeasurable` and **withholds** — it is never a licence to produce.
+**Belt-demand gating (why "on" no longer means "floods").** The **four** producers that mint belt depth
+now consult `lib/governance/demand-gate.js` before producing. They mint only when depth is at or below a
+floor (`BELT_DEMAND_FLOOR`, default 3; a garbage value yields NaN → `unmeasurable` → withhold, never a
+silent revert to the default). An unreadable gauge is `unmeasurable` and **withholds** — it is never a
+licence to produce.
+
+**They do not all read the same gauge, and that is the point** (SD-LEO-INFRA-GATE-SIDE-BELT-001):
+
+| producer | mints into | gauge |
+|---|---|---|
+| `refill-auto-promote` | `strategic_directives_v2` | `countDispatchableBacklog` (SD depth) |
+| `fr-c-generator` | `strategic_directives_v2` | `countDispatchableBacklog` (SD depth) |
+| `feedback-fingerprint-promoter` | `quick_fixes` | `countClaimableQuickFixes` (QF depth) |
+| `promote-retro-action-items` | `quick_fixes` | `countClaimableQuickFixes` (QF depth) |
+
+The QF pair inject their gauge through `measureDemand`'s `gauge` parameter, because the DEFAULT gauge is
+`countDispatchableBacklog` — which reads `strategic_directives_v2` and cannot see a single quick fix.
+Gating QF minting on it would be an open loop failing in both directions: below the floor, minted QFs
+never raise the reading so the gate never closes; above it, minting is blocked no matter how starved the
+QF lane is.
+
+**One floor, two lanes.** `BELT_DEMAND_FLOOR` is a single global env var with no per-producer override,
+and the two lanes' depths differ by roughly 6× (SD ~21, QF ~145 at the time of writing). A floor tuned
+for one lane is not tuned for the other; a per-producer override is a known follow-up, not a shipped
+capability.
+
+**The gate guards MINTING, not reporting.** The QF producers gate only under `--apply`. A dry-run still
+prints its `[PROMOTABLE]` lines and records no decision — so on a dry-run-only day the startup badge
+reads `NEVER RAN`, which is correct: a recorded decision for a run that could never have minted would be
+a measurement of nothing.
 Every run emits `{engine, gauge_value, floor, decision, reason, measured_at}` to `audit_log` and the
 startup badge prints the last verdict per producer, so a correctly-quiet engine is distinguishable
 from a dead one.

--- a/lib/governance/demand-gate.js
+++ b/lib/governance/demand-gate.js
@@ -210,6 +210,12 @@ export function formatDemandDecision(d, engineName) {
 export const BELT_DEPTH_GATED_PRODUCERS = Object.freeze([
   'refill-auto-promote',
   'fr-c-generator',
+  // SD-LEO-INFRA-GATE-SIDE-BELT-001: the two QF-side minters. They gate on the QF reading
+  // (lib/fleet/belt-depth.cjs countClaimableQuickFixes) rather than the SD reading, injected at
+  // their call sites through measureDemand's gauge parameter — the default gauge counts
+  // strategic_directives_v2 and cannot see a quick_fix, so gating them on it would be an open loop.
+  'feedback-fingerprint-promoter',
+  'promote-retro-action-items',
 ]);
 
 /** Stagers, named so their exclusion is a recorded decision rather than an oversight. */

--- a/lib/governance/qf-mint-gate.mjs
+++ b/lib/governance/qf-mint-gate.mjs
@@ -1,0 +1,99 @@
+/**
+ * QF-SIDE BELT DEMAND GATE — SD-LEO-INFRA-GATE-SIDE-BELT-001 (GSB-B).
+ *
+ * The two cron producers that mint quick_fixes unattended were ungated: they could mint into a full
+ * belt indefinitely. This is the seam they call.
+ *
+ * WHY THE GATE IS HERE AND NOT IN scripts/create-quick-fix.js. Neither minter writes quick_fixes
+ * directly — each shells out via execFileSync to that CLI, which is ALSO how a human files a quick
+ * fix by hand. A gate at a shared boundary hits every caller, so putting it there would block a
+ * person at a keyboard. A belt-demand gate exists to stop UNATTENDED minting into a full belt, not
+ * to second-guess human judgement, so it belongs at the two cron callers.
+ *
+ * WHY IT INJECTS A QF GAUGE. measureDemand's DEFAULT gauge is countDispatchableBacklog
+ * (lib/governance/demand-gate-emit.js:86), which reads strategic_directives_v2 and cannot see a
+ * single quick_fix. Gating QF production on it is an open loop that fails in BOTH directions: below
+ * the floor, minted QFs never raise the reading so the gate never closes; above it, minting is
+ * blocked no matter how starved the QF lane is. Measured at authoring: SD depth 21 against floor 3,
+ * so the default gauge would have withheld every run and taken the harness-backlog drain to zero.
+ *
+ * WHY IT IS AN EXPORTED MODULE RATHER THAN INLINE CODE IN THE TWO SCRIPTS. Both minters are
+ * top-level-await scripts with no exports, so every existing guard test for them is a REGEX OVER
+ * SOURCE TEXT — which cannot see control flow, and control flow is all this gate is.
+ * scripts/sourcing-engine/refill-cron.mjs:117-127 records five one-line mutants surviving the whole
+ * suite at its previous inline callsite, for exactly that reason. Living in lib/ also means the seam
+ * imports with no credentials, so its failure paths are reachable in a unit test.
+ *
+ * @module lib/governance/qf-mint-gate
+ */
+import { measureDemand as defaultMeasure, recordDemandDecision as defaultRecord, resolveDemandFloor } from './demand-gate-emit.js';
+import { formatDemandDecision, mayProduce } from './demand-gate.js';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const { countClaimableQuickFixes } = require('../fleet/belt-depth.cjs');
+
+/**
+ * Producer names, EXPORTED CONSTANTS rather than string literals at the call site.
+ * refill-cron.mjs:110-112 records why: these must match their BELT_DEPTH_GATED_PRODUCERS entries
+ * exactly, and a typo does not fail loudly — it renders NEVER RAN on the startup badge forever,
+ * which reads identically to a producer that has simply not fired yet.
+ */
+export const FINGERPRINT_PROMOTER_ENGINE = 'feedback-fingerprint-promoter';
+export const RETRO_ACTION_PROMOTER_ENGINE = 'promote-retro-action-items';
+
+/**
+ * Measure QF-side demand, record it, print it, and say whether minting may proceed.
+ *
+ * recordDemandDecision and formatDemandDecision are UNCONDITIONAL, mirroring
+ * refill-cron.mjs:130-143: a withheld run that leaves no audit_log row is indistinguishable from a
+ * dead cron, which is the state this whole mechanism exists to make visible.
+ *
+ * A malformed decision THROWS rather than falling through. Proceeding ungated because the gate
+ * returned something unexpected is the fail-open flood wearing the costume of robustness.
+ *
+ * @param {object} supabase service-role client
+ * @param {{engine:string, env?:object, gauge?:Function, measure?:Function, record?:Function, log?:Function}} opts
+ * @returns {Promise<{allowed:boolean, demand:object}>}
+ */
+export async function openQfMintGate(supabase, {
+  engine,
+  env = process.env,
+  gauge = countClaimableQuickFixes,
+  measure = defaultMeasure,
+  record = defaultRecord,
+  log = console.log,
+} = {}) {
+  if (!engine) throw new Error('openQfMintGate: engine is required — an unnamed producer renders NEVER RAN on the badge');
+  const demand = await measure(supabase, { engine, floor: resolveDemandFloor(env), gauge });
+  // Record FIRST and unconditionally: even a malformed reading should leave a trace, and
+  // recordDemandDecision already no-ops on a falsy decision.
+  await record(supabase, demand);
+  // Validate BEFORE rendering. formatDemandDecision assumes a well-formed decision and throws a
+  // property-access error on anything else — so calling it first would replace this deliberate,
+  // engine-named failure with an opaque one, hiding WHICH producer received garbage.
+  if (!demand || typeof demand.decision !== 'string') {
+    throw new Error(`openQfMintGate: ${engine} received a malformed demand decision — refusing to mint ungated`);
+  }
+  log(formatDemandDecision(demand, engine));
+  return { allowed: mayProduce(demand), demand };
+}
+
+/**
+ * Run `mint` only when the gate permits it.
+ *
+ * The seam DELIBERATELY ENCLOSES THE MINTING CALLBACK rather than merely returning a boolean the
+ * caller is trusted to honour. A gate that only reports a verdict is one forgotten `if` away from
+ * being decorative, and that omission is invisible to a source-text test.
+ *
+ * @param {object} supabase
+ * @param {object} opts same as openQfMintGate
+ * @param {() => Promise<number>|number} mint performs the actual minting; returns how many it minted
+ * @returns {Promise<{minted:number, withheldByDemand:boolean, demand:object}>}
+ */
+export async function gatedQfMint(supabase, opts, mint) {
+  const { allowed, demand } = await openQfMintGate(supabase, opts);
+  if (!allowed) return { minted: 0, withheldByDemand: true, demand };
+  const minted = await mint();
+  return { minted: Number(minted) || 0, withheldByDemand: false, demand };
+}

--- a/scripts/feedback-fingerprint-promoter.mjs
+++ b/scripts/feedback-fingerprint-promoter.mjs
@@ -30,6 +30,11 @@ import { createClient } from '@supabase/supabase-js';
 import { groupByFingerprint, shouldPromote } from '../lib/shared/content-fingerprint.cjs';
 import { fetchAllPaginated } from '../lib/db/fetch-all-paginated.mjs';
 import { derivePromotedSeverity } from '../lib/feedback/promoted-severity.js';
+// SD-LEO-INFRA-GATE-SIDE-BELT-001: this producer mints quick_fixes unattended on a 6-hourly cron and
+// was ungated, so it could mint into a full belt indefinitely. The gate lives in lib/ (not inline
+// here) because this script has no exports and its guard tests are source-text regexes, which cannot
+// see control flow — and control flow is all a gate is.
+import { gatedQfMint, FINGERPRINT_PROMOTER_ENGINE } from '../lib/governance/qf-mint-gate.mjs';
 
 const apply = process.argv.includes('--apply');
 const WINDOW_DAYS = 14;
@@ -85,6 +90,10 @@ let promoted = 0;
 let skippedAlreadyPromoted = 0;
 let skippedBelowThreshold = 0;
 
+// Extracted so the demand gate can ENCLOSE the minting rather than merely precede it. A gate that
+// only returns a verdict is one forgotten `if` away from being decorative — and that omission is
+// invisible to a source-text guard test, which is all this script had.
+async function promoteAll() {
 for (const group of groups.values()) {
   if (!shouldPromote(group, THRESHOLD)) {
     skippedBelowThreshold++;
@@ -147,5 +156,23 @@ for (const group of groups.values()) {
     console.error(`  [PROMOTE_FAILED] create-quick-fix.js exited non-zero for fingerprint ${group.fingerprint.slice(0, 12)}: ${e.message}`);
   }
 }
+  return promoted;
+}
 
-console.log(`\nSummary: ${promoted} promoted, ${skippedAlreadyPromoted} already-promoted, ${skippedBelowThreshold} below threshold.`);
+// DRY-RUN IS DELIBERATELY UNGATED. Without --apply nothing is minted, so there is no belt to
+// protect — and gating here would suppress the [PROMOTABLE] output that four integration assertions
+// read. The gate guards MINTING, not reporting.
+//
+// The consequence of gating on apply is stated rather than discovered: on a dry-run-only day no
+// decision is recorded, so the startup badge reads NEVER RAN. That is the correct trade — a recorded
+// decision for a run that could never have minted would be a measurement of nothing.
+let withheldByDemand = false;
+if (!apply) {
+  await promoteAll();
+} else {
+  const result = await gatedQfMint(supabase, { engine: FINGERPRINT_PROMOTER_ENGINE }, promoteAll);
+  withheldByDemand = result.withheldByDemand;
+}
+
+console.log(`\nSummary: ${promoted} promoted, ${skippedAlreadyPromoted} already-promoted, ${skippedBelowThreshold} below threshold.`
+  + (withheldByDemand ? ' — WITHHELD by belt demand, nothing minted.' : ''));

--- a/scripts/promote-retro-action-items.mjs
+++ b/scripts/promote-retro-action-items.mjs
@@ -26,6 +26,10 @@ import { execFileSync } from 'node:child_process';
 import { createClient } from '@supabase/supabase-js';
 import { actionText, actionOwner, isActionable } from './lib/retro-action-item-filter.mjs';
 import { fetchAllPaginated } from '../lib/db/fetch-all-paginated.mjs';
+// SD-LEO-INFRA-GATE-SIDE-BELT-001: this producer mints quick_fixes unattended on a daily cron and
+// was ungated. The gate lives in lib/ rather than inline because this script has no exports and its
+// guard tests are source-text regexes, which cannot see control flow.
+import { gatedQfMint, RETRO_ACTION_PROMOTER_ENGINE } from '../lib/governance/qf-mint-gate.mjs';
 
 const apply = process.argv.includes('--apply');
 const LOOKBACK_DAYS = 7;
@@ -107,6 +111,9 @@ let skippedStatusUnavailable = 0;
 
 let skippedTestFixture = 0;
 
+// Extracted so the demand gate ENCLOSES the minting rather than merely preceding it — a gate that
+// only returns a verdict is one forgotten `if` away from being decorative.
+async function promoteAll() {
 for (const retro of retros || []) {
   if (retro.metadata?.action_items_promoted) {
     skippedAlreadyPromoted++;
@@ -201,5 +208,20 @@ for (const retro of retros || []) {
     console.error(`  [PROMOTE_FAILED] create-quick-fix.js exited non-zero for retro ${retro.id}: ${e.message}`);
   }
 }
+  return promoted;
+}
 
-console.log(`\nSummary: ${promoted} promoted, ${skippedAlreadyPromoted} already-promoted, ${skippedTerminalSd} terminal-SD, ${skippedStatusUnavailable} status-unavailable, ${skippedTestFixture} test-fixture, ${skippedNoHighPriority} with no high-priority items, ${skippedNonActionable} with only non-actionable items.`);
+// DRY-RUN IS DELIBERATELY UNGATED — without --apply nothing is minted, so there is no belt to
+// protect, and gating here would suppress the [PROMOTABLE] output the integration assertions read.
+// The gate guards MINTING, not reporting. Consequence, stated rather than discovered: on a
+// dry-run-only day no decision is recorded and the startup badge reads NEVER RAN.
+let withheldByDemand = false;
+if (!apply) {
+  await promoteAll();
+} else {
+  const result = await gatedQfMint(supabase, { engine: RETRO_ACTION_PROMOTER_ENGINE }, promoteAll);
+  withheldByDemand = result.withheldByDemand;
+}
+
+console.log(`\nSummary: ${promoted} promoted, ${skippedAlreadyPromoted} already-promoted, ${skippedTerminalSd} terminal-SD, ${skippedStatusUnavailable} status-unavailable, ${skippedTestFixture} test-fixture, ${skippedNoHighPriority} with no high-priority items, ${skippedNonActionable} with only non-actionable items.`
+  + (withheldByDemand ? ' — WITHHELD by belt demand, nothing minted.' : ''));

--- a/tests/unit/adam-sourcing-state-probe.test.js
+++ b/tests/unit/adam-sourcing-state-probe.test.js
@@ -9,6 +9,7 @@
 // SD-LEO-INFRA-ADAM-SOURCE-FROM-SSOT-CONTRACT-001 (FR-2)
 import { test } from 'vitest';
 import assert from 'node:assert/strict';
+import { BELT_DEPTH_GATED_PRODUCERS } from '../../lib/governance/demand-gate.js';
 import {
   SOURCING_FLAGS,
   RETIRED_SOURCING_FLAGS,
@@ -201,5 +202,10 @@ test('C4: the demand section is rendered by the composed path, not only by the p
   // Kills "drop demand from the renderSourcingStateLines call" and "replace the read with null".
   const out = await renderSourcingState({ supabase: null, env: {} });
   assert.match(out, /\[demand-gate\]/);
-  for (const engine of ['refill-auto-promote', 'fr-c-generator']) assert.match(out, new RegExp(engine));
+  // SD-LEO-INFRA-GATE-SIDE-BELT-001: iterate the REGISTRY, not a hardcoded pair. The literal list
+  // here was ['refill-auto-promote','fr-c-generator']; when the two QF minters joined
+  // BELT_DEPTH_GATED_PRODUCERS this test kept passing while silently ceasing to cover them — a
+  // check that cannot notice a new member is not a check on membership.
+  for (const engine of BELT_DEPTH_GATED_PRODUCERS) assert.match(out, new RegExp(engine));
+  assert.ok(BELT_DEPTH_GATED_PRODUCERS.length >= 4, 'expected the QF-side minters to be registered too');
 });

--- a/tests/unit/governance/qf-mint-gate.test.js
+++ b/tests/unit/governance/qf-mint-gate.test.js
@@ -1,0 +1,123 @@
+// GSB-B — the QF-side demand gate. SD-LEO-INFRA-GATE-SIDE-BELT-001, TS-4/TS-6/TS-7/TS-8.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import {
+  openQfMintGate, gatedQfMint, FINGERPRINT_PROMOTER_ENGINE, RETRO_ACTION_PROMOTER_ENGINE,
+} from '../../../lib/governance/qf-mint-gate.mjs';
+import { BELT_DEPTH_GATED_PRODUCERS, DEMAND_DECISION } from '../../../lib/governance/demand-gate.js';
+const require = createRequire(import.meta.url);
+const { countClaimableQuickFixes } = require('../../../lib/fleet/belt-depth.cjs');
+
+// DEMAND_DECISION values are LOWERCASE ('sourced' / 'withheld' / 'unmeasurable'). Imported rather
+// than spelled out: the first draft of this file hand-wrote 'SOURCED' and mayProduce silently
+// returned false, so the SOURCED arm asserted withheld behaviour and looked like a code defect.
+// A constant is a claim about the consumer — import it, do not retype it.
+const decision = (d) => ({ decision: d, gauge_value: 1, floor: 3, measured_at: '2026-08-03T00:00:00Z', engine: 'x' });
+const noop = () => {};
+
+describe('TS-4 — a WITHHELD decision prevents minting; a SOURCED one does not', () => {
+  // BOTH ARMS IN ONE SCENARIO. A suite whose every arm expects the same verdict is satisfied by a
+  // constant function — a gate that always withholds and a gate that never withholds would each
+  // pass a single-arm suite.
+  it('withheld => mint never runs; sourced => mint runs — same harness, opposite outcomes', async () => {
+    let mintCalls = 0;
+    const mint = async () => { mintCalls += 1; return 7; };
+    const base = { engine: 'e', gauge: async () => 0, record: async () => {}, log: noop };
+
+    const withheld = await gatedQfMint({}, { ...base, measure: async () => decision(DEMAND_DECISION.WITHHELD) }, mint);
+    expect(withheld.withheldByDemand).toBe(true);
+    expect(withheld.minted).toBe(0);
+    expect(mintCalls).toBe(0);
+
+    const sourced = await gatedQfMint({}, { ...base, measure: async () => decision(DEMAND_DECISION.SOURCED) }, mint);
+    expect(sourced.withheldByDemand).toBe(false);
+    expect(sourced.minted).toBe(7);
+    expect(mintCalls).toBe(1);
+  });
+
+  it('records and prints the decision EVEN WHEN WITHHELD', async () => {
+    // A withheld run leaving no audit_log row is indistinguishable from a dead cron, which is the
+    // exact ambiguity this mechanism exists to remove.
+    let recorded = null; let printed = null;
+    await gatedQfMint({}, {
+      engine: 'e', gauge: async () => 0, measure: async () => decision(DEMAND_DECISION.WITHHELD),
+      record: async (_sb, d) => { recorded = d; }, log: (m) => { printed = m; },
+    }, async () => 1);
+    expect(recorded).toBeTruthy();
+    expect(recorded.decision).toBe(DEMAND_DECISION.WITHHELD);
+    expect(printed).toMatch(/demand-gate/);
+  });
+
+  it('THROWS on a malformed decision rather than minting ungated', async () => {
+    await expect(gatedQfMint({}, {
+      engine: 'e', gauge: async () => 0, measure: async () => ({ nonsense: true }),
+      record: async () => {}, log: noop,
+    }, async () => 1)).rejects.toThrow(/malformed/);
+  });
+
+  it('THROWS when no engine is named — an unnamed producer renders NEVER RAN forever', async () => {
+    await expect(openQfMintGate({}, { measure: async () => decision(DEMAND_DECISION.SOURCED), record: async () => {}, log: noop }))
+      .rejects.toThrow(/engine is required/);
+  });
+});
+
+describe('TS-6 — the QF gauge is asserted by IDENTITY, not by outcome', () => {
+  // OUTCOME CANNOT DISCRIMINATE HERE. Live, the QF reading (145) and the SD reading (21) are BOTH
+  // above the floor (3), so a silent fallback to the default SD gauge produces exactly the same
+  // WITHHELD verdict as the correct wiring. An outcome-only assertion would pass on the broken code.
+  // So the test inspects WHICH FUNCTION reaches measureDemand.
+  it('defaults to countClaimableQuickFixes, not the SD-side gauge', async () => {
+    let seenGauge = null;
+    await openQfMintGate({}, {
+      engine: 'e',
+      measure: async (_sb, opts) => { seenGauge = opts.gauge; return decision(DEMAND_DECISION.SOURCED); },
+      record: async () => {}, log: noop,
+    });
+    expect(seenGauge).toBe(countClaimableQuickFixes);
+  });
+
+  it('passes the resolved floor through', async () => {
+    let seenFloor = null;
+    await openQfMintGate({}, {
+      engine: 'e', env: { BELT_DEMAND_FLOOR: '42' },
+      measure: async (_sb, opts) => { seenFloor = opts.floor; return decision(DEMAND_DECISION.SOURCED); },
+      record: async () => {}, log: noop,
+    });
+    expect(seenFloor).toBe(42);
+  });
+});
+
+describe('TS-7 — both producers are registered under the SAME names they use', () => {
+  // A name constant that drifts from its registry entry does not fail loudly: the startup badge
+  // simply renders NEVER RAN forever, which reads identically to a producer that has not fired yet.
+  it('each exported engine constant is in BELT_DEPTH_GATED_PRODUCERS', () => {
+    expect(BELT_DEPTH_GATED_PRODUCERS).toContain(FINGERPRINT_PROMOTER_ENGINE);
+    expect(BELT_DEPTH_GATED_PRODUCERS).toContain(RETRO_ACTION_PROMOTER_ENGINE);
+  });
+  it('the two QF engines are distinct from each other and from the SD-side pair', () => {
+    expect(FINGERPRINT_PROMOTER_ENGINE).not.toBe(RETRO_ACTION_PROMOTER_ENGINE);
+    expect([FINGERPRINT_PROMOTER_ENGINE, RETRO_ACTION_PROMOTER_ENGINE])
+      .not.toContain('refill-auto-promote');
+  });
+});
+
+describe('TS-8 — the gate is wired at BOTH call sites, and encloses the spawn', () => {
+  // Source assertions, deliberately narrow: they cannot see control flow (which is why the seam
+  // exists), but they CAN see that a call site was deleted — the mutant that matters most here.
+  const read = (p) => require('node:fs').readFileSync(require.resolve(p), 'utf8');
+  it.each([
+    ['../../../scripts/feedback-fingerprint-promoter.mjs', 'FINGERPRINT_PROMOTER_ENGINE'],
+    ['../../../scripts/promote-retro-action-items.mjs', 'RETRO_ACTION_PROMOTER_ENGINE'],
+  ])('%s calls gatedQfMint with its own engine constant', (path, konst) => {
+    const src = read(path);
+    expect(src).toMatch(/gatedQfMint\(/);
+    expect(src).toContain(konst);
+    // The gate must ENCLOSE the minting: gatedQfMint takes the loop as its callback.
+    expect(src).toMatch(/gatedQfMint\(supabase,\s*\{[^}]*\},\s*promoteAll\)/);
+  });
+
+  it('create-quick-fix.js is NOT gated — the shared boundary stays open to humans', () => {
+    const src = read('../../../scripts/create-quick-fix.js');
+    expect(src).not.toMatch(/qf-mint-gate|gatedQfMint|openQfMintGate/);
+  });
+});


### PR DESCRIPTION
## GSB-B — gate the two QF-side minters, at the callers

Second part of SD-LEO-INFRA-GATE-SIDE-BELT-001, on top of GSB-A (#6770). `feedback-fingerprint-promoter` (6-hourly) and `promote-retro-action-items` (daily) mint quick fixes unattended and could mint into a full belt indefinitely. They now consult the belt-demand gate.

### Where the gate goes — and why not the obvious place
Neither minter writes `quick_fixes` directly; each shells out to `scripts/create-quick-fix.js`, which is **also how a human files a quick fix by hand**. A gate at a shared boundary hits every caller. `create-quick-fix.js` is byte-unchanged, and a test asserts it stays that way.

### Which gauge, and why it's injected
`measureDemand`'s **default** gauge is `countDispatchableBacklog` — it reads `strategic_directives_v2` and cannot see a single quick fix. Gating QF production on it is an open loop failing **both** ways: below the floor, minted QFs never raise the reading so the gate never closes; above it, minting is blocked no matter how starved the QF lane is.

Measured: SD depth **21** against floor **3** — the default gauge would have withheld every run and taken the harness-backlog drain from **25 QFs/week to zero**. So the QF pair inject `countClaimableQuickFixes` (from GSB-A) through `measureDemand`'s existing gauge parameter.

### Why a `lib/` seam rather than inline code
Both minters are top-level-await scripts with **no exports**, so every existing guard test for them is a regex over source text — which cannot see control flow, and control flow is all a gate is. `refill-cron.mjs:117-127` records five one-line mutants surviving the whole suite at its previous inline callsite.

`gatedQfMint` takes the promotion loop as a **callback**, so the gate *encloses* the minting rather than returning a verdict a caller is trusted to honour — a gate that only reports is one forgotten `if` from being decorative.

### Two decisions, stated rather than discovered

1. **Dry-run is ungated.** Without `--apply` nothing is minted, so there's no belt to protect, and gating there would suppress the `[PROMOTABLE]` output four integration assertions read. Consequence accepted out loud: **on a dry-run-only day no decision is recorded and the badge reads NEVER RAN.** A recorded decision for a run that could never have minted measures nothing.
2. **One floor, two lanes.** `BELT_DEMAND_FLOOR` is a single global env var with no per-producer override, and the lanes differ ~6× (SD 21, QF 145). A floor tuned for one is not tuned for the other. **A per-producer override is a named follow-up, not shipped here.**

### TS-6 asserts gauge *identity*, not outcome
Live, QF=145 and SD=21 are **both** above floor 3 — so a silent fallback to the default gauge produces exactly the same WITHHELD verdict as correct wiring. An outcome-only assertion would pass on the broken code, so the test inspects *which function reaches* `measureDemand`.

### Mutation-proven — four mutants, each verified to have **applied**

| mutation | result |
|---|---|
| `gatedQfMint` ignores the verdict and mints anyway | **1 failed** |
| default gauge falls back to the SD-side reading | **1 failed** |
| delete the gate call from one minter | **1 failed** |
| malformed decision falls through instead of throwing | **1 failed** |
| restored | 11/11 · full run **72 files / 1147 tests** |

Live dry-run verified unchanged: `[PROMOTABLE]` still prints, no spawn, no demand-gate line.

### On the diff size
`CLAUDE_ADAM.md` is a **generated file**; the source row in `leo_protocol_sections` was updated and the generator re-run. The full generator output is committed because a **partial regeneration fails the drift gate** (precedent: 058f110). The churn in the other `CLAUDE_*.md` files is line-ending normalisation, not content — 29 added / 29 removed with identical text. Drift check passes.

Also: both names added to `BELT_DEPTH_GATED_PRODUCERS` with membership tests; each script exports its own engine constant (a typo renders NEVER RAN forever, not an error); and `adam-sourcing-state-probe.test.js:204` hardcoded the old pair — it would have kept passing while silently ceasing to cover the new producers, so it now iterates the registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
