### PR TITLE
feat(SD-LEO-INFRA-STORY-E2E-AUTO-001): a story→spec mapping must name a file that exists, or be NULL

### DIFF
--- a/lib/stories/e2e-path-guard.js
+++ b/lib/stories/e2e-path-guard.js
@@ -1,0 +1,92 @@
+/**
+ * SD-LEO-INFRA-STORY-E2E-AUTO-001 FR-1 — map to an existing exercising spec, or emit NULL.
+ *
+ * MEASURED over the full population (1390 rows with a non-null e2e_test_path; exact
+ * head-count, pagination verified 1390 collected = 1390 counted): 234 of 338 distinct paths
+ * name a file that DOES NOT EXIST, and 641 rows (46.1%) claim e2e_test_status='passing' for
+ * one of them. Sixteen distinct generators write this field, so the rule lives here once
+ * rather than sixteen times.
+ *
+ * THE TWO ARMS ARE DELIBERATELY SEPARATE AND ARE NEVER MERGED:
+ *   - specFileExists  — DECIDABLE. A file is there or it is not. Alone it accounts for
+ *                       1016 of the 1390 bad rows, and it cannot produce a false negative.
+ *   - specReferencesStory — HEURISTIC. It reads text and guesses. It can be wrong.
+ * Collapsing them into one "isValid" would let the heuristic's false negatives null out real
+ * coverage under cover of the arm that is actually sound. If the heuristic proves noisy, the
+ * honest move is to run existence-only and record relevance as unimplemented — never to keep
+ * a check that quietly discards true mappings.
+ *
+ * NULL is the honest "no mapping" and is a legitimate output, not a failure: 76 rows already
+ * model it (a missing file stamped 'not_created' — they point at nothing and say so).
+ */
+import { existsSync, readFileSync } from 'fs';
+import path from 'path';
+
+/**
+ * ARM 1 — EXISTENCE (decidable).
+ * Rejects sentinels ('N/A - documentation SD (no E2E required)'), absolute paths and any
+ * path containing '..' — a mapping must be a repo-relative path to a real file, and a
+ * traversal escaping the repo is not a coverage claim we can stand behind.
+ * @returns {boolean}
+ */
+export function specFileExists(repoRoot, candidatePath, deps = {}) {
+  const exists = deps.existsSync || existsSync;
+  if (typeof candidatePath !== 'string') return false;
+  const p = candidatePath.trim();
+  if (p === '' || !p.includes('/')) return false;
+  if (path.isAbsolute(p) || p.split(/[\\/]/).includes('..')) return false;
+  return exists(path.join(repoRoot, p));
+}
+
+/**
+ * ARM 2 — RELEVANCE (heuristic, and labelled as one).
+ * A spec exercises a story if its text names the story_key, the story's US-NNN token, the SD
+ * key, or the basename of one of the story's changed files. This is a text search, not proof:
+ * a spec can exercise a story without naming it, and can name it without exercising it. It is
+ * reported separately from existence so a caller can decline to rely on it.
+ * @returns {boolean}
+ */
+export function specReferencesStory(repoRoot, candidatePath, story = {}, deps = {}) {
+  const read = deps.readFileSync || readFileSync;
+  if (!specFileExists(repoRoot, candidatePath, deps)) return false;
+
+  let text;
+  try {
+    text = String(read(path.join(repoRoot, candidatePath.trim()), 'utf8'));
+  } catch {
+    // Unreadable is not "relevant". Fail closed on the heuristic arm too.
+    return false;
+  }
+
+  const needles = [];
+  if (story.story_key) {
+    needles.push(story.story_key);
+    const [sdPart, usPart] = String(story.story_key).split(':');
+    if (sdPart) needles.push(sdPart);
+    if (usPart) needles.push(usPart);
+  }
+  if (story.sd_key) needles.push(story.sd_key);
+  for (const f of story.changed_files || []) needles.push(path.basename(String(f)));
+
+  const hay = text.toLowerCase();
+  return needles.filter(Boolean).some((n) => hay.includes(String(n).toLowerCase()));
+}
+
+/**
+ * The choke-point: resolve a candidate mapping to itself or to NULL.
+ *
+ * @param {object} args
+ * @param {string} args.repoRoot
+ * @param {string|null} args.candidatePath
+ * @param {object} [args.story]
+ * @param {boolean} [args.requireRelevance=true] — set false to run existence-only, which is
+ *   the documented fallback if the heuristic arm proves noisy in practice.
+ * @returns {string|null} the path when it can be stood behind, else NULL
+ */
+export function resolveE2ePath({ repoRoot, candidatePath, story = {}, requireRelevance = true, deps = {} }) {
+  if (!specFileExists(repoRoot, candidatePath, deps)) return null;
+  if (requireRelevance && !specReferencesStory(repoRoot, candidatePath, story, deps)) return null;
+  return candidatePath.trim();
+}
+
+export default { specFileExists, specReferencesStory, resolveE2ePath };

--- a/lib/sub-agents/testing/phases/phase4-evidence.js
+++ b/lib/sub-agents/testing/phases/phase4-evidence.js
@@ -6,6 +6,13 @@
  * Extracted from TESTING sub-agent v3.0
  * SD: SD-LEO-REFAC-TESTING-INFRA-001
  */
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { specFileExists as specFileExistsDefault } from '../../../stories/e2e-path-guard.js';
+
+// Repo root resolved from this module's own location, so the check does not depend on the
+// caller's cwd (sub-agents run from worktrees and from the shared root).
+const DEFAULT_REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
 
 /**
  * Collect test evidence
@@ -103,9 +110,32 @@ export async function verifyUserStories(sdId, supabase, options = {}) {
   // grants removes the contradiction rather than removing the check: a story with neither a
   // passing e2e run NOR validation is still blocked, which the test suite pins in both
   // directions.
+  // SD-LEO-INFRA-STORY-E2E-AUTO-001 FR-2 — a NON-NULL mapping must name a file that exists.
+  //
+  // MEASURED over the full population (1390 non-null paths, exact head-count): 234 of 338
+  // distinct paths name a file that is not in the repo, and 641 rows (46.1%) claim
+  // e2e_test_status='passing' for one of them. Those rows clear clause 2 on path-presence AND
+  // clause 3 on status-passing, so nearly half of all mapped stories could pass this gate on
+  // a spec nobody ever wrote. Presence of a string was being read as evidence of coverage.
+  //
+  // This does NOT touch NULL handling. QF-20260801-425 relaxed clause 2 deliberately because
+  // 90.5% of completed+validated stories have e2e_test_path NULL and nothing populates it;
+  // that relaxation stands, and the tests above pin it in both directions. The difference
+  // that makes enforcing THIS case fair is remediation: QF-425's requirement had no action a
+  // worker could perform, whereas a fabricated path has an honest one-line fix — set it to
+  // NULL, which this filter accepts.
+  //
+  // Deliberately NOT escapable by validation_status: a path naming a file that does not exist
+  // is false regardless of who validated the story, and letting validation excuse it would
+  // rebuild the same "auto-populated state reads as achievement" defect one layer up.
+  const specExists = options.specFileExists || specFileExistsDefault;
+  const repoRoot = options.repoRoot || DEFAULT_REPO_ROOT;
+  const fabricatedMapping = (s) => s.e2e_test_path != null && !specExists(repoRoot, s.e2e_test_path);
+
   const incomplete = stories.filter(s =>
     !['completed', 'validated'].includes(s.status) ||
     (requireE2EMapping && !s.e2e_test_path && s.validation_status !== 'validated') ||
+    fabricatedMapping(s) ||
     (s.e2e_test_status !== 'passing' && s.validation_status !== 'validated')
   );
 

--- a/scripts/one-off/_flag-fabricated-e2e-mappings.mjs
+++ b/scripts/one-off/_flag-fabricated-e2e-mappings.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-STORY-E2E-AUTO-001 FR-3 — FLAG fabricated e2e mappings. Never rewrite them.
+ *
+ * Each row is a historical claim that a specific SD passed TESTING. Nulling it would clean the
+ * data and destroy the evidence of what cleared on fiction, so this writes ONLY to
+ * user_stories.metadata and leaves e2e_test_path / e2e_test_status exactly as found.
+ *
+ * CLASSIFIES rather than lumps — a missing file is not automatically a lie:
+ *   fiction_passing     claims 'passing' for a spec that does not exist. Clears TESTING
+ *                       clause 2 (path present) AND clause 3 (status passing) on fiction.
+ *   fiction_created     claims 'created' for a spec that does not exist.
+ *   honest_not_created  points at an absent file and SAYS SO ('not_created'). NOT fiction —
+ *                       this is the shape auto-trigger-stories emits, and it is the behaviour
+ *                       the other rows should have had. Flagged for visibility, not blame.
+ *   unclear_skipped     'skipped' on an absent file. Ambiguous; recorded, not judged.
+ *
+ * DRY-RUN BY DEFAULT. Pass --apply to write. Idempotent: a row already carrying this marker
+ * with the same classification is skipped, so a second run makes no further change.
+ */
+import { existsSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { getSupabaseClient } from '../../lib/sub-agent-executor/supabase-client.js';
+import { specFileExists } from '../../lib/stories/e2e-path-guard.js';
+
+const MARKER = 'fabricated_e2e_mapping_20260809';
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const APPLY = process.argv.includes('--apply');
+const supabase = await getSupabaseClient();
+
+function classify(status) {
+  if (status === 'passing') return 'fiction_passing';
+  if (status === 'created') return 'fiction_created';
+  if (status === 'not_created') return 'honest_not_created';
+  return 'unclear_skipped';
+}
+
+// --- Measure the POPULATION, not the cap -----------------------------------
+const { count: total, error: cErr } = await supabase
+  .from('user_stories').select('id', { count: 'exact', head: true }).not('e2e_test_path', 'is', null);
+if (cErr) { console.error('COUNT FAILED:', cErr.message); process.exit(1); }
+
+const rows = [];
+for (let from = 0; from < total; from += 1000) {
+  const { data, error } = await supabase
+    .from('user_stories')
+    .select('id, story_key, e2e_test_path, e2e_test_status, metadata')
+    .not('e2e_test_path', 'is', null)
+    .order('story_key')
+    .range(from, from + 999);
+  if (error) { console.error(`PAGE ${from} FAILED:`, error.message); process.exit(1); }
+  rows.push(...data);
+}
+if (rows.length !== total) {
+  console.error(`PAGINATION INCOMPLETE: ${rows.length} of ${total} — refusing to act on a partial population.`);
+  process.exit(1);
+}
+
+const targets = rows.filter((r) => !specFileExists(REPO_ROOT, r.e2e_test_path, { existsSync }));
+const byClass = {};
+for (const r of targets) { const c = classify(r.e2e_test_status); byClass[c] = (byClass[c] ?? 0) + 1; }
+console.log(`population: ${total} non-null paths | missing-file rows: ${targets.length}`);
+console.log('classification:', JSON.stringify(byClass));
+console.log(APPLY ? '\nAPPLYING (metadata only; path/status untouched)…' : '\nDRY RUN — pass --apply to write.');
+
+if (!APPLY) process.exit(0);
+
+// --- Flag, one row at a time, asserting rowcount ----------------------------
+let written = 0, skipped = 0;
+for (const r of targets) {
+  const classification = classify(r.e2e_test_status);
+  const prior = r.metadata && typeof r.metadata === 'object' ? r.metadata : {};
+  if (prior[MARKER] && prior[MARKER].classification === classification) { skipped += 1; continue; }
+
+  const merged = {
+    ...prior,
+    [MARKER]: {
+      classification,
+      observed_e2e_test_path: r.e2e_test_path,
+      observed_e2e_test_status: r.e2e_test_status,
+      finding: 'The referenced spec file does not exist in the repository. This row is FLAGGED, not rewritten: it is a historical record of what this story claimed, and erasing it would destroy the audit trail of what cleared TESTING on fiction.',
+      remediation: 'Set e2e_test_path to NULL (which the TESTING filter accepts), or point it at a spec that exists and exercises the story.',
+      sd: 'SD-LEO-INFRA-STORY-E2E-AUTO-001',
+      flagged_by: 'Alpha-3 cff8013c',
+    },
+  };
+
+  const { data: updated, error } = await supabase
+    .from('user_stories').update({ metadata: merged }).eq('id', r.id).select('id');
+  if (error) { console.error(`UPDATE FAILED ${r.story_key}: ${error.message}`); process.exit(1); }
+  // An UPDATE matching zero rows is indistinguishable from success unless asserted.
+  if (!updated || updated.length !== 1) {
+    console.error(`UPDATE MATCHED ${updated ? updated.length : 0} ROWS for ${r.story_key} — expected exactly 1. Aborting.`);
+    process.exit(1);
+  }
+  written += 1;
+}
+console.log(`flagged: ${written} | already-flagged (idempotent skip): ${skipped}`);
+
+// --- Read back the FIELD, not just the row ----------------------------------
+const { count: flaggedCount, error: rbErr } = await supabase
+  .from('user_stories').select('id', { count: 'exact', head: true }).not(`metadata->${MARKER}`, 'is', null);
+if (rbErr) { console.error('READBACK FAILED:', rbErr.message); process.exit(1); }
+console.log(`readback — rows carrying ${MARKER}: ${flaggedCount} (expected ${targets.length})`);
+if (flaggedCount !== targets.length) { console.error('READBACK MISMATCH — not all targets carry the marker.'); process.exit(1); }
+
+// Prove path/status were NOT touched.
+const { count: stillMissing, error: pErr } = await supabase
+  .from('user_stories').select('id', { count: 'exact', head: true })
+  .not('e2e_test_path', 'is', null).eq('e2e_test_status', 'passing');
+if (pErr) { console.error('PRESERVATION CHECK FAILED:', pErr.message); process.exit(1); }
+console.log(`preservation check — rows still non-null path + status=passing: ${stillMissing} (unchanged by design)`);

--- a/tests/unit/stories/e2e-path-guard.test.js
+++ b/tests/unit/stories/e2e-path-guard.test.js
@@ -1,0 +1,139 @@
+/**
+ * SD-LEO-INFRA-STORY-E2E-AUTO-001 — FR-1 guard + FR-2 gate enforcement.
+ *
+ * Two-sided throughout: each arm is proven to REJECT the fabricated mapping AND to PASS the
+ * real one. A gate that only rejects cannot discriminate; one that only passes is camouflage.
+ * The existence and relevance arms are tested SEPARATELY because they are separately trusted —
+ * existence is decidable, relevance is a heuristic, and merging them would let the heuristic's
+ * false negatives hide behind the sound arm.
+ */
+import { describe, it, expect } from 'vitest';
+import { specFileExists, specReferencesStory, resolveE2ePath } from '../../../lib/stories/e2e-path-guard.js';
+import { verifyUserStories } from '../../../lib/sub-agents/testing/phases/phase4-evidence.js';
+
+const ROOT = '/repo';
+const present = new Set(['/repo/tests/e2e/real.spec.ts', '/repo/tests/e2e/other.spec.ts']);
+const deps = {
+  existsSync: (p) => present.has(p.replace(/\\/g, '/')),
+  readFileSync: (p) => {
+    const k = p.replace(/\\/g, '/');
+    if (k === '/repo/tests/e2e/real.spec.ts') return "test('SD-X-001:US-001 does the thing', () => {})";
+    if (k === '/repo/tests/e2e/other.spec.ts') return "test('something entirely unrelated', () => {})";
+    throw new Error('ENOENT');
+  },
+};
+const story = { story_key: 'SD-X-001:US-001', changed_files: ['lib/marketing/autonomy-gate.js'] };
+
+describe('FR-1 arm 1 — existence (decidable)', () => {
+  it('REJECTS a path whose file does not exist — the 234-distinct-path case', () => {
+    expect(specFileExists(ROOT, 'tests/e2e/api-coverage-audit.spec.ts', deps)).toBe(false);
+  });
+
+  it('ACCEPTS a path whose file exists', () => {
+    expect(specFileExists(ROOT, 'tests/e2e/real.spec.ts', deps)).toBe(true);
+  });
+
+  it('REJECTS the documentation sentinel, which is prose and not a path', () => {
+    expect(specFileExists(ROOT, 'N/A - documentation SD (no E2E required)', deps)).toBe(false);
+  });
+
+  // The first cut of this test was VACUOUS and a mutation caught it: with the shape guard
+  // deleted, both paths still resolved outside the stub's existing-file set, so the assertion
+  // passed either way and proved nothing. Here existence is forced TRUE for every path, so
+  // the ONLY thing that can reject these is the absolute/traversal guard itself.
+  it('REJECTS an absolute path and a traversal even when the target exists — a mapping must stay inside the repo', () => {
+    const allExist = { existsSync: () => true };
+    expect(specFileExists(ROOT, '/etc/passwd', allExist)).toBe(false);
+    expect(specFileExists(ROOT, 'tests/../../outside/real.spec.ts', allExist)).toBe(false);
+    // Control: the same all-exists stub ACCEPTS an ordinary repo-relative path, so the two
+    // rejections above are the guard firing and not the stub refusing everything.
+    expect(specFileExists(ROOT, 'tests/e2e/anything.spec.ts', allExist)).toBe(true);
+  });
+
+  it('REJECTS empty, whitespace and non-string candidates rather than throwing', () => {
+    for (const bad of ['', '   ', null, undefined, 42, {}]) {
+      expect(specFileExists(ROOT, bad, deps)).toBe(false);
+    }
+  });
+});
+
+describe('FR-1 arm 2 — relevance (heuristic, kept separate on purpose)', () => {
+  it('ACCEPTS a spec that names the story', () => {
+    expect(specReferencesStory(ROOT, 'tests/e2e/real.spec.ts', story, deps)).toBe(true);
+  });
+
+  it('REJECTS an EXISTING spec that does not reference the story — proves this is a real second arm, not existence wearing a relevance name', () => {
+    expect(specReferencesStory(ROOT, 'tests/e2e/other.spec.ts', story, deps)).toBe(false);
+  });
+
+  it('REJECTS a nonexistent spec without attempting to read it', () => {
+    expect(specReferencesStory(ROOT, 'tests/e2e/nope.spec.ts', story, deps)).toBe(false);
+  });
+
+  it('matches on a changed-file basename as well as the story key', () => {
+    const byFile = { changed_files: ['lib/marketing/autonomy-gate.js'] };
+    expect(specReferencesStory(ROOT, 'tests/e2e/real.spec.ts', byFile, deps)).toBe(false);
+    const named = { story_key: 'SD-X-001:US-001' };
+    expect(specReferencesStory(ROOT, 'tests/e2e/real.spec.ts', named, deps)).toBe(true);
+  });
+});
+
+describe('FR-1 resolver — map correctly or emit NULL', () => {
+  it('returns NULL for a nonexistent spec', () => {
+    expect(resolveE2ePath({ repoRoot: ROOT, candidatePath: 'tests/e2e/ghost.spec.ts', story, deps })).toBe(null);
+  });
+
+  it('returns NULL for an existing but irrelevant spec', () => {
+    expect(resolveE2ePath({ repoRoot: ROOT, candidatePath: 'tests/e2e/other.spec.ts', story, deps })).toBe(null);
+  });
+
+  it('returns the path for an existing, story-referencing spec', () => {
+    expect(resolveE2ePath({ repoRoot: ROOT, candidatePath: 'tests/e2e/real.spec.ts', story, deps })).toBe('tests/e2e/real.spec.ts');
+  });
+
+  it('existence-only mode accepts an irrelevant existing spec — the documented fallback if the heuristic proves noisy', () => {
+    const r = resolveE2ePath({ repoRoot: ROOT, candidatePath: 'tests/e2e/other.spec.ts', story, requireRelevance: false, deps });
+    expect(r).toBe('tests/e2e/other.spec.ts');
+  });
+});
+
+/** Minimal stub matching the one call shape: .from().select().eq() -> {data, error}. */
+function stubSupabase(rows) {
+  return { from: () => ({ select: () => ({ eq: () => Promise.resolve({ data: rows, error: null }) }) }) };
+}
+const completed = (over = {}) => ({
+  story_key: 'SD-X-001:US-001', title: 'S', status: 'completed',
+  validation_status: 'validated', e2e_test_path: null, e2e_test_status: 'not_created', ...over,
+});
+
+describe('FR-2 — the gate rejects a mapping it cannot stand behind', () => {
+  it('BLOCKS the exact 641-row shape: status=passing on a spec that does not exist', async () => {
+    const rows = [completed({ e2e_test_path: 'tests/e2e/api-coverage-audit.spec.ts', e2e_test_status: 'passing' })];
+    const res = await verifyUserStories('sd-1', stubSupabase(rows), { sdType: 'feature', specFileExists: () => false });
+    expect(res.verified).toBe(false);
+  });
+
+  it('BLOCKS it even when validation_status=validated — validation cannot excuse a false path', async () => {
+    const rows = [completed({ e2e_test_path: 'tests/e2e/ghost.spec.ts', e2e_test_status: 'passing', validation_status: 'validated' })];
+    const res = await verifyUserStories('sd-1', stubSupabase(rows), { sdType: 'feature', specFileExists: () => false });
+    expect(res.verified).toBe(false);
+  });
+
+  it('PASSES the same row once the spec exists — the clean control', async () => {
+    const rows = [completed({ e2e_test_path: 'tests/e2e/real.spec.ts', e2e_test_status: 'passing' })];
+    const res = await verifyUserStories('sd-1', stubSupabase(rows), { sdType: 'feature', specFileExists: () => true });
+    expect(res.verified).toBe(true);
+  });
+
+  it('REGRESSION GUARD (QF-20260801-425): a validated story with a NULL path still passes, and the existence check is never consulted for it', async () => {
+    let consulted = false;
+    const res = await verifyUserStories('sd-1', stubSupabase([completed()]), {
+      sdType: 'feature',
+      specFileExists: () => { consulted = true; return false; },
+    });
+    expect(res.verified).toBe(true);
+    // NULL is the honest "no mapping" — nulling a fabricated path is the one-line remediation
+    // this gate leaves available, which is what makes enforcing the non-null case fair.
+    expect(consulted).toBe(false);
+  });
+});

--- a/tests/unit/testing-subagent/verify-user-stories-e2e-mapping.test.js
+++ b/tests/unit/testing-subagent/verify-user-stories-e2e-mapping.test.js
@@ -108,14 +108,22 @@ describe('verifyUserStories — the check must still have teeth', () => {
     expect(res.verified).toBe(false);
   });
 
-  it('ACCEPTS a completed, unvalidated story whose mapped e2e test PASSES', async () => {
+  // SD-LEO-INFRA-STORY-E2E-AUTO-001: this case previously used a path to a file that does not
+  // exist ('tests/e2e/foo.spec.ts') and asserted ACCEPTED — it encoded the very defect that SD
+  // measured, where 641 of 1390 rows claim a passing run of a spec nobody wrote. The INTENT
+  // (a genuinely mapped, genuinely passing e2e run is accepted) is preserved by declaring the
+  // file present, rather than by depending on a real fixture on disk.
+  it('ACCEPTS a completed, unvalidated story whose mapped e2e test PASSES and whose spec EXISTS', async () => {
     const rows = [{
       ...reportedStory(1),
       validation_status: 'pending',
       e2e_test_path: 'tests/e2e/foo.spec.ts',
       e2e_test_status: 'passing',
     }];
-    const res = await verifyUserStories('sd-1', stubSupabase(rows), { sdType: 'bugfix' });
+    const res = await verifyUserStories('sd-1', stubSupabase(rows), {
+      sdType: 'bugfix',
+      specFileExists: () => true,
+    });
     expect(res.verified).toBe(true);
   });
 


### PR DESCRIPTION
Nearly half of all mapped user stories could clear the TESTING gate on a spec file that nobody ever wrote.

## The measurement

Full population, not a sample — 1390 rows with a non-null `e2e_test_path`, exact head-count, pagination verified 1390 collected = 1390 counted (a capped fetch grouped in memory measures the cap, not the population).

| | |
|---|---|
| Distinct paths | 338 — **101 exist, 234 MISSING**, 3 sentinel |
| **Rows claiming `passing` for a nonexistent spec** | **641 of 1390 (46.1%)** |
| Rows with a missing file, any status | 1110 |
| Distinct writers | **16** — SYSTEM 321, PLAN 168, STORIES 47, PRODUCT_REQUIREMENTS_EXPERT 31, database-agent 15, long tail |

Those rows satisfy clause 2 by path-presence **and** clause 3 by status-passing, with no `validation_status` needed. Three hallucinated filenames account for 664 of them: `api-coverage-audit.spec.ts` (289), `accessibility-venture-creation.spec.ts` (270), `board-governance.spec.ts` (105). Presence of a string was being read as evidence of coverage.

## FR-1 — one guard, two arms kept apart

`lib/stories/e2e-path-guard.js`. One shared guard because sixteen generators write this field, and a per-writer patch is sixteen chances to drift.

The arms stay separate on purpose. `specFileExists` is **decidable** and alone accounts for 1016 of the 1390 bad rows. `specReferencesStory` **reads text and guesses**. Merged into one `isValid`, the heuristic's false negatives would null out real coverage under cover of the arm that is actually sound. `resolveE2ePath({requireRelevance: false})` is the documented existence-only fallback if the heuristic proves noisy in practice.

## FR-2 — the gate refuses a mapping it cannot stand behind

A non-null path must name a file that exists. **NULL handling is untouched**, and not escapable by `validation_status` — a path naming a file that does not exist is false regardless of who validated the story.

**Why enforcing this is fair, given QF-20260801-425.** That QF relaxed clause 2 because 90.5% of completed+validated stories have a NULL path and **no remediation existed** a worker could perform. Here one does: set the fabricated path to NULL, which the filter accepts. Mutation M7 — extending the check to NULL paths — reddens four of that QF's own tests, which is the guard against re-stranding its corpus.

**One existing test asserted that a passing claim for `tests/e2e/foo.spec.ts` — a file that does not exist — was ACCEPTED.** It encoded the defect. Its intent is preserved by declaring the file present rather than by depending on fiction.

## FR-3 — flag them, do not clean them

1110 rows flagged in `metadata` only; `e2e_test_path` and `e2e_test_status` left exactly as found. Each row is a historical claim that a specific SD passed TESTING, and erasing it would destroy the audit trail of what cleared on fiction.

Classified rather than lumped, because a missing file is not automatically a lie: `fiction_passing` 645, `fiction_created` 375, `honest_not_created` 76 (these point at an absent file and *say so* — the behaviour the others should have had), `unclear_skipped` 14. The 645-vs-641 delta is exactly the four sentinel rows (`N/A - documentation SD`) that also claim passing; a prose sentinel is not a spec.

Dry-run by default. Every update asserts it matched exactly one row. Readback counts the marker field, not the row. Second run flagged 0 and skipped 1110.

## Verification

**7/7 mutations each reddened a NAMED test. Full unit project: 3069 files / 37444 tests, 0 failures.**

The first cut of my traversal test was **vacuous and a mutation caught it**: with the shape guard deleted, `/etc/passwd` and `tests/../../outside/x.spec.ts` still resolved outside the stub's existing-file set, so the assertion passed either way. Rewritten to force existence TRUE so only the guard can reject — plus a control proving the stub is not simply refusing everything.

## Stated limit

A `user_stories` DB trigger would be the complete prevention choke-point across all sixteen writers and any future one. Trigger DDL is chairman-apply-gated and **out of scope here**, so FR-1 reaches only adopting writers and **FR-2 is what makes the property hold**. FR-4 (seeding this as a class invariant in the completeness critic — it is the third instance of "a generator emits a field asserting a contract it never fulfilled") is **owed, not delivered here**.

⚠️ **Enforcement turns a currently-green gate red for SDs carrying fiction.** FR-3 ships alongside so an operator can see which rows and why. Switch-on should be coordinated, not silent.

SD: SD-LEO-INFRA-STORY-E2E-AUTO-001 · LEAD-TO-PLAN 94 · PLAN-TO-EXEC 94

🤖 Generated with [Claude Code](https://claude.com/claude-code)
