### PR TITLE
fix: the suppressed-group counter reported 0 on a run that suppressed 34

### DIFF
--- a/scripts/feedback-fingerprint-promoter.mjs
+++ b/scripts/feedback-fingerprint-promoter.mjs
@@ -93,7 +93,9 @@ let skippedBelowThreshold = 0;
 // Extracted so the demand gate can ENCLOSE the minting rather than merely precede it. A gate that
 // only returns a verdict is one forgotten `if` away from being decorative — and that omission is
 // invisible to a source-text guard test, which is all this script had.
+let suppressedCount = 0;
 async function promoteAll(reportOnly = false) {
+  suppressedCount = 0;
 for (const group of groups.values()) {
   if (!shouldPromote(group, THRESHOLD)) {
     skippedBelowThreshold++;
@@ -112,6 +114,7 @@ for (const group of groups.values()) {
   console.log(`  sample: ${group.sample_body.slice(0, 120)}`);
 
   if (!apply || reportOnly) {
+    if (reportOnly) suppressedCount++;
     console.log(reportOnly ? '  [WITHHELD] would have created a QF-candidate here - suppressed by belt demand.' : '  [DRY RUN] would create QF-candidate here.');
     continue;
   }
@@ -156,7 +159,10 @@ for (const group of groups.values()) {
     console.error(`  [PROMOTE_FAILED] create-quick-fix.js exited non-zero for fingerprint ${group.fingerprint.slice(0, 12)}: ${e.message}`);
   }
 }
-  return promoted;
+  // REPORT-ONLY RETURNS WHAT IT SUPPRESSED, NOT WHAT IT MINTED. Returning `promoted` here made the
+  // gate print "suppressed 0" on a run that suppressed 34 — a number that looked measured and looked
+  // like good news. In report-only mode nothing is ever promoted, so `promoted` is 0 by construction.
+  return reportOnly ? suppressedCount : promoted;
 }
 
 // DRY-RUN IS DELIBERATELY UNGATED. Without --apply nothing is minted, so there is no belt to

--- a/scripts/promote-retro-action-items.mjs
+++ b/scripts/promote-retro-action-items.mjs
@@ -113,7 +113,9 @@ let skippedTestFixture = 0;
 
 // Extracted so the demand gate ENCLOSES the minting rather than merely preceding it — a gate that
 // only returns a verdict is one forgotten `if` away from being decorative.
+let suppressedCount = 0;
 async function promoteAll(reportOnly = false) {
+  suppressedCount = 0;
 for (const retro of retros || []) {
   if (retro.metadata?.action_items_promoted) {
     skippedAlreadyPromoted++;
@@ -178,6 +180,7 @@ for (const retro of retros || []) {
   for (const item of actionable) console.log(`  - ${actionText(item)}`);
 
   if (!apply || reportOnly) {
+    if (reportOnly) suppressedCount++;
     console.log(reportOnly ? '  [WITHHELD] would have created a QF-candidate here - suppressed by belt demand.' : '  [DRY RUN] would create QF-candidate here.');
     continue;
   }
@@ -208,7 +211,9 @@ for (const retro of retros || []) {
     console.error(`  [PROMOTE_FAILED] create-quick-fix.js exited non-zero for retro ${retro.id}: ${e.message}`);
   }
 }
-  return promoted;
+  // REPORT-ONLY RETURNS WHAT IT SUPPRESSED, NOT WHAT IT MINTED — see the fingerprint promoter for
+  // the measured failure this corrects ("suppressed 0" printed on a run that suppressed 34).
+  return reportOnly ? suppressedCount : promoted;
 }
 
 // DRY-RUN IS DELIBERATELY UNGATED — without --apply nothing is minted, so there is no belt to

--- a/tests/unit/governance/qf-mint-gate.test.js
+++ b/tests/unit/governance/qf-mint-gate.test.js
@@ -187,3 +187,31 @@ describe('SEC-GSB-2 — a WITHHELD run COUNTS and NAMES what it suppressed', () 
     }
   });
 });
+
+describe('SEC-GSB-2 follow-up — report-only returns what it SUPPRESSED, not what it minted', () => {
+  // MEASURED IN PRODUCTION, not hypothesised: the first live withheld run printed
+  // "suppressed 0 promotable group(s)" while its own log carried 34 [WITHHELD] lines. promoteAll
+  // returned `promoted`, which in report-only mode is 0 by construction. The number looked measured
+  // AND looked like good news — strictly worse than printing nothing, because it answers the
+  // question wrongly instead of leaving it open.
+  it('the count reaching the log is the callback return, so a wrong return is a wrong headline', async () => {
+    const logged = [];
+    const r = await gatedQfMint({}, {
+      engine: 'e', gauge: async () => 0,
+      measure: async () => decision(DEMAND_DECISION.WITHHELD),
+      record: async () => {}, log: (m) => logged.push(m),
+      onWithheld: async () => 34,
+    }, async () => 0);
+    expect(r.suppressed).toBe(34);
+    expect(logged.join('\n')).toMatch(/suppressed 34 promotable group/);
+  });
+
+  it('both minters return the suppressed counter in report-only mode', () => {
+    const read = (p) => require('node:fs').readFileSync(require.resolve(p), 'utf8');
+    for (const p of ['../../../scripts/feedback-fingerprint-promoter.mjs', '../../../scripts/promote-retro-action-items.mjs']) {
+      const s = read(p);
+      expect(s).toMatch(/return reportOnly \? suppressedCount : promoted;/);
+      expect(s).toMatch(/if \(reportOnly\) suppressedCount\+\+;/);
+    }
+  });
+});


### PR DESCRIPTION
fix: the suppressed-group counter reported 0 on a run that suppressed 34

MEASURED IN PRODUCTION, not hypothesised. The QF-side belt gate fired for the first time at
2026-08-03T19:25:11Z and printed:

  [demand-gate] feedback-fingerprint-promoter: WITHHELD suppressed 0 promotable group(s)
  Summary: 0 promoted, 18 already-promoted, 1188 below threshold. — WITHHELD by belt demand

while the same run's log carried THIRTY-FOUR "[WITHHELD] would have created a QF-candidate here"
lines. Confirmed locally: a dry run of the same script emits 34 promotable groups.

CAUSE: promoteAll(reportOnly) returned `promoted` — the count of items actually minted — and in
report-only mode nothing is ever minted, so that value is 0 BY CONSTRUCTION. The counter I added to
make an invisible loss visible was reading the wrong variable.

WHY THIS IS WORSE THAN PRINTING NOTHING. Before the counting fix, the suppression was invisible and
everyone knew it was invisible. After it, the run reported a number that LOOKED measured and LOOKED
like good news: "suppressed 0" reads as "the gate withheld and nothing was lost." It answers the
question wrongly instead of leaving it open, which is the failure mode this SD's parent work is
entirely about — a value at the wrong granularity manufacturing false agreement. I shipped one while
fixing another.

FIX: report-only returns the suppressed counter. Both minters now increment it on the withheld branch
and return `reportOnly ? suppressedCount : promoted`.

REGRESSION COVER: a unit test pins that the number reaching the log is the callback's return value,
so a wrong return is a wrong headline; and a source assertion pins that both minters increment and
return the counter rather than the mint count.

TWO PROCESS NOTES WORTH KEEPING. First, my carried rule "files are CRLF" is an OVER-GENERALISATION —
the gate file is CRLF, both minters are LF, and the \r\n patterns silently matched nothing until I
checked with cat -A. Line endings vary PER FILE, so a replacement must verify it applied regardless
of what the last file taught. Second, this defect was only visible because the fix printed the
[WITHHELD] lines alongside the count: the count and the enumeration disagreed IN THE SAME OUTPUT, and
the enumeration was right. A summary that cannot be cross-checked against its own detail is a
summary nobody can catch being wrong.

Live state at the time of this fix: two QF-side gate firings, both WITHHELD, gauge 146 then 147
against floor 3 — the pool GREW while withholding, which is the open loop this gate cannot close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)