### PR TITLE
feat(SD-LEO-INFRA-COORDINATOR-HEALTH-BREACH-001): breach flag fires only on canonical axes

### DIFF
--- a/scripts/adam-coordinator-health.mjs
+++ b/scripts/adam-coordinator-health.mjs
@@ -293,12 +293,25 @@ export async function computeFailLoudIntegrity(supabase, { selfReportedCounts, c
   };
 }
 
-/** Pure: a breach requires idle workers AND a non-empty backlog together (never idle alone). */
+/** Pure: a breach requires idle workers AND a non-empty backlog together (never idle alone).
+ *
+ * SD-LEO-INFRA-COORDINATOR-HEALTH-BREACH-001: planBreach is COMPUTED AND REPORTED but no
+ * longer breach arithmetic — the retired-axis rule. READER: the breach flag's consumers
+ * (advisory subject, persistReading score, the coordinator-performance drive-state axis) —
+ * every breach:true must be actionable on a CANONICAL axis. CLAUDE_ADAM.md 2a retired raw
+ * stamped-% as the KPI-2 target ("unstamped != off-plan"); the dispatch reason-code BAND is
+ * the scoring and band_breach is its axis in the assembled breach. Witnessed 2026-08-10
+ * 05:5xZ: coverage 3/27=11% fired breach:true alone every 6h in a feedback-band-heavy
+ * window — the ack-and-skip alarm-fatigue class. Plan starvation still alarms canonically
+ * via the plan-drift-coverage gauge trip (gauge-registry.js, pinned two-sided) — this flag
+ * was a DUPLICATE alarm on the retired axis. Mirrors the human_action_held precedent above:
+ * retained for observability, no longer arithmetic input.
+ */
 export function classifyBreach({ utilization, planAdherence, integrity }) {
   const idleWithBacklog = utilization.idle > 0 && utilization.dispatchable_backlog_size > 0;
   const integrityBreach = integrity.integrity_ok === false;
   const planBreach = planAdherence.status === 'measured' && planAdherence.starved === true;
-  return { breach: idleWithBacklog || integrityBreach || planBreach, idleWithBacklog, integrityBreach, planBreach };
+  return { breach: idleWithBacklog || integrityBreach, idleWithBacklog, integrityBreach, planBreach };
 }
 
 /**
@@ -331,7 +344,11 @@ export function buildCoordinatorHealthAdvisoryRows(
   const which = [
     reading.breach.idleWithBacklog && 'idle workers + non-empty dispatchable backlog',
     reading.breach.integrityBreach && `fail-loud integrity divergence (${(reading.integrity.divergent_fields || []).join(', ')})`,
-    reading.breach.planBreach && `plan-adherence starved (coverage ${(reading.plan_adherence.coverage * 100).toFixed(1)}%)`,
+    // SD-LEO-INFRA-COORDINATOR-HEALTH-BREACH-001: context, never the breach cause — this
+    // line only renders when a CANONICAL axis fired the advisory, and its wording must not
+    // read as the reason (the retired-axis rule; the plan-drift-coverage gauge is where
+    // plan starvation alarms canonically).
+    reading.breach.planBreach && `context: plan-adherence starved (coverage ${(reading.plan_adherence.coverage * 100).toFixed(1)}%) — observability, not a breach axis`,
     // SD-LEO-INFRA-COORDINATOR-HEALTH-KPI-001: the coordinator sees WHICH of the
     // six classes fired, not just 'breach'.
     ...(reading.breach.firing_failure_classes || []).map((c) => `failure class ${c}`),

--- a/tests/unit/adam/adam-coordinator-health.test.js
+++ b/tests/unit/adam/adam-coordinator-health.test.js
@@ -559,6 +559,31 @@ describe('runProbe integration (TS-1..TS-5 wired end-to-end)', () => {
     expect(inserted.some((i) => i.t === 'session_coordination')).toBe(false);
   });
 
+  // SD-LEO-INFRA-COORDINATOR-HEALTH-BREACH-001: the ASSEMBLY-layer fence (TESTING residual
+  // 6fecf403). The pure-classifier tests above cannot see the assembled breach at the
+  // runProbe layer — mutating the assembly to re-add plan starvation ran GREEN across all
+  // 92 tests until this fixture existed. Plan-only starvation through the WHOLE probe must
+  // yield breach:false (score 100, no advisory) with planBreach:true still reported.
+  it('ASSEMBLY: plan-only starvation through runProbe yields breach:false, planBreach reported, score 100, no advisory', async () => {
+    vi.spyOn(waveLinkage, 'computeWaveLinkageCoverage').mockResolvedValueOnce({ coverage: 3 / 27, linked: 3, total: 27, starved: true, unlinkedKeys: ['SD-U1'] });
+    const inserted = [];
+    const supabase = makeFakeSupabase(
+      {
+        claude_sessions: [liveCoordinatorRow()],
+        strategic_directives_v2: [],
+        codebase_health_snapshots: [],
+      },
+      { onInsert: (t, r) => inserted.push({ t, r }) },
+    );
+    const reading = await runProbe(supabase, { makePgClient: pgDisabled });
+    expect(reading.plan_adherence.status).toBe('measured');
+    expect(reading.breach.planBreach).toBe(true);   // observation survives
+    expect(reading.breach.breach).toBe(false);       // the retired axis fires nothing, through the ASSEMBLY
+    const snapshot = inserted.find((i) => i.t === 'codebase_health_snapshots');
+    expect(snapshot).toBeDefined();
+    expect(inserted.some((i) => i.t === 'session_coordination')).toBe(false); // no advisory dun
+  });
+
   it('on a real breach, resolves the live coordinator session id (not the broadcast fallback)', async () => {
     vi.spyOn(waveLinkage, 'computeWaveLinkageCoverage').mockResolvedValueOnce({ coverage: null, linked: 0, total: 0, starved: false, unlinkedKeys: [] });
     vi.spyOn(coordinatorResolve, 'getActiveCoordinatorId').mockResolvedValueOnce('live-coordinator-session-1');

--- a/tests/unit/adam/adam-coordinator-health.test.js
+++ b/tests/unit/adam/adam-coordinator-health.test.js
@@ -301,6 +301,49 @@ describe('classifyBreach + advisory (TS-4, TS-8)', () => {
     expect(result.idleWithBacklog).toBe(true);
   });
 
+  // SD-LEO-INFRA-COORDINATOR-HEALTH-BREACH-001 (TS-1, two-sided in one describe): the
+  // retired axis reports but never fires. Fixture is the WITNESSED incident shape
+  // (2026-08-10 05:5xZ: coverage 3/27=11% -> breach:true while every canonical axis was
+  // clean). Before this SD the mutation "drop planBreach from the OR" ran GREEN across all
+  // 106 related tests — the term was unprotected; these arms are its sole protection, so
+  // both directions live here.
+  const starvedMeasured = { status: 'measured', coverage: 3 / 27, starved: true };
+
+  it('INCIDENT SHAPE: plan-only starvation does NOT breach, but planBreach stays reported (retired axis)', () => {
+    const result = classifyBreach({ utilization: { idle: 0, dispatchable_backlog_size: 4 }, planAdherence: starvedMeasured, integrity: okIntegrity });
+    expect(result.breach).toBe(false);      // the false-dun stops
+    expect(result.planBreach).toBe(true);   // the observation survives (human_action_held precedent)
+  });
+
+  it('canonical axes still fire WITH plan starvation present (the exclusion never widens)', () => {
+    const idle = classifyBreach({ utilization: { idle: 2, dispatchable_backlog_size: 5 }, planAdherence: starvedMeasured, integrity: okIntegrity });
+    expect(idle.breach).toBe(true);
+    const integ = classifyBreach({ utilization: { idle: 0, dispatchable_backlog_size: 0 }, planAdherence: starvedMeasured, integrity: { integrity_ok: false } });
+    expect(integ.breach).toBe(true);
+  });
+
+  it('advisory prose renders plan starvation as CONTEXT, never as the breach cause', async () => {
+    const inserted = [];
+    const supabase = makeFakeSupabase({}, { onInsert: (t, r) => inserted.push({ t, r }) });
+    const reading = {
+      timestamp: '2026-08-10T05:55:00Z',
+      utilization: { idle: 2, dispatchable_backlog_size: 5 },
+      plan_adherence: { ...starvedMeasured },
+      integrity: okIntegrity,
+      // Canonical axis fired the advisory; the retired axis is present as observation.
+      breach: { breach: true, idleWithBacklog: true, integrityBreach: false, planBreach: true },
+    };
+    await pushCoordinatorHealthAdvisory(supabase, reading, { coordinatorId: 'c1' });
+    expect(inserted.length).toBe(1);
+    const subject = inserted[0].r.subject;
+    expect(subject).toContain('idle workers');
+    expect(subject).toContain('context: plan-adherence starved');
+    expect(subject).toContain('observability, not a breach axis');
+    // The context phrase must never be the sole listed reason: strip it and a canonical
+    // reason must remain.
+    expect(subject.replace(/context: plan-adherence starved[^;]*/, '')).toMatch(/idle workers/);
+  });
+
   it('emits exactly one propose-only advisory naming the breached KPI, never a dispatch call', async () => {
     const inserted = [];
     const supabase = makeFakeSupabase({}, { onInsert: (t, r) => inserted.push({ t, r }) });


### PR DESCRIPTION
## Summary
- `adam-coordinator-health.mjs` reported `breach:true` whenever plan-link coverage starved (witnessed 2026-08-10 05:5xZ: coverage 3/27=11% → breach with every canonical axis clean), even though CLAUDE_ADAM.md 2a retired raw stamped-% as the KPI-2 target. Every 6h run in a feedback-band-heavy window alarmed, training the ack-and-skip habit that nearly ate a true positive on c40a2677.
- `classifyBreach` now composes the flag from CANONICAL axes only (idleWithBacklog, integrityBreach, band_breach, firing_failure_classes, recompute divergence); plan starvation is demoted to a labeled subordinate diagnostic ("context: plan-adherence starved — observability, not a breach axis") and keeps recording in the readings row.
- An assembly-layer mutation-fence test locks the composition: the mutation that previously ran green (adding planBreach back into the flag) now runs red.

## Test plan
- [x] 41/41 unit tests including the witnessed 05:5xZ shape (coverage-starved + band clean → breach:false + labeled context) and canonical-axis still-fires cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)