### PR TITLE
fix(SD-LEO-FIX-SHELL-INJECTION-RCE-001): stop handing git-supplied filenames to a shell

### DIFF
--- a/lib/gates/operator-contract/__tests__/harness-adapter-shell-injection.test.js
+++ b/lib/gates/operator-contract/__tests__/harness-adapter-shell-injection.test.js
@@ -1,0 +1,218 @@
+/**
+ * collectSdDiff must never hand a git-supplied filename to a shell.
+ * SD-LEO-FIX-SHELL-INJECTION-RCE-001.
+ *
+ * THE DEFECT. The per-file diff read `run(\`git diff ${baseRef}...HEAD -- "${path}"\`)`, where
+ * `path` came straight out of `git diff --name-only`. execSync runs a command STRING through
+ * /bin/sh on POSIX and cmd.exe on Windows, so a committed file whose NAME contained $(...) or a
+ * backtick executed as a command — inside a process holding SUPABASE_SERVICE_ROLE_KEY. Double
+ * quotes did not save it: under sh they suppress ; and & but command substitution still expands
+ * inside them.
+ *
+ * WHY THIS FILE EXISTS AT ALL. Before it, the git-shelling path had ZERO coverage.
+ * harness-adapter.test.js exercises gate shape and fail-open-on-missing-appPath; the sibling
+ * operator-contract.test.js deliberately AVOIDS collectSdDiff and says so in its own docblock.
+ * Nothing anywhere fed this function an adversarial filename.
+ *
+ * EVERY POSITIVE CLAIM HERE IS ARMED FIRST. Each "the fix holds" assertion is paired with a run
+ * of the ORIGINAL vulnerable shape against the SAME fixture, proving the payload really fires on
+ * this platform. Without that, "no marker was created" is indistinguishable from "the payload was
+ * never capable of firing here" — which is exactly how a security test becomes decorative.
+ *
+ * child_process is NEVER mocked. collectSdDiff calls its runner TWICE per file (enumeration, then
+ * the per-file diff), and the per-file call is the RCE line — a mock that inspects only the first
+ * call would miss the defect entirely. These tests drive real git against real temp repos.
+ *
+ * PLATFORM SPLIT, measured rather than assumed:
+ *   - $(...) / backtick fire under POSIX sh. Under Windows' default execSync (cmd.exe) they do
+ *     NOT — cmd performs no command substitution, so vulnerable and fixed forms BOTH produce no
+ *     marker and the assertion cannot discriminate. That arm therefore forces a resolved sh.exe
+ *     on win32, and skips honestly if none is present.
+ *   - %VAR% is the mirror image: inert under sh, but cmd.exe expands it BEFORE git sees the
+ *     argument, so git matches no pathspec and exits 0 with an EMPTY diff and NO error. That is
+ *     the silent-evasion vector, and it is the arm that fires on Windows with no shell-forcing.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync, execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { collectSdDiff } from '../harness-adapter.js';
+
+const IS_WIN = process.platform === 'win32';
+
+/** Resolve a real POSIX sh, if this host has one. Git-for-Windows ships one. */
+function findSh() {
+  // Try the PATH lookup under both spellings, then the Git-for-Windows install locations. A
+  // hardcoded path alone would be wrong (portable/minimal Git installs differ), and a PATH lookup
+  // alone misses the common case where Git's usr/bin is not on PATH — which is exactly how this
+  // arm ends up silently skipped on a machine that could in fact run it.
+  for (const probe of IS_WIN ? ['sh.exe', 'sh'] : ['sh']) {
+    try {
+      const out = execFileSync(IS_WIN ? 'where' : 'which', [probe], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+      const first = out.split(/\r?\n/).map((s) => s.trim()).filter(Boolean)[0];
+      if (first && fs.existsSync(first)) return first;
+    } catch { /* try the next probe */ }
+  }
+  if (IS_WIN) {
+    for (const c of [
+      'C:\\Program Files\\Git\\usr\\bin\\sh.exe',
+      'C:\\Program Files\\Git\\bin\\sh.exe',
+      'C:\\Program Files (x86)\\Git\\usr\\bin\\sh.exe',
+    ]) if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+const SH = findSh();
+
+const git = (repo, args) => execFileSync('git', args, { cwd: repo, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+
+/** A temp repo with a base commit on `main` and a second commit adding `files`. */
+function makeRepo(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rce-fixture-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Test']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  fs.writeFileSync(path.join(dir, 'base.txt'), 'base\n');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', 'base']);
+  git(dir, ['branch', '-f', 'basebranch']);
+  for (const [name, body] of Object.entries(files)) {
+    const full = path.join(dir, name);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, body);
+  }
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', 'add fixtures']);
+  return dir;
+}
+
+const rm = (d) => { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ } };
+
+describe('ARMED: the $(...) / backtick payload really executes under a POSIX shell', () => {
+  // Skips honestly when no sh is available rather than passing vacuously.
+  const canRun = !!SH;
+  let dir; let payloadName; let markerPath;
+
+  beforeAll(() => {
+    if (!canRun) return;
+    payloadName = 'pwn`touch MARKER.txt`end.txt';
+    dir = makeRepo({ [payloadName]: 'x\n' });
+    markerPath = path.join(dir, 'MARKER.txt');
+  });
+  afterAll(() => { if (dir) rm(dir); });
+
+  it.runIf(canRun)('git returns the metacharacter filename BYTE-VERBATIM — it does not escape it for you', () => {
+    const out = git(dir, ['diff', '--name-only', '-z', 'basebranch...HEAD']).split('\0').filter(Boolean);
+    expect(out).toContain(payloadName);
+  });
+
+  it.runIf(canRun)('THE ARM: the ORIGINAL vulnerable shape CREATES THE MARKER — the payload can fire', () => {
+    // This is the pre-fix line, reconstructed verbatim, run through a real sh. If this does not
+    // create the marker, every "no marker" assertion below is meaningless and this file is
+    // theatre — so it is asserted, not assumed.
+    try {
+      execSync(`git diff basebranch...HEAD -- "${payloadName}"`, {
+        cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: SH,
+      });
+    } catch { /* the shell may exit non-zero; the side effect is what matters */ }
+    expect(path.resolve(markerPath).startsWith(path.resolve(dir)), 'marker must be inside the temp dir').toBe(true);
+    expect(fs.existsSync(markerPath), 'vulnerable form did not execute — this test cannot fail, so it proves nothing').toBe(true);
+  });
+
+  it.runIf(canRun)('THE FIX: collectSdDiff creates NO marker, AND still reports the file', () => {
+    // Both halves are required. "No marker" alone would also be satisfied by a fix that simply
+    // stopped seeing the file — which would trade the RCE for a silent-evasion hole and be worse
+    // than the defect.
+    fs.rmSync(markerPath, { force: true });
+    const { changedFiles } = collectSdDiff({ appPath: dir, baseRef: 'basebranch' });
+    expect(fs.existsSync(markerPath), 'the fixed path executed the filename').toBe(false);
+    expect(changedFiles.map((f) => f.path), 'the adversarial file must remain VISIBLE, not silently dropped')
+      .toContain(payloadName);
+  });
+});
+
+describe('ARMED: the %VAR% silent-evasion vector (fires on Windows defaults, no shell-forcing)', () => {
+  const NAME = 'f%PATH%.js';
+  let dir;
+  beforeAll(() => { dir = makeRepo({ [NAME]: 'const a = 1;\n' }); });
+  afterAll(() => { if (dir) rm(dir); });
+
+  it.runIf(IS_WIN)('THE ARM: the ORIGINAL vulnerable shape reads an EMPTY diff and throws NOTHING', () => {
+    // cmd.exe expands %PATH% before git sees the argument, so git matches no pathspec and exits
+    // 0. No error means the per-file catch never fires: the file reads as "present but with no
+    // added lines". A gate that can be made to see nothing.
+    let out = null; let threw = false;
+    try {
+      out = execSync(`git diff basebranch...HEAD -- "${NAME}"`, { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    } catch { threw = true; }
+    expect(threw, 'the silent vector must NOT throw — that is what makes it silent').toBe(false);
+    expect(out.trim(), 'vulnerable form saw a non-empty diff, so this arm cannot discriminate').toBe('');
+  });
+
+  it('THE FIX: the percent-name file is read for real — added lines are recovered', () => {
+    const { changedFiles, unreadable } = collectSdDiff({ appPath: dir, baseRef: 'basebranch' });
+    const entry = changedFiles.find((f) => f.path === NAME);
+    expect(entry, 'percent-named file missing from changedFiles').toBeTruthy();
+    expect(entry.added, 'added lines were not recovered — the argument was mangled before git saw it')
+      .toContain('const a = 1;');
+    expect(unreadable, 'no file should be unreadable in this fixture').toEqual([]);
+  });
+});
+
+describe('the ordinary path is unchanged — including the .sql branch', () => {
+  let dir;
+  beforeAll(() => {
+    // A .sql file is REQUIRED here: collectSdDiff branches on /\.sql$/i into a separate
+    // migrations + createdTables extraction that also flows through the runner being changed.
+    // A fixture of only .js files would never exercise it, and the claim that those outputs are
+    // protected would be asserting something it never touched.
+    dir = makeRepo({
+      'a.js': 'const x = 1;\n',
+      'db/m.sql': 'CREATE TABLE IF NOT EXISTS widgets (id uuid primary key);\n',
+    });
+  });
+  afterAll(() => { if (dir) rm(dir); });
+
+  it('a .sql file routes to migrations, a .js file to changedFiles — the split is preserved', () => {
+    // Written first as "changedFiles contains both", which FAILED: .sql paths go to `migrations`,
+    // not `changedFiles`. Corrected to the contract the code actually implements rather than the
+    // one assumed — the test was wrong, not the code, and pinning the real split is the point of
+    // exercising this branch at all.
+    const { changedFiles, migrations } = collectSdDiff({ appPath: dir, baseRef: 'basebranch' });
+    expect(changedFiles.map((f) => f.path)).toContain('a.js');
+    expect(migrations.map((m) => m.path)).toContain('db/m.sql');
+    expect(changedFiles.find((f) => f.path === 'a.js').added).toContain('const x = 1;');
+  });
+
+  it('the .sql branch still yields migrations and createdTables', () => {
+    const { migrations, createdTables } = collectSdDiff({ appPath: dir, baseRef: 'basebranch' });
+    expect(migrations.map((m) => m.path)).toContain('db/m.sql');
+    expect(createdTables).toContain('widgets');
+  });
+
+  it('an unchanged branch yields an EMPTY array, not one empty-string entry', () => {
+    // The old newline split produced [''] for an empty diff and leaned on filter(Boolean); the
+    // NUL split must behave the same way rather than emitting a phantom path.
+    const { changedFiles } = collectSdDiff({ appPath: dir, baseRef: 'HEAD' });
+    expect(changedFiles).toEqual([]);
+  });
+});
+
+describe('CONTROL: the fixture and the runner behave as claimed', () => {
+  it('a POSIX sh was resolvable, or the backtick arm honestly skipped', () => {
+    // Recorded so a skipped arm is visible rather than silently absent from the count.
+    expect(SH === null || typeof SH === 'string').toBe(true);
+  });
+
+  it('NOTE: an embedded double-quote payload is NOT fixture-tested here', () => {
+    // Stated rather than quietly omitted. `"` is illegal in an NTFS filename AND git itself
+    // refuses such a path (core.protectNTFS defaults to true, cross-platform), so it cannot be
+    // committed without -c core.protectNTFS=false plumbing. Its defence is ARCHITECTURAL — after
+    // this fix there is no shell layer for a quote to escape from — not measured by a fixture.
+    // This assertion exists to keep that admission in the suite instead of only in a PR body.
+    expect(true).toBe(true);
+  });
+});

--- a/lib/gates/operator-contract/harness-adapter.js
+++ b/lib/gates/operator-contract/harness-adapter.js
@@ -12,7 +12,14 @@
  * error) resolves to PASS with a warning — never a false block. Only an
  * unambiguous CREATOR-without-triple-and-no-valid-waiver produces a hard block.
  */
-import { execSync } from 'node:child_process';
+// SD-LEO-FIX-SHELL-INJECTION-RCE-001: execFileSync, NOT execSync and NOT spawnSync.
+// execFileSync takes an argv ARRAY and never involves a shell, which is the whole fix.
+// It is also the only drop-in for the contract below: like execSync it returns stdout as a
+// string and THROWS on a non-zero exit, so the fail-open per-file catch that records
+// `unreadable` keeps firing. spawnSync returns {stdout,stderr,status} and does NOT throw —
+// swapping it in here would silently stop that SEC-4b bookkeeping from ever recording a
+// genuine per-file diff failure.
+import { execFileSync } from 'node:child_process';
 import { evaluateOperatorContract, detectCreator, validateConsumer, detectWiring, validateCadence, validateReaper } from './index.js';
 import { RETENTION_POLICIES, SOAK_ENTRIES } from '../../retention/policies.js';
 
@@ -33,12 +40,33 @@ export function collectSdDiff({ appPath, baseRef = 'origin/main' } = {}) {
   // migration is invisible to detectCreator. Raised, and truncation is now recorded rather than
   // silently absorbed, because "read nothing" and "read successfully, found nothing" must not
   // look identical.
-  const run = (cmd) => execSync(cmd, {
+  // SD-LEO-FIX-SHELL-INJECTION-RCE-001. This helper used to take a COMMAND STRING and hand it to
+  // execSync, which runs it through /bin/sh on POSIX and cmd.exe on Windows. The per-file call
+  // below interpolated a GIT-SUPPLIED FILENAME into that string, so a committed file whose NAME
+  // contained $(...) or a backtick executed as a command — in a process holding
+  // SUPABASE_SERVICE_ROLE_KEY. Reproduced, not theorised: a throwaway repo with a
+  // backtick-`touch` filename returned it byte-verbatim from `git diff --name-only`, and running
+  // the interpolated command under real sh created the marker file.
+  //
+  // The fix is not escaping — escaping IS the failure mode. It is to never build a command
+  // string: `git` is the executable and every other token is a discrete argv element, so the OS
+  // hands them to git as data and no shell ever parses them.
+  const run = (args) => execFileSync('git', args, {
     cwd: appPath, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], maxBuffer: 64 * 1024 * 1024,
   });
   const unreadable = [];
-  // merge-base diff so we only see the SD's own changes
-  const nameOnly = run(`git diff --name-only ${baseRef}...HEAD`).split('\n').map((s) => s.trim()).filter(Boolean);
+  // merge-base diff so we only see the SD's own changes.
+  //
+  // -z is NUL-delimited AND suppresses git's path quoting entirely. That matters twice over:
+  // git's quoting is inconsistent BETWEEN SUBCOMMANDS (measured: `git status --short` quotes a
+  // backtick-bearing filename while plain `git diff --name-only` returns the identical name
+  // unquoted), and splitting on '\n' silently mis-parses any filename containing a literal
+  // newline — legal in a git tree entry — into bogus path fragments.
+  //
+  // No .trim() here, deliberately. The old newline split needed it to clean up whitespace
+  // artefacts; with NUL delimiters the bytes between separators ARE the path, and trimming would
+  // corrupt a filename that legitimately begins or ends with a space.
+  const nameOnly = run(['diff', '--name-only', '-z', `${baseRef}...HEAD`]).split('\0').filter(Boolean);
   const changedFiles = [];
   const migrations = [];
   const createdTables = [];
@@ -47,7 +75,18 @@ export function collectSdDiff({ appPath, baseRef = 'origin/main' } = {}) {
     let added = '';
     try {
       // only the added lines (leading '+', excluding the +++ header)
-      const patch = run(`git diff ${baseRef}...HEAD -- "${path}"`);
+      // THIS WAS THE RCE LINE. It read: run(`git diff ${baseRef}...HEAD -- "${path}"`) — the
+      // filename interpolated inside double quotes in a shell string. Double quotes do NOT save
+      // you: under POSIX sh they suppress ; and & but $(...) and backticks still expand inside
+      // them, and an embedded " ends the quoting and re-arms everything else.
+      //
+      // The path is now its own argv element after --, so git receives it as a pathspec and
+      // nothing parses it as syntax. This also closes a SECOND, quieter vector for free: under
+      // cmd.exe a file named f%PATH%.js had %PATH% expanded BEFORE git saw the argument, so git
+      // matched no pathspec and exited 0 with an EMPTY diff — no error, so the catch below never
+      // fired and the file read as having no added lines. A gate that could be made to see
+      // nothing is worse than one that crashes.
+      const patch = run(['diff', `${baseRef}...HEAD`, '--', path]);
       added = patch.split('\n').filter((l) => l.startsWith('+') && !l.startsWith('+++')).map((l) => l.slice(1)).join('\n');
     } catch (e) {
       // Named, not swallowed: an unreadable file is a KNOWN BLIND SPOT for this run.


### PR DESCRIPTION
## The defect, reproduced rather than argued

`collectSdDiff` read each file's diff with:

```js
const patch = run(`git diff ${baseRef}...HEAD -- "${path}"`);
```

where `path` came straight out of `git diff --name-only`. `execSync` runs a command **string** through `/bin/sh` on POSIX and `cmd.exe` on Windows, so a committed file whose **name** contained `$(...)` or a backtick executed as a command — inside a process holding `SUPABASE_SERVICE_ROLE_KEY`.

Reproduced, not inferred: a throwaway repo with a file named ``pwn`touch MARKER.txt`end.txt`` — `git diff --name-only` returns that name **byte-verbatim** (git does not escape it for you), and the interpolated command under a real `sh` **created the marker**.

The double quotes were never protection. Under `sh` they suppress `;` and `&` while command substitution still expands *inside* them, and an embedded `"` ends the quoting and re-arms the rest.

## The fix is not escaping — escaping *is* the failure mode

`git` is now the executable and every other token is a discrete argv element, so the OS hands them to git as data and no shell ever parses them.

**`execFileSync` specifically, not `spawnSync`.** Like `execSync` it returns stdout as a string and **throws** on non-zero exit, so the fail-open per-file `catch` that records `unreadable` keeps firing. `spawnSync` returns `{stdout,stderr,status}` and does *not* throw — swapping it in would have silently stopped that SEC-4b bookkeeping from ever recording a real per-file failure. A security fix that introduces a new silent failure is not a fix.

**`-z` earns its place three times.** It suppresses git's path quoting, which is **inconsistent between subcommands** — measured: `git status --short` quotes a backtick-bearing filename while plain `git diff --name-only` returns the identical name unquoted, so any parser keyed to one subcommand's quoting is wrong about the other. It also fixes a latent bug nobody was tracking: splitting on `\n` mis-parses a filename containing a literal newline — legal in a git tree entry — into bogus path fragments. The `.trim()` is deliberately gone: with NUL delimiters the bytes between separators *are* the path, and trimming would corrupt a name that legitimately begins or ends with a space.

**A second, quieter vector closes for free.** Under `cmd.exe` a file named `f%PATH%.js` had `%PATH%` expanded *before* git saw the argument, so git matched no pathspec and exited **0 with an empty diff**. No error meant the `catch` never fired and the file read as "present, no added lines". A gate that can be made to see nothing is worse than one that crashes.

## The verifier is the deliverable

This path had **zero** coverage before this PR. `harness-adapter.test.js` covers gate shape and fail-open; the sibling `operator-contract.test.js` deliberately *avoids* `collectSdDiff` and says so in its own docblock. Nothing anywhere fed this function an adversarial filename.

**Every positive claim is armed first.** The backtick arm runs the *original vulnerable shape* against the same fixture under a real `sh` and asserts the marker **is** created — because "no marker" is otherwise indistinguishable from "the payload could never fire here", which is exactly how a security test becomes decorative. That arm is platform-split **by measurement**: under Windows' default `execSync` (cmd.exe) there is no command substitution, so vulnerable and fixed forms *both* produce no marker and the assertion cannot discriminate; it resolves `sh.exe` (PATH under both spellings, then Git-for-Windows locations) and skips honestly if absent. The `%VAR%` arm is the mirror image and fires on Windows defaults with no shell-forcing. CI is ubuntu-latest, so the backtick arm fires there.

**Both halves are asserted:** no marker **and** the adversarial filename is *still returned* in `changedFiles`. "No marker" alone would also be satisfied by a fix that simply stopped seeing the file — trading the RCE for silent evasion, which is worse than the defect.

**`child_process` is never mocked.** `collectSdDiff` calls its runner **twice** per file and the per-file call is the RCE line; a mock inspecting only the first call would miss the defect entirely.

**One test of mine was wrong and the suite caught it.** I asserted `changedFiles` carried the `.sql` file. It does not — `.sql` routes to `migrations`. Corrected to the contract the code implements rather than the one I assumed.

## Stated plainly, not quietly omitted

**The embedded-double-quote payload is NOT fixture-tested.** `"` is illegal in an NTFS filename *and* git itself refuses such a path (`core.protectNTFS` defaults true, cross-platform), so it cannot be committed without `-c core.protectNTFS=false` plumbing. Its defence here is **architectural** — after this fix there is no shell layer for a quote to escape from — not measured by a fixture. A control test carries that admission so it lives in the suite, not only in this PR body.

## Mutation-proven

Reverting to `execSync` + the interpolated string turns **5 tests red**, with the file still parsing (a syntactically-broken mutation is not a red). Restored: **158/158 green** across `lib/gates/operator-contract`.

## Scope — deliberately not expanded

`collectSdDiff` is **CLI-only, not CI-reachable**. Two siblings carry the same pattern and **are** CI-reachable on every PR (ubuntu-latest, where `$(...)` fires):

- `scripts/docmon.js:162` (and unquoted `:386`)
- `scripts/lint/schema-reference-lint.mjs:153` — completely unquoted, `continue-on-error: false` → **blocking**

These are **named in the PRD and tracked separately**; the coordinator ruled this SD stays on `collectSdDiff`. They are not closed by this PR.

Latency context: 17,498 tracked files, **zero** containing `` $ ` ; & % ``. The defect required a hostile commit, not an accidental one — which is why this is a fix, not an incident.

SD: SD-LEO-FIX-SHELL-INJECTION-RCE-001
