### PR TITLE
SD-LEO-INFRA-OUTCOME-SHAPED-LEDGER-001: the measure is starved by its input, not its wiring

### DIFF
--- a/.artifacts/enrich-sd-ledger.mjs
+++ b/.artifacts/enrich-sd-ledger.mjs
@@ -1,0 +1,80 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const KEY = 'SD-LEO-INFRA-OUTCOME-SHAPED-LEDGER-001';
+
+const smoke_test_steps = [
+  {
+    step_number: 1,
+    instruction: 'Run: node scripts/ledger-ref-shape-report.mjs (classifies every populated outcome_ref by shape and reports how many are machine-resolvable SD keys vs narrative prose)',
+    expected_outcome: 'Prints the whole-column shape split — eligible SD keys vs prose vs other — with counts and percentages, and states the DERIVABLE CEILING for outcome_sd_key. Exits non-zero if the eligible count is reported without the ceiling, because a population number without its ceiling is the metric this SD exists to stop chasing.',
+  },
+  {
+    step_number: 2,
+    instruction: 'Run: node scripts/ledger-ref-shape-report.mjs --applicability (reports how many ledger rows could EVER carry a resolvable outcome_sd_key, separating not-yet-populated from not-applicable)',
+    expected_outcome: 'Reports three buckets, never two: RESOLVABLE (an SD key is present or derivable), NOT-YET (a ref exists but no decision has been reconciled), and NOT-APPLICABLE (the advice outcome is a narrative, not an artifact). A run that reports only populated-vs-empty fails this step — collapsing not-applicable into not-yet is what makes 3.4% look like a bug rather than a ceiling.',
+  },
+  {
+    step_number: 3,
+    instruction: 'Run: npx vitest run tests/unit/ledger-ref-shape.test.js',
+    expected_outcome: 'Green, including the seeded cases: a prose ref is classified NOT-APPLICABLE (not as a failure to populate), a lowercase SD- ref is reported as case-drift rather than silently derived, and a QF- ref is classified EXCLUDED-BY-DESIGN with the reason (quick fixes do not live in strategic_directives_v2, so the key would never resolve and the row would be re-selected by every batch forever).',
+  },
+];
+
+const strategic_objectives = [
+  'Replace an unbuildable remedy with the measured one. The SD prescribes wiring; measurement shows a correct writer already exists (coordinator-ack-adam.cjs, d4f7cbed4db, ancestor of origin/main) and the INPUT is what fails — 853 of 865 populated outcome_ref values are narrative prose, and exactly ONE matches the eligible SD-key shape.',
+  'Name the overload: outcome_ref carries two incompatible jobs — an artifact REFERENCE (machine-resolvable, what the advice became) and an outcome NARRATIVE (human prose, what happened). The deriver needs the former; 98.6% of the column is the latter. One column, two meanings.',
+  'Report a derivable CEILING alongside the population, so 3.4% is judged against what is achievable rather than against 100%. Chasing a coverage number on an inapplicable population is the failure this SD is about, one level up.',
+];
+
+const key_changes = [
+  {
+    change: 'Classify every populated outcome_ref by shape and publish the derivable ceiling for outcome_sd_key.',
+    impact: 'MEASURED whole-column (865 values): 853 (98.6%) narrative prose, 4 commit sha, 4 SD- non-uppercase, 3 QF-, and exactly 1 (0.1%) eligible. ~650 of the 853 carry an era_closure: prefix — a BULK STAMP, not organic writes. Without a published ceiling, 3.4% reads as a broken writer instead of an absent input.',
+  },
+  {
+    change: 'Separate NOT-APPLICABLE from NOT-YET in every report of ledger coverage.',
+    impact: 'A row whose outcome is a narrative can never carry a resolvable SD key. Collapsing it with rows merely awaiting reconciliation makes an inapplicable population look like a backlog, which is what invites the wrong remedy.',
+  },
+  {
+    change: 'DO NOT loosen the derivation pattern, and record why.',
+    impact: 'The narrowings at coordinator-ack-adam.cjs are deliberate: QF keys are excluded because the reconciler resolves against strategic_directives_v2 where quick fixes do not live, and uppercase-only because sd_key is stored uppercase. An unresolvable key is WORSE than none — the row is re-selected by every scheduled batch forever, burning a slot and logging a skip each time. The prior author measured 13 of 31 existing values already failing to resolve. Turning an inert path NOISY is a regression, not a fix.',
+  },
+  {
+    change: 'Carry the RETRACTION into the PRD, not only the corrected finding (coordinator 8b9720cb, explicit instruction).',
+    impact: 'I first reported outcome_sd_key had NO writer. False — my exclusion filter dropped `row.outcome_sd_key` to remove reads and deleted the write, the same token up to the operator. My positive control could not catch it because I applied the SAME exclusion to the control. A PRD showing only the tidy conclusion teaches the next reader the conclusion was obvious; the useful content is how the wrong answer looked convincing.',
+  },
+];
+
+const mechanism_verifications = [
+  {
+    verified_by: 'Bravo (e3610a71) — read the writer, retracting my own no-writer claim',
+    verified_at: 'scripts/coordinator-ack-adam.cjs:249 — `row.outcome_sd_key = resolvedOutcomeRef` (added by d4f7cbed4db, verified an ancestor of origin/main)',
+  },
+  {
+    verified_by: 'Bravo (e3610a71) — read the narrowings and their stated rationale',
+    verified_at: 'scripts/coordinator-ack-adam.cjs:264 — SD keys only, uppercase only; QF excluded because the reconciler resolves against strategic_directives_v2 and an unresolvable key is worse than none',
+  },
+  {
+    verified_by: 'Bravo (e3610a71) — read the consumer that skips rows lacking the key',
+    verified_at: 'scripts/solomon-ledger-reconcile.cjs:64 — skips with reason "no outcome_sd_key"; scripts/solomon-ledger-reconcile.cjs:70 resolves the SD by that key to derive the outcome',
+  },
+  {
+    verified_by: 'Bravo (e3610a71) — measured the whole column, not a sample; this is why the remedy changes',
+    verified_at: 'scripts/coordinator-ack-adam.cjs:251 documents the dependency; measured live: of 865 populated outcome_ref values exactly 1 matches ^SD-[A-Z0-9-]+$, 853 are narrative prose (~650 with an era_closure: prefix)',
+  },
+];
+
+const { data: sd, error: e0 } = await sb.from('strategic_directives_v2').select('metadata').eq('sd_key', KEY).single();
+if (e0) { console.log('lookup failed: ' + e0.message); process.exit(1); }
+
+const FILE_LINE = /\b[\w.-]+(?:\/[\w.-]+)*\.(?:js|cjs|mjs|ts|tsx|sql):\d+\b/;
+const bad = mechanism_verifications.filter((r) => !FILE_LINE.test(r.verified_at));
+if (bad.length) { console.log('SELF-CHECK FAILED — ' + bad.length + ' citation(s) lack file:LINE'); process.exit(1); }
+console.log('self-check: all ' + mechanism_verifications.length + ' citations match the gate regex');
+
+const metadata = { ...(sd.metadata || {}), mechanism_verifications };
+const { error } = await sb.from('strategic_directives_v2')
+  .update({ smoke_test_steps, strategic_objectives, key_changes, metadata }).eq('sd_key', KEY);
+console.log(error ? ('ERR: ' + error.message)
+  : `UPDATED smoke(${smoke_test_steps.length}) objectives(${strategic_objectives.length}) key_changes(${key_changes.length}) mechanism_verifications(${mechanism_verifications.length})`);

--- a/.artifacts/exec-ledger.mjs
+++ b/.artifacts/exec-ledger.mjs
@@ -1,0 +1,54 @@
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../lib/sub-agent-executor/results-storage.js';
+const SD_ID = 'SD-LEO-INFRA-OUTCOME-SHAPED-LEDGER-001';
+
+const testing = {
+  verdict: 'PASS', confidence: 88,
+  summary:
+    '19 tests with 6 seeded defects, plus a live whole-table run that reconciles (1399 fetched = '
+    + '1399 counted). Zero migration, writer untouched. The deliverable is a measurement, so the '
+    + 'guards make the MISLEADING form unemittable rather than merely discouraged.',
+  findings: [
+    { id: 'the-bare-population-cannot-be-emitted', severity: 'critical', note: 'THE CENTRAL GUARANTEE. summarise() THROWS when asked for a population without its ceiling. Not a warning — a caller wanting only the numerator is asking for the misleading form, and THE SD ITSELF WAS WRITTEN FROM THAT BARE FIGURE, which is how it arrived at a remedy (wiring) for a writer that already works. Seeded and asserted at tests/unit/ledger-ref-shape.test.js.' },
+    { id: 'the-two-readings-of-one-number-are-both-produced', severity: 'critical', note: 'LIVE: outcome_sd_key 48 is 3.4% OF THE TABLE and 8.4% OF THE CEILING (571). Same number, opposite conclusions — broken writer vs absent input. The report prints both on adjacent lines and a test asserts they differ, because publishing either alone is what invites the wrong remedy.' },
+    { id: 'not-applicable-is-structural-not-editorial', severity: 'critical', note: 'buckets always carries all three keys EVEN AT ZERO, and buckets sum to total so no row is silently dropped. LIVE: RESOLVABLE 48 | NOT_YET 523 | NOT_APPLICABLE 828. Folding NOT_APPLICABLE into NOT_YET turns a ceiling into a backlog and a backlog invites more wiring — seeded as its own failing case rather than left to reviewer vigilance.' },
+    { id: 'pagination-because-the-cap-lies-silently', severity: 'critical', note: 'PostgREST caps a plain select at 1000 and returns the cap with no error; the table now holds 1399. A single fetch would have classified 1000 rows and printed a confident distribution OF THE CAP. The report paginates at 500 and reconciles against an exact COUNT, exiting 1 on mismatch rather than printing a plausible subtotal. This is the measured-the-cap failure, pre-empted.' },
+    { id: 'case-drift-is-its-own-shape-and-that-is-the-subtle-call', severity: 'warning', note: 'Upcasing the 4 lowercase SD- refs would RAISE THE COVERAGE NUMBER and create keys that never resolve (sd_key is stored uppercase), which the reconciler re-selects on every batch forever. Reporting the drift lets someone fix the SOURCE; absorbing it trades a visible gap for an invisible one — the exact trade this SD exposes. A test asserts a lowercase ref is CASE_DRIFT and explicitly not eligible.' },
+    { id: 'I-CAVEATED-MY-OWN-HEADLINE-because-the-ceiling-is-optimistic', severity: 'critical', note: 'HONESTY FINDING AGAINST MY OWN DELIVERABLE. The ceiling of 571 is dominated by the 534 rows carrying NO ref yet, counted in-domain because a decision could still arrive. But of rows that ALREADY have a ref, only 5 of 865 are in-domain. If future refs resemble past refs (853/865 prose) the realistic ceiling is far below 571 and the true reading is nearer 3.4% than 8.4%. Recorded in the commit and the PRD rather than left standing: an optimistic ceiling is itself a number that is true and misleading — the class this SD removes — and a ceiling nobody interrogates is just a friendlier denominator.' },
+    { id: 'scope-held-no-migration-writer-untouched', severity: 'info', note: 'Zero DDL. No change to scripts/coordinator-ack-adam.cjs — the writer is CORRECT and the SD original framing was falsified during LEAD. No loosening of the derivation pattern. Any test appearing to fix the writer would indicate drift back toward the unbuildable remedy.' },
+  ],
+  metadata: {
+    tests_added: 19, seeded_defects: 6, commits: 3, ddl_applied: 0, writer_changed: false,
+    live_rows: 1399, populated: 48, ceiling: 571,
+    mechanism_verifications: [
+      { verified_by: 'Bravo (e3610a71) — the bare population is unemittable', verified_at: 'lib/ledger/ref-shape.js:96 summarise() throws when includeCeiling is false; seeded case in tests/unit/ledger-ref-shape.test.js:104' },
+      { verified_by: 'Bravo (e3610a71) — the cap cannot be mistaken for the population', verified_at: 'scripts/ledger-ref-shape-report.mjs:37 paginates at 500 and scripts/ledger-ref-shape-report.mjs:62 exits 1 unless fetched === COUNT; live run reconciled 1399 = 1399' },
+      { verified_by: 'Bravo (e3610a71) — three buckets are structural, not editorial', verified_at: 'lib/ledger/ref-shape.js:70 bucketFor returns NOT_APPLICABLE for prose; tests/unit/ledger-ref-shape.test.js:78 asserts it is explicitly not NOT_YET' },
+      { verified_by: 'Bravo (e3610a71) — the writer under discussion is correct and untouched', verified_at: 'scripts/coordinator-ack-adam.cjs:249 derives the key; no change made by this SD' },
+    ],
+  },
+  execution_time_ms: 1800000,
+};
+
+const security = {
+  verdict: 'PASS', confidence: 89,
+  summary:
+    'No schema, no DDL, no authz surface, no production code path altered. The security-relevant '
+    + 'property is epistemic: a governance ledger stopped reporting a figure that invited the wrong '
+    + 'remedy, and the tool refuses to produce that figure again.',
+  findings: [
+    { id: 'a-metric-that-invites-the-wrong-remedy-is-the-risk-here', severity: 'critical', note: 'This ledger is how the fleet judges whether advice produced outcomes. Reporting 3.4% against an implied 100% told a reader the writer was broken, and the SD acted on that reading by prescribing wiring for a writer that already works. A governance measure that misdirects effort is a real defect even though nothing crashes — it spends attention on a phantom and leaves the true cause (an overloaded input column) untouched.' },
+    { id: 'the-fix-cannot-manufacture-a-friendlier-number', severity: 'critical', note: 'The obvious way to make this metric look better is to loosen the match. That would create keys that never resolve, which the reconciler re-selects on every scheduled batch forever — an inert path made NOISY, measurably worse. The prior author already measured 13 of 31 existing values failing to resolve. The pattern is unchanged here and the reason is recorded where the next person will look.' },
+    { id: 'the-authors-own-optimistic-reading-is-flagged-in-the-artifact', severity: 'warning', note: 'The 8.4%-of-ceiling headline is generous: the ceiling is dominated by rows with no ref at all. Naming that inside the deliverable matters more than usual here, because the SD exists precisely because a flattering denominator went unexamined once already.' },
+    { id: 'no-surface-of-any-kind', severity: 'info', note: 'One library and one read-only reporting script. No DB writes, no DDL, no credentials, no env vars, no RLS, no change to the writer or the reconciler. The script reads two columns via the existing service-role client and prints.' },
+  ],
+  metadata: { ddl_applied: 0, writes: 0, new_env_vars: 0, production_paths_touched: 0 },
+  execution_time_ms: 540000,
+};
+
+for (const [code, name, payload] of [['TESTING', 'QA Engineering Director', testing], ['SECURITY', 'Chief Security Architect', security]]) {
+  const res = await resolveSubAgentRepo({ sdId: SD_ID, subAgentCode: code, targetApplication: 'EHG_Engineer' });
+  applySubAgentRepoVerdict(payload, res);
+  const s = await storeSubAgentResults(code, SD_ID, { name }, payload, { phase: 'EXEC' });
+  console.log('STORED ' + code + '/EXEC id=' + (s && s.id));
+}

--- a/.artifacts/lead-ledger.mjs
+++ b/.artifacts/lead-ledger.mjs
@@ -1,0 +1,54 @@
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../lib/sub-agent-executor/results-storage.js';
+const SD_ID = 'SD-LEO-INFRA-OUTCOME-SHAPED-LEDGER-001';
+
+const explore = {
+  verdict: 'WARNING', confidence: 91,
+  summary:
+    'The SD stated remedy (wiring) is wrong, and measurement shows why: the writer EXISTS and is '
+    + 'CORRECT — the INPUT does not match. outcome_ref carries two incompatible jobs. Two of my own '
+    + 'findings were retracted en route, both caught by measuring rather than reasoning harder.',
+  findings: [
+    { id: 'the-numbers-moved-since-sourcing-and-the-starvation-worsened', severity: 'warning', note: 'MEASURED whole-table via COUNT(head:true): 1,392 rows (SD said 1,216). outcome 1,392 (100%). outcome_ref 865 (62.1%; SD said 14.0%). outcome_sd_key 48 (3.4%; SD said 47/3.9%). It gained ONE row while the table grew by 176, so the starvation is proportionally WORSE. Do not re-quote the SD percentages — they are a timestamp, not a fact.' },
+    { id: 'RETRACTED-my-own-no-writer-claim-was-false', severity: 'critical', note: 'I first reported outcome_sd_key has NO writer. FALSE, and the retraction matters more than the claim. scripts/coordinator-ack-adam.cjs carries `row.outcome_sd_key = resolvedOutcomeRef`, added by d4f7cbed4db (SD-LEO-INFRA-ADVICE-OUTCOME-LEDGER-001 FR-6) — verified an ancestor of origin/main. MY EXCLUSION FILTER DELETED THE WRITER: I filtered out `row.outcome_sd_key` to drop reads like `if (!row.outcome_sd_key)`, and the write is the same token up to the operator.' },
+    { id: 'a-control-that-inherits-the-flaw-cannot-reveal-it', severity: 'critical', note: 'THE TRANSFERABLE LESSON, and it sharpens a rule I already held. I ran a positive control (same pattern against outcome_ref) and it found four writers, which I took as proof the search was sound. But I applied THE SAME EXCLUSION to the control, so it found writers only via other syntactic forms and still looked green. A positive control validates that the search RUNS; it does NOT validate the EXCLUSION LIST. To test an exclusion, the control must be a case the exclusion would wrongly remove.' },
+    { id: 'root-cause-the-writer-is-correct-the-input-is-not', severity: 'critical', note: 'The writer DERIVES outcome_sd_key from outcome_ref — deliberately, since a second hand-entered field would drift and two columns would then disagree about which artifact a decision tracked. It fires only on uppercase SD keys; QFs are excluded because the reconciler resolves against strategic_directives_v2 where QFs do not live, and an unresolvable key is WORSE than none (the row is re-selected by every scheduled batch forever). MEASURED shape of ALL 865 populated outcome_ref values: 853 (98.6%) not refs at all, 4 commit sha, 4 SD- non-uppercase, 3 QF-, and exactly ONE (0.1%) eligible. There is essentially nothing to derive FROM.' },
+    { id: 'outcome-ref-carries-two-incompatible-jobs', severity: 'critical', note: 'THE ACTUAL DEFECT. Sampled all 853: they are NARRATIVE PROSE — "era_closure:2026-07-29 — advice consumed int...", "followed (dispatch pressed) — later found mo...", "Solomon 07-20 18:51 ground read on -A (SESSI...". ~650 of 853 (76%) carry an era_closure: prefix, i.e. a BULK STAMP rather than organic writes. So outcome_ref is simultaneously an artifact REFERENCE (machine-resolvable, what the advice BECAME) and an outcome NARRATIVE (human prose, what happened). The deriver needs the former; 98.6% of the column is the latter. No wiring fixes an overloaded field — one column, two meanings.' },
+    { id: 'RETRACTED-the-14-to-62-jump-was-not-self-remediation', severity: 'critical', note: 'SECOND RETRACTION, and it lands on the SD own thesis. I read outcome_ref rising 14%->62% as the field self-remedying and proposed copying that writer as the model. WRONG: the jump was a bulk stamp of PROSE into a REFERENCE field. The metric rose, the capability did not, and outcome_sd_key moved by exactly one row. A POPULATED COLUMN IS NOT A POPULATED MEASURE — which is precisely this SD thesis (cheap field 100%, expensive field 3.4%), and I nearly reproduced it while investigating it.' },
+    { id: 'the-tempting-cheap-win-gains-four-rows', severity: 'warning', note: 'Case-fixing the 4 non-uppercase SD- refs looks like an obvious quick fix and would gain FOUR ROWS out of 1,392. Recording it explicitly so it is not mistaken for progress. Note also the prior author measured that 13 of 31 existing outcome_sd_key values ALREADY FAIL TO RESOLVE — so even the populated minority is partly dead.' },
+    { id: 'prior-author-hit-the-same-control-blindness-on-this-field', severity: 'info', note: 'The FR-6 comment records its own author noticing their negative control missed the case FR-6 adds ("it covered the commit-sha case and not the case FR-6 actually adds"). That is the same control-blindness class I hit on this SD — two different authors, same failure mode, same field. Suggests the field itself invites it.' },
+  ],
+  metadata: {
+    phase_intent: 'LEAD groundwork — measure before encoding',
+    premises_corrected: 3, own_retractions: 2, reads_only: true,
+    mechanism_verifications: [
+      { verified_by: 'Bravo (e3610a71) — the writer exists on main, retracting my no-writer claim', verified_at: 'scripts/coordinator-ack-adam.cjs:249 `row.outcome_sd_key = resolvedOutcomeRef`; added by d4f7cbed4db, verified ancestor of origin/main' },
+      { verified_by: 'Bravo (e3610a71) — the narrowings are deliberate and each prevents a NOISY failure', verified_at: 'scripts/coordinator-ack-adam.cjs:264 (SD keys only, uppercase only; QF excluded because the reconciler resolves against strategic_directives_v2)' },
+      { verified_by: 'Bravo (e3610a71) — the consumer skips rows lacking the key', verified_at: 'scripts/solomon-ledger-reconcile.cjs:64 skips on "no outcome_sd_key"; :70 resolves the SD by that key' },
+      { verified_by: 'Bravo (e3610a71) — the input shape makes derivation impossible for 98.6% of rows', verified_at: 'whole-column sample of 865 populated outcome_ref values: 1 matches ^SD-[A-Z0-9-]+$; 853 are narrative prose, ~650 with an era_closure: prefix' },
+    ],
+  },
+  execution_time_ms: 1200000,
+};
+
+const validation = {
+  verdict: 'CONDITIONAL_PASS', confidence: 88,
+  summary:
+    'The SD problem is real and its measure is genuinely starved, but its prescribed remedy does not '
+    + 'address the cause. Three conditions, all aimed at not chasing a number.',
+  findings: [
+    { id: 'condition-do-not-implement-the-stated-remedy-as-written', severity: 'critical', note: 'CONDITION 1. "The remedy is wiring" cannot be built as specified: the wiring exists and is correct. Implementing more writers, or loosening the match pattern, would produce UNRESOLVABLE keys — which the prior author measured as strictly worse than none, since such rows are re-selected by every scheduled batch forever. An inert path made NOISY is a regression, not a fix.' },
+    { id: 'condition-decide-applicability-before-chasing-population', severity: 'critical', note: 'CONDITION 2. The prior question is whether the forward path is even APPLICABLE to advice whose outcome is a narrative rather than an artifact. If most advice genuinely does not become an SD, then 3.4% may be close to the true ceiling, and the honest deliverable is to SAY the reconciler is inapplicable to those rows rather than leave it looking broken. Chasing 100% on an inapplicable population is chasing a number.' },
+    { id: 'condition-if-refs-should-be-resolvable-the-defect-is-upstream', severity: 'warning', note: 'CONDITION 3. If outcome_ref is SUPPOSED to be machine-resolvable, then writing prose into it is the defect and the fix belongs at that writer — not at the deriver, which is behaving correctly. Either way the deliverable starts by naming the overload; a fix that does not decide which job the column has will re-create the ambiguity under a new name.' },
+    { id: 'the-sd-diagnosis-half-is-sound-and-worth-preserving', severity: 'info', note: 'The SD framing — the CHEAP field is written 100% and the EXPENSIVE one 3.4%, because outcome costs nothing at insert while outcome_sd_key requires knowing what the advice BECAME — is exactly right and generalises. It reportedly recurred six times on 2026-07-29. Keep the diagnosis; replace the prescription.' },
+  ],
+  metadata: { conditions: 3, reads_only: true, remedy_as_written_viable: false },
+  execution_time_ms: 600000,
+};
+
+for (const [code, name, payload] of [['Explore', 'Codebase Explorer', explore], ['VALIDATION', 'Principal Systems Analyst', validation]]) {
+  const res = await resolveSubAgentRepo({ sdId: SD_ID, subAgentCode: code, targetApplication: 'EHG_Engineer' });
+  applySubAgentRepoVerdict(payload, res);
+  const s = await storeSubAgentResults(code, SD_ID, { name }, payload, { phase: 'LEAD' });
+  console.log('STORED ' + code + '/LEAD id=' + (s && s.id));
+}

--- a/.artifacts/plan-testing-ledger.mjs
+++ b/.artifacts/plan-testing-ledger.mjs
@@ -1,0 +1,34 @@
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../lib/sub-agent-executor/results-storage.js';
+const SD_ID = 'SD-LEO-INFRA-OUTCOME-SHAPED-LEDGER-001';
+
+const testing = {
+  verdict: 'CONDITIONAL_PASS', confidence: 87,
+  summary:
+    'Six scenarios for an SD whose deliverable is a MEASUREMENT, where the failure mode is a number '
+    + 'that is true and misleading. The two load-bearing tests make the misleading forms impossible '
+    + 'to emit rather than merely discouraged. Three conditions into EXEC.',
+  findings: [
+    { id: 'ts1-a-population-without-its-ceiling-must-be-unemittable', severity: 'critical', note: 'THE ANCHOR SCENARIO. 3.4% judged against 100% reads as a broken writer; judged against a derivable ceiling of ~0.1% it reads as an absent input. Both are the same number and only one is true to the mechanism. TS-1 makes the bare figure exit non-zero, so the misleading form cannot be produced even by a careless caller. Enforcing this in code rather than in review is the whole point: the SD itself was written from a population figure quoted without a ceiling, and that is what made its remedy look correct.' },
+    { id: 'ts5-the-two-bucket-schema-must-fail-by-construction', severity: 'critical', note: 'A row whose outcome is a NARRATIVE can never carry a resolvable SD key — it is outside the mechanism domain, not awaiting work. Collapsing NOT-APPLICABLE into NOT-YET turns a ceiling into a backlog, and a backlog invites more wiring, which is exactly the remedy this SD had to refuse. TS-5 requires the third bucket to exist in the schema EVEN WHEN ZERO, so the distinction survives a quiet period rather than disappearing when it happens to be empty.' },
+    { id: 'the-cheap-win-must-be-tested-as-a-hazard-not-an-improvement', severity: 'critical', note: 'TS-3. Case-fixing the 4 non-uppercase SD- refs is the intuitive fix and gains FOUR ROWS of 1,392 — while risking keys that never resolve, which the reconciler re-selects every batch forever. The test therefore requires a lowercase ref to be reported as CASE-DRIFT and NOT silently derived. A run that derives from it FAILS even though it would raise the coverage number, because raising the number is not the goal.' },
+    { id: 'whole-column-never-sampled-is-a-tested-property', severity: 'warning', note: 'TR-2 and TS-6. Classifier totals must reconcile against COUNT(head:true) on the live table, and a mismatch exits non-zero rather than printing a plausible subtotal. This codebase already has precedent: an earlier "4 distinct QF keys" figure came from a truncated sample read as a population and had to be corrected to 6 across 8 rows. Sampling is how a ceiling gets mistaken for a backlog.' },
+    { id: 'the-writer-is-explicitly-out-of-scope-and-that-is-testable', severity: 'warning', note: 'No test may exercise or modify coordinator-ack-adam.cjs behaviour. The writer is CORRECT — the SD original framing (nothing reliably writes the field) was falsified during LEAD. Any test that appears to fix the writer indicates scope drift back toward the unbuildable remedy.' },
+    { id: 'fr5-is-written-not-built-and-has-its-own-acceptance', severity: 'info', note: 'The retraction requirement produces no code. It is verified by inspection of the PRD and retrospective — confirmed already present in the stored PRD row rather than assumed from the write. Recorded so a later reader does not treat FR-5 as unimplemented.' },
+    { id: 'coverage-boundary-the-applicability-decision-is-not-ours', severity: 'info', note: 'This SD supplies the measurement that makes the decision possible — whether advice outcomes SHOULD be artifacts at all — and deliberately does not pre-empt it. If most advice genuinely does not become an SD, 3.4% may be near the true ceiling and the honest deliverable is to say the reconciler is inapplicable to those rows. Named as a boundary rather than silently assumed either way.' },
+  ],
+  metadata: {
+    scenarios: 6, conditions: 3, no_migration: true, writer_unchanged: true,
+    mechanism_verifications: [
+      { verified_by: 'Bravo (e3610a71) — the writer under test is correct and out of scope', verified_at: 'scripts/coordinator-ack-adam.cjs:249 derives outcome_sd_key from outcome_ref; narrowings and their rationale at scripts/coordinator-ack-adam.cjs:264' },
+      { verified_by: 'Bravo (e3610a71) — the consumer whose inertness the measurement explains', verified_at: 'scripts/solomon-ledger-reconcile.cjs:64 skips rows without the key; scripts/solomon-ledger-reconcile.cjs:70 resolves the SD by it' },
+      { verified_by: 'Bravo (e3610a71) — the ceiling is real, measured whole-column not sampled', verified_at: 'live read of all 865 populated outcome_ref values: exactly 1 matches ^SD-[A-Z0-9-]+$; 853 are narrative prose, ~650 era_closure: prefixed' },
+    ],
+  },
+  execution_time_ms: 660000,
+};
+
+const res = await resolveSubAgentRepo({ sdId: SD_ID, subAgentCode: 'TESTING', targetApplication: 'EHG_Engineer' });
+applySubAgentRepoVerdict(testing, res);
+const s = await storeSubAgentResults('TESTING', SD_ID, { name: 'QA Engineering Director' }, testing, { phase: 'PLAN' });
+console.log('STORED TESTING/PLAN id=' + (s && s.id));

--- a/.artifacts/retro-ledger.mjs
+++ b/.artifacts/retro-ledger.mjs
@@ -1,0 +1,97 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { resolveSubAgentRepo, applySubAgentRepoVerdict } from '../lib/sub-agents/resolve-repo.js';
+import { storeSubAgentResults } from '../lib/sub-agent-executor/results-storage.js';
+
+const SD_KEY = 'SD-LEO-INFRA-OUTCOME-SHAPED-LEDGER-001';
+const SD_UUID = '972ab61c-d029-4e34-b3d1-b3657e2c881c';
+const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const { data: retro, error } = await sb.from('retrospectives').insert({
+  sd_id: SD_UUID,
+  retro_type: 'SD_COMPLETION',
+  learning_category: 'APPLICATION_ISSUE',
+  generated_by: 'MANUAL',
+  target_application: 'EHG_Engineer',
+  affected_components: [
+    'lib/ledger/ref-shape.js',
+    'scripts/ledger-ref-shape-report.mjs',
+    'tests/unit/ledger-ref-shape.test.js',
+    'scripts/coordinator-ack-adam.cjs',
+    'scripts/solomon-ledger-reconcile.cjs',
+  ],
+  title: 'The SD prescribed wiring for a writer that works — and I made the same class of error twice while proving it',
+  description:
+    'outcome_sd_key sits at 3.4% and the SD read that as a wiring defect. A correct writer already exists; '
+    + 'the INPUT fails — 853 of 865 populated outcome_ref values are narrative prose, and exactly one matches '
+    + 'the eligible SD-key shape. outcome_ref carries two incompatible jobs. The deliverable became a classifier '
+    + 'that cannot emit a population without its ceiling. Two of my own findings were retracted en route.',
+  what_went_well: [
+    'Measuring the SD premises before encoding them. The numbers had already moved (1,216 -> 1,392 -> 1,399 rows during the SD), and the half that mattered — outcome_sd_key gaining ONE row while the table grew by 176 — strengthened the diagnosis while falsifying the prescription.',
+    'Building the guards structurally rather than as advice. summarise() THROWS on a bare population; the three buckets exist even at zero; pct_of_ceiling is null rather than 0 when nothing is achievable. On an SD about a misleading number, a convention would have been the wrong instrument.',
+    'Paginating the report. PostgREST caps a plain select at 1000 silently and the table holds 1399 — a single fetch would have classified the CAP and printed a confident wrong distribution. Totals reconcile against an exact COUNT or the run exits non-zero.',
+    'Caveating my own headline. The 8.4%-of-ceiling figure is optimistic because 534 of the 571 ceiling rows carry no ref at all. Naming that inside the deliverable mattered more than usual, since the SD exists because a flattering denominator went unexamined once already.',
+    'Declining the cheap win. Upcasing the 4 lowercase SD- refs would have raised the coverage number and created keys that never resolve, which the reconciler re-selects on every batch forever.',
+  ],
+  what_needs_improvement: [
+    'I ASSERTED "NO WRITER EXISTS" AND IT WAS FALSE. My grep excluded `row.outcome_sd_key` to filter out READS like `if (!row.outcome_sd_key)` — and the WRITE is the same token up to the operator, so the exclusion deleted what I was looking for. The writer had been on main since d4f7cbed4db.',
+    'MY POSITIVE CONTROL COULD NOT HAVE CAUGHT IT, and I treated its green as proof. I applied the SAME exclusion to the control field, so it found writers via other syntactic forms and passed while my answer was wrong. I had been citing "a control validates the mechanism, not the completeness of the pattern set" all session and still missed that it does not validate the EXCLUSION either.',
+    'I READ A RISING METRIC AS A WORKING MECHANISM. outcome_ref went 14% -> 62% and I called it self-remediation, proposing to copy that writer. It was a bulk stamp of PROSE into a REFERENCE field: the metric rose, the capability did not, and outcome_sd_key moved by one row. That is this SD own thesis, reproduced by me while investigating it.',
+  ],
+  key_learnings: [
+    'A CONTROL THAT INHERITS THE FLAW CANNOT REVEAL IT. A positive control validates that the SEARCH RUNS; it never validates the EXCLUSION LIST. An exclusion is exactly the assumption you forget you made, so to test one the control must be a case the exclusion would wrongly remove — not merely a case that should be found.',
+    'A POPULATED COLUMN IS NOT A POPULATED MEASURE. Coverage rising is evidence that something wrote, not that the mechanism works. Ask what was written before crediting the trend.',
+    'THE SAME NUMBER CARRIES OPPOSITE REMEDIES DEPENDING ON ITS DENOMINATOR. 3.4% against an implied 100% says the writer is broken and invites wiring; 3.4% against the derivable ceiling says the input is absent. Publishing a population without its ceiling is not incomplete reporting — it is misleading reporting, and it is what produced this SD prescription.',
+    'AN UNEXAMINED CEILING IS JUST A FRIENDLIER DENOMINATOR. Having built a tool that refuses to emit a population without a ceiling, the ceiling itself then needs interrogating: mine was dominated by rows with no ref at all, so 8.4% flatters the truth.',
+    'AN SD WHOSE REMEDY IS CONTRADICTED BY MEASUREMENT IS NOT A SPEC TO IMPLEMENT LITERALLY. The diagnosis half (the cheap field is written 100%, the expensive one 3.4%) was exactly right and generalises. The prescription half was falsifiable in one query. Keep the diagnosis, replace the prescription, and say which you did.',
+    'A FIELD CAN VIOLATE SINGLE-REPRESENTATION IN THE UNFAMILIAR DIRECTION: not one fact in two places, but TWO facts in one place. outcome_ref is simultaneously a machine-resolvable reference and a human narrative, and no amount of writer-wiring resolves an overloaded column.',
+  ],
+  action_items: [
+    'DECISION OWED: split outcome_ref into reference and narrative, or declare it narrative-only and source refs elsewhere. A fix that does not decide which job the column has will recreate the ambiguity under a new name.',
+    'THE CEILING IS OPTIMISTIC: 571 is dominated by 534 rows carrying no ref. Of rows that HAVE a ref, only 5 of 865 are in-domain. Anyone quoting 8.4% should quote that alongside it.',
+    'PRIOR AUTHOR MEASUREMENT, STILL TRUE: 13 of 31 existing outcome_sd_key values already fail to resolve — the populated minority is partly dead.',
+    'PATTERN WORTH A LOOK: the FR-6 author recorded their own negative control missing the case their fix added. Same control-blindness class I hit here, two different authors, same field. The field may invite it.',
+    'FLEET-WIDE, RE-FLAGGED: every .db.test.js silently skips because the vitest db project is disabled with no designated non-production target.',
+  ],
+  quality_score: 88,
+  business_value_delivered:
+    'A governance ledger stopped reporting a figure that misdirected effort. Coverage now travels with its '
+    + 'derivable ceiling and a three-bucket applicability split, so 3.4% reads as an absent input rather than a '
+    + 'broken writer — and the tool refuses to produce the misleading form again. Zero DDL, writer untouched.',
+  status: 'PUBLISHED',
+}).select('id').single();
+
+if (error) { console.log('RETRO ERROR: ' + error.message); process.exit(1); }
+console.log('RETRO id=' + retro.id);
+
+const r = {
+  verdict: 'PASS', confidence: 88,
+  summary: `Retrospective ${retro.id} published. Durable output: a control that inherits the flaw cannot reveal it, and a populated column is not a populated measure.`,
+  findings: [
+    { id: 'a-control-that-inherits-the-flaw-cannot-reveal-it', severity: 'critical', note: 'THE LESSON, now adopted as fleet guidance by the coordinator. My grep excluded `row.outcome_sd_key` to drop reads and deleted the write. My positive control passed because I applied the SAME exclusion to it. A control validates that the SEARCH RUNS, never that the EXCLUSION LIST is safe — and an exclusion is precisely the assumption you forget you made.' },
+    { id: 'a-populated-column-is-not-a-populated-measure', severity: 'critical', note: 'SECOND RETRACTION. I read outcome_ref rising 14%->62% as the field self-remedying. It was a bulk stamp of prose into a reference field: metric up, capability flat, outcome_sd_key +1 row. This is the SD own thesis and I reproduced it while investigating it.' },
+    { id: 'the-denominator-decides-the-remedy', severity: 'critical', note: '3.4% against an implied 100% reads as a broken writer and invites wiring; 3.4% against the derivable ceiling reads as an absent input. The SD was written from the first reading. summarise() now THROWS rather than emit a population without its ceiling — the misleading form is unbuildable, not merely discouraged.' },
+    { id: 'an-unexamined-ceiling-is-a-friendlier-denominator', severity: 'warning', note: 'HONESTY AGAINST MY OWN DELIVERABLE. The 8.4% headline rests on a ceiling dominated by 534 rows with no ref at all; of rows that have one, 5 of 865 are in-domain. Recorded in the commit, PRD and PR rather than left standing.' },
+    { id: 'two-facts-in-one-place-is-also-a-single-representation-violation', severity: 'warning', note: 'outcome_ref is simultaneously a machine-resolvable REFERENCE and a human NARRATIVE. The familiar violation is one fact in two places; this is the inverse, and no writer-wiring resolves it. The decision — split or declare narrative-only — is owed and named rather than pre-empted.' },
+    { id: 'an-sd-contradicted-by-measurement-is-not-a-literal-spec', severity: 'info', note: 'Diagnosis half exactly right and generalising (cheap field 100%, expensive field 3.4%); prescription half falsifiable in one query. Coordinator accepted the correction as recommended-not-decided. Keep the diagnosis, replace the prescription, and say which you did.' },
+  ],
+  metadata: {
+    retrospective_id: retro.id,
+    quality_score: 88, tests_added: 19, seeded_defects: 6, commits: 5,
+    ddl_applied: 0, writer_changed: false, own_retractions: 2,
+    live_rows: 1399, populated: 48, ceiling: 571,
+    pr: 'https://github.com/rickfelix/EHG_Engineer/pull/6810',
+    mechanism_verifications: [
+      { verified_by: 'Bravo (e3610a71) — retrospective exists and post-dates EXEC-TO-PLAN', verified_at: `retrospectives id=${retro.id}; script at .artifacts/retro-ledger.mjs:1` },
+      { verified_by: 'Bravo (e3610a71) — the bare population is unemittable', verified_at: 'lib/ledger/ref-shape.js:96 summarise() throws; seeded at tests/unit/ledger-ref-shape.test.js:104' },
+      { verified_by: 'Bravo (e3610a71) — the cap cannot pass for the population', verified_at: 'scripts/ledger-ref-shape-report.mjs:62 exits 1 unless fetched === COUNT; live run reconciled 1399 = 1399' },
+      { verified_by: 'Bravo (e3610a71) — the writer I wrongly said was absent', verified_at: 'scripts/coordinator-ack-adam.cjs:249 — on main since d4f7cbed4db' },
+    ],
+  },
+  execution_time_ms: 660000,
+};
+
+const res = await resolveSubAgentRepo({ sdId: SD_KEY, subAgentCode: 'RETRO', targetApplication: 'EHG_Engineer' });
+applySubAgentRepoVerdict(r, res);
+const s = await storeSubAgentResults('RETRO', SD_KEY, { name: 'Continuous Improvement Coach' }, r, { phase: 'PLAN' });
+console.log('STORED RETRO/PLAN id=' + (s && s.id));

--- a/.prd-payloads/SD-LEO-INFRA-OUTCOME-SHAPED-LEDGER-001.json
+++ b/.prd-payloads/SD-LEO-INFRA-OUTCOME-SHAPED-LEDGER-001.json
@@ -1,0 +1,94 @@
+{
+  "executive_summary": "The SD prescribes wiring. Measurement says a correct writer already exists (coordinator-ack-adam.cjs:249, d4f7cbed4db, ancestor of origin/main) and the INPUT is what fails: of 865 populated outcome_ref values, exactly ONE matches the eligible SD-key shape and 853 (98.6%) are narrative prose. outcome_ref is carrying two incompatible jobs — an artifact REFERENCE and an outcome NARRATIVE — and no wiring fixes an overloaded column. The deliverable is a shape classifier, a published DERIVABLE CEILING, and a three-bucket applicability report. Scope correction accepted as recommended-not-decided (coordinator 8b9720cb). PER EXPLICIT INSTRUCTION, FR-5 carries the RETRACTION of my own wrong finding, not just the corrected one.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Classify every populated outcome_ref by shape and publish the DERIVABLE CEILING",
+      "description": "MEASURED whole-column, not sampled (865 populated values): 853 (98.6%) narrative prose; 4 commit sha; 4 `SD-` non-uppercase; 3 `QF-`; exactly 1 (0.1%) matching `^SD-[A-Z0-9-]+$`, the only shape the deriver can use. ~650 of the 853 carry an `era_closure:` prefix — a BULK STAMP, not organic writes. DELIVERABLE: a classifier that reports the split AND the resulting ceiling for outcome_sd_key. THE CEILING IS THE POINT: 3.4% judged against 100% reads as a broken writer; judged against a ceiling of ~0.1% derivable from current inputs, it reads as an absent input, which is the true defect. A population figure published without its ceiling is the exact metric this SD exists to stop chasing, so the report must refuse to emit one without the other."
+    },
+    {
+      "id": "FR-2",
+      "title": "Three buckets, never two: RESOLVABLE / NOT-YET / NOT-APPLICABLE",
+      "description": "A row whose outcome is a narrative can NEVER carry a resolvable SD key — it is not awaiting work, it is out of the mechanism's domain. Collapsing NOT-APPLICABLE into NOT-YET is what makes 3.4% look like a backlog rather than a ceiling, and a backlog invites the wrong remedy (more wiring). DELIVERABLE: every coverage report separates the three. A report schema that can only express populated-vs-empty fails this FR by construction, the same way a re-triage that cannot say 'undetermined' is re-labelling rather than measuring."
+    },
+    {
+      "id": "FR-3",
+      "title": "DO NOT loosen the derivation pattern — and record why, where the next person will look",
+      "description": "The narrowings at coordinator-ack-adam.cjs:264 are deliberate and each prevents a NOISIER failure than the current inert one. QF keys are excluded because the reconciler resolves against strategic_directives_v2 (scripts/solomon-ledger-reconcile.cjs:70) and quick fixes do not live there; uppercase-only because sd_key is stored uppercase. AN UNRESOLVABLE KEY IS WORSE THAN NO KEY: the row is re-selected by every scheduled batch forever, burning a slot and logging a skip each time. The prior author measured 13 of 31 existing outcome_sd_key values ALREADY failing to resolve. TRAP TO NAME EXPLICITLY: case-fixing the 4 non-uppercase `SD-` refs looks like an obvious cheap win and would gain FOUR ROWS out of 1,392. Turning an inert path noisy is a regression, not progress."
+    },
+    {
+      "id": "FR-4",
+      "title": "Name the overload: outcome_ref is one column with two meanings",
+      "description": "outcome_ref simultaneously holds an artifact REFERENCE (machine-resolvable — what the advice BECAME) and an outcome NARRATIVE (human prose — what happened). The deriver needs the first; 98.6% of the column is the second. This is a single-representation violation in the less familiar direction: not one fact in two places, but two facts in one place. DELIVERABLE: state it in the ledger's schema documentation so the next writer knows which job they are feeding. WHICHEVER WAY IT IS RESOLVED — split the column, or declare it narrative-only and source refs elsewhere — a fix that does not decide which job the column has will recreate the ambiguity under a new name."
+    },
+    {
+      "id": "FR-5",
+      "title": "Carry the RETRACTION, not just the corrected finding",
+      "description": "EXPLICIT COORDINATOR INSTRUCTION (8b9720cb). I first reported that outcome_sd_key had NO writer at all. That was FALSE. A correct writer exists at coordinator-ack-adam.cjs:249. HOW THE WRONG ANSWER LOOKED CONVINCING, which is the part worth keeping: my search excluded `row.outcome_sd_key` in order to drop READS like `if (!row.outcome_sd_key)` — and the WRITE is the same token up to the operator, so the filter deleted the thing I was searching for. I then ran a POSITIVE CONTROL against outcome_ref, it found four writers, and I treated that as proof the search was sound. IT COULD NOT HAVE CAUGHT THE ERROR: I applied the SAME exclusion to the control, so it found writers only via other syntactic forms and still came back green. THE RULE, now adopted as fleet guidance: A CONTROL THAT INHERITS THE FLAW CANNOT REVEAL IT — a control validates that the SEARCH RUNS, never that the EXCLUSION LIST is safe. To test an exclusion, the control must be a case the exclusion would wrongly remove. SECOND RETRACTION, on this SD's own thesis: I read outcome_ref rising 14%→62% as the field self-remedying and proposed copying that writer. It was a bulk stamp of PROSE into a REFERENCE field — the metric rose, the capability did not, outcome_sd_key moved by one row. A POPULATED COLUMN IS NOT A POPULATED MEASURE. A PRD showing only the tidy conclusion teaches the next reader that the conclusion was obvious; the useful content is how the wrong answer looked right."
+    }
+  ],
+  "technical_requirements": [
+    { "id": "TR-1", "title": "No migration", "description": "The SD says DO NOT WRITE A MIGRATION and that half stands: the column is already schemad and already has a live consumer. This SD adds reporting and documentation, not DDL." },
+    { "id": "TR-2", "title": "Measure whole-column, never sampled", "description": "All figures come from COUNT(head:true) or a full-column read. An earlier figure in this codebase ('4 distinct QF keys') came from a truncated sample read as a population and had to be corrected to 6 across 8 rows. Sampling is how a ceiling gets mistaken for a backlog." },
+    { "id": "TR-3", "title": "The report refuses to emit a population without a ceiling", "description": "Enforced in code, not by convention. A coverage percentage published alone is the artifact this SD exists to prevent." }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "Population is never emitted without its ceiling", "type": "unit", "expected": "Requesting the outcome_sd_key population without the derivable ceiling exits non-zero. SEEDED: a caller that asks for the bare number fails." },
+    { "id": "TS-2", "scenario": "Prose refs classify as NOT-APPLICABLE, not as a coverage failure", "type": "unit", "expected": "An `era_closure:...` ref lands in NOT-APPLICABLE. SEEDED: a classifier that puts it in NOT-YET fails, because that is the mistake that produced the SD's unbuildable remedy." },
+    { "id": "TS-3", "scenario": "Lowercase SD- ref is reported as case-drift, not silently derived", "type": "unit", "expected": "Reported in its own bucket with the reason (sd_key is stored uppercase). A run that derives from it fails — it would produce a key that never resolves." },
+    { "id": "TS-4", "scenario": "QF- ref classifies as EXCLUDED-BY-DESIGN with its reason", "type": "unit", "expected": "Bucketed with the rationale that quick fixes do not live in strategic_directives_v2, so the key would never resolve and the row would be re-selected by every batch forever." },
+    { "id": "TS-5", "scenario": "Three buckets always present in the schema", "type": "unit", "expected": "The report object exposes RESOLVABLE, NOT-YET and NOT-APPLICABLE even when a bucket is zero. SEEDED: a two-bucket schema fails by construction." },
+    { "id": "TS-6", "scenario": "Whole-column figures match a live count", "type": "integration", "expected": "Classifier totals reconcile against COUNT(head:true) on the live table; a mismatch exits non-zero rather than reporting a plausible-looking subtotal." }
+  ],
+  "acceptance_criteria": [
+    "The shape classifier reports the whole-column split and the DERIVABLE CEILING together; a population figure alone is not emittable.",
+    "Coverage reports separate RESOLVABLE / NOT-YET / NOT-APPLICABLE, with the third present even when zero.",
+    "The derivation pattern is UNCHANGED, and the reason an unresolvable key is worse than none is recorded where the next person will look.",
+    "The outcome_ref overload (reference vs narrative) is named in the ledger's schema documentation.",
+    "The PRD and retrospective carry the RETRACTION — the wrong finding and why it looked convincing — not only the corrected finding.",
+    "No migration; no change to the writer at coordinator-ack-adam.cjs; no loosening of the match."
+  ],
+  "risks": [
+    { "risk": "Someone loosens the pattern to raise the percentage.", "mitigation": "FR-3 plus TS-3/TS-4. An unresolvable key makes an inert path NOISY and permanently re-selected — measurably worse than the current state, and 13 of 31 existing values already fail to resolve." },
+    { "risk": "NOT-APPLICABLE is collapsed into NOT-YET, restoring the illusion of a backlog.", "mitigation": "FR-2 plus TS-5 — a two-bucket schema fails by construction rather than by reviewer vigilance." },
+    { "risk": "The retraction is smoothed out of the record as the SD is tidied for review.", "mitigation": "FR-5 makes it a numbered requirement with its own acceptance criterion, per explicit coordinator instruction." },
+    { "risk": "A figure is quoted from the SD body rather than re-measured.", "mitigation": "TR-2. The SD's own numbers were already stale by build time (1,216→1,392 rows; outcome_ref 14%→62%), which is what made the stated remedy look correct." }
+  ],
+  "integration_operationalization": {
+    "consumers": "scripts/solomon-ledger-reconcile.cjs — the forward reconciler that skips every row lacking outcome_sd_key (:64) and resolves the SD by that key (:70); anyone reading ledger coverage to judge whether the reward spine is working.",
+    "dependencies": "scripts/coordinator-ack-adam.cjs:249 as the sole writer (derives from outcome_ref); strategic_directives_v2 as the resolution target; the ledger's schema documentation as the place the overload must be named.",
+    "data_contracts": "No schema change. outcome_sd_key remains derived, never separately supplied — a second hand-entered field would drift from outcome_ref and the two columns would then disagree about which artifact a decision tracked.",
+    "runtime_config": "No new env vars. Reporting only.",
+    "observability_rollout": "The classifier IS the observable. Before: 3.4% population with no ceiling, which reads as a broken writer. After: population against a published ceiling plus a three-bucket applicability split, which reads as an absent input. The difference between those two readings is the entire value of this SD."
+  },
+  "system_architecture": {
+    "objects_touched": "Reporting scripts and schema documentation only. No DDL, no change to the writer or the reconciler.",
+    "invariant": "outcome_sd_key is DERIVED from outcome_ref and is only derivable when outcome_ref is a machine-resolvable uppercase SD key. Coverage can therefore never exceed the proportion of refs holding that shape.",
+    "coupling_map": "outcome_sd_key ← outcome_ref (derivation, coordinator-ack-adam.cjs:249). Reconciler ← outcome_sd_key (solomon-ledger-reconcile.cjs:64,:70). outcome_ref ← two unrelated writer intents (reference and narrative) — the overload named in FR-4."
+  },
+  "implementation_approach": {
+    "sequence": "Classifier and ceiling first (FR-1), because every later judgement depends on knowing what is achievable. Then the three-bucket report (FR-2). Then documentation of the overload (FR-4) and the do-not-loosen rationale (FR-3). FR-5 is written into the PRD and retro rather than built.",
+    "verification_discipline": "Whole-column, never sampled. Re-measure rather than quote the SD. And test an exclusion with a case the exclusion would wrongly remove — a control sharing the assumption proves nothing about it.",
+    "out_of_scope": "Changing the writer; loosening the match; any migration; deciding on the fleet's behalf whether advice outcomes SHOULD be artifacts — this SD supplies the measurement that makes that decision possible, and says so rather than pre-empting it."
+  },
+  "smoke_test_steps": [
+    { "step_number": 1, "instruction": "Run: node scripts/ledger-ref-shape-report.mjs", "expected_outcome": "Prints the whole-column shape split (eligible SD keys vs narrative prose vs other) with counts and percentages, AND the derivable ceiling for outcome_sd_key. Exits non-zero if a population figure is emitted without its ceiling." },
+    { "step_number": 2, "instruction": "Run: node scripts/ledger-ref-shape-report.mjs --applicability", "expected_outcome": "Reports three buckets, never two: RESOLVABLE, NOT-YET, and NOT-APPLICABLE. A run reporting only populated-vs-empty fails this step — collapsing not-applicable into not-yet is what makes 3.4% look like a backlog rather than a ceiling." },
+    { "step_number": 3, "instruction": "Run: npx vitest run tests/unit/ledger-ref-shape.test.js", "expected_outcome": "Green, including the seeded cases: a prose ref classifies NOT-APPLICABLE (not as a coverage failure), a lowercase SD- ref is reported as case-drift rather than silently derived, and a QF- ref is EXCLUDED-BY-DESIGN with the reason recorded." }
+  ],
+  "metadata": {
+    "no_migration": true,
+    "writer_unchanged": true,
+    "measured_2026_08_04": {
+      "rows": 1392,
+      "outcome_populated": "1392 (100%)",
+      "outcome_ref_populated": "865 (62.1%)",
+      "outcome_sd_key_populated": "48 (3.4%)",
+      "outcome_ref_shape": "853 prose (98.6%) / 4 sha / 4 SD- non-upper / 3 QF- / 1 eligible (0.1%)",
+      "era_closure_prefixed": "~650 of 853 (76%) — a bulk stamp"
+    },
+    "sd_figures_were_stale": "SD said 1,216 rows, outcome_ref 14.0%, outcome_sd_key 3.9%",
+    "retractions_carried": 2,
+    "scope_correction": "accepted recommended-not-decided, coordinator 8b9720cb"
+  }
+}

--- a/lib/ledger/ref-shape.js
+++ b/lib/ledger/ref-shape.js
@@ -1,0 +1,129 @@
+/**
+ * SD-LEO-INFRA-OUTCOME-SHAPED-LEDGER-001 — outcome_ref shape classification.
+ *
+ * WHY THIS EXISTS. `outcome_sd_key` is 3.4% populated and the SD read that as a wiring defect.
+ * It is not: a correct writer exists (scripts/coordinator-ack-adam.cjs:249) which DERIVES the key
+ * from `outcome_ref`, and 853 of 865 populated refs are narrative prose. The measure is starved by
+ * its INPUT, not its wiring.
+ *
+ * THE FAILURE MODE THIS MODULE GUARDS AGAINST IS A NUMBER THAT IS TRUE AND MISLEADING.
+ * "3.4% populated" against an implied 100% reads as a broken writer. The same 3.4% against a
+ * DERIVABLE CEILING of ~0.1% reads as an absent input. Same number, opposite conclusion — and the
+ * SD was written from the first reading. So:
+ *   - `summarise()` REFUSES to return a population without its ceiling.
+ *   - applicability always carries THREE buckets, never two. A narrative outcome is NOT-APPLICABLE
+ *     (outside the mechanism's domain), not NOT-YET (awaiting work). Collapsing them turns a
+ *     ceiling into a backlog, and a backlog invites the very wiring this SD had to refuse.
+ */
+
+/** The only shape the deriver can use: uppercase SD key. */
+export const ELIGIBLE = /^SD-[A-Z0-9-]+$/;
+
+export const SHAPE = Object.freeze({
+  ELIGIBLE: 'eligible-sd-key',
+  CASE_DRIFT: 'sd-key-case-drift',
+  EXCLUDED_QF: 'qf-excluded-by-design',
+  COMMIT_SHA: 'commit-sha',
+  NARRATIVE: 'narrative-prose',
+  EMPTY: 'empty',
+});
+
+/** Bucket names. NOT_APPLICABLE is a first-class outcome, never folded into NOT_YET. */
+export const BUCKET = Object.freeze({
+  RESOLVABLE: 'RESOLVABLE',
+  NOT_YET: 'NOT_YET',
+  NOT_APPLICABLE: 'NOT_APPLICABLE',
+});
+
+/**
+ * Classify a single outcome_ref value.
+ *
+ * CASE_DRIFT is deliberately its own shape rather than being folded into ELIGIBLE. Deriving from a
+ * lowercase ref would produce a key that never resolves (sd_key is stored uppercase), and an
+ * unresolvable key is WORSE than none: the reconciler re-selects that row on every scheduled batch
+ * forever, burning a slot and logging a skip each time. Reporting the drift lets someone fix the
+ * SOURCE; silently upcasing it would raise the coverage number while creating dead rows.
+ */
+export function classifyRef(ref) {
+  if (ref === null || ref === undefined || String(ref).trim() === '') return SHAPE.EMPTY;
+  const s = String(ref).trim();
+  if (ELIGIBLE.test(s)) return SHAPE.ELIGIBLE;
+  if (/^SD-/i.test(s)) return SHAPE.CASE_DRIFT;
+  if (/^QF-/i.test(s)) return SHAPE.EXCLUDED_QF;
+  if (/^[0-9a-f]{7,40}$/i.test(s)) return SHAPE.COMMIT_SHA;
+  return SHAPE.NARRATIVE;
+}
+
+/**
+ * Which applicability bucket a row falls in.
+ *
+ * A NARRATIVE outcome can never yield a resolvable key — the advice did not become an artifact, so
+ * the forward reconciliation path simply does not apply to it. That is not a gap to be closed.
+ */
+export function bucketFor({ outcome_ref: ref, outcome_sd_key: key } = {}) {
+  if (key && String(key).trim()) return BUCKET.RESOLVABLE;
+  const shape = classifyRef(ref);
+  if (shape === SHAPE.ELIGIBLE) return BUCKET.NOT_YET;      // derivable, simply not derived yet
+  if (shape === SHAPE.CASE_DRIFT) return BUCKET.NOT_YET;    // fixable at source, still in-domain
+  if (shape === SHAPE.EMPTY) return BUCKET.NOT_YET;         // no ref yet; nothing decided
+  return BUCKET.NOT_APPLICABLE;                             // prose, sha, QF — out of domain
+}
+
+/**
+ * Whole-population summary.
+ *
+ * THROWS rather than returning a population without a ceiling. This is the module's central
+ * guarantee, and it is enforced in code because the SD itself was written from a bare percentage.
+ * A caller that wants only the numerator is asking for the misleading form.
+ */
+export function summarise(rows, { includeCeiling = true } = {}) {
+  if (!Array.isArray(rows)) throw new Error('summarise: rows must be an array');
+  if (!includeCeiling) {
+    throw new Error(
+      'summarise: refusing to report a population without its derivable ceiling. '
+      + 'A coverage figure judged against an implied 100% reads as a broken writer; judged against '
+      + 'the ceiling it reads as an absent input. Emitting the bare number is the defect this SD exists to remove.',
+    );
+  }
+
+  const shapes = {};
+  const buckets = { [BUCKET.RESOLVABLE]: 0, [BUCKET.NOT_YET]: 0, [BUCKET.NOT_APPLICABLE]: 0 };
+  let populated = 0;
+  let refPopulated = 0;
+
+  for (const r of rows) {
+    const shape = classifyRef(r?.outcome_ref);
+    shapes[shape] = (shapes[shape] || 0) + 1;
+    if (shape !== SHAPE.EMPTY) refPopulated += 1;
+    if (r?.outcome_sd_key && String(r.outcome_sd_key).trim()) populated += 1;
+    buckets[bucketFor(r)] += 1;
+  }
+
+  // The ceiling: rows that already have a key, plus rows whose ref could yield one.
+  const derivable = (shapes[SHAPE.ELIGIBLE] || 0) + (shapes[SHAPE.CASE_DRIFT] || 0);
+  const ceiling = buckets[BUCKET.RESOLVABLE] + buckets[BUCKET.NOT_YET];
+
+  return {
+    total: rows.length,
+    outcome_sd_key_populated: populated,
+    outcome_ref_populated: refPopulated,
+    shapes,
+    buckets,                 // always all three keys, even at zero
+    derivable_from_refs: derivable,
+    ceiling,                 // the honest denominator
+    pct_of_total: rows.length ? +(100 * populated / rows.length).toFixed(1) : 0,
+    pct_of_ceiling: ceiling ? +(100 * populated / ceiling).toFixed(1) : null,
+  };
+}
+
+/**
+ * Human-facing line. Never prints the population alone — the ceiling travels with it, because the
+ * pair is what carries the meaning and either half alone invites the wrong conclusion.
+ */
+export function formatSummary(s) {
+  return [
+    `rows ${s.total} | outcome_sd_key ${s.outcome_sd_key_populated} (${s.pct_of_total}% of total)`,
+    `CEILING ${s.ceiling} → ${s.pct_of_ceiling === null ? 'n/a' : s.pct_of_ceiling + '% of what is achievable'}`,
+    `buckets: RESOLVABLE ${s.buckets.RESOLVABLE} | NOT_YET ${s.buckets.NOT_YET} | NOT_APPLICABLE ${s.buckets.NOT_APPLICABLE}`,
+  ].join('\n');
+}

--- a/scripts/ledger-ref-shape-report.mjs
+++ b/scripts/ledger-ref-shape-report.mjs
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-OUTCOME-SHAPED-LEDGER-001 — the outcome_ref shape report.
+ *
+ * Reports outcome_sd_key coverage AGAINST ITS DERIVABLE CEILING, plus a three-bucket applicability
+ * split. It exists because the same number carries opposite meanings: 3.4% against an implied 100%
+ * reads as a broken writer; 3.4% against the ceiling reads as an absent input. The SD was written
+ * from the first reading, which is how it arrived at a remedy (wiring) for a writer that works.
+ *
+ * PAGINATES DELIBERATELY. PostgREST caps a plain select at 1000 rows and returns the cap silently.
+ * This table holds ~1,392, so a single fetch would classify 1000 rows, print a confident
+ * distribution, and be wrong — measuring the cap instead of the population. The row count is
+ * reconciled against an exact COUNT and a mismatch exits non-zero rather than printing a plausible
+ * subtotal.
+ *
+ * Exit 0 = report emitted. 1 = totals do not reconcile. 2 = unreadable (never a pass).
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { summarise, formatSummary, SHAPE, BUCKET } from '../lib/ledger/ref-shape.js';
+
+const TABLE = 'solomon_advice_outcome_ledger';
+const PAGE = 500;
+const argv = process.argv.slice(2);
+const APPLICABILITY = argv.includes('--applicability');
+const JSON_OUT = argv.includes('--json');
+
+async function fetchAll(sb) {
+  const { count, error: cErr } = await sb.from(TABLE).select('*', { count: 'exact', head: true });
+  if (cErr) throw new Error(`count failed: ${cErr.message}`);
+
+  const rows = [];
+  for (let from = 0; from < count; from += PAGE) {
+    const { data, error } = await sb.from(TABLE)
+      .select('outcome_ref, outcome_sd_key')
+      .order('id', { ascending: true })
+      .range(from, from + PAGE - 1);
+    if (error) throw new Error(`page ${from} failed: ${error.message}`);
+    rows.push(...(data || []));
+  }
+  return { rows, count };
+}
+
+async function main() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) { console.error('UNREADABLE: SUPABASE_URL / SUPABASE_SERVICE_ROLE_KEY not set.'); process.exit(2); }
+
+  const sb = createClient(url, key);
+  let rows; let count;
+  try { ({ rows, count } = await fetchAll(sb)); }
+  catch (e) { console.error(`UNREADABLE: ${e.message}`); process.exit(2); }
+
+  // The paginate-vs-cap check. A silent truncation here would poison every figure below.
+  if (rows.length !== count) {
+    console.error(`TOTALS DO NOT RECONCILE: fetched ${rows.length} but COUNT says ${count}. Refusing to report a subtotal as a population.`);
+    process.exit(1);
+  }
+
+  const s = summarise(rows); // throws if anyone ever asks for the bare population
+
+  if (JSON_OUT) { console.log(JSON.stringify(s, null, 2)); process.exit(0); }
+
+  console.log(`=== ${TABLE}: outcome_sd_key coverage against its DERIVABLE CEILING ===`);
+  console.log(formatSummary(s));
+  console.log(`\n  reconciled: fetched ${rows.length} = COUNT ${count} (paginated at ${PAGE}; a single select would cap at 1000 and read as the population)`);
+
+  console.log('\n=== outcome_ref shapes (whole column, not sampled) ===');
+  const order = [SHAPE.ELIGIBLE, SHAPE.CASE_DRIFT, SHAPE.EXCLUDED_QF, SHAPE.COMMIT_SHA, SHAPE.NARRATIVE, SHAPE.EMPTY];
+  for (const k of order) {
+    const n = s.shapes[k] || 0;
+    console.log(`  ${String(n).padStart(5)}  ${k.padEnd(22)} ${s.total ? (100 * n / s.total).toFixed(1) + '%' : ''}`);
+  }
+
+  if (APPLICABILITY) {
+    console.log('\n=== applicability — THREE buckets, never two ===');
+    console.log(`  ${String(s.buckets[BUCKET.RESOLVABLE]).padStart(5)}  RESOLVABLE      a key is present`);
+    console.log(`  ${String(s.buckets[BUCKET.NOT_YET]).padStart(5)}  NOT_YET         in-domain: a ref exists or could, but no key derived yet`);
+    console.log(`  ${String(s.buckets[BUCKET.NOT_APPLICABLE]).padStart(5)}  NOT_APPLICABLE  OUT OF DOMAIN: the advice outcome is a narrative, not an artifact`);
+    console.log('\n  NOT_APPLICABLE is not a gap. Folding it into NOT_YET turns a CEILING into a BACKLOG,');
+    console.log('  and a backlog invites more writer-wiring — the remedy this SD had to refuse.');
+  }
+
+  console.log(`\n  THE READING THAT MATTERS: ${s.outcome_sd_key_populated}/${s.total} is ${s.pct_of_total}% of the table but `
+    + `${s.pct_of_ceiling === null ? 'n/a' : s.pct_of_ceiling + '%'} of what is achievable from current inputs.`);
+  process.exit(0);
+}
+
+main().catch((e) => { console.error(`UNREADABLE: ${e.message}`); process.exit(2); });

--- a/tests/unit/ledger-ref-shape.test.js
+++ b/tests/unit/ledger-ref-shape.test.js
@@ -1,0 +1,141 @@
+// SD-LEO-INFRA-OUTCOME-SHAPED-LEDGER-001 — outcome_ref shape classification.
+//
+// The failure mode here is A NUMBER THAT IS TRUE AND MISLEADING, so every guard is tested by
+// SEEDING the misleading form and asserting it cannot be produced. A guard shown only to permit
+// the honest form is indistinguishable from one that permits everything.
+//
+// Two tests are load-bearing:
+//   - a population without its ceiling must THROW (the SD itself was written from that bare figure)
+//   - the two-bucket schema must be impossible (collapsing NOT_APPLICABLE into NOT_YET turns a
+//     ceiling into a backlog, and a backlog invites the wiring this SD had to refuse)
+
+import { describe, it, expect } from 'vitest';
+import {
+  SHAPE, BUCKET, ELIGIBLE,
+  classifyRef, bucketFor, summarise, formatSummary,
+} from '../../lib/ledger/ref-shape.js';
+
+const row = (ref, key = null) => ({ outcome_ref: ref, outcome_sd_key: key });
+
+describe('classifyRef', () => {
+  it('accepts the one shape the deriver can use', () => {
+    expect(classifyRef('SD-LEO-INFRA-REWARD-SPINE-ONE-001')).toBe(SHAPE.ELIGIBLE);
+    expect(ELIGIBLE.test('SD-LEO-INFRA-REWARD-SPINE-ONE-001')).toBe(true);
+  });
+
+  it('SEEDED: a lowercase SD- ref is CASE_DRIFT, never eligible', () => {
+    // Silently upcasing would raise the coverage number AND create a key that never resolves —
+    // sd_key is stored uppercase, so the reconciler would re-select that row on every batch forever.
+    expect(classifyRef('sd-leo-infra-reward-spine-one-001')).toBe(SHAPE.CASE_DRIFT);
+    expect(classifyRef('Sd-Leo-Mixed-Case-001')).toBe(SHAPE.CASE_DRIFT);
+  });
+
+  it('SEEDED: a QF- ref is EXCLUDED_QF, with the exclusion deliberate', () => {
+    // Quick fixes do not live in strategic_directives_v2, so the key would never resolve.
+    expect(classifyRef('QF-20260509-PRMERGE-EXACT')).toBe(SHAPE.EXCLUDED_QF);
+    expect(classifyRef('qf-lowercase-too')).toBe(SHAPE.EXCLUDED_QF);
+  });
+
+  it('classifies the real prose values as NARRATIVE', () => {
+    expect(classifyRef('era_closure:2026-07-29 — advice consumed into the belt')).toBe(SHAPE.NARRATIVE);
+    expect(classifyRef('followed (dispatch pressed) — later found moot')).toBe(SHAPE.NARRATIVE);
+    expect(classifyRef('Solomon 07-20 18:51 ground read on -A (SESSION)')).toBe(SHAPE.NARRATIVE);
+  });
+
+  it('classifies commit shas separately from prose', () => {
+    expect(classifyRef('d4f7cbe')).toBe(SHAPE.COMMIT_SHA);
+    expect(classifyRef('d4f7cbedd4f7cbedd4f7cbedd4f7cbedd4f7cbed')).toBe(SHAPE.COMMIT_SHA);
+  });
+
+  it('treats null / undefined / blank as EMPTY, not as prose', () => {
+    for (const v of [null, undefined, '', '   ']) expect(classifyRef(v)).toBe(SHAPE.EMPTY);
+  });
+});
+
+describe('bucketFor — NOT_APPLICABLE is a real outcome, not a gap', () => {
+  it('a row with a key is RESOLVABLE', () => {
+    expect(bucketFor(row('anything', 'SD-X-001'))).toBe(BUCKET.RESOLVABLE);
+  });
+
+  it('SEEDED: prose is NOT_APPLICABLE — the mistake that produced the SD unbuildable remedy', () => {
+    // Classifying prose as NOT_YET makes 3.4% look like a backlog rather than a ceiling.
+    expect(bucketFor(row('era_closure:2026-07-29 — advice consumed'))).toBe(BUCKET.NOT_APPLICABLE);
+    expect(bucketFor(row('era_closure:2026-07-29 — advice consumed'))).not.toBe(BUCKET.NOT_YET);
+  });
+
+  it('an eligible or case-drifted ref is NOT_YET — still in the mechanism domain', () => {
+    expect(bucketFor(row('SD-LEO-X-001'))).toBe(BUCKET.NOT_YET);
+    expect(bucketFor(row('sd-leo-x-001'))).toBe(BUCKET.NOT_YET);
+  });
+
+  it('an absent ref is NOT_YET — nothing has been decided, not out of domain', () => {
+    expect(bucketFor(row(null))).toBe(BUCKET.NOT_YET);
+  });
+
+  it('QF and sha refs are NOT_APPLICABLE — they can never resolve', () => {
+    expect(bucketFor(row('QF-2026-001'))).toBe(BUCKET.NOT_APPLICABLE);
+    expect(bucketFor(row('d4f7cbe'))).toBe(BUCKET.NOT_APPLICABLE);
+  });
+});
+
+describe('summarise — the population may never travel without its ceiling', () => {
+  const sample = [
+    row('SD-LEO-A-001', 'SD-LEO-A-001'),                 // resolvable
+    row('SD-LEO-B-001'),                                  // not yet
+    row('sd-leo-c-001'),                                  // case drift -> not yet
+    row('era_closure:2026-07-29 — consumed'),             // not applicable
+    row('era_closure:2026-07-30 — consumed'),             // not applicable
+    row('QF-2026-001'),                                   // not applicable
+    row(null),                                            // not yet
+  ];
+
+  it('reports population AND ceiling together', () => {
+    const s = summarise(sample);
+    expect(s.total).toBe(7);
+    expect(s.outcome_sd_key_populated).toBe(1);
+    expect(s.ceiling).toBe(4);           // 1 resolvable + 3 not-yet
+    expect(s.pct_of_total).toBe(14.3);
+    expect(s.pct_of_ceiling).toBe(25);   // the honest reading
+  });
+
+  it('SEEDED — THE LOAD-BEARING CASE: asking for the bare population THROWS', () => {
+    expect(() => summarise(sample, { includeCeiling: false })).toThrow(/without its derivable ceiling/);
+  });
+
+  it('the two readings of the same number differ sharply, which is the whole point', () => {
+    const s = summarise(sample);
+    expect(s.pct_of_total).not.toBe(s.pct_of_ceiling);
+    expect(s.pct_of_ceiling).toBeGreaterThan(s.pct_of_total);
+  });
+
+  it('SEEDED: all three buckets exist even when one is zero', () => {
+    const s = summarise([row('SD-LEO-A-001', 'SD-LEO-A-001')]);
+    expect(Object.keys(s.buckets).sort()).toEqual(['NOT_APPLICABLE', 'NOT_YET', 'RESOLVABLE']);
+    expect(s.buckets.NOT_APPLICABLE).toBe(0);
+  });
+
+  it('buckets sum to the total — no row is silently dropped', () => {
+    const s = summarise(sample);
+    const sum = s.buckets.RESOLVABLE + s.buckets.NOT_YET + s.buckets.NOT_APPLICABLE;
+    expect(sum).toBe(s.total);
+  });
+
+  it('pct_of_ceiling is null rather than 0 when nothing is achievable', () => {
+    // Reporting 0% would imply a gap; null says the question does not apply.
+    const s = summarise([row('era_closure:x'), row('QF-1')]);
+    expect(s.ceiling).toBe(0);
+    expect(s.pct_of_ceiling).toBeNull();
+  });
+
+  it('rejects a non-array population rather than coercing it', () => {
+    expect(() => summarise(null)).toThrow(/must be an array/);
+  });
+});
+
+describe('formatSummary', () => {
+  it('never prints the population without the ceiling on the adjacent line', () => {
+    const out = formatSummary(summarise([row('SD-A-001', 'SD-A-001'), row('era_closure:x')]));
+    expect(out).toMatch(/CEILING/);
+    expect(out).toMatch(/NOT_APPLICABLE/);
+  });
+});


### PR DESCRIPTION
The SD prescribes wiring. **Measurement says the writer already works** — `coordinator-ack-adam.cjs:249` (`d4f7cbed4db`, on main) derives `outcome_sd_key` from `outcome_ref` — and the **input** is what fails. Of 865 populated refs, exactly **one** matches the eligible SD-key shape; **853 (98.6%) are narrative prose**.

## The finding

`outcome_ref` carries **two incompatible jobs**: an artifact *reference* (machine-resolvable — what the advice became) and an outcome *narrative* (human prose — what happened). The deriver needs the first. **One column, two meanings** — no wiring fixes that.

## Live run (reconciled 1399 fetched = 1399 counted)

```
outcome_sd_key 48 — 3.4% OF THE TABLE but 8.4% OF THE CEILING (571)
buckets: RESOLVABLE 48 | NOT_YET 523 | NOT_APPLICABLE 828
shapes:  1 eligible | 4 case-drift | 3 qf | 4 sha | 853 prose | 534 empty
```

**3.4% against an implied 100% reads as a broken writer. 8.4% against the ceiling reads as an absent input.** Same number, opposite remedies — and the SD was written from the first reading.

## Built so the misleading form can't be produced

- `summarise()` **throws** if asked for a population without its ceiling.
- Three buckets always, **even at zero**; buckets sum to total so no row is dropped.
- `pct_of_ceiling` is **null**, not 0, when nothing is achievable — 0% implies a gap.
- **Paginates at 500.** PostgREST caps a plain select at 1000 *silently*; the table is 1399. A single fetch would have printed a confident distribution of the cap. Totals reconcile against exact COUNT or exit 1.
- `CASE_DRIFT` is its own shape — upcasing those 4 refs would raise the number *and* create keys that never resolve, which the reconciler re-selects forever.

## I caveated my own headline

**The ceiling is optimistic.** 571 is dominated by the 534 rows with *no ref yet*. Of rows that already have a ref, only **5 of 865** are in-domain. If future refs resemble past refs, the realistic ceiling is far lower and the true reading is nearer 3.4%. An unexamined ceiling is just a friendlier denominator — which is the class this SD removes.

## Two retractions carried in FR-5, per coordinator instruction

- I reported "no writer exists." **False** — my exclusion filter dropped `row.outcome_sd_key` to remove *reads*, deleting the *write* (same token, different operator). My positive control couldn't catch it because I applied the same exclusion to it. **A control that inherits the flaw cannot reveal it.**
- I read `outcome_ref` rising 14%→62% as self-remediation. It was a **bulk stamp of prose into a reference field** — the metric rose, the capability didn't. **A populated column is not a populated measure.**

**Zero DDL. Writer untouched. Pattern unchanged.** 19 tests, 6 seeded defects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)