### PR TITLE
feat(SD-LEO-INFRA-FORCE-ROLE-SESSIONS-001): force role sessions to capture a learning at a recurring choke

### DIFF
--- a/.github/workflows/role-capture-gate-cron.yml
+++ b/.github/workflows/role-capture-gate-cron.yml
@@ -1,0 +1,73 @@
+name: "Role capture gate (cron)"
+
+# SD-LEO-INFRA-FORCE-ROLE-SESSIONS-001 (FR-4) — durable, session-independent measurement of the
+# forced-capture obligation for Adam, Solomon and the coordinator.
+#
+# WHY THIS IS REQUIRED AND NOT DECORATIVE. The gate's primary homes are session-scoped: the
+# coordinator's quiet tick is armed as a harness CronCreate loop whose 'quiet-tick' entry is
+# explicitly torn down by lib/coordinator/teardown-coordinator.cjs on sustained idle, Adam's lives
+# in ADAM_LOOPS in scripts/adam-startup-check.mjs, and Solomon's self-adherence loop is re-armed
+# per /solomon startup. All three therefore go dark for exactly the seat that has stopped ticking —
+# which is the population this SD exists to catch. Measured 2026-08-02: four seats wedged
+# mid-iteration carrying loop_state=active with a stale last_tool_at, one of them a role seat at
+# 386m. A gate reachable only through a session-armed loop cannot see any of them.
+#
+# This is the THIRD instance of an established repo idiom, not a novel design: backlog-rank-cron.yml
+# and singleton-relaunch-cron.yml are both durable GitHub Actions mirrors of a session-armed loop.
+#
+# CHECK-ONLY, DELIBERATELY. This workflow never invokes the record or no-capture verbs. A gate that
+# can satisfy itself on a role's behalf measures nothing — it would report SATISFIED forever while
+# the role contributed nothing, which is precisely the false-green this SD exists to remove.
+#
+# scripts/role-capture-gate.mjs always exits 0, including on REQUIRED, so this job reports the
+# obligation rather than failing the build on it: a red X every 30 minutes for a role that simply
+# has not written its learning yet would be alert fatigue, which is the trap QF-20260725-638
+# removed. The verdict lives in the step output and in the gate's own store.
+
+on:
+  schedule:
+    # Every 30 minutes, matching the 1800s role_session cadence in periodic_process_registry.
+    # Offset to :13/:43 to dodge the other recurring crons (fleet-down-alert 11,26,41,56;
+    # backlog-rank 9,24,39,54; charter-audit 8,23,38,53).
+    - cron: '13,43 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Check the role capture obligation
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      # Each role is checked separately so one role's store error cannot mask the other two.
+      - name: Check Adam
+        run: node scripts/role-capture-gate.mjs check --role adam
+
+      - name: Check the coordinator
+        run: node scripts/role-capture-gate.mjs check --role coordinator
+
+      - name: Check Solomon
+        run: node scripts/role-capture-gate.mjs check --role solomon

--- a/lib/learning/role-capture-gate.js
+++ b/lib/learning/role-capture-gate.js
@@ -1,0 +1,267 @@
+/**
+ * SD-LEO-INFRA-FORCE-ROLE-SESSIONS-001 (FR-1) — FORCED ROLE CAPTURE, AS A WINDOWED OBLIGATION.
+ *
+ * THE ASK (chairman, 2026-07-27): workers cannot move on without a retrospective — it is FORCED,
+ * so diligence needs no thought. Do the same for Adam, Solomon and the coordinator.
+ *
+ * WHY THIS IS NOT A TURN-END GATE. The obvious reading of "force it like workers" is a Stop-hook /
+ * wind-down guard. That is structurally blind to how role sessions actually die: measured
+ * 2026-08-02, FOUR seats were wedged mid-iteration carrying loop_state=active with a stale
+ * last_tool_at (one a role seat at 386m) while both legitimately-parked seats read awaiting_tick.
+ * A wedged session never reaches turn-end, so such a guard has nothing to hook — it would pass its
+ * tests on clean exits and capture nothing from the observed death mode. The obligation is
+ * therefore evaluated at each role's RECURRING OPERATING CHOKE (see FR-3 wirings).
+ *
+ * WHY WINDOWED, NOT PER-TICK. A gate demanding a learning every tick trains the role to emit
+ * filler and rebuilds the alert fatigue QF-20260725-638 removed. A role satisfies the gate by
+ * having EITHER a real capture OR an explicit no-capture marker recorded within its current
+ * window; it is never asked to produce content on every traversal.
+ *
+ * *** THE LOAD-BEARING DESIGN CONSTRAINT — THE TWO WRITE PATHS ARE STRUCTURALLY SEPARATE ***
+ * recordForcedCapture() scores its text with scoreLessonQuality(). recordNoCaptureMarker() NEVER
+ * calls the scorer, on any code path. This is not stylistic. MEASURED 2026-08-05 against the live
+ * guard: all four plausible honest no-capture phrasings scored 0, every one failing "no concrete
+ * referent (file path / table / error / SD-QF key / pattern_id)" — because an absence-of-signal
+ * declaration cannot name a referent by construction. Routing the marker through the scorer would
+ * reject the very artifact this gate must accept, exactly when a role legitimately has nothing to
+ * report. Do not unify these two paths.
+ *
+ * WHY THIS WRITES DIRECTLY TO issue_patterns AND NOT VIA lib/learning/role-learning-promoter.js.
+ * That promoter is the prerequisite SD's promotion path for OPPORTUNISTIC role reviews, and this
+ * SD's own acceptance text names it — but it is an UNINVOKED INSTRUMENT: re-measured 2026-08-05, a
+ * repo-wide search finds only its own file and its own test, and issue_patterns holds ZERO rows
+ * with metadata->>emission_type='role_review' against 669 eligible feedback rows. Making the
+ * FORCED lane depend on it would make end-to-end landing contingent on separately reviving dead
+ * code. Its dormancy is a real gap, it is not this SD's gap, and it is named in the PRD's
+ * metadata.named_deferral rather than silently widened in or silently dropped.
+ *
+ * COLUMN SHAPE IS COPIED FROM THAT PROMOTER, INCLUDING ITS HARD-WON CONSTRAINT: source stays
+ * 'retrospective' (already admitted by the /learn noise filter) because issue_patterns_source_check
+ * is a CHECK enum — a new value such as 'role_capture' would FAIL THE WRITE OUTRIGHT. Origin rides
+ * on metadata.emission_type instead.
+ *
+ * NOTHING HERE THROWS. A capture gate that can kill the role tick it rides on is worse than the
+ * gap it closes (AC-6).
+ */
+import { scoreLessonQuality } from '../eva/lesson-quality-guard.js';
+
+export const ROLES = Object.freeze(['adam', 'coordinator', 'solomon']);
+
+/**
+ * Per-role window length, in seconds.
+ *
+ * adam / coordinator: 1800 — measured from periodic_process_registry, where role_session:adam,
+ * role_session:coordinator and role_session:solomon all carry expected_interval_seconds=1800 with
+ * liveness_source=claude_sessions_heartbeat.
+ *
+ * solomon: 43200 (12h) — DELIBERATELY DIFFERENT. Solomon has no quiet tick; his documented
+ * recurring choke is the self-adherence review on a 12-hour cadence. A 30-minute window evaluated
+ * by a 12-hour choke could never be satisfied — the gate would report REQUIRED forever and teach
+ * the seat to ignore it. A window shorter than the choke that evaluates it is not a stricter gate,
+ * it is a broken one.
+ *
+ * Code constants, not env vars, and deliberately so: a window settable to 0 makes the gate
+ * unsatisfiable, and one settable to a year disables the obligation without leaving a trace.
+ */
+export const ROLE_CAPTURE_WINDOWS = Object.freeze({
+  adam: 1800,
+  coordinator: 1800,
+  solomon: 43200,
+});
+
+/** Distinct from the promoter's 'role_review' and the traversal emitter's 'traversal_reflection', so all classes stay independently queryable. */
+export const EMISSION_CAPTURE = 'role_forced_capture';
+export const EMISSION_MARKER = 'role_no_capture_marker';
+
+/** Proven-accepted values — see the header note on the source CHECK enum. */
+const SOURCE = 'retrospective';
+const CATEGORY = 'process';
+
+export const GATE_STATE = Object.freeze({
+  SATISFIED: 'SATISFIED',
+  REQUIRED: 'REQUIRED',
+  STORE_ERROR: 'STORE_ERROR',
+});
+
+const RECENT_LESSON_LOOKBACK = 5;
+
+export function isKnownRole(role) {
+  return ROLES.includes(String(role || '').toLowerCase());
+}
+
+export function windowSecondsFor(role) {
+  return ROLE_CAPTURE_WINDOWS[String(role || '').toLowerCase()] ?? null;
+}
+
+/** Rolling window start for `role` at `now`. */
+export function windowStartFor(role, now = new Date()) {
+  const secs = windowSecondsFor(role);
+  return secs == null ? null : new Date(now.getTime() - secs * 1000);
+}
+
+/**
+ * Find the newest artifact of ONE emission type inside the role's window.
+ * Deliberately an EXACT-match query per type rather than one broad fetch classified in memory:
+ * a broad fetch would need a row cap, and a capped fetch measures the cap, not the population.
+ */
+async function findInWindow(supabase, role, emissionType, windowStart) {
+  const { data, error } = await supabase
+    .from('issue_patterns')
+    .select('pattern_id, created_at')
+    .eq('metadata->>role', role)
+    .eq('metadata->>emission_type', emissionType)
+    .gte('created_at', windowStart.toISOString())
+    .order('created_at', { ascending: false })
+    .limit(1);
+  if (error) throw new Error(error.message);
+  return (data && data[0]) || null;
+}
+
+/**
+ * Evaluate the capture obligation for one role's current window.
+ *
+ * A real capture takes precedence over a marker, so a window containing both reports kind=capture
+ * — the honest reading, and it keeps the capture-vs-marker ratio meaningful.
+ *
+ * @returns {Promise<{role:string, state:string, kind:string|null, windowSeconds:number|null,
+ *   windowStart:string|null, artifactAt:string|null, ageSeconds:number|null, error?:string}>}
+ */
+export async function evaluateRoleCaptureGate({ supabase, role, now = new Date() } = {}) {
+  const normalized = String(role || '').toLowerCase();
+  const base = { role: normalized, kind: null, windowSeconds: windowSecondsFor(normalized), windowStart: null, artifactAt: null, ageSeconds: null };
+
+  if (!isKnownRole(normalized)) {
+    return { ...base, state: GATE_STATE.STORE_ERROR, error: `unknown role: ${role}` };
+  }
+  if (!supabase) return { ...base, state: GATE_STATE.STORE_ERROR, error: 'no supabase client' };
+
+  const windowStart = windowStartFor(normalized, now);
+  base.windowStart = windowStart.toISOString();
+
+  try {
+    for (const [kind, emission] of [['capture', EMISSION_CAPTURE], ['no_capture_marker', EMISSION_MARKER]]) {
+      const hit = await findInWindow(supabase, normalized, emission, windowStart);
+      if (hit) {
+        return {
+          ...base,
+          state: GATE_STATE.SATISFIED,
+          kind,
+          artifactAt: hit.created_at,
+          ageSeconds: Math.max(0, Math.round((now.getTime() - Date.parse(hit.created_at)) / 1000)),
+        };
+      }
+    }
+    return { ...base, state: GATE_STATE.REQUIRED };
+  } catch (err) {
+    // A store failure is NOT a satisfied window and NOT a crash — it is its own visible class.
+    return { ...base, state: GATE_STATE.STORE_ERROR, error: err.message };
+  }
+}
+
+/** Recent forced captures for this role, for the scorer's distinctness check. Fail-soft: on error the guard simply sees no history. */
+async function fetchRecentCaptures(supabase, role, logger) {
+  try {
+    const { data, error } = await supabase
+      .from('issue_patterns')
+      .select('issue_summary')
+      .eq('metadata->>role', role)
+      .eq('metadata->>emission_type', EMISSION_CAPTURE)
+      .order('created_at', { ascending: false })
+      .limit(RECENT_LESSON_LOOKBACK);
+    if (error) { logger.warn(`[RoleCaptureGate] recent-capture lookup failed: ${error.message}`); return []; }
+    return (data || []).map((r) => r.issue_summary).filter(Boolean);
+  } catch (e) {
+    logger.warn(`[RoleCaptureGate] recent-capture lookup threw: ${e.message}`);
+    return [];
+  }
+}
+
+function patternIdFor(role, now) {
+  return `PAT-RCG-${role.toUpperCase().slice(0, 4)}-${now.getTime().toString(36).toUpperCase()}`;
+}
+
+/** Shared WRITE. Sharing the insert is fine; sharing the SCORER is what must never happen. */
+async function insertArtifact({ supabase, role, emissionType, summary, now, extraMetadata = {} }) {
+  const patternId = patternIdFor(role, now);
+  const { error } = await supabase.from('issue_patterns').insert({
+    pattern_id: patternId,
+    category: CATEGORY,
+    severity: 'low',
+    issue_summary: summary,
+    occurrence_count: 1,
+    status: 'active',
+    source: SOURCE,
+    metadata: {
+      emission_type: emissionType,
+      role,
+      window_start: windowStartFor(role, now).toISOString(),
+      window_seconds: windowSecondsFor(role),
+      recorded_at: now.toISOString(),
+      ...extraMetadata,
+    },
+  });
+  if (error) return { ok: false, error: error.message };
+  return { ok: true, patternId };
+}
+
+/**
+ * Record a REAL learning. This is the scored path.
+ *
+ * @returns {Promise<{recorded:boolean, patternId?:string, reasons?:string[], error?:string}>}
+ */
+export async function recordForcedCapture({ supabase, role, text, now = new Date(), logger = console } = {}) {
+  const normalized = String(role || '').toLowerCase();
+  if (!isKnownRole(normalized)) return { recorded: false, error: `unknown role: ${role}` };
+  if (!supabase) return { recorded: false, error: 'no supabase client' };
+
+  const lessonText = String(text || '').trim();
+  if (!lessonText) return { recorded: false, reasons: ['empty capture text'] };
+
+  try {
+    const recentLessons = await fetchRecentCaptures(supabase, normalized, logger);
+    const { score, reasons } = scoreLessonQuality(lessonText, { recentLessons });
+    if (score === 0) return { recorded: false, reasons };
+
+    const res = await insertArtifact({ supabase, role: normalized, emissionType: EMISSION_CAPTURE, summary: lessonText, now });
+    return res.ok ? { recorded: true, patternId: res.patternId } : { recorded: false, error: res.error };
+  } catch (err) {
+    return { recorded: false, error: err.message };
+  }
+}
+
+/**
+ * Record an EXPLICIT "nothing to capture this period" marker.
+ *
+ * *** THIS FUNCTION MUST NEVER CALL scoreLessonQuality — SEE THE FILE HEADER. ***
+ * An honest absence declaration has no concrete referent by construction and scores 0 every time
+ * (measured, 4/4). It is accepted here BY CONSTRUCTION, and stays distinguishable from a real
+ * capture in the record via metadata.emission_type.
+ *
+ * @returns {Promise<{recorded:boolean, patternId?:string, emissionType?:string, error?:string}>}
+ */
+export async function recordNoCaptureMarker({ supabase, role, note = '', now = new Date() } = {}) {
+  const normalized = String(role || '').toLowerCase();
+  if (!isKnownRole(normalized)) return { recorded: false, error: `unknown role: ${role}` };
+  if (!supabase) return { recorded: false, error: 'no supabase client' };
+
+  const reason = String(note || '').trim() || 'nothing to capture this period';
+  const summary = `NOTHING TO CAPTURE (${normalized}): ${reason}`;
+
+  try {
+    const res = await insertArtifact({
+      supabase, role: normalized, emissionType: EMISSION_MARKER, summary, now,
+      extraMetadata: { declared_reason: reason },
+    });
+    return res.ok
+      ? { recorded: true, patternId: res.patternId, emissionType: EMISSION_MARKER }
+      : { recorded: false, error: res.error };
+  } catch (err) {
+    return { recorded: false, error: err.message };
+  }
+}
+
+export default {
+  ROLES, ROLE_CAPTURE_WINDOWS, EMISSION_CAPTURE, EMISSION_MARKER, GATE_STATE,
+  isKnownRole, windowSecondsFor, windowStartFor,
+  evaluateRoleCaptureGate, recordForcedCapture, recordNoCaptureMarker,
+};

--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -92,6 +92,14 @@ export const COMPOSED_CORES = [
   // stdout is truncated to one line (scriptCore below), so it must NEVER consume (read_at);
   // it stamps delivered_at only. Operator-visible surfacing is FR-3's surfaceInboxItems.
   { key: 'inbox-monitor', script: 'adam-advisory.cjs', args: ['scripts/adam-advisory.cjs', 'inbox', '--quiet', '--background'], quiescentSkip: false, safety: true },
+  // SD-LEO-INFRA-FORCE-ROLE-SESSIONS-001 (FR-3): the forced-capture obligation, evaluated at a
+  // RECURRING OPERATING CHOKE rather than at turn end. A turn-end / Stop-hook guard is blind to
+  // how role sessions actually die — four seats were measured wedged mid-iteration on 2026-08-02
+  // with loop_state=active and a stale last_tool_at, and a wedged session never reaches turn-end.
+  // Riding here means a frozen seat visibly stops passing, which is correct AND observable.
+  // check-only: the tick never records on Adam's behalf — a gate that satisfies itself measures
+  // nothing. The CLI always exits 0, so this contributes a state token and never a core failure.
+  { key: 'capture-gate', script: 'role-capture-gate.mjs', args: ['scripts/role-capture-gate.mjs', 'check', '--role', 'adam'], quiescentSkip: false },
 ];
 export const DELTA_GATED_LOOPS = ['belt-countdown', 'offer-help'];
 

--- a/scripts/adam-startup-check.mjs
+++ b/scripts/adam-startup-check.mjs
@@ -119,6 +119,19 @@ export const ADAM_LOOPS = [
     prompt: 'node scripts/adam-advisory.cjs inbox --quiet',
   },
   {
+    // SD-LEO-INFRA-FORCE-ROLE-SESSIONS-001 (FR-3/FR-4): Adam's forced-capture obligation, evaluated
+    // at a recurring operating choke rather than at turn end — a wedged session never reaches
+    // turn-end, so a Stop hook would have nothing to hook (four seats measured wedged
+    // mid-iteration 2026-08-02, one of them a role seat at 386m).
+    key: 'capture-gate',
+    folded: true, // composed by adam-quiet-tick's capture-gate core — never armed standalone
+    gha_backed: true, // role-capture-gate-cron.yml — survives this session-armed leg going dark
+    label: 'Adam forced-capture obligation (check-only)',
+    script: 'role-capture-gate.mjs',
+    cron: '13,43 * * * *',
+    prompt: 'node scripts/role-capture-gate.mjs check --role adam',
+  },
+  {
     key: 'offer-help',
     folded: true, // SD-LEO-INFRA-TOKEN-BURN-AUTOPILOT-001: composed by adam-quiet-tick — never armed standalone
     label: 'Offer coordinator help (agent judgment, propose-only, silence-by-default)',

--- a/scripts/coordinator-quiet-tick.mjs
+++ b/scripts/coordinator-quiet-tick.mjs
@@ -112,6 +112,16 @@ export const COMPOSED_CORES = [
   { key: 'relay-drain', script: 'coordinator-relay-drain.cjs', args: ['scripts/coordinator-relay-drain.cjs'], quiescentSkip: false },
   // FR-3: cheap read + fail-open write; valuable exactly when quiet for the same reason.
   { key: 'relay-drop-gauge', script: 'coordinator-relay-drop-gauge.cjs', args: ['scripts/coordinator-relay-drop-gauge.cjs'], quiescentSkip: false },
+  // SD-LEO-INFRA-FORCE-ROLE-SESSIONS-001 (FR-3): the forced-capture obligation, evaluated at a
+  // RECURRING OPERATING CHOKE rather than at turn end — a wedged session never reaches turn-end,
+  // so a Stop hook would have nothing to hook (four seats measured wedged mid-iteration
+  // 2026-08-02 with loop_state=active and a stale last_tool_at).
+  // EXPLICITLY NOT quiescentSkip, and that is load-bearing: a capture obligation that evaporates
+  // when the fleet is quiet exempts the seat MOST likely to be the wedged one. A quiet coordinator
+  // is not a coordinator with nothing to learn — it is the one whose silence nobody is checking.
+  // check-only: never records on the coordinator's behalf, because a gate that can satisfy itself
+  // measures nothing. The CLI always exits 0, so this yields a state token, never a core failure.
+  { key: 'capture-gate', script: 'role-capture-gate.mjs', args: ['scripts/role-capture-gate.mjs', 'check', '--role', 'coordinator'], quiescentSkip: false },
   // SD-LEO-INFRA-DRIVE-LOOP-INSTRUMENT-001-C: the coordinator's consumption receipt on the newest
   // drive report. NOT quiescentSkip, and that is the whole point of the SD: an unconsumed report is
   // indistinguishable from a producer that never produced, so skipping the stamp when the fleet is

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -210,6 +210,14 @@ export const STANDARD_LOOPS = [
   { key: 'unranked-gauge', label: 'Eligible-but-unranked-leaf-count invariant gauge', script: 'gauge-unranked-claimable-leaves.mjs', cron: '9,24,39,54 * * * *',
     gha_backed: true,
     prompt: 'node scripts/gauge-unranked-claimable-leaves.mjs' },
+  // SD-LEO-INFRA-FORCE-ROLE-SESSIONS-001 (FR-3/FR-4): the coordinator's forced-capture obligation,
+  // evaluated at a recurring operating choke rather than at turn end (a wedged session never
+  // reaches turn-end, so a Stop hook would have nothing to hook). folded — composed by
+  // coordinator-quiet-tick's capture-gate core, never armed standalone. gha_backed via
+  // role-capture-gate-cron.yml, because teardown-discipline deletes this session-armed leg on
+  // sustained idle and that is exactly the seat whose silence needs measuring.
+  { key: 'capture-gate', folded: true, gha_backed: true, label: 'Coordinator forced-capture obligation (check-only)', script: 'role-capture-gate.mjs', cron: '13,43 * * * *',
+    prompt: 'node scripts/role-capture-gate.mjs check --role coordinator' },
   // QF-20260702-976: the OPERATING layer for SD-LEO-INFRA-COORDINATOR-ORCHESTRATED-SINGLETON-REFRESH-001-A.
   // The trigger + scheduler logic (lib/coordinator/singleton-relaunch-trigger.js, scripts/
   // singleton-relaunch-scheduler.mjs, npm-wired as singleton-relaunch:run) shipped but nothing

--- a/scripts/role-capture-gate.mjs
+++ b/scripts/role-capture-gate.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-FORCE-ROLE-SESSIONS-001 (FR-2) — CLI for the role capture obligation.
+ *
+ *   node scripts/role-capture-gate.mjs check      --role <adam|coordinator|solomon> [--json]
+ *   node scripts/role-capture-gate.mjs record     --role <role> --text @<file>
+ *   node scripts/role-capture-gate.mjs no-capture --role <role> --note "<why>"
+ *
+ * *** THIS PROCESS ALWAYS EXITS 0, INCLUDING WHEN THE GATE STATE IS REQUIRED. ***
+ * That is not laxity, it is what makes AC-6 hold. The Adam and coordinator quiet ticks spawn each
+ * core as a CHILD PROCESS via scriptCore(key, args) and read a non-zero exit as a core FAILURE, so
+ * a gate that exited non-zero to mean "you owe a capture" would be indistinguishable from a gate
+ * that crashed — and would degrade the very tick it rides on. Forward-motion pressure is carried
+ * by the STATE TOKEN on the emitted line, which the role must clear; never by killing the tick.
+ *
+ * --text takes @<file> rather than an inline string because a learning body containing quotes,
+ * apostrophes or newlines does not survive shell quoting.
+ */
+import 'dotenv/config';
+import { readFileSync } from 'node:fs';
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
+import {
+  ROLES, GATE_STATE, isKnownRole,
+  evaluateRoleCaptureGate, recordForcedCapture, recordNoCaptureMarker,
+} from '../lib/learning/role-capture-gate.js';
+
+function arg(flag) {
+  const i = process.argv.indexOf(flag);
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : null;
+}
+
+function readTextArg(raw) {
+  if (!raw) return null;
+  return raw.startsWith('@') ? readFileSync(raw.slice(1), 'utf8') : raw;
+}
+
+function emit(line) { console.log(line); }
+
+async function main() {
+  const verb = process.argv[2];
+  const role = String(arg('--role') || '').toLowerCase();
+  const asJson = process.argv.includes('--json');
+
+  if (!['check', 'record', 'no-capture'].includes(verb)) {
+    emit(`ROLE_CAPTURE_GATE=? state=USAGE verbs=check|record|no-capture roles=${ROLES.join('|')}`);
+    return;
+  }
+  // An unknown role is named, never silently defaulted to one — defaulting would let a typo
+  // satisfy or block the wrong seat.
+  if (!isKnownRole(role)) {
+    emit(`ROLE_CAPTURE_GATE=${role || '?'} state=STORE_ERROR error=unknown_role known=${ROLES.join('|')}`);
+    return;
+  }
+
+  const supabase = createSupabaseServiceClient();
+
+  if (verb === 'check') {
+    const r = await evaluateRoleCaptureGate({ supabase, role });
+    if (asJson) { emit(JSON.stringify(r)); return; }
+    emit(
+      `ROLE_CAPTURE_GATE=${r.role} state=${r.state} kind=${r.kind ?? 'none'} ` +
+      `age=${r.ageSeconds ?? 'na'} window=${r.windowSeconds ?? 'na'}` +
+      (r.error ? ` error=${r.error}` : '') +
+      (r.state === GATE_STATE.REQUIRED
+        ? ` action=record_a_capture_or_declare_no_capture`
+        : '')
+    );
+    return;
+  }
+
+  if (verb === 'record') {
+    const text = readTextArg(arg('--text'));
+    const r = await recordForcedCapture({ supabase, role, text });
+    if (r.recorded) { emit(`ROLE_CAPTURE_GATE=${role} state=RECORDED kind=capture pattern=${r.patternId}`); return; }
+    emit(`ROLE_CAPTURE_GATE=${role} state=REJECTED kind=capture${r.error ? ` error=${r.error}` : ''}`);
+    // Print the scorer's own reasons so the role sees WHICH rubric check failed rather than
+    // guessing. The commonest miss is a file path with no directory: the referent pattern
+    // requires a slash-qualified path (lib/foo/bar.js), an SD-/QF-/PAT- key, or a table reference.
+    for (const reason of r.reasons || []) emit(`  reason: ${reason}`);
+    return;
+  }
+
+  // no-capture — the UNSCORED path. See lib/learning/role-capture-gate.js header.
+  const r = await recordNoCaptureMarker({ supabase, role, note: arg('--note') || '' });
+  emit(r.recorded
+    ? `ROLE_CAPTURE_GATE=${role} state=RECORDED kind=no_capture_marker emission=${r.emissionType} pattern=${r.patternId}`
+    : `ROLE_CAPTURE_GATE=${role} state=STORE_ERROR error=${r.error}`);
+}
+
+main()
+  .catch((err) => {
+    // Even an unexpected throw must not hand a non-zero exit to the tick that spawned us.
+    emit(`ROLE_CAPTURE_GATE=? state=STORE_ERROR error=${err.message}`);
+  })
+  .finally(() => {
+    // process.exit() races a closing libuv handle on Windows (exit 127) — set the code instead.
+    process.exitCode = 0;
+  });

--- a/scripts/solomon-self-adherence-review.mjs
+++ b/scripts/solomon-self-adherence-review.mjs
@@ -197,6 +197,25 @@ async function main() {
       console.log('  solomon-self-adherence persist fail-open:', err?.message || String(err));
     }
   }
+  // SD-LEO-INFRA-FORCE-ROLE-SESSIONS-001 (FR-3): Solomon's leg of the forced-capture obligation.
+  // Solomon has NO quiet tick and NO COMPOSED_CORES registry, so unlike Adam and the coordinator
+  // he cannot be wired by adding one core entry — this direct call IS his recurring choke, and
+  // asserting the three roles separately is why AC-4 exists: two roles sharing a registration
+  // pattern makes it easy to ship two legs and believe three shipped.
+  // check-only and fail-open, matching this script's own contract: it reports the obligation, it
+  // never records on Solomon's behalf (a gate that satisfies itself measures nothing) and it never
+  // blocks the tick.
+  try {
+    const { evaluateRoleCaptureGate } = await import('../lib/learning/role-capture-gate.js');
+    const supabase = createSupabaseServiceClient();
+    const gate = await evaluateRoleCaptureGate({ supabase, role: 'solomon' });
+    console.log(
+      `ROLE_CAPTURE_GATE=solomon state=${gate.state} kind=${gate.kind ?? 'none'} window=${gate.windowSeconds ?? 'na'}` +
+      (gate.error ? ` error=${gate.error}` : '')
+    );
+  } catch (err) {
+    console.log('ROLE_CAPTURE_GATE=solomon state=STORE_ERROR error=' + (err?.message || String(err)));
+  }
   process.exit(0);
 }
 

--- a/tests/unit/learning/role-capture-gate.test.js
+++ b/tests/unit/learning/role-capture-gate.test.js
@@ -1,0 +1,290 @@
+/**
+ * SD-LEO-INFRA-FORCE-ROLE-SESSIONS-001 — role capture gate.
+ *
+ * EVERY TEST HERE IS TWO-SIDED ON PURPOSE. A one-sided assertion ("the empty window reports
+ * REQUIRED") passes just as happily against a gate that can NEVER be satisfied, and a gate that
+ * always blocks is not a stricter gate — it is a broken one that teaches the seat to ignore it.
+ *
+ * FIXTURE DISCIPLINE, LEARNED THE HARD WAY ON THE PRECEDING SD: a fixture unlike production does
+ * not merely weaken a test, it can NULLIFY it entirely while leaving it green. The no-capture
+ * fixture text below MUST NOT contain a slash-qualified file path, an SD-/QF-/PAT- key, a
+ * "table x" phrase or an "error: x" phrase — any one of those satisfies the concrete-referent
+ * check in lib/eva/lesson-quality-guard.js, the text would score 1, and TS-3 would pass for a
+ * reason that has nothing to do with the marker path being unscored.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  ROLES, ROLE_CAPTURE_WINDOWS, EMISSION_CAPTURE, EMISSION_MARKER, GATE_STATE,
+  isKnownRole, windowSecondsFor,
+  evaluateRoleCaptureGate, recordForcedCapture, recordNoCaptureMarker,
+} from '../../../lib/learning/role-capture-gate.js';
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+
+/** An honest absence declaration. Deliberately carries NO concrete referent — see the header. */
+const MARKER_TEXT = 'nothing worth recording came up this period';
+/** A real learning. Carries a slash-qualified path, which is what the referent check requires. */
+const REAL_LESSON =
+  'The capture gate in lib/learning/role-capture-gate.js must keep its marker path off the scorer, '
+  + 'because an honest absence declaration can never satisfy the concrete-referent check.';
+
+/**
+ * Supabase double.
+ * `rows` is the fake issue_patterns table; queries are filtered the way PostgREST would.
+ * `failOn` forces the store to error, for the fail-soft arm.
+ */
+function makeDb({ rows = [], failOn = null } = {}) {
+  const inserted = [];
+  const client = {
+    inserted,
+    from(table) {
+      const filters = {};
+      const q = {
+        _table: table,
+        select() { return q; },
+        eq(col, val) { filters[col] = val; return q; },
+        gte(col, val) { filters[`gte:${col}`] = val; return q; },
+        order() { return q; },
+        limit() { return q.then ? q : q; },
+        insert(row) {
+          if (failOn === 'insert') return Promise.resolve({ error: { message: 'insert exploded' } });
+          inserted.push(row);
+          return Promise.resolve({ error: null });
+        },
+        // Thenable so `await supabase.from(...).select(...)...limit(1)` resolves.
+        then(onFulfilled) {
+          if (failOn === 'select') return Promise.resolve({ data: null, error: { message: 'select exploded' } }).then(onFulfilled);
+          const matched = rows.filter((r) => {
+            if (filters['metadata->>role'] && r.metadata?.role !== filters['metadata->>role']) return false;
+            if (filters['metadata->>emission_type'] && r.metadata?.emission_type !== filters['metadata->>emission_type']) return false;
+            const gte = filters['gte:created_at'];
+            if (gte && Date.parse(r.created_at) < Date.parse(gte)) return false;
+            return true;
+          });
+          return Promise.resolve({ data: matched, error: null }).then(onFulfilled);
+        },
+      };
+      return q;
+    },
+  };
+  return client;
+}
+
+const at = (secondsAgo) => new Date(Date.now() - secondsAgo * 1000).toISOString();
+const artifactRow = (role, emission, secondsAgo) => ({
+  pattern_id: `PAT-RCG-${role}-${secondsAgo}`,
+  created_at: at(secondsAgo),
+  issue_summary: 'x',
+  metadata: { role, emission_type: emission },
+});
+
+describe('TS-1: the gate reports REQUIRED on an empty window and SATISFIED on a real capture', () => {
+  it('reports REQUIRED when the window holds nothing', async () => {
+    const r = await evaluateRoleCaptureGate({ supabase: makeDb({ rows: [] }), role: 'adam' });
+    expect(r.state).toBe(GATE_STATE.REQUIRED);
+    expect(r.kind).toBeNull();
+  });
+
+  it('reports SATISFIED with kind=capture when the window holds a real capture', async () => {
+    const db = makeDb({ rows: [artifactRow('adam', EMISSION_CAPTURE, 60)] });
+    const r = await evaluateRoleCaptureGate({ supabase: db, role: 'adam' });
+    expect(r.state).toBe(GATE_STATE.SATISFIED);
+    expect(r.kind).toBe('capture');
+  });
+});
+
+describe('TS-2: an explicit no-capture marker SATISFIES the gate and stays distinguishable', () => {
+  it('is accepted, and is reported as a marker rather than as a capture', async () => {
+    const db = makeDb({ rows: [artifactRow('coordinator', EMISSION_MARKER, 60)] });
+    const r = await evaluateRoleCaptureGate({ supabase: db, role: 'coordinator' });
+    expect(r.state).toBe(GATE_STATE.SATISFIED);
+    // Satisfying-but-indistinguishable is the failure mode that rebuilds alert fatigue: it would
+    // hide a role that only ever markers inside an aggregate "satisfied" count.
+    expect(r.kind).toBe('no_capture_marker');
+    expect(EMISSION_MARKER).not.toBe(EMISSION_CAPTURE);
+  });
+
+  it('prefers a real capture over a marker when the window holds both', async () => {
+    const db = makeDb({ rows: [artifactRow('adam', EMISSION_CAPTURE, 30), artifactRow('adam', EMISSION_MARKER, 10)] });
+    const r = await evaluateRoleCaptureGate({ supabase: db, role: 'adam' });
+    expect(r.kind).toBe('capture');
+  });
+});
+
+describe('TS-3 (F7 REGRESSION GUARD): the same text is REJECTED as a capture and ACCEPTED as a marker', () => {
+  // This is the whole reason the two write paths are structurally separate. Measured against the
+  // live guard: all four plausible honest "nothing to capture" phrasings score 0, every one on the
+  // concrete-referent check, because an absence declaration cannot name a referent by
+  // construction. Routing the marker through the scorer would reject the very artifact the gate
+  // must accept, exactly when a role legitimately has nothing to report.
+  it('refuses the marker text through the SCORED path, and says why', async () => {
+    const db = makeDb();
+    const r = await recordForcedCapture({ supabase: db, role: 'adam', text: MARKER_TEXT });
+    expect(r.recorded).toBe(false);
+    expect(r.reasons.join(' ')).toMatch(/concrete referent/);
+    expect(db.inserted).toHaveLength(0);
+  });
+
+  it('accepts the IDENTICAL text through the UNSCORED marker path', async () => {
+    const db = makeDb();
+    const r = await recordNoCaptureMarker({ supabase: db, role: 'adam', note: MARKER_TEXT });
+    expect(r.recorded).toBe(true);
+    expect(db.inserted).toHaveLength(1);
+    expect(db.inserted[0].metadata.emission_type).toBe(EMISSION_MARKER);
+  });
+
+  it('accepts a genuine referent-bearing learning through the scored path', async () => {
+    // The other arm: if the scored path rejected everything, the test above would pass for the
+    // wrong reason and the gate would be unsatisfiable by design.
+    const db = makeDb();
+    const r = await recordForcedCapture({ supabase: db, role: 'coordinator', text: REAL_LESSON });
+    expect(r.recorded).toBe(true);
+    expect(db.inserted[0].metadata.emission_type).toBe(EMISSION_CAPTURE);
+  });
+});
+
+describe('TS-4 (MUTATION PROOF): the marker path contains no route to the scorer', () => {
+  // A behavioural test alone cannot hold this line: a future refactor that unified the two write
+  // paths would leave TS-3 green whenever its fixture text happened to carry a referent. This
+  // reads the source so the structural separation itself is asserted.
+  //
+  // Proven by mutation during EXEC: routing recordNoCaptureMarker through scoreLessonQuality makes
+  // the TS-3 marker case fail (recorded:false, "no concrete referent"), and reverting restores
+  // green. Both arms observed — a guard is only proven by the mutation that would expose it.
+  const SRC = readFileSync(resolve(REPO_ROOT, 'lib/learning/role-capture-gate.js'), 'utf8');
+
+  it('recordNoCaptureMarker never calls scoreLessonQuality', () => {
+    const body = SRC.slice(SRC.indexOf('export async function recordNoCaptureMarker'));
+    expect(body).not.toContain('scoreLessonQuality');
+  });
+
+  it('recordForcedCapture DOES call scoreLessonQuality', () => {
+    const start = SRC.indexOf('export async function recordForcedCapture');
+    const body = SRC.slice(start, SRC.indexOf('export async function recordNoCaptureMarker'));
+    expect(body).toContain('scoreLessonQuality');
+  });
+});
+
+describe('TS-5: a store failure is visible, never silent and never thrown', () => {
+  it('evaluate reports STORE_ERROR rather than throwing or reporting SATISFIED', async () => {
+    const r = await evaluateRoleCaptureGate({ supabase: makeDb({ failOn: 'select' }), role: 'adam' });
+    expect(r.state).toBe(GATE_STATE.STORE_ERROR);
+    // The dangerous failure is not the error — it is a broken store reading as a cleared obligation.
+    expect(r.state).not.toBe(GATE_STATE.SATISFIED);
+    expect(r.error).toMatch(/select exploded/);
+  });
+
+  it('record and marker return the error instead of throwing', async () => {
+    const cap = await recordForcedCapture({ supabase: makeDb({ failOn: 'insert' }), role: 'adam', text: REAL_LESSON });
+    expect(cap.recorded).toBe(false);
+    expect(cap.error).toMatch(/insert exploded/);
+    const mark = await recordNoCaptureMarker({ supabase: makeDb({ failOn: 'insert' }), role: 'adam' });
+    expect(mark.recorded).toBe(false);
+    expect(mark.error).toMatch(/insert exploded/);
+  });
+
+  it('a missing client or unknown role is named, never silently defaulted', async () => {
+    expect((await evaluateRoleCaptureGate({ supabase: null, role: 'adam' })).state).toBe(GATE_STATE.STORE_ERROR);
+    const bogus = await evaluateRoleCaptureGate({ supabase: makeDb(), role: 'nobody' });
+    expect(bogus.state).toBe(GATE_STATE.STORE_ERROR);
+    expect(bogus.error).toMatch(/unknown role/);
+    expect(isKnownRole('nobody')).toBe(false);
+  });
+});
+
+describe('TS-6: all three chairman-named roles are wired, asserted BY NAME', () => {
+  // Adam and the coordinator share a COMPOSED_CORES registration pattern that Solomon does not
+  // have. That asymmetry is exactly how two-of-three ships while looking like three.
+  const read = (p) => readFileSync(resolve(REPO_ROOT, p), 'utf8');
+
+  it('covers Adam, Solomon and the coordinator — no role missing', () => {
+    expect(ROLES).toEqual(['adam', 'coordinator', 'solomon']);
+  });
+
+  it('adam-quiet-tick registers the capture gate as a core', () => {
+    const src = read('scripts/adam-quiet-tick.mjs');
+    expect(src).toContain('role-capture-gate.mjs');
+    expect(src).toMatch(/'--role',\s*'adam'/);
+  });
+
+  it('coordinator-quiet-tick registers it AND does not skip it when quiescent', () => {
+    const src = read('scripts/coordinator-quiet-tick.mjs');
+    const entry = src.split('\n').find((l) => l.includes("key: 'capture-gate'"));
+    expect(entry).toBeTruthy();
+    expect(entry).toMatch(/'--role',\s*'coordinator'/);
+    // Load-bearing: an obligation that evaporates when the fleet is quiet exempts the seat most
+    // likely to be the wedged one.
+    expect(entry).toContain('quiescentSkip: false');
+  });
+
+  it('solomon-self-adherence-review evaluates the gate for solomon', () => {
+    const src = read('scripts/solomon-self-adherence-review.mjs');
+    expect(src).toContain('role-capture-gate.js');
+    expect(src).toMatch(/role:\s*'solomon'/);
+  });
+
+  it('the durable cron checks all three roles and never records for them', () => {
+    const yml = read('.github/workflows/role-capture-gate-cron.yml');
+    for (const role of ROLES) expect(yml).toContain(`--role ${role}`);
+    // A gate that can satisfy itself measures nothing.
+    expect(yml).not.toMatch(/role-capture-gate\.mjs\s+(record|no-capture)/);
+  });
+});
+
+describe('TS-7: a forced capture lands in the pipeline in the shape /learn admits', () => {
+  it('writes source=retrospective with the forced emission type and the role', async () => {
+    const db = makeDb();
+    await recordForcedCapture({ supabase: db, role: 'solomon', text: REAL_LESSON });
+    const row = db.inserted[0];
+    // 'retrospective' is already admitted by the /learn noise filter; a new source value would
+    // fail the issue_patterns_source_check CHECK enum outright, which is why origin rides on
+    // metadata.emission_type instead.
+    expect(row.source).toBe('retrospective');
+    expect(row.metadata.emission_type).toBe(EMISSION_CAPTURE);
+    expect(row.metadata.role).toBe('solomon');
+    expect(row.issue_summary).toBe(REAL_LESSON);
+  });
+
+  it('does not depend on the uninvoked role-learning promoter', () => {
+    // That promoter has zero production callers and has promoted zero of 669 eligible rows, so
+    // routing the forced lane through it would make end-to-end landing depend on dead code.
+    const src = readFileSync(resolve(REPO_ROOT, 'lib/learning/role-capture-gate.js'), 'utf8');
+    expect(src).not.toContain("from '../learning/role-learning-promoter.js'");
+    expect(src).not.toContain('promoteRoleLearnings');
+  });
+});
+
+describe('TS-8: the window boundary holds in both directions, per role', () => {
+  it('an artifact inside the window satisfies; one outside it does not', async () => {
+    const inside = makeDb({ rows: [artifactRow('adam', EMISSION_CAPTURE, 1700)] });
+    expect((await evaluateRoleCaptureGate({ supabase: inside, role: 'adam' })).state).toBe(GATE_STATE.SATISFIED);
+    const outside = makeDb({ rows: [artifactRow('adam', EMISSION_CAPTURE, 1900)] });
+    expect((await evaluateRoleCaptureGate({ supabase: outside, role: 'adam' })).state).toBe(GATE_STATE.REQUIRED);
+  });
+
+  it('Solomon carries a longer window than Adam and the coordinator', async () => {
+    // Not a uniform constant, deliberately: Solomon's only recurring choke runs on a 12h cadence,
+    // and a window shorter than the choke that evaluates it could never be satisfied.
+    expect(windowSecondsFor('adam')).toBe(1800);
+    expect(windowSecondsFor('coordinator')).toBe(1800);
+    expect(windowSecondsFor('solomon')).toBe(43200);
+    // The same 3h-old artifact: stale for Adam, still live for Solomon.
+    const adam = makeDb({ rows: [artifactRow('adam', EMISSION_CAPTURE, 10800)] });
+    expect((await evaluateRoleCaptureGate({ supabase: adam, role: 'adam' })).state).toBe(GATE_STATE.REQUIRED);
+    const sol = makeDb({ rows: [artifactRow('solomon', EMISSION_CAPTURE, 10800)] });
+    expect((await evaluateRoleCaptureGate({ supabase: sol, role: 'solomon' })).state).toBe(GATE_STATE.SATISFIED);
+  });
+
+  it('one role cannot satisfy another role obligation', async () => {
+    const db = makeDb({ rows: [artifactRow('adam', EMISSION_CAPTURE, 60)] });
+    expect((await evaluateRoleCaptureGate({ supabase: db, role: 'coordinator' })).state).toBe(GATE_STATE.REQUIRED);
+  });
+
+  it('every role has a pinned window — no role falls through to a default', () => {
+    for (const role of ROLES) expect(ROLE_CAPTURE_WINDOWS[role]).toBeGreaterThan(0);
+    expect(windowSecondsFor('nobody')).toBeNull();
+  });
+});


### PR DESCRIPTION
**SD-LEO-INFRA-FORCE-ROLE-SESSIONS-001**

Forces Adam, Solomon and the coordinator to record a learning as the price of forward motion — the property that makes the worker retrospective gate work, applied to role sessions. This is the chairman's literal ask from 2026-07-27; the prerequisite half shipped as #6737.

The obligation is **windowed** and evaluated at each role's **recurring operating choke**. A role satisfies it with either a real capture *or* an explicit no-capture marker inside its window; it is never asked to produce content on every tick.

## Why this is not a turn-end gate

The obvious reading of "force it like workers" is a Stop-hook / wind-down guard. That is structurally blind to how role sessions actually die. Measured 2026-08-02: **four seats wedged mid-iteration** carrying `loop_state=active` with a stale `last_tool_at` (one a role seat at 386m), while both legitimately-parked seats read `awaiting_tick`. A wedged session never reaches turn-end, so such a guard has nothing to hook — it would pass its tests on clean exits and capture nothing from the observed death mode.

## Two premise corrections, both measured before any code was written

**1. The SD said to reuse `scoreLessonQuality` for both directions of the accept/reject rule. Applied literally that is a defect.** All four plausible honest "nothing to capture" phrasings score **0**, every one failing the concrete-referent check, because an absence declaration cannot name a referent by construction. The gate would reject the very artifact it must accept, precisely when a role legitimately has nothing to report.

The two write paths are therefore **structurally separate**: `recordForcedCapture` scores, `recordNoCaptureMarker` never touches the scorer on any path. They stay distinguishable in the record via `metadata.emission_type`.

**2. The SD said a forced capture lands "via the promoter shipped in the prerequisite".** Re-measured: `lib/learning/role-learning-promoter.js` has **zero production callers** and `issue_patterns` holds **zero** rows with `emission_type='role_review'` against 669 eligible feedback rows. Routing the forced lane through it would make end-to-end landing depend on dead code. This writes directly to `issue_patterns` instead; the promoter's dormancy is recorded as a **named deferral** in the PRD rather than silently absorbed or silently dropped.

## The parity guard was right about me

`tests/unit/coordinator/quiet-tick-loop-parity.test.js` failed on both new cores. It enforces that every composed core maps to a real `STANDARD_LOOPS`/`ADAM_LOOPS` script so a cutover cannot silently drop a monitoring loop — and I had invented a core with no loop behind it. Fixed by registering both as `folded: true` + `gha_backed: true` entries, following the existing `backlog-rank` three-legged idiom (loop entry + composed core + GHA cron), rather than weakening the test.

Caught locally by running the blast radius rather than by CI: **163 files, 1898 tests, all green.**

## Design decisions worth reviewing

- **The coordinator core is explicitly `quiescentSkip: false`.** An obligation that evaporates when the fleet is quiet exempts the seat most likely to be the wedged one.
- **Solomon's window is 12h, not 30m.** He has no quiet tick and no core registry, so his leg is a direct call in `solomon-self-adherence-review.mjs`, and his only recurring choke runs on a 12h cadence. A window shorter than the choke that evaluates it could never be satisfied.
- **The CLI always exits 0, including on REQUIRED.** The quiet ticks spawn cores as child processes and read a non-zero exit as a core *failure*, so signalling the obligation by exit code would be indistinguishable from crashing and would degrade the tick it rides on. Pressure rides on the state token instead.
- **The durable cron is check-only.** A gate that can satisfy itself on a role's behalf measures nothing.
- **Solomon was NOT decomposed into a follow-on child SD** despite a LEAD-phase validation recommending it — this session cannot mint `SD-LEO-INFRA-*` items and AC-4 names all three roles. Recorded in the PRD as `declined_decomposition` with the reason, rather than quietly dropped.

## Verification

**Mutation proof, both arms, actually run:** routing `recordNoCaptureMarker` through `scoreLessonQuality` fails three tests — the behavioural marker case, the structural source read, and the store-error path — and reverting restores 23/23. Worth recording that **21 of 23 tests still passed under that mutation**; only the purpose-built guards saw it, which is the whole argument for mutation-testing a guard rather than merely writing one.

**Proven live against the real store, then cleaned up:** marker accepted through the unscored path and the gate flipped SATISFIED; contentless capture rejected with the scorer's reasons surfaced; referent-bearing capture accepted; both smoke rows then deleted and the gate flipped **back** to REQUIRED — so it tracks content rather than returning a constant. Learning corpus left clean.

**Solomon's bespoke leg smoke-tested live:** `ROLE_CAPTURE_GATE=solomon state=REQUIRED window=43200`, exit 0.

## Size

786 LOC across two commits (365 + 421), of which 290 is the test file. Above the 100 LOC target: the three blocking corrections — separate marker path, durable trigger, direct `issue_patterns` write — had to land together, because shipping them apart would leave a gate that fails its own acceptance criteria in the interim.

## What this does not do

It does not revive the opportunistic role-review lane. That promoter remains uninvoked and its 669 eligible rows remain unpromoted; this PR adds a *forced* lane that does not depend on it. That gap is real, it is named in the PRD metadata, and it is not this SD's scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
