### PR TITLE
fix(QF-20260807-761): stop TS-5 writing its violation fixture into the tree TS-6 scans

### DIFF
--- a/scripts/lint-repo-resolution-drift.mjs
+++ b/scripts/lint-repo-resolution-drift.mjs
@@ -64,8 +64,8 @@ const ALLOWLIST_EXACT = new Set([
 ]);
 const ALLOWLIST_PREFIXES = ['tests/'];
 
-function toRelPosix(absPath) {
-  return path.relative(REPO_ROOT, absPath).split(path.sep).join('/');
+function toRelPosix(absPath, root = REPO_ROOT) {
+  return path.relative(root, absPath).split(path.sep).join('/');
 }
 
 function isAllowlisted(relPath) {
@@ -124,8 +124,8 @@ function walk(node, visit, seen = new Set()) {
   }
 }
 
-function scanFile(absPath) {
-  const relPath = toRelPosix(absPath);
+function scanFile(absPath, root = REPO_ROOT) {
+  const relPath = toRelPosix(absPath, root);
   const findings = [];
   if (isAllowlisted(relPath)) return findings;
 
@@ -160,9 +160,22 @@ function scanFile(absPath) {
   return findings;
 }
 
-export function runLint() {
-  const files = SCAN_ROOTS.flatMap((root) => collectFiles(path.join(REPO_ROOT, root)));
-  const findings = files.flatMap(scanFile);
+/**
+ * Lint a tree for hardcoded platform-repo literals.
+ *
+ * QF-20260807-761: `repoRoot` is OPTIONAL and defaults to this repo, so the CI entry point and
+ * every existing caller are byte-identical. It exists so a TEST can lint a HERMETIC fixture tree
+ * instead of writing a violation into the real scripts/ directory — that fixture was shared disk,
+ * and a whole-repo scan running concurrently would see it and fail `findings === []`. The test was
+ * order-dependent inside the ONE required check, so the race could block unrelated merges at
+ * random. Isolation, not retries, is the fix: with a private root there is nothing to race.
+ *
+ * @param {{repoRoot?: string, scanRoots?: string[]}} [opts]
+ * @returns {{filesScanned: number, findings: Array<{file: string, line: number|string, value: string}>}}
+ */
+export function runLint({ repoRoot = REPO_ROOT, scanRoots = SCAN_ROOTS } = {}) {
+  const files = scanRoots.flatMap((root) => collectFiles(path.join(repoRoot, root)));
+  const findings = files.flatMap((absPath) => scanFile(absPath, repoRoot));
   return { filesScanned: files.length, findings };
 }
 

--- a/tests/unit/scripts/lint-repo-resolution-drift.test.js
+++ b/tests/unit/scripts/lint-repo-resolution-drift.test.js
@@ -1,14 +1,48 @@
 // SD-LEO-INFRA-CANONICAL-REPO-APP-001 FR-4 (TS-5, TS-6)
+//
+// QF-20260807-761 — WHY TS-5 NOW LINTS A TEMP TREE. TS-5 used to write its violation fixture into
+// the REAL scripts/ directory while TS-6 lints the WHOLE repo off the same disk. Whether TS-6 saw
+// that fixture depended on ordering and on any other worker touching the tree concurrently: it
+// failed combined, passed alone. The failing arm was `filesScanned > 0`, and it was RIGHT — it
+// fired on a genuine race. This file sits in the ONE required check, so an order-dependent test
+// here can block unrelated merges at random.
+//
+// The fix is ISOLATION, not a retry: TS-5 builds a private repo-shaped temp tree and lints THAT
+// via runLint({ repoRoot }), so no fixture is ever written into the scanned repo and there is
+// nothing left to race. TS-6 still scans the real repo with default arguments.
+//
+// THE VACUITY ARM IS DELIBERATELY PRESERVED (coordinator-flagged: preserve, do not delete). It is
+// the scanned-zero guard: without it, a scan that collected NO files would report `findings === []`
+// and read as a clean pass. It now also has a two-sided proof of its own at the bottom.
+
 import { describe, it, expect, afterAll } from 'vitest';
-import { writeFileSync, rmSync, existsSync } from 'node:fs';
+import { writeFileSync, rmSync, mkdtempSync, mkdirSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { runLint } from '../../../scripts/lint-repo-resolution-drift.mjs';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
-const FIXTURE_PATH = path.join(REPO_ROOT, 'scripts', '__lint_repo_resolution_drift_fixture__.mjs');
+const FIXTURE_REL = 'scripts/__lint_repo_resolution_drift_fixture__.mjs';
+
+/** A private repo-shaped tree: <tmp>/scripts/<fixture>. Never inside the scanned repo. */
+function withFixture(source) {
+  const root = mkdtempSync(path.join(os.tmpdir(), 'lint-repo-drift-'));
+  mkdirSync(path.join(root, 'scripts'), { recursive: true });
+  writeFileSync(path.join(root, FIXTURE_REL), source, 'utf8');
+  return root;
+}
+
+const TEMP_ROOTS = [];
+const lintFixture = (source) => {
+  const root = withFixture(source);
+  TEMP_ROOTS.push(root);
+  return runLint({ repoRoot: root });
+};
+
+afterAll(() => {
+  for (const root of TEMP_ROOTS) {
+    try { rmSync(root, { recursive: true, force: true }); } catch { /* best effort */ }
+  }
+});
 
 describe('lint-repo-resolution-drift', () => {
   it('TS-6: passes clean against the current repo state (no false-flags on allowlisted anchors)', () => {
@@ -18,36 +52,56 @@ describe('lint-repo-resolution-drift', () => {
   });
 
   describe('TS-5: detects a new violation outside the allowlist', () => {
-    afterAll(() => {
-      if (existsSync(FIXTURE_PATH)) rmSync(FIXTURE_PATH);
-    });
-
     it('flags a literal platform-repo string introduced in a new, non-allowlisted file', () => {
-      writeFileSync(FIXTURE_PATH, "export const OWNER_REPO = 'rickfelix/ehg';\n", 'utf8');
-      const { findings } = runLint();
-      const hit = findings.find((f) => f.file === 'scripts/__lint_repo_resolution_drift_fixture__.mjs');
+      const { findings } = lintFixture("export const OWNER_REPO = 'rickfelix/ehg';\n");
+      const hit = findings.find((f) => f.file === FIXTURE_REL);
       expect(hit).toBeDefined();
       expect(hit.value).toBe('rickfelix/ehg');
     });
 
     it('flags a fully-literal string concatenation forming the same value', () => {
-      writeFileSync(FIXTURE_PATH, "export const OWNER_REPO = 'rickfelix' + '/' + 'ehg_engineer';\n", 'utf8');
-      const { findings } = runLint();
-      const hit = findings.find((f) => f.file === 'scripts/__lint_repo_resolution_drift_fixture__.mjs');
+      const { findings } = lintFixture("export const OWNER_REPO = 'rickfelix' + '/' + 'ehg_engineer';\n");
+      const hit = findings.find((f) => f.file === FIXTURE_REL);
       expect(hit).toBeDefined();
       expect(hit.value).toBe('rickfelix/ehg_engineer');
     });
 
     it('does NOT flag a dynamic (non-literal) concatenation — value is not statically known', () => {
-      writeFileSync(FIXTURE_PATH, "export function buildRepo(name) { return 'rickfelix/' + name; }\n", 'utf8');
-      const { findings } = runLint();
-      const hit = findings.find((f) => f.file === 'scripts/__lint_repo_resolution_drift_fixture__.mjs');
-      expect(hit).toBeUndefined();
+      const { findings } = lintFixture("export function buildRepo(name) { return 'rickfelix/' + name; }\n");
+      expect(findings.find((f) => f.file === FIXTURE_REL)).toBeUndefined();
     });
   });
 
   it('does not flag literal platform-repo strings inside tests/** (allowlisted for fixtures/mocks)', () => {
     const { findings } = runLint();
     expect(findings.find((f) => f.file.startsWith('tests/'))).toBeUndefined();
+  });
+
+  describe('QF-20260807-761: the isolation and the vacuity guard', () => {
+    it('ORDER-INDEPENDENCE: a TS-5 fixture never reaches the repo scan, in either order', () => {
+      // The regression itself. Lint the real repo, run the fixture case, lint the real repo again:
+      // the fixture must be invisible to BOTH repo scans. Pre-fix, the fixture was written into
+      // scripts/ and the second scan would find it.
+      const before = runLint();
+      const fixture = lintFixture("export const OWNER_REPO = 'rickfelix/ehg';\n");
+      const after = runLint();
+
+      expect(fixture.findings.find((f) => f.file === FIXTURE_REL), 'the fixture tree must still be linted').toBeDefined();
+      expect(before.findings, 'repo scan before the fixture was not clean').toEqual([]);
+      expect(after.findings, 'the fixture leaked into the repo scan — the race is still live').toEqual([]);
+    });
+
+    it('VACUITY GUARD is two-sided: a scan collecting zero files is NOT a clean pass', () => {
+      // Preserved and now proven. An empty tree yields findings === [] — indistinguishable from a
+      // real pass on `findings` alone. filesScanned is the only thing that separates them, which
+      // is exactly why the arm that fired on the race must stay.
+      const empty = mkdtempSync(path.join(os.tmpdir(), 'lint-repo-drift-empty-'));
+      TEMP_ROOTS.push(empty);
+      const { filesScanned, findings } = runLint({ repoRoot: empty });
+
+      expect(findings, 'an empty scan reports no findings — the trap the guard exists for').toEqual([]);
+      expect(filesScanned, 'a scan of nothing must not look like a clean repo').toBe(0);
+      expect(runLint().filesScanned, 'the real repo must scan a non-zero file count').toBeGreaterThan(0);
+    });
   });
 });


### PR DESCRIPTION
`tests/unit/scripts/lint-repo-resolution-drift.test.js` was order-dependent, and it sits in the **one required check** — so the race could block unrelated merges at random.

TS-5 wrote `scripts/__lint_repo_resolution_drift_fixture__.mjs` into the **real repo** while TS-6 lints the **whole repo** off the same disk. Whether TS-6 saw it depended on ordering.

## Mechanism proven, not waited on

A flaky test is a bad thing to demonstrate by re-running until it flakes. The leak is deterministic once you look at it directly:

| state | repo scan findings |
|---|---|
| clean | **0** |
| fixture written into `scripts/` (old design) | **1** ← the race |
| after cleanup | **0** |
| hermetic root (new design) | fixture tree **1**, repo scan **0** |

The old design put the violation *inside the scanned tree by construction*. Any concurrent whole-repo scan fails `findings === []`.

## The fix is isolation, not a retry

`runLint()` now takes an **optional** `{repoRoot, scanRoots}`. Every existing caller and the CI entry point are byte-identical — verified: the CLI with no arguments still scans **10283 files** and passes.

TS-5 builds a private repo-shaped temp tree and lints *that*. No fixture is ever written into the scanned repo, so there is nothing left to race.

## The vacuity arm is preserved

Per the coordinator's explicit instruction — and it earned it: **it fired correctly on a genuine race**. It now carries a two-sided proof of its own:

- an empty tree yields `findings === []` — indistinguishable from a clean pass on `findings` alone
- `filesScanned === 0` is the only thing separating them

That is precisely the scanned-zero trap the guard exists for, so the test now proves the guard rather than just carrying it.

Also adds an **order-independence** test: repo scan → fixture case → repo scan, asserting the fixture is invisible to *both* repo scans while still being detected inside its own tree.

## Honest caveat

The very first run in the fresh worktree failed one test. It did **not** reproduce in 10 consecutive runs afterwards, no fixture was left on disk, and `git status` showed only the two intended edits. **Cause not established** — recorded rather than papered over, since an unexplained failure in the very test being de-flaked is exactly the thing worth flagging. The deterministic probe above is what demonstrates the fix; the passing streak is not the evidence.

## Verification

**536 passed / 16 skipped** across `tests/unit/scripts` (50 files). Collection proven via `vitest list --project unit --filesOnly`. CLI default path re-run and green.

QF: QF-20260807-761
