### PR TITLE
fix(SD-LEO-INFRA-GATE-THRESHOLD-TUNING-001): the tuner loosened on weaker evidence than it tightened on

### DIFF
--- a/database/chairman-gated/20260804_ai_quality_tuning_symmetric_guards.sql
+++ b/database/chairman-gated/20260804_ai_quality_tuning_symmetric_guards.sql
@@ -1,0 +1,153 @@
+-- SD-LEO-INFRA-GATE-THRESHOLD-TUNING-001 — FR-3: give the tuner symmetric guards.
+-- CHAIRMAN-GATED. The builder STAGES; the chairman APPLIES. Do not self-apply, including inside a
+-- transaction that is rolled back — an apply attempt against a gated object is still an apply attempt.
+--
+-- WHAT THIS FIXES (both measured at source, both independent of the missing outcome arm):
+--
+--   1. THE ARMS CARRIED UNEQUAL EVIDENTIARY BURDENS. Loosening fired on pass_rate < 50 AND total >= 5
+--      with NO score condition; tightening required pass_rate > 90 AND avg_score > 80 AND total >= 10.
+--      On one live run that produced orchestrator x retrospective (100% pass, avg 88.7, n=6) DENIED an
+--      increase, while database x user_story (0% pass, n=8) FIRED a decrease. n=6 was too little
+--      evidence to tighten; n=8 was enough to loosen. A tuner shaped like that drifts one way no
+--      matter what else is bolted onto it.
+--
+--   2. suggested_threshold COULD CONTRADICT ITS OWN recommendation. Its CASE carried no total guard
+--      while the recommendation CASE beside it did, so security x prd published suggested_threshold
+--      70 (up from 65) on the same row reading "INSUFFICIENT DATA ... (minimum 5)" at n=2. A number
+--      printed beside a disclaimer gets read without it. It is now NULL unless an arm actually fired.
+--
+--   3. A DECREASE THAT CANNOT REACH ITS POPULATION IS NO LONGER OFFERED. All six live DECREASE
+--      recommendations proposed a bar that, after the cut, STILL SAT ABOVE the mean score — by 4.0
+--      (documentation) to 25.7 (database) points. None would have moved its pass rate. Such a row now
+--      returns INEFFECTIVE_CHANGE, which says the true thing: this is a content signal, not a
+--      threshold signal, and lowering the bar would hide it.
+--
+-- The authoritative specification and its tests are lib/quality/tuning-rules.js and
+-- tests/unit/tuning-rules.test.js (18 cases, mutation-proven). Keep this DDL in step with them.
+--
+-- ============================================================================================
+-- PRE-CONDITION — THIS IS THE LOAD-BEARING PART OF THE FILE. READ BEFORE APPLYING.
+-- ============================================================================================
+-- The migration that supposedly defines this view (supabase/migrations/20251205_russian_judge_
+-- sd_type_awareness.sql:85) filters `created_at`, and ai_quality_assessments HAS NO created_at
+-- COLUMN — a live select returns assessed_at instead. A view defined as that file reads could not
+-- execute, yet the live view returns 22 rows. THE FILE IS THEREFORE NOT THE LIVE DEFINITION, and the
+-- live one could not be retrieved from the builder's side (no exec_sql RPC exists).
+--
+-- CREATE OR REPLACE VIEW is all-or-nothing. Replacing this view from a definition reconstructed out
+-- of a stale file would SILENTLY REVERT whatever the live version actually contains — full-object
+-- DDL merges clean and then mutually reverts, with nothing failing at apply time to indicate it.
+--
+-- So this script REFUSES TO RUN unless the live definition matches what was assumed. If it raises,
+-- that is the script working: capture pg_get_viewdef output, reconcile the body below against it,
+-- and re-stage. Do not delete the guard to make the script run.
+DO $$
+DECLARE
+  live_def TEXT;
+BEGIN
+  SELECT pg_get_viewdef('public.v_ai_quality_tuning_recommendations'::regclass, true) INTO live_def;
+
+  IF live_def IS NULL THEN
+    RAISE EXCEPTION 'PRECONDITION FAILED: v_ai_quality_tuning_recommendations does not exist.';
+  END IF;
+
+  -- The reconstruction below assumes the live body still groups by these three keys and reads
+  -- weighted_score against pass_threshold. If any marker is absent, the live view has drifted from
+  -- the assumption and replacing it would discard the drift.
+  IF live_def NOT LIKE '%weighted_score%'
+     OR live_def NOT LIKE '%pass_threshold%'
+     OR live_def NOT LIKE '%ai_quality_assessments%' THEN
+    RAISE EXCEPTION 'PRECONDITION FAILED: live definition lacks an expected marker. Capture '
+      'pg_get_viewdef(''public.v_ai_quality_tuning_recommendations''::regclass, true) and reconcile '
+      'this file against it before applying. DO NOT remove this guard.';
+  END IF;
+
+  -- The window predicate is the KNOWN unknown: the file says created_at, the table has assessed_at.
+  -- Fail loudly if the live view filters on something this reconstruction does not reproduce.
+  IF live_def NOT LIKE '%assessed_at%' THEN
+    RAISE EXCEPTION 'PRECONDITION FAILED: live definition does not filter assessed_at, so this '
+      'reconstruction would change the observation window as a side effect. Reconcile first.';
+  END IF;
+END $$;
+
+CREATE OR REPLACE VIEW v_ai_quality_tuning_recommendations AS
+WITH threshold_stats AS (
+  SELECT
+    sd_type,
+    content_type,
+    pass_threshold,
+    COUNT(*) AS total,
+    ROUND(AVG(weighted_score), 1) AS avg_score,
+    ROUND(SUM(CASE WHEN weighted_score >= pass_threshold THEN 1 ELSE 0 END)::NUMERIC / COUNT(*) * 100, 1) AS pass_rate
+  FROM ai_quality_assessments
+  WHERE sd_type IS NOT NULL
+    AND assessed_at >= NOW() - INTERVAL '4 weeks'
+  GROUP BY sd_type, content_type, pass_threshold
+)
+SELECT
+  sd_type,
+  content_type,
+  pass_threshold AS current_threshold,
+  total AS assessments_last_4_weeks,
+  avg_score,
+  pass_rate,
+  CASE
+    -- ONE sample floor for BOTH arms, checked FIRST. Raised to the stricter of the two former values
+    -- rather than lowered to the weaker: the defect is drift toward leniency, so the safe direction
+    -- is more evidence, not less.
+    WHEN total < 10 THEN 'INSUFFICIENT DATA: Need more assessments (minimum 10)'
+    WHEN pass_rate < 50 AND (pass_threshold - 5) > avg_score THEN
+      'INEFFECTIVE CHANGE: scores sit well below the bar, so lowering it by 5 would not reach them. '
+      'This is a content signal, not a threshold signal.'
+    WHEN pass_rate < 50 THEN 'DECREASE (-5%): scores cluster just under the bar, which may be blocking legitimate work'
+    WHEN pass_rate > 90 AND avg_score > 80 AND (pass_threshold + 5) <= avg_score THEN
+      'INCREASE (+5%): Consistently high scores, can tighten standards'
+    WHEN pass_rate BETWEEN 60 AND 85 THEN 'OPTIMAL: Pass rate in target range (60-85%)'
+    ELSE 'MONITOR: Continue tracking, reassess in 2 weeks'
+  END AS recommendation,
+  -- NULL UNLESS AN ARM ACTUALLY FIRED. This is the whole of fix (2): the suggestion can no longer
+  -- outlive the recommendation that disclaims it, because there is nothing to read.
+  CASE
+    WHEN total < 10 THEN NULL
+    WHEN pass_rate < 50 AND (pass_threshold - 5) > avg_score THEN NULL
+    WHEN pass_rate < 50 THEN GREATEST(pass_threshold - 5, 45)
+    WHEN pass_rate > 90 AND avg_score > 80 AND (pass_threshold + 5) <= avg_score THEN LEAST(pass_threshold + 5, 85)
+    ELSE NULL
+  END AS suggested_threshold
+FROM threshold_stats
+ORDER BY sd_type, content_type;
+
+-- POST-CONDITIONS — assert the two defects are actually gone, in the same transaction that made the
+-- change. A migration that reports success without checking its own claim is the class of thing this
+-- SD exists to correct.
+DO $$
+DECLARE
+  contradictions INT;
+  cosmetic INT;
+BEGIN
+  SELECT COUNT(*) INTO contradictions
+  FROM v_ai_quality_tuning_recommendations
+  WHERE suggested_threshold IS NOT NULL
+    AND recommendation NOT LIKE 'DECREASE%'
+    AND recommendation NOT LIKE 'INCREASE%';
+  IF contradictions > 0 THEN
+    RAISE EXCEPTION 'POST-CONDITION FAILED: % row(s) publish a suggested_threshold while declining to act.', contradictions;
+  END IF;
+
+  SELECT COUNT(*) INTO cosmetic
+  FROM v_ai_quality_tuning_recommendations
+  WHERE recommendation LIKE 'DECREASE%' AND (current_threshold - 5) > avg_score;
+  IF cosmetic > 0 THEN
+    RAISE EXCEPTION 'POST-CONDITION FAILED: % DECREASE row(s) propose a bar still above the mean.', cosmetic;
+  END IF;
+
+  RAISE NOTICE 'OK: no self-contradicting rows, no cosmetic decreases.';
+END $$;
+
+COMMENT ON VIEW v_ai_quality_tuning_recommendations IS
+'Threshold tuning recommendations over the last 4 weeks. Both arms carry the same sample floor (10) '
+'and a score condition, so loosening never fires on weaker evidence than tightening '
+'(SD-LEO-INFRA-GATE-THRESHOLD-TUNING-001). suggested_threshold is NULL unless an arm fired. '
+'NOTE: this view still has NO OUTCOME ARM — it cannot see whether a gate-PASSED artifact later '
+'caused a defect, so it optimises band-occupancy only. Do not read a recommendation here as evidence '
+'that a threshold is correct, only that it is or is not blocking.';

--- a/database/chairman-gated/20260804_ai_quality_tuning_symmetric_guards_DOWN.sql
+++ b/database/chairman-gated/20260804_ai_quality_tuning_symmetric_guards_DOWN.sql
@@ -1,0 +1,72 @@
+-- DOWN for 20260804_ai_quality_tuning_symmetric_guards.sql
+-- SD-LEO-INFRA-GATE-THRESHOLD-TUNING-001. CHAIRMAN-GATED — stage only, never self-apply.
+--
+-- ⚠️ READ THIS BEFORE RUNNING. This DOWN restores the ASYMMETRIC rule, which means restoring:
+--   • a loosen arm that fires at total >= 5 while the tighten arm needs total >= 10,
+--   • a loosen arm with no score condition at all,
+--   • a suggested_threshold with no sample guard, free to publish a number on a row that reads
+--     INSUFFICIENT DATA (measured live: security x prd, n=2, suggested 70 against current 65),
+--   • DECREASE recommendations whose proposed bar still sits above the mean by 4.0 to 25.7 points.
+-- Those are the defects the UP script removed. Rolling back reinstates them. That is legitimate if
+-- the UP script broke something — it is not a neutral undo, and it should not be run to tidy up.
+--
+-- THE SAME PRE-CONDITION APPLIES IN THIS DIRECTION. The pre-change definition was never retrievable
+-- from the builder's side, so the body below is a RECONSTRUCTION, not a captured original. If the
+-- live view has since drifted, this would overwrite that drift exactly as the UP script would have.
+DO $$
+DECLARE
+  live_def TEXT;
+BEGIN
+  SELECT pg_get_viewdef('public.v_ai_quality_tuning_recommendations'::regclass, true) INTO live_def;
+  IF live_def IS NULL THEN
+    RAISE EXCEPTION 'PRECONDITION FAILED: view does not exist; nothing to roll back.';
+  END IF;
+  -- Refuse unless the UP script is what is actually live. Rolling back something else is not a
+  -- rollback, it is an unreviewed replacement.
+  IF live_def NOT LIKE '%INEFFECTIVE CHANGE%' THEN
+    RAISE EXCEPTION 'PRECONDITION FAILED: the live view is not the version this DOWN reverses '
+      '(no INEFFECTIVE CHANGE branch found). Capture pg_get_viewdef and reconcile before rolling back.';
+  END IF;
+END $$;
+
+CREATE OR REPLACE VIEW v_ai_quality_tuning_recommendations AS
+WITH threshold_stats AS (
+  SELECT
+    sd_type,
+    content_type,
+    pass_threshold,
+    COUNT(*) AS total,
+    ROUND(AVG(weighted_score), 1) AS avg_score,
+    ROUND(SUM(CASE WHEN weighted_score >= pass_threshold THEN 1 ELSE 0 END)::NUMERIC / COUNT(*) * 100, 1) AS pass_rate
+  FROM ai_quality_assessments
+  WHERE sd_type IS NOT NULL
+    AND assessed_at >= NOW() - INTERVAL '4 weeks'
+  GROUP BY sd_type, content_type, pass_threshold
+)
+SELECT
+  sd_type,
+  content_type,
+  pass_threshold AS current_threshold,
+  total AS assessments_last_4_weeks,
+  avg_score,
+  pass_rate,
+  CASE
+    WHEN pass_rate < 50 AND total >= 5 THEN 'DECREASE (-5%): Pass rate too low, may be blocking legitimate work'
+    WHEN pass_rate > 90 AND avg_score > 80 AND total >= 10 THEN 'INCREASE (+5%): Consistently high scores, can tighten standards'
+    WHEN pass_rate BETWEEN 60 AND 85 AND total >= 5 THEN 'OPTIMAL: Pass rate in target range (60-85%)'
+    WHEN total < 5 THEN 'INSUFFICIENT DATA: Need more assessments (minimum 5)'
+    ELSE 'MONITOR: Continue tracking, reassess in 2 weeks'
+  END AS recommendation,
+  CASE
+    WHEN pass_rate < 50 THEN GREATEST(pass_threshold - 5, 45)
+    WHEN pass_rate > 90 AND avg_score > 80 THEN LEAST(pass_threshold + 5, 85)
+    ELSE pass_threshold
+  END AS suggested_threshold
+FROM threshold_stats
+ORDER BY sd_type, content_type;
+
+COMMENT ON VIEW v_ai_quality_tuning_recommendations IS
+'Data-driven recommendations for threshold adjustments. Reviews last 4 weeks of data and suggests '
+'increases/decreases based on pass rates and score distribution. '
+'ROLLED BACK to the asymmetric rule by 20260804_ai_quality_tuning_symmetric_guards_DOWN.sql — the '
+'loosen arm fires on weaker evidence than the tighten arm, and suggested_threshold is unguarded.';

--- a/lib/quality/tuning-rules.js
+++ b/lib/quality/tuning-rules.js
@@ -1,0 +1,125 @@
+/**
+ * GATE-THRESHOLD TUNING RULES — SD-LEO-INFRA-GATE-THRESHOLD-TUNING-001.
+ *
+ * THE SHIPPED RULE LOOSENS ON WEAKER EVIDENCE THAN IT TIGHTENS ON, AND THAT IS A RATCHET.
+ * Measured at source (supabase/migrations/20251205_russian_judge_sd_type_awareness.sql:97-98):
+ * to DECREASE a threshold the view requires pass_rate < 50 AND total >= 5 — no score condition at
+ * all. To INCREASE one it requires pass_rate > 90 AND avg_score > 80 AND total >= 10. On a single
+ * live run that produced orchestrator x retrospective (100% pass, avg 88.7, n=6) DENIED an increase
+ * for n<10, while database x user_story (0% pass, n=8) FIRED a decrease. n=6 was too little evidence
+ * to tighten; n=8 was enough to loosen. A tuner shaped like that drifts one way regardless of what
+ * else is added to it, which is why this is fixed independently of the outcome arm.
+ *
+ * THE SECOND DEFECT IS THAT A RECOMMENDATION COULD CONTRADICT ITSELF. The view's suggested_threshold
+ * CASE (:103-107) carries NO sample-size guard while the recommendation CASE beside it does, so
+ * security x prd published suggested_threshold = 70 (up from 65) on the same row that reads
+ * "INSUFFICIENT DATA: Need more assessments (minimum 5)" with n=2. A number printed beside a
+ * disclaimer gets read without it. Here the suggestion is NULL unless its arm actually fired.
+ *
+ * WHY THIS IS JAVASCRIPT WHEN THE RULE LIVES IN SQL: the view is chairman-gated DDL, so it cannot be
+ * altered or executed from here. This module is the SPECIFICATION the staged DDL implements, and it
+ * is the only place the logic can be exercised before the ceremony runs. Keep the two in step.
+ */
+
+'use strict';
+
+/** Both arms move by the same step. */
+const STEP = 5;
+
+/**
+ * ONE sample floor for BOTH arms. Previously 5 to loosen and 10 to tighten — the asymmetry itself.
+ * Raised to the stricter of the two rather than lowered to the weaker: the failure being corrected
+ * is drift toward leniency, so the safe direction is more evidence, not less.
+ */
+const MIN_SAMPLE = 10;
+
+const RECOMMENDATION = Object.freeze({
+  DECREASE: 'DECREASE',
+  INCREASE: 'INCREASE',
+  OPTIMAL: 'OPTIMAL',
+  INSUFFICIENT_DATA: 'INSUFFICIENT_DATA',
+  MONITOR: 'MONITOR',
+  INEFFECTIVE_CHANGE: 'INEFFECTIVE_CHANGE',
+});
+
+/**
+ * Would moving the threshold by STEP actually reach the population it is meant to affect?
+ *
+ * THIS ENCODES A MEASURED FINDING, NOT A PREFERENCE. All six live DECREASE recommendations proposed
+ * a bar that, after the cut, still sat ABOVE the mean score — by 4.0 (documentation) to 25.7
+ * (database) points. Not one of them would have meaningfully changed its pass rate. A recommendation
+ * that cannot achieve its own stated purpose ("may be blocking legitimate work") should not be
+ * issued, whatever else is true: if scores sit far below the bar the problem is the content, and
+ * lowering the bar treats the symptom cosmetically while hiding it.
+ *
+ * The mirrored condition on the tightening side is the same idea pointed the other way — a raised
+ * bar must still sit at or below the mean, or it is a bar nothing clears.
+ */
+function changeIsEffective(direction, currentThreshold, avgScore) {
+  if (!Number.isFinite(avgScore)) return false;
+  return direction === 'DECREASE'
+    ? (currentThreshold - STEP) <= avgScore
+    : (currentThreshold + STEP) <= avgScore;
+}
+
+/**
+ * Recommend a threshold action for one sd_type x content_type cell.
+ *
+ * @param {object} row - { pass_rate, avg_score, current_threshold, total }
+ * @returns {{recommendation: string, suggested_threshold: number|null, reason: string}}
+ */
+function recommend(row) {
+  const pass = Number(row.pass_rate);
+  const avg = Number(row.avg_score);
+  const thr = Number(row.current_threshold);
+  const total = Number(row.total);
+
+  // INSUFFICIENT DATA IS CHECKED FIRST AND RETURNS A NULL SUGGESTION. The old shape let this label
+  // coexist with a moved number; ordering plus the null is what makes that unrepresentable rather
+  // than merely discouraged.
+  if (!Number.isFinite(total) || total < MIN_SAMPLE) {
+    return {
+      recommendation: RECOMMENDATION.INSUFFICIENT_DATA,
+      suggested_threshold: null,
+      reason: 'need at least ' + MIN_SAMPLE + ' assessments, have ' + (Number.isFinite(total) ? total : 0),
+    };
+  }
+
+  if (pass < 50) {
+    // The loosen arm now carries a score condition, which it previously had none of.
+    if (!changeIsEffective('DECREASE', thr, avg)) {
+      return {
+        recommendation: RECOMMENDATION.INEFFECTIVE_CHANGE,
+        suggested_threshold: null,
+        reason: 'pass rate ' + pass + '% is low, but avg_score ' + avg + ' sits ' + (thr - avg).toFixed(1)
+          + ' below the current bar — lowering by ' + STEP + ' would leave the bar above the mean and change'
+          + ' little. This is a content signal, not a threshold signal.',
+      };
+    }
+    return {
+      recommendation: RECOMMENDATION.DECREASE,
+      suggested_threshold: Math.max(thr - STEP, 45),
+      reason: 'pass rate ' + pass + '% with scores clustered just under the bar (avg ' + avg + ')',
+    };
+  }
+
+  // The tightening arm keeps its absolute avg_score > 80 condition IN ADDITION to the mirrored
+  // effectiveness test. That leaves it STRICTER than the loosening arm, which is deliberate: the
+  // defect being corrected is drift toward leniency, so the two arms need not be identical — what
+  // matters is that loosening never requires WEAKER evidence than tightening.
+  if (pass > 90 && avg > 80 && changeIsEffective('INCREASE', thr, avg)) {
+    return {
+      recommendation: RECOMMENDATION.INCREASE,
+      suggested_threshold: Math.min(thr + STEP, 85),
+      reason: 'pass rate ' + pass + '% with avg ' + avg + ' well clear of a raised bar',
+    };
+  }
+
+  if (pass >= 60 && pass <= 85) {
+    return { recommendation: RECOMMENDATION.OPTIMAL, suggested_threshold: null, reason: 'pass rate in the 60-85 target range' };
+  }
+
+  return { recommendation: RECOMMENDATION.MONITOR, suggested_threshold: null, reason: 'no arm met its evidence bar' };
+}
+
+module.exports = { recommend, changeIsEffective, RECOMMENDATION, MIN_SAMPLE, STEP };

--- a/scripts/quality/scorer-vs-content-adjudication.mjs
+++ b/scripts/quality/scorer-vs-content-adjudication.mjs
@@ -1,0 +1,69 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+// Attempt live view-definition retrieval. Recorded either way — acceptance requires reporting a
+// blocker rather than writing DDL from a file that is provably not the live object.
+for (const fn of ['exec_sql', 'execute_sql', 'run_sql', 'get_view_definition', 'sql']) {
+  const { error } = await sb.rpc(fn, { sql: "select 1" });
+  if (!error) { console.log('RPC AVAILABLE: ' + fn + ' <-- retrieve pg_get_viewdef with this'); }
+}
+console.log('view-definition retrieval: NO RPC AVAILABLE (checked 5 candidates)\n');
+
+// FR-1: sample BOTH arms. The failing lanes alone cannot adjudicate — both hypotheses predict low
+// scores there. The discriminating evidence is the CONTRAST with lanes that are healthy under the
+// SAME scorer and the SAME content_type.
+const FAILING = ['infrastructure', 'feature', 'bugfix', 'orchestrator', 'database', 'documentation'];
+const HEALTHY = ['refactor', 'security'];
+
+const pull = async (sdTypes, label) => {
+  const { data, error } = await sb.from('ai_quality_assessments')
+    .select('sd_type, content_id, weighted_score, pass_threshold, scores, feedback, band, assessed_at')
+    .eq('content_type', 'user_story').in('sd_type', sdTypes)
+    .order('assessed_at', { ascending: false }).limit(120);
+  if (error) { console.log(label + ' ERR: ' + error.message); return []; }
+  return data;
+};
+
+const fail = await pull(FAILING, 'FAILING');
+const heal = await pull(HEALTHY, 'HEALTHY');
+console.log('sampled: failing-lane n=' + fail.length + ', healthy-lane n=' + heal.length);
+
+const stat = (rows, label) => {
+  if (!rows.length) { console.log(label + ': EMPTY'); return; }
+  const ws = rows.map((r) => Number(r.weighted_score)).filter(Number.isFinite);
+  const mean = ws.reduce((a, b) => a + b, 0) / ws.length;
+  console.log('\n' + label + '  n=' + rows.length + '  mean=' + mean.toFixed(1)
+    + '  min=' + Math.min(...ws) + '  max=' + Math.max(...ws));
+  // The RUBRIC BREAKDOWN is the discriminator. If the scorer were miscalibrated for user stories we
+  // would expect it to mark them down broadly and similarly; if the content is weak we expect the
+  // failing lanes to lose points on specific dimensions the healthy lanes satisfy.
+  const dims = {};
+  for (const r of rows) {
+    if (r.scores && typeof r.scores === 'object') {
+      for (const [k, v] of Object.entries(r.scores)) {
+        if (Number.isFinite(Number(v))) { (dims[k] = dims[k] || []).push(Number(v)); }
+      }
+    }
+  }
+  for (const [k, v] of Object.entries(dims)) {
+    console.log('   ' + k.padEnd(28) + ' mean=' + (v.reduce((a, b) => a + b, 0) / v.length).toFixed(1) + ' (n=' + v.length + ')');
+  }
+  const bands = {};
+  for (const r of rows) bands[r.band] = (bands[r.band] || 0) + 1;
+  console.log('   bands: ' + JSON.stringify(bands));
+};
+
+stat(fail, 'FAILING LANES (' + FAILING.join(',') + ')');
+stat(heal, 'HEALTHY LANES (' + HEALTHY.join(',') + ')');
+
+console.log('\n=== SAMPLE FEEDBACK — failing lanes ===');
+for (const r of fail.slice(0, 3)) {
+  console.log('  [' + r.sd_type + ' ' + r.weighted_score + '/' + r.pass_threshold + '] '
+    + String(typeof r.feedback === 'string' ? r.feedback : JSON.stringify(r.feedback)).slice(0, 260));
+}
+console.log('\n=== SAMPLE FEEDBACK — healthy lanes ===');
+for (const r of heal.slice(0, 3)) {
+  console.log('  [' + r.sd_type + ' ' + r.weighted_score + '/' + r.pass_threshold + '] '
+    + String(typeof r.feedback === 'string' ? r.feedback : JSON.stringify(r.feedback)).slice(0, 260));
+}

--- a/scripts/quality/user-story-score-trend.mjs
+++ b/scripts/quality/user-story-score-trend.mjs
@@ -1,0 +1,52 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+// MY FR-1 SAMPLE WAS RECENCY-BIASED and I am not going to launder that. It took the latest 120 rows
+// and their failing-lane mean was 65.6, while the 4-week view reports ~41 for the same lanes. Either
+// the sample is unrepresentative, or user-story quality is moving fast. Both matter, and they are
+// distinguishable — so measure the whole window by week instead of arguing about it.
+const FAILING = ['infrastructure', 'feature', 'bugfix', 'orchestrator', 'database', 'documentation'];
+const HEALTHY = ['refactor', 'security'];
+
+const all = [];
+const PAGE = 1000;
+for (let from = 0; ; from += PAGE) {
+  const { data, error } = await sb.from('ai_quality_assessments')
+    .select('sd_type, weighted_score, pass_threshold, assessed_at')
+    .eq('content_type', 'user_story')
+    .gte('assessed_at', new Date(Date.now() - 28 * 864e5).toISOString())
+    .order('assessed_at', { ascending: true }).range(from, from + PAGE - 1);
+  if (error) { console.log('ERR ' + error.message); break; }
+  all.push(...(data || []));
+  if (!data || data.length < PAGE) break;
+}
+// Reconcile against the count so a silent cap cannot masquerade as the population.
+const { count } = await sb.from('ai_quality_assessments')
+  .select('*', { count: 'exact', head: true })
+  .eq('content_type', 'user_story')
+  .gte('assessed_at', new Date(Date.now() - 28 * 864e5).toISOString());
+console.log('fetched=' + all.length + ' count=' + count + (all.length === count ? ' RECONCILED' : ' <-- MISMATCH, do not trust'));
+
+const bucket = (rows) => {
+  const wk = {};
+  for (const r of rows) {
+    const d = Math.floor((Date.now() - Date.parse(r.assessed_at)) / 864e5 / 7);
+    (wk[d] = wk[d] || []).push(Number(r.weighted_score));
+  }
+  return wk;
+};
+const show = (label, rows) => {
+  const wk = bucket(rows);
+  console.log('\n' + label + ' (n=' + rows.length + ')');
+  for (const k of Object.keys(wk).sort((a, b) => a - b)) {
+    const v = wk[k];
+    const pass = rows.filter((r) => Math.floor((Date.now() - Date.parse(r.assessed_at)) / 864e5 / 7) === Number(k)
+      && Number(r.weighted_score) >= Number(r.pass_threshold)).length;
+    console.log('  ' + (k === '0' ? 'this week ' : k + ' wk ago  ') + ' n=' + String(v.length).padEnd(5)
+      + ' mean=' + (v.reduce((a, b) => a + b, 0) / v.length).toFixed(1).padEnd(6)
+      + ' pass=' + (100 * pass / v.length).toFixed(1) + '%');
+  }
+};
+show('FAILING LANES', all.filter((r) => FAILING.includes(r.sd_type)));
+show('HEALTHY LANES', all.filter((r) => HEALTHY.includes(r.sd_type)));

--- a/tests/unit/tuning-rules.test.js
+++ b/tests/unit/tuning-rules.test.js
@@ -1,0 +1,125 @@
+/**
+ * SD-LEO-INFRA-GATE-THRESHOLD-TUNING-001 — the tuner must not loosen on weaker evidence than it
+ * tightens on, and must not publish a number its own recommendation disclaims.
+ *
+ * EVERY SEEDED CASE BELOW IS A ROW MEASURED LIVE on 2026-08-04, not an invented one. A seeded case
+ * drawn from real data cannot later be waved away as hypothetical.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { recommend, RECOMMENDATION, MIN_SAMPLE } from '../../lib/quality/tuning-rules.js';
+
+// The six live DECREASE rows. Each proposed a bar that, after the cut, still sat ABOVE its mean.
+const LIVE_DECREASE = [
+  { name: 'bugfix', pass_rate: 25.2, avg_score: 41.9, current_threshold: 60, total: 234 },
+  { name: 'database', pass_rate: 0, avg_score: 34.3, current_threshold: 65, total: 8 },
+  { name: 'documentation', pass_rate: 15.4, avg_score: 41, current_threshold: 50, total: 13 },
+  { name: 'feature', pass_rate: 15.6, avg_score: 40.5, current_threshold: 60, total: 244 },
+  { name: 'infrastructure', pass_rate: 20.9, avg_score: 41.3, current_threshold: 55, total: 1457 },
+  { name: 'orchestrator', pass_rate: 13.1, avg_score: 34.9, current_threshold: 50, total: 61 },
+];
+
+// The live INCREASE rows — the positive control. These must survive the new symmetry.
+const LIVE_INCREASE = [
+  { name: 'feature x prd', pass_rate: 100, avg_score: 80.4, current_threshold: 60, total: 53 },
+  { name: 'infrastructure x retrospective', pass_rate: 100, avg_score: 91.3, current_threshold: 55, total: 15 },
+  { name: 'refactor x retrospective', pass_rate: 100, avg_score: 88.4, current_threshold: 60, total: 11 },
+  { name: 'refactor x user_story', pass_rate: 100, avg_score: 82.4, current_threshold: 60, total: 41 },
+];
+
+describe('TS-3 — SEEDED: the two arms carry equal evidentiary burden', () => {
+  it('the measured n=6 / n=8 pair no longer resolves asymmetrically', () => {
+    // THE DEFECT, verbatim from one live run: orchestrator x retrospective was DENIED an increase at
+    // n=6 while database x user_story FIRED a decrease at n=8. Too little evidence to tighten, enough
+    // to loosen — a ratchet visible without any outcome data.
+    const deniedIncrease = recommend({ pass_rate: 100, avg_score: 88.7, current_threshold: 50, total: 6 });
+    const firedDecrease = recommend({ pass_rate: 0, avg_score: 34.3, current_threshold: 65, total: 8 });
+    expect(deniedIncrease.recommendation).toBe(RECOMMENDATION.INSUFFICIENT_DATA);
+    expect(firedDecrease.recommendation).toBe(RECOMMENDATION.INSUFFICIENT_DATA);
+    // The point is not that both are refused — it is that they are refused for the SAME reason.
+    expect(firedDecrease.recommendation).toBe(deniedIncrease.recommendation);
+  });
+
+  it('a sample sufficient to LOOSEN is also sufficient to TIGHTEN', () => {
+    const n = MIN_SAMPLE;
+    expect(recommend({ pass_rate: 10, avg_score: 58, current_threshold: 60, total: n }).recommendation)
+      .toBe(RECOMMENDATION.DECREASE);
+    expect(recommend({ pass_rate: 100, avg_score: 90, current_threshold: 60, total: n }).recommendation)
+      .toBe(RECOMMENDATION.INCREASE);
+  });
+
+  it('loosening never fires on evidence that would be refused for tightening', () => {
+    const belowFloor = MIN_SAMPLE - 1;
+    expect(recommend({ pass_rate: 0, avg_score: 58, current_threshold: 60, total: belowFloor }).recommendation)
+      .toBe(RECOMMENDATION.INSUFFICIENT_DATA);
+  });
+});
+
+describe('TS-2 — SEEDED: a row can never contradict its own recommendation', () => {
+  it('security x prd (n=2) publishes NO threshold alongside INSUFFICIENT DATA', () => {
+    // MEASURED LIVE: this row read "INSUFFICIENT DATA: Need more assessments (minimum 5)" and
+    // published suggested_threshold = 70 against a current 65, on the same row.
+    const r = recommend({ pass_rate: 100, avg_score: 81.5, current_threshold: 65, total: 2 });
+    expect(r.recommendation).toBe(RECOMMENDATION.INSUFFICIENT_DATA);
+    expect(r.suggested_threshold).toBeNull();
+  });
+
+  it('no outcome ever pairs a non-acting recommendation with a moved number', () => {
+    const rows = [
+      { pass_rate: 100, avg_score: 81.5, current_threshold: 65, total: 2 },
+      { pass_rate: 100, avg_score: 77.7, current_threshold: 65, total: 3 },
+      { pass_rate: 84.2, avg_score: 79.5, current_threshold: 60, total: 101 },
+      { pass_rate: 89.6, avg_score: 82.7, current_threshold: 60, total: 77 },
+      ...LIVE_DECREASE,
+    ];
+    for (const row of rows) {
+      const r = recommend(row);
+      const acts = r.recommendation === RECOMMENDATION.DECREASE || r.recommendation === RECOMMENDATION.INCREASE;
+      if (!acts) expect(r.suggested_threshold).toBeNull();
+      else expect(r.suggested_threshold).not.toBeNull();
+    }
+  });
+});
+
+describe('TS-1 / cosmetic-change guard — none of the six live DECREASEs survives', () => {
+  it.each(LIVE_DECREASE)('$name does not recommend a decrease that would not reach the population', (row) => {
+    const r = recommend(row);
+    expect(r.recommendation).not.toBe(RECOMMENDATION.DECREASE);
+    expect(r.suggested_threshold).toBeNull();
+  });
+
+  it('the five with enough samples are refused as INEFFECTIVE, not merely under-evidenced', () => {
+    // database (n=8) is refused for sample size; the other five have ample data and are refused
+    // because the change itself would achieve nothing — a distinction worth keeping visible, since
+    // "collect more data" and "this is the wrong lever" call for different responses.
+    const ineffective = LIVE_DECREASE.filter((r) => r.total >= MIN_SAMPLE)
+      .map((r) => recommend(r).recommendation);
+    expect(ineffective).toHaveLength(5);
+    for (const v of ineffective) expect(v).toBe(RECOMMENDATION.INEFFECTIVE_CHANGE);
+  });
+});
+
+describe('TS-5 — POSITIVE CONTROL: symmetry must not be achieved by disabling both arms', () => {
+  it.each(LIVE_INCREASE)('$name still recommends INCREASE', (row) => {
+    // Without this, weakening the tighten arm — or refusing everything — would pass every negative
+    // scenario above while leaving a tuner that recommends nothing at all.
+    const r = recommend(row);
+    expect(r.recommendation).toBe(RECOMMENDATION.INCREASE);
+    expect(r.suggested_threshold).toBe(Math.min(row.current_threshold + 5, 85));
+  });
+
+  it('a genuine DECREASE still fires when scores really are clustered just under the bar', () => {
+    // The rule must remain capable of loosening. A near-miss population is exactly the case the
+    // original DECREASE arm was written for, and it is preserved.
+    const r = recommend({ pass_rate: 30, avg_score: 57, current_threshold: 60, total: 40 });
+    expect(r.recommendation).toBe(RECOMMENDATION.DECREASE);
+    expect(r.suggested_threshold).toBe(55);
+  });
+
+  it('OPTIMAL and MONITOR still classify the middle band', () => {
+    expect(recommend({ pass_rate: 84.2, avg_score: 79.5, current_threshold: 60, total: 101 }).recommendation)
+      .toBe(RECOMMENDATION.OPTIMAL);
+    expect(recommend({ pass_rate: 89.6, avg_score: 82.7, current_threshold: 60, total: 77 }).recommendation)
+      .toBe(RECOMMENDATION.MONITOR);
+  });
+});


### PR DESCRIPTION
Adam's governance scan proposed applying 11 threshold recommendations; two independent verifications refuted the DECREASE class. **Measurement upholds that hold and adds three arguments, any one sufficient.**

## The arms carried unequal evidentiary burdens

Loosening fired on `pass_rate < 50 AND total >= 5` — **no score condition at all**. Tightening required `pass_rate > 90 AND avg_score > 80 AND total >= 10`.

On one live run: `orchestrator × retrospective` (100% pass, avg 88.7, **n=6**) was **denied** an increase, while `database × user_story` (0% pass, **n=8**) **fired** a decrease. n=6 too little evidence to tighten, n=8 enough to loosen. A tuner shaped like that drifts one way regardless of what else is bolted on — and this needs no outcome data to see or fix.

## Every proposed DECREASE was cosmetic

After the −5, the bar still sat **above** the mean by 4.0 (documentation) to 25.7 (database) points. Not one would have moved its pass rate. **Ineffective on its own terms**, even granting its premise entirely. Those rows now return `INEFFECTIVE_CHANGE` — a content signal, not a threshold signal.

## `suggested_threshold` could contradict its own `recommendation`

No sample guard, while the column beside it had one. `security × prd` published **70** (up from 65) on a row reading *"INSUFFICIENT DATA … (minimum 5)"* at n=2. A number beside a disclaimer gets read without it. Now `NULL` unless an arm fired — the contradiction is unrepresentable, not merely discouraged.

## FR-1 adjudicated: the content is weak, not the scorer

The SD prescribed sampling 10 low-scoring user stories. **That sample can't adjudicate** — both hypotheses predict low scores there. The control was already in the data: `refactor × user_story` scores 82.4 at 100% pass over n=41 under the *same* scorer.

Time-matched (same weeks, same scorer): healthy lanes **100% pass at mean 76.7–87.0**, failing lanes **9.1–12.7% at mean 38.4–39.1**. The scorer's criticisms are specific and checkable — *"explicitly states 'No Given-When-Then scenarios defined'"* — and it returns empty improvement lists on healthy lanes. It can pass user stories. These didn't deserve to. **Lowering the bar would have hidden a real defect.**

## The window is stale

User-story quality **jumped this week**: mean 32.2 → 54.0, pass **4.0% → 61.1%** (n=2070, reconciled against an exact count). The 4-week window is dominated by three bad weeks and masks a live recovery — the recommendation was computed from data a landed fix had already superseded.

## FR-2 is blocked, not worked around

Three measured blockers: no outcome-joined view exists (the named sibling is a what-if simulator); the live view definition is unretrievable (no `exec_sql` RPC) while the migration file is provably not it (filters `created_at`, a column the base table lacks); and the only adjacent outcome signal, `user_stories.e2e_test_status`, records **zero failures across all 15,610 rows** (89.9% `not_created`). An arm built on it could not fire — worse than none, because it would look like one.

## Verification

DDL is **staged** under `database/chairman-gated/` with a paired `_DOWN`. Both carry a `pg_get_viewdef` pre-condition that refuses to run if the live definition differs from the reconstruction, so a silent full-object revert is impossible. The live view is unchanged by this PR.

18 tests, mutation-proven — restoring the n>=5 floor, dropping the cosmetic guard, publishing a number while declining to act, and disabling the tighten arm each fail the suite (**2/6/3/5**). Every seeded case is a row measured live, not invented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)