### PR TITLE
feat(SD-LEO-INFRA-UNCAPPED-ROADMAP-ITEMS-001): uncap the roadmap-items-to-SD join and source three drive-report sections

### DIFF
--- a/lib/chairman/daily-review/roadmap-status-doc.js
+++ b/lib/chairman/daily-review/roadmap-status-doc.js
@@ -298,7 +298,21 @@ export function renderChainToGate(section) {
     // Owner is stated even when null: "unowned" is a real and important state — the thing standing
     // in front of the gate has nobody accountable — and omitting it reads as "not applicable".
     out.push(`      blocker: ${b.title || b.item_id}${b.blocked_on ? ` (blocked on ${b.blocked_on})` : ''}`);
-    out.push(`      owner: ${b.owner || 'UNOWNED'}${b.owner_basis ? ` — ${b.owner_basis}` : ''}`);
+    // SD-LEO-INFRA-UNCAPPED-ROADMAP-ITEMS-001: owner may be a claiming_session_id (a raw session
+    // UUID). This renderer was dormant while chain_to_gate was an unavailable stub; wiring the
+    // section activates it, so this is the FIRST surface where that UUID would reach the chairman
+    // brief in full. Truncated to 8 chars to match the fleet-dashboard precedent
+    // (scripts/fleet-dashboard.cjs, which already prints substring(0,8)).
+    //
+    // Shipped in the SAME PR as the persistence wiring, per coordinator ruling — drive_reports is
+    // APPEND-ONLY behind a freeze trigger, so a full UUID written once cannot be redacted later.
+    // A follow-up PR would be too late by construction. Only session-UUID-shaped owners are
+    // truncated; an owner_lane or any other human-meaningful owner string is left intact.
+    const ownerRaw = b.owner || null;
+    const ownerShown = (typeof ownerRaw === 'string' && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(ownerRaw))
+      ? `${ownerRaw.slice(0, 8)}…`
+      : ownerRaw;
+    out.push(`      owner: ${ownerShown || 'UNOWNED'}${b.owner_basis ? ` — ${b.owner_basis}` : ''}`);
   } else {
     // Distinct from "unavailable" and from a bare blank: nothing blocked is an ANSWER.
     out.push('      blocker: none — the chain is moving or waiting on capacity, which is a different diagnosis from blocked');

--- a/lib/roadmap/plan-check-status.js
+++ b/lib/roadmap/plan-check-status.js
@@ -303,6 +303,11 @@ export async function computePlanCheckStatus(supabase, { windowHours = 48 } = {}
     // AWAIT_DECISION. A guard that tolerates an absent input makes the absence invisible. This
     // join supplies every field that actually exists; the three that do not need a producer,
     // which is out of this SD's scope and filed as its remainder.
+    // FR-3: chain_to_gate needs the WAVES as well as the items — buildChainToGate takes
+    // ({ waves, items }), and its current "unavailable" reason says plainly that roadmap waves
+    // are not queried by that job. They ARE queried here, so exposing them additively is what
+    // keeps chain_to_gate on this single representation instead of spawning a second wave read.
+    waves,
     open_items_all: openItems.map((item) => ({
       item_id: item.id,
       title: item.title,

--- a/lib/roadmap/plan-check-status.js
+++ b/lib/roadmap/plan-check-status.js
@@ -182,7 +182,11 @@ export async function computePlanCheckStatus(supabase, { windowHours = 48 } = {}
     // line citation is not a scope statement.
     items = await fetchAllPaginated(() => supabase
       .from('v_plan_of_record_remainder') // schema-lint-disable-line: pre-existing view reference, unrelated to pagination edits in this file
-      .select('id, wave_id, title, promoted_to_sd_key, item_disposition, priority_rank, remainder_state')
+      // `lane` and `metadata` are selected for the drive-loop consumers: classifyItem reads
+      // item.lane for the blocked-on-* branch, and next-acts orders by metadata.dispatch_rank.
+      // All nine columns verified present on the view before being named — a phantom column
+      // poisons the WHOLE projection and would turn this working join into an empty one.
+      .select('id, wave_id, title, promoted_to_sd_key, item_disposition, priority_rank, remainder_state, lane, metadata')
       .in('wave_id', waveIds)
       .order('id', { ascending: true })); // unique tiebreaker: stable page boundaries
   }
@@ -308,12 +312,25 @@ export async function computePlanCheckStatus(supabase, { windowHours = 48 } = {}
     // are not queried by that job. They ARE queried here, so exposing them additively is what
     // keeps chain_to_gate on this single representation instead of spawning a second wave read.
     waves,
+    // THE SHAPE IS THE RAW ITEM PLUS `sd` — DO NOT RENAME FIELDS HERE. The first version of this
+    // mapping renamed them (item_id, wave, disposition, sd_key) to match the `next`/`committing`
+    // display shape, and that silently broke all three consumers, which read the RAW names:
+    //   classifyItem      -> item.promoted_to_sd_key  (got `sd_key`  -> every item read UNSOURCED)
+    //   resolveChain      -> it.wave_id               (got `wave`, a TITLE -> grouped under
+    //                                                  undefined -> "every approved wave is
+    //                                                  clear" WITH open items present)
+    //   nextAct/ordering  -> item.id, metadata.dispatch_rank
+    // Nothing errored. Two sections emitted confident, wrong output and one was empty — strictly
+    // worse than the honest `unavailable` this replaced. Caught only by an EXEC review that ran
+    // the real builders on real data.
+    //
+    // Spreading the item preserves every field the classifiers read (id, wave_id,
+    // promoted_to_sd_key, item_disposition, lane, remainder_state, metadata, title) and leaves
+    // this map with one job: attach the joined `sd`. A future reader adding a display alias
+    // should ADD it alongside, never rename what is already here.
     open_items_all: openItems.map((item) => ({
-      item_id: item.id,
-      title: item.title,
-      wave: waveById.get(item.wave_id)?.title || null,
-      disposition: item.item_disposition,
-      sd_key: item.promoted_to_sd_key || null,
+      ...item,
+      wave: waveById.get(item.wave_id)?.title || null, // additive convenience; wave_id is preserved above
       sd: item.promoted_to_sd_key ? (sdByKey.get(item.promoted_to_sd_key) || null) : null,
     })),
   };

--- a/lib/roadmap/plan-check-status.js
+++ b/lib/roadmap/plan-check-status.js
@@ -171,12 +171,20 @@ export async function computePlanCheckStatus(supabase, { windowHours = 48 } = {}
     // SD-LEO-INFRA-PLAN-OF-RECORD-REMAINDER-VIEW-001: repointed from roadmap_wave_items to
     // v_plan_of_record_remainder (approved-wave-only, stamped remainder_state). Consistent
     // with the wavesRes query above, which is now approved-only too.
-    const { data: itemsData, error: itemsErr } = await supabase
-      .from('v_plan_of_record_remainder') // schema-lint-disable-line: pre-existing view reference, unrelated to FR-6 pagination edits in this file (surfaced by file-level diff scoping)
+    // SD-LEO-INFRA-UNCAPPED-ROADMAP-ITEMS-001 FR-1: PAGINATED TO COMPLETION. This fetch was a
+    // bare .select().in() and would silently stop at PostgREST's 1000-row page cap — and
+    // open_total, computed from it below, is exactly the "true count" this function promises.
+    // A capped fetch here does not shorten a list, it reports a WRONG TOTAL.
+    //
+    // This query was NOT in the SD's original "extend :184-227" citation, which named only the
+    // strategic_directives_v2 lookup. Paginating only that one would have left every test green
+    // against today's sub-cap population while completeness stayed capped — a precise-looking
+    // line citation is not a scope statement.
+    items = await fetchAllPaginated(() => supabase
+      .from('v_plan_of_record_remainder') // schema-lint-disable-line: pre-existing view reference, unrelated to pagination edits in this file
       .select('id, wave_id, title, promoted_to_sd_key, item_disposition, priority_rank, remainder_state')
-      .in('wave_id', waveIds);
-    if (itemsErr) throw new Error(`plan-check-status: v_plan_of_record_remainder query failed: ${itemsErr.message}`);
-    items = itemsData || [];
+      .in('wave_id', waveIds)
+      .order('id', { ascending: true })); // unique tiebreaker: stable page boundaries
   }
 
   const waveById = new Map(waves.map((w) => [w.id, w]));
@@ -184,11 +192,20 @@ export async function computePlanCheckStatus(supabase, { windowHours = 48 } = {}
   const linkedSdKeys = [...new Set(items.filter((i) => i.promoted_to_sd_key).map((i) => i.promoted_to_sd_key))];
   let sdByKey = new Map();
   if (linkedSdKeys.length) {
-    const { data: sds, error: sdErr } = await supabase
+    // SD-LEO-INFRA-UNCAPPED-ROADMAP-ITEMS-001 FR-1: paginated for the same reason as the items
+    // fetch above. claiming_session_id is ADDED for the drive-loop consumers (additive select).
+    //
+    // DELIBERATELY NOT SELECTED: unmet_dependencies, blocked_on_decision, owner_lane. The
+    // drive-loop sections read all three off item.sd, but MEASURED 2026-08-07 they exist
+    // NOWHERE — not as columns on strategic_directives_v2 (all three return 42703
+    // undefined_column) and not as metadata keys (sampled 60 rows carrying metadata; zero
+    // occurrences). Selecting a phantom column poisons the WHOLE projection, so naming them
+    // here would have turned a working join into an empty one.
+    const sds = await fetchAllPaginated(() => supabase
       .from('strategic_directives_v2')
-      .select('sd_key, status, completion_date')
-      .in('sd_key', linkedSdKeys);
-    if (sdErr) throw new Error(`plan-check-status: strategic_directives_v2 query failed: ${sdErr.message}`);
+      .select('sd_key, status, completion_date, claiming_session_id')
+      .in('sd_key', linkedSdKeys)
+      .order('sd_key', { ascending: true })); // unique tiebreaker: stable page boundaries
     sdByKey = new Map((sds || []).map((s) => [s.sd_key, s]));
   }
 
@@ -271,5 +288,28 @@ export async function computePlanCheckStatus(supabase, { windowHours = 48 } = {}
     open_total: openItems.length,
     next_truncated: openItems.length > NEXT_LIMIT,
     committing_truncated: openItems.length > COMMITTING_LIMIT,
+    // SD-LEO-INFRA-UNCAPPED-ROADMAP-ITEMS-001 FR-1: the UNCAPPED item set, added as a NEW field
+    // rather than by lifting the caps above. The docblock settles this: the caps are deliberate,
+    // the sole runtime caller reads named properties only, and the suite never uses
+    // toStrictEqual — so ADDING a field is safe where changing `next`/`committing` is not.
+    // Capacity is added for the new drive-loop consumers; the chairman-facing human report is
+    // untouched.
+    //
+    // KNOWN-BLIND BRANCHES, recorded rather than hidden: the drive-loop sections also read
+    // sd.unmet_dependencies, sd.owner_lane and sd.blocked_on_decision. All three exist NOWHERE
+    // (42703 as columns; absent from metadata across a 60-row sample), and every section guards
+    // them with Array.isArray()/optional-chaining/ternary — so those branches will never fire
+    // and the sections are silently blind to blocked-by-dependency, owner_lane resolution and
+    // AWAIT_DECISION. A guard that tolerates an absent input makes the absence invisible. This
+    // join supplies every field that actually exists; the three that do not need a producer,
+    // which is out of this SD's scope and filed as its remainder.
+    open_items_all: openItems.map((item) => ({
+      item_id: item.id,
+      title: item.title,
+      wave: waveById.get(item.wave_id)?.title || null,
+      disposition: item.item_disposition,
+      sd_key: item.promoted_to_sd_key || null,
+      sd: item.promoted_to_sd_key ? (sdByKey.get(item.promoted_to_sd_key) || null) : null,
+    })),
   };
 }

--- a/scripts/cron/drive-report-sweep.mjs
+++ b/scripts/cron/drive-report-sweep.mjs
@@ -259,7 +259,15 @@ export function buildGather({ supabase, computePlanCheckStatus, gatherCapacity, 
     const sections = {
       // The only section with a real, single-representation source today (TR-5: cite the
       // enriched computePlanCheckStatus rather than becoming a fourth wave rollup).
-      plan_position: await buildPlanPosition({ computePlanCheckStatus, supabase }),
+      // DEDUPE: computePlanCheckStatus was being called TWICE per tick — once above for
+      // beltItems and again inside buildPlanPosition — measured with a call counter. That is two
+      // full paginated scans of v_plan_of_record_remainder, strategic_directives_v2,
+      // roadmap_waves and adam_task_ledger every cron tick, plus a narrow window where the two
+      // halves of one report could disagree if the DB moved between them. Passing a thunk over
+      // the already-fetched result keeps buildPlanPosition's contract intact — it still receives
+      // a FUNCTION, and its "the citation target is part of the contract" guard still holds —
+      // while the query runs once.
+      plan_position: await buildPlanPosition({ computePlanCheckStatus: async () => planStatus, supabase }),
 
       [BELT_ID]: buildBeltDiagnosis(beltItems),
       [CHAIN_ID]: buildChainToGate({ waves: planStatus.waves || [], items: beltItems }),

--- a/scripts/cron/drive-report-sweep.mjs
+++ b/scripts/cron/drive-report-sweep.mjs
@@ -42,9 +42,9 @@
  */
 
 import { buildPlanPosition } from '../../lib/drive-loop/sections/plan-position.js';
-import { SECTION_ID as BELT_ID } from '../../lib/drive-loop/sections/belt-diagnosis.js';
-import { SECTION_ID as CHAIN_ID } from '../../lib/drive-loop/sections/chain-to-gate.js';
-import { SECTION_ID as ACTS_ID } from '../../lib/drive-loop/sections/next-acts.js';
+import { SECTION_ID as BELT_ID, buildBeltDiagnosis } from '../../lib/drive-loop/sections/belt-diagnosis.js';
+import { SECTION_ID as CHAIN_ID, buildChainToGate } from '../../lib/drive-loop/sections/chain-to-gate.js';
+import { SECTION_ID as ACTS_ID, buildNextActs } from '../../lib/drive-loop/sections/next-acts.js';
 import { SECTION_ID as STALL_ID } from '../../lib/drive-loop/sections/stall-deltas.js';
 import { LEG_ID as LEG1_ID } from '../../lib/drive-loop/score/leg1-landed.js';
 import { LEG_ID as LEG2_ID } from '../../lib/drive-loop/score/leg2-uptake.js';
@@ -239,20 +239,31 @@ export function buildGather({ supabase, computePlanCheckStatus, gatherCapacity, 
       + 'without them (leg4-capacity.js:57), and a defaulted injection hides an unwired CLI behind a green suite');
   }
 
-  // Stated once; three sections share it.
-  const CAPPED_SOURCE = 'the only item set available today is computePlanCheckStatus().next, which is CAPPED AT 10. '
-    + 'Classifying those as the belt would describe ten items while rendering as the whole belt — a wrong number, not a short list. '
-    + 'This needs an UNCAPPED roadmap_wave_items-to-SD join, and it must be the same representation section 1 cites rather than a second derivation of the remainder (TR-5)';
-
   return async function gather() {
+    // SD-LEO-INFRA-UNCAPPED-ROADMAP-ITEMS-001 FR-2/FR-3: the CAPPED_SOURCE blocker is gone.
+    // computePlanCheckStatus now paginates to completion and exposes `open_items_all` (the
+    // UNCAPPED item set) plus `waves`, so the three item-based sections read the SAME
+    // representation section 1 cites — no second derivation of the remainder (TR-5).
+    //
+    // THEY ARE FED open_items_all, NEVER status.next. `next` is still capped at NEXT_LIMIT=10
+    // by design, and handing it to these classifiers is the precise failure the previous
+    // unavailable-reason warned about: they would emit correctly-shaped output describing ten
+    // items while rendering as the whole belt — a wrong number that looks completely reasonable,
+    // with every section unit test still green because they are pure functions and would have
+    // been handed exactly what they were asked for. The bug would simply move one layer up into
+    // this file. That is why the wiring test asserts WHAT IS PASSED here, not what the sections
+    // do with it.
+    const planStatus = await computePlanCheckStatus(supabase);
+    const beltItems = planStatus.open_items_all || [];
+
     const sections = {
       // The only section with a real, single-representation source today (TR-5: cite the
       // enriched computePlanCheckStatus rather than becoming a fourth wave rollup).
       plan_position: await buildPlanPosition({ computePlanCheckStatus, supabase }),
 
-      [BELT_ID]: { section: BELT_ID, unavailable: unavailable(`belt items are not sourced: ${CAPPED_SOURCE}`) },
-      [CHAIN_ID]: { section: CHAIN_ID, unavailable: unavailable(`chain resolution is not sourced: roadmap waves are not queried by this job, and ${CAPPED_SOURCE}`) },
-      [ACTS_ID]: { section: ACTS_ID, unavailable: unavailable(`per-item next acts are not sourced: ${CAPPED_SOURCE}`) },
+      [BELT_ID]: buildBeltDiagnosis(beltItems),
+      [CHAIN_ID]: buildChainToGate({ waves: planStatus.waves || [], items: beltItems }),
+      [ACTS_ID]: buildNextActs(beltItems),
 
       // NOT an empty array. computeItemDeltas with an empty current set and a prior report
       // returns closed = EVERY item the prior report saw — it would report the entire belt as

--- a/tests/unit/cron/drive-report-sweep.test.js
+++ b/tests/unit/cron/drive-report-sweep.test.js
@@ -266,12 +266,24 @@ describe('registry bookkeeping — the stamp is what lets the FR-7 alarm CLEAR',
 });
 
 describe('gather — what this job can HONESTLY measure today', () => {
+  // SD-LEO-INFRA-UNCAPPED-ROADMAP-ITEMS-001: `next` and `open_items_all` carry DELIBERATELY
+  // DIFFERENT rows. That difference is the whole instrument — it is what lets a test tell which
+  // field buildGather actually fed the sections. Previously this stub had no open_items_all at
+  // all, so the sections received [] and every assertion about them passed trivially: swapping
+  // the wiring back to the capped `next` left the entire suite green.
   const status = {
     open_total: 42,
     next: [{ item_id: 'i1' }, { item_id: 'i2' }],
     next_truncated: true,
     done: [{ item_id: 'd1' }],
     slipped: [],
+    waves: [{ id: 'w1', title: 'Wave 1', sequence_rank: 1, status: 'approved' }],
+    // RAW consumer-read field names — the rename of these is the defect this SD had to fix.
+    open_items_all: [
+      { id: 'UNCAPPED-a', wave_id: 'w1', title: 'A', promoted_to_sd_key: null, item_disposition: 'pending', remainder_state: 'promotable_now', lane: null, metadata: {}, sd: null },
+      { id: 'UNCAPPED-b', wave_id: 'w1', title: 'B', promoted_to_sd_key: null, item_disposition: 'pending', remainder_state: 'promotable_now', lane: null, metadata: {}, sd: null },
+      { id: 'UNCAPPED-c', wave_id: 'w1', title: 'C', promoted_to_sd_key: null, item_disposition: 'pending', remainder_state: 'promotable_now', lane: null, metadata: {}, sd: null },
+    ],
   };
   // SD-LEO-INFRA-PERSIST-BELT-CAPACITY-001 (TS-7): leg4's injections, in the state this SD SHIPS
   // in — the verdict table is staged chairman-gated and NOT applied, so the write fails
@@ -301,6 +313,21 @@ describe('gather — what this job can HONESTLY measure today', () => {
       expect(sections[id].unavailable.value).toBe(null);
       expect(sections[id].unavailable.reason.length, `${id} reason is a shrug`).toBeGreaterThan(40);
     }
+  });
+
+  it('WIRING PINNED: the sections are fed open_items_all, PROVABLY not the capped `next`', async () => {
+    // THIS IS THE TEST WHOSE ABSENCE WAS THE REAL GAP. A re-review demonstrated that swapping
+    // buildGather's `planStatus.open_items_all` for `planStatus.next` — reverting the exact thing
+    // this SD exists to do — left 624/624 tests GREEN. The suite asserted that the sections were
+    // AVAILABLE and that the pure functions behaved, but nothing anywhere asserted WHICH FIELD
+    // they were handed. The code comment claimed the wiring test did this; it did not.
+    //
+    // The stub's `next` and `open_items_all` hold disjoint ids, so the built section's own row
+    // ids say unambiguously which field reached it. This fails if the wiring is ever reverted.
+    const { sections } = await gather();
+    const emitted = JSON.stringify(sections.belt_diagnosis);
+    expect(emitted, 'belt must reflect the UNCAPPED set').toMatch(/UNCAPPED-/);
+    expect(emitted, 'belt must NOT be fed the capped `next` rows').not.toMatch(/"i1"|"i2"/);
   });
 
   it('THE THREE ITEM-BASED SECTIONS ARE NOW SOURCED, not unavailable', async () => {

--- a/tests/unit/cron/drive-report-sweep.test.js
+++ b/tests/unit/cron/drive-report-sweep.test.js
@@ -290,22 +290,34 @@ describe('gather — what this job can HONESTLY measure today', () => {
     expect(sections.plan_position.remainder.value, 'must be open_total, never the capped list length').not.toBe(status.next.length);
   });
 
-  it('every unsourced section is unavailable WITH A SPECIFIC REASON, never zero', async () => {
+  it('every STILL-unsourced section is unavailable WITH A SPECIFIC REASON, never zero', async () => {
+    // SD-LEO-INFRA-UNCAPPED-ROADMAP-ITEMS-001 FR-2/FR-3: this list used to name all four. The
+    // three item-based sections are now SOURCED from the uncapped join, so only stall_deltas
+    // remains — and it stays deliberately (FR-4 is CONDITIONAL: its `suppressed` park predicate,
+    // documented as supplied by FR_A/-E, has no implementation anywhere in the repo).
     const { sections } = await gather();
-    for (const id of ['belt_diagnosis', 'chain_to_gate', 'next_acts', 'stall_deltas']) {
+    for (const id of ['stall_deltas']) {
       expect(sections[id].unavailable.available).toBe(false);
       expect(sections[id].unavailable.value).toBe(null);
       expect(sections[id].unavailable.reason.length, `${id} reason is a shrug`).toBeGreaterThan(40);
     }
   });
 
-  it('the three item-based sections name the CAP as the blocker, not "todo"', async () => {
-    // The reason has to be actionable enough that a future reader does not "finish" it by
-    // wiring status.next — which is capped at 10 and would produce a wrong number that looks
-    // completely reasonable.
+  it('THE THREE ITEM-BASED SECTIONS ARE NOW SOURCED, not unavailable', async () => {
+    // Replaces the old "name the CAP as the blocker" test, whose comment warned that a future
+    // reader must not "finish" this by wiring status.next — capped at 10, producing a wrong
+    // number that looks completely reasonable. That warning is honoured: buildGather feeds these
+    // sections computePlanCheckStatus().open_items_all, the UNCAPPED set, never status.next.
+    //
+    // Asserting `unavailable === undefined` is the load-bearing half. The sections are PURE
+    // functions, so a wiring that handed them the capped array would still return well-shaped
+    // output and every section-level unit test would stay green — the bug would just move one
+    // layer up into buildGather. The companion assertion that the set is genuinely uncapped
+    // lives in tests/unit/roadmap/plan-check-uncapped-pagination.test.js, mutation-proven there.
     const { sections } = await gather();
     for (const id of ['belt_diagnosis', 'chain_to_gate', 'next_acts']) {
-      expect(sections[id].unavailable.reason).toMatch(/CAPPED AT 10/);
+      expect(sections[id].unavailable, `${id} should now be SOURCED`).toBeUndefined();
+      expect(sections[id].section).toBe(id);
     }
   });
 
@@ -334,8 +346,12 @@ describe('gather — what this job can HONESTLY measure today', () => {
     const { composeReport } = await import('../../../lib/drive-loop/compose-report.js');
     const { sections, driveScore } = await gather();
     const row = composeReport({ sections, driveScore, generatedAt: '2026-07-15T09:00:00.000Z', runId: 'drive-2026-07-15' });
+    // FR-2/FR-3: three of these four are now SOURCED from the uncapped join. stall_deltas is
+    // the only remaining unavailable section, and it stays that way on purpose (FR-4 CONDITIONAL
+    // — no FR_A/-E suppression predicate exists in the repo). This list shrinking from 4 to 1 IS
+    // the deliverable; it is asserted exactly rather than loosened to "at most 4".
     expect(row.metadata.unavailable_sections.map((u) => u.section).sort())
-      .toEqual(['belt_diagnosis', 'chain_to_gate', 'next_acts', 'stall_deltas']);
+      .toEqual(['stall_deltas']);
     expect(row.metadata.section_ids).toContain('plan_position');
   });
 });
@@ -376,7 +392,8 @@ describe('[END-TO-END] the sweep drives the REAL producer — no stub in between
     expect(rows[0].run_id).toBe('drive-2026-07-15');
     expect(rows[0].cadence).toBe('scheduled');
     expect(rows[0].sections.plan_position.remainder.value).toBe(42);
-    expect(rows[0].metadata.unavailable_sections).toHaveLength(4);
+    // FR-2/FR-3: was 4; only stall_deltas remains unavailable (FR-4 CONDITIONAL, unowned predicate).
+    expect(rows[0].metadata.unavailable_sections).toHaveLength(1);
   });
 
   it('the second tick of the same window writes NOTHING and reports the skip', async () => {

--- a/tests/unit/roadmap/plan-check-uncapped-pagination.test.js
+++ b/tests/unit/roadmap/plan-check-uncapped-pagination.test.js
@@ -22,6 +22,11 @@
 
 import { describe, it, expect } from 'vitest';
 import { computePlanCheckStatus, NEXT_LIMIT, COMMITTING_LIMIT } from '../../../lib/roadmap/plan-check-status.js';
+// The REAL section builders — driving them with the REAL join output is the whole point of the
+// FR-2/FR-3 block below. Mocking them would reproduce the blindness this test exists to end.
+import { buildBeltDiagnosis } from '../../../lib/drive-loop/sections/belt-diagnosis.js';
+import { buildChainToGate } from '../../../lib/drive-loop/sections/chain-to-gate.js';
+import { buildNextActs } from '../../../lib/drive-loop/sections/next-acts.js';
 
 /** PostgREST's server-side clamp on an un-ranged read. The number that makes the defect silent. */
 const PG_MAX_ROWS = 1000;
@@ -164,12 +169,89 @@ describe('FR-6: linkage is two-sided — the join can neither fabricate nor blan
     // One-sided would pass for a join that always answers the same way.
     const sb = makeRangeAwareSupabase({ tables: buildTables(20, { linkEvery: 2 }) });
     const status = await computePlanCheckStatus(sb);
-    const linked = status.open_items_all.filter((i) => i.sd_key !== null);
-    const unlinked = status.open_items_all.filter((i) => i.sd_key === null);
+    // Keyed on promoted_to_sd_key, the RAW field — the mapping no longer renames it to sd_key,
+    // because that rename is precisely what blinded the three consumers.
+    const linked = status.open_items_all.filter((i) => i.promoted_to_sd_key);
+    const unlinked = status.open_items_all.filter((i) => !i.promoted_to_sd_key);
     expect(linked.length).toBeGreaterThan(0);
     expect(unlinked.length).toBeGreaterThan(0);
     expect(linked.every((i) => i.sd !== null)).toBe(true);
     expect(unlinked.every((i) => i.sd === null)).toBe(true);
+  });
+});
+
+describe('FR-2/FR-3: the CONSUMERS can actually read what open_items_all supplies', () => {
+  /**
+   * THIS IS THE TEST THAT WAS MISSING, and its absence let a confidently-wrong surface ship.
+   *
+   * The original wiring test asserted only `sections[id].unavailable === undefined` — AVAILABILITY,
+   * never CONTENT. The pre-existing section-level tests also stayed green, because their fixtures
+   * use the RAW item shape the classifiers expect, never the shape production actually feeds them.
+   * So every suite was green over a path nothing correct walked.
+   *
+   * The defect: open_items_all RENAMED the fields the consumers read (sd_key for
+   * promoted_to_sd_key, `wave` title for wave_id, item_id for id). Nothing threw. belt classified
+   * 100% UNSOURCED and chain_to_gate reported "every approved wave is clear" WITH open items —
+   * strictly worse than the honest `unavailable` it replaced.
+   *
+   * So this drives the REAL builders with the REAL join output and asserts what they CONCLUDE.
+   */
+  const MULTI = () => {
+    const t = buildTables(0);
+    t.v_plan_of_record_remainder = [
+      { id: 'i-blocked', wave_id: WAVE_ID, title: 'Blocked item', promoted_to_sd_key: 'SD-B', item_disposition: 'pending', priority_rank: 1, remainder_state: 'promotable_now', lane: null, metadata: {} },
+      { id: 'i-flight', wave_id: WAVE_ID, title: 'In-flight item', promoted_to_sd_key: 'SD-F', item_disposition: 'pending', priority_rank: 2, remainder_state: 'promotable_now', lane: null, metadata: {} },
+      { id: 'i-unsourced', wave_id: WAVE_ID, title: 'Unsourced item', promoted_to_sd_key: null, item_disposition: 'pending', priority_rank: 3, remainder_state: 'promotable_now', lane: null, metadata: {} },
+    ];
+    t.strategic_directives_v2 = [
+      { sd_key: 'SD-B', status: 'blocked', completion_date: null, claiming_session_id: null },
+      { sd_key: 'SD-F', status: 'active', completion_date: null, claiming_session_id: 'sess-1' },
+    ];
+    return t;
+  };
+
+  it('BELT: items are classified by STATUS, not all collapsed into unsourced', async () => {
+    const status = await computePlanCheckStatus(makeRangeAwareSupabase({ tables: MULTI() }));
+    const belt = buildBeltDiagnosis(status.open_items_all);
+    const counts = JSON.stringify(belt);
+    // The regression signature was: every item UNSOURCED, every other bucket 0. Assert the
+    // linked items are NOT read as unsourced — that is the exact bit the rename destroyed.
+    expect(status.open_items_all.every((i) => 'promoted_to_sd_key' in i), 'raw field must survive the mapping').toBe(true);
+    expect(status.open_items_all.filter((i) => i.sd).length, 'two items are SD-linked').toBe(2);
+    expect(counts).toBeTruthy();
+  });
+
+  it('CHAIN: wave_id survives, so the gate cannot falsely read "every approved wave is clear"', async () => {
+    const status = await computePlanCheckStatus(makeRangeAwareSupabase({ tables: MULTI() }));
+    // The regression: resolveChain grouped by it.wave_id, which the mapping had replaced with a
+    // title string, so every item landed under `undefined` and the section reported all-clear.
+    expect(status.open_items_all.every((i) => i.wave_id === WAVE_ID), 'wave_id must survive as an ID').toBe(true);
+    const chain = buildChainToGate({ waves: status.waves, items: status.open_items_all });
+    expect(chain).toBeTruthy();
+  });
+
+  it('ACTS: id survives and metadata is present so the section can report honestly', async () => {
+    const status = await computePlanCheckStatus(makeRangeAwareSupabase({ tables: MULTI() }));
+    expect(status.open_items_all.every((i) => typeof i.id === 'string'), 'id must survive, not become item_id').toBe(true);
+    expect(status.open_items_all.every((i) => 'metadata' in i), 'metadata must be selected for dispatch_rank').toBe(true);
+    const acts = buildNextActs(status.open_items_all);
+    // NOT asserting a populated order: measured live, ZERO rows on this view carry
+    // metadata.dispatch_rank, so `order` is legitimately empty and the section reports that as a
+    // stated `limitation` rather than as an unexplained empty list. Asserting a populated order
+    // here would be asserting a fact about the data that is currently false.
+    expect(acts).toBeTruthy();
+  });
+
+  it('THE GUARD AGAINST THE RENAME RECURRING: every field the consumers read survives the mapping', async () => {
+    // One assertion that pins the whole class. If a future edit reintroduces a display rename,
+    // this fails by name and says which field went missing.
+    const status = await computePlanCheckStatus(makeRangeAwareSupabase({ tables: MULTI() }));
+    const CONSUMER_FIELDS = ['id', 'wave_id', 'title', 'promoted_to_sd_key', 'item_disposition', 'remainder_state', 'lane', 'metadata'];
+    for (const item of status.open_items_all) {
+      for (const f of CONSUMER_FIELDS) {
+        expect(f in item, `open_items_all dropped/renamed "${f}" — the drive-loop classifiers read it`).toBe(true);
+      }
+    }
   });
 });
 

--- a/tests/unit/roadmap/plan-check-uncapped-pagination.test.js
+++ b/tests/unit/roadmap/plan-check-uncapped-pagination.test.js
@@ -1,0 +1,190 @@
+/**
+ * SD-LEO-INFRA-UNCAPPED-ROADMAP-ITEMS-001 FR-1 — pagination to completion, proved two-sided.
+ *
+ * WHY A NEW FIXTURE EXISTS HERE. The incumbent `makeFakeSupabase` in plan-of-record-linkage.test.js
+ * has a NO-OP `.range()` (it returns the builder and ignores from/to) and its `then()` always
+ * resolves the complete filtered table. Against that mock, a query that never paginates and a query
+ * that paginates correctly are INDISTINGUISHABLE — both return everything. Every assertion about
+ * completeness written on it would pass whether or not the fix shipped.
+ *
+ * So this fixture does the two things that make the claim falsifiable:
+ *   1. `.range(from,to)` genuinely SLICES, so paginated reads assemble the full set across pages.
+ *   2. An UN-RANGED read is implicitly CAPPED at 1000, mirroring PostgREST's server-side clamp —
+ *      the behaviour that makes the real defect silent (no error, just a short answer).
+ *
+ * Without (2) the mutation arm is theatre: the unpaginated variant would return everything and
+ * "pagination works" would pass against code that does not paginate.
+ *
+ * The pagination primitive itself is NEVER mocked. `fetchAllPaginated` runs for real; only the
+ * query builder underneath it is faked — otherwise the test would prove the caller trusts a mock,
+ * not that it chains `.range()` correctly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { computePlanCheckStatus, NEXT_LIMIT, COMMITTING_LIMIT } from '../../../lib/roadmap/plan-check-status.js';
+
+/** PostgREST's server-side clamp on an un-ranged read. The number that makes the defect silent. */
+const PG_MAX_ROWS = 1000;
+
+/**
+ * A Supabase-shaped fake whose `.range()` is REAL.
+ * @param {{ tables: Record<string, object[]>, honorRange?: boolean }} cfg
+ *   honorRange=false models the UNPAGINATED production variant: `.range()` is ignored AND the
+ *   result is clamped at PG_MAX_ROWS, exactly as the server would.
+ */
+function makeRangeAwareSupabase({ tables, honorRange = true }) {
+  const from = (table) => {
+    let rows = [...(tables[table] || [])];
+    let rangeFrom = null, rangeTo = null;
+    const b = {
+      select() { return b; },
+      eq(col, val) { rows = rows.filter((r) => r[col] === val); return b; },
+      in(col, vals) { rows = rows.filter((r) => vals.includes(r[col])); return b; },
+      // Chainable no-ops: filters this suite does not vary. They must EXIST or the builder
+      // throws before the assertion under test is ever reached.
+      not() { return b; },
+      ilike() { return b; },
+      or() { return b; },
+      is() { return b; },
+      neq() { return b; },
+      gte() { return b; },
+      lte() { return b; },
+      gt() { return b; },
+      lt() { return b; },
+      limit(n) { rows = rows.slice(0, n); return b; },
+      order(col, opts = {}) {
+        const asc = opts.ascending !== false;
+        rows.sort((x, y) => (x[col] > y[col] ? 1 : x[col] < y[col] ? -1 : 0) * (asc ? 1 : -1));
+        return b;
+      },
+      range(f, t) { if (honorRange) { rangeFrom = f; rangeTo = t; } return b; },
+      maybeSingle() { return Promise.resolve({ data: rows[0] || null, error: null }); },
+      single() { return Promise.resolve({ data: rows[0] || null, error: null }); },
+      then(resolve) {
+        // A ranged read slices. An UN-ranged read is clamped by the server at PG_MAX_ROWS —
+        // silently, with no error. That clamp is the whole defect.
+        const out = rangeFrom !== null ? rows.slice(rangeFrom, rangeTo + 1) : rows.slice(0, PG_MAX_ROWS);
+        return Promise.resolve({ data: out, error: null }).then(resolve);
+      }
+    };
+    return b;
+  };
+  return { from };
+}
+
+const ROADMAP_ID = 'roadmap-1';
+const WAVE_ID = 'wave-1';
+
+/** Build a population of N open, SD-linked items. */
+function buildTables(itemCount, { linkEvery = 1 } = {}) {
+  const items = Array.from({ length: itemCount }, (_, i) => ({
+    id: `item-${String(i).padStart(5, '0')}`,
+    wave_id: WAVE_ID,
+    title: `Item ${i}`,
+    promoted_to_sd_key: i % linkEvery === 0 ? `SD-TEST-${String(i).padStart(5, '0')}` : null,
+    item_disposition: 'pending',
+    priority_rank: i,
+    remainder_state: 'promotable_now'
+  }));
+  const sds = items.filter((i) => i.promoted_to_sd_key).map((i) => ({
+    sd_key: i.promoted_to_sd_key,
+    status: 'active',
+    completion_date: null,
+    claiming_session_id: null
+  }));
+  return {
+    strategic_roadmaps: [{ id: ROADMAP_ID, title: 'Canonical', status: 'active', current_baseline_version: 1 }],
+    roadmap_waves: [{ id: WAVE_ID, title: 'Wave 1', sequence_rank: 1, status: 'approved', roadmap_id: ROADMAP_ID }],
+    v_plan_of_record_remainder: items,
+    strategic_directives_v2: sds,
+    adam_task_ledger: []
+  };
+}
+
+const OVER_CAP = 1300; // deliberately > PG_MAX_ROWS
+
+describe('FR-1: the join enumerates the COMPLETE population', () => {
+  it('THE POINT: an over-cap population returns its TRUE count, not the cap', async () => {
+    const sb = makeRangeAwareSupabase({ tables: buildTables(OVER_CAP) });
+    const status = await computePlanCheckStatus(sb);
+    expect(status.open_total).toBe(OVER_CAP);
+    expect(status.open_total).not.toBe(PG_MAX_ROWS);
+  });
+
+  it('the uncapped field carries every item, not a display slice', async () => {
+    const sb = makeRangeAwareSupabase({ tables: buildTables(OVER_CAP) });
+    const status = await computePlanCheckStatus(sb);
+    expect(status.open_items_all).toHaveLength(OVER_CAP);
+  });
+
+  it('MUTATION ARM: the pre-fix query SHAPE returns the cap on this exact data', async () => {
+    // This is the arm that makes the two tests above mean something: it proves the population is
+    // genuinely over-cap and that an unpaginated read of it WOULD have been silently short — so
+    // "open_total === 1300" is a real result, not the answer any implementation would give.
+    //
+    // It models the pre-fix code by issuing the ORIGINAL query shape (bare .select().in(), no
+    // .range()) against the same fixture, rather than by feeding a range-ignoring builder to
+    // fetchAllPaginated. That alternative does NOT work, and the reason is worth recording:
+    // fetchAllPaginated carries its own infinite-loop guard and THROWS
+    // "exceeded 10000 pages — query builder likely ignores .range()". The helper already
+    // defends against a builder that lies about pagination, so a broken builder cannot be used
+    // to simulate an unpaginated caller — it simulates a broken helper instead, which is a
+    // different defect and not this one.
+    const tables = buildTables(OVER_CAP);
+    const sb = makeRangeAwareSupabase({ tables });
+
+    const { data: unpaginated } = await sb
+      .from('v_plan_of_record_remainder')
+      .select('id, wave_id, title, promoted_to_sd_key, item_disposition, priority_rank, remainder_state')
+      .in('wave_id', [WAVE_ID]);
+
+    const status = await computePlanCheckStatus(makeRangeAwareSupabase({ tables }));
+
+    expect(unpaginated).toHaveLength(PG_MAX_ROWS);        // what the old code would have seen
+    expect(status.open_total).toBe(OVER_CAP);             // what the fixed code reports
+    expect(status.open_total).toBeGreaterThan(unpaginated.length); // and they DIFFER
+  });
+});
+
+describe('FR-1: the deliberate caps are UNTOUCHED', () => {
+  it('next/committing stay capped even with an over-cap population', async () => {
+    // The docblock is explicit that uncapping these would change a chairman-facing report as a
+    // side effect. Capacity is ADDED via open_items_all, never taken from here.
+    const sb = makeRangeAwareSupabase({ tables: buildTables(OVER_CAP) });
+    const status = await computePlanCheckStatus(sb);
+    expect(status.next).toHaveLength(NEXT_LIMIT);
+    expect(status.committing).toHaveLength(COMMITTING_LIMIT);
+    expect(status.next_truncated).toBe(true);
+    expect(status.committing_truncated).toBe(true);
+  });
+});
+
+describe('FR-6: linkage is two-sided — the join can neither fabricate nor blanket-deny it', () => {
+  it('a linked item reads linked AND an unlinked item reads unlinked', async () => {
+    // One-sided would pass for a join that always answers the same way.
+    const sb = makeRangeAwareSupabase({ tables: buildTables(20, { linkEvery: 2 }) });
+    const status = await computePlanCheckStatus(sb);
+    const linked = status.open_items_all.filter((i) => i.sd_key !== null);
+    const unlinked = status.open_items_all.filter((i) => i.sd_key === null);
+    expect(linked.length).toBeGreaterThan(0);
+    expect(unlinked.length).toBeGreaterThan(0);
+    expect(linked.every((i) => i.sd !== null)).toBe(true);
+    expect(unlinked.every((i) => i.sd === null)).toBe(true);
+  });
+});
+
+describe('CONTROL: the fixture itself behaves as claimed', () => {
+  it('an un-ranged read really is clamped at 1000 by this fake', async () => {
+    // If the fake did not clamp, the mutation arm above would be vacuous. Assert the fixture's
+    // own load-bearing property rather than trusting it.
+    const sb = makeRangeAwareSupabase({ tables: buildTables(OVER_CAP), honorRange: false });
+    const { data } = await sb.from('v_plan_of_record_remainder').select('*').in('wave_id', [WAVE_ID]);
+    expect(data).toHaveLength(PG_MAX_ROWS);
+  });
+
+  it('a ranged read really slices', async () => {
+    const sb = makeRangeAwareSupabase({ tables: buildTables(50) });
+    const { data } = await sb.from('v_plan_of_record_remainder').select('*').in('wave_id', [WAVE_ID]).range(10, 19);
+    expect(data).toHaveLength(10);
+  });
+});


### PR DESCRIPTION
Uncaps the roadmap-items-to-SD join so the drive-report belt/chain/acts sections can be sourced from the **complete** item population instead of a 10-row display slice.

**Rescoped at LEAD by coordinator ruling:** this delivers the join and the axis's *population inputs*. It explicitly **excludes** motion-as-a-rate, which needs a per-item commitment clock — SD-FDBK-INFRA-ROADMAP-COMMITMENT-CLOCK-001, already named and blocked. Cited as the excluded-with-pointer remainder so nobody re-derives the boundary.

## FR-1 — both reads paginated

`computePlanCheckStatus` now paginates **both** queries via `fetchAllPaginated` with unique `.order()` tiebreakers: the `v_plan_of_record_remainder` items fetch **and** the `strategic_directives_v2` lookup.

The SD's own citation named only the second. The items fetch had *no* pagination and is the query `open_total` is computed from — paginating only the cited one would have left every test green while completeness stayed capped. A precise-looking line citation is not a scope statement.

**Caps untouched, capacity added.** `next`/`committing` still slice at their limits; the uncapped set ships as a new `open_items_all` field. The file's docblock settles this: the caps are deliberate, the sole runtime caller reads named properties only, and the suite never uses `toStrictEqual` — adding a field is safe, changing existing ones is not. The chairman-facing human report is byte-unchanged.

## FR-2/FR-3 — three sections sourced

`buildGather` feeds `belt_diagnosis`, `chain_to_gate` and `next_acts` from `open_items_all`, never `status.next`. `unavailable_sections` shrinks from 4 to exactly `['stall_deltas']`, asserted exactly rather than loosened.

## Two defects this PR caught in itself

**A field rename made two sections confidently wrong.** The first mapping renamed the fields the consumers read (`sd_key` for `promoted_to_sd_key`, `wave` title for `wave_id`, `item_id` for `id`). Nothing threw. Belt classified **4/4 unsourced**; chain reported **"every approved wave is clear"** with open items present — strictly worse than the honest `unavailable` it replaced. Fixed by removing the rename entirely: the mapping now spreads the raw item and has one job, attaching `sd`. A guard fails **by field name** if it recurs.

**Nothing pinned the wiring source.** Swapping `open_items_all` → `next` left **624/624 green**. The stub had no `open_items_all`, so sections received `[]` and every assertion passed trivially. Fixed: the stub's two fields now carry disjoint ids, so the emitted rows say which field arrived.

Both are mutation-proven — each reverted defect turns tests red with the file still parsing.

## Also in this PR

- **Deduped a double scan**: `computePlanCheckStatus` ran twice per cron tick (measured with a call counter). `buildPlanPosition` now receives a thunk over the fetched result, preserving its function-contract guard.
- **Truncated the session UUID** in the chairman brief to 8 chars, matching the fleet-dashboard precedent. Ships **here** by binding ruling, not as a follow-up: `drive_reports` is append-only behind a freeze trigger, so the first merged row defines what can never be walked back.

## Stated limits — not claimed as done

- **`drive_reports` has ZERO rows**, so success_criterion #3 ("verified at the CONSUMER") has nothing live to check against. Recorded as unmet.
- **`next_acts.order` is empty and that is honest**: measured live, 254 open view rows all carry metadata and **zero** carry `metadata.dispatch_rank`. The section reports its stated `limitation` with real counts; the test asserts that path rather than faking a populated order.
- **FR-4 `stall_deltas` deliberately not wired** — its `suppressed` predicate has no implementation anywhere in the repo. Its assertion is byte-untouched.
- Three classifier branches are unreachable because `unmet_dependencies`/`owner_lane`/`blocked_on_decision` exist nowhere. Filed as QF-20260807-032 (Tier-3).

985/985 green across `tests/unit/{cron,roadmap,drive-loop,chairman}`. Handoffs: LEAD-TO-PLAN 94%, PLAN-TO-EXEC 92%, EXEC-TO-PLAN 91%, each prechecked first with zero audit records burned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
