### PR TITLE
fix(QF-20260729-685): render NOT_MEASURED instead of silence — on BOTH idle terminals

### DIFF
--- a/lib/checkin/steps/idle.cjs
+++ b/lib/checkin/steps/idle.cjs
@@ -69,7 +69,7 @@ module.exports = {
     // fail-open so a gauge fault can never break a check-in.
     let beltBlockNote = '';
     try {
-      const { assessCoordinatorBeltBlock, formatCoordinatorBeltBlock } =
+      const { assessCoordinatorBeltBlock, formatCoordinatorBeltBlock, BELT_VERDICT } =
         await import('../../governance/coordinator-belt-block.js');
       const belt = assessCoordinatorBeltBlock({
         claimableDepth: claimableAtTier,
@@ -82,6 +82,19 @@ module.exports = {
           ` ⚠️  BELT BLOCKED ON THE COORDINATOR: ${belt.reason}. This is NOT "work ran out" —` +
           ` the largest bucket is a fence only the coordinator can clear. Holding a fence for a` +
           ` stated reason is correct; not NOTICING is the defect. ${formatCoordinatorBeltBlock(belt)}`;
+      } else if (belt.verdict === BELT_VERDICT.NOT_MEASURED) {
+        // QF-20260729-685. NOT_MEASURED carries blocked:false, so the branch above skipped it and
+        // an UNREAD belt rendered byte-identically to a healthy one: same silence, no note. The
+        // assessor is careful to return NOT_MEASURED rather than OK precisely so the two stay
+        // distinguishable, and the message threw that distinction away at the last step.
+        //
+        // THE WORDING ALREADY EXISTED AND WAS UNREACHABLE. formatCoordinatorBeltBlock has had a
+        // NOT_MEASURED arm since it was written ("This is NOT a healthy belt; it is an unread
+        // one"), but its only production caller sat inside `if (belt.blocked)`, which
+        // NOT_MEASURED can never satisfy. Tests reached that arm; production could not. So this
+        // is a wiring fix, not new prose — reuse the formatter rather than restate it, or the
+        // two copies drift.
+        beltBlockNote = ` ⚠️  ${formatCoordinatorBeltBlock(belt)}`;
       }
     } catch { /* fail-open: an unavailable gauge must not block the idle path */ }
 
@@ -100,7 +113,17 @@ module.exports = {
         ...ctx.base,
         action: 'idle_fable_propose',
         recommended_wakeup_seconds: idleWakeupSeconds,
-        message: `No Fable-fit work on the belt (${fencedList.length} item(s) fenced as non-creative${unclassified ? `, ${unclassified} unclassified — a coordinator can set metadata.work_class_override to admit them` : ''}). STANDING BY — per the Fable doctrine, propose a creative/design SD or await coordinator direction; do NOT pull general-harness work. Arm ScheduleWakeup(~${idleWakeupSeconds}s)${adaptiveCadenceNote} and proceed.`,
+        // QF-20260729-685: beltBlockNote is interpolated HERE TOO, and its absence was the wider
+        // half of the defect. This terminal was computing the note and then dropping it, so a
+        // Fable seat never saw the belt verdict at all — not the NOT_MEASURED case this QF names,
+        // and not even the loud BLOCKED_ON_COORDINATOR case the gauge was originally built to
+        // surface. On this path all three states collapsed, not two.
+        //
+        // Measured, not inferred: this seat resolves to idle_fable_propose on every pass, and its
+        // checkin output carried a fully populated belt_block object in the JSON while the message
+        // beside it said nothing about the belt. The structured verdict was never the thing that
+        // was missing — the rendering was.
+        message: `No Fable-fit work on the belt (${fencedList.length} item(s) fenced as non-creative${unclassified ? `, ${unclassified} unclassified — a coordinator can set metadata.work_class_override to admit them` : ''}).${beltBlockNote} STANDING BY — per the Fable doctrine, propose a creative/design SD or await coordinator direction; do NOT pull general-harness work. Arm ScheduleWakeup(~${idleWakeupSeconds}s)${adaptiveCadenceNote} and proceed.`,
       };
     }
     return {

--- a/tests/unit/governance/belt-block-not-measured-rendered.test.js
+++ b/tests/unit/governance/belt-block-not-measured-rendered.test.js
@@ -1,0 +1,135 @@
+/**
+ * QF-20260729-685 — NOT_MEASURED must not render as silence, on EITHER idle terminal.
+ *
+ * THE DEFECT. assessCoordinatorBeltBlock is careful to return NOT_MEASURED rather than OK when its
+ * inputs are absent, precisely so an UNREAD belt stays distinguishable from a healthy one. The idle
+ * message then threw that distinction away at the last step: the only render branch was
+ * `if (belt.blocked)`, and NOT_MEASURED carries blocked:false. Unread and healthy produced
+ * byte-identical output — the same silence.
+ *
+ * THE WORDING ALREADY EXISTED AND WAS UNREACHABLE. formatCoordinatorBeltBlock has always had a
+ * NOT_MEASURED arm ("This is NOT a healthy belt; it is an unread one"), but its only production
+ * caller sat inside that blocked-guard. Tests reached the arm; production could not.
+ *
+ * THE WIDER HALF, found by measurement rather than from the QF text: there are TWO idle terminals,
+ * and `idle_fable_propose` did not interpolate the note AT ALL. On that path all three states
+ * collapsed — including the loud BLOCKED_ON_COORDINATOR case the gauge was built for. A Fable seat
+ * could sit on a coordinator-fenced belt and be told only that no Fable-fit work was available.
+ *
+ * WHY THE CONTROLS ARE NOT OPTIONAL. "NOT_MEASURED renders a note" passes just as well for a fix
+ * that emits a note UNCONDITIONALLY, which would destroy the healthy/unread distinction from the
+ * other direction and make the gauge noise. Every positive assertion here is therefore paired with
+ * a healthy-belt run asserting SILENCE.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const idleStep = require('../../../lib/checkin/steps/idle.cjs');
+
+function makeCtx(base, model) {
+  return {
+    sb: {},
+    sessionId: 'test-session',
+    sessionMetadata: model ? { model } : {},
+    helpers: {
+      getCommsActivitySignals: async () => { throw new Error('stubbed'); },
+      computeAdaptiveCadence: () => ({ tight: false, intervalMs: 0, reason: '' }),
+      DEFAULT_IDLE_WAKEUP_SECONDS: 1200,
+    },
+    base,
+  };
+}
+
+/** Inputs present, belt genuinely fine — the state that SHOULD stay silent. */
+const HEALTHY = {
+  belt_ranked_claimable: 21,
+  belt_claimable_at_my_tier: 0,
+  belt_ineligibility_breakdown: { human_action_required: 17, needs_coordinator_review: 2 },
+};
+/** The breakdown never arrived — the gauge could not see. */
+const UNMEASURED = {
+  belt_ranked_claimable: 21,
+  belt_claimable_at_my_tier: 0,
+  // belt_ineligibility_breakdown deliberately absent
+};
+/** Coordinator-owned bucket largest — the loud case. */
+const BLOCKED = {
+  belt_ranked_claimable: 21,
+  belt_claimable_at_my_tier: 0,
+  belt_ineligibility_breakdown: { needs_coordinator_review: 10, human_action_required: 9 },
+};
+
+const run = (base, model) => idleStep.run(makeCtx(base, model));
+
+describe('the plain idle terminal', () => {
+  it('THE POINT: an UNMEASURED belt says so instead of going silent', async () => {
+    const out = await run(UNMEASURED);
+    expect(out.action).toBe('idle');
+    expect(out.message).toMatch(/NOT_MEASURED/);
+    expect(out.message).toMatch(/unread/i);
+  });
+
+  it('CONTROL: a HEALTHY belt stays silent — the note is not unconditional', async () => {
+    // Without this, an always-emit "fix" passes the test above while erasing the distinction
+    // from the other side.
+    const out = await run(HEALTHY);
+    expect(out.message).not.toMatch(/NOT_MEASURED/);
+    expect(out.message).not.toMatch(/BELT BLOCKED/);
+  });
+
+  it('DIFFERENTIAL: the belt note is the ONLY thing separating unmeasured from healthy', async () => {
+    // THIS TEST WAS REWRITTEN AFTER IT PASSED A MUTATION IT SHOULD HAVE FAILED. The first version
+    // compared whole messages for UNMEASURED vs HEALTHY and asserted they differed — which stayed
+    // green with the NOT_MEASURED arm disabled, because those two inputs differ in
+    // belt_ineligibility_breakdown, and that field ALSO drives the unrelated tierNote. The
+    // assertion was reading a difference the fix had nothing to do with: a test that cannot fail
+    // when the feature is removed is theatre, and only the mutation run exposed it.
+    //
+    // Fixed by silencing the confounder: with belt_ranked_claimable 0, formatIdleIneligibilityNote
+    // returns '' for BOTH inputs, so the belt note is the only remaining source of difference.
+    const quiet = { belt_ranked_claimable: 0, belt_claimable_at_my_tier: 0 };
+    const [unmeasured, healthy] = await Promise.all([
+      run({ ...quiet }),                                                        // breakdown absent
+      run({ ...quiet, belt_ineligibility_breakdown: { human_action_required: 3 } }),
+    ]);
+    expect(unmeasured.message).not.toBe(healthy.message);
+    expect(unmeasured.message).toMatch(/NOT_MEASURED/);
+    expect(healthy.message).not.toMatch(/NOT_MEASURED/);
+  });
+
+  it('the blocked case is UNCHANGED — this fix adds an arm, it does not move one', async () => {
+    const out = await run(BLOCKED);
+    expect(out.message).toMatch(/BELT BLOCKED ON THE COORDINATOR/);
+  });
+});
+
+describe('the idle_fable_propose terminal — the wider half', () => {
+  it('renders the belt note at all, which it previously never did', async () => {
+    const out = await run(BLOCKED, 'fable');
+    expect(out.action).toBe('idle_fable_propose');
+    expect(out.message).toMatch(/BELT BLOCKED ON THE COORDINATOR/);
+  });
+
+  it('surfaces NOT_MEASURED on this terminal too', async () => {
+    const out = await run(UNMEASURED, 'fable');
+    expect(out.action).toBe('idle_fable_propose');
+    expect(out.message).toMatch(/NOT_MEASURED/);
+  });
+
+  it('CONTROL: a healthy belt on a Fable seat stays silent', async () => {
+    const out = await run(HEALTHY, 'fable');
+    expect(out.action).toBe('idle_fable_propose');
+    expect(out.message).not.toMatch(/NOT_MEASURED|BELT BLOCKED/);
+  });
+
+  it('CONTROL: the Fable terminal is genuinely being exercised, not the plain one', async () => {
+    // If modelWorkClasses ever stopped recognising this model, every assertion above would run
+    // against the 'idle' terminal and pass for the wrong reason.
+    const [fable, plain] = await Promise.all([run(HEALTHY, 'fable'), run(HEALTHY)]);
+    expect(fable.action).toBe('idle_fable_propose');
+    expect(plain.action).toBe('idle');
+    expect(fable.message).not.toBe(plain.message);
+  });
+});


### PR DESCRIPTION
## The defect as filed

`assessCoordinatorBeltBlock` deliberately returns `NOT_MEASURED` rather than `OK` when its inputs are missing, so an **unread** belt stays distinguishable from a **healthy** one. The idle message threw that distinction away at the last step: the only render branch was `if (belt.blocked)`, and `NOT_MEASURED` carries `blocked: false`. Unread and healthy produced byte-identical output.

## The wording already existed and was unreachable

`formatCoordinatorBeltBlock` has had a `NOT_MEASURED` arm since it was written — *"This is NOT a healthy belt; it is an unread one"* — but its only production caller sat inside that blocked-guard, which `NOT_MEASURED` can never satisfy. **Tests reached that arm; production could not.** So this is a wiring fix: it reuses the formatter rather than restating it, or the two copies drift.

## The wider half — found by measuring, not by reading the QF

There are **two** idle terminals, and `idle_fable_propose` did not interpolate the note **at all** — it computed `beltBlockNote` and dropped it. On that path **all three states collapsed**, not two, including the loud `BELT BLOCKED ON THE COORDINATOR` case the gauge was originally built to surface. A Fable seat could sit on a fully coordinator-fenced belt and be told only that no Fable-fit work was available.

Measured, not inferred: this seat resolves to `idle_fable_propose` on every pass, and its checkin JSON carried a fully populated `belt_block` object while the message beside it said nothing about the belt. The structured verdict was never missing — **the rendering was.**

That also narrows the QF's own premise, which is worth recording: the three states collapse in the **message**, not in the payload.

## Mutation-proven in both halves, separately

| mutation | result |
|---|---|
| disable the `NOT_MEASURED` arm | the NOT_MEASURED tests fail |
| drop `${beltBlockNote}` from the fable terminal | the fable tests fail |

A first mutation attempt left the file syntactically broken and vitest reported **"no tests"**. Recorded because that is *not* a red — it is an unparsed file, and treating it as proof would have proved nothing.

## A control caught one of my own tests being theatre

The original DIFFERENTIAL compared whole messages for unmeasured-vs-healthy and asserted they differed — and it stayed **green with the fix disabled**, because those two inputs differ in `belt_ineligibility_breakdown`, and that field *also* drives the unrelated `tierNote`. It was reading a difference the fix had nothing to do with.

Rewritten with `belt_ranked_claimable: 0` so `tierNote` is empty on both sides and the belt note is the only remaining source of difference. It now fails under the same mutation.

Every positive assertion is paired with a healthy-belt run asserting **silence**, because *"NOT_MEASURED renders a note"* passes equally well for a fix that emits unconditionally — which would destroy the distinction from the other direction.

## Unrelated flake observed

`tests/unit/governance/revisit-tags.test.js` passed **15/15 in 1.55s alone** but timed out at **~90s** in a combined run — a 58× slowdown under parallel load. It is a repo-wide filesystem scanner with zero references to anything this PR touches. Logged separately; not caused here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
