### PR TITLE
feat(SD-LEO-INFRA-STAMP-ARMING-TIME-001): stamp arming time so a never-produced report is distinguishable from not-yet-due

### DIFF
--- a/lib/gates/operator-contract/__tests__/venture-and-self-cadence.test.js
+++ b/lib/gates/operator-contract/__tests__/venture-and-self-cadence.test.js
@@ -45,7 +45,15 @@ describe('evaluateVentureOperatorContract (FR-7 — shared validator at the vent
 describe('registerOperatorContractCadence (FR-8 self-registration)', () => {
   it('upserts an ARMED registry row for the gate itself via the shared primitive', async () => {
     let upserted = null;
-    const supabase = { from: () => ({ upsert: async (row) => { upserted = row; return { error: null }; } }) };
+    // SD-LEO-INFRA-STAMP-ARMING-TIME-001: registerArmedMachinery now READS the existing row before
+    // upserting, so armed_at is written once and then AGES rather than being reset every tick.
+    // The mock must answer that read; data:null is "no prior row" (first registration).
+    const supabase = {
+      from: () => ({
+        select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }),
+        upsert: async (row) => { upserted = row; return { error: null }; },
+      }),
+    };
     const r = await registerOperatorContractCadence(supabase, { expectedIntervalSeconds: 3600 });
     expect(r.ok).toBe(true);
     expect(upserted.process_key).toMatch(/operator-contract-gate/);

--- a/lib/loop-governance/__tests__/governance.test.js
+++ b/lib/loop-governance/__tests__/governance.test.js
@@ -86,7 +86,15 @@ describe('buildLoopHealthDigest (FR-7 — monthly chairman digest)', () => {
 describe('registerDigestCadence (FR-7 monthly cadence)', () => {
   it('arms the monthly digest with a ~30d interval', async () => {
     let upserted = null;
-    const supabase = { from: () => ({ upsert: async (row) => { upserted = row; return { error: null }; } }) };
+    // SD-LEO-INFRA-STAMP-ARMING-TIME-001: registerArmedMachinery now READS the existing row before
+    // upserting, so armed_at is written once and then AGES rather than being reset every tick.
+    // The mock must answer that read; data:null is "no prior row" (first registration).
+    const supabase = {
+      from: () => ({
+        select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: null, error: null }) }) }),
+        upsert: async (row) => { upserted = row; return { error: null }; },
+      }),
+    };
     const r = await registerDigestCadence(supabase);
     expect(r.ok).toBe(true);
     expect(upserted.expected_interval_seconds).toBe(30 * 86400);

--- a/lib/machinery-class/armed-registration.js
+++ b/lib/machinery-class/armed-registration.js
@@ -20,6 +20,13 @@
 const DEFAULT_EXPECTED_INTERVAL_SECONDS = 86400;
 
 /**
+ * FR-7's "past 2x cadence" rule (SD-LEO-INFRA-DRIVE-LOOP-INSTRUMENT-001-B AC-8), set at
+ * REGISTRATION rather than only in the success-path stamp. Sampled live before this SD: every one
+ * of the 27 self_stamped rows with a null last_fired_at carried the column default 3, never 2.
+ */
+const ARMED_GRACE_MULTIPLIER = 2;
+
+/**
  * Derive a stable, unique process_key for an SD/QF's ARMED registration.
  * @param {string} sdKey
  * @returns {string}
@@ -46,7 +53,30 @@ export async function registerArmedMachinery(supabase, sd, opts = {}) {
   }
   const processKey = armedProcessKey(sdKey);
   try {
-    const { error } = await supabase.from('periodic_process_registry').upsert({
+    // SD-LEO-INFRA-STAMP-ARMING-TIME-001 FR-1 — READ BEFORE UPSERT, and the reason is the whole SD.
+    //
+    // THE ARMING TIME MUST AGE. This function runs on EVERY in-window tick, so writing
+    // `armed_at: new Date()` inline would reset the clock on every tick, the row would never grow
+    // older than its grace window, and the FR-7 alarm this SD exists to build could NEVER fire —
+    // a fix that silently defeats itself while all of its tests pass. armed_at is therefore
+    // written ONCE and preserved thereafter (tests/unit/machinery-class/armed-registration-arming-time.test.js
+    // registers twice with an advanced clock and asserts the value is byte-identical).
+    //
+    // The same read fixes a second, pre-existing defect: `last_fired_at: null` used to be written
+    // UNCONDITIONALLY, so re-registering a process that HAD fired wiped its real stamp and sent it
+    // back to looking never-produced. It is now sent only when inserting a new row.
+    const { data: existing, error: readError } = await supabase
+      .from('periodic_process_registry')
+      .select('liveness_source_ref, last_fired_at')
+      .eq('process_key', processKey)
+      .maybeSingle();
+    if (readError) return { ok: false, error: readError.message };
+
+    const priorRef = existing?.liveness_source_ref && typeof existing.liveness_source_ref === 'object'
+      ? existing.liveness_source_ref : {};
+    const nowIso = new Date().toISOString();
+
+    const payload = {
       process_key: processKey,
       display_name: `G3 ARMED: ${sdKey}`,
       owner: opts.owner || 'g3-activation',
@@ -54,14 +84,28 @@ export async function registerArmedMachinery(supabase, sd, opts = {}) {
       expected_interval_seconds: Number.isFinite(opts.expectedIntervalSeconds) && opts.expectedIntervalSeconds > 0
         ? opts.expectedIntervalSeconds : DEFAULT_EXPECTED_INTERVAL_SECONDS,
       liveness_source: 'self_stamped',
-      liveness_source_ref: { sd_key: sdKey, activation_trigger: opts.activationTrigger.trim() },
+      // Spread FIRST so an existing armed_at (and any key a later SD adds) survives; the explicit
+      // keys below re-assert the contract fields without dropping what was already there.
+      liveness_source_ref: {
+        ...priorRef,
+        sd_key: sdKey,
+        activation_trigger: opts.activationTrigger.trim(),
+        armed_at: priorRef.armed_at || nowIso,
+      },
+      // FR-7's "past 2x cadence" rule. Without this the row inherits the column default (3), so the
+      // alarm the PRD promises at 2x would not fire until 3x.
+      grace_multiplier: ARMED_GRACE_MULTIPLIER,
       session_bound: false,
       currently_expected_active: true,
-      last_fired_at: null,
-      updated_at: new Date().toISOString(),
-    }, { onConflict: 'process_key' });
+      updated_at: nowIso,
+    };
+    if (!existing) payload.last_fired_at = null;
+
+    const { error } = await supabase
+      .from('periodic_process_registry')
+      .upsert(payload, { onConflict: 'process_key' });
     if (error) return { ok: false, error: error.message };
-    return { ok: true, processKey };
+    return { ok: true, processKey, armedAt: payload.liveness_source_ref.armed_at };
   } catch (e) {
     return { ok: false, error: (e && e.message) || String(e) };
   }

--- a/scripts/periodic-liveness-watcher.mjs
+++ b/scripts/periodic-liveness-watcher.mjs
@@ -245,6 +245,45 @@ async function evaluateRow(row, ctx = {}) {
   // self_stamped: lastFiredAt already = row.last_fired_at
 
   if (!lastFiredAt) {
+    // SD-LEO-INFRA-STAMP-ARMING-TIME-001 FR-2 — a null last_fired_at CONFLATES two states:
+    // "not due yet" and "never produced when it should have". That conflation is why AC-8/FR-7 of
+    // SD-LEO-INFRA-DRIVE-LOOP-INSTRUMENT-001-B shipped UNMET: the alarm works once a report has
+    // succeeded ONCE, and is blind precisely for a report that has NEVER been produced — which is
+    // the state at merge and the most missing a report can be.
+    //
+    // An arming time separates them, so BOTH acceptance criteria survive: FR-7 gets its alarm, and
+    // the never-false-OVERDUE criterion is untouched because this branch requires an EXPLICIT
+    // armed_at that only registration writes.
+    //
+    // THE GUARD IS THE POINT, not a formality. This early return is reached by far more than armed
+    // rows. Measured live before writing this: of the 66 rows carrying a null last_fired_at, only
+    // 27 are self_stamped; the other 39 resolve lastFiredAt in the branches above and 16 of them
+    // already read OK. Keying this on row age instead of an explicit armed_at would have emitted
+    // 60 alarms, roughly 33 of them false — role_session:adam/coordinator/solomon sit at ~1487
+    // cadences elapsed with a null last_fired_at and last_state OK. Requiring armed_at makes this
+    // branch STRUCTURALLY unable to reach them.
+    const armedAt = row.liveness_source_ref?.armed_at;
+    const armedMs = armedAt ? Date.parse(armedAt) : NaN;
+    // A malformed armed_at falls through to UNVERIFIED — an unparseable timestamp is not evidence
+    // that something is overdue, and fail-soft here keeps the never-false-OVERDUE property.
+    // overdueThresholdMs does Number(row.grace_multiplier), and Number(null) is 0 — a row carrying
+    // an armed_at but no grace_multiplier would get a threshold of 0 and alarm INSTANTLY. Today
+    // that is unreachable because the only writer of armed_at also writes grace_multiplier, which
+    // is precisely the kind of cross-file coupling a later edit breaks silently. Require a real
+    // positive window.
+    const thresholdMs = overdueThresholdMs(row);
+    if (Number.isFinite(armedMs) && Number.isFinite(thresholdMs) && thresholdMs > 0) {
+      const armedAgeMs = Date.now() - armedMs;
+      if (armedAgeMs > thresholdMs) {
+        return {
+          process_key: row.process_key,
+          state: STATE.OVERDUE,
+          armed_at: armedAt,
+          age_ms: armedAgeMs,
+          reason: 'armed_never_produced',
+        };
+      }
+    }
     return { process_key: row.process_key, state: STATE.UNVERIFIED, reason: 'no_last_fired_data_available' };
   }
 

--- a/tests/unit/chairman/sms-channel-health.test.js
+++ b/tests/unit/chairman/sms-channel-health.test.js
@@ -25,6 +25,13 @@ function makeMock({ obligations = [], selectError = null, registryError = null }
       update: (p) => { state.op = 'update'; state.payload = p; return c; },
       upsert: (p) => { state.op = 'upsert'; state.payload = p; return finishThenable(); },
       eq: () => c, in: () => c, is: () => c, gte: () => c, order: () => c, limit: () => c,
+      // SD-LEO-INFRA-STAMP-ARMING-TIME-001: registerArmedMachinery now READS the existing row
+      // before upserting, so armed_at is written once and then AGES instead of being reset on
+      // every in-window tick. data:null models "no prior row" (first registration); registryError
+      // still surfaces so the existing failure-path assertions keep exercising a real error.
+      maybeSingle: async () => (registryError
+        ? { data: null, error: { message: registryError } }
+        : { data: null, error: null }),
       then: (res, rej) => finish().then(res, rej),
     };
     function finishThenable() { return { then: (res, rej) => finish().then(res, rej), select: () => finishThenable() }; }

--- a/tests/unit/machinery-class/armed-registration.test.js
+++ b/tests/unit/machinery-class/armed-registration.test.js
@@ -5,12 +5,25 @@
 import { describe, it, expect } from 'vitest';
 import { armedProcessKey, registerArmedMachinery } from '../../../lib/machinery-class/armed-registration.js';
 
-function fakeSb({ error = null } = {}) {
+// SD-LEO-INFRA-STAMP-ARMING-TIME-001 FR-1: registerArmedMachinery now READS the existing row
+// before upserting (so armed_at is written once and then AGES, and so a real last_fired_at is not
+// wiped on re-registration). The mock models that read; `existing` is the row already in the table,
+// or null for a first registration.
+function fakeSb({ error = null, readError = null, existing = null } = {}) {
   const calls = [];
   return {
     calls,
     from(table) {
       return {
+        select() {
+          return {
+            eq() {
+              return {
+                maybeSingle: () => Promise.resolve({ data: existing, error: readError }),
+              };
+            },
+          };
+        },
         upsert(payload, options) {
           calls.push({ table, payload, options });
           return Promise.resolve({ data: error ? null : [payload], error });
@@ -79,5 +92,79 @@ describe('registerArmedMachinery', () => {
     const result = await registerArmedMachinery(sb, { sd_key: 'SD-X-001' }, { activationTrigger: 'trigger' });
     expect(result.ok).toBe(false);
     expect(result.error).toBe('boom');
+  });
+});
+
+/**
+ * SD-LEO-INFRA-STAMP-ARMING-TIME-001 FR-1 / TS-1 / TS-5.
+ *
+ * THE ARMING TIME MUST AGE. registerArmedMachinery runs on every in-window tick, so an inline
+ * `armed_at: new Date()` would reset the clock each tick, the row would never pass its grace
+ * window, and the FR-7 alarm could never fire — while every single-registration test still passed.
+ * The only test that can see that defect registers TWICE with time in between, so that is the
+ * first test here.
+ */
+describe('registerArmedMachinery — arming time (FR-1)', () => {
+  it('stamps armed_at and grace_multiplier 2 on FIRST registration', async () => {
+    const sb = fakeSb();
+    const before = Date.now();
+    const result = await registerArmedMachinery(sb, { sd_key: 'SD-X-001' }, { activationTrigger: 'trigger' });
+    expect(result.ok).toBe(true);
+
+    const payload = sb.calls[0].payload;
+    expect(payload.grace_multiplier).toBe(2);
+    expect(payload.last_fired_at).toBeNull();
+    const armedMs = Date.parse(payload.liveness_source_ref.armed_at);
+    expect(Number.isFinite(armedMs)).toBe(true);
+    expect(armedMs).toBeGreaterThanOrEqual(before - 1000);
+    expect(result.armedAt).toBe(payload.liveness_source_ref.armed_at);
+  });
+
+  it('PRESERVES the original armed_at on re-registration — the value must AGE, not reset', async () => {
+    const originalArmedAt = new Date(Date.now() - 5 * 86400 * 1000).toISOString();
+    const sb = fakeSb({
+      existing: {
+        liveness_source_ref: { sd_key: 'SD-X-001', activation_trigger: 'trigger', armed_at: originalArmedAt },
+        last_fired_at: null,
+      },
+    });
+
+    const result = await registerArmedMachinery(sb, { sd_key: 'SD-X-001' }, { activationTrigger: 'trigger' });
+    expect(result.ok).toBe(true);
+    // BYTE-IDENTICAL, not merely "present". A re-stamped armed_at would still be a valid ISO
+    // string and would still satisfy a presence check, which is exactly how this defect hides.
+    expect(sb.calls[0].payload.liveness_source_ref.armed_at).toBe(originalArmedAt);
+  });
+
+  it('does NOT reset a real last_fired_at when re-registering (pre-existing defect)', async () => {
+    const firedAt = new Date(Date.now() - 60_000).toISOString();
+    const sb = fakeSb({ existing: { liveness_source_ref: { armed_at: '2026-01-01T00:00:00.000Z' }, last_fired_at: firedAt } });
+
+    await registerArmedMachinery(sb, { sd_key: 'SD-X-001' }, { activationTrigger: 'trigger' });
+    // Omitted from the upsert entirely, so ON CONFLICT DO UPDATE leaves the stored value alone.
+    // Previously `last_fired_at: null` was written unconditionally, sending a process that HAD
+    // fired back to looking never-produced.
+    expect('last_fired_at' in sb.calls[0].payload).toBe(false);
+  });
+
+  it('preserves unrelated pre-existing liveness_source_ref keys', async () => {
+    const sb = fakeSb({ existing: { liveness_source_ref: { armed_at: '2026-01-01T00:00:00.000Z', custom_key: 'keep-me' }, last_fired_at: null } });
+    await registerArmedMachinery(sb, { sd_key: 'SD-X-001' }, { activationTrigger: 'trigger' });
+    expect(sb.calls[0].payload.liveness_source_ref).toMatchObject({
+      custom_key: 'keep-me',
+      sd_key: 'SD-X-001',
+      activation_trigger: 'trigger',
+      armed_at: '2026-01-01T00:00:00.000Z',
+    });
+  });
+
+  it('fails closed (no upsert) when the pre-read errors', async () => {
+    const sb = fakeSb({ readError: { message: 'read failed' } });
+    const result = await registerArmedMachinery(sb, { sd_key: 'SD-X-001' }, { activationTrigger: 'trigger' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('read failed');
+    // Critical: an unreadable prior row must NOT fall through to an upsert, because that upsert
+    // would write a fresh armed_at over an older one and silently reset the alarm clock.
+    expect(sb.calls).toHaveLength(0);
   });
 });

--- a/tests/unit/periodic-liveness/watcher-armed-never-produced.test.js
+++ b/tests/unit/periodic-liveness/watcher-armed-never-produced.test.js
@@ -1,0 +1,111 @@
+/**
+ * SD-LEO-INFRA-STAMP-ARMING-TIME-001 FR-2 / TS-2, TS-3, TS-4.
+ *
+ * A null last_fired_at CONFLATES "not due yet" with "never produced when it should have". This
+ * suite proves the watcher now separates them — and, just as importantly, that it does NOT reach
+ * the rows it must never alarm on.
+ *
+ * BOTH ARMS ON EVERY ASSERTION. A test that only shows the alarm firing has not shown that the
+ * branch DISCRIMINATES; it is equally satisfied by a branch that fires on everything, which is
+ * precisely the 60-alarm failure mode this design was corrected away from.
+ */
+import { describe, it, expect } from 'vitest';
+import { evaluateRow, STATE } from '../../../scripts/periodic-liveness-watcher.mjs';
+
+const HOUR = 3600;
+const daysAgo = (n) => new Date(Date.now() - n * 86400 * 1000).toISOString();
+
+/** A self_stamped row that has never been stamped — the ARMED signature. */
+function armedRow(overrides = {}) {
+  return {
+    process_key: 'g3-armed-sd-test-001',
+    // evaluateRow short-circuits to INTENTIONALLY_DOWN without this. All 66 real rows carrying a
+    // null last_fired_at are currently_expected_active=true, so omitting it made the fixture
+    // unlike production and every case passed through a branch under test.
+    currently_expected_active: true,
+    // EVERY real row has a created_at, and most of the blind ones are ancient (role_session:adam
+    // is ~1487 cadences old). Omitting it here made the regression guard below BLIND: a mutation
+    // that fell back to created_at when armed_at was absent — the exact 60-alarm design this SD
+    // was corrected away from — passed 6/6 against a fixture where created_at was undefined.
+    // A fixture unlike production does not merely weaken a test, it can nullify it entirely.
+    created_at: daysAgo(30),
+    liveness_source: 'self_stamped',
+    expected_interval_seconds: 24 * HOUR,
+    grace_multiplier: 2,
+    last_fired_at: null,
+    liveness_source_ref: { sd_key: 'SD-TEST-001', activation_trigger: 'when X ships' },
+    ...overrides,
+  };
+}
+
+describe('watcher FR-2: armed_never_produced', () => {
+  it('ARM 1 — armed and PAST the grace window with no stamp: OVERDUE', async () => {
+    const row = armedRow({
+      liveness_source_ref: { sd_key: 'SD-TEST-001', activation_trigger: 't', armed_at: daysAgo(5) },
+    });
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.OVERDUE);
+    expect(result.reason).toBe('armed_never_produced');
+    expect(result.armed_at).toBe(row.liveness_source_ref.armed_at);
+  });
+
+  it('ARM 2 — armed but INSIDE the grace window: UNVERIFIED, not an alarm', async () => {
+    // Same row, same code path, only the age differs. 24h interval x2 grace = 48h window; 1 day in
+    // is not yet due. Without this arm, a branch that fired unconditionally would look correct.
+    const row = armedRow({
+      liveness_source_ref: { sd_key: 'SD-TEST-001', activation_trigger: 't', armed_at: daysAgo(1) },
+    });
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.UNVERIFIED);
+    expect(result.reason).toBe('no_last_fired_data_available');
+  });
+
+  it('REGRESSION GUARD — NO armed_at, very old row, null last_fired_at: still UNVERIFIED', async () => {
+    // This is the never-false-OVERDUE acceptance criterion of
+    // SD-LEO-INFRA-DRIVE-LOOP-INSTRUMENT-001-B, held intact. It mirrors real production rows:
+    // role_session:adam/coordinator/solomon sit at ~1487 cadences elapsed with a null
+    // last_fired_at and last_state OK. An OVERDUE here means the change reached the 39
+    // non-self_stamped blind rows it must not touch.
+    const row = armedRow({
+      process_key: 'role_session:adam',
+      expected_interval_seconds: 1800,
+      liveness_source_ref: { sd_key: 'SD-OTHER-001', activation_trigger: 't' },
+    });
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.UNVERIFIED);
+    expect(result.reason).toBe('no_last_fired_data_available');
+  });
+
+  it('a MALFORMED armed_at fails soft to UNVERIFIED — an unparseable date is not evidence', async () => {
+    const row = armedRow({
+      liveness_source_ref: { sd_key: 'SD-TEST-001', activation_trigger: 't', armed_at: 'not-a-date' },
+    });
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.UNVERIFIED);
+  });
+
+  it('a null grace_multiplier does NOT produce an instant alarm', async () => {
+    // overdueThresholdMs does Number(row.grace_multiplier); Number(null) is 0, which would make
+    // every armed row instantly "past" a zero-length window. Unreachable today because the only
+    // writer of armed_at also writes grace_multiplier — which is exactly the sort of cross-file
+    // coupling a later edit severs silently.
+    const row = armedRow({
+      grace_multiplier: null,
+      liveness_source_ref: { sd_key: 'SD-TEST-001', activation_trigger: 't', armed_at: daysAgo(5) },
+    });
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.UNVERIFIED);
+  });
+
+  it('an already-stamped row is untouched by the new branch', async () => {
+    // last_fired_at non-null must still take the pre-existing age-vs-threshold path. Fresh stamp
+    // with an old armed_at: the arming time must NOT drag a healthy row into OVERDUE.
+    const row = armedRow({
+      last_fired_at: new Date(Date.now() - 60_000).toISOString(),
+      liveness_source_ref: { sd_key: 'SD-TEST-001', activation_trigger: 't', armed_at: daysAgo(90) },
+    });
+    const result = await evaluateRow(row);
+    expect(result.state).toBe(STATE.OK);
+    expect(result.reason).not.toBe('armed_never_produced');
+  });
+});


### PR DESCRIPTION
Closes **AC-8 / FR-7** of `SD-LEO-INFRA-DRIVE-LOOP-INSTRUMENT-001-B`, which shipped with that criterion recorded **UNMET**.

## The defect

A null `last_fired_at` **conflates two states** — *not due yet* and *never produced when it should have*. `periodic-liveness-watcher.mjs:247` returns `UNVERIFIED` for either, and `UNVERIFIED` escalates only past 7 continuous days. So the alarm works once a report has succeeded **once**, and is blind precisely for a report that has **never** been produced — the state at merge, and the most missing a report can be.

The coordinator ruling (`eb23a872`) dissolved the apparent FR-7-vs-never-false-OVERDUE conflict rather than picking a side: stamp the **arming time**, and the two states become distinguishable.

## Changes

**FR-1 — `lib/machinery-class/armed-registration.js`**
Writes `armed_at` into the existing `liveness_source_ref` JSONB and sets `grace_multiplier: 2` at registration.

> **`armed_at` is written once and then PRESERVED.** This function runs on *every in-window tick*. An inline `armed_at: new Date()` would reset the clock each tick, the row would never age past its grace window, and the alarm this SD exists to build **could never fire** — while every single-registration test still passed.

The same pre-read fixes a **pre-existing defect** the spine did not mention: `last_fired_at: null` was written unconditionally, so re-registering a process that *had* fired wiped its real stamp.

**FR-2 — `scripts/periodic-liveness-watcher.mjs`**
A guarded branch *inside* the existing null-`lastFiredAt` return (additive; the non-null path is provably untouched). Requires an **explicit `armed_at`**, which only registration writes.

> That requirement is the whole design, not a formality. **Measured before writing it:** of the 66 rows carrying a null `last_fired_at`, only **27** are `self_stamped`; the other 39 resolve earlier and **16 already read OK**. Keying on row age instead would emit **60 alarms, ~33 of them false** — `role_session:adam/coordinator/solomon` sit at ~1487 cadences elapsed with a null `last_fired_at` and `last_state OK`.

## Zero schema change

`periodic_process_registry` has **no `armed_at` column** (17 enumerated live), so the value rides in the existing JSONB. No migration, no chairman-gated DDL.

## Both fixes proven by mutation — and the second mutation found a blind test

| Mutation | Result |
|---|---|
| `armed_at` preservation to a bare `now()` | **Caught.** `armed_at` moved `07-31` to `08-05`. **11 of 13 tests still passed** under the defect — only the twice-register test can see it. |
| Fall back to `created_at` when `armed_at` absent | **Initially passed 6/6 — the guard was blind.** The fixture omitted `created_at` while every real row has one. Fixture corrected; the guard now fails with `OVERDUE` instead of `UNVERIFIED` on a row it must never touch. |

The second one matters more than the first: the test written specifically to prevent the 60-alarm design could not actually detect it. A fixture unlike production does not merely weaken a test — it can nullify it entirely.

**19 tests pass.** Both arms asserted on every branch (fires *and* stays quiet), per TS-1..TS-6.

## Named deferral — not silently widened, not silently dropped

**21** `self_stamped` `cron_script:*` / `standard_loop:*` rows past 2x cadence are **not reached** by this SD — they never call `registerArmedMachinery`. Includes `standard_loop:advisory-drain` at 2210x, `idle-qf-hint` at 2208x, and `gha_cron:periodic-liveness-watcher-cron.yml` at 2334x — **the watcher cannot see its own cron**. Recorded in `PRD.metadata.named_deferral`; escalated to the coordinator (signal `c6d63afe`) before this PRD was written, no ruling received.

**Honesty boundary:** those 27 rows have never *recorded a stamp*. That is either a dead process or a stamp call nobody wired — `periodic_process_registry` cannot distinguish the two, and no claim is made here that 27 loops are dead. FR-7's alarm is correct either way.

## Size

288 LOC over the 100 target: two guarded edits plus the two-sided coverage the PRD requires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
