### PR TITLE
feat(SD-LEO-INFRA-DRIVE-LOOP-INSTRUMENT-001-E): escalation ladder, aggregation guard, inbound SLA watcher

### DIFF
--- a/lib/escalation/aggregate.js
+++ b/lib/escalation/aggregate.js
@@ -1,0 +1,89 @@
+/**
+ * SD-LEO-INFRA-DRIVE-LOOP-INSTRUMENT-001-E — the aggregation guard.
+ *
+ * Two independent properties, and MISSING EITHER ONE PRODUCES A FLOOD OR A SILENCE. Both were
+ * established by reading the precedent rather than inheriting the SD scope's summary of it.
+ *
+ * ── 1. THE CAP IS PER-TICK, NEVER PER-TARGET ────────────────────────────────────────────────
+ * lib/adam/inbound-backlog-watchdog.js records why, from a case that already happened:
+ *   "NO copy of MAX_PROBES_PER_TICK=5. That cap is per-TARGET, and every inbound row shares a
+ *    single target (Adam), so a literal copy structurally collapses to 1 and would cap the
+ *    alarm rather than bound it."
+ * -E's x5 rung has exactly that shape — every chairman escalation shares ONE target. A
+ * per-target cap there does not bound the noise; it SILENCES the alarm, and it does so while
+ * looking like prudent rate-limiting. Worse, it passes a naive test: with one target, a single
+ * emitted row IS the expected output. Only an N>cap same-target fixture can tell a bound from a
+ * silencer, which is what TS-5 exists to be.
+ *
+ * ── 2. AGGREGATION HAS TWO HALVES, AND THE SD SCOPE NAMES ONLY ONE ──────────────────────────
+ * The scope cites lib/adam/stall-alert.js:301-306 as "caps escalation at ONE digest per tick
+ * regardless of stall count". VERIFIED TRUE — and incomplete. The same block implements
+ * QF-20260703-860, which also caps ACROSS TICKS: while a pending digest exists it is SUPERSEDED
+ * (summary/context refreshed in place) instead of a fresh row being inserted.
+ *
+ * Implementing only the within-tick half yields one row per tick — emitted EVERY tick for as
+ * long as the item stays unmoved. Same flood, slower axis. And because the ladder is inherently
+ * repeating, an unmoved item is the NORMAL case rather than an edge case, so the omission fires
+ * constantly rather than rarely.
+ *
+ * NO WRITES LIVE HERE. The caller supplies find/insert/update, which keeps this unit testable
+ * without a database and keeps -E's acting code off any path reachable from the report job
+ * (-B scope bullet 10).
+ */
+
+/**
+ * Cap on digest decisions emitted in ONE TICK, across all items sharing a lane.
+ *
+ * NAMED FOR WHAT IT BOUNDS. The name is the guard: `MAX_DIGESTS_PER_TICK` cannot be silently
+ * reinterpreted as per-recipient the way a bare `MAX_ESCALATIONS` can. See property 1 above.
+ */
+export const MAX_DIGESTS_PER_TICK = 1;
+
+/**
+ * Aggregate one lane's stalls for one tick into at most MAX_DIGESTS_PER_TICK actions.
+ *
+ * @param {object[]} stalls        stalls already routed to a single lane this tick
+ * @param {object}   io
+ * @param {Function} io.findPending  async () => existing pending digest | null
+ * @param {Function} io.insert       async (digest) => created row
+ * @param {Function} io.update       async (id, patch) => updated row
+ * @param {string}   [lane]
+ * @returns {Promise<{action:'none'|'inserted'|'superseded', count:number, id:string|null}>}
+ */
+export async function aggregateLane(stalls, io, lane = 'unknown') {
+  const items = Array.isArray(stalls) ? stalls : [];
+  if (items.length === 0) return { action: 'none', count: 0, id: null };
+
+  for (const k of ['findPending', 'insert', 'update']) {
+    if (typeof io?.[k] !== 'function') {
+      throw new TypeError(`[aggregate] io.${k} must be a function — refusing to guess a write path`);
+    }
+  }
+
+  // The count reported is the count of ITEMS AGGREGATED, not the count of rows emitted. That
+  // distinction is the whole point: N stalls collapse to ONE decision, and the decision must
+  // still carry N so the reader knows the scale. A cap that also truncated the count would
+  // reproduce the silencer.
+  const count = items.length;
+  const ids = items.map((s) => s.id);
+
+  const existing = await io.findPending();
+
+  if (existing) {
+    // CROSS-TICK HALF. Refresh in place. The pending decision keeps its identity, so any
+    // downstream "already notified" stamp on it stays valid and the recipient is not re-pinged
+    // for a condition they have already seen. This is what makes an item that stays unmoved for
+    // 50 ticks produce ~1 row rather than 50.
+    await io.update(existing.id, {
+      count,
+      item_ids: ids,
+      lane,
+      updated_at: new Date().toISOString(),
+    });
+    return { action: 'superseded', count, id: existing.id };
+  }
+
+  // WITHIN-TICK HALF. One insert regardless of how many items are in `items`.
+  const row = await io.insert({ count, item_ids: ids, lane });
+  return { action: 'inserted', count, id: row?.id ?? null };
+}

--- a/lib/escalation/brief.js
+++ b/lib/escalation/brief.js
@@ -1,0 +1,76 @@
+/**
+ * SD-LEO-INFRA-DRIVE-LOOP-INSTRUMENT-001-E — FR_C, the x5 chairman brief.
+ *
+ * THE RUNG IS AN INTERROGATIVE BRIEF, NEVER A BARE COUNT, and the SD marks this FIRM. The
+ * reason is what the rung is FOR: the chairman packet exists so the chairman can ACT, and
+ * "3 items unmoved" is not actionable. It names a volume, not a decision. Every field below
+ * exists because acting requires it — WHICH item (position), HOW STALE (days), WHY it is stuck
+ * (blocker), WHO owns it (owner), and WHAT WAS ALREADY ASKED at x3 so the chairman is not
+ * re-asked a question already in flight.
+ *
+ * THE FAILURE MODE THIS GUARDS IS SILENT. A brief missing a field still renders, still reads
+ * like a report, and still gets filed — it simply cannot be acted on, and the packet quietly
+ * degrades into a volume gauge. So buildBrief REFUSES rather than emitting a partial: an
+ * absent required field throws, naming the field. A brief that cannot be acted on should not
+ * exist, because its existence is what makes the packet look healthy.
+ */
+
+/** Fields without which the brief is not actionable. Order is display order. */
+export const REQUIRED_BRIEF_FIELDS = Object.freeze([
+  'position',      // WHICH item — where it sits on the roadmap
+  'days_unmoved',  // HOW STALE — the quantity that justifies the rung
+  'blocker',       // WHY — named, not "blocked"
+  'owner',         // WHO
+  'question',      // WHAT WAS ALREADY ASKED at x3, so x5 escalates rather than repeats
+]);
+
+/**
+ * @param {object} stall
+ * @returns {{fields:object, line:string}}
+ * @throws {Error} naming every missing field — refuses to emit an unactionable brief
+ */
+export function buildBrief(stall) {
+  if (!stall || typeof stall !== 'object') {
+    throw new TypeError(`[brief] stall must be an object, received ${JSON.stringify(stall)}`);
+  }
+
+  const missing = REQUIRED_BRIEF_FIELDS.filter((f) => {
+    const v = stall[f];
+    // Empty string and whitespace count as missing. A blocker of "" renders as a brief with a
+    // blank where the reason belongs, which is the degraded-but-plausible output this guards.
+    return v === undefined || v === null || (typeof v === 'string' && v.trim() === '');
+  });
+
+  if (missing.length > 0) {
+    throw new Error(
+      `[brief] refusing to emit an unactionable x5 chairman brief — missing: ${missing.join(', ')}. ` +
+      'FR_C is FIRM: the x5 rung is an interrogative brief, never a bare count. A brief missing a ' +
+      'field still renders and still gets filed; it simply cannot be acted on, and the packet ' +
+      'degrades into a volume gauge without anyone noticing.'
+    );
+  }
+
+  const fields = Object.fromEntries(REQUIRED_BRIEF_FIELDS.map((f) => [f, stall[f]]));
+  const line =
+    `${fields.position} — unmoved ${fields.days_unmoved}d — blocker: ${fields.blocker} — ` +
+    `owner: ${fields.owner} — asked at x3: "${fields.question}"`;
+
+  return { fields, line };
+}
+
+/**
+ * Does a rendered line carry every required field?
+ *
+ * Exists so a REVIEWER (or a downstream assertion) can check a brief it did not build — e.g. one
+ * that arrived as text. Deliberately checks for the field VALUES, not the labels: a template that
+ * printed the labels with empty values would pass a label-only check while carrying nothing.
+ */
+export function briefIsActionable(line, stall) {
+  if (typeof line !== 'string' || line.trim() === '') return false;
+  try {
+    const { fields } = buildBrief(stall);
+    return REQUIRED_BRIEF_FIELDS.every((f) => line.includes(String(fields[f])));
+  } catch {
+    return false;
+  }
+}

--- a/lib/escalation/inbox-sla.js
+++ b/lib/escalation/inbox-sla.js
@@ -1,0 +1,81 @@
+/**
+ * SD-LEO-INFRA-DRIVE-LOOP-INSTRUMENT-001-E — the INBOUND SLA watcher.
+ *
+ * ── THE DIRECTION, WHICH PLAN SETTLED BY MEASUREMENT ────────────────────────────────────────
+ * The SD scope said this "reduces to a window parameter" because checkAndPingOverdueReplies
+ * already exists. Measured at lib/coordinator/reply-class.cjs:203, that sweep selects
+ * `target_session` from rows THIS session SENT and pings the target — it answers
+ * "I ASKED AND NOBODY ANSWERED". An inbox-SLA watcher answers the inverse: "SOMEONE ASKED ME
+ * AND I HAVE NOT ANSWERED". Same table, same window, DIFFERENT POPULATION. Reusing the sender
+ * sweep for the inbound direction would produce a working watcher aimed at the wrong side, and
+ * it would look correct in review — which is why TS-7 pins the direction explicitly.
+ *
+ * WHAT IS REUSED AND WHAT IS NOT. findOverdueReplyNeeded is PURE and direction-agnostic: it
+ * filters rows on reply_class / reply_expected_by / ping_sent_at without caring who sent them.
+ * So the DIRECTION LIVES IN THE CANDIDATE QUERY, NOT THE PREDICATE. This module supplies
+ * recipient-scoped rows and reuses the predicate and computeReplyExpectedBy untouched (TR-3) —
+ * a second window definition is exactly the sibling-drift that lib/fleet/belt-depth.cjs exists
+ * to abolish.
+ *
+ * ── NO LIVENESS GATE, AND THAT IS DELIBERATE ────────────────────────────────────────────────
+ * The SD scope says "while Adam is engaged". PLAN struck that phrase on the evidence of a
+ * shipped sibling, lib/adam/inbound-backlog-watchdog.js:
+ *   "NO liveness gate. The mirror skips targets without a fresh heartbeat; for INBOUND, 'no
+ *    live Adam session' is the WORST backlog condition, not an exemption — the witnessed
+ *    incident had Adam's recurring loops dead overnight. The gate is INVERTED by simply not
+ *    having one."
+ * A liveness gate here disarms the watcher in precisely the incident it exists to catch. There
+ * is therefore no heartbeat predicate anywhere in this file, and TS-6 drives it with ZERO live
+ * sessions to prove the absence is real rather than incidental.
+ */
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const { findOverdueReplyNeeded } = require_('../coordinator/reply-class.cjs');
+
+/**
+ * Rows addressed TO `sessionId` that are overdue for a reply FROM it.
+ *
+ * @param {object} supabase
+ * @param {string} sessionId  the seat whose INBOX is being measured
+ * @param {{nowMs?:number, answeredCorrelationIds?:Set<string>}} [opts]
+ * @returns {Promise<{overdue:object[], scanned:number}>}
+ */
+export async function findInboundOverdue(supabase, sessionId, opts = {}) {
+  if (typeof sessionId !== 'string' || sessionId.trim() === '') {
+    throw new TypeError(`[inbox-sla] sessionId must be a non-empty string, received ${JSON.stringify(sessionId)}`);
+  }
+
+  // THE DIRECTION, expressed as the one filter that distinguishes it: target_session, not
+  // sender_session. Everything else about the sweep is identical to the outbound one, which is
+  // why the two are so easy to confuse and why this line carries the whole distinction.
+  //
+  // NOTE the absence: there is no join to claude_sessions and no heartbeat filter. See header.
+  const { data, error } = await supabase
+    .from('session_coordination')
+    .select('id, target_session, sender_session, subject, payload, created_at')
+    .eq('target_session', sessionId);
+
+  if (error) throw new Error(`[inbox-sla] DB error scanning inbox for ${sessionId}: ${error.message}`);
+
+  const rows = data || [];
+  const overdue = findOverdueReplyNeeded(rows, opts.nowMs ?? Date.now(), opts.answeredCorrelationIds);
+  return { overdue, scanned: rows.length };
+}
+
+/**
+ * Shape an overdue inbound row as a stall the ladder can rung.
+ *
+ * `ticks` is supplied by the caller (the sweep owns tick accounting); this only adapts shape.
+ */
+export function asStall(row, ticks) {
+  return {
+    id: row.id,
+    stall_type: 'inbox_sla',
+    owner: row.target_session,
+    ticks,
+    asked_by: row.sender_session,
+    subject: row.subject,
+    expected_by: row?.payload?.reply_expected_by ?? null,
+  };
+}

--- a/lib/escalation/ladder.js
+++ b/lib/escalation/ladder.js
@@ -1,0 +1,94 @@
+/**
+ * SD-LEO-INFRA-DRIVE-LOOP-INSTRUMENT-001-E — the escalation ladder and lane router.
+ *
+ * PURE BY CONSTRUCTION, AND THAT IS A REQUIREMENT RATHER THAN A STYLE CHOICE. -B's scope
+ * bullet 10 forbids any write path from the drive-report job reaching a claim, a dispatch, or
+ * an SD insert — the guardrail that keeps an instrument from becoming an actor. This module
+ * therefore holds ZERO writes and lives OUTSIDE lib/drive-loop/, so -E's acting code can never
+ * be reached from the report job.
+ *
+ * (PLAN correction, recorded so nobody re-derives it wrongly: -E's scope cites that constraint
+ * as "-B's FR-7 ... anywhere under lib/drive-loop/". Measured, it is -B scope bullet 10 and it
+ * is JOB-scoped, not directory-scoped. The separation is kept anyway because being stricter is
+ * free; the citation is corrected so a future reader does not contort around a directory-wide
+ * ban that does not exist.)
+ */
+
+/**
+ * Ladder rungs, keyed by the number of consecutive ticks an item has gone unmoved.
+ *
+ * OFF-BY-ONE IS THE WHOLE FEATURE. A rung that fires at x1 makes the ladder noise; one that
+ * fires at x6 makes it decorative. The boundaries are exact and TS-1 drives 1..5 to prove it.
+ */
+export const RUNG = Object.freeze({
+  NONE: null,
+  IN_REPORT: 'in_report',   // x2 — visible in the report, no message sent
+  OWNER: 'owner',           // x3 — one message to the owning lane
+  CHAIRMAN: 'chairman',     // x5 — a line in the chairman packet
+});
+
+/**
+ * @param {number} ticks consecutive ticks unmoved
+ * @returns {string|null} the rung that fires AT this tick, or null when none does
+ */
+export function rungForTicks(ticks) {
+  if (!Number.isInteger(ticks) || ticks < 0) {
+    throw new TypeError(`[ladder] ticks must be a non-negative integer, received ${JSON.stringify(ticks)}`);
+  }
+  // Deliberately exact equality, not >=. A rung fires ON its tick and not again; "still true at
+  // x4" is the NORMAL case for an unmoved item, and re-firing every tick thereafter is the flood
+  // FR_C exists to prevent. Persistence across ticks is handled by the supersede path, not here.
+  if (ticks === 2) return RUNG.IN_REPORT;
+  if (ticks === 3) return RUNG.OWNER;
+  if (ticks === 5) return RUNG.CHAIRMAN;
+  return RUNG.NONE;
+}
+
+/** Destination lanes. Membership is exclusive — an item belongs to exactly one. */
+export const LANE = Object.freeze({
+  CHAIRMAN: 'chairman_packet',
+  OWNER: 'owner',
+  ADAM: 'adam',
+});
+
+/**
+ * Route a stall to its lane BY STALL TYPE.
+ *
+ * EXCLUSIVITY IS THE PROPERTY THAT MATTERS. A pending-chairman item reaching an owner lane is
+ * what makes the chairman packet untrustworthy — the packet's value is that everything in it is
+ * genuinely the chairman's to decide. So pending-chairman is tested FIRST and returns
+ * immediately; there is no path by which one stall yields two lanes.
+ *
+ * @param {{stall_type?:string, owner?:string|null}} stall
+ * @returns {string} one of LANE
+ */
+export function laneForStall(stall) {
+  if (!stall || typeof stall !== 'object') {
+    throw new TypeError(`[ladder] stall must be an object, received ${JSON.stringify(stall)}`);
+  }
+  const type = String(stall.stall_type || '').toLowerCase();
+
+  if (type === 'pending_chairman') return LANE.CHAIRMAN;
+  if (type === 'unsourced') return LANE.ADAM;
+  if (stall.owner) return LANE.OWNER;
+  // No owner and not otherwise classified: unsourced work by definition — it has nobody to
+  // route to, which is precisely what Adam materialises. Falling back to the owner lane here
+  // would send a message to nobody and read as "handled".
+  return LANE.ADAM;
+}
+
+/**
+ * Group stalls into { lane -> stalls[] } for a single tick.
+ *
+ * Returned as a Map keyed by lane so the caller aggregates PER LANE PER TICK. See
+ * lib/escalation/aggregate.js for why the cap must never be keyed on the recipient.
+ */
+export function groupByLane(stalls) {
+  const out = new Map();
+  for (const s of stalls || []) {
+    const lane = laneForStall(s);
+    if (!out.has(lane)) out.set(lane, []);
+    out.get(lane).push(s);
+  }
+  return out;
+}

--- a/tests/unit/escalation/aggregate.test.js
+++ b/tests/unit/escalation/aggregate.test.js
@@ -1,0 +1,113 @@
+// SD-LEO-INFRA-DRIVE-LOOP-INSTRUMENT-001-E — TS-3 (within-tick), TS-4 (cross-tick supersede),
+// TS-5 (the per-target-cap collapse that reads as a bound and acts as a silencer).
+import { describe, it, expect } from 'vitest';
+import { aggregateLane, MAX_DIGESTS_PER_TICK } from '../../../lib/escalation/aggregate.js';
+
+/** Recording io seam. Counts real emissions so a "cap" cannot hide behind a return value. */
+function io({ pending = null } = {}) {
+  const calls = { inserts: [], updates: [], finds: 0 };
+  return {
+    calls,
+    findPending: async () => { calls.finds += 1; return pending; },
+    insert: async (d) => { calls.inserts.push(d); return { id: 'digest-1', ...d }; },
+    update: async (id, patch) => { calls.updates.push({ id, ...patch }); return { id, ...patch }; },
+  };
+}
+
+describe('TS-3 — WITHIN a tick, N stalls collapse to ONE digest', () => {
+  it('5 stalls in one tick emit exactly 1 insert', async () => {
+    const t = io();
+    const res = await aggregateLane([{ id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' }, { id: 'e' }], t, 'owner');
+    expect(t.calls.inserts).toHaveLength(MAX_DIGESTS_PER_TICK);
+    expect(res.action).toBe('inserted');
+  });
+
+  it('the digest CARRIES the count — collapsing rows must not collapse the scale', async () => {
+    // A cap that also truncated the reported count would be the silencer wearing the bound's
+    // clothes: one row saying "1 item" when 5 are stalled reads as a quiet system.
+    const t = io();
+    const res = await aggregateLane([{ id: 'a' }, { id: 'b' }, { id: 'c' }], t, 'owner');
+    expect(res.count).toBe(3);
+    expect(t.calls.inserts[0].count).toBe(3);
+    expect(t.calls.inserts[0].item_ids).toEqual(['a', 'b', 'c']);
+  });
+
+  it('an empty tick emits nothing at all', async () => {
+    const t = io();
+    const res = await aggregateLane([], t, 'owner');
+    expect(res.action).toBe('none');
+    expect(t.calls.inserts).toHaveLength(0);
+    expect(t.calls.finds).toBe(0); // does not even probe — no work, no reads
+  });
+});
+
+describe('TS-4 — ACROSS ticks, a pending digest is SUPERSEDED, never re-inserted', () => {
+  it('with a pending digest, it updates in place and inserts nothing', async () => {
+    const t = io({ pending: { id: 'existing-digest' } });
+    const res = await aggregateLane([{ id: 'a' }, { id: 'b' }], t, 'chairman_packet');
+    expect(t.calls.inserts).toHaveLength(0);
+    expect(t.calls.updates).toHaveLength(1);
+    expect(t.calls.updates[0].id).toBe('existing-digest');
+    expect(res.action).toBe('superseded');
+  });
+
+  it('THE 5-TICK CASE — an unmoved item emits ~1 row total, not one per tick', async () => {
+    // The PRD's smoke step 4, as a unit test. Without the supersede half this is 5 inserts:
+    // capped within each tick, unbounded across them. Because the ladder repeats, "still
+    // unmoved" is the normal case, so the omission floods continuously rather than rarely.
+    let pending = null;
+    const inserts = [];
+    const updates = [];
+    const seam = {
+      findPending: async () => pending,
+      insert: async (d) => { inserts.push(d); pending = { id: 'digest-1' }; return pending; },
+      update: async (id, patch) => { updates.push({ id, ...patch }); return { id }; },
+    };
+    for (let tick = 0; tick < 5; tick++) {
+      await aggregateLane([{ id: 'stuck-item' }], seam, 'chairman_packet');
+    }
+    expect(inserts).toHaveLength(1);   // one row ever created
+    expect(updates).toHaveLength(4);   // refreshed on each subsequent tick
+  });
+
+  it('the supersede refreshes count and ids so the digest does not go stale', async () => {
+    const t = io({ pending: { id: 'existing-digest' } });
+    await aggregateLane([{ id: 'a' }, { id: 'b' }, { id: 'c' }], t, 'owner');
+    expect(t.calls.updates[0].count).toBe(3);
+    expect(t.calls.updates[0].item_ids).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('TS-5 — the PER-TARGET CAP COLLAPSE: a bound and a silencer look identical at N=1', () => {
+  it('N items sharing ONE target still report N, and still emit exactly one row', async () => {
+    // THE DISCRIMINATING FIXTURE. Every one of these escalates to the SAME target (the
+    // chairman), which is the shape the x5 rung always has. A per-TARGET cap of 1 would emit
+    // one row here and look correct — the giveaway is the COUNT. A silencer reports 1; a bound
+    // reports 7 and sends once. Asserting only "one row emitted" cannot tell them apart, which
+    // is precisely why the inbound-backlog-watchdog refused to copy MAX_PROBES_PER_TICK.
+    const t = io();
+    const seven = Array.from({ length: 7 }, (_, i) => ({ id: `item-${i}`, target: 'chairman' }));
+    const res = await aggregateLane(seven, t, 'chairman_packet');
+
+    expect(t.calls.inserts).toHaveLength(1); // bounded
+    expect(res.count).toBe(7);               // NOT collapsed to 1 — this is the discriminator
+    expect(t.calls.inserts[0].count).toBe(7);
+    expect(t.calls.inserts[0].item_ids).toHaveLength(7);
+  });
+
+  it('the cap constant is named for what it bounds', async () => {
+    // Cheap, and it pins the property the name carries: a bare MAX_ESCALATIONS can be silently
+    // reinterpreted as per-recipient by the next reader. MAX_DIGESTS_PER_TICK cannot.
+    expect(MAX_DIGESTS_PER_TICK).toBe(1);
+  });
+});
+
+describe('io contract — refuses to guess a write path', () => {
+  for (const missing of ['findPending', 'insert', 'update']) {
+    it(`throws when io.${missing} is absent`, async () => {
+      const t = io();
+      delete t[missing];
+      await expect(aggregateLane([{ id: 'a' }], t, 'owner')).rejects.toThrow(TypeError);
+    });
+  }
+});

--- a/tests/unit/escalation/brief.test.js
+++ b/tests/unit/escalation/brief.test.js
@@ -1,0 +1,89 @@
+// SD-LEO-INFRA-DRIVE-LOOP-INSTRUMENT-001-E — TS-8: the x5 rung is an interrogative brief.
+import { describe, it, expect } from 'vitest';
+import { buildBrief, briefIsActionable, REQUIRED_BRIEF_FIELDS } from '../../../lib/escalation/brief.js';
+
+const complete = () => ({
+  position: 'Wave 3 / roadmap #12',
+  days_unmoved: 9,
+  blocker: 'awaiting chairman ruling on DDL',
+  owner: 'adam',
+  question: 'do we apply the migration or defer to next wave?',
+});
+
+describe('TS-8 — a complete brief carries every field the chairman needs to ACT', () => {
+  it('renders position, days, blocker, owner, and the x3 question', () => {
+    const { line, fields } = buildBrief(complete());
+    for (const f of REQUIRED_BRIEF_FIELDS) {
+      expect(line).toContain(String(fields[f]));
+    }
+  });
+
+  it('the question is carried VERBATIM so x5 escalates rather than re-asks', () => {
+    // The point of carrying the x3 question is that the chairman sees what is already in
+    // flight. A paraphrase would make it look like a second, different question.
+    const s = complete();
+    expect(buildBrief(s).line).toContain(s.question);
+  });
+});
+
+describe('TS-8 — a BARE COUNT fails, and so does every partial', () => {
+  it('refuses a bare count outright', () => {
+    // The literal failure FR_C names: "3 items unmoved" is a volume, not a decision.
+    expect(() => buildBrief({ count: 3 })).toThrow(/never a bare count/i);
+  });
+
+  for (const field of REQUIRED_BRIEF_FIELDS) {
+    it(`refuses when '${field}' is missing, and NAMES it`, () => {
+      // Each field individually, because a brief missing exactly one still renders and still
+      // reads like a report — that is the silent degradation this guards. A single
+      // all-fields-present test cannot see which field a future edit dropped.
+      const s = complete();
+      delete s[field];
+      expect(() => buildBrief(s)).toThrow(new RegExp(`missing: .*${field}`));
+    });
+  }
+
+  it('treats an EMPTY blocker as missing — a blank where the reason belongs is not a reason', () => {
+    // The plausible-but-useless case: blocker: '' renders a brief with a gap in it. Truthiness
+    // checks alone would let this through, and the output looks structurally correct.
+    expect(() => buildBrief({ ...complete(), blocker: '   ' })).toThrow(/missing: .*blocker/);
+  });
+
+  it('names ALL missing fields at once rather than one per attempt', () => {
+    const err = (() => { try { buildBrief({ owner: 'adam' }); } catch (e) { return e.message; } })();
+    for (const f of ['position', 'days_unmoved', 'blocker', 'question']) {
+      expect(err).toContain(f);
+    }
+  });
+});
+
+describe('briefIsActionable — checks VALUES, not labels', () => {
+  it('accepts a line that carries the values', () => {
+    const s = complete();
+    expect(briefIsActionable(buildBrief(s).line, s)).toBe(true);
+  });
+
+  it('REJECTS a line with the labels but empty values', () => {
+    // The load-bearing case. A template that printed
+    //   "position: — unmoved d — blocker: — owner: — asked at x3:"
+    // passes any label-presence check while carrying no information at all. Checking for the
+    // VALUES is what distinguishes a brief from its skeleton.
+    const s = complete();
+    const skeleton = 'position: — unmoved d — blocker: — owner: — asked at x3: ""';
+    expect(briefIsActionable(skeleton, s)).toBe(false);
+  });
+
+  it('rejects an empty or non-string line', () => {
+    const s = complete();
+    for (const bad of ['', '   ', null, undefined, 42]) {
+      expect(briefIsActionable(bad, s)).toBe(false);
+    }
+  });
+
+  it('rejects when the underlying stall is itself incomplete', () => {
+    const s = complete();
+    const line = buildBrief(s).line;
+    delete s.blocker;
+    expect(briefIsActionable(line, s)).toBe(false);
+  });
+});

--- a/tests/unit/escalation/inbox-sla.test.js
+++ b/tests/unit/escalation/inbox-sla.test.js
@@ -1,0 +1,118 @@
+// SD-LEO-INFRA-DRIVE-LOOP-INSTRUMENT-001-E — TS-6 (no liveness gate) and TS-7 (direction).
+import { describe, it, expect } from 'vitest';
+import { findInboundOverdue, asStall } from '../../../lib/escalation/inbox-sla.js';
+
+const ME = 'session-me';
+const OTHER = 'session-other';
+const PAST = new Date(Date.now() - 60_000).toISOString();
+
+const replyNeeded = (over) => ({
+  payload: { reply_class: 'reply-needed', reply_expected_by: PAST },
+  ...over,
+});
+
+/**
+ * Supabase stub that RECORDS its filters, so the test can assert WHICH column the direction
+ * was expressed on — not merely that some rows came back. A stub that ignores .eq() would make
+ * the sender and inbox directions indistinguishable, which is the exact confusion under test.
+ */
+function stub(rows) {
+  const eqCalls = [];
+  const chain = {
+    select() { return chain; },
+    eq(col, val) { eqCalls.push([col, val]); return chain; },
+    then(res) {
+      // Honour the recorded filter so direction actually affects the result set.
+      const filtered = rows.filter((r) => eqCalls.every(([c, v]) => r[c] === v));
+      return Promise.resolve({ data: filtered, error: null }).then(res);
+    },
+  };
+  return { eqCalls, from() { return chain; } };
+}
+
+describe('TS-7 — DIRECTION: the watcher is INBOUND (recipient), not the sender sweep', () => {
+  it('returns the row addressed TO me and NOT the row I sent', async () => {
+    // THE DISCRIMINATING FIXTURE. Both rows are overdue and reply-needed; the ONLY difference is
+    // direction. A sender-scoped implementation returns the wrong one and every other assertion
+    // in this suite would still pass — the two sweeps share table, window, and predicate.
+    const rows = [
+      replyNeeded({ id: 'inbound', target_session: ME, sender_session: OTHER }),
+      replyNeeded({ id: 'outbound', target_session: OTHER, sender_session: ME }),
+    ];
+    const { overdue } = await findInboundOverdue(stub(rows), ME);
+    expect(overdue.map((r) => r.id)).toEqual(['inbound']);
+  });
+
+  it('the direction is expressed on target_session — asserted on the FILTER, not the result', async () => {
+    // Pins the mechanism as well as the outcome. A future edit could get the right rows for the
+    // wrong reason (e.g. filtering in memory); this fails if the column ever flips to sender.
+    const s = stub([]);
+    await findInboundOverdue(s, ME);
+    expect(s.eqCalls).toContainEqual(['target_session', ME]);
+    expect(s.eqCalls.map(([c]) => c)).not.toContain('sender_session');
+  });
+
+  it('rejects a missing sessionId rather than scanning everything', async () => {
+    for (const bad of ['', '   ', null, undefined, 42]) {
+      await expect(findInboundOverdue(stub([]), bad)).rejects.toThrow(TypeError);
+    }
+  });
+});
+
+describe('TS-6 — NO LIVENESS GATE: it fires when nothing is alive', () => {
+  it('returns overdue rows with ZERO live sessions present', async () => {
+    // The sibling watchdog's incident: Adam's loops were dead overnight, and a liveness gate
+    // would have treated the WORST backlog condition as an exemption. The stub models no
+    // heartbeat data at all — if the implementation consulted liveness it would have to query
+    // something that is not here, and this test would break rather than silently pass.
+    const rows = [replyNeeded({ id: 'inbound', target_session: ME, sender_session: OTHER })];
+    const { overdue } = await findInboundOverdue(stub(rows), ME);
+    expect(overdue.map((r) => r.id)).toEqual(['inbound']);
+  });
+
+  it('POSITIVE CONTROL — it also stays silent when nothing is overdue', async () => {
+    // Without this the test above passes for a watcher that fires unconditionally, which would
+    // be a different defect wearing the same green.
+    const future = new Date(Date.now() + 3_600_000).toISOString();
+    const rows = [{
+      id: 'not-yet', target_session: ME, sender_session: OTHER,
+      payload: { reply_class: 'reply-needed', reply_expected_by: future },
+    }];
+    const { overdue } = await findInboundOverdue(stub(rows), ME);
+    expect(overdue).toHaveLength(0);
+  });
+
+  it('the single-fire dedup gate is honoured (already pinged => not re-surfaced)', async () => {
+    const rows = [{
+      id: 'pinged', target_session: ME, sender_session: OTHER,
+      payload: { reply_class: 'reply-needed', reply_expected_by: PAST, ping_sent_at: PAST },
+    }];
+    const { overdue } = await findInboundOverdue(stub(rows), ME);
+    expect(overdue).toHaveLength(0);
+  });
+
+  it('an answered row is not surfaced', async () => {
+    const rows = [{
+      id: 'answered', target_session: ME, sender_session: OTHER,
+      payload: { reply_class: 'reply-needed', reply_expected_by: PAST, correlation_id: 'c-1' },
+    }];
+    const { overdue } = await findInboundOverdue(stub(rows), ME, {
+      answeredCorrelationIds: new Set(['c-1']),
+    });
+    expect(overdue).toHaveLength(0);
+  });
+});
+
+describe('asStall — shape adaptation for the ladder', () => {
+  it('carries who asked and when it was due, so the x5 brief can be interrogative', async () => {
+    const row = {
+      id: 'r1', target_session: ME, sender_session: OTHER, subject: 'need a ruling',
+      payload: { reply_expected_by: PAST },
+    };
+    const stall = asStall(row, 5);
+    expect(stall).toMatchObject({
+      id: 'r1', stall_type: 'inbox_sla', owner: ME, ticks: 5,
+      asked_by: OTHER, subject: 'need a ruling', expected_by: PAST,
+    });
+  });
+});

--- a/tests/unit/escalation/ladder.test.js
+++ b/tests/unit/escalation/ladder.test.js
@@ -1,0 +1,85 @@
+// SD-LEO-INFRA-DRIVE-LOOP-INSTRUMENT-001-E — TS-1 (rung exactness) and TS-2 (lane isolation).
+import { describe, it, expect } from 'vitest';
+import { rungForTicks, laneForStall, groupByLane, RUNG, LANE } from '../../../lib/escalation/ladder.js';
+
+describe('TS-1 — rungs fire at EXACTLY x2/x3/x5, and nowhere else', () => {
+  // The PRD calls off-by-one "the whole feature": a rung at x1 makes the ladder noise, a rung
+  // at x6 makes it decorative. So this asserts the full 0..8 range rather than spot-checking
+  // the three hits — a spot check cannot see a rung that ALSO fires somewhere it should not.
+  const expected = {
+    0: RUNG.NONE, 1: RUNG.NONE,
+    2: RUNG.IN_REPORT,
+    3: RUNG.OWNER,
+    4: RUNG.NONE,
+    5: RUNG.CHAIRMAN,
+    6: RUNG.NONE, 7: RUNG.NONE, 8: RUNG.NONE,
+  };
+  for (const [ticks, rung] of Object.entries(expected)) {
+    it(`x${ticks} => ${rung === null ? 'nothing' : rung}`, () => {
+      expect(rungForTicks(Number(ticks))).toBe(rung);
+    });
+  }
+
+  it('x4 and x6 are SILENT — persistence is not a re-fire', () => {
+    // The load-bearing pair. An unmoved item is still unmoved at x4 and x6; if the ladder used
+    // >= instead of ===, both would fire and the chairman rung would repeat every tick forever.
+    // That is the exact flood FR_C exists to prevent, and >= passes a naive x2/x3/x5 spot check.
+    expect(rungForTicks(4)).toBe(RUNG.NONE);
+    expect(rungForTicks(6)).toBe(RUNG.NONE);
+    expect(rungForTicks(7)).toBe(RUNG.NONE);
+  });
+
+  it('rejects non-integer / negative ticks rather than coercing', () => {
+    for (const bad of [-1, 1.5, '3', null, undefined, NaN]) {
+      expect(() => rungForTicks(bad)).toThrow(TypeError);
+    }
+  });
+});
+
+describe('TS-2 — lanes are EXCLUSIVE; pending-chairman never reaches an owner lane', () => {
+  it('pending_chairman goes to the chairman packet even when an owner is set', () => {
+    // The failure that matters: a pending-chairman item that also carries an owner must NOT
+    // route to the owner. If it did, the chairman packet stops being the authoritative list of
+    // what is the chairman's to decide — which is the only reason the packet is worth reading.
+    expect(laneForStall({ stall_type: 'pending_chairman', owner: 'alpha' })).toBe(LANE.CHAIRMAN);
+  });
+
+  it('owner-lane stall routes to its owner', () => {
+    expect(laneForStall({ stall_type: 'owner_stall', owner: 'alpha' })).toBe(LANE.OWNER);
+  });
+
+  it('unsourced work routes to Adam', () => {
+    expect(laneForStall({ stall_type: 'unsourced' })).toBe(LANE.ADAM);
+  });
+
+  it('an ownerless, unclassified stall goes to Adam rather than a phantom owner lane', () => {
+    // Falling back to OWNER here would emit a message to nobody and read as handled.
+    expect(laneForStall({ stall_type: 'something_else', owner: null })).toBe(LANE.ADAM);
+  });
+
+  it('THE SIMULTANEOUS CASE — three types in one tick, each in exactly one lane', () => {
+    // Per the PRD smoke step 2: stall all three types at once and assert no overlap. Grouping
+    // is what a per-lane aggregator consumes, so an item appearing twice would be double-sent.
+    const stalls = [
+      { id: 'a', stall_type: 'pending_chairman', owner: 'alpha' },
+      { id: 'b', stall_type: 'owner_stall', owner: 'bravo' },
+      { id: 'c', stall_type: 'unsourced' },
+    ];
+    const grouped = groupByLane(stalls);
+    expect(grouped.get(LANE.CHAIRMAN).map((s) => s.id)).toEqual(['a']);
+    expect(grouped.get(LANE.OWNER).map((s) => s.id)).toEqual(['b']);
+    expect(grouped.get(LANE.ADAM).map((s) => s.id)).toEqual(['c']);
+
+    // Exclusivity stated as a COUNT, not as three separate memberships: every stall appears
+    // exactly once across all lanes. Three passing membership checks would still allow a
+    // fourth lane holding a duplicate.
+    const total = [...grouped.values()].reduce((n, arr) => n + arr.length, 0);
+    expect(total).toBe(stalls.length);
+  });
+
+  it('rejects a non-object stall rather than routing it somewhere', () => {
+    for (const bad of [null, undefined, 'stall', 42]) {
+      expect(() => laneForStall(bad)).toThrow(TypeError);
+    }
+  });
+});


### PR DESCRIPTION
## What this is

The x2/x3/x5 escalation ladder, an aggregation guard, and an inbound SLA watcher for the Drive Loop. Four modules under `lib/escalation/`, 50 unit tests, every load-bearing property mutation-verified.

## PLAN settled three deferred ambiguities by reading the cited code — two citations were wrong

| Scope claim | Measured |
|---|---|
| Watcher "reduces to a window parameter" | True for the **sender** sweep only. `checkAndPingOverdueReplies` selects `target_session` from rows the session *sent* — it answers "I asked and nobody answered". An inbox watcher is the inverse population. |
| "while Adam is engaged" | **Struck.** A shipped sibling removed that liveness gate deliberately: *"for INBOUND, no live Adam session is the WORST backlog condition, not an exemption"* — the witnessed incident had Adam's loops dead overnight. |
| "-B's FR-7 forbids writes anywhere under `lib/drive-loop/`" | It is **-B scope bullet 10**, and it is **job-scoped**, not directory-scoped. Separation kept anyway (stricter is free); citation corrected so nobody contorts around a ban that doesn't exist. |

## One hazard the scope never named

Found while verifying a *different* citation: `MAX_PROBES_PER_TICK` is per-**target**, and *"every inbound row shares a single target, so a literal copy structurally collapses to 1 and would cap the alarm rather than bound it."*

The x5 rung shares one target — the chairman. A per-target cap there is a **silencer wearing a bound**, and it passes a naive test because one emitted row is the expected shape at N=1. TS-5 discriminates on the reported **count**, not the row total.

## The recurring shape

The discriminating filter was never where it first appeared to be:

- **Direction** lives in the candidate query, not the predicate
- **Scale** lives in the reported count, not the row total
- **Persistence** lives in the supersede, not the cap

In each case the obvious assertion passes both the correct and the broken implementation.

## Mutation-verified

| Mutation | Caught by |
|---|---|
| ladder `===` → `>=` | 4 tests, incl. "persistence is not a re-fire" |
| count truncated to cap (the silencer) | TS-5 count assertions; every row-count assertion stayed green |
| cross-tick supersede removed | TS-4 five-tick case (5 inserts where 1 belongs) |
| `target_session` → `sender_session` | TS-7, on both result and filter column |
| whitespace accepted as present | brief's empty-blocker test |

## Verified

- 50/50 unit tests; source restored byte-identical after every mutation run
- TESTING PASS 95%, SECURITY PASS 100%, RETRO PASS 100%
- EXEC-TO-PLAN 84, PLAN-TO-LEAD 95
- Reuses `findOverdueReplyNeeded` and `computeReplyExpectedBy` untouched (TR-3) — no second window definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)