### PR TITLE
fix(QF-20260809-138): derive the live scope count from the basis row's own series query

### DIFF
--- a/scripts/solomon-forecast-trigger-check.mjs
+++ b/scripts/solomon-forecast-trigger-check.mjs
@@ -48,6 +48,26 @@ const OPEN_STATUSES = ['draft', 'in_progress', 'active', 'pending_approval'];
 export const VELOCITY_DELTA = 0.15;
 export const SCOPE_DELTA = 0.10;
 
+/**
+ * QF-20260809-138: same-series-by-construction. The basis row embeds its own series definition
+ * (metadata.scope_series_query, v17+, e.g. "strategic_directives_v2 count where status NOT IN
+ * (completed,cancelled)") precisely for this consumption. Counting the live scope with the
+ * hardcoded narrow OPEN_STATUSES compared 35 (draft+active+pending_approval) against a canonical
+ * 59 on 2026-08-09 — a daily false-fire whose ack-and-skip consumer nearly ate a genuine +20.4%
+ * canonical fire the same day. Parse the exclusion set out of the basis's own query:
+ *   null      -> field absent (pre-v17 basis): caller falls back to OPEN_STATUSES
+ *   undefined -> field present but unparseable: caller must SKIP the scope comparison
+ *                (a cross-series compare is the defect; an explicit skip is honest)
+ *   string[]  -> statuses to exclude via NOT IN (same series as the basis count)
+ */
+export function scopeExclusionsFromSeriesQuery(q) {
+  if (typeof q !== 'string' || !q.trim()) return null;
+  const m = /NOT\s+IN\s*\(([^)]+)\)/i.exec(q);
+  if (!m) return undefined;
+  const list = m[1].split(',').map((s) => s.trim().replace(/^['"]|['"]$/g, '')).filter(Boolean);
+  return list.length ? list : undefined;
+}
+
 async function resolveTarget(sb) {
   try { const id = await getActiveSolomonId(sb); if (id) return id; } catch { /* fall through */ }
   return 'broadcast-solomon';
@@ -79,18 +99,34 @@ export async function runDailyTriggers(sb, { nowMs = Date.now() } = {}) {
   const since = new Date(nowMs - 7 * DAY).toISOString();
   const { count: completed7d } = await sb.from('strategic_directives_v2')
     .select('id', { count: 'exact', head: true }).eq('status', 'completed').gte('completion_date', since);
-  const { count: openScope } = await sb.from('strategic_directives_v2')
-    .select('id', { count: 'exact', head: true }).in('status', OPEN_STATUSES);
+
+  // QF-20260809-138: derive the live scope from the basis row's OWN series definition so fires
+  // and no-fires are same-series by construction; OPEN_STATUSES survives only as the pre-v17
+  // fallback for basis rows that predate the embedded query.
+  const exclusions = scopeExclusionsFromSeriesQuery(m.scope_series_query);
+  let openScope = null;
+  let scopeSeries;
+  if (exclusions === null) {
+    scopeSeries = 'narrow_fallback_pre_v17';
+    ({ count: openScope } = await sb.from('strategic_directives_v2')
+      .select('id', { count: 'exact', head: true }).in('status', OPEN_STATUSES));
+  } else if (exclusions === undefined) {
+    scopeSeries = 'unparseable_query_scope_skipped';
+  } else {
+    scopeSeries = 'basis_canonical';
+    ({ count: openScope } = await sb.from('strategic_directives_v2')
+      .select('id', { count: 'exact', head: true }).not('status', 'in', `(${exclusions.join(',')})`));
+  }
 
   const liveVelocity = (completed7d || 0) / 7;
   const fired = [];
   if (Number(m.velocity_per_day) > 0 && Math.abs(liveVelocity - m.velocity_per_day) / m.velocity_per_day > VELOCITY_DELTA) {
     fired.push(`velocity ${m.velocity_per_day}/d -> ${liveVelocity.toFixed(1)}/d`);
   }
-  if (Number(m.open_scope_count) > 0 && Math.abs((openScope || 0) - m.open_scope_count) / m.open_scope_count > SCOPE_DELTA) {
-    fired.push(`scope ${m.open_scope_count} -> ${openScope}`);
+  if (openScope !== null && Number(m.open_scope_count) > 0 && Math.abs((openScope || 0) - m.open_scope_count) / m.open_scope_count > SCOPE_DELTA) {
+    fired.push(`scope ${m.open_scope_count} -> ${openScope} (${scopeSeries})`);
   }
-  if (!fired.length) return { status: 'clean', liveVelocity, openScope };
+  if (!fired.length) return { status: 'clean', liveVelocity, openScope, scopeSeries };
 
   const target = await resolveTarget(sb);
   // One episode per basis: keyed on the basis timestamp so a re-check of the SAME drift

--- a/tests/unit/solomon-forecast-trigger-check.test.js
+++ b/tests/unit/solomon-forecast-trigger-check.test.js
@@ -13,7 +13,7 @@
  * validation chain.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { runWeeklyReminder, KNOWN_RESET_DAYS } from '../../scripts/solomon-forecast-trigger-check.mjs';
+import { runWeeklyReminder, runDailyTriggers, scopeExclusionsFromSeriesQuery, KNOWN_RESET_DAYS } from '../../scripts/solomon-forecast-trigger-check.mjs';
 
 function makeMockSupabase({ existingUnread = false } = {}) {
   return {
@@ -72,5 +72,111 @@ describe('runWeeklyReminder — account-aware epoch naming', () => {
     const res = await runWeeklyReminder(sb, { nowMs: NOW, resolveIdentity: () => null, sendRow });
     expect(res.status).toBe('pending-reminder');
     expect(sendRow).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * QF-20260809-138 — same-series-by-construction scope counting.
+ *
+ * The live open-scope count must derive from the basis row's OWN metadata.scope_series_query
+ * (canonical: status NOT IN (completed,cancelled)), never the hardcoded narrow OPEN_STATUSES —
+ * comparing a narrow numerator (35 on 2026-08-09) to a canonical baseline (59) false-fired daily.
+ * The mock RECORDS which filter method the code chose (.not vs .in) so these tests observe the
+ * series-selection predicate itself, not a pre-filtered fixture.
+ */
+function makeDailyMock({ basisMeta, completed7d = 0, openCount = 0 }) {
+  const calls = { scopeFilter: null, scopeArgs: null };
+  return {
+    calls,
+    from: (table) => {
+      if (table === 'feedback') {
+        return { select: () => ({ eq: () => ({ order: () => ({
+          limit: async () => ({ data: [{ created_at: '2026-08-10T12:16:15Z', metadata: basisMeta }] }),
+        }) }) }) };
+      }
+      // strategic_directives_v2: completed7d awaits at .gte; openScope awaits at .in or .not
+      return {
+        select: () => ({
+          eq: () => ({ gte: async () => ({ count: completed7d }) }),
+          in: async (col, list) => { calls.scopeFilter = 'in'; calls.scopeArgs = list; return { count: openCount }; },
+          not: async (col, op, val) => { calls.scopeFilter = 'not'; calls.scopeArgs = val; return { count: openCount }; },
+        }),
+      };
+    },
+  };
+}
+
+describe('scopeExclusionsFromSeriesQuery — basis series parsing', () => {
+  it('parses the canonical v17+ query into an exclusion list', () => {
+    expect(scopeExclusionsFromSeriesQuery('strategic_directives_v2 count where status NOT IN (completed,cancelled)'))
+      .toEqual(['completed', 'cancelled']);
+  });
+
+  it('handles quoting/spacing/case drift', () => {
+    expect(scopeExclusionsFromSeriesQuery("... status not in ( 'completed' , \"cancelled\" )"))
+      .toEqual(['completed', 'cancelled']);
+  });
+
+  it('returns null for an absent field (pre-v17 basis -> narrow fallback)', () => {
+    expect(scopeExclusionsFromSeriesQuery(undefined)).toBeNull();
+    expect(scopeExclusionsFromSeriesQuery('')).toBeNull();
+  });
+
+  it('returns undefined for a present-but-unparseable query (-> scope comparison skipped)', () => {
+    expect(scopeExclusionsFromSeriesQuery('count everything open, trust me')).toBeUndefined();
+    expect(scopeExclusionsFromSeriesQuery('status NOT IN ()')).toBeUndefined();
+  });
+});
+
+describe('runDailyTriggers — same-series scope counting (QF-20260809-138)', () => {
+  const BASIS = { velocity_per_day: 12, open_scope_count: 49 };
+
+  it('counts the live scope via the basis-embedded NOT IN series when the query is present', async () => {
+    const sb = makeDailyMock({
+      basisMeta: { ...BASIS, scope_series_query: 'strategic_directives_v2 count where status NOT IN (completed,cancelled)' },
+      completed7d: 84, // 12/day: velocity clean
+      openCount: 50,   // within 10% of 49: scope clean
+    });
+    const res = await runDailyTriggers(sb, { nowMs: Date.parse('2026-08-10T13:00:00Z') });
+    expect(res.status).toBe('clean');
+    expect(res.scopeSeries).toBe('basis_canonical');
+    expect(sb.calls.scopeFilter).toBe('not');
+    expect(sb.calls.scopeArgs).toBe('(completed,cancelled)');
+  });
+
+  it('def-site repro 2026-08-09: a canonical 59 vs basis 49 fires on the SAME series (no narrow 35 false read)', async () => {
+    const sb = makeDailyMock({
+      basisMeta: { ...BASIS, scope_series_query: 'strategic_directives_v2 count where status NOT IN (completed,cancelled)' },
+      completed7d: 84,
+      openCount: 59, // +20.4% canonical — the REAL fire the narrow series nearly ate
+    });
+    // sendOnce will consult session_coordination; give the mock that lane too
+    sb.from = ((orig) => (table) => table === 'session_coordination'
+      ? { select: () => ({ eq: () => ({ eq: () => ({ is: () => ({ limit: async () => ({ data: [{ id: 'unread' }] }) }) }) }) }) }
+      : orig(table))(sb.from);
+    const res = await runDailyTriggers(sb, { nowMs: Date.parse('2026-08-10T13:00:00Z') });
+    expect(res.status).toBe('FIRED');
+    expect(res.fired.join(' ')).toContain('scope 49 -> 59 (basis_canonical)');
+  });
+
+  it('falls back to the narrow OPEN_STATUSES only for a pre-v17 basis lacking the query', async () => {
+    const sb = makeDailyMock({ basisMeta: { ...BASIS }, completed7d: 84, openCount: 49 });
+    const res = await runDailyTriggers(sb, { nowMs: Date.parse('2026-08-10T13:00:00Z') });
+    expect(res.status).toBe('clean');
+    expect(res.scopeSeries).toBe('narrow_fallback_pre_v17');
+    expect(sb.calls.scopeFilter).toBe('in');
+    expect(sb.calls.scopeArgs).toEqual(['draft', 'in_progress', 'active', 'pending_approval']);
+  });
+
+  it('SKIPS the scope comparison (never cross-series-compares) when the query is present but unparseable', async () => {
+    const sb = makeDailyMock({
+      basisMeta: { ...BASIS, scope_series_query: 'a prose sentence with no exclusion clause' },
+      completed7d: 84,
+    });
+    const res = await runDailyTriggers(sb, { nowMs: Date.parse('2026-08-10T13:00:00Z') });
+    expect(res.status).toBe('clean');
+    expect(res.scopeSeries).toBe('unparseable_query_scope_skipped');
+    expect(res.openScope).toBeNull();
+    expect(sb.calls.scopeFilter).toBeNull(); // neither series was counted
   });
 });


### PR DESCRIPTION
## Summary
- The daily forecast trigger (`scripts/solomon-forecast-trigger-check.mjs`) counted live open scope with the hardcoded narrow status list but compared it to the basis's CANONICAL `open_scope_count` (status NOT IN completed,cancelled) — a ratio whose numerator and baseline span different extents. It false-fired daily (35 vs 59 on 2026-08-09), and the resulting ack-and-skip habit in its consumer nearly ate a genuine +20.4% canonical fire.
- New `scopeExclusionsFromSeriesQuery()` parses the exclusion set from the basis row's own `metadata.scope_series_query` (embedded since v17 for exactly this consumption) → fires and no-fires are same-series by construction. Narrow constant survives only as the pre-v17 fallback; an unparseable query skips the scope comparison observably (`scopeSeries` in the return) instead of cross-comparing.
- Live measurement at fix time: old numerator 25 vs basis 49 (would false-fire again today, 49% delta); canonical 49 vs 49 = clean.

## Test plan
- [x] 8 new unit tests: parser (canonical/quoting/absent/unparseable) + series selection observed through a filter-recording mock (canonical .not path, def-site 49→59 fire repro, pre-v17 .in fallback, unparseable skip)
- [x] 4 existing weekly-reminder tests unmodified and green (12/12)

🤖 Generated with [Claude Code](https://claude.com/claude-code)