### PR TITLE
feat(SD-LEO-INFRA-WORKER-REACHABLE-ACK-001): a reachable ack verb for the advisory lane, and a refusal that reads as a refusal

### DIFF
--- a/lib/checkin/steps/idle.cjs
+++ b/lib/checkin/steps/idle.cjs
@@ -66,7 +66,12 @@ module.exports = {
         const summary = pending.map((d) => (d.payload && d.payload.kind) || d.message_type).join(', ');
         directiveNote = ` PENDING DIRECTIVE${pending.length > 1 ? 'S' : ''} (${pending.length}): ${summary}`
           + ' — READ AND ACTION THEM NOW. You hold no claim, so nothing is competing with them.'
-          + ' Ack a coordinator_directive with: node scripts/worker-ack-directive.cjs --id <id>.';
+          // SD-LEO-INFRA-WORKER-REACHABLE-ACK-001: name BOTH lanes. Naming only the directive verb
+          // is why advisory rows piled up — a worker who tried it on a coordinator_reply got a
+          // (correct) refusal and had nowhere else to go, so rulings sat unacked until a later
+          // /checkin drained them. A verb nobody is told about is not reachable in practice.
+          + ' Ack a coordinator_directive with: node scripts/worker-ack-directive.cjs --id <id>.'
+          + ' Ack a coordinator_reply / completion_nudge with: node scripts/worker-ack-advisory.cjs --id <id>.';
       }
     } catch { /* fail-open: no directive surfacing */ }
     // 7. idle -> recommend a wakeup (ScheduleWakeup is a HARNESS tool, not Node-callable)

--- a/lib/checkin/steps/resume.cjs
+++ b/lib/checkin/steps/resume.cjs
@@ -200,7 +200,7 @@ module.exports = {
         }
         if (pendingDirectives.length) {
           const summary = pendingDirectives.map(d => d.kind).join(', ');
-          resumeMessage = `${resumeMessage} PENDING DIRECTIVE${pendingDirectives.length > 1 ? 'S' : ''} (${pendingDirectives.length}): ${summary} — read and action them now; they do NOT require dropping ${ctx.mySd}. Ack a coordinator_directive with: node scripts/worker-ack-directive.cjs --id <id>.`;
+          resumeMessage = `${resumeMessage} PENDING DIRECTIVE${pendingDirectives.length > 1 ? 'S' : ''} (${pendingDirectives.length}): ${summary} — read and action them now; they do NOT require dropping ${ctx.mySd}. Ack a coordinator_directive with: node scripts/worker-ack-directive.cjs --id <id>; ack a coordinator_reply / completion_nudge with: node scripts/worker-ack-advisory.cjs --id <id> (SD-LEO-INFRA-WORKER-REACHABLE-ACK-001 — the advisory lane has its own verb; the directive path correctly refuses those kinds).`;
         }
         return { ...ctx.base, action: 'resume', sd: ctx.mySd,
           ...(pendingAssignment ? { pending_work_assignment: pendingAssignment } : {}),

--- a/lib/fleet/worker-status.cjs
+++ b/lib/fleet/worker-status.cjs
@@ -154,6 +154,25 @@ const DIRECTIVE_KINDS = Object.freeze([
   'review_request',
 ]);
 
+// SD-LEO-INFRA-WORKER-REACHABLE-ACK-001 / FR-2: the ADVISORY lane — kinds that are NOT
+// directives and must NEVER be added to DIRECTIVE_KINDS above.
+//
+// WHY THIS LIST EXISTS AS ITS OWN THING. worker-ack-directive.cjs correctly refuses these
+// ("this path is reserved for genuine directives, never advisory rows"), and that refusal is
+// deliberate — it is not the bug. The bug was that a worker then had NO way at all to
+// acknowledge a coordinator RULING: the row sat unacknowledged until some later /checkin
+// happened to drain it, so the coordinator could not distinguish "read and actioned" from
+// "never reached". The fix is a SEPARATE reachable verb for this lane, not a widened
+// directive allow-list — deriving this as "everything not in DIRECTIVE_KINDS" would silently
+// enrol every future kind by default, which is the exclusion-set trap.
+//
+// Deliver-not-consume is UNAFFECTED: that is keyed on DIRECTIVE_KINDS in
+// scripts/hooks/coordination-inbox.cjs and read_at stays NULL for those rows.
+const ADVISORY_KINDS = Object.freeze([
+  'coordinator_reply',
+  'completion_nudge',
+]);
+
 // Kinds that must NEVER be starved out of coordination-inbox.cjs's oldest-N row cap —
 // a subset of DIRECTIVE_KINDS whose urgency requires priority-exempt selection, not just
 // deliver-not-consume semantics. Kept as its own list (not "all of DIRECTIVE_KINDS") so
@@ -462,6 +481,7 @@ module.exports = {
   PAYLOAD_KINDS,
   FRAMING_CLASSES,
   DIRECTIVE_KINDS,
+  ADVISORY_KINDS,
   PRIORITY_EXEMPT_DIRECTIVE_KINDS,
   ADAM_EXCLUDED_KINDS,
   DRAIN_SETS,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "LEO Protocol development environment with Claude Code multi-agent workflow support",
   "type": "module",
   "scripts": {
+    "ack:advisory": "node scripts/worker-ack-advisory.cjs",
     "schema:snapshot:prd": "node scripts/snapshot-prd-schema.js",
     "schema:check-drift": "node scripts/snapshot-prd-schema.js --check-drift",
     "migration:apply": "node scripts/apply-migration.js",

--- a/scripts/worker-ack-advisory.cjs
+++ b/scripts/worker-ack-advisory.cjs
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+/**
+ * Worker-side ACK of an ADVISORY row — SD-LEO-INFRA-WORKER-REACHABLE-ACK-001 / FR-2.
+ *
+ * THE GAP THIS CLOSES. A coordinator RULING arrives as payload.kind='coordinator_reply', which is
+ * deliberately NOT a DIRECTIVE_KIND — scripts/worker-ack-directive.cjs refuses it, correctly, with
+ * "this path is reserved for genuine directives, never advisory rows". But that left a worker with
+ * NO way to acknowledge a ruling at all: the row stayed unacknowledged until some later /checkin
+ * happened to drain it, so the coordinator could not tell "read and actioned" from "never
+ * reached". Measured repeatedly in one session — rulings sat unacked for hours while the worker
+ * had already acted on them.
+ *
+ * WHY A SEPARATE VERB RATHER THAN A WIDER ALLOW-LIST. Adding coordinator_reply to DIRECTIVE_KINDS
+ * would have been the small edit, and it would have been wrong: DIRECTIVE_KINDS also drives
+ * deliver-not-consume (read_at stays NULL) in scripts/hooks/coordination-inbox.cjs and
+ * priority-exempt selection. Widening it to buy an ack verb changes semantics the ack has nothing
+ * to do with. The lanes stay separate; only the allow-list differs.
+ *
+ * The row is stamped by the SAME shared core as the directive path (ackRow), so the two verbs
+ * cannot drift.
+ *
+ * Usage:
+ *   node scripts/worker-ack-advisory.cjs --id <message_id> [--note "<text>"]
+ */
+'use strict';
+
+const { getServiceClient } = require('../lib/fleet/worker-status.cjs');
+const { ackAdvisory } = require('./worker-ack-directive.cjs');
+
+function argVal(argv, flag) {
+  const i = argv.indexOf(flag);
+  return i >= 0 && i + 1 < argv.length ? argv[i + 1] : null;
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const id = argVal(argv, '--id');
+  const note = argVal(argv, '--note');
+  // An explicit id is REQUIRED — never a silently-resolved "newest unacked row", which is the
+  // defect QF-20260727-454 pinned across every sanctioned ack path (acking a row before it was
+  // read, because recency was used as a proxy for identity).
+  if (!id) {
+    console.error('Usage: node scripts/worker-ack-advisory.cjs --id <message_id> [--note "<text>"]');
+    // FR-1: exitCode, not exit() — process.exit() here aborts on Windows with
+    // "Assertion failed: !(handle->flags & UV_HANDLE_CLOSING)" and the shell reads 127
+    // (command-not-found), making a deliberate refusal indistinguishable from a missing binary.
+    process.exitCode = 2;
+    return;
+  }
+
+  const supabase = getServiceClient();
+  try {
+    const result = await ackAdvisory(supabase, id, { note, sessionId: process.env.CLAUDE_SESSION_ID || null });
+    if (result.alreadyAcked) {
+      console.log(`worker-ack-advisory: id=${id} already acknowledged at ${result.acknowledgedAt} (idempotent no-op).`);
+    } else {
+      console.log(`✓ advisory acknowledged: id=${id} kind=${result.kind} actioned_at=${result.acknowledgedAt}`);
+    }
+  } catch (e) {
+    console.error(`worker-ack-advisory: ${(e && e.message) || e}`);
+    process.exitCode = 1;
+  }
+}
+
+module.exports = { main };
+
+if (require.main === module) {
+  main();
+}

--- a/scripts/worker-ack-directive.cjs
+++ b/scripts/worker-ack-directive.cjs
@@ -17,14 +17,25 @@
  */
 'use strict';
 
-const { getServiceClient, DIRECTIVE_KINDS } = require('../lib/fleet/worker-status.cjs');
+const { getServiceClient, DIRECTIVE_KINDS, ADVISORY_KINDS } = require('../lib/fleet/worker-status.cjs');
 
 function argVal(argv, flag) {
   const i = argv.indexOf(flag);
   return i >= 0 && i + 1 < argv.length ? argv[i + 1] : null;
 }
 
-async function ackDirective(supabase, id, { note = null, sessionId = null } = {}) {
+/**
+ * Shared ack core — SD-LEO-INFRA-WORKER-REACHABLE-ACK-001 / FR-2.
+ *
+ * Both lanes stamp the SAME row the SAME way; only the ALLOWED KINDS differ. Extracted so the
+ * advisory verb cannot drift from the directive one, and so the lane allow-list stays the single
+ * thing that distinguishes them — never a second copy of the read/update logic.
+ *
+ * @param {Object} supabase
+ * @param {string} id
+ * @param {{allowedKinds: string[], laneLabel: string, refusalCode: string, note?: string, sessionId?: string}} opts
+ */
+async function ackRow(supabase, id, { allowedKinds, laneLabel, refusalCode, note = null, sessionId = null }) {
   const { data: row, error: readError } = await supabase
     .from('session_coordination')
     .select('id, payload, target_session, acknowledged_at')
@@ -35,10 +46,10 @@ async function ackDirective(supabase, id, { note = null, sessionId = null } = {}
   }
 
   const kind = row.payload && row.payload.kind;
-  if (!kind || !DIRECTIVE_KINDS.includes(kind)) {
+  if (!kind || !allowedKinds.includes(kind)) {
     throw Object.assign(
-      new Error(`refusing to ack — payload.kind='${kind}' is not a DIRECTIVE_KIND (this path is reserved for genuine directives, never advisory rows)`),
-      { code: 'NOT_A_DIRECTIVE' }
+      new Error(`refusing to ack — payload.kind='${kind}' is not a ${laneLabel} (this path is reserved for genuine ${laneLabel === 'DIRECTIVE_KIND' ? 'directives, never advisory rows' : 'advisory rows, never directives'})`),
+      { code: refusalCode }
     );
   }
   if (sessionId && row.target_session && row.target_session !== sessionId) {
@@ -64,13 +75,49 @@ async function ackDirective(supabase, id, { note = null, sessionId = null } = {}
   return { alreadyAcked: false, acknowledgedAt: actionedAt, kind };
 }
 
+/**
+ * DIRECTIVE lane. Behaviour is byte-for-byte what it always was: only DIRECTIVE_KINDS are
+ * acked here, and an advisory row is still refused. That refusal is correct and deliberate —
+ * see ADVISORY_KINDS in lib/fleet/worker-status.cjs for the lane that now has its own verb.
+ */
+async function ackDirective(supabase, id, opts = {}) {
+  return ackRow(supabase, id, {
+    ...opts,
+    allowedKinds: DIRECTIVE_KINDS,
+    laneLabel: 'DIRECTIVE_KIND',
+    refusalCode: 'NOT_A_DIRECTIVE',
+  });
+}
+
+/**
+ * ADVISORY lane (coordinator_reply / completion_nudge) — SD-LEO-INFRA-WORKER-REACHABLE-ACK-001.
+ * Deliberately a SEPARATE entry point rather than a widened DIRECTIVE_KINDS: a coordinator ruling
+ * had no worker-reachable ack at all, so it lingered until some later /checkin drained it.
+ */
+async function ackAdvisory(supabase, id, opts = {}) {
+  return ackRow(supabase, id, {
+    ...opts,
+    allowedKinds: ADVISORY_KINDS,
+    laneLabel: 'ADVISORY_KIND',
+    refusalCode: 'NOT_AN_ADVISORY',
+  });
+}
+
 async function main() {
   const argv = process.argv.slice(2);
   const id = argVal(argv, '--id');
   const note = argVal(argv, '--note');
   if (!id) {
     console.error('Usage: node scripts/worker-ack-directive.cjs --id <message_id> [--note "<text>"]');
-    process.exit(2);
+    // SD-LEO-INFRA-WORKER-REACHABLE-ACK-001 / FR-1: process.exitCode, NOT process.exit().
+    // MEASURED: process.exit() here fires before startup's async handles settle and the process
+    // ABORTS — "Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), src/win/async.c:76" — so
+    // the shell saw 127, which is command-not-found. A deliberate refusal was therefore
+    // indistinguishable from a missing binary, and every caller branching on the code mis-read it.
+    // Setting exitCode lets the loop drain and the intended code actually reach the caller. Same
+    // fix, same reason, as scripts/execute-subagent.js.
+    process.exitCode = 2;
+    return;
   }
 
   const supabase = getServiceClient();
@@ -83,11 +130,12 @@ async function main() {
     }
   } catch (e) {
     console.error(`worker-ack-directive: ${(e && e.message) || e}`);
-    process.exit(1);
+    // FR-1: exitCode, not exit() — see the note above. A refusal must read as a refusal.
+    process.exitCode = 1;
   }
 }
 
-module.exports = { ackDirective };
+module.exports = { ackDirective, ackAdvisory, ackRow };
 
 if (require.main === module) {
   main();

--- a/tests/unit/coordination/ack-paths-explicit-id-source-pins.test.js
+++ b/tests/unit/coordination/ack-paths-explicit-id-source-pins.test.js
@@ -21,6 +21,10 @@ const read = (rel) => readFileSync(path.join(REPO_ROOT, rel), 'utf8');
 
 const ACK_PATHS = [
   'scripts/worker-ack-directive.cjs',
+  // SD-LEO-INFRA-WORKER-REACHABLE-ACK-001 / FR-2: the advisory lane's own verb is a NEW sanctioned
+  // ack surface, so it joins this pin rather than sitting outside it — the whole point of this
+  // file is that the guarantee covers the entire surface, not a subset that happens to be listed.
+  'scripts/worker-ack-advisory.cjs',
   'scripts/coordinator-ack-adam.cjs',
   'scripts/coordinator-ack-signal.cjs',
   'scripts/ack-chairman-directive.cjs',

--- a/tests/unit/coordination/worker-reachable-advisory-ack.test.js
+++ b/tests/unit/coordination/worker-reachable-advisory-ack.test.js
@@ -1,0 +1,196 @@
+/**
+ * A worker can acknowledge an ADVISORY row, and the DIRECTIVE lane is unchanged.
+ * SD-LEO-INFRA-WORKER-REACHABLE-ACK-001 — FR-1..FR-5.
+ *
+ * THE SYMPTOM WAS TWO DEFECTS AND ONLY ONE WAS A BUG.
+ *
+ * The kind refusal in worker-ack-directive.cjs is CORRECT and deliberate: DIRECTIVE_KINDS
+ * excludes coordinator_reply/completion_nudge because that path is "reserved for genuine
+ * directives, never advisory rows". Widening it would have been the small edit and the wrong one —
+ * DIRECTIVE_KINDS also drives deliver-not-consume (read_at stays NULL) and priority-exempt
+ * selection, so buying an ack verb by widening it would change semantics the ack has nothing to do
+ * with. FR-3 pins that it did NOT widen.
+ *
+ * The real bugs: (1) the refusal was UNREADABLE — the script intended exit 2 but the process
+ * ABORTED during teardown ("Assertion failed: !(handle->flags & UV_HANDLE_CLOSING),
+ * src/win/async.c:76") and the shell saw 127, i.e. command-not-found; and (2) the advisory lane had
+ * NO worker-reachable ack at all, so coordinator RULINGS sat unacknowledged until some later
+ * /checkin drained them.
+ *
+ * WHY THE read_at ARM IS A UNIT TEST. Live, there were no undrained DIRECTIVE rows at the moment I
+ * checked, so read_at had NOTHING TO OBSERVE — and an unobserved invariant is not a passed one. It
+ * is pinned here structurally instead: the ack writes an exact key set, so a future edit that
+ * starts stamping read_at reds regardless of what rows happen to exist.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const REPO_ROOT = process.cwd();
+const { ackDirective, ackAdvisory } = require_(path.join(REPO_ROOT, 'scripts/worker-ack-directive.cjs'));
+const { DIRECTIVE_KINDS, ADVISORY_KINDS } = require_(path.join(REPO_ROOT, 'lib/fleet/worker-status.cjs'));
+
+const ROW_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+/** Fake client capturing exactly what the ack writes. */
+function makeSupabase(kind, { acknowledged_at = null } = {}) {
+  const capture = { updates: [] };
+  const client = {
+    capture,
+    from() {
+      return {
+        select: () => ({ eq: () => ({ single: async () => ({ data: { id: ROW_ID, payload: { kind }, target_session: null, acknowledged_at }, error: null }) }) }),
+        update(patch) { capture.updates.push(patch); return { eq: async () => ({ error: null }) }; }
+      };
+    }
+  };
+  return client;
+}
+
+describe('SD-LEO-INFRA-WORKER-REACHABLE-ACK-001', () => {
+  describe('FR-1: the refusal exit code is REACHABLE (not an abort reported as 127)', () => {
+    const CLIS = ['scripts/worker-ack-directive.cjs', 'scripts/worker-ack-advisory.cjs'];
+
+    // WHY THE SOURCE PIN IS THE LOAD-BEARING ARM, and this is the honest part.
+    //
+    // My first attempt spawned each CLI with NO --id and asserted exit 2. That test was VACUOUS,
+    // and mutation is what exposed it: restoring `process.exit(2)` on that path reddened NOTHING.
+    // The reason is structural — with no --id, main() returns BEFORE getServiceClient(), so no
+    // async handles are open and process.exit() exits cleanly. The abort only happens once a
+    // supabase client EXISTS: that is the catch path, measured live at exit 127 with
+    // "Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), src/win/async.c:76", and now
+    // measured at a clean exit 1 after the fix.
+    //
+    // A credential-free unit test cannot construct that client, so it cannot reach the failing
+    // branch by spawning. Rather than keep an arm that only LOOKS like it covers FR-1, the
+    // invariant is pinned where it is actually decidable: this file must never call process.exit.
+    // Comments must be stripped before this assertion. Both CLIs EXPLAIN the fix in prose that
+    // contains the literal "process.exit()", and a naive grep counts that comment as the code it
+    // describes — the same trap that nearly made me report an unlanded fix earlier in this
+    // session. Strip block and line comments, then test only what executes.
+    const codeOf = (rel) => readFileSync(path.join(REPO_ROOT, rel), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+    it('neither CLI calls process.exit — the abort path is closed by construction', () => {
+      for (const rel of CLIS) {
+        expect(codeOf(rel), `${rel} still calls process.exit() — it will abort whenever a client is open`).not.toMatch(/process\.exit\(/);
+      }
+    });
+
+    it('CONTROL: the comment-stripper does not blind the pin — it still sees real code', () => {
+      // A stripper that ate everything would make the arm above vacuous. Prove it retains the
+      // executable statements this file is actually about.
+      for (const rel of CLIS) {
+        const code = codeOf(rel);
+        expect(code).toMatch(/process\.exitCode/);
+        expect(code).toMatch(/argVal\(argv, '--id'\)/);
+      }
+    });
+
+    it('CONTROL: both CLIs still SET an exit code — the fix is not "delete the exit"', () => {
+      // Two-sided. Deleting process.exit() without setting process.exitCode would satisfy the pin
+      // above while making every refusal exit 0 — a silent success, strictly worse than 127.
+      for (const rel of CLIS) {
+        const src = readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+        expect(src).toMatch(/process\.exitCode\s*=\s*2/);
+        expect(src).toMatch(/process\.exitCode\s*=\s*1/);
+      }
+    });
+
+    it('the usage refusal (no --id) reaches the shell as the documented code 2', () => {
+      // Kept because it proves the code genuinely propagates, but it is NOT the FR-1 detector —
+      // see the note above. Exit status read from execFileSync, never through a pipe.
+      for (const rel of CLIS) {
+        let status = 0;
+        try {
+          execFileSync(process.execPath, [path.join(REPO_ROOT, rel)], { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] });
+        } catch (e) { status = e.status; }
+        expect(status, `${rel} usage refusal`).toBe(2);
+      }
+    });
+  });
+
+  describe('FR-2: the ADVISORY lane has a worker-reachable ack', () => {
+    it('acks a coordinator_reply and stamps acknowledged_at + actioned_by', async () => {
+      const sb = makeSupabase('coordinator_reply');
+      const res = await ackAdvisory(sb, ROW_ID, { sessionId: 'sess-1' });
+
+      expect(res.alreadyAcked).toBe(false);
+      expect(res.kind).toBe('coordinator_reply');
+      const patch = sb.capture.updates[0];
+      expect(patch.acknowledged_at).toBeTruthy();
+      expect(patch.payload.actioned_by).toBe('sess-1');
+    });
+
+    it('acks a completion_nudge too — both advisory kinds are reachable', async () => {
+      const sb = makeSupabase('completion_nudge');
+      await expect(ackAdvisory(sb, ROW_ID, {})).resolves.toMatchObject({ kind: 'completion_nudge' });
+    });
+
+    it('is idempotent: an already-acked row is a no-op, not a re-stamp', async () => {
+      const sb = makeSupabase('coordinator_reply', { acknowledged_at: '2099-01-01T00:00:00Z' });
+      const res = await ackAdvisory(sb, ROW_ID, {});
+      expect(res.alreadyAcked).toBe(true);
+      expect(sb.capture.updates, 'an idempotent no-op must not write').toEqual([]);
+    });
+  });
+
+  describe('FR-3: the DIRECTIVE contract did NOT widen', () => {
+    it('DIRECTIVE_KINDS still excludes both advisory kinds', () => {
+      expect(DIRECTIVE_KINDS).not.toContain('coordinator_reply');
+      expect(DIRECTIVE_KINDS).not.toContain('completion_nudge');
+    });
+
+    it('the directive verb STILL REFUSES an advisory row', async () => {
+      // The refusal that exposed the gap is correct and must survive the fix.
+      const sb = makeSupabase('coordinator_reply');
+      const err = await ackDirective(sb, ROW_ID, {}).catch((e) => e);
+      expect(err.code).toBe('NOT_A_DIRECTIVE');
+      expect(sb.capture.updates, 'a refused directive ack must not write').toEqual([]);
+    });
+
+    it('the advisory verb REFUSES a directive row — the lanes do not blur in either direction', async () => {
+      // Two-sided. Without this, "advisory acks anything" would satisfy every arm above while
+      // quietly making the advisory verb a back door into the directive lane.
+      const sb = makeSupabase('coordinator_directive');
+      const err = await ackAdvisory(sb, ROW_ID, {}).catch((e) => e);
+      expect(err.code).toBe('NOT_AN_ADVISORY');
+      expect(sb.capture.updates).toEqual([]);
+    });
+
+    it('CONTROL: a genuine directive kind still acks normally', async () => {
+      const sb = makeSupabase('coordinator_request');
+      await expect(ackDirective(sb, ROW_ID, {})).resolves.toMatchObject({ alreadyAcked: false, kind: 'coordinator_request' });
+    });
+
+    it('ADVISORY_KINDS is its OWN list, not the complement of DIRECTIVE_KINDS', () => {
+      // Structural. A complement ("everything not a directive") would silently enrol every FUTURE
+      // kind into the advisory lane by default — the exclusion-set trap. An explicit frozen list
+      // means a new kind joins nothing until someone names it.
+      expect(Object.isFrozen(ADVISORY_KINDS)).toBe(true);
+      expect([...ADVISORY_KINDS].sort()).toEqual(['completion_nudge', 'coordinator_reply']);
+      for (const k of ADVISORY_KINDS) expect(DIRECTIVE_KINDS).not.toContain(k);
+    });
+  });
+
+  describe('FR-4: deliver-not-consume — the ack never touches read_at', () => {
+    it('the ack writes EXACTLY {acknowledged_at, payload} and nothing else', async () => {
+      // read_at IS NULL is the deliberate delivered-but-not-consumed signal for DIRECTIVE_KINDS
+      // (scripts/hooks/coordination-inbox.cjs); resume.cjs:176-179 records that forcing it
+      // re-introduces a corrected regression. Asserting the exact key set catches a future edit
+      // that adds read_at, which a "read_at is still null" assertion over incidental rows would
+      // miss whenever no such row happens to exist.
+      for (const kind of ['coordinator_request', 'coordinator_reply']) {
+        const sb = makeSupabase(kind);
+        const ack = kind === 'coordinator_reply' ? ackAdvisory : ackDirective;
+        await ack(sb, ROW_ID, {});
+        expect(Object.keys(sb.capture.updates[0]).sort()).toEqual(['acknowledged_at', 'payload']);
+      }
+    });
+  });
+});


### PR DESCRIPTION
The symptom — *"coordinator rulings stay unacknowledged"* — was **two defects, and only one of them was a bug.**

## The refusal is correct. Do not widen DIRECTIVE_KINDS.

`DIRECTIVE_KINDS` deliberately excludes `coordinator_reply` and `completion_nudge`: that path is *"reserved for genuine directives, never advisory rows."*

Widening it would have been the one-line edit and the wrong one — `DIRECTIVE_KINDS` also drives **deliver-not-consume** (`read_at` stays NULL) and priority-exempt selection, so buying an ack verb by widening it changes semantics the ack has nothing to do with. FR-3 pins that it did not widen, **in both directions**: the advisory verb refuses a directive row too, so neither lane becomes a back door into the other.

## FR-1 — the refusal was unreadable

The script intended exit 2. But with a supabase client open, `process.exit()` fired before handles settled and the process **aborted**:

```
Assertion failed: !(handle->flags & UV_HANDLE_CLOSING), src/win/async.c:76
```

The shell saw **127** — command-not-found — so a deliberate refusal was indistinguishable from a missing binary. Now `process.exitCode`, matching the fix already shipped in `execute-subagent.js` for the same abort class.

Measured live on a real row: the refusal path *with a client* went **127 → clean exit 1**.

## FR-2 — the advisory lane gets its own verb

`scripts/worker-ack-advisory.cjs`, sharing one `ackRow()` core with the directive path so the two cannot drift. `ADVISORY_KINDS` is its **own frozen list**, not the complement of `DIRECTIVE_KINDS` — a complement would silently enrol every future kind into the advisory lane by default.

**Dogfooded on a real coordinator ruling** (`b3fdd954`, `kind=coordinator_reply`): the directive verb refused it, the advisory verb acked it, and DB readback showed `acknowledged_at`, `payload.actioned_at` and `actioned_by` set with the kind unchanged.

## My first FR-1 test was vacuous, and the mutation is what exposed it

It spawned each CLI with no `--id` and asserted exit 2. Restoring `process.exit(2)` on that path reddened **nothing** — because with no `--id`, `main()` returns *before* `getServiceClient()`, so no handles are open and `process.exit()` exits cleanly. **The abort only exists once a client does.** I had tested a path that never had the bug, and it looked like coverage.

A credential-free unit test cannot reach that branch by spawning, so the invariant is pinned where it *is* decidable — neither CLI may call `process.exit` at all — with a **control** that they still *set* a code, since deleting the exit without setting one exits 0: a silent success, strictly worse than 127. Re-mutating the **real** catch path reds both arms.

That pin then had to **strip comments first**: both files explain the fix in prose containing the literal `process.exit()`, and a naive grep counts its own comment as the code it describes. A further control proves the stripper did not blind the pin.

## FR-4 — stated honestly

`read_at` had **nothing to observe** live: no undrained directive rows existed at check time, and an unobserved invariant is not a passed one. It is pinned structurally instead — the ack writes **exactly** `{acknowledged_at, payload}`, so a future edit that starts stamping `read_at` reds regardless of which rows happen to exist.

## Scope discipline

The new script **joins `ACK_PATHS`** in `ack-paths-explicit-id-source-pins.test.js` rather than sitting outside a guarantee meant to cover the whole ack surface. That pin also asserts exact textual shapes inside `worker-ack-directive.cjs` — reading it first is why the refactor preserved `argVal(argv, '--id')` and `if (!id) {`.

## Verification

**Full unit project: 3063 files / 37357 tests passing, 0 failures.** Collection proven via `vitest list --project unit --filesOnly`. No EOL churn — diffstat identical with `--ignore-cr-at-eol`.

SD: SD-LEO-INFRA-WORKER-REACHABLE-ACK-001 · LEAD-TO-PLAN 94 · PLAN-TO-EXEC 92
