### PR TITLE
feat(SD-LEO-INFRA-OWNERSHIP-PRESERVATION-ASSERTION-001): schedule a dormant fence and give the p.*-refreeze drift class a detector

### DIFF
--- a/.github/workflows/divergence-fence-cron.yml
+++ b/.github/workflows/divergence-fence-cron.yml
@@ -51,12 +51,20 @@ jobs:
       # the right fix is having the secret, not relying on the report.
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      # SUPABASE_DB_URL IS FED FROM secrets.DATABASE_URL, AND THE MAPPING IS THE WHOLE POINT.
+      # The first version of this file injected SUPABASE_POOLER_URL — WHICH IS NOT A REPO SECRET
+      # (confirmed against the live secret list by two independent reviewers). It would have
+      # expanded EMPTY on every run, so `conn` was falsy, the script exited 2, and the seed step
+      # died before the fence ever ran: a daily red workflow whose parity check never executed.
+      # Meanwhile DATABASE_URL IS a real secret, WAS already injected here, and was read by
+      # nothing in the import graph. The script accepts SUPABASE_POOLER_URL || SUPABASE_DB_URL,
+      # so mapping the secret that exists onto the name the script reads is the entire fix.
+      #
+      # It passed locally because .env carries the pooler URL — a green hand-run says nothing
+      # about a runner's environment, and that is exactly the gap this cost.
+      SUPABASE_DB_URL: ${{ secrets.DATABASE_URL }}
+      # Kept so the workflow starts working the moment this secret is added, without another PR.
       SUPABASE_POOLER_URL: ${{ secrets.SUPABASE_POOLER_URL }}
-      DATABASE_URL: ${{ secrets.DATABASE_URL }}
-      # SD-FDBK-INFRA-RESTORE-STRICT-TLS-001: the pooler presents the Supabase Root 2021 CA,
-      # which is absent from the runner trust store. Trust that CA explicitly via the committed
-      # bundle rather than disabling verification.
-      NODE_EXTRA_CA_CERTS: ${{ github.workspace }}/certs/supabase-root-2021-ca.pem
 
     steps:
       - name: Checkout

--- a/.github/workflows/divergence-fence-cron.yml
+++ b/.github/workflows/divergence-fence-cron.yml
@@ -1,0 +1,82 @@
+name: "Divergence fence (cron)"
+
+# SD-LEO-INFRA-OWNERSHIP-PRESERVATION-ASSERTION-001 — the named dispatcher for
+# scripts/severity-pair-divergence-fence.mjs.
+#
+# THE FENCE EXISTED, WAS CORRECT, AND HAD NEVER RUN. Zero workflow references, zero npm
+# scripts, and zero rows in the live periodic_process_registry across 246 registered
+# processes — the registered-verifier-never-dispatched class. It even has a proven true
+# positive: its first genuine run caught a real FR-3 divergence against the production
+# catalog. An instrument nobody invokes is indistinguishable from an absent one, so this
+# file is the difference between a fence and a file that describes one.
+#
+# WHAT IT NOW CHECKS: the two original couplings PLUS view-vs-base-table column parity for
+# the p.*-refreeze drift class. Measured live 2026-08-07: v_patterns_with_decay was missing
+# SIX columns present on issue_patterns — including both its only consumer selects — so that
+# consumer raised 42703 every run and silently fell back to the base table, unnoticed for
+# months. That drift is what this schedule exists to notice next time.
+#
+# Static wiring pinned by tests/unit/cron/divergence-fence-wiring.test.js — renaming this
+# file or the script without updating ACTIVATION_TRIGGER fails CI.
+
+on:
+  schedule:
+    # Daily. Schema drift accrues on the timescale of migrations, not minutes, and the
+    # instrument's value is that it runs AT ALL rather than that it runs often.
+    - cron: '40 7 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  fence:
+    name: Live coupling + column-parity divergence check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    env:
+      # TWO CLIENTS, TWO CREDENTIAL SETS — and this is the one part of this workflow that
+      # could not be copied from a cron exemplar. The catalog reads use node-postgres
+      # (SUPABASE_POOLER_URL), while armed registration and the breakage alert use
+      # supabase-js (SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY). Omitting the pooler URL does
+      # not fail loudly by itself: an in-repo ruling at solomon-late-verdict-reconcile-cron.yml
+      # records that SUPABASE_POOLER_URL is injected into ZERO cron workflows here and is
+      # silently undefined on a runner. The fence now registers BEFORE that check can exit and
+      # emits an UNREADABLE alert, so a missing secret is reported rather than invisible — but
+      # the right fix is having the secret, not relying on the report.
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SUPABASE_POOLER_URL: ${{ secrets.SUPABASE_POOLER_URL }}
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+      # SD-FDBK-INFRA-RESTORE-STRICT-TLS-001: the pooler presents the Supabase Root 2021 CA,
+      # which is absent from the runner trust store. Trust that CA explicitly via the committed
+      # bundle rather than disabling verification.
+      NODE_EXTRA_CA_CERTS: ${{ github.workspace }}/certs/supabase-root-2021-ca.pem
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Prove the fence can FAIL before trusting that it passed
+        # A fence that has never failed is indistinguishable from a fence that CANNOT fail.
+        # The seeded run mutates one side of EVERY coupling in memory (nothing is written) and
+        # must exit non-zero; the script itself exits 3 with FENCE IS BROKEN if it passes.
+        # Running this FIRST means a green live run below is worth something.
+        run: node scripts/severity-pair-divergence-fence.mjs --seed-divergence || test $? -eq 1
+
+      - name: Run divergence fence
+        run: node scripts/severity-pair-divergence-fence.mjs

--- a/.prd-payloads/SD-LEO-INFRA-OWNERSHIP-PRESERVATION-ASSERTION-001.json
+++ b/.prd-payloads/SD-LEO-INFRA-OWNERSHIP-PRESERVATION-ASSERTION-001.json
@@ -1,0 +1,94 @@
+{
+  "executive_summary": "Give the p.*-refreeze column-drift class a STANDING detector, by extending an instrument that already exists and has never been invoked. THE JUSTIFICATION IS NOT AN ARGUMENT, IT IS A LIVE MEASUREMENT: v_patterns_with_decay is drifted RIGHT NOW — 30 view columns against 29 base columns, six base columns absent, INCLUDING both columns its only direct consumer selects. So context-builder.js:413 raises 42703 on every run, :421 catches any error whose message contains 'column', and it SILENTLY falls back to the base table. The defect is ACTIVE, not historical, and no instrument in the repo noticed. SCOPE NOTE: this SD's ORIGINAL deliverable — the three-piece ownership-preservation assertion — is ALREADY DELIVERED on main (PR #6727 / commit c6daedd1) and MUST NOT be rebuilt; see metadata.satisfied_elsewhere. This SD was rescoped by coordinator ruling, amended once on a measured correction.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Add a CLASS-WIDE view-vs-base-table column-parity comparator to lib/policy/severity-pair-coupling.js",
+      "description": "compareViewBaseParity({ viewCols, baseCols }) returning { verdict, viewCols, baseCols, missingFromView, detail }. PURELY ADDITIVE — the aggregator allCouplingsAgree(results):235 reads ONLY .verdict, so the new comparator slots beside compareSeverityPair:94 and compareCountVisibility:137 with NO aggregator change. TWO HARD RULES, both measured from the existing module: (a) it MUST ALWAYS return an object, never null — allCouplingsAgree returns FALSE for a non-array or empty list (:237, 'nothing measured is not success'), and a null element would be read as not-AGREES by accident rather than by design; (b) on an empty or unreadable column list it MUST return UNREADABLE, NEVER AGREES — UNREADABLE is explicitly not a pass (:20-22), and a parity check that reports agreement because it read nothing is the fail-open this whole family exists to abolish. CLASS-WIDE is the point: the catalog query is naturally class-wide across ~185 views, and that breadth is what earns the instrument a schedule. v_patterns_with_decay is the NAMED CASE, not the whole scope."
+    },
+    {
+      "id": "FR-2",
+      "title": "Extend scripts/severity-pair-divergence-fence.mjs to run the parity coupling — EXTEND, never rebuild",
+      "description": "Push the parity result into the results array at fence:115. THE EXTEND-VS-REBUILD DECISION WAS ADJUDICATED, not assumed: this fence is DORMANT on four independently-measured surfaces (zero workflow refs, zero npm scripts, ZERO ROWS in the live periodic_process_registry across 246 registered processes — a registry read, not a file grep — and its unit test never spawns the script). It is extended rather than replaced because it has a PROVEN TRUE POSITIVE (its first genuine non-seeded run caught a real FR-3 divergence against the production catalog, commit 8efe46502a3) and already encodes disciplines a rebuild would silently lose: UNREADABLE exits non-zero rather than passing, and the seeded self-test must FAIL or the fence self-reports BROKEN. Building a third instrument beside a working-but-unscheduled one is the single-representation violation this SD family exists to kill. The parity read fits the existing pg.Client and its try/finally naturally (pg_attribute/pg_class, same connection)."
+    },
+    {
+      "id": "FR-3",
+      "title": "--seed-divergence MUST gain a parity-specific mutation",
+      "description": "NOT optional, and the reason is a real blind spot rather than tidiness. The exit-3 BROKEN check asserts only that the AGGREGATE seeded run FAILS. The two existing seeds already make it fail, so a new comparator with no seed of its own would ride along permanently untested — a positive control that validates the mechanism while proving nothing about the pattern just added. The seed is an in-memory mutation of the parity side (drop a column from the view list), consistent with the existing seeds being pure in-memory string mutation, deliberately not a transaction and not DDL."
+    },
+    {
+      "id": "FR-4",
+      "title": "Register as armed machinery and WIRE IT TO A CONSUMER",
+      "description": "registerArmedMachinery(supabase, { sd_key }, { activationTrigger: '<the workflow path>', expectedIntervalSeconds }) plus a paired cron workflow and a tests/unit/cron/*-wiring.test.js proving the workflow actually invokes the script. ORDERING IS LOAD-BEARING AND IS THE OPPOSITE OF THE OBVIOUS ONE: register BEFORE stamping, because registerArmedMachinery upserts last_fired_at: null on insert — stamping first erases the stamp on every run and puts the staleness alarm permanently back into the stuck-on state. THE CONSUMER WIRE IS THE POINT OF THE WHOLE SD: emitBreakageAlert('schema-drift', '<detector-name>', {...}) — the 'schema-drift' break class ALREADY EXISTS (defaultSeverity critical, alertType system_health) so no new class is needed, and the emitter is fail-soft by construction so it can never corrupt the detector's exit code. A detector nobody reads is indistinguishable from an absent one; that is precisely the condition this fence has been in since it was written."
+    },
+    {
+      "id": "FR-5",
+      "title": "Hoist the context-builder select literal inline — ADJACENT action, NOT the scope boundary",
+      "description": "context-builder.js:411 holds its column list in a const named VIEW_SELECT and calls .select(VIEW_SELECT). The existing BLOCKING lint's extractor records only INLINE literal select lists, so it sees a table reference and zero column refs — measured by running the real extractor: as-committed 0 violations, hoisted inline 22 column refs and exactly 2 violations. The hoist is cheap and it trips TODAY. IT IS EXPLICITLY NOT THE SCOPE BOUNDARY (coordinator ruling AMENDED on this point): the hoist answers 'do the columns this consumer NAMES still exist?', while the detector answers 'does the view still expose everything the base table HAS?' Those are DISJOINT questions and the hoist subtracts NOTHING from FR-1..FR-4. FORBIDDEN BY NAME, because each is a tempting way to make the hoist PR green while re-blinding the lint: (a) adding the file or either relation to scripts/lint/schema-reference-allowlist.json; (b) a schema-lint-disable-line pragma; (c) dropping metadata/dedup_fingerprint from the select. THE CORRECT WAY TO GREEN IT is to apply the 20260801 migration and regenerate the snapshot."
+    },
+    {
+      "id": "FR-6",
+      "title": "State the live-drift measurement in the PR and the completion message",
+      "description": "The standing-detector case is evidenced, not argued, and the evidence must travel with the change: the view is drifted now, its only direct consumer degrades silently on every run, and nothing reported it. Recording that in the PR is what stops a later reader from reading this SD as speculative hardening."
+    }
+  ],
+  "technical_requirements": [
+    { "id": "TR-1", "title": "ZERO edits to the hash-bound migration", "description": "database/migrations/20260801_refresh_v_patterns_with_decay_column_drift.sql has sha256 32f28e1a9cf967366cb523b178f5363dd68e932fcb85c75a7803df347000b59a, byte-identical to the blob a chairman verbal is bound to — and that verbal is ALREADY IN FRONT OF THE CHAIRMAN. Editing the file moves the hash out from under a live ask for the second time and costs a re-bind. The detector reads catalogs at RUNTIME and never touches migration files, so this constraint costs the design nothing. Verified twice independently (by the builder and by VALIDATION)." },
+    { "id": "TR-2", "title": "UNREADABLE must never resolve to AGREES", "description": "A parity comparator that cannot read the catalog must say so. Reporting agreement from an empty read is a false green on the exact axis the instrument exists to guard, and it is indistinguishable from a healthy run on every surface downstream." },
+    { "id": "TR-3", "title": "Two clients, two credential sets — this is NEW WORK, not a copy", "description": "MEASURED COMPLICATION: the fence connects via node-postgres to SUPABASE_POOLER_URL/SUPABASE_DB_URL and imports no supabase-js at all. But every consumer wire runs on supabase-js — registerArmedMachinery, stampLastFired, and emitBreakageAlert's default client. So the extended script must hold BOTH, and its workflow env must carry the pg connection string IN ADDITION TO SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY. No existing cron exemplar demonstrates a pg connection string (chairman-decision-sla-cron.yml carries only the supabase pair), so that env block cannot be copied and must be written and verified." },
+    { "id": "TR-4", "title": "Exit code 1 conflates DIVERGED with UNREADABLE", "description": "Pre-existing in the fence and inherited by this extension: exit 1 covers both. A consumer that must distinguish them has to parse --json, which the fence already emits. Named here rather than silently inherited, so a later reader does not mistake exit 1 for 'drift found'." }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "POSITIVE CONTROL — a genuinely drifted view is DETECTED", "type": "unit", "expected": "compareViewBaseParity with baseCols containing a column absent from viewCols returns DIVERGED and names the missing column in missingFromView. Seeded from the REAL measured case: six columns absent from v_patterns_with_decay." },
+    { "id": "TS-2", "scenario": "SEEDED — an unreadable catalog returns UNREADABLE, never AGREES", "type": "unit", "expected": "Empty or null viewCols/baseCols yields UNREADABLE. An implementation that returns AGREES here passes every other scenario while reporting a healthy belt it never read — the fail-open this SD exists to prevent." },
+    { "id": "TS-3", "scenario": "SEEDED — the comparator never returns null", "type": "unit", "expected": "Every input shape returns an object with a .verdict. A null return would be read by allCouplingsAgree as not-AGREES by accident, which happens to be safe today and is not a contract." },
+    { "id": "TS-4", "scenario": "NEGATIVE CONTROL — a view at parity does NOT fire", "type": "unit", "expected": "viewCols a superset of baseCols returns AGREES. Without this, a comparator that returned DIVERGED unconditionally would satisfy TS-1 and TS-2 and alarm on all ~185 views forever." },
+    { "id": "TS-5", "scenario": "--seed-divergence makes the PARITY coupling fail specifically", "type": "integration", "expected": "With the parity seed applied and the OTHER couplings forced to agree, the fence still trips. Asserting only the aggregate seeded failure would pass on the pre-existing seeds alone and prove nothing about the comparator this SD adds (FR-3)." },
+    { "id": "TS-6", "scenario": "WIRING — the workflow actually invokes the script and ACTIVATION_TRIGGER equals the workflow path", "type": "unit", "expected": "Static fs assertions, no DB or network. Armed logic with no dispatcher is indistinguishable from logic that always passes, and the failure is silent because absence has no error message." },
+    { "id": "TS-7", "scenario": "Registration precedes stamping", "type": "unit", "expected": "register is called before stamp. Reversed, registerArmedMachinery's last_fired_at: null erases the stamp every run and re-arms the staleness alarm permanently, while every individual piece still looks correct." },
+    { "id": "TS-8", "scenario": "The hoisted select trips the EXISTING blocking lint", "type": "integration", "expected": "Running the real extractor over the hoisted context-builder yields the 2 violations. And the three forbidden escapes are absent: no allowlist entry for the file or either relation, no disable pragma, and both columns still present in the select." }
+  ],
+  "acceptance_criteria": [
+    "compareViewBaseParity exists, is class-wide, and returns UNREADABLE (never AGREES, never null) when it cannot read.",
+    "The fence runs the parity coupling; the aggregator is UNCHANGED.",
+    "--seed-divergence mutates the parity side, and a test proves the parity coupling fails on its own seed rather than riding the existing ones.",
+    "The detector is registered in periodic_process_registry, paired with a cron workflow and a wiring test, and register precedes stamp.",
+    "The detector emits to a CONSUMER via the existing 'schema-drift' break class — the dormancy that made the substrate worth extending is closed by the extension.",
+    "The context-builder literal is hoisted inline and none of the three named re-blinding escapes appears in the diff.",
+    "database/migrations/20260801_refresh_v_patterns_with_decay_column_drift.sql has ZERO diff lines; its sha256 still reads 32f28e1a…",
+    "The PR and completion message state the live-drift measurement as the detector's justification."
+  ],
+  "risks": [
+    { "risk": "The parity comparator reports AGREES when it could not read the catalog.", "mitigation": "TR-2 + TS-2. This is the highest-value failure to seed because it makes every run look healthy and is invisible on every downstream surface." },
+    { "risk": "A third instrument gets built beside the dormant fence because extending an unfamiliar file is harder than starting fresh.", "mitigation": "FR-2 records the adjudication and its evidence: four measured dormancy surfaces plus a proven true positive. The dormancy is the thing being fixed, not a reason to abandon the substrate." },
+    { "risk": "The hoist is read as the scope boundary and FR-1..FR-4 get trimmed as 'residual'.", "mitigation": "FR-5 states the disjointness explicitly and the coordinator ruling was AMENDED on this exact point after the 2-of-6 coverage measurement. A PRD written on the residual framing under-scopes by the whole defect class." },
+    { "risk": "The hoist PR is greened by silencing the lint rather than fixing the drift.", "mitigation": "FR-5 forbids the three escapes BY NAME and states the correct remedy. Naming them matters because each is individually reasonable-looking." },
+    { "risk": "The migration file is edited to 'also fix the drift', invalidating a live chairman verbal.", "mitigation": "TR-1, plus a zero-diff acceptance criterion on that path." },
+    { "risk": "The workflow ships without the pg connection string and the detector fails on every tick.", "mitigation": "TR-3 names it as new work rather than a copy, because no existing cron exemplar carries that env." }
+  ],
+  "integration_operationalization": {
+    "consumers": "system_alerts via emitBreakageAlert('schema-drift', …) — the operator-facing surface. Downstream: anyone asking 'has any view drifted from its base table', which is unanswerable today. Also SD-FDBK-ENH-LEARNING-LOOP-DESTROYS-001, whose FR-5 migration repairs the one instance this detector would have caught six months earlier.",
+    "dependencies": "lib/policy/severity-pair-coupling.js (additive); scripts/severity-pair-divergence-fence.mjs (substrate); lib/machinery-class/armed-registration.js; lib/breakage/emit-breakage-alert.cjs; lib/coordinator/break-class-taxonomy.cjs ('schema-drift' exists); pg via SUPABASE_POOLER_URL/SUPABASE_DB_URL AND supabase-js via SUPABASE_URL/SUPABASE_SERVICE_ROLE_KEY.",
+    "data_contracts": "No schema changes. Reads pg_attribute/pg_class at runtime. Writes only a periodic_process_registry row and system_alerts rows through existing writers.",
+    "runtime_config": "One new cron workflow. Its env block is NOT copyable from an existing exemplar (TR-3).",
+    "observability_rollout": "Before: the class is undetected and a live instance is drifting unnoticed. After: one scheduled check across ~185 views emitting to system_alerts. The fence's own four-surface dormancy is closed as a side effect — the never-invoked instrument dies with its extension."
+  },
+  "system_architecture": {
+    "objects_touched": "MODIFIED: lib/policy/severity-pair-coupling.js (+1 comparator), scripts/severity-pair-divergence-fence.mjs (run it, seed it, register, stamp, emit), scripts/modules/learning/context-builder.js (hoist one literal). NEW: a cron workflow + a wiring test + comparator tests. UNCHANGED, with a zero-diff criterion: database/migrations/20260801_refresh_v_patterns_with_decay_column_drift.sql.",
+    "invariant": "A parity verdict is reported only when the catalog was actually read. Unreadable is reported as unreadable, never as agreement — the reading and its provenance live or die together.",
+    "coupling_map": "pg catalog (pg_attribute/pg_class) -> compareViewBaseParity -> allCouplingsAgree (UNCHANGED) -> fence exit code -> emitBreakageAlert('schema-drift') -> system_alerts. Schedule: cron workflow -> registerArmedMachinery -> periodic_process_registry -> liveness watcher."
+  },
+  "implementation_approach": {
+    "sequence": "TR-1 first as a standing constraint, not a step. Then FR-1 (pure, testable without a database), then FR-3's seed alongside it so the comparator is never momentarily unfalsifiable, then FR-2 wiring into the fence, then FR-4 registration + consumer, then FR-5 the hoist last since it is adjacent and independent.",
+    "verification_discipline": "Seed the two failures that would make this look finished while being wrong: UNREADABLE resolving to AGREES, and a parity seed that never fires because the aggregate was already failing on the pre-existing seeds. Keep TS-4 as the negative control — a comparator that fired unconditionally would satisfy every positive scenario while alarming on 185 views forever.",
+    "out_of_scope": "The ownership-preservation assertion (ALREADY DELIVERED — metadata.satisfied_elsewhere). Applying the 20260801 migration (chairman-gated). TWO SEPARATE DEFECTS found in the existing blocking lint while validating the hoist, both real and neither this SD: (a) filter-clause blindness — the extractor parses columns only inside select/insert/update/upsert, so .order() and .eq() column references are invisible; (b) substring membership — findViolations calls String.includes() against array-literal strings, so a missing column whose name is a substring of a survivor is invisible forever. Both are blind spots inside a BLOCKING gate and deserve their own item."
+  },
+  "metadata": {
+    "rescoped": true,
+    "original_deliverable_already_shipped": "PR #6727 / commit c6daedd1",
+    "coordinator_ruling_amended": "detector justified on the CLASS, not on the hoist residual",
+    "live_drift_measured": "view 30 cols vs base 29; six absent incl. both the consumer selects; consumer 42703s and silently falls back",
+    "hash_bound_file_zero_diff": true,
+    "evidence_rows": "VALIDATION 0da50ff6-ec2b-4526-b913-19d3937d6fdf; Explore 3e457a67-cc37-4d8d-82be-472f71ee8363"
+  }
+}

--- a/lib/policy/severity-pair-coupling.js
+++ b/lib/policy/severity-pair-coupling.js
@@ -237,3 +237,117 @@ export function allCouplingsAgree(results) {
   if (list.length === 0) return false; // nothing measured is not success
   return list.every((r) => r && r.verdict === AGREES);
 }
+
+/**
+ * VIEW-vs-BASE-TABLE COLUMN PARITY — SD-LEO-INFRA-OWNERSHIP-PRESERVATION-ASSERTION-001.
+ *
+ * THE DEFECT CLASS: a view defined with `p.*` has its column list EXPANDED AND FROZEN at
+ * CREATE. The base table then gains a column and the view does not. Nothing errors, nothing
+ * alarms, and the view quietly stops exposing what its own definition claims to.
+ *
+ * THIS IS NOT HYPOTHETICAL AND IT IS NOT HISTORICAL. Measured live on 2026-08-07:
+ * v_patterns_with_decay serves 30 columns against issue_patterns' 29, with SIX base columns
+ * absent (metadata, dedup_fingerprint, data_quality_status, content_embedding,
+ * embedding_updated_at, auto_block_on_match) — including BOTH columns its only direct
+ * consumer selects. So scripts/modules/learning/context-builder.js raises 42703 on every
+ * run and silently falls back to the base table. The drift is active right now, and no
+ * instrument in this repo noticed it for months.
+ *
+ * ── WHY THIS LIVES BESIDE THE SEVERITY-PAIR COMPARATORS RATHER THAN IN A NEW SCRIPT ────────
+ * The fence that runs these comparators was fully built, correct, and NEVER INVOKED — zero
+ * workflow references, zero npm scripts, and zero rows in the live periodic_process_registry
+ * across 246 registered processes. A new detector beside it would have made two instruments
+ * for one question and left the working one dormant. Extending it means the wire that gives
+ * this comparator a schedule also ends the fence's own dormancy: the never-invoked instrument
+ * dies with its extension.
+ *
+ * ── ASYMMETRY IS THE WHOLE POINT: THIS IS NOT A SET-EQUALITY CHECK ─────────────────────────
+ * A view LEGITIMATELY carries columns the base table does not — v_patterns_with_decay computes
+ * seven (recency_status, days_since_update, decay_adjusted_confidence, …). Comparing the sets
+ * for equality would report a permanent false DIVERGENCE on every correctly-coupled view in
+ * the database. The invariant is ONE-DIRECTIONAL: every BASE column must appear in the VIEW.
+ * Extra view columns are computed output and are not drift.
+ *
+ * ── EMPTY IS UNREADABLE, NEVER AGREES, AND [] IS THE TRAP ──────────────────────────────────
+ * The natural guard `if (!viewCols || !baseCols)` LETS AN EMPTY ARRAY THROUGH, because `[]` is
+ * truthy. Empty-vs-empty then compares equal and a naive "every base column is in the view"
+ * returns AGREES — a parity check reporting agreement about a catalog it never read. That is
+ * the exact fail-open this module's design rule forbids, and it is the shape a silently-empty
+ * catalog query actually takes. Length is checked, not just presence.
+ *
+ * @param {object} o
+ * @param {string[]} o.viewCols   column names the view exposes
+ * @param {string[]} o.baseCols   column names the base table has
+ * @param {string} [o.viewName]   for the detail message only
+ * @param {string} [o.baseName]   for the detail message only
+ * @returns {{verdict: string, viewCols: string[]|null, baseCols: string[]|null, missingFromView: string[], detail: string}}
+ */
+export function compareViewBaseParity({ viewCols, baseCols, viewName = 'the view', baseName = 'the base table' } = {}) {
+  const readable = (v) => Array.isArray(v) && v.length > 0;
+
+  // ALWAYS returns an object — never null. allCouplingsAgree reads `r && r.verdict`, so a null
+  // element would be counted as not-AGREES BY ACCIDENT rather than by decision. Safe today,
+  // and not a contract; a later refactor of the aggregator would silently change what it means.
+  if (!readable(viewCols) || !readable(baseCols)) {
+    return {
+      verdict: UNREADABLE,
+      viewCols: Array.isArray(viewCols) ? viewCols : null,
+      baseCols: Array.isArray(baseCols) ? baseCols : null,
+      missingFromView: [],
+      detail:
+        'Could not read a column list for '
+        + [!readable(viewCols) && viewName, !readable(baseCols) && baseName].filter(Boolean).join(' and ')
+        + '. UNREADABLE is not a pass: an empty catalog read and a view at parity are the same '
+        + 'answer to a check that only asks whether anything is missing.',
+    };
+  }
+
+  const view = new Set(viewCols.map((c) => String(c).toLowerCase()));
+  const missingFromView = baseCols.filter((c) => !view.has(String(c).toLowerCase()));
+
+  if (missingFromView.length > 0) {
+    return {
+      verdict: DIVERGED,
+      viewCols,
+      baseCols,
+      missingFromView,
+      detail:
+        `DIVERGENCE: ${viewName} is missing ${missingFromView.length} column(s) present on `
+        + `${baseName}: ${missingFromView.join(', ')}. A p.* view freezes its column list at CREATE, `
+        + 'so the base table gained these and the view did not. Any consumer selecting them gets '
+        + '42703 — and a consumer that catches that error degrades silently.',
+    };
+  }
+
+  return {
+    verdict: AGREES,
+    viewCols,
+    baseCols,
+    missingFromView: [],
+    detail:
+      `${viewName} exposes every column on ${baseName} (${baseCols.length} base column(s) covered by `
+      + `${viewCols.length} view column(s)). Extra view columns are computed output, not drift.`,
+  };
+}
+
+/**
+ * The parity half of --seed-divergence. SD-LEO-INFRA-OWNERSHIP-PRESERVATION-ASSERTION-001, FR-3.
+ *
+ * EXPORTED AND PURE ON PURPOSE. The fence's exit-3 BROKEN check asserts only that the AGGREGATE
+ * seeded run FAILS — and the two pre-existing seeds already make it fail. A parity comparator with
+ * no seed of its own would therefore ride along PERMANENTLY UNTESTED behind a control that passes
+ * for reasons unrelated to it: a positive control that validates the mechanism while proving
+ * nothing about the pattern just added.
+ *
+ * Pure and exported rather than an inline mutation inside main() because the fence has no
+ * injection seam — argv is parsed at module scope, main() runs at import, and every terminus calls
+ * process.exit(), so the seeded path cannot be imported and asserted. This shape lets a unit test
+ * prove the parity coupling fails ON ITS OWN SEED without a database and without refactoring main().
+ *
+ * @param {string[]} viewCols
+ * @returns {string[]} the view's columns with one dropped, so parity must report DIVERGED
+ */
+export function seedParityDivergence(viewCols) {
+  if (!Array.isArray(viewCols) || viewCols.length === 0) return [];
+  return viewCols.slice(1);
+}

--- a/scripts/severity-pair-divergence-fence.mjs
+++ b/scripts/severity-pair-divergence-fence.mjs
@@ -44,6 +44,7 @@
  */
 import 'dotenv/config';
 import pg from 'pg';
+import { pathToFileURL } from 'node:url';
 import {
   compareSeverityPair,
   compareCountVisibility,
@@ -53,7 +54,7 @@ import {
   AGREES,
   UNREADABLE,
 } from '../lib/policy/severity-pair-coupling.js';
-import { registerArmedMachinery } from '../lib/machinery-class/armed-registration.js';
+import { registerArmedMachinery, armedProcessKey } from '../lib/machinery-class/armed-registration.js';
 import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 
 const VIEW_NAME = 'chairman_all_decision_signals';
@@ -173,20 +174,45 @@ async function ensureArmedRegistration() {
  * only asserts "the fence still exits 1" would pass with the alert permanently broken. The
  * 'schema-drift' break class already exists (critical / system_health); no new class is minted.
  */
-async function emitDriftAlert(divergedResults, deps = {}) {
+export async function emitDriftAlert(divergedResults, deps = {}, sourceService = 'divergence-fence') {
   if (!divergedResults.length) return { ok: true, skipped: 'no_divergence' };
   try {
     const { emitBreakageAlert } = deps.emitBreakageAlert
       ? { emitBreakageAlert: deps.emitBreakageAlert }
       : await import('../lib/breakage/emit-breakage-alert.cjs');
     const detail = divergedResults.map((r) => r.detail).join(' | ');
-    return await emitBreakageAlert('schema-drift', 'divergence-fence', {
+    return await emitBreakageAlert('schema-drift', sourceService, {
       title: `Divergence fence tripped: ${divergedResults.length} coupling(s)`,
       message: detail,
       metadata: { sd_key: SD_KEY, couplings: divergedResults.length },
     });
   } catch (e) {
     console.warn(`alert: emit threw (${e.message}) — continuing`);
+    return { ok: false, error: e.message };
+  }
+}
+
+/**
+ * Stamp last_fired_at on a HEALTHY completed run.
+ *
+ * WITHOUT THIS THE FIX ABOVE INVERTS INTO A PERMANENT FALSE ALARM, which is the whole reason it
+ * is here. Registering-before-the-credential-check gives the staleness watcher a row to read —
+ * but a row that is never stamped reads as armed-and-never-produced FOREVER, no matter how many
+ * healthy runs happen. So the moment the credentials are fixed, a true positive would become a
+ * permanent false one, and an alarm that cannot clear is an alarm everyone learns to ignore.
+ * Registration and stamping had to land in the same change; shipping either alone is worse than
+ * shipping neither.
+ *
+ * Stamped ONLY on a clean run: a tripped or unreadable fence has not successfully produced.
+ */
+async function stampIfHealthy(ok) {
+  if (!ok) return { ok: false, skipped: 'not_healthy' };
+  try {
+    const { stampLastFired } = await import('../lib/periodic-liveness/stamp-last-fired.js');
+    const supabase = createSupabaseServiceClient();
+    return await stampLastFired(supabase, armedProcessKey(SD_KEY));
+  } catch (e) {
+    console.warn(`registry: stamp threw (${e.message}) — continuing`);
     return { ok: false, error: e.message };
   }
 }
@@ -200,7 +226,18 @@ async function main() {
     console.error('UNREADABLE: no SUPABASE_POOLER_URL / SUPABASE_DB_URL in env — cannot read the catalog.');
     // Tell a consumer rather than dying quietly. Unmeasurable is a reportable state, not a pass
     // and not a silence — and this is the branch a GHA runner without the secret actually takes.
-    await emitDriftAlert([{ detail: 'UNREADABLE: the divergence fence has no pooler credentials on this runner, so no coupling was measured. An unmeasured fence is not a passing fence.' }]);
+    //
+    // A DISTINCT source_service, AND THAT IS NOT COSMETIC. recordSystemAlert dedups on
+    // (source_service, break_class, resolved_at IS NULL). A tripped-fence alert from an earlier
+    // run sits open almost by definition — the drift it reports is exactly what nobody has fixed
+    // yet — so sharing a source_service would let that open row SWALLOW this one, and the alert
+    // built to cure the dead-and-invisible mode would itself be invisible. The obvious fix for a
+    // silent failure is easy to make silent in the same way.
+    await emitDriftAlert(
+      [{ detail: 'UNREADABLE: the divergence fence has no catalog credentials on this runner (SUPABASE_POOLER_URL / SUPABASE_DB_URL both unset), so NO coupling was measured. An unmeasured fence is not a passing fence.' }],
+      {},
+      'divergence-fence-unreadable',
+    );
     process.exit(2);
   }
 
@@ -289,6 +326,9 @@ async function main() {
   if (!ok && !SEED) {
     await emitDriftAlert(results.filter((r) => r.verdict !== AGREES));
   }
+  // Stamp only a clean, non-seeded run. See stampIfHealthy: without this the registry row never
+  // ages out of armed-never-produced and the watcher alarms forever on a healthy fence.
+  if (!SEED) await stampIfHealthy(ok);
 
   if (SEED && ok) {
     // The seeded run MUST fail. If it passed, the fence cannot detect divergence and
@@ -303,7 +343,24 @@ function fmt(pair) {
   return Array.isArray(pair) ? `[${pair.join(', ')}]` : '(unreadable)';
 }
 
-main().catch((err) => {
-  console.error(`UNREADABLE: ${err.message}`);
-  process.exit(2);
-});
+/**
+ * ENTRYPOINT GUARD — SD-LEO-INFRA-OWNERSHIP-PRESERVATION-ASSERTION-001.
+ *
+ * main() used to run UNCONDITIONALLY at import, and every terminus calls process.exit(). That made
+ * the module physically unimportable: any test that touched it would open a database connection
+ * and then kill the test runner. So EVERY assertion about this file had to be a regex over its
+ * source text, and anything invisible in the text was invisible to the suite — measured, five
+ * separate mutations to this script stayed GREEN across the entire 36,000-test unit project.
+ *
+ * The guard is the shape scripts/cron/payment-attribution-sweep.mjs already uses. It changes
+ * nothing about how the CLI behaves and makes the exported seams (emitDriftAlert's deps parameter,
+ * in particular) actually reachable by a test — which is what lets the consumer wire be asserted
+ * two-sided instead of trusted because one live row appeared once.
+ */
+const isMain = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isMain) {
+  main().catch((err) => {
+    console.error(`UNREADABLE: ${err.message}`);
+    process.exit(2);
+  });
+}

--- a/scripts/severity-pair-divergence-fence.mjs
+++ b/scripts/severity-pair-divergence-fence.mjs
@@ -18,24 +18,63 @@
  * mutation is strictly safer and exactly as probative: it exercises the same comparison
  * code against a pair that differs.
  *
+ * ── EXTENDED BY SD-LEO-INFRA-OWNERSHIP-PRESERVATION-ASSERTION-001 ─────────────────────────
+ * A THIRD coupling: view-vs-base-table COLUMN PARITY, for the p.*-refreeze drift class.
+ * A view defined with `p.*` freezes its column list at CREATE; the base table later gains a
+ * column and the view does not. Measured live 2026-08-07: v_patterns_with_decay was missing SIX
+ * columns present on issue_patterns, including both its only consumer selects — so that consumer
+ * raised 42703 on every run and silently fell back to the base table, for months, unnoticed.
+ *
+ * THIS FENCE WAS THE RIGHT SUBSTRATE PRECISELY BECAUSE IT WAS DORMANT. It was fully built,
+ * correct, and NEVER INVOKED — zero workflow references, zero npm scripts, and zero rows in the
+ * live periodic_process_registry across 246 registered processes. Building a second detector
+ * beside it would have left the working one dark. Extending it means the schedule and the
+ * consumer wire that give column-parity a home also end this fence's own dormancy.
+ *
  * Usage:
- *   node scripts/check-severity-pair-divergence.mjs
- *   node scripts/check-severity-pair-divergence.mjs --seed-divergence
- *   node scripts/check-severity-pair-divergence.mjs --json
+ *   node scripts/severity-pair-divergence-fence.mjs
+ *   node scripts/severity-pair-divergence-fence.mjs --seed-divergence
+ *   node scripts/severity-pair-divergence-fence.mjs --json
+ *
+ * (The usage block previously named scripts/check-severity-pair-divergence.mjs, a file that has
+ * never existed. NOT RENAMING THE SCRIPT: a rename would invalidate the wiring test's path
+ * literals, ACTIVATION_TRIGGER and the registry row for no functional gain. Fixing the pointer
+ * instead is the cheap half of that choice, and leaving a docstring that names a nonexistent
+ * file is how the next reader concludes the instrument does not exist.)
  */
 import 'dotenv/config';
 import pg from 'pg';
 import {
   compareSeverityPair,
   compareCountVisibility,
+  compareViewBaseParity,
+  seedParityDivergence,
   allCouplingsAgree,
   AGREES,
   UNREADABLE,
 } from '../lib/policy/severity-pair-coupling.js';
+import { registerArmedMachinery } from '../lib/machinery-class/armed-registration.js';
+import { createSupabaseServiceClient } from '../lib/supabase-client.js';
 
 const VIEW_NAME = 'chairman_all_decision_signals';
 const INGRESS_POLICY = 'anon_feedback_ingress_bounds';
 const ANON_SELECT_POLICY = 'telegram_bot_select_feedback';
+
+/** SD-LEO-INFRA-OWNERSHIP-PRESERVATION-ASSERTION-001 — armed-machinery identity. */
+export const SD_KEY = 'SD-LEO-INFRA-OWNERSHIP-PRESERVATION-ASSERTION-001';
+export const ACTIVATION_TRIGGER = '.github/workflows/divergence-fence-cron.yml';
+export const EXPECTED_INTERVAL_SECONDS = 24 * 60 * 60;
+
+/**
+ * The view/base pairs checked for column parity.
+ *
+ * DATA-DRIVEN ON PURPOSE — the catalog query is naturally class-wide, and a comparator hard-wired
+ * to one view could never earn a schedule. v_patterns_with_decay is the NAMED CASE (it is the one
+ * measured drifting), not the scope. Adding a pair here is the whole cost of covering another view.
+ */
+export const PARITY_PAIRS = Object.freeze([
+  { view: 'v_patterns_with_decay', base: 'issue_patterns' },
+]);
 
 const argv = process.argv.slice(2);
 const SEED = argv.includes('--seed-divergence');
@@ -68,10 +107,100 @@ function extractLimitPredicate(policyExpr) {
   return { literal: st ? st[0] : null, correlatedColumn: null };
 }
 
+/**
+ * Live column list for one relation, from the catalog.
+ *
+ * attnum > 0 excludes system columns (ctid, xmin, …) and NOT attisdropped excludes columns
+ * dropped-but-not-vacuumed. Omitting either would make EVERY view look drifted — a class-wide
+ * false positive that a hand-fed unit test cannot catch, because the query is the part under test.
+ * relkind is left open so the SAME function reads a view ('v') and a table ('r').
+ */
+async function readColumns(client, relname) {
+  const { rows } = await client.query(
+    `select a.attname
+       from pg_attribute a
+       join pg_class c on c.oid = a.attrelid
+       join pg_namespace n on n.oid = c.relnamespace
+      where n.nspname = 'public' and c.relname = $1
+        and a.attnum > 0 and not a.attisdropped
+      order by a.attnum`,
+    [relname],
+  );
+  return rows.map((r) => r.attname);
+}
+
+/**
+ * Register this fence as armed machinery. FAIL-SOFT and DELIBERATELY CALLED FIRST.
+ *
+ * ── WHY BEFORE THE CREDENTIAL CHECK, WHICH IS THE OPPOSITE OF THE OBVIOUS ORDER ────────────
+ * main() used to exit(2) on a missing pooler URL as its very first act — before connecting,
+ * before every comparator, before registration and before any alert. So on a runner without that
+ * secret the fence emitted NOTHING and wrote NO REGISTRY ROW, which means the staleness watcher
+ * had no row to find and could not report it overdue. Dead and invisible, identical to never
+ * having been scheduled.
+ *
+ * That is not hypothetical: .github/workflows/solomon-late-verdict-reconcile-cron.yml:38-40
+ * carries an in-repo ruling that SUPABASE_POOLER_URL is injected into ZERO cron workflows in this
+ * repo and is silently undefined on a GHA runner. Registering first means a fence that cannot read
+ * its catalog still leaves a row that ages, so the watcher can say so.
+ *
+ * Uses supabase-js while the catalog read uses node-postgres — two clients, two credential sets,
+ * both required in the workflow env. Stated because it is the one thing about this script that
+ * cannot be copied from a cron exemplar.
+ */
+async function ensureArmedRegistration() {
+  try {
+    const supabase = createSupabaseServiceClient();
+    const r = await registerArmedMachinery(supabase, { sd_key: SD_KEY }, {
+      activationTrigger: ACTIVATION_TRIGGER,
+      expectedIntervalSeconds: EXPECTED_INTERVAL_SECONDS,
+    });
+    if (r && r.ok === false) console.warn(`registry: registration failed (${r.error}) — continuing; the measurement matters more than its bookkeeping`);
+    return r;
+  } catch (e) {
+    // Never let bookkeeping break the fence. A registration failure must not convert a readable
+    // catalog into an unreadable verdict.
+    console.warn(`registry: registration threw (${e.message}) — continuing`);
+    return { ok: false, error: e.message };
+  }
+}
+
+/**
+ * Tell a consumer. FAIL-SOFT BY CONTRACT, which is exactly why its test must be two-sided.
+ *
+ * emitBreakageAlert swallows every error and returns {ok:false}, so a wire that throws on every
+ * call is INVISIBLE in the exit code — the only thing any other check here inspects. A test that
+ * only asserts "the fence still exits 1" would pass with the alert permanently broken. The
+ * 'schema-drift' break class already exists (critical / system_health); no new class is minted.
+ */
+async function emitDriftAlert(divergedResults, deps = {}) {
+  if (!divergedResults.length) return { ok: true, skipped: 'no_divergence' };
+  try {
+    const { emitBreakageAlert } = deps.emitBreakageAlert
+      ? { emitBreakageAlert: deps.emitBreakageAlert }
+      : await import('../lib/breakage/emit-breakage-alert.cjs');
+    const detail = divergedResults.map((r) => r.detail).join(' | ');
+    return await emitBreakageAlert('schema-drift', 'divergence-fence', {
+      title: `Divergence fence tripped: ${divergedResults.length} coupling(s)`,
+      message: detail,
+      metadata: { sd_key: SD_KEY, couplings: divergedResults.length },
+    });
+  } catch (e) {
+    console.warn(`alert: emit threw (${e.message}) — continuing`);
+    return { ok: false, error: e.message };
+  }
+}
+
 async function main() {
+  // FIRST, before anything that can exit. See ensureArmedRegistration's header.
+  await ensureArmedRegistration();
+
   const conn = process.env.SUPABASE_POOLER_URL || process.env.SUPABASE_DB_URL;
   if (!conn) {
     console.error('UNREADABLE: no SUPABASE_POOLER_URL / SUPABASE_DB_URL in env — cannot read the catalog.');
+    // Tell a consumer rather than dying quietly. Unmeasurable is a reportable state, not a pass
+    // and not a silence — and this is the branch a GHA runner without the secret actually takes.
+    await emitDriftAlert([{ detail: 'UNREADABLE: the divergence fence has no pooler credentials on this runner, so no coupling was measured. An unmeasured fence is not a passing fence.' }]);
     process.exit(2);
   }
 
@@ -81,6 +210,7 @@ async function main() {
   let viewExpr = null;
   let ingressExpr = null;
   let anonSelectExpr = null;
+  const parityInputs = [];
   try {
     const v = await client.query('select definition from pg_views where schemaname = $1 and viewname = $2', ['public', VIEW_NAME]);
     viewExpr = v.rows[0]?.definition ?? null;
@@ -98,6 +228,15 @@ async function main() {
       if (row.polname === INGRESS_POLICY) ingressExpr = row.check_expr;
       if (row.polname === ANON_SELECT_POLICY) anonSelectExpr = row.using_expr;
     }
+
+    // Column parity, one catalog read per side per pair. Same connection, same try/finally.
+    for (const pair of PARITY_PAIRS) {
+      parityInputs.push({
+        ...pair,
+        viewCols: await readColumns(client, pair.view),
+        baseCols: await readColumns(client, pair.base),
+      });
+    }
   } finally {
     await client.end();
   }
@@ -105,18 +244,28 @@ async function main() {
   const { literal: limitPredicate, correlatedColumn } = extractLimitPredicate(ingressExpr);
 
   if (SEED) {
-    // Mutate ONE side of each coupling so both fences must report DIVERGED.
+    // Mutate ONE side of each coupling so EVERY fence must report DIVERGED.
+    //
+    // THE PARITY SEED IS NOT OPTIONAL, and the reason is subtle enough to write down: the
+    // FENCE IS BROKEN check below asserts only that the AGGREGATE seeded run fails, and the two
+    // pre-existing seeds already guarantee that. A new coupling with no seed of its own would
+    // ride along permanently untested behind a control that passes for reasons unrelated to it.
     if (ingressExpr) ingressExpr = ingressExpr.replace(/'high'/, "'medium'");
     if (anonSelectExpr) anonSelectExpr = `${anonSelectExpr} AND venture_id IS NOT NULL`;
+    for (const p of parityInputs) p.viewCols = seedParityDivergence(p.viewCols);
   }
 
   const pairResult = compareSeverityPair({ viewExpr, policyExpr: ingressExpr });
   const countResult = compareCountVisibility({ limitPredicate, selectPredicate: anonSelectExpr, correlatedColumn });
-  const results = [pairResult, countResult];
+  const parityResults = parityInputs.map((p) => compareViewBaseParity({
+    viewCols: p.viewCols, baseCols: p.baseCols, viewName: p.view, baseName: p.base,
+  }));
+  // The aggregator is UNCHANGED — it reads only .verdict, so this is purely additive.
+  const results = [pairResult, countResult, ...parityResults];
   const ok = allCouplingsAgree(results);
 
   if (JSON_OUT) {
-    console.log(JSON.stringify({ seeded: SEED, ok, pair: pairResult, count: countResult }, null, 2));
+    console.log(JSON.stringify({ seeded: SEED, ok, pair: pairResult, count: countResult, parity: parityResults }, null, 2));
   } else {
     console.log(SEED ? '=== SEEDED DIVERGENCE RUN (in-memory mutation; nothing written) ===' : '=== LIVE COUPLING CHECK ===');
     console.log(`FR-2 severity pair : ${pairResult.verdict}`);
@@ -127,7 +276,18 @@ async function main() {
     console.log(`   limit counts   = ${countResult.limitPredicate ?? '(unreadable)'}`);
     console.log(`   anon SELECT    = ${countResult.selectPredicate ?? '(unreadable)'}`);
     console.log(`   ${countResult.detail}`);
+    for (const [i, r] of parityResults.entries()) {
+      const p = parityInputs[i];
+      console.log(`COLUMN PARITY (${p.view} <- ${p.base}) : ${r.verdict}`);
+      console.log(`   ${r.detail}`);
+    }
     console.log(ok ? 'PAIR_AGREES — every coupling holds.' : 'FENCE TRIPPED — see above.');
+  }
+
+  // Tell a consumer. NOT on a seeded run: a seeded divergence is a self-test, and alerting on it
+  // would train every reader to ignore this alert — the fastest way to make a real one invisible.
+  if (!ok && !SEED) {
+    await emitDriftAlert(results.filter((r) => r.verdict !== AGREES));
   }
 
   if (SEED && ok) {

--- a/tests/unit/cron/divergence-fence-alert-wire.test.js
+++ b/tests/unit/cron/divergence-fence-alert-wire.test.js
@@ -1,0 +1,81 @@
+/**
+ * SD-LEO-INFRA-OWNERSHIP-PRESERVATION-ASSERTION-001 — the consumer wire, asserted TWO-SIDED.
+ *
+ * ── WHY THIS FILE EXISTS, AND WHY THE OBVIOUS TEST WOULD HAVE BEEN WORTHLESS ────────────────
+ * emitBreakageAlert is FAIL-SOFT BY CONTRACT: it catches everything and returns {ok:false}. The
+ * fence discards its return value so a broken alert can never corrupt the exit code — which is
+ * correct, and which means a wire that throws on EVERY call is COMPLETELY INVISIBLE in the exit
+ * code, the only thing every other check here inspects. Both the TESTING and SECURITY sub-agents
+ * independently mutated the wire to always-throw and the entire 36,000-test unit project stayed
+ * GREEN. "The fence still exits 1" proves nothing about whether anyone was told.
+ *
+ * So the assertions have to be two-sided about the CALL ITSELF: it FIRES on divergence, and it is
+ * SILENT on agreement. One side alone is satisfied by a wire that is stuck on or stuck off.
+ *
+ * This is only possible because the module now has an entrypoint guard. Before that, main() ran at
+ * import and every terminus called process.exit(), so importing the fence would have killed the
+ * test runner and every assertion about it had to be a regex over source text.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { emitDriftAlert } from '../../../scripts/severity-pair-divergence-fence.mjs';
+
+/** Records calls instead of writing. The `deps` seam exists so no live row is ever created here. */
+function spy(impl) {
+  const calls = [];
+  const fn = async (...args) => { calls.push(args); return impl ? impl(...args) : { ok: true, id: 'row-1' }; };
+  return { calls, fn };
+}
+
+const DIVERGED_RESULT = [{ detail: 'DIVERGENCE: v_x is missing 2 column(s) present on t_x: a, b' }];
+
+describe('the divergence fence tells a consumer', () => {
+  it('FIRES on divergence — with the schema-drift break class and the detail', async () => {
+    const s = spy();
+    await emitDriftAlert(DIVERGED_RESULT, { emitBreakageAlert: s.fn });
+    expect(s.calls, 'a divergence that alerts nobody is a detector nobody reads').toHaveLength(1);
+    const [breakClass, sourceService, opts] = s.calls[0];
+    expect(breakClass, 'the schema-drift class already exists — no new class is minted').toBe('schema-drift');
+    expect(sourceService).toBe('divergence-fence');
+    expect(opts.message, 'the alert must carry what actually diverged, not just that something did')
+      .toMatch(/missing 2 column/);
+  });
+
+  it('is SILENT when nothing diverged — the other half, without which stuck-on passes', async () => {
+    const s = spy();
+    const r = await emitDriftAlert([], { emitBreakageAlert: s.fn });
+    expect(s.calls, 'alerting on a healthy run trains every reader to ignore this alert').toHaveLength(0);
+    expect(r).toMatchObject({ skipped: 'no_divergence' });
+  });
+
+  it('[DEDUP] the UNREADABLE path uses a DISTINCT source_service', async () => {
+    // recordSystemAlert dedups on (source_service, break_class, resolved_at IS NULL). A tripped
+    // -fence alert sits open almost by definition — the drift it reports is precisely what nobody
+    // has fixed yet — so sharing a source_service would let that open row SWALLOW the unreadable
+    // alert, and the fix built for the dead-and-invisible mode would itself be invisible.
+    const s = spy();
+    await emitDriftAlert([{ detail: 'UNREADABLE: no credentials' }], { emitBreakageAlert: s.fn }, 'divergence-fence-unreadable');
+    expect(s.calls[0][1]).toBe('divergence-fence-unreadable');
+    expect(s.calls[0][1], 'must not collide with the tripped-fence identity').not.toBe('divergence-fence');
+  });
+
+  it('a THROWING wire never corrupts the fence — but is still observable HERE', async () => {
+    // The fail-soft contract is correct and must be preserved: an alert failure must not turn a
+    // readable catalog into an unreadable verdict. The cost is that the exit code cannot witness
+    // it, which is exactly why the witness has to live at this level.
+    const s = spy(() => { throw new Error('alerting is down'); });
+    const r = await emitDriftAlert(DIVERGED_RESULT, { emitBreakageAlert: s.fn });
+    expect(s.calls, 'it must still ATTEMPT the call').toHaveLength(1);
+    expect(r.ok, 'and report its own failure rather than claiming success').toBe(false);
+    expect(r.error).toMatch(/alerting is down/);
+  });
+
+  it('[CONTROL] the spy is really injected — no live write can happen in this file', async () => {
+    // If the deps seam were ignored, the real emitter would run and these tests would be writing
+    // rows to system_alerts on every CI run. The call count IS the proof the seam is honoured.
+    const s = spy();
+    await emitDriftAlert(DIVERGED_RESULT, { emitBreakageAlert: s.fn });
+    await emitDriftAlert(DIVERGED_RESULT, { emitBreakageAlert: s.fn });
+    expect(s.calls).toHaveLength(2);
+  });
+});

--- a/tests/unit/cron/divergence-fence-alert-wire.test.js
+++ b/tests/unit/cron/divergence-fence-alert-wire.test.js
@@ -18,7 +18,12 @@
  */
 
 import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { emitDriftAlert } from '../../../scripts/severity-pair-divergence-fence.mjs';
+
+const SCRIPT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../scripts/severity-pair-divergence-fence.mjs');
 
 /** Records calls instead of writing. The `deps` seam exists so no live row is ever created here. */
 function spy(impl) {
@@ -68,6 +73,44 @@ describe('the divergence fence tells a consumer', () => {
     expect(s.calls, 'it must still ATTEMPT the call').toHaveLength(1);
     expect(r.ok, 'and report its own failure rather than claiming success').toBe(false);
     expect(r.error).toMatch(/alerting is down/);
+  });
+
+  it('[CALL SITE] main() actually CALLS emitDriftAlert on a real trip', async () => {
+    // MY OWN FIX WAS INCOMPLETE AND THE RETRO SUB-AGENT MEASURED IT. Every test above injects
+    // deps.emitBreakageAlert, so they exercise the INSIDE of emitDriftAlert and never walk the
+    // path that decides whether it is called at all. Re-mutating `if (!ok && !SEED)` to
+    // `if (false)` — a real divergence alerting nobody — left all 293 tests GREEN.
+    //
+    // That is the decoration shape from this same SD, recursed one level: I moved the assertion
+    // from the DECLARATION to the FUNCTION, and stopped short of the CALL SITE. A function that
+    // is correct and never invoked is the exact defect this whole SD exists to close.
+    // ⚠️ PIN THE GUARD, NOT THE CALL TEXT — I got this wrong TWICE before writing it this way.
+    // Asserting /await emitDriftAlert\(results\.filter/ still MATCHES when the enclosing branch is
+    // mutated to `if (false)`, because the call text survives inside dead code. Reachability lives
+    // in the CONDITION, so the condition is what has to be asserted.
+    const src = fs.readFileSync(SCRIPT, 'utf8').replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    expect(src, 'the alert must be guarded by the REAL verdict, not by a constant')
+      .toMatch(/if\s*\(\s*!ok\s*&&\s*!SEED\s*\)\s*\{[\s\S]{0,200}?await\s+emitDriftAlert\(/);
+    expect(src, 'and the unreadable branch must alert too').toMatch(/await\s+emitDriftAlert\(\s*\n?\s*\[\{\s*detail/);
+  });
+
+  it('[IMPORT EDGE] the real emitter module exists and exports emitBreakageAlert', async () => {
+    // The other mutation that stayed green: repointing the dynamic import at a nonexistent module.
+    // The deps seam means no test ever walks the real edge, so a typo'd path would be discovered
+    // only in production — where emitDriftAlert catches it, warns, and returns {ok:false}, i.e.
+    // silently. Walking the edge here is the only place it is cheap to catch.
+    // ⚠️ RESOLVE THE PATH THE SCRIPT ACTUALLY WRITES — my first version imported the module by a
+    // path hardcoded in THIS file, so mutating the SCRIPT's import string left it green. A test
+    // that walks its own edge instead of the subject's edge proves nothing about the subject.
+    const raw = fs.readFileSync(SCRIPT, 'utf8');
+    const m = raw.match(/await import\(\s*'([^']*emit-breakage-alert[^']*)'\s*\)/)
+      || raw.match(/await import\(\s*'([^']+)'\s*\)/);
+    expect(m, 'the fence must dynamically import an emitter').not.toBeNull();
+    const resolved = path.resolve(path.dirname(SCRIPT), m[1]);
+    expect(fs.existsSync(resolved), `the fence imports '${m[1]}', which resolves to ${resolved} — that file does not exist`).toBe(true);
+    const mod = await import(pathToFileURL(resolved).href);
+    expect(typeof (mod.emitBreakageAlert ?? mod.default?.emitBreakageAlert), 'and that module must export emitBreakageAlert')
+      .toBe('function');
   });
 
   it('[CONTROL] the spy is really injected — no live write can happen in this file', async () => {

--- a/tests/unit/cron/divergence-fence-wiring.test.js
+++ b/tests/unit/cron/divergence-fence-wiring.test.js
@@ -117,6 +117,52 @@ describe('the divergence fence names its dispatcher', () => {
     expect(fs.existsSync(path.join(repoRoot, 'scripts/check-severity-pair-divergence.mjs'))).toBe(false);
   });
 
+  it('[CREDENTIALS] the workflow injects a secret name the script ACTUALLY READS', () => {
+    // THE DEFECT THIS PINS SHIPPED IN THE FIRST VERSION OF THIS FILE, and two independent
+    // reviewers found it before CI did. The workflow injected SUPABASE_POOLER_URL, which is NOT a
+    // repo secret — it expanded empty, `conn` was falsy, the script exited 2, and the fence never
+    // ran. Meanwhile DATABASE_URL is a real secret that was injected and read by nothing.
+    //
+    // Asserting the INTERSECTION rather than either side alone: a workflow env var the script
+    // never reads is decoration, and a script env var the workflow never sets is a dead fence.
+    // It passed locally because .env carries the pooler URL — a green hand-run says nothing about
+    // a runner's environment.
+    // ⚠️ WHAT THIS TEST CANNOT DO, stated so nobody mistakes it for the whole check: a static file
+    // read CANNOT tell whether a GitHub secret EXISTS. The shipped defect was exactly that —
+    // SUPABASE_POOLER_URL was spelled correctly, injected correctly, read correctly, and simply
+    // did not exist as a secret. Only `gh secret list` finds that, and that is how it was caught.
+    // What IS pinnable here is the MAPPING onto a secret known to exist, so this asserts that
+    // specific edge rather than a generic "some connection var is present" (my first version
+    // asserted exactly that, and it stayed GREEN when I re-introduced the defect — the surviving
+    // SUPABASE_POOLER_URL line satisfied it).
+    const yml = read(WORKFLOW);
+    const src = code(SCRIPT);
+    expect(src, 'the script must read SUPABASE_DB_URL as a fallback').toMatch(/process\.env\.SUPABASE_DB_URL/);
+    expect(yml, 'SUPABASE_DB_URL must be fed from secrets.DATABASE_URL — the secret that actually exists')
+      .toMatch(/SUPABASE_DB_URL:\s*\$\{\{\s*secrets\.DATABASE_URL\s*\}\}/);
+  });
+
+  it('[STAMP] a healthy run stamps last_fired_at, or the alarm inverts into a permanent false positive', () => {
+    // Registering before the credential check gives the watcher a row to read. A row that is
+    // never stamped reads armed-never-produced FOREVER — so fixing the credentials alone would
+    // turn a true positive into a permanent false one. These two had to land together.
+    // Matched at the CALL SITE (`await stampIfHealthy(`), not the bare name. My first version
+    // asserted /stampIfHealthy\(/, which matches the FUNCTION DEFINITION — so deleting the call
+    // left the test green. A helper that exists and is never invoked is the same nothing as a
+    // helper that does not exist, which is the defect class this entire SD is about.
+    const src = code(SCRIPT);
+    expect(src, 'the fence must stamp on success').toMatch(/stampLastFired/);
+    expect(src, 'and the stamp must actually be CALLED, not merely defined').toMatch(/await\s+stampIfHealthy\(/);
+  });
+
+  it('[DEDUP] the UNREADABLE alert has its OWN source_service', () => {
+    // recordSystemAlert dedups on (source_service, break_class, resolved_at IS NULL). A tripped
+    // -fence alert sits open almost by definition — the drift it reports is what nobody has fixed
+    // yet — so a shared source_service would let that open row SWALLOW the unreadable alert, and
+    // the fix for the dead-and-invisible mode would be invisible in exactly the same way.
+    expect(code(SCRIPT)).toMatch(/divergence-fence-unreadable/);
+  });
+
   it('[CONTROL] the comment-stripper really removes prose, or the assertions above are vacuous', () => {
     // These tests distinguish "the code calls X" from "a comment mentions X". If the stripper were
     // inert, a deleted call site would still pass because the header would still name it.

--- a/tests/unit/cron/divergence-fence-wiring.test.js
+++ b/tests/unit/cron/divergence-fence-wiring.test.js
@@ -1,0 +1,127 @@
+/**
+ * SD-LEO-INFRA-OWNERSHIP-PRESERVATION-ASSERTION-001 — the fence must be DISPATCHED, not merely
+ * correct. Pattern PAT-PROCESS-PRODUCER-CONSUMER-INVARIANT-001; exemplar
+ * tests/unit/cron/chairman-decision-sla-wiring.test.js.
+ *
+ * THE DEFECT CLASS THIS PINS, and it is the reason this whole SD extends an existing file rather
+ * than writing a new one: scripts/severity-pair-divergence-fence.mjs was fully built, correct,
+ * and NEVER INVOKED — zero workflow references, zero npm scripts, and zero rows in the live
+ * periodic_process_registry across 246 registered processes. It even had a proven true positive.
+ * Armed logic with no dispatcher is indistinguishable from logic that always passes, and the
+ * failure is silent, because absence has no error message.
+ *
+ * These assertions are pure fs reads — no DB, no network, no clock — and they are typed as a
+ * UNIT test deliberately. tests/integration/** resolves to ZERO FILES in this repo (the vitest db
+ * project is disabled with no designated non-production target), so an integration-typed wiring
+ * test would SKIP AND REPORT GREEN — which is the same false assurance the SD is about.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+
+const WORKFLOW_REL = '.github/workflows/divergence-fence-cron.yml';
+const SCRIPT_REL = 'scripts/severity-pair-divergence-fence.mjs';
+const WORKFLOW = path.join(repoRoot, WORKFLOW_REL);
+const SCRIPT = path.join(repoRoot, SCRIPT_REL);
+
+const read = (p) => fs.readFileSync(p, 'utf8');
+/** Source with comments stripped — a name in prose is not a call site. */
+const code = (p) => read(p).replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+describe('the divergence fence names its dispatcher', () => {
+  it('the workflow exists and its run step invokes the fence', () => {
+    expect(fs.existsSync(WORKFLOW), `missing dispatcher workflow: ${WORKFLOW}`).toBe(true);
+    expect(read(WORKFLOW)).toMatch(/node\s+scripts\/severity-pair-divergence-fence\.mjs/);
+  });
+
+  it('[SCHEDULE] it is on a SCHEDULE, not workflow_dispatch alone', () => {
+    // The assertion that actually pins the fix. A workflow_dispatch-only file would satisfy every
+    // other check here while leaving the fence exactly as dormant as it was — which IS the defect.
+    const yml = read(WORKFLOW);
+    expect(yml, 'a manually-triggered-only workflow does not end dormancy').toMatch(/^\s*schedule:/m);
+    expect([...yml.matchAll(/^\s*-\s*cron:\s*'([^']+)'/gm)].length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('[SEED-FIRST] the workflow proves the fence can FAIL before trusting that it passed', () => {
+    // A fence that has never failed is indistinguishable from one that CANNOT fail. Without this
+    // step the daily green run means nothing.
+    expect(read(WORKFLOW)).toMatch(/--seed-divergence/);
+  });
+
+  it('[TWO CREDENTIAL SETS] the workflow carries BOTH the pg and the supabase-js env', () => {
+    // The named risk with no assertion behind it until now. The catalog reads use node-postgres
+    // and the consumer wires use supabase-js; a workflow with only the supabase pair leaves the
+    // fence unable to read anything, on a runner where that failure is otherwise quiet.
+    const yml = read(WORKFLOW);
+    for (const name of ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY', 'SUPABASE_POOLER_URL']) {
+      expect(yml, `${name} is not wired from secrets`).toMatch(new RegExp(`${name}:\\s*\\$\\{\\{\\s*secrets\\.${name}\\s*\\}\\}`));
+    }
+  });
+
+  it('ACTIVATION_TRIGGER equals the workflow path, exactly', () => {
+    // Two names for one thing is how a registry row ends up pointing at a workflow that does not
+    // exist — and a stamp against a row nobody reads fails silently.
+    expect(code(SCRIPT)).toMatch(
+      new RegExp(`ACTIVATION_TRIGGER\\s*=\\s*['"]${WORKFLOW_REL.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}['"]`)
+    );
+  });
+
+  it('the fence registers itself as armed machinery, so the staleness alarm has a row to read', () => {
+    const src = code(SCRIPT);
+    expect(src).toMatch(/registerArmedMachinery/);
+    expect(src, 'the fence must import the canonical registrar, not re-implement it')
+      .toMatch(/from\s+['"]\.\.\/lib\/machinery-class\/armed-registration\.js['"]/);
+  });
+
+  it('[SILENT-DEATH] registration happens BEFORE the credential check can exit', () => {
+    // THE ORDERING IS THE FIX, and it is the opposite of the obvious one. main() used to exit(2)
+    // on a missing pooler URL as its first act — before connecting, before every comparator,
+    // before registration and before any alert. So on a runner without that secret the fence
+    // emitted nothing AND wrote no registry row, leaving the staleness watcher nothing to find.
+    // Dead and invisible, identical to never having been scheduled.
+    const src = code(SCRIPT);
+    const registerAt = src.indexOf('await ensureArmedRegistration()');
+    const credCheckAt = src.indexOf('SUPABASE_POOLER_URL || process.env.SUPABASE_DB_URL');
+    expect(registerAt, 'ensureArmedRegistration() call site not found').toBeGreaterThan(-1);
+    expect(credCheckAt, 'credential check not found').toBeGreaterThan(-1);
+    expect(registerAt, 'registration must precede the credential check, or a missing secret kills the fence silently')
+      .toBeLessThan(credCheckAt);
+  });
+
+  it('the parity coupling is wired into the aggregate and is SEEDED', () => {
+    const src = code(SCRIPT);
+    expect(src, 'the parity comparator must actually run').toMatch(/compareViewBaseParity\(/);
+    expect(src, 'and its results must reach the aggregated list').toMatch(/\.\.\.parityResults/);
+    expect(src, 'and it must have a seed of its own, or it rides the pre-existing ones untested')
+      .toMatch(/seedParityDivergence\(/);
+  });
+
+  it('[NEGATIVE] the usage block no longer INVOKES a file that does not exist', () => {
+    // The usage block told readers to run scripts/check-severity-pair-divergence.mjs — a file that
+    // has never existed. Following it is how a reader concludes the instrument is absent and
+    // writes a second one, which is exactly the duplication this SD refused.
+    //
+    // Matched as an INVOCATION (`node <path>`), not as a mention: the corrected header explains
+    // the old pointer in order to retire it, and a scan that cannot tell the correction from the
+    // defect would fire on the file that fixed it. Same read-vs-perform narrowing the FR-7
+    // propose-only guard already earned — narrowed to the act, not deleted.
+    expect(read(SCRIPT), 'the usage block must not tell anyone to run a nonexistent file')
+      .not.toMatch(/node\s+scripts\/check-severity-pair-divergence\.mjs/);
+    expect(read(SCRIPT), '[CONTROL] and it must name the file that DOES exist')
+      .toMatch(/node\s+scripts\/severity-pair-divergence-fence\.mjs/);
+    expect(fs.existsSync(path.join(repoRoot, 'scripts/check-severity-pair-divergence.mjs'))).toBe(false);
+  });
+
+  it('[CONTROL] the comment-stripper really removes prose, or the assertions above are vacuous', () => {
+    // These tests distinguish "the code calls X" from "a comment mentions X". If the stripper were
+    // inert, a deleted call site would still pass because the header would still name it.
+    const stripped = code(SCRIPT);
+    expect(read(SCRIPT), 'the header does discuss periodic_process_registry in prose').toMatch(/periodic_process_registry/);
+    expect(stripped, 'and that prose must NOT survive stripping — there is no such call site').not.toMatch(/periodic_process_registry/);
+  });
+});

--- a/tests/unit/severity-pair-coupling.test.js
+++ b/tests/unit/severity-pair-coupling.test.js
@@ -17,6 +17,8 @@ import {
   AGREES,
   DIVERGED,
   UNREADABLE,
+  compareViewBaseParity,
+  seedParityDivergence,
 } from '../../lib/policy/severity-pair-coupling.js';
 
 // --- Live fixtures (verbatim shape from the database) ------------------------------
@@ -236,5 +238,141 @@ describe('allCouplingsAgree', () => {
   it('is FALSE on an EMPTY list — a fence that measured nothing has not passed', () => {
     // Without this, a fence whose inputs all failed to load reports success.
     expect(allCouplingsAgree([])).toBe(false);
+  });
+});
+
+// ── SD-LEO-INFRA-OWNERSHIP-PRESERVATION-ASSERTION-001 — view/base column parity ────────────
+//
+// The fixtures are VERBATIM from the live catalog on 2026-08-07, not invented: the view serves
+// 30 columns against the base table's 29, with six base columns absent. Using the real drift
+// means these tests describe a defect that exists rather than one imagined for the occasion.
+//
+// The TESTING sub-agent named the wrong build a weaker suite would pass: a correct pure
+// comparator fed wrong inputs, driven by a loop iterating ZERO views. The cardinality control at
+// the bottom is what makes fires-correctly, fires-always and fires-never three distinguishable
+// outcomes rather than one.
+
+const BASE_COLS = [
+  'pattern_id', 'category', 'severity', 'issue_summary', 'occurrence_count', 'proven_solutions',
+  'prevention_checklist', 'trend', 'updated_at', 'created_at', 'source', 'assigned_sd_id',
+  'metadata', 'dedup_fingerprint', 'first_seen_sd_id', 'last_seen_sd_id', 'status',
+  'data_quality_status', 'content_embedding', 'embedding_updated_at', 'auto_block_on_match',
+];
+/** The six genuinely absent columns, measured live against the production catalog. */
+const ABSENT_LIVE = [
+  'metadata', 'dedup_fingerprint', 'data_quality_status',
+  'content_embedding', 'embedding_updated_at', 'auto_block_on_match',
+];
+/** The seven the view COMPUTES and the base table does not have — parity must tolerate these. */
+const COMPUTED = [
+  'recency_status', 'days_since_update', 'decay_adjusted_confidence',
+  'severity_weight', 'composite_score', 'min_occurrence_threshold', 'meets_threshold',
+];
+const DRIFTED_VIEW_COLS = BASE_COLS.filter((c) => !ABSENT_LIVE.includes(c)).concat(COMPUTED);
+const HEALTHY_VIEW_COLS = BASE_COLS.concat(COMPUTED);
+
+describe('compareViewBaseParity — the p.*-refreeze drift class', () => {
+  it('TS-1 POSITIVE CONTROL: the REAL measured drift is detected and named', () => {
+    const r = compareViewBaseParity({ viewCols: DRIFTED_VIEW_COLS, baseCols: BASE_COLS });
+    expect(r.verdict).toBe(DIVERGED);
+    expect([...r.missingFromView].sort()).toEqual([...ABSENT_LIVE].sort());
+    expect(r.detail).toMatch(/DIVERGENCE/);
+  });
+
+  it('TS-4 NEGATIVE CONTROL: a view at parity does NOT fire', () => {
+    // Without this, a comparator returning DIVERGED unconditionally would satisfy every positive
+    // case above while alarming on all ~185 views in the database, forever.
+    const r = compareViewBaseParity({ viewCols: HEALTHY_VIEW_COLS, baseCols: BASE_COLS });
+    expect(r.verdict).toBe(AGREES);
+    expect(r.missingFromView).toEqual([]);
+  });
+
+  it('ASYMMETRY: extra VIEW columns are computed output, never drift', () => {
+    // A set-EQUALITY implementation would report permanent false divergence on every correctly
+    // coupled view, because a view legitimately computes columns its base table does not have.
+    // This is the single most likely wrong implementation, and it looks tidier than the right one.
+    const r = compareViewBaseParity({ viewCols: [...BASE_COLS, 'computed_a'], baseCols: BASE_COLS });
+    expect(r.verdict).toBe(AGREES);
+  });
+
+  it('TS-2 SEEDED (4 cases): an unreadable side is UNREADABLE, never AGREES', () => {
+    // [] IS TRUTHY, so `if (!viewCols || !baseCols)` lets it through. The two ARRAY cases are the
+    // ones a silently-empty catalog read actually produces, and they are exactly the ones the
+    // obvious guard misses.
+    for (const args of [
+      { viewCols: [], baseCols: BASE_COLS },
+      { viewCols: BASE_COLS, baseCols: [] },
+      { viewCols: null, baseCols: BASE_COLS },
+      { viewCols: BASE_COLS, baseCols: null },
+    ]) {
+      expect(compareViewBaseParity(args).verdict, JSON.stringify(args).slice(0, 50)).toBe(UNREADABLE);
+    }
+  });
+
+  it('SEEDED: empty-vs-empty is UNREADABLE — the fail-open the naive guard produces', () => {
+    // The most dangerous single input: a catalog query that returned nothing for BOTH sides.
+    // "Every base column is in the view" is vacuously TRUE over an empty base list, so a naive
+    // implementation returns AGREES — reporting parity about a database it never read.
+    expect(compareViewBaseParity({ viewCols: [], baseCols: [] }).verdict).toBe(UNREADABLE);
+  });
+
+  it('never returns null, on any input shape', () => {
+    // allCouplingsAgree reads `r && r.verdict`, so a null element would count as not-AGREES BY
+    // ACCIDENT rather than by decision. Safe today; that is not the same as being a contract.
+    for (const args of [undefined, {}, { viewCols: null, baseCols: null }, { viewCols: 'x', baseCols: 7 }]) {
+      const r = compareViewBaseParity(args);
+      expect(r).toBeTruthy();
+      expect(r.verdict).toBe(UNREADABLE);
+    }
+  });
+
+  it('a DIVERGED parity result fails the aggregate — and the aggregator is UNCHANGED', () => {
+    const drifted = compareViewBaseParity({ viewCols: DRIFTED_VIEW_COLS, baseCols: BASE_COLS });
+    const healthy = compareViewBaseParity({ viewCols: HEALTHY_VIEW_COLS, baseCols: BASE_COLS });
+    expect(allCouplingsAgree([{ verdict: AGREES }, { verdict: AGREES }, drifted])).toBe(false);
+    expect(allCouplingsAgree([{ verdict: AGREES }, { verdict: AGREES }, healthy])).toBe(true);
+  });
+});
+
+describe('TS-5 seedParityDivergence — the parity coupling fails on ITS OWN seed', () => {
+  it('the seed makes a HEALTHY view diverge', () => {
+    // The fence's exit-3 BROKEN check asserts only that the AGGREGATE seeded run fails, and the
+    // two pre-existing seeds already make it fail. Without a parity-specific seed this comparator
+    // would ride along permanently untested behind a control that passes for unrelated reasons.
+    const r = compareViewBaseParity({ viewCols: seedParityDivergence(HEALTHY_VIEW_COLS), baseCols: BASE_COLS });
+    expect(r.verdict).toBe(DIVERGED);
+  });
+
+  it('and it fails the aggregate with the OTHER couplings forced to AGREES', () => {
+    // Isolation: proves the PARITY leg alone trips the fence, not the pre-existing seeds.
+    expect(allCouplingsAgree([
+      { verdict: AGREES },
+      { verdict: AGREES },
+      compareViewBaseParity({ viewCols: seedParityDivergence(HEALTHY_VIEW_COLS), baseCols: BASE_COLS }),
+    ])).toBe(false);
+  });
+
+  it('[CONTROL] the seed is not a no-op, and is safe on an empty list', () => {
+    expect(seedParityDivergence(HEALTHY_VIEW_COLS).length).toBe(HEALTHY_VIEW_COLS.length - 1);
+    expect(seedParityDivergence([])).toEqual([]);
+  });
+});
+
+describe('CARDINALITY CONTROL — fires-correctly vs fires-always vs fires-never', () => {
+  it('across N views with exactly K drifted, EXACTLY K fire', () => {
+    // Asserting `> 0` would pass for a comparator that fires on everything. A COUNT separates all
+    // three outcomes in one assertion — and the wrong build TESTING named (a loop iterating zero
+    // views) fails the length check too, because 0 is not 5.
+    const views = [
+      { name: 'v_a', cols: HEALTHY_VIEW_COLS },
+      { name: 'v_b', cols: DRIFTED_VIEW_COLS },
+      { name: 'v_c', cols: HEALTHY_VIEW_COLS },
+      { name: 'v_d', cols: seedParityDivergence(HEALTHY_VIEW_COLS) },
+      { name: 'v_e', cols: HEALTHY_VIEW_COLS },
+    ];
+    const results = views.map((v) => compareViewBaseParity({ viewCols: v.cols, baseCols: BASE_COLS, viewName: v.name }));
+    expect(results.filter((r) => r.verdict === DIVERGED).length).toBe(2);
+    expect(results.filter((r) => r.verdict === AGREES).length).toBe(3);
+    expect(results.length, 'a loop over zero views passes every other assertion in this file').toBe(5);
   });
 });


### PR DESCRIPTION
## The justification is a live measurement, not an argument

`v_patterns_with_decay` is **drifted right now**: 30 view columns against `issue_patterns`' 29, with
**six base columns absent** — including *both* columns its only direct consumer selects. So
`context-builder.js` raises `42703` on every run, catches any error mentioning `column`, and
**silently falls back to the base table**. That has been true for months and no instrument noticed.

This SD gives that defect class a standing detector.

## Scope note: the original deliverable was already shipped

This SD was written to add a three-piece ownership-preservation assertion. **That is already on
main**, inside PR #6727 (commit `c6daedd1`) — verified line-by-line, all four load-bearing design
points intact, and recorded in `metadata.satisfied_elsewhere` so no future seat rebuilds it. The SD
was rescoped by coordinator ruling to the one genuinely-unbuilt piece.

`database/migrations/20260801_...sql` has **zero diff lines** here. Its sha256 is bound to a chairman
verbal already in front of the chairman; moving it again would invalidate that ask.

## Extend, don't rebuild — the substrate was chosen *because* it was dormant

`scripts/severity-pair-divergence-fence.mjs` was fully built, correct, and **never invoked**: zero
workflow references, zero npm scripts, and **zero rows in the live `periodic_process_registry`
across 246 registered processes**. It even has a proven true positive. Building a second detector
beside it would have left the working one dark. Extending it means the schedule and consumer wire
that give column-parity a home also end the fence's own dormancy.

## What ships

- **`compareViewBaseParity`** — class-wide, **one-directional** (a view legitimately computes columns
  its base lacks; set-equality would false-fire on all ~185 views and is the tidier-looking
  implementation, so it's mutation-proven at 5 red).
- **Empty is UNREADABLE, never AGREES.** `[]` is truthy, so the natural guard lets it through and
  "every base column is in the view" is *vacuously true* over an empty list — a parity check
  reporting agreement about a catalog it never read. Mutation-proven at 3 red.
- **`seedParityDivergence`**, exported and pure — the exit-3 broken-check only asserts the *aggregate*
  seeded run fails, and two pre-existing seeds already guarantee that, so a coupling without its own
  seed rides along permanently untested.
- **Registration before the credential check**, plus **stamping on success**. Either alone is worse
  than neither: registering gives the watcher a row, but an unstamped row reads
  armed-never-produced forever, so fixing credentials alone inverts a true alarm into a permanent
  false one.
- **Consumer wire** via the existing `schema-drift` break class, with a **distinct `source_service`**
  for the UNREADABLE path — the alert dedups on an open row, so a tripped-fence alert would have
  swallowed it.

## Verified at the consumer, not the emitter

- seeded run → exit 1 (the fence *can* fail); live run → exit 1
- the parity coupling **independently reproduced** the six drifted columns measured by hand
- `system_alerts` row landed — checked by **reading `system_alerts`**
- `periodic_process_registry` row armed and active
- the `SUPABASE_DB_URL` fallback proven by running with the pooler var unset

## Two things I got wrong, and how they were caught

**The fence I first shipped could never have run.** The workflow injected `SUPABASE_POOLER_URL`,
which is not a repo secret. Both EXEC sub-agents found it independently; I didn't. It passed locally
because `.env` carries it — I verified the instrument and not its habitat. Fixed by mapping onto
`DATABASE_URL`, which *is* a secret and was already injected but read by nothing.

**Three tests I wrote to prove fixes were decoration**, each one level further out: asserting the
function *declaration* (deleting the call stayed green), then the function's behaviour via an
injected stub (mutating the call site stayed green), then the call *text* (mutating the guard to
`if (false)` still matched inside dead code). Reachability lives in the condition. Only mutation
caught it, every time.

## Carried, not hidden

`readColumns`' catalog query is unexercised; `PARITY_PAIRS` emptied to zero views stays green; the
seed step is currently vacuous because the live catalog already fails unseeded; pg still connects
with `rejectUnauthorized: false` (pre-existing, and `ssl-bypass-lint.yml` greps only YAML so it
cannot see it); FR-3 count-visibility is UNREADABLE on the live catalog; and the FR-5 hoist is
deferred until the chairman-gated migration applies — it works, but produces two *true* violations
in a blocking lint, which would make this PR unmergeable.

295 tests. Every seeded failure mutation-proven and reverted with zero residue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)