### PR TITLE
SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-B: convert the quiet-failure liveness and alarm consumers

### DIFF
--- a/scripts/coordinator-hourly-review.cjs
+++ b/scripts/coordinator-hourly-review.cjs
@@ -235,7 +235,12 @@ try {
     .order('scanned_at', { ascending: false })
     .limit(25);
   let isFixtureHealthSnapshot = null;
-  try { ({ isFixtureHealthSnapshot } = await import('../lib/governance/fixture-exclusion.mjs')); } catch { /* keep all rows */ }
+  try {
+    ({ isFixtureHealthSnapshot } = await import('../lib/governance/fixture-exclusion.mjs'));
+  } catch (e) {
+    // ANNOUNCE rather than silently evaluating unfiltered — see the same note in health-urgency.js.
+    console.error(`[coordinator-hourly-review] fixture predicate unavailable, heartbeat read UNFILTERED: ${e?.message || e}`);
+  }
   const hbUsable = typeof isFixtureHealthSnapshot === 'function'
     ? (hbRows || []).filter((r) => !isFixtureHealthSnapshot(r))
     : (hbRows || []);

--- a/scripts/coordinator-hourly-review.cjs
+++ b/scripts/coordinator-hourly-review.cjs
@@ -225,12 +225,23 @@ async function reportGaugeHealth(sb) {
 // single invariant drifting (false all-clear) -- so a stale/missing heartbeat alarms here.
 try {
   const { checkGaugeRunnerLiveness } = await import('../lib/governance/gauge-runner-liveness.js');
-  const { data: hb } = await sb.from('codebase_health_snapshots')
-    .select('scanned_at, findings')
+  // SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-B FR-3: take the newest NON-SYNTHETIC heartbeat, not simply
+  // the newest row. This read takes ORDER BY scanned_at DESC LIMIT 1, so ONE synthetic row in this
+  // dimension was enough to make a DEAD gauge runner report ALIVE — a single row defeats it, which
+  // is why the fix is a scan window rather than a bigger sample.
+  const { data: hbRows } = await sb.from('codebase_health_snapshots')
+    .select('scanned_at, findings, metadata')
     .eq('dimension', 'gauge_runner_heartbeat')
     .order('scanned_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
+    .limit(25);
+  let isFixtureHealthSnapshot = null;
+  try { ({ isFixtureHealthSnapshot } = await import('../lib/governance/fixture-exclusion.mjs')); } catch { /* keep all rows */ }
+  const hbUsable = typeof isFixtureHealthSnapshot === 'function'
+    ? (hbRows || []).filter((r) => !isFixtureHealthSnapshot(r))
+    : (hbRows || []);
+  // No real heartbeat in the window leaves hb undefined, so checkGaugeRunnerLiveness receives
+  // undefined and reports DEAD — the correct direction for a liveness alarm.
+  const hb = hbUsable[0];
   const liveness = checkGaugeRunnerLiveness(hb?.scanned_at, Date.now());
   if (liveness.alarm) {
     const ageNote = liveness.ageMs == null ? 'no heartbeat ever recorded' : Math.floor(liveness.ageMs / 60000) + 'm stale';

--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -975,8 +975,13 @@ function printHealth(d) {
 }
 
 // ── Section: Periodic-Process Liveness (SD-LEO-INFRA-PERIODIC-PROCESS-LIVENESS-001, FR-5) ──
-async function printPeriodicLiveness() {
-  const { data: rows, error } = await supabase
+// `client` is injectable ONLY so the render path can be unit-tested; production passes nothing and
+// uses the module-scope client — the same treatment printStuckSeatStrip got, and for the same
+// reason: this renderer was omitted from module.exports, so nothing could reach it from a test.
+// (SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-B FR-1, prerequisite for FR-4.)
+async function printPeriodicLiveness(client) {
+  const sb = client || supabase;
+  let { data: rows, error } = await sb
     .from('periodic_process_registry')
     .select('process_key, display_name, process_type, currently_expected_active, last_fired_at, last_state, updated_at')
     .order('process_type', { ascending: true });
@@ -993,6 +998,29 @@ async function printPeriodicLiveness() {
     console.log('  (registry empty)');
     console.log('');
     return;
+  }
+
+  // SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-B FR-4: exclude e2e fixture residue from the panel.
+  //
+  // THE FILTER IS ADDED, NOT SUBSTITUTED, and that distinction is the whole point. The
+  // `__watcher_self__` exclusion below is a SELF-exclusion — the watcher declining to list itself,
+  // while still using its own row for the age line — and isFixtureProcessKey('__watcher_self__')
+  // is FALSE. So swapping one for the other would make the watcher appear in its own list: a
+  // regression that reads like a tidy-up. Two different concerns, both required.
+  //
+  // Degrade-safe like the rest of this file, but LOUDLY: if the predicate cannot load we say so
+  // rather than silently rendering unfiltered. An unannounced fallback here is indistinguishable
+  // from a working filter, which is the failure this SD family exists to abolish.
+  let isFixtureProcessKey = null;
+  try { ({ isFixtureProcessKey } = require('../lib/governance/fixture-exclusion.mjs')); } catch { /* announced below */ }
+  let fixtureCount = 0;
+  if (typeof isFixtureProcessKey === 'function') {
+    const before = rows.length;
+    rows = rows.filter((r) => !isFixtureProcessKey(r.process_key));
+    fixtureCount = before - rows.length;
+    if (fixtureCount > 0) console.log(`  (${fixtureCount} e2e fixture row(s) excluded)`);
+  } else {
+    console.log('  (fixture predicate unavailable — rendering UNFILTERED)');
   }
 
   const self = rows.find((r) => r.process_key === '__watcher_self__');
@@ -2753,7 +2781,7 @@ async function main() {
 }
 
 // Export read-only renderers for unit testing (SD-LEO-INFRA-COORDINATOR-DASHBOARD-SURFACES-001).
-module.exports = { printFeedback, reconcilePAliveWithLiveness, computeSolomonLedgerRollup, printWorkers, printChairmanEmailChannelHealth, printAvailable, printWorkerInbox, resolveInboxAudience, printAttentionStrip, printQA, printStuckSeatStrip };
+module.exports = { printFeedback, printPeriodicLiveness, reconcilePAliveWithLiveness, computeSolomonLedgerRollup, printWorkers, printChairmanEmailChannelHealth, printAvailable, printWorkerInbox, resolveInboxAudience, printAttentionStrip, printQA, printStuckSeatStrip };
 
 // Only run the CLI when invoked directly, so requiring this module in a test does
 // not execute main() against the live database.

--- a/scripts/lib/health-urgency.js
+++ b/scripts/lib/health-urgency.js
@@ -163,7 +163,14 @@ export async function checkHealthFreshness(supabase) {
   // silently dropping data — for a staleness check, over-reporting freshness is the dangerous
   // direction, so an unavailable filter must not also start hiding real rows.
   let isFixtureHealthSnapshot = null;
-  try { ({ isFixtureHealthSnapshot } = await import('../../lib/governance/fixture-exclusion.mjs')); } catch { /* keep all rows */ }
+  try {
+    ({ isFixtureHealthSnapshot } = await import('../../lib/governance/fixture-exclusion.mjs'));
+  } catch (e) {
+    // ANNOUNCE, never degrade in silence. The panel and the watcher both say so when their
+    // predicate cannot load; these two readers were left quiet, which is the inconsistency an
+    // adversarial review caught. An unreported fallback is indistinguishable from a working filter.
+    console.error(`[health-urgency] fixture predicate unavailable, freshness computed UNFILTERED: ${e?.message || e}`);
+  }
   const usable = typeof isFixtureHealthSnapshot === 'function'
     ? (recent || []).filter((r) => !isFixtureHealthSnapshot(r))
     : (recent || []);

--- a/scripts/lib/health-urgency.js
+++ b/scripts/lib/health-urgency.js
@@ -142,15 +142,34 @@ export function isHealthDerivedSD(sd) {
  * @param {Object} [supabase] - Supabase client
  * @returns {Promise<{ stale: boolean, message: string, lastScan: string|null, hoursOld: number|null }>}
  */
+// SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-B FR-2. How many recent rows to scan past before giving up.
+// A window is needed because the NEWEST row may be synthetic: the previous implementation took
+// LIMIT 1 unconditionally, so a single synthetic row anywhere in ANY dimension became "the latest
+// scan" and a stale scanner reported FRESH. That is the quiet-failure direction this SD closes, and
+// it is why this read is converted before the dimension-scoped one — this one has no dimension
+// filter at all, so every dimension can defeat it.
+const FRESHNESS_SCAN_WINDOW = 50;
+
 export async function checkHealthFreshness(supabase) {
   const sb = supabase || getSupabase();
 
-  const { data: latest } = await sb
+  const { data: recent } = await sb
     .from('codebase_health_snapshots')
-    .select('scanned_at')
+    .select('scanned_at, metadata')
     .order('scanned_at', { ascending: false })
-    .limit(1)
-    .single();
+    .limit(FRESHNESS_SCAN_WINDOW);
+
+  // First NON-SYNTHETIC row wins. If the predicate cannot load we keep every row rather than
+  // silently dropping data — for a staleness check, over-reporting freshness is the dangerous
+  // direction, so an unavailable filter must not also start hiding real rows.
+  let isFixtureHealthSnapshot = null;
+  try { ({ isFixtureHealthSnapshot } = await import('../../lib/governance/fixture-exclusion.mjs')); } catch { /* keep all rows */ }
+  const usable = typeof isFixtureHealthSnapshot === 'function'
+    ? (recent || []).filter((r) => !isFixtureHealthSnapshot(r))
+    : (recent || []);
+  // Exhausting the window without finding a real row falls through to the not-found branch, which
+  // reports STALE. That is deliberate: a staleness alarm must fail toward stale, never toward fresh.
+  const latest = usable[0] || null;
 
   if (!latest) {
     return {

--- a/scripts/periodic-liveness-watcher.mjs
+++ b/scripts/periodic-liveness-watcher.mjs
@@ -381,7 +381,17 @@ async function stampStateChangeAnchor(row, evaluation) {
   }
 }
 
-async function main() {
+/**
+ * @param {{includeFixtures?: boolean}} [opts] — includeFixtures:true KEEPS __e2e_ rows in the
+ *   evaluation set. Exists for ONE caller: tests/integration/periodic-process-liveness-realdb.test.js,
+ *   whose fixtures are themselves named __e2e_periodic_liveness_*__ and which asserts that this
+ *   watcher EMITS OVERDUE for them. That suite needs the real path over synthetic rows, so filtering
+ *   them would break the regression suite that guards this very file. It is the same shape as the
+ *   reaper: a consumer for which seeing fixture rows IS the function.
+ *   THE OPT-OUT ANNOUNCES ITSELF on every use — an escape hatch that engages silently is the
+ *   fence-bypass class, and this one is quiet by nature because it only ever runs in tests.
+ */
+async function main({ includeFixtures = false } = {}) {
   const { data: rows, error } = await supabase.from('periodic_process_registry').select('*').neq('process_key', WATCHER_SELF_KEY);
   if (error) throw new Error(`registry query failed: ${error.message}`);
 
@@ -399,7 +409,9 @@ async function main() {
   // which would classify the REAL rows __watcher_self__ and __eva_scheduler_watcher_self__ as
   // fixtures and blind the very instrument this watcher exists to keep honest.
   let liveRows = rows || [];
-  try {
+  if (includeFixtures) {
+    console.log('[periodic-liveness-watcher] includeFixtures=true — EVALUATING __e2e_ FIXTURE ROWS. This opt-out exists for the realdb regression suite only; it must never be set in production.');
+  } else try {
     const { isFixtureProcessKey } = await import('../lib/governance/fixture-exclusion.mjs');
     const before = liveRows.length;
     liveRows = liveRows.filter((r) => !isFixtureProcessKey(r.process_key));

--- a/scripts/periodic-liveness-watcher.mjs
+++ b/scripts/periodic-liveness-watcher.mjs
@@ -385,8 +385,34 @@ async function main() {
   const { data: rows, error } = await supabase.from('periodic_process_registry').select('*').neq('process_key', WATCHER_SELF_KEY);
   if (error) throw new Error(`registry query failed: ${error.message}`);
 
+  // SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-B FR-4: drop e2e fixture residue before evaluating liveness.
+  //
+  // This is the ALARM PRODUCER, so an unfiltered fixture row here does not merely look wrong on a
+  // panel — it emits a real OVERDUE signal for a process that was never meant to exist, and the
+  // resulting noise is what trains people to ignore the alarm.
+  //
+  // ADDED, NOT SUBSTITUTED: the .neq above is a SELF-exclusion (the watcher not evaluating itself)
+  // and isFixtureProcessKey('__watcher_self__') is FALSE, so replacing one with the other would put
+  // the watcher back into its own evaluation set. Two different concerns.
+  //
+  // Keyed on '__e2e_' ONLY, never the canonical FIXTURE_KEY_RE: that regex carries a bare ^__ branch
+  // which would classify the REAL rows __watcher_self__ and __eva_scheduler_watcher_self__ as
+  // fixtures and blind the very instrument this watcher exists to keep honest.
+  let liveRows = rows || [];
+  try {
+    const { isFixtureProcessKey } = await import('../lib/governance/fixture-exclusion.mjs');
+    const before = liveRows.length;
+    liveRows = liveRows.filter((r) => !isFixtureProcessKey(r.process_key));
+    const dropped = before - liveRows.length;
+    if (dropped > 0) console.log(`[periodic-liveness-watcher] excluded ${dropped} e2e fixture row(s) from evaluation`);
+  } catch (e) {
+    // Announce rather than silently evaluating unfiltered — an unreported fallback is
+    // indistinguishable from a working filter.
+    console.error(`[periodic-liveness-watcher] fixture predicate unavailable, EVALUATING UNFILTERED: ${e?.message || e}`);
+  }
+
   const classes = parseLivenessClasses(process.env.LIVENESS_CLASSES);
-  const { evaluate, skipped } = partitionRowsByClasses(rows || [], classes);
+  const { evaluate, skipped } = partitionRowsByClasses(liveRows, classes);
   if (classes) {
     console.log(`[periodic-liveness-watcher] class filter active (${[...classes].join(',')}): evaluating ${evaluate.length}, skipping ${skipped.length} row(s) owned by the other venue`);
   }

--- a/tests/integration/periodic-process-liveness-realdb.test.js
+++ b/tests/integration/periodic-process-liveness-realdb.test.js
@@ -32,7 +32,11 @@ const ts = Date.now();
 const fixtureKeys = [];
 
 async function insertFixture({ suffix = 'fixture', ...overrides } = {}) {
-  const processKey = `__e2e_periodic_liveness_${suffix}_${ts}__`;
+    // SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-B: these fixture keys are __e2e_-prefixed, which the new
+  // canonical fixture filter in the watcher excludes from evaluation. This suite asserts the watcher
+  // EMITS OVERDUE for exactly these rows, so it must opt in via runWatcher({ includeFixtures: true }).
+  // Seeing fixture rows IS this suite's function — the same carve-out the reaper gets.
+const processKey = `__e2e_periodic_liveness_${suffix}_${ts}__`;
   fixtureKeys.push(processKey);
   const { error } = await supabase.from('periodic_process_registry').insert({
     process_key: processKey,
@@ -96,8 +100,8 @@ describe.skipIf(!HAS_REAL_DB)('Periodic-process liveness registry -- REAL DB', (
     expect(evaluation.state).toBe(STATE.OVERDUE);
 
     // Run the full watcher (not just evaluateRow) to exercise the real emission+dedup path.
-    await runWatcher();
-    await runWatcher(); // second run -- must NOT double-emit
+    await runWatcher({ includeFixtures: true });
+    await runWatcher({ includeFixtures: true }); // second run -- must NOT double-emit
 
     const { data: flags } = await supabase
       .from('session_coordination')
@@ -114,14 +118,14 @@ describe.skipIf(!HAS_REAL_DB)('Periodic-process liveness registry -- REAL DB', (
     await supabase.from('periodic_process_registry')
       .update({ last_fired_at: new Date(Date.now() - 60_000).toISOString() })
       .eq('process_key', processKey);
-    await runWatcher();
+    await runWatcher({ includeFixtures: true });
     const { data: afterEpisode1 } = await supabase.from('session_coordination').select('id').eq('payload->>process_key', processKey).eq('payload->>state', 'OVERDUE');
     expect(afterEpisode1.length).toBe(1);
 
     // Recovery: stamp it fresh -> OK. The watcher must persist last_state=OK so a future OVERDUE
     // is recognized as a NEW transition, not swallowed by a permanent "already flagged once" latch.
     await stampLastFired(supabase, processKey);
-    await runWatcher();
+    await runWatcher({ includeFixtures: true });
     const { data: row1 } = await supabase.from('periodic_process_registry').select('last_state').eq('process_key', processKey).single();
     expect(row1.last_state).toBe(STATE.OK);
 
@@ -129,7 +133,7 @@ describe.skipIf(!HAS_REAL_DB)('Periodic-process liveness registry -- REAL DB', (
     await supabase.from('periodic_process_registry')
       .update({ last_fired_at: new Date(Date.now() - 60_000).toISOString() })
       .eq('process_key', processKey);
-    await runWatcher();
+    await runWatcher({ includeFixtures: true });
 
     const { data: afterEpisode2 } = await supabase.from('session_coordination').select('id').eq('payload->>process_key', processKey).eq('payload->>state', 'OVERDUE');
     expect(afterEpisode2.length).toBe(2); // one row per genuine episode, not stuck at 1 forever
@@ -143,7 +147,7 @@ describe.skipIf(!HAS_REAL_DB)('Periodic-process liveness registry -- REAL DB', (
     const evaluation = await evaluateRow(row);
     expect(evaluation.state).toBe(STATE.OK);
 
-    await runWatcher();
+    await runWatcher({ includeFixtures: true });
     const { data: flags } = await supabase.from('session_coordination').select('id').eq('payload->>process_key', processKey);
     expect(flags.length).toBe(0);
   });
@@ -158,7 +162,7 @@ describe.skipIf(!HAS_REAL_DB)('Periodic-process liveness registry -- REAL DB', (
     const evaluation = await evaluateRow(row);
     expect(evaluation.state).toBe(STATE.INTENTIONALLY_DOWN);
 
-    await runWatcher();
+    await runWatcher({ includeFixtures: true });
     const { data: flags } = await supabase.from('session_coordination').select('id').eq('payload->>process_key', processKey);
     expect(flags.length).toBe(0);
   });
@@ -178,7 +182,7 @@ describe.skipIf(!HAS_REAL_DB)('Periodic-process liveness registry -- REAL DB', (
       .update({ last_fired_at: new Date(Date.now() - 60_000).toISOString() })
       .eq('process_key', processKey);
 
-    await runWatcher();
+    await runWatcher({ includeFixtures: true });
 
     const { data: flags } = await supabase
       .from('session_coordination')
@@ -200,8 +204,8 @@ describe.skipIf(!HAS_REAL_DB)('Periodic-process liveness registry -- REAL DB', (
       .update({ last_fired_at: new Date(Date.now() - 60_000).toISOString() })
       .eq('process_key', processKey);
 
-    await expect(runWatcher()).resolves.toBeDefined(); // first miss: owner-first
-    await expect(runWatcher()).resolves.toBeDefined(); // second miss: ladder attempt (fails soft)
+    await expect(runWatcher({ includeFixtures: true })).resolves.toBeDefined(); // first miss: owner-first
+    await expect(runWatcher({ includeFixtures: true })).resolves.toBeDefined(); // second miss: ladder attempt (fails soft)
 
     const { data: row } = await supabase.from('periodic_process_registry').select('last_state').eq('process_key', processKey).single();
     expect(row.last_state).toBe(STATE.OVERDUE);

--- a/tests/unit/governance/quiet-failure-consumers.test.js
+++ b/tests/unit/governance/quiet-failure-consumers.test.js
@@ -1,0 +1,146 @@
+/**
+ * Quiet-failure consumer conversions — SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-B.
+ *
+ * WHY EVERY TEST HERE INJECTS ITS OWN ROWS. The live tables are CLEAN: codebase_health_snapshots
+ * carries 4,009 rows (exact, fully paginated) with ZERO synthetic markers, and all 194
+ * periodic_process_registry rows are unmarked. A filter over an already-clean table renders
+ * identically whether it is present, absent, or NEUTERED — so any test that reads the live table and
+ * asserts "output unchanged" CANNOT FAIL. The first draft of this SD's PRD contained exactly such a
+ * test; it was deleted rather than reworded. These tests drive pure/injectable functions instead.
+ *
+ * AND WHY THEY LIVE IN THE UNIT TIER. tests/helpers/db-target.js DESIGNATED_NON_PROD_REFS is empty,
+ * so the vitest `db` project only runs when VITEST_DB_ALLOW_REF names the live ref, and no workflow
+ * runs `npm run test:db`. A db-project test proving these conversions would be CI-uninvoked — an
+ * instrument nobody invokes is indistinguishable from an absent one.
+ *
+ * ASSERTIONS USE UNIQUE DISPLAY TOKENS, NEVER SUBSTRINGS. An earlier ad-hoc run of the panel control
+ * reported a false FAIL because it searched for "e2e fixture", which collides with the exclusion-count
+ * line the conversion itself prints — an assertion matching the very message announcing correct
+ * behaviour. Distinctive tokens (E2EPROBEROW, WATCHERSELFROW…) make that collision impossible.
+ */
+import { describe, test, expect, vi } from 'vitest';
+import { checkHealthFreshness } from '../../../scripts/lib/health-urgency.js';
+
+const { printPeriodicLiveness } = require('../../../scripts/fleet-dashboard.cjs');
+
+// ── helpers ────────────────────────────────────────────────────────────────────────────────
+const isoAgo = (hoursAgo) => new Date(Date.now() - hoursAgo * 3600000).toISOString();
+const snapshot = (hoursAgo, metadata) => ({ scanned_at: isoAgo(hoursAgo), metadata });
+const healthClient = (rows) => ({
+  from: () => ({ select: () => ({ order: () => ({ limit: async () => ({ data: rows, error: null }) }) }) }),
+});
+
+const registryRow = (process_key, display_name, process_type = 'cron') => ({
+  process_key,
+  display_name,
+  process_type,
+  currently_expected_active: true,
+  last_fired_at: isoAgo(0),
+  last_state: 'OK',
+  updated_at: null,
+});
+const registryClient = (rows) => ({
+  from: () => ({ select: () => ({ order: async () => ({ data: rows, error: null }) }) }),
+});
+
+async function renderPanel(rows) {
+  const lines = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation((...a) => lines.push(a.join(' ')));
+  try {
+    await printPeriodicLiveness(registryClient(rows));
+  } finally {
+    spy.mockRestore();
+  }
+  return lines.join('\n');
+}
+
+// ── periodic_process_registry: the panel ───────────────────────────────────────────────────
+describe('printPeriodicLiveness — fixture filter ADDED, not substituted (FR-4)', () => {
+  // THE CONTROL. One evaluation carrying BOTH row types, asserted independently.
+  //
+  // A test seeding only an __e2e_ row passes under a CORRECT implementation and under a broken
+  // replace-the-self-exclusion-with-the-predicate one, because isFixtureProcessKey('__watcher_self__')
+  // is FALSE — so under the broken version the watcher silently reappears in its own list. Only
+  // asserting both in the same render distinguishes them.
+  test('THE CONTROL: __e2e_ excluded by the filter AND __watcher_self__ still excluded by the self-check', async () => {
+    const out = await renderPanel([
+      registryRow('__watcher_self__', 'WATCHERSELFROW', 'watcher'),
+      registryRow('__e2e_fixture_probe', 'E2EPROBEROW', 'test'),
+      registryRow('gha_cron:real-job.yml', 'REALJOBROW'),
+    ]);
+    expect(out).not.toContain('E2EPROBEROW');    // fixture filter did its job
+    expect(out).not.toContain('WATCHERSELFROW'); // self-exclusion survived the conversion
+    expect(out).toContain('REALJOBROW');         // and a real row is untouched
+  });
+
+  // THE FIVE REAL ROWS. Two lead with a bare dunder — the canonical FIXTURE_KEY_RE's ^__ branch
+  // would classify them as fixtures — and three merely SOUND test-shaped. A name is a claim, not
+  // evidence. __eva_scheduler_watcher_self__ is the load-bearing one: it proves the panel uses the
+  // __e2e_-only predicate rather than the canonical key regex.
+  test('THE CONTROL: real rows survive, including bare-dunder and test-sounding names', async () => {
+    const out = await renderPanel([
+      registryRow('__eva_scheduler_watcher_self__', 'SCHEDULERSELFROW', 'watcher'),
+      registryRow('gha_cron:venture-fixture-sweep.yml', 'SWEEPROW'),
+      registryRow('standard_loop:account-usage-sample', 'LOOPSAMPLEROW', 'loop'),
+      registryRow('cron_script:account-usage-sample.mjs', 'SCRIPTSAMPLEROW'),
+    ]);
+    expect(out).toContain('SCHEDULERSELFROW');
+    expect(out).toContain('SWEEPROW');
+    expect(out).toContain('LOOPSAMPLEROW');
+    expect(out).toContain('SCRIPTSAMPLEROW');
+  });
+
+  test('the exclusion is announced rather than silent', async () => {
+    const out = await renderPanel([
+      registryRow('__e2e_a', 'AAA'),
+      registryRow('gha_cron:real.yml', 'REALJOBROW'),
+    ]);
+    expect(out).toContain('1 e2e fixture row(s) excluded');
+  });
+
+  test('renders without a database — proving FR-1 export + injection landed', () => {
+    expect(typeof printPeriodicLiveness).toBe('function');
+  });
+});
+
+// ── codebase_health_snapshots: the staleness check ─────────────────────────────────────────
+describe('checkHealthFreshness — one synthetic row cannot mask a stale scanner (FR-2)', () => {
+  // THE CORE HAZARD. This read has NO dimension filter at all, so a synthetic row in ANY dimension
+  // becomes "the latest scan". Before conversion this returned stale:false on these inputs.
+  test('a fresh SYNTHETIC row does not hide a 40h-old real scan', async () => {
+    const r = await checkHealthFreshness(healthClient([
+      snapshot(0, { synthetic: true }),
+      snapshot(40, { source: 'health-scan' }),
+    ]));
+    expect(r.stale).toBe(true);
+    expect(r.hoursOld).toBe(40);
+  });
+
+  // FAIL-SAFE DIRECTION. If every row in the window is synthetic we must report STALE, never fresh —
+  // a staleness alarm that fails toward "fresh" is silent exactly when it matters.
+  test('an all-synthetic window fails toward STALE', async () => {
+    const r = await checkHealthFreshness(healthClient([
+      snapshot(0, { synthetic: true }),
+      snapshot(1, { is_fixture: true }),
+    ]));
+    expect(r.stale).toBe(true);
+    expect(r.lastScan).toBeNull();
+  });
+
+  // THE OVER-EATING CONTROL, varying a different axis than the positives above: real rows carrying
+  // unrelated metadata shapes, and the null metadata most real rows actually have.
+  test('THE CONTROL: real rows survive regardless of metadata shape', async () => {
+    await expect(checkHealthFreshness(healthClient([snapshot(1, { source: 'health-scan', run_id: 'abc' })])))
+      .resolves.toMatchObject({ stale: false });
+    await expect(checkHealthFreshness(healthClient([snapshot(2, { is_fixture: false })])))
+      .resolves.toMatchObject({ stale: false });
+    await expect(checkHealthFreshness(healthClient([snapshot(3, null)])))
+      .resolves.toMatchObject({ stale: false });
+  });
+
+  // Strict === true only: a truthy-but-wrong-shaped value must not sweep a real row up.
+  test('only strict boolean true marks a row synthetic', async () => {
+    const r = await checkHealthFreshness(healthClient([snapshot(1, { synthetic: 'yes' })]));
+    expect(r.stale).toBe(false);
+  });
+});


### PR DESCRIPTION
Second child of the one-synthetic-row orchestrator, and the one that runs before C because the failure directions differ: a polluted panel over-reports and someone notices, while a polluted liveness alarm under-reports and goes silent.

## The dominant design constraint: the hazard is latent

Measured at LEAD and re-measured at retro: `codebase_health_snapshots` carries **4,016 rows (fully paginated) with zero synthetic markers**, and all **207** `periodic_process_registry` rows are unmarked. This child fixes **structural exposure**, not a live incident.

That lowers urgency and *raises* the correctness bar. A filter over an already-clean table renders identically whether it is present, absent, or **neutered** — so every proof here injects its own rows into pure functions. The first draft of this PRD contained exactly such a vacuous test (asserting "output unchanged"); it was **deleted rather than reworded**.

## Four converted sites

| Site | Why | Tested |
|---|---|---|
| `health-urgency.js` `checkHealthFreshness` | **No dimension filter at all** — a synthetic row in *any* dimension became "the latest scan". Sharpest instance. | unit-tested |
| `coordinator-hourly-review.cjs:246+` heartbeat | `ORDER BY scanned_at DESC LIMIT 1` — **one** synthetic row made a dead runner read ALIVE | not unit-tested (see gaps) |
| `fleet-dashboard.cjs` `printPeriodicLiveness` | panel; required an export+DI prerequisite because it had **no test path at all** | unit-tested, mutation-killed |
| `periodic-liveness-watcher.mjs` `main()` | the **alarm producer** — filter consumed at `:415`, not merely computed | not unit-tested (see gaps) |

Both snapshot readers **fail toward alarm**: an exhausted window reports STALE/DEAD, never fresh/alive. All four **announce** when the predicate cannot load — an unreported fallback is indistinguishable from a working filter.

## The filter is ADDED, never substituted

The existing `__watcher_self__` checks are **self**-exclusions (the watcher declining to list itself while still using its own row for the age line). `isFixtureProcessKey('__watcher_self__')` is `false`, so *replacing* one with the other would put the watcher back in its own output — a regression shaped exactly like a tidy-up. The mutation proof kills that specific breach, and THE CONTROL feeds one evaluation **both** row types, because a test seeding either alone passes under both the correct and the broken implementation.

## A defect this PR found in itself

The filter initially **broke the regression suite guarding its own file** — `periodic-process-liveness-realdb.test.js` names its fixtures `__e2e_periodic_liveness_*__` and asserts the watcher *emits* OVERDUE for them. Latent only because the db vitest project is CI-disabled.

Fixed with a **loud opt-out**: `runWatcher({ includeFixtures: true })` announces on every use, is a call parameter rather than an env flag (so production cannot inherit it), and is unreachable from the CLI path. This is a fourth consumer for which *seeing* fixture rows is the function, alongside the reaper and the RLS probe.

## Known gaps, carried not hidden

- Two of four sites are not unit-tested. `coordinator-hourly-review.cjs` genuinely has no export path; **`runWatcher` IS exported and could be tested — that test is simply not written.**
- db-project tests are **CI-unreachable repo-wide** (`DESIGNATED_NON_PROD_REFS` empty, no workflow runs them). This gap concealed the defect above — filing a gap is not fixing it.
- The audit artifact disposes of remaining read sites **by class** (writes, backfills, by-id lookups), not per-site. A class disposition is weaker; a site can sit in a class and still aggregate.
- SECURITY recommendation to distinguish "window exhausted by filter" from "genuinely fewer rows" is **not done**.

## Verification

- Governance suite **1234 passed** / 75 of 76 files
- Mutation proof **3/3 killed**, both directions, including the boundary breach
- SECURITY CONDITIONAL_PASS 88, **0 critical** — suppression vector requires pre-existing service-role access (RLS unchanged by this diff); no DDL, no dependency, no secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)