### PR TITLE
fix(QF-20260807-447): test the catalog query the whole drift detector rests on

### DIFF
--- a/scripts/severity-pair-divergence-fence.mjs
+++ b/scripts/severity-pair-divergence-fence.mjs
@@ -116,7 +116,7 @@ function extractLimitPredicate(policyExpr) {
  * false positive that a hand-fed unit test cannot catch, because the query is the part under test.
  * relkind is left open so the SAME function reads a view ('v') and a table ('r').
  */
-async function readColumns(client, relname) {
+export async function readColumns(client, relname) {
   const { rows } = await client.query(
     `select a.attname
        from pg_attribute a

--- a/tests/unit/cron/divergence-fence-read-columns.test.js
+++ b/tests/unit/cron/divergence-fence-read-columns.test.js
@@ -1,0 +1,106 @@
+/**
+ * QF-20260807-447 — readColumns' catalog query, the untested part of the drift detector.
+ *
+ * Follow-through from SD-LEO-INFRA-OWNERSHIP-PRESERVATION-ASSERTION-001 completion flag 0af4cb6f.
+ *
+ * ── THE DEFECT CLASS, MEASURED NOT ARGUED ─────────────────────────────────────────────────────
+ * The whole view-vs-base column-parity detector rests on one catalog query, and nothing exercised
+ * it. Measured on PG 17.4 against the live catalog:
+ *   issue_patterns          → 29 columns WITH the filters, 35 WITHOUT (six system columns)
+ *   v_patterns_with_decay   → 30 columns either way (views carry no system columns)
+ * So dropping `attnum > 0` or `NOT attisdropped` adds SIX to every BASE side and ZERO to every
+ * VIEW side — every pair looks permanently drifted, across all ~185 views. A detector that fires
+ * on everything is exactly as useless as one that fires on nothing, and it is the failure mode
+ * that trains readers to ignore the alert.
+ *
+ * Verified before this file existed: both mutations stayed GREEN across the entire unit project.
+ *
+ * ── WHAT A UNIT TEST CAN AND CANNOT PROVE HERE, STATED RATHER THAN GLOSSED ────────────────────
+ * THE FILTERS EXECUTE SERVER-SIDE. A fake client returns whatever it is handed, so no injected
+ * double can demonstrate that Postgres excluded a system column — the filtering is not in the JS.
+ * That bounds the honest claim, so the assertions split into two kinds and each says which it is:
+ *
+ *   BEHAVIOURAL (real, runs here): parameterisation, the returned mapping, and attnum ordering.
+ *   SHAPE (a text assertion, deliberately): that BOTH filters are present in the query.
+ *
+ * The shape assertions are not a lazy substitute for a database test — a database test would be
+ * WORSE. The vitest `db` project is DISABLED in this repo (no designated non-production target),
+ * so tests/integration/** resolves to ZERO FILES and a DB-backed test would SKIP AND REPORT GREEN.
+ * A test that cannot run is not stronger than a text assertion that can; it is weaker, because it
+ * looks stronger. The measured numbers above are recorded here so the next reader can re-derive
+ * the class without re-discovering it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readColumns } from '../../../scripts/severity-pair-divergence-fence.mjs';
+
+/** Records the SQL and params instead of connecting. */
+function fakeClient(rows = []) {
+  const calls = [];
+  return {
+    calls,
+    query: async (sql, params) => { calls.push({ sql, params }); return { rows }; },
+  };
+}
+
+describe('readColumns — BEHAVIOURAL (these genuinely execute)', () => {
+  it('binds the relation name as a PARAMETER, never string-concatenated', async () => {
+    // The one security-relevant property, and the only one a double can actually witness.
+    const c = fakeClient([]);
+    await readColumns(c, "feedback'; drop table x; --");
+    expect(c.calls).toHaveLength(1);
+    expect(c.calls[0].params, 'the relation name must arrive as a bound parameter').toEqual(["feedback'; drop table x; --"]);
+    expect(c.calls[0].sql, 'and must NOT be interpolated into the SQL text').not.toContain('drop table');
+    expect(c.calls[0].sql).toMatch(/\$1/);
+  });
+
+  it('returns the attnames, in the order the catalog returned them', async () => {
+    // ORDER IS LOAD-BEARING and not decoration: the query orders by attnum so the two sides of a
+    // parity comparison are read in a stable, comparable order.
+    const c = fakeClient([{ attname: 'id' }, { attname: 'severity' }, { attname: 'created_at' }]);
+    expect(await readColumns(c, 'feedback')).toEqual(['id', 'severity', 'created_at']);
+  });
+
+  it('an empty catalog read returns [] — and the comparator turns THAT into UNREADABLE', async () => {
+    // readColumns must NOT invent a fallback. Returning [] is what lets compareViewBaseParity
+    // report UNREADABLE rather than a vacuous AGREES over an empty base list.
+    expect(await readColumns(fakeClient([]), 'nope')).toEqual([]);
+  });
+});
+
+describe('readColumns — SHAPE (text assertions, and here is why that is the strongest available)', () => {
+  /** The SQL the function actually issues, captured through the injected client. */
+  async function capturedSql() {
+    const c = fakeClient([]);
+    await readColumns(c, 'anything');
+    return c.calls[0].sql;
+  }
+
+  it('filters attnum > 0 — WITHOUT IT every base table gains its six system columns', async () => {
+    // Measured: issue_patterns 29 -> 35. Views gain none, so the base side inflates alone and
+    // EVERY pair reports DIVERGED forever.
+    expect(await capturedSql(), 'system columns (ctid, xmin, …) would inflate every BASE side only')
+      .toMatch(/attnum\s*>\s*0/);
+  });
+
+  it('filters NOT attisdropped — WITHOUT IT a dropped-but-unvacuumed column reads as present', async () => {
+    // The subtler half: a column DROPped from the base but not yet vacuumed still has a
+    // pg_attribute row. Counting it makes the base side claim a column the view could not
+    // possibly expose — a divergence that describes a ghost.
+    expect(await capturedSql()).toMatch(/not\s+a?\.?attisdropped/i);
+  });
+
+  it('scopes to the public schema and joins through pg_class/pg_namespace', async () => {
+    // Without the namespace join, a same-named relation in another schema can answer for this one —
+    // and the parity verdict would then describe a table nobody asked about.
+    const sql = await capturedSql();
+    expect(sql).toMatch(/pg_attribute/);
+    expect(sql).toMatch(/pg_class/);
+    expect(sql).toMatch(/pg_namespace/);
+    expect(sql).toMatch(/nspname\s*=\s*'public'/);
+  });
+
+  it('orders by attnum, so both sides of a parity read are comparable', async () => {
+    expect(await capturedSql()).toMatch(/order\s+by\s+a?\.?attnum/i);
+  });
+});


### PR DESCRIPTION
Follow-through from `SD-LEO-INFRA-OWNERSHIP-PRESERVATION-ASSERTION-001` completion flag `0af4cb6f`,
coordinator-assigned and ruled GO.

## The gap

`readColumns()` builds the `pg_attribute`/`pg_class` query the entire view-vs-base column-parity
detector depends on — and **nothing exercised it**. Every prior assertion about that file was a
regex over source text or a hand-fed test of the pure comparator. Verified: both filter-removal
mutations stayed **green across the whole unit project**.

## The class, measured on PG 17.4 against the live catalog

| relation | with filters | without |
|---|---|---|
| `issue_patterns` (base) | 29 | **35** (six system columns) |
| `v_patterns_with_decay` (view) | 30 | 30 |

Dropping `attnum > 0` or `NOT attisdropped` adds six to every **base** side and zero to every
**view** side — so every pair reads permanently DIVERGED, across all ~185 views. A detector that
fires on everything is exactly as useless as one that fires on nothing, and it's the failure mode
that trains readers to ignore the alert.

## What a unit test can honestly claim here

**The filters execute server-side**, so no injected double can witness Postgres excluding a system
column — the filtering isn't in the JS. The assertions are therefore split and labelled:

- **BEHAVIOURAL** (genuinely execute): parameter binding, the returned mapping, `attnum` ordering,
  and `[]` on an empty read — so the comparator can still reach UNREADABLE rather than a vacuous
  AGREES over an empty base list.
- **SHAPE** (text assertions, deliberately): both filters present in the emitted SQL.

The shape assertions are **not** a lazy substitute for a database test — a database test would be
*worse*. The vitest `db` project is disabled here, so `tests/integration/**` resolves to zero files
and a DB-backed test would **skip and report green**. A test that cannot run isn't stronger than a
text assertion that can; it's weaker, because it looks stronger. The measured numbers are recorded
in the test file so the next reader can re-derive the class instead of re-discovering it.

`readColumns` is exported solely to make it reachable — it already took an injectable client.

## Mutation-proven

Three mutations verified red, each reverted with zero residue:
- drop `attnum > 0` → the system-column assertion fails
- drop `NOT attisdropped` → the ghost-column assertion fails
- string-concatenate the relation name instead of binding `$1` → the parameterisation test fails
  (the one security-relevant property a double can actually witness)

267 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)