### PR TITLE
fix(QF-20260808-447): adopt the canonical body reader at 3 sites; correct the ticket's premise

### DIFF
--- a/lib/coordinator/reply-class.cjs
+++ b/lib/coordinator/reply-class.cjs
@@ -29,6 +29,9 @@ const RECONCILE_HORIZON_MS = 24 * 60 * 60_000; // 24h
 // consult), so without this exclusion a pinged-but-never-answered consult
 // falsely dedups as "already answered" and the real answer never gets sent.
 const { PAYLOAD_KINDS } = require('../fleet/worker-status.cjs');
+// QF-20260808-447: adopt the canonical dual-read instead of hand-rolling a 36th variant.
+// lane-contract.cjs has no requires of its own, so this cannot introduce a cycle.
+const { readCanonicalBody } = require('../coordination/lane-contract.cjs');
 const ANSWER_KIND = PAYLOAD_KINDS.ADAM_ADVISORY;
 
 /** Pure: true iff v is one of the 3 canonical reply-class values. */
@@ -228,8 +231,13 @@ async function checkAndPingOverdueReplies(supabase, { sessionId, senderType = 'w
         sender_type: senderType,
         target_session: target,
         message_type: 'INFO',
-        subject: `[PING_ON_SILENCE] ${(row.subject || row.payload.body || '').slice(0, 60)}`,
-        body: `Reminder: no reply yet to "${(row.payload.body || row.body || '').slice(0, 200)}" (sent ${row.created_at || 'earlier'}).`,
+        // QF-20260808-447: subject-first is deliberate and PRESERVED; only the fallback
+        // changes. Was `row.payload.body`, which (a) missed a row whose prose lives in the
+        // TOP-LEVEL body column and (b) THREW outright when payload was null. The body line
+        // below was already a correct dual-read by hand — routed through the same helper so
+        // there is one representation of this rule rather than two that can drift apart.
+        subject: `[PING_ON_SILENCE] ${(row.subject || readCanonicalBody(row)).slice(0, 60)}`,
+        body: `Reminder: no reply yet to "${readCanonicalBody(row).slice(0, 200)}" (sent ${row.created_at || 'earlier'}).`,
         payload: { kind: 'ping_on_silence', reply_to: corr, correlation_id: corr, reply_class: 'fire-and-forget' },
       }, { select: 'id', single: true });
       await supabase

--- a/scripts/coordinator-relay-drain.cjs
+++ b/scripts/coordinator-relay-drain.cjs
@@ -16,6 +16,8 @@ require('dotenv').config();
 const { createClient } = require('@supabase/supabase-js');
 const { drainRelayQueue } = require('../lib/coordinator/relay-queue.cjs');
 const { resolvePeerTarget } = require('../lib/coordinator/peer-target.cjs');
+// QF-20260808-447: adopt the canonical dual-read instead of hand-rolling a 36th variant.
+const { readCanonicalBody } = require('../lib/coordination/lane-contract.cjs');
 
 const DRY_RUN = process.argv.includes('--dry-run');
 
@@ -72,7 +74,9 @@ function makeSendRelay(supabase, { resolvePeerTarget: resolvePeer = resolvePeerT
           sender_type: 'coordinator',
           target_session: resolved.target,
           message_type: 'INFO',
-          subject: `[RELAYED] ${String(row.payload.body || '').slice(0, 60)}`,
+          // QF-20260808-447: was payload.body only — a row whose prose lives in the TOP-LEVEL
+      // body column relayed with an empty subject preview.
+      subject: `[RELAYED] ${readCanonicalBody(row).slice(0, 60)}`,
           body: row.payload.body || null,
           // SD-LEO-INFRA-CORRECTION-DELIVERY-PATH-001-C / FR-4: kind stays adam_advisory (that IS the
           // lane every reader drains), but the correction sub-discriminators must SURVIVE the relay.

--- a/scripts/fw3-cmv-rejecter.cjs
+++ b/scripts/fw3-cmv-rejecter.cjs
@@ -25,6 +25,8 @@ const {
   listPendingFramings, recordVerdict, checkStructuralSeparation, detectFakeSeparation,
 } = require('../lib/governance/fw3-cmv-rejecter.cjs');
 const { getActiveSolomonId } = require('../lib/coordinator/solomon-identity.cjs');
+// QF-20260808-447: adopt the canonical dual-read instead of hand-rolling a 36th variant.
+const { readCanonicalBody } = require('../lib/coordination/lane-contract.cjs');
 
 async function main() {
   const argv = process.argv.slice(2);
@@ -49,7 +51,9 @@ async function main() {
     for (const f of items) {
       console.log(`\n• id=${f.id} from=${String(f.sender_session).slice(0, 8)} at=${f.created_at}`);
       console.log(`  subject: ${f.subject}`);
-      const body = (f.payload && f.payload.body) || '';
+      // QF-20260808-447: was payload.body only, so a row carrying prose in the TOP-LEVEL
+      // body column printed "body:" empty — the lane looked empty rather than broken.
+      const body = readCanonicalBody(f);
       console.log(`  body: ${String(body).slice(0, 400)}${body.length > 400 ? '…' : ''}`);
     }
     console.log('\nAdversarial pass: for each framing, try to REJECT on CMV grounds (does it drift from the north-star? is the framing foreclosing the real problem?). Then: record <id> rejected|survived --grounds "..."');

--- a/tests/unit/qf447-canonical-body-adoption.test.js
+++ b/tests/unit/qf447-canonical-body-adoption.test.js
@@ -1,0 +1,117 @@
+// QF-20260808-447: adopt the CANONICAL body reader; do not hand-roll a 36th variant.
+//
+// PREMISE CORRECTION — read this before trusting the ticket. QF-447 was filed (from my own
+// report) as a fleet-wide, class-shaped blindness: "the ENTIRE coordinator_request class
+// renders text-less". MEASURED, that is FALSE for shipped code. Every worker-facing inbox
+// reader already does the dual-read (worker-checkin.cjs:544, fleet-dashboard.cjs x3,
+// read-adam-directives.cjs:87, read-solomon-directives.cjs:43) — several fixed by the earlier
+// QF-20260703-672. The reader that was actually blind was an ad-hoc one-liner in a worker's
+// own loop prompt, which lives in no file in this repo.
+//
+// The REAL finding is 4 production sites, all secondary/derived paths, never a primary inbox
+// render. 3 are fixed here. The 4th is deliberately NOT fixed — see the exclusion test.
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const R = (p) => fs.readFileSync(path.join(process.cwd(), p), 'utf8');
+
+// The canonical reader under test, required through its real module path.
+import { createRequire } from 'node:module';
+const require_ = createRequire(import.meta.url);
+const { readCanonicalBody } = require_(
+  path.join(process.cwd(), 'lib/coordination/lane-contract.cjs')
+);
+
+describe('readCanonicalBody — the behaviour every adopter inherits', () => {
+  it('reads payload.body when present (the canonical location)', () => {
+    expect(readCanonicalBody({ payload: { body: 'from payload' }, body: 'from column' }))
+      .toBe('from payload');
+  });
+
+  it('falls back to the TOP-LEVEL body column — the case that caused the incident', () => {
+    // coordinator_request writes here. A reader that only knows payload.body sees '' and
+    // concludes the lane is EMPTY rather than that its reader is BROKEN.
+    expect(readCanonicalBody({ payload: { kind: 'coordinator_request' }, body: 'top level' }))
+      .toBe('top level');
+  });
+
+  it('returns empty string (never throws) when payload is null', () => {
+    // The pre-fix reply-class site did `row.payload.body` and would THROW here.
+    expect(readCanonicalBody({ payload: null, body: undefined })).toBe('');
+    expect(readCanonicalBody(null)).toBe('');
+  });
+
+  it('treats an EMPTY payload.body as absent and still finds the column', () => {
+    expect(readCanonicalBody({ payload: { body: '' }, body: 'column wins' })).toBe('column wins');
+  });
+});
+
+describe('QF-447 adoption sites', () => {
+  const SITES = [
+    'scripts/fw3-cmv-rejecter.cjs',
+    'scripts/coordinator-relay-drain.cjs',
+    'lib/coordinator/reply-class.cjs',
+  ];
+
+  it.each(SITES)('%s routes its body read through readCanonicalBody', (f) => {
+    const src = R(f);
+    expect(src).toContain('readCanonicalBody');
+    expect(src).toMatch(/require\(['"][^'"]*lane-contract\.cjs['"]\)/);
+  });
+
+  // The EXACT expressions that were blind, per file. Pinning these — rather than asserting a
+  // global absence of /row\.payload\.body/ — is deliberate, and the first version of this test
+  // got it wrong in an instructive way: a blanket pattern also matched (a) legitimate
+  // dual-reads that already carry `|| row.body` (reply-class.cjs:373) and (b) WRITE-side
+  // construction building a payload for a NEW row (coordinator-relay-drain.cjs:80,96). Both
+  // are correct code the sweep must not touch. A grep for one statement form is not a test for
+  // the behaviour, and an over-broad pin would have pushed a future maintainer to "fix" code
+  // that was already right.
+  const OLD_FORMS = {
+    'scripts/fw3-cmv-rejecter.cjs': "(f.payload && f.payload.body) || ''",
+    'scripts/coordinator-relay-drain.cjs': "String(row.payload.body || '').slice(0, 60)",
+    'lib/coordinator/reply-class.cjs': "(row.subject || row.payload.body || '')",
+  };
+
+  it.each(SITES)('%s no longer contains its specific pre-fix blind expression', (f) => {
+    // Strip comments: this file and the patched sources both QUOTE the old form in their
+    // explanatory prose, and a scan matching its own commentary is the self-satisfying trap.
+    const executable = R(f)
+      .split('\n')
+      .filter((l) => {
+        const t = l.trim();
+        return !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*');
+      })
+      .join('\n');
+    expect(executable).not.toContain(OLD_FORMS[f]);
+  });
+
+  it('preserves the already-correct dual-read and write sites it must NOT touch', () => {
+    // Two-sided control: proves the change was surgical, not a blanket rewrite.
+    const rc = R('lib/coordinator/reply-class.cjs');
+    expect(rc).toContain('(row.payload && row.payload.body) || row.body || null'); // :373 dual-read
+    const rd = R('scripts/coordinator-relay-drain.cjs');
+    expect(rd).toContain('body: row.payload.body || null'); // :80/:96 payload CONSTRUCTION
+  });
+});
+
+describe('QF-447 DELIBERATE EXCLUSION — do not "finish the sweep" here', () => {
+  it('solomon-advisory computeConsultSignature is NOT converted, on purpose', () => {
+    // This site feeds a SHA-256 dedup signature. Adding the top-level body to its fallback
+    // chain changes the HASH for every row that currently falls through to row.subject,
+    // invalidating every previously-computed signature and silently re-firing dedup.
+    // A naive "adopt the helper everywhere" sweep — which is what the ticket literally asked
+    // for — would have made that change invisibly. Re-keying a dedup hash is a migration
+    // decision, not a QF. This test exists so the exclusion is a recorded decision rather
+    // than an oversight someone later "fixes".
+    const src = R('scripts/solomon-advisory.cjs');
+    expect(src).toContain('function computeConsultSignature');
+    const fn = src.slice(
+      src.indexOf('function computeConsultSignature'),
+      src.indexOf('function computeConsultSignature') + 500
+    );
+    expect(fn).toContain('createHash');
+    expect(fn).not.toContain('readCanonicalBody');
+  });
+});


### PR DESCRIPTION
## Premise correction, first

This QF was filed **from my own report** as a fleet-wide, class-shaped blindness: *"the ENTIRE `coordinator_request` class renders text-less."* **Measured, that is false for shipped code.**

Every worker-facing inbox reader already does the dual-read:

| Reader | Line | Form |
|---|---|---|
| `worker-checkin.cjs` | 544 | `m.body \|\| p.body` |
| `fleet-dashboard.cjs` | ×3 | `s.body \|\| s.payload?.body` |
| `read-adam-directives.cjs` | 87 | `r.body \|\| r.payload.body \|\| r.subject` |
| `read-solomon-directives.cjs` | 43 | same |

Several were fixed by the earlier **QF-20260703-672**. The reader that was actually blind was an **ad-hoc one-liner in a worker's own loop prompt** — it lives in no file in this repo.

The canonical helper also already existed: `lib/coordination/lane-contract.cjs::readCanonicalBody()`, whose own header names this defect as *"the coordinator_request body-drop, instance 4."* **The defect was an unadopted instrument, not a missing one** — building the ticket as literally written would have added a 36th hand-rolled variant.

## The real finding: 4 sites, all derived paths

| Site | Symptom | Action |
|---|---|---|
| `fw3-cmv-rejecter.cjs:52` | body preview printed empty for a top-level-body row | **fixed** |
| `coordinator-relay-drain.cjs:75` | relayed subject preview printed empty | **fixed** |
| `reply-class.cjs:231` | ping subject blind; also **threw** when `payload` was null | **fixed** |
| `solomon-advisory.cjs:253` | feeds a SHA-256 dedup signature | **deliberately NOT fixed** |

### Why the 4th is excluded

`computeConsultSignature` hashes its result. Adding the top-level body to its fallback chain **changes the hash for every row currently falling through to `row.subject`**, invalidating stored signatures and silently re-firing dedup. Re-keying a dedup hash is a migration decision, not a QF.

A naive "adopt the helper everywhere" sweep — what the ticket literally asked for — would have made that change invisibly. A test pins the exclusion so it is a **recorded decision, not an oversight someone later "fixes"**, and a mutation proves that guard actually fires.

## Two of my own instruments had the bug class they were auditing

Both caught, both recorded in the code:

1. **The census classifier** used a `(?<![\w.])` lookbehind that rejected dotted receivers like `result.reply.body` — a genuine fallback — and mis-binned 4 already-correct sites as blind.
2. **The first version of this test** asserted a global absence of `/row\.payload\.body/`, which also matched legitimate dual-reads (`reply-class.cjs:373`) and **write-side payload construction** (`relay-drain:80,96`). A grep for one statement form is not a test for the behavior.

The test now pins the **exact pre-fix expressions** per file and carries a two-sided control asserting the untouched-correct sites are still present — proving the change was surgical, not a blanket rewrite.

## Verification

- 4 mutations, all caught (3 reverts + "finish the sweep" into the dedup hash)
- Restore byte-identical (file copies, never `git checkout --`)
- 23 files / 276 tests green in `tests/unit/coordination/`
- Modules load under **real `node`**, not just vitest

## Doors still hand-rolled — NOT closed by this PR

Stated so a green run isn't over-read as class closure: 7 remaining `payload.body`-only hits are **test assertions** on payloads the tests construct (`adam-advisory.test.js` ×4, `twoway-roundtrip.test.js` ×3), plus `lane-contract.cjs:109` which is the helper's own internal read (correct by construction). Those are not lane readers. The dedup-signature site above remains open by decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)