### PR TITLE
fix(QF-20260807-690): the fixture-sweep flag gate discarded its query error — a broken query quiet-no-opped the whole sweep

### DIFF
--- a/.github/workflows/venture-fixture-sweep.yml
+++ b/.github/workflows/venture-fixture-sweep.yml
@@ -61,11 +61,21 @@ jobs:
           import { createClient } from '@supabase/supabase-js';
           import fs from 'node:fs';
           const sb = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
-          const { data } = await sb
+          const { data, error } = await sb
             .from('leo_feature_flags')
             .select('is_enabled')
             .eq('flag_key', 'VENTURE_FIXTURE_SWEEP_V1')
             .maybeSingle();
+          // QF-20260807-690: the error used to be DISCARDED, so a broken query quiet-no-opped the
+          // entire sweep. Measured against the live table: an ABSENT flag row returns
+          // {data:null, error:null} while a BAD COLUMN returns {data:null, error:"column ... does
+          // not exist"} — identical `data`, so `error` is the ONLY thing separating "flag is off"
+          // from "I could not read the flag". Discarding it collapsed those into one silent
+          // no-op. Fail LOUD here; an empty result is still legitimately quiet below.
+          if (error) {
+            console.error(`FATAL: VENTURE_FIXTURE_SWEEP_V1 flag query failed — cannot distinguish "flag disabled" from "cannot read the flag": ${error.message}`);
+            process.exit(1);
+          }
           const enabled = data?.is_enabled === true;
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `enabled=${enabled}\n`);
           console.log(enabled

--- a/tests/unit/workflows/venture-fixture-sweep-flag-error.test.js
+++ b/tests/unit/workflows/venture-fixture-sweep-flag-error.test.js
@@ -1,0 +1,85 @@
+/**
+ * The fixture-sweep feature-flag gate must fail LOUD on a query error.
+ * QF-20260807-690.
+ *
+ * THE DEFECT. The gate destructured only `data` and threw the error away, so a broken query
+ * produced `enabled=false` and the ENTIRE sweep quiet-no-opped. Measured against the live table,
+ * which is what makes this a real trap rather than a style nit:
+ *
+ *   absent flag row  -> { data: null, error: null }
+ *   bad column       -> { data: null, error: 'column ... does not exist' }
+ *
+ * IDENTICAL `data`. So `error` is the ONLY thing separating "the flag is off" from "I could not
+ * read the flag", and discarding it collapses those two into one silent no-op — the guard cannot
+ * distinguish nothing-to-do from cannot-see.
+ *
+ * WHY THESE ASSERTIONS ARE STRUCTURAL, NOT GREPS. "contains process.exit(1)" would pass even if
+ * the exit sat on the EMPTY path, which would break the legitimate quiet no-op — the opposite
+ * defect. So the test extracts the embedded script from the YAML and proves the exit lives INSIDE
+ * the `if (error)` block and nowhere else.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import yaml from 'js-yaml';
+
+const WORKFLOW = path.resolve(process.cwd(), '.github/workflows/venture-fixture-sweep.yml');
+
+function gateScript() {
+  const doc = yaml.load(readFileSync(WORKFLOW, 'utf8'));
+  const steps = doc.jobs['fixture-sweep'].steps;
+  const gate = steps.find((s) => s.id === 'gate');
+  if (!gate) throw new Error('gate step not found — the workflow shape changed');
+  const m = gate.run.match(/<<'EOF'\n([\s\S]*?)\nEOF/);
+  if (!m) throw new Error('embedded heredoc script not found in the gate step');
+  return m[1];
+}
+
+describe('QF-20260807-690: the flag gate distinguishes "off" from "cannot read"', () => {
+  it('the workflow still parses and the gate step still exists', () => {
+    // Guards the extraction itself: every assertion below is vacuous if the shape moved.
+    const doc = yaml.load(readFileSync(WORKFLOW, 'utf8'));
+    expect(doc.jobs['fixture-sweep']).toBeTruthy();
+    expect(doc.jobs['fixture-sweep'].steps.some((s) => s.id === 'gate')).toBe(true);
+  });
+
+  it('destructures error from the flag query rather than discarding it', () => {
+    expect(gateScript()).toMatch(/const\s*\{\s*data\s*,\s*error\s*\}\s*=\s*await\s+sb/);
+  });
+
+  it('exits non-zero on a query error, naming the underlying message', () => {
+    const src = gateScript();
+    expect(src).toMatch(/if\s*\(error\)\s*\{/);
+    expect(src).toMatch(/error\.message/);
+    expect(src).toMatch(/process\.exit\(1\)/);
+  });
+
+  it('the exit lives ONLY inside the error branch — an empty result must stay a quiet no-op', () => {
+    // THE two-sided arm. Failing loud on a legitimately-absent flag row would be the mirror-image
+    // defect: a sweep that cannot be disabled. Locate the if(error) block by brace matching and
+    // prove every process.exit sits within it.
+    const src = gateScript();
+    const start = src.indexOf('if (error) {');
+    expect(start, 'no if (error) block to bound').toBeGreaterThan(-1);
+
+    let depth = 0;
+    let end = -1;
+    for (let i = src.indexOf('{', start); i < src.length; i++) {
+      if (src[i] === '{') depth++;
+      else if (src[i] === '}') { depth--; if (depth === 0) { end = i; break; } }
+    }
+    expect(end, 'unbalanced braces in the error branch').toBeGreaterThan(start);
+
+    const exits = [...src.matchAll(/process\.exit\(/g)].map((m) => m.index);
+    expect(exits.length, 'expected at least one exit').toBeGreaterThan(0);
+    for (const at of exits) {
+      expect(at > start && at < end, `a process.exit at ${at} sits OUTSIDE the error branch`).toBe(true);
+    }
+  });
+
+  it('CONTROL: the enabled computation still treats an absent row as simply disabled', () => {
+    // Absent row is {data:null, error:null} — it must fall through to enabled=false, not throw.
+    expect(gateScript()).toMatch(/const\s+enabled\s*=\s*data\?\.is_enabled\s*===\s*true/);
+  });
+});


### PR DESCRIPTION
The feature-flag gate destructured only `data` and threw the error away. A broken query therefore produced `enabled=false` and the **entire sweep silently did nothing** — a guard that cannot distinguish *nothing-to-do* from *cannot-see*.

## Measured against the live table

This is what makes it a real trap rather than a style nit:

| case | result |
|---|---|
| absent flag row | `{ data: null, error: null }` |
| bad column | `{ data: null, error: 'column ... does not exist' }` |

**Identical `data`.** So `error` is the *only* thing separating "the flag is off" from "I could not read the flag" — and discarding it collapsed both into one silent no-op.

Now the error branch exits non-zero naming the underlying message, while a legitimately absent flag row still falls through to `enabled=false` and stays quiet. Empty is not an error.

## The tests are structural, not greps

`expect(src).toContain('process.exit(1)')` would pass **even if the exit sat on the empty path** — which would break the legitimate quiet no-op, i.e. a sweep that can no longer be disabled. That is the mirror-image defect and the easy one to ship by accident.

So the test extracts the embedded script out of the YAML and **brace-matches the `if (error)` block**, asserting every `process.exit` lives inside it.

## Mutation proof

| mutation | result |
|---|---|
| discard the error again | **only** `destructures error from the flag query` fails (1 of 5) |
| move the exit onto `!enabled` | **only** `the exit lives ONLY inside the error branch` fails (1 of 5) |

The second mutation is the one that earns the structural approach — it is **green under a naive grep test**.

## Also verified

- The workflow still parses (`js-yaml`) and the `gate` step still exists — every assertion above is vacuous if that shape moved, so it is checked explicitly.
- The extracted script passes `node --check`, with the exit code read directly rather than through a pipe.
- Only one query site exists in this workflow, so there are no sibling discarded-error cases left behind.

## Diff hygiene

The diff is **11 insertions / 1 deletion**. An intermediate edit pass had rewritten all 122 lines as CRLF; that was caught by noticing a 234-line diffstat on a ten-line change, and normalized back to LF so the diff is the change and nothing else.

**13/13 green** in `tests/unit/workflows`. Collection proven via `vitest list --project unit --filesOnly`.

QF: QF-20260807-690
