### PR TITLE
fix(SD-LEO-INFRA-ROLE-BLIND-SESSION-001): real invocation found the defect surviving in the fix

### DIFF
--- a/lib/fleet/role-status-identity.cjs
+++ b/lib/fleet/role-status-identity.cjs
@@ -88,13 +88,40 @@ const ROLE_VERDICT = Object.freeze({ ROLE: 'role', WORKER: 'worker', UNKNOWN: 'u
 /** Pure: classify a claude_sessions.metadata object. Exported so the DB shape is testable alone. */
 function verdictFromMetadata(metadata) {
   if (!metadata || typeof metadata !== 'object') return ROLE_VERDICT.UNKNOWN;
+  // non_fleet is authoritative on its own. The SD's Solomon amendment says the class fires on ANY
+  // `role=*/non_fleet=true` seat, so a seat that declares itself non-fleet is a role seat even if
+  // its role string is one this module has never heard of.
+  if (metadata.non_fleet === true) return ROLE_VERDICT.ROLE;
+
   const raw = metadata.role;
   // An ABSENT role key is a genuine worker signal: every role seat sets it at startup. An empty
   // or non-string value is NOT — that is a malformed row, and guessing "worker" from malformed
   // data is the same collapse this predicate exists to prevent.
   if (raw === undefined || raw === null) return ROLE_VERDICT.WORKER;
   if (typeof raw !== 'string' || !raw.trim()) return ROLE_VERDICT.UNKNOWN;
-  return roleIdentityFor(raw) ? ROLE_VERDICT.ROLE : ROLE_VERDICT.WORKER;
+  return isRoleName(raw) ? ROLE_VERDICT.ROLE : ROLE_VERDICT.WORKER;
+}
+
+/**
+ * Is this role STRING a role seat — including lifecycle variants of a known role?
+ *
+ * FOUND BY A REAL INVOCATION, NOT BY A TEST. Running the actual hook against live sessions showed
+ * a heartbeating `role=adam_retired` seat being told `[ROLE] WORKER (callsign: Adam)` — this SD's
+ * own defect, surviving for a role variant the naming map does not contain. No unit test with
+ * fixtures I chose would have tried that string, because I would have picked the roles I already
+ * knew about.
+ *
+ * The PREDICATE is deliberately wider than ROLE_IDENTITY. That map exists to give a seat a
+ * status-line NAME, and a retired seat may legitimately have no name; but it is still not a fleet
+ * worker, and telling it to push WIP on a claim-bound branch is still wrong. Family match on
+ * `<known>_<suffix>` rather than "any non-empty string" so `role: 'gardener'` stays WORKER — an
+ * unrecognised role is a real answer, not a lifecycle variant.
+ */
+function isRoleName(raw) {
+  const v = String(raw || '').trim().toLowerCase();
+  if (!v) return false;
+  if (ROLE_IDENTITY[v]) return true;
+  return Object.keys(ROLE_IDENTITY).some((known) => v.startsWith(`${known}_`));
 }
 
 /** Pure: classify the on-disk identity file contents. */
@@ -164,6 +191,6 @@ async function shouldApplyWorkerMachinery(opts) {
 
 module.exports = {
   ROLE_IDENTITY, roleIdentityFor, writeRoleStatusIdentity, IDENTITY_DIR,
-  ROLE_VERDICT, verdictFromMetadata, verdictFromIdentityFile, readIdentityFile,
+  ROLE_VERDICT, verdictFromMetadata, verdictFromIdentityFile, readIdentityFile, isRoleName,
   roleVerdictFor, shouldApplyWorkerMachinery,
 };

--- a/tests/unit/fleet/role-predicate.test.js
+++ b/tests/unit/fleet/role-predicate.test.js
@@ -128,3 +128,25 @@ describe('TS-12 CONTROL — the role-side assertions can actually fail', () => {
     expect(real).not.toBe(await stub());                  // the real predicate must DIFFER
   });
 });
+
+describe('lifecycle role variants — found by a REAL invocation, not by a fixture', () => {
+  it('adam_retired is a ROLE seat, not a worker', async () => {
+    // Running the actual hook against live sessions showed a heartbeating role=adam_retired seat
+    // being told "[ROLE] WORKER (callsign: Adam)" — this SD's own defect, surviving for a variant
+    // my ROLE_IDENTITY map does not contain. I would never have picked this string as a fixture.
+    expect(verdictFromMetadata({ role: 'adam_retired' })).toBe(ROLE_VERDICT.ROLE);
+  });
+
+  it('non_fleet=true is authoritative on its own, whatever the role string says', () => {
+    // The SD's Solomon amendment: the class fires on ANY role=*/non_fleet=true seat.
+    expect(verdictFromMetadata({ non_fleet: true, role: 'something-unheard-of' })).toBe(ROLE_VERDICT.ROLE);
+    expect(verdictFromMetadata({ non_fleet: true })).toBe(ROLE_VERDICT.ROLE);
+  });
+
+  it('an unrecognised role is STILL a worker — family match, not any-non-empty-string', () => {
+    // The widening is for lifecycle variants of a KNOWN role, not a blanket "anything with a role
+    // key is a role seat". An unrecognised role is a real answer.
+    expect(verdictFromMetadata({ role: 'gardener' })).toBe(ROLE_VERDICT.WORKER);
+    expect(verdictFromMetadata({ role: 'adamant' })).toBe(ROLE_VERDICT.WORKER);   // prefix, not family
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #6800. The `INVOCATION_PATH_PROOF` gate refused LEAD-FINAL — machinery-class
deliverable with no ACTIVATED evidence. I ran the real hook against **live** role sessions instead
of registering an ARMED row, and it caught what 19 unit tests did not:

```
BEFORE: role=adam_retired (live, heartbeating) → "[ROLE] WORKER (callsign: Adam)"
```

That is **this SD's own defect, surviving inside its fix** — for a role variant `ROLE_IDENTITY`
doesn't contain. No unit test with fixtures I chose would have tried that string, because I'd have
picked the roles I already knew about.

## The fix, bounded on purpose

- `non_fleet === true` is authoritative on its own — the SD's Solomon amendment says the class
  fires on **any** `role=*/non_fleet=true` seat.
- A role string matching `<known>_<suffix>` is a lifecycle **variant** of a known role.

Deliberately **not** "any non-empty role string": `role='gardener'` stays WORKER, and a test pins
`role='adamant'` as WORKER so the family match cannot decay into a prefix match. An unrecognised
role is a real answer, not a variant.

The predicate is now wider than `ROLE_IDENTITY`, and that separation is the point — the map exists
to give a seat a status-line **name**, and a retired seat may legitimately have none, but it is
still not a fleet worker.

## Verified at the real hook, not just in tests

| seat | before | after |
|---|---|---|
| `adam_retired` (live) | `WORKER (callsign: Adam)` | `ADAM_RETIRED session (non_fleet)` |
| `solomon` (live) | role lines | role lines |
| my own worker session | full directive | full directive, unchanged |

508 tests across 31 uncapped suites.

## One self-inflicted stumble worth recording

My edit left a duplicate `const raw`, making the module unparseable. **vitest reported "no tests"
rather than a failure** — a suite that cannot load looks identical to a suite with nothing in it.
I checked the module parses before believing that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)