### PR TITLE
feat(SD-LEO-INFRA-BOTH-BELT-GAUGES-001): scope-capable belt gauges for reporting — the demand gate keeps reading the fleet total

### DIFF
--- a/lib/fleet/belt-depth.cjs
+++ b/lib/fleet/belt-depth.cjs
@@ -75,6 +75,15 @@ function requireResolvableLane(scope) {
  * the silent undercount with no alarm. This check converts that coincidence into an
  * enforced invariant: the moment a variant appears, the scoped read REFUSES instead of
  * under-reporting.
+ *
+ * ⚠ READ THIS BEFORE DELETING THIS FUNCTION AS DEAD CODE. It exists BECAUSE the variant
+ * count in quick_fixes is currently ZERO — not despite it. If you re-run the measurement,
+ * find zero variants, and conclude the guard never fires and can go: that zero is exactly
+ * what the guard is protecting, and removing it restores a silent undercount in the
+ * SOURCED direction the first time anyone writes 'ehg' instead of 'EHG'. A guard whose
+ * condition is currently false is not dead code; it is a guard that is working. The only
+ * evidence that would retire this is an ENFORCED constraint on the column (a CHECK, an
+ * enum, or a normalising trigger) — at which point delete it and cite the constraint.
  */
 async function assertLaneUnambiguous(supabase, table, scope) {
   const { fetchAllPaginated } = await import('../db/fetch-all-paginated.mjs');

--- a/lib/fleet/belt-depth.cjs
+++ b/lib/fleet/belt-depth.cjs
@@ -32,6 +32,65 @@ const { applyClaimableQfFilter } = require('../coordinator/qf-supply-predicate.c
 // which is precisely the over-count this QF fixes.
 const ELIGIBILITY_COLUMNS = 'id, sd_key, sd_type, status, metadata, target_application, dependencies';
 
+// ---------------------------------------------------------------------------
+// LANE SCOPING — SD-LEO-INFRA-BOTH-BELT-GAUGES-001. REPORTING AND DIAGNOSIS ONLY.
+//
+// NO GATE CONSUMES A SCOPED READING, and that is a REQUIREMENT (FR-1), not a
+// limitation to be tidied up later. The demand gate compares `value <= floor`, so
+// every scoping moves the reading DOWN and therefore MONOTONICALLY TOWARD SOURCED.
+// Measured live: 158 fleet-wide vs 1 in the EHG lane against floor 3 — scoping the
+// gate would flip today's verdict from WITHHELD to SOURCED, i.e. fail open ON ITS
+// FIRST RUN on the exact axis demand-gate.js exists to hold. Worse, it is unfixable
+// from here: both minters shell out to create-quick-fix.js, which mints into the
+// GLOBAL pool, so a lane reading cannot correctly gate a global mint no matter how
+// carefully the scoping is done. The mismatch is between the reading and the ACTION.
+//
+// So: scope-CAPABLE for reporting, and the gate keeps reading the fleet total.
+const normalizeLane = (v) => String(v == null ? '' : v).toLowerCase().replace(/[^a-z0-9]/g, '');
+
+/** A scope that cannot be resolved to a lane is a FAILED MEASUREMENT, never 0. */
+function requireResolvableLane(scope) {
+  if (typeof scope !== 'string' || normalizeLane(scope) === '') {
+    throw new Error(`belt-depth: unresolvable lane scope (${JSON.stringify(scope)}) — refusing to guess. A scoped read that cannot name its lane must surface as UNMEASURABLE, because returning 0 reads as an empty belt and 0 <= floor SOURCES.`);
+  }
+}
+
+/**
+ * THROW if more than one spelling in `table` normalizes to `scope`.
+ *
+ * WHY THIS EXISTS RATHER THAN A BARE .eq(). A head-count cannot filter in memory, so
+ * the QF gauge must push the lane into PostgREST as an exact match — and an exact
+ * match silently drops every other spelling of the same lane. That undercount is the
+ * SOURCED direction, and it is silent.
+ *
+ * MEASURED 2026-08-04, and the result is backwards from what the design assumed:
+ * quick_fixes has 1343 rows and ZERO variant lanes, so .eq() is exactly correct there
+ * TODAY — while strategic_directives_v2 has SIX variant lanes and 22 at-risk rows
+ * (EHG/ehg, datadistill/DataDistill, axiom-insights/"Axiom Insights", ...) and is the
+ * gauge that holds its rows and can normalize in memory. The hazard is absent where it
+ * would be unfixable and present where it is trivial.
+ *
+ * That makes the clean QF column SAFE BY COINCIDENCE — safe because the data happens
+ * to be tidy, with nothing enforcing it. One 'ehg' landing in quick_fixes would restore
+ * the silent undercount with no alarm. This check converts that coincidence into an
+ * enforced invariant: the moment a variant appears, the scoped read REFUSES instead of
+ * under-reporting.
+ */
+async function assertLaneUnambiguous(supabase, table, scope) {
+  const { fetchAllPaginated } = await import('../db/fetch-all-paginated.mjs');
+  // Paginated deliberately: a truncated read could miss the very variant this guards
+  // against, turning the guard into decoration that always passes.
+  const rows = await fetchAllPaginated(() => supabase.from(table).select('target_application'));
+  const want = normalizeLane(scope);
+  const spellings = new Set();
+  for (const r of rows || []) {
+    if (normalizeLane(r.target_application) === want) spellings.add(r.target_application);
+  }
+  if (spellings.size > 1) {
+    throw new Error(`belt-depth: lane ${JSON.stringify(scope)} is AMBIGUOUS in ${table} — ${JSON.stringify([...spellings])}. An exact-match scope would count one spelling and silently drop the rest, under-reporting toward SOURCED. Refusing to report a number that is wrong in the fail-open direction.`);
+  }
+}
+
 /**
  * Count belt depth with ineligible rows excluded BEFORE emission.
  *
@@ -43,16 +102,26 @@ const ELIGIBILITY_COLUMNS = 'id, sd_key, sd_type, status, metadata, target_appli
  * @param {object} supabase
  * @returns {Promise<{dispatchable:number, raw:number, ineligible:Record<string,number>}>}
  */
-async function countDispatchableBacklog(supabase) {
+async function countDispatchableBacklog(supabase, scope) {
   const { fetchAllPaginated } = await import('../db/fetch-all-paginated.mjs');
   // queryFactory must return a FRESH builder per page and must NOT pre-range — fetchAllPaginated
   // applies .range() itself.
-  const rows = await fetchAllPaginated(() =>
+  let rows = await fetchAllPaginated(() =>
     supabase
       .from('strategic_directives_v2')
       .select(ELIGIBILITY_COLUMNS)
       .eq('status', 'draft')
       .is('claiming_session_id', null));
+
+  // Scoped in MEMORY, not in the query, and that is the correct choice here rather than a
+  // convenience: this gauge already holds the rows, and strategic_directives_v2 is the table
+  // that actually carries spelling variants (6 lanes, 22 rows). Normalizing absorbs them, so a
+  // scoped SD reading is exact by construction and needs no ambiguity guard.
+  if (scope !== undefined && scope !== null) {
+    requireResolvableLane(scope);
+    const want = normalizeLane(scope);
+    rows = (rows || []).filter((r) => normalizeLane(r.target_application) === want);
+  }
 
   const ineligible = {};
   let dispatchable = 0;
@@ -112,9 +181,17 @@ async function countDispatchableBacklog(supabase) {
  * @param {object} supabase
  * @returns {Promise<number>} count of unclaimed, claimable-status quick_fixes
  */
-async function countClaimableQuickFixes(supabase) {
-  const { count, error } = await applyClaimableQfFilter(
-    supabase.from('quick_fixes').select('id', { count: 'exact', head: true }));
+async function countClaimableQuickFixes(supabase, scope) {
+  let builder = supabase.from('quick_fixes').select('id', { count: 'exact', head: true });
+  if (scope !== undefined && scope !== null) {
+    requireResolvableLane(scope);
+    // Guard BEFORE the read, not after: once the count comes back there is nothing in it that
+    // could reveal the dropped spellings — an undercount and a genuinely small lane are the
+    // same number.
+    await assertLaneUnambiguous(supabase, 'quick_fixes', scope);
+    builder = builder.eq('target_application', scope);
+  }
+  const { count, error } = await applyClaimableQfFilter(builder);
   if (error) throw error;
   // A NON-NUMERIC COUNT IS A FAILED MEASUREMENT, NOT AN EMPTY BELT — and this branch, not the
   // `error` branch above, is the dangerous one. PostgREST returns {count:null, error:null} for a
@@ -140,9 +217,9 @@ async function countClaimableQuickFixes(supabase) {
  * @param {object} supabase
  * @returns {Promise<{sdDepth:number, qfDepth:number, total:number, raw:number, ineligible:object}>}
  */
-async function countBeltDepth(supabase) {
-  const sd = await countDispatchableBacklog(supabase);
-  const qfDepth = await countClaimableQuickFixes(supabase);
+async function countBeltDepth(supabase, scope) {
+  const sd = await countDispatchableBacklog(supabase, scope);
+  const qfDepth = await countClaimableQuickFixes(supabase, scope);
   return { sdDepth: sd.dispatchable, qfDepth, total: sd.dispatchable + qfDepth, raw: sd.raw, ineligible: sd.ineligible };
 }
 

--- a/tests/unit/coordinator/qf-supply-gauge-agreement.test.js
+++ b/tests/unit/coordinator/qf-supply-gauge-agreement.test.js
@@ -61,8 +61,47 @@ describe('FR-4: gauge and chokepoint agree on the axis where they used to disagr
       expect(isAutoStartableQF(f.row, Date.now())).toBe(f.claimable);
       // The property that actually matters: nothing is counted as supply that a worker cannot take.
       if (isClaimableQfSupply(f.row)) expect(isAutoStartableQF(f.row, Date.now())).toBe(true);
+
+      // SD-LEO-INFRA-BOTH-BELT-GAUGES-001 — THE OTHER DIRECTION, which was unasserted.
+      //
+      // The line above catches PHANTOM supply (counted but unclaimable) — the original defect. It
+      // is silent about INVISIBLE supply: work a worker CAN take that the gauge does not count.
+      // That direction is the dangerous one for the demand gate, because a lower reading makes
+      // `value <= floor` MORE likely and therefore SOURCES — under-reporting causes over-minting.
+      //
+      // The naive converse (claimable -> supply) is FALSE BY DESIGN, and the NOTE above says why:
+      // isAutoStartableQF answers "is this row FIT for auto-start" while the candidate query
+      // answers "is it FREE", so a row held by a live session is legitimately claimable-but-not-
+      // supply. Asserting the bare converse would pin a fiction. Controlling for the claimant axis
+      // gives the property that is actually true and actually load-bearing:
+      //
+      //   for a FREE row, FIT and COUNTED must agree exactly.
+      //
+      // HONEST SCOPE OF WHAT THIS ADDS, measured rather than asserted. I mutated the predicate to
+      // `&& target_application === 'EHG'` — the exact lane narrowing this SD proposes — and three
+      // tests failed, but the FIRST was line 60's `toBe(f.supply)`. The fixture table already pins
+      // both predicates on all five rows, so it catches that mutation WITHOUT this block. Claiming
+      // "without this the change ships green" would have been false, and it is the kind of claim a
+      // test comment is never audited for.
+      //
+      // What this DOES add is a constraint on fixtures not yet written: a future row given
+      // supply:false + claimable:true while FREE is a contradiction of the model, and the table
+      // alone would happily encode it as expected behaviour — pinning the defect as the
+      // requirement, which is the failure mode this suite has already hit once elsewhere.
+      if (f.row.claiming_session_id === null) {
+        expect(isClaimableQfSupply(f.row)).toBe(isAutoStartableQF(f.row, Date.now()));
+      }
     });
   }
+
+  it('the free-row biconditional is not vacuous — free rows exist on BOTH sides of it', () => {
+    // Control for the control. If every free fixture landed on one side, the assertion above would
+    // hold trivially and could never discriminate — the cannot-fail shape this suite already
+    // guards against one paragraph down.
+    const free = fixtures.filter((f) => f.row.claiming_session_id === null);
+    expect(free.some((f) => isClaimableQfSupply(f.row))).toBe(true);
+    expect(free.some((f) => !isClaimableQfSupply(f.row))).toBe(true);
+  });
 
   it('the intersection is NON-EMPTY — an always-false gauge would trivially "agree"', () => {
     // Load-bearing control. Without it, a gauge that counts nothing satisfies every assertion above

--- a/tests/unit/governance/belt-gauge-contract-freeze.test.js
+++ b/tests/unit/governance/belt-gauge-contract-freeze.test.js
@@ -1,0 +1,162 @@
+// SD-LEO-INFRA-BOTH-BELT-GAUGES-001 — THE CONTRACT FREEZE.
+//
+// WRITTEN AND GREEN BEFORE ANY CHANGE, DELIBERATELY. A freeze authored after the change tests the
+// change; a freeze authored before it tests the contract. Everything here must pass against today's
+// code untouched — if any assertion needs editing to accommodate the lane-scope work, that edit IS
+// the finding, and the design is wrong.
+//
+// WHAT IT PROTECTS. Two failure modes, both silent, both permanent:
+//
+// 1. PERMANENT WITHHOLD. measureDemand calls gauge(supabase) with ONE argument. Anything that makes
+//    the gauge throw, or return a shape normalizeGaugeReading cannot read, becomes gauge_absent ->
+//    UNMEASURABLE -> mayProduce false -> both QF minters withheld FOREVER, announcing UNMEASURABLE
+//    into a GHA log nobody reads. That is the silent-off failure lib/governance/demand-gate.js
+//    exists to prevent, reachable one level down inside the gauge.
+//
+// 2. SILENT CONSUMER DEGRADATION. Nine call sites read these gauges. Two degrade without erroring:
+//    coordinator-capacity-forecast coerces a non-number to a 0 QF contribution and over-reports a
+//    deficit; adam-coordinator-health asserts EXACT EQUALITY against a second counter, so scoping
+//    one side and not the other sets integrity_ok=false on every run, forever.
+//
+// NOTE ON ARGC: argc is deliberately NOT frozen. It is legitimately 1 today and becomes 2 if the
+// scope ships as an input parameter. Freezing it would forbid the intended change rather than
+// protect the contract — the distinction this file is about.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { measureDemand, resolveDemandFloor } from '../../../lib/governance/demand-gate-emit.js';
+import { DEMAND_DECISION } from '../../../lib/governance/demand-gate.js';
+
+const require_ = createRequire(import.meta.url);
+const { countClaimableQuickFixes, countDispatchableBacklog, countBeltDepth } =
+  require_('../../../lib/fleet/belt-depth.cjs');
+
+/**
+ * A supabase stub WIDE ENOUGH for both gauges' real chains, and deliberately wider than the ones
+ * already in the suite. The existing stubs model select->eq->is->range and select->is->in exactly;
+ * a second .eq() (which any lane scope would add) makes them return undefined and throw a
+ * TypeError. Widening here means the freeze does not itself become the thing that breaks.
+ */
+function wideStub({ count = 0, rows = [] } = {}) {
+  const chain = {
+    select() { return chain; },
+    eq() { return chain; },
+    is() { return chain; },
+    in() { return chain; },
+    not() { return chain; },
+    or() { return chain; },
+    order() { return chain; },
+    range() { return Promise.resolve({ data: rows, count, error: null }); },
+    then(res) { return Promise.resolve({ data: rows, count, error: null }).then(res); },
+  };
+  return { from() { return chain; } };
+}
+
+describe('FREEZE 1 — a scope-less call can never yield UNMEASURABLE', () => {
+  // Exercised through the REAL measureDemand and the REAL decideDemand. A `measure:` or `decide:`
+  // stub here would assert the stub, which is the trap TS-6's own header records elsewhere in this
+  // suite: when the outcome cannot discriminate, the test proves nothing.
+  it('a healthy gauge called with one argument yields a real verdict and a finite value', async () => {
+    const demand = await measureDemand(wideStub({ count: 7 }), {
+      engine: 'freeze-test',
+      floor: 3,
+      gauge: async () => 7,
+    });
+    expect(demand.decision).not.toBe(DEMAND_DECISION.UNMEASURABLE);
+    expect([DEMAND_DECISION.SOURCED, DEMAND_DECISION.WITHHELD]).toContain(demand.decision);
+    // Assert the VALUE, not merely that it is finite — a wrong-but-finite reading is the defect
+    // this whole SD is about, and finiteness cannot see it.
+    expect(demand.gauge_value).toBe(7);
+    expect(demand.decision).toBe(DEMAND_DECISION.WITHHELD); // 7 > floor 3
+  });
+
+  it('a reading at or below the floor sources — both sides of the comparison move', async () => {
+    const demand = await measureDemand(wideStub({ count: 1 }), {
+      engine: 'freeze-test', floor: 3, gauge: async () => 1,
+    });
+    expect(demand.decision).toBe(DEMAND_DECISION.SOURCED);
+    expect(demand.gauge_value).toBe(1);
+  });
+
+  // THE POSITIVE CONTROL. Without this, "not.toBe(UNMEASURABLE)" passes trivially in a world where
+  // unmeasurable is unreachable — a cannot-fail assertion dressed as a guard. This proves the state
+  // EXISTS and is reachable, so the assertions above are load-bearing.
+  it('a THROWING gauge really does reach UNMEASURABLE — the state is reachable', async () => {
+    const demand = await measureDemand(wideStub(), {
+      engine: 'freeze-test', floor: 3,
+      gauge: async () => { throw new Error('gauge exploded'); },
+    });
+    expect(demand.decision).toBe(DEMAND_DECISION.UNMEASURABLE);
+    expect(demand.gauge_value).toBeNull();
+  });
+
+  it('a gauge returning a shape the normalizer cannot read ALSO reaches UNMEASURABLE', async () => {
+    // The per-lane-object hazard, pinned as a hazard rather than as an aspiration: an object with
+    // no .dispatchable is exactly what a naive lane envelope would produce.
+    const demand = await measureDemand(wideStub(), {
+      engine: 'freeze-test', floor: 3,
+      gauge: async () => ({ EHG_Engineer: 155, EHG: 1 }),
+    });
+    expect(demand.decision).toBe(DEMAND_DECISION.UNMEASURABLE);
+  });
+
+  it('the floor resolves to its documented default when unset', () => {
+    expect(resolveDemandFloor({})).toBe(3);
+  });
+});
+
+describe('FREEZE 2 — return shapes, by EXACT key set', () => {
+  // Exact key-set equality is the load-bearing detail. toMatchObject passes when a key is ADDED,
+  // and an added key is precisely what breaks the two silent consumers. So compare the sorted key
+  // list, not a subset.
+  it('countDispatchableBacklog returns exactly {dispatchable, ineligible, raw}', async () => {
+    const res = await countDispatchableBacklog(wideStub({ rows: [] }));
+    expect(Object.keys(res).sort()).toEqual(['dispatchable', 'ineligible', 'raw']);
+    expect(typeof res.dispatchable).toBe('number');
+  });
+
+  it('countClaimableQuickFixes returns a BARE NUMBER, not an envelope', async () => {
+    const res = await countClaimableQuickFixes(wideStub({ count: 12 }));
+    expect(typeof res).toBe('number');
+    expect(res).toBe(12);
+  });
+
+  it('countBeltDepth returns exactly {ineligible, qfDepth, raw, sdDepth, total} and total is the sum', async () => {
+    const res = await countBeltDepth(wideStub({ count: 4, rows: [] }));
+    expect(Object.keys(res).sort()).toEqual(['ineligible', 'qfDepth', 'raw', 'sdDepth', 'total']);
+    expect(res.total).toBe(res.sdDepth + res.qfDepth);
+  });
+
+  // FORWARD-COMPATIBILITY INVARIANT. Green today (the second arg is ignored) and green after the
+  // scope ships (the second arg defaults to unscoped). This is the single assertion that says
+  // "adding the parameter must not change the default behaviour" — the whole design constraint,
+  // in one line.
+  it('passing an explicit undefined scope equals passing nothing', async () => {
+    const a = await countClaimableQuickFixes(wideStub({ count: 9 }));
+    const b = await countClaimableQuickFixes(wideStub({ count: 9 }), undefined);
+    expect(b).toBe(a);
+  });
+
+  it('the same invariant holds for the backlog gauge', async () => {
+    const a = await countDispatchableBacklog(wideStub({ rows: [] }));
+    const b = await countDispatchableBacklog(wideStub({ rows: [] }), undefined);
+    expect(Object.keys(b).sort()).toEqual(Object.keys(a).sort());
+    expect(b.dispatchable).toBe(a.dispatchable);
+  });
+});
+
+describe('FREEZE 3 — the direction property that bounds the whole defect', () => {
+  // The original SD framed this as 0.7% imprecision and called it harmless. The real property is
+  // stronger and points the other way: because total >= any lane and the gate is `value <= floor`,
+  // blindness can only ever produce a false WITHHELD, NEVER a false SOURCED. There is no flood
+  // risk in this defect, and any change that could source where the fleet total would not has
+  // inverted it.
+  it('a smaller reading can only move the verdict toward SOURCED, never away', async () => {
+    const bigger = await measureDemand(wideStub(), { engine: 'e', floor: 3, gauge: async () => 158 });
+    const smaller = await measureDemand(wideStub(), { engine: 'e', floor: 3, gauge: async () => 1 });
+    expect(bigger.decision).toBe(DEMAND_DECISION.WITHHELD);
+    expect(smaller.decision).toBe(DEMAND_DECISION.SOURCED);
+    // Stated as the invariant rather than the example: scoping DOWN is monotonically toward
+    // sourcing, which is the fail-OPEN direction of a module built to fail closed.
+    expect(smaller.gauge_value).toBeLessThan(bigger.gauge_value);
+  });
+});

--- a/tests/unit/governance/belt-gauge-lane-scope.test.js
+++ b/tests/unit/governance/belt-gauge-lane-scope.test.js
@@ -1,0 +1,107 @@
+// SD-LEO-INFRA-BOTH-BELT-GAUGES-001 — TS-8: the scoped path refuses rather than under-reports.
+//
+// WHY EVERY ASSERTION HERE IS TWO-SIDED. The failure this guards is a SILENT UNDERCOUNT, and an
+// undercount is a perfectly ordinary-looking number. `expect(...).not.toBe(145)` cannot tell a
+// throw from a 0, and 0 is the dangerous answer: the demand gate compares `value <= floor`, so 0
+// SOURCES. A test that only checks "not the happy value" would pass on the exact defect.
+//
+// The gate itself is NOT scoped and must never be (FR-1). Everything here is the reporting path.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const { countClaimableQuickFixes, countDispatchableBacklog } =
+  require_('../../../lib/fleet/belt-depth.cjs');
+
+/**
+ * Stub modelling BOTH shapes this module uses: a head-count (`{count}` awaited directly) and a
+ * paginated row fetch (`.range()` per page). `laneRows` feeds the ambiguity guard's read.
+ */
+function stub({ count = 0, laneRows = [], sdRows = null } = {}) {
+  const calls = { eq: [], tables: [] };
+  const make = (table) => {
+    let page = 0;
+    const chain = {
+      select() { return chain; },
+      eq(col, val) { calls.eq.push([col, val]); return chain; },
+      is() { return chain; },
+      in() { return chain; },
+      range() {
+        // One page then empty, so fetchAllPaginated terminates.
+        const rows = page++ === 0 ? (table === 'quick_fixes' ? laneRows : (sdRows || [])) : [];
+        return Promise.resolve({ data: rows, count, error: null });
+      },
+      then(res) { return Promise.resolve({ data: [], count, error: null }).then(res); },
+    };
+    return chain;
+  };
+  return { from(t) { calls.tables.push(t); return make(t); }, __calls: calls };
+}
+
+describe('TS-8a — an unresolvable scope THROWS, and specifically does not return 0', () => {
+  for (const bad of ['', '   ', '!!!', 42, {}, []]) {
+    it(`rejects ${JSON.stringify(bad)} rather than guessing`, async () => {
+      // SIDE ONE: it throws.
+      await expect(countClaimableQuickFixes(stub({ count: 9 }), bad)).rejects.toThrow(/unresolvable lane/i);
+      // SIDE TWO: it did not merely return something falsy. Captured explicitly, because a
+      // function that returned 0 would satisfy "did not return 9" just as well as a throw does.
+      let returned = 'DID_NOT_RETURN';
+      try { returned = await countClaimableQuickFixes(stub({ count: 9 }), bad); } catch { /* expected */ }
+      expect(returned).toBe('DID_NOT_RETURN');
+      expect(returned).not.toBe(0);
+    });
+  }
+
+  it('the SD gauge refuses on the same axis', async () => {
+    await expect(countDispatchableBacklog(stub({ sdRows: [] }), '')).rejects.toThrow(/unresolvable lane/i);
+  });
+});
+
+describe('TS-8b — an AMBIGUOUS lane refuses rather than counting one spelling', () => {
+  // MEASURED 2026-08-04: quick_fixes has 1343 rows and ZERO variant lanes, so .eq() is correct
+  // there TODAY. That is SAFE BY COINCIDENCE — nothing enforces the tidiness. This test is the
+  // enforcement: the moment a second spelling appears, the scoped read refuses.
+  it('two spellings of one lane => throw naming both', async () => {
+    const s = stub({ count: 5, laneRows: [{ target_application: 'EHG' }, { target_application: 'ehg' }] });
+    await expect(countClaimableQuickFixes(s, 'EHG')).rejects.toThrow(/AMBIGUOUS/);
+  });
+
+  it('POSITIVE CONTROL — a single spelling does NOT throw, so the guard is not always-on', async () => {
+    // Without this, the assertion above passes just as well against a guard that refuses
+    // everything, which would be a different bug wearing the same green.
+    const s = stub({ count: 5, laneRows: [{ target_application: 'EHG' }, { target_application: 'EHG' }] });
+    await expect(countClaimableQuickFixes(s, 'EHG')).resolves.toBe(5);
+    expect(s.__calls.eq).toContainEqual(['target_application', 'EHG']);
+  });
+
+  it('a DIFFERENT lane sharing no normal form does not trigger ambiguity', async () => {
+    const s = stub({ count: 2, laneRows: [{ target_application: 'EHG' }, { target_application: 'EHG_Engineer' }] });
+    await expect(countClaimableQuickFixes(s, 'EHG')).resolves.toBe(2);
+  });
+});
+
+describe('TS-8c — the SD gauge absorbs spelling variants instead of dropping them', () => {
+  // The measured asymmetry, pinned: strategic_directives_v2 is the table that ACTUALLY carries
+  // variants (6 lanes, 22 rows), and it is the gauge that holds its rows — so normalising in
+  // memory makes a scoped SD reading exact by construction. A .eq() here would have dropped them.
+  it('EHG and ehg both count toward the EHG lane', async () => {
+    const rows = [
+      { id: 1, sd_key: 'A', sd_type: 'feature', status: 'draft', metadata: {}, target_application: 'EHG', dependencies: null },
+      { id: 2, sd_key: 'B', sd_type: 'feature', status: 'draft', metadata: {}, target_application: 'ehg', dependencies: null },
+      { id: 3, sd_key: 'C', sd_type: 'feature', status: 'draft', metadata: {}, target_application: 'EHG_Engineer', dependencies: null },
+    ];
+    const res = await countDispatchableBacklog(stub({ sdRows: rows }), 'EHG');
+    // raw is post-scope: the two EHG spellings, NOT the Engineer row.
+    expect(res.raw).toBe(2);
+  });
+
+  it('CONTROL — the same fixture unscoped sees all three, so the filter is doing the work', async () => {
+    const rows = [
+      { id: 1, sd_key: 'A', sd_type: 'feature', status: 'draft', metadata: {}, target_application: 'EHG', dependencies: null },
+      { id: 2, sd_key: 'B', sd_type: 'feature', status: 'draft', metadata: {}, target_application: 'ehg', dependencies: null },
+      { id: 3, sd_key: 'C', sd_type: 'feature', status: 'draft', metadata: {}, target_application: 'EHG_Engineer', dependencies: null },
+    ];
+    const res = await countDispatchableBacklog(stub({ sdRows: rows }));
+    expect(res.raw).toBe(3);
+  });
+});

--- a/tests/unit/governance/belt-gauge-lane-scope.test.js
+++ b/tests/unit/governance/belt-gauge-lane-scope.test.js
@@ -8,6 +8,8 @@
 // The gate itself is NOT scoped and must never be (FR-1). Everything here is the reporting path.
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
+import { openQfMintGate } from '../../../lib/governance/qf-mint-gate.mjs';
+import { DEMAND_DECISION } from '../../../lib/governance/demand-gate.js';
 
 const require_ = createRequire(import.meta.url);
 const { countClaimableQuickFixes, countDispatchableBacklog } =
@@ -77,6 +79,66 @@ describe('TS-8b — an AMBIGUOUS lane refuses rather than counting one spelling'
   it('a DIFFERENT lane sharing no normal form does not trigger ambiguity', async () => {
     const s = stub({ count: 2, laneRows: [{ target_application: 'EHG' }, { target_application: 'EHG_Engineer' }] });
     await expect(countClaimableQuickFixes(s, 'EHG')).resolves.toBe(2);
+  });
+});
+
+describe('TS-6b — the REAL gauge, run across the floor (FR-5)', () => {
+  // FR-5 AS WRITTEN WOULD HAVE BEEN A NO-OP, and saying so is the point of this block.
+  //
+  // The ruling was: "TS-6's fixture MUST STRADDLE THE FLOOR or the identity-preserving mutation is
+  // invisible." Correct diagnosis, wrong lever. TS-6 asserts gauge IDENTITY
+  // (expect(seenGauge).toBe(countClaimableQuickFixes)) while STUBBING `measure`, so the gauge is
+  // captured and never called. Its `decision()` helper hardcodes BOTH gauge_value:1 AND the
+  // decision, so changing that 1 to a 7 changes nothing any assertion can observe — it is a
+  // fixture for a stub, not an input to a comparison. Editing it would have produced literal
+  // compliance and zero additional discrimination.
+  //
+  // The mutation actually feared is one INSIDE countClaimableQuickFixes that preserves its
+  // identity — a lane narrowing being the live candidate. Identity assertions cannot see it and
+  // neither can a stubbed measure. The only thing that can is running the REAL gauge through the
+  // REAL measureDemand with a count that MOVES ACROSS THE FLOOR, which is what these two do:
+  // omitting `measure` lets defaultMeasure run, and omitting `gauge` lets the real gauge run.
+  // FILTER-AWARE ON PURPOSE. A stub that returns a fixed count no matter what is applied to it
+  // cannot see a lane narrowing at all — the mutation would add .eq('target_application', ...),
+  // the count would come back unchanged, and this whole block would stay green while proving
+  // nothing. Modelling the filter's EFFECT is what makes the floor-straddle discriminating:
+  // an unscoped read returns `count`, a lane-scoped one returns the smaller `scopedCount`, and
+  // the verdict flips across the floor exactly as it would in production.
+  const gateStub = (count, scopedCount = count) => ({
+    from: () => {
+      let scoped = false;
+      const c = {
+        select: () => c,
+        eq: (col) => { if (col === 'target_application') scoped = true; return c; },
+        is: () => c, in: () => c,
+        then: (r) => Promise.resolve({ data: [], count: scoped ? scopedCount : count, error: null }).then(r),
+      };
+      return c;
+    },
+  });
+
+  it('a real reading ABOVE the floor withholds — and a LANE NARROWING would flip it', async () => {
+    // scopedCount 1 is the trap being set: if a future edit teaches countClaimableQuickFixes to
+    // filter by target_application, this stub returns 1 instead of 7, 1 <= 3 SOURCES, and this
+    // assertion fails. That is the identity-preserving mutation ruling (7) was aimed at, and it
+    // is caught here rather than in TS-6, which cannot see it.
+    const { allowed, demand } = await openQfMintGate(gateStub(7, 1), {
+      engine: 'fr5', env: { BELT_DEMAND_FLOOR: '3' }, record: async () => {}, log: () => {},
+    });
+    expect(demand.gauge_value).toBe(7);
+    expect(demand.decision).toBe(DEMAND_DECISION.WITHHELD);
+    expect(allowed).toBe(false);
+  });
+
+  it('a real reading AT OR BELOW the floor sources — the fixture straddles', async () => {
+    // The other side. Without it the pair above is satisfied by a gauge that always reads high,
+    // which is precisely the "cannot see a mutation that preserves what it asserts" trap.
+    const { allowed, demand } = await openQfMintGate(gateStub(2), {
+      engine: 'fr5', env: { BELT_DEMAND_FLOOR: '3' }, record: async () => {}, log: () => {},
+    });
+    expect(demand.gauge_value).toBe(2);
+    expect(demand.decision).toBe(DEMAND_DECISION.SOURCED);
+    expect(allowed).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What this is

Both belt gauges gain an **optional lane scope**, and **no gate consumes it**. That non-scoping is FR-1 — a requirement, not a limitation.

## Why the original design was refused

The SD was sourced to make the gauges application-aware so the demand gate would stop withholding an EHG-lane producer on a number describing EHG_Engineer's belt. LEAD measurement refuted the premise:

- The gate's only comparison is `reading.value <= floor`. Every scoping moves the reading **down**, monotonically toward SOURCED. Measured live: **fleet 158 → WITHHELD, EHG lane 1 → SOURCED** against floor 3. The change would fail open on its first run, on the exact axis the module exists to hold.
- It is unfixable from inside this SD: both minters shell out to `create-quick-fix.js`, which mints into the **global** pool. A lane reading cannot gate a global mint — the mismatch is between the reading and the *action*.

Coordinator accepted the reduction in full. The real finding (a producer whose work is lane-specific minting into a pool that is not) is filed separately.

## The measurement that changed the design

The ruling assumed `.eq()` scoping was unsafe because of spelling variants. Measured by paginated fetch:

| table | rows | variant lanes | rows a naive `.eq()` misses |
|---|---|---|---|
| `quick_fixes` (head-count gauge, forced onto `.eq()`) | 1343 | **0** | 0 |
| `strategic_directives_v2` (row-fetch gauge, can normalize) | 5543 | **6** | 22 |

The hazard is absent exactly where it would be unfixable and present exactly where it is trivial. So the SD gauge normalizes in memory; the QF gauge uses `.eq()` — but that is **safe by coincidence**, and `assertLaneUnambiguous` converts the coincidence into an enforced invariant. A second spelling makes the scoped read refuse rather than silently under-report.

An unresolvable scope **throws** rather than returning 0, because `0 <= floor` sources.

## PR size justification (464 lines, over the 400 threshold)

**~94 lines are source** (`lib/fleet/belt-depth.cjs`); **370 are tests**. The split is deliberate:

- `belt-gauge-contract-freeze.test.js` (162) was authored and green **before** any change. A freeze written afterward tests the change; written before, it tests the contract. It passes **unedited** against the final code — the acceptance criterion that would have halted the design.
- `belt-gauge-lane-scope.test.js` (169) covers the throw (two-sided), the ambiguity guard with a positive control, and FR-5.

Splitting would ship the source change without the freeze that bounds it, which is the riskier arrangement.

## Verified, not asserted

- Freeze suite passes **unedited**.
- Mutation: neutering the ambiguity guard kills exactly one test, positive control stays green.
- Mutation: an identity-preserving lane narrowing **fails** the new TS-6b while `qf-mint-gate.test.js` stays **21/21 green** — the blindness the coordinator predicted, now demonstrated.
- 335 files / 4298 tests / 0 failures across governance, coordinator, fleet.
- Live smoke: gate reads the fleet total (158), scoped gauges return 157 and 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)