### PR TITLE
fix(QF-20260803-422): a fenced stranded row must not end the check-in ladder

### DIFF
--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -1137,14 +1137,26 @@ async function recoverStrandedFinal(sb, sessionId, base) {
     // FR-1: refusals are loud even when nothing is adopted. Returning a bare null here is what made
     // "every stranded row is fenced" indistinguishable from "there is nothing stranded" — and an
     // operator cannot act on a distinction the output does not draw.
+    //
+    // QF-20260803-422 — THE LOUDNESS IS KEPT; THE EARLY RETURN IS NOT. This block used to RETURN
+    // that refusal object, and runSteps (lib/checkin/pipeline.cjs:18) treats ANY truthy return as
+    // "resolved". So one fenced row ended the ladder at step 8 of 18 and silently skipped
+    // adopt-orphan, critical-qf-jump, the merged-pool SD self-claim and the QF self-claim — for
+    // EVERY worker in the fleet. Measured: ~17.5h continuous, 151 open quick_fixes and 38 draft SDs
+    // invisible behind a single row.
+    //
+    // The contract it broke is documented two lines below, on this function's own last statement:
+    // `return null` / "fail-open -> caller continues to normal self-claim". An instrument added to
+    // END one silence has to obey the rule that keeps the ladder moving, or it manufactures a
+    // bigger one.
+    //
+    // So the refusal is CARRIED, not returned: stash it on `base`, which every downstream
+    // resolution already spreads (`...base`), so the FIELD propagates for free; carryFencedRefusals
+    // at the runSteps seam puts it in the MESSAGE. That message half is not optional — FR-2's own
+    // lesson, 20 lines up, is "soft holds go in the MESSAGE, not only in a field ... a field a
+    // caller may or may not print reproduces that".
     if (skipped.length) {
-      return {
-        ...base,
-        action: 'idle',
-        sd: null,
-        skipped_fenced: skipped,
-        message: `No stranded SD adopted: ${skipped.length} candidate(s) are FENCED and were deliberately not claimed — ${skipped.join('; ')}. This is a refusal, not an absence. Clear the fence (or the hold it names) if recovery is intended.`,
-      };
+      base.skipped_fenced = skipped;
     }
   } catch { /* fail-open -> caller continues to normal self-claim */ }
   return null;
@@ -1898,7 +1910,36 @@ async function resolveCheckin(sb, sessionId, { getCoordinator = getActiveCoordin
     base: null,
     helpers: CHECKIN_HELPERS,
   };
-  return runSteps(CHECKIN_STEPS, ctx);
+  const resolution = await runSteps(CHECKIN_STEPS, ctx);
+  return carryFencedRefusals(resolution, ctx);
+}
+
+/**
+ * QF-20260803-422 — carry a step-8 fence refusal onto WHATEVER resolution finally wins.
+ *
+ * recoverStrandedFinal (step 8 of 18) refuses to adopt fenced stranded rows and must say so. It can
+ * no longer say so by RETURNING the refusal — that ends the ladder and suppresses steps 9-14 (see
+ * the long comment on its skipped-refusal block). It stashes on ctx.base instead; this puts the
+ * explanation into the winning resolution's message so the refusal stays as loud as FR-1 made it.
+ *
+ * APPLIED AT THE SINGLE runSteps SEAM, not inside steps 9-14, for one reason: any step added to the
+ * ladder later inherits this automatically. Per-step appending would be an unwritten obligation on
+ * every future step author — and an unwritten obligation on a step author is precisely what caused
+ * the defect this fixes.
+ *
+ * Note it does NOT fire on recoverStrandedFinal's own success return: that path returns from inside
+ * the loop before `base.skipped_fenced` is ever set, and already carries its own "skipped N fenced
+ * rows to reach this one" wording. So there is no double-append.
+ */
+function carryFencedRefusals(resolution, ctx) {
+  const skipped = ctx && ctx.base ? ctx.base.skipped_fenced : null;
+  if (!resolution || !Array.isArray(skipped) || skipped.length === 0) return resolution;
+  const note = `\n\nNOTE — ${skipped.length} stranded candidate(s) were FENCED and deliberately NOT claimed: ${skipped.join('; ')}. This is a refusal, not an absence. It did NOT stop this check-in from resolving. Clear the fence (or the hold it names) if recovery is intended.`;
+  return {
+    ...resolution,
+    skipped_fenced: skipped,
+    message: typeof resolution.message === 'string' ? resolution.message + note : resolution.message,
+  };
 }
 
 /**
@@ -1942,7 +1983,7 @@ async function main() {
 // top (imports are referenced directly — never re-derived).
 const CHECKIN_HELPERS = { ws, tryClaim, stampDirectedAssignment, ackMessage, extractSdFromAssignment, extractDirectedSd, isInformationalNudge, classifyDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, registerRollCall, rehydrateCallsign, selfClearQuarantine, mergeCheckinModelEffort, recoverStrandedFinal, describeSoftHolds, adoptOrphanInProgress, isSelfClaimDisabled, isGlobalStandDownActive, isBuildForbiddenSession, ensureActiveBaseline, isCriticalQfJumpEligible, tryClaimDraftCandidate, baselinedCandidateEligible, isSdInFlight, selfClaimQuickFix, selfHealStaleClaim, findOwnSdClaim, healOwnClaimPointer, confirmRowGone, surfaceCoordinatorMessages, fetchOutstandingSignals, formatOutstandingWarning, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, sortByDispatchRank, resolveWorkerTierRank, isTieringActive, fetchLowerTierBacklogData, ladderTopRank, seatCapabilityIsVerified, fetchFableWindowActive, claimableForTier, claimableForRepo, getCommsActivitySignals, computeAdaptiveCadence, antiWinddownDirective, ASSIGNMENT_RECENCY_WINDOW_MS, TERMINAL_CLAIM_ERRORS, QF_CANDIDATE_LIMIT, SELF_CLAIM_CANDIDATE_LIMIT, DEFAULT_IDLE_WAKEUP_SECONDS };
 
-module.exports = { ADOPTABLE_ORPHAN_STATUSES, CHECKIN_HELPERS, stampDirectedAssignment, extractSdFromAssignment, extractDirectedSd, isInformationalNudge, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, sortQfCandidatesBySeverity, QF_SEVERITY_RANK, isCriticalQfJumpEligible, CRITICAL_QF_JUMP_GRACE_MS, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, describeSoftHolds, adoptOrphanInProgress, pendingDirectedAssignmentBlocksAdoption, isSelfClaimDisabled, isQuarantined, isParked, selfClearQuarantine, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, findOwnSdClaim, healOwnClaimPointer, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs };
+module.exports = { ADOPTABLE_ORPHAN_STATUSES, CHECKIN_HELPERS, stampDirectedAssignment, extractSdFromAssignment, extractDirectedSd, isInformationalNudge, tryClaim, registerRollCall, ackMessage, isCoordinatorPush, surfaceCoordinatorMessages, rehydrateCallsign, runCheckin, resolveCheckin, assignFleetIdentityAtCheckin, selfClaimQuickFix, isAutoStartableQF, sortQfCandidatesBySeverity, QF_SEVERITY_RANK, isCriticalQfJumpEligible, CRITICAL_QF_JUMP_GRACE_MS, selfClaimDraftSd, fetchDraftCandidates, fetchNewestDraftCandidates, fetchFleetCriticalCandidates, fetchRankedCandidates, tryClaimDraftCandidate, draftDepsSatisfied, baselinedCandidateEligible, recoverStrandedFinal, describeSoftHolds, adoptOrphanInProgress, pendingDirectedAssignmentBlocksAdoption, isSelfClaimDisabled, isQuarantined, isParked, selfClearQuarantine, isGlobalStandDownActive, isSdInFlight, isForeignSessionLive, foreignClaimantBlocksSteal, selfHealStaleClaim, findOwnSdClaim, healOwnClaimPointer, confirmRowGone, orderByRankMap, orderByFleetCriticalThenRank, sortByDispatchRank, DISPATCH_RANK_TTL_MS, PRIORITY_RANK, SD_KEY_RE, DEFAULT_IDLE_WAKEUP_SECONDS, STALE_QF_DAYS, antiWinddownDirective, mergeCheckinModelEffort, parseCheckinArgs, carryFencedRefusals };
 
 if (require.main === module) {
   main().catch(err => {

--- a/tests/unit/checkin/resume-final-reads-holds.test.js
+++ b/tests/unit/checkin/resume-final-reads-holds.test.js
@@ -69,14 +69,19 @@ describe('FR-1 — a structurally fenced row is REFUSED, and the refusal is loud
     expect(r?.action).not.toBe('resume_final');
   });
 
-  it('SAYS WHY rather than returning a bare idle — silence is what let the original hold pass unread', async () => {
+  // REWRITTEN BY QF-20260803-422 — this test used to assert `expect(r).not.toBeNull()`, i.e. it
+  // PINNED the early return that suppressed steps 9-14 of the check-in ladder for the whole fleet.
+  // It was not merely silent about the defect; it held it in place. The contract it should have
+  // asserted is BOTH halves at once: the refusal is loud AND it does not stop the pipeline.
+  it('SAYS WHY without RETURNING — the refusal is carried on base, not used to end the ladder', async () => {
     const sb = fakeSb({ stranded: [row('SD-FENCED-001', { requires_human_action: true })] });
-    const r = await recoverStrandedFinal(sb, 'sess-1', {});
-    expect(r).not.toBeNull();
-    expect(r.skipped_fenced).toEqual(expect.arrayContaining([expect.stringContaining('SD-FENCED-001')]));
-    // Asserted on the MESSAGE, not only a field: an operator reads the message.
-    expect(r.message).toMatch(/FENCED/);
-    expect(r.message).toMatch(/refusal, not an absence/);
+    const base = {};
+    const r = await recoverStrandedFinal(sb, 'sess-1', base);
+    // Half one: falsy, so lib/checkin/pipeline.cjs runSteps() keeps descending the ladder.
+    expect(r).toBeFalsy();
+    // Half two: the refusal survives — loudness is preserved, only its delivery changed.
+    expect(base.skipped_fenced).toEqual(expect.arrayContaining([expect.stringContaining('SD-FENCED-001')]));
+    expect(base.skipped_fenced.join(' ')).toMatch(/human_action_required/);
   });
 
   // THE DISCRIMINATOR THIS SUITE WAS MISSING. The header claims these tests assert the SHARED
@@ -90,10 +95,14 @@ describe('FR-1 — a structurally fenced row is REFUSED, and the refusal is loud
   it('refuses a test-fixture SD — an axis a requires_human_action one-liner would miss', async () => {
     const claimed = [];
     const sb = fakeSb({ stranded: [row('SD-TEST-PHANTOM-001')], claimed });
-    const r = await recoverStrandedFinal(sb, 'sess-1', {});
+    const base = {};
+    const r = await recoverStrandedFinal(sb, 'sess-1', base);
     expect(claimed).not.toContain('SD-TEST-PHANTOM-001');
     expect(r?.action).not.toBe('resume_final');
-    expect(JSON.stringify(r?.skipped_fenced || [])).toMatch(/SD-TEST-PHANTOM-001/);
+    // QF-20260803-422: reads the carried refusal off `base` now, not off the (deliberately falsy)
+    // return. Asserted on the array itself rather than JSON.stringify(x || []) — the old form
+    // would have matched an EMPTY carry against "[]" and quietly reported nothing wrong.
+    expect(base.skipped_fenced).toEqual(expect.arrayContaining([expect.stringContaining('SD-TEST-PHANTOM-001')]));
   });
 
   it('reaches an eligible row PAST a fenced one, and reports what it skipped', async () => {
@@ -216,5 +225,143 @@ describe('describeSoftHolds', () => {
     expect(describeSoftHolds({ metadata: { hold_b: { reason: 'via reason' } } })[0]).toMatch(/via reason/);
     // No recognised field: still surfaced rather than dropped — an unreadable hold is still a hold.
     expect(describeSoftHolds({ metadata: { hold_c: { odd: 1 } } })[0]).toMatch(/odd/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// QF-20260803-422 — THE FENCED REFUSAL MUST NOT STOP THE LADDER.
+//
+// THE DEFECT. lib/checkin/pipeline.cjs runSteps() ends the pipeline on ANY truthy step return.
+// recover-stranded-final is step 8 of 18. FR-1 (above) made its refusal loud by RETURNING an
+// object — so a single fenced row terminated every worker's check-in at step 8, silently skipping
+// adopt-orphan, critical-qf-jump, the merged-pool SD self-claim and the QF self-claim. Measured
+// live: ~17.5h continuous, hiding 151 open quick_fixes and 38 draft SDs behind ONE row.
+//
+// WHY THE OLD SUITE MISSED IT. The FR-1 test above asserted `expect(r).not.toBeNull()`. It did not
+// merely fail to catch the regression — it PINNED it. Every test in this file called
+// recoverStrandedFinal DIRECTLY, so nothing here ever observed what the pipeline does with its
+// return value. A unit boundary drawn one level below the defect cannot see the defect.
+//
+// So these tests drive the REAL runSteps, the REAL step module, and the REAL carry seam. Only the
+// DB and the downstream lanes are stubbed. Re-tighten the refusal into a return and this goes red.
+describe('QF-20260803-422 — a fenced-only stranded set still reaches the self-claim lanes', () => {
+  const { runSteps } = require_('../../../lib/checkin/pipeline.cjs');
+  const recoverStep = require_('../../../lib/checkin/steps/recover-stranded-final.cjs');
+  const { carryFencedRefusals } = checkin;
+
+  async function runLadder(strandedRows) {
+    const reached = [];
+    const ctx = {
+      sb: fakeSb({ stranded: strandedRows }),
+      sessionId: 'sess-1',
+      base: {},
+      helpers: { recoverStrandedFinal },
+    };
+    const lane = (name, resolution) => ({
+      name,
+      run: () => { reached.push(name); return resolution; },
+    });
+    const steps = [
+      recoverStep,                                    // the REAL step 8
+      lane('adopt-orphan'),                           // step 9
+      lane('critical-qf-jump'),                       // step 11
+      lane('merged-pool-self-claim'),                 // step 12 — the draft SD lane
+      lane('self-claim-qf', {                         // step 13 — the QF lane, resolves here
+        action: 'self_claimed_qf', qf: 'QF-STUB-001',
+        message: 'Self-claimed QF-STUB-001.',
+      }),
+    ];
+    return { reached, resolution: carryFencedRefusals(await runSteps(steps, ctx), ctx) };
+  }
+
+  const FENCED = [row('SD-FENCED-001', { requires_human_action: true })];
+
+  it('reaches BOTH the draft self-claim lane and the QF lane past a fenced-only stranded set', async () => {
+    const { reached, resolution } = await runLadder(FENCED);
+    // The four lanes the defect suppressed. Named individually so a partial regression is legible.
+    expect(reached).toContain('adopt-orphan');
+    expect(reached).toContain('critical-qf-jump');
+    expect(reached).toContain('merged-pool-self-claim');
+    expect(reached).toContain('self-claim-qf');
+    // And the ladder actually RESOLVED to real work rather than idling.
+    expect(resolution.action).toBe('self_claimed_qf');
+    expect(resolution.qf).toBe('QF-STUB-001');
+  });
+
+  it('CARRIES the fenced explanation into the winning resolution — loudness survives the fix', async () => {
+    const { resolution } = await runLadder(FENCED);
+    // In the MESSAGE, not only in a field: FR-2's own lesson is that a field a caller may or may
+    // not print reproduces the silence. Trading one silence for the other is not a fix.
+    expect(resolution.message).toMatch(/FENCED/);
+    expect(resolution.message).toMatch(/SD-FENCED-001/);
+    expect(resolution.message).toMatch(/refusal, not an absence/);
+    // And it says the refusal did not suppress the resolution — the distinction that was missing.
+    expect(resolution.message).toMatch(/did NOT stop this check-in/);
+    expect(resolution.skipped_fenced).toEqual(expect.arrayContaining([expect.stringContaining('SD-FENCED-001')]));
+    // The claim it rides on is still intact and un-mangled.
+    expect(resolution.message).toMatch(/Self-claimed QF-STUB-001/);
+  });
+
+  // TWO-SIDED CONTROL. Without this, an unconditional note would satisfy the assertions above —
+  // the carry would look correct while actually being a constant. A control that can only confirm
+  // is not a control.
+  it('appends NOTHING when no row was fenced', async () => {
+    const { reached, resolution } = await runLadder([]);
+    expect(reached).toContain('self-claim-qf');
+    expect(resolution.message).toBe('Self-claimed QF-STUB-001.');
+    expect(resolution.skipped_fenced).toBeUndefined();
+  });
+
+  // The other side of the ladder contract: a genuinely adoptable row MUST still short-circuit.
+  // Making the refusal non-terminal must not make the SUCCESS non-terminal too.
+  it('still stops the ladder when a stranded row IS adoptable', async () => {
+    const { reached, resolution } = await runLadder([row('SD-ADOPTABLE-001')]);
+    expect(resolution.action).toBe('resume_final');
+    expect(resolution.sd).toBe('SD-ADOPTABLE-001');
+    expect(reached).toEqual([]); // nothing below step 8 ran
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// THE WIRING ASSERTION — added after mutation testing exposed that the suite above did NOT need it
+// to pass, which is the whole problem.
+//
+// HOW THIS WAS CAUGHT. Deleting the `carryFencedRefusals(...)` CALL from resolveCheckin left all 19
+// tests green. The ladder tests above call the helper THEMSELVES, so they prove the helper works
+// and prove nothing about whether the production entry point invokes it. A step-8 refusal could
+// have gone silent again with a full green suite.
+//
+// This is the same shape as TS-9 on SD-LEO-INFRA-RESUME-FINAL-READ-001 ("nothing asserts the gate
+// CONSUMES computeReposForSD") — a guard tested in isolation, upstream of the verdict that reports
+// it. Recognising the class one day earlier did not prevent repeating it; only the mutation did.
+//
+// So this drives the REAL resolveCheckin — real coordinator resolution, real 18-step ladder, real
+// carry seam — and asserts on what a worker actually receives.
+describe('QF-20260803-422 — resolveCheckin WIRES the carry (not just the helper in isolation)', () => {
+  const { resolveCheckin } = checkin;
+  const opts = { getCoordinator: async () => null };
+
+  it('the resolution a worker actually receives carries the fenced refusal', async () => {
+    const sb = fakeSb({ stranded: [row('SD-FENCED-001', { requires_human_action: true })] });
+    const r = await resolveCheckin(sb, 'sess-1', opts);
+    // Whatever the ladder resolved to, the refusal rode along.
+    expect(r.message).toMatch(/SD-FENCED-001/);
+    expect(r.message).toMatch(/FENCED/);
+    expect(r.skipped_fenced).toEqual(expect.arrayContaining([expect.stringContaining('SD-FENCED-001')]));
+  });
+
+  it('and it did NOT resolve at step 8 — the ladder ran past the refusal', async () => {
+    const sb = fakeSb({ stranded: [row('SD-FENCED-001', { requires_human_action: true })] });
+    const r = await resolveCheckin(sb, 'sess-1', opts);
+    // The defect's signature was action:'idle' WITHOUT the terminal idle step's own wording.
+    // Reaching step 14 proves steps 9-13 were offered their turn.
+    expect(r.message).toMatch(/never wait on a human|STANDING BY|Self-claimed|Claimed/);
+    expect(r.recommended_wakeup_seconds).toBeTypeOf('number');
+  });
+
+  it('two-sided: with nothing fenced, no refusal text is attached', async () => {
+    const r = await resolveCheckin(fakeSb({ stranded: [] }), 'sess-1', opts);
+    expect(r.message).not.toMatch(/FENCED/);
+    expect(r.skipped_fenced).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

`runSteps()` ([lib/checkin/pipeline.cjs:18](../blob/main/lib/checkin/pipeline.cjs#L18)) resolves the check-in on **any** truthy step return. `recover-stranded-final` is step 8 of 18, and SD-LEO-INFRA-RESUME-FINAL-READ-001 FR-1 made its refusal loud by *returning* an object — so a single fenced row ended every worker's check-in at step 8, silently skipping `adopt-orphan`, `critical-qf-jump`, the merged-pool SD self-claim and the QF self-claim.

Measured live: **~17.5h continuous**, hiding **151 open quick_fixes and 38 draft SDs** behind one row.

The contract it broke is documented two lines below it, on the same function's own last statement: `return null` / *"fail-open -> caller continues to normal self-claim"*.

**The fence is not touched.** It is correct and load-bearing — that row auto-chained to `completed` with its PR open and its migration unapplied, which is exactly what the fence now prevents. Clearing it would re-open the incident and mask this bug until the next fenced row.

## The fix

The refusal is **carried, not returned**: stashed on `base` (which every downstream resolution already spreads, so the field propagates for free), then appended to the winning resolution's *message* by `carryFencedRefusals` at the single `runSteps` seam. FR-2's own lesson applies — a field a caller may or may not print reproduces the silence, so the message half is not optional.

Applied at the seam rather than in steps 9–14 so any step added later inherits it. A per-step rule is an unwritten obligation on future authors, which is the class of thing that caused this.

**14 lines of production code**; the rest is comments and tests.

## The regression test is the deliverable

The prior FR-1 test asserted `expect(r).not.toBeNull()` — it did not merely miss the defect, it **pinned** it. Rewritten to assert both halves: the refusal is loud **and** it does not stop the pipeline.

New tests drive the real `runSteps`, the real step module, and the real `resolveCheckin`, asserting a fenced-only stranded set still reaches both the draft self-claim lane and the QF lane, and that the resolution still carries the explanation. Two-sided controls included (nothing appended when nothing is fenced; an adoptable row still short-circuits).

## Test plan

Mutation-verified, byte-identical restore confirmed:

| Mutation | Result |
|---|---|
| restore the early return (the original defect) | 6 red |
| drop the carry wiring | 1 red |
| unconditional note (constant masquerading as a carry) | 3 red |

That middle mutation **initially survived**. The first draft of the ladder tests called `carryFencedRefusals` themselves — proving the helper worked while proving nothing about whether `resolveCheckin` invokes it. Deleting the call left all 19 tests green. Same shape as TS-9 one SD ago (*"nothing asserts the gate CONSUMES computeReposForSD"*); recognising the class a day earlier did not prevent repeating it, only the mutation did. Fixed by driving the real entry point end-to-end.

Regression: **1156 passed / 0 failed** across 91 suites importing the changed modules (96 matched; 5 excluded by the quarantine manifest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)