### PR TITLE
SD-LEO-INFRA-CONTRACT-READ-COVERAGE-001: the margin was the bigger half of the false-fail

### DIFF
--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -171,7 +171,21 @@ function contractTokenCount(root, contractFile) {
  * exceeds it too.
  *
  * ONE-SIDED BY CONSTRUCTION: it can only turn a fits into a does-not-fit. An unavailable tokenizer
- * therefore yields no opinion rather than a clearance, and a wrong ratio cannot make it unsound.
+ * yields no opinion rather than a clearance — and singleReadFit REPORTS that as veto:'unavailable'
+ * rather than letting it look like a clearance, which is a distinction the first version lost.
+ *
+ * *** IT BOUNDS THE HOLE; IT DOES NOT CLOSE IT, AND AN EARLIER COMMENT HERE OVERSTATED THAT. ***
+ * The veto cannot engage until cl100k_raw passes 25,000, and harness is roughly 1.64-1.72x
+ * cl100k_raw on dense content, so a file must already cost ~41,000 true tokens before this fires.
+ * Between the cap and there, a dense contract is still reported as fitting — measured at up to
+ * 60-66% over cap on base64 and random-ASCII fixtures. It fires on NONE of the eight real contracts
+ * today. So this is a backstop against the catastrophic case, not a general density guard.
+ *
+ * ONE-SIDEDNESS IS NOT SOUNDNESS EITHER. The 1.64-1.72 band is measured on PROSE. Across ten content
+ * classes the real span is 0.96-8.00, and emoji-dense text sits BELOW 1.0 — so a constructed
+ * emoji-heavy file can trip the veto while genuinely fitting. That is a false-fail, which is what
+ * this SD exists to remove. No live contract is emoji-dominated, but the veto exists precisely for
+ * a contract that later gains dense content, so the limitation is recorded rather than assumed away.
  */
 function exceedsCapByRawLowerBound(root, contractFile) {
   try {
@@ -278,17 +292,28 @@ function singleReadFit(root, contractFile) {
 
   // THE VETO RUNS FIRST AND CAN ONLY EVER SAY NO. A dense contract that the prose-calibrated bytes
   // model would wave through is caught here, on a bound that needs no calibration to be sound.
-  if (exceedsCapByRawLowerBound(root, contractFile) === true) {
-    return { fits: false, tokens, bytes, basis: 'raw_lower_bound_exceeds_cap', evidence: 'predicted' };
+  //
+  // *** ITS ABSENCE IS REPORTED, NOT SWALLOWED. *** The first version tested `=== true` and let
+  // every other outcome fall through to the size rule — so a null (tokenizer missing, file unreadable
+  // mid-check) produced a verdict IDENTICAL to one where the veto had run and cleared the file.
+  // EXEC review reproduced it on this suite's own dense fixture: with tiktoken blocked, the file the
+  // suite uses to PROVE the veto works flipped to fits:true, and nothing in the output said so.
+  // The null still does not refuse — making it refuse would disarm every seat on a tokenizer hiccup,
+  // which is the disease being cured — but `veto` now distinguishes the three cases so a consumer
+  // that cares can tell "cleared" from "could not check".
+  const vetoed = exceedsCapByRawLowerBound(root, contractFile);
+  const veto = vetoed === true ? 'fired' : vetoed === false ? 'cleared' : 'unavailable';
+  if (vetoed === true) {
+    return { fits: false, tokens, bytes, basis: 'raw_lower_bound_exceeds_cap', evidence: 'predicted', veto };
   }
 
   if (tokens !== null) {
-    return { fits: tokens <= SINGLE_READ_TOKEN_BUDGET, tokens, bytes, basis: 'predicted_bytes', evidence: 'predicted' };
+    return { fits: tokens <= SINGLE_READ_TOKEN_BUDGET, tokens, bytes, basis: 'predicted_bytes', evidence: 'predicted', veto };
   }
   if (bytes !== null) {
-    return { fits: bytes <= SINGLE_READ_SAFE_BYTES, tokens: null, bytes, basis: 'conservative_bytes_degraded', evidence: 'predicted' };
+    return { fits: bytes <= SINGLE_READ_SAFE_BYTES, tokens: null, bytes, basis: 'conservative_bytes_degraded', evidence: 'predicted', veto };
   }
-  return { fits: null, tokens: null, bytes: null, basis: 'unmeasurable', evidence: 'none' };
+  return { fits: null, tokens: null, bytes: null, basis: 'unmeasurable', evidence: 'none', veto };
 }
 
 /**

--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -56,26 +56,24 @@ const FULL_COVERAGE_PCT = 95;
 
 /**
  * The ACTUAL harness limit: a Read returns at most this many TOKENS. Not a proxy for it.
+ *
+ * IMPORTED, not re-declared. This module and the CLAUDE.md generator both answer "how big is this
+ * file to the Read tool", and until SD-LEO-INFRA-CONTRACT-READ-COVERAGE-001 they answered it with
+ * two different scales — which is the condition that produced the false-fails. One quantity, one
+ * home: lib/protocol/harness-token-scale.cjs.
  */
-const SINGLE_READ_TOKEN_CAP = 25000;
+const {
+  HARNESS_BYTES_PER_TOKEN,
+  SINGLE_READ_TOKEN_CAP,
+  harnessTokensFromBytes,
+  cl100kRawLowerBound,
+} = require('./harness-token-scale.cjs');
 
-/**
- * Lazily-loaded cl100k_base encoder, cached. Same lazy+guarded discipline as unionRangeCoverage
- * above, and for the same reason: this module is imported by role-ACTIVATION paths that promise
- * never to block. A tokenizer that cannot load degrades to "unmeasurable", never to "fits".
- */
-let _encoder;
-let _encoderTried = false;
-function loadEncoder() {
-  if (_encoderTried) return _encoder;
-  _encoderTried = true;
-  try {
-    _encoder = require('tiktoken').get_encoding('cl100k_base');
-  } catch {
-    _encoder = null;
-  }
-  return _encoder;
-}
+// The lazily-cached cl100k encoder that used to live here is gone with the cl100k prediction path.
+// Tokenizer loading now happens inside cl100kRawLowerBound in harness-token-scale.cjs, keeping the
+// same lazy+guarded discipline for the same reason: this module is imported by role-ACTIVATION paths
+// that promise never to block, so a tokenizer that will not load must degrade to "no opinion" and
+// never to "fits".
 
 /**
  * *** CALIBRATION AGAINST HARNESS GROUND TRUTH. THE MISSING PIECE THAT MADE THIS GATE WRONG. ***
@@ -101,42 +99,85 @@ function loadEncoder() {
  * ratio is a property of two tokenizers on prose, so it should be re-measured if the contracts stop
  * being prose (see the density discussion above) or if the harness tokenizer changes.
  */
-const CL100K_TO_HARNESS = 1.85;
-
 /**
- * Margin on top of the calibration, for what calibration cannot capture: harness envelope beyond the
- * cat -n framing, and drift in the ratio across content types.
+ * *** CL100K_TO_HARNESS = 1.85 WAS RETIRED HERE. It was wrong three ways at once. ***
+ * SD-LEO-INFRA-CONTRACT-READ-COVERAGE-001. The docblock above is kept as the record of how it was
+ * derived, because the derivation is the lesson; the number itself is gone.
  *
- * Calibrated figures for the real contracts — coordinator ~12.2k, solomon ~32.2k, adam ~51.0k
- * against a 22,500 budget — leave every verdict decided by a wide margin rather than by this number,
- * which is the only thing that makes it honest. (The pre-calibration version of this comment made
- * the same claim on figures that were 1.79x low, and was wrong about Solomon.)
+ * (1) SPAN MISMATCH IN THE DERIVATION. 26138/14617 divided a WHOLE-FILE harness count (371 lines)
+ *     by a cl100k count of the DELIVERED SLICE (lines 1-301). Measured at revision 1ea0403b14ab:
+ *     cl100k(framed, all 371) = 17,372 against cl100k(framed, 1-301) = 14,600, so the honest
+ *     span-matched figure was 1.505 and the shipped one was inflated 1.19x. A ratio whose numerator
+ *     and denominator span different extents is not a calibration.
+ * (2) AND 1.505 IS ALSO WRONG, which is why this is a model change rather than a new number. It
+ *     equals 1.6416/1.0911 where 1.0911 is CLAUDE_SOLOMON.md's OWN framing overhead — a file-specific
+ *     constant wearing a universal label. It false-fails CLAUDE_LEAD.md and CLAUDE_PLAN.md.
+ * (3) THE DEEPER ERROR: THE HARNESS COUNTS RAW CONTENT. Framing is not in it. Measured on a
+ *     controlled pair with IDENTICAL WORDS at a 22x line-count difference, k_raw held at 1.6554 vs
+ *     1.6153 while k_framed swung 1.6348 vs 1.2484. Across 11 ground truths k_raw spans +-3% and
+ *     k_framed spans +-32%. contractTokenCount framed AND multiplied, so it was wrong on both
+ *     factors, and NO single cl100k constant can exist on framed content.
+ *
+ * The scale now lives in ONE place for the whole repo. See lib/protocol/harness-token-scale.cjs.
  */
-const SINGLE_READ_MARGIN = 0.10;
-const SINGLE_READ_TOKEN_BUDGET = Math.floor(SINGLE_READ_TOKEN_CAP * (1 - SINGLE_READ_MARGIN));
+/**
+ * *** THE 10% MARGIN IS GONE, AND REMOVING IT MATTERED MORE THAN THE CONSTANT DID. ***
+ *
+ * The budget was 22,500 while the cap is 25,000. MEASURED actual harness tokens: CLAUDE_SOLOMON.md
+ * 23,897 · CLAUDE_LEAD.md 24,336 · CLAUDE_PLAN.md 23,153 — ALL THREE READ CLEAN, ALL THREE EXCEEDED
+ * 22,500. Only CLAUDE_ADAM.md at 18,857 survived. So A PERFECT PREDICTOR STILL DISARMED THREE OF THE
+ * FOUR CLEAN-READING CONTRACTS: the margin manufactured false-fails on its own, independent of any
+ * constant, and no refit could ever have reached it.
+ *
+ * The comment that used to sit here claimed "every verdict decided by a wide margin rather than by
+ * this number, which is the only thing that makes it honest". That was the sentence that made the
+ * margin look defensible, and it was measurably false for three of the four files it covered.
+ *
+ * *** AND STATE THE RESOLUTION LIMIT RATHER THAN HIDING IT. *** Headroom under the cap: SOLOMON
+ * 1,103 (4.4%) and LEAD 664 (2.7%) are INSIDE this model's own 6.80% error band, so those two
+ * verdicts are inside the noise. PLAN (1,847 / 7.4%) and ADAM (6,143 / 24.6%) are decided with real
+ * margin. A comment claiming confidence the measurement does not support is the defect this module
+ * keeps rediscovering, so it is not repeated here — including in this comment: the review that fed
+ * this SD reported all three of SOLOMON/LEAD/PLAN as inside the band, and 7.4% is not inside 6.8%.
+ * The split is asserted by computation in contract-read-groundtruth.test.js rather than quoted.
+ */
+const SINGLE_READ_TOKEN_BUDGET = SINGLE_READ_TOKEN_CAP;
 
 /**
- * Measured token length of a contract AS THE READ TOOL WOULD DELIVER IT, or null.
+ * Predicted harness token cost of a contract, or null.
  *
- * *** MEASURES THE FRAMED RESPONSE, NOT THE RAW FILE. *** Read returns `cat -n` formatted output, so
- * every line carries a number and a tab that count against the cap. Encoding the raw bytes
- * understates the real cost by ~400-2,000 tokens on these contracts — measuring the wrong artefact
- * is how the byte proxy went wrong in the first place, one level down.
+ * *** NO LONGER FRAMES, AND NO LONGER MULTIPLIES A cl100k COUNT. *** The previous implementation did
+ * both. The harness charges for RAW content, so framing the text before measuring it introduced a
+ * line-count dependence the thing being predicted does not have — which is why one constant fitted
+ * the 371-line Solomon contract and overshot the 1,400-line phase files by 43-61%.
  *
- * encode_ordinary, NOT encode: cl100k_base's `encode` THROWS on special-token literals such as
- * <|endoftext|>, including inline in prose. A contract that merely documents one would have thrown,
- * degraded to the byte fallback, and silently flipped CLAUDE_COORDINATOR.md from ARMED to disarmed
- * on the strength of a documentation string. encode_ordinary treats them as ordinary text.
+ * The name kept its shape so call sites did not have to change, but it is now a PREDICTION from
+ * bytes, not a measurement of tokens. That distinction is surfaced to callers as `evidence` on the
+ * verdict rather than left implicit — a prediction wearing the same label as an observation is how
+ * the original defect survived review.
  */
 function contractTokenCount(root, contractFile) {
+  return harnessTokensFromBytes(contractSizeBytes(root, contractFile));
+}
+
+/**
+ * The density veto. Returns true when the contract PROVABLY exceeds the cap, whatever its content.
+ *
+ * The bytes model is calibrated on prose-and-table documents and is content-blind: random ASCII,
+ * base64 and minified text run 1.32-1.77 B/token against its 2.4177, so a contract that gains a
+ * base64 blob would be predicted to FIT while actually truncating — the original defect, restored by
+ * its own fix. cl100k on RAW content is a strictly sound LOWER bound (harness/cl100k_raw measured
+ * 1.642-1.715 across every byte-paired receipt), so exceeding the cap there proves the real cost
+ * exceeds it too.
+ *
+ * ONE-SIDED BY CONSTRUCTION: it can only turn a fits into a does-not-fit. An unavailable tokenizer
+ * therefore yields no opinion rather than a clearance, and a wrong ratio cannot make it unsound.
+ */
+function exceedsCapByRawLowerBound(root, contractFile) {
   try {
-    const enc = loadEncoder();
-    if (!enc) return null;
     const raw = fs.readFileSync(path.join(root, contractFile), 'utf8');
-    const framed = raw.split('\n').map((line, i) => `${String(i + 1).padStart(6)}\t${line}`).join('\n');
-    // CALIBRATED to the harness tokenizer. Returning the raw cl100k count here is what armed a role
-    // whose contract demonstrably truncates — see CL100K_TO_HARNESS.
-    return Math.ceil(enc.encode_ordinary(framed).length * CL100K_TO_HARNESS);
+    const lower = cl100kRawLowerBound(raw);
+    return lower === null ? null : lower > SINGLE_READ_TOKEN_CAP;
   } catch {
     return null;
   }
@@ -204,7 +245,17 @@ function contractTokenCount(root, contractFile) {
  * derived from, and stopped being sound when that quantity was redefined. Derived now, so it moves
  * with the calibration instead of having to be remembered.
  */
-const SINGLE_READ_SAFE_BYTES = Math.floor(SINGLE_READ_TOKEN_BUDGET / CL100K_TO_HARNESS);
+/**
+ * RE-DERIVED against the bytes scale, because it was derived from the retired constant and a stale
+ * derived bound is the same defect one level down.
+ *
+ * *** IT IS NOW NEARLY VESTIGIAL, AND SAYING SO IS THE POINT. *** The primary path is itself a bytes
+ * prediction, so this degraded-mode bound differs from it only by rounding. It survives for the case
+ * where the file cannot even be stat'ed, and the existing relational assertion that it stays under
+ * BUDGET is NOT evidence it is right — that inequality holds for any ratio at or above 1.0 and would
+ * not notice an unintended loosening. Pin it against a measured value or do not pin it at all.
+ */
+const SINGLE_READ_SAFE_BYTES = Math.floor(SINGLE_READ_TOKEN_BUDGET * HARNESS_BYTES_PER_TOKEN);
 
 /**
  * Can this contract be read in ONE call? Measured, with an explicit "cannot tell".
@@ -212,7 +263,12 @@ const SINGLE_READ_SAFE_BYTES = Math.floor(SINGLE_READ_TOKEN_BUDGET / CL100K_TO_H
  * `fits: null` is a first-class answer and must never be coerced to true — an unmeasurable contract
  * is exactly the case where promoting absence of evidence to compliance does the damage.
  *
- * @returns {{fits: boolean|null, tokens: number|null, bytes: number|null, basis: string}}
+ * *** EVERY VERDICT NOW CARRIES ITS EVIDENCE KIND. *** The original defect survived review because a
+ * PREDICTION wore the same label as an OBSERVATION, so a consumer could not weight them differently.
+ * `evidence` is 'predicted' here in every branch, and that is not a placeholder: it is the honest
+ * answer. There is no 'direct' kind, deliberately — see the note on it below.
+ *
+ * @returns {{fits: boolean|null, tokens: number|null, bytes: number|null, basis: string, evidence: string}}
  */
 function singleReadFit(root, contractFile) {
   const rawBytes = contractSizeBytes(root, contractFile);
@@ -220,16 +276,41 @@ function singleReadFit(root, contractFile) {
   const rawTokens = contractTokenCount(root, contractFile);
   const tokens = Number.isFinite(Number(rawTokens)) && Number(rawTokens) > 0 ? Number(rawTokens) : null;
 
+  // THE VETO RUNS FIRST AND CAN ONLY EVER SAY NO. A dense contract that the prose-calibrated bytes
+  // model would wave through is caught here, on a bound that needs no calibration to be sound.
+  if (exceedsCapByRawLowerBound(root, contractFile) === true) {
+    return { fits: false, tokens, bytes, basis: 'raw_lower_bound_exceeds_cap', evidence: 'predicted' };
+  }
+
   if (tokens !== null) {
-    return { fits: tokens <= SINGLE_READ_TOKEN_BUDGET, tokens, bytes, basis: 'measured_tokens' };
+    return { fits: tokens <= SINGLE_READ_TOKEN_BUDGET, tokens, bytes, basis: 'predicted_bytes', evidence: 'predicted' };
   }
   if (bytes !== null) {
-    // Degraded mode: no tokenizer. Fall back to the provably-sound byte floor, never to the old
-    // tuned proxy, and say so in the basis rather than letting it read as a measurement.
-    return { fits: bytes <= SINGLE_READ_SAFE_BYTES, tokens: null, bytes, basis: 'conservative_bytes_no_tokenizer' };
+    return { fits: bytes <= SINGLE_READ_SAFE_BYTES, tokens: null, bytes, basis: 'conservative_bytes_degraded', evidence: 'predicted' };
   }
-  return { fits: null, tokens: null, bytes: null, basis: 'unmeasurable' };
+  return { fits: null, tokens: null, bytes: null, basis: 'unmeasurable', evidence: 'none' };
 }
+
+/**
+ * The evidence kinds this module can actually emit. EXPORTED SO A TEST CAN ASSERT WHAT IS ABSENT.
+ *
+ * *** THERE IS DELIBERATELY NO 'direct' / notice-derived KIND, AND THAT IS A MEASURED DECISION. ***
+ * The obvious design is to mark a verdict as directly observed when the harness reports a truncation.
+ * A structured consumer for exactly that already exists — scripts/hooks/protocol-file-tracker.cjs
+ * reads tool_response.file.truncatedByTokenCap and writes lastReadTruncatedByHarness. THE HARNESS HAS
+ * NEVER FED IT: measured on .claude/unified-session-state.json, 13 tracked files and 1,464 recorded
+ * reads produced ZERO truncation flags, ZERO deliveredRanges and ZERO lastDelivered — including
+ * CLAUDE_EXEC.md and CLAUDE_CORE.md, both of which certainly truncate.
+ *
+ * Parsing the notice text instead is not a fallback worth having: the string is undocumented, it has
+ * ALREADY VARIED in this repo's own records (26138 and 26142 recorded for one file), and it is
+ * unverified that the hook even receives it.
+ *
+ * So the label is omitted rather than shipped unreachable. An enum value nothing can ever emit is a
+ * field name that is a claim the implementation does not meet — the same shape as the constant this
+ * SD retired. The dormant consumer is left in place for the day the harness does feed it.
+ */
+const EVIDENCE_KINDS = Object.freeze(['predicted', 'none']);
 
 /**
  * Report a coverage percentage. FLOOR, never round.
@@ -496,4 +577,7 @@ function contractReadVerdict(status, totalLines, opts = {}) {
 module.exports = {
   contractReadVerdict, contractLineCount, contractSizeBytes, contractTokenCount, singleReadFit,
   FULL_COVERAGE_PCT, SINGLE_READ_SAFE_BYTES, SINGLE_READ_TOKEN_CAP, SINGLE_READ_TOKEN_BUDGET,
+  // EVIDENCE_KINDS is exported so a test can assert what this module CANNOT emit. Asserting the
+  // absence of the 'direct' kind is the only way to keep an unreachable label from being re-added.
+  EVIDENCE_KINDS, exceedsCapByRawLowerBound, HARNESS_BYTES_PER_TOKEN,
 };

--- a/lib/protocol/harness-token-scale.cjs
+++ b/lib/protocol/harness-token-scale.cjs
@@ -1,0 +1,88 @@
+'use strict';
+/**
+ * THE ONE PLACE THAT KNOWS HOW MANY HARNESS TOKENS A FILE COSTS.
+ * SD-LEO-INFRA-CONTRACT-READ-COVERAGE-001.
+ *
+ * *** WHY THIS FILE EXISTS: TWO CONSTANTS FOR ONE PHYSICAL QUANTITY. ***
+ * Until now the repo carried two rival answers to "how big is this file to the Read tool":
+ *   claude-md-generator/index.js  HARNESS_BYTES_PER_TOKEN = 2.4177   (bytes, blocking, correct)
+ *   contract-read-coverage.cjs    CL100K_TO_HARNESS = 1.85           (cl100k on FRAMED text, wrong)
+ * The second overshot by 43-61% on the phase-file family and manufactured false partial-read
+ * verdicts that disarmed live seats. Two representations of one quantity is the condition; this
+ * module collapses it to one, which is the point of the fix rather than a tidiness pass.
+ *
+ * PROVENANCE OF THE NUMBER, which is not mine and is deliberately not re-derived here: it comes
+ * from the harness's own truncation notices on this file family — a padded CLAUDE_LEAD.md at
+ * 64,613 bytes reported 26,722 tokens, agreeing to 0.1% with CLAUDE_PLAN.md at 92,184 bytes /
+ * 38,166 tokens. Six byte-paired receipts put the spread at 2.3698-2.5820 B/token, max error 6.80%.
+ *
+ * *** THE HONEST LIMIT, STATED HERE BECAUSE IT IS INVISIBLE AT THE CALL SITE. ***
+ * A CONSTANT CARRIES ITS CALIBRATION DOMAIN. This one is calibrated on PROSE-AND-TABLE protocol
+ * documents. It is CONTENT-BLIND: SECURITY measured 1.32 B/token for random ASCII, 1.40 for base64
+ * and 1.77 for minified text, so a contract that gains a base64 blob costs far more per byte than
+ * this predicts and would be waved through as fitting while it truncates — the original defect,
+ * restored by the fix. `cl100kRawLowerBound` below exists to close exactly that hole, and it needs
+ * no calibration at all.
+ *
+ * NOT chosen because it is the most accurate model. On a single basis cl100k-on-RAW is about twice
+ * as tight (+-3.0% against +-4.3%). It is chosen because it is already shipped, already validated,
+ * and already the only blocking consumer — so reusing it yields one representation instead of a
+ * third rival. That distinction is recorded because the earlier draft of this SD justified bytes by
+ * comparing an ~8% spread against ~25%, which compared bytes-on-RAW against cl100k-on-FRAMED — two
+ * different bases, the very defect class this SD closes.
+ */
+
+/** Bytes per harness token for prose-and-table protocol documents. See the domain warning above. */
+const HARNESS_BYTES_PER_TOKEN = 2.4177;
+
+/** The Read tool's hard per-call token cap. Not a budget, not a target — the wall. */
+const SINGLE_READ_TOKEN_CAP = 25000;
+
+/**
+ * Predicted harness token cost of `bytes` of prose-and-table content.
+ * Returns null for anything that is not a usable positive size, because a coverage verdict built on
+ * a coerced zero is worse than one that says it cannot tell.
+ */
+function harnessTokensFromBytes(bytes) {
+  const n = Number(bytes);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return Math.round(n / HARNESS_BYTES_PER_TOKEN);
+}
+
+/**
+ * A STRICTLY SOUND LOWER BOUND on harness tokens, with NO calibration constant.
+ *
+ * Every byte-paired receipt puts harness/cl100k_raw between 1.642 and 1.715, i.e. the harness always
+ * charges MORE than cl100k does on raw content. So cl100k_raw exceeding the cap proves the file
+ * exceeds the cap, whatever its content density. That makes this a one-sided VETO: it can only ever
+ * turn a fits into a does-not-fit, never the reverse, so a wrong ratio cannot make it unsound.
+ *
+ * It is the density guard the bytes model cannot be: a base64 blob tokenizes densely in cl100k too,
+ * so this fires on precisely the content that defeats a bytes calibration.
+ *
+ * Returns null when the tokenizer is unavailable — an absent veto must read as "no opinion", never
+ * as "cleared".
+ */
+function cl100kRawLowerBound(text) {
+  try {
+    // eslint-disable-next-line global-require
+    const enc = require('tiktoken').get_encoding('cl100k_base');
+    try {
+      // encode_ordinary, never encode: cl100k's `encode` THROWS on special-token literals such as
+      // <|endoftext|>, and a contract that merely DOCUMENTS one would take the throw path and lose
+      // its veto — silently, and on exactly the kind of file most worth checking.
+      return enc.encode_ordinary(String(text)).length;
+    } finally {
+      if (typeof enc.free === 'function') enc.free();
+    }
+  } catch {
+    return null;
+  }
+}
+
+module.exports = {
+  HARNESS_BYTES_PER_TOKEN,
+  SINGLE_READ_TOKEN_CAP,
+  harnessTokensFromBytes,
+  cl100kRawLowerBound,
+};

--- a/lib/protocol/harness-token-scale.cjs
+++ b/lib/protocol/harness-token-scale.cjs
@@ -50,6 +50,17 @@ function harnessTokensFromBytes(bytes) {
 }
 
 /**
+ * Deferred so nothing loads at import time — this module is pulled in by role-activation paths that
+ * promise never to block. INJECTABLE so the failure branch below is reachable from a test: it fires
+ * only when the tokenizer itself will not load, which no ordinary fixture can provoke, and a
+ * mutation converting that branch from null to 0 survived the entire suite because of it.
+ */
+function defaultEncoderLoader() {
+  // eslint-disable-next-line global-require
+  return require('tiktoken').get_encoding('cl100k_base');
+}
+
+/**
  * A STRICTLY SOUND LOWER BOUND on harness tokens, with NO calibration constant.
  *
  * Every byte-paired receipt puts harness/cl100k_raw between 1.642 and 1.715, i.e. the harness always
@@ -63,10 +74,9 @@ function harnessTokensFromBytes(bytes) {
  * Returns null when the tokenizer is unavailable — an absent veto must read as "no opinion", never
  * as "cleared".
  */
-function cl100kRawLowerBound(text) {
+function cl100kRawLowerBound(text, loadEncoder = defaultEncoderLoader) {
   try {
-    // eslint-disable-next-line global-require
-    const enc = require('tiktoken').get_encoding('cl100k_base');
+    const enc = loadEncoder();
     try {
       // encode_ordinary, never encode: cl100k's `encode` THROWS on special-token literals such as
       // <|endoftext|>, and a contract that merely DOCUMENTS one would take the throw path and lose

--- a/scripts/modules/claude-md-generator/index.js
+++ b/scripts/modules/claude-md-generator/index.js
@@ -10,6 +10,9 @@ import path from 'path';
 import crypto from 'crypto';
 import { execSync } from 'child_process';
 import { writeFileAtomic } from '../../../lib/utils/atomic-write.js';
+// The single home for the harness token scale. CJS because lib/protocol/ is CJS and the coverage
+// module cannot import ESM; ESM reads it back through default interop.
+import harnessTokenScale from '../../../lib/protocol/harness-token-scale.cjs';
 
 import {
   getActiveProtocol,
@@ -556,7 +559,14 @@ export const SINGLE_READ_TOKEN_CAP = 25000;
 // This value comes from the harness's own truncation notice on this file family: a padded
 // CLAUDE_LEAD.md at 64,613 bytes reported 26,722 tokens. It independently agrees with a second
 // derivation (92,184 bytes / 38,166 tokens on CLAUDE_PLAN.md) to 0.1%.
-export const HARNESS_BYTES_PER_TOKEN = 2.4177;
+// RE-EXPORTED, NOT RE-DECLARED. SD-LEO-INFRA-CONTRACT-READ-COVERAGE-001 collapsed the two rival
+// answers to "how big is this file to the Read tool" into one home. This file used to hold the
+// value; lib/protocol/contract-read-coverage.cjs held a different one (CL100K_TO_HARNESS = 1.85, on
+// cl100k of FRAMED text) that overshot by 43-61% on exactly the family this constant was measured
+// on, and manufactured false partial-read verdicts that disarmed live seats. Two representations of
+// one physical quantity is the condition that produced it. The export shape is unchanged so every
+// consumer and the test pinning 2.4177 keep working.
+export const { HARNESS_BYTES_PER_TOKEN } = harnessTokenScale;
 
 // THROW only for files a shipped SD has actually made fit; WARN for the rest.
 //

--- a/tests/fixtures/protocol/contract-read-groundtruth.json
+++ b/tests/fixtures/protocol/contract-read-groundtruth.json
@@ -1,0 +1,120 @@
+{
+  "_README": [
+    "MEASURED HARNESS GROUND TRUTH for the contract-read coverage model.",
+    "SD-LEO-INFRA-CONTRACT-READ-COVERAGE-001.",
+    "",
+    "harness_tokens is what the READ TOOL ITSELF reported, never a prediction. Two sources:",
+    "  notice       - the tool printed a truncation notice carrying the whole-file token count.",
+    "  differential - H(f) = 2*H(f+P) - H(f+2P), using the over-cap error as a second measurement",
+    "                 channel. H(P) came out identical across five host files, so the method is exact.",
+    "                 It yields harness counts for files that read CLEAN, which is why the SD's",
+    "                 original premise -- that a clean read gives only an upper bound -- was wrong.",
+    "",
+    "WHY THIS IS FROZEN AND NOT READ FROM DISK: CLAUDE_SOLOMON.md grew 1,933 bytes between being",
+    "measured and the next morning. A suite that reads today's file cannot distinguish a fixed",
+    "instrument from a changed file, and at HEAD that file admits no coherent budget at all.",
+    "",
+    "ONLY THE ROWS WITH BOTH bytes AND harness_tokens can validate a BYTES model. The clean-read rows",
+    "carry tokens measured at a revision whose byte count was not recorded, so they are kept for the",
+    "budget argument and explicitly excluded from the calibration set. Recording that split is the",
+    "point: 'validate against all 11' was not executable, and pretending otherwise would have produced",
+    "a suite that looked twice as strong as it is."
+  ],
+
+  "calibration_set": [
+    { "name": "CLAUDE_ADAM.md@truncating",   "bytes": 106286, "harness_tokens": 42190, "source": "notice" },
+    { "name": "CLAUDE_SOLOMON.md@pre-split", "bytes": 67501,  "harness_tokens": 26143, "source": "notice" },
+    { "name": "CLAUDE_LEAD.md@pre-fix",      "bytes": 66228,  "harness_tokens": 27462, "source": "notice" },
+    { "name": "CLAUDE_PLAN.md@pre-fix",      "bytes": 92184,  "harness_tokens": 38166, "source": "notice" },
+    { "name": "CLAUDE_EXEC.md@pre-fix",      "bytes": 90071,  "harness_tokens": 37056, "source": "notice" },
+    { "name": "CLAUDE_CORE.md@pre-fix",      "bytes": 94199,  "harness_tokens": 39750, "source": "notice" }
+  ],
+
+  "verdict_set": [
+    {
+      "name": "CLAUDE_SOLOMON.md@371-pre-split",
+      "sha": "1ea0403b14ab",
+      "bytes": 67501,
+      "harness_tokens": 26138,
+      "line_count": 371,
+      "read_outcome": "truncated",
+      "expected_fits": false,
+      "source": "notice",
+      "notice_string": "PARTIAL view — showing lines 1-301 of 371 total (26138 tokens, cap 25000)",
+      "note": "THE NEAR-MISS NEGATIVE, and the only one. Every other expected-false row is 48-61% over cap, which any not-catastrophically-wrong model catches; this one is 4.6% over and is what actually discriminates. Numerator corrected from 26142 to 26138: measured by reconstructing the 371-line file and counting it whole. Four places in the repo already said 26138; only the coverage module and its test said 26142, hardcoded as observed-not-computed."
+    },
+    {
+      "name": "CLAUDE_SOLOMON.md@fixture-59080",
+      "bytes": 59080,
+      "harness_tokens": 23897,
+      "line_count": 310,
+      "read_outcome": "clean",
+      "expected_fits": true,
+      "source": "differential",
+      "note": "THE DECISIVE REFUTATION CASE, bound to its recorded byte count. The shipped 1.85 model predicted 28,270 for this file and therefore PREDICTED TRUNCATION on a read that came back clean. Note it exceeds the OLD 22,500 budget, so no predictor could have cleared it until the margin went."
+    },
+    {
+      "name": "CLAUDE_LEAD.md@24336",
+      "bytes": 58622,
+      "harness_tokens": 24336,
+      "read_outcome": "clean",
+      "expected_fits": true,
+      "source": "differential",
+      "note": "Over the old 22,500 budget while reading clean. Headroom under the cap is 664 tokens (2.7%), INSIDE the model's own 6.80% error band -- its verdict is corroboration, not proof."
+    },
+    {
+      "name": "CLAUDE_PLAN.md@23153",
+      "bytes": 55186,
+      "harness_tokens": 23153,
+      "read_outcome": "clean",
+      "expected_fits": true,
+      "source": "differential",
+      "note": "Over the old budget while reading clean. 1,847 tokens of headroom (7.4%), also inside the error band."
+    },
+    {
+      "name": "CLAUDE_ADAM.md@18857",
+      "bytes": 47258,
+      "harness_tokens": 18857,
+      "read_outcome": "clean",
+      "expected_fits": true,
+      "source": "differential",
+      "note": "The ONLY contract decided with real margin -- 24.6% headroom, comfortably outside the error band."
+    },
+    {
+      "name": "CLAUDE_EXEC.md@37059",
+      "bytes": 90072,
+      "harness_tokens": 37059,
+      "read_outcome": "truncated",
+      "expected_fits": false,
+      "source": "differential"
+    },
+    {
+      "name": "CLAUDE_CORE.md@40285",
+      "bytes": 95531,
+      "harness_tokens": 40285,
+      "read_outcome": "truncated",
+      "expected_fits": false,
+      "source": "differential"
+    }
+  ],
+
+  "tolerance": {
+    "relative_pct": 8.0,
+    "absolute_tokens": 2000,
+    "both_required": true,
+    "measured_max_error_pct": 6.8,
+    "theatre_threshold_pct": 56.7,
+    "leakage_begins_pct": 22.0,
+    "note": "BOTH bounds are asserted, and the theatre threshold is recorded so nobody can widen the tolerance into meaninglessness by accident. At 56.7% the RETIRED 1.85 model passes this same suite and it stops discriminating between the defect and the fix entirely; individual defective points start slipping through at 22.0%. The chosen 8.0% sits just above the measured 6.80% max and far below both."
+  },
+
+  "retired_model_overshoot_pct": {
+    "_note": "The 1.85 cl100k-on-framed model's overshoot against the calibration set. Used as the TWO-SIDED CONTROL: the retired model must FAIL the same tolerance the new one passes, or the tolerance proves nothing.",
+    "CLAUDE_ADAM.md@truncating": 27.7,
+    "CLAUDE_SOLOMON.md@pre-split": 22.0,
+    "CLAUDE_LEAD.md@pre-fix": 52.7,
+    "CLAUDE_PLAN.md@pre-fix": 54.1,
+    "CLAUDE_EXEC.md@pre-fix": 56.7,
+    "CLAUDE_CORE.md@pre-fix": 42.9
+  }
+}

--- a/tests/fixtures/protocol/contract-read-groundtruth.json
+++ b/tests/fixtures/protocol/contract-read-groundtruth.json
@@ -3,55 +3,103 @@
     "MEASURED HARNESS GROUND TRUTH for the contract-read coverage model.",
     "SD-LEO-INFRA-CONTRACT-READ-COVERAGE-001.",
     "",
+    "*** EVERY ROW PAIRS bytes AND harness_tokens FOR THE SAME ARTIFACT. THE FIRST DRAFT DID NOT. ***",
+    "EXEC review found two mispairings in this file, and the first is the exact defect class this SD",
+    "exists to close, committed inside the fixture that certifies the fix:",
+    "  - CLAUDE_SOLOMON.md@fixture-59080 paired bytes 59,080 with harness_tokens 23,897. 23,897 is the",
+    "    cost of the CURRENT 61,013-byte file. A fresh token count against a stale byte count -- a",
+    "    quantity whose two halves describe different artifacts, which is precisely how 1.85 was",
+    "    derived. It was also the one row keeping the suite green.",
+    "  - CLAUDE_SOLOMON.md@pre-split recorded 67,501 B while the git blob at 1ea0403b14ab is 67,131.",
+    "    The difference is exactly 370, the newline count: a CRLF artifact. That row is the",
+    "    worst-error point, so the tolerance figure derived from it was wrong too (6.80% -> 6.23%).",
+    "Every row now carries a sha where one exists, and bytes are read from the blob, not remembered.",
+    "",
     "harness_tokens is what the READ TOOL ITSELF reported, never a prediction. Two sources:",
     "  notice       - the tool printed a truncation notice carrying the whole-file token count.",
     "  differential - H(f) = 2*H(f+P) - H(f+2P), using the over-cap error as a second measurement",
-    "                 channel. H(P) came out identical across five host files, so the method is exact.",
-    "                 It yields harness counts for files that read CLEAN, which is why the SD's",
-    "                 original premise -- that a clean read gives only an upper bound -- was wrong.",
+    "                 channel. H(P) was identical across five host files, and the method reproduces",
+    "                 the notice figures to +/-1, so it is exact. It yields harness counts for files",
+    "                 that read CLEAN, which is why the SD's premise -- that a clean read gives only",
+    "                 an upper bound -- was wrong.",
     "",
-    "WHY THIS IS FROZEN AND NOT READ FROM DISK: CLAUDE_SOLOMON.md grew 1,933 bytes between being",
-    "measured and the next morning. A suite that reads today's file cannot distinguish a fixed",
-    "instrument from a changed file, and at HEAD that file admits no coherent budget at all.",
-    "",
-    "ONLY THE ROWS WITH BOTH bytes AND harness_tokens can validate a BYTES model. The clean-read rows",
-    "carry tokens measured at a revision whose byte count was not recorded, so they are kept for the",
-    "budget argument and explicitly excluded from the calibration set. Recording that split is the",
-    "point: 'validate against all 11' was not executable, and pretending otherwise would have produced",
-    "a suite that looked twice as strong as it is."
+    "FROZEN, NOT READ FROM DISK: CLAUDE_SOLOMON.md grew 1,933 bytes overnight mid-SD. A suite that",
+    "reads today's file cannot tell a fixed instrument from a changed file."
   ],
-
   "calibration_set": [
-    { "name": "CLAUDE_ADAM.md@truncating",   "bytes": 106286, "harness_tokens": 42190, "source": "notice" },
-    { "name": "CLAUDE_SOLOMON.md@pre-split", "bytes": 67501,  "harness_tokens": 26143, "source": "notice" },
-    { "name": "CLAUDE_LEAD.md@pre-fix",      "bytes": 66228,  "harness_tokens": 27462, "source": "notice" },
-    { "name": "CLAUDE_PLAN.md@pre-fix",      "bytes": 92184,  "harness_tokens": 38166, "source": "notice" },
-    { "name": "CLAUDE_EXEC.md@pre-fix",      "bytes": 90071,  "harness_tokens": 37056, "source": "notice" },
-    { "name": "CLAUDE_CORE.md@pre-fix",      "bytes": 94199,  "harness_tokens": 39750, "source": "notice" }
+    {
+      "name": "CLAUDE_ADAM.md@truncating",
+      "bytes": 106286,
+      "harness_tokens": 42190,
+      "source": "notice",
+      "pairing": "same-measurement",
+      "note": "bytes and notice recorded together in one measurement"
+    },
+    {
+      "name": "CLAUDE_SOLOMON.md@pre-split",
+      "bytes": 67131,
+      "harness_tokens": 26138,
+      "source": "notice",
+      "sha": "1ea0403b14ab",
+      "cl100k_framed": 17372,
+      "pairing": "git-verified",
+      "note": "CORRECTED. Was 67,501 B / 26,143 tokens; the blob is 67,131 B (the 370-byte delta is the newline count) and the measured whole-file count is 26,138. This is the worst-error point, so it sets measured_max_error_pct."
+    },
+    {
+      "name": "CLAUDE_LEAD.md@pre-fix",
+      "bytes": 66228,
+      "harness_tokens": 27462,
+      "source": "notice",
+      "pairing": "same-measurement"
+    },
+    {
+      "name": "CLAUDE_PLAN.md@pre-fix",
+      "bytes": 92184,
+      "harness_tokens": 38166,
+      "source": "notice",
+      "pairing": "same-measurement"
+    },
+    {
+      "name": "CLAUDE_EXEC.md@pre-fix",
+      "bytes": 90071,
+      "harness_tokens": 37056,
+      "source": "notice",
+      "pairing": "same-measurement"
+    },
+    {
+      "name": "CLAUDE_CORE.md@pre-fix",
+      "bytes": 94199,
+      "harness_tokens": 39750,
+      "source": "notice",
+      "pairing": "same-measurement"
+    }
   ],
-
   "verdict_set": [
     {
       "name": "CLAUDE_SOLOMON.md@371-pre-split",
       "sha": "1ea0403b14ab",
-      "bytes": 67501,
+      "bytes": 67131,
       "harness_tokens": 26138,
       "line_count": 371,
       "read_outcome": "truncated",
       "expected_fits": false,
       "source": "notice",
-      "notice_string": "PARTIAL view — showing lines 1-301 of 371 total (26138 tokens, cap 25000)",
-      "note": "THE NEAR-MISS NEGATIVE, and the only one. Every other expected-false row is 48-61% over cap, which any not-catastrophically-wrong model catches; this one is 4.6% over and is what actually discriminates. Numerator corrected from 26142 to 26138: measured by reconstructing the 371-line file and counting it whole. Four places in the repo already said 26138; only the coverage module and its test said 26142, hardcoded as observed-not-computed."
+      "pairing": "git-verified",
+      "notice_string": "PARTIAL view - showing lines 1-301 of 371 total (26138 tokens, cap 25000)",
+      "note": "THE NEAR-MISS NEGATIVE, and the only one. Every other expected-false row is 48-61% over cap, which any not-catastrophically-wrong model catches; this one is 4.6% over and is what actually discriminates. Numerator 26,138 not 26,142: measured by reconstructing the 371-line blob and counting it whole."
     },
     {
-      "name": "CLAUDE_SOLOMON.md@fixture-59080",
+      "name": "CLAUDE_SOLOMON.md@59080",
+      "sha": "75b6c5b23d90",
       "bytes": 59080,
-      "harness_tokens": 23897,
+      "harness_tokens": 23120,
       "line_count": 310,
       "read_outcome": "clean",
       "expected_fits": true,
       "source": "differential",
-      "note": "THE DECISIVE REFUTATION CASE, bound to its recorded byte count. The shipped 1.85 model predicted 28,270 for this file and therefore PREDICTED TRUNCATION on a read that came back clean. Note it exceeds the OLD 22,500 budget, so no predictor could have cleared it until the margin went."
+      "pairing": "git-verified",
+      "cl100k_framed": 15281,
+      "note": "THE DECISIVE REFUTATION CASE, correctly paired at last. The shipped 1.85 model predicted 28,270 for this blob (15,281 framed x 1.85) and therefore PREDICTED TRUNCATION on a read that came back clean. Its measured cost is 23,120 -- above the OLD 22,500 budget, so no predictor could have cleared it until the margin went. The SD's stated cl100k figure of 15,281 was correct for THIS revision all along."
     },
     {
       "name": "CLAUDE_LEAD.md@24336",
@@ -60,7 +108,8 @@
       "read_outcome": "clean",
       "expected_fits": true,
       "source": "differential",
-      "note": "Over the old 22,500 budget while reading clean. Headroom under the cap is 664 tokens (2.7%), INSIDE the model's own 6.80% error band -- its verdict is corroboration, not proof."
+      "pairing": "same-measurement",
+      "note": "Over the old 22,500 budget while reading clean. 664 tokens of headroom (2.7%), inside the model's error band -- its verdict is corroboration, not proof."
     },
     {
       "name": "CLAUDE_PLAN.md@23153",
@@ -69,7 +118,8 @@
       "read_outcome": "clean",
       "expected_fits": true,
       "source": "differential",
-      "note": "Over the old budget while reading clean. 1,847 tokens of headroom (7.4%), also inside the error band."
+      "pairing": "same-measurement",
+      "note": "Over the old budget while reading clean. 1,847 tokens of headroom (7.4%), OUTSIDE the 6.23% error band -- decided with real margin. An earlier draft of this note said 'also inside the band', repeating a review figure that was never checked."
     },
     {
       "name": "CLAUDE_ADAM.md@18857",
@@ -78,7 +128,8 @@
       "read_outcome": "clean",
       "expected_fits": true,
       "source": "differential",
-      "note": "The ONLY contract decided with real margin -- 24.6% headroom, comfortably outside the error band."
+      "pairing": "same-measurement",
+      "note": "24.6% headroom, comfortably outside the error band."
     },
     {
       "name": "CLAUDE_EXEC.md@37059",
@@ -86,7 +137,8 @@
       "harness_tokens": 37059,
       "read_outcome": "truncated",
       "expected_fits": false,
-      "source": "differential"
+      "source": "differential",
+      "pairing": "same-measurement"
     },
     {
       "name": "CLAUDE_CORE.md@40285",
@@ -94,27 +146,53 @@
       "harness_tokens": 40285,
       "read_outcome": "truncated",
       "expected_fits": false,
-      "source": "differential"
+      "source": "differential",
+      "pairing": "same-measurement"
     }
   ],
-
   "tolerance": {
     "relative_pct": 8.0,
     "absolute_tokens": 2000,
     "both_required": true,
-    "measured_max_error_pct": 6.8,
-    "theatre_threshold_pct": 56.7,
-    "leakage_begins_pct": 22.0,
-    "note": "BOTH bounds are asserted, and the theatre threshold is recorded so nobody can widen the tolerance into meaninglessness by accident. At 56.7% the RETIRED 1.85 model passes this same suite and it stops discriminating between the defect and the fix entirely; individual defective points start slipping through at 22.0%. The chosen 8.0% sits just above the measured 6.80% max and far below both."
+    "measured_max_error_pct": 6.23,
+    "theatre_threshold_pct": 22.96,
+    "note": "CORRECTED. measured_max_error_pct was 6.80, computed from the mispaired 67,501-byte SOLOMON row; against the git blob (67,131) it is 6.23. theatre_threshold_pct was 56.7, taken from a recorded overshoot rather than computed -- it is now the HONESTLY COMPUTED overshoot of the retired model on the one row where cl100k_framed is git-verified (17,372 x 1.85 = 32,138 against a measured 26,138 = 22.96%). A tolerance at or above that passes the retired model on this row and the suite stops discriminating. BOTH bounds are asserted; 8.0 sits above the measured 6.23 and well below 22.96."
   },
-
-  "retired_model_overshoot_pct": {
-    "_note": "The 1.85 cl100k-on-framed model's overshoot against the calibration set. Used as the TWO-SIDED CONTROL: the retired model must FAIL the same tolerance the new one passes, or the tolerance proves nothing.",
-    "CLAUDE_ADAM.md@truncating": 27.7,
-    "CLAUDE_SOLOMON.md@pre-split": 22.0,
-    "CLAUDE_LEAD.md@pre-fix": 52.7,
-    "CLAUDE_PLAN.md@pre-fix": 54.1,
-    "CLAUDE_EXEC.md@pre-fix": 56.7,
-    "CLAUDE_CORE.md@pre-fix": 42.9
+  "known_residual_false_fail": {
+    "_note": [
+      "*** THE SD DELIVERED ONE SEAT, NOT TWO. RECORDED HERE RATHER THAN OMITTED. ***",
+      "CLAUDE_ADAM.md went disarmed -> ARMED, decided with 24.6% margin. CLAUDE_SOLOMON.md at HEAD is",
+      "STILL DISARMED, and it is a FALSE fail: a no-offset Read of the live 61,013-byte file returns",
+      "all 310 lines with no truncation notice, and its measured cost is 23,896 -- 1,104 under the cap",
+      "-- while the bytes model predicts 25,236. Overshoot 5.61%, inside the model's own error band.",
+      "This is the same failure mode the SD was filed against, surviving at a different point on the",
+      "curve. The margin fix cleared three of the four; the predictor's resolution is what blocks the",
+      "fourth.",
+      "The test below asserts the CONTRADICTION explicitly and is SELF-RETIRING: improve the model so",
+      "it clears this file and the test reddens, and whoever does that should delete it."
+    ],
+    "name": "CLAUDE_SOLOMON.md@HEAD",
+    "sha": "9e95ffbf57ae",
+    "bytes": 61013,
+    "harness_tokens": 23896,
+    "line_count": 310,
+    "read_outcome": "clean",
+    "cl100k_framed": 15763,
+    "pairing": "git-verified"
+  },
+  "retired_model": {
+    "_note": [
+      "*** THE TWO-SIDED CONTROL, COMPUTED. THE FIRST VERSION WAS FAKE. ***",
+      "It derived the retired model's prediction FROM the measured harness count by multiplying by a",
+      "recorded overshoot percentage, so the assertion reduced to 'every recorded overshoot exceeds",
+      "8.0' -- a statement about this file's own constants. cl100k was never invoked. That is exactly",
+      "the shape the new suite's docblock indicts the old one for: comparing two numbers that came",
+      "from the same belief.",
+      "The control now runs the retired model for real -- cl100k on FRAMED text times 1.85 -- on every",
+      "row carrying a git-verified cl100k_framed. Only rows with that field can participate, and the",
+      "suite asserts at least one does rather than silently controlling on nothing."
+    ],
+    "constant": 1.85,
+    "basis": "cl100k_framed"
   }
 }

--- a/tests/unit/protocol/contract-read-coverage.test.js
+++ b/tests/unit/protocol/contract-read-coverage.test.js
@@ -10,7 +10,7 @@
 import { describe, it, expect } from 'vitest';
 import { createRequire } from 'node:module';
 const require_ = createRequire(import.meta.url);
-const { contractReadVerdict, singleReadFit, FULL_COVERAGE_PCT, SINGLE_READ_SAFE_BYTES, SINGLE_READ_TOKEN_CAP, SINGLE_READ_TOKEN_BUDGET } = require_('../../../lib/protocol/contract-read-coverage.cjs');
+const { contractReadVerdict, singleReadFit, FULL_COVERAGE_PCT, SINGLE_READ_SAFE_BYTES, SINGLE_READ_TOKEN_CAP, SINGLE_READ_TOKEN_BUDGET, EVIDENCE_KINDS, exceedsCapByRawLowerBound, HARNESS_BYTES_PER_TOKEN } = require_('../../../lib/protocol/contract-read-coverage.cjs');
 
 describe('contractReadVerdict — the inversion, both halves', () => {
   it('THE DILIGENT READER: paginated full coverage reports FULLY READ', () => {
@@ -287,90 +287,129 @@ describe('the byte proxy is RETIRED — readability is measured in tokens', () =
    *   2nd: "1.32 B/token is the densest case"               — measured, but a sample MAX, not a max.
    * cl100k_base is byte-level BPE with 256 single-byte fallbacks, so the true floor is 1.0 B/token.
    */
-  it('THE MARGIN IS APPLIED, not merely declared', () => {
-    /**
-     * *** THIS IS THE ONE MUTANT THAT SURVIVED THE WHOLE SUITE. *** Changing singleReadFit to
-     * compare against SINGLE_READ_TOKEN_CAP (25,000) instead of SINGLE_READ_TOKEN_BUDGET (22,500)
-     * — i.e. DELETING the safety margin — passed every test. Every margin assertion checked the
-     * two constants' RELATIONSHIP; none checked that the smaller one is what the comparison uses.
-     * The docblock calls the margin load-bearing, and it was the only safety mechanism here with
-     * zero behavioural coverage.
-     *
-     * A contract sized into the band between budget and cap is the only thing that can tell them
-     * apart, so build one instead of hoping a real file lands there.
-     */
-    const osx = require_('os'); const fsx = require_('fs'); const px = require_('path');
-    const dir = fsx.mkdtempSync(px.join(osx.tmpdir(), 'ctr-margin-'));
-    const file = 'BAND.md';
-    const line = 'lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod\n';
+  /**
+   * *** THE MARGIN TEST IS GONE BECAUSE THE MARGIN IS GONE, AND THAT WAS THE BIGGER FIX. ***
+   * SD-LEO-INFRA-CONTRACT-READ-COVERAGE-001. It grew a synthetic file until the prediction landed
+   * strictly between a 22,500 budget and the 25,000 cap, then asserted `fits === false` — pinning
+   * the margin as a requirement.
+   *
+   * The margin was measurably wrong. Actual harness tokens: CLAUDE_SOLOMON.md 23,897,
+   * CLAUDE_LEAD.md 24,336, CLAUDE_PLAN.md 23,153 — all three READ CLEAN and all three sat in that
+   * band, so the margin disarmed three of the four clean-reading contracts on its own. A perfect
+   * predictor could not have cleared them. Budget is now the cap, the band is empty, and this test
+   * would throw `overshot the band` on its first iteration rather than merely fail.
+   *
+   * What replaces it is NOT another band test — it is the ground-truth suite in
+   * contract-read-groundtruth.test.js, which checks the prediction against measured harness output
+   * instead of against a second constant.
+   */
+  it('the budget is the CAP — no margin, because the margin manufactured false-fails', () => {
+    expect(SINGLE_READ_TOKEN_BUDGET).toBe(SINGLE_READ_TOKEN_CAP);
 
-    // Grow until the FRAMED measurement lands strictly between budget and cap.
-    let body = '';
-    for (let i = 0; i < 20000; i++) {
-      body += line;
-      if (i % 20 !== 0) continue;   // stride 20, not 200: the band is 2,500 wide and a 3,600-token step can leap clean over it
-      fsx.writeFileSync(px.join(dir, file), body);
-      const t = singleReadFit(dir, file).tokens;
-      if (t > SINGLE_READ_TOKEN_BUDGET && t < SINGLE_READ_TOKEN_CAP) break;
-      if (t >= SINGLE_READ_TOKEN_CAP) throw new Error(`overshot the band at ${t} tokens`);
+    // The three measured clean readers that the old 22,500 budget disarmed. Each is asserted as a
+    // NUMBER here rather than read off disk, so the test states the fact it depends on.
+    for (const measured of [23897, 24336, 23153]) {
+      expect(measured).toBeGreaterThan(22500);              // the old budget would have disarmed it
+      expect(measured).toBeLessThanOrEqual(SINGLE_READ_TOKEN_BUDGET);  // it genuinely fits
     }
-
-    const fit = singleReadFit(dir, file);
-    expect(fit.tokens).toBeGreaterThan(SINGLE_READ_TOKEN_BUDGET);
-    expect(fit.tokens).toBeLessThan(SINGLE_READ_TOKEN_CAP);
-    expect(fit.fits).toBe(false);   // the margin, doing its job
-
-    // MUTATION: compare against SINGLE_READ_TOKEN_CAP instead of the budget -> fits true. Fails.
-    // That mutation survived all 58 tests before this one existed.
   });
 
-  it('the surviving byte constant is sound at the 1.0 B/token FLOOR, not at a sampled ratio', () => {
-    // It is now only the no-tokenizer fallback, so it must hold even for input that encodes at one
-    // token per byte. Anything above 25,000 is unsound at that floor.
-    expect(SINGLE_READ_SAFE_BYTES).toBeLessThanOrEqual(SINGLE_READ_TOKEN_CAP * 1.0);
+  it('SAFE_BYTES is the degraded-mode bound and is re-derived from the live scale', () => {
+    // It was derived from the RETIRED constant, so leaving it alone would have been the same defect
+    // one level down. Pinned against the arithmetic that produces it, not against the old floor.
+    expect(SINGLE_READ_SAFE_BYTES).toBe(Math.floor(SINGLE_READ_TOKEN_BUDGET * HARNESS_BYTES_PER_TOKEN));
 
-    // MUTATION: restore 32,000 (the "1.32 B/token" derivation) -> unsound at the floor, fails.
+    // NOT asserted: `SAFE_BYTES <= BUDGET`. That inequality held for every ratio at or above 1.0,
+    // so it would not have noticed the bound loosening — it is the shape of assertion that let the
+    // original defect through, and repeating it here would buy nothing.
   });
 
-  it('MEASURES rather than infers — a file can be over the byte bound and still fit', () => {
+  it('a dense file is vetoed even though the prose-calibrated bytes model would clear it', () => {
     /**
-     * *** DELIBERATELY NOT PINNED TO TODAY'S CONTRACT SIZES. *** The first version of this test
-     * asserted `sol.bytes > SINGLE_READ_SAFE_BYTES` and `coord.fits === true` against the live
-     * files — i.e. it required Solomon's contract to stay over 25 KB and the coordinator's to stay
-     * small. Trimming either (both desirable, and one is an active sibling SD) would have failed a
-     * test with nothing wrong. That is the same defect as the arming table this SD replaced, just
-     * pointed at a different fact.
-     *
-     * The BEHAVIOUR is what matters: bytes and tokens can disagree, and tokens decide. Built from
-     * a synthetic file so it stays true whatever happens to the real contracts.
+     * *** THE REGRESSION THE FIX ITSELF BUYS, AND THE GUARD THAT CLOSES IT. ***
+     * The bytes model is calibrated on prose-and-table documents at 2.4177 B/token. Random ASCII,
+     * base64 and minified text run 1.32-1.77, so a contract that gains a blob costs far more per
+     * byte than the model predicts and would be waved through AS FITTING WHILE IT TRUNCATES — the
+     * original defect, restored by its own fix. Nothing else in this suite covers that.
      */
     const osx = require_('os'); const fsx = require_('fs'); const px = require_('path');
-    const dir = fsx.mkdtempSync(px.join(osx.tmpdir(), 'ctr-prose-'));
-    // Prose runs ~4.2 bytes/token, so this is far over the byte bound and far under the token one.
-    // 700 lines: ~30.8KB, comfortably over the byte bound, and ~17k CALIBRATED tokens — under the
-    // budget. Sized against the calibrated scale; at 1200 it was 29,242 calibrated tokens and the
-    // premise of the test (over on bytes, under on tokens) no longer held.
-    fsx.writeFileSync(px.join(dir, 'P.md'), 'the quick brown fox jumps over the lazy dog\n'.repeat(700));
+    const dir = fsx.mkdtempSync(px.join(osx.tmpdir(), 'ctr-dense-'));
 
-    const fit = singleReadFit(dir, 'P.md');
-    expect(fit.basis).toBe('measured_tokens');
-    expect(fit.bytes).toBeGreaterThan(SINGLE_READ_SAFE_BYTES);  // the byte proxy would disarm it
-    expect(fit.tokens).toBeLessThan(SINGLE_READ_TOKEN_BUDGET);
-    expect(fit.fits).toBe(true);                                // ...measurement says otherwise
+    /**
+     * SIZED INTO THE GAP DELIBERATELY, and every number here was MEASURED rather than assumed. The
+     * bytes model clears anything up to 25,000 * 2.4177 = 60,442 B. This fixture is 49,336 B, which
+     * the model predicts at 20,406 tokens — comfortably fitting — while cl100k_raw measures 35,381,
+     * well over the cap. That gap is the only window in which this test proves anything.
+     *
+     * BASE64 OF PSEUDO-RANDOM BYTES, and the two rejected alternatives are worth recording because
+     * both looked right:
+     *   - `'someBase64ish'.repeat(n)` tokenizes at 4.87 B/token. Repetition is precisely what BPE
+     *     compresses best, so a repeated "dense" string is not dense at all.
+     *   - Sampling a base64 ALPHABET with an LCG gives the same problem: the low bits of an LCG are
+     *     highly structured, and the result still merges.
+     * Encoding random BYTES yields 1.394 B/token, which independently reproduces the 1.40 that this
+     * module's own docblock records SECURITY as having measured for base64.
+     *
+     * Deterministic LCG, never Math.random: a fixture that changes between runs cannot be a fixture.
+     */
+    let seed = 12345;
+    const raw = Buffer.alloc(37000);
+    for (let i = 0; i < raw.length; i++) {
+      seed = (seed * 1103515245 + 12345) % 2147483648;
+      raw[i] = (seed >> 16) & 0xff;   // high bits: the low bits of an LCG are too structured
+    }
+    fsx.writeFileSync(px.join(dir, 'D.md'), raw.toString('base64'));
 
-    // MUTATION: compare bytes instead of tokens -> fits false. Fails.
+    const fit = singleReadFit(dir, 'D.md');
+    const bytesModelSays = Math.round(fit.bytes / HARNESS_BYTES_PER_TOKEN);
+    expect(bytesModelSays).toBeLessThanOrEqual(SINGLE_READ_TOKEN_BUDGET);  // the model would clear it
+    expect(fit.fits).toBe(false);                                          // the veto does not
+    expect(fit.basis).toBe('raw_lower_bound_exceeds_cap');
+  });
+
+  it('the veto is ONE-SIDED — it never turns a does-not-fit into a fit', () => {
+    // A sound lower bound can only ever add refusals. If this ever flips a verdict the other way,
+    // the veto has stopped being a bound and become a second predictor.
+    const osx = require_('os'); const fsx = require_('fs'); const px = require_('path');
+    const dir = fsx.mkdtempSync(px.join(osx.tmpdir(), 'ctr-small-'));
+    fsx.writeFileSync(px.join(dir, 'S.md'), 'the quick brown fox jumps over the lazy dog\n'.repeat(50));
+
+    expect(exceedsCapByRawLowerBound(dir, 'S.md')).toBe(false);
+    expect(singleReadFit(dir, 'S.md').fits).toBe(true);
+  });
+
+  it('every verdict carries its evidence kind, and there is NO direct kind to carry', () => {
+    /**
+     * The original defect survived review because a PREDICTION wore the same label as an
+     * OBSERVATION. Each verdict now says which it is — and 'direct' is deliberately absent, because
+     * nothing can produce it: the structured consumer exists at protocol-file-tracker.cjs:232 and
+     * the harness has never fed it (0 truncation flags across 1,464 recorded reads). This assertion
+     * is a FALSIFIABLE NEGATIVE: re-adding an unreachable label reddens here.
+     */
+    expect(EVIDENCE_KINDS).not.toContain('direct');
+    expect(EVIDENCE_KINDS).not.toContain('notice_derived');
+
+    const osx = require_('os'); const fsx = require_('fs'); const px = require_('path');
+    const dir = fsx.mkdtempSync(px.join(osx.tmpdir(), 'ctr-ev-'));
+    fsx.writeFileSync(px.join(dir, 'E.md'), 'hello world\n'.repeat(10));
+    expect(EVIDENCE_KINDS).toContain(singleReadFit(dir, 'E.md').evidence);
+    expect(singleReadFit(dir, 'ABSENT.md').evidence).toBe('none');
   });
 
   it('the real contracts are measured by the same rule (reported, not required)', () => {
     // Sanity only, and deliberately asserts nothing about SIZE — just that each real contract is
-    // genuinely measured and that fits/tokens agree with each other. Whatever the sibling SD does
-    // to CLAUDE_ADAM.md, this keeps passing and the arming table keeps telling the truth.
+    // genuinely evaluated and that fits/tokens agree with each other. Whatever a sibling SD does to
+    // any contract's length, this keeps passing and the arming table keeps telling the truth.
     const root = process.cwd();
     for (const f of ['CLAUDE_COORDINATOR.md', 'CLAUDE_SOLOMON.md', 'CLAUDE_ADAM.md']) {
       const fit = singleReadFit(root, f);
-      expect(fit.basis).toBe('measured_tokens');
       expect(fit.tokens).toBeGreaterThan(0);
-      expect(fit.fits).toBe(fit.tokens <= SINGLE_READ_TOKEN_BUDGET);
+      expect(EVIDENCE_KINDS).toContain(fit.evidence);
+      // The veto can refuse a file the size rule would clear, so agreement is asserted only on the
+      // path where the size rule actually decided.
+      if (fit.basis === 'predicted_bytes') {
+        expect(fit.fits).toBe(fit.tokens <= SINGLE_READ_TOKEN_BUDGET);
+      }
     }
   });
 
@@ -618,116 +657,80 @@ describe('SEC-F16 — a REQUEST must never stand in for a MEASUREMENT', () => {
   });
 });
 
-describe('SEC-F10/F11 — measuring the right artefact, with the right encoder', () => {
+describe('SEC-F10/F11 — measuring the right artefact', () => {
   it('a contract mentioning a special-token literal does not silently degrade', () => {
-    // cl100k_base `encode` THROWS on <|endoftext|> even inline in prose. That throw would fall
-    // through to the byte fallback and flip a 25,587-byte contract from ARMED to disarmed on the
-    // strength of a documentation string. encode_ordinary treats it as text.
+    // cl100k_base `encode` THROWS on <|endoftext|> even inline in prose. That throw used to fall
+    // through to the byte fallback and flip a contract from ARMED to disarmed on the strength of a
+    // documentation string. The veto now owns the only tokenizer call and uses encode_ordinary, so
+    // the same file must still be evaluated rather than degraded.
     const os = require_('os'); const fsx = require_('fs'); const p = require_('path');
     const dir = fsx.mkdtempSync(p.join(os.tmpdir(), 'ctr-special-'));
     fsx.writeFileSync(p.join(dir, 'X.md'), '# doc\nmentions <|endoftext|> inline\n'.repeat(50));
 
     const fit = singleReadFit(dir, 'X.md');
-    expect(fit.basis).toBe('measured_tokens');   // NOT the byte fallback
+    expect(fit.basis).toBe('predicted_bytes');   // NOT the degraded fallback, NOT vetoed
     expect(fit.tokens).toBeGreaterThan(0);
+    // The veto must have reached a real answer rather than throwing to null.
+    expect(exceedsCapByRawLowerBound(dir, 'X.md')).toBe(false);
 
-    // MUTATION: swap encode_ordinary back to encode -> throws, basis becomes
-    // conservative_bytes_no_tokenizer, fails.
+    // MUTATION: swap encode_ordinary back to encode in harness-token-scale.cjs -> the veto throws,
+    // returns null, and this assertion fails.
   });
 
-  it('counts the FRAMED response, not the raw file', () => {
-    // Read returns cat -n output; the line numbers and tabs count against the cap. Measuring raw
-    // bytes understates the real cost — measuring the wrong artefact is the same error the byte
-    // proxy made, one level down.
-    const root = process.cwd();
-    const framed = singleReadFit(root, 'CLAUDE_COORDINATOR.md').tokens;
-    const rawTokens = require_('tiktoken').get_encoding('cl100k_base')
-      .encode_ordinary(require_('fs').readFileSync(require_('path').join(root, 'CLAUDE_COORDINATOR.md'), 'utf8')).length;
-    expect(framed).toBeGreaterThan(rawTokens);
-  });
-
-  it('IS CALIBRATED TO THE HARNESS TOKENIZER, against a recorded ground-truth observation', () => {
-    /**
-     * *** THE GATE SHIPPED WRONG BECAUSE THIS ASSERTION DID NOT EXIST. ***
-     *
-     * cl100k_base is GPT-4's tokenizer; the 25k cap is a CLAUDE limit. I knew that, called it an
-     * irreducible error source, covered it with a 10% margin and shipped — never testing whether the
-     * two were actually close. They are not: cl100k UNDERCOUNTS by ~1.79x.
-     *
-     * GROUND TRUTH, recorded from an actual no-argument Read of CLAUDE_SOLOMON.md:
-     *     "PARTIAL view — showing lines 1-301 of 371 total (26142 tokens, cap 25000)"
-     * cl100k on that exact framed slice: 14,617. Ratio 26,142 / 14,617 = 1.788.
-     *
-     * Uncalibrated, CLAUDE_SOLOMON.md measured 17,390 and this SD ARMED Solomon, reporting "the byte
-     * proxy was disarming a role that already complies" as its headline finding. It was the opposite:
-     * the contract truncates. I had replaced a byte proxy with a token proxy and never validated the
-     * token proxy against the thing it proxies.
-     *
-     * This test re-derives the ratio from the file the observation was taken on, so it fails if the
-     * calibration is removed OR if the contract changes enough to invalidate the recorded datum.
-     */
-    const fsx = require_('fs'); const px = require_('path');
-    const root = process.cwd();
-    const HARNESS_TOKENS_LINES_1_TO_301 = 26142;   // observed, not computed
-    const OBSERVED_LINES = 301;
-
-    const raw = fsx.readFileSync(px.join(root, 'CLAUDE_SOLOMON.md'), 'utf8');
-    const slice = raw.split('\n').slice(0, OBSERVED_LINES).join('\n');
-    const framed = slice.split('\n').map((l, i) => `${String(i + 1).padStart(6)}\t${l}`).join('\n');
-    const cl100k = require_('tiktoken').get_encoding('cl100k_base').encode_ordinary(framed).length;
-
-    const observedRatio = HARNESS_TOKENS_LINES_1_TO_301 / cl100k;
-    // The shipped constant must not UNDERSTATE the measured ratio — understating re-creates the bug.
-    expect(SINGLE_READ_TOKEN_BUDGET).toBeGreaterThan(0);
-    expect(observedRatio).toBeGreaterThan(1.5);   // the two tokenizers are NOT close; that is the point
-
-    // And the consequence that matters: Solomon's contract must NOT be reported as fitting.
-    expect(singleReadFit(root, 'CLAUDE_SOLOMON.md').fits).toBe(false);
-
-    // MUTATION: drop the CL100K_TO_HARNESS multiplier from contractTokenCount -> Solomon reports
-    // fits:true and this fails. That mutation IS the state this SD shipped in for six commits.
-  });
+  /**
+   * *** TWO TESTS WERE DELETED HERE, AND BOTH WERE GREEN WHEN THEY WERE DELETED. ***
+   * SD-LEO-INFRA-CONTRACT-READ-COVERAGE-001. Neither would have announced itself; they are recorded
+   * because a silently-passing test that pins abolished behaviour is worse than a failing one.
+   *
+   * 1. `counts the FRAMED response, not the raw file` asserted that the module measures cat -n
+   *    framed output. THE HARNESS COUNTS RAW CONTENT — framing is not in it. Measured on a
+   *    controlled pair with IDENTICAL WORDS at a 22x line-count difference: k_raw held at 1.6554 vs
+   *    1.6153 while k_framed swung 1.6348 vs 1.2484. Framing before predicting introduced a
+   *    line-count dependence the harness does not have, which is exactly why one constant fitted a
+   *    371-line file and overshot the 1,400-line phase files by 43-61%.
+   *    IT STAYED GREEN BY ARITHMETIC COINCIDENCE after the fix: bytes-model tokens for
+   *    CLAUDE_COORDINATOR.md are 10,553 against cl100k_raw 6,190, so `framed > raw` still held with
+   *    no framing anywhere in the code. A test can survive the deletion of the very thing it names.
+   *
+   * 2. `IS CALIBRATED TO THE HARNESS TOKENIZER` re-derived the ratio as 26142 / cl100k(lines 1-301).
+   *    That is the SPAN-MISMATCHED derivation itself — a whole-file harness count (371 lines) over a
+   *    delivered-slice cl100k count (301 lines) — reproduced as an assertion. It also read the
+   *    CURRENT 310-line CLAUDE_SOLOMON.md and sliced 0..301 out of it, so it measured 97% of a
+   *    DIFFERENT FILE than the datum came from. Its own staleness guard ("fails if the contract
+   *    changes enough to invalidate the recorded datum") DID NOT FIRE: the observed ratio had
+   *    already drifted to 26142/15640 = 1.6715 against a `> 1.5` assertion loose enough to pass a
+   *    file it no longer described. And its closing assertion required
+   *    `singleReadFit('CLAUDE_SOLOMON.md').fits === false` — pinning the false-fail as a REQUIREMENT.
+   *    Deleted rather than corrected in place, because correcting it would preserve the reasoning
+   *    that produced it. The salvageable half — that Solomon's PRE-SPLIT 371-line contract genuinely
+   *    did not fit — is true for the right reason and is asserted from the recorded fixture in
+   *    contract-read-groundtruth.test.js.
+   *
+   * The recorded numerator is 26,138, not 26,142. Measured by reconstructing the 371-line file and
+   * counting it whole; four places in the repo already said 26138 and only this module and this test
+   * said 26142, hardcoded as "observed, not computed".
+   */
 
   it('DEGRADED MODE IS NEVER MORE PERMISSIVE THAN MEASURED MODE', () => {
     /**
-     * *** THE SEVENTH FINDING, AND IT WAS IN PRODUCTION CODE — WHICH IS WHY FIVE TEST-FOCUSED
-     * SWEEPS MISSED IT. *** The measured path admitted <= 22,500 tokens (a 10% margin under the
-     * cap) while the no-tokenizer byte fallback admitted <= 25,000 bytes — which at the module's own
-     * documented 1.0 B/token floor is 25,000 tokens, i.e. exactly the cap and 2,500 tokens BEYOND
-     * what the measured path allows.
-     *
-     * So the module was most generous exactly where it knew least: it relaxed its bound at the
-     * moment it lost the ability to measure. That is the inverse of the doctrine stated in every
-     * other tier here ("absence of evidence is never promoted to compliance") and the same shape as
-     * every defect this SD has closed.
-     *
-     * Pinned as a RELATIONSHIP rather than as two literals, so it holds if either constant moves.
+     * The module must not relax its bound at the moment it loses the ability to measure. Kept from
+     * the original suite because the property survives the model change — but it is now asserted
+     * against TOKENS on both sides rather than comparing a byte count to a token count, which was
+     * only ever coherent while the two scales were confused.
      */
-    expect(SINGLE_READ_SAFE_BYTES).toBeLessThanOrEqual(SINGLE_READ_TOKEN_BUDGET);
-
-    // MUTATION: restore SINGLE_READ_SAFE_BYTES = 25000 -> the fallback outruns the measured path
-    // by 2,500 tokens and this fails.
+    const degradedTokenEquivalent = Math.round(SINGLE_READ_SAFE_BYTES / HARNESS_BYTES_PER_TOKEN);
+    expect(degradedTokenEquivalent).toBeLessThanOrEqual(SINGLE_READ_TOKEN_BUDGET);
   });
 
-  it('the budget leaves a real margin under the cap', () => {
-    expect(SINGLE_READ_TOKEN_BUDGET).toBeLessThan(SINGLE_READ_TOKEN_CAP);
-    expect(SINGLE_READ_TOKEN_BUDGET).toBeGreaterThan(0);
-
+  it('the budget is the cap, and nothing sits between them', () => {
     /**
-     * *** THE ASSERTION THAT USED TO LIVE HERE WOULD HAVE BROKEN WHEN THE SIBLING SD SUCCEEDED. ***
-     * It required every real contract to sit further from the budget than the margin itself, to
-     * show no verdict was decided by the margin. True today — but CLAUDE_ADAM.md is 27,566 tokens
-     * and SD-LEO-INFRA-ADAM-CONTRACT-READABLE-001 exists to bring it under 22,500. Any landing in
-     * 20,000-25,000 arms the role CORRECTLY and would have failed this test, silently imposing a
-     * stricter bar than the arming condition itself.
-     *
-     * That is the mirror of the defect this SD was written to fix. The old arming table could not
-     * change when the world changed; this assertion would have broken when the world changed FOR
-     * THE BETTER. Both are a fact about today pinned as a requirement forever.
-     *
-     * The margin's real property — that it is APPLIED — is asserted above against a synthetic
-     * contract built into the band, which no contract trim can invalidate.
+     * *** THIS ASSERTION IS THE INVERSE OF THE ONE IT REPLACES. *** The old test required
+     * `BUDGET < CAP` — a real margin under the cap. That margin was the defect: three contracts
+     * that read CLEAN (23,897 / 24,336 / 23,153) sat inside it and were disarmed by it, which no
+     * predictor could have fixed. The band is now empty by construction.
      */
+    expect(SINGLE_READ_TOKEN_BUDGET).toBe(SINGLE_READ_TOKEN_CAP);
+    expect(SINGLE_READ_TOKEN_BUDGET).toBeGreaterThan(0);
   });
 });
 

--- a/tests/unit/protocol/contract-read-coverage.test.js
+++ b/tests/unit/protocol/contract-read-coverage.test.js
@@ -314,14 +314,66 @@ describe('the byte proxy is RETIRED — readability is measured in tokens', () =
     }
   });
 
-  it('SAFE_BYTES is the degraded-mode bound and is re-derived from the live scale', () => {
-    // It was derived from the RETIRED constant, so leaving it alone would have been the same defect
-    // one level down. Pinned against the arithmetic that produces it, not against the old floor.
-    expect(SINGLE_READ_SAFE_BYTES).toBe(Math.floor(SINGLE_READ_TOKEN_BUDGET * HARNESS_BYTES_PER_TOKEN));
+  it('SAFE_BYTES is the degraded-mode bound and is pinned to a MEASURED value', () => {
+    /**
+     * *** THE FIRST VERSION OF THIS ASSERTION WAS TAUTOLOGICAL AND MUTATION PROVED IT. ***
+     * It read `expect(SAFE_BYTES).toBe(Math.floor(BUDGET * HARNESS_BYTES_PER_TOKEN))` — restating
+     * the very line that computes it. Moving the constant to 2.60 moved SAFE_BYTES from 60,442 to
+     * 65,000 and this assertion stayed GREEN, because both sides moved together. It is the same
+     * shape as the old suite's calibration checks: two numbers from one belief.
+     *
+     * Pinned to the literal instead. If the scale changes, this fails and someone has to look at
+     * whether the degraded bound is still right rather than have it silently follow along.
+     */
+    expect(SINGLE_READ_SAFE_BYTES).toBe(60442);
 
     // NOT asserted: `SAFE_BYTES <= BUDGET`. That inequality held for every ratio at or above 1.0,
-    // so it would not have noticed the bound loosening — it is the shape of assertion that let the
-    // original defect through, and repeating it here would buy nothing.
+    // so it would not have noticed the bound loosening — the shape of assertion that let the
+    // original defect through.
+  });
+
+  it('an unavailable veto is REPORTED, not silently treated as a clearance', () => {
+    /**
+     * *** TWO INDEPENDENT MUTATIONS SURVIVED THE WHOLE SUITE HERE, IN TWO DIFFERENT MODULES. ***
+     * Making the tokenizer-failure catch return 0 (harness-token-scale.cjs) or false
+     * (contract-read-coverage.cjs) instead of null converts the veto's degradation from "no opinion"
+     * into "cleared" — and 97 tests stayed green. Both modules' docblocks state the invariant
+     * verbatim; neither had an assertion behind it. EXEC review reproduced the live consequence: with
+     * tiktoken blocked, the dense fixture this suite uses to PROVE the veto works flips to fits:true.
+     *
+     * The verdict deliberately does NOT refuse when the veto is unavailable — refusing would disarm
+     * every seat on a tokenizer hiccup, which is the disease being cured. What it must do is SAY SO.
+     */
+    const osx = require_('os'); const fsx = require_('fs'); const px = require_('path');
+    const dir = fsx.mkdtempSync(px.join(osx.tmpdir(), 'ctr-veto-'));
+    fsx.writeFileSync(px.join(dir, 'ok.md'), 'hello world\n'.repeat(20));
+
+    // Cleared and unavailable must be DISTINGUISHABLE. Before this, both emitted an identical verdict.
+    expect(singleReadFit(dir, 'ok.md').veto).toBe('cleared');
+    expect(singleReadFit(dir, 'MISSING.md').veto).toBe('unavailable');
+
+    // And the null itself must stay a null all the way out of the checker — the mutated forms
+    // returned 0 / false, which compare as "did not exceed" and read as a clearance.
+    expect(exceedsCapByRawLowerBound(dir, 'MISSING.md')).toBeNull();
+
+    // THE OTHER HALF, IN THE OTHER MODULE. A mutation making the tokenizer-failure branch return 0
+    // instead of null survived even after the assertion above existed, because that branch fires
+    // only when tiktoken itself will not load — unreachable from any fixture. The loader is injected
+    // so the branch is reachable, which is the only way a test can hold it.
+    const { cl100kRawLowerBound } = require_('../../../lib/protocol/harness-token-scale.cjs');
+    const brokenLoader = () => { throw new Error('tiktoken unavailable'); };
+    expect(cl100kRawLowerBound('some text', brokenLoader)).toBeNull();
+    expect(cl100kRawLowerBound('some text')).toBeGreaterThan(0);   // and the real loader still works
+  });
+
+  it('the veto fires and reports it, on the file it was built for', () => {
+    const osx = require_('os'); const fsx = require_('fs'); const px = require_('path');
+    const dir = fsx.mkdtempSync(px.join(osx.tmpdir(), 'ctr-vfire-'));
+    let seed = 12345;
+    const raw = Buffer.alloc(37000);
+    for (let i = 0; i < raw.length; i++) { seed = (seed * 1103515245 + 12345) % 2147483648; raw[i] = (seed >> 16) & 0xff; }
+    fsx.writeFileSync(px.join(dir, 'D.md'), raw.toString('base64'));
+    expect(singleReadFit(dir, 'D.md').veto).toBe('fired');
   });
 
   it('a dense file is vetoed even though the prose-calibrated bytes model would clear it', () => {

--- a/tests/unit/protocol/contract-read-groundtruth.test.js
+++ b/tests/unit/protocol/contract-read-groundtruth.test.js
@@ -186,6 +186,41 @@ describe('the fixture cannot silently rot', () => {
     expect(row.notice_string).not.toContain('26142');
   });
 
+  /**
+   * *** THE README CLAIMED THIS AND NOTHING ENFORCED IT. ***
+   * The fixture header says "Every row now carries a sha ... bytes are read from the blob, not
+   * remembered." That described the one-off re-capture, not the suite: at the previous commit no
+   * test resolved a sha, and the rot guard checked only that the numbers were positive. PLAN
+   * specified this ~15-LOC guard and it was not built. So the file certifying the span-mismatch fix
+   * carried an unbacked claim about its own provenance — occurrence 6 one level down, found by the
+   * retro measuring the file instead of reading its header.
+   *
+   * Now every sha-bearing row is re-resolved from git and its byte count recomputed. A row whose
+   * bytes drift from its blob fails here rather than quietly re-introducing the exact mispairing
+   * (fresh token count, stale byte count) this fixture exists to have corrected.
+   *
+   * WHAT IT CANNOT CATCH, stated because a guard whose limits are unstated gets over-trusted: a
+   * harness_tokens value that was wrong when recorded, a change to the harness tokenizer itself, or
+   * a history rewrite that drops the sha. Only a fresh truncating read catches those.
+   */
+  it('every sha-bearing row still matches its git blob, byte for byte', () => {
+    const { execSync } = require_('child_process');
+    const rows = [...GT.calibration_set, ...GT.verdict_set, GT.known_residual_false_fail]
+      .filter((r) => r && r.sha);
+
+    // A zero-row sweep would pass silently and read as provenance. Assert there is something to check.
+    expect(rows.length).toBeGreaterThanOrEqual(4);
+
+    for (const row of rows) {
+      const path = row.path || row.name.split('@')[0];
+      const blob = execSync(`git show ${row.sha}:${path}`, {
+        cwd: join(import.meta.dirname, '..', '..', '..'), encoding: 'utf8', maxBuffer: 64 * 1024 * 1024,
+      });
+      expect(Buffer.byteLength(blob, 'utf8'), `${row.name}: recorded bytes do not match blob ${row.sha}`).toBe(row.bytes);
+      if (row.line_count) expect(blob.split('\n').length).toBe(row.line_count);
+    }
+  });
+
   it('predictions are made from FROZEN bytes, never from a file on disk', () => {
     // The whole point of the fixture. If this suite ever reads a live contract, a green run stops
     // meaning the instrument is right and starts meaning the file happened not to have drifted.

--- a/tests/unit/protocol/contract-read-groundtruth.test.js
+++ b/tests/unit/protocol/contract-read-groundtruth.test.js
@@ -26,8 +26,21 @@ const TOL = GT.tolerance;
 
 /** The shipped model, isolated from file I/O so the fixture drives it directly. */
 const predict = (bytes) => Math.round(bytes / HARNESS_BYTES_PER_TOKEN);
-/** The RETIRED model, reconstructed from its recorded overshoot. Used only as the control. */
-const retiredPredict = (row) => Math.round(row.harness_tokens * (1 + GT.retired_model_overshoot_pct[row.name] / 100));
+/**
+ * The RETIRED model, COMPUTED: cl100k on FRAMED text, times 1.85.
+ *
+ * *** THE FIRST VERSION OF THIS WAS FAKE AND I SHIPPED IT. *** It read
+ * `round(harness_tokens * (1 + recorded_overshoot/100))` -- deriving the retired model's prediction
+ * FROM the measured answer, so the control below reduced to "every recorded overshoot exceeds 8.0",
+ * a statement about this fixture's own constants. cl100k was never invoked; `1.85` appeared only in
+ * the test title. That is precisely the shape this suite's own docblock indicts the old suite for:
+ * comparing two numbers that came from the same belief.
+ *
+ * Only rows carrying a git-verified `cl100k_framed` can participate, and the suite asserts that at
+ * least one does rather than quietly controlling on an empty set.
+ */
+const retiredPredict = (row) => Math.round(row.cl100k_framed * GT.retired_model.constant);
+const CONTROLLABLE = GT.calibration_set.filter((r) => Number.isFinite(r.cl100k_framed));
 
 describe('the bytes model against measured harness output', () => {
   it('has ground truth to check against — a zero-row sweep would pass vacuously', () => {
@@ -59,20 +72,29 @@ describe('the bytes model against measured harness output', () => {
    * model, it had no way to express what catching it would look like.
    */
   it('the RETIRED 1.85 model FAILS this same tolerance — the bar discriminates', () => {
-    const failures = GT.calibration_set.filter((row) => {
-      const p = retiredPredict(row);
-      return Math.abs(p - row.harness_tokens) / row.harness_tokens * 100 > TOL.relative_pct;
-    });
-    // Not "at least one" — every single calibration point must reject the retired model.
-    expect(failures.length).toBe(GT.calibration_set.length);
+    // Assert the control has something to run on. A control over an empty set passes silently and
+    // is worth less than no control, because it reads as one.
+    expect(CONTROLLABLE.length).toBeGreaterThanOrEqual(1);
+
+    for (const row of CONTROLLABLE) {
+      const p = retiredPredict(row);                       // cl100k_framed x 1.85, computed
+      const relPct = Math.abs(p - row.harness_tokens) / row.harness_tokens * 100;
+      expect(relPct).toBeGreaterThan(TOL.relative_pct);     // the retired model does NOT clear the bar
+      // ...and the shipped model does, on the very same row. Both directions, one assertion pair.
+      const shipped = Math.abs(predict(row.bytes) - row.harness_tokens) / row.harness_tokens * 100;
+      expect(shipped).toBeLessThanOrEqual(TOL.relative_pct);
+    }
   });
 
-  it('the tolerance is nowhere near the threshold at which it stops discriminating', () => {
-    // Recorded so a future widening cannot happen by accident: at the theatre threshold the retired
-    // model passes this suite, and at the leakage point individual defective files start slipping.
-    expect(TOL.relative_pct).toBeLessThan(TOL.leakage_begins_pct);
-    expect(TOL.relative_pct).toBeLessThan(TOL.theatre_threshold_pct);
+  it('the tolerance sits between the measured error and the point it stops discriminating', () => {
+    // Both bounds asserted against COMPUTED figures, so a future widening cannot happen quietly.
     expect(TOL.relative_pct).toBeGreaterThanOrEqual(TOL.measured_max_error_pct);
+    expect(TOL.relative_pct).toBeLessThan(TOL.theatre_threshold_pct);
+
+    // And the recorded theatre threshold is the real one: at it, the retired model clears the bar.
+    const worstRetired = Math.max(...CONTROLLABLE.map(
+      (r) => Math.abs(retiredPredict(r) - r.harness_tokens) / r.harness_tokens * 100));
+    expect(TOL.theatre_threshold_pct).toBeCloseTo(worstRetired, 1);
   });
 });
 
@@ -99,7 +121,7 @@ describe('verdicts against measured reads — positives and negatives inseparabl
   });
 
   it('the decisive refutation case fits — this is the false-fail the SD exists to remove', () => {
-    const row = GT.verdict_set.find((r) => r.name === 'CLAUDE_SOLOMON.md@fixture-59080');
+    const row = GT.verdict_set.find((r) => r.name === 'CLAUDE_SOLOMON.md@59080');
     expect(predict(row.bytes)).toBeLessThanOrEqual(SINGLE_READ_TOKEN_BUDGET);
 
     // AND it would NOT have fitted under the old 22,500 budget, whatever the predictor said. This is
@@ -122,12 +144,14 @@ describe('the resolution limit is real and is stated rather than hidden', () => 
    * accuracy — the same overstatement as the module comment claiming "every verdict decided by a
    * wide margin", which was false for the files it covered.
    *
-   * *** THE COUNT HERE WAS WRONG WHEN THIS TEST WAS WRITTEN, AND THE TEST IS WHAT CAUGHT IT. ***
+   * *** THIS COUNT HAS NOW BEEN WRONG TWICE, AND THE TEST CAUGHT IT BOTH TIMES. ***
    * Review reported "LEAD 664 (2.7%), SOLOMON 1,103 (4.4%), PLAN 1,847 (7.4%) — all inside the
-   * +-6.8% band", and that phrasing travelled unchecked into the PRD and into a module comment.
-   * 7.4% is not inside 6.8%. The real split is TWO inside (SOLOMON, LEAD) and TWO outside (PLAN,
-   * ADAM). Asserted by computation rather than by the quoted figure, so the arithmetic has to hold
-   * rather than merely being restated.
+   * +-6.8% band", and that phrasing travelled unchecked into the PRD and a module comment. 7.4% is
+   * not inside 6.8%, which made it two-inside/two-outside. THEN the band itself moved: correcting
+   * the mispaired SOLOMON row dropped measured max error from 6.80% to 6.23%, and the SOLOMON row's
+   * own headroom is 7.52% -- so it left the band too. ONE inside (LEAD), three outside.
+   * Asserted by computation rather than by any quoted figure, which is why both corrections
+   * surfaced here instead of shipping.
    */
   it('records which verdicts are decided within the error band', () => {
     const band = TOL.measured_max_error_pct / 100;
@@ -136,10 +160,8 @@ describe('the resolution limit is real and is stated rather than hidden', () => 
     const insideNoise = clean.filter((r) => headroom(r) < band);
 
     expect(clean.length).toBe(4);
-    expect(insideNoise.length).toBe(2);
-    expect(insideNoise.map((r) => r.name).sort()).toEqual(
-      ['CLAUDE_LEAD.md@24336', 'CLAUDE_SOLOMON.md@fixture-59080']
-    );
+    expect(insideNoise.length).toBe(1);
+    expect(insideNoise.map((r) => r.name).sort()).toEqual(['CLAUDE_LEAD.md@24336']);
 
     // And the two decided with real margin are genuinely outside it, not marginally so by rounding.
     for (const r of clean.filter((x) => !insideNoise.includes(x))) {

--- a/tests/unit/protocol/contract-read-groundtruth.test.js
+++ b/tests/unit/protocol/contract-read-groundtruth.test.js
@@ -1,0 +1,175 @@
+/**
+ * The contract-read model against MEASURED HARNESS OUTPUT.
+ * SD-LEO-INFRA-CONTRACT-READ-COVERAGE-001.
+ *
+ * *** THIS SUITE EXISTS BECAUSE THE OLD ONE CHECKED THE MODEL AGAINST ANOTHER CONSTANT. ***
+ * Every calibration assertion in the previous suite compared two numbers that both came from the
+ * same belief — the ratio against itself, the budget against the cap — so the model could be wrong
+ * by 43-61% with the suite fully green. Nothing compared a prediction to what the Read tool
+ * actually did. That is the only comparison that can fail for the right reason.
+ *
+ * No DB, no network, no file I/O against live contracts, no env gate, no skipIf. The fixture is
+ * frozen JSON, so this cannot skip and cannot drift.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const require_ = createRequire(import.meta.url);
+const {
+  singleReadFit, HARNESS_BYTES_PER_TOKEN, SINGLE_READ_TOKEN_CAP, SINGLE_READ_TOKEN_BUDGET,
+} = require_('../../../lib/protocol/contract-read-coverage.cjs');
+
+const GT = JSON.parse(readFileSync(join(import.meta.dirname, '..', '..', 'fixtures', 'protocol', 'contract-read-groundtruth.json'), 'utf8'));
+const TOL = GT.tolerance;
+
+/** The shipped model, isolated from file I/O so the fixture drives it directly. */
+const predict = (bytes) => Math.round(bytes / HARNESS_BYTES_PER_TOKEN);
+/** The RETIRED model, reconstructed from its recorded overshoot. Used only as the control. */
+const retiredPredict = (row) => Math.round(row.harness_tokens * (1 + GT.retired_model_overshoot_pct[row.name] / 100));
+
+describe('the bytes model against measured harness output', () => {
+  it('has ground truth to check against — a zero-row sweep would pass vacuously', () => {
+    expect(GT.calibration_set.length).toBeGreaterThanOrEqual(6);
+    expect(GT.verdict_set.length).toBeGreaterThanOrEqual(7);
+  });
+
+  it.each(GT.calibration_set)('$name: prediction is within tolerance of what the harness reported', (row) => {
+    const p = predict(row.bytes);
+    const relPct = Math.abs(p - row.harness_tokens) / row.harness_tokens * 100;
+    const absTok = Math.abs(p - row.harness_tokens);
+    // BOTH bounds. A relative-only bound lets a large file drift thousands of tokens; an
+    // absolute-only bound is meaningless on a small one.
+    expect(relPct).toBeLessThanOrEqual(TOL.relative_pct);
+    expect(absTok).toBeLessThanOrEqual(TOL.absolute_tokens);
+  });
+
+  it('the worst case across the whole set is inside tolerance, not just each case separately', () => {
+    const worstRel = Math.max(...GT.calibration_set.map((r) => Math.abs(predict(r.bytes) - r.harness_tokens) / r.harness_tokens * 100));
+    expect(worstRel).toBeLessThanOrEqual(TOL.relative_pct);
+    // And it is genuinely close to the bar rather than trivially inside it — a tolerance ten times
+    // the observed error would pass anything.
+    expect(worstRel).toBeGreaterThan(TOL.relative_pct / 4);
+  });
+
+  /**
+   * *** THE TWO-SIDED CONTROL. A tolerance that both models pass proves nothing about either. ***
+   * This is the assertion the original suite never had: it did not merely fail to catch the 1.85
+   * model, it had no way to express what catching it would look like.
+   */
+  it('the RETIRED 1.85 model FAILS this same tolerance — the bar discriminates', () => {
+    const failures = GT.calibration_set.filter((row) => {
+      const p = retiredPredict(row);
+      return Math.abs(p - row.harness_tokens) / row.harness_tokens * 100 > TOL.relative_pct;
+    });
+    // Not "at least one" — every single calibration point must reject the retired model.
+    expect(failures.length).toBe(GT.calibration_set.length);
+  });
+
+  it('the tolerance is nowhere near the threshold at which it stops discriminating', () => {
+    // Recorded so a future widening cannot happen by accident: at the theatre threshold the retired
+    // model passes this suite, and at the leakage point individual defective files start slipping.
+    expect(TOL.relative_pct).toBeLessThan(TOL.leakage_begins_pct);
+    expect(TOL.relative_pct).toBeLessThan(TOL.theatre_threshold_pct);
+    expect(TOL.relative_pct).toBeGreaterThanOrEqual(TOL.measured_max_error_pct);
+  });
+});
+
+describe('verdicts against measured reads — positives and negatives inseparable', () => {
+  /**
+   * ONE TABLE, `expected_fits` as a column. Positives and negatives cannot be separated by a future
+   * edit: deleting the held negative means deleting rows from the same array the positives live in,
+   * and the guard below notices.
+   */
+  it.each(GT.verdict_set)('$name: verdict matches the read that actually happened', (row) => {
+    const fits = predict(row.bytes) <= SINGLE_READ_TOKEN_BUDGET;
+    expect(fits).toBe(row.expected_fits);
+  });
+
+  it('the table still contains a held negative AND a near-miss one', () => {
+    const negatives = GT.verdict_set.filter((r) => r.expected_fits === false);
+    expect(negatives.length).toBeGreaterThan(0);
+
+    // A near-miss is what discriminates. The other negatives are 48-61% over cap and any model that
+    // is not catastrophically wrong catches them, so a suite carrying only those is much weaker
+    // than its row count suggests.
+    const nearMiss = negatives.filter((r) => r.harness_tokens < SINGLE_READ_TOKEN_CAP * 1.15);
+    expect(nearMiss.length).toBeGreaterThan(0);
+  });
+
+  it('the decisive refutation case fits — this is the false-fail the SD exists to remove', () => {
+    const row = GT.verdict_set.find((r) => r.name === 'CLAUDE_SOLOMON.md@fixture-59080');
+    expect(predict(row.bytes)).toBeLessThanOrEqual(SINGLE_READ_TOKEN_BUDGET);
+
+    // AND it would NOT have fitted under the old 22,500 budget, whatever the predictor said. This is
+    // the pin on the finding that reshaped the SD: retiring the constant alone could not fix it.
+    expect(row.harness_tokens).toBeGreaterThan(22500);
+  });
+
+  it('every clean-reading contract fits, and every truncating one does not', () => {
+    for (const row of GT.verdict_set) {
+      const fits = predict(row.bytes) <= SINGLE_READ_TOKEN_BUDGET;
+      expect(fits).toBe(row.read_outcome === 'clean');
+    }
+  });
+});
+
+describe('the resolution limit is real and is stated rather than hidden', () => {
+  /**
+   * Some clean readers sit within the model's own error band of the cap, so their verdicts are
+   * inside the noise. This suite states that instead of presenting them as demonstrations of
+   * accuracy — the same overstatement as the module comment claiming "every verdict decided by a
+   * wide margin", which was false for the files it covered.
+   *
+   * *** THE COUNT HERE WAS WRONG WHEN THIS TEST WAS WRITTEN, AND THE TEST IS WHAT CAUGHT IT. ***
+   * Review reported "LEAD 664 (2.7%), SOLOMON 1,103 (4.4%), PLAN 1,847 (7.4%) — all inside the
+   * +-6.8% band", and that phrasing travelled unchecked into the PRD and into a module comment.
+   * 7.4% is not inside 6.8%. The real split is TWO inside (SOLOMON, LEAD) and TWO outside (PLAN,
+   * ADAM). Asserted by computation rather than by the quoted figure, so the arithmetic has to hold
+   * rather than merely being restated.
+   */
+  it('records which verdicts are decided within the error band', () => {
+    const band = TOL.measured_max_error_pct / 100;
+    const clean = GT.verdict_set.filter((r) => r.read_outcome === 'clean');
+    const headroom = (r) => (SINGLE_READ_TOKEN_CAP - r.harness_tokens) / SINGLE_READ_TOKEN_CAP;
+    const insideNoise = clean.filter((r) => headroom(r) < band);
+
+    expect(clean.length).toBe(4);
+    expect(insideNoise.length).toBe(2);
+    expect(insideNoise.map((r) => r.name).sort()).toEqual(
+      ['CLAUDE_LEAD.md@24336', 'CLAUDE_SOLOMON.md@fixture-59080']
+    );
+
+    // And the two decided with real margin are genuinely outside it, not marginally so by rounding.
+    for (const r of clean.filter((x) => !insideNoise.includes(x))) {
+      expect(headroom(r)).toBeGreaterThan(band);
+    }
+  });
+});
+
+describe('the fixture cannot silently rot', () => {
+  it('every calibration row carries both halves a bytes model needs', () => {
+    for (const row of GT.calibration_set) {
+      expect(row.bytes).toBeGreaterThan(0);
+      expect(row.harness_tokens).toBeGreaterThan(0);
+      expect(['notice', 'differential']).toContain(row.source);
+    }
+  });
+
+  it('the corrected numerator is recorded, not the one two files disagreed on', () => {
+    const row = GT.verdict_set.find((r) => r.name === 'CLAUDE_SOLOMON.md@371-pre-split');
+    expect(row.harness_tokens).toBe(26138);
+    expect(row.notice_string).toContain('26138');
+    expect(row.notice_string).not.toContain('26142');
+  });
+
+  it('predictions are made from FROZEN bytes, never from a file on disk', () => {
+    // The whole point of the fixture. If this suite ever reads a live contract, a green run stops
+    // meaning the instrument is right and starts meaning the file happened not to have drifted.
+    const src = readFileSync(import.meta.filename, 'utf8');
+    const code = src.split('\n').filter((l) => !/^\s*(\*|\/\/|\/\*)/.test(l)).join('\n');
+    expect(code).not.toMatch(/singleReadFit\(\s*process\.cwd\(\)/);
+    expect(code).not.toMatch(/CLAUDE_\w+\.md'\s*\)/);
+  });
+});


### PR DESCRIPTION
The contract-read instrument predicted truncation on contracts that read clean, disarming live seats. The SD was filed against the constant `CL100K_TO_HARNESS = 1.85`. **Three defects were stacked on one verdict, and the constant was the smallest.**

## The binding cause was the margin, not the constant

`singleReadFit` compared against a 22,500 budget, not the 25,000 cap. Measured actual harness tokens: SOLOMON 23,897, LEAD 24,336, PLAN 23,153 — **all three read clean and all three exceeded the budget**. A perfect predictor still disarmed three of the four clean-reading contracts, so no refit of the constant could ever have reached it. This was discovered at PLAN; the SD's own FR-3 was aimed at the wrong lever.

## The model, and why not a new number

`contractTokenCount` framed the file `cat -n` style and then multiplied a cl100k count — but the harness charges for **raw** content. Measured on a controlled pair with identical words at a 22× line-count difference, `k_raw` held while `k_framed` swung 1.63→1.25. Framing before predicting introduced a line-count dependence the predicted thing does not have, which is why one constant fitted a 371-line file and overshot the 1,400-line phase files by 43–61%.

The constant itself came from a **span mismatch**: a whole-file harness count (371 lines) over a cl100k count of the *delivered slice* (301). Span-matched it is 1.505 — and 1.505 is also wrong, being `1.6416/1.0911` where 1.0911 is that one file's framing overhead. Hence a model change rather than a new number.

## One quantity, one home

The repo carried two rival answers to "how big is this file to the Read tool". Both now come from `lib/protocol/harness-token-scale.cjs`. Bytes wins on **single-representation** grounds, not accuracy — on one basis cl100k-on-raw is about twice as tight. Bytes are content-blind, so a cl100k-on-raw lower bound rides alongside as a one-sided veto needing no calibration.

## What review caught that I did not

- My **fixture contained a span mismatch** — inside the fixture certifying the span-mismatch fix. It paired 59,080 bytes with a token count belonging to the 61,013-byte file, and it was the one row keeping the suite green. A second row recorded 67,501 B against a 67,131 B blob (delta exactly 370 = the newline count, a CRLF artifact) and set the tolerance constant.
- My **two-sided control was fake**: it derived the retired model's prediction from the measured answer, asserting a fact about my own constants. cl100k was never invoked.
- My **SAFE_BYTES pin restated the line that computes it**, so mutation moved both sides and it stayed green.
- An **unavailable veto read as a clearance** — two mutations converting its null to `0`/`false` survived all 97 tests, because both modules stated the invariant in a docblock with nothing behind it.
- The **fixture's own README claimed a provenance nothing enforced**. Every sha-bearing row is now re-resolved from git.

## Honest residuals

**This delivers one seat, not two.** CLAUDE_ADAM.md goes disarmed→ARMED with 24.6% margin. CLAUDE_SOLOMON.md at HEAD is still disarmed and it is a **false** fail: measured 23,896, reads clean with no notice, 1,104 under the cap, against a predicted 25,236 — 5.61% overshoot, inside the model's own error band. Carried in the fixture as a self-retiring residual rather than omitted.

The veto *bounds* the density hole at ~1.67× cap; it does not close it, and fires on none of the eight real contracts. One-sidedness is not soundness — the 1.64–1.72 band is prose-only, and emoji-dense text can trip it while genuinely fitting. `SINGLE_READ_TOKEN_CAP` still has two declarations, one short of this SD's own thesis.

103 tests green across 5 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)