### PR TITLE
fix(QF-20260808-450): restore the success-path return object; main was unparseable

### DIFF
--- a/scripts/modules/orchestrator/subagent-execution.js
+++ b/scripts/modules/orchestrator/subagent-execution.js
@@ -77,7 +77,17 @@ export async function executeSubAgent(subAgent, sdId, options = {}) {
     // stored RAW via safeInsert with no mapVerdict and no original_verdict.
     // The verdict is now passed through UNMODIFIED; mapping and provenance belong to the canonical
     // writer, which this path already invokes via realExecuteSubAgent.
-    verdict: result.verdict,
+    //
+    // QF-20260808-450: the edit above also deleted this `return {` opener and the two identity
+    // fields, leaving `verdict: result.verdict,` dangling with no enclosing object — the file
+    // stopped parsing (node --check: Unexpected token ':' at the next line). Restored to match
+    // the error path below, which returns the same sub_agent_code/sub_agent_name pair. The
+    // verdict pass-through itself is UNCHANGED: this fixes the syntax the removal broke, it does
+    // not reinstate the `|| 'WARNING'` laundering that removal was correct to delete.
+    return {
+      sub_agent_code: code,
+      sub_agent_name: name,
+      verdict: result.verdict,
       confidence: result.confidence !== undefined ? result.confidence : 50,
       critical_issues: result.critical_issues || [],
       warnings: result.warnings || [],

--- a/tests/unit/qf450-subagent-execution-loads.test.js
+++ b/tests/unit/qf450-subagent-execution-loads.test.js
@@ -1,0 +1,62 @@
+// QF-20260808-450: scripts/modules/orchestrator/subagent-execution.js was UNPARSEABLE on main.
+//
+// Commit 4263e776 (SD-LEO-INFRA-WRITER-SUB-AGENT-001/FR-2) correctly removed the
+// `verdict: result.verdict || 'WARNING'` laundering, but the edit also deleted the success path's
+// `return {` opener and its sub_agent_code/sub_agent_name fields — leaving `verdict:
+// result.verdict,` dangling with no enclosing object. node --check failed; the module could not
+// load at all.
+//
+// WHY NO TEST CAUGHT IT: nothing in tests/ imported this module. A module with zero importers is
+// invisible to the whole suite — a green run says nothing about it. The FIRST test below is
+// therefore the load itself: an ESM import fails outright on a syntax error, so this file failing
+// to parse can never again be a silent green.
+//
+// (Separately reported, NOT fixed here: scripts/lint/no-unfenced-verdict-mutation-lint.mjs — which
+// DOES cover this file — catches a parse failure, console.warn's "skipped (parse)", and returns []
+// i.e. CLEAN. Its own comment says "a silent drop and a pass look identical downstream", then
+// returns the pass. That is why CI stayed green on a broken file. Fixing it is a separate change
+// with real blast radius — any legitimately unparseable file would start failing CI — so it is a
+// reported finding, not scope smuggled into a hotfix.)
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const REL = 'scripts/modules/orchestrator/subagent-execution.js';
+
+describe('QF-450 subagent-execution module health', () => {
+  it('LOADS — an ESM import throws on a syntax error, which is the whole point of this test', async () => {
+    const mod = await import(`../../${REL}`);
+    expect(typeof mod.executeSubAgent).toBe('function');
+    // The other exports the orchestrator depends on; a partial module is also a broken module.
+    expect(typeof mod.normalizeDetailedAnalysis).toBe('function');
+    expect(typeof mod.storeSubAgentResult).toBe('function');
+  });
+
+  describe('success-path return shape', () => {
+    // Comment-stripped: this file and the source both QUOTE the broken form in their prose, and a
+    // scan that matches its own commentary is the self-satisfying-test trap.
+    const executable = fs
+      .readFileSync(path.join(process.cwd(), REL), 'utf8')
+      .split('\n')
+      .filter((l) => {
+        const t = l.trim();
+        return !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*');
+      })
+      .join('\n');
+
+    it('restores the identity fields the error path also returns', () => {
+      // Both branches must carry these, or a caller cannot tell which agent produced a result.
+      expect(executable.match(/sub_agent_code:\s*code/g) || []).toHaveLength(2);
+      expect(executable.match(/sub_agent_name:\s*name/g) || []).toHaveLength(2);
+    });
+
+    it('passes the verdict through UNMODIFIED — the FR-2 removal is NOT reinstated', () => {
+      // The regression that matters most: this hotfix restores SYNTAX, it must not restore the
+      // `|| 'WARNING'` laundering. WARNING sits in the evidence gate's ACCEPT set, so reinstating
+      // it would silently promote a crashed sub-agent to a passing verdict.
+      expect(executable).toContain('verdict: result.verdict,');
+      expect(executable).not.toMatch(/verdict:\s*result\.verdict\s*\|\|/);
+      expect(executable).not.toContain("|| 'WARNING'");
+    });
+  });
+});


### PR DESCRIPTION
## The break

`scripts/modules/orchestrator/subagent-execution.js` **did not parse on `main`.**

Commit `4263e776` (SD-LEO-INFRA-WRITER-SUB-AGENT-001/FR-2) correctly removed the `verdict: result.verdict || 'WARNING'` laundering — but the edit also deleted the success path's `return {` opener and its `sub_agent_code`/`sub_agent_name` fields, leaving `verdict: result.verdict,` dangling with no enclosing object. The closing `};` was still present, so `node --check` failed at the next line with `Unexpected token ':'` and the module could not load at all.

Premise verified independently before claiming: `node --check` on a fresh `origin/main` checkout, exit 1.

## The fix

Restored the opener and the two identity fields, matching the error path below which returns the same pair.

**The verdict pass-through is unchanged.** This fixes the syntax the removal broke; it does **not** reinstate the laundering that removal was correct to delete. A test pins that explicitly — `WARNING` sits in the evidence gate's ACCEPT set, so reinstating it would silently promote a crashed sub-agent to a passing verdict.

## Why no test caught it

**Nothing in `tests/` imported this module.** A module with zero importers is invisible to the entire suite — a green run said nothing about it.

The first test added here is the load itself: an ESM import throws on a syntax error, so this file failing to parse can never again be a silent green. **Mutation-verified** — re-breaking the file exactly as `main` had it fails the load test. (The verdict pin still passes under that mutation, correctly: it measures a different property.)

Verification: `node --check` exit 0, real ESM import resolves 5 exports (parse ≠ load), 3/3 tests green, restore byte-identical from a file copy.

## Reported separately, deliberately NOT fixed here

`scripts/lint/no-unfenced-verdict-mutation-lint.mjs` **does** cover this file. Its `lintFile()` catches a parse failure, `console.warn`s `skipped (parse)`, and `return []` — i.e. **clean**.

Its own comment on that line reads:

> *"A file the parser cannot read is NOT a clean file — say so, because a silent drop and a pass look identical downstream."*

…and then it returns the pass. It "says so" to a log line nobody gates on. **That is why CI stayed green on a broken file** — the same skipped-check-renders-green class as QF-20260807-278.

Making it fail-closed has real blast radius (any legitimately unparseable file — TS/JSX/fixtures — would start failing CI), so it is a reported finding rather than scope smuggled into a hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)