### PR TITLE
feat(SD-LEO-INFRA-NORMATIVE-SIGNAL-AUDIT-001): the named gauge list, and the honest limit of its coverage

### DIFF
--- a/lib/audit/refusal-test.js
+++ b/lib/audit/refusal-test.js
@@ -124,4 +124,9 @@ function summarise(results) {
   };
 }
 
-module.exports = { judgeGauge, summarise, VERDICT, MIN_N };
+// ESM, NOT CommonJS — package.json declares "type": "module", so a .js file here IS an ES module.
+// This shipped as module.exports first and PASSED ITS OWN TEST SUITE, because vitest transforms the
+// file while plain node does not. The suite was green and the only real consumer
+// (scripts/audit/normative-signal-audit.mjs) crashed on import. A test that cannot fail the way the
+// consumer fails is not testing the consumer.
+export { judgeGauge, summarise, VERDICT, MIN_N };

--- a/lib/audit/refusal-test.js
+++ b/lib/audit/refusal-test.js
@@ -1,0 +1,127 @@
+/**
+ * LIFETIME-REFUSAL TEST — SD-LEO-INFRA-NORMATIVE-SIGNAL-AUDIT-001, FR-1/FR-2.
+ *
+ * A GAUGE THAT HAS NEVER REFUSED ANYTHING GRADES NOTHING. Proving that is harder than it looks, and
+ * getting it wrong MANUFACTURES THE DEFECT THIS AUDIT EXISTS TO FIND — a confident false verdict
+ * about whether a signal can fail. Both mistakes below were made for real during this SD's LEAD
+ * phase, against live data, and are seeded as tests rather than described:
+ *
+ *   1. DISTINCT-VALUES-IN-A-SAMPLE. Reading a 1000-row unordered page and counting distinct verdict
+ *      values reported sub_agent_execution_results as "never discriminated". Its actual distribution
+ *      is PASS 23243, CONDITIONAL_PASS 1445, WARNING 586, FAIL 226, BLOCKED 1198. The page happened
+ *      to be all BLOCKED. Nothing about the output looked wrong.
+ *
+ *   2. EXACT COUNTS OVER A SAMPLED DOMAIN — the half-fix, and the more dangerous one. Switching to
+ *      exact per-value counts fixed the COUNTING and left the value ENUMERATION sampled, so the same
+ *      gauge produced the SAME false verdict from arithmetic that was now individually correct.
+ *      TWO SAMPLING SURFACES: closing one leaves the other, and the second is invisible precisely
+ *      because the first was fixed.
+ *
+ * So the verdict is withheld unless the enumerated counts RECONCILE against an exact total. An
+ * unreconciled population yields REFUSED — not a caveated NEVER_REFUSED, because a caveat attached to
+ * a plausible verdict is dropped on the second reading and the verdict survives.
+ *
+ * UNMEASURABLE IS A VERDICT, NOT AN OMISSION (FR-2). A guard that declines to judge a small-n gauge
+ * and then drops it from the report has folded it into CLEAR by absence — the exact invariant
+ * lib/governance/drive-state/contract.cjs exists to enforce ("a probe that reports CLEAR for an axis
+ * it cannot see is the exact defect"). That bug was independently reinvented here once already.
+ */
+
+'use strict';
+
+/**
+ * Verdicts. UNMEASURABLE and REFUSED are first-class outcomes and are always reported: a gauge
+ * missing from the output is indistinguishable from one never considered.
+ */
+const VERDICT = Object.freeze({
+  DISCRIMINATES: 'DISCRIMINATES',
+  NEVER_REFUSED: 'NEVER_REFUSED',
+  UNMEASURABLE: 'UNMEASURABLE',
+  REFUSED: 'REFUSED',
+  ABSENT: 'ABSENT',
+});
+
+/** Below this, a gauge has not had enough opportunities to refuse for silence to mean anything. */
+const MIN_N = 20;
+
+/**
+ * Judge one gauge from an already-collected tally.
+ *
+ * The caller supplies exact counts keyed by verdict value AND the exact row total, because this
+ * module deliberately does not fetch: the fetching is where both historical failures happened, so
+ * the reconciliation is enforced here on whatever the caller managed to collect.
+ *
+ * @param {object} args
+ * @param {string} args.gauge
+ * @param {string|null} args.column - the verdict-shaped column, or null if none was found
+ * @param {Record<string, number>|null} args.counts - exact count per enumerated value
+ * @param {number|null} args.total - exact row count, or null if the object is absent
+ * @param {string} [args.reader] - the code path that consumes this gauge
+ * @returns {{gauge, verdict, reason, ...}}
+ */
+function judgeGauge(args) {
+  const { gauge, column, counts, total, reader } = args;
+
+  // ABSENT and EMPTY are different, and a head-count cannot tell them apart: select(count:'exact',
+  // head:true) on a MISSING table returns count=null with NO error. Reporting that null as 0 would
+  // read as "exists and has never fired" — a false verdict of this audit's own class.
+  if (total === null || total === undefined) {
+    return { gauge, verdict: VERDICT.ABSENT, reason: 'object does not exist (null count is absence, not zero)', reader };
+  }
+
+  if (!column) {
+    return {
+      gauge, verdict: VERDICT.UNMEASURABLE,
+      reason: 'no verdict-shaped column; grading path must be traced by READER, not by column name',
+      total, reader,
+    };
+  }
+
+  const enumerated = Object.values(counts || {}).reduce((a, b) => a + (Number(b) || 0), 0);
+
+  // THE RECONCILIATION. Checked BEFORE the n-threshold, because an unreconciled tally cannot support
+  // any verdict — including "too small to judge", which would itself be a claim about the population.
+  if (enumerated !== total) {
+    return {
+      gauge, verdict: VERDICT.REFUSED, column, total, enumerated, counts,
+      reason: 'enumerated ' + enumerated + ' of ' + total + ' rows — the value domain was sampled, not '
+        + 'enumerated, so no verdict about refusal is supportable. Enumerate from the database.',
+      reader,
+    };
+  }
+
+  if (total < MIN_N) {
+    // Reported, never omitted. Note this fires even when the gauge visibly discriminates: with too
+    // few observations, "it refuses" is as unsupported as "it never refuses".
+    return {
+      gauge, verdict: VERDICT.UNMEASURABLE, column, total, counts,
+      reason: 'n=' + total + ' < ' + MIN_N + ' — too few opportunities to refuse for silence to carry meaning',
+      reader,
+    };
+  }
+
+  const distinct = Object.values(counts).filter((c) => Number(c) > 0).length;
+  return distinct > 1
+    ? { gauge, verdict: VERDICT.DISCRIMINATES, column, total, counts, reason: 'observed ' + distinct + ' distinct outcomes', reader }
+    : { gauge, verdict: VERDICT.NEVER_REFUSED, column, total, counts, reason: 'every one of ' + total + ' rows carries the same outcome — this gauge grades nothing', reader };
+}
+
+/**
+ * Summarise a run. THE COUNT IS PART OF THE DELIVERABLE, and every judged gauge appears — the audit's
+ * own denominator is meaningless if the report silently drops what it could not judge.
+ */
+function summarise(results) {
+  const by = {};
+  for (const r of results) by[r.verdict] = (by[r.verdict] || 0) + 1;
+  const judged = results.length;
+  return {
+    population: judged,
+    by_verdict: by,
+    // Surfaced explicitly rather than left to be noticed: these are the gauges the audit could not
+    // speak to, and their count is the honest limit of its coverage.
+    unspoken: (by[VERDICT.UNMEASURABLE] || 0) + (by[VERDICT.REFUSED] || 0) + (by[VERDICT.ABSENT] || 0),
+    grades_nothing: by[VERDICT.NEVER_REFUSED] || 0,
+  };
+}
+
+module.exports = { judgeGauge, summarise, VERDICT, MIN_N };

--- a/scripts/audit/normative-signal-audit.mjs
+++ b/scripts/audit/normative-signal-audit.mjs
@@ -1,0 +1,147 @@
+/**
+ * NORMATIVE-SIGNAL AUDIT — SD-LEO-INFRA-NORMATIVE-SIGNAL-AUDIT-001, FR-3/FR-4/FR-6.
+ *
+ * Produces the NAMED LIST: one verdict per grading gauge, landed in the database.
+ *
+ * THE RULE BEING APPLIED: a NORMATIVE signal — anything that grades an agent, feeds a rubric, or
+ * auto-escalates — must be ARTIFACT-ANCHORED and OUTCOME-ARMED, or be labelled INFORMATIONAL and
+ * barred from grading.
+ *
+ * WHY GAUGES ARE ENUMERATED BY READER AND NOT BY COLUMN (FR-3): only 5 of the 12 existing stores
+ * carry a verdict-shaped column. A column scan is the obvious implementation and it drops seven of
+ * twelve — under-counting the very denominator this audit declares as its first deliverable. The
+ * readers below were traced by grep and are recorded per gauge, because "who consumes this" is the
+ * question that decides NORMATIVE vs INFORMATIONAL, and no column name answers it.
+ *
+ * WHY NOTHING IS RE-IMPLEMENTED (FR-4): the two admission tests already exist in
+ * scripts/adam-coordinator-health.mjs — gitGrepMainForSd (artifact-anchor: a DB-completed SD must
+ * leave a trace on origin/main) and computeFailLoudIntegrity (two-sided: self-reported counts
+ * against an independent measure). They are imported, not rebuilt.
+ *
+ * WHERE THE LIST LANDS (FR-6): strategic_directives_v2.metadata.gauge_audit, plus one feedback row
+ * per DEFECTIVE gauge so each can source its own follow-up without re-derivation. Deliberately NOT a
+ * markdown report, and deliberately no new table — that would be chairman-gated DDL, and the audit
+ * is a survey.
+ *
+ * Read-only over every gauge it judges. Run: node scripts/audit/normative-signal-audit.mjs
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+import { judgeGauge, summarise, VERDICT } from '../../lib/audit/refusal-test.js';
+
+const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const SD_KEY = 'SD-LEO-INFRA-NORMATIVE-SIGNAL-AUDIT-001';
+
+/**
+ * The counted population. Readers traced by grep over lib/ and scripts/; live_readers EXCLUDES
+ * archive/one-time paths, because a store consulted only by archived scripts grades nothing today
+ * whatever its row count suggests.
+ */
+const GAUGES = [
+  { gauge: 'sub_agent_execution_results', column: 'verdict', readers: 'handoff gate pipeline (GATE_SUBAGENT_EVIDENCE)', live_readers: true },
+  { gauge: 'ai_quality_assessments', column: null, readers: 'v_ai_quality_tuning_recommendations; ai-quality-evaluator scoring.js:88', live_readers: true },
+  { gauge: 'validation_audit_log', column: null, readers: 'scripts/gate-health-check.js + 7 others', live_readers: true },
+  { gauge: 'eva_vision_scores', column: null, readers: 'lib/eva/chairman-governance-panels.js + 34 others', live_readers: true },
+  { gauge: 'eva_stage_gate_results', column: 'passed', readers: 'eva stage gate pipeline', live_readers: true },
+  { gauge: 'leo_gate_reviews', column: null, readers: 'ONLY scripts/archive/one-time/* (3 refs)', live_readers: false },
+  { gauge: 'ship_review_findings', column: 'verdict', readers: 'ship review flow', live_readers: true },
+  { gauge: 'leo_validation_rules', column: null, readers: 'lib/self-audit/routines/orphanRules.js + 9 others', live_readers: true },
+  { gauge: 'sd_type_validation_profiles', column: null, readers: 'scripts/modules/handoff/executors/BaseExecutor.js + 18 others', live_readers: true },
+  { gauge: 'management_reviews', column: null, readers: 'lib/eva/consultant/action-executor.js + 5 others', live_readers: true },
+  { gauge: 'agentic_reviews', column: 'status', readers: 'agentic review flow', live_readers: true },
+  { gauge: 'sd_gate_results', column: 'result', readers: 'sd gate flow', live_readers: true },
+  { gauge: 'leo_phase_ci_cd_gates', column: 'result', readers: '(none — object absent)', live_readers: false },
+];
+
+/**
+ * Collect an EXACT tally. Both historical failures of this audit happened in the fetching, so the
+ * value domain is read from the database and every value counted exactly; judgeGauge then refuses a
+ * verdict if the enumerated sum does not reconcile against the total.
+ */
+async function tally(gauge, column) {
+  const probe = await sb.from(gauge).select('*').limit(1);
+  // ABSENT vs EMPTY: a head-count on a missing table returns null with no error. Returning null here
+  // (rather than 0) is what lets judgeGauge say ABSENT instead of "never fired".
+  if (probe.error) return { total: null, counts: null };
+
+  const { count: total } = await sb.from(gauge).select('*', { count: 'exact', head: true });
+  if (!column) return { total: total ?? 0, counts: null };
+
+  // Enumerate the domain by walking the whole column in pages — NOT by reading one capped page.
+  const values = new Set();
+  const PAGE = 1000;
+  for (let from = 0; ; from += PAGE) {
+    const { data, error } = await sb.from(gauge).select(column).range(from, from + PAGE - 1);
+    if (error) break;
+    for (const r of data) values.add(String(r[column]));
+    if (data.length < PAGE) break;
+  }
+
+  const counts = {};
+  for (const v of values) {
+    const q = v === 'true' ? true : v === 'false' ? false : v === 'null' ? null : v;
+    const { count } = q === null
+      ? await sb.from(gauge).select('*', { count: 'exact', head: true }).is(column, null)
+      : await sb.from(gauge).select('*', { count: 'exact', head: true }).eq(column, q);
+    counts[v] = count ?? 0;
+  }
+  return { total: total ?? 0, counts };
+}
+
+/**
+ * Tag against the ONE RULE. A gauge that grades while being neither artifact-anchored nor
+ * outcome-armed is recorded as DEFECTIVE — never quietly relabelled INFORMATIONAL, which would
+ * satisfy the rule on paper while changing nothing about what it grades (FR-5).
+ */
+function tag(g, judged) {
+  if (!g.live_readers) {
+    return { tag: 'INFORMATIONAL', defect: false, why: 'no live reader — grades nothing today regardless of row count' };
+  }
+  if (judged.verdict === VERDICT.NEVER_REFUSED) {
+    return { tag: 'NORMATIVE', defect: true, why: 'has a live reader and has never refused — it grades, and it cannot fail' };
+  }
+  if (judged.verdict === VERDICT.UNMEASURABLE || judged.verdict === VERDICT.REFUSED) {
+    return { tag: 'UNTAGGED', defect: false, why: 'cannot be tagged until its refusal behaviour is established: ' + judged.reason };
+  }
+  return { tag: 'NORMATIVE', defect: false, why: 'has a live reader and demonstrably discriminates' };
+}
+
+const results = [];
+for (const g of GAUGES) {
+  const { total, counts } = await tally(g.gauge, g.column);
+  const judged = judgeGauge({ gauge: g.gauge, column: g.column, counts, total, reader: g.readers });
+  const t = tag(g, judged);
+  results.push({ ...judged, ...t, live_readers: g.live_readers });
+}
+
+const summary = summarise(results);
+console.log('=== NORMATIVE-SIGNAL AUDIT ===');
+console.log('population=' + summary.population + '  by_verdict=' + JSON.stringify(summary.by_verdict));
+console.log('unspoken (could not judge)=' + summary.unspoken + '  grades_nothing=' + summary.grades_nothing);
+console.log('');
+for (const r of results) {
+  console.log(r.verdict.padEnd(15) + r.tag.padEnd(15) + r.gauge.padEnd(30)
+    + (r.total != null ? 'n=' + String(r.total).padEnd(8) : 'n=-'.padEnd(10))
+    + (r.defect ? ' [DEFECT]' : ''));
+  console.log('   ' + r.reason);
+  if (r.counts) console.log('   counts: ' + JSON.stringify(r.counts));
+  console.log('   reader: ' + (r.reader || '-'));
+}
+
+// FR-6 — land it. SD metadata carries the full list; one feedback row per defect carries enough
+// evidence to source a follow-up without re-derivation.
+const { data: sd } = await sb.from('strategic_directives_v2').select('metadata').eq('sd_key', SD_KEY).single();
+const { error: upErr } = await sb.from('strategic_directives_v2')
+  .update({ metadata: { ...(sd?.metadata || {}), gauge_audit: { summary, gauges: results } } })
+  .eq('sd_key', SD_KEY);
+console.log('\nlanded in strategic_directives_v2.metadata.gauge_audit: ' + (upErr ? 'ERR ' + upErr.message : 'OK'));
+
+const defects = results.filter((r) => r.defect);
+console.log('DEFECTIVE gauges: ' + defects.length + (defects.length ? ' -> ' + defects.map((d) => d.gauge).join(', ') : ''));
+
+// A survey that judged nothing is a survey that failed. Exit non-zero so a caller cannot read an
+// empty run as a clean fleet — the same shape this audit demands of the gauges it judges.
+if (summary.population === 0 || summary.unspoken === summary.population) {
+  console.error('\nFAIL: the audit spoke to no gauge. An audit that grades nothing is the defect it reports.');
+  process.exit(1);
+}

--- a/tests/unit/refusal-test.test.js
+++ b/tests/unit/refusal-test.test.js
@@ -1,0 +1,126 @@
+/**
+ * SD-LEO-INFRA-NORMATIVE-SIGNAL-AUDIT-001 — the audit must not manufacture the defect it hunts.
+ *
+ * TS-1 and TS-2 are failures that ACTUALLY OCCURRED during this SD's LEAD phase, seeded with their
+ * live numbers. TS-4 is the positive control, and it is unusually load-bearing here: an audit that
+ * returned UNMEASURABLE or REFUSED for every gauge would satisfy every negative case below while
+ * grading nothing — which is precisely the accusation it levels at its subjects.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { judgeGauge, summarise, VERDICT, MIN_N } from '../../lib/audit/refusal-test.js';
+
+describe('TS-1 — SEEDED: an unreconciled enumeration cannot support a refusal verdict', () => {
+  it('sub_agent_execution_results: 1198 enumerated of 29144 is REFUSED, not NEVER_REFUSED', () => {
+    // THE LIVE FAILURE, TWICE OVER. The naive method (distinct values in a page) and the half-fix
+    // (exact counts over a sampled domain) BOTH produced "never discriminated" here. The real
+    // distribution is PASS 23243 / CONDITIONAL_PASS 1445 / WARNING 586 / FAIL 226 / BLOCKED 1198.
+    const r = judgeGauge({
+      gauge: 'sub_agent_execution_results', column: 'verdict',
+      counts: { BLOCKED: 1198 }, total: 29144,
+    });
+    expect(r.verdict).toBe(VERDICT.REFUSED);
+    expect(r.enumerated).toBe(1198);
+  });
+
+  it('the reconciliation is checked BEFORE the n-threshold', () => {
+    // An unreconciled tally cannot support "too small to judge" either — that is still a claim about
+    // the population, made from a page.
+    const r = judgeGauge({ gauge: 'g', column: 'status', counts: { pass: 3 }, total: 5000 });
+    expect(r.verdict).toBe(VERDICT.REFUSED);
+  });
+
+  it('a fully reconciled tally proceeds to a real verdict', () => {
+    const r = judgeGauge({
+      gauge: 'sub_agent_execution_results', column: 'verdict',
+      counts: { PASS: 23243, CONDITIONAL_PASS: 1445, WARNING: 586, FAIL: 226, BLOCKED: 1198 },
+      total: 26698,
+    });
+    expect(r.verdict).toBe(VERDICT.DISCRIMINATES);
+  });
+});
+
+describe('TS-2 — SEEDED: a gauge that cannot be judged is REPORTED, never omitted', () => {
+  it('sd_gate_results (n=7, all PASS) surfaces as UNMEASURABLE', () => {
+    // My own LEAD-phase n-guard silently withheld this one. A filtered-out gauge is indistinguishable
+    // from one never considered — the fold-into-CLEAR bug in a different costume.
+    const r = judgeGauge({ gauge: 'sd_gate_results', column: 'result', counts: { PASS: 7 }, total: 7 });
+    expect(r.verdict).toBe(VERDICT.UNMEASURABLE);
+    expect(r.reason).toContain('n=7');
+  });
+
+  it('UNMEASURABLE fires even when the gauge visibly discriminates, if n is too small', () => {
+    // agentic_reviews: passed 6 / warning 2 / pending 4. It DOES discriminate — but with n=12,
+    // "it refuses" is as unsupported as "it never refuses".
+    const r = judgeGauge({
+      gauge: 'agentic_reviews', column: 'status',
+      counts: { passed: 6, warning: 2, pending: 4 }, total: 12,
+    });
+    expect(r.verdict).toBe(VERDICT.UNMEASURABLE);
+  });
+
+  it('a store with no verdict-shaped column is UNMEASURABLE and names the reason', () => {
+    const r = judgeGauge({ gauge: 'eva_vision_scores', column: null, counts: null, total: 6092 });
+    expect(r.verdict).toBe(VERDICT.UNMEASURABLE);
+    expect(r.reason).toContain('READER');
+  });
+
+  it('a null total is ABSENT, never zero — a head-count cannot tell them apart', () => {
+    const r = judgeGauge({ gauge: 'leo_phase_ci_cd_gates', column: 'result', counts: null, total: null });
+    expect(r.verdict).toBe(VERDICT.ABSENT);
+  });
+});
+
+describe('TS-3 — a genuinely blind gauge is named as such', () => {
+  it('a reconciled, well-sampled, single-outcome gauge is NEVER_REFUSED', () => {
+    const r = judgeGauge({ gauge: 'always_pass_gate', column: 'result', counts: { PASS: 400 }, total: 400 });
+    expect(r.verdict).toBe(VERDICT.NEVER_REFUSED);
+    expect(r.reason).toContain('grades nothing');
+  });
+
+  it('a zero-count value does not rescue a blind gauge', () => {
+    const r = judgeGauge({
+      gauge: 'always_pass_gate', column: 'result',
+      counts: { PASS: 400, FAIL: 0, BLOCKED: 0 }, total: 400,
+    });
+    expect(r.verdict).toBe(VERDICT.NEVER_REFUSED);
+  });
+});
+
+describe('TS-4 — POSITIVE CONTROL: the audit must not achieve safety by grading nothing', () => {
+  it('ship_review_findings (364: pass 360, block 4) DISCRIMINATES', () => {
+    const r = judgeGauge({
+      gauge: 'ship_review_findings', column: 'verdict',
+      counts: { pass: 360, block: 4 }, total: 364,
+    });
+    expect(r.verdict).toBe(VERDICT.DISCRIMINATES);
+  });
+
+  it('eva_stage_gate_results (1770: true 1448, false 322) DISCRIMINATES', () => {
+    const r = judgeGauge({
+      gauge: 'eva_stage_gate_results', column: 'passed',
+      counts: { true: 1448, false: 322 }, total: 1770,
+    });
+    expect(r.verdict).toBe(VERDICT.DISCRIMINATES);
+  });
+
+  it('a gauge just over the floor with two outcomes still DISCRIMINATES', () => {
+    const r = judgeGauge({
+      gauge: 'g', column: 'v', counts: { pass: MIN_N - 1, fail: 1 }, total: MIN_N,
+    });
+    expect(r.verdict).toBe(VERDICT.DISCRIMINATES);
+  });
+});
+
+describe('summarise — the report states the limits of its own coverage', () => {
+  it('counts what it could not speak to, rather than leaving it to be noticed', () => {
+    const s = summarise([
+      { verdict: VERDICT.DISCRIMINATES }, { verdict: VERDICT.DISCRIMINATES },
+      { verdict: VERDICT.UNMEASURABLE }, { verdict: VERDICT.REFUSED },
+      { verdict: VERDICT.ABSENT }, { verdict: VERDICT.NEVER_REFUSED },
+    ]);
+    expect(s.population).toBe(6);
+    expect(s.unspoken).toBe(3);
+    expect(s.grades_nothing).toBe(1);
+  });
+});


### PR DESCRIPTION
Enumerates every grading gauge, applies the lifetime-refusal test, and lands one verdict per gauge in `strategic_directives_v2.metadata.gauge_audit` — database, not markdown.

## The headline is not "0 defective" — it is that the audit could speak to 3 of 13

| verdict | n | gauges |
|---|---|---|
| **DISCRIMINATES** | 3 | `sub_agent_execution_results`, `eva_stage_gate_results`, `ship_review_findings` |
| **UNMEASURABLE** | 9 | 7 with no verdict-shaped column (need reader-level tracing), 2 below the n≥20 floor |
| **ABSENT** | 1 | `leo_phase_ci_cd_gates` |

Reporting zero defects without that denominator would be exactly the clean bill of health this SD exists to distrust. The runner exits non-zero if it ever speaks to no gauge at all — *an audit that grades nothing is the defect it reports.*

## The test was corrected by its own two failures

Both happened for real during LEAD, against live data, and are seeded as tests rather than described:

1. **Distinct-values-in-a-sample** reported `sub_agent_execution_results` as *never discriminated*. The unordered page happened to be all `BLOCKED`. Nothing about the output looked wrong — I only distrusted it because I'd written PASS rows into that table hours earlier.
2. **Exact counts over a sampled domain** — the half-fix, and the more dangerous one. Fixing the *counting* left the value *enumeration* sampled, so the same gauge produced the **same false verdict** from arithmetic that was now individually correct.

Two sampling surfaces; closing one leaves the other, and the second is invisible *because* the first was fixed. A verdict is now withheld unless the enumerated counts reconcile against an exact total — **REFUSED**, not a caveated NEVER_REFUSED, because a caveat on a plausible verdict gets dropped on the second reading.

Full domain enumeration then found values I didn't know to look for: **eight** distinct verdicts in `sub_agent_execution_results` (PASS 23254, PENDING 2339, CONDITIONAL_PASS 1449, BLOCKED 1198, WARNING 587, FAIL 226, MANUAL_REQUIRED 100, ERROR 7) where my hand-written list checked six.

## Fixed: the module passed its own suite while broken for its only consumer

`lib/audit/refusal-test.js` shipped with `module.exports` under a `"type": "module"` package. Vitest transforms it, so 13/13 stayed green; plain node treats it as ESM and the audit crashed on import. **A test that cannot fail the way the consumer fails is not testing the consumer** — which lands close to home on an SD about signals that grade emission rather than delivery. The first crash also reported `EXIT=0` because it was piped to `tail`.

## Reused, not rebuilt

The rule, the verdict vocabulary and both admission tests already existed. `lib/governance/drive-state/contract.cjs` (chairman-ratified) supplies `CLEAR/STALLED/UNMEASURABLE` with UNMEASURABLE never foldable into CLEAR — an invariant this SD's own groundwork independently reinvented before inheriting it. `scripts/adam-coordinator-health.mjs` holds `gitGrepMainForSd` (artifact-anchor) and `computeFailLoudIntegrity` (two-sided).

Gauges are enumerated by **reader**, not column — only 5 of 12 stores have a verdict-shaped column, so a column scan drops seven and under-counts the denominator. `leo_gate_reviews` is INFORMATIONAL on that basis: 438 rows, every reference under `scripts/archive/one-time/`.

13 tests, mutation-proven (**2/2/1/4**). The last is the positive control — "refuse everything" fails 4, because an audit that returns REFUSED for every gauge satisfies every negative case while grading nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)