### PR TITLE
feat(SD-LEO-INFRA-QUIET-HOURS-GATE-001): quiet-hours gate honors measured chairman presence for reply-to-inbound

### DIFF
--- a/lib/comms/adam-outbound/chairman-sms-gate/index.js
+++ b/lib/comms/adam-outbound/chairman-sms-gate/index.js
@@ -28,6 +28,7 @@
  */
 
 import { evaluate as defaultEvaluate, effectiveType } from '../rubric-engine/index.js';
+import { inQuietHours } from '../rubric-engine/lint.js';
 
 /**
  * Private Twilio-sender factory. The ONLY place credentials are read. Not exported — callers
@@ -196,7 +197,7 @@ async function evalOverAsk(message, context, opts) {
  * The sole chairman-SMS send path.
  * @param {object} message - the message (see rubric-engine evaluate() shape)
  * @param {object} context - rubric context (quiet-hours, rate cap, chairmanInitiated?)
- * @param {object} opts - { sender?, evaluate?, console?, fallbackSend?, classifyOverAsk?, overAskAttested? } injectable seams
+ * @param {object} opts - { sender?, evaluate?, console?, fallbackSend?, classifyOverAsk?, overAskAttested?, presenceResolver?, presenceResolverOpts? } injectable seams
  * @returns {Promise<{sent:boolean, held?:boolean, routedToConsole?:boolean, transportFailed?:boolean, fallbackFired?:boolean, reason:string, verdict?:string, authorityClass?:string, blockedReasons?:string[], overAsk?:boolean}>}
  */
 export async function sendChairmanSMS(message = {}, context = {}, opts = {}) {
@@ -205,6 +206,38 @@ export async function sendChairmanSMS(message = {}, context = {}, opts = {}) {
   const fallbackSend = typeof opts.fallbackSend === 'function' ? opts.fallbackSend : defaultFallbackSend;
   const log = opts.console || console;
   const isDecision = effectiveType(message) === 'decision'; // classifier hardening (FR-4)
+
+  // SD-LEO-INFRA-QUIET-HOURS-GATE-001: measured-presence reply window. Consulted ONLY when the
+  // caller declares a reply-class send (context.replyToInbound === true), no allowance is already
+  // in force, and the send is inside the quiet window — daytime and unsolicited paths take zero
+  // new code. On a measured grant (chairman inbound within the trailing window, read from
+  // sms_relay_staging by the resolver — never self-attested), the context gains
+  // allowQuietHours + quietHoursAllowReason='measured_presence_reply', and the message gains a
+  // dedupeKey riding the durable obligation upsert (onConflict dedupe_key, ignoreDuplicates) so
+  // ONE granting inbound row licenses at most ONE reply. Fail-closed: any resolver error or an
+  // unreadable window leaves the context untouched and the send blocks exactly as pre-SD.
+  if (context.replyToInbound === true && !context.allowQuietHours) {
+    try {
+      if (inQuietHours(context)) {
+        const resolvePresence = typeof opts.presenceResolver === 'function'
+          ? opts.presenceResolver
+          : (await import('../presence-reply-window.js')).resolvePresenceReplyWindow;
+        const presence = await resolvePresence(
+          context.now instanceof Date || Number.isFinite(context.now) ? context.now : Date.now(),
+          opts.presenceResolverOpts || {},
+        );
+        if (presence && presence.allowed === true && presence.grantRowId) {
+          context = { ...context, allowQuietHours: true, quietHoursAllowReason: presence.reason || 'measured_presence_reply' };
+          message = { ...message, dedupeKey: message.dedupeKey || `presence_reply:${presence.grantRowId}` };
+          log.warn(`[chairman-sms-gate] quiet-hours reply allowed by measured presence (grant ${presence.grantRowId}, inbound ${presence.grantReceivedAt || 'n/a'})`);
+        }
+      }
+    } catch (err) {
+      // inQuietHours throws without a usable clock — same condition makes evaluate() throw below,
+      // so behavior stays byte-identical to pre-SD; resolver errors land here too (fail-closed).
+      log.warn(`[chairman-sms-gate] presence reply-window unavailable, quiet-hours unchanged (fail-closed): ${err.message}`);
+    }
+  }
 
   // QF-20260725-652: over-ask gate — runs BEFORE the rubric gate, mirroring how adam-advisory.cjs
   // runs the Adam Outbound Gate before dispatch. HELD (not sent) when the ask was Adam's to execute.

--- a/lib/comms/adam-outbound/presence-reply-window.js
+++ b/lib/comms/adam-outbound/presence-reply-window.js
@@ -1,0 +1,83 @@
+/**
+ * Measured chairman-presence reply window — SD-LEO-INFRA-QUIET-HOURS-GATE-001.
+ *
+ * The quiet-hours lint (rubric-engine/lint.js check 7) takes context.allowQuietHours as a pure
+ * input; quiet-hours-extension.js supplies it from a durable chairman_preferences row (explicit
+ * verbal authorization). This module supplies the SECOND, measured source: the chairman texted
+ * within the trailing window, so a REPLY to him is not an intrusion — CLAUDE_ADAM.md 5g and the
+ * PRESENCE>QUIET ruling, witnessed as a live defect 2026-08-09 (~10:25pm ET ack held to the 6am
+ * flush). decision-scheduler/index.js pre-registered this exact signal as a future enhancement.
+ *
+ * Presence is MEASURED from sms_relay_staging (the inbound-only staging table written solely by
+ * the relay RPC), never self-attested by a caller. Fail-closed throughout, mirroring
+ * quiet-hours-extension.js: unset CHAIRMAN_PHONE, a query error, or no matching row all return
+ * { allowed: false } — only positive, measured evidence opens the window, and the caller
+ * (chairman-sms-gate) applies it to reply-class sends only.
+ *
+ * Phone matching uses the shared phoneKey normalizer (digits, last 10) — provider from_phone
+ * formats drift (country codes, spacing), and adam-quiet-tick.mjs pins raw equality as
+ * label-grade only. For this gate the no-match failure direction is safe (no bypass), but the
+ * normalizer is what keeps the feature functional across formats.
+ */
+
+import { phoneKey } from '../../solomon/chairman-sms-exchanges.js';
+
+export const PRESENCE_WINDOW_MINUTES = 15;
+
+/**
+ * Resolve whether a chairman inbound message within the trailing window grants a one-reply
+ * quiet-hours allowance.
+ *
+ * @param {Date|number} now - current time (Date or finite epoch ms, matching the etHour convention)
+ * @param {object} [opts]
+ * @param {object} [opts.supabase] - injectable client (tests); defaults to a service-role client from env
+ * @param {string} [opts.chairmanPhone] - injectable identity (tests); defaults to CHAIRMAN_PHONE
+ * @param {number} [opts.windowMinutes] - trailing window; defaults to PRESENCE_WINDOW_MINUTES
+ * @returns {Promise<{allowed: boolean, reason: string, grantRowId?: string, grantReceivedAt?: string}>}
+ */
+export async function resolvePresenceReplyWindow(now, opts = {}) {
+  try {
+    const nowMs = now instanceof Date ? now.getTime()
+      : (typeof now === 'number' && Number.isFinite(now)) ? now
+        : NaN;
+    if (!Number.isFinite(nowMs)) return { allowed: false, reason: 'invalid_now' };
+
+    const chairmanPhone = opts.chairmanPhone ?? process.env.CHAIRMAN_PHONE;
+    if (!chairmanPhone) return { allowed: false, reason: 'no_chairman_phone' };
+    const want = phoneKey(chairmanPhone);
+    if (!want) return { allowed: false, reason: 'no_chairman_phone' };
+
+    const windowMinutes = Number.isFinite(opts.windowMinutes) ? opts.windowMinutes : PRESENCE_WINDOW_MINUTES;
+
+    let supabase = opts.supabase;
+    if (!supabase) {
+      const { createClient } = await import('@supabase/supabase-js');
+      supabase = createClient(
+        process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
+        process.env.SUPABASE_SERVICE_ROLE_KEY,
+      );
+    }
+
+    const sinceIso = new Date(nowMs - windowMinutes * 60_000).toISOString();
+    const { data, error } = await supabase
+      .from('sms_relay_staging')
+      .select('id, from_phone, received_at')
+      .gte('received_at', sinceIso)
+      .order('received_at', { ascending: false })
+      .limit(50);
+    if (error) return { allowed: false, reason: `query_error: ${error.message}` };
+
+    const grant = (data || []).find((r) => phoneKey(r.from_phone) === want);
+    if (!grant) return { allowed: false, reason: 'no_recent_chairman_inbound' };
+
+    return {
+      allowed: true,
+      reason: 'measured_presence_reply',
+      grantRowId: grant.id,
+      grantReceivedAt: grant.received_at,
+    };
+  } catch (err) {
+    // Fail-closed: a resolver failure must land exactly on pre-SD behavior (the send blocks).
+    return { allowed: false, reason: `resolver_error: ${err?.message || err}` };
+  }
+}

--- a/lib/comms/adam-outbound/rubric-engine/lint.js
+++ b/lib/comms/adam-outbound/rubric-engine/lint.js
@@ -130,8 +130,14 @@ export function lint(message = {}, context = {}) {
   add('no_secrets', secrets.length === 0, true, secrets.length === 0 ? 'ok' : `secret(s) detected: ${secrets.join(', ')}`);
 
   // 7. quiet hours (all, unless explicitly allowed e.g. a ratified heartbeat schedule)
-  const quiet = inQuietHours(context) && !context.allowQuietHours;
-  add('quiet_hours', !quiet, true, quiet ? 'within 22:00-06:00 ET quiet window' : 'ok');
+  // SD-LEO-INFRA-QUIET-HOURS-GATE-001: when a window send IS allowed, the detail names WHY
+  // (context.quietHoursAllowReason, e.g. 'measured_presence_reply') so a passed reply is
+  // auditable. Predicate shape unchanged; daytime and blocked paths byte-identical.
+  const inWindow = inQuietHours(context);
+  const quiet = inWindow && !context.allowQuietHours;
+  const allowReason = typeof context.quietHoursAllowReason === 'string' && context.quietHoursAllowReason
+    ? context.quietHoursAllowReason : 'allowed';
+  add('quiet_hours', !quiet, true, quiet ? 'within 22:00-06:00 ET quiet window' : inWindow ? `ok (${allowReason})` : 'ok');
 
   // 8. rate cap (all, when the caller supplies window state)
   if (Number.isInteger(context.rateCap)) {

--- a/tests/unit/comms/adam-outbound/presence-reply-window.test.js
+++ b/tests/unit/comms/adam-outbound/presence-reply-window.test.js
@@ -1,0 +1,218 @@
+/**
+ * SD-LEO-INFRA-QUIET-HOURS-GATE-001 — measured chairman-presence reply window.
+ *
+ * Covers the resolver (window predicate, phone normalization, fail-closed edges), the
+ * chokepoint wiring in sendChairmanSMS (reply-class-only consultation, once-per-grant
+ * dedupeKey, preference-path independence), and the lint's reason-aware quiet_hours detail.
+ *
+ * Mock doctrine (from tests/unit/adam/adam-quiet-tick-sms-inbound.test.js): the supabase mock
+ * APPLIES the gte filter so the test observes the resolver's predicate, not a pre-filtered
+ * fixture. CHAIRMAN_PHONE is saved/restored around every case that touches it.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { resolvePresenceReplyWindow, PRESENCE_WINDOW_MINUTES } from '../../../../lib/comms/adam-outbound/presence-reply-window.js';
+import { sendChairmanSMS } from '../../../../lib/comms/adam-outbound/chairman-sms-gate/index.js';
+import { lint } from '../../../../lib/comms/adam-outbound/rubric-engine/lint.js';
+
+const NOW = Date.parse('2026-08-10T03:25:00Z'); // 23:25 ET on 2026-08-09 (inside 22:00-06:00)
+
+/** A supabase mock whose query builder APPLIES the received_at >= gte filter. */
+function makeStagingMock(rows, { error = null } = {}) {
+  const calls = { gte: null, table: null };
+  const builder = (table) => {
+    calls.table = table;
+    const state = { gteCol: null, gteVal: null };
+    const chain = {
+      select: () => chain,
+      gte: (col, val) => { state.gteCol = col; state.gteVal = val; calls.gte = { col, val }; return chain; },
+      order: () => chain,
+      limit: () => Promise.resolve(
+        error
+          ? { data: null, error }
+          : {
+            data: rows.filter((r) => !state.gteVal || r.received_at >= state.gteVal),
+            error: null,
+          },
+      ),
+    };
+    return chain;
+  };
+  return { from: vi.fn(builder), calls };
+}
+
+const minutesAgo = (n) => new Date(NOW - n * 60_000).toISOString();
+
+describe('resolvePresenceReplyWindow()', () => {
+  const savedPhone = process.env.CHAIRMAN_PHONE;
+  beforeEach(() => { process.env.CHAIRMAN_PHONE = '5551234567'; });
+  afterEach(() => {
+    if (savedPhone === undefined) delete process.env.CHAIRMAN_PHONE;
+    else process.env.CHAIRMAN_PHONE = savedPhone;
+  });
+
+  it('grants on a chairman inbound row inside the trailing window', async () => {
+    const sb = makeStagingMock([{ id: 'row-1', from_phone: '5551234567', received_at: minutesAgo(10) }]);
+    const res = await resolvePresenceReplyWindow(NOW, { supabase: sb });
+    expect(res.allowed).toBe(true);
+    expect(res.reason).toBe('measured_presence_reply');
+    expect(res.grantRowId).toBe('row-1');
+    expect(sb.calls.table).toBe('sms_relay_staging');
+    // The predicate is the resolver's, observed through the applied filter:
+    expect(Date.parse(sb.calls.gte.val)).toBe(NOW - PRESENCE_WINDOW_MINUTES * 60_000);
+  });
+
+  it('refuses when the only chairman row is OUTSIDE the window (filter applied, not fixture-trimmed)', async () => {
+    const sb = makeStagingMock([{ id: 'row-old', from_phone: '5551234567', received_at: minutesAgo(20) }]);
+    const res = await resolvePresenceReplyWindow(NOW, { supabase: sb });
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toBe('no_recent_chairman_inbound');
+  });
+
+  it('matches across provider format drift via phoneKey normalization', async () => {
+    const sb = makeStagingMock([{ id: 'row-fmt', from_phone: '+1 (555) 123-4567', received_at: minutesAgo(5) }]);
+    const res = await resolvePresenceReplyWindow(NOW, { supabase: sb });
+    expect(res.allowed).toBe(true);
+    expect(res.grantRowId).toBe('row-fmt');
+  });
+
+  it('ignores non-chairman inbound rows inside the window', async () => {
+    const sb = makeStagingMock([{ id: 'row-other', from_phone: '9998887777', received_at: minutesAgo(2) }]);
+    const res = await resolvePresenceReplyWindow(NOW, { supabase: sb });
+    expect(res.allowed).toBe(false);
+  });
+
+  it('is inert (fail-closed) when CHAIRMAN_PHONE is unset, even with matching rows', async () => {
+    delete process.env.CHAIRMAN_PHONE;
+    const sb = makeStagingMock([{ id: 'row-1', from_phone: '5551234567', received_at: minutesAgo(1) }]);
+    const res = await resolvePresenceReplyWindow(NOW, { supabase: sb });
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toBe('no_chairman_phone');
+    expect(sb.from).not.toHaveBeenCalled();
+  });
+
+  it('fails closed without throwing on a query error', async () => {
+    const sb = makeStagingMock([], { error: { message: 'relation is on fire' } });
+    const res = await resolvePresenceReplyWindow(NOW, { supabase: sb });
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toMatch(/query_error/);
+  });
+
+  it('fails closed on an unusable now', async () => {
+    const res = await resolvePresenceReplyWindow('not-a-clock', { supabase: makeStagingMock([]) });
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toBe('invalid_now');
+  });
+});
+
+describe('sendChairmanSMS() presence reply-window wiring', () => {
+  const QUIET_REPLY = { nowHourET: 23, rateCap: 10, sentInWindow: 0, replyToInbound: true };
+  const makeSender = () => ({ send: vi.fn(async () => ({ sid: 'SM-test' })) });
+  const silentConsole = { warn: vi.fn(), error: vi.fn(), log: vi.fn() };
+  const ACK = { type: 'status', body: 'ack: workers spinning up now — on it.' };
+  const grantResolver = (id = 'grant-1') => vi.fn(async () => ({
+    allowed: true, reason: 'measured_presence_reply', grantRowId: id, grantReceivedAt: minutesAgo(3),
+  }));
+  const refuseResolver = () => vi.fn(async () => ({ allowed: false, reason: 'no_recent_chairman_inbound' }));
+
+  it('TS-1: a reply within the presence window passes during quiet hours and carries the grant dedupeKey', async () => {
+    const sender = makeSender();
+    const presenceResolver = grantResolver('grant-1');
+    const res = await sendChairmanSMS(ACK, QUIET_REPLY, { sender, console: silentConsole, presenceResolver });
+    expect(res.sent).toBe(true);
+    expect(presenceResolver).toHaveBeenCalledTimes(1);
+    expect(sender.send).toHaveBeenCalledTimes(1);
+    expect(sender.send.mock.calls[0][0].dedupeKey).toBe('presence_reply:grant-1');
+  });
+
+  it('TS-2: a reply AFTER the window blocks with the standard quiet_hours finding', async () => {
+    const sender = makeSender();
+    const res = await sendChairmanSMS(ACK, QUIET_REPLY, { sender, console: silentConsole, presenceResolver: refuseResolver() });
+    expect(res.sent).toBe(false);
+    expect(res.held).toBe(true);
+    expect((res.blockedReasons || []).join(' ')).toMatch(/quiet_hours/);
+    expect(sender.send).not.toHaveBeenCalled();
+  });
+
+  it('TS-3: an unsolicited quiet-hours send never consults the resolver and stays blocked', async () => {
+    const sender = makeSender();
+    const presenceResolver = grantResolver();
+    const { replyToInbound: _omit, ...unsolicited } = QUIET_REPLY;
+    const res = await sendChairmanSMS(ACK, unsolicited, { sender, console: silentConsole, presenceResolver });
+    expect(res.sent).toBe(false);
+    expect(presenceResolver).not.toHaveBeenCalled();
+    expect(sender.send).not.toHaveBeenCalled();
+  });
+
+  it('TS-3b: a daytime reply never consults the resolver (no added latency outside the window)', async () => {
+    const sender = makeSender();
+    const presenceResolver = grantResolver();
+    const res = await sendChairmanSMS(ACK, { ...QUIET_REPLY, nowHourET: 14 }, { sender, console: silentConsole, presenceResolver });
+    expect(res.sent).toBe(true);
+    expect(presenceResolver).not.toHaveBeenCalled();
+  });
+
+  it('TS-4: the preference-extension path is untouched — allowQuietHours passes without the resolver', async () => {
+    const sender = makeSender();
+    const presenceResolver = grantResolver();
+    const ctx = { nowHourET: 23, rateCap: 10, sentInWindow: 0, allowQuietHours: true };
+    const res = await sendChairmanSMS(ACK, ctx, { sender, console: silentConsole, presenceResolver });
+    expect(res.sent).toBe(true);
+    expect(presenceResolver).not.toHaveBeenCalled();
+    expect(sender.send.mock.calls[0][0].dedupeKey).toBeUndefined();
+  });
+
+  it('TS-5: a throwing resolver fails closed to the pre-SD block', async () => {
+    const sender = makeSender();
+    const presenceResolver = vi.fn(async () => { throw new Error('staging unreachable'); });
+    const res = await sendChairmanSMS(ACK, QUIET_REPLY, { sender, console: silentConsole, presenceResolver });
+    expect(res.sent).toBe(false);
+    expect(res.held).toBe(true);
+    expect(sender.send).not.toHaveBeenCalled();
+  });
+
+  it('TS-6: once-per-grant — a second send on the same granting row carries the SAME dedupeKey (durable upsert dedupes downstream)', async () => {
+    const sender = makeSender();
+    const presenceResolver = grantResolver('grant-9');
+    await sendChairmanSMS(ACK, QUIET_REPLY, { sender, console: silentConsole, presenceResolver });
+    await sendChairmanSMS(ACK, QUIET_REPLY, { sender, console: silentConsole, presenceResolver });
+    const keys = sender.send.mock.calls.map((c) => c[0].dedupeKey);
+    expect(keys).toEqual(['presence_reply:grant-9', 'presence_reply:grant-9']);
+    // Uniqueness is enforced by enqueueChairmanSms' upsert (onConflict: 'dedupe_key',
+    // ignoreDuplicates: true — sms-bridge.js): the second identical key inserts nothing.
+  });
+
+  it('a caller-supplied dedupeKey is never overwritten by the presence grant', async () => {
+    const sender = makeSender();
+    const res = await sendChairmanSMS({ ...ACK, dedupeKey: 'caller-key' }, QUIET_REPLY, {
+      sender, console: silentConsole, presenceResolver: grantResolver('grant-2'),
+    });
+    expect(res.sent).toBe(true);
+    expect(sender.send.mock.calls[0][0].dedupeKey).toBe('caller-key');
+  });
+});
+
+describe('lint() quiet_hours reason-aware detail', () => {
+  const MSG = { type: 'status', body: 'ack: on it.' };
+
+  it('a window-allowed send names its reason in the finding detail', () => {
+    const { findings, blocked } = lint(MSG, { nowHourET: 23, allowQuietHours: true, quietHoursAllowReason: 'measured_presence_reply' });
+    expect(blocked).toBe(false);
+    const qh = findings.find((f) => f.check === 'quiet_hours');
+    expect(qh.ok).toBe(true);
+    expect(qh.detail).toBe('ok (measured_presence_reply)');
+  });
+
+  it('a window-allowed send without a reason reports the default', () => {
+    const { findings } = lint(MSG, { nowHourET: 23, allowQuietHours: true });
+    expect(findings.find((f) => f.check === 'quiet_hours').detail).toBe('ok (allowed)');
+  });
+
+  it('daytime detail and the blocked detail are byte-identical to pre-SD', () => {
+    const day = lint(MSG, { nowHourET: 14 });
+    expect(day.findings.find((f) => f.check === 'quiet_hours').detail).toBe('ok');
+    const night = lint(MSG, { nowHourET: 23 });
+    const qh = night.findings.find((f) => f.check === 'quiet_hours');
+    expect(qh.ok).toBe(false);
+    expect(qh.detail).toBe('within 22:00-06:00 ET quiet window');
+  });
+});


### PR DESCRIPTION
## Summary
- Witnessed defect (2026-08-09 ~10:25pm ET): the chairman texted and Adam's acknowledgment was HELD by the quiet-hours lint until the 6am flush — the lint accepted only the durable preference-extension override, so measured presence never reached it (CLAUDE_ADAM.md 5g + PRESENCE>QUIET ruling say inbound presence overrides the window).
- New `lib/comms/adam-outbound/presence-reply-window.js`: measures chairman inbound from `sms_relay_staging` (trailing 15 min, shared `phoneKey` normalization, fail-closed on unset `CHAIRMAN_PHONE` / query error / no match).
- Wired at the `sendChairmanSMS` chokepoint (the only `evaluate()` caller — covers all six senders uniformly), consulted ONLY for reply-class sends (new explicit `context.replyToInbound`) already inside the window with no allowance in force.
- A grant stamps `quietHoursAllowReason=measured_presence_reply` (visible in the lint finding) and rides the durable `dedupe_key` upsert (`presence_reply:<grantRowId>`) — one granting inbound row licenses at most ONE reply.
- Unsolicited sends and the `chairman_preferences` extension path are byte-identical (`quiet-hours-extension.js` zero diff); `lint.js:133` predicate shape unchanged (detail-only edit).
- Closes the presence gap pre-registered at `decision-scheduler/index.js:41-48`.

## Test plan
- [x] 18 new unit tests (resolver window/phone/fail-closed edges; chokepoint reply-class-only + once-per-grant + preference independence; lint reason detail)
- [x] All adjacent suites unmodified and green: rubric-engine (TS-5 quiet-hours block), quiet-hours-extension, chairman-sms-gate, gate-context — 54/54
- [x] SD smoke steps: baseline 11pm block → presence-reply pass with `ok (measured_presence_reply)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)