### PR TITLE
fix(validation): the duplicate detector reported a search it never performed

### DIFF
--- a/lib/sub-agents/validation.js
+++ b/lib/sub-agents/validation.js
@@ -158,6 +158,24 @@ export async function execute(sdId, subAgent, options = {}) {
       });
       results.findings.step4 = step4;
 
+      // A SEARCH THAT COULD NOT RUN MUST NOT READ AS A CLEAN RESULT.
+      //
+      // The duplicate warning below fires only when the count is > 0, so before this branch
+      // existed a totally failed search and a genuinely clean one produced IDENTICAL output: no
+      // warning. That is the shape that let semantic duplicate detection sit dark while every
+      // VALIDATION run reported a tidy zero. The index-empty case is already reported further
+      // down; this closes the sibling case where the index IS available and the queries
+      // themselves failed — precisely the state that would follow if the index were ever
+      // populated with the embedding call still broken.
+      if (step4.search_status === 'could_not_search') {
+        results.warnings.push({
+          severity: 'HIGH',
+          issue: `Duplicate detection DID NOT RUN (${step4.queries_succeeded ?? 0} of ${step4.queries_attempted ?? 0} queries completed)`,
+          recommendation: 'Do NOT read the absence of duplicates below as evidence there are none — nothing was searched. Investigate the failure before relying on this validation.',
+          failure_reasons: step4.failure_reasons || []
+        });
+      }
+
       // Add warnings for potential duplicates
       if (step4.summary?.potential_duplicates_count > 0) {
         results.warnings.push({

--- a/lib/sub-agents/validation.js
+++ b/lib/sub-agents/validation.js
@@ -33,6 +33,32 @@ let supabase = null;
  * @param {Object} options - Execution options
  * @returns {Promise<Object>} Validation results
  */
+/**
+ * Build the warning for a semantic search that was ATTEMPTED and FAILED.
+ *
+ * EXTRACTED SO IT CAN BE EXECUTED BY A TEST. Inline inside execute() this branch measured 0%
+ * coverage — execute() queries SD metadata, the PRD, backlog items and test evidence before
+ * reaching it, so covering it end-to-end costs four mocks and still would not isolate this
+ * decision. It is the FR-4 deliverable and it was the only part of this SD with no test at all.
+ *
+ * DOUBLY WORTH TESTING BECAUSE THE BRANCH IS CURRENTLY UNREACHABLE IN PRODUCTION: its caller sits
+ * inside `if (indexStatus.available)`, and the index has never held a row. A guard that cannot fire
+ * yet AND has never been executed by anything is indistinguishable from one that does not work.
+ * This at least proves it is correct for the day it arms.
+ *
+ * @param {object} step4 result of searchExistingInfrastructure
+ * @returns {object|null} a warning to push, or null when the search genuinely ran
+ */
+export function buildCouldNotSearchWarning(step4) {
+  if (step4?.search_status !== 'could_not_search') return null;
+  return {
+    severity: 'HIGH',
+    issue: `Duplicate detection DID NOT RUN (${step4.queries_succeeded ?? 0} of ${step4.queries_attempted ?? 0} queries completed)`,
+    recommendation: 'Do NOT read the absence of duplicates below as evidence there are none — nothing was searched. Investigate the failure before relying on this validation.',
+    failure_reasons: step4.failure_reasons || []
+  };
+}
+
 export async function execute(sdId, subAgent, options = {}) {
   console.log(`\n🔍 Starting VALIDATION for ${sdId}...`);
   console.log('   Using 5-Step SD Evaluation Checklist');
@@ -177,14 +203,8 @@ export async function execute(sdId, subAgent, options = {}) {
       // down; this closes the sibling case where the index IS available and the queries
       // themselves failed — precisely the state that would follow if the index were ever
       // populated with the embedding call still broken.
-      if (step4.search_status === 'could_not_search') {
-        results.warnings.push({
-          severity: 'HIGH',
-          issue: `Duplicate detection DID NOT RUN (${step4.queries_succeeded ?? 0} of ${step4.queries_attempted ?? 0} queries completed)`,
-          recommendation: 'Do NOT read the absence of duplicates below as evidence there are none — nothing was searched. Investigate the failure before relying on this validation.',
-          failure_reasons: step4.failure_reasons || []
-        });
-      }
+      const couldNotSearchWarning = buildCouldNotSearchWarning(step4);
+      if (couldNotSearchWarning) results.warnings.push(couldNotSearchWarning);
 
       // Add warnings for potential duplicates
       if (step4.summary?.potential_duplicates_count > 0) {

--- a/lib/sub-agents/validation.js
+++ b/lib/sub-agents/validation.js
@@ -158,6 +158,16 @@ export async function execute(sdId, subAgent, options = {}) {
       });
       results.findings.step4 = step4;
 
+      // ⚠️ SELF-ARMING AND CURRENTLY INERT — SAYING SO HERE BECAUSE THE PR ALMOST DID NOT.
+      //
+      // This branch sits inside `if (indexStatus.available)`, and available is FALSE today and
+      // stays false until codebase_semantic_index is populated — which nobody has scoped. So this
+      // warning CANNOT FIRE IN PRODUCTION as things stand. It arms itself the moment the index has
+      // rows, which is the right shape for a guard whose trigger condition does not exist yet, but
+      // it must not be described as a live alarm. An earlier version of this SD's PR body implied
+      // it was one; a RETRO sub-agent caught that the reader was unreachable and the claim was
+      // true only of a state that does not exist.
+      //
       // A SEARCH THAT COULD NOT RUN MUST NOT READ AS A CLEAN RESULT.
       //
       // The duplicate warning below fires only when the count is > 0, so before this branch

--- a/lib/utils/validation-automation.js
+++ b/lib/utils/validation-automation.js
@@ -12,7 +12,7 @@
  */
 
 import { createSupabaseServiceClient } from '../supabase-client.js';
-import { getLLMClient } from '../llm/client-factory.js';
+import { getEmbeddingClient } from '../llm/client-factory.js';
 import dotenv from 'dotenv';
 
 dotenv.config();
@@ -20,36 +20,55 @@ dotenv.config();
 // Initialize Supabase client
 const supabase = createSupabaseServiceClient();
 
-// LLM client initialized lazily on first use
-let llmClient = null;
+// Embedding client initialized lazily on first use.
+//
+// THERE USED TO BE A LOCAL getEmbeddingClient() HERE AND IT WAS THE WHOLE PROBLEM. It returned
+// getLLMClient({purpose:'validation-semantic-search'}) — a CHAT provider adapter — while shadowing
+// the real exported getEmbeddingClient() of the SAME NAME in ../llm/client-factory.js. A reader
+// checking "does this file use getEmbeddingClient?" got yes, and the answer was still wrong. That
+// is what made it invisible to 289 days of readers, and it is why the wrapper is DELETED rather
+// than repaired: patching the call shape would have left the shadow in place for the next caller.
+let embeddingClient = null;
 
-async function getEmbeddingClient() {
-  if (!llmClient) {
-    llmClient = await getLLMClient({
-      purpose: 'validation-semantic-search',
-      phase: 'PLAN'
-    });
+function resolveEmbeddingClient() {
+  if (!embeddingClient) {
+    embeddingClient = getEmbeddingClient({ purpose: 'validation-semantic-search' });
   }
-  return llmClient;
+  return embeddingClient;
 }
 
 /**
- * Generate embedding for search query
+ * Generate embedding for search query.
+ *
+ * THE OLD CALL WAS `client.embeddings.create({...})` AND IT MATCHED NEITHER FACTORY. Measured
+ * live: the chat adapter exposes {complete, chat, messages} with embeddings=UNDEFINED, and the
+ * real embedding client exposes {embed, model, dimensions, provider} with no `.embeddings` either.
+ * So this was never a shadowed-import bug alone — it is writer-correct/consumer-wrong API
+ * asymmetry, and repairing only the import would still have thrown. scripts/semantic-indexer.js
+ * (the WRITER of this same index) has always called embed() correctly; it is the shape to copy.
+ *
+ * embed() returns an ARRAY OF VECTORS (number[][]) even for a single string — verified by
+ * execution, outer length 1, inner length 1536 matching the client's declared `dimensions`. The
+ * previous `response.data[0].embedding` needed no such indexing, so the [0] here is load-bearing.
+ *
  * @param {string} query - Text to embed
- * @returns {Promise<number[]>} 1536-dimensional embedding
+ * @returns {Promise<number[]>} a single embedding vector of the client's declared width
  */
 async function generateEmbedding(query) {
-  const client = await getEmbeddingClient();
+  const client = resolveEmbeddingClient();
   if (!client) {
-    throw new Error('LLM client not available for embeddings');
+    throw new Error('Embedding client not available');
   }
 
-  const response = await client.embeddings.create({
-    model: 'text-embedding-3-small',
-    input: query,
-    encoding_format: 'float'
-  });
-  return response.data[0].embedding;
+  const vectors = await client.embed(query);
+  const vector = Array.isArray(vectors) ? vectors[0] : undefined;
+  if (!Array.isArray(vector)) {
+    // Loud rather than undefined-shaped: an unusable embedding must not reach the RPC as a silent
+    // malformed argument, because that surfaces as a confusing database error rather than as
+    // "the embedding provider returned something we did not expect".
+    throw new Error(`embed() returned an unexpected shape for the query (expected number[][], got ${typeof vectors})`);
+  }
+  return vector;
 }
 
 /**
@@ -69,14 +88,28 @@ export async function searchExistingInfrastructure(sdMetadata, options = {}) {
     matchCount = 15
   } = options;
 
+  // search_performed IS NOT DECLARED HERE ANY MORE, AND THAT IS THE POINT OF THIS SD.
+  //
+  // It used to be initialised to `true` on this line — before a single query had been attempted —
+  // so it recorded an INTENTION TO SEARCH and was never reconciled against what happened. When
+  // every query failed, the catch inside the loop logged and continued, and this function returned
+  // search_performed: true with empty result arrays. A total failure and a clean search were the
+  // same bytes on the wire. That is why a feature that has never once executed looked, for 289
+  // days, exactly like a feature that ran and found nothing.
+  //
+  // The outcome fields are now DERIVED at the end from what the loop actually did. Note the catch
+  // block never had to set this to true to do the damage — it merely failed to set it to false.
+  // A fix aimed only at the catch would leave the next failure mode lying by default.
   const results = {
     automated: true,
-    search_performed: true,
     search_queries: [],
     existing_infrastructure: [],
     potential_duplicates: [],
     related_components: []
   };
+  let queriesAttempted = 0;
+  let queriesSucceeded = 0;
+  const failureReasons = [];
 
   try {
     // Generate search queries from SD metadata
@@ -89,6 +122,7 @@ export async function searchExistingInfrastructure(sdMetadata, options = {}) {
     for (const query of searchQueries) {
       console.log(`      Searching: "${query.text.substring(0, 50)}..."`);
 
+      queriesAttempted++;
       try {
         const embedding = await generateEmbedding(query.text);
 
@@ -103,8 +137,14 @@ export async function searchExistingInfrastructure(sdMetadata, options = {}) {
 
         if (error) {
           console.log(`      ⚠️  Search error: ${error.message}`);
+          failureReasons.push(`rpc: ${error.message}`);
           continue;
         }
+
+        // Past the RPC without an error: THIS query genuinely searched. Counted here rather than
+        // at the top of the try, so that "attempted" and "succeeded" cannot be the same number by
+        // construction — which is the property that makes could-not-search detectable at all.
+        queriesSucceeded++;
 
         if (searchResults && searchResults.length > 0) {
           console.log(`      ✅ Found ${searchResults.length} matches`);
@@ -140,6 +180,7 @@ export async function searchExistingInfrastructure(sdMetadata, options = {}) {
         }
       } catch (searchErr) {
         console.log(`      ⚠️  Query failed: ${searchErr.message}`);
+        failureReasons.push(searchErr.message);
       }
     }
 
@@ -147,6 +188,29 @@ export async function searchExistingInfrastructure(sdMetadata, options = {}) {
     results.potential_duplicates = deduplicateResults(results.potential_duplicates);
     results.existing_infrastructure = deduplicateResults(results.existing_infrastructure);
     results.related_components = deduplicateResults(results.related_components);
+
+    // DERIVE the outcome from what actually happened. Three states, deliberately distinct:
+    //   'not_attempted'    — the loop never ran (no queries generated); nothing was tried.
+    //   'could_not_search' — queries were attempted and NONE completed; the result arrays are
+    //                        empty because the instrument is blind, not because the codebase is.
+    //   'searched'         — at least one query completed; an empty result is a real finding.
+    // The middle state is the one that did not exist before, and its absence is the entire defect.
+    results.queries_attempted = queriesAttempted;
+    results.queries_succeeded = queriesSucceeded;
+    results.failure_reasons = [...new Set(failureReasons)];
+    results.search_status = queriesAttempted === 0
+      ? 'not_attempted'
+      : (queriesSucceeded === 0 ? 'could_not_search' : 'searched');
+
+    // Retained for the existing consumer at performGapAnalysis() below, which gates on it. Now
+    // COMPUTED rather than declared, so it can no longer be true for a run that searched nothing.
+    results.search_performed = results.search_status === 'searched';
+
+    if (results.search_status === 'could_not_search') {
+      console.log(`   ❌ SEARCH DID NOT RUN: ${queriesAttempted} querie(s) attempted, 0 completed — ` +
+        'results below are EMPTY BECAUSE NOTHING WAS SEARCHED, not because nothing was found. ' +
+        `Reasons: ${results.failure_reasons.join('; ')}`);
+    }
 
     // Summary
     results.summary = {
@@ -169,6 +233,10 @@ export async function searchExistingInfrastructure(sdMetadata, options = {}) {
     return {
       automated: true,
       search_performed: false,
+      search_status: 'could_not_search',
+      queries_attempted: queriesAttempted,
+      queries_succeeded: queriesSucceeded,
+      failure_reasons: [...new Set([...failureReasons, error.message])],
       error: error.message,
       fallback_commands: [
         'find . -name "*.ts" -o -name "*.tsx" | xargs grep -l "<feature-keywords>"',
@@ -425,23 +493,50 @@ function calculateKeywordOverlap(keywords1, keywords2) {
  */
 export async function checkSemanticIndexStatus() {
   try {
-    const { count, error } = await supabase
+    // A head:true COUNT CANNOT TELL AN ABSENT TABLE FROM AN EMPTY ONE. Measured live against a
+    // fabricated table name in this repo: PostgREST returned error=null AND count=null — no error
+    // at all. So `available: count > 0` would have reported a dropped or renamed table as merely
+    // "empty" and told the operator to run the indexer, which is useless advice for a schema
+    // problem. The non-head select below distinguishes them: a missing relation raises PGRST205,
+    // an empty one returns an empty array. Same defect class as search_performed above — an
+    // instrument that cannot tell "nothing there" from "could not look" — in the same file.
+    const { data, error } = await supabase
       .from('codebase_semantic_index')
-      .select('*', { count: 'exact', head: true });
+      .select('id')
+      .limit(1);
 
     if (error) {
+      const absent = error.code === 'PGRST205' || error.code === '42P01';
       return {
         available: false,
-        error: error.message
+        entity_count: null,
+        table_present: !absent,
+        error: error.message,
+        message: absent
+          ? 'Semantic index TABLE DOES NOT EXIST - this is a schema problem, not an empty index; running the indexer will not help'
+          : `Semantic index unreadable: ${error.message}`
       };
     }
 
+    if (!data || data.length === 0) {
+      return {
+        available: false,
+        entity_count: 0,
+        table_present: true,
+        message: 'Semantic index is empty - run scripts/semantic-indexer.js first'
+      };
+    }
+
+    // Only pay for the exact count once the table is known to exist and be non-empty.
+    const { count } = await supabase
+      .from('codebase_semantic_index')
+      .select('*', { count: 'exact', head: true });
+
     return {
-      available: count > 0,
+      available: true,
       entity_count: count,
-      message: count > 0
-        ? `Semantic index available with ${count} entities`
-        : 'Semantic index is empty - run scripts/semantic-indexer.js first'
+      table_present: true,
+      message: `Semantic index available with ${count} entities`
     };
   } catch (err) {
     return {

--- a/lib/utils/validation-automation.js
+++ b/lib/utils/validation-automation.js
@@ -506,15 +506,22 @@ export async function checkSemanticIndexStatus() {
       .limit(1);
 
     if (error) {
+      // THREE OUTCOMES, NOT TWO — and the first version of this fix got that wrong in the exact
+      // way this SD exists to prevent. It wrote `table_present: !absent`, which turns ANY error
+      // that is not PGRST205/42P01 — RLS 42501, a network fault, an expired JWT — into a POSITIVE
+      // ASSERTION THAT THE TABLE EXISTS, manufactured from evidence that says nothing either way.
+      // The function whose whole purpose is telling ABSENT from EMPTY had acquired a third case,
+      // COULD-NOT-LOOK, and answered it definitively. Caught by a RETRO sub-agent before merge.
       const absent = error.code === 'PGRST205' || error.code === '42P01';
       return {
         available: false,
         entity_count: null,
-        table_present: !absent,
+        // null, not false: "we could not determine whether it exists" is its own answer.
+        table_present: absent ? false : null,
         error: error.message,
         message: absent
           ? 'Semantic index TABLE DOES NOT EXIST - this is a schema problem, not an empty index; running the indexer will not help'
-          : `Semantic index unreadable: ${error.message}`
+          : `Semantic index UNREADABLE - cannot tell whether the table exists: ${error.message}`
       };
     }
 

--- a/tests/unit/validation-automation-search-honesty.test.js
+++ b/tests/unit/validation-automation-search-honesty.test.js
@@ -1,0 +1,187 @@
+// The VALIDATION semantic search must not report a search it did not perform.
+// SD-LEO-INFRA-VALIDATION-DUPE-DETECTION-DEAD-001.
+//
+// WHAT THIS SUITE IS ACTUALLY GUARDING. searchExistingInfrastructure() used to set
+// `search_performed: true` in its results INITIALIZER, before attempting anything. When every
+// query failed, the per-query catch logged and continued, and the function returned
+// search_performed:true with empty arrays. A TOTAL FAILURE AND A CLEAN RESULT WERE THE SAME BYTES.
+// That is why a feature which has never once executed looked, for 289 days, exactly like a
+// feature that ran and found nothing.
+//
+// EVERY DISCRIMINATOR HERE IS TESTED FROM BOTH SIDES ON PURPOSE. A single-arm assertion
+// ("failure reports could_not_search") is satisfiable by a constant, and a constant would be a
+// new way to lie. So could_not_search is paired with searched, and absent-table is paired with
+// empty-table. If either pair collapses to one arm, the test stops measuring anything.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// GUARDED AT THE MODULE BOUNDARY. validation-automation.js builds a Supabase service client at
+// IMPORT TIME (module scope), so merely importing it in the unit tier would construct a real
+// client against whatever SUPABASE_URL is in the environment. Mocking here makes that
+// UNREACHABLE rather than merely unused — the distinction between a test that is safe and one
+// that happens not to have connected yet.
+const rpcMock = vi.fn();
+const selectMock = vi.fn();
+
+vi.mock('../../lib/supabase-client.js', () => ({
+  createSupabaseServiceClient: () => ({
+    rpc: (...args) => rpcMock(...args),
+    from: () => ({
+      select: (...args) => selectMock(...args),
+    }),
+  }),
+}));
+
+const embedMock = vi.fn();
+
+// THE MOCK DELIBERATELY EXPORTS BOTH FACTORY FUNCTIONS, INCLUDING THE ONE THE FIXED CODE NO
+// LONGER IMPORTS. Reason: this suite's value depends on it going RED against the pre-fix module,
+// and the pre-fix module imports getLLMClient. A mock exporting only getEmbeddingClient would make
+// the old module fail to LOAD, so every test would fail for a missing-export reason that has
+// nothing to do with the defect — a red that proves the mock is incomplete, not that the bug is
+// caught. getLLMClient is modelled with its REAL measured surface (complete/chat/messages present,
+// embeddings UNDEFINED) so the old `client.embeddings.create(...)` throws exactly the production
+// TypeError rather than a mock artifact.
+vi.mock('../../lib/llm/client-factory.js', () => ({
+  getEmbeddingClient: () => ({
+    embed: (...args) => embedMock(...args),
+    model: 'test-embedding-model',
+    dimensions: 1536,
+    provider: 'test',
+  }),
+  getLLMClient: async () => ({
+    complete: () => {},
+    chat: {},
+    messages: {},
+    // embeddings intentionally absent — this is the measured adapter surface, and the absence is
+    // the whole defect.
+  }),
+}));
+
+const { searchExistingInfrastructure, checkSemanticIndexStatus } =
+  await import('../../lib/utils/validation-automation.js');
+
+const SD = { title: 'a feature', description: 'some description of a feature', target_application: 'EHG_Engineer' };
+const vector = () => [Array.from({ length: 1536 }, () => 0.01)];
+
+beforeEach(() => {
+  rpcMock.mockReset();
+  selectMock.mockReset();
+  embedMock.mockReset();
+});
+
+describe('a search that could not run must never report that it searched', () => {
+  it('TS-1: EVERY query fails -> could_not_search, search_performed FALSE', async () => {
+    // THE REGRESSION TEST FOR THE 289-DAY DEFECT. Against the pre-fix code this returns
+    // search_performed:true with empty arrays, which is indistinguishable from a clean run.
+    embedMock.mockRejectedValue(new Error('embedding provider exploded'));
+
+    const r = await searchExistingInfrastructure(SD, { application: 'EHG_Engineer' });
+
+    expect(r.search_status).toBe('could_not_search');
+    expect(r.search_performed).toBe(false);
+    expect(r.queries_succeeded).toBe(0);
+    expect(r.queries_attempted).toBeGreaterThan(0);
+    expect(r.failure_reasons.join(' ')).toContain('embedding provider exploded');
+  });
+
+  it('TS-2: every query succeeds and genuinely matches nothing -> searched, search_performed TRUE', async () => {
+    // The other arm. Without it, an implementation that returned could_not_search
+    // UNCONDITIONALLY would pass TS-1 and be just as useless.
+    embedMock.mockResolvedValue(vector());
+    rpcMock.mockResolvedValue({ data: [], error: null });
+
+    const r = await searchExistingInfrastructure(SD, { application: 'EHG_Engineer' });
+
+    expect(r.search_status).toBe('searched');
+    expect(r.search_performed).toBe(true);
+    expect(r.queries_succeeded).toBeGreaterThan(0);
+    expect(r.summary.potential_duplicates_count).toBe(0);
+    // An empty result from a search that RAN is a real finding, and must look different from TS-1.
+    expect(r.failure_reasons).toEqual([]);
+  });
+
+  it('TS-3: partial failure -> searched, but the losses are recorded rather than hidden', async () => {
+    embedMock
+      .mockResolvedValueOnce(vector())
+      .mockRejectedValue(new Error('provider rate limited'));
+    rpcMock.mockResolvedValue({ data: [], error: null });
+
+    const r = await searchExistingInfrastructure(SD, { application: 'EHG_Engineer' });
+
+    expect(r.search_status).toBe('searched');
+    expect(r.queries_succeeded).toBeGreaterThan(0);
+    if (r.queries_attempted > r.queries_succeeded) {
+      expect(r.failure_reasons.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('an RPC error is a failed query, not a quiet empty result', async () => {
+    // This is the exact live condition found while building: semantic_code_search DOES NOT EXIST
+    // in the database (PGRST202, same code a fabricated RPC name returns). Pre-fix, this produced
+    // search_performed:true and a tidy zero.
+    embedMock.mockResolvedValue(vector());
+    rpcMock.mockResolvedValue({ data: null, error: { code: 'PGRST202', message: 'Could not find the function public.semantic_code_search' } });
+
+    const r = await searchExistingInfrastructure(SD, { application: 'EHG_Engineer' });
+
+    expect(r.search_status).toBe('could_not_search');
+    expect(r.search_performed).toBe(false);
+    expect(r.failure_reasons.join(' ')).toContain('semantic_code_search');
+  });
+});
+
+describe('the embedding call shape — the defect that matched neither factory', () => {
+  it('TS-6: embed() returns number[][], and the FLAT vector is what reaches the RPC', async () => {
+    // The old call was `client.embeddings.create(...)` returning `response.data[0].embedding` — a
+    // single vector needing no indexing. embed() returns an ARRAY OF VECTORS, so the [0] is
+    // load-bearing. A regression that passed the outer array through would send a number[][] to
+    // the RPC and fail confusingly at the database rather than here.
+    embedMock.mockResolvedValue(vector());
+    rpcMock.mockResolvedValue({ data: [], error: null });
+
+    await searchExistingInfrastructure(SD, { application: 'EHG_Engineer' });
+
+    expect(rpcMock).toHaveBeenCalled();
+    const passed = rpcMock.mock.calls[0][1].query_embedding;
+    expect(Array.isArray(passed)).toBe(true);
+    expect(passed).toHaveLength(1536);
+    expect(typeof passed[0]).toBe('number');   // flat, NOT an array of arrays
+  });
+
+  it('an unexpected embed() shape fails LOUDLY rather than reaching the RPC malformed', async () => {
+    embedMock.mockResolvedValue({ not: 'an array' });
+
+    const r = await searchExistingInfrastructure(SD, { application: 'EHG_Engineer' });
+
+    expect(r.search_status).toBe('could_not_search');
+    expect(rpcMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('index status must tell ABSENT from EMPTY', () => {
+  it('TS-7: a MISSING table is reported as a schema problem, not as an empty index', async () => {
+    // Measured live: a head:true count against a fabricated table returns error:null AND
+    // count:null — no error at all. So the previous head-only probe reported a dropped table as
+    // "empty" and advised running the indexer, which cannot help.
+    selectMock.mockReturnValue({ limit: () => Promise.resolve({ data: null, error: { code: 'PGRST205', message: "Could not find the table 'public.codebase_semantic_index'" } }) });
+
+    const s = await checkSemanticIndexStatus();
+
+    expect(s.available).toBe(false);
+    expect(s.table_present).toBe(false);
+    expect(s.message).toMatch(/DOES NOT EXIST|schema problem/i);
+    expect(s.message).not.toMatch(/run scripts\/semantic-indexer/i);
+  });
+
+  it('TS-8: a PRESENT but EMPTY table still advises running the indexer', async () => {
+    // Two-sided partner to TS-7. Either arm alone is satisfiable by a constant message.
+    selectMock.mockReturnValue({ limit: () => Promise.resolve({ data: [], error: null }) });
+
+    const s = await checkSemanticIndexStatus();
+
+    expect(s.available).toBe(false);
+    expect(s.table_present).toBe(true);
+    expect(s.entity_count).toBe(0);
+    expect(s.message).toMatch(/run scripts\/semantic-indexer/i);
+  });
+});

--- a/tests/unit/validation-automation-search-honesty.test.js
+++ b/tests/unit/validation-automation-search-honesty.test.js
@@ -173,6 +173,25 @@ describe('index status must tell ABSENT from EMPTY', () => {
     expect(s.message).not.toMatch(/run scripts\/semantic-indexer/i);
   });
 
+  it('TS-7b: an error that proves NEITHER — presence is UNKNOWN, never asserted true', async () => {
+    // THE ARM I ORIGINALLY SHIPPED WITHOUT A TEST, and it carried the defect this SD exists to
+    // remove. `table_present: !absent` made every non-absence error (RLS 42501, network, expired
+    // JWT) a POSITIVE claim that the table exists — manufactured from evidence that says nothing
+    // either way. I enforced two-sidedness on every other discriminator and skipped it on the arm
+    // I added last. A RETRO sub-agent caught it before merge, not me.
+    for (const err of [
+      { code: '42501', message: 'permission denied for table codebase_semantic_index' },
+      { code: 'PGRST301', message: 'JWT expired' },
+      { message: 'network unreachable' },
+    ]) {
+      selectMock.mockReturnValue({ limit: () => Promise.resolve({ data: null, error: err }) });
+      const s = await checkSemanticIndexStatus();
+      expect(s.available, `${err.code}: must not be available`).toBe(false);
+      expect(s.table_present, `${err.code}: presence must be UNKNOWN (null), never asserted`).toBeNull();
+      expect(s.message).toMatch(/UNREADABLE|cannot tell/i);
+    }
+  });
+
   it('TS-8: a PRESENT but EMPTY table still advises running the indexer', async () => {
     // Two-sided partner to TS-7. Either arm alone is satisfiable by a constant message.
     selectMock.mockReturnValue({ limit: () => Promise.resolve({ data: [], error: null }) });

--- a/tests/unit/validation-could-not-search-warning.test.js
+++ b/tests/unit/validation-could-not-search-warning.test.js
@@ -1,0 +1,51 @@
+// FR-4: a search that was ATTEMPTED and FAILED must reach the LEAD reader as a warning.
+// SD-LEO-INFRA-VALIDATION-DUPE-DETECTION-DEAD-001.
+//
+// THIS FILE EXISTS BECAUSE THE BRANCH IT COVERS MEASURED 0% AND I NEARLY SHIPPED IT THAT WAY.
+// A coverage run on the changed files reported lib/sub-agents/validation.js at 0/0/0/0 — the FR-4
+// deliverable had no test at all, while every other discriminator in this SD was two-sided. The
+// branch is ALSO unreachable in production today (its caller sits inside `if
+// (indexStatus.available)` and codebase_semantic_index has never held a row), so without this file
+// a guard that cannot fire yet and has never been executed by anything would be indistinguishable
+// from one that does not work.
+import { describe, it, expect } from 'vitest';
+import { buildCouldNotSearchWarning } from '../../lib/sub-agents/validation.js';
+
+describe('FR-4: could_not_search must not read as a clean result', () => {
+  it('raises a HIGH warning naming the failure when the search could not run', () => {
+    const w = buildCouldNotSearchWarning({
+      search_status: 'could_not_search',
+      queries_attempted: 3,
+      queries_succeeded: 0,
+      failure_reasons: ['rpc: Could not find the function public.semantic_code_search'],
+    });
+    expect(w).not.toBeNull();
+    expect(w.severity).toBe('HIGH');
+    expect(w.issue).toMatch(/DID NOT RUN/);
+    expect(w.issue).toContain('0 of 3');
+    expect(w.failure_reasons[0]).toMatch(/semantic_code_search/);
+    // The recommendation must forbid the exact misreading this SD exists to prevent.
+    expect(w.recommendation).toMatch(/absence of duplicates/i);
+  });
+
+  it('stays SILENT when the search genuinely ran — the other arm', () => {
+    // Without this, an implementation that warned unconditionally would pass the test above and
+    // make every clean validation look broken. A single arm is satisfiable by a constant.
+    expect(buildCouldNotSearchWarning({ search_status: 'searched', queries_attempted: 3, queries_succeeded: 3 })).toBeNull();
+  });
+
+  it('stays silent for not_attempted and for a missing/blank result', () => {
+    // not_attempted is a different state: nothing was tried, so there is nothing to warn about
+    // here — the index-unavailable branch reports that case separately.
+    expect(buildCouldNotSearchWarning({ search_status: 'not_attempted' })).toBeNull();
+    expect(buildCouldNotSearchWarning({})).toBeNull();
+    expect(buildCouldNotSearchWarning(null)).toBeNull();
+    expect(buildCouldNotSearchWarning(undefined)).toBeNull();
+  });
+
+  it('degrades safely when the counters are absent', () => {
+    const w = buildCouldNotSearchWarning({ search_status: 'could_not_search' });
+    expect(w.issue).toContain('0 of 0');
+    expect(w.failure_reasons).toEqual([]);
+  });
+});


### PR DESCRIPTION
**SD-LEO-INFRA-VALIDATION-DUPE-DETECTION-DEAD-001**

## Measured live, pre-fix and post-fix, identical conditions

```
before:  search_performed=true   duplicates=0   (no status field)
after:   search_performed=false  duplicates=0   status=could_not_search
```

Every query failed in both runs. The first line is the defect in one line: *"I searched and found no duplicates"* from a function that searched nothing.

## The SD's premise was wrong, and the correction matters more than the fix

The SD is filed as a 176-day regression from 2026-02-10. It is not. `codebase_semantic_index` **has never held a row** — created 2025-10-19, indexer added the same day, and no npm script, CI job or cron has ever invoked it. Corroborated three ways: `scope_embedding` populated for 0 of 5546 SDs, `embedding_generated_at` non-null zero times ever, and 0 of 28,999 `sub_agent_execution_results` (1375 of them VALIDATION) carrying a step-4 finding. The feature has been dark **289 days and was never once alive**; the 2026-02-10 change is a second latent defect stacked on something never turned on.

**The honest instrument then found a third layer on its first run:** `semantic_code_search` — the RPC this calls — **does not exist in the database** (PGRST202, the same code a fabricated RPC name returns; no migration anywhere creates it). Three independent deaths: no RPC, no rows, and a call shape matching no client. Any one alone would have been fatal. Pre-fix, all three together still produced `search_performed: true`.

## What actually caused the silence

`search_performed` was set `true` at `validation-automation.js:74` **in the results initializer**, before anything was attempted — an intention, never reconciled against outcome. The catch inside the loop never had to set it true; **it merely failed to set it false**. A fix aimed at the catch would leave the next failure mode lying by default. The outcome is now derived from `queries_attempted` vs `queries_succeeded` → `searched` | `could_not_search` | `not_attempted`, with `search_performed` computed for the existing reader at `:210`.

## The obvious fix was also wrong

`.embeddings.create()` matches **neither** factory — the chat adapter exposes `{complete, chat, messages}` with `embeddings` undefined, and the real exported `getEmbeddingClient` exposes `{embed, model, dimensions, provider}` with no `.embeddings` either. Deleting the shadowing wrapper is necessary but insufficient; repairing the import alone still throws. `embed()` returns `number[][]` even for one string (verified: 1×1536, matching declared dimensions), so the `[0]` is load-bearing. `scripts/semantic-indexer.js` — the *writer* of this same index — has always called `embed()` correctly. Writer-correct, consumer-wrong, for 289 days.

Also fixed, same defect class, same file: `checkSemanticIndexStatus` used a `head:true` count, and that returns `error: null` **and** `count: null` for a *missing* table (proven live against a fabricated name with a positive control). A dropped table read as "empty" and advised running the indexer — useless for a schema problem.

And the new signal has a reader, or it would be the same silence in a new costume: `validation.js` now raises a HIGH warning on `could_not_search`, since its duplicate alarm fires only when the count exceeds zero.

## Tests: 8, and the first red was untrustworthy

They go red against pre-fix code — but my initial mock exported only `getEmbeddingClient`, so the pre-fix module (which imports `getLLMClient`) failed to **load**, and every test failed for a missing-export reason unrelated to the defect. A red proving the mock is incomplete is not a red proving the bug is caught. The mock now models `getLLMClient` with its real measured surface. Every discriminator is two-sided — `could_not_search`/`searched`, absent-table/empty-table — because a single arm is satisfiable by a constant, and a constant would just be a new way to lie.

## Scope — please do not misread this

**This does not restore duplicate detection.** The index is empty and the RPC is missing; populating and creating them is out of scope. What ships is an instrument that reports its own blindness truthfully — which is what makes the turn-it-on-or-delete-it decision possible for the first time. Today that call cannot be made, because the thing reports success either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## ⚠️ Turning this on is THREE tasks, not one — read before scoping

A feature that reports `search_performed: true` **looks like it is nearly working.** It is not. Semantic code-duplicate detection is dead **three independent ways**, and any one alone is fatal. It has never functioned at any point in its existence.

**1. The RPC does not exist.** `supabase.rpc('semantic_code_search', {...})` returns `PGRST202` — the *identical* code a deliberately fabricated RPC name returns, run as a negative control in the same session. No migration anywhere in `database/migrations/` creates this function. **This was found by the repaired instrument on its first honest run** — pre-fix the failure was swallowed and reported as `search_performed: true` with zero duplicates.

**2. The index has never held a row.** `codebase_semantic_index`: 0 rows, verified *empty* and not *missing* (non-head select returned `data:[]` with no error; positive control returned a row; a fabricated table name returned `PGRST205`). Table created 2025-10-19, indexer added the same day, and **no npm script, CI job or cron has ever invoked it.** Corroborated: `scope_embedding` populated for 0 of 5546 SDs, `embedding_generated_at` non-null zero times ever, 0 of 28,999 sub-agent rows carrying a step-4 finding.

**3. The call shape matched no client** — fixed by this PR, and the only one of the three it fixes.

So switching this on requires: authoring and applying a migration for `semantic_code_search` with a signature matching the call site; running `scripts/semantic-indexer.js` and deciding who re-runs it on drift (an index populated once and never refreshed decays into a different kind of lie); plus the embedding repair here. **None of the first two is scoped by anyone**, and the value is unproven — nothing has ever measured whether semantic code-duplicate detection catches anything worth the cost.

**The honest options** for whoever picks this up: turn it on (three pieces of work, unproven value); delete it (defensible — it has never worked, and the duplicates it was meant to prevent were caught by humans and by a *different* live gate, `OVERLAPPING_SCOPE_DETECTION`, throughout); or leave it honest, which is the state this PR creates — costs nothing, reports truthfully, preserves the option.

That decision is *makeable* for the first time only because the instrument stopped claiming success. It is recorded in the SD metadata under `TURNING_THIS_ON_IS_THREE_TASKS_NOT_ONE__READ_BEFORE_SCOPING` as well as here.


---

## Correction — two things I claimed that a RETRO sub-agent disproved before merge

**The new signal does NOT have a live reader, and I said it did.** Above I wrote that the `could_not_search` warning has a reader "or it would be the same silence in a new costume." That warning sits inside `if (indexStatus.available)`, and `available` is **false today and stays false** until the index is populated — which nobody has scoped. The warning is genuinely **self-arming**: it fires the moment the index has rows, which is the right shape for a guard whose trigger condition does not exist yet. But it is **inert in production right now**, and describing it as a live alarm was exactly the class of overclaim this SD exists to remove. Now marked inert in the code.

**And I took my proof at the producer, not the consumer.** The pre/post measurement (`search_performed=true` → `false`) was obtained by calling `searchExistingInfrastructure()` directly — which, while the index is empty, is the *only* path that reaches it. That proves **the function** became honest. It does not prove **the system** did, because the consumer never runs. Verify at the consumer, not at the thing you edited.

**A third defect: I shipped the fixed defect class inside the fix.** `table_present: !absent` turned any error that is *not* `PGRST205`/`42P01` — RLS `42501`, a network fault, an expired JWT — into a **positive assertion that the table exists**, manufactured from evidence that proves nothing either way. The function whose whole purpose is telling *absent* from *empty* had acquired a third case, *could-not-look*, and answered it definitively — one function below the code removing the identical pattern. It is now `null` (could-not-determine is its own answer). **It was also the only arm with no test**: TS-7 covered absent→false, TS-8 covered empty→true, and the arm I added last had nothing driving it. I enforced two-sidedness on every other discriminator in the suite and skipped it precisely where I had just written new logic. TS-7b now drives three non-absence errors and asserts presence is UNKNOWN, never asserted. Tests 8 → 9.
