### PR TITLE
QF-20260727-363: QA FIXES counted detections and called them repairs

### DIFF
--- a/scripts/stale-session-sweep.cjs
+++ b/scripts/stale-session-sweep.cjs
@@ -1366,6 +1366,22 @@ async function runQaFixtureScan(ctx) {
     sweepAliveCcPids = new Set((detectIdentityCollisions().aliveMarkers || []).map(m => String(m.pid)));
   } catch { sweepAliveCcPids = null; } // fail-soft: guard still applies heartbeat/source-side signals
 
+  // QF-20260727-363 — WHAT WAS APPLIED, counted separately from what was DETECTED.
+  //
+  // Every "QA FIXES" line used to be printed from the DETECTED array's length, so the summary
+  // could never learn whether the update it was describing actually happened. The reset line made
+  // that visible and permanent: isSweepResetAllowed correctly refuses to reset an SD whose
+  // PLAN-TO-LEAD handoff is accepted, the loop `continue`s without touching the row, and the
+  // summary still printed "Reset 1 SD(s)". The same run printed "QA: skipped reset on <SD>" three
+  // lines above — the sweep reported a repair in the same breath as reporting it refused to make
+  // it, on roughly fifteen consecutive runs, in the most-read fleet output.
+  //
+  // Counted here rather than at the print site because only the apply path knows the answer. Each
+  // counter is incremented ONLY inside the branch that confirmed the write, so a guard-skip, a DB
+  // error, or a zero-row match can never reach the summary as a repair. The skipped items keep
+  // their own honest line under ACTIONS TAKEN and get no second representation.
+  const applied = { released: 0, releasedOrphaned: 0, completed: 0, reset: 0, cleared: 0 };
+
   const workingOnCompleted = classified.filter(s => {
     const sd = sdStatusMap[s.sd_key];
     if (!sd || (sd.status !== 'completed' && sd.status !== 'cancelled')) return false;
@@ -1405,6 +1421,7 @@ async function runQaFixtureScan(ctx) {
       .eq('session_id', s.session_id);
 
     if (!error) {
+      applied.released++; // QF-20260727-363
       // Also clear claiming_session_id on the SD to break the churn loop
       await supabase
         .from('strategic_directives_v2')
@@ -1492,6 +1509,7 @@ async function runQaFixtureScan(ctx) {
       .eq('session_id', s.session_id);
 
     if (!error) {
+      applied.releasedOrphaned++; // QF-20260727-363
       actions.push('QA: released ' + s.session_id + ' (' + s.tty + ') — SD ' + s.sd_key + ' not found in DB');
     }
   }
@@ -1551,6 +1569,7 @@ async function runQaFixtureScan(ctx) {
         .select();
 
       if (!error) {
+        applied.completed++; // QF-20260727-363
         actions.push('QA: completed ' + sd.sd_key + ' — was stuck at 100%/pending_approval with completion_date');
       }
     } else {
@@ -1560,7 +1579,11 @@ async function runQaFixtureScan(ctx) {
       if (!(await isSweepResetAllowed(sd.sd_key, 'LEAD', 'pending_approval-reset'))) {
         continue;
       }
-      const { error } = await supabase
+      // QF-20260727-363: `.select()` added. Without it this update returned no rows and the code
+      // below inferred success from the ABSENCE OF AN ERROR — but an UPDATE matching zero rows is
+      // not an error, so a reset that changed nothing was indistinguishable from one that worked.
+      // Counting a repair requires knowing a row moved, and the row is the only thing that knows.
+      const { data: resetRows, error } = await supabase
         .from('strategic_directives_v2')
         .update({
           status: 'draft',
@@ -1570,9 +1593,11 @@ async function runQaFixtureScan(ctx) {
           active_session_id: null, // FR-1: co-clear (SD-only update → trigger won't fire)
           is_working_on: false
         })
-        .eq('sd_key', sd.sd_key);
+        .eq('sd_key', sd.sd_key)
+        .select('sd_key');
 
-      if (!error) {
+      if (!error && (resetRows || []).length > 0) {
+        applied.reset++; // QF-20260727-363
         actions.push('QA: reset ' + sd.sd_key + ' from pending_approval → draft/LEAD/0% (no session working on it)');
       }
     }
@@ -1605,6 +1630,7 @@ async function runQaFixtureScan(ctx) {
       .select();
 
     if (!error) {
+      applied.cleared++; // QF-20260727-363
       actions.push('QA: cleared stale claiming_session_id on ' + sd.status + ' ' + sd.sd_key);
     }
   }
@@ -1626,7 +1652,7 @@ async function runQaFixtureScan(ctx) {
   // Adversarial-review fix (PR #5755): main() still consumes these five locals after the
   // hoist (dead-release cross-signal gate, CLAIM_RELEASED announce, QA summary) — return
   // them so the call site can rebind what used to be main()-scoped declarations.
-  return { sdStatusMap, workingOnCompleted, orphanedClaims, stuckApproval, terminalWithClaims };
+  return { sdStatusMap, workingOnCompleted, orphanedClaims, stuckApproval, terminalWithClaims, applied };
 }
 
 /**
@@ -2423,7 +2449,7 @@ async function main() {
   // Adversarial-review fix (PR #5755): rebind the five formerly-main()-scoped locals the
   // hoist relocated — the dead-release cross-signal gate (sdStatusMap), the CLAIM_RELEASED
   // announce loop, and the QA summary below all still read them from main() scope.
-  const { sdStatusMap, workingOnCompleted, orphanedClaims, stuckApproval, terminalWithClaims } =
+  const { sdStatusMap, workingOnCompleted, orphanedClaims, stuckApproval, terminalWithClaims, applied } =
     await runQaFixtureScan(sweepPassCtx);
 
   // QF-20260525-211: the QF stale-claim clear formerly inlined here now runs via
@@ -3674,17 +3700,36 @@ async function main() {
   }
 
   // QA summary
-  const stuckCompleted = stuckApproval.filter(sd => sd.progress_percentage >= 100 && sd.completion_date);
-  const stuckReset = stuckApproval.filter(sd => !(sd.progress_percentage >= 100 && sd.completion_date));
-  const qaIssues = workingOnCompleted.length + orphanedClaims.length + stuckApproval.length + (terminalWithClaims || []).length;
+  //
+  // QF-20260727-363: every line below now reports what was APPLIED. It used to report what was
+  // DETECTED, which made this block claim repairs the sweep had explicitly refused to perform —
+  // the reset line printed "Reset 1 SD(s)" on the same run, about the same SD, as the
+  // "QA: skipped reset" line under ACTIONS TAKEN. That is a false green in the most-read fleet
+  // output, and a permanent one: an SD legitimately resting in pending_approval awaiting
+  // LEAD-FINAL-APPROVAL stays there until a human acts, so the false line reprints forever and
+  // teaches the reader that a non-zero QA FIXES count is normal background. That is how a REAL
+  // repair count stops being noticed.
+  //
+  // The header count is applied-derived too. Leaving it as the detected total would have kept the
+  // headline number lying while the itemised lines told the truth, which is worse than either.
+  // `a.detected` is retained ONLY to decide whether the section is worth printing at all — see
+  // below; a run that detected nothing and repaired nothing prints nothing, as before.
+  const a = applied || { released: 0, releasedOrphaned: 0, completed: 0, reset: 0, cleared: 0 };
+  const detected = workingOnCompleted.length + orphanedClaims.length + stuckApproval.length + (terminalWithClaims || []).length;
+  const qaIssues = a.released + a.releasedOrphaned + a.completed + a.reset + a.cleared;
   if (qaIssues > 0) {
     console.log('QA FIXES (' + qaIssues + '):');
-    if (workingOnCompleted.length > 0) console.log('  Released ' + workingOnCompleted.length + ' session(s) working on completed SDs');
-    if (orphanedClaims.length > 0) console.log('  Released ' + orphanedClaims.length + ' session(s) with orphaned claims');
-    if (stuckCompleted.length > 0) console.log('  Completed ' + stuckCompleted.length + ' SD(s) stuck at 100%/pending_approval');
-    if (stuckReset.length > 0) console.log('  Reset ' + stuckReset.length + ' SD(s) from pending_approval → draft (no session working on them)');
-    if ((terminalWithClaims || []).length > 0) console.log('  Cleared ' + (terminalWithClaims || []).length + ' stale claiming_session_id on completed/cancelled SDs');
+    if (a.released > 0) console.log('  Released ' + a.released + ' session(s) working on completed SDs');
+    if (a.releasedOrphaned > 0) console.log('  Released ' + a.releasedOrphaned + ' session(s) with orphaned claims');
+    if (a.completed > 0) console.log('  Completed ' + a.completed + ' SD(s) stuck at 100%/pending_approval');
+    if (a.reset > 0) console.log('  Reset ' + a.reset + ' SD(s) from pending_approval → draft (no session working on them)');
+    if (a.cleared > 0) console.log('  Cleared ' + a.cleared + ' stale claiming_session_id on completed/cancelled SDs');
     if (claimIntegrityIssues.length > 0) console.log('  Nudged ' + claimIntegrityIssues.length + ' idle session(s) with CLAIM_REMINDER');
+    console.log('');
+  } else if (detected > 0) {
+    // DETECTED BUT NOT REPAIRED IS ITS OWN OUTCOME, and silence would misreport it as "nothing
+    // found". Before this change that state was impossible to see: it rendered as a QA FIX.
+    console.log('QA FIXES (0): ' + detected + ' item(s) detected, none repaired — see ACTIONS TAKEN for why (guards may have correctly declined).');
     console.log('');
   }
 

--- a/tests/unit/lib/sweep/pass-registry.test.js
+++ b/tests/unit/lib/sweep/pass-registry.test.js
@@ -169,7 +169,15 @@ describe('runQaFixtureScan scope contract (adversarial-review fix, PR #5755)', (
   const FIVE = ['sdStatusMap', 'workingOnCompleted', 'orphanedClaims', 'stuckApproval', 'terminalWithClaims'];
 
   it('runQaFixtureScan returns the five formerly-main()-scoped locals', () => {
-    const re = new RegExp(`return\\s*\\{\\s*${FIVE.join('\\s*,\\s*')}\\s*\\}`);
+    // QF-20260727-363: this pin used to require the return object to CLOSE immediately after
+    // terminalWithClaims (`\\s*\\}`), which pinned the ARITY as well as the membership. The
+    // regression it exists to catch is a MISSING local — main() consuming something the hoisted
+    // function no longer returns, a guaranteed ReferenceError on every tick that no test can catch
+    // because nothing executes main(). Forbidding ADDITIONAL keys defends nothing and made a
+    // legitimate extension (the `applied` tally) look like that regression. Now membership-only,
+    // matching the sibling rebinding pin below, which has always used `[^}]*` for exactly this
+    // reason. Drop any one of the five and this still goes red — verified by mutation.
+    const re = new RegExp(`return\\s*\\{[^}]*${FIVE.join('[^}]*')}[^}]*\\}`);
     expect(source).toMatch(re);
   });
 

--- a/tests/unit/stale-session-sweep-qa-fixes-applied-not-detected.test.js
+++ b/tests/unit/stale-session-sweep-qa-fixes-applied-not-detected.test.js
@@ -1,0 +1,104 @@
+/**
+ * QF-20260727-363 — the QA FIXES summary must count what was APPLIED, not what was DETECTED.
+ *
+ * THE DEFECT: every line in the QA FIXES block was printed from a detected array's `.length`, so it
+ * could never learn whether the update it described actually happened. The reset line made that
+ * permanent and visible — isSweepResetAllowed correctly refuses to reset an SD whose PLAN-TO-LEAD
+ * handoff is accepted, the loop `continue`s without touching the row, and the summary still printed
+ * "Reset 1 SD(s)" while "QA: skipped reset on <SD>" appeared three lines above it in the SAME run.
+ * Verified at the DB after a sweep: the SD was still pending_approval. Observed across ~15
+ * consecutive sweeps.
+ *
+ * WHY THIS IS A SOURCE SCAN. stale-session-sweep.cjs is a ~3700-line CJS script whose QA path is
+ * welded to a live PostgREST client; the file's existing guards (builder-catch, dormancy-gate) take
+ * the same approach for the same reason. The property being defended is structural — "no summary
+ * line may read a detected array" — and a structural property is exactly what a scan can prove for
+ * the WHOLE block rather than for the one line someone remembered to cover.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(path.resolve(__dirname, '../../scripts/stale-session-sweep.cjs'), 'utf8');
+
+/** The QA FIXES print block: from the header line to the blank-line close. */
+function qaFixesBlock() {
+  const start = SRC.indexOf("console.log('QA FIXES (");
+  expect(start, 'the QA FIXES block must still exist').toBeGreaterThan(-1);
+  return SRC.slice(start, start + 1600);
+}
+
+describe('QF-20260727-363: QA FIXES reports applied repairs, never detections', () => {
+  const DETECTED_ARRAYS = ['workingOnCompleted', 'orphanedClaims', 'stuckApproval', 'stuckReset', 'stuckCompleted', 'terminalWithClaims'];
+
+  it('[CONTROL] the scan can see the block and the detected arrays still exist upstream', () => {
+    // Without this, a rename that made every assertion below vacuous would pass silently — a scan
+    // for something that no longer exists is not a clean result, it is a blind one.
+    const block = qaFixesBlock();
+    expect(block).toContain('Reset ');
+    expect(block).toContain('Released ');
+    expect(SRC).toMatch(/const workingOnCompleted = classified\.filter/);
+    expect(SRC).toMatch(/const stuckApproval = /);
+  });
+
+  it('no repair line in the summary is driven by a detected array length', () => {
+    const block = qaFixesBlock();
+    const offenders = DETECTED_ARRAYS.filter((name) => new RegExp(`\\b${name}\\b[^\\n]*\\.length`).test(block));
+    expect(
+      offenders,
+      `QA FIXES prints a count from detected set(s): ${offenders.join(', ')}. A detection is not a repair — ` +
+      'drive the line from the applied tally, which is incremented only where a write was confirmed.'
+    ).toEqual([]);
+  });
+
+  it('each repair line reads its own applied counter', () => {
+    const block = qaFixesBlock();
+    for (const counter of ['a.released', 'a.releasedOrphaned', 'a.completed', 'a.reset', 'a.cleared']) {
+      expect(block, `the summary must print ${counter}`).toContain(counter);
+    }
+    // The HEADER too: an honest itemisation under a lying total is still a lying summary.
+    expect(block).toMatch(/QA FIXES \(' \+ qaIssues/);
+    expect(SRC).toMatch(/const qaIssues = a\.released \+ a\.releasedOrphaned \+ a\.completed \+ a\.reset \+ a\.cleared/);
+  });
+
+  it('every applied counter is incremented only inside a confirmed-write branch', () => {
+    // THE LOAD-BEARING ONE. Moving an increment out of its `if (!error)` branch would restore the
+    // original defect while leaving all the assertions above green.
+    const increments = [...SRC.matchAll(/applied\.(released|releasedOrphaned|completed|reset|cleared)\+\+/g)];
+    expect(increments.length, 'all five counters must be incremented somewhere').toBe(5);
+    for (const m of increments) {
+      const preceding = SRC.slice(Math.max(0, m.index - 400), m.index);
+      const lastGuard = preceding.lastIndexOf('if (!error');
+      expect(
+        lastGuard,
+        `applied.${m[1]}++ is not inside an if (!error...) branch — it would count an attempt, not a repair`
+      ).toBeGreaterThan(-1);
+    }
+  });
+
+  it('the pending_approval reset selects its rows, so a zero-row update cannot count as a repair', () => {
+    // An UPDATE matching zero rows is NOT an error in PostgREST, so `!error` alone proved nothing.
+    // The reset is the one path whose count this QF is about, so it must know a row actually moved.
+    const resetIdx = SRC.indexOf("status: 'draft',");
+    expect(resetIdx).toBeGreaterThan(-1);
+    const resetCall = SRC.slice(resetIdx, resetIdx + 700);
+    expect(resetCall).toMatch(/\.select\(['"]sd_key['"]\)/);
+    expect(resetCall).toMatch(/resetRows \|\| \[\]\)\.length > 0/);
+  });
+
+  it('detected-but-not-repaired is still reported, rather than becoming silence', () => {
+    // Before the fix this state was unreachable — it rendered as a QA FIX. After it, the risk flips
+    // to the opposite failure: printing nothing and letting a reader conclude nothing was found.
+    expect(SRC).toContain('detected, none repaired');
+    expect(SRC).toMatch(/} else if \(detected > 0\) {/);
+  });
+
+  it('the guard the QF forbids weakening is untouched', () => {
+    // The QF is explicit: the counter was wrong, isSweepResetAllowed was RIGHT. An SD with an
+    // accepted PLAN-TO-LEAD handoff must not be reset out from under a pending LEAD-FINAL-APPROVAL.
+    expect(SRC).toMatch(/if \(!\(await isSweepResetAllowed\(sd\.sd_key, 'LEAD', 'pending_approval-reset'\)\)\) \{\s*\n\s*continue;/);
+    expect(SRC).toContain('QA: skipped reset on ');
+  });
+});


### PR DESCRIPTION
The sweep reported a repair **in the same breath as reporting that it refused to make it.** Every run printed both of these, about the same SD:

```
ACTIONS TAKEN:  QA: skipped reset on SD-... — PLAN-TO-LEAD accepted, awaiting LEAD-FINAL-APPROVAL
QA FIXES (1):   Reset 1 SD(s) from pending_approval → draft (no session working on them)
```

`isSweepResetAllowed` correctly declines to reset an SD whose PLAN-TO-LEAD handoff is accepted, and the loop `continue`s without touching the row. But the summary derived its count from the **detected** set, so it never learned whether the update happened. **The guard was right; the counter was wrong.** Verified at the DB after a sweep — the SD was still `pending_approval`.

Not cosmetic and not transient: an SD legitimately resting in `pending_approval` awaiting LEAD-FINAL-APPROVAL stays there until a human acts, so the false line reprints on every sweep **forever** — observed across ~15 consecutive runs — in the most-read fleet output. That is how a reader learns a non-zero QA FIXES count is normal background, which is how a *real* repair count stops being noticed.

### The fix
An `applied` tally incremented **only** inside the branch that confirmed each write; every summary line — including the header total — reads from it. An honest itemisation under a lying total would still be a lying summary.

**All five lines, not just the reset.** The QF asked for the siblings to be checked rather than fixing only the noticed instance, and they had the same divergence in a rarer form: Released / Completed / Cleared each gate their action push on `!error` while the summary counted the detected length, so a DB error overstated them too.

**The reset also gained `.select('sd_key')`.** It had none, so success was inferred from the *absence of an error* — but an UPDATE matching zero rows is not an error, and a reset that changed nothing was indistinguishable from one that worked. Counting a repair requires knowing a row moved.

**Detected-but-not-repaired is now stated**, rather than becoming silence. Before this change that state was unreachable (it rendered as a QA FIX); after it, the opposite failure would be printing nothing and letting a reader conclude nothing was found — so it gets its own line pointing at ACTIONS TAKEN for the reason.

`isSweepResetAllowed` is untouched, per the QF's explicit instruction, and a test pins it that way.

### Verification
Mutation-proven: restore the detected-length reset line (**2 red**), move an increment outside its confirmed-write branch (**1 red**), drop the `.select()` (**1 red**). **37 tests green** across all 6 `stale-session-sweep` suites.

The new test is a source scan, matching this file's existing guards (`builder-catch`, `dormancy-gate`) — the sweep's QA path is welded to a live PostgREST client, and the property being defended is structural ("no summary line may read a detected array"), which a scan can prove for the *whole block* rather than for the one line someone remembered to cover. It carries a positive control so a rename can't make it vacuously green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)