### PR TITLE
fix(QF-20260807-067): durable mirror written before verifiers — finalize AFTER verification

### DIFF
--- a/lib/harness/run-journal.mjs
+++ b/lib/harness/run-journal.mjs
@@ -243,21 +243,41 @@ export class RunJournal {
  * @param {{insertEvent?: Function}} [args.seams] - injectable for tests
  * @returns {Promise<{persisted: boolean}>}
  */
-export async function finalizeMirror({ supabase, journal, ventureId, seams = {} }) {
+export async function finalizeMirror({ supabase, journal, ventureId, seams = {}, allowRefinalize = false }) {
+  // QF-20260807-067, THE ORDERING DEFECT (distinct from the timing one runArc fixes): this
+  // appended its own lifecycle entry AFTER the write, so the mirrored payload could never
+  // contain it and the mirror was ALWAYS exactly one entry short of the journal. That makes
+  // "mirror count == journal count" unreachable no matter WHEN finalize is called. Sealing the
+  // entry BEFORE the snapshot puts it inside the payload, so the counts match.
+  // Worded as a seal, never "persisted" — the write has not happened yet, and reporting an
+  // intention in the past tense is how a journal starts lying about itself.
+  journal.append({
+    kind: 'lifecycle',
+    event: 'finalize-mirror snapshot sealed (system_events, harness_run_journal_finalized)',
+    touched_tables: ['system_events'],
+  });
+  const entries = journal.readAll();
+
   const doWrite = seams.insertEvent || (async () => {
-    const { error } = await supabase.from('system_events').insert({
+    const row = {
       event_type: 'harness_run_journal_finalized',
       idempotency_key: `harness_run_journal_finalized:${journal.runId}`,
-      payload: { run_id: journal.runId, venture_id: ventureId ?? null, entries: journal.readAll() },
+      payload: { run_id: journal.runId, venture_id: ventureId ?? null, entries },
       created_at: new Date().toISOString(),
-    });
+    };
+    // Default remains a plain INSERT, so write-once stays DB-enforced exactly as before.
+    // allowRefinalize upserts on the idempotency key: still ONE row per run (write-once in the
+    // sense that matters — no duplicate mirrors), but a run whose mirror froze pre-verification
+    // can be corrected. Without it the s2026-alpha4-0807 mirror is permanently wrong.
+    const { error } = allowRefinalize
+      ? await supabase.from('system_events').upsert(row, { onConflict: 'idempotency_key' })
+      : await supabase.from('system_events').insert(row);
     if (error) throw new Error(error.message);
   });
 
   try {
     await doWrite();
-    journal.append({ kind: 'lifecycle', event: 'finalize-mirror persisted (system_events, harness_run_journal_finalized)', touched_tables: ['system_events'] });
-    return { persisted: true };
+    return { persisted: true, entryCount: entries.length };
   } catch (e) {
     const message = String(e && e.message || e).slice(0, 400);
     // Loud-fail (NC-7): a mirror write failure is always an escalation, never swallowed.

--- a/scripts/harness/s20-run.mjs
+++ b/scripts/harness/s20-run.mjs
@@ -330,10 +330,6 @@ export async function runArc({ runId, entryStage = 20, toStage = 26, clockStart,
     journal.append({ kind: 'lifecycle', event: `capability-gap bridge failed (non-blocking): ${err.message}` });
   }
 
-  // FR-3/FR-4 (SD-LEO-INFRA-RUN-EVIDENCE-DURABILITY-001): durable system_events mirror of
-  // the journal, independent of both .harness-runs scratch and the fixture's own lifecycle.
-  const mirror = await finalizeMirror({ supabase, journal, ventureId, seams: seams.finalizeMirror ? { insertEvent: seams.finalizeMirror } : {} });
-
   // O10 run-meta verdict, graded ONCE at run level: every per-loop O-req mapped (not dead)
   // AND the containment sweep found no residue AND the journal is non-empty/durable.
   const o10AllMapped = coverage.uncovered.length === 0;
@@ -345,6 +341,18 @@ export async function runArc({ runId, entryStage = 20, toStage = 26, clockStart,
   } else {
     journal.finding('DEAD_LOOP', `O10 run-meta verdict FAILED: all_mapped=${o10AllMapped} residue_clean=${o10ResidueClean} journal_durable=${o10JournalDurable}`, { o_requirements: ['O10'] });
   }
+
+  // FR-3/FR-4 (SD-LEO-INFRA-RUN-EVIDENCE-DURABILITY-001): durable system_events mirror of the
+  // journal, independent of both .harness-runs scratch and the fixture's own lifecycle.
+  //
+  // QF-20260807-067 — THE TIMING DEFECT. This used to run BEFORE the coverage close-out and the
+  // O10 verdict, so the durable record was a PRE-VERIFICATION SNAPSHOT presenting itself as the
+  // run of record: on s2026-alpha4-0807 it froze at 44 of 52 entries and carried none of the
+  // verification outcomes. Since the mirror is write-once, nothing could ever repair it. It now
+  // runs LAST, after every verification entry (coverage findings, O10 verdict, and any §H10
+  // verifier disagreement), so the durable record is what was actually concluded — not what was
+  // known before anyone checked. Sequencing, not a second write: still exactly one finalize.
+  const mirror = await finalizeMirror({ supabase, journal, ventureId, seams: seams.finalizeMirror ? { insertEvent: seams.finalizeMirror } : {} });
 
   return { runId, ventureId, coverage, mirror, o10: { pass: o10Pass, allMapped: o10AllMapped, residueClean: o10ResidueClean, journalDurable: o10JournalDurable }, journalPath: journal.path };
 }

--- a/tests/unit/harness/finalize-mirror-after-verification.test.js
+++ b/tests/unit/harness/finalize-mirror-after-verification.test.js
@@ -1,0 +1,105 @@
+/**
+ * QF-20260807-067 — the durable mirror was a PRE-VERIFICATION SNAPSHOT presenting itself as the
+ * run of record. On s2026-alpha4-0807 it froze at 44 of 52 journal entries and carried none of
+ * the verification outcomes, and because the mirror is write-once nothing could ever repair it.
+ *
+ * TWO defects, and the second is why the acceptance criterion was unreachable on its own:
+ *   TIMING   — runArc called finalizeMirror before the coverage close-out and O10 verdict.
+ *   ORDERING — finalizeMirror appended its OWN lifecycle entry AFTER the write, so the mirror
+ *              was always exactly one entry short of the journal, whenever it ran.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { rmSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RunJournal, finalizeMirror } from '../../../lib/harness/run-journal.mjs';
+
+let baseDir;
+const mkJournal = (id = 'qf067') => new RunJournal(id, { baseDir, clock: () => '2026-08-07T13:00:00Z' });
+
+beforeEach(() => { baseDir = mkdtempSync(join(tmpdir(), 'qf067-')); });
+afterEach(() => { rmSync(baseDir, { recursive: true, force: true }); });
+
+/** Capture what the mirror WOULD persist, via the injectable write seam. */
+function captureSeam() {
+  const captured = [];
+  return { captured, insertEvent: async () => { captured.push('written'); } };
+}
+
+describe('QF-20260807-067: the mirror captures the journal COMPLETELY', () => {
+  it('ACCEPTANCE: mirror entry count EQUALS journal entry count', async () => {
+    const journal = mkJournal();
+    journal.append({ kind: 'lifecycle', event: 'run arc started' });
+    journal.finding('CANNOT_DRIVE', 'a finding', { o_requirements: ['O6'] });
+    const seam = captureSeam();
+
+    const res = await finalizeMirror({ supabase: null, journal, seams: seam });
+
+    // The count the mirror sealed is the count the journal ends with — no off-by-one.
+    expect(res.entryCount).toBe(journal.readAll().length);
+    expect(res.persisted).toBe(true);
+  });
+
+  it('the self-append is INSIDE the snapshot — the old post-write append made equality impossible', async () => {
+    const journal = mkJournal();
+    journal.append({ kind: 'lifecycle', event: 'run arc started' });
+    await finalizeMirror({ supabase: null, journal, seams: captureSeam() });
+
+    const all = journal.readAll();
+    const sealEntry = all.find((e) => String(e.event).includes('finalize-mirror snapshot sealed'));
+    expect(sealEntry).toBeDefined();
+    // It is the LAST entry, and the sealed count included it.
+    expect(all[all.length - 1].event).toBe(sealEntry.event);
+  });
+
+  it('the seal entry does NOT claim persistence before the write has happened', async () => {
+    const journal = mkJournal();
+    await finalizeMirror({ supabase: null, journal, seams: captureSeam() });
+    const sealEntry = journal.readAll().find((e) => String(e.event).includes('finalize-mirror'));
+    // "sealed" describes what just happened; "persisted" would be an intention in the past tense.
+    expect(sealEntry.event).toContain('sealed');
+    expect(sealEntry.event).not.toContain('persisted');
+  });
+
+  it('a write failure still fails LOUD (NC-7) and is never swallowed', async () => {
+    const journal = mkJournal();
+    const boom = { insertEvent: async () => { throw new Error('db down'); } };
+    await expect(finalizeMirror({ supabase: null, journal, seams: boom }))
+      .rejects.toThrow(/finalize-mirror write failed for run qf067: db down/);
+  });
+});
+
+describe('QF-20260807-067: write-once preserved, with a correction path', () => {
+  const fakeSupabase = (calls) => ({
+    from: () => ({
+      insert: async (row) => { calls.push({ op: 'insert', row }); return { error: null }; },
+      upsert: async (row, opts) => { calls.push({ op: 'upsert', row, opts }); return { error: null }; },
+    }),
+  });
+
+  it('DEFAULT is a plain INSERT — write-once stays DB-enforced exactly as before', async () => {
+    const calls = [];
+    await finalizeMirror({ supabase: fakeSupabase(calls), journal: mkJournal() });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].op).toBe('insert');
+  });
+
+  it('allowRefinalize upserts on the idempotency key — still ONE row per run, but correctable', async () => {
+    const calls = [];
+    await finalizeMirror({ supabase: fakeSupabase(calls), journal: mkJournal('s2026-alpha4-0807'), allowRefinalize: true });
+    expect(calls[0].op).toBe('upsert');
+    expect(calls[0].opts).toEqual({ onConflict: 'idempotency_key' });
+    // One row per run is what write-once actually protects; the key is unchanged.
+    expect(calls[0].row.idempotency_key).toBe('harness_run_journal_finalized:s2026-alpha4-0807');
+  });
+
+  it('the mirrored payload carries the entries, not just a count', async () => {
+    const calls = [];
+    const journal = mkJournal();
+    journal.finding('RESIDUE', 'leftover rows', {});
+    await finalizeMirror({ supabase: fakeSupabase(calls), journal });
+    const { entries } = calls[0].row.payload;
+    expect(entries).toHaveLength(journal.readAll().length);
+    expect(entries.some((e) => e.finding_type === 'RESIDUE')).toBe(true);
+  });
+});

--- a/tests/unit/harness/run-evidence-durability.test.js
+++ b/tests/unit/harness/run-evidence-durability.test.js
@@ -87,10 +87,14 @@ describe('FR-3/FR-4: finalizeMirror persists to system_events, independent of th
     const insertEvent = vi.fn(async () => undefined);
     const result = await finalizeMirror({ supabase: {}, journal, ventureId: 'v1', seams: { insertEvent } });
 
-    expect(result).toEqual({ persisted: true });
+    // QF-20260807-067: the lifecycle entry is now SEALED BEFORE the write rather than appended
+    // after it, so the mirrored payload actually contains it and mirror-count == journal-count.
+    // The invariant this test guards — one write, and the mirror leaves a journal trace — is
+    // unchanged; only the entry's timing and wording moved, plus entryCount on the result.
+    expect(result).toEqual({ persisted: true, entryCount: journal.readAll().length });
     expect(insertEvent).toHaveBeenCalledTimes(1);
     const events = journal.readAll();
-    expect(events.some((e) => e.event.includes('finalize-mirror persisted'))).toBe(true);
+    expect(events.some((e) => e.event.includes('finalize-mirror snapshot sealed'))).toBe(true);
   });
 
   it('hard-fails (throws) on any write failure — no pending-migration grace window since system_events has no CHECK blocking this write', async () => {


### PR DESCRIPTION
## Problem

**BETA-blocking 3 of 4.** The durable mirror was a **pre-verification snapshot presenting itself as the run of record**. On `s2026-alpha4-0807` it froze at 44 of 52 journal entries, carrying none of the verification outcomes — and because the mirror is write-once, nothing could ever repair it.

## Two defects, and the second is why the acceptance criterion was unreachable on its own

**Timing.** `runArc` called `finalizeMirror` before the coverage close-out and the O10 verdict, so even the run's *own* verdict missed the durable record. It now runs last, after every verification entry. Sequencing only — still exactly one finalize.

**Ordering.** `finalizeMirror` appended its own lifecycle entry *after* the write, so the mirrored payload could never contain it and the mirror was **always exactly one entry short of the journal, no matter when it ran**. "Mirror count == journal count" was unachievable by re-timing alone. The entry is now sealed *before* the snapshot.

That entry says **"sealed", not "persisted"** — at that point the write hasn't happened, and reporting an intention in the past tense is how a journal starts lying about itself. There's a test pinning that wording.

## The correction path

`allowRefinalize` (default **off**) upserts on the idempotency key, so a run whose mirror froze pre-verification can be corrected. Write-once *in the sense that matters* — one row per run, no duplicate mirrors — is preserved, and the default path remains a plain `INSERT` with the constraint DB-enforced exactly as before.

## Verification

**The QF's stated acceptance, run live:** the `s2026-alpha4-0807` re-mirror retry now **completes** where it previously threw on the unique constraint.

| | before | after |
|---|---|---|
| durable mirror | 44 entries | **56** |
| filesystem journal | 55 | 56 |
| verifier disagreements in mirror | absent | **present** |

Mirror count equals journal count exactly, and the verifier disagreements reached the durable record for the first time.

- 11 tests across the two harness files.
- **Mutation-proved:** excluding the seal entry from the snapshot (restoring the old off-by-one) turns the acceptance test red.
- No regression: 20 harness test files / 177 tests green.
- One pre-existing test updated — it pinned the post-write append. The invariant it guards (one write, and the mirror leaves a journal trace) is unchanged; only the entry's timing and wording moved. It was not relaxed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)