### PR TITLE
fix(QF-20260807-195): work-class no-signal default was DENY, inverting the module's own policy

### DIFF
--- a/lib/fleet/work-class.cjs
+++ b/lib/fleet/work-class.cjs
@@ -70,14 +70,54 @@ function modelWorkClasses(model) {
  * Pure fence predicate shared by the SD axis and the QF filter.
  * Returns null (admissible) or a reason string:
  *   'work_class_mismatch'     — item is a class this model must not take
- *   'work_class_unclassified' — fail-closed: unknown class on a restricted model
+ *
+ * QF-20260807-195 (feedback 8740004e / signal 8cf4545b): 'unclassified' NO LONGER FENCES.
+ *
+ * This module stated one policy and implemented its opposite. C-STARVE above says creative
+ * detection "errs toward ADMITTING plausibly-creative work for Fable; only clearly-general work
+ * is hard-denied" — but text matching NEITHER regex returned 'unclassified', and this function
+ * turned that into a NON-NULL reason, which IS a fence. So the default for no-signal text was
+ * DENY: the exact inverse of the stated policy, and the recall-tuning only ever reached rows that
+ * had ALREADY matched CREATIVE_RE. The doc line here used to say "fail-closed", so the module
+ * carried two contradictory statements of intent and the deny half won silently.
+ *
+ * Measured: a Fable seat idled repeatedly against a 21-item belt while 3 rows sat
+ * work_class_unclassified. Two-sided controls confirmed the classifier itself is sound
+ * (clearly-creative -> creative_design, clearly-general -> general_harness), so this was purely
+ * the no-signal default polarity.
+ *
+ * ADMIT-OR-SURFACE, NEVER SILENT-FENCE: unclassified is admissible, and
+ * workClassAdmissionNote() below exists so a caller can SAY it was admitted-without-signal.
+ * Admitting silently would trade one invisible behaviour for another.
+ *
+ * SCOPE: the classifier only. requires_human_action / chairman-axis holds are an INDEPENDENT
+ * fence — this change neither clears nor weakens them, by construction: it returns a work-class
+ * verdict and nothing else.
  */
 function workClassIneligibilityReason(row, sessionModel) {
   const admissible = modelWorkClasses(sessionModel);
   if (!admissible) return null; // unrestricted model (or unknown) — no fence
   const cls = deriveWorkClass(row);
   if (cls === 'any' || admissible.includes(cls)) return null;
-  return cls === 'unclassified' ? 'work_class_unclassified' : 'work_class_mismatch';
+  // Only a POSITIVE mismatch fences. No-signal text is not evidence of a wrong class.
+  if (cls === 'unclassified') return null;
+  return 'work_class_mismatch';
 }
 
-module.exports = { WORK_CLASSES, deriveWorkClass, modelWorkClasses, workClassIneligibilityReason };
+/**
+ * QF-20260807-195: the SURFACE half of admit-or-surface. Returns 'admitted_unclassified' when a
+ * restricted model is being handed an item whose class could not be derived, else null.
+ *
+ * Deliberately a SEPARATE function rather than a second return value from the fence predicate:
+ * that predicate is a first-truthy-wins ladder where the return channel IS control flow, so
+ * smuggling a non-fencing note through it would make the note indistinguishable from a fence.
+ */
+function workClassAdmissionNote(row, sessionModel) {
+  if (!modelWorkClasses(sessionModel)) return null;
+  return deriveWorkClass(row) === 'unclassified' ? 'admitted_unclassified' : null;
+}
+
+module.exports = {
+  WORK_CLASSES, CREATIVE_RE, GENERAL_RE,
+  deriveWorkClass, modelWorkClasses, workClassIneligibilityReason, workClassAdmissionNote,
+};

--- a/tests/unit/fleet/work-class-default-polarity.test.js
+++ b/tests/unit/fleet/work-class-default-polarity.test.js
@@ -1,0 +1,99 @@
+/**
+ * QF-20260807-195 (feedback 8740004e / signal 8cf4545b) — the work-class module stated one
+ * policy and implemented its opposite.
+ *
+ * C-STARVE says creative detection "errs toward ADMITTING plausibly-creative work for Fable;
+ * only clearly-general work is hard-denied". But text matching NEITHER regex derived
+ * 'unclassified', and workClassIneligibilityReason turned that into a non-null reason — which IS
+ * a fence. The default for no-signal text was DENY, and the recall-tuning only ever reached rows
+ * that had already matched CREATIVE_RE.
+ *
+ * The last describe block is the one the fix is really about: it pins the POLICY SENTENCE in the
+ * source to the CODE BEHAVIOUR, so the two cannot silently diverge again.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const MODULE_PATH = join(process.cwd(), 'lib/fleet/work-class.cjs');
+const { deriveWorkClass, workClassIneligibilityReason, workClassAdmissionNote } = require_(MODULE_PATH);
+
+const NO_SIGNAL = { title: 'Core Skills Rebuild', description: 'from-scratch regeneration of the most-used skills' };
+const CLEARLY_CREATIVE = { title: 'Design the landing page hero', description: 'brand palette' };
+const CLEARLY_GENERAL = { title: 'Fix flaky cron gate', description: 'harness lint' };
+
+describe('QF-20260807-195: no-signal text must not hard-deny the Fable lane', () => {
+  it('derives unclassified for text matching neither regex (the classifier is honest)', () => {
+    expect(deriveWorkClass(NO_SIGNAL)).toBe('unclassified');
+  });
+
+  it('THE FIX: unclassified is ADMISSIBLE for fable — it no longer fences', () => {
+    expect(workClassIneligibilityReason(NO_SIGNAL, 'fable')).toBeNull();
+  });
+
+  it('SURFACES the admission rather than admitting silently', () => {
+    // Trading a silent fence for a silent admission would be no improvement.
+    expect(workClassAdmissionNote(NO_SIGNAL, 'fable')).toBe('admitted_unclassified');
+    expect(workClassAdmissionNote(CLEARLY_CREATIVE, 'fable')).toBeNull();
+  });
+
+  it('the surface note rides a SEPARATE channel from the fence verdict', () => {
+    // The fence predicate is first-truthy-wins, so a note returned through it would be
+    // indistinguishable from a fence. Both are queried here to prove they are independent.
+    expect(workClassIneligibilityReason(NO_SIGNAL, 'fable')).toBeNull();
+    expect(workClassAdmissionNote(NO_SIGNAL, 'fable')).toBeTruthy();
+  });
+});
+
+describe('QF-20260807-195: two-sided — clearly-general is STILL hard-denied', () => {
+  it('a clearly-general item still fences for fable (the fence is not gutted)', () => {
+    expect(deriveWorkClass(CLEARLY_GENERAL)).toBe('general_harness');
+    expect(workClassIneligibilityReason(CLEARLY_GENERAL, 'fable')).toBe('work_class_mismatch');
+  });
+
+  it('a clearly-creative item is admissible, as it always was', () => {
+    expect(workClassIneligibilityReason(CLEARLY_CREATIVE, 'fable')).toBeNull();
+  });
+
+  it('non-fable models are entirely unaffected — the fence stays a no-op for them', () => {
+    for (const model of ['sonnet', 'opus', undefined, null, 'unknown-model']) {
+      expect(workClassIneligibilityReason(CLEARLY_GENERAL, model)).toBeNull();
+      expect(workClassAdmissionNote(NO_SIGNAL, model)).toBeNull();
+    }
+  });
+
+  it('an explicit override still wins over derivation, in both directions', () => {
+    expect(workClassIneligibilityReason({ ...CLEARLY_GENERAL, metadata: { work_class_override: 'creative_design' } }, 'fable')).toBeNull();
+    expect(workClassIneligibilityReason({ ...CLEARLY_CREATIVE, metadata: { work_class_override: 'general_harness' } }, 'fable')).toBe('work_class_mismatch');
+  });
+});
+
+describe('QF-20260807-195: the POLICY SENTENCE is pinned to the CODE BEHAVIOUR', () => {
+  const src = readFileSync(MODULE_PATH, 'utf8');
+
+  it('the module still states the C-STARVE admit-toward-creative policy', () => {
+    // If someone deletes the policy, this fails and they must decide deliberately.
+    expect(src).toMatch(/only clearly-general work is hard-denied/i);
+  });
+
+  it('and the code HONOURS it: the only fencing verdict is a positive mismatch', () => {
+    // The sentence above is a claim about behaviour. These assertions are that behaviour.
+    // Divergence between them is exactly what shipped, so they are asserted together.
+    const fenced = [NO_SIGNAL, CLEARLY_CREATIVE, CLEARLY_GENERAL]
+      .filter((row) => workClassIneligibilityReason(row, 'fable') !== null);
+    expect(fenced).toEqual([CLEARLY_GENERAL]);
+  });
+
+  it('the retired fail-closed intent is GONE from the source, not just overridden', () => {
+    // Two contradictory policy statements is the condition that let the deny half win silently.
+    expect(src).not.toMatch(/fail-closed: unknown class on a restricted model/i);
+  });
+
+  it("'work_class_unclassified' is no longer a returnable fence reason", () => {
+    for (const row of [NO_SIGNAL, {}, { title: '' }, null]) {
+      expect(workClassIneligibilityReason(row, 'fable')).not.toBe('work_class_unclassified');
+    }
+  });
+});

--- a/tests/unit/fleet/work-class.test.js
+++ b/tests/unit/fleet/work-class.test.js
@@ -35,10 +35,14 @@ describe('TS-2 workClassAxes ctx-gating (via classifyDispatchIneligibility)', ()
     expect(classifyDispatchIneligibility(general, { session_model: 'opus' })).toBeNull();
     expect(classifyDispatchIneligibility(general, { session_model: 'claude-sonnet-5' })).toBeNull();
   });
-  it('fable session: general fenced, creative admitted, unclassified fail-closed', () => {
+  // QF-20260807-195: 'unclassified fail-closed' was the INVERSION — the module's own C-STARVE
+  // policy says only clearly-general work is hard-denied, and no-signal text is not evidence of
+  // a wrong class. The two-sided halves of this test (general fenced, creative admitted) are
+  // UNCHANGED and still asserted; only the no-signal default flipped, deliberately.
+  it('fable session: general fenced, creative admitted, unclassified ADMITTED (not fail-closed)', () => {
     expect(classifyDispatchIneligibility(general, { session_model: 'claude-fable-5' })).toBe('work_class_mismatch');
     expect(classifyDispatchIneligibility(creative, { session_model: 'fable' })).toBeNull();
-    expect(classifyDispatchIneligibility(blank, { session_model: 'fable' })).toBe('work_class_unclassified');
+    expect(classifyDispatchIneligibility(blank, { session_model: 'fable' })).toBeNull();
   });
   it('override work_class_override=any admits everywhere', () => {
     expect(classifyDispatchIneligibility(sd({ title: 'Fix cron', metadata: { work_class_override: 'any' } }), { session_model: 'fable' })).toBeNull();


### PR DESCRIPTION
## Problem

`lib/fleet/work-class.cjs` **stated one policy and implemented its opposite.**

Its C-STARVE comment says creative detection *"errs toward ADMITTING plausibly-creative work for Fable; only clearly-general work is hard-denied."* But text matching **neither** regex derived `unclassified`, and `workClassIneligibilityReason` turned that into a non-null reason — which *is* a fence. So the default for no-signal text was **DENY**, the exact inverse of the stated intent, and the recall-tuning only ever reached rows that had **already** matched `CREATIVE_RE`.

A second doc line said `fail-closed: unknown class on a restricted model`. The module carried **two contradictory statements of intent**, and the deny half won silently.

**Measured** (signal `8cf4545b`, logged as feedback `8740004e`): a Fable seat idled repeatedly against a 21-item belt while 3 rows sat `work_class_unclassified`. Two-sided controls confirmed the classifier itself is sound — clearly-creative → `creative_design`, clearly-general → `general_harness` — so this was purely the no-signal default polarity.

## Fix

Only a **positive mismatch** fences now.

**Admit-or-surface, never silent-fence.** `workClassAdmissionNote()` reports `admitted_unclassified` so a caller can say the item was admitted without signal — trading a silent fence for a silent admission would be no improvement. It's a *separate function* on purpose: the fence predicate is a first-truthy-wins ladder where the return channel **is** control flow, so a note smuggled through it would be indistinguishable from a fence.

The retired `fail-closed` doc line is **deleted** rather than left contradicting the policy, and a test pins the **policy sentence to the code behaviour** so they cannot diverge again.

**Scope:** classifier only. `requires_human_action` / chairman-axis holds are an independent fence; this returns a work-class verdict and nothing else, so it cannot clear them.

## Verification

- **12 tests**, two-sided throughout: clearly-general is **still hard-denied**, non-fable models are a byte-identical no-op, and an explicit override still wins in both directions.
- The policy-pin block asserts the sentence exists, that the code honours it (`[NO_SIGNAL, CREATIVE, GENERAL]` filtered by the fence yields exactly `[GENERAL]`), and that the retired fail-closed intent is gone from source.
- **Mutation-proved:** restoring the fail-closed deny reddens **4 tests**, including the policy-to-code pin.
- No regression: **154 fleet test files / 1923 tests green.**
- One pre-existing test updated — it pinned the old default. Its two-sided halves (general fenced, creative admitted) are unchanged and still asserted; only the no-signal default flipped, deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)