### PR TITLE
FR-1: attribute every vision score to its rubric, and calibrate thresholds per instrument

### DIFF
--- a/lib/handoff/threshold-resolver.js
+++ b/lib/handoff/threshold-resolver.js
@@ -222,3 +222,205 @@ export function calculateDynamicThreshold(baseThreshold, addressable, total) {
   const floor = baseThreshold * MIN_ADJUSTED_THRESHOLD_RATIO;
   return Math.round(Math.max(ratioBased, floor));
 }
+
+// ─── RUBRIC IDENTITY ──────────────────────────────────────────────────────────
+// SD-FDBK-FIX-HEAL-BEFORE-COMPLETE-001 FR-1.
+//
+// eva_vision_scores.total_score is written by several incommensurable instruments and read as one
+// number. Measured over the FULL table (6059/6059 rows, paginated):
+//
+//   n=2537   capabilities_present,key_changes_delivered,smoke_tests_pass,success_criteria_met,success_metrics_achieved
+//   n=1646   A01..A07,V01..V11
+//   n=1136   elapsed_ms,semantic,structural
+//   n= 454   feasibility,impact,innovation,strategic_alignment,sustainability
+//
+// WHY IDENTITY IS DERIVED FROM THE KEY SET RATHER THAN A DECLARED FIELD. The PRD assumed a
+// discriminator already exists in the data. It does not: only 290/6059 rows (4.8%) carry
+// rubric_snapshot.rubric at all, and rubric_snapshot.mode='sd-heal' covers 3121 rows spanning
+// ELEVEN distinct dimension counts (5d:1322, 3d:1139, 18d:638) — one label sitting on the heal
+// rubric, the latency signature and the vision rubric simultaneously. The dimension KEY SET is the
+// only discriminator actually present, so it is the one used here.
+//
+// NOTE that dimension COUNT alone is insufficient: two DIFFERENT 5-dimension rubrics exist
+// (heal-completeness and eva-5dim). Matching on count would merge them.
+
+/** Exact-key-set rubrics, transcribed from the census — not inferred from naming. */
+const EXACT_RUBRICS = [
+  ['sd-heal-5dim-v1', ['capabilities_present', 'key_changes_delivered', 'smoke_tests_pass', 'success_criteria_met', 'success_metrics_achieved']],
+  ['eva-5dim-v1',     ['feasibility', 'impact', 'innovation', 'strategic_alignment', 'sustainability']],
+];
+
+/** A dimension key that is a DURATION, not a 0-100 quality score. */
+const LATENCY_KEYS = new Set(['elapsed_ms']);
+
+/** Vision-family keys are opaque ordinals: A01..A08, V01..V11. */
+const VISION_KEY_RX = /^[AV]\d{2}$/;
+
+/**
+ * Name the instrument that produced a dimension_scores object.
+ *
+ * Returns a stable rubric id, or 'unregistered' when the signature is not one this registry knows.
+ * 'unregistered' is a DELIBERATE outcome rather than a fallback to some default rubric: 76 distinct
+ * signatures exist and quietly treating an unknown one as the vision rubric would reintroduce
+ * exactly the cross-instrument comparison this function exists to prevent.
+ *
+ * @param {Object|null} dimensionScores
+ * @returns {string} rubric id
+ */
+export function identifyRubric(dimensionScores) {
+  if (!dimensionScores || typeof dimensionScores !== 'object' || Array.isArray(dimensionScores)) {
+    return 'unregistered';
+  }
+  const keys = Object.keys(dimensionScores);
+  if (keys.length === 0) return 'unregistered';
+
+  // Latency FIRST. A signature carrying a millisecond duration is not a quality rubric no matter
+  // what else it carries, and must be caught before any count- or family-based rule can claim it.
+  if (keys.some(k => LATENCY_KEYS.has(k))) return 'latency-3dim';
+
+  const sorted = [...keys].sort();
+  for (const [id, expect] of EXACT_RUBRICS) {
+    if (sorted.length === expect.length && sorted.every((k, i) => k === expect[i])) return id;
+  }
+
+  // Vision FAMILY, not a single fixed width. The 18-key form is the modal one but the same
+  // instrument also emitted 11..17-key rows as it grew; they are one rubric at several widths, and
+  // treating each width as its own rubric would fragment the registry for no behavioural gain.
+  if (keys.every(k => VISION_KEY_RX.test(k))) return 'vision-av-v1';
+
+  return 'unregistered';
+}
+
+/**
+ * Rubrics whose scores are NOT quality measurements and must never be threshold-compared.
+ * elapsed_ms is a duration in milliseconds sharing a JSONB column with 0-100 scores; dimScoreOf
+ * returns it verbatim, so 1200 clears NARROW_FEATURE_DIM_FLOOR (50) and a stopwatch reading counts
+ * as a fully-addressed dimension. 1136 rows carry this signature.
+ */
+export const NON_COMPARABLE_RUBRICS = new Set(['latency-3dim']);
+
+// ─── PER-RUBRIC CALIBRATION ───────────────────────────────────────────────────
+// Emitted by scripts/analysis/rubric-threshold-calibration.mjs, which imports identifyRubric from
+// THIS file so the calibration and the runtime agree by construction. Re-run it to refresh.
+//
+// WHY THRESHOLDS ARE PER-RUBRIC AND NOT ONE NUMBER. The four instruments have measurably different
+// score distributions — the medians span NINETEEN POINTS (heal 92.0, eva 82.0, vision 73.0). A
+// single nominal threshold therefore means completely different things: 90 sits near the heal
+// rubric's p40 (routine) and above the vision rubric's p90 (near-unreachable). One number against
+// four distributions is not one standard, it is four different standards wearing one label.
+//
+// MEASURED 2026-08-03 over 6059 rows (full population, not a sample).
+export const QUANTILE_GRID = [0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90];
+export const RUBRIC_QUANTILES = {
+  'sd-heal-5dim-v1': { n: 2537, q: [59.4, 89.0, 92.0, 92.0, 92.0, 95.0, 96.0, 96.0, 99.0] },
+  'vision-av-v1':    { n: 1841, q: [44.0, 62.0, 67.0, 70.0, 73.0, 76.0, 79.0, 82.0, 85.0] },
+  'latency-3dim':    { n: 1136, q: [76.0, 80.0, 85.0, 87.0, 88.0, 90.0, 90.0, 93.0, 97.0] },
+  'eva-5dim-v1':     { n:  454, q: [72.0, 78.0, 78.0, 80.2, 82.0, 82.0, 83.0, 85.0, 87.0] },
+};
+
+/** Score standing at percentile `p` of a rubric's measured distribution (linear interpolation). */
+export function quantileFor(rubric, p) {
+  const entry = RUBRIC_QUANTILES[rubric];
+  if (!entry) return null;
+  const grid = QUANTILE_GRID, q = entry.q;
+  if (p <= grid[0]) return q[0];
+  if (p >= grid[grid.length - 1]) return q[q.length - 1];
+  for (let i = 1; i < grid.length; i++) {
+    if (p <= grid[i]) {
+      const t = (p - grid[i - 1]) / (grid[i] - grid[i - 1]);
+      return q[i - 1] + (q[i] - q[i - 1]) * t;
+    }
+  }
+  return q[q.length - 1];
+}
+
+/**
+ * Target percentile per sd_type tier — the STRINGENCY the type demands, expressed independently of
+ * any one rubric's number line. Derived from the existing SD_TYPE_THRESHOLDS tiers (90 / 80 / 70)
+ * so the ordering of types is preserved exactly; only the scale it is expressed on changes.
+ */
+export function targetPercentile(sdType) {
+  const base = SD_TYPE_THRESHOLDS[sdType] ?? SD_TYPE_THRESHOLDS._default;
+  if (base >= 90) return 0.75;   // Tier 1 — top quartile of its own instrument
+  if (base >= 80) return 0.60;   // Tier 2
+  return 0.45;                   // Tier 3
+}
+
+/**
+ * COVERAGE BANDS — an explicit policy decision, recorded as one rather than left to emerge.
+ *
+ * A 5-dimension instrument can only express coverage in fifths; an 18-dimension one in eighteenths.
+ * Under continuous ratio-narrowing the two therefore land on different rungs for identical work,
+ * and any agreement between them is arithmetic coincidence (12/18 and 2/3 agree; 14/18 and 4/5 do
+ * not). Banding makes agreement STRUCTURAL: any two coverages inside one band are treated
+ * identically, whatever granularity produced them.
+ *
+ * THE COST, STATED PLAINLY: banding introduces cliffs. Coverage 0.749 and 0.750 fall either side of
+ * a rung and receive different thresholds. That is inherent to quantisation and is the price of
+ * removing instrument-driven spread; it is not a defect to be discovered later.
+ *
+ * Chairman/coordinator-facing: the rung boundaries below are the tunable policy. Alternatives
+ * considered were (b) continuous ratios, accepting instrument-driven spread, and (c) per-rubric
+ * calibrated bases — (c) is in fact ALSO implemented above, because the calibration data turned out
+ * to exist once the full population was measured.
+ */
+export const COVERAGE_BANDS = [
+  { minCoverage: 0.90, factor: 1.00 },
+  { minCoverage: 0.75, factor: 0.85 },
+  { minCoverage: 0.60, factor: 0.70 },
+  { minCoverage: 0.00, factor: MIN_ADJUSTED_THRESHOLD_RATIO },
+];
+
+export function coverageBandFactor(coverage) {
+  for (const band of COVERAGE_BANDS) if (coverage >= band.minCoverage) return band.factor;
+  return MIN_ADJUSTED_THRESHOLD_RATIO;
+}
+
+/**
+ * The STRINGENCY a piece of work is actually held to, as a percentile of its own rubric.
+ *
+ * This is the quantity that must agree across rubrics. Its numeric threshold DELIBERATELY does not:
+ * forcing two instruments with a 19-point median gap onto one number would re-create the
+ * incommensurability this module exists to remove.
+ */
+export function effectiveStringency(sdType, addressable, total) {
+  const coverage = total > 0 ? addressable / total : 1;
+  return targetPercentile(sdType) * coverageBandFactor(coverage);
+}
+
+/** Base threshold for a (sd_type, rubric) pair — AC-2's discriminating resolver. */
+export function resolveThreshold(sdType, rubric) {
+  const v = quantileFor(rubric, targetPercentile(sdType));
+  return v === null ? (SD_TYPE_THRESHOLDS[sdType] ?? SD_TYPE_THRESHOLDS._default) : Math.round(v);
+}
+
+/**
+ * The number a score is ACTUALLY compared against, end to end. This is the seam gates should call.
+ *
+ * Two distinct refusals, named separately rather than collapsed into one "cannot score" — a policy
+ * refusal and a coverage gap are different facts and a caller may reasonably treat them differently:
+ *   - NON_COMPARABLE: the rubric is not a quality measurement at all (latency).
+ *   - UNREGISTERED:   the signature is not in the registry, so nothing is known about its scale.
+ *
+ * DELIBERATELY NOT WIRED INTO ANY GATE IN THIS COMMIT. Existing callers keep using
+ * SD_TYPE_THRESHOLDS + calculateDynamicThreshold, so no gate changes behaviour on merge. Migrating
+ * a gate is a separate change with its own stated blast radius.
+ */
+export function resolveEffectiveThreshold(sdType, dimensionScores, sdMetadata = null) {
+  const rubric = identifyRubric(dimensionScores);
+  if (NON_COMPARABLE_RUBRICS.has(rubric)) {
+    throw new Error(
+      `resolveEffectiveThreshold: rubric '${rubric}' is a latency measurement, not a quality score — ` +
+      `refusing to threshold-compare it (elapsed_ms is milliseconds; it clears a 0-100 quality floor by magnitude alone)`
+    );
+  }
+  if (!RUBRIC_QUANTILES[rubric]) {
+    throw new Error(
+      `resolveEffectiveThreshold: unregistered rubric signature — nothing is known about its score ` +
+      `scale, so no threshold is meaningful. Add it to RUBRIC_QUANTILES via ` +
+      `scripts/analysis/rubric-threshold-calibration.mjs.`
+    );
+  }
+  const { addressable, total } = countAddressableDimensions(sdType, dimensionScores, sdMetadata);
+  return Math.round(quantileFor(rubric, effectiveStringency(sdType, addressable, total)));
+}

--- a/scripts/analysis/rubric-signature-census.cjs
+++ b/scripts/analysis/rubric-signature-census.cjs
@@ -1,0 +1,129 @@
+/**
+ * Census of eva_vision_scores rubric signatures.
+ *
+ * FULL PAGINATION, not a capped fetch. A .limit(N) followed by client-side grouping
+ * measures N, not the population — recorded failure mode.
+ */
+require('dotenv').config();
+const { createClient } = require('@supabase/supabase-js');
+
+const PAGE = 500;
+
+(async () => {
+  const sb = createClient(
+    process.env.SUPABASE_URL,
+    process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY
+  );
+
+  const { count: expected, error: cErr } = await sb
+    .from('eva_vision_scores').select('*', { count: 'exact', head: true });
+  if (cErr) throw new Error('count failed: ' + cErr.message);
+
+  const sigCounts = new Map();   // signature -> { n, dimCount, example, snapshotRubrics:Set }
+  let seen = 0;
+
+  for (let from = 0; from < expected; from += PAGE) {
+    const { data, error } = await sb
+      .from('eva_vision_scores')
+      .select('id, sd_id, total_score, dimension_scores, rubric_snapshot')
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1);
+    if (error) throw new Error(`page ${from} failed: ${error.message}`);
+    if (!data || data.length === 0) break;
+
+    for (const row of data) {
+      seen++;
+      const ds = row.dimension_scores;
+      let sig, dimCount;
+      if (!ds || typeof ds !== 'object' || Array.isArray(ds)) {
+        sig = `<non-object:${ds === null ? 'null' : typeof ds}>`;
+        dimCount = 0;
+      } else {
+        const keys = Object.keys(ds).sort();
+        dimCount = keys.length;
+        sig = keys.join(',');
+      }
+      let rec = sigCounts.get(sig);
+      if (!rec) {
+        rec = { n: 0, dimCount, example: row.id, rubrics: new Set(), modes: new Set(), withRubricKey: 0 };
+        sigCounts.set(sig, rec);
+      }
+      rec.n++;
+      // REPORT rubric AND mode SEPARATELY. The first version of this census used
+      // `rs.rubric || rs.mode`, which is the very conflation it exists to detect: it
+      // reported mode values in a column labelled rubric, making 'sd-heal' look like a
+      // rubric identifier spanning six incompatible dimension counts.
+      const rs = row.rubric_snapshot;
+      if (rs && typeof rs === 'object' && !Array.isArray(rs)) {
+        if (typeof rs.rubric === 'string' && rs.rubric) { rec.rubrics.add(rs.rubric); rec.withRubricKey++; }
+        else rec.rubrics.add('<no-rubric-key>');
+        rec.modes.add(typeof rs.mode === 'string' && rs.mode ? rs.mode : '<no-mode-key>');
+      } else if (typeof rs === 'string') {
+        rec.rubrics.add('<string-snapshot>'); rec.modes.add('<string-snapshot>');
+      } else {
+        rec.rubrics.add('<absent>'); rec.modes.add('<absent>');
+      }
+    }
+  }
+
+  // FALSIFY THE CENSUS: if pagination silently dropped rows, say so rather than
+  // reporting a clean-looking total that measured less than the population.
+  console.log(`expected=${expected} seen=${seen} ${seen === expected ? 'OK' : '*** MISMATCH — census is INCOMPLETE ***'}`);
+  console.log(`distinct dimension-key signatures = ${sigCounts.size}`);
+  console.log('');
+
+  const rows = [...sigCounts.entries()].sort((a, b) => b[1].n - a[1].n);
+  let totalWithRubric = 0;
+  for (const [, rec] of rows) totalWithRubric += rec.withRubricKey;
+  console.log(`rows carrying an explicit rubric_snapshot.rubric = ${totalWithRubric} / ${expected} ` +
+              `(${((totalWithRubric / expected) * 100).toFixed(1)}%)`);
+  console.log('');
+
+  for (const [sig, rec] of rows.slice(0, 12)) {
+    const shown = sig.length > 80 ? sig.slice(0, 80) + '…' : sig;
+    console.log(
+      `n=${String(rec.n).padStart(5)}  dims=${String(rec.dimCount).padStart(3)}  ` +
+      `rubricKey=${rec.withRubricKey}\n` +
+      `        rubric=[${[...rec.rubrics].join('|')}]\n` +
+      `        mode  =[${[...rec.modes].join('|')}]\n` +
+      `        keys  =[${shown}]`
+    );
+  }
+
+  // THE DECIDING QUESTION for FR-1: does any single mode label span DIFFERENT dimension
+  // counts? If so, mode cannot serve as the rubric discriminator the PRD assumes exists.
+  //
+  // COUNTED PER ROW. The first version accumulated per SIGNATURE — for each signature it
+  // credited the signature's FULL row count to every mode appearing anywhere in it, so a
+  // signature holding one 'sd-heal-batch' row reported all 2537 against that mode. The
+  // qualitative spread was real; the numbers were inflated. Attribution is not fixed by
+  // fixing the instrument that produced it, so this is a separate pass over rows.
+  console.log('\n=== does mode discriminate the rubric? (per-ROW cross-tab) ===');
+  const modeDimRows = new Map();
+  for (let from = 0; from < expected; from += PAGE) {
+    const { data, error } = await sb
+      .from('eva_vision_scores')
+      .select('dimension_scores, rubric_snapshot')
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1);
+    if (error) throw new Error(`crosstab page ${from} failed: ${error.message}`);
+    if (!data || data.length === 0) break;
+    for (const row of data) {
+      const ds = row.dimension_scores;
+      const d = (ds && typeof ds === 'object' && !Array.isArray(ds)) ? Object.keys(ds).length : -1;
+      const rs = row.rubric_snapshot;
+      let m;
+      if (rs && typeof rs === 'object' && !Array.isArray(rs)) m = (typeof rs.mode === 'string' && rs.mode) ? rs.mode : '<no-mode-key>';
+      else if (typeof rs === 'string') m = '<string-snapshot>';
+      else m = '<absent>';
+      if (!modeDimRows.has(m)) modeDimRows.set(m, new Map());
+      const dm = modeDimRows.get(m);
+      dm.set(d, (dm.get(d) || 0) + 1);
+    }
+  }
+  for (const [m, dm] of [...modeDimRows.entries()].sort((a, b) => b[1].size - a[1].size)) {
+    const tot = [...dm.values()].reduce((a, b) => a + b, 0);
+    const spread = [...dm.entries()].sort((a, b) => b[1] - a[1]).map(([d, n]) => `${d}d:${n}`).join(' ');
+    console.log(`mode='${m}' n=${tot} spans ${dm.size} distinct dimension count(s) -> ${spread}`);
+  }
+})().catch(e => { console.error('CENSUS FAILED:', e.message); process.exit(1); });

--- a/scripts/analysis/rubric-threshold-calibration.mjs
+++ b/scripts/analysis/rubric-threshold-calibration.mjs
@@ -1,0 +1,87 @@
+/**
+ * Per-rubric total_score distribution — the calibration input for resolveThreshold(sdType, rubric).
+ *
+ * WHY THIS EXISTS. FR-1 AC-2 requires the resolver to produce DIFFERENT base thresholds for
+ * different rubrics under one sd_type. Any specific pair of numbers invented at a keyboard would be
+ * a policy dressed as a measurement, and it would gate real work. The rubrics DO have measurably
+ * different score distributions, so the offsets are derived here instead of guessed.
+ *
+ * IMPORTS identifyRubric FROM THE LIB rather than re-implementing the classifier. A second copy of
+ * the matching rules is the same single-representation defect this SD exists to remove — and a
+ * calibration computed with a classifier that disagrees with the shipped one is worse than no
+ * calibration, because it looks derived.
+ *
+ * Re-run:  node scripts/analysis/rubric-threshold-calibration.mjs
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { identifyRubric } from '../../lib/handoff/threshold-resolver.js';
+
+const PAGE = 500;
+
+function quantile(sortedNums, q) {
+  if (sortedNums.length === 0) return null;
+  const pos = (sortedNums.length - 1) * q;
+  const lo = Math.floor(pos), hi = Math.ceil(pos);
+  if (lo === hi) return sortedNums[lo];
+  return sortedNums[lo] + (sortedNums[hi] - sortedNums[lo]) * (pos - lo);
+}
+
+const sb = createClient(
+  process.env.SUPABASE_URL,
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_KEY
+);
+
+const { count: expected, error: cErr } = await sb
+  .from('eva_vision_scores').select('*', { count: 'exact', head: true });
+if (cErr) throw new Error('count failed: ' + cErr.message);
+
+const byRubric = new Map();
+let seen = 0, nullScores = 0;
+
+for (let from = 0; from < expected; from += PAGE) {
+  const { data, error } = await sb
+    .from('eva_vision_scores')
+    .select('total_score, dimension_scores')
+    .order('id', { ascending: true })
+    .range(from, from + PAGE - 1);
+  if (error) throw new Error(`page ${from} failed: ${error.message}`);
+  if (!data || data.length === 0) break;
+  for (const row of data) {
+    seen++;
+    const rubric = identifyRubric(row.dimension_scores);
+    if (!byRubric.has(rubric)) byRubric.set(rubric, []);
+    const s = row.total_score;
+    if (typeof s !== 'number' || !Number.isFinite(s)) { nullScores++; continue; }
+    byRubric.get(rubric).push(s);
+  }
+}
+
+// A census that silently read fewer rows than exist reports a clean-looking number for a
+// population it never saw.
+console.log(`expected=${expected} seen=${seen} ${seen === expected ? 'OK' : '*** INCOMPLETE ***'}`);
+console.log(`rows with non-numeric total_score = ${nullScores}\n`);
+
+const GRID = [0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90];
+const rows = [...byRubric.entries()].sort((a, b) => b[1].length - a[1].length);
+
+console.log('rubric                 n  ' + GRID.map(q => ('p' + Math.round(q * 100)).padStart(6)).join(''));
+for (const [rubric, scores] of rows) {
+  const s = [...scores].sort((a, b) => a - b);
+  if (s.length === 0) { console.log(`${rubric.padEnd(20)} ${String(scores.length).padStart(5)}   (no numeric scores)`); continue; }
+  console.log(`${rubric.padEnd(20)} ${String(s.length).padStart(5)}  ` +
+    GRID.map(q => quantile(s, q).toFixed(1).padStart(6)).join(''));
+}
+
+// Emitted in paste-ready form so the table shipped in the lib is the table this run MEASURED,
+// rather than a hand-transcription of it. Hand-copying a 45-number grid is a defect waiting to
+// happen, and a mistyped calibration is invisible — it just gates slightly wrong forever.
+console.log('\n// ── paste into lib/handoff/threshold-resolver.js ──');
+console.log(`// MEASURED ${new Date().toISOString().slice(0, 10)} over ${seen} rows (full population).`);
+console.log('export const RUBRIC_QUANTILES = {');
+for (const [rubric, scores] of rows) {
+  const s = [...scores].sort((a, b) => a - b);
+  if (s.length === 0) continue;
+  console.log(`  '${rubric}': { n: ${s.length}, q: [${GRID.map(q => quantile(s, q).toFixed(1)).join(', ')}] },`);
+}
+console.log('};');

--- a/tests/unit/vision-rubric-attribution.test.js
+++ b/tests/unit/vision-rubric-attribution.test.js
@@ -1,0 +1,110 @@
+// FR-1 — a score is only comparable to a threshold once you know WHICH INSTRUMENT WROTE IT.
+// SD-FDBK-FIX-HEAL-BEFORE-COMPLETE-001.
+//
+// eva_vision_scores.total_score is written by several incommensurable instruments and read as one
+// number. Measured over the FULL table (6059/6059 rows, not a sampled page):
+//
+//   n=2537  5 dims  capabilities_present, key_changes_delivered, smoke_tests_pass, …   (heal completeness)
+//   n=1646 18 dims  A01..A07, V01..V11                                                  (vision rubric)
+//   n=1136  3 dims  elapsed_ms, semantic, structural                                    (LATENCY, not quality)
+//   n= 454  5 dims  feasibility, impact, innovation, strategic_alignment, sustainability (eva-5dim-v1)
+//
+// THE PRD PREMISE IS FALSE AND THIS FILE ENCODES THE CORRECTED ONE. FR-1 states "the discriminator
+// already exists in the data … rubric A simply carries no identifier." Measured: only 290 / 6059
+// rows (4.8%) carry rubric_snapshot.rubric at all, and mode='sd-heal' spans 3121 rows across ELEVEN
+// distinct dimension counts (5d:1322, 3d:1139, 18d:638) — one label covering the heal rubric, the
+// latency signature and the vision rubric simultaneously. Neither field discriminates. The only
+// discriminator actually present today is the DIMENSION KEY SET.
+import { describe, it, expect } from 'vitest';
+import {
+  countAddressableDimensions,
+  calculateDynamicThreshold,
+  SD_TYPE_THRESHOLDS,
+  dimScoreOf,
+} from '../../lib/handoff/threshold-resolver.js';
+
+// The four real signatures, transcribed from the census rather than invented.
+const VISION_18 = ['A01','A02','A03','A04','A05','A06','A07','V01','V02','V03','V04','V05','V06','V07','V08','V09','V10','V11'];
+const EVA_5 = ['feasibility','impact','innovation','strategic_alignment','sustainability'];
+const LATENCY_3 = ['elapsed_ms','semantic','structural'];
+
+/** Score a signature so that `addressedCount` of its dimensions clear NARROW_FEATURE_DIM_FLOOR (50). */
+function scoreSignature(keys, addressedCount) {
+  const out = {};
+  keys.forEach((k, i) => { out[k] = i < addressedCount ? 80 : 20; });
+  return out;
+}
+
+/** The number the gate ACTUALLY compares a score against, end to end. */
+function effectiveThreshold(sdType, dimensionScores, sdMetadata = null) {
+  const base = SD_TYPE_THRESHOLDS[sdType] ?? SD_TYPE_THRESHOLDS._default;
+  const { addressable, total } = countAddressableDimensions(sdType, dimensionScores, sdMetadata);
+  return calculateDynamicThreshold(base, addressable, total);
+}
+
+describe('FR-1 AC-4 — the 3-dim elapsed_ms signature is a LATENCY metric and must never be threshold-compared', () => {
+  // n=1136 rows. elapsed_ms is a DURATION IN MILLISECONDS sitting in the same JSONB column as
+  // 0-100 quality scores. Nothing in the resolver knows the difference.
+  it('elapsed_ms is not a 0-100 quality score, and the resolver currently reads it as one', () => {
+    expect(dimScoreOf(1200)).toBe(1200);   // a millisecond duration, read as a "score"
+  });
+
+  it('REFUSES to produce an effective threshold for a latency signature', () => {
+    // THE DECIDING BEHAVIOUR. On current main this signature sails through: every dimension
+    // "scores" >= 50 (1200ms trivially clears a floor meant for quality points), so all three read
+    // as addressable, no narrowing occurs, and the SD is held to the FULL base bar on the strength
+    // of a stopwatch reading. The gate must reject the signature outright, not score it.
+    const latency = { elapsed_ms: 1200, semantic: 85, structural: 90 };
+    expect(() => effectiveThreshold('feature', latency))
+      .toThrow(/latency|not a quality score|non-comparable/i);
+  });
+});
+
+describe('FR-1 — the effective threshold must not depend on WHICH INSTRUMENT scored the work', () => {
+  // THE DECIDING ASSERTION. Asserts the FINAL EFFECTIVE VALUE — the number actually compared
+  // against total_score — never an intermediate. A test on the base threshold alone would pass
+  // while the narrowing step reintroduced the whole disagreement one line later.
+  it('the same work under an 18-dim and a 5-dim rubric yields the SAME effective bar', () => {
+    // "The same work": it meaningfully addresses ~80% of whatever scope its rubric enumerates.
+    const under18 = scoreSignature(VISION_18, 14);  // 14/18 = 0.778
+    const under5  = scoreSignature(EVA_5, 4);       //  4/5  = 0.800
+
+    const t18 = effectiveThreshold('feature', under18);
+    const t5  = effectiveThreshold('feature', under5);
+
+    // On current main these are 70 and 72: the bar moves because an 18-dim instrument can express
+    // fractions a 5-dim instrument cannot. The work did not change; the ruler did.
+    expect(t18).toBe(t5);
+  });
+
+  it('a rubric with MORE dimensions does not mechanically lower the bar for identical coverage', () => {
+    // Same proportion addressed (2/3) expressed at two granularities. Any rubric-blind
+    // ratio-narrowing makes these agree by luck here and disagree elsewhere; the fix must make
+    // agreement structural rather than coincidental.
+    const coarse = scoreSignature(['a','b','c'], 2);
+    const fine   = scoreSignature(VISION_18, 12);
+    expect(effectiveThreshold('feature', coarse)).toBe(effectiveThreshold('feature', fine));
+  });
+});
+
+describe('FR-1 AC-2 — thresholds resolve on (sd_type, rubric), not sd_type alone', () => {
+  it('the resolver accepts a rubric identity and DISCRIMINATES on it', async () => {
+    // Behavioural, not a source-pin on today's constants: two named rubrics for ONE sd_type must
+    // not collapse to the same base number, because a 5-dim 80 and an 18-dim 80 are not the
+    // same claim about the work.
+    const mod = await import('../../lib/handoff/threshold-resolver.js');
+    expect(typeof mod.resolveThreshold).toBe('function');
+    expect(mod.resolveThreshold('feature', 'vision-18dim-v1'))
+      .not.toBe(mod.resolveThreshold('feature', 'eva-5dim-v1'));
+  });
+});
+
+describe('FR-1 AC-1 — every row is attributable to a NAMED rubric', () => {
+  it('identifies a rubric from its dimension key set, since 95.2% of rows declare none', () => {
+    // The backfill discriminator. mode= cannot serve: it spans 11 dimension counts.
+    const mod = require('../../lib/handoff/threshold-resolver.js');
+    expect(mod.identifyRubric(scoreSignature(VISION_18, 18))).toBe('vision-18dim-v1');
+    expect(mod.identifyRubric(scoreSignature(EVA_5, 5))).toBe('eva-5dim-v1');
+    expect(mod.identifyRubric(scoreSignature(LATENCY_3, 3))).toBe('latency-3dim');
+  });
+});

--- a/tests/unit/vision-rubric-attribution.test.js
+++ b/tests/unit/vision-rubric-attribution.test.js
@@ -1,110 +1,180 @@
 // FR-1 — a score is only comparable to a threshold once you know WHICH INSTRUMENT WROTE IT.
 // SD-FDBK-FIX-HEAL-BEFORE-COMPLETE-001.
 //
-// eva_vision_scores.total_score is written by several incommensurable instruments and read as one
-// number. Measured over the FULL table (6059/6059 rows, not a sampled page):
+// Measured over the FULL table (6059/6059 rows, paginated — a capped page grouped client-side
+// measures the cap, not the population):
 //
-//   n=2537  5 dims  capabilities_present, key_changes_delivered, smoke_tests_pass, …   (heal completeness)
-//   n=1646 18 dims  A01..A07, V01..V11                                                  (vision rubric)
-//   n=1136  3 dims  elapsed_ms, semantic, structural                                    (LATENCY, not quality)
-//   n= 454  5 dims  feasibility, impact, innovation, strategic_alignment, sustainability (eva-5dim-v1)
+//   n=2537  capabilities_present,key_changes_delivered,smoke_tests_pass,success_criteria_met,success_metrics_achieved
+//   n=1646  A01..A07,V01..V11
+//   n=1136  elapsed_ms,semantic,structural                      <- LATENCY, not quality
+//   n= 454  feasibility,impact,innovation,strategic_alignment,sustainability
 //
 // THE PRD PREMISE IS FALSE AND THIS FILE ENCODES THE CORRECTED ONE. FR-1 states "the discriminator
-// already exists in the data … rubric A simply carries no identifier." Measured: only 290 / 6059
-// rows (4.8%) carry rubric_snapshot.rubric at all, and mode='sd-heal' spans 3121 rows across ELEVEN
-// distinct dimension counts (5d:1322, 3d:1139, 18d:638) — one label covering the heal rubric, the
-// latency signature and the vision rubric simultaneously. Neither field discriminates. The only
-// discriminator actually present today is the DIMENSION KEY SET.
+// already exists in the data … rubric A simply carries no identifier." Measured: only 290/6059 rows
+// (4.8%) carry rubric_snapshot.rubric at all, and mode='sd-heal' spans 3121 rows across ELEVEN
+// distinct dimension counts. Neither field discriminates; the dimension KEY SET is the only
+// discriminator present.
 import { describe, it, expect } from 'vitest';
 import {
+  identifyRubric,
+  resolveThreshold,
+  resolveEffectiveThreshold,
+  effectiveStringency,
+  coverageBandFactor,
+  quantileFor,
   countAddressableDimensions,
   calculateDynamicThreshold,
   SD_TYPE_THRESHOLDS,
+  RUBRIC_QUANTILES,
   dimScoreOf,
 } from '../../lib/handoff/threshold-resolver.js';
 
-// The four real signatures, transcribed from the census rather than invented.
+// The real signatures, transcribed from the census rather than invented.
 const VISION_18 = ['A01','A02','A03','A04','A05','A06','A07','V01','V02','V03','V04','V05','V06','V07','V08','V09','V10','V11'];
 const EVA_5 = ['feasibility','impact','innovation','strategic_alignment','sustainability'];
+const HEAL_5 = ['capabilities_present','key_changes_delivered','smoke_tests_pass','success_criteria_met','success_metrics_achieved'];
 const LATENCY_3 = ['elapsed_ms','semantic','structural'];
 
-/** Score a signature so that `addressedCount` of its dimensions clear NARROW_FEATURE_DIM_FLOOR (50). */
-function scoreSignature(keys, addressedCount) {
+/** Score a signature so `addressed` of its dimensions clear NARROW_FEATURE_DIM_FLOOR (50). */
+function scoreSignature(keys, addressed) {
   const out = {};
-  keys.forEach((k, i) => { out[k] = i < addressedCount ? 80 : 20; });
+  keys.forEach((k, i) => { out[k] = i < addressed ? 80 : 20; });
   return out;
 }
 
-/** The number the gate ACTUALLY compares a score against, end to end. */
-function effectiveThreshold(sdType, dimensionScores, sdMetadata = null) {
-  const base = SD_TYPE_THRESHOLDS[sdType] ?? SD_TYPE_THRESHOLDS._default;
-  const { addressable, total } = countAddressableDimensions(sdType, dimensionScores, sdMetadata);
-  return calculateDynamicThreshold(base, addressable, total);
-}
-
-describe('FR-1 AC-4 — the 3-dim elapsed_ms signature is a LATENCY metric and must never be threshold-compared', () => {
-  // n=1136 rows. elapsed_ms is a DURATION IN MILLISECONDS sitting in the same JSONB column as
-  // 0-100 quality scores. Nothing in the resolver knows the difference.
-  it('elapsed_ms is not a 0-100 quality score, and the resolver currently reads it as one', () => {
-    expect(dimScoreOf(1200)).toBe(1200);   // a millisecond duration, read as a "score"
+describe('FR-1 AC-1 — every row is attributable to a NAMED rubric', () => {
+  it('identifies each rubric from its dimension key set', () => {
+    expect(identifyRubric(scoreSignature(VISION_18, 18))).toBe('vision-av-v1');
+    expect(identifyRubric(scoreSignature(EVA_5, 5))).toBe('eva-5dim-v1');
+    expect(identifyRubric(scoreSignature(HEAL_5, 5))).toBe('sd-heal-5dim-v1');
+    expect(identifyRubric(scoreSignature(LATENCY_3, 3))).toBe('latency-3dim');
   });
 
-  it('REFUSES to produce an effective threshold for a latency signature', () => {
-    // THE DECIDING BEHAVIOUR. On current main this signature sails through: every dimension
-    // "scores" >= 50 (1200ms trivially clears a floor meant for quality points), so all three read
-    // as addressable, no narrowing occurs, and the SD is held to the FULL base bar on the strength
-    // of a stopwatch reading. The gate must reject the signature outright, not score it.
-    const latency = { elapsed_ms: 1200, semantic: 85, structural: 90 };
-    expect(() => effectiveThreshold('feature', latency))
-      .toThrow(/latency|not a quality score|non-comparable/i);
+  it('separates the TWO different 5-dimension rubrics — dimension count alone would merge them', () => {
+    // eva-5dim and sd-heal-5dim are both 5 wide. A count-based classifier reports one rubric here
+    // and silently pools 2537 heal rows with 454 eva rows.
+    expect(identifyRubric(scoreSignature(EVA_5, 5)))
+      .not.toBe(identifyRubric(scoreSignature(HEAL_5, 5)));
+  });
+
+  it('returns unregistered for an unknown signature instead of defaulting to a real rubric', () => {
+    // 76 distinct signatures exist. Quietly treating an unknown one as the vision rubric would
+    // reintroduce the cross-instrument comparison this whole function prevents.
+    expect(identifyRubric({ alignment: 80, clarity: 70 })).toBe('unregistered');
+    for (const v of [null, undefined, [], {}, 'a string snapshot']) {
+      expect(identifyRubric(v)).toBe('unregistered');
+    }
   });
 });
 
-describe('FR-1 — the effective threshold must not depend on WHICH INSTRUMENT scored the work', () => {
-  // THE DECIDING ASSERTION. Asserts the FINAL EFFECTIVE VALUE — the number actually compared
-  // against total_score — never an intermediate. A test on the base threshold alone would pass
-  // while the narrowing step reintroduced the whole disagreement one line later.
-  it('the same work under an 18-dim and a 5-dim rubric yields the SAME effective bar', () => {
-    // "The same work": it meaningfully addresses ~80% of whatever scope its rubric enumerates.
-    const under18 = scoreSignature(VISION_18, 14);  // 14/18 = 0.778
-    const under5  = scoreSignature(EVA_5, 4);       //  4/5  = 0.800
-
-    const t18 = effectiveThreshold('feature', under18);
-    const t5  = effectiveThreshold('feature', under5);
-
-    // On current main these are 70 and 72: the bar moves because an 18-dim instrument can express
-    // fractions a 5-dim instrument cannot. The work did not change; the ruler did.
-    expect(t18).toBe(t5);
+describe('FR-1 AC-4 — the elapsed_ms signature is a LATENCY metric and is never threshold-compared', () => {
+  it('elapsed_ms is read verbatim as a "score" by the scorer', () => {
+    expect(dimScoreOf(1200)).toBe(1200);   // milliseconds, in a 0-100 column
   });
 
-  it('a rubric with MORE dimensions does not mechanically lower the bar for identical coverage', () => {
-    // Same proportion addressed (2/3) expressed at two granularities. Any rubric-blind
-    // ratio-narrowing makes these agree by luck here and disagree elsewhere; the fix must make
-    // agreement structural rather than coincidental.
-    const coarse = scoreSignature(['a','b','c'], 2);
-    const fine   = scoreSignature(VISION_18, 12);
-    expect(effectiveThreshold('feature', coarse)).toBe(effectiveThreshold('feature', fine));
+  it('a millisecond duration clears the QUALITY floor by magnitude alone', () => {
+    // This is WHY the signature is dangerous rather than merely odd: 1200 >= 50, so the stopwatch
+    // reading counts as a fully-addressed dimension, no narrowing occurs, and the SD is held to the
+    // full base bar on the strength of it. 1136 rows.
+    const { addressable, total } = countAddressableDimensions('feature', { elapsed_ms: 1200, semantic: 85, structural: 90 });
+    expect(addressable).toBe(3);
+    expect(total).toBe(3);
+  });
+
+  it('REFUSES to produce an effective threshold for it', () => {
+    expect(() => resolveEffectiveThreshold('feature', { elapsed_ms: 1200, semantic: 85, structural: 90 }))
+      .toThrow(/latency|not a quality score/i);
+  });
+
+  it('refuses an UNREGISTERED signature with a DIFFERENT error than the latency refusal', () => {
+    // Two distinct facts. Collapsing them into one "cannot score" is the FR-4 defect in miniature:
+    // a policy refusal and an unknown scale look identical and neither can be acted on.
+    expect(() => resolveEffectiveThreshold('feature', { alignment: 80, clarity: 70 }))
+      .toThrow(/unregistered/i);
+    expect(() => resolveEffectiveThreshold('feature', { alignment: 80, clarity: 70 }))
+      .not.toThrow(/latency/i);
   });
 });
 
 describe('FR-1 AC-2 — thresholds resolve on (sd_type, rubric), not sd_type alone', () => {
-  it('the resolver accepts a rubric identity and DISCRIMINATES on it', async () => {
-    // Behavioural, not a source-pin on today's constants: two named rubrics for ONE sd_type must
-    // not collapse to the same base number, because a 5-dim 80 and an 18-dim 80 are not the
-    // same claim about the work.
-    const mod = await import('../../lib/handoff/threshold-resolver.js');
-    expect(typeof mod.resolveThreshold).toBe('function');
-    expect(mod.resolveThreshold('feature', 'vision-18dim-v1'))
-      .not.toBe(mod.resolveThreshold('feature', 'eva-5dim-v1'));
+  it('two rubrics under ONE sd_type do not collapse to the same number', () => {
+    // Behavioural, not a source-pin on today's constants.
+    expect(resolveThreshold('feature', 'vision-av-v1'))
+      .not.toBe(resolveThreshold('feature', 'eva-5dim-v1'));
+  });
+
+  it('the spread is MEASURED, not invented — the medians really are 19 points apart', () => {
+    const median = (r) => RUBRIC_QUANTILES[r].q[4];   // p50
+    expect(median('sd-heal-5dim-v1') - median('vision-av-v1')).toBeCloseTo(19.0, 1);
+  });
+
+  it('sd_type ordering is preserved within a rubric — the scale changed, not the ranking', () => {
+    // A calibration that scrambled the type hierarchy would satisfy "the numbers differ" while
+    // destroying the policy the types encode.
+    expect(resolveThreshold('feature', 'vision-av-v1'))
+      .toBeGreaterThan(resolveThreshold('documentation', 'vision-av-v1'));
   });
 });
 
-describe('FR-1 AC-1 — every row is attributable to a NAMED rubric', () => {
-  it('identifies a rubric from its dimension key set, since 95.2% of rows declare none', () => {
-    // The backfill discriminator. mode= cannot serve: it spans 11 dimension counts.
-    const mod = require('../../lib/handoff/threshold-resolver.js');
-    expect(mod.identifyRubric(scoreSignature(VISION_18, 18))).toBe('vision-18dim-v1');
-    expect(mod.identifyRubric(scoreSignature(EVA_5, 5))).toBe('eva-5dim-v1');
-    expect(mod.identifyRubric(scoreSignature(LATENCY_3, 3))).toBe('latency-3dim');
+describe('FR-1 — the STRINGENCY must not depend on which instrument scored the work', () => {
+  // THE DECIDING ASSERTION, AND A CORRECTION TO HOW IT WAS FIRST WRITTEN.
+  //
+  // The first version of this file asserted the two effective thresholds were NUMERICALLY EQUAL
+  // (it failed 70 vs 72, which is what proved the defect). That assertion is wrong as a target:
+  // the rubrics' medians are 19 points apart, so forcing them onto one number re-creates exactly
+  // the incommensurability FR-1 exists to remove. What must agree is the STRINGENCY — the
+  // percentile of its own instrument that the work is held to. The numbers must then DIFFER, and
+  // differ by the measured amount.
+  it('the same work under an 18-dim and a 5-dim rubric is held to the SAME percentile', () => {
+    const t18 = effectiveStringency('feature', 14, 18);   // 0.778 coverage
+    const t5  = effectiveStringency('feature', 4, 5);     // 0.800 coverage
+    expect(t18).toBe(t5);
+  });
+
+  it('…and that agreement is STRUCTURAL, not the arithmetic luck the old ratio relied on', () => {
+    // Under continuous ratios, 12/18 and 2/3 agreed (same fraction) while 14/18 and 4/5 did not.
+    // Banding makes every pair inside a rung agree, including the pair that used to disagree.
+    expect(coverageBandFactor(14 / 18)).toBe(coverageBandFactor(4 / 5));
+    expect(coverageBandFactor(12 / 18)).toBe(coverageBandFactor(2 / 3));
+  });
+
+  it('the resulting NUMBERS differ, because equal stringency on unequal scales must differ', () => {
+    const n18 = resolveEffectiveThreshold('feature', scoreSignature(VISION_18, 14));
+    const n5  = resolveEffectiveThreshold('feature', scoreSignature(EVA_5, 4));
+    expect(n18).not.toBe(n5);
+    // Each sits at the same percentile of its OWN distribution — that is what makes them equal.
+    const s = effectiveStringency('feature', 14, 18);
+    expect(n18).toBe(Math.round(quantileFor('vision-av-v1', s)));
+    expect(n5).toBe(Math.round(quantileFor('eva-5dim-v1', s)));
+  });
+
+  it('THE OLD MECHANISM held identical work to different stringencies — the defect, pinned', () => {
+    // Guards against a silent revert to sd_type-only + continuous-ratio narrowing. Under the old
+    // path both rubrics got base 90 and produced 70 vs 72 — two numbers on two different scales,
+    // neither comparable to the other, and nothing in the code able to notice.
+    const old = (dims, addressable, total) =>
+      calculateDynamicThreshold(SD_TYPE_THRESHOLDS.feature, addressable, total) && // eslint-disable-line no-unused-expressions
+      calculateDynamicThreshold(SD_TYPE_THRESHOLDS.feature, addressable, total);
+    expect(old(VISION_18, 14, 18)).toBe(70);
+    expect(old(EVA_5, 4, 5)).toBe(72);
+    expect(old(VISION_18, 14, 18)).not.toBe(old(EVA_5, 4, 5));
+  });
+});
+
+describe('FR-1 — the band boundaries are a POLICY, and cliffs are their stated cost', () => {
+  it('coverage either side of a rung boundary is treated differently — acknowledged, not hidden', () => {
+    expect(coverageBandFactor(0.7499)).not.toBe(coverageBandFactor(0.7500));
+  });
+
+  it('full coverage is never narrowed', () => {
+    expect(coverageBandFactor(1.0)).toBe(1.0);
+    expect(effectiveStringency('feature', 18, 18)).toBe(effectiveStringency('feature', 5, 5));
+  });
+
+  it('narrowing can never invert the tier ordering', () => {
+    // A band factor deep enough to drop a Tier-1 SD below an un-narrowed Tier-3 one would let
+    // narrowing rewrite policy. Both arms asserted so a constant factor cannot satisfy this.
+    expect(effectiveStringency('feature', 1, 18)).toBeLessThan(effectiveStringency('feature', 18, 18));
+    expect(effectiveStringency('feature', 1, 18)).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
SD-FDBK-FIX-HEAL-BEFORE-COMPLETE-001 FR-1. **Additive only — no gate changes behaviour on merge.**
56 tests pass across all 5 `threshold-resolver` consumer suites, unchanged.

## The defect, measured over the full population (6059/6059 rows)

`eva_vision_scores.total_score` is written by four incommensurable instruments and compared against **one** threshold table.

| rubric | n | p25 | p50 | p75 | p90 |
|---|---|---|---|---|---|
| `sd-heal-5dim-v1` | 2537 | 90.0 | **92.0** | 96.0 | 99.0 |
| `vision-av-v1` | 1841 | 65.0 | **73.0** | 80.0 | 85.0 |
| `eva-5dim-v1` | 454 | 78.0 | **82.0** | 84.0 | 87.0 |
| `latency-3dim` | 1136 | *not a quality score at all* | | | |

**A 19-point median gap.** A nominal threshold of 90 sits near the heal rubric's p40 — routine — and above the vision rubric's p90 — near-unreachable. One number against four distributions is four standards wearing one label.

## The PRD premise was false

FR-1 assumed the discriminator already exists in the data. It does not:

- only **290 / 6059 rows (4.8%)** carry `rubric_snapshot.rubric` at all;
- `rubric_snapshot.mode='sd-heal'` covers **3121 rows spanning eleven distinct dimension counts** (5d:1322, 3d:1139, 18d:638) — one label on the heal rubric, the latency signature and the vision rubric simultaneously.

Dimension *count* is insufficient too: two different 5-wide rubrics exist, and a count-based classifier pools 2537 heal rows with 454 eva rows. Identity is therefore derived from the exact key set, plus a family rule for the `A01`/`V01` ordinals the vision instrument emitted at widths 11–18.

## The latency signature is refused, not scored

`elapsed_ms` is a duration in **milliseconds** sharing a JSONB column with 0–100 scores. `dimScoreOf` returns it verbatim, so `1200` clears the quality floor of 50 by magnitude alone, reads as a fully-addressed dimension, suppresses narrowing, and holds the SD to the full base bar on the strength of a stopwatch. 1136 rows. Unregistered signatures throw a **separately named** error — a policy refusal and an unknown scale are different facts.

## I corrected my own deciding assertion

The red pin (fd39322) asserted the two effective thresholds were **numerically equal**; it failed `70 vs 72`, which is what proved the defect. Building to it literally would have been wrong — with medians 19 points apart, forcing both rubrics onto one number re-creates the incommensurability this fixes. What must agree is **stringency**: the percentile of its own instrument the work is held to. The numbers must then differ, by the measured amount. Both are asserted.

## Policy decision, recorded as one

A coverage band now shifts the **target percentile** rather than multiplying a number, so cross-rubric agreement is structural instead of arithmetic luck (12/18 and 2/3 agreed; 14/18 and 4/5 did not). Rungs: `>=0.90 / >=0.75 / >=0.60 / floor`. Escalated with three options; taken as (a) after no reply, per a pre-committed rule. **Stated cost:** banding creates cliffs — 0.749 and 0.750 land either side of a rung. Asserted in the tests rather than left to be discovered.

Option (c), per-rubric calibrated bases, also ships: I had said it needed calibration data nobody had, then measured the full population and found it does exist. Bases are derived from measured quantiles, and the calibration script imports `identifyRubric` **from the lib** so calibration and runtime cannot drift.

## Deliberately not wired into any gate

Gates keep calling `SD_TYPE_THRESHOLDS` + `calculateDynamicThreshold`. Migrating one is a separate change with its own blast radius — it moves every threshold on every scoring SD, and that needs a decision, not a drive-by.

## Mutation-proven (6/6)

The harness **aborts** if a pattern fails to match, because a no-op mutation reports "tests passed" and is indistinguishable from a survivor.

| mutant | verdict |
|---|---|
| `identifyRubric` always says vision | killed by 2 |
| latency refusal removed | killed by 1 |
| coverage banding flattened to no-op | killed by 2 |
| `resolveThreshold` ignores the rubric | killed by 1 |
| stringency ignores coverage entirely | killed by 1 |
| exact match degraded to length-only | killed by 3 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)