### PR TITLE
feat(SD-LEO-INFRA-DRIVE-STATE-OBSERVABILITY-001): give the drive-state verdict a time axis

### DIFF
--- a/.github/workflows/drive-reports-ddl.yml
+++ b/.github/workflows/drive-reports-ddl.yml
@@ -29,6 +29,12 @@ on:
     paths:
       - 'database/migrations/20260803_drive_reports.sql'
       - 'tests/ddl/drive-reports-ddl.db.test.js'
+      # SD-LEO-INFRA-DRIVE-STATE-OBSERVABILITY-001 TR-5. This filter lists LITERAL paths, so a PR
+      # touching only a NEW migration and its NEW ddl test would have triggered NOTHING — green
+      # with zero CI signal, which is the same failure class the drive-state SD exists to remove.
+      # Adding the paths is the whole fix; the tier still refuses to become a general one.
+      - 'database/migrations/20260808_drive_state_verdicts.sql'
+      - 'tests/ddl/drive-state-verdicts-ddl.db.test.js'
       - 'vitest.ddl.config.mjs'
       # Self-validating: edits to this file re-run it.
       - '.github/workflows/drive-reports-ddl.yml'

--- a/database/migrations/20260808_drive_state_verdicts.sql
+++ b/database/migrations/20260808_drive_state_verdicts.sql
@@ -84,7 +84,71 @@ CREATE INDEX IF NOT EXISTS drive_state_verdicts_axis_recorded_idx
 CREATE INDEX IF NOT EXISTS drive_state_verdicts_run_idx
   ON public.drive_state_verdicts (run_id);
 
+-- ─────────────────────────────────────────────────────────────────────────────────────────────
+-- POSTURE. The first draft of this file shipped ENABLE ROW LEVEL SECURITY and nothing else, which
+-- SECURITY review flagged against the sibling's MEASURED decision: 20260803_drive_reports.sql:12-18
+-- surveyed recent table migrations and found "RLS on, no policy" was the OUTLIER — five of six use
+-- an explicit service_role policy and four carry a verify block.
+--
+-- Why the bare form is wrong even though nothing is exposed today: Supabase's ALTER DEFAULT
+-- PRIVILEGES grants anon/authenticated on new public tables. RLS-with-no-policy blocks the ROWS,
+-- so reads return nothing — but THE GRANT STILL EXISTS and nothing says so. Per
+-- 20260803_drive_reports.sql:8-10, any non-service grant on a table of this class is a
+-- RECLASSIFICATION TRIGGER. It would then sit one permissive policy away from publishing chairman
+-- decision titles and fleet diagnosis to anon. Revoking is the difference between "not exposed"
+-- and "cannot be exposed by an accident nobody would see".
+-- ─────────────────────────────────────────────────────────────────────────────────────────────
 ALTER TABLE public.drive_state_verdicts ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS drive_state_verdicts_service_role ON public.drive_state_verdicts;
+CREATE POLICY drive_state_verdicts_service_role
+  ON public.drive_state_verdicts
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- PUBLIC included deliberately: the tripwire reclassifies on ANY non-service grant, so revoking
+-- only the two named roles would be narrower than the rule it serves.
+REVOKE ALL ON public.drive_state_verdicts FROM anon, authenticated, PUBLIC;
+GRANT ALL ON public.drive_state_verdicts TO service_role;
+
+-- VERIFY, because CREATE TABLE IF NOT EXISTS above advertises an idempotence that hides a real
+-- failure: if the table already exists in some other shape, every CHECK and the UNIQUE silently
+-- do NOT land and this file still reports success. An unapplied-or-partially-applied migration
+-- would be indistinguishable from a correct one. This block aborts the deploy instead.
+DO $verify$
+DECLARE
+  missing text;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.drive_state_verdicts'::regclass
+      AND contype = 'u' AND conname = 'drive_state_verdicts_one_row_per_run_axis'
+  ) THEN
+    RAISE EXCEPTION 'drive_state_verdicts: UNIQUE (run_id, axis) did not land — a retry could write twelve rows';
+  END IF;
+
+  FOR missing IN
+    SELECT c FROM unnest(ARRAY['axis', 'state', 'action_taken']) AS c
+    WHERE NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conrelid = 'public.drive_state_verdicts'::regclass
+        AND contype = 'c' AND pg_get_constraintdef(oid) ILIKE '%' || c || ' = ANY%'
+    )
+  LOOP
+    RAISE EXCEPTION 'drive_state_verdicts: CHECK on % did not land — its closed vocabulary is unenforced and the drift guard has nothing to diverge from', missing;
+  END LOOP;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.role_table_grants
+    WHERE table_schema = 'public' AND table_name = 'drive_state_verdicts'
+      AND grantee IN ('anon', 'authenticated', 'PUBLIC')
+  ) THEN
+    RAISE EXCEPTION 'drive_state_verdicts: a non-service grant is present — this table is permission-class and must not carry one';
+  END IF;
+END
+$verify$;
 
 COMMENT ON TABLE public.drive_state_verdicts IS
   'SD-LEO-INFRA-DRIVE-STATE-OBSERVABILITY-001: durable history of the six-axis drive-state verdict, one row per (run_id, axis). Written only by the coordinator hourly review. No boolean or numeric health column exists here by design — see the header.';

--- a/database/migrations/20260808_drive_state_verdicts.sql
+++ b/database/migrations/20260808_drive_state_verdicts.sql
@@ -1,0 +1,90 @@
+-- SD-LEO-INFRA-DRIVE-STATE-OBSERVABILITY-001 — FR-1.
+--
+-- THE GAP THIS CLOSES: lib/governance/drive-state/ computes a six-axis verdict over
+-- CLEAR / STALLED / UNMEASURABLE and contains NO write path. Both consumers render it and drop it
+-- (coordinator-hourly-review.cjs reportDriveState console.logs the line array; adam-pm-board.mjs
+-- returns the lines to its caller). Because nothing is retained, no question with a time dimension
+-- is answerable: how long an axis has been STALLED, whether one flipped today, whether the
+-- unmeasurable count is trending. An axis can sit stalled indefinitely while every individual
+-- hourly render still reads as an ordinary report.
+--
+-- GRAIN: ONE ROW PER (run_id, axis) — six rows per run. Taken from
+-- database/migrations/20260614_adam_adherence_ledger.sql, already one row per (run_id, probe)
+-- carrying a three-value categorical verdict that includes an "unknown" member.
+--
+-- WHAT IS DELIBERATELY ABSENT: there is NO boolean column and NO numeric score/health column on
+-- this table. That absence is the structural defence of the three-state vocabulary, not a
+-- stylistic choice. The rejected alternative was the codebase_health_snapshots idiom, whose
+-- `score NUMERIC NOT NULL CHECK (0..100)` would force every UNMEASURABLE axis to carry a number —
+-- and its existing consumer (lib/governance/recursion-governor.js:160) already demonstrates the
+-- coercion, writing 0 when no measurement exists. An UNMEASURABLE axis stored as 0 is
+-- indistinguishable from a genuine zero, which is the exact fold contract.cjs:9-14 forbids.
+
+CREATE TABLE IF NOT EXISTS public.drive_state_verdicts (
+  id           BIGSERIAL PRIMARY KEY,
+
+  -- The grouping key that makes six rows one run. Without it the six rows of a run cannot be
+  -- reliably re-assembled, and every duration derived from the table is guesswork.
+  run_id       TEXT NOT NULL,
+
+  -- CHECK IS LOAD-BEARING, NOT DECORATION. Prose ("axis text NOT NULL") gives the drift guard
+  -- nothing to diverge from and makes its test vacuous by construction. Note the precedent does
+  -- NOT supply this: adam_adherence_ledger constrains `verdict` but leaves `probe`, its per-row
+  -- key, unconstrained — so following the template alone would have left `axis` open.
+  -- THIS LIST IS A SECOND REPRESENTATION OF lib/governance/drive-state/contract.cjs AXES and it is
+  -- accepted ONLY because tests/unit/governance/drive-state-vocabulary-drift.test.js parses this
+  -- constraint and asserts set-equality against the frozen list, in both directions. If that test
+  -- is ever deleted, this CHECK must be deleted with it.
+  axis         TEXT NOT NULL CHECK (axis IN (
+                 'chairman_decisions',
+                 'coordinator_performance',
+                 'roadmap_motion',
+                 'venture_stage_motion',
+                 'fleet_health',
+                 'learning_conversion'
+               )),
+
+  -- The three-state vocabulary, stored as its literal token. UNMEASURABLE is a first-class state,
+  -- never folded into CLEAR: a probe that cannot see is not a probe that sees nothing wrong.
+  state        TEXT NOT NULL CHECK (state IN ('CLEAR', 'STALLED', 'UNMEASURABLE')),
+
+  -- contract.cjs:63-68 requires a citation on EVERY state, not only UNMEASURABLE — that is the
+  -- whole difference between a checked all-clear and an unchecked one, so it is NOT NULL here too.
+  citation     TEXT NOT NULL,
+
+  -- Mandatory only when state = UNMEASURABLE (contract.cjs:69-71). Enforced as a row-level rule
+  -- rather than a bare NOT NULL, so a CLEAR row is not forced to invent one.
+  reason       TEXT,
+
+  action_taken TEXT NOT NULL CHECK (action_taken IN ('NONE', 'RECORDED', 'UNVERIFIABLE')),
+  -- contract.cjs:75-77: RECORDED requires an artifact to point at.
+  action_citation TEXT,
+
+  -- NOT SUPPLIED BY THE WRITER. This table exists to measure a DURATION, so the timestamp is the
+  -- one column whose provenance actually matters, and a client clock is the wrong authority: two
+  -- producers with any drift interleave into a history that is subtly out of order and shows
+  -- nothing wrong. The database clock is single-sourced.
+  recorded_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+
+  CONSTRAINT drive_state_verdicts_unmeasurable_needs_reason
+    CHECK (state <> 'UNMEASURABLE' OR (reason IS NOT NULL AND btrim(reason) <> '')),
+  CONSTRAINT drive_state_verdicts_recorded_needs_citation
+    CHECK (action_taken <> 'RECORDED' OR (action_citation IS NOT NULL AND btrim(action_citation) <> '')),
+
+  -- Without this a retried run writes twelve rows and the "exactly six per run" property holds
+  -- only on the happy path. The grain template pointedly lacks this constraint, so precedent
+  -- would not have supplied it.
+  CONSTRAINT drive_state_verdicts_one_row_per_run_axis UNIQUE (run_id, axis)
+);
+
+-- The duration query reads recent rows per axis and walks them in time order.
+CREATE INDEX IF NOT EXISTS drive_state_verdicts_axis_recorded_idx
+  ON public.drive_state_verdicts (axis, recorded_at DESC);
+
+CREATE INDEX IF NOT EXISTS drive_state_verdicts_run_idx
+  ON public.drive_state_verdicts (run_id);
+
+ALTER TABLE public.drive_state_verdicts ENABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE public.drive_state_verdicts IS
+  'SD-LEO-INFRA-DRIVE-STATE-OBSERVABILITY-001: durable history of the six-axis drive-state verdict, one row per (run_id, axis). Written only by the coordinator hourly review. No boolean or numeric health column exists here by design — see the header.';

--- a/lib/retention/policies.js
+++ b/lib/retention/policies.js
@@ -47,6 +47,13 @@ export const RETENTION_POLICIES = [
   { table: 'validation_audit_log', timestampColumn: 'created_at',  hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
   { table: 'model_usage_log',      timestampColumn: 'captured_at', hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
   { table: 'permission_audit_log', timestampColumn: 'created_at',  hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
+  // SD-LEO-INFRA-DRIVE-STATE-OBSERVABILITY-001: drive_state_verdicts accumulates SIX ROWS PER
+  // HOURLY RUN — ~52k rows/year, unbounded, and it carries partially-untrusted text (chairman
+  // decision titles reach the citation column via an anon-insertable feedback row). The
+  // operator-contract gate caught the absence of this entry, correctly: a table whose creator
+  // ships no retention path is exactly the accumulation this repo keeps paying for. recorded_at is
+  // the DB-defaulted timestamp column.
+  { table: 'drive_state_verdicts', timestampColumn: 'recorded_at', hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
   // SD-REFILL-00LHUVME: eva_scheduler_metrics was unbounded (140,302 rows / 12d at authoring,
   // x1.63 in 24h per row-growth-snapshot.cjs) and uncovered by RETENTION-POLICY-UNBOUNDED-001.
   // created_at verified on live schema (occurred_at also exists); 0 triggers/FKs/inbound-FKs.

--- a/scripts/coordinator-hourly-review.cjs
+++ b/scripts/coordinator-hourly-review.cjs
@@ -362,19 +362,43 @@ async function reportDriveState(sb) {
   // dead for weeks while every hourly report looked perfectly normal. That is precisely the defect
   // this SD exists to remove, recreated one layer down. So the existing lines are untouched AND a
   // distinguishable banner is printed when the write fails.
-  // The verdict's own field is `axes` (index.cjs:70), NOT `entries`, and `measured_at` is the
-  // compute's single clock read — reusing it as run_id avoids a second, slightly-later timestamp
-  // that would make the six rows disagree with the verdict they came from.
-  if (verdict && Array.isArray(verdict.axes)) {
-    const { persistDriveState } = require('./lib/drive-state-verdict-store.cjs');
-    const runId = verdict.measured_at;
-    try {
-      await persistDriveState({ supabase: sb, runId, entries: verdict.axes });
-    } catch (e) {
-      console.log(`⚠️  DRIVE-STATE HISTORY NOT WRITTEN (${e && e.message ? e.message : String(e)}) — the verdict above rendered, but it was NOT recorded, so no duration question can be answered about this run.`);
-    }
+  await persistRenderedVerdict(verdict, sb);
+}
+
+/**
+ * EXPORTED SO IT CAN BE EXECUTED BY A TEST, and that is the whole reason it is a function.
+ *
+ * The first version of this lived inline in reportDriveState and was "covered" by two regexes over
+ * this file's own source text. A mutation review then dead-coded the call — `if (false) await
+ * persistDriveState(...)` — and it SURVIVED the entire unit project, 3063 files and 37,365 tests.
+ * Silent in production too: no write, no banner, no failure. That is precisely this SD's own thesis
+ * ("an axis can sit stalled indefinitely while every hourly render reads as normal") reproduced one
+ * layer down, inside the fix written to remove it. A regex pins a STATEMENT FORM; only an executed
+ * test pins the DATA FLOW.
+ *
+ * @param {object|null} verdict computeDriveState's return: {axes, summary, measured_at}
+ * @param {object} sb supabase client
+ */
+async function persistRenderedVerdict(verdict, sb) {
+  // The verdict's own field is `axes` (index.cjs:70), NOT `entries`.
+  if (!verdict || !Array.isArray(verdict.axes)) return { persisted: false, reason: 'no_verdict' };
+
+  const { persistDriveState } = require('./lib/drive-state-verdict-store.cjs');
+  // measured_at is the compute's SINGLE clock read. Taking a fresh timestamp here would stamp the
+  // six rows a moment after the verdict they came from, so the history and the report would
+  // disagree about when the reading happened.
+  const runId = verdict.measured_at;
+  try {
+    const res = await persistDriveState({ supabase: sb, runId, entries: verdict.axes });
+    return { persisted: true, run_id: runId, written: res.written };
+  } catch (e) {
+    // VISIBLE, never swallowed. Byte-identical output under failure would mean persistence could
+    // be dead for weeks while every report looked normal.
+    console.log(`⚠️  DRIVE-STATE HISTORY NOT WRITTEN (${e && e.message ? e.message : String(e)}) — the verdict above rendered, but it was NOT recorded, so no duration question can be answered about this run.`);
+    return { persisted: false, reason: 'write_failed', error: e && e.message ? e.message : String(e) };
   }
 }
+
 
 async function main() {
   let sb;
@@ -513,4 +537,4 @@ if (require.main === module) {
   }).catch(function (e) { console.error('[HOURLY-REVIEW] error (non-fatal): ' + e.message); }).finally(function () { process.exit(0); });
 }
 
-module.exports = { dispatchSolomonReminder, SOLOMON_REMINDER, buildFoundationsPointer, reconcileStaleSolomonInbound };
+module.exports = { dispatchSolomonReminder, SOLOMON_REMINDER, buildFoundationsPointer, reconcileStaleSolomonInbound, persistRenderedVerdict };

--- a/scripts/coordinator-hourly-review.cjs
+++ b/scripts/coordinator-hourly-review.cjs
@@ -335,14 +335,45 @@ async function reportDriveState(sb) {
   const { renderDriveState, renderRefusal } = require('../lib/governance/drive-state/render.cjs');
 
   let lines;
+  let verdict = null;
   try {
-    const verdict = await computeDriveState({ adapters: ADAPTERS, supabase: sb });
+    verdict = await computeDriveState({ adapters: ADAPTERS, supabase: sb });
     lines = renderDriveState(verdict); // returns an ARRAY of lines
   } catch (e) {
+    verdict = null;
     lines = renderRefusal(e && e.message ? e.message : String(e));
   }
   console.log('');
   for (const line of lines) console.log(line);
+
+  // SD-LEO-INFRA-DRIVE-STATE-OBSERVABILITY-001 FR-3 — THE SINGLE WRITER.
+  //
+  // This review is the ONLY caller that persists. adam-pm-board.mjs computes the same verdict and
+  // deliberately does NOT write: both writing would record the same instant under two run_ids and
+  // silently inflate every count and duration derived from the table. This review is chosen because
+  // its cadence is regular and external, which is what makes a time series interpretable; the PM
+  // board is on-demand and would sample irregularly. THAT IS A DECISION WITH A REASON — if you are
+  // here to "fix" the missing write on the PM board, this comment is why it is missing.
+  //
+  // ORDER IS LOAD-BEARING: the render above has already happened and is never gated on the write.
+  //
+  // THE FAILURE IS VISIBLE, NOT SWALLOWED. An earlier draft required the output be byte-identical
+  // under a persistence failure — but byte-identical means INVISIBLE, and persistence could then be
+  // dead for weeks while every hourly report looked perfectly normal. That is precisely the defect
+  // this SD exists to remove, recreated one layer down. So the existing lines are untouched AND a
+  // distinguishable banner is printed when the write fails.
+  // The verdict's own field is `axes` (index.cjs:70), NOT `entries`, and `measured_at` is the
+  // compute's single clock read — reusing it as run_id avoids a second, slightly-later timestamp
+  // that would make the six rows disagree with the verdict they came from.
+  if (verdict && Array.isArray(verdict.axes)) {
+    const { persistDriveState } = require('./lib/drive-state-verdict-store.cjs');
+    const runId = verdict.measured_at;
+    try {
+      await persistDriveState({ supabase: sb, runId, entries: verdict.axes });
+    } catch (e) {
+      console.log(`⚠️  DRIVE-STATE HISTORY NOT WRITTEN (${e && e.message ? e.message : String(e)}) — the verdict above rendered, but it was NOT recorded, so no duration question can be answered about this run.`);
+    }
+  }
 }
 
 async function main() {

--- a/scripts/lib/drive-state-verdict-store.cjs
+++ b/scripts/lib/drive-state-verdict-store.cjs
@@ -19,8 +19,28 @@
 // vocabulary — the precise thing this SD is forbidden to create. The schema CHECK is the one
 // unavoidable second copy, and it is held in agreement by a two-sided drift test.
 const { AXES, STATE, STATES, ACTIONS } = require('../../lib/governance/drive-state/contract.cjs');
+const { safeCitation } = require('../../lib/governance/drive-state/render.cjs');
 
 const TABLE = 'drive_state_verdicts';
+
+/**
+ * SANITISE AT THE SINK, not only at the sources. (SECURITY SEC-3.)
+ *
+ * Citations carry genuinely untrusted text: chairman-decisions.cjs:139 puts `feedback` titles into
+ * one, and that table's anon INSERT policy constrains only source_type — an unauthenticated party
+ * can supply the string. Every adapter wraps its own citation in safeCitation, EXCEPT the
+ * adapter_threw path at index.cjs:60, which interpolates a raw error message unbounded.
+ *
+ * That was tolerable while a citation was a console line that scrolled away. THIS SD CONVERTS IT
+ * INTO A DURABLE ROW, and a rendered string and a stored one have completely different exposure
+ * lifetimes — which makes the sink the right place for the guarantee. Relying on every current and
+ * FUTURE adapter to remember is convention; doing it here is construction.
+ */
+const CITATION_MAX = 400;
+function cleanText(v, max = CITATION_MAX) {
+  if (typeof v !== 'string') return v;
+  try { return safeCitation(v, max); } catch { return v.slice(0, max); }
+}
 
 /**
  * Persist one computed verdict as SIX rows, one per (run_id, axis).
@@ -79,10 +99,10 @@ async function persistDriveState({ supabase, runId, entries, table = TABLE } = {
       run_id: runId,
       axis: e.axis,
       state: e.state,
-      citation: e.citation,
-      reason: typeof e.reason === 'string' && e.reason.trim() !== '' ? e.reason : null,
+      citation: cleanText(e.citation),
+      reason: typeof e.reason === 'string' && e.reason.trim() !== '' ? cleanText(e.reason) : null,
       action_taken: e.action_taken,
-      action_citation: typeof e.action_citation === 'string' && e.action_citation.trim() !== '' ? e.action_citation : null,
+      action_citation: typeof e.action_citation === 'string' && e.action_citation.trim() !== '' ? cleanText(e.action_citation) : null,
     };
   });
 

--- a/scripts/lib/drive-state-verdict-store.cjs
+++ b/scripts/lib/drive-state-verdict-store.cjs
@@ -1,0 +1,155 @@
+/**
+ * SD-LEO-INFRA-DRIVE-STATE-OBSERVABILITY-001 — FR-2 (persist) and FR-5 (duration).
+ *
+ * lib/governance/drive-state/ computes a six-axis verdict and has NO write path; both consumers
+ * render it and discard it. This module is the write path, plus the one question the history
+ * exists to answer.
+ *
+ * WHY IT LIVES IN scripts/lib AND NOT lib/drive-loop/: tests/unit/drive-loop/report-posture.test.js
+ * fails the build on any `.insert(` under lib/drive-loop/. That boundary is deliberate (that
+ * subsystem proposes, it does not write), and this is a different subsystem that shares only the
+ * word "drive". Same reason scripts/lib/capacity-verdict-store.mjs sits here.
+ *
+ * Shape template: scripts/lib/capacity-verdict-store.mjs:94-140.
+ */
+
+'use strict';
+
+// IMPORTED, NEVER REDECLARED. A retyped axis list would be a second representation of the frozen
+// vocabulary — the precise thing this SD is forbidden to create. The schema CHECK is the one
+// unavoidable second copy, and it is held in agreement by a two-sided drift test.
+const { AXES, STATE, STATES, ACTIONS } = require('../../lib/governance/drive-state/contract.cjs');
+
+const TABLE = 'drive_state_verdicts';
+
+/**
+ * Persist one computed verdict as SIX rows, one per (run_id, axis).
+ *
+ * THROWS on write failure. It does not log-and-continue, because a persist that swallows its own
+ * failure recreates — one layer down — the exact blindness this SD exists to remove: the history
+ * would silently stop growing while every hourly render still looked normal.
+ *
+ * @param {object} opts
+ * @param {object} opts.supabase   service client
+ * @param {string} opts.runId      groups the six rows into one run
+ * @param {Array}  opts.entries    the verdict's axis entries (contract-shaped)
+ * @returns {Promise<{run_id: string, written: number}>}
+ */
+async function persistDriveState({ supabase, runId, entries, table = TABLE } = {}) {
+  if (!supabase) throw new Error('persistDriveState(): supabase client is required');
+  if (typeof runId !== 'string' || runId.trim() === '') {
+    throw new Error('persistDriveState(): runId must be a non-empty string — it is the key that makes six rows one run, and rows without it cannot be re-assembled into a history');
+  }
+  if (!Array.isArray(entries)) throw new Error('persistDriveState(): entries must be an array');
+
+  // The write is guarded against a SHORT verdict as well as a wrong one. Six rows is the whole
+  // premise of "all axes checked"; five rows renders identically to six on any consumer that
+  // does not count, so a partial verdict must fail here rather than become a durable half-truth.
+  if (entries.length !== AXES.length) {
+    throw new Error(
+      `persistDriveState(): expected ${AXES.length} axis entries, got ${entries.length}. `
+      + 'A short verdict stored is a hole that reads exactly like an all-clear.'
+    );
+  }
+
+  const seen = new Set();
+  const rows = entries.map((e) => {
+    if (!AXES.includes(e?.axis)) {
+      throw new Error(`persistDriveState(): unrecognised axis ${JSON.stringify(e?.axis)} — expected one of ${AXES.join(', ')}`);
+    }
+    if (seen.has(e.axis)) throw new Error(`persistDriveState(): duplicate axis ${e.axis} in one verdict`);
+    seen.add(e.axis);
+
+    if (!STATES.includes(e?.state)) {
+      throw new Error(`persistDriveState(): unrecognised state ${JSON.stringify(e?.state)} for axis ${e.axis} — expected one of ${STATES.join(', ')}`);
+    }
+    if (!ACTIONS.includes(e?.action_taken)) {
+      throw new Error(`persistDriveState(): unrecognised action_taken ${JSON.stringify(e?.action_taken)} for axis ${e.axis}`);
+    }
+    // Guarded at the write, not left to the CHECK, so the failure names the axis.
+    if (e.state === STATE.UNMEASURABLE && (typeof e.reason !== 'string' || e.reason.trim() === '')) {
+      throw new Error(`persistDriveState(): axis ${e.axis} is UNMEASURABLE with no reason — an unexplained UNMEASURABLE is the state this vocabulary exists to prevent`);
+    }
+    if (typeof e.citation !== 'string' || e.citation.trim() === '') {
+      throw new Error(`persistDriveState(): axis ${e.axis} has no citation — the contract requires one on EVERY state, which is the difference between a checked all-clear and an unchecked one`);
+    }
+
+    // recorded_at is DELIBERATELY NOT SENT: the column default fires. See the migration header.
+    return {
+      run_id: runId,
+      axis: e.axis,
+      state: e.state,
+      citation: e.citation,
+      reason: typeof e.reason === 'string' && e.reason.trim() !== '' ? e.reason : null,
+      action_taken: e.action_taken,
+      action_citation: typeof e.action_citation === 'string' && e.action_citation.trim() !== '' ? e.action_citation : null,
+    };
+  });
+
+  const { data, error } = await supabase.from(table).insert(rows).select('id, axis, state');
+
+  if (error) {
+    const err = new Error(
+      `persistDriveState(): durable write failed (${error.code || 'no-code'}): ${error.message}. `
+      + 'Throwing rather than letting the history silently stop growing while the render still looks normal.'
+    );
+    err.code = error.code;
+    err.cause = error;
+    throw err;
+  }
+
+  return { run_id: runId, written: Array.isArray(data) ? data.length : rows.length };
+}
+
+/**
+ * FR-5 — the duration question the history exists to answer: for each axis, how long has it been
+ * stalled, counting only its CURRENT UNBROKEN run of STALLED readings.
+ *
+ * IMPLEMENTED IN JS OVER FETCHED ROWS, ON PURPOSE. A SQL grouping or a view could not be
+ * exercised by the repo's applying test fake (tests/unit/governance/drive-state-axes.test.js
+ * implements eq/in/gte/not/order/limit and has no grouping, aggregation or HAVING), so it could
+ * only ever be tested against an approximation that passes while the real query is wrong.
+ *
+ * CONTIGUITY IS THE WHOLE POINT. A naive "count the STALLED rows" reports a span that reaches back
+ * across a period in which the axis RECOVERED. STALLED, then CLEAR, then STALLED is TWO short
+ * stalls, never one long one — and the difference is exactly the kind of silently-wrong metric
+ * this SD was written to stop producing.
+ *
+ * @returns {Promise<Array<{axis: string, since: string, runs: number}>>} one entry per CURRENTLY
+ *          stalled axis; an axis that is not stalled right now is absent.
+ */
+async function currentStallSpans({ supabase, table = TABLE, limit = 2000 } = {}) {
+  if (!supabase) throw new Error('currentStallSpans(): supabase client is required');
+
+  const { data, error } = await supabase
+    .from(table)
+    .select('axis, state, recorded_at, run_id')
+    .order('recorded_at', { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    const err = new Error(`currentStallSpans(): read failed (${error.code || 'no-code'}): ${error.message}`);
+    err.cause = error;
+    throw err;
+  }
+
+  const byAxis = new Map();
+  for (const row of data || []) {
+    if (!byAxis.has(row.axis)) byAxis.set(row.axis, []);
+    byAxis.get(row.axis).push(row);
+  }
+
+  const out = [];
+  for (const [axis, rows] of byAxis) {
+    // rows are newest-first. The current span ends the moment a non-STALLED reading appears.
+    if (rows.length === 0 || rows[0].state !== STATE.STALLED) continue;
+    let i = 0;
+    while (i < rows.length && rows[i].state === STATE.STALLED) i += 1;
+    const span = rows.slice(0, i);
+    out.push({ axis, since: span[span.length - 1].recorded_at, runs: span.length });
+  }
+  out.sort((a, b) => String(a.since).localeCompare(String(b.since)));
+  return out;
+}
+
+module.exports = { persistDriveState, currentStallSpans, TABLE };

--- a/tests/ddl/drive-state-verdicts-ddl.db.test.js
+++ b/tests/ddl/drive-state-verdicts-ddl.db.test.js
@@ -18,7 +18,25 @@ import path from 'node:path';
 import pg from 'pg';
 
 const MIGRATION = path.resolve(process.cwd(), 'database/migrations/20260808_drive_state_verdicts.sql');
-const CONN = process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/postgres';
+/**
+ * NO connectionString, and NO DATABASE_URL. Both were wrong, and SECURITY measured why:
+ * pg's connectionString OVERRIDES the PGHOST/PGUSER/PGPASSWORD/PGDATABASE block the workflow sets
+ * (.github/workflows/drive-reports-ddl.yml:70-75), and the service container creates only the role
+ * ddl_runner — there is no 'postgres' role — so in CI this connected as a non-existent role and
+ * beforeAll failed, meaning NONE of the constraint proofs below would ever have run.
+ *
+ * Worse, DATABASE_URL is this repo's convention for the REAL database (~20 scripts resolve it).
+ * vitest.ddl.config.mjs:19-21 justifies gating on nothing precisely because 'there is no
+ * production database it could possibly be pointed at by mistake' — reading DATABASE_URL made
+ * that false. Same construction as the sibling, tests/ddl/drive-reports-ddl.db.test.js:106-107.
+ */
+const PG = {
+  host: process.env.PGHOST || '127.0.0.1',
+  port: Number(process.env.PGPORT || 5432),
+  user: process.env.PGUSER || 'postgres',
+  password: process.env.PGPASSWORD || 'postgres',
+  database: process.env.PGDATABASE || 'postgres',
+};
 
 let client;
 
@@ -35,11 +53,18 @@ const insert = (over = {}) => {
 };
 
 beforeAll(async () => {
-  client = new pg.Client({ connectionString: CONN });
+  client = new pg.Client(PG);
   await client.connect();
   await client.query(fs.readFileSync(MIGRATION, 'utf8'));
 });
-afterAll(async () => { if (client) await client.end(); });
+// CLEANUP. The prior version only closed the client, leaving ~11 rows behind on whatever it had
+// connected to. Cheap here, and the difference between a throwaway container and a table someone
+// later finds mysterious rows in.
+afterAll(async () => {
+  if (!client) return;
+  try { await client.query('DROP TABLE IF EXISTS public.drive_state_verdicts'); } catch { /* best effort */ }
+  await client.end();
+});
 
 describe('[CONTROL, asserted first] a sound row is ACCEPTED', () => {
   it('accepts a well-formed verdict row', async () => {

--- a/tests/ddl/drive-state-verdicts-ddl.db.test.js
+++ b/tests/ddl/drive-state-verdicts-ddl.db.test.js
@@ -1,0 +1,102 @@
+/**
+ * SD-LEO-INFRA-DRIVE-STATE-OBSERVABILITY-001 — TS-6 and TS-9, the shape proven against real postgres.
+ *
+ * THE FILENAME IS *.db.test.js ON PURPOSE AND IT IS NOT THE HAZARD. vitest.ddl.config.mjs:36
+ * includes exactly tests/ddl/ ** /*.db.test.js and is run with an explicit --config, so this file
+ * IS collected. The hazard is a file matching DB_INCLUDE that is reachable ONLY by the DEFAULT
+ * config — that file belongs to zero projects and reports green while never running. An earlier
+ * draft of this SD's acceptance criterion banned the filename outright and would have blocked the
+ * very tier it mandated; the rule is about REACHABILITY, not the name.
+ *
+ * A CHECK constraint cannot be asserted from the unit tier — the unit test parses the migration
+ * TEXT, which proves what we wrote, not what postgres accepted. This proves postgres enforces it.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import pg from 'pg';
+
+const MIGRATION = path.resolve(process.cwd(), 'database/migrations/20260808_drive_state_verdicts.sql');
+const CONN = process.env.DATABASE_URL || 'postgres://postgres:postgres@localhost:5432/postgres';
+
+let client;
+
+const SOUND = {
+  run_id: 'run-a', axis: 'fleet_health', state: 'CLEAR',
+  citation: 'checked', action_taken: 'NONE',
+};
+const insert = (over = {}) => {
+  const row = { ...SOUND, ...over };
+  return client.query(
+    'INSERT INTO public.drive_state_verdicts (run_id, axis, state, citation, reason, action_taken, action_citation) VALUES ($1,$2,$3,$4,$5,$6,$7)',
+    [row.run_id, row.axis, row.state, row.citation, row.reason ?? null, row.action_taken, row.action_citation ?? null]
+  );
+};
+
+beforeAll(async () => {
+  client = new pg.Client({ connectionString: CONN });
+  await client.connect();
+  await client.query(fs.readFileSync(MIGRATION, 'utf8'));
+});
+afterAll(async () => { if (client) await client.end(); });
+
+describe('[CONTROL, asserted first] a sound row is ACCEPTED', () => {
+  it('accepts a well-formed verdict row', async () => {
+    await expect(insert({ run_id: 'ctl-1' })).resolves.toBeTruthy();
+  });
+});
+
+describe('the closed vocabularies are enforced BY POSTGRES, not just by our prose', () => {
+  it('rejects an axis outside the frozen six', async () => {
+    await expect(insert({ run_id: 'r1', axis: 'rogue_axis' })).rejects.toThrow();
+  });
+  it('rejects a state outside CLEAR / STALLED / UNMEASURABLE', async () => {
+    await expect(insert({ run_id: 'r2', state: 'FINE' })).rejects.toThrow();
+  });
+  it('rejects an action_taken outside NONE / RECORDED / UNVERIFIABLE', async () => {
+    await expect(insert({ run_id: 'r3', action_taken: 'DONE' })).rejects.toThrow();
+  });
+});
+
+describe('the row-level contract rules', () => {
+  it('rejects UNMEASURABLE with no reason', async () => {
+    await expect(insert({ run_id: 'r4', state: 'UNMEASURABLE', reason: null })).rejects.toThrow();
+  });
+  it('accepts UNMEASURABLE WITH a reason — the two-sided half', async () => {
+    await expect(insert({ run_id: 'r5', state: 'UNMEASURABLE', reason: 'no_cohort' })).resolves.toBeTruthy();
+  });
+  it('rejects action_taken=RECORDED with no action_citation', async () => {
+    await expect(insert({ run_id: 'r6', action_taken: 'RECORDED' })).rejects.toThrow();
+  });
+  it('requires a citation on EVERY state', async () => {
+    await expect(insert({ run_id: 'r7', citation: null })).rejects.toThrow();
+  });
+});
+
+describe('[TS-9] UNIQUE (run_id, axis) — a retry cannot write twelve rows', () => {
+  it('rejects the same (run_id, axis) twice, and ACCEPTS the same axis under a different run', async () => {
+    await insert({ run_id: 'dup-1' });
+    await expect(insert({ run_id: 'dup-1' })).rejects.toThrow();
+    // The other direction: the constraint must not block the next run's reading of the same axis.
+    await expect(insert({ run_id: 'dup-2' })).resolves.toBeTruthy();
+  });
+});
+
+describe('[TS-6] the shape carries no field that could collapse the three states', () => {
+  it('has no boolean and no numeric health column, scoped to non-key columns', async () => {
+    const { rows } = await client.query(
+      "SELECT column_name, data_type FROM information_schema.columns WHERE table_name = 'drive_state_verdicts'"
+    );
+    const nonKey = rows.filter((r) => r.column_name !== 'id');
+    expect(nonKey.some((r) => r.data_type === 'boolean')).toBe(false);
+    expect(nonKey.some((r) => ['numeric', 'integer', 'real', 'double precision'].includes(r.data_type))).toBe(false);
+    // And the column a duration depends on is defaulted by the DATABASE, not the writer.
+    const recordedAt = rows.find((r) => r.column_name === 'recorded_at');
+    expect(recordedAt).toBeTruthy();
+    const { rows: def } = await client.query(
+      "SELECT column_default FROM information_schema.columns WHERE table_name='drive_state_verdicts' AND column_name='recorded_at'"
+    );
+    expect(String(def[0].column_default || '')).toMatch(/now\(\)/i);
+  });
+});

--- a/tests/unit/governance/drive-state-persist-wiring.test.js
+++ b/tests/unit/governance/drive-state-persist-wiring.test.js
@@ -1,0 +1,129 @@
+/**
+ * SD-LEO-INFRA-DRIVE-STATE-OBSERVABILITY-001 — the WIRING, executed rather than grepped.
+ *
+ * WHY THIS FILE EXISTS. The persist call was originally inline in reportDriveState and "covered" by
+ * two regexes over that file's own source text. A mutation review then dead-coded the call —
+ * `if (false) await persistDriveState(...)` — and it SURVIVED the entire unit project: 3063 files,
+ * 37,365 tests, all green. It is silent in production too: no write, no banner, nothing. Two more
+ * mutations survived the same way (writing to a wrong table, and taking a second clock reading for
+ * run_id instead of reusing measured_at).
+ *
+ * That is this SD's own thesis — "an axis can sit stalled indefinitely while every hourly render
+ * reads as normal" — reproduced one layer down, inside the fix written to remove it. A REGEX PINS A
+ * STATEMENT FORM; ONLY AN EXECUTED TEST PINS THE DATA FLOW. So the block was extracted into an
+ * exported function and this file calls it for real.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const { persistRenderedVerdict } = require_('../../../scripts/coordinator-hourly-review.cjs');
+const { AXES, STATE, ACTION } = require_('../../../lib/governance/drive-state/contract.cjs');
+
+/** Captures the table AND the rows, so a wrong-table write is visible rather than silently green. */
+function captureClient({ failWith = null } = {}) {
+  const calls = { tables: [], rows: null };
+  return {
+    calls,
+    from(table) {
+      calls.tables.push(table);
+      return {
+        insert(rows) {
+          calls.rows = rows;
+          return { select: () => Promise.resolve(failWith ? { data: null, error: failWith } : { data: rows, error: null }) };
+        },
+      };
+    },
+  };
+}
+
+const MEASURED_AT = '2026-08-08T16:00:00.000Z';
+const verdict = (over = {}) => ({
+  axes: AXES.map((axis) => ({
+    axis, state: STATE.CLEAR, citation: `${axis} checked`, action_taken: ACTION.NONE,
+    owed: null, in_motion: null, stalled: null, reason: null,
+  })),
+  summary: { clear: 6, stalled: 0, unmeasurable: 0 },
+  measured_at: MEASURED_AT,
+  ...over,
+});
+
+describe('[EXECUTED WIRING] the hourly review actually writes the verdict it rendered', () => {
+  it('[KILLS THE DEAD-CODE MUTATION] a rendered verdict results in six rows being inserted', async () => {
+    // The mutation that survived 37,365 tests was making this call unreachable. This test calls the
+    // real exported function and asserts the WRITE HAPPENED — not that a string appears in a file.
+    const c = captureClient();
+    const res = await persistRenderedVerdict(verdict(), c);
+    expect(res.persisted).toBe(true);
+    expect(c.calls.rows).toHaveLength(6);
+    expect(res.written).toBe(6);
+  });
+
+  it('[KILLS THE WRONG-TABLE MUTATION] the rows land on drive_state_verdicts', async () => {
+    const c = captureClient();
+    await persistRenderedVerdict(verdict(), c);
+    expect(c.calls.tables).toContain('drive_state_verdicts');
+  });
+
+  it('[KILLS THE SECOND-CLOCK-READ MUTATION] run_id IS the verdict measured_at, not a fresh timestamp', async () => {
+    // The inline comment claimed this; nothing enforced it. A second clock read would stamp the six
+    // rows a moment after the verdict they came from, so the history and the report would disagree
+    // about when the reading happened — and no test would have noticed.
+    const c = captureClient();
+    await persistRenderedVerdict(verdict(), c);
+    expect(c.calls.rows.every((r) => r.run_id === MEASURED_AT)).toBe(true);
+  });
+
+  it('[KILLS THE WRONG-FIELD MUTATION] reading entries instead of axes yields no write at all', async () => {
+    // A verdict shaped with `entries` (the field that does NOT exist on the real return) must not
+    // silently succeed — the guard has to see the absence.
+    const c = captureClient();
+    const res = await persistRenderedVerdict({ entries: verdict().axes, measured_at: MEASURED_AT }, c);
+    expect(res.persisted).toBe(false);
+    expect(c.calls.rows).toBeNull();
+  });
+
+  it('the six rows carry every axis exactly once, with the state and citation intact', async () => {
+    const c = captureClient();
+    const v = verdict();
+    v.axes[1].state = STATE.STALLED;
+    v.axes[2].state = STATE.UNMEASURABLE;
+    v.axes[2].reason = 'no_cohort';
+    await persistRenderedVerdict(v, c);
+    expect(c.calls.rows.map((r) => r.axis).sort()).toEqual([...AXES].sort());
+    const byAxis = Object.fromEntries(c.calls.rows.map((r) => [r.axis, r]));
+    expect(byAxis[AXES[1]].state).toBe('STALLED');
+    expect(byAxis[AXES[2]].state).toBe('UNMEASURABLE');
+    expect(byAxis[AXES[2]].reason).toBe('no_cohort');
+    expect(c.calls.rows.every((r) => typeof r.citation === 'string' && r.citation.length > 0)).toBe(true);
+  });
+});
+
+describe('[TS-3, executed] a write failure is REPORTED, never silent', () => {
+  it('returns write_failed and does not throw out of the review', async () => {
+    // The render already happened before this point; a persistence failure must not take the whole
+    // hourly review down, but it must also not be invisible. Both halves asserted.
+    const c = captureClient({ failWith: { code: '42P01', message: 'relation does not exist' } });
+    const res = await persistRenderedVerdict(verdict(), c);
+    expect(res.persisted).toBe(false);
+    expect(res.reason).toBe('write_failed');
+    expect(String(res.error)).toMatch(/durable write failed/);
+  });
+
+  it('[CONTROL] the success path does NOT report a failure — the signal is two-sided', async () => {
+    const res = await persistRenderedVerdict(verdict(), captureClient());
+    expect(res.persisted).toBe(true);
+    expect(res.reason).toBeUndefined();
+  });
+});
+
+describe('a missing or refused verdict writes nothing', () => {
+  it('a null verdict (the render-refusal path) does not attempt a write', async () => {
+    const c = captureClient();
+    const res = await persistRenderedVerdict(null, c);
+    expect(res.persisted).toBe(false);
+    expect(res.reason).toBe('no_verdict');
+    expect(c.calls.tables).toHaveLength(0);
+  });
+});

--- a/tests/unit/governance/drive-state-verdict-store.test.js
+++ b/tests/unit/governance/drive-state-verdict-store.test.js
@@ -1,0 +1,276 @@
+/**
+ * SD-LEO-INFRA-DRIVE-STATE-OBSERVABILITY-001 — the store, the duration query, and the drift guard.
+ *
+ * ROUTED TO THE UNIT TIER DELIBERATELY. A file matching DB_INCLUDE (tests/integration/** or
+ * *.db.test.js) that is reachable only by the default config is a member of ZERO PROJECTS here:
+ * vitest.config.js:288 excludes those paths from `unit` UNCONDITIONALLY while :172 admits them to
+ * `db` only when the gate is open, and the gate is closed (tests/helpers/db-target.js:25
+ * DESIGNATED_NON_PROD_REFS is a frozen empty array). Such a file REPORTS GREEN WHILE NEVER RUNNING.
+ * So these live in tests/unit/ and exercise a filter-applying fake, and the table's SHAPE is proven
+ * separately in the DDL tier against a real postgres.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const require_ = createRequire(import.meta.url);
+const { persistDriveState, currentStallSpans, TABLE } = require_('../../../scripts/lib/drive-state-verdict-store.cjs');
+const { AXES, STATE, ACTION } = require_('../../../lib/governance/drive-state/contract.cjs');
+
+/** A table-aware capture fake: it records what was inserted and which table it was aimed at, so a
+ *  wrong-table write is catchable rather than silently green. */
+function captureClient({ failWith = null } = {}) {
+  const calls = { table: null, rows: null, selected: false };
+  return {
+    calls,
+    from(table) {
+      calls.table = table;
+      return {
+        insert(rows) {
+          calls.rows = rows;
+          return {
+            select() {
+              calls.selected = true;
+              return Promise.resolve(failWith ? { data: null, error: failWith } : { data: rows.map((r, i) => ({ id: i + 1, axis: r.axis, state: r.state })), error: null });
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+/** A reading fake that APPLIES order and limit, so an inverted sort is caught rather than assumed. */
+function readClient(rows) {
+  return {
+    from() {
+      return {
+        select() {
+          const state = { rows: [...rows] };
+          const api = {
+            order(col, { ascending }) {
+              state.rows.sort((a, b) => (ascending ? 1 : -1) * String(a[col]).localeCompare(String(b[col])));
+              return api;
+            },
+            limit(n) { state.rows = state.rows.slice(0, n); return Promise.resolve({ data: state.rows, error: null }); },
+          };
+          return api;
+        },
+      };
+    },
+  };
+}
+
+const entry = (axis, state, over = {}) => ({
+  axis,
+  state,
+  citation: `${axis} checked`,
+  action_taken: ACTION.NONE,
+  ...(state === STATE.UNMEASURABLE ? { reason: 'no_cohort' } : {}),
+  ...over,
+});
+const fullVerdict = (stateFor = () => STATE.CLEAR) => AXES.map((a) => entry(a, stateFor(a)));
+
+describe('[CONTROL, asserted first] a well-formed verdict is written as six rows', () => {
+  it('writes exactly six rows to drive_state_verdicts, one per axis', async () => {
+    // Leads deliberately: a store stuck at "throw" would satisfy every rejection test below while
+    // being useless, so the accept path is the control and it goes first.
+    const c = captureClient();
+    const res = await persistDriveState({ supabase: c, runId: 'run-1', entries: fullVerdict() });
+    expect(res.written).toBe(6);
+    expect(c.calls.table).toBe(TABLE);
+    expect(c.calls.rows.map((r) => r.axis).sort()).toEqual([...AXES].sort());
+    expect(c.calls.rows.every((r) => r.run_id === 'run-1')).toBe(true);
+  });
+
+  it('[TS-1 amended] carries citation and action_taken per row, and NEVER sends recorded_at', async () => {
+    const c = captureClient();
+    await persistDriveState({ supabase: c, runId: 'run-1', entries: fullVerdict() });
+    expect(c.calls.rows.every((r) => typeof r.citation === 'string' && r.citation.length > 0)).toBe(true);
+    expect(c.calls.rows.every((r) => r.action_taken === ACTION.NONE)).toBe(true);
+    // The DB clock is the single authority for the one column a duration depends on.
+    expect(c.calls.rows.every((r) => !('recorded_at' in r))).toBe(true);
+  });
+});
+
+describe('[TS-2 amended — two-sided] all three states round-trip distinctly', () => {
+  it('CLEAR stays CLEAR, STALLED stays STALLED, UNMEASURABLE stays UNMEASURABLE with its reason', async () => {
+    // The original was one-sided: a store writing UNMEASURABLE for EVERY axis would have passed it.
+    // All three states appear in ONE verdict, so a constant-writing store cannot survive.
+    const mixed = [
+      entry(AXES[0], STATE.CLEAR),
+      entry(AXES[1], STATE.STALLED),
+      entry(AXES[2], STATE.UNMEASURABLE, { reason: 'unmeasurable_until_linkage' }),
+      entry(AXES[3], STATE.CLEAR),
+      entry(AXES[4], STATE.STALLED),
+      entry(AXES[5], STATE.CLEAR),
+    ];
+    const c = captureClient();
+    await persistDriveState({ supabase: c, runId: 'run-1', entries: mixed });
+    const byAxis = Object.fromEntries(c.calls.rows.map((r) => [r.axis, r]));
+    expect(byAxis[AXES[0]].state).toBe('CLEAR');
+    expect(byAxis[AXES[1]].state).toBe('STALLED');
+    expect(byAxis[AXES[2]].state).toBe('UNMEASURABLE');
+    expect(byAxis[AXES[2]].reason).toBe('unmeasurable_until_linkage');
+    // No field collapses the three states into a pass/fail.
+    expect(Object.values(byAxis).some((r) => typeof r.state === 'boolean' || typeof r.state === 'number')).toBe(false);
+  });
+
+  it('refuses an UNMEASURABLE axis with no reason', async () => {
+    const bad = fullVerdict().map((e, i) => (i === 0 ? { ...e, state: STATE.UNMEASURABLE, reason: '  ' } : e));
+    await expect(persistDriveState({ supabase: captureClient(), runId: 'r', entries: bad })).rejects.toThrow(/UNMEASURABLE with no reason/);
+  });
+});
+
+describe('[TS-3 amended] a write failure THROWS rather than being swallowed', () => {
+  it('propagates the error so the caller can print a visible banner', async () => {
+    const c = captureClient({ failWith: { code: '23505', message: 'duplicate key' } });
+    await expect(persistDriveState({ supabase: c, runId: 'r', entries: fullVerdict() })).rejects.toThrow(/durable write failed/);
+  });
+});
+
+describe('the store refuses a verdict that would become a durable half-truth', () => {
+  it('refuses a SHORT verdict — five rows renders identically to six on anything that does not count', async () => {
+    const short = fullVerdict().slice(0, 5);
+    await expect(persistDriveState({ supabase: captureClient(), runId: 'r', entries: short })).rejects.toThrow(/expected 6 axis entries, got 5/);
+  });
+  it('refuses an unrecognised axis', async () => {
+    const bad = [...fullVerdict().slice(0, 5), entry('not_an_axis', STATE.CLEAR)];
+    await expect(persistDriveState({ supabase: captureClient(), runId: 'r', entries: bad })).rejects.toThrow(/unrecognised axis/);
+  });
+  it('refuses an empty runId — rows without it cannot be reassembled into a history', async () => {
+    await expect(persistDriveState({ supabase: captureClient(), runId: '  ', entries: fullVerdict() })).rejects.toThrow(/runId must be a non-empty string/);
+  });
+});
+
+describe('[TS-5 / TS-7] the duration query, and contiguity', () => {
+  const R = (axis, state, t) => ({ axis, state, recorded_at: t, run_id: t });
+
+  it('[THE POINT] an axis STALLED in two consecutive runs reports a span with its first-seen time', async () => {
+    const c = readClient([R('fleet_health', STATE.STALLED, '2026-08-08T10:00:00Z'), R('fleet_health', STATE.STALLED, '2026-08-08T11:00:00Z')]);
+    const spans = await currentStallSpans({ supabase: c });
+    expect(spans).toHaveLength(1);
+    expect(spans[0].axis).toBe('fleet_health');
+    expect(spans[0].since).toBe('2026-08-08T10:00:00Z');
+    expect(spans[0].runs).toBe(2);
+  });
+
+  it('[THE OTHER SIDE] an axis STALLED in only one run, then CLEAR, returns NOTHING', async () => {
+    const c = readClient([R('fleet_health', STATE.STALLED, '2026-08-08T10:00:00Z'), R('fleet_health', STATE.CLEAR, '2026-08-08T11:00:00Z')]);
+    expect(await currentStallSpans({ supabase: c })).toEqual([]);
+  });
+
+  it('[TS-7 CONTIGUITY] STALLED / CLEAR / STALLED is TWO short stalls, never one long one', async () => {
+    // A naive count of STALLED rows would report a span reaching back across the RECOVERY —
+    // a silently wrong duration, which is the exact class this SD exists to stop producing.
+    const c = readClient([
+      R('roadmap_motion', STATE.STALLED, '2026-08-08T09:00:00Z'),
+      R('roadmap_motion', STATE.CLEAR, '2026-08-08T10:00:00Z'),
+      R('roadmap_motion', STATE.STALLED, '2026-08-08T11:00:00Z'),
+    ]);
+    const spans = await currentStallSpans({ supabase: c });
+    expect(spans).toHaveLength(1);
+    expect(spans[0].runs).toBe(1);
+    // The span starts at the SECOND stall, not the first.
+    expect(spans[0].since).toBe('2026-08-08T11:00:00Z');
+  });
+
+  it('an UNMEASURABLE reading breaks the span too — it is not a STALLED reading', async () => {
+    const c = readClient([
+      R('learning_conversion', STATE.STALLED, '2026-08-08T09:00:00Z'),
+      R('learning_conversion', STATE.UNMEASURABLE, '2026-08-08T10:00:00Z'),
+      R('learning_conversion', STATE.STALLED, '2026-08-08T11:00:00Z'),
+    ]);
+    expect((await currentStallSpans({ supabase: c }))[0].runs).toBe(1);
+  });
+});
+
+describe('[TS-4 / FR-4] vocabulary drift between the schema CHECK and contract.cjs AXES', () => {
+  const MIGRATION = path.resolve(__dirname, '../../../database/migrations/20260808_drive_state_verdicts.sql');
+
+  /** Parse the axis CHECK out of the real migration text. Returns null when absent. */
+  function parseAxisCheck(sql) {
+    const m = /axis\s+TEXT\s+NOT\s+NULL\s+CHECK\s*\(\s*axis\s+IN\s*\(([^)]*)\)/i.exec(sql);
+    if (!m) return null;
+    return m[1].split(',').map((s) => s.trim().replace(/^'|'$/g, '')).filter(Boolean);
+  }
+
+  it('[PARSER CONTROL — without this every assertion below is vacuously true] the parser finds the real constraint AND returns null when there is none', () => {
+    const sql = fs.readFileSync(MIGRATION, 'utf8');
+    expect(parseAxisCheck(sql)).not.toBeNull();
+    // A silently-null parser would make set-equality trivially pass on both sides.
+    expect(parseAxisCheck('CREATE TABLE x (axis TEXT NOT NULL);')).toBeNull();
+  });
+
+  it('the schema vocabulary EQUALS contract.cjs AXES', () => {
+    const parsed = parseAxisCheck(fs.readFileSync(MIGRATION, 'utf8'));
+    expect([...parsed].sort()).toEqual([...AXES].sort());
+  });
+
+  it('[BOTH DIRECTIONS, by mutating the REAL parsed pair] an extra schema axis fails, and a missing one fails', () => {
+    // Mutating the real pair, not comparing two synthetic lists — a synthetic comparison tests the
+    // comparator, not schema-vs-contract.
+    const parsed = parseAxisCheck(fs.readFileSync(MIGRATION, 'utf8'));
+    expect([...parsed, 'rogue_axis'].sort()).not.toEqual([...AXES].sort());
+    expect([...parsed].slice(0, -1).sort()).not.toEqual([...AXES].sort());
+  });
+
+  /**
+   * The DDL only — comments STRIPPED.
+   *
+   * This exists because the first version of the assertion below scanned raw file text and FAILED
+   * on its own documentation: the migration header explains why the codebase_health_snapshots
+   * idiom was REJECTED (quoting its `score NUMERIC NOT NULL`), and the COMMENT ON says the table
+   * has "no boolean or numeric health column". Both are prose ABOUT the absence, and a raw scan
+   * read them as the presence. A scanner is a filter over a shape you assumed — assume the DDL,
+   * and strip everything that is not DDL first.
+   */
+  function ddlOnly(sql) {
+    return sql
+      .replace(/--[^\n]*/g, '')                    // line comments
+      .replace(/COMMENT\s+ON[\s\S]*?;/gi, '');     // COMMENT ON ... ; statements
+  }
+
+  it('[CONTROL for the stripper] comment text is removed, and the real column definitions survive', () => {
+    const stripped = ddlOnly(fs.readFileSync(MIGRATION, 'utf8'));
+    // If the stripper ate everything, every assertion below would pass vacuously.
+    expect(/CREATE TABLE/i.test(stripped)).toBe(true);
+    expect(/run_id\s+TEXT NOT NULL/i.test(stripped)).toBe(true);
+    expect(stripped.includes('codebase_health_snapshots')).toBe(false); // prose gone
+  });
+
+  it('the migration declares UNIQUE (run_id, axis) and no boolean/numeric health column', () => {
+    const ddl = ddlOnly(fs.readFileSync(MIGRATION, 'utf8'));
+    expect(/UNIQUE\s*\(\s*run_id\s*,\s*axis\s*\)/i.test(ddl)).toBe(true);
+    // Scoped to NON-KEY columns: a bare numeric scan false-positives on `id BIGSERIAL`.
+    const body = ddl.slice(ddl.indexOf('run_id'));
+    expect(/\b(score|health|value)\s+(numeric|integer|real|double)/i.test(body)).toBe(false);
+    expect(/\bBOOLEAN\b/i.test(body)).toBe(false);
+  });
+
+  it('[POSITIVE CONTROL] the same assertion DOES fire on a table that has those columns', () => {
+    // Proves the check can fail, rather than being a regex that never matches anything.
+    const bad = ddlOnly('CREATE TABLE t (\n  run_id TEXT NOT NULL,\n  score NUMERIC NOT NULL,\n  ok BOOLEAN\n);');
+    const body = bad.slice(bad.indexOf('run_id'));
+    expect(/\b(score|health|value)\s+(numeric|integer|real|double)/i.test(body)).toBe(true);
+    expect(/\bBOOLEAN\b/i.test(body)).toBe(true);
+  });
+});
+
+describe('[TS-8] the single-writer decision is enforced, not just documented', () => {
+  it('adam-pm-board does NOT persist — a second writer would double-count one instant', () => {
+    const board = fs.readFileSync(path.resolve(__dirname, '../../../scripts/adam-pm-board.mjs'), 'utf8');
+    expect(board.includes('drive-state-verdict-store')).toBe(false);
+    expect(/persistDriveState/.test(board)).toBe(false);
+  });
+
+  it('coordinator-hourly-review DOES persist, and reads the verdict field that actually exists', () => {
+    const review = fs.readFileSync(path.resolve(__dirname, '../../../scripts/coordinator-hourly-review.cjs'), 'utf8');
+    expect(review.includes('drive-state-verdict-store')).toBe(true);
+    // verdict.axes is the real field (index.cjs:70). Guarding on verdict.entries would make the
+    // whole persist a silent no-op that looks fine — this pins the field name.
+    expect(/Array\.isArray\(verdict\.axes\)/.test(review)).toBe(true);
+  });
+});

--- a/tests/unit/retention/retention-policy.test.js
+++ b/tests/unit/retention/retention-policy.test.js
@@ -15,7 +15,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../../../');
 
 describe('policy registry (TS-1)', () => {
-  it('registers all 13 unbounded tables with the VERIFIED timestamp columns', () => {
+  it('registers all 14 unbounded tables with the VERIFIED timestamp columns', () => {
     const m = Object.fromEntries(RETENTION_POLICIES.map((p) => [p.table, p.timestampColumn]));
     expect(m).toEqual({
       workflow_trace_log: 'created_at',
@@ -44,6 +44,14 @@ describe('policy registry (TS-1)', () => {
       // DATABASE-stamped (DEFAULT now(), deliberately never sent by the writer), so it is exactly
       // the kind of column this registry's header asks for: one no upstream value can influence.
       belt_capacity_verdicts: 'recorded_at',
+      // SD-LEO-INFRA-DRIVE-STATE-OBSERVABILITY-001: drive_state_verdicts takes SIX rows per hourly
+      // drive-state run (~52,500/yr) and exists precisely to be queried over time, so it is the
+      // same slow-leak archetype as belt_capacity_verdicts directly above. It also carries
+      // partially-untrusted text — chairman decision titles reach the citation column via an
+      // anon-insertable feedback row — which makes indefinite retention a second-order concern,
+      // not only a size one. Keyed on recorded_at, DATABASE-stamped (DEFAULT now(), deliberately
+      // never sent by the writer), which is the column class this registry's header asks for.
+      drive_state_verdicts: 'recorded_at',
     });
   });
 


### PR DESCRIPTION
## The gap

`lib/governance/drive-state/` computes a six-axis verdict over CLEAR / STALLED / UNMEASURABLE and contains **no write path**. Both consumers render it and discard it, so no question with a time dimension is answerable — how long an axis has been STALLED, whether one flipped today, whether the unmeasurable count is trending. An axis can sit stalled indefinitely while every individual hourly render still reads as an ordinary report.

## What ships

- **FR-1** `drive_state_verdicts` — one row per `(run_id, axis)`, six per run. `CHECK` on axis **and** state, `UNIQUE (run_id, axis)`, `recorded_at` defaulted by the DB. No boolean, no numeric health column: that absence is the structural defence of the three-state vocabulary. Full RLS posture (service_role policy, REVOKE, GRANT) plus a `DO $verify$` block that aborts the deploy if the constraints did not land.
- **FR-2** a store that imports the vocabulary from `contract.cjs` rather than redeclaring it, refuses short/duplicate/unexplained verdicts, sanitises at the sink, and **throws** on write error.
- **FR-3** the coordinator hourly review is the **single writer**; `adam-pm-board` deliberately does not, or one instant lands twice under two `run_id`s. A write failure prints a visible banner — byte-identical output would mean persistence could die unnoticed for weeks.
- **FR-4** a two-sided vocabulary-drift guard that mutates the *real* parsed pair, with a parser control.
- **FR-5** the duration query, in JS over fetched rows, with contiguous spans: STALLED / CLEAR / STALLED is **two** stalls, not one.
- **TR-5** widened the path-filtered DDL workflow, which otherwise would not have run for this migration at all.
- Retention policy added — the operator-contract gate correctly refused a table that accumulates ~52k rows/year with no reaper.

## Verification

`tests/unit/governance/` — **80 files / 1309 tests pass, 11 skipped** (baseline 78 / 1281 / 11). Zero failures, no new skips.

Tests are routed to tiers that actually execute: a file matching `DB_INCLUDE` reachable only by the default config is a member of **zero projects** and reports green while never running. Both new test files were verified collected.

A mutation review dead-coded the persist call and it survived all 37,365 tests, because the "coverage" was regexes over the file's own source text. The block was extracted and tested for real; the same mutation now fails 6 tests.

## Known open items (in the retrospective, not hidden)

- `currentStallSpans` has no production caller yet — the duration question is answerable in code, not in practice.
- The migration is not applied to the live DB; FR-3 is not live until it lands.
- `currentStallSpans` fails open on an empty read, and its 2000-row window is ~14 days.
- The forcing-function-on-stall is **descoped**: this makes a stall visible in history, it does not make a stall cost anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)