### PR TITLE
feat(SD-LEO-INFRA-INGRESS-BOUND-DEFINER-BASIS-001): stage the definer basis + fix the probe that could not detect the fix

### DIFF
--- a/database/chairman-gated/20260804_ingress_bound_definer_basis.sql
+++ b/database/chairman-gated/20260804_ingress_bound_definer_basis.sql
@@ -1,0 +1,113 @@
+-- SD-LEO-INFRA-INGRESS-BOUND-DEFINER-BASIS-001 — give the anon ingress bound a basis that can bind
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- STAGED, NOT APPLIED. CHAIRMAN-GATED. DO NOT RUN THIS FILE.
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- There is NO non-production database. This lands directly on a live production ingress path, and
+-- it converts a bound that has been INERT for its entire life into one that REJECTS. Applying it
+-- without an approved threshold is not a deployment, it is an outage with a commit message.
+--
+-- PREREQUISITE, per the SD: chairman approval of (a) the per-source thresholds below and (b) the
+-- projected rejection volume they imply. Both are measured and recorded — see
+-- strategic_directives_v2.metadata.ingress_bound_projection.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- THE DEFECT, VERIFIED LIVE (not inherited from the SD text)
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+--   pg_policy.polpermissive = false                     -> RESTRICTIVE, as claimed
+--   pg_get_expr(polwithcheck) contains, verbatim:
+--       ( SELECT (count(*) < 50) FROM feedback f
+--         WHERE NOT (f.source_type IS DISTINCT FROM feedback.source_type)
+--           AND f.created_at > (now() - '01:00:00'::interval) )
+--   ...and calls NO definer function.
+--
+-- An inline subquery inside a policy executes as the INSERTING role. anon's SELECT policy is
+-- telegram-only, so for every non-telegram source the visible basis is n=1 and `count(*) < 50` is
+-- arithmetically incapable of being false. The limit is dormant, not absent.
+--
+-- NOT THE SAME BUG as check_feedback_rate_limit(venture_id), which venture_user_insert_feedback
+-- also calls: verified live prosecdef = TRUE. That function IS definer and DOES bind. It is
+-- deliberately untouched here — changing it would be a fix aimed at a control that works.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- WHY PER-SOURCE THRESHOLDS, MEASURED
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- Replaying the exact live bound over 30 days, UNCAPPED (every row, no sample):
+--
+--   source_type          inserts   would_reject_at_50   peak_prior_hour
+--   auto_capture           8309          1226 (14.8%)          213
+--   manual_feedback        3666             0  (0.0%)           48
+--   manual_capture          114             0                    4
+--   error_capture            16             0                    4
+--   claude_code_intake        3             0                    1
+--   TOTAL                 12108          1226 (10.1%)
+--
+-- auto_capture bursts to 4.3x the limit; manual_feedback peaks at 48 against that same 50 — about
+-- 4% headroom on HUMAN submissions, with no warning before it starts rejecting them. The two
+-- populations differ by >2 orders of magnitude, so one shared number either fails to bind the
+-- noisy source or endangers the human one. It cannot do both.
+--
+-- THRESHOLDS BELOW ARE PROPOSALS FOR THE CHAIRMAN, NOT DECISIONS I MADE:
+--   auto_capture      250  -- above the observed 213 peak, so it bounds runaway rather than normal
+--                          -- operation. Set it at/below 213 only with intent to reject today's
+--                          -- traffic; the projection says that is 14.8% of that source.
+--   manual_feedback   200  -- ~4x the observed 48 peak. Real headroom, because a false reject here
+--                          -- is a lost human report, which no retry recovers.
+--   default            50  -- unchanged for the low-volume sources (peaks of 4, 4, 1).
+--
+-- ROLLBACK: restore the original WITH CHECK captured verbatim at the head of this file, and DROP
+-- the function. The policy is RESTRICTIVE either way, so rollback never widens access.
+
+BEGIN;
+
+-- ── The basis ────────────────────────────────────────────────────────────────────────────────
+-- SECURITY DEFINER is the entire fix: it makes the count independent of what the INSERTING role
+-- can see. STABLE (not IMMUTABLE) because it reads a table whose contents change. search_path is
+-- pinned — a SECURITY DEFINER function with a mutable search_path is a privilege-escalation
+-- surface, which would be a worse defect than the one being repaired.
+CREATE OR REPLACE FUNCTION public.fn_anon_ingress_prior_hour_count(p_source_type text)
+RETURNS bigint
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+  SELECT count(*)
+  FROM public.feedback f
+  WHERE f.source_type IS NOT DISTINCT FROM p_source_type
+    AND f.created_at > now() - interval '1 hour';
+$function$;
+
+COMMENT ON FUNCTION public.fn_anon_ingress_prior_hour_count(text) IS
+  'SD-LEO-INFRA-INGRESS-BOUND-DEFINER-BASIS-001: real prior-hour ingress count for the RESTRICTIVE '
+  'anon bound. SECURITY DEFINER so the basis does not collapse to the inserting role''s visible '
+  'rows (anon SELECT is telegram-only, which made the inline-subquery basis n=1 and the bound inert).';
+
+-- Callable by the ingress roles only. It answers one aggregate question and exposes no rows, but
+-- it still reads a table the caller cannot, so the grant is deliberately narrow.
+REVOKE ALL ON FUNCTION public.fn_anon_ingress_prior_hour_count(text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.fn_anon_ingress_prior_hour_count(text) TO anon, authenticated;
+
+-- ── The bound ────────────────────────────────────────────────────────────────────────────────
+-- Stays RESTRICTIVE. The severity and category clauses are carried over BYTE-FOR-BYTE from the
+-- live policy; only the counting term changes. Retyping the untouched half is how an unrelated
+-- clause silently disappears.
+DROP POLICY IF EXISTS anon_feedback_ingress_bounds ON public.feedback;
+
+CREATE POLICY anon_feedback_ingress_bounds ON public.feedback
+  AS RESTRICTIVE
+  FOR INSERT
+  WITH CHECK (
+    ((severity IS NULL) OR ((severity)::text <> ALL ((ARRAY['critical'::character varying, 'high'::character varying])::text[])))
+    AND ((category)::text IS DISTINCT FROM 'chairman_decision_deferred'::text)
+    AND (
+      public.fn_anon_ingress_prior_hour_count((source_type)::text)
+      < CASE (source_type)::text
+          WHEN 'auto_capture'    THEN 250
+          WHEN 'manual_feedback' THEN 200
+          ELSE 50
+        END
+    )
+  );
+
+COMMIT;

--- a/scripts/anon-write-contract-probe.mjs
+++ b/scripts/anon-write-contract-probe.mjs
@@ -348,6 +348,20 @@ export async function assertIngressBoundCannotBind(q, table, source) {
   await q('reset role');
   await q('rollback to savepoint sp_bound');
 
+  // SD-LEO-INFRA-INGRESS-BOUND-DEFINER-BASIS-001: read the BASIS ITSELF, not only its symptom.
+  //
+  // The visibility gap below (definer.n > 1 && anon.n <= 1) is a SYMPTOM of the inline-subquery
+  // basis — but the fix for that basis is a SECURITY DEFINER function, which deliberately does NOT
+  // close the gap: anon's SELECT surface stays exactly as narrow as it is today (that narrowing is
+  // owned by SD-LEO-INFRA-CONTROL-SURFACE-POSTURE-001 and widening it was explicitly ruled out).
+  //
+  // So a gap-only detector NEVER FLIPS. It would keep reporting this finding after the defect is
+  // gone, and inverting its EXPECTED would produce a check that is wrong in BOTH states. Measured
+  // here rather than assumed: with_check is already fetched above and was simply never examined.
+  const withCheck = String(pol.with_check || '');
+  const inlineBasis = /\bselect\b[\s\S]*\bcount\s*\(/i.test(withCheck);
+  const definerFnBasis = /fn_anon_ingress_prior_hour_count\s*\(/i.test(withCheck);
+
   return {
     applicable: true,
     restrictive: String(pol.permissive).toUpperCase() === 'RESTRICTIVE',
@@ -355,7 +369,13 @@ export async function assertIngressBoundCannotBind(q, table, source) {
     anonBasis: asAnon.n,
     // Non-vacuity: without this, a source with no recent rows agrees at 0 and "passes".
     vacuous: definer.n <= 1,
-    cannotBind: definer.n > 1 && asAnon.n <= 1
+    // The basis, read from the policy — this is what actually flips when the SD lands.
+    inlineBasis,
+    definerFnBasis,
+    // cannotBind now requires the DEFECT (an inline counting subquery) to still be present, not
+    // merely the visibility gap it exploits. Same verdict today; correctly GREEN once the basis
+    // becomes a definer call, which is what makes the reddening a real acceptance signal.
+    cannotBind: inlineBasis && definer.n > 1 && asAnon.n <= 1
   };
 }
 


### PR DESCRIPTION
## Summary

`anon_feedback_ingress_bounds` is a rate limit that **cannot rate-limit**. Verified live, not
inherited from the SD text: `polpermissive=false` (RESTRICTIVE), and its WITH CHECK carries an
inline `SELECT count(*) < 50 FROM feedback ...` with no definer call. An inline subquery in a
policy executes as the **inserting** role, and anon's SELECT is telegram-only — so for every
non-telegram source the visible basis is `n=1` and `count(*) < 50` can never be false.

**The DDL is STAGED and NOT APPLIED.** There is no non-production database; this lands directly on
a live ingress path and turns a dormant bound into one that rejects.

## The threshold is your decision, and it is measured

Replaying the exact live bound over 30 days, **uncapped** (every row, no sample):

| source_type | inserts | would reject @50 | peak prior-hour |
|---|---|---|---|
| `auto_capture` | 8,309 | **1,226 (14.8%)** | **213** |
| `manual_feedback` | 3,666 | 0 | **48** |
| `manual_capture` | 114 | 0 | 4 |
| `error_capture` | 16 | 0 | 4 |
| **TOTAL** | 12,108 | **1,226 (10.1%)** | |

`auto_capture` bursts to **4.3× the limit**; `manual_feedback` peaks at **48 against that same
50** — roughly 4% headroom on human submissions, with no warning before it starts rejecting them.
The two populations differ by more than two orders of magnitude, so one shared number either fails
to bind the noisy source or endangers the human one.

Staged thresholds are **proposals, not decisions I made**: `auto_capture` 250 (above the 213 peak,
so it bounds runaway rather than normal operation), `manual_feedback` 200 (~4× the 48 peak — a
false reject here loses a human report no retry recovers), default 50 unchanged.

## The probe could not have detected its own acceptance criterion

FR-4 says the probe will **redden** when the basis is fixed, and that reddening is the acceptance
signal. **It would not have.** `cannotBind` was `definer.n > 1 && asAnon.n <= 1` — the *visibility
gap*, a symptom. The fix is a SECURITY DEFINER function, which deliberately **leaves that gap
intact** (widening anon SELECT was explicitly ruled out and belongs to
SD-LEO-INFRA-CONTROL-SURFACE-POSTURE-001). Both counts are unchanged by this SD, so the detector
never flips.

Following FR-4 literally — inverting EXPECTED — would have produced a check **wrong in both
states**: green while the defect is live, red once fixed.

The policy's `with_check` was already fetched and never examined. The detector now reads the basis
itself, proven against the **real** live and staged policies:

```
LIVE   inlineBasis=true   definerFnBasis=false  -> fires
STAGED inlineBasis=false  definerFnBasis=true   -> clears
```

with a control recording that the old gap-only predicate still fires after apply.

## Safety

- Validation is **read-only** — nothing executed, not even inside `BEGIN`/`ROLLBACK`, because a
  concurrent caller on this shared production path would observe the replacement in that window.
- It asserts the defect is **still live** and the function does **not** exist, making "staged" a
  verified state rather than an intention.
- Severity/category clauses carried **byte-for-byte** from the live policy and asserted equal —
  retyping the untouched half is how an unrelated clause silently disappears.
- `check_feedback_rate_limit` untouched (`prosecdef=true`, verified) — the SD warns that filing
  against both would file a bug against a working control.
- No `GRANT SELECT`; the anon read surface is unchanged.

Sub-agents: TESTING PASS, SECURITY PASS. Chain: LEAD-TO-PLAN 95, PLAN-TO-EXEC 92, EXEC-TO-PLAN 93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)