### PR TITLE
fix(QF-20260804-048): canonical evidence reader that throws instead of answering a false zero

### DIFF
--- a/lib/sub-agents/evidence-status.js
+++ b/lib/sub-agents/evidence-status.js
@@ -1,0 +1,140 @@
+/**
+ * Canonical reader for "does this SD have sub-agent evidence?"
+ * QF-20260804-048.
+ *
+ * WHY THIS EXISTS. sub_agent_execution_results.sd_id holds a UUID, but every worker reasons in
+ * sd_key. So the natural hand-rolled query filters that UUID column with a KEY string — and
+ * PostgREST returns EMPTY WITH NO ERROR for the mismatch. The result is, in one worker's words,
+ * "a CONSTANT wearing the shape of a measurement": it cannot report anything but zero, and nothing
+ * in the response distinguishes "no evidence exists" from "you asked with the wrong value format".
+ *
+ * MEASURED HARM, two different workers on one night, both acting on the false zero:
+ *   - one ran a per-tick blocker re-check that returned empty unconditionally for ~50 minutes and
+ *     reported "blocker UNCHANGED" throughout, while a real TESTING/FAIL row sat invisible to it;
+ *   - another reported "evidence rows: 0" for seven consecutive cycles (~105 min), concluded the SD
+ *     "provably cannot advance", and escalated asking to be re-routed off it. The gate then passed
+ *     LEAD-TO-PLAN at 94 with GATE_SUBAGENT_EVIDENCE green — the evidence had been there all along.
+ * So it does not merely mislead: it produced a false blocker report, a false escalation, and a
+ * request to abandon workable work.
+ *
+ * THE ROOT IS THAT NO CANONICAL READER EXISTED, so every caller invented one and invented the same
+ * bug. This is that reader.
+ *
+ * DESIGN RULE, and the whole point: **THROW ON AN UNRESOLVABLE INPUT — NEVER RETURN EMPTY.** An
+ * empty result must mean "this SD genuinely has no such evidence" and nothing else. A helper that
+ * answered "0" for a typo would just relocate the defect behind a friendlier name.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+/** Verdicts the evidence gate treats as satisfying a requirement. */
+export const ACCEPTED_VERDICTS = Object.freeze(['PASS', 'CONDITIONAL_PASS', 'WARNING']);
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function defaultClient() {
+  const url = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) throw new Error('evidence-status: SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY required');
+  return createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+}
+
+/**
+ * Resolve an sd_key OR uuid to the canonical strategic_directives_v2.id.
+ *
+ * THROWS when the input cannot be resolved. That is deliberate and is the fix: the defect this QF
+ * documents is a lookup that answers "nothing here" when it means "I could not ask the question".
+ *
+ * @param {string} sdKeyOrId
+ * @param {{supabase?:object}} [opts]
+ * @returns {Promise<string>} the canonical id
+ */
+export async function resolveSdId(sdKeyOrId, { supabase } = {}) {
+  if (typeof sdKeyOrId !== 'string' || !sdKeyOrId.trim()) {
+    throw new Error('evidence-status: an sd_key or sd id is required (got ' + JSON.stringify(sdKeyOrId) + ')');
+  }
+  const input = sdKeyOrId.trim();
+  const db = supabase || defaultClient();
+
+  // A UUID may still not exist; confirm rather than assume, so a stale id cannot masquerade as
+  // "no evidence" further down.
+  const column = UUID_RE.test(input) ? 'id' : 'sd_key';
+  const { data, error } = await db
+    .from('strategic_directives_v2')
+    .select('id')
+    .eq(column, input)
+    .maybeSingle();
+
+  if (error) throw new Error(`evidence-status: SD lookup failed for ${input}: ${error.message}`);
+  if (!data || !data.id) {
+    throw new Error(
+      `evidence-status: no strategic directive matches ${JSON.stringify(input)} (looked up by ${column}). `
+      + 'Refusing to return an empty evidence set for an unresolvable SD — that is the defect this helper exists to prevent.'
+    );
+  }
+  return data.id;
+}
+
+/**
+ * Evidence rows for an SD, keyed by sub-agent code (latest row per code).
+ *
+ * Accepts an sd_key OR a uuid and resolves it, so a caller reasoning in keys — which is every
+ * caller — cannot silently query a uuid column with a key.
+ *
+ * @param {string} sdKeyOrId
+ * @param {{supabase?:object, phase?:string, sinceMs?:number, nowMs?:number}} [opts]
+ * @returns {Promise<{sdId:string, rows:Array, byCode:Object}>}
+ */
+export async function getEvidence(sdKeyOrId, { supabase, phase, sinceMs, nowMs = Date.now() } = {}) {
+  const db = supabase || defaultClient();
+  const sdId = await resolveSdId(sdKeyOrId, { supabase: db });
+
+  let q = db
+    .from('sub_agent_execution_results')
+    .select('id, sub_agent_code, verdict, phase, created_at')
+    .eq('sd_id', sdId)
+    .order('created_at', { ascending: false });
+
+  if (phase) q = q.eq('phase', phase);
+  if (Number.isFinite(sinceMs)) q = q.gte('created_at', new Date(nowMs - sinceMs).toISOString());
+
+  const { data, error } = await q;
+  if (error) throw new Error(`evidence-status: evidence query failed for ${sdId}: ${error.message}`);
+
+  const rows = data || [];
+  const byCode = {};
+  for (const r of rows) {
+    // rows are newest-first, so the first sighting of a code is its latest row
+    const code = String(r.sub_agent_code || '').toUpperCase();
+    if (code && !byCode[code]) byCode[code] = r;
+  }
+  return { sdId, rows, byCode };
+}
+
+/**
+ * Does this SD have accepted evidence for every required sub-agent code?
+ *
+ * @param {string} sdKeyOrId
+ * @param {string[]} requiredCodes
+ * @param {{supabase?:object, phase?:string, sinceMs?:number, nowMs?:number, acceptedVerdicts?:string[]}} [opts]
+ * @returns {Promise<{sdId:string, satisfied:boolean, present:string[], missing:string[], rejected:Array}>}
+ */
+export async function hasEvidenceFor(sdKeyOrId, requiredCodes, opts = {}) {
+  if (!Array.isArray(requiredCodes) || requiredCodes.length === 0) {
+    throw new Error('evidence-status: requiredCodes must be a non-empty array — an empty requirement is trivially satisfied and hides the question');
+  }
+  const accepted = opts.acceptedVerdicts || ACCEPTED_VERDICTS;
+  const { sdId, byCode } = await getEvidence(sdKeyOrId, opts);
+
+  const present = [];
+  const missing = [];
+  const rejected = [];
+  for (const raw of requiredCodes) {
+    const code = String(raw).toUpperCase();
+    const row = byCode[code];
+    if (!row) { missing.push(code); continue; }
+    if (accepted.includes(String(row.verdict).toUpperCase())) present.push(code);
+    else rejected.push({ code, verdict: row.verdict, id: row.id });
+  }
+  return { sdId, satisfied: missing.length === 0 && rejected.length === 0, present, missing, rejected };
+}

--- a/tests/unit/sub-agents/evidence-status.test.js
+++ b/tests/unit/sub-agents/evidence-status.test.js
@@ -1,0 +1,154 @@
+/**
+ * The canonical evidence reader must THROW where the hand-rolled query returned a false zero.
+ * QF-20260804-048.
+ *
+ * THE DEFECT BEING PREVENTED: sub_agent_execution_results.sd_id is a UUID; every worker reasons in
+ * sd_key; PostgREST returns EMPTY WITH NO ERROR when you filter the uuid column with a key string.
+ * Two workers hand-rolled that query on the same night and both acted on the false zero — one
+ * reported "blocker UNCHANGED" for ~50 minutes while a real FAIL row sat invisible, the other
+ * declared his SD "provably cannot advance" and asked to be re-routed off it, minutes before the
+ * gate passed at 94 with the evidence green all along.
+ *
+ * SO THE ASSERTION THAT MATTERS IS NOT "it returns the right rows" — it is that an UNANSWERABLE
+ * question RAISES instead of resolving to zero. A helper that returned [] for a typo would just
+ * relocate the defect behind a friendlier name.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { resolveSdId, getEvidence, hasEvidenceFor, ACCEPTED_VERDICTS } from '../../../lib/sub-agents/evidence-status.js';
+
+const UUID = '7a269865-5b22-4dff-95f8-1fbd95645d8b';
+const KEY = 'SD-LEO-INFRA-COORDINATION-LANE-DRAIN-001';
+
+/**
+ * Supabase fake that mimics the REAL failure: a filter that does not match returns
+ * { data: null/[] , error: null } — empty, with NO error.
+ */
+function fakeDb({ sd = null, rows = [] } = {}) {
+  const calls = { sdFilters: [], evidenceFilters: [] };
+  return {
+    __calls: calls,
+    from(table) {
+      const q = {
+        _table: table,
+        select() { return q; },
+        order() { return q; },
+        eq(col, val) {
+          if (table === 'strategic_directives_v2') calls.sdFilters.push([col, val]);
+          else calls.evidenceFilters.push([col, val]);
+          q._eq = q._eq || []; q._eq.push([col, val]);
+          return q;
+        },
+        gte() { return q; },
+        maybeSingle() {
+          // Only resolve when the filter matches how the fake SD is addressed.
+          const match = (q._eq || []).some(([c, v]) => sd && ((c === 'id' && v === sd.id) || (c === 'sd_key' && v === sd.sd_key)));
+          return Promise.resolve({ data: match ? { id: sd.id } : null, error: null });
+        },
+        then(res) { return Promise.resolve({ data: rows, error: null }).then(res); }
+      };
+      return q;
+    }
+  };
+}
+
+const SD = { id: UUID, sd_key: KEY };
+
+describe('resolveSdId — an unanswerable question RAISES, never resolves to empty', () => {
+  it('THE POINT: an unknown key THROWS rather than yielding an empty evidence set', async () => {
+    const db = fakeDb({ sd: SD });
+    await expect(resolveSdId('SD-DOES-NOT-EXIST-001', { supabase: db })).rejects.toThrow(/no strategic directive matches/i);
+  });
+
+  it('a uuid that does not exist ALSO throws — a stale id must not masquerade as "no evidence"', async () => {
+    const db = fakeDb({ sd: SD });
+    await expect(resolveSdId('00000000-0000-4000-8000-000000000000', { supabase: db })).rejects.toThrow(/no strategic directive matches/i);
+  });
+
+  it.each([[''], ['   '], [null], [undefined], [42], [{}]])('rejects a non-string / blank input (%s)', async (bad) => {
+    await expect(resolveSdId(bad, { supabase: fakeDb({ sd: SD }) })).rejects.toThrow(/sd_key or sd id is required/i);
+  });
+
+  it('resolves a KEY to the uuid — the translation every caller was hand-rolling', async () => {
+    const db = fakeDb({ sd: SD });
+    await expect(resolveSdId(KEY, { supabase: db })).resolves.toBe(UUID);
+    expect(db.__calls.sdFilters).toContainEqual(['sd_key', KEY]);
+  });
+
+  it('accepts a uuid unchanged, looked up by id', async () => {
+    const db = fakeDb({ sd: SD });
+    await expect(resolveSdId(UUID, { supabase: db })).resolves.toBe(UUID);
+    expect(db.__calls.sdFilters).toContainEqual(['id', UUID]);
+  });
+});
+
+describe('getEvidence — the uuid column is never filtered with a key', () => {
+  it('filters sd_id with the resolved UUID even when handed a KEY', async () => {
+    // This is the exact mistake that produced the false zeros: .eq('sd_id', '<KEY>').
+    const db = fakeDb({ sd: SD, rows: [{ id: 'r1', sub_agent_code: 'TESTING', verdict: 'PASS', created_at: new Date().toISOString() }] });
+    const out = await getEvidence(KEY, { supabase: db });
+    expect(out.sdId).toBe(UUID);
+    expect(db.__calls.evidenceFilters).toContainEqual(['sd_id', UUID]);
+    expect(db.__calls.evidenceFilters.find(([c, v]) => c === 'sd_id' && v === KEY)).toBeUndefined();
+  });
+
+  it('keys byCode on the LATEST row per code (rows arrive newest-first)', async () => {
+    const rows = [
+      { id: 'new', sub_agent_code: 'TESTING', verdict: 'PASS', created_at: '2026-08-07T12:00:00Z' },
+      { id: 'old', sub_agent_code: 'TESTING', verdict: 'FAIL', created_at: '2026-08-01T12:00:00Z' }
+    ];
+    const out = await getEvidence(KEY, { supabase: fakeDb({ sd: SD, rows }) });
+    expect(out.byCode.TESTING.id).toBe('new');
+  });
+
+  it('an unresolvable SD throws BEFORE any evidence query runs', async () => {
+    const db = fakeDb({ sd: SD, rows: [] });
+    await expect(getEvidence('SD-NOPE-001', { supabase: db })).rejects.toThrow();
+    expect(db.__calls.evidenceFilters).toEqual([]);
+  });
+});
+
+describe('hasEvidenceFor', () => {
+  const row = (code, verdict) => ({ id: code, sub_agent_code: code, verdict, created_at: '2026-08-07T12:00:00Z' });
+
+  it('satisfied when every required code has an accepted verdict', async () => {
+    const db = fakeDb({ sd: SD, rows: [row('TESTING', 'PASS'), row('SECURITY', 'CONDITIONAL_PASS')] });
+    const out = await hasEvidenceFor(KEY, ['TESTING', 'SECURITY'], { supabase: db });
+    expect(out).toMatchObject({ satisfied: true, missing: [], rejected: [] });
+  });
+
+  it('reports MISSING and REJECTED separately — they need different remedies', async () => {
+    // Blending them is how "run the agent again" gets applied to a code that ran and FAILED.
+    const db = fakeDb({ sd: SD, rows: [row('TESTING', 'FAIL')] });
+    const out = await hasEvidenceFor(KEY, ['TESTING', 'SECURITY'], { supabase: db });
+    expect(out.satisfied).toBe(false);
+    expect(out.missing).toEqual(['SECURITY']);
+    expect(out.rejected).toEqual([{ code: 'TESTING', verdict: 'FAIL', id: 'TESTING' }]);
+  });
+
+  it('is case-insensitive on the code, so "Explore" and "EXPLORE" are one requirement', async () => {
+    const db = fakeDb({ sd: SD, rows: [row('Explore', 'PASS')] });
+    await expect(hasEvidenceFor(KEY, ['explore'], { supabase: db })).resolves.toMatchObject({ satisfied: true });
+  });
+
+  it('REFUSES an empty requirement list rather than reporting trivially satisfied', async () => {
+    // "satisfied: true because nothing was required" is a green light that measured nothing.
+    await expect(hasEvidenceFor(KEY, [], { supabase: fakeDb({ sd: SD }) })).rejects.toThrow(/non-empty array/i);
+  });
+
+  it('CONDITIONAL_PASS and WARNING count as accepted, matching the gate', async () => {
+    expect(ACCEPTED_VERDICTS).toEqual(['PASS', 'CONDITIONAL_PASS', 'WARNING']);
+  });
+});
+
+describe('CONTROL — the fake reproduces the real failure it is guarding against', () => {
+  it('a mismatched filter returns EMPTY WITH NO ERROR (the silent-zero shape)', async () => {
+    // If the fake errored on a mismatch it would be easier than reality, and these tests would
+    // prove nothing about the defect. Here the wrong filter yields null + no error, exactly as
+    // PostgREST does — which is why the hand-rolled query could never report its own failure.
+    const db = fakeDb({ sd: SD });
+    const res = await db.from('strategic_directives_v2').select('id').eq('sd_key', 'SD-WRONG-001').maybeSingle();
+    expect(res.error).toBeNull();
+    expect(res.data).toBeNull();
+  });
+});


### PR DESCRIPTION
## The defect

`sub_agent_execution_results.sd_id` holds a **UUID**; every worker reasons in **sd_key**; PostgREST returns **empty with no error** when you filter that uuid column with a key string. The natural hand-rolled query is *"a CONSTANT wearing the shape of a measurement"* — it cannot report anything but zero, and nothing distinguishes *no evidence exists* from *you asked with the wrong value format*.

Two workers invented that query on the same night and both acted on the false zero: one reported "blocker UNCHANGED" for ~50 minutes while a real FAIL row sat invisible; the other declared his SD "provably cannot advance" and asked to be re-routed off it — shortly before the gate passed LEAD-TO-PLAN at 94 with the evidence green all along. A false blocker report, a false escalation, and a request to abandon workable work.

**No canonical reader existed**, so every caller invented one and invented the same bug.

## The fix

`lib/sub-agents/evidence-status.js` — accepts an sd_key **or** a uuid, resolves the key itself, and **throws on an unresolvable input rather than returning empty**. That refusal is the entire point: a helper answering "0" for a typo would only relocate the defect behind a friendlier name.

Same reasoning elsewhere in the module: an empty `requiredCodes` list is rejected rather than reported trivially satisfied; a non-existent uuid throws too, so a stale id cannot masquerade as "no evidence"; and MISSING is reported separately from REJECTED, since blending them is how "just run the agent again" gets applied to a code that ran and **failed**.

## The QF's second, unexplained defect — accounted for, as it asked

The report was that a *corrected* query still returned 0 while "its own positive control showed a **fleet** evidence row 0.2h old." That needs no second bug: the control was **fleet-scoped** and the query was **SD-scoped**, so they measured different populations. A fleet-wide row existing 0.2h ago says nothing about whether one particular SD has rows — the control could never have falsified the query it was meant to check.

Same class as the primary defect: an instrument reading green while measuring something other than the question. Recorded as an explanation, not a code change — the remedy is a control scoped to the SD under test.

## Verification

19 tests. The fake reproduces the real failure shape (mismatched filter returns null with **no error**) and carries a control proving it — a fake that errored on a mismatch would be easier than reality and would prove nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)