### PR TITLE
feat(SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001): checkin/dispatch reads the row's own claim, release and freshness markers at hand-time

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001.json
@@ -1,0 +1,193 @@
+{
+  "executive_summary": "Check-in hands a worker seat work whose own row markers say it should not be handed. Measured at the def-site (lib/checkin/, a 20-step first-truthy-wins pipeline), the three reported defects do NOT share the root the SD assumed, so this PRD scopes them separately on a coordinator ruling. FR-1 is a genuine hand-time blindness: resume.cjs asks a SD-only predicate whether the seat holds anything, so a seat holding a quick-fix is invisible and the ladder falls through to the self-claim tiers — measured live, 2 of 2 claimed QFs sit in exactly that state. FR-2's premise is FALSE as originally written: the machine-readable guard already exists and already runs at hand-time, and the structured writer already exists; what is missing is that a deliberate release records its rationale as prose while the mechanical sweep clears the claim with no marker, so the QF returns to the queue unmarked. FR-3 holds: every 'freshness' concept on the dispatch path measures whether the RECIPIENT is alive, never whether the instruction's factual claim is still true. Verification is two-sided per FR — each guard is proven to FIRE on the positive control and to NOT fire on the negative control, so a guard that refuses everything cannot pass.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "resume must see BOTH claim kinds before the ladder falls through to self-claim",
+      "description": "lib/checkin/steps/resume.cjs is step 5 of the first-truthy-wins pipeline in lib/checkin/pipeline.cjs, and it short-circuits every self-claim tier below it. Its `if (!ctx.mySd)` branch (line 19) asks findOwnSdClaim (scripts/worker-checkin.cjs:1566) what this session holds; that function selects ONLY from strategic_directives_v2, with .limit(1), and never queries quick_fixes. The SAME FILE's else branch (line 39) already imports and calls getMyClaims (lib/claim/get-my-claims.cjs), which queries BOTH strategic_directives_v2 and quick_fixes and deliberately carries NO .limit(1) — its own header states it exists to detect multiplicity. So the correct predicate is already present in the file and is used only on the branch that structurally cannot stack. Consequence: a seat whose mirror claude_sessions.sd_key is NULL while it authoritatively holds a QF is invisible to resume, resume returns undefined, and the ladder continues down to merged-pool-self-claim and self-claim-qf — handing additional vehicles onto a seat that already deliberately holds one. Fix: use getMyClaims in the !ctx.mySd branch so resume sees both claim kinds. This EXTENDS a live guard; it introduces no new predicate, no new query surface and no schema change. MEASURED LIVE, whole population not a sample (n=2): 2 of 2 quick_fixes carrying an authoritative claiming_session_id have a NULL mirror — 100% of the live population sits in the stacking-reachable state and ZERO are in the state where resume short-circuits correctly.",
+      "priority": "critical",
+      "acceptance_criteria": [
+        "POSITIVE CONTROL: a session that authoritatively holds a QF (quick_fixes.claiming_session_id = this session) while claude_sessions.sd_key is NULL resolves to action='resume' naming that QF, and is handed ZERO additional vehicles.",
+        "NEGATIVE CONTROL: a session holding nothing (no SD and no QF authoritatively claimed) still falls through resume normally and receives its ordinary single hand — the guard must not refuse everything.",
+        "A session authoritatively holding an SD with a NULL mirror continues to resume that SD exactly as before (no regression to the existing SD-side self-heal path).",
+        "Multiplicity remains DETECTION-ONLY: when getMyClaims reports more than one held claim, ctx.base.claim_multiplicity is still surfaced and NO claim is auto-released. Proven by a test asserting no release/update call is made on the multiplicity path.",
+        "The read-error case does not silently read as 'holds nothing': when getMyClaims returns an error, resume does not treat the seat as empty (a partial read must not authorise a hand)."
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "A deliberate release must WRITE the structured marker — not leave the rationale as prose",
+      "description": "RE-SCOPED ON COORDINATOR RULING. The SD as authored asserts the release note 'lives in prose that nothing reads at hand-time' and must be machine-read. Measured at the def-site, that premise is FALSE in both halves. READ SIDE ALREADY EXISTS AND ALREADY RUNS AT HAND-TIME: isAutoStartableQF gates on quick_fixes.not_before (scripts/worker-checkin.cjs:684) and on isChairmanGatedQF (line 692, lib/fleet/qf-gated-hold.cjs — owner='chairman' plus release_condition), each returning false; QF_CANDIDATE_COLUMNS (line 729) already selects not_before, owner and release_condition. WRITE SIDE ALREADY EXISTS: scripts/defer-quick-fix.js is the canonical hold-state contract writer (--not-before / --reason / --owner / --release-condition, SD-LEO-INFRA-HOLD-STATE-CONTRACT-001) and at line 137 it clears claiming_session_id together with not_before atomically. MEASURED: QF-20260804-073 has not_before, reason, owner and release_condition ALL NULL, with the entire blocking rationale sitting in verification_notes as prose; the coordinator independently measured this is FLEET-WIDE, dozens of QFs with all-NULL markers. THE ACTUAL MECHANISM: a worker records a blocking rationale as prose and does not invoke the structured verb; the claim is later cleared MECHANICALLY by the stale-session sweep, which writes no marker because a swept stale claim is not a deliberate release; the QF returns to status='open' with every marker column NULL and is therefore fully claimable again, and is re-handed to a seat that also cannot satisfy the blocking condition. Therefore the deliverable is on the WRITE path, not the read path: a deliberate worker-initiated QF release must write the structured marker, and a deliberate release recorded without one must FAIL LOUDLY rather than silently returning an unmarked row to the queue. EXPLICITLY OUT OF SCOPE, and this boundary is load-bearing: the sweep's mechanical stale-claim clear is NOT a deliberate release and must keep clearing without a marker — requiring one there would strand every genuinely-dead claim. DO NOT BUILD A PROSE PARSER: it would duplicate a working guard and still miss the cause.",
+      "priority": "high",
+      "acceptance_criteria": [
+        "POSITIVE CONTROL: a deliberate worker-initiated QF release that supplies a blocking rationale results in the structured marker being persisted on the row (not_before and/or release_condition + owner + reason), such that the existing isAutoStartableQF guard excludes it on the next hand — proven by asserting isAutoStartableQF returns false for the resulting row.",
+        "FAIL-LOUD CONTROL: a deliberate release recorded with a rationale but NO structured marker is refused loudly (non-zero exit / explicit error naming the missing columns), never silently completing.",
+        "NEGATIVE CONTROL: a release with no blocking rationale at all — ordinary completion or hand-back — is unaffected and still succeeds without a marker. The guard must not make every release require a hold.",
+        "SWEEP BOUNDARY PRESERVED: the stale-session sweep's mechanical clear of a dead session's QF claim still succeeds with no structured marker. Proven by a test that exercises the sweep path and asserts it is NOT refused.",
+        "No prose parsing is introduced anywhere: verification_notes is never read as a source of guard state."
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "A dispatch instruction carrying a factual premise must stamp the MEASUREMENT time and default to re-verify",
+      "description": "MEASURED AT THE DEF-SITE. The dispatch path is saturated with the word 'freshness' and every instance measures the RECIPIENT: lib/coordinator/dispatch.cjs:110 and :182 check heartbeat freshness to decide whether a seat is alive; lib/coordinator/detectors.cjs:43 and :338 define live-coordinator and stalled-loop windows; scripts/worker-checkin.cjs:803 DISPATCH_RANK_TTL_MS (1h) bounds the staleness of a dispatch RANK. NONE of these measure whether a factual claim embedded in the instruction is still true. lib/checkin/steps/directed-assignment.cjs carries ZERO handling of an instruction body — no payload.instruction, apply, body or steps — so the prose a worker is expected to act on is never inspected, never bounded and never re-validated. Reported incident: an 08-05 dispatch closed with an apply-instruction ('drive_reports returns PGRST205, prepend-commit-apply') that was FALSE by read-time (the table had been applied), and a worker following it literally would have attempted to apply a live permission-class table. A three-day-old premise is a lead, not a fact. THE DELIVERABLE IS NOT A GENERIC PROSE RE-VALIDATOR — arbitrary claims cannot be mechanically re-checked, and pretending otherwise would produce a guard that asserts what it never measured. Instead, follow the precedent already established at the same choke point: lib/coordinator/dispatch.cjs lines 304-342 already stamp payload.effort_recommendation onto WORK_ASSIGNMENT rows as they pass through. Attach the premise contract at that identical choke point: an instruction carrying a factual premise must record the time that premise was MEASURED (never the time the message was sent — a send-time stamp certifies only that the message is new, which is exactly the false comfort this defect is made of), and at claim-time a premise older than the freshness bound must surface an explicit RE-VERIFY-BEFORE-EXECUTING instruction to the worker rather than being handed on as fact.",
+      "priority": "medium",
+      "acceptance_criteria": [
+        "POSITIVE CONTROL: a WORK_ASSIGNMENT whose premise measurement time is older than the freshness bound surfaces an explicit re-verify directive to the worker at claim-time; the instruction is NOT presented as current fact.",
+        "NEGATIVE CONTROL: a WORK_ASSIGNMENT whose premise was measured within the bound dispatches and is presented normally, with no re-verify noise added.",
+        "A premise stamp records MEASUREMENT time, not send time. Proven by a test in which the two differ and the guard's verdict follows the measurement time, not the send time.",
+        "ABSENT-STAMP CASE IS EXPLICIT: an instruction carrying no premise stamp at all is treated as unverified (surfaced), never as fresh. A missing stamp must not read as a passing one.",
+        "No generic prose re-validation is attempted and none is claimed anywhere in the code or its output."
+      ]
+    }
+  ],
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "title": "Extend live guards; introduce no duplicate predicate",
+      "description": "FR-1 reuses getMyClaims (lib/claim/get-my-claims.cjs), already imported in resume.cjs. FR-2 reuses the existing isAutoStartableQF read-guard and the defer-quick-fix.js writer. FR-3 reuses the dispatch.cjs choke point that already stamps effort_recommendation. No new predicate, no new query surface, no schema change. This SD's own prior-art note requires extending live guards rather than re-implementing them, and a prior SD in this session cost ~200 lines by violating exactly that."
+    },
+    {
+      "id": "TR-2",
+      "title": "Every guard is proven two-sided",
+      "description": "For each FR the guard must be proven to FIRE on the positive control AND to NOT fire on the negative control. A guard proven only on the positive side is indistinguishable from one that refuses everything, and would silently halt the fleet's hand-path."
+    },
+    {
+      "id": "TR-3",
+      "title": "Read errors must not read as 'nothing held'",
+      "description": "getMyClaims reports partial-read errors deliberately so a caller can distinguish 'you hold nothing' from 'I could not see one of the two surfaces'. FR-1 must not collapse those two states — a surface that could not be read must never authorise handing more work."
+    }
+  ],
+  "test_scenarios": [
+    {
+      "id": "TS-1",
+      "scenario": "Seat authoritatively holds a QF with a NULL mirror; check-in runs",
+      "type": "unit",
+      "expected": "resume returns action='resume' naming the QF; no self-claim tier is reached and zero additional vehicles are handed"
+    },
+    {
+      "id": "TS-2",
+      "scenario": "Seat holds nothing at all; check-in runs",
+      "type": "unit",
+      "expected": "resume falls through and the seat receives its ordinary single hand — the negative control proving the guard does not refuse everything"
+    },
+    {
+      "id": "TS-3",
+      "scenario": "getMyClaims returns a partial-read error during resume",
+      "type": "unit",
+      "expected": "the seat is not treated as empty; no additional vehicle is handed on the strength of an unreadable surface"
+    },
+    {
+      "id": "TS-4",
+      "scenario": "Session holds two claims; check-in runs",
+      "type": "unit",
+      "expected": "claim_multiplicity is surfaced and NO release/update is issued — multiplicity stays detection-only per ruling"
+    },
+    {
+      "id": "TS-5",
+      "scenario": "Deliberate QF release supplying a blocking rationale",
+      "type": "unit",
+      "expected": "the structured marker is persisted and isAutoStartableQF returns false for the resulting row"
+    },
+    {
+      "id": "TS-6",
+      "scenario": "Deliberate QF release with a rationale but no structured marker",
+      "type": "unit",
+      "expected": "refused loudly with an error naming the missing columns; never silently completes"
+    },
+    {
+      "id": "TS-7",
+      "scenario": "Stale-session sweep mechanically clears a dead session's QF claim",
+      "type": "unit",
+      "expected": "the clear succeeds with no structured marker — the sweep boundary is preserved and dead claims are never stranded"
+    },
+    {
+      "id": "TS-8",
+      "scenario": "WORK_ASSIGNMENT whose premise measurement time is older than the bound, and a second whose send time is fresh but measurement time is stale",
+      "type": "unit",
+      "expected": "both surface a re-verify directive; the verdict follows measurement time, never send time"
+    },
+    {
+      "id": "TS-9",
+      "scenario": "WORK_ASSIGNMENT carrying no premise stamp at all",
+      "type": "unit",
+      "expected": "treated as unverified and surfaced; a missing stamp never reads as fresh"
+    }
+  ],
+  "acceptance_criteria": [
+    "Every FR's guard is proven two-sided: it fires on the positive control and does not fire on the negative control.",
+    "FR-1 changes resume.cjs to consult getMyClaims on the !ctx.mySd branch and introduces no new predicate.",
+    "Multiplicity remains detected and surfaced but unacted-on, per the coordinator ruling that picking a winner is a separate policy directive.",
+    "No prose parser is built for FR-2, and the sweep's mechanical clear still succeeds without a marker.",
+    "FR-3 claims no generic prose re-validation; it stamps measurement time and defaults to re-verify.",
+    "Each behavioural arm is mutation-proven against a baseline verified green FIRST, with every mutation redding at least one named test."
+  ],
+  "risks": [
+    {
+      "risk": "FR-1's guard is too broad and refuses a legitimate hand, halting the fleet's self-claim path across every seat.",
+      "mitigation": "The negative control (TS-2) is mandatory: a seat holding nothing must still receive its ordinary hand. resume already short-circuits for SD holders today, so this only widens visibility to the QF surface — it adds no new refusal class.",
+      "severity": "medium"
+    },
+    {
+      "risk": "FR-2's fail-loud requirement is applied to the sweep, stranding every genuinely-dead QF claim behind a marker nobody can supply.",
+      "mitigation": "TS-7 pins the sweep boundary explicitly as a test, not a comment. The requirement attaches only to a DELIBERATE worker-initiated release.",
+      "severity": "high"
+    },
+    {
+      "risk": "FR-3 is read as promising that stale instructions are mechanically detected, when only stamped premises can be bounded.",
+      "mitigation": "The absent-stamp case (TS-9) is an explicit acceptance criterion and surfaces as UNVERIFIED, never as fresh. The PRD and the code state plainly that no generic prose re-validation is performed.",
+      "severity": "medium"
+    },
+    {
+      "risk": "The live population behind FR-1 is small (n=2), so the measurement could be read as thin evidence.",
+      "mitigation": "It is the WHOLE population of authoritatively-claimed QFs, not a sample of it, and the ratio is 2 of 2 with zero counter-examples. The mechanism is additionally established by reading the code path directly, independent of the population size.",
+      "severity": "low"
+    }
+  ],
+  "system_architecture": {
+    "summary": "Check-in is a 20-step ordered pipeline (lib/checkin/pipeline.cjs runs lib/checkin/steps/index.cjs; the FIRST step returning a truthy value becomes the resolution). resume sits at step 5, above every acquisition tier, so what resume can SEE determines whether a seat can be stacked. Dispatch is a separate choke point (lib/coordinator/dispatch.cjs) that validates and decorates WORK_ASSIGNMENT rows in flight.",
+    "components": [
+      {
+        "name": "lib/checkin/steps/resume.cjs",
+        "change": "FR-1: the !ctx.mySd branch consults getMyClaims (both claim kinds, no limit) instead of the SD-only, limit-1 findOwnSdClaim. Multiplicity handling is untouched and stays detection-only."
+      },
+      {
+        "name": "lib/claim/get-my-claims.cjs",
+        "change": "Reused unchanged — it already answers the ownership question across both tables and already reports partial-read errors."
+      },
+      {
+        "name": "the deliberate QF release path (scripts/defer-quick-fix.js and its callers)",
+        "change": "FR-2: a deliberate release carrying a blocking rationale writes the structured marker; one recorded without a marker fails loudly. The read-guard in isAutoStartableQF is reused unchanged."
+      },
+      {
+        "name": "lib/coordinator/dispatch.cjs",
+        "change": "FR-3: at the same choke point that already stamps effort_recommendation, carry a premise MEASUREMENT-time stamp; claim-time surfaces re-verify when the premise is stale or unstamped."
+      },
+      {
+        "name": "scripts/stale-session-sweep.cjs",
+        "change": "UNCHANGED BY DESIGN — a swept stale claim is not a deliberate release and must keep clearing without a marker. Pinned by TS-7."
+      }
+    ]
+  },
+  "implementation_approach": {
+    "summary": "Three independent, small changes, each extending a guard that already exists, each proven two-sided and mutation-proven against a baseline verified green first. FR-1 is the smallest and closes the whole reported stacking mechanism; FR-2 moves the fix from the read side (already correct) to the write side; FR-3 attaches a freshness contract to the existing dispatch choke point rather than inventing a validator.",
+    "steps": [
+      "Write the failing two-sided arms for FR-1 FIRST (QF-held-with-null-mirror; holds-nothing; partial-read error; multiplicity-unacted), and confirm they fail for the RIGHT reason before touching resume.cjs.",
+      "Change resume.cjs's !ctx.mySd branch to consult getMyClaims, preserving the existing SD self-heal (healOwnClaimPointer) behaviour for SD claims.",
+      "Measure the FR-2 deliberate-release call sites, then make a rationale-bearing release write the structured marker and refuse loudly without one; pin the sweep boundary with TS-7 before changing anything.",
+      "Attach the FR-3 premise stamp at the dispatch choke point alongside effort_recommendation, and surface re-verify at claim-time for stale AND unstamped premises.",
+      "Mutation-prove every arm: verify the baseline is GREEN first, then confirm each mutation reds at least one NAMED test and that no mutation is a no-op.",
+      "Run the full unit project and report the counts."
+    ]
+  },
+  "integration_operationalization": {
+    "consumers": "Every fleet worker seat calling scripts/worker-checkin.cjs each loop pass — the resume step is on the hand-path of all of them, so an FR-1 regression would be fleet-wide and immediate. Secondary consumers: the coordinator dispatch path (lib/coordinator/dispatch.cjs) for FR-3, and any operator running scripts/defer-quick-fix.js for FR-2.",
+    "dependencies": "lib/claim/get-my-claims.cjs (existing, reused unchanged — the ownership predicate across strategic_directives_v2 and quick_fixes). lib/fleet/qf-gated-hold.cjs isChairmanGatedQF and scripts/worker-checkin.cjs isAutoStartableQF (existing read-guard, reused unchanged). scripts/defer-quick-fix.js (existing hold-state contract writer). No new dependency is introduced and no schema change is required — quick_fixes already carries not_before, reason, owner and release_condition.",
+    "data_contracts": "OWNERSHIP is answered by the authoritative claiming_session_id columns on strategic_directives_v2 and quick_fixes; LIVENESS is answered by the claude_sessions.sd_key mirror. Conflating them is the defect FR-1 fixes, and get-my-claims.cjs documents the split explicitly. FR-2 relies on the marker columns already read by isAutoStartableQF. FR-3 adds a premise MEASUREMENT-time field to the WORK_ASSIGNMENT payload, alongside the effort_recommendation field the same choke point already writes; payloads without it remain valid and are treated as unverified.",
+    "runtime_config": "No new environment variables, feature flags or settings. FR-3's freshness bound follows the existing convention of a module-level constant beside DISPATCH_RANK_TTL_MS rather than runtime configuration, so behaviour is identical across every seat with nothing to misconfigure.",
+    "observability_rollout": "FR-1 is observable in the check-in JSON: a QF-holding seat resolves to action='resume' naming the QF instead of self_claimed/self_claimed_qf, and claim_multiplicity continues to surface when present. FR-2 is observable as a loud refusal on the release path plus the marker columns becoming non-NULL on deliberately-released rows — the same live query used to measure this SD (markers all-NULL, fleet-wide) is the rollout check. FR-3 is observable as a re-verify directive on the surfaced assignment. Rollout is a plain merge with no migration and no backfill; the pre-existing fleet-wide all-NULL marker population is NOT retroactively marked by this change and stays visible to that same query."
+  },
+  "metadata": {
+    "sd_key": "SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001"
+  }
+}

--- a/lib/checkin/steps/directed-assignment.cjs
+++ b/lib/checkin/steps/directed-assignment.cjs
@@ -4,6 +4,11 @@
 // SD-LEO-INFRA-WORKER-ESCALATION-WRITE-001 (FR-1) — the WORK_ASSIGNMENT lane of the receipt
 // contract. Safe as a top-level require: receipt-ledger.cjs imports nothing.
 const { recordReceipt, LANES, STATES, DISPOSITIONS } = require('../../coordination/receipt-ledger.cjs');
+// SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 (FR-3): claim-time premise-freshness verdict. This file
+// previously carried ZERO handling of an instruction body — the prose a worker acts on was never
+// inspected, bounded or re-validated, while every 'freshness' check on the dispatch path measured
+// the RECIPIENT. Safe as a top-level require: premise-freshness.cjs imports nothing.
+const { assessInstructionPremise, PREMISE_FRESHNESS_BOUND_MS } = require('../../coordination/premise-freshness.cjs');
 
 module.exports = {
   name: 'directed-assignment',
@@ -225,9 +230,17 @@ module.exports = {
             // SD-MAN-INFRA-MEDIUM-EFFORT-HARDENING-001 (FR-5): surface the coordinator's
             // ADVISORY effort recommendation so the worker banner can render it.
             const effortRec = assignment.payload?.effort_recommendation || null;
+            // SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 (FR-3): claim-time is the moment the worker
+            // is about to act on the instruction, so it is where a stale or unstamped premise
+            // must stop reading as current fact. The directive LEADS the message — a caveat
+            // trailing the instruction lands where attention no longer is. Fresh premises and
+            // instruction-less assignments add zero noise. The verdict is computed HERE, at
+            // read-time, never persisted at dispatch — a persisted verdict would itself go stale.
+            const premise = assessInstructionPremise(assignment.payload, Date.now());
             return { ...ctx.base, action: 'claimed_assignment', sd: sdKey,
               ...(effortRec ? { effort_recommendation: effortRec, effort_recommendation_reason: assignment.payload?.effort_recommendation_reason || null } : {}),
-              message: `Claimed assigned ${sdKey} via claim_sd.${effortRec ? ` Recommended effort: ${effortRec} (advisory).` : ''} Run: node scripts/sd-start.js ${sdKey}. ${antiWinddownDirective(ctx.base.belt_ranked_claimable)}` };
+              ...(premise.directive ? { premise_reverify: { verdict: premise.verdict, measured_at: premise.measuredAt, bound_ms: PREMISE_FRESHNESS_BOUND_MS } } : {}),
+              message: `${premise.directive ? `${premise.directive} ` : ''}Claimed assigned ${sdKey} via claim_sd.${effortRec ? ` Recommended effort: ${effortRec} (advisory).` : ''} Run: node scripts/sd-start.js ${sdKey}. ${antiWinddownDirective(ctx.base.belt_ranked_claimable)}` };
           }
           // QF-20260703-780: a terminal-class RPC verdict means this assignment can NEVER
           // succeed (unlike e.g. claimed_by_live_peer, which may resolve next tick) -- ack it

--- a/lib/checkin/steps/resume.cjs
+++ b/lib/checkin/steps/resume.cjs
@@ -21,6 +21,37 @@ module.exports = {
         const healed = await healOwnClaimPointer(sb, sessionId, owned);
         ctx.base.self_healed_own_claim_pointer = { sd: owned, cache_updated: healed };
         ctx.mySd = owned;
+      } else {
+        // SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 (FR-1): findOwnSdClaim answers the ownership
+        // question for ONE KIND — strategic_directives_v2 only, .limit(1), never quick_fixes. So a
+        // seat whose mirror is NULL while it authoritatively holds a QUICK-FIX was invisible HERE:
+        // this step returned undefined and the ladder fell through to merged-pool-self-claim and
+        // self-claim-qf, stacking more vehicles onto a seat that already deliberately held one.
+        // Measured live when this shipped (whole population, n=2): 2 of 2 authoritatively-claimed
+        // QFs had a NULL mirror — 100% of them sat in exactly this state.
+        // getMyClaims is the EXISTING both-kinds predicate, already required by the else branch
+        // below; this asks it the question this branch was never asking.
+        // DELIBERATELY NOT A WHOLESALE SWAP: findOwnSdClaim also requires is_working_on=true, which
+        // getMyClaims does not test. Using it for SDs too would newly resume PARKED SD claims — a
+        // behaviour change this FR does not own. SD semantics are left byte-identical.
+        try {
+          const { getMyClaims } = require('../../claim/get-my-claims.cjs');
+          const { claims, error } = await getMyClaims(sb, sessionId);
+          const qf = (claims || []).find((c) => c.kind === 'QF');
+          if (qf) {
+            const healed = await healOwnClaimPointer(sb, sessionId, qf.key);
+            ctx.base.self_healed_own_claim_pointer = { sd: qf.key, cache_updated: healed };
+            ctx.mySd = qf.key;
+          } else if (error) {
+            // A SURFACE WE COULD NOT READ IS NOT "HOLDS NOTHING". get-my-claims reports partial-read
+            // errors precisely so a caller can tell those apart, and handing work on the strength of
+            // an unreadable claim surface is the same defect class this FR closes. Stop the ladder
+            // rather than continue into the acquisition tiers on incomplete evidence.
+            return { ...ctx.base, action: 'idle', recommended_wakeup_seconds: 300,
+              claim_surface_unreadable: error,
+              message: `Claim surface unreadable (${error}) — not handing work this tick. A surface that could not be read is not evidence the seat is empty; retrying shortly.` };
+          }
+        } catch { /* fail-open to prior behaviour — detection must never break an otherwise valid checkin */ }
       }
     } else {
       // SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-002 (FR-8): the branch above only runs when the mirror

--- a/lib/coordination/premise-freshness.cjs
+++ b/lib/coordination/premise-freshness.cjs
@@ -1,0 +1,98 @@
+/**
+ * SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 (FR-3) — the premise-freshness contract for
+ * WORK_ASSIGNMENT instruction bodies.
+ *
+ * Every 'freshness' concept on the dispatch path measures the RECIPIENT (heartbeat windows in
+ * lib/coordinator/dispatch.cjs and detectors.cjs, DISPATCH_RANK_TTL_MS on the dispatch rank).
+ * None measures whether a factual claim EMBEDDED IN the instruction is still true. Reported
+ * incident: an 08-05 dispatch carried an apply-instruction ("drive_reports returns PGRST205,
+ * prepend-commit-apply") that was FALSE by read-time — the table had since been applied — and a
+ * worker following it literally would have re-applied a live permission-class table.
+ *
+ * THIS MODULE IS NOT A PROSE RE-VALIDATOR, and deliberately claims nothing about instruction
+ * CONTENT. Arbitrary factual claims cannot be mechanically re-checked; a guard pretending to
+ * would assert what it never measured. The contract is narrower and honest:
+ *   WRITE side  the dispatcher records WHEN the premise was MEASURED (payload.premise_measured_at)
+ *               — never the send time; a send-time stamp certifies only that the message is new,
+ *               which is exactly the false comfort this defect is made of.
+ *   READ side   at claim-time, a premise older than the bound — or an instruction body carrying
+ *               no stamp at all — surfaces an explicit RE-VERIFY-BEFORE-EXECUTING directive to
+ *               the worker instead of being handed on as fact.
+ *
+ * Detection is by KEY PRESENCE (payload.instruction / apply / body / steps — the fields
+ * directed-assignment previously never inspected), never by reading the prose, so the verdict is
+ * content-blind by construction.
+ *
+ * The verdict is computed at READ time, never persisted at write time: a persisted "fresh"
+ * verdict would itself go stale — the exact defect class this FR closes.
+ */
+
+// One hour, mirroring DISPATCH_RANK_TTL_MS (worker-checkin.cjs) — the precedent bound for how
+// long dispatch-path state stays trustworthy without re-measurement.
+const PREMISE_FRESHNESS_BOUND_MS = 60 * 60 * 1000;
+
+// The instruction-carrying payload fields (the FR's measured absence list). A payload with any
+// of these is an instruction a worker is expected to ACT on, so its premise needs a stamp.
+const INSTRUCTION_BODY_KEYS = Object.freeze(['instruction', 'apply', 'body', 'steps']);
+
+/** True iff the payload carries a non-empty instruction body under any contract key. */
+function hasInstructionBody(payload) {
+  if (!payload || typeof payload !== 'object') return false;
+  return INSTRUCTION_BODY_KEYS.some((k) => {
+    const v = payload[k];
+    if (v == null) return false;
+    if (typeof v === 'string') return v.trim().length > 0;
+    if (Array.isArray(v)) return v.length > 0;
+    return typeof v === 'object' ? Object.keys(v).length > 0 : Boolean(v);
+  });
+}
+
+/**
+ * Assess an assignment payload's premise at claim-time.
+ *
+ * @param {object|null|undefined} payload - the WORK_ASSIGNMENT row's payload
+ * @param {number} [nowMs] - injected clock for tests
+ * @returns {{verdict:'no_instruction'|'fresh'|'stale'|'unstamped',
+ *            measuredAt:string|null, ageMs:number|null, directive:string|null}}
+ *   directive is non-null exactly when the worker must re-verify (stale/unstamped); it is the
+ *   worker-facing text and never claims any re-validation was performed.
+ */
+function assessInstructionPremise(payload, nowMs = Date.now()) {
+  if (!hasInstructionBody(payload)) {
+    return { verdict: 'no_instruction', measuredAt: null, ageMs: null, directive: null };
+  }
+  const raw = payload.premise_measured_at;
+  const measured = raw ? Date.parse(raw) : NaN;
+  if (!Number.isFinite(measured)) {
+    // A missing (or unreadable) stamp must never read as a passing one.
+    return {
+      verdict: 'unstamped',
+      measuredAt: null,
+      ageMs: null,
+      directive: 'RE-VERIFY BEFORE EXECUTING: this instruction carries no premise measurement '
+        + 'time — its factual premise is UNVERIFIED. Treat it as a lead, not a fact; check the '
+        + 'live state it describes before acting on it.',
+    };
+  }
+  const ageMs = nowMs - measured;
+  if (ageMs > PREMISE_FRESHNESS_BOUND_MS) {
+    const ageHours = (ageMs / (60 * 60 * 1000)).toFixed(1);
+    return {
+      verdict: 'stale',
+      measuredAt: new Date(measured).toISOString(),
+      ageMs,
+      directive: `RE-VERIFY BEFORE EXECUTING: this instruction's premise was measured ${ageHours}h `
+        + `ago (${new Date(measured).toISOString()}), beyond the `
+        + `${Math.round(PREMISE_FRESHNESS_BOUND_MS / 60000)}min freshness bound. Treat it as a `
+        + 'lead, not a fact; re-verify the live state it describes before acting on it.',
+    };
+  }
+  return { verdict: 'fresh', measuredAt: new Date(measured).toISOString(), ageMs, directive: null };
+}
+
+module.exports = {
+  PREMISE_FRESHNESS_BOUND_MS,
+  INSTRUCTION_BODY_KEYS,
+  hasInstructionBody,
+  assessInstructionPremise,
+};

--- a/lib/coordination/premise-freshness.cjs
+++ b/lib/coordination/premise-freshness.cjs
@@ -31,6 +31,13 @@
 // long dispatch-path state stays trustworthy without re-measurement.
 const PREMISE_FRESHNESS_BOUND_MS = 60 * 60 * 1000;
 
+// A measurement can honestly sit slightly in the future (clock skew between the measuring seat
+// and the claiming seat); beyond this, the stamp asserts a measurement that has not happened
+// yet, which certifies nothing — without this bound, one future-dated stamp (a tz-naive local
+// string parses as LOCAL time — enough on a US-Eastern seat) silences the guard entirely by
+// making ageMs negative, which passes every staleness test forever. Found by SECURITY probe.
+const CLOCK_SKEW_TOLERANCE_MS = 5 * 60 * 1000;
+
 // The instruction-carrying payload fields (the FR's measured absence list). A payload with any
 // of these is an instruction a worker is expected to ACT on, so its premise needs a stamp.
 const INSTRUCTION_BODY_KEYS = Object.freeze(['instruction', 'apply', 'body', 'steps']);
@@ -52,7 +59,7 @@ function hasInstructionBody(payload) {
  *
  * @param {object|null|undefined} payload - the WORK_ASSIGNMENT row's payload
  * @param {number} [nowMs] - injected clock for tests
- * @returns {{verdict:'no_instruction'|'fresh'|'stale'|'unstamped',
+ * @returns {{verdict:'no_instruction'|'fresh'|'stale'|'unstamped'|'future',
  *            measuredAt:string|null, ageMs:number|null, directive:string|null}}
  *   directive is non-null exactly when the worker must re-verify (stale/unstamped); it is the
  *   worker-facing text and never claims any re-validation was performed.
@@ -75,6 +82,18 @@ function assessInstructionPremise(payload, nowMs = Date.now()) {
     };
   }
   const ageMs = nowMs - measured;
+  if (ageMs < -CLOCK_SKEW_TOLERANCE_MS) {
+    // A stamp from the future is not evidence of freshness — it is evidence the stamp is wrong.
+    return {
+      verdict: 'future',
+      measuredAt: new Date(measured).toISOString(),
+      ageMs,
+      directive: 'RE-VERIFY BEFORE EXECUTING: this instruction\'s premise measurement time is in '
+        + `the FUTURE (${new Date(measured).toISOString()}) — the stamp is wrong (clock skew or a `
+        + 'timezone-naive timestamp), so the premise is UNVERIFIED. Treat it as a lead, not a '
+        + 'fact; check the live state it describes before acting on it.',
+    };
+  }
   if (ageMs > PREMISE_FRESHNESS_BOUND_MS) {
     const ageHours = (ageMs / (60 * 60 * 1000)).toFixed(1);
     return {
@@ -92,6 +111,7 @@ function assessInstructionPremise(payload, nowMs = Date.now()) {
 
 module.exports = {
   PREMISE_FRESHNESS_BOUND_MS,
+  CLOCK_SKEW_TOLERANCE_MS,
   INSTRUCTION_BODY_KEYS,
   hasInstructionBody,
   assessInstructionPremise,

--- a/lib/coordinator/dispatch.cjs
+++ b/lib/coordinator/dispatch.cjs
@@ -55,6 +55,11 @@ const { getActiveAdamId } = require('./adam-identity.cjs');
 // imported from lib/fleet/drain-set-registry.js at the call site (registry-reader repoint).
 const { getActiveSolomonId } = require('./solomon-identity.cjs');
 const { getActiveCoordinatorId } = require('./resolve.cjs');
+// SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 (FR-3): shared premise-freshness contract — the same
+// module the claim-time reader (lib/checkin/steps/directed-assignment.cjs) consumes, so the
+// write-side detection and the read-side verdict can never disagree on what counts as an
+// instruction body. LEAF import: premise-freshness.cjs requires nothing.
+const { hasInstructionBody } = require('../coordination/premise-freshness.cjs');
 
 // Sentinel target → role, for the target-drain warn. 'broadcast' (all roles) resolves to
 // null: no single drain set applies, so the check stays silent.
@@ -342,6 +347,46 @@ async function stampEffortRecommendation(supabase, row, logger = console) {
     row.payload = { ...payload, effort_recommendation: rec.effort, effort_recommendation_reason: rec.reason };
   } catch (e) {
     logger && logger.warn && logger.warn(`[dispatch] effort recommendation skipped: ${e.message}`);
+  }
+}
+
+/**
+ * SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 (FR-3): premise-measurement contract at this same
+ * choke point, sibling to stampEffortRecommendation. An instruction body (payload.instruction /
+ * apply / body / steps) carries factual premises a worker will act on, and until this SD nothing
+ * on the dispatch path bounded or even recorded WHEN those premises were measured — every
+ * 'freshness' check here measures the RECIPIENT, never the claim inside the instruction.
+ *
+ * WHAT THIS STAMP DOES — normalization only, never fabrication:
+ *   - an unparseable premise_measured_at is STRIPPED (with a loud warn): absent reads as
+ *     UNVERIFIED at claim-time, which is the safe direction; parseable garbage reading as
+ *     anything at all is not.
+ *   - an instruction body with NO stamp is warned about but passed through unstamped. It is
+ *     DELIBERATELY NOT defaulted to now: this function runs at SEND time, and a send-time stamp
+ *     certifies only that the message is new — exactly the false comfort this defect is made of.
+ *     The read side (lib/checkin/steps/directed-assignment.cjs) treats the absence as
+ *     unverified and surfaces RE-VERIFY-BEFORE-EXECUTING to the worker.
+ * The freshness VERDICT is computed at claim-time, never persisted here — a persisted verdict
+ * would itself go stale, which is the defect class this FR closes.
+ * @private
+ */
+function stampPremiseMeasurement(row, logger = console) {
+  try {
+    if (row.message_type !== 'WORK_ASSIGNMENT') return;
+    const payload = row.payload && typeof row.payload === 'object' ? row.payload : null;
+    if (!payload || !hasInstructionBody(payload)) return;
+    const raw = payload.premise_measured_at;
+    if (raw == null) {
+      logger && logger.warn && logger.warn('[dispatch] WORK_ASSIGNMENT carries an instruction body with NO premise_measured_at — the worker will be told to RE-VERIFY before executing. If the premise was just measured, stamp the MEASUREMENT time (never the send time).');
+      return;
+    }
+    if (!Number.isFinite(Date.parse(raw))) {
+      const { premise_measured_at: _dropped, ...rest } = payload;
+      row.payload = rest;
+      logger && logger.warn && logger.warn(`[dispatch] premise_measured_at ${JSON.stringify(raw)} is unparseable — stripped so the worker treats the premise as UNVERIFIED rather than trusting a garbage stamp.`);
+    }
+  } catch (e) {
+    logger && logger.warn && logger.warn(`[dispatch] premise measurement stamp skipped: ${e.message}`);
   }
 }
 
@@ -1090,6 +1135,11 @@ async function insertCoordinationRow(supabase, row, opts = {}) {
   // the dispatch is only prose and, past the recency window, vanishes entirely. Preempt-scoped and
   // fail-soft; routine dispatches are byte-identical to before.
   await stampReleaseRequest(supabase, row, logger);
+  // SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 (FR-3): premise-measurement normalization for
+  // instruction-carrying WORK_ASSIGNMENTs — strips an unparseable premise_measured_at (absent
+  // reads as UNVERIFIED at claim-time, garbage must not read as anything) and warns when an
+  // instruction body ships with no measurement stamp. NEVER defaults the stamp to send time.
+  stampPremiseMeasurement(row, logger);
   // FR-2 (SD-LEO-INFRA-THREE-WAY-COMMS-RELIABILITY-001-C): stamp the protocol version on every row
   // through the choke point so a stale long-lived-singleton reader can detect a skew instead of
   // silently misreading it. Only stamps INTO an existing payload object — never invents one (some
@@ -1265,6 +1315,7 @@ module.exports = {
   stampEffortRecommendation,
   stampModelRecommendation, // SD-LEO-INFRA-OPERATIONALIZE-FABLE-USE-001 — exported for TS-4/TS-5/TS-6 fixtures
   stampReleaseRequest, // SD-LEO-INFRA-FULL-UTILISATION-RECOVERY-001 FR-2 — exported for unit fixtures
+  stampPremiseMeasurement, // SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 FR-3 — exported for unit fixtures
   isTerminalSdStatus,
   isTerminalQfStatus,
   assertSdDispatchable,

--- a/scripts/defer-quick-fix.js
+++ b/scripts/defer-quick-fix.js
@@ -19,8 +19,15 @@
 
 import { createClient } from '@supabase/supabase-js';
 import dotenv from 'dotenv';
+import { createRequire } from 'node:module';
 import { isMainModule } from '../lib/utils/is-main-module.js';
 import { checkHoldStamp, buildProvenancedStamp, logHoldStateViolation } from '../lib/governance/hold-state-contract.js';
+
+// SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 (FR-2): the SAME predicate the hand-time read guard
+// runs (worker-checkin.cjs isAutoStartableQF -> isChairmanGatedQF). Reused verbatim rather than
+// re-derived so the writer can only accept marker combinations the reader actually excludes.
+const require_ = createRequire(import.meta.url);
+const { isChairmanGatedQF } = require_('../lib/fleet/qf-gated-hold.cjs');
 
 dotenv.config();
 
@@ -64,6 +71,44 @@ export function validateNotBefore(value) {
   return { valid: true, iso: new Date(parsed).toISOString() };
 }
 
+/**
+ * SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 (FR-2): a deliberate release is only valid when it
+ * persists a marker the hand-time guard (isAutoStartableQF) actually reads. Two such markers
+ * exist, and this classifier accepts EXACTLY those two — a marker combination the guard cannot
+ * see (e.g. owner='worker' + release_condition) is refused, because writing it would feel like
+ * a hold while excluding nothing:
+ *
+ *   time_gated   not_before in ISO form            (isAutoStartableQF's not_before gate)
+ *   event_gated  owner='chairman' + release_condition  (isChairmanGatedQF, reused verbatim)
+ *
+ * The refusal NAMES the missing columns (never a silent completion): before this SD, a worker
+ * whose blocker had no natural timestamp had no structured verb at all — the rationale went
+ * into verification_notes as prose, the stale-claim sweep later cleared the claim with no
+ * marker (correctly — a swept claim is not a deliberate release), and the row returned to the
+ * queue fully claimable by the next seat that also could not satisfy the blocking condition.
+ */
+export function classifyDeliberateHoldMarker({ notBefore, owner, releaseCondition } = {}) {
+  if (notBefore) {
+    const v = validateNotBefore(notBefore);
+    if (!v.valid) return { valid: false, error: v.error };
+    return { valid: true, mode: 'time_gated', iso: v.iso };
+  }
+  if (isChairmanGatedQF({ owner, release_condition: releaseCondition })) {
+    return { valid: true, mode: 'event_gated', iso: null };
+  }
+  const ownerShown = owner && String(owner).trim() ? `'${String(owner).trim()}'` : 'NULL';
+  const condShown = releaseCondition && String(releaseCondition).trim() ? 'present' : 'NULL';
+  return {
+    valid: false,
+    code: 'DELIBERATE_RELEASE_MARKER_MISSING',
+    error: 'deliberate release refused: no guard-visible hold marker. Missing columns: '
+      + 'not_before (time-gated hold) — or, for an event-gated hold, owner=\'chairman\' '
+      + `(owner is ${ownerShown}) + release_condition (${condShown}). `
+      + 'A rationale recorded only as prose is invisible at hand-time; persist the marker '
+      + 'isAutoStartableQF reads (SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 FR-2).',
+  };
+}
+
 function displayHelp() {
   console.log(`
 Defer Quick-Fix — durable time-gated defer (SD-LEO-FIX-QUICK-FIXES-NEEDS-001)
@@ -72,9 +117,18 @@ Usage:
   node scripts/defer-quick-fix.js <QF-ID> --not-before <ISO-timestamp> [--reopen]
     [--reason <text>] [--owner <text>] [--release-condition <text>]
 
+  Event-gated form (SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 FR-2 — a blocker with no
+  natural timestamp; excluded from the worker lane via the chairman-gated hold marker):
+  node scripts/defer-quick-fix.js <QF-ID> --owner chairman \\
+    --release-condition <text> --reason <text> [--reopen]
+
 Options:
-  --not-before <ts>   Required. ISO-8601 timestamp. The QF is not claimable/
+  --not-before <ts>   ISO-8601 timestamp. The QF is not claimable/
                       auto-startable by any picker until this time passes.
+                      Required unless the event-gated form (owner='chairman'
+                      + --release-condition + --reason) is used instead — a
+                      deliberate release MUST persist one of the two markers
+                      the hand-time guard reads, or it is refused loudly.
   --reopen            Also set status='open' (use when clearing a manual
                       status='escalated' defer workaround).
   --reason <text>     Hold-state contract stamp (SD-LEO-INFRA-HOLD-STATE-CONTRACT-001):
@@ -102,15 +156,28 @@ Example:
 const FAR_FUTURE_PARK_DAYS = 30;
 
 export async function deferQuickFix(qfId, notBefore, { reopen = false, reason, owner, releaseCondition, writingSessionId, supabaseClient = null } = {}) {
-  const validation = validateNotBefore(notBefore);
-  if (!validation.valid) {
-    throw new Error(validation.error);
+  // SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 (FR-2): accept exactly the two guard-visible marker
+  // shapes; refuse everything else LOUDLY, naming the missing columns, before any DB write.
+  const marker = classifyDeliberateHoldMarker({ notBefore, owner, releaseCondition });
+  if (!marker.valid) {
+    const err = new Error(marker.error);
+    if (marker.code) err.code = marker.code;
+    throw err;
   }
 
-  const daysOut = (Date.parse(validation.iso) - Date.now()) / (24 * 60 * 60 * 1000);
-  if (daysOut > FAR_FUTURE_PARK_DAYS && !(releaseCondition && String(releaseCondition).trim())) {
-    const err = new Error(`--not-before is ${Math.round(daysOut)} days out (>${FAR_FUTURE_PARK_DAYS}) and requires --release-condition -- a far-future park with no release trigger never resurfaces (QF-20260720-137)`);
-    err.code = 'FAR_FUTURE_PARK_REQUIRES_RELEASE_CONDITION';
+  if (marker.mode === 'time_gated') {
+    const daysOut = (Date.parse(marker.iso) - Date.now()) / (24 * 60 * 60 * 1000);
+    if (daysOut > FAR_FUTURE_PARK_DAYS && !(releaseCondition && String(releaseCondition).trim())) {
+      const err = new Error(`--not-before is ${Math.round(daysOut)} days out (>${FAR_FUTURE_PARK_DAYS}) and requires --release-condition -- a far-future park with no release trigger never resurfaces (QF-20260720-137)`);
+      err.code = 'FAR_FUTURE_PARK_REQUIRES_RELEASE_CONDITION';
+      throw err;
+    }
+  } else if (!(reason && String(reason).trim())) {
+    // Event-gated: owner + release_condition are guaranteed by the classifier; the rationale
+    // itself must ALSO land structured — an event hold whose "why" exists only as prose is the
+    // exact half-marker state FR-2 exists to refuse.
+    const err = new Error('event-gated release refused: missing column: reason. An owner=\'chairman\' + release_condition hold must carry its rationale in the reason column, not as prose (SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 FR-2).');
+    err.code = 'DELIBERATE_RELEASE_MARKER_MISSING';
     throw err;
   }
 
@@ -119,13 +186,19 @@ export async function deferQuickFix(qfId, notBefore, { reopen = false, reason, o
     process.env.SUPABASE_SERVICE_ROLE_KEY
   );
 
-  const holdCheck = checkHoldStamp({ reason, owner, review_at: validation.iso, release_condition: releaseCondition });
-  if (!holdCheck.ok && holdCheck.mode === 'observe') {
-    await logHoldStateViolation(supabase, {
-      surface: 'quick_fix_defer',
-      stamp: { reason, owner, review_at: validation.iso, release_condition: releaseCondition },
-      errors: holdCheck.errors,
-    });
+  // Hold-state contract check stays scoped to the time-gated path (byte-identical to before this
+  // SD — every pre-existing write was time-gated). The event-gated arm cannot satisfy review_at
+  // by construction (its release trigger is the condition, not a timestamp) and already enforces
+  // {reason, owner, release_condition} unconditionally above — stricter than observe mode.
+  if (marker.mode === 'time_gated') {
+    const holdCheck = checkHoldStamp({ reason, owner, review_at: marker.iso, release_condition: releaseCondition });
+    if (!holdCheck.ok && holdCheck.mode === 'observe') {
+      await logHoldStateViolation(supabase, {
+        surface: 'quick_fix_defer',
+        stamp: { reason, owner, review_at: marker.iso, release_condition: releaseCondition },
+        errors: holdCheck.errors,
+      });
+    }
   }
   const stamped = buildProvenancedStamp({ reason, owner, release_condition: releaseCondition }, writingSessionId);
 
@@ -134,7 +207,8 @@ export async function deferQuickFix(qfId, notBefore, { reopen = false, reason, o
   // is no other way out, because lib/quick-fix-claim.mjs exports claimQuickFix and no releaseQuickFix,
   // and `npm run sd:release` reports "no SD claimed" for a QF since it only queries
   // strategic_directives_v2. Clearing the authoritative column here is the whole release path.
-  const update = { not_before: validation.iso, claiming_session_id: null };
+  const update = { claiming_session_id: null };
+  if (marker.mode === 'time_gated') update.not_before = marker.iso;
   if (reopen) update.status = 'open';
   if (stamped.reason) update.reason = stamped.reason;
   if (stamped.owner) update.owner = stamped.owner;
@@ -210,7 +284,9 @@ async function main() {
       releaseCondition: parsed.releaseCondition,
       writingSessionId: process.env.CLAUDE_SESSION_ID || null,
     });
-    console.log(`✅ ${result.id}: not_before=${result.not_before}, status=${result.status}`);
+    console.log(result.not_before
+      ? `✅ ${result.id}: not_before=${result.not_before}, status=${result.status}`
+      : `✅ ${result.id}: event-gated hold (owner=${result.owner}, release_condition=${result.release_condition}), status=${result.status}`);
     process.exitCode = 0;
   } catch (err) {
     console.error(`❌ ${err.message}`);

--- a/scripts/defer-quick-fix.js
+++ b/scripts/defer-quick-fix.js
@@ -91,7 +91,12 @@ export function classifyDeliberateHoldMarker({ notBefore, owner, releaseConditio
   if (notBefore) {
     const v = validateNotBefore(notBefore);
     if (!v.valid) return { valid: false, error: v.error };
-    return { valid: true, mode: 'time_gated', iso: v.iso };
+    // A PAST not_before is still accepted — it is the deliberate un-park verb (often with
+    // --reopen) — but it excludes NOTHING at hand-time, so it must never masquerade as a hold.
+    // The adversarial review reproduced the trap: a mistyped or tz-naive-parsed-to-past
+    // timestamp printed a clean success while the row stayed immediately re-handable.
+    const inPast = Date.parse(v.iso) <= Date.now();
+    return { valid: true, mode: 'time_gated', iso: v.iso, inPast };
   }
   if (isChairmanGatedQF({ owner, release_condition: releaseCondition })) {
     return { valid: true, mode: 'event_gated', iso: null };
@@ -166,6 +171,9 @@ export async function deferQuickFix(qfId, notBefore, { reopen = false, reason, o
   }
 
   if (marker.mode === 'time_gated') {
+    if (marker.inPast) {
+      console.warn(`⚠️  not_before ${marker.iso} is in the PAST — this write holds NOTHING at hand-time; the row is immediately claimable again. If you meant to hold, supply a future timestamp (or the event-gated form); if you meant to un-park, this is the expected effect.`);
+    }
     const daysOut = (Date.parse(marker.iso) - Date.now()) / (24 * 60 * 60 * 1000);
     if (daysOut > FAR_FUTURE_PARK_DAYS && !(releaseCondition && String(releaseCondition).trim())) {
       const err = new Error(`--not-before is ${Math.round(daysOut)} days out (>${FAR_FUTURE_PARK_DAYS}) and requires --release-condition -- a far-future park with no release trigger never resurfaces (QF-20260720-137)`);

--- a/tests/unit/checkin/premise-freshness-fr3.test.js
+++ b/tests/unit/checkin/premise-freshness-fr3.test.js
@@ -59,6 +59,21 @@ describe('assessInstructionPremise — the claim-time verdict', () => {
     expect(r.directive).not.toBeNull();
   });
 
+  it('a FUTURE-DATED stamp is surfaced, never fresh — one wrong stamp must not silence the guard forever (SECURITY probe)', () => {
+    // Without the future bound, ageMs goes negative and passes every staleness test — a
+    // tz-naive local timestamp on a US-Eastern seat is enough to reach this state honestly.
+    const r = assessInstructionPremise({ instruction: 'apply migration X', premise_measured_at: new Date(NOW + 24 * 3600_000).toISOString() }, NOW);
+    expect(r.verdict).toBe('future');
+    expect(r.directive).toMatch(/RE-VERIFY BEFORE EXECUTING/);
+    expect(r.directive).toMatch(/UNVERIFIED/);
+  });
+
+  it('NEGATIVE: slight clock skew (within tolerance) still reads fresh — the future bound must not refuse honest stamps', () => {
+    const r = assessInstructionPremise({ instruction: 'apply migration X', premise_measured_at: new Date(NOW + 2 * 60_000).toISOString() }, NOW);
+    expect(r.verdict).toBe('fresh');
+    expect(r.directive).toBeNull();
+  });
+
   it('every instruction-body key the FR names is detected: instruction, apply, body, steps', () => {
     for (const key of ['instruction', 'apply', 'body', 'steps']) {
       expect(hasInstructionBody({ [key]: 'do the thing' }), key).toBe(true);

--- a/tests/unit/checkin/premise-freshness-fr3.test.js
+++ b/tests/unit/checkin/premise-freshness-fr3.test.js
@@ -1,0 +1,211 @@
+/**
+ * SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 (FR-3) — a dispatch instruction carrying a factual
+ * premise must stamp the MEASUREMENT time and default to re-verify.
+ *
+ * THE INCIDENT: an 08-05 dispatch closed with an apply-instruction ("drive_reports returns
+ * PGRST205, prepend-commit-apply") that was FALSE by read-time — the table had been applied —
+ * and a worker following it literally would have re-applied a live permission-class table.
+ * Every 'freshness' check on the dispatch path measures the RECIPIENT (heartbeats, rank TTLs);
+ * none measured the premise inside the instruction, and directed-assignment carried ZERO
+ * handling of an instruction body.
+ *
+ * NOT A PROSE RE-VALIDATOR — the contract is content-blind by construction (key presence, never
+ * prose), and the content-blindness is asserted below as a control: claiming otherwise would be
+ * a guard asserting what it never measured.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {
+  assessInstructionPremise, hasInstructionBody, PREMISE_FRESHNESS_BOUND_MS,
+} = require('../../../lib/coordination/premise-freshness.cjs');
+const { stampPremiseMeasurement } = require('../../../lib/coordinator/dispatch.cjs');
+const { resolveCheckin } = require('../../../scripts/worker-checkin.cjs');
+
+const NOW = Date.now();
+const minutesAgo = (m) => new Date(NOW - m * 60_000).toISOString();
+const silent = { warn: () => {}, error: () => {}, log: () => {} };
+
+describe('assessInstructionPremise — the claim-time verdict', () => {
+  it('no instruction body → no verdict, no directive (routine dispatches stay noise-free)', () => {
+    const r = assessInstructionPremise({ sd_key: 'SD-X', kind: 'resume', reason: 'cold-recovery' }, NOW);
+    expect(r).toMatchObject({ verdict: 'no_instruction', directive: null });
+  });
+
+  it('fresh premise (within the bound) → presented normally, no re-verify noise', () => {
+    const r = assessInstructionPremise({ instruction: 'apply migration X', premise_measured_at: minutesAgo(10) }, NOW);
+    expect(r.verdict).toBe('fresh');
+    expect(r.directive).toBeNull();
+  });
+
+  it('stale premise (older than the bound) → explicit RE-VERIFY directive, not current fact', () => {
+    const r = assessInstructionPremise({ instruction: 'apply migration X', premise_measured_at: minutesAgo(180) }, NOW);
+    expect(r.verdict).toBe('stale');
+    expect(r.directive).toMatch(/RE-VERIFY BEFORE EXECUTING/);
+    expect(r.directive).toMatch(/lead, not a fact/);
+  });
+
+  it('ABSENT stamp with an instruction body → UNVERIFIED and surfaced, never fresh', () => {
+    const r = assessInstructionPremise({ instruction: 'apply migration X' }, NOW);
+    expect(r.verdict).toBe('unstamped');
+    expect(r.directive).toMatch(/RE-VERIFY BEFORE EXECUTING/);
+    expect(r.directive).toMatch(/UNVERIFIED/);
+  });
+
+  it('an UNPARSEABLE stamp is treated as absent — garbage must not read as a passing stamp', () => {
+    const r = assessInstructionPremise({ instruction: 'apply migration X', premise_measured_at: 'three days ago' }, NOW);
+    expect(r.verdict).toBe('unstamped');
+    expect(r.directive).not.toBeNull();
+  });
+
+  it('every instruction-body key the FR names is detected: instruction, apply, body, steps', () => {
+    for (const key of ['instruction', 'apply', 'body', 'steps']) {
+      expect(hasInstructionBody({ [key]: 'do the thing' }), key).toBe(true);
+    }
+    expect(hasInstructionBody({ steps: ['a', 'b'] })).toBe(true);
+    expect(hasInstructionBody({ instruction: '   ' }), 'blank strings are not a body').toBe(false);
+    expect(hasInstructionBody({ sd_key: 'SD-X' })).toBe(false);
+    expect(hasInstructionBody(null)).toBe(false);
+  });
+
+  it('CONTENT-BLIND CONTROL: the verdict is identical for arbitrary instruction prose — no re-validation is attempted or claimed', () => {
+    const stamps = { premise_measured_at: minutesAgo(180) };
+    const a = assessInstructionPremise({ instruction: 'drive_reports returns PGRST205, prepend-commit-apply', ...stamps }, NOW);
+    const b = assessInstructionPremise({ instruction: 'entirely different claim about different state', ...stamps }, NOW);
+    expect(a.verdict).toBe(b.verdict);
+    expect(a.directive).toBe(b.directive);
+  });
+});
+
+describe('measurement time vs send time — the stamp the defect is made of', () => {
+  it('a FRESHLY-SENT row with a STALE measurement is stale: the verdict follows measurement time', () => {
+    // Send time (row.created_at) plays no part in the verdict — pass a payload whose stamp is
+    // old while "now" is the moment of a brand-new send.
+    const r = assessInstructionPremise({ instruction: 'x', premise_measured_at: minutesAgo(3 * 24 * 60) }, NOW);
+    expect(r.verdict).toBe('stale');
+  });
+
+  it('an OLD send with a FRESH measurement is fresh: recency of the message proves nothing either way', () => {
+    const r = assessInstructionPremise({ instruction: 'x', premise_measured_at: minutesAgo(5) }, NOW);
+    expect(r.verdict).toBe('fresh');
+  });
+});
+
+describe('stampPremiseMeasurement — the dispatch choke-point write side', () => {
+  it('preserves a caller-supplied measurement stamp byte-for-byte (never overwrites with now)', () => {
+    const measured = minutesAgo(30);
+    const row = { message_type: 'WORK_ASSIGNMENT', payload: { instruction: 'x', premise_measured_at: measured } };
+    stampPremiseMeasurement(row, silent);
+    expect(row.payload.premise_measured_at).toBe(measured);
+  });
+
+  it('NEVER fabricates a stamp for an unstamped instruction — a send-time default is the false comfort this defect is made of', () => {
+    const row = { message_type: 'WORK_ASSIGNMENT', payload: { instruction: 'x' } };
+    stampPremiseMeasurement(row, silent);
+    expect(row.payload).not.toHaveProperty('premise_measured_at');
+  });
+
+  it('strips an unparseable stamp so it reads as UNVERIFIED downstream, and says so', () => {
+    const warns = [];
+    const row = { message_type: 'WORK_ASSIGNMENT', payload: { instruction: 'x', premise_measured_at: 'yesterday-ish' } };
+    stampPremiseMeasurement(row, { warn: (m) => warns.push(m) });
+    expect(row.payload).not.toHaveProperty('premise_measured_at');
+    expect(warns.join(' ')).toMatch(/unparseable/);
+  });
+
+  it('leaves non-WORK_ASSIGNMENT rows and instruction-less payloads untouched', () => {
+    const info = { message_type: 'INFO', payload: { body: 'status prose', premise_measured_at: 'garbage' } };
+    stampPremiseMeasurement(info, silent);
+    expect(info.payload.premise_measured_at).toBe('garbage');
+    const plain = { message_type: 'WORK_ASSIGNMENT', payload: { sd_key: 'SD-X' } };
+    stampPremiseMeasurement(plain, silent);
+    expect(plain.payload).toEqual({ sd_key: 'SD-X' });
+  });
+});
+
+/**
+ * Claim-time surfacing through the REAL pipeline (same harness as
+ * work-assignment-receipt-lane.test.js) — the directive must reach the worker on the
+ * claimed_assignment result, leading the message, or the whole contract is inert.
+ */
+function fakeSb({ sdRow, assignedKey }) {
+  return {
+    rpc: () => Promise.resolve({ data: { success: true }, error: null }),
+    from(table) {
+      const filters = {};
+      return {
+        select() { return this; }, gte() { return this; },
+        order() { return this; }, limit() { return this; }, is() { return this; },
+        eq(col, val) { filters[col] = val; return this; },
+        maybeSingle() {
+          if (table === 'claude_sessions') return Promise.resolve({ data: { metadata: { role: 'worker' }, sd_key: null }, error: null });
+          if (table === 'strategic_directives_v2') {
+            if (filters.sd_key !== assignedKey || !sdRow) return Promise.resolve({ data: null, error: null });
+            return Promise.resolve({ data: structuredClone(sdRow), error: null });
+          }
+          return Promise.resolve({ data: null, error: null });
+        },
+        insert() { return Promise.resolve({ error: null }); },
+        update() { return { eq() { return Promise.resolve({ error: null }); } }; },
+      };
+    },
+  };
+}
+
+async function runDirected(payloadExtra) {
+  const assignedKey = 'SD-PREMISE-001';
+  const sb = fakeSb({
+    assignedKey,
+    sdRow: { status: 'in_progress', sd_type: 'feature', sd_key: assignedKey, target_application: null, metadata: {} },
+  });
+  const ws = require('../../../lib/fleet/worker-status.cjs');
+  const orig = ws.getMessagesForSession;
+  ws.getMessagesForSession = async () => [{
+    id: 'msg-premise-1',
+    message_type: 'WORK_ASSIGNMENT',
+    payload: { assigned_sd: assignedKey, ...payloadExtra },
+    created_at: new Date().toISOString(), // always a FRESH send — the verdict must not care
+  }];
+  try {
+    return await resolveCheckin(sb, 'sess-premise-1', { getCoordinator: async () => null });
+  } finally {
+    ws.getMessagesForSession = orig;
+  }
+}
+
+describe('FR-3 at claim-time — the worker is told to re-verify, or nothing is added', () => {
+  it('POSITIVE: a freshly-SENT assignment with a stale MEASUREMENT surfaces the re-verify directive', async () => {
+    const res = await runDirected({ instruction: 'drive_reports returns PGRST205 — prepend-commit-apply it', premise_measured_at: minutesAgo(3 * 24 * 60) });
+    expect(res.action).toBe('claimed_assignment');
+    expect(res.premise_reverify).toMatchObject({ verdict: 'stale' });
+    expect(res.message).toMatch(/^RE-VERIFY BEFORE EXECUTING/);
+  });
+
+  it('ABSENT-STAMP: an instruction with no premise stamp is surfaced as unverified, never fresh', async () => {
+    const res = await runDirected({ instruction: 'apply the pending migration' });
+    expect(res.action).toBe('claimed_assignment');
+    expect(res.premise_reverify).toMatchObject({ verdict: 'unstamped' });
+    expect(res.message).toMatch(/^RE-VERIFY BEFORE EXECUTING/);
+  });
+
+  it('NEGATIVE: a within-bound measurement dispatches normally with zero re-verify noise', async () => {
+    const res = await runDirected({ instruction: 'apply the pending migration', premise_measured_at: minutesAgo(10) });
+    expect(res.action).toBe('claimed_assignment');
+    expect(res.premise_reverify).toBeUndefined();
+    expect(res.message).not.toMatch(/RE-VERIFY/);
+  });
+
+  it('NEGATIVE: an ordinary assignment with no instruction body is untouched', async () => {
+    const res = await runDirected({});
+    expect(res.action).toBe('claimed_assignment');
+    expect(res.premise_reverify).toBeUndefined();
+    expect(res.message).not.toMatch(/RE-VERIFY/);
+  });
+});
+
+describe('the bound itself', () => {
+  it('mirrors the dispatch-path precedent (1h) and is exported for consumers, not re-derived', () => {
+    expect(PREMISE_FRESHNESS_BOUND_MS).toBe(60 * 60 * 1000);
+  });
+});

--- a/tests/unit/checkin/resume-sees-both-claim-kinds-fr1.test.js
+++ b/tests/unit/checkin/resume-sees-both-claim-kinds-fr1.test.js
@@ -1,0 +1,143 @@
+/**
+ * SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 FR-1 — resume must see BOTH claim kinds.
+ *
+ * resume is step 5 of the first-truthy-wins ladder (lib/checkin/pipeline.cjs), sitting ABOVE every
+ * acquisition tier, so WHAT IT CAN SEE decides whether a seat can be stacked. Its `!ctx.mySd`
+ * branch asked findOwnSdClaim — strategic_directives_v2 ONLY, .limit(1), never quick_fixes — so a
+ * seat whose mirror (claude_sessions.sd_key) is NULL while it authoritatively holds a QF was
+ * invisible: resume returned undefined and the ladder fell through to merged-pool-self-claim and
+ * self-claim-qf, handing MORE vehicles onto a seat that already deliberately held one.
+ *
+ * MEASURED LIVE when this shipped, whole population not a sample (n=2): 2 of 2 quick_fixes carrying
+ * an authoritative claiming_session_id had a NULL mirror — 100% in the stacking-reachable state.
+ *
+ * These drive the REAL step through the REAL pipeline runner with only the DB stubbed, following
+ * tests/unit/checkin/canary-claim-fence.test.js. Asserting the predicate in isolation would prove
+ * the module while leaving the LADDER — the thing that actually stacks — unproven.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+
+const resume = require('../../../lib/checkin/steps/resume.cjs');
+const { runSteps } = require('../../../lib/checkin/pipeline.cjs');
+
+const ME = 'sess-under-test';
+
+/**
+ * Supabase double covering BOTH access shapes resume reaches:
+ *   findOwnSdClaim — .from(t).select().eq().eq().limit(1).maybeSingle()
+ *   getMyClaims    — .from(t).select().eq('claiming_session_id', id)  [awaited directly]
+ * A builder that is BOTH thenable and chainable, so neither caller needs a bespoke stub.
+ */
+function makeSb({ sdRows = [], qfRows = [], sdError = null, qfError = null } = {}) {
+  const calls = { tables: [] };
+  const api = {
+    from(table) { calls.tables.push(table); api._t = table; return api; },
+    select() { return api; },
+    eq() { return api; },
+    limit() { return api; },
+    maybeSingle() {
+      // findOwnSdClaim's shape: it also filters is_working_on=true, which the rows encode.
+      const row = sdRows.find((r) => r.is_working_on === true) || null;
+      return Promise.resolve({ data: row, error: sdError });
+    },
+    then(resolve, reject) {
+      const isQf = api._t === 'quick_fixes';
+      const payload = isQf ? { data: qfRows, error: qfError } : { data: sdRows, error: sdError };
+      return Promise.resolve(payload).then(resolve, reject);
+    },
+  };
+  api._calls = calls;
+  return api;
+}
+
+function makeCtx({ sb, mySd = null } = {}) {
+  return {
+    sb,
+    sessionId: ME,
+    opts: {},
+    mySd,
+    sessionRole: null,
+    sessionMetadata: {},
+    base: { callsign: null },
+    helpers: {
+      ws: { getMessagesForSession: async () => [], DIRECTIVE_KINDS: [] },
+      confirmRowGone: async () => false,
+      selfHealStaleClaim: async () => {},
+      findOwnSdClaim: async (sb2, sid) => {
+        const { data } = await sb2.from('strategic_directives_v2').select('sd_key')
+          .eq('claiming_session_id', sid).eq('is_working_on', true).limit(1).maybeSingle();
+        return data ? data.sd_key : null;
+      },
+      healOwnClaimPointer: async () => true,
+      extractDirectedSd: () => null,
+      ASSIGNMENT_RECENCY_WINDOW_MS: 86_400_000,
+    },
+  };
+}
+
+/** A stand-in for every acquisition tier BELOW resume. If the ladder reaches it, the seat got stacked. */
+function stackingTier(hits) {
+  return { name: 'acquisition-tier-below-resume', async run() { hits.push('handed'); return { action: 'self_claimed_qf', qf: 'QF-EXTRA' }; } };
+}
+
+describe('FR-1 — a seat holding a QF is not handed more work', () => {
+  it('POSITIVE: QF held authoritatively + NULL mirror resolves to resume, and NOTHING below runs', async () => {
+    const hits = [];
+    const sb = makeSb({ sdRows: [], qfRows: [{ id: 'QF-20260807-999', status: 'open' }] });
+    const res = await runSteps([resume, stackingTier(hits)], makeCtx({ sb }));
+    expect(res).toBeTruthy();
+    expect(res.action).toBe('resume');
+    expect(res.sd).toBe('QF-20260807-999');
+    // The whole point: the ladder must NOT continue into an acquisition tier.
+    expect(hits).toEqual([]);
+  });
+
+  it('NEGATIVE CONTROL: a seat holding NOTHING still falls through and receives its ordinary hand', async () => {
+    // Without this, a guard that refuses every hand would pass the positive arm and halt the fleet.
+    const hits = [];
+    const sb = makeSb({ sdRows: [], qfRows: [] });
+    const res = await runSteps([resume, stackingTier(hits)], makeCtx({ sb }));
+    expect(res.action).toBe('self_claimed_qf');
+    expect(hits).toEqual(['handed']);
+  });
+
+  it('an authoritatively-held SD with a NULL mirror still resumes — no regression to the SD path', async () => {
+    const hits = [];
+    const sb = makeSb({ sdRows: [{ sd_key: 'SD-X-001', is_working_on: true, status: 'active' }], qfRows: [] });
+    const res = await runSteps([resume, stackingTier(hits)], makeCtx({ sb }));
+    expect(res.action).toBe('resume');
+    expect(res.sd).toBe('SD-X-001');
+    expect(hits).toEqual([]);
+  });
+
+  it('an UNREADABLE quick_fixes surface does not read as "holds nothing"', async () => {
+    // get-my-claims reports partial-read errors precisely so a caller can tell "you hold nothing"
+    // from "I could not see one of the two surfaces". Handing work on an unreadable surface is the
+    // same class of defect as the blindness this FR fixes.
+    const hits = [];
+    const sb = makeSb({ sdRows: [], qfRows: [], qfError: { message: 'connection reset' } });
+    await runSteps([resume, stackingTier(hits)], makeCtx({ sb }));
+    expect(hits).toEqual([]);
+  });
+});
+
+describe('FR-1 — multiplicity stays DETECTION-ONLY (coordinator ruling)', () => {
+  it('surfaces claim_multiplicity without releasing anything', async () => {
+    // resume.cjs states in terms that picking a winner between two authoritative claims is a POLICY
+    // decision, deliberately not self-healed here. Ruled: leave it detected and unacted.
+    const sb = makeSb({
+      sdRows: [{ sd_key: 'SD-A-001', is_working_on: true, status: 'active' }],
+      qfRows: [{ id: 'QF-B-002', status: 'open' }],
+    });
+    const ctx = makeCtx({ sb, mySd: 'SD-A-001' });
+    const released = vi.fn();
+    ctx.helpers.selfHealStaleClaim = released;
+    const res = await runSteps([resume], ctx);
+    expect(res.action).toBe('resume');
+    expect(ctx.base.claim_multiplicity).toBeTruthy();
+    expect(ctx.base.claim_multiplicity.held).toEqual(expect.arrayContaining(['SD-A-001', 'QF-B-002']));
+    expect(released).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/checkin/resume-sees-both-claim-kinds-fr1.test.js
+++ b/tests/unit/checkin/resume-sees-both-claim-kinds-fr1.test.js
@@ -112,6 +112,33 @@ describe('FR-1 — a seat holding a QF is not handed more work', () => {
     expect(hits).toEqual([]);
   });
 
+  it('BOUNDARY PIN: a PARKED SD claim (is_working_on=false) is NOT resumed by the new branch', async () => {
+    // The commit's stated reason for not swapping findOwnSdClaim wholesale: getMyClaims does not
+    // test is_working_on, so widening the new branch to SDs would newly resume PARKED claims — a
+    // behaviour change FR-1 does not own. TESTING's independent mutation battery proved this
+    // boundary had no fixture (widening `c.kind === 'QF'` to include 'SD' kept everything green);
+    // this test is that missing pin. The parked SD is VISIBLE to getMyClaims here — only the
+    // QF-kind filter keeps it un-resumed, which is exactly what the mutation removes.
+    const hits = [];
+    const sb = makeSb({ sdRows: [{ sd_key: 'SD-PARKED-001', is_working_on: false, status: 'active' }], qfRows: [] });
+    const res = await runSteps([resume, stackingTier(hits)], makeCtx({ sb }));
+    expect(res.action).toBe('self_claimed_qf');
+    expect(hits).toEqual(['handed']);
+  });
+
+  it('HEAL PIN: the QF resume path heals the mirror and says so, like the SD path does', async () => {
+    // TESTING's battery deleted healOwnClaimPointer from the QF branch and everything stayed
+    // green — the heal was stubbed but never asserted. Without it the mirror stays NULL and the
+    // seat re-derives its own claim from the authoritative table on every single tick.
+    const ctx = makeCtx({ sb: makeSb({ sdRows: [], qfRows: [{ id: 'QF-20260807-999', status: 'open' }] }) });
+    const heal = vi.fn(async () => true);
+    ctx.helpers.healOwnClaimPointer = heal;
+    const res = await runSteps([resume], ctx);
+    expect(res.action).toBe('resume');
+    expect(heal).toHaveBeenCalledWith(ctx.sb, ME, 'QF-20260807-999');
+    expect(ctx.base.self_healed_own_claim_pointer).toEqual({ sd: 'QF-20260807-999', cache_updated: true });
+  });
+
   it('an UNREADABLE quick_fixes surface does not read as "holds nothing"', async () => {
     // get-my-claims reports partial-read errors precisely so a caller can tell "you hold nothing"
     // from "I could not see one of the two surfaces". Handing work on an unreadable surface is the

--- a/tests/unit/claim/guard-order-and-mismatch-fr7-fr8.test.js
+++ b/tests/unit/claim/guard-order-and-mismatch-fr7-fr8.test.js
@@ -67,9 +67,23 @@ describe('FR-7: ORDER ships, FILTER does not', () => {
 
 describe('FR-8: resume detects MISMATCH and MULTIPLICITY, not just NULL', () => {
   const elseBranch = (() => {
-    const i = RESUME.indexOf('} else {');
+    // ANCHORED, NOT POSITIONAL (SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 FR-1). This used to slice
+    // from the FIRST `} else {` in the file. When FR-1 added an earlier `} else {` to the
+    // !ctx.mySd branch, that slice silently began measuring a DIFFERENT branch — it happened to
+    // fail loudly only because the new block contains healOwnClaimPointer. Had it not, every
+    // assertion below would have gone GREEN while measuring code they were never about. Anchor on
+    // the multiplicity branch's own marker so the region cannot drift.
+    const marker = RESUME.indexOf('SD-LEO-INFRA-CLAIM-LIFECYCLE-RELEASE-002 (FR-8)');
+    const i = RESUME.lastIndexOf('} else {', marker);
     return RESUME.slice(i, RESUME.indexOf('    // 4. already working', i));
   })();
+
+  it('the slice actually landed on the multiplicity branch (anti-drift control)', () => {
+    // Without this, a future edit that moves the anchor turns every assertion below into a
+    // vacuous pass over the wrong region.
+    expect(elseBranch).toMatch(/MULTIPLICITY/);
+    expect(elseBranch).not.toMatch(/FR-1\): findOwnSdClaim answers the ownership/);
+  });
 
   it('consults the authoritative source even when the mirror is NON-empty', () => {
     // The original code only looked when ctx.mySd was null, which is why both states were invisible.

--- a/tests/unit/defer-quick-fix-deliberate-release-fr2.test.js
+++ b/tests/unit/defer-quick-fix-deliberate-release-fr2.test.js
@@ -131,6 +131,24 @@ describe('FR-2 fail-loud — a rationale without a guard-visible marker is refus
     expect(classifyDeliberateHoldMarker({ notBefore: inHours(2) })).toMatchObject({ valid: true, mode: 'time_gated' });
     expect(classifyDeliberateHoldMarker({ owner: 'chairman', releaseCondition: 'x' })).toMatchObject({ valid: true, mode: 'event_gated' });
   });
+
+  it('a PAST not_before is flagged inPast and warned about loudly — accepted (the un-park verb) but never a silent pseudo-hold', async () => {
+    // Adversarial review reproduced the trap: a mistyped/tz-naive-parsed-to-past timestamp
+    // printed a clean success while the row stayed immediately re-handable. The un-park use
+    // (past not_before, often with --reopen) is legitimate, so this stays ACCEPTED — the fix
+    // is honesty, not refusal.
+    expect(classifyDeliberateHoldMarker({ notBefore: inHours(-2) })).toMatchObject({ valid: true, mode: 'time_gated', inPast: true });
+    expect(classifyDeliberateHoldMarker({ notBefore: inHours(2) })).toMatchObject({ valid: true, mode: 'time_gated', inPast: false });
+    const warns = [];
+    const orig = console.warn;
+    console.warn = (m) => warns.push(String(m));
+    try {
+      const stub = makeSupabaseStub({ id: 'QF-X', status: 'open', not_before: inHours(-2) });
+      await deferQuickFix('QF-X', inHours(-2), { supabaseClient: stub.client });
+      expect(warns.join(' ')).toMatch(/PAST[\s\S]*holds NOTHING/);
+      expect(stub.update).toHaveBeenCalled(); // still writes — un-park preserved
+    } finally { console.warn = orig; }
+  });
 });
 
 describe('FR-2 negative controls — markerless paths that must KEEP succeeding', () => {

--- a/tests/unit/defer-quick-fix-deliberate-release-fr2.test.js
+++ b/tests/unit/defer-quick-fix-deliberate-release-fr2.test.js
@@ -1,0 +1,178 @@
+/**
+ * SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 (FR-2) — a deliberate QF release must WRITE the
+ * structured marker, and a deliberate release recorded without one must FAIL LOUDLY.
+ *
+ * THE MECHANISM THIS CLOSES: a worker records a blocking rationale as prose
+ * (verification_notes) and never invokes the structured verb; the stale-claim sweep later
+ * clears the claim MECHANICALLY, writing no marker (correctly — a swept claim is not a
+ * deliberate release); the QF returns to status='open' with every marker column NULL and is
+ * re-handed to a seat that also cannot satisfy the blocking condition. Measured fleet-wide by
+ * the coordinator: dozens of QFs with all-NULL markers.
+ *
+ * TWO-SIDED THROUGHOUT: each guard is proven to FIRE on the positive control and to NOT fire
+ * on the negative control, so a writer that refuses every release cannot pass. The positive
+ * controls are proven against the REAL hand-time reader (isAutoStartableQF), not a re-derived
+ * predicate — the whole point is that the written marker is one the live guard actually reads.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { deferQuickFix, classifyDeliberateHoldMarker } from '../../scripts/defer-quick-fix.js';
+import { clearAndReopenQf } from '../../lib/fleet/best-effort-release.mjs';
+import { releaseWorkItemOnSessionEnd } from '../../lib/fleet/release-work-item.mjs';
+
+const require_ = createRequire(import.meta.url);
+const { isAutoStartableQF } = require_('../../scripts/worker-checkin.cjs');
+
+const NOW = Date.now();
+const inHours = (h) => new Date(NOW + h * 3600_000).toISOString();
+
+/** A row the hand-time guard would HAND OUT absent any hold marker (the two-sided baseline). */
+function claimableRow(extra = {}) {
+  return {
+    id: 'QF-FR2-SPECIMEN', status: 'open', pr_url: null, commit_sha: null,
+    factory_lane: false, routing_tier: 1,
+    title: 'tidy the belt summary copy', description: 'wording only',
+    created_at: new Date(NOW - 3600_000).toISOString(),
+    not_before: null, owner: null, release_condition: null,
+    ...extra,
+  };
+}
+
+function makeSupabaseStub(returnData, returnError = null) {
+  const update = vi.fn().mockReturnThis();
+  const eq = vi.fn().mockReturnThis();
+  const select = vi.fn().mockReturnThis();
+  const single = vi.fn().mockResolvedValue({ data: returnData, error: returnError });
+  const maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+  const insert = vi.fn().mockResolvedValue({ error: null });
+  return {
+    client: { from: () => ({ update, eq, select, single, maybeSingle, insert }) },
+    update, eq, select, single, insert,
+  };
+}
+
+describe('FR-2 baseline — the specimen row IS claimable without markers (two-sided anchor)', () => {
+  it('the hand-time guard hands out the unmarked row', () => {
+    // Without this control the positive cases below could pass on a row the guard refuses for
+    // an unrelated reason (age, tier, risk keywords) — proving nothing about the marker.
+    expect(isAutoStartableQF(claimableRow(), NOW)).toBe(true);
+  });
+
+  it('prose in verification_notes is INVISIBLE to the guard — by design, not omission', () => {
+    // The defect in one line: the rationale as prose excludes nothing. Only the structured
+    // marker does. This pins the no-prose-parser boundary from the READ side.
+    const row = claimableRow({ verification_notes: 'BLOCKED: needs the chairman apply first' });
+    expect(isAutoStartableQF(row, NOW)).toBe(true);
+  });
+});
+
+describe('FR-2 positive controls — a deliberate release persists a marker the guard reads', () => {
+  it('time-gated: reason + not_before is written, and isAutoStartableQF refuses the result', async () => {
+    const stub = makeSupabaseStub({ id: 'QF-X', status: 'open', not_before: inHours(24) });
+    await deferQuickFix('QF-X', inHours(24), {
+      reason: 'needs a clean 24h observation window', owner: 'worker', releaseCondition: null,
+      supabaseClient: stub.client,
+    });
+    const written = stub.update.mock.calls[0][0];
+    expect(written).toMatchObject({ claiming_session_id: null, reason: 'needs a clean 24h observation window' });
+    expect(written.not_before).toBeTruthy();
+    expect(isAutoStartableQF(claimableRow({ not_before: written.not_before }), NOW)).toBe(false);
+  });
+
+  it('event-gated: owner=chairman + release_condition + reason, NO timestamp, is written and refused by the guard', async () => {
+    const stub = makeSupabaseStub({ id: 'QF-X', status: 'open', owner: 'chairman', release_condition: 'EU send planned' });
+    await deferQuickFix('QF-X', null, {
+      reason: 'apply is chairman-gated', owner: 'chairman', releaseCondition: 'EU send planned',
+      supabaseClient: stub.client,
+    });
+    const written = stub.update.mock.calls[0][0];
+    expect(written).toMatchObject({
+      claiming_session_id: null, owner: 'chairman',
+      release_condition: 'EU send planned', reason: 'apply is chairman-gated',
+    });
+    expect(written.not_before).toBeUndefined();
+    expect(isAutoStartableQF(claimableRow({ owner: written.owner, release_condition: written.release_condition }), NOW)).toBe(false);
+  });
+});
+
+describe('FR-2 fail-loud — a rationale without a guard-visible marker is refused, naming columns', () => {
+  it('reason alone (no marker at all) is refused before any DB write, naming not_before and release_condition', async () => {
+    const stub = makeSupabaseStub({ id: 'QF-X' });
+    await expect(deferQuickFix('QF-X', null, {
+      reason: 'blocked on sibling PR', supabaseClient: stub.client,
+    })).rejects.toThrow(/not_before[\s\S]*release_condition/);
+    expect(stub.update).not.toHaveBeenCalled();
+  });
+
+  it('a marker combination the guard CANNOT SEE (owner=worker + release_condition) is refused, not written', async () => {
+    // The sharp edge: this LOOKS structured, but isAutoStartableQF only excludes
+    // owner='chairman' holds — writing it would feel like a hold while excluding nothing.
+    const stub = makeSupabaseStub({ id: 'QF-X' });
+    await expect(deferQuickFix('QF-X', null, {
+      reason: 'blocked', owner: 'worker', releaseCondition: 'sibling merges',
+      supabaseClient: stub.client,
+    })).rejects.toMatchObject({ code: 'DELIBERATE_RELEASE_MARKER_MISSING' });
+    expect(stub.update).not.toHaveBeenCalled();
+    // ...and the refusal is honest about WHY: the guard genuinely would not exclude that row.
+    expect(isAutoStartableQF(claimableRow({ owner: 'worker', release_condition: 'sibling merges' }), NOW)).toBe(true);
+  });
+
+  it('event-gated without a structured reason is refused, naming the reason column', async () => {
+    const stub = makeSupabaseStub({ id: 'QF-X' });
+    await expect(deferQuickFix('QF-X', null, {
+      owner: 'chairman', releaseCondition: 'EU send planned', supabaseClient: stub.client,
+    })).rejects.toThrow(/missing column: reason/);
+    expect(stub.update).not.toHaveBeenCalled();
+  });
+
+  it('classifier verdicts carry the refusal code so callers can branch without string-matching', () => {
+    expect(classifyDeliberateHoldMarker({})).toMatchObject({ valid: false, code: 'DELIBERATE_RELEASE_MARKER_MISSING' });
+    expect(classifyDeliberateHoldMarker({ notBefore: inHours(2) })).toMatchObject({ valid: true, mode: 'time_gated' });
+    expect(classifyDeliberateHoldMarker({ owner: 'chairman', releaseCondition: 'x' })).toMatchObject({ valid: true, mode: 'event_gated' });
+  });
+});
+
+describe('FR-2 negative controls — markerless paths that must KEEP succeeding', () => {
+  it('ordinary hand-back (clearAndReopenQf) still succeeds with no marker columns at all', async () => {
+    const updates = [];
+    const chain = {
+      update(payload) { updates.push(payload); return this; },
+      eq() { return this; }, filter() { return this; }, is() { return this; },
+      select: async () => ({ data: [{ id: 'QF-HB' }], error: null }),
+    };
+    const sb = { from: () => chain };
+    const res = await clearAndReopenQf(sb, 'QF-HB');
+    expect(res).toMatchObject({ changed: true, reason: 'reopened' });
+    expect(updates[0]).toEqual({ status: 'open', claiming_session_id: null });
+    for (const col of ['not_before', 'owner', 'release_condition', 'reason']) {
+      expect(updates[0]).not.toHaveProperty(col);
+    }
+  });
+
+  it('SWEEP BOUNDARY: the mechanical work-item reset still reopens a dead claim with no marker', async () => {
+    // A swept stale claim is NOT a deliberate release. Requiring a marker here would strand
+    // every genuinely-dead claim — the load-bearing boundary the PRD names.
+    const updates = [];
+    const chain = {
+      update(payload) { updates.push(payload); return this; },
+      eq() { return this; }, filter() { return this; }, is() { return this; },
+      select: async () => ({ data: [{ id: 'QF-SWEPT' }], error: null }),
+    };
+    const sb = { from: () => chain };
+    const res = await releaseWorkItemOnSessionEnd(sb, 'QF-SWEPT', 'stale_session_sweep');
+    expect(res).toMatchObject({ ok: true, kind: 'qf', action: 'qf_reopened' });
+    expect(updates[0]).toEqual({ status: 'open' });
+  });
+});
+
+describe('FR-2 no-prose-parser boundary (write side)', () => {
+  it('the deliberate-release writer never reads verification_notes as guard state', () => {
+    // Comments may NAME the column while explaining the defect; CODE must never touch it.
+    const stripComments = (s) => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    const src = stripComments(readFileSync(new URL('../../scripts/defer-quick-fix.js', import.meta.url), 'utf8'));
+    expect(src.includes('verification_notes'), 'defer-quick-fix.js must not consult prose').toBe(false);
+    const gate = stripComments(readFileSync(new URL('../../lib/fleet/qf-gated-hold.cjs', import.meta.url), 'utf8'));
+    expect(gate.includes('verification_notes'), 'the gated-hold predicate must not consult prose').toBe(false);
+  });
+});

--- a/tests/unit/worker-checkin-own-claim-detect.test.js
+++ b/tests/unit/worker-checkin-own-claim-detect.test.js
@@ -130,7 +130,13 @@ describe('resume.cjs step — SILENT-STARVE reproduction and fix (reproduces the
     const findOwnSdClaim = vi.fn(async () => null);
     const healOwnClaimPointer = vi.fn(async () => false);
     const ctx = {
-      sb: {},
+      // GENUINELY IDLE means both claim surfaces were READ and both came back empty. This was
+      // `sb: {}`, which reads as "don't care" but is actually an UNREADABLE client — and since
+      // SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001 FR-1 the two are deliberately no longer the same
+      // outcome (an unreadable surface must not authorise a hand). Give the fixture the state its
+      // own name claims; every assertion below is unchanged and still meaningful.
+      sb: { from() { return this; }, select() { return this; }, eq() { return this; },
+        then(res, rej) { return Promise.resolve({ data: [], error: null }).then(res, rej); } },
       sessionId: 'genuinely-idle-session',
       sessionRole: null,
       mySd: null,


### PR DESCRIPTION
## Summary
- **FR-1** (`lib/checkin/steps/resume.cjs`): the resume step's empty-mirror branch now consults `getMyClaims` (both `strategic_directives_v2` AND `quick_fixes`), so a seat authoritatively holding a quick-fix with a NULL `claude_sessions.sd_key` mirror resumes it instead of the check-in ladder stacking more vehicles onto the seat (measured live: 2 of 2 claimed QFs sat in the stacking-reachable state). Read errors stop the ladder; multiplicity stays detection-only per coordinator ruling; parked-SD semantics byte-identical and now pinned by fixture.
- **FR-2** (`scripts/defer-quick-fix.js`): the deliberate QF release verb accepts exactly the two guard-visible marker shapes — `not_before` (time-gated) or `owner='chairman'`+`release_condition` (event-gated, predicate reused verbatim from `lib/fleet/qf-gated-hold.cjs`) — and refuses anything else loudly, naming the missing columns. The mechanical sweep clear stays markerless (pinned). No prose parser anywhere.
- **FR-3** (`lib/coordination/premise-freshness.cjs` + `lib/coordinator/dispatch.cjs` + `lib/checkin/steps/directed-assignment.cjs`): a WORK_ASSIGNMENT instruction body carries a `premise_measured_at` MEASUREMENT stamp (never defaulted to send time); at claim-time a stale, missing, or future-dated stamp surfaces RE-VERIFY-BEFORE-EXECUTING leading the message. Content-blind by construction — key presence only, no prose re-validation attempted or claimed.

## Test plan
- [x] 118 tests green across the affected suite (new: `resume-sees-both-claim-kinds-fr1`, `defer-quick-fix-deliberate-release-fr2`, `premise-freshness-fr3`)
- [x] Two-sided controls on every guard (fires on positive, silent on negative)
- [x] 9 mutations each redded named tests (6 author + 3 sub-agent-derived: future-stamp silencing, parked-SD widening, QF-heal deletion)
- [x] TESTING sub-agent PASS (conf 92, independent 8-mutation battery, wider regression 1270/1270); SECURITY sub-agent PASS (conf 90)

🤖 Generated with [Claude Code](https://claude.com/claude-code)