### PR TITLE
fix(QF-20260727-475): mark claim provenance where feedback becomes EXEC work instructions

### DIFF
--- a/scripts/sd-from-feedback.js
+++ b/scripts/sd-from-feedback.js
@@ -135,7 +135,11 @@ function prompt(rl, question) {
 async function fetchFeedbackItems(includeAll = false) {
   let query = supabase
     .from('feedback')
-    .select('id, type, title, description, priority, status, source_type, created_at')
+    // QF-20260727-475: `category` MUST be selected — deriveClaimProvenance() reads its VALUE to
+    // decide whether this row's claims are first-hand or relayed. Selecting it is not optional
+    // just because a filter elsewhere mentions it; an unselected column reads undefined and the
+    // deriver would silently classify every row the same way.
+    .select('id, type, title, description, priority, status, source_type, category, created_at')
     .order('priority', { ascending: true })
     .order('created_at', { ascending: true });
 
@@ -234,6 +238,65 @@ async function resolveParentSd(parentKey) {
 }
 
 /**
+ * QF-20260727-475 — categories whose rows are AUTHORED BY AN AGENT relaying something it did not
+ * measure first-hand: a worker signal, a sub-agent finding, another role's review.
+ *
+ * TWO INDEPENDENT WITNESSES, EIGHT HOURS APART. An SD embedded three material claims that were
+ * WRONG — a named insertion point that could not see the rows its own ACs staged, a security
+ * assertion false on win32 (this fleet IS win32), and an in-flight rule contradicted by live
+ * measurement — each stated with the SAME CONFIDENCE as the verified parts. The worker's words:
+ * "I ACTED ON ALL FOUR BECAUSE NOTHING IN THE ARTIFACT DISTINGUISHED THEM FROM VERIFIED FACT."
+ * Then a sub-agent INFO finding travelled sub-agent -> worker -> coordinator -> worker -> a
+ * DURABLE MIGRATION HEADER with no verification at any hop, and was false in all three parts
+ * against pg_catalog — the named object did not exist in the database at all.
+ */
+const RELAYED_CLAIM_CATEGORIES = new Set([
+  'harness_backlog', 'coordinator_review', 'coordinator_adam_review', 'fleet_retro',
+  'invariant_gauge_finding', 'adam_adherence_drift', 'solomon_adherence_drift',
+  'adam_solomon_health', 'adam_self_assessment', 'completion_flag', 'completion_flag_witness',
+  'wind_down_survey',
+]);
+
+/**
+ * Classify how this row's substantive claims were obtained.
+ *
+ * NEVER returns 'measured'. Nothing available here can prove first-hand measurement, and awarding
+ * it would recreate the defect at one remove — a provenance tag that lies is worse than none.
+ * Absence of evidence is not evidence of verification, so the floor is 'unverified'.
+ *
+ * @param {{category?:string, source_type?:string}} feedback
+ * @returns {'relayed_unverified'|'unverified'}
+ */
+export function deriveClaimProvenance(feedback) {
+  const category = String((feedback && feedback.category) || '').toLowerCase();
+  if (RELAYED_CLAIM_CATEGORIES.has(category)) return 'relayed_unverified';
+  if (String((feedback && feedback.source_type) || '').toLowerCase() === 'auto_capture') {
+    return 'relayed_unverified';
+  }
+  return 'unverified';
+}
+
+/**
+ * The banner an EXEC agent reads before the inherited text.
+ *
+ * Per-SENTENCE provenance cannot be derived automatically — no reader here knows which clause the
+ * author measured. So this marks the ROW and names the four claim types that have actually caused
+ * harm (mechanism, insertion point, root cause, proposed fix), telling the consumer which
+ * sentences to re-derive. That is the stated acceptance: a worker can tell verified fact from
+ * relayed inference and knows what to check before acting.
+ */
+export function claimProvenanceBanner(provenance) {
+  return [
+    `> **CLAIM PROVENANCE: ${provenance.toUpperCase().replace(/_/g, '-')}.**`,
+    '> The text below was authored from a signal, sub-agent finding, or review — NOT from',
+    '> first-hand measurement by this SD. Any **mechanism, insertion point, root cause or',
+    '> proposed fix** in it is a LEAD, not a specification: re-derive it against the live',
+    '> system before acting. Verified parts and inferred parts are NOT distinguished here.',
+    '',
+  ].join('\n');
+}
+
+/**
  * Create SD from feedback item
  */
 async function createSdFromFeedback(feedback, parentId = null) {
@@ -252,11 +315,17 @@ async function createSdFromFeedback(feedback, parentId = null) {
     ? sanitizeUserText(feedback.description || feedback.title).content
     : (feedback.description || feedback.title);
 
+  // QF-20260727-475: stamp provenance ON THE DESCRIPTION, because the description is what a
+  // full-authority EXEC agent reads verbatim as its work instructions (see FR-5 note above).
+  // Putting it only in metadata would leave the consumer that actually acts on the text unmarked.
+  const claimProvenance = deriveClaimProvenance(feedback);
+  const describedBody = `${claimProvenanceBanner(claimProvenance)}\n${safeDescription}`;
+
   const sdData = {
     id: sdKey,  // Human-readable key (per schema: id=VARCHAR for main identifier)
     sd_key: sdKey,  // Same for backward compatibility
     title: feedback.title,
-    description: safeDescription,
+    description: describedBody,
     rationale: `Created from feedback item. Source: ${feedback.source_type || 'manual'}. Original ID: ${feedback.id}`,
     sd_type: sdType,
     status: 'draft',
@@ -272,11 +341,13 @@ async function createSdFromFeedback(feedback, parentId = null) {
     sdData.metadata = JSON.stringify({
       contract_governed: true,
       contract_parent_chain: [parentId],
-      source_feedback_id: feedback.id
+      source_feedback_id: feedback.id,
+      claim_provenance: claimProvenance
     });
   } else {
     sdData.metadata = JSON.stringify({
-      source_feedback_id: feedback.id
+      source_feedback_id: feedback.id,
+      claim_provenance: claimProvenance
     });
   }
 

--- a/tests/unit/scripts/sd-from-feedback-claim-provenance.test.js
+++ b/tests/unit/scripts/sd-from-feedback-claim-provenance.test.js
@@ -1,0 +1,89 @@
+/**
+ * QF-20260727-475 — a reader must be able to tell relayed inference from verified fact.
+ *
+ * Two independent witnesses, eight hours apart. An SD carried three material claims that were
+ * WRONG, each stated with the same confidence as the verified parts, and the worker acted on all
+ * of them: "NOTHING IN THE ARTIFACT DISTINGUISHED THEM FROM VERIFIED FACT." Then a sub-agent INFO
+ * finding travelled sub-agent → worker → coordinator → worker → a durable migration header with
+ * no verification at any hop, and was false in all three parts against pg_catalog.
+ *
+ * The property that matters: the deriver must NEVER award 'measured'. A provenance tag that
+ * overclaims recreates the defect one level up — the reader would trust the tag instead of the
+ * prose, and be wrong in exactly the same way.
+ */
+import { describe, it, expect } from 'vitest';
+import { deriveClaimProvenance, claimProvenanceBanner } from '../../../scripts/sd-from-feedback.js';
+
+describe('QF-475 — provenance never overclaims', () => {
+  it('never returns "measured", whatever the input', () => {
+    // THE LOAD-BEARING ASSERTION. Nothing available at this seam can prove first-hand
+    // measurement, so claiming it would be a lie with a confident-looking label.
+    const inputs = [
+      { category: 'harness_backlog' }, { category: 'coordinator_review' },
+      { category: 'ci_failure' }, { category: 'feature_flag_governance' },
+      { source_type: 'manual_feedback' }, { source_type: 'auto_capture' },
+      {}, null, undefined, { category: 'MEASURED' }, { category: 'verified' },
+    ];
+    for (const f of inputs) expect(deriveClaimProvenance(f)).not.toBe('measured');
+  });
+
+  it('floors at "unverified" — absence of evidence is not evidence of verification', () => {
+    expect(deriveClaimProvenance({})).toBe('unverified');
+    expect(deriveClaimProvenance(null)).toBe('unverified');
+    expect(deriveClaimProvenance({ category: 'ci_failure' })).toBe('unverified');
+  });
+});
+
+describe('QF-475 — the relayed lanes are the ones that caused harm', () => {
+  it.each([
+    'harness_backlog',        // 747 live rows — the auto-promoted worker-signal lane
+    'coordinator_review',     // witness #1 came through here
+    'coordinator_adam_review',
+    'fleet_retro',
+    'invariant_gauge_finding',
+    'adam_adherence_drift',
+  ])('classifies %s as relayed_unverified', (category) => {
+    expect(deriveClaimProvenance({ category })).toBe('relayed_unverified');
+  });
+
+  it('treats auto_capture as relayed even when the category is unknown', () => {
+    expect(deriveClaimProvenance({ source_type: 'auto_capture', category: 'something_new' }))
+      .toBe('relayed_unverified');
+  });
+
+  it('CONTROL — a direct human-authored lane is NOT marked relayed', () => {
+    // Without this, the classifier could mark literally everything relayed and still pass every
+    // assertion above, which would make the banner noise the reader learns to skip.
+    expect(deriveClaimProvenance({ category: 'ci_failure', source_type: 'manual_feedback' }))
+      .toBe('unverified');
+  });
+
+  it('is case-insensitive on category', () => {
+    expect(deriveClaimProvenance({ category: 'HARNESS_BACKLOG' })).toBe('relayed_unverified');
+  });
+});
+
+describe('QF-475 — the banner names what to re-derive', () => {
+  it('names all four claim types that actually caused harm', () => {
+    const banner = claimProvenanceBanner('relayed_unverified');
+    for (const claimType of ['mechanism', 'insertion point', 'root cause', 'proposed fix']) {
+      expect(banner.toLowerCase()).toContain(claimType);
+    }
+  });
+
+  it('says the text is a LEAD, not a specification', () => {
+    // The acceptance is that a worker knows which sentences to re-derive before acting.
+    expect(claimProvenanceBanner('relayed_unverified')).toMatch(/LEAD, not a specification/);
+  });
+
+  it('states the provenance verbatim so a reader can see which class applies', () => {
+    expect(claimProvenanceBanner('relayed_unverified')).toContain('RELAYED-UNVERIFIED');
+    expect(claimProvenanceBanner('unverified')).toContain('UNVERIFIED');
+  });
+
+  it('is admitted to NOT distinguish per-sentence, rather than implying it does', () => {
+    // Per-claim provenance cannot be derived automatically. Saying so is the honest contract;
+    // implying sentence-level marking would be the same overclaim the deriver refuses to make.
+    expect(claimProvenanceBanner('relayed_unverified')).toMatch(/NOT distinguished/);
+  });
+});


### PR DESCRIPTION
## Summary

**Two independent witnesses, eight hours apart.** An SD embedded three material claims that were **wrong** — a named insertion point that could not see the rows its own ACs staged, a security assertion false on win32 (this fleet *is* win32), and an in-flight rule contradicted by live measurement — each stated with the **same confidence as the verified parts**. The worker's words: *"I acted on all four because nothing in the artifact distinguished them from verified fact."*

Then a sub-agent INFO finding travelled sub-agent → worker → coordinator → worker → a **durable migration header** with no verification at any hop. It was false in all three parts against `pg_catalog` — the named object did not exist in the database at all.

## Where it's stamped, and why there

`sd-from-feedback.js`, whose own FR-5 comment identifies the exact hop: the feedback description *"becomes a new SD's description — read verbatim by a full-authority EXEC agent as its work instructions."* The file already classifies origin for **security** (`isUntrustedOrigin` / `sanitizeUserText`); this adds the same distinction for **epistemic** provenance, which was missing.

The banner goes on the **description**, not only in metadata — metadata alone would leave the consumer that actually acts on the text unmarked, which is the whole defect.

## Two deliberate refusals to overclaim

- `deriveClaimProvenance()` **never returns `measured`.** Nothing at this seam can prove first-hand measurement, and awarding it would recreate the defect one level up: the reader would trust a confident tag instead of the prose and be wrong the same way. The floor is `unverified` — absence of evidence is not evidence of verification.
- Per-**sentence** provenance cannot be derived automatically, so the banner marks the **row**, names the four claim types that have actually caused harm (mechanism, insertion point, root cause, proposed fix), and **says** it does not distinguish sentence-level rather than implying it does.

## One thing that would have silently broken it

`category` had to be **added to the select** at `:138`. It was not selected, so keying on it would have read `undefined` and classified every row identically — the exact defect I fixed this morning in QF-20260728-544 (filtered-but-unselected column).

## Test plan

- 15 tests, including a **CONTROL** proving a direct human lane is *not* marked relayed — without it, marking everything relayed would pass every other assertion and train readers to skip the banner.
- Mutation-proven: 15/15 fail with the production file reverted.
- 518 tests green across 47 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)