### PR TITLE
fix(SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001): forecaster belt spans the dispatchable-leaf extent, not raw-unclaimed

### DIFF
--- a/lib/fleet/claim-eligibility.cjs
+++ b/lib/fleet/claim-eligibility.cjs
@@ -522,6 +522,22 @@ const PRE_LEAD_PASS_PHASES = new Set(['LEAD', 'LEAD_APPROVAL']);
  * caller composes this with the other eligibility axes.
  * @returns {Promise<boolean>} true when the child is blocked by a parent that has not yet passed LEAD.
  */
+/**
+ * The PURE parent-LEAD-pending verdict over an already-resolved parent row. Shared so the async
+ * DB path (parentLeadPending) and an in-memory caller that already holds the parent row (the
+ * capacity forecaster, SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001 — it fetches every non-terminal
+ * row and resolves the parent from that set, avoiding a per-child DB round-trip) apply the SAME
+ * phase logic. A null/absent parent (terminal, or not in the caller's set) is NOT pending — the
+ * child is workable (fail-open, mirrors the async version's error/!data branch).
+ * @param {{status?: string, current_phase?: string}|null|undefined} parentRow
+ * @returns {boolean} true when the parent has not yet passed LEAD (child not yet dispatchable)
+ */
+function parentLeadPendingVerdict(parentRow) {
+  if (!parentRow) return false;                                  // absent/terminal -> not pending
+  if (parentRow.status === 'completed') return false;            // parent done -> children fully workable
+  return PRE_LEAD_PASS_PHASES.has(String(parentRow.current_phase || '').toUpperCase());
+}
+
 async function parentLeadPending(sb, sd) {
   const parentRef = sd && sd.parent_sd_id;
   if (!parentRef) return false;                                  // not an orchestrator child
@@ -532,8 +548,7 @@ async function parentLeadPending(sb, sd) {
       .or(`id.eq.${parentRef},sd_key.eq.${parentRef}`)           // parent_sd_id references the parent id (== sd_key here)
       .maybeSingle();
     if (error || !data) return false;                            // fail-open: can't confirm -> don't strand the child
-    if (data.status === 'completed') return false;               // parent done -> children fully workable
-    return PRE_LEAD_PASS_PHASES.has(String(data.current_phase || '').toUpperCase());
+    return parentLeadPendingVerdict(data);
   } catch {
     return false;                                                // fail-open
   }
@@ -821,4 +836,4 @@ async function liveClaimWriteFenceReason(sb, sdKey, claimantSessionId = null, li
 Object.freeze(INELIGIBILITY_AXES);
 const INELIGIBILITY_AXIS_NAMES = Object.freeze(INELIGIBILITY_AXES.map((fn) => fn.name).filter(Boolean));
 
-module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, classifyAllDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, parentLeadPending, TEST_FIXTURE_KEY_RE, resolveHoldProvenance, formatHoldProvenance, isDispatchAuthorized, liveClaimWriteFenceReason, CLAIM_WRITE_FENCE_AXES, execBoundaryHoldReason, isLeadBlockerActive, INELIGIBILITY_AXIS_NAMES };
+module.exports = { draftDepsSatisfied, evaluateDispatchEligibility, baselinedCandidateEligible, classifyDispatchIneligibility, classifyAllDispatchIneligibility, coordinatorReservation, isSeatBusyOnDirectedWork, parentLeadPending, parentLeadPendingVerdict, TEST_FIXTURE_KEY_RE, resolveHoldProvenance, formatHoldProvenance, isDispatchAuthorized, liveClaimWriteFenceReason, CLAIM_WRITE_FENCE_AXES, execBoundaryHoldReason, isLeadBlockerActive, INELIGIBILITY_AXIS_NAMES };

--- a/scripts/coordinator-backlog-rank.mjs
+++ b/scripts/coordinator-backlog-rank.mjs
@@ -33,73 +33,26 @@ import { guardMutation, resolveOwnSessionId } from '../lib/coordinator-mutation-
 // demotes bare-shell stubs. FIXTURE_RE catches epoch-stamped TEST-E2E keys; the
 // bare-shell demotion uses the shared bareShellLastCompare so the test suite
 // exercises the real comparator, not a re-implementation.
-import { isFixtureSd, isBareShell, bareShellLastCompare, isStartedSd, stripDispatchRank, isUnactionableRemediationSd } from '../lib/coordinator/sd-exclusion.mjs';
-// SD-LEO-INFRA-FORECASTER-DEP-SENTINEL-BELTDEPTH-001: resolve dependency keys via the canonical
-// blocker rule (the same SSOT coordinator-audit.mjs imports) so the ranker and the capacity
-// forecaster AGREE on the 'no dependencies' sentinel ({sd_key:'none'} / bare 'none') and on
-// free-text non-SD placeholders. parseSdDependencies returns ONLY real /^SD-/ blocker keys —
-// handling both the [{sd_id}]/[{sd_key}] object and raw-string shapes the old hand-rolled
-// resolver coerced, while correctly dropping the sentinel the hand-rolled one mis-counted.
-import { parseSdDependencies } from '../lib/utils/parse-sd-dependencies.cjs';
+// SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001: isFixtureSd / isStartedSd / isUnactionableRemediationSd /
+// parseSdDependencies / parentLeadPending / classifyDispatchIneligibility / resolveHoldProvenance /
+// formatHoldProvenance / checkMetadataDependency moved with the leaf SSOT into claimable-leaves.mjs;
+// only the ranker-specific classifiers remain imported here.
+import { isBareShell, bareShellLastCompare, stripDispatchRank } from '../lib/coordinator/sd-exclusion.mjs';
 import { resolveCanonicalWaveIds } from '../lib/roadmap/canonical-roadmap.js';
 // SD-LEO-INFRA-ADAM-WORK-SELECTION-001 FR-2/FR-3: ONE roadmap-marker predicate, imported rather
 // than re-declared. A hardcoded copy here had already drifted from the reader's list by 326 SDs.
 import { isPlanLinked } from '../lib/adam/work-selection-gate.js';
-// SD-REFILL-00MFWEGZ: reuse the canonical parent-LEAD-pass dispatch gate so the ranking surface
-// mirrors what claim-eligibility actually blocks (no drift between rank-vs-claim).
-import { parentLeadPending, classifyDispatchIneligibility, resolveHoldProvenance, formatHoldProvenance } from '../lib/fleet/claim-eligibility.cjs';
-// SD-REFILL-00AH2L4Q: honor the SAME canonical metadata blocker key (metadata.blocked_by_sd_key)
-// that dependency-resolver + worker-checkin enforce, so the dispatch ranker does not keep a
-// metadata-blocked SD on the claimable belt (the convention was inconsistently enforced fleet-wide).
-import { checkMetadataDependency } from './modules/sd-next/dependency-resolver.js';
-// SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 9 — computeClaimableLeaves is the SSOT
-// claimable-SD computation that worker-checkin's dispatch_rank consumer relies on; a capped read
-// here would silently make some non-terminal SDs unrankable/unclaimable. strategic_directives_v2
-// is the flagship growing table.
+// SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 9 — the terminal-ranked cleanup read below
+// must not be capped; strategic_directives_v2 is the flagship growing table.
 import { fetchAllPaginated } from '../lib/db/fetch-all-paginated.mjs';
 
-// Collect every blocker sd_key for an SD: the `dependencies` column PLUS the canonical
-// metadata.blocked_by_sd_key. ONE predicate, shared by depKeys collection and the unmet check.
-export function blockerKeysFor(d) {
-  const keys = parseSdDependencies(d.dependencies);
-  const { blockerSdKey } = checkMetadataDependency(d.metadata);
-  if (blockerSdKey) keys.push(blockerSdKey);
-  return keys;
-}
-
-/**
- * SD-LEO-INFRA-BACKLOG-RANK-CLAIMABLE-ELIGIBILITY-ALIGN-001: the DB-FREE claimable gate for the ranker,
- * composed so the ranked belt matches the actually-claimable set the worker resolver enforces. Returns
- * null when the SD passes every DB-free claimable axis, or a reason string when it must be excluded:
- *   - 'claimed'  — a live session already holds it (claiming_session_id set)
- *   - 'in_flight' — started/mid-build past LEAD draft (resumed via resume_orphan, never fresh-ranked)
- *   - 'fixture'  — backlog-rank's BROADER fixture detection (epoch TEST-E2E keys / metadata.is_fixture)
- *   - else the SHARED claim-eligibility reason: 'orchestrator_parent' | 'human_action_required' |
- *     'co_author_pending' | 'sd_deferred' | 'sd_terminal' | 'test_fixture_key'.
- * The shared predicate (classifyDispatchIneligibility) is the SSOT — re-implementing it is exactly how
- * the requires_human_action skip drifted out of the ranker. Pure; the DB-backed axes (dependency/metadata
- * blockers, parent-LEAD-pending) remain in the async claim loop. Exported for unit testing.
- * @param {object} d - an SD row (sd_key, sd_type, status, current_phase, claiming_session_id, metadata)
- * @returns {null|string}
- */
-export function claimableDbFreeReason(d) {
-  if (!d) return 'missing';
-  if (d.claiming_session_id) return 'claimed';
-  if (isStartedSd(d)) return 'in_flight';
-  if (isFixtureSd(d.sd_key, d.metadata)) return 'fixture';
-  // SD-FDBK-INFRA-RANKER-FORECAST-EXCLUSION-PARITY-001: an un-actionable auto-filed venture-remediation
-  // SD (SD-LEO-FIX-REMEDIATION-* targeting a venture repo, not EHG_Engineer) cannot be actioned by any
-  // fleet worker, so it must not earn a real dispatch_rank. The capacity-forecaster already excludes
-  // these from belt depth via isExcludedFromBelt -> isUnactionableRemediationSd; the ranker previously
-  // demoted ONLY bare-shell stubs (isBareShell), so a ~345-char remediation stub slipped through and
-  // even outranked a real walk-blocker. Calling the SAME shared predicate here makes the two belts agree
-  // by construction (SSOT, can't diverge). NOTE: FR-1 described a 'generated_by fr-c' criterion, but the
-  // forecaster's actual detector is this key-prefix+target predicate — parity (FR-4) requires the SAME
-  // predicate in both paths, so we reuse the existing SSOT rather than introduce a divergent new one
-  // (spec-conflict signaled 2cde0ce8).
-  if (isUnactionableRemediationSd(d)) return 'unactionable_venture_remediation';
-  return classifyDispatchIneligibility(d); // null => eligible on the DB-free axes
-}
+// SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001: the claimable-leaf SSOT moved to the client-free
+// scripts/lib/claimable-leaves.mjs so the capacity forecaster can reuse the SAME predicates without
+// importing this file's module-scope Supabase client. Imported locally (this file's body still calls
+// blockerKeysFor + computeClaimableLeaves) AND re-exported so every existing importer of these three
+// keeps resolving from this path unchanged (barrel — a bare `export … from` would not bind them here).
+import { blockerKeysFor, claimableDbFreeReason, computeClaimableLeaves } from './lib/claimable-leaves.mjs';
+export { blockerKeysFor, claimableDbFreeReason, computeClaimableLeaves };
 // SD-LEO-INFRA-FLEET-CRITICAL-DISPATCH-LANE-001 (FR-1): the narrow, explicit fleet-critical predicate.
 // metadata.fleet_critical===true marks work whose ABSENCE blocks ALL fleet progress. Exported pure so
 // the band ordering is unit-testable. STRICT === true so a stray truthy value can't silently enrol.
@@ -243,131 +196,6 @@ const sb = createClient(
   process.env.SUPABASE_SERVICE_ROLE_KEY,
 );
 
-/**
- * SD-LEO-INFRA-GUARANTEE-CLAIMABLE-SD-RANKED-001-D (FR-4): the claimable-leaf computation, extracted
- * out of main() so the eligible-but-unranked-leaf-count gauge (scripts/gauge-unranked-claimable-leaves.mjs)
- * reuses the SAME claimable set the ranker itself acts on — never a second re-derivation that could drift
- * from what the ranker (and therefore worker-checkin) actually considers claimable. main() below is
- * byte-identical in behavior; it now calls this function instead of inlining the fetch+filter.
- * @param {object} sb - supabase service-role client
- * @param {{ quiet?: boolean }} [opts] - QF-20260704-051: quiet=true silences the per-skip
- *   console.log lines below (still counts them) — for callers like fleet-dashboard.cjs that
- *   poll this on every render and must not spam stdout with ranker skip-reason logging.
- * @returns {Promise<{ error?: object, sds: object[], byKey: Map, depStatus: object, claimable: object[], humanActionHolds: Array<{sd_key: string, provenance: object|null}> }>}
- */
-export async function computeClaimableLeaves(sb, opts = {}) {
-  const log = opts.quiet ? () => {} : console.log;
-  let sds;
-  try {
-    sds = await fetchAllPaginated(() => sb.from('strategic_directives_v2')
-      // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: + title, description to classify bare-shell stubs.
-      // SD-FDBK-INFRA-SHARED-FLEET-WORKER-001: + current_phase for the in-flight (started) guard.
-      // SD-REFILL-00MFWEGZ: + parent_sd_id so parentLeadPending can exclude an orchestrator child
-      // whose parent has not yet passed LEAD (else the field is undefined → the gate silently no-ops).
-      .select('sd_key, title, description, status, sd_type, priority, created_at, current_phase, claiming_session_id, dependencies, metadata, parent_sd_id')
-      .not('status', 'in', '("completed","cancelled","deferred")')
-      .order('sd_key', { ascending: true }));
-  } catch (error) {
-    console.error('[BACKLOG-RANK] load failed:', error.message);
-    return { error, sds: [], byKey: new Map(), depStatus: {}, claimable: [], humanActionHolds: [] };
-  }
-
-  // ── dependency graph: edges dep -> dependents (over non-terminal set + completed deps resolved) ──
-  const byKey = new Map((sds || []).map(d => [d.sd_key, d]));
-  const depKeys = new Set();
-  (sds || []).forEach(d => blockerKeysFor(d).forEach(k => depKeys.add(k)));
-  let depStatus = {};
-  if (depKeys.size) {
-    const { data: deps } = await sb.from('strategic_directives_v2').select('sd_key,status').in('sd_key', Array.from(depKeys));
-    (deps || []).forEach(d => { depStatus[d.sd_key] = d.status; });
-  }
-
-  // ── claimable leaves ──
-  const claimable = [];
-  // QF-20260704-193: held SDs with their coalesced provenance, returned so consumers
-  // (fleet-dashboard) can SURFACE hold reasons instead of rendering nothing.
-  const humanActionHolds = [];
-  let fixtureSkips = 0;
-  let inFlightSkips = 0;
-  let awaitingConvergenceSkips = 0;
-  let humanActionSkips = 0;
-  let ineligibleSkips = 0;
-  let depBlockedSkips = 0;
-  for (const d of (sds || [])) {
-    // SD-LEO-INFRA-BACKLOG-RANK-CLAIMABLE-ELIGIBILITY-ALIGN-001: the DB-free claimable axes (claimed /
-    // in-flight / fixture / the SHARED claim-eligibility predicate) are computed by one pure helper so
-    // the ranked belt matches the actually-claimable set the worker resolver enforces. The shared
-    // predicate (classifyDispatchIneligibility) closes the drift that was missing the requires_human_action
-    // skip — RHA-held SDs were leaking onto 'claimable', inflating belt depth and masking genuine
-    // starvation behind a deliberate all-held state.
-    const dbFreeSkip = claimableDbFreeReason(d);
-    if (dbFreeSkip) {
-      switch (dbFreeSkip) {
-        case 'claimed': break;                              // claimed by a live session — silent (not a skip-log)
-        case 'in_flight':
-          inFlightSkips++;
-          log(`  [skip] in-flight (${d.current_phase}) excluded from fresh ranking: ${d.sd_key}`);
-          break;
-        case 'fixture':
-          fixtureSkips++;
-          log(`  [skip] fixture excluded from ranking: ${d.sd_key}`);
-          break;
-        case 'co_author_pending':
-          // NOT idle-belt depth: a co-authored SD awaiting convergence would let a parked worker write
-          // the PRD before the co-author input lands (SD-LEO-INFRA-CO-AUTHOR-CONVERGE-BEFORE-CLAIMABLE-001).
-          awaitingConvergenceSkips++;
-          log(`  [skip] awaiting co-author convergence (not idle-belt depth): ${d.sd_key}`);
-          break;
-        case 'human_action_required': {
-          humanActionSkips++;
-          // QF-20260704-193: the hold reasons already EXIST under ad-hoc metadata keys —
-          // print them so a 3 AM operator can tell deliberate parking from an accidental
-          // freeze without hand-querying metadata (live: 47 rha-frozen sprint children).
-          const prov = resolveHoldProvenance(d.metadata);
-          humanActionHolds.push({ sd_key: d.sd_key, provenance: prov });
-          log(`  [skip] requires human action — not worker-claimable (not idle-belt depth): ${d.sd_key} [${formatHoldProvenance(prov)}]`);
-          break;
-        }
-        default:
-          ineligibleSkips++;
-          log(`  [skip] dispatch-ineligible (${dbFreeSkip}): ${d.sd_key}`);
-      }
-      continue;
-    }
-    // SD-REFILL-00AH2L4Q: include metadata.blocked_by_sd_key (via blockerKeysFor) so a metadata-blocked
-    // SD whose blocker is not yet completed is NOT ranked/dispatched — matching worker-checkin's claim guard.
-    const unmet = blockerKeysFor(d)
-      .filter(k => (byKey.has(k) ? byKey.get(k).status !== 'completed' : depStatus[k] !== 'completed'));
-    if (unmet.length) {
-      // QF-20260703-999: this exclusion previously had NO skip-log (unlike every other exclusion
-      // reason above), so a dep-blocked SD vanished from both ranked and skip output with zero trace.
-      depBlockedSkips++;
-      log(`  [skip] dependency-blocked (${unmet.join(', ')}): ${d.sd_key}`);
-      continue;
-    }
-    // SD-REFILL-00MFWEGZ: an orchestrator child whose PARENT has not passed LEAD is not yet
-    // dispatchable (claim-eligibility blocks it via the same gate, and it would hit the hard
-    // parent-LEAD EXEC-transition block) — exclude it from fresh ranking so the ranked belt
-    // matches the actually-claimable set. parentLeadPending early-returns false for parentless
-    // SDs (no fetch) and fail-opens on error (never strands a child).
-    if (await parentLeadPending(sb, d)) {
-      log(`  [skip] parent not past LEAD — child not yet dispatchable: ${d.sd_key}`);
-      continue;
-    }
-    claimable.push(d);
-  }
-  if (fixtureSkips) log(`[BACKLOG-RANK] ${fixtureSkips} fixture SD(s) excluded from ranking`);
-  if (inFlightSkips) log(`[BACKLOG-RANK] ${inFlightSkips} in-flight SD(s) excluded from fresh ranking`);
-  if (awaitingConvergenceSkips) log(`[BACKLOG-RANK] ${awaitingConvergenceSkips} SD(s) awaiting co-author convergence (excluded from claimable depth)`);
-  if (humanActionSkips) log(`[BACKLOG-RANK] ${humanActionSkips} SD(s) requiring human action excluded from claimable depth (not worker-claimable)`);
-  if (ineligibleSkips) log(`[BACKLOG-RANK] ${ineligibleSkips} SD(s) dispatch-ineligible (orchestrator-parent / deferred / terminal) excluded from claimable depth`);
-  if (depBlockedSkips) log(`[BACKLOG-RANK] ${depBlockedSkips} SD(s) dependency-blocked excluded from claimable depth`);
-  // Deterministic order (adversarial-review I4): the select has no .order(), so without
-  // this sort the dashboard's grouped render could reorder between ticks and defeat the
-  // steady-state suppress hash.
-  humanActionHolds.sort((a, b) => a.sd_key.localeCompare(b.sd_key));
-  return { sds, byKey, depStatus, claimable, humanActionHolds };
-}
 
 async function main() {
   const { error, sds, byKey, depStatus, claimable } = await computeClaimableLeaves(sb);

--- a/scripts/coordinator-capacity-forecast.mjs
+++ b/scripts/coordinator-capacity-forecast.mjs
@@ -104,6 +104,8 @@ async function main() {
   const {
     idleNow, freeingSoon, building, stalled,
     claimableCount, openQfCount, claimable, rows, workers, maskedIds,
+    // SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001 (FR-3): the named extent + raw-vs-dispatchable split.
+    beltExtent, rawUnclaimed, dispatchableCount,
   } = inputs;
 
   // THE LADDER IS NO LONGER SPELLED HERE. computeBeltVerdict owns it, and drive-report-sweep.mjs
@@ -121,7 +123,7 @@ async function main() {
   for (const r of rows) {
     console.log(`    ${r.sess} ${String(r.callsign).padEnd(8)} ${r.state.padEnd(13)} ${r.eta.padEnd(18)} ${r.detail}`);
   }
-  console.log(`  BELT: ${beltDepth} claimable (${claimable.length} SD + ${openQfCount} QF)  |  DEMAND(soon): ${demandSoon} (idle ${idleNow} + freeing-soon ${freeingSoon})  |  buffer ${BELT_BUFFER}`);
+  console.log(`  BELT: ${beltDepth} claimable [${beltExtent}: ${dispatchableCount} dispatchable of ${rawUnclaimed} raw-unclaimed] (${claimable.length} SD + ${openQfCount} QF)  |  DEMAND(soon): ${demandSoon} (idle ${idleNow} + freeing-soon ${freeingSoon})  |  buffer ${BELT_BUFFER}`);
   if (claimable.length) console.log(`        claimable SDs: ${claimable.map(d => d.sd_key.replace('SD-LEO-INFRA-', '')).join(', ')}`);
 
   // SD-LEO-INFRA-BELT-TIER-AWARE-CLAIMABILITY-001 (FR-3): TRUE per-tier claimable depth so a tier-specific
@@ -239,7 +241,7 @@ async function main() {
   }
 
   // machine-readable last line for the cron/log (+ sourcing-engine awareness fields, FR-2)
-  console.log(`  GAUGE belt=${beltDepth} idle=${idleNow} freeing_soon=${freeingSoon} demand=${demandSoon} deficit=${Math.max(0, deficit)} verdict=${verdict} masked_stall=${maskedIds.size} engine_on=${awareness.anyOn} unpromoted=${awareness.countStr}`);
+  console.log(`  GAUGE belt=${beltDepth} belt_extent=${beltExtent} dispatchable=${dispatchableCount} raw_unclaimed=${rawUnclaimed} idle=${idleNow} freeing_soon=${freeingSoon} demand=${demandSoon} deficit=${Math.max(0, deficit)} verdict=${verdict} masked_stall=${maskedIds.size} engine_on=${awareness.anyOn} unpromoted=${awareness.countStr}`);
 
   try {
     await stampLastFired(sb, 'standard_loop:capacity-forecast');
@@ -280,6 +282,11 @@ async function main() {
         // suppressed one.
         auto_refill_on: autoRefillOn,
         unpromoted_count: unpromotedCount,
+        // SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001 (FR-3): the extent belt_depth spans, recorded so a
+        // reader of belt_capacity_verdicts can never mistake raw-unclaimed for the dispatchable-leaf belt.
+        belt_extent: beltExtent,
+        dispatchable_count: dispatchableCount,
+        raw_unclaimed: rawUnclaimed,
       },
     });
   } catch (err) {

--- a/scripts/lib/capacity-inputs.mjs
+++ b/scripts/lib/capacity-inputs.mjs
@@ -46,16 +46,22 @@
 'use strict';
 
 import { fetchAllPaginated, renderCount } from '../../lib/db/fetch-all-paginated.mjs';
-import { isExcludedFromBelt } from '../../lib/coordinator/sd-exclusion.mjs';
-import { classifyDispatchIneligibility } from '../../lib/fleet/claim-eligibility.cjs';
+import { isBareShell } from '../../lib/coordinator/sd-exclusion.mjs';
+import { parentLeadPendingVerdict } from '../../lib/fleet/claim-eligibility.cjs';
 import { countClaimableQuickFixes } from '../../lib/fleet/belt-depth.cjs';
+// SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001: reuse the ranker's PURE leaf predicates from the
+// client-free SSOT so the forecaster belt spans the DISPATCHABLE-leaf extent (what the ranker
+// counts as "1 claimable leaf"), not the raw-unclaimed extent. Applied IN-MEMORY on the rows this
+// module already fetches — never a second SD-table read or per-child parent fetch.
+import { claimableDbFreeReason, blockerKeysFor } from './claimable-leaves.mjs';
 import { isLiveCountableWorker } from './live-countable-worker.mjs';
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);
 const { stalledLoopSessionIds, maskedStallSessionIds } = require('../../lib/coordinator/detectors.cjs');
 const { getActiveCoordinatorId } = require('../../lib/coordinator/resolve.cjs');
-const { parseSdDependencies } = require('../../lib/utils/parse-sd-dependencies.cjs');
+// SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001: dependency keys now come from the shared blockerKeysFor
+// (which folds in metadata.blocked_by_sd_key too) — the bare parseSdDependencies require was dropped.
 
 // SD-FDBK-INFRA-STALL-AFTER-COMPLETION-001 — DORMANT BY DEFAULT. See the forecast script header for
 // the full reasoning: process_alive_at is currently fleet-broken, so keying the masked-stall detector
@@ -202,7 +208,10 @@ export async function gatherCapacityInputs(sb, { now = Date.now() } = {}) {
     // SD-REFILL-00306WTS: + target_application so un-actionable auto-filed venture remediation
     // SDs (target_application != EHG_Engineer) are excluded from belt depth (false-SURPLUS fix).
     fetchAllPaginated(() => sb.from('strategic_directives_v2')
-      .select('sd_key, title, description, status, sd_type, current_phase, progress_percentage, claiming_session_id, dependencies, metadata, target_application')
+      // SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001: + id + parent_sd_id so the shared leaf predicates
+      // can resolve an orchestrator child's parent IN-MEMORY (parent_sd_id references the parent id or
+      // sd_key) without a per-child DB round-trip.
+      .select('id, sd_key, title, description, status, sd_type, current_phase, progress_percentage, claiming_session_id, dependencies, metadata, target_application, parent_sd_id')
       .not('status', 'in', '("completed","cancelled","deferred")')
       .order('sd_key', { ascending: true })) // unique tiebreaker (FR-6)
       .catch(() => []),
@@ -225,11 +234,14 @@ export async function gatherCapacityInputs(sb, { now = Date.now() } = {}) {
   const openQfCountRendered = renderCount(openQfCountRaw);
   const openQfCount = typeof openQfCountRendered === 'number' ? openQfCountRendered : 0; // fail-open: unreadable → 0 belt contribution, unchanged from the prior fallback
 
-  // ── resolve dependency statuses → claimable belt ──
-  // parseSdDependencies handles the live shape mix ([{sd_id}], [{sd_key}], raw strings) AND drops the
-  // 'none' sentinel + free-text non-SD placeholders, returning only real /^SD-/ blocker keys.
+  // ── resolve dependency statuses → DISPATCHABLE-LEAF belt (SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001) ──
+  // blockerKeysFor is the SAME shared predicate the ranker uses: `dependencies` column PLUS the
+  // canonical metadata.blocked_by_sd_key (the forecaster previously read only the top-level column,
+  // so metadata-blocked rows leaked onto the belt).
+  const byKey = new Map((sds || []).map(d => [d.sd_key, d]));
+  const byId = new Map((sds || []).filter(d => d.id != null).map(d => [d.id, d]));
   const depKeys = new Set();
-  (sds || []).forEach(d => parseSdDependencies(d.dependencies).forEach(k => depKeys.add(k)));
+  (sds || []).forEach(d => blockerKeysFor(d).forEach(k => depKeys.add(k)));
   let depStatus = {};
   if (depKeys.size) {
     // SD-LEO-INFRA-COUNT-TRUNCATION-DISCIPLINE-001 FR-6 batch 9: bounded by design — depKeys is
@@ -240,6 +252,7 @@ export async function gatherCapacityInputs(sb, { now = Date.now() } = {}) {
   }
   const claimable = [];
   const claimsBySession = {};
+  let rawUnclaimed = 0;      // every unclaimed non-terminal row, pre-exclusion — the extent the bug measured
   let beltExcludes = 0;
   let ineligibleExcludes = 0;
   for (const d of (sds || [])) {
@@ -247,26 +260,40 @@ export async function gatherCapacityInputs(sb, { now = Date.now() } = {}) {
       (claimsBySession[d.claiming_session_id] ||= []).push(d);
       continue;
     }
-    // SD-FDBK-INFRA-BACKLOG-RANK-EXCLUSION-001: fixtures and bare-shell stubs are not real
-    // belt — neither can pass LEAD-TO-PLAN. Excluding them keeps beltDepth honest so a
-    // forecast deficit (and the proactive Adam reach-out) is not masked by non-distributable rows.
-    if (isExcludedFromBelt(d)) { beltExcludes++; continue; }
-    // SD-LEO-INFRA-BACKLOG-RANK-CLAIMABLE-ELIGIBILITY-ALIGN-001: apply the SHARED claim-eligibility
-    // predicate (the SSOT the worker resolver uses) so belt depth == actually-claimable depth. Catches
-    // orchestrator_parent, human_action_required (the previously-missing axis), co_author_pending,
-    // sd_deferred, sd_terminal, test_fixture_key. Without this the forecaster over-counted RHA-held +
-    // co-author-pending SDs and fired false belt-low DEFICITs that masked genuine starvation.
-    const ineligible = classifyDispatchIneligibility(d);
-    if (ineligible) {
-      ineligibleExcludes++;
-      console.log(`  [belt-skip] ${ineligible} (not worker-claimable): ${d.sd_key}`);
+    rawUnclaimed++;
+    // ── the DISPATCHABLE-LEAF predicate, shared with the ranker (never a parallel re-count) ──
+    // claimableDbFreeReason folds in-flight/started + fixture + un-actionable-venture-remediation +
+    // the full classifyDispatchIneligibility axis table (human-action/orchestrator/co-author/deferred/
+    // terminal/clone-tree). The forecaster PREVIOUSLY missed the in-flight axis, so started-but-unclaimed
+    // SDs read as fresh supply.
+    const reason = claimableDbFreeReason(d);
+    if (reason && reason !== 'claimed') {
+      // Non-distributable stubs vs dispatch-ineligible holds — kept separate for the emitted breakdown.
+      if (reason === 'in_flight' || reason === 'fixture' || reason === 'unactionable_venture_remediation') beltExcludes++;
+      else ineligibleExcludes++;
+      console.log(`  [belt-skip] ${reason} (not dispatchable-leaf): ${d.sd_key}`);
       continue;
     }
-    const unmet = parseSdDependencies(d.dependencies).filter(k => depStatus[k] !== 'completed');
-    if (unmet.length === 0) claimable.push(d);
+    // isBareShell on top: computeClaimableLeaves DEMOTES bare-shell but does not DROP it — the
+    // forecaster keeps dropping it (a bare-shell cannot pass LEAD-TO-PLAN), so the forecaster count is
+    // a SUBSET of the ranker leaf set. Under-count is the SAFE deficit direction (never masks starvation).
+    if (isBareShell(d)) { beltExcludes++; continue; }
+    // blockerKeysFor: `dependencies` + metadata.blocked_by_sd_key, resolved against the in-memory
+    // non-terminal set (a completed/absent blocker is satisfied).
+    const unmet = blockerKeysFor(d).filter(k => (byKey.has(k) ? byKey.get(k).status !== 'completed' : depStatus[k] !== 'completed'));
+    if (unmet.length) { ineligibleExcludes++; continue; }
+    // Parent-LEAD IN-MEMORY: an orchestrator child whose parent has not passed LEAD is not yet
+    // dispatchable. Resolve the parent from the already-fetched non-terminal set (by id or sd_key) and
+    // apply the shared pure verdict — no per-child DB round-trip. An absent/terminal parent => not pending.
+    if (d.parent_sd_id != null) {
+      const parent = byId.get(d.parent_sd_id) || byKey.get(d.parent_sd_id);
+      if (parentLeadPendingVerdict(parent)) { ineligibleExcludes++; continue; }
+    }
+    claimable.push(d);
   }
-  if (beltExcludes) console.log(`[CAPACITY-FORECAST] ${beltExcludes} non-distributable SD(s) (fixture/bare-shell/un-actionable-venture-remediation) excluded from belt depth`);
-  if (ineligibleExcludes) console.log(`[CAPACITY-FORECAST] ${ineligibleExcludes} dispatch-ineligible SD(s) (human-action/orchestrator/co-author-pending/deferred/terminal) excluded from belt depth (claim-eligibility SSOT)`);
+  if (beltExcludes) console.log(`[CAPACITY-FORECAST] ${beltExcludes} non-distributable SD(s) (in-flight/fixture/bare-shell/un-actionable-venture-remediation) excluded from dispatchable-leaf belt`);
+  if (ineligibleExcludes) console.log(`[CAPACITY-FORECAST] ${ineligibleExcludes} dispatch-ineligible SD(s) (human-action/orchestrator/co-author/deferred/terminal/dep-blocked/parent-LEAD) excluded from dispatchable-leaf belt (shared leaf SSOT)`);
+  console.log(`[CAPACITY-FORECAST] belt extent=dispatchable-leaf: ${claimable.length} dispatchable of ${rawUnclaimed} raw-unclaimed`);
 
   // ── classify live workers (exclude coordinator + adam + non_fleet + fixtures + released) ──
   // SD-LEO-INFRA-FORECASTER-FIXTURE-WORKER-EXCLUSION-001: use the canonical isDispatchableFleetMember
@@ -340,6 +367,12 @@ export async function gatherCapacityInputs(sb, { now = Date.now() } = {}) {
     claimable, rows, workers, claimsBySession,
     maskedIds, stalledIds, phaseMinActuals,
     beltExcludes, ineligibleExcludes,
+    // SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001 (FR-3): NAME the extent + the raw-vs-dispatchable
+    // breakdown so a reader (and the persisted verdict detail) can never mistake raw-unclaimed for
+    // the dispatchable-leaf belt again. beltExtent labels which extent claimableCount spans.
+    beltExtent: 'dispatchable-leaf',
+    rawUnclaimed,
+    dispatchableCount: claimable.length,
     now,
   };
 }

--- a/scripts/lib/claimable-leaves.mjs
+++ b/scripts/lib/claimable-leaves.mjs
@@ -1,0 +1,149 @@
+/**
+ * claimable-leaves.mjs — the client-free SSOT for the dispatchable-leaf belt.
+ * SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001.
+ *
+ * WHY THIS MODULE EXISTS: the ranker (coordinator-backlog-rank.mjs) and the capacity forecaster
+ * (capacity-inputs.mjs) must agree on "how deep is the DISPATCHABLE belt". These three functions
+ * were defined inside coordinator-backlog-rank.mjs, but importing them from there constructs a
+ * Supabase client at module scope (that file's CLI entry) and throws at import wherever
+ * SUPABASE_URL is absent — taking the forecaster's unit tests with it. Holding them here, with the
+ * client PASSED IN (never constructed), lets both consumers share ONE representation of the leaf
+ * predicate. coordinator-backlog-rank.mjs re-exports these (barrel) so its existing importers are
+ * unchanged; the forecaster consumes the PURE predicates in-memory (no duplicate DB reads).
+ *
+ * The pure DB-free predicates (blockerKeysFor, claimableDbFreeReason) are the shared
+ * representation; computeClaimableLeaves is the async ranker wrapper. The forecaster does NOT call
+ * computeClaimableLeaves — it applies the pure predicates to rows it already fetched (see
+ * capacity-inputs.mjs) to avoid a second SD-table pagination + per-child parent fetches.
+ */
+
+import { fetchAllPaginated } from '../../lib/db/fetch-all-paginated.mjs';
+import { isFixtureSd, isStartedSd, isUnactionableRemediationSd } from '../../lib/coordinator/sd-exclusion.mjs';
+import { parseSdDependencies } from '../../lib/utils/parse-sd-dependencies.cjs';
+import { parentLeadPending, classifyDispatchIneligibility, resolveHoldProvenance, formatHoldProvenance } from '../../lib/fleet/claim-eligibility.cjs';
+import { checkMetadataDependency } from '../modules/sd-next/dependency-resolver.js';
+
+// Collect every blocker sd_key for an SD: the `dependencies` column PLUS the canonical
+// metadata.blocked_by_sd_key. ONE predicate, shared by depKeys collection and the unmet check.
+export function blockerKeysFor(d) {
+  const keys = parseSdDependencies(d.dependencies);
+  const { blockerSdKey } = checkMetadataDependency(d.metadata);
+  if (blockerSdKey) keys.push(blockerSdKey);
+  return keys;
+}
+
+/**
+ * SD-LEO-INFRA-BACKLOG-RANK-CLAIMABLE-ELIGIBILITY-ALIGN-001: the DB-FREE claimable gate for the ranker,
+ * composed so the ranked belt matches the actually-claimable set the worker resolver enforces. Returns
+ * null when the SD passes every DB-free claimable axis, or a reason string when it must be excluded:
+ *   - 'claimed'  — a live session already holds it (claiming_session_id set)
+ *   - 'in_flight' — started/mid-build past LEAD draft (resumed via resume_orphan, never fresh-ranked)
+ *   - 'fixture'  — backlog-rank's BROADER fixture detection (epoch TEST-E2E keys / metadata.is_fixture)
+ *   - 'unactionable_venture_remediation' — auto-filed SD-LEO-FIX-REMEDIATION-* targeting a venture repo
+ *   - else the SHARED claim-eligibility reason: 'orchestrator_parent' | 'human_action_required' |
+ *     'co_author_pending' | 'sd_deferred' | 'sd_terminal' | 'test_fixture_key' | 'test_clone_build_tree'.
+ * The shared predicate (classifyDispatchIneligibility) is the SSOT — re-implementing it is exactly how
+ * the requires_human_action skip drifted out of the ranker. Pure; the DB-backed axes (dependency/metadata
+ * blockers, parent-LEAD-pending) remain in the async claim loop / the consumer. Exported for unit testing.
+ * @param {object} d - an SD row (sd_key, sd_type, status, current_phase, claiming_session_id, metadata)
+ * @returns {null|string}
+ */
+export function claimableDbFreeReason(d) {
+  if (!d) return 'missing';
+  if (d.claiming_session_id) return 'claimed';
+  if (isStartedSd(d)) return 'in_flight';
+  if (isFixtureSd(d.sd_key, d.metadata)) return 'fixture';
+  if (isUnactionableRemediationSd(d)) return 'unactionable_venture_remediation';
+  return classifyDispatchIneligibility(d); // null => eligible on the DB-free axes
+}
+
+/**
+ * The SSOT claimable-leaf computation the ranker (dispatch_rank) relies on. Async: it reads
+ * strategic_directives_v2 itself and resolves parent-LEAD per candidate. The forecaster does NOT
+ * call this (it would duplicate the SD read + add per-child fetches) — it reuses the pure
+ * predicates above on its already-fetched rows. This wrapper is unchanged behaviourally from its
+ * former home in coordinator-backlog-rank.mjs.
+ * @returns {Promise<{ error?: object, sds: object[], byKey: Map, depStatus: object, claimable: object[], humanActionHolds: Array<{sd_key: string, provenance: object|null}> }>}
+ */
+export async function computeClaimableLeaves(sb, opts = {}) {
+  const log = opts.quiet ? () => {} : console.log;
+  let sds;
+  try {
+    sds = await fetchAllPaginated(() => sb.from('strategic_directives_v2')
+      .select('sd_key, title, description, status, sd_type, priority, created_at, current_phase, claiming_session_id, dependencies, metadata, parent_sd_id')
+      .not('status', 'in', '("completed","cancelled","deferred")')
+      .order('sd_key', { ascending: true }));
+  } catch (error) {
+    console.error('[BACKLOG-RANK] load failed:', error.message);
+    return { error, sds: [], byKey: new Map(), depStatus: {}, claimable: [], humanActionHolds: [] };
+  }
+
+  const byKey = new Map((sds || []).map(d => [d.sd_key, d]));
+  const depKeys = new Set();
+  (sds || []).forEach(d => blockerKeysFor(d).forEach(k => depKeys.add(k)));
+  let depStatus = {};
+  if (depKeys.size) {
+    const { data: deps } = await sb.from('strategic_directives_v2').select('sd_key,status').in('sd_key', Array.from(depKeys));
+    (deps || []).forEach(d => { depStatus[d.sd_key] = d.status; });
+  }
+
+  const claimable = [];
+  const humanActionHolds = [];
+  let fixtureSkips = 0;
+  let inFlightSkips = 0;
+  let awaitingConvergenceSkips = 0;
+  let humanActionSkips = 0;
+  let ineligibleSkips = 0;
+  let depBlockedSkips = 0;
+  for (const d of (sds || [])) {
+    const dbFreeSkip = claimableDbFreeReason(d);
+    if (dbFreeSkip) {
+      switch (dbFreeSkip) {
+        case 'claimed': break;
+        case 'in_flight':
+          inFlightSkips++;
+          log(`  [skip] in-flight (${d.current_phase}) excluded from fresh ranking: ${d.sd_key}`);
+          break;
+        case 'fixture':
+          fixtureSkips++;
+          log(`  [skip] fixture excluded from ranking: ${d.sd_key}`);
+          break;
+        case 'co_author_pending':
+          awaitingConvergenceSkips++;
+          log(`  [skip] awaiting co-author convergence (not idle-belt depth): ${d.sd_key}`);
+          break;
+        case 'human_action_required': {
+          humanActionSkips++;
+          const prov = resolveHoldProvenance(d.metadata);
+          humanActionHolds.push({ sd_key: d.sd_key, provenance: prov });
+          log(`  [skip] requires human action — not worker-claimable (not idle-belt depth): ${d.sd_key} [${formatHoldProvenance(prov)}]`);
+          break;
+        }
+        default:
+          ineligibleSkips++;
+          log(`  [skip] dispatch-ineligible (${dbFreeSkip}): ${d.sd_key}`);
+      }
+      continue;
+    }
+    const unmet = blockerKeysFor(d)
+      .filter(k => (byKey.has(k) ? byKey.get(k).status !== 'completed' : depStatus[k] !== 'completed'));
+    if (unmet.length) {
+      depBlockedSkips++;
+      log(`  [skip] dependency-blocked (${unmet.join(', ')}): ${d.sd_key}`);
+      continue;
+    }
+    if (await parentLeadPending(sb, d)) {
+      log(`  [skip] parent not past LEAD — child not yet dispatchable: ${d.sd_key}`);
+      continue;
+    }
+    claimable.push(d);
+  }
+  if (fixtureSkips) log(`[BACKLOG-RANK] ${fixtureSkips} fixture SD(s) excluded from ranking`);
+  if (inFlightSkips) log(`[BACKLOG-RANK] ${inFlightSkips} in-flight SD(s) excluded from fresh ranking`);
+  if (awaitingConvergenceSkips) log(`[BACKLOG-RANK] ${awaitingConvergenceSkips} SD(s) awaiting co-author convergence (excluded from claimable depth)`);
+  if (humanActionSkips) log(`[BACKLOG-RANK] ${humanActionSkips} SD(s) requiring human action excluded from claimable depth (not worker-claimable)`);
+  if (ineligibleSkips) log(`[BACKLOG-RANK] ${ineligibleSkips} SD(s) dispatch-ineligible (orchestrator-parent / deferred / terminal) excluded from claimable depth`);
+  if (depBlockedSkips) log(`[BACKLOG-RANK] ${depBlockedSkips} SD(s) dependency-blocked excluded from claimable depth`);
+  humanActionHolds.sort((a, b) => a.sd_key.localeCompare(b.sd_key));
+  return { sds, byKey, depStatus, claimable, humanActionHolds };
+}

--- a/tests/unit/capacity-forecaster-belt-extent.test.js
+++ b/tests/unit/capacity-forecaster-belt-extent.test.js
@@ -1,0 +1,157 @@
+/**
+ * SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001 — the forecaster belt spans the DISPATCHABLE-LEAF extent.
+ *
+ * The bug (measured live 2026-08-10 ~07:45Z): the forecaster counted the RAW-UNCLAIMED extent, so
+ * its deficit alarm read SURPLUS while the true dispatchable leaf belt was 1 and workers were about
+ * to idle. These tests pin the fix two-sided: raw >> floor + leaf <= floor FIRES a DEFICIT (positive
+ * control), each real-gap class (in-flight/parent-LEAD/metadata-blocker) drops from the count
+ * (behaviour changes vs the pre-fix forecaster), bare-shell stays dropped (forecaster subset-of
+ * ranker), the SD table is read ONCE (no duplicate computeClaimableLeaves fetch), and the emitted
+ * inputs carry the named raw-vs-dispatchable breakdown.
+ */
+import { describe, it, expect } from 'vitest';
+import { gatherCapacityInputs, BELT_BUFFER } from '../../scripts/lib/capacity-inputs.mjs';
+import { computeBeltVerdict } from '../../lib/drive-loop/belt-verdict.js';
+import { claimableDbFreeReason, blockerKeysFor } from '../../scripts/lib/claimable-leaves.mjs';
+import { isBareShell } from '../../lib/coordinator/sd-exclusion.mjs';
+
+/** Fake supabase mirroring capacity-inputs.test.js, plus a from()-call counter for the read-count assertion. */
+function fakeClient({ sessions = [], sds = [], qfCount = 0, counter } = {}) {
+  const table = (rows) => {
+    const b = {
+      _rows: rows,
+      select() { return b; }, eq() { return b; }, in() { return b; }, is() { return b; },
+      not() { return b; }, gte() { return b; }, order() { return b; }, limit() { return b; },
+      range(from, to) { return Promise.resolve({ data: b._rows.slice(from, to + 1), error: null }); },
+      then(res) { return Promise.resolve({ data: b._rows, error: null }).then(res); },
+    };
+    return b;
+  };
+  return {
+    from(name) {
+      if (counter) counter[name] = (counter[name] || 0) + 1;
+      if (name === 'claude_sessions') return table(sessions);
+      if (name === 'strategic_directives_v2') return table(sds);
+      if (name === 'quick_fixes') {
+        const b = {
+          select() { return b; }, eq() { return b; }, in() { return b; }, is() { return b; },
+          not() { return b; }, order() { return b; },
+          then(res) { return Promise.resolve({ count: qfCount, error: null }).then(res); },
+        };
+        return b;
+      }
+      return table([]);
+    },
+  };
+}
+
+const liveIdle = (over = {}) => ({
+  session_id: `s-${Math.random().toString(36).slice(2)}`,
+  terminal_id: 't', sd_key: null,
+  heartbeat_at: new Date().toISOString(), process_alive_at: new Date().toISOString(),
+  loop_state: 'active', expected_silence_until: null, metadata: { callsign: 'Alpha' },
+  status: 'active', released_reason: null, released_at: null, ...over,
+});
+
+const sd = (over = {}) => ({
+  id: over.sd_key || 'SD-CLEAN-001',
+  sd_key: 'SD-CLEAN-001',
+  title: 'A real strategic directive with a genuine described body of work',
+  description: 'A substantive, non-bare-shell description that differs from the title entirely.',
+  status: 'draft', sd_type: 'infrastructure', current_phase: 'LEAD', progress_percentage: 0,
+  claiming_session_id: null, dependencies: null, metadata: {}, target_application: 'EHG_Engineer',
+  parent_sd_id: null, ...over,
+});
+
+// The six-row shape from TESTING Q3: 1 clean dispatchable leaf + 5 gap-class rows that RAW counts but
+// the dispatchable-leaf extent drops.
+const cleanLeaf = () => sd({ sd_key: 'SD-CLEAN-001', id: 'SD-CLEAN-001' });
+const bareShell = () => sd({ sd_key: 'SD-BARESHELL-001', id: 'SD-BARESHELL-001', title: 'Bare shell', description: 'Bare shell' });
+const humanHeld = () => sd({ sd_key: 'SD-HUMAN-001', id: 'SD-HUMAN-001', metadata: { requires_human_action: true } });
+const inFlight = () => sd({ sd_key: 'SD-INFLIGHT-001', id: 'SD-INFLIGHT-001', current_phase: 'EXEC' });
+const ventureRemediation = () => sd({ sd_key: 'SD-LEO-FIX-REMEDIATION-001', id: 'SD-LEO-FIX-REMEDIATION-001', target_application: 'EHG' });
+const depBlocked = () => sd({ sd_key: 'SD-DEPBLOCK-001', id: 'SD-DEPBLOCK-001', dependencies: [{ sd_key: 'SD-BLOCKER-999' }] });
+
+describe('belt extent — dispatchable-leaf, not raw-unclaimed', () => {
+  it('TS-1: raw >> floor but leaf <= floor FIRES a DEFICIT (the silent-hour shape)', async () => {
+    const out = await gatherCapacityInputs(fakeClient({
+      sessions: [liveIdle(), liveIdle()], // idleNow=2 -> floor = demandSoon(2) + buffer(1) = 3
+      sds: [cleanLeaf(), bareShell(), humanHeld(), inFlight(), ventureRemediation(), depBlocked()],
+      qfCount: 0,
+    }));
+    expect(out.rawUnclaimed, 'six unclaimed rows — the extent the bug measured').toBe(6);
+    expect(out.dispatchableCount, 'only the clean leaf is dispatchable').toBe(1);
+    const cap = computeBeltVerdict({ idleNow: out.idleNow, freeingSoon: out.freeingSoon, claimableCount: out.claimableCount, openQfCount: out.openQfCount, buffer: BELT_BUFFER });
+    expect(cap.beltDepth).toBe(1); // >0, so DEFICIT not DEFICIT-URGENT (proves the EXCLUSIONS caught it)
+    expect(cap.verdict).toBe('DEFICIT');
+    expect(cap.deficit).toBe(2);
+    // The bug's reading: raw 6 vs floor 3 -> would have read SURPLUS.
+    const buggy = computeBeltVerdict({ idleNow: out.idleNow, freeingSoon: out.freeingSoon, claimableCount: out.rawUnclaimed, openQfCount: 0, buffer: BELT_BUFFER });
+    expect(buggy.verdict, 'the pre-fix raw-unclaimed count read SURPLUS during the exact silent hour').toBe('SURPLUS');
+  });
+
+  it('TS-3: bare-shell stays excluded (forecaster subset-of ranker, safe deficit direction)', async () => {
+    const out = await gatherCapacityInputs(fakeClient({ sds: [cleanLeaf(), bareShell()] }));
+    expect(out.claimableCount).toBe(1);
+  });
+
+  it('TS-4: an in-flight/started (past-LEAD) unclaimed row no longer counts as supply', async () => {
+    const out = await gatherCapacityInputs(fakeClient({ sds: [cleanLeaf(), inFlight()] }));
+    expect(out.claimableCount, 'in-flight was counted before the fix; now dropped via the shared isStartedSd axis').toBe(1);
+  });
+
+  it('TS-5: an orchestrator child whose parent has not passed LEAD is dropped (in-memory parent resolution)', async () => {
+    const parent = sd({ sd_key: 'SD-PARENT-001', id: 'SD-PARENT-001', sd_type: 'orchestrator', current_phase: 'LEAD' });
+    const child = sd({ sd_key: 'SD-CHILD-001', id: 'SD-CHILD-001', parent_sd_id: 'SD-PARENT-001' });
+    const out = await gatherCapacityInputs(fakeClient({ sds: [cleanLeaf(), parent, child] }));
+    // parent is an orchestrator (dropped by classifyDispatchIneligibility) AND the child is parent-LEAD-pending.
+    expect(out.claimableCount, 'only the clean leaf; the orchestrator parent and its pre-LEAD child both drop').toBe(1);
+  });
+
+  it('TS-6: a metadata.blocked_by_sd_key row is dropped (blockerKeysFor, not just top-level deps)', async () => {
+    const blocked = sd({ sd_key: 'SD-METABLOCK-001', id: 'SD-METABLOCK-001', dependencies: null, metadata: { blocked_by_sd_key: 'SD-BLOCKER-999' } });
+    const out = await gatherCapacityInputs(fakeClient({ sds: [cleanLeaf(), blocked] }));
+    expect(out.claimableCount, 'the metadata blocker (uncompleted) drops it — previously counted').toBe(1);
+  });
+
+  it('TS-2: forecaster claimable set == the ranker pure-predicate leaf set minus bare-shell (subset parity, derived)', async () => {
+    const rows = [cleanLeaf(), bareShell(), humanHeld(), inFlight(), ventureRemediation(), depBlocked(),
+      sd({ sd_key: 'SD-CLEAN-002', id: 'SD-CLEAN-002' })];
+    const byKey = new Map(rows.map(r => [r.sd_key, r]));
+    // Derive the expected set from the SAME shared predicates (never a hardcoded list):
+    const expected = rows
+      .filter(d => !d.claiming_session_id)
+      .filter(d => { const r = claimableDbFreeReason(d); return !r || r === 'claimed'; })
+      .filter(d => !isBareShell(d))
+      .filter(d => blockerKeysFor(d).every(k => (byKey.has(k) ? byKey.get(k).status === 'completed' : false)))
+      .map(d => d.sd_key).sort();
+    const out = await gatherCapacityInputs(fakeClient({ sds: rows }));
+    const actual = out.claimable.map(d => d.sd_key).sort();
+    expect(actual).toEqual(expected);
+    expect(actual).toEqual(['SD-CLEAN-001', 'SD-CLEAN-002']);
+  });
+
+  it('TS-9: the SD table is read ONCE — no duplicate computeClaimableLeaves fetch', async () => {
+    const counter = {};
+    await gatherCapacityInputs(fakeClient({ sds: [cleanLeaf(), depBlocked()], counter }));
+    // One paginated leaf read + at most one dep-status read = the from() count must not double from a
+    // second computeClaimableLeaves(sb) pagination. The forecaster reuses pure predicates in-memory.
+    expect(counter['strategic_directives_v2'], 'the leaf read + the dep-status read — never a 2nd full pagination').toBeLessThanOrEqual(2);
+  });
+
+  it('TS-10: QF still counts when SD belt is 0 (the QF term survives the refactor)', async () => {
+    const out = await gatherCapacityInputs(fakeClient({ sds: [], qfCount: 2 }));
+    const cap = computeBeltVerdict({ idleNow: out.idleNow, freeingSoon: out.freeingSoon, claimableCount: out.claimableCount, openQfCount: out.openQfCount, buffer: BELT_BUFFER });
+    expect(out.claimableCount).toBe(0);
+    expect(cap.beltDepth, 'beltDepth === openQfCount').toBe(2);
+    expect(cap.verdict).not.toBe('DEFICIT-URGENT');
+  });
+
+  it('TS-11: the emitted inputs NAME the extent + carry the raw-vs-dispatchable breakdown (FR-3, asserted not prose)', async () => {
+    const out = await gatherCapacityInputs(fakeClient({ sds: [cleanLeaf(), bareShell(), inFlight()] }));
+    expect(out.beltExtent).toBe('dispatchable-leaf');
+    expect(out.rawUnclaimed).toBe(3);
+    expect(out.dispatchableCount).toBe(1);
+    expect(out.claimableCount).toBe(out.dispatchableCount);
+  });
+});

--- a/tests/unit/coordinator-sd-exclusion.test.js
+++ b/tests/unit/coordinator-sd-exclusion.test.js
@@ -35,6 +35,12 @@ const RANKER = resolve(__dirname, '../../scripts/coordinator-backlog-rank.mjs');
 // now holds the code keeps it doing that. Loosening the pattern instead (or dropping the assertion
 // because "it moved") would retire a guard over a file move and leave the deletion undetected.
 const FORECASTER = resolve(__dirname, '../../scripts/lib/capacity-inputs.mjs');
+// SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001: REPOINTED, not relaxed (same discipline as FORECASTER
+// above). The ranker's claimable-leaf predicates (isFixtureSd / isStartedSd + the SD SELECT that
+// feeds them) MOVED verbatim into the client-free scripts/lib/claimable-leaves.mjs so the capacity
+// forecaster could reuse ONE representation instead of a parallel count. The call sites still exist;
+// pointing these guards at the file that now holds them keeps them catching call-site DELETION.
+const LEAVES = resolve(__dirname, '../../scripts/lib/claimable-leaves.mjs');
 
 describe('isFixtureSd — fixture inclusion', () => {
   it('excludes the witnessed epoch-stamped UAT fixture keys (the b5f21465 gap)', () => {
@@ -233,33 +239,38 @@ describe('isStartedSd — the REAL ranker in-flight guard', () => {
 describe('production wiring guards (catch call-site deletion)', () => {
   const rankerSrc = readFileSync(RANKER, 'utf8');
   const forecasterSrc = readFileSync(FORECASTER, 'utf8');
+  const leavesSrc = readFileSync(LEAVES, 'utf8');
 
-  it('the ranker imports and applies the fixture skip + bare-shell comparator', () => {
-    expect(rankerSrc).toMatch(/from '\.\.\/lib\/coordinator\/sd-exclusion\.mjs'/);
-    expect(rankerSrc).toContain('isFixtureSd(d.sd_key, d.metadata)');
+  it('the leaf SSOT imports and applies the fixture skip; the ranker keeps the bare-shell comparator', () => {
+    // The fixture skip moved into the shared leaf module (via claimableDbFreeReason); the bare-shell
+    // demotion comparator stays in the ranker's sort. Both call sites still exist — repointed, not dropped.
+    expect(leavesSrc).toMatch(/from '(\.\.\/)+lib\/coordinator\/sd-exclusion\.mjs'/);
+    expect(leavesSrc).toContain('isFixtureSd(d.sd_key, d.metadata)');
     expect(rankerSrc).toContain('bareShellLastCompare(a, b)');
   });
 
-  it('the ranker imports and applies the in-flight (started) guard', () => {
-    expect(rankerSrc).toContain('isStartedSd');
-    expect(rankerSrc).toContain('isStartedSd(d)');
+  it('the leaf SSOT imports and applies the in-flight (started) guard', () => {
+    expect(leavesSrc).toContain('isStartedSd');
+    expect(leavesSrc).toContain('isStartedSd(d)');
   });
 
-  it('the forecaster imports and applies the belt exclusion', () => {
-    // The relative depth is allowed to vary (the belt build now sits one directory deeper); the
-    // MODULE and the CALL are what this guard is about, and both are still asserted exactly.
+  it('the forecaster imports and applies the belt exclusion (shared leaf predicate + bare-shell on top)', () => {
+    // SD-LEO-INFRA-CAPACITY-FORECASTER-BELT-001: the forecaster's belt exclusion is now the SHARED
+    // claimableDbFreeReason (the ranker's leaf predicate) PLUS isBareShell applied on top — the wire
+    // this guard exists to catch. isExcludedFromBelt was replaced, so the guard tracks the new call.
     expect(forecasterSrc).toMatch(/from '(\.\.\/)+lib\/coordinator\/sd-exclusion\.mjs'/);
-    expect(forecasterSrc).toContain('isExcludedFromBelt(d)');
+    expect(forecasterSrc).toContain('claimableDbFreeReason(d)');
+    expect(forecasterSrc).toContain('isBareShell(d)');
   });
 
-  it('both scripts SELECT the columns their classifiers read', () => {
-    // bare-shell needs title+description; is_fixture needs metadata.
-    expect(rankerSrc).toMatch(/select\([^)]*title[^)]*description[^)]*metadata/s);
+  it('both the leaf SSOT and the forecaster SELECT the columns their classifiers read', () => {
+    // bare-shell needs title+description; is_fixture needs metadata. The ranker SELECT moved into the leaf SSOT.
+    expect(leavesSrc).toMatch(/select\([^)]*title[^)]*description[^)]*metadata/s);
     expect(forecasterSrc).toMatch(/select\([^)]*title[^)]*description[^)]*metadata/s);
   });
 
-  it('the ranker SELECTs current_phase for the in-flight guard', () => {
-    expect(rankerSrc).toMatch(/select\([^)]*current_phase/s);
+  it('the leaf SSOT SELECTs current_phase for the in-flight guard', () => {
+    expect(leavesSrc).toMatch(/select\([^)]*current_phase/s);
   });
 
   // SD-FDBK-INFRA-COORDINATOR-BACKLOG-RANK-001: the ranker must sweep stale ranks off TERMINAL SDs too


### PR DESCRIPTION
**The defect (measured live 2026-08-10 ~07:45Z):** the capacity forecaster counted the RAW-UNCLAIMED extent (~176 rows including in-flight/started SDs, orchestrator children whose parent is still in LEAD, metadata-blocked rows, and non-leaf parents), so its deficit alarm read SURPLUS while the true dispatchable leaf belt was **1** and workers were about to idle — the refill ping the forecaster exists to produce stayed silent and the coordinator had to hand-detect the shortage.

**FR-1 — one representation.** MOVE `claimableDbFreeReason` + `blockerKeysFor` + `computeClaimableLeaves` out of `coordinator-backlog-rank.mjs` into the new client-free `scripts/lib/claimable-leaves.mjs` (`sb` passed as arg; the ranker's module-scope client stays behind). `coordinator-backlog-rank.mjs` re-exports them (import + export barrel) so all 6 importers + their tests are unchanged.

**FR-2 — the forecaster reuses the PURE predicates in-memory.** `capacity-inputs.mjs` applies `claimableDbFreeReason` + `blockerKeysFor` + `isBareShell` to the rows it already fetches — NOT `computeClaimableLeaves(sb)`, which would add a duplicate SD pagination + N per-child `parentLeadPending` round-trips on the 10-min forecaster and the daily sweep (testing-agent Q1). Parent-LEAD resolves in-memory from the non-terminal set via a new pure `parentLeadPendingVerdict()` shared with the async path. `isBareShell` stays applied on top so the forecaster count is a **subset** of the ranker leaf set — the *safe* deficit direction (under-count never masks starvation; `computeClaimableLeaves` only demotes bare-shell, so a naive swap would re-inflate in the same over-count direction as the bug).

**FR-3 — the emitted metric names the extent.** The GAUGE/BELT lines and the `belt_capacity_verdicts` detail now carry `belt_extent=dispatchable-leaf` and a raw-unclaimed-vs-dispatchable breakdown, so a reader can never mistake raw for dispatchable again.

**Premise refinement (measured, signaled):** the four hold classes the plan named (human-action/review-held/chairman-ratification/lead-blocker) were ALREADY excluded via `classifyDispatchIneligibility` (pinned test); the real gap was in-flight / parent-LEAD / metadata-blocker / non-leaf.

**Tests:** 9 new two-sided cases — TS-1 (raw≫floor + leaf≤floor → DEFICIT while the raw count reads SURPLUS, the silent-hour shape), each gap-class drop, subset-parity **derived from the shared predicates** (not a hardcoded list), a read-count spy (SD table read once), QF-with-SD=0, and the raw-vs-dispatchable emission. **128 green** across the affected surface; eslint clean.

**Size (+405/−216):** dominated by the MOVE (net-neutral logic) + the 157-line test; the real new logic is ~83 LOC in the forecaster + 21 in claim-eligibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)