### PR TITLE
SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-A: table-shaped fixture predicates on the canonical exclusion module

### DIFF
--- a/.artifacts/mutation-proof.mjs
+++ b/.artifacts/mutation-proof.mjs
@@ -1,0 +1,115 @@
+/**
+ * MUTATION PROOF for SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-A (FR-3 / TS-6).
+ *
+ * A test that still passes when the thing it tests is neutered is not a test. This script breaks
+ * each predicate in turn and asserts the suite goes RED, then restores the file and asserts GREEN.
+ *
+ * TWO DIRECTIONS, deliberately. Under-detection mutations (predicate always false) prove the
+ * POSITIVE arms are load-bearing. The final mutation goes the other way — it makes the
+ * periodic_process_registry predicate reuse the canonical FIXTURE_KEY_RE, reproducing the exact
+ * over-eating defect this SD exists to prevent. If THE CONTROL block is real, that must go red too.
+ * A one-directional mutation proof would leave the over-eating direction unverified, which is the
+ * direction that destroys real data.
+ */
+import { readFileSync, writeFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+const MODULE = 'lib/governance/fixture-exclusion.mjs';
+const SUITES = 'tests/unit/governance/fixture-exclusion-per-table.test.js tests/unit/governance/fixture-exclusion.test.js';
+const ORIGINAL = readFileSync(MODULE, 'utf8');
+
+const MUTATIONS = [
+  {
+    name: 'isFixtureProcessKey -> always false',
+    direction: 'under-detection',
+    from: 'return typeof processKey === \'string\' && processKey.startsWith(FIXTURE_PROCESS_KEY_PREFIX);',
+    to: 'return false;',
+  },
+  {
+    name: 'isFixtureHealthSnapshot -> always false',
+    direction: 'under-detection',
+    from: 'return hasFixtureMarker(row.metadata);',
+    to: 'return false;',
+  },
+  {
+    name: 'isFixtureCoordinationRow -> always false',
+    direction: 'under-detection',
+    from: 'return hasFixtureMarker(row.payload);',
+    to: 'return false;',
+  },
+  {
+    name: 'isFixtureQfByCreatedBy -> always false',
+    direction: 'under-detection',
+    from: 'return qf.created_by === FIXTURE_CREATED_BY;',
+    to: 'return false;',
+  },
+  {
+    // The opt-in boundary itself is load-bearing: folding created_by back into isFixtureQf would
+    // expose five live consumers (incl. the dispatch queue) to a one-column suppression vector.
+    name: 'created_by folded back into isFixtureQf (THE OPT-IN BOUNDARY BREACH)',
+    direction: 'over-detection — re-exposes an anon-writable suppression vector',
+    from: '  if (typeof qf.id === \'string\' && /^QF-(TEST|DEMO)\\b/i.test(qf.id)) return true;',
+    to: '  if (typeof qf.id === \'string\' && /^QF-(TEST|DEMO)\\b/i.test(qf.id)) return true;\n  if (qf.created_by === FIXTURE_CREATED_BY) return true;',
+  },
+  {
+    name: 'isFixtureVenture is_demo branch removed',
+    direction: 'under-detection',
+    from: '  if (v.is_demo === true) return true;\n',
+    to: '',
+  },
+  {
+    name: 'hasFixtureMarker accepts truthy instead of strict true',
+    direction: 'over-detection',
+    from: 'return carrier.is_fixture === true || carrier.synthetic === true;',
+    to: 'return Boolean(carrier.is_fixture) || Boolean(carrier.synthetic);',
+  },
+  {
+    // THE ONE THAT MATTERS MOST: reintroduce the over-eating defect.
+    name: 'isFixtureProcessKey reuses canonical FIXTURE_KEY_RE (THE OVER-EATING DEFECT)',
+    direction: 'OVER-EATING — would destroy 5 real production rows',
+    from: 'return typeof processKey === \'string\' && processKey.startsWith(FIXTURE_PROCESS_KEY_PREFIX);',
+    to: 'return typeof processKey === \'string\' && FIXTURE_KEY_RE.test(processKey);',
+  },
+];
+
+function suiteIsGreen() {
+  try {
+    execSync(`npx vitest run ${SUITES}`, { stdio: 'pipe', encoding: 'utf8' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+console.log('Baseline (unmutated) ...');
+if (!suiteIsGreen()) {
+  console.error('BASELINE IS RED — cannot run a mutation proof against a failing suite.');
+  process.exit(2);
+}
+console.log('  baseline GREEN\n');
+
+let survivors = 0;
+for (const m of MUTATIONS) {
+  if (!ORIGINAL.includes(m.from)) {
+    console.error(`SKIP (anchor not found — mutation is vacuous): ${m.name}`);
+    survivors++;
+    continue;
+  }
+  writeFileSync(MODULE, ORIGINAL.replace(m.from, m.to));
+  const green = suiteIsGreen();
+  writeFileSync(MODULE, ORIGINAL); // restore before anything else can read it
+  const verdict = green ? 'SURVIVED — TEST IS VACUOUS' : 'killed';
+  console.log(`  [${green ? 'FAIL' : ' OK '}] ${m.name}\n         direction: ${m.direction}\n         ${verdict}`);
+  if (green) survivors++;
+}
+
+// Restore-and-verify: never leave a mutated module behind, and prove the restore by re-reading
+// from disk rather than trusting the write.
+writeFileSync(MODULE, ORIGINAL);
+const restored = readFileSync(MODULE, 'utf8') === ORIGINAL;
+console.log(`\nmodule restored (re-read from disk): ${restored ? 'yes' : 'NO — MANUAL FIX REQUIRED'}`);
+console.log(`final suite: ${suiteIsGreen() ? 'GREEN' : 'RED — MANUAL FIX REQUIRED'}`);
+console.log(survivors === 0
+  ? `\nALL ${MUTATIONS.length} MUTATIONS KILLED — every predicate is load-bearing.`
+  : `\n${survivors} MUTATION(S) SURVIVED — those tests do not test what they claim.`);
+process.exitCode = survivors === 0 && restored ? 0 : 1;

--- a/lib/governance/fixture-exclusion.mjs
+++ b/lib/governance/fixture-exclusion.mjs
@@ -1,21 +1,42 @@
 // SD-LEO-FIX-FIXTURE-PREFIX-EXCLUSION-001: canonical fixture-exclusion predicates for
 // metrics/gauges/counts.
 //
-// Fixture/test rows (ZZZ_-, UAT-, TEST--prefixed keys; __e2e/is_demo/is_synthetic
-// ventures) leaked into real gauges because the exclusion logic was fragmented across
-// 7+ helpers with divergent prefix sets — none covered ZZZ_. This module is the
-// CANONICAL union. Pure, top-level-await-free .mjs so BOTH worlds consume it (the
-// proven lib/coordinator/sd-exclusion.mjs interop pattern): ESM `import`s it; CJS
-// `require()`s it.
+// Fixture/test rows (ZZZ_-, UAT-, TEST--prefixed keys; __e2e/is_demo ventures) leaked into
+// real gauges because the exclusion logic was fragmented across 7+ helpers with divergent
+// prefix sets — none covered ZZZ_. This module is the CANONICAL union. Pure,
+// top-level-await-free .mjs so BOTH worlds consume it (the proven
+// lib/coordinator/sd-exclusion.mjs interop pattern): ESM `import`s it; CJS `require()`s it.
 //
-// Existing helpers documented as MIRRORS of subsets of this union (full collapse is
-// follow-on scope; when adding a NEW fixture prefix, add it HERE first, then sync):
+// ⚠ THE TOP-LEVEL-AWAIT-FREE PROPERTY IS LOAD-BEARING AND FAILS SILENTLY. scripts/fleet-dashboard.cjs:475
+// require()s this module from CJS INSIDE A TRY/CATCH. Introduce a top-level await (or any async
+// module evaluation) and that require throws, the catch swallows it, and the dashboard degrades to
+// UNFILTERED output — a filter that quietly stops filtering, with no error anywhere. Keep every
+// export synchronous, pure and side-effect-free. tests/unit/governance/fixture-exclusion-cjs-pin.cjs
+// pins this OUTSIDE vitest, because vitest's own ESM pipeline can satisfy a require() that plain
+// node cannot.
+//
+// MIRRORS — and the distinction below matters, because collapsing the wrong one reintroduces the
+// over-exclusion class this module exists to prevent (SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-A).
+// When adding a NEW fixture prefix, add it HERE first, then sync the DRIFT entries only.
+//
+// UNPAID DRIFT (should converge on this union):
 //   - lib/coordinator/sd-exclusion.mjs FIXTURE_RE (SD dispatch/belt exclusion)
-//   - lib/fleet/claim-eligibility.cjs TEST_FIXTURE_KEY_RE (dispatch classifier)
 //   - lib/sourcing-engine/refill-candidate-validity.js FIXTURE_TITLE_RE
 //   - scripts/sweep-fixture-residue.mjs FIXTURE_CLASS_RE (venture residue sweep)
 //   - SQL view v_sd_next_candidates NOT LIKE list (chairman-gated DDL — parity deferred,
 //     flagged in this SD's completion flags)
+//
+// DELIBERATE DIVERGENCE — DO NOT COLLAPSE. Each is narrower or broader ON PURPOSE:
+//   - lib/fleet/claim-eligibility.cjs TEST_FIXTURE_KEY_RE — narrower BY DESIGN. It gates DISPATCH
+//     eligibility, where over-exclusion STRANDS REAL WORK from ever being claimed. Widening it to
+//     this union needs the same adversarial precision review PR #6186 ran here.
+//   - lib/eva/chairman-decision-watcher.js FIXTURE_VENTURE_NAME_RE — excludes a bare `__` prefix ON
+//     PURPOSE so `__citest_chairman__:<run>` can still exercise that module's real write path.
+//   - lib/chairman/chairman-actionable.mjs FIXTURE_NAME_PATTERNS — a documented mirror of a
+//     SEPARATE canonical source (the get_pending_chairman_items SQL RPC), deliberately a superset.
+//   - scripts/reap-e2e-liveness-fixtures.mjs E2E_FIXTURE_PREFIX — narrower BY NECESSITY; see the
+//     periodic_process_registry section below. This module now consumes that same '__e2e_' string
+//     rather than the bare ^__ branch, so read-side and delete-side agree.
 //
 // PRECISION OVER RECALL (TR-3): a real row must never be excluded. Regexes are
 // boundary-anchored (prefix-position only — 'LATEST'/'FASTEST' never match); missing
@@ -75,28 +96,127 @@ export function isFixtureSdKey(key, metadata) {
 }
 
 /**
- * Is this ventures row a fixture? Flag-first (is_demo / is_synthetic), name-prefix
- * backstop for the ~half-unflagged-synthetic class. Fail-open on missing fields.
- * @param {{name?: string|null, is_demo?: boolean, is_synthetic?: boolean}|null} v
+ * Is this ventures row a fixture? Flag-first (is_demo), name-prefix backstop for the
+ * ~half-unflagged-synthetic class. Fail-open on missing fields.
+ *
+ * is_synthetic WAS read here and has been REMOVED (SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-A):
+ * ventures.is_synthetic is a PHANTOM column — migration 20260312 was never applied, and a
+ * live select reproduces PostgREST 42703. The branch never threw (it read an absent property
+ * as undefined) but it could never be true either, so it was dead code sitting inside the one
+ * predicate the codebase is supposed to trust. Do not reinstate it; use is_demo.
+ *
+ * NOT a fixture marker, deliberately: ventures.is_scaffolding. It flags a REAL venture used as
+ * a build-out vehicle (excluded from gate calibration), which is a different question from
+ * "this row is not real". Treating it as fixture-shaped would make this predicate over-eat on
+ * genuine ventures.
+ * @param {{name?: string|null, is_demo?: boolean}|null} v
  */
 export function isFixtureVenture(v) {
   if (!v || typeof v !== 'object') return false;
-  if (v.is_demo === true || v.is_synthetic === true) return true;
+  if (v.is_demo === true) return true;
   if (typeof v.name !== 'string') return false;
   return FIXTURE_VENTURE_NAME_RE.test(v.name) || EPOCH_TAIL_RE.test(v.name);
 }
 
 /**
- * Is this quick_fixes row a fixture? quick_fixes has NO flag columns, so the title/id
- * prefix is the only available discriminant.
- * @param {{id?: string|null, title?: string|null}|null} qf
+ * The one value that marks a quick_fixes row as harness-produced. quick_fixes has 43 columns
+ * and its three jsonb columns (files_changed, compliance_details, runtime_observation) are each
+ * already committed to an unrelated dialect, so created_by is the only free carrier.
+ *
+ * WHY THIS SPECIFIC VALUE, and it is not arbitrary: created_by is DEFAULTED AND UNTRUTHFUL —
+ * 1,355 of 1,376 live rows carry 'UAT_AGENT' (98.47%, EXACT full-population counts, not a
+ * capped sample), including rows genuinely filed by workers. A marker equal to that default
+ * would classify essentially the whole table as fixtures. FIXTURE_HARNESS is verified DISTINCT
+ * from it and matches 0 live rows today, so this predicate can only ever ADD detections for
+ * rows a producer explicitly marked — the precision-over-recall direction this module requires.
+ * It stays inert until producers (child D) adopt it; that is expected, not a defect.
+ */
+export const FIXTURE_CREATED_BY = 'FIXTURE_HARNESS';
+
+/**
+ * Is this quick_fixes row a fixture? id/title prefix, plus the explicit created_by marker.
+ * @param {{id?: string|null, title?: string|null, created_by?: string|null}|null} qf
  */
 export function isFixtureQf(qf) {
   if (!qf || typeof qf !== 'object') return false;
   if (typeof qf.id === 'string' && /^QF-(TEST|DEMO)\b/i.test(qf.id)) return true;
+  if (qf.created_by === FIXTURE_CREATED_BY) return true;
   // PRECISION-FIRST (adversarial-review CRITICAL fix, PR #6186): the earlier bare
   // TEST-/UAT-/DEMO title branches matched REAL bug reports titled 'Test-fixture
   // ventures leak…' (two live instances in two weeks) — silently hiding real open work
   // from every dispatch surface. Only unambiguous markers remain: ZZZ_/dunder prefixes.
   return typeof qf.title === 'string' && /^\s*(ZZZ_|__)/i.test(qf.title);
+}
+
+// ─── periodic_process_registry ────────────────────────────────────────────────────────────
+// THE ONE PLACE FIXTURE_KEY_RE MUST NOT BE REUSED, and the reason is the whole point of this SD.
+//
+// FIXTURE_KEY_RE (above) carries a bare ^__ alternative. Applied to this table it would classify
+// REAL PRODUCTION ROWS as fixtures. Enumerated live (194 rows, full fetch — not a sample):
+//   __watcher_self__               — the liveness watcher's own marker
+//   __eva_scheduler_watcher_self__ — the scheduler watcher's own marker
+// Reaping or hiding either BLINDS THE INSTRUMENT the filter exists to protect. And per the same
+// safety argument in scripts/reap-e2e-liveness-fixtures.mjs:24-27, name keywords are equally
+// unsafe — three further live rows read as test-shaped but are REAL processes:
+//   gha_cron:venture-fixture-sweep.yml, standard_loop:account-usage-sample,
+//   cron_script:account-usage-sample.mjs
+// One of those IS the venture-fixture-sweep cron, so a keyword predicate here could disable the
+// very cleanup control this SD family installs. A NAME IS A CLAIM, NOT EVIDENCE.
+//
+// So the discriminant is the '__e2e_' prefix ONLY. This is the same string and the same
+// semantics as scripts/reap-e2e-liveness-fixtures.mjs E2E_FIXTURE_PREFIX, kept as ONE
+// representation: that module is the DELETE-side consumer, this is the read-side consumer, and
+// they must never diverge — a reaper that deletes more than the filter hides is the worst case.
+export const FIXTURE_PROCESS_KEY_PREFIX = '__e2e_';
+
+/**
+ * Is this periodic_process_registry row fixture residue? Takes the KEY ONLY — deliberately never
+ * consults last_state or age, because a predicate that reads symptoms can be argued into
+ * classifying a real row that merely looks abandoned. Provenance decides, not symptoms.
+ * @param {string|null|undefined} processKey
+ */
+export function isFixtureProcessKey(processKey) {
+  return typeof processKey === 'string' && processKey.startsWith(FIXTURE_PROCESS_KEY_PREFIX);
+}
+
+// ─── jsonb-carrier tables ─────────────────────────────────────────────────────────────────
+/**
+ * ONE representation of what a fixture marker looks like inside a jsonb column, shared by every
+ * jsonb-carrier table so the two never drift apart.
+ *
+ * Two accepted keys, and the second is not redundancy: `synthetic` is SHIPPED PRECEDENT —
+ * scripts/solomon/trend-eyes-receipt-rls-probe.mjs already writes metadata:{synthetic:true,…}
+ * into live codebase_health_snapshots rows. Refusing it would leave real synthetic rows
+ * unfiltered today; `is_fixture` is the forward-looking canonical key matching isFixtureSdKey's
+ * existing metadata contract. Strict === true only — a truthy string or 1 does NOT qualify, so a
+ * row carrying an unrelated key of another shape can never be silently swept up.
+ * @param {Record<string, unknown>|null|undefined} carrier
+ */
+export function hasFixtureMarker(carrier) {
+  if (!carrier || typeof carrier !== 'object') return false;
+  return carrier.is_fixture === true || carrier.synthetic === true;
+}
+
+/**
+ * Is this codebase_health_snapshots row synthetic? Reads the metadata jsonb column.
+ *
+ * NOT keyed on `dimension`: a shipped acceptance probe requires its seed keep
+ * dimension='trend_eyes_sweep_receipt', and dimension is a legitimate grouping key for real rows.
+ * Keying on it would over-eat. The table's liveness consumers read ORDER BY scanned_at DESC
+ * LIMIT 1 per dimension, so ONE unfiltered synthetic row is enough to make a dead runner read
+ * alive — this predicate is what stops that.
+ * @param {{metadata?: Record<string, unknown>|null}|null} row
+ */
+export function isFixtureHealthSnapshot(row) {
+  if (!row || typeof row !== 'object') return false;
+  return hasFixtureMarker(row.metadata);
+}
+
+/**
+ * Is this session_coordination row synthetic? Reads the payload jsonb column.
+ * @param {{payload?: Record<string, unknown>|null}|null} row
+ */
+export function isFixtureCoordinationRow(row) {
+  if (!row || typeof row !== 'object') return false;
+  return hasFixtureMarker(row.payload);
 }

--- a/lib/governance/fixture-exclusion.mjs
+++ b/lib/governance/fixture-exclusion.mjs
@@ -134,13 +134,37 @@ export function isFixtureVenture(v) {
 export const FIXTURE_CREATED_BY = 'FIXTURE_HARNESS';
 
 /**
- * Is this quick_fixes row a fixture? id/title prefix, plus the explicit created_by marker.
- * @param {{id?: string|null, title?: string|null, created_by?: string|null}|null} qf
+ * Is this quick_fixes row marked as harness-produced via created_by?
+ *
+ * DELIBERATELY NOT FOLDED INTO isFixtureQf, and this is a security decision, not tidiness.
+ * isFixtureQf is already consumed by five live surfaces — scripts/fleet-dashboard.cjs:476,
+ * scripts/modules/sd-next/data-loaders.js:473 (the DISPATCH QUEUE workers claim from),
+ * scripts/adam-github-assessment.mjs:136, scripts/adam-self-adherence-review.mjs:105 and
+ * lib/governance/recursion-governor.js:128. quick_fixes RLS is permissive to anon+authenticated
+ * (pre-existing, not introduced here) and the anon key ships client-side, so folding this branch
+ * into isFixtureQf would let any caller hide a REAL quick fix from all five surfaces by writing
+ * one free-text column — with no visible id or title change to give it away. The id/title markers
+ * at least alter something a human reads.
+ *
+ * So consumers must opt in EXPLICITLY, and only after child D makes producers set created_by
+ * truthfully (TR-3). Until then this matches 0 live rows by construction. That inertness is the
+ * point: the predicate exists so producers have something to write against, not so gauges can
+ * start trusting a self-asserted string today.
+ * @param {{created_by?: string|null}|null} qf
+ */
+export function isFixtureQfByCreatedBy(qf) {
+  if (!qf || typeof qf !== 'object') return false;
+  return qf.created_by === FIXTURE_CREATED_BY;
+}
+
+/**
+ * Is this quick_fixes row a fixture? id/title prefix only — see isFixtureQfByCreatedBy for why
+ * the created_by marker is a separate, opt-in predicate rather than folded in here.
+ * @param {{id?: string|null, title?: string|null}|null} qf
  */
 export function isFixtureQf(qf) {
   if (!qf || typeof qf !== 'object') return false;
   if (typeof qf.id === 'string' && /^QF-(TEST|DEMO)\b/i.test(qf.id)) return true;
-  if (qf.created_by === FIXTURE_CREATED_BY) return true;
   // PRECISION-FIRST (adversarial-review CRITICAL fix, PR #6186): the earlier bare
   // TEST-/UAT-/DEMO title branches matched REAL bug reports titled 'Test-fixture
   // ventures leak…' (two live instances in two weeks) — silently hiding real open work
@@ -163,10 +187,12 @@ export function isFixtureQf(qf) {
 // One of those IS the venture-fixture-sweep cron, so a keyword predicate here could disable the
 // very cleanup control this SD family installs. A NAME IS A CLAIM, NOT EVIDENCE.
 //
-// So the discriminant is the '__e2e_' prefix ONLY. This is the same string and the same
-// semantics as scripts/reap-e2e-liveness-fixtures.mjs E2E_FIXTURE_PREFIX, kept as ONE
-// representation: that module is the DELETE-side consumer, this is the read-side consumer, and
-// they must never diverge — a reaper that deletes more than the filter hides is the worst case.
+// So the discriminant is the '__e2e_' prefix ONLY. This constant is THE single declaration of that
+// string: scripts/reap-e2e-liveness-fixtures.mjs re-exports it as E2E_FIXTURE_PREFIX rather than
+// declaring its own. The dependency points that way because this module must stay zero-import and
+// side-effect-free for its CJS consumers, while the reaper imports dotenv and builds a Supabase
+// client at module scope. Read side and DELETE side therefore cannot drift — and the divergence
+// that matters most is a reaper deleting MORE than the filter hides.
 export const FIXTURE_PROCESS_KEY_PREFIX = '__e2e_';
 
 /**

--- a/package.json
+++ b/package.json
@@ -114,7 +114,6 @@
     "lint:venture-artifacts": "node scripts/lint/venture-artifacts-write-lint.mjs",
     "lint:realtime-teardown": "node scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs",
     "lint:count-delta-gate": "node scripts/lint/count-delta-gate-lint.mjs",
-
     "lint:no-process-cwd": "node scripts/lint/no-process-cwd-in-sub-agents-lint.mjs",
     "lint:ismainmodule-classguard": "node scripts/lint/ismainmodule-classguard-lint.mjs",
     "lint:mocked-sut-import": "node scripts/lint/no-mocked-sut-import-lint.mjs",
@@ -634,7 +633,8 @@
     "audit:unreachable-midphase": "node scripts/audit-unreachable-midphase-sds.mjs",
     "audit:worktree-env-divergence": "node scripts/audit-worktree-env-divergence.mjs",
     "flags:enroll-tier-gate": "node scripts/enroll-migration-tier-gate-flag.mjs",
-    "audit:anon-write-contract": "node scripts/anon-write-contract-probe.mjs"
+    "audit:anon-write-contract": "node scripts/anon-write-contract-probe.mjs",
+    "test:cjs-pins": "node tests/unit/governance/fixture-exclusion-cjs-pin.cjs"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.85.0",

--- a/scripts/reap-e2e-liveness-fixtures.mjs
+++ b/scripts/reap-e2e-liveness-fixtures.mjs
@@ -45,8 +45,20 @@ import { createClient } from '@supabase/supabase-js';
 // class of defect this QF is about. Caught only because the dry run's output was empty.
 import { isMainModule } from '../lib/utils/is-main-module.js';
 
-/** The one prefix that is fixture residue. Exported so the safety argument is testable. */
-export const E2E_FIXTURE_PREFIX = '__e2e_';
+/**
+ * The one prefix that is fixture residue. Exported so the safety argument is testable.
+ *
+ * SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-A: this is now RE-EXPORTED from the canonical predicate
+ * module rather than declared here, so the DELETE side (this reaper) and the READ side
+ * (isFixtureProcessKey, used by the liveness gauges) are literally the same string. Two
+ * independently-declared literals that merely happen to match today is the drift this SD family
+ * exists to abolish — and the divergence that matters most is a reaper deleting MORE than the
+ * filter hides. The dependency points this way (script imports lib) because fixture-exclusion.mjs
+ * must stay zero-import and side-effect-free for its CJS consumers; this file imports
+ * dotenv/config and constructs a Supabase client at module scope, so it can never be the importee.
+ */
+export { FIXTURE_PROCESS_KEY_PREFIX as E2E_FIXTURE_PREFIX } from '../lib/governance/fixture-exclusion.mjs';
+import { FIXTURE_PROCESS_KEY_PREFIX as E2E_FIXTURE_PREFIX } from '../lib/governance/fixture-exclusion.mjs';
 
 /**
  * True iff this row is e2e fixture residue and safe to delete.

--- a/tests/unit/governance/fixture-exclusion-cjs-pin.cjs
+++ b/tests/unit/governance/fixture-exclusion-cjs-pin.cjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+/**
+ * CJS INTEROP PIN for lib/governance/fixture-exclusion.mjs — SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-A FR-5.
+ *
+ * WHY THIS IS A .cjs FILE RUN BY PLAIN NODE, AND NOT A VITEST TEST:
+ * scripts/fleet-dashboard.cjs:475 loads this .mjs through Node's native synchronous require(ESM)
+ * interop, which only works while the module has no top-level await and no async evaluation. That
+ * require sits INSIDE A TRY/CATCH, so when it breaks the dashboard does not error — it silently
+ * falls back to UNFILTERED output. The failure mode is a filter that quietly stops filtering.
+ *
+ * A vitest test could not prove this. Vitest transforms modules through its OWN ESM pipeline, so a
+ * `createRequire(...)` call inside a vitest file can resolve happily while plain `node` cannot load
+ * the module at all — a green suite hiding a module Node itself rejects. The only honest check runs
+ * in the same loader the real consumer uses, so this file is executed by node directly.
+ *
+ * RUN:      node tests/unit/governance/fixture-exclusion-cjs-pin.cjs
+ * WIRED AT: npm run test:cjs-pins (and the EXEC gate for this SD)
+ *
+ * PROVEN RED/GREEN, not merely asserted: temporarily add `await Promise.resolve();` at the top level
+ * of fixture-exclusion.mjs and this script exits 1 with ERR_REQUIRE_ASYNC_MODULE. A pin never
+ * observed to fail is indistinguishable from an absent one.
+ */
+
+const path = require('path');
+
+const MODULE_PATH = path.resolve(__dirname, '../../../lib/governance/fixture-exclusion.mjs');
+
+// Every export the CJS consumers actually destructure. If a future edit converts this module to
+// something require() cannot load, the require below throws before we get here.
+const REQUIRED_EXPORTS = [
+  'FIXTURE_KEY_RE',
+  'UAT_FIXTURE_KEY_RE',
+  'FIXTURE_VENTURE_NAME_RE',
+  'EPOCH_TAIL_RE',
+  'isFixtureSdKey',
+  'isFixtureVenture',
+  'isFixtureQf',
+  'FIXTURE_CREATED_BY',
+  'FIXTURE_PROCESS_KEY_PREFIX',
+  'isFixtureProcessKey',
+  'hasFixtureMarker',
+  'isFixtureHealthSnapshot',
+  'isFixtureCoordinationRow',
+];
+
+let mod;
+try {
+  mod = require(MODULE_PATH);
+} catch (err) {
+  console.error('❌ CJS PIN FAILED: plain node could not require() the module.');
+  console.error(`   ${err.code || err.name}: ${err.message}`);
+  console.error('   This is the exact failure scripts/fleet-dashboard.cjs:475 SWALLOWS in its');
+  console.error('   try/catch — in production the dashboard would silently stop filtering.');
+  process.exit(1);
+}
+
+const missing = REQUIRED_EXPORTS.filter((name) => mod[name] === undefined);
+if (missing.length > 0) {
+  console.error(`❌ CJS PIN FAILED: require() succeeded but ${missing.length} export(s) missing.`);
+  console.error(`   Missing: ${missing.join(', ')}`);
+  process.exit(1);
+}
+
+// Exercise a predicate through the CJS handle rather than only counting exports — a module can
+// export a name and still be broken. Two-sided so the check cannot pass by always-false.
+if (mod.isFixtureProcessKey('__e2e_liveness_probe') !== true) {
+  console.error('❌ CJS PIN FAILED: isFixtureProcessKey did not classify an __e2e_ key as fixture.');
+  process.exit(1);
+}
+if (mod.isFixtureProcessKey('__watcher_self__') !== false) {
+  console.error('❌ CJS PIN FAILED: isFixtureProcessKey classified the REAL row __watcher_self__ as');
+  console.error('   a fixture. That is the over-eating defect this SD exists to prevent.');
+  process.exit(1);
+}
+
+console.log(`✅ CJS PIN: require() works, ${REQUIRED_EXPORTS.length} exports present, predicate two-sided.`);

--- a/tests/unit/governance/fixture-exclusion-cjs-pin.cjs
+++ b/tests/unit/governance/fixture-exclusion-cjs-pin.cjs
@@ -14,7 +14,11 @@
  * in the same loader the real consumer uses, so this file is executed by node directly.
  *
  * RUN:      node tests/unit/governance/fixture-exclusion-cjs-pin.cjs
- * WIRED AT: npm run test:cjs-pins (and the EXEC gate for this SD)
+ * WIRED AT: npm run test:cjs-pins — AND NOWHERE ELSE. No CI workflow and no gate invokes it, so
+ *           today this pin only runs when a human or an agent remembers to type it. That is a
+ *           REAL GAP, recorded here rather than papered over: an instrument nobody invokes is
+ *           indistinguishable from an absent one, and this very docblock has now twice carried a
+ *           wiring claim that outran reality. Wiring it into CI is a follow-on (completion flag).
  *
  * PROVEN RED/GREEN, not merely asserted: temporarily add `await Promise.resolve();` at the top level
  * of fixture-exclusion.mjs and this script exits 1 with ERR_REQUIRE_ASYNC_MODULE. A pin never

--- a/tests/unit/governance/fixture-exclusion-cjs-pin.cjs
+++ b/tests/unit/governance/fixture-exclusion-cjs-pin.cjs
@@ -36,6 +36,7 @@ const REQUIRED_EXPORTS = [
   'isFixtureVenture',
   'isFixtureQf',
   'FIXTURE_CREATED_BY',
+  'isFixtureQfByCreatedBy',
   'FIXTURE_PROCESS_KEY_PREFIX',
   'isFixtureProcessKey',
   'hasFixtureMarker',

--- a/tests/unit/governance/fixture-exclusion-per-table.test.js
+++ b/tests/unit/governance/fixture-exclusion-per-table.test.js
@@ -1,0 +1,167 @@
+/**
+ * Per-table fixture predicates — SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-A.
+ *
+ * Every block here is TWO-SIDED, and each negative arm varies a DIFFERENT AXIS than its positive
+ * arm. A negative built by mutating its positive (same row, flag flipped) inherits the positive's
+ * assumption and passes while the predicate is wrong — so the negatives below use REAL production
+ * shapes instead, enumerated live from the tables rather than invented.
+ *
+ * This file extends the precedent set by fixture-exclusion.test.js, whose QF-031 block is labelled
+ * "THE CONTROL" for the same reason: over-exclusion is the fatal direction. A filter that over-eats
+ * deletes real signal while reporting success.
+ */
+import { describe, test, expect } from 'vitest';
+import {
+  FIXTURE_KEY_RE,
+  FIXTURE_CREATED_BY,
+  FIXTURE_PROCESS_KEY_PREFIX,
+  isFixtureProcessKey,
+  hasFixtureMarker,
+  isFixtureHealthSnapshot,
+  isFixtureCoordinationRow,
+  isFixtureQf,
+  isFixtureVenture,
+} from '../../../lib/governance/fixture-exclusion.mjs';
+
+describe('periodic_process_registry — the over-eating control (FR-2)', () => {
+  test('POSITIVE: __e2e_ residue is classified as fixture', () => {
+    expect(isFixtureProcessKey('__e2e_liveness_probe')).toBe(true);
+    expect(isFixtureProcessKey('__e2e_run_1784287684096')).toBe(true);
+    expect(FIXTURE_PROCESS_KEY_PREFIX).toBe('__e2e_');
+  });
+
+  // THE CONTROL. These five are REAL rows, enumerated live from the table (194 rows, full fetch,
+  // not a sample). They are precisely why this predicate may NOT reuse FIXTURE_KEY_RE: that regex
+  // carries a bare ^__ branch matching the first two, and any name-keyword approach matches the
+  // last three. Reaping or hiding __watcher_self__ or __eva_scheduler_watcher_self__ blinds the
+  // liveness instrument the filter exists to protect, and gha_cron:venture-fixture-sweep.yml IS
+  // the cleanup cron a sibling child revives. A NAME IS A CLAIM, NOT EVIDENCE.
+  test.each([
+    ['__watcher_self__', 'liveness watcher own marker — bare dunder'],
+    ['__eva_scheduler_watcher_self__', 'scheduler watcher own marker — bare dunder'],
+    ['gha_cron:venture-fixture-sweep.yml', 'REAL cron whose name contains "fixture"'],
+    ['standard_loop:account-usage-sample', 'REAL loop whose name contains "sample"'],
+    ['cron_script:account-usage-sample.mjs', 'REAL script whose name contains "sample"'],
+  ])('THE CONTROL: real row %s survives (%s)', (processKey) => {
+    expect(isFixtureProcessKey(processKey)).toBe(false);
+  });
+
+  // The five above protect only the rows that exist TODAY. This asserts the general SHAPE, so a
+  // sixth real dunder or test-sounding row added later is protected without editing a list.
+  test('GENERAL SHAPE: bare dunder and test-sounding names are not fixtures by themselves', () => {
+    expect(isFixtureProcessKey('__some_future_watcher_self__')).toBe(false);
+    expect(isFixtureProcessKey('__eva_new_internal_marker')).toBe(false);
+    expect(isFixtureProcessKey('gha_cron:some-test-harness.yml')).toBe(false);
+    expect(isFixtureProcessKey('cron_script:fixture-sweep-v2.mjs')).toBe(false);
+  });
+
+  // Proof the control is LOAD-BEARING rather than incidentally satisfied: the canonical regex
+  // really would have eaten the real rows. If FIXTURE_KEY_RE ever loses its bare ^__ branch this
+  // fails, telling the next reader the hazard changed rather than letting the control rot silently.
+  test('the hazard is real — FIXTURE_KEY_RE would have matched the real dunder rows', () => {
+    expect(FIXTURE_KEY_RE.test('__watcher_self__')).toBe(true);
+    expect(FIXTURE_KEY_RE.test('__eva_scheduler_watcher_self__')).toBe(true);
+    expect(isFixtureProcessKey('__watcher_self__')).toBe(false);
+  });
+
+  test('takes the key only — non-strings fail open to NOT-fixture', () => {
+    expect(isFixtureProcessKey(null)).toBe(false);
+    expect(isFixtureProcessKey(undefined)).toBe(false);
+    expect(isFixtureProcessKey({ process_key: '__e2e_x' })).toBe(false);
+  });
+});
+
+describe('jsonb-carrier tables — codebase_health_snapshots and session_coordination', () => {
+  test('POSITIVE: both accepted marker keys classify as fixture', () => {
+    expect(isFixtureHealthSnapshot({ metadata: { synthetic: true } })).toBe(true);
+    expect(isFixtureHealthSnapshot({ metadata: { is_fixture: true } })).toBe(true);
+    expect(isFixtureCoordinationRow({ payload: { is_fixture: true } })).toBe(true);
+    expect(isFixtureCoordinationRow({ payload: { synthetic: true } })).toBe(true);
+  });
+
+  // NEGATIVE ARM VARIES A DIFFERENT AXIS: not "the same row with the flag false", but real rows
+  // carrying UNRELATED jsonb content, which is what production rows actually look like.
+  test('THE CONTROL: real rows with unrelated jsonb content survive', () => {
+    expect(isFixtureHealthSnapshot({
+      dimension: 'gauge_runner_heartbeat',
+      metadata: { source: 'coordinator-hourly-review', run_id: 'abc123' },
+    })).toBe(false);
+    expect(isFixtureCoordinationRow({
+      message_type: 'INFO',
+      payload: { kind: 'roll_call', callsign: 'Alpha-2' },
+    })).toBe(false);
+    // A row with no carrier at all is real, not fixture (fail open).
+    expect(isFixtureHealthSnapshot({ dimension: 'trend_eyes_sweep_receipt' })).toBe(false);
+    expect(isFixtureCoordinationRow({ message_type: 'INFO' })).toBe(false);
+  });
+
+  // dimension is a legitimate grouping key for REAL rows, and a shipped acceptance probe pins one
+  // specific value, so keying on it would over-eat. The predicate must ignore it entirely.
+  test('dimension is NOT a fixture discriminant', () => {
+    expect(isFixtureHealthSnapshot({ dimension: 'trend_eyes_sweep_receipt', metadata: {} })).toBe(false);
+    expect(isFixtureHealthSnapshot({ dimension: '__e2e_anything', metadata: {} })).toBe(false);
+  });
+
+  test('only strict boolean true qualifies — truthy values must not sweep a real row up', () => {
+    expect(hasFixtureMarker({ is_fixture: 'yes' })).toBe(false);
+    expect(hasFixtureMarker({ synthetic: 1 })).toBe(false);
+    expect(hasFixtureMarker({ is_fixture: false })).toBe(false);
+    expect(hasFixtureMarker(null)).toBe(false);
+    expect(hasFixtureMarker('is_fixture')).toBe(false);
+  });
+});
+
+describe('quick_fixes created_by carrier (TR-3)', () => {
+  test('POSITIVE: the explicit marker classifies as fixture', () => {
+    expect(isFixtureQf({ id: 'QF-20260807-001', created_by: FIXTURE_CREATED_BY })).toBe(true);
+  });
+
+  // THE VACUITY GUARD. created_by is defaulted and untruthful: 1,355 of 1,376 live rows carry
+  // 'UAT_AGENT' (98.47%, EXACT full-population counts obtained by pagination), including rows
+  // genuinely filed by workers. Had the marker equalled that default, this predicate would
+  // classify nearly the whole table as fixtures AND a naive test would still pass. Asserting the
+  // distinctness is what makes the mutation proof meaningful instead of vacuous.
+  test('THE CONTROL: the marker is DISTINCT from the untruthful default', () => {
+    expect(FIXTURE_CREATED_BY).not.toBe('UAT_AGENT');
+    expect(isFixtureQf({ id: 'QF-20260807-002', created_by: 'UAT_AGENT' })).toBe(false);
+    expect(isFixtureQf({
+      id: 'QF-20260728-967',
+      created_by: 'UAT_AGENT',
+      title: 'Fleet dashboard shows stale liveness',
+    })).toBe(false);
+  });
+
+  test('existing id/title behavior is unchanged by the created_by addition', () => {
+    expect(isFixtureQf({ id: 'QF-TEST-001' })).toBe(true);
+    expect(isFixtureQf({ title: 'ZZZ_fixture qf' })).toBe(true);
+    expect(isFixtureQf({
+      id: 'QF-20260807-985',
+      title: 'Trend-Eyes liveness predicate has zero callers',
+    })).toBe(false);
+  });
+});
+
+describe('ventures — phantom is_synthetic branch removed (FR-4)', () => {
+  // Pins the REMOVAL. is_synthetic is a phantom column (migration 20260312 never applied; a live
+  // select reproduces PostgREST 42703), so the branch could never be true on a real row. If
+  // someone reinstates it, this test fails.
+  test('is_synthetic:true alone does NOT classify a venture as fixture', () => {
+    expect(isFixtureVenture({ name: 'MarketLens', is_demo: false, is_synthetic: true })).toBe(false);
+  });
+
+  test('is_demo still classifies, and real ventures still survive', () => {
+    expect(isFixtureVenture({ name: 'MarketLens', is_demo: true })).toBe(true);
+    expect(isFixtureVenture({ name: 'MarketLens', is_demo: false })).toBe(false);
+    expect(isFixtureVenture({ name: '__e2e_venture', is_demo: false })).toBe(true);
+  });
+
+  // PLAN ruling: is_scaffolding marks a REAL venture used as a build-out vehicle, a different
+  // question from "this row is not real". Treating it as fixture-shaped would over-eat.
+  test('is_scaffolding is NOT a fixture marker', () => {
+    expect(isFixtureVenture({
+      name: 'Scaffold Venture',
+      is_demo: false,
+      is_scaffolding: true,
+    })).toBe(false);
+  });
+});

--- a/tests/unit/governance/fixture-exclusion-per-table.test.js
+++ b/tests/unit/governance/fixture-exclusion-per-table.test.js
@@ -20,6 +20,7 @@ import {
   isFixtureHealthSnapshot,
   isFixtureCoordinationRow,
   isFixtureQf,
+  isFixtureQfByCreatedBy,
   isFixtureVenture,
 } from '../../../lib/governance/fixture-exclusion.mjs';
 
@@ -113,7 +114,15 @@ describe('jsonb-carrier tables — codebase_health_snapshots and session_coordin
 
 describe('quick_fixes created_by carrier (TR-3)', () => {
   test('POSITIVE: the explicit marker classifies as fixture', () => {
-    expect(isFixtureQf({ id: 'QF-20260807-001', created_by: FIXTURE_CREATED_BY })).toBe(true);
+    expect(isFixtureQfByCreatedBy({ id: 'QF-20260807-001', created_by: FIXTURE_CREATED_BY })).toBe(true);
+  });
+
+  // THE OPT-IN BOUNDARY. isFixtureQf is consumed by five live surfaces including the dispatch
+  // queue, and quick_fixes RLS is permissive to anon (pre-existing). If created_by were folded
+  // into isFixtureQf, anyone could hide a REAL quick fix from all five by writing one free-text
+  // column, with no id or title change to give it away. This asserts the separation holds.
+  test('created_by does NOT leak into isFixtureQf — consumers must opt in explicitly', () => {
+    expect(isFixtureQf({ id: 'QF-20260807-001', created_by: FIXTURE_CREATED_BY })).toBe(false);
   });
 
   // THE VACUITY GUARD. created_by is defaulted and untruthful: 1,355 of 1,376 live rows carry
@@ -123,8 +132,8 @@ describe('quick_fixes created_by carrier (TR-3)', () => {
   // distinctness is what makes the mutation proof meaningful instead of vacuous.
   test('THE CONTROL: the marker is DISTINCT from the untruthful default', () => {
     expect(FIXTURE_CREATED_BY).not.toBe('UAT_AGENT');
-    expect(isFixtureQf({ id: 'QF-20260807-002', created_by: 'UAT_AGENT' })).toBe(false);
-    expect(isFixtureQf({
+    expect(isFixtureQfByCreatedBy({ id: 'QF-20260807-002', created_by: 'UAT_AGENT' })).toBe(false);
+    expect(isFixtureQfByCreatedBy({
       id: 'QF-20260728-967',
       created_by: 'UAT_AGENT',
       title: 'Fleet dashboard shows stale liveness',

--- a/tests/unit/governance/fixture-exclusion.test.js
+++ b/tests/unit/governance/fixture-exclusion.test.js
@@ -62,7 +62,12 @@ describe('predicate matrix (TS-1)', () => {
   test('venture predicate: flags OR name-prefix backstop; real ventures pass through', () => {
     expect(isFixtureVenture({ name: 'MarketLens', is_demo: false, is_synthetic: false })).toBe(false);
     expect(isFixtureVenture({ name: 'MarketLens', is_demo: true })).toBe(true);
-    expect(isFixtureVenture({ name: 'Real Co', is_synthetic: true })).toBe(true);
+    // SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-A: this line previously asserted is_synthetic:true
+    // classified as a fixture. ventures.is_synthetic is a PHANTOM column — migration 20260312 was
+    // never applied and a live select reproduces 42703 — so that branch could only ever fire on an
+    // in-memory object like this one, never on a real row. The flag-first behavior under test is
+    // is_demo; the removal itself is pinned in fixture-exclusion-per-table.test.js.
+    expect(isFixtureVenture({ name: 'Real Co', is_demo: true })).toBe(true);
     for (const name of ['ZZZ_seed_venture', '__e2e_venture', 'TEST-venture', 'UAT-venture', 'parity-test-1', 'test-stub', 'Test Venture for claims']) {
       expect(isFixtureVenture({ name }), name).toBe(true);
     }
@@ -116,7 +121,8 @@ describe('computePortfolioMaturity excludes fixture ventures (TS-2)', () => {
       { name: 'CronGenius', is_demo: false, is_synthetic: false },
       { name: 'ZZZ_seed', is_demo: false, is_synthetic: false },
       { name: 'Real-flagged', is_demo: true },
-      { name: 'Synthetic-co', is_synthetic: true },
+      // was is_synthetic:true — a phantom column no live row can carry; is_demo is the real flag
+      { name: 'Synthetic-co', is_demo: true },
     ]));
     expect(result.ventureCount).toBe(2);
   });


### PR DESCRIPTION
Dependency-root child of the one-synthetic-row orchestrator. Extends `lib/governance/fixture-exclusion.mjs` — the canonical fixture predicate union — with per-table predicates for the five tables whose consumers currently read synthetic rows as real. One module, per-table carriers, **no new module and no DDL**.

## The load-bearing decision

`periodic_process_registry` does **not** reuse `FIXTURE_KEY_RE`. That regex carries a bare `^__` branch which matches **real production rows**. Enumerated live (194 rows, exact full fetch):

- `__watcher_self__` and `__eva_scheduler_watcher_self__` — the liveness and scheduler watchers' own markers
- `gha_cron:venture-fixture-sweep.yml`, `standard_loop:account-usage-sample`, `cron_script:account-usage-sample.mjs` — real processes whose names merely sound test-shaped

Reaping or hiding the first two blinds the very instrument the filter protects, and the third list includes the cleanup cron a sibling child revives — an over-eager predicate here could disable the mechanism this SD family installs. The discriminant is `__e2e_` only, and `scripts/reap-e2e-liveness-fixtures.mjs` now re-exports the canonical constant so read-side and delete-side cannot drift.

Also removes a dead branch reading `ventures.is_synthetic`, a phantom column (migration 20260312 never applied; live select reproduces 42703). Two existing tests asserted it while constructing in-memory objects; both now use `is_demo`. Production behaviour is unchanged because no live row can carry the column.

## Verification — performed, not asserted

- **8/8 mutations killed, in both directions.** Five under-detection mutations prove the positive arms are load-bearing; three over-detection ones prove the controls are, including one reintroducing the over-eating defect and one breaching the `quick_fixes` opt-in boundary. Re-runnable: `node .artifacts/mutation-proof.mjs`
- **CJS pin runs outside vitest by design** and was proven RED (`ERR_REQUIRE_ASYNC_MODULE`, exit 1) before being accepted green. `scripts/fleet-dashboard.cjs:475` requires this module inside a try/catch, so a top-level await would otherwise degrade the dashboard to unfiltered output with no error anywhere. Vitest's ESM pipeline can satisfy a `require()` plain node cannot, so a vitest-based pin would have proved nothing.
- **Governance suite:** 1226 passed / 11 skipped across 74 files (entire `tests/unit/governance/`, not this SD alone).
- Every negative test arm varies a **different axis** than its positive and uses real production shapes, so no control passes by inheriting its positive's assumption.

## Defects found post-commit by sub-agents, and fixed

Three, two of which were false claims I had written into comments:

1. **Violated this SD's own TR-3** — folded the `created_by` marker into `isFixtureQf`, which five live consumers read including the dispatch queue (`scripts/modules/sd-next/data-loaders.js:473`). With `quick_fixes` RLS permissive to anon (pre-existing), that made a real quick fix suppressible via one free-text column with no visible id/title change. Now a separate opt-in export, `isFixtureQfByCreatedBy`.
2. **"ONE representation" was false** — two independent literals that merely matched. Now genuinely one, verified by identity.
3. **"WIRED AT: npm run test:cjs-pins" was false** — no such script. It now exists; and a later pass caught that the *same sentence* still falsely claimed EXEC-gate wiring, which is now stated as the open gap it is.

## Known gaps (carried, not hidden)

- `test:cjs-pins` is an npm script but is **not** in any CI workflow — it still runs only when invoked.
- The mutation set covers the five new/changed carriers, not `isFixtureSdKey` or `isFixtureQf`'s id/title branches.
- `quick_fixes` RLS is `FOR ALL USING(true)` to anon+authenticated and the anon key ships client-side — flagged MEDIUM by SECURITY and **pre-existing**, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)