### PR TITLE
QF-20260807-118: the class guard could not see a normalization suffix — and two more live instances were hiding behind it

### DIFF
--- a/eslint-rules/no-raw-ismainmodule-comparison.js
+++ b/eslint-rules/no-raw-ismainmodule-comparison.js
@@ -18,11 +18,31 @@
  *
  * Correct pattern: `isMainModule(import.meta.url)` (lib/utils/is-main-module.js).
  *
- * Deliberately NARROW by design: only the bare `process.argv[1]` MemberExpression
- * is matched, not a wrapped/transformed variant (`.replace(...)`, `new URL(...)`) —
- * those are structurally different, unproven-instance shapes out of this SD's scope
- * (matches the precision philosophy of the sibling rules over broad matching that
- * risks false positives).
+ * SCOPE CORRECTION (QF-20260807-118). This rule USED to say it deliberately did not match
+ * "a wrapped/transformed variant (`.replace(...)`, `new URL(...)`) — those are structurally
+ * different, unproven-instance shapes out of this SD's scope". That scoping decision was
+ * reasonable when written and has since been FALSIFIED BY A LIVE INSTANCE:
+ * scripts/drive-report-produce.mjs shipped
+ *
+ *     import.meta.url === `file://${process.argv[1]}`.replace(/\\/g, '/')
+ *
+ * — the SAME broken comparison with a normalization suffix — and it silently no-opped the
+ * only writer of drive_reports on every non-Linux seat: exit 0, no output, no row. The
+ * `.replace()` was an ATTEMPT to fix the Windows backslash problem, which is exactly why the
+ * suffixed form is the one a careful author reaches for. It does not work: the replace fixes
+ * the separators but not the `file://` vs `file:///` prefix, so the comparison still never
+ * matches. THE MORE SOPHISTICATED-LOOKING FORM IS THE MORE BROKEN ONE, and it was the form
+ * the guard could not see.
+ *
+ * MEASURED before this change, on the real file: the BARE pattern was caught at 91:5, the
+ * SUFFIXED pattern in the identical position reported "0 ungoverned violations across 2162
+ * files". Same file, same run, one variable. So the guard ran in CI, went green, and missed
+ * the defect it exists to prevent.
+ *
+ * Still narrow, deliberately: the BASE of the chain must be the exact banned construction.
+ * `new URL(process.argv[1], ...)` is NOT matched — that is a genuinely different shape with a
+ * legitimate reading, and no live instance has been observed. Precision is preserved; the
+ * unproven-instance exclusion is simply no longer applied to a shape that has been proven.
  *
  * Escape hatch (REQUIRES a non-empty REASON after the `--` separator):
  *
@@ -85,7 +105,38 @@ function isFileUrlLiteral(node) {
  * @param {import('estree').Node} node
  * @returns {boolean}
  */
+/**
+ * Strip any chain of string-method calls off an expression and return its base.
+ *
+ * QF-20260807-118: `` `file://${process.argv[1]}`.replace(/\\/g, '/') `` parses as a
+ * CallExpression whose callee is a MemberExpression on the TemplateLiteral — so a matcher that
+ * only inspected the node itself saw a CallExpression, found no TemplateLiteral, and returned
+ * false. Unwrapping is what makes the guard see through the normalization suffix.
+ *
+ * A LOOP, not a single unwrap: `.replace(a,b).replace(c,d)` and `.replace(…).toLowerCase()` are
+ * the same anti-pattern one link further out, and a single unwrap would miss them — the exact
+ * shape of the bug being fixed, reintroduced in the fix.
+ *
+ * Only method-call chains are unwrapped. The base must still be the exact banned construction,
+ * so this widens WHAT WRAPS the pattern, never what the pattern is.
+ * @param {import('estree').Node} node
+ * @returns {import('estree').Node}
+ */
+function unwrapStringMethodCalls(node) {
+  let current = node;
+  // Bounded to keep a pathological chain from spinning; far beyond any real expression.
+  for (let i = 0; i < 20; i += 1) {
+    if (!current || current.type !== 'CallExpression') return current;
+    const callee = current.callee;
+    if (!callee || callee.type !== 'MemberExpression' || callee.computed) return current;
+    current = callee.object;
+  }
+  return current;
+}
+
 function isFileUrlArgv1Expression(node) {
+  // Unwrap FIRST so every check below sees through `.replace(…)` and friends.
+  node = unwrapStringMethodCalls(node);
   if (!node) return false;
   if (node.type === 'TemplateLiteral') {
     if (node.expressions.length !== 1 || node.quasis.length !== 2) return false;

--- a/scripts/cron/drive-report-sms-sweep.mjs
+++ b/scripts/cron/drive-report-sms-sweep.mjs
@@ -46,6 +46,10 @@
  */
 
 import { sendDriveSms, factsFromReport } from '../drive-report-sms.mjs';
+// QF-20260807-118: canonical cross-platform entry guard. The hand-rolled
+// `file://${process.argv[1]}`.replace(...) form this replaces NEVER fired on Windows — and the
+// widened class-guard lint found this file only after that blind spot was closed.
+import { isMainModule } from '../../lib/utils/is-main-module.js';
 import { etParts, windowKey } from './drive-report-sweep.mjs';
 import { LAST_RUN_FIELD } from '../../lib/drive-loop/report-posture.js';
 
@@ -255,7 +259,7 @@ export async function runDriveSmsSweep({ nowMs, findLatestReport, enqueue, findO
 }
 
 // ── CLI ────────────────────────────────────────────────────────────────────────────────────
-if (import.meta.url === `file://${process.argv[1]}`.replace(/\\/g, '/')) {
+if (isMainModule(import.meta.url)) {
   if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
     throw new Error('drive-report-sms-sweep: SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required');
   }

--- a/scripts/cron/drive-report-sweep.mjs
+++ b/scripts/cron/drive-report-sweep.mjs
@@ -57,6 +57,10 @@ import { aggregateScore } from '../../lib/drive-loop/score/aggregate.js';
 import { unavailable, LAST_RUN_FIELD } from '../../lib/drive-loop/report-posture.js';
 import { armedProcessKey } from '../../lib/machinery-class/armed-registration.js';
 import { produceDriveReport } from '../drive-report-produce.mjs';
+// QF-20260807-118: canonical cross-platform entry guard. The hand-rolled
+// `file://${process.argv[1]}`.replace(...) form this replaces NEVER fired on Windows — and the
+// widened class-guard lint found this file only after that blind spot was closed.
+import { isMainModule } from '../../lib/utils/is-main-module.js';
 
 export const ET_ZONE = 'America/New_York';
 
@@ -357,7 +361,7 @@ export async function runDriveReportSweep({ nowMs, produce, gather, persist, reg
 // ── CLI ────────────────────────────────────────────────────────────────────────────────────
 // Everything above is pure of clocks and clients; this block is the thin edge that supplies the
 // real ones. Nothing here is decision logic, deliberately.
-if (import.meta.url === `file://${process.argv[1]}`.replace(/\\/g, '/')) {
+if (isMainModule(import.meta.url)) {
   const { createClient } = await import('@supabase/supabase-js');
   const { computePlanCheckStatus } = await import('../../lib/roadmap/plan-check-status.js');
   const { registerArmedMachinery } = await import('../../lib/machinery-class/armed-registration.js');

--- a/tests/unit/lint/ismainmodule-classguard-suffixed-variant.test.js
+++ b/tests/unit/lint/ismainmodule-classguard-suffixed-variant.test.js
@@ -1,0 +1,86 @@
+/**
+ * QF-20260807-118 — the class guard must see through a normalization suffix.
+ *
+ * THE DEFECT: the rule matched `import.meta.url === \`file://${process.argv[1]}\`` but NOT the
+ * same comparison with `.replace(/\\/g,'/')` appended, because the suffix makes the right-hand
+ * node a CallExpression rather than a TemplateLiteral. That exclusion was DELIBERATE and
+ * DOCUMENTED — the rule called wrapped variants "unproven-instance shapes out of scope" — and it
+ * was falsified by three live instances, one of which (scripts/drive-report-produce.mjs) silently
+ * no-opped the only writer of drive_reports on every non-Linux seat.
+ *
+ * The `.replace()` is an ATTEMPT to fix the Windows backslash problem, which is exactly why a
+ * careful author reaches for it. It does not work — it normalizes the separators but not the
+ * `file://` vs `file:///` prefix — so THE MORE SOPHISTICATED-LOOKING FORM IS THE MORE BROKEN ONE,
+ * and it was precisely the form the guard could not see.
+ *
+ * WHY THESE ASSERTIONS ARE POSITIVE. A test that only asserted "the current tree is clean" would
+ * PASS AGAINST THE BROKEN RULE, because the broken rule calls everything clean. That is the trap
+ * this entire defect class sets. So every case below feeds the rule source it must REJECT, and the
+ * negative controls feed it source it must ACCEPT — proving the widening did not become a blanket.
+ */
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+import rule from '../../../eslint-rules/no-raw-ismainmodule-comparison.js';
+
+const RULE_NAME = 'no-raw-ismainmodule-comparison';
+const linter = new Linter({ configType: 'flat' });
+
+function lint(code) {
+  return linter.verify(code, {
+    languageOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+    plugins: { local: { rules: { [RULE_NAME]: rule } } },
+    rules: { [`local/${RULE_NAME}`]: 'error' },
+  });
+}
+const violations = (code) => lint(code).filter((m) => m.ruleId === `local/${RULE_NAME}`).length;
+
+describe('QF-20260807-118 — suffixed and chained variants are caught', () => {
+  it('CATCHES the exact live form that shipped in three files', () => {
+    // Verbatim shape from scripts/drive-report-produce.mjs, drive-report-sweep.mjs and
+    // drive-report-sms-sweep.mjs before this fix.
+    const code = 'if (import.meta.url === `file://${process.argv[1]}`.replace(/\\\\/g, "/")) { run(); }';
+    expect(violations(code), 'the suffixed form is the one that shipped broken').toBe(1);
+  });
+
+  it('CATCHES a CHAIN of suffixes, not just one', () => {
+    // A single unwrap would pass this — which would be the same bug one link further out,
+    // reintroduced inside its own fix.
+    const code = 'if (import.meta.url === `file://${process.argv[1]}`.replace(/a/g,"b").toLowerCase()) { run(); }';
+    expect(violations(code)).toBe(1);
+  });
+
+  it('CATCHES the concat form with a suffix, and either operand order', () => {
+    expect(violations('if (import.meta.url === ("file://" + process.argv[1]).replace(/a/g,"b")) { run(); }')).toBe(1);
+    expect(violations('if (("file://" + process.argv[1]).replace(/a/g,"b") === import.meta.url) { run(); }')).toBe(1);
+  });
+
+  it('still CATCHES the bare form — the original contract must not regress', () => {
+    expect(violations('if (import.meta.url === `file://${process.argv[1]}`) { run(); }')).toBe(1);
+    expect(violations('if (import.meta.url === "file://" + process.argv[1]) { run(); }')).toBe(1);
+  });
+
+  // NEGATIVE CONTROLS — the widening must not become a blanket. The original rule's narrowness
+  // existed to avoid false positives, and that concern is still valid; only the proven-instance
+  // exclusion was lifted.
+  it('does NOT flag the correct helper', () => {
+    expect(violations('import { isMainModule } from "../lib/utils/is-main-module.js";\nif (isMainModule(import.meta.url)) { run(); }')).toBe(0);
+  });
+
+  it('does NOT flag new URL(process.argv[1]) — a different shape with a legitimate reading', () => {
+    expect(violations('if (import.meta.url === new URL(process.argv[1], "file:").href) { run(); }')).toBe(0);
+  });
+
+  it('does NOT flag an unrelated argv comparison or an unrelated .replace chain', () => {
+    expect(violations('if (process.argv[1] === somePath.replace(/a/g,"b")) { run(); }')).toBe(0);
+    expect(violations('if (import.meta.url === `https://${process.argv[1]}`.replace(/a/g,"b")) { run(); }')).toBe(0);
+    expect(violations('if (import.meta.url === `file://${process.argv[2]}`.replace(/a/g,"b")) { run(); }')).toBe(0);
+  });
+
+  // PRAGMA SEMANTICS ARE DELIBERATELY NOT RE-TESTED HERE. The existing RuleTester suite
+  // (tests/unit/eslint-rules/no-raw-ismainmodule-comparison.test.js) owns them, and it can:
+  // RuleTester registers the rule under its bare name, so ESLint's NATIVE eslint-disable-next-line
+  // processing matches and suppresses. This suite registers it as `local/…` for flat config, so a
+  // bare-name pragma cannot match natively — my first draft asserted suppression here and failed,
+  // testing the harness rather than the rule. That existing suite is run alongside this one in CI
+  // and is what proves the widening did not disturb pragma handling.
+});


### PR DESCRIPTION
A CI guard built for exactly one defect **ran, went green, and missed it** — which is how that defect shipped in `scripts/drive-report-produce.mjs` and silently no-opped the only writer of `drive_reports` on every non-Linux seat.

### Root-caused, with both candidates tested rather than one assumed

**Candidate (b) — a parse failure whose synthetic message is discarded by the `ruleId` filter — is REFUTED.** Injecting the *bare* pattern into the real file was caught at `91:5`, so it parses fine and top-level `await` is not the issue.

**Candidate (a) is CONFIRMED.** Same probe file, same run, one variable: the bare form is caught, the `.replace(…)`-suffixed form is missed, because the suffix makes the right-hand node a `CallExpression` rather than a `TemplateLiteral`.

### The gap was deliberate and documented

The rule said it deliberately did not match "a wrapped/transformed variant (`.replace(...)`, `new URL(...)`) — those are structurally different, unproven-instance shapes out of this SD's scope." Reasonable when written, and falsified since.

The `.replace()` is an **attempt to fix** the Windows backslash problem, which is exactly why a careful author reaches for it. It doesn't work — it normalizes the separators but not `file://` vs `file:///` — so **the more sophisticated-looking form is the more broken one**, and it was precisely the form the guard couldn't see.

### The widening immediately paid for itself

With the suffix visible, the lint found **two more live instances** that were invisible before:

| file | note |
|---|---|
| `scripts/cron/drive-report-sms-sweep.mjs:258` | the chairman's drive SMS path |
| `scripts/cron/drive-report-sweep.mjs:360` | the sweep |

Both are cron entrypoints carrying the identical broken guard; both would exit 0 having done nothing on any non-Linux seat. **Blast radius was 3 files, not 1.** Both are fixed here — leaving them would turn main red the moment the rule lands, and allowlisting them would be the same blindness by a shorter route.

Unwrapping is a **loop**, not a single unwrap: `.replace(a,b).replace(c,d)` and `.replace(…).toLowerCase()` are the same anti-pattern one link further out, and a single unwrap would miss them — the bug reintroduced inside its own fix.

### Still narrow

The **base** of the chain must be the exact banned construction. `new URL(process.argv[1], …)` is **not** matched: genuinely different shape, legitimate reading, no live instance observed. Precision is preserved; only the unproven-instance exclusion is lifted, and only for a shape now proven three times.

### Tests assert positively

A test asserting "the tree is clean" would **pass against the broken rule** — the broken rule calls everything clean. That is the trap this class sets. Eight cases feed the rule source it must **reject** (suffixed, chained, concat-suffixed, both operand orders, bare) and source it must **accept** (`isMainModule`, `new URL`, unrelated argv, `https`, `argv[2]`).

One self-inflicted test defect disclosed: I first asserted pragma suppression here and it failed — `RuleTester` registers the rule under its bare name so ESLint's *native* directive matches, while this flat-config suite registers it as `local/…` where a bare-name pragma cannot. I was testing the harness, not the rule. Pragma semantics stay owned by the existing `RuleTester` suite, which runs alongside this one and passes unchanged.

**554 tests green across 42 suites** covering the rule, the lint driver, and both fixed crons. The lint reports 0 violations on the clean tree and exits non-zero naming the file when the pattern is reintroduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)