### PR TITLE
fix(SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001): the crashed EXPLORE CLI no longer launders the evidence gate

### DIFF
--- a/lib/sub-agent-executor/executor.js
+++ b/lib/sub-agent-executor/executor.js
@@ -447,6 +447,17 @@ export async function executeSubAgent(code, sdId, options = {}) {
     };
 
   } catch (error) {
+    // SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001: check the sentinel FIRST, above the logging.
+    //
+    // A refusal is not a failed execution and must not be narrated as one. Reporting
+    // "EXPLORE execution failed" would tell an operator that a run was attempted and broke, when in
+    // fact nothing ran and nothing should have — and this SD is precisely about a record that
+    // asserted a state the system was never in. The re-throw carries the message to the CLI, which
+    // prints it once and exits 4.
+    if (error?.isBuiltinAgentRefusal) {
+      throw error;
+    }
+
     console.error(`\n${code} execution failed:`, error.message);
 
     // Complete task contract with failure (if created)
@@ -461,6 +472,13 @@ export async function executeSubAgent(code, sdId, options = {}) {
       }
     }
 
+    // THE LAUNDERING CAME FROM THE STORE BELOW. An unregistered code threw PGRST116 in the loader,
+    // landed in this catch, and got an ERROR row written — and that row, being the newest for its
+    // normalized code, advisory-PASSED the LEAD-TO-PLAN evidence gate at score 100. So running the
+    // broken CLI is what UNLOCKED the gate: a worker who never invoked it was hard-blocked, and one
+    // who invoked it and let it crash was let through. The sentinel re-throw above is what makes
+    // this store unreachable for a refused code rather than merely unused — guarding only at the
+    // throw site would have changed the error text and nothing else.
     // Store error result
     const errorResult = {
       verdict: 'ERROR',

--- a/lib/sub-agent-executor/instruction-loader.js
+++ b/lib/sub-agent-executor/instruction-loader.js
@@ -22,7 +22,50 @@ import { SUB_AGENT_CATEGORY_MAPPING } from './phase-model-config.js';
  * @param {number} [compositionContext.maxPromptTokens] - Token budget for dynamic knowledge
  * @returns {Promise<Object>} Sub-agent data with formatted instructions
  */
+/**
+ * Codes that are Claude Code BUILT-INS, deliberately absent from leo_sub_agents.
+ * SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001.
+ *
+ * ONLY 'EXPLORE'. 'Plan' is the other built-in named by leo_protocol_sections id=289/290, but no
+ * required-agent set asks for it and nothing was measured about its CLI path, so adding it here
+ * would be carrying a control to a sink I never examined. The set exists so a measured addition is
+ * a one-line change, not so unmeasured ones are cheap.
+ */
+export const BUILTIN_AGENT_CODES = new Set(['EXPLORE']);
+
+/**
+ * Sentinel for a refusal, so the caller can tell "this must not run" apart from "this run failed".
+ *
+ * That distinction is the whole fix. executor.js catches every throw from here and writes an ERROR
+ * row; a plain Error would therefore produce the exact tombstone this SD exists to stop, just with
+ * better wording. The catch checks isBuiltinAgentRefusal and skips the store.
+ */
+export class BuiltinAgentRefusalError extends Error {
+  constructor(code) {
+    super(
+      `${code} is a read-only Claude Code BUILT-IN and is deliberately NOT registered in `
+      + 'leo_sub_agents (leo_protocol_sections id=289/290). It has no scripted producer and this CLI '
+      + 'cannot run it.\n'
+      + `  To record ${code} evidence, use ONE of the two sanctioned routes:\n`
+      + '    1. Task(subagent_type="Explore", ...) and let the agent write via storeSubAgentResults\n'
+      + '    2. node scripts/record-explore-evidence.js --sd-id <SD> --verdict <V> --summary "..."\n'
+      + '  Refusing WITHOUT writing an evidence row: a crash here used to write an ERROR tombstone '
+      + 'that advisory-passed the LEAD-TO-PLAN gate at score 100.'
+    );
+    this.name = 'BuiltinAgentRefusalError';
+    this.isBuiltinAgentRefusal = true;
+    this.code = code;
+  }
+}
+
 export async function loadSubAgentInstructions(code, compositionContext = {}) {
+  // BEFORE the lookup, deliberately. Refusing after it would still reach the .single() below, whose
+  // PGRST116 on zero rows is what produced the tombstone in the first place — and the point is to
+  // make that path UNREACHABLE for this code, not merely unlikely.
+  if (BUILTIN_AGENT_CODES.has(String(code || '').toUpperCase())) {
+    throw new BuiltinAgentRefusalError(String(code).toUpperCase());
+  }
+
   console.log(`\nLoading sub-agent instructions: ${code}...`);
 
   const supabase = await getSupabaseClient();

--- a/scripts/execute-subagent.js
+++ b/scripts/execute-subagent.js
@@ -240,6 +240,15 @@ async function main() {
     process.exit(exitCode);
 
   } catch (error) {
+    // SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001: a REFUSAL exits 4, distinct from the generic
+    // fatal-error 3 below. The distinction is load-bearing for verification, not cosmetic: this
+    // path ALREADY exited non-zero when the unregistered code crashed, so any test asserting only
+    // "exits non-zero" would pass against the old broken behaviour and prove nothing about the fix.
+    // A refusal is also not a stack-trace situation — the message says what to do instead.
+    if (error?.isBuiltinAgentRefusal) {
+      console.error(`\n⛔ Refused: ${error.message}`);
+      process.exit(4);
+    }
     console.error('\n💥 Fatal Error:', error.message);
     console.error('\nStack Trace:', error.stack);
     process.exit(3);

--- a/scripts/modules/handoff/gates/subagent-evidence-gate.js
+++ b/scripts/modules/handoff/gates/subagent-evidence-gate.js
@@ -477,7 +477,13 @@ export async function validateSubagentEvidence(ctx, supabase) {
         max_score: 100,
         issues: [head],
         details: { reason: 'SUBAGENT_EVIDENCE_NOT_RUN', non_evidence: nonEvidence, ...verdictDetails },
-        remediation: `Re-run ${nonEvidence.map(f => f.agent).join(', ')} for SD ${sdKey} until it writes a real verdict. If the agent code cannot be executed at all (e.g. it names a Claude Code agent TYPE with no row in the sub-agent catalog), that is a REQUIREMENT defect, not a worker error — the required-agent list is naming something no CLI path can satisfy.`
+        // SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001 corrected the second half of this text. It used
+        // to say an unexecutable agent code was "a REQUIREMENT defect, not a worker error — the
+        // required-agent list is naming something no CLI path can satisfy". That was true when
+        // written and is now FALSE for the case it was written about: Explore has a sanctioned
+        // producer. Leaving it would send a worker to file a defect instead of running the writer —
+        // a remediation that was accurate once and quietly stopped being so.
+        remediation: `Re-run ${nonEvidence.map(f => f.agent).join(', ')} for SD ${sdKey} until it writes a real verdict. If the agent is a read-only Claude Code BUILT-IN (Explore), it has no CLI producer BY DESIGN — use the Task tool, or record the run with scripts/record-explore-evidence.js. If some OTHER code cannot be executed at all, that is a REQUIREMENT defect rather than a worker error: the required-agent list is naming something no path can satisfy.`
       });
     }
 

--- a/scripts/modules/handoff/gates/subagent-evidence-gate.js
+++ b/scripts/modules/handoff/gates/subagent-evidence-gate.js
@@ -438,40 +438,39 @@ export async function validateSubagentEvidence(ctx, supabase) {
       const ne = nonEvidence.map(f => `${f.agent}=${f.verdict}`).join(', ');
       const head = `SUBAGENT_EVIDENCE_NOT_RUN: ${ne} — the run crashed or never finished, so no check was performed. A row existing is not the check having run.`;
 
-      // QF-20260804-926 — RESTORE THE DOCUMENTED SAFETY VALVE.
+      // SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001: THE QF-20260804-926 SAFETY VALVE IS RETIRED
+      // BECAUSE ITS OWN STATED PRECONDITION IS NOW MET.
       //
-      // QF-20260804-569 made non-evidence block UNCONDITIONALLY, ignoring verdict mode. That half
-      // is correct and hard-won — a crashed run must not buy the same passage as a real one — but
-      // it shipped WITHOUT its satisfiability half, and required-subagents.js:49-56 had already
-      // named the precondition verbatim:
+      // QF-20260804-569 made non-evidence block unconditionally. QF-20260804-926 softened it back to
+      // honour SUBAGENT_VERDICT_MODE, and said exactly why, quoting required-subagents.js:49-56:
       //
       //   "PRECONDITION FOR PROMOTING SUBAGENT_VERDICT_MODE=block: the residual ~10% ... is 100%
       //    attributable to the unregistered-EXPLORE CLI path leaving a tombstone as the last row.
       //    Resolve that first ... Until then the gate's advisory default keeps this cost at zero."
       //
-      // LEAD-TO-PLAN still requires 'Explore', a Claude Code BUILT-IN absent from leo_sub_agents,
-      // so `--code EXPLORE` throws and writes a tombstone. Blocking on it makes LEAD-TO-PLAN
-      // unpassable for any seat restricted to the CLI path — no action available to that worker
-      // produces a passing row. Measured cohort: ~10% of SDs (187/209 = 89.5% unaffected).
+      // That is precisely what this SD resolved, and in the order the precondition implies:
+      //   - scripts/record-explore-evidence.js gives Explore a sanctioned producer, so a seat is no
+      //     longer restricted to a CLI path that cannot succeed. THAT was the whole reason blocking
+      //     here was unfair: no action available to the worker produced a passing row. Now one does.
+      //   - execute-subagent --code EXPLORE now REFUSES before the leo_sub_agents lookup and writes
+      //     NO row, so this branch can no longer be reached by the crash that used to populate it.
       //
-      // So non-evidence now honours the SAME mode flag as a rejecting verdict, until Explore is
-      // resolved (harness_backlog 6529e3a3). This is NOT re-softening ERROR/PENDING generally:
-      // they remain a DISTINCT class, they are still never accepted, and under
-      // SUBAGENT_VERDICT_MODE=block they still block. What returns is the operator's ability to
-      // turn the enforcement on deliberately rather than having it arrive as a side effect.
-      if (mode !== 'block') {
-        const warn = `${head} (mode: ${mode} — advisory until the required-agent list is satisfiable from every invocation path; see required-subagents.js:49-56)`;
-        console.log(`   ⚠️  ${warn}`);
-        return {
-          passed: true,
-          score: 100,
-          max_score: 100,
-          issues: [],
-          warnings: [...unknownWarnings, warn],
-          details: { reason: 'SUBAGENT_EVIDENCE_NOT_RUN_ADVISORY', non_evidence: nonEvidence, ...verdictDetails }
-        };
-      }
-
+      // AND THE SOFTENING WAS WORSE THAN A LENIENCY, which is what justifies retiring it rather than
+      // waiting for the global flag. Measured: with no row at all the gate BLOCKS here in both modes
+      // (:556 below, not mode-gated), but with an ERROR tombstone as the newest row it PASSED at
+      // score 100. So RUNNING THE BROKEN CLI CONVERTED A BLOCK INTO A PASS — the crash was the key.
+      // A worker who never invoked it was stopped; one who invoked it and let it crash was let
+      // through. That is not a safety valve, it is a laundering path, and it is closed here.
+      //
+      // SCOPE, deliberately narrow: this changes ONLY the non-evidence class. The rejecting-verdict
+      // branch below still honours SUBAGENT_VERDICT_MODE, resolveSubagentVerdictMode is untouched,
+      // and the global advisory->block flip (measured at 32/313 SDs) remains a separate decision.
+      // ERROR was always documented as a DISTINCT class from a rejection — "there is no verdict for
+      // that mode to be lenient about" (:397-401) — so only that class stops being negotiable.
+      //
+      // Blast radius, measured rather than inherited: 8 of 314 SDs hold an ERROR-newest Explore row
+      // (2.5%, not the ~10% this comment block used to assert), and SEVEN of those eight are already
+      // completed. Each is remediable with the new writer.
       console.log(`   ❌ ${head}`);
       return buildFailResult({
         score: 0,

--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -182,6 +182,26 @@ export async function runPrerequisitePreflight(supabase, handoffType, sdId) {
         // that re-invokes an agent that already ran, instead of investigating why it failed.
         const missing = evidenceResult.details?.missing || [];
         const failing = evidenceResult.details?.failing || [];
+        // SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001: NON-EVIDENCE IS A THIRD CLASS, and this
+        // function's own comment above is the reason it must be read here.
+        //
+        // The gate tracks crashed/never-finished runs in `non_evidence`, separate from both
+        // `missing` (no row) and `failing` (a rejecting verdict). Until this SD that branch
+        // advisory-PASSED, so a non-evidence failure never reached this code. Now it blocks — and
+        // with missing=[] AND failing=[] the fallback below would have fired, emitting
+        // "Missing sub-agent evidence for: required agent(s)": no agent named, and the wrong
+        // remedy, telling a worker to re-invoke an agent that already ran. That is verbatim the
+        // defect described at :176-182, which this file was changed to fix. Reproducing it while
+        // closing a laundering path would be trading one silent misdirection for another.
+        const nonEvidence = evidenceResult.details?.non_evidence || [];
+        if (nonEvidence.length > 0) {
+          issues.push({
+            code: 'SUBAGENT_EVIDENCE_NOT_RUN',
+            message: `Sub-agent evidence exists but the run did not complete: ${nonEvidence.map(n => `${n.agent}=${n.verdict}`).join(', ')} — a row existing is not the check having run.`,
+            remediation: evidenceResult.remediation
+              || `Re-run ${nonEvidence.map(n => n.agent).join(', ')} until it writes a real verdict. If the agent is a read-only Claude Code BUILT-IN (e.g. Explore) it has no CLI producer by design — use the Task tool, or scripts/record-explore-evidence.js.`
+          });
+        }
         if (failing.length > 0) {
           issues.push({
             code: 'SUBAGENT_EVIDENCE_BAD_VERDICT',
@@ -190,7 +210,11 @@ export async function runPrerequisitePreflight(supabase, handoffType, sdId) {
               || 'Investigate why the sub-agent(s) returned a non-passing verdict, then re-run them — the gate reads the LATEST row per agent, so a successful re-run supersedes the failed one.'
           });
         }
-        if (missing.length > 0 || failing.length === 0) {
+        // The fallback fires only when NOTHING ELSE explained the failure. nonEvidence joins
+        // failing in suppressing it, for the same reason failing already did: if a named class
+        // accounts for the block, adding an unnamed "required agent(s)" line on top tells the
+        // worker to chase a second, non-existent problem.
+        if (missing.length > 0 || (failing.length === 0 && nonEvidence.length === 0)) {
           issues.push({
             code: 'SUBAGENT_EVIDENCE_MISSING',
             message: `Missing sub-agent evidence for: ${missing.join(', ') || 'required agent(s)'}`,

--- a/scripts/record-explore-evidence.js
+++ b/scripts/record-explore-evidence.js
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * Sanctioned transcription writer for Explore evidence.
+ * SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001, FR-1.
+ *
+ * WHY THIS EXISTS. Explore is a Claude Code BUILT-IN (leo_protocol_sections id=289/290), deliberately
+ * NOT a row in leo_sub_agents — it is read-only and cannot write its own evidence. Registering it was
+ * considered and RULED OUT: it would create a second representation of what Explore is, and measured,
+ * it would not even fix the majority path (a DB row alone is not Task-spawnable, and the Task tool
+ * writes 211 of 314 Explore rows today). So the boundary stays, and the evidence gets a producer
+ * instead. Before this script, 36 one-off scripts hand-wrote that row.
+ *
+ * THE REFUSAL AT THE BOTTOM IS THE POINT, not a nicety. This SD exists because a CRASHED run wrote an
+ * ERROR tombstone that advisory-passed the LEAD-TO-PLAN gate at score 100 — a LOUD fail-open, but a
+ * fail-open. A writer that will record a verdict with no summary and no findings would replace that
+ * with a well-formed EMPTY PASS: invisible instead of countable, and strictly worse. That would be
+ * this SD committing the exact defect class it was opened to close, so the writer refuses.
+ *
+ * Usage:
+ *   node scripts/record-explore-evidence.js --sd-id <SD-KEY-or-uuid> --verdict PASS \
+ *     --summary "what the Explore run actually concluded" [--phase LEAD] [--confidence 90] \
+ *     [--findings "one finding" --findings "another"]
+ */
+
+import { storeSubAgentResults } from '../lib/sub-agent-executor/results-storage.js';
+import { toCanonicalRepoPath } from '../lib/sub-agents/resolve-repo.js';
+import { getSupabaseClient } from '../lib/sub-agent-executor/supabase-client.js';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const VALID_VERDICTS = new Set(['PASS', 'CONDITIONAL_PASS', 'WARNING', 'FAIL']);
+
+/** Minimal argv parser: repeated flags collect into an array. */
+export function parseArgs(argv) {
+  const out = { findings: [] };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (!a.startsWith('--')) continue;
+    const key = a.slice(2);
+    const val = argv[i + 1] && !argv[i + 1].startsWith('--') ? argv[++i] : 'true';
+    if (key === 'findings') out.findings.push(val);
+    else out[key.replace(/-/g, '_')] = val;
+  }
+  return out;
+}
+
+/**
+ * The empty-evidence guard, exported so it is testable without spawning or touching a database.
+ * Returns null when acceptable, or a reason string when the record must be refused.
+ *
+ * NOTE the asymmetry: a verdict is REQUIRED and never defaulted. Defaulting to PASS would let a
+ * caller record a pass by omission, which is the same laundering in a friendlier costume.
+ */
+export function refusalReason({ sd_id, verdict, summary, findings = [] }) {
+  if (!sd_id) return 'missing --sd-id';
+  if (!verdict) return 'missing --verdict (never defaulted: a pass by omission is still a pass nobody vouched for)';
+  if (!VALID_VERDICTS.has(String(verdict).toUpperCase())) {
+    return `unrecognised --verdict "${verdict}" (expected one of: ${[...VALID_VERDICTS].join(', ')})`;
+  }
+  const hasSummary = typeof summary === 'string' && summary.trim().length > 0;
+  const hasFindings = Array.isArray(findings) && findings.filter((f) => String(f || '').trim()).length > 0;
+  if (!hasSummary && !hasFindings) {
+    return 'refusing to record a verdict with no summary and no findings — an empty PASS is invisible '
+      + 'where the ERROR tombstone it replaces was at least countable, which is the failure mode this '
+      + 'SD exists to prevent';
+  }
+  return null;
+}
+
+export async function recordExploreEvidence(args, { store = storeSubAgentResults, supabase = null } = {}) {
+  const reason = refusalReason(args);
+  if (reason) {
+    const err = new Error(`record-explore-evidence: ${reason}`);
+    err.isRefusal = true;
+    throw err;
+  }
+
+  const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+  const results = {
+    verdict: String(args.verdict).toUpperCase(),
+    confidence: args.confidence ? Number(args.confidence) : 90,
+    summary: args.summary || '',
+    findings: args.findings || [],
+    metadata: {
+      // Canonical, NOT the worktree path: v_sub_agent_repo_compliance compares
+      // metadata->>repo_path to applications.local_path by exact string equality, so a
+      // worktree-valued repo_path fails SUB_AGENT_REPO_RESOLUTION.
+      repo_path: toCanonicalRepoPath(repoRoot),
+      executed_from_cwd: process.cwd(),
+      recorded_by: 'scripts/record-explore-evidence.js',
+      producer_note: 'Explore is a read-only BUILT-IN and cannot write its own row; this is the '
+        + 'sanctioned transcription path (SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001 FR-1).'
+    }
+  };
+
+  // sub_agent_code is 'Explore' exactly. The evidence gate groups on a NORMALIZED code, so casing
+  // does not decide matching — but it does decide what a human reads in the row, and every existing
+  // Task-path row uses this spelling.
+  const stored = await store('Explore', args.sd_id, null, results, { phase: args.phase || 'LEAD' });
+  return stored;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  let stored;
+  try {
+    stored = await recordExploreEvidence(args);
+  } catch (e) {
+    console.error(`\n${e.message}`);
+    if (e.isRefusal) {
+      console.error('\n  Record what the Explore run actually concluded, e.g.:');
+      console.error('    node scripts/record-explore-evidence.js --sd-id <SD> --verdict PASS \\');
+      console.error('      --summary "enumerated the 6 call sites; 4 are attacker-reachable"');
+      process.exit(2);
+    }
+    process.exit(1);
+  }
+
+  // Read the row back. A success return is not persistence — this script exists to be trusted by a
+  // gate, so it verifies rather than reporting the writer's own optimism.
+  const client = await getSupabaseClient();
+  const { data, error } = await client
+    .from('sub_agent_execution_results')
+    .select('id,sub_agent_code,phase,verdict,created_at')
+    .eq('id', stored.id)
+    .maybeSingle();
+
+  if (error || !data) {
+    console.error(`\n  WROTE but could not read back id=${stored?.id}: ${error?.message || 'no row'}`);
+    process.exit(1);
+  }
+  console.log('\n  Explore evidence recorded and read back:');
+  console.log(`    id      ${data.id}`);
+  console.log(`    code    ${data.sub_agent_code}`);
+  console.log(`    phase   ${data.phase}`);
+  console.log(`    verdict ${data.verdict}`);
+}
+
+// Only run when invoked directly, so the exports above stay importable by tests.
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main();
+}

--- a/tests/unit/handoff/prerequisite-preflight-non-evidence.test.js
+++ b/tests/unit/handoff/prerequisite-preflight-non-evidence.test.js
@@ -1,0 +1,92 @@
+/**
+ * Preflight must NAME the agent whose run did not complete.
+ * SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001, FR-6 / TS-9.
+ *
+ * WHY THIS FILE EXISTS, and it is not a nice-to-have. Closing the tombstone laundering made the gate
+ * fail with missing=[] AND failing=[], because non-evidence is a THIRD array. prerequisite-preflight
+ * never read it, so its fallback would have emitted:
+ *
+ *     "Missing sub-agent evidence for: required agent(s)"
+ *
+ * No agent named, and the wrong remedy — it tells a worker to re-invoke an agent that ALREADY RAN.
+ * That is verbatim the defect prerequisite-preflight.js:176-182 documents itself as fixing. The
+ * advisory pass had kept that branch unreachable; closing the laundering opened it. Fixing one
+ * silent misdirection by introducing another would not have been a fix.
+ *
+ * HOW THIS TEST WAS FOUND. A mutation run reverting the preflight change produced ZERO red — the
+ * only mutation of five that did. The gap was in the suite, not the code, and this file closes it.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { runPrerequisitePreflight } from '../../../scripts/modules/handoff/pre-checks/prerequisite-preflight.js';
+
+function makeMockSupabase({ sdRow, evidenceRows = [] }) {
+  return {
+    from: (table) => {
+      if (table === 'sub_agent_execution_results') {
+        return { select: () => ({ eq: () => ({ gte: async () => ({ data: evidenceRows, error: null }) }) }) };
+      }
+      const builder = {
+        select: () => builder,
+        eq: () => builder,
+        or: () => builder,
+        gte: () => builder,
+        not: () => builder,
+        order: () => builder,
+        limit: async () => ({ data: [], error: null }),
+        single: async () => (table === 'strategic_directives_v2' ? { data: sdRow, error: null } : { data: null, error: null })
+      };
+      return builder;
+    }
+  };
+}
+
+const BASE_SD = { id: 'SD-TEST-NONEVIDENCE-001', sd_key: 'SD-TEST-NONEVIDENCE-001', sd_type: 'infrastructure' };
+
+// PLAN-TO-LEAD requires RETRO. A row EXISTS but its verdict is ERROR: the run crashed or never
+// finished, which is the state the broken EXPLORE CLI used to manufacture.
+const RETRO_TOMBSTONE = [{ sub_agent_code: 'RETRO', verdict: 'ERROR', created_at: '2099-01-01T00:00:00Z' }];
+
+describe('preflight diagnoses non-evidence by name (SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001)', () => {
+  it('NAMES the tombstoned agent instead of emitting the bare "required agent(s)"', async () => {
+    const supabase = makeMockSupabase({ sdRow: BASE_SD, evidenceRows: RETRO_TOMBSTONE });
+    const result = await runPrerequisitePreflight(supabase, 'PLAN-TO-LEAD', 'SD-TEST-NONEVIDENCE-001');
+
+    const notRun = result.issues.find((i) => i.code === 'SUBAGENT_EVIDENCE_NOT_RUN');
+    expect(notRun, 'preflight did not surface the non-evidence class at all').toBeTruthy();
+    expect(notRun.message).toContain('RETRO');
+    expect(notRun.message).toMatch(/ERROR/);
+  });
+
+  it('does NOT also emit the unnamed SUBAGENT_EVIDENCE_MISSING fallback', async () => {
+    // The regression this guards: with missing=[] and failing=[], the old condition fired the
+    // fallback anyway, so a worker saw a second, non-existent problem naming no agent.
+    const supabase = makeMockSupabase({ sdRow: BASE_SD, evidenceRows: RETRO_TOMBSTONE });
+    const result = await runPrerequisitePreflight(supabase, 'PLAN-TO-LEAD', 'SD-TEST-NONEVIDENCE-001');
+
+    const bare = result.issues.find(
+      (i) => i.code === 'SUBAGENT_EVIDENCE_MISSING' && /required agent\(s\)/.test(i.message)
+    );
+    expect(bare, 'the unnamed fallback fired alongside a named diagnosis — the wrong remedy, twice').toBeFalsy();
+  });
+
+  it('the remediation points at the sanctioned routes for a read-only built-in', async () => {
+    // A diagnosis that names the agent but not the fix still strands the worker who hit this via
+    // Explore, which has no CLI producer BY DESIGN.
+    const supabase = makeMockSupabase({ sdRow: BASE_SD, evidenceRows: RETRO_TOMBSTONE });
+    const result = await runPrerequisitePreflight(supabase, 'PLAN-TO-LEAD', 'SD-TEST-NONEVIDENCE-001');
+    const notRun = result.issues.find((i) => i.code === 'SUBAGENT_EVIDENCE_NOT_RUN');
+    expect(notRun.remediation).toMatch(/record-explore-evidence\.js|Task tool/);
+  });
+
+  it('CONTROL: a genuinely MISSING row still reports SUBAGENT_EVIDENCE_MISSING and names the agent', async () => {
+    // Two-sided. Without this, suppressing the fallback could have suppressed it everywhere, and
+    // the absence case — which was always correct — would have lost its diagnosis.
+    const supabase = makeMockSupabase({ sdRow: BASE_SD, evidenceRows: [] });
+    const result = await runPrerequisitePreflight(supabase, 'PLAN-TO-LEAD', 'SD-TEST-NONEVIDENCE-001');
+    const missing = result.issues.find((i) => i.code === 'SUBAGENT_EVIDENCE_MISSING');
+    expect(missing, 'the missing-row diagnosis was lost').toBeTruthy();
+    expect(missing.message).toContain('RETRO');
+    expect(result.issues.find((i) => i.code === 'SUBAGENT_EVIDENCE_NOT_RUN'), 'a missing row is not a crashed run').toBeFalsy();
+  });
+});

--- a/tests/unit/sub-agent-executor/explore-fail-fast-no-tombstone.test.js
+++ b/tests/unit/sub-agent-executor/explore-fail-fast-no-tombstone.test.js
@@ -1,0 +1,139 @@
+/**
+ * Refusing to run a built-in must leave NO evidence row.
+ * SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001, FR-2 / TS-2 / TS-8.
+ *
+ * THE DEFECT THIS PINS. `execute-subagent --code EXPLORE` used to throw PGRST116 in the loader,
+ * land in the executor's catch, and get an ERROR row written. That row became the newest for its
+ * normalized code and ADVISORY-PASSED the LEAD-TO-PLAN evidence gate at score 100. So running the
+ * broken CLI converted a block into a pass: a worker who never invoked it was hard-blocked, one who
+ * invoked it and let it crash was let through. The crash was the key to the gate.
+ *
+ * WHY THE ASSERTION IS "NO ROW" AND NOT "IT THREW". A fail-fast placed only at the throw site would
+ * have been caught by the SAME handler that writes the tombstone — the refusal would have changed
+ * the error text and nothing else. So what must be proven is the ABSENCE OF A WRITE, at the level
+ * of what reached the database client. Asserting the throw would be green against that no-op.
+ *
+ * WHY THERE IS A POSITIVE CONTROL. "No insert was captured" also passes when the harness never
+ * reached the executor at all — a bad mock path, a changed arg shape, an import error. So the
+ * identical harness is driven with a NON-built-in code whose load fails, and that one MUST capture
+ * an ERROR insert. Without it this file would assert nothing.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const EXPLORE_SD = 'SD-TEST-EXPLORE-FAIL-FAST';
+
+/**
+ * Permissive fake: every read resolves empty, every insert is captured. Deliberately loose about
+ * which query arrives, because this test is about ONE fact — whether anything was written to
+ * sub_agent_execution_results — and a strict mock would fail for unrelated reasons and be mistaken
+ * for the behaviour under test.
+ */
+function makeMockSupabase(capture, { subAgentLookup } = {}) {
+  const thenable = (result) => ({
+    select() { return this; },
+    eq() { return this; },
+    is() { return this; },
+    in() { return this; },
+    gte() { return this; },
+    lte() { return this; },
+    order() { return this; },
+    limit() { return Promise.resolve(result); },
+    maybeSingle() { return Promise.resolve(result); },
+    single() { return Promise.resolve(result); },
+    then(res) { return Promise.resolve(result).then(res); }
+  });
+
+  return {
+    from(table) {
+      if (table === 'leo_sub_agents') {
+        return thenable(subAgentLookup || { data: null, error: { message: 'no rows', code: 'PGRST116' } });
+      }
+      if (table === 'sub_agent_execution_results') {
+        const base = thenable({ data: [], error: null });
+        return {
+          ...base,
+          insert(record) {
+            capture.inserts.push(record);
+            return {
+              select: () => ({ single: async () => ({ data: { id: 'mock-row', ...record }, error: null }) })
+            };
+          }
+        };
+      }
+      return thenable({ data: [], error: null });
+    },
+    rpc: async () => ({ data: null, error: null })
+  };
+}
+
+async function runExecutor(code, capture, opts) {
+  vi.resetModules();
+  vi.doMock('../../../lib/sub-agent-executor/supabase-client.js', () => ({
+    getSupabaseClient: async () => makeMockSupabase(capture, opts),
+    default: async () => makeMockSupabase(capture, opts)
+  }));
+  const { executeSubAgent } = await import('../../../lib/sub-agent-executor/executor.js');
+  let threw = null;
+  try {
+    await executeSubAgent(code, EXPLORE_SD, {});
+  } catch (e) {
+    threw = e;
+  }
+  return threw;
+}
+
+describe('EXPLORE fail-fast writes no tombstone', () => {
+  let capture;
+  beforeEach(() => { capture = { inserts: [] }; });
+  afterEach(() => { vi.resetModules(); vi.doUnmock('../../../lib/sub-agent-executor/supabase-client.js'); });
+
+  it('writes NO row to sub_agent_execution_results', async () => {
+    // THE assertion. Not "it threw" — the pre-fix code threw too, and wrote a row on the way out.
+    const err = await runExecutor('EXPLORE', capture);
+    expect(err, 'the refusal must still surface to the caller').toBeTruthy();
+    expect(capture.inserts, 'a refusal wrote an evidence row — the tombstone path is still reachable').toEqual([]);
+  });
+
+  it('POSITIVE CONTROL: the identical harness DOES capture an ERROR insert for a non-built-in code', async () => {
+    // Without this, the assertion above also passes when the harness never reached the executor
+    // (wrong mock path, changed arg shape, import error) — the default failure mode of a
+    // mock-based absence test. A code that is NOT in BUILTIN_AGENT_CODES fails its lookup, lands in
+    // the same catch, and must write the tombstone that EXPLORE no longer writes.
+    const err = await runExecutor('TESTING', capture);
+    expect(err, 'the control must also throw, or it is not the same path').toBeTruthy();
+    expect(capture.inserts.length, 'the control captured no insert — the harness never reached the writer, so the absence test above proves nothing').toBeGreaterThan(0);
+    const verdicts = capture.inserts.map(r => r.verdict);
+    expect(verdicts).toContain('ERROR');
+  });
+
+  it('carries the refusal sentinel, so the catch can tell "must not run" from "run failed"', async () => {
+    const err = await runExecutor('EXPLORE', capture);
+    expect(err.isBuiltinAgentRefusal).toBe(true);
+  });
+
+  it('the refusal message names both sanctioned routes rather than just refusing', async () => {
+    // A refusal that does not say what to do instead is a dead end. This is the message a worker
+    // sees at the moment they are blocked.
+    const err = await runExecutor('EXPLORE', capture);
+    expect(err.message).toMatch(/Task\(subagent_type="Explore"/);
+    expect(err.message).toMatch(/record-explore-evidence\.js/);
+  });
+
+  it('refuses BEFORE the leo_sub_agents lookup — observed, not inferred from the message', async () => {
+    // Placement matters: refusing AFTER the lookup would still reach the .single() whose PGRST116
+    // produced the tombstone. Asserted by observing that the table was never queried, because a
+    // string-match on the error text would survive a move of the guard.
+    const queried = [];
+    vi.resetModules();
+    vi.doMock('../../../lib/sub-agent-executor/supabase-client.js', () => ({
+      getSupabaseClient: async () => {
+        const inner = makeMockSupabase(capture);
+        return { ...inner, from(table) { queried.push(table); return inner.from(table); } };
+      }
+    }));
+    const { executeSubAgent } = await import('../../../lib/sub-agent-executor/executor.js');
+    try { await executeSubAgent('EXPLORE', EXPLORE_SD, {}); } catch { /* expected */ }
+    expect(queried, 'the built-in code reached the leo_sub_agents lookup').not.toContain('leo_sub_agents');
+  });
+});

--- a/tests/unit/sub-agent-executor/record-explore-evidence.test.js
+++ b/tests/unit/sub-agent-executor/record-explore-evidence.test.js
@@ -1,0 +1,103 @@
+/**
+ * The sanctioned Explore transcription writer must refuse empty evidence.
+ * SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001, FR-1 / TS-7.
+ *
+ * WHY THE REFUSAL IS THE TEST-WORTHY PART. This SD closes a fail-open where a crashed CLI wrote an
+ * ERROR tombstone that advisory-passed the evidence gate at score 100. That failure was at least
+ * LOUD — the row was visible, warned about, and countable (all 8 live instances were found in one
+ * query). A writer that will record a verdict with no summary and no findings replaces it with a
+ * well-formed EMPTY PASS: invisible instead of countable, and strictly worse. Asserting only "a row
+ * was written" would be satisfied by a bare re-export of storeSubAgentResults, so the assertions
+ * here are about what the writer REFUSES, not what it writes.
+ *
+ * No database and no subprocess: refusalReason() and recordExploreEvidence(args, {store}) are
+ * exported for exactly this, and the store is injected.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { refusalReason, recordExploreEvidence, parseArgs } from '../../../scripts/record-explore-evidence.js';
+
+const GOOD = { sd_id: 'SD-X', verdict: 'PASS', summary: 'enumerated 6 call sites; 4 attacker-reachable' };
+
+describe('record-explore-evidence: the empty-evidence refusal', () => {
+  it('refuses a verdict carrying no summary and no findings', () => {
+    const reason = refusalReason({ sd_id: 'SD-X', verdict: 'PASS' });
+    expect(reason).toMatch(/no summary and no findings/);
+  });
+
+  it('refuses when summary is only whitespace — blank is not content', () => {
+    expect(refusalReason({ sd_id: 'SD-X', verdict: 'PASS', summary: '   \n  ' })).toMatch(/no summary and no findings/);
+  });
+
+  it('refuses when findings is an array of blanks', () => {
+    expect(refusalReason({ sd_id: 'SD-X', verdict: 'PASS', findings: ['', '  '] })).toMatch(/no summary and no findings/);
+  });
+
+  it('ACCEPTS findings with no summary — either one is real evidence', () => {
+    // Two-sided. A guard that rejected everything would satisfy the refusal tests above while
+    // making the writer useless, and the whole point of FR-1 is that a sanctioned producer EXISTS.
+    expect(refusalReason({ sd_id: 'SD-X', verdict: 'PASS', findings: ['leo_sub_agents has 33 codes, zero EXPLORE'] })).toBeNull();
+  });
+
+  it('ACCEPTS a summary with no findings', () => {
+    expect(refusalReason(GOOD)).toBeNull();
+  });
+});
+
+describe('record-explore-evidence: the verdict is never defaulted', () => {
+  it('refuses a MISSING verdict rather than assuming PASS', () => {
+    // A pass by omission is still a pass nobody vouched for — the same laundering the tombstone
+    // performed, in a friendlier costume.
+    expect(refusalReason({ sd_id: 'SD-X', summary: 'real content' })).toMatch(/missing --verdict/);
+  });
+
+  it('refuses an unrecognised verdict rather than passing it through', () => {
+    expect(refusalReason({ sd_id: 'SD-X', verdict: 'PROBABLY_FINE', summary: 'x' })).toMatch(/unrecognised --verdict/);
+  });
+
+  it('refuses a missing sd_id', () => {
+    expect(refusalReason({ verdict: 'PASS', summary: 'x' })).toMatch(/missing --sd-id/);
+  });
+});
+
+describe('record-explore-evidence: what actually reaches the writer', () => {
+  it('does NOT call the store at all when the record is refused', async () => {
+    // The refusal must happen BEFORE the write, not be cleaned up after one.
+    const store = vi.fn();
+    await expect(recordExploreEvidence({ sd_id: 'SD-X', verdict: 'PASS' }, { store }))
+      .rejects.toThrow(/no summary and no findings/);
+    expect(store).not.toHaveBeenCalled();
+  });
+
+  it('POSITIVE CONTROL: a valid record DOES reach the store — so the assertion above discriminates', async () => {
+    // Without this, "store not called" would also pass if recordExploreEvidence were broken outright
+    // (bad import, wrong arg shape) — the standard failure mode of a mock-based absence assertion.
+    const store = vi.fn().mockResolvedValue({ id: 'row-1' });
+    const out = await recordExploreEvidence(GOOD, { store });
+    expect(store).toHaveBeenCalledTimes(1);
+    expect(out).toEqual({ id: 'row-1' });
+  });
+
+  it('writes sub_agent_code Explore, the CALLER verdict, and a canonical repo_path', async () => {
+    const store = vi.fn().mockResolvedValue({ id: 'row-2' });
+    await recordExploreEvidence({ ...GOOD, verdict: 'CONDITIONAL_PASS', phase: 'PLAN' }, { store });
+    const [code, sdId, subAgent, results, options] = store.mock.calls[0];
+    expect(code).toBe('Explore');
+    expect(sdId).toBe('SD-X');
+    expect(subAgent).toBeNull();
+    expect(results.verdict).toBe('CONDITIONAL_PASS');   // caller's, not defaulted
+    expect(options.phase).toBe('PLAN');                 // caller's, not defaulted
+    // A worktree-valued repo_path fails SUB_AGENT_REPO_RESOLUTION, so this must be canonical:
+    // forward slashes and no .worktrees segment.
+    expect(results.metadata.repo_path).not.toMatch(/\.worktrees/);
+    expect(results.metadata.repo_path).not.toMatch(/\\/);
+  });
+});
+
+describe('record-explore-evidence: argv parsing', () => {
+  it('collects repeated --findings into an array', () => {
+    const args = parseArgs(['--sd-id', 'SD-X', '--verdict', 'PASS', '--findings', 'one', '--findings', 'two']);
+    expect(args.sd_id).toBe('SD-X');
+    expect(args.findings).toEqual(['one', 'two']);
+  });
+});

--- a/tests/unit/subagent-evidence-gate.test.js
+++ b/tests/unit/subagent-evidence-gate.test.js
@@ -641,18 +641,26 @@ describe('QF-20260804-569: ERROR/PENDING are non-evidence, not rejections', () =
 });
 
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-// QF-20260804-926 — the safety valve QF-20260804-569 removed.
+// SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001 SUPERSEDES QF-20260804-926 HERE.
 //
-// required-subagents.js:49-56 names the precondition verbatim: promoting to block is gated on the
-// unregistered-EXPLORE CLI tombstone being resolved first, and "until then the gate's advisory
-// default keeps this cost at zero". The strict half shipped without the satisfiability half, so
-// LEAD-TO-PLAN became unpassable for seats restricted to the CLI path.
+// QF-20260804-926 made non-evidence honour SUBAGENT_VERDICT_MODE, and named its own expiry:
+// required-subagents.js:49-56 gated promotion on the unregistered-EXPLORE CLI tombstone being
+// resolved first, "until then the gate's advisory default keeps this cost at zero". That
+// precondition is now met — Explore has a sanctioned producer (scripts/record-explore-evidence.js)
+// and the CLI refuses without writing a row — so the advisory branch is retired.
 //
-// Non-evidence therefore honours the SAME mode flag as a rejecting verdict. This is NOT a
-// re-softening: ERROR/PENDING remain a distinct class, are never ACCEPTED, and still block under
-// SUBAGENT_VERDICT_MODE=block.
+// WHY IT HAD TO GO RATHER THAN WAIT FOR THE GLOBAL FLAG: with NO row the gate blocks in both modes,
+// but with an ERROR tombstone as the newest row it PASSED at score 100. Running the broken CLI
+// therefore converted a block into a pass. That is a laundering path wearing a safety valve's name.
+//
+// TWO TESTS BELOW WERE REPLACED, NOT DELETED (the advisory-passes assertion, and the mode CONTROL
+// that used ERROR as its input). The control MOVED to a FAIL verdict rather than being dropped:
+// without a two-sided control on some input, a one-sided "ERROR blocks" test would still pass if
+// the mode flag stopped being consulted at all.
+//
+// SCOPE: only the non-evidence class changed. A REJECTING verdict still honours the mode flag.
 // ─────────────────────────────────────────────────────────────────────────────────────────────
-describe('QF-20260804-926: non-evidence respects verdict mode', () => {
+describe('non-evidence blocks unconditionally (SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001, superseding QF-20260804-926)', () => {
   const errorRow = [{ sub_agent_code: 'TESTING', created_at: '2026-04-24T21:00:00Z', verdict: 'ERROR' }];
 
   it('BLOCKS under SUBAGENT_VERDICT_MODE=block — the strict half is intact', async () => {
@@ -663,14 +671,28 @@ describe('QF-20260804-926: non-evidence respects verdict mode', () => {
     expect(r.details.reason).toBe('SUBAGENT_EVIDENCE_NOT_RUN');
   });
 
-  it('WARNS (does not block) in the advisory default — the documented safety valve', async () => {
+  it('an ERROR tombstone BLOCKS in the advisory default — the laundering is closed', async () => {
+    // REPLACES the QF-20260804-926 assertion that this advisory-PASSED at score 100. That pass is
+    // the defect SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001 exists to close: it meant running the
+    // broken EXPLORE CLI converted a block into a pass, so the crash was the key to the gate.
     delete process.env.SUBAGENT_VERDICT_MODE;
     const supabase = makeSupabase({ phaseStart: PHASE_START_ISO, evidenceRows: errorRow });
     const r = await validateSubagentEvidence({ sd: makeSD(), handoffType: 'PLAN-TO-EXEC' }, supabase);
-    expect(r.passed).toBe(true);
-    expect(r.details.reason).toBe('SUBAGENT_EVIDENCE_NOT_RUN_ADVISORY');
-    // Never silent: an advisory pass must still say the check did not run.
-    expect(r.warnings.join('\n')).toMatch(/SUBAGENT_EVIDENCE_NOT_RUN/);
+    expect(r.passed).toBe(false);
+    expect(r.details.reason).toBe('SUBAGENT_EVIDENCE_NOT_RUN');
+    expect(r.details.non_evidence).toEqual([expect.objectContaining({ agent: 'TESTING', verdict: 'ERROR' })]);
+  });
+
+  it('CONTROL: a MISSING row already blocked in both modes — so this test proves nothing on its own', async () => {
+    // Kept deliberately, and labelled for what it is. The missing-row branch is not mode-gated and
+    // was already blocking before this SD, so it is green before the change, after it, and under
+    // every mutation. It pins a FACT, not the BEHAVIOUR under test. It earns its place only as the
+    // contrast that shows which of the two states actually changed.
+    delete process.env.SUBAGENT_VERDICT_MODE;
+    const supabase = makeSupabase({ phaseStart: PHASE_START_ISO, evidenceRows: [] });
+    const r = await validateSubagentEvidence({ sd: makeSD(), handoffType: 'PLAN-TO-EXEC' }, supabase);
+    expect(r.passed).toBe(false);
+    expect(r.details.missing.length).toBeGreaterThan(0);
   });
 
   it('is still NOT accepted as a passing verdict in either mode', async () => {
@@ -682,10 +704,17 @@ describe('QF-20260804-926: non-evidence respects verdict mode', () => {
     expect(classifyVerdict('ERROR')).toBe('nonevidence');   // still a distinct class
   });
 
-  it('CONTROL: the two modes genuinely differ — the flag is actually consulted', async () => {
-    // Without this, both branches could return the same verdict and the "restoration" would be
-    // cosmetic. Same input, two modes, opposite outcomes.
-    const supabase = () => makeSupabase({ phaseStart: PHASE_START_ISO, evidenceRows: errorRow });
+  it('RETAINED TWO-SIDED CONTROL: the mode flag is still consulted — on a REJECTING verdict', async () => {
+    // MOVED, not deleted. The QF-20260804-926 version of this control used an ERROR row, which no
+    // longer discriminates now that non-evidence blocks in both modes. Dropping it outright would
+    // have left the suite with only one-sided "ERROR blocks" assertions — and those stay green even
+    // if resolveSubagentVerdictMode stops being consulted at all, which is exactly the regression a
+    // control exists to catch.
+    //
+    // A FAIL verdict is the right carrier: it is the REJECTING class, which this SD deliberately
+    // left mode-gated. Same input, two modes, opposite outcomes.
+    const failRow = [{ sub_agent_code: 'TESTING', created_at: '2026-04-24T21:00:00Z', verdict: 'FAIL' }];
+    const supabase = () => makeSupabase({ phaseStart: PHASE_START_ISO, evidenceRows: failRow });
     process.env.SUBAGENT_VERDICT_MODE = 'block';
     const blocked = await validateSubagentEvidence({ sd: makeSD(), handoffType: 'PLAN-TO-EXEC' }, supabase());
     delete process.env.SUBAGENT_VERDICT_MODE;


### PR DESCRIPTION
## The SD's own premise was wrong, and the real defect is sharper

The filed SD said the LEAD-TO-PLAN evidence gate *silently passes* when the required Explore row is missing. Measured against the live gate in both verdict modes, that is false twice over:

| newest row for the code | advisory (shipped default) | block |
|---|---|---|
| **no row at all** | **BLOCKS** | blocks |
| **ERROR tombstone** | **PASSES, score 100** | blocks |
| fresh PASS | passes | passes |

Without the row the gate already blocks — `subagent-evidence-gate.js:556` is not mode-gated. What actually laundered the block was the **crash**:

> **Running the broken CLI is what unlocked the gate.** A worker who never invoked `execute-subagent --code EXPLORE` was hard-blocked. A worker who invoked it, let it throw PGRST116, and let `executor.js:474` write an `ERROR` tombstone was **let through** — that row became the newest for the normalized code and advisory-passed at score 100.

So a fix aimed at "make the missing case blocking" would have been a **no-op**. That was the original scoping, and it was caught before any code was written.

**I hit this myself and did not notice.** On `SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001` I ran the broken CLI at `05:28:49Z`, writing the laundering tombstone, and escaped only because I separately wrote a real Explore row at `05:37:03Z`. That SD sat green for ~8 minutes on evidence nobody produced.

## Three pieces, in dependency order

**1 — `scripts/record-explore-evidence.js`, a sanctioned producer.** Explore is a read-only Claude Code **built-in** (`leo_protocol_sections` id=289/290), deliberately outside `leo_sub_agents`, so it cannot write its own evidence. Before this, 36 one-off scripts hand-wrote that row.

The refusal in it is the point, not a nicety: it rejects a verdict with **no summary and no findings**, and rejects a **missing verdict** rather than defaulting to PASS. Registering Explore was ruled out partly because it would trade a *loud* fail-open (an ERROR tombstone is visible, warned, countable — all 8 live instances found in one query) for a *silent* one. A writer that accepts empty evidence would do exactly that, and this SD would have committed the class it was opened to close.

**2 — fail-fast, with a coupled edit site.** A throw in `instruction-loader.js` alone would have changed nothing: `executor.js:449` catches every throw from there and writes the tombstone at `:474` — the same handler. So the refusal is a **sentinel** (`BuiltinAgentRefusalError`) thrown *before* the `leo_sub_agents` lookup, re-thrown by the catch **above both the failure logging and the store**. That makes the tombstone path unreachable for this code rather than merely unused.

The sentinel is checked above the logging deliberately. `"EXPLORE execution failed"` would tell an operator a run was attempted and broke, when nothing ran and nothing should have — and this SD is about records asserting states the system was never in.

Exit code **4**, distinct from the crash's 3. That is a verification requirement, not cosmetics: `execute-subagent.js` already exited non-zero on the crash, so a test asserting only "exits non-zero" would pass against the *old broken behaviour*.

Only `EXPLORE` is in `BUILTIN_AGENT_CODES`. `Plan` is the other built-in named by the same protocol sections, but no required-agent set asks for it and nothing was measured about its CLI path — adding it would be carrying a control to a sink I never examined.

**3 — the ERROR class stops clearing the gate, plus its coupled preflight edit.** `QF-20260804-926` softened this branch and named its own expiry, quoting `required-subagents.js:49-56`: promotion was gated on "the unregistered-EXPLORE CLI tombstone being resolved first". Pieces 1 and 2 are exactly that resolution — a seat is no longer confined to a CLI path that cannot succeed, which was the entire fairness argument for the softening.

Closing the gate **alone** would have shipped a new silent misdirection. Under the change the gate fails with `missing=[]` **and** `failing=[]`, because non-evidence is a third array `prerequisite-preflight.js` never read. Its fallback would have emitted *"Missing sub-agent evidence for: required agent(s)"* — naming no agent, telling a worker to re-invoke an agent that already ran. That is **verbatim** the defect documented at `prerequisite-preflight.js:176-182`, which that file was changed to fix. Preflight now reads `details.non_evidence`, names the agent, and the bare fallback fires only when nothing else explains the block.

## Why not simply register EXPLORE

Option A was ruled out by the coordinator and ratified by Adam, on measured grounds rather than taste:

- It creates **two representations** of what Explore is — built-in *and* sub-agent — against live doctrine.
- It is **incomplete**: a DB row alone is not Task-spawnable (needs `instructions` populated or a `.partial` + `AGENT_CODE_MAP` entry), and the Task path is the **majority producer at 211/314**. It would not fix the path most evidence actually travels.
- `instruction-loader.js:202` renders `description` as the **runtime prompt**, and all 33 rows have `instructions` NULL. So the two-column insert that stops the crash is the same insert that yields a generic executor able to emit a well-formed **empty PASS** — trading a countable tombstone for an invisible one.

## Tests: replaced, not deleted — and mutation-proven

I predicted piece 3 would turn exactly two tests red, then measured **2 failed / 65 passed** — precisely those two. A surprise there would have meant I'd misread the branch.

Both were replaced rather than removed. The advisory-passes assertion became its inverse. The two-sided mode **control was moved to a FAIL verdict**, because an ERROR row no longer discriminates now that non-evidence blocks in both modes — and deleting it would have left only one-sided "ERROR blocks" assertions, which stay green even if `resolveSubagentVerdictMode` is never consulted again. A missing-row test is retained and **labelled as pinning a fact rather than a behaviour**: green before, after, and under every mutation, earning its place only as contrast.

**Mutation results — 5/5 discriminating**, each mutation verified to parse first, each red attributed to a named test:

| mutation | red |
|---|---|
| delete the writer's empty-evidence refusal | **4** |
| revert **only** the executor sentinel (keep the loader throw) | **1** |
| revert **only** the loader fail-fast (keep the sentinel) | **4** |
| restore the gate's advisory branch | **1** |
| revert the preflight `non_evidence` branch | **3** |

**The second row is the load-bearing one.** Reverting only the sentinel still throws — so a test asserting "it threw" would stay green while the tombstone came back. It goes red, which means the assertion is about the **absence of a write**.

**The last row was 0 red on the first run.** Four of five mutations discriminated and the preflight change had *no test at all*. The gap was in my suite, not the code — the mutation pass is the only thing that could have found it, since everything was green either way.

Every absence assertion carries a **positive control**: the identical harness driven with a non-built-in code must capture an `ERROR` insert. Without it, "no insert captured" also passes when the harness never reached the executor. Placement is proven by observing that `leo_sub_agents` was **never queried**, not by matching an error string — a string match would survive moving the guard back below the lookup.

**Collection proven, not inferred** (a green `vitest run <path>` proves nothing — an explicit path bypasses the project include):

```
npx vitest list --project unit --filesOnly
[unit] tests/unit/subagent-evidence-gate.test.js
[unit] tests/unit/handoff/prerequisite-preflight-non-evidence.test.js
[unit] tests/unit/sub-agent-executor/explore-fail-fast-no-tombstone.test.js
[unit] tests/unit/sub-agent-executor/record-explore-evidence.test.js
```

**89/89 green.**

## A stale remediation, found by a test

The gate told workers that an unexecutable agent code is *"a REQUIREMENT defect, not a worker error — the required-agent list is naming something no CLI path can satisfy."* True when written; **false for the exact case it described** once this SD created the producer. Left alone it would have sent someone to file a defect instead of running the writer. Corrected rather than working around it — text that was accurate once and quietly stopped being so is the same failure class as the tombstone.

## Scope, stated so review can hold me to it

**Only the non-evidence class changed.** A rejecting verdict still honours `SUBAGENT_VERDICT_MODE`; `resolveSubagentVerdictMode` is untouched; the missing-row branch is untouched (changing it would be the no-op). The global advisory→block flip — measured at **32/313 SDs** — remains a separate decision and is **out of scope**. Registering EXPLORE is out of scope and ruled out.

**Blast radius, measured rather than inherited: 8 of 314 SDs (2.5%)** hold an ERROR-newest Explore row — not the ~10% the removed comment asserted. **Seven of the eight are already completed**; only `SD-LEO-INFRA-STANDING-OBSERVABILITY-ACCEPTANCE-001` is live, and it is the natural first customer for the new writer.

Closes `feedback` `6529e3a3-f4a9-43eb-8737-063c7e6ff020`, with a correction: its claim that *no producer can write the Explore row* is false — the Task-tool path writes **211 of 314**. The accurate scoping is **no CLI/scripted producer**; its "6 historical rows" was a capped fetch.

SD: SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001
