### PR TITLE
fix(QF-20260807-283): publish the evidence-writer contract instead of pointing at work the gate cannot see

### DIFF
--- a/scripts/modules/handoff/gates/subagent-evidence-gate.js
+++ b/scripts/modules/handoff/gates/subagent-evidence-gate.js
@@ -44,6 +44,29 @@ const RACE_WINDOW_SECONDS = 30;
 const ACCEPT_VERDICTS = new Set(['PASS', 'CONDITIONAL_PASS', 'WARNING']);
 
 /**
+ * QF-20260807-283 — PUBLISH THE CONTRACT, don't patch the Nth rediscovery.
+ *
+ * The old remediation said "invoke the missing sub-agent(s) via Task tool", which points at work
+ * THIS GATE CANNOT SEE: a Task-tool sub-agent does NOT write sub_agent_execution_results by
+ * itself. A worker who obeys that hint produces nothing the gate can read, re-runs, and is blocked
+ * identically — the hint actively costs a round trip. Measured, not theoretical: one seat burned
+ * two failed handoffs and a blocked tick rediscovering the real writers while precedent rows
+ * written the correct way already sat in the table, and a second seat had independently used the
+ * same writer hours earlier. Independent rediscoveries of one contract measure its
+ * DISCOVERABILITY, so the fix is to publish it at the moment of need rather than patch site N+1.
+ *
+ * Both writers are named WITH their applicability, because choosing the wrong one — not ignorance
+ * that a writer exists — is the actual failure mode. Single representation: every remediation
+ * string below interpolates THIS constant, so the contract cannot drift between sites.
+ */
+export const EVIDENCE_WRITER_CONTRACT =
+  'Evidence must reach sub_agent_execution_results — a Task-tool sub-agent alone does NOT write it. '
+  + 'Two canonical writers: (1) REGISTERED codes — `node scripts/execute-subagent.js --code <CODE> --sd-id <SD>`; '
+  + '(2) Task-tool runs and read-only built-ins — persist via `storeSubAgentResults` from '
+  + "lib/sub-agent-executor/results-storage.js with source='manual' "
+  + '(metadata.repo_path canonical + metadata.executed_from_cwd; there are no top-level repo_path/local_path columns).';
+
+/**
  * Verdicts that DO NOT satisfy a required sub-agent.
  *   FAIL            — the agent ran and rejected, or crashed and wrote an error row.
  *   BLOCKED         — the agent could not reach a verdict. NOT a pass.
@@ -561,7 +584,7 @@ export async function validateSubagentEvidence(ctx, supabase) {
       max_score: 100,
       wait_reason: `Sub-agent evidence not yet written for ${missing.join(', ')} (phase started <${RACE_WINDOW_SECONDS}s ago; agent may be mid-write)`,
       details: { reason: 'SUBAGENT_EVIDENCE_WRITE_LAG', race_window_seconds: RACE_WINDOW_SECONDS, ...sharedDetails },
-      remediation: `Re-check shortly; the required sub-agent(s) (${missing.join(', ')}) may still be writing to sub_agent_execution_results. If still missing after the race window, invoke them via the Task tool.`
+      remediation: `Re-check shortly; the required sub-agent(s) (${missing.join(', ')}) may still be writing to sub_agent_execution_results. If still missing after the race window: ${EVIDENCE_WRITER_CONTRACT}`
     });
   }
 
@@ -571,7 +594,7 @@ export async function validateSubagentEvidence(ctx, supabase) {
     max_score: 100,
     issues: [`SUBAGENT_EVIDENCE_MISSING: ${missing.join(', ')}`],
     details: { reason: 'SUBAGENT_EVIDENCE_MISSING', ...sharedDetails },
-    remediation: `Invoke the missing sub-agent(s) via Task tool for SD ${sdKey} before re-running the ${handoffType} handoff, OR set LEO_DISABLE_SUBAGENT_EVIDENCE_GATE=1 as an emergency bypass.`
+    remediation: `Produce evidence for ${missing.join(', ')} on SD ${sdKey}, then re-run the ${handoffType} handoff. ${EVIDENCE_WRITER_CONTRACT} Emergency bypass: LEO_DISABLE_SUBAGENT_EVIDENCE_GATE=1 (audit-logged).`
   });
 }
 
@@ -587,8 +610,9 @@ export function createSubagentEvidenceGate(supabase) {
     validator: async (ctx) => validateSubagentEvidence(ctx, supabase),
     required: true,
     remediation:
-      'Invoke the missing sub-agent(s) via Task tool for this SD before re-running the handoff. ' +
-      'Emergency bypass: LEO_DISABLE_SUBAGENT_EVIDENCE_GATE=1 (logs audit_log warning).'
+      'Produce evidence for the missing sub-agent(s) on this SD, then re-run the handoff. ' +
+      EVIDENCE_WRITER_CONTRACT +
+      ' Emergency bypass: LEO_DISABLE_SUBAGENT_EVIDENCE_GATE=1 (logs audit_log warning).'
   };
 }
 

--- a/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
+++ b/scripts/modules/handoff/pre-checks/prerequisite-preflight.js
@@ -167,7 +167,9 @@ export async function runPrerequisitePreflight(supabase, handoffType, sdId) {
     // an ordering speed-bump, not a quality catch). A WAIT verdict (evidence may
     // still be mid-write) is intentionally NOT treated as a preflight failure.
     try {
-      const { validateSubagentEvidence } = await import('../gates/subagent-evidence-gate.js');
+      // QF-20260807-283: pull the published contract from the GATE rather than restating it here —
+      // a second copy of the writer contract is the drift this QF exists to prevent.
+      const { validateSubagentEvidence, EVIDENCE_WRITER_CONTRACT } = await import('../gates/subagent-evidence-gate.js');
       const evidenceResult = await validateSubagentEvidence(
         { sd, handoffType: handoffType.toUpperCase(), supabase, sdId: sd.id },
         supabase
@@ -218,7 +220,12 @@ export async function runPrerequisitePreflight(supabase, handoffType, sdId) {
           issues.push({
             code: 'SUBAGENT_EVIDENCE_MISSING',
             message: `Missing sub-agent evidence for: ${missing.join(', ') || 'required agent(s)'}`,
-            remediation: evidenceResult.remediation || 'Invoke the missing sub-agent(s) via the Task tool before re-running the handoff.'
+            // QF-20260807-283: the bare fallback used to say "invoke via the Task tool", which
+            // names work the gate cannot see — a Task-tool agent alone writes no evidence row, so
+            // a worker who follows it is blocked identically on the next attempt. Fall back to the
+            // gate's published contract instead of a second, weaker statement of it.
+            remediation: evidenceResult.remediation
+              || `Produce evidence for the required sub-agent(s) before re-running the handoff. ${EVIDENCE_WRITER_CONTRACT}`
           });
         }
       }

--- a/tests/unit/handoff/subagent-evidence-writer-contract.test.js
+++ b/tests/unit/handoff/subagent-evidence-writer-contract.test.js
@@ -1,0 +1,64 @@
+/**
+ * The evidence gate must PUBLISH the writer contract, not point at work it cannot see.
+ * QF-20260807-283.
+ *
+ * THE DEFECT. Every remediation said "invoke the missing sub-agent(s) via Task tool". A Task-tool
+ * sub-agent does NOT write sub_agent_execution_results by itself, so a worker who obeys that hint
+ * produces nothing the gate can read, re-runs, and is blocked identically — the hint costs a round
+ * trip rather than saving one. Measured: one seat burned two failed handoffs and a blocked tick
+ * rediscovering the real writers while precedent rows written the correct way already sat in the
+ * table, and a second seat had independently used the same writer hours earlier.
+ *
+ * WHY IT IS A CONTRACT TEST AND NOT A WORDING TEST. Independent rediscoveries of one contract
+ * measure its DISCOVERABILITY; the fix is to publish it at the moment of need. So what must hold
+ * is that BOTH writers are named WITH their applicability — choosing the wrong one, not ignorance
+ * that a writer exists, is the actual failure mode — and that the misleading Task-tool-only hint
+ * is gone from the blocking paths.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  EVIDENCE_WRITER_CONTRACT,
+  createSubagentEvidenceGate
+} from '../../../scripts/modules/handoff/gates/subagent-evidence-gate.js';
+
+describe('QF-20260807-283: the evidence gate publishes its writer contract', () => {
+  it('names BOTH canonical writers, each with its applicability', () => {
+    // Both halves required. A message naming only one writer sends every worker in the other
+    // situation down the path that produces invisible work.
+    expect(EVIDENCE_WRITER_CONTRACT).toMatch(/scripts\/execute-subagent\.js/);
+    expect(EVIDENCE_WRITER_CONTRACT).toMatch(/REGISTERED/i);
+    expect(EVIDENCE_WRITER_CONTRACT).toMatch(/storeSubAgentResults/);
+    expect(EVIDENCE_WRITER_CONTRACT).toMatch(/results-storage\.js/);
+  });
+
+  it('states plainly that a Task-tool agent alone writes NO evidence row', () => {
+    // The correction that actually saves the round trip: the old hint was not merely vague, it
+    // was wrong about what produces a row.
+    expect(EVIDENCE_WRITER_CONTRACT).toMatch(/Task-tool sub-agent alone does NOT write/i);
+    expect(EVIDENCE_WRITER_CONTRACT).toMatch(/sub_agent_execution_results/);
+  });
+
+  it('carries the metadata shape that the repo-resolution gate actually reads', () => {
+    // Folklore said to store top-level repo_path/local_path; following it produces evidence the
+    // gate cannot read. Naming the real shape here is the difference between a worker writing a
+    // row and writing a malformed one.
+    expect(EVIDENCE_WRITER_CONTRACT).toMatch(/metadata\.repo_path/);
+    expect(EVIDENCE_WRITER_CONTRACT).toMatch(/executed_from_cwd/);
+  });
+
+  it('the registered gate definition SURFACES the contract, not a Task-tool-only hint', () => {
+    // The contract is worthless if the string a blocked worker actually sees does not contain it.
+    const gate = createSubagentEvidenceGate({});
+    expect(gate.remediation).toContain(EVIDENCE_WRITER_CONTRACT);
+    expect(gate.remediation).not.toMatch(/Invoke the missing sub-agent\(s\) via Task tool/);
+  });
+
+  it('CONTROL: the emergency bypass is still documented and still called a bypass', () => {
+    // Two-sided. Rewriting the remediation could easily have dropped the escape hatch, or worse,
+    // promoted it from "emergency bypass" to an ordinary-looking option.
+    const gate = createSubagentEvidenceGate({});
+    expect(gate.remediation).toMatch(/LEO_DISABLE_SUBAGENT_EVIDENCE_GATE=1/);
+    expect(gate.remediation).toMatch(/bypass/i);
+  });
+});


### PR DESCRIPTION
Every `SUBAGENT_EVIDENCE_MISSING` remediation said **"invoke the missing sub-agent(s) via Task tool"**.

A Task-tool sub-agent does **not** write `sub_agent_execution_results` by itself. So a worker who obeys that hint produces nothing the gate can read, re-runs, and is blocked identically — **the hint costs a round trip rather than saving one.**

## Why publish rather than patch

Measured, not theoretical: one seat burned two failed handoffs and a blocked tick rediscovering the real writers **while precedent rows written the correct way already sat in the table**, and a second seat had independently used the same writer hours earlier.

Independent rediscoveries of one contract measure its **discoverability**. Five sites rebuilding the same contract from error text is the signal to publish it at the moment of need, not to patch site N+1.

## What the message now says

`EVIDENCE_WRITER_CONTRACT` names **both** writers *with their applicability* — because picking the wrong one, not ignorance that a writer exists, is the actual failure mode:

1. **Registered codes** → `node scripts/execute-subagent.js --code <CODE> --sd-id <SD>`
2. **Task-tool runs and read-only built-ins** → `storeSubAgentResults` from `lib/sub-agent-executor/results-storage.js` with `source='manual'`

It also carries the metadata shape the repo-resolution gate actually reads — `metadata.repo_path` + `executed_from_cwd`, and explicitly that there are **no** top-level `repo_path`/`local_path` columns. Folklore about those columns produces evidence the gate cannot read, so a worker following the hint would still write a malformed row.

## Single representation

All four remediation sites interpolate the one exported constant: the race-window WAIT, the blocking FAIL, the registered gate definition, and the `prerequisite-preflight` fallback.

The preflight pulls it from the gate's own module rather than restating it — **a second copy of the contract is exactly the drift this QF exists to prevent.**

## Verification

**867 passed / 1 skipped** across `tests/unit/handoff` (90 files). Collection proven via `vitest list --project unit --filesOnly`.

**Mutation-proven**, each red attributed to exactly one named test:

| mutation | result |
|---|---|
| restore the Task-tool-only hint | **only** `the registered gate definition SURFACES the contract` fails (1 of 5) |
| drop the second writer from the contract | **only** `names BOTH canonical writers` fails (1 of 5) |

**Two-sided:** a control pins that the emergency bypass is still documented *and* still called a bypass. Rewriting remediation text could easily have dropped the escape hatch — or worse, promoted it from "emergency bypass" to an ordinary-looking option.

QF: QF-20260807-283
