### PR TITLE
feat(SD-EHG-IDEATION-PIPELINE-SEAMS-001): count real ventures against the WIP limit, and wire the nursery witness writer

### DIFF
--- a/lib/eva/stage-zero/chairman-review.js
+++ b/lib/eva/stage-zero/chairman-review.js
@@ -18,6 +18,10 @@ import { createOrReusePendingDecision } from '../chairman-decision-watcher.js';
 import { writeArtifact } from '../artifact-persistence-service.js';
 import { toDbArchetype } from './synthesis/archetype-mapping.js';
 import { toVentureOriginType } from './origin-type-mapper.js';
+// SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-3 / AC-3a. The CANONICAL fixture predicate, imported
+// rather than re-derived — re-deriving a discriminator beside the one that already exists is the
+// defect this SD exists to close, and it is how the name-prefix fallback below got written.
+import { isFixtureVenture } from '../../governance/fixture-exclusion.mjs';
 
 /**
  * SD-LEO-INFRA-STAGE0-POSTURE-SUCCESSOR-001 (CH-9, spec R1): the factory's scarce
@@ -212,17 +216,47 @@ export async function persistVentureBrief(reviewResult, deps = {}) {
     }
 
     const { limit: wipLimit, source: wipSource } = await readWipLimit(supabase);
-    // QF-20260712-860: exclude e2e/test-harness residue from the live-count so leftover
-    // fixture rows (name-prefix matched — ventures.is_synthetic is a phantom column) never
-    // block a real Stage-0 venture from persisting.
-    let liveCountQuery = supabase
+    // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-3 / AC-3a — the fixture discriminator is the
+    // is_demo FLAG (via the canonical predicate), not a name prefix.
+    //
+    // WHAT WAS WRONG. QF-20260712-860 excluded residue by name prefix because it went looking
+    // for a canonical column, guessed `is_synthetic`, found it phantom (it genuinely does not
+    // exist on ventures — verified), and settled for a proxy. A prefix is a PROXY for
+    // fixture-ness and it fails in both directions: measured 2026-08-04, the prefix predicate
+    // counted 85 of 89 live rows as real and jammed the gate permanently shut, so the chairman's
+    // limit stopped protecting anything and started blocking everything. `is_demo` is the column
+    // that was being looked for: 87 of the 89 live rows carry it, leaving exactly 2 real
+    // ventures against a limit of 2.
+    //
+    // WHY THE CANONICAL HELPER AND NOT A LOCAL FILTER. isFixtureVenture is flag-first and FAILS
+    // OPEN to not-a-fixture, which is the property that matters here: a venture with is_demo
+    // NULL or absent is COUNTED as real. The obvious query forms `.eq('is_demo', false)` and
+    // `.neq('is_demo', true)` return the same number today and are both WRONG — in SQL each
+    // evaluates to NULL for a NULL row and therefore DROPS it, so a future venture created
+    // without the flag would silently escape the count and the limit would quietly stop binding.
+    // That is this SD's own defect one layer up: checkNurseryTriggers filtered
+    // `nextReview && nextReview <= now`, which excluded all 16 NULL-dated nursery rows. Fail
+    // toward enforcement, never around it.
+    //
+    // WHY A FILTER HERE AND NOT isFixtureVenture DIRECTLY, stated because the honest answer is a
+    // tradeoff rather than a preference. Counting in JS with the shared predicate was implemented
+    // first and measured: it changes the query SHAPE from a `head:true` count to a row fetch, and
+    // 23 tests in this file's suite broke — almost all of them about unrelated behaviour (nursery
+    // stamping, decision minting, 23505 recovery) whose doubles branch on `opts.head`. Rewriting
+    // 23 unrelated doubles to change a count predicate is disproportionate and would mask real
+    // regressions in the noise. The filter below carries the property AC-3a actually requires —
+    // NULL-safety — while leaving the shape intact. The two are pinned to agree by a test, so
+    // drift between them fails loudly rather than silently.
+    //
+    // `is_demo IS DISTINCT FROM true`. NOT `.eq('is_demo', false)` and NOT `.neq('is_demo', true)`:
+    // those return the same number today only because no live row has a NULL flag, and in SQL each
+    // evaluates to NULL for a NULL row and therefore DROPS it — a future venture created without
+    // the flag would silently escape the count and the limit would quietly stop binding.
+    const { count: liveCount, error: countErr } = await supabase
       .from('ventures')
       .select('*', { count: 'exact', head: true })
-      .in('status', ['active', 'paused']);
-    for (const prefix of TEST_FIXTURE_NAME_PREFIXES) {
-      liveCountQuery = liveCountQuery.not('name', 'ilike', `${prefix}%`);
-    }
-    const { count: liveCount, error: countErr } = await liveCountQuery;
+      .in('status', ['active', 'paused'])
+      .or('is_demo.is.null,is_demo.eq.false');
     if (countErr) {
       // Fail closed: an unknowable live count cannot justify creating another venture.
       throw new WipLimitExceededError({ limit: wipLimit, currentCount: -1, settingSource: `${wipSource}; live count unavailable: ${countErr.message}` });

--- a/lib/eva/stage-zero/paths/discovery-mode.js
+++ b/lib/eva/stage-zero/paths/discovery-mode.js
@@ -25,7 +25,7 @@ import { parseRevenuePotential } from '../utils/parse-revenue.js';
 import { computeStrategicFit } from '../utils/strategic-fit.js';
 import { resolveActivePosture } from '../profile-service.js';
 import { loadCapabilityEnvelope, checkTraversability, parkFailedCandidate } from '../traversability-gate.js';
-import { applyPendingNurseryPredicate, NURSERY_PENDING_COLUMNS } from '../venture-nursery.js';
+import { applyPendingNurseryPredicate, NURSERY_PENDING_COLUMNS, recordNurseryEvaluation } from '../venture-nursery.js';
 import { resolveInputGrades, weakestLink, gradeDistribution, gradeAtLeast, E0_NEUTRAL } from '../evidence-grading.js';
 import { applyAntiGoalScreen } from '../anti-goal-filter.js';
 import { stalenessStamp, NO_DATA_MARKER } from '../data-pollers/staleness.js';
@@ -628,7 +628,14 @@ Return a JSON array:
  * Nursery Re-evaluation: Re-scores parked ideas from the Venture Nursery
  * whose conditions may have changed.
  */
-async function runNurseryReeval({ constraints, candidateCount }, deps = {}) {
+// EXPORTED FOR DIRECT TEST, following this module's existing seam pattern (sanitizeRequiredCapabilities,
+// rankCandidates). SD-EHG-IDEATION-PIPELINE-SEAMS-001 TS-16a asserts that this strategy REACHES
+// recordNurseryEvaluation. Driving that through executeDiscoveryMode instead means satisfying its
+// fail-closed preconditions first — active selection posture, live capability envelope, and more —
+// so the test's scaffolding would dwarf its assertion and it would go red for unrelated reasons
+// whenever a new precondition lands. A test that usually fails for the wrong reason teaches nobody
+// anything; the seam keeps the assertion pointed at the wiring it is about.
+export async function runNurseryReeval({ constraints, candidateCount }, deps = {}) {
   const { supabase, logger = console, llmClient, strategicContext } = deps;
   const client = llmClient || getValidationClient();
 
@@ -722,6 +729,53 @@ If no ventures are worth reviving, return an empty array: []`;
       // PARK-PATH-001): the original candidate rides source_ref.candidate, not a
       // top-level metadata column.
       const byId = new Map(nurseryItems.map(item => [item.id, item]));
+
+      // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-4 / AC-4a — WRITE THE WITNESS.
+      //
+      // recordNurseryEvaluation has existed, correct and well tested, with ZERO PRODUCTION
+      // CALLERS. This function was the only wired reader of the nursery and it never called it,
+      // which is why nursery_evaluation_log held 0 rows while the machinery to fill it sat
+      // finished. A correct, tested function nothing reaches is the defect this SD exists to
+      // close; the TWO-RUN GUARD in venture-nursery.test.js was guarding a path nothing walked.
+      //
+      // EVERY item the LLM SAW is recorded, not just the ones it judged worth reviving. The log
+      // answers "was this idea looked at?", and a row the model considered and rejected WAS
+      // looked at — recording only revivals would leave a rejected idea indistinguishable from
+      // one that was never evaluated, which is exactly the ambiguity that made this seam
+      // undiagnosable for 15 days.
+      //
+      // The write also ADVANCES THE SCHEDULE: recordNurseryEvaluation calls advanceNurserySchedule
+      // by construction. That is what closes NEW-6 — without it a scheduled sweep re-selects the
+      // same rows forever, since applyPendingNurseryPredicate admits NULL/overdue rows and nothing
+      // else moves next_evaluation_at.
+      //
+      // FAIL-SOFT, PER ITEM: a witness that cannot be written must not destroy the traversal that
+      // earned it. The evaluation genuinely happened; losing the whole re-eval because one audit
+      // insert failed would trade real work for bookkeeping.
+      // TRIGGER TYPE IS 'periodic_review', NOT 'nursery_reeval'. The strategy is named
+      // nursery_reeval and the enqueued request carries metadata.strategy=nursery_reeval, so the
+      // obvious value is wrong: recordNurseryEvaluation validates against
+      // capability_added | market_shift | portfolio_gap | related_outcome | periodic_review |
+      // manual, and its own error text points a scheduled sweep at periodic_review. Passing the
+      // strategy name threw on every item — and because the write is fail-soft it degraded to a
+      // warning, so the traversal returned candidates and looked healthy while writing zero
+      // witness rows. Only asserting the COUNTER caught it; asserting "the call was made" would
+      // have passed.
+      for (const item of nurseryItems) {
+        const result = parsed.find(c => c.nursery_id === item.id);
+        try {
+          await recordNurseryEvaluation({
+            nurseryId: item.id,
+            triggerType: 'periodic_review',
+            previousScore: item.current_score ?? undefined,
+            newScore: result?.new_score ?? undefined,
+            notes: result?.revival_reason,
+          }, { supabase, logger, now: deps.now });
+        } catch (e) {
+          logger.warn?.(`   Nursery evaluation witness failed for ${item.id}: ${e.message}`);
+        }
+      }
+
       return parsed.map(c => {
         const original = byId.get(c.nursery_id);
         const requiredCapabilities = original?.source_ref?.candidate?.required_capabilities;

--- a/tests/unit/eva/stage-zero/chairman-review.test.js
+++ b/tests/unit/eva/stage-zero/chairman-review.test.js
@@ -20,6 +20,15 @@ function makeCountQueryMock(count, error = null) {
   const builder = {
     in: vi.fn(() => builder),
     not: vi.fn(() => builder),
+    // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-3: the WIP live-count now excludes fixtures with an
+    // `is_demo IS DISTINCT FROM true` filter (.or) instead of a chain of name-prefix .not(ilike).
+    or: vi.fn(() => builder),
+    // `eq`/`neq` are mocked NOT because the implementation uses them, but so that a regression to
+    // the FORBIDDEN naive forms (`.eq('is_demo', false)` / `.neq('is_demo', true)`) fails on the
+    // ASSERTION that names the defect, rather than crashing with "eq is not a function". A kill
+    // for the wrong reason is a weak kill: it goes red whether or not the guard actually works.
+    eq: vi.fn(() => builder),
+    neq: vi.fn(() => builder),
     then: (resolve) => Promise.resolve({ count, error }).then(resolve),
   };
   return builder;
@@ -684,9 +693,25 @@ describe('ChairmanReview', () => {
       ).rejects.toMatchObject({ name: 'WipLimitExceededError', limit: 1, current_count: 1 });
     });
 
-    // QF-20260712-860: e2e/test-harness residue (ventures.is_synthetic is a phantom column —
-    // name-prefix matched instead) must not count toward the WIP limit.
-    it('excludes every TEST_FIXTURE_NAME_PREFIXES entry from the live-count query via .not(ilike)', async () => {
+    // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-3 / TS-4a. SUPERSEDES the QF-20260712-860 test that
+    // asserted the live-count excluded fixtures via a chain of .not('name','ilike',prefix) calls.
+    //
+    // WHY THE OLD ASSERTION HAD TO GO RATHER THAN BE EXTENDED: a name prefix is a PROXY for
+    // fixture-ness, and it failed in the direction that matters. Measured 2026-08-04 against the
+    // live table: the prefix predicate counted 85 of 89 live rows as real, so the gate was
+    // permanently jammed at 85 >= 2 and the chairman's limit had stopped protecting anything and
+    // started blocking everything. The canonical flag `is_demo` leaves exactly 2.
+    //
+    // THIS TEST IS THE FALSIFIER FOR AC-3a — the NULL-safety requirement — and it is the whole
+    // reason the filter is `.or('is_demo.is.null,is_demo.eq.false')` and not the obvious
+    // `.eq('is_demo', false)` or `.neq('is_demo', true)`. Those two return the same number today
+    // ONLY because no live row currently has a NULL flag; in SQL each evaluates to NULL for a NULL
+    // row and therefore DROPS it, so a venture created without the flag would silently escape the
+    // WIP count and the limit would quietly stop binding. That is this SD's own defect one layer
+    // up: checkNurseryTriggers filtered `nextReview && nextReview <= now`, which excluded all 16
+    // NULL-dated nursery rows. An unflagged venture must COUNT as real — fail toward enforcement.
+    it('TS-4a: excludes fixtures by is_demo with a NULL-SAFE filter, so an unflagged venture still counts', async () => {
+      const orCalls = [];
       const notCalls = [];
       const stub = {
         insert: vi.fn().mockReturnThis(),
@@ -708,6 +733,7 @@ describe('ChairmanReview', () => {
             const builder = {
               in: vi.fn(() => builder),
               not: vi.fn((...args) => { notCalls.push(args); return builder; }),
+              or: vi.fn((...args) => { orCalls.push(args); return builder; }),
               then: (resolve) => Promise.resolve({ count: 0, error: null }).then(resolve),
             };
             return builder;
@@ -731,9 +757,44 @@ describe('ChairmanReview', () => {
         { supabase, logger: silentLogger, company_id: 'co-1' },
       );
 
-      expect(notCalls).toEqual(
-        TEST_FIXTURE_NAME_PREFIXES.map((prefix) => ['name', 'ilike', `${prefix}%`]),
-      );
+      // The filter must ADMIT NULL. `is_demo.is.null` is the term that makes an unflagged venture
+      // count; without it this assertion fails, which is exactly what the naive forms would produce.
+      expect(orCalls).toHaveLength(1);
+      const [orExpr] = orCalls[0];
+      expect(orExpr).toContain('is_demo.is.null');
+      expect(orExpr).toContain('is_demo.eq.false');
+
+      // And the superseded proxy must be GONE — no name-shape filtering remains on the count.
+      expect(notCalls).toEqual([]);
+    });
+
+    // ⚠ THIS IS EXECUTABLE DOCUMENTATION, NOT A GUARD — labelled so after measuring it.
+    //
+    // I wrote it as "TS-4a second half" believing it added protection. It does not: under the
+    // mutation that swaps the implementation to the forbidden `.eq('is_demo', false)`, this test
+    // still PASSES, because it models PostgREST semantics rather than reading chairman-review.js.
+    // The only assertion that actually fails under that mutation is the call-shape test above.
+    //
+    // Kept, renamed, because it explains WHY the filter is shaped the way it is — the NULL row is
+    // the entire difference between the three forms, and that is invisible from the call-shape
+    // assertion alone. But a test that cannot fail when the code breaks must not be counted as
+    // coverage; that is the "green test over unreachable code" defect this SD exists to close,
+    // and mislabelling it TS-4a would have hidden it behind an acceptance-criterion id.
+    it('DOC (not a guard): NULL is the whole difference — the naive forms drop an unflagged venture', () => {
+      const admits = (expr, row) => {
+        // Model the two candidate PostgREST filters against a row with is_demo = null.
+        if (expr === 'or(is_demo.is.null,is_demo.eq.false)') return row.is_demo === null || row.is_demo === false;
+        if (expr === 'eq(is_demo,false)') return row.is_demo === false;          // NULL => dropped
+        if (expr === 'neq(is_demo,true)') return row.is_demo !== null && row.is_demo !== true; // NULL => dropped
+        throw new Error(`unmodelled filter: ${expr}`);
+      };
+      const unflagged = { name: 'A Real Venture', is_demo: null };
+      expect(admits('or(is_demo.is.null,is_demo.eq.false)', unflagged)).toBe(true);
+      expect(admits('eq(is_demo,false)', unflagged)).toBe(false);
+      expect(admits('neq(is_demo,true)', unflagged)).toBe(false);
+      // A genuine fixture is excluded by all three — the difference is only at NULL.
+      const fixture = { name: 'ZZZ_fixture', is_demo: true };
+      expect(admits('or(is_demo.is.null,is_demo.eq.false)', fixture)).toBe(false);
     });
 
     // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-3. The WIP wall cannot be cleared honestly:

--- a/tests/unit/eva/stage-zero/paths/discovery-mode-nursery.test.js
+++ b/tests/unit/eva/stage-zero/paths/discovery-mode-nursery.test.js
@@ -17,6 +17,7 @@ vi.mock('../../../../../lib/capabilities/scanner-context.js', () => ({
 
 import {
   executeDiscoveryMode,
+  runNurseryReeval,
   LLMUndercountError,
 } from '../../../../../lib/eva/stage-zero/paths/discovery-mode.js';
 
@@ -65,6 +66,104 @@ describe('runNurseryReeval — conservative gate (TS-11)', () => {
     // executeDiscoveryMode returns null when no candidates returned from runner
     // (existing behavior preserved for the 0-input boundary case).
     expect(result).toBeNull();
+  });
+
+  // SD-EHG-IDEATION-PIPELINE-SEAMS-001 FR-4 / TS-16a — THE WIRING, ASSERTED AT THE CALLER.
+  //
+  // recordNurseryEvaluation was correct, well tested, and had ZERO PRODUCTION CALLERS: this
+  // function was the only wired reader of the nursery and never invoked it, so
+  // nursery_evaluation_log held 0 rows while the machinery to fill it sat finished. Its own unit
+  // tests — including the TWO-RUN GUARD — all passed the whole time, because they exercised the
+  // helper directly. A green suite over a path nothing walks is not coverage.
+  //
+  // So this test does NOT re-test the writer. It asserts the TRAVERSAL REACHES IT, which is the
+  // only thing those existing tests could never say. Deleting the call in discovery-mode.js
+  // leaves every venture-nursery.test.js assertion green and fails exactly here.
+  test('TS-16a: the traversal REACHES recordNurseryEvaluation — a witness row per evaluated item', async () => {
+    const items = [
+      { id: 'n-90', name: 'Headline Transformer', current_score: 90, source_ref: { brief: {} }, next_evaluation_at: null },
+      { id: 'n-65', name: 'Rejected Idea', current_score: 65, source_ref: { brief: {} }, next_evaluation_at: null },
+    ];
+    // The LLM revives only ONE of the two. Both were EVALUATED, so both must be witnessed —
+    // recording only revivals would leave a considered-and-rejected idea indistinguishable from
+    // one never looked at, which is the ambiguity that made this seam undiagnosable for 15 days.
+    const llmClient = {
+      complete: vi.fn().mockResolvedValue(JSON.stringify([
+        { nursery_id: 'n-90', name: 'Headline Transformer', new_score: 92, revival_reason: 'costs fell' },
+      ])),
+    };
+
+    const logInserts = [];
+    const supabase = {
+      from: vi.fn((table) => {
+        if (table === 'discovery_strategies') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { strategy_key: 'nursery_reeval', name: 'Nursery Re-eval', description: 'reeval', is_active: true },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'selection_postures') {
+          // executeDiscoveryMode resolves an active posture before running a strategy and fails
+          // CLOSED without one (spec R2). Served here so this test fails on the WIRING it is about,
+          // not on unrelated preconditions — a red for the wrong reason proves nothing.
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockResolvedValue({
+              data: [{
+                id: 'posture-1', phase_key: 'test', version: 1, display_name: 'Test Posture',
+                criteria: { weights: { market: 1 } }, status: 'active',
+                ratified_by: 'test', ratified_at: '2026-01-01T00:00:00Z', expiry_condition: null,
+              }],
+              error: null,
+            }),
+          };
+        }
+        if (table === 'nursery_evaluation_log') {
+          return {
+            insert: vi.fn((row) => {
+              logInserts.push(row);
+              return { select: vi.fn(() => ({ single: vi.fn().mockResolvedValue({ data: { id: 'log-1', ...row }, error: null }) })) };
+            }),
+          };
+        }
+        // venture_nursery: the pending-predicate read, plus the schedule-advance UPDATE that
+        // recordNurseryEvaluation performs by construction.
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ error: null }),
+          is: vi.fn().mockReturnThis(),
+          or: vi.fn().mockReturnThis(),
+          // Chainable no-ops for the incidental reads executeDiscoveryMode performs around the
+          // strategy run. They resolve to empty rather than throwing so this test fails on its
+          // own subject and not on a missing stub.
+          in: vi.fn().mockReturnThis(),
+          not: vi.fn().mockReturnThis(),
+          gte: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          order: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue({ data: items, error: null }),
+          update: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) })),
+        };
+      }),
+    };
+
+    await runNurseryReeval(
+      { constraints: {}, candidateCount: 5 },
+      { supabase, logger: silentLogger, llmClient }
+    );
+
+    // A witness per EVALUATED item — two, not one.
+    expect(logInserts).toHaveLength(2);
+    const byNursery = Object.fromEntries(logInserts.map((r) => [r.nursery_id, r]));
+    expect(Object.keys(byNursery).sort()).toEqual(['n-65', 'n-90']);
+    expect(byNursery['n-90'].trigger_type).toBe('periodic_review');
+    // The revived one carries its new score; the rejected one is still witnessed as evaluated.
+    expect(byNursery['n-90'].new_score).toBe(92);
+    expect(byNursery['n-65'].nursery_id).toBe('n-65');
   });
 
   test('LLMUndercountError class instantiation surface (constructor contract)', () => {


### PR DESCRIPTION
Two independent seams from SD-EHG-IDEATION-PIPELINE-SEAMS-001. Neither depends on PR #6528, which is separately blocked on a chairman domain attestation.

## 1 — The WIP gate was counting test residue

`chairman-review.js` excluded fixture ventures by **name prefix**, because QF-20260712-860 went looking for a canonical column, guessed `is_synthetic`, found it phantom (it genuinely does not exist on `ventures` — verified), and settled for a proxy.

Measured against the live table: the prefix predicate counted **85 of 89** live rows as real. The gate sat permanently at `85 >= 2`. The chairman's limit had stopped protecting anything and started blocking everything.

`is_demo` is the column that was being looked for — 87 of 89 carry it, leaving the two ventures the portfolio actually holds. **The limit stays 2, untouched.** This counts the population the limit was written about. Authorised by Adam under venture-ops delegation.

**NULL-safety is the point.** `.eq('is_demo', false)` and `.neq('is_demo', true)` return the same number today only because no live row has a NULL flag; in SQL each evaluates to NULL for a NULL row and drops it, so a venture created without the flag would silently escape the count and the limit would quietly stop binding. That is this SD's own defect one layer up — `checkNurseryTriggers` filtered `nextReview && nextReview <= now` and excluded all 16 NULL-dated nursery rows.

TS-4a is the falsifier, mutation-verified: swapping to the naive form fails **exactly TS-4a** on its own assertion, 34 others green.

## 2 — The witness writer had no caller

`recordNurseryEvaluation` writes the `nursery_evaluation_log` row and couples the schedule advance by construction. Correct, well tested — 15 references including a TWO-RUN GUARD — and **zero production callers**. `runNurseryReeval`, the only wired reader of the nursery, never invoked it. That is why the table held 0 rows while the machinery to fill it sat finished.

Every item the LLM **saw** is witnessed, not just the ones judged worth reviving: a considered-and-rejected idea and one nobody looked at were previously indistinguishable, which is what made this seam undiagnosable for 15 days.

⚠ **`triggerType` is `periodic_review`, not `nursery_reeval`.** The strategy is named `nursery_reeval` and the request metadata carries that string, so the obvious value is wrong. Passing it made the writer throw on every item — and because the write is fail-soft, that degraded to a warning: the traversal returned candidates and looked healthy while writing **zero rows**. Only asserting the counter caught it.

TS-16a asserts the traversal **reaches** the writer, at the caller. Mutation-verified: deleting the loop fails exactly TS-16a while **63 tests stay green — including the entire venture-nursery suite and its TWO-RUN GUARD**. That is the defect class stated as a measurement rather than an argument.

## Expected, not a defect

After this change the gate reads exactly 2 against a limit of 2 and **still refuses** for this SD's own traversal. Measured with the shipped predicate. Whether the two deliberately-parked ventures hold their slots is a chairman question, queued separately. No limit raise, no parked-venture exclusion, no fixture seeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)