### PR TITLE
feat(SD-LEO-INFRA-WIRE-EXISTING-RETROSPECTIVEQUALITYRUBRIC-001): delete the retro existence auto-pass; calibrate the shared rubric

### DIFF
--- a/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.js
@@ -300,29 +300,19 @@ async function checkAutoPassConditions(ctx, retrospective, children, allChildren
     };
   }
 
-  // INFRASTRUCTURE FAST-PATH
-  // Infrastructure/process/documentation SDs produce inherently thin retrospectives
-  // that fail the AI rubric's learning_specificity criterion (40% weight).
-  // These SDs are simple by design — the retrospective gate adds friction without value.
-  if ((sdType === 'infrastructure' || sdType === 'process' || sdType === 'documentation') && retrospective) {
-    console.log(`   🏗️ INFRASTRUCTURE AUTO-PASS: ${sdType} SD with retrospective exists`);
-    console.log(`      Retrospective quality_score: ${retrospective.quality_score || 0}/100`);
-
-    return {
-      passed: true,
-      // FR-3: decorative citation removed — see the DATABASE arm above for the full reasoning.
-      score: 55,
-      max_score: 100,
-      issues: [],
-      warnings: [`${sdType} auto-pass: Thin retrospective expected for ${sdType} SDs`],
-      details: {
-        infrastructure_auto_pass: true,
-        sd_type: sdType,
-        retrospective_id: retrospective.id,
-        retrospective_quality: retrospective.quality_score
-      }
-    };
-  }
+  // INFRASTRUCTURE FAST-PATH — DELETED (SD-LEO-INFRA-WIRE-EXISTING-RETROSPECTIVEQUALITYRUBRIC-001).
+  //
+  // The arm returned passed:true score:55 on sdType∈(infrastructure,process,documentation) AND
+  // retro-EXISTENCE — 70.4% of SDs (3935/5591 measured) cleared completion on a retro merely
+  // existing, and its justifying comment ("thin retrospectives ... fail the AI rubric's
+  // learning_specificity criterion") was PROSE that FR-0 measured FALSE: a thin-but-SD-specific
+  // infra retro scores 67 blended against the standard path's threshold 55 and passes without
+  // any bypass. Deleting the arm therefore does NOT re-break PAT-AUTO-047's two-gate
+  // consistency; infra/process/doc SDs now flow to the standard path below (:84-92), which was
+  // already wired to the shared RetrospectiveQualityRubric all along. The discrimination the AI
+  // criterion cannot provide (it scored textbook template content 8/10 on specificity — SD-ID
+  // splicing reads as specificity) comes from the rubric's deterministic detectBoilerplate
+  // penalty, calibrated with the template-assertion corpus in the same SD.
 
   return null; // No auto-pass
 }

--- a/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.test.js
+++ b/scripts/modules/handoff/executors/plan-to-lead/gates/retrospective-quality.test.js
@@ -175,18 +175,42 @@ describe('RETROSPECTIVE_QUALITY_GATE', () => {
     expect(result.score).toBe(82);
   });
 
-  it('auto-passes for infrastructure type SD with retrospective', async () => {
+  // SD-LEO-INFRA-WIRE-EXISTING-RETROSPECTIVEQUALITYRUBRIC-001: the infrastructure existence
+  // auto-pass is deliberately DELETED. These tests previously ratified passed:true on retro
+  // existence — the hole that let 70.4% of SDs (3935/5591 measured) clear completion without
+  // content scoring. Infra/process/doc SDs now flow to the standard blended validation; FR-0
+  // measured that thin-but-SD-specific retros pass it (67 >= 55), so no PAT-AUTO-047 re-break.
+  it('infrastructure SD with a CONTENT-WORTHY retro passes via the STANDARD path (no auto-pass)', async () => {
     const retro = { id: 'retro-6', quality_score: 45 };
     const supabase = buildSupabase({ retrospective: retro });
+    // FR-0 anchor: thin-legit-specific infra retro scored 67 blended against threshold 55.
+    validateSDCompletionReadiness.mockResolvedValue({ passed: true, score: 67, issues: [], warnings: [], improvements: [] });
+    getThresholdProfile.mockResolvedValue({ retrospectiveQuality: 55 });
     const gate = createRetrospectiveQualityGate(supabase);
 
     const ctx = { sd: createMockSD({ sd_type: 'infrastructure', id: 'infra-uuid' }) };
     const result = await gate.validator(ctx);
 
     expect(result.passed).toBe(true);
-    expect(result.details.infrastructure_auto_pass).toBe(true);
-    // Score should be at least 55 (floor for infrastructure)
-    expect(result.score).toBeGreaterThanOrEqual(55);
+    expect(result.score).toBe(67);
+    expect(result.details?.infrastructure_auto_pass).toBeUndefined();
+    expect(validateSDCompletionReadiness).toHaveBeenCalled();
+  });
+
+  it('infrastructure SD with a BOILERPLATE retro FAILS — existence alone no longer passes', async () => {
+    const retro = { id: 'retro-7', quality_score: 70 };
+    const supabase = buildSupabase({ retrospective: retro });
+    // FR-0 anchor: template-boilerplate blended ~49 after the -25 detectBoilerplate penalty.
+    validateSDCompletionReadiness.mockResolvedValue({ passed: false, score: 49, issues: ['boilerplate'], warnings: [], improvements: [] });
+    getThresholdProfile.mockResolvedValue({ retrospectiveQuality: 55 });
+    const gate = createRetrospectiveQualityGate(supabase);
+
+    const ctx = { sd: createMockSD({ sd_type: 'infrastructure', id: 'infra-uuid-2' }) };
+    const result = await gate.validator(ctx);
+
+    expect(result.passed).toBe(false);
+    expect(result.score).toBe(49);
+    expect(result.details?.infrastructure_auto_pass).toBeUndefined();
   });
 
   // SD-LEO-INFRA-RETROSPECTIVE-GATES-FAIL-001 — new failure-mode tests.
@@ -240,20 +264,23 @@ describe('RETROSPECTIVE_QUALITY_GATE', () => {
     expect(validateSDCompletionReadiness).not.toHaveBeenCalled();
   });
 
-  it('passes auto-pass fast-path for infrastructure with a valid SD-completion retro (no regression)', async () => {
-    // AC4 + AC7: a valid retro (all three filters satisfied → helper returns it) passes the
-    // existing infrastructure fast-path unchanged. Regression guard for FR5.
+  it('infrastructure with a valid SD-completion retro is CONTENT-scored, never existence-passed', async () => {
+    // Rewritten by SD-LEO-INFRA-WIRE-EXISTING-RETROSPECTIVEQUALITYRUBRIC-001: this test used to
+    // ratify the existence fast-path ("passes ... unchanged") — the 70.4% hole. The retro-filter
+    // regression it guarded (a valid three-filter retro reaches scoring) is preserved: the retro
+    // must arrive AND be scored, not short-circuited.
     const retro = { id: 'retro-valid', quality_score: 70, retro_type: 'SD_COMPLETION', status: 'PUBLISHED' };
     const supabase = buildSupabase({ retrospective: retro });
+    validateSDCompletionReadiness.mockResolvedValue({ passed: true, score: 67, issues: [], warnings: [], improvements: [] });
+    getThresholdProfile.mockResolvedValue({ retrospectiveQuality: 55 });
     const gate = createRetrospectiveQualityGate(supabase);
 
     const ctx = { sd: createMockSD({ sd_type: 'infrastructure', id: 'infra-valid-uuid' }) };
     const result = await gate.validator(ctx);
 
     expect(result.passed).toBe(true);
-    expect(result.details.infrastructure_auto_pass).toBe(true);
-    expect(result.score).toBeGreaterThanOrEqual(55);
-    // Fast-path short-circuits before the quality validator is invoked.
-    expect(validateSDCompletionReadiness).not.toHaveBeenCalled();
+    expect(result.details?.infrastructure_auto_pass).toBeUndefined();
+    // The valid retro reached the CONTENT scorer — the filter regression this test guards.
+    expect(validateSDCompletionReadiness).toHaveBeenCalled();
   });
 });

--- a/scripts/modules/rubrics/retrospective-quality-rubric.js
+++ b/scripts/modules/rubrics/retrospective-quality-rubric.js
@@ -151,7 +151,27 @@ Look for "meta-lessons" about process, architecture, or methodology - not just p
     /continue.*current.*approach/i,
     /maintain.*momentum/i,
     /stay.*course/i,
-    /keep.*doing.*what/i
+    /keep.*doing.*what/i,
+
+    // Handoff-retro TEMPLATE ASSERTIONS (SD-LEO-INFRA-WIRE-EXISTING-RETROSPECTIVEQUALITYRUBRIC-001).
+    // The 44 patterns above catch ASPIRATIONAL filler ("improve X", "continue Y"); the corpus that
+    // actually dominates fleet boilerplate is the auto-generator's template ASSERTIONS
+    // (lead-to-plan/retrospective.js:136-147), every one writer-stamped is_boilerplate:false.
+    // FR-0 measured the gap live: a textbook template retro scored 68 with boilerplate_penalty 0,
+    // and the AI criterion graded its learning_specificity 8/10 because splicing an SD-ID into
+    // filler reads as specificity. These anchored full-phrase patterns are the deterministic
+    // discrimination the AI cannot provide — anchored to the complete distinctive assertion so
+    // genuine prose that merely echoes a word or two ("the SD scope was clear to reviewers")
+    // cannot trip the penalty.
+    /SD was clear and well-defined/i,
+    /acceptance criteria were comprehensive and actionable/i,
+    /dependencies were correctly identified upfront/i,
+    /simplicity assessment was accurate/i,
+    /handoff validation passed all gates/i,
+    /all validation gates passed/i,
+    /phase completed - handoff executed/i,
+    /benefit from the \d+-handoff workflow/i,
+    /was the primary implementation vector/i
   ];
 
   /**

--- a/tests/unit/retro-boilerplate-template-corpus.test.js
+++ b/tests/unit/retro-boilerplate-template-corpus.test.js
@@ -1,0 +1,74 @@
+// SD-LEO-INFRA-WIRE-EXISTING-RETROSPECTIVEQUALITYRUBRIC-001 — the template-assertion corpus,
+// pinned two-sided against detectBoilerplate.
+//
+// FR-0 measured the gap live: a textbook template retro (the LEAD_TO_PLAN handoff-retro
+// generator's output) scored 68 on the AI rubric with boilerplate_penalty 0 — the 44 existing
+// patterns catch ASPIRATIONAL filler while the live corpus is template ASSERTIONS, and the AI
+// criterion graded the template's learning_specificity 8/10 (SD-ID splicing reads as
+// specificity). The deterministic penalty below is the discrimination the AI cannot provide.
+// Substring-redundancy audit (PLAN mandate): each new pattern checked against the existing 44
+// and its siblings — no containment either direction (the existing list has no template-
+// assertion shapes; the new anchored phrases share no substrings with each other).
+
+import { describe, it, expect } from 'vitest';
+import { RetrospectiveQualityRubric } from '../../scripts/modules/rubrics/retrospective-quality-rubric.js';
+
+// Verbatim content class of retro 1908315c (measured FR-0 boilerplate sample), including the
+// writer-stamped is_boilerplate:false flags that assert the opposite of reality.
+const TEMPLATE_RETRO = {
+  what_went_well: [
+    { achievement: 'SD was clear and well-defined for planning', is_boilerplate: false },
+    { achievement: 'Acceptance criteria were comprehensive and actionable', is_boilerplate: false },
+    { achievement: 'Dependencies were correctly identified upfront', is_boilerplate: false },
+    { achievement: 'Simplicity assessment was accurate and helpful', is_boilerplate: false },
+    { achievement: 'Handoff validation passed all gates successfully', is_boilerplate: false }
+  ],
+  key_learnings: [
+    { learning: 'LEAD-TO-PLAN revealed that infrastructure SDs targeting EHG_Engineer benefit from the 4-handoff workflow', is_boilerplate: false },
+    { learning: 'Implement core changes was the primary implementation vector for SD-TEST-001', is_boilerplate: false }
+  ],
+  action_items: [],
+  what_needs_improvement: []
+};
+
+// Content class of retro 26fbab8e (measured FR-0 thin-legit sample): terse but SD-specific.
+const SPECIFIC_RETRO = {
+  what_went_well: [
+    'key_changes_delivered met target (95/100): All three FRs merged to main via PR #6919 (39c26da4f02)',
+    'Heal scoring produced an actionable score (91/100) captured for the learning loop'
+  ],
+  key_learnings: [
+    '[success_metrics_achieved] scored 90/100 (gap: 3pts) — backward compatibility held: 1270/1270 across 110 files',
+    '[smoke_tests_pass] scored 85/100 — no smoke_test_steps declared on the SD (plan-created, derived fields empty)'
+  ],
+  action_items: [],
+  what_needs_improvement: []
+};
+
+describe('detectBoilerplate: template-assertion corpus (two-sided)', () => {
+  it('flags the generator template corpus at the -25 cap, ignoring is_boilerplate:false stamps', () => {
+    const r = RetrospectiveQualityRubric.detectBoilerplate(TEMPLATE_RETRO);
+    expect(r.hasBoilerplate).toBe(true);
+    expect(r.matchCount).toBeGreaterThanOrEqual(5);
+    expect(r.scorePenalty).toBe(25);
+  });
+
+  it('leaves thin-but-SD-specific content untouched (0 matches, 0 penalty)', () => {
+    const r = RetrospectiveQualityRubric.detectBoilerplate(SPECIFIC_RETRO);
+    expect(r.matchCount).toBe(0);
+    expect(r.scorePenalty).toBe(0);
+  });
+
+  it('anchored patterns do not fire on near-miss genuine prose', () => {
+    const r = RetrospectiveQualityRubric.detectBoilerplate({
+      what_went_well: [
+        'the SD scope was clear to reviewers after the second pass',
+        'we validated the dependencies against the live catalog before EXEC',
+        'the acceptance tests were comprehensive for the new resolver ladder'
+      ],
+      key_learnings: ['the handoff chain design benefits from measured premises'],
+      action_items: [], what_needs_improvement: []
+    });
+    expect(r.matchCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- **Deletes the infrastructure/process/documentation existence fast-path** from RETROSPECTIVE_QUALITY (`checkAutoPassConditions`): 70.4% of SDs (3935/5591 measured) cleared completion on a retro merely existing. FR-0 measured the arm's justification false — thin-but-SD-specific infra retros score 67 blended vs the standard threshold 55, so deletion does NOT re-break PAT-AUTO-047.
- **Calibrates the ONE shared `RetrospectiveQualityRubric`**: 9 anchored patterns for the handoff-retro generator's template-assertion corpus (`lead-to-plan/retrospective.js:136-147`). Measured live on the FR-0 samples: boilerplate 7 matches → -25 cap → blended ~49 FAIL; thin-legit 0 matches → 67 PASS. The AI criterion alone was fooled by SD-ID splicing (scored template content 8/10 specificity).
- Both retro gates (PLAN-TO-LEAD standard path, LEAD-FINAL tier-3 arm) inherit through `validateSDCompletionReadiness` — zero per-gate predicates added; other five fast-path arms byte-identical.

## Expected fleet effect
Template-generated retros start failing PLAN-TO-LEAD for infra/process/doc — working as intended; the failure prints the rubric's actionable improvements. Failures WITHOUT boilerplate matches would indicate AI drift (rollback trigger), not pattern trouble.

## Test plan
- [x] Two-sided corpus tests (template → 25 penalty incl. is_boilerplate:false stamps; specific → 0; near-miss prose → 0)
- [x] Gate tests rewritten to the new contract (content-scored pass at 67, boilerplate fail at 49, arm absent)
- [x] 121 tests green across the plan-to-lead gates directory + 60 across rubric consumers
- [x] Live verification against the measured FR-0 rows; plain-node imports OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)