### PR TITLE
fix(QF-20260807-594): stem false-high UAT filings at the faucet, and fold re-files by finding identity

### DIFF
--- a/lib/quick-fix/uat-filing-gate.js
+++ b/lib/quick-fix/uat-filing-gate.js
@@ -1,0 +1,181 @@
+/**
+ * Faucet-side gate for UAT filings. QF-20260807-594.
+ *
+ * MEASURED, twice and independently: every quick-fix arriving in the last 7 days was filed by
+ * UAT_AGENT (96/96), and 58 of them (60%) came in at high or critical. The coordinator's own
+ * count a few hours earlier was 85/85 at the same 60%. So this is not a spike — it is the
+ * steady-state arrival shape, and the drain cannot outrun it.
+ *
+ * TWO RULES, BOTH AT THE FILING SITE. The drain side is deliberately untouched: re-grading the
+ * existing backlog would rewrite history that people have already triaged against, and the
+ * ratified ruling is explicit that the standing HIGH backlog stays as-is.
+ *
+ * RULE 1 — SEVERITY (ratified 2026-08-03). HIGH is for MEASURED harm to work or safety.
+ * Everything else files medium and is still routed; nothing is dropped, nothing is silenced.
+ *
+ * RULE 2 — DEDUP KEYED ON FINDING IDENTITY, NEVER ON SURFACE ALONE. This is the whole design
+ * risk and it is worth being explicit about. A fold keyed on "which file/page was this about"
+ * silences every later finding on that surface forever — the first report about a page makes
+ * the page permanently un-reportable. Ask what state would silence the alarm: with a
+ * surface-key, the answer is "one filing, ever". So identity here is derived from WHAT THE
+ * FINDING SAYS (title + expected + actual), not from where it was found, and a genuinely new
+ * finding on an already-filed surface has a different identity and still arrives.
+ *
+ * ON THE HONESTY OF RULE 1. The severity test below is a HEURISTIC over free text, not a proof.
+ * It cannot know whether harm was truly measured; it can only see whether the filing SHOWS a
+ * measurement. It is built to fail toward `medium` — the recoverable direction, since a
+ * medium that should have been high still arrives and is still routed, whereas a high that
+ * should have been medium consumes the scarce attention this whole QF exists to protect.
+ * The audited override exists precisely because the heuristic will be wrong sometimes.
+ */
+
+/** Severities this gate may downgrade. */
+export const ELEVATED = Object.freeze(['high', 'critical']);
+
+/** The severity everything else files at. Still routed — this is a downgrade, not a drop. */
+export const DEFAULT_SEVERITY = 'medium';
+
+/**
+ * Harm that is harm BY CLASS. Data loss and security do not need a stopwatch to be serious, and
+ * a gate that demanded one would push exactly the wrong findings down. Failing toward HIGH here
+ * is the safe direction.
+ */
+const INTRINSIC_HARM = /\b(data[ -]?loss|corrupt(?:s|ed|ion)?|credential|secret|security|\brls\b|auth[a-z]*|privilege|leak(?:s|ed|ing)?|breach|unrecoverable|irreversible|destroy(?:s|ed)?|silently (?:wrong|drops?|discards?)|incorrect result)\b/i;
+
+/**
+ * Harm to WORK — real, but only countable harm distinguishes "this blocked a seat for an hour"
+ * from "this is untidy". These require a quantity to hold HIGH.
+ */
+const WORK_HARM = /\b(block(?:s|ed|ing)?|stall(?:s|ed|ing)?|strand(?:s|ed|ing)?|wedge[ds]?|hang(?:s|ing)?|crash(?:es|ed|ing)?|stuck|outage|deadlock|cannot|unable|prevent(?:s|ed)?|breaks?|broken)\b/i;
+
+/**
+ * Evidence that something was actually COUNTED. This is what separates a measurement from an
+ * adjective — "slow" is a feeling, "adds 40 min per handoff" is a measurement.
+ */
+const QUANTITY = /\b\d+(?:\.\d+)?\s*(?:%|percent|x\b|times|min(?:ute)?s?|hours?|hrs?|secs?|seconds?|days?|weeks?|rows?|files?|seats?|workers?|sessions?|runs?|prs?|sds?|qfs?|tests?|commits?|occurrences?|instances?|calls?|times per)\b/i;
+
+/**
+ * Does this filing SHOW measured harm to work or safety?
+ * @param {string} text
+ * @returns {{measured:boolean, basis:string}}
+ */
+export function hasMeasuredHarm(text) {
+  const t = String(text || '');
+  if (INTRINSIC_HARM.test(t)) return { measured: true, basis: 'intrinsic-harm-class (safety/data)' };
+  const harm = WORK_HARM.test(t);
+  const qty = QUANTITY.test(t);
+  if (harm && qty) return { measured: true, basis: 'work-harm with a quantity' };
+  if (harm) return { measured: false, basis: 'harm asserted but never quantified' };
+  return { measured: false, basis: 'no harm to work or safety described' };
+}
+
+/**
+ * Apply the ratified severity rule.
+ *
+ * Returns the severity to file at plus a REASON — the downgrade must be visible at the filing
+ * site and recorded on the row. A gate that silently rewrites a field teaches nobody anything
+ * and is indistinguishable, to the filer, from having been ignored.
+ *
+ * @param {{severity:string,title?:string,description?:string,expected?:string,actual?:string,steps?:string}} f
+ * @param {{override?:string}} [opts] override = audited justification that keeps the elevated severity
+ * @returns {{severity:string, downgraded:boolean, from:string, reason:string, basis:string}}
+ */
+export function applySeverityRule(f = {}, opts = {}) {
+  const from = String(f.severity || '').toLowerCase();
+  if (!ELEVATED.includes(from)) {
+    return { severity: from, downgraded: false, from, reason: 'not an elevated severity', basis: 'n/a' };
+  }
+  const text = [f.title, f.description, f.expected, f.actual, f.steps].filter(Boolean).join('\n');
+  const { measured, basis } = hasMeasuredHarm(text);
+  if (measured) {
+    return { severity: from, downgraded: false, from, reason: `measured harm shown: ${basis}`, basis };
+  }
+  if (opts.override) {
+    return { severity: from, downgraded: false, from, reason: `audited override: ${opts.override}`, basis };
+  }
+  return {
+    severity: DEFAULT_SEVERITY,
+    downgraded: true,
+    from,
+    basis,
+    reason: `filed ${DEFAULT_SEVERITY}, not ${from}: ${basis}. HIGH is reserved for MEASURED harm to work or safety (ratified 2026-08-03). Still routed — nothing is dropped. If harm WAS measured, say so with a number and re-file, or pass an audited justification.`
+  };
+}
+
+/** Words too common to carry finding identity. Kept small on purpose — an aggressive stoplist
+ *  erases the very nouns that distinguish two findings on one surface. */
+const STOP = new Set(['the', 'and', 'for', 'that', 'this', 'with', 'from', 'when', 'then', 'than',
+  'has', 'have', 'was', 'were', 'are', 'but', 'not', 'its', 'it', 'a', 'an', 'is', 'of', 'to',
+  'in', 'on', 'at', 'by', 'be', 'as', 'or', 'if', 'so', 'we', 'you', 'should', 'would', 'could',
+  'will', 'does', 'did', 'can', 'into', 'over', 'after', 'before', 'because']);
+
+/**
+ * Significant tokens of a text — lowercased, punctuation-stripped, stopworded, length>=3.
+ *
+ * NUMBERS ARE KEPT AT ANY LENGTH, and that exception is load-bearing rather than tidy-up. The
+ * plain length>=3 filter silently ate "3" and "30", which made "gate allows 3 retries" and
+ * "gate allows 30 retries" identical to this function — two different findings collapsing into
+ * one, in the very code whose job is to tell findings apart. The control test caught it; the
+ * docstring had already claimed digits were preserved while the filter was quietly dropping
+ * them, which is the more useful half of the lesson.
+ *
+ * @param {string} text
+ * @returns {Set<string>}
+ */
+export function findingTokens(text) {
+  return new Set(
+    String(text || '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .split(' ')
+      .filter((w) => (/^\d+$/.test(w) || w.length >= 3) && !STOP.has(w))
+  );
+}
+
+/**
+ * The identity of a finding: what it CLAIMS, not where it was found.
+ * @param {{title?:string,expected?:string,actual?:string}} f
+ * @returns {Set<string>}
+ */
+export function findingIdentity(f = {}) {
+  return findingTokens([f.title, f.expected, f.actual].filter(Boolean).join(' '));
+}
+
+/**
+ * Jaccard overlap of two token sets. 1 = identical vocabulary, 0 = disjoint.
+ * @returns {number}
+ */
+export function similarity(a, b) {
+  if (!a?.size || !b?.size) return 0;
+  let shared = 0;
+  for (const t of a) if (b.has(t)) shared++;
+  return shared / (a.size + b.size - shared);
+}
+
+/**
+ * Default fold threshold. Deliberately HIGH: the cost of folding a real new finding (it never
+ * arrives, and nobody knows) is far worse than the cost of one near-duplicate getting through
+ * (a human sees two similar rows and closes one).
+ */
+export const DUPLICATE_THRESHOLD = 0.82;
+
+/**
+ * Find an already-filed QF that is the SAME FINDING as this one.
+ *
+ * @param {{title?:string,expected?:string,actual?:string}} candidate
+ * @param {Array<{id:string,title?:string,expected_behavior?:string,actual_behavior?:string,status?:string}>} rows
+ * @param {{threshold?:number}} [opts]
+ * @returns {{row:object, score:number}|null}
+ */
+export function findDuplicateFinding(candidate, rows, opts = {}) {
+  const threshold = Number.isFinite(opts.threshold) ? opts.threshold : DUPLICATE_THRESHOLD;
+  const mine = findingIdentity(candidate);
+  if (!mine.size) return null; // nothing to compare — never fold on an empty identity
+  let best = null;
+  for (const r of rows || []) {
+    const theirs = findingIdentity({ title: r.title, expected: r.expected_behavior, actual: r.actual_behavior });
+    const score = similarity(mine, theirs);
+    if (score >= threshold && (!best || score > best.score)) best = { row: r, score };
+  }
+  return best;
+}

--- a/scripts/create-quick-fix.js
+++ b/scripts/create-quick-fix.js
@@ -33,6 +33,10 @@ import { checkFeedbackPremiseLiveness, logForceLivenessOverride } from '../lib/e
 import { normalizeToUTC } from './hooks/stop-subagent-enforcement/time-utils.js';
 import { renderCount } from '../lib/db/fetch-all-paginated.mjs';
 import { loadActiveApplications, validateTargetApplication, detectMisdesignation } from '../lib/fleet/qf-target-application.js';
+// QF-20260807-594: faucet-side severity rule + finding-identity dedup. 96/96 of last-7d
+// arrivals are UAT filings and 60% come in elevated; both gates live HERE, at the filing
+// site, because the drain cannot outrun the faucet.
+import { applySeverityRule, findDuplicateFinding } from '../lib/quick-fix/uat-filing-gate.js';
 
 // Cross-platform path resolution (SD-WIN-MIG-005 fix)
 const __filename = fileURLToPath(import.meta.url);
@@ -168,6 +172,22 @@ async function createQuickFix(options = {}) {
     console.log(`   Valid severities: ${validSeverities.join(', ')}`);
     process.exit(1);
   }
+
+  // QF-20260807-594 RULE 1 — severity at the filing site. HIGH is for MEASURED harm to work or
+  // safety (ratified 2026-08-03); everything else files medium and is STILL ROUTED. Applied
+  // here, before routing and insert, so the tier decision downstream sees the real severity.
+  // The downgrade is announced rather than applied silently: a quietly rewritten field is
+  // indistinguishable, to the filer, from having been ignored, and teaches nobody the rule.
+  const severityVerdict = applySeverityRule(
+    { severity, title, description, expected, actual, steps },
+    { override: options.severityJustification }
+  );
+  if (severityVerdict.downgraded) {
+    console.log(`\n⚠️  [SEVERITY_RULE] ${severityVerdict.from} → ${severityVerdict.severity}`);
+    console.log(`   ${severityVerdict.reason}`);
+    console.log('   Override (audited): --severity-justification "<the measured harm>"');
+  }
+  severity = severityVerdict.severity;
 
   // EVA Pre-Check: warn if vision/architecture docs exist for this topic
   try {
@@ -325,6 +345,55 @@ async function createQuickFix(options = {}) {
         }
         console.warn(`\n⚠️  [ALLOW_DUPLICATE] proceeding anyway: ${options.allowDuplicate}`);
       }
+    }
+
+    // QF-20260807-594 RULE 2 — fold a RE-FILED FINDING, keyed on finding IDENTITY.
+    //
+    // The gate above keys on a 40-char title prefix inside a 60-minute window; that catches a
+    // double-submit but not the same finding arriving again on Thursday. Widening THAT gate
+    // would have been the cheap move and the wrong one: a surface-keyed fold with a long window
+    // silences every later finding about the same page forever. Ask what state would silence
+    // the alarm — with a surface key the answer is "one filing, ever".
+    //
+    // So this keys on what the finding CLAIMS (title + expected + actual), not where it was
+    // found. A genuinely new finding on an already-filed surface has a different identity and
+    // still arrives; that is a required acceptance side, not a nice-to-have.
+    //
+    // Fails OPEN, matching every other scan on this hot path: a DB error must never brick QF
+    // creation. Note that failing open here means UNDER-folding, which is the recoverable
+    // direction — a duplicate that gets through is visible, a real finding that never arrives
+    // is not.
+    // NO TIME WINDOW, and that is a correction rather than an oversight. This first shipped with
+    // a 7-day window, and the wiring proof happened to replay a 10-day-old open QF straight
+    // through it — the gate stayed silent on an exact duplicate. AGE IS THE WRONG KEY: an OPEN
+    // quick-fix is unfixed no matter when it was filed, so re-filing it is a duplicate on day 8
+    // exactly as much as on day 6. A window here buys nothing and leaves a hole that widens
+    // every day. Status is the gate. The set is small (~157 open repo-wide) and explicitly
+    // capped below so this can never silently measure the cap instead of the population.
+    const DUP_SCAN_CAP = 2000;
+    try {
+      const { data: recent, error: dupErr } = await supabase
+        .from('quick_fixes').select('id, title, expected_behavior, actual_behavior, status, created_at')
+        .in('status', ['open', 'in_progress']).limit(DUP_SCAN_CAP);
+      if (dupErr) throw dupErr;
+      if ((recent || []).length >= DUP_SCAN_CAP) {
+        console.warn(`\n⚠️  [FINDING_DEDUP_TRUNCATED] open-QF scan hit its ${DUP_SCAN_CAP}-row cap; dedup saw a subset, not the population.`);
+      }
+      const hit = findDuplicateFinding({ title, expected, actual }, recent || []);
+      if (hit) {
+        console.error(`\n❌ [DUPLICATE_FINDING] this finding was already filed as ${hit.row.id} (${hit.row.status}):`);
+        console.error(`     ${(hit.row.title || '').slice(0, 90)}`);
+        console.error(`   identity overlap ${(hit.score * 100).toFixed(0)}% — keyed on the FINDING, not the surface.`);
+        console.error('   A genuinely different finding on this same surface would not match here.');
+        if (!options.allowDuplicate) {
+          console.error('   Inspect: node scripts/read-quick-fix.js ' + hit.row.id);
+          console.error('   Override (audited): --allow-duplicate "<reason>"');
+          process.exit(1);
+        }
+        console.warn(`\n⚠️  [ALLOW_DUPLICATE] proceeding anyway: ${options.allowDuplicate}`);
+      }
+    } catch (e) {
+      console.warn(`\n⚠️  [FINDING_DEDUP_DEGRADED] identity dedup failed-open (${e?.message || e}); proceeding without it.`);
     }
   }
 
@@ -719,6 +788,10 @@ for (let i = 0; i < args.length; i++) {
     options.type = args[++i];
   } else if (arg === '--severity') {
     options.severity = args[++i];
+  } else if (arg === '--severity-justification') {
+    // QF-20260807-594: audited escape from the severity rule. The rule is a heuristic over
+    // free text and will sometimes be wrong; this is how a real HIGH gets filed anyway.
+    options.severityJustification = args[++i];
   } else if (arg === '--description') {
     options.description = args[++i];
   } else if (arg === '--steps') {
@@ -767,6 +840,8 @@ Options:
   --title                Issue title
   --type                 Issue type (bug, polish, typo, documentation)
   --severity             Severity (critical, high, medium, low)
+  --severity-justification  Audited override for the severity rule; high/critical is otherwise
+                         reserved for MEASURED harm to work or safety and files medium instead.
   --description          Brief description
   --steps                Steps to reproduce
   --expected             Expected behavior

--- a/tests/unit/quick-fix/uat-filing-gate.test.js
+++ b/tests/unit/quick-fix/uat-filing-gate.test.js
@@ -1,0 +1,178 @@
+/**
+ * QF-20260807-594 — the three-sided acceptance, plus the arms that keep it from lying.
+ *
+ * THE RATIFIED ACCEPTANCE HAS THREE SIDES, ALL REQUIRED:
+ *   (a) a synthetic MEASURED-HARM finding still files HIGH
+ *   (b) a synthetic COSMETIC finding files medium
+ *   (c) a genuinely NEW DISTINCT finding on a previously-filed surface STILL ARRIVES
+ *
+ * (c) IS VACUOUS ON ITS OWN AND THAT IS THE WHOLE TRAP. If the dedup never folds anything, (c)
+ * passes trivially and the suite reports success for a gate that does nothing. So every
+ * "still arrives" assertion below is paired with a "and this one DOES fold" assertion built on
+ * the same code path. A one-sided dedup test cannot tell a working fold from an absent one.
+ *
+ * Likewise (a) and (b) are two halves of one control: a rule that downgraded EVERYTHING would
+ * pass (b) alone, and a rule that downgraded NOTHING would pass (a) alone. Neither is a gate.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  applySeverityRule, hasMeasuredHarm, findingIdentity, similarity,
+  findDuplicateFinding, DEFAULT_SEVERITY, DUPLICATE_THRESHOLD
+} from '../../../lib/quick-fix/uat-filing-gate.js';
+
+const MEASURED = {
+  severity: 'high',
+  title: 'Handoff gate blocks every new SD on first run',
+  expected: 'the gate passes on a clean tree',
+  actual: 'it blocks the handoff and costs roughly 40 minutes per SD across 6 seats'
+};
+
+const COSMETIC = {
+  severity: 'high',
+  title: 'Dashboard header spacing is inconsistent',
+  expected: 'the header aligns with the table below it',
+  actual: 'it sits a few pixels off and looks untidy'
+};
+
+describe('(a) measured harm still files HIGH', () => {
+  it('keeps high when the filing shows a quantity attached to real work harm', () => {
+    const out = applySeverityRule(MEASURED);
+    expect(out.severity).toBe('high');
+    expect(out.downgraded).toBe(false);
+  });
+
+  it('keeps high for safety/data classes WITHOUT demanding a stopwatch', () => {
+    // Failing toward HIGH here is deliberate: requiring a number would push exactly the
+    // findings that matter most into medium.
+    const out = applySeverityRule({
+      severity: 'critical', title: 'Session tokens written to the shared log',
+      actual: 'a credential leak — anyone reading the log can reuse them'
+    });
+    expect(out.severity).toBe('critical');
+    expect(out.downgraded).toBe(false);
+  });
+
+  it('critical is treated as elevated too, not just high', () => {
+    expect(applySeverityRule({ ...COSMETIC, severity: 'critical' }).downgraded).toBe(true);
+  });
+});
+
+describe('(b) cosmetic files medium — and is ROUTED, not dropped', () => {
+  it('downgrades an unquantified cosmetic finding to medium', () => {
+    const out = applySeverityRule(COSMETIC);
+    expect(out.severity).toBe(DEFAULT_SEVERITY);
+    expect(out.downgraded).toBe(true);
+  });
+
+  it('the downgrade explains itself and names the from-severity', () => {
+    // A silently rewritten field is indistinguishable, to the filer, from being ignored.
+    const out = applySeverityRule(COSMETIC);
+    expect(out.from).toBe('high');
+    expect(out.reason).toMatch(/measured harm/i);
+    expect(out.reason).toMatch(/still routed/i);
+  });
+
+  it('harm ASSERTED but never quantified is not measured harm', () => {
+    // The single most common false-high shape: strong words, no number.
+    const out = applySeverityRule({
+      severity: 'high', title: 'Search is broken', actual: 'it feels slow and sometimes breaks'
+    });
+    expect(out.severity).toBe(DEFAULT_SEVERITY);
+    expect(out.basis).toMatch(/never quantified/i);
+  });
+
+  it('an audited override keeps the elevated severity and says so', () => {
+    const out = applySeverityRule(COSMETIC, { override: 'measured on 3 seats, evidence in thread' });
+    expect(out.severity).toBe('high');
+    expect(out.downgraded).toBe(false);
+    expect(out.reason).toMatch(/audited override/i);
+  });
+
+  it('leaves non-elevated severities completely alone', () => {
+    for (const s of ['medium', 'low']) {
+      expect(applySeverityRule({ ...COSMETIC, severity: s }).severity).toBe(s);
+    }
+  });
+});
+
+describe('(c) a NEW distinct finding on an already-filed surface STILL ARRIVES', () => {
+  const filed = [{
+    id: 'QF-EXISTING-001',
+    title: 'Dashboard header spacing is inconsistent',
+    expected_behavior: 'the header aligns with the table below it',
+    actual_behavior: 'it sits a few pixels off and looks untidy'
+  }];
+
+  it('a genuinely different finding on the SAME surface is not folded', () => {
+    const fresh = {
+      title: 'Dashboard header dropdown throws on an empty venture list',
+      expected: 'an empty state renders',
+      actual: 'the component throws and the page goes blank'
+    };
+    expect(findDuplicateFinding(fresh, filed)).toBeNull();
+  });
+
+  it('CONTROL — the SAME finding IS folded, so the test above is not vacuous', () => {
+    // Without this arm, "not folded" would also pass if the fold were entirely broken.
+    const refiled = {
+      title: 'Dashboard header spacing is inconsistent',
+      expected: 'the header aligns with the table below it',
+      actual: 'it sits a few pixels off and looks untidy'
+    };
+    const hit = findDuplicateFinding(refiled, filed);
+    expect(hit).not.toBeNull();
+    expect(hit.row.id).toBe('QF-EXISTING-001');
+    expect(hit.score).toBeGreaterThanOrEqual(DUPLICATE_THRESHOLD);
+  });
+
+  it('a re-file with light rewording still folds — identity is not string equality', () => {
+    const reworded = {
+      title: 'Dashboard header spacing inconsistent',
+      expected: 'header aligns with the table below it',
+      actual: 'sits a few pixels off, looks untidy'
+    };
+    expect(findDuplicateFinding(reworded, filed)).not.toBeNull();
+  });
+
+  it('IDENTITY IS NOT SURFACE: same surface words, different claim, different identity', () => {
+    // The defect this rule exists to prevent — a surface-keyed fold would silence this forever.
+    const a = findingIdentity({ title: 'venture dashboard', actual: 'the export button does nothing' });
+    const b = findingIdentity({ title: 'venture dashboard', actual: 'totals are off by one row' });
+    expect(similarity(a, b)).toBeLessThan(DUPLICATE_THRESHOLD);
+  });
+
+  it('never folds against an empty identity', () => {
+    expect(findDuplicateFinding({}, filed)).toBeNull();
+    expect(findDuplicateFinding({ title: 'a of the' }, filed)).toBeNull();
+  });
+
+  it('folds against the BEST match when several are close', () => {
+    const rows = [
+      { id: 'FAR', title: 'unrelated thing entirely', expected_behavior: 'x', actual_behavior: 'y' },
+      ...filed
+    ];
+    expect(findDuplicateFinding({ ...COSMETIC, expected: filed[0].expected_behavior, actual: filed[0].actual_behavior }, rows).row.id)
+      .toBe('QF-EXISTING-001');
+  });
+});
+
+describe('CONTROLS — the detectors can actually fire and actually refuse', () => {
+  it('hasMeasuredHarm is two-sided on the same shape of input', () => {
+    expect(hasMeasuredHarm('blocks the handoff for 40 minutes').measured).toBe(true);
+    expect(hasMeasuredHarm('blocks the handoff sometimes').measured).toBe(false);
+  });
+
+  it('similarity is 1 for identical vocabulary and 0 for disjoint', () => {
+    expect(similarity(findingTokensOf('alpha beta gamma'), findingTokensOf('gamma beta alpha'))).toBe(1);
+    expect(similarity(findingTokensOf('alpha beta'), findingTokensOf('delta epsilon'))).toBe(0);
+  });
+
+  it('digits are preserved — 3 retries and 30 retries are different findings', () => {
+    const a = findingIdentity({ title: 'gate allows 3 retries' });
+    const b = findingIdentity({ title: 'gate allows 30 retries' });
+    expect(similarity(a, b)).toBeLessThan(1);
+  });
+
+  function findingTokensOf(s) { return findingIdentity({ title: s }); }
+});


### PR DESCRIPTION
Coordinator-directed, first of the shaped queue. Both changes are at the **filing site**; the drain side is deliberately untouched and the standing HIGH backlog is not re-graded, per the ratified ruling.

## Measured before building

The QF's premise got the same treatment as any other inherited claim: **96 of 96** quick-fixes filed in the last 7 days came from `UAT_AGENT`, **58 (60%)** at high or critical. The coordinator's independent count hours earlier was 85/85 at the same 60% — steady state, not a spike.

**Scoping checked before patching.** `create-quick-fix.js` never sets `created_by`, so "all 96 are UAT_AGENT" did not by itself prove filings flow through this file. **95 of 96 carry a `routing_tier`, which only this script writes** — that's what confirms the traffic passes here rather than around it.

## Rule 1 — severity

`high`/`critical` is reserved for **measured** harm to work or safety (ratified 2026-08-03). Everything else files `medium` **and is still routed** — nothing is dropped.

The downgrade announces itself with its reason and an audited override (`--severity-justification`), never applied silently: a quietly rewritten field is indistinguishable, to the filer, from being ignored. The test is a heuristic over free text and is built to **fail toward medium** — the recoverable direction, since a medium that should have been high still arrives.

## Rule 2 — dedup keyed on finding identity

The cheap move was widening the existing 40-char-title / 60-minute gate. That gate keys on **surface**, and a surface-keyed fold with a long window silences every later finding about the same page *forever* — the first report about a surface makes that surface permanently un-reportable. Ask what state would silence the alarm: with a surface key, the answer is "one filing, ever."

So identity is derived from what the finding **claims** (title + expected + actual), never from where it was found.

**No time window — corrected mid-build.** This first shipped with a 7-day window, and the wiring proof replayed a 10-day-old open QF straight through it: an exact duplicate, gate silent. Age is the wrong key — an *open* quick-fix is unfixed whenever it was filed. Status is the gate. The scan is explicitly capped and warns if it hits the cap, so it cannot silently measure the cap instead of the population.

## The unit suite proves the functions; it does not prove the CLI calls them

Shipping a correct module the faucet never invokes would be the exact producer-with-no-consumer defect. So all three acceptance sides were proven **live, through the real CLI**:

| side | result |
|---|---|
| (a) measured harm | **not** downgraded; blocked before insert, no row |
| (b) cosmetic high | announced `high → medium` |
| (c) new distinct finding on an already-filed surface | **arrived** (row created) |
| control: exact re-file | blocked at 100% identity overlap, exit 1, no row |

(c) is vacuous without that control — if the fold never fired, "it arrived" would pass for a gate that does nothing. Every row these proofs created was deleted; the open-QF count returned to 157.

## A control caught my own bug

`findingTokens` dropped tokens under 3 characters, so "3 retries" and "30 retries" were identical to the function whose whole job is telling findings apart — while the docstring already claimed digits were preserved. Numbers are now kept at any length.

## Size — flagged, not shaved

**110 executable lines** (131 further lines are documentation) against the QF's 45-line estimate, over the 75-line Tier-2 ceiling. Splitting the PR to duck the count would be shaving the number rather than getting the ceiling amended, so it's reported for a ruling instead.

## Known unrelated flake

`tests/unit/scripts/lint-repo-resolution-drift.test.js` failed once in a combined run and passed alone and on re-run. Its TS-5 case writes a fixture violation into `scripts/` while TS-6 lints the repo — a self-inflicted race. The failing assertion was `filesScanned > 0` (the lint scanned *zero* files), which a change that only *adds* files cannot cause. Logged separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)