### PR TITLE
fix(QF-20260807-278): make the dry-run verdict state its own reason

### DIFF
--- a/scripts/modules/handoff/cli/cli-main.js
+++ b/scripts/modules/handoff/cli/cli-main.js
@@ -302,6 +302,44 @@ export async function introspectGateStatus(sdId, { json = true } = {}) {
  * @param {string} sdId - SD identifier
  * @returns {Promise<Object>} Result
  */
+/**
+ * QF-20260807-278: render the dry-run verdict so it states its OWN reason.
+ *
+ * The old line printed only two numbers and a verdict:
+ *   Aggregate: 83% (threshold: 75%) => WOULD FAIL
+ * 83 is ABOVE 75. The verdict was correct — a blocking gate fails the handoff at any score —
+ * but those two numbers are all a reader has, so the line taught a threshold rule that is not
+ * the rule. A preview whose output cannot be trusted at face value is the defect this QF names.
+ *
+ * VERDICT LOGIC IS UNCHANGED; only what it SAYS changes. Blocking gates are read from the same
+ * `evaluationResults` the FAILED GATE DETAILS block already uses — one source, not a second
+ * computation (1-REP). Extracted as a pure function so it is testable without a database:
+ * the CLI builds its orchestrator internally, so an inline block could only be exercised by a
+ * live run against real data.
+ *
+ * @param {object} result dryRunHandoff result
+ * @returns {string[]} lines to print
+ */
+export function formatDryRunVerdict(result = {}) {
+  const blockingGates = (result.evaluationResults || [])
+    .filter((r) => r && r.enabled && r.passed === false)
+    .map((r) => r.name);
+  const lines = [
+    `  Aggregate: ${result.aggregateScore}% (threshold: ${result.gateThreshold}%) => ${result.wouldPass ? 'WOULD PASS' : 'WOULD FAIL'}`,
+  ];
+  if (!result.wouldPass && blockingGates.length > 0) {
+    // Only say "the aggregate met the threshold" when it actually did — a note that prints on
+    // every failure would be a sentence nobody can learn anything from.
+    const meets = typeof result.aggregateScore === 'number'
+      && typeof result.gateThreshold === 'number'
+      && result.aggregateScore >= result.gateThreshold;
+    lines.push(meets
+      ? `  NOTE: the aggregate MEETS the threshold; the verdict is set by BLOCKING GATE(S): ${blockingGates.join(', ')}`
+      : `  Blocking gate(s): ${blockingGates.join(', ')}`);
+  }
+  return lines;
+}
+
 export async function handleDryRunCommand(handoffType, sdId, options = {}) {
   if (!handoffType || !sdId) {
     console.log('Usage: node scripts/handoff.js dry-run HANDOFF_TYPE SD-ID [--evaluate]');
@@ -364,7 +402,17 @@ export async function handleDryRunCommand(handoffType, sdId, options = {}) {
     }
 
     console.log('  ' + '-'.repeat(86));
-    console.log(`  Aggregate: ${result.aggregateScore}% (threshold: ${result.gateThreshold}%) => ${result.wouldPass ? 'WOULD PASS' : 'WOULD FAIL'}`);
+    // QF-20260807-278: this line used to print only the aggregate and the verdict, e.g.
+    //   Aggregate: 83% (threshold: 75%) => WOULD FAIL
+    // 83 is ABOVE 75, so the arithmetic on display contradicts the verdict beside it. The
+    // verdict is not decided by the aggregate alone — a blocking gate fails the handoff at
+    // any score — but a reader has only these two numbers to reason from, so the line
+    // teaches a threshold rule that is not the rule.
+    //
+    // The VERDICT LOGIC IS UNCHANGED. Only what it SAYS changes, so the displayed reason
+    // matches the real one. Blocking gates are read from the same evaluationResults the
+    // FAILED GATE DETAILS block below already uses — one source, not a second computation.
+    for (const line of formatDryRunVerdict(result)) console.log(line);
     console.log('');
 
     // Show failed gate details

--- a/tests/unit/dry-run-verdict-reason.test.js
+++ b/tests/unit/dry-run-verdict-reason.test.js
@@ -1,0 +1,83 @@
+// QF-20260807-278: a preview verdict must state its OWN reason.
+//
+// The summary line printed only two numbers and a verdict:
+//   Aggregate: 83% (threshold: 75%) => WOULD FAIL
+// 83 is ABOVE 75. The verdict is correct — a blocking gate fails the handoff at any score —
+// but those two numbers are all a reader has, so the line taught a threshold rule that is not
+// the rule. Measured live on SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-E before the fix.
+//
+// SCOPE, stated so a green run is not over-read: this covers the aggregate-line legibility
+// defect found while investigating QF-278. The ticket's parity legs — (a) the witnessed PRD
+// replaying to the SAME rejection as execute, (b) a passing PRD passing both identically —
+// are NOT closed here and are NOT asserted below. Claiming them would be exactly the
+// trusted-optimistic-preview trap this QF is about.
+import { describe, it, expect } from 'vitest';
+import { formatDryRunVerdict } from '../../scripts/modules/handoff/cli/cli-main.js';
+
+const render = (result) => formatDryRunVerdict(result).join('\n');
+
+describe('dry-run verdict states its own reason', () => {
+  it('names the blocking gates when the aggregate MEETS the threshold but the verdict is FAIL', () => {
+    // The exact measured shape: 83 >= 75 yet WOULD FAIL.
+    const out = render({
+      aggregateScore: 83,
+      gateThreshold: 75,
+      wouldPass: false,
+      evaluationResults: [
+        { name: 'GATE_SUBAGENT_EVIDENCE', enabled: true, passed: false },
+        { name: 'GATE_PRD_EXISTS', enabled: true, passed: false },
+        { name: 'SOMETHING_PASSING', enabled: true, passed: true },
+      ],
+    });
+    expect(out).toContain('=> WOULD FAIL');
+    expect(out).toContain('the aggregate MEETS the threshold');
+    expect(out).toContain('GATE_SUBAGENT_EVIDENCE');
+    expect(out).toContain('GATE_PRD_EXISTS');
+    expect(out).not.toContain('SOMETHING_PASSING'); // passing gates are never named as blockers
+  });
+
+  it('does NOT claim the aggregate met the threshold when it genuinely did not', () => {
+    // Two-sided: a note that printed on every failure would say nothing at all.
+    const out = render({
+      aggregateScore: 40,
+      gateThreshold: 75,
+      wouldPass: false,
+      evaluationResults: [{ name: 'GATE_A', enabled: true, passed: false }],
+    });
+    expect(out).toContain('=> WOULD FAIL');
+    expect(out).not.toContain('the aggregate MEETS the threshold');
+    expect(out).toContain('GATE_A'); // still names what blocked
+  });
+
+  // POSITIVE CONTROL — without this the suite would pass if the code always appended a note.
+  it('stays silent on a genuinely passing preview', () => {
+    const out = render({
+      aggregateScore: 95,
+      gateThreshold: 75,
+      wouldPass: true,
+      evaluationResults: [{ name: 'GATE_A', enabled: true, passed: true }],
+    });
+    expect(out).toContain('=> WOULD PASS');
+    expect(out).not.toContain('the aggregate MEETS the threshold');
+    expect(out).not.toContain('Blocking gate');
+  });
+
+  it('ignores DISABLED gates when naming blockers', () => {
+    const out = render({
+      aggregateScore: 83,
+      gateThreshold: 75,
+      wouldPass: false,
+      evaluationResults: [
+        { name: 'DISABLED_ONE', enabled: false, passed: false },
+        { name: 'REAL_BLOCKER', enabled: true, passed: false },
+      ],
+    });
+    expect(out).toContain('REAL_BLOCKER');
+    expect(out).not.toContain('DISABLED_ONE');
+  });
+
+  it('does not crash when evaluationResults is absent', () => {
+    const out = render({ aggregateScore: 83, gateThreshold: 75, wouldPass: false });
+    expect(out).toContain('=> WOULD FAIL');
+  });
+});


### PR DESCRIPTION
## What

Investigating this ticket surfaced a defect it doesn't describe, and this PR closes **that** one.

The summary line printed two numbers and a verdict:

```
Aggregate: 83% (threshold: 75%) => WOULD FAIL
```

**83 is above 75.** The verdict is correct — a blocking gate fails the handoff at any score — but those two numbers are all a reader has, so the line teaches a threshold rule that isn't the rule. A preview whose output can't be trusted at face value is exactly the class this QF names; this is a second instance of it, reachable with no DB state.

**Verdict logic is unchanged.** Only what it *says* changes, so the displayed reason matches the real one. When `wouldPass` is false while the aggregate *meets* the threshold, the blocking gates are named; when the aggregate genuinely fell short, the note doesn't fire — a sentence printed on every failure teaches nothing. Blocking gates come from the same `evaluationResults` the FAILED GATE DETAILS block already reads: one source, not a second computation (1-REP).

Extracted as the pure exported `formatDryRunVerdict` because the CLI builds its orchestrator internally (`createHandoffSystem`, no injection seam) — an inline block could only be exercised by a live run against real data, i.e. the tests would need a database to assert a formatting rule.

**Verified against the real command**, not just the unit — the live dry-run now prints:

```
Aggregate: 83% (threshold: 75%) => WOULD FAIL
NOTE: the aggregate MEETS the threshold; the verdict is set by BLOCKING GATE(S): GATE_SUBAGENT_EVIDENCE, GATE_PRD_EXISTS
```

## What this does NOT close

Stated so a green run isn't over-read. The ticket's parity legs remain **OPEN** and are not asserted by these tests:
- **(a)** the witnessed PRD replaying to the same rejection as execute
- **(b)** a passing PRD passing both identically

Two measured facts for whoever takes them:
- dry-run and execute build **different validation contexts** — execute carries `gitContext`, `waitState` and cloned real `options`; dry-run passes `options: {}` and omits the other two — but **both load the PRD via the same `prdRepo.getBySdId`**, so the 100-vs-57 delta is *not* a data divergence.
- Replaying the witnessed SD today ends `WOULD FAIL` rather than reproducing the original PASS. Evidence rows are time-sensitive and the repo moved between the witness and the replay, so that is **not** a refutation of the report.

## Proof

| Mutation | Kills |
|---|---|
| Drop the reason line (the original defect) | 3 tests |
| Always claim the threshold was met | 1 test |
| Name disabled/passing gates as blockers | 2 tests |

Positive control included — a genuinely passing preview must stay silent. 5 new tests; **40** CLI and **900** handoff tests still green.

QF-20260807-278