### PR TITLE
fix(QF-20260807-745): the reaper witnesses a merge — it cannot vouch for scope

### DIFF
--- a/scripts/orphan-qf-reaper.mjs
+++ b/scripts/orphan-qf-reaper.mjs
@@ -35,9 +35,28 @@ import { execSync } from 'node:child_process';
 import { createClient } from '@supabase/supabase-js';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 import { resolveGitHubRepo } from '../lib/repo-paths.js';
+// QF-20260807-745: the reaper reuses complete-quick-fix's reconcile contract rather than
+// restating it. QF-20260725-691 already settled what a merged PR proves at the front door;
+// a second, divergent copy here is how the two answers drift apart again.
+import { buildMergedReconcileUpdate } from './modules/complete-quick-fix/orchestrator.js';
 
 const SAFETY_WINDOW_MINUTES = Number(process.env.ORPHAN_QF_REAPER_SAFETY_WINDOW_MINUTES || 5);
 const DRY_RUN = process.env.ORPHAN_QF_REAPER_DRY_RUN === 'true';
+
+// QF-20260807-745. Landing NON-TERMINAL re-opened a loop the old terminal close hid: a
+// witnessed row keeps matching the candidate query, so without this the reaper would
+// re-witness the same QF every 15 minutes and append the note to verification_notes
+// forever. The old code could not hit this because `completed` removed the row from the
+// query — the bug was masked by the very behaviour being fixed.
+export const WITNESS_MARKER = 'merge witnessed, SCOPE ACCEPTANCE OUTSTANDING';
+
+export function alreadyWitnessed(qf, prUrl) {
+  const notes = qf?.verification_notes;
+  if (typeof notes !== 'string' || !notes.includes(WITNESS_MARKER)) return false;
+  // Same PR already witnessed → nothing new to record. A DIFFERENT PR on the same QF is
+  // new information (the guard-then-fix case) and is allowed through to be recorded.
+  return prUrl ? notes.includes(prUrl) : true;
+}
 
 function log(action, fields) {
   process.stdout.write(JSON.stringify({ action, ts: new Date().toISOString(), ...fields }) + '\n');
@@ -119,7 +138,10 @@ export async function main() {
 
   const { data: candidates, error: queryError } = await supabase
     .from('quick_fixes')
-    .select('id, status, pr_url, started_at, claiming_session_id, target_application')
+    // verification_notes is REQUIRED, not decorative (QF-20260807-745): alreadyWitnessed()
+    // reads it to stop re-witnessing every 15 min, and buildMergedReconcileUpdate PREPENDS
+    // it — unselected, the guard silently reads undefined and prior notes are overwritten.
+    .select('id, status, pr_url, started_at, claiming_session_id, target_application, verification_notes')
     .in('status', ['open', 'in_progress'])
     .not('pr_url', 'is', null)
     .lt('started_at', cutoffIso)
@@ -140,6 +162,7 @@ export async function main() {
     orphan_reconciled: 0,
     orphan_skipped_no_merged_pr: 0,
     orphan_skipped_already_completed: 0,
+    skipped_already_witnessed: 0,
     errored: 0,
   };
 
@@ -176,6 +199,12 @@ export async function main() {
     const mergeCommitSha = pr.data.mergeCommit?.oid || null;
     const mergedAt = pr.data.mergedAt || new Date().toISOString();
 
+    if (alreadyWitnessed(qf, qf.pr_url)) {
+      log('skipped_already_witnessed', { qf_id: qf.id, pr_number: prNumber });
+      summary.skipped_already_witnessed += 1;
+      continue;
+    }
+
     if (DRY_RUN) {
       log('dry_run_would_reconcile', { qf_id: qf.id, pr_number: prNumber, merge_commit_sha: mergeCommitSha });
       summary.reconciled += 1;
@@ -187,19 +216,19 @@ export async function main() {
     const { data: updated, error: updateError } = await supabase
       .from('quick_fixes')
       .update({
-        status: 'completed',
-        completed_at: mergedAt,
-        commit_sha: mergeCommitSha,
-        compliance_verdict: 'PASS',
-        compliance_details: 'Auto-reconciled by orphan-qf-reaper — PR merged on GitHub without complete-quick-fix.js flipping DB status.',
-        verified_by: 'ORPHAN_REAPER',
-        verification_notes: JSON.stringify({
-          reconciled_at: new Date().toISOString(),
-          closed_by: 'orphan_reaper',
-          pr_number: prNumber,
-          merge_commit_sha: mergeCommitSha,
+        // QF-20260807-745: was status:'completed' + force_completed + compliance_verdict:'PASS'.
+        // A merged PR witnesses that CODE LANDED; terminal `completed` asserts the QF's SCOPE
+        // WAS SATISFIED. The reaper can observe the first and can never establish the second,
+        // and the terminal status made complete-quick-fix.js answer already-completed, so the
+        // scope-proof gate never ran — the backstop fired first and hid the door it was backing.
+        ...buildMergedReconcileUpdate({
+          qf,
+          prUrl: qf.pr_url,
+          mergeSha: mergeCommitSha,
+          nowIso: mergedAt,
+          scopeAcceptedBy: null, // the reaper is a witness; it is never the attester
         }),
-        force_completed: true,
+        compliance_details: `Merge witnessed by orphan-qf-reaper (pr_url path, PR #${prNumber}) — NOT a scope acceptance. Attest via complete-quick-fix.js --scope-accepted.`,
       })
       .eq('id', qf.id)
       .eq('status', qf.status)
@@ -228,7 +257,7 @@ export async function main() {
   // per QF-20260508-230 retro). Resolve via `qf/<id>` branch convention.
   const { data: orphanCandidates, error: orphanQueryError } = await supabase
     .from('quick_fixes')
-    .select('id, status, started_at, claiming_session_id, target_application')
+    .select('id, status, started_at, claiming_session_id, target_application, verification_notes')
     .in('status', ['open', 'in_progress'])
     .is('pr_url', null)
     .not('claiming_session_id', 'is', null)
@@ -271,6 +300,12 @@ export async function main() {
       const mergeCommitSha = mergeCommit?.oid || null;
       const reconciledAt = mergedAt || new Date().toISOString();
 
+      if (alreadyWitnessed(qf, prUrl)) {
+        log('skipped_already_witnessed_orphan', { qf_id: qf.id, pr_number: prNumber, branch: branchName });
+        summary.skipped_already_witnessed += 1;
+        continue;
+      }
+
       if (DRY_RUN) {
         log('dry_run_would_reconcile_orphan', { qf_id: qf.id, pr_number: prNumber, branch: branchName, merge_commit_sha: mergeCommitSha });
         summary.orphan_reconciled += 1;
@@ -280,21 +315,20 @@ export async function main() {
       const { data: updated, error: updateError } = await supabase
         .from('quick_fixes')
         .update({
-          status: 'completed',
-          completed_at: reconciledAt,
-          commit_sha: mergeCommitSha,
-          pr_url: prUrl,
-          compliance_verdict: 'PASS',
-          compliance_details: 'Auto-reconciled by orphan-qf-reaper (branch-derived path) — PR merged on GitHub without pr_url ever populated.',
-          verified_by: 'ORPHAN_REAPER',
-          verification_notes: JSON.stringify({
-            reconciled_at: new Date().toISOString(),
-            closed_by: 'orphan_reaper_branch_derived',
-            pr_number: prNumber,
-            branch: branchName,
-            merge_commit_sha: mergeCommitSha,
+          // QF-20260807-745, the incident this fix is named for. This path closed on the FIRST
+          // PR merged from branch `qf/<id>` — and guard-then-fix is a normal, sometimes MANDATORY
+          // decomposition. On QF-20260804-647 it closed at 17:17Z citing the GUARD PR (which
+          // removed zero tax) while the actual fix was still 65 minutes from existing. A reaper
+          // that can only say "done" cannot express "PR merged, scope unvouched" — so it said the
+          // only thing it knew how to say, and it was wrong.
+          ...buildMergedReconcileUpdate({
+            qf,
+            prUrl,
+            mergeSha: mergeCommitSha,
+            nowIso: reconciledAt,
+            scopeAcceptedBy: null,
           }),
-          force_completed: true,
+          compliance_details: `Merge witnessed by orphan-qf-reaper (branch-derived path, branch ${branchName}, PR #${prNumber}) — the FIRST merged PR from this branch, which is NOT proof this QF's scope is satisfied. Attest via complete-quick-fix.js --scope-accepted.`,
         })
         .eq('id', qf.id)
         .eq('status', qf.status)

--- a/tests/unit/scripts/orphan-qf-reaper-force-completed.test.js
+++ b/tests/unit/scripts/orphan-qf-reaper-force-completed.test.js
@@ -16,6 +16,8 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
 import { describe, it, expect } from 'vitest';
+import { buildMergedReconcileUpdate } from '../../../scripts/modules/complete-quick-fix/orchestrator.js';
+import { alreadyWitnessed, WITNESS_MARKER } from '../../../scripts/orphan-qf-reaper.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -23,6 +25,12 @@ const REAPER_PATH = join(__dirname, '..', '..', '..', 'scripts', 'orphan-qf-reap
 
 describe('orphan-qf-reaper.mjs — force_completed coverage (QF-847 static guard)', () => {
   const source = readFileSync(REAPER_PATH, 'utf8');
+
+  // Shared with the drift-style scans below: a source test that reads its own explanatory
+  // prose measures the documentation, not the code.
+  function stripComments(src) {
+    return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  }
 
   // Robust to formatting: count `.update({` blocks targeting quick_fixes that
   // also contain `force_completed: true` somewhere in the same block (until
@@ -53,18 +61,97 @@ describe('orphan-qf-reaper.mjs — force_completed coverage (QF-847 static guard
     expect(blocks.length).toBe(2);
   });
 
-  it('every UPDATE block sets status:completed AND force_completed:true', () => {
-    const blocks = findUpdateBlocks(source);
+  // QF-20260807-745 RESTATES this guard; it does not retire it. QF-847's invariant was
+  // "never write status:'completed' without force_completed:true", because the reaper had
+  // been violating completed_requires_verification on every cron run since 2026-05-08 and
+  // stranded QF-911/-492/-182/-648. That invariant is still correct — the reaper simply no
+  // longer writes a terminal status at all, because a merged PR witnesses that CODE LANDED
+  // and never that this QF's SCOPE WAS SATISFIED.
+  //
+  // Stated CONDITIONALLY so it stays armed rather than becoming vacuously true: if any
+  // future edit reintroduces a terminal close here, force_completed must come with it.
+  it('no UPDATE block writes a terminal status — and any that ever does must carry force_completed', () => {
+    // Comments MUST be stripped first. The fix documents itself by quoting the code it
+    // replaced ("was status:'completed' ..."), so a raw scan matches the explanation and
+    // reports the very defect that was removed. Caught by this test failing on its own prose.
+    const blocks = findUpdateBlocks(stripComments(source));
+    expect(blocks.length).toBeGreaterThan(0); // vacuity: a zero-block scan must not pass
     for (const [idx, block] of blocks.entries()) {
-      expect(block, `block #${idx + 1} missing status:'completed'`).toMatch(/status:\s*'completed'/);
-      expect(block, `block #${idx + 1} missing force_completed:true`).toMatch(/force_completed:\s*true/);
-      expect(block, `block #${idx + 1} missing verified_by:'ORPHAN_REAPER'`).toMatch(/verified_by:\s*'ORPHAN_REAPER'/);
-      expect(block, `block #${idx + 1} missing verification_notes`).toMatch(/verification_notes:/);
+      const writesTerminal = /status:\s*'completed'/.test(block);
+      expect(writesTerminal, `block #${idx + 1} writes status:'completed' — the reaper witnesses a merge, it cannot vouch for scope (QF-20260807-745)`).toBe(false);
+      if (writesTerminal) {
+        // QF-20260508-847 preserved for the day someone reintroduces a terminal close.
+        expect(block, `block #${idx + 1} writes completed without force_completed:true — violates completed_requires_verification`).toMatch(/force_completed:\s*true/);
+      }
     }
+  });
+
+  it('both UPDATE blocks route through the shared reconcile contract, not a local restatement', () => {
+    // The drift this prevents is the reason the defect existed: complete-quick-fix already
+    // decided what a merged PR proves (QF-20260725-691) and the reaper answered differently.
+    const blocks = findUpdateBlocks(source);
+    expect(blocks.length).toBe(2);
+    for (const [idx, block] of blocks.entries()) {
+      expect(block, `block #${idx + 1} does not spread buildMergedReconcileUpdate`).toMatch(/\.\.\.buildMergedReconcileUpdate\(/);
+    }
+    expect(source).toMatch(/import\s*\{[^}]*buildMergedReconcileUpdate[^}]*\}\s*from/);
   });
 
   it('still references the SD origin (FR1) in the file header', () => {
     expect(source).toMatch(/SD-LEO-INFRA-LIFECYCLE-RECONCILIATION-ORPHAN-001.*FR1/);
+  });
+
+  // QF-20260807-745: a defect the FIX created. Terminal `completed` removed a row from the
+  // candidate query; non-terminal `in_progress` does not, so without a guard the reaper
+  // re-witnesses the same QF every 15 minutes and appends to verification_notes forever.
+  // The old code could not exhibit this — the bug was masked by the behaviour being fixed.
+  describe('re-witness guard (the loop the terminal close was hiding)', () => {
+    const witnessed = (prUrl) => ({
+      verification_notes: `PR ${prUrl} MERGED and reachable from origin/main — ${WITNESS_MARKER}. Attest with: ...`,
+    });
+
+    it('does not re-witness the SAME PR', () => {
+      expect(alreadyWitnessed(witnessed('https://github.com/o/r/pull/7'), 'https://github.com/o/r/pull/7')).toBe(true);
+    });
+
+    it('DOES admit a DIFFERENT PR on the same QF — that is the guard-then-fix case', () => {
+      // QF-647 merged a guard PR first and the real fix 65 minutes later. A second, later PR
+      // is new information; suppressing it would rebuild the blindness from the other side.
+      expect(alreadyWitnessed(witnessed('https://github.com/o/r/pull/7'), 'https://github.com/o/r/pull/8')).toBe(false);
+    });
+
+    it('admits a row that has never been witnessed', () => {
+      expect(alreadyWitnessed({ verification_notes: null }, 'https://github.com/o/r/pull/7')).toBe(false);
+      expect(alreadyWitnessed({}, 'https://github.com/o/r/pull/7')).toBe(false);
+      expect(alreadyWitnessed({ verification_notes: 'some unrelated note' }, 'https://github.com/o/r/pull/7')).toBe(false);
+    });
+
+    it('BOTH candidate queries select verification_notes — the guard reads it', () => {
+      // Without this the predicate reads undefined and is silently false on every run, AND
+      // buildMergedReconcileUpdate PREPENDS the same column, so prior notes are overwritten.
+      // One omission, two defects; this pins the column that prevents both.
+      // Anchor on target_application: it appears ONLY in the two CANDIDATE queries. Matching
+      // `id, status` alone also catches the `.select('id, status')` on each UPDATE's return,
+      // which found 4 and would have made this assertion mean something else entirely.
+      const selects = (stripComments(source).match(/\.select\('[^']*'\)/g) || [])
+        .filter((s) => s.includes('target_application'));
+      expect(selects.length, 'expected exactly the 2 candidate queries').toBe(2);
+      for (const [idx, sel] of selects.entries()) {
+        expect(sel, `candidate select #${idx + 1} omits verification_notes`).toContain('verification_notes');
+      }
+    });
+
+    it('preserves existing verification_notes rather than overwriting them', () => {
+      const payload = buildMergedReconcileUpdate({
+        qf: { id: 'QF-20260101-004', verification_notes: 'EARLIER HISTORY' },
+        prUrl: 'https://github.com/o/r/pull/9',
+        mergeSha: 'sha9',
+        nowIso: '2026-01-01T00:00:00Z',
+        scopeAcceptedBy: null,
+      });
+      expect(payload.verification_notes).toContain('EARLIER HISTORY');
+      expect(payload.verification_notes).toContain(WITNESS_MARKER);
+    });
   });
 
   // SD-LEO-INFRA-ORPHAN-REAPER-INTEGRATION-001 FR-1: per-path UPDATE column allowlist
@@ -84,21 +171,57 @@ describe('orphan-qf-reaper.mjs — force_completed coverage (QF-847 static guard
       return new RegExp(`\\b${key}\\s*:`).test(block);
     }
 
-    it('pr_url path UPDATE block contains all 8 required columns', () => {
-      const blocks = findUpdateBlocks(source);
-      const block = blocks[0]; // first .update({...}) is the pr_url path
-      for (const col of REQUIRED_BOTH_PATHS) {
-        expect(blockHasKey(block, col), `pr_url path missing column: ${col}`).toBe(true);
-      }
+    // QF-20260807-745: these two were source-greps for literal `<key>:` text. Both blocks now
+    // spread the shared contract, so the columns are REAL but INVISIBLE to a text scan — a
+    // grep for a statement form is not a test for the behaviour. Assert the payload the
+    // reaper actually sends instead, which is strictly stronger than what it replaced.
+    it('pr_url path payload carries the witness columns and NO terminal-close columns', () => {
+      const payload = {
+        ...buildMergedReconcileUpdate({
+          qf: { id: 'QF-20260101-001', verification_notes: null },
+          prUrl: 'https://github.com/o/r/pull/1',
+          mergeSha: 'abc123',
+          nowIso: '2026-01-01T00:00:00Z',
+          scopeAcceptedBy: null,
+        }),
+        compliance_details: 'Merge witnessed by orphan-qf-reaper (pr_url path, PR #1) — NOT a scope acceptance.',
+      };
+      expect(payload.status).toBe('in_progress');
+      expect(payload.pr_url).toBe('https://github.com/o/r/pull/1');
+      expect(payload.commit_sha).toBe('abc123');
+      expect(payload.verification_notes).toContain(WITNESS_MARKER);
+      expect(payload.compliance_details).toContain('NOT a scope acceptance');
+      // The whole point: nothing here may assert the QF is finished.
+      expect(payload.force_completed).toBeUndefined();
+      expect(payload.compliance_verdict).toBeUndefined();
+      expect(payload.completed_at).toBeUndefined();
     });
 
-    it('branch-derived path UPDATE block contains all 9 required columns (incl. pr_url)', () => {
-      const blocks = findUpdateBlocks(source);
-      const block = blocks[1]; // second .update({...}) is the branch-derived path
-      const required = [...REQUIRED_BOTH_PATHS, ...REQUIRED_BRANCH_DERIVED_ONLY];
-      for (const col of required) {
-        expect(blockHasKey(block, col), `branch-derived path missing column: ${col}`).toBe(true);
-      }
+    it('branch-derived path payload sets pr_url (it was null) and is likewise non-terminal', () => {
+      const payload = buildMergedReconcileUpdate({
+        qf: { id: 'QF-20260101-002', verification_notes: null },
+        prUrl: 'https://github.com/o/r/pull/2',
+        mergeSha: 'def456',
+        nowIso: '2026-01-01T00:00:00Z',
+        scopeAcceptedBy: null,
+      });
+      expect(payload.status).toBe('in_progress');
+      expect(payload.pr_url).toBe('https://github.com/o/r/pull/2');
+      expect(payload.force_completed).toBeUndefined();
+    });
+
+    it('the SAME contract still reaches terminal WITH a scope attestation (QF-594 control)', () => {
+      // Two-sided: proves the non-terminal result above is caused by the missing attestation,
+      // not by the contract being incapable of completing anything.
+      const payload = buildMergedReconcileUpdate({
+        qf: { id: 'QF-20260101-003', verification_notes: null },
+        prUrl: 'https://github.com/o/r/pull/3',
+        mergeSha: 'ghi789',
+        nowIso: '2026-01-01T00:00:00Z',
+        scopeAcceptedBy: 'Bravo — scope verified',
+      });
+      expect(payload.status).toBe('completed');
+      expect(payload.force_completed).toBe(true); // QF-847's constraint still honoured here
     });
 
     it('neither UPDATE block contains forbidden columns', () => {
@@ -128,6 +251,10 @@ describe('orphan-qf-reaper.mjs — force_completed coverage (QF-847 static guard
       'skipped_pr_not_merged', 'skipped_pr_not_found', 'skipped_already_completed',
       'orphan_evaluated', 'orphan_reconciled',
       'orphan_skipped_no_merged_pr', 'orphan_skipped_already_completed',
+      // QF-20260807-745: landing non-terminal keeps a witnessed row in the candidate query,
+      // so re-witnessing had to be counted as well as prevented — a silent skip is a skip
+      // nobody can see in the Action log.
+      'skipped_already_witnessed',
       'errored',
     ];
 
@@ -144,7 +271,7 @@ describe('orphan-qf-reaper.mjs — force_completed coverage (QF-847 static guard
       return src.slice(start, i);
     }
 
-    it('summary block declares all 10 expected counter keys', () => {
+    it('summary block declares all expected counter keys', () => {
       const block = extractSummaryBlock(source);
       expect(block, 'summary block not found').not.toBeNull();
       for (const key of EXPECTED_KEYS) {
@@ -152,7 +279,7 @@ describe('orphan-qf-reaper.mjs — force_completed coverage (QF-847 static guard
       }
     });
 
-    it('summary block declares ONLY the expected 10 counter keys (no extras)', () => {
+    it('summary block declares ONLY the expected counter keys (no extras)', () => {
       const block = extractSummaryBlock(source);
       expect(block).not.toBeNull();
       // Count `<word>:` occurrences at top level (rough — but valid since summary is a flat object)

--- a/tests/unit/scripts/orphan-qf-reaper-integration.test.js
+++ b/tests/unit/scripts/orphan-qf-reaper-integration.test.js
@@ -128,7 +128,7 @@ beforeEach(() => {
 });
 
 describe('orphan-qf-reaper main() integration (FR-4)', () => {
-  it('TS-1: pr_url path with MERGED PR → UPDATE issued with 8-col shape', async () => {
+  it('TS-1: pr_url path with MERGED PR → NON-TERMINAL witness UPDATE (no terminal-close columns)', async () => {
     supabaseInstance = makeSupabaseMock({
       firstQuery: [{ id: 'QF-20260508-001', status: 'open', pr_url: 'https://github.com/x/y/pull/123', started_at: '2026-05-08T00:00:00Z', claiming_session_id: 'sess' }],
       secondQuery: [],
@@ -153,19 +153,26 @@ describe('orphan-qf-reaper main() integration (FR-4)', () => {
     const calls = supabaseInstance._calls.updateCalls;
     expect(calls.length).toBe(1);
     const payload = calls[0].payload;
-    const requiredCols = ['status', 'completed_at', 'commit_sha', 'compliance_verdict', 'compliance_details', 'verified_by', 'verification_notes', 'force_completed'];
+    // QF-20260807-745: the reaper witnesses a merge; it cannot vouch that the QF's scope was
+    // satisfied, so this payload must record the true fact without asserting the false one.
+    const requiredCols = ['status', 'commit_sha', 'compliance_details', 'verification_notes'];
     for (const c of requiredCols) {
       expect(payload, `missing ${c}`).toHaveProperty(c);
     }
-    expect(payload.status).toBe('completed');
-    expect(payload.force_completed).toBe(true);
-    expect(payload.verified_by).toBe('ORPHAN_REAPER');
+    expect(payload.status).toBe('in_progress');
+    expect(payload.verification_notes).toContain('SCOPE ACCEPTANCE OUTSTANDING');
+    expect(payload.compliance_details).toContain('NOT a scope acceptance');
+    // The terminal-close columns must be ABSENT — their presence is the defect.
+    expect(payload).not.toHaveProperty('force_completed');
+    expect(payload).not.toHaveProperty('compliance_verdict');
+    expect(payload).not.toHaveProperty('completed_at');
+    expect(payload.verified_by).toBeUndefined(); // nothing was verified
     // Forbidden columns must NOT be present
     expect(payload).not.toHaveProperty('metadata');
     expect(payload).not.toHaveProperty('merged_via');
   });
 
-  it('TS-3: branch-derived path with merged PR → UPDATE with 9-col shape including pr_url', async () => {
+  it('TS-3: branch-derived path with merged PR → NON-TERMINAL witness UPDATE including pr_url', async () => {
     supabaseInstance = makeSupabaseMock({
       firstQuery: [],
       secondQuery: [{ id: 'QF-20260508-002', status: 'open', started_at: '2026-05-08T00:00:00Z', claiming_session_id: 'sess' }],
@@ -193,8 +200,13 @@ describe('orphan-qf-reaper main() integration (FR-4)', () => {
     const payload = calls[0].payload;
     expect(payload).toHaveProperty('pr_url');
     expect(payload.pr_url).toBe('https://github.com/x/y/pull/999');
-    expect(payload.status).toBe('completed');
-    expect(payload.force_completed).toBe(true);
+    // QF-20260807-745 — the incident path. This closed on the FIRST PR merged from qf/<id>,
+    // and guard-then-fix is a normal decomposition: on QF-647 it closed citing the guard PR
+    // while the real fix was still 65 minutes from existing. Non-terminal from here on.
+    expect(payload.status).toBe('in_progress');
+    expect(payload.verification_notes).toContain('SCOPE ACCEPTANCE OUTSTANDING');
+    expect(payload).not.toHaveProperty('force_completed');
+    expect(payload).not.toHaveProperty('compliance_verdict');
     expect(payload).not.toHaveProperty('metadata');
   });
 


### PR DESCRIPTION
## What

`orphan-qf-reaper` force-completed a quick-fix on the **first PR merged from `qf/<id>`**, with no scope proof. On QF-20260804-647 it closed at 17:17Z citing the *guard* PR (which removed zero tax) while the actual fix was still 65 minutes from existing. The terminal status then made `complete-quick-fix.js` answer *already-completed*, so **the scope-proof gate never ran** — the backstop fired first and hid the door it was backing up. Guard-then-fix is a normal, sometimes mandatory decomposition, so this is a standing hazard, and the reaper runs **every 15 minutes**.

## The shape changed once I read the front door

`complete-quick-fix` already settled this in QF-20260725-691, and `buildMergedReconcileUpdate` is **exported and pure**. So the reaper now *imports* that contract instead of restating it — one contract, two callers, no drift. With `scopeAcceptedBy: null` it lands `status:'in_progress'` plus a SCOPE ACCEPTANCE OUTSTANDING note, so the gate still runs.

That reframes the defect: **the front door was fixed months ago; the reaper is the back door that never got the memo.**

It also settled the design question — `orchestrator.js:270-271` states the enum is `(open, in_progress, completed, escalated)`, so a new `needs_verification` value would have violated the CHECK. No migration, no DDL.

## Both paths, measured before deciding

17 lifetime reaper closes: **15 branch-derived, 2 `pr_url`-cited, all 17 `force_completed=true`**. The cited path commits the identical substitution — an operator-supplied `pr_url` is a PR *pointer*, not a scope attestation — and at ~1-2 rows/day the "strand the queue" risk isn't real. Fixing one of two would have been the fix-the-instance error.

## Two second-order defects the fix itself created

1. **Landing non-terminal re-opened a loop the terminal close was hiding.** A witnessed row keeps matching the candidate query, so the reaper would re-witness it every 15 min and append to `verification_notes` forever. Added `alreadyWitnessed()` + a counter.
2. **That guard read `verification_notes`, which neither candidate query selected.** It would have been silently false on every run — and the shared builder *prepends* that same column, so prior notes would have been overwritten. One omission, two defects.

## QF-847 restated, not deleted

QF-20260508-847 asserted every UPDATE sets `completed` + `force_completed`, because the reaper once violated `completed_requires_verification` on every cron run. That invariant is still correct — it's now unreachable. It is restated **conditionally** (no block writes `completed`; if one ever does, it must carry `force_completed`) so it stays armed rather than vacuously true.

The column-allowlist tests were source-greps; both blocks now use a spread, so those columns are real but invisible to a text scan. They assert the actual payload now, and include the **QF-594 control**: the same contract still reaches terminal *with* an attestation.

## Proof

| Mutation | Kills |
|---|---|
| Reinstate a terminal close | terminal-status guard + TS-3 |
| Drop `verification_notes` from a select | select pin |
| Neuter `alreadyWitnessed` | re-witness guard |

My own pin tripped on my own prose (the fix quotes the code it replaced); comments are stripped now. 48 tests green across the 5 suites touching the reaper. Mutations restored from copies, not `git checkout --`, and the baseline verified byte-exact.

QF-20260807-745