### PR TITLE
fix(QF-20260805-181): coordinator-health probe cannot detect a dead coordinator

### DIFF
--- a/scripts/adam-coordinator-health.mjs
+++ b/scripts/adam-coordinator-health.mjs
@@ -157,6 +157,81 @@ async function countRoadmapLinkExceptionsLive(supabase) {
 }
 
 /**
+ * QF-20260805-181: coordinator LIVENESS. Every field above is worker- or backlog-scoped, so a
+ * DEAD coordinator produced a payload identical to a healthy one. Measured harm (coordinator's
+ * own audit, session_coordination c4e0f407): the seat was dark 2026-08-04 21:55Z → 2026-08-05
+ * 10:53Z (13h, zero tool calls, 28 worker signals undelivered, 4 workers stuck) and all FIVE
+ * probe runs inside that window reported integrity_ok=true.
+ *
+ * last_tool_at is the WORK-PROVING field. heartbeat_at proves only that the row was touched — a
+ * tick daemon stamps it fresh while the seat sits frozen at an interactive prompt, and that
+ * daemon-stamped-alive/work-frozen signature is precisely the freeze class that defeats every
+ * heartbeat-based check.
+ *
+ * The coordinator row is resolved by a narrow server-side jsonb filter on metadata.is_coordinator
+ * — NOT via getActiveCoordinatorId (lib/coordinator/resolve.cjs currently returns the fixture
+ * value 'sess-987', a separate known defect), and NOT by scanning the capped 1000-row page
+ * computeUtilization reads, which would make this verdict depend on the coordinator landing
+ * inside a heartbeat window.
+ *
+ * Every non-measurable outcome (no row, absent/unparseable last_tool_at, query failure) reports
+ * coordinator_liveness_ok=false under a DISTINCT reason: an unreadable instrument must never be
+ * indistinguishable from a healthy coordinator, and a null age must never narrate as a fresh 0.
+ */
+export const COORDINATOR_LIVENESS_MAX_AGE_MINUTES = 30;
+
+export async function computeCoordinatorLiveness(supabase, { nowMs = Date.now() } = {}) {
+  const base = { coordinator_session_id: null, coordinator_last_tool_age_minutes: null, coordinator_liveness_ok: false };
+  const { data, error } = await supabase
+    .from('claude_sessions')
+    .select('session_id, last_tool_at, heartbeat_at')
+    .eq('metadata->>is_coordinator', 'true')
+    .order('heartbeat_at', { ascending: false })
+    .limit(1);
+  if (error) return { ...base, reason: 'query_failed', error: error.message };
+  const row = (data || [])[0];
+  if (!row) return { ...base, reason: 'no_coordinator_row' };
+  if (!row.last_tool_at) return { ...base, coordinator_session_id: row.session_id, reason: 'last_tool_at_missing' };
+  const ageMinutes = (nowMs - new Date(row.last_tool_at).getTime()) / 60000;
+  if (!Number.isFinite(ageMinutes)) {
+    return { ...base, coordinator_session_id: row.session_id, reason: 'last_tool_at_unparseable' };
+  }
+  const ok = ageMinutes <= COORDINATOR_LIVENESS_MAX_AGE_MINUTES;
+  return {
+    coordinator_liveness_ok: ok,
+    coordinator_session_id: row.session_id,
+    coordinator_last_tool_age_minutes: Math.round(ageMinutes * 10) / 10,
+    ...(ok ? {} : { reason: 'last_tool_at_stale' }),
+  };
+}
+
+/**
+ * Pure merge (QF-20260805-181). Liveness rides ON the integrity verdict rather than becoming a
+ * second breach axis, so classifyBreach's existing `integrity_ok === false` test and the
+ * advisory's divergent_fields rendering both carry it with no further wiring.
+ */
+export function applyCoordinatorLiveness(integrity, liveness) {
+  const merged = {
+    ...integrity,
+    coordinator_session_id: liveness.coordinator_session_id,
+    coordinator_last_tool_age_minutes: liveness.coordinator_last_tool_age_minutes,
+  };
+  if (liveness.coordinator_liveness_ok !== false) return merged;
+  console.error(
+    `[adam-coordinator-health] ALARM coordinator_liveness: ${liveness.reason}` +
+    ` (coordinator=${liveness.coordinator_session_id ?? 'none'},` +
+    ` last_tool_age_minutes=${liveness.coordinator_last_tool_age_minutes ?? 'null'},` +
+    ` threshold=${COORDINATOR_LIVENESS_MAX_AGE_MINUTES}m)`,
+  );
+  return {
+    ...merged,
+    integrity_ok: false,
+    coordinator_liveness_reason: liveness.reason,
+    divergent_fields: [...(integrity.divergent_fields || []), 'coordinator_liveness'],
+  };
+}
+
+/**
  * KPI-3: fail-loud integrity guard. Independently recomputes a raw dispatchable-count signal
  * (draft + unclaimed) and cross-checks it against the coordinator's OWN self-reported count —
  * computeClaimableLeaves (scripts/coordinator-backlog-rank.mjs), the same dependency/hold-aware
@@ -394,7 +469,12 @@ export async function computeSharpenings(supabase, { utilization, integrity, now
 export async function runProbe(supabase, opts = {}) {
   const utilization = await computeUtilization(supabase, opts);
   const planAdherence = await computePlanAdherence(supabase);
-  const integrity = await computeFailLoudIntegrity(supabase, opts);
+  // QF-20260805-181: injectable seam mirrors claimableLeavesFn/gitGrep/makePgClient in this file.
+  const livenessFn = opts.coordinatorLivenessFn || computeCoordinatorLiveness;
+  const integrity = applyCoordinatorLiveness(
+    await computeFailLoudIntegrity(supabase, opts),
+    await livenessFn(supabase, opts),
+  );
   const baseBreach = classifyBreach({ utilization, planAdherence, integrity });
   // KPI-0 delta: outcome/flow leads the reading (S1); the six classes + band
   // extend the breach signal (S2/S3) without altering the base classifier.
@@ -483,7 +563,12 @@ async function main() {
   let reading;
   if (dryRun) {
     const utilization = await computeUtilization(supabase);
-    const integrity = await computeFailLoudIntegrity(supabase);
+    // QF-20260805-181: --dry-run must not read healthier than the real run — it is the mode a
+    // human invokes when asking "is the coordinator alive?", so it carries the same verdict.
+    const integrity = applyCoordinatorLiveness(
+      await computeFailLoudIntegrity(supabase),
+      await computeCoordinatorLiveness(supabase),
+    );
     const sharp = await computeSharpenings(supabase, { utilization, integrity });
     reading = {
       timestamp: new Date().toISOString(),

--- a/scripts/adam-coordinator-health.mjs
+++ b/scripts/adam-coordinator-health.mjs
@@ -158,25 +158,15 @@ async function countRoadmapLinkExceptionsLive(supabase) {
 
 /**
  * QF-20260805-181: coordinator LIVENESS. Every field above is worker- or backlog-scoped, so a
- * DEAD coordinator produced a payload identical to a healthy one. Measured harm (coordinator's
- * own audit, session_coordination c4e0f407): the seat was dark 2026-08-04 21:55Z → 2026-08-05
- * 10:53Z (13h, zero tool calls, 28 worker signals undelivered, 4 workers stuck) and all FIVE
- * probe runs inside that window reported integrity_ok=true.
+ * dead coordinator read identically to a healthy one (measured: 13h dark, five probe runs inside
+ * the window all reported integrity_ok=true).
  *
- * last_tool_at is the WORK-PROVING field. heartbeat_at proves only that the row was touched — a
- * tick daemon stamps it fresh while the seat sits frozen at an interactive prompt, and that
- * daemon-stamped-alive/work-frozen signature is precisely the freeze class that defeats every
- * heartbeat-based check.
- *
- * The coordinator row is resolved by a narrow server-side jsonb filter on metadata.is_coordinator
- * — NOT via getActiveCoordinatorId (lib/coordinator/resolve.cjs currently returns the fixture
- * value 'sess-987', a separate known defect), and NOT by scanning the capped 1000-row page
- * computeUtilization reads, which would make this verdict depend on the coordinator landing
- * inside a heartbeat window.
- *
- * Every non-measurable outcome (no row, absent/unparseable last_tool_at, query failure) reports
- * coordinator_liveness_ok=false under a DISTINCT reason: an unreadable instrument must never be
- * indistinguishable from a healthy coordinator, and a null age must never narrate as a fresh 0.
+ * Key on last_tool_at, NEVER heartbeat_at: a tick daemon stamps the heartbeat fresh while the
+ * seat sits frozen at an interactive prompt, which is the exact class that went unseen.
+ * Resolve via the narrow metadata.is_coordinator filter — not getActiveCoordinatorId (returns
+ * the fixture 'sess-987', separate defect), and not the capped 1000-row page above.
+ * Every unmeasurable outcome fails loud under its own reason: an unreadable instrument must not
+ * look like a healthy coordinator, and a null age must never narrate as a fresh 0.
  */
 export const COORDINATOR_LIVENESS_MAX_AGE_MINUTES = 30;
 
@@ -207,8 +197,9 @@ export async function computeCoordinatorLiveness(supabase, { nowMs = Date.now() 
 
 /**
  * Pure merge (QF-20260805-181). Liveness rides ON the integrity verdict rather than becoming a
- * second breach axis, so classifyBreach's existing `integrity_ok === false` test and the
- * advisory's divergent_fields rendering both carry it with no further wiring.
+ * second breach axis, so classifyBreach's `integrity_ok === false` test and the advisory's
+ * divergent_fields rendering both carry it with no further wiring. ALARM goes to stderr so it
+ * never corrupts the JSON payload main() writes to stdout.
  */
 export function applyCoordinatorLiveness(integrity, liveness) {
   const merged = {
@@ -217,12 +208,7 @@ export function applyCoordinatorLiveness(integrity, liveness) {
     coordinator_last_tool_age_minutes: liveness.coordinator_last_tool_age_minutes,
   };
   if (liveness.coordinator_liveness_ok !== false) return merged;
-  console.error(
-    `[adam-coordinator-health] ALARM coordinator_liveness: ${liveness.reason}` +
-    ` (coordinator=${liveness.coordinator_session_id ?? 'none'},` +
-    ` last_tool_age_minutes=${liveness.coordinator_last_tool_age_minutes ?? 'null'},` +
-    ` threshold=${COORDINATOR_LIVENESS_MAX_AGE_MINUTES}m)`,
-  );
+  console.error(`[adam-coordinator-health] ALARM coordinator_liveness: ${liveness.reason} (coordinator=${liveness.coordinator_session_id ?? 'none'}, last_tool_age_minutes=${liveness.coordinator_last_tool_age_minutes ?? 'null'}, threshold=${COORDINATOR_LIVENESS_MAX_AGE_MINUTES}m)`);
   return {
     ...merged,
     integrity_ok: false,

--- a/tests/unit/adam/adam-coordinator-health.test.js
+++ b/tests/unit/adam/adam-coordinator-health.test.js
@@ -12,6 +12,9 @@ import {
   pushCoordinatorHealthAdvisory,
   persistReading,
   runProbe,
+  computeCoordinatorLiveness,
+  applyCoordinatorLiveness,
+  COORDINATOR_LIVENESS_MAX_AGE_MINUTES,
 } from '../../../scripts/adam-coordinator-health.mjs';
 import * as waveLinkage from '../../../lib/roadmap/wave-linkage-coverage.js';
 import * as genuineWorker from '../../../lib/fleet/genuine-worker.mjs';
@@ -19,12 +22,29 @@ import * as coordinatorResolve from '../../../lib/coordinator/resolve.cjs';
 
 const minutesAgo = (m) => new Date(Date.now() - m * 60_000).toISOString();
 
+/** QF-20260805-181: a coordinator row that is alive by the WORK-PROVING field (last_tool_at). */
+const liveCoordinatorRow = (lastToolMinutesAgo = 1) => ({
+  session_id: 'coord-1', sd_key: null, status: 'active',
+  heartbeat_at: minutesAgo(0), last_tool_at: minutesAgo(lastToolMinutesAgo),
+  metadata: { is_coordinator: true },
+});
+
 /**
  * Minimal fake Supabase: select().eq()/.in()/.not()/.order()/.limit() over seeded tables; insert() logs rows.
  * capAt: { tableName: n } simulates PostgREST's default page cap (QF-20260720-161 regression coverage) —
  * applied post-filter/post-sort like the real server-side default, so an unordered query truncates to an
  * arbitrary slice while an explicitly-ordered one keeps the correct (e.g. freshest) rows within the cap.
  */
+/**
+ * QF-20260805-181: resolve a PostgREST `column->>key` jsonb path (plain columns pass through).
+ * Without this the coordinator-liveness filter matches nothing in the fake, so a seeded HEALTHY
+ * coordinator would read as "no coordinator row" and the test would pass for the wrong reason.
+ */
+function jsonbPath(row, col) {
+  const [base, key] = col.split('->>');
+  return key === undefined ? row[base] : row[base]?.[key];
+}
+
 function makeFakeSupabase(tables, { onInsert, capAt } = {}) {
   return {
     from(tableName) {
@@ -37,7 +57,7 @@ function makeFakeSupabase(tables, { onInsert, capAt } = {}) {
       let countMode = false;
       const builder = {
         select(_cols, opts) { if (opts && opts.count === 'exact') countMode = true; return builder; },
-        eq(col, val) { filters.push((r) => r[col] === val); return builder; },
+        eq(col, val) { filters.push((r) => (col.includes('->>') ? String(jsonbPath(r, col) ?? '') === String(val) : r[col] === val)); return builder; },
         in(col, vals) { filters.push((r) => vals.includes(r[col])); return builder; },
         is(col, val) { filters.push((r) => (r[col] ?? null) === val); return builder; },
         not(col, op, val) { filters.push((r) => r[col] !== val); return builder; },
@@ -383,6 +403,88 @@ describe('persistReading (TS-6)', () => {
   });
 });
 
+/**
+ * QF-20260805-181 — the probe could not distinguish a dead coordinator from a healthy one.
+ * The measured window (2026-08-04 21:55Z → 2026-08-05 10:53Z, 13h dark) had FIVE probe runs
+ * report integrity_ok=true, because a tick daemon kept heartbeat_at fresh while the seat sat
+ * frozen. So the load-bearing case here is the freeze signature specifically: fresh heartbeat,
+ * stale last_tool_at. A liveness check keyed on heartbeat_at would pass that case.
+ */
+describe('coordinator liveness (QF-20260805-181)', () => {
+  const sessions = (rows) => makeFakeSupabase({ claude_sessions: rows });
+
+  it('alarms on the FREEZE signature — heartbeat_at fresh, last_tool_at 13h stale', async () => {
+    const frozen = { ...liveCoordinatorRow(), heartbeat_at: minutesAgo(0), last_tool_at: minutesAgo(13 * 60) };
+    const liveness = await computeCoordinatorLiveness(sessions([frozen]));
+    expect(liveness.coordinator_liveness_ok).toBe(false);
+    expect(liveness.reason).toBe('last_tool_at_stale');
+    expect(liveness.coordinator_last_tool_age_minutes).toBeCloseTo(780, 0);
+    // The heartbeat this check must NOT be fooled by is genuinely fresh in this fixture.
+    expect(new Date(frozen.heartbeat_at).getTime()).toBeGreaterThan(Date.now() - 60_000);
+  });
+
+  it('passes a genuinely live coordinator (two-sided — the check is not stuck reporting dead)', async () => {
+    const liveness = await computeCoordinatorLiveness(sessions([liveCoordinatorRow(2)]));
+    expect(liveness.coordinator_liveness_ok).toBe(true);
+    expect(liveness.coordinator_session_id).toBe('coord-1');
+    expect(liveness.reason).toBeUndefined();
+  });
+
+  it.each([
+    ['no coordinator row at all', [], 'no_coordinator_row'],
+    ['a coordinator row with a null last_tool_at', [{ ...liveCoordinatorRow(), last_tool_at: null }], 'last_tool_at_missing'],
+    ['an unparseable last_tool_at', [{ ...liveCoordinatorRow(), last_tool_at: 'not-a-date' }], 'last_tool_at_unparseable'],
+  ])('never reads healthy for %s, and reports a DISTINCT reason', async (_label, rows, reason) => {
+    const liveness = await computeCoordinatorLiveness(sessions(rows));
+    expect(liveness.coordinator_liveness_ok).toBe(false);
+    expect(liveness.reason).toBe(reason);
+    // A null age must never narrate as a fresh 0.
+    expect(liveness.coordinator_last_tool_age_minutes).toBeNull();
+  });
+
+  it('a stale verdict flips integrity_ok and names coordinator_liveness WITHOUT dropping prior divergences', () => {
+    const merged = applyCoordinatorLiveness(
+      { integrity_ok: false, divergent_fields: ['dispatchable_count'] },
+      { coordinator_liveness_ok: false, reason: 'last_tool_at_stale', coordinator_session_id: 'c1', coordinator_last_tool_age_minutes: 780 },
+    );
+    expect(merged.integrity_ok).toBe(false);
+    expect(merged.divergent_fields).toEqual(['dispatchable_count', 'coordinator_liveness']);
+  });
+
+  it('a live verdict attaches the age field but never flips a passing integrity verdict', () => {
+    const merged = applyCoordinatorLiveness(
+      { integrity_ok: true, divergent_fields: [] },
+      { coordinator_liveness_ok: true, coordinator_session_id: 'c1', coordinator_last_tool_age_minutes: 2 },
+    );
+    expect(merged.integrity_ok).toBe(true);
+    expect(merged.divergent_fields).toEqual([]);
+    expect(merged.coordinator_last_tool_age_minutes).toBe(2);
+  });
+
+  it('drives a full-probe breach + advisory naming coordinator_liveness (end-to-end, the 5 all-clear runs)', async () => {
+    vi.spyOn(waveLinkage, 'computeWaveLinkageCoverage').mockResolvedValueOnce({ coverage: null, linked: 0, total: 0, starved: false, unlinkedKeys: [] });
+    const inserted = [];
+    const supabase = makeFakeSupabase(
+      {
+        claude_sessions: [{ ...liveCoordinatorRow(), last_tool_at: minutesAgo(13 * 60) }],
+        strategic_directives_v2: [],
+        codebase_health_snapshots: [],
+      },
+      { onInsert: (t, r) => inserted.push({ t, r }) },
+    );
+    const reading = await runProbe(supabase, {
+      makePgClient: async () => { throw new Error('pg-disabled-in-unit'); },
+      recipients: { coordinatorId: 'c-test' },
+    });
+    expect(reading.integrity.integrity_ok).toBe(false);
+    expect(reading.integrity.divergent_fields).toContain('coordinator_liveness');
+    expect(reading.integrity.coordinator_last_tool_age_minutes).toBeGreaterThan(COORDINATOR_LIVENESS_MAX_AGE_MINUTES);
+    expect(reading.breach.breach).toBe(true);
+    const advisory = inserted.find((i) => i.t === 'session_coordination');
+    expect(advisory.r.subject).toContain('coordinator_liveness');
+  });
+});
+
 describe('runProbe integration (TS-1..TS-5 wired end-to-end)', () => {
   // SD-LEO-FIX-ADAM-COORDINATOR-HEALTH-001: runProbe's raw-SQL recompute creates its
   // OWN pg client (createDatabaseClient) OUTSIDE the injected supabase; without an
@@ -395,11 +497,18 @@ describe('runProbe integration (TS-1..TS-5 wired end-to-end)', () => {
     vi.spyOn(waveLinkage, 'computeWaveLinkageCoverage').mockResolvedValueOnce({ coverage: null, linked: 0, total: 0, starved: false, unlinkedKeys: [] });
     const inserted = [];
     const supabase = makeFakeSupabase(
-      { claude_sessions: [], strategic_directives_v2: [], codebase_health_snapshots: [] },
+      {
+        // QF-20260805-181: a healthy run now requires a LIVE coordinator. An empty session table
+        // is the dead-coordinator condition, so seeding [] here would make "no breach" unreachable.
+        claude_sessions: [liveCoordinatorRow()],
+        strategic_directives_v2: [],
+        codebase_health_snapshots: [],
+      },
       { onInsert: (t, r) => inserted.push({ t, r }) },
     );
     const reading = await runProbe(supabase, { makePgClient: pgDisabled });
     expect(reading.recompute.recompute_ok).toBeNull(); // pg seam stubbed — no live recompute, deterministic
+    expect(reading.integrity.coordinator_last_tool_age_minutes).toBeLessThan(COORDINATOR_LIVENESS_MAX_AGE_MINUTES);
     expect(reading.utilization).toBeDefined();
     expect(reading.plan_adherence.status).toBe('unmeasurable_until_linkage');
     expect(reading.integrity.integrity_ok).toBe(true);


### PR DESCRIPTION
## Problem

`scripts/adam-coordinator-health.mjs` computed only worker- and backlog-scoped fields, so a **dead coordinator produced a payload identical to a healthy one**.

Measured harm (coordinator's own audit, `session_coordination` row `c4e0f407`): the coordinator seat was dark 2026-08-04 21:55Z → 2026-08-05 10:53Z — 13 hours, zero tool calls, 28 worker signals undelivered, 4 workers stuck. **Five probe runs fired inside that window and every one reported `integrity_ok=true`.**

## Fix

The probe now resolves the active coordinator row and reports `coordinator_last_tool_age_minutes`. Past 30 minutes it emits an ALARM line (stderr, so it never corrupts the JSON payload on stdout) and sets `integrity_ok=false` with `coordinator_liveness` in `divergent_fields`.

Three decisions worth flagging for review:

- **`last_tool_at`, not `heartbeat_at`.** A tick daemon stamps `heartbeat_at` fresh while the seat sits frozen at an interactive prompt — that daemon-stamped-alive/work-frozen signature is exactly the freeze class that defeated the existing checks. `last_tool_at` is the work-proving field.
- **Liveness rides *on* the integrity verdict** rather than becoming a second breach axis, so `classifyBreach` and the advisory's `divergent_fields` rendering both carry it with no further wiring.
- **Every non-measurable outcome fails loud under a distinct reason** (`no_coordinator_row`, `last_tool_at_missing`, `last_tool_at_unparseable`, `query_failed`). An unreadable instrument must never be indistinguishable from a healthy coordinator, and a null age must never narrate as a fresh 0.

The coordinator row is resolved by a narrow server-side jsonb filter on `metadata.is_coordinator` — deliberately **not** `getActiveCoordinatorId` (which currently returns the fixture value `sess-987`, a separate known defect), and not by scanning the capped 1000-row page `computeUtilization` reads, which would make the verdict depend on the coordinator landing inside a heartbeat window.

`--dry-run` carries the same verdict as the real run — it is the mode a human invokes when asking "is the coordinator alive?", so it must not read healthier.

## Verification

- 37/37 unit tests pass (`tests/unit/adam/adam-coordinator-health.test.js`); 21/21 in the related oversight suites.
- **Mutation-proved:** forcing the threshold check to always-healthy turns exactly the two harm-encoding tests red — the freeze-signature test and the end-to-end all-clear test. The rest stay green, so those two are genuinely load-bearing rather than decoration.
- **Live dry-run** against the real DB reports the actual coordinator (`909d861e`) at `coordinator_last_tool_age_minutes: 0.8`, `integrity_ok: true` — the healthy path confirmed on real data, not just fixtures.

The lead test asserts the freeze signature specifically: fresh `heartbeat_at`, 13h-stale `last_tool_at`. A liveness check keyed on `heartbeat_at` would pass that case, which is the whole reason the outage went unseen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)