### PR TITLE
feat(SD-LEO-INFRA-FLEET-WIDE-VITEST-001): a test file in zero collected projects never runs, and the suite still says green

### DIFF
--- a/lib/testing/vitest-membership.js
+++ b/lib/testing/vitest-membership.js
@@ -1,0 +1,145 @@
+/**
+ * SD-LEO-INFRA-FLEET-WIDE-VITEST-001 FR-1 — fleet-wide project-membership completeness.
+ *
+ * A test file that belongs to ZERO collected vitest projects never runs, and the suite still
+ * reports GREEN. MEASURED: 3087 distinct collected paths vs 3616 tracked test files = 529
+ * members of no project — 229 stranded by the gated-db config path and 12 ordinary unit tests
+ * swallowed by a shared exclude, both invisible until enumerated. vitest.config.js:126 records
+ * this same class previously stranding tests/smoke.test.js and breaking every commit for days.
+ *
+ * PRIOR ART (FR-4): Alpha built a NARROW version of this check inside DRIVE-STATE's own tests
+ * ("no test this SD adds is a member of zero projects"). This supersedes rather than duplicates
+ * it — a guard scoped to one SD cannot see the 229 and the 12 that live everywhere else.
+ *
+ * THE POPULATION MUST COME FROM VITEST'S OWN COLLECTION, never a repo glob. A glob measures
+ * what the config INTENDS to collect; only `vitest list` measures what it ACTUALLY collects,
+ * and the gap between those two is precisely this defect. AC-3 pins that with a fixture that
+ * swaps the source and must flip the verdict.
+ *
+ * THE EXCLUSION SET IS CLOSED AND EXHAUSTIVE — five NAMED categories, each derived from an
+ * authority rather than hand-listed. It is emphatically NOT "minus everything currently
+ * uncollected": that formulation would have absorbed the 12 tests/unit/agents/ files this SD
+ * exists to fix, and the guard's first act would have been to hide a defect it detected.
+ */
+
+/** Named reasons a tracked test file is legitimately outside vitest's collection. */
+export const EXCLUSION_REASONS = Object.freeze({
+  PLAYWRIGHT: 'playwright_owned',
+  QUARANTINE: 'quarantined',
+  NON_VITEST_SUITE: 'non_vitest_suite',
+  PRODUCT_TREE: 'product_tree_not_tests',
+  NAMED_SHARED_EXCLUDE: 'named_shared_exclude',
+});
+
+const norm = (p) => String(p).replace(/\\/g, '/').replace(/^\.\//, '');
+
+/**
+ * Classify one tracked file. Returns an EXCLUSION_REASONS value when the file is legitimately
+ * uncollected, or null when it SHOULD be collected (and therefore must be, or the guard fails).
+ *
+ * @param {string} file repo-relative path
+ * @param {object} authorities all derived, none hand-listed:
+ *   playwrightDir      from playwright.config testDir
+ *   quarantined        from vitest.config's own manifest loader (manifest.quarantined[].file)
+ *   vitestMjsAnchors   the config's NARROW .mjs include anchors; anything .mjs/.cjs outside
+ *                      them is a node:test suite the config deliberately omits
+ *   productTrees       source trees named in SHARED_EXCLUDE that are not test locations
+ *   namedExcludes      literal file paths named in SHARED_EXCLUDE
+ */
+export function classifyTrackedFile(file, authorities = {}) {
+  const f = norm(file);
+  const {
+    playwrightDir = 'tests/e2e',
+    quarantined = [],
+    vitestMjsAnchors = [],
+    productTrees = [],
+    namedExcludes = [],
+  } = authorities;
+
+  const dir = norm(playwrightDir).replace(/\/$/, '');
+  if (f === dir || f.startsWith(`${dir}/`)) return EXCLUSION_REASONS.PLAYWRIGHT;
+
+  if (quarantined.some((q) => { const n = norm(q); return f === n || f.endsWith(`/${n}`); })) {
+    return EXCLUSION_REASONS.QUARANTINE;
+  }
+
+  if (namedExcludes.some((n) => f === norm(n) || f.endsWith(`/${norm(n)}`))) {
+    return EXCLUSION_REASONS.NAMED_SHARED_EXCLUDE;
+  }
+
+  if (productTrees.some((t) => { const n = norm(t).replace(/\/$/, ''); return f.startsWith(`${n}/`); })) {
+    return EXCLUSION_REASONS.PRODUCT_TREE;
+  }
+
+  // vitest's unit include targets `.test.js` broadly, plus NARROW `.mjs` anchors. Every other
+  // test-shaped file (.spec.*, and .mjs/.cjs outside those anchors) is a suite vitest is not
+  // meant to collect — the config comment states the repo's .test.mjs files are node:test-based
+  // and not vitest-compatible.
+  if (/\.test\.(mjs|cjs)$/.test(f)) {
+    const anchored = vitestMjsAnchors.some((a) => f.startsWith(`${norm(a).replace(/\/$/, '')}/`));
+    return anchored ? null : EXCLUSION_REASONS.NON_VITEST_SUITE;
+  }
+  if (/\.spec\.(js|mjs|cjs|ts|tsx)$/.test(f)) return EXCLUSION_REASONS.NON_VITEST_SUITE;
+  if (!/\.test\.(js|ts|tsx)$/.test(f)) return EXCLUSION_REASONS.NON_VITEST_SUITE;
+
+  return null; // should be collected
+}
+
+/**
+ * The verdict: which tracked files that SHOULD be collected are members of zero projects.
+ *
+ * An empty `collected` is treated as an ERROR, never as "everything is fine" — an enumeration
+ * that failed to run would otherwise make this guard pass while collecting nothing, which is
+ * the same green-but-blind failure it exists to catch.
+ */
+export function findUnmembered({ collected, tracked, authorities }) {
+  if (!Array.isArray(collected) || collected.length === 0) {
+    throw new Error('vitest-membership: collected enumeration is empty — refusing to report a pass. An enumeration that could not run is an error, not an empty set.');
+  }
+  const inCollection = new Set(collected.map(norm));
+  const unmembered = [];
+  for (const file of tracked.map(norm)) {
+    if (classifyTrackedFile(file, authorities) !== null) continue;
+    if (!inCollection.has(file)) unmembered.push(file);
+  }
+  return unmembered.sort();
+}
+
+/**
+ * The DB_INCLUDE patterns from vitest.config.js:113-119. These files are stranded by the
+ * gated-db config path, which CANNOT be repaired here: `tests/setup.db.js` does not gate at
+ * runtime (it passes a real SUPABASE_URL through via `||=`), and vitest.config.js:163 states
+ * 125 of 225 db suites do not self-guard — so ungating discovery would run them against
+ * whatever the URL points at. Coordinator verified that premise independently and split the
+ * runtime-gate work to a sibling data-integrity SD.
+ */
+export const KNOWN_STRANDED_DB_PATTERNS = Object.freeze([
+  /(^|\/)tests\/integration\/.*\.test\.js$/,
+  /(^|\/)tests\/database\/.*\.test\.js$/,
+  /(^|\/)tests\/db-invariants\/.*\.test\.js$/,
+  /(^|\/)tests\/migration-readiness\/.*\.test\.js$/,
+  /\.db\.test\.js$/,
+]);
+
+/**
+ * ADVISORY SPLIT — and the reason it is not a blind check.
+ *
+ * The guard runs in advisory mode ONLY for the gated-db class, and only until the sibling SD
+ * lands the runtime gate. Everything else FAILS immediately. The waiver is defined by the
+ * DB_INCLUDE PATTERNS, deliberately NOT by "whatever is currently unmembered" — a
+ * currently-failing snapshot would absorb the next real defect the moment it appeared, which
+ * is the catch-all this guard exists to prevent. A NEW orphan outside those patterns is a
+ * hard failure on day one.
+ *
+ * @returns {{waived: string[], blocking: string[]}}
+ */
+export function splitAdvisory(unmembered) {
+  const waived = [];
+  const blocking = [];
+  for (const f of unmembered) {
+    (KNOWN_STRANDED_DB_PATTERNS.some((re) => re.test(f)) ? waived : blocking).push(f);
+  }
+  return { waived, blocking };
+}
+
+export default { EXCLUSION_REASONS, classifyTrackedFile, findUnmembered, splitAdvisory, KNOWN_STRANDED_DB_PATTERNS };

--- a/scripts/one-off/_quarantine-surfaced-agents-tests.mjs
+++ b/scripts/one-off/_quarantine-surfaced-agents-tests.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * SD-LEO-INFRA-FLEET-WIDE-VITEST-001 — register the two RED test files that FR-3 surfaced.
+ *
+ * FR-3 narrowed SHARED_EXCLUDE's agents glob (aimed at the lib/agents source tree) so it stopped
+ * swallowing the tests/unit/agents tree. 12 files became collected for the first time; 10 pass, 2 do
+ * not. They were red all along — nothing could see them.
+ *
+ * QUARANTINE, NOT RE-EXCLUSION, and the difference is the whole point of this SD. Re-excluding
+ * would return them to invisibility: no record, no count, suite green, nobody knows. The
+ * manifest is the repo's DECLARED debt register (vitest.config.js:283-284), the membership
+ * guard treats quarantine as a NAMED category, and every entry carries its real error and a
+ * linked feedback row. The debt stays counted.
+ *
+ * Fixing the underlying product drift is OUT of this SD's scope — that is a separate ticket.
+ */
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const MANIFEST = path.join(REPO, 'tests/quarantine-manifest.json');
+const SESSION = 'cff8013c-93e3-41d2-bea1-f511c2189051';
+const LINKED = 'feedback:16fe70aa-ecc9-439f-b050-7b8c930103bb';
+const NOW = '2026-08-09T03:35:00.000Z';
+
+const ENTRIES = [
+  {
+    file: 'tests/unit/agents/venture-state-machine-jit-check.test.js',
+    reason_class: 'assertion-drift',
+    error_signature: "TypeError: stateMachine._approveHandoff is not a function // 4 tests; also \"TypeError: Cannot destructure property 'data' of '(intermediate value)' as it is undefined\". The suite targets a method that no longer exists on VentureStateMachine — the implementation moved on while the test could not fail, because vitest never collected it.",
+    linked_ref: LINKED,
+    quarantined_at: NOW,
+    quarantined_by: SESSION,
+    triage_note: 'NEVER COLLECTED until SD-LEO-INFRA-FLEET-WIDE-VITEST-001 FR-3 narrowed SHARED_EXCLUDE \'**/agents/**\' (aimed at lib/agents/**, it also swallowed tests/unit/agents/**). Not a new regression — a pre-existing red that nothing could observe. Quarantined rather than re-excluded so it stays counted in the declared register and visible to the membership guard. De-quarantine by realigning the suite with the current VentureStateMachine API, or delete it if the behaviour it asserts is gone.',
+  },
+  {
+    file: 'tests/unit/agents/agent-registry.test.js',
+    reason_class: 'timeout',
+    error_signature: 'Unknown Error: TypeError: fetch failed // a live network call inside a unit test; the unit tier pins a nonexistent spawn root and synthetic credentials, so any real fetch fails by design.',
+    linked_ref: LINKED,
+    quarantined_at: NOW,
+    quarantined_by: SESSION,
+    triage_note: 'NEVER COLLECTED until SD-LEO-INFRA-FLEET-WIDE-VITEST-001 FR-3, same cause as the sibling entry. reason_class set to the registered "timeout" class; the precise cause is an unmocked network call (TypeError: fetch failed) per error_signature. De-quarantine when the fetch is injected or mocked so the suite is genuinely a unit test.',
+  },
+];
+
+const manifest = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+const before = manifest.quarantined.length;
+for (const e of ENTRIES) {
+  if (manifest.quarantined.some((q) => q.file === e.file)) { console.log(`already present, skipping: ${e.file}`); continue; }
+  manifest.quarantined.push(e);
+}
+fs.writeFileSync(MANIFEST, `${JSON.stringify(manifest, null, 2)}\n`, 'utf8');
+
+// Read back from disk — not from the in-memory object I just mutated.
+const back = JSON.parse(fs.readFileSync(MANIFEST, 'utf8'));
+console.log(`quarantined: ${before} -> ${back.quarantined.length}`);
+for (const e of ENTRIES) {
+  const found = back.quarantined.find((q) => q.file === e.file);
+  console.log(`  ${found ? 'OK  ' : 'MISS'} ${e.file}${found ? ` (${found.reason_class})` : ''}`);
+  if (!found) process.exitCode = 1;
+}

--- a/tests/quarantine-manifest.json
+++ b/tests/quarantine-manifest.json
@@ -1358,6 +1358,24 @@
       "quarantined_by": "89b12649-6a0a-44ce-9208-424b564f6611",
       "triage_note": "GT-1 golden regression test ('status is closed when the reaper last fired 29 days ago AND the backlog shows a measured decline') fails deterministically (fixed clock 2026-07-16T12:00:00Z, not time-flaky) on a clean origin/main checkout — verified in an isolated throwaway worktree with zero file overlap with SD-LEO-FEAT-SMS-INBOUND-RELAY-001. Pre-existing regression, not caused by this SD; discovered only because it blocked this SD's required unit-tier CI check on merge.",
       "triaged_by": "SD-LEO-FEAT-SMS-INBOUND-RELAY-001"
+    },
+    {
+      "file": "tests/unit/agents/venture-state-machine-jit-check.test.js",
+      "reason_class": "assertion-drift",
+      "error_signature": "TypeError: stateMachine._approveHandoff is not a function // 4 tests; also \"TypeError: Cannot destructure property 'data' of '(intermediate value)' as it is undefined\". The suite targets a method that no longer exists on VentureStateMachine — the implementation moved on while the test could not fail, because vitest never collected it.",
+      "linked_ref": "feedback:16fe70aa-ecc9-439f-b050-7b8c930103bb",
+      "quarantined_at": "2026-08-09T03:35:00.000Z",
+      "quarantined_by": "cff8013c-93e3-41d2-bea1-f511c2189051",
+      "triage_note": "NEVER COLLECTED until SD-LEO-INFRA-FLEET-WIDE-VITEST-001 FR-3 narrowed SHARED_EXCLUDE '**/agents/**' (aimed at lib/agents/**, it also swallowed tests/unit/agents/**). Not a new regression — a pre-existing red that nothing could observe. Quarantined rather than re-excluded so it stays counted in the declared register and visible to the membership guard. De-quarantine by realigning the suite with the current VentureStateMachine API, or delete it if the behaviour it asserts is gone."
+    },
+    {
+      "file": "tests/unit/agents/agent-registry.test.js",
+      "reason_class": "timeout",
+      "error_signature": "Unknown Error: TypeError: fetch failed // a live network call inside a unit test; the unit tier pins a nonexistent spawn root and synthetic credentials, so any real fetch fails by design.",
+      "linked_ref": "feedback:16fe70aa-ecc9-439f-b050-7b8c930103bb",
+      "quarantined_at": "2026-08-09T03:35:00.000Z",
+      "quarantined_by": "cff8013c-93e3-41d2-bea1-f511c2189051",
+      "triage_note": "NEVER COLLECTED until SD-LEO-INFRA-FLEET-WIDE-VITEST-001 FR-3, same cause as the sibling entry. reason_class set to the registered \"timeout\" class; the precise cause is an unmocked network call (TypeError: fetch failed) per error_signature. De-quarantine when the fetch is injected or mocked so the suite is genuinely a unit test."
     }
   ]
 }

--- a/tests/unit/testing/vitest-membership.test.js
+++ b/tests/unit/testing/vitest-membership.test.js
@@ -1,0 +1,183 @@
+/**
+ * SD-LEO-INFRA-FLEET-WIDE-VITEST-001 — the membership-completeness guard.
+ *
+ * Two-sided throughout. The pure-logic arms run on injected fixtures so they are fast and
+ * deterministic; the LIVE arm runs vitest's own collection against the real repo, because a
+ * guard that only ever sees a fixture cannot see the config it is meant to police.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { classifyTrackedFile, findUnmembered, splitAdvisory, EXCLUSION_REASONS } from '../../../lib/testing/vitest-membership.js';
+
+const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+
+/** Authorities, DERIVED — never hand-listed. Guessing the manifest shape is what would make the count wrong. */
+function loadAuthorities() {
+  const cfg = fs.readFileSync(path.join(REPO, 'vitest.config.js'), 'utf8');
+  const pw = fs.readFileSync(path.join(REPO, 'playwright.config.js'), 'utf8');
+  const manifest = JSON.parse(fs.readFileSync(path.join(REPO, 'tests/quarantine-manifest.json'), 'utf8'));
+
+  const playwrightDir = (pw.match(/testDir:\s*['"]\.?\/?([^'"]+)['"]/) || [])[1] || 'tests/e2e';
+  // The config's NARROW .mjs include anchors, e.g. '**/tests/unit/org/**/*.test.mjs'.
+  const vitestMjsAnchors = [...cfg.matchAll(/'\*\*\/([^']+?)\/\*\*\/\*\.test\.mjs'/g)].map((m) => m[1]);
+  return {
+    playwrightDir,
+    quarantined: (manifest.quarantined || []).map((e) => e.file),
+    vitestMjsAnchors,
+    // SHARED_EXCLUDE entries that are SOURCE trees, not test locations. lib/agents holds
+    // product code; tests/unit/agents does NOT and must stay in the population (FR-3).
+    productTrees: ['lib/agents', 'applications', 'archive', 'press-kit', 'scratch', 'test'],
+    namedExcludes: ['tests/integration.test.js', 'tests/a11y.spec.js'],
+  };
+}
+
+function enumerateCollected() {
+  const out = execFileSync('npx', ['vitest', 'list', '--filesOnly'], {
+    cwd: REPO, encoding: 'utf8', timeout: 600000, maxBuffer: 64 * 1024 * 1024, shell: true,
+  });
+  return [...new Set(out.split('\n')
+    .map((l) => l.trim())
+    .filter((l) => /\.(test|spec)\.(js|mjs|cjs|ts|tsx)$/.test(l))
+    .map((l) => l.replace(/^\[[a-z-]+\]\s*/, '').replace(/\\/g, '/')))];
+}
+
+function enumerateTracked() {
+  const out = execFileSync('git', ['ls-files'], { cwd: REPO, encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  return out.split('\n').map((l) => l.trim()).filter((l) => /\.(test|spec)\.(js|mjs|cjs|ts|tsx)$/.test(l));
+}
+
+const AUTH = {
+  playwrightDir: 'tests/e2e',
+  quarantined: ['tests/unit/flaky.test.js'],
+  vitestMjsAnchors: ['tests/unit/org'],
+  productTrees: ['lib/agents'],
+  namedExcludes: ['tests/integration.test.js'],
+};
+
+describe('classifyTrackedFile — the exclusion set is CLOSED and each arm is named', () => {
+  it('a plain unit test SHOULD be collected (returns null)', () => {
+    expect(classifyTrackedFile('tests/unit/thing.test.js', AUTH)).toBe(null);
+  });
+
+  it('KEEPS tests/unit/agents/** in the population — the 12 files this SD fixes must NOT be exempted', () => {
+    // If this ever returns a reason, the guard has been widened to hide the defect it found.
+    expect(classifyTrackedFile('tests/unit/agents/agent-registry.test.js', AUTH)).toBe(null);
+  });
+
+  it('excludes Playwright-owned specs, derived from testDir', () => {
+    expect(classifyTrackedFile('tests/e2e/login.spec.ts', AUTH)).toBe(EXCLUSION_REASONS.PLAYWRIGHT);
+  });
+
+  it('excludes quarantined files, matched the way vitest.config globs them', () => {
+    expect(classifyTrackedFile('tests/unit/flaky.test.js', AUTH)).toBe(EXCLUSION_REASONS.QUARANTINE);
+  });
+
+  it('excludes node:test .mjs OUTSIDE the config anchors, but KEEPS .mjs inside them', () => {
+    expect(classifyTrackedFile('tests/unit/adam-startup.test.mjs', AUTH)).toBe(EXCLUSION_REASONS.NON_VITEST_SUITE);
+    expect(classifyTrackedFile('tests/unit/org/spine.test.mjs', AUTH)).toBe(null);
+  });
+
+  it('excludes product source trees but NOT test trees that merely share a name', () => {
+    expect(classifyTrackedFile('lib/agents/api.test.js', AUTH)).toBe(EXCLUSION_REASONS.PRODUCT_TREE);
+    // The distinction FR-3 turns on: same word, different tree.
+    expect(classifyTrackedFile('tests/unit/agents/api.test.js', AUTH)).toBe(null);
+  });
+
+  it('excludes literal paths named in SHARED_EXCLUDE', () => {
+    expect(classifyTrackedFile('tests/integration.test.js', AUTH)).toBe(EXCLUSION_REASONS.NAMED_SHARED_EXCLUDE);
+  });
+});
+
+describe('findUnmembered — two-sided, and it cannot pass on a failed enumeration', () => {
+  const tracked = ['tests/unit/a.test.js', 'tests/unit/b.test.js'];
+
+  it('AC-1 POSITIVE CONTROL: an orphan that should be collected but is not makes the guard RED', () => {
+    const res = findUnmembered({ collected: ['tests/unit/a.test.js'], tracked, authorities: AUTH });
+    expect(res).toEqual(['tests/unit/b.test.js']);
+  });
+
+  it('AC-2 NEGATIVE CONTROL: nothing unmembered when everything in the population is collected', () => {
+    const res = findUnmembered({ collected: tracked, tracked, authorities: AUTH });
+    expect(res).toEqual([]);
+  });
+
+  it('AC-3 SOURCE SWAP: feeding a tracked-file glob as the "collection" flips the verdict to a false clean', () => {
+    // The blind implementation: use the tracked list as if it were the collection. It reports
+    // clean while b.test.js is stranded — which is exactly why the population must come from
+    // vitest's own enumeration and never from a glob.
+    const blind = findUnmembered({ collected: tracked, tracked, authorities: AUTH });
+    const honest = findUnmembered({ collected: ['tests/unit/a.test.js'], tracked, authorities: AUTH });
+    expect(blind).toEqual([]);
+    expect(honest).toEqual(['tests/unit/b.test.js']);
+    expect(blind).not.toEqual(honest);
+  });
+
+  it('an EMPTY collection throws rather than passing — a failed enumeration is an error, not a clean bill', () => {
+    expect(() => findUnmembered({ collected: [], tracked, authorities: AUTH })).toThrow(/refusing to report a pass/);
+  });
+
+  it('NARROWNESS CONTROL: widening the exclusion set to a catch-all would hide a real orphan', () => {
+    // Simulates the tempting "exempt anything not currently collected" formulation.
+    const catchAll = { ...AUTH, productTrees: ['tests'] };
+    const hidden = findUnmembered({ collected: ['tests/unit/a.test.js'], tracked, authorities: catchAll });
+    const real = findUnmembered({ collected: ['tests/unit/a.test.js'], tracked, authorities: AUTH });
+    expect(hidden).toEqual([]);      // the catch-all reports clean...
+    expect(real).toEqual(['tests/unit/b.test.js']); // ...while the honest set still sees the orphan
+  });
+});
+
+describe('splitAdvisory — the waiver is PATTERN-scoped, not a snapshot of what happens to fail', () => {
+  it('waives the gated-db class', () => {
+    const { waived, blocking } = splitAdvisory(['tests/database/x.test.js', 'lib/y.db.test.js']);
+    expect(waived).toHaveLength(2);
+    expect(blocking).toEqual([]);
+  });
+
+  it('BLOCKS anything outside that class — a NEW orphan fails on day one', () => {
+    const { waived, blocking } = splitAdvisory(['tests/unit/brand-new-orphan.test.js']);
+    expect(waived).toEqual([]);
+    expect(blocking).toEqual(['tests/unit/brand-new-orphan.test.js']);
+  });
+
+  it('the 12 agents files would NOT have been waived — the advisory split could not have hidden them', () => {
+    // Proves the waiver is scoped by DB_INCLUDE patterns and not by "currently unmembered".
+    // Had it been a snapshot, FR-3's defect would have been absorbed instead of fixed.
+    const { waived, blocking } = splitAdvisory(['tests/unit/agents/agent-registry.test.js']);
+    expect(waived).toEqual([]);
+    expect(blocking).toHaveLength(1);
+  });
+});
+
+describe('LIVE: every tracked test file that should be collected IS collected', () => {
+  // ADVISORY for the gated-db class ONLY, until the sibling data-integrity SD lands the runtime
+  // gate in tests/setup.db.js. That class cannot be repaired here without running 125
+  // non-self-guarding suites against a live database (vitest.config.js:163; coordinator
+  // verified independently). Everything else is BLOCKING from day one.
+  it('no tracked test file outside the waived gated-db class belongs to zero collected projects', () => {
+    const collected = enumerateCollected();
+    const tracked = enumerateTracked();
+    const unmembered = findUnmembered({ collected, tracked, authorities: loadAuthorities() });
+    const { waived, blocking } = splitAdvisory(unmembered);
+
+    if (waived.length > 0) {
+      // Reported every run so the debt stays visible instead of decaying into background noise.
+      console.warn(
+        `[vitest-membership] ADVISORY: ${waived.length} gated-db test file(s) are members of zero ` +
+        'collected projects and never run. Not blocked here — repairing this requires a runtime ' +
+        'gate in tests/setup.db.js (sibling data-integrity SD). Promote this guard to blocking ' +
+        'when that lands.'
+      );
+    }
+    if (blocking.length > 0) {
+      throw new Error(
+        `${blocking.length} tracked test file(s) belong to ZERO collected vitest projects — ` +
+        `they never run and the suite still reports green:\n  ${blocking.slice(0, 40).join('\n  ')}` +
+        (blocking.length > 40 ? `\n  …and ${blocking.length - 40} more` : '')
+      );
+    }
+    expect(blocking).toEqual([]);
+  }, 900000);
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -75,7 +75,16 @@ const SHARED_EXCLUDE = [
   '**/node_modules/**',
   '**/applications/**',
   '**/press-kit/**',
-  '**/agents/**',
+  // SD-LEO-INFRA-FLEET-WIDE-VITEST-001 FR-3. This was '**/agents/**', aimed at the product
+  // source tree — but that glob also matched tests/unit/agents/**, so 12 ordinary unit tests
+  // were members of ZERO collected projects and never ran while the suite reported green.
+  // MEASURED: 12 tracked files under tests/unit/agents/, 0 collected.
+  //
+  // Anchored to the source trees it was actually for. NOT written as an exception list
+  // ("exclude agents EXCEPT tests/unit/agents") — an exception list would grow one entry per
+  // discovery and quietly become the catch-all the membership guard exists to prevent.
+  'lib/agents/**',
+  'scripts/agents/**',
   '**/archive/**',
   // SD-LEO-INFRA-TEST-ESTATE-HYGIENE-001: the unanchored '**/*.test.js' include
   // swept the orphaned legacy test/ root (CI separately --excludes it, so local


### PR DESCRIPTION
A test file that belongs to **zero collected vitest projects** never runs — and the suite still reports GREEN.

## The measurement

Enumerated vitest's **own** collection (`npx vitest list --filesOnly` = 3087 distinct paths) against `git ls-files` (3616 tracked test files). **529 tracked test files belong to no collected project.** It partitions exactly, no double-counting:

| bucket | count | cause |
|---|---|---|
| **db_include** | **229** | stranded by the gated-db config path |
| playwright | 71 | `tests/e2e/**`, owned by `playwright.config.js:47` |
| quarantined | 162 | declared debt register — *exactly* the manifest count, cross-check: quarantined-but-collected = **0** |
| remainder | 67 | UAT specs, node:test `.mjs`/`.cjs`, named excludes — **and 12 ordinary unit tests nothing collected** |

`vitest.config.js:126` records this same class previously stranding `tests/smoke.test.js` and breaking every commit in the repo for days. This is a recurrence, not a hypothesis.

## FR-1 — the guard, and why it isn't blind

Population comes from **vitest's own enumeration, never a repo glob**. A glob measures what the config *intends* to collect; the gap between intent and reality *is* this defect. AC-3 pins it with a source-swap fixture that flips the verdict.

An **empty enumeration throws** rather than passing — a failed enumeration is an error, not a clean bill.

The exclusion set is **five named, closed categories**, each derived from an authority rather than hand-listed. Emphatically *not* "minus everything currently uncollected": that formulation would have absorbed the 12 files below, and the guard's first act would have been to hide a defect it detected. A **narrowness control** reds if it's ever widened to a catch-all.

## FR-3 — the second defect, found by measuring

`SHARED_EXCLUDE` carried `'**/agents/**'`, aimed at the `lib/agents` source tree — but it also swallowed the `tests/unit/agents` tree. **12 unit tests, zero collected.** Narrowed to the trees it was actually for.

Deliberately **not** written as an exception list ("exclude agents EXCEPT tests/unit/agents") — an exception list grows one entry per discovery and becomes the same catch-all. Verified **both directions**: 12 now collected, `lib/agents` still 0.

## FR-2 is deliberately absent

The obvious fix — ungating db discovery — is the pattern the config itself calls correct for smoke. But `tests/setup.db.js` **does not gate at runtime**: it passes a real `SUPABASE_URL` through via `||=`, and `vitest.config.js:163` states **125 of 225 db suites do not self-guard**. Ungating discovery would run them against whatever the URL points at.

The coordinator verified that independently and split the runtime gate to a **sibling data-integrity SD**. So FR-1 ships **ADVISORY for the gated-db class only** — waived by *pattern*, never by a snapshot of what happens to fail, so a **new orphan outside that class is a hard failure on day one**. Promote to blocking when the sibling lands.

> The fix that would have made my own guard green fastest is the one with the data-loss arm. That's exactly when to stop and ask.

## The guard's first catch

Of the 12 files FR-3 surfaced, **10 pass and 2 were red all along** — invisible because nothing collected them:

- `venture-state-machine-jit-check.test.js` — 4 tests, `stateMachine._approveHandoff is not a function`. The implementation moved on while the test could not fail.
- `agent-registry.test.js` — `TypeError: fetch failed`, a live network call inside a unit test.

Both **registered in the declared quarantine manifest** with real error signatures and a linked feedback row — **not re-excluded**. Re-exclusion would return them to invisibility, which is the defect this SD is about. Fixing the underlying drift is out of scope.

## Verification

- Guard **RED on 241** against the broken config = 229 + 12, **independently confirming a partition computed earlier by a different method**
- After FR-3: collected 3088 → **3100** (+12 exactly), `lib/agents` still 0, guard 241 → **229**
- **7/7 mutations reddened a named test**, including **M6 which reverts FR-3 and reds the LIVE arm** — the guard genuinely detects that defect rather than passing its own fixtures
- **Full unit project: 3082 files / 37681 tests, 0 failures**

## Known gaps

229 files remain stranded (FR-2, sibling SD). **A live data-loss hole exists today**: 125 unguarded db suites + a real URL passed through — found here, not fixed here. 2 tests quarantined, not fixed. **The advisory waiver must be removed when the sibling lands**, or it decays into the permanent exemption this guard exists to prevent.

SD: SD-LEO-INFRA-FLEET-WIDE-VITEST-001 · LEAD-TO-PLAN 94 · PLAN-TO-EXEC 94

🤖 Generated with [Claude Code](https://claude.com/claude-code)
