### PR TITLE
fix(SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001): land two commits that missed #6882 — the alias bypass and the exit code are live on main

### DIFF
--- a/lib/sub-agent-executor/instruction-loader.js
+++ b/lib/sub-agent-executor/instruction-loader.js
@@ -34,6 +34,27 @@ import { SUB_AGENT_CATEGORY_MAPPING } from './phase-model-config.js';
 export const BUILTIN_AGENT_CODES = new Set(['EXPLORE']);
 
 /**
+ * Normalize an agent code THE SAME WAY THE EVIDENCE GATE DOES.
+ *
+ * This must stay byte-compatible with `norm` in
+ * scripts/modules/handoff/gates/subagent-evidence-gate.js:358, and the reason is a measured bypass
+ * rather than tidiness. The guard below originally keyed on plain toUpperCase(), while the gate keys
+ * AGENT IDENTITY on a normalizer that strips a trailing -AGENT. So `EXPLORE-AGENT` slipped past the
+ * refusal, reached the leo_sub_agents lookup, wrote the ERROR tombstone — and the gate then folded
+ * it back to EXPLORE and attributed it to the required `Explore`. The refusal and the identity
+ * function disagreed, so the code that was supposed to be unreachable was reachable under an alias.
+ *
+ * A guard whose notion of "which agent is this" differs from the consumer's is the defect shape this
+ * SD is about, not a detail: the whole fix rests on the gate and the guard meaning the same thing by
+ * a code.
+ */
+export const normalizeAgentCode = (s) => String(s || '')
+  .trim()
+  .toUpperCase()
+  .replace(/-AGENT$/, '')
+  .replace(/-+/g, '_');
+
+/**
  * Sentinel for a refusal, so the caller can tell "this must not run" apart from "this run failed".
  *
  * That distinction is the whole fix. executor.js catches every throw from here and writes an ERROR
@@ -62,8 +83,8 @@ export async function loadSubAgentInstructions(code, compositionContext = {}) {
   // BEFORE the lookup, deliberately. Refusing after it would still reach the .single() below, whose
   // PGRST116 on zero rows is what produced the tombstone in the first place — and the point is to
   // make that path UNREACHABLE for this code, not merely unlikely.
-  if (BUILTIN_AGENT_CODES.has(String(code || '').toUpperCase())) {
-    throw new BuiltinAgentRefusalError(String(code).toUpperCase());
+  if (BUILTIN_AGENT_CODES.has(normalizeAgentCode(code))) {
+    throw new BuiltinAgentRefusalError(normalizeAgentCode(code));
   }
 
   console.log(`\nLoading sub-agent instructions: ${code}...`);

--- a/scripts/execute-subagent.js
+++ b/scripts/execute-subagent.js
@@ -247,7 +247,18 @@ async function main() {
     // A refusal is also not a stack-trace situation — the message says what to do instead.
     if (error?.isBuiltinAgentRefusal) {
       console.error(`\n⛔ Refused: ${error.message}`);
-      process.exit(4);
+      // process.exitCode, NOT process.exit(). MEASURED: process.exit(4) here aborted the process
+      // with a libuv assertion (!(handle->flags & UV_HANDLE_CLOSING)) and the shell observed 127,
+      // deterministically 5/5 — never the 4 this branch claimed to produce. Exiting hard fires
+      // before the async handles opened during startup have settled. Setting exitCode lets node
+      // drain and exit with the intended status.
+      //
+      // Worth stating plainly because I asserted the opposite in a commit message: this branch
+      // advertised "exit 4, distinct from the crash's 3" as a VERIFICATION property, and the
+      // property did not hold until this change. 127 is also the shell's "command not found",
+      // which would have made the refusal look like a missing binary.
+      process.exitCode = 4;
+      return;
     }
     console.error('\n💥 Fatal Error:', error.message);
     console.error('\nStack Trace:', error.stack);

--- a/scripts/modules/handoff/gates/subagent-evidence-gate.js
+++ b/scripts/modules/handoff/gates/subagent-evidence-gate.js
@@ -539,11 +539,18 @@ export async function validateSubagentEvidence(ctx, supabase) {
   // `failing` is carried here too: when some agents are absent AND others wrote a
   // rejecting row, absence still decides the verdict (unchanged behavior), but the
   // bad verdicts must remain visible in details rather than being dropped.
+  // SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001: nonEvidence is carried for the SAME reason failing
+  // is, and omitting it reproduced the defect one level down. In a MIXED state — one agent absent,
+  // another holding a crash row — absence decides the verdict, but details.non_evidence was
+  // undefined, so prerequisite-preflight's non-evidence branch had nothing to read and reported
+  // only the missing agent. The tombstone stayed invisible behind the absence diagnosis: the same
+  // "wrong diagnosis, right block" shape the preflight edit exists to prevent, mirrored.
   const sharedDetails = {
     required,
     present: [...present],
     missing,
     failing,
+    non_evidence: nonEvidence,
     phase_started_at: phaseStartedAt.toISOString()
   };
 

--- a/scripts/modules/phase-subagent-orchestrator/execution.js
+++ b/scripts/modules/phase-subagent-orchestrator/execution.js
@@ -135,6 +135,14 @@ async function executeSubAgent(subAgent, sdId, options = {}) {
     };
 
   } catch (error) {
+    // SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001: a REFUSAL must not be converted into a verdict.
+    // This catch turns any throw into a synthetic FAIL, which is the REJECTING class — and that
+    // class is still mode-gated, so under the shipping advisory default a refusal laundered through
+    // here would PASS the evidence gate at score 100. Unreachable today only because the
+    // orchestrator runs codes present in leo_sub_agents and none normalize to a built-in; that is
+    // a coincidence of registration, not a guarantee, so the invariant is held here in code.
+    if (error?.isBuiltinAgentRefusal) throw error;
+
     console.error(`   Execution failed: ${error.message}`);
 
     return {

--- a/tests/unit/handoff/prerequisite-preflight-non-evidence.test.js
+++ b/tests/unit/handoff/prerequisite-preflight-non-evidence.test.js
@@ -79,6 +79,37 @@ describe('preflight diagnoses non-evidence by name (SD-LEO-INFRA-EXPLORE-UNREGIS
     expect(notRun.remediation).toMatch(/record-explore-evidence\.js|Task tool/);
   });
 
+  it('MIXED STATE: one agent MISSING and another NON-EVIDENCE yields BOTH named diagnoses', async () => {
+    // RE-DERIVED FROM A DESTROYED LEAD. A sibling security agent left an untracked scratch test
+    // asserting exactly this, and it FAILED ("non-evidence diagnosis lost"). I deleted that scratch
+    // in a cleanup sweep before reading it, so the failing case could not be re-read — a peer who
+    // had run it relayed the assertion text, and this reconstructs it.
+    //
+    // WHY IT IS THE INTERESTING CASE. When some agents are absent AND another holds a crash row,
+    // absence decides the verdict, so the gate returns through the MISSING branch. That branch built
+    // sharedDetails carrying `failing` but NOT `nonEvidence`, so details.non_evidence was undefined
+    // and the tombstone vanished behind the absence diagnosis. A worker would fix the missing agent,
+    // re-run, and only then discover the second problem — one round trip per hidden class.
+    //
+    // That is the "reports a subset and reads as complete" shape this SD family exists to close, so
+    // a fix for it that is itself only tested in the single-class case would be exactly the kind of
+    // partial coverage the SD is about.
+    const supabase = makeMockSupabase({
+      sdRow: BASE_SD,
+      evidenceRows: [{ sub_agent_code: 'TESTING', verdict: 'ERROR', created_at: '2099-01-01T00:00:00Z' }]
+    });
+    // EXEC-TO-PLAN requires TESTING and SECURITY: TESTING holds a crash row, SECURITY is absent.
+    const result = await runPrerequisitePreflight(supabase, 'EXEC-TO-PLAN', 'SD-TEST-NONEVIDENCE-001');
+
+    const missing = result.issues.find((i) => i.code === 'SUBAGENT_EVIDENCE_MISSING');
+    const notRun = result.issues.find((i) => i.code === 'SUBAGENT_EVIDENCE_NOT_RUN');
+
+    expect(missing, 'the absent agent was not reported').toBeTruthy();
+    expect(missing.message).toContain('SECURITY');
+    expect(notRun, 'non-evidence diagnosis lost — the tombstone is hidden behind the absence').toBeTruthy();
+    expect(notRun.message).toContain('TESTING');
+  });
+
   it('CONTROL: a genuinely MISSING row still reports SUBAGENT_EVIDENCE_MISSING and names the agent', async () => {
     // Two-sided. Without this, suppressing the fallback could have suppressed it everywhere, and
     // the absence case — which was always correct — would have lost its diagnosis.

--- a/tests/unit/sub-agent-executor/explore-fail-fast-no-tombstone.test.js
+++ b/tests/unit/sub-agent-executor/explore-fail-fast-no-tombstone.test.js
@@ -107,6 +107,37 @@ describe('EXPLORE fail-fast writes no tombstone', () => {
     expect(verdicts).toContain('ERROR');
   });
 
+  it('EXPLORE-AGENT is refused too — the guard and the gate must agree on identity', async () => {
+    // A MEASURED BYPASS, found by adversarial review. The guard originally keyed on plain
+    // toUpperCase() while the evidence gate keys agent IDENTITY on a normalizer that strips a
+    // trailing -AGENT (subagent-evidence-gate.js:358). So `EXPLORE-AGENT` slipped past the refusal,
+    // reached the lookup, wrote the ERROR tombstone — and the gate then folded it back to EXPLORE
+    // and attributed it to the required `Explore`. The refusal was unreachable under an alias.
+    //
+    // A guard whose notion of "which agent is this" differs from its consumer's is the defect shape
+    // this SD is about, not a naming detail.
+    const err = await runExecutor('EXPLORE-AGENT', capture);
+    expect(err?.isBuiltinAgentRefusal, 'the -AGENT alias evaded the refusal').toBe(true);
+    expect(capture.inserts, 'the alias wrote a tombstone the gate would fold back to EXPLORE').toEqual([]);
+  });
+
+  it('lowercase and padded spellings are refused', async () => {
+    for (const variant of ['explore', 'Explore', '  EXPLORE  ']) {
+      const c = { inserts: [] };
+      const err = await runExecutor(variant, c);
+      expect(err?.isBuiltinAgentRefusal, `variant ${JSON.stringify(variant)} evaded the refusal`).toBe(true);
+      expect(c.inserts, `variant ${JSON.stringify(variant)} wrote a row`).toEqual([]);
+    }
+  });
+
+  it('CONTROL: a NON-built-in code is still allowed through to the lookup', async () => {
+    // Two-sided. A guard that refused everything would satisfy every assertion above while breaking
+    // the executor for all 33 registered agents.
+    const c = { inserts: [] };
+    const err = await runExecutor('TESTING', c);
+    expect(err?.isBuiltinAgentRefusal, 'a registered code was wrongly refused as a built-in').toBeFalsy();
+  });
+
   it('carries the refusal sentinel, so the catch can tell "must not run" from "run failed"', async () => {
     const err = await runExecutor('EXPLORE', capture);
     expect(err.isBuiltinAgentRefusal).toBe(true);


### PR DESCRIPTION
Follow-up to #6882. **Two commits missed that merge and their fixes are currently live-broken on main.**

## What happened, plainly

#6882 merged at 10:49:19Z with three commits. `c61e20bb598` (10:56:15Z) and `5e9a09fb06e` (11:00:37Z) were authored *after* the merge and pushed to a branch whose only PR was already closed. I verified the PR was `MERGED` and never verified **which commits were in it** — the same not-checking-the-actual-thing this SD family exists to close, committed in my own release step.

Found while a retrospective agent was checking citations, by ancestry test rather than by trusting the merge notification:

```
git merge-base --is-ancestor c61e20bb598 origin/main  -> STRANDED
git merge-base --is-ancestor 5e9a09fb06e origin/main  -> STRANDED
```

Measured on `origin/main` content right now:
- `lib/sub-agent-executor/instruction-loader.js` — **0** occurrences of `normalizeAgentCode`: the alias bypass is open.
- `scripts/execute-subagent.js` — still calls `process.exit(4)`: the libuv abort and exit **127** are live.

The laundering fix itself **did** land — the non-evidence branch on main returns `buildFailResult` with no mode check. So the core defect is closed; what is missing is refusal *purity* and the exit code.

## What this restores

**1 — `EXPLORE-AGENT` bypasses the refusal (live on main).** The guard keys on `toUpperCase()`; the evidence gate keys agent *identity* on a normalizer that strips a trailing `-AGENT` (`subagent-evidence-gate.js:358`). So the alias slips past the refusal, reaches the `leo_sub_agents` lookup, writes the ERROR tombstone — and the gate folds it back to `EXPLORE` and attributes it to the required `Explore`. FR-2 says "make that path unreachable"; under an alias it is reachable.

A guard whose notion of *which agent is this* differs from its consumer's is the defect shape this SD is about, not a naming detail. Fixed by exporting `normalizeAgentCode` and keying the guard on it, with a comment requiring it stay byte-compatible with the gate's.

Measured reassurance, not an excuse: `Explore` appears 246 times and `EXPLORE` 79 times in the wild, with **zero `-AGENT` variants** — the hole was reachable but never exercised.

**2 — the exit code I advertised does not exist (live on main).** A prior commit argued exit 4 was "a verification requirement rather than cosmetics", since a test asserting only non-zero would pass against the old crash. Measured by EXEC review: **127**, deterministically 5/5, aborting with `!(handle->flags & UV_HANDLE_CLOSING)` — `process.exit(4)` fires before startup's async handles settle. And **no test asserted the exit code at all**, which is why it shipped. 127 is also the shell's "command not found", so a deliberate refusal reads as a missing binary. Now `process.exitCode = 4` and the process drains; verified live at 4 with zero aborts.

**3 — the sentinel was honoured at 2 of 4 catch sites.** Two orchestrator wrappers convert any throw into a synthetic `FAIL` — the *rejecting* class, which this SD deliberately left mode-gated, so under the shipping advisory default a laundered refusal would pass at score 100. Unreachable today only because the orchestrator runs codes present in `leo_sub_agents`; that is a coincidence of registration, not a guarantee. Fixed in `phase-subagent-orchestrator/execution.js`. The sibling site is **not** fixed here — see the escalation below.

**4 — `sharedDetails` carried `failing` but not `nonEvidence`.** In a mixed state (one agent absent, another holding a crash row) absence decides the verdict, so the gate returns via the MISSING branch and `details.non_evidence` was undefined — the tombstone hid behind the absence diagnosis, one round trip per hidden class.

## The mixed-state test, and how it was nearly lost

A sibling security sub-agent left four untracked `__secreview` scratch files in the worktree. **I deleted them without reading them**, believing they belonged to another session; they carried this session's own scratchpad path. One was a *failing* test asserting exactly the mixed-state case. Untracked deletion is unrecoverable — a peer who had run it relayed the assertion text, and their deliberate restraint is the only reason the finding survived. My glob matched the directory name but not the differently-named files inside it, so the file I never listed was the red one.

Re-derived here and **mutation-proven**: removing `non_evidence: nonEvidence` from `sharedDetails` turns that test red and **only** that test (1 failed / 4 passed). My suite had tested each class alone and had no mixed-state case, so nothing in it demonstrated the fix worked.

## Verification

**93/93 green.** Collection proven via `vitest list --project unit --filesOnly`, not inferred from a targeted run.

New coverage in this PR: the `-AGENT` alias, lowercase and padded spellings, a two-sided control that a *registered* code is still allowed through (a guard refusing everything would satisfy the bypass tests while breaking all 33 agents), and the mixed-state preflight case.

## Escalated separately, deliberately not fixed here

`scripts/modules/orchestrator/subagent-execution.js` **does not parse on main**. Its success-path `return {` opener is gone — the only `return {` left is at `:99`, inside the catch — so `verdict: result.verdict,` parses as a label and the next key is a syntax error. Introduced by `4263e776b7c`, which removed `verdict: result.verdict || 'WARNING'` and took the opener with it. Imported by `scripts/modules/orchestrator/index.js:63`. Reach not traced. I reverted my own additive edit rather than ship a change to a file that cannot load; a coordinator-owned hotfix is already sourced.

## Corrections to earlier numbers in this SD

- Blast radius is **7 of 313** SDs holding an ERROR-newest Explore row, **all seven already completed** — re-measured over the full 29,583-row table, paged. Earlier commits said 8/314 with seven completed.
- The `subagent-execution.js` `return {` is at **:99**, not `:105` as an earlier message stated.

SD: SD-LEO-INFRA-EXPLORE-UNREGISTERED-LEO-001
