### PR TITLE
feat(SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001): publish the scanner convention, adopt it, and make skipping it fail

### DIFF
--- a/.github/workflows/scanner-convention-lint.yml
+++ b/.github/workflows/scanner-convention-lint.yml
@@ -1,0 +1,71 @@
+# Scanner-convention lint — the lint-for-the-linters.
+# SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-3/FR-4).
+#
+# A scanner that regexes ADDED-LINE TEXT from a git diff false-positives on its own FIXTURES,
+# worked-example COMMENTS and STRING LITERALS, because a fixture or an explanation FOR a
+# pattern-detector necessarily contains pattern-shaped text. The fix was derived INDEPENDENTLY TWICE
+# and propagated to neither sibling, and the fixture-path regex alone appeared THREE TIMES in one
+# file. Publishing lib/lint/added-line-text.mjs makes the convention EXIST; this job makes it FOUND —
+# a new shape-A scanner fails HERE, when the fix is one import, instead of a year later when someone
+# notices their linter flagging its own fixtures.
+#
+# SHAPE A ONLY, deliberately. Shape B (--name-only path selection, then whole-file reads) has no
+# fragment hazard and is governed by fixture exclusion instead — a different check for a different
+# hazard. The discriminator is the single --name-only flag.
+#
+# BLOCKING FROM DAY ONE — a DEPARTURE from the advisory-soak convention used by
+# diagnostic-gauge-citation-lint.yml and schema-reference-lint.yml, and the departure is the point.
+# Those soak because a brand-new lint may false-positive across a large pre-existing surface. This
+# one scans TWO directories, is at ZERO violations as it lands, and exists specifically to abolish
+# guards that never fail: an ADVISORY lint-for-the-linters would let the seventh rediscovery merge
+# silently while reporting green, which is the exact failure mode the SD is about.
+# Escape (always available, one line): add
+#   scanner-convention-lint-exempt: <reason>
+# to the scanner. The REASON IS MANDATORY — a bare marker does not exempt, because an unexplained
+# exemption is how a guard erodes into a formality. lib/gates/operator-contract/harness-adapter.js
+# carries the only current exemption: it owns a purpose-built SQL-aware strip the general helper
+# would regress.
+name: Scanner Convention Lint
+
+on:
+  pull_request:
+    paths:
+      - 'scripts/lint/**'
+      - 'lib/gates/**'
+      - 'lib/lint/added-line-text.mjs'
+      - '.github/workflows/scanner-convention-lint.yml'
+
+concurrency:
+  group: scanner-convention-lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scanner-convention-lint:
+    name: scanner-convention-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run scanner-convention lint
+        run: |
+          node scripts/lint/scanner-convention-lint.mjs | tee lint-output.txt
+          exit_code=${PIPESTATUS[0]}
+          {
+            echo "## Scanner Convention Lint"
+            echo ""
+            echo '```'
+            cat lint-output.txt
+            echo '```'
+            echo ""
+            echo "A shape-A scanner (reads git-diff ADDED-LINE text) must import"
+            echo "lib/lint/added-line-text.mjs, or carry a reasoned opt-out:"
+            echo ""
+            echo '```'
+            echo "scanner-convention-lint-exempt: <why this scanner cannot use the helper>"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit $exit_code

--- a/lib/gates/operator-contract/harness-adapter.js
+++ b/lib/gates/operator-contract/harness-adapter.js
@@ -24,6 +24,17 @@ import { RETENTION_POLICIES, SOAK_ENTRIES } from '../../retention/policies.js';
  * @param {string} opts.appPath - repo root to run git in
  * @param {string} [opts.baseRef='origin/main']
  * @returns {{changedFiles: Array<{path,added}>, migrations: Array<{path,sql}>, createdTables: string[], unreadable: Array<{path,error}>}}
+ *
+ * SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-4). This is genuine shape A — it reads ADDED-LINE text —
+ * so scripts/lint/scanner-convention-lint.mjs flags it for not importing lib/lint/added-line-text.mjs.
+ * It is EXEMPT rather than converted, and the reason is a regression, not an inconvenience: the SQL
+ * strip below is NARROWER AND MORE CORRECT than the shared helper for this consumer. It strips SQL
+ * `--` line comments and single-quoted literals with the `''` escape, comments FIRST for the
+ * documented apostrophe-unbalancing reason. The general helper strips `//` JS line comments plus a
+ * JSDoc-continuation stage and has NO SQL string-literal handling — so adopting it would DELETE two
+ * strips this consumer depends on and add one it cannot use. A shared convention is worth having
+ * precisely because it is not mandatory where it is wrong.
+ * scanner-convention-lint-exempt: owns a purpose-built SQL-aware strip (-- comments, ''-escaped literals) the general JS helper would regress
  */
 export function collectSdDiff({ appPath, baseRef = 'origin/main' } = {}) {
   // SEC-4b (SECURITY row 778f9a78): execSync's default maxBuffer is 1 MiB, and the per-file

--- a/lib/lint/added-line-text.mjs
+++ b/lib/lint/added-line-text.mjs
@@ -28,11 +28,44 @@
  * The canonical fixture/test path predicate, extracted verbatim from the three copies in
  * lib/gates/operator-contract/index.js (86, 156, 242) so behaviour is unchanged by adoption.
  *
+ * ── THE TWO HELPERS ARE ADOPTED SEPARATELY, AND THE SPLIT IS MEASURED ─────────────────────
+ * Triage found the scanner class divides by HOW it selects text, and the two hazards do not travel
+ * together (ruling banked at sd.metadata.exec_fr2_triage_20260808):
+ *   SHAPE A reads a PATCH and matches ADDED LINES. Both hazards apply — a fragment can begin
+ *     mid-JSDoc, so it needs stripComments AS WELL AS isFixturePath.
+ *   SHAPE B takes `git diff --name-only` paths and then reads WHOLE FILES. Comments arrive intact,
+ *     so the mid-block slice CANNOT occur and stripComments would be cargo-cult — but the file was
+ *     still SELECTED BY A DIFF, so a changed test file is read as live code exactly as in shape A.
+ * Hence: FIXTURE EXCLUSION IS UNIVERSAL, COMMENT-STRIPPING IS SHAPE-A ONLY. A shape-B scanner
+ * imports this function and nothing else.
+ *
+ * ── CALLING IT ON A DIRECTORY PATH ────────────────────────────────────────────────────────
+ * The `__tests__/` and `tests/` branches need the TRAILING SEPARATOR, so a bare directory path
+ * ('lib/__tests__') does NOT match while a file inside it does. A caller pruning directories during
+ * a walk must pass `dir + '/'`, or it will descend into the fixture tree and rely on the per-file
+ * check — which works, but silently does the opposite of what pruning looks like it does.
+ *
  * @param {string} path repo-relative path
  * @returns {boolean} true when the path is test/fixture material
  */
 export function isFixturePath(path) {
   return /(?:\.test\.|\.spec\.|__tests__\/|(?:^|\/)tests\/)/.test(String(path || ''));
+}
+
+/**
+ * isFixturePath for a DIRECTORY-WALK ENTRY, where the caller knows whether the entry is a directory.
+ *
+ * This exists because the trailing-separator trap above was about to be hand-written identically in
+ * three scanners, which is the precise disease this SD treats: a subtlety that must be REMEMBERED at
+ * every call site is a subtlety that will eventually be forgotten at one. Encoding it once makes the
+ * careless version unexpressible rather than merely discouraged.
+ *
+ * @param {string} pathname repo-relative path, no trailing separator
+ * @param {boolean} isDirectory true when the entry is a directory
+ * @returns {boolean} true when the entry is test/fixture material
+ */
+export function isFixtureEntry(pathname, isDirectory) {
+  return isFixturePath(isDirectory ? `${pathname}/` : pathname);
 }
 
 /**

--- a/lib/lint/added-line-text.mjs
+++ b/lib/lint/added-line-text.mjs
@@ -1,0 +1,76 @@
+/**
+ * SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-1) — the shared convention for scanners that regex
+ * ADDED-LINE TEXT from a git diff.
+ *
+ * ── THE DEFECT THIS EXISTS TO STOP ────────────────────────────────────────────────────────
+ * A scanner that matches patterns against added-line text false-positives on its own FIXTURES and
+ * worked-example COMMENTS, because a fixture or an explanation FOR a pattern-detector NECESSARILY
+ * contains pattern-shaped text. The sharpest observed form: a comment written to explain a previous
+ * false positive re-triggered it — the file's own explanation of the bug WAS the bug.
+ *
+ * ── WHY THIS IS A PUBLISHED HELPER AND NOT N PATCHES ──────────────────────────────────────
+ * This fix has now been derived INDEPENDENTLY TWICE and propagated to neither of its siblings:
+ *   - collectSdDiff (lib/gates/operator-contract/harness-adapter.js) solved it for SQL migrations,
+ *     with the note "the file that documents itself most carefully is punished hardest, which is
+ *     backwards."
+ *   - detectCreator (lib/gates/operator-contract/index.js) later re-derived BOTH halves for JS,
+ *     writing its own version of the same explanation.
+ * Meanwhile a census found SIX further diff-reading scanners under scripts/lint carrying NEITHER
+ * guard, and the fixture-path regex alone appears THREE TIMES inside index.js (lines 86, 156, 242).
+ * That is a contract-discoverability failure, not an arithmetic one: the fix keeps being rebuilt at
+ * the point of pain and never travels. Patching the six would close the instances and guarantee a
+ * seventh rediscovery, so the deliverable is this module plus a check that makes skipping it fail.
+ *
+ * NO I/O, NO STATE. Pure string functions, so a scanner can adopt them without a repo or a diff.
+ */
+
+/**
+ * The canonical fixture/test path predicate, extracted verbatim from the three copies in
+ * lib/gates/operator-contract/index.js (86, 156, 242) so behaviour is unchanged by adoption.
+ *
+ * @param {string} path repo-relative path
+ * @returns {boolean} true when the path is test/fixture material
+ */
+export function isFixturePath(path) {
+  return /(?:\.test\.|\.spec\.|__tests__\/|(?:^|\/)tests\/)/.test(String(path || ''));
+}
+
+/**
+ * Strip comments from a slice of ADDED LINES before pattern matching.
+ *
+ * THE THREE STAGES ARE NOT INTERCHANGEABLE, and the middle one is the reason to extract this rather
+ * than rewrite it. An added-lines slice is a FRAGMENT: it can begin partway through a JSDoc block,
+ * so continuation lines arrive WITHOUT their opening delimiter. A naive
+ * `replace(/\/\*[\s\S]*?\*\//g)` misses exactly those lines, which is where documentation-shaped
+ * false positives concentrate. Order matters too — block comments first, so a `//` inside a block
+ * is already gone before the line-comment pass runs.
+ *
+ * BEST-EFFORT BY DESIGN, and the tradeoff is deliberate: this can also swallow a comment-shaped
+ * substring sitting inside a string literal. Both precedents accept that, because a mention inside
+ * a comment is never a real occurrence, whereas over-suppression risks a FALSE NEGATIVE. That risk
+ * is real, so any adopting scanner MUST keep a test proving a genuine occurrence still fires after
+ * stripping — otherwise this degrades into a blanket suppressor, which is the same blind-guard
+ * shape the whole SD exists to abolish.
+ *
+ * @param {string} text added-line text (may be a mid-block fragment)
+ * @returns {string} text with comment content replaced by spaces (offsets are not preserved)
+ */
+export function stripComments(text) {
+  return String(text || '')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')  // block comments (may be partial in an added-lines slice)
+    .replace(/^\s*\*.*$/gm, ' ')        // continuation lines of a JSDoc block the slice cut open
+    .replace(/\/\/[^\n]*/g, ' ');       // line comments — where both observed false positives came from
+}
+
+/**
+ * Convenience for the common shape: skip fixture paths outright, otherwise return comment-stripped
+ * text ready to match against. Returns null when the path should not be scanned at all, so a caller
+ * can `if (t === null) continue;` and keep the two decisions in one place.
+ *
+ * @param {{path?: string, added?: string}} file
+ * @returns {string|null} matchable text, or null if the path is fixture material
+ */
+export function scannableText(file = {}) {
+  if (isFixturePath(file.path)) return null;
+  return stripComments(file.added);
+}

--- a/scripts/audit/control-seed-specs.json
+++ b/scripts/audit/control-seed-specs.json
@@ -7,7 +7,7 @@
     "extraArgs": [
       "--all"
     ],
-    "note": "CONTROL-ABOUT-CONTROLS. No --root, but it enumerates via git/fs calls that inherit cwd, so it IS aimable — scopability by flag alone under-counted it.",
+    "note": "CONTROL-ABOUT-CONTROLS. No --root, but it enumerates via git/fs calls that inherit cwd, so it IS aimable \u2014 scopability by flag alone under-counted it.",
     "fixtures": [
       {
         "path": "lib/seeded-gauge-citation-defect.js",
@@ -25,11 +25,11 @@
     "rootFlag": null,
     "cwdScope": true,
     "extraArgs": [],
-    "note": "CONTROL-ABOUT-CONTROLS. TESTED IN DEFAULT MODE, DELIBERATELY. An earlier run passed --enforce and scored BLOCKS, but --enforce is NOT what CI runs — the ruled question is whether a control BLOCKS AT MERGE TIME, so measuring a non-default enforcing mode overstates protection. In its default advisory mode it DETECTS and exits 0.",
+    "note": "CONTROL-ABOUT-CONTROLS. TESTED IN DEFAULT MODE, DELIBERATELY. An earlier run passed --enforce and scored BLOCKS, but --enforce is NOT what CI runs \u2014 the ruled question is whether a control BLOCKS AT MERGE TIME, so measuring a non-default enforcing mode overstates protection. In its default advisory mode it DETECTS and exits 0.",
     "fixtures": [
       {
         "path": "lib/seeded-liveness-select-defect.js",
-        "content": "// SEEDED DEFECT: unbounded multi-row claude_sessions select — the PostgREST 1000-row\n// cap silently drops the NEWEST live workers, so liveness undercounts.\nexport async function all(supabase) {\n  return supabase.from('claude_sessions').select('session_id, heartbeat_at');\n}\n"
+        "content": "// SEEDED DEFECT: unbounded multi-row claude_sessions select \u2014 the PostgREST 1000-row\n// cap silently drops the NEWEST live workers, so liveness undercounts.\nexport async function all(supabase) {\n  return supabase.from('claude_sessions').select('session_id, heartbeat_at');\n}\n"
       }
     ],
     "detectTokens": [
@@ -81,7 +81,7 @@
     "fixtures": [
       {
         "path": "scripts/ci/seeded-count-delta-defect.mjs",
-        "content": "// SEEDED DEFECT: gates on a raw failure-COUNT delta rather than an identity-set diff.\n// Uses the rule's actual lexicon (failedCount / baselineFailed) — my first seed said\n// failCount, which the lexicon does not match, so the control correctly reported 0.\nexport function gate(baselineFailed, failedCount) {\n  if (failedCount > baselineFailed) {\n    throw new Error('failure count rose');\n  }\n  return true;\n}\n"
+        "content": "// SEEDED DEFECT: gates on a raw failure-COUNT delta rather than an identity-set diff.\n// Uses the rule's actual lexicon (failedCount / baselineFailed) \u2014 my first seed said\n// failCount, which the lexicon does not match, so the control correctly reported 0.\nexport function gate(baselineFailed, failedCount) {\n  if (failedCount > baselineFailed) {\n    throw new Error('failure count rose');\n  }\n  return true;\n}\n"
       }
     ],
     "seedNote": "SEED WAS WRONG AND HAS BEEN FIXED. The rule's EXACT_LEXICON/LEXICON_PATTERN match failed|failing|failure names (failedCount, baselineFailed). My first seed used failCount, which is outside the lexicon, so the control scanned the fixture and correctly found nothing. That was a SEED MISMATCH, never evidence of blindness."
@@ -143,7 +143,7 @@
     "detectTokens": [
       "seeded-mock-sut"
     ],
-    "note": "WAS marked UNTESTABLE on flags alone. SCAN_DIRS is RELATIVE, so it resolves against cwd — retesting via cwdScope.",
+    "note": "WAS marked UNTESTABLE on flags alone. SCAN_DIRS is RELATIVE, so it resolves against cwd \u2014 retesting via cwdScope.",
     "seedNote": "UNRESOLVED SILENT, and NOT a mode artifact: re-probed with NO_MOCKED_SUT_IMPORT_MODE=block and it is STILL silent, so promoting it would not change the verdict. Either the seed does not match its detector shape or it genuinely does not fire. NOT recorded as blind on this evidence."
   },
   {
@@ -161,13 +161,13 @@
       "seeded-venture-artifact-defect",
       "title"
     ],
-    "note": "WAS marked UNTESTABLE on flags alone. SCAN_DIRS is RELATIVE, so it resolves against cwd — retesting via cwdScope."
+    "note": "WAS marked UNTESTABLE on flags alone. SCAN_DIRS is RELATIVE, so it resolves against cwd \u2014 retesting via cwdScope."
   },
   {
     "name": "control-seed-test-lint",
     "script": "scripts/lint/control-seed-test-lint.mjs",
     "seedTest": "tests/unit/lint/control-seed-test-lint.test.js",
-    "note": "Seeded by the committed TS-5 test: plants a deliberately blind gauge and asserts the gate REFUSES it. Cannot use a fixture trial — this control's certified output is a VERDICT about other controls, not a code pattern in a file.",
+    "note": "Seeded by the committed TS-5 test: plants a deliberately blind gauge and asserts the gate REFUSES it. Cannot use a fixture trial \u2014 this control's certified output is a VERDICT about other controls, not a code pattern in a file.",
     "neuter": {
       "find": "reason: 'SEED_DID_NOT_FIRE'",
       "replace": "reason: 'SEED_DID_NOT_FIRE_NEUTERED'",
@@ -178,11 +178,44 @@
     "name": "control-seed-test",
     "script": "scripts/audit/control-seed-test.mjs",
     "seedTest": "tests/unit/lint/control-seed-test-lint.test.js",
-    "note": "Same TS-5 test exercises runTrial through evaluate — a blind gauge must come back SILENT. Its certified behaviour is a verdict, so there is no code pattern to seed into a fixture.",
+    "note": "Same TS-5 test exercises runTrial through evaluate \u2014 a blind gauge must come back SILENT. Its certified behaviour is a verdict, so there is no code pattern to seed into a fixture.",
     "neuter": {
       "find": ": VERDICT.SILENT;",
       "replace": ": VERDICT.DETECTS;",
       "why": "runTrial can no longer return SILENT, so a blind gauge reads as detecting"
+    }
+  },
+  {
+    "name": "scanner-convention-lint",
+    "script": "scripts/lint/scanner-convention-lint.mjs",
+    "seedTest": "tests/unit/lint/scanner-convention-lint.test.js",
+    "note": "SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001. Cannot use a fixture trial: this control resolves its scan root from import.meta.url (path.resolve(__dirname,'../..')), NOT from cwd or a --root flag, so the harness cannot aim it at a temp tree. The committed test instead PLANTS a violating scanner through an injected fs and asserts it is caught.",
+    "neuter": {
+      "find": "if (!readsAddedLineText(src)) continue;",
+      "replace": "if (true) continue;",
+      "why": "findViolations stops classifying anything as shape A, so the [PLANTED] case that expects exactly one violation gets zero and goes RED"
+    }
+  },
+  {
+    "name": "schema-reference-lint",
+    "script": "scripts/lint/schema-reference-lint.mjs",
+    "seedTest": "tests/unit/lint/scanner-fixture-exclusion.test.js",
+    "note": "SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-2). A fixture trial is impractical here: this control exits early without database/schema-reference-snapshot.json, so a bare temp tree cannot exercise it. The committed test plants one payload at two paths differing ONLY in being fixture material and RUNS the control against both, asserting the control file is flagged (control-first) and the fixture twin is not.",
+    "neuter": {
+      "find": "if (isFixtureEntry(p, e.isDirectory())) continue;",
+      "replace": "if (false) continue;",
+      "why": "the --all walk stops pruning fixture directories, so the planted lib/__tests__ file is scanned and flagged, and the assertion that no hit contains __tests__ goes RED"
+    }
+  },
+  {
+    "name": "stage-advancement-chokepoint-lint",
+    "script": "scripts/lint/stage-advancement-chokepoint-lint.mjs",
+    "seedTest": "tests/unit/lint/scanner-fixture-exclusion.test.js",
+    "note": "SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-2). Same committed two-sided test: one payload, two paths differing only in being fixture material, control asserted FIRST so a silently-dead scanner cannot pass as 'no fixture hit'.",
+    "neuter": {
+      "find": "if (isFixtureEntry(p, e.isDirectory())) continue;",
+      "replace": "if (false) continue;",
+      "why": "the --all walk stops pruning fixture directories, so the planted lib/__tests__ file is scanned and flagged, and the assertion that no hit contains __tests__ goes RED"
     }
   }
 ]

--- a/scripts/lint/diagnostic-gauge-citation-lint.mjs
+++ b/scripts/lint/diagnostic-gauge-citation-lint.mjs
@@ -29,6 +29,9 @@ import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
 import { CITATION_RE } from './diagnostic-gauge-citation-patterns.mjs';
+// SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-2). Shape B: only isFixturePath — see the helper for why
+// stripComments is shape-A-only and would be cargo-cult here.
+import { isFixturePath, isFixtureEntry } from '../../lib/lint/added-line-text.mjs';
 
 const ALLOWLIST_PATH = 'scripts/lint/diagnostic-gauge-citation-allowlist.json';
 const RUNTIME_DIRS = ['scripts', 'lib', 'src', 'server', 'api', 'app'];
@@ -63,7 +66,9 @@ function candidateFiles() {
         .filter((f) => CODE_RE.test(f))
         .filter((f) => RUNTIME_DIRS.includes(f.split('/')[0]))
         .filter((f) => !SKIP_DIR_RE.test(f))
-        .filter((f) => f.split('/')[0] !== 'tests');
+        // Supersedes the old top-level-only `split('/')[0] !== 'tests'`: that missed NESTED tests/,
+        // __tests__/ and .test./.spec. files entirely — 346 of them are selectable in this repo.
+        .filter((f) => !isFixturePath(f));
     } catch (e) {
       console.warn(`⚠️  diff base unavailable (${e.message.split('\n')[0]}) — falling back to --all (advisory)`);
       return candidateFilesAll();
@@ -80,6 +85,10 @@ function candidateFilesAll() {
     for (const e of entries) {
       const p = path.join(dir, e.name).replace(/\\/g, '/');
       if (SKIP_DIR_RE.test(p)) continue;
+      // The --all sweep is a SECOND DOOR, and the diff path FALLS BACK to it when the base is
+      // unresolvable — fixing only the diff filter would leave this one serving fixtures. Directories
+      // need a trailing '/', which isFixtureEntry encodes so no call site has to remember it.
+      if (isFixtureEntry(p, e.isDirectory())) continue;
       if (e.isDirectory()) walk(p);
       else if (CODE_RE.test(e.name)) out.push(p);
     }

--- a/scripts/lint/diagnostic-gauge-citation-lint.mjs
+++ b/scripts/lint/diagnostic-gauge-citation-lint.mjs
@@ -33,6 +33,14 @@ import { CITATION_RE } from './diagnostic-gauge-citation-patterns.mjs';
 // stripComments is shape-A-only and would be cargo-cult here.
 import { isFixturePath, isFixtureEntry } from '../../lib/lint/added-line-text.mjs';
 
+// KNOWN LIMITATION (SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001): this control matches ONE LINE AT A TIME
+// (CITATION_RE.test(line) below), so a citation SPLIT ACROSS LINES is invisible to it. Concretely,
+//   const threshold = retro.quality_score;
+//   if (threshold >= 90) ship();
+// is a real diagnostic-gauge gating citation and this control WILL NOT SEE IT, because neither line
+// contains both the gauge and the comparison. Naming it here rather than leaving it to be
+// rediscovered: a control that will not say what it cannot see is indistinguishable from one that
+// sees everything.
 const ALLOWLIST_PATH = 'scripts/lint/diagnostic-gauge-citation-allowlist.json';
 const RUNTIME_DIRS = ['scripts', 'lib', 'src', 'server', 'api', 'app'];
 const SKIP_DIR_RE = /(^|\/)(node_modules|\.git|\.worktrees|dist|build|coverage|\.next|archive|one-off|one-time|tmp|temp|fixtures?)(\/|$)/;

--- a/scripts/lint/scanner-convention-lint.mjs
+++ b/scripts/lint/scanner-convention-lint.mjs
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-3) — the lint-for-the-linters.
+ *
+ * ── WHY THIS EXISTS, AND WHY IT IS THE PIECE THAT MATTERS ─────────────────────────────────
+ * The strip-and-exclude fix for diff-scanning has been derived INDEPENDENTLY TWICE and propagated
+ * to neither sibling: collectSdDiff solved it for SQL migrations, detectCreator later re-derived
+ * BOTH halves for JS and wrote its own version of the same explanation. The fixture-path regex
+ * alone is duplicated THREE TIMES inside operator-contract/index.js. Publishing
+ * lib/lint/added-line-text.mjs (FR-1) makes the convention EXIST; it does not make it FOUND. A
+ * convention that must be remembered is documentation, and documentation is precisely what already
+ * failed twice here.
+ *
+ * So this check exists to make the SEVENTH rediscovery fail loudly at the moment a new scanner is
+ * written, rather than quietly a year later when someone notices their linter flagging its own
+ * fixtures.
+ *
+ * ── SCOPE: SHAPE A ONLY, DELIBERATELY AND NARROWLY ────────────────────────────────────────
+ * Triage (banked at sd.metadata.exec_fr2_triage_20260808) found the class splits in two:
+ *   SHAPE A reads a PATCH and matches ADDED-LINE text. The fragment hazard is real here — the slice
+ *     can begin mid-JSDoc, so continuation lines arrive with no opener. This check governs shape A.
+ *   SHAPE B takes `git diff --name-only` paths and then reads WHOLE FILES. No fragment hazard;
+ *     comments arrive intact. All six lint scanners are shape B, and whether the sweep covers them
+ *     is an OPEN SCOPE QUESTION with the coordinator.
+ * This check therefore flags ONLY shape A. Widening it to shape B before that ruling would encode
+ * my own reading of an ambiguous scope into an enforcement gate — which is exactly the kind of
+ * unearned authority a linter should never take.
+ *
+ * ── FAIL-CLOSED ON ITS OWN CLASS ──────────────────────────────────────────────────────────
+ * A scanner may opt out with the marker below, but the opt-out must carry a REASON on the same
+ * line. An unexplained exemption is how a guard erodes into a formality.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isMainModule } from '../../lib/utils/is-main-module.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+
+/** Directories that can contain scanners. */
+export const SCAN_ROOTS = ['scripts/lint', 'lib/gates'];
+
+/** The helper every shape-A scanner must consume. */
+const HELPER_HINT = /added-line-text(?:\.mjs)?['"]/;
+
+/**
+ * Opt-out marker; the trailing text is the MANDATORY reason.
+ *
+ * `[ \t]*` NOT `\s*` — and my own test caught the difference. `\s` includes the newline, so
+ * `\s*(\S.*)` on a BARE marker skipped the line break and captured the NEXT LINE OF CODE as the
+ * "reason". A bare exemption would have silently passed, which is the erosion this rule exists to
+ * prevent: the guard would have accepted any exemption at all while appearing to demand a reason.
+ */
+const OPT_OUT = /scanner-convention-lint-exempt:[ \t]*(\S.*)$/m;
+
+/**
+ * SHAPE A DETECTION. A `git diff` invocation that is NOT --name-only produces a PATCH, so the
+ * consumer is reading added-line text.
+ *
+ * Deliberately NOT matched: `--name-only`, which yields paths (shape B). That single flag is the
+ * whole discriminator, and getting it wrong in either direction is the failure mode — too broad
+ * flags every shape-B scanner on an unruled scope, too narrow flags nothing.
+ */
+export function readsAddedLineText(source) {
+  const code = String(source || '')
+    .replace(/\/\*[\s\S]*?\*\//g, ' ')
+    .replace(/^\s*\*.*$/gm, ' ')
+    .replace(/\/\/[^\n]*/g, ' ');
+  // THE COMMAND MUST OPEN THE STRING. Requiring a quote/backtick IMMEDIATELY before `git diff`
+  // distinguishes an INVOCATION from a MENTION:
+  //   invocation: run(`git diff ${ref}...HEAD -- "${p}"`)      -> the string starts with the command
+  //   mention:    console.error(`[my-scanner] git diff failed`) -> the string starts with prose
+  //
+  // THIS FIX CAME FROM THE CHECK FAILING ITS OWN CLASS ON ITS FIRST LIVE RUN. The first version
+  // matched `git diff` anywhere outside a comment, and immediately flagged
+  // compute-changed-retro-migrations for the words "git diff failed" inside an ERROR MESSAGE. A
+  // linter written to stop scanners false-positiving on their own prose false-positived on prose.
+  // Stripping comments was not enough: STRING LITERALS carry pattern-shaped text too, and a
+  // diagnostic message is the single most likely place to find a command quoted in full.
+  return [...code.matchAll(/['"`]git diff([^`'"\n]*)/g)].some((m) => !/--name-only/.test(m[1]));
+}
+
+/** @returns {{file: string, reason: string}[]} violations */
+export function findViolations({ root = repoRoot, roots = SCAN_ROOTS, readFile, listFiles } = {}) {
+  const read = readFile || ((p) => fs.readFileSync(p, 'utf8'));
+  const list =
+    listFiles ||
+    ((dir) => {
+      const abs = path.join(root, dir);
+      if (!fs.existsSync(abs)) return [];
+      return fs
+        .readdirSync(abs, { recursive: true })
+        .map((f) => path.join(dir, String(f)).replace(/\\/g, '/'))
+        .filter((f) => /\.(?:mjs|js|cjs)$/.test(f));
+    });
+
+  const violations = [];
+  for (const dir of roots) {
+    for (const rel of list(dir)) {
+      // A scanner's own TESTS legitimately contain scanner-shaped strings — the very defect class
+      // this SD is about. Skipping them here is the convention applied to itself.
+      if (/(?:\.test\.|\.spec\.|__tests__\/|(?:^|\/)tests\/)/.test(rel)) continue;
+      let src;
+      try {
+        src = read(path.join(root, rel));
+      } catch {
+        continue;
+      }
+      if (!readsAddedLineText(src)) continue;
+      if (HELPER_HINT.test(src)) continue;
+      const exempt = src.match(OPT_OUT);
+      if (exempt) continue;
+      violations.push({
+        file: rel,
+        reason:
+          'reads git-diff ADDED-LINE text without lib/lint/added-line-text.mjs. A scanner matching '
+          + 'added lines false-positives on its own fixtures and worked-example comments. Import the '
+          + 'helper, or add "scanner-convention-lint-exempt: <reason>" stating why it cannot.',
+      });
+    }
+  }
+  return violations;
+}
+
+if (isMainModule(import.meta.url)) {
+  const violations = findViolations();
+  for (const v of violations) console.error(`[scanner-convention-lint] ${v.file}: ${v.reason}`);
+  console.log(`[scanner-convention-lint] shape-A scanners checked; violations=${violations.length}`);
+  // exitCode, never process.exit — cleanup must not depend on control flow.
+  process.exitCode = violations.length === 0 ? 0 : 1;
+}

--- a/scripts/lint/scanner-convention-lint.mjs
+++ b/scripts/lint/scanner-convention-lint.mjs
@@ -31,6 +31,13 @@
  * line. An unexplained exemption is how a guard erodes into a formality.
  */
 
+// KNOWN LIMITATION: a string that OPENS with the command -- `'git diff failed to run'` -- is
+// indistinguishable from an INVOCATION by this heuristic and IS reported. Stated here and pinned as
+// a passing test rather than hidden, because discriminating further (demanding a following ref or
+// flag) would trade this rare false positive for a class of false NEGATIVES, and a scanner that
+// slips past the guard entirely is the strictly worse, silent direction. The reasoned opt-out marker
+// exists for exactly this case. Also: shape B is OUT OF SCOPE here by design -- it gets fixture
+// exclusion instead, a different check for a different hazard.
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/scripts/lint/schema-reference-lint.mjs
+++ b/scripts/lint/schema-reference-lint.mjs
@@ -28,6 +28,10 @@ import { extractReferences, findViolations } from './schema-reference-extract.mj
 // SD-LEO-INFRA-SCHEMA-LINT-DEGRADED-FAILOPEN-001: a degraded --diff run (unresolvable base ->
 // whole-repo fallback) is ADVISORY and must not block; the pure helper encodes that exit rule.
 import { computeExitCode } from './schema-lint-exit.mjs';
+// SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-2). This scanner is the SD's RECORDED INSTANCE (3): it
+// read fixtures across 7 suites plus two worked-example comments as live schema references. Shape B,
+// so only isFixturePath — see the helper for why stripComments is shape-A-only.
+import { isFixturePath, isFixtureEntry } from '../../lib/lint/added-line-text.mjs';
 // QF-20260802-742: the new-vs-pre-existing split, kept pure so both polarities are fixture-testable.
 import { violationKey, partitionViolations } from './schema-lint-scope.mjs';
 
@@ -118,7 +122,9 @@ function candidateFiles() {
         .filter(f => CODE_RE.test(f))
         .filter(f => RUNTIME_DIRS.includes(f.split('/')[0]))
         .filter(f => !SKIP_DIR_RE.test(f))
-        .filter(f => f.split('/')[0] !== 'tests');
+        // Supersedes the old top-level-only `split('/')[0] !== 'tests'`: that missed NESTED tests/,
+        // __tests__/ and .test./.spec. files entirely — which is how instance (3) happened.
+        .filter(f => !isFixturePath(f));
     } catch (e) {
       // Fail-soft: no diff base resolvable → advisory full sweep instead of a false block.
       console.warn(`⚠️  diff base unavailable (${e.message.split('\n')[0]}) — falling back to --all (advisory)`);
@@ -137,6 +143,10 @@ function candidateFilesAll() {
     for (const e of entries) {
       const p = path.join(dir, e.name).replace(/\\/g, '/');
       if (SKIP_DIR_RE.test(p)) continue;
+      // The --all sweep is a SECOND DOOR, and the diff path FALLS BACK to it when the base is
+      // unresolvable — fixing only the diff filter would leave this one serving fixtures. Directories
+      // need a trailing '/', which isFixtureEntry encodes so no call site has to remember it.
+      if (isFixtureEntry(p, e.isDirectory())) continue;
       if (e.isDirectory()) walk(p);
       else if (CODE_RE.test(e.name)) out.push(p);
     }

--- a/scripts/lint/schema-reference-lint.mjs
+++ b/scripts/lint/schema-reference-lint.mjs
@@ -35,6 +35,12 @@ import { isFixturePath, isFixtureEntry } from '../../lib/lint/added-line-text.mj
 // QF-20260802-742: the new-vs-pre-existing split, kept pure so both polarities are fixture-testable.
 import { violationKey, partitionViolations } from './schema-lint-scope.mjs';
 
+// KNOWN LIMITATION (SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001): this control compares references against
+// a COMMITTED SNAPSHOT, so its truth is only as current as that file. Concretely, a table CREATED by
+// a migration in THIS SAME PR is not in the snapshot yet and reads as a PHANTOM (false positive),
+// and a table DROPPED since the snapshot was taken still reads as valid (false negative). The
+// staleness warning below is advisory and never blocks, so the false negative is the silent
+// direction. Regenerate with: npm run schema:snapshot:lint
 const SNAPSHOT_PATH = 'database/schema-reference-snapshot.json';
 const ALLOWLIST_PATH = 'scripts/lint/schema-reference-allowlist.json';
 const RUNTIME_DIRS = ['scripts', 'lib', 'src', 'server', 'api', 'app'];

--- a/scripts/lint/session-coordination-insert-classguard-lint.mjs
+++ b/scripts/lint/session-coordination-insert-classguard-lint.mjs
@@ -44,6 +44,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
 
 const SCAN_DIRS = ['scripts', 'lib'];
+// KNOWN LIMITATION (SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001): this control is EXCLUSION-SCOPED, so a
+// raw insert introduced inside anything it skips is invisible BY DESIGN -- concretely, a raw
+// .from('session_coordination').insert(...) added to lib/coordinator/dispatch.cjs (EXCLUDE_PATHS),
+// to any fixture/test path (isFixturePath), or to a file outside scripts/ and lib/ is never
+// reported. The dispatch.cjs exclusion is deliberate (it IS the choke point), but it means the choke
+// point itself is unguarded by this control: nothing here stops a SECOND raw insert being added
+// beside the canonical one.
 const SCAN_EXTENSIONS = new Set(['.js', '.mjs', '.cjs']);
 const EXCLUDE_DIR_SEGMENTS = ['node_modules', '.git', '.worktrees', 'dist', 'build', 'coverage', 'archive', 'one-time', 'temp'];
 const EXCLUDE_FILE_RE = /(\.test\.|\.spec\.|\.d\.ts$|\.min\.js$)/i;

--- a/scripts/lint/session-coordination-insert-classguard-lint.mjs
+++ b/scripts/lint/session-coordination-insert-classguard-lint.mjs
@@ -36,6 +36,9 @@ import rule from '../../eslint-rules/no-raw-session-coordination-insert.js';
 // sharing this driver's diff/all/exclusion machinery — flags target_session sourced from an
 // echoed row field instead of a fresh identity-resolver call.
 import echoedTargetRule from '../../eslint-rules/no-echoed-session-coordination-target.js';
+// SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-2). Shape B: only isFixturePath — see the helper for why
+// stripComments is shape-A-only and would be cargo-cult here.
+import { isFixturePath } from '../../lib/lint/added-line-text.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '..', '..');
@@ -95,6 +98,16 @@ function walk(dir, out) {
 
 function isExcluded(relPath) {
   if (EXCLUDE_PATHS.has(relPath)) return true;
+  // FR-2 lands HERE rather than at the two call sites because both candidateFilesDiff and
+  // candidateFilesAll already funnel through this predicate — one door, so the diff path and the
+  // --all sweep cannot drift apart.
+  //
+  // This scanner ALREADY MEANT to exclude test material and covered three of the four shapes
+  // (EXCLUDE_FILE_RE catches .test./.spec. basenames, EXCLUDE_DIR_PREFIXES catches a top-level
+  // tests/); a file merely NESTED under __tests__/ without .test. in its name slipped through, which
+  // is 5 live files (scripts/__tests__/replay/*.mjs). So this closes an inconsistency in the
+  // scanner's OWN exclusion policy — it is not a new policy imported from elsewhere.
+  if (isFixturePath(relPath)) return true;
   return EXCLUDE_DIR_PREFIXES.some((prefix) => relPath.startsWith(prefix));
 }
 

--- a/scripts/lint/stage-advancement-chokepoint-lint.mjs
+++ b/scripts/lint/stage-advancement-chokepoint-lint.mjs
@@ -28,6 +28,9 @@
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 import path from 'node:path';
+// SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-2). Shape B: only isFixturePath — see the helper for why
+// stripComments is shape-A-only and would be cargo-cult here.
+import { isFixturePath, isFixtureEntry } from '../../lib/lint/added-line-text.mjs';
 
 const ALLOWLIST_PATH = 'scripts/lint/stage-advancement-chokepoint-allowlist.json';
 const RUNTIME_DIRS = ['scripts', 'lib', 'database'];
@@ -72,7 +75,9 @@ function candidateFiles() {
         .filter((f) => RUNTIME_DIRS.includes(f.split('/')[0]))
         .filter((f) => !SKIP_DIR_RE.test(f))
         .filter((f) => !SKIP_FILE_RE.test(f))
-        .filter((f) => f.split('/')[0] !== 'tests');
+        // Supersedes the old top-level-only `split('/')[0] !== 'tests'`: that missed NESTED tests/,
+        // __tests__/ and .test./.spec. files entirely — 342 of them are selectable in this repo.
+        .filter((f) => !isFixturePath(f));
     } catch (e) {
       console.warn(`⚠️  diff base unavailable (${e.message.split('\n')[0]}) — falling back to --all (advisory)`);
       return candidateFilesAll();
@@ -89,6 +94,10 @@ function candidateFilesAll() {
     for (const e of entries) {
       const p = path.join(dir, e.name).replace(/\\/g, '/');
       if (SKIP_DIR_RE.test(p) || SKIP_FILE_RE.test(p)) continue;
+      // The --all sweep is a SECOND DOOR, and the diff path FALLS BACK to it when the base is
+      // unresolvable — fixing only the diff filter would leave this one serving fixtures. Directories
+      // need a trailing '/', which isFixtureEntry encodes so no call site has to remember it.
+      if (isFixtureEntry(p, e.isDirectory())) continue;
       if (e.isDirectory()) walk(p);
       else if (CODE_RE.test(e.name)) out.push(p);
     }

--- a/scripts/lint/stage-advancement-chokepoint-lint.mjs
+++ b/scripts/lint/stage-advancement-chokepoint-lint.mjs
@@ -32,6 +32,13 @@ import path from 'node:path';
 // stripComments is shape-A-only and would be cargo-cult here.
 import { isFixturePath, isFixtureEntry } from '../../lib/lint/added-line-text.mjs';
 
+// KNOWN LIMITATION (SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001): two concrete blind spots, both by
+// construction. (1) Matching is PER LINE, so a write whose assignment spans lines -- a .update({
+// object literal with current_lifecycle_stage on a later line than the .update( -- is not seen.
+// (2) READ_CONTEXT_RE below skips any line OPENING with SELECT/WHERE/AND/OR/JOIN/ON/--, so a
+// genuine write placed on such a line (e.g. a CTE line beginning with a JOIN keyword that also
+// carries a SET) is skipped with it. That exclusion exists to kill read-context false positives and
+// it buys that at the cost of these writes.
 const ALLOWLIST_PATH = 'scripts/lint/stage-advancement-chokepoint-allowlist.json';
 const RUNTIME_DIRS = ['scripts', 'lib', 'database'];
 const SKIP_DIR_RE = /(^|\/)(node_modules|\.git|\.worktrees|dist|build|coverage|\.next|archive|one-off|one-time|tmp|temp|fixtures?)(\/|$)/i;

--- a/tests/unit/lint/added-line-text.test.js
+++ b/tests/unit/lint/added-line-text.test.js
@@ -1,0 +1,97 @@
+/**
+ * SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-1 / AC-1) — the shared strip-and-exclude helper.
+ *
+ * These reproduce the TWO HISTORICAL FALSE POSITIVES the helper exists to defeat, plus the
+ * two-sided control that stops it becoming a blanket suppressor.
+ *
+ * Typed UNIT deliberately: tests/integration/** resolves to ZERO FILES in this repo, so an
+ * integration-typed test would SKIP AND REPORT GREEN — the same false assurance this SD is about.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { stripComments, isFixturePath, scannableText } from '../../../lib/lint/added-line-text.mjs';
+
+/** The shape both observed false positives took: a real-looking call in non-code context. */
+const CREATOR_CALL = "supabase.from('leo_feature_flags').insert({ flag_key: 'X' })";
+
+describe('stripComments — the comment false positive', () => {
+  it('removes a LINE comment containing creator-shaped text', () => {
+    // The exact recorded failure: a comment written to EXPLAIN a previous false positive contained
+    // both halves of the rule and re-triggered it. The file's own explanation of the bug was the bug.
+    const added = `// we previously mis-read ${CREATOR_CALL} as a real creation\nconst x = 1;`;
+    expect(stripComments(added)).not.toMatch(/\.insert\(/);
+    expect(stripComments(added)).toMatch(/const x = 1;/);
+  });
+
+  it('removes a whole BLOCK comment', () => {
+    const added = `/* example: ${CREATOR_CALL} */\nconst y = 2;`;
+    expect(stripComments(added)).not.toMatch(/\.insert\(/);
+  });
+
+  it('[FRAGMENT] removes JSDoc CONTINUATION lines whose opener the diff slice cut off', () => {
+    // THE ASSERTION THAT JUSTIFIES EXTRACTING RATHER THAN REWRITING. An added-lines slice is a
+    // FRAGMENT: it can begin partway through a JSDoc block, so ` * ...` lines arrive with no `/**`.
+    // A naive /\/\*[\s\S]*?\*\//g misses exactly these — and documentation-shaped false positives
+    // concentrate here.
+    const added = ` * worked example: ${CREATOR_CALL}\n * and more prose\nconst z = 3;`;
+    expect(stripComments(added), 'orphaned JSDoc continuation lines must be stripped').not.toMatch(/\.insert\(/);
+    expect(stripComments(added)).toMatch(/const z = 3;/);
+  });
+
+  it('[TRUE POSITIVE SURVIVES] a REAL call outside a comment is NOT suppressed', () => {
+    // R-5, and the two-sided half of AC-1. Stripping is best-effort and could in principle swallow
+    // too much; a helper that suppressed everything would pass every "no false positive" test while
+    // silently disarming the scanner — a FALSE NEGATIVE, which is worse than the noise it replaced.
+    // This is the control that keeps the helper honest.
+    const added = `${CREATOR_CALL}\n// and a comment mentioning ${CREATOR_CALL}`;
+    const out = stripComments(added);
+    expect(out, 'a genuine occurrence must still be matchable').toMatch(/\.insert\(/);
+    expect(out.match(/\.insert\(/g)).toHaveLength(1); // the commented one is gone, the real one remains
+  });
+});
+
+describe('isFixturePath — the fixture false positive', () => {
+  // EACH ALTERNATIVE IS ISOLATED ON PURPOSE. The first draft of this test used
+  // 'lib/gates/__tests__/operator-contract.test.js' as the .test. case — but that path ALSO matches
+  // via __tests__/, so breaking the .test. branch left the suite green. A mutation run caught it:
+  // the predicate is a four-way alternation, and a case that satisfies two branches cannot tell you
+  // which one fired. Every entry below exercises EXACTLY ONE branch.
+  it.each([
+    ['lib/foo.test.js', '.test. alone — no __tests__ dir, no tests/ dir'],
+    ['lib/x/y.spec.js', '.spec. alone'],
+    ['lib/gates/__tests__/helper.js', '__tests__/ alone — no .test. suffix'],
+    ['tests/unit/foo.js', 'leading tests/ alone'],
+    ['src/tests/bar.js', 'nested /tests/ alone'],
+  ])('excludes %s (%s)', (p) => {
+    expect(isFixturePath(p), `${p} should be treated as fixture material`).toBe(true);
+  });
+
+  it('[TWO-SIDED] does NOT exclude ordinary source paths', () => {
+    // Without this, a predicate that returned true for everything would pass the test above and
+    // silently exclude the entire repo from scanning.
+    for (const p of ['lib/gates/operator-contract/index.js', 'scripts/lint/schema-reference-lint.mjs']) {
+      expect(isFixturePath(p), `${p} must remain scannable`).toBe(false);
+    }
+  });
+
+  it('tolerates junk input rather than throwing', () => {
+    for (const p of [undefined, null, '', 123]) expect(isFixturePath(p)).toBe(false);
+  });
+});
+
+describe('scannableText — the two decisions in one place', () => {
+  it('returns null for a fixture path so callers can skip', () => {
+    expect(scannableText({ path: 'lib/__tests__/x.test.js', added: CREATOR_CALL })).toBeNull();
+  });
+
+  it('returns comment-stripped text for a real source path', () => {
+    const out = scannableText({ path: 'lib/real.js', added: `// ${CREATOR_CALL}\nconst a = 1;` });
+    expect(out).not.toBeNull();
+    expect(out).not.toMatch(/\.insert\(/);
+  });
+
+  it('preserves a real occurrence in a real source path', () => {
+    const out = scannableText({ path: 'lib/real.js', added: CREATOR_CALL });
+    expect(out).toMatch(/\.insert\(/);
+  });
+});

--- a/tests/unit/lint/scanner-convention-lint.test.js
+++ b/tests/unit/lint/scanner-convention-lint.test.js
@@ -1,0 +1,98 @@
+/**
+ * SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-3 / AC-3) — the lint-for-the-linters.
+ *
+ * A guard that has never failed is indistinguishable from an absent one, which is this SD's whole
+ * subject. So the central test PLANTS a violating scanner and asserts the check catches it, rather
+ * than asserting the repo is currently clean — a state that would also hold if the check did nothing.
+ *
+ * Typed UNIT deliberately: tests/integration/** resolves to ZERO FILES here, so an integration-typed
+ * test would SKIP AND REPORT GREEN.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readsAddedLineText, findViolations } from '../../../scripts/lint/scanner-convention-lint.mjs';
+
+const PATCH_READER = 'const patch = run(`git diff ${baseRef}...HEAD -- "${path}"`);';
+const NAME_ONLY = 'execSync(`git diff --name-only --diff-filter=ACMR ${base}...HEAD`)';
+
+describe('readsAddedLineText — the shape-A discriminator', () => {
+  it('flags a git diff that yields a PATCH', () => {
+    expect(readsAddedLineText(PATCH_READER)).toBe(true);
+  });
+
+  it('[THE DISCRIMINATOR] does NOT flag --name-only, which yields PATHS', () => {
+    // This single flag separates shape A from shape B. Too broad and every shape-B lint scanner is
+    // flagged on a scope that has not been ruled; too narrow and nothing is caught.
+    expect(readsAddedLineText(NAME_ONLY)).toBe(false);
+  });
+
+  it('[REGRESSION] ignores a git diff quoted inside an ERROR MESSAGE', () => {
+    // Found on the check's FIRST LIVE RUN, and it is this SD's own defect class committed by the
+    // enforcement tool: the first version flagged compute-changed-retro-migrations for the words
+    // "git diff failed" inside a console.error. Stripping comments is not enough — STRING LITERALS
+    // carry pattern-shaped text too, and a diagnostic is the likeliest place to quote a command.
+    expect(readsAddedLineText('console.error(`[my-scanner] git diff failed (${e.message})`);')).toBe(false);
+  });
+
+  it('[KNOWN LIMIT] a string that OPENS with the command is treated as an invocation', () => {
+    // Stated as a test rather than left as a surprise. `'git diff failed to run'` is a MESSAGE, but
+    // it opens with the command and is therefore indistinguishable from one by this heuristic.
+    // Discriminating further (demanding a following ref or flag) would trade a rare false positive
+    // for a class of false NEGATIVES — a scanner that slipped past the guard entirely — and a false
+    // negative here is strictly worse, because it is the silent direction.
+    // The reasoned opt-out marker exists precisely for this case.
+    expect(readsAddedLineText("throw new Error('git diff failed to run');")).toBe(true);
+  });
+
+  it('ignores a git diff mentioned only in a COMMENT', () => {
+    // The check must not commit the defect it polices — a linter that flags its own prose is the
+    // exact failure this SD exists to abolish.
+    expect(readsAddedLineText('// we used to call git diff <ref> here\nconst x = 1;')).toBe(false);
+    expect(readsAddedLineText(' * example: git diff <ref> -- path\nconst y = 2;')).toBe(false);
+  });
+});
+
+describe('findViolations — planted violation, injected fs', () => {
+  const fixtures = (files) => ({
+    root: '/fake',
+    roots: ['scripts/lint'],
+    listFiles: () => Object.keys(files),
+    readFile: (p) => {
+      const key = Object.keys(files).find((k) => p.endsWith(k.replace(/\//g, require('node:path').sep)) || p.endsWith(k));
+      if (key) return files[key];
+      throw new Error('not found: ' + p);
+    },
+  });
+
+  it('[PLANTED] CATCHES a shape-A scanner that skips the helper', () => {
+    const v = findViolations(fixtures({ 'scripts/lint/bad-scanner.mjs': PATCH_READER }));
+    expect(v).toHaveLength(1);
+    expect(v[0].file).toBe('scripts/lint/bad-scanner.mjs');
+  });
+
+  it('PASSES a shape-A scanner that imports the helper', () => {
+    const good = `import { stripComments } from '../../lib/lint/added-line-text.mjs';\n${PATCH_READER}`;
+    expect(findViolations(fixtures({ 'scripts/lint/good-scanner.mjs': good }))).toHaveLength(0);
+  });
+
+  it('PASSES a shape-B scanner (--name-only) untouched', () => {
+    // Shape B is deliberately out of this check's scope until the coordinator rules on it.
+    expect(findViolations(fixtures({ 'scripts/lint/nameonly.mjs': NAME_ONLY }))).toHaveLength(0);
+  });
+
+  it('honours an opt-out that carries a REASON', () => {
+    const opted = `// scanner-convention-lint-exempt: matches only SQL keywords, never identifiers\n${PATCH_READER}`;
+    expect(findViolations(fixtures({ 'scripts/lint/opted.mjs': opted }))).toHaveLength(0);
+  });
+
+  it('does NOT honour a bare opt-out marker with no reason', () => {
+    // An unexplained exemption is how a guard erodes into a formality.
+    const bare = `// scanner-convention-lint-exempt:\n${PATCH_READER}`;
+    expect(findViolations(fixtures({ 'scripts/lint/bare.mjs': bare }))).toHaveLength(1);
+  });
+
+  it('skips a scanner TEST file, which legitimately contains scanner-shaped strings', () => {
+    const v = findViolations(fixtures({ 'scripts/lint/__tests__/x.test.js': PATCH_READER }));
+    expect(v).toHaveLength(0);
+  });
+});

--- a/tests/unit/lint/scanner-fixture-exclusion.test.js
+++ b/tests/unit/lint/scanner-fixture-exclusion.test.js
@@ -1,0 +1,133 @@
+/**
+ * SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-2 / AC-5) — fixture exclusion in the shape-B scanners.
+ *
+ * VERIFIED AT THE CONSUMER, NOT AT THE MERGE. Asserting that each scanner imports isFixturePath
+ * would pass even if the import were dead — the "adopted but not wired" shape. So these tests RUN
+ * each scanner against a planted tree and assert its selection actually changed.
+ *
+ * TWO-SIDED, because over-suppression is the failure this fix could introduce. Every case asserts
+ * BOTH that the fixture twin is skipped AND that a byte-identical file outside the fixture path is
+ * still flagged. A one-sided test would pass for a scanner that had simply stopped working.
+ *
+ * Typed UNIT deliberately: tests/integration/** resolves to ZERO FILES here, so an integration-typed
+ * test would SKIP AND REPORT GREEN.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, copyFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { isFixturePath, isFixtureEntry } from '../../../lib/lint/added-line-text.mjs';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+describe('isFixtureEntry — the trailing-separator trap, encoded once', () => {
+  it('[THE TRAP] matches a fixture DIRECTORY, which the bare path does NOT', () => {
+    // This is the whole reason the helper exists. `__tests__/` and `tests/` carry a separator, so a
+    // walk pruning on isFixturePath('lib/__tests__') descends into the fixture tree while LOOKING
+    // like it prunes. Three scanners were about to hand-write the `? p + '/' : p` fix independently.
+    expect(isFixturePath('lib/__tests__')).toBe(false);
+    expect(isFixtureEntry('lib/__tests__', true)).toBe(true);
+  });
+
+  it('treats a nested tests/ directory the same way', () => {
+    expect(isFixturePath('lib/tests')).toBe(false);
+    expect(isFixtureEntry('lib/tests', true)).toBe(true);
+  });
+
+  it('[CONTROL] does NOT suppress an ordinary directory', () => {
+    // Without this, a helper that returned true unconditionally would pass every case above while
+    // silently disarming all four scanners — a false NEGATIVE, worse than the noise it replaces.
+    expect(isFixtureEntry('lib/gates', true)).toBe(false);
+    expect(isFixtureEntry('scripts/lint', true)).toBe(false);
+  });
+
+  it('[CONTROL] does NOT suppress an ordinary source file', () => {
+    expect(isFixtureEntry('lib/gates/index.js', false)).toBe(false);
+    expect(isFixtureEntry('scripts/lint/schema-reference-lint.mjs', false)).toBe(false);
+  });
+
+  it('still flags a fixture FILE when isDirectory is false', () => {
+    expect(isFixtureEntry('lib/foo.test.js', false)).toBe(true);
+    expect(isFixtureEntry('lib/__tests__/helper.js', false)).toBe(true);
+  });
+});
+
+/**
+ * One payload carrying a violation for each of the four scanners, written to two paths that differ
+ * ONLY by being fixture material. Any difference in verdict is therefore attributable to the path.
+ */
+const PAYLOAD = [
+  'const row = {};',
+  'supabase.from("session_coordination").insert(row);',        // classguard
+  'supabase.from("totally_fake_table_xyz").select("*");',      // schema-reference
+  'db.update({ current_lifecycle_stage: 5 });',                // stage-advancement
+  'if (retrospectives.quality_score > 80) { go(); }',          // diagnostic-gauge
+  '',
+].join('\n');
+
+const FIXTURE_REL = 'lib/__tests__/planted.mjs';
+const CONTROL_REL = 'lib/planted-real.mjs';
+
+function plantTree() {
+  const root = mkdtempSync(path.join(tmpdir(), 'scanner-fx-'));
+  mkdirSync(path.join(root, 'lib', '__tests__'), { recursive: true });
+  mkdirSync(path.join(root, 'scripts'), { recursive: true });
+  mkdirSync(path.join(root, 'database'), { recursive: true });
+  writeFileSync(path.join(root, FIXTURE_REL), PAYLOAD);
+  writeFileSync(path.join(root, CONTROL_REL), PAYLOAD);
+  // schema-reference-lint exits early without a snapshot; give it the real one.
+  copyFileSync(
+    path.join(REPO, 'database/schema-reference-snapshot.json'),
+    path.join(root, 'database/schema-reference-snapshot.json')
+  );
+  return root;
+}
+
+/** @returns {string[]} paths the scanner reported a violation in */
+function runScanner(scanner, root, extraArgs = []) {
+  let out;
+  try {
+    out = execFileSync(
+      process.execPath,
+      [path.join(REPO, 'scripts/lint', `${scanner}.mjs`), '--all', '--json', ...extraArgs],
+      { cwd: root, encoding: 'utf8', timeout: 120000 }
+    );
+  } catch (e) {
+    // A scanner that finds violations EXITS 1, and execFileSync throws on that — so the exception is
+    // the expected path here, not the error path. The control assertion below is what proves the run
+    // was real; swallowing this without it would turn a crashed scanner into a silent pass.
+    if (e.stdout == null) throw e;
+    out = e.stdout;
+  }
+  const parsed = JSON.parse(out.slice(out.indexOf('{')));
+  // The four scanners disagree on the key: three emit `file`, classguard emits `filePath`.
+  return (parsed.violations || []).map((v) => (v.file || v.filePath).replace(/\\/g, '/'));
+}
+
+const SCANNERS = [
+  { name: 'diagnostic-gauge-citation-lint', args: [] },
+  { name: 'stage-advancement-chokepoint-lint', args: [] },
+  { name: 'schema-reference-lint', args: [] },
+  // classguard resolves its scan root from --root rather than cwd.
+  { name: 'session-coordination-insert-classguard-lint', args: null },
+];
+
+describe('shape-B scanners skip fixture material selected from a diff', () => {
+  for (const { name, args } of SCANNERS) {
+    it(`${name}: skips ${FIXTURE_REL}, still flags ${CONTROL_REL}`, () => {
+      const root = plantTree();
+      try {
+        const hits = runScanner(name, root, args === null ? ['--root', root] : args);
+        // CONTROL FIRST: if the scanner silently stopped working, "no fixture hit" would be
+        // meaningless. This asserts the scanner is alive before reading anything into its silence.
+        expect(hits.some((h) => h.endsWith('planted-real.mjs'))).toBe(true);
+        expect(hits.some((h) => h.includes('__tests__'))).toBe(false);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    }, 120000);
+  }
+});


### PR DESCRIPTION
## SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 — publish the scanner convention, then make skipping it fail

A scanner that pattern-matches repo text selected from a diff false-positives on its own **fixtures**, **worked-example comments** and — found here — **string literals**, because a fixture or an explanation *for* a pattern-detector necessarily contains pattern-shaped text. The sharpest recorded form: a comment written to explain a previous false positive re-triggered it.

The fix had been derived **independently twice** and propagated to neither sibling, and the fixture-path regex alone appeared **three times inside one file**. That is a contract-discoverability failure, not N arithmetic bugs — so the deliverable is a published helper, adoption, and a check that makes the seventh rediscovery fail loudly.

### What ships

| FR | Commit | What |
|----|--------|------|
| FR-1 | `c24d65875e4` | `lib/lint/added-line-text.mjs` — the convention as one module (`isFixturePath`, `stripComments`, `scannableText`) |
| FR-3 | `6870e6ba674` | `scripts/lint/scanner-convention-lint.mjs` — lint-for-the-linters, shape-A only |
| FR-2 | `1bd14a16aa8` | Fixture exclusion adopted in the four susceptible shape-B scanners |
| FR-4 | `fc1a871f8f4` | Reasoned opt-out for the one shape-A consumer, then the check wired into CI (blocking) |

### The class splits, and the treatments differ

Triage found two shapes, and conflating them would have produced cargo-cult patches:

- **Shape A** reads a *patch* and matches added lines. The slice can begin mid-JSDoc, so it needs `stripComments` **and** `isFixturePath`.
- **Shape B** takes `--name-only` paths then reads *whole files*. Comments arrive intact, so the mid-block slice cannot occur — but the file was still **selected by a diff**, so a changed test file is read as live code exactly as in shape A.

Hence **fixture exclusion is universal; comment-stripping is shape-A only**. Shape-B adopters import `isFixturePath` and nothing else — which is why FR-1 exported them separately.

### Two findings that generalise beyond this SD

**Every scanner had two doors.** Each has a `--diff` filter *and* an `--all` `walk()`, and the diff path **falls back to the walk** when the git base is unresolvable — so the sweep is reachable in ordinary diff mode. The walk didn't check `tests/` at all, making it the *more* exposed door. Patching only the visible diff filter would have read as complete while the fallback kept serving fixtures.

**The trailing-separator trap.** `isFixturePath`'s `__tests__/` and `tests/` branches need the separator, so it returns **false** for a bare directory path — a walk pruning on `isFixturePath('lib/__tests__')` descends into the fixture tree *while looking like it prunes*. This was about to be hand-written identically in three files, which is precisely this SD's disease, so it is now `isFixtureEntry(path, isDirectory)`: encoded once, unit-tested, and unexpressible to get wrong at a call site.

### Verification

Verified **at the consumer, not at the merge** — asserting a scanner imports the helper would pass on a dead import. Each scanner is *run* against a planted tree holding one payload written to two paths differing only in being fixture material. **Two-sided throughout, with the control asserted first**: if a scanner had simply stopped working, "no fixture hit" would be meaningless.

Mutations, each confirmed applied (a mutation that doesn't mutate proves nothing):

- `isFixturePath` → `false` — **13 tests fail**; live scanners go 1 → 2 flagged files each
- `isFixtureEntry` drops the slash — **2 tests fail** (the trap-specific case isolates it)
- restored — **210/210** across `tests/unit/lint/`

Typed UNIT deliberately: `tests/integration/**` resolves to zero files here and would skip green.

### AC-5: verdicts are measured, not asserted

Susceptible = 4, modified = 4. Counts moved in **both** directions from the starting framing: my own triage had marked only one scanner susceptible (measurement says four — 346 / 346 / 342 / 5 real files admitted), while the two SQL scanners are **not applicable** and deliberately unpatched. Both are confined to `database/migrations/`, which holds 1416 files and exactly one subdirectory (`rollback`); `rls-anon`'s sweep is a non-recursive `readdirSync` that cannot descend into a test tree, and the repo's only two fixture-shaped `.sql` files live under `tests/security/`, unreachable by either. They were admitted only by synthetic probes — counting those would satisfy AC-5 by inflating the numerator to match a chosen number. Full verdicts banked at `sd.metadata.exec_fr2_verdicts_20260808`.

### FR-4 — the exemption that keeps the check honest (`fc1a871f8f4`)

`collectSdDiff` genuinely reads added-line text, so the check flags it correctly. It is **exempted rather than converted**, because the SQL strip it already carries is *narrower and more correct* for this consumer than the shared helper:

| | block comments | line comments | string literals |
|---|---|---|---|
| `collectSdDiff` | yes | SQL `--` | single-quoted, `''` escape |
| shared helper | yes | JS `//` + JSDoc continuation | none |

Adopting the helper would **delete two strips this consumer depends on** and add one it cannot use — a regression wearing the shape of compliance. A shared convention is worth having precisely because it is not mandatory where it is wrong, and the opt-out is what keeps the check honest: without it, the only ways to go green would be a regression or a suppressed check. The reason is mandatory — a bare marker does not exempt.

Verified two-sided **on the real file**, not just the unit fixture: stripping the reason → 0→1 violation; removing the marker → 0→1; restored → 0. So the exemption is load-bearing rather than decorative, which a green check alone could never show.

### The check is now wired, blocking from day one

A deliberate **departure** from the advisory-soak convention used by `diagnostic-gauge-citation-lint.yml` and `schema-reference-lint.yml`. Those soak because a new lint may false-positive across a large pre-existing surface; this one scans two directories and lands at **zero violations**. An advisory lint-for-the-linters would let the seventh rediscovery merge silently while reporting green — a guard that never fails, which is the precise failure this SD exists to abolish. Shipping it advisory would have been the SD committing its own defect class on its final commit.

Escape, always available and one line: `scanner-convention-lint-exempt: <reason>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
