### PR TITLE
fix(QF-20260804-926): restore the advisory safety valve the previous QF removed

### DIFF
--- a/scripts/modules/handoff/gates/subagent-evidence-gate.js
+++ b/scripts/modules/handoff/gates/subagent-evidence-gate.js
@@ -437,6 +437,41 @@ export async function validateSubagentEvidence(ctx, supabase) {
     if (nonEvidence.length > 0) {
       const ne = nonEvidence.map(f => `${f.agent}=${f.verdict}`).join(', ');
       const head = `SUBAGENT_EVIDENCE_NOT_RUN: ${ne} — the run crashed or never finished, so no check was performed. A row existing is not the check having run.`;
+
+      // QF-20260804-926 — RESTORE THE DOCUMENTED SAFETY VALVE.
+      //
+      // QF-20260804-569 made non-evidence block UNCONDITIONALLY, ignoring verdict mode. That half
+      // is correct and hard-won — a crashed run must not buy the same passage as a real one — but
+      // it shipped WITHOUT its satisfiability half, and required-subagents.js:49-56 had already
+      // named the precondition verbatim:
+      //
+      //   "PRECONDITION FOR PROMOTING SUBAGENT_VERDICT_MODE=block: the residual ~10% ... is 100%
+      //    attributable to the unregistered-EXPLORE CLI path leaving a tombstone as the last row.
+      //    Resolve that first ... Until then the gate's advisory default keeps this cost at zero."
+      //
+      // LEAD-TO-PLAN still requires 'Explore', a Claude Code BUILT-IN absent from leo_sub_agents,
+      // so `--code EXPLORE` throws and writes a tombstone. Blocking on it makes LEAD-TO-PLAN
+      // unpassable for any seat restricted to the CLI path — no action available to that worker
+      // produces a passing row. Measured cohort: ~10% of SDs (187/209 = 89.5% unaffected).
+      //
+      // So non-evidence now honours the SAME mode flag as a rejecting verdict, until Explore is
+      // resolved (harness_backlog 6529e3a3). This is NOT re-softening ERROR/PENDING generally:
+      // they remain a DISTINCT class, they are still never accepted, and under
+      // SUBAGENT_VERDICT_MODE=block they still block. What returns is the operator's ability to
+      // turn the enforcement on deliberately rather than having it arrive as a side effect.
+      if (mode !== 'block') {
+        const warn = `${head} (mode: ${mode} — advisory until the required-agent list is satisfiable from every invocation path; see required-subagents.js:49-56)`;
+        console.log(`   ⚠️  ${warn}`);
+        return {
+          passed: true,
+          score: 100,
+          max_score: 100,
+          issues: [],
+          warnings: [...unknownWarnings, warn],
+          details: { reason: 'SUBAGENT_EVIDENCE_NOT_RUN_ADVISORY', non_evidence: nonEvidence, ...verdictDetails }
+        };
+      }
+
       console.log(`   ❌ ${head}`);
       return buildFailResult({
         score: 0,

--- a/tests/unit/subagent-evidence-gate.test.js
+++ b/tests/unit/subagent-evidence-gate.test.js
@@ -639,3 +639,57 @@ describe('QF-20260804-569: ERROR/PENDING are non-evidence, not rejections', () =
     expect(ne).not.toBe(classifyVerdict('PASS'));
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+// QF-20260804-926 — the safety valve QF-20260804-569 removed.
+//
+// required-subagents.js:49-56 names the precondition verbatim: promoting to block is gated on the
+// unregistered-EXPLORE CLI tombstone being resolved first, and "until then the gate's advisory
+// default keeps this cost at zero". The strict half shipped without the satisfiability half, so
+// LEAD-TO-PLAN became unpassable for seats restricted to the CLI path.
+//
+// Non-evidence therefore honours the SAME mode flag as a rejecting verdict. This is NOT a
+// re-softening: ERROR/PENDING remain a distinct class, are never ACCEPTED, and still block under
+// SUBAGENT_VERDICT_MODE=block.
+// ─────────────────────────────────────────────────────────────────────────────────────────────
+describe('QF-20260804-926: non-evidence respects verdict mode', () => {
+  const errorRow = [{ sub_agent_code: 'TESTING', created_at: '2026-04-24T21:00:00Z', verdict: 'ERROR' }];
+
+  it('BLOCKS under SUBAGENT_VERDICT_MODE=block — the strict half is intact', async () => {
+    process.env.SUBAGENT_VERDICT_MODE = 'block';
+    const supabase = makeSupabase({ phaseStart: PHASE_START_ISO, evidenceRows: errorRow });
+    const r = await validateSubagentEvidence({ sd: makeSD(), handoffType: 'PLAN-TO-EXEC' }, supabase);
+    expect(r.passed).toBe(false);
+    expect(r.details.reason).toBe('SUBAGENT_EVIDENCE_NOT_RUN');
+  });
+
+  it('WARNS (does not block) in the advisory default — the documented safety valve', async () => {
+    delete process.env.SUBAGENT_VERDICT_MODE;
+    const supabase = makeSupabase({ phaseStart: PHASE_START_ISO, evidenceRows: errorRow });
+    const r = await validateSubagentEvidence({ sd: makeSD(), handoffType: 'PLAN-TO-EXEC' }, supabase);
+    expect(r.passed).toBe(true);
+    expect(r.details.reason).toBe('SUBAGENT_EVIDENCE_NOT_RUN_ADVISORY');
+    // Never silent: an advisory pass must still say the check did not run.
+    expect(r.warnings.join('\n')).toMatch(/SUBAGENT_EVIDENCE_NOT_RUN/);
+  });
+
+  it('is still NOT accepted as a passing verdict in either mode', async () => {
+    // The half that must not regress. Advisory means "does not block", never "counts as a pass".
+    delete process.env.SUBAGENT_VERDICT_MODE;
+    const supabase = makeSupabase({ phaseStart: PHASE_START_ISO, evidenceRows: errorRow });
+    const r = await validateSubagentEvidence({ sd: makeSD(), handoffType: 'PLAN-TO-EXEC' }, supabase);
+    expect(r.details.non_evidence).toEqual([expect.objectContaining({ agent: 'TESTING', verdict: 'ERROR' })]);
+    expect(classifyVerdict('ERROR')).toBe('nonevidence');   // still a distinct class
+  });
+
+  it('CONTROL: the two modes genuinely differ — the flag is actually consulted', async () => {
+    // Without this, both branches could return the same verdict and the "restoration" would be
+    // cosmetic. Same input, two modes, opposite outcomes.
+    const supabase = () => makeSupabase({ phaseStart: PHASE_START_ISO, evidenceRows: errorRow });
+    process.env.SUBAGENT_VERDICT_MODE = 'block';
+    const blocked = await validateSubagentEvidence({ sd: makeSD(), handoffType: 'PLAN-TO-EXEC' }, supabase());
+    delete process.env.SUBAGENT_VERDICT_MODE;
+    const advisory = await validateSubagentEvidence({ sd: makeSD(), handoffType: 'PLAN-TO-EXEC' }, supabase());
+    expect(blocked.passed).not.toBe(advisory.passed);
+  });
+});


### PR DESCRIPTION
## Summary

**Live blocker, disclosed by the worker who shipped it.** QF-20260804-569 had two coupled halves
and only one landed: `ERROR`/`PENDING` now block **unconditionally**, while `LEAD-TO-PLAN` still
requires `Explore` — a Claude Code built-in absent from `leo_sub_agents`. So `--code EXPLORE`
throws, writes a tombstone, and that tombstone now **blocks** where it previously passed
advisorily. For a seat restricted to the CLI path there is no action that produces a passing
Explore row.

**The code named this precondition and I missed it** — `required-subagents.js:49-56`:

> PRECONDITION FOR PROMOTING SUBAGENT_VERDICT_MODE=block: … 100% attributable to the
> unregistered-EXPLORE CLI path leaving a tombstone as the last row. Resolve that first …
> **Until then the gate's advisory default keeps this cost at zero.**

The advisory default *was* the mitigation. I removed it while believing I was only tightening a
predicate. I then **retracted my own correct alarm** about it, having read lines 24-49, cited the
measurements, and stopped one paragraph short of the precondition — a retraction built on a partial
read of the file I was quoting.

## Fix — option (c), explicitly not a re-softening

Non-evidence honours the same mode flag as a rejecting verdict, until Explore is satisfiable from
every invocation path (`harness_backlog 6529e3a3`). The hard-won half is preserved:

- still a **distinct class** (`classifyVerdict` → `'nonevidence'`)
- still **never accepted** as passing, in either mode
- still **blocks** under `SUBAGENT_VERDICT_MODE=block`
- an advisory pass still emits the NOT_RUN warning — never silent

What returns is the operator's ability to enable enforcement *deliberately*, rather than having it
arrive as a side effect of a predicate change.

## Test plan

- **281 tests across 17 uncapped suites**; source `+35`, inside the QF cap.
- Both modes pinned, plus a **control** asserting they genuinely differ on identical input —
  without it the restoration could be cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)