### PR TITLE
fix(SD-LEO-INFRA-FLEET-HEALTH-VERDICT-001): the health verdict was satisfied by the condition it should report

### DIFF
--- a/lib/fleet/health-verdict.cjs
+++ b/lib/fleet/health-verdict.cjs
@@ -1,0 +1,145 @@
+/**
+ * FLEET HEALTH VERDICT — SD-LEO-INFRA-FLEET-HEALTH-VERDICT-001.
+ *
+ * THE VERDICT USED TO BE SATISFIED BY THE CONDITION IT SHOULD REPORT. scripts/fleet-dashboard.cjs
+ * counted sessions passing a heartbeat-led OR and called >=3 of them HEALTHY. Heartbeats do not stop
+ * when a seat freezes, exits its loop, or misses an armed wake, so THREE STALLED SEATS — exactly the
+ * threshold — were by themselves sufficient to print FLEET HEALTH [OK]. That is not hypothetical:
+ * operator escalations about stalled seats coexisted with [OK] for an afternoon, and the contradicting
+ * number was already on screen (the stale count printed directly beneath the verdict).
+ *
+ * WHY THIS IS A SEPARATE MODULE: the fix must be exercisable without a database. Every `.db.test.js`
+ * in this repo silently SKIPS, so a suite that needed live rows would report green having executed
+ * nothing — the same silent-false-negative class this SD exists to remove.
+ *
+ * SCOPE LIMIT, CARRIED FORWARD DELIBERATELY (lib/fleet/stuck-seat-predicate.cjs:32): this is a
+ * LIVENESS GAUGE, NOT A TAMPER-EVIDENT CONTROL. Both columns it reads are writable by the seat being
+ * judged. The threat model is an ACCIDENT — a wedged worker — and a wedged worker is by definition not
+ * writing. A fix that advertised a repaired verdict while dropping this caveat would let a reader trust
+ * the dashboard more than it earns, which is precisely how the broken verdict came to be believed.
+ */
+
+'use strict';
+
+const { classifySeat, VERDICT } = require('./stuck-seat-predicate.cjs');
+
+/**
+ * Four-valued health. UNKNOWN is first-class and is NOT a flavour of DOWN: DOWN is a measured claim
+ * that no seat is working, UNKNOWN is the admission that the gauge could not measure. Collapsing them
+ * would page an operator for an instrument outage, and the reverse (collapsing into HEALTHY) is the
+ * defect this module exists to remove.
+ */
+const HEALTH = Object.freeze({ HEALTHY: 'HEALTHY', DEGRADED: 'DEGRADED', DOWN: 'DOWN', UNKNOWN: 'UNKNOWN' });
+
+/** Exact exclusion reasons. Tests pin these strings, not their truthiness — a truthy assertion cannot
+ *  tell "excluded by the rule under test" from "excluded by an earlier guard". */
+const EXCLUDED = Object.freeze({
+  LOOP_EXITED: 'loop_exited',
+  NO_LIVENESS_ROW: 'no_liveness_row',
+  TOOL_SILENT: 'tool_silent_past_cut_point',
+  NO_TOOL_CLOCK: 'last_tool_at_never_written'
+});
+
+/**
+ * Decide whether ONE session counts toward fleet health.
+ *
+ * @param {object} session   - a v_active_sessions row (carries loop_state; NOT last_tool_at).
+ * @param {object|undefined} liveness - the matching claude_sessions row (last_tool_at, metadata).
+ * @param {object} opts - { cutPointMinutes, now }
+ * @returns {{live: boolean, reason: string|null}}
+ */
+function countsAsLive(session, liveness, opts) {
+  // RULE 1 IS CATEGORICAL AND IS CHECKED FIRST SO NOTHING CAN RESCUE IT. An exited loop is
+  // unambiguous — the seat said so itself. Specimen e3610a71 was counted active purely because its
+  // heartbeat was 11 seconds old while its loop had exited and its tools had been silent 152 minutes.
+  // Ordering matters: were this checked after classification, a seat that exited moments after a tool
+  // call would classify HEALTHY and be counted, which is the bug wearing a new hat.
+  if (session && session.loop_state === 'exited') {
+    return { live: false, reason: EXCLUDED.LOOP_EXITED };
+  }
+
+  // A seat with no liveness row cannot be classified. NOT COUNTING IT IS THE POINT: a seat whose
+  // liveness could not be established is in the same epistemic position as a frozen one, and the
+  // present defect IS a category that should not count being counted. Whether this is a per-seat gap
+  // or a total instrument failure is decided by the caller, which can see the whole population.
+  if (!liveness) {
+    return { live: false, reason: EXCLUDED.NO_LIVENESS_ROW };
+  }
+
+  const seat = classifySeat(liveness, { cutPointMinutes: opts.cutPointMinutes, now: opts.now });
+
+  // NO WAKE-OVERDUE EXCLUSION, AND THE REASON IS MEASURED RATHER THAN ASSUMED. This module briefly
+  // excluded seats sitting past their own armed wake deadline; the live fleet falsified that within
+  // minutes. expected_wake_at is written when a wakeup is ARMED and is never cleared when the session
+  // actually wakes, so "overdue" is the STEADY STATE OF A WORKING SEAT: measured 2026-08-04, seat
+  // 28303922 read 504 minutes overdue with a 3-minute-old tool clock, and e3610a71 read 14 minutes
+  // overdue while executing the tool call that took the measurement. Four of seven claimed seats were
+  // excluded, at least three of them demonstrably working.
+  // THE POINT GENERALISES, AND IT IS THIS SD'S OWN THESIS TURNED ON ITS AUTHOR: a field that does not
+  // stop meaning something when the seat is fine cannot testify that the seat is broken. That is
+  // exactly the heartbeat's failure, reproduced one field over by the fix written to repair it.
+  // classifySeat returns `wake` as a DIAGNOSTIC and deliberately does not verdict on it; that judgement
+  // is restored here rather than overridden.
+
+  // UNKNOWN MUST NOT BECOME THE NEW COUNTS-AS-HEALTHY. classifySeat returns THREE verdicts and only
+  // one of them is evidence of work. last_tool_at has documented silent-loss paths, so folding UNKNOWN
+  // into the healthy tally would let the blindest seats score cleanest — and it would look like an
+  // improvement while doing it, because the health number would rise.
+  if (seat.verdict === VERDICT.STUCK) return { live: false, reason: EXCLUDED.TOOL_SILENT };
+  if (seat.verdict === VERDICT.UNKNOWN) return { live: false, reason: EXCLUDED.NO_TOOL_CLOCK };
+  return { live: true, reason: null };
+}
+
+/**
+ * Compute the fleet health verdict over a population.
+ *
+ * @param {object} args
+ * @param {Array<object>} args.sessions        - claimed sessions (the old activeSessions population).
+ * @param {Array<object>} args.livenessRows    - claude_sessions rows from fetchPopulation().
+ * @param {boolean} args.truncated             - fetchPopulation's truncation flag.
+ * @param {number} args.cutPointMinutes
+
+ * @param {number|Date} [args.now]
+ * @returns {{verdict: string, live: number, evaluated: number, excluded: Array, blindReason: string|null}}
+ */
+function computeHealthVerdict(args) {
+  const sessions = args.sessions || [];
+  const index = new Map();
+  for (const row of args.livenessRows || []) {
+    if (row && row.session_id) index.set(row.session_id, row);
+  }
+
+  const excluded = [];
+  let live = 0;
+  for (const s of sessions) {
+    const r = countsAsLive(s, index.get(s.session_id), {
+      cutPointMinutes: args.cutPointMinutes,
+      now: args.now
+    });
+    if (r.live) live++;
+    else excluded.push({ session_id: s.session_id, reason: r.reason });
+  }
+
+  // INSTRUMENT BLINDNESS IS NOT A FLEET STATE, AND THIS IS THE FAILURE MODE THE PRD DID NOT ANTICIPATE.
+  // v_active_sessions does not expose last_tool_at at all (measured, not assumed), so liveness arrives
+  // by joining a second query. If that join is truncated, or if it matched NOTHING while seats exist,
+  // then every seat classifies unclassifiable and a naive count would report DOWN across a possibly
+  // healthy fleet — the original defect inverted, and far louder. Reporting UNKNOWN says what is true:
+  // the gauge could not measure. A verdict that cannot fail toward alarm is as useless as one that
+  // cannot fail toward alert.
+  let blindReason = null;
+  if (args.truncated) {
+    blindReason = 'liveness_population_truncated';
+  } else if (sessions.length > 0 && excluded.length === sessions.length &&
+             excluded.every((e) => e.reason === EXCLUDED.NO_LIVENESS_ROW)) {
+    blindReason = 'liveness_join_matched_nothing';
+  }
+  if (blindReason) {
+    return { verdict: HEALTH.UNKNOWN, live, evaluated: sessions.length, excluded, blindReason };
+  }
+
+  const verdict = live >= 3 ? HEALTH.HEALTHY : live >= 1 ? HEALTH.DEGRADED : HEALTH.DOWN;
+  return { verdict, live, evaluated: sessions.length, excluded, blindReason: null };
+}
+
+module.exports = { computeHealthVerdict, countsAsLive, HEALTH, EXCLUDED };

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -341,6 +341,22 @@ async function loadData() {
     hasTickAlive(s) ||
     hasExpectedSilence(s)
   );
+  // SD-LEO-INFRA-FLEET-HEALTH-VERDICT-001: liveness for the HEALTH VERDICT arrives by a second query.
+  // v_active_sessions above does NOT expose last_tool_at (measured, not assumed) — the only signal that
+  // did not lie on any of the three stalled specimens. So the verdict joins claude_sessions by
+  // session_id rather than trusting the heartbeat-led OR, which counts a frozen seat as a working one.
+  // A failure here yields NO rows, which the verdict reports as UNKNOWN rather than as a fleet-wide
+  // DOWN — the gauge being blind is not the same claim as the fleet being dead.
+  let livenessRows = [];
+  let livenessTruncated = false;
+  try {
+    const { fetchPopulation } = require('../lib/fleet/stuck-seat-population.cjs');
+    const pop = await fetchPopulation(supabase);
+    livenessRows = pop.seats;
+    livenessTruncated = pop.truncated;
+  } catch (e) {
+    livenessTruncated = true; // unreadable is not healthy, and it is not DOWN either
+  }
   const staleSessions = sessions.filter(s =>
     s.heartbeat_age_seconds >= STALE_THRESHOLD &&
     !hasPidAlive(s) &&
@@ -462,7 +478,7 @@ async function loadData() {
 
   return {
     sessions, allSessions, children, workable, coordMessages, rawSessions, sdStatusMap, qfStatusMap,
-    claimedSdIds, activeSessions, staleSessions, idleSessions,
+    claimedSdIds, activeSessions, staleSessions, idleSessions, livenessRows, livenessTruncated,
     completedChildren, totalChildren, orchPct,
     unclaimedChildren, unclaimedStandalone, bareShellSDs: bareShells,
     humanActionHolds,
@@ -890,14 +906,41 @@ async function printCoaching(d) {
 
 // ── Section: Health ──
 function printHealth(d) {
-  const health = d.activeSessions.length >= 3 ? 'HEALTHY' : d.activeSessions.length >= 1 ? 'DEGRADED' : 'DOWN';
-  const icon = health === 'HEALTHY' ? '[OK]' : health === 'DEGRADED' ? '[!!]' : '[XX]';
+  // SD-LEO-INFRA-FLEET-HEALTH-VERDICT-001. THIS USED TO BE A PURE COUNT OF activeSessions, and that
+  // count was satisfied by the very condition it should have reported: three stalled seats — exactly
+  // the >=3 threshold — printed [OK] while operators escalated, with the contradicting stale count
+  // rendered two lines below. The verdict now consults the stuck-seat classifier this file has
+  // imported all along, ~790 lines down at printStuckSeatStrip.
+  const { computeHealthVerdict, HEALTH } = require('../lib/fleet/health-verdict.cjs');
+  const hv = computeHealthVerdict({
+    sessions: d.activeSessions,
+    livenessRows: d.livenessRows,
+    truncated: d.livenessTruncated,
+    cutPointMinutes: STUCK_SEAT_CUT_POINT_MINUTES,
+  });
+  const health = hv.verdict;
+  const icon = health === HEALTH.HEALTHY ? '[OK]' : health === HEALTH.DEGRADED ? '[!!]'
+    : health === HEALTH.UNKNOWN ? '[??]' : '[XX]';
 
   console.log('FLEET HEALTH ' + icon);
   console.log('─'.repeat(72));
-  console.log('  Active:  ' + d.activeSessions.length + ' workers');
+  console.log('  Working: ' + hv.live + ' of ' + hv.evaluated + ' claimed seats (tool-verified)');
   console.log('  Unclaimed: ' + d.idleSessions.length + ' sessions (no SD claim)');
   console.log('  Stale:   ' + d.staleSessions.length + ' sessions');
+  if (hv.blindReason) {
+    console.log('  ?? UNKNOWN: ' + hv.blindReason + ' — the gauge could not measure. NOT a healthy');
+    console.log('     fleet, and NOT a dead one; no verdict is being asserted here.');
+  }
+  if (hv.excluded.length) {
+    const by = {};
+    for (const e of hv.excluded) by[e.reason] = (by[e.reason] || 0) + 1;
+    console.log('  Excluded: ' + Object.entries(by).map(([k, v]) => v + ' ' + k).join(', '));
+    console.log('     (heartbeat-fresh but not working — the gap this verdict used to miss)');
+  }
+  // SCOPE LIMIT, STATED BESIDE THE VERDICT IT QUALIFIES (lib/fleet/stuck-seat-predicate.cjs:32):
+  // a liveness gauge, not a tamper-evident control. Both columns are writable by the seat being
+  // judged; the threat model is an accident, and a wedged worker is by definition not writing.
+  console.log('  Basis:   last_tool_at + loop_state — a liveness gauge, NOT a tamper-evident control');
   console.log('  Orch:    ' + d.completedChildren + '/' + d.totalChildren + ' children complete (' + d.orchPct + '%)');
   console.log('  Status:  ' + health);
 

--- a/tests/unit/fleet-health-verdict.test.js
+++ b/tests/unit/fleet-health-verdict.test.js
@@ -1,0 +1,159 @@
+/**
+ * SD-LEO-INFRA-FLEET-HEALTH-VERDICT-001 — the fleet health verdict must not be satisfied by the
+ * condition it should report.
+ *
+ * THE THREE SPECIMENS ARE A CONTROL, NOT A REPETITION. Each is a case where a DIFFERENT signal lied:
+ * ab29dc41 the heartbeat, e7c92ad8 the wake state, e3610a71 loop_state (honest, never consulted).
+ * Three near-identical cases would let a fix that repairs one arm pass all of them.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computeHealthVerdict, HEALTH, EXCLUDED } from '../../lib/fleet/health-verdict.cjs';
+
+const NOW = Date.parse('2026-08-04T12:00:00.000Z');
+const minsAgo = (m) => new Date(NOW - m * 60000).toISOString();
+const OPTS = { cutPointMinutes: 120, now: NOW };
+
+// The three specimens measured live by the coordinator, verbatim.
+const AB29 = { session_id: 'ab29dc41', loop_state: 'active' };
+const AB29_LIVE = { session_id: 'ab29dc41', last_tool_at: minsAgo(146), heartbeat_at: minsAgo(0.5) };
+const E7C9 = { session_id: 'e7c92ad8', loop_state: 'awaiting_tick' };
+// e7c92ad8 was originally diagnosed as stalled BECAUSE its wake was 90m past due. Measurement on the
+// live fleet later falsified overdue-wake as a stuck signal (expected_wake_at is never cleared on
+// wake, so working seats read hundreds of minutes overdue). The specimen is retained with the overdue
+// wake intact, but the exclusion basis is its TOOL CLOCK — the signal that survived falsification.
+const E7C9_LIVE = { session_id: 'e7c92ad8', last_tool_at: minsAgo(131), heartbeat_at: minsAgo(0.08),
+  metadata: { expected_wake_at: minsAgo(90) } };
+const E361 = { session_id: 'e3610a71', loop_state: 'exited' };
+const E361_LIVE = { session_id: 'e3610a71', last_tool_at: minsAgo(152), heartbeat_at: minsAgo(0.18) };
+
+const run = (sessions, livenessRows, extra) =>
+  computeHealthVerdict({ sessions, livenessRows, truncated: false, ...OPTS, ...extra });
+
+describe('TS-1 — the SD claim, made executable', () => {
+  it('the exact three-specimen fixture yields DOWN, not HEALTHY', () => {
+    // Three is EXACTLY the >=3 threshold, which is why these three seats were by themselves
+    // sufficient to print [OK]. This fixture must never produce HEALTHY again.
+    const r = run([AB29, E7C9, E361], [AB29_LIVE, E7C9_LIVE, E361_LIVE]);
+    expect(r.verdict).toBe(HEALTH.DOWN);
+    expect(r.live).toBe(0);
+    expect(r.evaluated).toBe(3);
+  });
+});
+
+describe('TS-2 — each specimen is excluded for its OWN reason', () => {
+  const reasonFor = (id, sessions, rows) =>
+    run(sessions, rows).excluded.find((e) => e.session_id === id).reason;
+
+  it('ab29dc41: tool-silent 146m behind a 29-second heartbeat', () => {
+    expect(reasonFor('ab29dc41', [AB29], [AB29_LIVE])).toBe(EXCLUDED.TOOL_SILENT);
+  });
+
+  it('e7c92ad8: tool-silent past the cut behind a 5-second heartbeat', () => {
+    expect(reasonFor('e7c92ad8', [E7C9], [E7C9_LIVE])).toBe(EXCLUDED.TOOL_SILENT);
+  });
+
+  it('e3610a71: excluded on loop_state alone', () => {
+    expect(reasonFor('e3610a71', [E361], [E361_LIVE])).toBe(EXCLUDED.LOOP_EXITED);
+  });
+});
+
+describe('TS-3 — SEEDED: UNKNOWN must not become the new counts-as-healthy', () => {
+  it('a seat with NULL last_tool_at does not count toward HEALTHY', () => {
+    // A build that folded UNKNOWN into the healthy count would pass every stalled-seat test above
+    // while RAISING the health number. Raising the number is not the goal.
+    const blind = { session_id: 'blind-1', loop_state: 'active' };
+    const rows = [{ session_id: 'blind-1', last_tool_at: null }];
+    const r = run([blind], rows);
+    expect(r.live).toBe(0);
+    expect(r.verdict).toBe(HEALTH.DOWN);
+    expect(r.excluded[0].reason).toBe(EXCLUDED.NO_TOOL_CLOCK);
+  });
+
+  it('three blind seats are DOWN, not HEALTHY — the defect shape, re-armed', () => {
+    const seats = ['b1', 'b2', 'b3'].map((id) => ({ session_id: id, loop_state: 'active' }));
+    const rows = ['b1', 'b2', 'b3'].map((id) => ({ session_id: id, last_tool_at: null }));
+    expect(run(seats, rows).verdict).toBe(HEALTH.DOWN);
+  });
+});
+
+describe('TS-4 — SEEDED: exited stays excluded even when the classifier would say HEALTHY', () => {
+  it('a seat that exited seconds after a tool call is still excluded, on loop_state', () => {
+    // A build implementing only the classifier wiring would let HEALTHY rescue this seat, silently
+    // subsuming a categorical exclusion into an inference.
+    const s = { session_id: 'exited-fresh', loop_state: 'exited' };
+    const rows = [{ session_id: 'exited-fresh', last_tool_at: minsAgo(1) }];
+    const r = run([s], rows);
+    expect(r.live).toBe(0);
+    expect(r.excluded[0].reason).toBe(EXCLUDED.LOOP_EXITED);
+  });
+});
+
+describe('TS-5 — POSITIVE CONTROL: the fix must not achieve correctness by reporting DOWN', () => {
+  const liveSeat = (id) => ({ session_id: id, loop_state: 'active' });
+  const liveRow = (id) => ({ session_id: id, last_tool_at: minsAgo(2),
+    metadata: { expected_wake_at: new Date(NOW + 10 * 60000).toISOString() } });
+
+  it('three genuinely live seats still yield HEALTHY', () => {
+    // Without this, a verdict hardcoded to DOWN passes TS-1 through TS-4 completely.
+    const ids = ['w1', 'w2', 'w3'];
+    const r = run(ids.map(liveSeat), ids.map(liveRow));
+    expect(r.verdict).toBe(HEALTH.HEALTHY);
+    expect(r.live).toBe(3);
+    expect(r.excluded).toHaveLength(0);
+  });
+
+  it('one live seat is DEGRADED — the middle band still works', () => {
+    expect(run([liveSeat('w1')], [liveRow('w1')]).verdict).toBe(HEALTH.DEGRADED);
+  });
+
+  it('a live seat is not excluded by a wake that is armed but not yet due', () => {
+    expect(run([liveSeat('w1')], [liveRow('w1')]).live).toBe(1);
+  });
+
+  it('REGRESSION: an overdue wake is NOT evidence of stalling — 504m overdue, working, counts live', () => {
+    // Pins a falsification, so the rule cannot be re-added by someone who finds "past its own declared
+    // deadline" as intuitively compelling as I did. expected_wake_at is written when a wakeup is ARMED
+    // and never cleared when the seat wakes, so overdue is the steady state of a WORKING seat. These
+    // are the live values measured on seat 28303922 on 2026-08-04, and on e3610a71 — the session that
+    // wrote this test, 14 minutes "overdue" while running the tool call that measured it.
+    const rows = [{ session_id: 'w1', last_tool_at: minsAgo(3),
+      metadata: { expected_wake_at: minsAgo(504) } }];
+    const r = run([liveSeat('w1')], rows);
+    expect(r.live).toBe(1);
+    expect(r.excluded).toHaveLength(0);
+  });
+});
+
+describe('instrument blindness is reported as UNKNOWN, never as DOWN', () => {
+  it('a truncated liveness population yields UNKNOWN', () => {
+    // DOWN is a measured claim that no seat is working. UNKNOWN is the admission that the gauge could
+    // not measure. Collapsing them would page an operator for an instrument outage.
+    const r = run([AB29], [AB29_LIVE], { truncated: true });
+    expect(r.verdict).toBe(HEALTH.UNKNOWN);
+    expect(r.blindReason).toBe('liveness_population_truncated');
+  });
+
+  it('a liveness join that matched nothing yields UNKNOWN, not a fleet-wide DOWN', () => {
+    const ids = ['w1', 'w2', 'w3'];
+    const r = run(ids.map((id) => ({ session_id: id, loop_state: 'active' })), []);
+    expect(r.verdict).toBe(HEALTH.UNKNOWN);
+    expect(r.blindReason).toBe('liveness_join_matched_nothing');
+  });
+
+  it('a PARTIAL join is not blindness — it is per-seat exclusion, and still reports a real verdict', () => {
+    // The distinction matters: one unmatched seat among three live ones must not suppress the verdict.
+    const ids = ['w1', 'w2', 'w3'];
+    const sessions = [...ids.map((id) => ({ session_id: id, loop_state: 'active' })),
+      { session_id: 'ghost', loop_state: 'active' }];
+    const rows = ids.map((id) => ({ session_id: id, last_tool_at: minsAgo(2) }));
+    const r = run(sessions, rows);
+    expect(r.verdict).toBe(HEALTH.HEALTHY);
+    expect(r.blindReason).toBeNull();
+    expect(r.excluded[0].reason).toBe(EXCLUDED.NO_LIVENESS_ROW);
+  });
+
+  it('an empty fleet is DOWN, not UNKNOWN — nothing to measure is itself a measurement', () => {
+    expect(run([], []).verdict).toBe(HEALTH.DOWN);
+  });
+});


### PR DESCRIPTION
## The defect

`FLEET HEALTH` counted sessions passing a heartbeat-led OR and called `>=3` of them HEALTHY. Heartbeats do not stop when a seat freezes or exits its loop, so **three stalled seats — exactly the threshold — were by themselves sufficient to print `[OK]`**. Operators escalated stalled seats for an afternoon against a green verdict, with the contradicting stale count rendered two lines beneath it.

## The fix is wiring, not building

The broken verdict (`fleet-dashboard.cjs:893`) and a validated single-row classifier (`:1684`, already `require`d and invoked) lived **in the same file ~790 lines apart**. No sample store was built — the SD prescribed one; `classifySeat` derives from a single row, so it would have been new machinery duplicating a working instrument.

- Verdict consults `classifySeat`; `loop_state='exited'` is excluded **categorically**, checked first so no other signal can rescue it.
- `UNKNOWN` is excluded, not folded into the healthy count. A seat whose liveness cannot be established is in the same epistemic position as a frozen one — folding it in would reproduce this defect *while raising the health number*.

## Two things measurement changed

**1. `v_active_sessions` does not expose `last_tool_at` at all.** Checked before wiring rather than after; the naive fix would have classified every seat UNKNOWN and pinned the fleet at DOWN. Liveness now joins `claude_sessions` by `session_id`. When that join is truncated or matches nothing the verdict is `UNKNOWN` — **a blind gauge is not a dead fleet**, and reporting one as the other pages for an instrument outage.

**2. A rule I wrote was falsified by the live fleet within minutes.** This briefly excluded seats past their own armed wake deadline. But `expected_wake_at` is never cleared when a session wakes, so working seats read hundreds of minutes overdue — `28303922` at 504m with a 3m-old tool clock, and `e3610a71` at 14m *while running the tool call that took the measurement*. Four of seven seats excluded, at least three demonstrably working. Removed, with a regression test pinning the falsification.

> A field that does not stop meaning something when the seat is fine cannot testify that the seat is broken — the heartbeat's exact failure, reproduced one field over by the fix written to repair it.

## Verification

Mutation-tested, each mutation verified as applied: folding UNKNOWN into healthy (**2 fail**), dropping the exited exclusion (**2**), hardcoding DOWN (**3**), restoring the old pure count (**9**). The suite can fail.

15/15 green. The three specimens are used verbatim as a **three-sided control** — each is a case where a different signal lied. TS-5 is a positive control: without it, a verdict hardcoded to DOWN passes everything else.

Live run: `Working: 7 of 7 claimed seats` → HEALTHY. Today's fleet is genuinely healthy, so the verdict is unchanged — the fix bites only when seats stall.

Carries the classifier's own scope limit onto the health line: **a liveness gauge, not a tamper-evident control.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)