### PR TITLE
QF-20260807-992: the drive-report producer's entry guard never fired on Windows — exit 0, no output, no row

### DIFF
--- a/scripts/drive-report-produce.mjs
+++ b/scripts/drive-report-produce.mjs
@@ -25,6 +25,8 @@
  */
 
 import { composeReport } from '../lib/drive-loop/compose-report.js';
+// QF-20260807-992: the canonical cross-platform entry guard — see the CLI block at the bottom.
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 /**
  * @param {object} o
@@ -68,7 +70,25 @@ export async function produceDriveReport({ gather, persist, findExisting = null,
 
 // CLI entry only. Nothing above touches a network or a clock, so the whole decision surface is
 // testable; this block is the thin edge that supplies the real ones.
-if (import.meta.url === `file://${process.argv[1]}`.replace(/\\/g, '/')) {
+//
+// QF-20260807-992 — THIS GUARD USED TO BE HAND-ROLLED AND NEVER FIRED ON WINDOWS.
+// It read: import.meta.url === `file://${process.argv[1]}`.replace(/\\/g, '/')
+// PROVEN on both platforms rather than argued: on Windows that template builds
+// `file://C:/Users/...` — TWO slashes — while import.meta.url is `file:///C:/Users/...` — THREE.
+// No match, so main() never ran: the producer exited 0, printed NOTHING, and wrote NO ROW. On
+// Linux both render `file:///home/...`, which is why the GHA path was unaffected and the defect
+// stayed invisible for as long as nobody ran it by hand.
+//
+// That silence is the whole danger. An entry point that never fires is indistinguishable from a
+// run that had nothing to do — and this is the ONLY writer of drive_reports, so the empty table
+// would have been blamed on the chairman-gated migration (applied 18:20Z) rather than on a guard.
+// The same hand-rolled pattern printed nothing and exited 0 in a reaper script earlier the same
+// day (QF-20260807-190); recognising the exit-0-no-output signature from that is the only reason
+// this was caught instead of filed as a successful verification.
+//
+// pathToFileURL is Node's own encoder — the same one import.meta.url is built with — so it also
+// survives spaces, '#' and unicode in a path, which a manual slash-replace silently mis-encodes.
+if (isMainModule(import.meta.url)) {
   const { createClient } = await import('@supabase/supabase-js');
   const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
   const runId = process.env.GITHUB_RUN_ID || process.env.DRIVE_RUN_ID;

--- a/tests/unit/drive-loop/produce-entry-guard.test.js
+++ b/tests/unit/drive-loop/produce-entry-guard.test.js
@@ -1,0 +1,107 @@
+/**
+ * QF-20260807-992 — the drive-report producer's CLI entry guard must FIRE, on every platform.
+ *
+ * THE DEFECT: scripts/drive-report-produce.mjs:71 hand-rolled the guard as
+ *   import.meta.url === `file://${process.argv[1]}`.replace(/\\/g, '/')
+ * On Windows that builds `file://C:/…` (TWO slashes) against an import.meta.url of
+ * `file:///C:/…` (THREE). It never matched, so main() never ran: exit 0, no output, NO ROW
+ * written. On Linux both render `file:///home/…`, so the GHA path worked and the defect was
+ * invisible until someone ran it by hand.
+ *
+ * WHY THE ASSERTIONS BELOW ARE POSITIVE, NOT NEGATIVE — this is the coordinator's explicit
+ * instruction and it is the difference between a real proof and a comfortable one: it is not
+ * enough to show the guard "stopped not-firing". A guard that returns false for EVERYTHING also
+ * stops not-firing, and would pass any test that only checks the old expression is gone. So the
+ * load-bearing case asserts the guard returns TRUE for a Windows-shaped argv — the exact input
+ * that used to produce false.
+ *
+ * The producer is the ONLY writer of drive_reports. An entry point that never fires is
+ * indistinguishable from a run with nothing to do, so an empty table reads as "the migration is
+ * still gated" rather than "the guard is broken" — which is precisely how this survived.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { isMainModule } from '../../../lib/utils/is-main-module.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const PRODUCER = path.resolve(__dirname, '../../../scripts/drive-report-produce.mjs');
+const SRC = readFileSync(PRODUCER, 'utf8');
+
+// The exact broken expression, reproduced so the two can be compared on identical input rather
+// than described in prose.
+const handRolled = (argv1) => `file://${argv1}`.replace(/\\/g, '/');
+
+const origArgv1 = process.argv[1];
+afterEach(() => { process.argv[1] = origArgv1; });
+
+describe('QF-20260807-992 — producer entry guard fires cross-platform', () => {
+  it('FIRES for a Windows argv path — the case that used to silently return false', () => {
+    const winPath = String.raw`C:\Users\rickf\Projects\_EHG\EHG_Engineer\scripts\drive-report-produce.mjs`;
+    process.argv[1] = winPath;
+    const metaUrl = pathToFileURL(winPath).href;
+
+    // THE LOAD-BEARING ASSERTION. Positive, on the exact input that broke.
+    expect(isMainModule(metaUrl)).toBe(true);
+
+    // And the counter-demonstration on the SAME input: the old expression disagrees, which is the
+    // defect stated as a comparison rather than as a claim.
+    expect(handRolled(winPath)).toBe('file://C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/drive-report-produce.mjs');
+    expect(metaUrl).toBe('file:///C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/drive-report-produce.mjs');
+    expect(handRolled(winPath) === metaUrl, 'the old guard must be shown FAILING here').toBe(false);
+  });
+
+  it('FIRES for a POSIX-shaped argv path — the platform that always worked must not regress', () => {
+    // NOTE: asserted against the HOST's own resolution, not a hardcoded POSIX URL. My first
+    // version expected 'file:///home/...' and failed here, because pathToFileURL on Windows
+    // resolves a leading-slash path against the current drive ('file:///C:/home/...'). The
+    // property under test — the guard agrees with whatever Node derives from argv[1] — is
+    // host-independent; the literal URL string is not, and hardcoding it tests the host instead
+    // of the guard.
+    const posixPath = '/home/runner/work/EHG_Engineer/scripts/drive-report-produce.mjs';
+    process.argv[1] = posixPath;
+    expect(isMainModule(pathToFileURL(posixPath).href)).toBe(true);
+  });
+
+  it('FIRES for paths with spaces and unicode, which the manual replace mis-encodes', () => {
+    // Not decoration: pathToFileURL applies Node's own percent-encoding — the same encoder
+    // import.meta.url is built with — while a slash-replace leaves the raw bytes.
+    const spaced = String.raw`C:\Users\Rick Felix\proj\drive-report-produce.mjs`;
+    process.argv[1] = spaced;
+    const metaUrl = pathToFileURL(spaced).href;
+    expect(isMainModule(metaUrl)).toBe(true);
+    expect(metaUrl).toContain('%20');
+    expect(handRolled(spaced) === metaUrl).toBe(false);
+  });
+
+  it('does NOT fire when the module is imported rather than executed', () => {
+    // The guard must still be a guard. A predicate that returns true for everything would pass
+    // every assertion above and make the producer run on import.
+    process.argv[1] = String.raw`C:\Users\rickf\some\other-entrypoint.mjs`;
+    const someModule = pathToFileURL(String.raw`C:\Users\rickf\lib\imported-module.mjs`).href;
+    expect(isMainModule(someModule)).toBe(false);
+  });
+
+  it('does NOT fire when argv[1] is absent (embedded / -e / REPL)', () => {
+    process.argv[1] = undefined;
+    expect(isMainModule('file:///anything.mjs')).toBe(false);
+  });
+
+  it('the producer imports the canonical guard and no hand-rolled template survives IN CODE', () => {
+    expect(SRC).toMatch(/import \{ isMainModule \} from '\.\.\/lib\/utils\/is-main-module\.js'/);
+    expect(SRC).toMatch(/if \(isMainModule\(import\.meta\.url\)\)/);
+
+    // COMMENTS ARE STRIPPED BEFORE THE SCAN, and that is not a convenience. My first version
+    // scanned the raw source and went RED — because the fix's own comment QUOTES the broken
+    // expression to explain what was wrong. The documentation of a defect tripped the detector for
+    // that defect. Same shape as a cron `*/15` silently closing a block comment: prose about code,
+    // read as code. The pin must assert about what SHIPS.
+    const code = SRC.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/^\s*\/\/.*$/gm, ' ');
+    expect(code, 'a hand-rolled file:// entry guard reappeared in executable code')
+      .not.toMatch(/`file:\/\/\$\{process\.argv\[1\]\}`/);
+    // Two-sided: prove the stripper did not simply eat everything, or the assertion above is
+    // vacuous and would pass against a file that reintroduced the bug.
+    expect(code).toMatch(/isMainModule\(import\.meta\.url\)/);
+  });
+});

--- a/tests/unit/drive-loop/produce-entry-guard.test.js
+++ b/tests/unit/drive-loop/produce-entry-guard.test.js
@@ -40,16 +40,21 @@ describe('QF-20260807-992 — producer entry guard fires cross-platform', () => 
   it('FIRES for a Windows argv path — the case that used to silently return false', () => {
     const winPath = String.raw`C:\Users\rickf\Projects\_EHG\EHG_Engineer\scripts\drive-report-produce.mjs`;
     process.argv[1] = winPath;
-    const metaUrl = pathToFileURL(winPath).href;
 
-    // THE LOAD-BEARING ASSERTION. Positive, on the exact input that broke.
-    expect(isMainModule(metaUrl)).toBe(true);
+    // THE LOAD-BEARING ASSERTION, and it is HOST-INDEPENDENT: the guard must agree with whatever
+    // Node's own encoder derives from argv[1]. That is the actual contract — isMainModule delegates
+    // to pathToFileURL, the same encoder import.meta.url is built with — and it holds on every
+    // platform. The old expression did NOT delegate, which is the entire defect.
+    expect(isMainModule(pathToFileURL(winPath).href)).toBe(true);
 
-    // And the counter-demonstration on the SAME input: the old expression disagrees, which is the
-    // defect stated as a comparison rather than as a claim.
+    // THE DEFECT, DEMONSTRATED AS PURE STRING MATH so it is valid on any host. Do NOT rebuild the
+    // expected URL with pathToFileURL here: on Linux a backslash string is a RELATIVE filename, so
+    // it yields file:///home/runner/…/C:\Users\… and the comparison would test the host instead of
+    // the guard. WINDOWS_CORRECT is what Node emits for this path ON Windows, written as a literal
+    // precisely because it is the other platform's answer.
+    const WINDOWS_CORRECT = 'file:///C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/drive-report-produce.mjs';
     expect(handRolled(winPath)).toBe('file://C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/drive-report-produce.mjs');
-    expect(metaUrl).toBe('file:///C:/Users/rickf/Projects/_EHG/EHG_Engineer/scripts/drive-report-produce.mjs');
-    expect(handRolled(winPath) === metaUrl, 'the old guard must be shown FAILING here').toBe(false);
+    expect(handRolled(winPath), 'two slashes vs three — the old guard can never match').not.toBe(WINDOWS_CORRECT);
   });
 
   it('FIRES for a POSIX-shaped argv path — the platform that always worked must not regress', () => {


### PR DESCRIPTION
**CRITICAL PATH.** This is the only writer of `drive_reports`, whose migration the chairman applied at 18:20Z. Until this fix the producer could not be run by hand on a non-Linux seat at all — which is the path the coordinator needs tonight, since the GHA route is window-gated.

### The defect, proven on both platforms rather than argued

Line 71 hand-rolled the ESM entry guard. On Windows the template builds `file://C:/…` (**two** slashes) while `import.meta.url` is `file:///C:/…` (**three**) — no match, `main()` never ran, the process exited 0 and printed nothing. On Linux both render `file:///home/…`, so the GHA path worked and the defect stayed invisible until someone ran it by hand.

### Why it survived

An entry point that never fires is **indistinguishable from a run with nothing to do**. The empty `drive_reports` table read as "the chairman-gated migration hasn't landed" — a story that was true for weeks and had just stopped being true. The coordinator's GHA dispatch (run 31207150740) then went **green while producing nothing**, because the sweep's ET window skipped it. Two different false greens over the same empty table, each with a plausible innocent explanation.

### Proof the fix FIRES, not merely stops not-firing

The coordinator asked for exactly this distinction, and it matters — a guard that returns false for everything also "stops not-firing". Running the producer from a Windows seat now reaches real business logic and throws `produceDriveReport(): runId is required`, the correct behaviour for a manual invocation with no run id. Before: silence.

The test asserts **positively** that `isMainModule` returns `true` for a Windows-shaped argv, and demonstrates the old expression returning `false` on that same input. It also covers POSIX, spaces/unicode (which a slash-replace mis-encodes but `pathToFileURL` — Node's own encoder, the one `import.meta.url` is built with — handles), the imported-not-executed case, and absent `argv[1]`.

### Two defects in my own test, found and fixed

- I hardcoded a POSIX expectation (`file:///home/…`) which fails on a Windows host, because `pathToFileURL` resolves a leading-slash path against the current drive. The property under test is host-independent; the literal URL is not.
- My regression pin scanned the raw source and went **red — because this fix's own comment quotes the broken expression to explain it.** The documentation of a defect tripped the detector for that defect, the same shape as a cron `*/15` silently closing a block comment. Comments are stripped before the scan now, with a two-sided check so the stripper can't make the assertion vacuous.

**229 tests green** across all 18 suites that import the producer or the guard.

### Separate finding — reported, not fixed here

`scripts/lint/ismainmodule-classguard-lint.mjs` scans 2162 files and reports **"0 ungoverned violations" with this exact pattern reintroduced into the producer**. Measured by mutation, not inferred. Its allowlist is empty and its own doc claims 100% coverage of `scripts/**` — so a guard built for precisely this defect ran in CI, went green, and missed it. The `scripts/archive/**` hits are legitimately excluded, so the producer was the only live site. That deserves its own QF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)