### PR TITLE
QF-20260807-190: reap the e2e fixture rows that are 77% of the liveness panel's alarms, and close the leak that made them

### DIFF
--- a/scripts/reap-e2e-liveness-fixtures.mjs
+++ b/scripts/reap-e2e-liveness-fixtures.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * QF-20260807-190 — reap e2e fixture residue from periodic_process_registry.
+ *
+ * ── WHY THIS EXISTS ───────────────────────────────────────────────────────────────────────
+ * MEASURED 2026-08-07T16:51Z: 53 rows whose process_key begins `__e2e_periodic_liveness_` had
+ * leaked into the PRODUCTION registry and were 49 of the 64 OVERDUE rows — 77% of every alarm on
+ * the fleet-health panel, against 15 real ones. All carry expected_interval_seconds=5, so they
+ * alarm within seconds of creation and never stop; max consecutive_miss_count was 953.
+ *
+ * That is not cosmetic. The panel is the surface an operator scans to decide whether anything
+ * needs attention, and a permanent block of false OVERDUE entries trains the reader to skip the
+ * section — which is exactly where a genuinely dead process would appear.
+ *
+ * ── THE PREDICATE IS THE WHOLE SAFETY ARGUMENT ────────────────────────────────────────────
+ * `__e2e_` ONLY, never a bare `__` prefix. Two REAL rows lead with `__`:
+ *   __watcher_self__              — the liveness watcher's own marker
+ *   __eva_scheduler_watcher_self  — the scheduler watcher's own marker
+ * Reaping either BLINDS THE INSTRUMENT THIS REAPER EXISTS TO UNBLIND. The second one was not in
+ * the original report and surfaced only by enumerating prefixes FROM THE DATA rather than from
+ * the one example that had been noticed — which is why isReapable is a pure, tested predicate
+ * and not an inline filter string.
+ *
+ * AND NEVER MATCH ON NAME KEYWORDS. Three live rows contain test/fixture/sample in their keys —
+ * gha_cron:venture-fixture-sweep.yml, standard_loop:account-usage-sample,
+ * cron_script:account-usage-sample.mjs — and they read as REAL processes whose names merely sound
+ * test-shaped. A name is a claim, not evidence.
+ *
+ * ── DRY-RUN IS THE DEFAULT, AND THAT IS NOT POLITENESS ────────────────────────────────────
+ * This deletes rows from a production table. Nothing here constitutes authorization to do that;
+ * the QF that specifies this script says so explicitly, and a QF description is not an approval.
+ * So the default prints exactly what WOULD be deleted and exits without writing. `--apply`
+ * requires the operator to have obtained that authorization separately.
+ *
+ * Usage:
+ *   node scripts/reap-e2e-liveness-fixtures.mjs            # dry run (default) — prints the plan
+ *   node scripts/reap-e2e-liveness-fixtures.mjs --apply    # delete, once authorized
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+// The CANONICAL entry-point predicate, not a hand-rolled one. My first version compared
+// import.meta.url to a `file://` + process.argv[1] string with a slash swap, and on Windows it
+// silently NEVER MATCHED — the script ran, printed nothing, and exited 0. A reaper whose main()
+// never fires is indistinguishable from a reaper that found nothing to reap, which is the exact
+// class of defect this QF is about. Caught only because the dry run's output was empty.
+import { isMainModule } from '../lib/utils/is-main-module.js';
+
+/** The one prefix that is fixture residue. Exported so the safety argument is testable. */
+export const E2E_FIXTURE_PREFIX = '__e2e_';
+
+/**
+ * True iff this row is e2e fixture residue and safe to delete.
+ *
+ * Deliberately takes the KEY ONLY: a predicate that also consulted last_state or age could be
+ * argued into reaping a real row that merely looked abandoned. Provenance decides, not symptoms.
+ */
+export function isReapable(processKey) {
+  return typeof processKey === 'string' && processKey.startsWith(E2E_FIXTURE_PREFIX);
+}
+
+async function main() {
+  const apply = process.argv.includes('--apply');
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+  // select('*') rather than naming columns: a phantom column in a PostgREST select returns 42703
+  // and poisons the ENTIRE projection, which would render as "no residue found".
+  const { data, error } = await supabase.from('periodic_process_registry').select('*');
+  if (error) {
+    console.error(`[reap-e2e] read failed: ${error.message}`);
+    process.exit(1);
+  }
+
+  const reapable = (data || []).filter((r) => isReapable(r.process_key));
+  const overdue = reapable.filter((r) => r.last_state === 'OVERDUE').length;
+  const allOverdue = (data || []).filter((r) => r.last_state === 'OVERDUE').length;
+
+  console.log(`[reap-e2e] registry rows: ${(data || []).length}`);
+  console.log(`[reap-e2e] fixture residue (${E2E_FIXTURE_PREFIX}*): ${reapable.length}`);
+  console.log(`[reap-e2e] of which OVERDUE: ${overdue} of ${allOverdue} total OVERDUE`);
+  // Name the survivors so the operator can see the reaper is NOT touching them.
+  const dunderKept = (data || []).filter((r) => /^__/.test(r.process_key || '') && !isReapable(r.process_key));
+  console.log(`[reap-e2e] __-leading rows DELIBERATELY KEPT: ${dunderKept.map((r) => r.process_key).join(', ') || '(none)'}`);
+
+  if (reapable.length === 0) {
+    console.log('[reap-e2e] nothing to reap.');
+    return;
+  }
+
+  if (!apply) {
+    console.log('[reap-e2e] DRY RUN — no rows deleted. Re-run with --apply once deletion is authorized.');
+    for (const r of reapable) console.log(`  would delete: ${r.process_key}`);
+    return;
+  }
+
+  // Delete BY EXPLICIT KEY LIST, not by a LIKE pattern. The keys were already filtered through
+  // isReapable in this process, so the write cannot widen beyond what was just printed — a
+  // server-side pattern would be a second, unreviewed representation of the predicate.
+  const keys = reapable.map((r) => r.process_key);
+  const { error: delErr, count } = await supabase
+    .from('periodic_process_registry')
+    .delete({ count: 'exact' })
+    .in('process_key', keys);
+  if (delErr) {
+    console.error(`[reap-e2e] delete failed: ${delErr.message}`);
+    process.exit(1);
+  }
+  // Report what LANDED, not what was attempted.
+  console.log(`[reap-e2e] deleted ${count ?? 'unknown'} row(s) of ${keys.length} targeted.`);
+}
+
+if (isMainModule(import.meta.url)) {
+  main().catch((e) => { console.error(`[reap-e2e] ${e?.message || e}`); process.exit(1); });
+}

--- a/tests/integration/periodic-process-liveness-realdb.test.js
+++ b/tests/integration/periodic-process-liveness-realdb.test.js
@@ -56,6 +56,31 @@ describe.skipIf(!HAS_REAL_DB)('Periodic-process liveness registry -- REAL DB', (
       await supabase.from('session_coordination').delete().eq('payload->>process_key', key);
       await supabase.from('periodic_process_registry').delete().eq('process_key', key);
     }
+
+    // QF-20260807-190 — SWEEP THIS RUN'S WHOLE PREFIX, not just the keys this process remembers.
+    //
+    // The header above claimed "zero residue". 53 fixture rows in the production registry
+    // falsified it, and the leak distribution NAMES THE MECHANISM: counts fall monotonically in
+    // fixture-creation order — silenced 22, recovers_then_relapses 15, healthy 6, stood_down 4,
+    // owner_first 3, ladder_pre_migration 3. A silently-failing delete would leak all six EQUALLY,
+    // because every run creates all six. Leaking fewer of the later ones is what happens when the
+    // run TERMINATES PART-WAY and afterAll never executes at all.
+    //
+    // So the loop above cannot be the whole cleanup: it is driven by an in-memory array that only
+    // exists while the process does. This sweep is keyed on `ts`, which is stamped once at module
+    // load, so it removes every fixture from THIS run — including any whose insert succeeded
+    // before a crash — and touches no other run's rows.
+    //
+    // It does NOT fix an aborted run (nothing in-process can); scripts/reap-e2e-liveness-fixtures.mjs
+    // is the out-of-band recovery for residue already in the table. This closes the narrower gap:
+    // a run that reaches afterAll now cleans up completely rather than only what it recorded.
+    const { error: sweepErr } = await supabase
+      .from('periodic_process_registry')
+      .delete()
+      .like('process_key', `__e2e_periodic_liveness_%_${ts}__`);
+    // SURFACED, not swallowed. The deletes above ignore their error entirely, which is how a
+    // cleanup can fail on every run while its header still claims zero residue.
+    if (sweepErr) console.warn(`[e2e-cleanup] prefix sweep for ts=${ts} failed: ${sweepErr.message}`);
   });
 
   it('TS-1: a self-stamped fixture fired twice then silenced 3x its interval is flagged OVERDUE with exactly one session_coordination row', async () => {

--- a/tests/unit/periodic-liveness/reap-e2e-fixtures-predicate.test.js
+++ b/tests/unit/periodic-liveness/reap-e2e-fixtures-predicate.test.js
@@ -1,0 +1,91 @@
+/**
+ * QF-20260807-190 — the reaper's predicate is the whole safety argument, so it is pinned here.
+ *
+ * This reaper deletes rows from a PRODUCTION table. The only thing standing between "removes 53
+ * abandoned test fixtures" and "blinds the fleet's liveness watchers" is which keys `isReapable`
+ * returns true for. A bare `__` prefix — the obvious shorthand, and the one a hurried reader would
+ * write — destroys `__watcher_self__` and `__eva_scheduler_watcher_self`, each of which is a
+ * watcher's own liveness marker. That is not a near-miss; it is deleting the instrument the reaper
+ * exists to unblind.
+ *
+ * The second of those two rows was NOT in the original report. It surfaced only by enumerating
+ * every `__`-leading prefix from the live data instead of from the single example that had been
+ * noticed. So this suite asserts the real rows by name rather than asserting a regex shape: a
+ * shape-only test would have passed against the predicate that kills them.
+ */
+import { describe, it, expect } from 'vitest';
+import { isReapable, E2E_FIXTURE_PREFIX } from '../../../scripts/reap-e2e-liveness-fixtures.mjs';
+
+// Measured live 2026-08-07T16:51Z, then RE-READ IN FULL from the reaper's own dry run. These are
+// REAL rows and deleting either is the worst outcome this QF could produce, so they are named
+// explicitly rather than described.
+//
+// The second key was briefly wrong here: my prefix survey printed keys sliced to 28 characters for
+// display, and I copied `__eva_scheduler_watcher_self` — the TRUNCATED form — into this constant as
+// though it were the key. Both forms happen to return false, so every assertion still passed; the
+// test was green and the datum was fiction. An identifier shortened for display and then re-consumed
+// as input is its own defect class, and a constant that documents a production row must be the
+// whole row.
+const REAL_WATCHER_ROWS = ['__watcher_self__', '__eva_scheduler_watcher_self__'];
+
+// Also live, also real: keys that merely SOUND test-shaped. A name is a claim, not evidence.
+const REAL_BUT_TEST_SOUNDING = [
+  'gha_cron:venture-fixture-sweep.yml',
+  'standard_loop:account-usage-sample',
+  'cron_script:account-usage-sample.mjs',
+];
+
+// Real fixture keys observed in the leak, one per test in creation order.
+const ACTUAL_LEAKED_FIXTURES = [
+  '__e2e_periodic_liveness_silenced_1752349227697__',
+  '__e2e_periodic_liveness_recovers_then_relapses_1752349227697__',
+  '__e2e_periodic_liveness_healthy_1752349227697__',
+  '__e2e_periodic_liveness_stood_down_1752349227697__',
+  '__e2e_periodic_liveness_owner_first_1752349227697__',
+  '__e2e_periodic_liveness_ladder_pre_migration_1752349227697__',
+];
+
+describe('QF-20260807-190 — reaper predicate', () => {
+  it('reaps every shape of fixture residue actually observed in the leak', () => {
+    for (const key of ACTUAL_LEAKED_FIXTURES) {
+      expect(isReapable(key), `${key} is fixture residue and must be reapable`).toBe(true);
+    }
+    // The unregistered-stamp fixture from the same suite uses a different infix.
+    expect(isReapable('__e2e_unregistered_1752349227697__')).toBe(true);
+  });
+
+  it('NEVER reaps the watcher self-markers — the load-bearing control', () => {
+    for (const key of REAL_WATCHER_ROWS) {
+      expect(isReapable(key), `${key} is a REAL watcher marker and must survive`).toBe(false);
+    }
+  });
+
+  it('a bare __ prefix would kill them, which is why the predicate is __e2e_', () => {
+    // The counter-test, stated as a live comparison rather than as prose. If someone later
+    // "simplifies" the predicate to /^__/, this is the assertion that explains what breaks.
+    const naive = (k) => typeof k === 'string' && k.startsWith('__');
+    for (const key of REAL_WATCHER_ROWS) {
+      expect(naive(key)).toBe(true);        // the naive predicate DOES match them
+      expect(isReapable(key)).toBe(false);  // ours does not
+    }
+    expect(E2E_FIXTURE_PREFIX).toBe('__e2e_');
+  });
+
+  it('NEVER reaps real processes whose names merely sound test-shaped', () => {
+    for (const key of REAL_BUT_TEST_SOUNDING) {
+      expect(isReapable(key), `${key} reads test-ish but is real`).toBe(false);
+    }
+  });
+
+  it('reaps on PROVENANCE only — a fixture-looking key elsewhere in the name is not enough', () => {
+    // The prefix must LEAD. A real key that merely contains the marker later is not residue.
+    expect(isReapable('gha_cron:not__e2e_periodic_liveness_thing.yml')).toBe(false);
+    expect(isReapable('standard_loop:__e2e_lookalike')).toBe(false);
+  });
+
+  it('is total on junk input rather than throwing into a delete path', () => {
+    for (const bad of [null, undefined, 42, {}, [], '']) {
+      expect(isReapable(bad)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
**Measured 2026-08-07T16:51Z:** 53 rows keyed `__e2e_periodic_liveness_*` had leaked into the **production** registry and were **49 of the 64 OVERDUE rows — 77% of every alarm on the fleet-health panel**, against 15 real ones. All carry `expected_interval_seconds=5`, so they alarm within seconds and never stop; max `consecutive_miss_count` 953; created 2026-07-12 to 07-20.

Not cosmetic. That panel is what an operator scans to decide whether anything needs attention, and a permanent block of false OVERDUE trains the reader to skip the section — which is exactly where a genuinely dead process would appear. Sibling QF-20260727-131 removed the *recovery-lag* false alarms; this residue was the larger remaining contributor and is independent of it.

### Leak mechanism — confirmed, not assumed

The QF required confirming the hypothesis before fixing. The leak counts fall monotonically in fixture-**creation** order:

| # | fixture | leaked |
|---|---|---|
| 1 | silenced | 22 |
| 2 | recovers_then_relapses | 15 |
| 3 | healthy | 6 |
| 4 | stood_down | 4 |
| 5 | owner_first | 3 |
| 6 | ladder_pre_migration | 3 |

A silently-failing delete would leak all six **equally** — every run creates all six. Leaking fewer of the later ones is the signature of runs terminating part-way, so `afterAll` never executes. The distribution *discriminates* between the two candidate mechanisms; plausibility alone would not have.

### The predicate is the whole safety argument

`__e2e_` only, **never** a bare `__` prefix. Two real rows lead with `__` — `__watcher_self__` and `__eva_scheduler_watcher_self__` — each a watcher's own liveness marker. Reaping either **blinds the instrument this reaper exists to unblind.** The second was not in the original report and surfaced only by enumerating prefixes *from the data* rather than from the one noticed example. Mutation-proven: widening to `/^__/` turns the suite red.

Never match on name keywords either — three live rows contain test/fixture/sample and read as real processes. A name is a claim, not evidence.

### Dry-run is the default, and that isn't politeness

This deletes from a production table and **nothing here authorizes that**; `--apply` is for an operator who has obtained authorization separately. The dry run names the `__`-leading rows it is *deliberately keeping*, so the safety property is visible at run time rather than only in tests. Deletion goes by explicit key list already filtered in-process — a server-side `LIKE` would be a second, unreviewed copy of the predicate.

### Test-side leak fix

`afterAll` now also sweeps this run's whole `ts`-keyed prefix, so a run that reaches cleanup removes fixtures whose insert succeeded but whose key never reached the in-memory array — and the sweep's error is **surfaced**. The existing deletes ignore their errors entirely, which is how a cleanup fails on every run while its header still claims "zero residue". This cannot fix an aborted run (nothing in-process can), which is why the reaper exists for residue already in the table.

### Two self-inflicted defects found while building this

- My entry guard compared `import.meta.url` to a hand-built `file://` string and **never matched on Windows**. The script ran, printed nothing, exited 0 — a reaper whose `main()` never fires is indistinguishable from one that found nothing to reap, the exact class this QF is about. Now uses the canonical `isMainModule`. Caught only because the dry run's output was empty.
- A test constant named `__eva_scheduler_watcher_self` *without* its trailing underscores, copied from a survey that sliced keys to 28 chars for display. Both forms return false, so every assertion passed — green test, fiction datum. An identifier shortened for display and then re-consumed as input is its own defect class.

**101 tests green** across all 10 suites in the periodic-liveness area, selected by grep for what imports these sources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)