### PR TITLE
feat(SD-LEO-INFRA-STORY-E2E-WRITE-001): wire the existing e2e-path guard into the live story writer — fiction paths persist NULL at write

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-STORY-E2E-WRITE-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-STORY-E2E-WRITE-001.json
@@ -1,0 +1,89 @@
+{
+  "executive_summary": "Prevention half of the STORY-E2E pair (sibling SD-LEO-INFRA-STORY-E2E-AUTO-001 delivered detection + remediation). The SD as authored instructed BUILDING a write-time choke-point; measured at LEAD against main eee090393fa, that premise was false: lib/stories/e2e-path-guard.js (resolveE2ePath / specFileExists / specReferencesStory) already exists, is tested 17/17, and has ZERO write-side importers — resolveE2ePath has zero importers anywhere. The deliverable is therefore WIRING and policy: route the one live fabricating writer through the existing guard at the existence-only bar the sibling gate deliberately chose (requireRelevance:false — the relevance arm is heuristic and must never null real coverage), rule explicitly that aspirational paths persist as NULL (the intent already lives once, honestly, in the CHECK-constrained e2e_test_status='not_created'; the path column was a second, lying representation), thread the correct repo root for the two-repo corpus, and declare the server-side trigger blind spot at its source rather than building a second enforcement site for a path that has never fired (story_test_mappings: 0 rows). Every acceptance criterion carries a positive-control injection because the measured baseline is already quiet (0 of 443 stories created in the last 6 days carry a non-null path) — a green-by-default AC cannot distinguish fix from no-op.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "Wire the existing guard into the live fabricating writer — a fiction path becomes NULL at write",
+      "priority": "critical",
+      "description": "scripts/modules/auto-trigger-stories.mjs is the only live writer that FABRICATES e2e_test_path: generateE2ETestPath (lines ~74-115) is pure string templating that never touches the filesystem, and the insert (~line 1140) persists the fabricated path with e2e_test_status='not_created' (honest about non-existence — the sibling FR-3 explicitly declined to blame this class). Wire the write path through the EXISTING lib/stories/e2e-path-guard.js resolveE2ePath({ repoRoot, candidatePath, story, requireRelevance: false }): persist the returned value when the spec file exists, NULL otherwise. ASPIRATIONAL-PATH RULING (explicit, per LEAD): fabricated not-yet-existing paths persist as NULL — e2e_test_status='not_created' remains the single honest representation of intent, and the status stamping is NOT changed by this FR. The documentation-SD sentinel string ('N/A - documentation SD (no E2E required)') also becomes NULL — it is neither NULL nor a path, and specFileExists already rejects it. requireRelevance MUST be false: the relevance arm is stricter than the sibling gate's deliberate existence-only predicate and would re-derive the judgment call that gate refused to make. REUSE, never re-derive: the wiring imports the guard; no second existence predicate may appear.",
+      "acceptance_criteria": [
+        "POSITIVE CONTROL (not green-by-default): drive the writer's path arm with a story whose templated candidate names a NONEXISTENT spec file and observe e2e_test_path=NULL in the persisted/insert-bound row — the fiction path is refused AT write, not filtered later.",
+        "NEGATIVE CONTROL: the same arm with a candidate naming an EXISTING spec file persists the path unchanged — real coverage is never nulled.",
+        "Sentinel control: a documentation-type story persists e2e_test_path=NULL, not the 'N/A - …' sentinel string.",
+        "e2e_test_status semantics are untouched: 'not_created' (and 'not_applicable' for documentation) stamping is byte-identical before and after the wiring — proven by asserting the status value in the same controls.",
+        "Single representation: the wiring imports resolveE2ePath/specFileExists from lib/stories/e2e-path-guard.js; grep proves no new existence predicate was introduced in the writer."
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Repo-root contract — the guard is only sound against the right filesystem root",
+      "priority": "high",
+      "description": "The story corpus spans two repos. scripts/modules/handoff/map-e2e-tests-to-stories.js derives paths from a REAL filesystem scan rooted in ../ehg (a different repo), so it is existence-safe by construction — but routing it through the guard with the EHG_Engineer root would null out REAL coverage (VALIDATION confirmed this exact hazard). Deliverable: an explicit repo-root contract at the choke-point call site — the guard call must receive the repoRoot of the TARGET repo for the story's spec, and map-e2e-tests-to-stories.js is either routed through the guard with its own ../ehg root or left un-routed with a documented exemption stating that its scan IS the existence proof (decide in EXEC; either outcome must be recorded in the file at the call site). The contract must be stated where the next caller will see it (the guard call site), not only in the PRD.",
+      "acceptance_criteria": [
+        "Two-sided repo-root test: an ehg-rooted REAL spec path is preserved when validated against the ehg root, and the SAME path is (correctly) refused against the EHG_Engineer root — proving the verdict follows the root, so a wrong-root wiring cannot silently pass.",
+        "map-e2e-tests-to-stories.js outcome recorded in-file: either routed through the guard with its own root, or a comment at the write site documenting the scan-is-existence-proof exemption.",
+        "No call site passes a hardcoded root that disagrees with the target repo of the paths it validates."
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "Declare and bound the server-side blind spot — do not build a second enforcement site for zero coverage",
+      "priority": "medium",
+      "description": "The Postgres trigger sync_test_evidence_to_user_stories (defined byte-equivalently in BOTH database/migrations/20251210_unified_test_evidence.sql:352 and 20251211_unified_test_evidence_fixed.sql:246 — a mutual-revert hazard) writes e2e_test_path server-side where no JS choke-point can see it; a DB trigger conversely cannot see the filesystem (enforcement splits by observability). MEASURED: story_test_mappings has 0 rows — the trigger has NEVER fired; its source is test_results from executed tests, so its paths carry existence-by-provenance. Deliverable: declare the blind spot at the JS choke-point (comment naming the trigger, both DDL sites, the 0-row measurement date, and the provenance argument), and record the mutual-revert DDL hazard to the durable feedback channel. EXPLICITLY OUT: any migration/DDL change (schema is a Tier-3 risk class and the trigger has zero live traffic to protect against); building a companion DB-side CHECK or trigger (a second enforcement site for a never-fired path is exactly the umbrella-guard anti-pattern).",
+      "acceptance_criteria": [
+        "The choke-point call site carries the blind-spot declaration: trigger name, both migration file:line sites, the story_test_mappings row count with measurement date, and the existence-by-provenance rationale.",
+        "The 20251210/20251211 byte-equivalent DDL hazard is recorded via the durable feedback channel (log-harness-bug or capture-completion-flags), with both file paths.",
+        "No migration files are added or modified by this SD — proven by the PR diff containing zero database/migrations changes."
+      ]
+    },
+    {
+      "id": "FR-4",
+      "title": "Measure the counter-pressure instrument — the function that demands the fiction",
+      "priority": "medium",
+      "description": "Live DB function public.validate_story_e2e_requirements reports a NULL e2e_test_path as an ISSUE — it actively pressures writers toward exactly the fabrication this SD prevents; left unmeasured it will make the FR-1 NULLs read as regressions on whatever surface consumes it. Deliverable is MEASUREMENT + routing, not change: census its consumers (grep code; check gates/reports/dashboards), classify each as verdict-consumer vs display-only, and route the finding — if any consumer treats 'NULL path' as a blocking issue, file the reconciliation to the durable feedback channel naming the consumer and the contradiction; DDL change to the function is OUT (chairman-gated class).",
+      "acceptance_criteria": [
+        "A consumer census for validate_story_e2e_requirements exists in the PR (comment or short doc note at the choke-point, or the feedback-channel record), with each consumer named and classified (verdict vs display).",
+        "The contradiction (a live instrument demanding non-NULL paths while the write side enforces NULL-unless-exists) is recorded durably with the census attached — never silently left for the next session to rediscover.",
+        "No DDL change to the function in this SD."
+      ]
+    }
+  ],
+  "technical_requirements": [
+    {
+      "id": "TR-1",
+      "title": "Extend live instruments; introduce no duplicate predicate",
+      "description": "FR-1/FR-2 reuse lib/stories/e2e-path-guard.js verbatim (requireRelevance:false). The wiring must not re-derive existence checking, path sanitization, or sentinel rejection — all three already live in the guard and are tested. A second predicate is how the write side and the read gate drift."
+    },
+    {
+      "id": "TR-2",
+      "title": "Every guard proven two-sided with positive-control injection",
+      "description": "The measured baseline is quiet (0/443 recent stories carry a path), so a 'no new fiction rows' assertion is green even if the wiring is inert. Every AC must inject the failing input (a fiction path) and observe the NULL, and inject the passing input (a real file) and observe preservation. Mutation-proof against a baseline verified green first."
+    },
+    {
+      "id": "TR-3",
+      "title": "No schema changes",
+      "description": "No DDL: no CHECK on e2e_test_path, no trigger amendment, no migration files. The server-side blind spot is declared and bounded (FR-3), not closed — it has zero live traffic and its source carries existence-by-provenance."
+    }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "Writer path arm driven with a fabricated (nonexistent) spec path", "type": "unit", "expected": "Persisted/insert-bound row carries e2e_test_path=NULL; e2e_test_status still 'not_created'" },
+    { "id": "TS-2", "scenario": "Writer path arm driven with a spec path whose file EXISTS (temp fixture)", "type": "unit", "expected": "Path persisted unchanged; status unchanged — real coverage never nulled" },
+    { "id": "TS-3", "scenario": "Documentation-type story", "type": "unit", "expected": "e2e_test_path=NULL (sentinel string gone); documentation status semantics unchanged" },
+    { "id": "TS-4", "scenario": "Repo-root flip: same real ehg-rooted path validated against ehg root and against EHG_Engineer root", "type": "unit", "expected": "Preserved against its own root; refused against the wrong root — verdict follows the root" },
+    { "id": "TS-5", "scenario": "Grep control: no new existence predicate in the writer", "type": "static", "expected": "Writer imports the guard; no fs.existsSync/statSync on spec paths outside lib/stories/e2e-path-guard.js" },
+    { "id": "TS-6", "scenario": "PR diff contains zero database/migrations changes", "type": "static", "expected": "FR-3/TR-3 boundary held" }
+  ],
+  "acceptance_criteria": [
+    "Every FR's guard is proven two-sided: the fiction input is observed becoming NULL (positive control) and the real-file input is observed preserved (negative control) — no green-by-default assertions.",
+    "The existing guard is reused with requireRelevance:false; no new predicate, no schema change, no migration.",
+    "The aspirational-path ruling (fabricated paths persist NULL; intent stays solely in e2e_test_status) is stated in the code at the wiring site.",
+    "The server-side trigger blind spot and the counter-pressure function census are recorded durably, not narrated.",
+    "Each behavioural arm is mutation-proven against a baseline verified green FIRST, with every mutation redding at least one named test."
+  ],
+  "risks": [
+    { "risk": "Nulling aspirational paths breaks a consumer that treated the templated path as a scaffolding target.", "mitigation": "VALIDATION searched for such a consumer and found none (recorded in evidence 377e96cf); the status column carries the intent unchanged; blast radius is new writes only.", "severity": "low" },
+    { "risk": "A wrong repoRoot at a guard call site nulls REAL coverage in the ehg-rooted corpus.", "mitigation": "FR-2's two-sided repo-root flip test makes a wrong-root wiring fail loudly in unit tests; map-e2e's outcome is recorded in-file either way.", "severity": "medium" },
+    { "risk": "The declared-but-open server-side blind spot later goes live (story_test_mappings gains traffic) and writes unchecked paths.", "mitigation": "The declaration names the trigger and measurement date at the choke-point, and the provenance argument (paths from executed tests) bounds the harm; re-measure when the table gains rows.", "severity": "low" },
+    { "risk": "validate_story_e2e_requirements consumers read the new NULLs as regressions.", "mitigation": "FR-4's census + durable routing surfaces every consumer before the wiring lands; contradiction recorded with names, not left to rediscovery.", "severity": "medium" }
+  ]
+}

--- a/scripts/modules/auto-trigger-stories.mjs
+++ b/scripts/modules/auto-trigger-stories.mjs
@@ -27,6 +27,10 @@
 import { randomUUID } from 'crypto';
 import { isPersonaStoryRoleEnabled } from '../lib/persona-extractor.js';
 import { getLLMClient } from '../../lib/llm/client-factory.js';
+// SD-LEO-INFRA-STORY-E2E-WRITE-001 (FR-1): the EXISTING write-time choke-point (sibling
+// STORY-E2E-AUTO-001 FR-1). Reused verbatim, never re-derived — a second existence predicate
+// is how the write side and the read gate drift.
+import { resolveE2ePath } from '../../lib/stories/e2e-path-guard.js';
 
 /**
  * SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 Option B helper.
@@ -64,14 +68,43 @@ const LLM_CONFIG = {
 // ============================================
 
 /**
- * Generate E2E test path based on SD type and story details
+ * Generate E2E test path based on SD type and story details.
+ *
+ * SD-LEO-INFRA-STORY-E2E-WRITE-001 (FR-1): the templated candidate is now routed through the
+ * existing choke-point (lib/stories/e2e-path-guard.js resolveE2ePath, requireRelevance:false —
+ * the sibling gate's deliberate existence-only bar; the relevance arm is heuristic and must
+ * never null real coverage). A candidate naming a spec file that DOES NOT EXIST persists as
+ * NULL: the intent "a test should exist here" already lives once, honestly, in the
+ * CHECK-constrained e2e_test_status='not_created' — the path column carrying a fabricated
+ * string was a second, lying representation (measured by the sibling SD: 641 rows claimed
+ * 'passing' against nonexistent files). The documentation sentinel string is likewise NULL now:
+ * it was neither NULL nor a path. Status stamping is byte-identical to before.
+ *
+ * FR-2 (repo-root contract): the guard is only sound against the filesystem root the candidate
+ * is relative to. repoRoot is INJECTABLE (options.repoRoot, or STORY_E2E_REPO_ROOT env —
+ * mirroring map-e2e-tests-to-stories.js's EHG_APP_PATH precedent), defaulting to process.cwd().
+ * Callers generating stories whose specs live in a DIFFERENT repo must pass that repo's root,
+ * or a real existing spec would be (wrongly) refused. deps is threaded for test injection.
+ *
+ * FR-3 (declared blind spot, measured 2026-08-10): the Postgres trigger
+ * sync_test_evidence_to_user_stories (defined byte-equivalently in BOTH
+ * database/migrations/20251210_unified_test_evidence.sql:352 AND
+ * 20251211_unified_test_evidence_fixed.sql:246 — mutual-revert hazard, flagged to the feedback
+ * channel) writes e2e_test_path server-side where this choke-point cannot see it. It has NEVER
+ * fired (story_test_mappings: 0 rows), and its source is test_results from EXECUTED tests, so
+ * its paths carry existence-by-provenance. Deliberately NOT given a companion DB-side check: a
+ * second enforcement site for a zero-traffic path is the umbrella-guard anti-pattern.
+ *
  * @param {string} sdId - Strategic directive ID
  * @param {string} sdType - SD type (feature, infrastructure, documentation, etc.)
  * @param {string} storyNumber - Story number (e.g., '001')
  * @param {string} storyTitle - Story title for slug generation
- * @returns {Object} - { path: string, status: string }
+ * @param {object} [options]
+ * @param {string} [options.repoRoot] - filesystem root the candidate path is relative to
+ * @param {object} [options.deps] - injected fs deps for the guard (tests)
+ * @returns {Object} - { path: string|null, status: string }
  */
-function generateE2ETestPath(sdId, sdType, storyNumber, storyTitle) {
+export function generateE2ETestPath(sdId, sdType, storyNumber, storyTitle, { repoRoot, deps } = {}) {
   // Normalize SD ID to create slug (e.g., SD-VISION-V2-003 -> vision-v2-003)
   const sdSlug = sdId.toLowerCase().replace(/^sd-/, '').replace(/[^a-z0-9]+/g, '-');
 
@@ -106,12 +139,32 @@ function generateE2ETestPath(sdId, sdType, storyNumber, storyTitle) {
     default: `tests/e2e/${sdSlug}-us-${storyNumber}.spec.ts`
   };
 
-  const path = pathPatterns[sdType] || pathPatterns.default;
-
-  // Determine initial status based on SD type
+  // Status semantics are byte-identical to pre-wiring: documentation SDs are
+  // 'not_applicable', everything else starts 'not_created'. Only the PATH column changed
+  // owner — it now tells the truth or stays NULL.
   const status = sdType === 'documentation' ? 'not_applicable' : 'not_created';
 
-  return { path, status };
+  // Documentation SDs never carried a real path — the old sentinel string was neither NULL
+  // nor a path (and the guard rejects it anyway: no '/'). NULL is the honest value.
+  if (sdType === 'documentation') {
+    return { path: null, status };
+  }
+
+  const candidatePath = pathPatterns[sdType] || pathPatterns.default;
+
+  // FR-1 wiring: existence-only bar (requireRelevance:false — see function header).
+  // A brand-new story's templated spec almost never exists yet, so the common honest
+  // outcome is { path: null, status: 'not_created' } — pointing at nothing and saying so.
+  const root = repoRoot || process.env.STORY_E2E_REPO_ROOT || process.cwd();
+  const resolved = resolveE2ePath({
+    repoRoot: root,
+    candidatePath,
+    story: { title: storyTitle },
+    requireRelevance: false,
+    ...(deps ? { deps } : {}),
+  });
+
+  return { path: resolved, status };
 }
 
 /**

--- a/scripts/modules/auto-trigger-stories.mjs
+++ b/scripts/modules/auto-trigger-stories.mjs
@@ -25,12 +25,31 @@
  */
 
 import { randomUUID } from 'crypto';
+import { fileURLToPath } from 'url';
+import nodePath from 'path';
 import { isPersonaStoryRoleEnabled } from '../lib/persona-extractor.js';
 import { getLLMClient } from '../../lib/llm/client-factory.js';
 // SD-LEO-INFRA-STORY-E2E-WRITE-001 (FR-1): the EXISTING write-time choke-point (sibling
 // STORY-E2E-AUTO-001 FR-1). Reused verbatim, never re-derived — a second existence predicate
 // is how the write side and the read gate drift.
 import { resolveE2ePath } from '../../lib/stories/e2e-path-guard.js';
+
+/**
+ * SD-LEO-INFRA-STORY-E2E-WRITE-001 (FR-2, closed by adversarial review): the repo root the
+ * guard checks against must be the TARGET repo of the story's spec, and the story corpus spans
+ * two repos. EHG-app-target SDs' specs live in the sibling ehg checkout (the EHG_APP_PATH
+ * precedent from map-e2e-tests-to-stories.js — same env var, same relative fallback);
+ * everything else validates against this repo (STORY_E2E_REPO_ROOT override, else cwd).
+ * Without this, a real ehg spec re-generated after EXEC would be checked against the WRONG
+ * disk and nulled — the exact real-coverage loss FR-2's contract forbids.
+ */
+export function resolveStoryE2eRoot(targetApplication) {
+  if (String(targetApplication || '').trim().toUpperCase() === 'EHG') {
+    return process.env.EHG_APP_PATH
+      || nodePath.join(nodePath.dirname(fileURLToPath(import.meta.url)), '../../../ehg');
+  }
+  return process.env.STORY_E2E_REPO_ROOT || process.cwd();
+}
 
 /**
  * SD-LEO-INFRA-AUTO-STORY-QUALITY-GATE-001 Option B helper.
@@ -484,23 +503,25 @@ ${existingStories.map(s => `- ${s.story_key}: ${s.title}`).join('\n')}`);
  * @returns {Promise<string>} SD type (feature, documentation, infrastructure, database, security)
  */
 async function getSDType(supabase, sdId) {
+  // SD-LEO-INFRA-STORY-E2E-WRITE-001 (FR-2): target_application rides along so the e2e-path
+  // guard can be pointed at the story's TARGET repo root (see resolveStoryE2eRoot).
   try {
     const { data: sd, error } = await supabase
       .from('strategic_directives_v2')
-      .select('sd_type')
+      .select('sd_type, target_application')
       .or(`id.eq.${sdId},sd_key.eq.${sdId}`)
       .single();
 
     if (error || !sd) {
       console.log(`   ⚠️  Could not fetch SD type, defaulting to 'feature'`);
-      return 'feature';
+      return { sdType: 'feature', targetApplication: null };
     }
 
     // sd_type takes precedence over category
-    return sd.sd_type || 'feature';
+    return { sdType: sd.sd_type || 'feature', targetApplication: sd.target_application || null };
   } catch (err) {
     console.log(`   ⚠️  SD type lookup error: ${err.message}, defaulting to 'feature'`);
-    return 'feature';
+    return { sdType: 'feature', targetApplication: null };
   }
 }
 
@@ -1135,7 +1156,9 @@ async function generateUserStoriesFromPRD(supabase, prd, resolvedSdId, sdKey, pr
   }
 
   // SD-TYPE-AWARE: Fetch SD type for criteria transformation
-  const sdType = await getSDType(supabase, resolvedSdId);
+  const { sdType, targetApplication } = await getSDType(supabase, resolvedSdId);
+  // FR-2: the guard validates existence against the story's TARGET repo, not the running repo.
+  const e2eRepoRoot = resolveStoryE2eRoot(targetApplication);
   console.log(`   📋 SD Type: ${sdType} (criteria will be ${sdType === 'feature' || sdType === 'security' ? 'STRICT' : sdType === 'documentation' ? 'LENIENT' : 'MODERATE'})`);
 
   for (let i = 0; i < functionalRequirements.length; i++) {
@@ -1163,7 +1186,7 @@ async function generateUserStoriesFromPRD(supabase, prd, resolvedSdId, sdKey, pr
     // SD-LEO-INFRA-AUTO-TRIGGER-STORIES-FK-FIX-001: slug uses sdKey (stable, sd-key-format),
     // sd_id uses resolvedSdId (FK target).
     const storyTitle = fr.requirement || `Implement ${fr.id}`;
-    const e2eConfig = generateE2ETestPath(sdKey, sdType, storyNumber, storyTitle);
+    const e2eConfig = generateE2ETestPath(sdKey, sdType, storyNumber, storyTitle, { repoRoot: e2eRepoRoot });
 
     const userStory = {
       id: randomUUID(),
@@ -1196,7 +1219,9 @@ async function generateUserStoriesFromPRD(supabase, prd, resolvedSdId, sdKey, pr
       metadata: {
         sd_type_at_generation: sdType,
         criteria_transformation_applied: true,
-        e2e_path_auto_generated: true,
+        // Truthful provenance (adversarial-review INFO): the flag now tracks whether a path
+        // was actually persisted — a guard-refused NULL row must not claim auto-generation.
+        e2e_path_auto_generated: e2eConfig.path != null,
         generation_version: '1.3.0'
       }
     };

--- a/scripts/modules/handoff/map-e2e-tests-to-stories.js
+++ b/scripts/modules/handoff/map-e2e-tests-to-stories.js
@@ -167,6 +167,15 @@ export async function mapE2ETestsToUserStories(sdId, supabase, options = {}) {
   }
 
   // Step 4: Update database
+  //
+  // SD-LEO-INFRA-STORY-E2E-WRITE-001 (FR-2) — DOCUMENTED EXEMPTION from the write-time
+  // choke-point (lib/stories/e2e-path-guard.js), decided rather than inherited: every
+  // new_test_path written below comes from the Step-1 filesystem scan of the EHG app repo
+  // (EHG_APP_PATH, ../ehg) — THE SCAN IS THE EXISTENCE PROOF. Routing these through the
+  // guard would require threading the ../ehg root; routing them with THIS repo's root
+  // (the natural mistake) would refuse every real path and null out genuine coverage —
+  // the exact hazard the repo-root contract exists to prevent. A path that was just
+  // enumerated from disk cannot fail an existence check against the same disk.
   let successCount = 0;
   let errorCount = 0;
 

--- a/tests/unit/stories/e2e-path-write-wiring.test.js
+++ b/tests/unit/stories/e2e-path-write-wiring.test.js
@@ -1,0 +1,111 @@
+/**
+ * SD-LEO-INFRA-STORY-E2E-WRITE-001 — the write-time choke-point WIRING.
+ *
+ * The guard itself (lib/stories/e2e-path-guard.js) shipped under the sibling SD and is pinned
+ * by its own 17 tests. These tests pin the WIRING: the live fabricating writer
+ * (scripts/modules/auto-trigger-stories.mjs generateE2ETestPath) now routes its templated
+ * candidate through resolveE2ePath(requireRelevance:false), so a fiction path becomes NULL at
+ * write while a real file is preserved. Every positive control here INJECTS the failing input —
+ * the measured baseline is already quiet (0/443 recent stories carry a path), so an assertion
+ * over live rows would be green even with the wiring deleted (TR-2's green-by-default hazard).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { generateE2ETestPath } from '../../../scripts/modules/auto-trigger-stories.mjs';
+
+const noFile = { existsSync: () => false };
+const everyFile = { existsSync: () => true };
+
+describe('TS-1 — a fabricated path is refused AT write', () => {
+  it('a feature story whose templated spec does not exist persists path=NULL, status untouched', () => {
+    const r = generateE2ETestPath('SD-X-001', 'feature', '001', 'add widget', { repoRoot: '/repo', deps: noFile });
+    expect(r.path).toBeNull();
+    expect(r.status).toBe('not_created'); // the honest intent marker is the ONLY representation left
+  });
+
+  it('every non-documentation sd_type falls to NULL on a nonexistent spec — no pattern escapes the guard', () => {
+    for (const sdType of ['feature', 'security', 'infrastructure', 'database', 'api', 'unknown-type']) {
+      const r = generateE2ETestPath('SD-X-001', sdType, '002', 't', { repoRoot: '/repo', deps: noFile });
+      expect(r.path, sdType).toBeNull();
+      expect(r.status, sdType).toBe('not_created');
+    }
+  });
+});
+
+describe('TS-2 — a real existing spec is preserved (real coverage never nulled)', () => {
+  it('the templated candidate is returned unchanged when the file exists', () => {
+    const r = generateE2ETestPath('SD-X-001', 'feature', '001', 'add widget', { repoRoot: '/repo', deps: everyFile });
+    expect(r.path).toBe('tests/e2e/x-001-us-001.spec.ts');
+    expect(r.status).toBe('not_created');
+  });
+});
+
+describe('TS-3 — the documentation sentinel is gone', () => {
+  it('documentation SDs persist NULL, never the "N/A - …" sentinel string; status semantics unchanged', () => {
+    const r = generateE2ETestPath('SD-X-001', 'documentation', '001', 'write docs', { repoRoot: '/repo', deps: everyFile });
+    expect(r.path).toBeNull();
+    expect(r.status).toBe('not_applicable');
+  });
+});
+
+describe('TS-4 — repo-root contract, exercised THROUGH the wiring', () => {
+  // The guard's own two-root sensitivity is already pinned by its tests; this drives the
+  // WIRING's root selection, so mutating the wiring's root handling reds here.
+  const EHG_ROOT = '/repos/ehg';
+  const ENGINEER_ROOT = '/repos/EHG_Engineer';
+  // Only the ehg tree contains the spec: existence keys off which root the wiring passes down.
+  const fsOnlyInEhg = { existsSync: (p) => String(p).replace(/\\/g, '/').startsWith(EHG_ROOT + '/') };
+
+  it('the wiring with the CORRECT root preserves the real path', () => {
+    const r = generateE2ETestPath('SD-X-001', 'feature', '001', 't', { repoRoot: EHG_ROOT, deps: fsOnlyInEhg });
+    expect(r.path).toBe('tests/e2e/x-001-us-001.spec.ts');
+  });
+
+  it('the wiring with the WRONG root refuses the same path — the verdict follows the root', () => {
+    const r = generateE2ETestPath('SD-X-001', 'feature', '001', 't', { repoRoot: ENGINEER_ROOT, deps: fsOnlyInEhg });
+    expect(r.path).toBeNull();
+  });
+});
+
+describe('TS-5 — single representation, positively asserted', () => {
+  const src = readFileSync(new URL('../../../scripts/modules/auto-trigger-stories.mjs', import.meta.url), 'utf8');
+
+  it('POSITIVE: the writer imports the guard (reds if unwired — the writer had zero fs checks before, so absence-only proves nothing)', () => {
+    expect(src).toMatch(/from '\.\.\/\.\.\/lib\/stories\/e2e-path-guard\.js'/);
+    expect(src).toMatch(/resolveE2ePath\(\{/);
+    expect(src).toMatch(/requireRelevance: false/); // the sibling gate's deliberate existence-only bar
+  });
+
+  it('NEGATIVE: no second existence predicate in the writer', () => {
+    const stripComments = (s) => s.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    const code = stripComments(src);
+    expect(code).not.toMatch(/existsSync|statSync|accessSync/);
+  });
+});
+
+describe('FR-4 — the counter-pressure instrument census, pinned', () => {
+  // Measured 2026-08-10: public.validate_story_e2e_requirements (which reports a NULL
+  // e2e_test_path as an ISSUE — the exact fabrication pressure this SD removes) and both its
+  // relatives have ZERO code consumers: their only caller is each other inside the defining
+  // migration. The write-side NULLs therefore cannot regress any live code path through them.
+  // If this test reds, a consumer appeared and the recorded contradiction (feedback channel,
+  // SD-LEO-INFRA-STORY-E2E-WRITE-001) must be re-evaluated BEFORE relying on that consumer.
+  it('validate_story_e2e_requirements and relatives have zero callers under scripts/ and lib/', () => {
+    for (const fn of ['validate_story_e2e_requirements', 'validate_sd_stories_e2e_requirements', 'get_e2e_template_for_sd']) {
+      let out = '';
+      try {
+        out = execSync(`git grep -l "${fn}" -- scripts lib`, { encoding: 'utf8', cwd: new URL('../../..', import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1') });
+      } catch { /* non-zero exit = no matches = the pinned state */ }
+      expect(out.trim(), `${fn} gained a code consumer — re-evaluate the recorded contradiction`).toBe('');
+    }
+  });
+});
+
+describe('status column ownership is untouched (regression pin)', () => {
+  it('the wiring changed only the path owner: not_created / not_applicable stamping is byte-identical', () => {
+    expect(generateE2ETestPath('SD-A-1', 'feature', '001', 't', { repoRoot: '/r', deps: noFile }).status).toBe('not_created');
+    expect(generateE2ETestPath('SD-A-1', 'feature', '001', 't', { repoRoot: '/r', deps: everyFile }).status).toBe('not_created');
+    expect(generateE2ETestPath('SD-A-1', 'documentation', '001', 't', { repoRoot: '/r', deps: noFile }).status).toBe('not_applicable');
+  });
+});

--- a/tests/unit/stories/e2e-path-write-wiring.test.js
+++ b/tests/unit/stories/e2e-path-write-wiring.test.js
@@ -12,7 +12,8 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
-import { generateE2ETestPath } from '../../../scripts/modules/auto-trigger-stories.mjs';
+import { fileURLToPath } from 'node:url';
+import { generateE2ETestPath, resolveStoryE2eRoot } from '../../../scripts/modules/auto-trigger-stories.mjs';
 
 const noFile = { existsSync: () => false };
 const everyFile = { existsSync: () => true };
@@ -91,13 +92,52 @@ describe('FR-4 — the counter-pressure instrument census, pinned', () => {
   // migration. The write-side NULLs therefore cannot regress any live code path through them.
   // If this test reds, a consumer appeared and the recorded contradiction (feedback channel,
   // SD-LEO-INFRA-STORY-E2E-WRITE-001) must be re-evaluated BEFORE relying on that consumer.
-  it('validate_story_e2e_requirements and relatives have zero callers under scripts/ and lib/', () => {
+  it('validate_story_e2e_requirements and relatives have zero callers under scripts/, lib/ and src/', () => {
+    // Adversarial-review hardening: a broken census instrument must FAIL LOUD, never read as
+    // the pinned-good state. git grep exits 1 for "no matches" (the pinned state) but 128 for
+    // a bad cwd / not-a-repo — only exit 1 may be swallowed. cwd goes through fileURLToPath so
+    // a checkout path containing spaces cannot silently break the instrument.
+    const repoRoot = fileURLToPath(new URL('../../..', import.meta.url));
     for (const fn of ['validate_story_e2e_requirements', 'validate_sd_stories_e2e_requirements', 'get_e2e_template_for_sd']) {
       let out = '';
       try {
-        out = execSync(`git grep -l "${fn}" -- scripts lib`, { encoding: 'utf8', cwd: new URL('../../..', import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1') });
-      } catch { /* non-zero exit = no matches = the pinned state */ }
+        out = execSync(`git grep -l "${fn}" -- scripts lib src`, { encoding: 'utf8', cwd: repoRoot });
+      } catch (e) {
+        if (e.status !== 1) throw new Error(`census instrument broke (exit ${e.status}): ${e.message}`);
+        // exit 1 = genuinely zero matches = the pinned state
+      }
       expect(out.trim(), `${fn} gained a code consumer — re-evaluate the recorded contradiction`).toBe('');
+    }
+  });
+});
+
+describe('FR-2 — production root resolution follows the story TARGET repo', () => {
+  // Adversarial-review WARNING closed: the production call site previously defaulted every
+  // SD to process.cwd(), so an ehg-target SD's REAL spec (created after EXEC) would have been
+  // checked against the wrong disk and nulled on re-generation.
+  it('EHG-target SDs resolve to the ehg checkout (EHG_APP_PATH override honored)', () => {
+    const prev = process.env.EHG_APP_PATH;
+    try {
+      process.env.EHG_APP_PATH = '/custom/ehg';
+      expect(resolveStoryE2eRoot('EHG')).toBe('/custom/ehg');
+      expect(resolveStoryE2eRoot(' ehg ')).toBe('/custom/ehg');
+      delete process.env.EHG_APP_PATH;
+      expect(resolveStoryE2eRoot('EHG').replace(/\\/g, '/')).toMatch(/\/ehg$/);
+    } finally {
+      if (prev === undefined) delete process.env.EHG_APP_PATH; else process.env.EHG_APP_PATH = prev;
+    }
+  });
+
+  it('non-EHG targets resolve to this repo (STORY_E2E_REPO_ROOT override, else cwd)', () => {
+    const prev = process.env.STORY_E2E_REPO_ROOT;
+    try {
+      process.env.STORY_E2E_REPO_ROOT = '/custom/engineer';
+      expect(resolveStoryE2eRoot('EHG_Engineer')).toBe('/custom/engineer');
+      expect(resolveStoryE2eRoot(null)).toBe('/custom/engineer');
+      delete process.env.STORY_E2E_REPO_ROOT;
+      expect(resolveStoryE2eRoot('EHG_Engineer')).toBe(process.cwd());
+    } finally {
+      if (prev === undefined) delete process.env.STORY_E2E_REPO_ROOT; else process.env.STORY_E2E_REPO_ROOT = prev;
     }
   });
 });


### PR DESCRIPTION
## Summary
- **FR-1**: `generateE2ETestPath` (scripts/modules/auto-trigger-stories.mjs) is exported with an injectable `{repoRoot, deps}` seam and routes its templated candidate through the EXISTING `lib/stories/e2e-path-guard.js` `resolveE2ePath` (`requireRelevance:false` — the sibling gate's deliberate existence-only bar). A candidate naming a nonexistent spec persists **NULL**; the documentation sentinel string is gone (NULL); `e2e_test_status` stamping is byte-identical. This shuts off the false-'passing' pump the sibling SD measured (641 rows claiming passing against nonexistent files) and closes a latent prototype-chain type-confusion write (SECURITY-verified).
- **FR-2**: repo-root contract — root injectable (`STORY_E2E_REPO_ROOT` env precedent), root-flip test drives the WIRING; `map-e2e-tests-to-stories.js` carries the decided in-file exemption (its fs scan of ../ehg IS the existence proof; guard-with-wrong-root would null real coverage).
- **FR-3**: server-side trigger blind spot (never fired, 0 rows) declared at the wiring site; the 20251210/20251211 byte-equivalent DDL hazard routed to the feedback channel. No DDL in this PR.
- **FR-4**: `validate_story_e2e_requirements` zero-consumer census pinned by an assertable test; the reconcile-or-drop contradiction recorded durably.

## Test plan
- [x] 40/40 tests in tests/unit/stories/ (17 guard + wiring suite); 94/94 wider regression incl. adjacent story suites
- [x] Every positive control injects the failing input (baseline is quiet: 0/443 recent stories carry a path — green-by-default guarded per TR-2)
- [x] 7 mutations (3 author + 4 independent TESTING) each redded named tests; flip-requireRelevance redding the preservation tests proves the existence-only bar live
- [x] TESTING sub-agent PASS conf 95 (fe4684f3); SECURITY PASS conf 92 (38eb05a3); zero database/migrations changes in the three-dot diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)