### PR TITLE
fix(QF-20260807-251): retro quality gate — dock empty filler, not the token "nothing"

### DIFF
--- a/database/migrations/20260808_qf251_retro_quality_vacuous_predicate.sql
+++ b/database/migrations/20260808_qf251_retro_quality_vacuous_predicate.sql
@@ -15,8 +15,22 @@
 -- applied wins, silently. If another migration touching
 -- public.auto_validate_retrospective_quality is in flight, reconcile them BEFORE applying.
 --
--- Live body UNVERIFIED from the authoring seat (no exec_sql RPC there); the apply seat reads
--- the deployed function and diffs it against this file before applying.
+-- @chairman-gated
+-- Ruled by Adam 2026-08-08: CREATE OR REPLACE FUNCTION is NOT in the delegated-apply lane
+-- (that lane is a strict additive subset — CREATE TABLE/INDEX, nullable columns, CHECK-widen,
+-- allow-listed INSERTs; behaviour mutations default-deny), and this function IS the gate
+-- instrument, which invokes proposer-is-not-approver on top. Path is the chairman ceremony:
+-- @approved-by header, 3-factor apply from the coordinator seat.
+--
+-- The marker is why check-migration-readiness reports EXPECTED_PENDING rather than
+-- DRIFT_DETECTED for this file (CHAIRMAN-GATED-EXEMPT-001). It is a statement of fact about a
+-- ruling, not a way to quiet a red check: the live body genuinely differs from this file, and
+-- it is SUPPOSED to until the ceremony runs. Remove it and the divergence must go red again.
+--
+-- Live body was UNVERIFIED from the authoring seat (no exec_sql RPC there). The readiness probe
+-- has since read the deployed function directly and its diff shows the OLD substring predicate
+-- still live — which confirms the deployed body matches 20260523 and turns that inference into
+-- a measurement. The apply seat re-reads and diffs again before applying.
 
 BEGIN;
 

--- a/database/migrations/20260808_qf251_retro_quality_vacuous_predicate.sql
+++ b/database/migrations/20260808_qf251_retro_quality_vacuous_predicate.sql
@@ -1,0 +1,273 @@
+-- QF-20260807-251: retro quality gate — match meaning, not substring
+--
+-- The "Dismissive statement check for what_needs_improvement" docked 10 points PER ITEM on a
+-- bare substring match for '%nothing%' / '%no significant%'. Precision was taxed: an item that
+-- states an empty set exactly ("the two vocabularies share NOTHING") scored lower than one that
+-- hedged. Severity is gate-integrity, not cosmetics — validateSDCompletionReadiness falls back
+-- to the stored quality_score when the AI evaluator is unavailable, so the penalty propagated
+-- into completion decisions.
+--
+-- Semantic diff vs 20260523_fix_retrospective_publish_gate_ordering.sql is ONE predicate. The
+-- whole function body is restated because CREATE OR REPLACE FUNCTION has no partial form.
+--
+-- ⚠ FULL-BODY DDL HAZARD: this is the 6th migration to replace this function. Two files that
+-- each carry the whole body merge CLEANLY in git and then MUTUALLY REVERT on apply — last
+-- applied wins, silently. If another migration touching
+-- public.auto_validate_retrospective_quality is in flight, reconcile them BEFORE applying.
+--
+-- Live body UNVERIFIED from the authoring seat (no exec_sql RPC there); the apply seat reads
+-- the deployed function and diffs it against this file before applying.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.auto_validate_retrospective_quality()
+ RETURNS trigger
+ LANGUAGE plpgsql
+AS $function$
+DECLARE
+  validation_result JSONB;
+  issues JSONB := '[]'::jsonb;
+  score INTEGER := 0;
+  generic_phrases TEXT[] := ARRAY[
+    'SD completed',
+    'no issues',
+    'no significant challenges',
+    'LEO Protocol followed successfully',
+    'went well',
+    'completed at 100%',
+    'no problems'
+  ];
+  phrase TEXT;
+  item TEXT;
+  should_recalculate BOOLEAN := FALSE;
+  arr_len INTEGER;
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    should_recalculate := TRUE;
+  ELSIF TG_OP = 'UPDATE' THEN
+    IF (OLD.what_went_well IS DISTINCT FROM NEW.what_went_well) OR
+       (OLD.key_learnings IS DISTINCT FROM NEW.key_learnings) OR
+       (OLD.action_items IS DISTINCT FROM NEW.action_items) OR
+       (OLD.what_needs_improvement IS DISTINCT FROM NEW.what_needs_improvement) THEN
+      should_recalculate := TRUE;
+    END IF;
+  END IF;
+
+  IF NOT should_recalculate THEN
+    -- Score is NOT recomputed (status-only UPDATE, no content change).
+    -- NEW.quality_score holds the stored value from the previous INSERT/UPDATE.
+    -- FR-2: Still enforce the publish gate against that stored score.
+    IF (TG_OP = 'INSERT' AND NEW.status = 'PUBLISHED')
+       OR (TG_OP = 'UPDATE' AND OLD.status IS DISTINCT FROM 'PUBLISHED' AND NEW.status = 'PUBLISHED') THEN
+      IF NEW.quality_score IS NULL OR NEW.quality_score < 70 THEN
+        RAISE EXCEPTION 'PUBLISHED retrospectives must have quality_score >= 70 (current: %)', COALESCE(NEW.quality_score, 0)
+          USING HINT = 'Improve retrospective completeness to reach 70+ score';
+      END IF;
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  -- ==========================================================================
+  -- what_went_well scoring
+  -- ==========================================================================
+  IF NEW.what_went_well IS NOT NULL AND jsonb_typeof(NEW.what_went_well) = 'array' THEN
+    arr_len := jsonb_array_length(NEW.what_went_well);
+    IF arr_len >= 5 THEN
+      score := score + 20;
+    ELSIF arr_len < 3 THEN
+      issues := issues || jsonb_build_object(
+        'field', 'what_went_well',
+        'issue', 'Too few items (need at least 5 for full credit, minimum 3)',
+        'current_count', arr_len
+      );
+    ELSE
+      score := score + 10;
+    END IF;
+  ELSE
+    -- NULL or not an array
+    issues := issues || jsonb_build_object(
+      'field', 'what_went_well',
+      'issue', 'Too few items (need at least 5 for full credit, minimum 3)',
+      'current_count', 0
+    );
+  END IF;
+
+  -- Generic phrase check for what_went_well
+  IF NEW.what_went_well IS NOT NULL AND jsonb_typeof(NEW.what_went_well) = 'array' THEN
+    FOR i IN 0..jsonb_array_length(NEW.what_went_well) - 1 LOOP
+      item := NEW.what_went_well->>i;
+      IF item IS NOT NULL THEN
+        FOREACH phrase IN ARRAY generic_phrases LOOP
+          IF item ILIKE '%' || phrase || '%' THEN
+            score := score - 5;
+            issues := issues || jsonb_build_object(
+              'field', 'what_went_well',
+              'issue', format('Generic statement detected: "%s"', phrase),
+              'item', item
+            );
+            EXIT;
+          END IF;
+        END LOOP;
+      END IF;
+    END LOOP;
+  END IF;
+
+  -- ==========================================================================
+  -- key_learnings scoring
+  -- ==========================================================================
+  IF NEW.key_learnings IS NOT NULL AND jsonb_typeof(NEW.key_learnings) = 'array' THEN
+    arr_len := jsonb_array_length(NEW.key_learnings);
+    IF arr_len >= 5 THEN
+      score := score + 30;
+    ELSIF arr_len >= 3 THEN
+      score := score + 20;
+    ELSE
+      issues := issues || jsonb_build_object(
+        'field', 'key_learnings',
+        'issue', 'Too few learnings (need at least 5 for full credit, minimum 3)',
+        'current_count', arr_len
+      );
+    END IF;
+  ELSE
+    -- NULL or not an array
+    issues := issues || jsonb_build_object(
+      'field', 'key_learnings',
+      'issue', 'Too few learnings (need at least 5 for full credit, minimum 3)',
+      'current_count', 0
+    );
+  END IF;
+
+  -- Vague learning check for key_learnings
+  IF NEW.key_learnings IS NOT NULL AND jsonb_typeof(NEW.key_learnings) = 'array' THEN
+    FOR i IN 0..jsonb_array_length(NEW.key_learnings) - 1 LOOP
+      item := NEW.key_learnings->>i;
+      IF item IS NOT NULL AND length(item) < 20 THEN
+        issues := issues || jsonb_build_object(
+          'field', 'key_learnings',
+          'issue', 'Learning too vague/short (should be >20 chars with specific details)',
+          'item', item
+        );
+      END IF;
+    END LOOP;
+  END IF;
+
+  -- ==========================================================================
+  -- action_items scoring
+  -- ==========================================================================
+  IF NEW.action_items IS NOT NULL AND jsonb_typeof(NEW.action_items) = 'array' THEN
+    arr_len := jsonb_array_length(NEW.action_items);
+    IF arr_len >= 3 THEN
+      score := score + 20;
+    ELSIF arr_len < 2 THEN
+      issues := issues || jsonb_build_object(
+        'field', 'action_items',
+        'issue', 'Too few action items (need at least 3)',
+        'current_count', arr_len
+      );
+    ELSE
+      score := score + 10;
+    END IF;
+  ELSE
+    -- NULL or not an array
+    issues := issues || jsonb_build_object(
+      'field', 'action_items',
+      'issue', 'Too few action items (need at least 3)',
+      'current_count', 0
+    );
+  END IF;
+
+  -- ==========================================================================
+  -- what_needs_improvement scoring
+  -- ==========================================================================
+  IF NEW.what_needs_improvement IS NOT NULL AND jsonb_typeof(NEW.what_needs_improvement) = 'array' THEN
+    arr_len := jsonb_array_length(NEW.what_needs_improvement);
+    IF arr_len >= 3 THEN
+      score := score + 20;
+    ELSIF arr_len >= 1 THEN
+      score := score + 10;
+    ELSE
+      issues := issues || jsonb_build_object(
+        'field', 'what_needs_improvement',
+        'issue', 'No improvement areas identified (every SD has room for improvement)',
+        'current_count', 0
+      );
+    END IF;
+  ELSE
+    -- NULL or not an array
+    issues := issues || jsonb_build_object(
+      'field', 'what_needs_improvement',
+      'issue', 'No improvement areas identified (every SD has room for improvement)',
+      'current_count', 0
+    );
+  END IF;
+
+  -- Dismissive statement check for what_needs_improvement
+  IF NEW.what_needs_improvement IS NOT NULL AND jsonb_typeof(NEW.what_needs_improvement) = 'array' THEN
+    FOR i IN 0..jsonb_array_length(NEW.what_needs_improvement) - 1 LOOP
+      item := NEW.what_needs_improvement->>i;
+      -- QF-20260807-251: was `item ILIKE '%no significant%' OR item ILIKE '%nothing%'` — a
+      -- SUBSTRING dock. It penalised the token wherever it appeared, so a finding precise
+      -- enough to state an empty set was taxed for saying so: measured firing on five
+      -- emphatic findings, including 'shares almost nothing with what was ratified' and
+      -- 'changed NOTHING OBSERVABLE'. That is the grep-is-not-a-test class living inside a
+      -- scoring gate, and it rewards hedging over precision.
+      --
+      -- The heuristic MEANT 'this item is empty filler'. So match that: the item must BE a
+      -- vacuous phrase, anchored end to end, not merely contain one. The full anchor is what
+      -- encodes 'short' — a real finding cannot be entirely equal to 'nothing to report' —
+      -- so no separate length test is added; a second condition that can never fail
+      -- independently would be a guard measuring nothing.
+      --
+      -- '%no significant%' is FOLDED IN rather than kept: it carried the identical defect
+      -- ('no significant change in latency was observed' is a real finding) and fixing only
+      -- the reported token would have left its twin in place.
+      --
+      -- Deliberate, stated trade: a PADDED vacuous item ('There is nothing that needs
+      -- improvement here, all good') no longer docks. Under-docking a hedged retro is far
+      -- less harmful than taxing a precise one, because validateSDCompletionReadiness falls
+      -- back to this stored score when the AI evaluator is unavailable — so the old
+      -- behaviour let a vaguer retro outscore a sharper one in a COMPLETION decision.
+      IF item IS NOT NULL AND btrim(lower(item)) ~ '^(n/?a|none|nothing|no comment|nothing to (report|add|note|say|improve)|no (significant|major|notable|other) (issues?|problems?|concerns?|improvements?|areas?|findings?)( to report| identified| found| noted)?)[.!]*$' THEN
+        score := score - 10;
+        issues := issues || jsonb_build_object(
+          'field', 'what_needs_improvement',
+          'issue', 'Dismissive statement detected - be constructive about improvements',
+          'item', item
+        );
+      END IF;
+    END LOOP;
+  END IF;
+
+  -- ==========================================================================
+  -- Specificity bonus (references to quantitative data)
+  -- ==========================================================================
+  IF (NEW.what_went_well::text || NEW.key_learnings::text || NEW.what_needs_improvement::text)
+     ~ '\d+ (lines?|files?|tests?|hours?|minutes?|LOC|components?)' THEN
+    score := score + 10;
+  END IF;
+
+  score := LEAST(score, 100);
+  score := GREATEST(score, 0);
+
+  NEW.quality_score := score;
+  NEW.quality_issues := issues;
+  NEW.quality_validated_at := NOW();
+  NEW.quality_validated_by := 'SYSTEM';
+
+  -- FR-2 + SD-FDBK-FIX-FIX-RETROSPECTIVE-TRIGGER-001:
+  -- Enforce the publish gate AFTER the score has been computed (above).
+  -- This covers the primary bug path: direct PUBLISHED INSERT where the score
+  -- was just freshly computed and must be validated before persisting.
+  IF (TG_OP = 'INSERT' AND NEW.status = 'PUBLISHED')
+     OR (TG_OP = 'UPDATE' AND OLD.status IS DISTINCT FROM 'PUBLISHED' AND NEW.status = 'PUBLISHED') THEN
+    IF NEW.quality_score IS NULL OR NEW.quality_score < 70 THEN
+      RAISE EXCEPTION 'PUBLISHED retrospectives must have quality_score >= 70 (current: %)', COALESCE(NEW.quality_score, 0)
+        USING HINT = 'Improve retrospective completeness to reach 70+ score';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$function$;
+
+COMMIT;

--- a/tests/fixtures/qf251-vacuous-regex.json
+++ b/tests/fixtures/qf251-vacuous-regex.json
@@ -1,0 +1,3 @@
+{
+  "vacuousRegex": "^(n/?a|none|nothing|no comment|nothing to (report|add|note|say|improve)|no (significant|major|notable|other) (issues?|problems?|concerns?|improvements?|areas?|findings?)( to report| identified| found| noted)?)[.!]*$"
+}

--- a/tests/unit/retro-quality-vacuous-predicate.test.js
+++ b/tests/unit/retro-quality-vacuous-predicate.test.js
@@ -1,0 +1,149 @@
+// QF-20260807-251 — the retro quality gate must dock EMPTY FILLER, not the token "nothing".
+//
+// WHAT THIS TEST CAN AND CANNOT DO, stated up front so nobody reads more into a green run than
+// it earns. The dock lives in a plpgsql trigger (public.auto_validate_retrospective_quality),
+// and CI has no database, so this exercises the PREDICATE — the regex — and NOT the trigger's
+// execution, the score arithmetic, or the publish gate. To stop that gap becoming a drift gap,
+// the regex has exactly ONE source of truth: tests/fixtures/qf251-vacuous-regex.json, which the
+// migration generator emitted alongside the SQL. The last test here pins that the shipped .sql
+// actually contains that exact string, so a mirror that silently diverges fails loudly.
+//
+// Postgres `~` is POSIX ERE and this asserts with JS RegExp. The pattern deliberately uses only
+// constructs the two share — alternation, groups, `?`, a character class, `^`/`$` — so no
+// feature in it can mean different things on the two engines.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const REPO = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const { vacuousRegex } = JSON.parse(
+  readFileSync(resolve(REPO, 'tests/fixtures/qf251-vacuous-regex.json'), 'utf8'),
+);
+const MIGRATION = resolve(REPO, 'database/migrations/20260808_qf251_retro_quality_vacuous_predicate.sql');
+
+// Mirrors the SQL call site: btrim(lower(item)) ~ '<regex>'
+const docks = (item) => new RegExp(vacuousRegex).test(String(item).trim().toLowerCase());
+
+// Leg (a) — the five MEASURED false positives. Verbatim from the banked originals at
+// retrospectives.metadata.quality_trigger_false_positives (row c075c90c-7489-4f53-b245-a72e53853e52)
+// for Charlie's three; Alpha-2's two as reported in the ticket. These are replayed, not paraphrased.
+const CHARLIE_BANKED = [
+  'SIX CORRECTIONS. What shipped shares almost nothing with what was ratified at SD creation. That is the headline finding of this SD, not a footnote — the SD was right about the HAZARD and wrong about the REMEDY, repeatedly, and each correction came from a different reviewer.',
+  'CORRECTION 3 — THE PLANNED ASSERTION WOULD HAVE BEEN PRINT-ONLY AND COULD NEVER HAVE FAILED THE PROBE. probeTable:463 set res.bound and main():522-530 merely PRINTED it, while main():532 folded ONLY r.code into the exit code. Adding the equality inside assertIngressBoundCannotBind would have changed NOTHING OBSERVABLE. This is the THIRD instance of the detector-nobody-reads defect class in a single arc, and I would have shipped it.',
+  'CORRECTION 5 (SECURITY) — THE VACUITY GATE SAT ABOVE THE BASIS CHECK, so definerFnBasis, a pure policy-TEXT read needing ZERO rows, was gated behind a row-count precondition it does not need. A quiet hour therefore swallowed a re-inlined policy and exited 0. MEASURED on live prod by replaying the probe cron window (17 6 * * *, one-hour lookback) over 30 days: 17 OF 30 RUNS (56.7%) WOULD HAVE BEEN VACUOUS AND ASSERTED NOTHING. Because retiring compareCountVisibility was made CONTINGENT on covering the re-inline path, 43% coverage did not satisfy the contingency I had already claimed was met.',
+];
+
+const ALPHA2_REPORTED = [
+  'the two vocabularies share NOTHING',
+  'NOTHING currently expires this state',
+];
+
+describe('leg (a): every measured emphatic finding scores UNDOCKED', () => {
+  it.each(CHARLIE_BANKED)('Charlie banked specimen: %s', (item) => {
+    expect(docks(item), 'emphatic finding still docked').toBe(false);
+  });
+
+  it.each(ALPHA2_REPORTED)('Alpha-2 reported specimen: %s', (item) => {
+    expect(docks(item), 'emphatic finding still docked').toBe(false);
+  });
+
+  it('the OLD substring rule docked all five — proving these are regressions, not new passes', () => {
+    // Without this the leg above could pass vacuously against a rule that never fired on them.
+    const oldRule = (i) => /no significant/i.test(i) || /nothing/i.test(i);
+    for (const item of [...CHARLIE_BANKED, ...ALPHA2_REPORTED]) {
+      expect(oldRule(item), 'specimen was NOT docked by the old rule — wrong fixture').toBe(true);
+    }
+  });
+
+  it('NOTHING-currently-expires-this-state survives a leading token — the case a stem match breaks', () => {
+    // A `^nothing` stem predicate looks right and is wrong: a hyphen is a word boundary, so the
+    // hyphenated compressed form of this very specimen would match it. Anchoring end-to-end is
+    // what makes a leading "NOTHING" safe.
+    expect(docks('NOTHING-currently-expires-this-state')).toBe(false);
+    expect(docks('NOTHING currently expires this state')).toBe(false);
+  });
+});
+
+describe('leg (b): genuinely vacuous filler STILL docks (the positive control)', () => {
+  const VACUOUS = [
+    'nothing', 'Nothing.', 'NOTHING', 'none', 'None.', 'N/A', 'n/a', 'na',
+    'nothing to report', 'Nothing to report.', 'nothing to add', 'nothing to note',
+    'no comment', 'no significant issues', 'No significant issues.',
+    'no major concerns', 'no notable improvements', 'no significant issues identified',
+    'no other findings', '  nothing to report  ',
+  ];
+  it.each(VACUOUS)('docks: %s', (item) => {
+    expect(docks(item), 'vacuous filler slipped through — the gate would stop docking').toBe(true);
+  });
+
+  it('folds in the %no significant% twin rather than leaving it substring-matched', () => {
+    // Kept deliberately: it carried the identical defect.
+    expect(docks('no significant issues')).toBe(true);                                  // still filler
+    expect(docks('No significant change in latency was observed after the fix.')).toBe(false); // real finding
+  });
+});
+
+describe('leg (c): gate-fallback — precision must not lose to hedging', () => {
+  // validateSDCompletionReadiness falls back to the STORED quality_score when the AI evaluator
+  // is unavailable, so any dock delta between a precise and a hedged retro can move a completion
+  // decision. Modelled as the dock count the trigger would apply per item.
+  const docksApplied = (items) => items.filter(docks).length;
+
+  const precise = [
+    'the two vocabularies share NOTHING',
+    'NOTHING currently expires this state',
+  ];
+  const hedged = [
+    'there may be some minor areas that could potentially be improved somewhat',
+    'a few things could perhaps be tightened up in places',
+  ];
+
+  it('a precise empty-set retro is docked no more than its hedged equivalent', () => {
+    expect(docksApplied(precise)).toBe(0);
+    expect(docksApplied(hedged)).toBe(0);
+    expect(docksApplied(precise)).toBeLessThanOrEqual(docksApplied(hedged));
+  });
+
+  it('under the OLD rule precision LOST to hedging — the defect this leg exists for', () => {
+    const oldRule = (i) => /no significant/i.test(i) || /nothing/i.test(i);
+    const oldPrecise = precise.filter(oldRule).length; // 2 → −20
+    const oldHedged = hedged.filter(oldRule).length;   // 0
+    expect(oldPrecise).toBeGreaterThan(oldHedged);
+  });
+});
+
+describe('the SQL and this mirror cannot drift', () => {
+  it('the shipped migration contains the exact WHOLE predicate this file asserts against', () => {
+    // Pins the COMPLETE expression, not just the regex substring. A `toContain(regex)` pin
+    // passed a mutation that injected characters INSIDE the quotes ('XX^(n/?a|...') because the
+    // regex was still present somewhere — it caught truncation but not prefix/suffix injection,
+    // which is nearly the exact corruption that a String.replace `$'` expansion caused while
+    // this migration was being generated. Pin the delimiters and the whole line survives.
+    const sql = readFileSync(MIGRATION, 'utf8');
+    expect(sql).toContain(`btrim(lower(item)) ~ '${vacuousRegex}' THEN`);
+  });
+
+  it('the migration declares the predicate EXACTLY ONCE', () => {
+    const sql = readFileSync(MIGRATION, 'utf8');
+    expect((sql.match(/btrim\(lower\(item\)\) ~ '/g) || []).length).toBe(1);
+  });
+
+  it('the restated function body is not duplicated — full-body DDL must carry one copy', () => {
+    // The `$'` corruption spliced the tail of the function back into itself and every other
+    // assertion here still passed. These landmarks are singular in a correct body.
+    const sql = readFileSync(MIGRATION, 'utf8');
+    expect((sql.match(/Specificity bonus/g) || []).length).toBe(1);
+    expect((sql.match(/CREATE OR REPLACE FUNCTION public\.auto_validate_retrospective_quality/g) || []).length).toBe(1);
+    expect((sql.match(/\$function\$/g) || []).length).toBe(2); // open + close, nothing spliced between
+  });
+
+  it('the migration no longer contains the substring dock it replaced (comments stripped)', () => {
+    // Comments MUST be stripped: the migration documents itself by quoting the old predicate,
+    // so a raw scan would match its own explanation and report the defect as still present.
+    const sql = readFileSync(MIGRATION, 'utf8').replace(/^\s*--.*$/gm, '');
+    expect(sql).not.toContain("ILIKE '%nothing%'");
+    expect(sql).not.toContain("ILIKE '%no significant%'");
+    expect(sql).toContain('auto_validate_retrospective_quality'); // vacuity: we scanned the real file
+  });
+});

--- a/tests/unit/retro-quality-vacuous-predicate.test.js
+++ b/tests/unit/retro-quality-vacuous-predicate.test.js
@@ -124,6 +124,17 @@ describe('the SQL and this mirror cannot drift', () => {
     expect(sql).toContain(`btrim(lower(item)) ~ '${vacuousRegex}' THEN`);
   });
 
+  it('the migration declares itself chairman-gated — the apply is deferred BY DESIGN', () => {
+    // Adam ruled 2026-08-08 that CREATE OR REPLACE FUNCTION is outside the delegated-apply lane
+    // and that this function, being the gate instrument, also invokes proposer-is-not-approver.
+    // check-migration-readiness reads this marker (CHAIRMAN-GATED-EXEMPT-001) and reports
+    // EXPECTED_PENDING instead of DRIFT_DETECTED — because the live body genuinely differs from
+    // this file and is SUPPOSED to until the ceremony runs. Pinned so the ruling travels with
+    // the artifact: if someone deletes the marker, the divergence goes red again, correctly.
+    const sql = readFileSync(MIGRATION, 'utf8');
+    expect(/^\s*--\s*(@chairman-gated|requires[-_]chairman[-_]apply)\b/im.test(sql)).toBe(true);
+  });
+
   it('the migration declares the predicate EXACTLY ONCE', () => {
     const sql = readFileSync(MIGRATION, 'utf8');
     expect((sql.match(/btrim\(lower\(item\)\) ~ '/g) || []).length).toBe(1);


### PR DESCRIPTION
## What

The retro quality trigger docked **10 points per item** on a bare substring match for `%nothing%` / `%no significant%` over `what_needs_improvement`. It penalised the token wherever it appeared, so a finding precise enough to state an empty set was taxed for saying so — the grep-is-not-a-test class living inside a scoring gate.

Not cosmetic: `validateSDCompletionReadiness` falls back to this stored `quality_score` when the AI evaluator is unavailable, so the penalty **propagated into completion decisions**. Under the old rule a precise empty-set retro scored *worse* than a vaguer one; a test asserts that inversion explicitly.

## The predicate

The heuristic meant *"this item is empty filler"*, so it now matches that: the item must **be** a vacuous phrase, anchored end to end, not merely contain one. The full anchor is what encodes "short" — a real finding cannot be entirely equal to `nothing to report` — so no separate length test was added, because a second condition that can never fail independently is a guard measuring nothing.

`%no significant%` is **folded in**, not kept: it carried the identical defect (*"no significant change in latency was observed"* is a real finding).

**A stem match would have been wrong and looked right.** `^nothing` fails on Alpha-2's own specimen `NOTHING-currently-expires-this-state` — a hyphen is a word boundary — so it would have re-docked one of the five findings this fix protects. Pinned as its own test.

Deliberate trade, stated: a *padded* vacuous item ("There is nothing that needs improvement here") no longer docks. Under-docking a hedged retro is far less harmful than taxing a precise one when the score feeds a completion gate.

## Tests exercise the regex, not the trigger

CI has no database. The regex has **one** source of truth (`tests/fixtures/qf251-vacuous-regex.json`, emitted by the generator) and a pin binds the shipped `.sql` to it. All three acceptance legs are covered, replaying the banked originals **verbatim** from `retrospectives.metadata.quality_trigger_false_positives` (row `c075c90c`) — plus a control proving the **old** rule docked all five, otherwise leg (a) could pass against fixtures the defect never touched.

## Two of my own failures, both caught

**The generator corrupted the migration.** `String.replace` treats `$'` in the *replacement* as "everything after the match", and the predicate ends `[.!]*$' THEN` — so the function tail was spliced back into itself: 314 lines instead of 273, `$function$` markers gone. **31 of 32 tests passed on that corrupted file.** Fixed with a replacer function; the body is now verified byte-identical to the original apart from the one predicate, with duplication landmarks added.

**The drift pin was too weak**, exposed by mutation: `toContain(regex)` passed an injection *inside* the quotes because the regex was still present somewhere. It now pins the whole delimited predicate.

| Mutation | Kills |
|---|---|
| Unanchored regex | leg (a) — 18 tests |
| Never-matching regex | docking control — 22 tests |
| Injection inside the quotes | drift pin |
| Duplicated function body | duplication landmarks |

34 green; restore verified byte-exact.

## Apply is not included

This is a `CREATE OR REPLACE FUNCTION` migration and the authoring seat cannot read or apply DDL (no `exec_sql` RPC). Per the coordinator's ruling the apply seat runs it and reads the **live** function body first, diffing it against this file — so "the newest migration is what is deployed" remains an inference until that readback happens.

⚠️ **Full-body DDL hazard**: this is the 6th migration to replace this function. Two files each carrying the whole body merge cleanly in git and then mutually revert on apply — last applied wins, silently.

QF-20260807-251