### PR TITLE
feat(SD-LEO-INFRA-SESSION-TICK-DAEMONS-001): close the prior session id at rotation so tick daemons stop heartbeating dead sessions

### DIFF
--- a/lib/fleet/daemon-census.cjs
+++ b/lib/fleet/daemon-census.cjs
@@ -1,0 +1,100 @@
+// SD-LEO-INFRA-SESSION-TICK-DAEMONS-001 FR-4 — the assertion that would have caught this.
+//
+// The accumulation ran for DAYS because nothing ever compared "how many daemons are stamping" to
+// "how many conversations are alive". A one-time cleanup without this assertion buys one quiet
+// week; the whole point of FR-4 is the second half.
+//
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+// THE SIGNATURE, AND WHY IT IS NOT A COUNT COMPARISON
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+// "Daemon count materially exceeds live conversations" is the right instinct but the wrong
+// instrument: a bare count difference tells an operator that something is wrong and nothing about
+// what to do, and it needs a definition of "live conversation" that does not exist.
+//
+// A leaked daemon has an exact, per-row signature instead. heartbeat_at and process_alive_at are
+// BOTH written by the daemon, so two agreeing liveness signals are really one signal. last_tool_at
+// is the only value the CONVERSATION writes, which makes it the sole independent discriminator.
+// So a leak is: the daemon is stamping RIGHT NOW while the conversation has not acted in a long
+// time. That names the offending session ids, which is actionable, and it degrades to a count for
+// anyone who just wants a number.
+//
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+// WHERE THE THRESHOLD COMES FROM — MEASURED, NOT PICKED
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+// A PARKED /loop worker is alive but tool-silent between wakeups, so it shares the "stale
+// last_tool_at" half of the signature. Getting this wrong releases parked workers, which is the
+// false-death outage session-tick.cjs:181-184 calls the seam all five prior attempts fell down.
+//
+// ScheduleWakeup CLAMPS its delay to [60, 3600] seconds, so a parked worker's last_tool_at cannot
+// exceed roughly one hour plus one turn by construction. Census of this host on 2026-08-04, all
+// 5,910 non-released rows: 11 were heartbeat-fresh; 10 of those had last_tool_at under 1h, and
+// exactly ONE was 51h stale — b22451df, the session this SD witnessed. Nothing at all fell between
+// 1h and 24h.
+//
+// STALE_MS sits at 6h: six times the structural parked-worker ceiling, and inside a measured empty
+// gap rather than next to a cluster. It is an ALARM threshold, never a kill threshold — nothing
+// here terminates or releases anything, which is why a threshold is admissible at all. The FR-1
+// closure that DOES write deliberately reads no clock.
+
+/** Daemon considered to be stamping right now. */
+const FRESH_MS = 5 * 60 * 1000;
+/** Conversation considered long-dead. Six times the [60,3600]s ScheduleWakeup ceiling. */
+const STALE_MS = 6 * 60 * 60 * 1000;
+
+const ms = (t) => {
+  if (!t) return null;
+  const v = new Date(t).getTime();
+  return Number.isFinite(v) ? v : null;
+};
+
+/**
+ * Pure. Which rows carry the leaked-daemon signature?
+ *
+ * A row qualifies when the daemon is stamping (heartbeat_at within freshMs) AND the conversation
+ * is long silent (last_tool_at present and older than staleMs).
+ *
+ * A MISSING last_tool_at is NOT a leak. Absence is not evidence — a session that has genuinely
+ * never run a tool is indistinguishable from one whose column was never populated, and alarming on
+ * "unknown" is how an assertion trains its operator to ignore it. Measured: zero heartbeat-fresh
+ * rows on this host have a null last_tool_at, so this costs nothing today and stays honest if that
+ * changes.
+ *
+ * @param {object} o
+ * @param {Array<{session_id:string, heartbeat_at:*, last_tool_at:*}>} o.rows
+ * @param {number} o.now  epoch ms — injected so the predicate is testable and never reads a clock itself
+ * @returns {Array<{session_id:string, heartbeatAgeMs:number, lastToolAgeMs:number}>}
+ */
+function leakedDaemonSessions({ rows, now, freshMs = FRESH_MS, staleMs = STALE_MS } = {}) {
+  if (!Array.isArray(rows) || !Number.isFinite(now)) return [];
+  const out = [];
+  for (const r of rows) {
+    if (!r || !r.session_id) continue;
+    const hb = ms(r.heartbeat_at);
+    const lt = ms(r.last_tool_at);
+    if (hb === null || lt === null) continue;      // absent => not evidence
+    const hbAge = now - hb;
+    const ltAge = now - lt;
+    if (hbAge >= 0 && hbAge <= freshMs && ltAge > staleMs) {
+      out.push({ session_id: r.session_id, heartbeatAgeMs: hbAge, lastToolAgeMs: ltAge });
+    }
+  }
+  return out;
+}
+
+/**
+ * The assertion itself. ok=false means the census diverged and the caller should exit non-zero.
+ */
+function assertDaemonCensus({ rows, now, freshMs, staleMs } = {}) {
+  const leaked = leakedDaemonSessions({ rows, now, freshMs, staleMs });
+  return {
+    ok: leaked.length === 0,
+    leaked,
+    detail: leaked.length === 0
+      ? 'census clean — every stamping daemon has a conversation that acted recently'
+      : `${leaked.length} daemon(s) stamping for a conversation that has not acted in over ` +
+        `${Math.round((staleMs ?? STALE_MS) / 3600000)}h: ` +
+        leaked.map((l) => `${l.session_id.slice(0, 8)}(${Math.round(l.lastToolAgeMs / 3600000)}h)`).join(', '),
+  };
+}
+
+module.exports = { leakedDaemonSessions, assertDaemonCensus, FRESH_MS, STALE_MS };

--- a/lib/fleet/graceful-kill.mjs
+++ b/lib/fleet/graceful-kill.mjs
@@ -94,17 +94,34 @@ export function isWorkDurableAfterPrepark(pre, wasDirty) {
  * (claude_sessions.pid) is known to sometimes hold a shell wrapper.
  */
 export function reconcilePid({ dbPid, markerPid, pidIsClaudeResult }) {
-  if (!dbPid) return { ok: false, detail: 'claude_sessions.pid is null — nothing to verify or kill' };
-  if (markerPid && markerPid !== dbPid) {
+  // SD-LEO-INFRA-SESSION-TICK-DAEMONS-001 FR-3 — fall back to the tick marker when the row never
+  // recorded a pid. A null claude_sessions.pid used to end the operation here, which made exactly
+  // the daemons this SD is about UNKILLABLE: a leaked daemon whose row has no pid could not be
+  // identified at all, so there was no way to clean one up by hand.
+  //
+  // The marker is the right fallback because it is the artifact that ties a pid back to the
+  // session that owns it (session-tick.cjs:579), and session-tick REWRITES it on parent-PID
+  // adoption, so it tracks rotation rather than going stale the way the row's pid does.
+  //
+  // THE FALLBACK CHANGES WHICH PID WE CONSIDER, NEVER WHETHER WE VERIFY IT. Everything below is
+  // unchanged and still gates on a positive claude.exe probe; a marker-sourced pid earns no
+  // trust the DB pid would not have earned. The caller must probe THIS pid — see the call site.
+  const pid = dbPid || markerPid;
+  if (!pid) {
+    return { ok: false, detail: 'claude_sessions.pid is null and no tick marker records a pid — nothing to verify or kill' };
+  }
+  // Only meaningful when the row HAS a pid: two sources naming different processes is a genuine
+  // ambiguity. A null dbPid is not a disagreement, it is an absence.
+  if (dbPid && markerPid && markerPid !== dbPid) {
     return { ok: false, detail: `pid disagreement: claude_sessions.pid=${dbPid} but the SessionStart marker says ${markerPid} — refusing to guess which is the agent` };
   }
   if (pidIsClaudeResult === false) {
-    return { ok: false, detail: `pid ${dbPid} is not a live claude.exe — it is most likely the shell wrapper that claude_sessions.pid falls back to (process.ppid), and killing it would terminate the wrong process` };
+    return { ok: false, detail: `pid ${pid} is not a live claude.exe — it is most likely the shell wrapper that claude_sessions.pid falls back to (process.ppid), and killing it would terminate the wrong process` };
   }
   if (pidIsClaudeResult !== true) {
-    return { ok: false, detail: `could not confirm pid ${dbPid} is a live claude.exe; refusing rather than killing an unverified pid` };
+    return { ok: false, detail: `could not confirm pid ${pid} is a live claude.exe; refusing rather than killing an unverified pid` };
   }
-  return { ok: true, pid: dbPid };
+  return { ok: true, pid, source: dbPid ? 'db' : 'marker' };
 }
 
 /**
@@ -139,10 +156,16 @@ export async function gracefulKillSession(supabase, sessionId, deps = {}) {
     steps.push('identify');
     const session = await getSession();
     if (!session) return { ...verdict('refused', 'identify', `no session row for ${sessionId}`), steps };
+    const markerPid = readMarkerPid ? readMarkerPid(sessionId) : null;
+    // FR-3: probe the pid we would ACTUALLY kill. This used to probe session.pid unconditionally,
+    // which was harmless only while a null dbPid ended the operation. Now that the marker can
+    // supply the pid, probing session.pid would verify one process and terminate another — the
+    // precise shape of defect this module's verifyGone comment already refuses to ship.
+    const probePid = session.pid || markerPid;
     const rec = reconcilePid({
       dbPid: session.pid,
-      markerPid: readMarkerPid ? readMarkerPid(sessionId) : null,
-      pidIsClaudeResult: pidIsClaude ? pidIsClaude(session.pid) : undefined,
+      markerPid,
+      pidIsClaudeResult: pidIsClaude ? pidIsClaude(probePid) : undefined,
     });
     if (!rec.ok) return { ...verdict('refused', 'identify', rec.detail), steps };
 

--- a/lib/fleet/graceful-kill.test.js
+++ b/lib/fleet/graceful-kill.test.js
@@ -159,7 +159,86 @@ describe('FR2-IDENTIFY: refuse rather than kill the wrong process', () => {
 
   it('reconcilePid is pure and refuses a null pid', () => {
     expect(reconcilePid({ dbPid: null }).ok).toBe(false);
-    expect(reconcilePid({ dbPid: 1, markerPid: 1, pidIsClaudeResult: true })).toEqual({ ok: true, pid: 1 });
+    expect(reconcilePid({ dbPid: 1, markerPid: 1, pidIsClaudeResult: true })).toEqual({ ok: true, pid: 1, source: 'db' });
+  });
+
+  // SD-LEO-INFRA-SESSION-TICK-DAEMONS-001 FR-3 / TS-6
+  describe('FR-3: marker fallback when claude_sessions.pid is null', () => {
+    it('identifies via the marker pid when the row never recorded one', () => {
+      expect(reconcilePid({ dbPid: null, markerPid: 4242, pidIsClaudeResult: true }))
+        .toEqual({ ok: true, pid: 4242, source: 'marker' });
+    });
+
+    it('still refuses when NEITHER source has a pid', () => {
+      expect(reconcilePid({ dbPid: null, markerPid: null, pidIsClaudeResult: true }).ok).toBe(false);
+    });
+
+    // The fallback must not buy the marker any trust the DB pid would not have earned.
+    it('refuses a marker pid that is not a live claude.exe', () => {
+      expect(reconcilePid({ dbPid: null, markerPid: 4242, pidIsClaudeResult: false }).ok).toBe(false);
+    });
+
+    it('refuses a marker pid whose probe told us nothing (PROBE_FAILED)', () => {
+      expect(reconcilePid({ dbPid: null, markerPid: 4242, pidIsClaudeResult: undefined }).ok).toBe(false);
+    });
+
+    it('a null dbPid is an absence, not a disagreement — it does not trip the mismatch refusal', () => {
+      const r = reconcilePid({ dbPid: null, markerPid: 4242, pidIsClaudeResult: true });
+      expect(r.ok).toBe(true);
+      expect(r.detail).toBeUndefined();
+    });
+
+    it('still refuses when both sources name DIFFERENT live pids', () => {
+      expect(reconcilePid({ dbPid: 1, markerPid: 2, pidIsClaudeResult: true }).ok).toBe(false);
+    });
+  });
+});
+
+// SD-LEO-INFRA-SESSION-TICK-DAEMONS-001 FR-3 — the CALL SITE, which is the load-bearing half.
+// reconcilePid choosing the marker pid is useless if the caller probes a different one: the run
+// would verify one process and then terminate another.
+describe('FR-3 call site: the pid that gets probed is the pid that gets killed', () => {
+  it('probes and kills the MARKER pid when the row has no pid', async () => {
+    const { d } = deps({
+      getSession: vi.fn(async () => ({ pid: null, sd_key: 'QF-1', worktree_path: 'C:/wt' })),
+      readMarkerPid: vi.fn(() => 7777),
+    });
+    const r = await gracefulKillSession({}, 's1', d);
+    expect(r.outcome).toBe('killed');
+    expect(d.pidIsClaude).toHaveBeenCalledWith(7777);   // probed the marker pid, not null
+    expect(d.kill).toHaveBeenCalledWith(7777, 'SIGTERM');
+    expect(d.verifyGone).toHaveBeenCalledWith(7777);
+  });
+
+  it('refuses — and kills NOTHING — when the row has no pid and no marker exists', async () => {
+    const { d } = deps({
+      getSession: vi.fn(async () => ({ pid: null, sd_key: 'QF-1', worktree_path: 'C:/wt' })),
+      readMarkerPid: vi.fn(() => null),
+    });
+    const r = await gracefulKillSession({}, 's1', d);
+    expect(r.outcome).toBe('refused');
+    expect(d.kill).not.toHaveBeenCalled();
+  });
+
+  it('a marker pid that fails the claude.exe probe is refused, not killed', async () => {
+    const { d } = deps({
+      getSession: vi.fn(async () => ({ pid: null, sd_key: 'QF-1', worktree_path: 'C:/wt' })),
+      readMarkerPid: vi.fn(() => 7777),
+      pidIsClaude: vi.fn(() => false),
+    });
+    const r = await gracefulKillSession({}, 's1', d);
+    expect(r.outcome).toBe('refused');
+    expect(d.kill).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL — the DB pid still wins when present, so the fallback is not silently always-on', async () => {
+    const { d } = deps({
+      getSession: vi.fn(async () => ({ pid: 4242, sd_key: 'QF-1', worktree_path: 'C:/wt' })),
+      readMarkerPid: vi.fn(() => 4242),
+    });
+    const r = await gracefulKillSession({}, 's1', d);
+    expect(r.outcome).toBe('killed');
+    expect(d.kill).toHaveBeenCalledWith(4242, 'SIGTERM');
   });
 });
 

--- a/lib/sessions/rotation-closure.cjs
+++ b/lib/sessions/rotation-closure.cjs
@@ -29,8 +29,68 @@
 // defect for loop_state. Read the other way it is the guarantee this FR needs: a SessionStart-hosted
 // closure sees every rotation and never sees a parked worker waking up.
 
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+// WHERE cc_parent_pid ACTUALLY LIVES, AND WHY THE WIRING READS FILES INSTEAD OF THE TABLE
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+// The EXEC handoff for this FR said to fetch rows WHERE cc_parent_pid = process.ppid. Both halves
+// of that are wrong, and both were caught by measuring rather than by reading:
+//
+//   1. `cc_parent_pid` IS NOT A COLUMN on claude_sessions. Probed live: PostgREST answers
+//      "column claude_sessions.cc_parent_pid does not exist". It exists ONLY on the tick marker
+//      .claude/pids/tick-<sid>.json (session-tick.cjs:99) and inside event payloads. This one
+//      fails LOUD, which is the only reason it did not ship silently.
+//   2. `process.ppid || process.pid` is the DEGRADED FALLBACK, not the canonical derivation.
+//      capture-session-id.cjs:492-495 — the process that WRITES the marker — uses
+//      findClaudeCodePid() and logs outcome:'degraded' when it has to fall back to ppid. Joining
+//      on ppid would therefore MISS every marker written the normal way, and would have failed
+//      SILENTLY: zero rows closed, FR looks wired, defect fully intact.
+//
+// The obvious substitute is claude_sessions.tty, which this very hook writes as `win-<ppid>`.
+// MEASURED AND REJECTED: across all 12,914 rows on this host, tty has a degenerate bucket —
+// 'unknown' holds 3,582 sessions, 3,228 of them non-terminal, belonging to unrelated processes.
+// Keying closure on tty would mass-release the entire host's live fleet on one hook run. That is
+// the false-death outage this SD exists to avoid, reached by a different door.
+//
+// So the join key is the marker file, which is the artifact that ties a pid to a session
+// (session-tick.cjs:579 calls it exactly that). It is also SELF-CLEANING: the daemon unlinks its
+// marker on exit (session-tick.cjs:110), so a marker naming a dead pid means a HARD-KILLED daemon,
+// not ordinary accumulation. That bounds the only residual false-positive — Windows pid recycling
+// handing a stale marker our pid — to a window that requires both a hard kill and a recycle.
+
+const fs = require('fs');
+const path = require('path');
+
 /** Statuses a row can hold and still be worth closing. Terminal rows are left alone. */
 const TERMINAL_STATUSES = Object.freeze(['released', 'exited', 'killed', 'reaped']);
+
+/**
+ * Read .claude/pids/tick-*.json and return session_id -> cc_parent_pid.
+ *
+ * Pure apart from the directory read. Every per-file failure is skipped rather than thrown: a
+ * half-written marker (the writer is not atomic) must not take out SessionStart.
+ *
+ * @param {string} pidsDir
+ * @returns {Map<string, number|string>}
+ */
+function readTickMarkers(pidsDir) {
+  const out = new Map();
+  let files;
+  try {
+    files = fs.readdirSync(pidsDir);
+  } catch {
+    return out; // no marker dir yet — nothing has ticked on this host
+  }
+  for (const f of files) {
+    if (!f.startsWith('tick-') || !f.endsWith('.json')) continue;
+    try {
+      const m = JSON.parse(fs.readFileSync(path.join(pidsDir, f), 'utf8'));
+      // Require BOTH fields. A marker missing cc_parent_pid must never collapse into a
+      // match-anything value — that is how a filter turns into a fleet-wide release.
+      if (m && m.session_id && m.cc_parent_pid) out.set(String(m.session_id), m.cc_parent_pid);
+    } catch { /* skip unreadable/partial marker */ }
+  }
+  return out;
+}
 
 /**
  * Pure. Which prior rows does this rotation close?
@@ -52,4 +112,4 @@ function sessionsToClose({ currentSessionId, parentPid, rows } = {}) {
     .map((r) => r.session_id);
 }
 
-module.exports = { sessionsToClose, TERMINAL_STATUSES };
+module.exports = { sessionsToClose, readTickMarkers, TERMINAL_STATUSES };

--- a/lib/sessions/rotation-closure.cjs
+++ b/lib/sessions/rotation-closure.cjs
@@ -1,0 +1,55 @@
+// SD-LEO-INFRA-SESSION-TICK-DAEMONS-001 FR-1 — which prior session rows a rotation closes.
+//
+// THE DEFECT. /clear (and compaction resume) rotates the conversation to a NEW session_id while
+// the Claude Code process survives. session-tick.cjs has exactly two exits: parent-PID death
+// (:181, which DELIBERATELY survives /clear) and the 0-row PATCH self-exit once the row reaches
+// status='released' (:350). Nothing flips either at rotation, so the old daemon is immortal and
+// stamps BOTH heartbeat_at and process_alive_at every 30s for a conversation that can never act
+// again. Verified live at LEAD: b22451df was still heartbeat-fresh with last_tool_at ~2 days stale.
+//
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+// WHY THIS PREDICATE READS NO CLOCK, AND WHY THAT IS THE WHOLE DESIGN
+// ═══════════════════════════════════════════════════════════════════════════════════════════════
+// A PARKED /loop worker and a ROTATED-OUT session are indistinguishable by activity: neither is
+// using tools, neither is advancing last_tool_at, and both can sit quiet for many minutes. Any
+// predicate of the form "no activity for N minutes" therefore closes both.
+//
+// session-tick.cjs:181-184 records what that costs, verbatim: removing PID rediscovery
+// "re-breaks parked workers and trades false-life for false-death — the seam all five prior
+// attempts at this defect fell down."
+//
+// So the trigger is the ROTATION EVENT, which is a thing that HAPPENED and is known exactly when
+// it happens. A parked worker is excluded STRUCTURALLY rather than carefully: it has not rotated,
+// so its session_id still matches the current one, so it is never selected. There is no threshold
+// to tune and no window to get wrong.
+//
+// The host hook matters for the same reason. SessionStart fires on /clear and on compaction resume
+// (both ROTATE the id) and does NOT fire when a ScheduleWakeup tick resumes an already-running
+// session — see the header of scripts/hooks/loop-state-resume-clear.cjs, which documents that as a
+// defect for loop_state. Read the other way it is the guarantee this FR needs: a SessionStart-hosted
+// closure sees every rotation and never sees a parked worker waking up.
+
+/** Statuses a row can hold and still be worth closing. Terminal rows are left alone. */
+const TERMINAL_STATUSES = Object.freeze(['released', 'exited', 'killed', 'reaped']);
+
+/**
+ * Pure. Which prior rows does this rotation close?
+ *
+ * @param {object} o
+ * @param {string} o.currentSessionId  the session id SessionStart just registered
+ * @param {number|string} o.parentPid  cc_parent_pid of the surviving Claude Code process
+ * @param {Array<{session_id:string, cc_parent_pid:*, status:string}>} o.rows  candidate rows
+ * @returns {Array<string>} session_ids to mark released
+ */
+function sessionsToClose({ currentSessionId, parentPid, rows } = {}) {
+  if (!currentSessionId || parentPid === undefined || parentPid === null) return [];
+  if (!Array.isArray(rows)) return [];
+  const pid = String(parentPid);
+  return rows
+    .filter((r) => r && String(r.cc_parent_pid) === pid)     // same surviving CC process
+    .filter((r) => r.session_id && r.session_id !== currentSessionId)  // ROTATED OUT — the whole test
+    .filter((r) => !TERMINAL_STATUSES.includes(String(r.status || '').toLowerCase()))
+    .map((r) => r.session_id);
+}
+
+module.exports = { sessionsToClose, TERMINAL_STATUSES };

--- a/scripts/assert-daemon-census.mjs
+++ b/scripts/assert-daemon-census.mjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-SESSION-TICK-DAEMONS-001 FR-4 — run the census assertion against the live fleet.
+ *
+ *   node scripts/assert-daemon-census.mjs             # assert; exit 1 if the census diverged
+ *   node scripts/assert-daemon-census.mjs --cleanup   # also release the leaked sessions
+ *
+ * The predicate and its threshold rationale live in lib/fleet/daemon-census.cjs. This file is only
+ * the live plumbing, deliberately: the logic is unit-tested (including TS-7, a control proving the
+ * assertion can actually fail), and a script that cannot be tested should not hold the reasoning.
+ *
+ * --cleanup writes status='released', which is the same lever FR-1 pulls: the daemon's PATCH
+ * filters status=in.(active,idle,stale) (session-tick.cjs:331), so a released row 0-rows its next
+ * write and every daemon serving it exits itself.
+ *
+ * READS THE WHOLE POPULATION, never a capped page. A capped fetch grouped in memory measures the
+ * cap, and a census that silently measures its own limit is worse than no census.
+ */
+import 'dotenv/config';
+import os from 'node:os';
+import { createRequire } from 'node:module';
+import { createClient } from '@supabase/supabase-js';
+
+const { assertDaemonCensus } = createRequire(import.meta.url)('../lib/fleet/daemon-census.cjs');
+
+const cleanup = process.argv.includes('--cleanup');
+const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const hostname = os.hostname();
+
+async function fetchAll() {
+  const rows = [];
+  for (let from = 0; ; from += 1000) {
+    const { data, error } = await supabase
+      .from('claude_sessions')
+      .select('session_id,status,heartbeat_at,last_tool_at')
+      .eq('hostname', hostname)
+      .neq('status', 'released')
+      .range(from, from + 999);
+    if (error) throw new Error(error.message);
+    if (!data || data.length === 0) break;
+    rows.push(...data);
+    if (data.length < 1000) break;
+  }
+  return rows;
+}
+
+const rows = await fetchAll();
+const result = assertDaemonCensus({ rows, now: Date.now() });
+
+console.log(`daemon census — host=${hostname} non-released rows=${rows.length}`);
+console.log(result.ok ? `PASS: ${result.detail}` : `FAIL: ${result.detail}`);
+
+if (result.ok) process.exit(0);
+
+for (const l of result.leaked) {
+  console.log(`  ${l.session_id}  heartbeat ${Math.round(l.heartbeatAgeMs / 1000)}s ago, ` +
+              `last tool ${Math.round(l.lastToolAgeMs / 3600000)}h ago`);
+}
+
+if (!cleanup) {
+  console.log('\nre-run with --cleanup to release these rows (their daemons then self-exit).');
+  process.exit(1);
+}
+
+const ids = result.leaked.map((l) => l.session_id);
+const { error } = await supabase.from('claude_sessions').update({ status: 'released' }).in('session_id', ids);
+if (error) { console.log('cleanup FAILED: ' + error.message); process.exit(1); }
+console.log(`\nreleased ${ids.length} leaked session(s). Re-run without --cleanup to confirm.`);
+process.exit(0);

--- a/scripts/hooks/session-register.cjs
+++ b/scripts/hooks/session-register.cjs
@@ -237,6 +237,103 @@ async function captureAccountIdentity(supabase, sessionId) {
   }
 }
 
+/**
+ * SD-LEO-INFRA-SESSION-TICK-DAEMONS-001 FR-1 — close the session ids this rotation replaced.
+ *
+ * /clear and compaction-resume mint a NEW session_id while the Claude Code process survives.
+ * session-tick.cjs has exactly two exits — parent-PID death (:181, which DELIBERATELY survives
+ * /clear) and the 0-row PATCH self-exit (:350) — and nothing flipped either at rotation, so the
+ * outgoing session's daemon became immortal, stamping heartbeat_at AND process_alive_at every 30s
+ * for a conversation that can never act again.
+ *
+ * status='released' is necessary and SUFFICIENT: the daemon's PATCH filters
+ * `status=in.(active,idle,stale)` (session-tick.cjs:331), so releasing the row 0-rows its next
+ * write and it exits itself. Verified at the consumer, not at this write.
+ *
+ * WHY THIS HOOK. SessionStart fires on /clear and on compaction resume (both ROTATE the id) and
+ * does NOT fire when a ScheduleWakeup tick resumes an already-running session — documented in the
+ * header of loop-state-resume-clear.cjs as a defect for loop_state. Read the other way it is the
+ * guarantee this FR needs: we see every rotation and never see a parked worker waking up.
+ *
+ * A PARKED /loop WORKER IS EXCLUDED STRUCTURALLY, NOT CAREFULLY. One Claude Code process hosts one
+ * conversation, so a row sharing our cc_parent_pid with a DIFFERENT session_id has necessarily
+ * rotated out. There is no elapsed-time, last_tool_at or heartbeat condition anywhere below, and
+ * adding one would re-open the seam session-tick.cjs:181-184 names verbatim: it "trades false-life
+ * for false-death — the seam all five prior attempts at this defect fell down."
+ *
+ * Fire-and-forget and totally swallowed: this runs at every SessionStart on the host, so it must
+ * never be able to stop a session from starting.
+ */
+async function closeRotatedOutSessions(supabase, currentSessionId, overrides = {}) {
+  try {
+    const { sessionsToClose, readTickMarkers } = require('../../lib/sessions/rotation-closure.cjs');
+
+    // Derive the pid EXACTLY as capture-session-id.cjs:492-493 does — that process writes the
+    // markers we are about to join against, so agreeing by construction is the point. Using this
+    // hook's own process.ppid instead would silently match nothing (see rotation-closure.cjs
+    // header): findClaudeCodePid() is primary, ppid only its logged-degraded fallback.
+    //
+    // `overrides` exists so tests can pin the pid and marker dir. Production passes neither: a
+    // test that had to stub live PID discovery would be asserting against its own stub.
+    let parentPid = overrides.parentPid;
+    if (parentPid === undefined) {
+      const { findClaudeCodePid } = require('./capture-session-id.cjs');
+      parentPid = findClaudeCodePid() || process.ppid || process.pid;
+    }
+
+    const markers = readTickMarkers(
+      overrides.pidsDir || path.resolve(__dirname, '../../.claude/pids')
+    );
+    const candidateIds = [...markers.keys()];
+    if (!candidateIds.length) return;
+
+    // FAIL-CLOSED IDENTITY GUARD. This predicate is "everything on our pid EXCEPT us", so it is
+    // only as safe as `us`. Measured on live data: with a correct currentSessionId the pid-22196
+    // group closes exactly the one rotated-out id; with an id matching NO row it closes BOTH —
+    // including the live session. Nothing downstream notices, because releasing our own row is a
+    // perfectly ordinary-looking write.
+    //
+    // What made that unreachable in practice was only that our own marker usually does not exist
+    // yet when this runs (the new daemon spawns concurrently), so our row is never among the
+    // candidates. That is safety by coincidence, not by design, and it evaporates the moment the
+    // spawn order changes. So: if we DO have a marker, it must name the pid we are about to act
+    // on. Disagreement means identity resolution and the marker record contradict each other —
+    // exactly the smear this file's getCurrentSessionId() comment describes — and the only safe
+    // reading of a contradiction is to close nothing.
+    const ownMarkerPid = markers.get(String(currentSessionId));
+    if (ownMarkerPid !== undefined && String(ownMarkerPid) !== String(parentPid)) {
+      process.stderr.write(
+        `[session-register] rotation.skipped reason=identity_pid_mismatch ` +
+        `marker=${ownMarkerPid} discovered=${parentPid}\n`
+      );
+      return;
+    }
+
+    const { data, error } = await supabase
+      .from('claude_sessions').select('session_id,status').in('session_id', candidateIds);
+    if (error || !data) return;
+
+    // The predicate's row shape carries cc_parent_pid, which claude_sessions does NOT have as a
+    // column — the marker supplies it. Attaching it here keeps the shipped, unit-tested predicate
+    // untouched and confines the file-join to the wiring.
+    const rows = data.map((r) => ({ ...r, cc_parent_pid: markers.get(r.session_id) }));
+    const toClose = [...new Set(sessionsToClose({ currentSessionId, parentPid, rows }))];
+    if (!toClose.length) return;
+
+    const { error: relErr } = await supabase
+      .from('claude_sessions').update({ status: 'released' }).in('session_id', toClose);
+    process.stderr.write(
+      `[session-register] rotation.closed pid=${parentPid} n=${toClose.length} ` +
+      `ids=${toClose.map((s) => String(s).slice(0, 8)).join(',')}` +
+      (relErr ? ` error=${relErr.message}` : '') + `\n`
+    );
+  } catch (err) {
+    process.stderr.write(
+      `[session-register] rotation.failed reason=${(err?.message || String(err)).slice(0, 200)}\n`
+    );
+  }
+}
+
 async function main() {
   let supabase;
   try {
@@ -335,6 +432,10 @@ async function main() {
       .eq('session_id', sessionId)
       .eq('loop_state', LOOP_STATE_AWAITING_TICK);
   } catch { /* best-effort observability; never block SessionStart */ }
+
+  // SD-LEO-INFRA-SESSION-TICK-DAEMONS-001 (FR-1). Last, and awaited only so its stderr lands
+  // inside this hook's output — it cannot throw (fully wrapped) and cannot block startup.
+  await closeRotatedOutSessions(supabase, sessionId);
 }
 
 // SD-LEO-INFRA-FIX-SESSION-REGISTER-001: only auto-invoke main() when this
@@ -367,6 +468,8 @@ if (require.main === module) {
 
 module.exports = {
   getCurrentSessionId, main, emitSessionCreated,
+  // FR-1 — exported so the rotation closure is testable without running SessionStart.
+  closeRotatedOutSessions,
   // QF-20260726-514 — exported so the account capture is testable without running SessionStart.
   resolveAccountIdentity, captureAccountIdentity,
 };

--- a/tests/acceptance/rotation-closes-all-daemons.cjs
+++ b/tests/acceptance/rotation-closes-all-daemons.cjs
@@ -1,0 +1,96 @@
+/**
+ * SD-LEO-INFRA-SESSION-TICK-DAEMONS-001 FR-2 / TS-3 ACCEPTANCE.
+ * "Two daemons on the same cc_parent_pid serving one sid: after rotation, BOTH exit."
+ *
+ * ═══════════════════════════════════════════════════════════════════════════════════════════════
+ * FR-2 NEEDED NO NEW CODE, AND THIS RUN IS WHY
+ * ═══════════════════════════════════════════════════════════════════════════════════════════════
+ * FR-2 was written as "a self-check in the daemon, because one session id can have MANY daemons",
+ * on the evidence that killing the marker pid did not stop the stamping. That evidence is real —
+ * this run reproduces it — but it indicts kill-by-marker-pid (FR-3's problem), not the rotation
+ * path. FR-1 does not kill anything. It RELEASES THE ROW, and every daemon serving that sid
+ * PATCHes that same row behind the same `status=in.(active,idle,stale)` filter
+ * (session-tick.cjs:331), so a release 0-rows ALL of them and each exits itself at :350.
+ * "Every daemon notices" is therefore structural: the exit condition is derived from shared state,
+ * not per-daemon state, so it cannot reach one daemon and miss another.
+ *
+ * MEASURED 2026-08-04: daemons 55172 and 29320 on one sid, both stamping; the marker named only
+ * 29320 (so a marker-pid-only kill provably misses 55172); row released; BOTH exited inside 2s.
+ *
+ * Adding a second "rotated-out self-check" would have been a redundant mechanism guarding an
+ * already-closed door — and a second exit path in a daemon whose two exits are load-bearing is
+ * exactly the sort of thing the five prior attempts at this defect died on.
+ *
+ * Kept as a runnable script rather than a vitest suite because it spawns real daemons and writes
+ * a real row: the `db` project is disabled without a designated non-production target, so a suite
+ * here would silently never run — the failure mode this whole SD is about.
+ *
+ *   node tests/acceptance/rotation-closes-all-daemons.cjs
+ *
+ * Throwaway session id, LEO_TICK_MS=2000 so the run takes seconds. Cleans up after itself.
+ */
+require('dotenv').config();
+const { spawn } = require('child_process');
+const path = require('path');
+const fs = require('fs');
+const { createClient } = require('@supabase/supabase-js');
+
+const ROOT = 'C:/Users/rickf/Projects/_EHG/EHG_Engineer';
+const TICK = path.join(ROOT, 'scripts/session-tick.cjs');
+const SID = 'fr2-accept-' + process.pid;
+const MARKER = path.join(ROOT, '.claude/pids', `tick-${SID}.json`);
+const s = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const alive = (pid) => { try { process.kill(pid, 0); return true; } catch { return false; } };
+
+(async () => {
+  // A long-lived parent so the ONLY exit path under test is the released-row one,
+  // never parent-ESRCH.
+  const parent = spawn(process.execPath, ['-e', 'setTimeout(()=>{},120000)'], { stdio: 'ignore' });
+  await sleep(400);
+  console.log(`parent pid=${parent.pid} alive=${alive(parent.pid)}`);
+
+  await s.from('claude_sessions').delete().eq('session_id', SID);
+  const { error: insErr } = await s.from('claude_sessions').insert({
+    session_id: SID, status: 'active', hostname: require('os').hostname(),
+    heartbeat_at: new Date().toISOString(),
+  });
+  if (insErr) { console.log('INSERT FAILED: ' + insErr.message); parent.kill(); process.exit(1); }
+
+  const env = { ...process.env, CLAUDE_SESSION_ID: SID, CC_PARENT_PID: String(parent.pid), LEO_TICK_MS: '2000' };
+  const a = spawn(process.execPath, [TICK], { env, stdio: 'ignore', detached: true });
+  const b = spawn(process.execPath, [TICK], { env, stdio: 'ignore', detached: true });
+  a.unref(); b.unref();
+  console.log(`daemon A pid=${a.pid}  daemon B pid=${b.pid}   (same sid, same cc_parent_pid)`);
+
+  await sleep(7000);
+  const { data: r1 } = await s.from('claude_sessions').select('heartbeat_at,process_alive_at').eq('session_id', SID).maybeSingle();
+  console.log(`\n[phase 1: both should be RUNNING and stamping]`);
+  console.log(`  A alive=${alive(a.pid)}  B alive=${alive(b.pid)}`);
+  console.log(`  heartbeat_at=${r1 && r1.heartbeat_at}  process_alive_at=${r1 && r1.process_alive_at}`);
+  console.log(`  marker names pid=${fs.existsSync(MARKER) ? JSON.parse(fs.readFileSync(MARKER,'utf8')).tick_pid : '(none)'}  <- only ONE of the two`);
+
+  // THE ROTATION EVENT — exactly what FR-1's closure writes.
+  await s.from('claude_sessions').update({ status: 'released' }).eq('session_id', SID);
+  console.log(`\n[released the row — FR-1's write]`);
+
+  for (let i = 1; i <= 8; i++) {
+    await sleep(2000);
+    const aA = alive(a.pid), bA = alive(b.pid);
+    console.log(`  +${i * 2}s  A alive=${aA}  B alive=${bA}`);
+    if (!aA && !bA) break;
+  }
+
+  const finalA = alive(a.pid), finalB = alive(b.pid);
+  console.log(`\nRESULT: A exited=${!finalA}  B exited=${!finalB}  -> FR-2 acceptance ${(!finalA && !finalB) ? 'PASS' : 'FAIL'}`);
+
+  // cleanup
+  try { if (finalA) process.kill(a.pid); } catch {}
+  try { if (finalB) process.kill(b.pid); } catch {}
+  try { parent.kill(); } catch {}
+  await s.from('claude_sessions').delete().eq('session_id', SID);
+  try { fs.unlinkSync(MARKER); } catch {}
+  console.log('cleaned up (row deleted, processes killed, marker removed)');
+  process.exit(0);
+})();

--- a/tests/unit/fleet/daemon-census.test.js
+++ b/tests/unit/fleet/daemon-census.test.js
@@ -1,0 +1,92 @@
+/**
+ * SD-LEO-INFRA-SESSION-TICK-DAEMONS-001 FR-4 / TS-7.
+ *
+ * TS-7 IS THE POINT: a census assertion that has only ever run on a clean host has not been shown
+ * to detect anything. It would pass vacuously forever and read exactly like a working alarm. So
+ * the control here is a deliberately leaked daemon, and it must make the assertion FAIL.
+ *
+ * The two-sided half matters just as much: a PARKED /loop worker shares the "stale last_tool_at"
+ * side of the signature, and an alarm that fires on parked workers gets muted, which is how you
+ * arrive back at days of silent accumulation.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const { leakedDaemonSessions, assertDaemonCensus, STALE_MS } =
+  createRequire(import.meta.url)('../../../lib/fleet/daemon-census.cjs');
+
+const NOW = Date.parse('2026-08-04T14:00:00Z');
+const agoMin = (m) => new Date(NOW - m * 60_000).toISOString();
+const agoH = (h) => new Date(NOW - h * 3_600_000).toISOString();
+
+const row = (session_id, hb, lt) => ({ session_id, heartbeat_at: hb, last_tool_at: lt });
+
+describe('FR-4 census — TS-7 control', () => {
+  it('TS-7 FAILS against a deliberately leaked daemon', () => {
+    // b22451df as measured live: stamping this second, conversation silent for 51h.
+    const r = assertDaemonCensus({ rows: [row('b22451df', agoMin(0), agoH(51))], now: NOW });
+    expect(r.ok).toBe(false);
+    expect(r.leaked.map((l) => l.session_id)).toEqual(['b22451df']);
+    expect(r.detail).toContain('b22451df');
+  });
+
+  it('passes on a clean census — and that pass is only meaningful because TS-7 can fail', () => {
+    const r = assertDaemonCensus({ rows: [row('live', agoMin(0), agoMin(2))], now: NOW });
+    expect(r.ok).toBe(true);
+  });
+});
+
+describe('FR-4 census — the parked worker must never trip it', () => {
+  // ScheduleWakeup clamps to [60,3600]s, so ~1h + one turn is the structural ceiling.
+  it.each([5, 20, 30, 60, 90])('parked worker %i minutes between wakeups is NOT leaked', (mins) => {
+    const r = assertDaemonCensus({ rows: [row('parked', agoMin(0), agoMin(mins))], now: NOW });
+    expect(r.ok).toBe(true);
+  });
+
+  it('CONTROL — the same parked worker DOES trip it once past the threshold, so the margin is real', () => {
+    const r = assertDaemonCensus({ rows: [row('parked', agoMin(0), agoH(7))], now: NOW });
+    expect(r.ok).toBe(false);
+  });
+
+  it('leaves a 6x margin over the 1h parked ceiling', () => {
+    expect(STALE_MS).toBe(6 * 60 * 60 * 1000);
+  });
+});
+
+describe('FR-4 census — what is deliberately NOT flagged', () => {
+  it('a dead daemon (stale heartbeat) is not a leak — nothing is stamping', () => {
+    // This is an ordinary abandoned row, not a daemon burning cycles for a dead conversation.
+    const r = assertDaemonCensus({ rows: [row('old', agoH(30), agoH(30))], now: NOW });
+    expect(r.ok).toBe(true);
+  });
+
+  it('a missing last_tool_at is UNKNOWN, not a leak', () => {
+    // Absence is not evidence. Alarming on unknown is how an assertion gets muted.
+    expect(assertDaemonCensus({ rows: [row('new', agoMin(0), null)], now: NOW }).ok).toBe(true);
+  });
+
+  it('an unparseable timestamp is skipped rather than coerced', () => {
+    expect(assertDaemonCensus({ rows: [row('bad', agoMin(0), 'not-a-date')], now: NOW }).ok).toBe(true);
+  });
+
+  it('a future heartbeat (clock skew) is not counted as fresh', () => {
+    const future = new Date(NOW + 60_000).toISOString();
+    expect(assertDaemonCensus({ rows: [row('skew', future, agoH(51))], now: NOW }).ok).toBe(true);
+  });
+});
+
+describe('FR-4 census — shape', () => {
+  it('returns every leaked session, not just the first', () => {
+    const rows = [
+      row('a', agoMin(0), agoH(51)),
+      row('b', agoMin(1), agoH(20)),
+      row('ok', agoMin(0), agoMin(3)),
+    ];
+    expect(leakedDaemonSessions({ rows, now: NOW }).map((l) => l.session_id)).toEqual(['a', 'b']);
+  });
+
+  it('is inert on junk input rather than throwing', () => {
+    expect(leakedDaemonSessions({ rows: null, now: NOW })).toEqual([]);
+    expect(leakedDaemonSessions({ rows: [null, {}], now: NOW })).toEqual([]);
+    expect(leakedDaemonSessions({ rows: [], now: NaN })).toEqual([]);
+  });
+});

--- a/tests/unit/sessions/rotation-closure-wiring.test.js
+++ b/tests/unit/sessions/rotation-closure-wiring.test.js
@@ -1,0 +1,216 @@
+/**
+ * SD-LEO-INFRA-SESSION-TICK-DAEMONS-001 FR-1 — the WIRING, not the predicate.
+ *
+ * rotation-closure.test.js proves the predicate picks the right session ids. This file proves the
+ * hook feeds it the right rows, which is where this FR very nearly died: the EXEC handoff said to
+ * join on `claude_sessions.cc_parent_pid`, and that column DOES NOT EXIST. The join key lives only
+ * on the tick marker file. A test that exercised the predicate alone would have stayed green
+ * through that entire mistake.
+ *
+ * Every test pins parentPid and pidsDir. Nothing here reads live PID discovery — a test that had
+ * to stub that would be asserting against its own stub.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const require_ = createRequire(import.meta.url);
+const { readTickMarkers } = require_('../../../lib/sessions/rotation-closure.cjs');
+const { closeRotatedOutSessions } = require_('../../../scripts/hooks/session-register.cjs');
+
+/** Write a throwaway .claude/pids-shaped dir. Returns its path. */
+function markerDir(markers) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rot-close-'));
+  for (const [name, body] of Object.entries(markers)) {
+    fs.writeFileSync(path.join(dir, name), typeof body === 'string' ? body : JSON.stringify(body));
+  }
+  return dir;
+}
+
+/**
+ * Minimal supabase double. Records the ids it was asked to release so a test can assert on the
+ * WRITE rather than on a return value — closeRotatedOutSessions is fire-and-forget by design and
+ * deliberately returns nothing.
+ */
+function fakeSupabase(rows) {
+  const released = [];
+  return {
+    released,
+    from() {
+      return {
+        select: () => ({ in: (_c, ids) => ({ data: rows.filter((r) => ids.includes(r.session_id)), error: null }) }),
+        update: (patch) => ({ in: (_c, ids) => { released.push({ patch, ids }); return { error: null }; } }),
+      };
+    },
+  };
+}
+
+describe('FR-1 wiring — marker reader', () => {
+  it('reads session_id -> cc_parent_pid from tick markers', () => {
+    const dir = markerDir({ 'tick-aaa.json': { session_id: 'aaa', cc_parent_pid: 111 } });
+    expect(readTickMarkers(dir).get('aaa')).toBe(111);
+  });
+
+  it('skips a marker missing cc_parent_pid instead of admitting a match-anything entry', () => {
+    // A marker that lost its pid must not become a wildcard — that is how a scoped filter turns
+    // into a fleet-wide release.
+    const dir = markerDir({ 'tick-bbb.json': { session_id: 'bbb' } });
+    expect(readTickMarkers(dir).has('bbb')).toBe(false);
+  });
+
+  it('skips a half-written marker rather than throwing (the writer is not atomic)', () => {
+    const dir = markerDir({ 'tick-ccc.json': '{"session_id":"ccc","cc_pare' });
+    expect(() => readTickMarkers(dir)).not.toThrow();
+    expect(readTickMarkers(dir).size).toBe(0);
+  });
+
+  it('ignores non-tick files and returns empty for a missing dir', () => {
+    const dir = markerDir({ 'spawn-errors.log': 'noise', 'pid-42.json': '{}' });
+    expect(readTickMarkers(dir).size).toBe(0);
+    expect(readTickMarkers(path.join(dir, 'nope')).size).toBe(0);
+  });
+});
+
+describe('FR-1 wiring — closure', () => {
+  const PID = 22196;
+
+  it('releases the rotated-out session id on our own CC process', async () => {
+    const dir = markerDir({
+      'tick-old.json': { session_id: 'old', cc_parent_pid: PID },
+      'tick-new.json': { session_id: 'new', cc_parent_pid: PID },
+    });
+    const sb = fakeSupabase([
+      { session_id: 'old', status: 'active' },
+      { session_id: 'new', status: 'active' },
+    ]);
+    await closeRotatedOutSessions(sb, 'new', { parentPid: PID, pidsDir: dir });
+    expect(sb.released).toEqual([{ patch: { status: 'released' }, ids: ['old'] }]);
+  });
+
+  it("writes status='released' specifically — the only value that stops the daemon", async () => {
+    // session-tick.cjs:331 PATCHes `status=in.(active,idle,stale)`. Any other status leaves the
+    // daemon ticking, which is this SD's defect with a tidier status column.
+    const dir = markerDir({ 'tick-old.json': { session_id: 'old', cc_parent_pid: PID } });
+    const sb = fakeSupabase([{ session_id: 'old', status: 'active' }]);
+    await closeRotatedOutSessions(sb, 'new', { parentPid: PID, pidsDir: dir });
+    expect(sb.released[0].patch).toEqual({ status: 'released' });
+  });
+
+  // ─── TS-2: THE LOAD-BEARING ONE ────────────────────────────────────────────────────────────
+  it('TS-2 leaves a PARKED /loop worker on a DIFFERENT CC process completely alone', async () => {
+    const dir = markerDir({
+      'tick-parked.json': { session_id: 'parked', cc_parent_pid: 99999 },
+      'tick-new.json': { session_id: 'new', cc_parent_pid: PID },
+    });
+    const sb = fakeSupabase([
+      { session_id: 'parked', status: 'active' },   // alive, between wakeups, no tool use
+      { session_id: 'new', status: 'active' },
+    ]);
+    await closeRotatedOutSessions(sb, 'new', { parentPid: PID, pidsDir: dir });
+    expect(sb.released).toEqual([]); // nothing to close — and 'parked' was never a candidate
+  });
+
+  it('TS-2b gives the identical verdict no matter how quiet the parked worker has been', async () => {
+    // No elapsed-time, last_tool_at or heartbeat input exists anywhere in this path. Rows carrying
+    // wildly different activity histories must be indistinguishable to it.
+    const dir = markerDir({ 'tick-parked.json': { session_id: 'parked', cc_parent_pid: 99999 } });
+    const fresh = fakeSupabase([{ session_id: 'parked', status: 'active', last_tool_at: new Date().toISOString() }]);
+    const ancient = fakeSupabase([{ session_id: 'parked', status: 'active', last_tool_at: '2020-01-01T00:00:00Z' }]);
+    await closeRotatedOutSessions(fresh, 'new', { parentPid: PID, pidsDir: dir });
+    await closeRotatedOutSessions(ancient, 'new', { parentPid: PID, pidsDir: dir });
+    expect(fresh.released).toEqual(ancient.released);
+    expect(fresh.released).toEqual([]);
+  });
+
+  // ─── CONTROL: prove TS-2 is not vacuous ────────────────────────────────────────────────────
+  it('CONTROL — the same parked worker IS released once it shares our pid, so TS-2 can fail', async () => {
+    // If this control did not release, TS-2 would be passing because the harness closes nothing
+    // at all rather than because the parked worker is correctly excluded.
+    const dir = markerDir({ 'tick-parked.json': { session_id: 'parked', cc_parent_pid: PID } });
+    const sb = fakeSupabase([{ session_id: 'parked', status: 'active' }]);
+    await closeRotatedOutSessions(sb, 'new', { parentPid: PID, pidsDir: dir });
+    expect(sb.released).toEqual([{ patch: { status: 'released' }, ids: ['parked'] }]);
+  });
+
+  it('never releases the CURRENT session id', async () => {
+    const dir = markerDir({ 'tick-new.json': { session_id: 'new', cc_parent_pid: PID } });
+    const sb = fakeSupabase([{ session_id: 'new', status: 'active' }]);
+    await closeRotatedOutSessions(sb, 'new', { parentPid: PID, pidsDir: dir });
+    expect(sb.released).toEqual([]);
+  });
+
+  it('leaves already-released rows alone (no pointless re-write)', async () => {
+    const dir = markerDir({ 'tick-old.json': { session_id: 'old', cc_parent_pid: PID } });
+    const sb = fakeSupabase([{ session_id: 'old', status: 'released' }]);
+    await closeRotatedOutSessions(sb, 'new', { parentPid: PID, pidsDir: dir });
+    expect(sb.released).toEqual([]);
+  });
+
+  it('closes idle and stale rows too — both still tick', async () => {
+    // The daemon PATCH survives active|idle|stale, so all three keep a daemon alive.
+    const dir = markerDir({
+      'tick-i.json': { session_id: 'i', cc_parent_pid: PID },
+      'tick-s.json': { session_id: 's', cc_parent_pid: PID },
+    });
+    const sb = fakeSupabase([
+      { session_id: 'i', status: 'idle' },
+      { session_id: 's', status: 'stale' },
+    ]);
+    await closeRotatedOutSessions(sb, 'new', { parentPid: PID, pidsDir: dir });
+    expect(sb.released[0].ids.sort()).toEqual(['i', 's']);
+  });
+
+  it('is a no-op when no markers exist, without touching the DB', async () => {
+    const dir = markerDir({});
+    const sb = fakeSupabase([{ session_id: 'old', status: 'active' }]);
+    await closeRotatedOutSessions(sb, 'new', { parentPid: PID, pidsDir: dir });
+    expect(sb.released).toEqual([]);
+  });
+
+  // ─── Fail-closed identity guard ────────────────────────────────────────────────────────────
+  it('closes NOTHING when our own marker names a different pid than we discovered', async () => {
+    // Identity resolution and the marker record contradict each other. Without this guard the
+    // group is closed wholesale; measured live, that included the session doing the closing.
+    const dir = markerDir({
+      'tick-me.json': { session_id: 'me', cc_parent_pid: 777 },   // marker says 777
+      'tick-old.json': { session_id: 'old', cc_parent_pid: PID },
+    });
+    const sb = fakeSupabase([
+      { session_id: 'me', status: 'active' },
+      { session_id: 'old', status: 'active' },
+    ]);
+    await closeRotatedOutSessions(sb, 'me', { parentPid: PID, pidsDir: dir }); // discovered PID
+    expect(sb.released).toEqual([]);
+  });
+
+  it('CONTROL — the same setup DOES close once the marker agrees, so the guard can be observed', async () => {
+    const dir = markerDir({
+      'tick-me.json': { session_id: 'me', cc_parent_pid: PID },   // now agrees
+      'tick-old.json': { session_id: 'old', cc_parent_pid: PID },
+    });
+    const sb = fakeSupabase([
+      { session_id: 'me', status: 'active' },
+      { session_id: 'old', status: 'active' },
+    ]);
+    await closeRotatedOutSessions(sb, 'me', { parentPid: PID, pidsDir: dir });
+    expect(sb.released).toEqual([{ patch: { status: 'released' }, ids: ['old'] }]);
+  });
+
+  it('still closes when we have NO marker yet — the normal fresh-rotation case', async () => {
+    // The new daemon spawns concurrently with this hook, so our marker is usually absent. The
+    // guard must not turn that ordinary case into a no-op, or the FR never fires at all.
+    const dir = markerDir({ 'tick-old.json': { session_id: 'old', cc_parent_pid: PID } });
+    const sb = fakeSupabase([{ session_id: 'old', status: 'active' }]);
+    await closeRotatedOutSessions(sb, 'me', { parentPid: PID, pidsDir: dir });
+    expect(sb.released).toEqual([{ patch: { status: 'released' }, ids: ['old'] }]);
+  });
+
+  it('swallows a DB failure — SessionStart must never abort', async () => {
+    const dir = markerDir({ 'tick-old.json': { session_id: 'old', cc_parent_pid: PID } });
+    const exploding = { from() { throw new Error('supabase down'); } };
+    await expect(closeRotatedOutSessions(exploding, 'new', { parentPid: PID, pidsDir: dir }))
+      .resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/sessions/rotation-closure.test.js
+++ b/tests/unit/sessions/rotation-closure.test.js
@@ -1,0 +1,72 @@
+/**
+ * SD-LEO-INFRA-SESSION-TICK-DAEMONS-001 FR-1 — rotation closure.
+ *
+ * TS-2 IS THE LOAD-BEARING TEST AND IT IS WRITTEN FIRST, before any closure logic ships. A parked
+ * /loop worker and a rotated-out session are indistinguishable by activity, and session-tick.cjs
+ * :181-184 records that conflating them is "the seam all five prior attempts at this defect fell
+ * down." A fix that closes parked workers passes every other assertion here.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const { sessionsToClose } = createRequire(import.meta.url)('../../../lib/sessions/rotation-closure.cjs');
+
+const row = (session_id, cc_parent_pid = 4242, status = 'active') => ({ session_id, cc_parent_pid, status });
+
+describe('FR-1 rotation closure', () => {
+  it('closes the PRIOR session id after a rotation on the same CC process', () => {
+    const out = sessionsToClose({ currentSessionId: 'new', parentPid: 4242, rows: [row('old'), row('new')] });
+    expect(out).toEqual(['old']);
+  });
+
+  it('TS-2: a PARKED worker is NEVER closed — structurally, not carefully', () => {
+    // The parked worker has not rotated, so its session_id IS the current one and it can never be
+    // selected. No threshold, no window, nothing to tune. This is the test five prior attempts
+    // would have failed.
+    const out = sessionsToClose({ currentSessionId: 'parked', parentPid: 4242, rows: [row('parked')] });
+    expect(out).toEqual([]);
+  });
+
+  it('TS-2b: the predicate reads NO clock field at all', () => {
+    // Same rows, wildly different timestamps — identical verdict. If a future edit introduces a
+    // staleness heuristic, this fails.
+    const fresh = { ...row('old'), last_tool_at: new Date().toISOString(), heartbeat_at: new Date().toISOString() };
+    const ancient = { ...row('old'), last_tool_at: '2020-01-01T00:00:00Z', heartbeat_at: '2020-01-01T00:00:00Z' };
+    const a = sessionsToClose({ currentSessionId: 'new', parentPid: 4242, rows: [fresh] });
+    const b = sessionsToClose({ currentSessionId: 'new', parentPid: 4242, rows: [ancient] });
+    expect(a).toEqual(b);
+    expect(a).toEqual(['old']);
+  });
+
+  it('does not touch another CC process — a peer session on the same host is not ours to close', () => {
+    const out = sessionsToClose({ currentSessionId: 'new', parentPid: 4242, rows: [row('peer', 9999)] });
+    expect(out).toEqual([]);
+  });
+
+  it('leaves already-terminal rows alone (no pointless re-release)', () => {
+    const rows = [row('a', 4242, 'released'), row('b', 4242, 'exited'), row('c', 4242, 'active')];
+    expect(sessionsToClose({ currentSessionId: 'new', parentPid: 4242, rows })).toEqual(['c']);
+  });
+
+  it('TS-3: closes the row ONCE even when several daemons serve that id', () => {
+    // Multiple daemons per session id is witnessed; the marker file names only the newest. Closure
+    // is per-ROW, and every daemon serving it exits via its own 0-row PATCH — which is why this
+    // returns one id rather than one entry per daemon.
+    const out = sessionsToClose({ currentSessionId: 'new', parentPid: 4242, rows: [row('old'), row('old')] });
+    expect(out).toEqual(['old', 'old']);   // both rows map to the same id; the caller dedupes/PATCHes by id
+    expect(new Set(out).size).toBe(1);
+  });
+
+  it('degrades safely on missing inputs rather than closing something', () => {
+    expect(sessionsToClose({})).toEqual([]);
+    expect(sessionsToClose({ currentSessionId: 'new', parentPid: null, rows: [row('old')] })).toEqual([]);
+    expect(sessionsToClose({ currentSessionId: 'new', parentPid: 4242, rows: null })).toEqual([]);
+  });
+
+  it('CONTROL: a staleness-based predicate WOULD close the parked worker', () => {
+    // Proves TS-2 is not vacuous. This is the rejected design, run against the same parked row.
+    const parked = { ...row('parked'), last_tool_at: '2020-01-01T00:00:00Z' };
+    const stalenessBased = (rows) => rows.filter(r => Date.now() - new Date(r.last_tool_at) > 60_000).map(r => r.session_id);
+    expect(stalenessBased([parked])).toEqual(['parked']);                       // the trap fires...
+    expect(sessionsToClose({ currentSessionId: 'parked', parentPid: 4242, rows: [parked] })).toEqual([]);  // ...ours does not
+  });
+});


### PR DESCRIPTION
## Summary

/clear and compaction-resume rotate the conversation to a new `session_id` while the Claude Code process survives. `session-tick.cjs` has exactly two exits — parent-PID death (`:181`, which deliberately survives /clear) and the 0-row PATCH self-exit on `status='released'` (`:350`) — and nothing flipped either at rotation, so the old daemon became immortal, stamping both `heartbeat_at` and `process_alive_at` every 30s for a conversation that can never act again.

The trigger is the **rotation event**, never inactivity. A parked `/loop` worker and a rotated-out session are indistinguishable by activity, and `session-tick.cjs:181-184` records that conflating them "trades false-life for false-death — the seam all five prior attempts at this defect fell down." PID rediscovery is untouched, and no write path in this PR reads a clock.

- **FR-1** — rotation closure wired into the SessionStart hook. A parked worker is excluded *structurally*: one CC process hosts one conversation, so a row sharing our pid with a different `session_id` has necessarily rotated out.
- **FR-2** — **no new code.** FR-1 releases the row; every daemon serving that sid PATCHes that same row behind the same filter, so a release 0-rows all of them. Proven live rather than assumed.
- **FR-3** — `reconcilePid` falls back to the tick marker when `claude_sessions.pid` is null, which is what made leaked daemons unkillable. The fallback changes *which* pid is considered, never *whether* it is verified.
- **FR-4** — census assertion + one-time cleanup.

## Two corrections found by measuring

The EXEC handoff said to join on `claude_sessions.cc_parent_pid = process.ppid`. Both halves were wrong:

1. `cc_parent_pid` **is not a column** on that table — it lives only on `.claude/pids/tick-<sid>.json`. Fails loud.
2. `process.ppid` is the **degraded fallback**, not the derivation — the marker's writer uses `findClaudeCodePid()` and logs `outcome='degraded'` when it falls back. Joining on ppid would have matched nothing and failed **silently**.

`claude_sessions.tty` was the obvious substitute and was **measured and rejected**: across all 12,914 rows on this host it has a degenerate `'unknown'` bucket holding 3,228 non-terminal sessions from unrelated processes. Keying closure on it would have released the host's entire live fleet in one hook run.

A live dry run then caught a hazard the unit tests missed: the predicate is "everything on our pid except us", so it is only as safe as *us*. With an unmatched `currentSessionId` it closed the whole group **including the live session** — unreachable only because our own marker usually doesn't exist yet, i.e. safety by coincidence. Hence the fail-closed identity guard.

## Test plan

- 40 unit tests across the closure, census, and `reconcilePid`; 145 green across 14 affected suites post-rebase.
- Every assertion is paired with a **control that makes it fail** — TS-2 (parked worker untouched) + a control releasing that same worker once it shares our pid; TS-7 (census) + a deliberately leaked daemon; FR-3 + a control proving the DB pid still wins.
- **Live FR-2 acceptance** (`tests/acceptance/rotation-closes-all-daemons.cjs`): daemons 55172 and 29320 on one sid, marker naming only 29320 (so a marker-pid-only kill provably misses the other), row released, **both exited inside 2s**.
- **Live FR-4 acceptance** on the session this SD witnessed: assert → exit 1 naming `b22451df(51h)` → `--cleanup` → heartbeat **frozen 93s** (three tick intervals — the daemon exited, not just a status column flip) → re-assert → exit 0, census clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)