### PR TITLE
fix(QF-20260808-782): cap the idle-QF hint sender per (qf,target) — the durable fix

### DIFF
--- a/scripts/coordinator-idle-qf-hint.mjs
+++ b/scripts/coordinator-idle-qf-hint.mjs
@@ -236,7 +236,9 @@ export async function runIdleQfHintCore(supabase, { nowMs = Date.now(), dryRun =
   // denominator half. `hinted` alone cannot separate 1-of-10 from 9-of-10 — a pass that reports
   // completion while reaching a minority is the same camouflage as a stranded QF that the gauge
   // still counts, which is the other half of this SD.
-  const summary = { idleWorkers: 0, hinted: 0, skippedGated: 0, attempted: 0, undelivered: 0, undeliveredReasons: [] };
+  // QF-20260808-782: skippedCapped/capUnknown are initialised to 0 rather than left undefined —
+  // a counter that only appears once it fires cannot be distinguished from one that never ran.
+  const summary = { idleWorkers: 0, hinted: 0, skippedGated: 0, attempted: 0, undelivered: 0, undeliveredReasons: [], skippedCapped: 0, capUnknown: 0 };
 
   // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 9: claude_sessions is unbounded and this
   // read has no heartbeat/status filter at all (the QF-763 `.order()` only avoids a STALENESS bias
@@ -298,7 +300,44 @@ function recordUndelivered(summary, worker, reason) {
  * @param {Array} ranked - hintable QFs, best first
  * @param {{summary:object, supabase:object, coordinatorId:string, dryRun:boolean, insertRow?:Function}} deps
  */
-export async function deliverHints(idle, ranked, { summary, supabase, coordinatorId, dryRun = false, insertRow = insertCoordinationRow } = {}) {
+/**
+ * QF-20260808-782: how many hints for THIS (qf, target) pair already exist.
+ *
+ * UNKNOWN IS NOT ZERO — and that distinction is the whole guard. If this read fails, or PostgREST
+ * returns a null count (which a `head:true` count does on a table it cannot see, WITHOUT an error),
+ * returning 0 would silently re-uncap the sender: every tick would look like "first hint" forever,
+ * which is precisely the 82-identical-sends bug this QF exists to stop. So an unreadable count
+ * returns null, the caller treats null as UNKNOWN, and the uncertainty is COUNTED in the summary
+ * rather than resolved in the sender's favour.
+ */
+async function countPriorHintsDefault(supabase, { qfId, targetSession }) {
+  try {
+    const { count, error } = await supabase
+      .from('session_coordination')
+      .select('id', { count: 'exact', head: true })
+      .eq('target_session', targetSession)
+      .eq('payload->>qf_id', qfId);
+    if (error) return null;
+    return typeof count === 'number' ? count : null;
+  } catch {
+    // A THROW IS JUST ANOTHER WAY OF "CANNOT READ THE COUNT". It must not kill the sweep — this
+    // file already learned that lesson once (FR-5: one unreachable addressee starved every worker
+    // later in the loop, observed 2026-07-26). Returning null routes a throw to the same UNKNOWN
+    // branch as an error or a null count, so the blindness is COUNTED rather than swallowed.
+    return null;
+  }
+}
+
+/**
+ * QF-20260808-782: at most this many hints for one (qf, target) pair, ever.
+ * Measured motivation: 82 byte-identical hints for ONE qf to ONE seat in 5.7h (04:08–09:50),
+ * plus 12 and 2 for two others — 96 of that seat's last 127 inbox rows, burying a direct
+ * coordinator feedback request for 2h20m. An unacked hint after 3 sends means the reader is not
+ * reading that lane; it does not mean the reader needs 79 more.
+ */
+export const HINT_SEND_CAP = 3;
+
+export async function deliverHints(idle, ranked, { summary, supabase, coordinatorId, dryRun = false, insertRow = insertCoordinationRow, countPriorHints = countPriorHintsDefault } = {}) {
   // One-hint-per-worker, one-QF-per-hint this tick: consume the ranked list as we go so no QF
   // is double-hinted and no worker gets more than one suggestion.
   const remaining = [...ranked];
@@ -309,6 +348,28 @@ export async function deliverHints(idle, ranked, { summary, supabase, coordinato
     );
     if (idx === -1) continue;
     const [qf] = remaining.splice(idx, 1);
+
+    // QF-20260808-782: CAP AND STOP. Checked BEFORE `attempted` because a capped pair was never
+    // attempted — counting it would inflate the denominator of the delivery ratio and make a
+    // working cap look like degraded delivery.
+    //
+    // The QF goes BACK on the list: this WORKER has heard about it enough times, but the work is
+    // still unhinted and another worker in this pass may fit it. Dropping it would silently reduce
+    // supply — the same reasoning the throw/error paths below already use.
+    if (!dryRun) {
+      const prior = await countPriorHints(supabase, { qfId: qf.id, targetSession: worker.session_id });
+      if (prior === null) {
+        // Blind, not clean. Send (matching today's behaviour rather than starving the seat), but
+        // COUNT the blindness so a cap that cannot see is visible instead of indistinguishable
+        // from a cap that saw nothing.
+        summary.capUnknown = (summary.capUnknown || 0) + 1;
+      } else if (prior >= HINT_SEND_CAP) {
+        summary.skippedCapped = (summary.skippedCapped || 0) + 1;
+        remaining.splice(idx, 0, qf);
+        continue;
+      }
+    }
+
     summary.attempted += 1;
     if (!dryRun) {
       // FR-5: SKIP-AND-CONTINUE. insertCoordinationRow -> assertDispatchTarget FAILS CLOSED and
@@ -367,7 +428,8 @@ async function main() {
   const pct = ratio === null ? 'n/a' : `${Math.round(ratio * 100)}%`;
   console.log(
     `IDLE_QF_HINT idleWorkers=${summary.idleWorkers} delivered=${summary.hinted} attempted=${summary.attempted}`
-    + ` ratio=${pct} undelivered=${summary.undelivered} skippedGated=${summary.skippedGated}${dryRun ? ' (dry-run)' : ''}`,
+    + ` ratio=${pct} undelivered=${summary.undelivered} skippedGated=${summary.skippedGated}`
+    + ` skippedCapped=${summary.skippedCapped || 0} capUnknown=${summary.capUnknown || 0}${dryRun ? ' (dry-run)' : ''}`,
   );
   // FR-6: the alarm must be DURABLE, not just loud. emitDeliveryAlarm no-ops unless the pass is
   // genuinely degraded (threshold + minSample floor both applied inside).

--- a/tests/unit/coordinator/idle-qf-hint-send-cap.test.js
+++ b/tests/unit/coordinator/idle-qf-hint-send-cap.test.js
@@ -1,0 +1,136 @@
+// QF-20260808-782: cap the idle-QF hint sender. THE DURABLE FIX, not the mitigation.
+//
+// MEASURED: 82 byte-identical hints for ONE qf to ONE seat in 5.7h (04:08–09:50), plus 12 and 2
+// for two others — 96 of that seat's last 127 inbox rows. They buried a direct coordinator
+// feedback request for 2h20m. The coordinator dropped the loop from its battery as IMMEDIATE
+// MITIGATION; that is not a fix, and a reader who sees the symptom stopped will wrongly close this
+// as already-done. The sender itself had no cap: `eligibleIdleWorkers` is pure over live state
+// with "no persistence, no backoff and no memory of who was hinted" (its own comment).
+//
+// An unacked hint after 3 sends means the reader is not reading that lane. It does not mean the
+// reader needs 79 more.
+import { describe, it, expect } from 'vitest';
+import { deliverHints, HINT_SEND_CAP } from '../../../scripts/coordinator-idle-qf-hint.mjs';
+
+const QF = { id: 'QF-TEST-001', title: 'a hintable quick fix', severity: 'medium' };
+const WORKER = { session_id: 'sess-worker-1', metadata: {} };
+
+const freshSummary = () => ({
+  idleWorkers: 0, hinted: 0, skippedGated: 0, attempted: 0,
+  undelivered: 0, undeliveredReasons: [], skippedCapped: 0, capUnknown: 0,
+});
+
+/** Records every send so we can assert on what actually left. */
+function makeInsert(sent) {
+  return async (_sb, row) => { sent.push(row); return { data: { id: 'row-1' }, error: null }; };
+}
+
+const run = async ({ prior, dryRun = false }) => {
+  const sent = [];
+  const summary = freshSummary();
+  await deliverHints([WORKER], [QF], {
+    summary,
+    supabase: {},
+    coordinatorId: 'coord-1',
+    dryRun,
+    insertRow: makeInsert(sent),
+    countPriorHints: async () => prior,
+  });
+  return { sent, summary };
+};
+
+describe('QF-782 idle-qf-hint send cap', () => {
+  it('SENDS a first-time hint — the cap must not block fresh work', async () => {
+    // Two-sided control. A cap that blocks everything passes every "it stopped" assertion below
+    // while silently starving the belt of hints entirely.
+    const { sent, summary } = await run({ prior: 0 });
+    expect(sent).toHaveLength(1);
+    expect(summary.hinted).toBe(1);
+    expect(summary.attempted).toBe(1);
+    expect(summary.skippedCapped).toBe(0);
+  });
+
+  it('still sends at one BELOW the cap', async () => {
+    const { sent, summary } = await run({ prior: HINT_SEND_CAP - 1 });
+    expect(sent).toHaveLength(1);
+    expect(summary.skippedCapped).toBe(0);
+  });
+
+  it('STOPS at the cap — this is the 82x bug', async () => {
+    const { sent, summary } = await run({ prior: HINT_SEND_CAP });
+    expect(sent).toHaveLength(0);
+    expect(summary.hinted).toBe(0);
+    expect(summary.skippedCapped).toBe(1);
+  });
+
+  it('STOPS well past the cap (the 82nd send never happens)', async () => {
+    const { sent, summary } = await run({ prior: 82 });
+    expect(sent).toHaveLength(0);
+    expect(summary.skippedCapped).toBe(1);
+  });
+
+  it('does NOT count a capped pair as attempted — the delivery ratio stays honest', async () => {
+    // Counting it would inflate the denominator and make a WORKING cap read as degraded delivery,
+    // which is how a correct guard gets reverted by whoever watches the ratio.
+    const { summary } = await run({ prior: HINT_SEND_CAP });
+    expect(summary.attempted).toBe(0);
+    expect(summary.undelivered).toBe(0);
+  });
+
+  describe('UNKNOWN is not zero', () => {
+    it('an unreadable count still sends, but is COUNTED as blind', async () => {
+      // Treating unknown as 0 would silently re-uncap the sender: every tick looks like "first
+      // hint" forever. Sending matches today's behaviour rather than starving the seat — but the
+      // blindness has to be visible, or a cap that cannot see is indistinguishable from a cap
+      // that saw nothing.
+      const { sent, summary } = await run({ prior: null });
+      expect(sent).toHaveLength(1);
+      expect(summary.capUnknown).toBe(1);
+      expect(summary.skippedCapped).toBe(0);
+    });
+
+    it('the REAL default survives a supabase that throws, and still delivers', async () => {
+      // No countPriorHints injected — this exercises countPriorHintsDefault for real, against a
+      // client with no .from(). FR-5 precedent: one unreachable addressee once starved every
+      // worker later in the loop, so a broken count must not kill the sweep.
+      const sent = [];
+      const summary = freshSummary();
+      await deliverHints([WORKER], [QF], {
+        summary, supabase: {}, coordinatorId: 'c', dryRun: false, insertRow: makeInsert(sent),
+      });
+      expect(sent).toHaveLength(1);
+      expect(summary.hinted).toBe(1);
+      expect(summary.capUnknown).toBe(1);
+    });
+  });
+
+  it('leaves the QF available for ANOTHER worker when one is capped', async () => {
+    // The worker has heard enough; the WORK is still unhinted. Dropping it would silently reduce
+    // supply — the same reasoning the existing throw/error paths use.
+    const sent = [];
+    const summary = freshSummary();
+    const capped = { session_id: 'sess-capped', metadata: {} };
+    const fresh = { session_id: 'sess-fresh', metadata: {} };
+    await deliverHints([capped, fresh], [QF], {
+      summary, supabase: {}, coordinatorId: 'c', dryRun: false,
+      insertRow: makeInsert(sent),
+      countPriorHints: async (_sb, { targetSession }) =>
+        (targetSession === 'sess-capped' ? HINT_SEND_CAP : 0),
+    });
+    expect(summary.skippedCapped).toBe(1);
+    expect(sent).toHaveLength(1);
+    expect(sent[0].target_session).toBe('sess-fresh');
+  });
+
+  it('does not consult the counter in dry-run', async () => {
+    let consulted = false;
+    const summary = freshSummary();
+    await deliverHints([WORKER], [QF], {
+      summary, supabase: {}, coordinatorId: 'c', dryRun: true,
+      insertRow: async () => { throw new Error('dry-run must not send'); },
+      countPriorHints: async () => { consulted = true; return 99; },
+    });
+    expect(consulted).toBe(false);
+    expect(summary.hinted).toBe(1);
+  });
+});


### PR DESCRIPTION
## Measured

**82 byte-identical hints for one QF to one seat in 5.7h** (04:08–09:50), plus 12 and 2 for two others — **96 of that seat's last 127 inbox rows**. They buried a direct coordinator feedback request for **2h20m**.

An unacked hint after 3 sends means the reader is not reading that lane. It does not mean the reader needs 79 more.

## This is NOT moot

The coordinator dropped the loop from its battery as **immediate mitigation**. That is not a fix, and a reader who sees the symptom stopped will wrongly close this as already-done.

The sender itself had no cap. `eligibleIdleWorkers` is pure over live state with *"no persistence, no backoff and no memory of who was hinted"* — **the defect was documented in its own comment.**

## The fix

Count prior sends for `(qf.id, target_session)` before dispatch; at `HINT_SEND_CAP` (3), **stop**.

- **Checked before `attempted`** — a capped pair was never attempted. Counting it would inflate the delivery-ratio denominator and make a *working* cap read as degraded delivery, which is how a correct guard gets reverted by whoever watches the ratio.
- **The QF goes back on the list** — that *worker* has heard enough, but the *work* is still unhinted and another worker this pass may fit it. The same reasoning the existing throw/error paths already use.

## UNKNOWN is not zero — this is the whole guard

A failed read, a **null count** (which a `head:true` count returns on a table it cannot see, *without an error*), or a **throw** all return `null` → treated as UNKNOWN → the hint still sends (matching today's behaviour rather than starving the seat) but increments `summary.capUnknown`.

**Resolving unknown to 0 would silently re-uncap the sender** — every tick looks like "first hint" forever, which *is* the 82× bug.

Both counters initialise to `0` rather than staying undefined (a counter that only appears once it fires can't be distinguished from one that never ran) and both surface on the `IDLE_QF_HINT` line.

A throw is just another way of "cannot read the count" and must not kill the sweep — **this file already learned that once** (FR-5: one unreachable addressee starved every worker later in the loop, 2026-07-26).

## Verification

9 new tests, two-sided. **3 mutations, all caught:**

| Mutation | Caught by |
|---|---|
| remove the cap | 4 tests |
| treat UNKNOWN as zero | 2 tests |
| **cap EVERYTHING** | 3 tests |

Mutation 3 is the one a one-sided suite ships: a "working" cap that **silently starves the belt** passes every it-stopped assertion. Restores byte-identical. **Existing suites 37/37 green, no regressions.**

## What a green run does not prove

These exercise `deliverHints` with an injected counter plus one test of the real default against a broken client. They do **not** prove the live PostgREST `payload->>qf_id` filter matches production rows — that needs a real tick to confirm `skippedCapped` moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)