### PR TITLE
fix(QF-20260807-269): H6 residue assertions generated from the journal, not the fence text

### DIFF
--- a/scripts/harness/s20-run.mjs
+++ b/scripts/harness/s20-run.mjs
@@ -267,17 +267,48 @@ export async function runPostLaunchDrivers({ supabase, journal, ventureId, clock
   }
 }
 
+/**
+ * §H5.6 names the ghost-venture scheduler class as a STANDING check — it must run even on a leg
+ * that never wrote to these tables (the spec's cited harm is 35 stale rows left by OTHER cancelled
+ * ventures). It is unioned into the journal-derived list, never a substitute for it.
+ */
+export const SCHEDULER_FENCE_TABLES = Object.freeze(['eva_scheduler_queue', 'eva_scheduler_metrics']);
+
 /** §H6 containment sweep (run-level; teardown is the separate explicit step). */
 export async function containmentSweep({ supabase, journal, runId, ventureId, advancePolicy = 'real-gates' }) {
-  // Fence 6: ghost-venture scheduler residue must be zero DURING the run too.
-  for (const table of ['eva_scheduler_queue', 'eva_scheduler_metrics']) {
+  // QF-20260807-269: this was the hard-coded literal ['eva_scheduler_queue',
+  // 'eva_scheduler_metrics'], copied from the §H5.6 fence TEXT rather than derived from what the
+  // run actually did. §H6 requires the opposite — the assertion list is GENERATED from the
+  // journal's touched-tables set.
+  //
+  // The hand-coded list produced an exactly INVERTED guard, measured on s2026-alpha4-0807: it
+  // asserted zero rows for those two tables (which appear in NO entry's touched_tables, so the
+  // assertions were vacuous) while asserting NOTHING about the four tables the run demonstrably
+  // wrote — ventures=1, venture_stage_work=20, venture_artifacts=36, system_events=2. The sweep
+  // printed "containment complete" with 59 rows of fixture residue in tables it never examined.
+  //
+  // 1-REP: the fence-text literal is DELETED, not kept beside the derived list. Keeping both
+  // recreates the drift the instant a run touches a table the fence text never named — exactly
+  // what the acceptance test exercises. SCHEDULER_FENCE_TABLES survives ONLY because §H5.6 makes
+  // the ghost-venture class a STANDING check that must run even on a leg that never wrote there;
+  // it is unioned in, and it is not the source of truth.
+  const tables = [...new Set([...SCHEDULER_FENCE_TABLES, ...journal.touchedTables()])];
+  for (const table of tables) {
     const { count, error } = await supabase.from(table).select('*', { count: 'exact', head: true }).eq('venture_id', ventureId);
     if (error) {
       journal.finding('NO_DATA_GAUGE', `containment: ${table} unverifiable: ${error.message}`, { table });
     } else if ((count ?? 0) > 0) {
       journal.finding('RESIDUE', `containment: ${count} ${table} row(s) reference the fixture MID-RUN (ghost-venture class)`, { table, count });
     } else {
-      journal.append({ kind: 'fence_assertion', event: `containment: zero ${table} rows for fixture`, detail: { table } });
+      // detail.count records the MEASUREMENT, not just the table name. Without it a real
+      // zero-row query is indistinguishable from a hard-coded pass-through log line — the
+      // second half of the same s2026-alpha4-0807 finding. detail.source says WHY the table
+      // was checked, so a reader can tell a derived assertion from the standing fence.
+      journal.append({
+        kind: 'fence_assertion',
+        event: `containment: zero ${table} rows for fixture`,
+        detail: { table, count: count ?? 0, source: SCHEDULER_FENCE_TABLES.includes(table) ? 'h5.6_standing_fence' : 'journal_touched_tables' },
+      });
     }
   }
   // Enumerated divergences the run exercises are journaled up-front for the diff auditor.

--- a/tests/unit/harness/containment-sweep-journal-derived.test.js
+++ b/tests/unit/harness/containment-sweep-journal-derived.test.js
@@ -1,0 +1,105 @@
+/**
+ * QF-20260807-269 — the §H6 residue-assertion list was hand-coded from the fence TEXT instead of
+ * generated from the journal's touched-tables, producing an exactly INVERTED guard.
+ *
+ * Measured on run s2026-alpha4-0807: the sweep asserted zero rows for eva_scheduler_queue and
+ * eva_scheduler_metrics — which appear in NO entry's touched_tables, so those assertions were
+ * vacuous — while asserting NOTHING about the four tables the run demonstrably wrote
+ * (ventures=1, venture_stage_work=20, venture_artifacts=36, system_events=2). It printed
+ * "containment complete" with 59 rows of residue in tables it never examined.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { rmSync, mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RunJournal } from '../../../lib/harness/run-journal.mjs';
+import { containmentSweep, SCHEDULER_FENCE_TABLES } from '../../../scripts/harness/s20-run.mjs';
+
+let baseDir;
+beforeEach(() => { baseDir = mkdtempSync(join(tmpdir(), 'qf269-')); });
+afterEach(() => { rmSync(baseDir, { recursive: true, force: true }); });
+
+const mkJournal = (id = 'qf269') => new RunJournal(id, { baseDir, clock: () => '2026-08-07T13:00:00Z' });
+
+/** Fake supabase recording which tables were actually queried; every table reads back empty. */
+function spySupabase(counts = {}) {
+  const queried = [];
+  return {
+    queried,
+    from: (table) => ({
+      select: () => ({ eq: async () => { queried.push(table); return { count: counts[table] ?? 0, error: null }; } }),
+    }),
+  };
+}
+
+const sweptTables = (journal) => journal.readAll()
+  .filter((e) => e.kind === 'fence_assertion' && e.detail?.table)
+  .map((e) => e.detail.table);
+
+describe('QF-20260807-269: the assertion list is GENERATED from the journal', () => {
+  // THE QF'S STATED ACCEPTANCE: a novel table, asserted with zero code change.
+  it('ACCEPTANCE: a run touching a NOVEL table gets that table asserted, no code change', async () => {
+    const journal = mkJournal();
+    journal.append({ kind: 'observation', event: 'wrote somewhere new', touched_tables: ['a_table_nobody_enumerated'] });
+    const supabase = spySupabase();
+
+    await containmentSweep({ supabase, journal, runId: 'qf269', ventureId: 'v1' });
+
+    expect(supabase.queried).toContain('a_table_nobody_enumerated');
+    expect(sweptTables(journal)).toContain('a_table_nobody_enumerated');
+  });
+
+  it('REGRESSION, the exact inversion: the four written tables are all swept', async () => {
+    const journal = mkJournal();
+    const written = ['ventures', 'venture_stage_work', 'venture_artifacts', 'system_events'];
+    for (const t of written) journal.append({ kind: 'observation', event: `wrote ${t}`, touched_tables: [t] });
+    const supabase = spySupabase();
+
+    await containmentSweep({ supabase, journal, runId: 'qf269', ventureId: 'v1' });
+
+    // Every table the run actually touched is asserted — the thing the old list never did.
+    for (const t of written) expect(sweptTables(journal)).toContain(t);
+  });
+
+  it('the §H5.6 standing scheduler fence still runs on a leg that touched nothing', async () => {
+    const journal = mkJournal();
+    const supabase = spySupabase();
+    await containmentSweep({ supabase, journal, runId: 'qf269', ventureId: 'v1' });
+    // Standing check: the spec's harm is stale rows left by OTHER ventures, so it cannot be
+    // dropped just because this leg wrote nowhere.
+    for (const t of SCHEDULER_FENCE_TABLES) expect(sweptTables(journal)).toContain(t);
+  });
+
+  it('records the COUNT, so a real query is distinguishable from a pass-through log line', async () => {
+    const journal = mkJournal();
+    journal.append({ kind: 'observation', event: 'wrote', touched_tables: ['venture_artifacts'] });
+    await containmentSweep({ supabase: spySupabase(), journal, runId: 'qf269', ventureId: 'v1' });
+
+    const assertion = journal.readAll().find((e) => e.detail?.table === 'venture_artifacts');
+    expect(assertion.detail.count).toBe(0);
+    expect(assertion.detail.source).toBe('journal_touched_tables');
+  });
+
+  it('a touched table WITH residue is a RESIDUE finding, not a green assertion', async () => {
+    const journal = mkJournal();
+    journal.append({ kind: 'observation', event: 'wrote', touched_tables: ['venture_artifacts'] });
+    await containmentSweep({ supabase: spySupabase({ venture_artifacts: 36 }), journal, runId: 'qf269', ventureId: 'v1' });
+
+    const finding = journal.readAll().find((e) => e.finding_type === 'RESIDUE');
+    expect(finding).toBeDefined();
+    expect(finding.event).toContain('36');
+    // And it must NOT also be reported clean — two-sided.
+    expect(sweptTables(journal)).not.toContain('venture_artifacts');
+  });
+
+  it('1-REP: no hard-coded fence-text list remains as a second source of truth', async () => {
+    // SCHEDULER_FENCE_TABLES is the standing §H5.6 check, unioned in — the derived list is the
+    // source of truth. Guard that it did not silently regrow into the full assertion set.
+    expect(SCHEDULER_FENCE_TABLES).toEqual(['eva_scheduler_queue', 'eva_scheduler_metrics']);
+    const journal = mkJournal();
+    journal.append({ kind: 'observation', event: 'wrote', touched_tables: ['novel_one', 'novel_two'] });
+    const supabase = spySupabase();
+    await containmentSweep({ supabase, journal, runId: 'qf269', ventureId: 'v1' });
+    expect(supabase.queried.sort()).toEqual([...SCHEDULER_FENCE_TABLES, 'novel_one', 'novel_two'].sort());
+  });
+});


### PR DESCRIPTION
## Problem

**BETA-blocking 1 of 4.** The run-level containment sweep asserted a **hard-coded literal copied from the §H5.6 fence text** instead of deriving from what the run actually did. §H6 requires the opposite — the assertion list is *generated* from the journal's touched-tables set.

The hand-coded list produced an **exactly inverted guard**, measured on `s2026-alpha4-0807`:

| | asserted? | touched? | rows found |
|---|---|---|---|
| `eva_scheduler_queue` | ✅ | ❌ never | 0 (vacuous) |
| `eva_scheduler_metrics` | ✅ | ❌ never | 0 (vacuous) |
| `ventures` | ❌ | ✅ | **1** |
| `venture_stage_work` | ❌ | ✅ | **20** |
| `venture_artifacts` | ❌ | ✅ | **36** |
| `system_events` | ❌ | ✅ | **2** |

It printed *"containment complete"* while **59 rows** of fixture residue sat in tables it never examined. Covering exactly the untouched tables and none of the touched ones is what identifies the list as hand-written rather than derived. Containment held only because teardown — which was *already* journal-derived — happened to be correct.

## Fix

The list is now `SCHEDULER_FENCE_TABLES ∪ journal.touchedTables()`.

**1-REP: the fence-text literal is deleted**, not kept beside the derived list. Keeping both recreates the drift the instant a run touches a table the fence text never named — which is exactly what the acceptance test exercises. `SCHEDULER_FENCE_TABLES` survives *only* because §H5.6 makes the ghost-venture class a **standing** check that must run even on a leg that never wrote there (the spec's cited harm is 35 stale rows left by *other* cancelled ventures). It is unioned in, and it is not the source of truth.

Each green assertion now records `detail.count`, so a real zero-row query is distinguishable from a hard-coded pass-through log line — the second half of the same finding — and `detail.source` says whether the table came from the journal or the standing fence.

## Verification

- **6 tests**, including the QF's stated acceptance: a run touching a novel table gets that table asserted **with no code change**.
- Plus the exact regression (all four written tables swept), the standing-fence case (still runs on a leg that touched nothing), and a two-sided residue case (a touched table *with* rows produces a `RESIDUE` finding and is **not** also reported clean).
- **Mutation-proved:** restoring the hard-coded list turns **5 of the 6 red**, including the acceptance case.
- No regression: 20 harness test files / 176 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)