### PR TITLE
fix(QF-20260727-714): add an audited zero-code completion path

### DIFF
--- a/scripts/modules/complete-quick-fix/cli.js
+++ b/scripts/modules/complete-quick-fix/cli.js
@@ -117,6 +117,14 @@ export function parseArguments(args) {
       // audited escape hatch for the rare case that still needs to merge immediately.
       'skip-ci-wait':       { type: 'boolean' },
       'reason':             { type: 'string' },
+      // QF-20260727-714: a QF whose deliverable is a DB write, a refutation, or a decision has
+      // NO commit and NO PR — and validatePR unconditionally requires a github.com URL, so the
+      // harness could not complete it at all. --auto-pr is not a path either: it merely DEFERS
+      // validation until a post-push `gh pr create`, which correctly refuses with "No commits
+      // between main and main" on an empty branch. The only remaining route was a coordinator
+      // hand-writing the row out-of-band. This flag replaces that hand-write with an audited one.
+      'no-code-deliverable':  { type: 'boolean' },
+      'deliverable-evidence': { type: 'string' },
       // QF-20260604-479: explicit override to complete a QF with an EMPTY branch diff
       // (false-completion guard). The ONLY way past the guard; NOT bypassable by --force-complete.
       'allow-empty-diff':   { type: 'boolean' },
@@ -147,6 +155,19 @@ export function parseArguments(args) {
     throw new Error(
       '[FORCE_COMPLETE_NO_REASON] --force-complete requires --reason "<text>". ' +
       'The reason is recorded in verification_notes as a structured audit trail.'
+    );
+  }
+
+  // QF-20260727-714: --no-code-deliverable REQUIRES --deliverable-evidence, mirroring the
+  // force-complete/--reason contract above. A no-code completion with no stated evidence is a
+  // vanity completion — the exact "signal-production accepted as work-production" failure this
+  // repo keeps re-finding — and it would turn this flag into a universal PR-requirement bypass.
+  // The evidence string is what a reader uses to check the deliverable actually landed.
+  if (values['no-code-deliverable'] && !values['deliverable-evidence']) {
+    throw new Error(
+      '[NO_CODE_DELIVERABLE_NO_EVIDENCE] --no-code-deliverable requires --deliverable-evidence "<text>". ' +
+      'State WHERE the deliverable landed (table + row id, decision record, or refuting measurement) — ' +
+      'it is recorded in verification_notes as the standing audit trail.'
     );
   }
 
@@ -228,6 +249,10 @@ export function parseArguments(args) {
     // QF-20260702-515: separate CI-wait bypass; only takes effect alongside forceComplete.
     skipCiWait:        values['skip-ci-wait']     || false,
     reason:            values['reason'],
+    // QF-20260727-714: zero-code completion path. Guaranteed to carry evidence by the
+    // NO_CODE_DELIVERABLE_NO_EVIDENCE check above, so downstream may rely on it being present.
+    noCodeDeliverable:  values['no-code-deliverable'] || false,
+    deliverableEvidence: values['deliverable-evidence'],
     overCapReason:     values['over-cap-reason']   || undefined,
     acceptComplianceWarn: values['accept-compliance-warn'] || false,
     acceptLowConfidence: values['accept-low-confidence'] || false,
@@ -277,6 +302,14 @@ Options:
   --uat-verified        UAT verified (yes/no, will prompt if not provided)
   --verification-notes  Optional notes about verification
   --force-complete      Bypass self-verification + LOC-cap blocks; sets quick_fixes.force_completed=true.
+  --no-code-deliverable Complete a QF whose deliverable is NOT a code change (a DB write, a
+                        refutation, a decision). Skips the PR requirement ONLY for this path —
+                        validatePR and the normal path are unchanged. Sets force_completed=true.
+                        REQUIRES --deliverable-evidence.
+  --deliverable-evidence
+                        Required with --no-code-deliverable. State WHERE the deliverable landed
+                        (table + row id, decision record, refuting measurement). Recorded in
+                        verification_notes; it is the only artifact a reader can audit.
                         REQUIRES --reason "<text>". Used for already-merged PRs or audit-trailed exceptions.
                         Does NOT skip waiting for CI to complete before an auto-merge — see --skip-ci-wait.
   --skip-ci-wait        Skip the wait-for-CI-completion gate that --force-complete otherwise enforces

--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -699,15 +699,26 @@ export async function completeQuickFix(qfId, options = {}) {
   // against an unpushed/commit-less branch and then wedged on the PR-URL prompt
   // under --non-interactive. Only the PR-creation side effect moves — the commit
   // still happens after verification (this is NOT the commit-before-verify reorder).
-  const deferAutoPr = !prUrl && options.autoPr;
+  // QF-20260727-714: --no-code-deliverable suppresses auto-PR entirely. A zero-code QF has an
+  // empty branch, so a deferred `gh pr create` would correctly refuse ("No commits between main
+  // and main") — and suppressing it here also keeps the SECOND validatePR (in the deferAutoPr
+  // block further down) unreachable on this path, rather than patching two gates that must stay
+  // in agreement.
+  const deferAutoPr = !prUrl && options.autoPr && !options.noCodeDeliverable;
 
-  if (!prUrl && !options.autoPr) {
+  if (!prUrl && !options.autoPr && !options.noCodeDeliverable) {
     const prInput = await prompt('\nGitHub PR URL (required): ');
     prUrl = prInput.trim();
   }
 
   // When the PR will be auto-created post-push, there is no URL to validate yet.
-  if (!deferAutoPr && !validatePR(prUrl, qfId, qf.title)) {
+  //
+  // QF-20260727-714: --no-code-deliverable also skips it, because the deliverable is a DB write,
+  // a refutation, or a decision — there is nothing to commit and a PR URL could only be
+  // fabricated. THE NORMAL PATH IS UNCHANGED: without this flag a PR is still mandatory, and
+  // validatePR itself is untouched, so this is a scoped exemption rather than a weakened guard.
+  // The flag cannot be passed without --deliverable-evidence (enforced in cli.js).
+  if (!deferAutoPr && !options.noCodeDeliverable && !validatePR(prUrl, qfId, qf.title)) {
     process.exit(1);
   }
 
@@ -913,6 +924,20 @@ export async function completeQuickFix(qfId, options = {}) {
       timestamp: new Date().toISOString(),
       operator_supplied_notes: verificationNotes || null
     });
+  } else if (options.noCodeDeliverable) {
+    // QF-20260727-714: audit-trail the zero-code completion. THE EVIDENCE IS THE WHOLE POINT —
+    // it is the only artifact a reader can use to check the deliverable actually landed, because
+    // there is no commit, no diff and no PR to inspect. cli.js refuses the flag without it, so
+    // this field is never empty. no_pr_reason records WHY the PR requirement was exempted rather
+    // than leaving a reader to infer that the gate simply failed to run.
+    finalVerificationNotes = JSON.stringify({
+      no_code_deliverable: true,
+      deliverable_evidence: options.deliverableEvidence,
+      no_pr_reason: 'deliverable is not a code change — no commit exists to open a PR against',
+      operator: process.env.CLAUDE_SESSION_ID || 'unknown',
+      timestamp: new Date().toISOString(),
+      operator_supplied_notes: verificationNotes || null
+    });
   }
 
   const { error: updateError } = await supabase
@@ -922,7 +947,12 @@ export async function completeQuickFix(qfId, options = {}) {
       actual_loc: actualLoc,
       actual_source_loc: actualSourceLoc,
       actual_test_loc: actualTestLoc,
-      force_completed: Boolean(options.forceComplete),
+      // QF-20260727-714: a no-code completion is force_completed too. The row's
+      // completed_requires_verification CHECK is satisfied WITHOUT fabricating uat_verified or a
+      // commit — same contract this file already documents for --force-complete. Marking it
+      // force_completed is also the honest label: no PR was reviewed and no diff was merged, so
+      // the row must not read like an ordinary verified completion.
+      force_completed: Boolean(options.forceComplete || options.noCodeDeliverable),
       commit_sha: commitSha,
       branch_name: branchName,
       pr_url: finalPrUrl,

--- a/tests/unit/complete-quick-fix/qf-779-autopr-branch-order.test.js
+++ b/tests/unit/complete-quick-fix/qf-779-autopr-branch-order.test.js
@@ -40,7 +40,16 @@ describe('QF-20260603-778 A1: --auto-pr defers PR creation until AFTER commit+pu
 
   it('the PR-URL prompt is SKIPPED under --auto-pr (gated by !options.autoPr)', () => {
     // Corrected shape: `if (!prUrl && !options.autoPr) { prompt(...) }`
-    expect(src).toMatch(/if \(!prUrl && !options\.autoPr\)[\s\S]*?GitHub PR URL/);
+    //
+    // QF-20260727-714: the tail of the condition is no longer pinned. This assertion protects ONE
+    // contract — that --auto-pr suppresses the PR-URL prompt — but it was written as a literal
+    // match on the whole condition, so it also froze the condition against ever gaining another
+    // skip clause. Adding --no-code-deliverable (a second, unrelated reason to skip the prompt)
+    // broke it while leaving the auto-pr contract fully intact. Pinning `!prUrl && !options.autoPr`
+    // as a PREFIX keeps the real guarantee and stops the test failing on additions it does not
+    // actually care about. Deliberately NOT relaxed to "mentions autoPr somewhere" — the ordering
+    // and the !prUrl conjunction are both part of what QF-779 fixed.
+    expect(src).toMatch(/if \(!prUrl && !options\.autoPr[^)]*\)[\s\S]*?GitHub PR URL/);
   });
 
   it('createAutoPR is DEFERRED until AFTER commitAndPushChanges (branch is pushed first)', () => {

--- a/tests/unit/scripts/complete-quick-fix-no-code-deliverable.test.js
+++ b/tests/unit/scripts/complete-quick-fix-no-code-deliverable.test.js
@@ -1,0 +1,85 @@
+/**
+ * QF-20260727-714 — completing a QF whose deliverable is not code.
+ *
+ * validatePR unconditionally requires a github.com URL, so a QF delivering a DB write, a
+ * refutation, or a decision could not be completed by the harness at all. --auto-pr is not a
+ * path: it DEFERS validation to a post-push `gh pr create`, which correctly refuses with
+ * "No commits between main and main" on an empty branch. The only remaining route was a
+ * coordinator hand-writing the row out-of-band — twice observed (QF-20260727-154, and
+ * QF-20260727-344 closed by direct row write on 2026-08-04).
+ *
+ * The danger in fixing it is obvious: an unguarded exemption turns the PR requirement off for
+ * everyone. So the tests are TWO-SIDED — the flag must be refused without evidence, AND the
+ * normal path must still demand a PR. Either assertion alone would pass on a broken fix.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseArguments } from '../../../scripts/modules/complete-quick-fix/cli.js';
+import { validatePR } from '../../../scripts/modules/complete-quick-fix/verification.js';
+
+const QF = 'QF-20260727-714';
+
+describe('QF-714 — the flag cannot be used without evidence', () => {
+  it('REFUSES --no-code-deliverable with no --deliverable-evidence', () => {
+    // THE LOAD-BEARING ASSERTION. An evidence-free no-code completion is a vanity completion:
+    // nothing to review, nothing to audit, and the PR gate silently off.
+    expect(() => parseArguments([QF, '--no-code-deliverable']))
+      .toThrow(/NO_CODE_DELIVERABLE_NO_EVIDENCE/);
+  });
+
+  it('the refusal names the flag that fixes it', () => {
+    expect(() => parseArguments([QF, '--no-code-deliverable']))
+      .toThrow(/--deliverable-evidence/);
+  });
+
+  it('CONTROL — with evidence it parses, so the refusal is a guard and not a dead flag', () => {
+    const { options } = parseArguments([QF, '--no-code-deliverable', '--deliverable-evidence', 'wrote feedback row b307d75b']);
+    expect(options.noCodeDeliverable).toBe(true);
+    expect(options.deliverableEvidence).toBe('wrote feedback row b307d75b');
+  });
+
+  it('defaults to OFF when the flag is absent', () => {
+    const { options } = parseArguments([QF, '--pr-url', 'https://github.com/o/r/pull/1']);
+    expect(options.noCodeDeliverable).toBe(false);
+    expect(options.deliverableEvidence).toBeUndefined();
+  });
+});
+
+describe('QF-714 — the normal path is untouched', () => {
+  it('validatePR STILL rejects a missing or non-github URL', () => {
+    // The fix exempts a scoped path; it must not weaken the predicate itself. If this ever goes
+    // green for a bad URL, the exemption has become a universal bypass.
+    expect(validatePR(undefined, QF, 't')).toBe(false);
+    expect(validatePR('', QF, 't')).toBe(false);
+    expect(validatePR('https://gitlab.com/o/r/merge_requests/1', QF, 't')).toBe(false);
+  });
+
+  it('validatePR still accepts a real PR URL', () => {
+    expect(validatePR('https://github.com/rickfelix/EHG_Engineer/pull/6824', QF, 't')).toBe(true);
+  });
+
+  it('--deliverable-evidence alone does NOT enable the exemption', () => {
+    // Guards against the inverse mistake: treating the presence of evidence as the switch, which
+    // would let an ordinary code QF skip its PR by passing a note.
+    const { options } = parseArguments([QF, '--deliverable-evidence', 'some note']);
+    expect(options.noCodeDeliverable).toBe(false);
+  });
+});
+
+describe('QF-714 — the completion is labelled honestly', () => {
+  it('force_completed is set for a no-code completion', async () => {
+    // No PR was reviewed and no diff merged, so the row must not read like an ordinary verified
+    // completion. force_completed also satisfies completed_requires_verification WITHOUT
+    // fabricating uat_verified — the contract this file already documents for --force-complete.
+    const src = await import('node:fs').then((fs) =>
+      fs.readFileSync('scripts/modules/complete-quick-fix/orchestrator.js', 'utf8'));
+    expect(src).toMatch(/force_completed:\s*Boolean\(options\.forceComplete\s*\|\|\s*options\.noCodeDeliverable\)/);
+  });
+
+  it('the evidence is persisted to verification_notes, not just accepted', () => {
+    // Accepting evidence and dropping it would leave the completion unauditable — the exact
+    // failure this QF exists to fix, with an extra flag.
+    const src = require('node:fs').readFileSync('scripts/modules/complete-quick-fix/orchestrator.js', 'utf8');
+    expect(src).toMatch(/deliverable_evidence:\s*options\.deliverableEvidence/);
+    expect(src).toMatch(/no_code_deliverable:\s*true/);
+  });
+});


### PR DESCRIPTION
## Summary

A QF whose deliverable is a **DB write, a refutation, or a decision** could not be completed by the harness at all. `validatePR` (`verification.js:222`) unconditionally requires a `github.com` URL — and `--auto-pr` isn't a path either: it merely *defers* validation to a post-push `gh pr create`, which correctly refuses with *"No commits between main and main"* on an empty branch. The only remaining route was a coordinator hand-writing the row out-of-band.

**Twice observed, the second one mine:** QF-20260727-154 (the ticket's instance — worker idled ~50min, coordinator completed by hand), and QF-20260727-344, which I closed as a zero-code refutation on 2026-08-04 by writing status directly to the row for exactly this reason. The defect is reproducing, not historical.

## The guard that makes it safe

`--no-code-deliverable` **requires** `--deliverable-evidence`, mirroring the existing `--force-complete`/`--reason` contract. An evidence-free no-code completion is a vanity completion, and it would turn this flag into a universal PR-requirement bypass.

The evidence is the **only** artifact a reader can audit — there's no commit and no diff to inspect — so it's persisted to `verification_notes` alongside an explicit `no_pr_reason`, rather than merely accepted and dropped.

**The normal path is untouched.** `validatePR` itself is not modified; the exemption is a scoped condition at the call site.

## A correction I made mid-build

I had noted a second `validatePR` call at `:851` that also seemed to need skipping. Reading it showed it sits *inside* the `deferAutoPr` block — so suppressing auto-PR for zero-code (`deferAutoPr && !noCodeDeliverable`) makes it unreachable. Better than patching two gates that must then stay in agreement.

`force_completed` is set for this path: no PR was reviewed and no diff merged, so the row must not read like an ordinary verified completion. That also satisfies `completed_requires_verification` **without fabricating `uat_verified`** — the contract this file already documents.

## Test plan

- 9 tests asserting **both sides**: the flag is refused without evidence, **and** `validatePR` still rejects missing/non-github URLs. Either assertion alone would pass on a broken fix.
- A **CONTROL** that the flag *with* evidence parses — so the refusal is a guard, not a dead flag.
- A test that `--deliverable-evidence` **alone** does not enable the exemption (guards the inverse mistake).
- Mutation-proven: 5/9 fail with the guard reverted. 527 tests green across 48 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)