### PR TITLE
fix(QF-20260808-834): stop hard-interrupting toward an inert SMS drain

### DIFF
--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -813,8 +813,30 @@ async function main() {
     }
     // QF-20260719-848: undrained chairman SMS as first-class hard-interrupt lines (mirrors
     // QUIET_TICK_INBOX_DIRECTIVE) — the contract INBOUND WATCH duty. Act: drain + reply.
+    // QF-20260808-834: the QUIET_TICK_SMS_INBOUND token IS the hard interrupt (adam-startup-check
+    // allowlists these tokens; a tick with none is read as a NO-OP). It points at
+    // scripts/sms-relay-drain.cjs, which is INERT while SMS_RELAY_DRAIN_ENABLED is unset. So an
+    // undrained row re-fired the interrupt EVERY tick toward a remediation nobody could perform,
+    // and a genuinely-new inbound then hid behind the permanent stale one — alert fatigue that
+    // masks the very thing the detector exists to catch.
+    //
+    // DOWNGRADE, DO NOT SILENCE. The ticket offered "skip entirely when the flag is off" and
+    // named the trade itself: pre-cutover inbounds would not be surfaced AT ALL. A detector that
+    // goes fully dark on a CHAIRMAN SMS channel is a worse failure than the one being fixed, and
+    // "what state silences this alarm, and can anyone reach it?" is exactly the question that
+    // should stop a blanket skip. So: withhold the INTERRUPT TOKEN (the thing that falsely
+    // promises an actionable drain) while still printing the row. Visibility is preserved;
+    // only the false call-to-action is removed.
+    const smsDrainEnabled = !['', '0', 'false', 'off', 'no']
+      .includes(String(process.env.SMS_RELAY_DRAIN_ENABLED ?? '').trim().toLowerCase());
     for (const s of smsInbound.rows) {
-      console.log(`QUIET_TICK_SMS_INBOUND=adam id=${s.id} from=${s.fromPhone} chairman=${s.isChairman} sig=${s.signatureValid} age=${s.ageMin}m body="${s.body}" — undrained chairman SMS; DRAIN+reply per CHAIRMAN SMS CHANNEL DUTY (node scripts/sms-relay-drain.cjs)`);
+      const detail = `id=${s.id} from=${s.fromPhone} chairman=${s.isChairman} sig=${s.signatureValid} age=${s.ageMin}m body="${s.body}"`;
+      if (!smsDrainEnabled) {
+        // Deliberately NOT a QUIET_TICK_* token — this line must not re-arm the interrupt.
+        console.log(`  sms-inbound (not interrupting) ${detail} — undrained, but SMS_RELAY_DRAIN_ENABLED is unset so scripts/sms-relay-drain.cjs is a no-op. Surfaced for visibility only. Durable fix: complete the SMS drain cutover.`);
+        continue;
+      }
+      console.log(`QUIET_TICK_SMS_INBOUND=adam ${detail} — undrained chairman SMS; DRAIN+reply per CHAIRMAN SMS CHANNEL DUTY (node scripts/sms-relay-drain.cjs)`);
     }
     for (const p of outboundSilence.probed) {
       console.log(`QUIET_TICK_OUTBOUND_PROBE=adam target=${p.target} row=${p.rowId}`);

--- a/tests/unit/qf834-sms-inbound-no-inert-interrupt.test.js
+++ b/tests/unit/qf834-sms-inbound-no-inert-interrupt.test.js
@@ -1,0 +1,67 @@
+// QF-20260808-834: stop hard-interrupting toward an INERT remediation.
+//
+// QUIET_TICK_* tokens ARE the interrupt — adam-startup-check allowlists them and reads a tick
+// carrying none as a NO-OP. QUIET_TICK_SMS_INBOUND points at scripts/sms-relay-drain.cjs, which is
+// a no-op while SMS_RELAY_DRAIN_ENABLED is unset. So every undrained row re-fired the interrupt on
+// every tick toward an action nobody could take, and a genuinely-new inbound hid behind the
+// permanent stale one.
+//
+// WHAT THIS SUITE PROVES, and what it does NOT. These are SOURCE pins on the emit site. The emit
+// lives inside a long tick function that reaches the network and the DB, so this does not execute
+// it. It proves the shipped source withholds the interrupt token when the flag is off and still
+// emits it when on — not that a live tick behaves that way. Saying so explicitly, because a suite
+// that cannot run the thing it describes must not be read as if it did.
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const raw = fs.readFileSync(path.join(process.cwd(), 'scripts/adam-quiet-tick.mjs'), 'utf8');
+// Strip comments: the source's own explanation names the token being pinned, and a scan that
+// matches its own commentary is the self-satisfying-test trap.
+const src = raw
+  .split('\n')
+  .filter((l) => {
+    const t = l.trim();
+    return !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*');
+  })
+  .join('\n');
+
+// The block from the flag read to the end of the emit loop.
+const block = src.slice(src.indexOf('const smsDrainEnabled'), src.indexOf('QUIET_TICK_OUTBOUND_PROBE'));
+
+describe('QF-834 SMS inbound interrupt is gated on the drain flag', () => {
+  it('reads SMS_RELAY_DRAIN_ENABLED at all (the file previously had ZERO references)', () => {
+    expect(src).toContain('SMS_RELAY_DRAIN_ENABLED');
+  });
+
+  it('withholds the interrupt when the drain is disabled', () => {
+    expect(block).toContain('if (!smsDrainEnabled)');
+    expect(block).toContain('continue;');
+  });
+
+  it('the not-interrupting branch emits NO QUIET_TICK_ token — it must not re-arm', () => {
+    // The whole point. If this branch carried any QUIET_TICK_* token it would be indistinguishable
+    // from the interrupt it replaces, and the fix would be cosmetic.
+    const quiet = block.slice(block.indexOf('if (!smsDrainEnabled)'), block.indexOf('continue;'));
+    expect(quiet.length).toBeGreaterThan(0);
+    expect(quiet).not.toContain('QUIET_TICK_');
+  });
+
+  it('STILL emits the interrupt when the drain IS enabled — two-sided', () => {
+    // A fix that removed the token unconditionally would pass every test above and silently
+    // disable the detector forever.
+    expect(block).toContain('QUIET_TICK_SMS_INBOUND=adam');
+  });
+
+  it('does NOT go dark: the disabled path still prints the row', () => {
+    // The ticket offered "skip entirely". A detector that goes fully dark on a CHAIRMAN SMS
+    // channel is a worse failure than the alert fatigue being fixed.
+    const quiet = block.slice(block.indexOf('if (!smsDrainEnabled)'), block.indexOf('continue;'));
+    expect(quiet).toContain('console.log');
+    expect(quiet).toContain('${detail}');
+  });
+
+  it('treats explicit falsey flag values as OFF, not just unset', () => {
+    expect(src).toContain("['', '0', 'false', 'off', 'no']");
+  });
+});


### PR DESCRIPTION
## Premise — verified, and it held

`adam-quiet-tick.mjs` had **zero** references to `SMS_RELAY_DRAIN_ENABLED`; `surfaceSmsInbound` (:481) queried undrained rows regardless, and the emit (:817) raised `QUIET_TICK_SMS_INBOUND` pointing at `scripts/sms-relay-drain.cjs`.

## Why it mattered

**`QUIET_TICK_*` tokens ARE the interrupt** — `adam-startup-check` allowlists them and reads a tick carrying none as a NO-OP. The drain is a no-op while the flag is unset. So every undrained row re-fired the interrupt **on every tick**, toward an action nobody could perform — and a genuinely-new inbound then hid behind the permanent stale one. Alert fatigue that masks exactly what the detector exists to catch.

## Downgrade, don't silence

The ticket offered *"skip entirely when the flag is off"* and **named the trade itself**: pre-cutover inbounds would not be surfaced at all.

A detector that goes fully dark on a **chairman SMS channel** is a worse failure than the alert fatigue being fixed. *"What state silences this alarm, and can anyone reach it?"* is the question that should stop a blanket skip.

So this withholds the **interrupt token** — the false promise of an actionable drain — while still printing the row. Visibility preserved; only the false call-to-action removed. The disabled-path line deliberately carries **no** `QUIET_TICK_` token, or it would be indistinguishable from the interrupt it replaces.

Flag parsing treats `''`, `'0'`, `'false'`, `'off'`, `'no'` as OFF — not just unset.

## Verification

6 source pins, two-sided. **2 mutations caught:**
1. the quiet branch re-arming the token
2. the detector silenced **unconditionally** — the failure a one-sided test would have shipped

Restores byte-identical. Module parses **and loads** under real `node`.

## Scope honesty

These are **source pins**. The emit lives inside a tick function that reaches the network and DB, so the suite does not execute it — it proves the shipped source gates the token, not that a live tick does. Stated so a green run isn't over-read.

The **durable** fix remains completing the SMS drain cutover (harness_backlog); this removes a false interrupt, it does not deliver the drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)