### PR TITLE
fix(QF-20260808-528): STEP 0 discovery ran through a shell and reported success over a scan that examined nothing

### DIFF
--- a/scripts/prd/integration-discovery.js
+++ b/scripts/prd/integration-discovery.js
@@ -12,7 +12,7 @@
  * Part of SD-LEO-INFRA-INTEGRATION-AWARE-PRD-001 (FR-1)
  */
 
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import fs from 'fs';
 import path from 'path';
 // crypto import removed - unused
@@ -132,6 +132,42 @@ export function scanBarrelExports(repoRoot, scopePaths = ['lib', 'scripts']) {
 }
 
 /**
+ * Run `git grep -l -E <pattern> -- <paths>` with NO shell involved.
+ *
+ * WHY ARGV AND NOT A SHELL. The previous form interpolated the alternation regex into a shell
+ * string. On Windows `execSync` runs it through cmd.exe, which reads the `|` between patterns
+ * as a PIPE: it split the command and tried to execute `router\.post\(` as a program. Measured
+ * on win32 — shell form exits 255 with "'router\.post\' is not recognized as an internal or
+ * external command"; this argv form returns 7 files for the identical pattern. Every caller
+ * wrapped the call in a bare `catch {}`, so the scan returned EMPTY on every Windows seat and
+ * STEP 0 reported a successful discovery that had examined nothing.
+ *
+ * WHY `status === 1` IS NOT A FAILURE. git grep exits 1 for "no matches found", and that
+ * includes a scope path that does not exist — measured: a nonexistent pathspec exits 1 with
+ * EMPTY stderr, indistinguishable from an ordinary empty result, so it cannot be treated as an
+ * error. Genuine failures (not a repository, malformed regex, git missing, timeout) exit 128
+ * or fail to spawn; those are rethrown so they surface instead of degrading into a silent
+ * empty scan, which is the exact defect this replaces.
+ *
+ * @param {string} repoRoot - Repository root to scan from
+ * @param {string} pattern - Extended-regex pattern, passed as ONE argv element
+ * @param {string[]} scopePaths - Pathspecs, each its own argv element
+ * @returns {string} Newline-separated matching file paths, or '' when there are no matches
+ */
+function gitGrepFiles(repoRoot, pattern, scopePaths) {
+  try {
+    return execFileSync(
+      'git',
+      ['grep', '-l', '-E', pattern, '--', ...scopePaths],
+      { encoding: 'utf8', cwd: repoRoot, timeout: SCAN_TIMEOUT_MS }
+    ).trim();
+  } catch (err) {
+    if (err.status === 1) return '';
+    throw err;
+  }
+}
+
+/**
  * Scan for router registrations (Express/Fastify route patterns).
  *
  * @param {string} repoRoot - Repository root path
@@ -157,12 +193,8 @@ export function scanRouterRegistrations(repoRoot, scopePaths = ['lib', 'scripts'
     ];
 
     const grepPattern = routePatterns.join('|');
-    const scopeArgs = scopePaths.map(p => `"${p}"`).join(' ');
 
-    const output = execSync(
-      `git grep -l -E '${grepPattern}' -- ${scopeArgs} 2>/dev/null || echo ""`,
-      { encoding: 'utf8', cwd: repoRoot, timeout: SCAN_TIMEOUT_MS }
-    ).trim();
+    const output = gitGrepFiles(repoRoot, grepPattern, scopePaths);
 
     if (!output) return results;
 
@@ -187,8 +219,10 @@ export function scanRouterRegistrations(repoRoot, scopePaths = ['lib', 'scripts'
         });
       }
     }
-  } catch {
-    // Scanning failed, return empty
+  } catch (err) {
+    // LOUD, not silent. This bare catch is the second half of the defect: it swallowed the
+    // cmd.exe breakage whole, so STEP 0 reported a discovery that had scanned nothing.
+    console.error(`   scanRouterRegistrations failed: ${String(err.message).split('\n')[0]}`);
   }
 
   return results;
@@ -215,12 +249,8 @@ export function scanRegistryPatterns(repoRoot, scopePaths = ['lib', 'scripts', '
     ];
 
     const grepPattern = registryPatterns.join('|');
-    const scopeArgs = scopePaths.map(p => `"${p}"`).join(' ');
 
-    const output = execSync(
-      `git grep -l -E '${grepPattern}' -- ${scopeArgs} 2>/dev/null || echo ""`,
-      { encoding: 'utf8', cwd: repoRoot, timeout: SCAN_TIMEOUT_MS }
-    ).trim();
+    const output = gitGrepFiles(repoRoot, grepPattern, scopePaths);
 
     if (!output) return results;
 
@@ -244,8 +274,8 @@ export function scanRegistryPatterns(repoRoot, scopePaths = ['lib', 'scripts', '
         });
       }
     }
-  } catch {
-    // Scanning failed
+  } catch (err) {
+    console.error(`   scanRegistryPatterns failed: ${String(err.message).split('\n')[0]}`);
   }
 
   return results;
@@ -273,12 +303,8 @@ export function scanValidationSchemas(repoRoot, scopePaths = ['lib', 'scripts', 
     ];
 
     const grepPattern = schemaPatterns.join('|');
-    const scopeArgs = scopePaths.map(p => `"${p}"`).join(' ');
 
-    const output = execSync(
-      `git grep -l -E '${grepPattern}' -- ${scopeArgs} 2>/dev/null || echo ""`,
-      { encoding: 'utf8', cwd: repoRoot, timeout: SCAN_TIMEOUT_MS }
-    ).trim();
+    const output = gitGrepFiles(repoRoot, grepPattern, scopePaths);
 
     if (!output) return results;
 
@@ -303,8 +329,8 @@ export function scanValidationSchemas(repoRoot, scopePaths = ['lib', 'scripts', 
         });
       }
     }
-  } catch {
-    // Scanning failed
+  } catch (err) {
+    console.error(`   scanValidationSchemas failed: ${String(err.message).split('\n')[0]}`);
   }
 
   return results;
@@ -326,10 +352,11 @@ export function scanConsumers(repoRoot, targetFiles = []) {
       const baseName = path.basename(targetFile, path.extname(targetFile));
       const _dirName = path.dirname(targetFile);
 
-      const output = execSync(
-        `git grep -l -E "from\\s+['\"].*${baseName}['\"]" -- "lib" "scripts" "src" 2>/dev/null || echo ""`,
-        { encoding: 'utf8', cwd: repoRoot, timeout: SCAN_TIMEOUT_MS }
-      ).trim();
+      const output = gitGrepFiles(
+        repoRoot,
+        `from\\s+['"].*${baseName}['"]`,
+        ['lib', 'scripts', 'src']
+      );
 
       if (!output) continue;
 
@@ -341,8 +368,8 @@ export function scanConsumers(repoRoot, targetFiles = []) {
           type: 'consumer'
         });
       }
-    } catch {
-      // Continue with next file
+    } catch (err) {
+      console.error(`   scanConsumers failed for ${targetFile}: ${String(err.message).split('\n')[0]}`);
     }
   }
 

--- a/scripts/prd/prd-creator.js
+++ b/scripts/prd/prd-creator.js
@@ -233,6 +233,33 @@ export async function createPRDWithValidatedContent(
   llmContent,
   stakeholderPersonas = []
 ) {
+  // QF-20260808-528: two named pre-checks, so a mis-call fails HERE instead of as a bare
+  // Postgres error that names neither the argument nor the column.
+  //
+  // (a) CLIENT-FIRST SIGNATURE. This function takes the supabase client as argument ONE, which
+  //     is easy to mis-order; without this guard the mistake surfaces much deeper as a
+  //     "cannot read properties of undefined" on some unrelated line.
+  if (!supabase || typeof supabase.from !== 'function') {
+    throw new Error(
+      'createPRDWithValidatedContent: argument 1 must be a Supabase client — this signature is ' +
+      'client-first: (supabase, prdId, sdId, sdIdValue, prdTitle, sdData, llmContent, personas).'
+    );
+  }
+
+  // (b) WRONG ID FOR THE FK. sdIdValue is written to product_requirements_v2.sd_id, whose FK
+  //     prd_sd_fk targets strategic_directives_v2.id — and that PK is the SD KEY STRING
+  //     (measured: id = "SD-LEO-FEAT-INTELLIGENT-UAT-FEEDBACK-001"), NOT the UUID that the
+  //     creation scripts print as the SD's uuid (uuid_id / uuid_internal_pk). Passing the UUID
+  //     raises 23503 with no hint about which of the two id-ish values was wrong.
+  const UUID_SHAPE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (UUID_SHAPE.test(String(sdIdValue ?? '').trim())) {
+    throw new Error(
+      `createPRDWithValidatedContent: sdIdValue must be the SD key (strategic_directives_v2.id, ` +
+      `e.g. "SD-LEO-FEAT-EXAMPLE-001") but received a UUID (${sdIdValue}). The FK prd_sd_fk targets ` +
+      `the key column, not uuid_id — passing the UUID raises Postgres 23503. Pass sdData.id / sd_key.`
+    );
+  }
+
   // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-077 FR-001: Validate executive_summary at creation
   // Check the provided value explicitly (empty/short strings should not silently fall through to defaults)
   if (llmContent.executive_summary !== undefined && llmContent.executive_summary !== null) {

--- a/tests/unit/prd/integration-discovery-shell.test.js
+++ b/tests/unit/prd/integration-discovery-shell.test.js
@@ -1,0 +1,96 @@
+/**
+ * STEP 0 integration discovery must not ride a shell, and must not fail silently.
+ * QF-20260808-528.
+ *
+ * THE DEFECT. Every scanner built `git grep -l -E '<pattern>' -- <paths>` as a SHELL STRING.
+ * On Windows execSync runs cmd.exe, which reads the `|` between alternation patterns as a
+ * PIPE — it split the command and tried to execute `router\.post\(` as a program (exit 255).
+ * Each caller wrapped that in a bare `catch {}`, so the scan returned EMPTY and STEP 0
+ * reported a successful discovery over a scan that had examined nothing. Measured on win32
+ * against the unmodified file: 0/0/0 results; after the argv fix: 6/32/151.
+ *
+ * WHY THERE ARE THREE DIFFERENT ARMS. The shell-vs-argv difference is platform-dependent —
+ * the old code WORKED under POSIX sh, so a Windows-only assertion would be green on CI
+ * (100% ubuntu) and prove nothing there. So this file carries one arm per failure mode:
+ *   1. LOUDNESS  — cross-platform. The bare `catch {}` logged nothing; a real failure now
+ *                  must reach stderr. Red on every platform before the fix.
+ *   2. NO-SHELL  — fires on POSIX. A caller-supplied filename carrying $(...) would be
+ *                  command-substituted by sh inside the old double-quoted string.
+ *   3. RESULTS   — fires on Windows. The alternation pattern must actually return matches.
+ * The assertions themselves are true on both platforms, so none of them are OS-gated; they
+ * simply have different discriminating power per platform, which is stated rather than hidden.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import {
+  scanRouterRegistrations,
+  scanRegistryPatterns,
+  scanValidationSchemas,
+  scanConsumers
+} from '../../../scripts/prd/integration-discovery.js';
+
+const REPO_ROOT = process.cwd();
+
+describe('QF-20260808-528: STEP 0 discovery uses argv, not a shell', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('LOUD: a genuine failure reaches stderr instead of being swallowed', () => {
+    // THE cross-platform arm. Pre-fix this was `catch {}` — zero output, empty result, and a
+    // caller that could not tell "nothing to find" from "the scan never ran".
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    spy.mockClear(); // restoreAllMocks alone left the spy installed, so a prior test's call leaked in
+    const notARepo = fs.mkdtempSync(path.join(os.tmpdir(), 'qf528-norepo-'));
+    try {
+      const result = scanRouterRegistrations(notARepo);
+      expect(result, 'a failed scan must still return a usable empty array').toEqual([]);
+      expect(spy, 'the failure was swallowed — silent empty scan is the defect').toHaveBeenCalled();
+      expect(String(spy.mock.calls[0][0])).toMatch(/scanRouterRegistrations failed/);
+    } finally {
+      try { fs.rmSync(notARepo, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
+  it('NO-SHELL: a caller-supplied filename carrying $(...) is never executed', () => {
+    // scanConsumers interpolates path.basename(targetFile) into the pattern, and the old form
+    // put that inside DOUBLE quotes — where sh performs command substitution. Fires on POSIX.
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'qf528-inject-'));
+    const marker = path.join(dir, 'pwned.txt').replace(/\\/g, '/');
+    try {
+      scanConsumers(REPO_ROOT, [`evil$(touch ${marker}).js`]);
+      expect(
+        fs.existsSync(marker),
+        'command substitution executed — the pattern still reaches a shell'
+      ).toBe(false);
+    } finally {
+      try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* best effort */ }
+    }
+  });
+
+  it('RESULTS: alternation patterns actually match (0 here means the scan never ran)', () => {
+    // Fires on Windows, where cmd.exe used to split the pattern on its `|`. Uses this repo as
+    // the fixture: it demonstrably contains registry and validation-schema patterns.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    spy.mockClear(); // restoreAllMocks alone left the spy installed, so a prior test's call leaked in
+    const registry = scanRegistryPatterns(REPO_ROOT);
+    const schemas = scanValidationSchemas(REPO_ROOT);
+
+    expect(spy, 'a scan of this repo should not be erroring at all').not.toHaveBeenCalled();
+    expect(registry.length, 'registry scan returned nothing — shell breakage or a dead scan').toBeGreaterThan(0);
+    expect(schemas.length, 'schema scan returned nothing — shell breakage or a dead scan').toBeGreaterThan(0);
+  });
+
+  it('NO MATCHES is not an error: git grep exit 1 returns empty and stays quiet', () => {
+    // Two-sided against the loudness arm. git grep exits 1 both for "no matches" AND for a
+    // pathspec that matches nothing (measured: exit 1, EMPTY stderr — indistinguishable). If
+    // exit 1 were treated as a failure, every ordinary empty scan would scream.
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    spy.mockClear(); // restoreAllMocks alone left the spy installed, so a prior test's call leaked in
+    const result = scanConsumers(REPO_ROOT, ['no_such_file_qf528_zzz.js']);
+
+    expect(result).toEqual([]);
+    expect(spy, 'an ordinary empty result was reported as a failure').not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/prd/prd-creator-id-guard.test.js
+++ b/tests/unit/prd/prd-creator-id-guard.test.js
@@ -1,0 +1,69 @@
+/**
+ * createPRDWithValidatedContent must reject a mis-call by NAME, before Postgres does.
+ * QF-20260808-528.
+ *
+ * TWO FOOTGUNS, both hit while writing a real PRD. The signature is CLIENT-FIRST, which is easy
+ * to mis-order; and `sdIdValue` is written to product_requirements_v2.sd_id, whose FK targets
+ * strategic_directives_v2.id — the SD KEY STRING, not the UUID the creation scripts print as
+ * the SD's uuid. Measured: id = "SD-LEO-FEAT-INTELLIGENT-UAT-FEEDBACK-001" while uuid_id holds
+ * the UUID. Passing the UUID raised a bare 23503 naming neither the argument nor the column.
+ *
+ * THE POSITIVE CONTROL IS THE POINT. Both negative assertions below would also pass against a
+ * guard that rejected EVERY call — which would break PRD creation entirely. The third test
+ * drives a CORRECT id through and asserts it reaches the next validation instead, so the guard
+ * is proven two-sided rather than merely loud.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createPRDWithValidatedContent } from '../../../scripts/prd/prd-creator.js';
+
+const SD_KEY = 'SD-LEO-FEAT-EXAMPLE-001';
+const SD_UUID = 'd0129bf6-1b4d-49be-a7be-97b761029f55';
+
+// Minimal stand-in: only needs to look like a client to get past the first guard.
+const fakeSupabase = {
+  from: () => ({
+    select: () => ({ eq: () => ({ limit: () => ({ maybeSingle: async () => ({ data: null }) }) }) })
+  })
+};
+
+const goodContent = {
+  executive_summary: 'x'.repeat(60),
+  functional_requirements: [{ id: 'FR-1', title: 'something' }]
+};
+
+describe('QF-20260808-528: createPRDWithValidatedContent pre-checks', () => {
+  it('rejects a UUID in sdIdValue and names the column, the FK and the fix', async () => {
+    await expect(
+      createPRDWithValidatedContent(fakeSupabase, 'PRD-X', SD_KEY, SD_UUID, 'T', {}, goodContent)
+    ).rejects.toThrow(/sdIdValue must be the SD key/);
+  });
+
+  it('the message explains WHICH id was wrong rather than surfacing a bare 23503', async () => {
+    // A named error that does not say what to pass instead just relocates the confusion.
+    const err = await createPRDWithValidatedContent(
+      fakeSupabase, 'PRD-X', SD_KEY, SD_UUID, 'T', {}, goodContent
+    ).catch(e => e);
+    expect(err.message).toMatch(/23503/);
+    expect(err.message).toMatch(/uuid_id|sd_key/);
+  });
+
+  it('rejects a mis-ordered call where argument 1 is not a client', async () => {
+    await expect(
+      createPRDWithValidatedContent(SD_KEY, 'PRD-X', SD_KEY, SD_KEY, 'T', {}, goodContent)
+    ).rejects.toThrow(/argument 1 must be a Supabase client/);
+  });
+
+  it('CONTROL: a CORRECT sd key passes the pre-check and reaches the next validation', async () => {
+    // Deliberately empty functional_requirements: the call must fail on THAT, proving the id
+    // guard let a valid key through instead of rejecting everything.
+    const err = await createPRDWithValidatedContent(
+      fakeSupabase, 'PRD-X', SD_KEY, SD_KEY, 'T', {},
+      { executive_summary: 'x'.repeat(60), functional_requirements: [] }
+    ).catch(e => e);
+
+    expect(err, 'expected the downstream validation to reject').toBeTruthy();
+    expect(err.message, 'the id guard rejected a VALID sd key').not.toMatch(/sdIdValue must be/);
+    expect(err.message).toMatch(/functional_requirements/);
+  });
+});


### PR DESCRIPTION
STEP 0 integration discovery ran its `git grep` through a **shell**, and every caller wrapped it in a bare `catch {}`. On Windows those two facts compose into a scan that returns nothing and reports success.

## The mechanism, measured

`execSync` on win32 runs cmd.exe, which reads the `|` between alternation patterns as a **pipe** — it splits the command and tries to execute the second pattern as a program:

```
'router\.post\' is not recognized as an internal or external command,
operable program or batch file.
```

That throws (exit 255), the bare `catch {}` swallows it, and `scanRouterRegistrations` returns `[]`. STEP 0 then reports a completed discovery over a scan that examined nothing.

Measured against the **verified-unmodified** file on main vs this branch, same repo, same host:

| scanner | before | after |
|---|---|---|
| routerRegistrations | **0** | 6 |
| registryPatterns | **0** | 32 |
| validationSchemas | **0** | 151 |

The "before" run also leaks cmd.exe errors to the console — visible, but attached to nothing that fails.

## The fix

All four `git grep` sites now go through one argv runner — no shell, pattern as a single argv element, pathspecs as their own elements. The four swallowing catches now name the scanner that failed.

## A premise in the QF that the measurement contradicts

The QF asked that "a genuine path error still fails loud". **A nonexistent pathspec is not an error to `git grep`** — measured: exit **1** with *empty stderr*, byte-indistinguishable from an ordinary empty result. Treating exit 1 as failure would make every legitimately-empty scan scream.

The real discriminator, measured:

| condition | exit | stderr |
|---|---|---|
| no matches | 1 | *(empty)* |
| nonexistent pathspec | 1 | *(empty)* |
| not a git repository | 128 | `fatal: not a git repository…` |
| malformed regex | 128 | `fatal: … Unmatched [ or [^` |

So the runner returns empty on 1 and rethrows everything else. That is what the code keys on, and why.

## Second defect: two named pre-checks on `createPRDWithValidatedContent`

Both footguns were hit writing a real PRD:

1. **Client-first signature** — argument 1 is the Supabase client, easy to mis-order; without a guard the mistake surfaces much deeper as an unrelated undefined-property crash.
2. **Wrong id for the FK** — `sdIdValue` is written to `product_requirements_v2.sd_id`, whose FK `prd_sd_fk` targets `strategic_directives_v2.id`. That PK is the **SD key string** (measured: `id = "SD-LEO-FEAT-INTELLIGENT-UAT-FEEDBACK-001"`), not the UUID the creation scripts print — the UUID lives in `uuid_id` / `uuid_internal_pk`. Passing it raised a bare **23503** naming neither the argument nor the column.

## Verification

**25/25 green** across `tests/unit/prd/`. Collection proven with `vitest list --project unit --filesOnly`, not inferred from a targeted run.

**Mutation-proven**, each red attributed to exactly one named test:

| mutation | result |
|---|---|
| restore the silent `catch {}` | **only** `LOUD: a genuine failure reaches stderr` fails (1 of 4) |
| restore the shell form | **only** `RESULTS: alternation patterns actually match` fails (1 of 4) |

The id guard carries a **positive control**: a correct SD key passes the pre-check and reaches the next validation. Without it, a guard that rejected *every* call would satisfy both negative tests while breaking PRD creation entirely.

### Platform honesty about the test arms

The old code **worked** under POSIX `sh`, so a Windows-only assertion would be green on CI (100% ubuntu) and prove nothing there. The file carries one arm per failure mode, and says so in its header:

- **LOUDNESS** — cross-platform; red on every platform before the fix.
- **NO-SHELL** — fires on POSIX; a caller-supplied filename carrying `$(…)` would be command-substituted inside the old double-quoted string.
- **RESULTS** — fires on Windows; the alternation pattern must actually return matches.

None are OS-gated — the assertions hold on both platforms, they simply have different discriminating power, which is stated rather than hidden.

## Full-suite delta

Full unit project: **3042 files / 37194 tests passing**, 4 failures — **none attributable to this change**, established rather than assumed:

- 2 in `complete-quick-fix/external-timeout-and-coverage-gate.test.js` — **already fail on unmodified main** (verified against a `git diff --quiet` baseline).
- 2 in `metric-evidence-resolver.test.js` — worktree-environmental; it spawns `node + vitest` and is sensitive to running from a linked worktree. Proven by **stashing only my two source edits and re-running: still 2 failed / 27 passed**.

Neither file imports `scripts/prd/`.

QF: QF-20260808-528
