### PR TITLE
fix(QF-20260808-463): stop losing lessons to a non-string solution; correct the ticket's premise

### DIFF
--- a/lib/learning/issue-knowledge-base.js
+++ b/lib/learning/issue-knowledge-base.js
@@ -179,9 +179,21 @@ export class IssueKnowledgeBase {
     // Update proven solutions
     // QF-20260525-885: coerce non-array proven_solutions to [] so .find() below is safe.
     let solutions = Array.isArray(pattern.proven_solutions) ? pattern.proven_solutions : [];
-    const existingSolution = solutions.find(s =>
-      s.solution.toLowerCase() === solution_applied.toLowerCase()
-    );
+    // QF-20260808-463: the line above guards the CONTAINER; this one used to assume the CONTENTS.
+    // `s.solution.toLowerCase is not a function` threw here and killed the whole update — the
+    // upstream extractor writes `solution: retro.action_items[0]`, and an action item is very
+    // often an OBJECT, not a string. `solution_applied` can arrive non-string the same way.
+    //
+    // Deliberately NOT `String(v).toLowerCase()`: that stringifies every object to
+    // '[object Object]', so two unrelated object-valued solutions would compare EQUAL and get
+    // silently merged into one another's stats. A crash replaced by a wrong merge is worse than
+    // the crash, because the merge is silent. A non-string simply cannot match, and a non-string
+    // target matches nothing at all.
+    const lower = (v) => (typeof v === 'string' ? v.toLowerCase() : null);
+    const target = lower(solution_applied);
+    const existingSolution = target === null
+      ? undefined
+      : solutions.find(s => s && lower(s.solution) === target);
 
     if (existingSolution) {
       // Update existing solution stats

--- a/scripts/auto-extract-patterns-from-retro.js
+++ b/scripts/auto-extract-patterns-from-retro.js
@@ -49,6 +49,28 @@ const CATEGORY_SUBAGENT_MAPPING = {
 /**
  * Get related sub-agents for a category
  */
+/**
+ * QF-20260808-463: action_items entries are NOT reliably strings. Passing one straight through as
+ * `solution` put an object into proven_solutions, and the knowledge base then threw
+ * "s.solution.toLowerCase is not a function" on the next comparison — killing the update and
+ * losing the lesson. Fixed at BOTH ends: this coerces at the producer, and the KB no longer
+ * assumes its element shapes.
+ *
+ * NOT `String(item)`: that renders every object as '[object Object]', so two unrelated action
+ * items would become the same string and get merged into one another's stats. JSON is used only
+ * as a last resort because it is at least distinct per item and preserves the content.
+ */
+export function actionItemToText(item) {
+  if (typeof item === 'string') return item;
+  if (item && typeof item === 'object') {
+    for (const key of ['action', 'text', 'description', 'title', 'item', 'summary']) {
+      if (typeof item[key] === 'string' && item[key].trim()) return item[key];
+    }
+    return JSON.stringify(item);
+  }
+  return null;
+}
+
 function getRelatedSubAgents(category) {
   return CATEGORY_SUBAGENT_MAPPING[category] || ['VALIDATION'];
 }
@@ -186,7 +208,8 @@ async function extractPatternsFromImprovements(retro, sdId, _sdKey, linkedFeedba
         category: category,
         severity: severity,
         sd_id: sdId,
-        solution: retro.action_items.length > 0 ? retro.action_items[0] : null,
+        // QF-20260808-463: was `retro.action_items[0]` raw — an object reached the KB and threw.
+        solution: retro.action_items.length > 0 ? actionItemToText(retro.action_items[0]) : null,
         resolution_time_minutes: null,
         related_sub_agents: relatedSubAgents,
         source_feedback_ids: linkedFeedbackIds

--- a/tests/unit/qf463-action-item-coercion.test.js
+++ b/tests/unit/qf463-action-item-coercion.test.js
@@ -1,0 +1,85 @@
+// QF-20260808-463: "s.solution.toLowerCase is not a function" — a lesson lost on the learning loop.
+//
+// PREMISE CORRECTION, stated first. The ticket says the extractor "DESTROYS 4 lessons while
+// REPORTING SUCCESS". The reporting half is ALREADY FIXED on main by
+// SD-FDBK-ENH-LEARNING-LOOP-DESTROYS-001: auto-extract-patterns-from-retro.js logs a per-lesson
+// "LESSON LOST", prints a structured "N lesson(s) DESTROYED and not persisted", returns them to
+// the caller as `patterns.destroyed`, and exits NON-ZERO (`process.exit(lessons_destroyed > 0 ? 2
+// : 0)`). It does not report success over a failure.
+//
+// The TYPE ERROR is real, but in a DIFFERENT FILE than the ticket names:
+// lib/learning/issue-knowledge-base.js compared `s.solution.toLowerCase()` against every element
+// of proven_solutions. That line already carried a guard from QF-20260525-885 — "coerce non-array
+// proven_solutions to [] so .find() below is safe" — which hardened the CONTAINER and left the
+// CONTENTS assumed. A guard that checks the array cannot see the shapes inside it.
+//
+// Fixed at BOTH ends of one data path: the producer coerces (here), and the consumer no longer
+// assumes element shape.
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { actionItemToText } from '../../scripts/auto-extract-patterns-from-retro.js';
+
+describe('actionItemToText — the producer coercion', () => {
+  it('passes a string straight through', () => {
+    expect(actionItemToText('rerun the gate')).toBe('rerun the gate');
+  });
+
+  it('pulls the text field out of a typical action-item object', () => {
+    expect(actionItemToText({ action: 'rerun the gate', owner: 'EXEC' })).toBe('rerun the gate');
+    expect(actionItemToText({ description: 'add a guard' })).toBe('add a guard');
+  });
+
+  it('NEVER returns [object Object] — two unrelated objects must stay DISTINGUISHABLE', () => {
+    // This is the whole reason String(item) was rejected. If both collapsed to the same string,
+    // the KB would MERGE two unrelated solutions' stats — a silent wrong answer, which is worse
+    // than the crash this replaces.
+    const a = actionItemToText({ foo: 1 });
+    const b = actionItemToText({ bar: 2 });
+    expect(a).not.toContain('[object Object]');
+    expect(b).not.toContain('[object Object]');
+    expect(a).not.toBe(b);
+  });
+
+  it('returns a STRING or null for every shape the extractor can hand it', () => {
+    for (const v of [null, undefined, 42, true, {}, { action: '' }, ['x']]) {
+      const out = actionItemToText(v);
+      expect(out === null || typeof out === 'string').toBe(true);
+    }
+  });
+
+  it('ignores an empty/whitespace text field rather than returning blank', () => {
+    expect(actionItemToText({ action: '   ', text: 'real one' })).toBe('real one');
+  });
+});
+
+describe('issue-knowledge-base consumer guard', () => {
+  const src = fs
+    .readFileSync(path.join(process.cwd(), 'lib/learning/issue-knowledge-base.js'), 'utf8')
+    .split('\n')
+    .filter((l) => {
+      const t = l.trim();
+      return !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*');
+    })
+    .join('\n');
+
+  it('no longer calls .toLowerCase() directly on a proven_solutions element', () => {
+    expect(src).not.toContain('s.solution.toLowerCase()');
+  });
+
+  it('routes both sides through a type-checked normaliser', () => {
+    expect(src).toContain("typeof v === 'string'");
+    expect(src).toContain('lower(s.solution) === target');
+  });
+
+  it('does NOT fall back to String() coercion (that would false-merge objects)', () => {
+    expect(src).not.toMatch(/String\(\s*(v|s\.solution|solution_applied)\s*\)\s*\.toLowerCase/);
+  });
+
+  it('KNOWN, NOT FIXED HERE: pattern.issue_summary.toLowerCase() is the same unguarded class', () => {
+    // Reported rather than fixed — it feeds similarity SCORING, so changing what it matches has
+    // its own blast radius and belongs in its own change. Pinned so the finding is recorded
+    // rather than rediscovered; flip this expectation when it is deliberately fixed.
+    expect(src).toContain('pattern.issue_summary.toLowerCase()');
+  });
+});


### PR DESCRIPTION
## Premise correction, first

The ticket says the extractor *"DESTROYS 4 lessons while REPORTING SUCCESS"*. **The reporting half is already fixed on `main`** by SD-FDBK-ENH-LEARNING-LOOP-DESTROYS-001 (4 commits). Measured in shipped code before building anything:

| Line | Behaviour |
|---|---|
| `:214` | per-lesson `❌ LESSON LOST` |
| `:218-222` | structured `⚠️ N lesson(s) DESTROYED and not persisted` |
| `:222` | returned to the caller as `patterns.destroyed` |
| `:446` | `process.exit(lessons_destroyed > 0 ? 2 : 0)` — **exits non-zero** |

It does not report success over a failure.

## The real defect — in a different file than the ticket names

`lib/learning/issue-knowledge-base.js:183` compared `s.solution.toLowerCase()` against every element of `proven_solutions`.

That exact line **already carried a guard**, from QF-20260525-885:

> *"coerce non-array proven_solutions to `[]` so `.find()` below is safe"*

It hardened the **container** and left the **contents** assumed. A guard that checks the array cannot see the shapes inside it.

## Fixed at both ends of one data path

- **Producer** (the file the ticket *did* name): `auto-extract-patterns-from-retro.js:189` passed `retro.action_items[0]` straight through as `solution` — and an action item is very often an **object**. Now coerced via `actionItemToText()`.
- **Consumer**: the KB no longer assumes element shape. A non-string cannot match; a non-string target matches nothing.

### Why not `String(v)`

It renders every object as `[object Object]`, so two unrelated solutions would compare **equal** and be merged into one another's stats. **A crash replaced by a silent wrong merge is worse than the crash.** JSON is the last resort only because it stays distinct per item — and there's a test asserting exactly that.

## Reported, not fixed

`pattern.issue_summary.toLowerCase()` in the same file is the identical unguarded class. It feeds similarity **scoring**, so changing what it matches carries its own blast radius and belongs in its own change. Pinned by a test so the finding is recorded rather than rediscovered — flip that expectation when it's deliberately fixed.

## Verification

9 tests, including a control that two distinct objects stay distinguishable. **2 mutations caught** (reverting the KB guard; swapping JSON for `String`). Restores byte-identical. **31 files / 247 tests green** across the learning/pattern/retro suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)