### PR TITLE
feat(SD-LEO-INFRA-COMPLETION-FAIL-OWN-001): widen CHAIRMAN_APPLY_VERIFICATION to ungated SDs

### DIFF
--- a/scripts/modules/handoff/executors/lead-final-approval/gates.js
+++ b/scripts/modules/handoff/executors/lead-final-approval/gates.js
@@ -1340,6 +1340,11 @@ export function createPhaseCoverageExitGate(supabase) {
  * fail-open). This gate is the reconciliation, not a fourth mechanism: it REUSES the mature
  * classifier verbatim, by invoking it, and adds the one thing missing — refusal.
  *
+ * WIDENED to ALL SDs by SD-LEO-INFRA-COMPLETION-FAIL-OWN-001 (2026-08-10, ruling 454e005a):
+ * the requires_chairman_apply flag now selects which clearance ceremony a refusal names, not
+ * whether enforcement happens. See the dated comment inside the validator for why the original
+ * unflagged-SDs-see-no-change scoping went stale.
+ *
  * @returns {Object} Gate definition
  */
 export function createChairmanApplyVerificationGate() {
@@ -1361,14 +1366,17 @@ export function createChairmanApplyVerificationGate() {
       const rawFlag = sd.metadata?.requires_chairman_apply;
       const gated = rawFlag === true || rawFlag === 'true';
 
-      // Not flagged → not applicable. Unflagged SDs must see no behaviour change at all.
-      if (!gated) {
-        console.log('   ℹ️  metadata.requires_chairman_apply not set — not applicable');
-        return {
-          passed: true, score: 100, max_score: 100, issues: [], warnings: [],
-          details: { applicable: false }
-        };
-      }
+      // WIDENED 2026-08-10 (SD-LEO-INFRA-COMPLETION-FAIL-OWN-001, coordinator ruling 454e005a):
+      // this branch used to return passed:true/applicable:false for unflagged SDs — "Unflagged
+      // SDs must see no behaviour change at all." That scoping was correct when written: no role
+      // was defined as the applier for an ungated migration, so a completion-block would have
+      // been unclearable, and an unclearable block is worse than a silent miss. The standing
+      // 2026-06-16 token authority plus ruling 454e005a have since named an applier for BOTH
+      // classes (ungated → coordinator, delegable via database-agent; gated → chairman approval
+      // + coordinator apply), which is the one condition that makes blocking legitimate. The
+      // flag now selects WHICH clearance ceremony a refusal names, not WHETHER enforcement
+      // happens. SD-LEO-FEAT-VENTURE-DEMAND-VALIDATION-001 reached status=completed with two
+      // absent tables through the old early-return; that is the incident this widening closes.
 
       try {
         // Which migration(s) does this SD own? Deliberately does NOT reuse or improve
@@ -1412,8 +1420,19 @@ export function createChairmanApplyVerificationGate() {
         }
 
         if (!owned.length) {
-          return failClosed(`no migration file could be associated with ${sdKey}`, sdKey,
-            ['Declare the SD\'s migration(s) in metadata.migration_files so this gate can verify them.']);
+          // A gated SD is an explicit promise that a migration exists — finding none is
+          // unverifiable, and unverifiable is not verified. An UNGATED SD owning nothing in the
+          // corpus is the majority of the fleet: the classifier ran and found nothing of ours to
+          // verify, which is a determinate pass, not the old applicable:false skip.
+          if (gated) {
+            return failClosed(`no migration file could be associated with ${sdKey}`, sdKey,
+              ['Declare the SD\'s migration(s) in metadata.migration_files so this gate can verify them.']);
+          }
+          console.log('   ✅ no migration associated with this SD — nothing to verify');
+          return {
+            passed: true, score: 100, max_score: 100, issues: [], warnings: [],
+            details: { applicable: true, migrationless: true }
+          };
         }
 
         // PARTIAL is not APPLIED. A half-applied migration is precisely the state this gate exists
@@ -1421,24 +1440,30 @@ export function createChairmanApplyVerificationGate() {
         const unapplied = owned.filter(f => f.status !== 'APPLIED' && f.status !== 'NO_DDL');
         if (unapplied.length) {
           console.log(`   ❌ ${unapplied.length} migration(s) not applied`);
+          // Applier-reachability is a requirement, not rationale (ruling 454e005a condition 4):
+          // a refusal must name the ceremony that clears it, or it recreates the unclearable
+          // block the original scoping existed to avoid.
+          const clearance = gated
+            ? 'REMEDIATION (chairman-gated): obtain the chairman GO, then the coordinator applies via the apply-migration.js token ceremony, then re-run this handoff.'
+            : 'REMEDIATION (ungated): route the apply to the coordinator — delegable via database-agent over the pooler (standing 2026-06-16 token authority; ruling 454e005a) — then re-run this handoff.';
           return {
             passed: false, score: 0, max_score: 100,
             issues: [
-              `${sdKey} is chairman-gated but its migration is NOT applied to the live database.`,
+              `${sdKey}'s own migration is merged but NOT applied to the live database${gated ? ' (chairman-gated)' : ''}.`,
               ...unapplied.map(f => `  ${f.file} → ${f.status}${f.missing?.length ? ` (missing: ${f.missing.slice(0, 3).join(', ')})` : ''}`),
               '',
-              'REMEDIATION: obtain the chairman GO and apply the migration, then re-run this handoff.',
-              'Completing now would mark the SD done against a production migration that was never applied.'
+              clearance,
+              'Completing now would mark the SD done against a migration that was never applied — code-shipped is not capability-live.'
             ],
             warnings: [],
-            details: { applicable: true, unapplied: unapplied.map(f => ({ file: f.file, status: f.status })) }
+            details: { applicable: true, gated, unapplied: unapplied.map(f => ({ file: f.file, status: f.status })) }
           };
         }
 
-        console.log(`   ✅ ${owned.length} chairman-gated migration(s) verified applied`);
+        console.log(`   ✅ ${owned.length} owned migration(s) verified applied`);
         return {
           passed: true, score: 100, max_score: 100, issues: [], warnings: [],
-          details: { applicable: true, verified: owned.map(f => f.file) }
+          details: { applicable: true, gated, verified: owned.map(f => f.file) }
         };
       } catch (e) {
         return failClosed(e.message, sdKey);
@@ -1484,8 +1509,9 @@ export function getRequiredGates(supabase, prdRepo, sd = null) {
   gates.push(createRetrospectiveExistsGate(supabase));
   gates.push(createPRMergeVerificationGate(supabase));
 
-  // Chairman-Apply Verification (SD-LEO-INFRA-CHAIRMAN-APPLY-FLAG-001) — refuses completion of
-  // a chairman-gated SD whose staged migration was never applied. Registration is a manual push
+  // Chairman-Apply Verification (SD-LEO-INFRA-CHAIRMAN-APPLY-FLAG-001; widened to all SDs by
+  // SD-LEO-INFRA-COMPLETION-FAIL-OWN-001) — refuses completion of
+  // any SD whose own staged migration was never applied. Registration is a manual push
   // (there is no directory scan here), so a gate that is written but not pushed silently does
   // nothing — which is how the flag it enforces became decorative in the first place.
   gates.push(createChairmanApplyVerificationGate());

--- a/tests/unit/chairman-apply-verification-widened.test.js
+++ b/tests/unit/chairman-apply-verification-widened.test.js
@@ -1,0 +1,143 @@
+// SD-LEO-INFRA-COMPLETION-FAIL-OWN-001
+// CHAIRMAN_APPLY_VERIFICATION widened to UNGATED SDs (coordinator ruling 454e005a).
+//
+// The incident: SD-LEO-FEAT-VENTURE-DEMAND-VALIDATION-001 reached status=completed while
+// venture_demand_verdicts and venture_consent_events did not exist — its flag was unset, so the
+// gate declared itself not applicable and the ungated branch went completely unenforced.
+// Every positive-control case below PASSES against the pre-widening code; that is the point.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const classifyMigrationApplyState = vi.fn();
+vi.mock(
+  '../../scripts/modules/handoff/executors/lead-final-approval/chairman-apply-state.js',
+  () => ({ classifyMigrationApplyState: (...a) => classifyMigrationApplyState(...a) })
+);
+
+const { createChairmanApplyVerificationGate } = await import(
+  '../../scripts/modules/handoff/executors/lead-final-approval/gates.js'
+);
+
+const gate = () => createChairmanApplyVerificationGate();
+const sdWith = (metadata) => ({ sd: { sd_key: 'SD-TEST-001', metadata } });
+
+beforeEach(() => classifyMigrationApplyState.mockReset());
+
+describe('positive control: an UNGATED SD with its own NOT_APPLIED migration is blocked', () => {
+  it('blocks, names the file + missing objects, and names the coordinator clearance path', async () => {
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [
+        { file: '20260101_SD-TEST-001_add_thing.sql', status: 'NOT_APPLIED', missing: ['table:thing'] },
+        { file: '20260102_unrelated.sql', status: 'APPLIED' }
+      ],
+      error: null
+    });
+    const r = await gate().validator(sdWith({}));
+    expect(r.passed).toBe(false);
+    expect(r.score).toBe(0);
+    const text = r.issues.join('\n');
+    expect(text).toContain('20260101_SD-TEST-001_add_thing.sql');
+    expect(text).toContain('NOT_APPLIED');
+    // Applier-reachability (ruling condition 4): the refusal must say WHO clears it.
+    expect(text).toMatch(/REMEDIATION \(ungated\)/);
+    expect(text).toMatch(/coordinator/i);
+    expect(text).not.toMatch(/chairman GO/);
+  });
+
+  it('would have blocked the incident SD: PARTIAL counts as not applied for ungated too', async () => {
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [{ file: '20260101_SD-TEST-001_add_thing.sql', status: 'PARTIAL', missing: ['table:thing'] }],
+      error: null
+    });
+    const r = await gate().validator(sdWith({}));
+    expect(r.passed).toBe(false);
+    expect(r.issues.join('\n')).toContain('PARTIAL');
+  });
+});
+
+describe('accept half: the widened gate does not blanket-block ungated SDs', () => {
+  it('passes an ungated SD whose owned migration is APPLIED', async () => {
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [{ file: '20260101_SD-TEST-001_add_thing.sql', status: 'APPLIED' }],
+      error: null
+    });
+    const r = await gate().validator(sdWith({}));
+    expect(r.passed).toBe(true);
+    expect(r.details.verified).toEqual(['20260101_SD-TEST-001_add_thing.sql']);
+    expect(r.details.gated).toBe(false);
+  });
+
+  it('passes an ungated SD owning no migration at all (the fleet majority)', async () => {
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [{ file: '20260102_unrelated.sql', status: 'APPLIED' }],
+      error: null
+    });
+    const r = await gate().validator(sdWith({}));
+    expect(r.passed).toBe(true);
+    expect(r.details.migrationless).toBe(true);
+  });
+});
+
+describe('fail-closed now reaches the ungated population', () => {
+  it('blocks an ungated SD when the classifier errors (previously the early-return passed it)', async () => {
+    classifyMigrationApplyState.mockResolvedValue({ files: [], error: 'connect ECONNREFUSED' });
+    const r = await gate().validator(sdWith({}));
+    expect(r.passed).toBe(false);
+    expect(r.details.fail_closed).toBe(true);
+  });
+
+  it('blocks an ungated SD whose DECLARED migration is absent from the corpus', async () => {
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [{ file: '20260102_unrelated.sql', status: 'APPLIED' }],
+      error: null
+    });
+    const r = await gate().validator(sdWith({ migration_files: ['20260101_typo.sql'] }));
+    expect(r.passed).toBe(false);
+    expect(r.issues.join('\n')).toContain('20260101_typo.sql');
+  });
+
+  it('still fails closed for a GATED SD owning nothing — the flag is a promise a migration exists', async () => {
+    classifyMigrationApplyState.mockResolvedValue({ files: [], error: null });
+    const r = await gate().validator(sdWith({ requires_chairman_apply: true }));
+    expect(r.passed).toBe(false);
+    expect(r.details.fail_closed).toBe(true);
+  });
+});
+
+describe('gated refusals name the chairman ceremony (clearance path per class)', () => {
+  it('a gated NOT_APPLIED refusal instructs chairman GO + coordinator apply', async () => {
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [{ file: '20260101_SD-TEST-001_add_thing.sql', status: 'NOT_APPLIED', missing: [] }],
+      error: null
+    });
+    const r = await gate().validator(sdWith({ requires_chairman_apply: true }));
+    expect(r.passed).toBe(false);
+    const text = r.issues.join('\n');
+    expect(text).toMatch(/REMEDIATION \(chairman-gated\)/);
+    expect(text).toMatch(/chairman GO/);
+  });
+});
+
+describe('probe-shape pin: the gate consults the real classifier, never a head-count', () => {
+  // Measured live twice (2026-08-09, worker + coordinator independently): on the SAME absent
+  // table a real select errors PGRST205 while select(id,{count:'exact',head:true}) returns NO
+  // error and count=null — a head-count gate cannot tell an absent table from an empty one.
+  it('the gate source imports chairman-apply-state and contains no head-count existence probe', () => {
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const src = fs.readFileSync(
+      path.join(here, '../../scripts/modules/handoff/executors/lead-final-approval/gates.js'),
+      'utf8'
+    );
+    const start = src.indexOf('export function createChairmanApplyVerificationGate');
+    const end = src.indexOf('function failClosed');
+    expect(start).toBeGreaterThan(-1);
+    expect(end).toBeGreaterThan(start);
+    const gateSection = src.slice(start, end);
+    expect(gateSection).toContain("import('./chairman-apply-state.js')");
+    expect(gateSection).not.toMatch(/count:\s*['"]exact['"]/);
+    expect(gateSection).not.toMatch(/head:\s*true/);
+  });
+});

--- a/tests/unit/head-count-absent-table-negative-control.db.test.js
+++ b/tests/unit/head-count-absent-table-negative-control.db.test.js
@@ -1,0 +1,39 @@
+// SD-LEO-INFRA-COMPLETION-FAIL-OWN-001 — the head-count trap, pinned live.
+//
+// A gate probing existence with select(id,{count:'exact',head:true}) reads a MISSING table as a
+// healthy zero: PostgREST returns NO error and count=null on an absent relation, while a real
+// select errors PGRST205. This test runs BOTH shapes against a guaranteed-absent table and
+// asserts the divergence, so nobody later swaps the classifier's real probe (to_regclass /
+// real select) for the cheap shape as a "simplification". Measured live twice on 2026-08-09
+// (worker + coordinator independently) before being pinned here.
+//
+// Live test in the DB tier (.db.test.js → DB_INCLUDE): the unit tier deliberately replaces
+// credentials with the test.invalid.local sentinel (tests/setup.unit.js FR-1), so a live probe
+// there hangs against a fake host until timeout — measured on this file's first run. The db
+// project loads real credentials via tests/setup.db.js and is gated on a designated target;
+// skipIf below is the residual guard for a credential-less shell.
+
+import { describe, it, expect } from 'vitest';
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+// Name chosen to be absurd enough that no migration will ever create it.
+const ABSENT_TABLE = 'zz_absent_negative_control_completion_fail_own_001';
+
+describe.skipIf(!url || !key)('negative control: head-count cannot distinguish absent from empty', () => {
+  it('real select errors PGRST205 on the absent table; head-count silently returns null', async () => {
+    const sb = createClient(url, key);
+
+    const real = await sb.from(ABSENT_TABLE).select('*').limit(1);
+    expect(real.error).toBeTruthy();
+    expect(real.error.code).toBe('PGRST205');
+
+    const head = await sb.from(ABSENT_TABLE).select('id', { count: 'exact', head: true });
+    // BOTH halves matter: no error AND a null count — the shape that reads absent as empty.
+    expect(head.error).toBeNull();
+    expect(head.count).toBeNull();
+  }, 30_000);
+});

--- a/tests/unit/lead-final-chairman-apply-verification.test.js
+++ b/tests/unit/lead-final-chairman-apply-verification.test.js
@@ -24,20 +24,28 @@ const sdWith = (metadata) => ({ sd: { sd_key: 'SD-TEST-001', metadata } });
 
 beforeEach(() => classifyMigrationApplyState.mockReset());
 
-describe('TS-3: an SD without the flag is completely unaffected', () => {
-  it('passes as not-applicable and never consults the classifier', async () => {
+describe('an SD without the flag is enforced too (widened by SD-LEO-INFRA-COMPLETION-FAIL-OWN-001)', () => {
+  // These cases previously asserted the OLD contract (unflagged → applicable:false, classifier
+  // never consulted). That contract is deliberately reversed per coordinator ruling 454e005a:
+  // an applier now exists for ungated migrations, so blocking is clearable and legitimate.
+  it('consults the classifier and passes migrationless when the SD owns no migration', async () => {
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [{ file: '20260102_unrelated.sql', status: 'APPLIED' }],
+      error: null
+    });
     const r = await gate().validator(sdWith({}));
     expect(r.passed).toBe(true);
-    expect(r.details.applicable).toBe(false);
-    // The regression that matters: unflagged SDs must not gain a new dependency or failure mode.
-    expect(classifyMigrationApplyState).not.toHaveBeenCalled();
+    expect(r.details.applicable).toBe(true);
+    expect(r.details.migrationless).toBe(true);
+    expect(classifyMigrationApplyState).toHaveBeenCalled();
   });
 
-  it('treats a non-affirmative flag value as not applicable', async () => {
+  it('treats a non-affirmative flag value as ungated (enforced, coordinator ceremony)', async () => {
     for (const v of [false, 'false', 1, null, undefined, 'yes']) {
+      classifyMigrationApplyState.mockResolvedValue({ files: [], error: null });
       const r = await gate().validator(sdWith({ requires_chairman_apply: v }));
       expect(r.passed).toBe(true);
-      expect(r.details.applicable).toBe(false);
+      expect(r.details.migrationless).toBe(true);
     }
   });
 


### PR DESCRIPTION
## Summary
- An SD whose own migration is merged-but-unapplied now FAILS completion regardless of `metadata.requires_chairman_apply` — the flag selects WHICH clearance ceremony the refusal names (chairman vs coordinator), no longer WHETHER enforcement happens.
- Reuses `classifyMigrationApplyState` verbatim; zero changes to the classifier or wrapper — extension of the ONE enforcing gate, not a fourth mechanism.
- Ungated SDs owning no migration pass with `details.migrationless:true` (fleet majority — no behaviour change). Gated SDs owning nothing still fail closed (the flag promises a migration exists).
- Fail-closed (classifier error, missing declared file) now reaches the ungated population.
- Refusals name the per-class clearance path (applier-reachability, ruling 454e005a condition 4).

## Why now (cross-author reversal, announced)
The original "Unflagged SDs must see no behaviour change at all" scoping was correct when written: no role was defined as applier for ungated migrations, so a block would have been unclearable. The standing 2026-06-16 token authority + coordinator ruling 454e005a named appliers for both classes — blocks are now clearable, which is the one condition that makes enforcement legitimate. Incident closed: SD-LEO-FEAT-VENTURE-DEMAND-VALIDATION-001 reached `status=completed` with two absent tables through the old `applicable:false` early-return.

## Test plan
- [x] 25 unit tests across both gate test files (widened positive/negative controls, fail-closed, per-class clearance, probe-shape pin)
- [x] 1390 tests green across all 136 gates.js-consuming unit files
- [x] db-tier live negative control (head-count reads absent table as healthy zero: PGRST205 vs silent null) — assertions verified live via plain node
- [x] Plain-node import of modified gates.js verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)