### PR TITLE
fix(QF-20260807-201): verifier disagreement is inexpressible in the journal schema

### DIFF
--- a/lib/harness/run-journal.mjs
+++ b/lib/harness/run-journal.mjs
@@ -50,11 +50,25 @@ export const EVENT_KINDS = Object.freeze([
   'fence_assertion',        // §H5/§H6 fence check result
   'checkpoint',             // §H7 cap-boundary continuation point
   'lifecycle',              // fixture created / torn down / run started / finalized
+  // QF-20260807-201: §H10 mandates that verifier disagreement is journaled and never silently
+  // resolved — but until now the schema could not express one. On run s2026-alpha4-0807 two
+  // fresh-context verifiers disputed the runner summary and both verdicts had to be demoted to
+  // 'lifecycle', where they are indistinguishable from ordinary run narration and invisible to
+  // any reader filtering by kind. BETA's §4 grading reads this record, so a disagreement that
+  // cannot be found by kind is a disagreement that did not reach the grader.
+  'verifier_disagreement',  // §H10: an independent verifier disputes the run's own summary
 ]);
 
 export const FINDING_TYPES = Object.freeze([
   'DEAD_LOOP', 'NO_DATA_GAUGE', 'CANNOT_DRIVE', 'TEST_MODE_DIVERGENCE', 'FENCE_BREACH', 'RESIDUE',
 ]);
+
+/**
+ * QF-20260807-201: which verdict GOVERNS when verifiers diverge. Recording the disagreement
+ * without recording who wins leaves the reader to guess, which is the silent resolution §H10
+ * forbids. 'owner_recount' is the §H10 default (the arc owner's recount governs).
+ */
+export const DISAGREEMENT_RULES = Object.freeze(['owner_recount', 'verifier_majority', 'unresolved']);
 
 export class RunJournal {
   /**
@@ -91,6 +105,17 @@ export class RunJournal {
     if (e.kind === 'finding' && !FINDING_TYPES.includes(e.finding_type)) {
       throw new Error(`finding requires finding_type in ${FINDING_TYPES.join('|')}`);
     }
+    // QF-20260807-201: same allowlist discipline as 'finding'. A disagreement missing either
+    // verdict, or missing the governing rule, is exactly the half-record §H10 forbids — so it
+    // is rejected at write time rather than persisted as an unreadable entry.
+    if (e.kind === 'verifier_disagreement') {
+      if (!e.claim || !e.counter_claim) {
+        throw new Error('verifier_disagreement requires both claim (the run summary) and counter_claim (the verifier verdict)');
+      }
+      if (!DISAGREEMENT_RULES.includes(e.governing_rule)) {
+        throw new Error(`verifier_disagreement requires governing_rule in ${DISAGREEMENT_RULES.join('|')}`);
+      }
+    }
     const row = {
       seq: ++this._seq,
       at: this.clock(),
@@ -100,6 +125,13 @@ export class RunJournal {
       o_requirements: e.o_requirements || [],
       touched_tables: e.touched_tables || [],
       ...(e.finding_type ? { finding_type: e.finding_type } : {}),
+      // QF-20260807-201: PERSIST the three disagreement fields at top level, not just validate
+      // them. Validating a field and then dropping it from the row is the failure this whole QF
+      // set is about — the write looks correct and the record is empty. Top level (not detail)
+      // so a reader can filter/grep them the same way it filters by kind.
+      ...(e.kind === 'verifier_disagreement'
+        ? { claim: e.claim, counter_claim: e.counter_claim, governing_rule: e.governing_rule }
+        : {}),
       detail: e.detail || {},
     };
     appendFileSync(this.path, JSON.stringify(row) + '\n');
@@ -120,6 +152,26 @@ export class RunJournal {
       event,
       o_requirements: detail.o_requirements || [],
       detail,
+    });
+  }
+
+  /**
+   * QF-20260807-201: journal a §H10 verifier disagreement as a first-class entry. Mirrors
+   * finding()'s shape so the two record types are written the same way.
+   * @param {string} event - one-line summary of what diverged
+   * @param {{claim: string, counter_claim: string, governing_rule: string, detail?: object}} v
+   *   claim = the run's own summary; counter_claim = the verifier's verdict;
+   *   governing_rule = which one governs (DISAGREEMENT_RULES).
+   */
+  verifierDisagreement(event, v = {}) {
+    return this.append({
+      kind: 'verifier_disagreement',
+      event,
+      claim: v.claim,
+      counter_claim: v.counter_claim,
+      governing_rule: v.governing_rule,
+      o_requirements: v.detail?.o_requirements || [],
+      detail: v.detail || {},
     });
   }
 

--- a/tests/unit/harness/run-journal-verifier-disagreement.test.js
+++ b/tests/unit/harness/run-journal-verifier-disagreement.test.js
@@ -1,0 +1,95 @@
+/**
+ * QF-20260807-201 — §H10 mandates that verifier disagreement is journaled and never silently
+ * resolved, but the journal schema could not express one. On run s2026-alpha4-0807 two
+ * fresh-context verifiers disputed the runner's own summary and both verdicts had to be demoted
+ * to `lifecycle`, where they are indistinguishable from run narration. BETA's §4 grading reads
+ * this record, so a disagreement not findable by kind never reaches the grader.
+ *
+ * The acceptance case named in the QF is the LAST test here: replay that real disagreement and
+ * find it by kind.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { rmSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RunJournal, EVENT_KINDS, DISAGREEMENT_RULES } from '../../../lib/harness/run-journal.mjs';
+
+let baseDir;
+const j = (runId = 'qf201') => new RunJournal(runId, { baseDir, clock: () => '2026-08-07T13:00:00Z' });
+const VALID = { claim: 'positive=7/9', counter_claim: '6 CANNOT_DRIVE across O3,O5,O6,O7,O8', governing_rule: 'owner_recount' };
+
+beforeEach(() => { baseDir = mkdtempSync(join(tmpdir(), 'qf201-')); });
+afterEach(() => { rmSync(baseDir, { recursive: true, force: true }); });
+
+describe('QF-20260807-201: verifier_disagreement is a first-class journal kind', () => {
+  it('is an allowed kind — the demotion path to lifecycle is gone', () => {
+    expect(EVENT_KINDS).toContain('verifier_disagreement');
+    expect(() => j().append({ kind: 'verifier_disagreement', event: 'e', ...VALID })).not.toThrow();
+  });
+
+  it('PERSISTS both verdicts and the governing rule — validating then dropping them is the bug', () => {
+    const row = j().append({ kind: 'verifier_disagreement', event: 'coverage lens disputes summary', ...VALID });
+    // Read back from disk, not the return value: the record is what the grader sees.
+    const [onDisk] = j().readAll();
+    for (const r of [row, onDisk]) {
+      expect(r.claim).toBe(VALID.claim);
+      expect(r.counter_claim).toBe(VALID.counter_claim);
+      expect(r.governing_rule).toBe('owner_recount');
+    }
+  });
+
+  it('rejects a half-record: a disagreement missing either verdict', () => {
+    expect(() => j().append({ kind: 'verifier_disagreement', event: 'e', counter_claim: 'x', governing_rule: 'owner_recount' }))
+      .toThrow(/requires both claim/);
+    expect(() => j().append({ kind: 'verifier_disagreement', event: 'e', claim: 'x', governing_rule: 'owner_recount' }))
+      .toThrow(/requires both claim/);
+  });
+
+  it('rejects a disagreement with no governing rule — silent resolution is what H10 forbids', () => {
+    expect(() => j().append({ kind: 'verifier_disagreement', event: 'e', claim: 'a', counter_claim: 'b' }))
+      .toThrow(/governing_rule/);
+    expect(() => j().append({ kind: 'verifier_disagreement', event: 'e', claim: 'a', counter_claim: 'b', governing_rule: 'vibes' }))
+      .toThrow(/governing_rule/);
+    expect(DISAGREEMENT_RULES).toEqual(['owner_recount', 'verifier_majority', 'unresolved']);
+  });
+
+  it('the verifierDisagreement() convenience writes the same record as a raw append', () => {
+    const a = j('conv-a').verifierDisagreement('e', VALID);
+    const b = j('conv-b').append({ kind: 'verifier_disagreement', event: 'e', ...VALID });
+    const strip = (r) => ({ ...r, run_id: undefined });
+    expect(strip(a)).toEqual(strip(b));
+  });
+
+  it('does not disturb the other kinds — findings still require a finding_type', () => {
+    expect(() => j().finding('CANNOT_DRIVE', 'still works')).not.toThrow();
+    expect(() => j().append({ kind: 'finding', event: 'no type' })).toThrow(/finding_type/);
+    expect(() => j().append({ kind: 'not_a_kind', event: 'e' })).toThrow(/unknown journal kind/);
+  });
+
+  // THE QF'S STATED ACCEPTANCE: replay the real s2026-alpha4-0807 disagreement and find it BY KIND.
+  it('replaying the s2026-alpha4-0807 disagreement yields entries a reader finds by kind', () => {
+    const journal = j('s2026-alpha4-0807-replay');
+    journal.append({ kind: 'lifecycle', event: 'run arc started' });
+    journal.verifierDisagreement('H10 verifier A (coverage lens) disputes the runner summary', {
+      claim: 'positive=7/9 mapping_covered=9/9 O10=pass, CANNOT_DRIVE: O5,O6',
+      counter_claim: '6 CANNOT_DRIVE spanning O3,O5,O6,O7,O8; O4 substantively empty; O10 self-graded',
+      governing_rule: 'owner_recount',
+    });
+    journal.verifierDisagreement('H10 verifier B (fence lens) — H6 residue assertion-list inversion', {
+      claim: 'containment sweep complete',
+      counter_claim: 'sweep asserted only untouched tables; 59 rows of residue sat in the four written ones',
+      governing_rule: 'owner_recount',
+    });
+
+    const found = journal.readAll().filter((e) => e.kind === 'verifier_disagreement');
+    expect(found).toHaveLength(2);
+    // Both verdicts survive the round-trip, so the grader can see WHAT diverged...
+    expect(found[0].claim).toContain('7/9');
+    expect(found[0].counter_claim).toContain('O3');
+    expect(found[1].counter_claim).toContain('59 rows');
+    // ...and which one governs, so nothing is left silently resolved.
+    expect(found.every((e) => e.governing_rule === 'owner_recount')).toBe(true);
+    // The regression that motivated the QF: these must NOT be lifecycle rows.
+    expect(journal.readAll().filter((e) => e.kind === 'lifecycle')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Problem

**BETA-blocking 2 of 4.** §H10 mandates that verifier disagreement is *journaled and never silently resolved* — but the journal schema had no way to express one.

On run `s2026-alpha4-0807` two fresh-context verifiers disputed the runner's own summary. Both `EVENT_KINDS` and `FINDING_TYPES` are closed allowlists, so `kind: 'verifier_disagreement'` threw and `finding_type: 'VERIFIER_DISAGREEMENT'` threw. Both verdicts had to be demoted to `lifecycle`, where they are indistinguishable from ordinary run narration and invisible to any reader filtering by kind. BETA's §4 grading reads that record — **a disagreement not findable by kind never reaches the grader.**

The closed allowlists are good design; they stop typo'd kinds. §H10 was simply added without a matching kind.

## Fix

A first-class `verifier_disagreement` kind carrying **both verdicts plus the governing rule**. Recording that verifiers diverged without recording which verdict wins leaves the reader to guess — and guessing *is* the silent resolution §H10 forbids. `DISAGREEMENT_RULES` is `owner_recount` (the §H10 default), `verifier_majority`, or `unresolved`.

Two decisions worth review:

- **Validation matches `finding`'s discipline.** A disagreement missing either verdict, or carrying an unknown rule, is rejected *at write time* rather than persisted as an unreadable half-record.
- **The three fields are PERSISTED at top level, not merely validated.** I caught this while writing it: the row builder would have validated `claim`/`counter_claim`/`governing_rule` and then dropped them, since it only copies an allowlist of fields. That is precisely the failure this whole QF set exists to fix — the write looks correct and the record comes back empty. Top level rather than nested in `detail` so a reader can filter them the same way it filters by kind.

## Verification

- **7 tests**, including the QF's stated acceptance case: replay the real `s2026-alpha4-0807` disagreement and find it by kind, with both verdicts surviving the round-trip and the lifecycle-demotion path confirmed gone.
- **Mutation-proved:** making the row validate the fields and then drop them turns exactly the persistence test and the acceptance test red, and leaves the other five green — so those two are genuinely load-bearing rather than decoration.
- Assertions read **back from disk**, not from the return value, because the record is what the grader actually sees.
- No regression: 20 harness test files / 177 tests green, and the §H9 seeded-defect calibration still returns GO.

🤖 Generated with [Claude Code](https://claude.com/claude-code)