### PR TITLE
fix(QF-20260807-289): handoff.js fail-closed argv — reject unknown flags on the canonical mutating script

### DIFF
--- a/lib/handoff-argv-guard.mjs
+++ b/lib/handoff-argv-guard.mjs
@@ -1,0 +1,119 @@
+/**
+ * QF-20260807-289 — fail-closed argv for handoff.js.
+ *
+ * handoff.js is THE canonical state-mutating process script (CLAUDE.md names it as the
+ * never-bypass path). It read argv positionally and ignored anything it did not recognise,
+ * so a flag that does not exist was indistinguishable from a flag that does nothing. A
+ * worker passed `execute PLAN-TO-EXEC <SD> --precheck` expecting a dry run and performed
+ * the REAL transition. A no-op flag on an irreversible command is worse than an error:
+ * the operator believes they are safe precisely when they are not.
+ *
+ * Builtin-free on purpose. handoff.js keeps its top-level imports free of anything that
+ * resolves through node_modules so it still loads inside an orphaned worktree whose
+ * node_modules junction is dangling; a guard that cannot load in that state would be
+ * absent exactly when a confused invocation is most likely.
+ *
+ * SCOPE. This rejects unknown flags. It deliberately does NOT implement a dry run —
+ * because two already exist (see NEAR_MISS below), which is the whole reason the accident
+ * was a near miss rather than a missing feature.
+ */
+
+/**
+ * Every flag reachable on the `node scripts/handoff.js ...` path, with the parse site that
+ * consumes it. Sites were enumerated by reading the parsers, NOT by grepping handoff.js —
+ * handoff.js is a 145-line thin wrapper that reads only argv[0]/argv[2] and
+ * `--bypass-validation`. A whitelist derived from the wrapper would reject every entry
+ * below except one, and would hard-break the fleet on the canonical script.
+ */
+export const KNOWN_HANDOFF_FLAGS = new Set([
+  // cli/cli-main.js — global + execute
+  '--bypass-validation',   // :556  documented bypass (audit-logged downstream)
+  '--bypass-reason',       // :557  its mandatory reason payload
+  '--pattern-id',          // :567
+  '--followup-sd-key',     // :568
+  '--no-cache',            // :940
+  '--evaluate',            // :1373 dry-run gate scoring
+  '--dry-run',             // :1378 REAL dry run on execute — short-circuits before the executor
+  '--text',                // :1426 introspect output format
+  '--vision-key',          // :1333
+  '--arch-key',            // :1334
+
+  // No parse site — `--help` falls to the switch's `default:` arm, which calls
+  // displayHelp(). Verified by running it: `handoff.js --help` exits 0 and prints usage
+  // today. Registered because rejecting the universal help convention on the fleet's most
+  // used script would be a regression, and because asking for help mutates nothing.
+  '--help',
+
+  // auto-proceed-resolver.js — reads process.argv directly, not the CLI's `args`
+  '--auto-proceed',        // :48
+  '--no-auto-proceed',     // :49
+
+  // lib/cross-sd-overlap.js parseAckFlags(), invoked from INSIDE gates on the execute
+  // path (plan-to-exec + lead-final-approval). Far from the CLI and easy to miss.
+  '--acknowledge-cross-sd-overlap', // :123
+  '--ack-reason',                   // :126
+
+  // cli/leo5-commands.js — kickback / invalidate / resume subcommands
+  '--from',                // :198
+  '--to',                  // :199
+  '--reason',              // :200, :263
+  '--type',                // :267
+  '--correction',          // :334
+  '--notes',               // :338
+]);
+
+/**
+ * Flags an operator plausibly reaches for, mapped to the real spelling. `--precheck` is
+ * the recorded near miss: `precheck` and `dry-run` are both genuine COMMANDS, and
+ * `--dry-run` is a genuine FLAG on execute. The correct invocation was one token away, so
+ * naming it in the error is most of this fix's value.
+ */
+export const NEAR_MISS = new Map([
+  ['--precheck', "`handoff.js precheck TYPE SD-ID` (a command, not a flag), or `handoff.js execute TYPE SD-ID --dry-run`"],
+  ['--dryrun', '--dry-run'],
+  ['--dry', '--dry-run'],
+  ['--check', "`handoff.js precheck TYPE SD-ID`"],
+  ['--no-execute', "`handoff.js execute TYPE SD-ID --dry-run`"],
+  ['--bypass', '--bypass-validation (and its required --bypass-reason)'],
+  ['--autoproceed', '--auto-proceed'],
+]);
+
+/**
+ * Return the unknown flags in `args`, in order, without duplicates.
+ *
+ * Only `--`-prefixed tokens are inspected, so flag VALUES are never mistaken for flags.
+ * A bare `--` terminates scanning (conventional end-of-options).
+ *
+ * `--flag=value` is matched on its name half. Accepting the `=` form here does not claim
+ * the parsers support it — they read values positionally — but this guard's job is
+ * rejecting flags that do not exist, and mis-rejecting a real flag is the failure
+ * direction that breaks every seat.
+ */
+export function findUnknownFlags(args = []) {
+  const unknown = [];
+  for (const raw of args) {
+    if (typeof raw !== 'string') continue;
+    if (raw === '--') break;
+    if (!raw.startsWith('--')) continue;
+    const name = raw.includes('=') ? raw.slice(0, raw.indexOf('=')) : raw;
+    if (KNOWN_HANDOFF_FLAGS.has(name)) continue;
+    if (!unknown.includes(name)) unknown.push(name);
+  }
+  return unknown;
+}
+
+/** Human-facing rejection text. Separated from process control so it is testable. */
+export function formatUnknownFlagError(unknown) {
+  const lines = [
+    `[handoff.js] ❌ Unknown flag${unknown.length > 1 ? 's' : ''}: ${unknown.join(', ')}`,
+    '   NOTHING WAS EXECUTED. handoff.js mutates strategic_directives_v2, so an',
+    '   unrecognised flag is refused rather than ignored — a flag that silently does',
+    '   nothing lets you believe a real transition was a rehearsal.',
+  ];
+  for (const flag of unknown) {
+    if (NEAR_MISS.has(flag)) lines.push(`   Did you mean: ${NEAR_MISS.get(flag)}`);
+  }
+  lines.push('   Documented flags: ' + [...KNOWN_HANDOFF_FLAGS].join(' '));
+  lines.push('   Full usage: node scripts/handoff.js help');
+  return lines.join('\n');
+}

--- a/scripts/handoff.js
+++ b/scripts/handoff.js
@@ -32,6 +32,25 @@ import { spawnSync } from 'node:child_process';
 import { assertCwdValid, ExecContextError } from '../lib/exec-context-guard.mjs';
 import { getRepoRoot } from '../lib/repo-paths.js';
 import { planHandoffReexec } from '../lib/handoff-reexec.mjs';
+import { findUnknownFlags, formatUnknownFlagError } from '../lib/handoff-argv-guard.mjs';
+
+// === QF-20260807-289: fail-closed argv, FIRST statement that inspects input ===
+// Runs ahead of the re-exec preflight, the claim guard and the heavy import graph, so a
+// rejected invocation cannot spawn a child, touch a claim, or reach an executor. Placed
+// here rather than in cli/index.js because by the time main() dispatches, `execute` has
+// already been chosen and the only thing between argv and an UPDATE is gate scoring.
+//
+// Previously an unrecognised flag was simply not read. Positional parsing means a typo
+// and a supported option are byte-identical in effect: both are dropped, and the command
+// proceeds. That let `execute PLAN-TO-EXEC <SD> --precheck` run a real phase transition
+// while its author believed they had asked for a rehearsal — the silent no-op is the
+// defect, not the missing feature. Both dry-run paths already exist (`precheck` and
+// `dry-run` commands, plus `--dry-run` on execute), so the guard names them on rejection.
+const _unknownFlags = findUnknownFlags(process.argv.slice(2));
+if (_unknownFlags.length > 0) {
+  console.error(formatUnknownFlagError(_unknownFlags));
+  process.exit(2);
+}
 
 // === FR-1 (SD-FDBK-INFRA-WORKTREE-AUTO-REMOVED-001): re-exec recovery ===
 // When cwd is an orphaned worktree (its branch was deleted by

--- a/scripts/lib/handoff-preflight.js
+++ b/scripts/lib/handoff-preflight.js
@@ -236,7 +236,12 @@ async function validateSDHandoffState(sdId, targetPhase, _options = {}) {
         requiredHandoffs.find(r => !result.handoffs.accepted.includes(r));
 
       if (firstMissing) {
-        result.command = `node scripts/handoff.js execute ${firstMissing} --sd-id ${sd.sd_key || sd.id}`;
+        // QF-20260807-289: was `execute ${firstMissing} --sd-id ${key}`. handoff.js reads
+        // the SD id POSITIONALLY from args[2], so that form handed it the literal string
+        // '--sd-id' as the SD key and the real key was never read at all. Surfaced by the
+        // fail-closed argv guard, which rejects '--sd-id' because nothing parses it —
+        // registering the flag instead would have preserved the silent misfire.
+        result.command = `node scripts/handoff.js execute ${firstMissing} ${sd.sd_key || sd.id}`;
       }
     }
 
@@ -355,7 +360,11 @@ async function verifyCompleteHandoffChain(sdId) {
 
     if (!result.canComplete && result.chain.missing.length > 0) {
       result.blockers.push(
-        `Run: node scripts/handoff.js execute ${result.chain.missing[0]} --sd-id ${sd.sd_key || sd.id}`
+        // QF-20260807-289: second instance of the positional-vs-flag mistake in this same
+        // file (see the remediation builder above). Fixing only the first would have been
+        // the fix-the-instance error, and the sibling sits 120 lines away where a diff
+        // review never looks.
+        `Run: node scripts/handoff.js execute ${result.chain.missing[0]} ${sd.sd_key || sd.id}`
       );
     }
 

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/prerequisite-check.js
@@ -115,7 +115,12 @@ export function createPrerequisiteCheckGate(supabase) {
           max_score: 100,
           issues: ['BLOCKING: No accepted EXEC-TO-PLAN handoff found - LEO Protocol violation'],
           warnings: [],
-          remediation: 'Complete EXEC-TO-PLAN handoff before attempting PLAN-TO-LEAD. Run: node scripts/handoff.js exec-to-plan --sd-id <SD-ID>'
+          // QF-20260807-289: this remediation named a command that does not exist. There is
+          // no `exec-to-plan` subcommand (the verb is `execute`, the type is its argument),
+          // and the SD id is positional, not a --sd-id flag. An operator following it
+          // verbatim got the help text and no handoff — a gate that blocks you and then
+          // hands you an invocation that cannot work.
+          remediation: 'Complete EXEC-TO-PLAN handoff before attempting PLAN-TO-LEAD. Run: node scripts/handoff.js execute EXEC-TO-PLAN <SD-ID>'
         };
       }
 

--- a/tests/unit/handoff-argv-guard.test.js
+++ b/tests/unit/handoff-argv-guard.test.js
@@ -1,0 +1,144 @@
+// QF-20260807-289 — fail-closed argv on handoff.js.
+//
+// Two things are under test, and the second matters more than the first.
+//   1. The guard rejects unknown flags and accepts real ones.
+//   2. The whitelist STAYS complete. A fail-closed guard on the canonical mutating script
+//      fails in two directions, and they are not symmetric: missing a rejection lets one
+//      bad invocation through, while a WRONGLY rejected flag hard-breaks that invocation
+//      for every seat in the fleet. A hand-maintained list rots, so the drift test below
+//      reads the parsers and fails the moment a parse site outruns the registry.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  KNOWN_HANDOFF_FLAGS,
+  NEAR_MISS,
+  findUnknownFlags,
+  formatUnknownFlagError,
+} from '../../lib/handoff-argv-guard.mjs';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+
+describe('findUnknownFlags', () => {
+  it('flags the invocation that caused this QF', () => {
+    expect(findUnknownFlags(['execute', 'PLAN-TO-EXEC', 'SD-X-001', '--precheck'])).toEqual(['--precheck']);
+  });
+
+  it('accepts a documented bypass with its reason', () => {
+    const args = ['execute', 'PLAN-TO-EXEC', 'SD-X-001', '--bypass-validation', '--bypass-reason', 'TICKET-1'];
+    expect(findUnknownFlags(args)).toEqual([]);
+  });
+
+  it('accepts every registered flag, so the registry can never reject itself', () => {
+    expect(findUnknownFlags([...KNOWN_HANDOFF_FLAGS])).toEqual([]);
+  });
+
+  it('never mistakes a flag VALUE for a flag', () => {
+    // --bypass-reason is positional; its value must not be re-scanned as an option.
+    expect(findUnknownFlags(['execute', 'X', 'SD-1', '--bypass-reason', 'not-a-flag'])).toEqual([]);
+    expect(findUnknownFlags(['execute', 'LEAD-TO-PLAN', 'SD-ABC-001'])).toEqual([]);
+  });
+
+  it('stops scanning at a bare -- terminator', () => {
+    expect(findUnknownFlags(['execute', '--', '--whatever'])).toEqual([]);
+  });
+
+  it('matches the name half of --flag=value', () => {
+    expect(findUnknownFlags(['--bypass-reason=TICKET-1'])).toEqual([]);
+    expect(findUnknownFlags(['--nonsense=1'])).toEqual(['--nonsense']);
+  });
+
+  it('reports each unknown flag once, in order', () => {
+    expect(findUnknownFlags(['--zed', '--alpha', '--zed'])).toEqual(['--zed', '--alpha']);
+  });
+
+  it('ignores single-dash tokens rather than guessing at them', () => {
+    expect(findUnknownFlags(['-v'])).toEqual([]);
+  });
+});
+
+describe('formatUnknownFlagError', () => {
+  it('states that nothing ran — the operator believed they were safe', () => {
+    expect(formatUnknownFlagError(['--precheck'])).toContain('NOTHING WAS EXECUTED');
+  });
+
+  it('names the two real dry-run paths when --precheck is the near miss', () => {
+    const msg = formatUnknownFlagError(['--precheck']);
+    expect(msg).toContain('precheck TYPE SD-ID');
+    expect(msg).toContain('--dry-run');
+  });
+
+  it('lists the documented flags so the operator can self-correct', () => {
+    expect(formatUnknownFlagError(['--nope'])).toContain('--bypass-validation');
+  });
+
+  it('every near-miss key is itself unknown, or the suggestion would be unreachable', () => {
+    for (const key of NEAR_MISS.keys()) {
+      expect(KNOWN_HANDOFF_FLAGS.has(key), `${key} is registered AND in NEAR_MISS`).toBe(false);
+    }
+  });
+});
+
+// The registry must cover every flag the handoff path actually parses. Comments are
+// stripped first: cli-main.js discusses "--vision-key/--arch-key" in prose, and matching
+// prose would let a test pass on a flag no code reads (and, worse, hide a real parse site
+// behind a false positive).
+const PARSER_FILES = [
+  'scripts/modules/handoff/cli/cli-main.js',
+  'scripts/modules/handoff/cli/leo5-commands.js',
+  'scripts/modules/handoff/auto-proceed-resolver.js',
+  'lib/cross-sd-overlap.js',
+];
+
+const PARSE_SITE = /(?:args|argv)\.(?:includes|indexOf|lastIndexOf)\(\s*'(--[a-z0-9-]+)'|===\s*'(--[a-z0-9-]+)'|getFlag\(\s*'(--[a-z0-9-]+)'/g;
+
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+describe('registry drift', () => {
+  it('registers every flag parsed on the handoff.js path', () => {
+    const missing = [];
+    for (const rel of PARSER_FILES) {
+      const src = stripComments(readFileSync(resolve(REPO, rel), 'utf8'));
+      for (const m of src.matchAll(PARSE_SITE)) {
+        const flag = m[1] || m[2] || m[3];
+        if (flag && !KNOWN_HANDOFF_FLAGS.has(flag)) missing.push(`${rel}: ${flag}`);
+      }
+    }
+    expect(missing, `unregistered flags would be REJECTED at runtime:\n${missing.join('\n')}`).toEqual([]);
+  });
+
+  it('actually finds parse sites — a regex that matches nothing would pass vacuously', () => {
+    // Without this the drift test is a green light wired to no bulb.
+    const src = stripComments(readFileSync(resolve(REPO, 'scripts/modules/handoff/cli/cli-main.js'), 'utf8'));
+    expect([...src.matchAll(PARSE_SITE)].length).toBeGreaterThan(3);
+  });
+});
+
+// End-to-end at the consumer: the guard has to fire in the real binary, not just in a
+// unit. Both cases exit before any DB work, so this touches nothing.
+describe('handoff.js binary', () => {
+  const run = (args) => {
+    try {
+      return { status: 0, out: execFileSync(process.execPath, ['scripts/handoff.js', ...args], { cwd: REPO, encoding: 'utf8', stdio: 'pipe' }) };
+    } catch (e) {
+      return { status: e.status, out: `${e.stdout || ''}${e.stderr || ''}` };
+    }
+  };
+
+  it('refuses --precheck on execute, non-zero, without reaching a gate', () => {
+    const { status, out } = run(['execute', 'PLAN-TO-EXEC', 'SD-DOES-NOT-EXIST-001', '--precheck']);
+    expect(status).toBe(2);
+    expect(out).toContain('Unknown flag');
+    expect(out).toContain('NOTHING WAS EXECUTED');
+  });
+
+  it('still runs a legitimate invocation — the fleet-breaking direction', () => {
+    const { status, out } = run(['help']);
+    expect(status).toBe(0);
+    expect(out).toContain('LEO Protocol Handoff System');
+  });
+});


### PR DESCRIPTION
## What

`handoff.js` is the canonical writer for `strategic_directives_v2`. It read argv positionally and silently ignored anything it did not recognise, so a typo and a supported option were byte-identical in effect. A worker passed `execute PLAN-TO-EXEC <SD> --precheck` expecting a rehearsal and performed the real transition.

The guard is the first statement that inspects input — ahead of the re-exec preflight, the claim guard, and the heavy import graph — so a rejected invocation cannot spawn a child, touch a claim, or reach an executor. Exit 2, nothing mutated, the unknown flag named, the documented flags listed.

## Two corrections to the ticket's premise

**1. "argv read only at :114 and :124" is true of the wrapper, not the path.** `handoff.js` is 145 lines that delegate. Flags are consumed in `cli-main.js`, `leo5-commands.js`, `auto-proceed-resolver.js` (reading `process.argv` directly), and `lib/cross-sd-overlap.js` `parseAckFlags()` — called from *inside gates*. A whitelist built from the two cited lines would have legalised one flag and rejected nineteen, on the script every seat must use. The registry cites a parse site per flag, and a drift test reads those parsers and fails the moment a new site outruns it.

**2. `handoff.js` does have dry runs.** `precheck` and `dry-run` are commands, `--dry-run` is a flag on execute that short-circuits before the executor, and all three appear in `--help`. The accident was a near miss, not a missing feature — so the rejection names the real forms.

## Validated against a second, independent source

A whitelist derived only from the parsers inherits the parsers' blind spots, so all 152 real `handoff.js` invocation forms in the repo were run through the guard. That caught what reading could not:

- `--help` works today via the switch's `default:` arm — registering it prevents a regression on universal convention.
- Three live paths hand `handoff.js` a `--sd-id` flag **nothing parses**. The SD id is positional, so those strings have been passing the literal `"--sd-id"` as the SD key. Two sat in one file 120 lines apart; one named a subcommand (`exec-to-plan`) that does not exist. Fixed rather than whitelisted — registering an unparsed flag would preserve the exact silent misfire this change abolishes.

## Proof

Mutation, not a green tree:

| Mutation | Kills |
|---|---|
| Neuter `process.exit(2)` | binary test |
| Drop one flag from the registry | drift test |
| Blank the `PARSE_SITE` regex | vacuity check |

16 guard tests; 850 tests green across the 86 files importing the changed sources.

QF-20260807-289