### PR TITLE
fix(SD-LEO-INFRA-TODOIST-YOUTUBE-ROADMAP-001): map title + refuse title-less mints at the roadmap promotion step, backfill the 1087

### DIFF
--- a/lib/roadmap/wave-item-row.js
+++ b/lib/roadmap/wave-item-row.js
@@ -1,0 +1,49 @@
+/**
+ * Build a roadmap_wave_items insert row from a clustered intake item — the ONE place the promotion
+ * step maps a title and refuses a title-less mint. SD-LEO-INFRA-TODOIST-YOUTUBE-ROADMAP-001.
+ *
+ * WHY THIS EXISTS: scripts/roadmap-generate.js promoted intake items into roadmap_wave_items with
+ * only {wave_id, source_type, source_id} — title omitted -> NULL. A title-less capture is
+ * un-groomable (no human or engine can distill it) and invisible to every title-keyed dedup axis,
+ * so 1087 accumulated and gated the Wave-0 distillation program. A prior fix backfilled the DATA
+ * but never the PRODUCER, so the nulls re-grew (414 -> 1087). This helper is the durable
+ * recurrence-stopper: map title:item.title (already on the clustered item — wave-clusterer SELECTs
+ * and spreads it, no round-trip) and SKIP-and-collect (loud, non-fatal) an unusable-title item so
+ * one bad row never mints a title-less capture and never aborts a whole wave.
+ *
+ * EXTRACTED as a pure importable helper (not inlined) because roadmap-generate.js self-invokes
+ * main() at module load and is therefore not unit-testable in place — the same reason
+ * lib/roadmap/full-create-guard.js was extracted from that file. Both promotion paths
+ * (createWaves array insert, runIncremental single-row insert) call this.
+ *
+ * PARITY: title usability is decided by the SHARED isUsableTitle (resolve-source-title.js) — the
+ * SAME predicate the backfill and the dedup axis use — never a re-implementation, so the producer
+ * and the backfill cannot disagree on "usable".
+ */
+
+import { isUsableTitle } from '../sourcing-engine/resolve-source-title.js';
+
+/**
+ * @param {{ id?: string, source_type?: string, title?: any }} item - a clustered intake item
+ * @param {string} waveId - the roadmap_waves row id this item belongs to
+ * @returns {{ row: object } | { skip: true, reason: string, source_id: (string|null) }}
+ *   { row } when the item carries a usable title (the insert payload, title included);
+ *   { skip, reason, source_id } when it does not — the caller logs it loudly and drops it,
+ *   NEVER inserts a title-less row and NEVER throws.
+ */
+export function buildWaveItemRow(item, waveId) {
+  if (!item || typeof item !== 'object') {
+    return { skip: true, reason: 'missing_item', source_id: null };
+  }
+  if (!isUsableTitle(item.title)) {
+    return { skip: true, reason: 'unusable_source_title', source_id: item.id ?? null };
+  }
+  return {
+    row: {
+      wave_id: waveId,
+      source_type: item.source_type,
+      source_id: item.id,
+      title: String(item.title).trim(),
+    },
+  };
+}

--- a/scripts/roadmap-generate.js
+++ b/scripts/roadmap-generate.js
@@ -34,6 +34,9 @@ import {
 // brand-new parallel 'EVA Intake Roadmap' instead of writing into the existing one).
 import { resolveCanonicalRoadmap } from '../lib/roadmap/canonical-roadmap.js';
 import { evaluateFullCreate, roadmapsToArchive, REFUSE_REASON_REQUIRED, AUDIT_SEVERITY } from '../lib/roadmap/full-create-guard.js';
+// SD-LEO-INFRA-TODOIST-YOUTUBE-ROADMAP-001: map title + refuse a title-less mint at both promotion
+// sites (extracted so it is unit-testable — this file self-invokes main() at load).
+import { buildWaveItemRow } from '../lib/roadmap/wave-item-row.js';
 
 dotenv.config();
 
@@ -117,15 +120,21 @@ async function createWaves(roadmapId, waves, items) {
 
     if (waveErr) throw new Error(`Failed to create wave ${i}: ${waveErr.message}`);
 
-    // Insert wave items — reference intake source directly
-    const waveItems = wave.item_indices
-      .map(idx => items[idx - 1])
-      .filter(Boolean)
-      .map(item => ({
-        wave_id: waveRow.id,
-        source_type: item.source_type,
-        source_id: item.id,
-      }));
+    // Insert wave items — reference intake source directly. SD-LEO-INFRA-TODOIST-YOUTUBE-ROADMAP-001:
+    // map title via buildWaveItemRow; an unusable-title item is SKIPPED and collected (loud,
+    // non-fatal) rather than minted title-less — so the whole wave still lands.
+    const waveItems = [];
+    const titleSkips = [];
+    for (const idx of wave.item_indices) {
+      const item = items[idx - 1];
+      if (!item) continue;
+      const built = buildWaveItemRow(item, waveRow.id);
+      if (built.skip) { titleSkips.push(built.source_id); continue; }
+      waveItems.push(built.row);
+    }
+    if (titleSkips.length > 0) {
+      console.warn(`  Warning: wave ${i} skipped ${titleSkips.length} title-less item(s) (unusable source title): ${titleSkips.join(', ')}`);
+    }
 
     if (waveItems.length > 0) {
       const { error: itemErr } = await supabase
@@ -295,13 +304,16 @@ async function runIncremental(roadmap, options) {
     const wave = existingWaves[a.wave_index - 1];
     if (!item || !wave) continue;
 
+    // SD-LEO-INFRA-TODOIST-YOUTUBE-ROADMAP-001: map title + refuse a title-less mint (skip+log+continue).
+    const built = buildWaveItemRow(item, wave.id);
+    if (built.skip) {
+      console.warn(`  Warning: skipped title-less item ${item.id} for wave ${wave.title} (unusable source title)`);
+      continue;
+    }
+
     const { error } = await supabase
       .from('roadmap_wave_items')
-      .insert({
-        wave_id: wave.id,
-        source_type: item.source_type,
-        source_id: item.id,
-      });
+      .insert(built.row);
 
     if (error) {
       console.warn(`  Warning: Could not insert item ${item.id} into wave ${wave.title}: ${error.message}`);

--- a/tests/unit/roadmap/wave-item-title.test.js
+++ b/tests/unit/roadmap/wave-item-title.test.js
@@ -1,0 +1,87 @@
+/**
+ * SD-LEO-INFRA-TODOIST-YOUTUBE-ROADMAP-001 — the roadmap promotion step maps title + refuses a
+ * title-less mint. Two-sided on the pure helper (titled -> row / unusable -> skip), plus a
+ * source-text wiring pin proving BOTH roadmap-generate.js call sites call it (the pure-helper test
+ * is blind to a half-wired extraction; the producer fns are unexported + the file self-invokes
+ * main(), so an execution-level wiring test is not achievable — the pin is the precedent-backed
+ * bound, cf. tests/unit/roadmap/plan-of-record-remainder-grep-guard.test.js).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { buildWaveItemRow } from '../../../lib/roadmap/wave-item-row.js';
+import { isUsableTitle } from '../../../lib/sourcing-engine/resolve-source-title.js';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+
+describe('buildWaveItemRow — map title, refuse a title-less mint', () => {
+  it('TS-1: a usable title maps to a titled insert row', () => {
+    const out = buildWaveItemRow({ id: 'src-1', source_type: 'todoist', title: 'A real task title' }, 'wave-9');
+    expect(out).toEqual({ row: { wave_id: 'wave-9', source_type: 'todoist', source_id: 'src-1', title: 'A real task title' } });
+  });
+
+  it('TS-1b: a title with surrounding whitespace is trimmed onto the row', () => {
+    const out = buildWaveItemRow({ id: 'src-2', source_type: 'youtube', title: '  Trim me  ' }, 'wave-9');
+    expect(out.row.title).toBe('Trim me');
+  });
+
+  it('TS-2: the full isUsableTitle rejection set is SKIPPED, not minted title-less, never thrown', () => {
+    // Parity: these are exactly what the shared isUsableTitle rejects (empty / whitespace /
+    // (untitled) / non-string). A re-implementation that missed (untitled) or the numeric case
+    // would let the producer and the backfill disagree on "usable".
+    const unusable = ['', '   ', null, undefined, '(untitled)', '  (untitled)  ', 123, {}];
+    for (const title of unusable) {
+      // guard: the shared predicate agrees these are all unusable (locks parity)
+      expect(isUsableTitle(title), `isUsableTitle should reject ${JSON.stringify(title)}`).toBe(false);
+      const out = buildWaveItemRow({ id: 'src-x', source_type: 'todoist', title }, 'wave-9');
+      expect(out.skip, `title ${JSON.stringify(title)} must skip`).toBe(true);
+      expect(out.reason).toBeTruthy();
+      expect(out.row).toBeUndefined();
+    }
+  });
+
+  it('TS-2b: a missing/non-object item skips with a reason (never throws)', () => {
+    expect(buildWaveItemRow(null, 'w').skip).toBe(true);
+    expect(buildWaveItemRow(undefined, 'w').reason).toBeTruthy();
+  });
+
+  it('TS-3: createWaves-style mapping keeps only usable rows and collects the skips', () => {
+    const items = [
+      { id: 'a', source_type: 'todoist', title: 'Good one' },
+      { id: 'b', source_type: 'youtube', title: '' },          // skip
+      { id: 'c', source_type: 'todoist', title: '(untitled)' }, // skip
+      { id: 'd', source_type: 'youtube', title: 'Also good' },
+    ];
+    const rows = [];
+    const skips = [];
+    for (const item of items) {
+      const built = buildWaveItemRow(item, 'wave-1');
+      if (built.skip) { skips.push(built.source_id); continue; }
+      rows.push(built.row);
+    }
+    expect(rows.map(r => r.source_id)).toEqual(['a', 'd']);
+    expect(skips).toEqual(['b', 'c']);
+    expect(rows.every(r => isUsableTitle(r.title))).toBe(true);
+  });
+
+  it('TS-7: a backfilled/mapped row is visible to the title-keyed dedup axis (was invisible while title-less)', () => {
+    const out = buildWaveItemRow({ id: 'e', source_type: 'todoist', title: 'Dedup me' }, 'wave-1');
+    // The dedup axis keys on a usable title; a title-less row (skip) never reaches it.
+    expect(isUsableTitle(out.row.title)).toBe(true);
+  });
+});
+
+describe('TS-8: wiring pin — both roadmap-generate.js promotion sites call buildWaveItemRow', () => {
+  const src = readFileSync(path.join(ROOT, 'scripts', 'roadmap-generate.js'), 'utf8');
+  it('imports the helper and references it at least twice (createWaves + runIncremental)', () => {
+    expect(src).toContain("from '../lib/roadmap/wave-item-row.js'");
+    const refs = (src.match(/buildWaveItemRow\(/g) || []).length;
+    expect(refs, 'both the full-mode and incremental-mode inserts must call buildWaveItemRow').toBeGreaterThanOrEqual(2);
+  });
+  it('neither insert mints the old title-less {wave_id, source_type, source_id}-only shape', () => {
+    // The pre-fix shape had source_id: immediately followed by a closing of the object with no title.
+    // After the fix, the insert payload comes from built.row (which always carries title).
+    expect(src).not.toMatch(/source_id:\s*item\.id,\s*\}\s*\)\s*;/);
+  });
+});


### PR DESCRIPTION
**The defect (measured live 2026-08-10):** `scripts/roadmap-generate.js` promoted intake items into `roadmap_wave_items` with only `{wave_id, source_type, source_id}` — title omitted → NULL. A title-less capture is un-groomable and invisible to every title-keyed dedup axis, so **1087 of 1423** pending un-promoted rows (todoist 738, youtube 349) accumulated and gated the Wave-0 distillation program. A prior fix backfilled the *data* but never the *producer*, so the nulls re-grew (414 → 1087) — this closes the recurrence root.

**FR-1 — the durable producer fix.** New `lib/roadmap/wave-item-row.js` `buildWaveItemRow(item, waveId)` maps `title: item.title` (already on the clustered item — `wave-clusterer` SELECTs and spreads it, **no round-trip**) and **skips + collects** (loud, non-fatal, never throws) an unusable-title item. Usability is the **shared** `isUsableTitle` (no re-implementation, so the producer and the backfill cannot disagree). Extracted as a pure importable helper because `roadmap-generate.js` self-invokes `main()` at load — the same reason `full-create-guard.js` was extracted from this file. Wired at **both** promotion sites: `createWaves` (array insert: partition usable/skip, insert usable, warn skips) and `runIncremental` (single row: skip+log+continue).

**FR-2 — disposition the 1087 (operational, verified).** Re-ran the existing general `backfill-414-null-titles.mjs`:
- dry-run: `scanned 1087, recovered=1087, dispositioned(dropped)=0` (all recoverable from `eva_*_intake.title`)
- `--apply`: `APPLIED recovered=1087 dispositioned=0 of 1087`
- **post-apply re-count: title-null pending todoist/youtube = 0** (titled pending now 1535); a re-run scans **0** (idempotent). No silent-delete.

**FR-3 — tests.** Two-sided on the helper (usable maps incl. trim; the full `isUsableTitle` rejection set — empty/whitespace/`(untitled)`/non-string — skips; never throws) + a **source-text wiring pin** proving both call sites reference the helper (the only guard against a half-wired extraction). **28 green** incl. the `full-create-guard` and `null-title-backfill` precedents.

**Premise refinement (measured, signaled):** both mints are in ONE file at the *promotion* step (not two ingest producers); todoist is 738 not 651; 100% recoverable. Blast radius low: title is not in the `UNIQUE(wave_id, source_type, source_id)` key and downstream readers want it present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)