### PR TITLE
fix(QF-20260807-159): stamp a guess as a guess, and surface the hold-flip

### DIFF
--- a/lib/fleet/tier-ladder.cjs
+++ b/lib/fleet/tier-ladder.cjs
@@ -265,6 +265,30 @@ function normalizeEffort(effort) {
 }
 
 /**
+ * QF-20260807-159 (item 2): was the effort RECOGNISED, or did normalizeEffort fall back?
+ *
+ * normalizeEffort already computes this and then throws it away, so the caller cannot
+ * distinguish `--effort xhigh` (a report) from `--effort tuesday` (a guess that happens to
+ * land on xhigh). Both then get stamped effort_source='worker_self_report', which dresses a
+ * guess as a report — and the check-in contract keys authoritative-wins-over-worker on that
+ * field, so an unrecognised value inherits the standing of a real one.
+ *
+ * Deliberately a SEPARATE predicate rather than changing normalizeEffort's return shape:
+ * every existing caller keeps its contract, and a recognition check that nobody is forced to
+ * read cannot break a ranking path.
+ */
+function isKnownEffort(effort) {
+  const raw = typeof effort === 'string' ? effort.toLowerCase().trim() : '';
+  const key = EFFORT_SYNONYMS[raw] || raw;
+  return Object.prototype.hasOwnProperty.call(EFFORT_STRENGTH, key);
+}
+
+/** Same question for a model id: does it resolve to a known family, or is the rank a guess? */
+function isKnownModel(model) {
+  return Boolean(familyFromModelId(model));
+}
+
+/**
  * Model-dominant capability score: any stronger model outranks any weaker model
  * regardless of effort. Normalizes both inputs first (unknown => strongest).
  * @param {string} [model]
@@ -487,6 +511,8 @@ module.exports = {
   EFFORT_STRENGTH,
   EFFORT_SPAN,
   capabilityScore,
+  isKnownEffort,
+  isKnownModel,
   rankForModelEffort,
   normalizeModel,
   familyFromModelId,

--- a/scripts/worker-checkin.cjs
+++ b/scripts/worker-checkin.cjs
@@ -83,7 +83,7 @@ function getDispatchAuthMode() {
 }
 // SD-LEO-INFRA-COMPLEXITY-TIERED-WORKER-ASSIGNMENT-001 (FR-3): WORK-DOWN-NEVER-UP on the PULL path.
 // SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-B (FR-3): --model/--effort capture at check-in.
-const { resolveWorkerTierRank, isTieringActive, normalizeModel, normalizeEffort, rankForModelEffort, ladderTopRank, familyFromModelId, seatCapabilityIsVerified } = require('../lib/fleet/tier-ladder.cjs');
+const { resolveWorkerTierRank, isTieringActive, normalizeModel, normalizeEffort, rankForModelEffort, ladderTopRank, familyFromModelId, seatCapabilityIsVerified, isKnownEffort, isKnownModel } = require('../lib/fleet/tier-ladder.cjs');
 // SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001 (FR-2): tier-aware "claimable-to-MY-rung" rollup.
 const { claimableForTier, claimableForRepo } = require('../lib/fleet/tier-claimable.cjs');
 // SD-LEO-INFRA-AUTO-TIERING-ACTIVATION-001-E (FR-6): backlog-gated downward claims. The fetcher is
@@ -1839,22 +1839,60 @@ function mergeCheckinModelEffort(sessionMetadata, { model: cliModel = null, effo
     // never silently overwritten by a self-report. The two automatic sources
     // (worker_self_report, sessionstart_observed) may replace each other.
     const priorSource = current.model_source;
+    // QF-20260807-159: 'conservative_up_guess' joins the AUTOMATIC set. It is this fix's own
+    // second-order trap — the guard reads "anything not in this list is authoritative", so a
+    // new automatic value silently acquires chairman standing and a later GENUINE self-report
+    // could never overwrite a guess. That is strictly worse than the defect being fixed:
+    // it would pin a seat to a mis-guessed tier permanently.
     const externallyStamped = priorSource
-      && priorSource !== 'worker_self_report' && priorSource !== 'sessionstart_observed';
-    if (!externallyStamped && next.model_source !== 'worker_self_report') {
-      next.model_source = 'worker_self_report';
+      && priorSource !== 'worker_self_report' && priorSource !== 'sessionstart_observed'
+      && priorSource !== 'conservative_up_guess';
+    // QF-20260807-159 (item 2): a model id naming no known family does NOT get ranked as
+    // reported — it is silently resolved conservative-UP to the strongest family. Stamping
+    // that as worker_self_report dresses a GUESS as a REPORT, and this very field is what
+    // authoritative-wins-over-worker keys on, so the guess inherits a real report's standing.
+    // Name the guess instead. The value still ranks conservative-UP (unchanged); only its
+    // PROVENANCE becomes honest, so a reader can tell "the seat said this" from "we assumed".
+    const modelSource = isKnownModel(cliModel) ? 'worker_self_report' : 'conservative_up_guess';
+    if (!externallyStamped && next.model_source !== modelSource) {
+      next.model_source = modelSource;
       changed = true;
     }
   }
 
   if (cliEffort) {
     const effortSource = current.effort_source;
-    const chairmanWins = effortSource && effortSource !== 'worker_self_report';
+    // QF-20260807-159: same second-order trap as model_source above — a prior
+    // 'conservative_up_guess' must NOT read as a chairman stamp, or a guess would
+    // permanently outrank the worker's own later, correct report.
+    const chairmanWins = effortSource
+      && effortSource !== 'worker_self_report' && effortSource !== 'conservative_up_guess';
     if (!chairmanWins) {
       const normalized = normalizeEffort(cliEffort);
       if (next.effort !== normalized) { next.effort = normalized; changed = true; }
-      if (next.effort_source !== 'worker_self_report') { next.effort_source = 'worker_self_report'; changed = true; }
+      // QF-20260807-159 (item 2): same guess-vs-report distinction as model above. An
+      // unrecognised effort lands on xhigh by conservative-UP fallback, which is the RIGHT
+      // value and the WRONG provenance if it is recorded as a self-report.
+      const effortSourceNext = isKnownEffort(cliEffort) ? 'worker_self_report' : 'conservative_up_guess';
+      if (next.effort_source !== effortSourceNext) { next.effort_source = effortSourceNext; changed = true; }
     }
+  }
+
+  // QF-20260807-159 (item 4): SURFACE a re-attestation that changes the seat's model FAMILY.
+  // Measured twice on 2026-08-07: two seats sat in a doctrine hold that every dashboard
+  // rendered as healthy idle — Bravo went idle_fable_propose -> idle on re-attesting, with
+  // belt_ranked_claimable=22 and claimable_at_my_tier=3 available the whole time; Charlie was
+  // held off nine claimable SDs the same way. Neither hold was visible; only the FLIP was, and
+  // the flip was being absorbed silently. Announce it here, where the prior family is still in
+  // hand — a correction nobody can see is indistinguishable from a seat that was never held.
+  // Emitted to stderr so it cannot corrupt the single-JSON-object stdout contract.
+  const priorFamily = current.model_family || (current.model ? familyFromModelId(current.model) : null);
+  const nextFamily = next.model_family || (next.model ? familyFromModelId(next.model) : null);
+  if (changed && priorFamily && nextFamily && priorFamily !== nextFamily) {
+    console.error(`[checkin] MODEL FAMILY RE-ATTESTED: ${priorFamily} -> ${nextFamily}. `
+      + 'If this seat was held by a family-keyed doctrine (e.g. the Fable no-general-work hold), '
+      + 'that hold is LIFTING NOW and the belt it was hiding becomes claimable this pass. '
+      + 'A silent flip is the tell that a hold existed (QF-20260807-159).');
   }
 
   if (changed) {

--- a/tests/unit/checkin-model-guess-provenance.test.js
+++ b/tests/unit/checkin-model-guess-provenance.test.js
@@ -1,0 +1,119 @@
+// QF-20260807-159 items (2) and (4): a guess must be legible as a guess, and a hold-flip
+// must be visible.
+//
+// Item (1) of the ticket is NOT tested here because it was ALREADY SHIPPED on 2026-07-25
+// (capture-session-id.cjs stamps `sessionstart_observed`); a writer census confirmed exactly
+// two model_source writers and no third. Testing it would assert behaviour this QF did not
+// change — a green light wired to someone else's bulb.
+//
+// WHAT THE DEFECT ACTUALLY WAS, once the premise was corrected: both held seats were a TRUE
+// self-report of a WRONG value. Source-field truthfulness was never the gap, so these tests
+// target the two things that were: an unrecognised value laundering itself as a report, and a
+// hold whose only tell was a flip nobody surfaced.
+import { describe, it, expect, vi } from 'vitest';
+import { mergeCheckinModelEffort } from '../../scripts/worker-checkin.cjs';
+import { isKnownEffort, isKnownModel } from '../../lib/fleet/tier-ladder.cjs';
+
+describe('recognition predicates', () => {
+  it('knows the real efforts and the documented synonym', () => {
+    for (const e of ['low', 'medium', 'high', 'xhigh', 'max']) {
+      expect(isKnownEffort(e), `${e} should be known`).toBe(true);
+    }
+  });
+  it('does not know an invented effort', () => {
+    expect(isKnownEffort('tuesday')).toBe(false);
+    expect(isKnownEffort('')).toBe(false);
+    expect(isKnownEffort(undefined)).toBe(false);
+  });
+  it('knows real model ids and not invented ones', () => {
+    expect(isKnownModel('opus')).toBe(true);
+    expect(isKnownModel('claude-opus-5[1m]')).toBe(true);
+    expect(isKnownModel('gpt-9-turbo')).toBe(false);
+  });
+});
+
+describe('item (2): a guess is stamped as a guess, not as a report', () => {
+  it('an unrecognised --effort stamps conservative_up_guess', () => {
+    const { metadata } = mergeCheckinModelEffort({}, { effort: 'tuesday' });
+    expect(metadata.effort).toBe('xhigh');                       // value unchanged: still conservative-UP
+    expect(metadata.effort_source).toBe('conservative_up_guess'); // provenance now honest
+  });
+
+  it('an unrecognised --model stamps conservative_up_guess', () => {
+    const { metadata } = mergeCheckinModelEffort({}, { model: 'gpt-9-turbo' });
+    expect(metadata.model_source).toBe('conservative_up_guess');
+  });
+
+  // POSITIVE CONTROL — without this the suite would pass if EVERYTHING were marked a guess.
+  it('a GENUINE --model/--effort report still stamps worker_self_report', () => {
+    const { metadata } = mergeCheckinModelEffort({}, { model: 'claude-opus-5[1m]', effort: 'xhigh' });
+    expect(metadata.model_source).toBe('worker_self_report');
+    expect(metadata.effort_source).toBe('worker_self_report');
+  });
+
+  it('a chairman stamp still WINS over a worker effort report (contract preserved)', () => {
+    const prior = { effort: 'low', effort_source: 'chairman' };
+    const { metadata } = mergeCheckinModelEffort(prior, { effort: 'xhigh' });
+    expect(metadata.effort).toBe('low');
+    expect(metadata.effort_source).toBe('chairman');
+  });
+
+  // The second-order trap this fix created and had to close: a NEW automatic source silently
+  // acquires chairman standing, because the guard reads "anything not in this list wins".
+  it('a prior conservative_up_guess does NOT outrank a later genuine report', () => {
+    const priorE = { effort: 'xhigh', effort_source: 'conservative_up_guess' };
+    const afterE = mergeCheckinModelEffort(priorE, { effort: 'low' }).metadata;
+    expect(afterE.effort).toBe('low');
+    expect(afterE.effort_source).toBe('worker_self_report');
+
+    const priorM = { model: 'gpt-9-turbo', model_source: 'conservative_up_guess' };
+    const afterM = mergeCheckinModelEffort(priorM, { model: 'claude-opus-5[1m]' }).metadata;
+    expect(afterM.model_source).toBe('worker_self_report');
+  });
+
+  it('still a byte-identical no-op when neither flag is passed', () => {
+    const prior = { model: 'opus', model_source: 'worker_self_report' };
+    const r = mergeCheckinModelEffort(prior, {});
+    expect(r.changed).toBe(false);
+    expect(r.metadata).toBe(prior); // same reference, not a copy
+  });
+});
+
+describe('item (4): a model-family re-attestation is SURFACED', () => {
+  it('announces the flip that lifts a family-keyed doctrine hold', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      // The exact scenario measured on this seat: stamped fable, re-attests as opus.
+      mergeCheckinModelEffort({ model: 'fable', model_family: 'fable' }, { model: 'claude-opus-5[1m]' });
+      const said = spy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(said).toContain('MODEL FAMILY RE-ATTESTED');
+      expect(said).toContain('fable');
+      expect(said).toContain('opus');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('stays SILENT when the family does not change — the signal must mean something', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      // Same family, different exact id: a real change, but no doctrine hold can be lifting.
+      mergeCheckinModelEffort({ model: 'opus', model_family: 'opus' }, { model: 'claude-opus-5[1m]' });
+      const said = spy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(said).not.toContain('MODEL FAMILY RE-ATTESTED');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it('stays silent on a first stamp — there is no prior family to have held anything', () => {
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      mergeCheckinModelEffort({}, { model: 'claude-opus-5[1m]' });
+      const said = spy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(said).not.toContain('MODEL FAMILY RE-ATTESTED');
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Item (1) is deliberately NOT built

The ticket says the SessionStart autocapture stamps `worker_self_report`. **It doesn't.** `capture-session-id.cjs:330` stamps `sessionstart_observed`, shipped **2026-07-25** in `35e236bec9a` — thirteen days *before* the ticket was filed — and a writer census found exactly two `model_source` writers, no third and no RPC writer. Building it would have been a fix for a stamp that already stamps correctly.

Correcting the premise changed what the defect **is**: both held seats (Charlie and this one) were a **true self-report of a wrong value**. Source-field truthfulness was never the gap.

## (2) A guess was dressed as a report

An unrecognised `--model`/`--effort` resolves conservative-UP to the strongest family/effort. `normalizeEffort` computes that recognition and throws it away, so `--effort tuesday` and `--effort xhigh` were indistinguishable afterwards — and both were stamped `worker_self_report`. That field is what authoritative-wins-over-worker keys on, so **a guess inherited a real report's standing**.

Added `isKnownEffort` / `isKnownModel` as separate predicates (every existing caller keeps its contract) and stamped `conservative_up_guess`. The **value** is unchanged — only the provenance becomes honest.

### The second-order trap this created, and closed

Both guards read *"anything not in this list is authoritative"*, so a new automatic source silently acquires chairman standing. A prior `conservative_up_guess` would have blocked the worker's own later correct report and **pinned the seat to a mis-guessed tier permanently** — strictly worse than the defect. It now joins the automatic set in both guards, pinned by its own test.

## (4) The hold was invisible; only the flip could reveal it

Measured twice on 2026-08-07: this seat sat `idle_fable_propose` with `belt_ranked_claimable=22` and `claimable_at_my_tier=3` available the whole time, and flipped to `idle` the instant it re-attested. Charlie was held off nine claimable SDs the same way. Every dashboard rendered both as healthy idle.

`mergeCheckinModelEffort` now announces a model-**family** change, where the prior family is still in hand. It stays silent on a same-family id change and on a first stamp, so the signal means something when it fires. Emitted to stderr — stdout is a single-JSON-object contract.

## Proof

| Mutation | Kills |
|---|---|
| Flatten the guess marker | 2 provenance tests |
| Let a prior guess count as authoritative | the second-order test |
| Silence the announcement | the flip test |

12 new tests; **94** existing check-in tests and **2099** fleet tests still green. Module verified loadable under real `node`, not only vitest. Restores done from file copies, verified byte-exact.

QF-20260807-159