### PR TITLE
feat(SD-LEO-INFRA-GATE-THRESHOLD-TUNING-002): apply the one threshold change that is applicable, refuse two, report six held

### DIFF
--- a/lib/quality/threshold-acceptance.js
+++ b/lib/quality/threshold-acceptance.js
@@ -1,0 +1,115 @@
+/**
+ * THRESHOLD-CHANGE ACCEPTANCE — SD-LEO-INFRA-GATE-THRESHOLD-TUNING-002.
+ *
+ * THE JOB HERE IS TO MAKE THE SD FALSIFIABLE, WHICH IT WOULD NOT OTHERWISE BE.
+ *
+ * A threshold change is accepted by comparing gate pass-rate before and after. The obvious way to do
+ * that — read the 4-week view before, apply the change, read it again a few days later — IS BROKEN,
+ * and broken in a way that produces a real-looking number. Two 4-week windows taken days apart SHARE
+ * THREE WEEKS OF ASSESSMENTS. The delta they yield is computed mostly from the same rows on both
+ * sides, so it is diluted toward zero and cannot detect the change the SD itself made. The SD would
+ * then complete on a measurement STRUCTURALLY UNABLE TO FALSIFY IT.
+ *
+ * That is the same defect class as the sibling SD's stale-window finding, one layer up: there a fixed
+ * window could not track a step change in the data; here it cannot detect a change we ourselves make.
+ *
+ * So overlap is REFUSED rather than caveated. A caveat on a plausible number gets dropped; a refusal
+ * cannot be read past.
+ */
+
+'use strict';
+
+const OUTCOME = Object.freeze({
+  MEASURED: 'MEASURED',
+  INSUFFICIENT: 'INSUFFICIENT',
+  OVERLAPPING_WINDOW: 'OVERLAPPING_WINDOW',
+});
+
+/** Minimum post-change assessments before a pass-rate is worth reporting at all. */
+const MIN_AFTER = 5;
+
+/**
+ * Do two windows share any instant? Touching endpoints do not overlap — a change applied at T
+ * cleanly separates [.., T) from [T, ..).
+ */
+function windowsOverlap(before, after) {
+  return before.end > after.start && after.end > before.start;
+}
+
+const passRate = (rows) => {
+  const n = rows.length;
+  if (!n) return null;
+  const passed = rows.filter((r) => Number(r.weighted_score) >= Number(r.pass_threshold)).length;
+  return Math.round((passed / n) * 1000) / 10;
+};
+
+/**
+ * Evaluate one tuned type.
+ *
+ * @param {object} args
+ * @param {string} args.sd_type
+ * @param {number} args.before_threshold
+ * @param {number} args.after_threshold
+ * @param {{start:number,end:number}} args.beforeWindow
+ * @param {{start:number,end:number}} args.afterWindow
+ * @param {Array<object>} args.beforeRows - assessments in beforeWindow
+ * @param {Array<object>} args.afterRows  - assessments in afterWindow
+ * @returns {{outcome:string, ...}}
+ */
+function evaluateChange(args) {
+  // CHECKED FIRST, DELIBERATELY. If the windows overlap, every number downstream is contaminated —
+  // computing them and then labelling the result would invite exactly the reading this refuses.
+  if (windowsOverlap(args.beforeWindow, args.afterWindow)) {
+    return {
+      outcome: OUTCOME.OVERLAPPING_WINDOW,
+      sd_type: args.sd_type,
+      before_pass_rate: null,
+      after_pass_rate: null,
+      reason:
+        'before and after windows share assessments, so any delta would be computed largely from the '
+        + 'same rows and could not detect the change. Measure post-change assessments only.',
+    };
+  }
+
+  const after = args.afterRows || [];
+  // A NULL MEASUREMENT MUST NOT RENDER AS "UNCHANGED". This is the failure mode that would let the SD
+  // complete on applied-but-unmeasured changes, which its own scope forbids — and it is invisible in
+  // any summary that only prints failures, because "no movement" reads like a quiet success.
+  if (after.length < MIN_AFTER) {
+    return {
+      outcome: OUTCOME.INSUFFICIENT,
+      sd_type: args.sd_type,
+      before_pass_rate: passRate(args.beforeRows || []),
+      after_pass_rate: null,
+      after_n: after.length,
+      reason: 'only ' + after.length + ' post-change assessment(s); need ' + MIN_AFTER
+        + '. NOT the same as "no change observed".',
+    };
+  }
+
+  const before = passRate(args.beforeRows || []);
+  const now = passRate(after);
+  // A raised bar predicts pass-rate at or below the before-value. The prediction is recorded so the
+  // result can CONTRADICT it — a type whose pass-rate rises after its bar was raised means the
+  // population moved more than the threshold did, and that should surface rather than be averaged in.
+  const raised = Number(args.after_threshold) > Number(args.before_threshold);
+  const predicted = raised ? 'pass_rate_should_not_rise' : 'pass_rate_should_not_fall';
+  const contradicted = before === null ? false : (raised ? now > before : now < before);
+
+  return {
+    outcome: OUTCOME.MEASURED,
+    sd_type: args.sd_type,
+    before_threshold: args.before_threshold,
+    after_threshold: args.after_threshold,
+    before_pass_rate: before,
+    after_pass_rate: now,
+    after_n: after.length,
+    predicted,
+    contradicted,
+    reason: contradicted
+      ? 'pass rate moved AGAINST the direction the change predicted — the population moved more than the bar did'
+      : 'pass rate moved as predicted',
+  };
+}
+
+module.exports = { evaluateChange, windowsOverlap, OUTCOME, MIN_AFTER };

--- a/scripts/modules/ai-quality-evaluator/config.js
+++ b/scripts/modules/ai-quality-evaluator/config.js
@@ -26,7 +26,29 @@ export const SD_TYPE_PASS_THRESHOLDS = {
   database: 65,
 
   // Security SDs: Stricter (but not blocking)
-  security: 65
+  security: 65,
+
+  // Refactor SDs: raised 60 -> 65 by SD-LEO-INFRA-GATE-THRESHOLD-TUNING-002.
+  // BEFORE VALUE FOR ROLLBACK: no key at all — refactor fell through to DEFAULT_THRESHOLD (60).
+  // Deleting this line restores the prior behaviour exactly; that is the whole rollback.
+  //
+  // WHY THIS ONE AND NOT THE OTHER THREE RECOMMENDED. The tuning view recommends per
+  // (sd_type x content_type), but this table is keyed by sd_type ALONE and
+  // scripts/modules/ai-quality-evaluator/scoring.js:88 never passes content_type — so a per-cell
+  // recommendation cannot be applied without moving every other content_type in that type.
+  // refactor is the only one where that is harmless: ALL THREE of its cells clear 65 (prd 78.5,
+  // retrospective 88.4, user_story 82.4), so one key satisfies two recommendations with no
+  // collateral. feature 60->65 and infrastructure 55->60 were REFUSED, because each would also
+  // raise the bar on its user_story cell — feature x user_story at 40.5 avg / 15.6% pass, and
+  // infrastructure x user_story at 41.5 / 21.4% over n=1466, the largest cell in the view. Both are
+  // lanes SD-LEO-INFRA-GATE-THRESHOLD-TUNING-001 deliberately HELD, so raising them would be the
+  // exact opposite of what the same view recommends for them.
+  //
+  // CONSEQUENCE, RECORDED RATHER THAN LEFT AS A SIDE EFFECT: refactor x user_story is the control
+  // TUNING-001 used to exonerate the scorer — the healthy user_story lane proving the same scorer
+  // CAN pass user stories. This raises that control's bar on 2026-08-04. Anyone re-reading that
+  // exoneration needs to know the instrument moved, and when.
+  refactor: 65
 };
 
 // SD-type-aware blocking thresholds for feedback generation

--- a/scripts/quality/tuning-002-disposition.mjs
+++ b/scripts/quality/tuning-002-disposition.mjs
@@ -1,0 +1,78 @@
+/**
+ * SD-LEO-INFRA-GATE-THRESHOLD-TUNING-002 — snapshot + disposition report.
+ *
+ * FR-1 (snapshot), FR-3 (blocked six reported, never dropped) and the two REFUSED INCREASEs in one
+ * artifact. THE REPORT IS THE DELIVERABLE FOR EVERYTHING NOT APPLIED: a run that printed only the
+ * applied change would be indistinguishable from one that never considered the other nine, and
+ * silence about an adjudicated recommendation reads exactly like an oversight.
+ *
+ * Read-only. Run: node scripts/quality/tuning-002-disposition.mjs
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const { data: rows, error } = await sb.from('v_ai_quality_tuning_recommendations').select('*');
+if (error) { console.error('view read failed: ' + error.message); process.exit(2); }
+
+const kind = (r) => String(r.recommendation).split(':')[0].split(' ')[0];
+const cell = (r) => r.sd_type + ' x ' + r.content_type;
+
+// FR-1 — the frozen evidence base. The view MOVES while you measure it (infrastructure x user_story
+// was observed going n=1457/avg 41.3 -> n=1466/avg 41.5 inside forty minutes), so a diff against a
+// live read is not reviewable. Emitting the snapshot is what makes the rest of this citable.
+console.log('=== FR-1 SNAPSHOT (' + rows.length + ' rows) ===');
+for (const r of rows.filter((x) => ['DECREASE', 'INCREASE'].includes(kind(x)))) {
+  console.log('  ' + kind(r).padEnd(9) + cell(r).padEnd(34) + ' thr=' + String(r.current_threshold).padEnd(3)
+    + '-> ' + String(r.suggested_threshold).padEnd(3) + ' avg=' + String(r.avg_score).padEnd(5)
+    + ' pass=' + String(r.pass_rate).padEnd(5) + '% n=' + r.assessments_last_4_weeks);
+}
+
+// APPLIED. One config key satisfying two recommendations, with no collateral.
+console.log('\n=== APPLIED (1 change, satisfies 2 recommendations) ===');
+console.log('  refactor 60 -> 65   [refactor x retrospective 88.4/100%/n=11, refactor x user_story 82.4/100%/n=41]');
+console.log('    rollback: DELETE the refactor key — it did not exist before and fell through to DEFAULT_THRESHOLD 60');
+console.log('    consequence: refactor x user_story is TUNING-001 scorer-exoneration CONTROL. Its bar moved 2026-08-04.');
+
+// REFUSED — not descoped. The recommendation is sound for the named cell and unimplementable at the
+// granularity the config supports, which is a different thing from being wrong.
+console.log('\n=== REFUSED (2) — granularity mismatch, NOT a judgement on the recommendation ===');
+console.log('  scoring.js:88 resolves SD_TYPE_PASS_THRESHOLDS[sd.sd_type] and never sees content_type,');
+console.log('  so a per-cell recommendation cannot be applied without moving every cell in that sd_type.');
+for (const [rec, collateral] of [
+  ['feature x prd 60 -> 65', 'feature x user_story'],
+  ['infrastructure x retrospective 55 -> 60', 'infrastructure x user_story'],
+]) {
+  const c = rows.find((r) => cell(r) === collateral);
+  console.log('  ' + rec.padEnd(42) + ' would ALSO raise ' + collateral
+    + ' (avg ' + c.avg_score + ', ' + c.pass_rate + '% pass, n=' + c.assessments_last_4_weeks + ') — a HELD lane');
+}
+
+// FR-3 — the six held rows, reported with the measurement that holds them.
+const dec = rows.filter((r) => kind(r) === 'DECREASE');
+console.log('\n=== HELD (' + dec.length + ') — blocked by SD-LEO-INFRA-GATE-THRESHOLD-TUNING-001 (PR #6816) ===');
+let cosmetic = 0;
+for (const r of dec) {
+  const gap = Number(r.suggested_threshold) - Number(r.avg_score);
+  if (gap > 0) cosmetic++;
+  console.log('  ' + cell(r).padEnd(34) + ' thr=' + r.current_threshold + ' UNCHANGED; the -5 bar would still sit '
+    + gap.toFixed(1) + ' ABOVE the mean');
+}
+console.log('  -> ' + cosmetic + '/' + dec.length + ' are cosmetic: the cut would not move their pass rate.');
+console.log('  -> 001 FR-4 gates re-evaluation behind its FR-1 AND FR-2; FR-2 is blocked three ways, so the hold stands.');
+
+// FR-6 — the disposition travels with the SD so a re-source arrives answered.
+const ineff = rows.filter((r) => kind(r) === 'INEFFECTIVE').length;
+console.log('\n=== FR-6 RE-SOURCING NOTICE ===');
+console.log('  001 symmetric-guard DDL applied? ' + (ineff ? 'YES' : 'NO — still the permissive rule'));
+console.log('  While unapplied, the daily scan will KEEP emitting these ' + dec.length + ' DECREASEs and this SD will be');
+console.log('  re-sourced. The scan is deliberately not suppressed: one that stops reporting a live');
+console.log('  condition is worse than a duplicate SD. This disposition is the answer to attach next time.');
+
+// EXIT CODE CARRIES THE HELD-SET INVARIANT so a CI consumer cannot read a clean run as "all applied".
+const moved = dec.filter((r) => ({ bugfix: 60, database: 65, documentation: 50, feature: 60, infrastructure: 55, orchestrator: 50 })[r.sd_type] !== Number(r.current_threshold));
+if (moved.length) {
+  console.error('\nFAIL: ' + moved.length + ' held threshold(s) MOVED — a narrowed SD must not re-open the hold.');
+  process.exit(1);
+}
+console.log('\nOK: all ' + dec.length + ' held thresholds unchanged.');

--- a/tests/unit/threshold-acceptance.test.js
+++ b/tests/unit/threshold-acceptance.test.js
@@ -1,0 +1,108 @@
+/**
+ * SD-LEO-INFRA-GATE-THRESHOLD-TUNING-002 — the acceptance must be able to falsify the change.
+ *
+ * The two seeded scenarios below are the ways this SD could COMPLETE WHILE PROVING NOTHING: an
+ * overlapping-window comparison that yields a real number supporting an invalid inference, and a null
+ * post-change read passing as "unchanged". Both are invisible in a summary that only prints failures.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { evaluateChange, windowsOverlap, OUTCOME, MIN_AFTER } from '../../lib/quality/threshold-acceptance.js';
+
+const DAY = 864e5;
+const T = Date.parse('2026-08-04T00:00:00Z');
+const rows = (n, score, threshold) =>
+  Array.from({ length: n }, () => ({ weighted_score: score, pass_threshold: threshold }));
+
+describe('TS-3 — SEEDED: an overlapping comparison is REFUSED, not computed', () => {
+  it('two 4-week windows taken days apart are refused', () => {
+    // THE REALISTIC MISTAKE: read the 4-week view, apply the change, read it again days later.
+    // Those windows share three weeks of assessments, so the delta is diluted toward zero and cannot
+    // detect the change. It would still look like a measurement.
+    const r = evaluateChange({
+      sd_type: 'refactor', before_threshold: 60, after_threshold: 65,
+      beforeWindow: { start: T - 28 * DAY, end: T },
+      afterWindow: { start: T - 25 * DAY, end: T + 3 * DAY },
+      beforeRows: rows(50, 70, 60), afterRows: rows(50, 70, 65),
+    });
+    expect(r.outcome).toBe(OUTCOME.OVERLAPPING_WINDOW);
+    expect(r.after_pass_rate).toBeNull();
+  });
+
+  it('the refusal happens BEFORE any rate is computed, so no contaminated number is emitted', () => {
+    const r = evaluateChange({
+      sd_type: 'feature', before_threshold: 60, after_threshold: 65,
+      beforeWindow: { start: T - 10 * DAY, end: T },
+      afterWindow: { start: T - 1 * DAY, end: T + 5 * DAY },
+      beforeRows: rows(40, 90, 60), afterRows: rows(40, 20, 65),
+    });
+    expect(r.outcome).toBe(OUTCOME.OVERLAPPING_WINDOW);
+    expect(r.before_pass_rate).toBeNull();
+  });
+
+  it('cleanly separated windows are accepted — touching endpoints do not overlap', () => {
+    // Applying the change at T splits [.., T) from [T, ..) with no shared instant. Without this the
+    // refusal would reject the one comparison the SD actually wants.
+    expect(windowsOverlap({ start: T - 7 * DAY, end: T }, { start: T, end: T + 7 * DAY })).toBe(false);
+  });
+});
+
+describe('TS-4 — SEEDED: no post-change data reports INSUFFICIENT, never "unchanged"', () => {
+  it('a tuned type with zero post-change assessments is INSUFFICIENT', () => {
+    const r = evaluateChange({
+      sd_type: 'refactor', before_threshold: 60, after_threshold: 65,
+      beforeWindow: { start: T - 14 * DAY, end: T }, afterWindow: { start: T, end: T + DAY },
+      beforeRows: rows(40, 82, 60), afterRows: [],
+    });
+    expect(r.outcome).toBe(OUTCOME.INSUFFICIENT);
+    expect(r.after_pass_rate).toBeNull();
+    expect(r.after_n).toBe(0);
+  });
+
+  it('below the floor is still INSUFFICIENT — a rate from 4 rows is not a measurement', () => {
+    const r = evaluateChange({
+      sd_type: 'refactor', before_threshold: 60, after_threshold: 65,
+      beforeWindow: { start: T - 14 * DAY, end: T }, afterWindow: { start: T, end: T + DAY },
+      beforeRows: rows(40, 82, 60), afterRows: rows(MIN_AFTER - 1, 82, 65),
+    });
+    expect(r.outcome).toBe(OUTCOME.INSUFFICIENT);
+  });
+});
+
+describe('TS-5 — the measurement records its prediction and can contradict it', () => {
+  it('a raised bar that lowers pass-rate matches the prediction', () => {
+    const r = evaluateChange({
+      sd_type: 'refactor', before_threshold: 60, after_threshold: 65,
+      beforeWindow: { start: T - 14 * DAY, end: T }, afterWindow: { start: T, end: T + 7 * DAY },
+      beforeRows: rows(40, 62, 60), afterRows: rows(40, 62, 65),
+    });
+    expect(r.outcome).toBe(OUTCOME.MEASURED);
+    expect(r.before_pass_rate).toBe(100);
+    expect(r.after_pass_rate).toBe(0);
+    expect(r.contradicted).toBe(false);
+  });
+
+  it('a raised bar whose pass-rate RISES is flagged as contradicted, not averaged away', () => {
+    // The population moved more than the bar did. That is a real and interesting outcome, and it must
+    // surface per-type — a single blended number across four types would hide it entirely.
+    const r = evaluateChange({
+      sd_type: 'refactor', before_threshold: 60, after_threshold: 65,
+      beforeWindow: { start: T - 14 * DAY, end: T }, afterWindow: { start: T, end: T + 7 * DAY },
+      beforeRows: [...rows(20, 90, 60), ...rows(20, 10, 60)],
+      afterRows: rows(40, 90, 65),
+    });
+    expect(r.outcome).toBe(OUTCOME.MEASURED);
+    expect(r.contradicted).toBe(true);
+  });
+
+  it('a genuine measurement is produced when the windows are clean and the data is there', () => {
+    // THE POSITIVE HALF: a checker that refused everything would pass every scenario above.
+    const r = evaluateChange({
+      sd_type: 'refactor', before_threshold: 60, after_threshold: 65,
+      beforeWindow: { start: T - 14 * DAY, end: T }, afterWindow: { start: T, end: T + 7 * DAY },
+      beforeRows: rows(30, 82, 60), afterRows: rows(30, 82, 65),
+    });
+    expect(r.outcome).toBe(OUTCOME.MEASURED);
+    expect(r.after_pass_rate).toBe(100);
+  });
+});


### PR DESCRIPTION
The governance scan surfaced **10 actionable tuning recommendations**. Measured live, they decompose as **6 DECREASE + 4 INCREASE** — and the six DECREASEs are the *same six* [TUNING-001](https://github.com/rickfelix/EHG_Engineer/pull/6816) held. So this SD is not ten items of new work; it's the mandatory per-type review 001 required. Coordinator ratified narrowing to the four INCREASEs before the PRD was written.

## EXEC found a second, structural narrowing

The view recommends per **(sd_type × content_type)**. But `scripts/modules/ai-quality-evaluator/scoring.js:88` resolves `SD_TYPE_PASS_THRESHOLDS[sd.sd_type]` and **never sees `content_type`**. A per-cell recommendation therefore cannot be applied without moving *every* content_type in that sd_type.

**Applied — 1 key satisfying 2 recommendations:** `refactor 60 → 65`. All three refactor cells clear 65 (prd 78.5, retrospective 88.4, user_story 82.4), so no collateral. It's an *add* — `refactor` had no key and fell through to `DEFAULT_THRESHOLD` 60, so deleting the line is the entire rollback.

**Refused — 2, for implementability, not merit:**

| recommendation | would also raise | state of that lane |
|---|---|---|
| `feature × prd` 60→65 | `feature × user_story` | avg 40.5, **15.6%** pass |
| `infrastructure × retrospective` 55→60 | `infrastructure × user_story` | avg 41.6, **21.7%** pass, **n=1471** — largest cell in the view |

Both are lanes 001 held. Applying them would raise the bar on precisely the cells the same view says are too strict.

**Held — 6, reported not dropped.** All six remain cosmetic: the −5 bar would still sit **4.0 to 25.7 points above the mean**, so none would move a pass rate. `tuning-002-disposition.mjs` exits non-zero if any held threshold moves — the risk a narrowed SD carries is drifting back to its original ten, and that drift would be quiet.

## Acceptance is built to be falsifiable

Two 4-week windows taken days apart **share three weeks of assessments**, so their delta is computed mostly from the same rows and cannot detect the change — the SD would complete on a measurement structurally unable to falsify it. Overlap is **refused**, not caveated; a caveat on a plausible number gets dropped, a refusal can't be read past. A thin post-change read reports `INSUFFICIENT` rather than passing as "unchanged".

## Recorded as a consequence, not a side effect

`refactor × user_story` is the control 001 used to **exonerate the scorer** — the healthy user_story lane proving the same scorer *can* pass user stories. This moves that control's bar, on 2026-08-04. Anyone re-reading that exoneration needs to know the instrument shifted, and when.

## Verification

8 tests, mutation-proven — un-refusing overlap, treating thin data as measured, dropping the contradiction flag, and refusing everything each fail the suite (**2/2/1/6**). The last is the positive control: a checker that refused every comparison would pass every other scenario here.

The view moved twice *during* this work (`infrastructure × user_story`: n=1457 → 1466 → 1471 within the hour), which is why FR-1 freezes a snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)