### PR TITLE
fix(SD-LEO-INFRA-RETRO-INTEGRITY-RUN-001): guard the retro sub-agent door + reconcile quality_score to diagnostic-only

### DIFF
--- a/lib/sub-agents/retro/db-operations.js
+++ b/lib/sub-agents/retro/db-operations.js
@@ -178,6 +178,36 @@ export async function storeRetrospective(supabase, retrospective) {
  */
 export async function enhanceRetrospective(supabase, existingId, newRetro, existing, semanticDeduplicateArray) {
   try {
+    // SD-LEO-INFRA-RETRO-INTEGRITY-RUN-001 FR-1 — CONSULT THE EXISTING CLOBBER GUARD.
+    //
+    // scripts/modules/handoff/lib/retro-clobber-guard.js was consulted at SEVEN call sites and
+    // every one of them was a HANDOFF door (exec-to-plan, lead-to-plan, plan-to-exec,
+    // plan-to-lead/state-transitions, orchestrator-completion-guardian x2, retrospective-enricher).
+    // THIS PATH — the RETRO sub-agent's own write — never asked, so a guard installed to stop
+    // retrospective content being overwritten did not cover the writer most likely to overwrite it:
+    // running `execute-subagent.js --code RETRO` against a finished, hand-authored retrospective.
+    // A correction that lands on one access path leaves the others serving the old behaviour.
+    //
+    // The guard's POLICY is already correct and is reused UNCHANGED rather than reimplemented —
+    // a second copy of the thresholds would drift from the seven existing callers. It permits the
+    // write only for `auto_thin` (auto-generated AND sparse) and refuses published_sd_completion,
+    // manual_retro, manual_retro_null_inferred and rich_existing_content.
+    const sdIdForGuard = existing?.sd_id || newRetro?.sd_id;
+    if (sdIdForGuard) {
+      const { isSafeToWriteRetro } = await import(
+        '../../../scripts/modules/handoff/lib/retro-clobber-guard.js'
+      );
+      const guard = await isSafeToWriteRetro(supabase, sdIdForGuard);
+      if (!guard.safe) {
+        console.warn(
+          `   ⛔ [ENFORCE] skipped retro enhancement for sdId=${sdIdForGuard} reason=${guard.reason}`
+        );
+        // Reported as a refusal, not a failure: nothing went wrong, a protected record was left
+        // alone. A caller that saw only `success:false` could not tell those apart.
+        return { success: true, id: existingId, skipped: true, reason: guard.reason };
+      }
+    }
+
     console.log('   📊 Applying semantic deduplication to retrospective arrays...');
 
     const MAX_KEY_LEARNINGS = 25;
@@ -220,7 +250,16 @@ export async function enhanceRetrospective(supabase, existingId, newRetro, exist
 
     const enhanced = {
       status: 'PUBLISHED',
-      quality_score: Math.max(newRetro.quality_score, existing.quality_score || 0),
+      // SD-LEO-INFRA-RETRO-INTEGRITY-RUN-001 FR-2 — quality_score is DELIBERATELY NOT SET HERE.
+      //
+      // It previously read `Math.max(newRetro.quality_score, existing.quality_score || 0)`, which
+      // was fabrication on two counts: the caller cannot know the score (the DB trigger computes
+      // it), and taking the MAX makes the value ratchet upward — a record whose content got worse
+      // kept the better number. The trigger overwrites any supplied value anyway
+      // (tests/integration/retro-trigger-draft-insert.test.js:45,65 documents that a pre-set value
+      // is transient), so supplying one only creates a window where the stored number is a claim
+      // nobody measured. Omitting the key lets the score be solely what the evaluation produced —
+      // which is what a DIAGNOSTIC gauge is supposed to be.
       title: `${newRetro.title}`,
       description: `${newRetro.description}\n\n[Original lesson captured during EXEC: ${existing.title}]`,
       key_learnings: mergedKeyLearnings,

--- a/lib/sub-agents/retro/enhance-clobber-guard.test.js
+++ b/lib/sub-agents/retro/enhance-clobber-guard.test.js
@@ -1,0 +1,157 @@
+/**
+ * SD-LEO-INFRA-RETRO-INTEGRITY-RUN-001 FR-1 + FR-2.
+ *
+ * The RETRO sub-agent's own write path never consulted the clobber guard. The guard had SEVEN
+ * consult sites and every one was a HANDOFF door, so the writer most likely to overwrite a
+ * finished retrospective — `execute-subagent.js --code RETRO` — was the one that never asked.
+ *
+ * These tests drive the REAL guard through a fake supabase rather than mocking the guard module.
+ * A mocked guard would prove enhanceRetrospective calls *something*; driving the real one proves
+ * the two are actually connected, which is the property that was missing.
+ */
+import { describe, it, expect } from 'vitest';
+import { enhanceRetrospective } from './db-operations.js';
+
+const SD_ID = '22eae8e5-cac5-4f65-bd0a-aae1fba6543f';
+
+/** Long entries so the guard's richness test (>=3 entries, avg len > 100) fires. */
+const RICH_LEARNINGS = [
+  { learning: 'A field name is a claim and the implementation is usually cheaper than the name, so read what a column CONTAINS before trusting what it is called.' },
+  { learning: 'Only an executed test pins the data flow; a regex over source pins a statement form and will happily pass against a dead-coded call site.' },
+  { learning: 'A correction that lands on one access path leaves every other path serving the old behaviour, which is why a guard on six doors is not a guard on the seventh.' },
+];
+const THIN_LEARNINGS = [{ learning: 'went well' }];
+
+/**
+ * Fake supabase. The guard SELECTs the newest retrospective for the sd_id; enhance then UPDATEs.
+ * Captures the update payload so assertions can be made on WHAT WAS WRITTEN, never on a log line.
+ */
+function fakeSupabase(guardRow) {
+  const updates = [];
+  return {
+    updates,
+    from() {
+      const b = {
+        select: () => b,
+        eq: () => b,
+        order: () => b,
+        limit: () => b,
+        maybeSingle: async () => ({ data: guardRow, error: null }),
+        single: async () => ({ data: { id: 'r-1' }, error: null }),
+        update: (payload) => {
+          updates.push(payload);
+          return b;
+        },
+      };
+      return b;
+    },
+  };
+}
+
+const newRetro = {
+  sd_id: SD_ID,
+  title: 'Completion retro',
+  description: 'desc',
+  quality_score: 95,
+  key_learnings: [{ learning: 'a new learning that is reasonably long so dedup has something to chew on' }],
+  what_went_well: [], what_needs_improvement: [], action_items: [],
+  success_patterns: [], failure_patterns: [], protocol_improvements: [],
+  conducted_date: '2026-08-09', objectives_met: true,
+};
+const dedupe = (a, b) => [...(a || []), ...(b || [])];
+
+describe('FR-1: the RETRO sub-agent door now consults the clobber guard', () => {
+  // REFUSE — the case that silently overwrote a finished retrospective before this change.
+  it('REFUSES to overwrite a PUBLISHED SD_COMPLETION retrospective, and writes NOTHING', async () => {
+    const existing = {
+      id: 'r-1', sd_id: SD_ID, status: 'PUBLISHED', retro_type: 'SD_COMPLETION',
+      generated_by: null, key_learnings: RICH_LEARNINGS, quality_score: 100,
+      what_went_well: [], what_needs_improvement: [], action_items: [],
+    };
+    const sb = fakeSupabase(existing);
+
+    const res = await enhanceRetrospective(sb, 'r-1', newRetro, existing, dedupe);
+
+    expect(res.skipped).toBe(true);
+    expect(res.reason).toBe('published_sd_completion');
+    // THE ASSERTION THAT MATTERS: no write occurred at all.
+    expect(sb.updates).toHaveLength(0);
+  });
+
+  it('REFUSES a rich manually-authored retrospective (generated_by null + rich content)', async () => {
+    const existing = {
+      id: 'r-1', sd_id: SD_ID, status: 'DRAFT', retro_type: null,
+      generated_by: null, key_learnings: RICH_LEARNINGS,
+      what_went_well: [], what_needs_improvement: [], action_items: [],
+    };
+    const sb = fakeSupabase(existing);
+
+    const res = await enhanceRetrospective(sb, 'r-1', newRetro, existing, dedupe);
+
+    expect(res.skipped).toBe(true);
+    expect(res.reason).toBe('manual_retro_null_inferred');
+    expect(sb.updates).toHaveLength(0);
+  });
+
+  // ACCEPT — proves the consult tightened the door rather than sealing it.
+  it('ENRICHES an auto_thin retrospective — the accept half', async () => {
+    const existing = {
+      id: 'r-1', sd_id: SD_ID, status: 'DRAFT', retro_type: null,
+      generated_by: 'SUB_AGENT', key_learnings: THIN_LEARNINGS,
+      what_went_well: [], what_needs_improvement: [], action_items: [],
+    };
+    const sb = fakeSupabase(existing);
+
+    const res = await enhanceRetrospective(sb, 'r-1', newRetro, existing, dedupe);
+
+    expect(res.skipped).toBeUndefined();
+    expect(sb.updates).toHaveLength(1);
+    expect(sb.updates[0].status).toBe('PUBLISHED');
+  });
+
+  it('reports a refusal as SUCCESS-with-skipped, not as a failure', async () => {
+    // Nothing went wrong when a protected record is left alone. A caller seeing only
+    // success:false could not distinguish "refused to clobber" from "the write broke".
+    const existing = {
+      id: 'r-1', sd_id: SD_ID, status: 'PUBLISHED', retro_type: 'SD_COMPLETION',
+      generated_by: null, key_learnings: RICH_LEARNINGS,
+      what_went_well: [], what_needs_improvement: [], action_items: [],
+    };
+    const res = await enhanceRetrospective(fakeSupabase(existing), 'r-1', newRetro, existing, dedupe);
+    expect(res.success).toBe(true);
+    expect(res.skipped).toBe(true);
+  });
+});
+
+describe('FR-2: the enhance write no longer fabricates a quality score', () => {
+  it('omits quality_score from the update payload entirely', async () => {
+    const existing = {
+      id: 'r-1', sd_id: SD_ID, status: 'DRAFT', retro_type: null,
+      generated_by: 'SUB_AGENT', key_learnings: THIN_LEARNINGS, quality_score: 40,
+      what_went_well: [], what_needs_improvement: [], action_items: [],
+    };
+    const sb = fakeSupabase(existing);
+
+    await enhanceRetrospective(sb, 'r-1', newRetro, existing, dedupe);
+
+    expect(sb.updates).toHaveLength(1);
+    // The caller cannot know the score — the DB trigger computes it. Supplying one created a
+    // window where the stored number was a claim nobody measured.
+    expect(sb.updates[0]).not.toHaveProperty('quality_score');
+  });
+
+  it('does not ratchet the score upward from the existing row', async () => {
+    // The old expression took Math.max(new, existing), so a record whose content got WORSE kept
+    // the better number. Asserted by giving the existing row the higher score.
+    const existing = {
+      id: 'r-1', sd_id: SD_ID, status: 'DRAFT', retro_type: null,
+      generated_by: 'SUB_AGENT', key_learnings: THIN_LEARNINGS, quality_score: 100,
+      what_went_well: [], what_needs_improvement: [], action_items: [],
+    };
+    const sb = fakeSupabase(existing);
+
+    await enhanceRetrospective(sb, 'r-1', { ...newRetro, quality_score: 10 }, existing, dedupe);
+
+    expect(JSON.stringify(sb.updates[0])).not.toContain('quality_score');
+  });
+});

--- a/lib/sub-agents/retro/index.js
+++ b/lib/sub-agents/retro/index.js
@@ -280,9 +280,18 @@ export async function execute(sdId, subAgent, options = {}) {
       }
 
       if (stored.success) {
-        const action = needsEnhancement ? 'enhanced' : 'stored';
+        // SD-LEO-INFRA-RETRO-INTEGRITY-RUN-001 FR-1 — report what ACTUALLY happened.
+        // enhanceRetrospective now returns { success: true, skipped: true, reason } when the
+        // clobber guard refuses to overwrite protected content. Reporting that as "enhanced"
+        // would be a message asserting something that did not occur — the exact class of defect
+        // this SD exists to remove, so the caller must not launder a refusal into a success verb.
+        const action = stored.skipped
+          ? `left unchanged (clobber guard: ${stored.reason})`
+          : (needsEnhancement ? 'enhanced' : 'stored');
         console.log(`   ✅ Retrospective ${action}: ${stored.id}`);
         results.findings.retrospective.id = stored.id;
+        results.findings.retrospective.write_skipped = stored.skipped === true;
+        if (stored.skipped) results.findings.retrospective.skip_reason = stored.reason;
         results.recommendations.push(
           `Retrospective ${action}: ${stored.id}`,
           'Review retrospective for insights',

--- a/scripts/generate-retrospective.js
+++ b/scripts/generate-retrospective.js
@@ -199,10 +199,22 @@ async function generateRetrospective(sdInput) {
     related_prs: [],
     tags: [sd.sd_key, 'automated-retro', 'quality-validated'],
 
-    // WORKAROUND: Set initial quality_score to bypass trigger ordering issue
-    // The auto_populate_retrospective_fields trigger runs before auto_validate_retrospective_quality
-    // and checks quality_score before it's calculated, so we provide a valid default
-    quality_score: 85,
+    // SD-LEO-INFRA-RETRO-INTEGRITY-RUN-001 FR-2 — the `quality_score: 85` pre-set that lived here
+    // is REMOVED, and its stated justification was measured before removal rather than assumed.
+    //
+    // The comment claimed it was needed because auto_populate_retrospective_fields checks
+    // quality_score before auto_validate_retrospective_quality calculates it. MEASURED at
+    // database/migrations/20260505_fix_retrospectives_auto_populate_predicate.sql:75-79: that
+    // check is guarded by `is_status_changing_to_published`, so it does NOT fire on a DRAFT
+    // insert — and this function already inserts as DRAFT (below), reads the calculated score
+    // back, and only promotes to PUBLISHED when it clears 70. The DRAFT-first flow ALREADY
+    // solves the ordering problem the constant was working around; the constant was vestigial.
+    //
+    // It was also actively harmful, which is why removing it belongs in this SD rather than a
+    // tidy-up: a literal 85 is a number nobody measured, and any path where the trigger declines
+    // to recalculate leaves that fabricated 85 standing as the stored score — high enough to
+    // satisfy the >= 70 publish gate on its own. Omitting the key makes the stored score solely
+    // what the evaluation produced.
 
     team_satisfaction: Math.min(10, Math.max(1, Math.floor(sd.progress / 10))),
     business_value_delivered: sd.priority >= 70 ? 'HIGH' : sd.priority >= 40 ? 'MEDIUM' : 'LOW',

--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -443,7 +443,9 @@ export function createRetrospectiveExistsGate(supabase) {
       const sdType = ctx.sd?.sd_type || ctx.sd?.category || 'feature';
 
       if (tier <= 2) {
-        const score = Math.max(retrospective.quality_score || 55, 55);
+        // FR-3: decorative citation removed. `passed: true` below is unconditional for tier<=2,
+        // so this only populated a reported number; report the floor the exemption guarantees.
+        const score = 55;
         console.log(`   ⏭️  SKIP: Tier ${tier} SD — retrospective gate exempt`);
         console.log(`   Score floor: ${score}/100`);
         return {
@@ -465,15 +467,30 @@ export function createRetrospectiveExistsGate(supabase) {
         };
       }
 
-      // Tier 3 SDs: require quality_score >= 60
+      // Tier 3 SDs: require a MEASURED assessment, not the stored diagnostic gauge.
+      //
+      // SD-LEO-INFRA-RETRO-INTEGRITY-RUN-001 FR-3 step 2 — this read
+      // `retrospective.quality_score < minScore`. Like the orchestrator fast-path, it is a REAL
+      // predicate, so deleting the citation would have OPENED the gate rather than reconciled it.
+      // Replaced with the AI-evaluator verdict — a measured signal — which is only safe to depend
+      // on because that evaluator's outage fallback was made FAIL-CLOSED in this same change.
+      // Previously it fell back to this exact gauge plus content presence, so citing it here
+      // would have relocated the fabricated dependency rather than removed it.
       const minScore = 60;
-      if (retrospective.quality_score < minScore) {
+      const { validateSDCompletionReadiness } = await import('../../../sd-quality-validation.js');
+      const assessment = await validateSDCompletionReadiness(ctx.sd, retrospective);
+
+      if (!assessment?.passed || assessment.score < minScore) {
         return {
           passed: false,
-          score: retrospective.quality_score,
+          score: assessment?.score ?? 0,
           max_score: 100,
-          issues: [`Retrospective quality score ${retrospective.quality_score}% is below minimum ${minScore}%`],
-          warnings: []
+          issues: [
+            assessment?.manual_review_required
+              ? 'Retrospective could not be assessed (evaluator unavailable) — MANUAL REVIEW REQUIRED. A gate that cannot run has not passed.'
+              : `Retrospective assessed score ${assessment?.score ?? 0}% is below minimum ${minScore}%`
+          ],
+          warnings: assessment?.warnings || []
         };
       }
 

--- a/scripts/modules/handoff/executors/lead-final-approval/gates/retrospective-exists.test.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates/retrospective-exists.test.js
@@ -7,8 +7,19 @@ vi.mock('../../../../sd-type-checker.js', () => ({
 vi.mock('../../../retro-filters.js', () => ({
   getFilteredRetrospective: vi.fn(),
 }));
+// SD-LEO-INFRA-RETRO-INTEGRITY-RUN-001 FR-3 — CROSS-AUTHOR EDIT, ANNOUNCED.
+// The tier-3 arm no longer gates on retrospectives.quality_score (a diagnostic gauge that a lint
+// rule forbids citing as a threshold, and which this SD measured to be writer-fabricated). It now
+// gates on the MEASURED assessment, so this suite must supply that signal. The FR5 intent is
+// UNCHANGED and both directions are still asserted — a good tier-3 retro passes, a bad one fails;
+// only the signal being trusted has changed. The mock's un-stubbed default is undefined, which
+// makes the gate fail closed — correct, so each test states its precondition explicitly.
+vi.mock('../../../../sd-quality-validation.js', () => ({
+  validateSDCompletionReadiness: vi.fn(),
+}));
 
 import { getFilteredRetrospective } from '../../../retro-filters.js';
+import { validateSDCompletionReadiness } from '../../../../sd-quality-validation.js';
 import { createRetrospectiveExistsGate } from '../gates.js';
 
 /**
@@ -98,7 +109,7 @@ describe('createRetrospectiveExistsGate (LEAD-FINAL-APPROVAL)', () => {
     expect(result.skipped).toBe(true);
   });
 
-  it('passes for tier-3 SDs with quality_score >= 60 (FR5 no-regression check)', async () => {
+  it('passes for tier-3 SDs whose retrospective ASSESSES at >= 60 (FR5 no-regression check)', async () => {
     const { getTierForSD } = await import('../../../../sd-type-checker.js');
     getTierForSD.mockReturnValueOnce(3);
     getFilteredRetrospective.mockResolvedValue({
@@ -106,23 +117,46 @@ describe('createRetrospectiveExistsGate (LEAD-FINAL-APPROVAL)', () => {
       leadToPlanAcceptedAt: '2026-04-01T00:00:00.000Z',
       error: null,
     });
+    // FR-3: the gate now trusts the measured assessment, not the stored gauge.
+    validateSDCompletionReadiness.mockResolvedValue({ passed: true, score: 75, issues: [], warnings: [] });
     const gate = createRetrospectiveExistsGate({});
     const result = await gate.validator(makeCtx());
     expect(result.passed).toBe(true);
     expect(result.score).toBe(75);
   });
 
-  it('fails for tier-3 SDs whose quality_score is below 60', async () => {
+  it('fails for tier-3 SDs whose retrospective ASSESSES below 60', async () => {
     const { getTierForSD } = await import('../../../../sd-type-checker.js');
     getTierForSD.mockReturnValueOnce(3);
     getFilteredRetrospective.mockResolvedValue({
-      retrospective: { id: 'r3', quality_score: 45, status: 'PUBLISHED', retro_type: 'SD_COMPLETION', created_at: '2026-04-20T00:00:00.000Z' },
+      // A HIGH stored gauge that would have passed the old predicate...
+      retrospective: { id: 'r3', quality_score: 95, status: 'PUBLISHED', retro_type: 'SD_COMPLETION', created_at: '2026-04-20T00:00:00.000Z' },
       leadToPlanAcceptedAt: '2026-04-01T00:00:00.000Z',
       error: null,
     });
+    // ...but the MEASURED assessment says no. This is strictly stronger than the original test:
+    // it now proves the fabricated gauge cannot buy a pass.
+    validateSDCompletionReadiness.mockResolvedValue({ passed: false, score: 45, issues: ['thin'], warnings: [] });
     const gate = createRetrospectiveExistsGate({});
     const result = await gate.validator(makeCtx());
     expect(result.passed).toBe(false);
     expect(result.issues[0]).toMatch(/below minimum 60%/);
+  });
+
+  it('FAILS CLOSED when the evaluator cannot run at all (manual review required)', async () => {
+    // Added by FR-3: a gate that cannot run has NOT passed. Previously an evaluator outage
+    // fell back to the stored gauge and could auto-pass.
+    const { getTierForSD } = await import('../../../../sd-type-checker.js');
+    getTierForSD.mockReturnValueOnce(3);
+    getFilteredRetrospective.mockResolvedValue({
+      retrospective: { id: 'r4', quality_score: 100, status: 'PUBLISHED', retro_type: 'SD_COMPLETION', created_at: '2026-04-20T00:00:00.000Z' },
+      leadToPlanAcceptedAt: '2026-04-01T00:00:00.000Z',
+      error: null,
+    });
+    validateSDCompletionReadiness.mockResolvedValue({ passed: false, score: 0, manual_review_required: true, issues: [], warnings: [] });
+    const gate = createRetrospectiveExistsGate({});
+    const result = await gate.validator(makeCtx());
+    expect(result.passed).toBe(false);
+    expect(result.issues[0]).toMatch(/MANUAL REVIEW REQUIRED/);
   });
 });

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.js
@@ -153,24 +153,52 @@ export function createRetrospectiveQualityGate(supabase) {
  */
 async function checkAutoPassConditions(ctx, retrospective, children, allChildrenComplete) {
   // ORCHESTRATOR FAST-PATH
-  if (allChildrenComplete && retrospective?.quality_score >= 60 && retrospective?.status === 'PUBLISHED') {
-    console.log(`   ✅ ORCHESTRATOR AUTO-PASS: All ${children.length} children completed + retrospective exists`);
-    console.log(`      Retrospective quality_score: ${retrospective.quality_score}/100`);
+  //
+  // SD-LEO-INFRA-RETRO-INTEGRITY-RUN-001 FR-3 step 2 — this predicate used to read
+  // `retrospective?.quality_score >= 60`. That cited retrospectives.quality_score as a GATING
+  // THRESHOLD, which scripts/lint/diagnostic-gauge-citation-lint.mjs:50 forbids and which this SD
+  // measured to be writer-fabricated. Unlike the five decorative arms below, this one is a REAL
+  // predicate, so it could not simply be deleted — deleting it would have OPENED the gate (every
+  // orchestrator with a PUBLISHED retro would auto-pass regardless of quality). It is REPLACED
+  // with the AI-evaluator verdict, which is a measured signal rather than a stored artifact.
+  //
+  // Scoped to this arm deliberately: the evaluation is only consulted for orchestrators, so the
+  // other auto-pass arms keep short-circuiting without paying for it. And it is safe to depend on
+  // now only because the evaluator's outage fallback was made FAIL-CLOSED in the same change —
+  // previously it fell back to this very gauge plus content presence, so citing it here would have
+  // moved the fabricated dependency into a catch block instead of removing it.
+  if (allChildrenComplete && retrospective?.status === 'PUBLISHED') {
+    const { validateSDCompletionReadiness: assessOrchestratorRetro } =
+      await import('../../../../sd-quality-validation.js');
+    const orchestratorAssessment = await assessOrchestratorRetro(ctx.sd, retrospective);
+
+    if (!orchestratorAssessment?.passed) {
+      // Not an auto-pass. Fall through to the standard path, which will evaluate and report
+      // properly rather than silently treating "did not qualify" as "failed".
+      console.log('   ↩️  Orchestrator fast-path declined — retrospective did not pass assessment; using standard validation');
+      return null;
+    }
+
+    console.log(`   ✅ ORCHESTRATOR AUTO-PASS: All ${children.length} children completed + retrospective assessed`);
+    console.log(`      Assessed score: ${orchestratorAssessment.score}/100 (measured, not the stored diagnostic gauge)`);
     console.log('      Rationale: Orchestrators coordinate, children produce deliverables');
 
     return {
       passed: true,
-      score: retrospective.quality_score,
+      // FR-3: the MEASURED assessment, not the stored diagnostic gauge.
+      score: orchestratorAssessment.score,
       max_score: 100,
       issues: [],
-      warnings: ['Orchestrator auto-pass: Quality validated via children completion'],
+      warnings: ['Orchestrator auto-pass: Quality validated via children completion + retrospective assessment'],
       details: {
         orchestrator_auto_pass: true,
         child_count: children.length,
         children_completed: children.filter(c => c.status === 'completed').length,
         children: children,
         retrospective_id: retrospective.id,
-        retrospective_quality: retrospective.quality_score
+        assessed_score: orchestratorAssessment.score,
+        // Reported for operator context ONLY — never used to decide the verdict above.
+        observed_diagnostic_quality_score: retrospective.quality_score
       }
     };
   }

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.js
@@ -184,7 +184,13 @@ async function checkAutoPassConditions(ctx, retrospective, children, allChildren
 
     return {
       passed: true,
-      score: Math.max(retrospective.quality_score || 60, 60),
+      // SD-LEO-INFRA-RETRO-INTEGRITY-RUN-001 FR-3 — stopped citing retrospectives.quality_score.
+      // scripts/lint/diagnostic-gauge-citation-lint.mjs:50 declares it a DIAGNOSTIC gauge that no
+      // consumer may cite as a gating threshold, and this SD's own premise is that the value was
+      // fabricated. The citation here was DECORATIVE: `passed: true` above is unconditional, so
+      // Math.max(quality_score || 60, 60) only populated a reported number and never influenced
+      // the decision. Reporting the floor the arm actually guarantees is the honest value.
+      score: 60,
       max_score: 100,
       issues: [],
       warnings: ['Database auto-pass: Validated via migration success + DATABASE sub-agent'],
@@ -205,7 +211,8 @@ async function checkAutoPassConditions(ctx, retrospective, children, allChildren
 
     return {
       passed: true,
-      score: Math.max(retrospective.quality_score || 50, 50),
+      // FR-3: decorative citation removed — see the DATABASE arm above for the full reasoning.
+      score: 50,
       max_score: 100,
       issues: [],
       warnings: [`${sdType} auto-pass: Simple fix validated via git commit evidence`],
@@ -227,7 +234,8 @@ async function checkAutoPassConditions(ctx, retrospective, children, allChildren
 
     return {
       passed: true,
-      score: Math.max(retrospective.quality_score || 55, 55),
+      // FR-3: decorative citation removed — see the DATABASE arm above for the full reasoning.
+      score: 55,
       max_score: 100,
       issues: [],
       warnings: ['Corrective auto-pass: Heal-generated SD with targeted gap-closure scope'],
@@ -250,7 +258,8 @@ async function checkAutoPassConditions(ctx, retrospective, children, allChildren
 
     return {
       passed: true,
-      score: Math.max(retrospective.quality_score || 55, 55),
+      // FR-3: decorative citation removed — see the DATABASE arm above for the full reasoning.
+      score: 55,
       max_score: 100,
       issues: [],
       warnings: ['Enhancement auto-pass: Narrow-scope improvement SD with inherently thin retrospective'],
@@ -273,7 +282,8 @@ async function checkAutoPassConditions(ctx, retrospective, children, allChildren
 
     return {
       passed: true,
-      score: Math.max(retrospective.quality_score || 55, 55),
+      // FR-3: decorative citation removed — see the DATABASE arm above for the full reasoning.
+      score: 55,
       max_score: 100,
       issues: [],
       warnings: [`${sdType} auto-pass: Thin retrospective expected for ${sdType} SDs`],

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.test.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.test.js
@@ -67,12 +67,47 @@ describe('RETROSPECTIVE_QUALITY_GATE', () => {
     const supabase = buildSupabase({ children, retrospective: retro });
     const gate = createRetrospectiveQualityGate(supabase);
 
+    // SD-LEO-INFRA-RETRO-INTEGRITY-RUN-001 FR-3: the orchestrator fast-path no longer gates on
+    // the STORED retrospectives.quality_score (a diagnostic gauge this SD measured to be
+    // writer-fabricated). It now requires a MEASURED assessment, so this test states that
+    // precondition explicitly instead of inheriting a pass from the stored number.
+    // The mock's un-stubbed default is undefined, which fails closed — correct by design.
+    validateSDCompletionReadiness.mockResolvedValue({ passed: true, score: 75, issues: [], warnings: [] });
+
     const ctx = { sd: createMockSD({ id: 'parent-uuid' }) };
     const result = await gate.validator(ctx);
 
     expect(result.passed).toBe(true);
     expect(result.details.orchestrator_auto_pass).toBe(true);
+    // Still 75, but now the ASSESSED score rather than the stored gauge.
     expect(result.score).toBe(75);
+  });
+
+  // SD-LEO-INFRA-RETRO-INTEGRITY-RUN-001 FR-3 — THE REFUSE HALF.
+  //
+  // Added because mutation-testing exposed that it was missing: disabling the new assessment
+  // guard killed ZERO tests, meaning the accept case alone could not tell a working guard from
+  // an absent one. That is the exact defect class this SD exists to abolish, found in my own
+  // control, so it is fixed here rather than noted.
+  it('DECLINES the orchestrator fast-path when the retrospective does not pass assessment', async () => {
+    const children = [
+      { id: 'child-1', title: 'Child 1', status: 'completed' },
+      { id: 'child-2', title: 'Child 2', status: 'completed' },
+    ];
+    // A high STORED gauge that would have auto-passed under the old quality_score >= 60 predicate.
+    const retro = { id: 'retro-1', quality_score: 95, status: 'PUBLISHED' };
+    const supabase = buildSupabase({ children, retrospective: retro });
+    const gate = createRetrospectiveQualityGate(supabase);
+
+    // ...but the MEASURED assessment says no.
+    validateSDCompletionReadiness.mockResolvedValue({ passed: false, score: 20, issues: ['thin'], warnings: [] });
+
+    const ctx = { sd: createMockSD({ id: 'parent-uuid' }) };
+    const result = await gate.validator(ctx);
+
+    // It must NOT auto-pass on the stored gauge; the fast-path declines and standard validation runs.
+    expect(result.details?.orchestrator_auto_pass).toBeUndefined();
+    expect(result.passed).toBe(false);
   });
 
   it('auto-passes for database type SD with retrospective', async () => {

--- a/scripts/modules/sd-quality-validation.js
+++ b/scripts/modules/sd-quality-validation.js
@@ -267,28 +267,44 @@ export async function validateRetrospectiveQuality(retrospective, sd = null) {
   } catch (error) {
     console.error(`Retrospective Quality Validation Error (${sdId}):`, error.message);
 
-    // Fallback: use stored quality_score if available (fail-open on AI outage)
+    // SD-LEO-INFRA-RETRO-INTEGRITY-RUN-001 FR-3 — THIS FALLBACK NOW FAILS CLOSED.
+    //
+    // It used to read: storedScore = quality_score || 0; fallbackPassed = fallbackScore >= 55 —
+    // and its own comment said "fail-open on AI outage". That combined BOTH defects this SD
+    // exists to remove, in the one place nobody looks:
+    //   * it gated on retrospectives.quality_score, which scripts/lint/diagnostic-gauge-citation-lint.mjs:50
+    //     declares a DIAGNOSTIC gauge no consumer may cite as a threshold — and which this SD
+    //     measured to be writer-fabricated;
+    //   * it auto-PASSED on that fabricated number plus mere content PRESENCE, so an evaluator
+    //     outage silently converted "we could not assess this" into "this is fine".
+    //
+    // A gate that cannot run has NOT passed. Could-this-pass-against-a-broken-build is the whole
+    // question, and a fail-open catch block answers yes by construction. So: no score is invented,
+    // the diagnostic gauge is not consulted, and the outcome is an explicit block requiring manual
+    // review. OPERATIONAL NOTE, stated rather than discovered: this changes behaviour on a real AI
+    // outage — work that previously slid through now stops and asks for a human. That is the
+    // intended trade, and it is why the reason is returned explicitly instead of as a bare false.
     const storedScore = retrospective.quality_score || 0;
-    const hasContent = (retrospective.key_learnings?.length > 0) && (retrospective.action_items?.length > 0);
-    const fallbackScore = (storedScore > 0 && hasContent) ? storedScore : 0;
-    const fallbackPassed = fallbackScore >= 55;
-
-    if (fallbackScore > 0) {
-      console.log(`   ⚠️  AI unavailable — using stored quality_score fallback: ${fallbackScore}/100`);
-    }
+    console.log(`   ⛔ AI evaluator unavailable — FAILING CLOSED (manual review required): ${error.message}`);
 
     return {
       retro_id: retroId,
       sd_id: sdId,
-      valid: fallbackPassed,
-      passed: fallbackPassed,
-      score: fallbackScore,
-      issues: fallbackPassed ? [] : [`AI quality assessment failed: ${error.message}`],
-      warnings: ['AI evaluator unavailable - using stored quality_score fallback', 'Manual review required'],
+      valid: false,
+      passed: false,
+      score: 0,
+      manual_review_required: true,
+      issues: [`AI quality assessment failed and no fallback is permitted: ${error.message}`],
+      warnings: [
+        'AI evaluator unavailable — FAIL-CLOSED, manual review required',
+        'The stored quality_score is a DIAGNOSTIC gauge and is deliberately NOT used as a fallback gate'
+      ],
       details: {
         error: error.message,
-        fallback_used: true,
-        stored_quality_score: storedScore
+        fallback_used: false,
+        fail_closed: true,
+        // Reported for operator context ONLY — never used to decide the verdict above.
+        observed_diagnostic_quality_score: storedScore
       }
     };
   }


### PR DESCRIPTION
Closes SD-LEO-INFRA-RETRO-INTEGRITY-RUN-001.

Retrospectives are where lessons are cheapest to keep. Two mechanisms were losing them.

## What changed

**FR-1 — the unguarded door.** The retro clobber guard had **seven** consult sites and every one was a *handoff* door. `lib/sub-agents/retro/db-operations.js` had **zero** guard references across 523 lines — and the RETRO sub-agent is the writer that produced the original corruption. The existing guard is now consulted there. It is **extended, not reimplemented**; a duplicated policy would drift from the seven existing callers. Deliberately *not* the enricher: measurement showed it already consults the guard and returns early before its replace.

**FR-2 — stop fabricating the score.** Removed `Math.max(new, existing)` from the enhance payload (the caller cannot know the score, and *max* ratchets upward so a record whose content got worse kept the better number) and the literal `quality_score: 85` pre-set.

**FR-3 — reconcile toward diagnostic-only.** A lint rule declares `quality_score` a diagnostic gauge that may not be cited as a gating threshold; nine sites cited it anyway. Five were **decorative** (`passed: true` was already unconditional, so the expression only set a reported number) and were removed. Two were **real predicates** — deleting those would have *opened* the gate rather than reconciled it, so they were **replaced** with the measured assessment.

Ordering was the fix, not a detail: the evaluator's fallback was made **fail-closed first**, because it fell back to the same fabricated gauge plus content presence and called itself fail-open-on-outage. Citing it beforehand would have moved the fabricated dependency into a catch block where nobody looks — strictly worse than the explicit predicate it replaced.

**FR-4** — no new DDL, and the two merged-but-unapplied chairman-gated restates are byte-unmodified, so nothing here can silently revert them.

## Premises falsified before they were built

Four comments explaining *why* something existed turned out to be claims:

1. the plan's `text[]` coercion mechanism — the columns are JSONB and were deliberately migrated to hold objects, so Postgres cannot produce that string;
2. the suggested enricher re-point — already subsumed;
3. the pre-set's trigger-ordering justification — the check is guarded by a publish transition and never fires on the DRAFT insert the function already does;
4. the replacement candidate's cleanliness — its catch block carried the same defect.

Each would have produced real work aimed at nothing.

## Verification

95 tests green across the changed modules. Every load-bearing control mutation-tested — **including one that exposed my own untested refuse half**: disabling the new guard initially killed zero tests, so the accept case could not distinguish a working guard from an absent one. Added the refuse case; the mutation now kills it.

The FR-1 guard **fired in production on this SD's own retrospective** (`ENFORCE skipped, reason=rich_existing_content`), which then surfaced a follow-on: the caller logged "enhanced" when nothing was enhanced. Fixed — a refusal is reported as a refusal.

**Not verified here:** the vitest `db` project is disabled in this environment, so the DB-level integration assertions could not be executed.

**Behaviour change to know about:** on an AI-evaluator outage the gate now blocks for manual review instead of auto-passing. A gate that cannot run has not passed.

## Out of scope, measured and routed

70.4% of SDs (3,935 of 5,591 — exact head-count, not a capped fetch) currently auto-pass the retrospective gate on a retrospective merely *existing*, whatever it contains. That is a fleet-wide behavioural change and is routed as a sibling SD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
