### PR TITLE
fix(QF-20260807-013): probe the O6 precondition instead of asserting it; commit the H5.1 fence

### DIFF
--- a/scripts/harness/s20-run.mjs
+++ b/scripts/harness/s20-run.mjs
@@ -111,6 +111,66 @@ export const LOOP_O_REQUIREMENTS = Object.freeze(ALL_O_REQUIREMENTS.filter((r) =
 export const ADVANCE_POLICIES = Object.freeze(['real-gates', 'fixture-artifact-seed']);
 export const FIXTURE_ARTIFACT_SEED_DIVERGENCE = 'fixture_artifact_seed';
 
+/**
+ * §H5.1 SPAWN-ENV FENCE. The shared .env carries a LIVE-mode STRIPE_SECRET_KEY, so the run
+ * process must spawn with that variable unset or holding a placeholder — an env-level override,
+ * NOT in-code filtering, because api/webhooks/stripe.js constructs a Stripe client straight from
+ * process.env without consulting lib/payments/stripe-client.js's fail-closed assertKeyAllowed.
+ * In-code filtering therefore cannot prove unreachability; emptying the variable can.
+ *
+ * THROWS on a live key rather than only journaling: a fence that records the breach it exists to
+ * prevent and then runs anyway is decoration. Returns the assertion for journaling.
+ *
+ * QF-20260807-013: first committed here. It was authored during the s2026-alpha4-0807 leg and
+ * lived ONLY as an uncommitted edit in the shared working tree — a binding green-light condition
+ * with no durable home, one `git checkout` away from being lost. BETA's leg depends on it.
+ */
+export function assertSpawnEnvStripeFence(env = process.env) {
+  const raw = env.STRIPE_SECRET_KEY;
+  const live = typeof raw === 'string' && /^(sk|rk)_live_/.test(raw);
+  const test = typeof raw === 'string' && /^(sk|rk)_test_/.test(raw);
+  if (live) {
+    throw new Error(
+      'H5.1 SPAWN-ENV FENCE: refusing to start — STRIPE_SECRET_KEY holds a LIVE-mode key. '
+      + 'Re-spawn with it unset (or a placeholder) so no code path can construct a live client.',
+    );
+  }
+  return {
+    kind: 'fence_assertion',
+    event: `H5.1 spawn-env: STRIPE_SECRET_KEY carries no live key (${test ? 'test-mode key present' : 'unset/placeholder'})`,
+    detail: { stripe_key_mode: test ? 'test' : 'absent_or_placeholder', live_key_reachable: false },
+  };
+}
+
+/**
+ * QF-20260807-013: PROBE the O6 payment-attribution precondition instead of asserting it.
+ *
+ * The previous reason was a hardcoded string claiming "no payment-attribution machinery found in
+ * EHG_Engineer lib/ — the attribution rail lives with the venture app". That was false at every
+ * checkable layer: the resolver module, the ops_payment_events store, the webhook ingest and the
+ * test-charge driver are all in this repo. Nothing had ever probed; the reason was written once
+ * and believed thereafter.
+ *
+ * So this returns a MEASURED verdict. `drivable` is only ever true because a probe said so, and
+ * every blocked verdict names the condition that was actually observed — never an assumption.
+ */
+export async function probeAttributionRail({ env = process.env, importer = (m) => import(m) } = {}) {
+  const key = env.STRIPE_SECRET_KEY;
+  if (!(typeof key === 'string' && /^(sk|rk)_test_/.test(key))) {
+    return { drivable: false, reason: 'no sk_test_ key in the run process env (chairman-gated input; E3 never runs on a live key)', probe: 'env' };
+  }
+  let resolver;
+  try {
+    resolver = await importer('../../lib/payments/attribution-resolver.js');
+  } catch (e) {
+    return { drivable: false, reason: `attribution-resolver module not importable: ${String(e.message).slice(0, 120)}`, probe: 'module' };
+  }
+  if (typeof resolver.resolveUnattributedEvents !== 'function') {
+    return { drivable: false, reason: 'attribution-resolver present but exports no resolveUnattributedEvents', probe: 'export' };
+  }
+  return { drivable: true, reason: 'attribution rail present and test key available', probe: 'export' };
+}
+
 /** The enumerated divergence set for a given advance policy. */
 export function allowedDivergencesFor(advancePolicy = 'real-gates') {
   return advancePolicy === 'fixture-artifact-seed'
@@ -255,15 +315,35 @@ export async function runPostLaunchDrivers({ supabase, journal, ventureId, clock
       }
     }
     // No implementation seam yet — the honest default per §H7: first-class finding.
-    const reason = {
-      stranger_visitor: 'no preview deploy exists for the fixture (preview() runs plan-mode without adapters — blocked_on_credentials by design, H5.2)',
-      conversion_event: 'depends on stranger_visitor reaching a live preview surface',
-      test_rail_payment: 'no payment-attribution machinery found in EHG_Engineer lib/ (attribution rail lives with the venture app; O6 undrivable from the platform repo alone)',
-      support_ticket: 'no support-ticket/triage machinery found in lib/ (O5 loop not built)',
-      incident_probe: 'no health-probe/remediation loop callable for a fixture venture (O5 loop not built)',
-      review_cadence: 'post-launch review cadence has no pre-scheduled machinery to fire under an injected clock (O8 scheduler absent)',
-    }[driver.key] || 'no driver seam wired';
-    journal.finding('CANNOT_DRIVE', `driver ${driver.key}: ${reason}`, { o_requirements: driver.o, at_clock: clock.now() });
+    //
+    // QF-20260807-013: test_rail_payment's entry used to be the hardcoded string "no
+    // payment-attribution machinery found in EHG_Engineer lib/ (attribution rail lives with the
+    // venture app)". Nothing ever probed — it was written once and believed thereafter — and it
+    // was false at every checkable layer: lib/payments/attribution-resolver.js, the
+    // ops_payment_events store, api/webhooks/stripe.js and the test-charge driver are all here.
+    // It now PROBES, so the reason is measured. The remaining entries are unprobed defaults and
+    // are labelled as such rather than presented as findings of absence.
+    let reason;
+    let probe = null;
+    if (driver.key === 'test_rail_payment') {
+      probe = await (seams.probeAttributionRail || probeAttributionRail)();
+      if (probe.drivable) {
+        // Precondition met — the leg is expected to drive it. Reaching here means the driver
+        // seam is still unwired, which is a DIFFERENT (and honest) blocker from "no machinery".
+        reason = `attribution rail IS present and a test key IS available (probe=${probe.probe}); blocked only on the harness driver seam, not on capability`;
+      } else {
+        reason = `${probe.reason} (measured, probe=${probe.probe})`;
+      }
+    } else {
+      reason = {
+        stranger_visitor: 'no preview deploy exists for the fixture (preview() runs plan-mode without adapters — blocked_on_credentials by design, H5.2)',
+        conversion_event: 'depends on stranger_visitor reaching a live preview surface',
+        support_ticket: 'no support-ticket/triage machinery found in lib/ (O5 loop not built)',
+        incident_probe: 'no health-probe/remediation loop callable for a fixture venture (O5 loop not built)',
+        review_cadence: 'post-launch review cadence has no pre-scheduled machinery to fire under an injected clock (O8 scheduler absent)',
+      }[driver.key] || 'no driver seam wired';
+    }
+    journal.finding('CANNOT_DRIVE', `driver ${driver.key}: ${reason}`, { o_requirements: driver.o, at_clock: clock.now(), ...(probe ? { probe } : {}) });
   }
 }
 
@@ -286,7 +366,7 @@ export async function containmentSweep({ supabase, journal, runId, ventureId, ad
   journal.append({ kind: 'fence_assertion', event: 'containment sweep complete', detail: { run_id: runId } });
 }
 
-export async function runArc({ runId, entryStage = 20, toStage = 26, clockStart, clockStepHours = 24, createFixtureFirst = false, sweepOnly = false, advancePolicy = 'real-gates', supabase: sb, seams = {}, baseDir } = {}) {
+export async function runArc({ runId, entryStage = 20, toStage = 26, clockStart, clockStepHours = 24, createFixtureFirst = false, sweepOnly = false, advancePolicy = 'real-gates', supabase: sb, seams = {}, baseDir, env = process.env } = {}) {
   const supabase = sb || makeClient();
   const clock = makeSteppingClock(clockStart || new Date().toISOString(), clockStepHours);
   const journal = new RunJournal(runId, { clock: clock.now, ...(baseDir ? { baseDir } : {}) });
@@ -299,6 +379,13 @@ export async function runArc({ runId, entryStage = 20, toStage = 26, clockStart,
   if (!ventureId) throw new Error(`no fixture venture for run ${runId} — create one first (s20-fixture.mjs create --run-id ${runId} or pass --create-fixture)`);
 
   journal.append({ kind: 'lifecycle', event: `run arc started (S${entryStage}..S${toStage})`, detail: { venture_id: ventureId, clock: clock.now() } });
+  // QF-20260807-013: journal-asserted AT RUN START, before any band can drive machinery that
+  // might reach a payment path. Throws (see the function) if a live key is reachable.
+  // `env` is a parameter, not a bypass seam: the default IS process.env, so a real run gets the
+  // real check. Unit tests pass an explicit env because the runner loads dotenv, which would
+  // otherwise inject the shared .env's live key into every test process — the fence firing there
+  // is the fence WORKING, but it makes the harness untestable without parameterization.
+  journal.append(assertSpawnEnvStripeFence(env));
 
   if (!sweepOnly) {
     const done = completedBands(journal);

--- a/tests/unit/harness/probe-before-assert-o6.test.js
+++ b/tests/unit/harness/probe-before-assert-o6.test.js
@@ -1,0 +1,117 @@
+/**
+ * QF-20260807-013 — CANNOT_DRIVE reasons must come from a live probe, not a hardcoded string.
+ *
+ * The O6 reason claimed "no payment-attribution machinery found in EHG_Engineer lib/ (attribution
+ * rail lives with the venture app)". Nothing ever probed — it was written once and believed
+ * thereafter — and it was false at every checkable layer: lib/payments/attribution-resolver.js,
+ * the ops_payment_events store, api/webhooks/stripe.js and the test-charge driver are all in this
+ * repo. Second instance in one instrument of assertion-without-measurement.
+ *
+ * Also covers the §H5.1 spawn-env fence, which until this commit existed ONLY as an uncommitted
+ * edit in the shared working tree despite being a binding green-light condition.
+ */
+import { describe, it, expect } from 'vitest';
+import { assertSpawnEnvStripeFence, probeAttributionRail, runPostLaunchDrivers } from '../../../scripts/harness/s20-run.mjs';
+
+const TEST_ENV = { STRIPE_SECRET_KEY: 'sk_test_abc' };
+
+describe('QF-20260807-013: O6 precondition is PROBED, never asserted', () => {
+  it('reports drivable ONLY after confirming the export exists — with a real test key', async () => {
+    const res = await probeAttributionRail({ env: TEST_ENV });
+    expect(res.drivable).toBe(true);
+    expect(res.probe).toBe('export');
+  });
+
+  it('THE REGRESSION: it does not claim the machinery is absent — the real module resolves', async () => {
+    const res = await probeAttributionRail({ env: TEST_ENV });
+    expect(res.reason).not.toMatch(/no payment-attribution machinery/i);
+    expect(res.reason).not.toMatch(/lives with the venture app/i);
+  });
+
+  // ACCEPTANCE, side 2: key deliberately absent still CANNOT_DRIVEs, with the HONEST reason.
+  it('ACCEPTANCE: with no test key it is undrivable, and the reason names the key — not the machinery', async () => {
+    for (const env of [{}, { STRIPE_SECRET_KEY: 'sk_live_real' }, { STRIPE_SECRET_KEY: 'placeholder' }]) {
+      const res = await probeAttributionRail({ env });
+      expect(res.drivable).toBe(false);
+      expect(res.probe).toBe('env');
+      expect(res.reason).toMatch(/sk_test_/);
+      expect(res.reason).not.toMatch(/no payment-attribution machinery/i);
+    }
+  });
+
+  it('a genuinely missing module yields a MEASURED module-level reason, not a guess', async () => {
+    const res = await probeAttributionRail({ env: TEST_ENV, importer: async () => { throw new Error('ENOENT'); } });
+    expect(res).toMatchObject({ drivable: false, probe: 'module' });
+    expect(res.reason).toMatch(/not importable: ENOENT/);
+  });
+
+  it('a module present but missing the export is distinguished from a module that is absent', async () => {
+    const res = await probeAttributionRail({ env: TEST_ENV, importer: async () => ({}) });
+    expect(res).toMatchObject({ drivable: false, probe: 'export' });
+    expect(res.reason).toMatch(/exports no resolveUnattributedEvents/);
+  });
+});
+
+/**
+ * WIRING, not just the unit. My first pass tested probeAttributionRail directly, and a mutation
+ * that reverted runPostLaunchDrivers to the hardcoded string left every test GREEN — the probe
+ * worked and nothing checked that the runner CALLED it. A test that cannot see the wiring is the
+ * same blindness this QF set exists to remove, so these drive the real code path.
+ */
+describe('QF-20260807-013: the RUNNER actually calls the probe', () => {
+  const mkJournal = () => {
+    const entries = [];
+    return {
+      entries,
+      append: (e) => entries.push(e),
+      finding: (finding_type, event, detail) => entries.push({ kind: 'finding', finding_type, event, detail }),
+    };
+  };
+  const clock = { now: () => '2026-08-07T13:00:00Z' };
+  const o6Entry = (j) => j.entries.find((e) => String(e.event).includes('test_rail_payment'));
+
+  it('journals the PROBE-measured reason, and attaches the probe evidence', async () => {
+    const journal = mkJournal();
+    await runPostLaunchDrivers({
+      supabase: null, journal, ventureId: 'v1', clock,
+      seams: { probeAttributionRail: async () => ({ drivable: false, reason: 'measured thing', probe: 'env' }) },
+    });
+    const entry = o6Entry(journal);
+    expect(entry.event).toContain('measured thing');
+    expect(entry.event).toContain('measured, probe=env');
+    expect(entry.detail.probe).toEqual({ drivable: false, reason: 'measured thing', probe: 'env' });
+  });
+
+  it('THE MUTATION GUARD: the hardcoded absent-machinery claim can never be journaled again', async () => {
+    const journal = mkJournal();
+    await runPostLaunchDrivers({
+      supabase: null, journal, ventureId: 'v1', clock,
+      seams: { probeAttributionRail: async () => ({ drivable: true, reason: 'rail present', probe: 'export' }) },
+    });
+    const entry = o6Entry(journal);
+    expect(entry.event).not.toMatch(/no payment-attribution machinery/i);
+    expect(entry.event).not.toMatch(/lives with the venture app/i);
+    // When the precondition IS met, the honest blocker is the driver seam — not capability.
+    expect(entry.event).toMatch(/blocked only on the harness driver seam, not on capability/);
+  });
+});
+
+describe('QF-20260807-013: §H5.1 spawn-env fence (now committed, not tree-local)', () => {
+  it('REFUSES to start on a live key — both sk_live_ and rk_live_', () => {
+    for (const k of ['sk_live_x', 'rk_live_x']) {
+      expect(() => assertSpawnEnvStripeFence({ STRIPE_SECRET_KEY: k })).toThrow(/SPAWN-ENV FENCE/);
+    }
+  });
+
+  it('permits an unset, placeholder, or test-mode key, and records which', () => {
+    expect(assertSpawnEnvStripeFence({}).detail.stripe_key_mode).toBe('absent_or_placeholder');
+    expect(assertSpawnEnvStripeFence({ STRIPE_SECRET_KEY: 'UNSET_FOR_SIM_RUN' }).detail.stripe_key_mode).toBe('absent_or_placeholder');
+    expect(assertSpawnEnvStripeFence(TEST_ENV).detail.stripe_key_mode).toBe('test');
+  });
+
+  it('returns a journalable fence_assertion asserting the live key is unreachable', () => {
+    const a = assertSpawnEnvStripeFence(TEST_ENV);
+    expect(a.kind).toBe('fence_assertion');
+    expect(a.detail.live_key_reachable).toBe(false);
+  });
+});

--- a/tests/unit/harness/s20-runner.test.js
+++ b/tests/unit/harness/s20-runner.test.js
@@ -134,7 +134,10 @@ describe('runArc (§H7 resume + §H3 coverage close-out)', () => {
 
     const executeStage = vi.fn(async ({ stageNumber }) => ({ template: `stage-${stageNumber}`, artifactId: 'a', validation: { valid: true }, output: {} }));
     const advanceStage = vi.fn(async () => ({}));
+    // QF-20260807-013: explicit env — the runner loads dotenv, which would otherwise inject the
+    // shared .env's LIVE Stripe key and trip the H5.1 spawn-env fence in every test process.
     const res = await runArc({
+      env: {},
       runId, entryStage: 20, toStage: 22, clockStart: '2026-07-12T09:00:00Z',
       supabase: fakeSupabase(), seams: { executeStage, advanceStage }, baseDir: BASE,
     });
@@ -161,7 +164,10 @@ describe('runArc (§H7 resume + §H3 coverage close-out)', () => {
     const runId = 't-arc-o10-pass';
     const executeStage = vi.fn(async ({ stageNumber }) => ({ template: `stage-${stageNumber}`, artifactId: 'a', validation: { valid: true }, output: {} }));
     const advanceStage = vi.fn(async () => ({}));
+    // QF-20260807-013: explicit env — the runner loads dotenv, which would otherwise inject the
+    // shared .env's LIVE Stripe key and trip the H5.1 spawn-env fence in every test process.
     const res = await runArc({
+      env: {},
       runId, entryStage: 20, toStage: 26, clockStart: '2026-07-12T09:00:00Z',
       supabase: fakeSupabase(), seams: { executeStage, advanceStage }, baseDir: BASE,
     });
@@ -174,7 +180,10 @@ describe('runArc (§H7 resume + §H3 coverage close-out)', () => {
 
   it('containment sweep journals scheduler residue as a RESIDUE finding when rows exist mid-run', async () => {
     const executeStage = vi.fn(async () => ({ artifactId: 'a', validation: { valid: true }, output: {} }));
+    // QF-20260807-013: explicit env — the runner loads dotenv, which would otherwise inject the
+    // shared .env's LIVE Stripe key and trip the H5.1 spawn-env fence in every test process.
     const res = await runArc({
+      env: {},
       runId: 't-arc-residue', entryStage: 21, toStage: 21, clockStart: '2026-07-12T09:00:00Z',
       supabase: fakeSupabase({ schedulerRows: 3 }), seams: { executeStage, advanceStage: vi.fn(async () => ({})) }, baseDir: BASE,
     });


### PR DESCRIPTION
> **Correction to the commit message:** it says "182 tests green"; the actual figure is **180**. I mistyped it and won't rewrite pushed history to hide it — the number here is the measured one.

## Problem

**BETA-blocking 4 of 4** (amended scope). The O6 `CANNOT_DRIVE` reason was a **hardcoded string** claiming *"no payment-attribution machinery found in EHG_Engineer lib/ — the attribution rail lives with the venture app."*

Nothing ever probed. It was written once and believed thereafter — and it was false at every checkable layer:

| Layer | Claimed | Actual |
|---|---|---|
| machinery | absent | `lib/payments/attribution-resolver.js`, full exports |
| store | elsewhere | `ops_payment_events` in this DB, with `livemode` |
| ingest | elsewhere | `api/webhooks/stripe.js` |
| driver | absent | `scripts/payments/test-charge-harness.mjs` |

Its only real skip condition — no `sk_test_` key — cleared when the chairman provisioned one. This is the **second instance in one instrument** of an assertion layer stating something it never measured (the first being the §H6 residue inversion).

## Fix

`probeAttributionRail()` returns a **measured** verdict. Every blocked result names the condition actually observed (`env`, `module`, or `export`), and when the precondition *is* met the honest blocker is the **driver seam, not capability**. That distinction is the whole finding: the harness reported a missing *capability* when what is missing is a *call*.

**Also commits `assertSpawnEnvStripeFence`.** Until now it existed *only* as an uncommitted edit in the shared working tree — a binding green-light condition that BETA's leg depends on, one `git checkout` from being lost. `runArc` now takes an explicit `env` (defaulting to `process.env`, so real runs get the real check) because the runner loads dotenv, which injects the shared live key into every test process. The fence firing there is the fence *working*, but it makes the harness untestable without parameterization.

## Verification

**The wiring is tested, not just the unit — and that came from a mutation that caught me.** My first pass tested `probeAttributionRail` directly. A mutation reverting the runner to the hardcoded string left **every test green**: the probe worked, and nothing checked that the runner *called* it. That is precisely the blindness this QF set exists to remove. Two tests now drive the real `runPostLaunchDrivers` path, and the identical mutation reddens both.

- **10 tests**, two-sided acceptance as the QF specifies: key present → drivable; key deliberately absent → undrivable with a reason naming **the key, never the machinery**.
- Distinguishes a missing module from a present-module-missing-export, so a future failure reports which.
- No regression: 20 harness test files / **180** tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)