### PR TITLE
feat(SD-LEO-INFRA-DRIVE-SCORE-DENOMINATOR-001): ratify the drive-score 3-leg/6-point denominator + fail-loud phantom-leg guard

### DIFF
--- a/.artifacts/alpha3-denom-rekey.mjs
+++ b/.artifacts/alpha3-denom-rekey.mjs
@@ -1,0 +1,20 @@
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+const s = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const SD='SD-LEO-INFRA-DRIVE-SCORE-DENOMINATOR-001';
+const { data: cur } = await s.from('strategic_directives_v2').select('metadata,scope').eq('sd_key',SD).single();
+const scope = 'IN (final, per coordinator SPLIT ruling 8280af5a): FR-2 ratify the 3-leg/6-point denominator in lib/drive-loop/score/aggregate.js via a frozen DRIVE_SCORE_LEGS SSOT (SPEC_LEG_COUNT derived, Adam d50b9f12 + coordinator ac704cbd provenance); FR-3 fail-loud phantom-leg guard (assertLegSetRatified / assertProducedLegsMatchSSOT — minting a leg is an explicit chairman-surfaced spec change). This SD ratifies the DENOMINATOR (its namesake) and builds the guard.\nOUT / SPLIT: leg INPUT wiring that makes measured_legs>0 is follow-on infrastructure, NOT this SD. leg1_landed (git-runner CI cron) -> SD-LEO-INFRA-DRIVE-SCORE-LEG1-001. leg2_uptake (prior-report top-5 snapshot; the live dispatch_rank CLEARS on claim, structurally excluding leg2 own numerator — the adding-to-an-exclusion-set class, coordinator 8280af5a) -> SD-LEO-INFRA-DRIVE-SCORE-LEG2-001. FR-4 (>0 measured legs positive control) re-keys to those follow-ons. This SD completion does NOT claim any leg wiring; leg4_capacity stays fail-closed pending APPLY-STATE-002.';
+const success_criteria = [
+  { criterion: 'FR-2: aggregate denominator reads 3 legs / 6 points, SPEC_LEG_COUNT derived from the frozen DRIVE_SCORE_LEGS SSOT, with Adam d50b9f12 + coordinator ac704cbd provenance inline; the placeholder NOT-RATIFIED/X8 wording is gone', measure: 'SPEC_LEG_COUNT===3 derived from DRIVE_SCORE_LEGS; aggregate.test.js asserts the ratified denominator LITERALLY (/X\/6/, not the prior self-referential constant) + the provenance tokens' },
+  { criterion: 'FR-3: a leg minted without a ratified_by marker, or a produced/SSOT leg-set drift, fails CI loudly', measure: 'assertLegSetRatified throws on a phantom (positive control); assertProducedLegsMatchSSOT fails bidirectionally; the ratified set passes — two-sided in drive-score-legs.test.js' },
+  { criterion: 'Leg INPUT wiring is split out and NOT claimed by this SD: leg1 -> SD-LEO-INFRA-DRIVE-SCORE-LEG1-001, leg2 -> SD-LEO-INFRA-DRIVE-SCORE-LEG2-001; FR-4 (>0 measured legs) re-keys to those follow-ons', measure: 'SD text + metadata name both follow-ons; leg1/leg2/leg4 remain in unavailable_legs with reasons' },
+];
+const metadata = { ...cur.metadata,
+  split_completion_ruling: '8280af5a (Option A SPLIT): FR-2/FR-3 land as this SD completion; leg2 snapshot -> SD-LEO-INFRA-DRIVE-SCORE-LEG2-001, leg1 -> SD-LEO-INFRA-DRIVE-SCORE-LEG1-001; FR-4 re-keyed to follow-ons',
+  leg1_split_followon: 'SD-LEO-INFRA-DRIVE-SCORE-LEG1-001',
+  leg2_split_followon: 'SD-LEO-INFRA-DRIVE-SCORE-LEG2-001',
+  fr4_rekeyed: 'FR-4 (>0 measured legs positive control) is delivered by the leg-wiring follow-ons, not this denominator-ratification SD',
+};
+const { error } = await s.from('strategic_directives_v2').update({ scope, success_criteria, metadata }).eq('sd_key',SD);
+if(error){console.error(error);process.exit(1);}
+console.log('re-keyed: FR-2/FR-3 completion; leg2 split to SD-LEO-INFRA-DRIVE-SCORE-LEG2-001');

--- a/lib/drive-loop/score/aggregate.js
+++ b/lib/drive-loop/score/aggregate.js
@@ -12,12 +12,13 @@
  * legs that actually measured. FR-7's fail-loud posture is only worth having if the aggregate
  * honours it; a fail-loud leg feeding a fail-soft sum is a fail-soft system.
  *
- * ── THE DENOMINATOR IS EMITTED, NEVER ASSUMED ─────────────────────────────────────────────
- * The spec says X/8 over four legs. Only three legs exist (measured: "leg 3" appears zero times in
- * the SD or the PRD, against three mentions of leg 1 and four of leg 4). So a hard-coded 8 would be
- * a lie today, and a hard-coded 6 would silently ratify a three-leg design nobody approved. The
- * denominator is computed from the legs actually supplied and stated in the emission, so a reader
- * always knows what the score is out of and can see when that changes.
+ * ── THE DENOMINATOR IS EMITTED, NEVER ASSUMED — AND NOW RATIFIED ──────────────────────────
+ * The score is still computed from the legs actually supplied (measured.length * POINTS_PER_LEG),
+ * so a reader always knows what it is out of. What changed (SD-LEO-INFRA-DRIVE-SCORE-DENOMINATOR-001,
+ * FR-2): the SPEC leg count is no longer a bare `4` that admitted itself a placeholder. It is
+ * DERIVED from the frozen DRIVE_SCORE_LEGS SSOT (= 3, ratified 3 legs / 6 points per Adam ruling
+ * d50b9f12, coordinator scope ac704cbd). A leg cannot silently join the set — the SSOT's
+ * ratified-marker rule + the guard test make a phantom leg a loud CI failure (drive-score-legs.js).
  *
  * ── CHAIRMAN DECISION LATENCY SITS BESIDE THE SCORE, UNGRADED ─────────────────────────────
  * Option A, ratified (SMS row 5d90338c, and the migration says so at :37). It is reported and never
@@ -27,8 +28,10 @@
 
 import { cite } from '../citation.js';
 import { isAvailable } from '../report-posture.js';
+import { SPEC_LEG_COUNT as RATIFIED_LEG_COUNT, RATIFICATION } from './drive-score-legs.js';
 
-export const SPEC_LEG_COUNT = 4;
+// DERIVED from the frozen SSOT (drive-score-legs.js), never a bare literal. = 3 (ratified).
+export const SPEC_LEG_COUNT = RATIFIED_LEG_COUNT;
 export const POINTS_PER_LEG = 2;
 
 /**
@@ -70,10 +73,12 @@ export function aggregateScore({ legs = [], decisionLatency = null } = {}) {
         + `${earned}/${possible} from a stalled fleet and one from broken instruments are the same `
         + 'number and opposite claims. Legs citing no rows (leg 4, by FR-2 design) contribute no '
         + 'row_ids and that is not a missing grain',
-      limitation: `THE DENOMINATOR IS NOT RATIFIED. The spec says X/${SPEC_LEG_COUNT * POINTS_PER_LEG} `
-        + `over ${SPEC_LEG_COUNT} legs, but only 3 legs are defined anywhere in the SD or PRD `
-        + '(measured: "leg 3" appears zero times). This total is over the legs actually supplied, '
-        + 'and the per-leg earning rules are likewise placeholders pending a ruling',
+      limitation: `Denominator RATIFIED at ${SPEC_LEG_COUNT} legs / ${SPEC_LEG_COUNT * POINTS_PER_LEG} `
+        + `points (Adam ruling ${RATIFICATION.ruling}, coordinator scope ${RATIFICATION.scope_ruling}): `
+        + 'the smallest-honest denominator over the legs actually defined. A new leg is an explicit '
+        + 'chairman-surfaced spec change (drive-score-legs.js ratified-marker rule), never a silent '
+        + 'widening. This run scores over the legs that MEASURED; unavailable legs are excluded, not '
+        + 'zeroed. UPTAKE_THRESHOLD (leg2) remains provisional/injectable, not ratified by this SD',
       source: 'lib/drive-loop/score/aggregate.js aggregateScore',
     }),
     possible,

--- a/lib/drive-loop/score/drive-score-legs.js
+++ b/lib/drive-loop/score/drive-score-legs.js
@@ -90,3 +90,10 @@ export function assertProducedLegsMatchSSOT(producedLegIds) {
     );
   }
 }
+
+// RUNTIME ENFORCEMENT, not test-only (SECURITY dda6a9b4). The docstring promises the invariant is
+// "enforced eagerly" — so it is: importing this SSOT runs the ratified-marker check, and a phantom
+// leg (a member added without a ratification token) throws at module load, in production, not only
+// under CI. On the shipped, ratified set this is a no-op; it only fires if the set is corrupted —
+// which is exactly the fail-loud FR-3 exists to guarantee.
+assertLegSetRatified();

--- a/lib/drive-loop/score/drive-score-legs.js
+++ b/lib/drive-loop/score/drive-score-legs.js
@@ -1,0 +1,92 @@
+/**
+ * DRIVE-SCORE LEG SET — the single source of truth for which legs the denominator is over.
+ * SD-LEO-INFRA-DRIVE-SCORE-DENOMINATOR-001 (FR-2 + FR-3).
+ *
+ * WHY THIS FILE EXISTS. Before this SD the leg count lived as a bare `SPEC_LEG_COUNT = 4` in
+ * aggregate.js while only three legs were ever defined — a number nobody ratified, sitting next
+ * to a limitation string that admitted it was a placeholder. A bare constant can be edited to 5
+ * in one commit and nothing notices; the denominator silently widens and every historical score
+ * re-bases. So the leg set is now a FROZEN SSOT and the count is DERIVED from it, and adding a leg
+ * is made loud by construction (see the ratified-marker rule below and the guard test that pins
+ * the produced leg-id set against this list).
+ *
+ * THE RATIFIED-MARKER RULE (FR-3). Every leg carries a `ratified_by` provenance token. The
+ * denominator is "the legs actually ratified", so a leg WITHOUT a ratified_by is a phantom — it
+ * cannot silently join the set, because assertLegSetRatified() throws on it. Minting a new leg is
+ * therefore an EXPLICIT spec change: add the leg here WITH a chairman-surfaced ratification token,
+ * or CI fails. This is the same anti-drift idiom the drive-report lanes use (a frozen SSOT the
+ * tests hold equal to the code that consumes it), applied to the leg vocabulary.
+ *
+ * RATIFICATION PROVENANCE. Adam ruling d50b9f12 (the chairman-accepted Drive-Loop A-review
+ * verdict, delegated lane per CLAUDE_ADAM.md 4b): the interim denominator is the SMALLEST HONEST
+ * one — the legs actually defined, 3 legs / 6 points. Any future leg mint (including reviving the
+ * long-absent "leg 3") is an explicit spec change surfaced to the chairman, never a silent
+ * widening. Coordinator scope ruling ac704cbd narrowed this SD's wiring to leg2; leg1's git-runner
+ * CI work is split to SD-LEO-INFRA-DRIVE-SCORE-LEG1-001. leg4_capacity is ratified but stays
+ * fail-closed until belt_capacity_verdicts applies (APPLY-STATE-002).
+ */
+
+/** The ratification token for this SD's denominator — the chairman-accepted Adam ruling. A leg
+ *  minted later must carry its OWN token (a new ruling / SMS row), never reuse this one blindly. */
+export const RATIFICATION = Object.freeze({
+  ruling: 'd50b9f12',
+  scope_ruling: 'ac704cbd',
+  note: 'smallest-honest denominator: the legs actually defined (3 legs / 6 points). A new leg is an explicit chairman-surfaced spec change.',
+});
+
+/**
+ * The ratified legs, frozen. Order is the emission order. Each carries a ratified_by marker;
+ * a leg without one is a phantom (assertLegSetRatified throws).
+ */
+export const DRIVE_SCORE_LEGS = Object.freeze([
+  Object.freeze({ id: 'leg1_landed', ratified_by: RATIFICATION.ruling }),
+  Object.freeze({ id: 'leg2_uptake', ratified_by: RATIFICATION.ruling }),
+  Object.freeze({ id: 'leg4_capacity', ratified_by: RATIFICATION.ruling }),
+]);
+
+/** The ratified leg ids, frozen — the population the produced report is pinned against (FR-3). */
+export const RATIFIED_LEG_IDS = Object.freeze(DRIVE_SCORE_LEGS.map((l) => l.id));
+
+/** The denominator's leg count, DERIVED from the SSOT — never a bare literal. = 3 (ratified). */
+export const SPEC_LEG_COUNT = DRIVE_SCORE_LEGS.length;
+
+/**
+ * Assert the leg set is fully ratified — every leg carries a ratified_by marker. Throws loudly on
+ * a phantom (a leg minted without an explicit ratification token). Called by the guard test and
+ * safe to call at import time by consumers that want the invariant enforced eagerly.
+ * @param {ReadonlyArray<{id:string, ratified_by?:string}>} [legs]
+ * @returns {ReadonlyArray<string>} the ratified ids
+ */
+export function assertLegSetRatified(legs = DRIVE_SCORE_LEGS) {
+  const phantoms = legs.filter((l) => !l || typeof l.ratified_by !== 'string' || l.ratified_by.trim() === '');
+  if (phantoms.length) {
+    throw new Error(
+      'DRIVE_SCORE_LEG_UNRATIFIED: ' + phantoms.map((p) => p?.id ?? '(unnamed)').join(', ') +
+      ' — a leg has no ratified_by marker. Minting a leg is an EXPLICIT spec change: add a ' +
+      'chairman-surfaced ratification token (a ruling/SMS row), never a silent denominator widening.'
+    );
+  }
+  return Object.freeze(legs.map((l) => l.id));
+}
+
+/**
+ * Assert the leg-id set a producer actually emitted matches the ratified SSOT — bidirectionally.
+ * A produced leg NOT in the SSOT is an unratified phantom; an SSOT leg the producer never emits is
+ * a dropped leg. Either fails loud (FR-3). This is the pin the guard test runs against buildGather.
+ * @param {ReadonlyArray<string>} producedLegIds
+ */
+export function assertProducedLegsMatchSSOT(producedLegIds) {
+  const ratified = new Set(RATIFIED_LEG_IDS);
+  const produced = new Set(producedLegIds);
+  const phantom = [...produced].filter((id) => !ratified.has(id));
+  const dropped = [...ratified].filter((id) => !produced.has(id));
+  if (phantom.length || dropped.length) {
+    throw new Error(
+      'DRIVE_SCORE_LEG_SET_DRIFT: ' +
+      (phantom.length ? `unratified leg(s) produced: ${phantom.join(', ')}. ` : '') +
+      (dropped.length ? `ratified leg(s) not produced: ${dropped.join(', ')}. ` : '') +
+      'The produced leg set must equal DRIVE_SCORE_LEGS. Adding a leg is an explicit spec change ' +
+      '(update the SSOT with a ratification token); dropping one is a regression.'
+    );
+  }
+}

--- a/tests/unit/drive-loop/score/aggregate.test.js
+++ b/tests/unit/drive-loop/score/aggregate.test.js
@@ -46,12 +46,20 @@ describe('aggregate — an unavailable leg is not a zero leg', () => {
     expect(r.unavailable_legs.map((u) => u.leg)).toEqual(['b', 'c']);
   });
 
-  it('states the denominator and its non-ratification in the emission', () => {
+  it('[FR-2] states the RATIFIED denominator (3 legs / 6 points) with provenance — literally, not tautologically', () => {
+    // SD-LEO-INFRA-DRIVE-SCORE-DENOMINATOR-001: the prior assertion read `X/${SPEC_LEG_COUNT*POINTS_PER_LEG}`
+    // — the SAME expression the source emits from the SAME imported constant, so it stayed green in
+    // lockstep and pinned nothing. Assert the ratified values LITERALLY instead, plus the derived count.
     const r = aggregateScore({ legs: [leg('a', 2)] });
+    expect(SPEC_LEG_COUNT).toBe(3);                 // derived from the frozen DRIVE_SCORE_LEGS SSOT
+    expect(SPEC_LEG_COUNT * POINTS_PER_LEG).toBe(6);
     expect(r.score.predicate).toMatch(/out of 2/);
     expect(r.score.predicate).toMatch(/UNAVAILABLE LEGS ARE EXCLUDED FROM THE DENOMINATOR/);
-    expect(r.score.limitation).toMatch(/DENOMINATOR IS NOT RATIFIED/);
-    expect(r.score.limitation).toMatch(new RegExp(`X/${SPEC_LEG_COUNT * POINTS_PER_LEG}`));
+    expect(r.score.limitation).toMatch(/RATIFIED at 3 legs \/ 6 points/);
+    expect(r.score.limitation).toMatch(/d50b9f12/);            // Adam ruling provenance
+    expect(r.score.limitation).toMatch(/ac704cbd/);            // coordinator scope provenance
+    expect(r.score.limitation).not.toMatch(/NOT RATIFIED/);    // the placeholder wording is gone
+    expect(r.score.limitation).not.toMatch(/X\/8/);
   });
 
   it('unions row_ids, and a leg citing NONE is not treated as a gap', () => {

--- a/tests/unit/drive-loop/score/drive-score-legs.test.js
+++ b/tests/unit/drive-loop/score/drive-score-legs.test.js
@@ -1,0 +1,58 @@
+/**
+ * SD-LEO-INFRA-DRIVE-SCORE-DENOMINATOR-001 FR-3 — the leg set cannot silently grow.
+ *
+ * Two-sided throughout, with a positive control: a guard that can never observe a plant is a
+ * guard that proves nothing. Each assertion first shows the guard FIRING on a seeded violation,
+ * then shows the ratified set PASSING — so a future edit that neuters the guard turns this red.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  DRIVE_SCORE_LEGS, RATIFIED_LEG_IDS, SPEC_LEG_COUNT, RATIFICATION,
+  assertLegSetRatified, assertProducedLegsMatchSSOT,
+} from '../../../../lib/drive-loop/score/drive-score-legs.js';
+
+describe('DRIVE_SCORE_LEGS — the ratified SSOT', () => {
+  it('is exactly the three defined legs, frozen, and SPEC_LEG_COUNT is derived from it', () => {
+    expect(RATIFIED_LEG_IDS).toEqual(['leg1_landed', 'leg2_uptake', 'leg4_capacity']);
+    expect(SPEC_LEG_COUNT).toBe(3);
+    expect(SPEC_LEG_COUNT).toBe(DRIVE_SCORE_LEGS.length); // derived, not a bare literal
+    expect(Object.isFrozen(DRIVE_SCORE_LEGS)).toBe(true);
+    expect(DRIVE_SCORE_LEGS.every((l) => Object.isFrozen(l))).toBe(true);
+  });
+
+  it('every ratified leg carries a ratified_by marker (the spec-change token)', () => {
+    for (const l of DRIVE_SCORE_LEGS) expect(l.ratified_by).toBe(RATIFICATION.ruling);
+  });
+});
+
+describe('FR-3 assertLegSetRatified — a phantom leg (no marker) fails loud', () => {
+  it('[POSITIVE CONTROL] fires on a leg minted WITHOUT a ratified_by marker', () => {
+    const withPhantom = [...DRIVE_SCORE_LEGS, { id: 'leg3_phantom' }]; // no ratified_by
+    expect(() => assertLegSetRatified(withPhantom)).toThrow(/DRIVE_SCORE_LEG_UNRATIFIED[\s\S]*leg3_phantom/);
+    // empty-string marker is also a phantom
+    expect(() => assertLegSetRatified([{ id: 'x', ratified_by: '  ' }])).toThrow(/UNRATIFIED/);
+  });
+
+  it('[NEGATIVE CONTROL] passes on the ratified set, and on a NEW leg added WITH a marker', () => {
+    expect(assertLegSetRatified()).toEqual(RATIFIED_LEG_IDS); // the shipped set
+    // Minting is legitimate ONLY as an explicit spec change — a leg WITH a ratification token.
+    const withMintedLeg = [...DRIVE_SCORE_LEGS, { id: 'leg3_revived', ratified_by: 'future-ruling-abc' }];
+    expect(assertLegSetRatified(withMintedLeg)).toContain('leg3_revived');
+  });
+});
+
+describe('FR-3 assertProducedLegsMatchSSOT — the produced set is pinned to the SSOT bidirectionally', () => {
+  it('[POSITIVE CONTROL] an unratified leg in the produced set fails loud', () => {
+    expect(() => assertProducedLegsMatchSSOT([...RATIFIED_LEG_IDS, 'leg5_snuck_in']))
+      .toThrow(/DRIVE_SCORE_LEG_SET_DRIFT[\s\S]*unratified leg\(s\) produced: leg5_snuck_in/);
+  });
+
+  it('[POSITIVE CONTROL] a ratified leg dropped from the produced set fails loud', () => {
+    expect(() => assertProducedLegsMatchSSOT(['leg1_landed', 'leg2_uptake'])) // leg4 dropped
+      .toThrow(/DRIVE_SCORE_LEG_SET_DRIFT[\s\S]*not produced: leg4_capacity/);
+  });
+
+  it('[NEGATIVE CONTROL] the exact ratified set passes (order-independent)', () => {
+    expect(() => assertProducedLegsMatchSSOT(['leg4_capacity', 'leg1_landed', 'leg2_uptake'])).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
Ratifies the chairman drive-score denominator and makes the leg set unable to silently grow. This SD was SPLIT (coordinator ruling 8280af5a) to its namesake — the ratified denominator + guard — with leg INPUT wiring moved to follow-ons.

- **FR-2**: new frozen `lib/drive-loop/score/drive-score-legs.js` SSOT (the 3 defined legs, each carrying a `ratified_by` marker); `SPEC_LEG_COUNT` is now DERIVED from it (was a bare `4` that admitted itself a placeholder). `aggregate.js`'s limitation string flips from 'NOT RATIFIED / X/8' to 'RATIFIED at 3 legs / 6 points' with Adam ruling `d50b9f12` + coordinator `ac704cbd` provenance. Per Adam's chairman-accepted ruling: the smallest-honest denominator; a new leg is an explicit chairman-surfaced spec change.
- **FR-3**: `assertLegSetRatified` / `assertProducedLegsMatchSSOT` make a phantom leg (no ratification marker) or a produced/SSOT drift a loud failure — enforced at **runtime** (import-time assertion), not CI-only (SECURITY hardening dda6a9b4).
- Replaced the **tautological** aggregate denominator test (asserted the same constant the source emits) with a literal `/X\/6/` + `expect(SPEC_LEG_COUNT).toBe(3)`.

## Split follow-ons (leg INPUT wiring — NOT claimed here)
- leg1_landed git-runner CI cron → **SD-LEO-INFRA-DRIVE-SCORE-LEG1-001**
- leg2_uptake prior-report top-5 snapshot → **SD-LEO-INFRA-DRIVE-SCORE-LEG2-001** (the live dispatch_rank clears on claim, structurally excluding leg2's own numerator — the adding-to-an-exclusion-set class)

## Gate evidence
- LEAD: VALIDATION 977b3213 (CONDITIONAL_PASS 90), prospective TESTING ab188d12
- PLAN: TESTING 29e84896 (PASS 88, baseline 269)
- EXEC: TESTING 73e6836c (PASS 95, both mutation probes went red), SECURITY dda6a9b4 (PASS 92)

## Test plan
- [x] `npx vitest run --project unit tests/unit/drive-loop/` — 18 files, 231 tests pass
- [x] Mutation-verified: reverting SPEC_LEG_COUNT to 4 or neutering the guard turns the suite red
- [x] Split state honest: leg1/leg2/leg4 stay unavailable; measured_legs empty until the follow-ons wire them

🤖 Generated with [Claude Code](https://claude.com/claude-code)