### PR TITLE
fix(SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001): close the CI- and workstation-reachable git shell-injection sinks

### DIFF
--- a/scripts/docmon.js
+++ b/scripts/docmon.js
@@ -18,7 +18,14 @@
 
 import fs from 'fs';
 import path from 'path';
-import { execSync } from 'child_process';
+// SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001: execFileSync, NOT execSync and NOT spawnSync.
+// execFileSync takes an argv ARRAY and never involves a shell, which is the whole fix. It is also
+// the only drop-in for the contract this file relies on: like execSync it returns stdout as a
+// string and THROWS on a non-zero exit. Three separate catches here depend on that throw — the
+// merge-base fallbacks to 'HEAD~1', the getChangedFiles fallback to a full scan, and
+// getBeforeWordCount's `return 0 // New file`. spawnSync returns {stdout,stderr,status} and does
+// NOT throw, so swapping it in would silently stop ALL THREE from ever firing.
+import { execFileSync } from 'child_process';
 import { fileURLToPath } from 'url';
 import { minimatch } from 'minimatch';
 
@@ -71,19 +78,44 @@ Configuration:
  * Get files changed in current diff
  * @returns {string[]} Array of changed file paths
  */
+// SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001.
+//
+// ONE RUNNER, NOT A FIX PER CALL SITE. Every git invocation in this file goes through here, so no
+// future call can reintroduce a shell by forgetting an argument. That is the stated principle at
+// lib/gates/operator-contract/harness-adapter.js:81-84, carried across rather than re-derived.
+//
+// --literal-pathspecs IS LOAD-BEARING HERE, unlike in the sibling lint. getChangedLines passes the
+// filename as a PATHSPEC after `--`, and `--` ends OPTION parsing WITHOUT disabling PATHSPEC MAGIC:
+// git still reads `:(glob)` and `:(literal)` as SYNTAX in an argument after `--`. MEASURED: with
+// argv-ization alone, a :(glob)-prefixed filename makes git return an EMPTY diff and throw NOTHING,
+// so the file becomes INVISIBLE to the Strunkian gate. Argv-safety alone would therefore have
+// converted this RCE into SILENT EVASION — worse than the defect, because a gate that can be made
+// to see nothing is worse than one that crashes. This is SEC-R1 from PR #6872 recurring verbatim.
+//
+// Applied in the RUNNER, so it also covers `git show` below, where it is INERT (a <rev>:<path>
+// object name is a single argv token, not a pathspec). Kept uniform on purpose: excluding it there
+// would need per-call-site logic, which is exactly the fragility the runner principle warns about.
+const runGit = (args) => execFileSync('git', ['--literal-pathspecs', ...args], { encoding: 'utf-8' });
+
 function getChangedFiles() {
   try {
     // Try to get merge base for PR context
     let mergeBase;
     try {
-      mergeBase = execSync('git merge-base origin/main HEAD', { encoding: 'utf-8' }).trim();
+      mergeBase = runGit(['merge-base', 'origin/main', 'HEAD']).trim();
     } catch {
       // Fallback to HEAD~1 for local pre-push
       mergeBase = 'HEAD~1';
     }
 
-    const diff = execSync(`git diff --name-only ${mergeBase}...HEAD`, { encoding: 'utf-8' });
-    return diff.split('\n').filter(f => f.trim());
+    // -z is NUL-delimited AND suppresses git's path quoting. Beyond the shell fix it closes a
+    // latent parsing bug: a filename containing a literal NEWLINE is legal in a git tree, and the
+    // old split('\n') never recovered it — git C-QUOTES such a name to "we\nird.md", so the parser
+    // produced ONE CONFIDENTLY WRONG path rather than obvious fragments. No .trim() per entry now:
+    // with NUL delimiters the bytes BETWEEN separators ARE the path, and trimming would corrupt a
+    // filename that legitimately begins or ends with a space.
+    const diff = runGit(['diff', '--name-only', '-z', `${mergeBase}...HEAD`]);
+    return diff.split('\0').filter(Boolean);
   } catch {
     console.warn('⚠️ Could not get git diff, scanning all files...');
     return getAllDocFiles();
@@ -154,12 +186,22 @@ function getChangedLines(filePath) {
   try {
     let mergeBase;
     try {
-      mergeBase = execSync('git merge-base origin/main HEAD', { encoding: 'utf-8' }).trim();
+      mergeBase = runGit(['merge-base', 'origin/main', 'HEAD']).trim();
     } catch {
       mergeBase = 'HEAD~1';
     }
 
-    const diff = execSync(`git diff -U0 ${mergeBase}...HEAD -- "${filePath}"`, { encoding: 'utf-8' });
+    // SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001. This was a live RCE: the filename was interpolated
+    // inside double quotes in a shell string. Double quotes do NOT save you — under POSIX sh they
+    // suppress `;` and `&` while $(...) and backticks STILL EXPAND inside them, and an embedded `"`
+    // ends the quoting and re-arms everything else. `filePath` comes from getChangedFiles above,
+    // i.e. any name an attacker can commit, and this runs on ubuntu on every PR touching docs/ or
+    // *.md — and unconditionally on every developer push via .husky/pre-push.
+    //
+    // The path is now its own argv element after `--`, so no SHELL parses it, and the runner's
+    // --literal-pathspecs stops GIT from parsing it as pathspec syntax. Both are required: the
+    // first closes execution, the second closes the silent-evasion hole the first opens.
+    const diff = runGit(['diff', '-U0', `${mergeBase}...HEAD`, '--', filePath]);
     const changedLines = new Set();
 
     // Parse unified diff to get line numbers
@@ -378,12 +420,17 @@ function getBeforeWordCount(filePath) {
   try {
     let mergeBase;
     try {
-      mergeBase = execSync('git merge-base origin/main HEAD', { encoding: 'utf-8' }).trim();
+      mergeBase = runGit(['merge-base', 'origin/main', 'HEAD']).trim();
     } catch {
       mergeBase = 'HEAD~1';
     }
 
-    const beforeContent = execSync(`git show ${mergeBase}:${filePath}`, { encoding: 'utf-8' });
+    // SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001. The WORST sink in this file: no quoting at all, so
+    // `;` `&` `|` were live under sh in addition to $(...) and backticks. It is also SILENT — the
+    // catch below returns 0 and the file is simply treated as new — so an injected payload left no
+    // trace in the output. The <rev>:<path> OBJECT-NAME form is a SINGLE argv token, so argv
+    // conversion alone fully closes this one; the runner's --literal-pathspecs is inert here.
+    const beforeContent = runGit(['show', `${mergeBase}:${filePath}`]);
     return countWords(beforeContent);
   } catch {
     return 0; // New file

--- a/scripts/lint/schema-reference-lint.mjs
+++ b/scripts/lint/schema-reference-lint.mjs
@@ -22,7 +22,14 @@
  * (never a failure).
  */
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
-import { execSync } from 'node:child_process';
+// SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001: execFileSync, NOT execSync and NOT spawnSync.
+// execFileSync takes an argv ARRAY and never involves a shell, which is the whole fix. It is also
+// the only drop-in for the contract this file already relies on: like execSync it returns stdout as
+// a string and THROWS on a non-zero exit. Both catches below depend on that throw — the one at :92
+// degrades to an advisory full sweep, and the one in baselineViolationKeys treats a throw as
+// "file did not exist at the merge base". spawnSync returns {stdout,stderr,status} and does NOT
+// throw, so swapping it in would silently stop BOTH catches from ever firing.
+import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { extractReferences, findViolations } from './schema-reference-extract.mjs';
 // SD-LEO-INFRA-SCHEMA-LINT-DEGRADED-FAILOPEN-001: a degraded --diff run (unresolvable base ->
@@ -37,6 +44,33 @@ const RUNTIME_DIRS = ['scripts', 'lib', 'src', 'server', 'api', 'app'];
 const SKIP_DIR_RE = /(^|\/)(node_modules|\.git|\.worktrees|dist|build|coverage|\.next|archive|one-off|one-time|tmp|temp|fixtures?)(\/|$)/;
 const CODE_RE = /\.(js|cjs|mjs|ts|tsx|jsx)$/;
 const STALE_DAYS = 7;
+
+// SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001.
+//
+// ONE RUNNER, NOT A FIX PER CALL SITE. Every git invocation in this file goes through here, so no
+// future call can reintroduce a shell by forgetting an argument. That is the stated principle at
+// lib/gates/operator-contract/harness-adapter.js:81-84, carried across rather than re-derived.
+//
+// NO --literal-pathspecs HERE, DELIBERATELY. It closes PATHSPEC MAGIC, and this file passes no
+// pathspec: the diffs take only refs, and the baseline read uses the <rev>:<path> OBJECT-NAME form,
+// which git parses as a SINGLE argv token. Adding the flag here would be an inert decoration that a
+// later reader could mistake for the protection. (docmon.js DOES pass a pathspec and DOES need it.)
+// `opts` exists so per-call stdio survives the conversion. The baseline read deliberately keeps
+// stderr on 'ignore'; folding that into the runner for every call would change unrelated output.
+const runGit = (args, opts = {}) => execFileSync('git', args, {
+  encoding: 'utf8', timeout: 30000, maxBuffer: 32 * 1024 * 1024, ...opts,
+});
+
+// SEC: argv-safety stops SHELLS, not ARGUMENT injection. `base` reaches git as a positional
+// argument, and a value LEADING WITH A DASH is parsed by git as an OPTION rather than a ref —
+// `--upload-pack=<program>` makes git EXECUTE the named program. This value is ENV-SUPPLIED
+// (process.env.SCHEMA_LINT_BASE below) and in CI is set from a workflow context expression at
+// .github/workflows/schema-reference-lint.yml:60, so it is not a hypothetical.
+//
+// This repo already adopted exactly this control for the identical sink — lib/fleet/tree-currency.cjs:53,
+// applied at :105 for its own SEC-1 finding — and it simply was not carried here. Same regex, reused
+// verbatim: two shape-guards that drift apart are worse than one shared one.
+const VALID_BASE_REF = /^[A-Za-z0-9._][A-Za-z0-9._/-]*$/;
 
 const args = process.argv.slice(2);
 const mode = args.includes('--all') ? 'all' : 'diff';
@@ -81,23 +115,42 @@ if (Number.isFinite(ageDays) && ageDays > STALE_DAYS) {
 /** Candidate files per mode. */
 function candidateFiles() {
   if (mode === 'diff') {
+    // SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001: validated OUTSIDE the try, deliberately.
+    // The catch below is fail-soft — it degrades an unresolvable base to an advisory whole-repo
+    // sweep so a transient git problem never false-blocks a PR. That is right for git failures and
+    // WRONG for this one: an option-shaped SCHEMA_LINT_BASE is an attack indicator, not a transient
+    // fault, and routing it into the same catch would let an attacker DISABLE this blocking lint
+    // just by supplying a malformed ref. So the refusal is loud and uncatchable here: a rejected
+    // ref must never be indistinguishable from an accepted one, which is the confusion the rest of
+    // this function exists to prevent.
+    const base = process.env.SCHEMA_LINT_BASE || 'origin/main';
+    if (!VALID_BASE_REF.test(base)) {
+      throw new Error(
+        `schema-reference-lint: refusing SCHEMA_LINT_BASE with option-like or unsafe shape: ${base}`
+      );
+    }
     try {
-      const base = process.env.SCHEMA_LINT_BASE || 'origin/main';
       // QF-20260802-742: resolve the merge base EXPLICITLY instead of leaning on the `...`
       // shorthand. The SHA becomes printable, so two runs whose scope is disputed can be
       // compared directly — on PR #6738 the checked set drifted 79 -> 140 files across 24
       // minutes with the violation count pinned, and there was no way to tell which run was
       // right. An explicit two-dot diff from that SHA also cannot widen if origin/main
       // advances between the fetch and the diff.
-      mergeBase = execSync(`git merge-base ${base} HEAD`, { encoding: 'utf8', timeout: 30000 }).trim();
+      mergeBase = runGit(['merge-base', base, 'HEAD']).trim();
       // QF-20260802-742: git merge-base exits 1 with no common ancestor (verified against a
       // deliberately shallowed clone), so the throw above normally covers it. This guard closes
       // the exit-0-but-empty case explicitly: a falsy mergeBase would make every baseline lookup
       // return null, and EVERY pre-existing violation would then read as new — the original bug,
       // silently restored. Routed into the same catch so it degrades to advisory, never blocks.
       if (!mergeBase) throw new Error(`merge-base ${base}..HEAD resolved empty (shallow clone?)`);
+      // SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001: -z on every enumeration. It is NUL-delimited AND
+      // suppresses git's path quoting, which fixes a latent parsing bug independent of the shell
+      // fix: a filename containing a literal NEWLINE is legal in a git tree, and the previous
+      // split('\n') never recovered it. Measured on the sibling SD — without -z git C-QUOTES such a
+      // name to "we\nird.js", so the old parser produced ONE CONFIDENTLY WRONG path rather than
+      // obvious fragments. A wrong name still looks like a name.
       const sources = [
-        execSync(`git diff --name-only --diff-filter=ACMR ${mergeBase}..HEAD`, { encoding: 'utf8', timeout: 30000 }),
+        runGit(['diff', '--name-only', '--diff-filter=ACMR', '-z', `${mergeBase}..HEAD`]),
       ];
       // QF-20260802-742: the previous code ALWAYS unioned staged + working-tree + untracked
       // files, on the stated assumption that "the latter two are empty in CI". They are not.
@@ -108,13 +161,17 @@ function candidateFiles() {
       // where the working tree is not the developer's: CI.
       if (!committedOnly) {
         sources.push(
-          execSync('git diff --name-only --diff-filter=ACMR --cached', { encoding: 'utf8', timeout: 30000 }),
-          execSync('git diff --name-only --diff-filter=ACMR', { encoding: 'utf8', timeout: 30000 }),
-          execSync('git ls-files --others --exclude-standard', { encoding: 'utf8', timeout: 30000 }),
+          runGit(['diff', '--name-only', '--diff-filter=ACMR', '--cached', '-z']),
+          runGit(['diff', '--name-only', '--diff-filter=ACMR', '-z']),
+          runGit(['ls-files', '--others', '--exclude-standard', '-z']),
         );
       }
-      const out = sources.join('\n');
-      return [...new Set(out.split('\n').map(s => s.trim()).filter(Boolean))]
+      // Each -z source is already NUL-TERMINATED, so a plain join concatenates cleanly and the
+      // split below needs no separator bookkeeping. No .trim() per entry, deliberately: with NUL
+      // delimiters the bytes BETWEEN separators ARE the path, and trimming would corrupt a filename
+      // that legitimately begins or ends with a space.
+      const out = sources.join('');
+      return [...new Set(out.split('\0').filter(Boolean))]
         .filter(f => CODE_RE.test(f))
         .filter(f => RUNTIME_DIRS.includes(f.split('/')[0]))
         .filter(f => !SKIP_DIR_RE.test(f))
@@ -150,9 +207,19 @@ function baselineViolationKeys(file) {
   if (!mergeBase) return null; // --all sweep or degraded fallback: nothing to compare against
   let prev;
   try {
-    prev = execSync(`git show ${mergeBase}:${file}`, {
-      encoding: 'utf8', timeout: 30000, maxBuffer: 32 * 1024 * 1024, stdio: ['ignore', 'pipe', 'ignore'],
-    });
+    // SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001. THIS WAS THE WORST OF THE THREE SINKS IN THIS FILE:
+    // `git show ${mergeBase}:${file}` with NO quoting at all, where `file` comes from
+    // git diff --name-only above — i.e. any name an attacker can commit. Unquoted means `;` `&` `|`
+    // were live under sh in addition to $(...) and backticks, and this runs on ubuntu on every PR
+    // touching lib/api/app/scripts. It is also DOUBLY SILENT: stderr is 'ignore' and the catch
+    // returns an empty Set, so an injected payload produced no error and no output to notice.
+    //
+    // The <rev>:<path> OBJECT-NAME form is a SINGLE argv token, so there is no pathspec to make
+    // literal — argv conversion alone fully closes this one.
+    // stdio keeps stderr on 'ignore' EXACTLY as before. That silence is pre-existing behaviour for
+    // the common "file is new, so it has no baseline" case; un-silencing it here would spam a line
+    // per added file and would be a behaviour change this SD has no mandate to make.
+    prev = runGit(['show', `${mergeBase}:${file}`], { stdio: ['ignore', 'pipe', 'ignore'] });
   } catch {
     return new Set(); // file did not exist at the merge base -> every violation in it is genuinely new
   }

--- a/scripts/lint/schema-reference-lint.mjs
+++ b/scripts/lint/schema-reference-lint.mjs
@@ -62,8 +62,16 @@ const runGit = (args, opts = {}) => execFileSync('git', args, {
 });
 
 // SEC: argv-safety stops SHELLS, not ARGUMENT injection. `base` reaches git as a positional
-// argument, and a value LEADING WITH A DASH is parsed by git as an OPTION rather than a ref —
-// `--upload-pack=<program>` makes git EXECUTE the named program. This value is ENV-SUPPLIED
+// argument, and a value LEADING WITH A DASH is parsed by git as an OPTION rather than a ref.
+//
+// PRECISION, because the prior art's wording does not transfer and an adversarial review caught it:
+// tree-currency.cjs cites `--upload-pack=<program>` making git EXECUTE the named program, which is
+// true for its FETCH-family sink. MEASURED HERE: `git merge-base --upload-pack=... HEAD` exits 129
+// with "error: unknown option" — merge-base has no exec-capable option, so THIS sink is not a
+// command-execution primitive today. The guard is still correct and still wanted: it fails CLOSED
+// against a whole class of option-shaped input rather than depending on the current option surface
+// of one subcommand, which is exactly the kind of thing that changes under you. Stated accurately
+// so a third site does not inherit an over-claim. This value is ENV-SUPPLIED
 // (process.env.SCHEMA_LINT_BASE below) and in CI is set from a workflow context expression at
 // .github/workflows/schema-reference-lint.yml:60, so it is not a hypothetical.
 //
@@ -119,10 +127,15 @@ function candidateFiles() {
     // The catch below is fail-soft — it degrades an unresolvable base to an advisory whole-repo
     // sweep so a transient git problem never false-blocks a PR. That is right for git failures and
     // WRONG for this one: an option-shaped SCHEMA_LINT_BASE is an attack indicator, not a transient
-    // fault, and routing it into the same catch would let an attacker DISABLE this blocking lint
-    // just by supplying a malformed ref. So the refusal is loud and uncatchable here: a rejected
-    // ref must never be indistinguishable from an accepted one, which is the confusion the rest of
-    // this function exists to prevent.
+    // fault, and it should never be absorbed by the same path that forgives a shallow clone.
+    //
+    // SCOPED HONESTLY, because the first version of this comment over-claimed and a review measured
+    // it: this does NOT stop someone disabling the lint by supplying a bad ref. SCHEMA_LINT_BASE=
+    // zzz-no-such-branch PASSES the guard, lands in the catch below, prints "NOT blocking this PR"
+    // and exits 0 — that degraded-advisory behaviour is deliberate
+    // (SD-LEO-INFRA-SCHEMA-LINT-DEGRADED-FAILOPEN-001), not a hole this guard was ever going to
+    // close. What the guard closes is the OPTION-SHAPED SUBSET, and it closes it loudly: a rejected
+    // ref must never be indistinguishable from an accepted one.
     const base = process.env.SCHEMA_LINT_BASE || 'origin/main';
     if (!VALID_BASE_REF.test(base)) {
       throw new Error(

--- a/tests/unit/docmon-shell-injection.test.js
+++ b/tests/unit/docmon-shell-injection.test.js
@@ -11,9 +11,15 @@
  * and the credentials are real.
  *
  * .test.js, NOT .test.mjs, DELIBERATELY. The vitest unit project includes a recursive .test.js glob
- * plus two narrow .mjs anchors that do not cover this directory. A file named with a .test.mjs
- * extension here is collected by ZERO projects and silently never runs — measured by A-B probe
- * during PLAN, which is the single most likely way this suite ends up decorative. Prove collection with
+ * plus two narrow .mjs anchors that do not cover this directory, so a .test.mjs file here is
+ * collected by ZERO projects — measured by A-B probe.
+ *
+ * WHERE THAT BECOMES SILENT, stated precisely rather than overstated: a TARGETED run of a
+ * non-collected file EXITS 1 with "No test files found", so running this file by name is safe and
+ * loud. The vacuity is SUITE-WIDE only. `npm test` and CI's test:coverage both run
+ * `vitest run --project unit`, and an uncollected file is simply ABSENT from that sweep — no error,
+ * no skip notice, just green. So the danger is not that the file fails quietly; it is that the
+ * suite succeeds without it and nothing reports a file that was never collected. Prove collection with
  * `npx vitest list --project unit tests/unit/docmon-shell-injection.test.js`; a green run is not
  * proof, because a file that never ran is also green.
  *
@@ -140,7 +146,25 @@ function commitRaw(dir, files) {
   git(dir, ['update-ref', 'refs/heads/main', commit]);
 }
 
-/** Run the REAL docmon against a fixture repo. Never throws; the side effects are what matter. */
+/**
+ * Run the REAL docmon against a fixture repo. Never throws; the side effects are what matter.
+ *
+ * MEASURED LIMIT OF THE "THE FIX" ASSERTIONS BELOW, stated because a green test that cannot fail is
+ * worse than no test. A mutation run reverting :386 to its pre-fix shell string produced ZERO red on
+ * this Windows host. Diagnosed with the TRUE pre-fix file from git history, not a reconstruction:
+ * the sink IS reached (git reports `fatal: path 'docs/pwn` + backtick + `touch' does not exist`),
+ * but Windows splits the command line on spaces and leaves the backtick LITERAL, so the payload
+ * never executes and no marker appears — with or without the fix.
+ *
+ * A ComSpec override pointing at a real sh was tried and MEASURED NOT TO WORK; the child still ran
+ * under cmd. That attempt was removed rather than left in place with a comment claiming otherwise.
+ *
+ * So on win32 these assertions are TRUE BUT NON-DISCRIMINATING. They discriminate on ubuntu, which
+ * is where CI runs and where the ARM above proves the payload fires. The honest local coverage is:
+ * the ARM tests (which force `shell: SH` and DO fire here) and the lint's guard tests. A Windows-
+ * native payload using `&` — live under cmd.exe at the unquoted sink — would close this gap and is
+ * the correct next step; it is not yet done, and this comment is not a substitute for it.
+ */
 function runDocmon(dir) {
   try {
     return execFileSync(process.execPath, [DOCMON, '--json'], {

--- a/tests/unit/docmon-shell-injection.test.js
+++ b/tests/unit/docmon-shell-injection.test.js
@@ -149,21 +149,19 @@ function commitRaw(dir, files) {
 /**
  * Run the REAL docmon against a fixture repo. Never throws; the side effects are what matter.
  *
- * MEASURED LIMIT OF THE "THE FIX" ASSERTIONS BELOW, stated because a green test that cannot fail is
- * worse than no test. A mutation run reverting :386 to its pre-fix shell string produced ZERO red on
- * this Windows host. Diagnosed with the TRUE pre-fix file from git history, not a reconstruction:
- * the sink IS reached (git reports `fatal: path 'docs/pwn` + backtick + `touch' does not exist`),
+ * HOW THIS BECAME DISCRIMINATING, recorded because the first version was not and looked identical.
+ * With a backtick payload, a mutation reverting :386 to its pre-fix shell string produced ZERO red
+ * on Windows. Diagnosed with the TRUE pre-fix file from git history rather than a reconstruction:
+ * the sink IS reached (git reported `fatal: path 'docs/pwn` + backtick + `touch' does not exist`),
  * but Windows splits the command line on spaces and leaves the backtick LITERAL, so the payload
- * never executes and no marker appears — with or without the fix.
+ * could not fire with or without the fix. The assertion was true for the wrong reason.
  *
- * A ComSpec override pointing at a real sh was tried and MEASURED NOT TO WORK; the child still ran
- * under cmd. That attempt was removed rather than left in place with a comment claiming otherwise.
+ * A ComSpec override pointing at a real sh was tried and MEASURED NOT TO WORK — the child still ran
+ * under cmd — and was removed rather than left with a comment claiming otherwise.
  *
- * So on win32 these assertions are TRUE BUT NON-DISCRIMINATING. They discriminate on ubuntu, which
- * is where CI runs and where the ARM above proves the payload fires. The honest local coverage is:
- * the ARM tests (which force `shell: SH` and DO fire here) and the lint's guard tests. A Windows-
- * native payload using `&` — live under cmd.exe at the unquoted sink — would close this gap and is
- * the correct next step; it is not yet done, and this comment is not a substitute for it.
+ * The payload now chains `&`-separated commands that fire under BOTH cmd.exe and sh (see the :386
+ * describe). MEASURED end-to-end against the true pre-fix file: marker CREATED before the fix,
+ * ABSENT after, with the file still reported. The pair discriminates on this host, not merely on CI.
  */
 function runDocmon(dir) {
   try {
@@ -178,41 +176,102 @@ function runDocmon(dir) {
 const rm = (d) => { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ } };
 
 describe('ARMED: docmon :386 — the UNQUOTED git show sink', () => {
-  const canRun = !!SH;
-  const NAME = 'docs/pwn`touch MARKER386.txt`end.md';
+  /**
+   * THE PAYLOAD IS CROSS-PLATFORM BY CONSTRUCTION, and it had to be. A backtick payload was tried
+   * first and MEASURED not to discriminate: reverting the fix left this test green, because Windows
+   * splits the command line on spaces and treats a backtick as a LITERAL character. The assertion
+   * was true for the wrong reason — the payload could not fire, so "no marker" said nothing about
+   * the fix. A ComSpec override to route the child through sh was also tried and measured NOT to
+   * work; the child still ran under cmd.
+   *
+   * `&` is the operator that IS live under cmd.exe at an unquoted sink, and it also separates
+   * commands under sh. Chaining BOTH shells' file-creating commands means one filename arms on
+   * either platform with no skip and no shell forcing:
+   *   cmd.exe -> `git show <rev>:docs/x` | `copy nul MARKER` | `touch ...`(fails) | `y.md`(fails)
+   *   sh      -> `git show ...&` | `copy ...`(fails) | `touch MARKER &` | `y.md &`(fails)
+   * Either way the marker appears. `copy nul <f>` is used rather than a redirect because `>` is
+   * illegal in an NTFS filename.
+   */
+  const NAME = 'docs/x&copy nul MARKER386.txt&touch MARKER386.txt&y.md';
   let dir; let marker;
 
   beforeAll(() => {
-    if (!canRun) return;
     dir = initRepo();
     commitOrdinary(dir, { [NAME]: '# Payload\n\nAdded prose line.\n' });
     marker = path.join(dir, 'MARKER386.txt');
   });
   afterAll(() => { if (dir) rm(dir); });
 
-  it.runIf(canRun)('git returns the metacharacter filename BYTE-VERBATIM — it does not escape it for you', () => {
+  it('git returns the metacharacter filename BYTE-VERBATIM — it does not escape it for you', () => {
     const out = git(dir, ['diff', '--name-only', '-z', 'HEAD~1...HEAD']).split('\0').filter(Boolean);
     expect(out).toContain(NAME);
   });
 
-  it.runIf(canRun)('THE ARM: the ORIGINAL unquoted shape CREATES THE MARKER — the payload can fire', () => {
-    // The pre-fix line reconstructed verbatim, run through a real sh. If this does not create the
-    // marker, every "no marker" assertion below is meaningless and this file is theatre.
+  it('THE ARM: the ORIGINAL unquoted shape CREATES THE MARKER — the payload can fire', () => {
+    // The pre-fix line reconstructed verbatim, run through whatever shell this host actually uses.
+    // MEASURED against the TRUE pre-fix file from git history: it creates the marker. If this ever
+    // stops firing, every "no marker" assertion below becomes meaningless and this file is theatre.
+    fs.rmSync(marker, { force: true });
     const base = git(dir, ['rev-parse', 'HEAD~1']).trim();
     try {
-      execSync(`git show ${base}:${NAME}`, { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: SH });
-    } catch { /* non-zero exit is fine; the side effect is the point */ }
+      execSync(`git show ${base}:${NAME}`, { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    } catch { /* non-zero exit is expected; the side effect is the point */ }
     expect(path.resolve(marker).startsWith(path.resolve(dir)), 'marker must be inside the temp dir').toBe(true);
     expect(fs.existsSync(marker), 'vulnerable form did not execute — this test cannot fail, so it proves nothing').toBe(true);
   });
 
-  it.runIf(canRun)('THE FIX: docmon creates NO marker, AND still reports the adversarial file', () => {
+  it('THE FIX: docmon creates NO marker, AND still reports the adversarial file', () => {
     // Both halves required. "No marker" alone would also be satisfied by a fix that simply stopped
     // seeing the file — trading execution for silent evasion, which is worse than the defect.
     fs.rmSync(marker, { force: true });
     const out = runDocmon(dir);
     expect(fs.existsSync(marker), 'the fixed path executed the filename').toBe(false);
-    expect(out, 'the adversarial file must remain VISIBLE to docmon, not silently dropped').toContain('pwn');
+    expect(out, 'the adversarial file must remain VISIBLE to docmon, not silently dropped').toContain('MARKER386');
+  });
+});
+
+describe('ARMED: docmon :162 — the DOUBLE-QUOTED sink, via the %VAR% vector', () => {
+  /**
+   * WHY %VAR% AND NOT `&` HERE. :162 interpolates the filename INSIDE DOUBLE QUOTES. Under cmd.exe
+   * that suppresses `&` and `|` — measured — so the payload that arms the unquoted sink is INERT
+   * here and would produce a test that cannot fail. `%VAR%` is the one construct cmd.exe still
+   * expands inside double quotes.
+   *
+   * THE FAILURE IS SILENT, WHICH IS WHY THE ASSERTION IS ABOUT WHAT IS SEEN, NOT ABOUT A MARKER.
+   * cmd expands %PATH% BEFORE git sees the argument, so git matches no pathspec and exits 0 with an
+   * EMPTY diff and NO error. getChangedLines therefore returns an empty set, and because
+   * checkBlacklist is gated on changed lines, the blacklisted word on the added line is NEVER
+   * REPORTED. The gate is made to see nothing — worse than a crash, and invisible in CI.
+   */
+  const NAME = 'docs/note%PATH%x.md';
+  let dir;
+
+  beforeAll(() => {
+    dir = initRepo();
+    // 'crucial' is a blacklisted word. It is only reported if getChangedLines recovered this line.
+    commitOrdinary(dir, { [NAME]: '# Note\n\nThis is a crucial improvement to the system.\n' });
+  });
+  afterAll(() => { if (dir) rm(dir); });
+
+  it('THE ARM: the ORIGINAL double-quoted shape yields an EMPTY diff and throws NOTHING', () => {
+    // Zero bytes AND no throw is what makes it silent — no catch fires, so the file reads as
+    // "present, nothing changed" rather than "unreadable".
+    const base = git(dir, ['rev-parse', 'HEAD~1']).trim();
+    let threw = false; let out = null;
+    try {
+      out = execSync(`git diff -U0 ${base}...HEAD -- "${NAME}"`, { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    } catch { threw = true; }
+    expect(threw, 'the vector must NOT throw — that is what makes it silent').toBe(false);
+    expect(out.trim(), 'the shell did not expand the variable here, so this arm cannot discriminate').toBe('');
+  });
+
+  it('THE FIX: docmon recovers the changed line and REPORTS the blacklisted word', () => {
+    // If :162 regresses, changedLines is empty, checkBlacklist reports nothing, and this count is 0
+    // while the run still exits cleanly. That silent zero is the whole failure mode.
+    const out = runDocmon(dir);
+    const parsed = JSON.parse(out);
+    expect(parsed.summary.filesScanned, 'the payload file was not scanned at all').toBeGreaterThan(0);
+    expect(parsed.summary.blacklistViolations, 'no violation reported — the changed line was never recovered, so the gate saw nothing').toBeGreaterThan(0);
   });
 });
 

--- a/tests/unit/docmon-shell-injection.test.js
+++ b/tests/unit/docmon-shell-injection.test.js
@@ -1,0 +1,289 @@
+/**
+ * docmon must never hand a git-supplied filename to a shell.
+ * SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001.
+ *
+ * THE DEFECT. Two sites in scripts/docmon.js built a /bin/sh command string from a filename that
+ * came straight out of `git diff --name-only`:
+ *   :162  git diff -U0 <mergeBase>...HEAD -- "<filePath>"   (double-quoted: $() and backtick live)
+ *   :386  git show <mergeBase>:<filePath>                    (UNQUOTED: ; & | $() backtick all live)
+ * Both run on ubuntu on every PR touching docs/ or *.md (.github/workflows/strunkian-gates.yml:36)
+ * and UNCONDITIONALLY on every developer push (.husky/pre-push:35), where the host is not ephemeral
+ * and the credentials are real.
+ *
+ * .test.js, NOT .test.mjs, DELIBERATELY. The vitest unit project includes a recursive .test.js glob
+ * plus two narrow .mjs anchors that do not cover this directory. A file named with a .test.mjs
+ * extension here is collected by ZERO projects and silently never runs — measured by A-B probe
+ * during PLAN, which is the single most likely way this suite ends up decorative. Prove collection with
+ * `npx vitest list --project unit tests/unit/docmon-shell-injection.test.js`; a green run is not
+ * proof, because a file that never ran is also green.
+ *
+ * THESE TESTS SPAWN, THEY DO NOT IMPORT. scripts/docmon.js has ZERO exports and runs top-level side
+ * effects off process.argv, so there is no function to call. Every assertion drives the real script
+ * as a subprocess against a real git repo. child_process is never mocked.
+ *
+ * EVERY POSITIVE CLAIM IS ARMED. Each "the fix holds" assertion is paired with a replay of the
+ * ORIGINAL vulnerable shape against the SAME fixture, proving the payload can actually fire here.
+ * Without that, "no marker was created" is indistinguishable from "the payload was never capable of
+ * firing on this platform" — which is exactly how a security test becomes decorative.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync, execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '../..');
+const DOCMON = path.join(REPO, 'scripts', 'docmon.js');
+const IS_WIN = process.platform === 'win32';
+
+/**
+ * Resolve a real POSIX sh if this host has one. Probes PATH under both spellings, THEN the
+ * Git-for-Windows install locations — a PATH-only lookup is exactly how this arm ends up silently
+ * skipped on a machine that could in fact run it.
+ */
+function findSh() {
+  for (const probe of IS_WIN ? ['sh.exe', 'sh'] : ['sh']) {
+    try {
+      const out = execFileSync(IS_WIN ? 'where' : 'which', [probe], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+      const first = out.split(/\r?\n/).map((s) => s.trim()).filter(Boolean)[0];
+      if (first && fs.existsSync(first)) return first;
+    } catch { /* try the next probe */ }
+  }
+  if (IS_WIN) {
+    for (const c of [
+      'C:\\Program Files\\Git\\usr\\bin\\sh.exe',
+      'C:\\Program Files\\Git\\bin\\sh.exe',
+      'C:\\Program Files (x86)\\Git\\usr\\bin\\sh.exe',
+    ]) if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+const SH = findSh();
+
+const git = (repo, args) => execFileSync('git', args, { cwd: repo, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+
+function initRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'docmon-inj-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Test']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  // THE FIXTURE MUST REACH THE SINK. docmon filters candidates through .strunkian-rules.json;
+  // without it the payload file is never selected and the suite passes having executed nothing.
+  const rules = path.join(REPO, '.strunkian-rules.json');
+  if (fs.existsSync(rules)) fs.copyFileSync(rules, path.join(dir, '.strunkian-rules.json'));
+  fs.mkdirSync(path.join(dir, 'docs'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'docs', 'base.md'), '# Base\n\nSome ordinary prose here.\n');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', 'base']);
+  return dir;
+}
+
+/** Commit `files` as a SECOND commit so `HEAD~1...HEAD` sees them as changed. */
+function commitOrdinary(dir, files) {
+  for (const [name, body] of Object.entries(files)) {
+    const full = path.join(dir, name);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, body);
+  }
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', 'payload']);
+}
+
+/**
+ * Commit paths the FILESYSTEM refuses. A literal newline and a colon are illegal in NTFS names and
+ * `git add` validates the worktree path, so these payloads cannot be committed the ordinary way.
+ * mktree writes a tree object directly, which is legitimate because docmon reads TREES.
+ * Without this, the -z and pathspec-magic vectors would be untestable on Windows and would ship on
+ * a promise — which is how the sibling SD's -z change shipped with zero discriminating coverage.
+ *
+ * CONSTRAINT, measured the hard way: `git mktree` builds ONE tree level and rejects ANY path
+ * containing a slash ("fatal: path docs/base.md contains slash"). That applies to the INHERITED
+ * entries too, not just the new ones — a nested base file breaks it before the payload is reached.
+ * So every fixture that goes through here uses FLAT names and initFlatRepo(). Nested payloads would
+ * need write-tree over a built index instead, which buys nothing for these two vectors.
+ */
+/**
+ * A repo whose base commit is FLAT. Required by commitRaw below — see the constraint recorded there.
+ */
+function initFlatRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'docmon-raw-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Test']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+  fs.writeFileSync(path.join(dir, 'base.md'), '# Base\n');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', 'base']);
+  return dir;
+}
+
+function commitRaw(dir, files) {
+  const parent = git(dir, ['rev-parse', 'HEAD']).trim();
+  const entries = [];
+  const baseTree = git(dir, ['ls-tree', '-z', '-r', 'HEAD']).split('\0').filter(Boolean);
+  for (const line of baseTree) {
+    const m = /^(\d+) blob ([0-9a-f]+)\t(.*)$/.exec(line);
+    if (m) entries.push([m[3], m[2], m[1]]);
+  }
+  for (const [name, body] of Object.entries(files)) {
+    const sha = execFileSync('git', ['hash-object', '-w', '--stdin'], { cwd: dir, input: body, encoding: 'utf8' }).trim();
+    entries.push([name, sha, '100644']);
+  }
+  entries.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  const spec = entries.map(([name, sha, mode]) => `${mode} blob ${sha}\t${name}\0`).join('');
+  const tree = execFileSync('git', ['mktree', '-z', '--missing'], { cwd: dir, input: spec, encoding: 'utf8' }).trim();
+  const commit = execFileSync('git', ['commit-tree', tree, '-p', parent, '-m', 'raw payload'], { cwd: dir, encoding: 'utf8' }).trim();
+  git(dir, ['update-ref', 'refs/heads/main', commit]);
+}
+
+/** Run the REAL docmon against a fixture repo. Never throws; the side effects are what matter. */
+function runDocmon(dir) {
+  try {
+    return execFileSync(process.execPath, [DOCMON, '--json'], {
+      cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 45000,
+    });
+  } catch (e) {
+    return e?.stdout || '';
+  }
+}
+
+const rm = (d) => { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ } };
+
+describe('ARMED: docmon :386 — the UNQUOTED git show sink', () => {
+  const canRun = !!SH;
+  const NAME = 'docs/pwn`touch MARKER386.txt`end.md';
+  let dir; let marker;
+
+  beforeAll(() => {
+    if (!canRun) return;
+    dir = initRepo();
+    commitOrdinary(dir, { [NAME]: '# Payload\n\nAdded prose line.\n' });
+    marker = path.join(dir, 'MARKER386.txt');
+  });
+  afterAll(() => { if (dir) rm(dir); });
+
+  it.runIf(canRun)('git returns the metacharacter filename BYTE-VERBATIM — it does not escape it for you', () => {
+    const out = git(dir, ['diff', '--name-only', '-z', 'HEAD~1...HEAD']).split('\0').filter(Boolean);
+    expect(out).toContain(NAME);
+  });
+
+  it.runIf(canRun)('THE ARM: the ORIGINAL unquoted shape CREATES THE MARKER — the payload can fire', () => {
+    // The pre-fix line reconstructed verbatim, run through a real sh. If this does not create the
+    // marker, every "no marker" assertion below is meaningless and this file is theatre.
+    const base = git(dir, ['rev-parse', 'HEAD~1']).trim();
+    try {
+      execSync(`git show ${base}:${NAME}`, { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: SH });
+    } catch { /* non-zero exit is fine; the side effect is the point */ }
+    expect(path.resolve(marker).startsWith(path.resolve(dir)), 'marker must be inside the temp dir').toBe(true);
+    expect(fs.existsSync(marker), 'vulnerable form did not execute — this test cannot fail, so it proves nothing').toBe(true);
+  });
+
+  it.runIf(canRun)('THE FIX: docmon creates NO marker, AND still reports the adversarial file', () => {
+    // Both halves required. "No marker" alone would also be satisfied by a fix that simply stopped
+    // seeing the file — trading execution for silent evasion, which is worse than the defect.
+    fs.rmSync(marker, { force: true });
+    const out = runDocmon(dir);
+    expect(fs.existsSync(marker), 'the fixed path executed the filename').toBe(false);
+    expect(out, 'the adversarial file must remain VISIBLE to docmon, not silently dropped').toContain('pwn');
+  });
+});
+
+describe('ARMED: docmon :162 — pathspec magic survives `--`, so argv alone is NOT enough', () => {
+  // The finding that argv-ization ALONE converts this RCE into SILENT EVASION. `--` ends OPTION
+  // parsing but leaves PATHSPEC MAGIC live, so a :(glob)-prefixed name yields an empty diff and no
+  // error — the file becomes invisible to the gate. SEC-R1 from PR #6872, recurring verbatim.
+  // Flat name: mktree rejects slashes (see commitRaw). This describe drives git directly rather
+  // than docmon, so the name does not need to satisfy docmon's doc-path patterns.
+  const ATTACK = ':(glob)hidden.md';
+  let dir;
+
+  beforeAll(() => {
+    dir = initFlatRepo();
+    commitRaw(dir, { [ATTACK]: '# Hidden\n\nThis line was added and must be seen.\n' });
+  });
+  afterAll(() => { if (dir) rm(dir); });
+
+  it('THE ARM: WITHOUT --literal-pathspecs git returns an EMPTY diff and throws NOTHING', () => {
+    // Zero bytes AND no throw is what makes it silent: the catch never fires, so the file reads as
+    // "present, no added lines" rather than "unreadable".
+    const base = git(dir, ['rev-parse', 'HEAD~1']).trim();
+    let threw = false; let out = null;
+    try {
+      out = execFileSync('git', ['diff', '-U0', `${base}...HEAD`, '--', ATTACK], { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    } catch { threw = true; }
+    expect(threw, 'the vector must NOT throw — that is what makes it silent').toBe(false);
+    expect(out, 'git already reads this path literally here, so this arm cannot discriminate').toBe('');
+  });
+
+  it('THE FIX: --literal-pathspecs recovers the real diff for the same path', () => {
+    const base = git(dir, ['rev-parse', 'HEAD~1']).trim();
+    const out = execFileSync('git', ['--literal-pathspecs', 'diff', '-U0', `${base}...HEAD`, '--', ATTACK], { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    expect(out, 'the flag is the whole difference between seeing the file and not').toContain('must be seen');
+  });
+});
+
+describe('ARMED: -z is load-bearing, not cosmetic', () => {
+  // Added because the sibling SD measured this honestly: deleting -z and restoring split(newline)
+  // left the ENTIRE suite green. A newline in the name is the case that actually separates them.
+  const NAME = 'we\nird.md';
+  let dir;
+
+  beforeAll(() => {
+    dir = initFlatRepo();
+    commitRaw(dir, { [NAME]: '# Weird\n\nProse body.\n' });
+  });
+  afterAll(() => { if (dir) rm(dir); });
+
+  it('THE ARM: WITHOUT -z git C-QUOTES the name, so a newline split cannot recover it', () => {
+    // It fails by QUOTING, not by shredding: git emits "we\nird.md" with a two-character escape, so
+    // the old parser produced ONE CONFIDENTLY WRONG path rather than obvious fragments. A wrong name
+    // still looks like a name, which is the worse failure of the two.
+    const base = git(dir, ['rev-parse', 'HEAD~1']).trim();
+    const quoted = execFileSync('git', ['diff', '--name-only', `${base}...HEAD`], { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    const fragments = quoted.split('\n').map((s) => s.trim()).filter(Boolean);
+    expect(fragments, 'the pre-fix parser must NOT be able to recover the true name').not.toContain(NAME);
+    expect(fragments.some((f) => f.startsWith('"')), 'git did not quote at all here, so -z buys nothing on this host').toBe(true);
+  });
+
+  it('THE FIX: with -z the newline name round-trips BYTE-EXACT', () => {
+    const base = git(dir, ['rev-parse', 'HEAD~1']).trim();
+    const names = execFileSync('git', ['diff', '--name-only', '-z', `${base}...HEAD`], { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }).split('\0').filter(Boolean);
+    expect(names, 'the NUL split or the dropped .trim() regressed').toContain(NAME);
+  });
+});
+
+describe('docmon behaviour is unchanged for ordinary input', () => {
+  let dir;
+  beforeAll(() => {
+    dir = initRepo();
+    commitOrdinary(dir, { 'docs/plain.md': '# Plain\n\nAn ordinary sentence for the validator.\n' });
+  });
+  afterAll(() => { if (dir) rm(dir); });
+
+  it('still emits well-formed JSON with a summary', () => {
+    const out = runDocmon(dir);
+    expect(out.trim().length, 'docmon produced no output at all').toBeGreaterThan(0);
+    const parsed = JSON.parse(out);
+    expect(parsed).toHaveProperty('summary');
+  });
+});
+
+describe('CONTROL: stated limits of this suite', () => {
+  it('NOTE: an embedded double-quote payload is NOT fixture-tested here', () => {
+    // Stated rather than quietly omitted. `"` is illegal in an NTFS filename AND git refuses such a
+    // path (core.protectNTFS defaults true, cross-platform). Its defence is ARCHITECTURAL — after
+    // this fix there is no shell layer for a quote to escape from — not measured by a fixture.
+    expect(true).toBe(true);
+  });
+
+  it('NOTE: a colon in a filename silently creates an NTFS Alternate Data Stream', () => {
+    // Measured during PLAN: writeFileSync on `a:payload.md` APPEARS to succeed but creates an ADS on
+    // file `a`, and `git add` then fails with "outside repository". A fixture author reading only the
+    // write result would conclude it worked. That is why colon-bearing payloads go through mktree.
+    expect(true).toBe(true);
+  });
+});

--- a/tests/unit/docmon-shell-injection.test.js
+++ b/tests/unit/docmon-shell-injection.test.js
@@ -232,10 +232,17 @@ describe('ARMED: docmon :386 — the UNQUOTED git show sink', () => {
 
 describe('ARMED: docmon :162 — the DOUBLE-QUOTED sink, via the %VAR% vector', () => {
   /**
-   * WHY %VAR% AND NOT `&` HERE. :162 interpolates the filename INSIDE DOUBLE QUOTES. Under cmd.exe
-   * that suppresses `&` and `|` — measured — so the payload that arms the unquoted sink is INERT
-   * here and would produce a test that cannot fail. `%VAR%` is the one construct cmd.exe still
-   * expands inside double quotes.
+   * WHY NOT `&` HERE. :162 interpolates the filename INSIDE DOUBLE QUOTES. Under cmd.exe that
+   * suppresses `&` and `|` — measured — so the payload that arms the unquoted sink is INERT here and
+   * would produce a test that cannot fail.
+   *
+   * THE NAME CARRIES BOTH SHELLS' EXPANSIONS, and it has to. A %VAR%-only payload was written first
+   * and an EXEC review caught that it would go RED on ubuntu: %VAR% is a cmd.exe-only expansion, so
+   * under sh the name stays literal, git MATCHES the file, and the diff is non-empty — the arm's
+   * `toBe('')` would fail on the very platform CI runs. `$(...)` is the mirror image: live under sh
+   * inside double quotes, inert under cmd. Carrying BOTH means exactly one of them expands on any
+   * host, the pathspec stops matching the real filename either way, and the arm holds everywhere
+   * without a platform gate.
    *
    * THE FAILURE IS SILENT, WHICH IS WHY THE ASSERTION IS ABOUT WHAT IS SEEN, NOT ABOUT A MARKER.
    * cmd expands %PATH% BEFORE git sees the argument, so git matches no pathspec and exits 0 with an
@@ -243,7 +250,7 @@ describe('ARMED: docmon :162 — the DOUBLE-QUOTED sink, via the %VAR% vector', 
    * checkBlacklist is gated on changed lines, the blacklisted word on the added line is NEVER
    * REPORTED. The gate is made to see nothing — worse than a crash, and invisible in CI.
    */
-  const NAME = 'docs/note%PATH%x.md';
+  const NAME = 'docs/note%PATH%$(echo z)x.md';
   let dir;
 
   beforeAll(() => {

--- a/tests/unit/lint/schema-lint-scope.test.js
+++ b/tests/unit/lint/schema-lint-scope.test.js
@@ -116,7 +116,14 @@ describe('the CI scope pin is wired in the lint itself', () => {
   const CODE = SRC.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
 
   it('resolves an explicit merge-base rather than relying on the ... shorthand', () => {
-    expect(CODE).toMatch(/git merge-base/);
+    // SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001 widened the first pattern, and the reason matters
+    // more than the edit. This assertion greps SOURCE TEXT, so it was pinned to one STATEMENT FORM
+    // — the shell string `git merge-base ...`. Converting that call to an argv array (execFileSync,
+    // to close a live shell-injection sink) left the BEHAVIOUR this test cares about completely
+    // intact while breaking the pattern. A grep for one statement form is not a test for the
+    // behaviour. The pattern now matches either spelling, so the next legitimate refactor of the
+    // call shape does not read as a regression of the merge-base pin.
+    expect(CODE).toMatch(/git merge-base|['"]merge-base['"]/);
     expect(CODE).toMatch(/\$\{mergeBase\}\.\.HEAD/);
   });
 

--- a/tests/unit/lint/schema-reference-lint-shell-injection.test.js
+++ b/tests/unit/lint/schema-reference-lint-shell-injection.test.js
@@ -68,7 +68,7 @@ const git = (repo, args) => execFileSync('git', args, { cwd: repo, encoding: 'ut
  * A repo the lint will actually WORK ON: real snapshot in place, a `basebranch` ref to diff from,
  * and a payload file under a RUNTIME_DIR matching CODE_RE so it survives candidateFiles filtering.
  */
-function makeRepo(payloadName) {
+function makeRepo(payloadName, { violating = true } = {}) {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'schemalint-inj-'));
   git(dir, ['init', '-q', '-b', 'main']);
   git(dir, ['config', 'user.email', 'test@example.invalid']);
@@ -88,7 +88,14 @@ function makeRepo(payloadName) {
   if (payloadName) {
     const full = path.join(dir, payloadName);
     fs.mkdirSync(path.dirname(full), { recursive: true });
-    fs.writeFileSync(full, 'export const b = 2;\n');
+    // THE CONTENT IS LOAD-BEARING, not filler. baselineViolationKeys — which contains the :153 sink
+    // — is only called for a file that HAS a violation to partition into new-vs-pre-existing. The
+    // first version of this fixture wrote `export const b = 2;`, produced no violation, and so never
+    // reached the sink at all: a mutation reverting :153 to a shell string left this suite GREEN.
+    // A .from() reference to a table absent from the snapshot is what makes the sink reachable.
+    fs.writeFileSync(full, violating
+      ? "export const q = db.from('totally_not_a_real_table_zz').select('*');\n"
+      : 'export const b = 2;\n');
     git(dir, ['add', '-A']);
     git(dir, ['commit', '-q', '-m', 'payload']);
   }
@@ -100,13 +107,10 @@ function makeRepo(payloadName) {
  * Trap 2 closed: SCHEMA_LINT_BASE is always set, or the run returns before the :153 sink.
  */
 function runLint(dir, baseRef, extraEnv = {}) {
-  // MEASURED LIMIT: reverting :153 to its pre-fix shell string produces ZERO red on this Windows
-  // host. Windows splits the command line on spaces and leaves backticks LITERAL, so the payload
-  // cannot execute here regardless of the fix. A ComSpec override to a real sh was tried and
-  // measured NOT to work — the child still ran under cmd — and was removed rather than kept with a
-  // comment claiming otherwise. These assertions discriminate on ubuntu (where CI runs and where
-  // the ARM proves the payload fires); locally the discriminating coverage is the GUARD tests below,
-  // which do go red when VALID_BASE_REF is removed.
+  // A ComSpec override to route this child through a real sh was tried and MEASURED NOT to work —
+  // the child still ran under cmd — and was removed rather than kept with a comment claiming
+  // otherwise. Discrimination on Windows comes instead from the `&` payload above, which is live
+  // under cmd.exe at an unquoted sink. No shell forcing anywhere in this file.
   try {
     const stdout = execFileSync(process.execPath, [LINT, '--diff'], {
       cwd: dir,
@@ -124,41 +128,50 @@ function runLint(dir, baseRef, extraEnv = {}) {
 const rm = (d) => { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ } };
 
 describe('ARMED: schema-reference-lint :153 — the UNQUOTED git show sink', () => {
-  const canRun = !!SH;
-  const NAME = 'scripts/pwn`touch MARKER153.txt`end.js';
+  // CROSS-PLATFORM PAYLOAD, and it had to be. A backtick payload was MEASURED not to discriminate:
+  // Windows splits the command line on spaces and treats a backtick as LITERAL, so reverting the fix
+  // left the test green — true for the wrong reason. `&` IS live under cmd.exe at an unquoted sink
+  // and also separates commands under sh, so chaining both shells' file-creating commands arms on
+  // either platform with no skip and no shell forcing. `copy nul <f>` rather than a redirect,
+  // because `>` is illegal in an NTFS filename.
+  const NAME = 'scripts/x&copy nul MARKER153.txt&touch MARKER153.txt&y.js';
   let dir; let marker;
 
   beforeAll(() => {
-    if (!canRun) return;
     dir = makeRepo(NAME);
     marker = path.join(dir, 'MARKER153.txt');
   });
   afterAll(() => { if (dir) rm(dir); });
 
-  it.runIf(canRun)('git returns the metacharacter filename BYTE-VERBATIM', () => {
+  it('git returns the metacharacter filename BYTE-VERBATIM', () => {
     const out = git(dir, ['diff', '--name-only', '-z', 'basebranch..HEAD']).split('\0').filter(Boolean);
     expect(out).toContain(NAME);
   });
 
-  it.runIf(canRun)('THE ARM: the ORIGINAL unquoted shape CREATES THE MARKER — the payload can fire', () => {
-    // The pre-fix line reconstructed verbatim, through a real sh. If this does not create the
-    // marker, every "no marker" assertion below proves nothing and this file is theatre.
+  it('THE ARM: the ORIGINAL unquoted shape CREATES THE MARKER — the payload can fire', () => {
+    // The pre-fix line reconstructed verbatim, through whatever shell this host actually uses.
+    // If this stops creating the marker, every "no marker" assertion below proves nothing.
+    fs.rmSync(marker, { force: true });
     const base = git(dir, ['rev-parse', 'basebranch']).trim();
     try {
-      execSync(`git show ${base}:${NAME}`, { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: SH });
-    } catch { /* non-zero exit is fine; the side effect is the point */ }
+      execSync(`git show ${base}:${NAME}`, { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+    } catch { /* non-zero exit is expected; the side effect is the point */ }
     expect(path.resolve(marker).startsWith(path.resolve(dir)), 'marker must be inside the temp dir').toBe(true);
     expect(fs.existsSync(marker), 'vulnerable form did not execute — this test cannot fail, so it proves nothing').toBe(true);
   });
 
-  it.runIf(canRun)('THE FIX: the lint REACHES the sink, creates NO marker, and still checks the file', () => {
+  it('THE FIX: the lint REACHES the sink, creates NO marker, and still checks the file', () => {
     // Three assertions, and the reachability one is not optional: "no marker" is worthless if the
     // sink was never entered. The scope line proves the merge base resolved and files were checked.
     fs.rmSync(marker, { force: true });
     const { stdout, stderr } = runLint(dir, 'basebranch');
     const out = stdout + stderr;
-    expect(out, 'the lint never got as far as resolving a merge base — the sink was not reached').toMatch(/merge_base=/);
+    // REACHABILITY FIRST. The reported violation is the proof: baselineViolationKeys — which holds
+    // the :153 sink — is only called for a file that HAS a violation to classify as new vs
+    // pre-existing. Reaching that report means the baseline read ran. Asserting only "no marker"
+    // would pass just as happily on a run that never entered the function.
     expect(out, 'zero files checked means candidateFiles filtered the payload out before the sink').toMatch(/file\(s\) checked/);
+    expect(out, 'no violation reported — baselineViolationKeys was never called, so :153 was not reached').toMatch(/totally_not_a_real_table_zz/);
     expect(fs.existsSync(marker), 'the fixed path executed the filename').toBe(false);
   });
 });
@@ -212,7 +225,9 @@ describe('ARMED: schema-reference-lint :92 — the env-supplied base ref', () =>
 
 describe('the lint still does its job after the conversion', () => {
   let dir;
-  beforeAll(() => { dir = makeRepo('scripts/ordinary.js'); });
+  // Clean content on purpose: this describe exercises the SUCCESS path, which is the only one that
+  // prints the scope line. A violating fixture takes the failure path and prints a different shape.
+  beforeAll(() => { dir = makeRepo('scripts/ordinary.js', { violating: false }); });
   afterAll(() => { if (dir) rm(dir); });
 
   it('an ordinary diff run reports a checked-file count and a resolved scope', () => {

--- a/tests/unit/lint/schema-reference-lint-shell-injection.test.js
+++ b/tests/unit/lint/schema-reference-lint-shell-injection.test.js
@@ -1,0 +1,242 @@
+/**
+ * schema-reference-lint must never hand a git-supplied filename OR an env-supplied ref to a shell.
+ * SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001.
+ *
+ * THE DEFECT. Two sites in scripts/lint/schema-reference-lint.mjs built a /bin/sh command string
+ * from an attacker-influenced value:
+ *   :92   git merge-base <base> HEAD    where base = process.env.SCHEMA_LINT_BASE, wholly unguarded
+ *   :153  git show <mergeBase>:<file>   UNQUOTED, where file came from git diff --name-only
+ * This job runs on ubuntu-latest on every PR touching lib/api/app/scripts
+ * (.github/workflows/schema-reference-lint.yml:69) and its job is continue-on-error:false.
+ *
+ * ON "BLOCKING": that setting governs whether a REGRESSION is caught, never whether a payload
+ * EXECUTES. Reachability is what makes the injection live. Recorded here because the SD's original
+ * framing leaned on blocking-ness as the severity argument, and that is the wrong predicate.
+ *
+ * THE FIXTURE MUST REACH THE SINK, and two measured ways it silently does not:
+ *   1. In --json mode a MISSING database/schema-reference-snapshot.json exits 0 having run ZERO git
+ *      commands. A test asserting "exit 0 and no marker" then passes without touching a sink.
+ *   2. WITHOUT SCHEMA_LINT_BASE, only `git merge-base origin/main HEAD` runs, throws in a temp repo,
+ *      leaves mergeBase null, and baselineViolationKeys returns BEFORE :153.
+ * So every fixture below copies the snapshot AND sets the base ref, and the tests assert the sink
+ * was REACHED rather than merely that nothing bad happened. Absence of a marker is not evidence
+ * when the code path was never entered.
+ *
+ * THESE TESTS SPAWN, THEY DO NOT IMPORT. The target has ZERO exports and runs top-level side
+ * effects off process.argv. child_process is never mocked.
+ *
+ * EVERY POSITIVE CLAIM IS ARMED: the original vulnerable shape is replayed against the SAME fixture
+ * under a real sh and proven to fire, before any claim that the fixed form does not.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { execFileSync, execSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(HERE, '../../..');
+const LINT = path.join(REPO, 'scripts', 'lint', 'schema-reference-lint.mjs');
+const SNAPSHOT = path.join(REPO, 'database', 'schema-reference-snapshot.json');
+const IS_WIN = process.platform === 'win32';
+
+/** Resolve a real POSIX sh if the host has one. PATH first, then Git-for-Windows locations. */
+function findSh() {
+  for (const probe of IS_WIN ? ['sh.exe', 'sh'] : ['sh']) {
+    try {
+      const out = execFileSync(IS_WIN ? 'where' : 'which', [probe], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+      const first = out.split(/\r?\n/).map((s) => s.trim()).filter(Boolean)[0];
+      if (first && fs.existsSync(first)) return first;
+    } catch { /* try the next probe */ }
+  }
+  if (IS_WIN) {
+    for (const c of [
+      'C:\\Program Files\\Git\\usr\\bin\\sh.exe',
+      'C:\\Program Files\\Git\\bin\\sh.exe',
+      'C:\\Program Files (x86)\\Git\\usr\\bin\\sh.exe',
+    ]) if (fs.existsSync(c)) return c;
+  }
+  return null;
+}
+const SH = findSh();
+
+const git = (repo, args) => execFileSync('git', args, { cwd: repo, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+
+/**
+ * A repo the lint will actually WORK ON: real snapshot in place, a `basebranch` ref to diff from,
+ * and a payload file under a RUNTIME_DIR matching CODE_RE so it survives candidateFiles filtering.
+ */
+function makeRepo(payloadName) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'schemalint-inj-'));
+  git(dir, ['init', '-q', '-b', 'main']);
+  git(dir, ['config', 'user.email', 'test@example.invalid']);
+  git(dir, ['config', 'user.name', 'Test']);
+  git(dir, ['config', 'commit.gpgsign', 'false']);
+
+  // Trap 1 closed: without this the lint exits 0 in --json mode having run ZERO git commands.
+  fs.mkdirSync(path.join(dir, 'database'), { recursive: true });
+  fs.copyFileSync(SNAPSHOT, path.join(dir, 'database', 'schema-reference-snapshot.json'));
+
+  fs.mkdirSync(path.join(dir, 'scripts'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'scripts', 'base.js'), 'export const a = 1;\n');
+  git(dir, ['add', '-A']);
+  git(dir, ['commit', '-q', '-m', 'base']);
+  git(dir, ['branch', '-f', 'basebranch']);
+
+  if (payloadName) {
+    const full = path.join(dir, payloadName);
+    fs.mkdirSync(path.dirname(full), { recursive: true });
+    fs.writeFileSync(full, 'export const b = 2;\n');
+    git(dir, ['add', '-A']);
+    git(dir, ['commit', '-q', '-m', 'payload']);
+  }
+  return dir;
+}
+
+/**
+ * Run the REAL lint. Never throws — the exit code and the side effects are what matter.
+ * Trap 2 closed: SCHEMA_LINT_BASE is always set, or the run returns before the :153 sink.
+ */
+function runLint(dir, baseRef, extraEnv = {}) {
+  // MEASURED LIMIT: reverting :153 to its pre-fix shell string produces ZERO red on this Windows
+  // host. Windows splits the command line on spaces and leaves backticks LITERAL, so the payload
+  // cannot execute here regardless of the fix. A ComSpec override to a real sh was tried and
+  // measured NOT to work — the child still ran under cmd — and was removed rather than kept with a
+  // comment claiming otherwise. These assertions discriminate on ubuntu (where CI runs and where
+  // the ARM proves the payload fires); locally the discriminating coverage is the GUARD tests below,
+  // which do go red when VALID_BASE_REF is removed.
+  try {
+    const stdout = execFileSync(process.execPath, [LINT, '--diff'], {
+      cwd: dir,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      timeout: 45000,
+      env: { ...process.env, SCHEMA_LINT_BASE: baseRef, CI: '', ...extraEnv },
+    });
+    return { stdout, stderr: '', failed: false };
+  } catch (e) {
+    return { stdout: e?.stdout || '', stderr: e?.stderr || '', failed: true };
+  }
+}
+
+const rm = (d) => { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ } };
+
+describe('ARMED: schema-reference-lint :153 — the UNQUOTED git show sink', () => {
+  const canRun = !!SH;
+  const NAME = 'scripts/pwn`touch MARKER153.txt`end.js';
+  let dir; let marker;
+
+  beforeAll(() => {
+    if (!canRun) return;
+    dir = makeRepo(NAME);
+    marker = path.join(dir, 'MARKER153.txt');
+  });
+  afterAll(() => { if (dir) rm(dir); });
+
+  it.runIf(canRun)('git returns the metacharacter filename BYTE-VERBATIM', () => {
+    const out = git(dir, ['diff', '--name-only', '-z', 'basebranch..HEAD']).split('\0').filter(Boolean);
+    expect(out).toContain(NAME);
+  });
+
+  it.runIf(canRun)('THE ARM: the ORIGINAL unquoted shape CREATES THE MARKER — the payload can fire', () => {
+    // The pre-fix line reconstructed verbatim, through a real sh. If this does not create the
+    // marker, every "no marker" assertion below proves nothing and this file is theatre.
+    const base = git(dir, ['rev-parse', 'basebranch']).trim();
+    try {
+      execSync(`git show ${base}:${NAME}`, { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: SH });
+    } catch { /* non-zero exit is fine; the side effect is the point */ }
+    expect(path.resolve(marker).startsWith(path.resolve(dir)), 'marker must be inside the temp dir').toBe(true);
+    expect(fs.existsSync(marker), 'vulnerable form did not execute — this test cannot fail, so it proves nothing').toBe(true);
+  });
+
+  it.runIf(canRun)('THE FIX: the lint REACHES the sink, creates NO marker, and still checks the file', () => {
+    // Three assertions, and the reachability one is not optional: "no marker" is worthless if the
+    // sink was never entered. The scope line proves the merge base resolved and files were checked.
+    fs.rmSync(marker, { force: true });
+    const { stdout, stderr } = runLint(dir, 'basebranch');
+    const out = stdout + stderr;
+    expect(out, 'the lint never got as far as resolving a merge base — the sink was not reached').toMatch(/merge_base=/);
+    expect(out, 'zero files checked means candidateFiles filtered the payload out before the sink').toMatch(/file\(s\) checked/);
+    expect(fs.existsSync(marker), 'the fixed path executed the filename').toBe(false);
+  });
+});
+
+describe('ARMED: schema-reference-lint :92 — the env-supplied base ref', () => {
+  const canRun = !!SH;
+  let dir;
+
+  beforeAll(() => { dir = makeRepo(null); });
+  afterAll(() => { if (dir) rm(dir); });
+
+  it.runIf(canRun)('THE ARM: an interpolated base ref EXECUTES under a real sh', () => {
+    // Proves the :92 sink was genuinely exploitable, not merely untidy. Argv-safety alone would
+    // close this one; the shape-guard below additionally closes ARGUMENT injection, which argv does
+    // NOT — a ref leading with a dash is read by git as an OPTION even inside an argv array.
+    const marker = path.join(dir, 'MARKER92.txt');
+    const payloadBase = 'main`touch MARKER92.txt`';
+    try {
+      execSync(`git merge-base ${payloadBase} HEAD`, { cwd: dir, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], shell: SH });
+    } catch { /* the side effect is the point */ }
+    expect(fs.existsSync(marker), 'vulnerable form did not execute — the arm cannot discriminate').toBe(true);
+    fs.rmSync(marker, { force: true });
+  });
+
+  it('THE GUARD: a metacharacter base ref is REFUSED and nothing is executed', () => {
+    const marker = path.join(dir, 'MARKER92.txt');
+    const { stdout, stderr, failed } = runLint(dir, 'main`touch MARKER92.txt`');
+    expect(failed, 'a refused ref must fail loudly, not degrade to an advisory sweep').toBe(true);
+    expect(stdout + stderr).toMatch(/refusing SCHEMA_LINT_BASE/);
+    expect(fs.existsSync(marker), 'the refusal must happen BEFORE git runs').toBe(false);
+  });
+
+  it('THE GUARD: an OPTION-shaped ref is refused too — argv-safety alone would not stop this', () => {
+    // git parses a dash-leading argument as an option even in an argv array: --output=<path> makes
+    // git CREATE that file and throw nothing. This is why the shape-guard exists on top of argv.
+    const target = path.join(dir, 'OWNED92.txt');
+    const { stdout, stderr, failed } = runLint(dir, `--output=${target}`);
+    expect(failed).toBe(true);
+    expect(stdout + stderr).toMatch(/refusing SCHEMA_LINT_BASE/);
+    expect(fs.existsSync(target), 'git honoured an option-shaped ref — the guard did not fire first').toBe(false);
+  });
+
+  it('THE GUARD IS TWO-SIDED: an ordinary ref is still ACCEPTED and the lint runs', () => {
+    // Without this, a guard that rejected EVERYTHING would also satisfy the tests above.
+    const { stdout, stderr } = runLint(dir, 'basebranch');
+    const out = stdout + stderr;
+    expect(out, 'the guard rejected a legitimate ref').not.toMatch(/refusing SCHEMA_LINT_BASE/);
+    expect(out, 'an accepted ref must actually resolve a merge base').toMatch(/merge_base=/);
+  });
+});
+
+describe('the lint still does its job after the conversion', () => {
+  let dir;
+  beforeAll(() => { dir = makeRepo('scripts/ordinary.js'); });
+  afterAll(() => { if (dir) rm(dir); });
+
+  it('an ordinary diff run reports a checked-file count and a resolved scope', () => {
+    const { stdout, stderr } = runLint(dir, 'basebranch');
+    const out = stdout + stderr;
+    expect(out).toMatch(/schema-reference-lint \(diff\)/);
+    expect(out).toMatch(/file\(s\) checked/);
+    expect(out).toMatch(/merge_base=/);
+  });
+});
+
+describe('CONTROL: stated limits of this suite', () => {
+  it('NOTE: an embedded double-quote payload is NOT fixture-tested here', () => {
+    // Illegal in an NTFS filename and refused by git itself (core.protectNTFS defaults true), so it
+    // cannot be committed without extra plumbing. Its defence is ARCHITECTURAL — after this fix
+    // there is no shell layer for a quote to escape from — not measured by a fixture.
+    expect(true).toBe(true);
+  });
+
+  it('NOTE: collection is proven separately, because a suite-wide run cannot report an absent file', () => {
+    // A targeted run of a non-collected file exits 1 "No test files found", so running this file by
+    // name is loud. The silent case is suite-wide: an uncollected file is simply ABSENT from
+    // `vitest run --project unit` with no error and no skip notice. Proof obligation is therefore
+    // `npx vitest list --project unit <this path>`, pasted in the PR — not a green suite.
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
Sibling of #6870/#6872, which closed the same class in a CLI-only sink. These two are reachable from CI **and** from every developer push. RCE closes as-scoped; this does not reopen it.

## Reproduced, not argued

A repo with files named `a$(id).md`, `b;whoami.md`, `` c`id`.md ``, `d&echo.md`. `git diff --name-only` returned all four **raw** — `od -c` confirms a literal `;` byte — and composing the `docmon.js:386` form through a real `sh` **created the marker file**.

## Six sites, two files, one runner each

| Site | Shape | Value |
|---|---|---|
| `docmon.js:85` | `git diff --name-only <sha>...HEAD` | git-produced SHA |
| `docmon.js:162` | `git diff -U0 <sha>...HEAD -- "<path>"` | **filename**, double-quoted |
| `docmon.js:386` | `git show <sha>:<path>` | **filename, UNQUOTED** |
| `schema-reference-lint.mjs:92` | `git merge-base <base> HEAD` | **`process.env.SCHEMA_LINT_BASE`, unguarded** |
| `schema-reference-lint.mjs:100` | `git diff --name-only <sha>..HEAD` | derivative SHA |
| `schema-reference-lint.mjs:153` | `git show <sha>:<file>` | **filename, UNQUOTED** |

The SD named three; LEAD widened to six. Fixing three of six would have committed the defect class the SD is about — `:92` in particular is the *identical* sink `tree-currency.cjs:53` and `harness-adapter.js` SEC-R2 were both written for, and the control simply had not been carried across.

Converted through **one `execFileSync` runner per file**, not per call site — a per-call-site fix is one forgotten argument from regressing (`harness-adapter.js:81-84`).

**`execFileSync`, not `spawnSync`.** Both files lean on `execSync` *throwing* on non-zero: the lint has two catches (degrade-to-advisory; "file did not exist at the merge base"), docmon has three (two merge-base fallbacks, and `return 0 // New file`). `spawnSync` does not throw, so swapping it in would have silently stopped all five from ever firing.

## `--literal-pathspecs` is load-bearing in docmon and deliberately absent in the lint

`docmon.js:162` passes the filename as a **pathspec** after `--`, and `--` ends *option* parsing without disabling **pathspec magic**. Measured: with argv-ization alone, a `:(glob)`-prefixed name makes git return an **empty diff and throw nothing** — the file goes invisible to the Strunkian gate. Argv-safety alone would have converted the RCE into **silent evasion**, which is worse than the defect.

That is SEC-R1 from #6872 recurring verbatim, inside the SD written to carry that lesson across. It was caught by the prospective TESTING review *before* any code was written, and the PRD was patched (FR-7/FR-8) so EXEC could not inherit the wrong plan.

The lint passes no pathspec at all — refs, plus a `<rev>:<path>` object name that is a single argv token — so the flag is **absent there, with a comment saying why**. An inert flag that a later reader mistakes for the protection is its own hazard.

## The base-ref guard is validated outside the fail-soft try, deliberately

The lint's catch degrades an unresolvable base to an advisory whole-repo sweep, so a transient git problem never false-blocks a PR. Correct for git failures, **wrong for this one**: an option-shaped `SCHEMA_LINT_BASE` is an attack indicator, and routing it into that catch would let an attacker **disable this blocking lint** by supplying a malformed ref. So the refusal is loud and uncatchable.

Verified two-sided by hand: `--upload-pack=touch PWNED` refused with no `PWNED` file; an ordinary ref still resolves (2 files checked, `merge_base=ec069ffd`).

## Mutation results — measured, and the negative half is stated

**4 of 7 mutations produce a named red.** All four *exploitable* sinks are covered:

| Mutation | Red |
|---|---|
| revert `docmon:162` | **1** (`%VAR%` test) |
| revert `docmon:386` | **1** (`&` test) |
| revert `lint:153` | **1** (`&` test) |
| drop `VALID_BASE_REF` | **2** (guard tests) |

It was **1 of 7 one commit ago**, and that is worth stating because 20 green tests looked identical either way. Two causes, both producing green:

1. **The payload could not fire.** A backtick is inert under cmd.exe — Windows splits on spaces and leaves it literal. Diagnosed against the *true pre-fix file from git history*: git reported `fatal: path 'docs/pwn` + backtick + `touch' does not exist`, proving the sink was reached while the payload did nothing. A `ComSpec` override to route the child through `sh` was tried and **measured not to work**; it was removed rather than left with a comment claiming otherwise. The payload now chains `&`-separated commands that fire under both shells (`copy nul` on cmd, `touch` on sh), so it arms with no skips and no shell forcing.
2. **The fixture never reached the sink.** The lint payload had no schema reference, so no violation, so `baselineViolationKeys` — which *holds* the `:153` sink — was never called. It now commits a `.from()` to an absent table and asserts the violation **is reported**; reachability first, because absence of a marker is not evidence when the path was never entered.

**What still does not discriminate, named rather than left to be found:**

- `lint:92` argv revert → 0 red, and this is **correct by design**: the guard rejects before git runs, so the runner underneath is unreachable. The guard itself is covered by 2 reds.
- `--literal-pathspecs` and `-z` → 0 red. Those tests drive git **directly**, so they demonstrate the mechanism without exercising docmon's runner. They are honest demonstrations, not fix verifications, and are labelled as such in-file. Closing them needs a payload that both matches docmon's doc-path filter and carries a pathspec prefix or newline — `mktree` rejects slashes and the filter rejects flat names, so it needs a nested-tree fixture. Not done.

## On severity: "BLOCKING" is the wrong argument

`continue-on-error: false` governs whether a **regression is caught**, never whether a payload **executes**. docmon's step carries `|| true`, so the payload runs and the step goes **green** — the non-blocking sink is the *stealthier* target. Leading with blocking-ness inverts the truth for a covert attacker.

"Every PR" is also imprecise — both workflows are paths-filtered. Severity is unchanged because **the malicious filename self-satisfies its own filter**: `docs/x;id.md` matches `docs/**` and is a doc docmon validates.

Both are `pull_request`, **not** `pull_request_target`, so fork PRs get a read-only token and no secrets. The repo is public and neither workflow declares `permissions:`. Fork blast radius is code execution on an ephemeral runner — real, but not the repo-write RCE that "critical" alone implies.

**The strongest vector was missing from the original scoping entirely:** `.husky/pre-push:35` runs `node scripts/docmon.js` **unconditionally on every push** (only `SKIP_DOCMON=1` opts out) — a non-ephemeral host, real developer credentials, no secret withholding. Same file, so this fix covers it.

## Test placement is a correctness requirement

Both suites are `.test.js`. The unit project's `.mjs` anchors do not cover these directories, so a `.test.mjs` file is collected by **zero** projects — and the schema-lint target being a `.mjs` file makes that the natural, fatal choice. A *targeted* run of an uncollected file exits 1 and is loud; the silent case is **suite-wide**, where `npm test` and CI's `test:coverage` simply run without it.

Collection proven, not assumed:

```
npx vitest list --project unit tests/unit/docmon-shell-injection.test.js
[unit] tests/unit/docmon-shell-injection.test.js > ARMED: docmon :386 — the UNQUOTED git show sink > THE ARM: the ORIGINAL unquoted shape CREATES THE MARKER — the payload can fire
[unit] tests/unit/docmon-shell-injection.test.js > ARMED: docmon :386 — the UNQUOTED git show sink > THE FIX: docmon creates NO marker, AND still reports the adversarial file
...
npx vitest list --project unit tests/unit/lint/schema-reference-lint-shell-injection.test.js
[unit] tests/unit/lint/schema-reference-lint-shell-injection.test.js > ARMED: schema-reference-lint :153 — the UNQUOTED git show sink > THE ARM: the ORIGINAL unquoted shape CREATES THE MARKER — the payload can fire
...
```

Both targets have **zero exports** and run top-level side effects off `process.argv`, so the tests spawn subprocesses rather than import. `child_process` is never mocked.

## Regression

**215/215 green** across 18 files. One regression I caused and fixed in the open: `tests/unit/lint/schema-lint-scope.test.js` greps **source text** for the literal `git merge-base`, so argv conversion broke the pattern while leaving the behaviour it pins fully intact. Widened to match either spelling, with the reason recorded in-test — a grep for one statement form is not a test for the behaviour. The repo has more assertions of this shape; any future call-form refactor will trip them the same way.

## Scope — deliberately not expanded

`lib/sub-agents/docmon.js:78` remains **out**: it ends in an irreducible `| tail -1` shell pipe (a genuinely different remediation), its path comes from a `readdir` walk rather than git, and its only CI entry point is cron + `workflow_dispatch`, not `pull_request`. Named so completion is not read as closure of the class.

Separately recommended and **not** self-claimed: a `scripts/lint/` lint + allowlist + workflow triple for this sink shape. That pattern exists 17 times in this repo and is missing for exactly this class. This is the **third** shell-injection SD; three independent rediscoveries measures a missing contract, not three unlucky bugs.

SD: SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001
