### PR TITLE
feat(SD-LEO-INFRA-WITHHELD-PROMOTIONS-GET-001): withheld QF promotions get a durable record

### DIFF
--- a/lib/governance/demand-gate-emit.js
+++ b/lib/governance/demand-gate-emit.js
@@ -44,6 +44,19 @@ import { normalizeGaugeReading, decideDemand } from './demand-gate.js';
 export const DEMAND_GATE_EVENT = 'DEMAND_GATE_DECISION';
 
 /**
+ * audit_log.event_type for what a withhold actually COST.
+ *
+ * SD-LEO-INFRA-WITHHELD-PROMOTIONS-GET-001: this has to be a SECOND event rather than a field on
+ * the first one, and the reason is structural rather than stylistic. recordDemandDecision runs
+ * inside openQfMintGate, BEFORE the allow/withhold verdict is known and long before anything has
+ * enumerated what was suppressed — so the decision row cannot carry the suppressed set by
+ * construction, no matter what is added to it. The consequence was that the DB side stayed
+ * illegible: a reader could see that a withhold happened and never what it cost, and had to open
+ * a GHA log for a single run to find out. That log is unqueryable and it expires.
+ */
+export const DEMAND_GATE_WITHHELD_RECORD_EVENT = 'DEMAND_GATE_WITHHELD_RECORD';
+
+/**
  * Belt depth at or below which production is warranted.
  *
  * NOT a magic number and NOT a permanent one. The fleet runs at most 3 concurrent worker seats, so
@@ -99,6 +112,44 @@ export async function measureDemand(supabase, { engine, floor, now, gauge = coun
     engine,
     measuredAt: now || new Date().toISOString(),
   });
+}
+
+/**
+ * Persist WHAT A WITHHOLD COST, as a second event after the decision.
+ *
+ * Same best-effort posture as recordDemandDecision, and for the same reason: losing an audit line
+ * must never stop production. Same `.select('id')` length check too — a silently-rejected insert
+ * here returns HTTP 200 with error=null and zero rows, so "no error" is not evidence the row
+ * landed. That check is the difference between an observability line and the appearance of one.
+ *
+ * @param {object} supabase
+ * @param {object} decision the demand decision (engine, gauge_value, floor, decision, reason)
+ * @param {{suppressed_groups:number, markers_written:number, markers_failed:number, marker_key:string, run_id:string|null}} cost
+ * @returns {Promise<boolean>} true when the row was written AND returned
+ */
+export async function recordWithheldCost(supabase, decision, cost) {
+  if (!supabase || !decision || !cost) return false;
+  try {
+    const { data, error } = await supabase.from('audit_log').insert({
+      event_type: DEMAND_GATE_WITHHELD_RECORD_EVENT,
+      entity_type: 'sourcing_engine',
+      entity_id: decision.engine,
+      // The decision is repeated here rather than referenced, because the two rows are not joined
+      // and a reader landing on this one should not need to go find the other to interpret it.
+      metadata: { ...decision, ...cost },
+      // A withhold that recorded NOTHING is not routine — it is the failure this SD exists to
+      // prevent, occurring. It must not be logged at the same severity as a successful one.
+      severity: cost.markers_failed > 0 || cost.markers_written === 0 ? 'warning' : 'info',
+      created_by: 'demand-gate',
+    }).select('id');
+    if (error) throw new Error(error.message);
+    return (data || []).length > 0;
+  } catch (e) {
+    if (typeof process !== 'undefined' && process.stderr) {
+      process.stderr.write(`[demand-gate] withheld cost NOT recorded for ${decision.engine}: ${e && e.message}\n`);
+    }
+    return false;
+  }
 }
 
 /**

--- a/lib/governance/demand-gate-emit.js
+++ b/lib/governance/demand-gate-emit.js
@@ -139,7 +139,13 @@ export async function recordWithheldCost(supabase, decision, cost) {
       metadata: { ...decision, ...cost },
       // A withhold that recorded NOTHING is not routine — it is the failure this SD exists to
       // prevent, occurring. It must not be logged at the same severity as a successful one.
-      severity: cost.markers_failed > 0 || cost.markers_written === 0 ? 'warning' : 'info',
+      //
+      // BUT markers_written === 0 ALONE IS NOT A FAULT. An all-SKIPPED run — every group already
+      // carrying a non-pending marker — legitimately writes nothing, and warning on it would fire
+      // every six hours on a healthy system until nobody reads the level at all. So the fault
+      // condition is: something was ATTEMPTED and none of it landed. Found at PLAN_VERIFICATION.
+      severity: (cost.markers_failed > 0 || (Number(cost.markers_attempted) > 0 && cost.markers_written === 0))
+        ? 'warning' : 'info',
       created_by: 'demand-gate',
     }).select('id');
     if (error) throw new Error(error.message);

--- a/lib/governance/qf-mint-gate.mjs
+++ b/lib/governance/qf-mint-gate.mjs
@@ -26,7 +26,7 @@
  *
  * @module lib/governance/qf-mint-gate
  */
-import { measureDemand as defaultMeasure, recordDemandDecision as defaultRecord, resolveDemandFloor } from './demand-gate-emit.js';
+import { measureDemand as defaultMeasure, recordDemandDecision as defaultRecord, resolveDemandFloor, recordWithheldCost } from './demand-gate-emit.js';
 import { formatDemandDecision, mayProduce } from './demand-gate.js';
 import { createRequire } from 'node:module';
 
@@ -134,13 +134,29 @@ export async function gatedQfMint(supabase, opts, mint) {
     // default no-ops for any producer still returning a scalar — which is what keeps the
     // out-of-scope retro promoter writing zero markers WITHOUT editing that file, and makes
     // "it writes none" an assertion rather than an inspection.
+    let cost = null;
     if (Array.isArray(groups) && groups.length > 0 && typeof opts.writeMarkers === 'function') {
-      try { await opts.writeMarkers(supabase, groups, demand); }
-      catch (e) {
+      try {
+        const written = await opts.writeMarkers(supabase, groups, demand);
+        cost = { suppressed_groups: groups.length, markers_written: Number(written) || 0, markers_failed: 0 };
+      } catch (e) {
         // Recording is observability, not the gate's verdict. A failed write must not convert a
-        // correct withhold into a crash — but it must never pass silently either.
+        // correct withhold into a crash — but it must never pass silently either, and it must not
+        // be recorded at the same severity as a success.
         (opts.log || console.log)(`[demand-gate] ${opts.engine}: WARNING durable withheld-record write failed: ${e.message}`);
+        cost = { suppressed_groups: groups.length, markers_written: 0, markers_failed: groups.length, error: e.message };
       }
+    }
+
+    // FR-6: WHAT THE WITHHOLD COST, on the DB side. The decision row written back in
+    // openQfMintGate cannot carry this — it is emitted before `allowed` is even known, let alone
+    // before anything has enumerated the suppressed set. So a reader could see THAT a withhold
+    // happened and never WHAT it cost, and had to open a per-run GHA log to find out. Second
+    // event, same best-effort posture: an audit line must never stop production.
+    if (cost) {
+      const emitCost = typeof opts.recordCost === 'function' ? opts.recordCost : recordWithheldCost;
+      try { await emitCost(supabase, demand, { ...cost, marker_key: 'withheld_pending', run_id: (typeof process !== 'undefined' && process.env?.GITHUB_RUN_ID) || null }); }
+      catch { /* best-effort: recordWithheldCost already warns to stderr and returns false */ }
     }
 
     if (suppressed !== null) {

--- a/lib/governance/qf-mint-gate.mjs
+++ b/lib/governance/qf-mint-gate.mjs
@@ -137,14 +137,29 @@ export async function gatedQfMint(supabase, opts, mint) {
     let cost = null;
     if (Array.isArray(groups) && groups.length > 0 && typeof opts.writeMarkers === 'function') {
       try {
-        const written = await opts.writeMarkers(supabase, groups, demand);
-        cost = { suppressed_groups: groups.length, markers_written: Number(written) || 0, markers_failed: 0 };
+        const res = await opts.writeMarkers(supabase, groups, demand);
+        // V-2: accept EITHER a bare count (kept, so existing callers and tests are unaffected) or
+        // the full {written, failed, attempted}. Hardcoding markers_failed:0 here erased partial
+        // failures at this boundary — a run where half the writes were rejected recorded as a
+        // clean 'info', and the partial survived only on the expiring log FR-6 exists to replace.
+        const isDetail = res && typeof res === 'object';
+        const written = isDetail ? (Number(res.written) || 0) : (Number(res) || 0);
+        const failedList = isDetail && Array.isArray(res.failed) ? res.failed : [];
+        cost = {
+          suppressed_groups: groups.length,
+          markers_written: written,
+          markers_failed: failedList.length,
+          // attempted distinguishes an all-SKIPPED run (every group already carried a non-pending
+          // marker — healthy) from an all-FAILED one. Without it, both look like written===0 and
+          // a healthy run logs at 'warning' every six hours until the signal means nothing.
+          markers_attempted: isDetail && Number.isFinite(res.attempted) ? res.attempted : written + failedList.length,
+        };
       } catch (e) {
         // Recording is observability, not the gate's verdict. A failed write must not convert a
         // correct withhold into a crash — but it must never pass silently either, and it must not
         // be recorded at the same severity as a success.
         (opts.log || console.log)(`[demand-gate] ${opts.engine}: WARNING durable withheld-record write failed: ${e.message}`);
-        cost = { suppressed_groups: groups.length, markers_written: 0, markers_failed: groups.length, error: e.message };
+        cost = { suppressed_groups: groups.length, markers_written: 0, markers_failed: groups.length, markers_attempted: groups.length, error: e.message };
       }
     }
 

--- a/lib/governance/qf-mint-gate.mjs
+++ b/lib/governance/qf-mint-gate.mjs
@@ -109,10 +109,40 @@ export async function gatedQfMint(supabase, opts, mint) {
     // [PROMOTABLE] output, no spawn. Whether the floor SHOULD withhold this much is an operational
     // decision; making the bill legible is not.
     let suppressed = null;
+    let groups = null;
     if (typeof opts.onWithheld === 'function') {
-      try { suppressed = Number(await opts.onWithheld(demand)) || 0; }
-      catch { suppressed = null; }   // a failed count must not turn a quiet run into a crash
+      try {
+        const reported = await opts.onWithheld(demand);
+        // SD-LEO-INFRA-WITHHELD-PROMOTIONS-GET-001: onWithheld may now return the GROUPS rather
+        // than a count, so the withheld set can be recorded durably instead of expiring as stdout.
+        //
+        // THE ARRAY BRANCH IS NOT COSMETIC. Number([{...},{...}]) is NaN, and NaN || 0 is 0 — so
+        // the previous expression reported "suppressed 0" for any array return. That is the exact
+        // defect fixed in 43c488c62ca ("the counter reported 0 on a run that suppressed 34"),
+        // which this widening would have silently reintroduced: a number that looks measured AND
+        // looks like good news. Measured on HEAD before the change, not predicted.
+        if (Array.isArray(reported)) {
+          groups = reported;
+          suppressed = reported.length;
+        } else {
+          suppressed = Number(reported) || 0;
+        }
+      } catch { suppressed = null; groups = null; }   // a failed count must not turn a quiet run into a crash
     }
+
+    // DURABLE RECORD. Injected so the gate stays unit-testable with a bare {} client, and so the
+    // default no-ops for any producer still returning a scalar — which is what keeps the
+    // out-of-scope retro promoter writing zero markers WITHOUT editing that file, and makes
+    // "it writes none" an assertion rather than an inspection.
+    if (Array.isArray(groups) && groups.length > 0 && typeof opts.writeMarkers === 'function') {
+      try { await opts.writeMarkers(supabase, groups, demand); }
+      catch (e) {
+        // Recording is observability, not the gate's verdict. A failed write must not convert a
+        // correct withhold into a crash — but it must never pass silently either.
+        (opts.log || console.log)(`[demand-gate] ${opts.engine}: WARNING durable withheld-record write failed: ${e.message}`);
+      }
+    }
+
     if (suppressed !== null) {
       (opts.log || console.log)(`[demand-gate] ${opts.engine}: WITHHELD suppressed ${suppressed} promotable group(s) — these do NOT queue, they expire on their source window`);
     }

--- a/lib/governance/withheld-registry.mjs
+++ b/lib/governance/withheld-registry.mjs
@@ -1,0 +1,207 @@
+/**
+ * Withheld-promotion registry — SD-LEO-INFRA-WITHHELD-PROMOTIONS-GET-001.
+ *
+ * WHAT WAS MISSING. The QF demand gate withholds promotion whenever the belt gauge sits at or
+ * above its floor, which is correct. But the withheld set existed durably NOWHERE: stdout inside
+ * one GHA run, plus an integer the caller destructured away one line after the gate computed it.
+ * Meanwhile the source rows age out of a rolling 14-day candidate window. A withheld group that
+ * never sees a below-floor run before its window closes is lost, silently, and the cron re-runs
+ * every six hours.
+ *
+ * The gate's own source already said so — "a withheld group does not queue, IT EXPIRES". The
+ * problem was named and understood; only the sink was absent.
+ *
+ * ── WHY feedback.metadata AND NOT A TABLE OR A STATUS VALUE ───────────────────────────────────
+ * The SD offered "table or feedback-status representation". Both are chairman-gated DDL:
+ * feedback_status_check admits nine values and none is a pending state (verified against live
+ * pg_constraint, not the migration snapshot), so the status option is ALTER TABLE DROP/ADD
+ * CONSTRAINT. feedback.metadata is live jsonb, nullable, DEFAULT '{}', with NO check constraint,
+ * and it already carries promotion state for this exact promoter (the promoted_to_qf stamp).
+ * It also delivers "the record outlives the window" for free, because feedback rows are never
+ * purged — rows from 2026-04-26 are still present.
+ *
+ * ── REGISTRY, NOT LEDGER ──────────────────────────────────────────────────────────────────────
+ * The SD was internally inconsistent here: one requirement stamps a RUN IDENTIFIER (implying an
+ * append-per-run log) while another presumes a mutable SET that entries leave by a named event.
+ * Append-per-run over a 6-hourly cron is ~144 rows/day and ~2,000 per window for 36 groups — a
+ * record less legible than the stdout it replaces, which would defeat the point. So: ONE marker
+ * per group, mutated in place, with run provenance preserved as counters (first/last/count).
+ *
+ * ── THE KEY IS THE FEEDBACK ROW ID, NOT THE FINGERPRINT ───────────────────────────────────────
+ * A fingerprint is derived from title+description and MOVES if a title is ever edited, orphaning
+ * its record and silently creating a second one. The two coincide today only because every
+ * current group is a singleton — a fact about today's data, not a property of the design.
+ */
+
+/** The metadata key. One namespace, no parallel copies. */
+export const MARKER_KEY = 'withheld_pending';
+
+/** Admission paths, mirroring the two branches of shouldPromote. */
+export const ADMISSION_SEVERITY_BYPASS = 'severity_bypass';
+export const ADMISSION_COUNT_THRESHOLD = 'count_threshold';
+
+/**
+ * Which branch of shouldPromote admitted this group?
+ *
+ * shouldPromote returns a bare boolean and does not report its reason, so this re-derives it —
+ * a two-readers hazard, and the reason the derivation lives in exactly one place.
+ *
+ * ORDER IS LOAD-BEARING. A group that is BOTH critical AND at/over the key threshold reports
+ * severity_bypass, because the severity branch returns first in shouldPromote. Reporting
+ * count_threshold for that group would be a lie about which rule was actually consulted.
+ *
+ * @param {{max_severity?: string, groupKeys?: Set<any>}} group
+ * @param {(s: string) => number} severityRank injected from content-fingerprint
+ * @param {number} threshold
+ * @returns {string}
+ */
+export function deriveAdmissionPath(group, severityRank, threshold) {
+  if (severityRank(group?.max_severity) >= severityRank('critical')) return ADMISSION_SEVERITY_BYPASS;
+  return ADMISSION_COUNT_THRESHOLD;
+}
+
+/**
+ * PURE: build the marker for one suppressed group. No I/O, no clock — `nowIso` and `runId` are
+ * passed in so the shape is testable and the timestamps are not invented here.
+ *
+ * @param {object} group      a group from groupByFingerprint: {fingerprint, rows, max_severity, groupKeys}
+ * @param {object} demand     the demand decision: {engine, gauge_value, floor, decision}
+ * @param {object} ctx        {runId, nowIso, severityRank, threshold, prior}
+ * @returns {object} the marker
+ */
+export function buildMarker(group, demand, { runId = null, nowIso, severityRank, threshold, prior = null } = {}) {
+  if (!nowIso) throw new Error('buildMarker: nowIso is required — a marker without a timestamp cannot be aged or ordered');
+  if (typeof severityRank !== 'function') throw new Error('buildMarker: severityRank must be injected');
+
+  const memberIds = Array.isArray(group?.rows) ? group.rows.map((r) => r.id).filter(Boolean) : [];
+
+  return {
+    fingerprint: group?.fingerprint ?? null,
+    member_feedback_ids: memberIds,
+    max_severity: group?.max_severity ?? null,
+    admission_path: deriveAdmissionPath(group, severityRank, threshold),
+
+    // GAUGE VALUE IS PASSED THROUGH, NEVER COERCED. An unmeasurable reading carries null, and a
+    // null that becomes 0 is indistinguishable from a real below-floor reading — the exact false-
+    // zero this subsystem documents elsewhere in its own source.
+    gauge_value: demand?.gauge_value ?? null,
+    floor: demand?.floor ?? null,
+    engine: demand?.engine ?? null,
+    decision: demand?.decision ?? null,
+
+    // Run provenance WITHOUT appending a row per run. This is what lets one mutable marker
+    // satisfy the run-identifier requirement.
+    first_withheld_at: prior?.first_withheld_at ?? nowIso,
+    last_withheld_at: nowIso,
+    first_withheld_run: prior?.first_withheld_run ?? runId,
+    last_withheld_run: runId,
+    withheld_run_count: (prior?.withheld_run_count ?? 0) + 1,
+
+    // Exit state. Present and null while pending, so a reader never has to distinguish
+    // "absent key" from "not yet promoted".
+    promoted_qf_id: prior?.promoted_qf_id ?? null,
+    disposed_by: prior?.disposed_by ?? null,
+    disposed_reason: prior?.disposed_reason ?? null,
+    disposed_at: prior?.disposed_at ?? null,
+  };
+}
+
+/** A marker is pending while it has neither been promoted nor dispositioned. */
+export function isPending(marker) {
+  return !!marker && !marker.promoted_qf_id && !marker.disposed_at;
+}
+
+/**
+ * Write one marker per suppressed group, keyed by MEMBER FEEDBACK ID.
+ *
+ * Idempotent by construction: re-running over an unchanged population updates the same rows and
+ * advances the counters rather than creating competing records.
+ *
+ * CARRIES THE EXISTING METADATA THROUGH. The promoter's success path rewrites metadata as a
+ * full-object spread from a snapshot read, so anything not carried is silently clobbered; this
+ * writer re-reads immediately before writing rather than trusting a snapshot it was handed.
+ *
+ * @param {object} supabase service-role client — a PARAMETER, so this module is unit-testable
+ * @param {Array<object>} groups suppressed groups
+ * @param {object} demand the demand decision
+ * @param {object} ctx {runId, nowIso, severityRank, threshold}
+ * @returns {Promise<{written: number, rows: string[]}>}
+ */
+export async function writeMarkers(supabase, groups, demand, ctx = {}) {
+  if (!supabase || typeof supabase.from !== 'function') {
+    throw new Error('writeMarkers: a supabase client is required');
+  }
+  if (!Array.isArray(groups) || groups.length === 0) return { written: 0, rows: [] };
+
+  const touched = [];
+  for (const group of groups) {
+    const ids = Array.isArray(group?.rows) ? group.rows.map((r) => r.id).filter(Boolean) : [];
+    for (const id of ids) {
+      const { data: row, error: readErr } = await supabase
+        .from('feedback').select('id, metadata').eq('id', id).maybeSingle();
+      if (readErr || !row) continue;
+
+      const prior = row.metadata?.[MARKER_KEY] ?? null;
+      // A marker that already left pending state is NOT resurrected by a later withheld run —
+      // exits are by recorded event only, in both directions.
+      if (prior && !isPending(prior)) continue;
+
+      const marker = buildMarker(group, demand, { ...ctx, prior });
+      const { error: writeErr } = await supabase
+        .from('feedback')
+        .update({ metadata: { ...(row.metadata || {}), [MARKER_KEY]: marker } })
+        .eq('id', id);
+      if (!writeErr) touched.push(id);
+    }
+  }
+  return { written: touched.length, rows: touched };
+}
+
+/**
+ * Read pending markers. Server-side filtered — a capped fetch grouped in memory measures the CAP,
+ * not the population.
+ *
+ * @param {object} supabase
+ * @param {{engine?: string}} [opts]
+ */
+export async function readPendingMarkers(supabase, { engine = null } = {}) {
+  let q = supabase.from('feedback').select('id, metadata').not(`metadata->>${MARKER_KEY}`, 'is', null);
+  const { data, error } = await q;
+  if (error) return { markers: [], error: error.message };
+  const markers = (data || [])
+    .map((r) => ({ feedback_id: r.id, marker: r.metadata?.[MARKER_KEY] }))
+    .filter((m) => isPending(m.marker))
+    .filter((m) => (engine ? m.marker?.engine === engine : true));
+  return { markers, error: null };
+}
+
+/**
+ * Consume a marker on promotion: stamp the minted QF id. This is one of exactly two ways an entry
+ * may leave pending state.
+ */
+export async function consumeMarker(supabase, feedbackId, qfId, { nowIso } = {}) {
+  if (!qfId) throw new Error('consumeMarker: a minted QF id is required — a consumption with no id is a silent exit');
+  const { data: row } = await supabase.from('feedback').select('id, metadata').eq('id', feedbackId).maybeSingle();
+  if (!row?.metadata?.[MARKER_KEY]) return { consumed: false };
+  const marker = { ...row.metadata[MARKER_KEY], promoted_qf_id: qfId, promoted_at: nowIso ?? null };
+  const { error } = await supabase.from('feedback')
+    .update({ metadata: { ...(row.metadata || {}), [MARKER_KEY]: marker } }).eq('id', feedbackId);
+  return { consumed: !error };
+}
+
+/**
+ * Dispose a marker explicitly. The other of exactly two exits — and it requires BOTH an actor and
+ * a reason, because a disposition with neither is indistinguishable from the silent expiry this
+ * whole module exists to abolish.
+ */
+export async function disposeMarker(supabase, feedbackId, { actor, reason, nowIso } = {}) {
+  if (!actor || !reason) {
+    throw new Error('disposeMarker: actor and reason are both required — an unattributed disposition is a silent exit wearing a verb');
+  }
+  const { data: row } = await supabase.from('feedback').select('id, metadata').eq('id', feedbackId).maybeSingle();
+  if (!row?.metadata?.[MARKER_KEY]) return { disposed: false };
+  const marker = { ...row.metadata[MARKER_KEY], disposed_by: actor, disposed_reason: reason, disposed_at: nowIso ?? null };
+  const { error } = await supabase.from('feedback')
+    .update({ metadata: { ...(row.metadata || {}), [MARKER_KEY]: marker } }).eq('id', feedbackId);
+  return { disposed: !error };
+}

--- a/lib/governance/withheld-registry.mjs
+++ b/lib/governance/withheld-registry.mjs
@@ -99,16 +99,30 @@ export function buildMarker(group, demand, { runId = null, nowIso, severityRank,
 
     // Exit state. Present and null while pending, so a reader never has to distinguish
     // "absent key" from "not yet promoted".
+    //
+    // promoted_at is the AUTHORITATIVE promotion stamp; promoted_qf_id is best-effort and stays
+    // null on the promoter's inline path, because create-quick-fix.js runs with stdio:'inherit'
+    // and its minted id is never captured by that process. Keeping them separate means the id
+    // field never has to hold something that is not an id.
+    promoted_at: prior?.promoted_at ?? null,
     promoted_qf_id: prior?.promoted_qf_id ?? null,
+    promoted_fingerprint: prior?.promoted_fingerprint ?? null,
     disposed_by: prior?.disposed_by ?? null,
     disposed_reason: prior?.disposed_reason ?? null,
     disposed_at: prior?.disposed_at ?? null,
   };
 }
 
-/** A marker is pending while it has neither been promoted nor dispositioned. */
+/**
+ * A marker is pending while it has neither been promoted nor dispositioned.
+ *
+ * PROMOTION IS DETECTED BY promoted_at, NOT BY promoted_qf_id. The id is genuinely unavailable on
+ * the promoter's inline path, so keying pending-ness on it would leave every inline-promoted
+ * marker permanently "pending" — a record that says a thing is outstanding when it has already
+ * been dealt with, which is the same illegibility this module exists to remove, inverted.
+ */
 export function isPending(marker) {
-  return !!marker && !marker.promoted_qf_id && !marker.disposed_at;
+  return !!marker && !marker.promoted_at && !marker.promoted_qf_id && !marker.disposed_at;
 }
 
 /**

--- a/lib/governance/withheld-registry.mjs
+++ b/lib/governance/withheld-registry.mjs
@@ -134,45 +134,82 @@ export async function writeMarkers(supabase, groups, demand, ctx = {}) {
   if (!Array.isArray(groups) || groups.length === 0) return { written: 0, rows: [] };
 
   const touched = [];
+  const failed = [];
+  let attempted = 0;
+
   for (const group of groups) {
     const ids = Array.isArray(group?.rows) ? group.rows.map((r) => r.id).filter(Boolean) : [];
     for (const id of ids) {
+      attempted++;
       const { data: row, error: readErr } = await supabase
         .from('feedback').select('id, metadata').eq('id', id).maybeSingle();
-      if (readErr || !row) continue;
+      if (readErr || !row) { failed.push({ id, stage: 'read', error: readErr?.message ?? 'row not found' }); continue; }
 
       const prior = row.metadata?.[MARKER_KEY] ?? null;
       // A marker that already left pending state is NOT resurrected by a later withheld run —
-      // exits are by recorded event only, in both directions.
-      if (prior && !isPending(prior)) continue;
+      // exits are by recorded event only, in both directions. Counted as skipped, not failed.
+      if (prior && !isPending(prior)) { attempted--; continue; }
 
       const marker = buildMarker(group, demand, { ...ctx, prior });
       const { error: writeErr } = await supabase
         .from('feedback')
         .update({ metadata: { ...(row.metadata || {}), [MARKER_KEY]: marker } })
         .eq('id', id);
-      if (!writeErr) touched.push(id);
+      if (writeErr) failed.push({ id, stage: 'write', error: writeErr.message });
+      else touched.push(id);
     }
   }
-  return { written: touched.length, rows: touched };
+
+  // FAILURES ARE REPORTED, NOT SWALLOWED. The first version returned {written: 0} on a run where
+  // every single write was rejected, and the caller then printed "0 source row(s) marked pending
+  // ... these now survive their 14-day window" — false, and with nothing raised to contradict it.
+  // That is a green reading that means nothing, which is the exact defect class this whole module
+  // was written to abolish, reproduced one level up inside the fix for it. Found at review.
+  //
+  // A TOTAL failure throws: if nothing could be recorded, the run has NOT protected anything and
+  // must not report as though it had. A PARTIAL failure returns the detail so the caller can say
+  // so precisely — a partial record is still worth keeping.
+  if (attempted > 0 && touched.length === 0 && failed.length > 0) {
+    throw new Error(`writeMarkers: all ${failed.length} durable write(s) failed — nothing was recorded (first: ${failed[0].error})`);
+  }
+  return { written: touched.length, rows: touched, failed, attempted };
 }
 
 /**
- * Read pending markers. Server-side filtered — a capped fetch grouped in memory measures the CAP,
- * not the population.
+ * Read pending markers.
+ *
+ * PAGINATED, AND THE DOCSTRING NOW MATCHES THE CODE. The first version claimed "server-side
+ * filtered — a capped fetch grouped in memory measures the CAP, not the population" while doing
+ * exactly the thing it warned against: a plain select, truncated by PostgREST at 1000 rows against
+ * a 5,477-row table, then filtered in memory. A comment asserting a property the code does not
+ * have is worse than no comment, because it stops the next reader from checking. Found at review.
+ *
+ * The MARKER-PRESENCE filter is genuinely server-side. The PENDING filter is applied in memory
+ * and that is stated rather than implied: pending-ness lives in a nested jsonb field, and the
+ * presence filter already narrows the set to rows that carry a marker at all — a population
+ * bounded by the number of groups ever withheld, not by the table.
  *
  * @param {object} supabase
- * @param {{engine?: string}} [opts]
+ * @param {{engine?: string, pageSize?: number}} [opts]
  */
-export async function readPendingMarkers(supabase, { engine = null } = {}) {
-  let q = supabase.from('feedback').select('id, metadata').not(`metadata->>${MARKER_KEY}`, 'is', null);
-  const { data, error } = await q;
-  if (error) return { markers: [], error: error.message };
-  const markers = (data || [])
+export async function readPendingMarkers(supabase, { engine = null, pageSize = 1000 } = {}) {
+  const rows = [];
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await supabase
+      .from('feedback').select('id, metadata')
+      .not(`metadata->>${MARKER_KEY}`, 'is', null)
+      .order('id', { ascending: true })
+      .range(from, from + pageSize - 1);
+    if (error) return { markers: [], error: error.message };
+    const page = data || [];
+    rows.push(...page);
+    if (page.length < pageSize) break;
+  }
+  const markers = rows
     .map((r) => ({ feedback_id: r.id, marker: r.metadata?.[MARKER_KEY] }))
     .filter((m) => isPending(m.marker))
     .filter((m) => (engine ? m.marker?.engine === engine : true));
-  return { markers, error: null };
+  return { markers, error: null, scanned: rows.length };
 }
 
 /**

--- a/lib/governance/withheld-registry.mjs
+++ b/lib/governance/withheld-registry.mjs
@@ -249,9 +249,16 @@ export async function disposeMarker(supabase, feedbackId, { actor, reason, nowIs
   if (!actor || !reason) {
     throw new Error('disposeMarker: actor and reason are both required — an unattributed disposition is a silent exit wearing a verb');
   }
+  // V-3, found at PLAN_VERIFICATION: without nowIso this returned {disposed:true} while leaving
+  // disposed_at null — and isPending() keys on disposed_at, so the marker stayed PENDING while the
+  // caller was told it had been disposed. A silent non-exit wearing a verb, in the very function
+  // whose error message above rails against that. The guard was one argument short of its own rule.
+  if (!nowIso) {
+    throw new Error('disposeMarker: nowIso is required — disposed_at is what ends pending state, so a disposition without it reports success and changes nothing');
+  }
   const { data: row } = await supabase.from('feedback').select('id, metadata').eq('id', feedbackId).maybeSingle();
   if (!row?.metadata?.[MARKER_KEY]) return { disposed: false };
-  const marker = { ...row.metadata[MARKER_KEY], disposed_by: actor, disposed_reason: reason, disposed_at: nowIso ?? null };
+  const marker = { ...row.metadata[MARKER_KEY], disposed_by: actor, disposed_reason: reason, disposed_at: nowIso };
   const { error } = await supabase.from('feedback')
     .update({ metadata: { ...(row.metadata || {}), [MARKER_KEY]: marker } }).eq('id', feedbackId);
   return { disposed: !error };

--- a/scripts/feedback-fingerprint-promoter.mjs
+++ b/scripts/feedback-fingerprint-promoter.mjs
@@ -215,13 +215,21 @@ for (const group of groups.values()) {
  * ambient environment and remains testable without one.
  */
 async function recordWithheld(sb, groups, demand) {
-  const { written } = await writeMarkers(sb, groups, demand, {
+  const { written, failed } = await writeMarkers(sb, groups, demand, {
     runId: process.env.GITHUB_RUN_ID || null,
     nowIso: new Date().toISOString(),
     severityRank,
     threshold: THRESHOLD,
   });
-  console.log(`  [WITHHELD_RECORDED] ${written} source row(s) marked pending across ${groups.length} group(s) — these now survive their 14-day window.`);
+  // THE HEADLINE MUST NOT OVERSTATE WHAT LANDED. The first version printed "these now survive
+  // their 14-day window" unconditionally, including on a run where every write was rejected —
+  // a claim of protection that had not happened, with nothing to contradict it. A total failure
+  // now throws inside writeMarkers; a partial one is reported as partial, here, in the headline.
+  if (failed && failed.length > 0) {
+    console.log(`  [WITHHELD_RECORDED] PARTIAL: ${written} of ${written + failed.length} source row(s) marked across ${groups.length} group(s) — ${failed.length} FAILED and are NOT protected (first: ${failed[0].error})`);
+  } else {
+    console.log(`  [WITHHELD_RECORDED] ${written} source row(s) marked pending across ${groups.length} group(s) — these now survive their 14-day window.`);
+  }
   return written;
 }
 

--- a/scripts/feedback-fingerprint-promoter.mjs
+++ b/scripts/feedback-fingerprint-promoter.mjs
@@ -27,7 +27,11 @@
 import 'dotenv/config';
 import { execFileSync } from 'node:child_process';
 import { createClient } from '@supabase/supabase-js';
-import { groupByFingerprint, shouldPromote } from '../lib/shared/content-fingerprint.cjs';
+import { groupByFingerprint, shouldPromote, severityRank } from '../lib/shared/content-fingerprint.cjs';
+// SD-LEO-INFRA-WITHHELD-PROMOTIONS-GET-001: the durable sink for withheld groups. In lib/, taking
+// supabase as a PARAMETER, for the same reason the gate is — this script builds its own client at
+// module scope and exports nothing, so anything left inline here is testable only by source regex.
+import { writeMarkers, MARKER_KEY } from '../lib/governance/withheld-registry.mjs';
 import { fetchAllPaginated } from '../lib/db/fetch-all-paginated.mjs';
 import { derivePromotedSeverity } from '../lib/feedback/promoted-severity.js';
 // SD-LEO-INFRA-GATE-SIDE-BELT-001: this producer mints quick_fixes unattended on a 6-hourly cron and
@@ -58,7 +62,19 @@ try {
     .select('id, title, description, severity, created_at, metadata')
     .eq('category', 'harness_backlog')
     .is('archived_at', null)
-    .gte('created_at', cutoff)
+    // SD-LEO-INFRA-WITHHELD-PROMOTIONS-GET-001: WAS a bare .gte('created_at', cutoff), which is
+    // the silent-expiry mechanism itself — a group withheld by the demand gate ages out of this
+    // window and becomes invisible to the very run that could finally promote it. A durable record
+    // that the promoter cannot SEE is readable-but-inert, a more expensive version of the defect.
+    //
+    // So: in-window OR carrying a pending marker. Both halves of this were verified live before
+    // being encoded, because a filter that silently matches nothing is precisely the class of bug
+    // this seat spent the day removing:
+    //   - with zero markers written, the widened query returns exactly the same 1264 rows as the
+    //     bare .gte, so the change is a provable no-op until a marker exists;
+    //   - and the second branch genuinely admits out-of-window rows (measured 3291 with a
+    //     predicate guaranteed to match them), so it is not a decorative disjunct.
+    .or(`created_at.gte.${cutoff},metadata->>${MARKER_KEY}.not.is.null`)
     // SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001 (FR-4): this predicate had NO status
     // filter at all, so a row already marked resolved stayed promotion-eligible for its whole
     // 14-day window. Measured live at authoring time: 38 resolved + 1 invalid in-window rows were
@@ -94,8 +110,13 @@ let skippedBelowThreshold = 0;
 // only returns a verdict is one forgotten `if` away from being decorative — and that omission is
 // invisible to a source-text guard test, which is all this script had.
 let suppressedCount = 0;
+// SD-LEO-INFRA-WITHHELD-PROMOTIONS-GET-001: the suppressed GROUPS, not just how many. A count
+// cannot be recorded durably in any useful way — you cannot re-promote an integer — and the
+// groups were already in hand at the point the counter was incremented.
+let suppressedGroups = [];
 async function promoteAll(reportOnly = false) {
   suppressedCount = 0;
+  suppressedGroups = [];
 for (const group of groups.values()) {
   if (!shouldPromote(group, THRESHOLD)) {
     skippedBelowThreshold++;
@@ -114,7 +135,7 @@ for (const group of groups.values()) {
   console.log(`  sample: ${group.sample_body.slice(0, 120)}`);
 
   if (!apply || reportOnly) {
-    if (reportOnly) suppressedCount++;
+    if (reportOnly) { suppressedCount++; suppressedGroups.push(group); }
     console.log(reportOnly ? '  [WITHHELD] would have created a QF-candidate here - suppressed by belt demand.' : '  [DRY RUN] would create QF-candidate here.');
     continue;
   }
@@ -149,9 +170,18 @@ for (const group of groups.values()) {
     const stampedAt = new Date().toISOString();
     for (const id of sourceIds) {
       const row = group.rows.find(r => r.id === id);
+      // SD-LEO-INFRA-WITHHELD-PROMOTIONS-GET-001: this spread is taken from a snapshot read at the
+      // top of the run, so anything written to metadata SINCE that read is clobbered here unless
+      // carried explicitly. A pending marker is exactly such a thing. CONSUME it rather than drop
+      // it: promotion is one of only two recorded ways out of pending, and a marker that simply
+      // vanished on promotion would be the silent exit this SD exists to abolish, relocated.
+      const priorMarker = row?.metadata?.[MARKER_KEY];
+      const consumed = priorMarker
+        ? { [MARKER_KEY]: { ...priorMarker, promoted_qf_id: group.fingerprint, promoted_at: stampedAt } }
+        : {};
       await supabase
         .from('feedback')
-        .update({ metadata: { ...(row?.metadata || {}), promoted_to_qf: true, promoted_at: stampedAt, promoted_fingerprint: group.fingerprint } })
+        .update({ metadata: { ...(row?.metadata || {}), ...consumed, promoted_to_qf: true, promoted_at: stampedAt, promoted_fingerprint: group.fingerprint } })
         .eq('id', id);
     }
     promoted++;
@@ -162,7 +192,12 @@ for (const group of groups.values()) {
   // REPORT-ONLY RETURNS WHAT IT SUPPRESSED, NOT WHAT IT MINTED. Returning `promoted` here made the
   // gate print "suppressed 0" on a run that suppressed 34 — a number that looked measured and looked
   // like good news. In report-only mode nothing is ever promoted, so `promoted` is 0 by construction.
-  return reportOnly ? suppressedCount : promoted;
+  //
+  // SD-LEO-INFRA-WITHHELD-PROMOTIONS-GET-001: report-only now returns the GROUPS. The gate derives
+  // the count from .length — NOT from Number(), which returns NaN for an array and would print
+  // "suppressed 0" again, reintroducing the exact defect the paragraph above records. Both halves
+  // are pinned by tests; suppressedCount is kept in step so the two can never disagree.
+  return reportOnly ? suppressedGroups : promoted;
 }
 
 // DRY-RUN IS DELIBERATELY UNGATED. Without --apply nothing is minted, so there is no belt to
@@ -172,11 +207,34 @@ for (const group of groups.values()) {
 // The consequence of gating on apply is stated rather than discovered: on a dry-run-only day no
 // decision is recorded, so the startup badge reads NEVER RAN. That is the correct trade — a recorded
 // decision for a run that could never have minted would be a measurement of nothing.
+/**
+ * SD-LEO-INFRA-WITHHELD-PROMOTIONS-GET-001: record the suppressed groups durably.
+ *
+ * A thin binding, not logic — it supplies the run context the pure registry needs and nothing
+ * else. GITHUB_RUN_ID is read here rather than inside the registry so the module stays free of
+ * ambient environment and remains testable without one.
+ */
+async function recordWithheld(sb, groups, demand) {
+  const { written } = await writeMarkers(sb, groups, demand, {
+    runId: process.env.GITHUB_RUN_ID || null,
+    nowIso: new Date().toISOString(),
+    severityRank,
+    threshold: THRESHOLD,
+  });
+  console.log(`  [WITHHELD_RECORDED] ${written} source row(s) marked pending across ${groups.length} group(s) — these now survive their 14-day window.`);
+  return written;
+}
+
 let withheldByDemand = false;
 if (!apply) {
   await promoteAll();
 } else {
-  const result = await gatedQfMint(supabase, { engine: FINGERPRINT_PROMOTER_ENGINE, onWithheld: () => promoteAll(true) }, promoteAll);
+  // SD-LEO-INFRA-WITHHELD-PROMOTIONS-GET-001: writeMarkers is passed ONLY here, never on the
+  // dry-run path above. Dry-run is deliberately ungated, so a durable write there would let every
+  // operator preview permanently change what the next real run consumes — an observation that
+  // mutates the thing observed. The opts literal stays brace-flat on purpose: a source-regex guard
+  // matches this call site with a [^}] class that a nested object would break.
+  const result = await gatedQfMint(supabase, { engine: FINGERPRINT_PROMOTER_ENGINE, onWithheld: () => promoteAll(true), writeMarkers: recordWithheld }, promoteAll);
   withheldByDemand = result.withheldByDemand;
 }
 

--- a/scripts/feedback-fingerprint-promoter.mjs
+++ b/scripts/feedback-fingerprint-promoter.mjs
@@ -80,7 +80,19 @@ try {
     // went on admitting its row forever and the candidate set grew monotonically toward the whole
     // table. Found at review. The nested `and(...)` requires the marker to be present AND not yet
     // promoted; the syntax was verified live before being encoded rather than assumed to parse.
-    .or(`created_at.gte.${cutoff},and(metadata->>${MARKER_KEY}.not.is.null,metadata->${MARKER_KEY}->>promoted_qf_id.is.null,metadata->${MARKER_KEY}->>disposed_at.is.null)`)
+    // V-1, found at PLAN_VERIFICATION: this predicate MUST test promoted_at, not only
+    // promoted_qf_id. Two of my own fixes cancelled each other — the query was written while the
+    // inline promotion path still stamped a fingerprint into promoted_qf_id, and a later commit
+    // correctly stopped doing that (an id field must not hold a non-id) without updating the
+    // query. Net effect: isPending() said false while this predicate said true, so a consumed row
+    // was re-admitted forever.
+    //
+    // And the damage was NOT merely a growing candidate set. A re-admitted consumed row makes the
+    // already-promoted check skip the WHOLE group, so any fingerprint once withheld-then-promoted
+    // became permanently unpromotable and its later recurrences were never marked pending at all
+    // — silent expiry, re-created inside the fix for silent expiry. It must stay in lockstep with
+    // isPending(); the two are now pinned to each other by test.
+    .or(`created_at.gte.${cutoff},and(metadata->>${MARKER_KEY}.not.is.null,metadata->${MARKER_KEY}->>promoted_at.is.null,metadata->${MARKER_KEY}->>promoted_qf_id.is.null,metadata->${MARKER_KEY}->>disposed_at.is.null)`)
     // SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001 (FR-4): this predicate had NO status
     // filter at all, so a row already marked resolved stayed promotion-eligible for its whole
     // 14-day window. Measured live at authoring time: 38 resolved + 1 invalid in-window rows were
@@ -232,7 +244,7 @@ for (const group of groups.values()) {
  * ambient environment and remains testable without one.
  */
 async function recordWithheld(sb, groups, demand) {
-  const { written, failed } = await writeMarkers(sb, groups, demand, {
+  const { written, failed, attempted } = await writeMarkers(sb, groups, demand, {
     runId: process.env.GITHUB_RUN_ID || null,
     nowIso: new Date().toISOString(),
     severityRank,
@@ -247,7 +259,13 @@ async function recordWithheld(sb, groups, demand) {
   } else {
     console.log(`  [WITHHELD_RECORDED] ${written} source row(s) marked pending across ${groups.length} group(s) — these now survive their 14-day window.`);
   }
-  return written;
+  // V-2: return the FAILURE DETAIL, not just the count. Returning only `written` erased partial
+  // failures at this boundary — the gate then had nothing to record but a zero, so a run where
+  // half the writes were rejected produced a durable cost row reading markers_failed:0 at
+  // severity 'info', and the partial survived only on stdout: the unqueryable expiring GHA log
+  // that FR-6 exists to replace. `attempted` travels too, so the gate can tell an all-SKIPPED run
+  // (healthy) from an all-FAILED one (not).
+  return { written, failed: failed || [], attempted };
 }
 
 let withheldByDemand = false;

--- a/scripts/feedback-fingerprint-promoter.mjs
+++ b/scripts/feedback-fingerprint-promoter.mjs
@@ -74,7 +74,13 @@ try {
     //     bare .gte, so the change is a provable no-op until a marker exists;
     //   - and the second branch genuinely admits out-of-window rows (measured 3291 with a
     //     predicate guaranteed to match them), so it is not a decorative disjunct.
-    .or(`created_at.gte.${cutoff},metadata->>${MARKER_KEY}.not.is.null`)
+    //
+    // TESTS PENDING-NESS, NOT MERE PRESENCE. The first version admitted any row carrying a marker
+    // at all — and neither exit (promotion or disposition) deletes the key, so a CONSUMED marker
+    // went on admitting its row forever and the candidate set grew monotonically toward the whole
+    // table. Found at review. The nested `and(...)` requires the marker to be present AND not yet
+    // promoted; the syntax was verified live before being encoded rather than assumed to parse.
+    .or(`created_at.gte.${cutoff},and(metadata->>${MARKER_KEY}.not.is.null,metadata->${MARKER_KEY}->>promoted_qf_id.is.null,metadata->${MARKER_KEY}->>disposed_at.is.null)`)
     // SD-LEO-INFRA-SIGNAL-PROMOTION-RESOLUTION-CHECK-001 (FR-4): this predicate had NO status
     // filter at all, so a row already marked resolved stayed promotion-eligible for its whole
     // 14-day window. Measured live at authoring time: 38 resolved + 1 invalid in-window rows were
@@ -176,8 +182,19 @@ for (const group of groups.values()) {
       // it: promotion is one of only two recorded ways out of pending, and a marker that simply
       // vanished on promotion would be the silent exit this SD exists to abolish, relocated.
       const priorMarker = row?.metadata?.[MARKER_KEY];
+      // THE QF ID IS NOT AVAILABLE HERE, AND THE FIELD NO LONGER PRETENDS OTHERWISE. create-quick-fix.js
+      // runs with stdio:'inherit' (deliberately — its output is streamed), so the minted id is never
+      // captured by this process. The first version stored group.fingerprint under promoted_qf_id,
+      // which made two writers of one field disagree: consumeMarker REFUSES a falsy id precisely
+      // because "consumed with no id" is a silent exit, while this path quietly satisfied the same
+      // field with something that is not an id at all. A field whose name is a claim the value does
+      // not support is the defect class this SD is about, in miniature.
+      //
+      // So: record what is actually known — that it was promoted, when, and by which fingerprint —
+      // and leave promoted_qf_id null. isPending treats promoted_at as a terminal stamp, so the
+      // marker still exits pending state correctly; it simply does not assert an id nobody captured.
       const consumed = priorMarker
-        ? { [MARKER_KEY]: { ...priorMarker, promoted_qf_id: group.fingerprint, promoted_at: stampedAt } }
+        ? { [MARKER_KEY]: { ...priorMarker, promoted_at: stampedAt, promoted_fingerprint: group.fingerprint } }
         : {};
       await supabase
         .from('feedback')

--- a/tests/unit/governance/qf-mint-gate.test.js
+++ b/tests/unit/governance/qf-mint-gate.test.js
@@ -206,12 +206,43 @@ describe('SEC-GSB-2 follow-up — report-only returns what it SUPPRESSED, not wh
     expect(logged.join('\n')).toMatch(/suppressed 34 promotable group/);
   });
 
-  it('both minters return the suppressed counter in report-only mode', () => {
+  // SD-LEO-INFRA-WITHHELD-PROMOTIONS-GET-001 SPLIT THIS LOOP RATHER THAN RELAXING IT.
+  //
+  // It used to iterate BOTH promoters and pin the literal `return reportOnly ? suppressedCount :
+  // promoted;`. The fingerprint promoter now returns the GROUPS so they can be recorded durably,
+  // which breaks that literal — but widening the regex to accommodate both would have retired the
+  // pin for the RETRO promoter too. That pin exists because a real production run printed
+  // "suppressed 0" while suppressing 34. A weakened pin at the site of a known live defect is
+  // worse than no pin, because it still reads as coverage.
+  it('the retro promoter still returns the suppressed COUNTER in report-only mode', () => {
     const read = (p) => require('node:fs').readFileSync(require.resolve(p), 'utf8');
-    for (const p of ['../../../scripts/feedback-fingerprint-promoter.mjs', '../../../scripts/promote-retro-action-items.mjs']) {
-      const s = read(p);
-      expect(s).toMatch(/return reportOnly \? suppressedCount : promoted;/);
-      expect(s).toMatch(/if \(reportOnly\) suppressedCount\+\+;/);
-    }
+    const s = read('../../../scripts/promote-retro-action-items.mjs');
+    expect(s).toMatch(/return reportOnly \? suppressedCount : promoted;/);
+    expect(s).toMatch(/if \(reportOnly\) suppressedCount\+\+;/);
+  });
+
+  it('the fingerprint promoter returns the suppressed GROUPS, and the gate counts them by length', async () => {
+    // Strictly stronger than the source regex it replaces: this exercises the actual path from
+    // callback return -> gate -> reported count -> the logged headline, rather than asserting that
+    // a particular line of text exists. The count is what the previous defect got wrong.
+    const logged = [];
+    const groups = [{ fingerprint: 'a', rows: [{ id: '1' }] }, { fingerprint: 'b', rows: [{ id: '2' }] }];
+    const r = await gatedQfMint({}, {
+      engine: 'e', gauge: async () => 0,
+      measure: async () => decision(DEMAND_DECISION.WITHHELD),
+      record: async () => {}, log: (m) => logged.push(m),
+      onWithheld: async () => groups,
+    }, async () => 0);
+    expect(r.suppressed).toBe(2);
+    expect(logged.join('\n')).toMatch(/suppressed 2 promotable group/);
+  });
+
+  it('the fingerprint promoter still increments the counter alongside collecting the groups', () => {
+    // Kept so the two can never silently disagree — a length and a counter that drift apart would
+    // reproduce the original "the number is wrong" defect in a new place.
+    const read = (p) => require('node:fs').readFileSync(require.resolve(p), 'utf8');
+    const s = read('../../../scripts/feedback-fingerprint-promoter.mjs');
+    expect(s).toMatch(/if \(reportOnly\) \{ suppressedCount\+\+; suppressedGroups\.push\(group\); \}/);
+    expect(s).toMatch(/return reportOnly \? suppressedGroups : promoted;/);
   });
 });

--- a/tests/unit/governance/qf-mint-gate.test.js
+++ b/tests/unit/governance/qf-mint-gate.test.js
@@ -237,6 +237,25 @@ describe('SEC-GSB-2 follow-up — report-only returns what it SUPPRESSED, not wh
     expect(logged.join('\n')).toMatch(/suppressed 2 promotable group/);
   });
 
+  // H1, found at EXEC-TO-PLAN review: deleting `writeMarkers: recordWithheld` from the promoter's
+  // opts literal killed ZERO tests across the entire 35k-test unit project. The only production
+  // call site of the durable write could be removed silently, leaving all of the exposure and none
+  // of the benefit — the same unpinned-call-site class this file already records above.
+  //
+  // Deliberately asserted for the FINGERPRINT promoter ONLY. The retro promoter must NOT gain this
+  // key: its scalar return is what makes the injected default no-op, and a test elsewhere depends
+  // on that asymmetry to prove the out-of-scope engine writes nothing.
+  it('the fingerprint promoter WIRES the durable recorder at its call site', () => {
+    const read = (p) => require('node:fs').readFileSync(require.resolve(p), 'utf8');
+    expect(read('../../../scripts/feedback-fingerprint-promoter.mjs'))
+      .toMatch(/writeMarkers:\s*recordWithheld/);
+  });
+
+  it('the retro promoter does NOT wire it — the out-of-scope engine records nothing', () => {
+    const read = (p) => require('node:fs').readFileSync(require.resolve(p), 'utf8');
+    expect(read('../../../scripts/promote-retro-action-items.mjs')).not.toMatch(/writeMarkers:/);
+  });
+
   it('the fingerprint promoter still increments the counter alongside collecting the groups', () => {
     // Kept so the two can never silently disagree — a length and a counter that drift apart would
     // reproduce the original "the number is wrong" defect in a new place.

--- a/tests/unit/governance/withheld-registry.test.js
+++ b/tests/unit/governance/withheld-registry.test.js
@@ -258,6 +258,24 @@ describe('FR-5 — exit only by a named, recorded event', () => {
     expect(isPending({ ...m, promoted_qf_id: 'QF-1' })).toBe(false);
   });
 
+  // The promoter's inline path cannot capture the minted id (create-quick-fix.js runs with
+  // stdio:'inherit'), so promoted_at is the authoritative stamp. Keying pending-ness on the id
+  // alone would leave every inline-promoted marker permanently "pending" — a record insisting
+  // something is outstanding after it has been dealt with.
+  it('promoted_at ALONE ends pending state, with no id present', () => {
+    const m = buildMarker(group(), demand(), { nowIso: NOW, severityRank, threshold: 3 });
+    expect(isPending({ ...m, promoted_at: NOW })).toBe(false);
+    expect(m.promoted_qf_id).toBeNull();
+  });
+
+  it('the marker carries promoted_at and promoted_fingerprint as first-class null-while-pending fields', () => {
+    const m = buildMarker(group(), demand(), { nowIso: NOW, severityRank, threshold: 3 });
+    // Present-and-null, so a reader never has to distinguish "absent key" from "not yet promoted".
+    expect(m).toHaveProperty('promoted_at', null);
+    expect(m).toHaveProperty('promoted_fingerprint', null);
+    expect(isPending(m)).toBe(true);
+  });
+
   it('a dispositioned marker is no longer pending', () => {
     const m = buildMarker(group(), demand(), { nowIso: NOW, severityRank, threshold: 3 });
     expect(isPending({ ...m, disposed_at: NOW, disposed_by: 'x', disposed_reason: 'y' })).toBe(false);
@@ -395,6 +413,16 @@ describe('writeMarkers — the real function, not an injected stub', () => {
     const res = await writeMarkers(db, [group()], demand(), ctx);
     expect(res.written).toBe(0);
     expect(db._store.get('fb-1').metadata[MARKER_KEY].promoted_qf_id).toBe('QF-9');
+  });
+
+  it('does NOT resurrect one consumed by the inline path, which stamps promoted_at and no id', async () => {
+    // The shape the promoter actually writes. If resurrection keyed only on promoted_qf_id, every
+    // inline-promoted marker would be re-marked pending on the next withheld run.
+    const inlineConsumed = { ...buildMarker(group(), demand(), ctx), promoted_at: NOW, promoted_fingerprint: 'abc123' };
+    const db = fakeDb([{ id: 'fb-1', metadata: { [MARKER_KEY]: inlineConsumed } }]);
+    const res = await writeMarkers(db, [group()], demand(), ctx);
+    expect(res.written).toBe(0);
+    expect(db._store.get('fb-1').metadata[MARKER_KEY].promoted_at).toBe(NOW);
   });
 
   // THE FALSE-ZERO. The first version returned {written: 0} when every write was rejected, and the

--- a/tests/unit/governance/withheld-registry.test.js
+++ b/tests/unit/governance/withheld-registry.test.js
@@ -1,0 +1,289 @@
+// SD-LEO-INFRA-WITHHELD-PROMOTIONS-GET-001.
+//
+// The defect: a withheld promotable group existed durably nowhere — stdout in one GHA run plus an
+// integer the caller discarded — while its source rows aged out of a 14-day window.
+//
+// THE FAILURE MODE OF A *RECORDING* FIX IS A FIX THAT RECORDS ON EVERY RUN. That looks identical
+// to a working one from outside while meaning nothing, which is the same class as the defect. So
+// the negative controls below were written BEFORE the write path and are the primary assertions;
+// the positive case is the easy half.
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import { gatedQfMint } from '../../../lib/governance/qf-mint-gate.mjs';
+import {
+  buildMarker,
+  deriveAdmissionPath,
+  isPending,
+  disposeMarker,
+  consumeMarker,
+  MARKER_KEY,
+  ADMISSION_SEVERITY_BYPASS,
+  ADMISSION_COUNT_THRESHOLD,
+} from '../../../lib/governance/withheld-registry.mjs';
+
+const require_ = createRequire(import.meta.url);
+const { severityRank, fingerprint } = require_('../../../lib/shared/content-fingerprint.cjs');
+
+const NOW = '2026-08-03T22:00:00.000Z';
+const group = (over = {}) => ({
+  fingerprint: 'abc123',
+  rows: [{ id: 'fb-1' }],
+  max_severity: 'critical',
+  groupKeys: new Set(['fb-1']),
+  ...over,
+});
+const demand = (over = {}) => ({ engine: 'e', gauge_value: 151, floor: 3, decision: 'withheld', ...over });
+
+describe('FR-8 — an ALLOWED run writes zero markers', () => {
+  // Forced via opts.gauge, NOT opts.measure. A measure stub asserts "handed the word sourced, I
+  // write nothing"; a gauge stub asserts "when the belt is genuinely below the floor, I write
+  // nothing". Only the second is the requirement — the real decideDemand runs in between.
+  it('writes nothing, and the zero carries positive controls so it can actually fail', async () => {
+    const writes = [];
+    const r = await gatedQfMint({}, {
+      engine: 'test-engine',
+      gauge: async () => 0,                     // real decideDemand: 0 <= floor 3 -> sourced
+      record: async () => {},
+      log: () => {},
+      onWithheld: async () => { throw new Error('withhold branch must not run on an allowed run'); },
+      writeMarkers: async (...a) => { writes.push(a); },
+    }, async () => 7);
+
+    // POSITIVE CONTROLS. writes.length === 0 alone is equally satisfied by a run that threw, a run
+    // where mint never fired, or an arm that never executed. A zero that cannot distinguish "ran
+    // and wrote nothing" from "never ran" is precisely the cannot-fail control this SD is about.
+    expect(r.demand.decision).toBe('sourced');
+    expect(r.minted).toBe(7);
+    expect(r.withheldByDemand).toBe(false);
+    expect(writes).toEqual([]);
+  });
+
+  it('the OTHER lever moves too — raising the floor above the gauge also allows', async () => {
+    // A suite that only ever moves one operand is satisfied by an implementation that reads only
+    // that operand. Both sides of the comparison get exercised.
+    const writes = [];
+    const r = await gatedQfMint({}, {
+      engine: 'test-engine',
+      env: { BELT_DEMAND_FLOOR: '999' },
+      gauge: async () => 151,
+      record: async () => {},
+      log: () => {},
+      writeMarkers: async (...a) => { writes.push(a); },
+    }, async () => 2);
+    expect(r.demand.decision).toBe('sourced');
+    expect(r.minted).toBe(2);
+    expect(writes).toEqual([]);
+  });
+});
+
+describe('FR-8 — a WITHHELD run does write, so the negative above is not vacuous', () => {
+  it('calls the writer exactly once with the groups', async () => {
+    const writes = [];
+    const r = await gatedQfMint({}, {
+      engine: 'test-engine',
+      gauge: async () => 151,
+      record: async () => {},
+      log: () => {},
+      onWithheld: async () => [group(), group({ fingerprint: 'def456', rows: [{ id: 'fb-2' }] })],
+      writeMarkers: async (sb, groups, d) => { writes.push({ groups, d }); },
+    }, async () => 0);
+
+    expect(r.withheldByDemand).toBe(true);
+    expect(writes).toHaveLength(1);
+    expect(writes[0].groups).toHaveLength(2);
+    expect(writes[0].d.decision).toBe('withheld');
+  });
+
+  it('does NOT call the writer when onWithheld returns a scalar — the out-of-scope engine writes nothing', async () => {
+    // This is what keeps scripts/promote-retro-action-items.mjs correct with ZERO edits to it,
+    // and turns "that engine writes no markers" from an inspection into an assertion.
+    const writes = [];
+    const r = await gatedQfMint({}, {
+      engine: 'retro-engine',
+      gauge: async () => 151,
+      record: async () => {},
+      log: () => {},
+      onWithheld: async () => 34,
+      writeMarkers: async (...a) => { writes.push(a); },
+    }, async () => 0);
+    expect(r.suppressed).toBe(34);
+    expect(writes).toEqual([]);
+  });
+});
+
+describe('FR-1 — the count comes from .length, never from Number()', () => {
+  // MEASURED ON HEAD BEFORE THE FIX: an array return reported suppressed:0, because
+  // Number([{},{}]) is NaN and NaN||0 is 0. That is the defect fixed in 43c488c62ca resurrected
+  // by this very widening — a number that looks measured and looks like good news.
+  it('reports the array length for an array return', async () => {
+    const r = await gatedQfMint({}, {
+      engine: 'e', gauge: async () => 151, record: async () => {}, log: () => {},
+      onWithheld: async () => [group(), group(), group()],
+    }, async () => 0);
+    expect(r.suppressed).toBe(3);
+  });
+
+  it('still reports the number for a scalar return (backward compatible)', async () => {
+    const r = await gatedQfMint({}, {
+      engine: 'e', gauge: async () => 151, record: async () => {}, log: () => {},
+      onWithheld: async () => 34,
+    }, async () => 0);
+    expect(r.suppressed).toBe(34);
+  });
+
+  it('a throwing onWithheld yields null, not a crash and not a false zero', async () => {
+    const r = await gatedQfMint({}, {
+      engine: 'e', gauge: async () => 151, record: async () => {}, log: () => {},
+      onWithheld: async () => { throw new Error('boom'); },
+    }, async () => 0);
+    expect(r.suppressed).toBeNull();
+    expect(r.withheldByDemand).toBe(true);
+  });
+
+  it('a failed durable write warns but does not convert a correct withhold into a crash', async () => {
+    const logs = [];
+    const r = await gatedQfMint({}, {
+      engine: 'e', gauge: async () => 151, record: async () => {}, log: (m) => logs.push(m),
+      onWithheld: async () => [group()],
+      writeMarkers: async () => { throw new Error('db down'); },
+    }, async () => 0);
+    expect(r.withheldByDemand).toBe(true);
+    expect(logs.join('\n')).toContain('durable withheld-record write failed');
+  });
+});
+
+describe('FR-9 — the UNMEASURABLE arm is a third outcome, not a withhold in disguise', () => {
+  it('takes the withhold branch but carries gauge_value null, never a coerced 0', async () => {
+    const r = await gatedQfMint({}, {
+      engine: 'e',
+      gauge: async () => { throw new Error('gauge unavailable'); },
+      record: async () => {}, log: () => {},
+      onWithheld: async () => [group()],
+    }, async () => 0);
+    expect(r.withheldByDemand).toBe(true);
+    expect(r.demand.decision).toBe('unmeasurable');
+    // A null that becomes 0 is indistinguishable from a real below-floor reading.
+    expect(r.demand.gauge_value).toBeNull();
+  });
+
+  it('buildMarker preserves that null rather than defaulting it', () => {
+    const m = buildMarker(group(), demand({ gauge_value: null, decision: 'unmeasurable' }), {
+      nowIso: NOW, severityRank, threshold: 3,
+    });
+    expect(m.gauge_value).toBeNull();
+    expect(m.decision).toBe('unmeasurable');
+  });
+});
+
+describe('admission_path — falsifiable, not decorative', () => {
+  it('a critical singleton reports severity_bypass', () => {
+    expect(deriveAdmissionPath(group(), severityRank, 3)).toBe(ADMISSION_SEVERITY_BYPASS);
+  });
+
+  it('a non-critical group over the key threshold reports count_threshold', () => {
+    const g = group({ max_severity: 'high', groupKeys: new Set(['a', 'b', 'c']) });
+    expect(deriveAdmissionPath(g, severityRank, 3)).toBe(ADMISSION_COUNT_THRESHOLD);
+  });
+
+  // THE DISCRIMINATOR. A group that satisfies BOTH must report the branch shouldPromote actually
+  // took — severity returns first. Without this case the field is unfalsifiable.
+  it('a group that is BOTH critical AND over the threshold reports severity_bypass', () => {
+    const g = group({ max_severity: 'critical', groupKeys: new Set(['a', 'b', 'c', 'd']) });
+    expect(deriveAdmissionPath(g, severityRank, 3)).toBe(ADMISSION_SEVERITY_BYPASS);
+  });
+});
+
+describe('FR-3 — registry semantics: one mutable marker, run provenance as counters', () => {
+  it('a first observation starts the counters', () => {
+    const m = buildMarker(group(), demand(), { nowIso: NOW, runId: 'run-1', severityRank, threshold: 3 });
+    expect(m.withheld_run_count).toBe(1);
+    expect(m.first_withheld_at).toBe(NOW);
+    expect(m.first_withheld_run).toBe('run-1');
+  });
+
+  it('a repeat run advances last_* and the count while first_* does NOT move', () => {
+    const first = buildMarker(group(), demand(), { nowIso: NOW, runId: 'run-1', severityRank, threshold: 3 });
+    const later = '2026-08-04T04:00:00.000Z';
+    const second = buildMarker(group(), demand(), { nowIso: later, runId: 'run-2', severityRank, threshold: 3, prior: first });
+    expect(second.withheld_run_count).toBe(2);
+    expect(second.first_withheld_at).toBe(NOW);      // unmoved — this is the registry property
+    expect(second.last_withheld_at).toBe(later);
+    expect(second.first_withheld_run).toBe('run-1');
+    expect(second.last_withheld_run).toBe('run-2');
+  });
+
+  it('four consecutive runs produce ONE marker with count 4, not four records', () => {
+    let m = null;
+    for (let i = 1; i <= 4; i++) {
+      m = buildMarker(group(), demand(), { nowIso: NOW, runId: `run-${i}`, severityRank, threshold: 3, prior: m });
+    }
+    expect(m.withheld_run_count).toBe(4);
+    expect(m.first_withheld_run).toBe('run-1');
+  });
+
+  it('the fingerprint MOVES when a title is edited — the precondition that makes the key choice matter', () => {
+    // Asserted rather than assumed: normalize() truncates at 200 chars and strips trailing
+    // punctuation and collapses whitespace, so a naive edit leaves the fingerprint unchanged and
+    // a test built on it would pass while proving nothing. This uses an interior word change.
+    const before = fingerprint('harness_backlog', 'the promoter drops withheld groups\nbody');
+    const after = fingerprint('harness_backlog', 'the promoter discards withheld groups\nbody');
+    expect(after).not.toBe(before);
+
+    // The marker follows the row id, so a moved fingerprint updates the same record rather than
+    // orphaning it. member_feedback_ids is the identity; fingerprint is carried, not keyed on.
+    const m1 = buildMarker(group({ fingerprint: before }), demand(), { nowIso: NOW, severityRank, threshold: 3 });
+    const m2 = buildMarker(group({ fingerprint: after }), demand(), { nowIso: NOW, severityRank, threshold: 3, prior: m1 });
+    expect(m2.member_feedback_ids).toEqual(['fb-1']);
+    expect(m2.fingerprint).toBe(after);
+    expect(m2.withheld_run_count).toBe(2);
+  });
+
+  it('a group that GROWS updates the member list rather than forking a record', () => {
+    const m1 = buildMarker(group(), demand(), { nowIso: NOW, severityRank, threshold: 3 });
+    const grown = group({ rows: [{ id: 'fb-1' }, { id: 'fb-2' }] });
+    const m2 = buildMarker(grown, demand(), { nowIso: NOW, severityRank, threshold: 3, prior: m1 });
+    expect(m2.member_feedback_ids).toEqual(['fb-1', 'fb-2']);
+    expect(m2.withheld_run_count).toBe(2);
+  });
+});
+
+describe('FR-5 — exit only by a named, recorded event', () => {
+  it('a fresh marker is pending', () => {
+    expect(isPending(buildMarker(group(), demand(), { nowIso: NOW, severityRank, threshold: 3 }))).toBe(true);
+  });
+
+  it('a promoted marker is no longer pending', () => {
+    const m = buildMarker(group(), demand(), { nowIso: NOW, severityRank, threshold: 3 });
+    expect(isPending({ ...m, promoted_qf_id: 'QF-1' })).toBe(false);
+  });
+
+  it('a dispositioned marker is no longer pending', () => {
+    const m = buildMarker(group(), demand(), { nowIso: NOW, severityRank, threshold: 3 });
+    expect(isPending({ ...m, disposed_at: NOW, disposed_by: 'x', disposed_reason: 'y' })).toBe(false);
+  });
+
+  it('consumeMarker REFUSES without a minted id — a consumption with no id is a silent exit', async () => {
+    await expect(consumeMarker({}, 'fb-1', null)).rejects.toThrow(/minted QF id is required/);
+  });
+
+  it('disposeMarker REFUSES without BOTH an actor and a reason', async () => {
+    await expect(disposeMarker({}, 'fb-1', { actor: 'me' })).rejects.toThrow(/actor and reason/);
+    await expect(disposeMarker({}, 'fb-1', { reason: 'stale' })).rejects.toThrow(/actor and reason/);
+  });
+
+  it('buildMarker refuses to invent a clock', () => {
+    expect(() => buildMarker(group(), demand(), { severityRank, threshold: 3 })).toThrow(/nowIso is required/);
+  });
+});
+
+describe('the marker survives a full-object metadata spread (FR-5 live hazard)', () => {
+  it('is preserved when unrelated metadata is rewritten around it', () => {
+    // The promoter's success path rewrites metadata as a spread from an earlier snapshot. The
+    // marker must be carried through, not clobbered. This pins the shape that makes that possible.
+    const marker = buildMarker(group(), demand(), { nowIso: NOW, severityRank, threshold: 3 });
+    const existing = { [MARKER_KEY]: marker, unrelated: 'keep me' };
+    const rewritten = { ...existing, promoted_to_qf: true };
+    expect(rewritten[MARKER_KEY]).toEqual(marker);
+    expect(rewritten.unrelated).toBe('keep me');
+  });
+});

--- a/tests/unit/governance/withheld-registry.test.js
+++ b/tests/unit/governance/withheld-registry.test.js
@@ -277,6 +277,70 @@ describe('FR-5 — exit only by a named, recorded event', () => {
   });
 });
 
+describe('FR-6 — what the withhold COST is recorded on the DB side', () => {
+  // The pre-existing decision row cannot carry this: it is written inside openQfMintGate, BEFORE
+  // `allowed` is known and long before anything has enumerated the suppressed set. So a DB reader
+  // could see THAT a withhold happened and never WHAT it cost, and had to open a per-run GHA log
+  // — unqueryable, and it expires. Hence a second event.
+  it('a withheld run emits the cost event with the suppressed count and marker reference', async () => {
+    const costs = [];
+    await gatedQfMint({}, {
+      engine: 'e', gauge: async () => 151, record: async () => {}, log: () => {},
+      onWithheld: async () => [group(), group({ fingerprint: 'b', rows: [{ id: 'fb-2' }] })],
+      writeMarkers: async () => 2,
+      recordCost: async (_sb, d, c) => { costs.push({ d, c }); return true; },
+    }, async () => 0);
+
+    expect(costs).toHaveLength(1);
+    expect(costs[0].c.suppressed_groups).toBe(2);
+    expect(costs[0].c.markers_written).toBe(2);
+    expect(costs[0].c.markers_failed).toBe(0);
+    expect(costs[0].c.marker_key).toBe(MARKER_KEY);
+    expect(costs[0].d.decision).toBe('withheld');
+  });
+
+  // The negative twin. Without it, "emits the cost event" is equally satisfied by emitting always.
+  it('an ALLOWED run emits NO cost event', async () => {
+    const costs = [];
+    const r = await gatedQfMint({}, {
+      engine: 'e', gauge: async () => 0, record: async () => {}, log: () => {},
+      onWithheld: async () => { throw new Error('must not run'); },
+      writeMarkers: async () => 5,
+      recordCost: async (...a) => { costs.push(a); return true; },
+    }, async () => 3);
+    expect(r.demand.decision).toBe('sourced');   // positive control: the arm really ran
+    expect(r.minted).toBe(3);
+    expect(costs).toEqual([]);
+  });
+
+  it('a withheld run with NO suppressed groups emits no cost event', async () => {
+    const costs = [];
+    await gatedQfMint({}, {
+      engine: 'e', gauge: async () => 151, record: async () => {}, log: () => {},
+      onWithheld: async () => [],
+      writeMarkers: async () => 0,
+      recordCost: async (...a) => { costs.push(a); return true; },
+    }, async () => 0);
+    expect(costs).toEqual([]);
+  });
+
+  it('a FAILED durable write is recorded as failed, not as a quiet success', async () => {
+    // The cost event must distinguish "recorded 34" from "recorded nothing". Logging both at the
+    // same severity would make the failure of this SD's own mechanism invisible in the audit trail.
+    const costs = [];
+    await gatedQfMint({}, {
+      engine: 'e', gauge: async () => 151, record: async () => {}, log: () => {},
+      onWithheld: async () => [group()],
+      writeMarkers: async () => { throw new Error('db down'); },
+      recordCost: async (_sb, _d, c) => { costs.push(c); return true; },
+    }, async () => 0);
+    expect(costs).toHaveLength(1);
+    expect(costs[0].markers_written).toBe(0);
+    expect(costs[0].markers_failed).toBe(1);
+    expect(costs[0].error).toContain('db down');
+  });
+});
+
 describe('writeMarkers — the real function, not an injected stub', () => {
   // Found at review: every writeMarkers reference in the first version of this suite was a STUB.
   // The read-modify-write loop, the non-resurrection guard and the metadata carry-through had

--- a/tests/unit/governance/withheld-registry.test.js
+++ b/tests/unit/governance/withheld-registry.test.js
@@ -10,6 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 import { gatedQfMint } from '../../../lib/governance/qf-mint-gate.mjs';
+import { recordWithheldCost } from '../../../lib/governance/demand-gate-emit.js';
 import {
   buildMarker,
   deriveAdmissionPath,
@@ -290,6 +291,15 @@ describe('FR-5 — exit only by a named, recorded event', () => {
     await expect(disposeMarker({}, 'fb-1', { reason: 'stale' })).rejects.toThrow(/actor and reason/);
   });
 
+  // V-3: without nowIso this returned {disposed:true} while leaving disposed_at null — and
+  // isPending keys on disposed_at, so the marker stayed PENDING while the caller was told it had
+  // been disposed. A silent non-exit wearing a verb, inside the function whose own error message
+  // rails against exactly that. The guard was one argument short of its own rule.
+  it('disposeMarker REFUSES without nowIso — disposed_at is what actually ends pending state', async () => {
+    await expect(disposeMarker({}, 'fb-1', { actor: 'me', reason: 'stale' }))
+      .rejects.toThrow(/nowIso is required/);
+  });
+
   it('buildMarker refuses to invent a clock', () => {
     expect(() => buildMarker(group(), demand(), { severityRank, threshold: 3 })).toThrow(/nowIso is required/);
   });
@@ -312,9 +322,38 @@ describe('FR-6 — what the withhold COST is recorded on the DB side', () => {
     expect(costs).toHaveLength(1);
     expect(costs[0].c.suppressed_groups).toBe(2);
     expect(costs[0].c.markers_written).toBe(2);
-    expect(costs[0].c.markers_failed).toBe(0);
     expect(costs[0].c.marker_key).toBe(MARKER_KEY);
     expect(costs[0].d.decision).toBe('withheld');
+  });
+
+  // THIS TEST REPLACES ONE THAT PINNED THE DEFECT. The earlier version asserted markers_failed
+  // === 0 against a stub that could not fail — so it was asserting the hardcoded zero the gate
+  // used to emit, i.e. pinning the bug as though it were the requirement. A test whose subject
+  // cannot produce the other outcome is not measuring anything.
+  it('a PARTIAL failure reaches the cost record — it is not erased at the gate boundary', async () => {
+    const costs = [];
+    await gatedQfMint({}, {
+      engine: 'e', gauge: async () => 151, record: async () => {}, log: () => {},
+      onWithheld: async () => [group(), group({ fingerprint: 'b', rows: [{ id: 'fb-2' }] })],
+      // The detail shape the real recordWithheld now returns.
+      writeMarkers: async () => ({ written: 1, failed: [{ id: 'fb-2', stage: 'write', error: 'denied' }], attempted: 2 }),
+      recordCost: async (_sb, _d, c) => { costs.push(c); return true; },
+    }, async () => 0);
+    expect(costs[0].markers_written).toBe(1);
+    expect(costs[0].markers_failed).toBe(1);   // was hardcoded 0 before the fix
+    expect(costs[0].markers_attempted).toBe(2);
+  });
+
+  it('a bare-number writeMarkers return still works (backward compatible)', async () => {
+    const costs = [];
+    await gatedQfMint({}, {
+      engine: 'e', gauge: async () => 151, record: async () => {}, log: () => {},
+      onWithheld: async () => [group()],
+      writeMarkers: async () => 1,
+      recordCost: async (_sb, _d, c) => { costs.push(c); return true; },
+    }, async () => 0);
+    expect(costs[0].markers_written).toBe(1);
+    expect(costs[0].markers_failed).toBe(0);
   });
 
   // The negative twin. Without it, "emits the cost event" is equally satisfied by emitting always.
@@ -356,6 +395,94 @@ describe('FR-6 — what the withhold COST is recorded on the DB side', () => {
     expect(costs[0].markers_written).toBe(0);
     expect(costs[0].markers_failed).toBe(1);
     expect(costs[0].error).toContain('db down');
+  });
+});
+
+describe('the cost event severity discriminates fault from health', () => {
+  // Mutation M3 (hardcoding severity to 'info') previously killed ZERO tests. recordWithheldCost
+  // is now exercised directly against a stub client so the ternary actually evaluates.
+  const stub = () => {
+    const inserted = [];
+    return {
+      inserted,
+      from() { return this; },
+      insert(row) { inserted.push(row); return { select: () => Promise.resolve({ data: [{ id: 'x' }], error: null }) }; },
+    };
+  };
+  const d = { engine: 'e', decision: 'withheld', gauge_value: 151, floor: 3 };
+
+  it('a clean run logs info', async () => {
+    const sb = stub();
+    await recordWithheldCost(sb, d, { suppressed_groups: 4, markers_written: 4, markers_failed: 0, markers_attempted: 4 });
+    expect(sb.inserted[0].severity).toBe('info');
+  });
+
+  it('ANY failure logs warning', async () => {
+    const sb = stub();
+    await recordWithheldCost(sb, d, { suppressed_groups: 4, markers_written: 3, markers_failed: 1, markers_attempted: 4 });
+    expect(sb.inserted[0].severity).toBe('warning');
+  });
+
+  it('attempted-but-none-written logs warning — the mechanism failing is not routine', async () => {
+    const sb = stub();
+    await recordWithheldCost(sb, d, { suppressed_groups: 4, markers_written: 0, markers_failed: 4, markers_attempted: 4 });
+    expect(sb.inserted[0].severity).toBe('warning');
+  });
+
+  // The discriminator. An all-SKIPPED run legitimately writes nothing, and warning on it would
+  // fire every six hours on a healthy system until nobody reads the level at all.
+  it('an ALL-SKIPPED run (nothing attempted) logs info, not warning', async () => {
+    const sb = stub();
+    await recordWithheldCost(sb, d, { suppressed_groups: 4, markers_written: 0, markers_failed: 0, markers_attempted: 0 });
+    expect(sb.inserted[0].severity).toBe('info');
+  });
+
+  it('carries the decision alongside the cost, so a reader needs only this row', async () => {
+    const sb = stub();
+    await recordWithheldCost(sb, d, { suppressed_groups: 4, markers_written: 4, markers_failed: 0, markers_attempted: 4 });
+    expect(sb.inserted[0].metadata.engine).toBe('e');
+    expect(sb.inserted[0].metadata.gauge_value).toBe(151);
+    expect(sb.inserted[0].metadata.suppressed_groups).toBe(4);
+  });
+});
+
+describe('the promoter source stays in lockstep with isPending (V-1)', () => {
+  const read = () => require_('node:fs').readFileSync(
+    require_.resolve('../../../scripts/feedback-fingerprint-promoter.mjs'), 'utf8');
+
+  // V-1: two of my own fixes cancelled each other. The candidate query keyed pending-ness on
+  // promoted_qf_id while a later commit correctly stopped writing that field, so isPending() said
+  // false and the query said true — and a re-admitted consumed row then made the already-promoted
+  // check skip the WHOLE group, making any once-withheld fingerprint permanently unpromotable.
+  // Mutation M2 (flipping this predicate either way) killed zero tests.
+  it('the candidate query tests EVERY field isPending tests', () => {
+    // The source interpolates the constant rather than hard-coding the key, so the pin matches
+    // `${MARKER_KEY}->>field.is.null` — the shape actually on disk. (My first version of this
+    // assertion looked for the expanded literal and failed, correctly: the test was wrong, not
+    // the code. Worth keeping the note, because a pin that matches nothing is the same class of
+    // useless guard this SD is about.)
+    const src = read();
+    for (const field of ['promoted_at', 'promoted_qf_id', 'disposed_at']) {
+      expect(src, `candidate query must test ${field} — isPending does`)
+        .toMatch(new RegExp(`\\$\\{MARKER_KEY\\}->>${field}\\.is\\.null`));
+    }
+  });
+
+  it('that pin is not vacuous — MARKER_KEY really is the key isPending reads', () => {
+    // Guards the indirection: if MARKER_KEY ever stopped naming the field the marker lives under,
+    // the regex above would still pass while testing nothing.
+    const m = buildMarker(group(), demand(), { nowIso: NOW, severityRank, threshold: 3 });
+    expect(Object.keys({ [MARKER_KEY]: m })).toEqual(['withheld_pending']);
+    expect(m).toHaveProperty('promoted_at');
+    expect(m).toHaveProperty('promoted_qf_id');
+    expect(m).toHaveProperty('disposed_at');
+  });
+
+  // Mutation M1 (deleting the consumption spread) killed zero tests.
+  it('the promotion path CONSUMES the marker rather than clobbering it', () => {
+    const src = read();
+    expect(src).toMatch(/promoted_at: stampedAt, promoted_fingerprint: group\.fingerprint/);
+    expect(src).toMatch(/\.\.\.consumed/);
   });
 });
 

--- a/tests/unit/governance/withheld-registry.test.js
+++ b/tests/unit/governance/withheld-registry.test.js
@@ -16,6 +16,7 @@ import {
   isPending,
   disposeMarker,
   consumeMarker,
+  writeMarkers,
   MARKER_KEY,
   ADMISSION_SEVERITY_BYPASS,
   ADMISSION_COUNT_THRESHOLD,
@@ -273,6 +274,93 @@ describe('FR-5 — exit only by a named, recorded event', () => {
 
   it('buildMarker refuses to invent a clock', () => {
     expect(() => buildMarker(group(), demand(), { severityRank, threshold: 3 })).toThrow(/nowIso is required/);
+  });
+});
+
+describe('writeMarkers — the real function, not an injected stub', () => {
+  // Found at review: every writeMarkers reference in the first version of this suite was a STUB.
+  // The read-modify-write loop, the non-resurrection guard and the metadata carry-through had
+  // never executed under test, so the mechanism that actually implements idempotency was unpinned.
+  const fakeDb = (rows, { failWrites = false, failReads = false } = {}) => {
+    const store = new Map(rows.map((r) => [r.id, r]));
+    return {
+      updates: [],
+      from() { return this; },
+      select() { return this; },
+      eq(_c, v) { this._id = v; return this; },
+      maybeSingle() {
+        if (failReads) return Promise.resolve({ data: null, error: { message: 'read denied' } });
+        return Promise.resolve({ data: store.get(this._id) ?? null, error: null });
+      },
+      update(patch) {
+        if (failWrites) return { eq: () => Promise.resolve({ error: { message: 'write denied' } }) };
+        return {
+          eq: (_c, id) => {
+            store.set(id, { ...store.get(id), ...patch });
+            this.updates.push({ id, patch });
+            return Promise.resolve({ error: null });
+          },
+        };
+      },
+      _store: store,
+    };
+  };
+  const ctx = { nowIso: NOW, runId: 'run-1', severityRank, threshold: 3 };
+
+  it('writes one marker per member row and carries existing metadata through', async () => {
+    const db = fakeDb([{ id: 'fb-1', metadata: { keep: 'me' } }]);
+    const res = await writeMarkers(db, [group()], demand(), ctx);
+    expect(res.written).toBe(1);
+    expect(db._store.get('fb-1').metadata.keep).toBe('me');
+    expect(db._store.get('fb-1').metadata[MARKER_KEY].withheld_run_count).toBe(1);
+  });
+
+  it('is idempotent across runs — the SAME row, counters advancing', async () => {
+    const db = fakeDb([{ id: 'fb-1', metadata: {} }]);
+    await writeMarkers(db, [group()], demand(), ctx);
+    await writeMarkers(db, [group()], demand(), { ...ctx, runId: 'run-2' });
+    const m = db._store.get('fb-1').metadata[MARKER_KEY];
+    expect(m.withheld_run_count).toBe(2);
+    expect(m.first_withheld_run).toBe('run-1');
+    expect(m.last_withheld_run).toBe('run-2');
+  });
+
+  it('does NOT resurrect a marker that already left pending state', async () => {
+    const consumedMarker = { ...buildMarker(group(), demand(), ctx), promoted_qf_id: 'QF-9' };
+    const db = fakeDb([{ id: 'fb-1', metadata: { [MARKER_KEY]: consumedMarker } }]);
+    const res = await writeMarkers(db, [group()], demand(), ctx);
+    expect(res.written).toBe(0);
+    expect(db._store.get('fb-1').metadata[MARKER_KEY].promoted_qf_id).toBe('QF-9');
+  });
+
+  // THE FALSE-ZERO. The first version returned {written: 0} when every write was rejected, and the
+  // caller then announced "these now survive their 14-day window" — a claim of protection that had
+  // not happened, with nothing raised to contradict it. That is this module's own defect class,
+  // reproduced inside the fix for it.
+  it('THROWS when every write fails, rather than reporting a silent zero', async () => {
+    const db = fakeDb([{ id: 'fb-1', metadata: {} }], { failWrites: true });
+    await expect(writeMarkers(db, [group()], demand(), ctx)).rejects.toThrow(/all 1 durable write\(s\) failed/);
+  });
+
+  it('reports a PARTIAL failure instead of throwing, so a partial record is kept', async () => {
+    const db = fakeDb([{ id: 'fb-1', metadata: {} }, { id: 'fb-2', metadata: {} }]);
+    let n = 0;
+    const origUpdate = db.update.bind(db);
+    db.update = (patch) => (++n === 2
+      ? { eq: () => Promise.resolve({ error: { message: 'write denied' } }) }
+      : origUpdate(patch));
+    const res = await writeMarkers(db, [group({ rows: [{ id: 'fb-1' }, { id: 'fb-2' }] })], demand(), ctx);
+    expect(res.written).toBe(1);
+    expect(res.failed).toHaveLength(1);
+  });
+
+  it('an empty group list writes nothing and does not throw', async () => {
+    const db = fakeDb([]);
+    await expect(writeMarkers(db, [], demand(), ctx)).resolves.toEqual({ written: 0, rows: [] });
+  });
+
+  it('refuses a client that is not a client, rather than failing later and vaguely', async () => {
+    await expect(writeMarkers(null, [group()], demand(), ctx)).rejects.toThrow(/supabase client is required/);
   });
 });
 

--- a/tests/unit/governance/withheld-registry.test.js
+++ b/tests/unit/governance/withheld-registry.test.js
@@ -7,7 +7,7 @@
 // to a working one from outside while meaning nothing, which is the same class as the defect. So
 // the negative controls below were written BEFORE the write path and are the primary assertions;
 // the positive case is the easy half.
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 import { gatedQfMint } from '../../../lib/governance/qf-mint-gate.mjs';
 import {


### PR DESCRIPTION
## What was wrong

The QF demand gate withholds promotion whenever the belt gauge sits at or above its floor — correct. But a withheld promotable group was recorded durably **nowhere**: stdout inside one GHA run, plus an integer the caller destructured away one line after the gate computed it. Meanwhile the source rows age out of a rolling 14-day window.

Three independent facts made the loss structural rather than incidental:

- the audit row is written **inside** `openQfMintGate`, before `allowed` is known — so it cannot carry the withheld set by construction
- the promoter's only write to `feedback` sits below a report-only short-circuit the withheld path always takes
- `onWithheld`'s return was coerced with `Number(x) || 0`, discarding the identities

The gate's own source already said so: *"a withheld group does not queue, IT EXPIRES."* The problem was named and understood; only the sink was missing.

**It is dated work.** No group has been lost *yet* — the gate is hours old with two decisions ever, both withheld. But the belt sits at **151 open quick-fixes against a floor of 3**, so the withhold is effectively permanent, and the earliest at-risk rows expire **2026-08-05T16:48:16Z** (reproduced independently to the second by SECURITY review). 34 groups, every one a critical-severity finding.

## What shipped

A pending-promotion registry on `feedback.metadata` — **no DDL, no chairman gate**. The SD offered "table or feedback-status representation"; both are DDL-bearing (`feedback_status_check` admits nine values, none of them pending — verified against live `pg_constraint`, not the migration snapshot). `feedback.metadata` is live jsonb with no CHECK, already carries promotion state for this same promoter, and delivers "outlives the window" free because feedback rows are never purged.

**Registry, not ledger.** The SD was internally inconsistent — one requirement stamps a run identifier, another presumes a mutable set. Append-per-run over a 6-hourly cron is ~2,000 rows per window for 36 groups, less legible than the stdout it replaces. One marker per group, mutated in place, run provenance as counters.

**Keyed on the feedback row id, not the fingerprint** — a fingerprint is derived from title+description and *moves* when a title is edited. They coincide today only because every current group is a singleton, which is a fact about today's data, not a property of the design.

## Reviewers: this PR is mostly a record of me getting it wrong

Adversarial review at EXEC and again at PLAN_VERIFICATION found **eight** defects. Three were the SD's own defect class reproduced inside the fix for it:

| # | defect |
|---|---|
| 1 | `writeMarkers` swallowed every failure and returned `{written:0}` unraised — a run where *every* write was rejected still printed "these now survive their 14-day window" |
| 2 | `readPendingMarkers`' docstring claimed server-side filtering while doing the exact capped-fetch-then-filter-in-memory it warned against (1000 cap vs 5477 rows) |
| 3 | `disposeMarker` without `nowIso` returned `{disposed:true}` while leaving the marker **pending** — a silent non-exit inside the function whose error message rails against silent exits |
| 4 | **two of my own fixes cancelled each other, four commits apart** — see below |
| 5 | one of my tests asserted `markers_failed === 0` against a stub that *could not fail*, pinning the defect as the requirement |
| 6 | the call site was unpinned: deleting `writeMarkers: recordWithheld` killed **zero** tests out of 35,199 |
| 7 | severity warned on healthy runs (all-skipped legitimately writes nothing), decaying the signal every 6h |
| 8 | FR-6 was entirely unimplemented |

**#4 is the one worth reading.** I wrote the candidate query to test `promoted_qf_id.is.null`. A later commit correctly stopped writing that field, because `create-quick-fix.js` runs with `stdio: 'inherit'` and an id column must not hold a fingerprint. Net: `isPending()` returned false while the query returned true. The damage wasn't a growing candidate set — a re-admitted consumed row makes the already-promoted check skip the **whole group**, so any fingerprint once withheld-then-promoted became **permanently unpromotable** and its recurrences were never marked pending. Silent expiry, re-created inside the fix for silent expiry. Both commits were correct in isolation.

## Verification

Two-sided throughout, because the failure mode of a *recording* fix is one that records on every run — indistinguishable from working, from outside.

- **Negative controls are the primary assertions**: an allowed run and a dry run each write **zero** markers, with positive controls in the same test (`decision === sourced`, `minted === 7`) plus a throwing `onWithheld`, so the zero cannot pass because an arm never ran.
- **Both operands move** — gauge below floor, and floor above gauge — since a suite that only moves one is satisfied by an implementation reading only one.
- **Mutation-verified**: reverting the `.length` derivation, removing the call-site wiring, and flipping the query predicate each now fail. Before the final review, three of those killed zero tests.
- **Query semantics verified live before encoding**, twice. The first control for the widened query came back **inconclusive** (delta 0, because every row carrying my probe key happens to be in-window) — re-run with a predicate that could actually admit: 3291 rows. An inconclusive control is not a passing one.
- 1192/1192 across 72 governance suites. Live dry run clean, 0 markers written.

## Size

6 files, +1145/−15 (three-dot against the merge-base; a two-dot diff against a moved main reports a phantom 5,455 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)