### PR TITLE
SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001: promotion records where a signal went, not that it was handled

### DIFF
--- a/lib/coordinator/detectors.cjs
+++ b/lib/coordinator/detectors.cjs
@@ -38,6 +38,7 @@
 const { hasCorrelatedReply } = require('./reply-correlation.cjs');
 const { hasSignalType } = require('./signal-router.cjs');
 const { isGenuinelyAcknowledged } = require('../retention/retention-ack-marker.cjs'); // FR-7
+const { isPromotionAcked } = require('./promotion-ack.cjs'); // SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001
 
 /** Default freshness window (ms) for "is this session a live coordinator". */
 const DEFAULT_COORDINATOR_FRESH_MS = 10 * 60 * 1000;
@@ -121,7 +122,10 @@ function detectThunderingHerd(data) {
 
 /**
  * REPLY_STARVATION — a worker signal left unanswered beyond threshold T.
- * "answered" = acknowledged_at set OR payload.routed_to_feedback_id set.
+ * "answered" = a genuine acknowledged_at (not a machine stamp), OR a routed_to_feedback_id that
+ * was NOT merely written by the router's own promotion, OR a correlated reply.
+ * The promotion carve-out is SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 FR-4: filing a signal into a
+ * backlog row records where it went, not that anyone answered it.
  * @param {{ signals: Array<object>, now?: number, thresholdMs?: number }} data
  * @returns {{ matched: boolean, reason: string, evidence: object }}
  */
@@ -152,7 +156,15 @@ function detectReplyStarvation(data) {
     // gauge report the lane as healthy because the row was deleted-in-waiting. Marking a stamp
     // without teaching the consumer to skip it would be an inert mechanism; this is the consumer.
     // Same predicate lib/adam/inbound-backlog.js already applies on its own lane.
-    const answered = isGenuinelyAcknowledged(sig) || !!(sig.payload && sig.payload.routed_to_feedback_id)
+    // SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 (FR-4): `routed_to_feedback_id` ALONE used to count as
+    // answered. That key is written by the signal router when it files a signal into a
+    // harness_backlog row — which says where the signal WENT, never that anyone ANSWERED it. So
+    // this gauge, the one instrument that should have alarmed on all 9 swallowed signals, was
+    // disabled by the very key the router writes. Removing the key is not an option (the router
+    // dedupes on it), so the clause must additionally require that the row is not merely
+    // promotion-marked. A router-filed row now stays "unanswered" until a human dispositions it.
+    const answered = isGenuinelyAcknowledged(sig)
+      || (!!(sig.payload && sig.payload.routed_to_feedback_id) && !isPromotionAcked(sig))
       || hasCorrelatedReply(sig, allSignals);
     if (answered) continue;
     // SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-3): `if (sig.read_at) continue` USED TO LIVE

--- a/lib/coordinator/detectors.cjs
+++ b/lib/coordinator/detectors.cjs
@@ -162,7 +162,12 @@ function detectReplyStarvation(data) {
     // this gauge, the one instrument that should have alarmed on all 9 swallowed signals, was
     // disabled by the very key the router writes. Removing the key is not an option (the router
     // dedupes on it), so the clause must additionally require that the row is not merely
-    // promotion-marked. A router-filed row now stays "unanswered" until a human dispositions it.
+    // promotion-marked. A router-filed row now stays "unanswered" until a human dispositions it —
+    // or until retention collects it, which is the honest bound: fleet-dashboard stamps read_at ON
+    // RENDER (correctly, and it never stamps acknowledged_at), and a non-null read_at arms
+    // cleanup_expired_coordination's second disjunct at read_at + 7 days. Not a writer to guard —
+    // that is legitimate delivery semantics, and 7 days is a large improvement on the ~24h these
+    // rows got pre-fix — but "until a human dispositions it" alone would overstate the guarantee.
     const answered = isGenuinelyAcknowledged(sig)
       || (!!(sig.payload && sig.payload.routed_to_feedback_id) && !isPromotionAcked(sig))
       || hasCorrelatedReply(sig, allSignals);

--- a/lib/coordinator/promotion-ack.cjs
+++ b/lib/coordinator/promotion-ack.cjs
@@ -52,7 +52,19 @@ function buildPromotionAckPayload(payload, feedbackId) {
   };
 }
 
-/** True when the router filed this row. Total: any shape in, boolean out. */
+/**
+ * True when the router filed this row. Total: any shape in, boolean out.
+ *
+ * STRICTLY `=== true`, and deliberately stricter than the SQL guards, which exclude ANY present
+ * value (`payload->>key IS NULL`). The asymmetry is intentional and runs the safe way: the only
+ * routes to a non-true value are a future un-marker or corruption, and in the first case `=== true`
+ * is the CORRECT reading — a dispositioned row should become collectable again — while the looser
+ * SQL side would protect it forever. Over-protection is clutter; under-protection is a lost signal.
+ *
+ * TO UN-MARK A ROW, DELETE THE KEY — never set it false. Setting false would make the JS and SQL
+ * predicates disagree behaviourally (JS: not promoted, SQL: still protected), which is precisely
+ * the kind of two-readers-of-one-question split this SD exists to close.
+ */
 function isPromotionAcked(row) {
   return row?.payload?.[PROMOTION_ACK_KEY] === true;
 }

--- a/lib/coordinator/promotion-ack.cjs
+++ b/lib/coordinator/promotion-ack.cjs
@@ -1,0 +1,89 @@
+/**
+ * promotion-ack.cjs — SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001.
+ *
+ * PROMOTION IS NOT DISPOSITION. The signal router used to stamp `acknowledged_at` while
+ * promoting a signal into a harness_backlog feedback row. The coordinator inbox selects
+ * `acknowledged_at IS NULL`, and that same inbox is what stamps `read_at` ON RENDER — so the
+ * ack removed the row from the very query that would have marked it read. Measured: 9 rows,
+ * 100% of everything the router had ever promoted, every one severity=critical, still firing
+ * the day the SD was filed. Nothing downstream re-raised them because an acked row looks handled.
+ *
+ * So promotion now records WHERE a signal went and stops claiming it was HANDLED:
+ *   - `payload.routed_to_feedback_id` — unchanged, still the re-aggregation dedup key.
+ *   - `payload.promotion_ack` — NEW. "the router filed this; a human still has not."
+ *   - `acknowledged_at` — left alone, and now means exactly one thing: a human or role
+ *     dispositioned this row.
+ *
+ * WHY A DISTINCT KEY RATHER THAN THE EXISTING `auto_acked`. lib/retention/retention-ack-marker.cjs
+ * marks retention-style machine acks with `auto_acked`, and a detector for THIS defect class must
+ * be able to exclude those while still catching router promotions. Reuse one key for both and the
+ * detector excludes precisely the population it exists to catch — a silent zero that looks like
+ * health. The names were collision-checked before adoption: zero code references and zero live
+ * rows carried `promotion_ack` / `promotion_ack_source` / `router_ack`.
+ *
+ * WHY THE MARKER LIVES IN `payload` AND NOT IN A NEW COLUMN. reviveArchivedSignal in
+ * lib/coordinator/worker-signal-starvation.cjs rebuilds rows through an EXPLICIT field map; a new
+ * column would be dropped there and archived rows would silently stop correlating. Riding inside
+ * the jsonb also means no migration.
+ *
+ * Everything here is PURE and total — no DB access, no I/O — so the two-sided proof is an
+ * in-memory unit test over crafted row objects. That is deliberate: this repo has no designated
+ * non-production database (the vitest `db` project is gated off), so a classifier that could only
+ * be exercised against live data could not be honestly tested at all.
+ */
+
+/** Marks a row the router filed but nobody has dispositioned. */
+const PROMOTION_ACK_KEY = 'promotion_ack';
+/** Provenance, so a later reader can tell WHICH automated writer set the marker. */
+const PROMOTION_ACK_SOURCE_KEY = 'promotion_ack_source';
+const PROMOTION_ACK_SOURCE = 'signal_router_promotion';
+
+/**
+ * Merge the promotion marker into a payload. Never mutates the input.
+ * @param {object|null|undefined} payload existing row payload
+ * @param {string} feedbackId the harness_backlog row this signal was promoted into
+ */
+function buildPromotionAckPayload(payload, feedbackId) {
+  return {
+    ...(payload || {}),
+    routed_to_feedback_id: feedbackId,
+    [PROMOTION_ACK_KEY]: true,
+    [PROMOTION_ACK_SOURCE_KEY]: PROMOTION_ACK_SOURCE
+  };
+}
+
+/** True when the router filed this row. Total: any shape in, boolean out. */
+function isPromotionAcked(row) {
+  return row?.payload?.[PROMOTION_ACK_KEY] === true;
+}
+
+/**
+ * The defect predicate, and the reason it keys on ROUTER PROVENANCE rather than on the bare
+ * (acknowledged_at set AND read_at null) pair.
+ *
+ * That bare pair is NOT the defect. scripts/coordinator-ack-signal.cjs stamps `acknowledged_at`
+ * without `read_at` as the LEGITIMATE coordinator disposition path, so acked-and-unread rows will
+ * always exist and "drive the count to zero" is not a reachable or desirable goal. Measured while
+ * writing this: 13 rows matched the bare pair, only 9 of which were router-promoted.
+ *
+ * What IS the defect is a row the ROUTER retired that nobody ever read. After this SD the router
+ * no longer sets `acknowledged_at`, so a row matching all three conditions means either a
+ * regression here or some other writer acking a promoted row behind our back — which is exactly
+ * what the stale-session-sweep STUCK-drain would have done.
+ *
+ * Stated as a rule rather than a count on purpose: the populations drift (the negative fixture
+ * moved 176 -> 416 -> 426 over three days), so an assertion pinned to a number measures the clock.
+ */
+function isRouterSwallowed(row) {
+  if (!row) return false;
+  return Boolean(row.acknowledged_at) && !row.read_at && isPromotionAcked(row);
+}
+
+module.exports = {
+  PROMOTION_ACK_KEY,
+  PROMOTION_ACK_SOURCE_KEY,
+  PROMOTION_ACK_SOURCE,
+  buildPromotionAckPayload,
+  isPromotionAcked,
+  isRouterSwallowed
+};

--- a/lib/coordinator/promotion-ack.cjs
+++ b/lib/coordinator/promotion-ack.cjs
@@ -68,8 +68,18 @@ function isPromotionAcked(row) {
  *
  * What IS the defect is a row the ROUTER retired that nobody ever read. After this SD the router
  * no longer sets `acknowledged_at`, so a row matching all three conditions means either a
- * regression here or some other writer acking a promoted row behind our back — which is exactly
- * what the stale-session-sweep STUCK-drain would have done.
+ * regression here or some other writer acking a promoted row behind our back. TWO such writers
+ * were found and guarded: the STUCK-drain (stale-session-sweep.cjs) and the TTL convergence pass
+ * (retention/session-coordination-ack-convergence.js). They are siblings called ~100 lines apart
+ * from the same main(); the second was found only because a reviewer enumerated the writers
+ * instead of trusting that the first was the only one.
+ *
+ * NOT YET WIRED — SAID PLAINLY SO REVIEW DOES NOT MISREAD THIS FILE. `isRouterSwallowed` has no
+ * production caller today: it is proven by unit test and consumed by nothing. A zero from a
+ * predicate nobody runs is not evidence of health, and the honest disclosure on
+ * stampRoutedToCoordinator would be asymmetric if this one carried no equivalent. Wiring it into
+ * the gauge registry (lib/governance/gauge-registry.js, which brings alerting, ownerRole routing
+ * and a staleness heartbeat) is the intended next step and is tracked as a completion flag.
  *
  * Stated as a rule rather than a count on purpose: the populations drift (the negative fixture
  * moved 176 -> 416 -> 426 over three days), so an assertion pinned to a number measures the clock.

--- a/lib/coordinator/promotion-ack.cjs
+++ b/lib/coordinator/promotion-ack.cjs
@@ -68,11 +68,20 @@ function isPromotionAcked(row) {
  *
  * What IS the defect is a row the ROUTER retired that nobody ever read. After this SD the router
  * no longer sets `acknowledged_at`, so a row matching all three conditions means either a
- * regression here or some other writer acking a promoted row behind our back. TWO such writers
- * were found and guarded: the STUCK-drain (stale-session-sweep.cjs) and the TTL convergence pass
- * (retention/session-coordination-ack-convergence.js). They are siblings called ~100 lines apart
- * from the same main(); the second was found only because a reviewer enumerated the writers
- * instead of trusting that the first was the only one.
+ * regression here or some other writer acking a promoted row behind our back. THREE such writers
+ * were found and guarded: the STUCK-drain (stale-session-sweep.cjs, ~1h fuse), the TTL
+ * convergence pass (retention/session-coordination-ack-convergence.js, 14d fuse), and the
+ * dead-letter drain (scripts/drain-dead-letter-coordination.mjs, manual). Each was found only
+ * because a reviewer ENUMERATED the writers rather than trusting that the previous one was the
+ * last — this comment said "TWO" until the third was found, so treat any count here as the
+ * current best knowledge rather than a closed set.
+ *
+ * KNOWN LIMITATION, stated rather than discovered later: a coordinator dispositioning an
+ * already-promoted signal via scripts/coordinator-ack-signal.cjs stamps acknowledged_at without
+ * read_at, so isRouterSwallowed() reports true for a genuinely handled row. Measured as a narrow
+ * race — 425 of 443 live signal rows are read-then-ack, and this fix pushes promoted rows further
+ * into that dominant order because they now reach the inbox (which stamps read_at on render)
+ * before a coordinator acks them.
  *
  * NOT YET WIRED — SAID PLAINLY SO REVIEW DOES NOT MISREAD THIS FILE. `isRouterSwallowed` has no
  * production caller today: it is proven by unit test and consumed by nothing. A zero from a

--- a/lib/coordinator/signal-router.cjs
+++ b/lib/coordinator/signal-router.cjs
@@ -29,6 +29,8 @@ const {
 // file used to reimplement. capBodySafe is the non-throwing INBOUND adapter — see FR-2 and the
 // module header for why the outbound throw contract must not escape into this hot loop.
 const { capBodySafe } = require('../shared/body-cap.cjs');
+// SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001: promotion marks provenance instead of disposition.
+const { buildPromotionAckPayload } = require('./promotion-ack.cjs');
 
 const WINDOW_MIN = 60;
 const THRESHOLD = 3;
@@ -251,18 +253,27 @@ async function insertFeedbackRow(supabase, group) {
   return { feedback: data, error };
 }
 
+/**
+ * Record WHERE a signal went. Deliberately does NOT record that it was handled.
+ *
+ * SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001: this used to stamp `acknowledged_at` alongside the
+ * feedback-id. The coordinator inbox selects `acknowledged_at IS NULL` and is also the only
+ * writer of `read_at` (it stamps on render) — so promoting a signal removed it from the very
+ * query that would have marked it read, and it left the fleet's view entirely. Measured: 9 rows,
+ * 100% of everything ever promoted, all severity=critical, including signals carrying explicit
+ * STOP/DO-NOT orders. Nothing re-raised them, because an acked row looks handled.
+ *
+ * The default is now NON-DISPOSING rather than disposing-with-a-guard. A guard is something the
+ * next edit forgets; a non-disposing default means a future bug here leaves a signal VISIBLE.
+ *
+ * `routed_to_feedback_id` is preserved unconditionally — loadRecentSignals() dedupes on that key
+ * and on nothing else, so dropping it would re-promote every signal on every tick.
+ */
 async function stampRouted(supabase, rows, feedbackId) {
-  // Update each contributing row's payload.routed_to_feedback_id and acknowledged_at.
-  // Supabase JSONB merge requires reading payload then writing back.
-  const now = new Date().toISOString();
   for (const r of rows) {
-    const merged = {
-      ...(r.payload || {}),
-      routed_to_feedback_id: feedbackId
-    };
     await supabase
       .from('session_coordination')
-      .update({ payload: merged, acknowledged_at: now })
+      .update({ payload: buildPromotionAckPayload(r.payload, feedbackId) })
       .eq('id', r.id);
   }
 }
@@ -343,6 +354,23 @@ function shouldRouteLone(group) {
   return severityRank(group.max_severity) >= severityRank(ROUTE_MIN_SEVERITY);
 }
 
+/**
+ * CURRENTLY UNREACHABLE (SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001, FR-7).
+ *
+ * Its only caller is ackAndRouteLoneSignal(), which has no production caller of its own: the two
+ * live entry points (lib/sweep/passes/coordination-detectors.cjs and lib/sweep/legacy-fallback.cjs)
+ * both call aggregateSignals() only. Confirmed at the data layer too — zero rows have ever carried
+ * `payload.routed_to_coordinator`.
+ *
+ * It is therefore left BEHAVIOURALLY UNCHANGED by that SD, and said so plainly rather than being
+ * "fixed" the same way stampRouted was: a change here would ship unexecuted and could not be
+ * two-sidedly proven, while reading in review as though both paths were covered. Its
+ * acknowledged_at stamp is also genuinely justified on this path (#4222 closed an
+ * unacked-forever incident here) — that justification never applied to stampRouted.
+ *
+ * To make it live, give ackAndRouteLoneSignal a caller; then revisit whether the ack should carry
+ * a promotion-style marker.
+ */
 async function stampRoutedToCoordinator(supabase, rows) {
   // Mark each contributing row routed-to-coordinator + acknowledged. Distinct from
   // stampRouted(): NO routed_to_feedback_id (no harness_backlog row exists for a lone signal).

--- a/lib/coordinator/signal-router.test.js
+++ b/lib/coordinator/signal-router.test.js
@@ -182,8 +182,18 @@ describe('SR-16: aggregateSignals end-to-end with mocked supabase — promotes �
     expect(result.skipped).toBe(0);
     expect(updatePayloads.length).toBe(3);
     for (const u of updatePayloads) {
+      // KEEP: the dedup guard. loadRecentSignals() filters on this key and nothing else, so
+      // dropping it would re-promote every signal on every tick.
       expect(u.payload.routed_to_feedback_id).toBe('fb-001');
-      expect(u.acknowledged_at).toBeTruthy();
+      // SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 (FR-6): this line USED TO ASSERT
+      // `expect(u.acknowledged_at).toBeTruthy()` — a FACT-PIN, not a behaviour pin. The suite
+      // title says nothing about acknowledged_at; it pinned an incidental side effect of the
+      // original two-way-comms work (#3521), and in doing so pinned the defect itself as
+      // intended behaviour. Promotion must NOT dispose: the row stays visible in the coordinator
+      // inbox (which selects acknowledged_at IS NULL) until a human actually dispositions it.
+      expect(u.acknowledged_at).toBeUndefined();
+      expect(u.payload.promotion_ack).toBe(true);
+      expect(u.payload.promotion_ack_source).toBe('signal_router_promotion');
     }
   });
 });

--- a/lib/fleet/outstanding-signals.cjs
+++ b/lib/fleet/outstanding-signals.cjs
@@ -138,8 +138,16 @@ function formatOutstandingWarning(result, opts = {}) {
   if (!result || !result.count) return null;
   if (!Number.isFinite(result.oldest_age_minutes) || result.oldest_age_minutes < alertAgeMin) return null;
   const truncated = result.count > result.shown ? ` (showing oldest ${result.shown})` : '';
+  // SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 (FR-9): surface the routed count. Annotating each row
+  // with `routed` while leaving this sentence unchanged would have added a field nobody reads —
+  // the same shape as a marker written but never consumed, which is the defect this SD is about.
+  const routed = (result.signals || []).filter((s) => s.routed).length;
+  const routedNote = routed > 0
+    ? ` ${routed} of the shown signal(s) were FILED by the router into a backlog row and are awaiting disposition — filed is not answered.`
+    : '';
   return `⚠ ${result.count} signal(s) you sent are still UNANSWERED${truncated} — oldest ${result.oldest_age_minutes}m. `
-    + 'Unacked means acknowledged_at is null; some may already be delivered (read) but not actioned.';
+    + 'Unacked means acknowledged_at is null; some may already be delivered (read) but not actioned.'
+    + routedNote;
 }
 
 module.exports = {

--- a/lib/fleet/outstanding-signals.cjs
+++ b/lib/fleet/outstanding-signals.cjs
@@ -29,6 +29,9 @@
 // and the difference is the consequence of being wrong.
 
 /** Oldest-first list cap. The cap must drop the NEWEST rows — see fetch(). */
+// SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 (FR-9): distinguish router-filed from never-touched.
+const { isPromotionAcked } = require('../coordinator/promotion-ack.cjs');
+
 const DEFAULT_LIST_CAP = 5;
 /** Age at which the surface also emits a human-readable line, not just the array. */
 const DEFAULT_ALERT_AGE_MIN = 30;
@@ -74,6 +77,13 @@ async function fetchOutstandingSignals(sb, sessionId, opts = {}) {
       .select('id, created_at, read_at, payload', { count: 'exact' })
       .eq('sender_session', sessionId)
       .not('payload->>signal_type', 'is', null)
+      // SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 (FR-9), the SENDER side of the same defect.
+      // The router used to ack on promotion, so a promoted signal silently left this banner too:
+      // the sender saw "delivered", the coordinator saw nothing, and neither end had a surface
+      // showing the gap. Now that promotion no longer acks, these rows correctly REMAIN here —
+      // they genuinely are unanswered — but they are annotated below rather than shown as
+      // identical to a never-routed signal, because "filed, awaiting disposition" and "nobody has
+      // touched this at all" are two different states that were wearing one stamp.
       .is('acknowledged_at', null)
       .order('created_at', { ascending: true })
       .limit(cap);
@@ -90,6 +100,11 @@ async function fetchOutstandingSignals(sb, sessionId, opts = {}) {
       // Surfaced, not collapsed: delivered-but-unanswered is the state that a read_at
       // predicate silently swallows, and the worker should be able to see the difference.
       delivered: !!r.read_at,
+      // Same principle, one state further along (SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 FR-9):
+      // "the router filed this into a backlog row, nobody has dispositioned it yet" is not the
+      // same as "nobody has touched this at all". Both are legitimately unanswered and both
+      // belong in this list — but collapsing them is what let a promoted signal read as handled.
+      routed: isPromotionAcked(r),
     }));
 
     return {

--- a/lib/retention/session-coordination-ack-convergence.js
+++ b/lib/retention/session-coordination-ack-convergence.js
@@ -14,6 +14,9 @@
 // silently capped at the PostgREST 1000-row max would leave older backlog rows un-converged
 // forever. session_coordination is a growing table, so paginate the candidate read.
 import { fetchAllPaginated } from '../db/fetch-all-paginated.mjs';
+import { createRequire } from 'module';
+// SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 (FR-8): the marker this pass must not converge over.
+const { PROMOTION_ACK_KEY } = createRequire(import.meta.url)('../coordinator/promotion-ack.cjs');
 
 const ACK_TTL_DAYS = 14;
 
@@ -32,6 +35,21 @@ export async function convergeAckTTL(supabase, { now = new Date() } = {}) {
       .select('id, payload')
       .is('acknowledged_at', null)
       .lte('created_at', cutoff)
+      // SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 (FR-8, second site). This pass is the SIBLING of the
+      // STUCK-drain in stale-session-sweep.cjs — both called from the same main(), ~100 lines
+      // apart, both stamping acknowledged_at on rows selected by a bare `acknowledged_at IS NULL`.
+      // Guarding one and not the other would have left the fix self-reverting on a longer fuse.
+      //
+      // AND THE ROUTER FIX IS WHAT CREATES THE EXPOSURE HERE. Before it, promoted signals were
+      // acked on the spot and never reached this candidate set at all. Now promotion deliberately
+      // leaves acknowledged_at NULL, so EVERY promoted signal sits here until ACK_TTL_DAYS and is
+      // then stamped to ack-SET / read-NULL / promotion_ack — which is precisely the swallowed
+      // state the SD exists to abolish, reached 14 days later instead of instantly, and destroyed
+      // by cleanup_expired_coordination on the next tick.
+      //
+      // A promoted row is filed and awaiting disposition, not an unacked row rotting in the lane,
+      // so TTL convergence is the wrong instrument for it.
+      .is(`payload->>${PROMOTION_ACK_KEY}`, null)
       .order('id', { ascending: true })); // unique tiebreaker: stable page boundaries (FR-6)
   } catch (selErr) {
     return { converged: 0, error: `select failed: ${selErr.message}` };

--- a/scripts/drain-dead-letter-coordination.mjs
+++ b/scripts/drain-dead-letter-coordination.mjs
@@ -9,6 +9,9 @@
 import 'dotenv/config';
 import { createClient } from '@supabase/supabase-js';
 import { classifyDeadLetterRow, summarizeDrain, HIGH_VALUE_KINDS } from '../lib/coordination/dead-letter-drain.js';
+import { createRequire } from 'module';
+// SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 (FR-8, third site).
+const { PROMOTION_ACK_KEY } = createRequire(import.meta.url)('../lib/coordinator/promotion-ack.cjs');
 
 const APPLY = process.argv.includes('--apply');
 const db = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
@@ -34,7 +37,21 @@ async function main() {
   const isLive = (sid) => { const s = byId.get(sid); return !!s && (s.status === 'active' || s.status === 'idle'); };
   const successors = { coordinator: LIVE_COORDINATOR }; // solomon/adam resolved only if role-orphans exist (none in the verified set)
 
-  const unacked = await all('session_coordination', 'id,target_session,payload,message_type,subject', (q) => q.is('acknowledged_at', null));
+  // SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 (FR-8, THIRD site) — and the worst of the three.
+  //
+  // The STUCK-drain and the TTL convergence pass both stamp acknowledged_at; this one stamps
+  // acknowledged_at AND read_at together, so a single write blinds four surfaces at once: the
+  // coordinator inbox, the sender's outstanding view, isRouterSwallowed (which requires
+  // !read_at), and REPLY_STARVATION — the last because no auto_acked marker is written either,
+  // so isGenuinelyAcknowledged reads it as a HUMAN answer rather than a machine stamp.
+  //
+  // Newly reachable BECAUSE of this SD: pre-fix, promoted rows carried acknowledged_at and never
+  // entered this selector at all. Measured during review, the real 9 promoted rows classify
+  // 9/9 as action='stamp' here. It is manual-only and dry-run by default, which is why it is not
+  // the emergency the STUCK-drain was — but "requires a human to run it" is not a guard.
+  const unacked = await all('session_coordination', 'id,target_session,payload,message_type,subject', (q) => q
+    .is('acknowledged_at', null)
+    .is(`payload->>${PROMOTION_ACK_KEY}`, null));
   const dead = unacked.filter((r) => { const t = r.target_session; return !t || !byId.has(t) || !isLive(t); });
   console.log(`unacked=${unacked.length} live-backlog(excluded)=${unacked.length - dead.length} dead-letter=${dead.length}`);
 

--- a/scripts/one-off/store-security-evidence-signal-router-auto-001-rereview.mjs
+++ b/scripts/one-off/store-security-evidence-signal-router-auto-001-rereview.mjs
@@ -1,0 +1,432 @@
+// SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 — SECURITY sub-agent RE-REVIEW evidence writer (EXEC phase).
+// Re-verification of commit 9fc14a16 against the two BLOCKING findings in the prior SECURITY row
+// (cdb59cda-89cb-4df0-8e43-0d55a1bdf85b, verdict FAIL). Canonical path:
+// resolveSubAgentRepo -> applySubAgentRepoVerdict -> storeSubAgentResults.
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../../lib/sub-agent-executor/results-storage.js';
+
+const SD_ID = '1182898f-1725-4b46-8a14-ed171d7685aa';
+const SD_KEY = 'SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001';
+const PHASE = 'EXEC';
+const CODE = 'SECURITY';
+
+const results = {
+  verdict: 'CONDITIONAL_PASS',
+  confidence: 88,
+  validation_mode: 'prospective',
+  execution_time_ms: 0,
+  summary:
+    'RE-REVIEW of 9fc14a16 against the prior SECURITY FAIL (row cdb59cda). BOTH BLOCKERS ARE GENUINELY CLOSED, ' +
+    'and I verified each adversarially rather than accepting the commit message. B1: the 304-file scope that ' +
+    'previously read 4 failed | 3618 passed now reads 309 files, 3652 passed, 1 skipped, ZERO failed — and the ' +
+    'convergence suite is 6/6. B2: scripts/drain-dead-letter-coordination.mjs:37 now carries the exclusion ' +
+    'importing PROMOTION_ACK_KEY, and the module header is corrected from TWO to THREE with the count ' +
+    'explicitly labelled current-knowledge-not-a-closed-set. I upgrade on measurement, not on the report. ' +
+    'THE SPECIFIC QUESTION ASKED — is the grep-cannot-see-runtime-death gap CLOSED or merely RELOCATED — is ' +
+    'answered by a six-mutation harness that PROVES each mutation landed (git diff non-empty) before running: ' +
+    'CLOSED for convergeAckTTL (deleting the guard, commenting it out, and the wrong-key import rebind all turn ' +
+    'the suite RED) and CLOSED for the STUCK-drain (relocating the guard to an unrelated query turns it RED, so ' +
+    'the block-scoping works). RELOCATED for the dead-letter drain: M5 — delete the guard from the real query ' +
+    'and bolt an identical .is() onto an unrelated helper in the same file — leaves the suite 14/14 GREEN. The ' +
+    'guard IS present and correct in shipped code (proven separately by a live positive control), but its ' +
+    'regression protection is defeatable by exactly the evasion the commit says it killed, on the newest guard ' +
+    'and the one the commit itself calls "the worst of the three". The test-file header claiming the residual ' +
+    'assertions "scope to the enclosing query block" is true of the sweep and NOT true of the dead-letter site. ' +
+    'FOURTH PATH FOUND, as asked. Not an ack-writer, which is why neither my first enumeration nor the three ' +
+    'guards cover it: lib/sweep/passes/dead-letter-planning.cjs (and its twin lib/sweep/legacy-fallback.cjs) ' +
+    'writes a COMPUTED patch (dl.update) rather than a literal acknowledged_at, so a grep for "acknowledged_at:" ' +
+    'cannot see it. Its selector is .is(acknowledged_at,null).is(read_at,null) — EXACTLY the post-fix promoted ' +
+    'state, and newly reachable for the same reason as path 3. Confirmed by EXECUTING the real planDeadLetters ' +
+    'against a crafted post-fix promoted row: 1 row planned, patch sets read_at + dead_letter, with a negative ' +
+    'control (same row, target alive) returning 0. It runs AUTOMATICALLY every sweep tick, unlike the manual ' +
+    'path 3. Harm is materially smaller than paths 1-3 and I will not inflate it: it never sets ' +
+    'acknowledged_at, so the coordinator inbox, the sender view and REPLY_STARVATION all keep showing the row; ' +
+    'what it does is stamp read_at and start a 7-day cleanup_expired_coordination fuse, after which the row is ' +
+    'ARCHIVED (not destroyed) while its content survives in the feedback row it was promoted into. ' +
+    'I ALSO RETRACT MY OWN S2a BACKFILL RECOMMENDATION — the coordinator is right and I was wrong. Measured: 8 ' +
+    'of the 10 promoted feedback rows are status=resolved, so disposition is recorded in feedback.status, not ' +
+    'in session_coordination.acknowledged_at. Un-acking them would resurface answered work as unhandled, which ' +
+    'is a different false state, not a repair. My error was treating session_coordination as the custody ' +
+    'surface when promotion exists precisely to move custody to feedback. S3b ROUTING IS CORRECT and I verified ' +
+    'the escalation actually happened rather than accepting that it was sent: row 8ef9f9d6 -> feedback 2c6555e3 ' +
+    '"PRE-EXISTING CRITICAL, found during SECURITY review of SIGNAL-ROUTER-A...". It is pre-existing and out of ' +
+    'scope; filing rather than blocking is the right call. S4 and S5 should NOT block. Two conditions remain, ' +
+    'both follow-ups against a control that is live and correct, neither a defect in shipped behaviour — which ' +
+    'is why this is CONDITIONAL_PASS and not FAIL, and equally why it is not a clean PASS.',
+  conditions: [
+    { action: 'Block-scope the dead-letter guard assertion in tests/unit/coordinator/promotion-ack-guards.test.js the same way the STUCK-drain assertion was scoped (slice to the enclosing query), and correct the test-file header, which claims the residual source assertions scope to the enclosing query block — true of the sweep, not of the dead-letter site. Mutation M5 proves the current assertion survives guard relocation.', priority: 'high', blocking: false },
+    { action: 'Assess lib/sweep/passes/dead-letter-planning.cjs and its twin lib/sweep/legacy-fallback.cjs as the FOURTH path: automatic, every sweep tick, selector .is(acknowledged_at,null).is(read_at,null) matches the post-fix promoted state, confirmed by executing planDeadLetters with a negative control. Either exclude promotion-marked rows or record in promotion-ack.cjs why a 7-day archive fuse on a promoted row is acceptable.', priority: 'medium', blocking: false }
+  ],
+  findings: [
+    {
+      id: 'R1-B1-CLOSED-red-tier-is-green',
+      severity: 'info',
+      note: 'VERIFIED CLOSED. I re-ran the IDENTICAL 304-file scope I used to raise the original finding — ' +
+        'tests/unit/coordinator, tests/unit/retention, tests/unit/fleet, tests/unit/coordination, lib/coordinator ' +
+        '(plus tests/unit/sweep) — so the before/after numbers span the same extent rather than a scope chosen ' +
+        'after the fact. BEFORE: 4 failed | 3618 passed | 1 skipped. NOW: 309 files, 3652 passed | 1 skipped, ' +
+        'ZERO failed. The three previously-red suites (session-coordination-ack-convergence, ' +
+        'promotion-ack-guards, promotion-ack) run 29/29. The mock rewrite is the right shape: a self-returning ' +
+        'builder that RECORDS filters instead of encoding their arrival order, which is what made the old mock ' +
+        'fail on a change the SUT handled correctly. I did not re-run the full 35k tier and do not claim to have ' +
+        'verified the "7 failed / 34998 passed baseline-identical" figure — that specific claim is RELAYED, NOT ' +
+        'VERIFIED-BY-ME. What I verified is that the regression I raised is gone in the scope I raised it in.',
+      recommendation: 'None. Closed.'
+    },
+    {
+      id: 'R2-B2-CLOSED-third-writer-guarded-and-the-guard-mechanism-proven-live',
+      severity: 'info',
+      note: 'VERIFIED CLOSED, and I proved the MECHANISM rather than the presence of a line. ' +
+        'scripts/drain-dead-letter-coordination.mjs:37 now chains .is(`payload->>${PROMOTION_ACK_KEY}`, null) ' +
+        'onto the candidate select, importing the key via createRequire. THE PROBLEM WITH TESTING THAT GUARD ' +
+        'TODAY: zero live rows carry promotion_ack (the router fix is unmerged), so any assertion about it ' +
+        'CANNOT FAIL and a green reading would be inert. So I ran a POSITIVE CONTROL on a POPULATED key with the ' +
+        'identical filter shape: total rows 5253; rows carrying payload.routed_to_feedback_id = 10; ' +
+        '.is(payload->>routed_to_feedback_id, null) = 5243. 5243 == 5253 - 10 exactly, so the ' +
+        '.is(payload->>KEY, null) shape genuinely EXCLUDES rows carrying the key at the PostgREST layer. ' +
+        'Because the exclusion sits in the SELECT, a promoted row never enters `unacked`, is never passed to ' +
+        'classifyDeadLetterRow, and is therefore never reached by the L64 update that writes acknowledged_at AND ' +
+        'read_at together. That is the specific four-surface blinding I raised — coordinator inbox, sender ' +
+        'outstanding view, isRouterSwallowed (needs !read_at) and REPLY_STARVATION (no auto_acked marker, so ' +
+        'isGenuinelyAcknowledged reads it as a human answer) — and it is prevented at the selector, which is the ' +
+        'strongest place to prevent it. The header correction from TWO to THREE, with the count labelled as ' +
+        'current knowledge rather than a closed set, is the right fix for the false-completeness half.',
+      recommendation: 'None on the control itself. See R3 for its regression protection.'
+    },
+    {
+      id: 'R3-CONDITION-the-grep-gap-is-CLOSED-twice-and-RELOCATED-once',
+      severity: 'medium',
+      note: 'THE DIRECT ANSWER TO THE QUESTION ASKED. I built a six-mutation harness that, for each mutation, ' +
+        'FIRST proves the mutation actually landed (git diff must be non-empty, else the case is reported ' +
+        'INVALID rather than passing) and then runs promotion-ack-guards + session-coordination-ack-convergence. ' +
+        'Baseline unmutated: 14/14 green. RESULTS — M1 delete the convergeAckTTL guard line: RED. M2 rebind the ' +
+        'convergeAckTTL import as { PROMOTION_ACK_SOURCE_KEY: PROMOTION_ACK_KEY } so it filters the WRONG ' +
+        'column: RED. M3 comment the convergeAckTTL guard out: RED. M4 delete the STUCK-drain guard from its ' +
+        'query and bolt an identical .is() elsewhere in the 3800-line file: RED (the slice-scoping works). ' +
+        'M6 rebind the dead-letter import to the wrong key: RED. So five of six evasions are genuinely dead, ' +
+        'and the behavioural spy on convergeAckTTL is real — it observes the filters actually applied and ' +
+        'asserts the exact column string, which is why M2 dies. THE ONE THAT SURVIVED — M5: delete the guard ' +
+        'from the dead-letter drain\'s real query and bolt an identical .is() onto an unrelated helper in the ' +
+        'same file. Suite stayed 14/14 GREEN. So the gap is CLOSED for convergeAckTTL and for the STUCK-drain, ' +
+        'and RELOCATED onto the dead-letter drain — the newest guard, and the one this very commit calls "the ' +
+        'worst of the three". The assertion at that site is file-global ' +
+        '(expect(deadLetter).toMatch(/\\.is\\(`payload->>\\${PROMOTION_ACK_KEY}`, null\\)/)) while the sweep\'s ' +
+        'equivalent was hardened with slice()-scoping in the same commit. The test-file header states that the ' +
+        'residual source assertions "(a) strip comments, and (b) scope to the enclosing query block rather than ' +
+        'matching file-globally" — (b) is true of the sweep and NOT true of the dead-letter site, so that ' +
+        'header is the same overclaim class the commit was written to remove, one file over. TO BE FAIR TO THE ' +
+        'FIX: drain-dead-letter-coordination.mjs is ~95 lines, not 3800, so accidental satisfaction is far less ' +
+        'likely there than it was in the sweep, and the shipped guard is correct today (R2). This is a ' +
+        'regression-protection gap, not a defect in the control — which is exactly why it is a CONDITION and ' +
+        'not a blocker.',
+      recommendation: 'Two lines: scope the dead-letter assertion with the same slice() idiom used for the ' +
+        'STUCK-drain (anchor on "session_coordination\', \'id,target_session" and cut at the closing paren), ' +
+        'and amend the test-file header so claim (b) describes what the file actually does at each of the three ' +
+        'sites. main() there has no injection point, so a behavioural spy would need a refactor — the scoped ' +
+        'source assertion is the proportionate fix.'
+    },
+    {
+      id: 'R4-FOURTH-PATH-dead-letter-planning-automatic-and-newly-reachable',
+      severity: 'medium',
+      note: 'ASKED FOR, AND FOUND. It is NOT an acknowledged_at writer, which is precisely why my first ' +
+        'enumeration missed it and why none of the three guards cover it: ' +
+        'lib/sweep/passes/dead-letter-planning.cjs:64 and its twin lib/sweep/legacy-fallback.cjs:101 both write ' +
+        'a COMPUTED patch — `.update(dl.update)` — so my original grep for the literal token "acknowledged_at:" ' +
+        'could never see them. THAT IS THE METHOD LESSON: I enumerated by ASSIGNMENT SYNTAX, and any writer ' +
+        'that builds its patch object elsewhere is invisible to that search. I re-enumerated by CALL SITE ' +
+        'instead and found three computed-patch updates on this table; the third ' +
+        '(scripts/hooks/coordination-inbox.cjs:735 `.update(upd)`, where upd.acknowledged_at is set ' +
+        'conditionally) I cleared BY EXECUTION rather than by reading — calling the real classifier on a ' +
+        'promoted-signal row shape returns {skip:true}, so it never reaches the ack branch. ' +
+        'WHY PATH 4 MATTERS: its selector is .is(acknowledged_at,null).is(read_at,null), which is EXACTLY the ' +
+        'state a promoted row now sits in, and it is newly reachable for the same reason as path 3 — pre-fix ' +
+        'those rows carried acknowledged_at and the caller filter excluded them. Confirmed by EXECUTING the real ' +
+        'exported planDeadLetters() against a crafted post-fix promoted row (ack null, read null, ' +
+        'promotion_ack true, target a stale coordinator UUID, past expires_at): 1 row planned, patch = ' +
+        '{read_at, payload:{...dead_letter:true, dead_letter_reason:target_dead}}, acknowledged_at NOT in the ' +
+        'patch. NEGATIVE CONTROL (identical row, target alive): 0 rows planned — so the probe discriminates and ' +
+        'is not just returning everything. It runs AUTOMATICALLY on every sweep tick, unlike the manual path 3. ' +
+        'I WILL NOT INFLATE THE HARM: because it never sets acknowledged_at, the coordinator inbox, the ' +
+        'sender\'s outstanding view and REPLY_STARVATION all continue to show the row (the starvation detector ' +
+        'deliberately does not skip read rows). What it actually does is stamp read_at and thereby start the ' +
+        'cleanup_expired_coordination fuse (expires_at < now AND read_at <= now-7d), after which the row is ' +
+        'ARCHIVED to retention_archive and deleted — 7 days, not instant, and archived rather than destroyed, ' +
+        'with the signal content independently preserved in the feedback row it was promoted into. So this is a ' +
+        'real fourth removal path, correctly characterised as slow and bounded rather than as a fifth ' +
+        'four-surface blinding. ALSO CLEARED IN THIS PASS, as classes my first enumeration never checked at ' +
+        'all: server-side writers (pg_proc across the public schema — only cleanup_expired_coordination, which ' +
+        'is DELETE-only, and an INSERT-lint function; neither updates acknowledged_at), TRIGGERS (one, BEFORE ' +
+        'INSERT, lint only), and REWRITE RULES (none). No hidden database-layer path exists.',
+      recommendation: 'Either add the promotion_ack exclusion to the dead-letter candidate read in both ' +
+        'dead-letter-planning.cjs and legacy-fallback.cjs (they are kept in lockstep by ' +
+        'sweep-legacy-twin-parity.test.js, so both or neither), or record explicitly in promotion-ack.cjs why a ' +
+        '7-day archive fuse on a promoted row is acceptable given the content lives in feedback. Do not leave ' +
+        'it unstated — an unenumerated path is how this SD got to a third writer.'
+    },
+    {
+      id: 'R5-RETRACTION-my-S2a-backfill-recommendation-was-wrong',
+      severity: 'info',
+      note: 'THE COORDINATOR IS RIGHT AND I WAS WRONG. Stating it as a retraction rather than burying it, ' +
+        'because a recommendation to mutate 9 production rows is the kind of advice that gets acted on. ' +
+        'MEASURED: of the 10 feedback rows the promoted signals were filed into, 8 are status=resolved ' +
+        '(dcf92daa, 66b0f7e7, 9d06bdb8, a8e7138e, f65e82a7, 48461d0a, 8b33b021, 26d2bccf); the 2 that are ' +
+        'status=new are the newest signal and my own S3b escalation filed minutes ago. So the disposition ' +
+        'record for these signals lives in feedback.status, NOT in session_coordination.acknowledged_at. ' +
+        'Un-acking them would push 8 already-answered items back into the coordinator inbox as unhandled — a ' +
+        'different false state, not a repair, and the mirror image of the defect this SD closes. MY ERROR: I ' +
+        'treated session_coordination as the custody surface, when promotion exists precisely to MOVE custody ' +
+        'to feedback; deletion of the coordination row therefore loses nothing operationally (content in ' +
+        'feedback, row in retention_archive). To answer the question as asked — "if you still think a backfill ' +
+        'is right, say what it should restore them TO" — there is no correct target state, which is itself the ' +
+        'proof the recommendation was wrong. Forward-only is right. ' +
+        'ONE FORWARD-LOOKING CONSEQUENCE WORTH RECORDING, which the same measurement surfaced: all 9 original ' +
+        'rows return hasCorrelatedReply=false even though 8 are resolved in feedback. After this fix, promoted ' +
+        'rows stay acknowledged_at-NULL with no correlated reply, so REPLY_STARVATION will alarm on them ' +
+        'indefinitely while feedback says resolved. The only state that silences the gauge is a manual ' +
+        'scripts/coordinator-ack-signal.cjs run, one id at a time, against 247 unacked signals — so the fix ' +
+        'removes the wrong auto-silencer without adding a right one. That is not a reason to backfill and not a ' +
+        'blocker; it is a reason to give the coordinator a bulk disposition verb, or to teach ' +
+        'isGenuinelyAcknowledged to consult the promoted feedback row\'s status, before the gauge gets tuned ' +
+        'out as noisy.',
+      recommendation: 'Do NOT backfill. Do consider, as a follow-up, either a bulk disposition verb or teaching ' +
+        'the starvation gauge to treat a promoted row whose feedback row is resolved as answered — otherwise ' +
+        'the gauge this SD just restored will alarm on resolved work.'
+    },
+    {
+      id: 'R6-S3b-routing-is-correct-and-the-escalation-was-verified-not-assumed',
+      severity: 'info',
+      note: 'THE ROUTING IS RIGHT — filing it, not blocking this PR, is the correct call and I would push back ' +
+        'if it were blocked here. The authenticated-role TRUNCATE exposure is pre-existing, sits entirely ' +
+        'outside this diff, and its fix is a grants audit (a REVOKE plus a sweep for the same pattern on other ' +
+        'tables), not anything this PR can carry. Blocking a communication-integrity fix on an unrelated ' +
+        'platform grant would delay a control that reduces harm while fixing nothing. I VERIFIED THE ' +
+        'ESCALATION ACTUALLY LANDED rather than accepting that it was sent: session_coordination row 8ef9f9d6 ' +
+        'exists (read_at SET, correlated reply present) and was promoted into feedback 2c6555e3, titled ' +
+        '"PRE-EXISTING CRITICAL, found during SECURITY review of SIGNAL-ROUTER-A...", status=new. Both related ' +
+        'notes are in scope of that filing: the migration file still shipping FOR ALL USING(true) WITH ' +
+        'CHECK(true) with no TO clause while live has diverged to a SELECT-only policy, and anon holding SELECT ' +
+        'on every signal body. One addition for the filed item: the TRUNCATE grant is RLS-invisible on EVERY ' +
+        'table that carries it, so the finding is a grants audit rather than a single revoke.',
+      recommendation: 'Keep the routing as filed. Add "sweep all tables for a TRUNCATE grant to authenticated" ' +
+        'to the filed item — the class, not the instance.'
+    },
+    {
+      id: 'R7-S4-and-S5-should-not-block',
+      severity: 'low',
+      note: 'ASKED DIRECTLY, ANSWERED DIRECTLY: NEITHER SHOULD BLOCK. S4 (fail-open on a missing or renamed ' +
+        'key) — the failure requires someone to rename or mistype the key, and the single-constant import at ' +
+        'all three sites plus the now-mutation-proven wrong-key assertions (M2 and M6 both RED) make that the ' +
+        'hard path rather than the easy one. The residual SQL/JS divergence at promotion_ack:false remains real ' +
+        '(SQL skips the row, isPromotionAcked returns false, so it is undrainable AND silent to the gauge) but ' +
+        'it is reachable only by a service-role writer choosing to write a non-true value, and it fails toward ' +
+        'RETENTION. S5 (promotion_ack_source has no readers) — the commit now frames it as provenance for a ' +
+        'human rather than a control, which is an honest description of what it is, and once described that ' +
+        'way it is not a defect. Neither is worth holding a control that reduces live harm. Both are correctly ' +
+        'stated rather than claimed otherwise, and that is the property that matters.',
+      recommendation: 'No action required to merge. If either is ever touched again, prefer making the SQL and ' +
+        'JS predicates agree over deleting either one.'
+    },
+    {
+      id: 'R8-why-conditional-pass-and-not-fail',
+      severity: 'info',
+      note: 'STATED EXPLICITLY BECAUSE THE INSTRUCTION WAS NOT TO UPGRADE AS A FORMALITY. The two findings that ' +
+        'produced the FAIL were defects in SHIPPED BEHAVIOUR: a red test tier reported green, and a live ' +
+        'unguarded writer that retired unread operational orders. Both are now closed and I verified each by ' +
+        'execution — a re-run at the identical scope, a live positive control on the guard mechanism, and a ' +
+        'mutation harness that proves it mutated before it reports. What remains is categorically different: ' +
+        'R3 is a weakness in a TEST protecting a guard that is present and correct, and R4 is a slow, ' +
+        'archived, bounded removal path whose content survives in feedback. Neither makes the deliverable ' +
+        'wrong; both are follow-ups. Holding FAIL for them would make the verdict a statement about my ' +
+        'thoroughness rather than about the artifact, and would block a control that measurably reduces harm ' +
+        'today. Equally, PASS would be wrong: a surviving mutation on the newest guard and an unenumerated ' +
+        'automatic fourth path are exactly the kind of residue that should be recorded as conditions rather ' +
+        'than waved through. CONDITIONAL_PASS is the accurate instrument, and the two conditions are named ' +
+        'above so they are auditable rather than remembered.',
+      recommendation: 'Merge with the two conditions tracked as completion flags. If only one is taken, take ' +
+        'R3 — it is two lines and it protects the guard that the commit itself calls the worst of the three.'
+    }
+  ],
+  recommendations: [
+    'CONDITION 1 (high, non-blocking): block-scope the dead-letter guard assertion in promotion-ack-guards.test.js with the same slice() idiom used for the STUCK-drain, and correct the test-file header — its claim that the residual assertions "scope to the enclosing query block" is true of the sweep and false of the dead-letter site. Mutation M5 proves the assertion currently survives guard relocation.',
+    'CONDITION 2 (medium, non-blocking): decide and record the disposition of the FOURTH path — lib/sweep/passes/dead-letter-planning.cjs and its lockstep twin lib/sweep/legacy-fallback.cjs. Selector .is(acknowledged_at,null).is(read_at,null) matches the post-fix promoted state; confirmed by executing planDeadLetters with a negative control. Either exclude promotion-marked rows in both files, or state in promotion-ack.cjs why a 7-day archive fuse is acceptable.',
+    'DO NOT BACKFILL the 9/10 promoted rows — retracting my own prior recommendation. 8 of 10 promoted feedback rows are status=resolved; disposition lives in feedback.status, and un-acking would resurface answered work as unhandled.',
+    'FOLLOW-UP (medium): the fix removes the wrong auto-silencer without adding a right one — promoted rows stay ack-NULL with no correlated reply, so REPLY_STARVATION will alarm on rows whose feedback row says resolved. Give the coordinator a bulk disposition verb, or teach the gauge to consult the promoted feedback row status, before the restored gauge is tuned out as noisy.',
+    'KEEP S3b FILED, NOT BLOCKING — verified the escalation landed (session_coordination 8ef9f9d6 -> feedback 2c6555e3). Add "sweep every table for a TRUNCATE grant to authenticated" to that item: the grant is RLS-invisible wherever it exists, so it is a grants audit, not one revoke.',
+    'S4 and S5 should not block. Both are honestly stated; the single-constant import plus the now-mutation-proven wrong-key assertions make the S4 rename path hard rather than easy.',
+    'METHOD NOTE FOR THE NEXT ENUMERATION: enumerate ack-writers by CALL SITE, never by assignment syntax. My first pass grepped the literal "acknowledged_at:" and was structurally blind to the three computed-patch writers (.update(dl.update) x2, .update(upd) x1) — one of which is the fourth path. Also check pg_proc, pg_trigger and pg_rewrite; I did this pass and they are clean, but no JS grep can see them.'
+  ],
+  warnings: [
+    'The grep-cannot-see-runtime-death gap is CLOSED for convergeAckTTL and the STUCK-drain and RELOCATED onto the dead-letter drain. Mutation M5 (delete the guard from the real query, bolt an identical .is() onto an unrelated helper) leaves the suite 14/14 GREEN. Five of six mutations correctly turn it red; this one does not.',
+    'The prior enumeration was blind by CONSTRUCTION, not by carelessness: grepping "acknowledged_at:" cannot see a writer that builds its patch object elsewhere. Three such writers exist on this table and one of them is the fourth path. Any future count of writers on session_coordination must be taken by call site.',
+    'The "7 failed / 34998 passed, baseline-identical" full-tier figure is RELAYED-UNVERIFIED — I did not re-run the full tier. What I VERIFIED-BY-ME is that the 304-file scope in which I raised the regression is now 309 files / 3652 passed / 0 failed.',
+    'The guard on the dead-letter drain cannot be tested against live data today because zero rows carry promotion_ack — a green assertion on that key is currently unfalsifiable. The mechanism was therefore proven with a positive control on a populated key of identical shape (5243 == 5253 - 10), not by observing the marker itself.',
+    'After this fix REPLY_STARVATION will alarm indefinitely on promoted rows whose feedback row is already resolved (all 9 show hasCorrelatedReply=false while 8 are resolved). The only reachable silencer is a manual per-id CLI against a 247-row backlog. A gauge that cannot be silenced by the workflow that actually dispositions the work gets tuned out.'
+  ],
+  critical_issues: [],
+  detailed_analysis:
+    'RE-REVIEW SCOPE: commit 9fc14a16 against the two BLOCKING findings in SECURITY row cdb59cda (FAIL). The ' +
+    'instruction was explicit — do not upgrade as a formality — so every claim below is either VERIFIED-BY-ME ' +
+    'by execution or labelled RELAYED-UNVERIFIED.\n\n' +
+    'B1 — CLOSED. Re-run at the IDENTICAL 304-file scope used to raise it, so the before and after span the ' +
+    'same extent rather than a scope chosen after the fact: 4 failed | 3618 passed BEFORE, 309 files / 3652 ' +
+    'passed / 1 skipped / ZERO failed NOW. The mock rewrite is structurally right — recording filters instead ' +
+    'of encoding their arrival order is what stops it failing on changes the SUT handles correctly. I did NOT ' +
+    're-run the full 35k tier; the "baseline-identical" figure is relayed.\n\n' +
+    'B2 — CLOSED, and proven at the mechanism rather than at the line. The guard is in the SELECT, so a ' +
+    'promoted row never enters the candidate set, is never classified, and never reaches the L64 write that ' +
+    'sets acknowledged_at AND read_at together — which is the four-surface blinding I raised. Testing that ' +
+    'guard directly today is unfalsifiable (zero rows carry promotion_ack), so I ran a positive control on a ' +
+    'POPULATED key of identical shape: 5253 total, 10 carrying routed_to_feedback_id, 5243 returned by ' +
+    '.is(payload->>routed_to_feedback_id, null). 5243 == 5253 - 10 exactly. The exclusion shape works.\n\n' +
+    'THE QUESTION ASKED — CLOSED OR RELOCATED. Six mutations, each proving it landed (non-empty git diff) ' +
+    'before running, else reported INVALID. Baseline 14/14 green. M1 delete convergeAckTTL guard: RED. M2 ' +
+    'rebind its import to the wrong key: RED. M3 comment it out: RED. M4 relocate the STUCK-drain guard to an ' +
+    'unrelated query in the same 3800-line file: RED. M6 rebind the dead-letter import: RED. M5 relocate the ' +
+    'DEAD-LETTER guard the same way M4 did: GREEN — SURVIVED. So: closed twice, relocated once, onto the ' +
+    'newest guard and the one the commit calls the worst of the three. The behavioural spy on convergeAckTTL is ' +
+    'genuine (M2 dying proves it asserts the exact column string, not merely that some filter was applied). ' +
+    'The test-file header claiming the residual assertions "scope to the enclosing query block" describes the ' +
+    'sweep accurately and the dead-letter site inaccurately — the same overclaim shape the commit set out to ' +
+    'remove, one file over. Mitigating and stated in fairness: that file is ~95 lines, not 3800, so accidental ' +
+    'satisfaction is far less likely, and the shipped guard is correct today.\n\n' +
+    'THE FOURTH PATH. Found, and the reason it was missed is the useful part. My first enumeration searched by ' +
+    'ASSIGNMENT SYNTAX ("acknowledged_at:"), which is structurally blind to any writer that builds its patch ' +
+    'object elsewhere. Re-enumerating by CALL SITE surfaced three computed-patch updates on this table. Two are ' +
+    'the fourth path: lib/sweep/passes/dead-letter-planning.cjs:64 and its lockstep twin ' +
+    'lib/sweep/legacy-fallback.cjs:101, both `.update(dl.update)`. Their selector is ' +
+    '.is(acknowledged_at,null).is(read_at,null) — exactly the post-fix promoted state, newly reachable for the ' +
+    'same reason path 3 was. Confirmed by EXECUTING the real exported planDeadLetters against a crafted ' +
+    'post-fix promoted row: 1 row planned, patch sets read_at and dead_letter, acknowledged_at absent; negative ' +
+    'control with the target alive returns 0, so the probe discriminates. It runs automatically every sweep ' +
+    'tick. The third computed-patch writer (coordination-inbox.cjs:735) I cleared BY EXECUTION — the real ' +
+    'classifier returns {skip:true} on a promoted-signal shape, so it never reaches the ack branch. I also ' +
+    'cleared three classes the first pass never checked at all: server-side functions (pg_proc — only the ' +
+    'DELETE-only cleanup and an INSERT lint), triggers (one, BEFORE INSERT, lint), and rewrite rules (none). ' +
+    'HARM, NOT INFLATED: path 4 never sets acknowledged_at, so the inbox, the sender view and REPLY_STARVATION ' +
+    'all keep showing the row; it stamps read_at and starts a 7-day cleanup fuse, after which the row is ' +
+    'ARCHIVED, with content independently preserved in feedback. Slow, bounded, and worth guarding or ' +
+    'explicitly accepting — not a fifth emergency.\n\n' +
+    'MY OWN RETRACTION. The backfill recommendation in my prior row was wrong and the coordinator was right. ' +
+    '8 of the 10 promoted feedback rows are status=resolved, so disposition is recorded in feedback.status, ' +
+    'not in acknowledged_at; un-acking would push answered work back into the inbox as unhandled. Asked what ' +
+    'the backfill should restore them TO, there is no correct target — which is the proof. My error was ' +
+    'treating session_coordination as the custody surface when promotion exists to move custody to feedback. ' +
+    'The same measurement did surface a genuine forward-looking issue: all 9 show hasCorrelatedReply=false ' +
+    'while 8 are resolved, so post-fix the restored gauge will alarm indefinitely on resolved work and its only ' +
+    'reachable silencer is a manual per-id CLI against 247 rows.\n\n' +
+    'S3b ROUTING. Correct as filed, and I verified it landed rather than accepting that it was sent (row ' +
+    '8ef9f9d6 -> feedback 2c6555e3). It is pre-existing, its fix is a grants audit, and blocking this PR on it ' +
+    'would delay a harm-reducing control while fixing nothing.\n\n' +
+    'VERDICT. Both behaviour-level blockers are closed and independently verified. What remains is one weak ' +
+    'test protecting a correct guard and one slow, archived, bounded removal path. That is CONDITIONAL_PASS ' +
+    'with two named conditions — not FAIL, which would make the verdict about my thoroughness rather than the ' +
+    'artifact, and not PASS, which would wave through a surviving mutation on the newest guard and an ' +
+    'unenumerated automatic fourth path.',
+  metadata: {
+    version: '2.0.0',
+    review_type: 'adversarial_re_review_with_mutation_harness_and_live_positive_controls',
+    supersedes_row: 'cdb59cda-89cb-4df0-8e43-0d55a1bdf85b',
+    prior_verdict: 'FAIL',
+    reviewed_commit: '9fc14a164bce5ba400a36164a0f2d46c1723b5cf',
+    branch: 'feat/SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001',
+    pr: 6786,
+    blocker_status: {
+      B1_red_tier: 'CLOSED — verified at the identical 304-file scope: 4 failed -> 0 failed (309 files, 3652 passed)',
+      B2_third_writer: 'CLOSED — guard in the SELECT; mechanism proven by live positive control (5243 == 5253 - 10)'
+    },
+    mutation_harness: {
+      method: 'each mutation proves it landed (non-empty git diff) before the suite runs; otherwise reported INVALID rather than passing',
+      baseline: '14/14 green',
+      M1_converge_delete_guard: 'RED (correct)',
+      M2_converge_rebind_import_to_wrong_key: 'RED (correct — proves the spy asserts the exact column string)',
+      M3_converge_comment_guard_out: 'RED (correct)',
+      M4_sweep_relocate_guard_to_unrelated_query: 'RED (correct — block-scoping works)',
+      M5_deadletter_relocate_guard_to_unrelated_line: 'GREEN — SURVIVED. The gap is relocated here.',
+      M6_deadletter_rebind_import_to_wrong_key: 'RED (correct)',
+      verdict: 'closed for convergeAckTTL and the STUCK-drain; relocated onto the dead-letter drain'
+    },
+    fourth_path: {
+      files: ['lib/sweep/passes/dead-letter-planning.cjs:64', 'lib/sweep/legacy-fallback.cjs:101'],
+      why_missed_first_time: 'writes a COMPUTED patch (.update(dl.update)), invisible to a grep for the literal "acknowledged_at:"',
+      selector: '.is(acknowledged_at, null).is(read_at, null) — exactly the post-fix promoted state',
+      automatic: true,
+      proof: 'executed the real exported planDeadLetters on a crafted post-fix promoted row -> 1 row planned, patch sets read_at + dead_letter, acknowledged_at absent',
+      negative_control: 'identical row with target alive -> 0 rows planned',
+      harm: 'does NOT ack, so inbox / sender view / REPLY_STARVATION all keep showing it; stamps read_at and starts a 7-day cleanup fuse; row is ARCHIVED and content survives in feedback'
+    },
+    classes_cleared_this_pass: {
+      computed_patch_writers: '3 found by call-site enumeration; coordination-inbox.cjs:735 cleared BY EXECUTION (classifier returns {skip:true} on a promoted signal)',
+      server_side_functions: 'pg_proc scan — only cleanup_expired_coordination (DELETE-only) and session_coordination_insert_lint; neither updates acknowledged_at',
+      triggers: 'one, BEFORE INSERT, lint only',
+      rewrite_rules: 'none'
+    },
+    s2_backfill_retraction: {
+      prior_recommendation: 'backfill the 9 victims (acknowledged_at -> NULL, promotion_ack -> true)',
+      status: 'RETRACTED — the coordinator was right',
+      evidence: '8 of 10 promoted feedback rows are status=resolved; disposition lives in feedback.status, not acknowledged_at; there is no correct target state to restore them to',
+      residual_issue: 'all 9 show hasCorrelatedReply=false while 8 are resolved, so post-fix REPLY_STARVATION will alarm indefinitely on resolved work; only silencer is a manual per-id CLI against 247 rows'
+    },
+    s3b_routing: {
+      assessment: 'routing is CORRECT — file, do not block',
+      escalation_verified: 'session_coordination 8ef9f9d6 -> feedback 2c6555e3 "PRE-EXISTING CRITICAL, found during SECURITY review of SIGNAL-ROUTER-A...", status=new',
+      addition_requested: 'the TRUNCATE grant is RLS-invisible on EVERY table carrying it — file as a grants audit, not a single revoke'
+    },
+    live_measurements: {
+      session_coordination_total: 5253,
+      rows_with_routed_to_feedback_id: 10,
+      positive_control_is_filter: '5243 returned == 5253 total - 10 marked (PASS)',
+      unacked_rows_drain_candidate_pool: 4802,
+      promoted_feedback_rows_resolved: '8 of 10',
+      test_scope_before: '304 files, 4 failed | 3618 passed',
+      test_scope_after: '309 files, 0 failed | 3652 passed | 1 skipped'
+    },
+    provenance: {
+      verified_by_me: ['B1 re-run at identical scope', 'B2 guard mechanism via live positive control', 'six-mutation harness with landing proof', 'fourth path via executed planDeadLetters with negative control', 'coordination-inbox classifier via execution', 'pg_proc/pg_trigger/pg_rewrite scan', 'feedback.status of all 10 promoted rows', 'S3b escalation row and feedback row'],
+      relayed_unverified: ['the full-tier "7 failed / 34998 passed, baseline-identical" figure']
+    }
+  }
+};
+
+const resolution = await resolveSubAgentRepo({
+  sdId: SD_ID,
+  subAgentCode: CODE,
+  targetApplication: 'EHG_Engineer',
+  fallback: 'EHG_Engineer'
+});
+applySubAgentRepoVerdict(results, resolution);
+
+// results.summary and results.findings are NOT mapped columns (verified: both land NULL).
+// Fold them into detailed_analysis, which IS mapped, so the per-section evidence persists.
+const NL = String.fromCharCode(10);
+const HR = '-'.repeat(72);
+results.detailed_analysis = [
+  'SUMMARY',
+  '=======',
+  results.summary,
+  '',
+  results.detailed_analysis,
+  '',
+  'PER-SECTION FINDINGS (re-review R1-R8)',
+  '='.repeat(72),
+  '',
+  results.findings.map((f) => (
+    '[' + String(f.severity).toUpperCase() + '] ' + f.id + NL +
+    'FINDING: ' + f.note + NL +
+    'RECOMMENDATION: ' + (f.recommendation || '(none - informational)')
+  )).join(NL + NL + HR + NL + NL)
+].join(NL);
+
+const stored = await storeSubAgentResults(
+  CODE,
+  SD_ID,
+  { name: 'Chief Security Architect' },
+  results,
+  { sdKey: SD_KEY, phase: PHASE }
+);
+
+console.log('STORED_VERDICT=' + results.verdict);
+console.log('STORED_CONFIDENCE=' + results.confidence);
+console.log('STORED_ROW_ID=' + (stored?.id || stored?.data?.id || JSON.stringify(stored)));
+console.log('REPO_PATH=' + results.metadata.repo_path);
+console.log('REPO_RESOLVED=' + results.metadata.repo_resolved);
+console.log('EXECUTED_FROM_CWD=' + results.metadata.executed_from_cwd);

--- a/scripts/one-off/store-security-evidence-signal-router-auto-001.mjs
+++ b/scripts/one-off/store-security-evidence-signal-router-auto-001.mjs
@@ -1,0 +1,612 @@
+// SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 — SECURITY sub-agent evidence writer (EXEC phase).
+// Canonical path: resolveSubAgentRepo -> applySubAgentRepoVerdict -> storeSubAgentResults.
+// Adversarial COMMUNICATION-INTEGRITY threat model of the promotion-ack change on
+// branch feat/SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001, PR #6786.
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../../lib/sub-agent-executor/results-storage.js';
+
+const SD_ID = '1182898f-1725-4b46-8a14-ed171d7685aa';
+const SD_KEY = 'SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001';
+const PHASE = 'EXEC';
+const CODE = 'SECURITY';
+
+const results = {
+  verdict: 'FAIL',
+  confidence: 92,
+  validation_mode: 'prospective',
+  execution_time_ms: 0,
+  summary:
+    'The CORE control is sound and correctly aimed: stampRouted() no longer stamps acknowledged_at, the ' +
+    'non-disposing default is the right failure direction, and the two guarded sweeps (stale-session-sweep ' +
+    'STUCK-drain, convergeAckTTL) are genuinely guarded. Verified by EXECUTION against the live database, not ' +
+    'by reading: the PostgREST guard predicate .is(`payload->>promotion_ack`, null) applies cleanly (guarded ' +
+    'count 4779 == baseline 4779, inverse 0, no error), and the guards fail CLOSED (a select failure returns ' +
+    '{converged:0,error} / catches to [] — the row is KEPT, never drained). No new exposure of signal bodies. ' +
+    'BUT THE PR CANNOT MERGE AS-IS, on two independently blocking findings. (1) It BREAKS 4 EXISTING TESTS: ' +
+    'tests/unit/retention/session-coordination-ack-convergence.test.js is 5/5 PASS on origin/main and 1/5 PASS ' +
+    'on HEAD — the new second .is() is not present on the suite\'s mock query builder, so convergeAckTTL now ' +
+    'returns "select failed: ....is is not a function". Scoped by running 304 files: exactly this one file, ' +
+    'exactly these 4 tests, 3618 other tests green. Ironically this red suite is what PROVES the fail-closed ' +
+    'direction, and the PR\'s own guard test stays GREEN through it because that test asserts the guard by ' +
+    'GREPPING THE SOURCE STRING (toMatch(/\\.is\\(`payload->>\\${PROMOTION_ACK_KEY}`, null\\)/)) rather than by ' +
+    'executing convergeAckTTL — a source-text assertion cannot see a function whose runtime behaviour it just ' +
+    'broke. (2) THE ENUMERATION OF ACK-WRITERS IS INCOMPLETE AND THE CODE ASSERTS OTHERWISE. promotion-ack.cjs ' +
+    'states "TWO such writers were found and guarded". A THIRD exists: scripts/drain-dead-letter-coordination.mjs ' +
+    '(+ lib/coordination/dead-letter-drain.js), which selects on the same bare .is(\'acknowledged_at\', null), ' +
+    'filters to rows whose target_session is not live, and writes acknowledged_at AND read_at. I ran its real ' +
+    'classifier against the 9 real swallowed rows: ALL NINE classify action=\'stamp\', reason "noise kind INFO ' +
+    'to a non-live session -> drained". That path is strictly WORSE than the two that were guarded, because it ' +
+    'also sets read_at — which defeats the new isRouterSwallowed predicate (it requires !read_at), leaves no ' +
+    'auto_acked marker so isGenuinelyAcknowledged() reads it as a HUMAN answer and the starvation gauge goes ' +
+    'silent, and makes the row immediately reapable by cleanup_expired_coordination. It is also NEWLY REACHABLE ' +
+    'BECAUSE OF THIS FIX: pre-fix promoted rows carried acknowledged_at and never entered that selector at all. ' +
+    'Reachability is not hypothetical — 221 of the 227 in-window unacked signals already target a non-live ' +
+    'session, so coordinator rotation before disposition is the NORM. Mitigating: the script is manual (--apply, ' +
+    'no scheduler found) and has never been applied (0 rows carry payload.dead_letter_drained). The SD\'s own ' +
+    'FR-8 rationale — "guarding one and not the other would have left the fix self-reverting on a longer fuse" ' +
+    '— applies verbatim to this third sibling. Both blockers are cheap: fix the mock, guard the third writer (or ' +
+    'at minimum correct the false completeness claim in the header and file the guard as a tracked follow-up). ' +
+    'Separately and NOT introduced by this diff, one CRITICAL pre-existing platform finding on the exact table ' +
+    'this SD designates as the communication-integrity substrate: role `authenticated` holds a TRUNCATE grant on ' +
+    'session_coordination, and RLS DOES NOT GATE TRUNCATE — proven with a positive control on a scratch table ' +
+    'built to mirror the live policy/grant posture exactly (UPDATE blocked 0-rows by RLS, TRUNCATE SUCCEEDED, ' +
+    'all inside a rolled-back transaction; real table untouched at 5214 rows). Any holder of a user JWT can ' +
+    'destroy the entire coordination bus, bypassing the archive-before-delete design entirely.',
+  findings: [
+    {
+      id: 'S0-BLOCKING-four-tests-broken-by-this-pr',
+      severity: 'critical',
+      note: 'tests/unit/retention/session-coordination-ack-convergence.test.js: origin/main = 5 passed / 5. ' +
+        'HEAD = 4 FAILED / 1 passed. Established two-sided by checking out ONLY origin/main:lib/retention/' +
+        'session-coordination-ack-convergence.js into the worktree, re-running (5/5 green), then restoring HEAD ' +
+        '(4/5 red) — so the cause is this file\'s change, not a pre-existing flake or an unrelated main drift. ' +
+        'Error: "select failed: supabase.from(...).select(...).is(...).lte(...).is is not a function" — the ' +
+        'suite\'s mockSupabase builder exposes .is() once, and convergeAckTTL now calls .is() twice ' +
+        '(acknowledged_at, then payload->>promotion_ack). Blast radius scoped by running 304 test files across ' +
+        'tests/unit/coordinator, tests/unit/retention, tests/unit/fleet, tests/unit/coordination and ' +
+        'lib/coordinator: 4 failed | 3618 passed | 1 skipped — exactly this one file. ' +
+        'SECOND-ORDER FINDING, which is the more important half: the PR\'s OWN guard test ' +
+        '(tests/unit/coordinator/promotion-ack-guards.test.js) is GREEN across this breakage, because it ' +
+        'asserts the guard by reading the source file and regex-matching the filter string, never by calling ' +
+        'convergeAckTTL. A test that greps for a line cannot observe that the function containing that line now ' +
+        'returns an error on every invocation. The guard is currently proven only in the sense that the ' +
+        'characters are present in the file.',
+      recommendation: 'Add the missing .is() to the mock query builder in session-coordination-ack-convergence.' +
+        'test.js and re-run (target 5/5). Then add ONE EXECUTING guard assertion to promotion-ack-guards.test.js ' +
+        '— call convergeAckTTL against a mock returning both a promotion-marked and an unmarked candidate and ' +
+        'assert the marked row is NOT in `updates` — so the guard is proven by behaviour and not only by grep.'
+    },
+    {
+      id: 'S1-BLOCKING-third-unguarded-ack-writer-and-a-false-completeness-claim',
+      severity: 'critical',
+      note: 'S1 (enumerate EVERY path that can set acknowledged_at or otherwise retire a signal). I enumerated ' +
+        'all 24 non-test, non-archive sites that assign acknowledged_at on session_coordination and classified ' +
+        'each by whether a promoted worker friction signal (message_type=INFO, payload.signal_type set, ' +
+        'target=a coordinator session) can enter its selector. THIRD UNGUARDED PATH FOUND: ' +
+        'scripts/drain-dead-letter-coordination.mjs L37 selects `.is(\'acknowledged_at\', null)` across the whole ' +
+        'table, filters to rows whose target_session is absent-or-not-live, and at L64 writes ' +
+        '`{acknowledged_at: now, read_at: now, payload:{...,dead_letter_drained}}`. VERIFIED BY EXECUTION, not by ' +
+        'reading: I imported the real lib/coordination/dead-letter-drain.js classifyDeadLetterRow() and ran it ' +
+        'over the 9 real swallowed rows fetched from the live DB — all 9 returned {action:\'stamp\', reason:' +
+        '"noise kind INFO to a non-live session -> drained"}. They classify as noise because kind resolves to ' +
+        '`payload.kind || message_type` = "INFO" (worker signals carry no payload.kind — confirmed, kind=(none) ' +
+        'on all 9) and "INFO" is not in HIGH_VALUE_KINDS, and resolveTargetRole finds no "-> COORD" arrow in the ' +
+        '[WORKER_SIGNAL:*] subject convention. WHY THIS PATH IS WORSE THAN THE TWO THAT WERE GUARDED: it stamps ' +
+        'read_at as well as acknowledged_at, so (a) the row leaves the coordinator inbox AND the sender\'s ' +
+        'outstanding view (both gate on acknowledged_at IS NULL), (b) it carries NO auto_acked marker, so ' +
+        'isGenuinelyAcknowledged() in detectors.cjs counts it as a genuine human answer and REPLY_STARVATION goes ' +
+        'silent, (c) the new isRouterSwallowed() cannot see it because that predicate requires !read_at, and (d) ' +
+        'acknowledged_at IS NOT NULL makes it immediately eligible for cleanup_expired_coordination (all 9 rows ' +
+        'carry expires_at = created + 24h, all already past by the time any drain would plausibly run). NEWLY ' +
+        'REACHABLE BECAUSE OF THIS FIX: pre-fix, promoted rows had acknowledged_at set and could never enter that ' +
+        'selector. REACHABILITY IS THE NORM, NOT AN EDGE CASE: measured live, 221 of the 227 in-window unacked ' +
+        'signals target a session that is not in the live set, i.e. coordinator rotation before disposition is ' +
+        'the default outcome. MITIGATING: the script is manual (--apply; grep across json/js/cjs/mjs/yml/yaml/md ' +
+        'found no scheduler, cron or sweep reference) and has demonstrably never been applied with markers ' +
+        '(0 rows carry payload.dead_letter_drained, 0 carry payload.dead_letter_retargeted). THE FALSE CLAIM IS ' +
+        'THE BLOCKING PART: lib/coordinator/promotion-ack.cjs states "TWO such writers were found and guarded... ' +
+        'the second was found only because a reviewer enumerated the writers instead of trusting that the first ' +
+        'was the only one." That sentence asserts a completeness the enumeration did not achieve, and it is ' +
+        'exactly the sentence a future maintainer will trust instead of re-enumerating. ' +
+        'PATHS CHECKED AND CLEARED (so the enumeration is auditable rather than assertive): ' +
+        'lib/sweep/passes/dead-letter-planning.cjs (automatic, in-sweep, selects ack NULL + read NULL — but ' +
+        'planDeadLetters writes read_at + dead_letter, NEVER acknowledged_at, so it does not ack; it does hide ' +
+        'the row from unread selectors and start a 7-day cleanup fuse, noted separately as S2b); ' +
+        'lib/fleet/orphan-reroute-sweep.js (retargets, never acks — improves delivery); ' +
+        'scripts/adam-advisory.cjs + scripts/solomon-advisory.cjs ackRows (explicit id list + ownership-scoped to ' +
+        'their own target_session); scripts/worker-ack-directive.cjs (single id, refuses non-DIRECTIVE_KIND, ' +
+        'refuses target mismatch); scripts/worker-checkin.cjs (worker\'s OWN inbox, target=worker, never a ' +
+        'coordinator-targeted signal); scripts/fleet-coaching.cjs (single replyToSignalId, and it genuinely ' +
+        'sends a reply); lib/coordinator/relay-queue.cjs (ack-as-claim on relay rows, id-scoped, unclaims on ' +
+        'send failure); lib/fleet/canary-session.js (pre-stamps its own INSERT); scripts/coordinator-ack-signal.cjs ' +
+        '(the legitimate human disposition path); scripts/hooks/coordination-inbox.cjs (L156 explicitly SKIPS ' +
+        'rows carrying payload.signal_type — friction signals are deferred to the dashboard, never acked here); ' +
+        'scripts/fleet-dashboard.cjs printInbox (stamps read_at on render, NEVER acknowledged_at — verified at ' +
+        'L1481-1487); lib/coordinator/signal-router.cjs stampRoutedToCoordinator (unreachable, and the disclosure ' +
+        'is accurate — confirmed 0 rows have ever carried payload.routed_to_coordinator).',
+      recommendation: 'Add the same `.is(`payload->>${PROMOTION_ACK_KEY}`, null)` guard to the candidate select ' +
+        'in scripts/drain-dead-letter-coordination.mjs (L37), OR — better, because it fixes the class rather than ' +
+        'the instance — teach classifyDeadLetterRow() that a row carrying payload.signal_type is never "noise ' +
+        'kind INFO"; a friction signal orphaned to a dead coordinator is the canonical RETARGET case, not the ' +
+        'drain case. Minimum acceptable to merge: correct the "TWO such writers were found and guarded" sentence ' +
+        'in promotion-ack.cjs to name the third and state that it is unguarded and why, and file the guard as a ' +
+        'tracked completion flag. Shipping a header that overstates the enumeration is how the next maintainer ' +
+        'inherits a false floor.'
+    },
+    {
+      id: 'S2a-retention-net-improvement-but-the-nine-victims-are-not-backfilled',
+      severity: 'high',
+      note: 'S2 (does any retention/TTL path now DELETE or archive differently?). NET DIRECTION IS AN ' +
+        'IMPROVEMENT, established from the LIVE function body (pg_get_functiondef, not the migration file): ' +
+        'cleanup_expired_coordination() reaps `expires_at < now() AND (acknowledged_at IS NOT NULL OR (read_at ' +
+        'IS NOT NULL AND read_at <= now() - 7 days))`. Pre-fix a promoted signal was acked instantly and ' +
+        'therefore archived+deleted at expires_at; post-fix acknowledged_at stays NULL so it is NOT reaped. The ' +
+        'fix strictly EXTENDS retention of the signals it protects. The convergeAckTTL exposure the SD ' +
+        'identifies is real and correctly guarded (14-day TTL ack -> immediate cleanup eligibility). ' +
+        'THE GAP: the fix is forward-only and ships no backfill. All 9 measured victims are live RIGHT NOW with ' +
+        'acknowledged_at SET, read_at NULL, and expires_at = created + 24h — every one of them falls due on ' +
+        '2026-08-04 (00:52Z through 19:49Z). At the next cleanup tick past each row\'s expires_at they are ' +
+        'archived to retention_archive and DELETED from session_coordination. Their subjects are the reason this ' +
+        'matters: "LIVE DATA-LOSS EXPOSURE, LARGER THAN THE INCIDENT", "DO NOT FF THE ROOT YET", "STOP — the ' +
+        'QF-450 PROPOSED migration is now DESTRUCTIVE", "I SHIPPED A GATE THAT WILL SILENTLY DISCARD 35 CRITICAL ' +
+        'IT[EMS]" — all severity=critical, all read_at NULL, i.e. never rendered to anyone. All 9 currently ' +
+        'target a LIVE session, so a backfill would put them straight into the coordinator inbox where the fix ' +
+        'intends them to be. The SD\'s own evidence population is on a <24h fuse.',
+      recommendation: 'Ship a one-off backfill alongside the fix: for the 9 rows matching (payload->>' +
+        'routed_to_feedback_id IS NOT NULL AND acknowledged_at IS NOT NULL AND read_at IS NULL), set ' +
+        'acknowledged_at = NULL and merge payload.promotion_ack = true + promotion_ack_source. Without it the ' +
+        'fix rescues future signals while the nine it was written for are deleted, and the "before" state ' +
+        'survives only inside retention_archive where no operational surface reads it.'
+    },
+    {
+      id: 'S2b-unbounded-growth-and-the-surfaces-that-hide-the-oldest',
+      severity: 'high',
+      note: 'S2 (does the inbox grow unboundedly; is there a display cap that pushes older unread signals out ' +
+        'of view?). YES to growth, and the truncation question has a more serious answer than the cap. LIVE ' +
+        'COUNTS (COUNT head:true, never fetch-to-count): 5214 session_coordination rows total; 438 carry ' +
+        'payload.signal_type; 247 of those are acknowledged_at IS NULL. Promotion no longer retires any of them ' +
+        'and the ONLY disposition path is scripts/coordinator-ack-signal.cjs, a manual one-id-at-a-time CLI — so ' +
+        'the queue is now monotonically increasing with no drain, and the SD ships no bulk-disposition verb to ' +
+        'match. THREE SEPARATE HIDERS in scripts/fleet-dashboard.cjs printInbox (L1402-1410), in increasing order ' +
+        'of harm: (i) `.limit(20)` with `.order(created_at, ascending:false)` shows the NEWEST 20 and pushes the ' +
+        'oldest below the fold — but this is DISCLOSED, the code deliberately re-queries the true set with ' +
+        'fetchAllPaginated and prints "N unread signal(s) (showing newest 20)", so it is visible truncation and I ' +
+        'do not treat it as the harm. Worth noting for consistency: the sibling module lib/fleet/outstanding-' +
+        'signals.cjs states in its header that "The cap must drop the NEWEST rows" and orders ascending — the ' +
+        'sender side and the coordinator side cap in OPPOSITE directions. (ii) `.gte(\'created_at\', now-7d)` — a ' +
+        'signal older than seven days silently leaves the inbox AND leaves trueCount, while remaining unacked and ' +
+        'undeleted. Measured: 20 unacked signals are already past that window and are invisible with no marker, ' +
+        'no alarm and no state change. Post-fix, promoted signals live past 7 days by design, so this window is ' +
+        'now the default terminus for them. (iii) `.eq(\'target_session\', coordinatorId)` — the inbox is scoped ' +
+        'to the CURRENT coordinator session id, so a signal addressed to a previous coordinator never appears for ' +
+        'the successor. Measured: only 6 of the 227 in-window unacked signals target a live session; 221 are ' +
+        'orphaned. orphan-reroute-sweep.js would retarget them but gates on read_at IS NULL, and printInbox ' +
+        'stamps read_at on render — so a signal that was rendered once and never acked can never be rerouted. ' +
+        'Net: the fix correctly stops the router from retiring signals, but the surface it hands them to cannot ' +
+        'hold them — (ii) and (iii) are pre-existing and out of this SD\'s diff, yet they are what determines ' +
+        'whether the fix delivers its intended outcome.',
+      recommendation: 'Out of scope to fix here, in scope to STATE. Add a bulk/queue disposition path for the ' +
+        'coordinator (the growth this SD creates has no drain), and file the printInbox 7-day window and the ' +
+        'target_session=coordinatorId scoping as follow-ups — a promoted signal that survives the router only to ' +
+        'age out of the render window in 7 days, or to be orphaned by the next coordinator rotation, has been ' +
+        'retired by a different door.'
+    },
+    {
+      id: 'S3-marker-write-surface-equals-the-service-role-key',
+      severity: 'medium',
+      note: 'S3 (can an untrusted or lower-privileged writer SET payload.promotion_ack to make a row ' +
+        'permanently undrainable?). Established by EXECUTING as each role over the pooler inside a transaction ' +
+        'that was ROLLED BACK (verified after: probe row untainted, 0 rows carrying the probe key, real table ' +
+        'unchanged at 5214 rows). LIVE POSTURE, read from pg_policy/pg_class rather than the migration file: RLS ' +
+        'IS ENABLED and there is exactly ONE policy, `service_role_full_access`, polcmd=\'r\' (SELECT ONLY), ' +
+        'polroles=PUBLIC, using=true, withcheck=NULL. RESULTS — anon: SELECT succeeds (5214 rows, bodies ' +
+        'readable), UPDATE denied 42501 at the GRANT layer, so anon CANNOT set the marker. authenticated: SELECT ' +
+        'succeeds, UPDATE returns 0 ROWS (RLS, since no permissive UPDATE policy exists), INSERT explicitly ' +
+        'denied by RLS. service_role: UPDATE/INSERT/DELETE all succeed. CONCLUSION: NO untrusted or lower-' +
+        'privileged writer can set promotion_ack today. But the block on `authenticated` rests ENTIRELY on RLS ' +
+        'having no permissive write policy — the TABLE GRANTS for authenticated are wide open (INSERT, UPDATE, ' +
+        'DELETE, TRUNCATE, SELECT). One `CREATE POLICY ... FOR ALL USING(true) WITH CHECK(true)` would ' +
+        'instantly hand every user-JWT holder full write, and THAT EXACT STATEMENT IS STILL IN THE REPO at ' +
+        'supabase/ehg_engineer/migrations/20260309_session_coordination.sql L67-71, with no TO clause (it would ' +
+        'apply to PUBLIC). The live database has diverged to the safer SELECT-only form; the file has not. ' +
+        'ON THE SD\'S "payload vs column" DECISION: within the fleet trust model the choice does not widen the ' +
+        'write surface, because every worker/sweep/agent process runs with the SAME service-role key — a column ' +
+        'would be writable by exactly the same set. The honest statement is that the marker\'s write surface IS ' +
+        'the service-role key, so a buggy or misbehaving first-party process can make a row permanently ' +
+        'undrainable. That denial-of-cleanup fails in the SAFE direction (rows accumulate; nothing is lost) and ' +
+        'is bounded by the same growth already covered in S2b. No HTTP/API route writes session_coordination ' +
+        'with caller-supplied payload (grep across server/route/api handlers: none).',
+      recommendation: 'Not blocking for this PR. Correct the stale policy in ' +
+        'supabase/ehg_engineer/migrations/20260309_session_coordination.sql to match the live SELECT-only, ' +
+        'service-role-scoped posture (add TO service_role, drop FOR ALL) so a re-apply cannot silently open ' +
+        'write access to every authenticated user, and revoke the unused INSERT/UPDATE/DELETE grants from ' +
+        '`authenticated` so the control does not rest on RLS alone.'
+    },
+    {
+      id: 'S3b-CRITICAL-authenticated-can-truncate-the-coordination-bus-rls-does-not-gate-truncate',
+      severity: 'critical',
+      note: 'PRE-EXISTING, NOT INTRODUCED BY THIS DIFF, and out of scope for this PR — but it lands on the exact ' +
+        'table this SD designates as the communication-integrity substrate, so it belongs in this threat model. ' +
+        'information_schema.role_table_grants shows `authenticated` holds TRUNCATE on session_coordination. ' +
+        'Postgres RLS applies to SELECT/INSERT/UPDATE/DELETE and NOT to TRUNCATE. I did not test this on the ' +
+        'real table (the cost of being wrong is destroying the fleet\'s comms bus). Instead I built a POSITIVE ' +
+        'CONTROL: a scratch table mirroring the live posture exactly — RLS enabled, one SELECT-only PUBLIC ' +
+        'policy USING(true), and the identical grant set to `authenticated` — then acted as `authenticated` on ' +
+        'it. RESULT: UPDATE -> "BLOCKED (0 rows — RLS)", TRUNCATE -> SUCCEEDED, table emptied. Entire ' +
+        'transaction rolled back; scratch table confirmed gone (to_regclass = null) and the real table confirmed ' +
+        'unchanged at 5214 rows. So any holder of a Supabase user JWT can wipe the whole coordination lane in ' +
+        'one statement, bypassing cleanup_expired_coordination\'s archive-before-delete design entirely — no ' +
+        'retention_archive copy, no count-integrity check, nothing to revive. This is a strictly larger version ' +
+        'of the harm this SD exists to prevent: the SD stops 9 signals being silently retired; this destroys all ' +
+        '5214 rows with no archive.',
+      recommendation: 'File as its own SD/QF, not on this PR. `REVOKE TRUNCATE, INSERT, UPDATE, DELETE ON ' +
+        'session_coordination FROM authenticated;` (nothing in the codebase writes this table as anything but ' +
+        'service_role — verified). Then sweep for the same pattern: a blanket TRUNCATE grant to `authenticated` ' +
+        'is RLS-invisible on EVERY table that has it, so the fix is a grants audit, not one revoke.'
+    },
+    {
+      id: 'S4-fails-closed-on-error-but-fails-OPEN-on-a-missing-or-renamed-key',
+      severity: 'medium',
+      note: 'S4 (if the filter errors or the key is absent/malformed, does the sweep drain the row or skip it?). ' +
+        'Answered by reading the code paths AND by execution. ON ERROR: FAIL-CLOSED, which is the safe direction ' +
+        'here — stale-session-sweep.cjs wraps the candidate read in try/catch and sets stuckSignals = [] (no ' +
+        'drain, rows kept); convergeAckTTL catches and returns {converged:0, error} without updating anything. ' +
+        'This is not a reading, it is observed behaviour: the 4 broken tests in finding S0 are literally the ' +
+        'error case executing, and convergeAckTTL converged 0. ON A MISSING OR RENAMED KEY: FAIL-OPEN, and this ' +
+        'is the sharper risk. `payload->>\'<absent key>\'` is SQL NULL, so `.is(<expr>, null)` MATCHES the row ' +
+        'and the sweep drains it. Measured live: a probe filter on a deliberately nonexistent key ' +
+        '(`payload->>zzz_no_such_key is null`) returned 5217 of ~5214 rows — i.e. a typo in the key name turns ' +
+        'BOTH guards into silent no-ops with no error and no observable difference. Well mitigated by importing ' +
+        'the shared PROMOTION_ACK_KEY constant at all three sites, and the guards test pins that the literal ' +
+        'string form is NOT used — good design, worth keeping. SECOND, UNGUARDED ISSUE — THE SQL PREDICATE AND ' +
+        'THE JS PREDICATE DISAGREE. isPromotionAcked() requires strictly `=== true`; the SQL guard excludes on ' +
+        'ANY non-null extraction. Proven against live Postgres across six payload shapes: {"promotion_ack":false} ' +
+        '-> ->> yields \'false\' -> SWEEP SKIPS (row kept) but isPromotionAcked() is false -> the detector treats ' +
+        'the routed row as ANSWERED and REPLY_STARVATION stays SILENT. Same for "yes" and 0. So a row carrying ' +
+        'promotion_ack:false is simultaneously permanently undrainable AND invisible to the alarm — the worst ' +
+        'combination available, reachable by any service-role writer (see S3) and by a future refactor that ' +
+        'writes the key as a tri-state. THIRD: stampRouted() issues its payload update with NO error check and ' +
+        'no writeback verification (`await supabase...update(...).eq(\'id\', r.id);`, return value discarded). ' +
+        'The entire protection now rides on that one unverified write, in a lane whose whole thesis is that a ' +
+        'silent write failure is the harm — and the repo already ships lib/db/writeback-verify.mjs for exactly ' +
+        'this.',
+      recommendation: 'Make the two predicates agree: either have the SQL guard test `payload->>promotion_ack ' +
+        'IS DISTINCT FROM \'true\'` (or .neq(...,\'true\')) so only the literal true is protected, or relax ' +
+        'isPromotionAcked to "key present" — but not one of each. And check stampRouted\'s update error: ' +
+        '`.select(\'id\')`, assert one row came back, log loudly on mismatch. A guard keyed on a marker whose ' +
+        'write is never verified is a guard keyed on an assumption.'
+    },
+    {
+      id: 'S5-promotion_ack_source-is-inert-provenance',
+      severity: 'low',
+      note: 'S5 (is promotion_ack_source trustworthy; does anything make a security decision on it?). NOTHING ' +
+        'MAKES A SECURITY DECISION ON IT — so there is no impersonation risk, because there is nothing to ' +
+        'impersonate INTO. Full-repo grep for promotion_ack_source / PROMOTION_ACK_SOURCE: written once in ' +
+        'buildPromotionAckPayload, exported, and read in exactly one place — an assertion in ' +
+        'lib/coordinator/signal-router.test.js. Zero production readers. The field\'s own docstring says it ' +
+        'exists "so a later reader can tell WHICH automated writer set the marker", but BOTH sweep guards and ' +
+        'both consumers (detectors.cjs, outstanding-signals.cjs) key on the bare `promotion_ack` boolean and ' +
+        'never consult the source. So the trust decision is made on a value any service-role writer can set, ' +
+        'while the field that would let a reader attribute it is written and discarded. This is the same shape ' +
+        'the SD itself warns against in outstanding-signals.cjs ("a field nobody reads — the same shape as a ' +
+        'marker written but never consumed"): the principle was applied to `routed` and not to ' +
+        'promotion_ack_source. Low severity precisely because nothing depends on it — but it means the ' +
+        'provenance claim in the header is aspirational, not enforced.',
+      recommendation: 'Either key the two sweep guards on `payload->>promotion_ack_source = ' +
+        '\'signal_router_promotion\'` (which makes the provenance load-bearing and narrows the guard to rows the ' +
+        'router actually filed), or delete the field and drop the provenance sentence. Writing a provenance ' +
+        'field that no reader consults is indistinguishable from not having one.'
+    },
+    {
+      id: 'S6-no-new-exposure-of-signal-bodies',
+      severity: 'info',
+      note: 'S6 (anything in the diff that logs, persists or exposes signal BODIES to a new surface?). NO. ' +
+        'Reviewed every added line touching body/subject/payload/console across the 9 changed files. ' +
+        'buildPromotionAckPayload adds two scalar keys to an existing jsonb column already holding the same ' +
+        'row\'s metadata. outstanding-signals.cjs adds a boolean `routed` per row and a COUNT of routed rows to ' +
+        'the warning sentence — no body text, no subject, no sender identity beyond what the surface already ' +
+        'emitted. stampRouted removed a column write and added none. No new console/log/persist sink for body ' +
+        'content anywhere in the diff. CONTEXT WORTH RECORDING THOUGH, from the S3 probe: role `anon` can ' +
+        'already SELECT every row of session_coordination including `body` — I read "LIVE DATA-LOSS EXPOSURE, ' +
+        'LARGER THAN THE..." as anon. Pre-existing (single PUBLIC SELECT policy, USING(true)), not introduced ' +
+        'here — but this diff DOES extend the residency of those bodies, since promoted signals are no longer ' +
+        'acked and therefore no longer reaped by cleanup_expired_coordination at expires_at. The confidentiality ' +
+        'exposure is unchanged in kind and longer in duration.',
+      recommendation: 'No action on this PR. Fold the anon-SELECT-on-signal-bodies exposure into the grants ' +
+        'audit recommended in S3b — operational STOP/DO-NOT orders and data-loss disclosures are not anon-read ' +
+        'material, and the retention extension this SD (correctly) introduces makes that more true, not less.'
+    },
+    {
+      id: 'S7-unwired-detector-is-acceptable-as-disclosed-but-its-predicate-is-blind-to-the-likeliest-instance',
+      severity: 'medium',
+      note: 'S7 (is shipping an unwired detector for a security-relevant class acceptable as disclosed?). THE ' +
+        'DISCLOSURE ITSELF IS ACCURATE AND UNUSUALLY GOOD — I verified it rather than accepting it: grep across ' +
+        'the repo confirms isRouterSwallowed has zero callers outside its own unit test, and it is NOT present ' +
+        'in lib/governance/gauge-registry.js. The header says so plainly and says why a zero from an unrun ' +
+        'predicate is not evidence of health. On the narrow question, YES this is acceptable as disclosed: it is ' +
+        'a pure total function, two-sidedly unit-tested, adds no attack surface, changes no behaviour, and the ' +
+        'wiring is tracked as a completion flag. A control that exists on paper AND SAYS SO is materially ' +
+        'different from one that is silently inert. THE REAL PROBLEM IS THE PREDICATE, NOT THE WIRING: ' +
+        'isRouterSwallowed requires `Boolean(acknowledged_at) && !read_at && isPromotionAcked(row)`. The third ' +
+        'ack-writer found in S1 (drain-dead-letter-coordination.mjs) stamps read_at ALONGSIDE acknowledged_at, ' +
+        'so a signal retired by that path scores FALSE. Given 221 of 227 in-window unacked signals are already ' +
+        'orphaned to non-live coordinator sessions, that path is the LIKELIEST future instance of this defect ' +
+        'class — and the detector written to catch the class would be structurally unable to see it even after ' +
+        'it is wired. The predicate encodes the shape of the ONE instance that was measured (ack set, read null, ' +
+        'the 9 rows) rather than the class (a promotion-marked row retired by anything other than a human).',
+      recommendation: 'When wiring it, widen the predicate to the class: a promotion-marked row whose ' +
+        'acknowledged_at was set by anything other than coordinator-ack-signal.cjs — i.e. ' +
+        'isPromotionAcked(row) && row.acknowledged_at && !isGenuinelyHumanAck(row) — and drop the !read_at ' +
+        'clause, which only encodes that the coordinator inbox had not rendered the nine measured rows yet. As ' +
+        'written it will report a clean zero through the exact scenario it exists to catch.'
+    }
+  ],
+  recommendations: [
+    'BLOCKING: repair the mock in tests/unit/retention/session-coordination-ack-convergence.test.js (add the ' +
+      'second .is()) — origin/main is 5/5, HEAD is 1/5, and the regression is caused by this PR.',
+    'BLOCKING: guard scripts/drain-dead-letter-coordination.mjs (or teach classifyDeadLetterRow that a row with ' +
+      'payload.signal_type is never "noise kind INFO"), and correct the "TWO such writers were found and ' +
+      'guarded" sentence in lib/coordinator/promotion-ack.cjs — verified by execution that all 9 real swallowed ' +
+      'rows classify action=stamp on that path.',
+    'HIGH: add an EXECUTING assertion to promotion-ack-guards.test.js — the current guard proof is a regex over ' +
+      'the source text and stayed green while the guarded function returned an error on every call.',
+    'HIGH: backfill the 9 existing victims (acknowledged_at -> NULL, payload.promotion_ack -> true). They are ' +
+      'unread, severity=critical, target a live session, and every one expires 2026-08-04 — after which ' +
+      'cleanup_expired_coordination archives and deletes them.',
+    'MEDIUM: reconcile the SQL guard (any non-null) with isPromotionAcked (=== true) — proven divergent against ' +
+      'live Postgres; promotion_ack:false is currently undrainable AND silent to the starvation gauge.',
+    'MEDIUM: check stampRouted\'s payload update for error / verify the writeback — the whole control now rides ' +
+      'on one unverified write in a lane whose thesis is that silent write failure is the harm.',
+    'MEDIUM: when wiring isRouterSwallowed, drop the !read_at clause — it encodes the one measured instance, not ' +
+      'the class, and is blind to the third ack-writer.',
+    'OUT OF SCOPE, FILE SEPARATELY (CRITICAL): revoke TRUNCATE/INSERT/UPDATE/DELETE on session_coordination from ' +
+      '`authenticated` — positive-control proven that RLS does not gate TRUNCATE, so any user-JWT holder can ' +
+      'destroy the entire coordination bus with no archive. Sweep other tables for the same grant pattern.',
+    'OUT OF SCOPE, FILE SEPARATELY: printInbox\'s 7-day created_at window and its target_session=coordinatorId ' +
+      'scoping retire signals by a different door (20 rows already aged out; 221 of 227 orphaned) — the fix ' +
+      'hands signals to a surface that structurally cannot hold them.',
+    'OUT OF SCOPE, FILE SEPARATELY: supabase/ehg_engineer/migrations/20260309_session_coordination.sql still ' +
+      'contains FOR ALL USING(true) WITH CHECK(true) with no TO clause; the live DB has diverged to SELECT-only. ' +
+      'Re-applying the file would grant every authenticated user full write on this table.'
+  ],
+  warnings: [
+    'The PR\'s guard test proves the guard by GREPPING THE SOURCE STRING, not by executing it. It stayed green ' +
+      'through a change that made the guarded function return an error on every invocation. Treat "guards test ' +
+      'passes" as evidence that the characters are present, not that the guard runs.',
+    'The completeness claim "TWO such writers were found and guarded" is false as written. A third exists and ' +
+      'is strictly worse (it stamps read_at too, defeating the new detector and the starvation gauge ' +
+      'simultaneously). The claim is the part that will be trusted instead of re-enumerated.',
+    'The fix is forward-only. The nine signals it was written for are still acked, still unread, and all expire ' +
+      '2026-08-04 — cleanup_expired_coordination will archive and delete them unless they are backfilled.',
+    'Every measurement in this review was taken with COUNT head:true or from a full paginated fetch, never by ' +
+      'fetching-to-count; and every claim about the live database (policies, grants, the cleanup function body, ' +
+      'the classifier verdicts, the guard filter semantics) was read from the LIVE database or produced by ' +
+      'EXECUTING the real code, not inferred from migration files or from the diff\'s own comments.'
+  ],
+  critical_issues: [
+    'BLOCKING — PR breaks 4 existing tests: tests/unit/retention/session-coordination-ack-convergence.test.js is ' +
+      '5/5 PASS on origin/main and 1/5 PASS on HEAD. Cause: convergeAckTTL now calls .is() twice and the ' +
+      'suite\'s mock builder exposes it once ("select failed: ....is is not a function"). Established two-sided ' +
+      'by swapping only that one file to origin/main and back. Scoped across 304 test files: exactly this file.',
+    'BLOCKING — A THIRD unguarded acknowledged_at writer exists and the code asserts that only two do. ' +
+      'scripts/drain-dead-letter-coordination.mjs selects the same bare .is(acknowledged_at, null), filters to ' +
+      'non-live targets, and writes acknowledged_at + read_at. Verified by running the REAL classifier over the ' +
+      'REAL 9 swallowed rows: all 9 return action=stamp, "noise kind INFO to a non-live session -> drained". It ' +
+      'is worse than the two guarded siblings because read_at is stamped too — the row becomes invisible to the ' +
+      'coordinator inbox, to the sender\'s outstanding view, to isRouterSwallowed (needs !read_at) and to ' +
+      'REPLY_STARVATION (no auto_acked marker, so isGenuinelyAcknowledged reads it as a human answer), and it ' +
+      'becomes immediately reapable by cleanup_expired_coordination. It is NEWLY REACHABLE because of this fix ' +
+      '(pre-fix promoted rows were acked and never entered that selector), and 221 of 227 in-window unacked ' +
+      'signals already target a non-live session, so it is the norm rather than an edge case. Mitigating: manual ' +
+      '--apply only, no scheduler, 0 rows ever drained by it.',
+    'CRITICAL but PRE-EXISTING and OUT OF SCOPE for this PR — role `authenticated` holds TRUNCATE on ' +
+      'session_coordination and Postgres RLS does not gate TRUNCATE. Proven with a positive control on a ' +
+      'scratch table mirroring the live policy/grant posture exactly (UPDATE blocked 0-rows by RLS; TRUNCATE ' +
+      'SUCCEEDED), inside a rolled-back transaction; real table verified untouched at 5214 rows. Any user-JWT ' +
+      'holder can destroy the entire coordination bus, bypassing archive-before-delete. Must be filed separately.'
+  ],
+  detailed_analysis:
+    'SCOPE: threat-modelled as a COMMUNICATION INTEGRITY control per the review brief — the asset is a worker\'s ' +
+    'ability to deliver a STOP/DO-NOT order, a data-loss exposure or a destructive-migration warning to the ' +
+    'coordinator, and the harm is silent destruction of that message.\n\n' +
+    'METHOD: every load-bearing claim below was produced by EXECUTION against the live database or the real ' +
+    'code, never by reading the diff\'s own comments. Live reads: pg_policy / pg_class (RLS posture), ' +
+    'information_schema.role_table_grants (grants), pg_get_functiondef (the deployed ' +
+    'cleanup_expired_coordination body, which I did NOT take from the migration file), COUNT head:true for ' +
+    'every population figure, fetchAllPaginated for every set. Executions: the real classifyDeadLetterRow over ' +
+    'the real 9 rows; the real isPromotionAcked over six crafted jsonb shapes cross-checked against live ' +
+    'Postgres ->> semantics; role-scoped SELECT/UPDATE/INSERT/DELETE as anon, authenticated and service_role in ' +
+    'a rolled-back transaction; a positive-control scratch table for the RLS-vs-TRUNCATE question; and 304 test ' +
+    'files run at HEAD and the regressing file re-run against origin/main.\n\n' +
+    'WHAT THE CHANGE GETS RIGHT. stampRouted() no longer writes acknowledged_at, and the choice of a ' +
+    'NON-DISPOSING DEFAULT over a disposing-default-with-a-guard is the correct security posture: a future bug ' +
+    'in that function leaves a signal VISIBLE rather than destroyed. routed_to_feedback_id is preserved, so ' +
+    'dedup survives. The FR-4 detector carve-out is the necessary consumer half — marking a row without ' +
+    'teaching the gauge to skip the mark would have been an inert mechanism. Both guarded sweeps are genuinely ' +
+    'guarded and both fail CLOSED on read error. FR-9 correctly refuses to collapse "filed" and "untouched" on ' +
+    'the sender side, and correctly surfaces the new field in the rendered sentence rather than adding a field ' +
+    'nobody reads. No new exposure of message bodies. The disclosures on stampRoutedToCoordinator and on ' +
+    'isRouterSwallowed are both accurate — I checked each rather than accepting them (zero rows have ever ' +
+    'carried payload.routed_to_coordinator; isRouterSwallowed has zero non-test callers and is absent from ' +
+    'gauge-registry.js).\n\n' +
+    'WHY IT STILL FAILS. Two blockers, both cheap. First, the PR is RED: it breaks 4 tests that are green on ' +
+    'main, and the reason the breakage was not noticed is itself the finding — the PR\'s own guard test asserts ' +
+    'the guard by regex-matching the SOURCE TEXT of the file, so it stayed green while convergeAckTTL began ' +
+    'returning an error on every call. A grep-shaped test cannot observe the runtime death of the line it ' +
+    'greps for. Second, the enumeration of ack-writers is incomplete AND the code claims it is complete. I ' +
+    'enumerated all 24 non-test assignment sites and cleared 21 of them with a stated reason each (id-scoped, ' +
+    'ownership-scoped, own-inbox, reply-bearing, or read_at-only); the twenty-second is ' +
+    'scripts/drain-dead-letter-coordination.mjs, which selects on the identical bare acknowledged_at-IS-NULL ' +
+    'predicate the SD calls out as the shared defect shape in its two siblings. Running its real classifier ' +
+    'over the real nine rows returns action=stamp on all nine. The SD\'s own FR-8 sentence — "guarding one and ' +
+    'not the other would have left the fix self-reverting on a longer fuse" — is the exact argument for ' +
+    'guarding the third.\n\n' +
+    'THE ASYMMETRY THAT MAKES THE THIRD PATH THE WORST ONE. The two guarded sweeps stamp acknowledged_at and ' +
+    'leave a marker (auto_acked), so isGenuinelyAcknowledged() still reports the row as unanswered and the ' +
+    'gauge can alarm. The dead-letter drain stamps acknowledged_at AND read_at AND leaves no auto_acked marker. ' +
+    'That single difference simultaneously (a) removes the row from the coordinator inbox and the sender\'s ' +
+    'banner, (b) converts it to "genuinely acknowledged" in the starvation detector so the gauge goes silent, ' +
+    '(c) puts it outside isRouterSwallowed\'s !read_at clause so the new classifier cannot see it even once ' +
+    'wired, and (d) makes it immediately reapable. Four independent surfaces blinded by one write. And the fix ' +
+    'is what makes that write reachable: pre-fix, promoted rows carried acknowledged_at and could never enter ' +
+    'the selector.\n\n' +
+    'ON RETENTION (S2). The direction is good and should be stated plainly: reading the DEPLOYED function body, ' +
+    'cleanup_expired_coordination reaps `expires_at < now() AND (acknowledged_at IS NOT NULL OR (read_at IS NOT ' +
+    'NULL AND read_at <= now()-7d))`, so removing the ack removes the row from the reaper. Pre-fix a promoted ' +
+    'signal died at expires_at (created+24h, measured on all 9); post-fix it survives. The cost is a queue that ' +
+    'grows with no drain — 247 unacked signals today, one manual per-id CLI as the only disposition path — and ' +
+    'a set of surfaces that cannot hold what the fix hands them: printInbox windows to 7 days (20 rows already ' +
+    'past it, invisible with no marker and no state change) and scopes to the CURRENT coordinator session id ' +
+    '(only 6 of 227 in-window unacked signals target a live session). The .limit(20) cap is the least of these ' +
+    'because it is honestly disclosed via a separately-paginated true count; the window and the session scoping ' +
+    'are not disclosed anywhere. None of that is in this diff, but it determines whether the diff achieves its ' +
+    'purpose, so it is stated rather than waved through.\n\n' +
+    'ON THE MARKER (S3/S4/S5). Within this trust model there is no lower-privileged writer: anon cannot write ' +
+    '(42501 at the grant layer), authenticated cannot write (0 rows, blocked by RLS having no permissive write ' +
+    'policy), and every legitimate fleet process holds the same service-role key — so putting the marker in ' +
+    'payload rather than a column does not widen the write surface at all, and the SD\'s stated reason ' +
+    '(reviveArchivedSignal rebuilds through an explicit field map and would silently drop a new column) is a ' +
+    'good one. Two real defects remain. The SQL guard and the JS predicate disagree on every encoding except ' +
+    'literal true — proven live: promotion_ack:false is skipped by both sweeps (undrainable) while ' +
+    'isPromotionAcked returns false (gauge silent), the worst available combination. And promotion_ack_source, ' +
+    'the field whose stated purpose is telling a later reader WHICH writer set the marker, has zero production ' +
+    'readers; both guards key on the bare boolean. The SD applies exactly the right principle to `routed` in ' +
+    'outstanding-signals.cjs ("a field nobody reads — the same shape as a marker written but never consumed") ' +
+    'and then does not apply it to its own provenance field.\n\n' +
+    'ON FAIL DIRECTION (S4). Fail-closed on ERROR (observed, not reasoned — the 4 red tests ARE the error path, ' +
+    'and convergeAckTTL converged 0). Fail-OPEN on a MISSING key: a probe on a nonexistent key matched 5217 of ' +
+    '~5214 rows, so a rename or typo silently converts both guards into no-ops with no error. Importing the ' +
+    'shared constant at all three sites is the right mitigation and the guards test pins that the literal ' +
+    'string is not used — keep both.\n\n' +
+    'BOTTOM LINE: the control is correctly conceived and mostly correctly built. It cannot merge with a red ' +
+    'suite it caused, and it should not merge asserting an enumeration it did not complete — particularly when ' +
+    'the unenumerated path is the one that blinds four surfaces at once and is now reachable only because of ' +
+    'this change.',
+  metadata: {
+    version: '1.0.0',
+    review_type: 'adversarial_communication_integrity_threat_model_live_db_verified',
+    worktree_path: 'C:/Users/rickf/Projects/_EHG/EHG_Engineer/.worktrees/SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001',
+    branch: 'feat/SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001',
+    pr: 6786,
+    brief_sections_answered: {
+      S1_can_a_signal_still_be_silently_retired: 'FAIL — third unguarded ack-writer found (drain-dead-letter-coordination.mjs); 21 other sites enumerated and cleared with stated reasons',
+      S2_availability_retention_side_effect: 'MIXED — deletion posture strictly IMPROVED (ack removal takes rows out of cleanup_expired_coordination); unbounded growth REAL (247 unacked, no drain); display cap disclosed, but the 7-day window and target_session scoping hide 20 + 221 rows respectively; the 9 existing victims are NOT backfilled and expire 2026-08-04',
+      S3_marker_integrity: 'PASS with caveats — anon cannot write (grant), authenticated cannot write (RLS only, grants wide open); marker write surface == service-role key == every fleet process; payload-vs-column does NOT widen it',
+      S4_fail_open_or_closed: 'FAIL-CLOSED on error (observed); FAIL-OPEN on a missing/renamed key (probe matched 5217/5214 rows); SQL guard and JS predicate proven divergent at promotion_ack:false',
+      S5_privilege_provenance: 'INERT — promotion_ack_source has zero production readers; both guards key on the bare boolean; no security decision depends on it',
+      S6_new_exposure_of_signal_bodies: 'PASS — none in the diff; pre-existing anon SELECT on bodies is extended in DURATION by the retention change',
+      S7_unwired_classifier: 'ACCEPTABLE AS DISCLOSED (disclosure verified accurate) but the PREDICATE is blind to the third path because it requires !read_at'
+    },
+    live_measurements: {
+      session_coordination_total: 5214,
+      signal_rows_total: 438,
+      unacked_signals: 247,
+      unacked_signals_within_printinbox_7d_window: 227,
+      unacked_signals_older_than_7d_permanently_invisible: 20,
+      unacked_in_window_signals_targeting_a_live_session: 6,
+      unacked_in_window_signals_orphaned_to_a_dead_session: 221,
+      rows_with_routed_to_feedback_id: 9,
+      swallowed_rows_ack_set_read_null: 9,
+      rows_with_promotion_ack_marker: 0,
+      rows_with_dead_letter_drained_marker: 0,
+      live_session_set_size: 11,
+      guard_filter_probe_guarded_vs_baseline: '4779 == 4779 (filter applies cleanly, no error)',
+      guard_filter_probe_inverse: 0,
+      nonexistent_key_probe_matched_rows: 5217,
+      nine_victims_expires_at: 'all 2026-08-04 (created + 24h)'
+    },
+    test_results: {
+      ack_convergence_suite_on_origin_main: '5 passed / 5',
+      ack_convergence_suite_on_HEAD: '4 FAILED / 1 passed',
+      broad_run_at_HEAD: '304 test files: 4 failed | 3618 passed | 1 skipped — regression confined to session-coordination-ack-convergence.test.js',
+      sd_own_new_tests: 'promotion-ack.test.js and promotion-ack-guards.test.js both PASS (guards test is source-grep-based, see finding S0)'
+    },
+    files_reviewed: [
+      'lib/coordinator/promotion-ack.cjs (new)',
+      'lib/coordinator/signal-router.cjs',
+      'lib/coordinator/detectors.cjs',
+      'lib/fleet/outstanding-signals.cjs',
+      'lib/retention/session-coordination-ack-convergence.js',
+      'scripts/stale-session-sweep.cjs (stuck-drain + planDeadLetters + loadLiveSessionIds)',
+      'tests/unit/coordinator/promotion-ack.test.js',
+      'tests/unit/coordinator/promotion-ack-guards.test.js',
+      'lib/coordinator/signal-router.test.js',
+      'scripts/drain-dead-letter-coordination.mjs (read-only — THIRD PATH)',
+      'lib/coordination/dead-letter-drain.js (read-only + EXECUTED against live rows)',
+      'lib/sweep/passes/dead-letter-planning.cjs (read-only)',
+      'lib/fleet/orphan-reroute-sweep.js (read-only)',
+      'scripts/fleet-dashboard.cjs printInbox (read-only)',
+      'scripts/hooks/coordination-inbox.cjs (read-only)',
+      'scripts/adam-advisory.cjs / solomon-advisory.cjs / worker-checkin.cjs / worker-ack-directive.cjs / fleet-coaching.cjs / relay-queue.cjs / canary-session.js / coordinator-ack-signal.cjs (ack-writer enumeration)',
+      'supabase/ehg_engineer/migrations/20260309_session_coordination.sql',
+      'database/migrations/20260713_fix_cleanup_expired_coordination_where_clause.sql'
+    ],
+    empirical_verifications: [
+      'LIVE pg_policy: session_coordination has RLS enabled and exactly ONE policy — service_role_full_access, polcmd=r (SELECT ONLY), polroles=PUBLIC, using=true, withcheck=NULL. The in-repo migration file still says FOR ALL USING(true) WITH CHECK(true) with no TO clause — live has diverged to the safer form',
+      'LIVE grants: anon = SELECT/REFERENCES/TRIGGER; authenticated = SELECT/INSERT/UPDATE/DELETE/TRUNCATE/REFERENCES/TRIGGER; service_role = full',
+      'EXECUTED as anon (rolled back): SELECT 5214 rows OK, body of a critical STOP signal READABLE, UPDATE payload -> DENIED 42501 at the grant layer',
+      'EXECUTED as authenticated (rolled back): SELECT OK, UPDATE payload -> 0 rows (RLS), INSERT -> RLS violation',
+      'EXECUTED as service_role (rolled back): UPDATE/INSERT/DELETE all succeed — confirms the probe row was reachable, so the 0-row results above are RLS and not a bad WHERE clause',
+      'POSITIVE CONTROL on a scratch table mirroring the live posture (RLS on, one SELECT-only PUBLIC policy, identical authenticated grants): as authenticated, UPDATE -> BLOCKED 0 rows, TRUNCATE -> SUCCEEDED (table emptied). Proves RLS does not gate TRUNCATE. Rolled back; to_regclass = null; real table verified unchanged at 5214 rows',
+      'LIVE pg_get_functiondef of cleanup_expired_coordination — read the DEPLOYED body rather than the migration file; confirms the reap predicate is expires_at < now() AND (ack NOT NULL OR read_at <= now()-7d) with archive-before-delete and a count-integrity RAISE',
+      'EXECUTED the real classifyDeadLetterRow() from lib/coordination/dead-letter-drain.js over the 9 real swallowed rows fetched live: 9/9 -> action=stamp, "noise kind INFO to a non-live session -> drained"',
+      'LIVE ->> semantics cross-checked against isPromotionAcked() over 6 jsonb shapes: true -> SKIP/alarms; false, "yes", 0 -> SKIP but SILENT; null and absent -> DRAIN',
+      'PostgREST probe on a nonexistent payload key returned 5217 of ~5214 rows — a renamed/typo key silently disarms both guards',
+      'Guard filter probe: ack-NULL 4779 == ack-NULL + promotion_ack IS NULL 4779, inverse 0 — the filter applies at PostgREST without error',
+      'git checkout of ONLY lib/retention/session-coordination-ack-convergence.js to origin/main and back, re-running the suite each time: 5/5 green on main, 4/5 red at HEAD — two-sided attribution of the regression to this PR',
+      'npx vitest run across tests/unit/coordinator, tests/unit/retention, tests/unit/fleet, tests/unit/coordination, lib/coordinator: 304 files, 4 failed | 3618 passed | 1 skipped',
+      'grep: isRouterSwallowed has zero callers outside its own unit test and is absent from lib/governance/gauge-registry.js — the unwired disclosure is accurate',
+      'grep: promotion_ack_source has zero production readers (one assertion in signal-router.test.js only)',
+      'grep across json/js/cjs/mjs/yml/yaml/md: drain-dead-letter-coordination.mjs has no scheduler, cron or sweep caller — manual --apply only',
+      'LIVE: 0 rows carry payload.dead_letter_drained or payload.dead_letter_retargeted — that script has never been applied with markers'
+    ],
+    notes_on_method: 'All probe scripts were transient and deleted; the two mutating probes ran inside explicit ' +
+      'transactions that were ROLLED BACK, with post-checks confirming zero tainted rows and an unchanged table ' +
+      'row count. No live data was modified by this review.'
+  }
+};
+
+// results.summary and results.findings are NOT mapped columns on sub_agent_execution_results
+// (verified by reading the row back: both landed NULL). Fold them into detailed_analysis, which IS
+// mapped and uncapped, so the per-section S1-S7 evidence is not silently discarded.
+const NL = String.fromCharCode(10);
+const HR = '-'.repeat(72);
+results.detailed_analysis = [
+  'SUMMARY',
+  '=======',
+  results.summary,
+  '',
+  results.detailed_analysis,
+  '',
+  'PER-SECTION FINDINGS (threat-model sections S1-S7 from the review brief)',
+  '='.repeat(72),
+  '',
+  results.findings.map((f) => (
+    '[' + String(f.severity).toUpperCase() + '] ' + f.id + NL +
+    'FINDING: ' + f.note + NL +
+    'RECOMMENDATION: ' + (f.recommendation || '(none - informational)')
+  )).join(NL + NL + HR + NL + NL)
+].join(NL);
+
+const resolution = await resolveSubAgentRepo({
+  sdId: SD_ID,
+  subAgentCode: CODE,
+  targetApplication: 'EHG_Engineer',
+  fallback: 'EHG_Engineer'
+});
+applySubAgentRepoVerdict(results, resolution);
+
+const stored = await storeSubAgentResults(
+  CODE,
+  SD_ID,
+  { name: 'Chief Security Architect' },
+  results,
+  { sdKey: SD_KEY, phase: PHASE }
+);
+
+console.log('STORED_VERDICT=' + results.verdict);
+console.log('STORED_CONFIDENCE=' + results.confidence);
+console.log('STORED_ROW_ID=' + (stored?.id || stored?.data?.id || JSON.stringify(stored)));
+console.log('REPO_PATH=' + results.metadata.repo_path);
+console.log('REPO_RESOLVED=' + results.metadata.repo_resolved);
+console.log('EXECUTED_FROM_CWD=' + results.metadata.executed_from_cwd);

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -31,6 +31,7 @@ const { PLAN_CONTENT_MARKER } = require('../lib/sd-enrichment-markers.cjs');
 const { describeUnreadableAssignment } = require('../lib/fleet/assignment-target.cjs');
 const { parseSdDependencies } = require('../lib/utils/parse-sd-dependencies.cjs'); // QF-20260525-542
 const { buildRetentionAckPayload } = require('../lib/retention/retention-ack-marker.cjs'); // FR-7
+const { PROMOTION_ACK_KEY } = require('../lib/coordinator/promotion-ack.cjs'); // SIGNAL-ROUTER-AUTO-001 FR-8
 // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate (same one the
 // worker self_claim path uses) so CLAIM_FIX never re-affirms an orchestrator PARENT / dep-blocked SD.
 const { evaluateDispatchEligibility, classifyDispatchIneligibility, TEST_FIXTURE_KEY_RE } = require('../lib/fleet/claim-eligibility.cjs');
@@ -3322,6 +3323,19 @@ async function main() {
         .select('id, sender_session, created_at, payload')
         .eq('payload->>signal_type', 'stuck')
         .is('acknowledged_at', null)
+        // SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 (FR-8) — WITHOUT THIS THE ROUTER FIX IS INERT.
+        // The router now leaves acknowledged_at null when it promotes a signal, so promoted
+        // type=stuck rows became eligible for this drain, which re-stamps acknowledged_at at the
+        // bottom of this block. Three of the nine measured swallowed signals are type=stuck: the
+        // drain would have re-acked them within the hour and put them straight back into the
+        // swallowed state, with every other acceptance criterion still passing.
+        //
+        // The severity gate below does not cover this: HELD_SEVERITIES protects rows whose sender
+        // is still LIVE, but senderIsDead() drains at any severity — and the condition that makes
+        // a signal most worth preserving (its sender has gone away) is exactly what makes it
+        // drainable. A promotion-marked row is already filed and awaiting disposition; it is not
+        // an unacked row rotting in the lane, which is what this drain exists to clear.
+        .is(`payload->>${PROMOTION_ACK_KEY}`, null)
         .order('id', { ascending: true })); // unique tiebreaker (FR-6)
     } catch { stuckSignals = []; } // prior behavior: read error ignored
     const stuck = stuckSignals || [];

--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -31,7 +31,7 @@ const { PLAN_CONTENT_MARKER } = require('../lib/sd-enrichment-markers.cjs');
 const { describeUnreadableAssignment } = require('../lib/fleet/assignment-target.cjs');
 const { parseSdDependencies } = require('../lib/utils/parse-sd-dependencies.cjs'); // QF-20260525-542
 const { buildRetentionAckPayload } = require('../lib/retention/retention-ack-marker.cjs'); // FR-7
-const { PROMOTION_ACK_KEY } = require('../lib/coordinator/promotion-ack.cjs'); // SIGNAL-ROUTER-AUTO-001 FR-8
+const { PROMOTION_ACK_KEY, isPromotionAcked } = require('../lib/coordinator/promotion-ack.cjs'); // SIGNAL-ROUTER-AUTO-001 FR-8
 // SD-LEO-FIX-COORDINATOR-SWEEP-CLAIMED-001: shared dispatch-eligibility predicate (same one the
 // worker self_claim path uses) so CLAIM_FIX never re-affirms an orchestrator PARENT / dep-blocked SD.
 const { evaluateDispatchEligibility, classifyDispatchIneligibility, TEST_FIXTURE_KEY_RE } = require('../lib/fleet/claim-eligibility.cjs');
@@ -3804,6 +3804,29 @@ function planDeadLetters(unreadMsgs, { allSessionIds, deadIds }, nowMs) {
     .filter(m => !allSessionIds.has(m.target_session) || deadIds.has(m.target_session))
     .filter(m => !m.expires_at || new Date(m.expires_at).getTime() <= nowMs)
     .filter(m => !(m.payload && m.payload.dead_letter === true))
+    // SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 (FR-8, FOURTH site) — and the only automatic one left.
+    //
+    // Guarded HERE, in the pure planner, rather than in each executor's select. Three reasons:
+    // one edit covers BOTH twins (dead-letter-planning.cjs and legacy-fallback.cjs, which
+    // sweep-legacy-twin-parity requires stay in lockstep); this function is pure, exported and
+    // already unit-tested, so the guard gets a real behavioural test instead of a fourth source
+    // scan; and it avoids a fourth call site to keep in sync.
+    //
+    // WHY THIS PATH IS THE DANGEROUS ONE. It never stamps acknowledged_at, so the inbox, the
+    // sender's view and the starvation gauge all keep showing the row — it looks harmless. What
+    // it stamps is read_at, and a non-null read_at ARMS THE SECOND DISJUNCT of
+    // cleanup_expired_coordination (`read_at IS NOT NULL AND read_at <= now() - 7 days`). Before
+    // the stamp a promoted row has both columns NULL and is permanently immune to cleanup — that
+    // immunity IS the preservation this SD buys. After it, the row is archived and deleted seven
+    // days later, still unread and undispositioned. payload is spread rather than clobbered, so
+    // promotion_ack survives on the row it can no longer protect.
+    //
+    // Newly reachable BECAUSE of this SD: pre-fix, promoted rows carried acknowledged_at and the
+    // executors' `.is('acknowledged_at', null)` excluded them outright. Measured against the 10
+    // live promoted rows: 10/10 uuid-like target, 10/10 not already dead-lettered, 9/10 read_at
+    // null. And unlike the STUCK-drain this runs on the */5 cron in BOTH flag modes and is NOT
+    // gated on _coordMutationAllowed.
+    .filter(m => !isPromotionAcked(m))
     .map(m => ({
       id: m.id,
       update: {

--- a/tests/unit/coord-adam-comms-resilient.test.js
+++ b/tests/unit/coord-adam-comms-resilient.test.js
@@ -289,6 +289,36 @@ describe('FR-4: planDeadLetters (pure)', () => {
     expect(u.payload.body).toBe('go');
   });
 
+  // SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 (FR-8, fourth site). BEHAVIOURAL, and guarded in the pure
+  // planner rather than in each executor's select so ONE edit covers both twins
+  // (dead-letter-planning.cjs and legacy-fallback.cjs, which sweep-legacy-twin-parity keeps in
+  // lockstep) and so the guard gets a real test instead of a fourth source scan.
+  it('SKIPS a promotion-marked row — it never stamps read_at, which would arm cleanup', () => {
+    // This path never touches acknowledged_at, so the inbox, the sender view and the starvation
+    // gauge all keep showing the row and it looks harmless. What it stamps is read_at, and a
+    // non-null read_at arms cleanup_expired_coordination's second disjunct — so the row is
+    // archived and deleted 7 days later, still unread. Before the stamp both columns are NULL
+    // and the row is permanently immune to cleanup; that immunity IS what promotion buys.
+    const promoted = row({ payload: { kind: 'coordinator_request', promotion_ack: true } });
+    expect(sweep.planDeadLetters([promoted], sets(), NOW)).toHaveLength(0);
+  });
+
+  it('DISCRIMINATES — an identical row WITHOUT the marker is still dead-lettered', () => {
+    // Without this half, a planner that returned [] unconditionally would satisfy the case above
+    // while silently disabling dead-lettering for everything.
+    expect(sweep.planDeadLetters([row()], sets(), NOW)).toHaveLength(1);
+  });
+
+  it('requires the marker to be strictly true, matching isPromotionAcked', () => {
+    // The SQL guards elsewhere exclude ANY present value (`payload->>key IS NULL`) while this
+    // predicate requires === true. Unreachable today because buildPromotionAckPayload only ever
+    // writes true, but the two are not interchangeable and a future writer could split them.
+    for (const v of [false, 'true', 1, null]) {
+      const r = row({ payload: { kind: 'coordinator_request', promotion_ack: v } });
+      expect(sweep.planDeadLetters([r], sets(), NOW), `promotion_ack=${JSON.stringify(v)}`).toHaveLength(1);
+    }
+  });
+
   it('row with a PAST expires_at keeps it (no backfill — only NULL is backfilled)', () => {
     const plan = sweep.planDeadLetters([row({ expires_at: iso(NOW - MIN) })], sets(), NOW);
     expect(plan).toHaveLength(1);

--- a/tests/unit/coordinator/promotion-ack-guards.test.js
+++ b/tests/unit/coordinator/promotion-ack-guards.test.js
@@ -1,0 +1,83 @@
+// SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 — WIRING ASSERTIONS for the two ack-writers.
+//
+// WHY THIS FILE HAD TO EXIST. The exclusion in stale-session-sweep.cjs carries a comment saying
+// "WITHOUT THIS THE ROUTER FIX IS INERT" — and deleting that line reddened NOTHING. The most
+// load-bearing line in the change had zero regression protection, which is the same defect class
+// the SD is about (a mechanism that looks enforced and is not), one level up.
+//
+// These are source assertions rather than behavioural ones because both call sites build a
+// PostgREST query against a live table and this repo has no designated non-production database
+// (the vitest `db` project is gated off). A source assertion is weaker than executing the query —
+// it proves the guard is PRESENT, not that it FILTERS — so the filtering half is proven
+// separately in promotion-ack.test.js against crafted row shapes. Neither half alone is enough.
+//
+// The pattern follows tests/unit/fleet/outstanding-signals.test.js:172-180, which pins wiring the
+// same way.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const read = (p) => readFileSync(path.join(REPO, p), 'utf8');
+
+const sweep = read('scripts/stale-session-sweep.cjs');
+const converge = read('lib/retention/session-coordination-ack-convergence.js');
+const router = read('lib/coordinator/signal-router.cjs');
+const detectors = read('lib/coordinator/detectors.cjs');
+
+describe('every writer that stamps acknowledged_at excludes promotion-marked rows', () => {
+  // Both passes are called from the same main() ~100 lines apart. The first was found at PLAN;
+  // the second only because a reviewer enumerated the writers rather than assuming the first was
+  // the only one. Guarding one and not the other leaves the fix self-reverting on a longer fuse.
+
+  it('the STUCK-drain excludes them (one-hour fuse)', () => {
+    expect(sweep).toContain('PROMOTION_ACK_KEY');
+    expect(sweep).toMatch(/\.is\(`payload->>\$\{PROMOTION_ACK_KEY\}`, null\)/);
+  });
+
+  it('the STUCK-drain imports the key rather than re-spelling it', () => {
+    // A literal string here would drift silently the day the key is renamed.
+    expect(sweep).toMatch(/require\(['"]\.\.\/lib\/coordinator\/promotion-ack\.cjs['"]\)/);
+    expect(sweep).not.toMatch(/\.is\(['"]payload->>promotion_ack['"]/);
+  });
+
+  it('the TTL convergence pass excludes them (fourteen-day fuse)', () => {
+    expect(converge).toContain('PROMOTION_ACK_KEY');
+    expect(converge).toMatch(/\.is\(`payload->>\$\{PROMOTION_ACK_KEY\}`, null\)/);
+  });
+
+  it('the TTL pass imports the key rather than re-spelling it', () => {
+    expect(converge).toMatch(/promotion-ack\.cjs/);
+    expect(converge).not.toMatch(/\.is\(['"]payload->>promotion_ack['"]/);
+  });
+});
+
+describe('the router records provenance and does not dispose', () => {
+  it('stampRouted does not write acknowledged_at', () => {
+    // The behavioural proof is in signal-router.test.js (SR-16 asserts the update shape). This
+    // catches the narrower regression of someone re-adding the column write to this function.
+    const fn = router.slice(router.indexOf('async function stampRouted('), router.indexOf('async function aggregateSignals('));
+    expect(fn).not.toMatch(/acknowledged_at/);
+    expect(fn).toContain('buildPromotionAckPayload');
+  });
+
+  it('stampRouted still writes routed_to_feedback_id via the shared builder', () => {
+    // Dropping the dedup key would re-promote every signal on every tick. The builder owns it,
+    // so assert the builder is used rather than re-asserting the key here.
+    expect(router).toMatch(/require\(['"]\.\/promotion-ack\.cjs['"]\)/);
+  });
+
+  it('the starvation gauge carves promotion-marked rows out of "answered"', () => {
+    expect(detectors).toContain('isPromotionAcked');
+    expect(detectors).toMatch(/routed_to_feedback_id\s*\)\s*&&\s*!isPromotionAcked\(sig\)/);
+  });
+
+  it('the docblock states the carve-out, so the contract is not documented-false', () => {
+    // The stated contract used to read "answered = acknowledged_at set OR routed_to_feedback_id
+    // set". Leaving that while changing the code would be worse than no docblock, because the
+    // next reader trusts it.
+    const doc = detectors.slice(detectors.indexOf('REPLY_STARVATION'), detectors.indexOf('function detectReplyStarvation'));
+    expect(doc).toMatch(/promotion/i);
+  });
+});

--- a/tests/unit/coordinator/promotion-ack-guards.test.js
+++ b/tests/unit/coordinator/promotion-ack-guards.test.js
@@ -5,24 +5,49 @@
 // load-bearing line in the change had zero regression protection, which is the same defect class
 // the SD is about (a mechanism that looks enforced and is not), one level up.
 //
-// These are source assertions rather than behavioural ones because both call sites build a
-// PostgREST query against a live table and this repo has no designated non-production database
-// (the vitest `db` project is gated off). A source assertion is weaker than executing the query —
-// it proves the guard is PRESENT, not that it FILTERS — so the filtering half is proven
-// separately in promotion-ack.test.js against crafted row shapes. Neither half alone is enough.
+// WHAT A SOURCE ASSERTION ACTUALLY PROVES — corrected, because the first version of this header
+// overclaimed and that overclaim is the same documented-false shape the SD exists to close.
+// It does NOT prove the guard is "present" in any operational sense. It proves CHARACTERS APPEAR
+// IN A FILE. A reviewer defeated the first version four ways while these tests stayed green:
+// comment the line out; delete the guard and bolt an identical `.is()` onto an unrelated query
+// elsewhere in the same file; or leave the asserted line byte-identical and re-bind the import
+// (`{ PROMOTION_ACK_SOURCE_KEY: PROMOTION_ACK_KEY }`) so it filters the WRONG KEY. A grep also
+// cannot see the runtime death of the line it greps for.
 //
-// The pattern follows tests/unit/fleet/outstanding-signals.test.js:172-180, which pins wiring the
-// same way.
+// So the real proof moved: convergeAckTTL takes an injectable client and is now asserted
+// BEHAVIOURALLY in tests/unit/retention/session-coordination-ack-convergence.test.js, which
+// observes the filters actually applied. What remains here is the residue — call sites buried
+// inside main() with no injection point — and for those the assertions now (a) strip comments,
+// and (b) scope to the enclosing query block rather than matching file-globally.
+//
+// Pattern follows tests/unit/fleet/outstanding-signals.test.js:172-180.
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
-const read = (p) => readFileSync(path.join(REPO, p), 'utf8');
+/**
+ * Read source with COMMENT LINES STRIPPED.
+ *
+ * The first version of this file matched raw source, so commenting a guard out left the test
+ * green — the regex happily matched the commented text. Stripping line comments closes that and
+ * the "assert on the real line, not on prose describing it" property is what makes these
+ * assertions mean anything at all.
+ */
+const read = (p) => readFileSync(path.join(REPO, p), 'utf8')
+  .split('\n').filter((l) => !/^\s*(\/\/|\*|\/\*)/.test(l)).join('\n');
+/**
+ * Raw source, comments intact — for the ONE assertion that is legitimately about prose.
+ * Stripping comments is right for guard lines (a commented-out guard must not pass) and wrong for
+ * a docblock-contract check, which has nothing but comments to assert on. Using the stripped
+ * reader for both made the docblock test unsatisfiable; that is the reader, not the contract.
+ */
+const readRaw = (p) => readFileSync(path.join(REPO, p), 'utf8');
 
 const sweep = read('scripts/stale-session-sweep.cjs');
 const converge = read('lib/retention/session-coordination-ack-convergence.js');
+const deadLetter = read('scripts/drain-dead-letter-coordination.mjs');
 const router = read('lib/coordinator/signal-router.cjs');
 const detectors = read('lib/coordinator/detectors.cjs');
 
@@ -31,25 +56,36 @@ describe('every writer that stamps acknowledged_at excludes promotion-marked row
   // the second only because a reviewer enumerated the writers rather than assuming the first was
   // the only one. Guarding one and not the other leaves the fix self-reverting on a longer fuse.
 
-  it('the STUCK-drain excludes them (one-hour fuse)', () => {
-    expect(sweep).toContain('PROMOTION_ACK_KEY');
-    expect(sweep).toMatch(/\.is\(`payload->>\$\{PROMOTION_ACK_KEY\}`, null\)/);
+  it('the STUCK-drain excludes them (one-hour fuse), IN ITS OWN QUERY BLOCK', () => {
+    // Scoped with slice() rather than matched file-globally: a file-global match is satisfied by
+    // an identical .is() bolted onto any of the ~3800 other lines, which is how the first version
+    // of this test was defeated.
+    const block = sweep.slice(sweep.indexOf("eq('payload->>signal_type', 'stuck')"));
+    const query = block.slice(0, block.indexOf('order('));
+    expect(query).toMatch(/\.is\(`payload->>\$\{PROMOTION_ACK_KEY\}`, null\)/);
   });
 
-  it('the STUCK-drain imports the key rather than re-spelling it', () => {
-    // A literal string here would drift silently the day the key is renamed.
-    expect(sweep).toMatch(/require\(['"]\.\.\/lib\/coordinator\/promotion-ack\.cjs['"]\)/);
+  it('the STUCK-drain BINDS the real key, not just any identifier named like it', () => {
+    // Asserting the import STATEMENT is not enough — `{ PROMOTION_ACK_SOURCE_KEY:
+    // PROMOTION_ACK_KEY }` satisfies that while pointing the guard at the wrong column. Assert
+    // the destructured NAME matches the exported name.
+    expect(sweep).toMatch(/\{\s*PROMOTION_ACK_KEY\s*\}\s*=\s*require\([^)]*promotion-ack\.cjs[^)]*\)/);
     expect(sweep).not.toMatch(/\.is\(['"]payload->>promotion_ack['"]/);
   });
 
-  it('the TTL convergence pass excludes them (fourteen-day fuse)', () => {
-    expect(converge).toContain('PROMOTION_ACK_KEY');
-    expect(converge).toMatch(/\.is\(`payload->>\$\{PROMOTION_ACK_KEY\}`, null\)/);
+  it('the dead-letter drain excludes them (manual, but it stamps read_at too)', () => {
+    // The worst of the three: one write blinds the inbox, the sender view, isRouterSwallowed
+    // (needs !read_at) AND the starvation gauge (no auto_acked marker, so it reads as a HUMAN
+    // answer). Manual-only is not a guard.
+    expect(deadLetter).toMatch(/\{\s*PROMOTION_ACK_KEY\s*\}\s*=\s*createRequire\([^)]*\)\([^)]*promotion-ack\.cjs[^)]*\)/);
+    expect(deadLetter).toMatch(/\.is\(`payload->>\$\{PROMOTION_ACK_KEY\}`, null\)/);
   });
 
-  it('the TTL pass imports the key rather than re-spelling it', () => {
-    expect(converge).toMatch(/promotion-ack\.cjs/);
-    expect(converge).not.toMatch(/\.is\(['"]payload->>promotion_ack['"]/);
+  it('every guarded site binds the key from the single module', () => {
+    // The count is knowledge, not a closed set — it said TWO until a reviewer found the third.
+    for (const [name, src] of [['sweep', sweep], ['converge', converge], ['deadLetter', deadLetter]]) {
+      expect(src, `${name} must import PROMOTION_ACK_KEY`).toMatch(/PROMOTION_ACK_KEY/);
+    }
   });
 });
 
@@ -77,7 +113,8 @@ describe('the router records provenance and does not dispose', () => {
     // The stated contract used to read "answered = acknowledged_at set OR routed_to_feedback_id
     // set". Leaving that while changing the code would be worse than no docblock, because the
     // next reader trusts it.
-    const doc = detectors.slice(detectors.indexOf('REPLY_STARVATION'), detectors.indexOf('function detectReplyStarvation'));
+    const raw = readRaw('lib/coordinator/detectors.cjs');
+    const doc = raw.slice(raw.indexOf('REPLY_STARVATION'), raw.indexOf('function detectReplyStarvation'));
     expect(doc).toMatch(/promotion/i);
   });
 });

--- a/tests/unit/coordinator/promotion-ack-guards.test.js
+++ b/tests/unit/coordinator/promotion-ack-guards.test.js
@@ -69,16 +69,27 @@ describe('every writer that stamps acknowledged_at excludes promotion-marked row
     // Asserting the import STATEMENT is not enough — `{ PROMOTION_ACK_SOURCE_KEY:
     // PROMOTION_ACK_KEY }` satisfies that while pointing the guard at the wrong column. Assert
     // the destructured NAME matches the exported name.
-    expect(sweep).toMatch(/\{\s*PROMOTION_ACK_KEY\s*\}\s*=\s*require\([^)]*promotion-ack\.cjs[^)]*\)/);
+    // Allows sibling names in the destructure (the sweep also imports isPromotionAcked for the
+    // fourth guard) but still requires PROMOTION_ACK_KEY to be bound to ITS OWN name — which is
+    // what defeats `{ PROMOTION_ACK_SOURCE_KEY: PROMOTION_ACK_KEY }`.
+    expect(sweep).toMatch(/\{[^}]*\bPROMOTION_ACK_KEY\b[^}:]*\}\s*=\s*require\([^)]*promotion-ack\.cjs[^)]*\)/);
     expect(sweep).not.toMatch(/\.is\(['"]payload->>promotion_ack['"]/);
   });
 
-  it('the dead-letter drain excludes them (manual, but it stamps read_at too)', () => {
-    // The worst of the three: one write blinds the inbox, the sender view, isRouterSwallowed
-    // (needs !read_at) AND the starvation gauge (no auto_acked marker, so it reads as a HUMAN
-    // answer). Manual-only is not a guard.
+  it('the dead-letter drain excludes them, IN ITS OWN QUERY BLOCK', () => {
+    // The worst of the manual three: one write blinds the inbox, the sender view,
+    // isRouterSwallowed (needs !read_at) AND the starvation gauge (no auto_acked marker, so it
+    // reads as a HUMAN answer). Manual-only is not a guard.
+    //
+    // SCOPED, after a reviewer's mutation harness caught that this assertion was still
+    // file-global while the sweep's had been slice-scoped in the same commit — so relocating
+    // this guard to an unrelated line survived. The header claimed both were scoped; that was
+    // true of one and false of the other, in the file whose whole subject is claims that do not
+    // hold on every surface.
+    const block = deadLetter.slice(deadLetter.indexOf("all('session_coordination'"));
+    const query = block.slice(0, block.indexOf('const dead'));
+    expect(query).toMatch(/\.is\(`payload->>\$\{PROMOTION_ACK_KEY\}`, null\)/);
     expect(deadLetter).toMatch(/\{\s*PROMOTION_ACK_KEY\s*\}\s*=\s*createRequire\([^)]*\)\([^)]*promotion-ack\.cjs[^)]*\)/);
-    expect(deadLetter).toMatch(/\.is\(`payload->>\$\{PROMOTION_ACK_KEY\}`, null\)/);
   });
 
   it('every guarded site binds the key from the single module', () => {

--- a/tests/unit/coordinator/promotion-ack-guards.test.js
+++ b/tests/unit/coordinator/promotion-ack-guards.test.js
@@ -69,10 +69,20 @@ describe('every writer that stamps acknowledged_at excludes promotion-marked row
     // Asserting the import STATEMENT is not enough — `{ PROMOTION_ACK_SOURCE_KEY:
     // PROMOTION_ACK_KEY }` satisfies that while pointing the guard at the wrong column. Assert
     // the destructured NAME matches the exported name.
-    // Allows sibling names in the destructure (the sweep also imports isPromotionAcked for the
-    // fourth guard) but still requires PROMOTION_ACK_KEY to be bound to ITS OWN name — which is
-    // what defeats `{ PROMOTION_ACK_SOURCE_KEY: PROMOTION_ACK_KEY }`.
-    expect(sweep).toMatch(/\{[^}]*\bPROMOTION_ACK_KEY\b[^}:]*\}\s*=\s*require\([^)]*promotion-ack\.cjs[^)]*\)/);
+    // TWO ASSERTIONS, because one positive regex cannot carry both jobs — and trying to make it
+    // carry both is how this REGRESSED.
+    //
+    // History worth keeping: the original strict `{ PROMOTION_ACK_KEY }` form did reject the
+    // alias attack. Adding `isPromotionAcked` to the sweep import broke that form, so the regex
+    // was loosened to allow siblings — and the loosened version silently ADMITS the alias again.
+    // Trace it against `{ PROMOTION_ACK_SOURCE_KEY: PROMOTION_ACK_KEY, isPromotionAcked }`:
+    // `[^}]*` eats `PROMOTION_ACK_SOURCE_KEY: `, the word-boundary match then lands on the
+    // renamed-TO identifier, and `[^}:]*` happily takes `, isPromotionAcked `. The old comment
+    // claimed this form "defeats" the alias; it did not. The `[^}:]*` forbids a colon AFTER the
+    // name, but in an alias the colon comes BEFORE it.
+    expect(sweep).toMatch(/\{[^}]*\bPROMOTION_ACK_KEY\b[^}]*\}\s*=\s*require\([^)]*promotion-ack\.cjs[^)]*\)/);
+    // The actual attack, asserted directly: aliasing ANOTHER export INTO this name.
+    expect(sweep).not.toMatch(/:\s*PROMOTION_ACK_KEY\b/);
     expect(sweep).not.toMatch(/\.is\(['"]payload->>promotion_ack['"]/);
   });
 
@@ -89,7 +99,11 @@ describe('every writer that stamps acknowledged_at excludes promotion-marked row
     const block = deadLetter.slice(deadLetter.indexOf("all('session_coordination'"));
     const query = block.slice(0, block.indexOf('const dead'));
     expect(query).toMatch(/\.is\(`payload->>\$\{PROMOTION_ACK_KEY\}`, null\)/);
-    expect(deadLetter).toMatch(/\{\s*PROMOTION_ACK_KEY\s*\}\s*=\s*createRequire\([^)]*\)\([^)]*promotion-ack\.cjs[^)]*\)/);
+    // Same PAIR as the sweep. This file currently imports a single symbol, so the strict form
+    // still holds — but it would break the identical way the moment a second symbol is added,
+    // which is exactly what happened next door. Pairing it now rather than after.
+    expect(deadLetter).toMatch(/\{[^}]*\bPROMOTION_ACK_KEY\b[^}]*\}\s*=\s*createRequire\([^)]*\)\([^)]*promotion-ack\.cjs[^)]*\)/);
+    expect(deadLetter).not.toMatch(/:\s*PROMOTION_ACK_KEY\b/);
   });
 
   it('every guarded site binds the key from the single module', () => {

--- a/tests/unit/coordinator/promotion-ack.test.js
+++ b/tests/unit/coordinator/promotion-ack.test.js
@@ -1,0 +1,135 @@
+// SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 — FR-5 classifier + FR-4/FR-8/FR-9 consumers.
+//
+// WHY EVERYTHING HERE IS IN-MEMORY. This repo has no designated non-production database: the
+// vitest `db` project is gated on a target that does not exist, so every run prints
+// "db project DISABLED". A detector that could only be exercised against live data could not be
+// honestly tested — proving it would mean writing synthetic rows into the very population being
+// measured. Worse, tests/integration/ resolves to ZERO files and reports GREEN BY ABSENCE, so
+// putting them there would look like coverage while asserting nothing.
+//
+// So the defect predicate is a pure total function and the proof is crafted row objects.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require_ = createRequire(import.meta.url);
+
+const {
+  PROMOTION_ACK_SOURCE,
+  buildPromotionAckPayload,
+  isPromotionAcked,
+  isRouterSwallowed
+} = require_('../../../lib/coordinator/promotion-ack.cjs');
+const { detectReplyStarvation } = require_('../../../lib/coordinator/detectors.cjs');
+
+describe('buildPromotionAckPayload — records provenance, never disposition', () => {
+  it('preserves the dedup key and adds the marker', () => {
+    const out = buildPromotionAckPayload({ signal_type: 'stuck', severity: 'critical' }, 'fb-1');
+    expect(out.routed_to_feedback_id).toBe('fb-1');
+    expect(out.promotion_ack).toBe(true);
+    expect(out.promotion_ack_source).toBe(PROMOTION_ACK_SOURCE);
+  });
+
+  it('preserves every pre-existing payload key', () => {
+    // The sweep's own comment warns that signal_type / severity / sender_callsign are
+    // load-bearing downstream and a blanket write would erase them.
+    const out = buildPromotionAckPayload({ signal_type: 'stuck', severity: 'critical', sender_callsign: 'Alpha-5' }, 'fb-1');
+    expect(out).toMatchObject({ signal_type: 'stuck', severity: 'critical', sender_callsign: 'Alpha-5' });
+  });
+
+  it('does not mutate its input', () => {
+    const original = { signal_type: 'stuck' };
+    buildPromotionAckPayload(original, 'fb-1');
+    expect(original.promotion_ack).toBeUndefined();
+  });
+
+  it('is total — a null payload is not a crash', () => {
+    expect(buildPromotionAckPayload(null, 'fb-1').promotion_ack).toBe(true);
+    expect(buildPromotionAckPayload(undefined, 'fb-1').routed_to_feedback_id).toBe('fb-1');
+  });
+
+  it('NEVER writes acknowledged_at — the whole point of the SD', () => {
+    // The function returns a payload, so acknowledged_at cannot appear in it. This asserts the
+    // contract explicitly so a future edit that starts merging column values here fails loudly.
+    expect(Object.keys(buildPromotionAckPayload({}, 'fb-1'))).not.toContain('acknowledged_at');
+  });
+});
+
+describe('isRouterSwallowed — keyed on router PROVENANCE, not the bare acked-and-unread pair', () => {
+  const swallowed = { acknowledged_at: '2026-08-03T12:00:00Z', read_at: null, payload: { promotion_ack: true } };
+
+  it('true for a router-swallowed row', () => {
+    expect(isRouterSwallowed(swallowed)).toBe(true);
+  });
+
+  it('FALSE for the LEGITIMATE coordinator disposition shape — the named exclusion', () => {
+    // scripts/coordinator-ack-signal.cjs stamps acknowledged_at without read_at BY DESIGN. Those
+    // rows are acked-and-unread forever and always will be. Keying on the bare pair would report
+    // them as offenders, so "drive the count to zero" was never reachable and is not the goal.
+    // Measured while building this: 13 rows matched the bare pair; only 9 were router-promoted.
+    expect(isRouterSwallowed({ acknowledged_at: '2026-08-03T12:00:00Z', read_at: null, payload: { signal_type: 'stuck' } })).toBe(false);
+  });
+
+  it('false for a read-then-acked row (the negative fixture shape, ~426 live rows)', () => {
+    expect(isRouterSwallowed({ acknowledged_at: '2026-08-03T12:00:00Z', read_at: '2026-08-03T11:00:00Z', payload: { promotion_ack: true } })).toBe(false);
+  });
+
+  it('false for an unacked row, promoted or not', () => {
+    expect(isRouterSwallowed({ acknowledged_at: null, read_at: null, payload: { promotion_ack: true } })).toBe(false);
+    expect(isRouterSwallowed({ acknowledged_at: null, read_at: null, payload: {} })).toBe(false);
+  });
+
+  it('PROOF IT CAN STILL FIRE after the fix', () => {
+    // A zero count in production must mean health, not a dead predicate. If some other writer
+    // acks a promoted row behind our back — which is exactly what the STUCK-drain would have
+    // done — this still reports it.
+    expect(isRouterSwallowed({ ...swallowed, payload: { promotion_ack: true, signal_type: 'stuck' } })).toBe(true);
+  });
+
+  it('is total — junk shapes return false rather than throwing', () => {
+    for (const junk of [null, undefined, {}, { payload: null }, { payload: { promotion_ack: 'yes' } }]) {
+      expect(isRouterSwallowed(junk)).toBe(false);
+    }
+  });
+
+  it('requires strict true, so a truthy-but-wrong marker does not count', () => {
+    expect(isPromotionAcked({ payload: { promotion_ack: 1 } })).toBe(false);
+    expect(isPromotionAcked({ payload: { promotion_ack: 'true' } })).toBe(false);
+  });
+});
+
+describe('FR-4 — the starvation gauge stops treating "routed" as "answered"', () => {
+  const old = new Date('2026-08-03T00:00:00Z').getTime();
+  const now = new Date('2026-08-03T12:00:00Z').getTime();
+  // sender_type:'worker' is REQUIRED — detectReplyStarvation skips every other sender at its
+  // first line. Omitting it made both cases below vacuous on the first run: the discriminating
+  // case "passed" because the row was filtered out before the answered-logic ran, not because
+  // the logic said answered. A fixture that misses a guard tests the guard, not the change.
+  const base = { id: 's1', created_at: new Date(old).toISOString(), sender_session: 'w1', sender_type: 'worker' };
+
+  it('a promoted-but-unactioned signal IS starving', () => {
+    // Before this SD, routed_to_feedback_id alone marked it answered — which is why the one
+    // gauge that should have alarmed on all 9 swallowed signals stayed silent.
+    const r = detectReplyStarvation({
+      signals: [{ ...base, payload: { signal_type: 'stuck', routed_to_feedback_id: 'fb-1', promotion_ack: true } }],
+      now
+    });
+    expect(r.matched).toBe(true);
+  });
+
+  it('DISCRIMINATES — a genuinely routed row without the promotion marker is still answered', () => {
+    // The half that stops "answered = never" from passing. If this also matched, the gauge would
+    // simply alarm on everything and the first assertion would prove nothing.
+    const r = detectReplyStarvation({
+      signals: [{ ...base, payload: { signal_type: 'stuck', routed_to_feedback_id: 'fb-1' } }],
+      now
+    });
+    expect(r.matched).toBe(false);
+  });
+
+  it('a genuinely acknowledged row is still answered', () => {
+    const r = detectReplyStarvation({
+      signals: [{ ...base, acknowledged_at: new Date(now).toISOString(), payload: { signal_type: 'stuck' } }],
+      now
+    });
+    expect(r.matched).toBe(false);
+  });
+});

--- a/tests/unit/retention/session-coordination-ack-convergence.test.js
+++ b/tests/unit/retention/session-coordination-ack-convergence.test.js
@@ -19,15 +19,24 @@ function mockSupabase({ candidates = [], updateError = null } = {}) {
   // Filters are RECORDED rather than shaped, so a test can assert WHICH filters were applied
   // (see the promotion-marker case below) without pinning the order they arrive in.
   const filters = [];
+  const tables = [];
   const builder = {
     select: vi.fn(() => builder),
     is: vi.fn((col, val) => { filters.push(['is', col, val]); return builder; }),
     lte: vi.fn((col, val) => { filters.push(['lte', col, val]); return builder; }),
-    order: vi.fn(() => builder),
+    // RECORDED, not ignored: the nested chain used to reach .range() only via .order(), so it
+    // incidentally pinned the pagination contract. Dropping to a self-returning builder lost
+    // that — deleting the FR-6 `.order('id')` unique tiebreaker (added by
+    // COUNT-TRUNCATION-DISCIPLINE-001 precisely for stable page boundaries) reddened nothing.
+    // Recording it restores the pin without re-encoding filter ORDER, which was the brittleness.
+    order: vi.fn((col, opts) => { filters.push(['order', col, opts]); return builder; }),
     range: vi.fn(async () => ({ data: candidates, error: null })),
   };
-  const from = vi.fn(() => ({
-    select: builder.select,
+  const from = vi.fn((table) => ({
+    // The table name is recorded because a builder that ignores its argument will happily report
+    // the right filters applied to the WRONG RELATION — changing the SUT to .from('other_table')
+    // left this suite green until this was added.
+    select: (...a) => { tables.push(table); return builder.select(...a); },
     update: vi.fn((patch) => {
       updates.push(patch);
       return {
@@ -38,7 +47,7 @@ function mockSupabase({ candidates = [], updateError = null } = {}) {
       };
     }),
   }));
-  return { supabase: { from }, updates, filters };
+  return { supabase: { from }, updates, filters, tables };
 }
 
 describe('convergeAckTTL', () => {
@@ -56,13 +65,24 @@ describe('convergeAckTTL', () => {
   // observed. That closes all four, and it exercises the ESM createRequire import at runtime
   // rather than asserting the import statement exists.
   it('EXCLUDES promotion-marked rows from TTL convergence (observed, not grepped)', async () => {
-    const { supabase, filters } = mockSupabase({ candidates: [] });
+    const { supabase, filters, tables } = mockSupabase({ candidates: [] });
     await convergeAckTTL(supabase);
+    // The right filters on the wrong relation is still wrong.
+    expect(tables).toContain('session_coordination');
     const isFilters = filters.filter((f) => f[0] === 'is');
     expect(isFilters).toContainEqual(['is', 'acknowledged_at', null]);
     // The exact column string matters: promotion_ack_source would pass a laxer assertion while
     // filtering the wrong key entirely.
     expect(isFilters).toContainEqual(['is', 'payload->>promotion_ack', null]);
+  });
+
+  it('still paginates with the FR-6 unique tiebreaker (pinned after the builder swap lost it)', async () => {
+    // Not about this SD, but the self-returning builder dropped a contract the old nested chain
+    // held incidentally: it reached .range() only via .order(), so deleting the FR-6 unique
+    // tiebreaker reddened nothing. Re-pinned rather than left to be rediscovered.
+    const { supabase, filters } = mockSupabase({ candidates: [] });
+    await convergeAckTTL(supabase);
+    expect(filters).toContainEqual(['order', 'id', { ascending: true }]);
   });
 
   it('no-ops when there are no candidates', async () => {

--- a/tests/unit/retention/session-coordination-ack-convergence.test.js
+++ b/tests/unit/retention/session-coordination-ack-convergence.test.js
@@ -6,18 +6,28 @@ import { convergeAckTTL } from '../../../lib/retention/session-coordination-ack-
 
 function mockSupabase({ candidates = [], updateError = null } = {}) {
   const updates = [];
+  // SELF-RETURNING BUILDER, replacing a hand-nested chain.
+  //
+  // The chain used to be spelled out literally (select -> is -> lte -> order -> range), so it
+  // encoded not just WHICH filters convergeAckTTL applies but the ORDER it applies them in. It
+  // has now broken twice on additive changes that were correct in production: once when
+  // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 added pagination (see the comment it left), and
+  // again when SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 added a second .is() after .lte() — which a
+  // real supabase client chains without complaint. A mock that fails on a change the SUT handles
+  // correctly is testing the mock.
+  //
+  // Filters are RECORDED rather than shaped, so a test can assert WHICH filters were applied
+  // (see the promotion-marker case below) without pinning the order they arrive in.
+  const filters = [];
+  const builder = {
+    select: vi.fn(() => builder),
+    is: vi.fn((col, val) => { filters.push(['is', col, val]); return builder; }),
+    lte: vi.fn((col, val) => { filters.push(['lte', col, val]); return builder; }),
+    order: vi.fn(() => builder),
+    range: vi.fn(async () => ({ data: candidates, error: null })),
+  };
   const from = vi.fn(() => ({
-    select: vi.fn(() => ({
-      is: vi.fn(() => ({
-        // FR-6 batch 8: convergeAckTTL now paginates the candidate read via
-        // fetchAllPaginated (.order().range()); extend the chain to match.
-        lte: vi.fn(() => ({
-          order: vi.fn(() => ({
-            range: vi.fn(async () => ({ data: candidates, error: null })),
-          })),
-        })),
-      })),
-    })),
+    select: builder.select,
     update: vi.fn((patch) => {
       updates.push(patch);
       return {
@@ -28,10 +38,33 @@ function mockSupabase({ candidates = [], updateError = null } = {}) {
       };
     }),
   }));
-  return { supabase: { from }, updates };
+  return { supabase: { from }, updates, filters };
 }
 
 describe('convergeAckTTL', () => {
+  // SD-LEO-INFRA-SIGNAL-ROUTER-AUTO-001 (FR-8, second site). BEHAVIOURAL, not a source scan.
+  //
+  // The first version of this guard was pinned only by a regex over the file. That is defeatable
+  // four ways — comment the line out (the regex matches commented text), bolt an identical .is()
+  // onto an unrelated query elsewhere in the file (a file-global match never checks position),
+  // or leave the asserted line byte-identical while re-binding the import
+  // (`{ PROMOTION_ACK_SOURCE_KEY: PROMOTION_ACK_KEY }`) so the guard filters the WRONG KEY while
+  // reading as correct. The last one defeats the entire "imports the key rather than re-spelling
+  // it" rationale, and a grep also cannot see the runtime death of the line it greps for.
+  //
+  // convergeAckTTL takes an injectable client, so the filters it ACTUALLY applies can just be
+  // observed. That closes all four, and it exercises the ESM createRequire import at runtime
+  // rather than asserting the import statement exists.
+  it('EXCLUDES promotion-marked rows from TTL convergence (observed, not grepped)', async () => {
+    const { supabase, filters } = mockSupabase({ candidates: [] });
+    await convergeAckTTL(supabase);
+    const isFilters = filters.filter((f) => f[0] === 'is');
+    expect(isFilters).toContainEqual(['is', 'acknowledged_at', null]);
+    // The exact column string matters: promotion_ack_source would pass a laxer assertion while
+    // filtering the wrong key entirely.
+    expect(isFilters).toContainEqual(['is', 'payload->>promotion_ack', null]);
+  });
+
   it('no-ops when there are no candidates', async () => {
     const { supabase } = mockSupabase({ candidates: [] });
     const r = await convergeAckTTL(supabase);


### PR DESCRIPTION
## Summary

`stampRouted` stamped `acknowledged_at` while promoting a signal into a backlog row. The coordinator inbox selects `acknowledged_at IS NULL` — and that same inbox is the **only writer of `read_at`** (it stamps on render). So the ack removed the row from the very query that would have marked it read. "Unread" never meant nobody looked; it meant the ack deleted the row from the lane first.

**Measured, full-range: 9 rows acked-and-unread carrying `routed_to_feedback_id` — 100% of everything the router has ever promoted**, all severity=critical, including signals carrying explicit STOP/DO-NOT orders. Still firing: one was promoted and acked the day the SD was filed.

## The fix

Promotion records **where a signal went** and stops claiming it was **handled**. `stampRouted` no longer writes `acknowledged_at`; it writes `payload.promotion_ack`. `routed_to_feedback_id` is preserved — `loadRecentSignals` dedupes on it and nothing else. `acknowledged_at` now means exactly one thing: a human or role dispositioned this.

Non-disposing **by default**, not disposing-with-a-guard. A guard is what the next edit forgets.

## Without one of these files it would have shipped inert

`scripts/stale-session-sweep.cjs` drains `signal_type='stuck' AND acknowledged_at IS NULL` and **re-stamps `acknowledged_at`**. Three of the nine rows are that type — so once promotion stopped acking, the drain would have re-acked them within the hour, straight back into the swallowed state, **with every other acceptance criterion still passing**. Its severity gate doesn't cover it: that protects rows whose sender is *live*, but `senderIsDead()` drains at any severity — and the condition that makes a signal most worth preserving is exactly what makes it drainable.

## Two more that the obvious fix misses

- `detectors.cjs` treated `routed_to_feedback_id` **alone** as answered, so the one gauge that should have alarmed on all 9 was disabled by the key the router writes. Removing the key isn't possible (dedup), so the clause now also requires the row not be merely promotion-marked. The docblock stating the old contract changed in the same hunk.
- A **distinct** marker, not the existing `auto_acked`. The detector must exclude retention-style machine acks while still catching promotions; one shared key would have made it blind to precisely the population it exists to catch.

## Falsifiability — measured, not asserted

Before this commit the change would have reddened **exactly 1 assertion in 35,067 tests**. The plan counted two other scenarios as protection: one could not execute at all, the other was a pure function unaffected by the change.

Three sabotages now redden **3, 3 and 1**. The classifier is pure and total so the proof is in-memory — this repo has no designated non-production database, and `tests/integration/` resolves to zero files and **reports green by absence**.

The predicate keys on router provenance, not the bare acked-and-unread pair: `coordinator-ack-signal.cjs` stamps acked-without-read as the *legitimate* path, so those rows always exist and "drive the count to zero" was never reachable. Acceptance is a **rule**, not a count — the negative fixture drifted 176 → 416 → 426 across three days.

Verified the jsonb operator genuinely **discriminates** (9 carry the key, 5209 lack it, sum = 5218 total) rather than merely parsing — an earlier check against `auto_acked` proved nothing, since that key is absent from every row so both arms agreed.

## Also

- `outstanding-signals.cjs` distinguishes "router filed it, nobody dispositioned it" from "nobody touched it at all" — both unanswered, both belong in the sender's banner, but collapsing them is what let a promoted signal read as handled from the sender's end too. (Charlie's routed review: the swallow was invisible from *both* ends.)
- `stampRoutedToCoordinator` documented as unreachable (no production caller, zero rows ever) and left **behaviourally untouched** rather than "fixed" unexecuted — a change there would ship unexecuted while reading in review as though both paths were covered.

## Test plan

414 tests across 20 suites green; the two router suites keep their 54. One new fixture bug caught by executing: omitting `sender_type:'worker'` made both starvation cases vacuous — the discriminating one "passed" by being filtered out before the logic ran.

🤖 Generated with [Claude Code](https://claude.com/claude-code)