### PR TITLE
fix(EVERY-CLAIM-WRITE-001): every SD claim reaffirm was failing 100% and printing success anyway

### DIFF
--- a/lib/claim-guard.mjs
+++ b/lib/claim-guard.mjs
@@ -196,7 +196,9 @@ export async function reaffirmClaimColumns(supabase, sdKey, sessionId) {
         `(${holder ? String(holder).slice(0, 8) : 'unknown'}) — not clobbering. ` +
         `Authoritative claim is enforced at the QF adopt entrypoint.`
       );
+      return { ok: false, reason: 'NOT_HELD', holder: holder || null };
     }
+    return { ok: true, reason: 'OK' };
   } else {
     // SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-002 (FR-6): the SD branch was the ONLY writer here
     // without a compare-and-set. It issued a bare .update(...).eq('sd_key', ...), so every reaffirm
@@ -211,21 +213,77 @@ export async function reaffirmClaimColumns(supabase, sdKey, sessionId) {
       .update({ claiming_session_id: sessionId, is_working_on: true, claim_gate_client_version: CLAIM_GUARD_CODE_VERSION }) // schema-lint-disable-line — new column (this SD's migration), chairman-apply-gated, not yet in the live snapshot
       .eq('sd_key', sdKey)
       .or(`claiming_session_id.is.null,claiming_session_id.eq.${sessionId}`)
-      .select('sd_key');
+      // SD-LEO-INFRA-EVERY-CLAIM-WRITE-001 (FR-1). THE PROJECTION IS PART OF THE FILTER.
+      // On a PostgREST *UPDATE* an `.or()` resolves its columns against the RETURNING projection,
+      // not against the table. Projecting only `sd_key` while filtering on `claiming_session_id`
+      // made this 42703 on EVERY call — a 100% silent failure, not the intermittent schema-cache
+      // lag it was first diagnosed as. MEASURED three-way, identical payload and filter:
+      //   proj=sd_key -> ERR 42703 | proj=sd_key,claiming_session_id -> OK | proj=* -> OK
+      // and a SELECT with the SAME `.or` returns rows, proving the column exists.
+      // THE ERROR MESSAGE MISNAMES ITS OWN CAUSE ("column ... does not exist"), which is exactly
+      // why it was misread — so the true cause is recorded HERE, where that message appears.
+      // `.eq()` is unaffected; only `.or()` behaves this way. Do not narrow this projection.
+      .select('sd_key,claiming_session_id');
 
     // A LOST CAS IS SILENT WITHOUT THIS. PostgREST reports zero updated rows, not an error, so the
     // no-op would look identical to success — which is how a stomp (or a failure to reaffirm) went
-    // unnoticed. Reaffirm stays best-effort defence-in-depth, so a lost race only warns; the
-    // authoritative claim decision lives at the claim entrypoint, not here.
+    // unnoticed. Reaffirm stays best-effort defence-in-depth: it never decides WHO holds the claim
+    // (that is the claim entrypoint's job) — it only reports, honestly, whether its own write landed.
     if (reaffirmErr) {
       console.warn(`[claimGuard] reaffirm: SD ${sdKey} update errored — ${reaffirmErr.message}`);
-    } else if (!reaffirmed || reaffirmed.length === 0) {
+      return { ok: false, reason: 'WRITE_FAULT', error: reaffirmErr.message };
+    }
+    if (!reaffirmed || reaffirmed.length === 0) {
       console.warn(
         `[claimGuard] reaffirm: SD ${sdKey} is held by another session — not clobbering. ` +
         'Authoritative claim is enforced at the claim entrypoint.'
       );
+      return { ok: false, reason: 'NOT_HELD' };
     }
+
+    // VALUE-EQUALITY READBACK (FR-2): the returned row IS the persisted value, so success is
+    // asserted from what the database now holds — never from the write we intended to make.
+    // A zero-row update and an errored update are both already handled above; this catches the
+    // third case, where a row came back holding something other than us.
+    const persisted = reaffirmed[0]?.claiming_session_id;
+    if (persisted !== sessionId) {
+      console.warn(
+        `[claimGuard] reaffirm: SD ${sdKey} readback mismatch — persisted ` +
+        `${persisted ? String(persisted).slice(0, 8) : 'null'}, expected ${String(sessionId).slice(0, 8)}.`
+      );
+      return { ok: false, reason: 'READBACK_MISMATCH', holder: persisted || null };
+    }
+    return { ok: true, reason: 'OK' };
   }
+}
+
+/**
+ * SD-LEO-INFRA-EVERY-CLAIM-WRITE-001 (FR-2/FR-3): turn a reaffirm outcome into a claim verdict.
+ *
+ * THE DEFECT THIS EXISTS TO KILL: all three success branches used to `await reaffirmClaimColumns()`,
+ * DISCARD the result, and `return { success: true }`. The write had been failing 100% of the time and
+ * nobody could tell, because the only report was a console.warn — a guard that reports to a LOG LINE
+ * instead of to the VERDICT buys nothing. A silently-unpersisted claim expires at the TTL while the
+ * owner is told it holds, and the handoff then dies at the LAST gate after all the work is done.
+ *
+ * WRITE_FAULT and NOT_HELD are kept DISTINCT (FR-3) because they need different operator responses:
+ * a fault means the database refused our write; NOT_HELD/READBACK_MISMATCH mean a peer legitimately
+ * owns the row. Both must stop a success banner, but only the first is a fault of ours. Single
+ * representation: every caller routes through here, so the three branches cannot drift apart again.
+ */
+export function reaffirmFailureVerdict(reaffirm) {
+  if (!reaffirm || reaffirm.ok) return null;
+  const holder = reaffirm.holder || null;
+  return {
+    success: false,
+    error: reaffirm.reason === 'WRITE_FAULT'
+      ? `claim_reaffirm_write_failed: ${reaffirm.error || 'unknown'}`
+      : 'claim_held_by_other_session',
+    reaffirm_reason: reaffirm.reason,
+    owner: holder
+      ? { session_id: holder, hostname: 'unknown', tty: 'unknown', note: 'Claim row is held by another session' }
+      : undefined
+  };
 }
 
 /**
@@ -470,7 +528,9 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
       .eq('session_id', sessionId);
 
     // QF-20260511-016: Re-affirm SD-row claim cols (idempotent defense vs. trigger overreach).
-    await reaffirmClaimColumns(supabase, sdKey, sessionId);
+    // EVERY-CLAIM-WRITE-001 (FR-2): propagate — a reaffirm that did not persist is not "already owned".
+    const reaffirmFail = reaffirmFailureVerdict(await reaffirmClaimColumns(supabase, sdKey, sessionId));
+    if (reaffirmFail) return reaffirmFail;
 
     return {
       success: true,
@@ -512,7 +572,9 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
           .update(stampBranch({ heartbeat_at: new Date().toISOString() }))
           .eq('session_id', sessionId);
         // QF-20260511-016: Re-affirm SD-row claim cols on adoption (idempotent).
-        await reaffirmClaimColumns(supabase, sdKey, sessionId);
+        // EVERY-CLAIM-WRITE-001 (FR-2): an adoption whose claim cols never persisted is not an adoption.
+        const adoptFail = reaffirmFailureVerdict(await reaffirmClaimColumns(supabase, sdKey, sessionId));
+        if (adoptFail) return adoptFail;
         return {
           success: true,
           claim: { session_id: sessionId, sd_key: sdKey, status: 'adopted_same_conversation' }
@@ -762,7 +824,11 @@ export async function claimGuard(sdKey, sessionId, options = {}) {
   }
 
   // QF-20260511-016: Use unified helper so all three success branches converge.
-  await reaffirmClaimColumns(supabase, sdKey, sessionId);
+  // EVERY-CLAIM-WRITE-001 (FR-2): verifyClaimOwnership above confirms the RPC's write, but the
+  // reaffirm's own columns (is_working_on, claim_gate_client_version) are written HERE — and this
+  // is precisely the path that reported "SD claimed successfully" while they never landed.
+  const acquireFail = reaffirmFailureVerdict(await reaffirmClaimColumns(supabase, sdKey, sessionId));
+  if (acquireFail) return acquireFail;
 
   return {
     success: true,

--- a/lib/claim-guard.test.js
+++ b/lib/claim-guard.test.js
@@ -81,11 +81,26 @@ function mockClaudeSessionsEnrichmentQuery(data, error = null) {
 // The chain is thenable so the pre-existing `await …update().eq()` call sites keep working unchanged,
 // and .select() resolves to ONE row so a CAS is treated as WON by default. Tests that need a LOST
 // CAS assert against the dedicated FR-6 suite, which stubs an empty result explicitly.
-function updateChainStub(rows = [{ sd_key: 'stub' }]) {
+//
+// SD-LEO-INFRA-EVERY-CLAIM-WRITE-001: the reaffirm now PROJECTS claiming_session_id and asserts
+// success from that readback rather than from the write it intended. So a won-CAS row must actually
+// CARRY the session — the old `{ sd_key: 'stub' }` row had no such field, which now reads (correctly)
+// as "the row came back holding someone else". The stub DERIVES it from the `.or()` filter it was
+// handed, exactly as the database would on a won CAS, instead of hardcoding a session constant that
+// could silently drift away from the caller's.
+function updateChainStub(rows = null) {
+  let session = null;
   const chain = {
     eq: vi.fn(() => chain),
-    or: vi.fn(() => chain),
-    select: vi.fn().mockResolvedValue({ data: rows, error: null }),
+    or: vi.fn((filter) => {
+      const m = /claiming_session_id\.eq\.([^,)\s]+)/.exec(String(filter || ''));
+      if (m) session = m[1];
+      return chain;
+    }),
+    select: vi.fn(() => Promise.resolve({
+      data: rows ?? [{ sd_key: 'stub', claiming_session_id: session }],
+      error: null
+    })),
     then: (resolve) => resolve({ data: null, error: null }),
   };
   return chain;

--- a/scripts/audit/control-seed-specs.json
+++ b/scripts/audit/control-seed-specs.json
@@ -7,7 +7,7 @@
     "extraArgs": [
       "--all"
     ],
-    "note": "CONTROL-ABOUT-CONTROLS. No --root, but it enumerates via git/fs calls that inherit cwd, so it IS aimable \u2014 scopability by flag alone under-counted it.",
+    "note": "CONTROL-ABOUT-CONTROLS. No --root, but it enumerates via git/fs calls that inherit cwd, so it IS aimable — scopability by flag alone under-counted it.",
     "fixtures": [
       {
         "path": "lib/seeded-gauge-citation-defect.js",
@@ -25,11 +25,11 @@
     "rootFlag": null,
     "cwdScope": true,
     "extraArgs": [],
-    "note": "CONTROL-ABOUT-CONTROLS. TESTED IN DEFAULT MODE, DELIBERATELY. An earlier run passed --enforce and scored BLOCKS, but --enforce is NOT what CI runs \u2014 the ruled question is whether a control BLOCKS AT MERGE TIME, so measuring a non-default enforcing mode overstates protection. In its default advisory mode it DETECTS and exits 0.",
+    "note": "CONTROL-ABOUT-CONTROLS. TESTED IN DEFAULT MODE, DELIBERATELY. An earlier run passed --enforce and scored BLOCKS, but --enforce is NOT what CI runs — the ruled question is whether a control BLOCKS AT MERGE TIME, so measuring a non-default enforcing mode overstates protection. In its default advisory mode it DETECTS and exits 0.",
     "fixtures": [
       {
         "path": "lib/seeded-liveness-select-defect.js",
-        "content": "// SEEDED DEFECT: unbounded multi-row claude_sessions select \u2014 the PostgREST 1000-row\n// cap silently drops the NEWEST live workers, so liveness undercounts.\nexport async function all(supabase) {\n  return supabase.from('claude_sessions').select('session_id, heartbeat_at');\n}\n"
+        "content": "// SEEDED DEFECT: unbounded multi-row claude_sessions select — the PostgREST 1000-row\n// cap silently drops the NEWEST live workers, so liveness undercounts.\nexport async function all(supabase) {\n  return supabase.from('claude_sessions').select('session_id, heartbeat_at');\n}\n"
       }
     ],
     "detectTokens": [
@@ -81,7 +81,7 @@
     "fixtures": [
       {
         "path": "scripts/ci/seeded-count-delta-defect.mjs",
-        "content": "// SEEDED DEFECT: gates on a raw failure-COUNT delta rather than an identity-set diff.\n// Uses the rule's actual lexicon (failedCount / baselineFailed) \u2014 my first seed said\n// failCount, which the lexicon does not match, so the control correctly reported 0.\nexport function gate(baselineFailed, failedCount) {\n  if (failedCount > baselineFailed) {\n    throw new Error('failure count rose');\n  }\n  return true;\n}\n"
+        "content": "// SEEDED DEFECT: gates on a raw failure-COUNT delta rather than an identity-set diff.\n// Uses the rule's actual lexicon (failedCount / baselineFailed) — my first seed said\n// failCount, which the lexicon does not match, so the control correctly reported 0.\nexport function gate(baselineFailed, failedCount) {\n  if (failedCount > baselineFailed) {\n    throw new Error('failure count rose');\n  }\n  return true;\n}\n"
       }
     ],
     "seedNote": "SEED WAS WRONG AND HAS BEEN FIXED. The rule's EXACT_LEXICON/LEXICON_PATTERN match failed|failing|failure names (failedCount, baselineFailed). My first seed used failCount, which is outside the lexicon, so the control scanned the fixture and correctly found nothing. That was a SEED MISMATCH, never evidence of blindness."
@@ -143,7 +143,7 @@
     "detectTokens": [
       "seeded-mock-sut"
     ],
-    "note": "WAS marked UNTESTABLE on flags alone. SCAN_DIRS is RELATIVE, so it resolves against cwd \u2014 retesting via cwdScope.",
+    "note": "WAS marked UNTESTABLE on flags alone. SCAN_DIRS is RELATIVE, so it resolves against cwd — retesting via cwdScope.",
     "seedNote": "UNRESOLVED SILENT, and NOT a mode artifact: re-probed with NO_MOCKED_SUT_IMPORT_MODE=block and it is STILL silent, so promoting it would not change the verdict. Either the seed does not match its detector shape or it genuinely does not fire. NOT recorded as blind on this evidence."
   },
   {
@@ -161,13 +161,13 @@
       "seeded-venture-artifact-defect",
       "title"
     ],
-    "note": "WAS marked UNTESTABLE on flags alone. SCAN_DIRS is RELATIVE, so it resolves against cwd \u2014 retesting via cwdScope."
+    "note": "WAS marked UNTESTABLE on flags alone. SCAN_DIRS is RELATIVE, so it resolves against cwd — retesting via cwdScope."
   },
   {
     "name": "control-seed-test-lint",
     "script": "scripts/lint/control-seed-test-lint.mjs",
     "seedTest": "tests/unit/lint/control-seed-test-lint.test.js",
-    "note": "Seeded by the committed TS-5 test: plants a deliberately blind gauge and asserts the gate REFUSES it. Cannot use a fixture trial \u2014 this control's certified output is a VERDICT about other controls, not a code pattern in a file.",
+    "note": "Seeded by the committed TS-5 test: plants a deliberately blind gauge and asserts the gate REFUSES it. Cannot use a fixture trial — this control's certified output is a VERDICT about other controls, not a code pattern in a file.",
     "neuter": {
       "find": "reason: 'SEED_DID_NOT_FIRE'",
       "replace": "reason: 'SEED_DID_NOT_FIRE_NEUTERED'",
@@ -182,7 +182,7 @@
     "name": "control-seed-test",
     "script": "scripts/audit/control-seed-test.mjs",
     "seedTest": "tests/unit/lint/control-seed-test-lint.test.js",
-    "note": "Same TS-5 test exercises runTrial through evaluate \u2014 a blind gauge must come back SILENT. Its certified behaviour is a verdict, so there is no code pattern to seed into a fixture.",
+    "note": "Same TS-5 test exercises runTrial through evaluate — a blind gauge must come back SILENT. Its certified behaviour is a verdict, so there is no code pattern to seed into a fixture.",
     "neuter": {
       "find": ": VERDICT.SILENT;",
       "replace": ": VERDICT.DETECTS;",
@@ -241,5 +241,20 @@
         "content": "// NOT the defect. A correctly guarded producer, present so the coverage denominator is\n// non-zero — see the note on this spec. The lint reads source as TEXT and never imports it,\n// so the unresolvable path below is irrelevant to the trial.\nimport { insertGuarded, CLASSIFICATION } from '../../lib/governance/fixture-producer-guard.mjs';\nexport async function ok(supabase) {\n  return insertGuarded(supabase, 'ventures', { name: 'TEST-seeded-guarded', is_demo: true },\n    { classification: CLASSIFICATION.FIXTURE, source: 'seed-trial' });\n}\n"
       }
     ]
+  },
+  {
+    "name": "or-filter-must-project",
+    "script": "scripts/lint/or-filter-must-project.mjs",
+    "seedTest": "tests/unit/claim/every-claim-write-reaffirm.test.js",
+    "note": "SD-LEO-INFRA-EVERY-CLAIM-WRITE-001 (FR-4). The control it guards: on a PostgREST UPDATE an .or() filter resolves its columns against the RETURNING projection, so filtering on a column the .select() omits returns 42703 on EVERY call — and the error names that column as missing when it exists, which is why the original defect was misdiagnosed as transient schema-cache staleness. seedTest form rather than fixtures because this control ships as a PURE FUNCTION over source text with no file-walking CLI, so there is no root to aim at a fixture directory; the committed test compensates by carrying BOTH directions itself — a hand-written broken chain that must be flagged, the real lib/quick-fix-claim.mjs that must NOT be (the positive control the coordinator directed me to leave untouched), an .eq-only chain that must NOT be flagged (measured: .eq does not resolve against the projection, so linting it would churn three working release sites), and an in-test mutation that narrows the real claim-guard projection back and asserts the lint catches it.",
+    "neuter": {
+      "find": "if (missing.length > 0) {",
+      "replace": "if (false) {",
+      "why": "the lint stops reporting findings, so the deliberately-broken chain in the seed test is no longer flagged and the FLAGS-the-narrowed-projection assertion goes RED — proving the control is what makes that test pass, not the test asserting its own premise."
+    },
+    "observability_proof": {
+      "input": "The SOURCE TEXT of a single .js/.mjs/.cjs file, passed directly to findUnprojectedOrFilters(source, filePath) as a string, with block and line comments BLANKED (not deleted, so reported line numbers stay true) before matching. It consumes NO database columns, NO environment variables, and NO filesystem walk — the caller supplies the text. Its OUTPUT SIGNAL is the returned array of findings, each {file, line, missing[], projection, message}; an empty array means no unprojected .or() filter was found in that text.",
+      "seen": "A REAL positive on REAL DEPLOYED SOURCE, not a temp-dir fixture: run against the pre-fix blob of lib/claim-guard.mjs as it stood on origin/main (blob ab68046eecdcb5f4d78bab0df94f9092fc4e5bed), it returns exactly ONE finding, at line 211, missing=claiming_session_id, projection=sd_key. That is the precise chain which, executed against live PostgREST under a service-role key on 2026-08-09, returned 42703 column strategic_directives_v2.claiming_session_id does not exist on every call while a SELECT with the identical .or filter returned rows — so the control fires on the exact deployed line whose live failure was independently observed, and the readback of claim_gate_client_version (NULL under that blob, 1 after the fix) is the persisted evidence of that failure. Two-sided in the same run: 0 findings on the fixed file, 0 on lib/quick-fix-claim.mjs and 0 on lib/claim/reacquire-self-live.mjs, both of which are correct and must never be flagged. NOTE the limitation that bounds this proof: reacquire-self-live passes a VARIABLE to .or(), so its 0 is unanalyzable-and-silent, not verified-clean."
+    }
   }
 ]

--- a/scripts/lint/or-filter-must-project.mjs
+++ b/scripts/lint/or-filter-must-project.mjs
@@ -19,6 +19,19 @@
  *
  * The 42703 it prevents says "column ... does not exist" about a column that DOES exist — the error
  * misnames its own cause, which is what made the original defect read as transient cache staleness.
+ *
+ * KNOWN LIMITATION — what this control CANNOT see, stated concretely so nobody reads a clean run as
+ * proof of absence:
+ *  1. A `.or()` whose argument is a VARIABLE rather than a string literal is invisible. MEASURED:
+ *     `.update({...}).eq('id', i).or(orFilter).select('id')` yields ZERO findings, and this is not
+ *     hypothetical — `lib/claim/reacquire-self-live.mjs:304` builds its filter into `orFilter` and
+ *     passes it exactly that way. That site is correct today (it projects the column), but if it
+ *     ever narrows its projection THIS LINT WILL NOT CATCH IT. A text scan cannot resolve a value.
+ *  2. A chain assembled across statements (`let q = sb.from(t).update(x); if (c) q = q.or(...);`)
+ *     is not contiguous text, so the window never sees the `.or()` and the `.select()` together.
+ *  3. The scan window ends at the first statement terminator or 2000 characters, whichever comes
+ *     first; a chain longer than that is truncated and under-reported.
+ * All three fail SILENT (a miss, never a false alarm). Closing them needs an AST pass, not a regex.
  */
 
 /** Columns referenced inside an `.or(...)` argument: `col.op.value`, comma-separated. */
@@ -44,7 +57,13 @@ export function projectionColumns(selectArg) {
  */
 export function findUnprojectedOrFilters(source, filePath = '<source>') {
   const findings = [];
-  const text = String(source || '');
+  // COMMENTS ARE BLANKED FIRST — A COMMENT IS NOT CODE. Measured: against the real pre-fix
+  // lib/claim-guard.mjs this reported TWO findings for ONE defect, because a comment above the
+  // chain quoting `.update(...)` opened a scan window that swallowed the genuine chain below it.
+  // Blanked (not deleted) so byte offsets — and therefore reported line numbers — stay true.
+  const text = String(source || '')
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:])\/\/[^\n]*/g, (m, p1) => p1 + ' '.repeat(m.length - p1.length));
   for (const m of text.matchAll(/\.update\s*\(/g)) {
     const chain = text.slice(m.index, m.index + 2000).split(/;\s*(?:\r?\n|$)/)[0];
     const orMatch = chain.match(/\.or\s*\(\s*[`'"]([^`'"]*)[`'"]/);

--- a/scripts/lint/or-filter-must-project.mjs
+++ b/scripts/lint/or-filter-must-project.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-EVERY-CLAIM-WRITE-001 (FR-4) — an `.or()` filter on an UPDATE must project the
+ * columns it filters on.
+ *
+ * WHY A LINT AND NOT A ONE-LINE FIX: a correct site already existed (lib/quick-fix-claim.mjs) while
+ * the broken one sat next to it, so the knowledge was present and simply not enforced. A pin catches
+ * the instance; only a property catches the class.
+ *
+ * THE RULE, MEASURED — and it is NARROWER than "any filter must project its columns":
+ *   - On a PostgREST **UPDATE**, an `.or()` resolves its columns against the RETURNING projection.
+ *     Filter on a column absent from `.select(...)` and you get 42703 on every call.
+ *   - `.eq()` is **UNAFFECTED**: `.update().eq('claiming_session_id', x).select('id')` works fine
+ *     (measured: OK rows=1). Several correct release sites do exactly this — flagging them would be
+ *     a false positive, so this lint deliberately does NOT look at `.eq()`.
+ *   - An UPDATE with **no `.select()`** resolves against the table and is fine.
+ *   - A **SELECT** with the same `.or()` always works. Only UPDATE chains are inspected.
+ * Over-broadening this rule would churn working code; that is why the scope is pinned here.
+ *
+ * The 42703 it prevents says "column ... does not exist" about a column that DOES exist — the error
+ * misnames its own cause, which is what made the original defect read as transient cache staleness.
+ */
+
+/** Columns referenced inside an `.or(...)` argument: `col.op.value`, comma-separated. */
+export function orFilterColumns(orArg) {
+  const cols = [];
+  for (const m of String(orArg || '').matchAll(/([A-Za-z_][A-Za-z0-9_]*)\.(?:is|eq|neq|gt|gte|lt|lte|like|ilike|in|cs|cd)\./g)) {
+    cols.push(m[1]);
+  }
+  return [...new Set(cols)];
+}
+
+/** Columns named in a `.select('a, b')` projection. `*` (or a bare `.select()`) means "everything". */
+export function projectionColumns(selectArg) {
+  const raw = String(selectArg ?? '').trim();
+  if (raw === '' || raw === '*') return '*';
+  return raw.split(',').map((c) => c.trim().split(/[\s:(]/)[0]).filter(Boolean);
+}
+
+/**
+ * Find UPDATE chains whose `.or()` filters on a column their `.select()` does not project.
+ * Text-scanned rather than AST-parsed to stay dependency-free; the chain window ends at the
+ * statement terminator so a later unrelated `.select()` cannot be misattributed.
+ */
+export function findUnprojectedOrFilters(source, filePath = '<source>') {
+  const findings = [];
+  const text = String(source || '');
+  for (const m of text.matchAll(/\.update\s*\(/g)) {
+    const chain = text.slice(m.index, m.index + 2000).split(/;\s*(?:\r?\n|$)/)[0];
+    const orMatch = chain.match(/\.or\s*\(\s*[`'"]([^`'"]*)[`'"]/);
+    if (!orMatch) continue;
+    const selectMatch = chain.match(/\.select\s*\(\s*[`'"]([^`'"]*)[`'"]\s*\)/);
+    if (!selectMatch) continue; // no projection requested -> resolves against the table -> fine
+    const projected = projectionColumns(selectMatch[1]);
+    if (projected === '*') continue;
+    const missing = orFilterColumns(orMatch[1]).filter((c) => !projected.includes(c));
+    if (missing.length > 0) {
+      findings.push({
+        file: filePath,
+        line: text.slice(0, m.index).split('\n').length,
+        missing,
+        projection: selectMatch[1],
+        message:
+          `.update(...).or(...) filters on ${missing.join(', ')} but .select('${selectMatch[1]}') does not project `
+          + `${missing.length > 1 ? 'them' : 'it'}. On a PostgREST UPDATE an .or() resolves against the RETURNING `
+          + 'projection, so this returns 42703 on EVERY call — and the error names the column as missing when it exists.'
+      });
+    }
+  }
+  return findings;
+}

--- a/tests/unit/claim/every-claim-write-reaffirm.test.js
+++ b/tests/unit/claim/every-claim-write-reaffirm.test.js
@@ -1,0 +1,167 @@
+// SD-LEO-INFRA-EVERY-CLAIM-WRITE-001 — the reaffirm write must LAND, and its outcome must reach
+// the VERDICT rather than a log line.
+//
+// TWO DEFECTS COMPOSED HERE, and the second is why the first survived:
+//  (1) `.update(...).or('claiming_session_id...').select('sd_key')` — on a PostgREST UPDATE an
+//      `.or()` resolves its columns against the RETURNING projection, so this 42703'd on EVERY call.
+//      Not intermittent, not a schema-cache lag: 100%, deterministic.
+//  (2) reaffirmClaimColumns console.warn'd, returned undefined, and all three callers discarded it
+//      and returned success:true — so sd-start printed "SD claimed successfully" over a write that
+//      never landed, and a claim silently expired at the TTL while its owner was told it held.
+//
+// THE FAKE RECORDS THE QUERY ON PURPOSE. A fake whose builder methods all return the same object and
+// the same fixture cannot tell the fixed code from the broken code — reverting the projection would
+// leave every assertion green. That exact blindness shipped (green) on QF-673 earlier this session
+// and was only caught by mutation. Here the projection is asserted DIRECTLY.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { reaffirmClaimColumns, reaffirmFailureVerdict } from '../../../lib/claim-guard.mjs';
+import { findUnprojectedOrFilters, orFilterColumns, projectionColumns } from '../../../scripts/lint/or-filter-must-project.mjs';
+
+const ME = '11111111-1111-4111-8111-111111111111';
+const PEER = '22222222-2222-4222-8222-222222222222';
+const KEY = 'SD-TEST-REAFFIRM-001';
+const repoFile = (p) => readFileSync(join(process.cwd(), p), 'utf8');
+
+/** Chainable fake that RECORDS every builder call, so the PROJECTION and FILTER are observable. */
+function makeSb({ data = [{ sd_key: KEY, claiming_session_id: ME }], error = null } = {}) {
+  const calls = [];
+  const o = {
+    update: (...a) => { calls.push({ m: 'update', a }); return o; },
+    eq: (...a) => { calls.push({ m: 'eq', a }); return o; },
+    or: (...a) => { calls.push({ m: 'or', a }); return o; },
+    select: (...a) => { calls.push({ m: 'select', a }); return Promise.resolve({ data, error }); }
+  };
+  return { from: (t) => { calls.push({ m: 'from', a: [t] }); return o; }, calls,
+    arg: (m) => calls.find((c) => c.m === m)?.a?.[0] };
+}
+
+describe('FR-1: the reaffirm UPDATE projects the column its .or() filters on', () => {
+  it('PROJECTS claiming_session_id — the core defect, and the only test that observes it', async () => {
+    // THE test. Every other assertion below would stay green with the old broken projection.
+    const sb = makeSb();
+    await reaffirmClaimColumns(sb, KEY, ME);
+    const projection = sb.arg('select');
+    const filtered = orFilterColumns(sb.arg('or'));
+    expect(filtered).toContain('claiming_session_id');
+    for (const col of filtered) expect(projection).toContain(col);
+  });
+
+  it('still filters null-OR-self, so reaffirm cannot steal a peer row', async () => {
+    const sb = makeSb();
+    await reaffirmClaimColumns(sb, KEY, ME);
+    expect(sb.arg('or')).toContain('claiming_session_id.is.null');
+    expect(sb.arg('or')).toContain(`claiming_session_id.eq.${ME}`);
+  });
+});
+
+describe('FR-2/FR-3: the outcome reaches the verdict, and the two failure modes stay distinct', () => {
+  it('reports OK only when the READBACK shows this session', async () => {
+    const r = await reaffirmClaimColumns(makeSb(), KEY, ME);
+    expect(r).toEqual({ ok: true, reason: 'OK' });
+  });
+
+  it('a WRITE ERROR is a FAULT — never a success', async () => {
+    // The exact CODIFY failure mode: the write errored and a success banner printed anyway.
+    const r = await reaffirmClaimColumns(makeSb({ data: null, error: { message: 'boom' } }), KEY, ME);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('WRITE_FAULT');
+  });
+
+  it('a LOST CAS (zero rows) is NOT_HELD — a peer owns it, which is not our fault', async () => {
+    const r = await reaffirmClaimColumns(makeSb({ data: [] }), KEY, ME);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('NOT_HELD');
+  });
+
+  it('WRITE_FAULT and NOT_HELD are DISTINCT — collapsing them would hide which one happened', async () => {
+    const fault = await reaffirmClaimColumns(makeSb({ data: null, error: { message: 'x' } }), KEY, ME);
+    const lost = await reaffirmClaimColumns(makeSb({ data: [] }), KEY, ME);
+    expect(fault.reason).not.toBe(lost.reason);
+  });
+
+  it('VALUE-EQUALITY READBACK: a row that comes back holding someone else is not success', async () => {
+    // Success is asserted from what the database now holds, never from the write we intended.
+    const r = await reaffirmClaimColumns(makeSb({ data: [{ sd_key: KEY, claiming_session_id: PEER }] }), KEY, ME);
+    expect(r.ok).toBe(false);
+    expect(r.reason).toBe('READBACK_MISMATCH');
+    expect(r.holder).toBe(PEER);
+  });
+
+  it('every non-ok outcome becomes a FAILING claim verdict; ok passes through untouched', () => {
+    expect(reaffirmFailureVerdict({ ok: true, reason: 'OK' })).toBeNull();
+    expect(reaffirmFailureVerdict({ ok: false, reason: 'WRITE_FAULT', error: 'e' }).success).toBe(false);
+    expect(reaffirmFailureVerdict({ ok: false, reason: 'NOT_HELD' }).success).toBe(false);
+    expect(reaffirmFailureVerdict({ ok: false, reason: 'READBACK_MISMATCH' }).success).toBe(false);
+    // A fault must be distinguishable from contention in the message an operator actually reads.
+    expect(reaffirmFailureVerdict({ ok: false, reason: 'WRITE_FAULT', error: 'e' }).error).toMatch(/write_failed/);
+    expect(reaffirmFailureVerdict({ ok: false, reason: 'NOT_HELD' }).error).toMatch(/held_by_other/);
+  });
+});
+
+describe('FR-2 (source property): no caller may DISCARD the reaffirm result', () => {
+  it('every reaffirmClaimColumns call site routes through the verdict helper', () => {
+    // The defect was structural — three call sites awaiting and dropping the value. A behavioural
+    // test on one branch would not have caught the other two, so assert the property over all of them.
+    // COMMENTS ARE BLANKED FIRST. The first version of this test matched the doc-comment above the
+    // helper — which mentions the function by name — and reported a discard that does not exist.
+    // A comment is not code; a scan that cannot tell them apart measures prose.
+    const src = repoFile('lib/claim-guard.mjs')
+      .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+      .replace(/^\s*\/\/.*$/gm, '');
+    const lines = src.split('\n');
+    const callSites = lines
+      .map((text, i) => ({ text, line: i + 1 }))
+      .filter(({ text }) => /\breaffirmClaimColumns\s*\(/.test(text) && !/^export async function/.test(text.trim()));
+    expect(callSites.length, 'expected the three known call sites').toBeGreaterThanOrEqual(3);
+    for (const { text, line } of callSites) {
+      expect(text, `line ${line} discards the reaffirm result`).toMatch(/reaffirmFailureVerdict\s*\(/);
+    }
+  });
+});
+
+describe('FR-4 (the lint): an .or() on an UPDATE must project the columns it filters on', () => {
+  it('FLAGS the narrowed projection — the shipped defect', () => {
+    const broken = "await sb.from('t').update({ a: 1 }).eq('sd_key', k).or(`claiming_session_id.is.null,claiming_session_id.eq.${s}`).select('sd_key');";
+    const found = findUnprojectedOrFilters(broken, 'broken.mjs');
+    expect(found).toHaveLength(1);
+    expect(found[0].missing).toEqual(['claiming_session_id']);
+  });
+
+  it('PASSES the real claimQuickFix — the positive control that proves the pattern works', () => {
+    // Coordinator-directed: claimQuickFix is already correct and must NOT be touched. If this ever
+    // fails, the lint has become over-broad, not the code wrong.
+    expect(findUnprojectedOrFilters(repoFile('lib/quick-fix-claim.mjs'), 'quick-fix-claim.mjs')).toEqual([]);
+  });
+
+  it('PASSES the fixed claim-guard, and would have FAILED it before the fix', () => {
+    const fixed = repoFile('lib/claim-guard.mjs');
+    expect(findUnprojectedOrFilters(fixed, 'claim-guard.mjs')).toEqual([]);
+    // MUTATION, in-test: narrow the projection back and the lint must catch it. Without this the
+    // suite could pass simply because the scanner never matches anything.
+    const mutated = fixed.replace(".select('sd_key,claiming_session_id')", ".select('sd_key')");
+    expect(mutated).not.toBe(fixed);
+    expect(findUnprojectedOrFilters(mutated, 'claim-guard.mjs').length).toBeGreaterThan(0);
+  });
+
+  it('does NOT flag .eq() filters — measured unaffected; flagging them would churn working code', () => {
+    // lib/claim-lifecycle-release.mjs filters .eq('claiming_session_id') while projecting only 'id'
+    // and works fine. The rule is about .or() specifically.
+    const eqOnly = "await sb.from('t').update({ a: 1 }).eq('id', i).eq('claiming_session_id', h).select('id');";
+    expect(findUnprojectedOrFilters(eqOnly, 'eq.mjs')).toEqual([]);
+  });
+
+  it('does NOT flag an UPDATE with no .select(), nor a SELECT chain', () => {
+    const noSelect = "await sb.from('t').update({ a: 1 }).eq('id', i).or('pipeline_mode.eq.building,pipeline_mode.is.null');";
+    expect(findUnprojectedOrFilters(noSelect, 'no-select.mjs')).toEqual([]);
+    const selectChain = "await sb.from('t').select('id').or('claiming_session_id.is.null');";
+    expect(findUnprojectedOrFilters(selectChain, 'select.mjs')).toEqual([]);
+  });
+
+  it('treats select(*) as projecting everything', () => {
+    expect(projectionColumns('*')).toBe('*');
+    const star = "await sb.from('t').update({ a: 1 }).or('claiming_session_id.is.null').select('*');";
+    expect(findUnprojectedOrFilters(star, 'star.mjs')).toEqual([]);
+  });
+});

--- a/tests/unit/claim/reaffirm-cas-fr6.test.js
+++ b/tests/unit/claim/reaffirm-cas-fr6.test.js
@@ -78,7 +78,10 @@ describe('FR-6: the SD branch compare-and-sets', () => {
     const reaffirm = await loadFn();
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
-      const s = stub([{ sd_key: 'SD-A' }]);
+      // EVERY-CLAIM-WRITE-001: a HEALTHY row must now carry claiming_session_id, because success is
+      // asserted from the readback rather than from the intended write. The old fixture omitted it,
+      // which is (correctly) no longer a healthy path. The test's intent is unchanged.
+      const s = stub([{ sd_key: 'SD-A', claiming_session_id: ME }]);
       await reaffirm(s.client, 'SD-A', ME);
       expect(warn).not.toHaveBeenCalled();      // a warning on a healthy path trains readers to ignore it
     } finally { warn.mockRestore(); }
@@ -90,8 +93,15 @@ describe('FR-6: the SD branch compare-and-sets', () => {
     const reaffirm = await loadFn();
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
+      // EVERY-CLAIM-WRITE-001 — ASSERTION UPDATED, PROPERTY PRESERVED. The property this test
+      // defends is "a lost race must never become an exception that kills the caller", and that is
+      // still asserted. `toBeUndefined()` pinned the RETURN VALUE, and returning nothing is exactly
+      // the defect this SD fixes: a reaffirm that reported only to a console.warn let all three
+      // callers return success:true over a write that never landed. So the no-throw property stays
+      // and the over-specified pin becomes an assertion on the reported reason.
       const s = stub([]);
-      await expect(reaffirm(s.client, 'SD-A', ME)).resolves.toBeUndefined();
+      const result = await reaffirm(s.client, 'SD-A', ME);   // must not throw
+      expect(result).toEqual({ ok: false, reason: 'NOT_HELD' });
     } finally { warn.mockRestore(); }
   });
 


### PR DESCRIPTION
## Two defects composing — and the second is why the first survived

**1. The write never landed.** On a PostgREST **UPDATE**, an `.or()` filter resolves its columns against the **RETURNING projection**, not the table. `reaffirmClaimColumns` filtered on `claiming_session_id` while projecting only `sd_key`, so it returned **42703 on every call**.

Measured three ways, identical payload and filter:

| projection | result |
|---|---|
| `sd_key` | **ERR 42703** |
| `sd_key,claiming_session_id` | OK |
| `*` | OK |

A **SELECT** with the *same* `.or` returns rows, proving the column exists. **The error message misnames its own cause** ("column ... does not exist"), which is exactly why this was first diagnosed as transient schema-cache staleness. It is deterministic, not transient, and reproducible on demand.

**2. The failure was invisible.** The function `console.warn`'d, returned `undefined`, and all three callers `await`ed it, **discarded** it, and returned `success:true` — so `sd-start` printed "SD claimed successfully" over a write that never landed. A guard that reports to a **log line** instead of to the **verdict** buys nothing.

**Blast radius:** a claim that never reaffirms expires at the 15-minute TTL while its owner is told it holds; the handoff then dies `GATE_CLAIM_VALIDITY_FAILED` / `NO_CLAIM` at the **last** gate, after all the work is done. That is verbatim the CODIFY-HONEST-ACTIVATION-001 failure.

The CAS added by CLAIM-LIFECYCLE-RELEASE-002 FR-6 is what **broke** reaffirm; the discard is what **protected** it.

## How it was found
Dogfooded the SD on itself. `sd-start` printed success and `claiming_session_id` read back **correct** — but `claim_gate_client_version` was **NULL** while reaffirm writes `1`. The claim was only right because `worker-checkin`'s `claim_sd` **RPC** set it by a different path. *One field that only the failing writer sets is what made a 100% silent failure visible.*

## The fix
- **FR-1** — project the column the `.or()` filters on.
- **FR-2** — return `{ok, reason}`; all three callers route through **one** verdict helper that reports success only when the **readback** confirms it.
- **FR-3** — `WRITE_FAULT` (the database refused our write) stays distinct from `NOT_HELD` / `READBACK_MISMATCH` (a peer legitimately owns the row). Both stop the banner; only the first is our fault.
- **FR-4** — a lint so the class cannot recur, with the already-correct `claimQuickFix` as its **passing fixture**.

## Verification
- **Live, two-sided:** `claim_gate_client_version` NULL → 1 with `{ok:true}`; a peer session gets `NOT_HELD` and **does not steal the row**.
- **Mutation, both directions:** revert the projection → **2 tests RED**; revert the propagation → **1 test RED**. A surviving mutation would mean the suite is blind.
- **373 files / 4221 tests green** (batch, not isolation).

## Scope narrowed on measurement — coordinator ratified
The original plan named three sites. Two are closed:
- **`claimQuickFix` is NOT affected** — it already projects its filtered column. I had earlier told the coordinator it was "likely the same bug"; that came from a synthetic probe **I wrote**, not the real code. **Refuted and corrected.** It is now the lint's positive control and was deliberately left untouched.
- **Release writes are NOT affected** — `.eq()` does not resolve against the projection (measured: OK rows=1). This is why the lint is scoped to `.or()` only: a rule over "any filter" would flag correct code such as `claim-lifecycle-release.mjs:117`.
- The phantom-`results` read site is **not reproducible** — the evidence gate selects real columns and throws.

## What a green suite does NOT prove
The unit tests use a fake client. They do **not** prove live PostgREST behaviour under service-role on another project ref, nor that other seats were affected. The projection rule was measured from **one seat against one project ref**. The live confirmation on other refs belongs to the coordinator.

Note: the source diff is comment-heavy on purpose — the true cause is recorded **at the call site where the misleading 42703 appears**, so the next reader doesn't re-derive the cache-staleness misdiagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
