### PR TITLE
feat(SD-LEO-INFRA-ROLE-BLIND-SESSION-001): read metadata.role before applying worker machinery

### DIFF
--- a/lib/fleet/role-status-identity.cjs
+++ b/lib/fleet/role-status-identity.cjs
@@ -63,4 +63,107 @@ function writeRoleStatusIdentity({ sessionId, role, nowIso, dir = IDENTITY_DIR }
   }
 }
 
-module.exports = { ROLE_IDENTITY, roleIdentityFor, writeRoleStatusIdentity, IDENTITY_DIR };
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// SD-LEO-INFRA-ROLE-BLIND-SESSION-001 FR-1 — the ONE shared role predicate.
+//
+// Three defects on 2026-08-03 (stop hook, SessionStart, SET_IDENTITY) shared one missing check:
+// session plumbing applied WORKER machinery without ever reading metadata.role. The fix is a
+// single predicate consumed by all three sites — deliberately not three fixes, because per-site
+// role logic is exactly the three-writers-one-guarded shape that produced the defect.
+//
+// WHY THREE-STATE AND NOT A BOOLEAN. `false` and "I could not find out" are different facts, and
+// collapsing them reproduces the bug one layer down: a hook with no DB reach would read UNKNOWN as
+// "not a role session" and apply worker doctrine to a role seat, which is the behaviour being
+// removed. Callers must decide explicitly what to do with UNKNOWN.
+//
+// THE FILE FALLBACK ALREADY EXISTS. writeRoleStatusIdentity above writes `role: true` into
+// .claude/fleet-identity-<sessionId>.json at role startup (see :56). That IS the hook-context
+// signal — no second marker is introduced here. Adding one would create a fourth place the role
+// lives, in the SD about the role not being read consistently.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+
+/** @enum {string} */
+const ROLE_VERDICT = Object.freeze({ ROLE: 'role', WORKER: 'worker', UNKNOWN: 'unknown' });
+
+/** Pure: classify a claude_sessions.metadata object. Exported so the DB shape is testable alone. */
+function verdictFromMetadata(metadata) {
+  if (!metadata || typeof metadata !== 'object') return ROLE_VERDICT.UNKNOWN;
+  const raw = metadata.role;
+  // An ABSENT role key is a genuine worker signal: every role seat sets it at startup. An empty
+  // or non-string value is NOT — that is a malformed row, and guessing "worker" from malformed
+  // data is the same collapse this predicate exists to prevent.
+  if (raw === undefined || raw === null) return ROLE_VERDICT.WORKER;
+  if (typeof raw !== 'string' || !raw.trim()) return ROLE_VERDICT.UNKNOWN;
+  return roleIdentityFor(raw) ? ROLE_VERDICT.ROLE : ROLE_VERDICT.WORKER;
+}
+
+/** Pure: classify the on-disk identity file contents. */
+function verdictFromIdentityFile(parsed) {
+  if (!parsed || typeof parsed !== 'object') return ROLE_VERDICT.UNKNOWN;
+  // Only `role === true` is affirmative. A worker's identity file simply lacks the key, which is
+  // indistinguishable from a truncated write — so absence here is UNKNOWN, not WORKER. The DB is
+  // the authority for "this is a worker"; the file can only ever confirm "this is a role".
+  return parsed.role === true ? ROLE_VERDICT.ROLE : ROLE_VERDICT.UNKNOWN;
+}
+
+/** Read the local identity file for a session, or null. Never throws. */
+function readIdentityFile(sessionId, dir = IDENTITY_DIR) {
+  if (typeof sessionId !== 'string' || !SESSION_ID_RE.test(sessionId)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(path.join(dir, `fleet-identity-${sessionId}.json`), 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Is this session a role-session (adam | coordinator | solomon)?
+ *
+ * DB first (claude_sessions.metadata.role is authoritative), identity file as the fallback for
+ * hook contexts with no DB reach. Returns a ROLE_VERDICT — never a bare boolean, so a caller
+ * cannot accidentally treat "could not look" as "not a role".
+ *
+ * @param {object} o
+ * @param {string} o.sessionId
+ * @param {object} [o.supabase]  optional; omit in hook contexts to force the file path
+ * @param {string} [o.dir]       identity dir override, for tests
+ * @returns {Promise<'role'|'worker'|'unknown'>}
+ */
+async function roleVerdictFor({ sessionId, supabase, dir = IDENTITY_DIR } = {}) {
+  if (typeof sessionId !== 'string' || !SESSION_ID_RE.test(sessionId)) return ROLE_VERDICT.UNKNOWN;
+
+  if (supabase) {
+    try {
+      const { data, error } = await supabase
+        .from('claude_sessions').select('metadata').eq('session_id', sessionId).maybeSingle();
+      // A query ERROR is not "no role" — fall through to the file rather than answering from a
+      // failed read. A missing ROW, however, is a real answer only if the file also says nothing.
+      if (!error && data) {
+        const v = verdictFromMetadata(data.metadata);
+        if (v !== ROLE_VERDICT.UNKNOWN) return v;
+      }
+    } catch { /* fall through to the file */ }
+  }
+
+  const fileVerdict = verdictFromIdentityFile(readIdentityFile(sessionId, dir));
+  return fileVerdict === ROLE_VERDICT.ROLE ? ROLE_VERDICT.ROLE : ROLE_VERDICT.UNKNOWN;
+}
+
+/**
+ * Convenience for the three fix sites: should worker machinery apply to this session?
+ *
+ * UNKNOWN maps to TRUE (apply worker machinery) — deliberately fail-loud rather than fail-quiet.
+ * A role seat that wrongly gets a worker banner is noise someone reports; a worker seat that
+ * wrongly loses its stop-hook guard goes incognito and strands a claim. The SD is explicit that a
+ * fix quieting a worker guard is worse than the noise it removes, so the ambiguous case keeps the
+ * guard. Callers needing to distinguish should use roleVerdictFor directly.
+ */
+async function shouldApplyWorkerMachinery(opts) {
+  return (await roleVerdictFor(opts)) !== ROLE_VERDICT.ROLE;
+}
+
+module.exports = {
+  ROLE_IDENTITY, roleIdentityFor, writeRoleStatusIdentity, IDENTITY_DIR,
+  ROLE_VERDICT, verdictFromMetadata, verdictFromIdentityFile, readIdentityFile,
+  roleVerdictFor, shouldApplyWorkerMachinery,
+};

--- a/scripts/hooks/__tests__/session-role-orient.test.js
+++ b/scripts/hooks/__tests__/session-role-orient.test.js
@@ -267,3 +267,63 @@ describe('static-pin: [ROLE] block content', () => {
     expect(lines).toMatch(/fleet-worker-loop-directive\.md/);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// SD-LEO-INFRA-ROLE-BLIND-SESSION-001 FR-3 — decide() reads metadata.role before falling through
+// to the worker directive. Two-sided: the role seat must LOSE the worker doctrine and the worker
+// seat must KEEP it, because a fix that quiets a worker guard is worse than the noise it removes.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+describe('FR-3 role-aware SessionStart', () => {
+  // Same load pattern as the rest of this suite: the hook is .cjs and exports its pure
+  // helpers, so we require() with a cache bust rather than importing at module scope.
+  const { decide, workerLines, COORDINATOR } = loadHook();
+  const COORD = { session_id: 'coord-abc' };
+  // Match worker INSTRUCTIONS, not worker WORDS. The first version of this regex included
+  // /belt|no callsign/ and failed on correct code, because the role lines legitimately say
+  // "no claim, no belt, no callsign" — i.e. they name those things in order to DISCLAIM them.
+  // Asserting the absence of a word is not the same as asserting the absence of a directive.
+  const workerDoctrine = /SAME-TURN NEXT-CLAIM|WIND-DOWN HANDSHAKE|Coordinator check-in EVERY|\[ROLE\] WORKER \(/;
+
+  it('a SOLOMON seat gets role lines, not the worker directive', () => {
+    const out = decide('sess-solomon', { role: 'solomon' }, COORD).join('\n');
+    expect(out).toMatch(/SOLOMON session \(non_fleet\)/);
+    expect(out).not.toMatch(workerDoctrine);
+  });
+
+  it('an ADAM seat gets role lines — two distinct roles, so the axis is metadata.role not one name', () => {
+    // Success criterion 5: a solomon-only test would admit a solomon-keyed implementation.
+    const out = decide('sess-adam', { role: 'adam' }, COORD).join('\n');
+    expect(out).toMatch(/ADAM session \(non_fleet\)/);
+    expect(out).not.toMatch(workerDoctrine);
+  });
+
+  it('TWO-SIDED: a WORKER seat still gets the full worker directive, unchanged', () => {
+    // The half that matters most. If this ever passes because the worker branch went quiet, the
+    // fix has broken the guard it was supposed to preserve.
+    const out = decide('sess-worker', { callsign: 'Alpha' }, COORD).join('\n');
+    expect(out).toMatch(/WORKER \(callsign: Alpha\)/);
+    expect(out).toMatch(/SAME-TURN NEXT-CLAIM/);
+    expect(out).toMatch(/WIND-DOWN HANDSHAKE/);
+  });
+
+  it('an UNRECOGNISED role still gets the worker directive — the predicate gates on known roles', () => {
+    const out = decide('sess-x', { role: 'gardener', callsign: 'Bravo' }, COORD).join('\n');
+    expect(out).toMatch(/WORKER \(callsign: Bravo\)/);
+  });
+
+  it('the coordinator branch still wins, and still keys on its own signal', () => {
+    // Pre-existing behaviour: coordinator is detected via is_coordinator, a DIFFERENT signal from
+    // metadata.role. Pinning it so the new role branch cannot shadow it.
+    expect(decide('c', { is_coordinator: true }, COORD)).toEqual(COORDINATOR);
+  });
+
+  it('CONTROL: the role assertions fail against the pre-fix behaviour', () => {
+    // Without this, "role seat has no worker doctrine" would be satisfied by any output that
+    // simply lacks those words — including an empty array. This proves the worker directive
+    // really does contain what we assert its absence of.
+    const preFix = workerLines('Alpha', COORD.session_id).join('\n');
+    expect(preFix).toMatch(workerDoctrine);          // the doctrine is genuinely present...
+    const roleOut = decide('sess-solomon', { role: 'solomon' }, COORD).join('\n');
+    expect(roleOut).not.toBe(preFix);                // ...and the role path genuinely differs
+  });
+});

--- a/scripts/hooks/coordination-inbox.cjs
+++ b/scripts/hooks/coordination-inbox.cjs
@@ -70,6 +70,27 @@ const FRICTION_TRIGGERS = {
 const IDENTITY_DIR = path.resolve(__dirname, '../../.claude');
 // Per-session identity file keyed by session ID (birth certificate UUID or resolved).
 // Falls back to shared file for sessions without a resolvable ID.
+/**
+ * SD-LEO-INFRA-ROLE-BLIND-SESSION-001 FR-4 — should a SET_IDENTITY write be refused?
+ *
+ * Returns a reason string to refuse, or null to allow. Exported so the decision is testable
+ * without driving the whole inbox flow.
+ *
+ * @param {string} sessionId
+ * @param {string} [dir] identity dir override, for tests
+ * @returns {string|null}
+ */
+function setIdentityRefusalReason(sessionId, dir) {
+  try {
+    const rp = require('../../lib/fleet/role-status-identity.cjs');
+    const existing = rp.readIdentityFile(String(sessionId || ''), dir || rp.IDENTITY_DIR);
+    if (rp.verdictFromIdentityFile(existing) === rp.ROLE_VERDICT.ROLE) {
+      return `role session (${existing.callsign || 'role'}) — worker callsigns are not assigned to role seats`;
+    }
+  } catch { /* predicate unavailable -> allow, exactly as before this SD */ }
+  return null;
+}
+
 function getIdentityFile(resolvedSessionId) {
   const csid = resolvedSessionId || process.env.CLAUDE_SESSION_ID;
   if (csid) return path.join(IDENTITY_DIR, `fleet-identity-${csid}.json`);
@@ -685,14 +706,38 @@ async function main() {
 
       // Handle SET_IDENTITY: write per-session identity file for statusline integration
       if (msg.message_type === 'SET_IDENTITY' && msg.payload) {
-        try {
-          fs.writeFileSync(getIdentityFile(sessionId), JSON.stringify({
-            color: msg.payload.color,
-            callsign: msg.payload.callsign,
-            display_name: msg.payload.display_name,
-            assigned_at: new Date().toISOString()
-          }));
-        } catch { /* ignore write errors */ }
+        // SD-LEO-INFRA-ROLE-BLIND-SESSION-001 FR-4: the RECEIVER now guards too.
+        //
+        // The sending side already refuses to hand a NATO callsign to a role seat. A guard on only
+        // one side is satisfied by any caller that skips that side, which is how a role session
+        // ended up wearing a worker callsign.
+        //
+        // The damage is not only cosmetic. This write REPLACES the identity file wholesale, and the
+        // role file it clobbers is the one writeRoleStatusIdentity wrote with `role: true` — the
+        // same marker FR-2's stop hook reads to choose role guidance over worker doctrine. So an
+        // unguarded SET_IDENTITY silently un-does FR-2 for that seat, and it also burns one of the
+        // 8 claim-gated NATO names on a session that will never hold a claim.
+        //
+        // Reads the EXISTING file rather than the DB: the file is what is about to be overwritten,
+        // so it is the authority on what is being destroyed, and this path has no budget for a
+        // round trip. Fail-open — an unreadable/absent file means "not known to be a role seat",
+        // which preserves today's behaviour for every worker.
+        const refuseReason = setIdentityRefusalReason(sessionId);
+
+        if (refuseReason) {
+          // Exactly one line, per the SD. A refusal nobody can see is indistinguishable from a
+          // write that silently failed.
+          console.log(`[coordination-inbox] SET_IDENTITY REFUSED for ${sessionId}: ${refuseReason}`);
+        } else {
+          try {
+            fs.writeFileSync(getIdentityFile(sessionId), JSON.stringify({
+              color: msg.payload.color,
+              callsign: msg.payload.callsign,
+              display_name: msg.payload.display_name,
+              assigned_at: new Date().toISOString()
+            }));
+          } catch { /* ignore write errors */ }
+        }
       }
 
       console.log('');
@@ -888,6 +933,7 @@ if (require.main === module) {
 }
 
 module.exports = {
+  setIdentityRefusalReason,
   // SD-LEO-INFRA-PARKED-WORKER-CLAIM-LAPSE-001 FR-7: exported so the dispatch-availability
   // predicate can be asserted directly instead of through a mock of its own query.
   selectAvailableSds,

--- a/scripts/hooks/session-role-orient.cjs
+++ b/scripts/hooks/session-role-orient.cjs
@@ -3,6 +3,13 @@
 const fs = require('fs');
 const path = require('path');
 const { drainAndExit } = require('../../lib/hooks/drain-undici.cjs'); // QF-20260719-890: drain before post-fetch exits
+// SD-LEO-INFRA-ROLE-BLIND-SESSION-001 FR-1/FR-3: the ONE shared role predicate. Required
+// defensively — a hook that throws at SessionStart takes the whole session start with it, and this
+// hook already treats every other failure as degrade-to-quiet.
+let ROLE_VERDICT = null; let verdictFromMetadata = () => null;
+try {
+  ({ ROLE_VERDICT, verdictFromMetadata } = require('../../lib/fleet/role-status-identity.cjs'));
+} catch { /* predicate unavailable -> behave exactly as before this SD */ }
 require('dotenv').config({ path: path.resolve(__dirname, '../../.env') });
 
 const COORD_FILE = path.resolve(__dirname, '../../.claude/active-coordinator.json');
@@ -77,9 +84,39 @@ async function findActiveCoord() {
   const cutoff = new Date(Date.now() - STALE_MIN * 60_000).toISOString();
   return (await pgGet(`claude_sessions?heartbeat_at=gte.${cutoff}&metadata->>is_coordinator=eq.true&order=heartbeat_at.desc&limit=1&select=session_id`))?.[0]?.session_id || null;
 }
+/**
+ * SD-LEO-INFRA-ROLE-BLIND-SESSION-001 FR-3: role lines for a non-worker seat.
+ *
+ * Deliberately short. A role session needs to know its seat and that it is NOT on the claim belt;
+ * everything the worker directive says about claims, worktrees, the belt and wind-down is not just
+ * noise here, it is wrong — a role seat never holds a claim.
+ */
+function roleLines(role) {
+  const name = String(role || 'role').trim().toLowerCase();
+  return [
+    `[ROLE] ${name.toUpperCase()} session (non_fleet). Not a fleet worker: you hold no SD claim.`,
+    '[ROLE] Fleet worker loop doctrine does not apply to this seat. Follow your own role contract.',
+    '[ROLE] You still own your turn lifecycle — if your seat runs a loop, arm your own wakeup.',
+  ];
+}
+
 function decide(sessionId, meta, coordFile) {
   if (meta?.is_coordinator) return COORDINATOR;
   if (coordFile?.session_id === sessionId) return COORDINATOR;
+
+  // FR-3: read metadata.role BEFORE falling through to workerLines.
+  //
+  // Note what was already here: the coordinator branch above keys on `meta.is_coordinator`, a
+  // DIFFERENT signal. So coordinator had an ad-hoc fix while the general axis was never added,
+  // and adam/solomon seats fell straight through to the worker directive. That is the defect —
+  // not that role-awareness was absent, but that it was implemented once, per-role, off to the
+  // side. Hence one shared predicate rather than a second special case.
+  //
+  // verdictFromMetadata (not the async roleVerdictFor) because `meta` is already fetched here and
+  // this hook runs on a strict startup budget — no second round trip. The file fallback is not
+  // needed on this path: if meta is null the hook already degrades to SOLO, which carries no
+  // worker doctrine either.
+  if (ROLE_VERDICT && verdictFromMetadata(meta) === ROLE_VERDICT.ROLE) return roleLines(meta.role);
   // SD-LEO-INFRA-SILENT-TRUNCATION-ONE-001 FR-1: this used to pass coordFile.session_id.slice(0, 8).
   // The [ROLE] line below is the ONLY place a worker is told who its coordinator is, and a worker
   // that addresses the coordinator builds target_session from it — so an 8-character prefix here is
@@ -115,4 +152,4 @@ function main() {
   });
 }
 if (require.main === module) main().then(() => drainAndExit(0)).catch(() => drainAndExit(0));
-module.exports = { readCoordFile, fetchMeta, findActiveCoord, decide, SOLO, COORDINATOR, workerLines };
+module.exports = { readCoordFile, fetchMeta, findActiveCoord, decide, SOLO, COORDINATOR, workerLines, roleLines };

--- a/scripts/hooks/stop-loop-wakeup-reminder.cjs
+++ b/scripts/hooks/stop-loop-wakeup-reminder.cjs
@@ -347,11 +347,27 @@ async function recordWindDown(supabase, sessionId, { reason, hadClaim } = {}) {
   }
 }
 
-const REMINDER = [
+/**
+ * SD-LEO-INFRA-ROLE-BLIND-SESSION-001 FR-2.
+ *
+ * The head of this reminder is TRUE FOR ANY SESSION — the transcript is the only evidence of an
+ * arm, regardless of seat. Only the tail below it is worker doctrine (claims, WIP pushes,
+ * worktrees, the wind-down handshake, loop_state). Splitting them here so a role seat keeps the
+ * check and loses only the vocabulary.
+ *
+ * The check itself is NOT role-gated, deliberately. The SD asks to keep the useful half, and
+ * exempting role seats from the arming reminder would trade a noise bug for a silence bug — a
+ * role seat that ends a turn unarmed goes just as quiet as a worker does.
+ */
+const REMINDER_HEAD = [
   'NO ScheduleWakeup tool_use found in THIS turn. This is read from the transcript, not from any',
   'state you set: saying "wakeup armed" in a /signal, or having loop_state=awaiting_tick, does NOT',
   'satisfy it. Only calling the tool does. If you believe you armed one, you armed it in a PREVIOUS',
   'turn — that is the stale-arm case this check exists to catch.',
+];
+
+/** Worker-only tail: every line here presumes a claim, a worktree, or the fleet belt. */
+const REMINDER_WORKER_TAIL = [
   'Worker stopping with NO ScheduleWakeup armed — you will go INCOGNITO and strand your claimed SD',
   '(the worktree then gets reaped by the claim-sweep). Run the WIND-DOWN HANDSHAKE before you stop:',
   "  1. If you hold an IN-PROGRESS SD: FINISH it or hand it off — never leave it half-done + unclaimed (orphan).",
@@ -364,8 +380,35 @@ const REMINDER = [
   '  4. Arm a SHORT grace ScheduleWakeup (~180s); on that tick RE-CHECK your inbox for a coordinator reply',
   '     BEFORE settling into the ~1200s idle cadence. (Short delay if work is in-flight, ~20min if truly idle.)',
   "  • To legitimately END the loop instead, set claude_sessions.loop_state='exited' for your session.",
-  '(This reminder fires once — if you stop again it will let you through.)',
-].join('\n');
+];
+
+/**
+ * Role-seat tail. A role session holds no claim, has no worktree to reap and is not on the belt,
+ * so none of the worker steps apply — but it still needs the arm, which is why this is a different
+ * tail rather than an exemption.
+ */
+const REMINDER_ROLE_TAIL = [
+  'This is a ROLE session (non_fleet): no claim, no worktree, no belt — the fleet wind-down',
+  'handshake does not apply to you. What DOES apply: if your seat runs a loop, arm the next tick',
+  'before you stop, or your loop simply ends here and nobody is watching for it.',
+  '  • If ending deliberately is correct for your seat, that is a legitimate stop — say so and end.',
+];
+
+const REMINDER_FOOT = '(This reminder fires once — if you stop again it will let you through.)';
+
+/** Compose the reminder for a seat. isRoleSession=true selects the role tail. */
+function reminderFor(isRoleSession) {
+  return [
+    ...REMINDER_HEAD,
+    ...(isRoleSession ? REMINDER_ROLE_TAIL : REMINDER_WORKER_TAIL),
+    REMINDER_FOOT,
+  ].join('\n');
+}
+
+// Preserved as the worker-seat reminder so existing importers and the static-pin regression tests
+// keep the exact string they assert on. Changing this constant's meaning would be a silent break
+// for anything that imports it.
+const REMINDER = reminderFor(false);
 
 /**
  * Run `fn` with process.stdout.write discarded, then restore it. Any diagnostic a transitively
@@ -533,7 +576,23 @@ async function main() {
       // The block reason is the ONLY channel that reaches the model, so the pending-wake state
       // rides here rather than on stderr (which the model never sees on a blocking Stop).
       const detail = armObservation ? `\n${armEvidence.formatPendingWake(armObservation, { sessionId }).trim()}` : '';
-      emitDecision({ decision: 'block', reason: REMINDER + detail });
+      // SD-LEO-INFRA-ROLE-BLIND-SESSION-001 FR-2: the CHECK is unchanged — shouldRemind above
+      // still gates on claim/loop-state and still blocks. Only the doctrine text is selected by
+      // seat. This is why a role seat previously had to set loop_state='exited' to escape: the
+      // worker gate treats a live loop_state as worker-shape, and a role seat that runs a loop
+      // has one. That escape is now unnecessary rather than merely unused.
+      //
+      // Read from the local identity file, not the DB: this runs inside the Stop budget after the
+      // DB round-trips above have already spent most of it, and writeRoleStatusIdentity has
+      // written role:true at role startup since ROLE-SESSION-NAMING-001. UNKNOWN falls back to the
+      // worker tail — the ambiguous seat keeps the fuller guidance, per the SD's rule that
+      // quieting a worker guard is worse than the noise it removes.
+      let isRoleSeat = false;
+      try {
+        const rp = require('../../lib/fleet/role-status-identity.cjs');
+        isRoleSeat = rp.verdictFromIdentityFile(rp.readIdentityFile(sessionId)) === rp.ROLE_VERDICT.ROLE;
+      } catch { /* predicate unavailable -> worker tail, exactly as before this SD */ }
+      emitDecision({ decision: 'block', reason: reminderFor(isRoleSeat) + detail });
       // RECORD THE BLOCK. Without this the step-C gate is UNINTERPRETABLE, and I only noticed
       // because I asked what state would silence it and whether anyone can reach that state.
       // 'second_stop_still_unarmed' requires TWO events: (1) a block fires, then (2) the worker
@@ -584,4 +643,4 @@ if (require.main === module) {
   main().catch(() => shutdown());
 }
 
-module.exports = { shouldRemind, shouldParkRecoverable, parkSessionRecoverable, classifyWindDownReason, recordWindDown, isFlagEnabled, muzzleStdout, SWALLOW, REMINDER };
+module.exports = { shouldRemind, shouldParkRecoverable, parkSessionRecoverable, classifyWindDownReason, recordWindDown, isFlagEnabled, muzzleStdout, SWALLOW, REMINDER, reminderFor, REMINDER_HEAD, REMINDER_ROLE_TAIL, REMINDER_WORKER_TAIL };

--- a/tests/unit/fleet/role-predicate.test.js
+++ b/tests/unit/fleet/role-predicate.test.js
@@ -1,0 +1,130 @@
+/**
+ * SD-LEO-INFRA-ROLE-BLIND-SESSION-001 FR-1 — the shared role predicate.
+ *
+ * Pure unit tests with a fake supabase and a temp identity dir. No live DB.
+ *
+ * The load-bearing case is TS-5: UNKNOWN must stay distinguishable from WORKER. Collapsing them
+ * reproduces the defect one layer down — a hook that cannot reach the DB would read "could not
+ * look" as "not a role session" and apply worker doctrine to a role seat, which is the exact
+ * behaviour this SD removes.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const {
+  ROLE_VERDICT, verdictFromMetadata, verdictFromIdentityFile,
+  roleVerdictFor, shouldApplyWorkerMachinery,
+} = require_('../../../lib/fleet/role-status-identity.cjs');
+
+/** Minimal supabase stub: one row, or an error. */
+const fakeDb = (row, error = null) => ({
+  from: () => ({ select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: row, error }) }) }) }),
+});
+
+let dir;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'roleid-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe('verdictFromMetadata — the DB shape alone', () => {
+  it('TS-1: metadata.role=solomon -> ROLE', () => {
+    expect(verdictFromMetadata({ role: 'solomon' })).toBe(ROLE_VERDICT.ROLE);
+  });
+
+  it('TS-2: metadata.role=adam -> ROLE (second role proves the axis is metadata.role, not one name)', () => {
+    // An Adam-only suite would admit an Adam-keyed implementation that leaves the class alive for
+    // solomon and coordinator. Success criterion 5 requires two distinct roles.
+    expect(verdictFromMetadata({ role: 'adam' })).toBe(ROLE_VERDICT.ROLE);
+    expect(verdictFromMetadata({ role: 'coordinator' })).toBe(ROLE_VERDICT.ROLE);
+  });
+
+  it('TS-3: no role key -> WORKER (every role seat sets it at startup, so absence is a real signal)', () => {
+    expect(verdictFromMetadata({ auto_proceed: true })).toBe(ROLE_VERDICT.WORKER);
+  });
+
+  it('an UNRECOGNISED role string is WORKER, not UNKNOWN — the key was set and read fine', () => {
+    expect(verdictFromMetadata({ role: 'gardener' })).toBe(ROLE_VERDICT.WORKER);
+  });
+
+  it('a MALFORMED role value is UNKNOWN, not WORKER — guessing from bad data is the collapse', () => {
+    expect(verdictFromMetadata({ role: '' })).toBe(ROLE_VERDICT.UNKNOWN);
+    expect(verdictFromMetadata({ role: 42 })).toBe(ROLE_VERDICT.UNKNOWN);
+    expect(verdictFromMetadata(null)).toBe(ROLE_VERDICT.UNKNOWN);
+  });
+});
+
+describe('verdictFromIdentityFile — the fallback carrier that already existed', () => {
+  it('role:true -> ROLE', () => {
+    expect(verdictFromIdentityFile({ role: true, callsign: 'Solomon' })).toBe(ROLE_VERDICT.ROLE);
+  });
+
+  it('a worker identity file is UNKNOWN, not WORKER', () => {
+    // The file can only ever CONFIRM a role. A worker's file simply lacks the key, which is
+    // indistinguishable from a truncated write — so the DB stays the authority for "worker".
+    expect(verdictFromIdentityFile({ callsign: 'Alpha' })).toBe(ROLE_VERDICT.UNKNOWN);
+  });
+});
+
+describe('roleVerdictFor — DB first, file fallback', () => {
+  it('TS-4: no DB reach, identity file says role:true -> ROLE', async () => {
+    writeFileSync(join(dir, 'fleet-identity-sess1.json'), JSON.stringify({ role: true }));
+    expect(await roleVerdictFor({ sessionId: 'sess1', dir })).toBe(ROLE_VERDICT.ROLE);
+  });
+
+  it('TS-5: no DB reach AND no identity file -> UNKNOWN, never WORKER', async () => {
+    // THE case. If this ever returns WORKER, a role seat with an unreachable DB gets worker
+    // doctrine — the original defect, rebuilt inside its own fix.
+    expect(await roleVerdictFor({ sessionId: 'nofile', dir })).toBe(ROLE_VERDICT.UNKNOWN);
+  });
+
+  it('a DB ERROR falls through to the file rather than answering from a failed read', async () => {
+    writeFileSync(join(dir, 'fleet-identity-sess2.json'), JSON.stringify({ role: true }));
+    const db = fakeDb(null, { message: 'connection refused' });
+    expect(await roleVerdictFor({ sessionId: 'sess2', supabase: db, dir })).toBe(ROLE_VERDICT.ROLE);
+  });
+
+  it('the DB wins over a stale file when it has a definite answer', async () => {
+    writeFileSync(join(dir, 'fleet-identity-sess3.json'), JSON.stringify({ role: true }));
+    const db = fakeDb({ metadata: { role: null } });   // definitively a worker now
+    expect(await roleVerdictFor({ sessionId: 'sess3', supabase: db, dir })).toBe(ROLE_VERDICT.WORKER);
+  });
+
+  it('an invalid sessionId is UNKNOWN (also the path-traversal guard)', async () => {
+    expect(await roleVerdictFor({ sessionId: '../../etc/passwd', dir })).toBe(ROLE_VERDICT.UNKNOWN);
+    expect(await roleVerdictFor({ sessionId: '', dir })).toBe(ROLE_VERDICT.UNKNOWN);
+  });
+});
+
+describe('shouldApplyWorkerMachinery — UNKNOWN keeps the guard', () => {
+  it('role session -> false (no worker machinery)', async () => {
+    const db = fakeDb({ metadata: { role: 'solomon' } });
+    expect(await shouldApplyWorkerMachinery({ sessionId: 's', supabase: db, dir })).toBe(false);
+  });
+
+  it('worker session -> true', async () => {
+    const db = fakeDb({ metadata: {} });
+    expect(await shouldApplyWorkerMachinery({ sessionId: 's', supabase: db, dir })).toBe(true);
+  });
+
+  it('UNKNOWN -> TRUE: the ambiguous case KEEPS the worker guard', async () => {
+    // Deliberately fail-loud. A role seat wrongly showing a worker banner is noise someone
+    // reports; a worker seat wrongly losing its stop-hook guard goes incognito and strands a
+    // claim. The SD says a fix that quiets a worker guard is worse than the noise it removes.
+    expect(await shouldApplyWorkerMachinery({ sessionId: 'nofile', dir })).toBe(true);
+  });
+});
+
+describe('TS-12 CONTROL — the role-side assertions can actually fail', () => {
+  it('a stubbed always-worker predicate breaks every role-side expectation', async () => {
+    // Without this, "role session gets no worker machinery" is satisfied just as well by an
+    // implementation that returns WORKER for everything — the cannot-fail shape.
+    const stub = async () => true;
+    expect(await stub()).toBe(true);                      // stub applies worker machinery always
+    const db = fakeDb({ metadata: { role: 'solomon' } });
+    const real = await shouldApplyWorkerMachinery({ sessionId: 's', supabase: db, dir });
+    expect(real).not.toBe(await stub());                  // the real predicate must DIFFER
+  });
+});

--- a/tests/unit/fleet/set-identity-role-guard.test.js
+++ b/tests/unit/fleet/set-identity-role-guard.test.js
@@ -1,0 +1,78 @@
+/**
+ * SD-LEO-INFRA-ROLE-BLIND-SESSION-001 FR-4 — the SET_IDENTITY receiver guard.
+ *
+ * The sending side already refuses to hand a NATO callsign to a role seat. A guard on only one
+ * side is satisfied by any caller that skips that side, which is how a role session ended up
+ * wearing a worker callsign.
+ *
+ * The damage is not cosmetic: the SET_IDENTITY handler REPLACES the identity file wholesale, and
+ * the file it clobbers is the one writeRoleStatusIdentity wrote with `role: true` — the same
+ * marker FR-2's stop hook reads. An unguarded write silently un-does FR-2 for that seat and burns
+ * one of the 8 claim-gated NATO names on a session that will never hold a claim.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const { setIdentityRefusalReason } = require_('../../../scripts/hooks/coordination-inbox.cjs');
+const { writeRoleStatusIdentity } = require_('../../../lib/fleet/role-status-identity.cjs');
+
+let dir;
+beforeEach(() => { dir = mkdtempSync(join(tmpdir(), 'setid-')); });
+afterEach(() => { rmSync(dir, { recursive: true, force: true }); });
+
+describe('FR-4 SET_IDENTITY refusal', () => {
+  it('REFUSES a write onto a solomon seat, and names why', () => {
+    writeRoleStatusIdentity({ sessionId: 'sess-solomon', role: 'solomon', dir });
+    const reason = setIdentityRefusalReason('sess-solomon', dir);
+    expect(reason).toBeTruthy();
+    expect(reason).toMatch(/role session/);
+    expect(reason).toMatch(/Solomon/);        // names the seat it is protecting
+  });
+
+  it('REFUSES on an adam seat too — two roles, so the guard is not keyed to one name', () => {
+    writeRoleStatusIdentity({ sessionId: 'sess-adam', role: 'adam', dir });
+    expect(setIdentityRefusalReason('sess-adam', dir)).toBeTruthy();
+  });
+
+  it('TWO-SIDED: ALLOWS the write for a worker seat', () => {
+    // The half that matters. A guard that refuses everything would pass every role-side
+    // assertion above while breaking callsign assignment for the entire fleet.
+    writeFileSync(join(dir, 'fleet-identity-sess-worker.json'), JSON.stringify({ callsign: 'Alpha' }));
+    expect(setIdentityRefusalReason('sess-worker', dir)).toBeNull();
+  });
+
+  it('ALLOWS the write when no identity file exists yet — the first assignment must land', () => {
+    // A brand-new worker has no file. Refusing here would mean no worker ever gets a callsign.
+    expect(setIdentityRefusalReason('sess-brandnew', dir)).toBeNull();
+  });
+
+  it('ALLOWS on a malformed/unreadable file — fail-open preserves pre-SD behaviour', () => {
+    writeFileSync(join(dir, 'fleet-identity-sess-bad.json'), '{not json');
+    expect(setIdentityRefusalReason('sess-bad', dir)).toBeNull();
+  });
+
+  it('the guard protects the exact marker FR-2 depends on', () => {
+    // Ties the two FRs together explicitly: what makes this refusal load-bearing is that the file
+    // being defended carries role:true, which the stop hook reads to pick its text.
+    writeRoleStatusIdentity({ sessionId: 'sess-link', role: 'coordinator', dir });
+    const rp = require_('../../../lib/fleet/role-status-identity.cjs');
+    expect(rp.verdictFromIdentityFile(rp.readIdentityFile('sess-link', dir))).toBe(rp.ROLE_VERDICT.ROLE);
+    expect(setIdentityRefusalReason('sess-link', dir)).toBeTruthy();
+  });
+
+  it('CONTROL: role and worker seats produce DIFFERENT verdicts from the same function', () => {
+    // Without this, every assertion above is satisfied by a function that always returns null
+    // (allow-everything) or always returns a string (refuse-everything).
+    writeRoleStatusIdentity({ sessionId: 'r', role: 'solomon', dir });
+    writeFileSync(join(dir, 'fleet-identity-w.json'), JSON.stringify({ callsign: 'Bravo' }));
+    const roleVerdict = setIdentityRefusalReason('r', dir);
+    const workerVerdict = setIdentityRefusalReason('w', dir);
+    expect(roleVerdict).toBeTruthy();
+    expect(workerVerdict).toBeNull();
+    expect(roleVerdict).not.toBe(workerVerdict);
+  });
+});

--- a/tests/unit/fleet/stop-hook-role-text.test.js
+++ b/tests/unit/fleet/stop-hook-role-text.test.js
@@ -1,0 +1,87 @@
+/**
+ * SD-LEO-INFRA-ROLE-BLIND-SESSION-001 FR-2 — the stop hook keeps its check, changes its text.
+ *
+ * WHY THE CHECK IS NOT ROLE-GATED. shouldRemind's worker gate is
+ *   hasActiveClaim || loop_state IN (active, awaiting_tick)
+ * so a ROLE seat that runs a loop has a live loop_state and is already worker-shaped by that
+ * predicate. That is exactly how the Solomon seat kept getting worker doctrine, and why the only
+ * escape was setting loop_state='exited'. The fix is NOT to exempt role seats from the reminder —
+ * a role seat that ends a turn unarmed goes just as silent as a worker. It is to keep the reminder
+ * and stop telling it to push WIP on a branch it does not have.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const hook = require_('../../../scripts/hooks/stop-loop-wakeup-reminder.cjs');
+const { reminderFor, REMINDER, shouldRemind } = hook;
+
+const WORKER_DOCTRINE = /WIND-DOWN HANDSHAKE|PUSH your WIP|claim-bound branch|prepark-wip|claim-sweep/;
+const ARM_REQUIREMENT = /NO ScheduleWakeup tool_use found in THIS turn/;
+
+describe('FR-2 reminder text is selected by seat', () => {
+  it('the WORKER reminder still carries the full wind-down doctrine', () => {
+    // The two-sided half. If this ever goes quiet, the fix broke the guard it was preserving.
+    const w = reminderFor(false);
+    expect(w).toMatch(ARM_REQUIREMENT);
+    expect(w).toMatch(WORKER_DOCTRINE);
+    expect(w).toMatch(/loop_state='exited'/);
+  });
+
+  it('the exported REMINDER constant is unchanged — importers and static pins keep their string', () => {
+    // Repurposing this constant's meaning would be a silent break for anything importing it.
+    expect(REMINDER).toBe(reminderFor(false));
+  });
+
+  it('the ROLE reminder drops every worker-doctrine instruction', () => {
+    expect(reminderFor(true)).not.toMatch(WORKER_DOCTRINE);
+  });
+
+  it('the ROLE reminder KEEPS the arm requirement — the useful half survives', () => {
+    // The SD is explicit: keep the arm-a-wakeup check, exempting role seats would trade a noise
+    // bug for a silence bug.
+    const r = reminderFor(true);
+    expect(r).toMatch(ARM_REQUIREMENT);
+    expect(r).toMatch(/arm the next tick/);
+  });
+
+  it('both seats share the same head — the transcript rule is true for any session', () => {
+    const head = 'NO ScheduleWakeup tool_use found in THIS turn';
+    expect(reminderFor(true)).toContain(head);
+    expect(reminderFor(false)).toContain(head);
+  });
+
+  it('CONTROL: the two texts genuinely differ, and each contains what the other asserts absent', () => {
+    // Without this, "role text has no worker doctrine" would be satisfied by an empty string, and
+    // by a reminderFor that ignored its argument entirely.
+    expect(reminderFor(true)).not.toBe(reminderFor(false));
+    expect(reminderFor(false)).toMatch(WORKER_DOCTRINE);   // the doctrine really is in the worker text
+  });
+});
+
+describe('FR-2 the CHECK itself is untouched', () => {
+  const base = { flagEnabled: true, enforcementDisabled: false, stopHookActive: false, loopState: 'active' };
+
+  it('still blocks an unarmed worker holding a claim', () => {
+    expect(shouldRemind({ ...base, hasActiveClaim: true, armVerdict: 'unarmed' })).toBe(true);
+  });
+
+  it('still blocks an unarmed session on a live loop_state — the path a role seat takes', () => {
+    // This is the case the SD cares about: a role seat running a loop is worker-shaped to this
+    // predicate. It must STILL be reminded; only its wording changes.
+    expect(shouldRemind({ ...base, hasActiveClaim: false, armVerdict: 'unarmed' })).toBe(true);
+  });
+
+  it('still lets an armed session through', () => {
+    expect(shouldRemind({ ...base, hasActiveClaim: true, armVerdict: 'armed' })).toBe(false);
+  });
+
+  it("still honours loop_state='exited' and the once-per-turn guard", () => {
+    expect(shouldRemind({ ...base, loopState: 'exited', hasActiveClaim: true, armVerdict: 'unarmed' })).toBe(false);
+    expect(shouldRemind({ ...base, stopHookActive: true, hasActiveClaim: true, armVerdict: 'unarmed' })).toBe(false);
+  });
+
+  it('still fails open on an unknown arm verdict', () => {
+    expect(shouldRemind({ ...base, hasActiveClaim: true, armVerdict: 'unknown' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Three chairman-witnessed defects on 2026-08-03 shared one missing check: session plumbing applied
**worker** machinery without ever reading `claude_sessions.metadata.role`. One shared predicate,
three consumers — deliberately not three fixes, since per-site role logic is the
three-writers-one-guarded shape that caused this.

- **FR-1** `lib/fleet/role-status-identity.cjs` — `isRoleSession`/`roleVerdictFor`, three-state.
- **FR-2** `stop-loop-wakeup-reminder.cjs` — keeps the check, swaps only the doctrine text.
- **FR-3** `session-role-orient.cjs` — reads role before emitting the worker directive.
- **FR-4** `coordination-inbox.cjs` — refuses a SET_IDENTITY write onto a role seat.

## What reading the code changed about the diagnosis

**FR-3.** The coordinator branch already returned early — but it keys on `meta.is_coordinator`, a
*different* signal. Role-awareness wasn't absent; it was implemented **once, per-role, off to the
side**, and adam/solomon fell straight through. That is the argument for one predicate rather than
a second special case.

**FR-2.** `shouldRemind`'s worker gate is `hasActiveClaim || loop_state IN (active, awaiting_tick)`
— so a role seat that *runs a loop* has a live `loop_state` and is already worker-shaped by that
predicate. That's how the Solomon seat kept drawing worker doctrine, and why the only escape was
`loop_state='exited'`. The gate is therefore **untouched**: exempting role seats would trade a
noise bug for a silence bug. The SD's criterion that the escape "becomes redundant" is met by
fixing the text.

**FR-4.** The write **replaces the identity file wholesale**, and the file it clobbers carries the
`role: true` marker FR-2 reads. An unguarded SET_IDENTITY silently un-does FR-2 for that seat — and
burns one of the 8 claim-gated NATO names on a session that will never hold a claim.

## Three-state, not boolean

`false` and "I could not find out" are different facts. Collapsing them rebuilds this bug one layer
down: a hook with no DB reach would read UNKNOWN as "not a role session". Asymmetries are
deliberate — in the DB an *absent* role key is WORKER but a *malformed* value is UNKNOWN; in the
identity file that reverses, since a worker's file lacks the key indistinguishably from a truncated
write. **The file can confirm a role; only the DB can confirm a worker.** UNKNOWN maps to
"apply worker machinery" everywhere: a role seat wrongly showing a banner is noise someone reports,
a worker seat wrongly losing its stop-hook guard goes incognito and strands a claim.

## Defects in my own tests, kept visible

- The FR-3 `workerDoctrine` regex matched `/belt|no callsign/`, and the role lines legitimately say
  "no claim, no belt, no callsign" — they *name* those things to disclaim them. Asserting absence
  of a **word** is not asserting absence of a **directive**.
- Tightening it still failed, because my role line recited "SAME-TURN NEXT-CLAIM / wind-down
  handshake" to negate them. I fixed the **code**: reciting worker doctrine to disclaim it still
  leaves that text in a role seat's context.

## Test plan

- **31 suites matched, 505 tests.** Every face is tested against **two distinct roles** (solomon
  and adam/coordinator) per the SD's criterion — an Adam-only suite admits an Adam-keyed
  implementation that leaves the class alive.
- Every FR has a **two-sided** control that fails against a no-op implementation. Without them,
  "role seat gets no worker machinery" is satisfied by an empty string.
- Sub-agents: TESTING PASS, SECURITY PASS.

**One flake, reported not papered over.** On the first uncapped run,
`session-role-orient > readCoordFile returns null when the file does not exist` failed. It passes
alone (29/29); a second identical run was 505/505; **five other suites** write the real
`.claude/active-coordinator.json`; none of my source changes reference it. Pre-existing parallel
race on a live shared repo file — signalled separately with the fix shape (inject the path).

Method note: I first scoped the regression with `head -20` (20 suites / 255 tests) after a `head
-12` run reported 12 suites / **267** tests. More files but fewer tests is impossible unless the cap
is choosing the sample. Uncapped there are 31 — and the flake only appeared once the cap came off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)