### PR TITLE
fix(SD-FDBK-FIX-HEAL-BEFORE-COMPLETE-001 D3,D4): rubric spoofing + the gate that wrote a signature its own resolver refuses

### DIFF
--- a/lib/handoff/threshold-resolver.js
+++ b/lib/handoff/threshold-resolver.js
@@ -257,6 +257,25 @@ const LATENCY_KEYS = new Set(['elapsed_ms']);
 const VISION_KEY_RX = /^[AV]\d{2}$/;
 
 /**
+ * Narrowest key set that may be claimed as the vision rubric.
+ *
+ * WITHOUT A FLOOR THE FAMILY RULE IS A LENIENCY LEVER, not a classifier. `keys.every(...)` is
+ * vacuously satisfiable: {A01: 90} — a SINGLE key — matched vision-av-v1, which is the most lenient
+ * rubric at every tier. Since identity is derived from the key set and several writers persist
+ * dimension_scores VERBATIM from LLM output with no key validation, renaming a five-key heal payload
+ * to A01..A05 moved the bugfix bar from 92 to 67 with no change to any score. Measured over the real
+ * heal rows: 493 of 2537 (19.4%) sit inside that window and would flip FAIL->PASS on the rename
+ * alone; at feature tier the window holds 1350 (53.2%).
+ *
+ * 11 IS MEASURED, NOT CHOSEN. The genuine instrument emits 11..18 keys (11:6, 12:13, 13:17, 14:36,
+ * 15:52, 16:16, 17:34, 18:1653). Everything below that is stragglers: widths 1,2,3,4,6,8 total
+ * FOURTEEN rows out of 1841. Those fourteen become 'unregistered' and are therefore REFUSED rather
+ * than scored — the honest price of the floor, and the right direction, since a 1-key "vision" score
+ * was never a vision score.
+ */
+const VISION_MIN_WIDTH = 11;
+
+/**
  * Name the instrument that produced a dimension_scores object.
  *
  * Returns a stable rubric id, or 'unregistered' when the signature is not one this registry knows.
@@ -286,9 +305,42 @@ export function identifyRubric(dimensionScores) {
   // Vision FAMILY, not a single fixed width. The 18-key form is the modal one but the same
   // instrument also emitted 11..17-key rows as it grew; they are one rubric at several widths, and
   // treating each width as its own rubric would fragment the registry for no behavioural gain.
-  if (keys.every(k => VISION_KEY_RX.test(k))) return 'vision-av-v1';
+  // The WIDTH FLOOR is what stops the family rule being a leniency lever — see VISION_MIN_WIDTH.
+  if (keys.length >= VISION_MIN_WIDTH && keys.every(k => VISION_KEY_RX.test(k))) return 'vision-av-v1';
 
   return 'unregistered';
+}
+
+/**
+ * Identify a rubric and CROSS-CHECK it against the identity the row declares for itself.
+ *
+ * WHY A SECOND, SEPARATE FUNCTION rather than folding this into identifyRubric: 95.2% of rows carry
+ * no declared rubric at all, so a cross-check cannot be the primary defence — the width floor is.
+ * This is the belt to that braces, and it only has anything to say about the 4.8% that self-declare.
+ *
+ * The two facts are INDEPENDENTLY WRITTEN and that is exactly why comparing them is worth anything:
+ * lib/programmatic/vision-score-row.js hard-codes rubric_snapshot.rubric='eva-5dim-v1' while storing
+ * dimension_scores verbatim from an LLM blob, so the label reflects which WRITER ran and the key set
+ * reflects what the MODEL emitted. A spoofed payload changes the second without touching the first.
+ *
+ * MEASURED COST: of 290 labelled rows, 288 already agree; exactly 2 disagree (both declaring
+ * eva-5dim-v1 while deriving 'unregistered'). No row declares one registered rubric and derives a
+ * different registered one — so today this refuses 2 rows, and the disagreement it is built to catch
+ * has not happened yet. That is the point of adding it before wiring rather than after.
+ *
+ * @param {Object|null} dimensionScores
+ * @param {Object|string|null} rubricSnapshot the row's rubric_snapshot column
+ * @returns {{rubric: string, declared: string|null, agrees: boolean}}
+ */
+export function identifyRubricChecked(dimensionScores, rubricSnapshot) {
+  const rubric = identifyRubric(dimensionScores);
+  const declared = (rubricSnapshot && typeof rubricSnapshot === 'object' && !Array.isArray(rubricSnapshot)
+    && typeof rubricSnapshot.rubric === 'string' && rubricSnapshot.rubric)
+    ? rubricSnapshot.rubric
+    : null;
+  // An ABSENT label is not a disagreement. Treating "undeclared" as a mismatch would refuse 95.2%
+  // of the table and would be a denial of service wearing a security fix.
+  return { rubric, declared, agrees: declared === null || declared === rubric };
 }
 
 /**
@@ -411,14 +463,14 @@ export function resolveEffectiveThreshold(sdType, dimensionScores, sdMetadata = 
   if (NON_COMPARABLE_RUBRICS.has(rubric)) {
     throw new Error(
       `resolveEffectiveThreshold: rubric '${rubric}' is a latency measurement, not a quality score — ` +
-      `refusing to threshold-compare it (elapsed_ms is milliseconds; it clears a 0-100 quality floor by magnitude alone)`
+      'refusing to threshold-compare it (elapsed_ms is milliseconds; it clears a 0-100 quality floor by magnitude alone)'
     );
   }
   if (!RUBRIC_QUANTILES[rubric]) {
     throw new Error(
-      `resolveEffectiveThreshold: unregistered rubric signature — nothing is known about its score ` +
-      `scale, so no threshold is meaningful. Add it to RUBRIC_QUANTILES via ` +
-      `scripts/analysis/rubric-threshold-calibration.mjs.`
+      'resolveEffectiveThreshold: unregistered rubric signature — nothing is known about its score ' +
+      'scale, so no threshold is meaningful. Add it to RUBRIC_QUANTILES via ' +
+      'scripts/analysis/rubric-threshold-calibration.mjs.'
     );
   }
   const { addressable, total } = countAddressableDimensions(sdType, dimensionScores, sdMetadata);

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js
@@ -49,6 +49,45 @@ import { countAddressableDimensions, calculateDynamicThreshold, SD_TYPE_THRESHOL
  * @param {object|string|null|undefined} snapshot
  * @returns {boolean}
  */
+/**
+ * dimension_scores payload for a fast-heal insert — EXPORTED so it can be EXECUTED by a test.
+ *
+ * THE GATE MUST NOT WRITE A SIGNATURE ITS OWN RESOLVER REFUSES. fastAutoHeal returns
+ * details:{structural, semantic, elapsed_ms}, and that whole object used to go in as
+ * dimension_scores, putting a DURATION IN MILLISECONDS in the same JSONB column as 0-100 quality
+ * scores. 1136 rows carry it. Two consequences:
+ *
+ *   1. dimScoreOf returns elapsed_ms verbatim, so 1200 clears NARROW_FEATURE_DIM_FLOOR (50) by
+ *      MAGNITUDE ALONE — the stopwatch reading counts as a fully-addressed dimension, suppresses
+ *      narrowing entirely, and the SD is held to the full base bar on the strength of it.
+ *   2. resolveEffectiveThreshold REFUSES the signature as non-comparable. Once any gate consumes
+ *      that resolver, this gate would write a row its own reader rejects: write latency row ->
+ *      refuse -> FAIL -> retry -> identical row. A livelock authored by one function in this file
+ *      and sprung by another.
+ *
+ * elapsed_ms is ALREADY preserved verbatim in rubric_snapshot.details on the same insert, so
+ * dropping it here discards nothing — it moves a timing fact out of a column meaning "quality
+ * dimension" into one meaning "how this ran".
+ *
+ * WHY THIS IS A FUNCTION AND NOT FOUR INLINE LINES: as inline code its only possible test was a
+ * regex over this file, and a mutant that reverted the payload to fastResult.details SURVIVED that
+ * regex — the destructuring line was still present, only its USE had changed. A source test cannot
+ * see which variable the payload actually uses. Exporting it makes the behaviour executable.
+ *
+ * @param {{details?: Object, structuralScore?: number, semanticScore?: number}} fastResult
+ * @returns {Object} dimension_scores, guaranteed free of latency keys
+ */
+export function buildFastHealDimensionScores(fastResult) {
+  if (!fastResult || !fastResult.details || typeof fastResult.details !== 'object') {
+    return {
+      structural: { score: fastResult?.structuralScore ?? 100 },
+      semantic: { score: fastResult?.semanticScore ?? 70 }
+    };
+  }
+  const { elapsed_ms: _elapsedMs, ...qualityDims } = fastResult.details;
+  return qualityDims;
+}
+
 export function isSdHealSnapshot(snapshot) {
   if (!snapshot || typeof snapshot !== 'object' || Array.isArray(snapshot)) return false;
   return snapshot.mode === 'sd-heal';
@@ -635,10 +674,7 @@ export function createHealBeforeCompleteGate(supabase) {
                 .select('id', { count: 'exact', head: true })
                 .eq('sd_id', sdKey);
 
-              const dimensionScores = fastResult.details || {
-                structural: { score: fastResult.structuralScore || 100 },
-                semantic: { score: fastResult.semanticScore || 70 }
-              };
+              const dimensionScores = buildFastHealDimensionScores(fastResult);
 
               const insertPayload = {
                 sd_id: sdKey,

--- a/tests/unit/rubric-spoofing-and-latency-write.test.js
+++ b/tests/unit/rubric-spoofing-and-latency-write.test.js
@@ -1,0 +1,146 @@
+// D3 + D4 — the two defects the EXEC SECURITY sub-agent found in FR-1's own code.
+// SD-FDBK-FIX-HEAL-BEFORE-COMPLETE-001.
+//
+// Neither was live-exploitable when found: resolveEffectiveThreshold is merged but wired into no
+// gate. Both are PRE-WIRING fixes, which is the only cheap moment to make them.
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  identifyRubric,
+  identifyRubricChecked,
+  resolveEffectiveThreshold,
+} from '../../lib/handoff/threshold-resolver.js';
+import { buildFastHealDimensionScores } from '../../scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js';
+
+const HEAL_5 = ['capabilities_present', 'key_changes_delivered', 'smoke_tests_pass', 'success_criteria_met', 'success_metrics_achieved'];
+const VISION_18 = ['A01','A02','A03','A04','A05','A06','A07','V01','V02','V03','V04','V05','V06','V07','V08','V09','V10','V11'];
+
+const score = (keys, addressed = keys.length) =>
+  Object.fromEntries(keys.map((k, i) => [k, i < addressed ? 80 : 20]));
+
+describe('D3 — the vision family rule is a classifier, not a leniency lever', () => {
+  it('THE ATTACK: renaming heal keys to A01..A05 no longer buys the lenient rubric', () => {
+    // This is the whole finding, expressed as the attacker would perform it. The heal payload is
+    // unchanged in every way that matters — same five values, same meaning — and only the KEY NAMES
+    // move. Before the width floor this classified as vision-av-v1 and dropped the bugfix bar from
+    // 92 to 67, flipping 493 of 2537 real heal rows (19.4%) from FAIL to PASS.
+    const genuineHeal = score(HEAL_5);
+    const renamed = score(['A01', 'A02', 'A03', 'A04', 'A05']);
+
+    expect(identifyRubric(genuineHeal)).toBe('sd-heal-5dim-v1');
+    expect(identifyRubric(renamed)).not.toBe('vision-av-v1');
+    expect(identifyRubric(renamed)).toBe('unregistered');
+  });
+
+  it('a one-key A/V payload cannot claim the most lenient rubric', () => {
+    // `keys.every(...)` is VACUOUSLY TRUE on a single key — that is how {A01:90} passed.
+    expect(identifyRubric({ A01: 90 })).toBe('unregistered');
+  });
+
+  it('and the spoof is REFUSED rather than silently scored', () => {
+    // Classification is only half the fix; what matters is that nothing downstream hands the
+    // payload a threshold anyway.
+    expect(() => resolveEffectiveThreshold('bugfix', score(['A01','A02','A03','A04','A05'])))
+      .toThrow(/unregistered/i);
+  });
+
+  it('the GENUINE instrument is untouched at every width it actually emits', () => {
+    // Both arms. A floor set too high would "fix" the spoof by breaking the real rubric, and a test
+    // that only asserted the spoof is rejected would not notice.
+    expect(identifyRubric(score(VISION_18))).toBe('vision-av-v1');
+    for (const width of [11, 12, 13, 14, 15, 16, 17, 18]) {
+      const keys = Array.from({ length: width }, (_, i) => `V${String(i + 1).padStart(2, '0')}`);
+      expect(identifyRubric(score(keys)), `width ${width}`).toBe('vision-av-v1');
+    }
+  });
+
+  it('the floor sits exactly at the measured boundary — 10 out, 11 in', () => {
+    const keys = (n) => Array.from({ length: n }, (_, i) => `V${String(i + 1).padStart(2, '0')}`);
+    expect(identifyRubric(score(keys(10)))).toBe('unregistered');
+    expect(identifyRubric(score(keys(11)))).toBe('vision-av-v1');
+  });
+});
+
+describe('D3 — the declared rubric is cross-checked, and an ABSENT label is not a disagreement', () => {
+  it('agrees when the label matches the key set', () => {
+    const r = identifyRubricChecked(score(VISION_18), { rubric: 'vision-av-v1' });
+    expect(r).toEqual({ rubric: 'vision-av-v1', declared: 'vision-av-v1', agrees: true });
+  });
+
+  it('DISAGREES when a row declares one rubric and its keys derive another', () => {
+    // The spoof signature seen from the other side: the writer stamps its own label while the model
+    // chooses the keys, so a payload that changes the key set alone shows up here.
+    const r = identifyRubricChecked(score(VISION_18), { rubric: 'eva-5dim-v1' });
+    expect(r.agrees).toBe(false);
+    expect(r.declared).toBe('eva-5dim-v1');
+    expect(r.rubric).toBe('vision-av-v1');
+  });
+
+  it('treats an unlabelled row as agreeing — 95.2% of rows declare nothing', () => {
+    // Both arms matter: a cross-check that called "undeclared" a mismatch would refuse almost the
+    // entire table. That is a denial of service wearing a security fix.
+    for (const snap of [null, undefined, {}, 'a raw prompt string', { mode: 'sd-heal' }]) {
+      expect(identifyRubricChecked(score(VISION_18), snap).agrees, String(snap)).toBe(true);
+    }
+  });
+});
+
+describe('D4 — the gate no longer writes the signature its own resolver refuses', () => {
+  // fastAutoHeal returns details:{structural, semantic, elapsed_ms} and that object went straight
+  // into dimension_scores. Wired, that is a livelock authored by one function in this file and
+  // sprung by another: write latency row -> refuse -> FAIL -> retry -> identical row.
+  //
+  // THESE ASSERTIONS EXECUTE THE BUILDER. The first version of this block regexed the gate source,
+  // and a mutant that reverted the payload to `fastResult.details` SURVIVED it — the destructuring
+  // line was still present, only its USE had changed. That is precisely the defect class this SD
+  // is about, reproduced by me one file over, so the inline code became an exported function.
+  // DELIBERATELY NOT 100/70. Those are the builder's own fallback defaults, and the first version of
+  // this fixture used them — so a mutant that threw the real scores away and returned a fresh
+  // {structural:100, semantic:70} SURVIVED, because the expected values coincided with the constant.
+  // Realistic-looking fixture values that happen to equal the defaults cannot detect a constant.
+  const fastResult = {
+    score: 88,
+    mode: 'fast-haiku',
+    details: { structural: { score: 93 }, semantic: { score: 61 }, elapsed_ms: 1200 },
+  };
+
+  it('strips elapsed_ms from what will be written as dimension_scores', () => {
+    const dims = buildFastHealDimensionScores(fastResult);
+    expect(Object.keys(dims).sort()).toEqual(['semantic', 'structural']);
+    expect(dims).not.toHaveProperty('elapsed_ms');
+  });
+
+  it('and the KEPT dimensions are unchanged — the strip is surgical, not a rebuild', () => {
+    // A builder that returned a fresh hard-coded object would pass the assertion above while
+    // silently discarding the real scores.
+    const dims = buildFastHealDimensionScores(fastResult);
+    expect(dims.structural).toEqual({ score: 93 });
+    expect(dims.semantic).toEqual({ score: 61 });
+  });
+
+  it('what it produces is CLASSIFIABLE — the whole point of the strip', () => {
+    // If this still read latency-3dim the livelock would survive the fix.
+    const dims = buildFastHealDimensionScores(fastResult);
+    expect(identifyRubric(dims)).not.toBe('latency-3dim');
+  });
+
+  it('falls back to a scored payload when details are absent', () => {
+    const dims = buildFastHealDimensionScores({ structuralScore: 90, semanticScore: 60 });
+    expect(dims).toEqual({ structural: { score: 90 }, semantic: { score: 60 } });
+    expect(identifyRubric(dims)).not.toBe('latency-3dim');
+  });
+
+  it('elapsed_ms is STILL preserved in rubric_snapshot.details — nothing is lost', () => {
+    // The fix is only free because the timing fact survives elsewhere on the same insert. If that
+    // duplication were ever removed this fix would start destroying data, and this says so.
+    const GATE = path.join(process.cwd(), 'scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js');
+    expect(fs.readFileSync(GATE, 'utf8')).toMatch(/details: fastResult\.details/);
+  });
+
+  it('a raw latency payload is still refused, so the resolver half is intact', () => {
+    expect(identifyRubric({ structural: 90, semantic: 85, elapsed_ms: 1200 })).toBe('latency-3dim');
+    expect(() => resolveEffectiveThreshold('feature', { structural: 90, semantic: 85, elapsed_ms: 1200 }))
+      .toThrow(/latency|not a quality score/i);
+  });
+});


### PR DESCRIPTION
The two defects the EXEC **SECURITY** sub-agent found in FR-1's own code. Neither was live-exploitable — `resolveEffectiveThreshold` is merged but wired into no gate — so both are **pre-wiring** fixes, which is the only cheap moment to make them.

98 tests green across 7 suites. **8/8 mutants killed.**

## D3 — rubric spoofing: a 25-point bar drop for a pure rename, zero score change

`identifyRubric`'s vision-family rule was `keys.every(k => VISION_KEY_RX.test(k))` with **no width floor**, and `every` is vacuously true on one key — `{A01: 90}` classified as `vision-av-v1`, the most lenient rubric at every tier.

Identity is derived from the key set, and several writers persist `dimension_scores` **verbatim from LLM output with no key validation**. So renaming a five-key heal payload to `A01..A05` moved the bugfix bar **92 → 67** with no score changed:

| tier | window | real heal rows inside |
|---|---|---|
| bugfix | `[67, 92)` | **493 / 2537 (19.4%)** flip FAIL→PASS |
| feature | `[81, 96)` | **1350 (53.2%)** |

This was my own defect, and it's the "a field name is a claim" rule exactly: I made the key set load-bearing for a threshold decision **without asking who can write key names.**

**The floor is measured, not chosen.** The genuine instrument emits 11–18 keys (11:6, 12:13, 13:17, 14:36, 15:52, 16:16, 17:34, 18:1653). Below that: widths 1,2,3,4,6,8 totalling **14 rows out of 1841**. Those 14 become `unregistered` and are refused rather than scored — the honest price, and the right direction, since a one-key "vision" score was never a vision score.

Plus `identifyRubricChecked` as a **separate** function: 95.2% of rows declare no rubric, so a cross-check cannot be the primary defence — the floor is. **An absent label is not a disagreement**; treating undeclared as mismatch would refuse 95.2% of the table, a denial of service wearing a security fix. Measured: of 290 labelled rows **288 already agree**, 2 disagree, and no row declares one registered rubric while deriving a different one.

## D4 — the gate wrote the signature its own resolver refuses

`fastAutoHeal` returns `details:{structural, semantic, elapsed_ms}` and that whole object went in as `dimension_scores` — a duration in **milliseconds** in the same JSONB column as 0–100 quality scores (1136 rows). `dimScoreOf` returns it verbatim, so `1200` clears the quality floor of 50 **by magnitude alone**. And once any gate consumes the resolver: write latency row → refuse → FAIL → retry → identical row. A livelock authored by one function in this file and sprung by another.

`elapsed_ms` is already duplicated into `rubric_snapshot.details` on the same insert, so the strip discards nothing.

## Two mutants survived first, and both corrections are the point

**D4-a survived because my D4 tests regexed the gate source.** Reverting the payload to `fastResult.details` left the destructuring line present and changed only its *use* — invisible to a source test. That's this SD's own defect class, reproduced by me one file over, three commits after writing the executing test that fixed it elsewhere. The inline code is now an exported `buildFastHealDimensionScores` and the assertions execute it.

**D4-b survived because my fixture used `structural:100 / semantic:70`** — the builder's own fallback defaults. A mutant discarding the real scores and returning a fresh `{100, 70}` matched my expectations exactly. Realistic-looking fixture values that coincide with the defaults cannot detect a constant. Now 93/61.

| mutant | verdict |
|---|---|
| D3-a floor removed entirely (the original defect) | killed by 4 |
| D3-b floor lowered to 1 | killed by 4 |
| D3-c floor raised to 19 (breaks the genuine rubric) | killed by 6 |
| D3-d cross-check always agrees | killed by 1 |
| D3-e absent label treated as disagreement | killed by 1 |
| D4-a strip reverted | killed by 2 |
| D4-b builder returns a fresh constant | killed by 1 |
| D4-c fallback drops semantic | killed by 1 |

**D3-c is the two-sided arm**: a floor set too high would "fix" the spoof by breaking the real instrument, and a suite that only asserted the spoof is rejected would never notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)