### PR TITLE
QF-20260727-131: clear a stale OVERDUE at the moment the process proves it is alive

### DIFF
--- a/lib/periodic-liveness/stamp-last-fired.js
+++ b/lib/periodic-liveness/stamp-last-fired.js
@@ -42,7 +42,73 @@ export async function stampLastFired(supabase, processKey) {
     return { stamped: false, reason: 'not_registered_as_self_stamped' };
   }
 
-  return { stamped: true };
+  const cleared = await clearOverdueOnStamp(supabase, processKey);
+  return { stamped: true, ...(cleared ? { cleared_overdue: true } : {}) };
+}
+
+/**
+ * QF-20260727-131 — clear a stale OVERDUE at the moment the process proves it is alive.
+ *
+ * ── THE DEFECT THIS CLOSES ────────────────────────────────────────────────────────────────
+ * `last_state` has ONE writer: periodic-liveness-watcher.mjs, invoked by a GHA cron declared at a
+ * fifteen-minute cadence. GitHub actually delivers that schedule at a MEASURED median of 83 minutes
+ * (p90 186m, max 647m; 43 of 59 observed intervals exceeded 45m). The thresholds it renders are
+ * 6/15/30/45m — so THE REFRESH PERIOD IS COARSER THAN THE THRESHOLDS, and a recovery stays
+ * invisible for longer than the outage that raised the alarm. Live: standard_loop:inbox rendered
+ * OVERDUE from a verdict 4h50m old while the watcher's own evaluateRow() returned OK for it.
+ *
+ * The recovery is ALREADY OBSERVED HERE, synchronously — this function is the process's own
+ * stamp. The system held proof of life and threw it away, deferring the clear to a poll. So the
+ * fix is not a new signal or a faster poll; it is using the one we already have.
+ *
+ * ── WHY EVERY GUARD IS A FILTER, NOT AN `if` ──────────────────────────────────────────────
+ * The tempting version is "we just stamped, so it must be OK". MEASURED FALSE at the boundary
+ * against the real evaluator: with expected_interval_seconds=0 or a NULL grace_multiplier the
+ * threshold is 0 (Number(null) === 0) and a FRESH stamp still evaluates OVERDUE; with
+ * currently_expected_active=false it evaluates INTENTIONALLY_DOWN, not OK. Expressing each
+ * condition as a declarative filter makes this write STRUCTURALLY UNABLE to disagree with
+ * evaluateRow, rather than agreeing with it by an assumption that a later edit can break.
+ * (`.gt()` also excludes NULLs: `NULL > 0` IS NULL, verified live.)
+ *
+ * `.eq('last_state','OVERDUE')` makes it TRANSITION-ONLY, preserving the per-episode dedup
+ * discipline that last_state_changed_at exists to enforce — a row already OK is never rewritten.
+ *
+ * NEVER-FALSE-OVERDUE IS UNTOUCHED: this moves OVERDUE->OK only, never the reverse, and only for
+ * a row whose own producer just stamped it. It introduces no new false-OK, because the watcher
+ * would compute the same OK from the same last_fired_at on its next run — the OK simply arrives
+ * on time instead of up to 10.8h late.
+ *
+ * FAIL-SOFT: a failure here must never break the caller's stamp. The stamp is the durable
+ * signal; this is a courtesy clear on top of it, and a process that cannot clear its banner must
+ * still be recorded as having run.
+ *
+ * SCOPE: self_stamped only. stampFromGithubActionsRun() has the same shape but stamps a PAST
+ * timestamp, so age != 0 there and a clear would have to re-derive the threshold; today's
+ * gha_cron OVERDUE rows are all genuinely overdue, so that path is deliberately left alone.
+ *
+ * @returns {Promise<boolean>} true iff a stale OVERDUE was actually cleared
+ */
+async function clearOverdueOnStamp(supabase, processKey) {
+  try {
+    const { data, error } = await supabase
+      .from('periodic_process_registry')
+      .update({ last_state: 'OK', last_state_changed_at: new Date().toISOString() })
+      .eq('process_key', processKey)
+      .eq('liveness_source', 'self_stamped')
+      .eq('currently_expected_active', true)
+      .eq('last_state', 'OVERDUE')
+      .gt('expected_interval_seconds', 0)
+      .gt('grace_multiplier', 0)
+      .select('process_key');
+    if (error) {
+      console.warn(`[stamp-last-fired] '${processKey}' stamped, but clearing its stale OVERDUE failed (non-fatal): ${error.message}`);
+      return false;
+    }
+    return Array.isArray(data) && data.length > 0;
+  } catch (e) {
+    console.warn(`[stamp-last-fired] '${processKey}' stamped, but clearing its stale OVERDUE threw (non-fatal): ${e?.message || e}`);
+    return false;
+  }
 }
 
 /**

--- a/tests/unit/periodic-liveness/stamp-last-fired.test.js
+++ b/tests/unit/periodic-liveness/stamp-last-fired.test.js
@@ -55,3 +55,110 @@ describe('stampFromGithubActionsRun', () => {
     expect(calls[0].val2).toBe('self_stamped');
   });
 });
+
+// ── QF-20260727-131: the stamp clears its own stale OVERDUE ──────────────────────────────
+//
+// last_state has ONE writer (periodic-liveness-watcher.mjs) on a GHA cron declared */15 that
+// GitHub delivers at a MEASURED median of 83m. The thresholds it renders are 6/15/30/45m, so the
+// refresh is coarser than the thresholds and a recovered process keeps displaying OVERDUE for
+// longer than the outage lasted — measured live at 4h50m on standard_loop:inbox while the
+// watcher's own evaluateRow() returned OK for that same row. The recovery is already observed
+// synchronously by the stamp; these tests pin that we now USE it.
+//
+// The assertions are on the FILTERS, not on a returned flag alone: the whole point of the design
+// is that each guard is declarative so the write cannot disagree with evaluateRow. A test that
+// only checked "did it clear?" would pass against a version that cleared unconditionally, which
+// is the false-OK this must never introduce.
+// The two UPDATEs must be answerable INDEPENDENTLY. My first version of this mock returned one
+// canned result for both, so configuring "the clear finds nothing" also made the STAMP find
+// nothing — three tests failed for a reason that had nothing to do with the code under test. A
+// harness that cannot distinguish the call it is describing tests the wrong thing.
+function chainableSupabase({ stampRegistered = true, rows = [], failWith = null, throwOn = false } = {}) {
+  const filters = [];
+  const calls = [];
+  const builder = {
+    eq: (col, val) => { filters.push(['eq', col, val]); return builder; },
+    gt: (col, val) => { filters.push(['gt', col, val]); return builder; },
+    select: () => {
+      const isStamp = calls.length === 1; // the stamp is the first update; the clear is the second
+      if (isStamp) {
+        return Promise.resolve({ data: stampRegistered ? [{ process_key: 'stamped' }] : [], error: null });
+      }
+      if (throwOn) throw new Error('boom');
+      return Promise.resolve(failWith ? { data: null, error: { message: failWith } } : { data: rows, error: null });
+    },
+  };
+  return {
+    calls,
+    filters,
+    from: () => ({
+      update: (payload) => { calls.push(payload); return builder; },
+    }),
+  };
+}
+
+describe('QF-20260727-131 — stampLastFired clears a stale OVERDUE at the moment of proof-of-life', () => {
+  it('clears OVERDUE and reports it, applying every guard as a filter', async () => {
+    const sb = chainableSupabase({ rows: [{ process_key: 'standard_loop:identity' }] });
+    const r = await stampLastFired(sb, 'standard_loop:identity');
+
+    expect(r.stamped).toBe(true);
+    expect(r.cleared_overdue).toBe(true);
+
+    // The clear is the SECOND update; the first is the stamp itself.
+    expect(sb.calls).toHaveLength(2);
+    expect(sb.calls[1]).toMatchObject({ last_state: 'OK' });
+    expect(sb.calls[1].last_state_changed_at).toBeTruthy();
+
+    const f = sb.filters;
+    // TRANSITION-ONLY — without this a row already OK is rewritten every stamp, destroying the
+    // per-episode dedup that last_state_changed_at exists to enforce.
+    expect(f).toContainEqual(['eq', 'last_state', 'OVERDUE']);
+    // AGREES WITH evaluateRow AT THE BOUNDARY. Measured false otherwise: interval=0 or a NULL
+    // grace_multiplier yields threshold 0 and a FRESH stamp still evaluates OVERDUE; an inactive
+    // row evaluates INTENTIONALLY_DOWN, not OK.
+    expect(f).toContainEqual(['eq', 'currently_expected_active', true]);
+    expect(f).toContainEqual(['gt', 'expected_interval_seconds', 0]);
+    expect(f).toContainEqual(['gt', 'grace_multiplier', 0]);
+    // Never widens beyond the class this helper owns.
+    expect(f).toContainEqual(['eq', 'liveness_source', 'self_stamped']);
+  });
+
+  it('reports NO clear when the row was not OVERDUE — silence is the correct answer', async () => {
+    // The filtered UPDATE matches zero rows. That is not an error and must not read as one, and
+    // it must not read as a repair either.
+    const sb = chainableSupabase({ rows: [] });
+    const r = await stampLastFired(sb, 'standard_loop:identity');
+    expect(r.stamped).toBe(true);
+    expect(r.cleared_overdue).toBeUndefined();
+  });
+
+  it('FAIL-SOFT: a failed clear never costs the caller its stamp', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const sb = chainableSupabase({ failWith: 'permission denied' });
+    const r = await stampLastFired(sb, 'standard_loop:identity');
+    // The stamp is the durable signal; a process that cannot clear its banner must still be
+    // recorded as having run.
+    expect(r.stamped).toBe(true);
+    expect(r.cleared_overdue).toBeUndefined();
+    expect(warn.mock.calls.some((c) => String(c[0]).includes('clearing its stale OVERDUE failed'))).toBe(true);
+    warn.mockRestore();
+  });
+
+  it('FAIL-SOFT: a THROWN clear also never costs the stamp', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const sb = chainableSupabase({ throwOn: true });
+    const r = await stampLastFired(sb, 'standard_loop:identity');
+    expect(r.stamped).toBe(true);
+    warn.mockRestore();
+  });
+
+  it('an UNREGISTERED key never reaches the clear at all', async () => {
+    // No stamp, no proof of life, so nothing to clear — the early return must short-circuit.
+    const sb = chainableSupabase({ stampRegistered: false });
+    // stampLastFired's own no-op path returns before the clear; only ONE update is attempted.
+    const r = await stampLastFired(sb, 'not-registered');
+    expect(r.stamped).toBe(false);
+    expect(sb.calls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
**Premise evolution, recorded rather than silently replaced** (coordinator ruling `19c5689a`). The QF's headline symptom — GHA crons rendering 264–282h overdue — is **resolved**, re-measured before any code was touched: those workflows stamp `last_fired_at` now, only 4 `gha_cron` rows are OVERDUE at all, median age 2h. The QF's own explicitly-unverified hypothesis (GHA-only workflows never stamp) is **refuted** as a current diagnosis, exactly as it warned it must not be assumed. What survives is its *intent*, now measured: a liveness panel that cries wolf trains readers to ignore the section where a genuinely dead process would appear.

### Root cause (RCA `b75d0acd`) — there is no latch; the verdict is never recomputed in time

`last_state` has **one** writer, `periodic-liveness-watcher.mjs`, on a GHA cron declared at a fifteen-minute cadence that GitHub actually delivers at a **measured median of 83 minutes** (p90 186m, max 647m; 43 of 59 intervals exceeded 45m). The thresholds it renders are 6/15/30/45m — so **the refresh period is coarser than the thresholds it renders**, and a recovery stays invisible for longer than the outage that raised the alarm.

Measured live: `standard_loop:inbox` rendered OVERDUE from a verdict **4h50m old** while the watcher's own `evaluateRow()` returned OK for that same row.

The recovery is **already observed synchronously** — by the process's own stamp. The system held proof of life and threw it away, deferring the clear to a poll. This fix isn't a new signal or a faster cron; it uses the one already in hand.

### Every guard is a filter, not an `if`

The tempting version — "we just stamped, so it must be OK" — is **measured false at the boundary**: with `expected_interval_seconds=0` or a NULL `grace_multiplier` the threshold is 0 (`Number(null)===0`) and a *fresh* stamp still evaluates OVERDUE; an inactive row evaluates INTENTIONALLY_DOWN. Declarative filters make the write **structurally unable** to disagree with `evaluateRow`, rather than agreeing with it by an assumption a later edit can break.

Never-false-OVERDUE is untouched: OVERDUE→OK only, only for a row whose own producer just stamped, and no new false-OK — the watcher computes the same OK from the same `last_fired_at` on its next run; the OK just arrives on time instead of up to 10.8h late. Nothing is suppressed or allowlisted. Scope is `self_stamped` only; the `gha_cron` sibling stamps a *past* timestamp, so age ≠ 0 there and today's `gha_cron` OVERDUEs are all genuine.

### Two corrections to my own analysis, both found by the RCA

- I reported `liveness_source_ref` holding the literal string `[object Object]` on all 7 rows. **Not real** — it was my instrument. All 246 rows hold real jsonb; I had interpolated the object into a template literal. The measurement invented the artifact it reported.
- I claimed the writer persists only on transition. **Wrong** — that guard is `stampStateChangeAnchor` and gates only `last_state_changed_at`; `last_state` is written unconditionally. The watcher code was correct all along, which is why hunting an evaluator bug was never going to find anything.

### Verification

Mutation-proven, 4 of 4 applicable: drop the transition-only filter (1 red), drop the active guard (1 red), drop the threshold guards (1 red), remove the call entirely (2 red). The fail-soft path resists single-line mutation because the error branch sits inside the try — defended twice; stated plainly rather than claimed as a fifth kill.

**145 tests green across all 15 suites that read this source**, selected by grepping for what imports it rather than by filename — a filename-shaped guess let a real regression reach CI earlier today.

### Known, out of scope, worth its own QF

53 `__e2e_periodic_liveness_*` fixture rows have leaked into the production registry and are **49 of the 64 OVERDUE rows (77%)** — `expected_interval_seconds=5`, `consecutive_miss_count` up to 953, oldest from 2026-07-05. `tests/integration/periodic-process-liveness-realdb.test.js` has an `afterAll` cleanup whose header claims "zero residue"; those 53 rows falsify that claim, so it isn't running on aborted runs. That is the larger contributor to the panel's noise and deserves a reaper of its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)