### PR TITLE
feat(SD-LEO-INFRA-HEAL-BEFORE-COMPLETE-001): SD-scoped heal on every path; reachable pre-completion remediation

### DIFF
--- a/scripts/eva/heal-command.mjs
+++ b/scripts/eva/heal-command.mjs
@@ -155,7 +155,13 @@ async function cmdSDQuery(opts) {
       .from('strategic_directives_v2')
       .select('sd_key, title, key_changes, success_criteria, success_metrics, strategic_objectives, smoke_test_steps, delivers_capabilities, completion_date, status, metadata');
 
-    q = opts.inProgress ? q.in('status', ['completed', 'in_progress', 'active']) : q.eq('status', 'completed');
+    // SD-LEO-INFRA-HEAL-BEFORE-COMPLETE-001 FR-3: an EXPLICIT --sd-id implies the widened status
+    // set — a named-SD query refusing the SD you named is a broken contract, and it made the
+    // HEAL_BEFORE_COMPLETE gate's printed remediation unreachable pre-completion. Set queries
+    // (--today/--last/--since) keep the completed-only default.
+    q = (opts.inProgress || opts.sdId)
+      ? q.in('status', ['completed', 'in_progress', 'active', 'pending_approval'])
+      : q.eq('status', 'completed');
     q = q.order('completion_date', { ascending: false }).order('sd_key', { ascending: true }); // unique tiebreaker (FR-6)
 
     if (opts.sdId) {
@@ -195,7 +201,7 @@ async function cmdSDQuery(opts) {
   if (!sds || sds.length === 0) {
     console.log('\nNo completed SDs found matching the filter.');
     if (opts.today) console.log('  (No SDs completed today)');
-    if (opts.sdId) console.log(`  (SD ${opts.sdId} not found or not completed)`);
+    if (opts.sdId) console.log(`  (SD ${opts.sdId} not found in completed/in_progress/active/pending_approval)`);
     process.exit(0);
   }
 

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/heal-before-complete.js
@@ -13,7 +13,9 @@
  *
  * Auto-heal strategy (3-tier fallback):
  *   1. Fast heal: Structural checks (DB state) + Claude Haiku semantic spot-check (~10-15s)
- *   2. Full heal: Full vision-dimension scoring via scoreSD() (~60-180s)
+ *   2. Scoped heal: same scorer fed the SD's resolved changed-file set
+ *      (SD-LEO-INFRA-HEAL-BEFORE-COMPLETE-001 — replaced the vision-dimension scoreSD()
+ *      fallback, whose repo-wide gauge a small SD could never move)
  *   3. Structural-only: Deterministic DB/file checks as last resort (~2s)
  *
  * - SD heal: BLOCKING — score must be >= (threshold - tolerance)
@@ -84,7 +86,9 @@ export function buildFastHealDimensionScores(fastResult) {
       semantic: { score: fastResult?.semanticScore ?? 70 }
     };
   }
-  const { elapsed_ms: _elapsedMs, ...qualityDims } = fastResult.details;
+  // scored_files (SD-LEO-INFRA-HEAL-BEFORE-COMPLETE-001) is provenance, not a quality dimension —
+  // same rule as elapsed_ms: it stays in rubric_snapshot.details, never in dimension_scores.
+  const { elapsed_ms: _elapsedMs, scored_files: _scoredFiles, ...qualityDims } = fastResult.details;
   return qualityDims;
 }
 
@@ -106,6 +110,56 @@ const FAST_HEAL_TIMEOUT_MS = 30_000; // 30 seconds for fast Haiku path
 const FAST_HEAL_SD_TYPES = ['infrastructure', 'documentation', 'fix', 'refactor', 'enhancement'];
 
 /**
+ * SD-LEO-INFRA-HEAL-BEFORE-COMPLETE-001 FR-2: resolve the SD's own changed-file set.
+ *
+ * The heal gauge must measure the SD's changed files, not the repo: the previous fallback scored
+ * vision/architecture extracted_dimensions (scoreSD), a gauge insensitive to the SD's diff, so a
+ * small honest SD re-rolled a stable sub-threshold number to EXHAUSTED. This resolver feeds the
+ * semantic scorer the actual work.
+ *
+ * Resolution ladder, best-effort and NEVER blocking:
+ *   1. SD-key-greppable commits (any branch) → their file lists
+ *   2. merge-base diff of the current branch vs origin/main
+ *   3. null — caller degrades to key_changes-only scoring with a logged warning.
+ * A git failure is a DEGRADATION, not a gate failure: the enforcement point stays the threshold
+ * comparison; blocking on git state would recreate an unclearable block.
+ *
+ * EXPORTED for unit testing.
+ *
+ * @param {string} sdKey
+ * @returns {string[]|null} changed file paths (deduped, capped) or null when unresolvable
+ */
+export function resolveSdChangedFiles(sdKey) {
+  try {
+    const commits = execSync(
+      `git log --all --grep="${sdKey}" --format=%H -n 20`,
+      { encoding: 'utf8', timeout: 8000 }
+    ).trim().split(/\r?\n/).filter(Boolean);
+
+    let files = [];
+    if (commits.length > 0) {
+      const out = execSync(
+        `git show --name-only --format= ${commits.slice(0, 10).join(' ')}`,
+        { encoding: 'utf8', timeout: 8000 }
+      );
+      files = out.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+    }
+
+    if (files.length === 0) {
+      const base = execSync('git merge-base HEAD origin/main', { encoding: 'utf8', timeout: 8000 }).trim();
+      const out = execSync(`git diff --name-only ${base}..HEAD`, { encoding: 'utf8', timeout: 8000 });
+      files = out.split(/\r?\n/).map((l) => l.trim()).filter(Boolean);
+    }
+
+    const deduped = [...new Set(files)];
+    return deduped.length > 0 ? deduped.slice(0, 100) : null;
+  } catch (e) {
+    console.debug('[HealBeforeComplete] changed-file resolution degraded:', e?.message || e);
+    return null;
+  }
+}
+
+/**
  * SD-LEO-INFRA-TYPE-AWARE-GATE-001: Fast auto-heal using structural checks + Claude Haiku.
  *
  * Produces a reliable score in ~10-15s instead of 60-180s by:
@@ -118,9 +172,15 @@ const FAST_HEAL_SD_TYPES = ['infrastructure', 'documentation', 'fix', 'refactor'
  * @param {string} sdType - SD type
  * @returns {Promise<{score: number, mode: string, details: Object}|null>} Score or null if fast heal unavailable
  */
-async function fastAutoHeal(supabase, sdKey, sdUuid, sdType) {
+async function fastAutoHeal(supabase, sdKey, sdUuid, sdType, opts = {}) {
   const startTime = Date.now();
   const details = { structural: {}, semantic: {} };
+  // FR-2 (SD-LEO-INFRA-HEAL-BEFORE-COMPLETE-001): when the caller resolved the SD's changed
+  // files, record what the scorer actually saw — an auditable answer to "scoped to WHAT?".
+  const changedFiles = Array.isArray(opts.changedFiles) && opts.changedFiles.length > 0
+    ? opts.changedFiles
+    : null;
+  details.scored_files = changedFiles || 'degraded:key_changes_only';
 
   // ── Phase 1: Structural verification (deterministic, <2s) ──
   let structuralScore = 0;
@@ -282,7 +342,7 @@ SUCCESS CRITERIA:
 
 RECENT GIT ACTIVITY:
 ${gitDiff}
-
+${changedFiles ? `\nFILES CHANGED BY THIS SD (score delivery against THESE, not the wider repo):\n- ${changedFiles.slice(0, 40).join('\n- ')}\n` : ''}
 STRUCTURAL VERIFICATION RESULTS:
 ${Object.entries(details.structural).map(([k, v]) => `- ${k}: ${v}`).join('\n')}
 
@@ -335,7 +395,9 @@ Respond with ONLY a JSON object: {"score": <0-100>, "reasoning": "<one sentence>
   return {
     score: compositeScore,
     mode,
-    details: { structural: details.structural, semantic: details.semantic, elapsed_ms: elapsedMs }
+    // scored_files must survive this reconstruction — the return builds a NEW details object, and
+    // omitting it here silently dropped the provenance the caller persists (caught by test).
+    details: { structural: details.structural, semantic: details.semantic, elapsed_ms: elapsedMs, scored_files: details.scored_files }
   };
 }
 
@@ -615,14 +677,20 @@ export function createHealBeforeCompleteGate(supabase) {
 
       healError = allErr;
       if (allScores && allScores.length > 0) {
-        // A FIFTH snapshot shape exists that no prior reading modelled: 161 rows store
-        // rubric_snapshot as a STRING (a raw LLM prompt), where `?.mode` yields undefined. Those
-        // rows are correctly excluded from the sd-heal set here — but note they remain eligible as
-        // the `allScores[0]` fallback, which is how a non-sd-heal rubric reaches the comparison.
-        // That selection breadth is FR-1's subject, not FR-3's; naming it so the next reader does
-        // not mistake this filter for the guarantee.
+        // SD-LEO-INFRA-HEAL-BEFORE-COMPLETE-001 FR-1: sd-heal rows ONLY. The previous fallback
+        // `[allScores[0]]` let a vision-scorer row — a repo/vision-wide gauge a small SD cannot
+        // move — become the verdict row whenever no sd-heal row existed yet. That is exactly the
+        // stable-sub-threshold HEAL_EXHAUSTED class (79/87 on IDEATION/CODIFY): the gate compared
+        // the SD's threshold against a number the SD's own work could not change. When only
+        // non-sd-heal rows exist, that is NO SCORE, and the auto-heal path below produces a
+        // fresh SD-scoped one. (The STRING-snapshot fifth shape — 161 raw-prompt rows — is
+        // likewise excluded by isSdHealSnapshot and now stays excluded instead of resurfacing
+        // via the fallback.)
         const sdHealMode = allScores.filter((s) => isSdHealSnapshot(s.rubric_snapshot));
-        healScores = sdHealMode.length > 0 ? [sdHealMode[0]] : [allScores[0]];
+        healScores = sdHealMode.length > 0 ? [sdHealMode[0]] : [];
+        if (sdHealMode.length === 0) {
+          console.log(`   ℹ️  ${allScores.length} score row(s) exist but none are sd-heal mode — treating as no score (SD-scoped auto-heal will run)`);
+        }
       } else {
         healScores = allScores;
       }
@@ -710,42 +778,61 @@ export function createHealBeforeCompleteGate(supabase) {
           }
         }
 
-        // ── Tier 2: Full vision-dimension scorer — ~60-180s ──
-        // SD-LEARN-FIX-ADDRESS-PAT-AUTO-054: tag auto-heal scores as sd-heal mode
+        // ── Tier 2: SD-diff-scoped scorer — replaces the vision-dimension scoreSD() fallback ──
+        // SD-LEO-INFRA-HEAL-BEFORE-COMPLETE-001 FR-2: scoreSD() scored eva_vision_documents
+        // extracted_dimensions — a vision/architecture rubric with no changed-files input, so a
+        // small SD re-rolled a stable sub-threshold number it could not move (non-determinism
+        // documented at trackBestHealScore). The gate now scores the SD's OWN changed files with
+        // the same scorer the fast path uses; vision-scorer.js is untouched for its /heal vision
+        // consumers — this gate simply stops calling it.
         if (!autoHealScore) {
           console.log(useFastHeal
-            ? '   🔄 Falling back to full vision-dimension scorer...'
-            : `   🔍 Full heal path (SD type: ${sdType} requires thorough scoring)`);
+            ? '   🔄 Falling back to SD-diff-scoped scorer...'
+            : `   🔍 Scoped heal path (SD type: ${sdType}) — scoring the SD's changed files`);
           try {
-            const { scoreSD } = await import('../../../../../../scripts/eva/vision-scorer.js');
-            const healPromise = scoreSD({ sdKey, supabase });
-            const timeoutPromise = new Promise((_, reject) =>
-              setTimeout(() => reject(new Error('Auto-heal timed out')), AUTO_HEAL_TIMEOUT_MS)
-            );
-            await Promise.race([healPromise, timeoutPromise]);
-
-            // Re-query for the newly created score
-            const { data: newScores } = await supabase
-              .from('eva_vision_scores')
-              .select('id, sd_id, total_score, threshold_action, rubric_snapshot, scored_at')
-              .eq('sd_id', sdKey)
-              .order('scored_at', { ascending: false })
-              .limit(1);
-
-            if (newScores && newScores.length > 0) {
-              autoHealScore = newScores[0];
-              // Tag the auto-created score as sd-heal mode if not already
-              if (autoHealScore.rubric_snapshot?.mode !== 'sd-heal') {
-                const updatedSnapshot = { ...(autoHealScore.rubric_snapshot || {}), mode: 'sd-heal', source: 'auto-heal-gate' };
-                await supabase.from('eva_vision_scores').update({ rubric_snapshot: updatedSnapshot }).eq('id', autoHealScore.id);
-                autoHealScore.rubric_snapshot = updatedSnapshot;
-              }
-              console.log(`   ✅ Full heal complete: score ${autoHealScore.total_score}/100 (mode: sd-heal)`);
+            const changedFiles = resolveSdChangedFiles(sdKey);
+            if (!changedFiles) {
+              console.log('   ⚠️  Changed-file resolution degraded — scoring against key_changes only');
             } else {
-              console.log('   ⚠️  Full heal ran but no score was persisted');
+              console.log(`   📁 Scoring against ${changedFiles.length} changed file(s)`);
+            }
+            const scopedResult = await fastAutoHeal(supabase, sdKey, sdUuid, sdType, { changedFiles });
+            if (scopedResult) {
+              let t2VisionId = null;
+              const { data: t2VisionDocs } = await supabase
+                .from('eva_vision_documents').select('id').order('created_at', { ascending: false }).limit(1);
+              if (t2VisionDocs && t2VisionDocs.length > 0) t2VisionId = t2VisionDocs[0].id;
+
+              const { count: t2IterCount } = await supabase
+                .from('eva_vision_scores').select('id', { count: 'exact', head: true }).eq('sd_id', sdKey);
+
+              const t2Payload = {
+                sd_id: sdKey,
+                total_score: scopedResult.score,
+                threshold_action: scopedResult.score >= threshold ? 'accept' : 'minor_sd',
+                iteration: (t2IterCount || 0) + 1,
+                dimension_scores: buildFastHealDimensionScores(scopedResult),
+                rubric_snapshot: {
+                  mode: 'sd-heal',
+                  source: 'scoped-fallback-heal',
+                  scoring_mode: scopedResult.mode,
+                  details: scopedResult.details
+                }
+              };
+              if (t2VisionId) t2Payload.vision_id = t2VisionId;
+
+              const { data: inserted, error: t2InsertErr } = await supabase
+                .from('eva_vision_scores')
+                .insert(t2Payload)
+                .select('id, sd_id, total_score, threshold_action, rubric_snapshot, scored_at');
+              if (t2InsertErr) console.log(`   ⚠️  Scoped heal score insert failed: ${t2InsertErr.message}`);
+              if (inserted && inserted.length > 0) {
+                autoHealScore = inserted[0];
+                console.log(`   ✅ Scoped heal complete: score ${autoHealScore.total_score}/100`);
+              }
             }
           } catch (err) {
-            console.log(`   ❌ Full heal failed: ${err.message}`);
+            console.log(`   ❌ Scoped heal failed: ${err.message}`);
           }
         }
 
@@ -812,16 +899,20 @@ export function createHealBeforeCompleteGate(supabase) {
           console.log('   All auto-heal tiers failed (fast, full, structural).');
           console.log('   This is unusual — check LLM provider connectivity.');
           console.log('');
-          console.log(`   Run manually: /heal sd --sd-id ${sdKey}`);
+          // SD-LEO-INFRA-HEAL-BEFORE-COMPLETE-001 FR-3: this gate runs PRE-completion, and the
+          // plain `/heal sd --sd-id` form selects completed SDs only — the printed fix returned
+          // "not found or not completed" at exactly the moment it was prescribed. --in-progress
+          // (heal-command.mjs, ALIGN-HEAL-GATE-001 FR-4) makes it reachable here.
+          console.log(`   Run manually: /heal sd --sd-id ${sdKey} --in-progress`);
           console.log('   Then retry PLAN-TO-LEAD.');
 
           return {
             passed: false,
             score: 0,
             max_score: 100,
-            issues: [`Auto-heal failed for ${sdKey} (all 3 tiers) — run /heal sd --sd-id ${sdKey} manually`],
-            warnings: ['Fast heal, full heal, and structural fallback all failed'],
-            remediation: `/heal sd --sd-id ${sdKey}`
+            issues: [`Auto-heal failed for ${sdKey} (all 3 tiers) — run /heal sd --sd-id ${sdKey} --in-progress manually`],
+            warnings: ['Fast heal, scoped heal, and structural fallback all failed'],
+            remediation: `/heal sd --sd-id ${sdKey} --in-progress`
           };
         }
 
@@ -1106,31 +1197,39 @@ export function createHealBeforeCompleteGate(supabase) {
           }
 
           if (!result) {
+            // SD-LEO-INFRA-HEAL-BEFORE-COMPLETE-001 FR-2: re-heal also scores the SD's changed
+            // files (same scoped scorer as Tier 2), never the vision dimensions.
             try {
-              const { scoreSD } = await import('../../../../../../scripts/eva/vision-scorer.js');
-              const healPromise = scoreSD({ sdKey, supabase });
-              const timeoutPromise = new Promise((_, reject) =>
-                setTimeout(() => reject(new Error('Auto-re-heal timed out')), AUTO_HEAL_TIMEOUT_MS)
-              );
-              await Promise.race([healPromise, timeoutPromise]);
+              const changedFiles = resolveSdChangedFiles(sdKey);
+              const scopedResult = await fastAutoHeal(supabase, sdKey, sdUuid, sdType, { changedFiles });
+              if (scopedResult) {
+                let reScopedVisionId = null;
+                const { data: reScopedDocs } = await supabase
+                  .from('eva_vision_documents').select('id').order('created_at', { ascending: false }).limit(1);
+                if (reScopedDocs && reScopedDocs.length > 0) reScopedVisionId = reScopedDocs[0].id;
 
-              const { data: newScores } = await supabase
-                .from('eva_vision_scores')
-                .select('id, sd_id, total_score, threshold_action, rubric_snapshot, scored_at')
-                .eq('sd_id', sdKey)
-                .order('scored_at', { ascending: false })
-                .limit(1);
+                const { count: reScopedIter } = await supabase
+                  .from('eva_vision_scores').select('id', { count: 'exact', head: true }).eq('sd_id', sdKey);
 
-              if (newScores && newScores.length > 0) {
-                result = newScores[0];
-                if (result.rubric_snapshot?.mode !== 'sd-heal') {
-                  const updatedSnapshot = { ...(result.rubric_snapshot || {}), mode: 'sd-heal', source: 'auto-re-heal-gate' };
-                  await supabase.from('eva_vision_scores').update({ rubric_snapshot: updatedSnapshot }).eq('id', result.id);
-                  result.rubric_snapshot = updatedSnapshot;
-                }
+                const reScopedPayload = {
+                  sd_id: sdKey,
+                  total_score: scopedResult.score,
+                  threshold_action: scopedResult.score >= threshold ? 'accept' : 'minor_sd',
+                  iteration: (reScopedIter || 0) + 1,
+                  dimension_scores: buildFastHealDimensionScores(scopedResult),
+                  rubric_snapshot: { mode: 'sd-heal', source: 'scoped-re-heal', scoring_mode: scopedResult.mode, details: scopedResult.details }
+                };
+                if (reScopedVisionId) reScopedPayload.vision_id = reScopedVisionId;
+
+                const { data: inserted, error: reScopedErr } = await supabase
+                  .from('eva_vision_scores')
+                  .insert(reScopedPayload)
+                  .select('id, sd_id, total_score, threshold_action, rubric_snapshot, scored_at');
+                if (reScopedErr) console.log(`   ⚠️  Scoped re-heal insert failed: ${reScopedErr.message}`);
+                if (inserted && inserted.length > 0) result = inserted[0];
               }
             } catch (err) {
-              console.log(`   ❌ Auto-re-heal failed: ${err.message}`);
+              console.log(`   ❌ Scoped re-heal failed: ${err.message}`);
             }
           }
 
@@ -1247,7 +1346,9 @@ export function createHealBeforeCompleteGate(supabase) {
         console.log(`   ❌ EXHAUSTED: ${exhaustedNote}`);
         console.log('');
         console.log('   Fix the gaps within this SD, re-ship, then re-run:');
-        console.log(`   /heal sd --sd-id ${sdKey}`);
+        // FR-3: --in-progress — the SD is not completed at PLAN-TO-LEAD, and the plain form
+        // refuses non-completed SDs.
+        console.log(`   /heal sd --sd-id ${sdKey} --in-progress`);
 
         return {
           passed: false,
@@ -1261,7 +1362,7 @@ export function createHealBeforeCompleteGate(supabase) {
             ...(visionAdvisory ? [`Vision heal advisory: ${visionAdvisory.score}/100`] : []),
             ...(intentAdvisory ? [`Intent-vs-Outcome advisory: ${intentAdvisory.coverage}% parent scope coverage (parent: "${intentAdvisory.parent_title}")`] : [])
           ],
-          remediation: `Fix identified gaps, re-ship, run /heal sd --sd-id ${sdKey}, then retry PLAN-TO-LEAD`,
+          remediation: `Fix identified gaps, re-ship, run /heal sd --sd-id ${sdKey} --in-progress, then retry PLAN-TO-LEAD`,
           details: {
             verdict: 'EXHAUSTED',
             reason_code: GATE_REASON_CODES.HEAL_EXHAUSTED,

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/heal-scoped-scoring.test.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/heal-scoped-scoring.test.js
@@ -1,0 +1,238 @@
+/**
+ * SD-LEO-INFRA-HEAL-BEFORE-COMPLETE-001 — SD-scoped heal on every path, reachable remediation.
+ *
+ * Two defects, both measured live before fixing:
+ *   1. CIRCULAR: the gate's printed fix `/heal sd --sd-id <K>` selected completed SDs only
+ *      (heal-command.mjs status filter), so it returned not-found at exactly the pre-completion
+ *      moment it was prescribed.
+ *   2. REPO-WIDE: with no sd-heal row, the verdict fell back to allScores[0] — often a
+ *      vision-scorer row whose repo/vision-wide gauge a small SD cannot move (the stable 79/87
+ *      HEAL_EXHAUSTED class) — and the Tier-2 fallback scored vision dimensions via scoreSD().
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+// Controllable git behaviour for resolveSdChangedFiles + fastAutoHeal's git log call.
+let execSyncImpl = () => '';
+vi.mock('child_process', () => ({
+  execSync: (...a) => execSyncImpl(...a),
+}));
+
+// Deterministic semantic scorer — no network.
+let semanticResponse = { content: '{"score": 90, "reasoning": "delivers key changes"}' };
+vi.mock('../../../../../../lib/llm/client-factory.js', () => ({
+  getFastClient: () => ({ model: 'mock-fast', complete: async () => semanticResponse }),
+}));
+
+import {
+  createHealBeforeCompleteGate,
+  resolveSdChangedFiles,
+  buildFastHealDimensionScores,
+} from './heal-before-complete.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const gateSource = () => fs.readFileSync(path.join(here, 'heal-before-complete.js'), 'utf8');
+
+beforeEach(() => {
+  execSyncImpl = () => '';
+  semanticResponse = { content: '{"score": 90, "reasoning": "delivers key changes"}' };
+});
+
+/**
+ * Supabase mock: eva_vision_scores list returns `existingRows`; inserts are captured and echoed
+ * back so the gate's verdict row is whatever IT created, observable via capturedInserts.
+ */
+function makeSupabase({ existingRows = [], sdType = 'infrastructure' }) {
+  const capturedInserts = [];
+  const handlers = {
+    strategic_directives_v2: () => ({
+      select() { return this; }, eq() { return this; }, order() { return this; }, limit() { return this; },
+      async single() {
+        return {
+          data: {
+            id: 'sd-uuid', sd_key: 'SD-TEST-001', sd_type: sdType, parent_sd_id: null,
+            title: 'test SD', metadata: {},
+            key_changes: [{ change: 'do the thing' }], success_criteria: [{ criterion: 'thing done' }], success_metrics: [],
+          },
+          error: null,
+        };
+      },
+      then(r) { return Promise.resolve({ data: [], error: null }).then(r); },
+    }),
+    eva_vision_scores: () => ({
+      _opts: null,
+      select(_f, opts) { this._opts = opts; return this; },
+      eq() { return this; }, is() { return this; }, order() { return this; }, limit() { return this; },
+      async single() { return { data: existingRows[0] || null, error: null }; },
+      then(r) {
+        if (this._opts?.head) return Promise.resolve({ count: existingRows.length + capturedInserts.length, error: null }).then(r);
+        return Promise.resolve({ data: existingRows, error: null }).then(r);
+      },
+      insert(payload) {
+        capturedInserts.push(payload);
+        return {
+          select: () => Promise.resolve({
+            data: [{ id: 'inserted-' + capturedInserts.length, ...payload, scored_at: new Date().toISOString() }],
+            error: null,
+          }),
+        };
+      },
+      update() { return { eq: () => Promise.resolve({ data: null, error: null }) }; },
+    }),
+    eva_vision_documents: () => ({
+      select() { return this; }, order() { return this; }, limit() { return this; },
+      then(r) { return Promise.resolve({ data: [{ id: 'vision-1' }], error: null }).then(r); },
+    }),
+    user_stories: () => ({
+      select() { return this; }, eq() { return this; },
+      then(r) { return Promise.resolve({ data: [], error: null }).then(r); },
+    }),
+    sd_phase_handoffs: () => ({
+      select() { return this; }, eq() { return this; },
+      then(r) { return Promise.resolve({ data: [{ id: 'h1' }, { id: 'h2' }], error: null }).then(r); },
+    }),
+    product_requirements_v2: () => ({
+      select() { return this; }, eq() { return this; }, limit() { return this; },
+      async single() { return { data: { id: 'prd-1', status: 'approved' }, error: null }; },
+    }),
+    retrospectives: () => ({
+      select() { return this; }, eq() { return this; }, order() { return this; }, limit() { return this; },
+      async single() { return { data: { id: 'r1', status: 'PUBLISHED', quality_score: 90 }, error: null }; },
+    }),
+    audit_log: () => ({ insert: () => Promise.resolve({ data: null, error: null }) }),
+    app_config: () => ({
+      select() { return this; }, eq() { return this; },
+      async single() { return { data: null, error: { code: 'PGRST116' } }; },
+    }),
+  };
+  return {
+    from: (t) => (handlers[t] ? handlers[t]() : {
+      select() { return this; }, eq() { return this; }, order() { return this; }, limit() { return this; },
+      single: () => Promise.resolve({ data: null, error: null }),
+      then(r) { return Promise.resolve({ data: [], error: null }).then(r); },
+    }),
+    _capturedInserts: capturedInserts,
+  };
+}
+
+const ctx = { sd: { id: 'sd-uuid', sd_key: 'SD-TEST-001', sd_type: 'infrastructure' }, sdId: 'sd-uuid' };
+
+describe('FR-1: a vision-mode row is never the verdict row', () => {
+  it('vision-only rows -> gate runs SD-scoped auto-heal instead of adopting allScores[0]', async () => {
+    const visionRow = {
+      id: 'vision-row-1', total_score: 79, threshold_action: 'gap_closure_sd',
+      rubric_snapshot: { vision_key: 'VISION-X', criteria: [] }, // no mode: 'sd-heal'
+      scored_at: new Date().toISOString(),
+    };
+    const supabase = makeSupabase({ existingRows: [visionRow] });
+    execSyncImpl = () => 'abc123 feat(SD-TEST-001): did the thing';
+
+    const result = await createHealBeforeCompleteGate(supabase).validator(ctx);
+
+    // The gate created its own sd-heal row rather than judging by the vision row.
+    expect(supabase._capturedInserts.length).toBeGreaterThan(0);
+    expect(supabase._capturedInserts[0].rubric_snapshot.mode).toBe('sd-heal');
+    expect(result.details.score_id).not.toBe('vision-row-1');
+    // Semantic 90 * 0.7 + structural (high, all checks green) — comfortably over the 80-3 bar.
+    expect(result.passed).toBe(true);
+  });
+
+  it('an existing sd-heal row is still selected exactly as before (no behaviour change)', async () => {
+    const sdHealRow = {
+      id: 'sdheal-row-1', total_score: 95, threshold_action: 'accept',
+      rubric_snapshot: { mode: 'sd-heal', source: 'fast-auto-heal' },
+      scored_at: new Date().toISOString(),
+    };
+    const supabase = makeSupabase({ existingRows: [sdHealRow] });
+    const result = await createHealBeforeCompleteGate(supabase).validator(ctx);
+    expect(result.passed).toBe(true);
+    expect(result.details.score_id).toBe('sdheal-row-1');
+    expect(supabase._capturedInserts.length).toBe(0);
+  });
+});
+
+describe('FR-2: fallback scoring is scoped to the SD changed files', () => {
+  it('records the resolved changed-file set in rubric_snapshot.details.scored_files', async () => {
+    const supabase = makeSupabase({ existingRows: [] });
+    execSyncImpl = (cmd) => {
+      if (String(cmd).includes('git log --all --grep')) return 'c1\nc2';
+      if (String(cmd).includes('git show')) return 'lib/a.js\nlib/b.js\n';
+      return '';
+    };
+    // Force the non-fast path so Tier-2 (scoped) produces the row: feature type skips Tier-1.
+    const supabaseF = makeSupabase({ existingRows: [], sdType: 'feature' });
+    const r = await createHealBeforeCompleteGate(supabaseF).validator({ sd: { id: 'sd-uuid', sd_key: 'SD-TEST-001', sd_type: 'feature' }, sdId: 'sd-uuid' });
+    expect(supabaseF._capturedInserts.length).toBeGreaterThan(0);
+    const snap = supabaseF._capturedInserts[0].rubric_snapshot;
+    expect(snap.source).toBe('scoped-fallback-heal');
+    expect(snap.details.scored_files).toEqual(['lib/a.js', 'lib/b.js']);
+    expect(r.details).toBeDefined();
+    expect(supabase._capturedInserts.length).toBe(0); // unused first mock untouched
+  });
+
+  it('degrades to key_changes-only when git is unavailable — never blocks on git state', async () => {
+    const supabase = makeSupabase({ existingRows: [], sdType: 'feature' });
+    execSyncImpl = () => { throw new Error('git unavailable'); };
+    const r = await createHealBeforeCompleteGate(supabase).validator({ sd: { id: 'sd-uuid', sd_key: 'SD-TEST-001', sd_type: 'feature' }, sdId: 'sd-uuid' });
+    expect(supabase._capturedInserts.length).toBeGreaterThan(0);
+    expect(supabase._capturedInserts[0].rubric_snapshot.details.scored_files).toBe('degraded:key_changes_only');
+    expect(typeof r.passed).toBe('boolean'); // verdict still produced
+  });
+
+  it('no vision-scorer import remains anywhere in the gate', () => {
+    expect(gateSource()).not.toContain("import('../../../../../../scripts/eva/vision-scorer.js')");
+  });
+});
+
+describe('resolveSdChangedFiles ladder', () => {
+  it('SD-key commits -> their file lists, deduped', () => {
+    execSyncImpl = (cmd) => {
+      if (String(cmd).includes('git log --all --grep')) return 'c1\nc2\n';
+      if (String(cmd).includes('git show')) return 'a.js\nb.js\na.js\n';
+      return '';
+    };
+    expect(resolveSdChangedFiles('SD-TEST-001')).toEqual(['a.js', 'b.js']);
+  });
+
+  it('no SD-key commits -> merge-base diff fallback', () => {
+    execSyncImpl = (cmd) => {
+      const c = String(cmd);
+      if (c.includes('git log --all --grep')) return '';
+      if (c.includes('merge-base')) return 'basehash';
+      if (c.includes('git diff --name-only')) return 'x.js\ny.js\n';
+      return '';
+    };
+    expect(resolveSdChangedFiles('SD-TEST-001')).toEqual(['x.js', 'y.js']);
+  });
+
+  it('git failure -> null (degradation, not a throw)', () => {
+    execSyncImpl = () => { throw new Error('boom'); };
+    expect(resolveSdChangedFiles('SD-TEST-001')).toBeNull();
+  });
+});
+
+describe('provenance never leaks into dimension_scores', () => {
+  it('scored_files and elapsed_ms are both excluded', () => {
+    const dims = buildFastHealDimensionScores({
+      details: { structural: { score: 80 }, semantic: { score: 90 }, elapsed_ms: 1234, scored_files: ['a.js'] },
+    });
+    expect(dims).toEqual({ structural: { score: 80 }, semantic: { score: 90 } });
+  });
+});
+
+describe('FR-3: printed remediation is reachable pre-completion', () => {
+  it('every /heal remediation string in the gate carries --in-progress', () => {
+    const src = gateSource();
+    const bare = src.match(/\/heal sd --sd-id \$\{sdKey\}(?! --in-progress)/g) || [];
+    expect(bare).toEqual([]);
+    expect((src.match(/--in-progress/g) || []).length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('heal-command.mjs honors an explicit --sd-id regardless of completion status', () => {
+    const cli = fs.readFileSync(path.join(here, '../../../../../../scripts/eva/heal-command.mjs'), 'utf8');
+    expect(cli).toMatch(/opts\.inProgress \|\| opts\.sdId/);
+  });
+});


### PR DESCRIPTION
## Summary
- **Never adopt a vision-mode score as the verdict row**: with only non-sd-heal rows, the gate now treats it as no-score and runs SD-scoped auto-heal — the `allScores[0]` fallback that let a repo/vision-wide gauge decide small-SD verdicts (the stable 79/87 HEAL_EXHAUSTED class on IDEATION/CODIFY) is gone.
- **Fallback + re-heal score the SD's changed files**: `scoreSD()` (vision dimensions) is removed from the gate; a changed-file resolver (SD-key commits → merge-base diff → null) feeds the same scorer the fast path uses, with `rubric_snapshot.details.scored_files` provenance. Degrades to key_changes-only on git ambiguity — never blocks on git state. `vision-scorer.js` untouched for its `/heal vision` consumers.
- **Reachable remediation**: both printed fixes now carry `--in-progress`, and `heal-command.mjs` honors an explicit `--sd-id` regardless of status (set queries stay completed-only). Measured: the plain form returned 'not found or not completed' at exactly the pre-completion moment it was prescribed.
- Thresholds, tolerance, narrowing, convergence guard, and HEAL reason codes unchanged.

## Test plan
- [x] 11 new tests: selection matrix (vision-only/sd-heal/none), scoped provenance, degradation, resolver ladder, dimension_scores leak guard, remediation-string pins
- [x] 129 tests green across the full plan-to-lead gates directory + heal app-config suite
- [x] Plain-node import verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)