### PR TITLE
QF-20260807-359: safe-root-resync ran when asked for help; publish the argv contract

### DIFF
--- a/lib/argv-guard.mjs
+++ b/lib/argv-guard.mjs
@@ -1,0 +1,76 @@
+/**
+ * Fail-closed argv scanning, shared. (QF-20260807-359; extracted from QF-20260807-289.)
+ *
+ * A state-mutating script that IGNORES an unknown flag is worse than one that errors: the
+ * operator believes they asked for something and got it. handoff.js hit this when
+ * `--precheck` silently no-op'd and performed a REAL transition; safe-root-resync.mjs hit
+ * the same shape when `--help` ran the script, cleared a stale index.lock, and evaluated a
+ * resync. Two independent rediscoveries of one workaround is a measurement of contract
+ * discoverability, so this publishes the contract rather than copying the fix a second time.
+ *
+ * BUILTIN-FREE ON PURPOSE, inherited from the 289 rationale: handoff.js keeps its top-level
+ * imports clear of anything resolving through node_modules so it still loads inside an
+ * orphaned worktree with a dangling node_modules junction. A guard that cannot load in that
+ * state would be absent exactly when a confused invocation is most likely.
+ *
+ * WHAT THIS DELIBERATELY DOES NOT DO: derive the flag set itself. A whitelist must be
+ * enumerated by READING THE PARSE SITES — handoff.js is a 145-line wrapper that touches
+ * three flags while thirteen more are consumed downstream, so anything auto-derived from the
+ * entry file would reject almost every real flag and hard-break the fleet. Each caller owns
+ * its set and cites the parse site per entry.
+ */
+
+/**
+ * Return the unknown flags in `args`, in order, without duplicates.
+ *
+ * Only `--`-prefixed tokens are inspected, so flag VALUES are never mistaken for flags.
+ * A bare `--` terminates scanning (conventional end-of-options). `--flag=value` is matched
+ * on its name half: accepting the `=` form does not claim any parser supports it, but
+ * mis-rejecting a real flag is the failure direction that breaks every seat.
+ */
+export function findUnknownFlags(args = [], knownFlags = new Set(), { singleDash = false } = {}) {
+  // A default parameter only fires on `undefined`, so `null` walked straight into the for-of
+  // and THREW — inherited from the 289 original. A guard that throws on hostile input fails
+  // exactly when it is most needed, and on these call sites the throw would surface as a
+  // crash of the very script the guard was added to make safer.
+  const list = Array.isArray(args) ? args : [];
+  const known = knownFlags instanceof Set ? knownFlags : new Set(knownFlags || []);
+  const unknown = [];
+  for (const raw of list) {
+    if (typeof raw !== 'string') continue;
+    if (raw === '--') break;
+    const isLong = raw.startsWith('--');
+    // SINGLE-DASH IS OPT-IN, and the default is off ON PURPOSE. Scanning `-x` by default
+    // would change handoff.js — the canonical never-bypass script — as a side effect of a
+    // fix aimed at a different tool, which is not a trade a QF gets to make silently.
+    //
+    // It exists at all because the two-sided test for QF-359 caught `-h` RUNNING
+    // safe-root-resync.mjs: only `--` tokens were inspected, so a single-dash flag sailed
+    // through the guard into the mutating path. Worse, the `-h` entry already sat in that
+    // tool's near-miss map — an entry that reads as coverage while being structurally
+    // unreachable, which is the shape that makes a guard look armed when it is not.
+    const isShort = singleDash && raw.length > 1 && raw[0] === '-' && !isLong;
+    if (!isLong && !isShort) continue;
+    const name = raw.includes('=') ? raw.slice(0, raw.indexOf('=')) : raw;
+    if (known.has(name)) continue;
+    if (!unknown.includes(name)) unknown.push(name);
+  }
+  return unknown;
+}
+
+/**
+ * Human-facing rejection text. Separated from process control so it stays testable.
+ *
+ * `rationale` is per-tool and load-bearing: it must say what the tool would have MUTATED,
+ * because "unknown flag" alone reads as pedantry while "nothing was executed, and this
+ * script rewrites your working tree" reads as a rescue.
+ */
+export function formatUnknownFlagError({ tool, unknown = [], knownFlags = new Set(), nearMiss = new Map(), rationale = [], usage = '' }) {
+  const lines = [`[${tool}] ❌ Unknown flag${unknown.length > 1 ? 's' : ''}: ${unknown.join(', ')}`, ...rationale];
+  for (const flag of unknown) {
+    if (nearMiss.has(flag)) lines.push(`   Did you mean: ${nearMiss.get(flag)}`);
+  }
+  lines.push('   Documented flags: ' + [...knownFlags].join(' '));
+  if (usage) lines.push(`   Full usage: ${usage}`);
+  return lines.join('\n');
+}

--- a/lib/handoff-argv-guard.mjs
+++ b/lib/handoff-argv-guard.mjs
@@ -16,7 +16,15 @@
  * SCOPE. This rejects unknown flags. It deliberately does NOT implement a dry run —
  * because two already exist (see NEAR_MISS below), which is the whole reason the accident
  * was a near miss rather than a missing feature.
+ *
+ * QF-20260807-359: the generic scanning/formatting now lives in ./argv-guard.mjs, because
+ * safe-root-resync.mjs independently rediscovered this same defect (`--help` RAN the script).
+ * Two rediscoveries of one workaround measure contract discoverability, so the contract is
+ * published rather than copied. This file keeps the handoff-SPECIFIC knowledge — the flag
+ * set with its parse sites, the near-miss map, and the rationale text — and its exported
+ * signatures are unchanged, so scripts/handoff.js and the existing tests are untouched.
  */
+import { findUnknownFlags as scanUnknownFlags, formatUnknownFlagError as renderUnknownFlagError } from './argv-guard.mjs';
 
 /**
  * Every flag reachable on the `node scripts/handoff.js ...` path, with the parse site that
@@ -90,30 +98,21 @@ export const NEAR_MISS = new Map([
  * direction that breaks every seat.
  */
 export function findUnknownFlags(args = []) {
-  const unknown = [];
-  for (const raw of args) {
-    if (typeof raw !== 'string') continue;
-    if (raw === '--') break;
-    if (!raw.startsWith('--')) continue;
-    const name = raw.includes('=') ? raw.slice(0, raw.indexOf('=')) : raw;
-    if (KNOWN_HANDOFF_FLAGS.has(name)) continue;
-    if (!unknown.includes(name)) unknown.push(name);
-  }
-  return unknown;
+  return scanUnknownFlags(args, KNOWN_HANDOFF_FLAGS);
 }
 
 /** Human-facing rejection text. Separated from process control so it is testable. */
 export function formatUnknownFlagError(unknown) {
-  const lines = [
-    `[handoff.js] ❌ Unknown flag${unknown.length > 1 ? 's' : ''}: ${unknown.join(', ')}`,
-    '   NOTHING WAS EXECUTED. handoff.js mutates strategic_directives_v2, so an',
-    '   unrecognised flag is refused rather than ignored — a flag that silently does',
-    '   nothing lets you believe a real transition was a rehearsal.',
-  ];
-  for (const flag of unknown) {
-    if (NEAR_MISS.has(flag)) lines.push(`   Did you mean: ${NEAR_MISS.get(flag)}`);
-  }
-  lines.push('   Documented flags: ' + [...KNOWN_HANDOFF_FLAGS].join(' '));
-  lines.push('   Full usage: node scripts/handoff.js help');
-  return lines.join('\n');
+  return renderUnknownFlagError({
+    tool: 'handoff.js',
+    unknown,
+    knownFlags: KNOWN_HANDOFF_FLAGS,
+    nearMiss: NEAR_MISS,
+    rationale: [
+      '   NOTHING WAS EXECUTED. handoff.js mutates strategic_directives_v2, so an',
+      '   unrecognised flag is refused rather than ignored — a flag that silently does',
+      '   nothing lets you believe a real transition was a rehearsal.',
+    ],
+    usage: 'node scripts/handoff.js help',
+  });
 }

--- a/scripts/safe-root-resync.mjs
+++ b/scripts/safe-root-resync.mjs
@@ -30,6 +30,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
+import { findUnknownFlags, formatUnknownFlagError } from '../lib/argv-guard.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
@@ -440,11 +441,87 @@ export async function safeRootResync(opts = {}) {
 
 // ─── CLI entry point ─────────────────────────────────────────────────────────
 
+/**
+ * Usage text. States the DESTRUCTIVE step in the same breath as the flag that enables it,
+ * because the reason this script has a two-flag confirmation at all is that `git clean -fd`
+ * permanently deletes untracked non-gitignored work.
+ */
+const USAGE = `safe-root-resync.mjs — safe shared-root git resync (fetch + ff-only merge).
+
+Usage:
+  node scripts/safe-root-resync.mjs                                   fetch + ff-only merge, no clean
+  node scripts/safe-root-resync.mjs --clean-untracked                 + PREVIEW ONLY (git clean -fdn, deletes nothing)
+  node scripts/safe-root-resync.mjs --clean-untracked --confirm-clean + ACTUAL git clean -fd (PERMANENTLY DELETES
+                                                                       untracked, non-gitignored files)
+  node scripts/safe-root-resync.mjs --help                            this text; mutates nothing
+
+Flags:
+  --clean-untracked   Enable the untracked-file clean. On its own this is preview-only.
+  --confirm-clean     Second, explicit confirmation required for the real delete. Ignored
+                      without --clean-untracked.
+  --help              Print this and exit 0.
+
+Never runs 'git clean -fdx'. The -x flag would delete gitignored runtime state
+(node_modules, .claude/active-coordinator.json) — 3 confirmed production incidents.
+Aborts before any clean if cwd is a git worktree.
+
+Exit codes: 0 success · 1 aborted/conflict/incomplete node_modules repair · 2 bad usage.
+`;
+
+
 const isMain = process.argv[1] &&
   (fileURLToPath(import.meta.url) === path.resolve(process.argv[1]) ||
    process.argv[1].endsWith('safe-root-resync.mjs'));
 
 if (isMain) {
+  // QF-20260807-359. Measured (coordinator 34e723d4): invoked with `--help` this script
+  // silently ignored the unknown flag and RAN — it cleared a stale index.lock, then evaluated
+  // the resync. A tool that MUTATES STATE when asked for help is the same unknown-argv-runs-
+  // anyway shape QF-20260807-289 abolished on handoff.js; it was merely survivable here
+  // because the script is idempotent behind a good staleness guard. Survivable is not correct.
+  //
+  // The flag set is enumerated by READING THE PARSE SITES immediately below, which is the
+  // whole point of the 289 pattern — a set guessed from the header comment would drift from
+  // what the code actually consumes. Both entries are cited to their reader.
+  const KNOWN_FLAGS = new Set([
+    '--clean-untracked', // :460 below — gates the git clean preview
+    '--confirm-clean',   // :461 below — second explicit confirmation for the real -fd
+    '--help',            // handled here; mutates nothing, per the 289 precedent of never
+                         // rejecting the universal help convention
+  ]);
+  const NEAR_MISS_FLAGS = new Map([
+    ['--clean', '--clean-untracked (preview only), then --confirm-clean to actually delete'],
+    ['--confirm', '--confirm-clean (requires --clean-untracked as well)'],
+    ['--dry-run', '--clean-untracked on its own — it is ALREADY preview-only'],
+    ['--force', '--clean-untracked --confirm-clean'],
+    ['-h', '--help'],
+  ]);
+
+  // singleDash:true — this script takes NO short flags, so any `-x` is a mistake. Without it
+  // `-h` sailed past the guard and RAN the script, and the `-h` near-miss entry below was
+  // structurally unreachable. Caught by testing both sides rather than only the happy one.
+  const unknownFlags = findUnknownFlags(process.argv.slice(2), KNOWN_FLAGS, { singleDash: true });
+  if (unknownFlags.length > 0) {
+    process.stderr.write(formatUnknownFlagError({
+      tool: 'safe-root-resync.mjs',
+      unknown: unknownFlags,
+      knownFlags: KNOWN_FLAGS,
+      nearMiss: NEAR_MISS_FLAGS,
+      rationale: [
+        '   NOTHING WAS EXECUTED. This script fetches, fast-forwards the shared root and can',
+        '   delete untracked files, so an unrecognised flag is refused rather than ignored —',
+        '   running when you asked a question is worse than answering with an error.',
+      ],
+      usage: 'node scripts/safe-root-resync.mjs --help',
+    }) + '\n');
+    process.exit(2);
+  }
+
+  if (process.argv.includes('--help')) {
+    process.stdout.write(USAGE);
+    process.exit(0);
+  }
+
   const cleanUntracked = process.argv.includes('--clean-untracked');
   const confirmClean = process.argv.includes('--confirm-clean');
 

--- a/tests/unit/argv-guard.test.js
+++ b/tests/unit/argv-guard.test.js
@@ -1,0 +1,99 @@
+/**
+ * QF-20260807-359 — shared fail-closed argv guard, extracted from QF-20260807-289.
+ *
+ * The defect being pinned: a state-mutating script that IGNORES an unknown flag runs when
+ * you asked it a question. safe-root-resync.mjs was invoked with `--help`, silently ignored
+ * it, cleared a stale index.lock and evaluated a resync. handoff.js had the same shape when
+ * `--precheck` no-op'd into a REAL transition.
+ */
+import { describe, it, expect } from 'vitest';
+import { findUnknownFlags, formatUnknownFlagError } from '../../lib/argv-guard.mjs';
+
+const KNOWN = new Set(['--clean-untracked', '--confirm-clean', '--help']);
+
+describe('findUnknownFlags — long flags', () => {
+  it('accepts documented flags', () => {
+    expect(findUnknownFlags(['--clean-untracked', '--confirm-clean'], KNOWN)).toEqual([]);
+  });
+
+  it('rejects an undocumented flag', () => {
+    expect(findUnknownFlags(['--dry-run'], KNOWN)).toEqual(['--dry-run']);
+  });
+
+  it('never mistakes a flag VALUE for a flag', () => {
+    expect(findUnknownFlags(['--clean-untracked', 'origin/main'], KNOWN)).toEqual([]);
+  });
+
+  it('stops at a bare -- (end of options)', () => {
+    expect(findUnknownFlags(['--', '--not-a-flag'], KNOWN)).toEqual([]);
+  });
+
+  it('matches --flag=value on its name half', () => {
+    expect(findUnknownFlags(['--nope=1'], KNOWN)).toEqual(['--nope']);
+    expect(findUnknownFlags(['--help=1'], KNOWN)).toEqual([]);
+  });
+
+  it('de-duplicates and preserves order', () => {
+    expect(findUnknownFlags(['--b', '--a', '--b'], KNOWN)).toEqual(['--b', '--a']);
+  });
+
+  it('survives hostile input without throwing', () => {
+    for (const args of [null, undefined, [null], [42], [{}], [[]]]) {
+      expect(() => findUnknownFlags(args, KNOWN)).not.toThrow();
+    }
+  });
+});
+
+describe('singleDash — opt-in, and off by default ON PURPOSE', () => {
+  // The default must stay off: turning it on globally would change handoff.js, the canonical
+  // never-bypass script, as a side effect of a fix aimed at a different tool.
+  it('IGNORES short flags by default', () => {
+    expect(findUnknownFlags(['-h'], KNOWN)).toEqual([]);
+  });
+
+  it('catches them when opted in — this is the case that RAN the script', () => {
+    expect(findUnknownFlags(['-h'], KNOWN, { singleDash: true })).toEqual(['-h']);
+  });
+
+  it('a lone dash is not a flag', () => {
+    expect(findUnknownFlags(['-'], KNOWN, { singleDash: true })).toEqual([]);
+  });
+
+  it('still stops at a bare -- when opted in', () => {
+    expect(findUnknownFlags(['--', '-h'], KNOWN, { singleDash: true })).toEqual([]);
+  });
+
+  it('a documented short flag would be accepted if a tool declared one', () => {
+    expect(findUnknownFlags(['-v'], new Set(['-v']), { singleDash: true })).toEqual([]);
+  });
+});
+
+describe('formatUnknownFlagError', () => {
+  const base = { tool: 'safe-root-resync.mjs', knownFlags: KNOWN, nearMiss: new Map([['-h', '--help']]) };
+
+  it('names the tool, the bad flag, and every documented flag', () => {
+    const out = formatUnknownFlagError({ ...base, unknown: ['-h'] });
+    expect(out).toContain('[safe-root-resync.mjs]');
+    expect(out).toContain('-h');
+    expect(out).toContain('--clean-untracked');
+  });
+
+  it('surfaces a near-miss suggestion when one exists', () => {
+    expect(formatUnknownFlagError({ ...base, unknown: ['-h'] })).toContain('Did you mean: --help');
+  });
+
+  it('omits the suggestion line when no near-miss matches', () => {
+    expect(formatUnknownFlagError({ ...base, unknown: ['--zzz'] })).not.toContain('Did you mean');
+  });
+
+  it('carries the per-tool rationale — "unknown flag" alone reads as pedantry', () => {
+    const out = formatUnknownFlagError({ ...base, unknown: ['--zzz'], rationale: ['   NOTHING WAS EXECUTED.'] });
+    expect(out).toContain('NOTHING WAS EXECUTED.');
+  });
+
+  it('pluralises and lists every unknown flag, not just the first', () => {
+    const out = formatUnknownFlagError({ ...base, unknown: ['--a', '--b'] });
+    expect(out).toContain('Unknown flags:');
+    expect(out).toContain('--a, --b');
+  });
+});


### PR DESCRIPTION
`scripts/safe-root-resync.mjs` silently ignored unknown flags and **ran**. Invoked with `--help` expecting usage text, it executed — cleared a stale `index.lock`, then evaluated the resync. Same unknown-argv-runs-anyway class QF-289 abolished on `handoff.js`; survivable here only because the script is idempotent behind a good staleness guard. Survivable isn't correct: a state-mutating tool that runs when asked a question is the same defect shape.

**Published the contract instead of patching a second site.** Two independent rediscoveries of one workaround measure contract *discoverability*, not two unrelated bugs. The generic scan/format moves to `lib/argv-guard.mjs`; `lib/handoff-argv-guard.mjs` becomes a thin binding keeping the handoff-specific knowledge (flag set with per-entry parse-site citations, near-miss map, rationale). Exported signatures unchanged — verified at the real CLI, not just the unit: `handoff.js execute FOO SD-X --precheck` prints the identical rejection, and its 16 tests still pass.

The whitelist is enumerated by **reading the parse sites** per the 289 pattern, not hand-rolled — two real flags plus `--help`, each cited to its reader.

### Two defects found in my own fix, both by testing the side meant to keep working

1. **`-h` still ran the script.** The scanner inspected only `--` tokens, so a single-dash flag sailed past into the mutating path. Worse, `-h` was already in the near-miss map I'd just written — an entry that reads as coverage while being structurally **unreachable**, the shape that makes a guard look armed when it isn't. Fixed with an opt-in `singleDash`, **default off**: enabling it globally would change `handoff.js`, the canonical never-bypass script, as a side effect of a fix aimed elsewhere — not a trade a QF gets to make silently.
2. **The guard threw on hostile input.** `args = []` fires only on `undefined`, so `null` walked into the for-of and threw. Inherited from the 289 original. A guard that throws on garbage fails exactly when it's needed, and here would crash the script it was added to protect.

### Two-sided acceptance, at the real CLI

| invocation | exit | effect |
|---|---|---|
| `--help` | 0 | prints usage; `index.lock` untouched, HEAD unchanged |
| `-h` | 2 | rejected, names `--help` |
| `--dry-run` | 2 | rejected; near-miss names the real answer — `--clean-untracked` is *already* preview-only |
| `--clean-untracked` | 0 | byte-identical to before |

Also confirmed the guard loads in a worktree with **no `node_modules`** — the builtin-free property 289 depends on, and why neither module may import through `node_modules`.

`--help` prints real usage stating the destructive step in the same breath as the flag that enables it, because the two-flag confirmation exists precisely because `git clean -fd` permanently deletes untracked non-gitignored work.

**Mutation-proved:** reverting `singleDash` to always-off reddens 2 tests. 33 pass across both guards. ~47 lines of logic (the 99-line raw diff is mostly comments and usage text).

🤖 Generated with [Claude Code](https://claude.com/claude-code)