### PR TITLE
fix(QF-20260809-827): scope the LEAD-FINAL readiness verdict to the retro assessment

### DIFF
--- a/scripts/modules/sd-quality-validation.js
+++ b/scripts/modules/sd-quality-validation.js
@@ -376,11 +376,21 @@ export async function validateSDCompletionReadiness(sd, retrospective = null) {
   }
 
   result.valid = result.issues.length === 0;
-  // QF-20260809-341: the RETROSPECTIVE_EXISTS tier-3 arm (lead-final-approval/gates.js) reads
-  // `assessment.passed` — a contract its own test ratifies by MOCKING this function with a
-  // passed key this function never emitted. With only `valid`, `!assessment?.passed` was true
-  // for every tier-3 SD, so the gate could not pass regardless of score. Emit both.
-  result.passed = result.valid;
+  // QF-20260809-341 emitted `passed` so the tier-3 RETROSPECTIVE_EXISTS arm could read it at
+  // all; QF-20260809-827 scopes it to the gate's SUBJECT. `passed = valid` required ZERO issues
+  // on ANY axis, so one AI-judge nit about the SD's own authoring text blocked LEAD-FINAL
+  // regardless of retro quality (live-hit: retro assessed 83/100, gate failed on a 4/10
+  // strategic-objectives note written at SD creation). Every consumer of `passed` reads it as
+  // the RETRO assessment's verdict: the tier-3 arm pairs it with the blended score threshold,
+  // the orchestrator fast-path names it "retrospective did not pass assessment", and the
+  // PLAN-TO-LEAD standard path explicitly demotes these same SD-authoring issues to ADVISORY
+  // warnings. The SD-authoring axis stays in `valid`/`issues`, and still shapes the blended
+  // `score` the gate thresholds — only the verdict bit is retro-scoped.
+  // manual_review_required rides up for the same reason: the fail-closed evaluator-outage path
+  // sets it on the retro sub-result, and the tier-3 arm branches its operator message on it —
+  // without the propagation an outage misprints as a score failure.
+  result.manual_review_required = Boolean(result.retroQuality?.manual_review_required);
+  result.passed = result.retroQuality ? result.retroQuality.passed === true : false;
 
   return result;
 }

--- a/tests/unit/sd-completion-readiness-passed-contract.test.js
+++ b/tests/unit/sd-completion-readiness-passed-contract.test.js
@@ -8,8 +8,28 @@
 // producer on its no-network early-return path, so the contract key can never silently vanish
 // behind a mock again.
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// QF-20260809-827: drive the REAL aggregate with mocked rubrics so the passed/manual_review
+// propagation is tested through the actual wire, not re-stated by a mock of the producer.
+vi.mock('../../scripts/modules/rubrics/sd-quality-rubric.js', () => ({
+  SDQualityRubric: class { async validateSDQuality() { return SD_RUBRIC_RESULT; } },
+}));
+vi.mock('../../scripts/modules/rubrics/retrospective-quality-rubric.js', () => ({
+  RetrospectiveQualityRubric: class { async validateRetrospectiveQuality() { return RETRO_RUBRIC_RESULT(); } },
+}));
+vi.mock('../../scripts/modules/sd-type-checker.js', () => ({
+  getScoringWeights: async () => ({ sdWeight: 0.3, retroWeight: 0.7 }),
+  isInfrastructureSDSync: () => true,
+}));
+
+let SD_RUBRIC_RESULT = { passed: true, score: 70, issues: [], warnings: [], details: {} };
+let RETRO_RUBRIC_RESULT = () => ({ passed: true, score: 90, issues: [], warnings: [], details: {} });
+
 import { validateSDCompletionReadiness } from '../../scripts/modules/sd-quality-validation.js';
+
+const SD = { id: 'uuid-1', sd_key: 'SD-T-001', sd_type: 'infrastructure', status: 'active' };
+const RETRO = { id: 'retro-1', sd_id: 'uuid-1', key_learnings: [], action_items: [] };
 
 describe('validateSDCompletionReadiness emits the passed key the gate consumes', () => {
   it('null SD: passed exists, mirrors valid, and is false', async () => {
@@ -18,6 +38,39 @@ describe('validateSDCompletionReadiness emits the passed key the gate consumes',
     // The load-bearing assertion: `passed` must be a boolean, not undefined — undefined is what
     // made the gate's `!assessment?.passed` unconditionally true.
     expect(r.passed).toBe(false);
-    expect(r.passed).toBe(r.valid);
+  });
+
+  it('QF-20260809-827: an SD-authoring nit does NOT flip passed when the retro assessment passed', async () => {
+    // The live-hit shape: retro assessed fine, but the SD-quality judge dinged the SD's own
+    // objectives text. `valid` (zero issues anywhere) goes false; `passed` — the gate's verdict
+    // bit — must follow the RETRO assessment, which is the gate's subject.
+    SD_RUBRIC_RESULT = { passed: false, score: 60, issues: ['strategic_objectives_measurability: 4/10'], warnings: [], details: {} };
+    const r = await validateSDCompletionReadiness(SD, RETRO);
+    expect(r.valid).toBe(false);
+    expect(r.passed).toBe(true);
+    expect(r.score).toBe(Math.round(60 * 0.3 + 90 * 0.7));
+  });
+
+  it('a FAILED retro assessment fails passed even when the SD itself is clean', async () => {
+    SD_RUBRIC_RESULT = { passed: true, score: 90, issues: [], warnings: [], details: {} };
+    RETRO_RUBRIC_RESULT = () => ({ passed: false, score: 40, issues: ['thin retro'], warnings: [], details: {} });
+    const r = await validateSDCompletionReadiness(SD, RETRO);
+    expect(r.passed).toBe(false);
+  });
+
+  it('evaluator OUTAGE propagates manual_review_required and fails closed', async () => {
+    // The fail-closed path sets manual_review_required on the retro sub-result; the tier-3 arm
+    // branches its operator message on the aggregate's copy — without propagation an outage
+    // misprints as a score failure (observed live as "score 83% is below minimum 60%").
+    RETRO_RUBRIC_RESULT = () => { throw new Error('AI evaluator down'); };
+    const r = await validateSDCompletionReadiness(SD, RETRO);
+    expect(r.passed).toBe(false);
+    expect(r.manual_review_required).toBe(true);
+  });
+
+  it('no retrospective at all: passed=false (the gate requires one), no throw', async () => {
+    const r = await validateSDCompletionReadiness(SD, null);
+    expect(r.passed).toBe(false);
+    expect(r.manual_review_required).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Follow-on to QF-20260809-341: `validateSDCompletionReadiness` emitted `passed = valid` (zero issues on ANY axis), so one AI-judge nit about the SD's own authoring text blocked LEAD-FINAL regardless of retro quality — live-hit: SD-LEO-INFRA-CHECKIN-DISPATCH-READ-001, retro assessed 83/100, blocked twice with the self-contradictory "score 83% is below minimum 60%".
- `passed` now travels from the RETRO assessment (the gate's subject; every consumer reads it that way), `manual_review_required` propagates from the fail-closed evaluator-outage path so an outage no longer misprints as a score failure. `valid`/`issues`/blended `score` untouched.

## Test plan
- [x] Contract test extended through the REAL aggregate with mocked rubrics (producer not mocked — that mock blindness shipped the original break): SD-nit-with-good-retro → passed, failed retro → blocked, outage → fail-closed + manual_review_required, no retro → blocked without throw
- [x] Full tests/unit/handoff suite 941 passed; colocated gate tests 39 passed
- [x] Mutation (revert to passed=valid) reds the pinning test

🤖 Generated with [Claude Code](https://claude.com/claude-code)