### PR TITLE
fix(QF-20260807-251): fold the live specificity regex forward before the apply

### DIFF
--- a/database/migrations/20260808_qf251_retro_quality_vacuous_predicate.sql
+++ b/database/migrations/20260808_qf251_retro_quality_vacuous_predicate.sql
@@ -256,7 +256,12 @@ BEGIN
   -- Specificity bonus (references to quantitative data)
   -- ==========================================================================
   IF (NEW.what_went_well::text || NEW.key_learnings::text || NEW.what_needs_improvement::text)
-     ~ '\d+ (lines?|files?|tests?|hours?|minutes?|LOC|components?)' THEN
+     -- FOLD-FORWARD (QF-20260807-251, caught at the apply safeguard): this line was transcribed
+     -- from 20260523 as `\d+`, which POSIX ERE does not honour, so the +10 specificity bonus
+     -- never fired. QF-20260529-565 already fixed it LIVE to [0-9]+ — and applying this
+     -- full-body replace with the dead form would have silently reverted that fix, last-applied-
+     -- wins. Carrying the live incumbent forward is fidelity to the approval, not new scope.
+     ~ '[0-9]+ (lines?|files?|tests?|hours?|minutes?|LOC|components?)' THEN
     score := score + 10;
   END IF;
 

--- a/tests/unit/retro-quality-vacuous-predicate.test.js
+++ b/tests/unit/retro-quality-vacuous-predicate.test.js
@@ -135,6 +135,21 @@ describe('the SQL and this mirror cannot drift', () => {
     expect(/^\s*--\s*(@chairman-gated|requires[-_]chairman[-_]apply)\b/im.test(sql)).toBe(true);
   });
 
+  it('carries the LIVE specificity regex forward — a full-body replace must not revert its incumbent', () => {
+    // Caught at the apply safeguard, not by me. This file restates the WHOLE function, and I
+    // transcribed line 259 from 20260523 as `\d+`, which POSIX ERE does not honour. QF-20260529-565
+    // had already fixed it live to [0-9]+ via pg_get_functiondef + replace + EXECUTE — a migration
+    // that mutates WITHOUT restating, and therefore invisible to every repo-text census I ran:
+    // it contains neither the function's CREATE OR REPLACE text nor the predicate I searched for.
+    // Applying my file as-is would have silently reverted a live fix, last-applied-wins.
+    const sql = readFileSync(MIGRATION, 'utf8');
+    expect(sql).toContain('[0-9]+ (lines?|files?|tests?|hours?|minutes?|LOC|components?)');
+    // Two-sided: the dead form must be gone from executable SQL. Comments are stripped because
+    // the fold-forward note above quotes the dead form to explain itself.
+    const code = sql.replace(/^\s*--.*$/gm, '');
+    expect(code).not.toContain('\\d+ (lines?');
+  });
+
   it('the migration declares the predicate EXACTLY ONCE', () => {
     const sql = readFileSync(MIGRATION, 'utf8');
     expect((sql.match(/btrim\(lower\(item\)\) ~ '/g) || []).length).toBe(1);


### PR DESCRIPTION
## What

Caught at the **apply safeguard**, not by me.

My QF-251 migration restates the whole `auto_validate_retrospective_quality` body, and I transcribed line 259 from `20260523` as `\d+` — which POSIX ERE does not honour, so the +10 numeric-specificity bonus never fires. The **live** function already carries `[0-9]+`, fixed by QF-20260529-565. Applying my file as-is would have **silently reverted that fix**, last-applied-wins — precisely the full-body DDL hazard my own header warns about, about to run under a chairman YES.

**One line changed.** The semantic diff versus live is now exactly one predicate — the vacuous-phrase anchor the approval covers. Carrying the live incumbent forward is fidelity to that approval, not new scope (per Adam; no new chairman ask).

## Why my baseline could not see it

`20260529` contains **zero** `CREATE OR REPLACE` statements. It patches the live body via `pg_get_functiondef` + `replace` + `EXECUTE` — a migration that **mutates without restating**.

Both of my censuses were text searches over the repo: one for the predicate I was fixing, one for the function's full-object declaration. Neither can see a change that never writes the body down. When the object is mutable and the repo is not its source of truth, only the live object is — and I had already written in that same file that I couldn't read it from my seat, which should have told me my baseline was an inference, not a fact.

## And my own marker hid the evidence

The readiness probe **did** see this divergence: its red diff contained both the expected vacuous-predicate change *and* this unexpected regex change. My `-- @chairman-gated` marker downgraded the whole file to `EXPECTED_PENDING` and swallowed both.

**An exemption scoped to a file exempts every difference in it, not just the one you had in mind.** The marker was still correct to add and was ruled so — but I justified it against the divergence I knew about and never asked what else it would cover. What caught this was a live readback at the apply seat, downstream of every check I wrote.

## Proof

Pinned two-sided: the file must carry `[0-9]+`, and the dead form must be absent from executable SQL (comments stripped, since the fold-forward note quotes it). 36 green; reinstating the dead form kills the new pin.

QF-20260807-251