### PR TITLE
fix(QF-20260809-341): emit passed from validateSDCompletionReadiness — the tier-3 retro gate reads it

### DIFF
--- a/scripts/modules/sd-quality-validation.js
+++ b/scripts/modules/sd-quality-validation.js
@@ -330,6 +330,7 @@ export async function validateSDCompletionReadiness(sd, retrospective = null) {
 
   if (!sd) {
     result.valid = false;
+    result.passed = false;
     result.issues.push('Strategic Directive is null or undefined');
     return result;
   }
@@ -375,6 +376,11 @@ export async function validateSDCompletionReadiness(sd, retrospective = null) {
   }
 
   result.valid = result.issues.length === 0;
+  // QF-20260809-341: the RETROSPECTIVE_EXISTS tier-3 arm (lead-final-approval/gates.js) reads
+  // `assessment.passed` — a contract its own test ratifies by MOCKING this function with a
+  // passed key this function never emitted. With only `valid`, `!assessment?.passed` was true
+  // for every tier-3 SD, so the gate could not pass regardless of score. Emit both.
+  result.passed = result.valid;
 
   return result;
 }

--- a/tests/unit/sd-completion-readiness-passed-contract.test.js
+++ b/tests/unit/sd-completion-readiness-passed-contract.test.js
@@ -1,0 +1,23 @@
+// QF-20260809-341 — the passed/valid wire, tested WITHOUT mocking the producer.
+//
+// The RETROSPECTIVE_EXISTS tier-3 arm reads `assessment.passed` (lead-final-approval/gates.js),
+// and its contract test ratifies that by MOCKING validateSDCompletionReadiness with a `passed`
+// key. The real function only emitted `valid`, so both sides were green while the wire was
+// broken: `!assessment?.passed` was true for EVERY tier-3 SD and the gate could not pass at any
+// score (observed live: "assessed score 75% is below minimum 60%"). This suite calls the REAL
+// producer on its no-network early-return path, so the contract key can never silently vanish
+// behind a mock again.
+
+import { describe, it, expect } from 'vitest';
+import { validateSDCompletionReadiness } from '../../scripts/modules/sd-quality-validation.js';
+
+describe('validateSDCompletionReadiness emits the passed key the gate consumes', () => {
+  it('null SD: passed exists, mirrors valid, and is false', async () => {
+    const r = await validateSDCompletionReadiness(null);
+    expect(r.valid).toBe(false);
+    // The load-bearing assertion: `passed` must be a boolean, not undefined — undefined is what
+    // made the gate's `!assessment?.passed` unconditionally true.
+    expect(r.passed).toBe(false);
+    expect(r.passed).toBe(r.valid);
+  });
+});


### PR DESCRIPTION
## Summary
- `validateSDCompletionReadiness` returned `{valid}` with no `passed` key, while the RETROSPECTIVE_EXISTS tier-3 arm (`lead-final-approval/gates.js:483`, changed in SD-LEO-INFRA-RETRO-INTEGRITY-RUN-001) checks `!assessment?.passed` — unconditionally true, so **every Tier-3 SD failed the gate at any score** (observed live on SD-LEO-INFRA-COMPLETION-FAIL-OWN-001: 'assessed score 75% is below minimum 60%').
- The gate's contract test ratifies `passed` by **mocking** the producer — both sides green, wire broken.
- Fix: producer emits `passed` mirroring `valid` on all return paths (8 LOC), honoring the ratified consumer contract.
- Added an unmocked wire test (no-network early-return path) so the contract key cannot silently vanish behind the mock again.

## Test plan
- [x] New wire test green
- [x] Existing retrospective-exists gate contract suite green (9 tests total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)