### PR TITLE
fix(QF-20260804-087): claim guard cannot see QF claims, blocking the rightful owner

### DIFF
--- a/scripts/hooks/__tests__/pre-tool-enforce-clmmulti-002.test.js
+++ b/scripts/hooks/__tests__/pre-tool-enforce-clmmulti-002.test.js
@@ -13,6 +13,12 @@ import { fileURLToPath } from 'node:url';
 
 const hookPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'pre-tool-enforce.cjs');
 const hookSrc = readFileSync(hookPath, 'utf8');
+// QF-20260804-087 moved the block/permit DECISION into its own module so it could be tested
+// behaviourally rather than by string-matching (tests/unit/worktree-claim-decision-qf087.test.js).
+// The pins below follow the invariant to its new address — they are not relaxed.
+const decisionSrc = readFileSync(
+  join(dirname(fileURLToPath(import.meta.url)), '..', 'worktree-claim-decision.cjs'), 'utf8',
+);
 
 // Slice covering only ENFORCEMENT 4 so assertions don't accidentally match
 // the other enforcements that legitimately read unified-session-state.json.
@@ -42,8 +48,26 @@ describe('PAT-CLMMULTI-002 — DB-corroborated, session-scoped worktree claim gu
     expect(enf4).not.toContain('state.sd?.id');
   });
 
-  it('compares sd_key (claimedSdKey vs worktreeSdKey), not a UUID id', () => {
-    expect(enf4).toContain('claimedSdKey !== worktreeSdKey');
+  it('compares sd_key (claimedSdKey vs worktreeKey), not a UUID id', () => {
+    // The guard hands the sd_key (never a UUID) to the decision...
+    expect(enf4).toMatch(/shouldBlockWorktreeEdit\(\{\s*worktreeKey: worktreeSdKey, claimedSdKey/);
+    // ...and the decision still performs the sd_key comparison this pin has always guarded.
+    expect(decisionSrc).toContain('claimedSdKey !== worktreeKey');
+  });
+
+  // QF-20260804-087: the guard read strategic_directives_v2 ONLY, so a QF claim (which lives in
+  // quick_fixes) was invisible and the rightful QF owner was blocked with no remedy. These pin the
+  // two properties a future refactor is most likely to quietly drop.
+  it('also resolves a QF claim from quick_fixes, scoped to the one key being edited', () => {
+    expect(hookSrc).toMatch(/async function sessionHoldsQuickFixClaim\(/);
+    expect(hookSrc).toContain('/rest/v1/quick_fixes?claiming_session_id=eq.');
+    // Scoped by id — never a blanket "any QF claim permits any QF worktree".
+    expect(hookSrc).toContain("'&id=eq.' + encodeURIComponent(qfKey)");
+  });
+
+  it('keeps the QF lookup TRI-STATE: null (unreadable) must not collapse into false (not held)', () => {
+    // Collapsing them would re-block the exact worker this fix unblocks on any transient blip.
+    expect(decisionSrc).toContain('if (qfHeld !== false) return false;');
   });
 
   it('exposes the LEO_CLAIM_GUARD=off kill-switch', () => {

--- a/scripts/hooks/pre-tool-enforce.cjs
+++ b/scripts/hooks/pre-tool-enforce.cjs
@@ -282,11 +282,41 @@ async function resolveSessionClaimedSdKey(sessionId) {
   }
 }
 
+// QF-20260804-087: the lookup above reads strategic_directives_v2 ONLY, so a QF claim — which
+// lives in quick_fixes — is invisible to it. This is the SECOND fail-soft lookup, same REST shape
+// and 1.5s timeout as its SD sibling. Returns the TRI-STATE true/false/null that
+// worktree-claim-decision.cjs documents and depends on — null (no creds / timeout / non-ok) is
+// NOT false, and collapsing the two rebuilds the bug.
+// quick_fixes.id IS the QF key (no qf_key column) and carries the same claiming_session_id column
+// name as the SD table — both live-verified against the schema, as was the id=eq. scoping.
+async function sessionHoldsQuickFixClaim(sessionId, qfKey) {
+  try {
+    const supabaseUrl = process.env.SUPABASE_URL;
+    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    if (!supabaseUrl || !serviceKey || !sessionId || !qfKey) return null;
+    const url = supabaseUrl +
+      '/rest/v1/quick_fixes?claiming_session_id=eq.' + encodeURIComponent(sessionId) +
+      '&id=eq.' + encodeURIComponent(qfKey) + '&select=id&limit=1';
+    const resp = await Promise.race([
+      fetch(url, { headers: { apikey: serviceKey, Authorization: 'Bearer ' + serviceKey } }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 1500)),
+    ]);
+    if (!resp || !resp.ok) return null;
+    const rows = await resp.json();
+    if (!Array.isArray(rows)) return null;
+    return rows.length > 0;
+  } catch {
+    return null;
+  }
+}
+
 // SD-FDBK-ENH-ENFORCEMENT-IDEA-OPERATOR-001: resolve THIS session's claude_sessions.metadata
 // (mirrors resolveSessionClaimedSdKey: REST + 1.5s timeout + fail-open → null on any error).
 // Used only by the AskUserQuestion guard, so the lookup happens at most once per
 // AskUserQuestion call (a rare tool), never on the hot path of other tools.
 const { isBlockableWorker, decideAskUserBlock, ASKUSER_DENY_MESSAGE } = require('./askuser-worker-policy.cjs');
+// QF-20260804-087: worktree-claim decision, extracted for the same reason as the policy above.
+const { shouldBlockWorktreeEdit, isQuickFixWorktree } = require('./worktree-claim-decision.cjs');
 // Resolves the calling session's { metadata, loopState } for the AskUserQuestion guard.
 // loop_state is a TOP-LEVEL claude_sessions column (active|awaiting_tick|exited|unknown) — it is
 // the autonomy signal that catches a /loop worker the coordinator has not yet callsigned.
@@ -922,7 +952,13 @@ async function main() {
         const worktreeSdKey = match[1];
         try {
           const claimedSdKey = await resolveSessionClaimedSdKey(_SESSION_ID);
-          if (claimedSdKey && claimedSdKey !== worktreeSdKey) {
+          // QF-20260804-087: NOT a wholesale `startsWith('QF-') -> allow` exemption — editing a QF
+          // worktree you do not hold is still blocked, and SD-vs-SD is untouched. See the decision
+          // module for why the qfHeld tri-state carries the whole fix.
+          const qfHeld = isQuickFixWorktree(worktreeSdKey)
+            ? await sessionHoldsQuickFixClaim(_SESSION_ID, worktreeSdKey)
+            : false; // not a QF target — the SD test is the whole guard, unchanged
+          if (shouldBlockWorktreeEdit({ worktreeKey: worktreeSdKey, claimedSdKey, qfHeld })) {
             const auditPromise = auditPermissionDecision(_SESSION_ID, TOOL_NAME, 'PAT-CLMMULTI-002', 'Worktree claim guard (DB-corroborated)', 'block', { worktreeSdKey, claimedSdKey });
             process.stderr.write(
               `CLAIM GUARD (PAT-CLMMULTI-002): Edit/Write blocked.\n` +

--- a/scripts/hooks/worktree-claim-decision.cjs
+++ b/scripts/hooks/worktree-claim-decision.cjs
@@ -1,0 +1,37 @@
+// worktree-claim-decision.cjs — pure predicate for the worktree claim guard (PAT-CLMMULTI-002).
+// QF-20260804-087.
+//
+// The guard resolved "what does this session hold" from strategic_directives_v2 ONLY. A QF claim
+// lives in quick_fixes and was therefore invisible to it, so a worker legitimately assigned a QF
+// while holding ANY SD claim (including a stale, forgotten one) was blocked from its own QF
+// worktree — and NO action available to that worker satisfied the check, because the QF claim was
+// real and recorded and the guard simply could not read the table it was in.
+//
+// Extracted as a pure function for the same reason as askuser-worker-policy.cjs: the hook runs
+// main() at load, so nothing inside it can be required, and a guard whose decision cannot be
+// unit-tested gets "verified" by source pins that pass whether or not the behaviour is right.
+
+/**
+ * @param {string} args.worktreeKey - first .worktrees/ path segment (an sd_key or a QF id)
+ * @param {string|null} args.claimedSdKey - this session's claimed sd_key; null = no claim OR an
+ *   unreadable lookup (the SD lookup's fail-open contract)
+ * @param {boolean|null} args.qfHeld - quick_fixes lookup, TRI-STATE and the tri-state is the fix:
+ *   true = holds this QF; false = query SUCCEEDED and it does not; null = could not tell. Collapse
+ *   null into false and any transient blip re-blocks the worker this exists to unblock.
+ * @returns {boolean} true ⇢ BLOCK the Edit/Write
+ */
+function shouldBlockWorktreeEdit({ worktreeKey, claimedSdKey, qfHeld }) {
+  // Holding (or possibly holding) this QF permits the edit even while an SD claim is open —
+  // the two claims are on different axes and were never in conflict.
+  if (qfHeld !== false) return false;
+  // Otherwise the original invariant, byte-for-byte: block only on a POSITIVE mismatch, so a
+  // null claimedSdKey (no claim, or an unreadable lookup) still fails OPEN.
+  return Boolean(claimedSdKey) && claimedSdKey !== worktreeKey;
+}
+
+/** True when a worktree segment names a quick-fix rather than an SD (drives the second lookup). */
+function isQuickFixWorktree(worktreeKey) {
+  return /^QF-/i.test(String(worktreeKey || ''));
+}
+
+module.exports = { shouldBlockWorktreeEdit, isQuickFixWorktree };

--- a/tests/unit/worktree-claim-decision-qf087.test.js
+++ b/tests/unit/worktree-claim-decision-qf087.test.js
@@ -1,0 +1,68 @@
+/**
+ * QF-20260804-087 — the worktree claim guard queried strategic_directives_v2 ONLY, so a QF claim
+ * (which lives in quick_fixes) was invisible to it. A worker holding ANY SD claim was blocked from
+ * its own assigned QF worktree with NO action available to it.
+ *
+ * These are BEHAVIOURAL tests against the extracted predicate, deliberately not the source-pin
+ * style used elsewhere for this hook (pre-tool-enforce-column-scope.test.js): a pin passes whether
+ * or not the decision is right, and the defect here was a wrong decision, not a missing string.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+
+const require_ = createRequire(import.meta.url);
+const { shouldBlockWorktreeEdit, isQuickFixWorktree } = require_('../../scripts/hooks/worktree-claim-decision.cjs');
+
+const QF = 'QF-20260804-048';
+const MY_SD = 'SD-MINE-001';
+const OTHER_SD = 'SD-THEIRS-002';
+
+describe('QF-20260804-087: the guard can finally see a QF claim', () => {
+  // THE REPORTED DEFECT, verbatim: assigned a QF, also holding an SD claim, blocked with no remedy.
+  it('permits editing my OWN QF worktree while I also hold an unrelated SD claim', () => {
+    expect(shouldBlockWorktreeEdit({ worktreeKey: QF, claimedSdKey: MY_SD, qfHeld: true })).toBe(false);
+  });
+
+  // The other half of the QF's stated acceptance: the SD invariant must survive the fix.
+  it('still blocks a FOREIGN SD worktree for that same session — no wholesale weakening', () => {
+    expect(shouldBlockWorktreeEdit({ worktreeKey: OTHER_SD, claimedSdKey: MY_SD, qfHeld: false })).toBe(true);
+  });
+
+  it('still blocks a QF worktree I do NOT hold — this is not a blanket QF exemption', () => {
+    expect(shouldBlockWorktreeEdit({ worktreeKey: QF, claimedSdKey: MY_SD, qfHeld: false })).toBe(true);
+  });
+
+  // The tri-state is the whole point: null must not collapse into false.
+  it('permits on an UNREADABLE QF lookup (null) — a transient blip must not rebuild the bug', () => {
+    expect(shouldBlockWorktreeEdit({ worktreeKey: QF, claimedSdKey: MY_SD, qfHeld: null })).toBe(false);
+  });
+
+  it('a null qfHeld is NOT equivalent to false — the two answers must diverge', () => {
+    const onNull = shouldBlockWorktreeEdit({ worktreeKey: QF, claimedSdKey: MY_SD, qfHeld: null });
+    const onFalse = shouldBlockWorktreeEdit({ worktreeKey: QF, claimedSdKey: MY_SD, qfHeld: false });
+    expect(onNull).not.toBe(onFalse);
+  });
+});
+
+describe('QF-20260804-087: pre-existing SD-vs-SD behaviour is byte-for-byte preserved', () => {
+  it('permits my own SD worktree', () => {
+    expect(shouldBlockWorktreeEdit({ worktreeKey: MY_SD, claimedSdKey: MY_SD, qfHeld: false })).toBe(false);
+  });
+
+  it('fails OPEN when this session holds no claim at all (null claimedSdKey)', () => {
+    expect(shouldBlockWorktreeEdit({ worktreeKey: OTHER_SD, claimedSdKey: null, qfHeld: false })).toBe(false);
+  });
+});
+
+describe('QF-20260804-087: QF worktree detection', () => {
+  it('recognises a QF id and does not mistake an SD key for one', () => {
+    expect(isQuickFixWorktree(QF)).toBe(true);
+    expect(isQuickFixWorktree(MY_SD)).toBe(false);
+  });
+
+  it('survives absent/garbage segments without throwing', () => {
+    expect(isQuickFixWorktree(null)).toBe(false);
+    expect(isQuickFixWorktree(undefined)).toBe(false);
+    expect(isQuickFixWorktree('')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem

`scripts/hooks/pre-tool-enforce.cjs` resolved *"what does this session hold"* from `strategic_directives_v2` **alone**. A quick-fix claim lives in `quick_fixes`, so it was invisible to that lookup.

The result: any worker holding an SD claim — **including a stale, forgotten one** — was blocked from its own assigned QF worktree by `PAT-CLMMULTI-002`, and **no action available to that worker satisfied the check**. The QF claim was real and recorded; the guard simply could not read the table it was in.

Observed live: a seat assigned QF-20260804-048 via check-in (`action=claimed_assignment`) could not Write into its own worktree. A claim-free seat is unaffected, which is why other QFs shipped normally and this stayed hidden.

## Fix

A second fail-soft lookup against `quick_fixes`, **scoped to the one key being edited** (`id=eq.<qfKey>`), so it answers *"do I hold THIS QF"* and can never widen into a blanket QF-worktree exemption. SD-vs-SD cross-claim protection is untouched — the guard defends a real invariant.

Two decisions worth review:

- **The lookup is tri-state, and that is the whole fix.** It matches the guard's documented *"block only on positive mismatch; fail-open"* contract: `true` holds, `false` means the query **succeeded** and this session does not hold it, `null` means we could not tell (no creds / timeout / non-ok). Collapsing `null` into `false` would let any transient lookup blip re-block the exact worker this fix exists to unblock. A plain boolean cannot express that difference.
- **The decision moved into `worktree-claim-decision.cjs`**, following the existing `askuser-worker-policy.cjs` precedent in this same hook. The hook runs `main()` at load, so nothing inside it can be `require`d — which is why this guard's neighbours are tested by *source pins*. A pin passes whether or not the decision is correct, and the defect here was a **wrong decision**, not a missing string.

I deliberately did **not** reuse `lib/claim/get-my-claims.cjs`, which already covers both tables. It takes an injected supabase client, and this hook is raw-`fetch`-only on a PreToolUse hot path — importing it would drag `@supabase/supabase-js` into every Edit/Write. Worth noting separately: that helper's own header says it was made CJS *so this hook could import it*, but the client-injection signature means this caller structurally cannot. Flagged, not fixed here.

## Verification

- **9 behavioural tests**, plus 22 green in the neighbouring hook/claim-guard suites.
- **Mutation-proved:** restoring the pre-fix blindness turns exactly the **3 QF-visibility tests red and leaves the 6 SD-invariant tests green** — the correct signature for a change that touches only the QF axis.
- **Live-checked three ways** against the real database, since a wrong column here returns empty *silently* rather than erroring: the QF I hold returns a row; one I do not hold returns a genuine empty (HTTP 200, not an error); and the same QF under a different session returns empty — so the session scoping is real, not coincidental.

The test matrix is the one the QF asked for: a session holding an SD claim **and** a QF claim may edit the QF worktree, but still may not edit a foreign SD worktree — nor a QF worktree it does not hold.

🤖 Generated with [Claude Code](https://claude.com/claude-code)