### PR TITLE
fix(SD-LEO-INFRA-FIVE-GUARDS-WIRED-001): five CI guards were unreachable, not merely quiet

### DIFF
--- a/.github/workflows/alter-default-override-lint.yml
+++ b/.github/workflows/alter-default-override-lint.yml
@@ -18,10 +18,30 @@ on:
       # AC-5: migrations that could change a default ...
       - 'database/migrations/**/*.sql'
       # ... and the known writer paths (where inserts/upserts live) ...
-      - 'scripts/**/*.{js,mjs,cjs,ts}'
-      - 'lib/**/*.{js,mjs,cjs,ts}'
-      - 'server/**/*.{js,mjs,cjs,ts}'
-      - 'api/**/*.{js,mjs,cjs,ts}'
+      #
+      # SD-LEO-INFRA-FIVE-GUARDS-WIRED-001: these 16 entries were PREVIOUSLY four brace-globs
+      # ('scripts/**/*.{js,mjs,cjs,ts}' and siblings). GitHub Actions does not expand brace
+      # alternation, so each matched only a literal filename ending in ".{js,mjs,cjs,ts}" —
+      # nothing. This workflow was NOT dormant (539 runs) because line 19's migrations glob is
+      # brace-free and fires normally; it was PARTIALLY wired, covering the migration half of
+      # its own drift class while never once evaluating the writer paths it exists to
+      # cross-check. A green check reading as full coverage is the more dangerous failure.
+      - 'scripts/**/*.js'
+      - 'scripts/**/*.mjs'
+      - 'scripts/**/*.cjs'
+      - 'scripts/**/*.ts'
+      - 'lib/**/*.js'
+      - 'lib/**/*.mjs'
+      - 'lib/**/*.cjs'
+      - 'lib/**/*.ts'
+      - 'server/**/*.js'
+      - 'server/**/*.mjs'
+      - 'server/**/*.cjs'
+      - 'server/**/*.ts'
+      - 'api/**/*.js'
+      - 'api/**/*.mjs'
+      - 'api/**/*.cjs'
+      - 'api/**/*.ts'
       # ... and the lint itself.
       - 'scripts/lint/alter-default-override-lint.mjs'
       - 'scripts/lint/alter-default-override-allowlist.json'

--- a/.github/workflows/count-delta-gate-lint.yml
+++ b/.github/workflows/count-delta-gate-lint.yml
@@ -17,9 +17,25 @@ name: Count-Delta Gate Assertion Lint
 on:
   pull_request:
     paths:
-      - 'scripts/ci/**/*.{js,mjs,cjs,ts,tsx}'
-      - 'scripts/hooks/**/*.{js,mjs,cjs,ts,tsx}'
-      - 'scripts/modules/**/*.{js,mjs,cjs,ts,tsx}'
+      # SD-LEO-INFRA-FIVE-GUARDS-WIRED-001: these 15 entries were PREVIOUSLY three brace-globs.
+      # GitHub Actions does not expand brace alternation, so they matched nothing and this
+      # workflow had run EXACTLY ONCE EVER — on its own introducing PR, matched by the literal
+      # machinery entries below. It has never evaluated a single one of the ~710 files it scans.
+      - 'scripts/ci/**/*.js'
+      - 'scripts/ci/**/*.mjs'
+      - 'scripts/ci/**/*.cjs'
+      - 'scripts/ci/**/*.ts'
+      - 'scripts/ci/**/*.tsx'
+      - 'scripts/hooks/**/*.js'
+      - 'scripts/hooks/**/*.mjs'
+      - 'scripts/hooks/**/*.cjs'
+      - 'scripts/hooks/**/*.ts'
+      - 'scripts/hooks/**/*.tsx'
+      - 'scripts/modules/**/*.js'
+      - 'scripts/modules/**/*.mjs'
+      - 'scripts/modules/**/*.cjs'
+      - 'scripts/modules/**/*.ts'
+      - 'scripts/modules/**/*.tsx'
       - 'eslint-rules/no-count-delta-gate-assertion.js'
       - 'scripts/lint/count-delta-gate-lint.mjs'
       - '.github/workflows/count-delta-gate-lint.yml'

--- a/.github/workflows/ismainmodule-classguard-lint.yml
+++ b/.github/workflows/ismainmodule-classguard-lint.yml
@@ -19,7 +19,21 @@ name: isMainModule Raw-Pattern Class Guard Lint
 on:
   pull_request:
     paths:
-      - 'scripts/**/*.{js,mjs,cjs,ts,tsx}'
+      # SD-LEO-INFRA-FIVE-GUARDS-WIRED-001: these 5 entries were PREVIOUSLY one brace-glob.
+      # GitHub Actions does not expand brace alternation, so it matched nothing and this
+      # workflow had run EXACTLY ONCE EVER — on its own introducing PR. SEVEN raw-pattern
+      # violations landed in scripts/** during the 32 days it was inert, every one of them
+      # AFTER the guard shipped. The header above claims this workflow "blocks ANY raw-pattern
+      # instance from day one, with zero exceptions"; that claim was true in intent and false
+      # in fact, and the allow-list is empty because nothing was grandfathered — the guard
+      # simply could not see them. All 7 are converted in the SAME commit as this expansion:
+      # the driver scans the whole tree rather than the PR diff, so enabling the filter first
+      # would red-line every scripts/** PR across the fleet.
+      - 'scripts/**/*.js'
+      - 'scripts/**/*.mjs'
+      - 'scripts/**/*.cjs'
+      - 'scripts/**/*.ts'
+      - 'scripts/**/*.tsx'
       - 'eslint-rules/no-raw-ismainmodule-comparison.js'
       - 'scripts/lint/ismainmodule-classguard-lint.mjs'
       - 'scripts/lint/ismainmodule-classguard-allowlist.json'

--- a/.github/workflows/realtime-subscribe-teardown-recursion-lint.yml
+++ b/.github/workflows/realtime-subscribe-teardown-recursion-lint.yml
@@ -20,8 +20,21 @@ name: Realtime Subscribe Teardown Recursion Lint
 on:
   pull_request:
     paths:
-      - 'lib/**/*.{js,mjs,cjs,ts,tsx}'
-      - 'server/**/*.{js,mjs,cjs,ts,tsx}'
+      # SD-LEO-INFRA-FIVE-GUARDS-WIRED-001: these 10 entries were PREVIOUSLY two brace-globs.
+      # GitHub Actions does not expand brace alternation, so they matched nothing and this
+      # workflow had run EXACTLY ONCE EVER — on its own introducing PR. The crash class it
+      # guards was fixed independently 3x before the guard existed; the guard then spent 32
+      # days unable to see the ~2116 files under lib/ and server/ it was written to police.
+      - 'lib/**/*.js'
+      - 'lib/**/*.mjs'
+      - 'lib/**/*.cjs'
+      - 'lib/**/*.ts'
+      - 'lib/**/*.tsx'
+      - 'server/**/*.js'
+      - 'server/**/*.mjs'
+      - 'server/**/*.cjs'
+      - 'server/**/*.ts'
+      - 'server/**/*.tsx'
       - 'eslint-rules/no-realtime-teardown-in-subscribe-callback.js'
       - 'scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs'
       - '.github/workflows/realtime-subscribe-teardown-recursion-lint.yml'

--- a/.github/workflows/workflow-path-filter-lint.yml
+++ b/.github/workflows/workflow-path-filter-lint.yml
@@ -1,0 +1,60 @@
+name: Workflow Path-Filter Lint
+
+# SD-LEO-INFRA-FIVE-GUARDS-WIRED-001 (FR-3 / FR-4)
+#
+# Blocks any PR that introduces a brace-alternation entry in a workflow `paths:` or
+# `paths-ignore:` block. GitHub Actions does NOT expand brace alternation, so an entry
+# written as 'scripts/**/*.{js,mjs,cjs,ts}' matches only a literal filename ending in
+# ".{js,mjs,cjs,ts}" — nothing. The workflow reads as wired, reports green, and never fires
+# on the source it exists to police.
+#
+# Five workflows in this repo were written that way. Three had run EXACTLY ONCE EVER, on
+# their own introducing PR. The class was fixed once, in one workflow, WITHOUT a guard — so
+# it stayed free to recur, and it did, four more times. This is the guard.
+#
+# ── WHY THIS WORKFLOW HAS NO `paths:` KEY ────────────────────────────────────────────────
+# THIS IS THE MOST IMPORTANT LINE IN THE FILE. If this workflow filtered itself by path, that
+# filter could carry the very defect this lint detects, and the guard would be silently
+# disabled by the bug it exists to catch — which is exactly how the original five failed.
+# It therefore runs on EVERY pull request, unconditionally. The scan is a parse of ~171 small
+# YAML files and costs seconds.
+#
+# Reviewer's at-a-glance check, which is the property the guard enforces applied to itself:
+#     sed -n '/^on:/,/^concurrency:/p' .github/workflows/workflow-path-filter-lint.yml | grep -c '{'
+# must print 0.
+#
+# Precedent: ssl-bypass-lint.yml is an always-on lint whose subject is also .github/workflows/**.
+# Unlike that one, this lint does NOT exclude its own file from the scan — a guard that skips
+# itself cannot verify the one file whose correctness it most depends on.
+#
+# GENUINELY BLOCKING (no continue-on-error): matches the posture of count-delta-gate-lint.yml
+# and ismainmodule-classguard-lint.yml. There is deliberately no allow-list — a path filter
+# that matches nothing has no legitimate use. If a filter is meant to match nothing, the entry
+# should be deleted, not written in a form that silently cannot fire.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  workflow-path-filter-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - name: Detect brace-alternation path filters (which match nothing)
+        run: node scripts/lint/workflow-path-filter-lint.mjs
+      # Paired with the parse check, which until now was enforced ONLY by a local pre-commit
+      # hook and by no CI workflow at all — so an unparseable workflow could reach main from
+      # any contributor who committed with --no-verify.
+      - name: Verify every workflow file still parses
+        run: node scripts/check-workflow-yaml.mjs

--- a/.github/workflows/workflow-path-filter-lint.yml
+++ b/.github/workflows/workflow-path-filter-lint.yml
@@ -21,7 +21,10 @@ name: Workflow Path-Filter Lint
 #
 # Reviewer's at-a-glance check, which is the property the guard enforces applied to itself:
 #     sed -n '/^on:/,/^concurrency:/p' .github/workflows/workflow-path-filter-lint.yml | grep -c '{'
-# must print 0.
+# must print 0. NOTE: that heuristic is for THIS FILE ONLY. Run against a workflow whose
+# comments discuss brace-globs (alter-default-override-lint.yml does) it prints a non-zero
+# count for comment text, which is a false positive — the authority is the lint itself, which
+# reads the PARSED paths: arrays and never the surrounding prose.
 #
 # Precedent: ssl-bypass-lint.yml is an always-on lint whose subject is also .github/workflows/**.
 # Unlike that one, this lint does NOT exclude its own file from the scan — a guard that skips
@@ -41,6 +44,12 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+
+# Least privilege: this job only reads the checkout. It runs on `pull_request` (never
+# `pull_request_target`), so a fork PR already gets a read-only token and no secrets; the
+# explicit grant makes that the stated contract rather than a default someone could change.
+permissions:
+  contents: read
 
 jobs:
   workflow-path-filter-lint:

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -885,6 +885,12 @@ echo "🔧 Checking staged workflow YAML..."
 STAGED_WORKFLOWS=$(git diff --cached --name-only --diff-filter=ACM | grep -E '^\.github/workflows/.*\.(yml|yaml)$' || true)
 if [ -n "$STAGED_WORKFLOWS" ]; then
   node scripts/check-workflow-yaml.mjs $STAGED_WORKFLOWS || exit 1
+  # SD-LEO-INFRA-FIVE-GUARDS-WIRED-001 (FR-4): same staged set, second rule — a brace-glob
+  # path filter parses perfectly and matches NOTHING, so the parse check above cannot see it.
+  # Catching it here means the author learns at commit time rather than discovering months
+  # later that a guard has run once ever. CI enforces it too (workflow-path-filter-lint.yml);
+  # this hook is the earlier, bypassable half, not the authority.
+  node scripts/lint/workflow-path-filter-lint.mjs $STAGED_WORKFLOWS || exit 1
 else
   echo "✅ No workflow files staged — skipping workflow-YAML gate"
 fi

--- a/scripts/apa-fixture-ratification-capture.mjs
+++ b/scripts/apa-fixture-ratification-capture.mjs
@@ -24,6 +24,7 @@
 import { createClient } from '@supabase/supabase-js';
 import 'dotenv/config';
 import { recordDisposition } from '../lib/decision-binding/disposition.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 function parseArgs(argv) {
   const out = { fixtureSet: null, confirmed: [], flagged: [], authority: 'chairman' };
@@ -93,7 +94,7 @@ async function main() {
   console.log(`\n${results.length} ratification(s) captured for fixture-set "${args.fixtureSet}".`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isMainModule(import.meta.url)) {
   main().catch((err) => {
     console.error('apa-fixture-ratification-capture: FAILED:', err.message);
     process.exit(1);

--- a/scripts/audit/control-seed-test.mjs
+++ b/scripts/audit/control-seed-test.mjs
@@ -52,6 +52,7 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { readFileSync } from 'node:fs';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
 
 const VERDICT = Object.freeze({
   BLOCKS: 'BLOCKS',        // detected AND non-zero exit — actually stops a merge
@@ -222,6 +223,6 @@ function main() {
   process.exitCode = 0;
 }
 
-if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('control-seed-test.mjs')) main();
+if (isMainModule(import.meta.url)) main();
 
 export { VERDICT };

--- a/scripts/consult-answer-bind.mjs
+++ b/scripts/consult-answer-bind.mjs
@@ -18,6 +18,7 @@
 import { createClient } from '@supabase/supabase-js';
 import 'dotenv/config';
 import { recordDisposition } from '../lib/decision-binding/disposition.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 /**
  * Bind a delivered consult answer to the SD-metadata blocked-state it
@@ -102,7 +103,7 @@ async function main() {
   console.log(`Consult answer bound: question_key=${result.disposition.payload.question_key}, SD "${args.sdKey}".${args.blockedStateKey} unblocked.`);
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isMainModule(import.meta.url)) {
   main().catch((err) => {
     console.error('consult-answer-bind: FAILED:', err.message);
     process.exit(1);

--- a/scripts/dispatch-auth-would-deny-report.mjs
+++ b/scripts/dispatch-auth-would-deny-report.mjs
@@ -19,6 +19,7 @@ import 'dotenv/config';
 import { createSupabaseServiceClient } from './lib/supabase-connection.js';
 import { WOULD_DENY_EVENT_TYPE } from '../lib/claim/gates/dispatch-authorization.cjs';
 import { fetchAllPaginated } from '../lib/db/fetch-all-paginated.mjs';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 /**
  * @param {object} supabase
@@ -78,7 +79,7 @@ async function main() {
   console.log('='.repeat(60));
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+if (isMainModule(import.meta.url)) {
   main().catch((err) => {
     console.error(err);
     process.exit(1);

--- a/scripts/fleet-kill.mjs
+++ b/scripts/fleet-kill.mjs
@@ -22,6 +22,7 @@ import { gracefulKillSession, isGracefulKillEnabled } from '../lib/fleet/gracefu
 import { sampleToolActivityTwice } from '../lib/fleet/release-work-item.mjs';
 import { bestEffortReleaseSd } from '../lib/fleet/best-effort-release.mjs';
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 const require = createRequire(import.meta.url);
 const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
@@ -127,7 +128,7 @@ async function main() {
   process.exit(verdict.outcome === 'killed' ? 0 : 1);
 }
 
-if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('fleet-kill.mjs')) {
+if (isMainModule(import.meta.url)) {
   main().catch((err) => {
     console.error(`fleet-kill failed: ${(err && err.message) || err}`);
     process.exit(1);

--- a/scripts/guard-firing-characterization.mjs
+++ b/scripts/guard-firing-characterization.mjs
@@ -27,6 +27,7 @@
  */
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 /**
  * Guards in scope. `action` is the event a guard writes WHEN IT FIRES; `denominator` is the event
@@ -116,6 +117,6 @@ async function main() {
   console.log('  that surface is NOT covered here and is named in the completion flags.\n');
 }
 
-if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('guard-firing-characterization.mjs')) {
+if (isMainModule(import.meta.url)) {
   main().catch((e) => { console.error('FATAL:', e.message); process.exitCode = 1; });
 }

--- a/scripts/lint/workflow-path-filter-lint.mjs
+++ b/scripts/lint/workflow-path-filter-lint.mjs
@@ -108,9 +108,14 @@ export function collectPathEntries(doc) {
   for (const [trigger, cfg] of Object.entries(on)) {
     if (!cfg || typeof cfg !== 'object') continue;
     for (const key of ['paths', 'paths-ignore']) {
-      const arr = cfg[key];
-      if (!Array.isArray(arr)) continue;
-      for (const entry of arr) {
+      const raw = cfg[key];
+      if (raw === undefined || raw === null) continue;
+      // A scalar `paths: 'scripts/**/*.{js,ts}'` is not the shape GitHub Actions documents,
+      // but skipping it because it is not an Array is precisely the failure this whole lint
+      // exists to prevent: a guard that silently declines to look at something. Normalise
+      // instead, so an off-spec shape is still EXAMINED rather than passed over in silence.
+      const entries = Array.isArray(raw) ? raw : [raw];
+      for (const entry of entries) {
         if (typeof entry === 'string') out.push({ trigger, key, entry });
       }
     }

--- a/scripts/lint/workflow-path-filter-lint.mjs
+++ b/scripts/lint/workflow-path-filter-lint.mjs
@@ -1,0 +1,263 @@
+#!/usr/bin/env node
+/**
+ * Workflow path-filter lint — SD-LEO-INFRA-FIVE-GUARDS-WIRED-001 (FR-3).
+ *
+ * GitHub Actions `paths:` filters DO NOT EXPAND BRACE ALTERNATION. A filter written as
+ * `scripts/**\/*.{js,mjs,cjs,ts}` matches only a literal filename ending in the seven
+ * characters `.{js,mjs,cjs,ts}` — i.e. nothing at all. The workflow stays green, appears
+ * wired, and never runs on the source it exists to police.
+ *
+ * THE FAILURE THIS EXISTS FOR. Five lint workflows in this repo were written that way.
+ * Measured at the time of the fix: count-delta-gate-lint, ismainmodule-classguard-lint and
+ * realtime-subscribe-teardown-recursion-lint had each run EXACTLY ONCE EVER — on their own
+ * introducing PR, matched by the literal `.github/workflows/<self>.yml` entry sitting beside
+ * the dead brace-glob. Zero runs since, across 488 `scripts/**` and 1436 `lib/**` file
+ * touches. A sixth workflow, session-coordination-insert-classguard-lint, was corrected on
+ * 2026-08-03 and went from 3 runs ever to 24 runs in a single day. That before/after is the
+ * whole argument: the mechanism is not theoretical, and the fix is not cosmetic.
+ *
+ * Seven violations of the ismainmodule class landed in `scripts/**` during the 32 days its
+ * guard was inert. Every one of them postdates the guard. Nothing was grandfathered — the
+ * guard simply could not see them.
+ *
+ * WHY THIS GUARD EXISTS RATHER THAN JUST FIXING THE FIVE. The class had already been fixed
+ * once, in one workflow, without a guard — which left it free to recur, and it did, four
+ * more times. A defect that recurs after a fix is not merely unfinished; it is unprotected.
+ * This is the single representation that makes instance six detectable instead of waiting
+ * for someone to notice a run count of 1.
+ *
+ * ── TWO CALIBRATIONS THAT MUST NOT DRIFT ─────────────────────────────────────────────────
+ *
+ * 1. `nobrace: true` IS LOAD-BEARING. minimatch expands braces BY DEFAULT, which is the
+ *    exact opposite of GitHub Actions. A matcher used with default options reports 4729
+ *    matches for the dead ismainmodule filter and GOES GREEN ON THE BUG — the instrument
+ *    built to detect the ambiguity commits it on its first run. GHA_MATCH_OPTS is exported
+ *    and asserted in the test suite so this cannot be silently dropped.
+ *
+ * 2. WE PARSE, WE DO NOT GREP. A textual scan for `{...,...}` also hits roughly 25 legitimate
+ *    `${{ }}` template expressions in `run:` and `github-script` bodies. Reading the parsed
+ *    `paths:`/`paths-ignore:` arrays makes those false positives structurally impossible
+ *    rather than filtered-out-by-hand.
+ *
+ * SCOPE IS DELIBERATELY NARROW. A survey of all 353 path entries in this repo found brace
+ * alternation to be the ONLY syntax-level defect class present: zero leading `./`, zero
+ * leading `/`, zero character classes, zero extglob, zero backslashes, zero negation. A
+ * separate population of 23 filters is dead by TARGET ABSENCE (the directory or extension
+ * does not exist) — a different root cause with a different blast radius, reported rather
+ * than folded in here, because a zero-match rule would fail against all 23 on day one.
+ *
+ * Usage:
+ *   node scripts/lint/workflow-path-filter-lint.mjs            # walk .github/workflows/
+ *   node scripts/lint/workflow-path-filter-lint.mjs <file...>  # check specific file(s)
+ */
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join, extname } from 'node:path';
+import yaml from 'js-yaml';
+
+const WORKFLOW_DIR = '.github/workflows';
+
+/**
+ * Match options that mirror GitHub Actions path-filter semantics.
+ *
+ * `nobrace` is not a preference — see calibration note 1 in the file header. Exported so a
+ * test can assert it, because the failure mode of losing it is a silently passing lint.
+ */
+export const GHA_MATCH_OPTS = Object.freeze({ nobrace: true, dot: true });
+
+/** A brace group. GHA expands none of these, so any occurrence in a path entry is dead. */
+const BRACE_GROUP = /\{([^{}]*)\}/g;
+
+/**
+ * PURE: does this single path-filter entry contain a brace group?
+ * @param {string} entry
+ * @returns {boolean}
+ */
+export function hasBraceAlternation(entry) {
+  if (typeof entry !== 'string') return false;
+  BRACE_GROUP.lastIndex = 0;
+  return BRACE_GROUP.test(entry);
+}
+
+/**
+ * PURE: expand a brace-glob entry into the literal entries it was MEANT to be.
+ * Only the first brace group is expanded — nothing in this repo nests them, and emitting a
+ * combinatorial suggestion for a case that does not exist would be noise.
+ * @param {string} entry
+ * @returns {string[]} the corrected entries, or [entry] when there is nothing to expand
+ */
+export function expandBraceEntry(entry) {
+  const m = /\{([^{}]*)\}/.exec(entry);
+  if (!m) return [entry];
+  const alternatives = m[1].split(',').map((s) => s.trim()).filter(Boolean);
+  if (alternatives.length === 0) return [entry];
+  return alternatives.map((alt) => entry.slice(0, m.index) + alt + entry.slice(m.index + m[0].length));
+}
+
+/**
+ * Collect every `paths:` / `paths-ignore:` entry from a parsed workflow document, tagged with
+ * the trigger and key it came from so a report can say WHERE precisely.
+ * @param {object} doc  parsed workflow YAML
+ * @returns {Array<{trigger: string, key: string, entry: string}>}
+ */
+export function collectPathEntries(doc) {
+  const out = [];
+  // js-yaml v4 uses the YAML 1.2 core schema, where `on` is a plain string key. The
+  // doc[true] fallback covers a 1.1-style parse rather than assuming which one ran.
+  const on = doc?.on ?? doc?.[true];
+  if (!on || typeof on !== 'object') return out;
+  for (const [trigger, cfg] of Object.entries(on)) {
+    if (!cfg || typeof cfg !== 'object') continue;
+    for (const key of ['paths', 'paths-ignore']) {
+      const arr = cfg[key];
+      if (!Array.isArray(arr)) continue;
+      for (const entry of arr) {
+        if (typeof entry === 'string') out.push({ trigger, key, entry });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Best-effort 1-indexed line number for a path entry, by locating it in the raw source.
+ * Reported as null rather than guessed when it cannot be found — a wrong line number sends a
+ * reader to the wrong place, which is worse than sending them to the file.
+ * @param {string} raw
+ * @param {string} entry
+ * @returns {number|null}
+ */
+export function findEntryLine(raw, entry) {
+  const lines = String(raw).split(/\r?\n/);
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.includes(entry)) continue;
+    // Must be a sequence item (`- <entry>`), not a mention inside a run: body.
+    if (/^\s*-\s*['"]?/.test(line)) return i + 1;
+  }
+  return null;
+}
+
+/**
+ * PURE over a YAML STRING — the shape the fixture tests drive, so they need no filesystem.
+ *
+ * @param {string} yamlString
+ * @param {{filename?: string}} [opts]
+ * @returns {{ok: boolean, parsed: boolean, error?: string, violations: Array<object>}}
+ *   `parsed:false` means the file could not be read as YAML. That is NOT a clean result —
+ *   callers must surface it as an INCOMPLETE scan, never fold it into a zero.
+ */
+export function findBraceGlobEntries(yamlString, { filename = '<string>' } = {}) {
+  let doc;
+  try {
+    doc = yaml.load(yamlString);
+  } catch (e) {
+    return {
+      ok: false,
+      parsed: false,
+      error: String(e && e.message ? e.message : e).split('\n')[0],
+      violations: [],
+    };
+  }
+  const violations = [];
+  for (const { trigger, key, entry } of collectPathEntries(doc)) {
+    if (!hasBraceAlternation(entry)) continue;
+    violations.push({
+      file: filename,
+      line: findEntryLine(yamlString, entry),
+      trigger,
+      key,
+      entry,
+      expansion: expandBraceEntry(entry),
+    });
+  }
+  return { ok: violations.length === 0, parsed: true, violations };
+}
+
+/**
+ * Resolve which workflow files to check: explicit CLI args when given, else a sorted walk.
+ * Mirrors scripts/check-workflow-yaml.mjs so the two behave the same from the command line.
+ * @param {string[]} args
+ * @returns {string[]}
+ */
+export function resolveWorkflowFiles(args = []) {
+  if (args.length > 0) return args;
+  if (!existsSync(WORKFLOW_DIR)) return [];
+  return readdirSync(WORKFLOW_DIR)
+    .filter((f) => ['.yml', '.yaml'].includes(extname(f)))
+    .sort()
+    // Forward slashes always. On Windows join() emits backslashes, and a reported path a
+    // reader copies into a workflow file or a grep has to be in the repo's own idiom —
+    // GitHub Actions path filters are forward-slash, on every platform.
+    .map((f) => join(WORKFLOW_DIR, f).split(/[\\/]/).join('/'));
+}
+
+function main() {
+  const files = resolveWorkflowFiles(process.argv.slice(2));
+  if (files.length === 0) {
+    console.error('[WORKFLOW_PATH_FILTER] no workflow files found to check');
+    process.exitCode = 1;
+    return;
+  }
+
+  const violations = [];
+  const unreadable = [];
+
+  for (const file of files) {
+    let raw;
+    try {
+      raw = readFileSync(file, 'utf8');
+    } catch (e) {
+      unreadable.push({ file, error: `cannot read: ${e.message}` });
+      continue;
+    }
+    const res = findBraceGlobEntries(raw, { filename: file });
+    if (!res.parsed) {
+      unreadable.push({ file, error: res.error });
+      continue;
+    }
+    violations.push(...res.violations);
+  }
+
+  // An unreadable file is reported BEFORE any verdict, because a scan that skipped a file
+  // has not established that the file is clean — and "0 violations" printed over a partial
+  // scan is exactly the shape of false assurance this whole SD is about.
+  if (unreadable.length > 0) {
+    console.error(
+      `❌ workflow-path-filter-lint: ${violations.length} brace-alternation entr${violations.length === 1 ? 'y' : 'ies'} found, ` +
+      `but ${unreadable.length} of ${files.length} file(s) could not be parsed — this scan is INCOMPLETE, not clean.`
+    );
+    for (const u of unreadable) console.error(`  ${u.file}  ${u.error}`);
+  }
+
+  if (violations.length > 0) {
+    if (unreadable.length === 0) {
+      console.error(`❌ workflow-path-filter-lint: ${violations.length} brace-alternation entr${violations.length === 1 ? 'y' : 'ies'} across ${files.length} file(s) scanned`);
+    }
+    console.error('');
+    for (const v of violations) {
+      const where = v.line === null ? v.file : `${v.file}:${v.line}`;
+      console.error(`  ${where}  on.${v.trigger}.${v.key}`);
+      console.error(`      ${v.entry}`);
+      console.error(`      GitHub Actions does not expand braces, so this matches only a literal filename ending in "${/\{[^{}]*\}/.exec(v.entry)?.[0] ?? ''}" — i.e. nothing.`);
+      console.error(`      Replace with ${v.expansion.length} explicit entr${v.expansion.length === 1 ? 'y' : 'ies'}:`);
+      for (const e of v.expansion) console.error(`        - '${e}'`);
+      console.error('');
+    }
+    console.error('There is deliberately no allow-list: a path filter that matches nothing has no legitimate use.');
+    console.error('If a filter is meant to match nothing, delete the entry instead of writing one that silently cannot fire.');
+    process.exitCode = 1;
+    return;
+  }
+
+  if (unreadable.length > 0) {
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`✅ workflow-path-filter-lint: 0 brace-alternation path filters across ${files.length} file(s) scanned (${WORKFLOW_DIR})`);
+}
+
+// Direct-execution guard via the canonical helper — the raw import.meta.url comparison is
+// Windows-broken, and this SD exists partly to remove seven instances of it.
+import { isMainModule } from '../../lib/utils/is-main-module.js';
+if (isMainModule(import.meta.url)) main();

--- a/scripts/solomon-judgment-expiry-run.mjs
+++ b/scripts/solomon-judgment-expiry-run.mjs
@@ -25,6 +25,7 @@
  */
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
+import { isMainModule } from '../lib/utils/is-main-module.js';
 import {
   selectExpiredJudgments,
   expiryPatch,
@@ -119,6 +120,6 @@ async function shutdown(code) {
   process.exit(code);
 }
 
-if (import.meta.url === `file://${process.argv[1]}` || process.argv[1]?.endsWith('solomon-judgment-expiry-run.mjs')) {
+if (isMainModule(import.meta.url)) {
   main().then(shutdown).catch((e) => { console.error('[judgment-expiry]', e.message); return shutdown(1); });
 }

--- a/tests/fixtures/workflow-yaml/bad-brace-glob-paths.yml
+++ b/tests/fixtures/workflow-yaml/bad-brace-glob-paths.yml
@@ -1,0 +1,41 @@
+# FIXTURE — deliberately broken. SD-LEO-INFRA-FIVE-GUARDS-WIRED-001 (FR-3).
+#
+# The workflow-path-filter lint MUST flag the brace-alternation entries here and MUST NOT
+# flag the literal ones sitting beside them. Both halves are asserted: a guard that flags
+# everything is as useless as one that flags nothing, and only the two-sided check
+# distinguishes them.
+#
+# Mirrors tests/fixtures/workflow-yaml/bad-plain-scalar.yml, the existing
+# deliberately-broken-fixture precedent in this directory.
+#
+# DO NOT "FIX" THIS FILE. Its brokenness is the assertion.
+name: Fixture — brace-glob path filters
+
+on:
+  pull_request:
+    paths:
+      # DEAD — GitHub Actions does not expand braces, so this matches nothing.
+      - 'scripts/**/*.{js,mjs,cjs,ts}'
+      # LIVE — a literal glob, must NOT be flagged.
+      - 'lib/**/*.js'
+      # DEAD — second offender, different shape (two alternatives, leading dot).
+      - 'server/**/*.{ts,tsx}'
+      # LIVE — plain path, must NOT be flagged.
+      - '.github/workflows/fixture.yml'
+  push:
+    branches: [main]
+    paths-ignore:
+      # DEAD, and in a paths-ignore block — the lint must read this key too. A dead
+      # paths-ignore silently fails to EXCLUDE, so the workflow over-fires rather than
+      # under-fires; the defect is the same, the symptom is inverted.
+      - 'docs/**/*.{md,mdx}'
+
+concurrency:
+  group: fixture-brace-glob
+  cancel-in-progress: true
+
+jobs:
+  noop:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "fixture only — never executed in CI"

--- a/tests/unit/lint/ismainmodule-conversion-fail-closed.test.js
+++ b/tests/unit/lint/ismainmodule-conversion-fail-closed.test.js
@@ -1,0 +1,108 @@
+// SD-LEO-INFRA-FIVE-GUARDS-WIRED-001 (FR-5).
+//
+// WHY THIS FILE EXISTS. Converting a raw `import.meta.url === file://+argv[1]` comparison to
+// isMainModule() is usually cosmetic. For three of the seven sites in this SD it was not: the
+// raw comparison NEVER matches on Windows, so those main-blocks had never executed. Fixing
+// the guard makes previously-unreachable code run for the first time, and two of the three
+// WRITE to the database when they run:
+//
+//   apa-fixture-ratification-capture.mjs  → INSERT into system_events
+//   consult-answer-bind.mjs               → INSERT into system_events
+//                                           + service-role UPDATE of strategic_directives_v2.metadata
+//
+// Dormancy was established by exact full-population counts, not sampling: 0 of 274
+// dispositions carry decision_type='ratification', and 0 of 5537 SDs carry the metadata key
+// consult-answer-bind writes. Neither script is referenced by any workflow or npm script, so
+// neither ran on Linux either.
+//
+// The behaviour change is an INVERSION, not new risk. Both fail closed when invoked bare.
+// What they did BEFORE the fix was print nothing and exit 0 — an operator running a fully
+// argued command read success while zero rows moved. The fix makes a lying command honest.
+// These tests pin the fail-closed half so that claim is enforced rather than believed.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+// The two scripts that (a) take required arguments and (b) can therefore be safely spawned
+// bare. Safety here rests on VALIDATION ORDERING, not on environment isolation: the vitest
+// unit project does not load .env, but a SPAWNED child runs its own `import 'dotenv/config'`
+// and loads repo-root .env regardless of the parent. So the argument check MUST come before
+// the first DB call, which is asserted structurally below as well as behaviourally.
+const SPAWNABLE = [
+  {
+    file: 'scripts/apa-fixture-ratification-capture.mjs',
+    expectedStderr: '--fixture-set is required',
+  },
+  {
+    file: 'scripts/consult-answer-bind.mjs',
+    expectedStderr: 'sdKey is required',
+  },
+];
+
+describe('converted main-blocks fail closed when invoked bare', () => {
+  for (const { file, expectedStderr } of SPAWNABLE) {
+    it(`${file} exits non-zero with its required-argument message`, () => {
+      const res = spawnSync(process.execPath, [file], { encoding: 'utf8', timeout: 60_000 });
+      const output = `${res.stdout || ''}${res.stderr || ''}`;
+
+      // Assert the MESSAGE, not just the code. A bare exit-code check would also pass if the
+      // process died for an unrelated reason — a missing module, a bad credential, a syntax
+      // error — and would therefore be green for a reason that has nothing to do with the
+      // guard. The message is what ties the result to the code path under test.
+      expect(output).toContain(expectedStderr);
+      expect(res.status).not.toBe(0);
+    });
+  }
+
+  it('the guarded block really is reachable now — the raw comparison is gone from all 7', () => {
+    // The companion to the above: proving they fail closed is only meaningful if the block
+    // can actually be entered. Before this SD these files exited 0 in silence because the
+    // guard never matched, and a fail-closed test would have been vacuously... failing.
+    const converted = [
+      'scripts/apa-fixture-ratification-capture.mjs',
+      'scripts/audit/control-seed-test.mjs',
+      'scripts/consult-answer-bind.mjs',
+      'scripts/dispatch-auth-would-deny-report.mjs',
+      'scripts/fleet-kill.mjs',
+      'scripts/guard-firing-characterization.mjs',
+      'scripts/solomon-judgment-expiry-run.mjs',
+    ];
+    for (const f of converted) {
+      const src = readFileSync(f, 'utf8');
+      expect(src, `${f} still contains the Windows-broken raw comparison`)
+        .not.toMatch(/import\.meta\.url === `file:\/\/\$\{process\.argv\[1\]\}`/);
+      expect(src, `${f} does not use the canonical guard`).toContain('isMainModule(import.meta.url)');
+    }
+  });
+
+  it('the required-argument check precedes the first DB call in both spawned scripts', () => {
+    // Structural backstop for the ordering the spawn tests depend on. If someone later moves
+    // a query above the validation, the spawn tests would start performing real reads/writes
+    // and would still pass — this is the assertion that would fail instead.
+    const apa = readFileSync('scripts/apa-fixture-ratification-capture.mjs', 'utf8');
+    expect(apa.indexOf("throw new Error('--fixture-set is required')"))
+      .toBeLessThan(apa.indexOf('recordDisposition('));
+
+    const consult = readFileSync('scripts/consult-answer-bind.mjs', 'utf8');
+    expect(consult.indexOf('sdKey is required')).toBeLessThan(consult.indexOf('recordDisposition('));
+  });
+});
+
+describe('dispatch-auth-would-deny-report is deliberately NOT spawn-tested', () => {
+  // It takes NO arguments — bare invocation is its documented happy path, and it performs a
+  // live fully-paginated read of system_events before exiting 0. A "exits non-zero with no
+  // args" test on it would pass ONLY when Supabase credentials are absent, and so could never
+  // distinguish "the guard now works" from "the secret is missing" — a test that is green for
+  // the wrong reason is worse than no test, and this SD is entirely about checks whose green
+  // means nothing. It gets a static assertion instead.
+  it('uses the canonical guard', () => {
+    const src = readFileSync('scripts/dispatch-auth-would-deny-report.mjs', 'utf8');
+    expect(src).toContain('isMainModule(import.meta.url)');
+    expect(src).toContain("from '../lib/utils/is-main-module.js'");
+  });
+
+  it('is read-only, so first execution cannot write — the reason it needs no containment', () => {
+    const src = readFileSync('scripts/dispatch-auth-would-deny-report.mjs', 'utf8');
+    expect(src).not.toMatch(/\.(insert|upsert|update|delete)\s*\(/);
+  });
+});

--- a/tests/unit/lint/workflow-path-filter-lint.test.js
+++ b/tests/unit/lint/workflow-path-filter-lint.test.js
@@ -125,6 +125,32 @@ describe('collectPathEntries', () => {
     expect(collectPathEntries({})).toEqual([]);
     expect(collectPathEntries({ on: 'push' })).toEqual([]);
   });
+
+  // REGRESSION — this shape was SILENTLY SKIPPED by the first implementation, which guarded
+  // on Array.isArray and moved on. A scalar `paths:` is off-spec for GitHub Actions, but
+  // declining to examine it is the very behaviour this lint exists to abolish: the failure is
+  // never "the guard said no", it is "the guard never looked". Found by adversarial review,
+  // not by the original suite, which is why it now has a test of its own.
+  it('examines a SCALAR paths: value instead of skipping it', () => {
+    const got = collectPathEntries({ on: { pull_request: { paths: 'scripts/**/*.{js,ts}' } } });
+    expect(got).toHaveLength(1);
+    expect(got[0].entry).toBe('scripts/**/*.{js,ts}');
+  });
+
+  it('flags a brace-glob written as a scalar paths-ignore value', () => {
+    const yamlSrc = "name: S\non:\n  push:\n    paths-ignore: 'docs/**/*.{md,mdx}'\njobs:\n  n:\n    runs-on: ubuntu-latest\n";
+    const res = findBraceGlobEntries(yamlSrc, { filename: 'scalar.yml' });
+    expect(res.ok).toBe(false);
+    expect(res.violations).toHaveLength(1);
+    expect(res.violations[0].key).toBe('paths-ignore');
+  });
+
+  it('still ignores a scalar that is perfectly legal', () => {
+    // The non-flagging twin, so the normalisation cannot be mistaken for flag-everything.
+    const got = collectPathEntries({ on: { pull_request: { paths: 'scripts/**/*.js' } } });
+    expect(got).toHaveLength(1);
+    expect(hasBraceAlternation(got[0].entry)).toBe(false);
+  });
 });
 
 describe('findBraceGlobEntries — the two-sided control over the fixture', () => {

--- a/tests/unit/lint/workflow-path-filter-lint.test.js
+++ b/tests/unit/lint/workflow-path-filter-lint.test.js
@@ -1,0 +1,224 @@
+// SD-LEO-INFRA-FIVE-GUARDS-WIRED-001 (FR-3, FR-4).
+//
+// The guard flags brace-alternation entries in workflow paths:/paths-ignore: blocks, because
+// GitHub Actions does not expand braces and such an entry matches NOTHING — the workflow
+// stays green and never fires on the source it polices.
+//
+// EVERY FLAGGING TEST HERE HAS A NON-FLAGGING TWIN. That is deliberate and is the whole
+// point: the defect under repair is a guard that could not fail, so a suite proving only
+// that this guard PASSES would reproduce the exact problem one level up.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+  findBraceGlobEntries,
+  hasBraceAlternation,
+  expandBraceEntry,
+  collectPathEntries,
+  resolveWorkflowFiles,
+  GHA_MATCH_OPTS,
+} from '../../../scripts/lint/workflow-path-filter-lint.mjs';
+
+const FIXTURE = 'tests/fixtures/workflow-yaml/bad-brace-glob-paths.yml';
+
+describe('GHA_MATCH_OPTS — the calibration that must not drift', () => {
+  // minimatch EXPANDS BRACES BY DEFAULT, which is the opposite of GitHub Actions. A matcher
+  // built with default options reports 4729 matches for a filter that really matches zero
+  // files, and goes green on the bug. Losing nobrace does not break a test elsewhere — it
+  // silently makes the whole instrument agree with the defect. So it is pinned here.
+  it('sets nobrace, without which the instrument commits the defect it detects', () => {
+    expect(GHA_MATCH_OPTS.nobrace).toBe(true);
+  });
+
+  it('sets dot, so a dotfile path like .github/** is matchable', () => {
+    expect(GHA_MATCH_OPTS.dot).toBe(true);
+  });
+
+  it('is frozen, so a caller cannot mutate the shared calibration', () => {
+    expect(Object.isFrozen(GHA_MATCH_OPTS)).toBe(true);
+  });
+});
+
+describe('hasBraceAlternation', () => {
+  it('FLAGS the exact shape that broke five workflows in this repo', () => {
+    expect(hasBraceAlternation('scripts/**/*.{js,mjs,cjs,ts}')).toBe(true);
+  });
+
+  it('FLAGS a two-alternative brace group', () => {
+    expect(hasBraceAlternation('lib/**/*.{ts,tsx}')).toBe(true);
+  });
+
+  // The non-flagging twin. These are the entries that DO fire today and must stay untouched.
+  it('does NOT flag a literal per-extension glob', () => {
+    expect(hasBraceAlternation('scripts/**/*.js')).toBe(false);
+  });
+
+  it('does NOT flag a plain path or a bare ** glob', () => {
+    expect(hasBraceAlternation('database/migrations/**/*.sql')).toBe(false);
+    expect(hasBraceAlternation('.github/workflows/some-lint.yml')).toBe(false);
+    expect(hasBraceAlternation('**.md')).toBe(false);
+  });
+
+  it('does NOT throw or flag on a non-string entry', () => {
+    expect(hasBraceAlternation(null)).toBe(false);
+    expect(hasBraceAlternation(42)).toBe(false);
+    expect(hasBraceAlternation(undefined)).toBe(false);
+  });
+});
+
+describe('expandBraceEntry', () => {
+  it('expands to exactly the entries the filter was MEANT to be — no more, no fewer', () => {
+    expect(expandBraceEntry('scripts/**/*.{js,mjs,cjs,ts}')).toEqual([
+      'scripts/**/*.js',
+      'scripts/**/*.mjs',
+      'scripts/**/*.cjs',
+      'scripts/**/*.ts',
+    ]);
+  });
+
+  it('preserves the prefix and suffix around the brace group', () => {
+    expect(expandBraceEntry('a/b/**/*.{x,y}.bak')).toEqual(['a/b/**/*.x.bak', 'a/b/**/*.y.bak']);
+  });
+
+  it('tolerates whitespace inside the group', () => {
+    expect(expandBraceEntry('lib/**/*.{ts, tsx}')).toEqual(['lib/**/*.ts', 'lib/**/*.tsx']);
+  });
+
+  it('returns the entry unchanged when there is nothing to expand', () => {
+    expect(expandBraceEntry('scripts/**/*.js')).toEqual(['scripts/**/*.js']);
+  });
+
+  it('does not widen coverage — expansion count equals the alternative count', () => {
+    // Coverage preservation is a stated acceptance criterion: the fix must be an expansion,
+    // never a widening. If this ever returns more entries than there were alternatives, the
+    // suggestion is telling someone to broaden a filter they only meant to repair.
+    const entry = 'server/**/*.{js,mjs,cjs,ts,tsx}';
+    expect(expandBraceEntry(entry)).toHaveLength(5);
+  });
+});
+
+describe('collectPathEntries', () => {
+  it('reads BOTH paths and paths-ignore, across multiple triggers', () => {
+    const doc = {
+      on: {
+        pull_request: { paths: ['a/**/*.js'] },
+        push: { branches: ['main'], 'paths-ignore': ['docs/**/*.md'] },
+      },
+    };
+    const got = collectPathEntries(doc);
+    expect(got).toHaveLength(2);
+    expect(got.map((e) => e.key).sort()).toEqual(['paths', 'paths-ignore']);
+  });
+
+  it('returns nothing for a workflow with no path filters at all', () => {
+    // FR-4: the meta-lint's own workflow carries NO paths: key by design, so this is the
+    // shape it must handle without complaint.
+    const doc = { on: { pull_request: {}, push: { branches: ['main'] }, workflow_dispatch: null } };
+    expect(collectPathEntries(doc)).toEqual([]);
+  });
+
+  it('survives a YAML 1.1 parse where the `on` key came through as boolean true', () => {
+    expect(collectPathEntries({ true: { pull_request: { paths: ['a/*.{js,ts}'] } } })).toHaveLength(1);
+  });
+
+  it('does not throw on a malformed or empty document', () => {
+    expect(collectPathEntries(null)).toEqual([]);
+    expect(collectPathEntries({})).toEqual([]);
+    expect(collectPathEntries({ on: 'push' })).toEqual([]);
+  });
+});
+
+describe('findBraceGlobEntries — the two-sided control over the fixture', () => {
+  const raw = readFileSync(FIXTURE, 'utf8');
+
+  it('DETECTS the deliberately broken entries', () => {
+    const res = findBraceGlobEntries(raw, { filename: FIXTURE });
+    expect(res.parsed).toBe(true);
+    expect(res.ok).toBe(false);
+    expect(res.violations).toHaveLength(3);
+  });
+
+  it('does NOT flag the literal entries sitting in the SAME paths block', () => {
+    // The half that makes the previous test mean something. A guard that flagged the whole
+    // block would also make that test pass.
+    const flagged = findBraceGlobEntries(raw, { filename: FIXTURE }).violations.map((v) => v.entry);
+    expect(flagged).not.toContain('lib/**/*.js');
+    expect(flagged).not.toContain('.github/workflows/fixture.yml');
+  });
+
+  it('reads paths-ignore too — a dead exclusion over-fires rather than under-fires', () => {
+    const keys = findBraceGlobEntries(raw, { filename: FIXTURE }).violations.map((v) => v.key);
+    expect(keys).toContain('paths-ignore');
+  });
+
+  it('reports a real 1-indexed line number pointing at the offending entry', () => {
+    const v = findBraceGlobEntries(raw, { filename: FIXTURE }).violations
+      .find((x) => x.entry === 'scripts/**/*.{js,mjs,cjs,ts}');
+    expect(v.line).toBeGreaterThan(0);
+    const lineText = raw.split(/\r?\n/)[v.line - 1];
+    // Assert the reported line actually CONTAINS the entry. A line number that merely looks
+    // plausible sends a reader to the wrong place, which is worse than naming only the file.
+    expect(lineText).toContain('scripts/**/*.{js,mjs,cjs,ts}');
+  });
+
+  it('carries the corrected expansion with each violation', () => {
+    const v = findBraceGlobEntries(raw, { filename: FIXTURE }).violations
+      .find((x) => x.entry === 'server/**/*.{ts,tsx}');
+    expect(v.expansion).toEqual(['server/**/*.ts', 'server/**/*.tsx']);
+  });
+});
+
+describe('findBraceGlobEntries — clean and unparseable inputs', () => {
+  it('passes a workflow whose filters are all literal', () => {
+    const clean = [
+      'name: Clean',
+      'on:',
+      '  pull_request:',
+      '    paths:',
+      "      - 'scripts/**/*.js'",
+      "      - 'scripts/**/*.mjs'",
+      'jobs:',
+      '  noop:',
+      '    runs-on: ubuntu-latest',
+    ].join('\n');
+    const res = findBraceGlobEntries(clean, { filename: 'clean.yml' });
+    expect(res.ok).toBe(true);
+    expect(res.violations).toEqual([]);
+  });
+
+  it('reports parsed:false on unparseable YAML rather than reporting it CLEAN', () => {
+    // The critical distinction. A file that could not be read has NOT been shown to be
+    // clean, and folding it into a zero is the false-assurance shape this SD is about.
+    const res = findBraceGlobEntries('name: Broken\non:\n  bad: : :\n', { filename: 'broken.yml' });
+    expect(res.parsed).toBe(false);
+    expect(res.ok).toBe(false);
+    expect(res.error).toBeTruthy();
+  });
+
+  it('detects the real defect in the actual bad-plain-scalar fixture, which must not parse', () => {
+    const res = findBraceGlobEntries(
+      readFileSync('tests/fixtures/workflow-yaml/bad-plain-scalar.yml', 'utf8'),
+      { filename: 'bad-plain-scalar.yml' }
+    );
+    expect(res.parsed).toBe(false);
+  });
+});
+
+describe('the repo itself', () => {
+  it('has zero brace-alternation path filters across every workflow', () => {
+    // The always-on half: this is what turns the guard from a unit-tested function into an
+    // actual standing constraint on the repository.
+    const files = resolveWorkflowFiles([]);
+    expect(files.length).toBeGreaterThan(100);
+    const offenders = [];
+    for (const f of files) {
+      const res = findBraceGlobEntries(readFileSync(f, 'utf8'), { filename: f });
+      expect(res.parsed, `${f} must parse`).toBe(true);
+      offenders.push(...res.violations.map((v) => `${v.file}:${v.line} ${v.entry}`));
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('reports forward-slash paths on every platform, matching GHA filter idiom', () => {
+    expect(resolveWorkflowFiles([]).every((f) => !f.includes('\\'))).toBe(true);
+  });
+});


### PR DESCRIPTION
## What was wrong

GitHub Actions **does not expand brace alternation**. A path filter written as `scripts/**/*.{js,mjs,cjs,ts}` matches only a literal filename ending in those seven characters — i.e. nothing. Five lint workflows were written that way.

This was measured, not inferred. The run counts are a natural experiment:

| workflow | runs ever | why |
|---|---|---|
| `alter-default-override-lint` | **539** | one entry (`database/migrations/**/*.sql`) is brace-free and fires |
| `count-delta-gate-lint` | **1** | its own introducing PR |
| `realtime-subscribe-teardown-recursion-lint` | **1** | its own introducing PR |
| `ismainmodule-classguard-lint` | **1** | its own introducing PR |
| `session-coordination-insert-classguard-lint` | 3 → **24 in one day** | corrected earlier today — the same fix, before/after |

Those three fired once each, on their own creation PR, matched by the literal `.github/workflows/<self>.yml` entry sitting beside the dead glob. Zero runs since, across 488 `scripts/**` and 1436 `lib/**` file touches. **They have only ever run when someone edited the lint's own machinery — never on the source they exist to police.**

`alter-default-override-lint` is the interesting one: it is **not** dormant, it is *partially wired*. It covers the migration half of its drift class while never evaluating the writer paths it exists to cross-check. A green check reading as full coverage is the worse failure mode.

## Consequence

**Seven** raw-`isMainModule` violations landed in `scripts/**` during the 32 days that guard was inert. Every one **postdates** it (guard 2026-07-02; violations 07-08 → 08-03), and `git cat-file` confirms all seven files were absent from the tree at the guard commit. Nothing was grandfathered — the allow-list stays empty, because the guard simply could not see them.

## ⚠️ Where reviewers should look

Three of the seven guards were **genuinely dead on Windows** (the other four carried an `endsWith` fallback and were already live). Fixing them makes never-executed code run for the first time, and **two arm database writes**:

- `apa-fixture-ratification-capture.mjs` → INSERT `system_events`
- `consult-answer-bind.mjs` → INSERT `system_events` **+ service-role UPDATE of `strategic_directives_v2.metadata`**

Dormancy proven by exact full-population counts: **0 of 274** dispositions are ratifications; **0 of 5537** SDs carry the metadata key. Neither script is referenced by any workflow or npm script, so neither ran on Linux either.

The change is an **inversion, not new risk**. Both fail closed when invoked bare. What they did *before* was print nothing and exit 0 — a fully-argued command reported success while zero rows moved. The fix makes a lying command honest. Fail-closed behaviour is now asserted on **message text**, not exit code alone (an exit-code-only check would also pass if the process died for an unrelated reason).

## Why this is one commit

The drivers scan the **whole tree**, not the PR diff, and `ismainmodule-classguard-lint` is blocking with no `continue-on-error`. Landing the filter fix before the source fixes would red-line **every** `scripts/**` PR across all parallel fleet sessions. That is also why this SD was not decomposed — splitting it would manufacture exactly that window.

## The new meta-guard

This class was fixed once *without* a guard, so it stayed free to recur — and did, four more times. `scripts/lint/workflow-path-filter-lint.mjs` makes instance six detectable instead of waiting for someone to notice a run count of 1.

- **Its own workflow carries no `paths:` key at all.** A filter there could carry the very defect it detects — which is exactly how the original five failed. It also does not exclude itself from its own scan. Reviewer check: `sed -n '/^on:/,/^concurrency:/p' .github/workflows/workflow-path-filter-lint.yml | grep -c '{'` prints `0`.
- **It parses, it does not grep.** A textual scan also hits ~25 legitimate `${{ }}` expressions in `run:` bodies. (Demonstrated in this very PR: my own grep flagged 2 comment lines in a file I had already fixed; the lint flagged 0.)
- **`GHA_MATCH_OPTS` pins `nobrace`, and the suite asserts it.** minimatch expands braces *by default* — a matcher built with defaults reports 4729 matches for a filter matching zero files and goes green on the bug. Without that pin, the instrument built to detect this ambiguity commits it on its first run.

## Verification — two-sided throughout

A guard that only ever passes is the defect under repair, so nothing here is demonstrated in one direction only.

- **Positive control:** against the pre-fix tree the lint reported **exactly the 10 known entries**. It finds real instances, not nothing.
- **Post-fix:** 0 across 171 files.
- **Negative control on a real workflow:** reintroducing a brace-glob → exit 1 naming `file:line`; revert → exit 0.
- **Fixture** asserts flagged *and* not-flagged entries in the same `paths:` block, plus a `paths-ignore:` case and an unparseable file (which must report an **INCOMPLETE** scan, never a clean one).
- **Regression:** all 7 converted scripts' existing suites pass (**77/77**) — run, not reasoned, because if `isMainModule()` returned true under vitest those imports would execute `main()` and write to the DB from the unit suite.
- The pre-commit hook ran the new lint live on this commit.

## Scope deliberately held

**23 further path filters are dead by target absence** rather than brace syntax (`slsa-verification.yml` has all six PR paths dead; `provenance-emission-audit.yml` points at `scripts/modules/handoff/**/*.{mjs,cjs}` where 337 files exist but none is `.mjs`/`.cjs`). Different root cause, different blast radius, and a zero-match rule would fail against all 23 on day one. Reported, not fixed here — the same discipline that produced this SD.

## Size

789 insertions. The fix itself is ~110 lines; the new guard (263) and its tests (373) are the bulk. My own PRD estimated ≤100 net LOC and under-counted the artifact it was proposing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)