### PR TITLE
QF-20260803-007: a green write that discarded part of its payload, in two places

### DIFF
--- a/lib/sub-agent-executor/results-storage.js
+++ b/lib/sub-agent-executor/results-storage.js
@@ -408,7 +408,17 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
   // FIX: Filter out nested findings from results.metadata before spreading
   // This prevents recursive snowballing where previous sub-agent results are nested
   const safeMetadata = (() => {
-    if (!results.metadata) return {};
+    // QF-20260803-007: a TOP-LEVEL results.findings was dropped without a trace. The strip below
+    // only ever saw results.metadata.findings, so a sub-agent returning findings at the top level —
+    // which they do — lost them with no marker and no warning. Caught by this QF's own test, which
+    // is worth stating plainly: the first version of this fix asserted the top-level key was
+    // "already stripped into metadata" and it was not. Deliberately recording only the KEYS, never
+    // the content, because the anti-snowball intent of the strip below is correct and copying
+    // findings onto the row would nest one sub-agent's results inside the next one's.
+    const topLevelFindings = results.findings
+      ? { _findings_stripped: true, _findings_had_keys: Object.keys(results.findings) }
+      : {};
+    if (!results.metadata) return topLevelFindings;
     // SD-LEO-INFRA-WRITER-SUB-AGENT-001 / FR-3a: verdict_chain is EXCLUDED from the caller-supplied
     // spread and re-attached below from the value this writer actually observed.
     //
@@ -436,7 +446,7 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
     // Record the attempt rather than dropping it silently — a caller sending a chain is either a bug
     // or a forgery, and both are worth seeing. (Absence of this key is the normal case.)
     if (_callerSuppliedChain !== undefined) rest._verdict_chain_from_caller_ignored = true;
-    return rest;
+    return { ...topLevelFindings, ...rest };
   })();
 
   // The chain THIS PROCESS built, captured before the spread can influence it. Mutators call
@@ -551,7 +561,16 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
         const artifact = await createArtifact(analysisStr, {
           source_tool: 'sub-agent-executor',
           type: 'analysis',
-          sd_id: sdId,
+          // QF-20260803-007 (bundled defect de801d8e): normalizedSdId, NOT sdId. This path passed
+          // the raw SD KEY while the results insert 50 lines down already used the normalized UUID
+          // — the same value, normalized for one write and not the other. agent_artifacts.sd_id has
+          // the identical UUID FK, so a caller who passes a key (store-sub-agent-repo-evidence.js
+          // does) got agent_artifacts_sd_id_fkey "Key (sd_id)=(SD-...) is not present", which the
+          // catch below turned into a console.warn and an inline fallback. Witnessed three times:
+          // twice on FLEET-DOWN-PAGER, and again today by a SECURITY sub-agent whose 21KB analysis
+          // silently fell back inline. Under the inline cap the content survives, so the only
+          // symptom is a warning nobody reads; over it, the analysis is gone.
+          sd_id: normalizedSdId,
           metadata: { sub_agent_code: code, field: 'detailed_analysis' }
         });
 
@@ -604,6 +623,12 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
     warnings: results.warnings || [],
     recommendations: results.recommendations || [],
     detailed_analysis: detailedAnalysis,
+    // QF-20260803-007: THE FIELD THIS QF IS NAMED FOR. `summary` is a real column on
+    // sub_agent_execution_results (verified live, not inferred from a migration) and this record
+    // never mentioned it — so every caller passing a summary got a green write, a created row, and
+    // no summary, with no error anywhere. Two sub-agents this morning wrote evidence rows whose
+    // substance was gone; one noticed only by reading the row back with select('*').
+    summary: typeof results.summary === 'string' && results.summary.trim() ? results.summary.trim() : null,
     execution_time: executionTimeSec,
     // SD-LEO-PROTOCOL-V4-4-0: Add adaptive validation mode fields
     validation_mode: results.validation_mode || 'prospective',  // Default to prospective for backward compatibility
@@ -616,6 +641,30 @@ export async function storeSubAgentResults(code, sdId, subAgent, results, option
     metadata,
     created_at: new Date().toISOString()
   };
+
+  // QF-20260803-007 — THE CLASS, which is why this exists and not just the one-line summary fix
+  // above: A WRITE THAT RETURNS GREEN WHILE DISCARDING PART OF ITS PAYLOAD. `summary` was dropped
+  // for months because an unmapped field and a deliberately-unpersisted field look EXACTLY alike
+  // in this object — both are simply absent. Nothing distinguished "we chose not to store this"
+  // from "we forgot", so neither a reader nor a test could tell them apart.
+  //
+  // The fix is to make the intent explicit and let anything outside it be loud. Deliberate
+  // non-columns are named WITH their reason; every other caller key that never reaches the record
+  // is reported. This is the enumeration the QF asks for — one pass over the caller's keys against
+  // the mapped set — and it is a warning, never a throw: a diagnostic that could break a write is
+  // worse than the defect it reports.
+  const PERSISTED_ELSEWHERE = Object.freeze({
+    findings: 'no findings column exists; key list recorded in metadata._findings_had_keys, content deliberately not copied',
+    confidence_score: 'folded into `confidence` by normalizeConfidence()',
+    execution_time_ms: 'converted to seconds into `execution_time`',
+    verdict_chain: 'ignored from the caller and rebuilt from what this process observed',
+    sd_id: 'normalized to a UUID and written as the record sd_id',
+    sd_key: 'display/logging only',
+  });
+  const unpersisted = Object.keys(results || {}).filter((k) => !(k in record) && !(k in PERSISTED_ELSEWHERE));
+  if (unpersisted.length > 0) {
+    console.warn(`   [PAYLOAD] ${code}: ${unpersisted.length} caller field(s) reach this writer and are NOT stored: ${unpersisted.join(', ')}. If that is intentional, add each to PERSISTED_ELSEWHERE with its reason — an omission must not read identical to a bug.`);
+  }
 
   // SD-LEO-INFRA-SUB-AGENT-EXECUTION-001-B (TR-003): Dedup check
   // Prevent duplicate records for same sd_id + sub_agent_code + phase within 5 minutes

--- a/tests/unit/sub-agent-executor/results-storage-payload-fidelity.test.js
+++ b/tests/unit/sub-agent-executor/results-storage-payload-fidelity.test.js
@@ -1,0 +1,168 @@
+/**
+ * QF-20260803-007 — a write that returns GREEN while DISCARDING part of its payload.
+ *
+ * Two independently-witnessed defects in one writer, claimed together because they are the same
+ * shape: it handles part of its input correctly and drops or mishandles the rest without saying so.
+ *
+ *   1. `summary` was never in the record. The column EXISTS on sub_agent_execution_results
+ *      (verified against the live table, not inferred from a migration), so a caller passing a
+ *      summary got a success return, a created row, and no summary — with no error anywhere.
+ *   2. The artifact compression path passed the RAW sd key where agent_artifacts.sd_id has the same
+ *      UUID FK the results row already normalizes for. The insert failed with
+ *      agent_artifacts_sd_id_fkey, the catch turned it into a console.warn, and the analysis fell
+ *      back inline. Under the inline cap the content survives and the only symptom is a warning
+ *      nobody reads; over it, the analysis is gone.
+ *
+ * WHY THESE TESTS ASSERT ON THE RECORD RATHER THAN ON A RETURN VALUE: the return value was GREEN
+ * throughout both defects. That is the entire class. So each test inspects what was actually handed
+ * to insert() — the "assert what LANDED" shape the QF asks for — and a test that trusted the call's
+ * result would have passed against the broken writer.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+function makeMockSupabase(capture) {
+  return {
+    from(table) {
+      return {
+        select() { return this; },
+        eq() { return this; },
+        is() { return this; },
+        gte() { return this; },
+        order() { return this; },
+        limit() { return Promise.resolve({ data: [], error: null }); },
+        insert(record) {
+          capture.insertedTable = table;
+          capture.inserted = record;
+          return {
+            select: () => ({
+              single: async () => ({ data: { id: 'mock-row-id', ...record }, error: null })
+            })
+          };
+        },
+        update(fields) {
+          return {
+            eq: () => ({
+              select: () => ({ single: async () => ({ data: { id: 'mock-row-id', ...fields }, error: null }) })
+            })
+          };
+        }
+      };
+    }
+  };
+}
+
+describe('QF-20260803-007 — the writer must not discard payload while returning green', () => {
+  const capture = {};
+
+  beforeEach(() => {
+    capture.inserted = null;
+    capture.insertedTable = null;
+    capture.artifactArgs = null;
+
+    vi.doMock('../../../lib/sub-agent-executor/supabase-client.js', () => ({
+      getSupabaseClient: async () => makeMockSupabase(capture)
+    }));
+    // A REAL normalizer stand-in, not an identity no-op: the artifact defect is precisely that the
+    // key and the UUID diverge, so a normalizer that returns its input unchanged would make the
+    // broken and fixed code indistinguishable and the test would pass either way.
+    vi.doMock('../../../scripts/modules/sd-id-normalizer.js', () => ({
+      normalizeSDId: async (_s, v) => (String(v).startsWith('SD-') ? '11111111-2222-3333-4444-555555555555' : v)
+    }));
+    vi.doMock('../../../lib/artifact-tools.js', () => ({
+      createArtifact: async (_content, opts) => {
+        capture.artifactArgs = opts;
+        return { artifact_id: 'artifact-1', token_count: 10, summary: 'compressed' };
+      }
+    }));
+  });
+
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('../../../lib/sub-agent-executor/supabase-client.js');
+    vi.doUnmock('../../../scripts/modules/sd-id-normalizer.js');
+    vi.doUnmock('../../../lib/artifact-tools.js');
+  });
+
+  it('persists summary — the field this QF is named for', async () => {
+    const { storeSubAgentResults } = await import('../../../lib/sub-agent-executor/results-storage.js');
+    await storeSubAgentResults('TESTING', 'SD-TEST-001', null, {
+      verdict: 'PASS',
+      confidence: 90,
+      summary: 'PASS — 49/49 tests, four mutations killed.',
+      detailed_analysis: 'short'
+    });
+
+    expect(capture.insertedTable).toBe('sub_agent_execution_results');
+    expect(capture.inserted.summary).toBe('PASS — 49/49 tests, four mutations killed.');
+    // The row must carry BOTH: the original defect stored detailed_analysis correctly, which is
+    // exactly why the missing summary went unnoticed for months.
+    expect(capture.inserted.detailed_analysis).toBe('short');
+  });
+
+  it('normalizes an absent or blank summary to null rather than storing whitespace', async () => {
+    const { storeSubAgentResults } = await import('../../../lib/sub-agent-executor/results-storage.js');
+    await storeSubAgentResults('TESTING', 'SD-TEST-001', null, { verdict: 'PASS', confidence: 90 });
+    expect(capture.inserted.summary).toBeNull();
+    expect('summary' in capture.inserted).toBe(true); // present-and-null, not absent
+
+    vi.resetModules();
+    const { storeSubAgentResults: store2 } = await import('../../../lib/sub-agent-executor/results-storage.js');
+    await store2('TESTING', 'SD-TEST-001', null, { verdict: 'PASS', confidence: 90, summary: '   ' });
+    expect(capture.inserted.summary).toBeNull();
+  });
+
+  it('sends the NORMALIZED uuid to the artifact insert, not the raw sd key', async () => {
+    const { storeSubAgentResults } = await import('../../../lib/sub-agent-executor/results-storage.js');
+    // Over RESULT_COMPRESSION_THRESHOLD (8KB) so the compression path actually fires.
+    await storeSubAgentResults('SECURITY', 'SD-TEST-001', null, {
+      verdict: 'PASS',
+      confidence: 90,
+      detailed_analysis: 'x'.repeat(9000)
+    });
+
+    expect(capture.artifactArgs, 'the compression path must have fired').not.toBeNull();
+    // THE ASSERTION THAT FAILS AGAINST THE OLD CODE: it passed 'SD-TEST-001' here.
+    expect(capture.artifactArgs.sd_id).toBe('11111111-2222-3333-4444-555555555555');
+    expect(capture.artifactArgs.sd_id).not.toBe('SD-TEST-001');
+    // And the two writes must agree — one value, normalized once, used by both.
+    expect(capture.inserted.sd_id).toBe(capture.artifactArgs.sd_id);
+  });
+
+  it('reports caller fields it does not store, so an omission cannot read like a bug', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { storeSubAgentResults } = await import('../../../lib/sub-agent-executor/results-storage.js');
+    await storeSubAgentResults('TESTING', 'SD-TEST-001', null, {
+      verdict: 'PASS',
+      confidence: 90,
+      some_future_field: 'nobody stores this'
+    });
+
+    const payloadWarnings = warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes('[PAYLOAD]'));
+    expect(payloadWarnings.length).toBe(1);
+    expect(payloadWarnings[0]).toContain('some_future_field');
+    warn.mockRestore();
+  });
+
+  it('stays SILENT for deliberately-unpersisted fields — a noisy check gets deleted', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { storeSubAgentResults } = await import('../../../lib/sub-agent-executor/results-storage.js');
+    // Every one of these is handled somewhere other than a same-named column. If the enumeration
+    // flagged them it would cry wolf on every ordinary write, and the next person would remove it.
+    await storeSubAgentResults('TESTING', 'SD-TEST-001', null, {
+      verdict: 'PASS',
+      confidence_score: 90,
+      execution_time_ms: 1234,
+      summary: 'stored',
+      findings: { a: 1 },
+      metadata: { phase: 'EXEC' }
+    });
+
+    const payloadWarnings = warn.mock.calls.map((c) => String(c[0])).filter((m) => m.includes('[PAYLOAD]'));
+    expect(payloadWarnings, `unexpected payload warning: ${payloadWarnings[0] || ''}`).toEqual([]);
+    // findings has NO column — it is routed into metadata, which is explicit handling and must be
+    // preserved rather than "fixed" by mapping it to a column that does not exist.
+    expect(capture.inserted.metadata._findings_stripped).toBe(true);
+    warn.mockRestore();
+  });
+});


### PR DESCRIPTION
Two independently-witnessed defects in one writer (`lib/sub-agent-executor/results-storage.js`), bundled by the QF because they are the same shape: **the writer handles part of its input correctly and drops or mishandles the rest without saying so.** The return value was green throughout both.

### 1. `summary` was never in the record
The column **exists** on `sub_agent_execution_results` — verified against the live table, not inferred from a migration — and the record object simply never mentioned it. Every caller passing a summary got a success return, a created row, and no summary, with no error anywhere. Two sub-agents this morning wrote evidence rows whose substance was gone; one noticed only by reading the row back with `select('*')`.

### 2. The artifact insert used the raw SD key
`createArtifact` got `sd_id: sdId` while the results insert 50 lines below already used `normalizedSdId` — the same value, normalized for one write and not the other. `agent_artifacts.sd_id` has the identical UUID FK, so a caller passing a key (`store-sub-agent-repo-evidence.js` does) got `agent_artifacts_sd_id_fkey`, which the `catch` turned into a `console.warn` and an inline fallback. Under the inline cap the content survives and the only symptom is a warning nobody reads; over it, the analysis is gone. Third witness today: a SECURITY sub-agent's 21KB analysis.

### 3. The class, which is why the QF names it
An unmapped field and a deliberately-unpersisted field looked **exactly alike** here — both simply absent. Nothing distinguished "we chose not to store this" from "we forgot", so neither a reader nor a test could tell them apart, and that is why `summary` survived for months. Deliberate non-columns are now named *with their reason*; any other caller key that never reaches the record is reported. It warns, never throws — a diagnostic that can break a write is worse than the defect it reports.

**That enumeration immediately earned its place.** My first version of it asserted a top-level `results.findings` was "already stripped into metadata". It was not — the strip only ever saw `results.metadata.findings`, so a sub-agent returning findings at the top level lost them with no marker at all. This QF's own test caught my wrong claim. Top-level findings now record their **key list only**; copying the content would nest one sub-agent's results inside the next one's, which is the snowballing the original strip correctly exists to prevent.

### Verification
Every fix is mutation-proven against the mutation that exposed the original defect — drop the summary mapping (4 red), restore the raw sd key (1 red), disable the enumeration (1 red), drop the top-level findings capture (1 red). **114 tests green across all 10 suites** that touch this writer.

The new tests assert on the record handed to `insert()` rather than on the call's return value, because the return value was green throughout both defects — that *is* the class, and a test that trusted it would have passed against the broken writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)