### PR TITLE
fix(QF-20260808-734): honour --verification-notes on the already-merged reconcile path

### DIFF
--- a/scripts/modules/complete-quick-fix/orchestrator.js
+++ b/scripts/modules/complete-quick-fix/orchestrator.js
@@ -270,6 +270,16 @@ export function buildMergedReconcileUpdate({ qf = {}, prUrl, mergeSha = null, no
   // (--scope-accepted). No status-CHECK widening: 'in_progress' is already in the enum
   // ('open','in_progress','completed','escalated'), so this needs no migration.
   const merged = `PR ${prUrl} MERGED and reachable from origin/main${mergeSha ? ` (${mergeSha})` : ''}`;
+  // QF-20260808-734: honour --verification-notes on this path instead of silently discarding it.
+  // Chose HONOUR over the loud-refusal pattern used for --uat-verified above, because the two
+  // flags differ in kind: --uat-verified would assert a UAT that genuinely did not re-run here
+  // (a false claim), whereas an operator's notes are a human attestation that is MORE valuable on
+  // this path, not less — the row closes on a merge rather than on a test run, so the prose is
+  // often the only thing explaining why the close is legitimate. Labelled so a reader can tell
+  // operator-supplied text from the machine-generated witness line it sits beside.
+  const rawOperatorNote = typeof options.verificationNotes === 'string' ? options.verificationNotes.trim() : '';
+  const operatorNote = rawOperatorNote ? `OPERATOR NOTES: ${rawOperatorNote}` : '';
+
   if (!scopeAcceptedBy) {
     const witnessNote = `${merged} — merge witnessed, SCOPE ACCEPTANCE OUTSTANDING (QF-20260725-691: a merged PR proves code landed, not that this QF's scope is satisfied; UAT not re-run in the reconcile path). Attest with: node scripts/complete-quick-fix.js ${qf.id || '<QF>'} --pr-url ${prUrl} --scope-accepted "<who/why>".`;
     return {
@@ -278,14 +288,18 @@ export function buildMergedReconcileUpdate({ qf = {}, prUrl, mergeSha = null, no
       commit_sha: mergeSha,
       // The merge IS a genuine CI witness — that part was never the lie.
       tests_passing: true,
-      verification_notes: [qf.verification_notes, witnessNote].filter(Boolean).join(' | '),
+      // QF-20260808-734: the operator's --verification-notes used to be dropped here without a
+      // word. The flag is parsed (cli.js) and advertised in --help, so it accepted the text,
+      // reported success, and the attestation never landed anywhere — a caller could only find
+      // out by reading the row back and comparing LENGTHS, since status said `completed`.
+      verification_notes: [qf.verification_notes, operatorNote, witnessNote].filter(Boolean).join(' | '),
       // QF-20260711-176 preserved: an unheld QF must not pin worktree reaping. The row is left
       // discoverable rather than closed, which is the point — it is NOT finished.
       claiming_session_id: null
     };
   }
   const reconcileNote = `${merged}; SCOPE ACCEPTED by ${scopeAcceptedBy} (QF-20260725-691 attestation; UAT not re-run in reconcile path).`;
-  const verification_notes = [qf.verification_notes, reconcileNote].filter(Boolean).join(' | ');
+  const verification_notes = [qf.verification_notes, operatorNote, reconcileNote].filter(Boolean).join(' | ');
   return {
     status: 'completed',
     pr_url: prUrl,

--- a/tests/unit/qf734-reconcile-honours-operator-notes.test.js
+++ b/tests/unit/qf734-reconcile-honours-operator-notes.test.js
@@ -1,0 +1,71 @@
+// QF-20260808-734: --verification-notes was SILENTLY DROPPED on the already-merged reconcile path.
+//
+// buildMergedReconcileUpdate built verification_notes from [qf.verification_notes, <machine note>]
+// and never read options.verificationNotes. The flag is parsed and advertised in --help, so it
+// accepted the text, the command exited SUCCESS, `status` read `completed`, and the attestation
+// landed nowhere. Found only by reading the row back and COMPARING LENGTHS — a status check cannot
+// see a field that was never written.
+//
+// THIS IS THE THIRD INSTANCE OF THE SAME DROP CLASS IN THIS ONE FUNCTION: QF-20260727-731 fixed a
+// dropped --runtime-observation here, and its own comment reads "Silence was the defect; a loud
+// failure is the fix." An option a caller passes must either be HONOURED or REFUSED LOUDLY —
+// never accepted and discarded.
+//
+// Honour was chosen over the loud-refusal used for --uat-verified because the flags differ in
+// kind: --uat-verified would assert a UAT that genuinely did not re-run (a false claim), while
+// operator notes are a human attestation that matters MORE on this path — the row closes on a
+// merge rather than a test run, so the prose is often the only thing explaining the close.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+const require_ = createRequire(import.meta.url);
+const { buildMergedReconcileUpdate } = require_(
+  path.join(process.cwd(), 'scripts/modules/complete-quick-fix/orchestrator.js')
+);
+
+const base = { qf: { verification_notes: 'PRIOR' }, prUrl: 'https://x/pr/1', mergeSha: 'abc123', nowIso: '2026-08-08T12:00:00Z' };
+
+describe('QF-734 reconcile path honours --verification-notes', () => {
+  it('includes operator notes on the SCOPE-ACCEPTED (completed) branch', () => {
+    const out = buildMergedReconcileUpdate({
+      ...base, scopeAcceptedBy: 'Bravo — because X', options: { verificationNotes: 'MY ATTESTATION' },
+    });
+    expect(out.status).toBe('completed');
+    expect(out.verification_notes).toContain('MY ATTESTATION');
+    expect(out.verification_notes).toContain('OPERATOR NOTES:');
+    expect(out.verification_notes).toContain('PRIOR');        // prior content preserved
+    expect(out.verification_notes).toContain('SCOPE ACCEPTED'); // machine note still present
+  });
+
+  it('includes operator notes on the WITNESS-ONLY (in_progress) branch too', () => {
+    // Both branches dropped it; fixing only the one you happened to exercise is how a
+    // half-fixed drop survives.
+    const out = buildMergedReconcileUpdate({
+      ...base, scopeAcceptedBy: null, options: { verificationNotes: 'MY ATTESTATION' },
+    });
+    expect(out.status).toBe('in_progress');
+    expect(out.verification_notes).toContain('MY ATTESTATION');
+    expect(out.verification_notes).toContain('SCOPE ACCEPTANCE OUTSTANDING');
+  });
+
+  // --- two-sided: the label must not appear when there is nothing to label ---
+  it('adds NO operator section when the flag was not passed', () => {
+    const out = buildMergedReconcileUpdate({ ...base, scopeAcceptedBy: 'Bravo — why', options: {} });
+    expect(out.verification_notes).not.toContain('OPERATOR NOTES:');
+    expect(out.verification_notes).toContain('PRIOR');
+  });
+
+  it('treats whitespace-only notes as absent rather than emitting an empty label', () => {
+    const out = buildMergedReconcileUpdate({
+      ...base, scopeAcceptedBy: 'Bravo — why', options: { verificationNotes: '   \n  ' },
+    });
+    expect(out.verification_notes).not.toContain('OPERATOR NOTES:');
+  });
+
+  it('does not throw when options is omitted entirely', () => {
+    const out = buildMergedReconcileUpdate({ ...base, scopeAcceptedBy: 'Bravo — why' });
+    expect(out.status).toBe('completed');
+    expect(out.verification_notes).not.toContain('OPERATOR NOTES:');
+  });
+});


### PR DESCRIPTION
## The drop

`buildMergedReconcileUpdate` built `verification_notes` from `[qf.verification_notes, <machine note>]` and **never read `options.verificationNotes`**. The flag is parsed in `cli.js` and advertised in `--help` — so it accepted the text, the command exited **SUCCESS**, the row read `status=completed`, and the operator's attestation landed nowhere.

The only way to notice was reading the row back and **comparing lengths**. A status check cannot see a field that was never written. (Found exactly that way while completing QF-447: 1529 chars stored against ~4000 sent.)

## This is the third instance of the same class in one function

`QF-20260727-731` fixed a dropped `--runtime-observation` at the very same call site. Its surviving comment:

> *"refuse BEFORE building, so the caller never gets a success exit with their input discarded. Silence was the defect; a loud failure is the fix."*

An option a caller passes must be **honoured or refused loudly** — never accepted and discarded.

## Why honour, not refuse

The path already refuses `--uat-verified` loudly (`UAT_VERIFIED_UNSUPPORTED_ON_RECONCILE`). I did **not** copy that, because the flags differ in kind:

- `--uat-verified` would assert a UAT that genuinely did not re-run here — a **false claim**.
- Operator notes are a human attestation that matters **more** on this path, not less: the row closes on a *merge* rather than a *test run*, so the prose is often the only thing explaining why the close is legitimate.

Labelled `OPERATOR NOTES:` so a reader can distinguish operator-supplied text from the machine-generated witness line beside it.

**Both branches fixed** — the scope-accepted (`completed`) branch and the witness-only (`in_progress`) branch both dropped it. Fixing only the one I happened to exercise is how a half-fixed drop survives.

## Verification

5 tests, two-sided — the label must **not** appear when the flag is absent, when notes are whitespace-only, or when `options` is omitted entirely. **Mutation verified:** reverting the join fails the suite.

## Pre-existing failures — measured, not assumed

`tests/unit/metric-evidence-resolver.test.js` (2) and `tests/unit/complete-quick-fix/external-timeout-and-coverage-gate.test.js` (2) fail **identically on a clean `origin/main` checkout of this file** — verified by reverting to the `origin/main` blob, re-running, and restoring byte-identical. The second one lives in the module I touched, so I measured rather than hand-waved it. Not introduced here; not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)