### PR TITLE
fix(QF-20260805-671): sub-agent crash was being reported as a REJECTION

### DIFF
--- a/lib/sub-agent-executor/instruction-loader.js
+++ b/lib/sub-agent-executor/instruction-loader.js
@@ -110,6 +110,31 @@ async function _composeExperience(code, context) {
  * @param {Object|null} compositionResult - Agent Experience Factory result (optional)
  * @returns {string} Formatted instructions
  */
+/**
+ * Coerce a proven_solutions entry to displayable text, whatever shape it arrived in.
+ *
+ * Returns '' (never null/undefined) so the caller's `|| 'No proven solution yet'` fallback is the
+ * single place the default lives. Object solutions are unwrapped by preferred key rather than
+ * JSON.stringify'd, because "[object Object]" or a raw blob in a sub-agent prompt is noise that
+ * looks like content — the pattern text is there to be READ by the agent.
+ *
+ * @param {Object|null|undefined} entry - a proven_solutions[] element
+ * @returns {string}
+ */
+export function solutionToText(entry) {
+  if (!entry) return '';
+  for (const candidate of [entry.solution, entry.method]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+    if (candidate && typeof candidate === 'object') {
+      for (const key of ['action', 'solution', 'description', 'summary', 'text']) {
+        if (typeof candidate[key] === 'string' && candidate[key].trim()) return candidate[key];
+      }
+      return 'See pattern details';
+    }
+  }
+  return entry.solution || entry.method ? 'See pattern details' : '';
+}
+
 export function formatInstructionsForClaude(subAgent, relevantPatterns = [], compositionResult = null) {
   const metadata = subAgent.metadata || {};
   const capabilities = subAgent.capabilities || [];
@@ -125,9 +150,13 @@ KNOWN ISSUES & PROVEN SOLUTIONS (from issue_patterns)
 `;
     relevantPatterns.forEach((p, i) => {
       const severityIcon = p.severity === 'critical' ? '[CRITICAL]' : p.severity === 'high' ? '[HIGH]' : '[MEDIUM]';
-      const topSolution = p.proven_solutions && p.proven_solutions.length > 0
-        ? p.proven_solutions[0].solution || p.proven_solutions[0].method || 'See pattern details'
-        : 'No proven solution yet';
+      // `.solution` is an OBJECT in some rows (e.g. {action, is_boilerplate}), so calling
+      // .substring on it threw TypeError and killed the WHOLE sub-agent run. The failure then
+      // wrote verdict=ERROR/confidence=0, which add-prd-to-database.js renders as
+      // "BLOCKED, N CRITICAL sub-agent(s) failed" — a CRASH wearing a REJECTION's clothes, which
+      // is worse than the crash: two SDs already shipped through it believing they were reviewed.
+      // Same class as the prevention_checklist coercion 15 lines below; handled the same way.
+      const topSolution = solutionToText(p.proven_solutions?.[0]) || 'No proven solution yet';
 
       patternSection += `
 ${i + 1}. ${severityIcon} [${p.pattern_id}] ${p.issue_summary}

--- a/tests/unit/sub-agent-executor/solution-to-text.test.js
+++ b/tests/unit/sub-agent-executor/solution-to-text.test.js
@@ -1,0 +1,53 @@
+// QF-20260805-671 — a crash wearing a rejection's clothes.
+//
+// instruction-loader.js called `.substring()` on `proven_solutions[0].solution`, which is an OBJECT
+// in 11 of 207 usable issue_patterns rows (measured by paginated walk; the DB exact count 1691
+// matched the walk, so it is not a truncated sample). The TypeError killed the ENTIRE sub-agent run,
+// which then wrote verdict=ERROR/confidence=0 — and add-prd-to-database.js renders that as
+// "BLOCKED, N CRITICAL sub-agent(s) failed". That is strictly worse than the crash: two SDs shipped
+// through it believing a reviewer had rejected them, when nothing had judged anything.
+//
+// Every case below is a way the fix could pass while still being wrong.
+import { describe, it, expect } from 'vitest';
+import { solutionToText } from '../../../lib/sub-agent-executor/instruction-loader.js';
+
+describe('solutionToText — the object-solution crash (QF-20260805-671)', () => {
+  it('[DECIDING] an OBJECT solution yields text instead of throwing', () => {
+    // The exact shape found live in PAT-LES-eeeedf0b296b.
+    const entry = { solution: { action: 'Continue following LEO Protocol best practices', is_boilerplate: true } };
+    const out = solutionToText(entry);
+    expect(typeof out).toBe('string');
+    expect(() => out.substring(0, 100)).not.toThrow();
+  });
+
+  it('[DECIDING] it extracts the REAL content, not a placeholder', () => {
+    // Without this, a fix that returned 'See pattern details' for every object would pass the
+    // throw-test above while silently deleting the pattern knowledge the prompt exists to carry.
+    const entry = { solution: { action: 'Use the pooler URL, never the direct URL' } };
+    expect(solutionToText(entry)).toBe('Use the pooler URL, never the direct URL');
+  });
+
+  it('[CONTROL] a plain string solution is returned verbatim — the common path is untouched', () => {
+    // 196 of 207 usable rows take this path. A fix that mangled them would be a far bigger
+    // regression than the bug it replaced, and would look identical in the deciding tests.
+    expect(solutionToText({ solution: 'Reuse the existing chokepoint' })).toBe('Reuse the existing chokepoint');
+  });
+
+  it('[CONTROL] falls back to .method when .solution is absent', () => {
+    expect(solutionToText({ method: 'Run the migration via the DATABASE sub-agent' })).toBe('Run the migration via the DATABASE sub-agent');
+  });
+
+  it('[CONTROL] an unrecognised object shape degrades to a marker, never to [object Object]', () => {
+    const out = solutionToText({ solution: { unexpected_key: 1 } });
+    expect(out).not.toContain('[object Object]');
+    expect(typeof out).toBe('string');
+    expect(() => out.substring(0, 100)).not.toThrow();
+  });
+
+  it("[CONTROL] an empty entry yields '' so the CALLER's default is the single source of that string", () => {
+    // Returning 'No proven solution yet' here would put the default in two places and let them drift.
+    expect(solutionToText(null)).toBe('');
+    expect(solutionToText(undefined)).toBe('');
+    expect(solutionToText({})).toBe('');
+  });
+});


### PR DESCRIPTION
## The bug
`lib/sub-agent-executor/instruction-loader.js` called `.substring()` on `proven_solutions[0].solution`, which is an **object** in some rows (e.g. `{action, is_boilerplate}`). The `TypeError` killed the entire sub-agent run.

**That is not the worst part.** The dead run writes `verdict=ERROR, confidence=0, raw_analysis=null` — and `add-prd-to-database.js` renders that as **"BLOCKED, N CRITICAL sub-agent(s) failed"**. So a crash is indistinguishable from a substantive rejection at the only surface anyone reads. Two SDs have already shipped through it. *A reviewer that died is not a reviewer that judged.*

## Blast radius — measured, not inherited
The figure I was handed was wrong in **both directions** over its history: dispatch said **57 of 207 (27.5%)**, correcting an original report of 11 as a "5× undercount".

A paginated walk of all **1691** rows — whose length **matches the DB exact count**, so it is not a truncated sample — gives **11 of 207 (5.3%)**. I then tested whether 57 could come from a different-but-reasonable reading (any-element-has-object; `[0]` ignoring the `.method` fallback). **Both also return 11.** So 57 isn't a population difference, and the original 11 was correct.

The defect is real and worth fixing at 5.3%. The severity was overstated 5×, and dispatch decisions were being made on it.

## The fix
`solutionToText()` coercion, mirroring the `prevention_checklist` string/JSONB handling 15 lines below **in the same function** — same class, same treatment. Object solutions are unwrapped by preferred key rather than `JSON.stringify`'d, because `"[object Object]"` in a sub-agent prompt is noise that *looks* like content.

## Verified against real data, not a synthetic object
- All **11 live landmine rows** render · 0 throw · 0 leak `[object Object]`
- **Control:** 60 previously-safe rows still render (the 196-row common path is untouched)
- **Control:** extracted text is the row's *real* content, not a placeholder
- **Control:** plain strings still pass through verbatim

**Mutation-proven:** reverting to the old raw behaviour turns exactly the object-path tests red (2 deciding + the `[object Object]` control) while the 3 string-path controls stay green — the tests fail precisely where the bug lived.

31/31 tests. Six new, four of them controls — one per way this fix could pass while being wrong.