### PR TITLE
feat(SD-LEO-FEAT-CODIFY-HONEST-ACTIVATION-001): codify the four honesty invariants the autonomous state removes a human to skip

### DIFF
--- a/.workflow-patterns.json
+++ b/.workflow-patterns.json
@@ -4,5 +4,5 @@
   "form_validation": [],
   "loading_patterns": [],
   "navigation": [],
-  "last_scan": "2026-07-01T23:16:44.644Z"
+  "last_scan": "2026-08-09T02:42:38.460Z"
 }

--- a/docs/reference/venture-email-provisioning.md
+++ b/docs/reference/venture-email-provisioning.md
@@ -53,7 +53,23 @@ domains (Pro cap 10; SES re-evaluation at venture 11+). AUP witness:
 `guardSequenceSend({captureRecordId})` refuses sequence-sends without a
 capture-record reference (typed `AupWitnessError`).
 
+**The witness proves PRESENCE, not PROVENANCE.** It refuses an absent or blank
+reference, so it is genuinely two-sided — but any non-empty string passes, because
+there is no capture-record store to resolve the reference against. Read a pass as
+"a reference exists", never as "consent is verified". Tightening belongs in
+`guardSequenceSend` itself so every caller inherits it; a second check added
+downstream becomes a replica that drifts from this one.
+
 ## Callers
+
+`lib/marketing/autonomy-gate.js` `checkConsentInvariant()` calls `guardSequenceSend`
+as the consent gate for autonomous per-send publish authorization
+(SD-LEO-FEAT-CODIFY-HONEST-ACTIVATION-001 FR-1). Before that SD the witness had
+**zero production callers** — defined, unit-tested, documented here, and invoked by
+nobody, which is indistinguishable from absent. It is now load-bearing on an
+authorization path, so the presence-vs-provenance limit above is a live constraint
+rather than a note: a directed channel whose recipients carry any non-empty
+reference will pass consent.
 
 `EVACOOIntegration.onboardVenture()` (`lib/agents/eva-coo-integration.js`) calls
 `provisionVentureEmail` when `venture.domain` is present, fail-soft (a provisioning

--- a/lib/marketing/ai/email-campaigns.js
+++ b/lib/marketing/ai/email-campaigns.js
@@ -13,7 +13,9 @@ const RETRY_DELAYS_MS = [1000, 4000, 16000]; // Exponential backoff
 const DEFAULT_STEP_DELAY_HOURS = 48;
 
 /**
- * Campaign enrollment states.
+ * Campaign enrollment states. Already exported at the foot of this file; the autonomy
+ * gate's suppression invariant imports it from there rather than re-declaring the literal
+ * 'unsubscribed' (SD-LEO-FEAT-CODIFY-HONEST-ACTIVATION-001 FR-1) — a replica drifts.
  */
 const ENROLLMENT_STATUS = {
   ACTIVE: 'active',

--- a/lib/marketing/autonomy-gate.js
+++ b/lib/marketing/autonomy-gate.js
@@ -22,6 +22,12 @@ import { recordPendingDecision } from '../chairman/record-pending-decision.mjs';
 // chairman queue. The authorization DECISION (allowed/denied, ledger propose row) is
 // unaffected -- only the chairman-facing side effect is skipped for a fixture.
 import { isFixtureVenture, fetchVentureForFixtureCheck } from '../eva/chairman-decision-watcher.js';
+// FR-1 honesty invariants derive from the EXISTING authority for each policy rather than
+// re-deriving it here — a replica of a policy drifts from the thing it copies.
+import { ENROLLMENT_STATUS } from './ai/email-campaigns.js';
+import { guardSequenceSend } from '../venture-email/provision-venture-email.js';
+import { AupWitnessError } from '../venture-email/errors.js';
+import { checkWriteBudget } from './marketlens-caps.js';
 
 const DEFAULT_RATE_LIMIT_MAX_POSTS = 50;
 const DEFAULT_RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000;
@@ -53,6 +59,177 @@ export async function checkRateLimit({ supabase, ventureId, channelType, maxPost
   return { allowed: true, count: current };
 }
 
+/* ───────────────────────────────────────────────────────────────────────────────
+ * FR-1 (SD-LEO-FEAT-CODIFY-HONEST-ACTIVATION-001) — per-send honesty invariants.
+ *
+ * The 'autonomous' state removes the human who kept each send honest and, before this
+ * change, replaced them with nothing but a ledger write and a rate limit. These four
+ * invariants are that human, codified. They run ONLY in the autonomous branch — the
+ * propose_and_approve path still has its human and is deliberately untouched.
+ *
+ * Every invariant returns a DISTINCT named refusal, never a shared catch-all and never a
+ * log line, so a refusal names which honesty property failed and whether it failed because
+ * the property was VIOLATED or because it could not be EVALUATED. Anything unevaluable
+ * fails CLOSED. Nothing here returns a pass it did not measure.
+ * ─────────────────────────────────────────────────────────────────────────────── */
+
+/**
+ * Channels that publish to a public timeline and therefore have no enumerable recipient
+ * list. The recipient-keyed invariants (suppression, consent) are structurally
+ * inapplicable to them — an explicit, auditable classification, NOT a data-absence pass.
+ *
+ * Polarity matters: any channel NOT named here is treated as DIRECTED and gets the strict
+ * recipient-keyed path, so a newly-added channel joins the SAFE side of this set by
+ * default. Adding a channel here is a deliberate assertion that it has no recipients.
+ */
+const BROADCAST_CHANNELS = Object.freeze(['x', 'bluesky']);
+
+/**
+ * marketing_content.lifecycle_state values that mean the content has cleared the REVIEW
+ * stage of the pipeline's own state machine (content-generator.js transitionContentState:
+ * IDEATE → GENERATE → REVIEW → SCHEDULE → DISPATCH → MEASURE → OPTIMIZE). Being *in*
+ * REVIEW means under review, not approved — so REVIEW is deliberately excluded.
+ */
+const REVIEWED_CONTENT_STATES = Object.freeze(['SCHEDULE', 'DISPATCH', 'MEASURE', 'OPTIMIZE']);
+
+export const HONESTY_INVARIANTS = Object.freeze(['suppression', 'consent', 'non_fabrication', 'aup_volume']);
+
+function isBroadcastChannel(channelType) {
+  return BROADCAST_CHANNELS.includes(channelType);
+}
+
+/** A malformed audience is not a small audience — it is an unknown one. Fails closed. */
+function normalizeAudience(audience) {
+  if (!Array.isArray(audience) || audience.length === 0) return null;
+  const cleaned = audience.filter((a) => typeof a === 'string' && a.trim() !== '');
+  return cleaned.length === audience.length ? cleaned : null;
+}
+
+/**
+ * Invariant 1 — suppression / opt-out. Reads the opt-out state from campaign_enrollments
+ * using email-campaigns.js's own ENROLLMENT_STATUS, so the two cannot disagree about what
+ * "unsubscribed" means.
+ */
+export async function checkSuppressionInvariant({ supabase, channelType, audience }) {
+  if (isBroadcastChannel(channelType)) {
+    return { ok: true, refusal: null, basis: 'NOT_APPLICABLE_BROADCAST_CHANNEL' };
+  }
+  const recipients = normalizeAudience(audience);
+  if (!recipients) return { ok: false, refusal: 'SUPPRESSION_AUDIENCE_UNRESOLVED' };
+
+  const { data, error } = await supabase
+    .from('campaign_enrollments')
+    .select('lead_email')
+    .eq('status', ENROLLMENT_STATUS.UNSUBSCRIBED)
+    .in('lead_email', recipients);
+
+  if (error) return { ok: false, refusal: 'SUPPRESSION_LOOKUP_FAILED', detail: error.message };
+  if (data && data.length > 0) {
+    return { ok: false, refusal: 'SUPPRESSION_LIST_HIT', detail: `${data.length} suppressed recipient(s)` };
+  }
+  return { ok: true, refusal: null, basis: 'NO_SUPPRESSION_HIT' };
+}
+
+/**
+ * Invariant 2 — consent / opt-in, enforced through the EXISTING Resend AUP witness
+ * (guardSequenceSend): a send may only reach a recipient captured through a real opt-in,
+ * evidenced by a capture-record reference.
+ *
+ * RESIDUAL, stated so no reader over-reads this: the witness proves a reference was
+ * SUPPLIED, not that it resolves to a genuine capture event — no capture-record table
+ * exists to resolve it against (measured absent). Tightening that belongs in
+ * guardSequenceSend, which is why this calls it instead of copying it.
+ */
+export function checkConsentInvariant({ channelType, audience, consentWitnesses }) {
+  if (isBroadcastChannel(channelType)) {
+    return { ok: true, refusal: null, basis: 'NOT_APPLICABLE_BROADCAST_CHANNEL' };
+  }
+  const recipients = normalizeAudience(audience);
+  if (!recipients) return { ok: false, refusal: 'CONSENT_AUDIENCE_UNRESOLVED' };
+
+  const witnesses = consentWitnesses || {};
+  for (const recipient of recipients) {
+    try {
+      guardSequenceSend({ captureRecordId: witnesses[recipient] });
+    } catch (err) {
+      if (err instanceof AupWitnessError) {
+        return { ok: false, refusal: 'CONSENT_WITNESS_MISSING', detail: recipient };
+      }
+      throw err;
+    }
+  }
+  return { ok: true, refusal: null, basis: 'CAPTURE_RECORD_WITNESSED' };
+}
+
+/**
+ * Invariant 3 — content non-fabrication. Requires the content to have cleared the
+ * pipeline's REVIEW stage before an unsupervised channel may send it.
+ *
+ * RESIDUAL, stated plainly: this proves the content was REVIEWED, not that its claims were
+ * VERIFIED. Screening copy against a claims registry is genuinely unimplemented — there is
+ * no claims_registry table (probed live: PGRST205, absent), the same absence
+ * lib/creative/quality-gate.js records for generated assets. That depth is reported on the
+ * result as unverifiedDepth rather than folded into a silent pass.
+ */
+export async function checkNonFabricationInvariant({ supabase, contentId }) {
+  if (typeof contentId !== 'string' || contentId.trim() === '') {
+    return { ok: false, refusal: 'NON_FABRICATION_CONTENT_UNIDENTIFIED' };
+  }
+  const { data, error } = await supabase
+    .from('marketing_content')
+    .select('lifecycle_state')
+    .eq('id', contentId)
+    .maybeSingle();
+
+  if (error) return { ok: false, refusal: 'NON_FABRICATION_LOOKUP_FAILED', detail: error.message };
+  if (!data) return { ok: false, refusal: 'NON_FABRICATION_CONTENT_UNKNOWN' };
+  if (!REVIEWED_CONTENT_STATES.includes(data.lifecycle_state)) {
+    return { ok: false, refusal: 'NON_FABRICATION_CONTENT_UNREVIEWED', detail: `lifecycle_state=${data.lifecycle_state}` };
+  }
+  return {
+    ok: true,
+    refusal: null,
+    basis: `REVIEW_CLEARED:${data.lifecycle_state}`,
+    unverifiedDepth: ['claims_registry_absent'],
+  };
+}
+
+/**
+ * Invariant 4 — AUP volume, delegated to the existing standing write-cap
+ * (marketlens-caps.checkWriteBudget → get_venture_write_budget_status). That helper
+ * already fails closed on any RPC fault; this only gives the two failure modes distinct
+ * names so "over the cap" and "could not read the cap" are never conflated.
+ */
+export async function checkAupVolumeInvariant({ supabase, ventureId, logger }) {
+  const budget = await checkWriteBudget(ventureId, logger ? { supabase, logger } : { supabase });
+  if (budget.error) return { ok: false, refusal: 'AUP_VOLUME_LOOKUP_FAILED', detail: budget.error };
+  if (budget.isOverBudget) {
+    return { ok: false, refusal: 'AUP_VOLUME_EXCEEDED', detail: `writesUsed=${budget.writesUsed}` };
+  }
+  return { ok: true, refusal: null, basis: `WITHIN_WRITE_BUDGET:${budget.writesRemaining}` };
+}
+
+/**
+ * Runs all four invariants. Deliberately does NOT short-circuit: an operator fixing an
+ * autonomous send should see every honesty property that failed in one refusal, not
+ * discover them one redeploy at a time.
+ */
+export async function evaluateHonestyInvariants({ supabase, ventureId, channelType, contentId, send = {}, logger }) {
+  const results = {
+    suppression: await checkSuppressionInvariant({ supabase, channelType, audience: send.audience }),
+    consent: checkConsentInvariant({ channelType, audience: send.audience, consentWitnesses: send.consentWitnesses }),
+    non_fabrication: await checkNonFabricationInvariant({ supabase, contentId }),
+    aup_volume: await checkAupVolumeInvariant({ supabase, ventureId, logger }),
+  };
+  const failed = HONESTY_INVARIANTS.filter((name) => !results[name].ok);
+  return {
+    ok: failed.length === 0,
+    refusal: failed.length > 0 ? results[failed[0]].refusal : null,
+    failedInvariants: failed,
+    results,
+  };
+}
+
 /**
  * Fail-closed authorization check. Reads venture_channel_autonomy for the channel's
  * current state; if 'autonomous', allows immediately. If 'propose_and_approve' (the
@@ -62,7 +239,7 @@ export async function checkRateLimit({ supabase, ventureId, channelType, maxPost
  * chairman_decisions / v_injection_quarantine_queue-adjacent views, and the call is
  * denied — the caller must retry after a human approves it.
  */
-export async function checkPublishAuthorization({ supabase, ventureId, channelType, contentId, correlationId }) {
+export async function checkPublishAuthorization({ supabase, ventureId, channelType, contentId, correlationId, send = {}, logger }) {
   const { data: autonomy, error: autonomyError } = await supabase
     .from('venture_channel_autonomy')
     .select('autonomy_state')
@@ -77,6 +254,19 @@ export async function checkPublishAuthorization({ supabase, ventureId, channelTy
   const autonomyState = autonomy?.autonomy_state || 'propose_and_approve';
 
   if (autonomyState === 'autonomous') {
+    // FR-1: the honesty invariants that stand in for the human this state removes. They
+    // run BEFORE authorization is granted and BEFORE the ledger write below — a refused
+    // attempt must not leave a decision:'accepted' row asserting it was authorized.
+    const honesty = await evaluateHonestyInvariants({ supabase, ventureId, channelType, contentId, send, logger });
+    if (!honesty.ok) {
+      return {
+        allowed: false,
+        autonomyState,
+        reason: `AUTONOMOUS_HONESTY_INVARIANT_FAILED (fail-closed): ${honesty.failedInvariants.join(', ')} — ${honesty.refusal}`,
+        honesty,
+      };
+    }
+
     // ADVERSARIAL REVIEW FIX: an autonomous channel MUST still write a ledger row per
     // publish attempt. Without one, checkRateLimit() (which counts ledger rows in the
     // window) never sees autonomous-tier activity — the exact unsupervised tier that
@@ -249,4 +439,10 @@ export async function evaluateGraduation({ supabase, ventureId, channelType, req
   return { success: true, autonomyState: update.autonomy_state, cleanStreak };
 }
 
-export default { checkRateLimit, checkPublishAuthorization, recordPublishOutcome, evaluateGraduation };
+export default {
+  checkRateLimit,
+  checkPublishAuthorization,
+  recordPublishOutcome,
+  evaluateGraduation,
+  evaluateHonestyInvariants,
+};

--- a/lib/marketing/publisher/index.js
+++ b/lib/marketing/publisher/index.js
@@ -29,7 +29,7 @@ const ADAPTERS = {
  * @param {string} [params.campaignId] - Campaign UUID for UTM
  * @returns {Promise<{success: boolean, postId?: string, postUrl?: string, error?: string}>}
  */
-export async function publish({ supabase, content, platform, options = {}, ventureId, campaignId }) {
+export async function publish({ supabase, content, platform, options = {}, ventureId, campaignId, send = {} }) {
   const AdapterClass = ADAPTERS[platform];
   if (!AdapterClass) {
     return { success: false, error: `Unsupported platform: ${platform}. Supported: ${Object.keys(ADAPTERS).join(', ')}` };
@@ -53,8 +53,11 @@ export async function publish({ supabase, content, platform, options = {}, ventu
   // MUST run before adapter construction — this is the enforcement chokepoint every
   // caller (content-pipeline.js, owned-audience-content-loop.js) passes through.
   // No log-only branch: a missing/errored read here denies the publish attempt.
+  // SD-LEO-FEAT-CODIFY-HONEST-ACTIVATION-001 FR-1: `send` carries the per-send facts the
+  // autonomous branch's honesty invariants judge (audience, consent witnesses). A directed
+  // channel that omits it is refused, not waved through — see evaluateHonestyInvariants.
   const authCheck = await checkPublishAuthorization({
-    supabase, ventureId, channelType: platform, contentId: content.id, correlationId: idempotencyKey
+    supabase, ventureId, channelType: platform, contentId: content.id, correlationId: idempotencyKey, send
   });
   if (!authCheck.allowed) {
     return { success: false, error: authCheck.reason, blockedBy: 'autonomy-gate' };

--- a/lib/venture-email/provision-venture-email.js
+++ b/lib/venture-email/provision-venture-email.js
@@ -156,6 +156,22 @@ export async function registerProvisioningOwner(supabase) {
 /**
  * AUP witness (FR-7): every sequence-send on the venture rail must carry a
  * capture-record reference. Refusal is typed and journal-able by the caller.
+ *
+ * ⚠️ PLACEHOLDER WITNESS — PRESENCE ONLY, NOT PROVENANCE.
+ * This proves a capture-record reference was SUPPLIED. It does NOT prove the reference
+ * resolves to a real opt-in event: there is no capture-record table to resolve it against
+ * (measured absent). Any non-empty string passes. Treat a pass as "a reference exists",
+ * never as "consent is verified".
+ *
+ * Tightening belongs HERE, at this definition site, not in the callers — resolving the
+ * reference once means every caller inherits it, whereas a second check bolted on
+ * downstream becomes a replica that drifts from this one.
+ *
+ * CONSUMERS (SD-LEO-FEAT-CODIFY-HONEST-ACTIVATION-001 FR-1): lib/marketing/autonomy-gate.js
+ * checkConsentInvariant() makes this the consent gate for autonomous per-send authorization.
+ * Before that SD this function had ZERO production callers, so the placeholder was
+ * inert; it is now load-bearing on an authorization path, which is why the limit is
+ * marked at the code a consumer actually reads rather than in a PR description.
  */
 export function guardSequenceSend({ captureRecordId } = {}) {
   if (!captureRecordId || typeof captureRecordId !== 'string' || captureRecordId.trim() === '') {

--- a/tests/unit/marketing/autonomy-gate.test.js
+++ b/tests/unit/marketing/autonomy-gate.test.js
@@ -124,7 +124,13 @@ describe('recordPublishOutcome', () => {
 });
 
 describe('checkPublishAuthorization — dedup + FR-7 chairman_decisions routing', () => {
-  function makeAuthSupabase({ autonomyState = null, autonomyError = null, acceptedRow = null, acceptedError = null, existingPending = null, existingPendingError = null, insertData = { id: 'ledger-new' }, insertError = null, ventureRow = { is_demo: false, name: 'Real Venture', launch_mode: 'live' } }) {
+  function makeAuthSupabase({ autonomyState = null, autonomyError = null, acceptedRow = null, acceptedError = null, existingPending = null, existingPendingError = null, insertData = { id: 'ledger-new' }, insertError = null, ventureRow = { is_demo: false, name: 'Real Venture', launch_mode: 'live' },
+    // SD-LEO-FEAT-CODIFY-HONEST-ACTIVATION-001 FR-1: the autonomous branch now evaluates
+    // four honesty invariants before authorizing. Defaults are the honest-and-healthy path
+    // (content past REVIEW, write budget under cap) so the pre-existing autonomous cases
+    // still describe an authorized send rather than silently becoming refusal tests.
+    contentRow = { lifecycle_state: 'SCHEDULE' }, contentError = null,
+    writeBudget = { is_over_budget: false, writes_used: 1, writes_remaining: 99 }, writeBudgetError = null }) {
     let ledgerMaybeSingleCallCount = 0;
     const autonomyChain = {
       select: vi.fn().mockReturnThis(),
@@ -150,13 +156,24 @@ describe('checkPublishAuthorization — dedup + FR-7 chairman_decisions routing'
       eq: vi.fn().mockReturnThis(),
       maybeSingle: vi.fn(() => Promise.resolve({ data: ventureRow, error: null })),
     };
+    // FR-1 invariant 3 reads marketing_content on its own chain — sharing ledgerChain would
+    // consume one of its call-count-based maybeSingle slots and corrupt the dedup mock.
+    const marketingContentChain = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn(() => Promise.resolve({ data: contentRow, error: contentError })),
+    };
     return {
       from: vi.fn((table) => {
         if (table === 'venture_channel_autonomy') return autonomyChain;
         if (table === 'ventures') return venturesChain;
+        if (table === 'marketing_content') return marketingContentChain;
         return ledgerChain;
       }),
+      // FR-1 invariant 4 delegates to marketlens-caps.checkWriteBudget, which calls this RPC.
+      rpc: vi.fn(() => Promise.resolve({ data: [writeBudget], error: writeBudgetError })),
       ledgerChain,
+      marketingContentChain,
     };
   }
 

--- a/tests/unit/marketing/honesty-invariants.test.js
+++ b/tests/unit/marketing/honesty-invariants.test.js
@@ -1,0 +1,292 @@
+/**
+ * SD-LEO-FEAT-CODIFY-HONEST-ACTIVATION-001 FR-1 — per-send honesty invariants.
+ *
+ * Two-sided throughout: every invariant is proven to BLOCK the dishonest send (a gate that
+ * only passes is camouflage) AND to PASS the clean one (a gate that only blocks cannot
+ * discriminate). The broadcast exemption gets its own narrowness control, because an
+ * exemption nobody tests is indistinguishable from a global bypass.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../../../lib/chairman/record-pending-decision.mjs', () => ({
+  recordPendingDecision: vi.fn().mockResolvedValue({ recorded: true, id: 'decision-1' }),
+}));
+
+import {
+  HONESTY_INVARIANTS,
+  checkSuppressionInvariant,
+  checkConsentInvariant,
+  checkNonFabricationInvariant,
+  checkAupVolumeInvariant,
+  evaluateHonestyInvariants,
+  checkPublishAuthorization,
+} from '../../../lib/marketing/autonomy-gate.js';
+
+/**
+ * @param suppressed rows returned by the campaign_enrollments suppression query
+ * @param contentRow  the marketing_content row (null = content unknown)
+ * @param writeBudget the get_venture_write_budget_status RPC payload
+ */
+function makeSupabase({
+  suppressed = [], suppressionError = null,
+  contentRow = { lifecycle_state: 'SCHEDULE' }, contentError = null,
+  writeBudget = { is_over_budget: false, writes_used: 1, writes_remaining: 99 }, writeBudgetError = null,
+  autonomyState = 'autonomous', insertData = { id: 'ledger-1' }, insertError = null,
+} = {}) {
+  const enrollmentsChain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn(() => Promise.resolve({ data: suppressed, error: suppressionError })),
+  };
+  const contentChain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn(() => Promise.resolve({ data: contentRow, error: contentError })),
+  };
+  const autonomyChain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn(() => Promise.resolve({ data: autonomyState ? { autonomy_state: autonomyState } : null, error: null })),
+  };
+  const ledgerChain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    single: vi.fn(() => Promise.resolve({ data: insertError ? null : insertData, error: insertError })),
+    maybeSingle: vi.fn(() => Promise.resolve({ data: null, error: null })),
+  };
+  const venturesChain = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn(() => Promise.resolve({ data: { is_demo: false, name: 'Real Venture', launch_mode: 'live' }, error: null })),
+  };
+
+  return {
+    from: vi.fn((table) => {
+      if (table === 'campaign_enrollments') return enrollmentsChain;
+      if (table === 'marketing_content') return contentChain;
+      if (table === 'venture_channel_autonomy') return autonomyChain;
+      if (table === 'ventures') return venturesChain;
+      return ledgerChain;
+    }),
+    rpc: vi.fn(() => Promise.resolve({ data: [writeBudget], error: writeBudgetError })),
+    enrollmentsChain,
+    contentChain,
+    ledgerChain,
+  };
+}
+
+const DIRECTED = 'email';           // NOT on the broadcast list — gets the strict path
+const AUDIENCE = ['lead@example.com'];
+const WITNESSES = { 'lead@example.com': 'cap-123' };
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('FR-1 invariant 1 — suppression / opt-out', () => {
+  it('BLOCKS a send to a suppressed recipient on a directed channel', async () => {
+    const supabase = makeSupabase({ suppressed: [{ lead_email: 'lead@example.com' }] });
+    const r = await checkSuppressionInvariant({ supabase, channelType: DIRECTED, audience: AUDIENCE });
+    expect(r.ok).toBe(false);
+    expect(r.refusal).toBe('SUPPRESSION_LIST_HIT');
+  });
+
+  it('PASSES a send to a recipient with no opt-out on record', async () => {
+    const supabase = makeSupabase({ suppressed: [] });
+    const r = await checkSuppressionInvariant({ supabase, channelType: DIRECTED, audience: AUDIENCE });
+    expect(r.ok).toBe(true);
+    expect(r.basis).toBe('NO_SUPPRESSION_HIT');
+  });
+
+  it('reads the opt-out state as email-campaigns defines it, not a re-declared literal', async () => {
+    const supabase = makeSupabase();
+    await checkSuppressionInvariant({ supabase, channelType: DIRECTED, audience: AUDIENCE });
+    expect(supabase.enrollmentsChain.eq).toHaveBeenCalledWith('status', 'unsubscribed');
+  });
+
+  it('fails CLOSED when the audience cannot be enumerated — an unknown audience is not an empty one', async () => {
+    const supabase = makeSupabase();
+    for (const audience of [undefined, [], ['ok@example.com', ''], 'not-an-array']) {
+      const r = await checkSuppressionInvariant({ supabase, channelType: DIRECTED, audience });
+      expect(r.ok).toBe(false);
+      expect(r.refusal).toBe('SUPPRESSION_AUDIENCE_UNRESOLVED');
+    }
+  });
+
+  it('fails CLOSED with a DISTINCT name when the suppression list cannot be read', async () => {
+    const supabase = makeSupabase({ suppressionError: { message: 'db down' } });
+    const r = await checkSuppressionInvariant({ supabase, channelType: DIRECTED, audience: AUDIENCE });
+    expect(r.ok).toBe(false);
+    // "could not check" must never be reported as "checked and clean".
+    expect(r.refusal).toBe('SUPPRESSION_LOOKUP_FAILED');
+  });
+
+  it('records a broadcast channel as structurally inapplicable, not as a silent pass', async () => {
+    const supabase = makeSupabase();
+    const r = await checkSuppressionInvariant({ supabase, channelType: 'x', audience: undefined });
+    expect(r.ok).toBe(true);
+    expect(r.basis).toBe('NOT_APPLICABLE_BROADCAST_CHANNEL');
+  });
+
+  it('NARROWNESS CONTROL: the broadcast exemption does not leak to unlisted channels', async () => {
+    const supabase = makeSupabase();
+    // If BROADCAST_CHANNELS were ever widened to a catch-all, this is the arm that reds.
+    const r = await checkSuppressionInvariant({ supabase, channelType: 'some-new-channel', audience: undefined });
+    expect(r.ok).toBe(false);
+    expect(r.refusal).toBe('SUPPRESSION_AUDIENCE_UNRESOLVED');
+  });
+});
+
+describe('FR-1 invariant 2 — consent / opt-in', () => {
+  it('BLOCKS a recipient with no capture-record witness', () => {
+    const r = checkConsentInvariant({ channelType: DIRECTED, audience: AUDIENCE, consentWitnesses: {} });
+    expect(r.ok).toBe(false);
+    expect(r.refusal).toBe('CONSENT_WITNESS_MISSING');
+    expect(r.detail).toBe('lead@example.com');
+  });
+
+  it('BLOCKS when only SOME recipients are witnessed — one unconsented recipient is enough', () => {
+    const r = checkConsentInvariant({
+      channelType: DIRECTED,
+      audience: ['a@example.com', 'b@example.com'],
+      consentWitnesses: { 'a@example.com': 'cap-1' },
+    });
+    expect(r.ok).toBe(false);
+    expect(r.detail).toBe('b@example.com');
+  });
+
+  it('PASSES when every recipient carries a capture-record reference', () => {
+    const r = checkConsentInvariant({ channelType: DIRECTED, audience: AUDIENCE, consentWitnesses: WITNESSES });
+    expect(r.ok).toBe(true);
+    expect(r.basis).toBe('CAPTURE_RECORD_WITNESSED');
+  });
+
+  it('delegates the witness rule to guardSequenceSend — a blank reference is refused there, not here', () => {
+    const r = checkConsentInvariant({ channelType: DIRECTED, audience: AUDIENCE, consentWitnesses: { 'lead@example.com': '   ' } });
+    expect(r.ok).toBe(false);
+    expect(r.refusal).toBe('CONSENT_WITNESS_MISSING');
+  });
+});
+
+describe('FR-1 invariant 3 — content non-fabrication', () => {
+  it('BLOCKS content that has not cleared REVIEW', async () => {
+    for (const state of ['IDEATE', 'GENERATE', 'REVIEW']) {
+      const supabase = makeSupabase({ contentRow: { lifecycle_state: state } });
+      const r = await checkNonFabricationInvariant({ supabase, contentId: 'c-1' });
+      expect(r.ok).toBe(false);
+      expect(r.refusal).toBe('NON_FABRICATION_CONTENT_UNREVIEWED');
+      expect(r.detail).toBe(`lifecycle_state=${state}`);
+    }
+  });
+
+  it('PASSES content that has cleared REVIEW — but reports the depth it did NOT verify', async () => {
+    const supabase = makeSupabase({ contentRow: { lifecycle_state: 'SCHEDULE' } });
+    const r = await checkNonFabricationInvariant({ supabase, contentId: 'c-1' });
+    expect(r.ok).toBe(true);
+    // The pass means REVIEWED, never CLAIM-VERIFIED. claims_registry is absent, and this
+    // annotation is what stops a reader over-reading the pass.
+    expect(r.unverifiedDepth).toContain('claims_registry_absent');
+  });
+
+  it('fails CLOSED with DISTINCT names for unknown content vs an unreadable lookup', async () => {
+    const unknown = await checkNonFabricationInvariant({ supabase: makeSupabase({ contentRow: null }), contentId: 'c-1' });
+    expect(unknown.refusal).toBe('NON_FABRICATION_CONTENT_UNKNOWN');
+
+    const errored = await checkNonFabricationInvariant({ supabase: makeSupabase({ contentError: { message: 'db down' } }), contentId: 'c-1' });
+    expect(errored.refusal).toBe('NON_FABRICATION_LOOKUP_FAILED');
+
+    const unnamed = await checkNonFabricationInvariant({ supabase: makeSupabase(), contentId: '  ' });
+    expect(unnamed.refusal).toBe('NON_FABRICATION_CONTENT_UNIDENTIFIED');
+  });
+});
+
+describe('FR-1 invariant 4 — AUP volume', () => {
+  it('BLOCKS a send over the standing write cap', async () => {
+    const supabase = makeSupabase({ writeBudget: { is_over_budget: true, writes_used: 500, writes_remaining: 0 } });
+    const r = await checkAupVolumeInvariant({ supabase, ventureId: 'v-1' });
+    expect(r.ok).toBe(false);
+    expect(r.refusal).toBe('AUP_VOLUME_EXCEEDED');
+  });
+
+  it('PASSES a send under the cap', async () => {
+    const r = await checkAupVolumeInvariant({ supabase: makeSupabase(), ventureId: 'v-1' });
+    expect(r.ok).toBe(true);
+  });
+
+  it('fails CLOSED with a DISTINCT name when the cap itself cannot be read', async () => {
+    const supabase = makeSupabase({ writeBudgetError: { message: 'rpc exploded' } });
+    const r = await checkAupVolumeInvariant({ supabase, ventureId: 'v-1', logger: { warn: vi.fn() } });
+    expect(r.ok).toBe(false);
+    // Over-the-cap and cannot-read-the-cap are different facts and must not share a name.
+    expect(r.refusal).toBe('AUP_VOLUME_LOOKUP_FAILED');
+  });
+});
+
+describe('FR-1 runner — evaluateHonestyInvariants', () => {
+  it('reports EVERY failing invariant, not just the first', async () => {
+    const supabase = makeSupabase({
+      contentRow: { lifecycle_state: 'GENERATE' },
+      writeBudget: { is_over_budget: true, writes_used: 500, writes_remaining: 0 },
+    });
+    const r = await evaluateHonestyInvariants({ supabase, ventureId: 'v-1', channelType: DIRECTED, contentId: 'c-1', send: {} });
+    expect(r.ok).toBe(false);
+    expect(r.failedInvariants).toEqual(['suppression', 'consent', 'non_fabrication', 'aup_volume']);
+  });
+
+  it('passes only when all four invariants pass', async () => {
+    const supabase = makeSupabase();
+    const r = await evaluateHonestyInvariants({
+      supabase, ventureId: 'v-1', channelType: DIRECTED, contentId: 'c-1',
+      send: { audience: AUDIENCE, consentWitnesses: WITNESSES },
+    });
+    expect(r.ok).toBe(true);
+    expect(r.failedInvariants).toEqual([]);
+    expect(Object.keys(r.results).sort()).toEqual([...HONESTY_INVARIANTS].sort());
+  });
+});
+
+describe('FR-1 enforcement inside checkPublishAuthorization', () => {
+  it('an autonomous channel is REFUSED when an honesty invariant fails', async () => {
+    const supabase = makeSupabase({ contentRow: { lifecycle_state: 'GENERATE' } });
+    const r = await checkPublishAuthorization({ supabase, ventureId: 'v-1', channelType: 'x', contentId: 'c-1' });
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toContain('AUTONOMOUS_HONESTY_INVARIANT_FAILED');
+    expect(r.honesty.failedInvariants).toEqual(['non_fabrication']);
+  });
+
+  it('a refused autonomous attempt writes NO ledger row — no row may claim it was accepted', async () => {
+    const supabase = makeSupabase({ contentRow: { lifecycle_state: 'GENERATE' } });
+    await checkPublishAuthorization({ supabase, ventureId: 'v-1', channelType: 'x', contentId: 'c-1' });
+    expect(supabase.ledgerChain.insert).not.toHaveBeenCalled();
+  });
+
+  it('an autonomous channel is ALLOWED when every invariant passes', async () => {
+    const supabase = makeSupabase();
+    const r = await checkPublishAuthorization({ supabase, ventureId: 'v-1', channelType: 'x', contentId: 'c-1' });
+    expect(r.allowed).toBe(true);
+    expect(supabase.ledgerChain.insert).toHaveBeenCalled();
+  });
+
+  it('a DIRECTED autonomous channel is refused without an audience, and allowed with a clean consented one', async () => {
+    const blocked = await checkPublishAuthorization({
+      supabase: makeSupabase(), ventureId: 'v-1', channelType: DIRECTED, contentId: 'c-1',
+    });
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.honesty.failedInvariants).toEqual(['suppression', 'consent']);
+
+    const allowed = await checkPublishAuthorization({
+      supabase: makeSupabase(), ventureId: 'v-1', channelType: DIRECTED, contentId: 'c-1',
+      send: { audience: AUDIENCE, consentWitnesses: WITNESSES },
+    });
+    expect(allowed.allowed).toBe(true);
+  });
+
+  it('SCOPE CONTROL: propose_and_approve is untouched — it still denies for its own reason, never the honesty one', async () => {
+    const supabase = makeSupabase({ autonomyState: 'propose_and_approve', contentRow: { lifecycle_state: 'GENERATE' } });
+    const r = await checkPublishAuthorization({ supabase, ventureId: 'v-1', channelType: 'x', contentId: 'c-1' });
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toContain('AUTONOMY_APPROVAL_REQUIRED');
+    expect(r.reason).not.toContain('HONESTY');
+    // The invariants never even ran on this branch — the human is still the check here.
+    expect(supabase.contentChain.maybeSingle).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/marketing/publisher.test.js
+++ b/tests/unit/marketing/publisher.test.js
@@ -53,6 +53,10 @@ function createMockSupabase(overrides = {}) {
       error: null
     },
     venture_channel_secrets: { maybeSingle: { data: { secret_ref: TEST_SECRET_REF }, error: null } },
+    // SD-LEO-FEAT-CODIFY-HONEST-ACTIVATION-001 FR-1: the autonomous branch now also
+    // requires the content to have cleared REVIEW. "Everything wired and healthy" now
+    // includes that, so these tests still exercise an authorized publish.
+    marketing_content: { maybeSingle: { data: { lifecycle_state: 'SCHEDULE' }, error: null } },
     channel_budgets: {
       single: {
         data: { status: 'active', current_month_spend_cents: 0, monthly_budget_cents: 10000, daily_limit_cents: null },
@@ -78,7 +82,14 @@ function createMockSupabase(overrides = {}) {
     return chain;
   };
 
-  const mock = { from: vi.fn((table) => builder(table)) };
+  const mock = {
+    from: vi.fn((table) => builder(table)),
+    // FR-1 invariant 4 (AUP volume) delegates to marketlens-caps.checkWriteBudget.
+    rpc: vi.fn(() => Promise.resolve({
+      data: [tableConfig.__writeBudget ?? { is_over_budget: false, writes_used: 1, writes_remaining: 99 }],
+      error: null,
+    })),
+  };
   return mock;
 }
 


### PR DESCRIPTION
FR-1 of SD-LEO-FEAT-CODIFY-HONEST-ACTIVATION-001. The `autonomous` state removed the human who kept each send honest and replaced them with a ledger write and a rate limit. These four invariants are that human, codified.

## Scope: FR-1 only

The coordinator split this SD after I measured that the demand-validation gate FR-2/3/4 depend on **does not exist** — zero grep hits, four candidate tables absent, the "300-visitor floor" appearing only in this SD's own plan doc. That half is now an Adam-sourced sibling. AC-4 spans both halves, so the split creates no safety gap.

`propose_and_approve` is **untouched** — it still has its human. A scope control asserts it denies for its own reason and that the invariants never even run on that branch.

## Derived from existing authorities, not re-implemented

| Invariant | Authority |
|---|---|
| suppression / opt-out | `campaign_enrollments` + email-campaigns' own `ENROLLMENT_STATUS` |
| consent / opt-in | `guardSequenceSend` — the Resend AUP witness |
| content non-fabrication | `marketing_content.lifecycle_state` past the pipeline's REVIEW stage |
| AUP volume | `marketlens-caps.checkWriteBudget` (already fail-closed) |

`guardSequenceSend` had **zero production callers** before this — defined, tested, documented, and invoked by nobody. An instrument nobody invokes is indistinguishable from an absent one.

## Two residuals, stated rather than buried

**Consent proves a reference was supplied, not that it resolves.** There is no capture-record table to resolve it against. Tightening that belongs inside `guardSequenceSend`, which is why this calls it instead of copying it.

**Non-fabrication proves the content was REVIEWED, not that its claims were VERIFIED.** Screening copy against a claims registry is genuinely unimplemented — `claims_registry` is absent (probed live: PGRST205), the same absence `lib/creative/quality-gate.js` records for generated assets. The passing result carries `unverifiedDepth: ['claims_registry_absent']` so a reader cannot over-read it.

## The broadcast exemption is declared, not inferred

The only caller is a broadcast path (`x`, `bluesky`) with no recipient parameter anywhere in the chain, so the recipient-keyed invariants have no subject there. That is recorded as `NOT_APPLICABLE_BROADCAST_CHANNEL` — an explicit classification, never a data-absence pass.

Polarity is deliberate: a channel **not** on the list gets the strict path, so a new channel joins the safe side by default. A narrowness control reds if that exemption ever widens to a catch-all.

## Distinct names, and VIOLATED never conflated with UNEVALUABLE

Every invariant returns its own named refusal, and separates "checked and bad" from "could not check" — `SUPPRESSION_LIST_HIT` vs `SUPPRESSION_LOOKUP_FAILED`, `AUP_VOLUME_EXCEEDED` vs `AUP_VOLUME_LOOKUP_FAILED`. Reporting an unreadable suppression list as a clean one is the exact lie this SD exists to prevent. Everything unevaluable fails closed.

Refusal happens **before** the ledger write, so a refused attempt leaves no `decision:'accepted'` row asserting it was authorized.

## Measured live, not inherited

- `venture_channel_autonomy`: **0 rows** — AC-4 holds, nothing is autonomous, and I re-verified rather than quoting the plan
- `campaign_enrollments`, `venture_write_ledger`: present; `get_venture_write_budget_status`: callable
- `claims_registry`: **absent** (PGRST205)

## Verification

**9/9 mutations each reddened a named test** — including one that widens the broadcast exemption and one that leaks the invariants onto `propose_and_approve`. Every invariant is two-sided: proven to block the dishonest send *and* pass the clean one.

**Full unit project: 3064 files / 37383 tests passing, 0 failures.**

SD: SD-LEO-FEAT-CODIFY-HONEST-ACTIVATION-001 · LEAD-TO-PLAN 94 · PLAN-TO-EXEC 85

🤖 Generated with [Claude Code](https://claude.com/claude-code)
