### PR TITLE
feat(SD-LEO-INFRA-COMPLETE-SMS-RELAY-001): exactly-once SMS drain claim + provisioning pin + go-live runbook

### DIFF
--- a/docs/runbooks/sms-relay-drain-go-live.md
+++ b/docs/runbooks/sms-relay-drain-go-live.md
@@ -1,0 +1,78 @@
+# SMS Relay Drain — Go-Live Runbook
+
+**Category**: Runbook
+**Status**: Approved
+**Version**: 1.0.0
+**Author**: SD-LEO-INFRA-COMPLETE-SMS-RELAY-001 (Alpha-4)
+**Last Updated**: 2026-08-10
+**Tags**: chairman-comms, sms, drain, go-live, cutover
+
+---
+
+## What this is
+
+The chairman SMS relay drain (`scripts/sms-relay-drain.cjs` → `drainSmsRelayStaging` in
+`lib/chairman/sms-bridge.js`) moves inbound chairman SMS replies out of `sms_relay_staging`
+into `chairman_decisions`, and the Adam quiet-tick surfaces an undrained reply as a **hard
+interrupt** (`QUIET_TICK_SMS_INBOUND`) so the chairman is answered within one tick.
+
+The whole path is **inert until `SMS_RELAY_DRAIN_ENABLED` is truthy**. Flipping it is a
+**production go-live of a chairman-facing channel** — that GO belongs to the chairman, routed
+via Adam as a labeled decision (the coordinator hands Adam the decision text once the FR-1
+exactly-once fix has merged). This runbook is the exact, ordered procedure for whoever performs
+the flip. **Completing SD-LEO-INFRA-COMPLETE-SMS-RELAY-001 does NOT make the channel live** —
+it makes the cutover *safe and performable*; this document is the remaining human step.
+
+## Precondition (must already be true)
+
+- **FR-1 exactly-once drain claim is merged.** `drainSmsRelayStaging` claims each staging row
+  with an atomic conditional UPDATE (`SET drained_at = now() WHERE id = ? AND drained_at IS NULL`)
+  and processes only the row it claimed. This makes the drain exactly-once even when the 5-min
+  cron and an Adam-tick-triggered manual drain run concurrently — without it, a re-drained row
+  could double-increment the FR-4 unmatched auto-suspend counter against the chairman's number.
+  (A double *reply* was already prevented one layer down by the decision-level atomic claim in
+  `handleInboundSmsReply`; FR-1 closes the residual side-effect double-count.)
+- Inbound chairman SMS is landing in `sms_relay_staging` (the Twilio webhook is cut over). Verify
+  with a recent `received_at` row before flipping.
+
+## Go-live steps (in order)
+
+1. **Set the GitHub repo variable** `SMS_RELAY_DRAIN_ENABLED = true`.
+   - Repo → Settings → Secrets and variables → Actions → Variables → `SMS_RELAY_DRAIN_ENABLED`.
+   - This is what `.github/workflows/sms-relay-drain-cron.yml` reads (`vars.SMS_RELAY_DRAIN_ENABLED`);
+     it arms the every-5-minutes cron drainer. The cron is `concurrency`-guarded, so it never
+     races itself — and with FR-1 it is safe even racing a manual seat drain.
+
+2. **Set the seat env on the designated drain seat(s)** — add `SMS_RELAY_DRAIN_ENABLED=true` to the
+   root `.env` of the seat that runs the Adam quiet-tick.
+   - New worktrees created by that seat inherit it automatically (the worktree provisioning path
+     copies `.env` verbatim — FR-2). **Existing worktrees do not** — they hold a `.env` snapshot
+     taken at creation, so either re-provision them or set the variable in their environment
+     directly if a live worktree must drain before its next re-creation.
+   - This is what flips the quiet-tick emission from `QUIET_TICK_SMS_SUPPRESSED` (informational,
+     not an interrupt) to `QUIET_TICK_SMS_INBOUND` (the hard interrupt that tells Adam to drain +
+     reply). The emission gate and the interrupt allowlist are already wired — setting the value
+     is the only action.
+
+3. **Canary (immediately after the flip).** Stage one inbound row (or wait for a real chairman
+   reply) and confirm:
+   - The next Adam quiet-tick prints `QUIET_TICK_SMS_INBOUND` (not `QUIET_TICK_SMS_SUPPRESSED`).
+   - A drain run stamps `drained_at` on the row **exactly once** and the reply lands in
+     `chairman_decisions` (or the correct non-answer outcome is logged once, e.g. `no_match`).
+   - `sms_relay_staging` has no growing undrained backlog (the drain's `checkBacklogStall`
+     signal stays quiet).
+
+## Rollback
+
+Set `SMS_RELAY_DRAIN_ENABLED` back to unset/`false` (repo variable + seat env). The runner and
+the quiet-tick emission return to inert/informational immediately; no data migration is involved.
+The FR-1 atomic claim and the provisioning path are behaviour-neutral while the flag is off, so
+they stay in place.
+
+## Why the flip is not an SD deliverable
+
+Per coordinator ruling 31b25783 (Option A): the flip is a chairman-facing production go-live and
+must be a labeled chairman decision routed via Adam, not a worker action. Wording the SD's
+completion as "channel live" would claim a live channel that is fenced on a pending chairman GO —
+the exact completed-while-inert class this project guards against (see VENTURE-DEMAND). Completion
+asserts only that this runbook exists and the cutover is performable.

--- a/lib/chairman/sms-bridge.js
+++ b/lib/chairman/sms-bridge.js
@@ -786,11 +786,23 @@ export async function consumeSmsReply(supabase, decisionId, { perDecisionCap = P
 /**
  * Drain undrained rows from sms_relay_staging (written by the untrusted public relay,
  * SD-LEO-FEAT-SMS-INBOUND-RELAY-001 FR-1/FR-2) through handleInboundSmsReply, marking
- * each row drained_at regardless of outcome so it is never reprocessed. Rows are
- * processed oldest-first and sequentially — concurrency across rows is unnecessary
- * (the single-use claim inside handleInboundSmsReply already serializes correctly per
- * decision) and sequential draining keeps the ambiguity check's candidate snapshot
- * consistent within one drain pass.
+ * each row drained_at so it is never reprocessed. Rows are processed oldest-first.
+ *
+ * EXACTLY-ONCE UNDER CONCURRENCY (SD-LEO-INFRA-COMPLETE-SMS-RELAY-001 FR-1). The prior
+ * shape SELECTed drained_at IS NULL then per-row UPDATEd drained_at — a TOCTOU: the 5-min
+ * cron and an Adam-tick-triggered manual drain (both invoke this fn) could each select the
+ * same undrained row and each call handleInboundSmsReply. A double CHAIRMAN REPLY is already
+ * prevented one layer down — the answer path claims the decision atomically
+ * (UPDATE chairman_decisions ... WHERE sms_reply_used_at IS NULL; the loser returns no_match
+ * and delivers nothing, verified at handleInboundSmsReply). What double-processing STILL did
+ * was run the second call's side-effects with no per-row guard: logInboundUnmatched and the
+ * inbound rate/auto-suspend counters, so a re-drained already-answered row could spuriously
+ * increment the FR-4 unmatched counter toward auto-suspending the chairman's number, plus
+ * wasted work. This makes the drain exactly-once at the staging layer too: CLAIM each row
+ * with a conditional UPDATE (SET drained_at WHERE id=? AND drained_at IS NULL) and process
+ * ONLY the row this invocation actually claimed — a concurrent drainer that already claimed
+ * it gets zero rows back and skips it, so handleInboundSmsReply runs at most once per row
+ * regardless of how many drainers race. No new schema: drained_at is the claim.
  *
  * @param {import('@supabase/supabase-js').SupabaseClient} supabase
  * @param {{limit?: number}} [opts]
@@ -806,18 +818,49 @@ export async function drainSmsRelayStaging(supabase, { limit = 50 } = {}) {
 
   const results = [];
   for (const row of rows || []) {
-    const outcome = await handleInboundSmsReply(supabase, {
-      from: row.from_phone,
-      to: row.to_phone,
-      body: row.body_raw,
-      messageSid: row.provider_message_id,
-      signatureValid: row.signature_valid,
-    });
-    await supabase
+    // FR-1: atomically CLAIM the row before doing any work. The conditional UPDATE succeeds
+    // for exactly one racing drainer; the WHERE drained_at IS NULL makes a second claim a
+    // no-op (returns zero rows). Claim FIRST, then process — so a lost claim never reaches
+    // handleInboundSmsReply and never touches its counters.
+    const claimedAt = new Date().toISOString();
+    const { data: claimed } = await supabase
       .from('sms_relay_staging')
-      .update({ drained_at: new Date().toISOString() })
-      .eq('id', row.id);
-    results.push({ id: row.id, outcome: outcome.outcome });
+      .update({ drained_at: claimedAt })
+      .eq('id', row.id)
+      .is('drained_at', null)
+      .select('id');
+
+    if (!claimed || claimed.length === 0) {
+      // A concurrent drainer claimed this row first — skip it, do not double-process.
+      continue;
+    }
+
+    try {
+      const outcome = await handleInboundSmsReply(supabase, {
+        from: row.from_phone,
+        to: row.to_phone,
+        body: row.body_raw,
+        messageSid: row.provider_message_id,
+        signatureValid: row.signature_valid,
+      });
+      results.push({ id: row.id, outcome: outcome.outcome });
+    } catch (e) {
+      // RELEASE the claim on a GENUINE processing error so the next tick retries — the same
+      // claim-then-roll-back-on-failure shape consumeSmsReply uses for over-cap debits. Without
+      // this, claim-first would turn a transient DB error into a permanently-lost chairman reply
+      // (drained_at set, never processed). Exactly-once for the concurrency case is preserved;
+      // at-least-once is restored for real errors. Best-effort release (fail-soft): if the
+      // release itself fails, the runner's fail-soft catch still exits 0 and the backlog-stall
+      // signal is the durable alarm. try/catch (not .catch on the builder — the supabase query
+      // builder is a thenable without a guaranteed .catch method).
+      try {
+        await supabase
+          .from('sms_relay_staging')
+          .update({ drained_at: null })
+          .eq('id', row.id);
+      } catch { /* best-effort release; runner fail-soft + backlog-stall are the durable alarms */ }
+      throw e;
+    }
   }
 
   return { drained: results.length, results };

--- a/tests/unit/chairman/sms-bridge.test.js
+++ b/tests/unit/chairman/sms-bridge.test.js
@@ -400,4 +400,53 @@ describe('drainSmsRelayStaging', () => {
     const result = await drainSmsRelayStaging(sb);
     expect(result.drained).toBe(0);
   });
+
+  // SD-LEO-INFRA-COMPLETE-SMS-RELAY-001 FR-1: exactly-once under concurrency. The fake's awaits
+  // yield to the microtask queue, so two drains launched together genuinely interleave at each
+  // await — the same TOCTOU window the 5-min cron and an Adam-tick manual drain hit in production.
+  // The atomic claim (UPDATE ... WHERE drained_at IS NULL) must let each row be processed by
+  // exactly one drainer. Observable proof: each processed row writes exactly one sms_inbound_log
+  // entry, so N staged rows → N log entries total across BOTH drains (not 2N).
+  it('two concurrent drains process each row exactly once (no double side-effects)', async () => {
+    const staging = [];
+    for (let i = 0; i < 5; i += 1) {
+      staging.push({
+        id: `stg-cc-${i}`, provider_message_id: `SM-cc-${i}`, from_phone: '+15550000009',
+        to_phone: '+15559999999', body_raw: `no candidate ${i}`, signature_valid: true,
+        received_at: new Date(Date.now() - (5 - i) * 1000).toISOString(), drained_at: null,
+      });
+    }
+    const sb = makeFakeSupabase({ sms_relay_staging: staging });
+
+    const [a, b] = await Promise.all([drainSmsRelayStaging(sb), drainSmsRelayStaging(sb)]);
+
+    // Every row claimed and processed exactly once, split across the two racing drains.
+    expect(a.drained + b.drained).toBe(5);
+    // Exactly one side-effect (inbound log entry) per row — the double-count FR-1 prevents.
+    expect(sb._tables.sms_inbound_log.length).toBe(5);
+    // Every staging row ends up claimed.
+    expect(sb._tables.sms_relay_staging.every((r) => r.drained_at)).toBe(true);
+  });
+
+  it('releases the claim (drained_at -> null) when handleInboundSmsReply throws, so the next tick retries', async () => {
+    const sb = makeFakeSupabase({
+      sms_relay_staging: [
+        { id: 'stg-throw', provider_message_id: 'SM-throw', from_phone: '+15551112222', to_phone: '+15559999999', body_raw: 'x', signature_valid: true, received_at: new Date().toISOString(), drained_at: null },
+      ],
+    });
+    // Force a throw on the FIRST post-claim read handleInboundSmsReply makes (sms_inbound_log
+    // count / notifications lookup). Make chairman_notifications.select throw once.
+    const realFrom = sb.from.bind(sb);
+    let thrown = false;
+    sb.from = (table) => {
+      if (table === 'sms_inbound_log' && !thrown) {
+        thrown = true;
+        return { select: () => { throw new Error('transient DB error'); } };
+      }
+      return realFrom(table);
+    };
+    await expect(drainSmsRelayStaging(sb)).rejects.toThrow(/transient DB error/);
+    // The claim was rolled back so the row is retryable, not lost.
+    expect(sb._tables.sms_relay_staging.find((r) => r.id === 'stg-throw').drained_at).toBe(null);
+  });
 });

--- a/tests/unit/sms-relay-provisioning-and-emission.test.js
+++ b/tests/unit/sms-relay-provisioning-and-emission.test.js
@@ -1,0 +1,64 @@
+// SD-LEO-INFRA-COMPLETE-SMS-RELAY-001 FR-2 + FR-4.
+//
+// FR-2: the worktree .env provisioning path forwards SMS_RELAY_DRAIN_ENABLED so that once an
+// operator sets it on the designated drain seat, that seat's NEW worktrees inherit it. Measured:
+// ensureWorktreeEssentials copies .env VERBATIM (whole-file copyFileSync, no key filter), so the
+// flag is forwarded by construction — this test PINS that behaviour (a future key-filtering
+// "optimization" that dropped the flag would silently re-inert the interrupt on worktree seats).
+//
+// FR-4: the SUPPRESSED->INBOUND emission flip and the interrupt allowlist are ALREADY wired
+// (env-gated in adam-quiet-tick, QUIET_TICK_SMS_INBOUND on the allowlist). This pins that so
+// nobody re-implements the flip and so the go-live runbook's canary assumption stays true.
+
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { ensureWorktreeEssentials } from '../../scripts/resolve-sd-workdir.js';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const read = (p) => fs.readFileSync(path.join(here, '../../', p), 'utf8');
+
+describe('FR-2: worktree .env provisioning forwards SMS_RELAY_DRAIN_ENABLED', () => {
+  it('copies the flag verbatim from repo-root .env into a fresh worktree .env', () => {
+    const base = fs.mkdtempSync(path.join(os.tmpdir(), 'sms-relay-prov-'));
+    const repoRoot = path.join(base, 'root');
+    const worktree = path.join(base, 'wt');
+    fs.mkdirSync(repoRoot, { recursive: true });
+    fs.mkdirSync(worktree, { recursive: true });
+    // A root .env that a drain-enabled seat would carry.
+    fs.writeFileSync(path.join(repoRoot, '.env'), 'FOO=bar\nSMS_RELAY_DRAIN_ENABLED=true\nBAZ=qux\n');
+
+    try {
+      ensureWorktreeEssentials(worktree, repoRoot, { activeSessionCount: 1 });
+      const wtEnv = fs.readFileSync(path.join(worktree, '.env'), 'utf8');
+      // The whole file rode across, flag included.
+      expect(wtEnv).toContain('SMS_RELAY_DRAIN_ENABLED=true');
+      expect(wtEnv).toContain('FOO=bar');
+    } finally {
+      fs.rmSync(base, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('FR-4: the emission flip + interrupt allowlist are already wired (pin, not new code)', () => {
+  const tick = read('scripts/adam-quiet-tick.mjs');
+  const startup = read('scripts/adam-startup-check.mjs');
+
+  it('quiet-tick gates SUPPRESSED vs INBOUND on SMS_RELAY_DRAIN_ENABLED', () => {
+    // The env-gate variable is derived from SMS_RELAY_DRAIN_ENABLED, and both tokens exist.
+    expect(tick).toMatch(/SMS_RELAY_DRAIN_ENABLED/);
+    expect(tick).toContain('QUIET_TICK_SMS_SUPPRESSED');
+    expect(tick).toContain('QUIET_TICK_SMS_INBOUND');
+    // The suppressed branch is the flag-OFF path; the inbound token is the flag-ON path.
+    const gateIdx = tick.indexOf('smsDrainEnabled');
+    expect(gateIdx).toBeGreaterThan(-1);
+  });
+
+  it('QUIET_TICK_SMS_INBOUND is on the interrupt allowlist; SUPPRESSED is deliberately not', () => {
+    expect(startup).toContain('QUIET_TICK_SMS_INBOUND');
+    // The allowlist prose explicitly keeps SUPPRESSED off the hard-interrupt set.
+    expect(startup).toMatch(/QUIET_TICK_SMS_SUPPRESSED[\s\S]{0,400}?(INFORMATIONAL|do not add|not a hard interrupt)/i);
+  });
+});


### PR DESCRIPTION
Coordinator ruling 31b25783 (Option A): FR-1 lands first; the flag flip is a chairman go-live routed via Adam, **not** an SD deliverable. Completion asserts code+provisioning+runbook present, **not** channel-live (VENTURE-DEMAND completed-while-inert avoidance).

## FR-1 — exactly-once drain (safety-critical)
`drainSmsRelayStaging` claimed rows via SELECT-then-update (TOCTOU: cron vs Adam-manual drain). Verified at the def-site that a double **chairman reply** was already prevented downstream (`handleInboundSmsReply` atomically claims the decision at `sms-bridge.js:673` — loser returns `no_match`, delivers nothing). The residual this closes: the second call's un-guarded side-effects (unmatched/rate/auto-suspend counters) counting against the chairman's number. Now: atomic per-row claim (`UPDATE ... WHERE id=? AND drained_at IS NULL`), process only the claimed row; **release the claim on a genuine throw** so a transient error retries.

## FR-2 — provisioning pin
Worktree `.env` copy (`ensureWorktreeEssentials`) is verbatim whole-file, so `SMS_RELAY_DRAIN_ENABLED` rides to new worktrees by construction; test guards against a future key-filter dropping it.

## FR-3 — go-live runbook
`docs/runbooks/sms-relay-drain-go-live.md`: ordered operator cutover (repo var + seat env + canary + rollback), labeling the flip a chairman GO via Adam.

## FR-4 — emission pin
Pins the already-wired SUPPRESSED→INBOUND env gate + interrupt allowlist.

## Test plan
- [x] 32 SMS tests green incl. two concurrent drains → each row once (5 rows → 5 log entries, not 10), claim-release-on-throw, provisioning forward, emission/allowlist pins
- [x] Plain-node import verified
- [x] I corrected an over-stated harm in my own escalation (double-reply → side-effect double-count) before building — signaled to coordinator

🤖 Generated with [Claude Code](https://claude.com/claude-code)