### PR TITLE
fix(SD-PAT-FIX-FIX-ABSENCE-SIGNAL-001): control-seed-test gate can now observe RED, not just infer it

### DIFF
--- a/.github/workflows/control-seed-test-lint.yml
+++ b/.github/workflows/control-seed-test-lint.yml
@@ -66,7 +66,17 @@ jobs:
       - name: Seed-test every new control in this diff
         run: |
           git fetch origin ${{ github.base_ref }} --depth=0 || true
-          node scripts/lint/control-seed-test-lint.mjs --diff | tee seed-output.txt
+          # FR-2: `2>&1` IS LOAD-BEARING, NOT TIDINESS. A bare pipe carries STDOUT ONLY, and
+          # every failure line in the lint is console.error while both success lines are
+          # console.log. Measured: running the real lint against a repo with one added
+          # control produced ZERO BYTES on stdout. So this summary was POPULATED ON PASS and
+          # BLANK ON FAIL — it rendered "A control that cannot catch its own seeded defect
+          # does not merge." above an empty code block exactly when the gate found something.
+          #
+          # FR-1/FR-5: `--diff` removed — it was never read (changedFiles() ignores argv), and
+          # enforcing is now the lint's DEFAULT, so no flag is needed to make this gate able
+          # to fail. Pass --advisory only to deliberately opt out.
+          node scripts/lint/control-seed-test-lint.mjs 2>&1 | tee seed-output.txt
           exit_code=${PIPESTATUS[0]}
           {
             echo "## Control Seed-Test Gate"

--- a/.github/workflows/control-seed-test-lint.yml
+++ b/.github/workflows/control-seed-test-lint.yml
@@ -60,6 +60,23 @@ jobs:
       # fixture trial, beyond the one already in KNOWN LIMITATIONS: it takes a dependency
       # on the test runner being installed, so it can fail for reasons that have nothing
       # to do with whether the control detects anything.
+      # ⚠️ TRIPWIRE — DO NOT ADD --ignore-scripts HERE WITHOUT READING THIS.
+      # SD-PAT-FIX-FIX-ABSENCE-SIGNAL-001, SECURITY row 72f19e83.
+      #
+      # scripts/audit/control-seed-specs.json is EDITABLE IN A PULL REQUEST, and it drives file
+      # writes and process spawns in this job. SECURITY found three ways to abuse that. They were
+      # accepted as DEFENSE-IN-DEPTH rather than CRITICAL on ONE MEASURED FACT: this job ALREADY
+      # executes PR-controlled code, because `npm ci` runs lifecycle scripts and package.json has
+      # an unconditional `postinstall`. So those bypasses grant an attacker nothing they could not
+      # get more simply. Verified directly — .npmrc carries no ignore-scripts.
+      #
+      # THAT IS SAFETY BY COINCIDENCE, AND THIS COMMENT EXISTS SO IT CANNOT LAPSE SILENTLY.
+      # Adding --ignore-scripts (a sensible hardening for entirely unrelated reasons) CLOSES the
+      # postinstall route and thereby RE-OPENS all three findings as genuinely exploitable, with
+      # nothing anywhere reporting that the trade changed. If you are adding that flag: good, but
+      # first fix the neuter trust model in scripts/audit/control-seed-test.mjs — an allowlist for
+      # spec.env, and stop treating attacker-controlled find/replace against public file content
+      # as safe because the values look reasonable.
       - name: Install dependencies
         run: npm ci --prefer-offline --no-audit
 

--- a/scripts/audit/control-seed-specs.json
+++ b/scripts/audit/control-seed-specs.json
@@ -167,12 +167,22 @@
     "name": "control-seed-test-lint",
     "script": "scripts/lint/control-seed-test-lint.mjs",
     "seedTest": "tests/unit/lint/control-seed-test-lint.test.js",
-    "note": "Seeded by the committed TS-5 test: plants a deliberately blind gauge and asserts the gate REFUSES it. Cannot use a fixture trial — this control's certified output is a VERDICT about other controls, not a code pattern in a file."
+    "note": "Seeded by the committed TS-5 test: plants a deliberately blind gauge and asserts the gate REFUSES it. Cannot use a fixture trial — this control's certified output is a VERDICT about other controls, not a code pattern in a file.",
+    "neuter": {
+      "find": "return { failures, trials, skipped, selected, specChanged };",
+      "replace": "return { failures: [], trials, skipped, selected, specChanged };",
+      "why": "evaluate() reports no failures at all — the blindest possible gate"
+    }
   },
   {
     "name": "control-seed-test",
     "script": "scripts/audit/control-seed-test.mjs",
     "seedTest": "tests/unit/lint/control-seed-test-lint.test.js",
-    "note": "Same TS-5 test exercises runTrial through evaluate — a blind gauge must come back SILENT. Its certified behaviour is a verdict, so there is no code pattern to seed into a fixture."
+    "note": "Same TS-5 test exercises runTrial through evaluate — a blind gauge must come back SILENT. Its certified behaviour is a verdict, so there is no code pattern to seed into a fixture.",
+    "neuter": {
+      "find": "const verdict = detected ? (code !== 0 ? VERDICT.BLOCKS : VERDICT.DETECTS) : VERDICT.SILENT;",
+      "replace": "const verdict = VERDICT.DETECTS;",
+      "why": "runTrial calls every control DETECTS, so a blind gauge never comes back SILENT"
+    }
   }
 ]

--- a/scripts/audit/control-seed-specs.json
+++ b/scripts/audit/control-seed-specs.json
@@ -169,9 +169,9 @@
     "seedTest": "tests/unit/lint/control-seed-test-lint.test.js",
     "note": "Seeded by the committed TS-5 test: plants a deliberately blind gauge and asserts the gate REFUSES it. Cannot use a fixture trial — this control's certified output is a VERDICT about other controls, not a code pattern in a file.",
     "neuter": {
-      "find": "return { failures, trials, skipped, selected, specChanged };",
-      "replace": "return { failures: [], trials, skipped, selected, specChanged };",
-      "why": "evaluate() reports no failures at all — the blindest possible gate"
+      "find": "reason: 'SEED_DID_NOT_FIRE'",
+      "replace": "reason: 'SEED_DID_NOT_FIRE_NEUTERED'",
+      "why": "the gate stops emitting the SEED_DID_NOT_FIRE reason its own seed-test asserts on"
     }
   },
   {
@@ -180,9 +180,9 @@
     "seedTest": "tests/unit/lint/control-seed-test-lint.test.js",
     "note": "Same TS-5 test exercises runTrial through evaluate — a blind gauge must come back SILENT. Its certified behaviour is a verdict, so there is no code pattern to seed into a fixture.",
     "neuter": {
-      "find": "const verdict = detected ? (code !== 0 ? VERDICT.BLOCKS : VERDICT.DETECTS) : VERDICT.SILENT;",
-      "replace": "const verdict = VERDICT.DETECTS;",
-      "why": "runTrial calls every control DETECTS, so a blind gauge never comes back SILENT"
+      "find": ": VERDICT.SILENT;",
+      "replace": ": VERDICT.DETECTS;",
+      "why": "runTrial can no longer return SILENT, so a blind gauge reads as detecting"
     }
   }
 ]

--- a/scripts/audit/control-seed-test.mjs
+++ b/scripts/audit/control-seed-test.mjs
@@ -50,7 +50,7 @@
 import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join, dirname } from 'node:path';
+import { join, dirname, resolve, sep } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { isMainModule } from '../../lib/utils/is-main-module.js';
 // FR-5 chokepoint (SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001). This module became a
@@ -140,7 +140,7 @@ export function runTrial(spec, repoRoot) {
     // exit 0 while doing so (advisory mode), so on exactly the interesting path the harness
     // read an empty string, saw no match, and scored a control SILENT that had in fact
     // reported the violation by name. spawnSync gives both streams on both paths.
-    const r = spawnSync('node', args, { cwd: runCwd, encoding: 'utf8', timeout: 120000, env: { ...process.env, ...(spec.env || {}) } });
+    const r = spawnSync('node', args, { cwd: runCwd, encoding: 'utf8', timeout: 120000, env: { ...process.env, ...safeSpecEnv(spec.env) } });
     code = typeof r.status === 'number' ? r.status : 1;
     out = `${r.stdout || ''}${r.stderr || ''}`;
     // FR-3: capture the STRUCTURAL failure. Note `r.status` is null on a timeout/ENOENT, which
@@ -305,9 +305,49 @@ export function classifySeedTrial({ cleanExit, mutationLanded, mutantExit, mutan
  * running it locally on a dirty tree measures the last commit. In CI — the venue where it
  * enforces — HEAD is the PR's merge commit, which is exactly the content under review.
  */
+// *** EVERY VALUE IN THE SPEC FILE IS ATTACKER-AUTHORED, BECAUSE THE SPEC FILE IS EDITABLE IN A
+// PULL REQUEST. *** SECURITY live-proved three reachable primitives here; the guards below close
+// them. The workflow uses `pull_request`, NOT `pull_request_target`, so a fork PR runs with a
+// read-only token and no secrets -- that BOUNDS the blast radius to an ephemeral job, it does not
+// remove it, and the bound is a property of the WORKFLOW TRIGGER rather than of this code. If the
+// trigger is ever changed, these guards are what stands between a spec edit and a writable token.
+
+// SEC-6, PRE-EXISTING (commit d89f4dfea3c0, predates this SD): `spec.env` was spread into the
+// child unfiltered, so `NODE_OPTIONS: "--require <file>"` preloads arbitrary code on any control
+// trial -- proved live, platform-independent. Nothing in-repo uses spec.env today, but an unused
+// hole is still a hole, and it sits a few lines from code this SD rewrote.
+const UNSAFE_ENV_RE = /^(NODE_OPTIONS|NODE_V8_COVERAGE|NODE_REPL_EXTERNAL_MODULE|LD_PRELOAD|LD_AUDIT|DYLD_)/i;
+function safeSpecEnv(env) {
+  return Object.fromEntries(Object.entries(env || {}).filter(([k]) => !UNSAFE_ENV_RE.test(k)));
+}
+
+// A refusal, never a verdict: these are harness/config faults, and scoring them as findings about
+// the control would be an accusation the evidence does not support.
+function harnessError(spec, code, reason) {
+  return { name: spec.name, verdict: SEED_TRIAL.HARNESS_ERROR, code, reason, evidence: [] };
+}
+
 export function runSeedTestTrial(spec, repoRoot, deps = {}) {
   const { spawn = spawnSync, exec = execFileSync } = deps;
-  const target = (spec.neuter?.file || spec.script).replace(/\\/g, '/');
+  // SEC-2: an EMPTY `find` is the sharpest edge here and it does not look like one. String
+  // .replace('') matches at index 0 ALWAYS, so `replace` is prepended unconditionally whatever
+  // the file contains -- and the mutation-landed check then confirms the file changed. Since the
+  // harness's very next step re-runs vitest inside that same worktree, prepended text is
+  // EXECUTED. Refuse it: a neuter must name real text it expects to find.
+  if (typeof spec.neuter?.find !== 'string' || spec.neuter.find.length === 0) {
+    return harnessError(spec, 'NEUTER_FIND_EMPTY', 'the neuter declares no non-empty `find` string; an empty find matches at position 0 unconditionally, which prepends arbitrary content rather than replacing anything');
+  }
+
+  // SEC-1: `neuter.file` was joined to the worktree root with NO containment, so `../../..`
+  // escaped into the real repo -- and, with the above, wrote code the follow-up vitest run would
+  // then import. Constraining it to the control's OWN script closes the traversal and the
+  // write-then-execute gadget together, and costs nothing: a neuter that edits some other file
+  // is not neutering the control under test anyway.
+  const declared = (spec.neuter?.file || spec.script).replace(/\\/g, '/');
+  const target = spec.script.replace(/\\/g, '/');
+  if (declared !== target) {
+    return harnessError(spec, 'NEUTER_FILE_NOT_SCRIPT', `the neuter targets ${declared}, which is not the control under test (${target}). A neuter may only edit the control it certifies.`);
+  }
   const wtParent = join(repoRoot, '.worktrees');
   const wt = join(wtParent, `.seedtrial-${spec.name.replace(/[^a-z0-9-]/gi, '_')}-${process.pid}`);
   const runVitest = (cwd) => {
@@ -328,6 +368,12 @@ export function runSeedTestTrial(spec, repoRoot, deps = {}) {
     }
 
     const p = join(wt, target);
+    // Second, INDEPENDENT containment check. The equality test above already bounds `target`,
+    // so reaching this means `spec.script` itself carried traversal -- a different door to the
+    // same room. A guard resting on another guard's correctness is one refactor from useless.
+    if (!resolve(p).startsWith(resolve(wt) + sep)) {
+      return harnessError(spec, 'NEUTER_PATH_ESCAPE', `the resolved neuter target escapes the trial worktree: ${resolve(p)}`);
+    }
     const before = readFileSync(p, 'utf8');
     const after = before.replace(spec.neuter.find, spec.neuter.replace);
     writeFileSync(p, after, 'utf8');

--- a/scripts/audit/control-seed-test.mjs
+++ b/scripts/audit/control-seed-test.mjs
@@ -196,6 +196,141 @@ export function runTrial(spec, repoRoot) {
   return { name: spec.name, verdict, exitCode: code, detected, treeClean, scannedZero, evidence: out.trim().split('\n').filter(Boolean).slice(-3) };
 }
 
+// ===========================================================================================
+// SD-PAT-FIX-FIX-ABSENCE-SIGNAL-001 — FR-7. THE seedTest FORM MUST REQUIRE AN OBSERVED RED.
+//
+// Until now `seedTest` ran the committed test and required it to PASS. A passing test proves
+// only that it passes; it cannot distinguish a test that CHECKS something from one that
+// checks nothing. Both seedTest specs are this gate's OWN machinery, so the control that
+// certifies every other control was itself certified by the form it declares insufficient.
+//
+// The fix: neuter the control and require the test to go RED. Which means the harness now
+// performs deliberate breakage on the control's own source — and the three ways that goes
+// wrong are all silent, so each gets a structural defence rather than a promise.
+// ===========================================================================================
+
+export const SEED_TRIAL = Object.freeze({
+  PROVEN_RED: 'PROVEN_RED',       // green when whole, red when neutered — the test genuinely fires
+  CANNOT_FAIL: 'CANNOT_FAIL',     // neutered and STILL green — the test asserts nothing
+  HARNESS_ERROR: 'HARNESS_ERROR', // the harness failed. NEVER a verdict about the control.
+});
+
+// A vitest run can go red for reasons that prove nothing about the control. Telling those
+// apart requires reading WHY it was red, not merely THAT it was red.
+const ASSERTION_RE = /AssertionError|expected .+ to |Tests\s+\d+ failed/i;
+const LOAD_CRASH_RE = /ERR_MODULE_NOT_FOUND|Failed to load url|Cannot find (module|package)|SyntaxError|ReferenceError/i;
+
+/**
+ * The whole decision, as a pure function — no spawning, no filesystem.
+ *
+ * It lives apart from the I/O deliberately: every rule below is a way this check could
+ * silently degrade into a rubber stamp, and rules that can only be exercised by building a
+ * git worktree are rules nothing will ever test. A unit test drives this directly.
+ */
+export function classifySeedTrial({ cleanExit, mutationLanded, mutantExit, mutantOut = '', neuterWhy }) {
+  // (1) POSITIVE CONTROL, AND IT MUST COME FIRST. If the test is already red before we touch
+  // anything, the scratch tree is broken (or the test does not pass at HEAD) and EVERY later
+  // observation is uninterpretable — a red mutant would then "prove" firing when the truth is
+  // the harness never worked. This is the same trap as reading a crash as a verdict, one level
+  // up: without it the harness is most confident exactly when it is most broken.
+  if (cleanExit !== 0) {
+    return { verdict: SEED_TRIAL.HARNESS_ERROR, code: 'RED_BEFORE_NEUTER', reason: 'the seed-test is RED before any neutering, so nothing measured after this point means anything (scratch tree mis-wired, or the test does not pass at HEAD)' };
+  }
+
+  // (2) PROVE THE MUTATION LANDED. A no-op edit leaves the test green, which is
+  // INDISTINGUISHABLE from a test that cannot fail — this SD's own defect class, inside its
+  // own remedy. It fired for real during PLAN: a mutation attempt was a silent no-op sed and
+  // would have been published as a surviving mutant. So this is an ERROR, never a verdict:
+  // a verdict absorbs the failure, an error cannot be mistaken for a measurement.
+  if (!mutationLanded) {
+    return { verdict: SEED_TRIAL.HARNESS_ERROR, code: 'MUTATION_NO_OP', reason: 'the neutering edit did not change the file — its `find` string no longer matches the control (a no-op mutation is indistinguishable from a test that cannot fail, so it is refused rather than scored)' };
+  }
+
+  // (3) A NEUTERED CONTROL THAT LEAVES THE TEST GREEN IS THE FINDING.
+  if (mutantExit === 0) {
+    return {
+      verdict: SEED_TRIAL.CANNOT_FAIL,
+      code: 'SURVIVED',
+      reason: `the control was neutered (${neuterWhy || 'see spec.neuter'}) and its seed-test still passed — the test does not detect the thing it certifies`,
+    };
+  }
+
+  // (4) RED IS NOT ENOUGH: IT MUST BE RED FOR THE RIGHT REASON. Breaking a module's syntax
+  // also turns a test red, while proving only that an unparseable file cannot be imported.
+  // Accepting any non-zero exit would let the weakest possible neutering pass as proof.
+  if (LOAD_CRASH_RE.test(mutantOut) && !ASSERTION_RE.test(mutantOut)) {
+    return { verdict: SEED_TRIAL.HARNESS_ERROR, code: 'LOAD_CRASH', reason: 'the neutered control failed to LOAD rather than failing an assertion — that proves the file was broken, not that the test detects behaviour. Use a neutering that keeps the module valid.' };
+  }
+  if (!ASSERTION_RE.test(mutantOut)) {
+    return { verdict: SEED_TRIAL.HARNESS_ERROR, code: 'UNEXPLAINED_RED', reason: 'the seed-test exited non-zero but produced no recognisable assertion failure, so WHY it went red is unknown — refusing to score an unexplained red as proof' };
+  }
+
+  return { verdict: SEED_TRIAL.PROVEN_RED, code: 'PROVEN', reason: `neutering the control (${neuterWhy || 'see spec.neuter'}) turned its seed-test RED on an assertion` };
+}
+
+/**
+ * Run the observed-RED trial for one `seedTest` spec. Never touches the working tree.
+ *
+ * *** WHY A NESTED WORKTREE UNDER .worktrees/ AND NO node_modules LINK ***
+ * Requiring an observed RED means editing the control's source and re-running vitest, and
+ * doing that in place would violate the invariant at the top of this file. So the trial runs
+ * in a throwaway `git worktree` at HEAD, which git creates without touching the real tree.
+ *
+ * It goes under `.worktrees/` — already in .gitignore — for two independent reasons, and the
+ * second was learned the hard way. First, an ignored path keeps `git status --porcelain`
+ * byte-identical, so the trial cannot trip the lint's own HARNESS_DIRTIED_TREE check. Second,
+ * node resolves `node_modules` by walking UP, so a worktree nested inside the repo finds the
+ * real one with NO symlink. The first draft put the worktree in os.tmpdir() and junctioned
+ * node_modules into it — and `git worktree remove --force` DELETED THE 557-PACKAGE
+ * node_modules THROUGH THE JUNCTION. Nesting removes the need for the link, which removes the
+ * hazard entirely: there is no longer a destructive cleanup to get right.
+ *
+ * KNOWN LIMITATION (FR-4): the trial evaluates HEAD, not uncommitted working-tree edits, so
+ * running it locally on a dirty tree measures the last commit. In CI — the venue where it
+ * enforces — HEAD is the PR's merge commit, which is exactly the content under review.
+ */
+export function runSeedTestTrial(spec, repoRoot, deps = {}) {
+  const { spawn = spawnSync, exec = execFileSync } = deps;
+  const target = (spec.neuter?.file || spec.script).replace(/\\/g, '/');
+  const wtParent = join(repoRoot, '.worktrees');
+  const wt = join(wtParent, `.seedtrial-${spec.name.replace(/[^a-z0-9-]/gi, '_')}-${process.pid}`);
+  const runVitest = (cwd) => {
+    const r = spawn('npx', ['vitest', 'run', '--project', 'unit', spec.seedTest], { cwd, encoding: 'utf8', timeout: 600000, shell: process.platform === 'win32' });
+    return { code: typeof r.status === 'number' ? r.status : 1, out: `${r.stdout || ''}${r.stderr || ''}` };
+  };
+
+  try {
+    mkdirSync(wtParent, { recursive: true });
+    exec('git', ['worktree', 'add', '--detach', '-q', wt, 'HEAD'], { cwd: repoRoot, stdio: 'pipe' });
+
+    const clean = runVitest(wt);
+    // Short-circuit: with the positive control already failing there is nothing to learn from
+    // mutating, and running anyway would only produce a red we could not interpret.
+    if (clean.code !== 0) {
+      const c = classifySeedTrial({ cleanExit: clean.code, mutationLanded: false, mutantExit: 1 });
+      return { ...c, name: spec.name, evidence: clean.out.trim().split('\n').filter(Boolean).slice(-3) };
+    }
+
+    const p = join(wt, target);
+    const before = readFileSync(p, 'utf8');
+    const after = before.replace(spec.neuter.find, spec.neuter.replace);
+    writeFileSync(p, after, 'utf8');
+    // Read BACK from disk rather than comparing the strings we just built: this must prove the
+    // FILE changed, not that our replace() returned something different.
+    const mutationLanded = readFileSync(p, 'utf8') !== before;
+
+    const mutant = mutationLanded ? runVitest(wt) : { code: 1, out: '' };
+    const c = classifySeedTrial({ cleanExit: clean.code, mutationLanded, mutantExit: mutant.code, mutantOut: mutant.out, neuterWhy: spec.neuter.why });
+    return { ...c, name: spec.name, evidence: mutant.out.trim().split('\n').filter((l) => /FAIL|AssertionError|expected|Tests\s/.test(l)).slice(-3) };
+  } catch (e) {
+    return { name: spec.name, verdict: SEED_TRIAL.HARNESS_ERROR, code: 'HARNESS_THREW', reason: `the observed-RED harness itself failed: ${e.message}`, evidence: [] };
+  } finally {
+    try { exec('git', ['worktree', 'remove', '--force', wt], { cwd: repoRoot, stdio: 'ignore' }); } catch {}
+    try { rmSync(wt, { recursive: true, force: true }); } catch {}
+    try { exec('git', ['worktree', 'prune'], { cwd: repoRoot, stdio: 'ignore' }); } catch {}
+  }
+}
+
 function main() {
   const argv = process.argv.slice(2);
   const specIdx = argv.indexOf('--spec');

--- a/scripts/audit/control-seed-test.mjs
+++ b/scripts/audit/control-seed-test.mjs
@@ -51,7 +51,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname, resolve, sep } from 'node:path';
-import { readFileSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
 import { isMainModule } from '../../lib/utils/is-main-module.js';
 // FR-5 chokepoint (SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001). This module became a
 // worktree-handling file the moment runSeedTestTrial started creating one, and the static guard
@@ -371,8 +371,21 @@ export function runSeedTestTrial(spec, repoRoot, deps = {}) {
     // Second, INDEPENDENT containment check. The equality test above already bounds `target`,
     // so reaching this means `spec.script` itself carried traversal -- a different door to the
     // same room. A guard resting on another guard's correctness is one refactor from useless.
-    if (!resolve(p).startsWith(resolve(wt) + sep)) {
-      return harnessError(spec, 'NEUTER_PATH_ESCAPE', `the resolved neuter target escapes the trial worktree: ${resolve(p)}`);
+    //
+    // realpathSync, NOT resolve(). The first version compared LEXICAL paths, which never touch
+    // the filesystem, so a symlink/junction committed by the same PR at an entirely ordinary
+    // looking path escaped it with no `..` anywhere in the diff -- SECURITY defeated it with a
+    // real Windows junction and the write landed outside the worktree. realpath dereferences,
+    // so the check now measures where the write ACTUALLY goes rather than what the string says.
+    let realP, realWt;
+    try {
+      realP = realpathSync(p);
+      realWt = realpathSync(wt);
+    } catch (e) {
+      return harnessError(spec, 'NEUTER_PATH_UNRESOLVABLE', `could not resolve the neuter target on disk: ${e.message}`);
+    }
+    if (!realP.startsWith(realWt + sep)) {
+      return harnessError(spec, 'NEUTER_PATH_ESCAPE', `the neuter target resolves OUTSIDE the trial worktree: ${realP} is not under ${realWt}`);
     }
     const before = readFileSync(p, 'utf8');
     const after = before.replace(spec.neuter.find, spec.neuter.replace);

--- a/scripts/audit/control-seed-test.mjs
+++ b/scripts/audit/control-seed-test.mjs
@@ -88,6 +88,10 @@ export function runTrial(spec, repoRoot) {
   const before = gitStatus(repoRoot);
   const dir = mkdtempSync(join(tmpdir(), 'seedtest-'));
   let out = '', code = 0;
+  // FR-3 (SD-PAT-FIX-FIX-ABSENCE-SIGNAL-001): spawnSync's STRUCTURAL failure channel, hoisted
+  // so the verdict logic below can consult it. Previously r.error was never read anywhere in
+  // this file, so a control that could not be launched at all was scored by its OUTPUT.
+  let spawnError = null;
 
   try {
     for (const f of spec.fixtures) {
@@ -123,6 +127,10 @@ export function runTrial(spec, repoRoot) {
     const r = spawnSync('node', args, { cwd: runCwd, encoding: 'utf8', timeout: 120000, env: { ...process.env, ...(spec.env || {}) } });
     code = typeof r.status === 'number' ? r.status : 1;
     out = `${r.stdout || ''}${r.stderr || ''}`;
+    // FR-3: capture the STRUCTURAL failure. Note `r.status` is null on a timeout/ENOENT, which
+    // the line above silently coerces to 1 — indistinguishable from a control that ran and
+    // exited 1. r.error is the only field that says WHY.
+    spawnError = r.error || null;
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -137,6 +145,34 @@ export function runTrial(spec, repoRoot) {
   // exited 1. Reading that as "ran and found nothing" would have recorded a control as SILENT
   // that never executed at all. A control that could not run is ERROR: not a pass, not a
   // failure, and never counted in the rate.
+  // *** STRUCTURE BEFORE TEXT — FR-3, SD-PAT-FIX-FIX-ABSENCE-SIGNAL-001 ***
+  // CRASH_RE below decides ERROR by MATCHING THE OUTPUT, which cannot see a control that
+  // produced no output because it never started. spawnSync reports that in `r.error`, and
+  // this file never read it: a 120s TIMEOUT or an ENOENT yields status:null -> code 1 -> no
+  // crash text -> the control fell through and was published as SILENT, i.e. AS ONE THAT RAN
+  // CLEAN AGAINST A REAL SEEDED DEFECT. Probed during PLAN: a control that DIED (exit 1,
+  // "could not connect to database") and one that genuinely RAN BLIND (exit 0, "scan
+  // complete") produced the SAME row.
+  //
+  // The tempting fix was to add timeout/ENOENT alternatives to CRASH_RE. That is the INSTANCE
+  // fix — it would need extending for every future failure shape, and each omission is silent.
+  // Reading the structural channel is the CLASS fix: it is true for every way a spawn can fail,
+  // including ones not yet invented.
+  if (spawnError) {
+    return {
+      name: spec.name,
+      verdict: VERDICT.ERROR,
+      exitCode: code,
+      treeClean,
+      reason: `control could not be executed (${spawnError.code || spawnError.name || 'spawn failure'}): ${spawnError.message}`,
+      evidence: [
+        `spawnSync error: ${spawnError.code || spawnError.name || 'unknown'} — ${spawnError.message}`,
+        `exit code ${code} here is COERCED, not reported: r.status was null because the process never returned one`,
+        out.trim() ? `output captured before failure: ${out.trim().split('\n').slice(-1)[0]}` : 'no output at all — the control produced nothing to match against',
+      ].filter(Boolean),
+    };
+  }
+
   if (CRASH_RE.test(out)) {
     return { name: spec.name, verdict: VERDICT.ERROR, exitCode: code, treeClean, reason: 'control did not run to completion (crash/unhandled error)', evidence: out.trim().split('\n').filter(Boolean).slice(-2) };
   }

--- a/scripts/audit/control-seed-test.mjs
+++ b/scripts/audit/control-seed-test.mjs
@@ -48,11 +48,27 @@
  */
 
 import { execFileSync, spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
+import { mkdtempSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { readFileSync } from 'node:fs';
 import { isMainModule } from '../../lib/utils/is-main-module.js';
+// FR-5 chokepoint (SD-LEO-INFRA-WORKTREE-REAPER-RESIDENT-001). This module became a
+// worktree-handling file the moment runSeedTestTrial started creating one, and the static guard
+// in tests/unit/worktree-delete-primitive-static-guard.test.js flagged both raw deletes here
+// immediately -- correctly.
+//
+// THE REASON IS REUSE, NOT A WIPE THREAT FROM node's rmSync, and that distinction is load-bearing
+// enough that the guard's own rationale carries a SECURITY correction saying so: a raw recursive
+// delete was NOT reproducible as following a nested junction on Node v24. What it IS, is a second
+// unreviewed implementation of a delete policy that is maintained in exactly one place here.
+//
+// Worth recording because this SD nearly learned it the expensive way: the first US-007 draft
+// junctioned node_modules into a scratch worktree, and `git worktree remove --force` -- git's own
+// removal, not node's -- deleted 557 packages through that junction. The shipped design needs no
+// link at all, so that hazard is gone; routing through safeRecursiveRm is about not maintaining a
+// private copy of the policy.
+import { safeRecursiveRm } from '../../lib/worktree-manager.js';
 
 const VERDICT = Object.freeze({
   BLOCKS: 'BLOCKS',        // detected AND non-zero exit — actually stops a merge
@@ -132,7 +148,7 @@ export function runTrial(spec, repoRoot) {
     // exited 1. r.error is the only field that says WHY.
     spawnError = r.error || null;
   } finally {
-    rmSync(dir, { recursive: true, force: true });
+    safeRecursiveRm(dir);
   }
 
   const after = gitStatus(repoRoot);
@@ -326,7 +342,7 @@ export function runSeedTestTrial(spec, repoRoot, deps = {}) {
     return { name: spec.name, verdict: SEED_TRIAL.HARNESS_ERROR, code: 'HARNESS_THREW', reason: `the observed-RED harness itself failed: ${e.message}`, evidence: [] };
   } finally {
     try { exec('git', ['worktree', 'remove', '--force', wt], { cwd: repoRoot, stdio: 'ignore' }); } catch {}
-    try { rmSync(wt, { recursive: true, force: true }); } catch {}
+    try { safeRecursiveRm(wt); } catch {}
     try { exec('git', ['worktree', 'prune'], { cwd: repoRoot, stdio: 'ignore' }); } catch {}
   }
 }

--- a/scripts/lint/control-seed-test-lint.mjs
+++ b/scripts/lint/control-seed-test-lint.mjs
@@ -114,6 +114,14 @@ function isControl(p) {
 // seed-tested — exactly the UNENFORCEABLE verdict it hands out to others.
 export function evaluate(repoRoot, files, specs, isControlFn = isControl) {
   const failures = [];
+  // FR-8 (SD-PAT-FIX-FIX-ABSENCE-SIGNAL-001): THE ACCEPTANCE METRIC.
+  // `trials` records controls a seeded-defect trial ACTUALLY RAN on; `skipped` records
+  // controls that were MATCHED but never trialled. Keeping both is what makes
+  // matched != trialsRun expressible — with only a match count, "how many controls were
+  // actually exercised" is unanswerable, and any trial count would be satisfiable as an
+  // alias of `matched` while measuring nothing.
+  const trials = [];
+  const skipped = [];
   const byName = new Map(specs.map((s) => [s.script?.replace(/\\/g, '/'), s]));
 
   for (const f of files.filter(isControlFn)) {
@@ -149,11 +157,20 @@ export function evaluate(repoRoot, files, specs, isControlFn = isControl) {
       if (r.status !== 0) {
         failures.push({ file: rel, reason: 'SEED_TEST_FAILED', detail: `its committed seed-test ${spec.seedTest} does not pass.`, evidence: `${r.stdout || ''}${r.stderr || ''}`.trim().split('\n').filter(Boolean).slice(-3) });
       }
+      // FR-8: this control was MATCHED but NO TRIAL WAS RUN — `continue` skips runTrial
+      // entirely. Recording it is what makes matched != trialsRun observable; without it the
+      // two numbers are always equal and the trial count is satisfiable as an alias of the
+      // match count, measuring nothing.
+      skipped.push({ file: rel, why: 'seedTest form — the committed test was run, but no seeded-defect TRIAL was performed' });
       continue;
     }
 
     // FR-3: the seed-test must be OBSERVED FIRING. This is the whole gate.
     const trial = runTrial(spec, repoRoot);
+    // FR-8: a TRIAL ACTUALLY RAN. This is the acceptance metric of
+    // SD-PAT-FIX-FIX-ABSENCE-SIGNAL-001 — recorded here, at the only place a trial happens,
+    // so the count cannot drift from the thing it counts.
+    trials.push({ file: rel, verdict: trial.verdict, exitCode: trial.exitCode, treeClean: trial.treeClean });
     if (trial.verdict === VERDICT.SILENT) {
       // An accusation ships with the evidence to refute it (FR-1 finding: four false
       // negatives, all accusing working controls of blindness).
@@ -168,7 +185,14 @@ export function evaluate(repoRoot, files, specs, isControlFn = isControl) {
       failures.push({ file: rel, reason: 'HARNESS_DIRTIED_TREE', detail: 'the working tree changed during the seed trial (TR-3 violation).' });
     }
   }
-  return failures;
+  // FR-8: BREAKING CHANGE, made deliberately rather than smuggled in. This returned a bare
+  // array; it now returns {failures, trials, skipped}. Returning an array with the counts
+  // bolted on as properties would have kept every existing caller working — and that is
+  // precisely the identity-preserving shape this SD exists to refuse, because nothing would
+  // ever have had to acknowledge the new information. The 4 tests this breaks are updated in
+  // the same commit; both seedTest specs point at that test file, so leaving it broken would
+  // make the gate fail itself.
+  return { failures, trials, skipped };
 }
 
 function main() {
@@ -189,14 +213,31 @@ function main() {
   }
 
   const specs = existsSync(join(repoRoot, SPEC_PATH)) ? JSON.parse(readFileSync(join(repoRoot, SPEC_PATH), 'utf8')) : [];
-  const failures = evaluate(repoRoot, files, specs);
-
-  if (argv.includes('--json')) { console.log(JSON.stringify({ failures }, null, 2)); return; }
+  const { failures, trials, skipped } = evaluate(repoRoot, files, specs);
 
   const controls = files.filter(isControl);
+  // FR-8: THE ACCEPTANCE METRIC, ON EVERY PATH. `matched` counts controls the diff selected;
+  // `trialsRun` counts controls a seeded-defect trial ACTUALLY RAN on. They are DIFFERENT
+  // numbers — a seedTest spec is matched and never trialled — and printing only `matched`
+  // is what let this gate report "each proved it FIRES" about controls it never exercised.
+  // This line prints on EVERY return path INCLUDING the no-controls path, so a run where
+  // trialsRun is 0 says so out loud instead of being inferred from silence.
+  const byVerdict = trials.reduce((acc, t) => ({ ...acc, [t.verdict]: (acc[t.verdict] || 0) + 1 }), {});
+  const summary = { matched: controls.length, trialsRun: trials.length, skipped: skipped.length, byVerdict };
+  const summaryLine = `control-seed-test-lint: matched ${summary.matched}, TRIALS RUN ${summary.trialsRun}`
+    + (summary.skipped ? `, skipped ${summary.skipped} (matched but never trialled)` : '')
+    + (trials.length ? ` — ${Object.entries(byVerdict).map(([k, v]) => `${k}:${v}`).join(' ')}` : '');
+
+  if (argv.includes('--json')) { console.log(JSON.stringify({ failures, trials, skipped, summary }, null, 2)); return; }
+
+  console.log(summaryLine);
+  for (const s of skipped) console.log(`   ⚠️  NO TRIAL: ${s.file} — ${s.why}`);
+
   if (!controls.length) { console.log('✅ control-seed-test-lint: no new controls in this diff.'); return; }
   if (!failures.length) {
-    console.log(`✅ control-seed-test-lint: ${controls.length} new control(s), each proved it FIRES on its own seeded defect.`);
+    // The old wording claimed every matched control "proved it FIRES", which was untrue for
+    // any seedTest spec — those are matched, skipped, and were counted as proven anyway.
+    console.log(`✅ control-seed-test-lint: ${summary.trialsRun} of ${summary.matched} new control(s) proved they FIRE on their own seeded defect.`);
     return;
   }
   console.error(`\n❌ control-seed-test-lint: ${failures.length} issue(s) across ${controls.length} new control(s)\n`);

--- a/scripts/lint/control-seed-test-lint.mjs
+++ b/scripts/lint/control-seed-test-lint.mjs
@@ -267,7 +267,7 @@ export function evaluate(repoRoot, files, specs, isControlFn = isControl, prevSp
   // ever have had to acknowledge the new information. The 4 tests this breaks are updated in
   // the same commit; both seedTest specs point at that test file, so leaving it broken would
   // make the gate fail itself.
-  return { failures, trials, skipped, selected, specChanged, specBaseUnavailable };
+  return { failures, trials, skipped, selected, specChanged, specBaseUnavailable, fromSpec };
 }
 
 function main() {
@@ -289,13 +289,13 @@ function main() {
 
   const specs = existsSync(join(repoRoot, SPEC_PATH)) ? JSON.parse(readFileSync(join(repoRoot, SPEC_PATH), 'utf8')) : [];
 
-  const { failures, trials, skipped, selected, specChanged, specBaseUnavailable } = evaluate(repoRoot, files, specs, isControl, previousSpecs(repoRoot));
+  const { failures, trials, skipped, selected, specChanged, specBaseUnavailable, fromSpec } = evaluate(repoRoot, files, specs, isControl, previousSpecs(repoRoot));
 
   const controls = selected.filter(isControl);
   if (specChanged) {
     console.log(specBaseUnavailable
-      ? `⚠️  ${SPEC_PATH} changed but its previous version could not be read, so this run re-trials ALL ${controls.length} control(s) it names rather than only the changed entries. Conservative on purpose: selecting none on an unreadable base would be an empty evaluation reported as a pass.`
-      : `ℹ️  ${SPEC_PATH} changed — re-trialling the ${controls.length} control(s) whose spec entry actually moved, because a weakened fixture is as dangerous as a neutered control.`);
+      ? `⚠️  ${SPEC_PATH} changed but its previous version could not be read, so this run re-trials ALL ${fromSpec.length} control(s) it names rather than only the changed entries. Conservative on purpose: selecting none on an unreadable base would be an empty evaluation reported as a pass.`
+      : `ℹ️  ${SPEC_PATH} changed — ${fromSpec.length} of its entr${fromSpec.length === 1 ? 'y' : 'ies'} moved and are re-trialled, because a weakened fixture is as dangerous as a neutered control. ${controls.length} control(s) selected in total for this run.`);
   }
   // FR-8: THE ACCEPTANCE METRIC, ON EVERY PATH. `matched` counts controls the diff selected;
   // `trialsRun` counts controls a seeded-defect trial ACTUALLY RAN on. They are DIFFERENT

--- a/scripts/lint/control-seed-test-lint.mjs
+++ b/scripts/lint/control-seed-test-lint.mjs
@@ -124,7 +124,30 @@ export function evaluate(repoRoot, files, specs, isControlFn = isControl) {
   const skipped = [];
   const byName = new Map(specs.map((s) => [s.script?.replace(/\\/g, '/'), s]));
 
-  for (const f of files.filter(isControlFn)) {
+  // FR-6: A CHANGED SEED SPEC MUST RE-TRIAL ITS CONTROL.
+  // The spec file is where the seeded defect ITSELF lives, so weakening a fixture is exactly as
+  // dangerous as neutering the control — and it was completely invisible. SPEC_PATH is a .json
+  // while CONTROL_GLOBS match /\.(mjs|js|cjs)$/, so it can NEVER be selected by widening a glob;
+  // it needs this explicit branch. The workflow's `paths:` filter already lists scripts/audit/**
+  // AND the spec file by name (verified), so such a PR always TRIGGERED the job — it then
+  // reported "no new controls in this diff" and exited green. The trigger fired and the
+  // evaluation was empty: this SD's own absence-as-pass shape, inside the gate built to stop it.
+  //
+  // Done HERE rather than in main() so it has a test seam. Putting selection logic in main()
+  // would make it unreachable from a unit test — which is how a rule ends up asserted only by
+  // the comment above it.
+  //
+  // KNOWN LIMITATION (FR-4 binds this gate too): this re-trials EVERY control the spec file
+  // names, not only the entries whose text changed. Diffing the JSON to find which entry moved
+  // would be more precise and is deliberately not done — a conservative over-trial costs CI
+  // time, a missed entry costs a silently weakened fixture, and those are not symmetric.
+  const specChanged = files.some((f) => f.replace(/\\/g, '/') === SPEC_PATH);
+  const fromSpec = specChanged
+    ? specs.map((s) => s.script?.replace(/\\/g, '/')).filter((s) => s && isControlFn(s))
+    : [];
+  const selected = [...new Set([...files, ...fromSpec])];
+
+  for (const f of selected.filter(isControlFn)) {
     const rel = f.replace(/\\/g, '/');
     const spec = byName.get(rel);
 
@@ -192,7 +215,7 @@ export function evaluate(repoRoot, files, specs, isControlFn = isControl) {
   // ever have had to acknowledge the new information. The 4 tests this breaks are updated in
   // the same commit; both seedTest specs point at that test file, so leaving it broken would
   // make the gate fail itself.
-  return { failures, trials, skipped };
+  return { failures, trials, skipped, selected, specChanged };
 }
 
 function main() {
@@ -213,9 +236,13 @@ function main() {
   }
 
   const specs = existsSync(join(repoRoot, SPEC_PATH)) ? JSON.parse(readFileSync(join(repoRoot, SPEC_PATH), 'utf8')) : [];
-  const { failures, trials, skipped } = evaluate(repoRoot, files, specs);
 
-  const controls = files.filter(isControl);
+  const { failures, trials, skipped, selected, specChanged } = evaluate(repoRoot, files, specs);
+
+  const controls = selected.filter(isControl);
+  if (specChanged) {
+    console.log(`ℹ️  ${SPEC_PATH} changed — re-trialling ${controls.length} control(s) it names, because a weakened fixture is as dangerous as a neutered control.`);
+  }
   // FR-8: THE ACCEPTANCE METRIC, ON EVERY PATH. `matched` counts controls the diff selected;
   // `trialsRun` counts controls a seeded-defect trial ACTUALLY RAN on. They are DIFFERENT
   // numbers — a seedTest spec is matched and never trialled — and printing only `matched`

--- a/scripts/lint/control-seed-test-lint.mjs
+++ b/scripts/lint/control-seed-test-lint.mjs
@@ -85,7 +85,14 @@ const KNOWN_LIMITATION_RE = /KNOWN LIMITATION/i;
 function changedFiles(repoRoot) {
   for (const base of ['origin/main...HEAD', 'HEAD~1']) {
     try {
-      const out = execFileSync('git', ['diff', '--name-only', '--diff-filter=A', base], { cwd: repoRoot, encoding: 'utf8' });
+      // FR-4: AMR, not A. `--diff-filter=A` sees ADDED files only, so it evaluates the FIRST
+      // EVENT IN A CONTROL'S LIFE AND NO LATER EDIT — a control MODIFIED into blindness, or
+      // RENAMED, was invisible to this gate. Measured over 30 days on scripts/lint +
+      // scripts/audit: 15 files added vs 15 modified, so roughly half the population was
+      // unreachable. Not novel: five in-repo lints already use ACMR
+      // (diagnostic-gauge-citation, session-coordination-insert-classguard,
+      // rls-anon-tenant-predicate, schema-reference, stage-advancement-chokepoint).
+      const out = execFileSync('git', ['diff', '--name-only', '--diff-filter=AMR', base], { cwd: repoRoot, encoding: 'utf8' });
       return out.split('\n').map((s) => s.trim()).filter(Boolean);
     } catch { /* try next base */ }
   }
@@ -194,7 +201,11 @@ function main() {
   }
   console.error(`\n❌ control-seed-test-lint: ${failures.length} issue(s) across ${controls.length} new control(s)\n`);
   for (const f of failures) {
-    console.error(`  ${f.reason.padEnd(20)} ${f.file}`);
+    // FR-3: SURFACE THE EXIT CODE. The harness records it and prints it in its own report, but
+    // this lint dropped it — so in the output a developer actually reads, the one field that
+    // separates a control that DIED from one that ran and saw nothing was absent.
+    const exit = typeof f.exitCode === 'number' ? ` (exit ${f.exitCode})` : '';
+    console.error(`  ${f.reason.padEnd(20)} ${f.file}${exit}`);
     console.error(`    ${f.detail}`);
     if (f.evidence?.length) f.evidence.forEach((e) => console.error(`      | ${e}`));
   }

--- a/scripts/lint/control-seed-test-lint.mjs
+++ b/scripts/lint/control-seed-test-lint.mjs
@@ -102,6 +102,21 @@ function changedFiles(repoRoot) {
   return null;
 }
 
+// The spec file as of the diff base, so evaluate() can tell WHICH entry moved. Returns null
+// when the base cannot be read — the caller re-trials everything and says so out loud, since
+// the one thing this must never do is quietly select nothing.
+function previousSpecs(repoRoot) {
+  for (const rev of ['origin/main', 'HEAD~1']) {
+    try {
+      const base = rev === 'origin/main'
+        ? execFileSync('git', ['merge-base', 'origin/main', 'HEAD'], { cwd: repoRoot, encoding: 'utf8' }).trim()
+        : rev;
+      return JSON.parse(execFileSync('git', ['show', `${base}:${SPEC_PATH}`], { cwd: repoRoot, encoding: 'utf8' }));
+    } catch { /* try next base */ }
+  }
+  return null;
+}
+
 function isControl(p) {
   const rel = p.replace(/\\/g, '/');
   return CONTROL_GLOBS.some((re) => re.test(rel));
@@ -112,7 +127,7 @@ function isControl(p) {
 // unscopable: TS-5 could not point a blind-gauge fixture at it, so the gate silently reported
 // zero failures and "passed". A control whose own scope predicate cannot be aimed cannot be
 // seed-tested — exactly the UNENFORCEABLE verdict it hands out to others.
-export function evaluate(repoRoot, files, specs, isControlFn = isControl) {
+export function evaluate(repoRoot, files, specs, isControlFn = isControl, prevSpecs = null) {
   const failures = [];
   // FR-8 (SD-PAT-FIX-FIX-ABSENCE-SIGNAL-001): THE ACCEPTANCE METRIC.
   // `trials` records controls a seeded-defect trial ACTUALLY RAN on; `skipped` records
@@ -137,14 +152,31 @@ export function evaluate(repoRoot, files, specs, isControlFn = isControl) {
   // would make it unreachable from a unit test — which is how a rule ends up asserted only by
   // the comment above it.
   //
-  // KNOWN LIMITATION (FR-4 binds this gate too): this re-trials EVERY control the spec file
-  // names, not only the entries whose text changed. Diffing the JSON to find which entry moved
-  // would be more precise and is deliberately not done — a conservative over-trial costs CI
-  // time, a missed entry costs a silently weakened fixture, and those are not symmetric.
+  // ONLY THE ENTRIES THAT ACTUALLY CHANGED — AND THE FIRST VERSION OF THIS GOT IT WRONG.
+  // That version re-trialled EVERY control the spec names, justified as "a conservative
+  // over-trial only costs CI time". MEASURED IN CI (run 30950096609): it surfaced 14 issues
+  // across 13 controls, of which exactly ONE belonged to the diff. The real cost is not CI
+  // time — it is that ANY PR touching this file INHERITS THE WHOLE CORPUS'S HEALTH, so under
+  // enforcement an unrelated PR is blocked by failures it did not cause. That is how a gate
+  // teaches people to ignore it. Compare entries against the merge base and re-trial only
+  // what moved.
+  //
+  // FALLING BACK IS DELIBERATE AND MUST BE LOUD: if the previous spec cannot be read we
+  // re-trial ALL of them rather than NONE. Selecting nothing on an unreadable base would be
+  // an empty evaluation reported as a pass — this SD's own defect, in the code fixing it.
   const specChanged = files.some((f) => f.replace(/\\/g, '/') === SPEC_PATH);
-  const fromSpec = specChanged
-    ? specs.map((s) => s.script?.replace(/\\/g, '/')).filter((s) => s && isControlFn(s))
-    : [];
+  let specBaseUnavailable = false;
+  let fromSpec = [];
+  if (specChanged) {
+    if (Array.isArray(prevSpecs)) {
+      const prev = new Map(prevSpecs.map((s) => [s.name, JSON.stringify(s)]));
+      fromSpec = specs.filter((s) => prev.get(s.name) !== JSON.stringify(s));
+    } else {
+      specBaseUnavailable = true;
+      fromSpec = specs;
+    }
+    fromSpec = fromSpec.map((s) => s.script?.replace(/\\/g, '/')).filter((s) => s && isControlFn(s));
+  }
   const selected = [...new Set([...files, ...fromSpec])];
 
   for (const f of selected.filter(isControlFn)) {
@@ -235,7 +267,7 @@ export function evaluate(repoRoot, files, specs, isControlFn = isControl) {
   // ever have had to acknowledge the new information. The 4 tests this breaks are updated in
   // the same commit; both seedTest specs point at that test file, so leaving it broken would
   // make the gate fail itself.
-  return { failures, trials, skipped, selected, specChanged };
+  return { failures, trials, skipped, selected, specChanged, specBaseUnavailable };
 }
 
 function main() {
@@ -257,11 +289,13 @@ function main() {
 
   const specs = existsSync(join(repoRoot, SPEC_PATH)) ? JSON.parse(readFileSync(join(repoRoot, SPEC_PATH), 'utf8')) : [];
 
-  const { failures, trials, skipped, selected, specChanged } = evaluate(repoRoot, files, specs);
+  const { failures, trials, skipped, selected, specChanged, specBaseUnavailable } = evaluate(repoRoot, files, specs, isControl, previousSpecs(repoRoot));
 
   const controls = selected.filter(isControl);
   if (specChanged) {
-    console.log(`ℹ️  ${SPEC_PATH} changed — re-trialling ${controls.length} control(s) it names, because a weakened fixture is as dangerous as a neutered control.`);
+    console.log(specBaseUnavailable
+      ? `⚠️  ${SPEC_PATH} changed but its previous version could not be read, so this run re-trials ALL ${controls.length} control(s) it names rather than only the changed entries. Conservative on purpose: selecting none on an unreadable base would be an empty evaluation reported as a pass.`
+      : `ℹ️  ${SPEC_PATH} changed — re-trialling the ${controls.length} control(s) whose spec entry actually moved, because a weakened fixture is as dangerous as a neutered control.`);
   }
   // FR-8: THE ACCEPTANCE METRIC, ON EVERY PATH. `matched` counts controls the diff selected;
   // `trialsRun` counts controls a seeded-defect trial ACTUALLY RAN on. They are DIFFERENT

--- a/scripts/lint/control-seed-test-lint.mjs
+++ b/scripts/lint/control-seed-test-lint.mjs
@@ -70,7 +70,7 @@
 import { execFileSync, spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { runTrial, VERDICT } from '../audit/control-seed-test.mjs';
+import { runTrial, VERDICT, runSeedTestTrial, SEED_TRIAL } from '../audit/control-seed-test.mjs';
 
 // THE SINGLE POINT THAT CHANGES WHEN THE FR-1 THRESHOLD IS RULED. Broad reading (blocks,
 // 67% < 80%) = all of these. Narrow reading (detects, 83% >= 80%) = trim to the
@@ -176,15 +176,35 @@ export function evaluate(repoRoot, files, specs, isControlFn = isControl) {
     // `fixtures`. Use `seedTest` only when the control cannot be aimed at a fixture, and expect a
     // reviewer to read the test.
     if (spec.seedTest) {
-      const r = spawnSync('npx', ['vitest', 'run', spec.seedTest], { cwd: repoRoot, encoding: 'utf8', timeout: 300000, shell: process.platform === 'win32' });
-      if (r.status !== 0) {
-        failures.push({ file: rel, reason: 'SEED_TEST_FAILED', detail: `its committed seed-test ${spec.seedTest} does not pass.`, evidence: `${r.stdout || ''}${r.stderr || ''}`.trim().split('\n').filter(Boolean).slice(-3) });
+      // FR-7 (SD-PAT-FIX-FIX-ABSENCE-SIGNAL-001): THIS FORM NOW REQUIRES AN OBSERVED RED.
+      // It used to run the test and require it to PASS — which proves only that it passes,
+      // never that it would notice if the control stopped working. A `neuter` declaration is
+      // mandatory so that omitting the proof is UNEXPRESSIBLE rather than merely discouraged;
+      // the alternative (treat a missing neuter as "nothing to check") would reproduce this
+      // SD's exact defect — an empty evaluation reported as a pass.
+      if (!spec.neuter) {
+        failures.push({ file: rel, reason: 'NO_NEUTER_DECLARED', detail: `uses the seedTest form but declares no \`neuter\` {find, replace, why}. Without one the gate can only observe that ${spec.seedTest} passes, which is not evidence it can fail.` });
+        skipped.push({ file: rel, why: 'seedTest form with no neuter declaration — no observed-RED trial was possible' });
+        continue;
       }
-      // FR-8: this control was MATCHED but NO TRIAL WAS RUN — `continue` skips runTrial
-      // entirely. Recording it is what makes matched != trialsRun observable; without it the
-      // two numbers are always equal and the trial count is satisfiable as an alias of the
-      // match count, measuring nothing.
-      skipped.push({ file: rel, why: 'seedTest form — the committed test was run, but no seeded-defect TRIAL was performed' });
+
+      const st = runSeedTestTrial(spec, repoRoot);
+      // FR-8: this IS a trial — the control was exercised against a deliberate defect, which
+      // is the same thing runTrial does, by a different route. Recording it here keeps the
+      // acceptance metric a count of controls actually exercised.
+      trials.push({ file: rel, form: 'seedTest', verdict: st.verdict, code: st.code });
+
+      if (st.code === 'RED_BEFORE_NEUTER') {
+        failures.push({ file: rel, reason: 'SEED_TEST_FAILED', detail: `its committed seed-test ${spec.seedTest} does not pass at HEAD.`, evidence: st.evidence });
+      } else if (st.verdict === SEED_TRIAL.CANNOT_FAIL) {
+        failures.push({ file: rel, reason: 'SEED_TEST_CANNOT_FAIL', detail: st.reason, evidence: st.evidence });
+      } else if (st.verdict === SEED_TRIAL.HARNESS_ERROR) {
+        // Loud, but NOT an accusation. The harness could not reach a verdict, and reporting
+        // that as blindness would be the false-positive shape FR-1 catalogued four times.
+        // Staying silent instead would be the absence-as-pass shape this SD exists to stop —
+        // so it blocks, and says plainly which of the two it is.
+        failures.push({ file: rel, reason: 'SEED_TRIAL_HARNESS_ERROR', detail: `${st.reason} — this is a HARNESS failure, not a finding that the control is blind.`, evidence: st.evidence });
+      }
       continue;
     }
 

--- a/scripts/lint/control-seed-test-lint.mjs
+++ b/scripts/lint/control-seed-test-lint.mjs
@@ -50,7 +50,21 @@
  *     Prefer `fixtures`; `seedTest` exists for controls that cannot be aimed at one.
  *
  * Usage:
- *   node scripts/lint/control-seed-test-lint.mjs [--diff|--all] [--json] [--enforce]
+ *   node scripts/lint/control-seed-test-lint.mjs [--json] [--advisory]
+ *
+ * ENFORCING IS THE DEFAULT (SD-PAT-FIX-FIX-ABSENCE-SIGNAL-001, FR-1). It used to require
+ * --enforce, and the workflow never passed it — so for the whole life of this gate every
+ * failure path, INCLUDING the honest "refusing to report a pass on an unknown set" refusal,
+ * exited 0. Requiring a flag makes the safe behaviour something each workflow author has to
+ * REMEMBER; inverting it makes the omission UNEXPRESSIBLE. Pass --advisory to opt out
+ * deliberately, which is a thing a reader can see in the diff.
+ *
+ * --enforce is still accepted as a no-op so an existing caller cannot break; it is redundant.
+ *
+ * FR-5: [--diff|--all] USED TO BE DOCUMENTED HERE AND NEITHER FLAG WAS EVER READ. main()
+ * parsed only --enforce and --json, and changedFiles() ignores argv entirely — running --all
+ * and --diff produced byte-identical output. A documented flag that no code reads is a false
+ * statement in the help text, so the claim is removed rather than the behaviour invented.
  */
 
 import { execFileSync, spawnSync } from 'node:child_process';
@@ -153,7 +167,11 @@ export function evaluate(repoRoot, files, specs, isControlFn = isControl) {
 function main() {
   const argv = process.argv.slice(2);
   const repoRoot = process.cwd();
-  const enforce = argv.includes('--enforce');
+  // FR-1: ENFORCING IS THE DEFAULT. Opting OUT must be explicit and visible in a diff;
+  // opting IN was invisible by omission, which is how this gate spent its whole life
+  // unable to fail. `--enforce` stays accepted as a redundant no-op so existing callers
+  // keep working — it no longer grants anything.
+  const enforce = !argv.includes('--advisory');
 
   const files = changedFiles(repoRoot);
   if (files === null) {

--- a/tests/unit/lint/control-seed-test-lint.test.js
+++ b/tests/unit/lint/control-seed-test-lint.test.js
@@ -88,3 +88,31 @@ describe('FR-8 — trialsRun is a real count, not an alias of matched', () => {
     expect(r.skipped).toHaveLength(0);
   });
 });
+
+// SD-PAT-FIX-FIX-ABSENCE-SIGNAL-001 — FR-6. A CHANGED SEED SPEC MUST RE-TRIAL ITS CONTROL.
+//
+// The spec file holds the seeded defect itself, so swapping a real fixture for a trivial one is
+// as dangerous as neutering the control. It is a .json and the control globs match .mjs/.js/.cjs,
+// so it can never be reached by widening a glob — and a PR touching only the spec used to report
+// "no new controls in this diff" and exit green, with the workflow having triggered correctly.
+const SPEC_PATH = 'scripts/audit/control-seed-specs.json';
+
+describe('FR-6 — a spec-only diff still evaluates the controls that spec names', () => {
+  it('[DECIDING] a diff containing ONLY the spec file selects the controls it names', () => {
+    const r = evaluate(process.cwd(), [SPEC_PATH], blindSpec, onlyBlind);
+    expect(r.specChanged).toBe(true);
+    expect(r.selected).toContain(BLIND);
+    // It must actually be EVALUATED, not merely listed — a trial ran on it.
+    expect(r.trials).toHaveLength(1);
+    expect(r.failures.some((f) => f.reason === 'SEED_DID_NOT_FIRE')).toBe(true);
+  });
+
+  it('[CONTROL] an unrelated diff does NOT trigger the expansion', () => {
+    // Without this, `specChanged` could be hardcoded true and the deciding test above would
+    // still pass while the gate re-trialled the whole corpus on every PR.
+    const r = evaluate(process.cwd(), ['README.md'], blindSpec, onlyBlind);
+    expect(r.specChanged).toBe(false);
+    expect(r.selected).not.toContain(BLIND);
+    expect(r.trials).toHaveLength(0);
+  });
+});

--- a/tests/unit/lint/control-seed-test-lint.test.js
+++ b/tests/unit/lint/control-seed-test-lint.test.js
@@ -9,7 +9,7 @@
 // No DB, no network: pure evaluate() against a committed fixture.
 import { describe, it, expect } from 'vitest';
 import { evaluate } from '../../../scripts/lint/control-seed-test-lint.mjs';
-import { classifySeedTrial, SEED_TRIAL } from '../../../scripts/audit/control-seed-test.mjs';
+import { classifySeedTrial, SEED_TRIAL, runSeedTestTrial } from '../../../scripts/audit/control-seed-test.mjs';
 
 const BLIND = 'tests/fixtures/control-seed-gate/blind-gauge-lint.mjs';
 const onlyBlind = (p) => p === BLIND;
@@ -206,5 +206,40 @@ describe('FR-7 — an observed RED, and only for the right reason', () => {
     const r = classifySeedTrial({ cleanExit: 0, mutationLanded: true, mutantExit: 1, mutantOut: 'exited with code 1' });
     expect(r.verdict).toBe(SEED_TRIAL.HARNESS_ERROR);
     expect(r.code).toBe('UNEXPLAINED_RED');
+  });
+});
+
+// SD-PAT-FIX-FIX-ABSENCE-SIGNAL-001 — SECURITY regressions, all live-proved before being fixed.
+//
+// scripts/audit/control-seed-specs.json IS EDITABLE IN A PULL REQUEST, so every field it carries
+// is attacker-authored input to code that writes files and spawns processes. These pin the two
+// primitives SECURITY demonstrated against the first US-007 implementation.
+//
+// All cases return BEFORE any worktree is created, so these are fast and touch nothing.
+describe('SECURITY — the spec file is untrusted input', () => {
+  const base = { name: 'attack', script: 'scripts/lint/control-seed-test-lint.mjs', seedTest: 'tests/unit/lint/control-seed-test-lint.test.js' };
+
+  it('[DECIDING] SEC-1: a neuter.file outside the control under test is refused', () => {
+    // `join(wt, '../../../..')` walked straight out of the trial worktree into the real repo.
+    const r = runSeedTestTrial({ ...base, neuter: { file: '../../../../etc/passwd', find: 'x', replace: 'y' } }, process.cwd());
+    expect(r.verdict).toBe(SEED_TRIAL.HARNESS_ERROR);
+    expect(r.code).toBe('NEUTER_FILE_NOT_SCRIPT');
+  });
+
+  it('[DECIDING] SEC-2: an EMPTY find is refused — it prepends rather than replaces', () => {
+    // The sharpest edge, and it does not look like one: ''.replace matches at index 0 ALWAYS, so
+    // `replace` is written unconditionally AND the mutation-landed check confirms a real change.
+    // The harness then re-runs vitest in that same worktree, so the prepended text EXECUTES.
+    const r = runSeedTestTrial({ ...base, neuter: { find: '', replace: 'import("child_process")' } }, process.cwd());
+    expect(r.verdict).toBe(SEED_TRIAL.HARNESS_ERROR);
+    expect(r.code).toBe('NEUTER_FIND_EMPTY');
+  });
+
+  it('[CONTROL] a well-formed neuter is NOT refused by these guards', () => {
+    // Without this, guards that reject EVERY spec would score a perfect pass on both tests above
+    // while disabling the feature entirely. It must fail for some LATER reason, never these two.
+    const r = runSeedTestTrial({ ...base, neuter: { find: 'genuinely-absent-token-xyz', replace: 'z' } }, process.cwd());
+    expect(r.code).not.toBe('NEUTER_FILE_NOT_SCRIPT');
+    expect(r.code).not.toBe('NEUTER_FIND_EMPTY');
   });
 });

--- a/tests/unit/lint/control-seed-test-lint.test.js
+++ b/tests/unit/lint/control-seed-test-lint.test.js
@@ -9,6 +9,7 @@
 // No DB, no network: pure evaluate() against a committed fixture.
 import { describe, it, expect } from 'vitest';
 import { evaluate } from '../../../scripts/lint/control-seed-test-lint.mjs';
+import { classifySeedTrial, SEED_TRIAL } from '../../../scripts/audit/control-seed-test.mjs';
 
 const BLIND = 'tests/fixtures/control-seed-gate/blind-gauge-lint.mjs';
 const onlyBlind = (p) => p === BLIND;
@@ -114,5 +115,61 @@ describe('FR-6 — a spec-only diff still evaluates the controls that spec names
     expect(r.specChanged).toBe(false);
     expect(r.selected).not.toContain(BLIND);
     expect(r.trials).toHaveLength(0);
+  });
+});
+
+// SD-PAT-FIX-FIX-ABSENCE-SIGNAL-001 — FR-7. THE seedTest FORM MUST REQUIRE AN OBSERVED RED.
+//
+// These drive the PURE classifier, never runSeedTestTrial. That is not only for speed: this
+// very file is the seed-test the trial runs, so a test here that invoked the trial would
+// spawn a worktree to run itself. Any spec used below must therefore stay `neuter`-free.
+//
+// Four of the six cases are CONTROLS, because every one of them is a way this check could
+// quietly become a rubber stamp while still reporting a verdict.
+describe('FR-7 — an observed RED, and only for the right reason', () => {
+  const REAL_RED = 'AssertionError: expected [] to have a length of 1';
+
+  it('[DECIDING] neutered and STILL GREEN is the finding — the test asserts nothing', () => {
+    const r = classifySeedTrial({ cleanExit: 0, mutationLanded: true, mutantExit: 0, neuterWhy: 'gate reports no failures' });
+    expect(r.verdict).toBe(SEED_TRIAL.CANNOT_FAIL);
+    expect(r.code).toBe('SURVIVED');
+  });
+
+  it('[DECIDING] green whole, red neutered, on an assertion → PROVEN_RED', () => {
+    const r = classifySeedTrial({ cleanExit: 0, mutationLanded: true, mutantExit: 1, mutantOut: REAL_RED });
+    expect(r.verdict).toBe(SEED_TRIAL.PROVEN_RED);
+  });
+
+  it('[CONTROL] already RED before neutering is never proof — the positive control dominates', () => {
+    // The dangerous direction: a mis-wired scratch tree makes the mutant red too, so without
+    // this rule the harness is most confident exactly when it is most broken. Note the inputs
+    // below would otherwise read as a textbook PROVEN_RED.
+    const r = classifySeedTrial({ cleanExit: 1, mutationLanded: true, mutantExit: 1, mutantOut: REAL_RED });
+    expect(r.verdict).toBe(SEED_TRIAL.HARNESS_ERROR);
+    expect(r.code).toBe('RED_BEFORE_NEUTER');
+  });
+
+  it('[CONTROL] a no-op mutation is an ERROR, never CANNOT_FAIL', () => {
+    // This fired for real during PLAN: a mutation attempt was a silent no-op and would have
+    // been published as a surviving mutant. "Neuter → still green" and "the edit never landed"
+    // produce identical observations, so the harness must refuse to score rather than guess.
+    const r = classifySeedTrial({ cleanExit: 0, mutationLanded: false, mutantExit: 0 });
+    expect(r.verdict).toBe(SEED_TRIAL.HARNESS_ERROR);
+    expect(r.code).toBe('MUTATION_NO_OP');
+    expect(r.verdict).not.toBe(SEED_TRIAL.CANNOT_FAIL);
+  });
+
+  it('[CONTROL] red because the module would not LOAD is not proof of detection', () => {
+    // Otherwise the weakest possible neutering — corrupting the file — passes as evidence,
+    // and every seedTest control could be certified by making its source unparseable.
+    const r = classifySeedTrial({ cleanExit: 0, mutationLanded: true, mutantExit: 1, mutantOut: 'Error: Failed to load url ../../../scripts/lint/x.mjs\nSyntaxError: Unexpected token' });
+    expect(r.verdict).toBe(SEED_TRIAL.HARNESS_ERROR);
+    expect(r.code).toBe('LOAD_CRASH');
+  });
+
+  it('[CONTROL] an unexplained red is refused rather than scored', () => {
+    const r = classifySeedTrial({ cleanExit: 0, mutationLanded: true, mutantExit: 1, mutantOut: 'exited with code 1' });
+    expect(r.verdict).toBe(SEED_TRIAL.HARNESS_ERROR);
+    expect(r.code).toBe('UNEXPLAINED_RED');
   });
 });

--- a/tests/unit/lint/control-seed-test-lint.test.js
+++ b/tests/unit/lint/control-seed-test-lint.test.js
@@ -238,8 +238,22 @@ describe('SECURITY — the spec file is untrusted input', () => {
   it('[CONTROL] a well-formed neuter is NOT refused by these guards', () => {
     // Without this, guards that reject EVERY spec would score a perfect pass on both tests above
     // while disabling the feature entirely. It must fail for some LATER reason, never these two.
-    const r = runSeedTestTrial({ ...base, neuter: { find: 'genuinely-absent-token-xyz', replace: 'z' } }, process.cwd());
+    //
+    // *** THE DEPENDENCY INJECTION IS LOAD-BEARING, NOT TIDINESS. *** This is the one case that
+    // gets PAST the guards, so it would otherwise reach the real body — building a git worktree
+    // and running a nested vitest INSIDE this very test file, which is itself the seed-test that
+    // trial runs. The first version did exactly that: standalone it passed in ~60s, but under
+    // full-suite CI load it blew the 60s timeout and turned the required check red. Caught by the
+    // RETRO agent reading the live PR, not by me. Stubbing `exec` makes it fail immediately at
+    // the first git call, which is all this test needs — it asserts WHICH refusal did not happen.
+    const explode = () => { throw new Error('stubbed: no real worktree in a unit test'); };
+    const r = runSeedTestTrial(
+      { ...base, neuter: { find: 'genuinely-absent-token-xyz', replace: 'z' } },
+      process.cwd(),
+      { exec: explode, spawn: explode },
+    );
     expect(r.code).not.toBe('NEUTER_FILE_NOT_SCRIPT');
     expect(r.code).not.toBe('NEUTER_FIND_EMPTY');
+    expect(r.code).toBe('HARNESS_THREW'); // reached the body, i.e. the guards let it through
   });
 });

--- a/tests/unit/lint/control-seed-test-lint.test.js
+++ b/tests/unit/lint/control-seed-test-lint.test.js
@@ -22,7 +22,7 @@ const blindSpec = [{
 
 describe('control-seed-test-lint — TS-5 (deciding scenario)', () => {
   it('REFUSES a deliberately blind gauge that ships a seed-test which cannot fail', () => {
-    const failures = evaluate(process.cwd(), [BLIND], blindSpec, onlyBlind);
+    const { failures } = evaluate(process.cwd(), [BLIND], blindSpec, onlyBlind);
     expect(failures.some((f) => f.reason === 'SEED_DID_NOT_FIRE')).toBe(true);
   });
 
@@ -30,17 +30,61 @@ describe('control-seed-test-lint — TS-5 (deciding scenario)', () => {
     // The fixture deliberately carries "KNOWN LIMITATIONS: none known." — a shrug that
     // satisfies a string match. This asserts the gate does NOT rely on that half, because a
     // declaration check is exactly as blind as the gauge it is inspecting.
-    const failures = evaluate(process.cwd(), [BLIND], blindSpec, onlyBlind);
+    const { failures } = evaluate(process.cwd(), [BLIND], blindSpec, onlyBlind);
     expect(failures.some((f) => f.reason === 'NO_KNOWN_LIMITATION')).toBe(false);
     expect(failures.some((f) => f.reason === 'SEED_DID_NOT_FIRE')).toBe(true);
   });
 
   it('FR-2: refuses a new control that ships with no seed-test at all', () => {
-    const failures = evaluate(process.cwd(), [BLIND], [], onlyBlind);
+    const { failures } = evaluate(process.cwd(), [BLIND], [], onlyBlind);
     expect(failures.some((f) => f.reason === 'NO_SEED_TEST')).toBe(true);
   });
 
   it('does not fire on a diff containing no new controls', () => {
-    expect(evaluate(process.cwd(), ['README.md'], blindSpec, onlyBlind)).toHaveLength(0);
+    expect(evaluate(process.cwd(), ['README.md'], blindSpec, onlyBlind).failures).toHaveLength(0);
+  });
+});
+
+// SD-PAT-FIX-FIX-ABSENCE-SIGNAL-001 — FR-8. THE ACCEPTANCE METRIC.
+//
+// The count of controls a trial ACTUALLY RAN on is the thing this SD asserts. The obvious
+// implementation is `trialsRun: matched`, and it would pass every test above, because in each
+// of those scenarios the two numbers happen to be equal. That is an IDENTITY-PRESERVING
+// MUTANT: it satisfies the letter of the metric while measuring nothing.
+//
+// So the deciding case here is one where they MUST DIVERGE. A seedTest spec is MATCHED by the
+// diff and then `continue`s past runTrial entirely — matched 1, trialsRun 0. A test suite
+// without this case cannot tell the real count from the alias.
+describe('FR-8 — trialsRun is a real count, not an alias of matched', () => {
+  const SEEDTEST_SPEC = [{
+    name: 'blind-gauge-lint',
+    script: BLIND,
+    seedTest: 'tests/unit/lint/does-not-need-to-exist.test.js',
+  }];
+
+  it('[DECIDING] a matched-but-never-trialled control makes matched != trialsRun', () => {
+    const { trials, skipped } = evaluate(process.cwd(), [BLIND], SEEDTEST_SPEC, onlyBlind);
+    // matched is 1 (the diff selected it) but NO trial ran — the seedTest form skips runTrial.
+    expect(trials).toHaveLength(0);
+    expect(skipped).toHaveLength(1);
+    expect(skipped[0].file).toBe(BLIND);
+    // If trialsRun were aliased to matched this would read 1 and the assertion would fail.
+    expect(trials.length).not.toBe(1);
+  });
+
+  it('a control that IS trialled is recorded with its verdict', () => {
+    const { trials, skipped } = evaluate(process.cwd(), [BLIND], blindSpec, onlyBlind);
+    expect(trials).toHaveLength(1);
+    expect(trials[0].file).toBe(BLIND);
+    expect(trials[0].verdict).toBeTruthy();
+    expect(skipped).toHaveLength(0);
+  });
+
+  it('[CONTROL] a diff with no controls yields zero of everything — not undefined', () => {
+    // Guards the no-controls path, which previously returned before emitting any count at all.
+    const r = evaluate(process.cwd(), ['README.md'], blindSpec, onlyBlind);
+    expect(r.failures).toHaveLength(0);
+    expect(r.trials).toHaveLength(0);
+    expect(r.skipped).toHaveLength(0);
   });
 });

--- a/tests/unit/lint/control-seed-test-lint.test.js
+++ b/tests/unit/lint/control-seed-test-lint.test.js
@@ -108,6 +108,41 @@ describe('FR-6 — a spec-only diff still evaluates the controls that spec names
     expect(r.failures.some((f) => f.reason === 'SEED_DID_NOT_FIRE')).toBe(true);
   });
 
+  // MEASURED IN CI (run 30950096609), which is why these exist: the first version re-trialled
+  // EVERY control the spec names and surfaced 14 issues across 13 controls, of which ONE
+  // belonged to the diff. The cost was never CI time — it was that any PR touching this file
+  // inherits the whole corpus's health.
+  const OTHER = 'scripts/lint/some-other-control.mjs';
+  const twoSpecs = [blindSpec[0], { name: 'other', script: OTHER, fixtures: [{ path: 'x.js', content: 'x\n' }] }];
+  const isEither = (p) => p === BLIND || p === OTHER;
+
+  it('[DECIDING] only the control whose spec ENTRY changed is re-trialled', () => {
+    // Previous spec differs for the blind gauge only; `other` is byte-identical.
+    const prev = [{ ...blindSpec[0], fixtures: [{ path: 'lib/real-defect.js', content: '// WEAKENED\n' }] }, twoSpecs[1]];
+    const r = evaluate(process.cwd(), [SPEC_PATH], twoSpecs, isEither, prev);
+    expect(r.selected).toContain(BLIND);
+    expect(r.selected).not.toContain(OTHER);
+    expect(r.specBaseUnavailable).toBe(false);
+  });
+
+  it('[CONTROL] an UNCHANGED spec entry drags in nothing, even when the file changed', () => {
+    // Without this, `fromSpec` could ignore prevSpecs entirely and the deciding test above
+    // would still pass on the strength of the blind gauge alone.
+    const r = evaluate(process.cwd(), [SPEC_PATH], twoSpecs, isEither, twoSpecs);
+    expect(r.selected).not.toContain(BLIND);
+    expect(r.selected).not.toContain(OTHER);
+    expect(r.trials).toHaveLength(0);
+  });
+
+  it('[CONTROL] an unreadable base falls back to ALL and says so — never to none', () => {
+    // The dangerous direction is selecting nothing: an empty evaluation reported as a pass is
+    // this SD's entire subject. Fail wide and loud, not narrow and quiet.
+    const r = evaluate(process.cwd(), [SPEC_PATH], twoSpecs, isEither, null);
+    expect(r.specBaseUnavailable).toBe(true);
+    expect(r.selected).toContain(BLIND);
+    expect(r.selected).toContain(OTHER);
+  });
+
   it('[CONTROL] an unrelated diff does NOT trigger the expansion', () => {
     // Without this, `specChanged` could be hardcoded true and the deciding test above would
     // still pass while the gate re-trialled the whole corpus on every PR.


### PR DESCRIPTION
## Summary
- The control-seed-test gate previously could not fail at all: findings never reached the job summary/exit code, a control that crashed mid-trial was published as one that "ran clean," and a weakened fixture escaped re-trial (US-001/002/003/004/005).
- The `seedTest` trial form now requires an OBSERVED RED — it builds a scratch git worktree, applies the neutering mutation, and runs vitest for real rather than inferring blindness from a diff (US-007).
- A no-op mutation (the neutering edit's `find` string no longer matches the control) is now refused as a HARNESS error (`MUTATION_NO_OP`) instead of being silently scored as a pass (US-006 support).
- The trial-count line now reports what was ACTUALLY run (`TRIALS RUN n — PROVEN_RED:x SILENT:y ...`) instead of a count that didn't match its own body (US-008).

## AC-1 verification (RED-CI proof)
AC-1 ("a neutered control turns this gate RED under enforcement") was proven live on a throwaway branch/PR (`proof/ac1-red-ci-demo-do-not-merge`, PR #6825 — CLOSED, never merged, branch deleted, no commit from it present on this branch). With `continue-on-error` temporarily flipped to `false` on that branch only, a deliberately neutered `ismainmodule-classguard-lint.mjs` control produced a real job failure (exit 1) with `SEED_DID_NOT_FIRE` + `NO_KNOWN_LIMITATION`, and the observed-RED worktree/vitest machinery completed inside GitHub Actions (`TRIALS RUN 3 — PROVEN_RED:2 SILENT:1`). This branch itself keeps `continue-on-error: true` (the documented 7-day advisory soak in the workflow header) — enforcement flip is a separate, dated follow-on, not part of this PR.

## Test plan
- [x] `tests/unit/lint/control-seed-test-lint.test.js` — updated/expanded for the new failure surfacing, harness-error refusal, and trial-count behavior
- [x] Live RED-CI proof on throwaway PR #6825 (see above), reviewed by the GITHUB sub-agent
- [ ] CI green on this PR (all workflows, including this gate's own advisory run against itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)