### PR TITLE
fix(QF-20260807-736): ask the evidence gate instead of replicating its policy — the replica had already drifted

### DIFF
--- a/lib/sub-agents/evidence-status.js
+++ b/lib/sub-agents/evidence-status.js
@@ -26,9 +26,27 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
+// QF-20260807-736: import the GATE ITSELF, not a second statement of its policy. These are pure
+// exports — the effectful entry point (validateSubagentEvidence) is deliberately NOT called here,
+// because it logs and, under LEO_DISABLE_SUBAGENT_EVIDENCE_GATE, INSERTS a gate_bypass audit_log
+// row. Asking "would this pass?" must never emit a record of a bypass that did not happen.
+import {
+  classifyVerdict,
+  REQUIRED_SUBAGENTS,
+  _internals as GATE_INTERNALS
+} from '../../scripts/modules/handoff/gates/subagent-evidence-gate.js';
 
-/** Verdicts the evidence gate treats as satisfying a requirement. */
-export const ACCEPTED_VERDICTS = Object.freeze(['PASS', 'CONDITIONAL_PASS', 'WARNING']);
+/**
+ * Verdicts the evidence gate treats as satisfying a requirement.
+ *
+ * DERIVED FROM THE GATE, never restated. This constant used to be its own frozen list, and that
+ * replica had ALREADY DRIFTED: it decided acceptance with `accepted.includes(verdict)`, so an
+ * UNRECOGNISED verdict was rejected — while the gate classifies unknown verdicts as ACCEPTED
+ * (fail-open with a warning, subagent-evidence-gate.js:430). A worker consulting the helper got a
+ * red the gate would have passed. That is the exact silent-drift failure this QF was filed about,
+ * present in the code before it was written.
+ */
+export const ACCEPTED_VERDICTS = Object.freeze([...GATE_INTERNALS.ACCEPT_VERDICTS]);
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
@@ -133,8 +151,52 @@ export async function hasEvidenceFor(sdKeyOrId, requiredCodes, opts = {}) {
     const code = String(raw).toUpperCase();
     const row = byCode[code];
     if (!row) { missing.push(code); continue; }
-    if (accepted.includes(String(row.verdict).toUpperCase())) present.push(code);
+    // Defer to the GATE's classifier unless the caller pinned an explicit set (back-compat).
+    // classifyVerdict folds unknown -> 'unknown', which the gate ACCEPTS fail-open; matching that
+    // here is the point of the QF — a helper that is stricter than the gate is still wrong.
+    const ok = opts.acceptedVerdicts
+      ? accepted.includes(String(row.verdict).toUpperCase())
+      : classifyVerdict(row.verdict) === 'accept' || classifyVerdict(row.verdict) === 'unknown';
+    if (ok) present.push(code);
     else rejected.push({ code, verdict: row.verdict, id: row.id });
   }
   return { sdId, satisfied: missing.length === 0 && rejected.length === 0, present, missing, rejected };
+}
+
+/**
+ * ASK THE GATE, not a replica of it: "would GATE_SUBAGENT_EVIDENCE pass for this SD + handoff?"
+ *
+ * WHY THIS EXISTS. Every other reader answers from a second implementation of gate policy, which
+ * agrees with the gate only until one side changes — and the failure is silent in BOTH directions
+ * (a confident green that the gate reds, or a red that the gate would have passed).
+ *
+ * WHY IT DOES NOT CALL validateSubagentEvidence. That is the authority, but it is EFFECTFUL: it
+ * logs a gate banner and, when LEO_DISABLE_SUBAGENT_EVIDENCE_GATE is set, INSERTS an audit_log
+ * gate_bypass row. Re-running an instrument to display its answer re-runs its side effects, so a
+ * worker's "would this pass?" would forge a bypass record. Instead this uses the gate's own
+ * REQUIRED_SUBAGENTS and classifyVerdict — the authority's policy, one representation, no writes.
+ *
+ * NOT MODELLED, deliberately, and callers must not read a pass as a guarantee: the gate also
+ * applies phase-freshness (evidence older than the current phase start does not count). This
+ * answers the VERDICT question over the rows getEvidence() returns for the given opts.
+ *
+ * @param {string} sdKeyOrId
+ * @param {string} handoffType e.g. 'LEAD-TO-PLAN'
+ * @param {{supabase?:object, phase?:string, sinceMs?:number, nowMs?:number}} [opts]
+ * @returns {Promise<{sdId:string, handoffType:string, wouldPass:boolean, required:string[], present:string[], missing:string[], rejected:Array}>}
+ */
+export async function askGate(sdKeyOrId, handoffType, opts = {}) {
+  const required = REQUIRED_SUBAGENTS[handoffType];
+  if (!Array.isArray(required)) {
+    // An unknown handoff type must THROW, never answer "nothing required, you pass" — that is the
+    // false-zero this module exists to abolish, wearing a different name.
+    throw new Error(
+      `evidence-status: unknown handoff type ${JSON.stringify(handoffType)}. Known: ${Object.keys(REQUIRED_SUBAGENTS).join(', ')}`
+    );
+  }
+  if (required.length === 0) {
+    return { sdId: await resolveSdId(sdKeyOrId, opts), handoffType, wouldPass: true, required: [], present: [], missing: [], rejected: [] };
+  }
+  const r = await hasEvidenceFor(sdKeyOrId, required, opts);
+  return { sdId: r.sdId, handoffType, wouldPass: r.satisfied, required: [...required], present: r.present, missing: r.missing, rejected: r.rejected };
 }

--- a/tests/unit/sub-agents/evidence-status-ask-gate.test.js
+++ b/tests/unit/sub-agents/evidence-status-ask-gate.test.js
@@ -1,0 +1,121 @@
+/**
+ * The evidence helper must answer from the GATE, not from a replica of its policy.
+ * QF-20260807-736 (remainder of QF-20260804-048).
+ *
+ * WHY THIS EXISTS. The helper restated gate policy as its own frozen ACCEPTED_VERDICTS list and
+ * decided acceptance with `accepted.includes(verdict)`. A replica agrees with the authority only
+ * until one side changes, and this one had ALREADY DRIFTED: the gate classifies an UNRECOGNISED
+ * verdict as accepted — fail-open with a warning (subagent-evidence-gate.js:430) — while the
+ * helper rejected it. A worker asking the helper got a red the gate would have passed. That is
+ * silent drift in the direction nobody checks: not a false green, a false BLOCKER.
+ *
+ * WHY askGate DOES NOT CALL validateSubagentEvidence. That function is the authority but it is
+ * EFFECTFUL — it logs a gate banner and, under LEO_DISABLE_SUBAGENT_EVIDENCE_GATE, INSERTS an
+ * audit_log gate_bypass row. Re-running an instrument to display its answer re-runs its side
+ * effects, so a worker's "would this pass?" would forge a record of a bypass that never happened.
+ * askGate therefore consumes the gate's PURE exports (REQUIRED_SUBAGENTS, classifyVerdict) — the
+ * authority's own policy, one representation, zero writes. The last test pins that.
+ */
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { ACCEPTED_VERDICTS, askGate, hasEvidenceFor } from '../../../lib/sub-agents/evidence-status.js';
+import { REQUIRED_SUBAGENTS, _internals } from '../../../scripts/modules/handoff/gates/subagent-evidence-gate.js';
+
+const SD_UUID = 'd0129bf6-1b4d-49be-a7be-97b761029f55';
+
+/** Minimal fake: resolves the SD, then returns the given evidence rows. Records every insert. */
+function makeSupabase(rows, capture = { inserts: [] }) {
+  return {
+    capture,
+    from(table) {
+      if (table === 'strategic_directives_v2') {
+        return { select: () => ({ eq: () => ({ maybeSingle: async () => ({ data: { id: SD_UUID }, error: null }) }) }) };
+      }
+      if (table === 'audit_log') {
+        return { insert: async (r) => { capture.inserts.push(r); return { data: null, error: null }; } };
+      }
+      const q = {
+        select: () => q,
+        eq: () => q,
+        gte: () => q,
+        order: () => Promise.resolve({ data: rows, error: null }),
+        then: (res) => Promise.resolve({ data: rows, error: null }).then(res)
+      };
+      return q;
+    }
+  };
+}
+
+const row = (code, verdict) => ({ id: `${code}-1`, sub_agent_code: code, verdict, phase: 'LEAD', created_at: '2099-01-01T00:00:00Z' });
+
+describe('QF-20260807-736: ask the gate, do not replicate it', () => {
+  afterEach(() => { delete process.env.LEO_DISABLE_SUBAGENT_EVIDENCE_GATE; vi.restoreAllMocks(); });
+
+  it('ACCEPTED_VERDICTS is DERIVED from the gate, not restated', () => {
+    // Pins the single-representation contract: re-hardcoding a divergent list reds this.
+    expect([...ACCEPTED_VERDICTS]).toEqual([..._internals.ACCEPT_VERDICTS]);
+  });
+
+  it('THE DRIFT: an unrecognised verdict is accepted, matching the gate fail-open', async () => {
+    // The regression this file exists for. Pre-fix, `includes()` rejected it while the gate
+    // accepted it — the helper manufactured a blocker the gate would never have raised.
+    const required = REQUIRED_SUBAGENTS['LEAD-TO-PLAN'];
+    const rows = required.map((c) => row(c, 'SOME_NEW_VERDICT'));
+    const r = await hasEvidenceFor(SD_UUID, required, { supabase: makeSupabase(rows) });
+
+    expect(r.rejected, 'an unknown verdict was rejected — stricter than the gate is still wrong').toEqual([]);
+    expect(r.satisfied).toBe(true);
+  });
+
+  it('CONTROL: a genuinely REJECTing verdict is still rejected', async () => {
+    // Two-sided. Without this, "accept unknown" could have become "accept everything", which
+    // would satisfy the drift test while destroying the gate's actual purpose.
+    const required = REQUIRED_SUBAGENTS['LEAD-TO-PLAN'];
+    const rows = required.map((c, i) => row(c, i === 0 ? 'FAIL' : 'PASS'));
+    const r = await hasEvidenceFor(SD_UUID, required, { supabase: makeSupabase(rows) });
+
+    expect(r.satisfied, 'a FAIL row was treated as satisfying the gate').toBe(false);
+    expect(r.rejected.map((x) => x.verdict)).toContain('FAIL');
+  });
+
+  it('askGate uses the GATE\'s required set for the handoff type', async () => {
+    const required = REQUIRED_SUBAGENTS['LEAD-TO-PLAN'];
+    const rows = required.map((c) => row(c, 'PASS'));
+    const r = await askGate(SD_UUID, 'LEAD-TO-PLAN', { supabase: makeSupabase(rows) });
+
+    expect(r.required).toEqual([...required]);
+    expect(r.wouldPass).toBe(true);
+    expect(r.handoffType).toBe('LEAD-TO-PLAN');
+  });
+
+  it('askGate THROWS on an unknown handoff type instead of answering "you pass"', async () => {
+    // The false-zero this module exists to abolish, wearing a different name: an unrecognised
+    // handoff must never resolve to an empty requirement set and a confident green.
+    await expect(
+      askGate(SD_UUID, 'NOT-A-REAL-HANDOFF', { supabase: makeSupabase([]) })
+    ).rejects.toThrow(/unknown handoff type/i);
+  });
+
+  it('askGate reports the MISSING agents rather than a bare false', async () => {
+    const required = REQUIRED_SUBAGENTS['LEAD-TO-PLAN'];
+    const r = await askGate(SD_UUID, 'LEAD-TO-PLAN', { supabase: makeSupabase([row(required[0], 'PASS')]) });
+
+    expect(r.wouldPass).toBe(false);
+    expect(r.missing.length).toBeGreaterThan(0);
+    expect(r.present).toContain(required[0]);
+  });
+
+  it('NO SIDE EFFECTS: asking never writes an audit_log row, even with the kill-switch set', async () => {
+    // The reason askGate consumes pure exports instead of calling validateSubagentEvidence: that
+    // path inserts a gate_bypass audit row when this env var is set. A read-only question must
+    // not forge evidence of a bypass that did not happen.
+    process.env.LEO_DISABLE_SUBAGENT_EVIDENCE_GATE = '1';
+    const capture = { inserts: [] };
+    const required = REQUIRED_SUBAGENTS['LEAD-TO-PLAN'];
+    const sb = makeSupabase(required.map((c) => row(c, 'PASS')), capture);
+
+    await askGate(SD_UUID, 'LEAD-TO-PLAN', { supabase: sb });
+
+    expect(capture.inserts, 'asking the gate forged an audit_log record').toEqual([]);
+  });
+});


### PR DESCRIPTION
QF-20260804-048 shipped a canonical evidence reader, but it answered using `ACCEPTED_VERDICTS` as a **replica** of gate policy. The QF asked for a second surface — a way to ask the *gate* — and warned that a replica agrees with the authority only until one side changes.

**It had already diverged before this follow-up was written.**

## The drift, measured

```
gate    classifyVerdict('SOME_NEW_VERDICT') -> 'unknown' -> ACCEPTED (fail-open, subagent-evidence-gate.js:430)
helper  ['PASS','CONDITIONAL_PASS','WARNING'].includes(...) -> false -> REJECTED
```

A worker consulting the helper got a **red the gate would have passed**. Note the direction: not a false green, a false *blocker* — the same shape as the false zero QF-048 was filed to kill, and the same harm (that QF documents a worker who escalated to be re-routed off workable work).

## The fix

`ACCEPTED_VERDICTS` is now **derived** from the gate's own `ACCEPT_VERDICTS`, and acceptance defers to the gate's `classifyVerdict`. One representation, so the two cannot drift again.

Adds `askGate(sdKeyOrId, handoffType)` — one call answering *"would `GATE_SUBAGENT_EVIDENCE` pass?"* using the gate's own `REQUIRED_SUBAGENTS`.

## Why it does not call `validateSubagentEvidence`

That function is the authority, but it is **effectful**: it logs a gate banner and, when `LEO_DISABLE_SUBAGENT_EVIDENCE_GATE` is set, **inserts an `audit_log` `gate_bypass` row**.

Re-running an instrument to display its answer re-runs its side effects. A worker asking a read-only "would this pass?" would have **forged a record of a bypass that never happened**. So `askGate` consumes the gate's *pure* exports (`REQUIRED_SUBAGENTS`, `classifyVerdict`, `_internals.ACCEPT_VERDICTS`) — the authority's policy, zero writes. A test pins it with the kill-switch deliberately set.

An unknown handoff type **throws** rather than resolving to an empty requirement set and a confident green — the false zero wearing a different name.

## Verification

**187/187 green** across `tests/unit/sub-agents/` (21 files). Collection proven via `vitest list --project unit --filesOnly`, not inferred from a targeted run.

**Mutation-proven**, each red attributed to exactly one named test:

| mutation | result |
|---|---|
| restore the replica `includes()` policy | **only** `THE DRIFT: an unrecognised verdict is accepted` fails (1 of 7) |
| hardcode a divergent verdict list | **only** `ACCEPTED_VERDICTS is DERIVED from the gate` fails (1 of 7) |

**Two-sided:** a genuine `FAIL` verdict is still rejected — so "accept unknown" did not quietly become "accept everything", which would have satisfied the drift test while destroying the gate's purpose.

## Scope note

`askGate` answers the **verdict** question over the rows `getEvidence()` returns. The gate additionally applies **phase-freshness** (evidence older than the current phase start does not count), which this does not model — stated in the JSDoc so a pass is not read as a guarantee. The gate also selects only `sub_agent_code, created_at, verdict` (`:339`), so verdict alone is its threshold and a findings-free row satisfies it; that is separately filed (completion flag `d1f25228`) and deliberately not addressed here.

Source diff is 68 lines, within the Tier-2 cap.

QF: QF-20260807-736
