### PR TITLE
fix(QF-20260804-569): a crashed sub-agent run is not evidence

### DIFF
--- a/scripts/modules/handoff/gates/subagent-evidence-gate.js
+++ b/scripts/modules/handoff/gates/subagent-evidence-gate.js
@@ -82,11 +82,31 @@ const REJECT_VERDICTS = new Set(['FAIL', 'BLOCKED', 'PENDING', 'MANUAL_REQUIRED'
  * @param {string|null|undefined} verdict
  * @returns {'accept'|'reject'|'unknown'}
  */
+/**
+ * QF-20260804-569 — verdicts that mean THE CHECK NEVER RAN, as distinct from ran-and-rejected.
+ *
+ * ERROR is written when the executor CRASHES (e.g. `--code EXPLORE` dies with "Failed to load
+ * sub-agent EXPLORE from database" and still writes a row). PENDING is written when a run never
+ * finished. Neither is a verdict about the SD — they are the absence of one.
+ *
+ * They used to sit in REJECT_VERDICTS alongside FAIL, which made them subject to
+ * SUBAGENT_VERDICT_MODE — advisory by default. So a crashed run bought the same passage as a real
+ * one: "a row exists" was being read as "the check ran". Measured on two separate SDs.
+ *
+ * This is a PREDICATE change, not a policy change. It does not make the gate stricter about real
+ * verdicts — FAIL/BLOCKED/MANUAL_REQUIRED keep exactly their current advisory-or-block behaviour.
+ * It stops a crash from counting as evidence at all.
+ */
+const NON_EVIDENCE_VERDICTS = new Set(['ERROR', 'PENDING']);
+
 export function classifyVerdict(verdict) {
   if (verdict === null || verdict === undefined) return 'unknown';
   const v = String(verdict).trim().toUpperCase();
   if (v === '') return 'unknown';
   if (ACCEPT_VERDICTS.has(v)) return 'accept';
+  // Checked BEFORE reject: both sets list ERROR/PENDING today, and this ordering is what makes
+  // them non-evidence rather than a rejection. Do not reorder.
+  if (NON_EVIDENCE_VERDICTS.has(v)) return 'nonevidence';
   if (REJECT_VERDICTS.has(v)) return 'reject';
   return 'unknown';
 }
@@ -374,11 +394,18 @@ export async function validateSubagentEvidence(ctx, supabase) {
   // exists and says FAIL is not "the agent may still be mid-write".
   const failing = [];
   const unknownVerdicts = [];
+  // QF-20260804-569: agents whose latest row proves the check DID NOT RUN (crash / never
+  // finished). Tracked separately from `failing` because a rejection is a verdict and these are
+  // the absence of one — and separately from `missing` because these are NOT the FR-2 race window
+  // (a row exists; the agent is not mid-write). They block unconditionally, ignoring
+  // SUBAGENT_VERDICT_MODE, since there is no verdict for that mode to be lenient about.
+  const nonEvidence = [];
   for (const r of required) {
     const row = latestByCode.get(norm(r));
     if (!row) continue;
     const klass = classifyVerdict(row.verdict);
-    if (klass === 'reject') failing.push({ agent: r, verdict: row.verdict, created_at: row.created_at });
+    if (klass === 'nonevidence') nonEvidence.push({ agent: r, verdict: row.verdict, created_at: row.created_at });
+    else if (klass === 'reject') failing.push({ agent: r, verdict: row.verdict, created_at: row.created_at });
     else if (klass === 'unknown') unknownVerdicts.push({ agent: r, verdict: row.verdict });
   }
 
@@ -403,6 +430,22 @@ export async function validateSubagentEvidence(ctx, supabase) {
       u => `SUBAGENT_VERDICT_UNKNOWN: ${u.agent} latest evidence carries unrecognised verdict ${JSON.stringify(u.verdict)} — accepted (fail-open), but classify it in ACCEPT_VERDICTS/REJECT_VERDICTS.`
     );
     for (const u of unknownVerdicts) console.log(`   ❔ ${u.agent}: unrecognised verdict ${JSON.stringify(u.verdict)} — accepted with warning`);
+
+    // QF-20260804-569: a crashed or never-finished run is NOT evidence. Checked before the
+    // verdict-mode branch below, and deliberately not routed through it — SUBAGENT_VERDICT_MODE
+    // decides how lenient to be about a VERDICT, and there is no verdict here.
+    if (nonEvidence.length > 0) {
+      const ne = nonEvidence.map(f => `${f.agent}=${f.verdict}`).join(', ');
+      const head = `SUBAGENT_EVIDENCE_NOT_RUN: ${ne} — the run crashed or never finished, so no check was performed. A row existing is not the check having run.`;
+      console.log(`   ❌ ${head}`);
+      return buildFailResult({
+        score: 0,
+        max_score: 100,
+        issues: [head],
+        details: { reason: 'SUBAGENT_EVIDENCE_NOT_RUN', non_evidence: nonEvidence, ...verdictDetails },
+        remediation: `Re-run ${nonEvidence.map(f => f.agent).join(', ')} for SD ${sdKey} until it writes a real verdict. If the agent code cannot be executed at all (e.g. it names a Claude Code agent TYPE with no row in the sub-agent catalog), that is a REQUIREMENT defect, not a worker error — the required-agent list is naming something no CLI path can satisfy.`
+      });
+    }
 
     if (failing.length === 0) {
       console.log(`   ✅ All required sub-agents have fresh PASSING evidence (${required.length}/${required.length})`);

--- a/tests/unit/subagent-evidence-gate.test.js
+++ b/tests/unit/subagent-evidence-gate.test.js
@@ -301,7 +301,10 @@ describe('classifyVerdict — verdict policy', () => {
     expect(classifyVerdict(v)).toBe('accept');
   });
 
-  it.each(['FAIL', 'BLOCKED', 'PENDING', 'MANUAL_REQUIRED'])('rejects %s', (v) => {
+  // QF-20260804-569: PENDING left this list — it is now `nonevidence` (the run never
+  // finished, so no check was performed). Its own classification is pinned in the
+  // QF-20260804-569 describe block below. FAIL/BLOCKED/MANUAL_REQUIRED are unchanged.
+  it.each(['FAIL', 'BLOCKED', 'MANUAL_REQUIRED'])('rejects %s', (v) => {
     expect(classifyVerdict(v)).toBe('reject');
   });
 
@@ -375,7 +378,9 @@ describe('validateSubagentEvidence — verdict enforcement (block mode)', () => 
     expect(result.details.failing).toEqual([]);
   });
 
-  it.each(['BLOCKED', 'PENDING', 'MANUAL_REQUIRED'])('%s does not satisfy', async (verdict) => {
+  // QF-20260804-569: PENDING still DOES NOT SATISFY — it now blocks unconditionally via the
+  // non-evidence path rather than via verdict mode, and is asserted there instead.
+  it.each(['BLOCKED', 'MANUAL_REQUIRED'])('%s does not satisfy', async (verdict) => {
     const supabase = rows({ sub_agent_code: 'TESTING', created_at: '2026-04-24T21:00:00Z', verdict });
     const result = await validateSubagentEvidence(ctx(), supabase);
     expect(result.passed).toBe(false);
@@ -550,9 +555,14 @@ describe('validateSubagentEvidence — advisory mode is the DEFAULT and does not
     });
     const result = await validateSubagentEvidence({ sd: makeSD(), handoffType: 'PLAN-TO-EXEC' }, supabase);
     expect(result.passed).toBe(false);
-    expect(result.details.failing).toEqual([
+    // QF-20260804-569: ERROR now lands in `non_evidence` rather than `failing`. The original
+    // intent of this regression — an execution-error verdict must NOT satisfy the gate, and must
+    // NOT be swallowed as `unknown` — is preserved and STRENGTHENED: non-evidence blocks
+    // unconditionally, where `failing` was subject to SUBAGENT_VERDICT_MODE (advisory by default).
+    expect(result.details.non_evidence).toEqual([
       expect.objectContaining({ agent: 'TESTING', verdict: 'ERROR' })
     ]);
+    expect(result.details.failing).toEqual([]);
     // And it must NOT be reported as an unknown verdict — that would mean it was accepted.
     expect(result.details.unknown_verdicts).toEqual([]);
   });
@@ -571,5 +581,61 @@ describe('validateSubagentEvidence — advisory mode is the DEFAULT and does not
     // the fail-open branch is deliberate and must still exist for values outside the constraint.
     expect(classifyVerdict('SOMETHING_INVENTED_LATER')).toBe('unknown');
     expect(classifyVerdict(null)).toBe('unknown');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// QF-20260804-569 — a crashed run is NOT evidence.
+//
+// ERROR (executor crashed) and PENDING (run never finished) used to sit in REJECT_VERDICTS, which
+// made them subject to SUBAGENT_VERDICT_MODE — advisory by default. So a crashed run bought the
+// same passage as a real one: "a row exists" was read as "the check ran". Measured on two separate
+// SDs before this fix.
+//
+// The fix is a PREDICATE change, so these tests pin BOTH halves: the new class, and the fact that
+// every other verdict is untouched. A change that quietly made FAIL stricter would be a different
+// (and unrequested) behaviour change.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+describe('QF-20260804-569: ERROR/PENDING are non-evidence, not rejections', () => {
+  it('classifies a crashed run as nonevidence', () => {
+    expect(classifyVerdict('ERROR')).toBe('nonevidence');
+  });
+
+  it('classifies a never-finished run as nonevidence', () => {
+    expect(classifyVerdict('PENDING')).toBe('nonevidence');
+  });
+
+  it('is case- and whitespace-insensitive, like every other verdict path', () => {
+    expect(classifyVerdict('  error ')).toBe('nonevidence');
+    expect(classifyVerdict('Pending')).toBe('nonevidence');
+  });
+
+  it('TWO-SIDED: a genuine rejection is STILL a rejection, not non-evidence', () => {
+    // The half that matters. If FAIL became nonevidence, this would silently convert an advisory
+    // warning into a hard block for every SD in the fleet — a policy change nobody asked for.
+    expect(classifyVerdict('FAIL')).toBe('reject');
+    expect(classifyVerdict('BLOCKED')).toBe('reject');
+    expect(classifyVerdict('MANUAL_REQUIRED')).toBe('reject');
+  });
+
+  it('TWO-SIDED: passing verdicts are untouched', () => {
+    expect(classifyVerdict('PASS')).toBe('accept');
+    expect(classifyVerdict('CONDITIONAL_PASS')).toBe('accept');
+    expect(classifyVerdict('WARNING')).toBe('accept');
+  });
+
+  it('TWO-SIDED: unrecognised and empty verdicts still fail open as unknown', () => {
+    expect(classifyVerdict('SOMETHING_NEW')).toBe('unknown');
+    expect(classifyVerdict('')).toBe('unknown');
+    expect(classifyVerdict(null)).toBe('unknown');
+  });
+
+  it('CONTROL: nonevidence is a DISTINCT class — not an alias for reject or unknown', () => {
+    // Without this, the whole change could be satisfied by returning 'reject' (the old behaviour)
+    // or 'unknown' (which fails OPEN and would be strictly worse than before).
+    const ne = classifyVerdict('ERROR');
+    expect(ne).not.toBe(classifyVerdict('FAIL'));
+    expect(ne).not.toBe(classifyVerdict('SOMETHING_NEW'));
+    expect(ne).not.toBe(classifyVerdict('PASS'));
   });
 });

--- a/tests/unit/subagent-verdict-laundering.test.js
+++ b/tests/unit/subagent-verdict-laundering.test.js
@@ -17,6 +17,22 @@ import { describe, it, expect } from 'vitest';
 import { mapVerdict, ABSENT_VERDICT } from '../../lib/sub-agent-executor/results-storage.js';
 import { classifyVerdict } from '../../scripts/modules/handoff/gates/subagent-evidence-gate.js';
 
+/**
+ * QF-20260804-569: this suite's subject is LAUNDERING — a verdict being softened into one the gate
+ * ACCEPTS. It previously pinned the exact class name 'reject', which made it brittle to a
+ * taxonomy change rather than to a behaviour change: ERROR and PENDING are now classified
+ * 'nonevidence' (the run crashed or never finished, so no check was performed), which blocks
+ * UNCONDITIONALLY where 'reject' was subject to SUBAGENT_VERDICT_MODE — strictly stronger than
+ * what these tests were defending.
+ *
+ * So assert the PROPERTY these tests actually mean: not accepted, and not fail-open 'unknown'.
+ * That survives the taxonomy growing again and still fails if anything is genuinely laundered.
+ */
+function expectBlocking(verdict, label) {
+  const klass = classifyVerdict(verdict);
+  expect(['reject', 'nonevidence'], `${label ?? verdict} classified ${klass}`).toContain(klass);
+}
+
 /** The eight values valid_verdict permits (migration 20260130). */
 const ALLOWED = new Set(['PASS', 'FAIL', 'BLOCKED', 'CONDITIONAL_PASS', 'WARNING', 'MANUAL_REQUIRED', 'PENDING', 'ERROR']);
 
@@ -24,39 +40,39 @@ describe('the gate can finally SEE rejecting verdicts (FR-2)', () => {
   it('MANUAL_REQUIRED reaches the gate as REJECT — 141 production rows were laundered here', () => {
     // BEFORE: mapVerdict -> 'WARNING' -> classifyVerdict -> 'accept' -> no warning at all.
     expect(mapVerdict('MANUAL_REQUIRED')).toBe('MANUAL_REQUIRED');
-    expect(classifyVerdict(mapVerdict('MANUAL_REQUIRED'))).toBe('reject');
+    expectBlocking(mapVerdict('MANUAL_REQUIRED'));
   });
 
   it('PENDING reaches the gate as REJECT — tested separately because the map treated both identically', () => {
     // Testing only MANUAL_REQUIRED and assuming PENDING followed is exactly how the second
     // one stays broken; the old map sent both to WARNING via two distinct lines.
     expect(mapVerdict('PENDING')).toBe('PENDING');
-    expect(classifyVerdict(mapVerdict('PENDING'))).toBe('reject');
+    expectBlocking(mapVerdict('PENDING'));
   });
 
   it('ERROR is stored as itself rather than flattened to FAIL', () => {
     // Both reject, so this is not a policy change — it is truthfulness. The old mapping
     // discarded the distinction between "the agent rejected" and "the agent crashed".
     expect(mapVerdict('ERROR')).toBe('ERROR');
-    expect(classifyVerdict(mapVerdict('ERROR'))).toBe('reject');
+    expectBlocking(mapVerdict('ERROR'));
   });
 
   it('UNKNOWN becomes BLOCKED — not in the eight, so it must translate, and it must reject', () => {
     expect(mapVerdict('UNKNOWN')).toBe('BLOCKED');
-    expect(classifyVerdict(mapVerdict('UNKNOWN'))).toBe('reject');
+    expectBlocking(mapVerdict('UNKNOWN'));
   });
 });
 
 describe('the unmodelled fallback no longer means "accepted" (FR-1)', () => {
   it('free text lands on a REJECTING verdict', () => {
     // BEFORE: `|| 'WARNING'` — not-understood silently meant accepted.
-    expect(classifyVerdict(mapVerdict('NEEDS_HUMAN'))).toBe('reject');
-    expect(classifyVerdict(mapVerdict('totally-made-up'))).toBe('reject');
+    expectBlocking(mapVerdict('NEEDS_HUMAN'));
+    expectBlocking(mapVerdict('totally-made-up'));
   });
 
   it('an agent that returned NOTHING lands on a REJECTING verdict — 15 production rows', () => {
     for (const nothing of [undefined, null, '']) {
-      expect(classifyVerdict(mapVerdict(nothing)), `verdict=${JSON.stringify(nothing)}`).toBe('reject');
+      expectBlocking(mapVerdict(nothing), `verdict=${JSON.stringify(nothing)}`);
     }
   });
 
@@ -106,7 +122,7 @@ describe('REGRESSION GUARD — the 60 live outliers must not become hard failure
     // change corrects. `includes` matching would read the embedded "pass" and accept them.
     const prose = 'FAIL — 4 of 6 prior REQUIRED items are closed and were re-verified, but the primary sd:next path is still inert';
     expect(mapVerdict(prose)).toBe('FAIL');
-    expect(classifyVerdict(mapVerdict(prose))).toBe('reject');
+    expectBlocking(mapVerdict(prose));
   });
 
   it('ERROR keeps its tripwire: only genuinely unclassifiable values land there', () => {
@@ -118,7 +134,7 @@ describe('REGRESSION GUARD — the 60 live outliers must not become hard failure
     // should look at, so ERROR is the right destination.
     for (const junk of ['HIGH', 'NO_DUPLICATES_FOUND_EXTEND_EXISTING_FILES']) {
       expect(mapVerdict(junk), junk).toBe('ERROR');
-      expect(classifyVerdict(mapVerdict(junk))).toBe('reject');
+      expectBlocking(mapVerdict(junk));
     }
     // And the pass-family does NOT land there — that is the regression guard.
     expect(mapVerdict('PASS_WITH_CONCERNS')).not.toBe('ERROR');
@@ -131,7 +147,7 @@ describe('REGRESSION GUARD — the 60 live outliers must not become hard failure
     expect(mapVerdict('STRATEGY_APPROVED_WITH_REQUIRED_ADDITIONS')).toBe('CONDITIONAL_PASS');
     expect(classifyVerdict(mapVerdict('STRATEGY_APPROVED_WITH_REQUIRED_ADDITIONS'))).toBe('accept');
     expect(mapVerdict('STRATEGY_BLOCK_ALL_ADDITIONS_COMMITTED_TO_EXEC')).toBe('BLOCKED');
-    expect(classifyVerdict(mapVerdict('STRATEGY_BLOCK_ALL_ADDITIONS_COMMITTED_TO_EXEC'))).toBe('reject');
+    expectBlocking(mapVerdict('STRATEGY_BLOCK_ALL_ADDITIONS_COMMITTED_TO_EXEC'));
   });
 
   it('only the FIRST THREE tokens are scanned — a verdict announces itself at the front', () => {
@@ -176,7 +192,7 @@ describe('absence is recorded as a value, not an omitted key (FR-4)', () => {
   it('the sentinel is NOT a valid verdict, so it can never be mistaken for one', () => {
     expect(ALLOWED.has(ABSENT_VERDICT)).toBe(false);
     // And if it ever reached the verdict column by accident, it would reject rather than pass.
-    expect(classifyVerdict(mapVerdict(ABSENT_VERDICT))).toBe('reject');
+    expectBlocking(mapVerdict(ABSENT_VERDICT));
   });
 });
 
@@ -191,7 +207,7 @@ describe('NEGATION — a negated pass is not a pass (found by review, not by me)
     'NOT A PASS', 'DID NOT PASS', 'CANNOT PROCEED', 'DO NOT PROCEED',
     'NOT APPROVED', 'NO PASS', 'UNABLE TO PROCEED', 'SHOULD NOT PROCEED',
   ])('%s REJECTS', (verdict) => {
-    expect(classifyVerdict(mapVerdict(verdict))).toBe('reject');
+    expectBlocking(mapVerdict(verdict));
   });
 
   it('OPPOSITE POLARITY: the un-negated forms still ACCEPT — the guard is narrow', () => {
@@ -202,7 +218,7 @@ describe('NEGATION — a negated pass is not a pass (found by review, not by me)
 
   it('negation does not flip a REJECTING verdict into acceptance', () => {
     // "NOT FAIL" is odd phrasing and rare; rejecting is the safe direction either way.
-    expect(classifyVerdict(mapVerdict('NOT FAIL'))).toBe('reject');
-    expect(classifyVerdict(mapVerdict('CANNOT BLOCK'))).toBe('reject');
+    expectBlocking(mapVerdict('NOT FAIL'));
+    expectBlocking(mapVerdict('CANNOT BLOCK'));
   });
 });


### PR DESCRIPTION
## Summary

`ERROR` (executor crashed) and `PENDING` (run never finished) sat in `REJECT_VERDICTS` alongside
`FAIL`, which made them subject to `SUBAGENT_VERDICT_MODE` — **advisory by default**. So a crashed
run bought the same passage as a real one: *"a row exists"* was being read as *"the check ran."*
Measured on two separate SDs.

New `nonevidence` class blocks **unconditionally** and does not consult verdict mode — that mode
decides how lenient to be about a *verdict*, and a crash produced none. Making it
blockable-but-configurable would recreate the bug behind a flag.

Kept out of `missing` deliberately: `missing` carries the FR-2 race-window WAIT ("the agent may
still be mid-write"), which is false when a row exists saying ERROR.

## Predicate change, not a policy change

The tests pin **both** halves. `FAIL`, `BLOCKED`, `MANUAL_REQUIRED` keep their exact current
advisory-or-block behaviour; `PASS`, `CONDITIONAL_PASS`, `WARNING` and unrecognised verdicts are
untouched. A change that quietly made `FAIL` stricter would be a different — and unrequested —
behaviour change.

The remediation text also names the QF's second half: if an agent code **cannot be executed at
all** (e.g. it names a Claude Code agent *type* with no row in the sub-agent catalog), that is a
**requirement defect, not a worker error**. The gate now says so instead of leaving each worker to
rediscover it.

## Two pre-existing suites updated — deliberately, not deleted

- **`subagent-evidence-gate.test.js`** — ERROR now lands in `non_evidence` rather than `failing`.
  The original regression's intent (an execution-error verdict must not satisfy the gate, and must
  not be swallowed as `unknown`) is preserved and **strengthened**: non-evidence blocks
  unconditionally where `failing` was advisory. Only the field moved.
- **`subagent-verdict-laundering.test.js`** — 14 assertions pinned the literal class `'reject'`.
  That suite's subject is *laundering*: a verdict softened into one the gate **accepts**. It was
  pinning a **name** when it meant a **property**. Rewritten to assert
  not-accepted-and-not-fail-open, which survives the taxonomy growing again and still fails if
  anything is genuinely laundered.

A test failing because the taxonomy grew is not the same as a test failing because behaviour
regressed. Treating those identically is how real regressions get deleted alongside stale ones.

## Test plan

- Source diff **+44/−1**, inside the QF 50-LOC cap; the remaining 99 lines are tests.
- **277 tests across 17 uncapped suites**, scoped by grepping for consumers rather than by folder.
- A control asserts `nonevidence` is a *distinct* class — not an alias for `reject` (the old
  behaviour) or `unknown` (which fails **open** and would be strictly worse than before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)