### PR TITLE
fix(QF-20260801-425): TESTING demanded an e2e_test_path 90% of stories cannot have

### DIFF
--- a/lib/sub-agents/testing/phases/phase4-evidence.js
+++ b/lib/sub-agents/testing/phases/phase4-evidence.js
@@ -85,11 +85,27 @@ export async function verifyUserStories(sdId, supabase, options = {}) {
 
   // A story is complete if:
   // 1. status is 'completed' or 'validated'
-  // 2. AND e2e_test_path exists (unless sd_type is exempt)
+  // 2. AND (e2e_test_path exists OR validation_status = 'validated') — unless sd_type is exempt
   // 3. AND (e2e_test_status = 'passing' OR validation_status = 'validated')
+  //
+  // QF-20260801-425 — clause 2 previously accepted NO alternative to an e2e_test_path, while
+  // clause 3 directly below it already accepted validation_status='validated' in place of a
+  // passing e2e run. The function contradicted itself, and the contradiction was unreachable
+  // for most callers: 12,634 of 13,966 completed AND validated stories (90.5%) have
+  // e2e_test_path NULL, and nothing in the pipeline populates it for most stories. So for any
+  // sd_type outside E2E_EXEMPT_SD_TYPES this clause demanded something nine-tenths of the
+  // corpus has never had and cannot obtain — one SD failed three consecutive handoff attempts
+  // against it with no remediation a worker could actually perform.
+  //
+  // The canonical promoter (scripts/auto-validate-user-stories-on-exec-complete.js) keys on
+  // validation_status and reports these same rows as fully validated, so the two checks
+  // disagreed about what "done" means. Granting clause 2 the alternative clause 3 already
+  // grants removes the contradiction rather than removing the check: a story with neither a
+  // passing e2e run NOR validation is still blocked, which the test suite pins in both
+  // directions.
   const incomplete = stories.filter(s =>
     !['completed', 'validated'].includes(s.status) ||
-    (requireE2EMapping && !s.e2e_test_path) ||
+    (requireE2EMapping && !s.e2e_test_path && s.validation_status !== 'validated') ||
     (s.e2e_test_status !== 'passing' && s.validation_status !== 'validated')
   );
 

--- a/tests/unit/testing-subagent/verify-user-stories-e2e-mapping.test.js
+++ b/tests/unit/testing-subagent/verify-user-stories-e2e-mapping.test.js
@@ -1,0 +1,153 @@
+// QF-20260801-425 — TESTING blocked EXEC-TO-PLAN on a requirement 90% of the corpus cannot meet.
+//
+// WHAT THE FILED QF SAID, AND WHY IT IS WRONG ON MECHANISM. It reported that
+// `user_stories.e2e_mapped` is selected and returns Postgres 42703 (undefined_column). It is
+// not. `e2e_mapped` appears exactly once in the repo — phase4-evidence.js:109 — as a DERIVED
+// OUTPUT field, `e2e_mapped: !!s.e2e_test_path`. The select at :60 reads only real columns.
+// The author saw `e2e_mapped: false` in the blocking report and reasonably inferred a queried
+// column; it is a correct rendering of a null path. A second plausible theory — case-sensitive
+// comparison against UPPERCASE stored values — was also refuted: all 15,524 user_stories rows
+// store lowercase (`completed`, `validated`, `passing`).
+//
+// THE ACTUAL DEFECT, measured. Clause 2 of the completeness filter demands an `e2e_test_path`
+// for any SD whose type is not in E2E_EXEMPT_SD_TYPES. But 12,634 of 13,966 completed AND
+// validated stories (90.5%) have `e2e_test_path` NULL, and nothing in the pipeline populates
+// it for most stories. So the clause demands something nine-tenths of the corpus has never
+// had and cannot obtain — which is why the reported SD failed three separate handoff attempts
+// with no reachable remediation.
+//
+// THE INTERNAL TELL. Clause 3 already accepts `validation_status === 'validated'` as an
+// alternative to a passing e2e run. Clause 2 accepts no alternative at all. The function
+// disagrees with itself, and the canonical promoter
+// (scripts/auto-validate-user-stories-on-exec-complete.js, which keys on validation_status)
+// sides with clause 3. The fix makes clause 2 consistent with clause 3 — it does not remove
+// a check, it removes a contradiction.
+//
+// This file is also the POSITIVE CONTROL. The first test below reproduces the exact blocking
+// shape from the reported SD and fails against the pre-fix code. There was no coverage of
+// verifyUserStories at all before this QF, which is how a self-contradicting filter survived.
+import { describe, it, expect } from 'vitest';
+import { verifyUserStories } from '../../../lib/sub-agents/testing/phases/phase4-evidence.js';
+
+/** Minimal stub matching the one call shape: .from().select().eq() -> {data, error}. */
+function stubSupabase(rows, error = null) {
+  return {
+    from: () => ({
+      select: () => ({
+        eq: () => Promise.resolve({ data: rows, error }),
+      }),
+    }),
+  };
+}
+
+/** The exact row shape of the 5 stories on the SD that blocked three times. */
+function reportedStory(n) {
+  return {
+    story_key: `SD-LEO-INFRA-SUBAGENT-VERDICT-LAUNDERED-001:US-00${n}`,
+    title: `Story ${n}`,
+    status: 'completed',
+    validation_status: 'validated',
+    e2e_test_path: null,
+    e2e_test_status: 'not_created',
+  };
+}
+
+const REPORTED = [1, 2, 3, 4, 5].map(reportedStory);
+
+describe('verifyUserStories — the QF-20260801-425 blocking shape', () => {
+  // POSITIVE CONTROL. Against the pre-fix code this FAILS, which is what makes the
+  // post-fix pass mean something. A fix verified only by a test written after it is a
+  // tautology.
+  it('accepts completed+validated stories with no e2e_test_path on a NON-exempt sd_type', async () => {
+    const res = await verifyUserStories('sd-1', stubSupabase(REPORTED), { sdType: 'bugfix' });
+    expect(res.verified).toBe(true);
+    expect(res.incomplete).toEqual([]);
+    expect(res.stories_count).toBe(5);
+  });
+
+  it('behaves identically for an exempt sd_type — the fix does not depend on the exemption list', async () => {
+    const res = await verifyUserStories('sd-1', stubSupabase(REPORTED), { sdType: 'infrastructure' });
+    expect(res.verified).toBe(true);
+  });
+
+  it('agrees with the canonical promoter, which keys on validation_status', async () => {
+    // The promoter reports "All user stories already validated" for exactly these rows while
+    // TESTING blocked them. Two checks disagreeing about what "done" means is the filed
+    // complaint; this asserts they now agree.
+    const res = await verifyUserStories('sd-1', stubSupabase(REPORTED), { sdType: 'feature' });
+    expect(res.verified).toBe(true);
+  });
+});
+
+describe('verifyUserStories — the check must still have teeth', () => {
+  // Every acceptance above needs a rejection twin, or the "fix" is indistinguishable from
+  // deleting the check. These are the cases that MUST still block.
+
+  it('BLOCKS a story that is not completed', async () => {
+    const rows = [{ ...reportedStory(1), status: 'ready' }];
+    const res = await verifyUserStories('sd-1', stubSupabase(rows), { sdType: 'bugfix' });
+    expect(res.verified).toBe(false);
+    expect(res.incomplete).toHaveLength(1);
+  });
+
+  it('BLOCKS a completed story that is neither validated nor e2e-passing', async () => {
+    // The case the e2e-mapping clause was really written for: no evidence of any kind.
+    const rows = [{ ...reportedStory(1), validation_status: 'pending', e2e_test_status: 'not_created' }];
+    const res = await verifyUserStories('sd-1', stubSupabase(rows), { sdType: 'bugfix' });
+    expect(res.verified).toBe(false);
+  });
+
+  it('BLOCKS a completed, unvalidated story whose mapped e2e test is FAILING', async () => {
+    const rows = [{
+      ...reportedStory(1),
+      validation_status: 'pending',
+      e2e_test_path: 'tests/e2e/foo.spec.ts',
+      e2e_test_status: 'failing',
+    }];
+    const res = await verifyUserStories('sd-1', stubSupabase(rows), { sdType: 'bugfix' });
+    expect(res.verified).toBe(false);
+  });
+
+  it('ACCEPTS a completed, unvalidated story whose mapped e2e test PASSES', async () => {
+    const rows = [{
+      ...reportedStory(1),
+      validation_status: 'pending',
+      e2e_test_path: 'tests/e2e/foo.spec.ts',
+      e2e_test_status: 'passing',
+    }];
+    const res = await verifyUserStories('sd-1', stubSupabase(rows), { sdType: 'bugfix' });
+    expect(res.verified).toBe(true);
+  });
+
+  it('reports a mixed set partially — only the genuinely incomplete story is named', async () => {
+    const rows = [reportedStory(1), { ...reportedStory(2), status: 'draft', validation_status: 'pending' }];
+    const res = await verifyUserStories('sd-1', stubSupabase(rows), { sdType: 'bugfix' });
+    expect(res.verified).toBe(false);
+    expect(res.incomplete).toHaveLength(1);
+    expect(res.incomplete[0].story_key).toContain('US-002');
+  });
+});
+
+describe('verifyUserStories — surrounding contract is unchanged', () => {
+  it('an SD with no stories verifies, rather than blocking on an empty set', async () => {
+    const res = await verifyUserStories('sd-1', stubSupabase([]), { sdType: 'bugfix' });
+    expect(res.verified).toBe(true);
+    expect(res.stories_count).toBe(0);
+  });
+
+  it('a query error reports verified:false with the error, never a silent pass', async () => {
+    // A read that failed has not shown the stories to be complete. This is the same class as
+    // the SD merged just before this QF: an unreadable input must never render as clean.
+    const res = await verifyUserStories('sd-1', stubSupabase(null, { message: 'boom' }));
+    expect(res.verified).toBe(false);
+    expect(res.error).toBe('boom');
+  });
+
+  it('still derives e2e_mapped from e2e_test_path for the stories it does report', async () => {
+    // The field the QF mistook for a column. It stays — it is a correct rendering, and the
+    // blocking report is less legible without it.
+    const rows = [{ ...reportedStory(1), status: 'draft', validation_status: 'pending' }];
+    const res = await verifyUserStories('sd-1', stubSupabase(rows), { sdType: 'bugfix' });
+    expect(res.incomplete[0].e2e_mapped).toBe(false);
+  });
+});


### PR DESCRIPTION
## The filed mechanism is wrong. The filed conclusion is right.

The QF reported that `user_stories.e2e_mapped` is SELECTed and returns Postgres 42703 (undefined_column). **It is not.** `e2e_mapped` occurs exactly once in the repo — `phase4-evidence.js:109` — as a *derived output field*:

```js
e2e_mapped: !!s.e2e_test_path
```

The select at `:60` reads only real columns. The author saw `e2e_mapped: false` in the blocking report and reasonably inferred a queried column; it is a correct rendering of a null path. There is no 42703 anywhere.

A second theory of mine was **also wrong**: case-sensitive comparison against UPPERCASE stored values (the QF prose shows `status=COMPLETED` against a lowercase array literal). Refuted by measuring all **15,524** `user_stories` rows with an exact COUNT — every value is lowercase. I'm recording that because it was plausible, it fit the report, and it was false.

Refuting the reason doesn't refute the conclusion. The handoff really did block, three times.

## The actual defect

Clause 2 of the completeness filter accepted **no alternative**:

```js
(requireE2EMapping && !s.e2e_test_path)
```

…while clause 3, immediately below it, already accepted `validation_status === 'validated'` in place of a passing e2e run. **The function contradicted itself.**

**Measured blast radius:** 12,634 of 13,966 completed *and* validated stories — **90.5%** — have `e2e_test_path` NULL, and nothing in the pipeline populates it for most stories. So for any `sd_type` outside `E2E_EXEMPT_SD_TYPES`, this clause demanded something nine-tenths of the corpus has never had and cannot obtain. That is why there was no reachable remediation across three handoff attempts.

The reported SD's 5 stories were all `completed` + `validated` + `e2e_test_path NULL`, `sd_type=bugfix` (not exempt).

The canonical promoter (`scripts/auto-validate-user-stories-on-exec-complete.js`) keys on `validation_status` and reports those same rows as fully validated. Two checks disagreed about what "done" means — which is the QF's title, and its expected-behaviour field explicitly asks for them to agree.

**The fix grants clause 2 the alternative clause 3 already grants.** It removes the contradiction, not the check.

## Positive control

A fix verified only by a test written after it is a tautology. There was **no coverage of `verifyUserStories` at all** before this QF — which is how a self-contradicting filter survived.

The new suite **fails 3/11 against the pre-fix code** — precisely the tests asserting the reported shape should pass — and **11/11 after**.

Every acceptance has a rejection twin. These still block:
- a story that is not `completed`
- a completed story with neither validation nor a passing e2e run
- a completed, unvalidated story whose mapped e2e test is **failing**

And a read error still reports `verified:false` rather than a silent pass.

180/180 across the 22 surrounding suites. No regressions.

## Honest cost

14,026 of 15,524 stories are validated, so this **does** weaken the e2e-mapping requirement in practice. The rival reading — that e2e mapping *should* be demanded and the real defect is that nothing populates the column — is a much larger SD, not a quick fix. Raised with the coordinator rather than decided silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)