### PR TITLE
SD-LEO-INFRA-LLM-ADAPTER-STREAMING-ABSENT-001: the consumer was retired two months before the function was filed as broken

### DIFF
--- a/docs/architecture/llm-stream-watchdog.md
+++ b/docs/architecture/llm-stream-watchdog.md
@@ -46,14 +46,33 @@ appear.
 
 | Caller | Path | Workload shape | Notes |
 |---|---|---|---|
-| Stage 17 archetype generation | `lib/eva/stage-17/archetype-generator.js:862` | HTML generation; tokens stream continuously | The motivating S17 caller — routes through `getLLMClient → AnthropicAdapter.complete → _completeWithStreaming`, auto-protected by the watchdog. |
-| Stage 17 design refinement | `lib/eva/stage-17/archetype-generator.js:1055` | Same as above, refinement pass | Same routing, same protection. |
+| Stage 17 archetype generation | `lib/eva/stage-17/archetype-generator.js:110` | HTML generation; tokens stream continuously | The motivating S17 caller — routes through `getLLMClient → AnthropicAdapter.complete → _completeWithStreaming`, auto-protected by the watchdog. |
+| Stage 17 design refinement | `lib/eva/stage-17/refinement.js:107` | Same as above, refinement pass | Same routing, same protection. |
+| PRD generation | `scripts/prd/llm-generator.js:104` | Long-form PRD body; continuous | Third live `{stream: true}` caller, previously undocumented here. |
+
+> **Corrected by SD-LEO-INFRA-LLM-ADAPTER-STREAMING-ABSENT-001.** The first two rows previously
+> cited lines 862 and 1055 of `archetype-generator.js` — a file that is 184 lines long, so both
+> pointed past EOF — and attributed the refinement caller to that file rather than to
+> `refinement.js`. These are the rows describing the LIVE streaming callers, so a reader repairing
+> streaming was sent to line numbers that do not exist in a file that does not contain the caller.
+> The historical line numbers are named here, in prose, rather than in the table: a stale pointer
+> inside a table is one a reader will follow.
 
 ### Direct SDK callers (currently unprotected)
 
-| Caller | Path | Reason | Follow-up |
-|---|---|---|---|
-| EVA chat service | `lib/integrations/eva-chat-service.js:318` | Bypasses the provider adapter — calls `client.messages.stream()` directly to wire `stream.on('text', ...)` for token-streaming UX | Wrap with `withStreamWatchdog(stream, { callerLabel: 'eva-chat' })` in a follow-up QF. Token-streaming UX is bursty, but never legitimately silent for >90s on a sonnet-tier 1024-token reply. |
+**None.** This section previously listed one, and both halves of that entry were wrong.
+
+It named `lib/integrations/eva-chat-service.js:318` and said the site "bypasses the provider adapter
+— calls `client.messages.stream()` directly". It never did: the function obtained its client from
+`createLLMClient`, a symbol `client-factory.js` has never exported, so it threw on a missing symbol
+before reaching any SDK call. And the line reference had drifted to `:335` before the function was
+removed entirely by SD-LEO-INFRA-LLM-ADAPTER-STREAMING-ABSENT-001 — its consumer had been retired
+by Chairman decision `cff73055` two months before anyone filed it as a defect.
+
+The prescribed follow-up (wrap it with the watchdog) was therefore unexecutable against a call that
+could not run, in a file that no longer contains it. Recorded rather than silently dropped, because
+a stale row that sends a reader to a line past EOF costs more than an absent one — which is exactly
+what the two rows above did until this SD.
 
 ### Non-streaming callers (out of scope)
 

--- a/lib/integrations/eva-chat-service.js
+++ b/lib/integrations/eva-chat-service.js
@@ -17,11 +17,14 @@ import { getClaudeModel } from '../config/model-config.js';
 // SD-LEO-INFRA-USER-STORY-QUALITY-001 (FR-3): BOTH LLM call sites in this file destructured
 // `createLLMClient` from a DYNAMIC import of client-factory.js — a symbol that module does not
 // export. The destructure therefore yielded `undefined` and the call threw
-// "createLLMClient is not a function" on EVERY invocation, live via generateEVAResponse (chat) and
-// streamMessage (streaming chat). That is a hard fail rather than the silent fallback the stories
-// module had, so it was visible to whoever hit it — but it means EVA chat has been dead on both
-// paths, not degraded. Static import so the symbol is resolved at load time and a future rename
-// breaks the build instead of one request.
+// "createLLMClient is not a function" on EVERY invocation. That is a hard fail rather than the
+// silent fallback the stories module had, so it was visible to whoever hit it — but it means EVA
+// chat was dead on both paths, not degraded. Static import so the symbol is resolved at load time
+// and a future rename breaks the build instead of one request.
+// UPDATED BY SD-LEO-INFRA-LLM-ADAPTER-STREAMING-ABSENT-001: this comment said "BOTH LLM call sites"
+// and named the streaming one. That site is gone — see the retirement block further down. Corrected
+// here because a correction that lands on the deletion site while the file header keeps describing
+// the deleted thing is how the next reader gets a false picture from a file that was just fixed.
 import { getLLMClient } from '../llm/client-factory.js';
 import { isMainModule } from '../utils/is-main-module.js';
 import { getSectionPrompt } from '../eva/friday-chat-prompt.js';
@@ -274,114 +277,47 @@ export async function getMessages(conversationId) {
 }
 
 /**
- * Stream EVA response tokens via SSE callbacks.
- * SD-LEO-INFRA-EVA-CHAT-CANVAS-004 (Phase 3 — Streaming)
+ * *** streamMessage WAS DELETED HERE. IT IS NOT MISSING, IT IS RETIRED. ***
+ * SD-LEO-INFRA-LLM-ADAPTER-STREAMING-ABSENT-001.
  *
- * @param {string} conversationId
- * @param {string} userContent
- * @param {string} userId
- * @param {{ onToken: (t:string)=>void, onComplete: (msg:object)=>void, onError: (e:Error)=>void }} callbacks
+ * READ THIS BEFORE FILING IT AS A DEFECT AGAIN. Three separate parties examined this function and
+ * each re-derived from scratch that it was dead: the parent SD that deliberately left it broken,
+ * the SD filed to repair it, and two independent review agents. The cost of that rediscovery is
+ * why this comment is longer than a deletion note needs to be.
+ *
+ * WHAT IT WAS: an SSE token-streaming entry point for EVA chat, added 2026-03-09 (86c2e384f1d,
+ * SD-LEO-INFRA-EVA-CHAT-CANVAS-004 Phase 3) together with its only caller, POST /api/eva/chat/stream
+ * in server/routes/eva-chat.js.
+ *
+ * WHY IT IS GONE: that route was deleted 2026-06-02 in f85cd2a7c92 (QF-20260602-028, PR #4185)
+ * under a ratified Chairman wire-or-cut decision, feedback cff73055 — "CUT CRUD + retire /stream".
+ * The route removal took the caller and left the callee. THE CONSUMER WAS RETIRED TWO MONTHS BEFORE
+ * ANYONE FILED THE FUNCTION AS BROKEN. Verified at deletion time: zero callers across all four
+ * repos by import graph and by git history; no SSE surface (text/event-stream) anywhere in this
+ * repo; the ehg frontend hook useEVAChatConversation.ts uses Supabase RPC only, with no fetch and
+ * no EventSource.
+ *
+ * NOTE the deleting QF's own justification was imprecise: it retained this module because
+ * "Friday-meeting uses it", which is true of sendMessage and was never true of streamMessage.
+ *
+ * IT ALSO NEVER DEMONSTRATED THE DEFECT IT WAS FILED FOR. It destructured `createLLMClient` from
+ * client-factory.js — a symbol that module has NEVER exported (git log -S on that file is empty) —
+ * so it threw on a missing symbol one line before it reached .messages.stream(). The streaming gap
+ * is real, but this call site never reached it.
+ *
+ * IF YOU NEED TOKEN STREAMING: the adapter layer HAS streaming transport and it is live in
+ * production — AnthropicAdapter._completeWithStreaming (lib/sub-agents/vetting/provider-adapters.js)
+ * calls real messages.stream(), GoogleAdapter uses SSE, and three callers pass {stream:true} today.
+ * What is absent is incremental DELIVERY: lib/llm/stream-watchdog.js onText() takes no argument and
+ * discards the token text, resolving to a single finalMessage(). It is a stall detector, not a pipe.
+ * Surfacing incremental events is roughly 150-200 LOC. See docs/architecture/llm-stream-watchdog.md.
+ *
+ * The exact call shape is preserved as an inert specimen at
+ * tests/fixtures/llm-call-shapes/dead-factory-messages-stream.fixture.mjs so a future lint rule has
+ * a positive subject. Reviving this path would also make two latent issues live immediately: there
+ * is no ownership check on conversationId, and both compat layers discard a claude-* model when the
+ * provider is google, which .env sets today.
  */
-export async function streamMessage(conversationId, userContent, _userId, callbacks) {
-  // Validate conversation
-  const { data: conv, error: convErr } = await supabase
-    .from('eva_chat_conversations')
-    .select('id')
-    .eq('id', conversationId)
-    .single();
-
-  if (convErr || !conv) {
-    callbacks.onError(new Error(`Conversation not found: ${conversationId}`));
-    return;
-  }
-
-  // Store user message
-  const { error: userErr } = await supabase
-    .from('eva_chat_messages')
-    .insert({ conversation_id: conversationId, role: 'user', content: userContent });
-
-  if (userErr) {
-    callbacks.onError(new Error(`Failed to store user message: ${userErr.message}`));
-    return;
-  }
-
-  // Get conversation history
-  const { data: history } = await supabase
-    .from('eva_chat_messages')
-    .select('role, content')
-    .eq('conversation_id', conversationId)
-    .order('created_at', { ascending: true });
-
-  const messages = (history || [{ role: 'user', content: userContent }]).map(m => ({
-    role: m.role,
-    content: m.content
-  }));
-
-  try {
-    // *** DELIBERATELY NOT REPAIRED IN SD-LEO-INFRA-USER-STORY-QUALITY-001 — SEE BELOW. ***
-    // This site has the same dead `createLLMClient` destructure as generateEVAResponse above, but
-    // repairing it is NOT the same one-line change, because it needs `.messages.stream()` with
-    // incremental token events and THE ADAPTER LAYER HAS NO STREAMING AT ALL — every adapter
-    // exposes only the non-incremental `.complete()`. The FR-4 compat layer deliberately provides
-    // `.messages.create` and NOT `.messages.stream`: a `.stream()` that resolved `.complete()` and
-    // emitted the whole response as one 'text' event would satisfy this call site while making the
-    // word "stream" false, which is the defect class this SD exists to remove, not a fix for it.
-    // Real streaming support in the adapter layer is separate work with a different blast radius.
-    // Left failing loudly (TypeError on call) rather than silently faked.
-    const { createLLMClient } = await import('../llm/client-factory.js');
-    const client = await createLLMClient('sonnet');
-
-    // Use Claude streaming API
-    const stream = client.messages.stream({
-      model: getClaudeModel('validation'),
-      max_tokens: 1024,
-      system: EVA_SYSTEM_PROMPT,
-      messages
-    });
-
-    let fullContent = '';
-
-    stream.on('text', (text) => {
-      fullContent += text;
-      callbacks.onToken(text);
-    });
-
-    const finalMessage = await stream.finalMessage();
-
-    const tokenCount = (finalMessage.usage?.input_tokens || 0) + (finalMessage.usage?.output_tokens || 0);
-
-    // Store the complete response
-    const { data: assistantMsg, error: assistantErr } = await supabase
-      .from('eva_chat_messages')
-      .insert({
-        conversation_id: conversationId,
-        role: 'assistant',
-        content: fullContent,
-        token_count: tokenCount,
-        model_used: finalMessage.model || getClaudeModel('validation')
-      })
-      .select()
-      .single();
-
-    if (assistantErr) {
-      callbacks.onError(new Error(`Failed to store response: ${assistantErr.message}`));
-      return;
-    }
-
-    // Auto-title if first exchange
-    if (history && history.length <= 1) {
-      const title = userContent.slice(0, 80) + (userContent.length > 80 ? '...' : '');
-      await supabase
-        .from('eva_chat_conversations')
-        .update({ title })
-        .eq('id', conversationId);
-    }
-
-    callbacks.onComplete(assistantMsg);
-  } catch (err) {
-    callbacks.onError(err);
-  }
-}
 
 export { buildSystemPrompt, EVA_BASE_PROMPT };
 

--- a/tests/fixtures/llm-call-shapes/dead-factory-messages-stream.fixture.js
+++ b/tests/fixtures/llm-call-shapes/dead-factory-messages-stream.fixture.js
@@ -28,15 +28,22 @@
  *
  * INERT BY THREE INDEPENDENT MECHANISMS, each verified rather than assumed:
  *   - `tests/` is outside dead-code-scanner.mjs IMPORT_GRAPH_DIRS, so it is never graph-scanned.
- *   - the vitest unit project collects only `*.test.js`, so a `.fixture.mjs` name cannot be run.
+ *   - the vitest unit project collects only `*.test.js`, so a `.fixture.js` name cannot be run.
  *   - nothing imports this file; the export exists solely to give a parser something to bind.
- * It remains lintable (eslint.config.js ignores only bundles/dist/build/node_modules), which is
- * what makes it usable as a rule fixture.
+ *
+ * LINTABILITY, CORRECTED AFTER REVIEW MEASURED IT. This file was originally named `.fixture.mjs`,
+ * and that made it EFFECTIVELY UNLINTABLE: eslint.config.js's main block matches only .js, .jsx,
+ * .ts and .tsx, so `--print-config` returned ONE rule (disabled) for the .mjs name against EIGHT
+ * for a sibling .js. A rule registered the ordinary way would not have
+ * fired on the very specimen kept to prove it can fire -- the "control that cannot fire" defect
+ * this fixture exists to prevent, reproduced inside the fixture. Renamed to `.js`, now 8 rules.
+ * NOTE the remaining limit: `npm run lint` is `eslint scripts/ lib/ tools/`, so `tests/` is outside
+ * its directory scope. A future rule must target this path explicitly (as
+ * scripts/lint/session-coordination-insert-classguard-lint.mjs does for its own subject).
  */
 
 // --- BEGIN PRESERVED SPECIMEN ---------------------------------------------------------------
 // Receiver origin: a FACTORY client. This is the half a call-form-only sweep cannot see.
-// eslint-disable-next-line no-unused-vars
 export async function deadFactoryMessagesStreamSpecimen(messages, model, systemPrompt) {
   const { createLLMClient } = await import('../../../lib/llm/client-factory.js');
   const client = await createLLMClient('sonnet');

--- a/tests/fixtures/llm-call-shapes/dead-factory-messages-stream.fixture.mjs
+++ b/tests/fixtures/llm-call-shapes/dead-factory-messages-stream.fixture.mjs
@@ -1,0 +1,60 @@
+/**
+ * *** PRESERVED SPECIMEN — NOT LIVE CODE, NOT A DEFECT, DO NOT FILE IT. ***
+ *
+ * This is a verbatim copy of a call shape that was DELETED from
+ * lib/integrations/eva-chat-service.js by SD-LEO-INFRA-LLM-ADAPTER-STREAMING-ABSENT-001.
+ * Find the deletion with:  git log -S dead-factory-messages-stream --oneline
+ * and diff the removed original with:  git show <that sha> -- lib/integrations/eva-chat-service.js
+ *
+ * WHY IT IS KEPT. SD-LEO-INFRA-LLM-STORY-CANARY-AND-LINT-001 plans a lint rule for exactly this
+ * defect class, and its own evidence recorded the deleted site as the ONLY live specimen in the
+ * repo. Deleting the last positive subject would hand that rule no way to prove it can fire — the
+ * "a control that cannot fire" defect that SD exists to prevent. So the specimen outlives the
+ * defect.
+ *
+ * WHY BOTH LINES MATTER. The defect is NOT the call form alone. A sweep keyed on `.messages.stream(`
+ * cannot tell a factory adapter from a raw SDK client, and ONLY THE FACTORY ADAPTERS ARE DEAD — a
+ * raw `new Anthropic()` client has a real `.messages.stream`. So the diagnostic pair is
+ * (call form x RECEIVER ORIGIN), and this fixture preserves the receiver-construction line as well
+ * as the call. A fixture carrying only the call would encode the very blindness the rule exists to
+ * remove.
+ *
+ * WHAT MADE IT DEAD, both independently fatal:
+ *   1. `createLLMClient` has NEVER been exported by lib/llm/client-factory.js (git log -S on that
+ *      file is empty). The destructure yields undefined and the call throws on a missing symbol.
+ *   2. Even with a real client, the FR-4 compat layer installs `.messages.create` and deliberately
+ *      NOT `.messages.stream`, because a `.stream()` that resolved `.complete()` and emitted one
+ *      blob would make the word "stream" false.
+ *
+ * INERT BY THREE INDEPENDENT MECHANISMS, each verified rather than assumed:
+ *   - `tests/` is outside dead-code-scanner.mjs IMPORT_GRAPH_DIRS, so it is never graph-scanned.
+ *   - the vitest unit project collects only `*.test.js`, so a `.fixture.mjs` name cannot be run.
+ *   - nothing imports this file; the export exists solely to give a parser something to bind.
+ * It remains lintable (eslint.config.js ignores only bundles/dist/build/node_modules), which is
+ * what makes it usable as a rule fixture.
+ */
+
+// --- BEGIN PRESERVED SPECIMEN ---------------------------------------------------------------
+// Receiver origin: a FACTORY client. This is the half a call-form-only sweep cannot see.
+// eslint-disable-next-line no-unused-vars
+export async function deadFactoryMessagesStreamSpecimen(messages, model, systemPrompt) {
+  const { createLLMClient } = await import('../../../lib/llm/client-factory.js');
+  const client = await createLLMClient('sonnet');
+
+  // Call form: `.messages.stream(` on that factory client. Neither compat layer defines it.
+  const stream = client.messages.stream({
+    model,
+    max_tokens: 1024,
+    system: systemPrompt,
+    messages,
+  });
+
+  let fullContent = '';
+  stream.on('text', (text) => {
+    fullContent += text;
+  });
+
+  const finalMessage = await stream.finalMessage();
+  return { fullContent, finalMessage };
+}
+// --- END PRESERVED SPECIMEN -----------------------------------------------------------------

--- a/tests/unit/llm/streaming-retirement.test.js
+++ b/tests/unit/llm/streaming-retirement.test.js
@@ -27,7 +27,7 @@ import { EventEmitter } from 'node:events';
 
 const REPO = join(import.meta.dirname, '..', '..', '..');
 const EVA = join(REPO, 'lib', 'integrations', 'eva-chat-service.js');
-const FIXTURE = join(REPO, 'tests', 'fixtures', 'llm-call-shapes', 'dead-factory-messages-stream.fixture.mjs');
+const FIXTURE = join(REPO, 'tests', 'fixtures', 'llm-call-shapes', 'dead-factory-messages-stream.fixture.js');
 const DOC = join(REPO, 'docs', 'architecture', 'llm-stream-watchdog.md');
 
 const parseModule = (src) => parse(src, { ecmaVersion: 'latest', sourceType: 'module' });
@@ -43,6 +43,11 @@ function exportedNames(src) {
       }
       for (const s of node.specifiers || []) names.add(s.exported.name);
     }
+    // M19/M20 killed here. The first walker handled only ExportNamedDeclaration, so adding
+    // `export default` or `export * from` to the module was invisible to an export-set EQUALITY --
+    // the guard would have reported the set unchanged while the module's surface had grown.
+    if (node.type === 'ExportDefaultDeclaration') names.add('default');
+    if (node.type === 'ExportAllDeclaration') names.add(node.exported ? node.exported.name : '*');
   }
   return names;
 }
@@ -168,6 +173,51 @@ describe('the preserved specimen', () => {
     expect(hasFactoryImport, 'receiver origin (dynamic import of client-factory) is missing from the CODE').toBe(true);
     expect(hasStreamCall, 'call form (.messages.stream) is missing from the CODE').toBe(true);
     expect(hasTextHandler, "the .on('text') incremental-delivery intent is missing from the CODE").toBe(true);
+
+    /**
+     * *** AND THEY MUST BE COUPLED. *** A mutation that kept the factory import but switched the
+     * .messages.stream receiver to a raw `new Anthropic()` client survived the previous version:
+     * both halves were present, and the specimen still demonstrated nothing, because a raw SDK
+     * client HAS a real .messages.stream. Presence of two halves is not the same as one linked
+     * pair, and the pair is the entire diagnostic.
+     */
+    /**
+     * *** AND THIS COUPLING CHECK ITSELF MATCHED THE DOCBLOCK ON ITS FIRST RUN. ***
+     * The raw-SDK half was written as `expect(src).not.toMatch(/new Anthropic\(/)` and failed
+     * immediately — against the fixture's own comment explaining that "a raw `new Anthropic()`
+     * client has a real .messages.stream". That is the FIFTH time in this SD a check read the prose
+     * instead of the code, and it happened inside the fix for the fourth. The lesson is not "be
+     * careful": it is that a substring check over a file containing prose about code is the wrong
+     * instrument, every time, and the AST is the right one.
+     */
+    let rawSdkConstruction = false;
+    let streamReceiver = null;
+    let factoryBinding = null;
+    const walk2 = (n) => {
+      if (!n || typeof n !== 'object') return;
+      if (n.type === 'NewExpression' && n.callee?.name === 'Anthropic') rawSdkConstruction = true;
+      // `const <name> = await createLLMClient(...)`
+      if (n.type === 'VariableDeclarator' && n.init?.type === 'AwaitExpression'
+          && n.init.argument?.type === 'CallExpression'
+          && n.init.argument.callee?.name === 'createLLMClient') factoryBinding = n.id?.name ?? null;
+      if (n.type === 'CallExpression' && n.callee?.type === 'MemberExpression'
+          && n.callee.property?.name === 'stream'
+          && n.callee.object?.type === 'MemberExpression'
+          && n.callee.object.property?.name === 'messages') {
+        streamReceiver = n.callee.object.object?.name ?? null;
+      }
+      for (const k of Object.keys(n)) {
+        const v = n[k];
+        if (Array.isArray(v)) v.forEach(walk2); else if (v && typeof v === 'object' && v.type) walk2(v);
+      }
+    };
+    walk2(ast);
+
+    expect(factoryBinding, 'no binding is assigned from the factory call').not.toBeNull();
+    expect(streamReceiver, 'the .messages.stream receiver is not the factory-derived binding')
+      .toBe(factoryBinding);
+    expect(rawSdkConstruction, 'a raw SDK client was constructed — the specimen no longer shows a FACTORY receiver')
+      .toBe(false);
   });
 
   it('is labelled so a future sweeper stops rather than files it', () => {
@@ -204,11 +254,23 @@ describe('every pointer in the watchdog doc resolves', () => {
     expect(citations.length).toBeGreaterThanOrEqual(3);
   });
 
-  it.each(citations)('$path:$line exists and the file is long enough', ({ path, line }) => {
+  it.each(citations)('$path:$line resolves AND the cited line is the streaming call', ({ path, line }) => {
+    /**
+     * M09c killed here. The first version checked existence and line count only, so repointing a
+     * citation from :110 to :1 stayed GREEN -- a citation can be badly wrong while still being
+     * in-range. That is precisely the staleness class this SD found three times in this document
+     * (two rows citing lines 862 and 1055 of a 184-line file), so a check that cannot detect
+     * in-range drift is not a check on the thing that went wrong.
+     */
     const full = join(REPO, path);
     expect(existsSync(full), `${path} does not exist`).toBe(true);
-    const count = readFileSync(full, 'utf8').split('\n').length;
-    expect(count, `${path} has ${count} lines, citation points at ${line}`).toBeGreaterThanOrEqual(line);
+    const lines = readFileSync(full, 'utf8').split('\n');
+    expect(lines.length, `${path} has ${lines.length} lines, citation points at ${line}`).toBeGreaterThanOrEqual(line);
+
+    // Every citation in this table names a live {stream: true} caller. Anchor on that, with a small
+    // window for ordinary edits above the call rather than a brittle exact-line match.
+    const window = lines.slice(Math.max(0, line - 4), line + 3).join('\n');
+    expect(window, `${path}:${line} does not point at a streaming call`).toMatch(/stream:\s*true/);
   });
 
   it('no table row still points at the deleted function', () => {
@@ -228,6 +290,14 @@ describe('THE HELD NEGATIVE — the streaming path this SD promises not to break
    * A held negative that cannot fail is worse than none, because it reads as protection. This is
    * the positive control that closes it — it drives the real _completeWithStreaming against the
    * same EventEmitter double shape the watchdog suite already uses.
+   *
+   * *** WHAT IT DOES NOT COVER, because the first draft of this docblock overstated it. *** Review
+   * mutated four things that this control leaves GREEN: removing the watchdog from the race,
+   * removing the wall-clock race, removing stream.abort() on timeout, and breaking complete()'s
+   * routing into _completeWithStreaming. So "closes a hole where no test could go red" is true for
+   * the TRANSPORT CALL and false for the three timeout behaviours the retirement block advertises
+   * as the surviving streaming story. Those remain untested; saying so is better than leaving a
+   * claim of coverage that does not exist.
    */
   const makeMockStream = () => {
     const ee = new EventEmitter();

--- a/tests/unit/llm/streaming-retirement.test.js
+++ b/tests/unit/llm/streaming-retirement.test.js
@@ -1,0 +1,280 @@
+/**
+ * Guards for SD-LEO-INFRA-LLM-ADAPTER-STREAMING-ABSENT-001 — a DELETION plus its safety case.
+ *
+ * *** A DELETION HAS AN INVERTED RISK PROFILE AND THE FIRST DRAFT OF THESE TESTS MISSED IT. ***
+ * Most assertions about a deletion are assertions about ABSENCE, and an absence assertion passes
+ * when the implementer deleted the wrong thing, deleted too much, or deleted nothing. PLAN review
+ * measured the gap: deleting the wrong function or nothing at all turns the absence check red, but
+ * deleting the MODULE or a sibling export would have left every scenario green, because the only
+ * test importing this module is vacuous (it imports inside `.catch(() => null)` and puts every
+ * assertion inside an `if`).
+ *
+ * So the guards here are deliberately positive wherever they can be: an export-set equality rather
+ * than a name absence, an existence-and-parse rather than an inertness check, and a streaming test
+ * that can actually go red.
+ *
+ * NOTHING HERE IMPORTS eva-chat-service.js. It builds a service-role Supabase client at import time
+ * (:29). The module is read as TEXT and parsed, which is also strictly stronger than grep: a parse
+ * distinguishes a real export from a mention in a comment — the exact ambiguity that put a
+ * non-exported symbol into an acceptance criterion during PLAN.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { parse } from 'acorn';
+import { EventEmitter } from 'node:events';
+
+const REPO = join(import.meta.dirname, '..', '..', '..');
+const EVA = join(REPO, 'lib', 'integrations', 'eva-chat-service.js');
+const FIXTURE = join(REPO, 'tests', 'fixtures', 'llm-call-shapes', 'dead-factory-messages-stream.fixture.mjs');
+const DOC = join(REPO, 'docs', 'architecture', 'llm-stream-watchdog.md');
+
+const parseModule = (src) => parse(src, { ecmaVersion: 'latest', sourceType: 'module' });
+
+/** Exported names, from the AST. Not a grep — a comment naming an export does not count. */
+function exportedNames(src) {
+  const names = new Set();
+  for (const node of parseModule(src).body) {
+    if (node.type === 'ExportNamedDeclaration') {
+      if (node.declaration) {
+        if (node.declaration.id) names.add(node.declaration.id.name);
+        for (const d of node.declaration.declarations || []) names.add(d.id.name);
+      }
+      for (const s of node.specifiers || []) names.add(s.exported.name);
+    }
+  }
+  return names;
+}
+
+describe('the deletion removed exactly one thing', () => {
+  it('streamMessage is gone from the module', () => {
+    expect(exportedNames(readFileSync(EVA, 'utf8')).has('streamMessage')).toBe(false);
+  });
+
+  /**
+   * THE OVER-DELETION GUARD — the scenario the first draft lacked entirely.
+   * An equality, not a subset: deleting a sibling export must fail here. Measured before the
+   * deletion, the module exported six names plus streamMessage.
+   */
+  it('every other export survived — asserted as an EQUALITY, so deleting a sibling fails', () => {
+    expect([...exportedNames(readFileSync(EVA, 'utf8'))].sort()).toEqual([
+      'EVA_BASE_PROMPT', 'buildSystemPrompt', 'createConversation',
+      'getMessages', 'listConversations', 'sendMessage',
+    ]);
+  });
+
+  it('the module still parses — a deletion that broke syntax would pass a grep', () => {
+    expect(() => parseModule(readFileSync(EVA, 'utf8'))).not.toThrow();
+  });
+
+  it('no source file CALLS or DEFINES streamMessage', () => {
+    /**
+     * Matches the CALL AND DEFINITION FORMS, never the bare name. Two earlier spellings of this
+     * check failed for the same reason twice: a name-only grep matches the retirement comment that
+     * documents the deletion, and the module header that describes the old defect. A check that
+     * cannot tell code from the prose narrating code reports on the wrong text — which is precisely
+     * the class this SD keeps finding.
+     *
+     * Also SCOPED to source: two repo-wide hits are GENERATED audit artifacts carrying bare
+     * exemption notes, so an unscoped assertion is unsatisfiable even after a correct deletion.
+     */
+    const out = execSync(
+      'git grep -nE "(function|const|await)[[:space:]]+streamMessage|streamMessage[[:space:]]*\\(|\\{[[:space:]]*streamMessage[[:space:]]*\\}" -- lib scripts server src || true',
+      { cwd: REPO, encoding: 'utf8' },
+    ).trim();
+    expect(out).toBe('');
+  });
+});
+
+describe('the retirement provenance is real, not pasted', () => {
+  /**
+   * REFERENTIAL INTEGRITY, NOT A LITERAL GREP. A test that greps for four tokens the implementer
+   * was told to write is paste-satisfiable, and is worse than no test because it launders a review
+   * criterion into a green check. These assertions fail for a wrong-but-plausible commit id.
+   */
+  const SHA = 'f85cd2a7c92';
+
+  it('the cited deletion commit exists and is an ancestor of HEAD', () => {
+    // `git cat-file -e <sha>^{commit}` needs the braces quoted under sh; `-t` avoids the issue and
+    // asserts the OBJECT TYPE, which is strictly more than existence — a tag or blob would fail.
+    const type = execSync(`git cat-file -t ${SHA}`, { cwd: REPO, encoding: 'utf8' }).trim();
+    expect(type).toBe('commit');
+    expect(() => execSync(`git merge-base --is-ancestor ${SHA} HEAD`, { cwd: REPO, stdio: 'pipe' })).not.toThrow();
+  });
+
+  it('its committer date is the date the record claims', () => {
+    const date = execSync(`git show -s --format=%cs ${SHA}`, { cwd: REPO, encoding: 'utf8' }).trim();
+    expect(date).toBe('2026-06-02');
+  });
+
+  it('it really did delete the route that was the only caller', () => {
+    const files = execSync(`git show --name-status --format= ${SHA}`, { cwd: REPO, encoding: 'utf8' });
+    expect(files).toMatch(/^D\s+server\/routes\/eva-chat\.js$/m);
+  });
+
+  it('the deletion site carries the provenance a future sweeper needs', () => {
+    // Deliberately weak and labelled as such: this checks the record is PRESENT. Whether it is
+    // comprehensible enough to stop a fourth rediscovery is review-only and no test claims it.
+    const src = readFileSync(EVA, 'utf8');
+    expect(src).toContain(SHA);
+    expect(src).toContain('cff73055');
+    expect(src).toContain('QF-20260602-028');
+  });
+});
+
+describe('the preserved specimen', () => {
+  it('EXISTS and PARSES — asserted together, because "is inert" alone passes when it is missing', () => {
+    expect(existsSync(FIXTURE)).toBe(true);
+    expect(() => parseModule(readFileSync(FIXTURE, 'utf8'))).not.toThrow();
+  });
+
+  it('preserves BOTH halves of the diagnostic pair, asserted on the AST not the text', () => {
+    /**
+     * *** THIS ASSERTION WAS SUBSTRING-BASED AND A FALSIFIER PROVED IT VACUOUS. ***
+     * Deleting the receiver-construction LINE from the specimen left the suite GREEN, because
+     * `createLLMClient` still appeared in the fixture's own docblock explaining what made the call
+     * dead. That is the FOURTH time in this SD that a check matched the prose narrating code rather
+     * than the code — the same shape as the doc-citation check, the streamMessage grep, and the
+     * fixture-import check. Comments are invisible to a parser, so the AST is the only surface
+     * where "the code contains X" means what it says.
+     *
+     * Both halves must survive: a raw `new Anthropic()` client has a real `.messages.stream`, so
+     * the call form ALONE is not the defect. The diagnostic pair is (call form x receiver origin),
+     * and a specimen carrying only the call would encode the blindness the sibling rule exists to
+     * remove.
+     */
+    const ast = parseModule(readFileSync(FIXTURE, 'utf8'));
+
+    let hasFactoryImport = false;   // receiver origin
+    let hasStreamCall = false;      // call form
+    let hasTextHandler = false;     // the incremental-delivery intent
+    const walk = (n) => {
+      if (!n || typeof n !== 'object') return;
+      if (n.type === 'ImportExpression' && n.source?.value?.includes('client-factory')) hasFactoryImport = true;
+      if (n.type === 'CallExpression') {
+        const c = n.callee;
+        if (c?.type === 'MemberExpression' && c.property?.name === 'stream'
+            && c.object?.type === 'MemberExpression' && c.object.property?.name === 'messages') hasStreamCall = true;
+        if (c?.type === 'MemberExpression' && c.property?.name === 'on' && n.arguments?.[0]?.value === 'text') hasTextHandler = true;
+      }
+      for (const k of Object.keys(n)) {
+        const v = n[k];
+        if (Array.isArray(v)) v.forEach(walk); else if (v && typeof v === 'object' && v.type) walk(v);
+      }
+    };
+    walk(ast);
+
+    expect(hasFactoryImport, 'receiver origin (dynamic import of client-factory) is missing from the CODE').toBe(true);
+    expect(hasStreamCall, 'call form (.messages.stream) is missing from the CODE').toBe(true);
+    expect(hasTextHandler, "the .on('text') incremental-delivery intent is missing from the CODE").toBe(true);
+  });
+
+  it('is labelled so a future sweeper stops rather than files it', () => {
+    const src = readFileSync(FIXTURE, 'utf8');
+    expect(src).toMatch(/PRESERVED SPECIMEN/);
+    expect(src).toMatch(/DO NOT FILE IT/);
+    expect(src).toMatch(/SD-LEO-INFRA-LLM-ADAPTER-STREAMING-ABSENT-001/);
+  });
+
+  it('is inert: not collected by the unit project and not imported by production', () => {
+    expect(FIXTURE.endsWith('.test.js')).toBe(false);
+    // IMPORT forms only. The retirement comment in eva-chat-service.js deliberately NAMES the
+    // fixture path so a reader can find the specimen — a name-only grep flagged that as an import,
+    // which would have punished the pointer this SD exists to leave behind.
+    const importers = execSync(
+      'git grep -nE "(import|require|from)[^\\n]*dead-factory-messages-stream" -- lib scripts server src || true',
+      { cwd: REPO, encoding: 'utf8' },
+    ).trim();
+    expect(importers).toBe('');
+  });
+});
+
+describe('every pointer in the watchdog doc resolves', () => {
+  /**
+   * Scoped to TABLE ROWS. A citation in a table is a pointer the reader is meant to follow; a
+   * citation inside prose describing a PAST error is a historical reference, and a check that
+   * cannot tell them apart would flag the very sentences that document the correction — the same
+   * trap as a source pin matching the comment that narrates the code.
+   */
+  const rows = readFileSync(DOC, 'utf8').split('\n').filter((l) => l.trim().startsWith('|'));
+  const citations = rows.flatMap((l) => [...l.matchAll(/`([\w./-]+\.(?:js|mjs|cjs)):(\d+)`/g)].map((m) => ({ path: m[1], line: Number(m[2]) })));
+
+  it('found citations to check — a zero-row sweep would pass vacuously', () => {
+    expect(citations.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it.each(citations)('$path:$line exists and the file is long enough', ({ path, line }) => {
+    const full = join(REPO, path);
+    expect(existsSync(full), `${path} does not exist`).toBe(true);
+    const count = readFileSync(full, 'utf8').split('\n').length;
+    expect(count, `${path} has ${count} lines, citation points at ${line}`).toBeGreaterThanOrEqual(line);
+  });
+
+  it('no table row still points at the deleted function', () => {
+    expect(rows.join('\n')).not.toMatch(/eva-chat-service\.js:\d+/);
+  });
+});
+
+describe('THE HELD NEGATIVE — the streaming path this SD promises not to break', () => {
+  /**
+   * *** THE FIRST VERSION OF THIS SAFETY CASE WAS THEATRE, MEASURED FOUR WAYS. ***
+   * It said "the diff does not touch the live callers and the suites stay green". But
+   * _completeWithStreaming has zero tests; both stage-17 suites vi.mock the client factory to
+   * `{complete: mockComplete}` with zero occurrences of "stream"; scripts/prd/llm-generator.js has
+   * no test at all; and the one test that builds a real adapter spies `messages.create` and never
+   * `.stream`. NO TEST IN THIS REPO COULD GO RED IF THE STREAMING PATH BROKE.
+   *
+   * A held negative that cannot fail is worse than none, because it reads as protection. This is
+   * the positive control that closes it — it drives the real _completeWithStreaming against the
+   * same EventEmitter double shape the watchdog suite already uses.
+   */
+  const makeMockStream = () => {
+    const ee = new EventEmitter();
+    let resolveFinal;
+    const finalPromise = new Promise((res) => { resolveFinal = res; });
+    return {
+      on: ee.on.bind(ee), off: ee.off.bind(ee), emit: ee.emit.bind(ee),
+      finalMessage: () => finalPromise,
+      abort() { this.aborted = true; },
+      aborted: false,
+      _resolveFinal: (v) => resolveFinal(v),
+    };
+  };
+
+  it('_completeWithStreaming resolves through the real streaming path', async () => {
+    const { AnthropicAdapter } = await import('../../../lib/sub-agents/vetting/provider-adapters.js');
+    const adapter = new AnthropicAdapter({ apiKey: 'test-key-not-used' });
+
+    const mock = makeMockStream();
+    let requested = null;
+    adapter.client = { messages: { stream: (params) => { requested = params; return mock; } } };
+
+    const promise = adapter._completeWithStreaming(
+      { model: 'claude-sonnet-4-5', max_tokens: 16, messages: [{ role: 'user', content: 'hi' }] },
+      { timeout: 5000, stallTimeout: 5000 },
+    );
+    mock.emit('text', 'hello ');
+    mock.emit('text', 'world');
+    mock._resolveFinal({ content: [{ type: 'text', text: 'hello world' }] });
+
+    const result = await promise;
+    // It really went through .messages.stream, not some other path.
+    expect(requested).toMatchObject({ model: 'claude-sonnet-4-5' });
+    expect(JSON.stringify(result)).toContain('hello world');
+  });
+
+  it('the three live {stream:true} callers still request streaming', () => {
+    // Cheap structural corroboration that the deletion did not disturb them. Not a substitute for
+    // the control above — this would pass if _completeWithStreaming were broken.
+    for (const [file, line] of [
+      ['lib/eva/stage-17/archetype-generator.js', 110],
+      ['lib/eva/stage-17/refinement.js', 107],
+      ['scripts/prd/llm-generator.js', 104],
+    ]) {
+      const lines = readFileSync(join(REPO, file), 'utf8').split('\n');
+      expect(lines.length, `${file} shrank past its cited caller`).toBeGreaterThanOrEqual(line);
+      expect(lines.join('\n'), `${file} no longer requests streaming`).toMatch(/stream:\s*true/);
+    }
+  });
+});

--- a/tests/unit/llm/streaming-retirement.test.js
+++ b/tests/unit/llm/streaming-retirement.test.js
@@ -100,7 +100,40 @@ describe('the retirement provenance is real, not pasted', () => {
    */
   const SHA = 'f85cd2a7c92';
 
-  it('the cited deletion commit exists and is an ancestor of HEAD', () => {
+  /**
+   * *** THESE THREE NEED GIT HISTORY, AND CI DOES NOT HAVE IT. FOUND BY CI, NOT BY REASONING. ***
+   * They went red on the first PR run with `fatal: Not a valid object name f85cd2a7c92`, because
+   * actions/checkout@v4 defaults to fetch-depth 1 and the cited commit is from 2026-06-02. The
+   * assertions were right about the repository and wrong about their environment — I asked whether
+   * they REACH the layer they judge, and never whether that layer EXISTS where they run.
+   *
+   * Not "fixed" by loosening: they are gated on history being present, so they run in full clones
+   * (local, and any workflow using fetch-depth 0) and are reported as SKIPPED in CI rather than
+   * silently passing. A skip is visible in the run output; a loosened assertion is not.
+   *
+   * WHAT GUARDS THE MERGE IN CI, since these do not: the shallow-safe consequence test below — the
+   * route file is absent at HEAD — plus the deliberately-weak token check. Stated plainly so nobody
+   * reads a green CI run as meaning the provenance was verified there.
+   *
+   * The shared unit-tier workflow is deliberately NOT changed to fetch full history: it runs on
+   * every PR in this repo and unshallowing it would cost the whole fleet time to serve one SD.
+   */
+  const isShallow = (() => {
+    try {
+      return execSync('git rev-parse --is-shallow-repository', { cwd: REPO, encoding: 'utf8' }).trim() === 'true';
+    } catch { return true; }
+  })();
+
+  it('SHALLOW-SAFE: the route that was the only caller is absent at HEAD', () => {
+    // The CONSEQUENCE of the retirement, checkable without history. This is what actually guards
+    // the merge in CI. If the route ever comes back, the deleted function's provenance block is
+    // describing a world that no longer holds and this reddens.
+    const tracked = execSync('git ls-files server/routes/eva-chat.js', { cwd: REPO, encoding: 'utf8' }).trim();
+    expect(tracked).toBe('');
+    expect(existsSync(join(REPO, 'server', 'routes', 'eva-chat.js'))).toBe(false);
+  });
+
+  it.skipIf(isShallow)('the cited deletion commit exists and is an ancestor of HEAD', () => {
     // `git cat-file -e <sha>^{commit}` needs the braces quoted under sh; `-t` avoids the issue and
     // asserts the OBJECT TYPE, which is strictly more than existence — a tag or blob would fail.
     const type = execSync(`git cat-file -t ${SHA}`, { cwd: REPO, encoding: 'utf8' }).trim();
@@ -108,12 +141,12 @@ describe('the retirement provenance is real, not pasted', () => {
     expect(() => execSync(`git merge-base --is-ancestor ${SHA} HEAD`, { cwd: REPO, stdio: 'pipe' })).not.toThrow();
   });
 
-  it('its committer date is the date the record claims', () => {
+  it.skipIf(isShallow)('its committer date is the date the record claims', () => {
     const date = execSync(`git show -s --format=%cs ${SHA}`, { cwd: REPO, encoding: 'utf8' }).trim();
     expect(date).toBe('2026-06-02');
   });
 
-  it('it really did delete the route that was the only caller', () => {
+  it.skipIf(isShallow)('it really did delete the route that was the only caller', () => {
     const files = execSync(`git show --name-status --format= ${SHA}`, { cwd: REPO, encoding: 'utf8' });
     expect(files).toMatch(/^D\s+server\/routes\/eva-chat\.js$/m);
   });

--- a/tests/unit/stage-17/refinement.test.js
+++ b/tests/unit/stage-17/refinement.test.js
@@ -14,7 +14,17 @@ vi.mock('../../../lib/llm/client-factory.js', () => ({
   getLLMClient: vi.fn().mockReturnValue({
     complete: mockComplete,
   }),
-  // Legacy export kept for backward-compat imports elsewhere
+  // *** createLLMClient IS NOT A LEGACY EXPORT. IT HAS NEVER EXISTED. ***
+  // This entry previously said "Legacy export kept for backward-compat imports elsewhere", which is
+  // false and actively misleading: `git log -S createLLMClient -- lib/llm/client-factory.js` is
+  // EMPTY, so the symbol was never exported by that module at any point in its history. The real
+  // export is getLLMClient, above.
+  // Two dead call sites destructured this phantom and threw "createLLMClient is not a function" on
+  // every invocation; one was repaired by SD-LEO-INFRA-USER-STORY-QUALITY-001 and the other deleted
+  // by SD-LEO-INFRA-LLM-ADAPTER-STREAMING-ABSENT-001. A comment asserting the phantom was a
+  // supported legacy export is exactly what would send the next implementer looking for it.
+  // The mock stays only because vi.mock replaces the whole module surface; it is not evidence the
+  // symbol exists, and nothing in this repo should import it.
   createLLMClient: vi.fn().mockResolvedValue({
     messages: { create: vi.fn() },
   }),


### PR DESCRIPTION
`streamMessage` called `.messages.stream()` on a client the compat layer never gave that method. A prior SD deliberately left it broken rather than shim it — correctly, since faking streaming over `.complete()` would make the word "stream" false. This SD was filed to build real streaming or convert the consumer off it.

**Neither was the answer.** The SD's own text asked for the check that overturned it: *"the implementer should confirm the absence of streaming before choosing a direction."* Two LEAD agents did, independently, and refuted three of four load-bearing claims.

## The consumer was already gone

`streamMessage` had **zero callers**. Its only caller ever was `POST /api/eva/chat/stream`, deleted 2026-06-02 (`f85cd2a7c92`, QF-20260602-028) under a ratified Chairman wire-or-cut decision, `cff73055`. The route removal took the caller and left the callee — and the orphaned callee re-litigated itself as new build work. Three parties examined it and each re-derived that from scratch, which is why the deletion leaves a provenance block rather than a one-line note.

Two further premises were wrong. The adapter layer **does** have streaming transport — `_completeWithStreaming` calls real `messages.stream()`, GoogleAdapter uses SSE, and three callers pass `{stream: true}` in production. What's absent is incremental **delivery**: the watchdog's `onText()` takes no argument and discards the token. And `createLLMClient` has never existed in `client-factory.js`'s history, so the site threw on a missing symbol one line before reaching the streaming call it was filed for.

## A deletion has an inverted risk profile

Most assertions about a deletion are assertions about *absence*, and those pass when you delete the wrong thing, too much, or nothing. PLAN review measured it: deleting the module or a sibling export left **9 of 9** scenarios green, because the only test importing this module is vacuous. So the export set is asserted as an **equality**, parsed from the AST rather than grepped.

**The held negative was theatre, measured four ways.** `_completeWithStreaming` had zero tests; both stage-17 suites mock the factory with zero occurrences of "stream"; the third caller has no test; the one real-adapter test spies `messages.create`. No test in this repo could go red if the streaming path broke. There is now a positive control that drives it, and a falsifier proving it fails when the path breaks.

## What review caught

41 mutations: 31 killed, 9 survived. Four closed here and each re-proven to die.

- **The specimen kept to prove a lint rule can fire was itself unlintable.** It shipped as `.fixture.mjs`; eslint matches only `.js/.jsx/.ts/.tsx` — measured, `--print-config` returned **1 disabled rule against 8** for a sibling `.js`. The artifact built to prevent "a control that cannot fire" reproduced that defect inside itself.
- **Two halves present is not a coupled pair.** Keeping the factory import while switching the `.messages.stream` receiver to a raw `new Anthropic()` client left the specimen proving nothing — and passing.
- **A citation can be badly wrong while still in range.** Repointing one from `:110` to `:1` passed an existence-plus-line-count check — the exact staleness class this SD found three times in that document.
- The export walker was blind to `export default` and `export * from`.

**And five times, a check read the prose narrating the code instead of the code** — the fifth inside the fix for the fourth. The resolution was identical every time: a substring check over a file containing prose about code is the wrong instrument. Comments are invisible to a parser.

## Honest residuals

The positive control covers the **transport call only**. Removing the watchdog, the wall-clock race, or `abort()` on timeout all leave it green — so the docblock claim that it "closes a hole where no test could go red" was overstated for the three timeout behaviours the retirement block advertises, and is corrected in place. An export-set equality is a name check and won't catch a sibling gutted to a stub. The specimen is asserted by construction; the sibling lint rule doesn't exist yet.

## Beyond the deletion

The SD's generalisable finding — enumerate a convention's other call forms — was run to exhaustion across four repos and closed with a number: **exactly three dead sites, nothing else**. Recorded as `issue_patterns` PAT-SWEEP-RECEIVER-AXIS-001, with the stronger half: the miss travels along the **receiver axis** too, and severity ranks by *reachability × silence*, not by how alarming the error looks.

That enumeration found a reachable-and-silent sibling, filed separately: `validation-automation.js` defines a **local `getEmbeddingClient()` that shadows the real working export**, so the VALIDATION sub-agent's duplicate detection has reported green without ever searching since 2026-02-10.

96 tests green across the affected suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)