### PR TITLE
feat(SD-LEO-INFRA-LEO-CREATE-PLAN-001): --depends-on and --roadmap-link-reason on the --from-plan lane, one canonical normalizeDependsOn

### DIFF
--- a/lib/sd-creation/source-adapters/child.js
+++ b/lib/sd-creation/source-adapters/child.js
@@ -8,22 +8,13 @@ import { supabase } from '../context.js';
 import { generateChildKey, deriveChildIndex } from '../../../scripts/modules/sd-key-generator.js';
 import { inheritStrategicFields, createSDOrThrow as createSD } from '../pipeline.js';
 import { classifyPlanLinkage } from '../plan-linkage-classifier.js';
-
-/**
- * PURE: normalize a --depends-on / overrides.dependsOn list of sibling sd_keys into the
- * canonical `dependencies` column shape ({sd_id: key} objects) that draftDepsSatisfied
- * (lib/fleet/claim-eligibility.cjs, the shared claim-eligibility predicate) reads. Non-string
- * or blank entries are dropped rather than throwing — a malformed single entry among several
- * good ones should not abort child creation.
- * @param {unknown} dependsOn
- * @returns {Array<{sd_id: string}>}
- */
-export function normalizeDependsOn(dependsOn) {
-  if (!Array.isArray(dependsOn) || dependsOn.length === 0) return [];
-  return dependsOn
-    .filter((k) => typeof k === 'string' && k.trim())
-    .map((k) => ({ sd_id: k.trim() }));
-}
+// SD-LEO-INFRA-LEO-CREATE-PLAN-001 (FR-3): this file used to carry its own strings-only
+// normalizeDependsOn — one of TWO divergent copies. All lanes now share the canonical
+// superset (bare string, {sd_id}, {sd_key} → {sd_id}) from proposal-lanes; bare-string
+// behavior is unchanged, object entries now normalize instead of being silently dropped.
+// The re-export preserves this module's public surface for existing importers.
+import { normalizeDependsOn } from '../../../scripts/modules/leo-create-sd/proposal-lanes.js';
+export { normalizeDependsOn };
 
 /**
  * Create child SD

--- a/lib/sd-creation/source-adapters/plan.js
+++ b/lib/sd-creation/source-adapters/plan.js
@@ -20,6 +20,9 @@ import {
 } from '../../../scripts/modules/plan-archiver.js';
 import { resolveVenturePrefix, createSDOrThrow as createSD } from '../pipeline.js';
 import { classifyPlanLinkage } from '../plan-linkage-classifier.js';
+// SD-LEO-INFRA-LEO-CREATE-PLAN-001 (FR-3): the ONE canonical normalizeDependsOn (superset:
+// bare string, {sd_id}, {sd_key}) — never a third divergent copy.
+import { normalizeDependsOn } from '../../../scripts/modules/leo-create-sd/proposal-lanes.js';
 
 /**
  * Compute a deterministic SHA256 hash of plan content for duplicate detection.
@@ -306,6 +309,22 @@ export async function createFromPlan(planPath = null, skipConfirmation = false, 
   // createSD's orchestrator gate (which throws when an orchestrator parent
   // arrives without a disposition).
   if (overrides.waveDisposition) createOptions.wave_disposition = overrides.waveDisposition;
+  // SD-LEO-INFRA-LEO-CREATE-PLAN-001 (FR-1): born-fenced dependencies in the SAME
+  // createSD INSERT — a post-insert UPDATE would reopen the claimable window the
+  // born-fenced design (child.js:91-97) exists to close. Canonical normalizeDependsOn
+  // (the proposal-lanes superset) so all lanes normalize identically. Only set when
+  // non-empty so the flag-absent payload stays byte-identical to today.
+  if (overrides.dependsOn) {
+    const deps = normalizeDependsOn(overrides.dependsOn);
+    if (deps.length > 0) createOptions.dependencies = deps;
+  }
+  // SD-LEO-INFRA-LEO-CREATE-PLAN-001 (FR-2): operator reason for the roadmap-link
+  // exception (mirrors direct-lane.js). pipeline.js destructures roadmap_link_reason
+  // and buildRoadmapLinkException sanitizes/bounds it; only recorded when the creation
+  // is actually unlinked (legal silence per that module's no-refusal contract).
+  if (typeof overrides.roadmapLinkReason === 'string' && overrides.roadmapLinkReason.trim()) {
+    createOptions.roadmap_link_reason = overrides.roadmapLinkReason;
+  }
   // 7f0a4f54: explicit `## Target Application` plan header takes precedence
   // over detectFromKeyChanges file-path inference. Without this, plans that
   // literally name the target still landed under the path-detector's default.

--- a/scripts/leo-create-sd.js
+++ b/scripts/leo-create-sd.js
@@ -147,13 +147,19 @@ Flags:
   --scope-slice <JSON>  (--child only) Declare the slice of parent orchestrator scope this
                         child claims. JSON shape: {stages?: number[], deliverable_globs?: string[]}.
                         Example: --scope-slice='{"stages":[18]}'
-  --depends-on <list>   (--child only) Comma-separated sibling SD keys this child depends on.
-                        Set on the dependencies column ATOMICALLY with the child's insert
-                        (QF-20260711-841 born-fenced sequencing) so the shared claim-eligibility
+  --depends-on <list>   (--child and --from-plan) Comma-separated SD keys this SD depends on.
+                        Set on the dependencies column ATOMICALLY with the insert
+                        (QF-20260711-841 born-fenced sequencing; extended to the plan lane by
+                        SD-LEO-INFRA-LEO-CREATE-PLAN-001) so the shared claim-eligibility
                         predicate (lib/fleet/claim-eligibility.cjs draftDepsSatisfied) blocks
-                        claiming until every referenced sibling completes -- no post-hoc
+                        claiming until every referenced SD completes -- no post-hoc
                         coordinator fencing window between birth and dependency-gating.
                         Example: --depends-on SD-LEO-ORCH-FOO-001-A,SD-LEO-ORCH-FOO-001-B
+  --roadmap-link-reason "<text>"  (--from-plan) Operator reason recorded on
+                        metadata.roadmap_link_exception when the creation is unlinked from the
+                        roadmap (register-first exception). Without it the exception stamps
+                        no-reason-supplied — the counted gap the sourcing health probe drives
+                        to zero. Recorded only when actually unlinked; never a refusal path.
   --target-repos <list> Set metadata.target_repos[] for cross-repo SDs (comma-separated).
                         Valid values: EHG, EHG_Engineer (case-insensitive; normalized).
                         When set, PR_MERGE_VERIFICATION at LEAD-FINAL scopes its scan
@@ -188,6 +194,8 @@ Flags:
 Dependency Field Guide:
   The "dependencies" column (JSONB array) is the CORRECT place for SD prerequisites.
   Format: [{"sd_id": "SD-XXX-001"}, {"sd_id": "SD-YYY-002"}]
+  Write it at creation with --depends-on (works on --child AND --from-plan):
+    node scripts/leo-create-sd.js --from-plan my-plan.md --depends-on SD-XXX-001 --yes
 
   It is the ONLY dependency home honored by EVERY consumer — sd:next's
   queue display, AUTO-PROCEED skip/process, the worker claim lanes, AND
@@ -385,7 +393,21 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
       const waveDispositionPlan = waveIdxPlan !== -1
         ? { waveId: args[waveIdxPlan + 1] }
         : (noWaveIdxPlan !== -1 ? { noWave: args[noWaveIdxPlan + 1] } : null);
-      // Path is any arg that isn't a flag or a flag's value
+      // SD-LEO-INFRA-LEO-CREATE-PLAN-001: creation-time relationship/reason intent.
+      // Comma-split contract copied from the child lane (:454) — without the split,
+      // --depends-on SD-A,SD-B would land ONE malformed dep and the SD is born
+      // silently unfenced.
+      const dependsOnIdxPlan = args.indexOf('--depends-on');
+      const dependsOnPlan = dependsOnIdxPlan !== -1 && args[dependsOnIdxPlan + 1]
+        ? args[dependsOnIdxPlan + 1].split(',').map((k) => k.trim()).filter(Boolean)
+        : null;
+      const linkReasonIdxPlan = args.indexOf('--roadmap-link-reason');
+      const roadmapLinkReasonPlan = linkReasonIdxPlan !== -1 ? args[linkReasonIdxPlan + 1] : null;
+      // Path is any arg that isn't a flag or a flag's value.
+      // A value-taking flag MUST appear in BOTH flagValuePositions and knownPlanFlags:
+      // the planPath predicate short-circuits on !startsWith('-') so only
+      // flagValuePositions stops a flag's VALUE (an SD key does not start with '-')
+      // from being silently adopted as planPath — the direct-lane.js:65-69 bug class.
       const flagValuePositions = new Set(
         [
           typeIdx !== -1 ? typeIdx + 1 : -1,
@@ -396,12 +418,15 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
           targetReposIdxPlan !== -1 ? targetReposIdxPlan + 1 : -1,
           waveIdxPlan !== -1 ? waveIdxPlan + 1 : -1,
           noWaveIdxPlan !== -1 ? noWaveIdxPlan + 1 : -1,
+          dependsOnIdxPlan !== -1 ? dependsOnIdxPlan + 1 : -1,
+          linkReasonIdxPlan !== -1 ? linkReasonIdxPlan + 1 : -1,
         ].filter(i => i > 0)
       );
       const knownPlanFlags = new Set([
         '--yes', '-y', '--type', '--title', '--priority', '--from-plan',
         '--vision-key', '--arch-key', '--migration-reviewed', '--security-reviewed',
-        '--target-repos', '--force-create', '--wave', '--no-wave'
+        '--target-repos', '--force-create', '--wave', '--no-wave',
+        '--depends-on', '--roadmap-link-reason'
       ]);
       const planPath = args.find((arg, i) =>
         i > 0 && !arg.startsWith('-') && !flagValuePositions.has(i) && !knownPlanFlags.has(arg)
@@ -417,6 +442,8 @@ Note: SD keys starting with QF- will be redirected to create-quick-fix.js.
         targetRepos: targetReposPlan,
         forceCreate,
         waveDisposition: waveDispositionPlan,
+        dependsOn: dependsOnPlan,
+        roadmapLinkReason: roadmapLinkReasonPlan,
       });
       exitFromResult(planRes);
     } else if (args[0] === '--child') {

--- a/scripts/modules/leo-create-sd/proposal-lanes.js
+++ b/scripts/modules/leo-create-sd/proposal-lanes.js
@@ -338,7 +338,16 @@ export function normalizeDependsOn(dependsOn) {
   for (const entry of dependsOn) {
     let key = null;
     if (typeof entry === 'string') key = entry.trim();
-    else if (entry && typeof entry === 'object') key = (entry.sd_id || entry.sd_key || '').trim();
+    else if (entry && typeof entry === 'object') {
+      // Only string-typed keys count. `(entry.sd_id || entry.sd_key || '').trim()` threw on
+      // {sd_id: 42} — contradicting this function's own fail-soft contract ("malformed
+      // entries are dropped ... must never crash SD creation"), and FR-3's de-dupe
+      // (SD-LEO-INFRA-LEO-CREATE-PLAN-001) made that latent throw shared across every
+      // lane (SECURITY LOW-2, evidence f54bdc8e). Dropped, not coerced: String({}) would
+      // mint a garbage-but-truthy '[object Object]' dependency key.
+      const raw = entry.sd_id ?? entry.sd_key;
+      key = typeof raw === 'string' ? raw.trim() : null;
+    }
     if (key) out.push({ sd_id: key });
   }
   return out;

--- a/scripts/modules/leo-create-sd/proposal-lanes.js
+++ b/scripts/modules/leo-create-sd/proposal-lanes.js
@@ -333,7 +333,15 @@ export function mapProposalToCreateArgs(normalized, proposal, filePath, opts = {
  * proposal without depends_on yields dependencies=[] (no behavior change). PURE.
  */
 export function normalizeDependsOn(dependsOn) {
-  if (!Array.isArray(dependsOn)) return [];
+  if (!Array.isArray(dependsOn)) {
+    // Whole-input shape mismatch must be as loud as a per-entry drop: a caller passing the
+    // CLI's own comma-string shape ('SD-A,SD-B') here would otherwise get [] silently and
+    // an SD born entirely unfenced (adversarial review PR #6935, INFO-1).
+    if (dependsOn != null) {
+      console.warn('⚠️  normalizeDependsOn: expected an ARRAY of entries, got ' + typeof dependsOn + ' — ALL dependencies dropped; the SD will not be fenced. (A comma string must be split before this call.)');
+    }
+    return [];
+  }
   const out = [];
   let dropped = 0;
   for (const entry of dependsOn) {
@@ -346,8 +354,11 @@ export function normalizeDependsOn(dependsOn) {
       // (SD-LEO-INFRA-LEO-CREATE-PLAN-001) made that latent throw shared across every
       // lane (SECURITY LOW-2, evidence f54bdc8e). Dropped, not coerced: String({}) would
       // mint a garbage-but-truthy '[object Object]' dependency key.
-      const raw = entry.sd_id ?? entry.sd_key;
-      key = typeof raw === 'string' ? raw.trim() : null;
+      // sd_id falls through to sd_key on blank/non-string — the old `||` semantics:
+      // {sd_id:'', sd_key:'SD-OK'} must keep fencing (a `??` here silently un-fenced that
+      // previously-valid shape — adversarial review PR #6935, the one WARNING).
+      const primary = typeof entry.sd_id === 'string' && entry.sd_id.trim() ? entry.sd_id : entry.sd_key;
+      key = typeof primary === 'string' ? primary.trim() : null;
     }
     if (key) out.push({ sd_id: key });
     else dropped += 1;

--- a/scripts/modules/leo-create-sd/proposal-lanes.js
+++ b/scripts/modules/leo-create-sd/proposal-lanes.js
@@ -335,6 +335,7 @@ export function mapProposalToCreateArgs(normalized, proposal, filePath, opts = {
 export function normalizeDependsOn(dependsOn) {
   if (!Array.isArray(dependsOn)) return [];
   const out = [];
+  let dropped = 0;
   for (const entry of dependsOn) {
     let key = null;
     if (typeof entry === 'string') key = entry.trim();
@@ -349,6 +350,13 @@ export function normalizeDependsOn(dependsOn) {
       key = typeof raw === 'string' ? raw.trim() : null;
     }
     if (key) out.push({ sd_id: key });
+    else dropped += 1;
+  }
+  if (dropped > 0) {
+    // LOUD, never silent: a dropped dep means the SD is born UNFENCED on that edge —
+    // born-fenced sequencing (QF-20260711-841) is the invariant at stake, and a generator
+    // that starts emitting numeric sd_id must be detectable (REGRESSION a0266b0d).
+    console.warn(`⚠️  normalizeDependsOn: dropped ${dropped} malformed dependency entr${dropped === 1 ? 'y' : 'ies'} — the SD will NOT be fenced on the dropped edge(s). Entries must be "SD-KEY" or {sd_id|sd_key: "SD-KEY"}.`);
   }
   return out;
 }

--- a/tests/unit/leo-create-sd-plan-flags.test.js
+++ b/tests/unit/leo-create-sd-plan-flags.test.js
@@ -40,6 +40,13 @@ describe('FR-3: one canonical normalizeDependsOn', () => {
     expect(fromChild([{ sd_id: 'SD-A' }, { sd_key: 'SD-B' }])).toEqual([{ sd_id: 'SD-A' }, { sd_id: 'SD-B' }]);
   });
 
+  it('malformed entries DROP, never throw and never coerce (SECURITY LOW-2, the fail-soft contract)', () => {
+    // {sd_id: 42} used to throw ".trim is not a function" — contradicting the function's
+    // own doc; String() coercion would mint a garbage '[object Object]' key instead.
+    expect(fromChild([{ sd_id: 42 }, { sd_id: { deep: true } }, { sd_id: 'SD-OK' }, {}]))
+      .toEqual([{ sd_id: 'SD-OK' }]);
+  });
+
   it('exactly one definition exists across the creation lanes (child.js only re-exports)', () => {
     const childSrc = read('../../lib/sd-creation/source-adapters/child.js');
     expect(childSrc).not.toMatch(/function\s+normalizeDependsOn/);

--- a/tests/unit/leo-create-sd-plan-flags.test.js
+++ b/tests/unit/leo-create-sd-plan-flags.test.js
@@ -1,0 +1,130 @@
+// SD-LEO-INFRA-LEO-CREATE-PLAN-001: --depends-on + --roadmap-link-reason on the
+// --from-plan lane. Incorporates the PLAN-phase TESTING gaps (evidence 5d2cc8fc):
+//   GAP-1: pins are PER-FILE/PER-BLOCK anchored windows, never a whole-source contains
+//          (scripts/leo-create-sd.js already contained '--depends-on' via the child lane,
+//          so an unanchored contains was green before the plan lane gained the flag).
+//   GAP-2: the comma-split contract is pinned — without split(','), SD-A,SD-B lands ONE
+//          malformed dep {sd_id:"SD-A,SD-B"} that fails soft (born silently unfenced).
+//   GAP-3: the child-lane surface now normalizes OBJECT entries (behavior-widening half
+//          of the de-dupe), asserted as behavior, not just source.
+//   GAP-4: knownPlanFlags.has(flag) is UNREACHABLE for flag tokens in the planPath
+//          predicate (short-circuits on !startsWith('-')); only flagValuePositions stops
+//          a flag VALUE being absorbed as planPath — so the pins target the
+//          flagValuePositions array literal specifically, not Set membership.
+
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { normalizeDependsOn as fromChild } from '../../lib/sd-creation/source-adapters/child.js';
+import { normalizeDependsOn as canonical } from '../../scripts/modules/leo-create-sd/proposal-lanes.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const read = (p) => fs.readFileSync(path.resolve(__dirname, p), 'utf-8');
+
+describe('FR-3: one canonical normalizeDependsOn', () => {
+  it('child.js re-exports the SAME function object as proposal-lanes (identity, not similarity)', () => {
+    // Reference identity is the strongest possible de-dupe assertion: a re-divergent
+    // copy cannot pass it no matter how behaviorally close it starts out.
+    expect(fromChild).toBe(canonical);
+  });
+
+  it('bare-string behavior unchanged (the behavior-preserving half)', () => {
+    expect(fromChild(['SD-A', ' SD-B ', '', null])).toEqual([{ sd_id: 'SD-A' }, { sd_id: 'SD-B' }]);
+    expect(fromChild(undefined)).toEqual([]);
+    expect(fromChild([])).toEqual([]);
+  });
+
+  it('object entries now normalize through the child surface (GAP-3: the widening half)', () => {
+    // The old child.js copy filtered typeof entry === 'string' and silently DROPPED these.
+    expect(fromChild([{ sd_id: 'SD-A' }, { sd_key: 'SD-B' }])).toEqual([{ sd_id: 'SD-A' }, { sd_id: 'SD-B' }]);
+  });
+
+  it('exactly one definition exists across the creation lanes (child.js only re-exports)', () => {
+    const childSrc = read('../../lib/sd-creation/source-adapters/child.js');
+    expect(childSrc).not.toMatch(/function\s+normalizeDependsOn/);
+    const lanesSrc = read('../../scripts/modules/leo-create-sd/proposal-lanes.js');
+    expect(lanesSrc).toMatch(/export function normalizeDependsOn/);
+  });
+});
+
+describe('CLI plan-branch wiring (anchored per-block pins, GAP-1/GAP-2/GAP-4)', () => {
+  let cli;
+  beforeAll(() => {
+    cli = read('../../scripts/leo-create-sd.js');
+  });
+
+  function planBranchWindow() {
+    // Anchor inside the plan branch specifically — the child lane also parses
+    // --depends-on, so an unanchored search proves nothing about this lane.
+    const idx = cli.indexOf('const dependsOnIdxPlan');
+    expect(idx).toBeGreaterThan(0);
+    return cli.slice(idx, idx + 2500);
+  }
+
+  it('parses --depends-on with the comma-split contract (GAP-2)', () => {
+    const w = planBranchWindow();
+    expect(w).toMatch(/args\.indexOf\('--depends-on'\)/);
+    expect(w).toMatch(/\.split\(','\)\.map\(\s*\(k\)\s*=>\s*k\.trim\(\)\s*\)\.filter\(Boolean\)/);
+  });
+
+  it('registers BOTH new flag values in flagValuePositions (GAP-4: the only guard that is reachable)', () => {
+    const w = planBranchWindow();
+    const arrStart = w.indexOf('const flagValuePositions');
+    expect(arrStart).toBeGreaterThan(0);
+    const arr = w.slice(arrStart, arrStart + 900);
+    expect(arr).toMatch(/dependsOnIdxPlan\s*!==\s*-1\s*\?\s*dependsOnIdxPlan\s*\+\s*1/);
+    expect(arr).toMatch(/linkReasonIdxPlan\s*!==\s*-1\s*\?\s*linkReasonIdxPlan\s*\+\s*1/);
+  });
+
+  it('registers both flags in knownPlanFlags (per-block, not whole-file: GAP-1)', () => {
+    const w = planBranchWindow();
+    const setStart = w.indexOf('const knownPlanFlags = new Set');
+    expect(setStart).toBeGreaterThan(0);
+    const block = w.slice(setStart, setStart + 400);
+    expect(block).toMatch(/'--depends-on'/);
+    expect(block).toMatch(/'--roadmap-link-reason'/);
+  });
+
+  it('threads both values into the createFromPlan overrides bag', () => {
+    const idx = cli.indexOf('const planRes = await createFromPlan(');
+    expect(idx).toBeGreaterThan(0);
+    const block = cli.slice(idx, idx + 600);
+    expect(block).toMatch(/dependsOn:\s*dependsOnPlan/);
+    expect(block).toMatch(/roadmapLinkReason:\s*roadmapLinkReasonPlan/);
+  });
+
+  it('help text no longer claims --depends-on is child-only (FR-4)', () => {
+    expect(cli).not.toMatch(/--depends-on <list>\s+\(--child only\)/);
+    expect(cli).toMatch(/--roadmap-link-reason/);
+  });
+});
+
+describe('plan adapter passthrough (both directions, anchored in plan.js source)', () => {
+  let src;
+  beforeAll(() => {
+    src = read('../../lib/sd-creation/source-adapters/plan.js');
+  });
+
+  it('dependencies set ONLY when normalized list is non-empty (flag-absent payload byte-identical)', () => {
+    const idx = src.indexOf('overrides.dependsOn');
+    expect(idx).toBeGreaterThan(0);
+    const w = src.slice(idx - 200, idx + 500);
+    expect(w).toMatch(/normalizeDependsOn\(overrides\.dependsOn\)/);
+    expect(w).toMatch(/deps\.length\s*>\s*0/);
+    expect(w).toMatch(/createOptions\.dependencies\s*=\s*deps/);
+  });
+
+  it('roadmap_link_reason set only for non-blank strings, mirroring the direct lane', () => {
+    const idx = src.indexOf('overrides.roadmapLinkReason');
+    expect(idx).toBeGreaterThan(0);
+    const w = src.slice(idx - 100, idx + 400);
+    expect(w).toMatch(/typeof overrides\.roadmapLinkReason === 'string'/);
+    expect(w).toMatch(/createOptions\.roadmap_link_reason\s*=\s*overrides\.roadmapLinkReason/);
+  });
+
+  it('imports the canonical normalizeDependsOn (no local copy)', () => {
+    expect(src).toMatch(/import \{ normalizeDependsOn \} from '\.\.\/\.\.\/\.\.\/scripts\/modules\/leo-create-sd\/proposal-lanes\.js'/);
+    expect(src).not.toMatch(/function\s+normalizeDependsOn/);
+  });
+});

--- a/tests/unit/leo-create-sd-plan-flags.test.js
+++ b/tests/unit/leo-create-sd-plan-flags.test.js
@@ -47,6 +47,14 @@ describe('FR-3: one canonical normalizeDependsOn', () => {
       .toEqual([{ sd_id: 'SD-OK' }]);
   });
 
+  it('blank sd_id falls through to sd_key — the || semantics the ?? hardening silently broke (PR #6935 WARNING)', () => {
+    // {sd_id:'', sd_key:'SD-OK'} fenced the SD before the hardening; a ?? fallback dropped
+    // it (born claimable, fail-open). The fallback must survive blank AND non-string sd_id.
+    expect(fromChild([{ sd_id: '', sd_key: 'SD-OK' }])).toEqual([{ sd_id: 'SD-OK' }]);
+    expect(fromChild([{ sd_id: 42, sd_key: 'SD-ALSO' }])).toEqual([{ sd_id: 'SD-ALSO' }]);
+    expect(fromChild([{ sd_id: '', sd_key: 42 }])).toEqual([]);
+  });
+
   it('exactly one definition exists across the creation lanes (child.js only re-exports)', () => {
     const childSrc = read('../../lib/sd-creation/source-adapters/child.js');
     expect(childSrc).not.toMatch(/function\s+normalizeDependsOn/);


### PR DESCRIPTION
## Summary
- **--depends-on on --from-plan**: comma-split SD keys land in the top-level `dependencies` JSONB (the only home every consumer honors) in the SAME createSD INSERT — born-fenced, no post-insert window. Registered in BOTH `knownPlanFlags` AND `flagValuePositions` (only the latter is reachable for flag values; a miss silently absorbs the value as planPath).
- **--roadmap-link-reason**: feeds `buildRoadmapLinkException`'s `operatorReason` — the `reason_supplied=false` drive-to-zero counter finally has a supply conduit at the highest-volume creation path.
- **One canonical normalizeDependsOn**: child.js's strings-only copy deleted; all lanes share the proposal-lanes superset (reference-identity test makes re-divergence impossible). Hardened: malformed object entries drop per the documented fail-soft contract instead of throwing — and the drop announces itself loudly, because a silently dropped dep means an SD born UNFENCED on that edge.
- **Sibling links (leg c of the SD title) DESCOPED, measured reason**: `metadata.sibling_sds` has ZERO readers (a write-only field is functionally identical to no field), and `metadata.related_sds` carries a live orchestrator-classification side effect (orchestrator-preflight.js:164-172 adds +20 confidence per related SD) that would silently nudge plain plan-created SDs toward orchestrator classification. If wanted later, it needs its own SD registering a side-effect-free consumer in the same PR.

## Test plan
- [x] 45/45 across 4 suites + 21/21 pre-existing consumers (capture-equivalence, child-born-fenced)
- [x] 4 mutations killed (flagValuePositions removal, split removal, length-guard removal, child re-divergence)
- [x] Evidence: TESTING dc702fea (PASS), SECURITY f54bdc8e (PASS 92, 0 crit/high/med), VALIDATION a60c3f51, REGRESSION a0266b0d (condition closed in 9fc027f55e7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)