### PR TITLE
feat(SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-E): revive the two inert cleanup controls

### DIFF
--- a/.github/workflows/e2e-fixture-reap.yml
+++ b/.github/workflows/e2e-fixture-reap.yml
@@ -1,0 +1,109 @@
+# E2E liveness-fixture reaper — scheduled cleanup of __e2e_ rows in periodic_process_registry.
+# SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-E (FR-1, FR-2).
+#
+# WHY THIS FILE EXISTS: scripts/reap-e2e-liveness-fixtures.mjs already worked and was already
+# correct — it just had NOTHING INVOKING IT. Measured at LEAD: 3 references repo-wide (the script,
+# its own predicate unit test, and a prose comment), ZERO in package.json, ZERO across
+# .github/workflows/, and no periodic_process_registry row. An instrument nobody invokes is
+# indistinguishable from an absent one, except that its existence hides the gap from the next
+# person who greps for a reaper. So the convention shipped HALF an invariant: rows were marked and
+# filtered, then accumulated forever.
+#
+# ── THE TRAP THIS WORKFLOW IS SHAPED TO AVOID (FR-2) ──────────────────────────────────────
+# THE REAPER DEFAULTS TO DRY RUN. Scheduling `node scripts/reap-e2e-liveness-fixtures.mjs` with no
+# flag would produce a green, exit-0, ZERO-WRITE job forever — scheduled but still inert, which is
+# the SAME defect this SD exists to close, reproduced one layer up. Dry run also returns BEFORE
+# setting an exit code, so residue > 0 emits no signal at all. A "scheduled" reaper that never
+# reaps is worse than an unscheduled one, because the gap now looks closed.
+#
+# ── WHY --apply IS FLAG-GATED RATHER THAN JUST SWITCHED ON ────────────────────────────────
+# The script's own header (lines 29-37) states that the QF specifying it does NOT authorize
+# production deletes, and that --apply requires authorization obtained separately. A scheduled
+# workflow running --apply IS that authorization, granted by omission. So --apply is gated on
+# leo_feature_flags.E2E_FIXTURE_REAP_V1, which ships ABSENT => disabled => the reap step does not
+# run. Merging this performs ZERO deletes. Enabling it is a deliberate, reviewable registry insert
+# by an operator who holds the authorization the script asks for — the same shape
+# venture-fixture-sweep.yml uses for VENTURE_FIXTURE_SWEEP_V1.
+#
+# The DRY-RUN step runs UNCONDITIONALLY and always reports the residue count, so the disabled state
+# is observable rather than silent: you can see what WOULD be reaped before anyone arms it.
+#
+# ── REGISTRATION IS AUTOMATIC ─────────────────────────────────────────────────────────────
+# Do NOT hand-write a periodic_process_registry row and do NOT call registerArmedMachinery (that is
+# a different convention, keyed g3-armed-<slug>, for machinery-class work). ADDING THIS FILE IS THE
+# REGISTRATION: lib/periodic-liveness/enumerate-processes.mjs:59-78 discovers .github/workflows/*.yml
+# and emits process_key=gha_cron:e2e-fixture-reap.yml. Run scripts/seed-periodic-process-registry.mjs
+# (idempotent) to materialise the row before the next zero-shadow sweep.
+name: E2E Fixture Reap
+
+on:
+  schedule:
+    # Wednesdays 03:41 UTC. Deliberately off-peak and non-colliding with the two neighbouring
+    # cleanup jobs (venture-fixture-sweep Sat 04:23, canary-venture-probe Sun 06:17), and off the
+    # top of the hour so it does not pile into the :00 cron crowd.
+    - cron: '41 3 * * 3'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  # State-mutating when armed, so a second run must never overlap a delete in flight.
+  group: e2e-fixture-reap
+  cancel-in-progress: false
+
+jobs:
+  fixture-reap:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # --ignore-scripts is load-bearing, not tidiness: --omit=dev alone fires the `prepare`
+      # lifecycle, which runs husky and dies "husky: not found" exit 127
+      # (orphan-qf-reaper.yml:52-56 documents it as PAT-CI-WORKFLOW-LIFECYCLE-001).
+      - name: Install dependencies
+        run: npm ci --omit=dev --ignore-scripts
+
+      # ALWAYS RUNS. This is what stops the disabled state from being silent: even with the flag
+      # absent, the job reports what residue exists and what WOULD be reaped.
+      - name: Report reapable residue (dry run — always)
+        run: node scripts/reap-e2e-liveness-fixtures.mjs
+
+      - name: Authorization gate (E2E_FIXTURE_REAP_V1)
+        id: gate
+        run: |
+          node --input-type=module <<'EOF'
+          import { createClient } from '@supabase/supabase-js';
+          import fs from 'node:fs';
+          const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+          // Surface the error rather than folding it into "off": a gate that reports a BROKEN
+          // query as "disabled" cannot see its own death (AC-5, same defect noted in
+          // venture-fixture-sweep.yml:51 which destructures only { data }).
+          const { data, error } = await sb
+            .from('leo_feature_flags')
+            .select('is_enabled')
+            .eq('flag_key', 'E2E_FIXTURE_REAP_V1')
+            .maybeSingle();
+          if (error) {
+            console.error(`E2E_FIXTURE_REAP_V1 gate FAILED TO READ: ${error.message}`);
+            console.error('Refusing to infer "disabled" from an unreadable flag — that is a false negative, not a safe default.');
+            process.exit(1);
+          }
+          const enabled = data?.is_enabled === true;
+          fs.appendFileSync(process.env.GITHUB_OUTPUT, `enabled=${enabled}\n`);
+          console.log(enabled
+            ? 'E2E_FIXTURE_REAP_V1 enabled — reap will run with --apply.'
+            : 'E2E_FIXTURE_REAP_V1 disabled (or absent) — dry run only, no deletes. This is the shipped default.');
+          EOF
+
+      - name: Reap e2e liveness fixtures (--apply; authorization-gated)
+        if: steps.gate.outputs.enabled == 'true'
+        run: node scripts/reap-e2e-liveness-fixtures.mjs --apply

--- a/.github/workflows/venture-fixture-sweep.yml
+++ b/.github/workflows/venture-fixture-sweep.yml
@@ -15,7 +15,20 @@ name: Venture Fixture Sweep
 on:
   schedule:
     - cron: '23 4 * * 6'   # Saturdays 04:23 UTC (low-traffic; distinct from the canary's Sun 06:17)
-  workflow_dispatch: {}
+  workflow_dispatch:
+    # SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-E (FR-4). This input did not exist, and its absence was a
+    # real gap: the flag's own precedent (CANARY_VENTURE_PROBE_V1) says "ships OFF; enable after the
+    # first supervised incremental run" — but with no inputs and --fix as the only run step, there
+    # was NO WAY TO PERFORM that supervised run. You could only choose between doing nothing and
+    # doing everything. Measured blast radius makes that a real problem, not a theoretical one: the
+    # first armed run soft-deletes 87 of 89 live ventures (all 87 via is_demo alone), sparing only
+    # "Image Alt Text Generator" — the live first-revenue venture — and "ApexNiche AI".
+    inputs:
+      dry_run:
+        description: 'Report what WOULD be swept without writing (leave true to preview)'
+        type: boolean
+        required: false
+        default: true
 
 permissions:
   contents: read
@@ -60,6 +73,16 @@ jobs:
             : 'VENTURE_FIXTURE_SWEEP_V1 disabled (or absent) — quiet no-op.');
           EOF
 
+      # ALWAYS RUNS. Reports the residue count without writing, so a disabled flag is an OBSERVABLE
+      # state rather than a silent one — you can see what WOULD be swept before anyone arms it, and
+      # a manual dry_run dispatch stops here. (FR-4)
+      - name: Report fixture residue (dry run — always)
+        run: node scripts/sweep-fixture-residue.mjs
+
+      # SOFT-DELETE PATH. Requires BOTH the flag AND a non-dry-run dispatch: a scheduled run has no
+      # inputs, so `inputs.dry_run` is empty and this is armed by the flag alone; a manual run must
+      # explicitly uncheck dry_run. Defaulting the input to true means the safe choice is the one
+      # you get by doing nothing.
       - name: Run fixture residue sweep (soft-delete; flag-gated)
-        if: steps.gate.outputs.enabled == 'true'
+        if: steps.gate.outputs.enabled == 'true' && inputs.dry_run != true
         run: node scripts/sweep-fixture-residue.mjs --fix

--- a/scripts/sweep-fixture-residue.mjs
+++ b/scripts/sweep-fixture-residue.mjs
@@ -20,6 +20,8 @@
 import 'dotenv/config';
 import { createRequire } from 'node:module';
 import { fetchAllPaginated } from '../lib/db/fetch-all-paginated.mjs';
+// QF-20260807-992's canonical cross-platform entry guard — see the CLI block at the bottom.
+import { isMainModule } from '../lib/utils/is-main-module.js';
 
 const require = createRequire(import.meta.url);
 const { createClient } = require('@supabase/supabase-js');
@@ -104,6 +106,27 @@ async function main() {
   process.exitCode = residue.length - fixed === 0 ? 0 : 1;
 }
 
-if (process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/').split('/').pop())) {
-  main().catch((e) => { console.error(e.message); process.exit(1); });
+// SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-E (FR-5) — TWO DEFECTS FIXED HERE, both of which made this
+// file contradict the comment four lines above it.
+//
+// 1. THE ENTRY GUARD WAS A SUFFIX MATCH, NOT AN IDENTITY CHECK. It read
+//    `import.meta.url.endsWith(basename(argv[1]))`, which is the same hand-rolled pattern
+//    QF-20260807-992 proved SILENTLY NEVER FIRES ON WINDOWS (a manual `file://C:/...` has two
+//    slashes; import.meta.url has three, so main() never ran and the script exited 0 printing
+//    nothing). It is also too loose in the other direction: ANY entry script whose basename ends
+//    the same way — say another `residue.mjs` — would fire main() here, and run --fix if that flag
+//    happened to be in argv. isMainModule uses Node's own pathToFileURL encoder, so it also
+//    survives spaces, '#' and unicode in a path.
+//
+// 2. THE CATCH HARD-EXITED, DEFEATING THE LINE ABOVE IT. `process.exit(1)` here undid the
+//    deliberate `process.exitCode` at :104 — the comment there explains that hard-exiting with live
+//    Supabase handles trips a libuv teardown assert on Windows (exit 127 AFTER printing CLEAN=true),
+//    and this line reintroduced exactly that, four lines later, on the FAILURE path. That matters
+//    most precisely when it fires: an error after partial soft-deletes is when you most need a
+//    trustworthy exit code and a clean teardown. process.exit also terminates before any `finally`
+//    runs, which is the mechanism by which a sibling probe leaked synthetic rows on its failure
+//    path — the inherited rule for this whole SD is that CLEANUP MUST NOT DEPEND ON CONTROL FLOW:
+//    SET an exit code, let the process end on its own.
+if (isMainModule(import.meta.url)) {
+  main().catch((e) => { console.error(e.message); process.exitCode = 1; });
 }

--- a/tests/unit/cron/e2e-fixture-reap-wiring.test.js
+++ b/tests/unit/cron/e2e-fixture-reap-wiring.test.js
@@ -1,0 +1,122 @@
+/**
+ * SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-E (FR-1, FR-2 / AC-3) — the reaper must be DISPATCHED, and
+ * dispatching it must not be a no-op. Exemplar: tests/unit/cron/divergence-fence-wiring.test.js.
+ *
+ * THE DEFECT CLASS THIS PINS: scripts/reap-e2e-liveness-fixtures.mjs was fully built, correct, and
+ * NEVER INVOKED — measured at LEAD as 3 references repo-wide (the script, its own predicate test,
+ * and a prose comment), zero in package.json, zero across .github/workflows/, and no
+ * periodic_process_registry row. Its own tests were its only callers.
+ *
+ * THE SECOND, SHARPER DEFECT — and the reason this file asserts more than "a workflow exists":
+ * THE REAPER DEFAULTS TO DRY RUN. A workflow that schedules it without deciding --apply is green,
+ * exit-0, and writes NOTHING, forever. That satisfies "it is scheduled" while leaving the control
+ * exactly as inert as it was, which is this SD's own defect reproduced one layer up. So the
+ * assertions below pin BOTH halves: that it is dispatched, and that dispatch can actually reap.
+ *
+ * Pure fs reads — no DB, no network, no clock — and typed as a UNIT test DELIBERATELY:
+ * tests/integration/** resolves to ZERO FILES in this repo (the vitest db project is disabled with
+ * no designated non-production target), so an integration-typed wiring test would SKIP AND REPORT
+ * GREEN, which is the same false assurance this SD exists to abolish.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../../..');
+
+const WORKFLOW_REL = '.github/workflows/e2e-fixture-reap.yml';
+const SCRIPT_REL = 'scripts/reap-e2e-liveness-fixtures.mjs';
+const WORKFLOW = path.join(repoRoot, WORKFLOW_REL);
+const SCRIPT = path.join(repoRoot, SCRIPT_REL);
+
+const read = (p) => fs.readFileSync(p, 'utf8');
+
+describe('the e2e fixture reaper names its dispatcher', () => {
+  it('the reaper script it dispatches actually exists', () => {
+    // Guards the inverse mistake: a workflow pointing at a path that was renamed or never landed
+    // would still satisfy the regex below while dispatching nothing.
+    expect(fs.existsSync(SCRIPT), `missing reaper script: ${SCRIPT}`).toBe(true);
+  });
+
+  it('the workflow exists and its run step invokes the reaper', () => {
+    expect(fs.existsSync(WORKFLOW), `missing dispatcher workflow: ${WORKFLOW}`).toBe(true);
+    expect(read(WORKFLOW)).toMatch(/node\s+scripts\/reap-e2e-liveness-fixtures\.mjs/);
+  });
+
+  it('[SCHEDULE] it is on a SCHEDULE, not workflow_dispatch alone', () => {
+    const yml = read(WORKFLOW);
+    expect(yml, 'a manually-triggered-only workflow does not end dormancy').toMatch(/^\s*schedule:/m);
+    expect([...yml.matchAll(/^\s*-\s*cron:\s*'([^']+)'/gm)].length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('[NOT-DRY-RUN-FOREVER] some step invokes the reaper with --apply', () => {
+    // THE ASSERTION THAT PINS THE REAL FIX. Without it, every other test here passes against a
+    // workflow that runs the reaper in its DEFAULT dry-run mode on a schedule — scheduled, green,
+    // and writing nothing, which is the defect wearing the fix's clothes.
+    const yml = read(WORKFLOW);
+    expect(
+      yml,
+      'the workflow schedules the reaper but never passes --apply: it would be green, exit-0 and zero-write forever'
+    ).toMatch(/reap-e2e-liveness-fixtures\.mjs\s+--apply/);
+  });
+
+  it('[AUTHORIZATION] the --apply step is gated, because the script says it is not authorized', () => {
+    // reap-e2e-liveness-fixtures.mjs's own header states the specifying QF does NOT authorize
+    // production deletes and that --apply requires authorization obtained separately. An ungated
+    // scheduled --apply would BE that authorization, granted by omission. So the apply step must
+    // carry an `if:` condition rather than running unconditionally.
+    const yml = read(WORKFLOW);
+    const applyLine = yml.split('\n').findIndex((l) => /reap-e2e-liveness-fixtures\.mjs\s+--apply/.test(l));
+    expect(applyLine, 'no --apply step found').toBeGreaterThan(-1);
+    // Look back over the step for its guard — a step is a handful of lines, so a small window.
+    const stepWindow = yml.split('\n').slice(Math.max(0, applyLine - 4), applyLine + 1).join('\n');
+    expect(
+      stepWindow,
+      'the --apply step runs unconditionally; it must be gated on an authorization flag'
+    ).toMatch(/^\s*if:\s/m);
+  });
+
+  it('[OBSERVABLE-WHEN-OFF] a dry-run step runs unconditionally, so the disabled state is not silent', () => {
+    // Without this the shipped default (flag absent) is a job that does nothing and says nothing,
+    // which is indistinguishable from a broken one. The unconditional dry run is what makes
+    // "disabled" a reported state rather than an absence.
+    const yml = read(WORKFLOW);
+    const lines = yml.split('\n');
+    const dryRunIdx = lines.findIndex((l) =>
+      /node\s+scripts\/reap-e2e-liveness-fixtures\.mjs\s*$/.test(l)
+    );
+    expect(dryRunIdx, 'no unconditional (no-flag) reaper invocation found').toBeGreaterThan(-1);
+    const stepWindow = lines.slice(Math.max(0, dryRunIdx - 4), dryRunIdx + 1).join('\n');
+    expect(stepWindow, 'the dry-run step must NOT be conditional — it is the always-on observability').not.toMatch(/^\s*if:\s/m);
+  });
+
+  it('[SECRETS] every secret the job reads is wired in env', () => {
+    const yml = read(WORKFLOW);
+    for (const key of ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY']) {
+      expect(yml, `${key} is not wired from secrets`).toMatch(
+        new RegExp(`${key}:\\s*\\$\\{\\{\\s*secrets\\.${key}\\s*\\}\\}`)
+      );
+    }
+  });
+
+  it('[INSTALL] the install step disables lifecycle scripts', () => {
+    // --omit=dev alone fires `prepare`, which runs husky and dies "husky: not found" exit 127
+    // (PAT-CI-WORKFLOW-LIFECYCLE-001, documented at orphan-qf-reaper.yml:52-56).
+    expect(read(WORKFLOW)).toMatch(/npm\s+ci[^\n]*--ignore-scripts/);
+  });
+
+  it('[NO-COLLISION] its cron does not collide with the neighbouring cleanup jobs', () => {
+    // Sharing a minute with venture-fixture-sweep (Sat 04:23) or canary-venture-probe (Sun 06:17)
+    // would stack service-role DB load; the repo's convention is deliberate offset.
+    const crons = [...read(WORKFLOW).matchAll(/^\s*-\s*cron:\s*'([^']+)'/gm)].map((m) => m[1]);
+    expect(crons.length).toBeGreaterThanOrEqual(1);
+    for (const c of crons) {
+      expect(c, 'collides with venture-fixture-sweep').not.toBe('23 4 * * 6');
+      expect(c, 'collides with canary-venture-probe').not.toBe('17 6 * * 0');
+      expect(c, 'top-of-the-hour crons pile into the :00 crowd').not.toMatch(/^0\s/);
+    }
+  });
+});

--- a/tests/unit/sweep-fixture-residue-entry-and-exit.test.js
+++ b/tests/unit/sweep-fixture-residue-entry-and-exit.test.js
@@ -1,0 +1,66 @@
+/**
+ * SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-E (FR-5 / AC-6) — the sweep's CLI edge: entry guard and exit
+ * code. Both were defects that made the file contradict its own comment four lines earlier.
+ *
+ * WHY THESE ARE SOURCE ASSERTIONS RATHER THAN A SPAWNED RUN. The two properties under test are
+ * "main() fires on the platform we actually run on" and "the failure path does not hard-exit".
+ * Reproducing the first genuinely requires a Windows entry-point resolution, and the second
+ * requires a real Supabase failure mid-sweep — neither is available in a unit tier, and faking
+ * either would test the fake. So these pin the SHAPE at the CLI edge, and the mutation evidence
+ * that they bite is recorded in the commit message rather than left implied.
+ *
+ * Typed UNIT deliberately: tests/integration/** resolves to ZERO FILES in this repo, so an
+ * integration-typed test here would SKIP AND REPORT GREEN — the exact false assurance this SD is
+ * about.
+ */
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+const SCRIPT = path.join(repoRoot, 'scripts/sweep-fixture-residue.mjs');
+const src = fs.readFileSync(SCRIPT, 'utf8');
+/** Comments stripped — this file DESCRIBES the old defects in prose, so a naive grep self-matches. */
+const code = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+describe('sweep-fixture-residue CLI edge', () => {
+  it('[ENTRY] uses the canonical isMainModule guard, not a hand-rolled suffix match', () => {
+    expect(code, 'must import the canonical guard').toMatch(
+      /import\s*\{\s*isMainModule\s*\}\s*from\s*['"][^'"]*is-main-module\.js['"]/
+    );
+    expect(code, 'the entry condition must be isMainModule(import.meta.url)').toMatch(
+      /if\s*\(\s*isMainModule\s*\(\s*import\.meta\.url\s*\)\s*\)/
+    );
+  });
+
+  it('[ENTRY] the endsWith suffix match is GONE', () => {
+    // The specific broken shape: import.meta.url.endsWith(<basename of argv[1]>). On Windows a
+    // hand-built file:// has two slashes where import.meta.url has three, so main() never ran and
+    // the script exited 0 printing NOTHING — indistinguishable from "there was nothing to do".
+    expect(code, 'hand-rolled endsWith entry guard still present').not.toMatch(
+      /import\.meta\.url\.endsWith\s*\(/
+    );
+  });
+
+  it('[EXIT] the failure path sets an exit CODE and never hard-exits', () => {
+    // THE ASSERTION THAT MATTERS. process.exit terminates before `finally` runs — the mechanism by
+    // which a sibling probe leaked synthetic rows on exactly its failure path — and hard-exiting
+    // with live Supabase handles trips the libuv teardown assert the :104 comment documents
+    // avoiding. Having process.exit(1) four lines below that comment defeated it.
+    expect(code, 'process.exit() must not appear anywhere in this script').not.toMatch(
+      /process\.exit\s*\(/
+    );
+    expect(code, 'the main() catch must set process.exitCode').toMatch(
+      /main\(\)\s*\.catch\s*\([^)]*\)\s*=>\s*\{[^}]*process\.exitCode\s*=\s*1/
+    );
+  });
+
+  it('[EXIT] the success path still reports residue through exitCode', () => {
+    // Guards the inverse mistake: removing the hard exit must not also remove the signal. An
+    // assertion tool whose exit code is always 0 cannot fail a build.
+    expect(code).toMatch(/process\.exitCode\s*=\s*residue\.length\s*-\s*fixed\s*===\s*0\s*\?\s*0\s*:\s*1/);
+  });
+});


### PR DESCRIPTION
Child E of SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001. The synthetic-row convention shipped **half an invariant**: rows got marked and filtered, then accumulated forever, because *both* cleanup controls were inert.

## Measured at LEAD
- `scripts/reap-e2e-liveness-fixtures.mjs` — **unscheduled**. 3 references repo-wide (the script, its own predicate test, a prose comment), 0 in `package.json`, 0 across ~110 workflows, no registry row. Its only callers were its own tests.
- `VENTURE_FIXTURE_SWEEP_V1` — **absent, not disabled**. `leo_feature_flags` holds 23 rows and none was that key, so the existing weekly cron fired and quiet-no-opped.

## The trap this PR is shaped around
**The reaper defaults to dry run.** Simply scheduling it yields a green, exit-0, zero-write job *forever* — scheduled and still inert, which is this SD's own defect reproduced one layer up, and worse than leaving it unscheduled because the gap then *looks* closed. So the workflow runs an **unconditional dry run** (the disabled state reports a residue count instead of being silent) plus a separate `--apply` step gated on `E2E_FIXTURE_REAP_V1`, which ships absent → **merging performs zero deletes**.

Gating rather than switching on is deliberate: the script's own header states the specifying QF does *not* authorize production deletes, so an ungated scheduled `--apply` would *be* that authorization, granted by omission.

## Also fixed
- `sweep-fixture-residue.mjs:108` — `main().catch(process.exit(1))` **defeated** the deliberate `process.exitCode` four lines above it, whose comment explains that hard-exiting with live Supabase handles trips a libuv teardown assert. It fired on the *failure* path, after possible partial soft-deletes. `process.exit` also skips `finally` — the mechanism that leaked synthetic rows on a sibling probe.
- `sweep-fixture-residue.mjs:107` — hand-rolled `endsWith` entry guard, the pattern QF-992 proved **silently never fires on Windows** (exit 0, no output). Now uses canonical `lib/utils/is-main-module.js`.
- `venture-fixture-sweep.yml` — had **no inputs** and `--fix` as its only step, so the "supervised incremental run" its own flag precedent requires was *impossible*. Added a `dry_run` input defaulting to **true** plus an unconditional dry-run step.

## Acceptance — measured on live data, not asserted
- **AC-1/AC-2 (seeded, because live residue was 0):** seeded a `__e2e_` row, ran `--apply`. Reaper reported *"deleted 1 row(s) of 1 targeted"* and *"__-leading rows DELIBERATELY KEPT: `__watcher_self__`, `__eva_scheduler_watcher_self__`"*. Independently re-queried after: residue **0**, both watchers **still present**. Counted delete, and the negative control held.
- **AC-4 (live dry run):** `residue=87` — exactly the LEAD figure, re-confirmed. **Zero hits** for "Image Alt Text Generator" (the live first-revenue venture), "ApexNiche AI", and "Canary Venture Probe".
- **Flag row created shipping OFF** (`is_enabled=false`, `lifecycle_state=disabled`, `risk_tier=high`) with the 87/2 counts in its description, so whoever enables it decides against numbers.

## Mutation-verified
Wiring tests that cannot fail *are* this SD's defect class, so each was proven to bite: removing `--apply` fails `[NOT-DRY-RUN-FOREVER]` + `[AUTHORIZATION]`; colliding the cron fails `[NO-COLLISION]`; restoring `process.exit(1)` fails `[EXIT]`; restoring the `endsWith` guard fails both `[ENTRY]` tests. Restored: 24/24.

Tests are typed **unit** deliberately — `tests/integration/**` resolves to zero files here, so an integration-typed wiring test would skip and report green.

## Post-merge action
Re-run `scripts/seed-periodic-process-registry.mjs` after merge. Registration is auto-discovered from `.github/workflows/*.yml`, and the seeder scans the merged tree — so `gha_cron:e2e-fixture-reap.yml` cannot exist until this lands. Not a defect; verified as the cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)