### PR TITLE
QF-20260807-368: an IDLE worker was never told it had pending directives

### DIFF
--- a/lib/checkin/steps/idle.cjs
+++ b/lib/checkin/steps/idle.cjs
@@ -30,7 +30,45 @@ module.exports = {
   formatIdleIneligibilityNote,
   async run(ctx) {
     const { sb, sessionId } = ctx;
-    const { getCommsActivitySignals, computeAdaptiveCadence, DEFAULT_IDLE_WAKEUP_SECONDS } = ctx.helpers;
+    const { getCommsActivitySignals, computeAdaptiveCadence, DEFAULT_IDLE_WAKEUP_SECONDS,
+      ws, ASSIGNMENT_RECENCY_WINDOW_MS } = ctx.helpers;
+
+    // QF-20260807-368 — SURFACE PENDING DIRECTIVES ON THE IDLE PATH TOO.
+    //
+    // resume.cjs added this surfacing for a CLAIM-HOLDING worker, because directive kinds other
+    // than WORK_ASSIGNMENT "had NO surfacing path" for one. That fixed the instance and left the
+    // class: a worker with NO claim never reaches resume.cjs, so it never gets the count either —
+    // and idle is precisely the state in which undrained directives accumulate.
+    //
+    // MEASURED on session 7c0540c2 (2026-08-07): three coordinator requests went unread, one a
+    // release request nudged THREE times while a peer sat blocked. Every check-in that afternoon
+    // returned idle_fable_propose and carried NO directive count; the backlog surfaced only when
+    // an unrelated claim collision flipped the action to `resume`. The escalation that finally
+    // worked was INCIDENTAL, not designed.
+    //
+    // The worker's own triage was also windowing the list — that half is the worker's to fix. But
+    // an idle worker was blind on BOTH surfaces at once: truncated list AND no count to contradict
+    // it. Closing this one means the harness always states the count, whatever the reader does.
+    //
+    // SAME CONTRACT AS resume.cjs, deliberately: SURFACE ONLY. We do NOT stamp read_at (read_at IS
+    // NULL is the deliberate deliver-not-consume signal for DIRECTIVE_KINDS — forcing it
+    // re-introduces a corrected regression), we do NOT touch the claim, and the whole block is
+    // fail-open so a directive-query fault can never break a check-in.
+    let directiveNote = '';
+    try {
+      const kinds = new Set(ws.DIRECTIVE_KINDS || []);
+      const dmsgs = await ws.getMessagesForSession(sb, sessionId, {
+        unackedOnly: true,
+        sinceIso: new Date(Date.now() - ASSIGNMENT_RECENCY_WINDOW_MS).toISOString(),
+      });
+      const pending = (dmsgs || []).filter((m) => kinds.has((m.payload && m.payload.kind) || m.message_type));
+      if (pending.length) {
+        const summary = pending.map((d) => (d.payload && d.payload.kind) || d.message_type).join(', ');
+        directiveNote = ` PENDING DIRECTIVE${pending.length > 1 ? 'S' : ''} (${pending.length}): ${summary}`
+          + ' — READ AND ACTION THEM NOW. You hold no claim, so nothing is competing with them.'
+          + ' Ack a coordinator_directive with: node scripts/worker-ack-directive.cjs --id <id>.';
+      }
+    } catch { /* fail-open: no directive surfacing */ }
     // 7. idle -> recommend a wakeup (ScheduleWakeup is a HARNESS tool, not Node-callable)
     // SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001 (FR-2): when the ranked pool is non-empty but NONE of
     // it is claimable at this worker's rung, say so explicitly — otherwise the agnostic count reads as
@@ -100,14 +138,14 @@ module.exports = {
         ...ctx.base,
         action: 'idle_fable_propose',
         recommended_wakeup_seconds: idleWakeupSeconds,
-        message: `No Fable-fit work on the belt (${fencedList.length} item(s) fenced as non-creative${unclassified ? `, ${unclassified} unclassified — a coordinator can set metadata.work_class_override to admit them` : ''}). STANDING BY — per the Fable doctrine, propose a creative/design SD or await coordinator direction; do NOT pull general-harness work. Arm ScheduleWakeup(~${idleWakeupSeconds}s)${adaptiveCadenceNote} and proceed.`,
+        message: `No Fable-fit work on the belt (${fencedList.length} item(s) fenced as non-creative${unclassified ? `, ${unclassified} unclassified — a coordinator can set metadata.work_class_override to admit them` : ''}). STANDING BY — per the Fable doctrine, propose a creative/design SD or await coordinator direction; do NOT pull general-harness work. Arm ScheduleWakeup(~${idleWakeupSeconds}s)${adaptiveCadenceNote} and proceed.${directiveNote}`,
       };
     }
     return {
       ...ctx.base,
       action: 'idle',
       recommended_wakeup_seconds: idleWakeupSeconds,
-      message: `No assignment and nothing claimable. IDLE.${tierNote}${beltBlockNote} The /checkin skill must now call ScheduleWakeup(~${idleWakeupSeconds}s)${adaptiveCadenceNote} and proceed — never wait on a human.`,
+      message: `No assignment and nothing claimable. IDLE.${tierNote}${beltBlockNote} The /checkin skill must now call ScheduleWakeup(~${idleWakeupSeconds}s)${adaptiveCadenceNote} and proceed — never wait on a human.${directiveNote}`,
     };
   },
 };

--- a/tests/unit/checkin-idle-directive-surfacing.test.js
+++ b/tests/unit/checkin-idle-directive-surfacing.test.js
@@ -1,0 +1,117 @@
+/**
+ * QF-20260807-368 — an IDLE worker must be told it has pending directives.
+ *
+ * THE DEFECT: `resume.cjs` surfaces a PENDING DIRECTIVES count, and its own comment says it was
+ * added because directive kinds other than WORK_ASSIGNMENT "had NO surfacing path" for a
+ * CLAIM-HOLDING worker. That fixed the instance and left the class — a worker with no claim never
+ * reaches resume.cjs, and idle is precisely the state in which undrained directives accumulate.
+ *
+ * MEASURED on session 7c0540c2 (2026-08-07): three coordinator requests went unread, one a release
+ * request nudged THREE times while a peer sat blocked. Every check-in that afternoon returned
+ * `idle_fable_propose` and carried no directive count; the backlog surfaced only when an unrelated
+ * claim collision flipped the action to `resume`. The escalation that worked was incidental.
+ *
+ * WHY THE SEEDED COUNT IS DELIBERATELY LARGE. The companion worker-side defect was a FIXED-SIZE
+ * window over a growing list — it behaved perfectly for six messages and failed from the seventh
+ * onward. A test with a short inbox therefore passes against the broken shape, which is exactly why
+ * this survived. So the fixture seeds TWELVE and asserts the reported count is TWELVE: any
+ * truncation, at any layer, shows up as a smaller number.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+const require = createRequire(import.meta.url);
+const idleStep = require('../../lib/checkin/steps/idle.cjs');
+
+const DIRECTIVE_KINDS = ['coordinator_request', 'coordinator_directive', 'fence_notice'];
+
+function makeCtx({ directives = [], model, throwOnFetch = false } = {}) {
+  const calls = { fetchOpts: null, writes: 0 };
+  return {
+    calls,
+    ctx: {
+      sb: {
+        // Any write attempt is a contract violation: this path is SURFACE-ONLY.
+        from() { calls.writes += 1; return { update: () => ({ eq: () => ({ select: async () => ({ data: [], error: null }) }) }) }; },
+      },
+      sessionId: 'S-1',
+      sessionMetadata: model ? { model } : {},
+      base: { belt_ranked_claimable: 0, belt_claimable_at_my_tier: 0, work_class_fenced: [] },
+      helpers: {
+        DEFAULT_IDLE_WAKEUP_SECONDS: 1200,
+        getCommsActivitySignals: async () => ({}),
+        computeAdaptiveCadence: () => ({ tight: false }),
+        ASSIGNMENT_RECENCY_WINDOW_MS: 6 * 60 * 60 * 1000,
+        ws: {
+          DIRECTIVE_KINDS,
+          getMessagesForSession: async (_sb, _sid, opts) => {
+            calls.fetchOpts = opts;
+            if (throwOnFetch) throw new Error('directive query exploded');
+            return directives;
+          },
+        },
+      },
+    },
+  };
+}
+
+const seed = (n) => Array.from({ length: n }, (_, i) => ({
+  id: `msg-${i}`,
+  payload: { kind: i === 0 ? 'coordinator_request' : 'coordinator_directive' },
+}));
+
+describe('QF-20260807-368 — idle surfaces pending directives', () => {
+  it('reports the FULL count on the plain idle terminal — 12 seeded, 12 reported', async () => {
+    const { ctx } = makeCtx({ directives: seed(12) });
+    const out = await idleStep.run(ctx);
+    expect(out.action).toBe('idle');
+    // The number is the assertion. Any window/truncation anywhere reports fewer than 12.
+    expect(out.message).toContain('PENDING DIRECTIVES (12)');
+    expect(out.message).toContain('READ AND ACTION THEM NOW');
+  });
+
+  it('reports it on the idle_fable_propose terminal too — the path that actually went silent', async () => {
+    // This is the terminal session 7c0540c2 hit on every check-in while three requests waited.
+    // Fixing only the plain `idle` return would repeat the exact fix-the-instance error being fixed.
+    const { ctx } = makeCtx({ directives: seed(12), model: 'fable' });
+    const out = await idleStep.run(ctx);
+    expect(out.action).toBe('idle_fable_propose');
+    expect(out.message).toContain('PENDING DIRECTIVES (12)');
+  });
+
+  it('says nothing when nothing is pending — silence must stay meaningful', async () => {
+    for (const model of [undefined, 'fable']) {
+      const { ctx } = makeCtx({ directives: [], model });
+      const out = await idleStep.run(ctx);
+      expect(out.message).not.toContain('PENDING DIRECTIVE');
+    }
+  });
+
+  it('SURFACE ONLY — asks for unacked rows and never writes', async () => {
+    // read_at IS NULL is the deliberate deliver-not-consume signal for DIRECTIVE_KINDS; stamping it
+    // here would re-introduce a corrected regression and forge a read receipt the worker never earned.
+    const { ctx, calls } = makeCtx({ directives: seed(3) });
+    await idleStep.run(ctx);
+    expect(calls.fetchOpts.unackedOnly).toBe(true);
+    expect(calls.fetchOpts.sinceIso).toBeTruthy();
+    expect(calls.writes, 'the idle path must not write anything').toBe(0);
+  });
+
+  it('FAIL-OPEN — a directive-query fault must never break the check-in', async () => {
+    // An idle worker that crashes its own check-in is worse off than one that misses a count.
+    const { ctx } = makeCtx({ throwOnFetch: true });
+    const out = await idleStep.run(ctx);
+    expect(out.action).toBe('idle');
+    expect(out.recommended_wakeup_seconds).toBe(1200);
+    expect(out.message).not.toContain('PENDING DIRECTIVE');
+  });
+
+  it('ignores non-directive kinds rather than inflating the count', async () => {
+    const { ctx } = makeCtx({ directives: [
+      { id: 'a', payload: { kind: 'coordinator_request' } },
+      { id: 'b', payload: { kind: 'coordinator_reply' } },   // not a directive kind
+      { id: 'c', payload: { kind: 'SET_IDENTITY' } },        // not a directive kind
+    ] });
+    const out = await idleStep.run(ctx);
+    expect(out.message).toContain('PENDING DIRECTIVE (1)');
+  });
+});


### PR DESCRIPTION
### Root cause measured — the QF's unverified half is now settled

The `PENDING DIRECTIVES (N)` count is emitted in exactly **one** place: `lib/checkin/steps/resume.cjs`. Confirmed by grepping every file under `lib/checkin/steps/`. A worker with no claim never reaches that step, so it never receives the count. There are **two** idle terminals (`idle` and `idle_fable_propose`) and neither carried it.

`resume.cjs`'s own comment names the shape: that surfacing was added because directive kinds other than `WORK_ASSIGNMENT` "had NO surfacing path" for a **claim-holding** worker. It fixed the instance and left the class — and idle is precisely the state in which undrained directives accumulate, so the gap sat exactly where it did the most damage.

### The measured incident

Session `7c0540c2`, 2026-08-07: three coordinator requests went unread, one a release request **nudged three times while Alpha-4 sat blocked** on the handback. Every check-in that afternoon returned `idle_fable_propose` and carried no directive count. The backlog surfaced only when an unrelated claim collision flipped the action to `resume` — **the escalation that finally worked was incidental, not designed.**

The worker's own triage was also windowing the list (a fixed ~6-message view over a growing inbox; 8 of 14 rows hidden by the end), and that half is being fixed separately. But an idle worker was blind on **both** surfaces at once: truncated list *and* no count to contradict it. Closing this one means the harness states the count regardless of what the reader does with the list.

### Contract preserved

Same as `resume.cjs`, deliberately: **surface only**. `read_at` is not stamped — `read_at IS NULL` is the deliberate deliver-not-consume signal for `DIRECTIVE_KINDS`, forcing it re-introduces a corrected regression, and it would forge a read receipt the worker never earned. The claim is not touched. The block is fail-open: an idle worker that crashes its own check-in is worse off than one missing a count.

**Both terminals patched.** Fixing only one would have repeated the exact fix-the-instance error this QF is about — and `idle_fable_propose` is the one that actually went silent.

### Tests seed twelve, not three

The companion worker-side defect was a fixed-size window that behaved perfectly for six messages and failed from the seventh onward. **A test with a short inbox passes against the broken shape** — which is why this survived. The fixture seeds 12 and asserts the reported count is 12, so truncation at any layer shows up as a smaller number. Also covers silence-when-empty, surface-only (`unackedOnly` requested, zero writes), fail-open, and non-directive kinds not inflating the count.

Mutation-proven, each terminal independently: drop the fable terminal's note (**1 red**), drop the plain idle terminal's note (**2 red**), break fail-open (**1 red**). **52 tests green** across the three suites exercising the idle step and the existing assignment-surfacing contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)