### PR TITLE
fix(QF-20260727-013): resolve account identity per-profile, and record when it cannot

### DIFF
--- a/scripts/hooks/session-register.cjs
+++ b/scripts/hooks/session-register.cjs
@@ -175,6 +175,43 @@ async function emitSessionCreated(supabase, { sessionId, payload, prior }) {
  * real answer downstream, and this whole defect family is honest values answering the wrong
  * question. Absent is the honest representation of "not determined".
  */
+/**
+ * QF-20260727-013 — fallback resolver, deliberately reachable ONLY via CLAUDE_CONFIG_DIR.
+ *
+ * lib/fleet/account-identity.cjs getAccountIdentity() reads ~/.claude.json oauthAccount and
+ * works on this host where the CLI returned nulls — which is why coordinator-quiet-tick could
+ * print a real account in the same process tree where this path resolved null. Two resolvers,
+ * same host, same second, opposite answers.
+ *
+ * BUT CALLING IT BARE IS THE TRAP, and it is the exact defect QF-20260726-514 was created to
+ * fix. With no argument it uses resolveRealConfigPath() = USERPROFILE/.claude.json, which does
+ * NOT respect CLAUDE_CONFIG_DIR: host-global, last-writer-wins, every seat reporting the same
+ * account. That looks correct right up until the fleet splits across accounts, which is the
+ * only time this field matters. So we pass the PATH SEAM explicitly and return null rather
+ * than read the host-global default — an unresolved account must stay absent, never guessed.
+ *
+ * @returns {object|null} same shape as resolveAccountIdentity, or null
+ */
+function resolveAccountFromConfigDir() {
+  const dir = process.env.CLAUDE_CONFIG_DIR;
+  if (!dir) return null; // no per-profile scope => refuse; see above
+  try {
+    const { getAccountIdentity } = require('../../lib/fleet/account-identity.cjs');
+    const id = getAccountIdentity(path.join(dir, '.claude.json'));
+    if (!id || !id.email) return null;
+    return {
+      account_email: id.email,
+      account_org_name: id.orgName || null,
+      account_org_id: null,              // not carried by oauthAccount — absent, not invented
+      account_subscription_type: null,   // ditto
+      account_auth_method: 'config_dir',
+      account_captured_at: new Date().toISOString(),
+    };
+  } catch {
+    return null;
+  }
+}
+
 function resolveAccountIdentity() {
   try {
     // execSync with a single command string, matching lib/simplifier/plugin-bridge.js — the
@@ -193,7 +230,11 @@ function resolveAccountIdentity() {
       windowsHide: true,
     });
     const j = JSON.parse(raw);
-    if (!j || j.loggedIn !== true || !j.email) return null;
+    // QF-20260727-013: the CLI can answer loggedIn:true while every identity field is null
+    // (measured 2026-07-28: email/orgId/orgName/subscriptionType all null). The guard below is
+    // CORRECT to reject that — absent beats a placeholder — but it left the stamp 100% dark.
+    // Fall back through the per-profile seam before giving up.
+    if (!j || j.loggedIn !== true || !j.email) return resolveAccountFromConfigDir();
     return {
       account_email: j.email,
       account_org_name: j.orgName || null,
@@ -203,7 +244,12 @@ function resolveAccountIdentity() {
       account_captured_at: new Date().toISOString(),
     };
   } catch {
-    return null; // never abort SessionStart for telemetry
+    // QF-20260727-013: the fallback must be reachable from HERE too, not only from the
+    // null-identity branch above. A missing/failing `claude` binary throws rather than
+    // returning a null-identity payload, and the original code returned null from this catch
+    // without ever consulting the per-profile config — so the seat stayed dark for the one
+    // failure mode where an on-disk answer was still available. Caught by its own unit test.
+    return resolveAccountFromConfigDir(); // still null-safe; never aborts SessionStart
   }
 }
 
@@ -228,7 +274,18 @@ async function captureAccountIdentity(supabase, sessionId) {
       ? data.metadata : {};
     if (meta.account_email) return;                   // already captured — nothing to do
     const acct = resolveAccountIdentity();
-    if (!acct) return;                                // unresolved => leave ABSENT, not null
+    if (!acct) {
+      // QF-20260727-013: RECORD THE DARKNESS. Leaving the identity keys absent is still right —
+      // a null account stored as a value is indistinguishable from a real answer downstream.
+      // But absent-because-unresolved and absent-because-never-asked were ALSO indistinguishable,
+      // and that is why a 100%-dark instrument survived unnoticed from 2026-07-26: nothing said
+      // it was dark. This key answers only "did we ask and fail", so the identity fields keep
+      // their honest absence while the failure itself stops being silent.
+      await supabase.from('claude_sessions')
+        .update({ metadata: { ...meta, account_unresolved_at: new Date().toISOString() } })
+        .eq('session_id', sessionId);
+      return;
+    }
     await supabase.from('claude_sessions')
       .update({ metadata: { ...meta, ...acct } })
       .eq('session_id', sessionId);

--- a/tests/unit/hooks/session-register-account-capture.test.js
+++ b/tests/unit/hooks/session-register-account-capture.test.js
@@ -69,6 +69,17 @@ describe('QF-514: account capture writes only what it could read', () => {
     await captureAccountIdentity(api, SID);
     if (calls.updates.length === 0) return; // unresolved account on this host — correct behaviour
     const written = calls.updates[0].metadata;
+    // QF-20260727-013: the escape hatch above keyed on "no write happened", which stopped being
+    // the right signal once an UNRESOLVED account also writes (metadata.account_unresolved_at, so
+    // darkness is recorded instead of silent). On a host without a resolvable account there is now
+    // a write, but still no identity — so gate on the identity itself. This preserves the control's
+    // intent exactly (assert the merge shape only when an account was genuinely written) rather
+    // than weakening it; CI caught this, where `claude auth status` does not exist.
+    if (!written.account_email) {
+      expect(written.account_unresolved_at).toEqual(expect.any(String));
+      expect(written.model).toBe('opus'); // the darkness write must still MERGE, never clobber
+      return;
+    }
     expect(written.model).toBe('opus');           // siblings survived the merge
     expect(written.effort).toBe('xhigh');
     expect(written.tier_rank).toBe(4);

--- a/tests/unit/hooks/session-register-account-fallback.test.js
+++ b/tests/unit/hooks/session-register-account-fallback.test.js
@@ -1,0 +1,110 @@
+/**
+ * QF-20260727-013 — the account stamp must not be able to go dark silently.
+ *
+ * QF-20260726-514 shipped resolveAccountIdentity() and it wrote nothing for two days: the CLI
+ * answered loggedIn:true with every identity field null, the guard correctly returned null, and
+ * NOTHING RECORDED THAT. A 100%-dark instrument was indistinguishable from a healthy one nobody
+ * had queried.
+ *
+ * The two properties pinned here are the ones easiest to regress by "simplifying":
+ *   1. the fallback NEVER reads the host-global config (that is last-writer-wins, the exact
+ *      defect 514 existed to fix — reintroduced "through a different door");
+ *   2. an unresolved account is RECORDED, while the identity fields keep their honest absence.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const require_ = createRequire(import.meta.url);
+const { resolveAccountIdentity, captureAccountIdentity } =
+  require_('../../../scripts/hooks/session-register.cjs');
+
+/** Records every metadata patch so we can assert on the WRITE, not a return value. */
+function fakeSupabase(existingMeta = {}) {
+  const writes = [];
+  return {
+    writes,
+    from() {
+      return {
+        select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { metadata: existingMeta }, error: null }) }) }),
+        update: (patch) => ({ eq: () => { writes.push(patch); return { error: null }; } }),
+      };
+    },
+  };
+}
+
+const ORIGINAL_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR;
+beforeEach(() => {
+  if (ORIGINAL_CONFIG_DIR === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+  else process.env.CLAUDE_CONFIG_DIR = ORIGINAL_CONFIG_DIR;
+  vi.restoreAllMocks();
+});
+
+describe('QF-013 — fallback is per-profile or nothing', () => {
+  it('returns null when CLAUDE_CONFIG_DIR is unset, rather than reading the host-global config', () => {
+    // THE LOAD-BEARING ASSERTION. Reading ~/.claude.json here would make every seat on the host
+    // report the same account and would look correct until the fleet splits across accounts.
+    delete process.env.CLAUDE_CONFIG_DIR;
+    const spy = vi.spyOn(require('node:child_process'), 'execSync').mockImplementation(() => {
+      throw new Error('claude CLI unavailable');
+    });
+    expect(resolveAccountIdentity()).toBeNull();
+    spy.mockRestore();
+  });
+
+  it('CONTROL — with CLAUDE_CONFIG_DIR set to a real profile, the fallback DOES resolve', () => {
+    // Without this, the assertion above passes just as well on a fallback that never works at all.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qf013-'));
+    fs.writeFileSync(path.join(dir, '.claude.json'), JSON.stringify({
+      oauthAccount: { emailAddress: 'seat@example.com', organizationName: 'Org', accountUuid: 'abcdefgh-1111-2222-3333-444444444444' },
+    }));
+    process.env.CLAUDE_CONFIG_DIR = dir;
+    const spy = vi.spyOn(require('node:child_process'), 'execSync').mockImplementation(() => {
+      throw new Error('claude CLI unavailable');
+    });
+    const got = resolveAccountIdentity();
+    spy.mockRestore();
+    expect(got).toMatchObject({ account_email: 'seat@example.com', account_org_name: 'Org' });
+  });
+
+  it('does not invent org_id / subscription_type the oauthAccount never carried', () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qf013-'));
+    fs.writeFileSync(path.join(dir, '.claude.json'), JSON.stringify({
+      oauthAccount: { emailAddress: 'seat@example.com', organizationName: 'Org', accountUuid: 'abcdefgh-1111-2222-3333-444444444444' },
+    }));
+    process.env.CLAUDE_CONFIG_DIR = dir;
+    const spy = vi.spyOn(require('node:child_process'), 'execSync').mockImplementation(() => {
+      throw new Error('nope');
+    });
+    const got = resolveAccountIdentity();
+    spy.mockRestore();
+    expect(got.account_org_id).toBeNull();
+    expect(got.account_subscription_type).toBeNull();
+  });
+});
+
+describe('QF-013 — darkness is recorded', () => {
+  it('stamps account_unresolved_at when nothing resolves, and writes NO identity fields', async () => {
+    delete process.env.CLAUDE_CONFIG_DIR;
+    const spy = vi.spyOn(require('node:child_process'), 'execSync').mockImplementation(() => {
+      throw new Error('claude CLI unavailable');
+    });
+    const sb = fakeSupabase({ model: 'opus' });
+    await captureAccountIdentity(sb, 'sess-1');
+    spy.mockRestore();
+
+    expect(sb.writes).toHaveLength(1);
+    const meta = sb.writes[0].metadata;
+    expect(meta.account_unresolved_at).toEqual(expect.any(String));
+    expect(meta.model).toBe('opus');            // read-modify-write preserved, never clobbered
+    expect('account_email' in meta).toBe(false); // absence stays honest — no placeholder
+  });
+
+  it('writes nothing at all when the account was already captured', async () => {
+    const sb = fakeSupabase({ account_email: 'already@example.com' });
+    await captureAccountIdentity(sb, 'sess-1');
+    expect(sb.writes).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

`QF-20260726-514` shipped `resolveAccountIdentity()` and it wrote nothing for two days. The CLI answered `loggedIn:true` with every identity field `null`, the guard correctly returned `null`, and **nothing recorded that** — a 100%-dark instrument is indistinguishable from a healthy one nobody queried.

## The premise moved, and I checked before building

`claude auth status --json` on this host **now returns a fully populated identity**, so the QF's stated mechanism no longer reproduces. The failure mode was real and observed, so the fallback ships as defence — but this PR does **not** claim to fix a currently-firing bug.

## The live cause today is different, and is NOT fixed here

All 10 active sessions still read `account_email=ABSENT`, and every one was **created 2026-07-31** — before the account resolved. The stamp is capture-if-absent *at SessionStart* with **no backfill**, so a long-lived session that registered while the account was unresolvable stays dark forever. Flagged for follow-up rather than smuggled into a QF.

## Not the obvious fix

Bare `getAccountIdentity()` uses `resolveRealConfigPath()` = `USERPROFILE/.claude.json`, which ignores `CLAUDE_CONFIG_DIR` — host-global, last-writer-wins, every seat reporting one account. That is exactly what QF-514 existed to fix, and its own comment warns about reintroducing it *"through a different door"*. So the fallback passes the **path seam** explicitly and returns `null` when `CLAUDE_CONFIG_DIR` is unset rather than reading the host default.

## My own test caught a gap in my fix

The fallback was reachable only from the null-identity branch, so a missing or failing `claude` binary threw straight past it to the outer catch — dark for the one failure mode where an on-disk answer was still available. Now reachable from both paths.

## Test plan

- Proven by mutation: reverting the production file fails **3 of 5** guards.
- The load-bearing assertion is that the fallback returns `null` with `CLAUDE_CONFIG_DIR` unset — paired with a **CONTROL** proving it *does* resolve when set, so the refusal isn't just a fallback that never works.
- 112 tests green across 15 suites touching this hook.
- UAT: happy path still resolves live; darkness path writes `account_unresolved_at` while identity fields keep their honest absence.

## Observation confirmed — needs a human call

The canary profile `.claude.json` resolves to the **same `accountUuid8` (`f65a1297`)** as host-global, though canary is meant to be OAuth-isolated. Reported as an observation by the QF author; I verified it reproduces. Not actioned here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)