### PR TITLE
chore(G2): chairman-gated apply ceremony - approval header, post-condition normalization fix, acceptance probe

### DIFF
--- a/database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier.sql
+++ b/database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier.sql
@@ -179,14 +179,23 @@ BEGIN
     END IF;
 
     -- 2. THE CORRELATION LANDED. Guards the exact silent failure described at clause (3): if the
-    --    outer reference had bound to the subquery alias, Postgres would render the predicate with
-    --    `f.source_type IS NOT DISTINCT FROM f.source_type`. Assert the rendered expression
-    --    references the OUTER table name inside the correlation, and does NOT contain the
-    --    self-comparison form.
-    IF wc !~ 'f\.source_type IS NOT DISTINCT FROM feedback\.source_type' THEN
-        RAISE EXCEPTION 'clause (3) is not correlated to the inserting row: expected f.source_type IS NOT DISTINCT FROM feedback.source_type, got: %', wc;
+    --    outer reference had bound to the subquery alias, the rendered predicate would contain a
+    --    self-comparison and NO reference to the outer table name.
+    --
+    --    LESSON STAMPED AT APPLY TIME (2026-08-03, first live run): the original assertion matched
+    --    the literal source spelling `f.source_type IS NOT DISTINCT FROM feedback.source_type` —
+    --    but pg_get_expr renders the NORMALIZED form `NOT f.source_type::text IS DISTINCT FROM
+    --    feedback.source_type::text`, so the check REJECTED A CORRECT APPLY and rolled it back.
+    --    The header of this very file warns that pg_get_expr output is a rendering, not source;
+    --    the instrument built to catch the mis-scoping committed the file's own documented trap.
+    --    Fixed to key on what normalization PRESERVES: outer columns render UNQUALIFIED at the
+    --    top level, so the table-qualified `feedback.source_type` token appears ONLY as a
+    --    correlated outer reference inside the subquery — and a collapsed binding renders both
+    --    sides as `f.source_type` with no `feedback.` token at all.
+    IF wc !~ 'feedback\.source_type' THEN
+        RAISE EXCEPTION 'clause (3) is not correlated to the inserting row: no outer reference feedback.source_type in the rendered predicate, got: %', wc;
     END IF;
-    IF wc ~ 'f\.source_type IS NOT DISTINCT FROM f\.source_type' THEN
+    IF wc ~ 'f\.source_type(::text)? IS DISTINCT FROM f\.source_type(::text)?' THEN
         RAISE EXCEPTION 'clause (3) correlation collapsed to a self-comparison (always TRUE) — the outer reference bound to the subquery alias.';
     END IF;
 

--- a/database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier.sql
+++ b/database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier.sql
@@ -15,6 +15,11 @@
 -- chairman-gated ceremony with the approval row referenced. Approval to AUTHOR is not approval to
 -- APPLY, and this file does not apply itself.
 --
+-- @approved-by: codestreetlabs@gmail.com
+-- (Approver header added 2026-08-03 ~21:2xZ during the chairman's own apply session, at his
+-- terminal, under his direction. The email is the repo's git user.email — the chairman's Code
+-- Street Labs identity. Approval provenance: the SMS above + in-terminal walkthrough this hour.)
+--
 -- ============================================================================================
 -- WHAT IS WRONG TODAY (the defect this amends)
 -- ============================================================================================

--- a/database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier_acceptance.mjs
+++ b/database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier_acceptance.mjs
@@ -162,10 +162,32 @@ try {
       console.log('\nB. DISCRIMINATOR — a DIFFERENT source_type, under its own threshold, must still be accepted');
       const ventureUnder = await windowCount('user_feedback');
       console.log(`  user_feedback rows in window = ${ventureUnder} (must be under ${THRESHOLD})`);
+      // LESSON STAMPED AT FIRST LIVE VERIFY (2026-08-03): this probe originally carried NO
+      // venture_id. For a non-telegram anon row the ONLY permissive path is
+      // venture_user_insert_feedback, which requires venture_id IS NOT NULL AND
+      // venture_exists_and_active(venture_id) — so the row was refused by the PERMISSIVE layer
+      // regardless of G2, in baseline AND verify. The baseline B-failure was OVERDETERMINED
+      // (G2 + missing venture), and the suite credited it entirely to G2 — the exact
+      // "permissive layer refused for an unrelated reason" hazard this test's own remark text
+      // warns about on the opposite arm. The probe must ride the venture path fully.
+      // Venture resolved AT RUN TIME (a hardcoded id goes stale silently). Selection calls the
+      // REAL venture_exists_and_active function (param p_venture_id, verified from pg_proc) —
+      // never a reimplementation of its semantics.
+      const { data: activeVentures } = await svc.from('ventures').select('id, name').order('updated_at', { ascending: false }).limit(25);
+      let ventureId = null;
+      for (const v of activeVentures || []) {
+        const { data: ok } = await svc.rpc('venture_exists_and_active', { p_venture_id: v.id }).then(r => r, () => ({ data: null }));
+        if (ok === true) { ventureId = v.id; console.log(`  venture-user path rides venture: ${v.name} (${v.id.slice(0, 8)})`); break; }
+      }
+      if (!ventureId) {
+        console.log('  *** NO ACTIVE VENTURE FOUND — the venture-user permissive path cannot be exercised.');
+        console.log('  *** Test B is NOT RUNNABLE, which is a FAIL, not a skip: an absence result would mean nothing.');
+      }
       const other = await probe('other-source-under-limit', {
         source_type: 'user_feedback',
         feedback_type: 'user_general',
         severity: 'low',
+        venture_id: ventureId,
       });
       const expectLanded = MODE === 'verify';
       record('B', `non-telegram anon insert ${expectLanded ? 'ACCEPTED (G2 fixed)' : 'DENIED (G2 present — this FAIL is the point of --baseline)'}`,


### PR DESCRIPTION
Chairman-gated G2 apply ceremony artifacts (SD-LEO-FIX-BOUND-ANON-TELEGRAM-001 gap G2, carried as follow-on).

**The DDL is already applied to prod by the chairman's hands** (MIGRATION_APPLY_PROD_PASS, sha f7f89d0b, 2026-08-03; approval on record: SMS 10:13Z, Option A). This PR lands the ceremony's repo artifacts:

- approval header stamp on the gated amendment (`-- @approved-by`, guard-required)
- post-condition 2 fix: the first live apply was CORRECT but self-rolled-back because the assertion matched source spelling while pg_get_expr renders the normalized form — now keyed on what normalization preserves
- acceptance B-probe fix: rides the venture_user permissive path (runtime venture lookup); B deliberately stays RED as a tripwire for the PRE-EXISTING dead venture-user ingress (newest user_feedback row Jul 4 — separate defect, routed to coordinator)

Verify: A/C1/C2/D green; B blocked-by-known-defect. Evidence row 56b378a3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)