### PR TITLE
fix(QF-20260807-278): precheck must not show a green check for a gate it never ran

### DIFF
--- a/scripts/modules/handoff/HandoffOrchestrator.js
+++ b/scripts/modules/handoff/HandoffOrchestrator.js
@@ -492,13 +492,33 @@ export class HandoffOrchestrator {
         console.log('');
         console.log('📊 GATE SCORES (Precheck)');
         console.log('─'.repeat(60));
+        // QF-20260807-278: a gate SKIPPED in precheck is recorded as { passed: true, score: 0,
+        // maxScore: 0 } (ValidationOrchestrator.js:1149 — LLM gates are deliberately not run
+        // here). This loop then rendered it as a green check at 0%, indistinguishable from a
+        // gate that actually ran and passed. A preview that shows a tick for a check it never
+        // performed is the trusted-optimistic preview this QF exists to stop.
+        //
+        // DISPLAY ONLY. `passed` is read 115 times across 44 files in this module; changing
+        // what a skip RECORDS is a contract change and is deliberately NOT done here. This
+        // reads the ALREADY-POPULATED results.skippedGates — the data existed and simply had
+        // no consumer anywhere in scripts/.
+        const skipped = new Set(result.skippedGates || []);
         for (const [gateName, gr] of Object.entries(result.gateResults)) {
           const pct = gr.maxScore > 0 ? Math.round((gr.score / gr.maxScore) * 100) : 0;
           const threshold = gr.threshold || 70;
+          if (skipped.has(gateName)) {
+            console.log(`   ⏭️  ${gateName}: NOT RUN in precheck (LLM gate — execute will evaluate it)`);
+            continue;
+          }
           const status = gr.passed !== false ? '✅' : '❌';
           console.log(`   ${status} ${gateName}: ${pct}% (threshold: ${threshold}%)`);
         }
         console.log(`   📈 Overall: ${result.normalizedScore || 0}%`);
+        if (skipped.size > 0) {
+          // Say it once more where a reader forms their conclusion: this preview is incomplete,
+          // and NAME what is missing so the gap is specific rather than a general disclaimer.
+          console.log(`   ⚠️  NOT AUTHORITATIVE: ${skipped.size} gate(s) were NOT RUN — ${[...skipped].join(', ')}. Execute evaluates them and can still reject.`);
+        }
         console.log('─'.repeat(60));
       }
 


### PR DESCRIPTION
## What

An LLM gate skipped in precheck is recorded as `{ passed: true, score: 0, maxScore: 0 }` (`ValidationOrchestrator.js:1149` — LLM gates are deliberately not run there). The precheck summary then rendered it as:

```
✅ SCOPE_REDUCTION_VERIFICATION: 0% (threshold: 70%)
```

— indistinguishable from a gate that actually ran and passed. **A preview showing a tick for a check it never performed** is the trusted-optimistic preview this QF exists to stop: the same rule as *"a skipped suite is not a passing gate"*, sitting in production gate output.

It now renders `NOT RUN` and names the skipped gates in a `NOT AUTHORITATIVE` line, so the gap is **specific** rather than a general disclaimer.

## Display only, deliberately

`passed` is read **115 times across 44 files** in this module. Changing what a skip *records* (`passed: null` / a `skipped` flag) reclassifies every one of those sites, each currently assuming a boolean — an **SD-sized contract change**, not a QF, and getting it wrong makes the gate lie in the *other* direction.

This reads the **already-populated** `results.skippedGates`, which had no consumer anywhere in `scripts/`: the data existed and was simply never surfaced.

## Proof — two-sided, against the real command

```
⏭️  SCOPE_REDUCTION_VERIFICATION: NOT RUN in precheck (LLM gate — execute will evaluate it)
⚠️  NOT AUTHORITATIVE: 1 gate(s) were NOT RUN — SCOPE_REDUCTION_VERIFICATION. Execute evaluates them and can still reject.
```

Mutating the branch out reverts it to `✅ SCOPE_REDUCTION_VERIFICATION: 0% (threshold: 70%)` — the defect itself. 90 files / 905 handoff+CLI tests still green.

## Still open — this PR does not touch them

- **The witnessed 100-vs-57 on `prdQualityValidation` is UNEXPLAINED.** Three hypotheses measured and killed: not PRD data (same `prdRepo.getBySdId`); not the context divergences (`gitContext` read by 4 files, all exec-to-plan/plan-to-lead, **none** plan-to-exec; `waitState` 1; `ctx.options` zero); and **not** this skip-as-pass — `prdQualityValidation` is not `llmPowered`, so line 1149 cannot reach it.
- The `passed`-semantics change remains an **SD**.

Also worth recording: **precheck and dry-run are different commands.** `precheckMode` is set only at `HandoffOrchestrator.js:474`; `dryRunHandoff` never sets it and therefore actually runs LLM gates. The ticket and the fleet notice both say "dry-run".

QF-20260807-278