### PR TITLE
feat(SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A): publish the hardened git runner, consolidate VALID_BASE_REF, adopt across the frozen census

### DIFF
--- a/lib/claim/wip-detector.cjs
+++ b/lib/claim/wip-detector.cjs
@@ -19,15 +19,17 @@ const { checkWorktreeWIP } = require('../execute/wip-guard.cjs');
  * Default git/gh runners (spawnSync-based, mirrors scripts/worktree-reaper.mjs's runGit/runGh).
  */
 function defaultRunGit(args, opts = {}) {
-  const { spawnSync } = require('child_process');
-  const res = spawnSync('git', args, {
+  // Adopted from the published runner (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A): same
+  // {stdout,stderr,code} never-throws contract, plus the env scrub + hardening flags this
+  // private copy never had.
+  const { runHardenedGit } = require('../git/hardened-runner.cjs');
+  const r = runHardenedGit(args, {
     cwd: opts.cwd || process.cwd(),
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-    windowsHide: true,
     timeout: opts.timeout || 10000,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    result: true,
   });
-  return { stdout: res.stdout || '', stderr: res.stderr || '', code: res.status == null ? 1 : res.status };
+  return { stdout: r.stdout, stderr: r.stderr, code: r.status == null ? 1 : r.status };
 }
 
 /**

--- a/lib/fleet/inflight-git-state.cjs
+++ b/lib/fleet/inflight-git-state.cjs
@@ -83,6 +83,27 @@ function defaultRunGh(args, opts = {}) {
 }
 
 function runSafe(bin, args, opts = {}) {
+  // GIT goes through the published hardened runner (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A)
+  // with envPassthrough: a RECORDED opt-out from the scrub, because this module's contract —
+  // encoded in its test (opts.env === undefined) — is that the child env stays AMBIENT so gh/git
+  // credential helpers resolve for the paired gh probe. The hardening FLAGS still apply.
+  if (bin === 'git') {
+    const { runHardenedGit } = require('../git/hardened-runner.cjs');
+    const r = runHardenedGit(args, {
+      cwd: opts.cwd || process.cwd(),
+      timeout: opts.timeout || PROBE_TIMEOUT_MS,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      envPassthrough: true,
+      result: true,
+    });
+    const gitTimedOut = !!(r.error && r.error.code === 'ETIMEDOUT');
+    return {
+      stdout: r.stdout,
+      stderr: r.stderr,
+      code: r.status == null ? 1 : r.status,
+      spawnError: r.error ? (gitTimedOut ? 'timeout' : String(r.error.code || 'spawn_error')) : null,
+    };
+  }
   const { spawnSync } = require('child_process');
   const res = spawnSync(bin, args, {
     cwd: opts.cwd || process.cwd(),

--- a/lib/fleet/source-tree-refresh.cjs
+++ b/lib/fleet/source-tree-refresh.cjs
@@ -108,7 +108,10 @@ function makeScrubbedGitRunner(cwd, {
   const sync = spawnSyncImpl || require('node:child_process').spawnSync;
   return (args, callOpts = {}) => {
     const o = { envPassthrough, envAugment, timeout, maxBuffer, stdio, result, ...callOpts };
-    const spawnOpts = { cwd, encoding: 'utf8', windowsHide: true };
+    // shell: false EXPLICITLY — spawnSync's default is already shell-less, but downstream
+    // contract tests (inflight-git-state TS-6) assert the marker on the real call so a future
+    // `shell: true` cannot slip in as an "option tweak" without flipping a stated false.
+    const spawnOpts = { cwd, encoding: 'utf8', windowsHide: true, shell: false };
     // envPassthrough leaves spawnOpts.env UNSET (child inherits ambient env) rather than passing
     // a copy — the inflight-git-state contract is `env === undefined`, not "env deep-equals".
     // envAugment applies AFTER the scrub: the scrub's denylist includes keys a caller may need to

--- a/lib/fleet/source-tree-refresh.cjs
+++ b/lib/fleet/source-tree-refresh.cjs
@@ -94,12 +94,39 @@ function scrubGitEnv(env) {
  * Routing both call sites through one factory turns the wire into a single testable object: an
  * effect test on this function covers what a per-site structural grep never could.
  */
-function makeScrubbedGitRunner(cwd, { spawnSync: spawnSyncImpl, env = process.env } = {}) {
+function makeScrubbedGitRunner(cwd, {
+  spawnSync: spawnSyncImpl, env = process.env,
+  // FR-0 (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A): adoption sites carry contracts the
+  // original runner cannot express — dirty-probing treats non-zero exit as data (not failure),
+  // inflight-git-state must leave the child env AMBIENT so gh/git credential helpers resolve
+  // (its test asserts opts.env === undefined), schema-reference-lint needs a 32MB maxBuffer
+  // (spawnSync's 1MB default returns status:null on overflow), and tree-currency pipes stderr
+  // explicitly. All four are factory/call opts here; defaults are byte-compatible with the
+  // original behavior so the existing consumer (worktree-reaper-tick) is untouched.
+  envPassthrough = false, envAugment, timeout, maxBuffer, stdio, result = false,
+} = {}) {
   const sync = spawnSyncImpl || require('node:child_process').spawnSync;
-  return (args) => {
-    const r = sync('git', args, {
-      cwd, encoding: 'utf8', windowsHide: true, env: scrubGitEnv(env),
-    });
+  return (args, callOpts = {}) => {
+    const o = { envPassthrough, envAugment, timeout, maxBuffer, stdio, result, ...callOpts };
+    const spawnOpts = { cwd, encoding: 'utf8', windowsHide: true };
+    // envPassthrough leaves spawnOpts.env UNSET (child inherits ambient env) rather than passing
+    // a copy — the inflight-git-state contract is `env === undefined`, not "env deep-equals".
+    // envAugment applies AFTER the scrub: the scrub's denylist includes keys a caller may need to
+    // POSITIVELY set (e.g. GIT_CONFIG_NOSYSTEM for no-fetch contexts) — setting them pre-scrub
+    // would be silently stripped, an inert decoration.
+    if (!o.envPassthrough) spawnOpts.env = { ...scrubGitEnv(env), ...(o.envAugment || {}) };
+    if (o.timeout != null) spawnOpts.timeout = o.timeout;
+    if (o.maxBuffer != null) spawnOpts.maxBuffer = o.maxBuffer;
+    if (o.stdio != null) spawnOpts.stdio = o.stdio;
+    const r = sync('git', args, spawnOpts);
+    if (o.result) {
+      return {
+        status: r ? r.status : null,
+        stdout: r && r.stdout != null ? r.stdout.toString() : '',
+        stderr: r && r.stderr != null ? r.stderr.toString() : '',
+        error: (r && r.error) || undefined,
+      };
+    }
     if (!r || r.status !== 0) {
       throw new Error(`git ${args.join(' ')} failed: ${((r && r.stderr) || '').toString().trim()}`);
     }

--- a/lib/fleet/tree-currency.cjs
+++ b/lib/fleet/tree-currency.cjs
@@ -49,8 +49,10 @@ const SELF_HEALABLE_BRANCH = 'main';
 /**
  * SEC-1: a ref must never be able to lead with a dash (git would read it as an option).
  * Deliberately strict — this gates a value that reaches a subprocess argv.
+ * Consolidated: this file was the ORIGIN copy of the regex; the published single representation
+ * now lives in lib/git/hardened-runner.cjs (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A).
  */
-const VALID_BASE_REF = /^[A-Za-z0-9._][A-Za-z0-9._/-]*$/;
+const { VALID_BASE_REF } = require('../git/hardened-runner.cjs');
 
 function defaultRunner(args, { cwd, timeoutMs }) {
   return execFileSync('git', args, {

--- a/lib/fleet/tree-currency.cjs
+++ b/lib/fleet/tree-currency.cjs
@@ -35,7 +35,6 @@
  * PURITY: all git invocation goes through an injectable `runner`, so the decision table
  * is unit-testable without a live git, and so callers can supply their own timeout.
  */
-const { execFileSync } = require('child_process');
 
 /** The ref an execution-source tree must be current with respect to. */
 const DEFAULT_BASE_REF = 'origin/main';
@@ -55,16 +54,17 @@ const SELF_HEALABLE_BRANCH = 'main';
 const { VALID_BASE_REF } = require('../git/hardened-runner.cjs');
 
 function defaultRunner(args, { cwd, timeoutMs }) {
-  return execFileSync('git', args, {
+  // SCRUB-2 (EXEC SECURITY, re-rated to BLOCKING after measurement): this runner is the
+  // PRODUCTION path — worktree-reaper-tick only injects a runner when opts.currencyRunner is set,
+  // i.e. in tests. Measured: with GIT_CONFIG_COUNT/core.fsmonitor set, the injected command RAN
+  // and assessTreeCurrency still returned reason="current". The source-tree scrub landed on one
+  // door; this one kept serving, on the same directory in the same tick.
+  // Adopted from the published runner (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A), which
+  // carries the same scrubGitEnv(process.env) wire plus the hardening flag set.
+  const { runHardenedGit } = require('../git/hardened-runner.cjs');
+  return runHardenedGit(args, {
     cwd,
     timeout: timeoutMs,
-    encoding: 'utf8',
-    // SCRUB-2 (EXEC SECURITY, re-rated to BLOCKING after measurement): this runner is the
-    // PRODUCTION path — worktree-reaper-tick only injects a runner when opts.currencyRunner is set,
-    // i.e. in tests. Measured: with GIT_CONFIG_COUNT/core.fsmonitor set, the injected command RAN
-    // and assessTreeCurrency still returned reason="current". The source-tree scrub landed on one
-    // door; this one kept serving, on the same directory in the same tick.
-    env: require('./source-tree-refresh.cjs').scrubGitEnv(process.env),
     stdio: ['ignore', 'pipe', 'pipe'],
   });
 }

--- a/lib/gates/operator-contract/harness-adapter.js
+++ b/lib/gates/operator-contract/harness-adapter.js
@@ -20,6 +20,7 @@
 // swapping it in here would silently stop that SEC-4b bookkeeping from ever recording a
 // genuine per-file diff failure.
 import { execFileSync } from 'node:child_process';
+import { VALID_BASE_REF } from '../../git/hardened-runner.cjs';
 import { evaluateOperatorContract, detectCreator, validateConsumer, detectWiring, validateCadence, validateReaper } from './index.js';
 import { RETENTION_POLICIES, SOAK_ENTRIES } from '../../retention/policies.js';
 
@@ -70,10 +71,10 @@ export function collectSdDiff({ appPath, baseRef = 'origin/main' } = {}) {
   // Not reachable today (the sole production caller at the bottom of this file passes no baseRef,
   // so the 'origin/main' default always applies), but it is a local command-execution primitive
   // the moment anyone wires baseRef to env, DB config or a flag. This repo already adopted the
-  // control for the IDENTICAL sink — lib/fleet/tree-currency.cjs:53 VALID_BASE_REF, applied at
-  // :105 for its own SEC-1 finding — and it simply was not carried here. Reuse the same shape,
-  // because safety-by-coincidence outlives the rule written to abolish it.
-  const VALID_BASE_REF = /^[A-Za-z0-9._][A-Za-z0-9._/-]*$/;
+  // control for the IDENTICAL sink — VALID_BASE_REF, formerly hand-copied here and at
+  // lib/fleet/tree-currency.cjs — and it simply was not carried here. Now imported from the
+  // published single representation (lib/git/hardened-runner.cjs), because safety-by-coincidence
+  // outlives the rule written to abolish it.
   if (!VALID_BASE_REF.test(String(baseRef || ''))) {
     // Thrown, not silently defaulted. The outer gate is fail-open and will record this as a
     // warning; substituting origin/main here would make a rejected ref indistinguishable from an

--- a/lib/gates/operator-contract/harness-adapter.js
+++ b/lib/gates/operator-contract/harness-adapter.js
@@ -19,8 +19,7 @@
 // `unreadable` keeps firing. spawnSync returns {stdout,stderr,status} and does NOT throw —
 // swapping it in here would silently stop that SEC-4b bookkeeping from ever recording a
 // genuine per-file diff failure.
-import { execFileSync } from 'node:child_process';
-import { VALID_BASE_REF } from '../../git/hardened-runner.cjs';
+import { VALID_BASE_REF, makeHardenedGitRunner } from '../../git/hardened-runner.cjs';
 import { evaluateOperatorContract, detectCreator, validateConsumer, detectWiring, validateCadence, validateReaper } from './index.js';
 import { RETENTION_POLICIES, SOAK_ENTRIES } from '../../retention/policies.js';
 
@@ -118,17 +117,18 @@ export function collectSdDiff({ appPath, baseRef = 'origin/main' } = {}) {
   // the function it guards.
   // `--no-ext-diff` is a `git diff` SUBCOMMAND option, not a global one — passing it before the
   // subcommand makes git exit non-zero on every call. Injected positionally instead.
-  const run = (rawArgs) => {
-    const args = rawArgs[0] === 'diff' ? ['diff', '--no-ext-diff', '--no-textconv', ...rawArgs.slice(1)] : rawArgs;
-    return execFileSync('git', [
-      '-c', 'core.fsmonitor=',   // a second config-driven child-process vector
-      '--literal-pathspecs', '--no-optional-locks', ...args,
-    ], {
-      cwd: appPath, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], maxBuffer: 64 * 1024 * 1024,
-      // GIT_CONFIG_NOSYSTEM keeps a system-level config out of the picture too.
-      env: { ...process.env, GIT_CONFIG_NOSYSTEM: '1' },
-    });
-  };
+  // Adopted from the published runner (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A). It carries
+  // everything this private copy had — --literal-pathspecs, --no-optional-locks,
+  // -c core.fsmonitor=, per-diff-verb --no-ext-diff/--no-textconv, GIT_CONFIG_NOSYSTEM (via
+  // noSystemConfig, applied POST-scrub so it is never silently stripped) — plus the env scrub of
+  // injected GIT_CONFIG_*/GIT_SSH_COMMAND/... this site never had. This is a no-fetch context,
+  // so noSystemConfig is safe here (the runner's default leaves system config alone because
+  // nulling it breaks credential resolution at fetch-capable sites).
+  const run = makeHardenedGitRunner(appPath, {
+    noSystemConfig: true,
+    stdio: ['ignore', 'pipe', 'ignore'],
+    maxBuffer: 64 * 1024 * 1024,
+  });
   const unreadable = [];
   // merge-base diff so we only see the SD's own changes.
   //

--- a/lib/git/hardened-runner-adoption.test.js
+++ b/lib/git/hardened-runner-adoption.test.js
@@ -1,0 +1,113 @@
+/**
+ * FR-4 invariant + FR-5 armed two-sided tests — SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A.
+ *
+ * THE INVARIANT (mechanical, not a prose site list): every file in the frozen adoption census
+ * routes git through the published hardened runner and contains NO direct git spawn of its own.
+ * This replaces the "BOTH production call sites" fact-pin shape (PAT-TEST-PINS-FACT-NOT-
+ * BEHAVIOUR-001): adding a 15th census file extends CENSUS below; a census file regressing to a
+ * private runner fails loudly here.
+ *
+ * RECORDED REMAINDER (measured 2026-08-10): 88 further files under lib/ and scripts/ spawn git
+ * DIRECTLY but in the argv-safe shape (execFileSync/spawnSync('git', [...])). They are outside
+ * this SD's frozen census — the dangerous shapes among them (template-literal exec, shell:true)
+ * are child B's advisory-lint ledger, and wholesale factory adoption is a future wave. This
+ * comment exists so the bound is a recorded decision, not a silent cap.
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const { OPT_OUTS, assertOptOutReasons } = require_('./hardened-runner.cjs');
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+/** The frozen census (R-2): 8 definition sites + 6 call-site runners, adopted by this SD. */
+const CENSUS = [
+  'scripts/docmon.js',
+  'scripts/lint/schema-reference-lint.mjs',
+  'lib/gates/operator-contract/harness-adapter.js',
+  'lib/fleet/tree-currency.cjs',
+  'lib/governance/checkout-freshness.js',
+  'lib/worktree/stale-base-guard.mjs',
+  'scripts/lint/no-process-cwd-in-sub-agents-lint.mjs',
+  'scripts/log-harness-bug.js',
+  'lib/worktree-reapability.js',
+  'lib/claim/wip-detector.cjs',
+  'lib/fleet/inflight-git-state.cjs',
+  'scripts/worktree-reaper.mjs',
+  'lib/governance/measurement-provenance.js',
+  'scripts/phantom-test-audit.js',
+];
+
+/** A direct git spawn: the private-runner shape the census files must never regrow. */
+const DIRECT_GIT_SPAWN = /(?:spawnSync|execFileSync|execFile|exec)\s*\(\s*['"]git['"]|execSync\s*\(\s*`git /;
+/** Importing the published runner (either export form, either module system). */
+const FACTORY_REF = /hardened-runner\.cjs|makeHardenedGitRunner|runHardenedGit/;
+
+function stripComments(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/[^\n]*/g, '$1');
+}
+
+describe('FR-4: no-private-runner invariant over the frozen census', () => {
+  for (const rel of CENSUS) {
+    it(`${rel} is factory-sourced with no direct git spawn`, () => {
+      const src = stripComments(fs.readFileSync(path.join(ROOT, rel), 'utf8'));
+      expect(FACTORY_REF.test(src), `${rel} must reference the published runner`).toBe(true);
+      expect(DIRECT_GIT_SPAWN.test(src), `${rel} must not carry a private git spawn`).toBe(false);
+    });
+  }
+
+  it('every recorded opt-out carries a non-empty reason (the ledger contract)', () => {
+    expect(() => assertOptOutReasons(OPT_OUTS)).not.toThrow();
+  });
+});
+
+describe('FR-5 armed two-sided: measurement-provenance defaultGit', () => {
+  it('RUNS: benign literal returns a real sha through the adopted runner', async () => {
+    const mod = await import('../governance/measurement-provenance.js');
+    const out = mod.defaultGit('rev-parse --short HEAD');
+    expect(out).toMatch(/^[0-9a-f]{4,40}$/);
+  });
+
+  it('NO SHELL: a command-chain payload creates no marker and returns empty', async () => {
+    const mod = await import('../governance/measurement-provenance.js');
+    const marker = path.join(ROOT, `.armed-marker-mp-${process.pid}`);
+    try {
+      // Under the OLD template-literal execSync this string reached a shell where the separator
+      // spawns a second command; under argv it is a bogus git arg -> error -> '' (fail-soft).
+      const payload = `rev-parse HEAD; node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '/')}','x')"`;
+      const out = mod.defaultGit(payload);
+      expect(out).toBe('');
+      expect(fs.existsSync(marker), 'the payload must never execute').toBe(false);
+    } finally {
+      try { fs.unlinkSync(marker); } catch { /* not created — the point */ }
+    }
+  });
+});
+
+describe('FR-5 armed two-sided: phantom-test-audit safeGit (via resolveAuditBase default path)', () => {
+  it('RUNS: the default seam resolves a real merge-base in this repo', async () => {
+    const mod = await import('../../scripts/phantom-test-audit.js');
+    // resolveAuditBase default git is safeGit; a real repo resolves a real sha or falls back.
+    const base = mod.resolveAuditBase({ repoPath: ROOT, baseRef: 'HEAD' });
+    expect(typeof base).toBe('string');
+    expect(base.length).toBeGreaterThan(0);
+  });
+
+  it('NO SHELL: a hostile baseRef becomes a literal git arg, never a second command', async () => {
+    const mod = await import('../../scripts/phantom-test-audit.js');
+    const marker = path.join(ROOT, `.armed-marker-pt-${process.pid}`);
+    try {
+      const hostile = `HEAD & node -e "require('fs').writeFileSync('${marker.replace(/\\/g, '/')}','x')"`;
+      // Fail-soft contract: unresolvable merge-base falls back to the baseRef string itself.
+      const base = mod.resolveAuditBase({ repoPath: ROOT, baseRef: hostile });
+      expect(base).toBe(hostile);
+      expect(fs.existsSync(marker), 'the payload must never execute').toBe(false);
+    } finally {
+      try { fs.unlinkSync(marker); } catch { /* not created — the point */ }
+    }
+  });
+});

--- a/lib/git/hardened-runner.cjs
+++ b/lib/git/hardened-runner.cjs
@@ -1,0 +1,153 @@
+'use strict';
+/**
+ * THE published hardened git runner — the ONE representation of the shell-injection-sink
+ * controls that four lineages re-derived by hand (QF-20260529-706, QF-20260701-683,
+ * SD-LEO-FIX-SHELL-INJECTION-RCE-001, SD-LEO-FIX-SHELL-INJECTION-REACHABLE-001).
+ * SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A.
+ *
+ * Before this module, the controls existed three times under three names in three files
+ * (harness-adapter run(), docmon runGit, schema-reference-lint runGit), each asserting the
+ * "ONE RUNNER, NOT A FIX PER CALL SITE" principle in identical hand-copied prose while
+ * implementing it privately. Import from here instead of re-deriving.
+ *
+ * MECHANISM -> SWITCH -> COVERED table (enumerated from git-scm.com documentation, not folklore):
+ *
+ * | mechanism (hostile-config vector)        | control here                          | covered |
+ * |------------------------------------------|---------------------------------------|---------|
+ * | core.fsmonitor (cmd git RUNS on status)  | -c core.fsmonitor= (cleared)          | yes     |
+ * | core.pager / GIT_PAGER (cmd on paged out)| -c core.pager= (cleared)              | yes     |
+ * | filter.<x>.clean/smudge (cmd on checkout)| env scrub of GIT_CONFIG_* injection   | partial¹|
+ * | credential.helper (cmd on auth)          | env scrub; system/global NOT nulled   | partial¹|
+ * | core.hooksPath / hooks (cmd on verbs)    | env scrub of GIT_* redirection keys   | partial¹|
+ * | .gitattributes ext diff/textconv         | --no-ext-diff --no-textconv (diff)    | yes     |
+ * | GIT_SSH_COMMAND / GIT_PROXY_COMMAND /    | scrubGitEnv denylist                  | yes     |
+ * |   GIT_EXTERNAL_DIFF / GIT_EXEC_PATH ...  |                                       |         |
+ * | GIT_CONFIG_COUNT/KEY_n/VALUE_n injection | scrubGitEnv prefix match ^GIT_CONFIG_ | yes     |
+ * | GIT_DIR/GIT_WORK_TREE/... redirection    | scrubGitEnv denylist                  | yes     |
+ * | pathspec magic (:(attr:...) etc.)        | --literal-pathspecs (DEFAULT ON)      | yes     |
+ * | index/optional lock side effects         | --no-optional-locks                   | yes     |
+ * | system/global config file contents       | NOT nulled by default                 | no¹     |
+ * | option-shaped ref args (--upload-pack=)  | validateBaseRef / VALID_BASE_REF      | yes     |
+ * | shell metacharacters in args             | argv array spawn — no shell, ever     | yes     |
+ *
+ * ¹ Reason (measured, source-tree-refresh.cjs:67-82): pointing GIT_CONFIG_NOSYSTEM/GLOBAL at
+ *   nothing BREAKS AUTHENTICATED FETCH on this fleet — credential.helper lives in system config,
+ *   github helpers in global. System/global config is the machine owner's own configuration; the
+ *   measured threat is ENV-INJECTED config, which the scrub removes. Callers in contexts that
+ *   never fetch (e.g. operator-contract gates) can opt IN via `noSystemConfig: true`, which is
+ *   per-call/per-factory — never global (R-7).
+ */
+
+const path = require('node:path');
+const { makeScrubbedGitRunner, scrubGitEnv, GIT_REDIRECT_ENV_KEYS, GIT_REDIRECT_ENV_PREFIXES } =
+  require(path.join(__dirname, '..', 'fleet', 'source-tree-refresh.cjs'));
+
+/**
+ * THE ref-shape allowlist — single representation. Formerly byte-identical hand-copies at
+ * lib/fleet/tree-currency.cjs:53 (origin), lib/gates/operator-contract/harness-adapter.js:76,
+ * scripts/lint/schema-reference-lint.mjs:91 — all three now import from here.
+ * Refuses anything option-shaped (leading '-'), empty, or carrying shell/pathspec metacharacters.
+ */
+const VALID_BASE_REF = /^[A-Za-z0-9._][A-Za-z0-9._/-]*$/;
+
+/** Throws before any process spawn — the refusal happens at validation, not inside git. */
+function validateBaseRef(ref) {
+  if (typeof ref !== 'string' || !VALID_BASE_REF.test(ref)) {
+    throw new Error(`HOSTILE_BASE_REF: refusing ref ${JSON.stringify(ref)} — must match ${VALID_BASE_REF}`);
+  }
+  return ref;
+}
+
+/**
+ * Recorded deliberate divergences from the default hardening. An opt-out is a LEDGER ENTRY, not a
+ * silent bypass: every record needs a non-empty reason (same contract the lint allowlists enforce —
+ * loadAllowlist throws /non-empty reason/; see fixture-producer-guard-lint.test.js:99-104).
+ */
+const OPT_OUTS = [
+  {
+    file: 'scripts/lint/schema-reference-lint.mjs',
+    opt: 'literalPathspecs: false',
+    reason: 'passes no pathspec at all — the flag would be inert decoration a later reader could '
+      + 'mistake for the protection (its own header, :64-67, documents this omission as deliberate)',
+  },
+];
+
+/** Refuses opt-out records whose reason is empty or whitespace — the backstop must be loud. */
+function assertOptOutReasons(records = OPT_OUTS) {
+  for (const r of records) {
+    if (!r || typeof r.reason !== 'string' || r.reason.trim() === '') {
+      throw new Error(`OPT_OUT_WITHOUT_REASON: ${JSON.stringify(r && r.file)} — an opt-out without a reason is a silent bypass`);
+    }
+  }
+  return records;
+}
+assertOptOutReasons();
+
+/** Git verbs whose output can invoke external diff/textconv drivers via .gitattributes. */
+const DIFF_VERBS = new Set(['diff', 'show', 'log', 'format-patch']);
+
+/**
+ * Build the ONE hardened runner.
+ *
+ * @param {string} cwd repo/worktree to run in
+ * @param {object} [opts]
+ *   Inherited from makeScrubbedGitRunner (FR-0): spawnSync, env, envPassthrough, timeout,
+ *   maxBuffer, stdio, result.
+ *   Added here:
+ *   - literalPathspecs (default TRUE — R-5: every measured flag-dependent site is covered by the
+ *     armed suites; forgetting an opt-IN silently reopens the pathspec-magic vector, so the safe
+ *     state is the default and divergence is a recorded opt-out)
+ *   - noSystemConfig (default FALSE — see footnote ¹ above; per-call opt for no-fetch contexts)
+ * @returns {(args: string[], callOpts?: object) => string|{status,stdout,stderr,error}}
+ */
+function makeHardenedGitRunner(cwd, opts = {}) {
+  const {
+    literalPathspecs = true,
+    noSystemConfig = false,
+    env = process.env,
+    ...scrubOpts
+  } = opts;
+  // noSystemConfig rides envAugment (post-scrub) — GIT_CONFIG_NOSYSTEM is on the scrub denylist,
+  // so setting it on the pre-scrub env would be silently stripped: inert decoration.
+  const envAugment = noSystemConfig
+    ? { ...(scrubOpts.envAugment || {}), GIT_CONFIG_NOSYSTEM: '1' }
+    : scrubOpts.envAugment;
+  const inner = makeScrubbedGitRunner(cwd, { ...scrubOpts, env, envAugment });
+  return (args, callOpts = {}) => {
+    if (!Array.isArray(args)) {
+      throw new Error('HARDENED_RUNNER_ARGV_ONLY: args must be an array — a string here is the sink shape this module abolishes');
+    }
+    const { literalPathspecs: lp = literalPathspecs, validateRefs = [], ...innerCallOpts } = callOpts;
+    for (const ref of validateRefs) validateBaseRef(ref);
+    const globalFlags = ['--no-optional-locks', '-c', 'core.fsmonitor=', '-c', 'core.pager='];
+    if (lp) globalFlags.unshift('--literal-pathspecs');
+    // Find the verb, skipping option-VALUE args (`-c k=v`, `-C <dir>` take a separate value).
+    let verbIdx = -1;
+    for (let i = 0; i < args.length; i += 1) {
+      const a = args[i];
+      if (a === '-c' || a === '-C') { i += 1; continue; }
+      if (!a.startsWith('-')) { verbIdx = i; break; }
+    }
+    const verb = verbIdx > -1 ? args[verbIdx] : null;
+    let finalArgs;
+    if (verb && DIFF_VERBS.has(verb)) {
+      finalArgs = [...globalFlags, ...args.slice(0, verbIdx + 1), '--no-ext-diff', '--no-textconv', ...args.slice(verbIdx + 1)];
+    } else {
+      finalArgs = [...globalFlags, ...args];
+    }
+    return inner(finalArgs, innerCallOpts);
+  };
+}
+
+module.exports = {
+  VALID_BASE_REF,
+  validateBaseRef,
+  OPT_OUTS,
+  assertOptOutReasons,
+  makeHardenedGitRunner,
+  // Re-exported so hardened-runner is a one-stop import for consolidating sites.
+  makeScrubbedGitRunner,
+  scrubGitEnv,
+  GIT_REDIRECT_ENV_KEYS,
+  GIT_REDIRECT_ENV_PREFIXES,
+};

--- a/lib/git/hardened-runner.cjs
+++ b/lib/git/hardened-runner.cjs
@@ -139,12 +139,21 @@ function makeHardenedGitRunner(cwd, opts = {}) {
   };
 }
 
+/**
+ * One-shot form for sites whose cwd varies per call (fleet reapers/detectors). Same hardening,
+ * no factory to hold.
+ */
+function runHardenedGit(args, { cwd = process.cwd(), ...opts } = {}) {
+  return makeHardenedGitRunner(cwd, opts)(args);
+}
+
 module.exports = {
   VALID_BASE_REF,
   validateBaseRef,
   OPT_OUTS,
   assertOptOutReasons,
   makeHardenedGitRunner,
+  runHardenedGit,
   // Re-exported so hardened-runner is a one-stop import for consolidating sites.
   makeScrubbedGitRunner,
   scrubGitEnv,

--- a/lib/git/hardened-runner.test.js
+++ b/lib/git/hardened-runner.test.js
@@ -1,0 +1,199 @@
+/**
+ * Hardened-runner suite — SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A (TS-1..TS-5, TS-8, TS-9,
+ * R-6, R-7). Spy-based: a fake spawnSync captures exactly what would reach git, so the tests
+ * assert the WIRE (argv, env, opts) without launching processes. The two real-git effect tests
+ * for the scrub live in tests/unit/fleet/scrub-wire.test.js and remain authoritative for
+ * behavior-through-a-real-git; this suite owns the runner CONTRACT.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const {
+  VALID_BASE_REF, validateBaseRef, OPT_OUTS, assertOptOutReasons,
+  makeHardenedGitRunner, makeScrubbedGitRunner,
+} = require_('./hardened-runner.cjs');
+
+/** Spy spawnSync returning a configurable result and capturing every call. */
+function makeSpy(result = { status: 0, stdout: 'ok', stderr: '' }) {
+  const calls = [];
+  const fn = (cmd, args, opts) => { calls.push({ cmd, args, opts }); return { ...result }; };
+  return { calls, fn };
+}
+
+describe('TS-1: hostile ref refused before any spawn', () => {
+  it('validateBaseRef throws on option-shaped refs', () => {
+    expect(() => validateBaseRef('--upload-pack=touch pwn')).toThrow(/HOSTILE_BASE_REF/);
+    expect(() => validateBaseRef('-c core.pager=calc')).toThrow(/HOSTILE_BASE_REF/);
+    expect(() => validateBaseRef('')).toThrow(/HOSTILE_BASE_REF/);
+    expect(validateBaseRef('origin/main')).toBe('origin/main');
+    expect(validateBaseRef('v1.2.3')).toBe('v1.2.3');
+  });
+
+  it('runner validateRefs callOpt refuses BEFORE spawnSync runs', () => {
+    const spy = makeSpy();
+    const run = makeHardenedGitRunner('/repo', { spawnSync: spy.fn });
+    expect(() => run(['merge-base', 'HEAD', '--evil'], { validateRefs: ['--evil'] }))
+      .toThrow(/HOSTILE_BASE_REF/);
+    expect(spy.calls.length, 'no git process may be spawned after refusal').toBe(0);
+  });
+});
+
+describe('default hardening flags (FR-1)', () => {
+  it('injects global flags before the verb; --literal-pathspecs is DEFAULT ON (R-5)', () => {
+    const spy = makeSpy();
+    const run = makeHardenedGitRunner('/repo', { spawnSync: spy.fn });
+    run(['status', '--porcelain']);
+    const args = spy.calls[0].args;
+    expect(args[0]).toBe('--literal-pathspecs');
+    expect(args).toContain('--no-optional-locks');
+    const fsmonIdx = args.indexOf('core.fsmonitor=');
+    expect(fsmonIdx).toBeGreaterThan(-1);
+    expect(args[fsmonIdx - 1]).toBe('-c');
+    expect(args.indexOf('status'), 'globals precede the verb').toBeGreaterThan(args.indexOf('--no-optional-locks'));
+  });
+
+  it('literalPathspecs: false is an OPT-OUT that removes only that flag', () => {
+    const spy = makeSpy();
+    const run = makeHardenedGitRunner('/repo', { spawnSync: spy.fn, literalPathspecs: false });
+    run(['status']);
+    expect(spy.calls[0].args).not.toContain('--literal-pathspecs');
+    expect(spy.calls[0].args).toContain('--no-optional-locks');
+  });
+
+  it('diff-family verbs get --no-ext-diff --no-textconv AFTER the verb', () => {
+    const spy = makeSpy();
+    const run = makeHardenedGitRunner('/repo', { spawnSync: spy.fn });
+    run(['diff', '--name-only', 'HEAD']);
+    const args = spy.calls[0].args;
+    const d = args.indexOf('diff');
+    expect(args[d + 1]).toBe('--no-ext-diff');
+    expect(args[d + 2]).toBe('--no-textconv');
+    spy.calls.length = 0;
+    run(['status']);
+    expect(spy.calls[0].args).not.toContain('--no-ext-diff');
+  });
+
+  it('verb detection skips -c/-C option VALUES', () => {
+    const spy = makeSpy();
+    const run = makeHardenedGitRunner('/repo', { spawnSync: spy.fn });
+    run(['-c', 'diff.noprefix=true', 'status']);
+    const args = spy.calls[0].args;
+    expect(args).not.toContain('--no-ext-diff');
+  });
+
+  it('argv-only: a string command is refused outright', () => {
+    const spy = makeSpy();
+    const run = makeHardenedGitRunner('/repo', { spawnSync: spy.fn });
+    expect(() => run('status --porcelain')).toThrow(/HARDENED_RUNNER_ARGV_ONLY/);
+    expect(spy.calls.length).toBe(0);
+  });
+});
+
+describe('TS-3: non-throwing result mode (FR-0)', () => {
+  it('returns {status,stdout,stderr} on non-zero instead of throwing', () => {
+    const spy = makeSpy({ status: 1, stdout: '', stderr: 'dirty' });
+    const run = makeHardenedGitRunner('/repo', { spawnSync: spy.fn, result: true });
+    const r = run(['diff', '--quiet']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toBe('dirty');
+  });
+
+  it('default (strict) mode still throws on non-zero — byte-compatible', () => {
+    const spy = makeSpy({ status: 128, stdout: '', stderr: 'boom' });
+    const run = makeScrubbedGitRunner('/repo', { spawnSync: spy.fn });
+    expect(() => run(['status'])).toThrow(/failed: boom/);
+  });
+});
+
+describe('TS-4/R-6/R-9: opts passthrough (FR-0)', () => {
+  it('timeout, maxBuffer and stdio reach spawnSync; call opts override factory opts', () => {
+    const spy = makeSpy();
+    const run = makeScrubbedGitRunner('/repo', { spawnSync: spy.fn, maxBuffer: 32 * 1024 * 1024, timeout: 30000 });
+    run(['log'], { stdio: ['ignore', 'pipe', 'pipe'] });
+    const o = spy.calls[0].opts;
+    expect(o.maxBuffer).toBe(32 * 1024 * 1024);
+    expect(o.timeout).toBe(30000);
+    expect(o.stdio).toEqual(['ignore', 'pipe', 'pipe']);
+    spy.calls.length = 0;
+    run(['log'], { maxBuffer: 64 * 1024 * 1024 });
+    expect(spy.calls[0].opts.maxBuffer, 'call opts win').toBe(64 * 1024 * 1024);
+  });
+
+  it('defaults leave timeout/maxBuffer/stdio UNSET — byte-compatible with the original runner', () => {
+    const spy = makeSpy();
+    makeScrubbedGitRunner('/repo', { spawnSync: spy.fn })(['status']);
+    const o = spy.calls[0].opts;
+    expect('timeout' in o).toBe(false);
+    expect('maxBuffer' in o).toBe(false);
+    expect('stdio' in o).toBe(false);
+  });
+});
+
+describe('TS-5: env passthrough (FR-0 / inflight-git-state contract)', () => {
+  it('envPassthrough leaves spawn env UNDEFINED so ambient credential helpers resolve', () => {
+    const spy = makeSpy();
+    const run = makeScrubbedGitRunner('/repo', { spawnSync: spy.fn, envPassthrough: true });
+    run(['fetch']);
+    expect(spy.calls[0].opts.env, 'the contract is env === undefined, not a copy').toBeUndefined();
+  });
+
+  it('default scrubs: injected GIT_CONFIG_* and redirection keys are removed', () => {
+    const spy = makeSpy();
+    const hostile = { ...process.env, GIT_CONFIG_COUNT: '1', GIT_DIR: '/evil', GIT_SSH_COMMAND: 'calc' };
+    makeScrubbedGitRunner('/repo', { spawnSync: spy.fn, env: hostile })(['status']);
+    const env = spy.calls[0].opts.env;
+    expect(env.GIT_CONFIG_COUNT).toBeUndefined();
+    expect(env.GIT_DIR).toBeUndefined();
+    expect(env.GIT_SSH_COMMAND).toBeUndefined();
+  });
+});
+
+describe('R-7: the scrub NEGATIVE contract (migrated intent from scrub-wire)', () => {
+  it('default hardened runner does NOT set GIT_CONFIG_NOSYSTEM/GLOBAL — auth must survive', () => {
+    const spy = makeSpy();
+    makeHardenedGitRunner('/repo', { spawnSync: spy.fn })(['fetch']);
+    const env = spy.calls[0].opts.env;
+    expect(env.GIT_CONFIG_NOSYSTEM, 'nulling system config breaks credential.helper (measured)').toBeUndefined();
+    expect(env.GIT_CONFIG_GLOBAL).toBeUndefined();
+  });
+
+  it('noSystemConfig: true survives the scrub via post-scrub augment (never inert)', () => {
+    const spy = makeSpy();
+    makeHardenedGitRunner('/repo', { spawnSync: spy.fn, noSystemConfig: true })(['status']);
+    expect(spy.calls[0].opts.env.GIT_CONFIG_NOSYSTEM).toBe('1');
+  });
+});
+
+describe('TS-9: opt-out ledger refuses reason-less records (R-3)', () => {
+  it('every shipped OPT_OUT carries a non-empty reason', () => {
+    expect(OPT_OUTS.length).toBeGreaterThan(0);
+    expect(() => assertOptOutReasons()).not.toThrow();
+  });
+  it('empty and whitespace-only reasons are refused', () => {
+    expect(() => assertOptOutReasons([{ file: 'x.js', reason: '' }])).toThrow(/OPT_OUT_WITHOUT_REASON/);
+    expect(() => assertOptOutReasons([{ file: 'x.js', reason: '   ' }])).toThrow(/OPT_OUT_WITHOUT_REASON/);
+    expect(() => assertOptOutReasons([{ file: 'x.js' }])).toThrow(/OPT_OUT_WITHOUT_REASON/);
+  });
+});
+
+describe('TS-2: hostile config neutralized through a REAL git (effect test)', () => {
+  it('poisoned core.fsmonitor/pager via -c clearing: status runs clean', () => {
+    // Effect, not structure: run real git status in this repo through the hardened runner with a
+    // hostile env injection attempt; the scrub removes GIT_CONFIG_* so the payload never lands.
+    const hostile = { ...process.env, GIT_CONFIG_COUNT: '1', GIT_CONFIG_KEY_0: 'core.fsmonitor', GIT_CONFIG_VALUE_0: 'node -e "process.exit(99)"' };
+    const run = makeHardenedGitRunner(process.cwd(), { env: hostile, result: true });
+    const r = run(['status', '--porcelain']);
+    expect(r.status, 'hostile injected fsmonitor must not run (exit 99 would surface)').toBe(0);
+  });
+});
+
+describe('TS-8: dual-load — ESM import and CJS require both work', () => {
+  it('ESM dynamic import exposes the same named exports', async () => {
+    const esm = await import('./hardened-runner.cjs');
+    expect(typeof esm.makeHardenedGitRunner).toBe('function');
+    expect(typeof esm.validateBaseRef).toBe('function');
+    expect(esm.VALID_BASE_REF).toBeInstanceOf(RegExp);
+    expect(esm.VALID_BASE_REF.source).toBe(VALID_BASE_REF.source);
+  });
+});

--- a/lib/governance/checkout-freshness.js
+++ b/lib/governance/checkout-freshness.js
@@ -16,7 +16,7 @@
  * @module lib/governance/checkout-freshness
  */
 
-import { execFileSync } from 'node:child_process';
+import { makeHardenedGitRunner } from '../git/hardened-runner.cjs';
 
 /** Canonical protocol files whose drift vs the base ref makes the checkout STALE-CRITICAL. */
 export const CRITICAL_PROTOCOL_FILES = Object.freeze([
@@ -55,8 +55,9 @@ export function evaluateFreshness(state, opts = {}) {
  * timeout-bounded. Path quoting uses double-quotes (works on both POSIX shells and Windows cmd).
  */
 export function makeGit({ cwd = process.cwd(), remote = 'origin', timeout = 10000 } = {}) {
-  // execFileSync (array args, NO shell) => no quoting/injection surface, cross-platform safe.
-  const git = (args) => execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout });
+  // Adopted from the published runner (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A): argv-only,
+  // env scrub (which deliberately PRESERVES system/global credential config — this seam fetches).
+  const git = makeHardenedGitRunner(cwd, { stdio: ['pipe', 'pipe', 'pipe'], timeout });
   return {
     fetch: (baseRef) => {
       // anchored strip: 'origin/main' -> 'main' (don't corrupt 'my-origin/main' or 'upstream/main')

--- a/lib/governance/measurement-provenance.js
+++ b/lib/governance/measurement-provenance.js
@@ -35,12 +35,16 @@
  *    buildProvenancedStamp (PAT-PROVENANCE-SPOOF-VIA-SPREAD-ORDER-001).
  */
 
-import { execSync } from 'node:child_process';
+import { runHardenedGit } from '../git/hardened-runner.cjs';
 
-/** Default git runner: trimmed stdout, '' on any failure (best-effort, bounded). */
+/** Default git runner: trimmed stdout, '' on any failure (best-effort, bounded).
+ *  The seam contract (args STRING in, stdout out) is unchanged for the 9 injected-fake call
+ *  sites; only the default implementation moved off the template-literal execSync shell sink
+ *  onto the published argv runner (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A). The strings
+ *  are internal literals ('rev-parse --short HEAD' etc.), so whitespace-split is exact. */
 export function defaultGit(argsString) {
   try {
-    return execSync(`git ${argsString}`, { encoding: 'utf-8', timeout: 8000 }).trim();
+    return runHardenedGit(String(argsString).trim().split(/\s+/), { timeout: 8000 }).trim();
   } catch {
     return '';
   }

--- a/lib/worktree-reapability.js
+++ b/lib/worktree-reapability.js
@@ -19,7 +19,7 @@
  * previously lived locally inside scripts/worktree-reaper.mjs; the reaper now
  * imports them from here so there is one canonical implementation.
  */
-import { spawnSync } from 'node:child_process';
+import { runHardenedGit } from './git/hardened-runner.cjs';
 import fs from 'node:fs';
 import path from 'node:path';
 
@@ -61,15 +61,14 @@ export function normalizePath(p) {
   catch { return String(p).replace(/\\/g, '/').toLowerCase(); }
 }
 
-/** Default git runner: spawnSync, never throws, returns {stdout,stderr,code}. */
+/** Default git runner: never throws, returns {stdout,stderr,code}. Adopted from the published
+ *  hardened runner (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A). */
 export function runGit(args, cwd = process.cwd()) {
-  const res = spawnSync('git', args, {
-    cwd, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'], windowsHide: true,
-  });
+  const r = runHardenedGit(args, { cwd, stdio: ['ignore', 'pipe', 'pipe'], result: true });
   return {
-    stdout: res.stdout || '',
-    stderr: res.stderr || '',
-    code: res.status == null ? 1 : res.status,
+    stdout: r.stdout,
+    stderr: r.stderr,
+    code: r.status == null ? 1 : r.status,
   };
 }
 

--- a/lib/worktree/stale-base-guard.mjs
+++ b/lib/worktree/stale-base-guard.mjs
@@ -15,7 +15,7 @@
  * @module lib/worktree/stale-base-guard
  */
 
-import { execFileSync } from 'node:child_process';
+import { makeHardenedGitRunner } from '../git/hardened-runner.cjs';
 import { checkoutFreshness } from '../governance/checkout-freshness.js';
 
 /**
@@ -54,7 +54,8 @@ export function renderStaleBaseWarning({ behind, baseRef = 'origin/main', critic
 
 /** Default IO seam: tree-clean probe + hard-reset, both scoped to the worktree root. */
 export function makeGuardGit({ cwd, remote = 'origin', timeout = 15000 } = {}) {
-  const git = (args) => execFileSync('git', args, { cwd, encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'], timeout });
+  // Adopted from the published runner (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A).
+  const git = makeHardenedGitRunner(cwd, { stdio: ['pipe', 'pipe', 'pipe'], timeout });
   return {
     isClean: () => git(['status', '--porcelain']).trim().length === 0,
     // reset --hard to the remote tip; untracked NEW files are preserved (reset only touches tracked).

--- a/scripts/audit/control-seed-specs.json
+++ b/scripts/audit/control-seed-specs.json
@@ -1,260 +1,288 @@
 [
-  {
-    "name": "diagnostic-gauge-citation-lint",
-    "script": "scripts/lint/diagnostic-gauge-citation-lint.mjs",
-    "rootFlag": null,
-    "cwdScope": true,
-    "extraArgs": [
-      "--all"
-    ],
-    "note": "CONTROL-ABOUT-CONTROLS. No --root, but it enumerates via git/fs calls that inherit cwd, so it IS aimable — scopability by flag alone under-counted it.",
-    "fixtures": [
-      {
-        "path": "lib/seeded-gauge-citation-defect.js",
-        "content": "// SEEDED DEFECT: cites a DIAGNOSTIC-ONLY gauge as a numeric gating threshold.\nexport function gate(retro) {\n  if (retro.quality_score >= 90) { return 'ship'; }\n  return 'block';\n}\n"
-      }
-    ],
-    "detectTokens": [
-      "quality_score",
-      "seeded-gauge-citation-defect"
-    ]
+ {
+  "name": "diagnostic-gauge-citation-lint",
+  "script": "scripts/lint/diagnostic-gauge-citation-lint.mjs",
+  "rootFlag": null,
+  "cwdScope": true,
+  "extraArgs": [
+   "--all"
+  ],
+  "note": "CONTROL-ABOUT-CONTROLS. No --root, but it enumerates via git/fs calls that inherit cwd, so it IS aimable — scopability by flag alone under-counted it.",
+  "fixtures": [
+   {
+    "path": "lib/seeded-gauge-citation-defect.js",
+    "content": "// SEEDED DEFECT: cites a DIAGNOSTIC-ONLY gauge as a numeric gating threshold.\nexport function gate(retro) {\n  if (retro.quality_score >= 90) { return 'ship'; }\n  return 'block';\n}\n"
+   }
+  ],
+  "detectTokens": [
+   "quality_score",
+   "seeded-gauge-citation-defect"
+  ]
+ },
+ {
+  "name": "fleet-liveness-select-lint",
+  "script": "scripts/lint/fleet-liveness-select-lint.mjs",
+  "rootFlag": null,
+  "cwdScope": true,
+  "extraArgs": [],
+  "note": "CONTROL-ABOUT-CONTROLS. TESTED IN DEFAULT MODE, DELIBERATELY. An earlier run passed --enforce and scored BLOCKS, but --enforce is NOT what CI runs — the ruled question is whether a control BLOCKS AT MERGE TIME, so measuring a non-default enforcing mode overstates protection. In its default advisory mode it DETECTS and exits 0.",
+  "fixtures": [
+   {
+    "path": "lib/seeded-liveness-select-defect.js",
+    "content": "// SEEDED DEFECT: unbounded multi-row claude_sessions select — the PostgREST 1000-row\n// cap silently drops the NEWEST live workers, so liveness undercounts.\nexport async function all(supabase) {\n  return supabase.from('claude_sessions').select('session_id, heartbeat_at');\n}\n"
+   }
+  ],
+  "detectTokens": [
+   "seeded-liveness-select-defect",
+   "claude_sessions"
+  ]
+ },
+ {
+  "name": "realtime-subscribe-teardown-recursion-lint",
+  "script": "scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs",
+  "rootFlag": "--root",
+  "fixtures": [
+   {
+    "path": "lib/seeded-realtime-defect.js",
+    "content": "// SEEDED DEFECT: teardown called synchronously inside the subscribe callback.\nexport function wire(supabase) {\n  const ch = supabase.channel('x');\n  ch.on('postgres_changes', {}, () => {}).subscribe((status) => {\n    if (status === 'SUBSCRIBED') {\n      supabase.removeChannel(ch);\n    }\n  });\n  return ch;\n}\n"
+   }
+  ]
+ },
+ {
+  "name": "session-coordination-insert-classguard-lint",
+  "script": "scripts/lint/session-coordination-insert-classguard-lint.mjs",
+  "rootFlag": "--root",
+  "fixtures": [
+   {
+    "path": "lib/seeded-coord-defect.js",
+    "content": "// SEEDED DEFECT: raw session_coordination insert bypassing insertCoordinationRow().\nexport async function send(supabase, payload) {\n  const { error } = await supabase.from('session_coordination').insert({\n    message_type: 'INFO',\n    payload\n  });\n  return error;\n}\n"
+   }
+  ]
+ },
+ {
+  "name": "alter-default-override-lint",
+  "script": "scripts/lint/alter-default-override-lint.mjs",
+  "rootFlag": "--root",
+  "fixtures": [
+   {
+    "path": "database/migrations/20260731000000_seeded_default.sql",
+    "content": "-- SEEDED DEFECT: migration sets a default that code below contradicts.\nALTER TABLE seeded_widgets ALTER COLUMN status SET DEFAULT 'active';\n"
+   },
+   {
+    "path": "lib/seeded-default-writer.js",
+    "content": "// SEEDED DEFECT: hardcodes a DIFFERENT literal than the migration default above,\n// silently negating it at insert time (the F12 drift class).\nexport async function create(supabase) {\n  return supabase.from('seeded_widgets').insert({ status: 'draft' });\n}\n"
+   }
+  ]
+ },
+ {
+  "name": "count-delta-gate-lint",
+  "script": "scripts/lint/count-delta-gate-lint.mjs",
+  "rootFlag": "--root",
+  "fixtures": [
+   {
+    "path": "scripts/ci/seeded-count-delta-defect.mjs",
+    "content": "// SEEDED DEFECT: gates on a raw failure-COUNT delta rather than an identity-set diff.\n// Uses the rule's actual lexicon (failedCount / baselineFailed) — my first seed said\n// failCount, which the lexicon does not match, so the control correctly reported 0.\nexport function gate(baselineFailed, failedCount) {\n  if (failedCount > baselineFailed) {\n    throw new Error('failure count rose');\n  }\n  return true;\n}\n"
+   }
+  ],
+  "seedNote": "SEED WAS WRONG AND HAS BEEN FIXED. The rule's EXACT_LEXICON/LEXICON_PATTERN match failed|failing|failure names (failedCount, baselineFailed). My first seed used failCount, which is outside the lexicon, so the control scanned the fixture and correctly found nothing. That was a SEED MISMATCH, never evidence of blindness."
+ },
+ {
+  "name": "ismainmodule-classguard-lint",
+  "script": "scripts/lint/ismainmodule-classguard-lint.mjs",
+  "rootFlag": "--root",
+  "fixtures": [
+   {
+    "path": "scripts/seeded-ismainmodule-defect.mjs",
+    "content": "// SEEDED DEFECT: the raw Windows-broken direct-execution guard. argv[1] is a\n// backslash path on Windows and import.meta.url is a file:// URL, so this never\n// matches and the guard silently no-ops.\nfunction main() { console.log('ran'); }\nif (import.meta.url === `file://${process.argv[1]}`) main();\n"
+   }
+  ]
+ },
+ {
+  "name": "metadata-flag-lint",
+  "script": "scripts/lint/metadata-flag-lint.mjs",
+  "rootFlag": "--root",
+  "fixtures": [
+   {
+    "path": "lib/seeded-metadata-orphan-defect.js",
+    "content": "// SEEDED DEFECT: writes metadata.is_seeded_orphan and nothing ever reads it (ORPHAN).\nexport async function mark(supabase, id) {\n  return supabase.from('widgets').update({ metadata: { is_seeded_orphan: true } }).eq('id', id);\n}\n"
+   }
+  ],
+  "detectTokens": [
+   "is_seeded_orphan"
+  ]
+ },
+ {
+  "name": "rls-anon-tenant-predicate-lint",
+  "script": "scripts/lint/rls-anon-tenant-predicate-lint.mjs",
+  "rootFlag": "--root",
+  "fixtures": [
+   {
+    "path": "database/migrations/20260731000001_seeded_rls_defect.sql",
+    "content": "-- SEEDED DEFECT: SELECT policy references a tenant-shaped column without binding it\n-- to the caller's own identity, so any anon caller reads every tenant's rows.\nCREATE POLICY seeded_anon_select_widgets ON public.widgets\n  FOR SELECT TO anon\n  USING (venture_id IS NOT NULL);\n"
+   }
+  ]
+ },
+ {
+  "name": "no-mocked-sut-import-lint",
+  "script": "scripts/lint/no-mocked-sut-import-lint.mjs",
+  "rootFlag": null,
+  "cwdScope": true,
+  "extraArgs": [
+   "--all"
+  ],
+  "fixtures": [
+   {
+    "path": "tests/unit/seeded-mock-sut.test.js",
+    "content": "import { vi } from 'vitest';\n// SEEDED DEFECT: mocks the module under test itself.\nvi.mock('../../lib/seeded-sut.js');\nimport { thing } from '../../lib/seeded-sut.js';\nit('x', () => { expect(thing).toBeDefined(); });\n"
+   },
+   {
+    "path": "lib/seeded-sut.js",
+    "content": "export const thing = 1;\n"
+   }
+  ],
+  "detectTokens": [
+   "seeded-mock-sut"
+  ],
+  "note": "WAS marked UNTESTABLE on flags alone. SCAN_DIRS is RELATIVE, so it resolves against cwd — retesting via cwdScope.",
+  "seedNote": "UNRESOLVED SILENT, and NOT a mode artifact: re-probed with NO_MOCKED_SUT_IMPORT_MODE=block and it is STILL silent, so promoting it would not change the verdict. Either the seed does not match its detector shape or it genuinely does not fire. NOT recorded as blind on this evidence."
+ },
+ {
+  "name": "venture-artifacts-write-lint",
+  "script": "scripts/lint/venture-artifacts-write-lint.mjs",
+  "rootFlag": null,
+  "cwdScope": true,
+  "fixtures": [
+   {
+    "path": "lib/seeded-venture-artifact-defect.js",
+    "content": "// SEEDED DEFECT: venture_artifacts insert omitting the NOT-NULL title column,\n// which inserts ZERO rows and swallows the error.\nexport async function write(supabase, ventureId) {\n  return supabase.from('venture_artifacts').insert({\n    venture_id: ventureId,\n    lifecycle_stage: 'stage_21',\n    artifact_type: 'design'\n  });\n}\n"
+   }
+  ],
+  "detectTokens": [
+   "seeded-venture-artifact-defect",
+   "title"
+  ],
+  "note": "WAS marked UNTESTABLE on flags alone. SCAN_DIRS is RELATIVE, so it resolves against cwd — retesting via cwdScope."
+ },
+ {
+  "name": "control-seed-test-lint",
+  "script": "scripts/lint/control-seed-test-lint.mjs",
+  "seedTest": "tests/unit/lint/control-seed-test-lint.test.js",
+  "note": "Seeded by the committed TS-5 test: plants a deliberately blind gauge and asserts the gate REFUSES it. Cannot use a fixture trial — this control's certified output is a VERDICT about other controls, not a code pattern in a file.",
+  "neuter": {
+   "find": "reason: 'SEED_DID_NOT_FIRE'",
+   "replace": "reason: 'SEED_DID_NOT_FIRE_NEUTERED'",
+   "why": "the gate stops emitting the SEED_DID_NOT_FIRE reason its own seed-test asserts on"
   },
-  {
-    "name": "fleet-liveness-select-lint",
-    "script": "scripts/lint/fleet-liveness-select-lint.mjs",
-    "rootFlag": null,
-    "cwdScope": true,
-    "extraArgs": [],
-    "note": "CONTROL-ABOUT-CONTROLS. TESTED IN DEFAULT MODE, DELIBERATELY. An earlier run passed --enforce and scored BLOCKS, but --enforce is NOT what CI runs — the ruled question is whether a control BLOCKS AT MERGE TIME, so measuring a non-default enforcing mode overstates protection. In its default advisory mode it DETECTS and exits 0.",
-    "fixtures": [
-      {
-        "path": "lib/seeded-liveness-select-defect.js",
-        "content": "// SEEDED DEFECT: unbounded multi-row claude_sessions select — the PostgREST 1000-row\n// cap silently drops the NEWEST live workers, so liveness undercounts.\nexport async function all(supabase) {\n  return supabase.from('claude_sessions').select('session_id, heartbeat_at');\n}\n"
-      }
-    ],
-    "detectTokens": [
-      "seeded-liveness-select-defect",
-      "claude_sessions"
-    ]
-  },
-  {
-    "name": "realtime-subscribe-teardown-recursion-lint",
-    "script": "scripts/lint/realtime-subscribe-teardown-recursion-lint.mjs",
-    "rootFlag": "--root",
-    "fixtures": [
-      {
-        "path": "lib/seeded-realtime-defect.js",
-        "content": "// SEEDED DEFECT: teardown called synchronously inside the subscribe callback.\nexport function wire(supabase) {\n  const ch = supabase.channel('x');\n  ch.on('postgres_changes', {}, () => {}).subscribe((status) => {\n    if (status === 'SUBSCRIBED') {\n      supabase.removeChannel(ch);\n    }\n  });\n  return ch;\n}\n"
-      }
-    ]
-  },
-  {
-    "name": "session-coordination-insert-classguard-lint",
-    "script": "scripts/lint/session-coordination-insert-classguard-lint.mjs",
-    "rootFlag": "--root",
-    "fixtures": [
-      {
-        "path": "lib/seeded-coord-defect.js",
-        "content": "// SEEDED DEFECT: raw session_coordination insert bypassing insertCoordinationRow().\nexport async function send(supabase, payload) {\n  const { error } = await supabase.from('session_coordination').insert({\n    message_type: 'INFO',\n    payload\n  });\n  return error;\n}\n"
-      }
-    ]
-  },
-  {
-    "name": "alter-default-override-lint",
-    "script": "scripts/lint/alter-default-override-lint.mjs",
-    "rootFlag": "--root",
-    "fixtures": [
-      {
-        "path": "database/migrations/20260731000000_seeded_default.sql",
-        "content": "-- SEEDED DEFECT: migration sets a default that code below contradicts.\nALTER TABLE seeded_widgets ALTER COLUMN status SET DEFAULT 'active';\n"
-      },
-      {
-        "path": "lib/seeded-default-writer.js",
-        "content": "// SEEDED DEFECT: hardcodes a DIFFERENT literal than the migration default above,\n// silently negating it at insert time (the F12 drift class).\nexport async function create(supabase) {\n  return supabase.from('seeded_widgets').insert({ status: 'draft' });\n}\n"
-      }
-    ]
-  },
-  {
-    "name": "count-delta-gate-lint",
-    "script": "scripts/lint/count-delta-gate-lint.mjs",
-    "rootFlag": "--root",
-    "fixtures": [
-      {
-        "path": "scripts/ci/seeded-count-delta-defect.mjs",
-        "content": "// SEEDED DEFECT: gates on a raw failure-COUNT delta rather than an identity-set diff.\n// Uses the rule's actual lexicon (failedCount / baselineFailed) — my first seed said\n// failCount, which the lexicon does not match, so the control correctly reported 0.\nexport function gate(baselineFailed, failedCount) {\n  if (failedCount > baselineFailed) {\n    throw new Error('failure count rose');\n  }\n  return true;\n}\n"
-      }
-    ],
-    "seedNote": "SEED WAS WRONG AND HAS BEEN FIXED. The rule's EXACT_LEXICON/LEXICON_PATTERN match failed|failing|failure names (failedCount, baselineFailed). My first seed used failCount, which is outside the lexicon, so the control scanned the fixture and correctly found nothing. That was a SEED MISMATCH, never evidence of blindness."
-  },
-  {
-    "name": "ismainmodule-classguard-lint",
-    "script": "scripts/lint/ismainmodule-classguard-lint.mjs",
-    "rootFlag": "--root",
-    "fixtures": [
-      {
-        "path": "scripts/seeded-ismainmodule-defect.mjs",
-        "content": "// SEEDED DEFECT: the raw Windows-broken direct-execution guard. argv[1] is a\n// backslash path on Windows and import.meta.url is a file:// URL, so this never\n// matches and the guard silently no-ops.\nfunction main() { console.log('ran'); }\nif (import.meta.url === `file://${process.argv[1]}`) main();\n"
-      }
-    ]
-  },
-  {
-    "name": "metadata-flag-lint",
-    "script": "scripts/lint/metadata-flag-lint.mjs",
-    "rootFlag": "--root",
-    "fixtures": [
-      {
-        "path": "lib/seeded-metadata-orphan-defect.js",
-        "content": "// SEEDED DEFECT: writes metadata.is_seeded_orphan and nothing ever reads it (ORPHAN).\nexport async function mark(supabase, id) {\n  return supabase.from('widgets').update({ metadata: { is_seeded_orphan: true } }).eq('id', id);\n}\n"
-      }
-    ],
-    "detectTokens": [
-      "is_seeded_orphan"
-    ]
-  },
-  {
-    "name": "rls-anon-tenant-predicate-lint",
-    "script": "scripts/lint/rls-anon-tenant-predicate-lint.mjs",
-    "rootFlag": "--root",
-    "fixtures": [
-      {
-        "path": "database/migrations/20260731000001_seeded_rls_defect.sql",
-        "content": "-- SEEDED DEFECT: SELECT policy references a tenant-shaped column without binding it\n-- to the caller's own identity, so any anon caller reads every tenant's rows.\nCREATE POLICY seeded_anon_select_widgets ON public.widgets\n  FOR SELECT TO anon\n  USING (venture_id IS NOT NULL);\n"
-      }
-    ]
-  },
-  {
-    "name": "no-mocked-sut-import-lint",
-    "script": "scripts/lint/no-mocked-sut-import-lint.mjs",
-    "rootFlag": null,
-    "cwdScope": true,
-    "extraArgs": [
-      "--all"
-    ],
-    "fixtures": [
-      {
-        "path": "tests/unit/seeded-mock-sut.test.js",
-        "content": "import { vi } from 'vitest';\n// SEEDED DEFECT: mocks the module under test itself.\nvi.mock('../../lib/seeded-sut.js');\nimport { thing } from '../../lib/seeded-sut.js';\nit('x', () => { expect(thing).toBeDefined(); });\n"
-      },
-      {
-        "path": "lib/seeded-sut.js",
-        "content": "export const thing = 1;\n"
-      }
-    ],
-    "detectTokens": [
-      "seeded-mock-sut"
-    ],
-    "note": "WAS marked UNTESTABLE on flags alone. SCAN_DIRS is RELATIVE, so it resolves against cwd — retesting via cwdScope.",
-    "seedNote": "UNRESOLVED SILENT, and NOT a mode artifact: re-probed with NO_MOCKED_SUT_IMPORT_MODE=block and it is STILL silent, so promoting it would not change the verdict. Either the seed does not match its detector shape or it genuinely does not fire. NOT recorded as blind on this evidence."
-  },
-  {
-    "name": "venture-artifacts-write-lint",
-    "script": "scripts/lint/venture-artifacts-write-lint.mjs",
-    "rootFlag": null,
-    "cwdScope": true,
-    "fixtures": [
-      {
-        "path": "lib/seeded-venture-artifact-defect.js",
-        "content": "// SEEDED DEFECT: venture_artifacts insert omitting the NOT-NULL title column,\n// which inserts ZERO rows and swallows the error.\nexport async function write(supabase, ventureId) {\n  return supabase.from('venture_artifacts').insert({\n    venture_id: ventureId,\n    lifecycle_stage: 'stage_21',\n    artifact_type: 'design'\n  });\n}\n"
-      }
-    ],
-    "detectTokens": [
-      "seeded-venture-artifact-defect",
-      "title"
-    ],
-    "note": "WAS marked UNTESTABLE on flags alone. SCAN_DIRS is RELATIVE, so it resolves against cwd — retesting via cwdScope."
-  },
-  {
-    "name": "control-seed-test-lint",
-    "script": "scripts/lint/control-seed-test-lint.mjs",
-    "seedTest": "tests/unit/lint/control-seed-test-lint.test.js",
-    "note": "Seeded by the committed TS-5 test: plants a deliberately blind gauge and asserts the gate REFUSES it. Cannot use a fixture trial — this control's certified output is a VERDICT about other controls, not a code pattern in a file.",
-    "neuter": {
-      "find": "reason: 'SEED_DID_NOT_FIRE'",
-      "replace": "reason: 'SEED_DID_NOT_FIRE_NEUTERED'",
-      "why": "the gate stops emitting the SEED_DID_NOT_FIRE reason its own seed-test asserts on"
-    },
-    "observability_proof": {
-      "input": "The set of control files CHANGED IN THE DIFF (git diff --name-only against the merge base) intersected with the specs in scripts/audit/control-seed-specs.json; each control's OWN SOURCE TEXT (scanned for the KNOWN LIMITATION declaration); and, per seeded trial, the child process EXIT CODE plus stdout of the control run against a planted fixture. It consumes NO database columns and NO environment variables.",
-      "seen": "Real positive observed in the deployment environment on 2026-08-08: this control BLOCKED PR #6875 in CI with 5 findings across 5 controls (NO_SEED_TEST x3, NO_KNOWN_LIMITATION x2), which is a live CI block, not a fixture trial. Additionally the NO_OBSERVABILITY_PROOF reason added by SD-LEO-INFRA-STANDING-OBSERVABILITY-ACCEPTANCE-001 was observed firing against THIS control at HEAD in a live run (matched 1, TRIALS RUN 1, PROVEN_RED:1) before this proof was declared."
-    }
-  },
-  {
-    "name": "control-seed-test",
-    "script": "scripts/audit/control-seed-test.mjs",
-    "seedTest": "tests/unit/lint/control-seed-test-lint.test.js",
-    "note": "Same TS-5 test exercises runTrial through evaluate — a blind gauge must come back SILENT. Its certified behaviour is a verdict, so there is no code pattern to seed into a fixture.",
-    "neuter": {
-      "find": ": VERDICT.SILENT;",
-      "replace": ": VERDICT.DETECTS;",
-      "why": "runTrial can no longer return SILENT, so a blind gauge reads as detecting"
-    }
-  },
-  {
-    "name": "scanner-convention-lint",
-    "script": "scripts/lint/scanner-convention-lint.mjs",
-    "seedTest": "tests/unit/lint/scanner-convention-lint.test.js",
-    "note": "SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001. Cannot use a fixture trial: this control resolves its scan root from import.meta.url (path.resolve(__dirname,'../..')), NOT from cwd or a --root flag, so the harness cannot aim it at a temp tree. The committed test instead PLANTS a violating scanner through an injected fs and asserts it is caught.",
-    "neuter": {
-      "find": "if (!readsAddedLineText(src)) continue;",
-      "replace": "if (true) continue;",
-      "why": "findViolations stops classifying anything as shape A, so the [PLANTED] case that expects exactly one violation gets zero and goes RED"
-    }
-  },
-  {
-    "name": "schema-reference-lint",
-    "script": "scripts/lint/schema-reference-lint.mjs",
-    "seedTest": "tests/unit/lint/scanner-fixture-exclusion.test.js",
-    "note": "SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-2). A fixture trial is impractical here: this control exits early without database/schema-reference-snapshot.json, so a bare temp tree cannot exercise it. The committed test plants one payload at two paths differing ONLY in being fixture material and RUNS the control against both, asserting the control file is flagged (control-first) and the fixture twin is not.",
-    "neuter": {
-      "find": "if (isFixtureEntry(p, e.isDirectory())) continue;",
-      "replace": "if (false) continue;",
-      "why": "the --all walk stops pruning fixture directories, so the planted lib/__tests__ file is scanned and flagged, and the assertion that no hit contains __tests__ goes RED"
-    }
-  },
-  {
-    "name": "stage-advancement-chokepoint-lint",
-    "script": "scripts/lint/stage-advancement-chokepoint-lint.mjs",
-    "seedTest": "tests/unit/lint/scanner-fixture-exclusion.test.js",
-    "note": "SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-2). Same committed two-sided test: one payload, two paths differing only in being fixture material, control asserted FIRST so a silently-dead scanner cannot pass as 'no fixture hit'.",
-    "neuter": {
-      "find": "if (isFixtureEntry(p, e.isDirectory())) continue;",
-      "replace": "if (false) continue;",
-      "why": "the --all walk stops pruning fixture directories, so the planted lib/__tests__ file is scanned and flagged, and the assertion that no hit contains __tests__ goes RED"
-    }
-  },
-  {
-    "name": "fixture-producer-guard-lint",
-    "script": "scripts/lint/fixture-producer-guard-lint.mjs",
-    "rootFlag": "--root",
-    "observability_proof": {
-      "input": "The SOURCE TEXT of every *.mjs/*.js/*.cjs file found by a recursive walk of four named roots (tests/integration, tests/database, scripts/harness, scripts/canary), read with readFileSync and stripped of comments and string bodies before matching; plus scripts/lint/fixture-producer-guard-allowlist.json, whose keys are '<repo-relative-file>' or '<repo-relative-file>:<line>'. Its OUTPUT SIGNAL is the process exit code (0 = clean, 1 = violations found OR zero guarded sites OR the startup selfTest failed) plus a stdout summary line carrying the guarded-site and unguarded-write counts, and one stderr line per violation naming file:line. It consumes NO database columns and NO environment variables.",
-      "seen": "Real UNPLANTED positive observed in the deployment environment (live invocation against the actual repository working tree, 2026-08-08): during the conversion sweep this control reported an unguarded ventures write in tests/integration/eva/venture-error-aggregation-realdb.test.js that a bulk rewrite had silently failed to convert — that file binds its supabase client as 'svc', so a rewrite keyed to one spelling matched zero sites there while reporting success on the other files. The control's count is what exposed it; the rewrite's own report said success. Separately, a planted two-sided probe on the same real tree showed the pre-fix build printing '2 write-site(s) found' AND 'every ventures write routes through insertGuarded' at exit 0, and the post-fix build exiting 1 naming both sites. HONEST LIMIT ON THIS FIELD: the .github/workflows/fixture-producer-guard-lint.yml job has so far only ever run GREEN — this control has NOT yet blocked a pull request in CI, so the positives cited above are live local invocations, not CI blocks."
-    },
-    "note": "SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-D (FR-6). TWO fixtures, and the second is load-bearing rather than decoration. This lint REFUSES to report success on zero guarded sites (a blind extractor and a clean tree otherwise print the same green), and that refusal returns BEFORE the violation listing. Seeding only the defect would therefore exercise the zero-guarded branch and never emit the seeded filename, scoring a firing control SILENT. The guarded twin puts the denominator above zero so the trial drives the REAL violation-reporting path. DETECTION IS DELIBERATELY KEYED ON THE SEEDED FILENAME ALONE: the summary line prints 'N unguarded ventures write-site(s)' on every run including a clean one, so declaring that phrase a detectToken would mark this control as firing when it found nothing.",
-    "fixtures": [
-      {
-        "path": "tests/integration/seeded-fixture-producer-defect.js",
-        "content": "// SEEDED DEFECT: a raw ventures insert that no producer-side assert ever checked.\nexport async function make(supabase) {\n  return supabase.from('ventures').insert({ name: 'seeded-unguarded-row', is_demo: true });\n}\n"
-      },
-      {
-        "path": "scripts/harness/seeded-fixture-producer-guarded.js",
-        "content": "// NOT the defect. A correctly guarded producer, present so the coverage denominator is\n// non-zero — see the note on this spec. The lint reads source as TEXT and never imports it,\n// so the unresolvable path below is irrelevant to the trial.\nimport { insertGuarded, CLASSIFICATION } from '../../lib/governance/fixture-producer-guard.mjs';\nexport async function ok(supabase) {\n  return insertGuarded(supabase, 'ventures', { name: 'TEST-seeded-guarded', is_demo: true },\n    { classification: CLASSIFICATION.FIXTURE, source: 'seed-trial' });\n}\n"
-      }
-    ]
-  },
-  {
-    "name": "or-filter-must-project",
-    "script": "scripts/lint/or-filter-must-project.mjs",
-    "seedTest": "tests/unit/claim/every-claim-write-reaffirm.test.js",
-    "note": "SD-LEO-INFRA-EVERY-CLAIM-WRITE-001 (FR-4). The control it guards: on a PostgREST UPDATE an .or() filter resolves its columns against the RETURNING projection, so filtering on a column the .select() omits returns 42703 on EVERY call — and the error names that column as missing when it exists, which is why the original defect was misdiagnosed as transient schema-cache staleness. seedTest form rather than fixtures because this control ships as a PURE FUNCTION over source text with no file-walking CLI, so there is no root to aim at a fixture directory; the committed test compensates by carrying BOTH directions itself — a hand-written broken chain that must be flagged, the real lib/quick-fix-claim.mjs that must NOT be (the positive control the coordinator directed me to leave untouched), an .eq-only chain that must NOT be flagged (measured: .eq does not resolve against the projection, so linting it would churn three working release sites), and an in-test mutation that narrows the real claim-guard projection back and asserts the lint catches it.",
-    "neuter": {
-      "find": "if (missing.length > 0) {",
-      "replace": "if (false) {",
-      "why": "the lint stops reporting findings, so the deliberately-broken chain in the seed test is no longer flagged and the FLAGS-the-narrowed-projection assertion goes RED — proving the control is what makes that test pass, not the test asserting its own premise."
-    },
-    "observability_proof": {
-      "input": "The SOURCE TEXT of a single .js/.mjs/.cjs file, passed directly to findUnprojectedOrFilters(source, filePath) as a string, with block and line comments BLANKED (not deleted, so reported line numbers stay true) before matching. It consumes NO database columns, NO environment variables, and NO filesystem walk — the caller supplies the text. Its OUTPUT SIGNAL is the returned array of findings, each {file, line, missing[], projection, message}; an empty array means no unprojected .or() filter was found in that text.",
-      "seen": "A REAL positive on REAL DEPLOYED SOURCE, not a temp-dir fixture: run against the pre-fix blob of lib/claim-guard.mjs as it stood on origin/main (blob ab68046eecdcb5f4d78bab0df94f9092fc4e5bed), it returns exactly ONE finding, at line 211, missing=claiming_session_id, projection=sd_key. That is the precise chain which, executed against live PostgREST under a service-role key on 2026-08-09, returned 42703 column strategic_directives_v2.claiming_session_id does not exist on every call while a SELECT with the identical .or filter returned rows — so the control fires on the exact deployed line whose live failure was independently observed, and the readback of claim_gate_client_version (NULL under that blob, 1 after the fix) is the persisted evidence of that failure. Two-sided in the same run: 0 findings on the fixed file, 0 on lib/quick-fix-claim.mjs and 0 on lib/claim/reacquire-self-live.mjs, both of which are correct and must never be flagged. NOTE the limitation that bounds this proof: reacquire-self-live passes a VARIABLE to .or(), so its 0 is unanalyzable-and-silent, not verified-clean."
-    }
+  "observability_proof": {
+   "input": "The set of control files CHANGED IN THE DIFF (git diff --name-only against the merge base) intersected with the specs in scripts/audit/control-seed-specs.json; each control's OWN SOURCE TEXT (scanned for the KNOWN LIMITATION declaration); and, per seeded trial, the child process EXIT CODE plus stdout of the control run against a planted fixture. It consumes NO database columns and NO environment variables.",
+   "seen": "Real positive observed in the deployment environment on 2026-08-08: this control BLOCKED PR #6875 in CI with 5 findings across 5 controls (NO_SEED_TEST x3, NO_KNOWN_LIMITATION x2), which is a live CI block, not a fixture trial. Additionally the NO_OBSERVABILITY_PROOF reason added by SD-LEO-INFRA-STANDING-OBSERVABILITY-ACCEPTANCE-001 was observed firing against THIS control at HEAD in a live run (matched 1, TRIALS RUN 1, PROVEN_RED:1) before this proof was declared."
   }
+ },
+ {
+  "name": "control-seed-test",
+  "script": "scripts/audit/control-seed-test.mjs",
+  "seedTest": "tests/unit/lint/control-seed-test-lint.test.js",
+  "note": "Same TS-5 test exercises runTrial through evaluate — a blind gauge must come back SILENT. Its certified behaviour is a verdict, so there is no code pattern to seed into a fixture.",
+  "neuter": {
+   "find": ": VERDICT.SILENT;",
+   "replace": ": VERDICT.DETECTS;",
+   "why": "runTrial can no longer return SILENT, so a blind gauge reads as detecting"
+  }
+ },
+ {
+  "name": "scanner-convention-lint",
+  "script": "scripts/lint/scanner-convention-lint.mjs",
+  "seedTest": "tests/unit/lint/scanner-convention-lint.test.js",
+  "note": "SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001. Cannot use a fixture trial: this control resolves its scan root from import.meta.url (path.resolve(__dirname,'../..')), NOT from cwd or a --root flag, so the harness cannot aim it at a temp tree. The committed test instead PLANTS a violating scanner through an injected fs and asserts it is caught.",
+  "neuter": {
+   "find": "if (!readsAddedLineText(src)) continue;",
+   "replace": "if (true) continue;",
+   "why": "findViolations stops classifying anything as shape A, so the [PLANTED] case that expects exactly one violation gets zero and goes RED"
+  }
+ },
+ {
+  "name": "schema-reference-lint",
+  "script": "scripts/lint/schema-reference-lint.mjs",
+  "seedTest": "tests/unit/lint/scanner-fixture-exclusion.test.js",
+  "note": "SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-2). A fixture trial is impractical here: this control exits early without database/schema-reference-snapshot.json, so a bare temp tree cannot exercise it. The committed test plants one payload at two paths differing ONLY in being fixture material and RUNS the control against both, asserting the control file is flagged (control-first) and the fixture twin is not.",
+  "neuter": {
+   "find": "if (isFixtureEntry(p, e.isDirectory())) continue;",
+   "replace": "if (false) continue;",
+   "why": "the --all walk stops pruning fixture directories, so the planted lib/__tests__ file is scanned and flagged, and the assertion that no hit contains __tests__ goes RED"
+  },
+  "observability_proof": {
+   "input": "git diff added-line file set (merge-base..HEAD via its runGit, now the published hardened runner) cross-referenced against relation names in database/schema-reference-snapshot.json; base ref from env SCHEMA_LINT_BASE (set in CI by .github/workflows/schema-reference-lint.yml:60)",
+   "seen": "real positives triaged as escapes into scripts/lint/schema-reference-allowlist.json (files/tables entries recorded under SD-LEO-INFRA-SCHEMA-REFERENCE-LINT-001) during the advisory soak that preceded the blocking flip pinned by tests/unit/schema-reference-lint-workflow-blocking.test.js (soak 2026-06-10..2026-06-17); the lint runs live on every PR via .github/workflows/schema-reference-lint.yml"
+  }
+ },
+ {
+  "name": "stage-advancement-chokepoint-lint",
+  "script": "scripts/lint/stage-advancement-chokepoint-lint.mjs",
+  "seedTest": "tests/unit/lint/scanner-fixture-exclusion.test.js",
+  "note": "SD-LEO-INFRA-SWEEP-REPO-SCANNERS-001 (FR-2). Same committed two-sided test: one payload, two paths differing only in being fixture material, control asserted FIRST so a silently-dead scanner cannot pass as 'no fixture hit'.",
+  "neuter": {
+   "find": "if (isFixtureEntry(p, e.isDirectory())) continue;",
+   "replace": "if (false) continue;",
+   "why": "the --all walk stops pruning fixture directories, so the planted lib/__tests__ file is scanned and flagged, and the assertion that no hit contains __tests__ goes RED"
+  }
+ },
+ {
+  "name": "fixture-producer-guard-lint",
+  "script": "scripts/lint/fixture-producer-guard-lint.mjs",
+  "rootFlag": "--root",
+  "observability_proof": {
+   "input": "The SOURCE TEXT of every *.mjs/*.js/*.cjs file found by a recursive walk of four named roots (tests/integration, tests/database, scripts/harness, scripts/canary), read with readFileSync and stripped of comments and string bodies before matching; plus scripts/lint/fixture-producer-guard-allowlist.json, whose keys are '<repo-relative-file>' or '<repo-relative-file>:<line>'. Its OUTPUT SIGNAL is the process exit code (0 = clean, 1 = violations found OR zero guarded sites OR the startup selfTest failed) plus a stdout summary line carrying the guarded-site and unguarded-write counts, and one stderr line per violation naming file:line. It consumes NO database columns and NO environment variables.",
+   "seen": "Real UNPLANTED positive observed in the deployment environment (live invocation against the actual repository working tree, 2026-08-08): during the conversion sweep this control reported an unguarded ventures write in tests/integration/eva/venture-error-aggregation-realdb.test.js that a bulk rewrite had silently failed to convert — that file binds its supabase client as 'svc', so a rewrite keyed to one spelling matched zero sites there while reporting success on the other files. The control's count is what exposed it; the rewrite's own report said success. Separately, a planted two-sided probe on the same real tree showed the pre-fix build printing '2 write-site(s) found' AND 'every ventures write routes through insertGuarded' at exit 0, and the post-fix build exiting 1 naming both sites. HONEST LIMIT ON THIS FIELD: the .github/workflows/fixture-producer-guard-lint.yml job has so far only ever run GREEN — this control has NOT yet blocked a pull request in CI, so the positives cited above are live local invocations, not CI blocks."
+  },
+  "note": "SD-LEO-INFRA-ONE-SYNTHETIC-ROW-001-D (FR-6). TWO fixtures, and the second is load-bearing rather than decoration. This lint REFUSES to report success on zero guarded sites (a blind extractor and a clean tree otherwise print the same green), and that refusal returns BEFORE the violation listing. Seeding only the defect would therefore exercise the zero-guarded branch and never emit the seeded filename, scoring a firing control SILENT. The guarded twin puts the denominator above zero so the trial drives the REAL violation-reporting path. DETECTION IS DELIBERATELY KEYED ON THE SEEDED FILENAME ALONE: the summary line prints 'N unguarded ventures write-site(s)' on every run including a clean one, so declaring that phrase a detectToken would mark this control as firing when it found nothing.",
+  "fixtures": [
+   {
+    "path": "tests/integration/seeded-fixture-producer-defect.js",
+    "content": "// SEEDED DEFECT: a raw ventures insert that no producer-side assert ever checked.\nexport async function make(supabase) {\n  return supabase.from('ventures').insert({ name: 'seeded-unguarded-row', is_demo: true });\n}\n"
+   },
+   {
+    "path": "scripts/harness/seeded-fixture-producer-guarded.js",
+    "content": "// NOT the defect. A correctly guarded producer, present so the coverage denominator is\n// non-zero — see the note on this spec. The lint reads source as TEXT and never imports it,\n// so the unresolvable path below is irrelevant to the trial.\nimport { insertGuarded, CLASSIFICATION } from '../../lib/governance/fixture-producer-guard.mjs';\nexport async function ok(supabase) {\n  return insertGuarded(supabase, 'ventures', { name: 'TEST-seeded-guarded', is_demo: true },\n    { classification: CLASSIFICATION.FIXTURE, source: 'seed-trial' });\n}\n"
+   }
+  ]
+ },
+ {
+  "name": "or-filter-must-project",
+  "script": "scripts/lint/or-filter-must-project.mjs",
+  "seedTest": "tests/unit/claim/every-claim-write-reaffirm.test.js",
+  "note": "SD-LEO-INFRA-EVERY-CLAIM-WRITE-001 (FR-4). The control it guards: on a PostgREST UPDATE an .or() filter resolves its columns against the RETURNING projection, so filtering on a column the .select() omits returns 42703 on EVERY call — and the error names that column as missing when it exists, which is why the original defect was misdiagnosed as transient schema-cache staleness. seedTest form rather than fixtures because this control ships as a PURE FUNCTION over source text with no file-walking CLI, so there is no root to aim at a fixture directory; the committed test compensates by carrying BOTH directions itself — a hand-written broken chain that must be flagged, the real lib/quick-fix-claim.mjs that must NOT be (the positive control the coordinator directed me to leave untouched), an .eq-only chain that must NOT be flagged (measured: .eq does not resolve against the projection, so linting it would churn three working release sites), and an in-test mutation that narrows the real claim-guard projection back and asserts the lint catches it.",
+  "neuter": {
+   "find": "if (missing.length > 0) {",
+   "replace": "if (false) {",
+   "why": "the lint stops reporting findings, so the deliberately-broken chain in the seed test is no longer flagged and the FLAGS-the-narrowed-projection assertion goes RED — proving the control is what makes that test pass, not the test asserting its own premise."
+  },
+  "observability_proof": {
+   "input": "The SOURCE TEXT of a single .js/.mjs/.cjs file, passed directly to findUnprojectedOrFilters(source, filePath) as a string, with block and line comments BLANKED (not deleted, so reported line numbers stay true) before matching. It consumes NO database columns, NO environment variables, and NO filesystem walk — the caller supplies the text. Its OUTPUT SIGNAL is the returned array of findings, each {file, line, missing[], projection, message}; an empty array means no unprojected .or() filter was found in that text.",
+   "seen": "A REAL positive on REAL DEPLOYED SOURCE, not a temp-dir fixture: run against the pre-fix blob of lib/claim-guard.mjs as it stood on origin/main (blob ab68046eecdcb5f4d78bab0df94f9092fc4e5bed), it returns exactly ONE finding, at line 211, missing=claiming_session_id, projection=sd_key. That is the precise chain which, executed against live PostgREST under a service-role key on 2026-08-09, returned 42703 column strategic_directives_v2.claiming_session_id does not exist on every call while a SELECT with the identical .or filter returned rows — so the control fires on the exact deployed line whose live failure was independently observed, and the readback of claim_gate_client_version (NULL under that blob, 1 after the fix) is the persisted evidence of that failure. Two-sided in the same run: 0 findings on the fixed file, 0 on lib/quick-fix-claim.mjs and 0 on lib/claim/reacquire-self-live.mjs, both of which are correct and must never be flagged. NOTE the limitation that bounds this proof: reacquire-self-live passes a VARIABLE to .or(), so its 0 is unanalyzable-and-silent, not verified-clean."
+  }
+ },
+ {
+  "name": "no-process-cwd-in-sub-agents-lint",
+  "script": "scripts/lint/no-process-cwd-in-sub-agents-lint.mjs",
+  "rootFlag": null,
+  "cwdScope": true,
+  "extraArgs": [
+   "--all"
+  ],
+  "note": "Surfaced by SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A adopting the published git runner in this lint (no control-logic change) — the control itself predates that diff and had no spec entry. Module-anchored REPO_ROOT, self-gated to lib/sub-agents/, so it is aimed by planting the seed there and running --all.",
+  "fixtures": [
+   {
+    "path": "lib/sub-agents/seeded-process-cwd-defect.js",
+    "content": "// SEEDED DEFECT: resolves repo paths against process.cwd() inside a sub-agent module.\nexport function repoPath() { return process.cwd(); }\n"
+   }
+  ],
+  "detectTokens": [
+   "seeded-process-cwd-defect",
+   "process.cwd"
+  ],
+  "observability_proof": {
+   "input": "ESLint rule no-process-cwd-in-sub-agents evaluated over lib/sub-agents/** source text; file set from git merge-base diff (default) or a module-anchored walk of SCAN_DIRS (--all)",
+   "seen": "live invocation at the LEAD phase of SD-LEO-INFRA-NO-PROCESS-CWD-SUB-AGENTS-001 measured 5 real violations, all resolved by that SD — recorded in the lint's own main() (\"The tree was measured clean at LEAD (5 violations, all resolved by this SD)\"); the lint runs blocking on every invocation since"
+  }
+ }
 ]

--- a/scripts/docmon.js
+++ b/scripts/docmon.js
@@ -25,7 +25,7 @@ import path from 'path';
 // merge-base fallbacks to 'HEAD~1', the getChangedFiles fallback to a full scan, and
 // getBeforeWordCount's `return 0 // New file`. spawnSync returns {stdout,stderr,status} and does
 // NOT throw, so swapping it in would silently stop ALL THREE from ever firing.
-import { execFileSync } from 'child_process';
+import { makeHardenedGitRunner } from '../lib/git/hardened-runner.cjs';
 import { fileURLToPath } from 'url';
 import { minimatch } from 'minimatch';
 
@@ -95,7 +95,10 @@ Configuration:
 // Applied in the RUNNER, so it also covers `git show` below, where it is INERT (a <rev>:<path>
 // object name is a single argv token, not a pathspec). Kept uniform on purpose: excluding it there
 // would need per-call-site logic, which is exactly the fragility the runner principle warns about.
-const runGit = (args) => execFileSync('git', ['--literal-pathspecs', ...args], { encoding: 'utf-8' });
+// Adopted from the published runner (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A):
+// --literal-pathspecs is its DEFAULT, and it adds the env scrub + fsmonitor/pager clearing this
+// private copy never had.
+const runGit = makeHardenedGitRunner(process.cwd());
 
 function getChangedFiles() {
   try {

--- a/scripts/lint/no-process-cwd-in-sub-agents-lint.mjs
+++ b/scripts/lint/no-process-cwd-in-sub-agents-lint.mjs
@@ -29,7 +29,7 @@
 //   node scripts/lint/no-process-cwd-in-sub-agents-lint.mjs --all --json
 import fs from 'node:fs';
 import path from 'node:path';
-import { execFileSync } from 'node:child_process';
+import { makeHardenedGitRunner } from '../../lib/git/hardened-runner.cjs';
 import { fileURLToPath } from 'node:url';
 import { Linter } from 'eslint';
 import rule from '../../eslint-rules/no-process-cwd-in-sub-agents.js';
@@ -97,7 +97,8 @@ function candidateFilesAll(root) {
  * execFileSync rather than execSync: no shell features are needed, so no shell is involved.
  */
 function candidateFilesDiff(root) {
-  const git = (args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' });
+  // Adopted from the published runner (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A).
+  const git = makeHardenedGitRunner(root);
   const base = git(['merge-base', 'HEAD', 'origin/main']).trim();
   const names = new Set();
   for (const args of [

--- a/scripts/lint/no-process-cwd-in-sub-agents-lint.mjs
+++ b/scripts/lint/no-process-cwd-in-sub-agents-lint.mjs
@@ -47,8 +47,8 @@ const PLUGIN_NS = 'sub-agents';
 const RULE_NAME = 'no-process-cwd-in-sub-agents';
 const RULE_ID = `${PLUGIN_NS}/${RULE_NAME}`;
 
-// Shapes this predicate knowingly does NOT catch. Printed every run so a zero-finding result is
-// never mistaken for a zero-defect codebase.
+// KNOWN LIMITATION: shapes this predicate knowingly does NOT catch. Printed every run so a
+// zero-finding result is never mistaken for a zero-defect codebase.
 const KNOWN_MISSED = [
   'indirect cwd: `const {cwd} = process; cwd()` — the member expression is destructured away, so the AST match cannot see it',
   'aliased: `const p = process; p.cwd()` — single-file AST does not track the alias',

--- a/scripts/lint/schema-reference-lint.mjs
+++ b/scripts/lint/schema-reference-lint.mjs
@@ -85,10 +85,11 @@ const runGit = (args, opts = {}) => execFileSync('git', args, {
 // (process.env.SCHEMA_LINT_BASE below) and in CI is set from a workflow context expression at
 // .github/workflows/schema-reference-lint.yml:60, so it is not a hypothetical.
 //
-// This repo already adopted exactly this control for the identical sink — lib/fleet/tree-currency.cjs:53,
-// applied at :105 for its own SEC-1 finding — and it simply was not carried here. Same regex, reused
-// verbatim: two shape-guards that drift apart are worse than one shared one.
-const VALID_BASE_REF = /^[A-Za-z0-9._][A-Za-z0-9._/-]*$/;
+// This repo already adopted exactly this control for the identical sink — lib/fleet/tree-currency.cjs,
+// applied for its own SEC-1 finding — and it simply was not carried here. Now imported from the
+// published single representation: two shape-guards that drift apart are worse than one shared one.
+// (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A)
+import { VALID_BASE_REF } from '../../lib/git/hardened-runner.cjs';
 
 const args = process.argv.slice(2);
 const mode = args.includes('--all') ? 'all' : 'diff';

--- a/scripts/lint/schema-reference-lint.mjs
+++ b/scripts/lint/schema-reference-lint.mjs
@@ -29,7 +29,6 @@ import { readFileSync, existsSync, readdirSync } from 'node:fs';
 // degrades to an advisory full sweep, and the one in baselineViolationKeys treats a throw as
 // "file did not exist at the merge base". spawnSync returns {stdout,stderr,status} and does NOT
 // throw, so swapping it in would silently stop BOTH catches from ever firing.
-import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { extractReferences, findViolations } from './schema-reference-extract.mjs';
 // SD-LEO-INFRA-SCHEMA-LINT-DEGRADED-FAILOPEN-001: a degraded --diff run (unresolvable base ->
@@ -67,8 +66,10 @@ const STALE_DAYS = 7;
 // later reader could mistake for the protection. (docmon.js DOES pass a pathspec and DOES need it.)
 // `opts` exists so per-call stdio survives the conversion. The baseline read deliberately keeps
 // stderr on 'ignore'; folding that into the runner for every call would change unrelated output.
-const runGit = (args, opts = {}) => execFileSync('git', args, {
-  encoding: 'utf8', timeout: 30000, maxBuffer: 32 * 1024 * 1024, ...opts,
+// Adopted from the published runner (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A) with
+// literalPathspecs: false — the opt-out above is RECORDED in the runner's OPT_OUTS ledger.
+const runGit = makeHardenedGitRunner(process.cwd(), {
+  literalPathspecs: false, timeout: 30000, maxBuffer: 32 * 1024 * 1024,
 });
 
 // SEC: argv-safety stops SHELLS, not ARGUMENT injection. `base` reaches git as a positional
@@ -89,7 +90,7 @@ const runGit = (args, opts = {}) => execFileSync('git', args, {
 // applied for its own SEC-1 finding — and it simply was not carried here. Now imported from the
 // published single representation: two shape-guards that drift apart are worse than one shared one.
 // (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A)
-import { VALID_BASE_REF } from '../../lib/git/hardened-runner.cjs';
+import { VALID_BASE_REF, makeHardenedGitRunner } from '../../lib/git/hardened-runner.cjs';
 
 const args = process.argv.slice(2);
 const mode = args.includes('--all') ? 'all' : 'diff';

--- a/scripts/log-harness-bug.js
+++ b/scripts/log-harness-bug.js
@@ -18,7 +18,7 @@
 // Idempotent: a SHA-256 dedup_hash over (date::symptom::file) prevents duplicate inserts.
 // Filter rows: category='harness_backlog' AND status='new' for the open backlog.
 import 'dotenv/config';
-import { execSync } from 'node:child_process';
+import { runHardenedGit } from '../lib/git/hardened-runner.cjs';
 import { realpathSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { createClient } from '@supabase/supabase-js';
@@ -31,9 +31,12 @@ import { emitFeedback } from '../lib/governance/emit-feedback.js';
  * never blocks the insert — purely advisory. Returns { commit, when, subject, via } or null.
  */
 export function findPossiblePriorFix({ symptom, file } = {}) {
+  // Adopted from the published runner (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A): this was a
+  // template-literal execSync — the exact sink shape the sibling lint (child B) forbids — with
+  // caller-influenced values (file path, symptom token) reaching the shell string. Now argv.
   const git = (args) => {
     try {
-      return execSync(`git ${args}`, { encoding: 'utf-8', timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+      return runHardenedGit(args, { timeout: 5000, stdio: ['pipe', 'pipe', 'pipe'] }).trim();
     } catch {
       return '';
     }
@@ -52,14 +55,14 @@ export function findPossiblePriorFix({ symptom, file } = {}) {
   try {
     // Source 1: most recent origin/main commit touching the cited file.
     if (file) {
-      const hit = parse(git(`log origin/main -n 1 --format="%h|%cI|%s" -- "${file.replace(/"/g, '')}"`), 'file:' + file);
+      const hit = parse(git(['log', 'origin/main', '-n', '1', '--format=%h|%cI|%s', '--', file]), 'file:' + file);
       if (hit) return hit;
     }
     // Source 2: the most distinctive identifier/path token from the symptom, matched (literal,
     // case-insensitive) against recent origin/main commit messages. Cheap vs. full-history pickaxe.
     const token = (symptom || '').match(/[A-Za-z0-9_./-]{8,}/g)?.sort((a, b) => b.length - a.length)[0];
     if (token) {
-      const hit = parse(git(`log origin/main -n 1 --format="%h|%cI|%s" -F -i --grep="${token.replace(/"/g, '')}"`), 'keyword:' + token);
+      const hit = parse(git(['log', 'origin/main', '-n', '1', '--format=%h|%cI|%s', '-F', '-i', '--grep=' + token]), 'keyword:' + token);
       if (hit) return hit;
     }
   } catch {

--- a/scripts/phantom-test-audit.js
+++ b/scripts/phantom-test-audit.js
@@ -17,7 +17,7 @@
  * testFiles})` does NO I/O — all git/fs lives in the CLI wrapper at the bottom
  * of this file, which collects inputs and invokes the pure function.
  */
-import { execSync } from 'node:child_process';
+import { runHardenedGit } from '../lib/git/hardened-runner.cjs';
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -151,8 +151,17 @@ export function collectAndAudit({ repoPath, baseRef = 'origin/main' }) {
 }
 
 function safeGit(cmd, cwd, opts = {}) {
+  // The SEAM contract stays a full command string (injected fakes and the gate test's pins both
+  // assert e.g. 'git merge-base HEAD origin/main' verbatim); only the DEFAULT implementation
+  // moved off execSync — the string is tokenized (quoted pathspecs unwrapped: the quotes were
+  // shell-level) and executed argv-style through the published hardened runner
+  // (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A). A shell metacharacter in the string is now a
+  // literal argument git rejects, never a second command.
   try {
-    return execSync(cmd, { encoding: 'utf8', cwd, timeout: 15000, maxBuffer: 8 * 1024 * 1024, ...opts });
+    const tokens = (String(cmd).trim().match(/"([^"]*)"|\S+/g) || [])
+      .map((t) => t.replace(/^"|"$/g, ''));
+    if (tokens[0] !== 'git') return '';
+    return runHardenedGit(tokens.slice(1), { cwd, timeout: 15000, maxBuffer: 8 * 1024 * 1024, ...opts });
   } catch (_err) {
     return '';
   }

--- a/scripts/worktree-reaper.mjs
+++ b/scripts/worktree-reaper.mjs
@@ -49,6 +49,7 @@
  */
 
 import { execSync, spawnSync } from 'node:child_process';
+import { runHardenedGit } from '../lib/git/hardened-runner.cjs';
 import fs from 'node:fs';
 import path from 'node:path';
 import readline from 'node:readline';
@@ -610,17 +611,18 @@ async function loadSdKeySets(supabase) {
 
 // ── Git / Gh runners ───────────────────────────────────────────────────
 
+// Adopted from the published hardened runner (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A);
+// exported (FR-5) so the fs-rm+prune fallback path that reaches it is testable.
 function runGit(args, opts = {}) {
-  const res = spawnSync('git', args, {
+  const r = runHardenedGit(args, {
     cwd: opts.cwd || process.cwd(),
-    encoding: 'utf8',
     stdio: ['ignore', 'pipe', 'pipe'],
-    windowsHide: true,
+    result: true,
   });
   return {
-    stdout: res.stdout || '',
-    stderr: res.stderr || '',
-    code: res.status == null ? 1 : res.status,
+    stdout: r.stdout,
+    stderr: r.stderr,
+    code: r.status == null ? 1 : r.status,
   };
 }
 
@@ -1655,6 +1657,7 @@ if (isMainModule) {
 
 // Exports for integration testing.
 export {
+  runGit,
   parseArgs,
   assertCwdIsMainRepoRoot,
   loadDotenvFromDir,

--- a/tests/unit/fleet/scrub-wire.test.js
+++ b/tests/unit/fleet/scrub-wire.test.js
@@ -130,7 +130,12 @@ describe('R5-4: the scrub is asserted by EFFECT, so unwiring it is detectable', 
     expect(start, 'defaultRunner must exist').toBeGreaterThan(-1);
     const next = src.indexOf('\nfunction ', start + 1);
     const body = src.slice(start, next > -1 ? next : src.length);
-    expect(body).toContain('scrubGitEnv(process.env)');
+    // The wire moved from an inline scrubGitEnv(process.env) to the published hardened runner
+    // (SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A), which carries the same scrub internally —
+    // proven by effect in lib/git/hardened-runner.test.js ('default scrubs' + TS-2). The rule
+    // here stays the same: the production path must be scrub-carrying, never a bare spawn.
+    expect(body).toContain('runHardenedGit(');
+    expect(body).not.toMatch(/execFileSync|spawnSync/);
   });
 });
 

--- a/tests/unit/harness/log-harness-bug-prior-fix-scan.test.js
+++ b/tests/unit/harness/log-harness-bug-prior-fix-scan.test.js
@@ -42,9 +42,14 @@ describe('QF-20260525-785: findPossiblePriorFix is best-effort and never throws'
 });
 
 describe('QF-20260525-785: source-level guards', () => {
-  it('git --format is quoted (regression pin: unquoted | is a shell pipe and breaks the scan)', () => {
-    expect(src).toMatch(/--format="%h\|%cI\|%s"/);
-    expect(src).not.toMatch(/--format=%h\|%cI\|%s(?!")/);
+  it('git --format | never reaches a shell (was: quoting pin; now: argv pin — SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A)', () => {
+    // The original rule: an unquoted | in --format was a SHELL PIPE and broke the scan. The
+    // quoting was the shell-era spelling of that rule. The scan now runs argv-style through the
+    // published hardened runner — | travels inside one discrete array token and no shell exists
+    // to interpret it — so the pin asserts the structural form instead of the quoting.
+    expect(src).toMatch(/'--format=%h\|%cI\|%s'/);
+    expect(src).not.toMatch(/execSync\(\s*`git /);
+    expect(src).toMatch(/runHardenedGit\(/);
   });
 
   it('main() is guarded so importing the module does not run the CLI', () => {

--- a/tests/unit/worktree-reaper/gh-shell-injection.test.js
+++ b/tests/unit/worktree-reaper/gh-shell-injection.test.js
@@ -166,7 +166,11 @@ describe('THE LOAD-BEARING ASSERTION — the real runners spawn without a shell'
       expect(spy).toHaveBeenCalledTimes(2);
       for (const [bin, args, opts] of spy.mock.calls) {
         expect(['gh', 'git']).toContain(bin);
-        expect(opts).not.toHaveProperty('shell'); // ABSENT — falsy would pass on ubuntu
+        // The RULE is "shell is never truthy". Two spellings satisfy it: ABSENT (gh's private
+        // runner) or EXPLICIT false (the published hardened runner, which git now routes
+        // through — SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001-A — where the stated false must be
+        // consciously flipped to regress). Asserting exact absence would fail the SAFER spelling.
+        expect([undefined, false]).toContain(opts.shell);
         expect(args).toContain(HOSTILE_BRANCH);   // discrete element, never concatenated
       }
     } finally {


### PR DESCRIPTION
Child A of the shell-injection contract orchestrator (parent SD-LEO-INFRA-PUBLISH-SHELL-INJECTION-001). Two commits, one reviewable arc:

**Commit 1 — publish (FR-0/FR-1/FR-2):** `makeScrubbedGitRunner` gains byte-compatible opts (non-throwing result mode, timeout/maxBuffer/stdio, envPassthrough, post-scrub envAugment); `lib/git/hardened-runner.cjs` ships THE runner (git-docs mechanism table, argv-only refusal, `VALID_BASE_REF`/`validateBaseRef`, `--literal-pathspecs` default-ON with reasoned opt-out ledger, per-verb `--no-ext-diff --no-textconv`, `noSystemConfig`); the 3 hand-copied `VALID_BASE_REF` regexes import the single representation.

**Commit 2 — adopt (FR-3/FR-4/FR-5):** all 14 frozen-census files route through the published runner. `log-harness-bug.js` loses a template-literal `execSync` with caller-influenced values; the two string-seam defaults (measurement-provenance, phantom-test-audit) keep their seam contracts while executing argv; inflight keeps its test-encoded ambient-env contract as a RECORDED opt-out; explicit `shell: false` stated on the runner spawn. FR-4 mechanical invariant: census files factory-sourced with zero direct spawns, opt-outs need reasons, the 88-file argv-safe remainder recorded (not silently capped). FR-5 armed two-sided tests prove the converted seams run real git AND cannot reach a shell.

**Size justification (646 LOC, ~320 source / ~326 tests):** the runner and its adoptions are one atomic arc — publishing without adopting ships an unconsumed module (the exact defect class this SD abolishes), and adopting without the FR-0 extension inverts error semantics at 3 sites (testing-agent T-1/T-2, CRITICAL). Commits are independently revertable per cluster.

**Tests:** 1788 green across the adopted subsystems + 28-test runner suite + invariant/armed suites; every touched module smoke-loaded under plain node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)