### PR TITLE
fix: dashboard crash on null sd_key stale row (1-line guard)

### DIFF
--- a/scripts/fleet-dashboard.cjs
+++ b/scripts/fleet-dashboard.cjs
@@ -638,7 +638,10 @@ function printWorkers(d) {
     console.log('');
     console.log('  Stale (' + d.staleSessions.length + '):');
     for (const s of d.staleSessions) {
-      const shortSd = s.sd_key.replace('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-', '').replace(/^SD-.*-/, '');
+      // sd_key can be null on a stale row (claim released / QF-holder mirror — the sd_key
+      // column is only a MIRROR, per SILENT-HOLDER-AUDIT-001); an unguarded .replace crashed
+      // the whole dashboard (harness bug b7839fd7).
+      const shortSd = (s.sd_key || '').replace('SD-LEO-ORCH-STAGE-VENTURE-WORKFLOW-001-', '').replace(/^SD-.*-/, '');
       console.log('  ' + pad(s.tty, 12) + pad(shortSd, 10) + s.heartbeat_age_human);
     }
   }


### PR DESCRIPTION
Every dashboard run has exited `DASHBOARD ERROR: Cannot read properties of null (reading 'replace')` since the SILENT-HOLDER-AUDIT-001 merge surfaced stale rows with `sd_key=null` (released claims / QF-holder mirror rows). The stale-session renderer at `printWorkers` called `s.sd_key.replace(...)` unguarded.

**Fix:** `(s.sd_key || '')` guard + provenance comment. Verified at the consumer: full dashboard render including the `Stale (1)` section that previously crashed.

Coordinator instrument-restoration (Tier-1, harness bug b7839fd7, dispatched-then-self-taken after ~50min dark).

🤖 Generated with [Claude Code](https://claude.com/claude-code)