### PR TITLE
fix(SD-LEO-FIX-SHELL-INJECTION-RCE-001): close the pathspec-magic hole the argv fix left open

### DIFF
--- a/lib/gates/operator-contract/__tests__/harness-adapter-shell-injection.test.js
+++ b/lib/gates/operator-contract/__tests__/harness-adapter-shell-injection.test.js
@@ -201,12 +201,150 @@ describe('the ordinary path is unchanged — including the .sql branch', () => {
   });
 });
 
-describe('CONTROL: the fixture and the runner behave as claimed', () => {
-  it('a POSIX sh was resolvable, or the backtick arm honestly skipped', () => {
-    // Recorded so a skipped arm is visible rather than silently absent from the count.
-    expect(SH === null || typeof SH === 'string').toBe(true);
+/**
+ * Build a repo whose commit contains paths the FILESYSTEM refuses. `:` and a literal newline are
+ * both illegal in an NTFS filename, and `git add`/`update-index` validate the worktree path — so
+ * the payloads below cannot be committed the ordinary way. `mktree` writes a tree object
+ * directly, which is legitimate here precisely because collectSdDiff reads TREES (`a...b`) and
+ * never needs a checkout. Without this the two vectors below would be untestable on Windows and
+ * would have shipped on a promise.
+ */
+function makeRepoRaw(files) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'rce-raw-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Test']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  fs.writeFileSync(path.join(dir, 'base.txt'), 'base\n');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', 'base']);
+  git(dir, ['branch', '-f', 'basebranch']);
+  const parent = git(dir, ['rev-parse', 'HEAD']).trim();
+
+  const entries = [['base.txt', git(dir, ['rev-parse', 'HEAD:base.txt']).trim()]];
+  for (const [name, body] of Object.entries(files)) {
+    const sha = execFileSync('git', ['hash-object', '-w', '--stdin'], { cwd: dir, input: body, encoding: 'utf8' }).trim();
+    entries.push([name, sha]);
+  }
+  entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  const spec = entries.map(([name, sha]) => `100644 blob ${sha}\t${name}\0`).join('');
+  const tree = execFileSync('git', ['mktree', '-z'], { cwd: dir, input: spec, encoding: 'utf8' }).trim();
+  const commit = execFileSync('git', ['commit-tree', tree, '-p', parent, '-m', 'raw fixtures'], { cwd: dir, encoding: 'utf8' }).trim();
+  git(dir, ['update-ref', 'refs/heads/main', commit]);
+  return dir;
+}
+
+describe('ARMED: SEC-R1 — pathspec magic survives `--` (the argv fix alone did NOT close this)', () => {
+  // Found by adversarial review AFTER the argv fix landed, and it falsified a comment shipped
+  // with that fix ("nothing parses it as syntax"). `--` ends OPTION parsing; it leaves PATHSPEC
+  // MAGIC live. Strictly worse than the %VAR% vector: that one needs cmd.exe, this works
+  // everywhere. Fixed with --literal-pathspecs in the runner.
+  const ATTACK = ':(literal)hidden.sql';
+  const CONTROL = 'hidden.sql';
+  const SQL = 'CREATE TABLE IF NOT EXISTS stealth_table (id uuid primary key);\n';
+  // TWO SEPARATE REPOS, deliberately. The first version of this fixture put both files in ONE
+  // repo and the arm FAILED — because `:(literal)hidden.sql` means "the literal path
+  // hidden.sql", the magic name resolved onto its own control sitting beside it and returned a
+  // perfectly good diff. A single-repo fixture cannot express this vector at all: the payload
+  // needs the plain name to be ABSENT for the empty read to be the empty read. Caught by the arm,
+  // which is the entire reason the arm exists.
+  let dir; let controlDir;
+  beforeAll(() => {
+    dir = makeRepoRaw({ [ATTACK]: SQL });
+    controlDir = makeRepoRaw({ [CONTROL]: SQL });
+  });
+  afterAll(() => { if (dir) rm(dir); if (controlDir) rm(controlDir); });
+
+  it('THE ARM: without --literal-pathspecs git returns an EMPTY diff and throws NOTHING', () => {
+    // The blinding itself, proven on this host before anything is claimed about the fix.
+    // Zero bytes AND no throw is what makes it silent: the per-file catch never fires, so
+    // `unreadable` stays empty and the gate reports a clean read of a file it never read.
+    let threw = false; let out = null;
+    try {
+      out = execFileSync('git', ['diff', 'basebranch...HEAD', '--', ATTACK], { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    } catch { threw = true; }
+    expect(threw, 'the vector must NOT throw — that is what makes it silent').toBe(false);
+    expect(out, 'git already reads this path literally, so this arm cannot discriminate').toBe('');
   });
 
+  it('THE ARM, other side: the SAME CONTENT under an ordinary name is read fine', () => {
+    // Two-sided by construction — identical bytes, identical fixture machinery, only the NAME
+    // differs. Without this, an empty diff could just mean the fixture never had content, and
+    // the vector above would be indistinguishable from a broken makeRepoRaw.
+    const out = execFileSync('git', ['diff', 'basebranch...HEAD', '--', CONTROL], { cwd: controlDir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    expect(out).toContain('CREATE TABLE');
+  });
+
+  it('THE FIX: collectSdDiff reads the magic-named file — the blocking CREATOR check is not blinded', () => {
+    const { migrations, createdTables, unreadable } = collectSdDiff({ appPath: dir, baseRef: 'basebranch' });
+    const entry = migrations.find((m) => m.path === ATTACK);
+    expect(entry, 'magic-named migration missing entirely').toBeTruthy();
+    expect(entry.sql, 'the file was enumerated but its CONTENT was never read — still blinded').toContain('CREATE TABLE');
+    expect(createdTables, 'detectCreator would see no table and the CREATOR check would flip').toContain('stealth_table');
+    expect(unreadable, 'a silently-empty read must never look like a successful one').toEqual([]);
+  });
+});
+
+describe('ARMED: -z is load-bearing, not cosmetic', () => {
+  // Added because a mutation review measured this honestly: deleting -z and restoring the old
+  // split('\n')+trim left the ENTIRE suite green. The -z half of the fix shipped with zero
+  // discriminating coverage, and the test that CLAIMED to guard it only pinned behaviour common
+  // to both forms. A newline in the name is the case that actually separates them.
+  const NAME = 'we\nird.js';
+  let dir;
+  beforeAll(() => { dir = makeRepoRaw({ [NAME]: 'const nl = 1;\n' }); });
+  afterAll(() => { if (dir) rm(dir); });
+
+  it('THE ARM: WITHOUT -z git C-QUOTES the name, so a newline split shreds it into fragments', () => {
+    const quoted = execFileSync('git', ['diff', '--name-only', 'basebranch...HEAD'], { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    const fragments = quoted.split('\n').map((s) => s.trim()).filter(Boolean);
+    // The discriminating claim is that the old form does NOT yield the true name. It fails by
+    // C-QUOTING rather than by splitting — git emits "we\nird.js" with a two-character \n escape
+    // inside literal quotes, so the old parser produced one CONFIDENTLY WRONG path rather than
+    // several obvious fragments. That is the worse failure of the two: a wrong name still looks
+    // like a name, and would have been reported as a real changed file.
+    expect(fragments, 'the pre-fix parser must NOT be able to recover the true name').not.toContain(NAME);
+    expect(fragments.some((f) => f.startsWith('"')), 'git did not quote at all here, so -z buys nothing on this host').toBe(true);
+  });
+
+  it('THE FIX: the newline-named file survives enumeration BYTE-EXACT and its content is read', () => {
+    const { changedFiles } = collectSdDiff({ appPath: dir, baseRef: 'basebranch' });
+    const entry = changedFiles.find((f) => f.path === NAME);
+    expect(entry, 'newline filename did not round-trip — the NUL split or the dropped .trim() regressed').toBeTruthy();
+    expect(entry.added).toContain('const nl = 1;');
+  });
+});
+
+describe('SEC-R2: an option-shaped baseRef is refused, not silently defaulted', () => {
+  let dir;
+  beforeAll(() => { dir = makeRepo({ 'a.js': 'const x = 1;\n' }); });
+  afterAll(() => { if (dir) rm(dir); });
+
+  it('THE ARM: git honours an option-shaped ref as an OPTION and creates a file, throwing nothing', () => {
+    // Argv-safety stops SHELLS, not ARGUMENT injection. Proven here rather than asserted, so the
+    // guard below is known to be defending something real.
+    const target = path.join(dir, 'OWNED.txt');
+    let threw = false;
+    try {
+      execFileSync('git', ['diff', `--output=${target}`, '--', 'a.js'], { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    } catch { threw = true; }
+    expect(threw, 'the primitive must be silent to be dangerous').toBe(false);
+    expect(fs.existsSync(target), 'git did not honour --output, so this arm proves nothing').toBe(true);
+  });
+
+  it('THE GUARD: collectSdDiff REFUSES it — loudly, rather than falling back to origin/main', () => {
+    // A silent fallback would make a rejected ref indistinguishable from an accepted one.
+    expect(() => collectSdDiff({ appPath: dir, baseRef: '--output=pwned.txt' })).toThrow(/unsafe shape/);
+    expect(fs.existsSync(path.join(dir, 'pwned.txt')), 'the refusal must happen BEFORE git runs').toBe(false);
+  });
+
+  it('the ordinary default ref shape is still accepted', () => {
+    // Two-sided: a guard that rejects everything would also pass the test above.
+    expect(() => collectSdDiff({ appPath: dir, baseRef: 'basebranch' })).not.toThrow();
+  });
+});
+
+describe('CONTROL: stated limits of this suite', () => {
   it('NOTE: an embedded double-quote payload is NOT fixture-tested here', () => {
     // Stated rather than quietly omitted. `"` is illegal in an NTFS filename AND git itself
     // refuses such a path (core.protectNTFS defaults to true, cross-platform), so it cannot be

--- a/lib/gates/operator-contract/harness-adapter.js
+++ b/lib/gates/operator-contract/harness-adapter.js
@@ -51,7 +51,38 @@ export function collectSdDiff({ appPath, baseRef = 'origin/main' } = {}) {
   // The fix is not escaping — escaping IS the failure mode. It is to never build a command
   // string: `git` is the executable and every other token is a discrete argv element, so the OS
   // hands them to git as data and no shell ever parses them.
-  const run = (args) => execFileSync('git', args, {
+  //
+  // SEC-R2 (adversarial security review of the fix above): argv-safety stops SHELLS, not
+  // ARGUMENT injection. baseRef is still interpolated into an argv element, and a value LEADING
+  // WITH A DASH is parsed by git as an OPTION rather than a ref — reproduced during review:
+  // baseRef='--output=<path>' made git honour --output, CREATE that file, and throw nothing.
+  // Not reachable today (the sole production caller at the bottom of this file passes no baseRef,
+  // so the 'origin/main' default always applies), but it is a local command-execution primitive
+  // the moment anyone wires baseRef to env, DB config or a flag. This repo already adopted the
+  // control for the IDENTICAL sink — lib/fleet/tree-currency.cjs:53 VALID_BASE_REF, applied at
+  // :105 for its own SEC-1 finding — and it simply was not carried here. Reuse the same shape,
+  // because safety-by-coincidence outlives the rule written to abolish it.
+  const VALID_BASE_REF = /^[A-Za-z0-9._][A-Za-z0-9._/-]*$/;
+  if (!VALID_BASE_REF.test(String(baseRef || ''))) {
+    // Thrown, not silently defaulted. The outer gate is fail-open and will record this as a
+    // warning; substituting origin/main here would make a rejected ref indistinguishable from an
+    // accepted one, which is the exact confusion the rest of this function exists to prevent.
+    throw new Error(`collectSdDiff: refusing baseRef with option-like or unsafe shape: ${baseRef}`);
+  }
+  // --literal-pathspecs is NOT decoration; it closes SEC-R1, found by adversarial review AFTER
+  // the argv fix landed. `--` ends OPTION parsing but does NOT disable PATHSPEC MAGIC: git still
+  // reads `:(literal)`, `:(icase)` and friends as SYNTAX in an argument after `--`. Measured,
+  // two-sided, same content and same fixture — only the NAME differs: `hidden.sql` yields its
+  // CREATE TABLE and detectCreator.is_creator=true, while `:(literal)hidden.sql` makes the
+  // per-file diff exit 0 with a ZERO-BYTE patch and throw NOTHING, so the catch never fires,
+  // `unreadable` stays empty, and the gate reports a clean read of a file it never read —
+  // flipping the blocking CREATOR check.
+  //
+  // That is the same silent-blinding CLASS as the %VAR% vector below, and strictly worse: %VAR%
+  // needs cmd.exe, this works everywhere. Fixing it in the RUNNER rather than at the two call
+  // sites is deliberate — a per-call-site fix is one forgotten argument away from regressing,
+  // and this way every git invocation in this function is literal by construction.
+  const run = (args) => execFileSync('git', ['--literal-pathspecs', ...args], {
     cwd: appPath, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], maxBuffer: 64 * 1024 * 1024,
   });
   const unreadable = [];
@@ -80,8 +111,12 @@ export function collectSdDiff({ appPath, baseRef = 'origin/main' } = {}) {
       // you: under POSIX sh they suppress ; and & but $(...) and backticks still expand inside
       // them, and an embedded " ends the quoting and re-arms everything else.
       //
-      // The path is now its own argv element after --, so git receives it as a pathspec and
-      // nothing parses it as syntax. This also closes a SECOND, quieter vector for free: under
+      // The path is now its own argv element after --, so no SHELL parses it. That is the whole
+      // of what argv-safety buys, and the first version of this comment overclaimed by saying
+      // "nothing parses it as syntax" — GIT still did. `--` ends option parsing but leaves
+      // PATHSPEC MAGIC live, so `:(literal)foo.sql` was still read as syntax and silently
+      // returned an empty diff. That is closed by --literal-pathspecs in the runner above (see
+      // SEC-R1 there), not by `--`. This also closes a SECOND, quieter vector for free: under
       // cmd.exe a file named f%PATH%.js had %PATH% expanded BEFORE git saw the argument, so git
       // matched no pathspec and exited 0 with an EMPTY diff — no error, so the catch below never
       // fired and the file read as having no added lines. A gate that could be made to see


### PR DESCRIPTION
Follow-up to #6870. Adversarial security review **after** that merge falsified a claim I shipped in it and found a live vector. Correction first.

## #6870's "5 tests RED" is wrong — the real number is 1

Its body says *"reverting to execSync + the interpolated string turns 5 tests RED"*. Two reviewers independently reverted to the **true parent commit** and both measured `1 failed | 157 passed`.

My mutation had been semantically broken — an argv array passed to a string-taking runner — so it produced **breakage-reds, not detection-reds**. That is precisely the error the "a syntactically-broken mutation is not a red" rule exists to catch, and I committed it while quoting the rule. The suite's real discriminating power was **1 test on Windows**. Corrected here rather than left standing in a merged commit.

## SEC-R1 — `--` does not disable pathspec magic (live, cross-platform)

#6870 moved the filename to its own argv element after `--`, and I commented that git *"receives it as a pathspec and nothing parses it as syntax."* The first half is right. **The second was false.** `--` ends **option** parsing only; git still reads `:(literal)`, `:(icase)` and friends as **syntax** in an argument after `--`.

Measured two-sided — identical content, identical fixture machinery, only the **name** differs:

| name | `migrations[0].sql` | `createdTables` | `detectCreator.is_creator` |
|---|---|---|---|
| `hidden.sql` (control) | the `CREATE TABLE` | `["stealth_table"]` | **true** |
| `:(literal)hidden.sql` | `""` | `[]` | **false** |

The per-file diff exits **0** with a **zero-byte** patch and **throws nothing** — so the catch never fires, `unreadable` stays empty, and the gate reports a clean read of a file it never read. That flips the **blocking** CREATOR check.

This is the same silent-blinding **class** #6870 claimed to close via the `%VAR%` vector, and strictly worse: `%VAR%` needs `cmd.exe`; this works everywhere. #6870 wrote *"a gate that could be made to see nothing is worse than one that crashes"* and then left a cross-platform way to do exactly that.

Fixed with `--literal-pathspecs` in the **runner**, not at the two call sites — a per-call-site fix is one forgotten argument away from regressing; this way every git invocation in the function is literal by construction.

## SEC-R2 — `baseRef` is argument-injectable, and the repo already had the control

Argv-safety stops **shells**, not **argument** injection. A ref leading with a dash is parsed by git as an **option**: `baseRef='--output=<path>'` makes git honour `--output`, **create that file**, and throw nothing.

Not reachable today — the sole production caller passes no `baseRef`, so the `origin/main` default always applies. The load-bearing part is that this isn't a new idea here: `lib/fleet/tree-currency.cjs:53` defines `VALID_BASE_REF` and `:98-105` records an **identical prior SEC-1 finding** for its own `baseRef`, with the same "not reachable today" caveat. The same sink in this file never got the guard. Same regex, reused deliberately.

It **throws** rather than falling back to `origin/main`: a silent fallback makes a rejected ref indistinguishable from an accepted one.

## The `-z` change had shipped with zero discriminating coverage

Proven by the same review: delete `-z`, restore the old `split('\n')`+`trim`, and the **entire suite stayed green**. The test that *claimed* to guard it only pinned behaviour common to both forms.

Now covered by a newline-in-filename fixture — the case that actually separates them. Worth noting *how* the old parser fails: by **C-quoting**, not by shredding. Git emits `"we\nird.js"` with a two-character escape, so the pre-fix code produced **one confidently wrong path** rather than obvious fragments. A wrong name still looks like a name.

## NTFS-illegal payloads are now actually tested, not waved at

`:` and a literal newline are illegal in NTFS filenames, and `git add` validates worktree paths — so these fixtures build tree objects directly via `mktree` + `commit-tree`. Legitimate because `collectSdDiff` reads **trees** and never needs a checkout. Without it both vectors would be untestable on Windows and would have shipped on a promise, which is how #6870's version of this got here.

**The arm caught my own fixture bug.** The first SEC-R1 fixture put attack and control in one repo and the arm **failed** — `:(literal)hidden.sql` means "the literal path `hidden.sql`", so the payload resolved onto its own control sitting beside it and returned a perfectly good diff. A single-repo fixture cannot express this vector at all. Two separate repos now; the arm is the only reason that was caught rather than shipped as a passing test.

## Mutation-proven, counted honestly

Each mutation verified to **parse and import** first:

| Mutation | Red |
|---|---|
| drop `--literal-pathspecs` | **1** (SEC-R1) |
| true pre-fix parse (no `-z`, old split) | **1** — was **0** before this PR |
| drop the `baseRef` guard | **1** (SEC-R2) |

**165/165** green across `lib/gates/operator-contract` (was 158).

Two tautological CONTROL tests removed. One asserted `SH === null || typeof SH === 'string'` — true for every possible execution — while claiming to make a skipped arm visible, which it never did.

## Scope unchanged

`scripts/docmon.js:162`/`:386` and `scripts/lint/schema-reference-lint.mjs:153` remain tracked separately. Review notes the two `git show` sites are **strictly worse** than the defect fixed here: with no surrounding quotes, `;` and `&` are live in addition to `$()` and backticks.

SD: SD-LEO-FIX-SHELL-INJECTION-RCE-001
