### PR TITLE
fix(SD-LEO-INFRA-ABSENT-GATE-SCORE-001): an absent gate2 score reads INAPPLICABLE, not FAILED

### DIFF
--- a/scripts/modules/traceability-validation/preflight/index.js
+++ b/scripts/modules/traceability-validation/preflight/index.js
@@ -37,7 +37,25 @@ export async function runPreflightChecks(sdUuid, validation, supabase) {
     }
 
     const gate2Validation = gate2Handoff[0].metadata?.gate2_validation;
-    if (!gate2Validation || !gate2Validation.passed) {
+
+    // ABSENT is not FAILED (SD-LEO-INFRA-ABSENT-GATE-SCORE-001). An accepted EXEC-TO-PLAN handoff
+    // that carries NO gate2_validation object is a gate that never produced a verdict — not-run /
+    // not-recorded — which is INAPPLICABLE, not a failing verdict. The never-handed-off case is
+    // already blocked above (the handoff-existence guard). A gate genuinely ruled inapplicable is
+    // recorded `passed:true` by the writer, so it takes the pass path below; and the writer's
+    // `{passed:false, score:0}` placeholder is PRESENT, so it correctly hard-blocks in the next
+    // branch. Hence: key ABSENT on `== null` ONLY — never on `!passed` — so a present-but-failed
+    // score (real or placeholder) keeps blocking downstream Gate-3 checks.
+    if (gate2Validation == null) {
+      validation.warnings ??= [];
+      validation.warnings.push('[PHASE 1] Gate 2 validation absent (not-run/not-recorded) - treated as INAPPLICABLE, not a failure');
+      console.log('   INAPPLICABLE Gate 2 score absent (no verdict recorded) - NOT blocking Gate 3');
+      console.log('   Note An instrument that produced no verdict is not a failing verdict');
+      console.log('='.repeat(60));
+      return { passed: true, gate2Data: null };
+    }
+
+    if (!gate2Validation.passed) {
       validation.issues.push('[PHASE 1] CRITICAL: Gate 2 validation failed - cannot proceed to Gate 3');
       validation.failed_gates.push('GATE2_FAILED');
       validation.passed = false;

--- a/scripts/modules/traceability-validation/preflight/index.test.js
+++ b/scripts/modules/traceability-validation/preflight/index.test.js
@@ -1,0 +1,93 @@
+/**
+ * Preflight absent-vs-failed gate2 tests — SD-LEO-INFRA-ABSENT-GATE-SCORE-001.
+ *
+ * The module had ZERO coverage. These pin the fix two-sided: an ABSENT gate2_validation reads
+ * INAPPLICABLE (positive control, does not cascade Gate-3 to FAILED); a PRESENT-and-failed score
+ * — including the writer's {passed:false,score:0} placeholder and a malformed {} — still hard-blocks
+ * (negative controls). Mutations are asserted, not just the return value (a return-only check would
+ * stay green if the code forgot to record the warning / failed_gate).
+ */
+import { describe, it, expect } from 'vitest';
+import { runPreflightChecks } from './index.js';
+
+/** The one supabase chain runPreflightChecks calls: .from().select().eq().eq().order().limit()->{data}. */
+function makeSupabaseStub(data) {
+  const chain = {
+    from: () => chain,
+    select: () => chain,
+    eq: () => chain,
+    order: () => chain,
+    limit: () => Promise.resolve({ data, error: null }),
+  };
+  return chain;
+}
+
+/** Fresh validation object, mirroring the production caller (traceability-validation/index.js:53-62). */
+function freshValidation() {
+  return { passed: true, score: 0, max_score: 100, issues: [], warnings: [], details: {}, failed_gates: [], gate_scores: {} };
+}
+
+const handoff = (gate2_validation) => [{ metadata: gate2_validation === undefined ? {} : { gate2_validation } }];
+
+describe('runPreflightChecks — absent gate2 reads INAPPLICABLE, not FAILED', () => {
+  it('TS-1a: ABSENT (key missing / undefined) → INAPPLICABLE, proceeds, no GATE2_FAILED', async () => {
+    const v = freshValidation();
+    const r = await runPreflightChecks('sd-uuid', v, makeSupabaseStub(handoff(undefined)));
+    expect(r).toEqual({ passed: true, gate2Data: null });
+    expect(v.warnings.some((w) => w.includes('INAPPLICABLE'))).toBe(true);
+    expect(v.failed_gates).not.toContain('GATE2_FAILED');
+    expect(v.passed).toBe(true);
+  });
+
+  it('TS-1b: ABSENT (explicit null) → INAPPLICABLE (== null makes it equivalent to undefined)', async () => {
+    const v = freshValidation();
+    const r = await runPreflightChecks('sd-uuid', v, makeSupabaseStub(handoff(null)));
+    expect(r).toEqual({ passed: true, gate2Data: null });
+    expect(v.failed_gates).not.toContain('GATE2_FAILED');
+    expect(v.passed).toBe(true);
+  });
+
+  it('TS-2: PRESENT and failed {passed:false,score:60} → GATE2_FAILED hard block', async () => {
+    const v = freshValidation();
+    const gate2 = { passed: false, score: 60, max_score: 100 };
+    const r = await runPreflightChecks('sd-uuid', v, makeSupabaseStub(handoff(gate2)));
+    expect(r.passed).toBe(false);
+    expect(r.gate2Data).toEqual(gate2);
+    expect(v.failed_gates).toContain('GATE2_FAILED');
+    expect(v.passed).toBe(false);
+  });
+
+  it('TS-3: the writer placeholder {passed:false,score:0} still hard-blocks (NOT soft-passed as absent)', async () => {
+    const v = freshValidation();
+    const r = await runPreflightChecks('sd-uuid', v, makeSupabaseStub(handoff({ passed: false, score: 0, warning: 'Fidelity data not populated' })));
+    expect(r.passed).toBe(false);
+    expect(v.failed_gates).toContain('GATE2_FAILED');
+  });
+
+  it('TS-4: PRESENT and passed {passed:true} → proceeds', async () => {
+    const v = freshValidation();
+    const gate2 = { passed: true, score: 85, max_score: 100 };
+    const r = await runPreflightChecks('sd-uuid', v, makeSupabaseStub(handoff(gate2)));
+    expect(r).toEqual({ passed: true, gate2Data: gate2 });
+    expect(v.failed_gates).toHaveLength(0);
+    expect(v.warnings.some((w) => w.includes('INAPPLICABLE'))).toBe(false);
+  });
+
+  it('TS-5: NO EXEC-TO-PLAN handoff → GATE2_HANDOFF (line-29 guard, unchanged)', async () => {
+    const v = freshValidation();
+    const r = await runPreflightChecks('sd-uuid', v, makeSupabaseStub([]));
+    expect(r).toEqual({ passed: false, gate2Data: null });
+    expect(v.failed_gates).toContain('GATE2_HANDOFF');
+    expect(v.failed_gates).not.toContain('GATE2_INAPPLICABLE');
+  });
+
+  it('TS-6: PRESENT-but-empty {} (passed===undefined) still blocks — boundary is key-present, not passed-truthy', async () => {
+    for (const malformed of [{}, { score: 50 }]) {
+      const v = freshValidation();
+      const r = await runPreflightChecks('sd-uuid', v, makeSupabaseStub(handoff(malformed)));
+      expect(r.passed, `malformed ${JSON.stringify(malformed)} must block, not read INAPPLICABLE`).toBe(false);
+      expect(v.failed_gates).toContain('GATE2_FAILED');
+      expect(v.warnings.some((w) => w.includes('INAPPLICABLE'))).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
**The defect:** `scripts/modules/traceability-validation/preflight/index.js:40` — `if (!gate2Validation || !gate2Validation.passed)` conflated an **absent** gate2 score (not-run / not-recorded) with a **failed** one. Both early-return-failed, cascading the whole of Gate 3 (PLAN-TO-LEAD) to FAILED. An instrument that produced no verdict is not a failing verdict.

**The fix (one site, ~15 source LOC):** split the conditional —
- absent (`gate2Validation == null`) → INAPPLICABLE: a warning, proceeds with `gate2Data: null` (which every downstream consumer already tolerates — Gate 4 already treats absent gate2 as legitimate-absence);
- present-and-failed (`!gate2Validation.passed`) → `GATE2_FAILED` hard block, unchanged.

**The load-bearing correctness constraint** (from VALIDATION): keyed on `== null` *only*, never on `!passed`. The writer's `{passed:false,score:0}` placeholder and a malformed `{}` are **present**, so they stay in the FAILED branch — a real failure is never soft-passed as absent. The never-handed-off case (line 29 guard) is untouched.

**Premise refinement (measured, signaled):** there is no machine-readable "ruled inapplicable" marker — a gate genuinely ruled inapplicable is already recorded `passed:true` and passes. Absent means not-recorded, which on the canonical EXEC-TO-PLAN path only co-occurs with an audit-logged `--bypass-validation` or a legacy record, so the soft-pass is bounded.

**Tests:** the module had **zero** coverage. Adds 7 two-sided cases — both absent forms → INAPPLICABLE (positive control), `{passed:false}` + placeholder + malformed `{}` → GATE2_FAILED (negative controls), asserted on the `validation` mutations not just the return value. 19 tests green across the traceability-validation surface.

Evidence: Explore 59680836, VALIDATION e9c50df0, prospective TESTING 49e04292.

🤖 Generated with [Claude Code](https://claude.com/claude-code)