### PR TITLE
fix(ci): unit-tier needs full git history — the contract-read fixture cannot resolve blobs at depth 1

### DIFF
--- a/.github/workflows/unit-tier.yml
+++ b/.github/workflows/unit-tier.yml
@@ -16,7 +16,21 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
+      # FULL HISTORY IS REQUIRED, NOT OPTIONAL. tests/unit/protocol/contract-read-groundtruth.test.js
+      # verifies sha-bearing fixture rows against their git blobs with `git show <sha>:<path>`, and
+      # those rows are DATA-DRIVEN FROM THE DATABASE - the SHAs appear nowhere in the test file. The
+      # default depth of 1 leaves the job holding only the tip commit, so any row referencing an
+      # older commit fails with `fatal: invalid object name` even though the object is reachable from
+      # the remote. Observed on PR #6821: `git show 1ea0403b14ab:CLAUDE_SOLOMON.md` failed here while
+      # `git branch -r --contains 1ea0403b14ab` listed origin/main plus five branches.
+      #
+      # This is DETERMINISTIC, not flaky, and it hits every PR regardless of whose diff it is -
+      # re-running until green would teach the fleet the opposite. Same reasoning and same fix as
+      # .github/workflows/test-coverage.yml, which has carried fetch-depth: 0 for this class of
+      # failure already.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
`Run Unit Tier` is failing **deterministically on every PR**, not just the one that surfaced it.

## What breaks

`tests/unit/protocol/contract-read-groundtruth.test.js` verifies sha-bearing fixture rows against their git blobs with `git show <sha>:<path>`. Those rows are **data-driven from the database** — the SHAs appear nowhere in the test file (grep returns 0).

`unit-tier.yml` checked out with a bare `actions/checkout@v4` and no `fetch-depth`, which defaults to **1**. The job holds only the tip commit, so any row referencing an older commit fails with `fatal: invalid object name`.

## The object was always reachable

Observed on PR #6821 — `git show 1ea0403b14ab:CLAUDE_SOLOMON.md` failed in CI, while locally:

- `git cat-file -t 1ea0403b14ab` → `commit`
- `git branch -r --contains 1ea0403b14ab` → `origin/main` plus five branches
- `origin/main:CLAUDE_SOLOMON.md` → exists

So this was never missing data. The job just couldn't see it.

## Why it matters beyond one PR

The rows are data-driven, so **any** row referencing a commit outside the checkout depth crashes the job regardless of whose diff it is. It failed 1 of 36,256 tests on a PR that touches none of the relevant code. Re-running until green would have taught the fleet the failure is flaky when it is deterministic.

## Precedent

`.github/workflows/test-coverage.yml:28-30` already carries `fetch-depth: 0` for this same class of failure, with a comment explaining it. `unit-tier` simply never got it.

## Follow-on — logged separately, deliberately not fixed here

The fixture **crashes** on an unreachable blob rather than reporting UNVERIFIABLE. `fetch-depth: 0` makes the blobs reachable today; it does not stop the test conflating *"I cannot check this"* with *"this is wrong"* — findings that need opposite responses. Filed to harness_backlog rather than widened into this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)