### PR TITLE
SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001: gate on whether a produced output has a READER

### DIFF
--- a/lib/gates/operator-contract/__tests__/citation-path-spoofing.test.js
+++ b/lib/gates/operator-contract/__tests__/citation-path-spoofing.test.js
@@ -1,0 +1,76 @@
+/**
+ * SEC-3 / SEC-4 — SECURITY row 778f9a78.
+ * SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001
+ *
+ * The producer refusal is this gate's CENTRAL claim: producer-side proof that the write
+ * happened is exactly what it exists to reject. It was an exact string compare, so
+ * `lib/producer.js:9` blocked while SIX equivalent spellings of the same file passed — measured
+ * at gate level under ENFORCE=1 as passed:true "consumer citation verified". A refusal that can
+ * be spelled around is the "check a caller can satisfy without changing the harm" shape this SD
+ * exists to abolish; shipping it inside this SD would have been self-refuting.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { validateConsumer } from '../index.js';
+import { createOperatorContractGate } from '../harness-adapter.js';
+
+const PRODUCER = 'lib/producer.js';
+const files = [{ path: PRODUCER, added: "await supabase.from('t').insert(row)" }];
+const check = (consumer) => validateConsumer({
+  changedFiles: files, createdTables: ['t'], producerFiles: [PRODUCER], allowOutOfDiffConsumer: true,
+  consumerEvidence: [{ consumer, observed_read: 'claims to read t', artifact: 'query_result' }],
+});
+
+describe('SEC-3 — every spelling of the producer is refused', () => {
+  it.each([
+    ['exact (already blocked)', 'lib/producer.js:9'],
+    ['dot-slash prefix', './lib/producer.js:9'],
+    ['interior dot segment', 'lib/./producer.js:9'],
+    ['doubled separator', 'lib//producer.js:9'],
+    ['upper case (same file on Windows)', 'LIB/PRODUCER.JS:9'],
+    ['backslash separator', 'lib\\producer.js:9'],
+    ['parent traversal', 'lib/x/../producer.js:9'],
+  ])('%s is rejected as PRODUCER-side', (_label, consumer) => {
+    const res = check(consumer);
+    expect(res.consumer_present).toBe(false);
+    expect(res.issues.join(' ')).toMatch(/PRODUCER/i);
+  });
+
+  it('a genuinely different file is still ACCEPTED — the guard is two-sided, not just strict', () => {
+    // Without this, "reject everything" would pass the suite above and break the gate.
+    const res = check('lib/consumer.js:12');
+    expect(res.consumer_present).toBe(true);
+  });
+
+  it('a file whose name merely CONTAINS the producer name is not refused', () => {
+    expect(check('lib/producer-helper.js:3').consumer_present).toBe(true);
+  });
+
+  it('test-file refusal also survives the same spellings', () => {
+    for (const c of ['./tests/unit/x.js:4', 'tests\\unit\\x.js:4', 'lib/../tests/unit/x.js:4']) {
+      expect(check(c).issues.join(' '), c).toMatch(/test file/i);
+    }
+  });
+});
+
+describe('SEC-4 — enforcement fails CLOSED; warn-first still fails open', () => {
+  const supabase = { from: () => ({ select: async () => ({ data: [], error: null }) }) };
+  const sd = { sd_key: 'SD-TEST-001', metadata: {} };
+  const brokenRepo = 'C:/definitely/not/a/repo/xyz';
+  afterEach(() => { delete process.env.ENFORCE_CONSUMER_CITATION; });
+
+  it('WARN-FIRST: a git error passes with a warning — never false-block the shared pipeline', async () => {
+    const res = await createOperatorContractGate(supabase, sd, brokenRepo).validator({ sd });
+    expect(res.passed).toBe(true);
+    expect(res.details.fail_open).toBe(true);
+  });
+
+  it('ENFORCED: the same error BLOCKS — a missing ref must not erase an enforced block', async () => {
+    // No malice needed: `git diff origin/main...HEAD` throws whenever the ref is absent, so a
+    // shallow clone, a --branch clone, or an unfetched worktree used to convert a block to a pass.
+    process.env.ENFORCE_CONSUMER_CITATION = '1';
+    const res = await createOperatorContractGate(supabase, sd, brokenRepo).validator({ sd });
+    expect(res.passed).toBe(false);
+    expect(res.issues).toContain('OPERATOR_CONTRACT_UNEVALUABLE');
+    expect(res.details.fail_open).toBe(false);
+  });
+});

--- a/lib/gates/operator-contract/__tests__/consumer-citation.test.js
+++ b/lib/gates/operator-contract/__tests__/consumer-citation.test.js
@@ -1,0 +1,171 @@
+/**
+ * SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001 — verify AT THE CONSUMER.
+ *
+ * Eleven founding instances in one day of producer-verified / consumer-broken. The strongest
+ * (corpus #7) survived a RATIFIED completion: a Trend-Eyes alarm whose receipt is written daily
+ * and read by nothing. INVOCATION_PATH_PROOF passed it because that gate asks whether the SWEEP
+ * RAN, never whether the sweep's OUTPUT HAS A READER. Producer invoked, consumer absent.
+ *
+ * These tests were authored RED, before the production edit, and each must-FAIL fixture was
+ * confirmed failing against the shipped predicate first — writing the PASS case first is how a
+ * one-sided proof gets written.
+ */
+import { describe, it, expect } from 'vitest';
+import { validateConsumer } from '../index.js';
+
+/** Producer writes to `feedback`; consumer reads it. Shared by both sides of the two-sided pair. */
+const PRODUCER_FILE = { path: 'lib/producer.js', added: "await supabase.from('feedback').insert({ kind: 'harness_backlog' })" };
+const CONSUMER_FILE = { path: 'lib/consumer.js', added: "const { data } = await supabase.from('feedback').select('id, kind')" };
+const WIRING_DIFF = [PRODUCER_FILE, CONSUMER_FILE];
+
+const CITATION = [{ consumer: 'lib/consumer.js:31', observed_read: "select on feedback where kind='harness_backlog' returned 14 rows", artifact: 'query_result' }];
+
+describe('hole A — an unrelated read must not satisfy the consumer check', () => {
+  // MEASURED on the shipped code: this returned consumer_present:true with the evidence string
+  // "contains a read-path acting on created output" — a FALSE CLAIM baked into the artifact,
+  // worse than a bare boolean because a reviewer reads that line and believes it.
+  it('a read-shaped call in an unrelated file does NOT prove consumption', () => {
+    const res = validateConsumer({
+      changedFiles: [{ path: 'scripts/totally-unrelated.js', added: "const { data } = await supabase.from('audit_log').select('id')" }],
+      createdTables: [],
+      consumerEvidence: CITATION,
+    });
+    expect(res.consumer_present).toBe(false);
+  });
+
+  it('a bare readX() call does NOT prove consumption', () => {
+    const res = validateConsumer({
+      changedFiles: [{ path: 'scripts/x.js', added: 'readConfig();' }],
+      createdTables: [],
+      consumerEvidence: CITATION,
+    });
+    expect(res.consumer_present).toBe(false);
+  });
+
+  it('no evidence string ever asserts "acting on created output" when nothing ties it to the output', () => {
+    const res = validateConsumer({
+      changedFiles: [{ path: 'scripts/x.js', added: "await supabase.from('other').select('id')" }],
+      createdTables: [],
+      consumerEvidence: CITATION,
+    });
+    expect(res.evidence.join(' ')).not.toMatch(/acting on created output/);
+  });
+});
+
+describe('FR-3 two-sided — same diff, evidence is the only difference', () => {
+  it('PASSES with a consumer citation naming the site and the observed read', () => {
+    const res = validateConsumer({ changedFiles: WIRING_DIFF, createdTables: ['feedback'], consumerEvidence: CITATION });
+    expect(res.consumer_present).toBe(true);
+    // TS-1: details must record WHICH citation satisfied it, not merely that one did.
+    expect(res.evidence.join(' ')).toContain('lib/consumer.js:31');
+  });
+
+  it('FAILS on producer-only evidence — evidence-shaped, but every noun is on the writing side', () => {
+    const res = validateConsumer({
+      changedFiles: WIRING_DIFF,
+      createdTables: ['feedback'],
+      consumerEvidence: [{ consumer: 'lib/producer.js:82', observed_read: 'insert returned no error; emitted 14 rows', artifact: 'emission_log' }],
+      producerFiles: ['lib/producer.js'],
+    });
+    expect(res.consumer_present).toBe(false);
+    expect(res.issues.join(' ')).toMatch(/producer/i);
+  });
+
+  it('FAILS on a citation with no file:line — a bare filename is not a citation', () => {
+    const res = validateConsumer({
+      changedFiles: WIRING_DIFF, createdTables: ['feedback'],
+      consumerEvidence: [{ consumer: 'lib/consumer.js', observed_read: 'read the rows', artifact: 'query_result' }],
+    });
+    expect(res.consumer_present).toBe(false);
+  });
+
+  it('FAILS on a file:line with no observed read — a location is not an observation', () => {
+    const res = validateConsumer({
+      changedFiles: WIRING_DIFF, createdTables: ['feedback'],
+      consumerEvidence: [{ consumer: 'lib/consumer.js:31' }],
+    });
+    expect(res.consumer_present).toBe(false);
+  });
+
+  it('FAILS on a boolean-only attestation — a boolean is a convention with extra steps', () => {
+    const res = validateConsumer({ changedFiles: WIRING_DIFF, createdTables: ['feedback'], consumerEvidence: { consumer_verified: true } });
+    expect(res.consumer_present).toBe(false);
+  });
+});
+
+describe('TS-9 emptiness sweep — a presence check cannot be reused as an evidence check', () => {
+  // real-callee-attestation.js accepts the literal "none" BY DESIGN (presence, never content).
+  // That gate is working to contract; this one is a CONTENT check and must reject all of these.
+  // NOTE `undefined` is deliberately NOT in this list, and the distinction is load-bearing:
+  // 'none' is a caller ASSERTING there is no consumer — a content claim, and it must fail.
+  // `undefined` is a caller not participating in the citation contract at all (legacy path).
+  // Collapsing the two would either break every existing caller or silently accept an
+  // assertion of absence. The legacy path is covered separately below, and must be LOUD.
+  const EMPTY_VALUES = ['none', 'None', 'NONE', ' none ', 'n/a', 'TBD', 'see above', 'verified', '', '   ', null, true, 1, {}, [], ['none']];
+  for (const v of EMPTY_VALUES) {
+    it(`rejects ${JSON.stringify(v)} as consumer evidence`, () => {
+      const res = validateConsumer({ changedFiles: WIRING_DIFF, createdTables: ['feedback'], consumerEvidence: v });
+      expect(res.consumer_present).toBe(false);
+    });
+  }
+
+  it('rejects an EMPTY array — "the field exists" is the check that let none through next door', () => {
+    expect(validateConsumer({ changedFiles: WIRING_DIFF, createdTables: ['feedback'], consumerEvidence: [] }).consumer_present).toBe(false);
+  });
+});
+
+describe('legacy path — absent evidence is permitted but never SILENT', () => {
+  it('omitting consumerEvidence keeps the pre-existing diff-only contract', () => {
+    const res = validateConsumer({ changedFiles: WIRING_DIFF, createdTables: ['feedback'] });
+    expect(res.consumer_present).toBe(true);
+    expect(res.citation_supplied).toBe(false);
+  });
+
+  it('the absence is REPORTED, so a legacy pass is distinguishable from a cited one', () => {
+    // Without this, "no citation supplied" and "citation verified" look identical to a reader —
+    // which is the silent-fallback class this whole SD exists to remove.
+    const legacy = validateConsumer({ changedFiles: WIRING_DIFF, createdTables: ['feedback'] });
+    const cited = validateConsumer({ changedFiles: WIRING_DIFF, createdTables: ['feedback'], consumerEvidence: CITATION });
+    expect(legacy.citation_supplied).toBe(false);
+    expect(cited.citation_supplied).toBe(true);
+    expect(cited.accepted_citations).toEqual(['lib/consumer.js:31']);
+  });
+
+  it('hole A is closed even on the legacy path — no created output means no consumption claim', () => {
+    const res = validateConsumer({ changedFiles: [{ path: 'scripts/x.js', added: 'readConfig();' }], createdTables: [] });
+    expect(res.consumer_present).toBe(false);
+    expect(res.issues.join(' ')).toMatch(/hole A/);
+  });
+});
+
+describe('totality — a partial classifier fails OPEN through the adapter catch', () => {
+  // harness-adapter.js:190-198 turns any throw into passed:true, so a throw here is a SILENT PASS.
+  it('never throws on hostile input', () => {
+    const hostile = [null, undefined, 42, 'str', { consumer: 42 }, [{ consumer: null, observed_read: {} }], [[]], [{ toString() { throw new Error('boom'); } }]];
+    for (const h of hostile) {
+      expect(() => validateConsumer({ changedFiles: WIRING_DIFF, createdTables: ['feedback'], consumerEvidence: h })).not.toThrow();
+    }
+  });
+
+  it('never throws on malformed changedFiles', () => {
+    for (const cf of [null, undefined, 'nope', [null], [{ path: null, added: 42 }]]) {
+      expect(() => validateConsumer({ changedFiles: cf, createdTables: ['feedback'], consumerEvidence: CITATION })).not.toThrow();
+    }
+  });
+});
+
+describe('backward compatibility — the pre-existing contract still holds', () => {
+  it('still ties a consumer to a created table when evidence is supplied', () => {
+    const res = validateConsumer({ changedFiles: WIRING_DIFF, createdTables: ['feedback'], consumerEvidence: CITATION });
+    expect(res.consumer_present).toBe(true);
+  });
+
+  it('a test file alone is still not a consumer', () => {
+    const res = validateConsumer({
+      changedFiles: [{ path: 'tests/unit/x.test.js', added: "await supabase.from('feedback').select('id')" }],
+      createdTables: ['feedback'],
+      consumerEvidence: [{ consumer: 'tests/unit/x.test.js:5', observed_read: 'read rows', artifact: 'query_result' }],
+    });
+    expect(res.consumer_present).toBe(false);
+  });
+});

--- a/lib/gates/operator-contract/__tests__/corpus-replay.test.js
+++ b/lib/gates/operator-contract/__tests__/corpus-replay.test.js
@@ -102,10 +102,33 @@ describe('FR-5 — coverage limits stated, never implied away', () => {
     expect(res.orphaned_producers).toBeUndefined();
   });
 
-  it('the replay set covers exactly 3 of 9 in-class, and the count is asserted not narrated', () => {
-    // A prose claim of "3 of 9" drifts the moment someone adds a replay. This binds it.
-    expect(REPLAYED).toHaveLength(3);
-    expect(CORPUS.in_class + CORPUS.out_of_class).toBe(CORPUS.total);
-    expect(REPLAYED.length).toBeLessThan(CORPUS.in_class);
+  it('the recall denominator matches the ACTUAL materialized corpus, not local literals', async () => {
+    // D6 (TESTING bc7f73bc): this test used to assert only its own constants — [12,8,10].length
+    // === 3 and 9 + 3 === 12 — which is true no matter what the corpus says. It pinned a fact
+    // about itself and bound nothing. It now reads the real corpus source, so editing the corpus
+    // without re-deriving the recall line fails here.
+    const { CORPUS: RECORDS } = await import('../../../../scripts/materialize-verify-consumer-corpus.mjs');
+    expect(RECORDS).toHaveLength(CORPUS.total);
+    expect(RECORDS.filter((r) => r.in_class)).toHaveLength(CORPUS.in_class);
+    expect(RECORDS.filter((r) => !r.in_class)).toHaveLength(CORPUS.out_of_class);
+    // Every replayed n must actually exist in the corpus and be in-class — a replay of an
+    // out-of-class instance would be a category error, and a replay of a nonexistent n is a typo
+    // that would otherwise inflate the numerator silently.
+    for (const n of REPLAYED) {
+      const rec = RECORDS.find((r) => r.n === n);
+      expect(rec, `replayed n=${n} is not in the corpus`).toBeDefined();
+      expect(rec.in_class, `replayed n=${n} is out-of-class`).toBe(true);
+    }
+    expect(REPLAYED.length).toBeLessThan(CORPUS.in_class); // never let it read as complete
+  });
+
+  it('every corpus record carries a citable evidence id, and inferred ones say so', async () => {
+    const { CORPUS: RECORDS } = await import('../../../../scripts/materialize-verify-consumer-corpus.mjs');
+    for (const r of RECORDS) expect(r.evidence_id, `n=${r.n} has no evidence id`).toBeTruthy();
+    // The one inferred attribution must stay marked. Presenting it as measured would be the
+    // citation-is-provenance failure this SD is about.
+    const inferred = RECORDS.filter((r) => r.provenance === 'inferred');
+    expect(inferred).toHaveLength(1);
+    expect(inferred[0].provenance_note).toMatch(/INFERRED/);
   });
 });

--- a/lib/gates/operator-contract/__tests__/corpus-replay.test.js
+++ b/lib/gates/operator-contract/__tests__/corpus-replay.test.js
@@ -1,0 +1,111 @@
+/**
+ * FR-5 REPLAYS — would-have-caught demonstrations against the founding corpus.
+ * SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001
+ *
+ * The corpus is materialized as 12 structured records at
+ * strategic_directives_v2.metadata.founding_corpus_records (9 in-class, 3 out-of-class).
+ * The PRD says eleven; the evidence says twelve and the reconciliation is recorded on the SD.
+ *
+ * HONEST RECALL. These replays cover 3 of the 9 IN-CLASS instances — never "3 of 3". The six
+ * in-SD instances (1-5) are function-level verification gaps, NOT table wirings, and this arm
+ * does not detect them; that is a real coverage limit, stated here rather than hidden behind a
+ * flattering ratio. The out-of-class three (two turn-behaviour lapses, one environment
+ * staleness) are unreplayable by construction.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { resolveOperatorContract } from '../harness-adapter.js';
+
+const supabase = { from: () => ({ select: async () => ({ data: [], error: null }) }) };
+const diffOf = (changedFiles) => ({ changedFiles, migrations: [], createdTables: [] });
+const run = (diff, metadata = {}) => resolveOperatorContract({ sd: { metadata }, appPath: '.', supabase, diff });
+
+afterEach(() => { delete process.env.ENFORCE_CONSUMER_CITATION; });
+
+/** Recall is reported against the IN-CLASS subset, with the out-of-class count on the same line. */
+const CORPUS = { total: 12, in_class: 9, out_of_class: 3 };
+const REPLAYED = [12, 8, 10];
+
+describe(`FR-5 replay — ${REPLAYED.length} of ${CORPUS.in_class} IN-CLASS (${CORPUS.out_of_class} out-of-class, not replayable)`, () => {
+  it('n=12 TREND-EYES UNWIRED ALARM — the hard-end case, required by FR-5', async () => {
+    // The only instance to survive a RATIFIED completion: handoffs at 93/94/87/92/96, a
+    // 100-quality retro, and a six-flag interrogation. INVOCATION_PATH_PROOF passed because it
+    // asks whether the producer RAN; nothing asked whether the output had a READER.
+    process.env.ENFORCE_CONSUMER_CITATION = '1';
+    const res = await run(diffOf([
+      { path: 'scripts/trend-eyes-sweep.mjs', added: "await supabase.from('trend_eyes_receipts').insert(receipt)" },
+    ]));
+    expect(res.verdict).toBe('FAIL');
+    expect(res.reason).toBe('CONSUMER_CITATION_MISSING');
+    expect(res.orphaned_producers).toEqual(['trend_eyes_receipts']);
+  });
+
+  it('n=12 — the PRODUCER-SIDE artifact that actually fooled the humans is rejected', async () => {
+    // The SECURITY artifact literally contained the words ZERO IMPORTS and no human converted
+    // it. Producer-side evidence reads like proof; this is the assertion that refuses it.
+    process.env.ENFORCE_CONSUMER_CITATION = '1';
+    const res = await run(
+      diffOf([{ path: 'scripts/trend-eyes-sweep.mjs', added: "await supabase.from('trend_eyes_receipts').insert(receipt)" }]),
+      { consumer_evidence: [{ consumer: 'scripts/trend-eyes-sweep.mjs:12', observed_read: 'the sweep ran and wrote the receipt', artifact: 'run_log' }] },
+    );
+    expect(res.verdict).toBe('FAIL');
+    expect(res.consumer_citation.issues.join(' ')).toMatch(/PRODUCER/i);
+  });
+
+  it('n=12 — naming a REAL out-of-diff reader clears it (the arm is satisfiable)', async () => {
+    // An orphan's reader lives outside the diff by definition. A gate nobody can pass gets
+    // bypassed, not obeyed — so this direction has to work.
+    process.env.ENFORCE_CONSUMER_CITATION = '1';
+    const res = await run(
+      diffOf([{ path: 'scripts/trend-eyes-sweep.mjs', added: "await supabase.from('trend_eyes_receipts').insert(receipt)" }]),
+      { consumer_evidence: [{ consumer: 'lib/chairman/daily-review/panel.js:88', observed_read: 'reads trend_eyes_receipts; returned 14 rows', artifact: 'query_result' }] },
+    );
+    expect(res.verdict).not.toBe('FAIL');
+    expect(res.consumer_citation.accepted).toEqual(['lib/chairman/daily-review/panel.js:88']);
+    // Out-of-diff acceptance must stay visibly marked, or it launders an operator assertion
+    // into something that looks diff-verified.
+    expect(res.consumer_citation.present).toBe(true);
+  });
+
+  it('n=8 PRODUCER NO-OP AT ITS ONLY CALLER — drive_reports stayed at ZERO rows', async () => {
+    // drive-report-produce.mjs exited 0 with no output; the Windows file:// guard meant main()
+    // never ran, and the cron dispatch went GREEN while producing nothing.
+    process.env.ENFORCE_CONSUMER_CITATION = '1';
+    const res = await run(diffOf([
+      { path: 'scripts/drive-report-produce.mjs', added: "await supabase.from('drive_reports').insert(report)" },
+    ]));
+    expect(res.verdict).toBe('FAIL');
+    expect(res.orphaned_producers).toEqual(['drive_reports']);
+  });
+
+  it('n=10 THE REAP VERIFICATION — a reaper whose main() never fires looks like a clean reap', async () => {
+    process.env.ENFORCE_CONSUMER_CITATION = '1';
+    const res = await run(diffOf([
+      { path: 'scripts/reap-e2e-liveness-fixtures.mjs', added: "await supabase.from('reap_receipts').insert({ deleted })" },
+    ]));
+    expect(res.verdict).toBe('FAIL');
+    expect(res.orphaned_producers).toEqual(['reap_receipts']);
+  });
+});
+
+describe('FR-5 — coverage limits stated, never implied away', () => {
+  it('IN-CLASS BUT NOT DETECTED: instances 1-5 are function-level gaps, not table wirings', async () => {
+    // Instance 2: "Math.min clamp removed but proven only at the probe, never through the
+    // resolver." A diff heuristic COULD catch this in principle (which is why FR-5 classes it
+    // in-class), but THIS arm reads table reads/writes and sees nothing here. Asserting the miss
+    // keeps the recall number honest: 3 of 9, not 9 of 9.
+    process.env.ENFORCE_CONSUMER_CITATION = '1';
+    const res = await run(diffOf([
+      { path: 'lib/probe/clamp.js', added: 'const capped = value; // Math.min removed' },
+      { path: 'lib/probe/resolver.js', added: 'return resolve(capped);' },
+    ]));
+    expect(res.verdict).not.toBe('FAIL');
+    expect(res.orphaned_producers).toBeUndefined();
+  });
+
+  it('the replay set covers exactly 3 of 9 in-class, and the count is asserted not narrated', () => {
+    // A prose claim of "3 of 9" drifts the moment someone adds a replay. This binds it.
+    expect(REPLAYED).toHaveLength(3);
+    expect(CORPUS.in_class + CORPUS.out_of_class).toBe(CORPUS.total);
+    expect(REPLAYED.length).toBeLessThan(CORPUS.in_class);
+  });
+});

--- a/lib/gates/operator-contract/__tests__/creator-path-regression.test.js
+++ b/lib/gates/operator-contract/__tests__/creator-path-regression.test.js
@@ -83,3 +83,28 @@ describe('unreadable files reach the verdict (they had zero readers)', () => {
     expect(res.unreadable_files).toEqual([{ path: 'huge.js', error: 'ENOBUFS' }]);
   });
 });
+
+describe('a test fixture is not a creator (this SD blocked ITSELF on it)', () => {
+  it('creator-shaped strings inside a test file do NOT make an SD a creator', async () => {
+    // Dogfood failure: this SD's own PLAN-TO-LEAD failed OPERATOR_CONTRACT_INCOMPLETE because a
+    // fixture string in __tests__ was read as real flag creation, so the gate demanded an armed
+    // cadence and a reaper for a flag that does not exist. detectWiring and validateConsumer both
+    // excluded test paths; detectCreator did not.
+    const { detectCreator } = await import('../index.js');
+    for (const path of [
+      'lib/gates/operator-contract/__tests__/creator-path-regression.test.js',
+      'tests/unit/x.js',
+      'lib/y.spec.js',
+    ]) {
+      const res = detectCreator({ changedFiles: [{ path, added: "await supabase.from('leo_feature_flags').insert({ key: 'my-flag' })" }] });
+      expect(res.is_creator, path).toBe(false);
+    }
+  });
+
+  it('a REAL flag insert in production code is still a creator — two-sided', async () => {
+    const { detectCreator } = await import('../index.js');
+    const res = detectCreator({ changedFiles: [{ path: 'scripts/add-flag.js', added: "await supabase.from('leo_feature_flags').insert({ key: 'my-flag' })" }] });
+    expect(res.is_creator).toBe(true);
+    expect(res.creator_kinds).toContain('flag');
+  });
+});

--- a/lib/gates/operator-contract/__tests__/creator-path-regression.test.js
+++ b/lib/gates/operator-contract/__tests__/creator-path-regression.test.js
@@ -1,0 +1,85 @@
+/**
+ * BLOCKING REGRESSION on the creator path — found independently by VALIDATION (72db4226) and
+ * REGRESSION (a54189e3), both by measuring HEAD against origin/main rather than by reading.
+ * SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001
+ *
+ * Closing hole A was right, but it landed on the BLOCKING creator path too: whenever
+ * createdTables is empty — every FLAG and DETECTOR creator — the CONSUMER leg became
+ * UNSATISFIABLE. Measured PASS -> FAIL on a required:true gate on the shared PLAN-TO-LEAD
+ * pipeline, outside the warn-first flag, with a waiver as the only exit. A gate that cannot be
+ * satisfied by doing the right thing does not get obeyed; it gets bypassed.
+ *
+ * No fixture for a flag/detector creator existed, which is why the whole suite stayed green
+ * through the regression.
+ */
+import { describe, it, expect } from 'vitest';
+import { resolveOperatorContract } from '../harness-adapter.js';
+
+const REGISTRY = [{ process_key: 'my-flag', currently_expected_active: true, expected_interval_seconds: 3600, last_fired_at: new Date().toISOString() }];
+const supabase = { from: () => ({ select: async () => ({ data: REGISTRY, error: null }) }) };
+
+/** A FLAG creator: inserts into leo_feature_flags, creates NO table. */
+const flagCreatorDiff = (extra = []) => ({
+  changedFiles: [
+    { path: 'scripts/add-flag.js', added: "await supabase.from('leo_feature_flags').insert({ key: 'my-flag' })" },
+    ...extra,
+  ],
+  migrations: [], createdTables: [],
+});
+
+const meta = (m = {}) => ({ metadata: { operator_capability_keys: ['my-flag'], ...m } });
+const run = (diff, sd) => resolveOperatorContract({ sd, appPath: '.', supabase, diff });
+
+describe('a FLAG creator that ships a reader is NOT blocked', () => {
+  it('a cited consumer satisfies the leg (this returned missing:[consumer] before the fix)', async () => {
+    const res = await run(
+      flagCreatorDiff(),
+      meta({ consumer_evidence: [{ consumer: 'lib/runtime/flag-reader.js:42', observed_read: 'reads my-flag; returned enabled=true', artifact: 'query_result' }] }),
+    );
+    expect(res.missing || []).not.toContain('consumer');
+    expect(res.verdict).toBe('pass');
+  });
+
+  it('the reader may live OUTSIDE the diff — a flag consumer usually predates the flag', async () => {
+    const res = await run(
+      flagCreatorDiff(),
+      meta({ consumer_evidence: [{ consumer: 'lib/elsewhere/never-in-this-diff.js:7', observed_read: 'gates behaviour on my-flag', artifact: 'query_result' }] }),
+    );
+    expect(res.missing || []).not.toContain('consumer');
+  });
+
+  it('STILL BLOCKS with no citation — the fix must not re-open hole A', async () => {
+    // Two-sided. If this passes, the regression fix has simply restored the false-PASS that
+    // hole A existed to remove, and the whole SD is a round trip.
+    const res = await run(flagCreatorDiff(), meta());
+    expect(res.missing).toContain('consumer');
+  });
+
+  it('STILL rejects producer-side evidence on the creator path', async () => {
+    const res = await run(
+      flagCreatorDiff(),
+      meta({ consumer_evidence: [{ consumer: 'scripts/add-flag.js:1', observed_read: 'the flag was inserted', artifact: 'run_log' }] }),
+    );
+    expect(res.missing).toContain('consumer');
+  });
+});
+
+describe('the miss classes ride on the verdict that most needs them', () => {
+  it('a non-creator, non-wired, non-orphan diff STILL carries its miss classes', async () => {
+    // This early-return path is the ONE place `wired:false` could be misread as "verified
+    // unwired" — and it was the one path that dropped the list. Same shape as the D1 defect.
+    const res = await run({ changedFiles: [{ path: 'lib/util.js', added: 'export const noop = () => {};' }], migrations: [], createdTables: [] }, { metadata: {} });
+    expect(res.wiring_miss_classes).toContain('rpc_indirection');
+    expect(res.wiring_miss_classes).toContain('dynamic_dispatch');
+  });
+});
+
+describe('unreadable files reach the verdict (they had zero readers)', () => {
+  it('an unreadable file is carried through, not absorbed', async () => {
+    const res = await run(
+      { changedFiles: [], migrations: [], createdTables: [], unreadable: [{ path: 'huge.js', error: 'ENOBUFS' }] },
+      { metadata: {} },
+    );
+    expect(res.unreadable_files).toEqual([{ path: 'huge.js', error: 'ENOBUFS' }]);
+  });
+});

--- a/lib/gates/operator-contract/__tests__/creator-path-regression.test.js
+++ b/lib/gates/operator-contract/__tests__/creator-path-regression.test.js
@@ -108,3 +108,23 @@ describe('a test fixture is not a creator (this SD blocked ITSELF on it)', () =>
     expect(res.creator_kinds).toContain('flag');
   });
 });
+
+describe('detectCreator does not scan comment prose (this SD blocked itself on its OWN comment)', () => {
+  it('a creator-shaped string inside a comment is NOT a creation', async () => {
+    const { detectCreator } = await import('../index.js');
+    for (const added of [
+      "// the string supabase.from('leo_feature_flags').insert(...) was read as real flag creation",
+      "/* discusses supabase.from('leo_feature_flags').insert(row) in prose */",
+      ' * a JSDoc continuation mentioning leo_feature_flags and .insert( together',
+    ]) {
+      expect(detectCreator({ changedFiles: [{ path: 'lib/real.js', added }] }).is_creator, added.slice(0, 40)).toBe(false);
+    }
+  });
+
+  it('a REAL flag insert in the same file as a comment mentioning it IS still detected', async () => {
+    // Two-sided. Stripping comments must not blind the rule to live code beside the prose.
+    const { detectCreator } = await import('../index.js');
+    const added = "// we insert into leo_feature_flags below\nawait supabase.from('leo_feature_flags').insert({ key: 'k' })";
+    expect(detectCreator({ changedFiles: [{ path: 'lib/real.js', added }] }).is_creator).toBe(true);
+  });
+});

--- a/lib/gates/operator-contract/__tests__/gate-factory-output.test.js
+++ b/lib/gates/operator-contract/__tests__/gate-factory-output.test.js
@@ -82,7 +82,10 @@ describe('D2 — the block names a remedy that can actually resolve it', () => {
 
 describe('fail-open still holds through the new branches', () => {
   it('an execution error resolves to passed:true with a warning, never a false block', async () => {
-    process.env.ENFORCE_CONSUMER_CITATION = '1';
+    // Deliberately does NOT set ENFORCE_CONSUMER_CITATION. Fail-open is the WARN-FIRST contract;
+    // under enforcement the direction flips to fail-CLOSED (SEC-4), covered in
+    // citation-path-spoofing.test.js. This test previously set the flag and still expected a
+    // pass — encoding the bypass as correct behaviour.
     // No injected diff + a non-git path => collectSdDiff throws for real, exercising the catch.
     const res = await createOperatorContractGate(supabase, sd, 'C:/definitely/not/a/repo/xyz').validator({ sd });
     expect(res.passed).toBe(true);

--- a/lib/gates/operator-contract/__tests__/gate-factory-output.test.js
+++ b/lib/gates/operator-contract/__tests__/gate-factory-output.test.js
@@ -1,0 +1,91 @@
+/**
+ * D1/D2 — the GATE FACTORY output layer, which had NO behavioural coverage at all.
+ * SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001
+ *
+ * TESTING (row bc7f73bc) found 11 of 19 mutants surviving, and the cluster that mattered was
+ * here: createOperatorContractGate OVERWROTE `warnings` with the waived-missing list, so every
+ * advisory the arm produced was built and discarded. The gate returned warnings:[] and reason
+ * NOT_APPLICABLE for a diff it had evaluated and found an orphan in — the arm was invisible in
+ * its own shipped default, and this SD's own branch would have reported NOT_APPLICABLE.
+ *
+ * The only prior test of this layer asserted toHaveProperty('passed'). That is a shape check;
+ * it cannot see a channel being dropped. These drive the REGISTERED entry point.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { createOperatorContractGate } from '../harness-adapter.js';
+const supabase = { from: () => ({ select: async () => ({ data: [], error: null }), insert: async () => ({ error: null }) }) };
+const sd = { sd_key: 'SD-TEST-001', metadata: {} };
+
+/** Corpus #7 through the REAL gate: a producer whose output nothing reads. */
+const ORPHAN_DIFF = {
+  changedFiles: [{ path: 'scripts/trend-eyes-sweep.mjs', added: "await supabase.from('trend_eyes_receipts').insert(receipt)" }],
+  migrations: [], createdTables: [],
+};
+
+const gateWith = (diff) => createOperatorContractGate(supabase, sd, '.', { diff });
+const UNARMED = { changedFiles: [{ path: 'lib/util.js', added: 'export const noop = () => {};' }], migrations: [], createdTables: [] };
+afterEach(() => { delete process.env.ENFORCE_CONSUMER_CITATION; });
+
+describe('D1 — the advisory REACHES the caller (kills mutants C and D)', () => {
+  it('an armed diff surfaces the advisory in warnings, not just in a discarded local', async () => {
+    const res = await gateWith(ORPHAN_DIFF).validator({ sd });
+    // The single assertion that would have caught the dropped channel.
+    expect(res.warnings.join(' ')).toMatch(/ORPHANED PRODUCER/);
+    expect(res.warnings.join(' ')).toMatch(/trend_eyes_receipts/);
+  });
+
+  it('details carry the evaluation, so a reviewer can see WHAT was evaluated', async () => {
+    const res = await gateWith(ORPHAN_DIFF).validator({ sd });
+    expect(res.details.wiring_detected).toBe(true);
+    expect(res.details.orphaned_producers).toEqual(['trend_eyes_receipts']);
+    expect(res.details.consumer_citation.present).toBe(false);
+    expect(res.details.wiring_miss_classes).toContain('rpc_indirection');
+  });
+
+  it('does NOT report NOT_APPLICABLE for a diff it actually evaluated', async () => {
+    // Reporting "not applicable" about work you did is a false statement, not a terse one.
+    const res = await gateWith(ORPHAN_DIFF).validator({ sd });
+    expect(res.details.reason).not.toMatch(/NOT_APPLICABLE/);
+    expect(res.details.reason).toMatch(/EVALUATED/);
+  });
+
+  it('still passes (warn-first) — visibility is not blocking', async () => {
+    const res = await gateWith(ORPHAN_DIFF).validator({ sd });
+    expect(res.passed).toBe(true);
+  });
+
+  it('a genuinely unarmed diff stays quiet — no advisory noise on every gate run', async () => {
+    const res = await gateWith(UNARMED).validator({ sd });
+    expect(res.warnings).toEqual([]);
+    expect(res.details.wiring_detected).toBeFalsy();
+  });
+});
+
+describe('D2 — the block names a remedy that can actually resolve it', () => {
+  it('a CONSUMER_CITATION_MISSING block names metadata.consumer_evidence', async () => {
+    // The generic text says "ship the OPERATOR TRIPLE / attach a waiver". Neither resolves this
+    // failure. A gate that names the wrong remedy trains people to bypass it.
+    process.env.ENFORCE_CONSUMER_CITATION = '1';
+    const res = await gateWith(ORPHAN_DIFF).validator({ sd });
+    expect(res.passed).toBe(false);
+    expect(res.issues).toContain('CONSUMER_CITATION_MISSING');
+    expect(res.details.remedy_field).toBe('metadata.consumer_evidence');
+  });
+
+  it('the blocked result still carries the advisory and the evaluated tables', async () => {
+    process.env.ENFORCE_CONSUMER_CITATION = '1';
+    const res = await gateWith(ORPHAN_DIFF).validator({ sd });
+    expect(res.details.orphaned_producers).toEqual(['trend_eyes_receipts']);
+    expect(res.warnings.join(' ')).toMatch(/ORPHANED PRODUCER/);
+  });
+});
+
+describe('fail-open still holds through the new branches', () => {
+  it('an execution error resolves to passed:true with a warning, never a false block', async () => {
+    process.env.ENFORCE_CONSUMER_CITATION = '1';
+    // No injected diff + a non-git path => collectSdDiff throws for real, exercising the catch.
+    const res = await createOperatorContractGate(supabase, sd, 'C:/definitely/not/a/repo/xyz').validator({ sd });
+    expect(res.passed).toBe(true);
+    expect(res.warnings.join(' ')).toMatch(/fail-open/);
+  });
+});

--- a/lib/gates/operator-contract/__tests__/venture-and-self-cadence.test.js
+++ b/lib/gates/operator-contract/__tests__/venture-and-self-cadence.test.js
@@ -88,3 +88,49 @@ describe('regressionFalsePositives (FR-8 / SC#5 zero-false-positive)', () => {
     expect(r.falsePositives[0].sd_key).toBe('SD-CREATOR');
   });
 });
+
+/**
+ * SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001 — hole B at the VENTURE seam.
+ * Same arm as the harness adapter. Both seams share one validator, so they must also share one
+ * answer; testing only the harness side would let the two drift apart silently.
+ */
+describe('hole B — venture seam arms on a wiring, not only on a creator', () => {
+  const wiredDiff = [
+    { path: 'lib/producer.js', added: "await supabase.from('venture_events').insert(row)" },
+    { path: 'lib/consumer.js', added: "const { data } = await supabase.from('venture_events').select('*')" },
+  ];
+
+  it('a wired non-creator venture change is EVALUATED, not short-circuited', () => {
+    const res = evaluateVentureOperatorContract({ changedFiles: wiredDiff });
+    expect(res.wiring_detected).toBe(true);
+    expect(res.wiring_tables).toEqual(['venture_events']);
+  });
+
+  it('warn-first by default: visible, non-blocking', () => {
+    const res = evaluateVentureOperatorContract({ changedFiles: wiredDiff, enforceConsumerCitation: false });
+    expect(res.verdict).not.toBe('FAIL');
+    expect(res.warnings.join(' ')).toMatch(/WIRING DETECTED/);
+  });
+
+  it('enforced: blocks with the SAME reason string the harness adapter uses', () => {
+    const res = evaluateVentureOperatorContract({ changedFiles: wiredDiff, enforceConsumerCitation: true });
+    expect(res.verdict).toBe('FAIL');
+    expect(res.reason).toBe('CONSUMER_CITATION_MISSING');
+  });
+
+  it('a genuine citation passes; the diff heuristic alone does not', () => {
+    const cited = evaluateVentureOperatorContract({
+      changedFiles: wiredDiff,
+      enforceConsumerCitation: true,
+      consumerEvidence: [{ consumer: 'lib/consumer.js:9', observed_read: 'select returned 3 rows', artifact: 'query_result' }],
+    });
+    expect(cited.verdict).not.toBe('FAIL');
+    // Same circularity guard as the harness side: no metadata must NOT self-certify.
+    expect(evaluateVentureOperatorContract({ changedFiles: wiredDiff, enforceConsumerCitation: true }).consumer_citation.present).toBe(false);
+  });
+
+  it('an unwired non-creator change still short-circuits', () => {
+    const res = evaluateVentureOperatorContract({ changedFiles: [{ path: 'lib/p.js', added: "await supabase.from('t').insert(r)" }] });
+    expect(res.wiring_detected).toBeUndefined();
+  });
+});

--- a/lib/gates/operator-contract/__tests__/venture-and-self-cadence.test.js
+++ b/lib/gates/operator-contract/__tests__/venture-and-self-cadence.test.js
@@ -129,8 +129,28 @@ describe('hole B — venture seam arms on a wiring, not only on a creator', () =
     expect(evaluateVentureOperatorContract({ changedFiles: wiredDiff, enforceConsumerCitation: true }).consumer_citation.present).toBe(false);
   });
 
-  it('an unwired non-creator change still short-circuits', () => {
-    const res = evaluateVentureOperatorContract({ changedFiles: [{ path: 'lib/p.js', added: "await supabase.from('t').insert(r)" }] });
+  it('a change touching no persistent output still short-circuits', () => {
+    // Was a write-only diff, which is now correctly an ORPHANED PRODUCER rather than "unwired".
+    const res = evaluateVentureOperatorContract({ changedFiles: [{ path: 'lib/util.js', added: 'export const noop = () => {};' }] });
     expect(res.wiring_detected).toBeUndefined();
+  });
+});
+
+describe('hole B — venture seam arms on an ORPHANED PRODUCER too (corpus #7 shape)', () => {
+  const orphan = [{ path: 'scripts/venture-sweep.mjs', added: "await supabase.from('venture_receipts').insert(r)" }];
+
+  it('a producer with no reader arms, and blocks when enforced', () => {
+    const res = evaluateVentureOperatorContract({ changedFiles: orphan, enforceConsumerCitation: true });
+    expect(res.orphaned_producers).toEqual(['venture_receipts']);
+    expect(res.verdict).toBe('FAIL');
+  });
+
+  it('an out-of-diff reader citation clears it, matching the harness seam exactly', () => {
+    const res = evaluateVentureOperatorContract({
+      changedFiles: orphan,
+      enforceConsumerCitation: true,
+      consumerEvidence: [{ consumer: 'lib/venture/panel.js:31', observed_read: 'reads venture_receipts; 7 rows', artifact: 'query_result' }],
+    });
+    expect(res.verdict).not.toBe('FAIL');
   });
 });

--- a/lib/gates/operator-contract/__tests__/wiring-arming-adapter.test.js
+++ b/lib/gates/operator-contract/__tests__/wiring-arming-adapter.test.js
@@ -18,7 +18,10 @@ const WIRED = diffOf([
   { path: 'lib/producer.js', added: "await supabase.from('feedback').insert(row)" },
   { path: 'lib/consumer.js', added: "const { data } = await supabase.from('feedback').select('*')" },
 ]);
-const UNWIRED = diffOf([{ path: 'lib/producer.js', added: "await supabase.from('feedback').insert(row)" }]);
+// A write-only diff is NOT "unwired" — it is an ORPHANED PRODUCER, and it arms. This fixture is
+// a change that touches no persistent output at all, which is the only genuinely unarmed shape.
+const UNARMED = diffOf([{ path: 'lib/util.js', added: 'export const slugify = (s) => s.trim().toLowerCase();' }]);
+const WRITE_ONLY = diffOf([{ path: 'lib/producer.js', added: "await supabase.from('feedback').insert(row)" }]);
 
 const CITATION = [{ consumer: 'lib/consumer.js:12', observed_read: 'select on feedback returned 14 rows', artifact: 'query_result' }];
 const run = (diff, metadata = {}) => resolveOperatorContract({ sd: { metadata }, appPath: '.', supabase: supabaseStub, now: NOW, diff });
@@ -33,9 +36,17 @@ describe('the ADAPTER actually arms on a wiring (mutation-visible)', () => {
     expect(res.wiring_tables).toEqual(['feedback']);
   });
 
-  it('an UNWIRED non-creator change still short-circuits — the blast radius stays bounded', async () => {
-    const res = await run(UNWIRED);
+  it('a change touching no persistent output still short-circuits — blast radius stays bounded', async () => {
+    const res = await run(UNARMED);
     expect(res.wiring_detected).toBeUndefined();
+  });
+
+  it('a WRITE-ONLY diff arms as an orphaned producer (this assertion used to encode the hole)', async () => {
+    // It previously asserted `wiring_detected` was undefined here — i.e. it pinned the silent
+    // pass as correct behaviour. That is the corpus #7 shape; it must arm.
+    const res = await run(WRITE_ONLY);
+    expect(res.wiring_detected).toBe(true);
+    expect(res.orphaned_producers).toEqual(['feedback']);
   });
 
   it('carries the miss classes through to the verdict, so coverage is never implied to be complete', async () => {

--- a/lib/gates/operator-contract/__tests__/wiring-arming-adapter.test.js
+++ b/lib/gates/operator-contract/__tests__/wiring-arming-adapter.test.js
@@ -1,0 +1,102 @@
+/**
+ * SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001 — hole B AT THE ADAPTER, not at the pure function.
+ *
+ * WHY THIS FILE EXISTS, and it is the SD's own thesis turned on itself: my first pass tested
+ * detectWiring() directly. A mutation that stopped resolveOperatorContract from CALLING it left
+ * all 80 tests GREEN — the producer was verified, the consumer was not. That is the third
+ * instance of unit-tests-the-function-but-not-the-wiring recorded today, and it reproduced
+ * inside the fix for that exact class. These tests drive the ADAPTER.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { resolveOperatorContract } from '../harness-adapter.js';
+
+const supabaseStub = { from: () => ({ select: async () => ({ data: [], error: null }) }) };
+const NOW = new Date('2026-08-07T22:00:00Z');
+
+const diffOf = (changedFiles) => ({ changedFiles, migrations: [], createdTables: [] });
+const WIRED = diffOf([
+  { path: 'lib/producer.js', added: "await supabase.from('feedback').insert(row)" },
+  { path: 'lib/consumer.js', added: "const { data } = await supabase.from('feedback').select('*')" },
+]);
+const UNWIRED = diffOf([{ path: 'lib/producer.js', added: "await supabase.from('feedback').insert(row)" }]);
+
+const CITATION = [{ consumer: 'lib/consumer.js:12', observed_read: 'select on feedback returned 14 rows', artifact: 'query_result' }];
+const run = (diff, metadata = {}) => resolveOperatorContract({ sd: { metadata }, appPath: '.', supabase: supabaseStub, now: NOW, diff });
+
+afterEach(() => { delete process.env.ENFORCE_CONSUMER_CITATION; });
+
+describe('the ADAPTER actually arms on a wiring (mutation-visible)', () => {
+  it('a wired non-creator change is EVALUATED, not short-circuited to a no-op pass', async () => {
+    const res = await run(WIRED);
+    // The single assertion a "stopped calling detectWiring" mutation cannot survive.
+    expect(res.wiring_detected).toBe(true);
+    expect(res.wiring_tables).toEqual(['feedback']);
+  });
+
+  it('an UNWIRED non-creator change still short-circuits — the blast radius stays bounded', async () => {
+    const res = await run(UNWIRED);
+    expect(res.wiring_detected).toBeUndefined();
+  });
+
+  it('carries the miss classes through to the verdict, so coverage is never implied to be complete', async () => {
+    const res = await run(WIRED);
+    expect(res.wiring_miss_classes).toContain('dynamic_dispatch');
+  });
+});
+
+describe('warn-first — visible in BOTH states, blocking in only one', () => {
+  it('DEFAULT (flag off): missing citation WARNS and does NOT block', async () => {
+    const res = await run(WIRED);
+    expect(res.consumer_citation.present).toBe(false);
+    expect(res.consumer_citation.enforced).toBe(false);
+    expect(res.verdict).not.toBe('FAIL');
+    // Unenforced must never mean silent, or this ships as a decorative arm.
+    expect(res.warnings.join(' ')).toMatch(/consumer-citation advisory/);
+    expect(res.warnings.join(' ')).toMatch(/WIRING DETECTED/);
+  });
+
+  it('ENFORCED (flag on): the same input BLOCKS with a named reason', async () => {
+    process.env.ENFORCE_CONSUMER_CITATION = '1';
+    const res = await run(WIRED);
+    expect(res.verdict).toBe('FAIL');
+    expect(res.reason).toBe('CONSUMER_CITATION_MISSING');
+  });
+
+  it('a genuine citation PASSES in the enforced mode — two-sided, not just fail-happy', async () => {
+    process.env.ENFORCE_CONSUMER_CITATION = '1';
+    const res = await run(WIRED, { consumer_evidence: CITATION });
+    expect(res.consumer_citation.present).toBe(true);
+    expect(res.consumer_citation.accepted).toEqual(['lib/consumer.js:12']);
+    expect(res.verdict).not.toBe('FAIL');
+    expect(res.warnings.join(' ')).not.toMatch(/WIRING DETECTED/);
+  });
+
+  it('producer-side evidence is REJECTED even when supplied — the whole point of the arm', async () => {
+    process.env.ENFORCE_CONSUMER_CITATION = '1';
+    const res = await run(WIRED, {
+      consumer_evidence: [{ consumer: 'lib/producer.js:1', observed_read: 'insert emitted 14 rows', artifact: 'emission_log' }],
+    });
+    expect(res.verdict).toBe('FAIL');
+    expect(res.consumer_citation.issues.join(' ')).toMatch(/PRODUCER/i);
+  });
+});
+
+describe('the verifier must not read the detector own signal', () => {
+  it('a diff-scanned read-path does NOT satisfy the arm — only an operator citation does', async () => {
+    process.env.ENFORCE_CONSUMER_CITATION = '1';
+    // WIRED contains a real `.select()` on the wired table. validateConsumer's legacy heuristic
+    // would call that a consumer and pass — but it is the SAME bit detectWiring used to declare
+    // the wiring. If this ever passes with no metadata, verifier and detector have collapsed into
+    // one signal and the arm self-certifies every wired SD it sees.
+    const res = await run(WIRED);
+    expect(res.verdict).toBe('FAIL');
+    expect(res.consumer_citation.present).toBe(false);
+  });
+});
+
+describe('fail-open contract preserved', () => {
+  it('does not throw on a hostile diff — the adapter catch would turn a throw into passed:true', async () => {
+    await expect(run(diffOf([{ path: null, added: null }]))).resolves.toBeTypeOf('object');
+    await expect(run(diffOf([]))).resolves.toBeTypeOf('object');
+  });
+});

--- a/lib/gates/operator-contract/__tests__/wiring-detection.test.js
+++ b/lib/gates/operator-contract/__tests__/wiring-detection.test.js
@@ -1,0 +1,74 @@
+/**
+ * SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001, HOLE B — arming on a producer->consumer WIRING.
+ *
+ * resolveOperatorContract short-circuited to a no-op pass whenever detectCreator() did not fire,
+ * so a change that CREATES nothing was never evaluated — and that is this SD's entire target
+ * class. Corpus #7 is exactly that shape: an EXISTING sweep writing an EXISTING receipt that
+ * nothing reads. It survived a ratified completion because every gate asked whether the producer
+ * RAN, never whether the output had a READER.
+ */
+import { describe, it, expect } from 'vitest';
+import { detectWiring } from '../index.js';
+
+const write = (path, table) => ({ path, added: `await supabase.from('${table}').insert(row)` });
+const read = (path, table) => ({ path, added: `const { data } = await supabase.from('${table}').select('*')` });
+
+describe('hole B — a wiring with no new table is DETECTED', () => {
+  it('CORPUS #7 SHAPE: existing producer writes, nothing reads -> NOT wired', () => {
+    // The receipt is written daily and read by nothing. detectWiring reports no wiring because
+    // there is no reader — which is precisely the finding, not a miss: the arm downstream then
+    // has nothing to pair, and the absent consumer is the defect.
+    const res = detectWiring({ changedFiles: [write('scripts/trend-eyes-sweep.mjs', 'trend_eyes_receipts')] });
+    expect(res.wired).toBe(false);
+  });
+
+  it('an existing producer wired to an existing consumer IS detected (the class that was never evaluated)', () => {
+    const res = detectWiring({ changedFiles: [write('lib/producer.js', 'feedback'), read('lib/consumer.js', 'feedback')] });
+    expect(res.wired).toBe(true);
+    expect(res.tables).toEqual(['feedback']);
+    expect(res.producerFiles).toEqual(['lib/producer.js']);
+    expect(res.consumerFiles).toEqual(['lib/consumer.js']);
+  });
+
+  it('a write and a read of DIFFERENT tables is not a wiring — no false pairing', () => {
+    const res = detectWiring({ changedFiles: [write('lib/a.js', 'table_a'), read('lib/b.js', 'table_b')] });
+    expect(res.wired).toBe(false);
+  });
+
+  it('test files never count as either side', () => {
+    const res = detectWiring({ changedFiles: [write('lib/p.js', 'feedback'), read('tests/unit/x.test.js', 'feedback')] });
+    expect(res.wired).toBe(false);
+  });
+
+  it('a single file that both writes and reads the same table counts as wired', () => {
+    const res = detectWiring({ changedFiles: [{ path: 'lib/both.js', added: "await supabase.from('t').insert(r);\nconst { data } = await supabase.from('t').select('*')" }] });
+    expect(res.wired).toBe(true);
+  });
+});
+
+describe('FR-4 — miss classes are declared, never claimed complete', () => {
+  it('every result carries its miss classes, so `wired:false` is not read as "verified unwired"', () => {
+    const res = detectWiring({ changedFiles: [] });
+    expect(res.miss_classes).toEqual(
+      expect.arrayContaining(['dynamic_dispatch', 'config_indirection', 'cross_repo_consumer', 'prose_only_wiring', 'aliased_value']),
+    );
+  });
+
+  it('a KNOWN miss: a consumer reached by dynamic dispatch is invisible to a static diff scan', () => {
+    // Documents the limit rather than pretending coverage. If this ever starts detecting, the
+    // heuristic improved and the miss class should be removed deliberately.
+    const res = detectWiring({
+      changedFiles: [write('lib/p.js', 'feedback'), { path: 'lib/c.js', added: "const t = cfg.table; const { data } = await supabase.from(t).select('*')" }],
+    });
+    expect(res.wired).toBe(false);
+    expect(res.miss_classes).toContain('dynamic_dispatch');
+  });
+});
+
+describe('totality — a throw here fails OPEN through the adapter catch', () => {
+  it('never throws on hostile input', () => {
+    for (const cf of [null, undefined, 'nope', [null], [{ path: 42, added: {} }], [{}], [[]]]) {
+      expect(() => detectWiring({ changedFiles: cf })).not.toThrow();
+    }
+  });
+});

--- a/lib/gates/operator-contract/__tests__/wiring-detection.test.js
+++ b/lib/gates/operator-contract/__tests__/wiring-detection.test.js
@@ -14,12 +14,29 @@ const write = (path, table) => ({ path, added: `await supabase.from('${table}').
 const read = (path, table) => ({ path, added: `const { data } = await supabase.from('${table}').select('*')` });
 
 describe('hole B — a wiring with no new table is DETECTED', () => {
-  it('CORPUS #7 SHAPE: existing producer writes, nothing reads -> NOT wired', () => {
-    // The receipt is written daily and read by nothing. detectWiring reports no wiring because
-    // there is no reader — which is precisely the finding, not a miss: the arm downstream then
-    // has nothing to pair, and the absent consumer is the defect.
+  it('CORPUS #7 SHAPE: existing producer writes, nothing reads -> ORPHANED PRODUCER', () => {
+    // THIS TEST PREVIOUSLY ASSERTED ONLY `wired:false`, with a comment calling that "precisely
+    // the finding, not a miss". That comment was a rationalisation and it was wrong: downstream,
+    // `wired:false` short-circuited to a silent PASS, so the arm let its own demonstration case
+    // through (measured: verdict pass, warnings []). The absent reader IS the defect, so it has
+    // to surface as a positive signal, not as the absence of one.
     const res = detectWiring({ changedFiles: [write('scripts/trend-eyes-sweep.mjs', 'trend_eyes_receipts')] });
     expect(res.wired).toBe(false);
+    expect(res.orphanedProducers).toEqual(['trend_eyes_receipts']);
+    expect(res.orphanProducerFiles).toEqual(['scripts/trend-eyes-sweep.mjs']);
+  });
+
+  it('a paired wiring leaves NO orphan — the two signals are mutually exclusive per table', () => {
+    const res = detectWiring({ changedFiles: [write('lib/p.js', 'feedback'), read('lib/c.js', 'feedback')] });
+    expect(res.orphanedProducers).toEqual([]);
+  });
+
+  it('one diff can carry both: a paired table and an orphaned one', () => {
+    const res = detectWiring({
+      changedFiles: [write('lib/p.js', 'paired'), read('lib/c.js', 'paired'), write('lib/p2.js', 'lonely')],
+    });
+    expect(res.tables).toEqual(['paired']);
+    expect(res.orphanedProducers).toEqual(['lonely']);
   });
 
   it('an existing producer wired to an existing consumer IS detected (the class that was never evaluated)', () => {

--- a/lib/gates/operator-contract/__tests__/wiring-detection.test.js
+++ b/lib/gates/operator-contract/__tests__/wiring-detection.test.js
@@ -89,3 +89,45 @@ describe('totality — a throw here fails OPEN through the adapter catch', () =>
     }
   });
 });
+
+describe('surviving mutants from TESTING bc7f73bc — verb and path classification', () => {
+  // MUTANT F: reclassifying upsert/update as READS survived, because every fixture used only
+  // .insert and .select. The write set is the half that creates orphans, so a verb silently
+  // moving to the read side would erase orphans wholesale.
+  it.each(['insert', 'upsert', 'update'])('%s is a WRITE (an orphan when unread)', (verb) => {
+    const res = detectWiring({ changedFiles: [{ path: 'lib/p.js', added: `await supabase.from('t').${verb}(row)` }] });
+    expect(res.orphanedProducers).toEqual(['t']);
+  });
+
+  it.each(['select', 'maybeSingle', 'single'])('%s is a READ (never an orphan on its own)', (verb) => {
+    const res = detectWiring({ changedFiles: [{ path: 'lib/c.js', added: `await supabase.from('t').${verb}('*')` }] });
+    expect(res.orphanedProducers).toEqual([]);
+    expect(res.wired).toBe(false);
+  });
+
+  it('upsert paired with a read is WIRED, not orphaned', () => {
+    const res = detectWiring({ changedFiles: [
+      { path: 'lib/p.js', added: "await supabase.from('t').upsert(row)" },
+      { path: 'lib/c.js', added: "await supabase.from('t').select('*')" },
+    ] });
+    expect(res.wired).toBe(true);
+    expect(res.orphanedProducers).toEqual([]);
+  });
+
+  // MUTANT G: only the `\.test\.` alternative of the test-path pattern was exercised, so
+  // dropping __tests__/ and /tests/ from the exclusion survived. A test file counting as a
+  // consumer is exactly how a wiring gets falsely cleared.
+  it.each([
+    'lib/__tests__/x.js',
+    'tests/unit/x.js',
+    'lib/x.test.js',
+    'lib/x.spec.js',
+  ])('%s never counts as a consumer', (path) => {
+    const res = detectWiring({ changedFiles: [
+      { path: 'lib/p.js', added: "await supabase.from('t').insert(row)" },
+      { path, added: "await supabase.from('t').select('*')" },
+    ] });
+    expect(res.wired).toBe(false);
+    expect(res.orphanedProducers).toEqual(['t']); // still an orphan — the test is not the reader
+  });
+});

--- a/lib/gates/operator-contract/harness-adapter.js
+++ b/lib/gates/operator-contract/harness-adapter.js
@@ -13,7 +13,7 @@
  * unambiguous CREATOR-without-triple-and-no-valid-waiver produces a hard block.
  */
 import { execSync } from 'node:child_process';
-import { evaluateOperatorContract, detectCreator, validateConsumer, validateCadence, validateReaper } from './index.js';
+import { evaluateOperatorContract, detectCreator, validateConsumer, detectWiring, validateCadence, validateReaper } from './index.js';
 import { RETENTION_POLICIES, SOAK_ENTRIES } from '../../retention/policies.js';
 
 /**
@@ -95,13 +95,57 @@ export function collectSdDiff({ appPath, baseRef = 'origin/main' } = {}) {
  * @param {Date} [opts.now]
  * @returns {Promise<{verdict, reason, missing, creator, waiver_audit}>}
  */
-export async function resolveOperatorContract({ sd, appPath, supabase, now = new Date() }) {
-  const { changedFiles, migrations, createdTables } = collectSdDiff({ appPath });
+export async function resolveOperatorContract({ sd, appPath, supabase, now = new Date(), diff }) {
+  // `diff` is an injectable seam (tests only; default reproduces prior behaviour EXACTLY).
+  // Without it the hole-B arming below is untestable: collectSdDiff shells out to git, so a test
+  // can only reach the pure detectWiring — and a mutation that stops the ADAPTER from calling it
+  // leaves every such test green. That is the unit-tests-the-function-but-not-the-wiring class,
+  // which is the very defect this SD exists to catch; it reproduced here during EXEC.
+  const { changedFiles, migrations, createdTables } = diff || collectSdDiff({ appPath });
   const creator = detectCreator({ changedFiles, migrations });
 
-  // Short-circuit: non-CREATOR → no-op pass (no DB reads needed).
+  // HOLE B (SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001): this short-circuit used to be
+  // unconditional, so a change that CREATES nothing was never evaluated — and "wire an EXISTING
+  // producer to an EXISTING consumer" is this SD's entire target class. Corpus #7 is that exact
+  // shape: an existing sweep writing an existing receipt that nothing reads.
+  //
+  // WARN-FIRST by deliberate choice. Arming on wiring widens the evaluated population sharply,
+  // so the default routes findings to `warnings` and does NOT block; ENFORCE_CONSUMER_CITATION=1
+  // promotes it. The flag is a distinct key rather than gate.required, because flipping
+  // gate.required here would de-fang the three already-blocking triple checks as collateral.
   if (!creator.is_creator) {
-    return evaluateOperatorContract({ creator, triple: {}, now });
+    const wiring = detectWiring({ changedFiles });
+    if (!wiring.wired) {
+      return evaluateOperatorContract({ creator, triple: {}, now });
+    }
+    // `?? []` IS THE LOAD-BEARING PART, and passing the raw value through was a real defect the
+    // adapter tests caught: `undefined` routes validateConsumer to its LEGACY heuristic, which
+    // answers "is there a read-path in this diff?" — the very bit detectWiring just used to
+    // declare the wiring. Verifier and detector would read ONE signal, so the check could never
+    // disagree with the thing it was checking, and every wired SD would self-certify. `[]` means
+    // "asserts absence", forcing the citation contract: a file:line an operator actually observed.
+    const consumerCheck = validateConsumer({
+      changedFiles,
+      createdTables: wiring.tables,
+      consumerEvidence: sd?.metadata?.consumer_evidence ?? [],
+      producerFiles: wiring.producerFiles,
+    });
+    const enforced = process.env.ENFORCE_CONSUMER_CITATION === '1';
+    const base = evaluateOperatorContract({ creator, triple: {}, now });
+    const note = consumerCheck.consumer_present
+      ? `consumer citation verified for wired table(s) ${wiring.tables.join(', ')}`
+      : `WIRING DETECTED (${wiring.tables.join(', ')}) with no consumer-side citation: ${consumerCheck.issues.join('; ') || 'no evidence supplied'}`;
+    return {
+      ...base,
+      // Never silent in either mode — an unenforced finding still has to be visible, or this
+      // repeats the decorative-arm failure the SD exists to stop.
+      warnings: [...(base.warnings || []), ...(consumerCheck.consumer_present ? [] : [`[consumer-citation${enforced ? '' : ' advisory'}] ${note}`])],
+      wiring_detected: true,
+      wiring_tables: wiring.tables,
+      wiring_miss_classes: wiring.miss_classes,
+      consumer_citation: { present: consumerCheck.consumer_present, enforced, issues: consumerCheck.issues, accepted: consumerCheck.accepted_citations || [] },
+      ...(enforced && !consumerCheck.consumer_present ? { verdict: 'FAIL', reason: 'CONSUMER_CITATION_MISSING' } : {}),
+    };
   }
 
   const consumer = validateConsumer({ changedFiles, createdTables });

--- a/lib/gates/operator-contract/harness-adapter.js
+++ b/lib/gates/operator-contract/harness-adapter.js
@@ -198,7 +198,7 @@ export async function resolveOperatorContract({ sd, appPath, supabase, now = new
  * @param {Object} sd
  * @param {string} appPath
  */
-export function createOperatorContractGate(supabase, sd, appPath) {
+export function createOperatorContractGate(supabase, sd, appPath, { diff } = {}) {
   return {
     name: 'OPERATOR_CONTRACT',
     required: true,
@@ -210,7 +210,10 @@ export function createOperatorContractGate(supabase, sd, appPath) {
 
       let audited = false;
       try {
-        const result = await resolveOperatorContract({ sd: targetSd, appPath: repoPath, supabase });
+        // `diff` is the same test-only seam resolveOperatorContract exposes, threaded one layer
+        // up. Without it the gate-factory output layer is only reachable through git, which is
+        // why it shipped with no behavioural coverage and lost the warnings channel unnoticed.
+        const result = await resolveOperatorContract({ sd: targetSd, appPath: repoPath, supabase, diff });
 
         // Audit-log a valid waiver application (FR-6) — best-effort, non-blocking.
         if (result.waiver_audit) {
@@ -224,15 +227,71 @@ export function createOperatorContractGate(supabase, sd, appPath) {
         }
 
         if (result.verdict === 'pass') {
-          console.log(`   ✅ ${result.reason}`);
+          // D1 (TESTING bc7f73bc): this used to OVERWRITE warnings with the waived-missing list,
+          // so every consumer-citation advisory the arm produced was built and thrown away. The
+          // gate returned warnings:[] and reason NOT_APPLICABLE for a diff it HAD evaluated and
+          // HAD found an orphan in — the arm was invisible in its own shipped default. Measured
+          // on this SD's own branch, which arms and would have reported NOT_APPLICABLE: the arm
+          // silently passing its own demonstration case, one layer above where 9640b3b1 fixed
+          // exactly that. The warnings channel is real and consumed (BaseExecutor -> handoff
+          // record -> ContentBuilder known_issues); nothing was missing but the wiring.
+          const warnings = [
+            ...(result.missing?.length ? [`waived missing: ${result.missing.join(', ')}`] : []),
+            ...(result.warnings || []),
+          ];
+          // A verdict that says NOT_APPLICABLE about a diff it evaluated is a false statement,
+          // not merely a terse one.
+          const reason = result.wiring_detected
+            ? `OPERATOR_CONTRACT_EVALUATED (non-CREATOR wiring): ${result.consumer_citation?.present ? 'consumer citation verified' : 'advisory raised'}`
+            : result.reason;
+          if (result.wiring_detected) {
+            console.log(`   ⚠️  ${reason}`);
+            for (const w of result.warnings || []) console.log(`      ${w}`);
+          } else {
+            console.log(`   ✅ ${reason}`);
+          }
           return {
             passed: true, score: 100, max_score: 100, issues: [],
-            warnings: result.missing?.length ? [`waived missing: ${result.missing.join(', ')}`] : [],
-            details: { reason: result.reason, missing: result.missing, waiver_audited: audited },
+            warnings,
+            details: {
+              reason, missing: result.missing, waiver_audited: audited,
+              wiring_detected: result.wiring_detected,
+              wiring_tables: result.wiring_tables,
+              orphaned_producers: result.orphaned_producers,
+              consumer_citation: result.consumer_citation,
+              wiring_miss_classes: result.wiring_miss_classes,
+            },
           };
         }
 
         console.log(`   ❌ ${result.reason}`);
+        // D2 (TESTING bc7f73bc): the triple/waiver text below cannot resolve a
+        // CONSUMER_CITATION_MISSING block — neither shipping a triple nor attaching a waiver
+        // touches it. A gate that names the wrong remedy trains people to bypass it.
+        if (result.reason === 'CONSUMER_CITATION_MISSING') {
+          const target = (result.orphaned_producers?.length ? result.orphaned_producers : result.wiring_tables) || [];
+          console.log(`   This change writes ${target.join(', ')} and nothing here reads it.`);
+          console.log('   NAME THE READER in the SD\'s metadata.consumer_evidence:');
+          console.log('     [{ "consumer": "path/to/reader.js:LINE",');
+          console.log('        "observed_read": "what you actually saw — e.g. select returned 14 rows",');
+          console.log('        "artifact": "query_result" }]');
+          console.log('   The reader may live OUTSIDE this diff (that is the normal case here).');
+          console.log('   It must NOT be a test file, and must NOT be the producer — producer-side');
+          console.log('   proof that the write HAPPENED is exactly what this gate exists to refuse.');
+          return {
+            passed: false, score: 0, max_score: 100,
+            issues: [result.reason],
+            warnings: result.warnings || [],
+            details: {
+              reason: result.reason,
+              wiring_tables: result.wiring_tables,
+              orphaned_producers: result.orphaned_producers,
+              consumer_citation: result.consumer_citation,
+              wiring_miss_classes: result.wiring_miss_classes,
+              remedy_field: 'metadata.consumer_evidence',
+            },
+          };
+        }
         console.log('   A CREATOR (new table/writer/flag/detector) must ship its OPERATOR TRIPLE:');
         console.log('     • CONSUMER — code that acts on the created output');
         console.log('     • ARMED CADENCE — a periodic_process_registry cron (not a bare CLI / off-by-default flag)');

--- a/lib/gates/operator-contract/harness-adapter.js
+++ b/lib/gates/operator-contract/harness-adapter.js
@@ -115,7 +115,12 @@ export async function resolveOperatorContract({ sd, appPath, supabase, now = new
   // gate.required here would de-fang the three already-blocking triple checks as collateral.
   if (!creator.is_creator) {
     const wiring = detectWiring({ changedFiles });
-    if (!wiring.wired) {
+    // ORPHANS ARE THE POINT. Arming only on `wired` meant a producer with NO consumer — the
+    // corpus #7 shape, and the whole reason this SD exists — returned a silent pass. Measured
+    // before this line changed: verdict `pass`, warnings []. The demonstration case walked
+    // straight through its own arm.
+    const orphans = wiring.orphanedProducers || [];
+    if (!wiring.wired && orphans.length === 0) {
       return evaluateOperatorContract({ creator, triple: {}, now });
     }
     // `?? []` IS THE LOAD-BEARING PART, and passing the raw value through was a real defect the
@@ -124,17 +129,24 @@ export async function resolveOperatorContract({ sd, appPath, supabase, now = new
     // declare the wiring. Verifier and detector would read ONE signal, so the check could never
     // disagree with the thing it was checking, and every wired SD would self-certify. `[]` means
     // "asserts absence", forcing the citation contract: a file:line an operator actually observed.
+    const armedTables = [...new Set([...wiring.tables, ...orphans])];
     const consumerCheck = validateConsumer({
       changedFiles,
-      createdTables: wiring.tables,
+      createdTables: armedTables,
       consumerEvidence: sd?.metadata?.consumer_evidence ?? [],
-      producerFiles: wiring.producerFiles,
+      producerFiles: [...new Set([...wiring.producerFiles, ...(wiring.orphanProducerFiles || [])])],
+      // An orphan's reader is outside the diff by definition; requiring it inside would make the
+      // arm unsatisfiable. Only relaxed when an orphan is actually present.
+      allowOutOfDiffConsumer: orphans.length > 0,
     });
     const enforced = process.env.ENFORCE_CONSUMER_CITATION === '1';
     const base = evaluateOperatorContract({ creator, triple: {}, now });
+    const shape = orphans.length > 0
+      ? `ORPHANED PRODUCER (${orphans.join(', ')}) — written here, read by nothing in this change`
+      : `WIRING DETECTED (${wiring.tables.join(', ')})`;
     const note = consumerCheck.consumer_present
-      ? `consumer citation verified for wired table(s) ${wiring.tables.join(', ')}`
-      : `WIRING DETECTED (${wiring.tables.join(', ')}) with no consumer-side citation: ${consumerCheck.issues.join('; ') || 'no evidence supplied'}`;
+      ? `consumer citation verified for ${armedTables.join(', ')}`
+      : `${shape} with no consumer-side citation: ${consumerCheck.issues.join('; ') || 'no evidence supplied'}`;
     return {
       ...base,
       // Never silent in either mode — an unenforced finding still has to be visible, or this
@@ -142,6 +154,7 @@ export async function resolveOperatorContract({ sd, appPath, supabase, now = new
       warnings: [...(base.warnings || []), ...(consumerCheck.consumer_present ? [] : [`[consumer-citation${enforced ? '' : ' advisory'}] ${note}`])],
       wiring_detected: true,
       wiring_tables: wiring.tables,
+      orphaned_producers: orphans,
       wiring_miss_classes: wiring.miss_classes,
       consumer_citation: { present: consumerCheck.consumer_present, enforced, issues: consumerCheck.issues, accepted: consumerCheck.accepted_citations || [] },
       ...(enforced && !consumerCheck.consumer_present ? { verdict: 'FAIL', reason: 'CONSUMER_CITATION_MISSING' } : {}),

--- a/lib/gates/operator-contract/harness-adapter.js
+++ b/lib/gates/operator-contract/harness-adapter.js
@@ -27,7 +27,7 @@ import { RETENTION_POLICIES, SOAK_ENTRIES } from '../../retention/policies.js';
  */
 export function collectSdDiff({ appPath, baseRef = 'origin/main' } = {}) {
   // SEC-4b (SECURITY row 778f9a78): execSync's default maxBuffer is 1 MiB, and the per-file
-  // catch below was EMPTY. A real `.from('x').insert()` line inside a patch of 1,789,084 bytes
+  // catch below was EMPTY. A real `.from('x').insert()` line inside a patch of 1,789,084 bytes  schema-lint-disable-line
   // produced ENOBUFS, was swallowed, and left added='' — so the line was invisible. The same
   // swallow blinds the three PRE-EXISTING blocking triple checks: a CREATE TABLE in a >1 MiB
   // migration is invisible to detectCreator. Raised, and truncation is now recorded rather than

--- a/lib/gates/operator-contract/harness-adapter.js
+++ b/lib/gates/operator-contract/harness-adapter.js
@@ -23,7 +23,7 @@ import { RETENTION_POLICIES, SOAK_ENTRIES } from '../../retention/policies.js';
  * @param {Object} opts
  * @param {string} opts.appPath - repo root to run git in
  * @param {string} [opts.baseRef='origin/main']
- * @returns {{changedFiles: Array<{path,added}>, migrations: Array<{path,sql}>, createdTables: string[]}}
+ * @returns {{changedFiles: Array<{path,added}>, migrations: Array<{path,sql}>, createdTables: string[], unreadable: Array<{path,error}>}}
  */
 export function collectSdDiff({ appPath, baseRef = 'origin/main' } = {}) {
   // SEC-4b (SECURITY row 778f9a78): execSync's default maxBuffer is 1 MiB, and the per-file
@@ -114,7 +114,12 @@ export async function resolveOperatorContract({ sd, appPath, supabase, now = new
   // can only reach the pure detectWiring — and a mutation that stops the ADAPTER from calling it
   // leaves every such test green. That is the unit-tests-the-function-but-not-the-wiring class,
   // which is the very defect this SD exists to catch; it reproduced here during EXEC.
-  const { changedFiles, migrations, createdTables } = diff || collectSdDiff({ appPath });
+  // `unreadable` IS DESTRUCTURED, and that is not incidental. VALIDATION and REGRESSION both
+  // caught that it had ZERO readers — a produced output nothing consumes, corpus n=12's exact
+  // shape, shipped inside the arm built to detect it. The SEC-4b comment claimed "named, not
+  // swallowed" while the name reached no consumer, which is an assertion layer stating what it
+  // never measured. It now reaches the verdict on every path below.
+  const { changedFiles, migrations, createdTables, unreadable = [] } = diff || collectSdDiff({ appPath });
   const creator = detectCreator({ changedFiles, migrations });
 
   // HOLE B (SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001): this short-circuit used to be
@@ -134,7 +139,16 @@ export async function resolveOperatorContract({ sd, appPath, supabase, now = new
     // straight through its own arm.
     const orphans = wiring.orphanedProducers || [];
     if (!wiring.wired && orphans.length === 0) {
-      return evaluateOperatorContract({ creator, triple: {}, now });
+      // The miss classes must ride on THIS verdict above all others. VALIDATION (72db4226)
+      // falsified the claim that they ride on every one: this early return dropped them, so on
+      // the single path where `wired:false` could be misread as "verified unwired" — the exact
+      // misreading the list exists to prevent — the list was absent. Same shape as the D1 defect
+      // one layer down, and found the same way: by someone checking at the consumer.
+      return {
+        ...evaluateOperatorContract({ creator, triple: {}, now }),
+        wiring_miss_classes: wiring.miss_classes,
+        unreadable_files: unreadable,
+      };
     }
     // `?? []` IS THE LOAD-BEARING PART, and passing the raw value through was a real defect the
     // adapter tests caught: `undefined` routes validateConsumer to its LEGACY heuristic, which
@@ -168,13 +182,37 @@ export async function resolveOperatorContract({ sd, appPath, supabase, now = new
       wiring_detected: true,
       wiring_tables: wiring.tables,
       orphaned_producers: orphans,
+      unreadable_files: unreadable,
       wiring_miss_classes: wiring.miss_classes,
       consumer_citation: { present: consumerCheck.consumer_present, enforced, issues: consumerCheck.issues, accepted: consumerCheck.accepted_citations || [] },
       ...(enforced && !consumerCheck.consumer_present ? { verdict: 'FAIL', reason: 'CONSUMER_CITATION_MISSING' } : {}),
     };
   }
 
-  const consumer = validateConsumer({ changedFiles, createdTables });
+  // BLOCKING REGRESSION, found independently by VALIDATION (72db4226) and REGRESSION (a54189e3)
+  // and measured end-to-end by both: closing hole A made the CONSUMER leg UNSATISFIABLE on the
+  // blocking creator path whenever createdTables is empty — i.e. every FLAG and DETECTOR creator.
+  // Base pushed "contains a read-path acting on created output" for any read when there was
+  // nothing to tie it to; refusing that is right, but here it converted a false PASS into a FALSE
+  // BLOCK on a required:true gate on the shared PLAN-TO-LEAD pipeline, outside the warn-first
+  // flag. Measured: a FLAG creator that DOES ship a reader returned passed:false missing:[consumer],
+  // and a perfect metadata.consumer_evidence could not rescue it because this call did not pass it.
+  // A gate that cannot be satisfied by doing the right thing leaves a waiver as the only exit.
+  const consumer = validateConsumer({
+    changedFiles,
+    createdTables,
+    consumerEvidence: sd?.metadata?.consumer_evidence,
+    // Passing producerFiles is load-bearing, and omitting it was a hole in this very fix — the
+    // two-sided test caught the creator path ACCEPTING a citation that pointed at the writer.
+    // Making a blocked gate satisfiable is only correct if it stays unsatisfiable by the thing
+    // it exists to refuse.
+    producerFiles: changedFiles
+      .filter((f) => /\.(?:insert|upsert|update)\s*\(/.test(String(f?.added || '')))
+      .map((f) => String(f?.path || '')),
+    // A flag/detector creator's output is not a table, so the cited reader is legitimately not
+    // tied to createdTables and legitimately may sit outside the diff.
+    allowOutOfDiffConsumer: createdTables.length === 0,
+  });
 
   // Capability keys for the cadence lookup: explicit metadata list, else derived from created tables.
   const meta = sd?.metadata || {};
@@ -193,16 +231,19 @@ export async function resolveOperatorContract({ sd, appPath, supabase, now = new
 
   const reaper = validateReaper({ retentionPolicies: [...RETENTION_POLICIES, ...SOAK_ENTRIES], createdTables });
 
-  return evaluateOperatorContract({
-    creator,
-    triple: {
-      consumer_present: consumer.consumer_present,
-      cadence_armed: cadence.cadence_armed,
-      reaper_present: reaper.reaper_present,
-    },
-    waiver: meta.operator_contract_waiver || null,
-    now,
-  });
+  return {
+    ...evaluateOperatorContract({
+      creator,
+      triple: {
+        consumer_present: consumer.consumer_present,
+        cadence_armed: cadence.cadence_armed,
+        reaper_present: reaper.reaper_present,
+      },
+      waiver: meta.operator_contract_waiver || null,
+      now,
+    }),
+    unreadable_files: unreadable,
+  };
 }
 
 /**
@@ -251,6 +292,11 @@ export function createOperatorContractGate(supabase, sd, appPath, { diff } = {})
           const warnings = [
             ...(result.missing?.length ? [`waived missing: ${result.missing.join(', ')}`] : []),
             ...(result.warnings || []),
+            // A file this run could not read is a KNOWN BLIND SPOT and must be visible, or the
+            // verdict silently means less than it appears to.
+            ...(result.unreadable_files?.length
+              ? [`operator-contract could not read ${result.unreadable_files.length} changed file(s) — verdict is INCOMPLETE for: ${result.unreadable_files.map((u) => u.path).join(', ')}`]
+              : []),
           ];
           // A verdict that says NOT_APPLICABLE about a diff it evaluated is a false statement,
           // not merely a terse one.

--- a/lib/gates/operator-contract/harness-adapter.js
+++ b/lib/gates/operator-contract/harness-adapter.js
@@ -26,7 +26,17 @@ import { RETENTION_POLICIES, SOAK_ENTRIES } from '../../retention/policies.js';
  * @returns {{changedFiles: Array<{path,added}>, migrations: Array<{path,sql}>, createdTables: string[]}}
  */
 export function collectSdDiff({ appPath, baseRef = 'origin/main' } = {}) {
-  const run = (cmd) => execSync(cmd, { cwd: appPath, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+  // SEC-4b (SECURITY row 778f9a78): execSync's default maxBuffer is 1 MiB, and the per-file
+  // catch below was EMPTY. A real `.from('x').insert()` line inside a patch of 1,789,084 bytes
+  // produced ENOBUFS, was swallowed, and left added='' — so the line was invisible. The same
+  // swallow blinds the three PRE-EXISTING blocking triple checks: a CREATE TABLE in a >1 MiB
+  // migration is invisible to detectCreator. Raised, and truncation is now recorded rather than
+  // silently absorbed, because "read nothing" and "read successfully, found nothing" must not
+  // look identical.
+  const run = (cmd) => execSync(cmd, {
+    cwd: appPath, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], maxBuffer: 64 * 1024 * 1024,
+  });
+  const unreadable = [];
   // merge-base diff so we only see the SD's own changes
   const nameOnly = run(`git diff --name-only ${baseRef}...HEAD`).split('\n').map((s) => s.trim()).filter(Boolean);
   const changedFiles = [];
@@ -39,7 +49,10 @@ export function collectSdDiff({ appPath, baseRef = 'origin/main' } = {}) {
       // only the added lines (leading '+', excluding the +++ header)
       const patch = run(`git diff ${baseRef}...HEAD -- "${path}"`);
       added = patch.split('\n').filter((l) => l.startsWith('+') && !l.startsWith('+++')).map((l) => l.slice(1)).join('\n');
-    } catch { /* fail-open per-file */ }
+    } catch (e) {
+      // Named, not swallowed: an unreadable file is a KNOWN BLIND SPOT for this run.
+      unreadable.push({ path, error: e?.message || String(e) });
+    }
 
     if (/\.sql$/i.test(path)) {
       migrations.push({ path, sql: added });
@@ -82,7 +95,7 @@ export function collectSdDiff({ appPath, baseRef = 'origin/main' } = {}) {
       changedFiles.push({ path, added });
     }
   }
-  return { changedFiles, migrations, createdTables: [...new Set(createdTables)] };
+  return { changedFiles, migrations, createdTables: [...new Set(createdTables)], unreadable };
 }
 
 /**
@@ -304,12 +317,34 @@ export function createOperatorContractGate(supabase, sd, appPath, { diff } = {})
           details: { reason: result.reason, missing: result.missing, creator_kinds: result.creator?.creator_kinds },
         };
       } catch (err) {
-        // FAIL-OPEN: never false-block the shared pipeline on an execution error.
+        // SEC-4 (SECURITY row 778f9a78): fail-open is right for the WARN-FIRST default and wrong
+        // under enforcement. Demonstrated: with ENFORCE_CONSUMER_CITATION=1 an orphan correctly
+        // blocks, but making git throw returns passed:true — and NO MALICE IS REQUIRED, since
+        // `git diff origin/main...HEAD` throws whenever the ref is simply absent (shallow clone,
+        // --branch clone, unfetched worktree). An enforced block a missing ref can erase is not
+        // a control.
+        //
+        // So the fail DIRECTION follows the mode: warn-first stays fail-OPEN (it must never
+        // false-block the shared PLAN-TO-LEAD pipeline every session hits), enforcement fails
+        // CLOSED (setting the flag IS opting into blocking, and "could not evaluate" must not
+        // read as "evaluated and fine").
+        const enforced = process.env.ENFORCE_CONSUMER_CITATION === '1';
+        if (enforced) {
+          console.log(`   ❌ UNEVALUABLE under enforcement: ${err.message}`);
+          console.log('   Enforcement fails CLOSED — an error is not a pass. Fetch origin/main');
+          console.log('   (a shallow or --branch clone cannot compute the merge-base diff).');
+          return {
+            passed: false, score: 0, max_score: 100,
+            issues: ['OPERATOR_CONTRACT_UNEVALUABLE'],
+            warnings: [],
+            details: { fail_open: false, enforced: true, error: err.message },
+          };
+        }
         console.log(`   ⚠️  fail-open (execution error): ${err.message}`);
         return {
           passed: true, score: 100, max_score: 100, issues: [],
           warnings: [`operator-contract gate fail-open: ${err.message}`],
-          details: { fail_open: true, error: err.message },
+          details: { fail_open: true, enforced: false, error: err.message },
         };
       }
     },

--- a/lib/gates/operator-contract/index.js
+++ b/lib/gates/operator-contract/index.js
@@ -106,6 +106,50 @@ export function detectCreator({ changedFiles = [], migrations = [] } = {}) {
  * @param {string[]} [input.createdTables] - table names the SD creates (from migrations)
  * @returns {{consumer_present: boolean, evidence: string[]}}
  */
+/**
+ * SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001, HOLE B — detect a producer->consumer WIRING in a
+ * change that creates nothing new.
+ *
+ * resolveOperatorContract short-circuits to a no-op pass when detectCreator() does not fire, so
+ * the entire target class of this SD — wiring an EXISTING producer to an EXISTING consumer — was
+ * never evaluated. Corpus #7 is exactly that shape: a sweep that already existed, writing a
+ * receipt that already existed, with no reader.
+ *
+ * PURE and INTENTIONALLY NARROW. It reports what it can see and nothing more:
+ *   MISS CLASSES (FR-4, stated honestly, never claimed complete)
+ *   - a consumer reached by dynamic dispatch, config indirection, or a registry lookup
+ *   - a producer/consumer split across repos (the reader lives in the venture app)
+ *   - a wiring expressed only in prose (evaluateTrigger reads SD text; this reads the diff)
+ *   - a write and read of the same value under different names (aliasing)
+ * A wiring this cannot see is a MISS, not a pass — callers must not read `false` as "verified
+ * unwired".
+ */
+export function detectWiring({ changedFiles = [] } = {}) {
+  const files = Array.isArray(changedFiles) ? changedFiles : [];
+  const isTestPath = (p) => /(?:\.test\.|\.spec\.|__tests__\/|\/tests\/)/.test(p);
+  const writes = new Map(); // table -> [paths]
+  const reads = new Map();
+  for (const f of files) {
+    const path = String(f?.path || '');
+    const added = String(f?.added || '');
+    if (isTestPath(path)) continue;
+    for (const m of added.matchAll(/\.from\(\s*['"`]([\w.]+)['"`]\s*\)\s*\.\s*(insert|upsert|update|select|maybeSingle|single)\s*\(/g)) {
+      const [, table, verb] = m;
+      const bucket = /^(insert|upsert|update)$/.test(verb) ? writes : reads;
+      if (!bucket.has(table)) bucket.set(table, []);
+      bucket.get(table).push(path);
+    }
+  }
+  const wiredTables = [...writes.keys()].filter((t) => reads.has(t));
+  return {
+    wired: wiredTables.length > 0,
+    tables: wiredTables,
+    producerFiles: [...new Set(wiredTables.flatMap((t) => writes.get(t)))],
+    consumerFiles: [...new Set(wiredTables.flatMap((t) => reads.get(t)))],
+    miss_classes: ['dynamic_dispatch', 'config_indirection', 'cross_repo_consumer', 'prose_only_wiring', 'aliased_value'],
+  };
+}
+
 export function validateConsumer({ changedFiles = [], createdTables = [], consumerEvidence, producerFiles = [] } = {}) {
   const evidence = [];
   const issues = [];

--- a/lib/gates/operator-contract/index.js
+++ b/lib/gates/operator-contract/index.js
@@ -59,7 +59,22 @@ export function detectCreator({ changedFiles = [], migrations = [] } = {}) {
 
   for (const f of changedFiles) {
     const path = String(f?.path || '');
-    const added = String(f?.added || '');
+    // IT SCANS COMMENT PROSE — the identical defect collectSdDiff already fixed for SQL, and the
+    // note there applies verbatim: "the file that documents itself most carefully is punished
+    // hardest, which is backwards."
+    //
+    // Demonstrated on this very SD, twice over. The FLAG rule is a WHOLE-TEXT conjunction
+    // (mentions leo_feature_flags AND contains an insert call), so the COMMENT I wrote to explain
+    // the previous false positive contained both halves and re-triggered it — this file's own
+    // explanation of the bug WAS the bug. Its PLAN-TO-LEAD then blocked demanding an armed cadence
+    // and a reaper for a flag that exists only inside a sentence.
+    //
+    // Best-effort strip, matching the SQL precedent: a mention inside a comment is never a
+    // creation, and a creator-shaped string in prose is exactly what documentation looks like.
+    const added = String(f?.added || '')
+      .replace(/\/\*[\s\S]*?\*\//g, ' ')  // block comments (may be partial in an added-lines slice)
+      .replace(/^\s*\*.*$/gm, ' ')        // continuation lines of a JSDoc block the slice cut open
+      .replace(/\/\/[^\n]*/g, ' ');       // line comments — where both false positives came from
     if (!/\.(?:js|cjs|mjs|ts)$/.test(path)) continue;
     // A TEST FIXTURE IS NOT A CREATOR. detectWiring and validateConsumer both exclude test
     // paths; detectCreator did not — an asymmetry REGRESSION (a54189e3) flagged and this SD then

--- a/lib/gates/operator-contract/index.js
+++ b/lib/gates/operator-contract/index.js
@@ -189,7 +189,29 @@ export function validateConsumer({ changedFiles = [], createdTables = [], consum
   const issues = [];
   const files = Array.isArray(changedFiles) ? changedFiles : [];
   const tables = Array.isArray(createdTables) ? createdTables : [];
+  // SEC-3 (SECURITY row 778f9a78): the producer refusal — this gate's CENTRAL claim — was an
+  // exact string compare, and SIX spellings walked past it while `lib/producer.js:9` correctly
+  // blocked: `./lib/producer.js`, `lib/./producer.js`, `lib//producer.js`, `LIB/PRODUCER.JS`,
+  // `lib\producer.js`, `lib/x/../producer.js`. Confirmed at gate level under ENFORCE=1 as
+  // passed:true "consumer citation verified". The case variant is not academic — the harness
+  // runs on Windows, where those name the same file.
+  //
+  // Case-folding ALWAYS (not just on win32) is deliberate: this list drives a REJECTION, so
+  // over-matching rejects more citations, which is the safe direction. A gate whose refusal can
+  // be spelled around is the "check a caller can satisfy without changing the harm" shape this
+  // SD exists to abolish — shipping it here would be self-refuting.
+  const normalizePath = (p) => {
+    const parts = String(p || '').replace(/\\/g, '/').split('/');
+    const out = [];
+    for (const seg of parts) {
+      if (seg === '' || seg === '.') continue;
+      if (seg === '..') { out.pop(); continue; }
+      out.push(seg);
+    }
+    return out.join('/').toLowerCase();
+  };
   const producers = Array.isArray(producerFiles) ? producerFiles.map((p) => String(p || '')) : [];
+  const producerKeys = new Set(producers.map(normalizePath));
   // `/tests/` REQUIRED A LEADING SLASH, so `tests/unit/x.js` — the repo-root-relative form git
   // diff actually emits, and the commonest shape in this repo — did NOT match. A test file was
   // therefore counted as a real consumer and could falsely clear a wiring. Found by the mutant-G
@@ -251,12 +273,15 @@ export function validateConsumer({ changedFiles = [], createdTables = [], consum
     if (!m) { issues.push(`citation "${site || String(site)}" is not path/to/file.js:LINE — a bare filename is not a citation`); continue; }
     const citedPath = m[1];
     if (!read) { issues.push(`citation ${site} names a location but no observed read — a location is not an observation`); continue; }
-    if (isTestPath(citedPath)) { issues.push(`citation ${site} points at a test file — a test is not the consumer`); continue; }
-    if (producers.includes(citedPath)) { issues.push(`citation ${site} points at the PRODUCER — a producer-side artifact is not consumer evidence`); continue; }
+    // Normalise BEFORE both checks — a `./` prefix or a backslash separator must not buy a pass
+    // through either the test-file refusal or the producer refusal.
+    const citedKey = normalizePath(citedPath);
+    if (isTestPath(citedPath) || isTestPath(citedKey)) { issues.push(`citation ${site} points at a test file — a test is not the consumer`); continue; }
+    if (producerKeys.has(citedKey)) { issues.push(`citation ${site} points at the PRODUCER — a producer-side artifact is not consumer evidence`); continue; }
     // The in-diff rule is correct for a paired wiring and WRONG for an orphaned producer, whose
     // reader is by definition outside the diff. Applying it there would make the orphan arm
     // unsatisfiable — a gate nobody can pass gets bypassed, not obeyed.
-    const inDiff = files.some((f) => String(f?.path || '') === citedPath);
+    const inDiff = files.some((f) => normalizePath(f?.path) === citedKey);
     if (!inDiff && !allowOutOfDiffConsumer) {
       issues.push(`citation ${site} names a file absent from this change — the cited consumer must be in the diff`); continue;
     }

--- a/lib/gates/operator-contract/index.js
+++ b/lib/gates/operator-contract/index.js
@@ -141,16 +141,34 @@ export function detectWiring({ changedFiles = [] } = {}) {
     }
   }
   const wiredTables = [...writes.keys()].filter((t) => reads.has(t));
+
+  // ORPHANED PRODUCERS — a table WRITTEN in this diff that NOTHING in this diff reads.
+  //
+  // This is the corpus #7 shape and it is the half that actually matters. The paired-wiring
+  // check above only fires when a consumer EXISTS; a producer with NO consumer sailed straight
+  // through it. Measured on the real shape before this was added: verdict `pass`, wiring
+  // undefined, warnings []. The arm silently passed its own demonstration case — and the test
+  // comment asserting that was "precisely the finding, not a miss" was a rationalisation, which
+  // is the same explain-away that let corpus #7 survive a ratified completion in the first place.
+  //
+  // FALSE-POSITIVE SHAPE, stated plainly: a write whose readers live OUTSIDE the diff lands here
+  // too. That is why the arm is warn-first, and why the citation for an orphan is allowed to name
+  // a file the diff does not contain — the ask is "name the reader", and an existing reader is a
+  // perfectly good answer. An orphan nobody can cite a reader for IS corpus #7.
+  const orphanedTables = [...writes.keys()].filter((t) => !reads.has(t));
+
   return {
     wired: wiredTables.length > 0,
     tables: wiredTables,
+    orphanedProducers: orphanedTables,
+    orphanProducerFiles: [...new Set(orphanedTables.flatMap((t) => writes.get(t)))],
     producerFiles: [...new Set(wiredTables.flatMap((t) => writes.get(t)))],
     consumerFiles: [...new Set(wiredTables.flatMap((t) => reads.get(t)))],
     miss_classes: ['dynamic_dispatch', 'config_indirection', 'cross_repo_consumer', 'prose_only_wiring', 'aliased_value'],
   };
 }
 
-export function validateConsumer({ changedFiles = [], createdTables = [], consumerEvidence, producerFiles = [] } = {}) {
+export function validateConsumer({ changedFiles = [], createdTables = [], consumerEvidence, producerFiles = [], allowOutOfDiffConsumer = false } = {}) {
   const evidence = [];
   const issues = [];
   const files = Array.isArray(changedFiles) ? changedFiles : [];
@@ -215,11 +233,17 @@ export function validateConsumer({ changedFiles = [], createdTables = [], consum
     if (!read) { issues.push(`citation ${site} names a location but no observed read — a location is not an observation`); continue; }
     if (isTestPath(citedPath)) { issues.push(`citation ${site} points at a test file — a test is not the consumer`); continue; }
     if (producers.includes(citedPath)) { issues.push(`citation ${site} points at the PRODUCER — a producer-side artifact is not consumer evidence`); continue; }
-    if (!files.some((f) => String(f?.path || '') === citedPath)) {
+    // The in-diff rule is correct for a paired wiring and WRONG for an orphaned producer, whose
+    // reader is by definition outside the diff. Applying it there would make the orphan arm
+    // unsatisfiable — a gate nobody can pass gets bypassed, not obeyed.
+    const inDiff = files.some((f) => String(f?.path || '') === citedPath);
+    if (!inDiff && !allowOutOfDiffConsumer) {
       issues.push(`citation ${site} names a file absent from this change — the cited consumer must be in the diff`); continue;
     }
     accepted.push(site);
-    evidence.push(`consumer-read verified at ${site}: ${read}`);
+    // Marked inline so an out-of-diff citation is never mistaken for one this change can verify:
+    // the reader was asserted by an operator, not observed in the diff.
+    evidence.push(`consumer-read verified at ${site}${inDiff ? '' : ' (OUT-OF-DIFF, operator-asserted)'}: ${read}`);
   }
 
   return { consumer_present: accepted.length > 0, evidence, issues, citation_supplied: true, accepted_citations: accepted };

--- a/lib/gates/operator-contract/index.js
+++ b/lib/gates/operator-contract/index.js
@@ -196,7 +196,7 @@ export function detectWiring({ changedFiles = [] } = {}) {
     // named is scope, a miss class hidden is a defect — and this list is what stops `wired:false`
     // from being read as "verified unwired".
     //   rpc_indirection      — 445 live .rpc() sites are wholly invisible to a .from() scan
-    //   builder_variable_split — const q = supabase.from('t'); q.insert(r)  (literal table, still missed)
+    //   builder_variable_split — const q = supabase.from('t'); q.insert(r)  (literal table, still missed)  schema-lint-disable-line
     //   comment_interposition  — a comment between .from() and the verb defeats the regex, and
     //                            that idiom is in live code (roadmap-status-doc, ownership-detection,
     //                            claim-validity-gate, critical-qf-jump)

--- a/lib/gates/operator-contract/index.js
+++ b/lib/gates/operator-contract/index.js
@@ -61,6 +61,14 @@ export function detectCreator({ changedFiles = [], migrations = [] } = {}) {
     const path = String(f?.path || '');
     const added = String(f?.added || '');
     if (!/\.(?:js|cjs|mjs|ts)$/.test(path)) continue;
+    // A TEST FIXTURE IS NOT A CREATOR. detectWiring and validateConsumer both exclude test
+    // paths; detectCreator did not — an asymmetry REGRESSION (a54189e3) flagged and this SD then
+    // demonstrated on itself: its own PLAN-TO-LEAD blocked with OPERATOR_CONTRACT_INCOMPLETE
+    // because the string "supabase.from('leo_feature_flags').insert(...)" inside a __tests__
+    // fixture was read as real flag creation. The gate demanded an armed cadence and a reaper for
+    // a flag that does not exist. Fixture text is the most likely place for creator-shaped
+    // strings to appear, so the omission fires hardest on well-tested changes.
+    if (/(?:\.test\.|\.spec\.|__tests__\/|(?:^|\/)tests\/)/.test(path)) continue;
 
     // WRITER — a CREATOR signal ONLY when the writer targets a table this SD also
     // CREATEs. Writing to an EXISTING table (audit_log, feedback, ...) is ordinary

--- a/lib/gates/operator-contract/index.js
+++ b/lib/gates/operator-contract/index.js
@@ -126,7 +126,11 @@ export function detectCreator({ changedFiles = [], migrations = [] } = {}) {
  */
 export function detectWiring({ changedFiles = [] } = {}) {
   const files = Array.isArray(changedFiles) ? changedFiles : [];
-  const isTestPath = (p) => /(?:\.test\.|\.spec\.|__tests__\/|\/tests\/)/.test(p);
+  // `/tests/` REQUIRED A LEADING SLASH, so `tests/unit/x.js` — the repo-root-relative form git
+  // diff actually emits, and the commonest shape in this repo — did NOT match. A test file was
+  // therefore counted as a real consumer and could falsely clear a wiring. Found by the mutant-G
+  // test that was written to pin the exclusion, which is the whole argument for writing it.
+  const isTestPath = (p) => /(?:\.test\.|\.spec\.|__tests__\/|(?:^|\/)tests\/)/.test(p);
   const writes = new Map(); // table -> [paths]
   const reads = new Map();
   for (const f of files) {
@@ -164,7 +168,19 @@ export function detectWiring({ changedFiles = [] } = {}) {
     orphanProducerFiles: [...new Set(orphanedTables.flatMap((t) => writes.get(t)))],
     producerFiles: [...new Set(wiredTables.flatMap((t) => writes.get(t)))],
     consumerFiles: [...new Set(wiredTables.flatMap((t) => reads.get(t)))],
-    miss_classes: ['dynamic_dispatch', 'config_indirection', 'cross_repo_consumer', 'prose_only_wiring', 'aliased_value'],
+    // The last three were MEASURED as undeclared misses by TESTING (row bc7f73bc) over 4180
+    // files / 13431 .from() sites, not guessed. Declaring them is the honest move: a miss class
+    // named is scope, a miss class hidden is a defect — and this list is what stops `wired:false`
+    // from being read as "verified unwired".
+    //   rpc_indirection      — 445 live .rpc() sites are wholly invisible to a .from() scan
+    //   builder_variable_split — const q = supabase.from('t'); q.insert(r)  (literal table, still missed)
+    //   comment_interposition  — a comment between .from() and the verb defeats the regex, and
+    //                            that idiom is in live code (roadmap-status-doc, ownership-detection,
+    //                            claim-validity-gate, critical-qf-jump)
+    miss_classes: [
+      'dynamic_dispatch', 'config_indirection', 'cross_repo_consumer', 'prose_only_wiring', 'aliased_value',
+      'rpc_indirection', 'builder_variable_split', 'comment_interposition',
+    ],
   };
 }
 
@@ -174,7 +190,11 @@ export function validateConsumer({ changedFiles = [], createdTables = [], consum
   const files = Array.isArray(changedFiles) ? changedFiles : [];
   const tables = Array.isArray(createdTables) ? createdTables : [];
   const producers = Array.isArray(producerFiles) ? producerFiles.map((p) => String(p || '')) : [];
-  const isTestPath = (p) => /(?:\.test\.|\.spec\.|__tests__\/|\/tests\/)/.test(p);
+  // `/tests/` REQUIRED A LEADING SLASH, so `tests/unit/x.js` — the repo-root-relative form git
+  // diff actually emits, and the commonest shape in this repo — did NOT match. A test file was
+  // therefore counted as a real consumer and could falsely clear a wiring. Found by the mutant-G
+  // test that was written to pin the exclusion, which is the whole argument for writing it.
+  const isTestPath = (p) => /(?:\.test\.|\.spec\.|__tests__\/|(?:^|\/)tests\/)/.test(p);
 
   // --- DIFF SIDE ------------------------------------------------------------------------
   // SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001, HOLE A: this used to push evidence reading

--- a/lib/gates/operator-contract/index.js
+++ b/lib/gates/operator-contract/index.js
@@ -106,21 +106,79 @@ export function detectCreator({ changedFiles = [], migrations = [] } = {}) {
  * @param {string[]} [input.createdTables] - table names the SD creates (from migrations)
  * @returns {{consumer_present: boolean, evidence: string[]}}
  */
-export function validateConsumer({ changedFiles = [], createdTables = [] } = {}) {
+export function validateConsumer({ changedFiles = [], createdTables = [], consumerEvidence, producerFiles = [] } = {}) {
   const evidence = [];
-  for (const f of changedFiles) {
+  const issues = [];
+  const files = Array.isArray(changedFiles) ? changedFiles : [];
+  const tables = Array.isArray(createdTables) ? createdTables : [];
+  const producers = Array.isArray(producerFiles) ? producerFiles.map((p) => String(p || '')) : [];
+  const isTestPath = (p) => /(?:\.test\.|\.spec\.|__tests__\/|\/tests\/)/.test(p);
+
+  // --- DIFF SIDE ------------------------------------------------------------------------
+  // SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001, HOLE A: this used to push evidence reading
+  // "contains a read-path acting on created output" whenever createdTables was EMPTY — i.e.
+  // for ANY read-shaped call anywhere in the diff, with nothing tying it to the produced
+  // output. That is worse than a bare boolean: the sentence ASSERTS the tie, so a reviewer
+  // reads it and believes it. With no created output there is nothing to tie to, so a read
+  // is no longer treated as consumption. (Measured: a bare `readConfig();` passed.)
+  const diffConsumers = [];
+  for (const f of files) {
     const path = String(f?.path || '');
     const added = String(f?.added || '');
-    if (/(?:\.test\.|\.spec\.|__tests__\/|\/tests\/)/.test(path)) continue; // tests are not consumers
+    if (isTestPath(path)) continue; // tests are not consumers
     const readsSomething = /\.(?:select|maybeSingle|single)\s*\(/.test(added) || /\bread[A-Z]\w*\s*\(/.test(added);
     if (!readsSomething) continue;
-    if (createdTables.length === 0) {
-      evidence.push(`consumer: ${path} contains a read-path acting on created output`);
-    } else if (createdTables.some((t) => added.includes(t))) {
-      evidence.push(`consumer: ${path} reads created table(s): ${createdTables.filter((t) => added.includes(t)).join(', ')}`);
+    const hit = tables.filter((t) => added.includes(String(t)));
+    if (hit.length > 0) {
+      diffConsumers.push(path);
+      evidence.push(`consumer: ${path} reads created table(s): ${hit.join(', ')}`);
     }
   }
-  return { consumer_present: evidence.length > 0, evidence };
+  if (tables.length === 0 && files.length > 0) {
+    issues.push('no created output to tie a consumer to — a read-shaped call alone is not consumption (hole A)');
+  }
+
+  // --- CITATION SIDE --------------------------------------------------------------------
+  // Absent consumerEvidence keeps the legacy diff-only contract (existing callers unchanged).
+  // SUPPLYING it — with any value, including a malformed one — opts into the citation
+  // contract and is validated strictly. Template: mechanism-claim-verifier.js FILE_LINE,
+  // "a bare filename is NOT a citation — the line is the proof".
+  if (consumerEvidence === undefined) {
+    return { consumer_present: evidence.length > 0, evidence, issues, citation_supplied: false };
+  }
+
+  const cites = Array.isArray(consumerEvidence) ? consumerEvidence : [];
+  if (!Array.isArray(consumerEvidence)) {
+    // Covers 'none'/'n/a'/''/true/1/{}/null and every other non-array: a presence check cannot
+    // be reused as an evidence check. real-callee-attestation.js accepts "none" BY DESIGN
+    // (presence, never content) and is working to contract; this is a CONTENT check.
+    issues.push('consumer evidence must be an array of citations, each naming a consumer site and the observed read');
+    return { consumer_present: false, evidence, issues, citation_supplied: true };
+  }
+  if (cites.length === 0) {
+    // "the field exists" is exactly the check that let "none" through next door.
+    issues.push('consumer evidence array is EMPTY — an existing field is not an observation');
+    return { consumer_present: false, evidence, issues, citation_supplied: true };
+  }
+
+  const accepted = [];
+  for (const c of cites) {
+    const site = typeof c?.consumer === 'string' ? c.consumer : '';
+    const read = typeof c?.observed_read === 'string' ? c.observed_read.trim() : '';
+    const m = /^(.+?):(\d+)$/.exec(site); // path:line — the line is the proof
+    if (!m) { issues.push(`citation "${site || String(site)}" is not path/to/file.js:LINE — a bare filename is not a citation`); continue; }
+    const citedPath = m[1];
+    if (!read) { issues.push(`citation ${site} names a location but no observed read — a location is not an observation`); continue; }
+    if (isTestPath(citedPath)) { issues.push(`citation ${site} points at a test file — a test is not the consumer`); continue; }
+    if (producers.includes(citedPath)) { issues.push(`citation ${site} points at the PRODUCER — a producer-side artifact is not consumer evidence`); continue; }
+    if (!files.some((f) => String(f?.path || '') === citedPath)) {
+      issues.push(`citation ${site} names a file absent from this change — the cited consumer must be in the diff`); continue;
+    }
+    accepted.push(site);
+    evidence.push(`consumer-read verified at ${site}: ${read}`);
+  }
+
+  return { consumer_present: accepted.length > 0, evidence, issues, citation_supplied: true, accepted_citations: accepted };
 }
 
 /**

--- a/lib/gates/operator-contract/venture-adapter.js
+++ b/lib/gates/operator-contract/venture-adapter.js
@@ -74,26 +74,35 @@ export function evaluateVentureOperatorContract({
   // single-validator design exists to prevent.
   if (!creator.is_creator) {
     const wiring = detectWiring({ changedFiles });
-    if (!wiring.wired) {
+    // Orphaned producers arm here too — a producer with no reader is the corpus #7 shape and the
+    // actual target class. See the harness adapter for the measurement that exposed this.
+    const orphans = wiring.orphanedProducers || [];
+    if (!wiring.wired && orphans.length === 0) {
       return evaluateOperatorContract({ creator, triple: {}, now });
     }
     // `?? []` forces the citation contract instead of validateConsumer's legacy diff heuristic —
     // that heuristic reads the same bit detectWiring used to declare the wiring, so it could
     // never disagree. See the harness adapter for the full note.
+    const armedTables = [...new Set([...wiring.tables, ...orphans])];
     const check = validateConsumer({
       changedFiles,
-      createdTables: wiring.tables,
+      createdTables: armedTables,
       consumerEvidence: consumerEvidence ?? [],
-      producerFiles: wiring.producerFiles,
+      producerFiles: [...new Set([...wiring.producerFiles, ...(wiring.orphanProducerFiles || [])])],
+      allowOutOfDiffConsumer: orphans.length > 0,
     });
     const base = evaluateOperatorContract({ creator, triple: {}, now });
+    const shape = orphans.length > 0
+      ? `ORPHANED PRODUCER (${orphans.join(', ')}) — written here, read by nothing in this change`
+      : `WIRING DETECTED (${wiring.tables.join(', ')})`;
     return {
       ...base,
       warnings: [...(base.warnings || []), ...(check.consumer_present ? [] : [
-        `[consumer-citation${enforceConsumerCitation ? '' : ' advisory'}] WIRING DETECTED (${wiring.tables.join(', ')}) with no consumer-side citation: ${check.issues.join('; ') || 'no evidence supplied'}`,
+        `[consumer-citation${enforceConsumerCitation ? '' : ' advisory'}] ${shape} with no consumer-side citation: ${check.issues.join('; ') || 'no evidence supplied'}`,
       ])],
       wiring_detected: true,
       wiring_tables: wiring.tables,
+      orphaned_producers: orphans,
       wiring_miss_classes: wiring.miss_classes,
       consumer_citation: { present: check.consumer_present, enforced: enforceConsumerCitation, issues: check.issues, accepted: check.accepted_citations || [] },
       ...(enforceConsumerCitation && !check.consumer_present ? { verdict: 'FAIL', reason: 'CONSUMER_CITATION_MISSING' } : {}),

--- a/lib/gates/operator-contract/venture-adapter.js
+++ b/lib/gates/operator-contract/venture-adapter.js
@@ -15,6 +15,7 @@
 import {
   detectCreator,
   validateConsumer,
+  detectWiring,
   validateCadence,
   validateReaper,
   evaluateOperatorContract,
@@ -49,6 +50,11 @@ export function evaluateVentureOperatorContract({
   capabilityKeys = [],
   waiver = null,
   now = new Date(),
+  consumerEvidence,
+  // Injected rather than read from process.env here: this evaluator is the pure venture seam and
+  // has no other ambient dependency. Default mirrors the harness adapter so one doctrine governs
+  // both — warn-first, promoted only by an explicit flag.
+  enforceConsumerCitation = process.env.ENFORCE_CONSUMER_CITATION === '1',
 } = {}) {
   const creator = detectCreator({ changedFiles, migrations });
 
@@ -61,8 +67,37 @@ export function evaluateVentureOperatorContract({
     creator.is_creator = true;
   }
 
+  // HOLE B, venture seam. Identical short-circuit to the harness adapter: a change that CREATES
+  // nothing was never evaluated, so "wire an existing producer to an existing consumer" — this
+  // SD's whole target class — passed here too. Fixing one seam and not the other would leave the
+  // shared validator with two different answers for one question, which is the duplication the
+  // single-validator design exists to prevent.
   if (!creator.is_creator) {
-    return evaluateOperatorContract({ creator, triple: {}, now });
+    const wiring = detectWiring({ changedFiles });
+    if (!wiring.wired) {
+      return evaluateOperatorContract({ creator, triple: {}, now });
+    }
+    // `?? []` forces the citation contract instead of validateConsumer's legacy diff heuristic —
+    // that heuristic reads the same bit detectWiring used to declare the wiring, so it could
+    // never disagree. See the harness adapter for the full note.
+    const check = validateConsumer({
+      changedFiles,
+      createdTables: wiring.tables,
+      consumerEvidence: consumerEvidence ?? [],
+      producerFiles: wiring.producerFiles,
+    });
+    const base = evaluateOperatorContract({ creator, triple: {}, now });
+    return {
+      ...base,
+      warnings: [...(base.warnings || []), ...(check.consumer_present ? [] : [
+        `[consumer-citation${enforceConsumerCitation ? '' : ' advisory'}] WIRING DETECTED (${wiring.tables.join(', ')}) with no consumer-side citation: ${check.issues.join('; ') || 'no evidence supplied'}`,
+      ])],
+      wiring_detected: true,
+      wiring_tables: wiring.tables,
+      wiring_miss_classes: wiring.miss_classes,
+      consumer_citation: { present: check.consumer_present, enforced: enforceConsumerCitation, issues: check.issues, accepted: check.accepted_citations || [] },
+      ...(enforceConsumerCitation && !check.consumer_present ? { verdict: 'FAIL', reason: 'CONSUMER_CITATION_MISSING' } : {}),
+    };
   }
 
   const consumer = validateConsumer({ changedFiles, createdTables });

--- a/scripts/lint/schema-reference-allowlist.json
+++ b/scripts/lint/schema-reference-allowlist.json
@@ -3,10 +3,18 @@
  "files": [
   "lib/gates/operator-contract/__tests__/operator-contract.test.js",
   "lib/gates/operator-contract/__tests__/venture-and-self-cadence.test.js",
+  "lib/gates/operator-contract/__tests__/consumer-citation.test.js",
+  "lib/gates/operator-contract/__tests__/corpus-replay.test.js",
+  "lib/gates/operator-contract/__tests__/creator-path-regression.test.js",
+  "lib/gates/operator-contract/__tests__/citation-path-spoofing.test.js",
+  "lib/gates/operator-contract/__tests__/gate-factory-output.test.js",
+  "lib/gates/operator-contract/__tests__/wiring-arming-adapter.test.js",
+  "lib/gates/operator-contract/__tests__/wiring-detection.test.js",
   "src/middleware/venture-scope.js"
  ],
  "_venture_scope_note": "SD-LEO-INFRA-ADAM-DURABLE-STANDING-001: this file has no static table references at all. validateVentureOwnership() calls .from(resourceTable) where resourceTable is a RUNTIME PARAMETER — the dynamic case this list exists for — and the only literal, supabase.from('table') at :162, is a placeholder inside a JSDoc usage example. The violation is pre-existing on origin/main (the file is byte-identical there); it surfaces only in a PR whose merge widens the diff-vs-base range to include this untouched file, so it blocks unrelated PRs at random. The inline pragma was rejected as the fix because this file's stored blob is CRLF while .gitattributes demands LF, so touching a single line renormalizes all 231 lines.",
  "_operator_contract_test_note": "SD-LEO-INFRA-OPERATOR-CONTRACT-GATE-001: these unit tests use deliberately-fictional fixture table names (foo_events, venture_signals) to exercise detectCreator/consumer/reaper against synthetic CREATOR diffs — they are not real relations.",
+ "_operator_contract_test_note_2": "SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001 extends the same escape to seven more suites in that directory, for the identical reason: this gate's whole job is to reason about supabase.from(...).insert/select STRINGS, so its fixtures must contain table-name-shaped text that is deliberately NOT a relation — 't', 'trend_eyes_receipts', 'reap_receipts', 'venture_events'. A fixture for a detector of DB references necessarily looks like a DB reference. Two flagged hits were NOT fixtures but COMMENTS (harness-adapter.js:30, index.js:199) and take the inline schema-lint-disable-line pragma instead, since allowlisting whole production files would blind the lint to real references beside the prose. Worth recording: this is the third tool in one day to read this SD's fixtures or comments as live code — detectCreator did it twice (a fixture, then the comment explaining the fixture) and both were real bugs that blocked this SD's own handoff. A linter that scans prose is a recurring shape here, not a one-off.",
  "tables": [
   "drive_reports",
   "drive_report_receipts",

--- a/scripts/materialize-verify-consumer-corpus.mjs
+++ b/scripts/materialize-verify-consumer-corpus.mjs
@@ -27,7 +27,7 @@ const SIX_FLAG = '06627c75-8279-4a6d-9d53-5b3595b002d6';
  * SD ships catches it". Conflating the two would let the replay hit rate read as a capability
  * claim. Recall is reported against this subset with the out-of-class count on the same line.
  */
-const CORPUS = [
+export const CORPUS = [
   { n: 1, source: 'alpha2_flag_six', label: 'resolver fixed, runSweep untested',
     what: 'Resolver fixed and runSweep left untested; a one-token revert restored a false all-clear with the suite green.',
     in_class: true, reason: 'A changed producer whose only caller is exercised by nothing is visible in the diff.',
@@ -113,7 +113,7 @@ const RECONCILIATION = {
   ledger_source_lost: 'The ledger itself was coordinator advisory 5cc83246, absent from all 4362 session_coordination rows (advisory-lane 24h expiry + prune). Three surviving rows reference it: 2c165276, dd408d1e, f423bb7c. The five labels were expanded from the SD own description, then traced to primary incident records.',
 };
 
-const SUMMARY = {
+export const SUMMARY = {
   total: CORPUS.length,
   in_class: inClass.length,
   out_of_class: outClass.length,
@@ -162,4 +162,10 @@ async function main() {
   console.log(`   recall rule: ${SUMMARY.recall_reporting_rule}`);
 }
 
-main().catch((e) => { console.error(`❌ ${e.message}`); process.exit(1); });
+// Guarded so importing this module for its CORPUS constant does NOT write to the database.
+// An unguarded side effect here would make a unit test a DB writer — the exact shape the
+// repo's DB-test guard exists to stop.
+import { fileURLToPath } from 'node:url';
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main().catch((e) => { console.error(`❌ ${e.message}`); process.exit(1); });
+}

--- a/scripts/materialize-verify-consumer-corpus.mjs
+++ b/scripts/materialize-verify-consumer-corpus.mjs
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+/**
+ * FR-5 — materialize the founding corpus as STRUCTURED RECORDS.
+ * SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001
+ *
+ * TESTING (row 6c9e89b9) measured that metadata.founding_corpus is a single ~200-char PROSE
+ * STRING — a pointer to a corpus, not a record of one — so FR-5 acceptance had nothing to assert
+ * against. This writes the records the acceptance criteria need, and it does NOT overwrite the
+ * prose pointer: the string stays as provenance for how the records were derived.
+ *
+ * COUNT RECONCILIATION (the reason this script exists rather than a hand-edit): the PRD says
+ * ELEVEN. The evidence says TWELVE. Instance seven (Trend-Eyes) was added by the coordinator at
+ * 20:24:28Z, AFTER the "eleven" was written at 19:41:19Z, and nobody re-reconciled the count. The
+ * coordinator's label "instance SEVEN" continues the 1-6 numbering INSIDE flag 06627c75 and skips
+ * the unnumbered ledger five — a numbering artifact, not evidence that it merges with an existing
+ * entry. Recorded here as 12 with the discrepancy explicit, because a corpus that quietly drops a
+ * member to match a stale total is the same failure this SD exists to catch.
+ */
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const SD_KEY = 'SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001';
+const SIX_FLAG = '06627c75-8279-4a6d-9d53-5b3595b002d6';
+
+/**
+ * in_class = "a diff heuristic COULD catch it" (FR-5's wording) — deliberately NOT "the arm this
+ * SD ships catches it". Conflating the two would let the replay hit rate read as a capability
+ * claim. Recall is reported against this subset with the out-of-class count on the same line.
+ */
+const CORPUS = [
+  { n: 1, source: 'alpha2_flag_six', label: 'resolver fixed, runSweep untested',
+    what: 'Resolver fixed and runSweep left untested; a one-token revert restored a false all-clear with the suite green.',
+    in_class: true, reason: 'A changed producer whose only caller is exercised by nothing is visible in the diff.',
+    evidence_id: SIX_FLAG, evidence_kind: 'feedback.completion_flag', provenance: 'measured' },
+  { n: 2, source: 'alpha2_flag_six', label: 'clamp proven at the probe, not the resolver',
+    what: 'Math.min clamp removed but proven only at the probe, never through the resolver.',
+    in_class: true, reason: 'Verification site differs from the changed site — both are in the diff.',
+    evidence_id: SIX_FLAG, evidence_kind: 'feedback.completion_flag', provenance: 'measured' },
+  { n: 3, source: 'alpha2_flag_six', label: 'return made the failure exit unreachable',
+    what: 'Probe seed leak fixed with a return, which made the exit unreachable, so a FAILED verify exited 0.',
+    in_class: true, reason: 'Unreachable code after a return is statically detectable.',
+    evidence_id: SIX_FLAG, evidence_kind: 'feedback.completion_flag', provenance: 'measured' },
+  { n: 4, source: 'alpha2_flag_six', label: 'dedup fixture never load-bearing',
+    what: 'Dedup fixture gave each finding a distinct class, so the index under test was never load-bearing.',
+    in_class: true, in_class_confidence: 'weak',
+    reason: 'Detectable in principle as a fixture whose values never collide on the key under test, but this is the hardest of the twelve to reduce to a diff rule.',
+    evidence_id: SIX_FLAG, evidence_kind: 'feedback.completion_flag', provenance: 'measured' },
+  { n: 5, source: 'alpha2_flag_six', label: 'hand-rolled main guard carried by ||',
+    what: 'Hand-rolled main guard whose || fallback silently carried it.',
+    in_class: true, reason: 'A hand-rolled entry guard is a literal, greppable pattern; the canonical isMainModule helper exists.',
+    evidence_id: SIX_FLAG, evidence_kind: 'feedback.completion_flag', provenance: 'measured' },
+  { n: 6, source: 'alpha2_flag_six', label: 'ended a turn without arming a ScheduleWakeup',
+    what: 'Alpha-2 ended a turn without arming a ScheduleWakeup after carrying the discipline fifteen passes.',
+    in_class: false, out_of_class_kind: 'turn_behaviour',
+    reason: 'Turn behaviour leaves no artifact in any diff. No diff heuristic can ever catch it.',
+    evidence_id: SIX_FLAG, evidence_kind: 'feedback.completion_flag',
+    corroborating_id: '69c2595b-dcf2-4d6f-99b9-9fea701b11ef', provenance: 'measured' },
+
+  { n: 7, source: 'ledger_five', label: 'stale classifier consumer',
+    what: 'The work-class classifier fix merged (QF-20260807-195, be4797bf) and the promised consumer check FAILED — because the shared root was 2 commits behind origin/main and still ran the OLD classifier. The fix was correct; the consumer was stale. Confirmed 29 min later: unclassified-fenced went 3 -> ZERO.',
+    in_class: false, out_of_class_kind: 'environment_staleness',
+    reason: 'The defect was in WHICH BUILD the consumer ran, not in any code property. No diff contains it. Distinct from the two turn-behaviour lapses and recorded as its own out-of-class kind rather than lumped with them.',
+    evidence_id: '0ce847f6-3886-4aab-8ad9-c2a8ab344061', evidence_kind: 'session_coordination',
+    corroborating_id: '1b889153-aafb-42d3-a4ad-d9b18be5943a', provenance: 'measured' },
+  { n: 8, source: 'ledger_five', label: 'producer no-op at its only caller',
+    what: 'drive-report-produce.mjs exited 0 with no output and drive_reports stayed at ZERO rows. On Windows the hand-rolled guard at :71 built file://C:/ (two slashes) against import.meta.url file:///C:/ (three) -> no match, main() never ran. The cron dispatch (run 31207150740) went GREEN while producing nothing.',
+    in_class: true, reason: 'Same greppable hand-rolled-entry-guard pattern as instance 5; a green caller over a producer that wrote zero rows is exactly the producer-ran-consumer-absent rung.',
+    evidence_id: 'c461eb63-a076-4e3f-ba12-25d5bf9ad2b1', evidence_kind: 'session_coordination.finding_2',
+    corroborating_id: 'QF-20260807-992', provenance: 'measured' },
+  { n: 9, source: 'ledger_five', label: 'phantom-column panel read',
+    what: 'A liveness panel verification read periodic_process_registry.liveness_verdict, which DOES NOT EXIST (PostgREST 42703). OVERDUE=0 would have concluded the panel was clean while 13 real alarms were live.',
+    in_class: true, reason: 'Column existence is checkable against the live schema; a select naming an absent column is detectable without running the panel.',
+    evidence_id: 'c461eb63-a076-4e3f-ba12-25d5bf9ad2b1', evidence_kind: 'session_coordination.finding_1', provenance: 'measured' },
+  { n: 10, source: 'ledger_five', label: 'the reap verification',
+    what: 'The reaper entry guard hand-compared import.meta.url to a file:// string and never matched on Windows: it ran, printed nothing, exited 0. A reaper whose main() never fires is indistinguishable from one that found nothing to reap. Caught only because the dry-run output was empty.',
+    in_class: true, reason: 'Same hand-rolled entry-guard pattern as 5 and 8.',
+    evidence_id: '2d950039-6057-4576-a9c8-e2592342e83c', evidence_kind: 'session_coordination',
+    corroborating_id: 'QF-20260807-190', provenance: 'measured',
+    caveat: 'The label maps to a two-incident arc (the reaper guard, and the post-delete verification of 53 __e2e_ rows which is the same event as instance 9). The ledger wording is lost, so this is the least crisply grounded of the twelve.' },
+  { n: 11, source: 'ledger_five', label: 'a dropped wakeup',
+    what: 'Bravo wrote "wakeup-armed +900s" into a reap-escalation signal and never called the ScheduleWakeup tool. The Stop hook caught it: saying wakeup armed in a /signal does NOT satisfy it.',
+    in_class: false, out_of_class_kind: 'turn_behaviour',
+    reason: 'Turn behaviour. No diff heuristic can ever catch it.',
+    evidence_id: 'c5e91feb-a875-44e5-9381-6916efdcc1c2', evidence_kind: 'session_coordination',
+    corroborating_id: 'QF-20260807-050', provenance: 'inferred',
+    provenance_note: 'ATTRIBUTION INFERRED, not documented: nobody attached an evidence id to the ledger\'s "dropped wakeup". The tie to Bravo\'s 18:07Z incident rests on clustering, timing, and the QF-050 routing note. What IS directly documented is that LEAD gate e37eae0d classified "ScheduleWakeup not armed" and "dropped wakeup" as TWO SEPARATE corpus members.' },
+
+  { n: 12, source: 'coordinator_addition', label: 'Trend-Eyes unwired alarm — THE DEMONSTRATION CASE',
+    what: 'checkTrendEyesLiveness has ZERO production callers; the receipt is written daily and NOTHING reads it.',
+    in_class: true, replay_required: true,
+    reason: 'The absent reader is statically detectable: a produced artifact with no importer.',
+    why_it_is_the_demo: 'FIRST instance to survive a RATIFIED completion — handoffs at 93/94/87/92/96, a 100-quality retro, and a six-flag completion interrogation. The SECURITY artifact even contained the words ZERO IMPORTS and no human converted it. INVOCATION_PATH_PROOF passed because it checks whether the producer RAN, while nothing asks whether the output has a READER.',
+    evidence_id: '1d0d8b6c-96af-406a-8054-b421ae170304', evidence_kind: 'session_coordination',
+    corroborating_id: 'QF-20260807-985', provenance: 'measured',
+    numbering_note: 'The coordinator called this "instance SEVEN". That continues the 1-6 numbering INSIDE flag 06627c75 and ignores the unnumbered ledger five. It is recorded here as n=12 in a single flat sequence; "corpus #7" in the PRD refers to THIS record.' },
+];
+
+const inClass = CORPUS.filter((c) => c.in_class);
+const outClass = CORPUS.filter((c) => !c.in_class);
+
+const RECONCILIATION = {
+  recorded_total: CORPUS.length,
+  prd_stated_total: 11,
+  discrepancy: 'PRD FR-5 and metadata.corpus_note both say ELEVEN. The evidence supports TWELVE (6 in-SD + 5 ledger + 1 coordinator addition).',
+  why: 'The "eleven" was written into the SD description at 2026-08-07T19:41:19Z. The coordinator added the Trend-Eyes instance at 20:24:28Z. The total was never re-reconciled.',
+  settled_by: [
+    'SD description d5c02796 wording: the ledger "adds at least five MORE" — additive to the six enumerated in the same sentence.',
+    'LEAD gate row e37eae0d classified "ScheduleWakeup not armed" AND "dropped wakeup" as TWO separate out-of-class entries, and counted 6 citable + 5 uncited = 11 with no overlap.',
+    'Two genuinely distinct dropped-wakeup incidents exist, by two different seats: Bravo 7c0540c2 at 18:07:16Z and Alpha-2 a3f4b741 at 19:09:52Z.',
+    'The other four ledger items belong to non-Alpha-2 seats, so the fleet ledger collects instances OUTSIDE Alpha-2 SD — its dropped wakeup is Bravo not Alpha-2.',
+  ],
+  evidence_id_gap_closed: 'LEAD gate e37eae0d recorded that the 5 ledger instances "carry no evidence IDs, so 5 of 11 corpus entries are currently unverifiable". Primary records were located for all five; 12 of 12 now carry a citable id. ONE attribution (n=11) is INFERRED and marked as such rather than presented as measured.',
+  ledger_source_lost: 'The ledger itself was coordinator advisory 5cc83246, absent from all 4362 session_coordination rows (advisory-lane 24h expiry + prune). Three surviving rows reference it: 2c165276, dd408d1e, f423bb7c. The five labels were expanded from the SD own description, then traced to primary incident records.',
+};
+
+const SUMMARY = {
+  total: CORPUS.length,
+  in_class: inClass.length,
+  out_of_class: outClass.length,
+  out_of_class_breakdown: { turn_behaviour: 2, environment_staleness: 1 },
+  citable_evidence_ids: CORPUS.filter((c) => c.evidence_id).length,
+  inferred_attributions: CORPUS.filter((c) => c.provenance === 'inferred').map((c) => c.n),
+  // The line FR-5 demands: a hit rate must never read as complete coverage.
+  recall_reporting_rule: `Report replay recall as "N of ${inClass.length} IN-CLASS (${outClass.length} out-of-class, not replayable)" — never as a bare "N of N".`,
+};
+
+async function main() {
+  const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+  const { data: sd, error: readErr } = await supabase
+    .from('strategic_directives_v2').select('id, metadata').eq('sd_key', SD_KEY).maybeSingle();
+  if (readErr) throw new Error(`read failed: ${readErr.message}`);
+  if (!sd) throw new Error(`SD not found: ${SD_KEY}`);
+
+  const metadata = {
+    ...(sd.metadata || {}),
+    // The prose pointer is PRESERVED, not replaced — it is the provenance for these records.
+    founding_corpus_records: CORPUS,
+    founding_corpus_summary: SUMMARY,
+    founding_corpus_reconciliation: RECONCILIATION,
+    founding_corpus_materialized_at: new Date().toISOString(),
+  };
+
+  const { data: updated, error } = await supabase
+    .from('strategic_directives_v2').update({ metadata }).eq('id', sd.id).select('id');
+  if (error) throw new Error(`update failed: ${error.message}`);
+  // An update matching zero rows is indistinguishable from success — so assert the row count.
+  if (!updated || updated.length !== 1) throw new Error(`update matched ${updated?.length ?? 0} rows, expected 1`);
+
+  // Read back from the DB rather than trusting the object we just sent.
+  const { data: verify } = await supabase
+    .from('strategic_directives_v2').select('metadata').eq('id', sd.id).maybeSingle();
+  const back = verify?.metadata?.founding_corpus_records;
+  if (!Array.isArray(back) || back.length !== CORPUS.length) {
+    throw new Error(`readback mismatch: got ${Array.isArray(back) ? back.length : typeof back}, expected ${CORPUS.length}`);
+  }
+  if (!verify?.metadata?.founding_corpus) throw new Error('readback: prose pointer was clobbered');
+
+  console.log(`✅ materialized ${back.length} corpus records (readback verified)`);
+  console.log(`   in-class ${SUMMARY.in_class} | out-of-class ${SUMMARY.out_of_class} (${SUMMARY.out_of_class_breakdown.turn_behaviour} turn-behaviour, ${SUMMARY.out_of_class_breakdown.environment_staleness} environment-staleness)`);
+  console.log(`   citable evidence ids ${SUMMARY.citable_evidence_ids}/${SUMMARY.total}; inferred attribution on n=${SUMMARY.inferred_attributions.join(',')}`);
+  console.log(`   ⚠️  PRD says 11, evidence says ${SUMMARY.total} — reconciliation recorded at metadata.founding_corpus_reconciliation`);
+  console.log(`   recall rule: ${SUMMARY.recall_reporting_rule}`);
+}
+
+main().catch((e) => { console.error(`❌ ${e.message}`); process.exit(1); });

--- a/tests/unit/gates/operator-contract-registration-proof.test.js
+++ b/tests/unit/gates/operator-contract-registration-proof.test.js
@@ -1,0 +1,82 @@
+/**
+ * SD-LEO-INFRA-VERIFY-CONSUMER-HANDOFF-001 — REGISTRATION PROOF (TS-7, the top risk).
+ *
+ * Two gates in this exact space are DEAD CODE: runtime-probe-coverage-gate.js shipped as
+ * "the NEW BLOCKING gate" and was never pushed, and integration-smoke-test-gate.js is
+ * unregistered AND returns {name, description, category, run} while the pipeline invokes
+ * gate.validator(ctx). Both have "tests" — which live under tests/integration/ and therefore
+ * execute ZERO times, because vitest.config.js routes that path to the db project and the db
+ * project is disabled (assessDbTarget -> no_designated_target).
+ *
+ * So: file existence is NOT acceptance, and neither is a test that never runs. This file is
+ * deliberately UNIT tier so it actually executes, and it asserts the arm is REACHED — present
+ * in the real getRequiredGates() output, carrying the interface the pipeline actually calls,
+ * and returning a real verdict when invoked.
+ *
+ * HOLE C is pinned here too: the orchestrator-child early return at plan-to-lead/index.js:259
+ * precedes the operator-contract push at :361, so child SDs are structurally excluded. That is
+ * recorded as a NAMED miss class (FR-4) rather than silently tolerated — the assertion below
+ * fails the moment someone changes it in either direction, forcing a deliberate decision.
+ */
+import { describe, it, expect } from 'vitest';
+import { PlanToLeadExecutor } from '../../../scripts/modules/handoff/executors/plan-to-lead/index.js';
+
+const GATE_NAME_FRAGMENT = /operator[_-]?contract/i;
+
+/** Minimal SD shaped like a normal (non-child) SD. */
+const normalSd = () => ({ id: 'sd-uuid', sd_key: 'SD-TEST-001', metadata: {}, target_application: 'EHG_Engineer' });
+/** An orchestrator child — the hole-C shape. */
+const childSd = () => ({ id: 'sd-uuid-child', sd_key: 'SD-TEST-CHILD-001', metadata: { parent_orchestrator: 'SD-PARENT-001' } });
+
+const supabaseStub = { from: () => ({ select: () => ({ eq: async () => ({ data: [], error: null }) }) }) };
+const makeExecutor = () => new PlanToLeadExecutor({ supabase: supabaseStub });
+
+const gateNames = (gates) => gates.map((g) => String(g?.name || ''));
+const findOperatorGate = (gates) => gates.find((g) => GATE_NAME_FRAGMENT.test(String(g?.name || '')));
+
+describe('TS-7 registration proof — the arm is REACHED, not merely written', () => {
+  it('operator-contract is present in the REAL getRequiredGates() output for a normal SD', async () => {
+    const gates = await makeExecutor().getRequiredGates(normalSd(), {});
+    const found = findOperatorGate(gates);
+    expect(found, `operator-contract gate absent from getRequiredGates(); names were: ${gateNames(gates).join(', ')}`).toBeDefined();
+  });
+
+  it('it exposes validator(), the method the pipeline actually calls', async () => {
+    // THE SINGLE ASSERTION that would have caught integration-smoke-test-gate.js, which
+    // exports run() instead — registered-looking, and structurally uncallable.
+    const found = findOperatorGate(await makeExecutor().getRequiredGates(normalSd(), {}));
+    expect(typeof found.validator).toBe('function');
+    expect(found.run, 'a run() method means the wrong interface — the pipeline calls validator()').toBeUndefined();
+  });
+
+  it('invoking that validator returns a real verdict shape, not a throw or undefined', async () => {
+    // Reached AND callable AND answering. File existence proves none of these three.
+    const found = findOperatorGate(await makeExecutor().getRequiredGates(normalSd(), {}));
+    const verdict = await found.validator({ sd: normalSd(), sd_id: 'sd-uuid', sdId: 'SD-TEST-001', handoffType: 'PLAN-TO-LEAD' });
+    expect(verdict).toBeTypeOf('object');
+    expect(verdict).not.toBeNull();
+    expect(verdict).toHaveProperty('passed');
+  });
+});
+
+describe('FR-4 HOLE C — orchestrator children are a NAMED miss class, not a silent gap', () => {
+  it('records that child SDs do NOT receive the operator-contract arm', async () => {
+    // plan-to-lead/index.js:259 early-returns a reduced gate set for orchestrator children,
+    // and that return precedes the push at :361. The arm can be correct, registered, and pass
+    // every other test here while never evaluating a large share of the fleet.
+    //
+    // This assertion DOCUMENTS the exclusion rather than accepting it quietly. If someone moves
+    // the push inside the child branch, this test fails and they must delete it deliberately —
+    // which is the point: the miss class cannot change without someone noticing.
+    const gates = await makeExecutor().getRequiredGates(childSd(), {});
+    expect(findOperatorGate(gates), 'HOLE C changed: child SDs now DO get the arm. That may be correct — update FR-4 miss classes and remove this assertion deliberately.').toBeUndefined();
+  });
+
+  it('the child gate set is genuinely reduced (guards against the fixture silently not being a child)', async () => {
+    // Two-sided: if childSd() stopped being recognised as a child, the test above would pass
+    // for the wrong reason. Comparing the two sets proves the branch actually fired.
+    const normal = gateNames(await makeExecutor().getRequiredGates(normalSd(), {}));
+    const child = gateNames(await makeExecutor().getRequiredGates(childSd(), {}));
+    expect(child.length).toBeLessThan(normal.length);
+  });
+});


### PR DESCRIPTION
Adds an operator-contract arm that asks whether a produced output has a **reader** — the rung existing gates never checked. `INVOCATION_PATH_PROOF` asks whether the producer *ran*; nothing asked whether the output was *consumed*.

**Closes three holes**
- **A** — a read-shaped call counted as consumption with nothing tying it to the created output (a bare `readConfig()` passed).
- **B** — changes that create nothing were never evaluated at all, which is this SD's entire target class.
- **Orphaned producers** — a table written in the diff that nothing reads. This is the actual corpus #7 shape, and the arm originally *passed* it.

Ships **warn-first** behind `ENFORCE_CONSUMER_CITATION` (set in zero production config; 17 of 22 sites are tests). FR-5 materializes a 12-record founding corpus with 3 replays; recall is reported as **3 of 9 in-class (3 out-of-class)**, never a bare 3-of-3.

**The SD committed its own defect class eight times while being built.** None was caught by reading code:

| # | Defect | Caught by |
|---|---|---|
| 1 | Unit-tested `detectWiring`, not the adapter calling it | mutation reddened **0 of 80** |
| 2 | Verifier read the detector's own signal, so it could never disagree | adapter test |
| 3 | Arm silently passed **corpus #7**, its own demo case | running the demo case |
| 4 | Gate factory **discarded every advisory** — `warnings:[]`, `NOT_APPLICABLE` | TESTING at the registered entry point |
| 5 | Producer refusal fell to **six spellings** of one filename | SECURITY at gate level |
| 6 | Hole A made the consumer leg **unsatisfiable** for FLAG/DETECTOR creators — false PASS became false BLOCK on a required shared-pipeline gate | VALIDATION + REGRESSION, independently, by differential execution |
| 7 | A **test fixture** read as real flag creation — blocked this SD | its own PLAN-TO-LEAD |
| 8 | A **comment** explaining #7 re-triggered #7 — the explanation of the bug was the bug | its own PLAN-TO-LEAD, again |

#8 repeats a fix `collectSdDiff` already carries for SQL: *"the file that documents itself most carefully is punished hardest, which is backwards."*

**Verification**: every fix is mutation-proved (removing the orphan arm reddens 5 of 7 replays; restoring exact path compare reddens exactly the 6 spellings). 153 tests pass on this surface; 36,743 in the full unit project. The 2 failures are pre-existing ANSI-colour assertions in `complete-quick-fix` with no import path here (verified, not assumed).

**Known-open, carried deliberately**
- The citation contract is **decorative** — the cited file is never checked to exist, so `x:1` is accepted. Safe warn-first (detection needs no citation); do **not** promote enforcement until existence-checking lands.
- FR-5 AC6 says "corpus #7", which is `n=7` in the shipped corpus (out-of-class, not replayed); the intended referent is `n=12`. Signalled as a spec conflict.
- Hole C: orchestrator children never receive this gate (named miss class, pinned by a two-sided test).
- **Confirmed pre-existing RCE** in `collectSdDiff` (shell interpolation of git-supplied filenames, proven with a working payload under `sh`) — untouched by this branch, filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)