### PR TITLE
SD-LEO-INFRA-DEAD-VENTURE-USER-001: assert the anon write contract at the database

### DIFF
--- a/.github/workflows/anon-write-contract-probe.yml
+++ b/.github/workflows/anon-write-contract-probe.yml
@@ -1,0 +1,48 @@
+# Anon write-contract probe — SD-LEO-INFRA-DEAD-VENTURE-USER-001 FR-6.
+#
+# The probe binary is invoked DIRECTLY so its exit code is the gate. That is not a style choice:
+# the vitest `db` project on this repo has an empty DESIGNATED_NON_PROD_REFS, so assessDbTarget
+# returns {allowed:false} and any live-tier test placed there SKIPS — and a skip reports green.
+#
+# Path filters below use literal per-extension entries. GitHub Actions does NOT expand brace
+# alternation, so 'scripts/**/*.{js,mjs,cjs}' matches nothing — four workflows in this repo carry
+# that pattern and have effectively never fired. tests/unit/anon-write-contract-probe.test.js
+# enforces this repo-wide, so the next one cannot repeat it either.
+name: anon-write-contract-probe
+
+on:
+  push:
+    paths:
+      - 'scripts/anon-write-contract-probe.mjs'
+      - 'tests/unit/anon-write-contract-probe.test.js'
+      - '.github/workflows/anon-write-contract-probe.yml'
+  pull_request:
+    paths:
+      - 'scripts/anon-write-contract-probe.mjs'
+      - 'tests/unit/anon-write-contract-probe.test.js'
+      - '.github/workflows/anon-write-contract-probe.yml'
+  schedule:
+    # The contract can change without anyone touching this repo — a sibling SD altering an anon
+    # policy is exactly the event this probe exists to catch, and it produces no diff here.
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci
+      # No continue-on-error anywhere in this file, and no job-level if:. A step that cannot fail
+      # the build is indistinguishable from a step that was never added.
+      - name: unit tier (pure — cannot skip)
+        run: npx vitest run --project unit tests/unit/anon-write-contract-probe.test.js
+      - name: live contract assertion
+        env:
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+        run: node scripts/anon-write-contract-probe.mjs

--- a/.github/workflows/anon-write-contract-probe.yml
+++ b/.github/workflows/anon-write-contract-probe.yml
@@ -10,6 +10,11 @@
 # enforces this repo-wide, so the next one cannot repeat it either.
 name: anon-write-contract-probe
 
+# Least privilege: the default repo token is write-capable and checkout persists it into
+# .git/config before npm ci runs dependency lifecycle scripts.
+permissions:
+  contents: read
+
 on:
   push:
     paths:
@@ -32,6 +37,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
@@ -40,9 +47,22 @@ jobs:
       # the build is indistinguishable from a step that was never added.
       - name: unit tier (pure — cannot skip)
         run: npx vitest run --project unit tests/unit/anon-write-contract-probe.test.js
+      # A missing secret must NAME ITSELF. SUPABASE_DB_PASSWORD was referenced here and is not a
+      # repo secret at all: it resolved to '' and the probe died on a connection error, so the
+      # live gate could never once have asserted the contract. Fail-closed is the right direction,
+      # but a permanently-red scheduled job is exactly how a genuine exit-2 gets ignored.
+      - name: assert credentials are present
+        env:
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+        run: |
+          if [ -z "$DATABASE_URL" ]; then
+            echo "::error::DATABASE_URL secret is empty or unset — the live contract assertion cannot run."
+            exit 1
+          fi
+      # The probe reads only the DB connection. SUPABASE_SERVICE_ROLE_KEY is deliberately NOT
+      # injected: it is consumed by a different export this script never calls, and a service-role
+      # key in a step that does not need it is gratuitous blast radius.
       - name: live contract assertion
         env:
-          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
-          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
         run: node scripts/anon-write-contract-probe.mjs

--- a/database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier_acceptance.mjs
+++ b/database/chairman-gated/20260803_bound_anon_ingress_source_type_qualifier_acceptance.mjs
@@ -185,7 +185,14 @@ try {
       }
       const other = await probe('other-source-under-limit', {
         source_type: 'user_feedback',
-        feedback_type: 'user_general',
+        // 'user_general' is NOT in feedback_feedback_type_check, whose live admitted set is
+        // {sentry_error, user_bug, user_feature_request, user_usability, user_other, venture_error}.
+        // As anon it returned 23514 at the CHECK and never reached RLS, so test B could never turn
+        // green regardless of policy state — the exact class this file's own header (:29-32) warns
+        // about and records as having voided a full battery four times. 'user_bug' is admitted and
+        // also satisfies venture_user_insert_feedback's `feedback_type LIKE 'user_%'`.
+        // SD-LEO-INFRA-DEAD-VENTURE-USER-001 FR-4.
+        feedback_type: 'user_bug',
         severity: 'low',
         venture_id: ventureId,
       });

--- a/docs/reference/anon-write-contract.md
+++ b/docs/reference/anon-write-contract.md
@@ -1,0 +1,110 @@
+# The anon write contract
+
+**Category**: Reference
+**Status**: Approved
+**Version**: 1.0.0
+**Author**: SD-LEO-INFRA-DEAD-VENTURE-USER-001
+**Last Updated**: 2026-08-04
+**Tags**: rls, postgres, anon, feedback, ingress
+
+## Read this first
+
+**No live caller is broken.** All five anon-path writers to `public.feedback` use the form that
+lands. This document describes a **latent trap**, not an outage — do not "fix" callers that are
+already correct, and do not restore the dropped `venture_user_select_feedback` policy (see
+[What not to do](#what-not-to-do)).
+
+## The contract
+
+Verdicts below are **measured** by `scripts/anon-write-contract-probe.mjs` against the live
+database, not derived from the documentation. Two of them contradict the intuitive reading.
+
+| Write form | Verdict | Cause |
+|---|---|---|
+| `INSERT` (bare, `Prefer: return=minimal`) | **LANDS** | — |
+| `INSERT ... RETURNING <target columns>` | **REFUSED** 42501 | the SELECT policy, applied to the readback |
+| `INSERT ... RETURNING 1` | **LANDS** | references no target column, so no readback |
+| `INSERT ... ON CONFLICT DO NOTHING` | **REFUSED** 42501 | the SELECT policy, on the arbiter check |
+| `INSERT ... ON CONFLICT DO UPDATE` | **REFUSED** 42501 | *additionally*, the absent anon UPDATE policy |
+
+Two findings here cost real time and are easy to get backwards:
+
+1. **`ON CONFLICT DO NOTHING` is refused even when no conflict occurs.** Measured with a freshly
+   generated `id`, so nothing could collide. The arbiter check is planned whether or not it fires,
+   so the refusal is a property of the *clause*, not of a collision. The probe originally shipped
+   expecting this to LAND; the first live run corrected it.
+2. **The two upsert forms are refused by different policies.** Establised by control, not argument:
+   granting anon a covering SELECT policy flips `RETURNING <cols>` and `DO NOTHING` to LANDS while
+   `DO UPDATE` stays refused; granting SELECT *and* UPDATE flips all three. So `DO UPDATE` is closed
+   by the absent anon UPDATE policy, applied to the conflicting row as a `WithCheckOption`. Note
+   that anon **holds** the UPDATE grant — this is a policy denial, not an ACL denial.
+
+### Why the error message misleads
+
+A single `42501` cannot distinguish *"the write was refused"* from *"the write succeeded and the
+readback was refused"*, and the wording favours the wrong reading. Four rounds of investigation on
+this SD went to the wrong hypothesis for exactly that reason. `42501` collapses at least five
+mechanisms; the probe therefore reports an **attributed cause** and never the bare code.
+
+## What to do instead
+
+Use the bare insert with a **client-side id**. This is not a new invention — it is already proven in
+production, and was written down a month before this document existed:
+
+> `ehg/src/integrations/feedback/feedbackDataAccess.ts:143-150` (landed 2026-07-12):
+> *"Postgres RLS requires a qualifying SELECT policy for INSERT...RETURNING to succeed — the
+> insert's own WITH CHECK policy is not sufficient on its own. […] generating the id client-side
+> means this insert path has zero runtime dependency on that policy."*
+
+If a caller genuinely needs server-generated state back, the existing escape hatch is a
+`SECURITY DEFINER` RPC — `apexniche-ai/src/lib/error-capture.ts:151` and
+`marketlens/src/lib/errorCapture.js:65` both POST to `/rest/v1/rpc/record_venture_error`.
+
+## What not to do
+
+**Do not widen anon's SELECT surface.** The `venture_user_select_feedback` policy that would have
+covered the readback was **deliberately dropped** — applied 2026-07-13T22:23:39Z, `prod_deploy=true`
+— as the closing step of a cross-tenant security fix whose earlier steps existed specifically to
+remove that policy's legitimate callers first. `SD-LEO-INFRA-CONTROL-SURFACE-POSTURE-001` is
+tightening this same surface. Restoring the policy re-opens what two SDs closed.
+
+## Enforcement
+
+`scripts/anon-write-contract-probe.mjs`, run in CI and on a schedule.
+
+```bash
+node scripts/anon-write-contract-probe.mjs                     # discover the class, probe each
+node scripts/anon-write-contract-probe.mjs --table public.feedback
+node scripts/anon-write-contract-probe.mjs --table public.feedback --control-grant-select
+```
+
+**Why a probe and not a lint.** All five live callers are in *other* repos (apexniche-ai, marketlens,
+ehg); EHG_Engineer has no anon feedback writer at all. A source lint shipped here would see **zero**
+of them. The database is the only layer all five share.
+
+It is safe against production — the only database there is — because the guarantee is
+**COMMIT-never-issued**: every statement runs inside a transaction that ends in `ROLLBACK`, and the
+query wrapper throws on any commit-family statement. That framing matters: a connection drop, a
+throw inside a catch, and an early return are all *already* safe.
+
+## This is a class, not a table
+
+The probe discovers its own targets: any table where anon can INSERT but has no unconditional anon
+SELECT coverage. Two members today — `feedback` and **`marketing_attribution`**, whose only live
+writer (`ehg/src/integrations/marketing/landingDataAccess.ts:85`) uses the bare form and carries the
+identical latent trap.
+
+## Related: a rate limit that cannot bind
+
+Distinct from the above, and easy to conflate — there are **two** rate limits on this path:
+
+- `check_feedback_rate_limit(venture_id)`, called from `venture_user_insert_feedback`'s WITH CHECK,
+  is `SECURITY DEFINER` and **does** bind. Not a defect.
+- The RESTRICTIVE `anon_feedback_ingress_bounds` policy counts with an **inline subquery that runs
+  as the inserting role**, so it is itself subject to the telegram-only SELECT policy. Its basis is
+  n=1 for every non-telegram source: the bound is arithmetically incapable of binding. Widened in a
+  rolled-back transaction the same basis saw auto_capture 10731, manual_feedback 6593. `SECURITY
+  DEFINER` is what that basis lacks.
+
+The remedy is filed as a separate chairman-gated SD rather than applied here: making a dormant limit
+suddenly bind would begin rejecting live traffic across four source types with existing volume.

--- a/docs/reference/anon-write-contract.md
+++ b/docs/reference/anon-write-contract.md
@@ -48,7 +48,9 @@ mechanisms; the probe therefore reports an **attributed cause** and never the ba
 
 ## What to do instead
 
-Use the bare insert with a **client-side id**. This is not a new invention — it is already proven in
+Use the bare insert with a **client-side id** — generate it with `crypto.randomUUID()`, not a
+counter or a hash of user input. A landed-vs-23505 response is a blind existence oracle, harmless
+while ids are unguessable and not harmless if they become predictable. This is not a new invention — it is already proven in
 production, and was written down a month before this document existed:
 
 > `ehg/src/integrations/feedback/feedbackDataAccess.ts:143-150` (landed 2026-07-12):
@@ -87,12 +89,36 @@ It is safe against production — the only database there is — because the gua
 query wrapper throws on any commit-family statement. That framing matters: a connection drop, a
 throw inside a catch, and an early return are all *already* safe.
 
+Two things that guarantee needed before it was true as written, both found by adversarial review
+rather than by reasoning about the code:
+
+- The guard originally anchored on the **start of the string**, and node-postgres sends a
+  param-less query over the simple protocol — which executes semicolon-separated statements. So
+  `select 1; commit` committed while the guard reported clean. It now inspects every statement.
+- `--table` is interpolated into `CREATE POLICY` and `::regclass`, which cannot take a bind
+  parameter, so the name is validated against a strict pattern. The operator already holds the DB
+  password, so this was never privilege escalation — it was the difference between safe by
+  construction and safe because nobody typed that.
+
+> **Control modes take an `AccessExclusiveLock`** on the target for the life of the transaction,
+> which blocks live ingress on a production table for as long as the run takes. A `lock_timeout` of
+> 1s bounds the acquisition, but do not run a control mode casually against a busy table. CI runs
+> the probe bare and never takes this lock.
+
 ## This is a class, not a table
 
-The probe discovers its own targets: any table where anon can INSERT but has no unconditional anon
-SELECT coverage. Two members today — `feedback` and **`marketing_attribution`**, whose only live
-writer (`ehg/src/integrations/marketing/landingDataAccess.ts:85`) uses the bare form and carries the
-identical latent trap.
+The probe discovers its own targets: any table where anon holds a permissive INSERT policy and has
+no *unconditional* anon SELECT policy. **Live, that is 59 candidates, not the 2 an earlier estimate
+claimed.** The estimate was wrong because a qual that is always-false *for anon* via a function call
+(`fn_is_chairman()`) is not statically distinguishable from one that is always-true, so the candidate
+set contains false positives.
+
+The probe asserts the contract only for tables it has a hand-written row builder for — today, just
+`public.feedback`. Every other candidate is reported **UNPROBED** on every run, loudly and by count.
+That is deliberate: a discovery step that quietly probes the one table it can and prints a clean
+pass reads exactly like a class that is covered. `marketing_attribution` is among the unprobed; its
+only live writer (`ehg/src/integrations/marketing/landingDataAccess.ts:85`) uses the bare form, so it
+carries the same latent trap and is a good candidate for the next builder.
 
 ## Related: a rate limit that cannot bind
 

--- a/package.json
+++ b/package.json
@@ -631,7 +631,8 @@
     "worker:recheck-blocker": "node scripts/worker-recheck-blocker.mjs",
     "audit:unreachable-midphase": "node scripts/audit-unreachable-midphase-sds.mjs",
     "audit:worktree-env-divergence": "node scripts/audit-worktree-env-divergence.mjs",
-    "flags:enroll-tier-gate": "node scripts/enroll-migration-tier-gate-flag.mjs"
+    "flags:enroll-tier-gate": "node scripts/enroll-migration-tier-gate-flag.mjs",
+    "audit:anon-write-contract": "node scripts/anon-write-contract-probe.mjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.85.0",

--- a/scripts/anon-write-contract-probe.mjs
+++ b/scripts/anon-write-contract-probe.mjs
@@ -118,12 +118,34 @@ export function discoverAsymmetricTables(policyRows = []) {
   return [...tables.values()].filter((t) => t.rls && t.canInsert && !t.fullSelect).map((t) => t.key).sort();
 }
 
-/** A guard the caller cannot satisfy without changing the harm. RELEASE SAVEPOINT is included and
- *  deliberately never used below — savepoints are discarded by the outer ROLLBACK anyway. */
-const COMMIT_FAMILY = /^\s*(commit|end|prepare\s+transaction|release\s+savepoint)\b/i;
+/**
+ * A guard the caller cannot satisfy without changing the harm.
+ *
+ * IT MUST INSPECT EVERY STATEMENT, NOT THE FIRST. The original spelling anchored `^` with no `m`
+ * flag and so read only the head of the string — and node-postgres sends a param-less query over
+ * the SIMPLE protocol, which executes semicolon-separated statements. `select 1; commit` therefore
+ * committed while the guard returned clean. Measured, not theorised: EXEC review reproduced the
+ * commit live. A guard that inspects a prefix of what it is guarding is narration, not enforcement.
+ */
+const COMMIT_FAMILY = /(^|;)\s*(commit|end|prepare\s+transaction|release\s+savepoint)\b/i;
 export function assertNotCommitFamily(sql) {
-  if (COMMIT_FAMILY.test(sql)) throw new Error(`COMMIT_FAMILY_STATEMENT_BLOCKED: ${String(sql).slice(0, 60)}`);
+  const text = String(sql);
+  if (COMMIT_FAMILY.test(text)) throw new Error(`COMMIT_FAMILY_STATEMENT_BLOCKED: ${text.slice(0, 80)}`);
   return sql;
+}
+
+/**
+ * Every table name reaching this file is interpolated into SQL — `regclass` casts and CREATE POLICY
+ * cannot take a bind parameter. Validate the shape rather than trusting the caller: `--table
+ * 'feedback; commit; --'` would otherwise smuggle a COMMIT past even a corrected guard by splitting
+ * it across a comment. The operator already holds the DB password, so this is not privilege
+ * escalation — it is the difference between safe by construction, which is what this file claims,
+ * and safe because nobody typed that.
+ */
+const QUALIFIED_NAME = /^[a-z_][a-z0-9_$]*\.[a-z_][a-z0-9_$]*$/i;
+export function assertQualifiedName(name) {
+  if (!QUALIFIED_NAME.test(String(name ?? ''))) throw new Error(`UNSAFE_TABLE_NAME: ${name}`);
+  return name;
 }
 
 /** Five independent ways RLS can be silently inert. Any one of them makes every verdict a lie. */
@@ -139,11 +161,14 @@ export async function assertRlsInForce(q, table, basePid) {
     [table]
   );
   const problems = [];
+  // Every check below is spelled as "must be affirmatively OK", never "must not be the bad value".
+  // `=== true` on bypass would fail OPEN if the subquery ever returned NULL — a guard whose unknown
+  // case is indistinguishable from its safe case is not a guard.
   if (r.usr !== 'anon') problems.push(`current_user=${r.usr}`);
-  if (r.bypass === true) problems.push('rolbypassrls=true');
+  if (r.bypass !== false) problems.push(`rolbypassrls=${r.bypass}`);
   if (r.rowsec !== 'on') problems.push(`row_security=${r.rowsec}`);
-  if (r.active !== true) problems.push('row_security_active=false');
-  if (r.relrls !== true) problems.push('relrowsecurity=false');
+  if (r.active !== true) problems.push(`row_security_active=${r.active}`);
+  if (r.relrls !== true) problems.push(`relrowsecurity=${r.relrls}`);
   if (basePid != null && r.pid !== basePid) problems.push(`backend_pid ${basePid}->${r.pid}`);
   return { ok: problems.length === 0, problems, pid: r.pid, port: r.port };
 }
@@ -203,11 +228,37 @@ async function attempt(q, name, sql, params) {
   }
 }
 
-const COLS = '(id, venture_id, feedback_type, source_type, source_application, title, type)';
-const VALS = '($1, $2, $3, $4, $5, $6, $7)';
-const row = (id, v, src, ft = 'user_bug') => [id, v, ft, src, 'anon-write-contract-probe', `probe ${id}`, 'issue'];
+/**
+ * Row builders, per table.
+ *
+ * A probe row must satisfy every NOT NULL, every CHECK, and the insert policy's own WITH CHECK
+ * before it reaches the SELECT-policy question this file exists to ask — otherwise it is rejected
+ * pre-RLS and the verdict means nothing. That is not a hypothetical: it is the defect this SD also
+ * repairs in the G2 acceptance battery, and the first draft of this probe committed it too.
+ *
+ * A builder is therefore per-table and hand-written. THIS IS THE HONEST LIMIT OF THE PROBE: it can
+ * only assert the contract for tables it can construct a valid row for. Discovery (below) finds far
+ * more candidates than there are builders, and every candidate without one is reported UNPROBED —
+ * loudly — because an unprobed table silently omitted from the output reads exactly like a table
+ * that passed.
+ */
+export const ROW_BUILDERS = {
+  'public.feedback': {
+    cols: '(id, venture_id, feedback_type, source_type, source_application, title, type)',
+    vals: '($1, $2, $3, $4, $5, $6, $7)',
+    // venture_user_insert_feedback additionally requires venture_id to be present and active and
+    // the per-venture rate limit not to be tripped — both via SECURITY DEFINER functions, so both
+    // genuinely bind for anon. `type` and `feedback_type` carry separate CHECK constraints.
+    preflight: `select v.id from ventures v
+                 where venture_exists_and_active(v.id)
+                   and not check_feedback_rate_limit(v.id) limit 1`,
+    build: (id, ctx, src) => [id, ctx, 'user_bug', src, 'anon-write-contract-probe', `probe ${id}`, 'issue']
+  }
+};
 
-export async function runForms(q, table, { ventureId, subjectSource, controlSource, uuid, basePid }) {
+export async function runForms(q, table, { builder, ctx, subjectSource, controlSource, uuid, basePid }) {
+  const COLS = builder.cols, VALS = builder.vals;
+  const row = (id, c, src) => builder.build(id, c, src);
   const observed = {}, attributions = {}, guards = [];
   const check = async (label) => {
     const g = await assertRlsInForce(q, table, basePid);
@@ -215,11 +266,11 @@ export async function runForms(q, table, { ventureId, subjectSource, controlSour
     return g.ok;
   };
   const forms = [
-    ['bare_insert',           `insert into ${table} ${COLS} values ${VALS}`,                                    () => row(uuid(), ventureId, subjectSource)],
-    ['returning_columns',     `insert into ${table} ${COLS} values ${VALS} returning id, title`,                 () => row(uuid(), ventureId, subjectSource)],
-    ['returning_literal',     `insert into ${table} ${COLS} values ${VALS} returning 1`,                         () => row(uuid(), ventureId, subjectSource)],
-    ['on_conflict_do_nothing',`insert into ${table} ${COLS} values ${VALS} on conflict (id) do nothing`,         () => row(uuid(), ventureId, subjectSource)],
-    ['positive_control',      `insert into ${table} ${COLS} values ${VALS} returning id`,                        () => row(uuid(), ventureId, controlSource)]
+    ['bare_insert',           `insert into ${table} ${COLS} values ${VALS}`,                                    () => row(uuid(), ctx, subjectSource)],
+    ['returning_columns',     `insert into ${table} ${COLS} values ${VALS} returning id, title`,                 () => row(uuid(), ctx, subjectSource)],
+    ['returning_literal',     `insert into ${table} ${COLS} values ${VALS} returning 1`,                         () => row(uuid(), ctx, subjectSource)],
+    ['on_conflict_do_nothing',`insert into ${table} ${COLS} values ${VALS} on conflict (id) do nothing`,         () => row(uuid(), ctx, subjectSource)],
+    ['positive_control',      `insert into ${table} ${COLS} values ${VALS} returning id`,                        () => row(uuid(), ctx, controlSource)]
   ];
   for (const [name, sql, mk] of forms) {
     if (!(await check(name))) return { observed, attributions, guards, aborted: name };
@@ -239,10 +290,10 @@ export async function runForms(q, table, { ventureId, subjectSource, controlSour
   let pending = null;
   await q(`SAVEPOINT ${sp}`);
   try {
-    await q(`insert into ${table} ${COLS} values ${VALS}`, row(seed, ventureId, subjectSource));
+    await q(`insert into ${table} ${COLS} values ${VALS}`, row(seed, ctx, subjectSource));
     try {
       await q(`insert into ${table} ${COLS} values ${VALS} on conflict (id) do update set title = excluded.title`,
-        row(seed, ventureId, subjectSource));
+        row(seed, ctx, subjectSource));
       observed.on_conflict_do_update = 'LANDS';
     } catch (err) {
       // Attribution is deferred to AFTER the savepoint rollback below: once a statement errors, the
@@ -274,6 +325,7 @@ function parseArgs(argv) {
     else if (argv[i] === '--subject-source') a.subjectSource = argv[++i];
   }
   if (a.table && !a.table.includes('.')) a.table = `public.${a.table}`;
+  if (a.table) assertQualifiedName(a.table);
   return a;
 }
 
@@ -281,6 +333,9 @@ const POLICY_PREFIX = 'zz_probe_ctl_';
 
 async function probeTable(client, q, table, args, uuid) {
   const control = args.grantSelect || args.grantUpdate;
+  const builder = ROW_BUILDERS[table];
+  if (!builder) return { code: EXIT.PROBE_INCONCLUSIVE, unprobed: true, reason: 'NO ROW BUILDER — this table is in the class but its contract was NOT asserted' };
+  assertQualifiedName(table);
   await q('BEGIN');
   try {
     // Prove BEGIN actually opened a transaction. Autocommit is the un-greppable commit and the
@@ -292,6 +347,11 @@ async function probeTable(client, q, table, args, uuid) {
     if (tx?.in_tx !== true) throw new Error('NOT_IN_TRANSACTION: BEGIN did not open a transaction — refusing to issue any write');
     await q("set local statement_timeout = '30s'");
     await q("set local idle_in_transaction_session_timeout = '60s'");
+    // CREATE POLICY takes an AccessExclusiveLock held until this transaction ends, which in control
+    // mode blocks ALL reads and writes to a live ingress table — including real anon submissions,
+    // which a short anon statement_timeout turns from "slow" into "failed". Fail to acquire rather
+    // than queue behind ourselves. CI never runs a control mode, so scheduled runs never take it.
+    await q("set local lock_timeout = '1s'");
 
     // Owner-privileged setup happens BEFORE dropping to anon, so there is no mid-run role toggle to
     // leak back across. FR-2a's "re-assert after the toggle" is satisfied by there being no toggle.
@@ -302,10 +362,12 @@ async function probeTable(client, q, table, args, uuid) {
       await q(`create policy ${POLICY_PREFIX}upd on ${table} for update to anon using (true) with check (true)`);
     }
 
-    const { rows: [v] } = await q(
-      'select v.id from ventures v where venture_exists_and_active(v.id) and not check_feedback_rate_limit(v.id) limit 1'
-    );
-    if (!v) return { code: EXIT.PROBE_INCONCLUSIVE, reason: 'no active venture satisfies the insert policy predicate' };
+    let ctx = null;
+    if (builder.preflight) {
+      const { rows: [v] } = await q(builder.preflight);
+      if (!v) return { code: EXIT.PROBE_INCONCLUSIVE, reason: 'no row satisfies the insert policy predicate — a probe row cannot be constructed' };
+      ctx = v.id;
+    }
 
     // telegram is the ONE source the RESTRICTIVE 50/hr ingress bound can actually bind on, because
     // it is the only anon-SELECT-covered source. Measure before trusting the control.
@@ -317,7 +379,7 @@ async function probeTable(client, q, table, args, uuid) {
 
     await q('set local role anon');
     const { rows: [p] } = await q('select pg_backend_pid() as pid');
-    const res = await runForms(q, table, { ventureId: v.id, subjectSource: args.subjectSource, controlSource: args.controlSource, uuid, basePid: p.pid });
+    const res = await runForms(q, table, { builder, ctx, subjectSource: args.subjectSource, controlSource: args.controlSource, uuid, basePid: p.pid });
 
     if (res.aborted) {
       const g = res.guards[res.guards.length - 1];
@@ -338,35 +400,66 @@ async function probeTable(client, q, table, args, uuid) {
 }
 
 export async function main(argv = process.argv.slice(2)) {
-  const args = parseArgs(argv);
-  const { randomUUID } = await import('node:crypto');
-  const client = await createDatabaseClient('ehg');
-  const q = (sql, params) => client.query(assertNotCommitFamily(sql), params);
+  let client = null;
   let worst = EXIT.OK;
   try {
+    const args = parseArgs(argv);
+    const { randomUUID } = await import('node:crypto');
+    // Inside the try: this throws when the DB password is absent, and outside it that surfaced as an
+    // unhandled rejection with no diagnostic and an exit code that never came from the EXIT map.
+    // DATABASE_URL is what CI actually has. Locally it is usually unset and the password path
+    // resolves instead; passing undefined leaves that path untouched.
+    client = await createDatabaseClient('ehg',
+      process.env.DATABASE_URL ? { connectionString: process.env.DATABASE_URL } : {});
+    const q = (sql, params) => client.query(assertNotCommitFamily(sql), params);
+
     let targets = args.table ? [args.table] : null;
     if (!targets) {
       const { rows } = await q(`select p.schemaname, p.tablename, p.roles::text[] as roles, p.cmd, p.qual, p.with_check,
                                        p.permissive, c.relrowsecurity
                                   from pg_policies p
                                   join pg_class c on c.oid = format('%I.%I', p.schemaname, p.tablename)::regclass`);
-      targets = discoverAsymmetricTables(rows);
-      console.log(`class members (anon can INSERT, no unconditional anon SELECT coverage): ${targets.join(', ') || '(none)'}`);
+      const candidates = discoverAsymmetricTables(rows);
+      const probable = candidates.filter((t) => ROW_BUILDERS[t]);
+      const unprobed = candidates.filter((t) => !ROW_BUILDERS[t]);
+      // Report the shortfall EXPLICITLY. A discovery step that silently probes the 1 table it has a
+      // builder for, out of the N it found, prints a clean pass and reads as "the class is covered".
+      // The count being large is a finding about this probe's reach, not a detail to round off.
+      console.log(`discovery: ${candidates.length} candidate(s) in the class; ${probable.length} have a row builder and WILL be asserted.`);
+      if (unprobed.length) {
+        console.log(`UNPROBED (${unprobed.length}) — in the class, contract NOT asserted, no row builder: ${unprobed.slice(0, 12).join(', ')}${unprobed.length > 12 ? `, +${unprobed.length - 12} more` : ''}`);
+        console.log('  A candidate is a table where anon holds a permissive INSERT policy and has no UNCONDITIONAL anon SELECT policy.');
+        console.log('  Some are false positives: a qual that is always-false for anon via a function (e.g. fn_is_chairman()) is not');
+        console.log('  statically distinguishable from one that is always-true. Add a ROW_BUILDERS entry to assert any of them.');
+      }
+      targets = probable;
     }
+
     for (const table of targets) {
-      const r = await probeTable(client, q, table, args, randomUUID);
+      // Per-table isolation. Without it the first target that throws aborts the whole run, and the
+      // tables after it — including the one this SD is actually about — are never probed at all.
+      let r;
+      try {
+        r = await probeTable(client, q, table, args, randomUUID);
+      } catch (err) {
+        r = { code: EXIT.ERROR, reason: `probe threw: ${err.message}` };
+      }
       console.log(`\n=== ${table} ===`);
       for (const [form, verdict] of Object.entries(r.observed || {})) {
         console.log(`  ${form.padEnd(24)} ${String(verdict).padEnd(10)} ${r.attributions?.[form] ?? ''}`);
       }
       console.log(`  -> [${Object.keys(EXIT).find((k) => EXIT[k] === r.code)}] ${r.reason}`);
-      if (r.code !== EXIT.OK) worst = worst === EXIT.OK ? r.code : worst;
+      if (r.code !== EXIT.OK && worst === EXIT.OK) worst = r.code;
+    }
+    if (!targets.length) {
+      console.log('no target had a row builder — nothing was asserted');
+      worst = EXIT.PROBE_INCONCLUSIVE;
     }
   } catch (err) {
     console.error(`probe error: ${err.message}`);
     worst = EXIT.ERROR;
   } finally {
-    await client.end().catch(() => {});
+    if (client) await client.end().catch(() => {});
   }
   return worst;
 }

--- a/scripts/anon-write-contract-probe.mjs
+++ b/scripts/anon-write-contract-probe.mjs
@@ -1,0 +1,375 @@
+#!/usr/bin/env node
+/**
+ * Anon write-contract probe — a standing assertion about what the anon role can and cannot
+ * write to tables whose RLS grants INSERT more broadly than SELECT.
+ * SD-LEO-INFRA-DEAD-VENTURE-USER-001.
+ *
+ * WHAT THIS EXISTS FOR. `public.feedback` accepts a bare anon INSERT, but refuses
+ * `INSERT ... RETURNING <target columns>` and `INSERT ... ON CONFLICT DO UPDATE`, both with 42501.
+ * The two refusals have DIFFERENT causes and conflating them teaches a false mechanism:
+ *   - RETURNING is subject to the SELECT policy, and anon's only SELECT policy here is telegram-only.
+ *   - ON CONFLICT DO UPDATE applies the UPDATE USING clause to the conflicting row as a
+ *     WithCheckOption, and anon has NO update policy at all (only service_role does). anon DOES hold
+ *     the UPDATE grant, so it is a policy denial, not an ACL denial.
+ *   - ON CONFLICT DO NOTHING needs neither policy and LANDS.
+ * No live caller is broken today: all five (in apexniche-ai, marketlens and ehg) send the bare form.
+ * This is regression prevention, not an outage repair — and the enforcement had to live HERE, at the
+ * database, because zero of those five callers live in this repo, so a source lint would see none.
+ *
+ * WHY IT IS SAFE TO RUN AGAINST PRODUCTION, which is the only database there is: the guarantee is
+ * COMMIT-NEVER-ISSUED, not ROLLBACK-in-finally. `query()` throws on any commit-family statement, and
+ * no COMMIT appears in this file. That framing matters — it means a connection drop, a throw inside a
+ * catch, and an early return before the finally block are ALL already safe. The finally-ROLLBACK is
+ * hygiene; stating it as the invariant would misplace where the safety actually comes from.
+ *
+ * THE FAILURE THIS FILE IS MOST GUARDED AGAINST is reporting a passing contract while testing
+ * nothing. If `SET LOCAL ROLE anon` fails to take effect, RLS is bypassed and every form LANDS. That
+ * is live here, not hypothetical: the connecting role is rolbypassrls=true AND rolsuper=false, so the
+ * obvious `is_superuser` guard reads clean while RLS is fully bypassed. Hence assertRlsInForce(),
+ * which leads with row_security_active() — false under owner, under BYPASSRLS, and under
+ * RLS-disabled alike — and runs before EVERY form rather than once at the top, because a
+ * transaction-mode pooler can land statements on different backends.
+ *
+ * Usage:
+ *   node scripts/anon-write-contract-probe.mjs                       # discover the class, probe each
+ *   node scripts/anon-write-contract-probe.mjs --table public.feedback
+ *   node scripts/anon-write-contract-probe.mjs --table public.feedback --control-grant-select
+ *   node scripts/anon-write-contract-probe.mjs --table public.feedback --control-grant-update
+ */
+
+import { createDatabaseClient } from './lib/supabase-connection.js';
+
+/** Distinct exit codes: a caller that cannot tell these apart treats inconclusive as a pass. */
+export const EXIT = {
+  OK: 0,
+  ERROR: 1,
+  CONTRACT_CHANGED: 2,
+  PROBE_MALFORMED: 3,
+  PROBE_INCONCLUSIVE: 4,
+  RLS_NOT_IN_FORCE: 5
+};
+
+/**
+ * The contract. LITERAL constants, deliberately never read from the database — a probe that derives
+ * its expectations from what it observes degrades into asserting whatever it last saw, which can
+ * never fail. If a sibling SD narrows anon INSERT, this probe SHOULD redden; that is the coupling.
+ */
+export const EXPECTED = Object.freeze({
+  bare_insert: 'LANDS',
+  returning_columns: 'REFUSED',
+  returning_literal: 'LANDS',
+  on_conflict_do_update: 'REFUSED',
+  // MEASURED, against the expectation this file originally shipped with. Reasoning from the docs
+  // said DO NOTHING needs no policy and would LAND; the first live run said REFUSED, with a FRESH
+  // id, so no collision ever occurred. The clause alone is sufficient. Recorded as measured rather
+  // than corrected-in-silence because the wrong value is the more intuitive one.
+  on_conflict_do_nothing: 'REFUSED',
+  positive_control: 'LANDS'
+});
+
+/** Pure. Returns the first differing form so a CI failure names what changed. */
+export function compare(observed, expected = EXPECTED) {
+  const keys = [...new Set([...Object.keys(expected), ...Object.keys(observed || {})])].sort();
+  const differingForms = keys.filter((k) => (observed || {})[k] !== expected[k]);
+  return { ok: differingForms.length === 0, differingForm: differingForms[0] ?? null, differingForms };
+}
+
+const normalizeQual = (q) => String(q ?? '').replace(/[\s()]/g, '').toLowerCase();
+/** `false` has several spellings and string-matching only one of them is how a guard goes quiet. */
+export function isAlwaysFalse(qual) {
+  return ['false', '1=0', 'null'].includes(normalizeQual(qual));
+}
+export function isAlwaysTrue(qual) {
+  return ['true', '1=1'].includes(normalizeQual(qual));
+}
+const rolesOf = (r) => (Array.isArray(r) ? r : String(r ?? '').replace(/[{}"]/g, '').split(',')).map((s) => String(s).trim());
+/** anon inherits PUBLIC. 228 policies on this database are TO PUBLIC — a roles @> '{anon}' filter
+ *  cannot see any of them, and would report a fully-covered table as an instance. */
+const anonReachable = (r) => { const x = rolesOf(r); return x.includes('anon') || x.includes('public'); };
+const isPermissive = (p) => String(p ?? 'PERMISSIVE').toUpperCase() === 'PERMISSIVE';
+
+/**
+ * Pure. Given pg_policies rows (joined with pg_class.relrowsecurity), return the tables in the
+ * defect class, sorted.
+ *
+ * A table is an instance when anon can actually INSERT and has NO unconditional SELECT coverage.
+ * Exact row-level coverage is statically undecidable — `USING (source_type = 'telegram')` covers
+ * some inserted rows and not others — so the rule is deliberately asymmetric: strict on the SELECT
+ * side (only an unconditional permissive SELECT policy counts as full coverage, because a
+ * conditional one MAY leave a gap) and conservative on the INSERT side (a with_check of false means
+ * anon cannot insert at all, so there is no trap). That second half is what correctly excludes the
+ * symmetric anon-deny tables, which would otherwise be reported for having a `false` SELECT policy.
+ *
+ * RESTRICTIVE policies never GRANT anything, so they cannot supply coverage — and `feedback` carries
+ * a RESTRICTIVE anon INSERT policy, so counting them would get this table wrong in both directions.
+ */
+export function discoverAsymmetricTables(policyRows = []) {
+  const tables = new Map();
+  for (const r of policyRows) {
+    const key = `${r.schemaname}.${r.tablename}`;
+    if (!tables.has(key)) tables.set(key, { key, rls: true, canInsert: false, fullSelect: false });
+    const t = tables.get(key);
+    if (r.relrowsecurity === false) t.rls = false;
+    if (!anonReachable(r.roles) || !isPermissive(r.permissive)) continue;
+    const cmd = String(r.cmd ?? '').toUpperCase();
+    if ((cmd === 'INSERT' || cmd === 'ALL') && !isAlwaysFalse(r.with_check)) t.canInsert = true;
+    if ((cmd === 'SELECT' || cmd === 'ALL') && isAlwaysTrue(r.qual)) t.fullSelect = true;
+  }
+  return [...tables.values()].filter((t) => t.rls && t.canInsert && !t.fullSelect).map((t) => t.key).sort();
+}
+
+/** A guard the caller cannot satisfy without changing the harm. RELEASE SAVEPOINT is included and
+ *  deliberately never used below — savepoints are discarded by the outer ROLLBACK anyway. */
+const COMMIT_FAMILY = /^\s*(commit|end|prepare\s+transaction|release\s+savepoint)\b/i;
+export function assertNotCommitFamily(sql) {
+  if (COMMIT_FAMILY.test(sql)) throw new Error(`COMMIT_FAMILY_STATEMENT_BLOCKED: ${String(sql).slice(0, 60)}`);
+  return sql;
+}
+
+/** Five independent ways RLS can be silently inert. Any one of them makes every verdict a lie. */
+export async function assertRlsInForce(q, table, basePid) {
+  const { rows: [r] } = await q(
+    `select current_user::text                                              as usr,
+            (select rolbypassrls from pg_roles where rolname = current_user) as bypass,
+            current_setting('row_security')                                  as rowsec,
+            row_security_active($1::regclass)                                as active,
+            (select relrowsecurity from pg_class where oid = $1::regclass)   as relrls,
+            pg_backend_pid()                                                 as pid,
+            inet_server_port()                                               as port`,
+    [table]
+  );
+  const problems = [];
+  if (r.usr !== 'anon') problems.push(`current_user=${r.usr}`);
+  if (r.bypass === true) problems.push('rolbypassrls=true');
+  if (r.rowsec !== 'on') problems.push(`row_security=${r.rowsec}`);
+  if (r.active !== true) problems.push('row_security_active=false');
+  if (r.relrls !== true) problems.push('relrowsecurity=false');
+  if (basePid != null && r.pid !== basePid) problems.push(`backend_pid ${basePid}->${r.pid}`);
+  return { ok: problems.length === 0, problems, pid: r.pid, port: r.port };
+}
+
+/** 42501 collapses at least five mechanisms onto one token; the whole LEAD investigation on this SD
+ *  was misled by that collapse. Never let the bare code stand as the verdict's explanation. */
+export async function attributeRefusal(q, table, form, err) {
+  if (err?.code !== '42501') return null;
+  const priv = form.startsWith('on_conflict') ? 'UPDATE' : form === 'bare_insert' ? 'INSERT' : 'SELECT';
+  try {
+    const { rows: [p] } = await q('select has_table_privilege(current_user, $1::regclass, $2) as ok', [table, priv]);
+    if (p?.ok === false) return `GRANT_DENIED(${priv})`;
+  } catch { return 'UNATTRIBUTED'; }
+  switch (form) {
+    case 'returning_columns':      return 'POLICY_DENIED(select_policy_on_returning_readback)';
+    case 'on_conflict_do_update':  return 'POLICY_DENIED(absent_anon_update_policy_via_conflict_row_withcheckoption)';
+    // MEASURED, and it corrected the expectation this probe shipped with: DO NOTHING is refused
+    // even with a FRESH id, so no collision ever occurs — the clause alone is sufficient. The cause
+    // is the SELECT policy, established by control rather than by argument: --control-grant-select
+    // flips this form AND returning_columns while leaving on_conflict_do_update refused.
+    case 'on_conflict_do_nothing': return 'POLICY_DENIED(select_policy_on_arbiter_check, planned regardless of collision)';
+    case 'bare_insert':            return 'POLICY_DENIED(insert_with_check)';
+    default:                       return 'UNATTRIBUTED';
+  }
+}
+
+/** Pre-RLS rejections are NOT contract verdicts. The acceptance battery this SD also repairs was
+ *  voided four times by exactly this, then committed the same defect at its own line 188. */
+export function classifyError(err) {
+  if (!err) return 'LANDS';
+  if (err.code === '42501') return 'REFUSED';
+  if (['23502', '23514', '23505', '23503'].includes(err.code)) return 'MALFORMED';
+  return 'ERROR';
+}
+
+/**
+ * Run one form and UNDO IT, whatever the outcome.
+ *
+ * The rollback-on-success half is not tidiness — it is what makes the forms independent, and its
+ * absence produced a false REFUSED on the first live run. `venture_user_insert_feedback`'s WITH
+ * CHECK calls check_feedback_rate_limit(venture_id), so every form that LANDS pushes the venture
+ * closer to its limit and changes the conditions the NEXT form is judged under. Leaving successes in
+ * place makes each verdict depend on how many earlier forms succeeded — a probe whose cells are
+ * coupled, which is the same defect that confounded this SD's original 2x2 one layer up.
+ */
+async function attempt(q, name, sql, params) {
+  const sp = `sp_${name}`;
+  await q(`SAVEPOINT ${sp}`);
+  try {
+    await q(sql, params);
+    await q(`ROLLBACK TO SAVEPOINT ${sp}`);
+    return { verdict: 'LANDS' };
+  } catch (err) {
+    await q(`ROLLBACK TO SAVEPOINT ${sp}`);
+    const verdict = classifyError(err);
+    return { verdict, code: err.code, constraint: err.constraint ?? null, detail: err.message };
+  }
+}
+
+const COLS = '(id, venture_id, feedback_type, source_type, source_application, title, type)';
+const VALS = '($1, $2, $3, $4, $5, $6, $7)';
+const row = (id, v, src, ft = 'user_bug') => [id, v, ft, src, 'anon-write-contract-probe', `probe ${id}`, 'issue'];
+
+export async function runForms(q, table, { ventureId, subjectSource, controlSource, uuid, basePid }) {
+  const observed = {}, attributions = {}, guards = [];
+  const check = async (label) => {
+    const g = await assertRlsInForce(q, table, basePid);
+    guards.push({ label, ...g });
+    return g.ok;
+  };
+  const forms = [
+    ['bare_insert',           `insert into ${table} ${COLS} values ${VALS}`,                                    () => row(uuid(), ventureId, subjectSource)],
+    ['returning_columns',     `insert into ${table} ${COLS} values ${VALS} returning id, title`,                 () => row(uuid(), ventureId, subjectSource)],
+    ['returning_literal',     `insert into ${table} ${COLS} values ${VALS} returning 1`,                         () => row(uuid(), ventureId, subjectSource)],
+    ['on_conflict_do_nothing',`insert into ${table} ${COLS} values ${VALS} on conflict (id) do nothing`,         () => row(uuid(), ventureId, subjectSource)],
+    ['positive_control',      `insert into ${table} ${COLS} values ${VALS} returning id`,                        () => row(uuid(), ventureId, controlSource)]
+  ];
+  for (const [name, sql, mk] of forms) {
+    if (!(await check(name))) return { observed, attributions, guards, aborted: name };
+    const r = await attempt(q, name, sql, mk());
+    observed[name] = r.verdict;
+    if (r.code) attributions[name] = (await attributeRefusal(q, table, name, r)) ?? `${r.verdict}(${r.code}${r.constraint ? ' ' + r.constraint : ''})`;
+  }
+  // ON CONFLICT DO UPDATE only evaluates the conflict-row WithCheckOption when a conflict ACTUALLY
+  // occurs. With a fresh uuid none fires and the statement is an ordinary insert — a vacuous cell.
+  // So seed the id bare first, then collide with it.
+  if (!(await check('on_conflict_do_update'))) return { observed, attributions, guards, aborted: 'on_conflict_do_update' };
+  // The seed and the collision share ONE savepoint scope: the seed must still be visible when the
+  // collision runs (a fresh uuid never conflicts, and DO UPDATE only evaluates the conflict-row
+  // WithCheckOption when a conflict actually occurs), but the pair must still leave nothing behind.
+  const seed = uuid();
+  const sp = 'sp_occ';
+  let pending = null;
+  await q(`SAVEPOINT ${sp}`);
+  try {
+    await q(`insert into ${table} ${COLS} values ${VALS}`, row(seed, ventureId, subjectSource));
+    try {
+      await q(`insert into ${table} ${COLS} values ${VALS} on conflict (id) do update set title = excluded.title`,
+        row(seed, ventureId, subjectSource));
+      observed.on_conflict_do_update = 'LANDS';
+    } catch (err) {
+      // Attribution is deferred to AFTER the savepoint rollback below: once a statement errors, the
+      // transaction is in an aborted state and every further query returns 25P02, so an attribution
+      // query issued here silently degrades to UNATTRIBUTED for every refusal.
+      observed.on_conflict_do_update = classifyError(err);
+      pending = err;
+    }
+  } catch (seedErr) {
+    // Not a contract verdict: without a landed seed no conflict is forced and the cell is vacuous.
+    observed.on_conflict_do_update = 'MALFORMED';
+    attributions.on_conflict_do_update = `seed row did not land (${seedErr.code}) — conflict never forced, cell vacuous`;
+  } finally {
+    await q(`ROLLBACK TO SAVEPOINT ${sp}`);
+  }
+  if (pending) {
+    attributions.on_conflict_do_update = (await attributeRefusal(q, table, 'on_conflict_do_update', pending))
+      ?? `${observed.on_conflict_do_update}(${pending.code}${pending.constraint ? ' ' + pending.constraint : ''})`;
+  }
+  return { observed, attributions, guards, aborted: null };
+}
+
+function parseArgs(argv) {
+  const a = { table: null, grantSelect: false, grantUpdate: false, subjectSource: 'manual_feedback', controlSource: 'telegram' };
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === '--table') a.table = argv[++i];
+    else if (argv[i] === '--control-grant-select') a.grantSelect = true;
+    else if (argv[i] === '--control-grant-update') a.grantUpdate = true;
+    else if (argv[i] === '--subject-source') a.subjectSource = argv[++i];
+  }
+  if (a.table && !a.table.includes('.')) a.table = `public.${a.table}`;
+  return a;
+}
+
+const POLICY_PREFIX = 'zz_probe_ctl_';
+
+async function probeTable(client, q, table, args, uuid) {
+  const control = args.grantSelect || args.grantUpdate;
+  await q('BEGIN');
+  try {
+    // Prove BEGIN actually opened a transaction. Autocommit is the un-greppable commit and the
+    // realistic breach — a static grep for COMMIT cannot see it. In autocommit every statement is
+    // its own transaction, so now() (transaction start) equals statement_timestamp(); inside a real
+    // multi-statement transaction the second statement onward makes them diverge.
+    await q('select 1');
+    const { rows: [tx] } = await q('select now() <> statement_timestamp() as in_tx');
+    if (tx?.in_tx !== true) throw new Error('NOT_IN_TRANSACTION: BEGIN did not open a transaction — refusing to issue any write');
+    await q("set local statement_timeout = '30s'");
+    await q("set local idle_in_transaction_session_timeout = '60s'");
+
+    // Owner-privileged setup happens BEFORE dropping to anon, so there is no mid-run role toggle to
+    // leak back across. FR-2a's "re-assert after the toggle" is satisfied by there being no toggle.
+    if (args.grantSelect || args.grantUpdate) {
+      await q(`create policy ${POLICY_PREFIX}sel on ${table} for select to anon using (true)`);
+    }
+    if (args.grantUpdate) {
+      await q(`create policy ${POLICY_PREFIX}upd on ${table} for update to anon using (true) with check (true)`);
+    }
+
+    const { rows: [v] } = await q(
+      'select v.id from ventures v where venture_exists_and_active(v.id) and not check_feedback_rate_limit(v.id) limit 1'
+    );
+    if (!v) return { code: EXIT.PROBE_INCONCLUSIVE, reason: 'no active venture satisfies the insert policy predicate' };
+
+    // telegram is the ONE source the RESTRICTIVE 50/hr ingress bound can actually bind on, because
+    // it is the only anon-SELECT-covered source. Measure before trusting the control.
+    const { rows: [c] } = await q(
+      `select count(*)::int as n from ${table} where source_type = $1 and created_at > now() - interval '1 hour'`,
+      [args.controlSource]
+    );
+    if (c && c.n >= 50) return { code: EXIT.PROBE_INCONCLUSIVE, reason: `${args.controlSource} last hour = ${c.n} (>=50): the ingress bound may bind, so a REFUSED control would be ambiguous` };
+
+    await q('set local role anon');
+    const { rows: [p] } = await q('select pg_backend_pid() as pid');
+    const res = await runForms(q, table, { ventureId: v.id, subjectSource: args.subjectSource, controlSource: args.controlSource, uuid, basePid: p.pid });
+
+    if (res.aborted) {
+      const g = res.guards[res.guards.length - 1];
+      return { code: EXIT.RLS_NOT_IN_FORCE, reason: `RLS not in force before "${res.aborted}": ${g.problems.join(', ')}`, guards: res.guards };
+    }
+    const malformed = Object.entries(res.observed).filter(([, v2]) => v2 === 'MALFORMED' || v2 === 'ERROR');
+    if (malformed.length) {
+      return { code: EXIT.PROBE_MALFORMED, reason: `pre-RLS rejection, not a contract verdict: ${malformed.map(([k]) => `${k}=${res.attributions[k]}`).join('; ')}`, ...res };
+    }
+    const cmp = compare(res.observed);
+    if (control) {
+      return { code: EXIT.CONTRACT_CHANGED, reason: `control mode: ${cmp.ok ? 'NO FLIP OBSERVED — the control proved nothing' : `flipped ${cmp.differingForms.join(', ')}`}`, control: true, flipped: cmp.differingForms, ...res };
+    }
+    return { code: cmp.ok ? EXIT.OK : EXIT.CONTRACT_CHANGED, reason: cmp.ok ? 'contract holds' : `CONTRACT CHANGED at ${cmp.differingForm}`, ...res };
+  } finally {
+    await q('ROLLBACK');
+  }
+}
+
+export async function main(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  const { randomUUID } = await import('node:crypto');
+  const client = await createDatabaseClient('ehg');
+  const q = (sql, params) => client.query(assertNotCommitFamily(sql), params);
+  let worst = EXIT.OK;
+  try {
+    let targets = args.table ? [args.table] : null;
+    if (!targets) {
+      const { rows } = await q(`select p.schemaname, p.tablename, p.roles::text[] as roles, p.cmd, p.qual, p.with_check,
+                                       p.permissive, c.relrowsecurity
+                                  from pg_policies p
+                                  join pg_class c on c.oid = format('%I.%I', p.schemaname, p.tablename)::regclass`);
+      targets = discoverAsymmetricTables(rows);
+      console.log(`class members (anon can INSERT, no unconditional anon SELECT coverage): ${targets.join(', ') || '(none)'}`);
+    }
+    for (const table of targets) {
+      const r = await probeTable(client, q, table, args, randomUUID);
+      console.log(`\n=== ${table} ===`);
+      for (const [form, verdict] of Object.entries(r.observed || {})) {
+        console.log(`  ${form.padEnd(24)} ${String(verdict).padEnd(10)} ${r.attributions?.[form] ?? ''}`);
+      }
+      console.log(`  -> [${Object.keys(EXIT).find((k) => EXIT[k] === r.code)}] ${r.reason}`);
+      if (r.code !== EXIT.OK) worst = worst === EXIT.OK ? r.code : worst;
+    }
+  } catch (err) {
+    console.error(`probe error: ${err.message}`);
+    worst = EXIT.ERROR;
+  } finally {
+    await client.end().catch(() => {});
+  }
+  return worst;
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/').split('/').pop());
+if (invokedDirectly) main().then((code) => process.exit(code));

--- a/scripts/anon-write-contract-probe.mjs
+++ b/scripts/anon-write-contract-probe.mjs
@@ -11,7 +11,9 @@
  *   - ON CONFLICT DO UPDATE applies the UPDATE USING clause to the conflicting row as a
  *     WithCheckOption, and anon has NO update policy at all (only service_role does). anon DOES hold
  *     the UPDATE grant, so it is a policy denial, not an ACL denial.
- *   - ON CONFLICT DO NOTHING needs neither policy and LANDS.
+ *   - ON CONFLICT DO NOTHING is ALSO refused, by the SELECT policy on the arbiter check — measured
+ *     with a fresh id, so no collision ever occurs. The clause alone is sufficient. This file
+ *     originally asserted it LANDS, reasoning from the docs; the first live run said otherwise.
  * No live caller is broken today: all five (in apexniche-ai, marketlens and ehg) send the bare form.
  * This is regression prevention, not an outage repair — and the enforcement had to live HERE, at the
  * database, because zero of those five callers live in this repo, so a source lint would see none.
@@ -316,6 +318,47 @@ export async function runForms(q, table, { builder, ctx, subjectSource, controlS
   return { observed, attributions, guards, aborted: null };
 }
 
+/**
+ * FR-7. A RESTRICTIVE bound that cannot bind, asserted rather than argued.
+ *
+ * `anon_feedback_ingress_bounds` counts prior rows with an INLINE SUBQUERY, and an inline subquery
+ * in a policy runs as the INSERTING role — so the count is itself subject to the telegram-only
+ * SELECT policy. As anon the basis is n=1 for every non-telegram source and the limit is
+ * arithmetically incapable of binding. SECURITY DEFINER is what that basis lacks.
+ *
+ * Do NOT confuse this with `check_feedback_rate_limit(venture_id)`, which the insert policy also
+ * calls: that one IS SECURITY DEFINER and does bind. Conflating them files a bug against a control
+ * that works — which is why the two bases are measured separately here and both are reported.
+ *
+ * The non-vacuity guard is the point: an empty table would make the two bases agree at zero and
+ * pass this check for entirely the wrong reason.
+ */
+export async function assertIngressBoundCannotBind(q, table, source) {
+  const { rows: [pol] } = await q(
+    `select permissive, qual, with_check from pg_policies
+      where schemaname = split_part($1,'.',1) and tablename = split_part($1,'.',2)
+        and policyname = 'anon_feedback_ingress_bounds'`, [table]);
+  if (!pol) return { applicable: false, note: 'anon_feedback_ingress_bounds is absent — the finding may already be remediated, or the policy renamed' };
+
+  const countSql = `select count(*)::int as n from ${table} where source_type = $1 and created_at > now() - interval '1 hour'`;
+  const { rows: [definer] } = await q(countSql, [source]);   // still the owner here
+  await q('savepoint sp_bound');
+  await q('set local role anon');
+  const { rows: [asAnon] } = await q(countSql, [source]);
+  await q('reset role');
+  await q('rollback to savepoint sp_bound');
+
+  return {
+    applicable: true,
+    restrictive: String(pol.permissive).toUpperCase() === 'RESTRICTIVE',
+    definerBasis: definer.n,
+    anonBasis: asAnon.n,
+    // Non-vacuity: without this, a source with no recent rows agrees at 0 and "passes".
+    vacuous: definer.n <= 1,
+    cannotBind: definer.n > 1 && asAnon.n <= 1
+  };
+}
+
 function parseArgs(argv) {
   const a = { table: null, grantSelect: false, grantUpdate: false, subjectSource: 'manual_feedback', controlSource: 'telegram' };
   for (let i = 0; i < argv.length; i++) {
@@ -377,6 +420,13 @@ async function probeTable(client, q, table, args, uuid) {
     );
     if (c && c.n >= 50) return { code: EXIT.PROBE_INCONCLUSIVE, reason: `${args.controlSource} last hour = ${c.n} (>=50): the ingress bound may bind, so a REFUSED control would be ambiguous` };
 
+    // FR-7, measured before dropping to anon so the definer-side basis is readable.
+    let bound = null;
+    if (!control) {
+      try { bound = await assertIngressBoundCannotBind(q, table, args.subjectSource); }
+      catch (e) { bound = { applicable: false, note: `not measurable: ${e.message}` }; }
+    }
+
     await q('set local role anon');
     const { rows: [p] } = await q('select pg_backend_pid() as pid');
     const res = await runForms(q, table, { builder, ctx, subjectSource: args.subjectSource, controlSource: args.controlSource, uuid, basePid: p.pid });
@@ -390,6 +440,7 @@ async function probeTable(client, q, table, args, uuid) {
       return { code: EXIT.PROBE_MALFORMED, reason: `pre-RLS rejection, not a contract verdict: ${malformed.map(([k]) => `${k}=${res.attributions[k]}`).join('; ')}`, ...res };
     }
     const cmp = compare(res.observed);
+    res.bound = bound;
     if (control) {
       return { code: EXIT.CONTRACT_CHANGED, reason: `control mode: ${cmp.ok ? 'NO FLIP OBSERVED — the control proved nothing' : `flipped ${cmp.differingForms.join(', ')}`}`, control: true, flipped: cmp.differingForms, ...res };
     }
@@ -447,6 +498,15 @@ export async function main(argv = process.argv.slice(2)) {
       console.log(`\n=== ${table} ===`);
       for (const [form, verdict] of Object.entries(r.observed || {})) {
         console.log(`  ${form.padEnd(24)} ${String(verdict).padEnd(10)} ${r.attributions?.[form] ?? ''}`);
+      }
+      if (r.bound?.applicable) {
+        const b = r.bound;
+        console.log(`  ingress-bound  RESTRICTIVE=${b.restrictive} definer-basis=${b.definerBasis} anon-basis=${b.anonBasis}` +
+          (b.vacuous ? '  [VACUOUS — too few recent rows to tell, not a pass]'
+                     : b.cannotBind ? '  [CANNOT BIND — the inline subquery counts as anon]'
+                                    : '  [binds, or the basis changed]'));
+      } else if (r.bound) {
+        console.log(`  ingress-bound  ${r.bound.note}`);
       }
       console.log(`  -> [${Object.keys(EXIT).find((k) => EXIT[k] === r.code)}] ${r.reason}`);
       if (r.code !== EXIT.OK && worst === EXIT.OK) worst = r.code;

--- a/tests/unit/anon-write-contract-probe.test.js
+++ b/tests/unit/anon-write-contract-probe.test.js
@@ -1,0 +1,297 @@
+/**
+ * Standing unit tier for the anon write-contract probe. SD-LEO-INFRA-DEAD-VENTURE-USER-001.
+ *
+ * NO DATABASE. That is deliberate and load-bearing: the vitest `db` project on this repo currently
+ * has an empty DESIGNATED_NON_PROD_REFS, so assessDbTarget returns {allowed:false} and every test
+ * placed there SKIPS — and a skip reports green. A live-tier test would be permanently, silently
+ * inert. Everything that can be proven without a connection is proven here instead, and CI invokes
+ * the probe binary directly so its exit code is the gate.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import {
+  EXPECTED, EXIT, compare, discoverAsymmetricTables,
+  isAlwaysFalse, isAlwaysTrue, assertNotCommitFamily, classifyError, assertRlsInForce
+} from '../../scripts/anon-write-contract-probe.mjs';
+
+const REPO = join(import.meta.dirname, '..', '..');
+const PROBE = join(REPO, 'scripts', 'anon-write-contract-probe.mjs');
+
+/**
+ * Strip comments before asserting on source. Found the hard way: the first draft of the two
+ * assertions below matched the PROSE THAT NARRATES THE CODE — a file whose comment says "no
+ * continue-on-error here" failed a /continue-on-error/ check, and the FR-4 fix failed its own
+ * "never sends user_general" check because the comment explaining the fix names the old value.
+ * A source assertion that cannot tell code from the commentary about code reports on the wrong text.
+ */
+const codeOf = (path, style = 'js') => readFileSync(path, 'utf8').split('\n')
+  .filter((l) => (style === 'yaml' ? !/^\s*#/.test(l) : !/^\s*(\/\/|\*|\/\*)/.test(l)))
+  .join('\n');
+
+describe('EXPECTED / compare — the standing mutation harness (TS-8)', () => {
+  // A mutation harness that cannot prove it mutated is hollow: a deep-clone that silently failed to
+  // change anything passes vacuously and reports the suite as protective.
+  it('baseline: an unmutated observation matches — the positive control', () => {
+    expect(compare({ ...EXPECTED })).toEqual({ ok: true, differingForm: null, differingForms: [] });
+  });
+
+  for (const key of Object.keys(EXPECTED)) {
+    it(`mutating ${key} reddens compare(), and the mutation provably landed`, () => {
+      const mutant = { ...EXPECTED, [key]: EXPECTED[key] === 'LANDS' ? 'REFUSED' : 'LANDS' };
+      const differingKeys = Object.keys(EXPECTED).filter((k) => mutant[k] !== EXPECTED[k]);
+      expect(differingKeys).toEqual([key]);          // proof the mutation landed, in exactly one key
+
+      const r = compare(mutant);
+      expect(r.ok).toBe(false);
+      expect(r.differingForm).toBe(key);             // also pins FR-6: the failure names the form
+    });
+  }
+
+  it('mutating the OBSERVATION side is caught too, not just the expectation side', () => {
+    const observed = { ...EXPECTED, returning_columns: 'LANDS' };
+    expect(compare(observed, EXPECTED).differingForm).toBe('returning_columns');
+  });
+
+  it('an observation missing a form is a failure, not a pass', () => {
+    const { positive_control, ...partial } = EXPECTED;
+    expect(compare(partial).ok).toBe(false);
+    expect(compare(partial).differingForms).toContain('positive_control');
+  });
+
+  // Both upsert forms are refused, and it is worth pinning WHY they are listed separately: they are
+  // refused by DIFFERENT policies, established by control on the live database, not by argument.
+  //   --control-grant-select  flips returning_columns + on_conflict_do_nothing, leaves DO UPDATE refused
+  //   --control-grant-update  additionally flips on_conflict_do_update
+  // The cell that stays refused under the first control is what proves the flip is a policy change
+  // and not RLS quietly switching off — the simultaneous negative FR-2 requires, supplied by data.
+  // THE MUTATION HARNESS ABOVE CANNOT CATCH A WRONG `EXPECTED`: it mutates relative to EXPECTED, so
+  // flipping EXPECTED itself moves both sides and every relative test still passes. This literal pin
+  // is what bites, and the live probe in CI is what would have caught the value being wrong in the
+  // first place — which is exactly how on_conflict_do_nothing got corrected.
+  it('pins every contract value literally — the one assertion a self-relative harness cannot make', () => {
+    expect(EXPECTED).toEqual({
+      bare_insert: 'LANDS',
+      returning_columns: 'REFUSED',
+      returning_literal: 'LANDS',
+      on_conflict_do_update: 'REFUSED',
+      on_conflict_do_nothing: 'REFUSED',
+      positive_control: 'LANDS'
+    });
+  });
+
+  it('the two upsert forms are distinct keys, so a control can flip one without the other', () => {
+    expect(Object.keys(EXPECTED)).toEqual(expect.arrayContaining(['on_conflict_do_nothing', 'on_conflict_do_update']));
+    const onlyDoNothingFlipped = { ...EXPECTED, on_conflict_do_nothing: 'LANDS' };
+    expect(compare(onlyDoNothingFlipped).differingForms).toEqual(['on_conflict_do_nothing']);
+  });
+});
+
+describe('discoverAsymmetricTables (TS-7) — over-reporting is as bad as under-reporting', () => {
+  const p = (tablename, cmd, o = {}) => ({
+    schemaname: 'public', tablename, cmd, roles: '{anon}', permissive: 'PERMISSIVE',
+    qual: null, with_check: null, relrowsecurity: true, ...o
+  });
+
+  // Mirrors the live shape measured during PLAN.
+  const LIVE = [
+    p('feedback', 'INSERT', { with_check: "(feedback_type ~~ 'user_%'::text)" }),
+    p('feedback', 'INSERT', { with_check: '(count_ok)', permissive: 'RESTRICTIVE' }),
+    p('feedback', 'SELECT', { qual: "(source_type = 'telegram'::text)" }),
+    p('marketing_attribution', 'INSERT', { with_check: '(true)' }),
+    p('protocol_improvement_queue', 'INSERT', { with_check: 'false' }),
+    p('protocol_improvement_queue', 'SELECT', { qual: 'false' }),
+    p('security_audit_events', 'INSERT', { with_check: 'false' }),
+    p('security_audit_events', 'SELECT', { qual: 'false' })
+  ];
+
+  it('deep-equals the sorted instance list — a `contains` assertion could never catch over-reporting', () => {
+    expect(discoverAsymmetricTables(LIVE)).toEqual(['public.feedback', 'public.marketing_attribution']);
+  });
+
+  it('a TO PUBLIC unconditional SELECT counts as coverage (228 live policies are TO PUBLIC)', () => {
+    const rows = [p('t', 'INSERT', { with_check: '(true)' }), p('t', 'SELECT', { roles: '{public}', qual: 'true' })];
+    expect(discoverAsymmetricTables(rows)).toEqual([]);
+  });
+
+  it('a RESTRICTIVE SELECT policy never grants coverage', () => {
+    const rows = [p('t', 'INSERT', { with_check: '(true)' }), p('t', 'SELECT', { qual: 'true', permissive: 'RESTRICTIVE' })];
+    expect(discoverAsymmetricTables(rows)).toEqual(['public.t']);
+  });
+
+  it('relrowsecurity=false is not an instance — there is no policy to gap', () => {
+    expect(discoverAsymmetricTables([p('t', 'INSERT', { with_check: '(true)', relrowsecurity: false })])).toEqual([]);
+  });
+
+  it.each(['false', '(1=0)', '(NULL)'])('an INSERT with_check of %s means anon cannot insert at all', (spelling) => {
+    expect(discoverAsymmetricTables([p('t', 'INSERT', { with_check: spelling })])).toEqual([]);
+  });
+
+  it('a table added AFTER authoring time is discovered — discovery is not a disguised hardcoded list', () => {
+    const rows = [...LIVE, p('some_table_that_did_not_exist_yet', 'INSERT', { with_check: '(true)' })];
+    expect(discoverAsymmetricTables(rows)).toEqual([
+      'public.feedback', 'public.marketing_attribution', 'public.some_table_that_did_not_exist_yet'
+    ]);
+  });
+
+  it('a policy TO service_role only is not anon-reachable', () => {
+    expect(discoverAsymmetricTables([p('t', 'INSERT', { with_check: '(true)', roles: '{service_role}' })])).toEqual([]);
+  });
+
+  it('isAlwaysFalse/isAlwaysTrue handle the spellings that defeat string matching', () => {
+    for (const f of ['false', '(false)', ' 1=0 ', '(1 = 0)', 'NULL']) expect(isAlwaysFalse(f)).toBe(true);
+    for (const t of ['true', '(true)', '(1 = 1)']) expect(isAlwaysTrue(t)).toBe(true);
+    expect(isAlwaysFalse("(source_type = 'telegram')")).toBe(false);
+    expect(isAlwaysTrue("(source_type = 'telegram')")).toBe(false);
+  });
+});
+
+describe('safety: COMMIT is never issued (TS-4)', () => {
+  it.each(['COMMIT', 'commit;', '  End ', 'PREPARE TRANSACTION \'x\'', 'release savepoint sp'])(
+    'the runtime guard throws on %s — a guard the caller cannot satisfy without changing the harm',
+    (sql) => { expect(() => assertNotCommitFamily(sql)).toThrow(/COMMIT_FAMILY_STATEMENT_BLOCKED/); }
+  );
+
+  it('ordinary statements pass through unchanged', () => {
+    for (const sql of ['BEGIN', 'ROLLBACK', 'SAVEPOINT sp', 'select 1', 'insert into t values (1)']) {
+      expect(assertNotCommitFamily(sql)).toBe(sql);
+    }
+  });
+
+  it('SECONDARY pin only: no literal COMMIT in the source. Theatre against autocommit — the runtime guard above is the real one', () => {
+    const src = readFileSync(PROBE, 'utf8');
+    const executable = src.split('\n').filter((l) => !/^\s*(\*|\/\/|\/\*)/.test(l)).join('\n');
+    expect(executable).not.toMatch(/\bq\(\s*['"`]\s*commit/i);
+  });
+
+  it('the probe asserts it is really inside a transaction — autocommit is the un-greppable commit', () => {
+    expect(readFileSync(PROBE, 'utf8')).toMatch(/NOT_IN_TRANSACTION/);
+  });
+});
+
+describe('RLS-in-force guard (TS-5) — the cannot-fail case', () => {
+  const base = { usr: 'anon', bypass: false, rowsec: 'on', active: true, relrls: true, pid: 42, port: 5432 };
+  const q = (over) => async () => ({ rows: [{ ...base, ...over }] });
+
+  it('passes only when all five conditions hold', async () => {
+    expect((await assertRlsInForce(q({}), 'public.feedback', 42)).ok).toBe(true);
+  });
+
+  // Each failure asserted SEPARATELY: a single combined case cannot prove each guard fires on its own.
+  it.each([
+    ['current_user is not anon',        { usr: 'postgres' }, /current_user=postgres/],
+    ['the role can BYPASSRLS',          { bypass: true },    /rolbypassrls=true/],
+    ['row_security is off',             { rowsec: 'off' },   /row_security=off/],
+    ['row_security_active is false',    { active: false },   /row_security_active=false/],
+    ['relrowsecurity is false',         { relrls: false },   /relrowsecurity=false/],
+    ['the pooler moved us to a new backend', { pid: 99 },    /backend_pid 42->99/]
+  ])('fails when %s', async (_label, over, re) => {
+    const r = await assertRlsInForce(q(over), 'public.feedback', 42);
+    expect(r.ok).toBe(false);
+    expect(r.problems.join(' ')).toMatch(re);
+  });
+
+  it('BYPASSRLS with rolsuper=false is caught — the live shape of this connection, where an is_superuser check reads clean', async () => {
+    const r = await assertRlsInForce(q({ usr: 'anon', bypass: true, active: false }), 'public.feedback', 42);
+    expect(r.ok).toBe(false);
+    expect(r.problems).toContain('rolbypassrls=true');
+    expect(r.problems).toContain('row_security_active=false');
+  });
+});
+
+describe('error classification (TS-6) — a pre-RLS rejection is not a contract verdict', () => {
+  it.each([
+    ['23502', 'MALFORMED'], ['23514', 'MALFORMED'], ['23505', 'MALFORMED'], ['23503', 'MALFORMED'],
+    ['42501', 'REFUSED'], ['08006', 'ERROR']
+  ])('%s classifies as %s', (code, verdict) => { expect(classifyError({ code })).toBe(verdict); });
+
+  it('no error means the write landed', () => { expect(classifyError(null)).toBe('LANDS'); });
+
+  it('the probe row carries every NOT NULL column — the defect this SD also repairs, not re-commits', () => {
+    const src = readFileSync(PROBE, 'utf8');
+    for (const col of ['source_application', 'source_type', 'title', 'type', 'venture_id']) {
+      expect(src).toMatch(new RegExp(`\\b${col}\\b`));
+    }
+    expect(src).toMatch(/venture_exists_and_active/);
+    expect(src).toMatch(/check_feedback_rate_limit/);
+  });
+});
+
+describe('exit codes (TS-13) — a caller that cannot tell these apart treats inconclusive as a pass', () => {
+  it('every outcome has a distinct code', () => {
+    const codes = Object.values(EXIT);
+    expect(new Set(codes).size).toBe(codes.length);
+    expect(EXIT.OK).toBe(0);
+    for (const [k, v] of Object.entries(EXIT)) if (k !== 'OK') expect(v).not.toBe(0);
+  });
+});
+
+describe('workflow path filters (TS-11) — repo-wide, so it also stops the NEXT dead workflow', () => {
+  const dir = join(REPO, '.github', 'workflows');
+  const files = existsSync(dir) ? readdirSync(dir).filter((f) => /\.ya?ml$/.test(f)) : [];
+  const filtersOf = (src) => {
+    const out = [];
+    let inBlock = false;
+    for (const line of src.split('\n')) {
+      if (/^\s*paths(-ignore)?\s*:/.test(line)) { inBlock = true; continue; }
+      if (inBlock) {
+        const m = line.match(/^\s*-\s*['"]?([^'"#]+?)['"]?\s*$/);
+        if (m) out.push(m[1].trim()); else if (line.trim() !== '') inBlock = false;
+      }
+    }
+    return out;
+  };
+
+  it('found workflows to check — a zero-file sweep would pass vacuously', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('no path filter uses brace alternation: Actions does NOT expand braces, and four workflows in this repo have effectively never fired because of it', () => {
+    const offenders = [];
+    for (const f of files) {
+      for (const filter of filtersOf(readFileSync(join(dir, f), 'utf8'))) {
+        if (/\{[^}]*,[^}]*\}/.test(filter)) offenders.push(`${f}: ${filter}`);
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("this SD's own workflow filter matches at least one file that exists today — a filter matching zero files is dead on arrival", () => {
+    const wf = join(dir, 'anon-write-contract-probe.yml');
+    expect(existsSync(wf)).toBe(true);
+    // Union of tracked and on-disk. `git ls-files` alone would fail for a file added in the same
+    // commit that adds the workflow — which is precisely this commit, and precisely the case where
+    // the check most needs to work.
+    const tracked = execSync('git ls-files', { cwd: REPO, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 })
+      .split('\n').map((s) => s.trim()).filter(Boolean);
+    const filters = filtersOf(readFileSync(wf, 'utf8'));
+    expect(filters.length).toBeGreaterThan(0);
+    for (const filter of filters) {
+      const re = new RegExp('^' + filter.replace(/[.+^$()|[\]\\]/g, '\\$&').replace(/\*\*\//g, '(?:.*/)?').replace(/\*/g, '[^/]*') + '$');
+      const matches = tracked.some((t) => re.test(t)) || existsSync(join(REPO, filter));
+      expect(matches, `filter "${filter}" matches no file that exists today`).toBe(true);
+    }
+  });
+
+  it('the probe step cannot be silently skipped: no continue-on-error, no job-level if:', () => {
+    const code = codeOf(join(dir, 'anon-write-contract-probe.yml'), 'yaml');
+    expect(code).not.toMatch(/continue-on-error/);
+    expect(code).not.toMatch(/^\s{4}if\s*:/m);
+    expect(code).toMatch(/node scripts\/anon-write-contract-probe\.mjs/);
+  });
+});
+
+describe('the G2 acceptance battery is reachable (TS-9, FR-4)', () => {
+  const g2 = join(REPO, 'database', 'chairman-gated', '20260803_bound_anon_ingress_source_type_qualifier_acceptance.mjs');
+
+  it('no longer sends a feedback_type outside the live CHECK', () => {
+    const code = codeOf(g2);
+    expect(code).not.toMatch(/user_general/);
+    expect(code).toMatch(/feedback_type:\s*'user_bug'/);
+  });
+
+  it('names the constraint at the change site, so the next editor knows what constrains the value', () => {
+    expect(readFileSync(g2, 'utf8')).toMatch(/feedback_feedback_type_check/);
+  });
+});

--- a/tests/unit/anon-write-contract-probe.test.js
+++ b/tests/unit/anon-write-contract-probe.test.js
@@ -13,7 +13,8 @@ import { join } from 'node:path';
 import { execSync } from 'node:child_process';
 import {
   EXPECTED, EXIT, compare, discoverAsymmetricTables,
-  isAlwaysFalse, isAlwaysTrue, assertNotCommitFamily, classifyError, assertRlsInForce
+  isAlwaysFalse, isAlwaysTrue, assertNotCommitFamily, assertQualifiedName,
+  classifyError, assertRlsInForce, attributeRefusal, runForms, ROW_BUILDERS
 } from '../../scripts/anon-write-contract-probe.mjs';
 
 const REPO = join(import.meta.dirname, '..', '..');
@@ -192,6 +193,39 @@ describe('RLS-in-force guard (TS-5) — the cannot-fail case', () => {
     expect(r.problems.join(' ')).toMatch(re);
   });
 
+  /**
+   * THE LIMIT OF THIS TIER, stated rather than papered over. Every test above drives
+   * assertRlsInForce through a MOCKED `q`, so it verifies the JS branching and is structurally
+   * blind to the SQL those branches judge: EXEC review replaced `row_security_active($1::regclass)`
+   * with a literal `true` and the whole suite stayed green. A mock cannot protect the query it
+   * stands in for.
+   *
+   * So this is a source pin — the weaker instrument, used knowingly. It catches the primitive being
+   * deleted or replaced, which is the realistic edit. It cannot catch the predicate being subtly
+   * wrong; only the live probe can, which is why CI invokes the binary directly.
+   */
+  it('SOURCE PIN: the guard query actually asks all five questions — a mocked test cannot check this', () => {
+    const code = codeOf(PROBE);
+    // Pin the CALL FORMS, not the bare identifiers. The first spelling of this test used bare names
+    // and stayed green through the mutation, because `problems.push(\`row_security_active=...\`)`
+    // contains the identifier too — the assertion was satisfied by the message that REPORTS the
+    // guard rather than the query that IS it. A value read only by a log line looks exactly like a
+    // guard, and so does a test that only greps for its name.
+    for (const predicate of [
+      'row_security_active($1::regclass)',   // false under owner, BYPASSRLS, and RLS-disabled alike
+      'select rolbypassrls from pg_roles',
+      "current_setting('row_security')",
+      'relrowsecurity from pg_class',
+      'pg_backend_pid()'
+    ]) {
+      expect(code, `guard predicate "${predicate}" is gone from the probe's SQL`).toContain(predicate);
+    }
+    // And the results must be CONSUMED, not merely selected — a value read only by a log line looks
+    // exactly like a guard.
+    expect(code).toMatch(/problems\.push\(`rolbypassrls=/);
+    expect(code).toMatch(/problems\.push\(`row_security_active=/);
+  });
+
   it('BYPASSRLS with rolsuper=false is caught — the live shape of this connection, where an is_superuser check reads clean', async () => {
     const r = await assertRlsInForce(q({ usr: 'anon', bypass: true, active: false }), 'public.feedback', 42);
     expect(r.ok).toBe(false);
@@ -230,11 +264,16 @@ describe('exit codes (TS-13) — a caller that cannot tell these apart treats in
 describe('workflow path filters (TS-11) — repo-wide, so it also stops the NEXT dead workflow', () => {
   const dir = join(REPO, '.github', 'workflows');
   const files = existsSync(dir) ? readdirSync(dir).filter((f) => /\.ya?ml$/.test(f)) : [];
+  // Parses BOTH YAML sequence styles. The block-only version passed vacuously on any workflow
+  // written as `paths: ['a','b']` — it found zero filters and reported clean, which is the same
+  // shape of hole the brace-alternation bug is: a check that silently matches nothing.
   const filtersOf = (src) => {
     const out = [];
     let inBlock = false;
     for (const line of src.split('\n')) {
-      if (/^\s*paths(-ignore)?\s*:/.test(line)) { inBlock = true; continue; }
+      const flow = line.match(/^\s*paths(-ignore)?\s*:\s*\[(.+)\]\s*$/);
+      if (flow) { out.push(...flow[2].split(',').map((s) => s.trim().replace(/^['"]|['"]$/g, ''))); inBlock = false; continue; }
+      if (/^\s*paths(-ignore)?\s*:\s*$/.test(line)) { inBlock = true; continue; }
       if (inBlock) {
         const m = line.match(/^\s*-\s*['"]?([^'"#]+?)['"]?\s*$/);
         if (m) out.push(m[1].trim()); else if (line.trim() !== '') inBlock = false;
@@ -242,6 +281,12 @@ describe('workflow path filters (TS-11) — repo-wide, so it also stops the NEXT
     }
     return out;
   };
+
+  it('the filter parser sees flow sequences too — a parser that finds nothing passes everything', () => {
+    expect(filtersOf("on:\n  push:\n    paths: ['scripts/a.mjs', 'scripts/b.mjs']\n")).toEqual(['scripts/a.mjs', 'scripts/b.mjs']);
+    expect(filtersOf("on:\n  push:\n    paths:\n      - 'scripts/a.mjs'\n")).toEqual(['scripts/a.mjs']);
+    expect(filtersOf("on:\n  push:\n    paths: ['scripts/**/*.{js,mjs}']\n")[0]).toMatch(/\{/);
+  });
 
   it('found workflows to check — a zero-file sweep would pass vacuously', () => {
     expect(files.length).toBeGreaterThan(0);
@@ -279,6 +324,156 @@ describe('workflow path filters (TS-11) — repo-wide, so it also stops the NEXT
     expect(code).not.toMatch(/continue-on-error/);
     expect(code).not.toMatch(/^\s{4}if\s*:/m);
     expect(code).toMatch(/node scripts\/anon-write-contract-probe\.mjs/);
+  });
+});
+
+/**
+ * Everything below closes a hole EXEC review PROVED by mutation: 11 of 27 mutations to the shipped
+ * probe survived the original suite, including replacing row_security_active() with a literal
+ * `true` — the primitive this file's own header calls the strongest. The common cause was import
+ * surface: attributeRefusal, runForms, attempt and parseArgs had ZERO executing tests, so any
+ * mutation inside them was invisible. A suite that imports nine symbols cannot protect fourteen.
+ */
+describe('runForms — the guard must ABORT, not merely observe', () => {
+  const builder = ROW_BUILDERS['public.feedback'];
+  const mkQ = (opts = {}) => {
+    const issued = [];
+    const q = async (sql) => {
+      issued.push(sql);
+      if (/current_user::text/.test(sql)) {
+        return { rows: [{ usr: opts.usr ?? 'anon', bypass: false, rowsec: 'on', active: opts.active ?? true, relrls: true, pid: 7, port: 5432 }] };
+      }
+      if (/has_table_privilege/.test(sql)) return { rows: [{ ok: true }] };
+      if (/^\s*(SAVEPOINT|ROLLBACK TO)/i.test(sql)) return { rows: [] };
+      if (opts.refuse && /insert into/i.test(sql)) { const e = new Error('denied'); e.code = '42501'; throw e; }
+      return { rows: [] };
+    };
+    return { q, issued };
+  };
+  const ctxArgs = { builder, ctx: 'v1', subjectSource: 'manual_feedback', controlSource: 'telegram', uuid: () => 'id-1', basePid: 7 };
+
+  it('aborts on the FIRST form when RLS is not in force, and records no verdicts', async () => {
+    const { q, issued } = mkQ({ active: false });
+    const res = await runForms(q, 'public.feedback', ctxArgs);
+    expect(res.aborted).toBe('bare_insert');
+    expect(res.observed).toEqual({});
+    // The real assertion: it must never have issued the write. Merely *noticing* the guard failed
+    // and continuing anyway would still produce a full, entirely meaningless verdict set.
+    expect(issued.some((s) => /insert into/i.test(s))).toBe(false);
+  });
+
+  it('undoes every form it runs — including the ones that SUCCEED', async () => {
+    const { q, issued } = mkQ();
+    await runForms(q, 'public.feedback', ctxArgs);
+    const savepoints = issued.filter((s) => /^SAVEPOINT/i.test(s)).length;
+    const rollbacks = issued.filter((s) => /^ROLLBACK TO SAVEPOINT/i.test(s)).length;
+    expect(savepoints).toBeGreaterThan(0);
+    // One rollback per savepoint. Leaving a success in place couples the forms: on the live table
+    // each landed insert pushes the venture toward its rate limit and changes what the NEXT form is
+    // judged under. That produced a false REFUSED on the first live run.
+    expect(rollbacks).toBe(savepoints);
+  });
+
+  it('re-checks the guard before EVERY form, not once at the top', async () => {
+    const { q } = mkQ();
+    const res = await runForms(q, 'public.feedback', ctxArgs);
+    expect(res.guards.length).toBe(Object.keys(EXPECTED).length);
+  });
+
+  it('when every insert is denied, DO UPDATE reports MALFORMED — not REFUSED — because its seed never landed', async () => {
+    const { q } = mkQ({ refuse: true });
+    const res = await runForms(q, 'public.feedback', ctxArgs);
+    for (const form of ['bare_insert', 'returning_columns', 'returning_literal', 'on_conflict_do_nothing', 'positive_control']) {
+      expect(res.observed[form]).toBe('REFUSED');
+    }
+    // This is the vacuity guard, and it is the whole reason the cell is built the way it is. DO
+    // UPDATE only evaluates the conflict-row check when a conflict ACTUALLY occurs; with no seeded
+    // row nothing collides, so a "REFUSED" here would be a verdict about an ordinary insert wearing
+    // an upsert's name. Reporting MALFORMED is the honest answer.
+    expect(res.observed.on_conflict_do_update).toBe('MALFORMED');
+    expect(res.attributions.on_conflict_do_update).toMatch(/conflict never forced/);
+  });
+});
+
+describe('attributeRefusal (FR-2b, TS-10) — 42501 alone is not a verdict', () => {
+  const q = (granted) => async (sql) => (/has_table_privilege/.test(sql) ? { rows: [{ ok: granted }] } : { rows: [] });
+
+  it('a GRANT-derived and a policy-derived 42501 produce DIFFERENT causes', async () => {
+    const grantDenied = await attributeRefusal(q(false), 'public.feedback', 'bare_insert', { code: '42501' });
+    const policyDenied = await attributeRefusal(q(true), 'public.feedback', 'bare_insert', { code: '42501' });
+    expect(grantDenied).toMatch(/^GRANT_DENIED/);
+    expect(policyDenied).toMatch(/^POLICY_DENIED/);
+    expect(grantDenied).not.toBe(policyDenied);
+  });
+
+  it('the two upsert forms are attributed to DIFFERENT policies — conflating them teaches a false mechanism', async () => {
+    const doNothing = await attributeRefusal(q(true), 'public.feedback', 'on_conflict_do_nothing', { code: '42501' });
+    const doUpdate = await attributeRefusal(q(true), 'public.feedback', 'on_conflict_do_update', { code: '42501' });
+    const returning = await attributeRefusal(q(true), 'public.feedback', 'returning_columns', { code: '42501' });
+    expect(doNothing).toMatch(/select_policy/);      // flips under --control-grant-select
+    expect(returning).toMatch(/select_policy/);      // flips under --control-grant-select
+    expect(doUpdate).toMatch(/update_policy/);       // needs --control-grant-update
+    expect(new Set([doNothing, doUpdate, returning]).size).toBe(3);
+  });
+
+  it('is silent for a non-42501 error rather than guessing', async () => {
+    expect(await attributeRefusal(q(true), 'public.feedback', 'bare_insert', { code: '23502' })).toBeNull();
+  });
+
+  it('reports UNATTRIBUTED rather than guessing when the privilege query itself fails', async () => {
+    const boom = async () => { throw new Error('25P02'); };
+    expect(await attributeRefusal(boom, 'public.feedback', 'bare_insert', { code: '42501' })).toBe('UNATTRIBUTED');
+  });
+});
+
+describe('table-name validation — the guard is worthless if the name can smuggle a statement', () => {
+  it.each(['public.feedback', 'public.marketing_attribution'])('accepts %s', (n) => {
+    expect(assertQualifiedName(n)).toBe(n);
+  });
+
+  it.each([
+    'feedback; commit; --',
+    'public.feedback; commit; --',
+    'public.feedback"',
+    'public.f oo',
+    'feedback',            // unqualified — reaches CREATE POLICY without a schema
+    ''
+  ])('rejects %s', (n) => { expect(() => assertQualifiedName(n)).toThrow(/UNSAFE_TABLE_NAME/); });
+});
+
+describe('the commit guard must see EVERY statement, not the first', () => {
+  // node-postgres sends a param-less query over the SIMPLE protocol, which executes
+  // semicolon-separated statements. The original guard anchored ^ with no /m and so inspected only
+  // the head of the string — `select 1; commit` committed while the guard returned clean.
+  it.each([
+    'select 1; commit',
+    'SAVEPOINT sp; COMMIT;',
+    'create policy p on t for select to anon using (true); commit; --',
+    'select 1;\ncommit'
+  ])('blocks a COMMIT hiding after the first statement: %s', (sql) => {
+    expect(() => assertNotCommitFamily(sql)).toThrow(/COMMIT_FAMILY_STATEMENT_BLOCKED/);
+  });
+
+  it('still allows a legitimate multi-statement string with no commit', () => {
+    expect(() => assertNotCommitFamily('select 1; select 2')).not.toThrow();
+  });
+});
+
+describe('row builders — the probe only claims what it can actually construct', () => {
+  it('the feedback builder supplies every NOT NULL column plus the policy-required venture_id', () => {
+    const b = ROW_BUILDERS['public.feedback'];
+    const row = b.build('id-1', 'venture-1', 'manual_feedback');
+    expect(row.length).toBe(b.cols.split(',').length);
+    expect(b.cols).toMatch(/source_application/);
+    expect(b.cols).toMatch(/\btype\b/);
+    expect(row).toContain('issue');       // `type` CHECK admits only issue|enhancement
+    expect(row).toContain('user_bug');    // feedback_type CHECK, and LIKE 'user_%' for the policy
+    expect(b.preflight).toMatch(/venture_exists_and_active/);
+    expect(b.preflight).toMatch(/check_feedback_rate_limit/);
+  });
+
+  it('a table with no builder is UNPROBED, never silently treated as passing', () => {
+    expect(ROW_BUILDERS['public.agents']).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
`public.feedback` accepts a bare anon INSERT but refuses `RETURNING <target columns>` and both `ON CONFLICT` forms with 42501. **No live caller is broken** — all five send the bare form — so this is regression prevention, not an outage repair.

The coordinator ruled the remedy is the caller-side contract, not widening anon SELECT (a sibling SD is tightening that exact surface, and the policy that would have covered the readback was deliberately dropped on 2026-07-13). It also promoted an objection to a requirement: a documented contract with no enforcement is a time bomb with better documentation.

**Measurement then moved where that enforcement could live.** All five live callers are in *other* repos (apexniche-ai, marketlens, ehg) and this repo has no anon feedback writer at all — a source lint here would have seen zero of them. The database is the only layer all five share.

## What the probe corrected about its own author

Every one of these was caught by executing, never by reading:

- **`ON CONFLICT DO NOTHING` is refused**, measured with a fresh id so no collision occurs. Reasoning from the docs said it would land.
- **The two upsert forms are closed by different policies**, established by control rather than argument: `--control-grant-select` flips `RETURNING` and `DO NOTHING` while leaving `DO UPDATE` refused; adding UPDATE flips the third. The cell that stays refused under the first control is the simultaneous negative proving the flip is a policy change and not RLS switching off.
- **The forms shared transaction state**, so each one that landed pushed the venture toward its rate limit and changed what the next form was judged under — the same coupled-cells confound that voided this SD's original 2×2, one layer up.

## What adversarial review then caught

- **Default mode never probed `feedback` at all.** Discovery returns 59 candidates live, not the 2 the PRD asserted, then threw on the first and aborted. The unit test was green because the fixture was hand-written to match the author's belief.
- **COMMIT-never-issued was not true.** The guard anchored on the string start with no `/m`, and node-postgres uses the simple protocol for param-less queries — `select 1; commit` committed while the guard reported clean.
- **The strongest guard was unprotected.** Replacing `row_security_active()` with a literal `true` left the suite green. The first fix stayed green too, because the assertion matched the message that *reports* the guard rather than the query that *is* it.
- **The live gate could never have authenticated** — it referenced a secret that does not exist.

## Scope discipline

No caller source file in any repo is modified. No DDL is applied. Seven collateral findings are routed to the durable feedback channel with file:line rather than opportunistically fixed, and the rate-limit remedy is filed as a chairman-gated follow-on because making a dormant limit suddenly bind would begin rejecting live traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)