### PR TITLE
fix(QF-20260728-544): select `tier` so the stall classifier can see its own input

### DIFF
--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -147,7 +147,12 @@ export async function readCriticalPathParents(sb) {
     // already finished, instead of escalating a stale board row.
     const data = await fetchAllPaginated(() => sb
       .from(TASK_LEDGER_TABLE)
-      .select('id, title, updated_at, status, source_kind, source_ref')
+      // QF-20260728-544: `tier` MUST be selected. stall-alert.js decides suppression on
+      // node.tier, and omitting it here left that value undefined on every row — the predicate
+      // could not see its own input, so QF-20260725-639's anchor suppression never fired once
+      // and 49 alerts/tick recurred. Selecting a column the WHERE clause already pins looks
+      // redundant; it is not, because the consumer reads the VALUE, not the filter.
+      .select('id, title, updated_at, status, tier, source_kind, source_ref')
       .eq('tier', 'parent')
       .in('status', ['open', 'in_progress', 'blocked'])
       .order('id', { ascending: true })); // unique tiebreaker (FR-6)

--- a/tests/unit/adam/quiet-tick-tier-select.test.js
+++ b/tests/unit/adam/quiet-tick-tier-select.test.js
@@ -1,0 +1,66 @@
+/**
+ * QF-20260728-544 — readCriticalPathParents MUST select `tier`.
+ *
+ * QF-20260725-639 shipped a correct suppression predicate (stall-alert.js:
+ * `node.tier === 'parent'`) and it never fired once, because the query feeding it selected
+ * 'id, title, updated_at, status, source_kind, source_ref' — no `tier`. node.tier was undefined
+ * on every row, so the comparison was always false and 49 alerts/tick recurred against a set
+ * where 100% of rows qualified for suppression by the query's own WHERE clause.
+ *
+ * WHY THE OMISSION LOOKED HARMLESS, and why this test exists: the query already pins the column
+ * with .eq('tier','parent'), so selecting it reads as redundant. It is not — the CONSUMER reads
+ * the VALUE, not the filter. A filtered-but-unselected column is invisible downstream, and
+ * nothing in the pipeline errors: it just silently reads undefined.
+ *
+ * ASSERTED AT SOURCE, deliberately. A behavioural test would have to stand up syncParentRollupStatus
+ * and the fetchAllPaginated stack to observe a field that is consumed in a DIFFERENT module — and
+ * that indirection is exactly what hid the defect for the life of QF-639. The select list is the
+ * precise thing that regressed, so it is the precise thing pinned here.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SRC = fs.readFileSync(
+  path.resolve(process.cwd(), 'scripts/adam-quiet-tick.mjs'),
+  'utf8'
+);
+
+/** The select list inside readCriticalPathParents, isolated from every other select in the file. */
+function readCriticalPathParentsSelect() {
+  const fnStart = SRC.indexOf('export async function readCriticalPathParents');
+  expect(fnStart, 'readCriticalPathParents must exist').toBeGreaterThan(-1);
+  const region = SRC.slice(fnStart, fnStart + 1500);
+  const m = region.match(/\.select\(\s*'([^']+)'/);
+  expect(m, 'readCriticalPathParents must call .select() with a literal column list').toBeTruthy();
+  return m[1].split(',').map((c) => c.trim());
+}
+
+describe('QF-20260728-544 — the stall classifier can see its own input', () => {
+  it('selects `tier`, the column stall-alert.js decides suppression on', () => {
+    expect(readCriticalPathParentsSelect()).toContain('tier');
+  });
+
+  it('still selects the columns the rest of the pipeline consumes', () => {
+    // Guards the opposite regression: "fixing" the select by replacing it rather than extending it.
+    const cols = readCriticalPathParentsSelect();
+    for (const required of ['id', 'title', 'updated_at', 'status', 'source_kind', 'source_ref']) {
+      expect(cols).toContain(required);
+    }
+  });
+
+  it('CONTROL — the extractor really reads this function, not the whole file', () => {
+    // Without this, a broken extractor that returned every select in the file (there are 10+)
+    // would satisfy both assertions above no matter what readCriticalPathParents actually does.
+    const cols = readCriticalPathParentsSelect();
+    expect(cols).not.toContain('orchestrator_state'); // belongs to the venture query, a different select
+    expect(cols).not.toContain('from_phone');         // belongs to the SMS query
+    expect(cols.length).toBeLessThan(10);
+  });
+
+  it('the query still pins tier=parent, so the selected value is meaningful', () => {
+    const fnStart = SRC.indexOf('export async function readCriticalPathParents');
+    const region = SRC.slice(fnStart, fnStart + 1500);
+    expect(region).toMatch(/\.eq\(\s*'tier'\s*,\s*'parent'\s*\)/);
+  });
+});


### PR DESCRIPTION
## Summary

`QF-20260725-639` shipped a correct anchor-suppression predicate and **it never fired once**.

`stall-alert.js` decides suppression on `node.tier === 'parent'`, but `readCriticalPathParents` selected `'id, title, updated_at, status, source_kind, source_ref'` — no `tier`. `node.tier` was `undefined` on every row, the comparison was always false, and 49 alerts/tick recurred against a set where **100% of rows qualified for suppression by the query's own WHERE clause**.

The omission looked harmless because the query already pins the column with `.eq('tier','parent')`, which makes selecting it read as redundant. It isn't — the consumer reads the **value**, not the filter. A filtered-but-unselected column is invisible downstream and nothing errors; it silently reads `undefined`.

## A change I made and reverted

I first also narrowed the predicate to require `source_kind='advisory_thread'`, reasoning that since this call site's query is parent-only, selecting `tier` would suppress 100% of rows — swapping a 100%-false-positive alarm for a 100%-false-negative one.

**Reverted.** The existing tests feed `checkAndAlertStalls` *mixed* parent+child sets and explicitly pin `{tier:'parent', source_kind:'sourced_sd'}` as suppressed. The parent-only rule is the intended contract, not an accident of the current caller — and suppressions are recorded via `QUIET_TICK_STALL_SUPPRESSED`, so zero alerts here is auditable rather than silent. Only the select changed.

## Test plan

- Regression guard asserts the select list **at source**, deliberately: the value is consumed in a different module, and that indirection is what hid this for the life of QF-639.
- Includes a **CONTROL** proving the extractor reads this function rather than any of the 10+ other selects in the file — without it, a broken extractor would satisfy the assertions no matter what the function does.
- **Proven by mutation**: reverting the one-line select makes the guard fail (1 of 4) while the control still passes, so the failure is specific to the defect.
- 522 tests green across 38 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)