### PR TITLE
fix(QF-20260808-673): surface chairman inbound by ANSWERED, not by drained_at

### DIFF
--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -478,25 +478,84 @@ export async function checkOversightStaleness(sb, { nowMs = Date.now() } = {}) {
   return out;
 }
 
+/** QF-20260808-673: how far back to look for an unanswered chairman inbound. */
+export const SMS_ANSWER_WINDOW_MIN = 60;
+
+/**
+ * QF-20260808-673: surface chairman inbound that was never ANSWERED.
+ *
+ * THE OLD PREDICATE WAS `drained_at IS NULL`, AND IT MISSES THE REAL MISS. `drained_at` means
+ * CONSUMED FROM STAGING BY THE DRAINER — not "the chairman got a reply". Those are different
+ * facts, and conflating them is the read_at-is-not-delivery class. Witnessed: chairman SMS
+ * b09ced65 arrived 19:22:00Z and was auto-drained 19:24:05Z, ~2 minutes later, BEFORE anyone
+ * answered it. The row races the drainer and loses, so by the next tick `drained_at IS NULL`
+ * returns nothing and the alarm is silent about a chairman who is still waiting.
+ *
+ * THE ANSWERED SIGNAL EXISTS AND IS QUERYABLE — the ticket's acceptance criterion asked to ADD a
+ * chairman-reply store, but one is already in service: `sms_outbound_obligations`. The ad-hoc
+ * reply path proves it — lib/comms/adam-outbound/chairman-sms-gate enqueues an obligation,
+ * dispatches it, then reads that row back for status/provider_message_id and only reports
+ * dispatched when it landed. Measured live: 590 rows to the chairman number, 589 with sent_at.
+ *
+ * `sent_at` is a SEND-SIDE fact (Twilio accepted; delivery callback is disabled), and that is the
+ * right bar HERE — this alarm asks "did Adam reply at all", not "did the handset receive it".
+ * The gate's own comment reaches the same conclusion: claiming delivery would be an over-claim.
+ */
 export async function surfaceSmsInbound(sb) {
   try {
     const chairmanPhone = process.env.CHAIRMAN_PHONE || null;
+    const sinceIso = new Date(Date.now() - SMS_ANSWER_WINDOW_MIN * 60_000).toISOString();
     const { data, error } = await sb
       .from('sms_relay_staging')
       .select('id, from_phone, body_raw, signature_valid, received_at')
-      .is('drained_at', null)
+      // WINDOW, deliberately NOT `drained_at IS NULL` — see above.
+      .gte('received_at', sinceIso)
       .order('received_at', { ascending: true })
       .limit(SMS_INBOUND_CAP);
     if (error) return { rows: [], count: 0, error: error.message };
-    const rows = (data || []).map((r) => ({
-      id: r.id,
-      fromPhone: r.from_phone,
-      isChairman: chairmanPhone ? r.from_phone === chairmanPhone : true,
-      signatureValid: r.signature_valid === true,
-      ageMin: Math.floor((Date.now() - new Date(r.received_at).getTime()) / 60_000),
-      body: String(r.body_raw || '').replace(/\s+/g, ' ').slice(0, 120),
-    }));
-    return { rows, count: rows.length };
+
+    const candidates = data || [];
+    if (candidates.length === 0) return { rows: [], count: 0 };
+
+    // One outbound read for the whole window, from the oldest row onward.
+    let replyTimes = null; // null = UNKNOWN, never silently 0
+    if (chairmanPhone) {
+      const { data: outs, error: oerr } = await sb
+        .from('sms_outbound_obligations')
+        .select('sent_at')
+        .eq('recipient_phone', chairmanPhone)
+        .not('sent_at', 'is', null)
+        .gte('sent_at', candidates[0].received_at);
+      if (!oerr) replyTimes = (outs || []).map((o) => new Date(o.sent_at).getTime());
+    }
+
+    // EXCLUDE ONLY ON POSITIVE EVIDENCE OF AN ANSWER. Two existing guarantees are preserved here
+    // deliberately, because the suite that asserts them is defending a real hazard:
+    // "surfaces BOTH (never drops on phone mismatch)" and "an unset env must not re-hide replies".
+    // Filtering by `from_phone === CHAIRMAN_PHONE` would silently hide a genuine chairman message
+    // whose number is formatted differently (missing country code, spacing) — trading the bug this
+    // ticket fixes for a quieter one. `isChairman` therefore remains a LABEL, never a gate.
+    //
+    // UNKNOWN IS NOT ANSWERED: if the reply store could not be read, or no chairman number is
+    // configured, nothing can be shown to have been answered — so every row surfaces. Resolving
+    // unknown to "answered" would silence a chairman-facing alarm on a failed query, the worst
+    // direction to fail on this channel.
+    const answeredUnknown = replyTimes === null;
+    const rows = candidates
+      .filter((r) => {
+        if (answeredUnknown) return true;
+        const t = new Date(r.received_at).getTime();
+        return !replyTimes.some((rt) => rt > t); // answered = a reply left AFTER it arrived
+      })
+      .map((r) => ({
+        id: r.id,
+        fromPhone: r.from_phone,
+        isChairman: chairmanPhone ? r.from_phone === chairmanPhone : true,
+        signatureValid: r.signature_valid === true,
+        ageMin: Math.floor((Date.now() - new Date(r.received_at).getTime()) / 60_000),
+        body: String(r.body_raw || '').replace(/\s+/g, ' ').slice(0, 120),
+      }));
+    return { rows, count: rows.length, answeredUnknown };
   } catch (e) {
     return { rows: [], count: 0, error: e && e.message };
   }

--- a/tests/unit/adam/adam-quiet-tick-sms-inbound.test.js
+++ b/tests/unit/adam/adam-quiet-tick-sms-inbound.test.js
@@ -16,6 +16,12 @@ function smsBuilder(rows) {
   const b = {
     select: () => b,
     is: (col, val) => { filters.push((r) => (val === null ? (r[col] === null || r[col] === undefined) : r[col] === val)); return b; },
+    // QF-20260808-673: the query now bounds by received_at WINDOW instead of drained_at. Applied
+    // as a REAL filter, like is(), so the test still observes the predicate rather than trusting
+    // a pre-filtered fixture — that observability is the point of this builder.
+    gte: (col, val) => { filters.push((r) => new Date(r[col]).getTime() >= new Date(val).getTime()); return b; },
+    eq: () => b,
+    not: () => b,
     order: () => b,
     limit: () => b,
     then: (resolve, reject) => Promise.resolve({ data: rows.filter((r) => filters.every((f) => f(r))), error: null }).then(resolve, reject),
@@ -24,12 +30,15 @@ function smsBuilder(rows) {
 }
 function errorBuilder(message) {
   const b = {
-    select: () => b, is: () => b, order: () => b, limit: () => b,
+    select: () => b, is: () => b, gte: () => b, eq: () => b, not: () => b, order: () => b, limit: () => b,
     then: (resolve, reject) => Promise.resolve({ data: null, error: { message } }).then(resolve, reject),
   };
   return b;
 }
-const makeSupabase = (builder) => ({ from: () => builder });
+// QF-20260808-673: table-aware now that surfaceSmsInbound also reads the reply store. Returning
+// the staging builder for BOTH tables would feed inbound rows in as 'replies' — a fake that lies.
+const emptyOutbound = () => { const b = { select: () => b, eq: () => b, not: () => b, gte: () => b, then: (res) => res({ data: [], error: null }) }; return b; };
+const makeSupabase = (builder) => ({ from: (t) => (t === 'sms_outbound_obligations' ? emptyOutbound() : builder) });
 
 const CHAIR = '+16135550100';
 const OTHER = '+15125550999';
@@ -40,7 +49,7 @@ afterEach(() => {
 });
 
 describe('surfaceSmsInbound', () => {
-  it('surfaces ONLY undrained rows (a drained row is excluded by the query filter)', async () => {
+  it('surfaces rows in the WINDOW regardless of drained_at (QF-673: drained is not answered)', async () => {
     process.env.CHAIRMAN_PHONE = CHAIR;
     const now = Date.now();
     const sb = makeSupabase(smsBuilder([
@@ -48,8 +57,14 @@ describe('surfaceSmsInbound', () => {
       { id: 'b', from_phone: CHAIR, body_raw: 'old', signature_valid: true, received_at: new Date(now - 120000).toISOString(), drained_at: new Date(now).toISOString() },
     ]));
     const res = await surfaceSmsInbound(sb);
-    expect(res.count).toBe(1);
-    expect(res.rows[0]).toMatchObject({ id: 'a', isChairman: true, signatureValid: true, body: 'YES' });
+    // QF-20260808-673 CHANGED THIS ASSERTION DELIBERATELY, and the old one encoded the bug.
+    // It required row 'b' to be EXCLUDED because it was drained. But drained means CONSUMED BY
+    // THE DRAINER, not ANSWERED — the witnessed miss (b09ced65) was auto-drained ~2 min after it
+    // arrived and never replied to, so the old predicate made a waiting chairman invisible.
+    // Both rows are in the window and neither has a reply after it, so BOTH must surface.
+    expect(res.count).toBe(2);
+    expect(res.rows.map((r) => r.id).sort()).toEqual(['a', 'b']);
+    expect(res.rows.find((r) => r.id === 'a')).toMatchObject({ isChairman: true, signatureValid: true, body: 'YES' });
     expect(res.rows[0].ageMin).toBeGreaterThanOrEqual(0);
   });
 

--- a/tests/unit/qf673-sms-answered-predicate.test.js
+++ b/tests/unit/qf673-sms-answered-predicate.test.js
@@ -1,0 +1,163 @@
+// QF-20260808-673: surface chairman inbound that was never ANSWERED.
+//
+// THE OLD PREDICATE (`drained_at IS NULL`) MISSES THE REAL MISS. `drained_at` means CONSUMED FROM
+// STAGING BY THE DRAINER, not "the chairman got a reply" — the read_at-is-not-delivery class.
+// Witnessed: chairman SMS b09ced65 arrived 19:22:00Z, auto-drained 19:24:05Z (~2 min), never
+// answered. The row races the drainer and loses, so the next tick's `drained_at IS NULL` returns
+// nothing while the chairman is still waiting.
+//
+// PREMISE CORRECTION recorded here because the ticket's acceptance criterion says otherwise: it
+// asks to ADD a chairman-reply outbound store, claiming none exists. One is already in service —
+// `sms_outbound_obligations`. The ad-hoc reply path proves it (chairman-sms-gate enqueues an
+// obligation, dispatches, then reads that row back for status/provider_message_id). Measured live:
+// 590 rows to the chairman number, 589 with `sent_at`. Nothing needed adding.
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { surfaceSmsInbound, SMS_ANSWER_WINDOW_MIN } from '../../scripts/adam-quiet-tick.mjs';
+
+const CHAIR = '+15550001111';
+const ago = (min) => new Date(Date.now() - min * 60_000).toISOString();
+
+/**
+ * Chainable fake that RECORDS the query it was asked to build.
+ *
+ * THE RECORDING IS NOT A CONVENIENCE — IT IS THE ONLY THING THAT MAKES THE CORE DEFECT VISIBLE.
+ * My first version had every builder method return the same object and the same fixture, so
+ * `.is('drained_at', null)` and `.gte('received_at', …)` were indistinguishable: reverting the fix
+ * to the old blind predicate left all 9 tests GREEN. The suite was asserting the post-filter logic
+ * (answered / signature / chairman) while being completely blind to the staging PREDICATE, which
+ * is the actual bug. A test that cannot observe its subject proves the logic, not the behaviour.
+ */
+function makeSb({ staging = [], stagingError = null, outbound = [], outboundError = null }) {
+  const calls = [];
+  const chain = (table, result) => {
+    const rec = (m) => (...args) => { calls.push({ table, m, args }); return o; };
+    const o = {
+      select: rec('select'), is: rec('is'), gte: rec('gte'), eq: rec('eq'),
+      not: rec('not'), order: rec('order'), limit: rec('limit'),
+      then: (res) => res(result),
+    };
+    return o;
+  };
+  const sb = {
+    from(table) {
+      calls.push({ table, m: 'from', args: [] });
+      if (table === 'sms_relay_staging') return chain(table, { data: staging, error: stagingError });
+      if (table === 'sms_outbound_obligations') return chain(table, { data: outbound, error: outboundError });
+      throw new Error('unexpected table ' + table);
+    },
+  };
+  sb.calls = calls;
+  sb.used = (table, m, arg0) =>
+    calls.some((c) => c.table === table && c.m === m && (arg0 === undefined || c.args[0] === arg0));
+  return sb;
+}
+
+const inbound = (over = {}) => ({
+  id: 'in-1', from_phone: CHAIR, body_raw: 'Are you still waiting on solomon?',
+  signature_valid: true, received_at: ago(20), ...over,
+});
+
+describe('QF-673 chairman inbound is surfaced by ANSWERED, not by drained_at', () => {
+  // Set per-test, not at collection time: assigning (and restoring) in the describe body runs
+  // during collection, BEFORE any test executes — the env would already be restored by the time
+  // the assertions ran, and the chairman-number filtering tests would be measuring nothing.
+  const prev = process.env.CHAIRMAN_PHONE;
+  beforeEach(() => { process.env.CHAIRMAN_PHONE = CHAIR; });
+  afterAll(() => {
+    if (prev === undefined) delete process.env.CHAIRMAN_PHONE;
+    else process.env.CHAIRMAN_PHONE = prev;
+  });
+
+  it('QUERIES BY WINDOW AND NEVER BY drained_at — the core defect', async () => {
+    // THE test. Everything else asserts post-filter logic and would stay green with the old
+    // predicate restored (verified by mutation). Only this observes the query itself.
+    const sb = makeSb({ staging: [inbound()], outbound: [] });
+    await surfaceSmsInbound(sb);
+    expect(sb.used('sms_relay_staging', 'gte', 'received_at')).toBe(true);
+    expect(sb.used('sms_relay_staging', 'is', 'drained_at')).toBe(false);
+  });
+
+  it('cross-references the ANSWERED signal in sms_outbound_obligations', async () => {
+    // The store the ticket said did not exist. If this read is ever dropped, "answered" silently
+    // becomes unknowable and the alarm degrades to the old always/never behaviour.
+    const sb = makeSb({ staging: [inbound()], outbound: [] });
+    await surfaceSmsInbound(sb);
+    expect(sb.used('sms_outbound_obligations', 'from')).toBe(true);
+    expect(sb.used('sms_outbound_obligations', 'not', 'sent_at')).toBe(true);
+  });
+
+  it('surfaces a DRAINED but UNANSWERED inbound — the witnessed miss', async () => {
+    // This is the case the old predicate could not see: the drainer already consumed the row.
+    // Nothing here mentions drained_at, which is the point.
+    const r = await surfaceSmsInbound(makeSb({ staging: [inbound()], outbound: [] }));
+    expect(r.count).toBe(1);
+    expect(r.rows[0].id).toBe('in-1');
+  });
+
+  it('does NOT surface an inbound that WAS answered after it arrived', async () => {
+    // Two-sided. Without this, an alarm that fires on every inbound forever would pass the test
+    // above and be indistinguishable from a working one.
+    const r = await surfaceSmsInbound(makeSb({
+      staging: [inbound({ received_at: ago(20) })],
+      outbound: [{ sent_at: ago(10) }], // reply AFTER the inbound
+    }));
+    expect(r.count).toBe(0);
+  });
+
+  it('a reply sent BEFORE the inbound does not count as answering it', async () => {
+    // Ordering is the whole predicate: an earlier outbound cannot be a reply to a later inbound.
+    const r = await surfaceSmsInbound(makeSb({
+      staging: [inbound({ received_at: ago(20) })],
+      outbound: [{ sent_at: ago(45) }],
+    }));
+    expect(r.count).toBe(1);
+  });
+
+  it('UNKNOWN IS NOT ANSWERED — an unreadable reply store still surfaces', async () => {
+    // Resolving a failed read to "answered" would silence a chairman-facing alarm on a query
+    // error, the worst direction to fail on this channel.
+    const r = await surfaceSmsInbound(makeSb({
+      staging: [inbound()], outboundError: { message: 'boom' },
+    }));
+    expect(r.count).toBe(1);
+    expect(r.answeredUnknown).toBe(true);
+  });
+
+  it('LABELS rather than drops: an invalid-signature row still surfaces', async () => {
+    const r = await surfaceSmsInbound(makeSb({
+      staging: [inbound({ signature_valid: false })], outbound: [],
+    }));
+    expect(r.count).toBe(1);
+    expect(r.rows[0].signatureValid).toBe(false);
+  });
+
+  it('LABELS rather than drops: a phone mismatch still surfaces (never hide on formatting)', async () => {
+    const r = await surfaceSmsInbound(makeSb({
+      staging: [inbound({ from_phone: '+19998887777' })], outbound: [],
+    }));
+    expect(r.count).toBe(1);
+    expect(r.rows[0].isChairman).toBe(false);
+  });
+
+  it('count always equals rows.length — preserves the #6907 render invariant', async () => {
+    // `sms=N` must reconcile against N surfaced lines; a count computed independently of the
+    // filtered set is exactly the disagreement #6906 fixed.
+    for (const outbound of [[], [{ sent_at: ago(1) }]]) {
+      const r = await surfaceSmsInbound(makeSb({ staging: [inbound()], outbound }));
+      expect(r.count).toBe(r.rows.length);
+    }
+  });
+
+  it('the window is a real bound, not decoration', async () => {
+    expect(SMS_ANSWER_WINDOW_MIN).toBeGreaterThanOrEqual(30);
+    expect(SMS_ANSWER_WINDOW_MIN).toBeLessThanOrEqual(120);
+  });
+
+  it('a staging read error reports the error and surfaces nothing', async () => {
+    const r = await surfaceSmsInbound(makeSb({ stagingError: { message: 'staging down' } }));
+    expect(r.count).toBe(0);
+    expect(r.error).toBe('staging down');
+  });
+
+
+});


### PR DESCRIPTION
## The bug

`drained_at` means **consumed from staging by the drainer**. It does not mean the chairman got a reply. Conflating them is the read_at-is-not-delivery class, and it made a waiting chairman invisible:

> SMS `b09ced65` arrived **19:22:00Z**, auto-drained **19:24:05Z** (~2 min), never answered. The next tick's `drained_at IS NULL` returned nothing.

The row races the drainer and loses.

**Now:** bound by a `received_at` **window**, and exclude a row **only on positive evidence of an answer** — an `sms_outbound_obligations` row to the chairman number with `sent_at` *after* that inbound arrived.

## Premise correction

The acceptance criterion says to **ADD** a chairman-reply outbound store because none exists — that sentence is what would make this a schema SD.

**Measured false.** `sms_outbound_obligations` is already in service: **591 rows, 590 to the chairman number, 589 with `sent_at`.** The ad-hoc reply path proves it at the definition site — `chairman-sms-gate` enqueues an obligation, dispatches it, then reads that row back for `status`/`provider_message_id`.

`sent_at` is a **send-side** fact (delivery callback disabled), and that's the right bar here: this alarm asks *"did Adam reply at all"*, not *"did the handset receive it"*. The gate's own comment reaches the same conclusion.

## My first test suite was blind, and mutation caught it

Every builder method on my fake returned the same object and the same fixture, so `.is('drained_at', null)` and `.gte('received_at', …)` were indistinguishable. **Reverting the fix to the old broken predicate left all 9 tests GREEN.**

The suite asserted post-filter logic while being completely blind to the staging predicate — *the actual bug*. The fake now **records** the query, and one test asserts it directly. That mutation is now caught.

## I backed out a filter because an existing test was right

My first version dropped rows whose `from_phone` ≠ `CHAIRMAN_PHONE`. `adam-quiet-tick-sms-inbound.test.js` explicitly forbids that:

> *"surfaces BOTH (never drops on phone mismatch)"* · *"an unset env must not re-hide replies"*

It defends a real hazard: a chairman number formatted differently (missing country code, spacing) would be **silently hidden** — trading this bug for a quieter one. **`isChairman` stays a LABEL, never a gate.**

**One assertion in that suite is deliberately changed:** it required a drained row to be *excluded*. That assertion encoded the bug. Its fake also gained `gte()` as a **real filter** (not a passthrough) so it still observes the predicate, and became **table-aware** so the reply-store read can't be fed inbound rows as "replies".

## UNKNOWN is not ANSWERED

An unreadable reply store, or no chairman number configured, surfaces everything and sets `answeredUnknown`. Resolving unknown to "answered" would silence a chairman-facing alarm on a failed query.

## Verification

**3 mutations caught:** old `drained_at` predicate · unknown-as-answered · surface-everything. **110 files / 1339 tests green** across the adam/quiet/sms suites.

## What a green run does not prove

These use a fake client. They do not prove the live PostgREST `sms_outbound_obligations` read returns rows under real RLS/service-role, nor that a real tick surfaces the right set. The live confirmation belongs to the seat that runs the tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)