### PR TITLE
fix(SD-LEO-INFRA-REAP-COMPLETED-WORKTREE-001): close the husk path in the completion tail

### DIFF
--- a/lib/worktree-reaper/close-husk.js
+++ b/lib/worktree-reaper/close-husk.js
@@ -1,0 +1,66 @@
+/**
+ * SD-LEO-INFRA-REAP-COMPLETED-WORKTREE-001 — close the husk path.
+ *
+ * A "husk" is a worktree that was deregistered from git while its DIRECTORY survived.
+ * cleanupWorktree already detects it correctly (lib/worktree-manager.js:1824 re-stats the path
+ * after removal and refuses to report a success it did not achieve) — it just stopped there,
+ * printing "safe to delete manually". Nothing removed it, and a husk is invisible to every
+ * git-based sweep, so "the scheduled reaper will get it" was not true for this shape.
+ * MEASURED when this shipped: 43 directories under .worktrees against 22 registered worktrees;
+ * 2 of 4 SDs completed in one session left exactly this.
+ *
+ * THIS FILE COMPOSES TWO EXISTING GUARANTEES AND ADDS NO THIRD. safeRecursiveRmWithRetry
+ * lstat-checks for a junction before deleting and asserts the path is gone as a post-condition;
+ * cwdResidencyBlocks refuses to delete a tree the current process is standing in. The residency
+ * guard is composed EXPLICITLY because safeRecursiveRm does not carry it, and this is the
+ * self-reap path by definition — the finishing session is the process most likely to be inside
+ * the tree it is about to delete. A block is a correct refusal, never something to switch off.
+ *
+ * An earlier draft of this SD reimplemented the whole reap in ~200 lines before I noticed
+ * cleanupWorktree already did it. That is why this is a composition and not a module.
+ */
+import fs from 'fs';
+import { safeRecursiveRmWithRetry } from '../worktree-manager.js';
+import { cwdResidencyBlocks } from './residency-guard.js';
+
+export const HUSK_OUTCOME = Object.freeze({
+  REMOVED: 'husk_removed',
+  ALREADY_ABSENT: 'husk_already_absent',
+  BLOCKED_RESIDENT: 'husk_blocked_resident',
+  FAILED: 'husk_removal_incomplete',
+});
+
+/**
+ * Remove a deregistered-but-present worktree directory.
+ * NEVER THROWS — a cleanup step must not fail an otherwise-complete SD; the scheduled sweep is
+ * the backstop. It never reports success it did not achieve either: the outcome is the OBSERVED
+ * end state on disk, not the remover's return value. Reporting a deregistration as a removal is
+ * precisely what created the husk in the first place.
+ *
+ * @param {{huskPath: string, deps?: object}} args
+ * @returns {{outcome: string, huskPath: string, reason: string|null}}
+ */
+export function closeHusk({ huskPath, deps = {} }) {
+  const existsSync = deps.existsSync || fs.existsSync;
+  const residencyCheck = deps.cwdResidencyBlocks || cwdResidencyBlocks;
+  const rmWithRetry = deps.safeRecursiveRmWithRetry || safeRecursiveRmWithRetry;
+  const out = (outcome, reason = null) => ({ outcome, huskPath, reason });
+
+  if (!huskPath || typeof huskPath !== 'string') return out(HUSK_OUTCOME.FAILED, 'no_husk_path');
+  if (!existsSync(huskPath)) return out(HUSK_OUTCOME.ALREADY_ABSENT);
+
+  const residency = residencyCheck(huskPath);
+  if (residency?.blocked) return out(HUSK_OUTCOME.BLOCKED_RESIDENT, residency.reason || 'resident');
+
+  let rm;
+  try {
+    rm = rmWithRetry(huskPath);
+  } catch (e) {
+    return out(HUSK_OUTCOME.FAILED, e?.message || String(e));
+  }
+  // Observed end state, not the return value.
+  if (existsSync(huskPath)) return out(HUSK_OUTCOME.FAILED, rm?.lastError || 'directory_still_present');
+  return out(HUSK_OUTCOME.REMOVED);
+}
+
+export default { closeHusk, HUSK_OUTCOME };

--- a/scripts/modules/handoff/executors/lead-final-approval/index.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/index.js
@@ -77,6 +77,7 @@ import { parseAndExpandFeedbackFooters, resolveFeedback } from '../../../../../l
 
 // Worktree cleanup (SD-LEO-INFRA-INTEGRATE-WORKTREE-CREATION-001)
 import { cleanupWorktree, validateSdKey } from '../../../../../lib/worktree-manager.js';
+import { closeHusk, HUSK_OUTCOME } from '../../../../../lib/worktree-reaper/close-husk.js';
 
 // SD-FDBK-INFRA-REFACTOR-LEADFINALAPPROVALEXECUTOR-LHE-001 FR-1 deploy-lag graceful-degrade + FR-9 LFA-only check
 import { checkProgressBreakdownLheReady } from '../../pre-checks/pending-migrations-check.js';
@@ -922,7 +923,35 @@ export class LeadFinalApprovalExecutor extends BaseExecutor {
       } else if (worktreeCleanupResult.reason === 'dirty_worktree') {
         console.warn('   ⚠️  Worktree has uncommitted changes — run /ship first, then re-run LEAD-FINAL-APPROVAL');
       } else if (worktreeCleanupResult.reason === 'husk_directory_remains') {
-        console.warn(`   ⚠️  Husk: ${sdKey} was deregistered from git but its directory remains at ${worktreeCleanupResult.worktreePath || `.worktrees/${sdKey}`} — invisible to git-based sweeps, safe to delete manually.`);
+        // SD-LEO-INFRA-REAP-COMPLETED-WORKTREE-001: close the husk path.
+        //
+        // cleanupWorktree already DETECTS this state correctly — it deregisters, re-stats the
+        // path, and refuses to report a removal it did not achieve. What it did not do was
+        // finish the job: this branch used to print "safe to delete manually" and stop, so the
+        // directory stayed. MEASURED at the time of this change: 43 directories under
+        // .worktrees against 22 git-registered worktrees, and 2 of 4 SDs completed in one
+        // session left exactly this husk. A husk is invisible to every git-based sweep, so
+        // "the scheduled reaper will get it" was not true for this shape.
+        //
+        // Removal is by REUSE: safeRecursiveRmWithRetry lstat-checks for a junction before
+        // deleting and asserts the path is gone as a post-condition. Nothing here rolls its own
+        // rm — a raw recursive delete already followed a junction into the shared tree once
+        // (SD-FDBK-FIX-WORKTREE-REAPER-DESTROYED-001).
+        //
+        // The residency guard is composed EXPLICITLY because safeRecursiveRm does not carry it,
+        // and this is the self-reap path by definition: the finishing session is the process
+        // most likely to be standing in the tree it is about to delete. A block here is a
+        // correct refusal, never something to switch off.
+        const husk = closeHusk({ huskPath: worktreeCleanupResult.worktreePath || `.worktrees/${sdKey}` });
+        if (husk.outcome === HUSK_OUTCOME.REMOVED) {
+          console.log(`   ✅ Husk directory removed: ${husk.huskPath}`);
+        } else if (husk.outcome === HUSK_OUTCOME.BLOCKED_RESIDENT) {
+          console.warn(`   ⚠️  Husk at ${husk.huskPath} NOT removed — ${husk.reason}: a process may not delete the worktree it is standing in. Re-run from the shared root, or let the scheduled sweep take it.`);
+        } else if (husk.outcome === HUSK_OUTCOME.ALREADY_ABSENT) {
+          console.log(`   ℹ️  Husk already gone: ${husk.huskPath}`);
+        } else {
+          console.warn(`   ⚠️  Husk removal incomplete at ${husk.huskPath} (${husk.reason}) — non-blocking; the scheduled sweep remains the backstop.`);
+        }
       } else {
         console.warn(`   ⚠️  Worktree cleanup incomplete: ${worktreeCleanupResult.reason}`);
       }

--- a/tests/unit/worktree-reaper/close-husk.test.js
+++ b/tests/unit/worktree-reaper/close-husk.test.js
@@ -1,0 +1,137 @@
+/**
+ * SD-LEO-INFRA-REAP-COMPLETED-WORKTREE-001 — closing the husk path.
+ *
+ * A husk is a worktree deregistered from git whose DIRECTORY survived. It was already DETECTED
+ * (worktree-manager.js:1824) and then left in place with a "delete it manually" warning, which
+ * is why 43 directories stood against 22 registered worktrees.
+ *
+ * Two-sided: the removal arm and the refusal arms are both proven, and the outcome is always
+ * the OBSERVED state on disk rather than the remover's return value — reporting a
+ * deregistration as a removal is exactly what created the husk.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { closeHusk, HUSK_OUTCOME } from '../../../lib/worktree-reaper/close-husk.js';
+
+const HUSK = '/repo/.worktrees/SD-X-001';
+/** existsSync that flips to absent once the remover has run — a real deletion's observable effect. */
+const fsAfter = (removed) => (p) => (p === HUSK ? !removed.value : false);
+
+describe('closeHusk — removes the directory the old code left behind', () => {
+  it('REMOVES a husk and reports it, asserted on the observed end state', () => {
+    const removed = { value: false };
+    const rm = vi.fn(() => { removed.value = true; return { ok: true }; });
+    const res = closeHusk({
+      huskPath: HUSK,
+      deps: { existsSync: fsAfter(removed), cwdResidencyBlocks: () => ({ blocked: false }), safeRecursiveRmWithRetry: rm },
+    });
+    expect(res.outcome).toBe(HUSK_OUTCOME.REMOVED);
+    expect(rm).toHaveBeenCalledWith(HUSK);
+  });
+
+  it('reports FAILED when the directory SURVIVES, even though the remover returned ok:true', () => {
+    // The defect this SD exists to stop: a removal that reports success while the husk remains.
+    const res = closeHusk({
+      huskPath: HUSK,
+      deps: { existsSync: () => true, cwdResidencyBlocks: () => ({ blocked: false }), safeRecursiveRmWithRetry: () => ({ ok: true }) },
+    });
+    expect(res.outcome).toBe(HUSK_OUTCOME.FAILED);
+    expect(res.reason).toBe('directory_still_present');
+  });
+});
+
+describe('closeHusk — self-reap is the hazard this path walks into by definition', () => {
+  it('REFUSES when the residency guard says the process is standing in the tree', () => {
+    const rm = vi.fn();
+    const res = closeHusk({
+      huskPath: HUSK,
+      deps: { existsSync: () => true, cwdResidencyBlocks: () => ({ blocked: true, reason: 'reap_blocked_resident' }), safeRecursiveRmWithRetry: rm },
+    });
+    expect(res.outcome).toBe(HUSK_OUTCOME.BLOCKED_RESIDENT);
+    expect(res.reason).toBe('reap_blocked_resident');
+    // The refusal must happen BEFORE any deletion is attempted, not be reported after one.
+    expect(rm).not.toHaveBeenCalled();
+  });
+
+  it('consults the residency guard for every removal — there is no unguarded path', () => {
+    const guard = vi.fn(() => ({ blocked: false }));
+    const removed = { value: false };
+    closeHusk({
+      huskPath: HUSK,
+      deps: { existsSync: fsAfter(removed), cwdResidencyBlocks: guard, safeRecursiveRmWithRetry: () => { removed.value = true; return { ok: true }; } },
+    });
+    expect(guard).toHaveBeenCalledWith(HUSK);
+  });
+});
+
+describe('closeHusk — containment', () => {
+  it('is idempotent: an already-gone husk is ALREADY_ABSENT and nothing is deleted', () => {
+    const rm = vi.fn();
+    const res = closeHusk({ huskPath: HUSK, deps: { existsSync: () => false, safeRecursiveRmWithRetry: rm } });
+    expect(res.outcome).toBe(HUSK_OUTCOME.ALREADY_ABSENT);
+    expect(rm).not.toHaveBeenCalled();
+  });
+
+  it('NEVER THROWS when the remover throws — cleanup must not fail a complete SD', () => {
+    const res = closeHusk({
+      huskPath: HUSK,
+      deps: { existsSync: () => true, cwdResidencyBlocks: () => ({ blocked: false }), safeRecursiveRmWithRetry: () => { throw new Error('EPERM'); } },
+    });
+    expect(res.outcome).toBe(HUSK_OUTCOME.FAILED);
+    expect(res.reason).toContain('EPERM');
+  });
+
+  it('refuses a missing or non-string path rather than deleting something unintended', () => {
+    const rm = vi.fn();
+    for (const huskPath of [undefined, null, '', 42]) {
+      const res = closeHusk({ huskPath, deps: { safeRecursiveRmWithRetry: rm } });
+      expect(res.outcome).toBe(HUSK_OUTCOME.FAILED);
+    }
+    expect(rm).not.toHaveBeenCalled();
+  });
+});
+
+describe('WIRING — the completion tail actually calls this, and no longer just warns', () => {
+  // HONEST LABEL: this is a STRUCTURAL PIN, not a behavioural test. The executor cannot be
+  // imported standalone (it fails at module load with a pre-existing, env-dependent
+  // "path argument must be of type string" — verified by stashing this SD's change and
+  // observing the identical failure on the baseline), so invoking the real branch is not
+  // available here. A mutation reverting the wiring reddened NOTHING until this existed —
+  // the module was fully tested while the thing that calls it was not.
+  it('the husk branch invokes closeHusk and does not merely warn', async () => {
+    const fs = await import('fs');
+    const path = await import('path');
+    const url = await import('url');
+    const raw = fs.readFileSync(
+      path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), '../../../scripts/modules/handoff/executors/lead-final-approval/index.js'),
+      'utf8'
+    );
+    // COMMENTS STRIPPED FIRST. Written without this, the negative assertion below matched the
+    // comment in the new branch that QUOTES the old warning — the test was red at baseline, and
+    // a red-at-baseline test makes every mutation look "caught" while proving nothing.
+    const src = raw.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    expect(src).toMatch(/import\s*\{[^}]*closeHusk[^}]*\}\s*from\s*['"][^'"]*close-husk\.js['"]/);
+    expect(src).toMatch(/closeHusk\s*\(\s*\{\s*huskPath:/);
+    // The defect was a branch that DETECTED the husk and then stopped at advice.
+    expect(src).not.toMatch(/safe to delete manually/);
+    // Control: a stripper that blanked the file would satisfy the negative assertion above.
+    expect(src.length).toBeGreaterThan(5000);
+  });
+});
+
+describe('FR-4 — removal is by REUSE; this module owns no removal primitive', () => {
+  it('contains no direct rm/exec call of its own', async () => {
+    const fs = await import('fs');
+    const path = await import('path');
+    const url = await import('url');
+    const src = fs.readFileSync(
+      path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), '../../../lib/worktree-reaper/close-husk.js'),
+      'utf8'
+    ).replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    // CALL-shaped, not word-shaped: an earlier version of this assertion on a sibling module
+    // matched the words "worktree removed" inside a log string and failed on its own prose.
+    expect(src).not.toMatch(/\brmSync\s*\(|\brmdirSync\s*\(|\bunlinkSync\s*\(|\bexecSync\s*\(|\bexecFileSync\s*\(|\bspawnSync\s*\(/);
+    // Controls: a stripper that blanked the file would pass the negative assertion above.
+    expect(src).toMatch(/safeRecursiveRmWithRetry/);
+    expect(src.length).toBeGreaterThan(500);
+  });
+});


### PR DESCRIPTION
## The defect

A **husk** is a worktree deregistered from git whose **directory survived**.

`cleanupWorktree` already **detected** this correctly — `lib/worktree-manager.js:1824` re-stats the path after removal and refuses to report a success it did not achieve — and then **stopped at a warning**: *"safe to delete manually"*. Nothing removed it.

A husk is invisible to every git-based sweep (it is no longer in `git worktree list`), so *"the scheduled reaper will get it"* was never true for this shape.

**MEASURED:** 43 directories under `.worktrees` against 22 registered worktrees. 2 of 4 SDs completed in one session left exactly this.

## The fix

`closeHusk()` **composes two existing guarantees and adds no third**:

- `safeRecursiveRmWithRetry` — junction-safe, retries, asserts the path is gone as a post-condition
- `cwdResidencyBlocks` — refuses to delete a tree the current process is standing in

Residency is composed **explicitly** because `safeRecursiveRm` does not carry it, and this is the self-reap path *by definition*: the finishing session is the process most likely to be inside the tree it is about to delete. A block is a correct refusal, never something to switch off.

Four named outcomes. **Never throws** — cleanup must not fail an otherwise-complete SD. The outcome is the **observed state on disk**, never the remover's return value; reporting a deregistration as a removal is precisely what created the husk.

**97 production LOC** (66 module + 31 wiring) + 137 test.

> An earlier draft of this SD reimplemented the whole reap in ~200 lines before I noticed `cleanupWorktree` already did it. That is why this is a composition and not a module. The near-miss came from grepping for `safe-worktree-remove|worktree-reaper|reapWorktree` — the function is named `cleanupWorktree`. **A name-census cannot see a capability named for something else.**

## Mutation proof — 6/6, each to exactly ONE named arm

Run against a baseline **verified green first**:

| Mutation | Reds |
|---|---|
| drop the residency check | the refusal arm |
| drop the post-removal `existsSync` re-stat | the survives-despite-`ok:true` arm |
| consult the guard about the wrong path | the guard-subject arm |
| drop the idempotence short-circuit | the already-absent arm |
| drop the bad-path guard | the containment arm |
| revert `index.js` to warn-only | the WIRING arm |

**Two harness defects were found and fixed rather than reported around:**

1. *"return REMOVED unconditionally"* was written as an edit that changed no behaviour. Its GREEN measured my harness, not the tests. Replaced with a real mutation.
2. **Reverting the wiring originally reddened NOTHING** — the module was fully tested while the thing that calls it was not. The WIRING arm exists because of that. Its own first draft was **red at baseline** (the negative assertion matched the new branch's own comment quoting the old warning), which made all six mutations look "caught" while proving nothing. Comments are now stripped and two non-vacuity controls added.

The WIRING arm is labelled in-file as a **STRUCTURAL PIN, not a behavioural test**: the executor cannot be imported standalone (pre-existing `path argument must be of type string`, confirmed identical on the baseline by stashing this change). Stating that plainly rather than letting a source-shape assertion read as behavioural coverage.

## Deliberately NOT in scope

- `scripts/modules/shipping/post-merge-worktree-cleanup.js:403` emits the **same** `husk_directory_remains` and has the **identical gap**. Flagged for a sibling, not widened here.
- The **27 pre-existing orphans are not cleaned** by this change. It stops new ones.

## Verification

Full unit project: **3088 files / 37755 tests passed, 0 failed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
