### PR TITLE
feat(SD-LEO-INFRA-CONTRACT-READ-FIT-001): a marginal fit prediction reads unknown, never PARTIAL

### DIFF
--- a/lib/protocol/contract-read-coverage.cjs
+++ b/lib/protocol/contract-read-coverage.cjs
@@ -65,6 +65,7 @@ const FULL_COVERAGE_PCT = 95;
 const {
   HARNESS_BYTES_PER_TOKEN,
   SINGLE_READ_TOKEN_CAP,
+  HARNESS_TOKEN_MAX_ERROR_FRACTION,
   harnessTokensFromBytes,
   cl100kRawLowerBound,
 } = require('./harness-token-scale.cjs');
@@ -142,6 +143,24 @@ const {
  * The split is asserted by computation in contract-read-groundtruth.test.js rather than quoted.
  */
 const SINGLE_READ_TOKEN_BUDGET = SINGLE_READ_TOKEN_CAP;
+
+/**
+ * *** THE MARGINAL BAND: A PREDICTION THIS CLOSE TO THE CAP IS A COIN FLIP, NOT A VERDICT. ***
+ * SD-LEO-INFRA-CONTRACT-READ-FIT-001.
+ *
+ * The bytes model has a documented max error of 6.80% (HARNESS_TOKEN_MAX_ERROR_FRACTION — six
+ * byte-paired receipts, see harness-token-scale.cjs). A prediction within that fraction of the cap
+ * has a true harness count that could sit on EITHER side of the wall, so a confident true/false there
+ * is a prediction wearing the costume of a measurement — exactly the inversion this module keeps
+ * retiring. CLAUDE_SOLOMON.md is the live proof: predicted 25,236 (0.94% over), but it reads clean in
+ * one no-offset call, so `fits:false` was a false statement that made every /solomon full read banner
+ * PARTIAL. Inside this band, singleReadFit returns the first-class `fits:null` ("cannot tell") instead.
+ *
+ * Derived from the scale's own error fraction, NOT a hand-picked literal — a magic margin is the same
+ * unmeasured-constant defect this SD family exists to remove. Pinned against the measured contract
+ * sizes in contract-read-fit-marginal.test.js.
+ */
+const SINGLE_READ_MARGIN_TOKENS = SINGLE_READ_TOKEN_CAP * HARNESS_TOKEN_MAX_ERROR_FRACTION;
 
 /**
  * Predicted harness token cost of a contract, or null.
@@ -275,7 +294,10 @@ const SINGLE_READ_SAFE_BYTES = Math.floor(SINGLE_READ_TOKEN_BUDGET * HARNESS_BYT
  * Can this contract be read in ONE call? Measured, with an explicit "cannot tell".
  *
  * `fits: null` is a first-class answer and must never be coerced to true — an unmeasurable contract
- * is exactly the case where promoting absence of evidence to compliance does the damage.
+ * is exactly the case where promoting absence of evidence to compliance does the damage. As of
+ * SD-LEO-INFRA-CONTRACT-READ-FIT-001 it ALSO means "marginal" (basis 'predicted_marginal'): a
+ * prediction within the model's own max error of the cap, where a confident boolean would be a coin
+ * flip. Downstream, marginal-null must read as UNKNOWN — never asserted-partial, never fits.
  *
  * *** EVERY VERDICT NOW CARRIES ITS EVIDENCE KIND. *** The original defect survived review because a
  * PREDICTION wore the same label as an OBSERVATION, so a consumer could not weight them differently.
@@ -308,6 +330,12 @@ function singleReadFit(root, contractFile) {
   }
 
   if (tokens !== null) {
+    // FR-1: a prediction within the model's own max error of the cap is inside the noise — return the
+    // honest "cannot tell" rather than a coin-flip boolean. This is the whole SD: it is what stops a
+    // 0.94%-over prediction (CLAUDE_SOLOMON.md) from asserting PARTIAL on a file that reads clean.
+    if (Math.abs(tokens - SINGLE_READ_TOKEN_CAP) <= SINGLE_READ_MARGIN_TOKENS) {
+      return { fits: null, tokens, bytes, basis: 'predicted_marginal', evidence: 'predicted', veto };
+    }
     return { fits: tokens <= SINGLE_READ_TOKEN_BUDGET, tokens, bytes, basis: 'predicted_bytes', evidence: 'predicted', veto };
   }
   if (bytes !== null) {
@@ -418,7 +446,16 @@ function contractSizeBytes(root, contractFile) {
  *      boolean punished.
  *   3. readCount      — last resort, and it is EXPLICITLY NOT treated as proof of a full read.
  *
- * @returns {{read: boolean, fully_read: boolean, coverage_pct: number|null, basis: string}}
+ * *** confirmed_partial (SD-LEO-INFRA-CONTRACT-READ-FIT-001) IS NARROWER THAN !fully_read, ON PURPOSE. ***
+ * `!fully_read` conflates two states a consumer must not: POSITIVE DISPROOF of a full read (measured
+ * short delivery, a sub-95% requested union, an explicit contradiction) versus mere INABILITY TO
+ * CONFIRM one (an upper-bound-only requested union, unknown coverage). Only the first is a fact about
+ * the reader's behavior; the second is the absence of evidence. `confirmed_partial` is true ONLY for
+ * the first, so a consumer can assert "you read this partially" without lying when it merely cannot
+ * tell — which is precisely what a marginal-fit contract (fit.fits === null) triggered before this SD.
+ *
+ * @returns {{read: boolean, fully_read: boolean, coverage_pct: number|null, basis: string,
+ *            confirmed_partial: boolean}}
  */
 function contractReadVerdict(status, totalLines, opts = {}) {
   /**
@@ -444,7 +481,7 @@ function contractReadVerdict(status, totalLines, opts = {}) {
    * All four are excluded by the three lines above.
    */
   if (!status || !(status.readCount > 0)) {
-    return { read: false, fully_read: false, coverage_pct: null, basis: 'no_read_recorded' };
+    return { read: false, fully_read: false, coverage_pct: null, basis: 'no_read_recorded', confirmed_partial: false };
   }
 
   const d = status.lastDelivered;
@@ -478,7 +515,7 @@ function contractReadVerdict(status, totalLines, opts = {}) {
     : (Number.isFinite(legacyBytes) && legacyBytes > 0 && legacyBytes <= SINGLE_READ_SAFE_BYTES);
 
   if (!deliveredContradicts && fitsInOneRead && status.lastReadWasPartial !== true) {
-    return { read: true, fully_read: true, coverage_pct: 100, basis: 'single_read_safe_size' };
+    return { read: true, fully_read: true, coverage_pct: 100, basis: 'single_read_safe_size', confirmed_partial: false };
   }
 
   // The denominator. Prefer the harness's own totalLines over a count of the file on disk: it
@@ -514,7 +551,8 @@ function contractReadVerdict(status, totalLines, opts = {}) {
   if (hasDelivered) {
     const pct = unionPct(status.deliveredRanges, denominator);
     if (pct !== null) {
-      return { read: true, fully_read: pct >= FULL_COVERAGE_PCT, coverage_pct: reportPct(pct), basis: 'delivered_ranges' };
+      // Measured delivery below the bar is POSITIVE disproof of a full read — confirmed_partial.
+      return { read: true, fully_read: pct >= FULL_COVERAGE_PCT, coverage_pct: reportPct(pct), basis: 'delivered_ranges', confirmed_partial: pct < FULL_COVERAGE_PCT };
     }
   } else {
     const pct = unionPct(status.ranges, denominator);
@@ -534,6 +572,11 @@ function contractReadVerdict(status, totalLines, opts = {}) {
         fully_read: false,
         coverage_pct: reportPct(pct),
         basis: pct >= FULL_COVERAGE_PCT ? 'requested_ranges_unconfirmed' : 'requested_ranges_incomplete',
+        // A sub-95% REQUESTED union is positive evidence the reader never even asked for the whole
+        // file (confirmed_partial). A >=95% requested union is only an UPPER bound — it cannot prove
+        // completeness (SEC-F18) and must NOT be asserted as partial: that is the marginal-file false
+        // PARTIAL this SD removes. So confirmed_partial tracks the disproof, not the inability.
+        confirmed_partial: pct < FULL_COVERAGE_PCT,
       };
     }
   }
@@ -587,7 +630,9 @@ function contractReadVerdict(status, totalLines, opts = {}) {
       read: true,
       fully_read: covered,
       coverage_pct: reportPct((Number(d.numLines) / Number(d.totalLines)) * 100),
-      basis: 'delivered_lines'
+      basis: 'delivered_lines',
+      // A measured single-record delivery short of the file is positive disproof of a full read.
+      confirmed_partial: !covered,
     };
   }
 
@@ -596,7 +641,19 @@ function contractReadVerdict(status, totalLines, opts = {}) {
   // NOT TREATED AS FULL, AND THAT IS THE WHOLE POINT. The old code reached exactly this state and
   // answered "fully read" whenever the last call carried no limit/offset — which is precisely the
   // truncated read. Absence of evidence is reported as absence, never promoted to completeness.
-  return { read: true, fully_read: false, coverage_pct: null, basis: 'unknown_coverage' };
+  //
+  // confirmed_partial tracks lastReadWasPartial HERE, and only here, because this tier is reached
+  // exactly when there is no range/delivered evidence to speak of. lastReadWasPartial === true is
+  // POSITIVE disproof of a clean full read (the reader used offset/limit — reliable in this
+  // direction; the module only distrusts the FALSE case, where a silent truncation records
+  // not-partial). A no-offset read of a marginal contract records lastReadWasPartial=false and
+  // therefore reads UNCONFIRMED, not partial — the whole point of this SD. A no-offset read of a
+  // genuinely over-cap contract ALSO records false here, but is caught at the consumer via
+  // fit.fits === false, so it still flags.
+  return {
+    read: true, fully_read: false, coverage_pct: null, basis: 'unknown_coverage',
+    confirmed_partial: status.lastReadWasPartial === true,
+  };
 }
 
 module.exports = {
@@ -605,4 +662,7 @@ module.exports = {
   // EVIDENCE_KINDS is exported so a test can assert what this module CANNOT emit. Asserting the
   // absence of the 'direct' kind is the only way to keep an unreachable label from being re-added.
   EVIDENCE_KINDS, exceedsCapByRawLowerBound, HARNESS_BYTES_PER_TOKEN,
+  // SINGLE_READ_MARGIN_TOKENS exported so a test can pin the marginal band against measured contract
+  // sizes rather than trusting the literal (SD-LEO-INFRA-CONTRACT-READ-FIT-001).
+  SINGLE_READ_MARGIN_TOKENS,
 };

--- a/lib/protocol/harness-token-scale.cjs
+++ b/lib/protocol/harness-token-scale.cjs
@@ -39,6 +39,20 @@ const HARNESS_BYTES_PER_TOKEN = 2.4177;
 const SINGLE_READ_TOKEN_CAP = 25000;
 
 /**
+ * The byte model's MAX calibration error, as a fraction. See the provenance block above: the six
+ * byte-paired receipts span 2.3698-2.5820 B/token, i.e. a worst-case 6.80% error between the
+ * prediction and the harness's own count.
+ *
+ * *** WHY IT IS EXPORTED, AND WHY A PREDICTION WITHIN THIS OF THE CAP IS A COIN FLIP. ***
+ * A prediction that lands within +-6.80% of the cap is inside this model's own noise — the true
+ * harness count could be on either side of the wall, and the model cannot say which. Consumers use
+ * this to mark such a verdict UNKNOWN rather than emitting a confident boolean that is really a coin
+ * flip (SD-LEO-INFRA-CONTRACT-READ-FIT-001). It lives here because it is a property of THIS scale,
+ * not of any one consumer — the same single-home reason the ratio itself does.
+ */
+const HARNESS_TOKEN_MAX_ERROR_FRACTION = 0.068;
+
+/**
  * Predicted harness token cost of `bytes` of prose-and-table content.
  * Returns null for anything that is not a usable positive size, because a coverage verdict built on
  * a coerced zero is worse than one that says it cannot tell.
@@ -93,6 +107,7 @@ function cl100kRawLowerBound(text, loadEncoder = defaultEncoderLoader) {
 module.exports = {
   HARNESS_BYTES_PER_TOKEN,
   SINGLE_READ_TOKEN_CAP,
+  HARNESS_TOKEN_MAX_ERROR_FRACTION,
   harnessTokensFromBytes,
   cl100kRawLowerBound,
 };

--- a/scripts/adam-register.cjs
+++ b/scripts/adam-register.cjs
@@ -277,9 +277,15 @@ function checkContractRead(projectDir) {
       // paginated read recorded "partial". Coverage is now derived from evidence. Fixed HERE at the
       // consumer rather than in the tracker, because that stamp also feeds
       // protocol-file-read-gate.js:159 and therefore every handoff.
-      const verdict = contractReadVerdict(status, contractLineCount(root, CONTRACT_FILE), { singleReadFit: singleReadFit(root, CONTRACT_FILE) });
+      const fit = singleReadFit(root, CONTRACT_FILE);
+      const verdict = contractReadVerdict(status, contractLineCount(root, CONTRACT_FILE), { singleReadFit: fit });
       result.contract_read = verdict.read;
-      result.contract_read_partial = !verdict.fully_read;
+      // FR-2 (SD-LEO-INFRA-CONTRACT-READ-FIT-001): assert PARTIAL only on POSITIVE disproof of a full
+      // read, OR when the contract is CONFIDENTLY over the single-read cap (fit.fits === false) and the
+      // read was not confirmed full. A near-cap MARGINAL prediction (fit.fits === null) with no disproof
+      // reads "unconfirmed" — never the false PARTIAL a marginal prediction produced via !fully_read.
+      result.contract_read_partial = verdict.confirmed_partial === true
+        || (fit.fits === false && verdict.fully_read !== true);
       result.contract_coverage_pct = verdict.coverage_pct;
       result.contract_read_basis = verdict.basis;
       result.contract_last_read_at = status.lastReadAt || null;
@@ -289,10 +295,14 @@ function checkContractRead(projectDir) {
       // distinguish a full read from a silently truncated one, which is the defect this SD closes.
       // Measured on TOKENS, not bytes: the byte proxy this replaced disarmed CLAUDE_SOLOMON.md
       // (67,501 B but only 15,965 tokens) even though it reads in one call.
-      const legacyFits = singleReadFit(root, CONTRACT_FILE).fits === true;
+      // A bare filename list carries no coverage evidence, so the fit prediction is the only signal.
+      // Assert PARTIAL only when the contract is CONFIDENTLY over-cap (fits === false); a marginal
+      // (null) or fitting (true) prediction cannot support a partial assertion (FR-2).
+      const fit = singleReadFit(root, CONTRACT_FILE);
       result.contract_read = true;
-      result.contract_read_partial = !legacyFits;
-      result.contract_read_basis = legacyFits ? 'legacy_array_single_read_safe' : 'legacy_array_no_evidence';
+      result.contract_read_partial = fit.fits === false;
+      result.contract_read_basis = fit.fits === true ? 'legacy_array_single_read_safe'
+        : fit.fits === false ? 'legacy_array_no_evidence' : 'legacy_array_marginal_unconfirmed';
     }
   } catch { /* fail-open: tracking unavailable must never break role activation */ }
   return result;

--- a/scripts/coordinator-startup-check.mjs
+++ b/scripts/coordinator-startup-check.mjs
@@ -590,13 +590,19 @@ export function checkCoordinatorContractRead(repoRoot = REPO_ROOT, stateReader =
       // coordinator that paginated (e.g. via /read-full) would have been recorded PARTIAL for doing
       // MORE work, which is the same inversion FR-3 removes for adam and solomon. One implementation,
       // three roles; the size tier inside the verdict is what keeps this file's happy path green.
+      const fit = singleReadFit(repoRoot, COORDINATOR_CONTRACT_FILE);
       const verdict = contractReadVerdict(
         status,
         contractLineCount(repoRoot, COORDINATOR_CONTRACT_FILE),
-        { singleReadFit: singleReadFit(repoRoot, COORDINATOR_CONTRACT_FILE) }
+        { singleReadFit: fit }
       );
       result.contract_read = verdict.read;
-      result.contract_read_partial = !verdict.fully_read;
+      // FR-2 (SD-LEO-INFRA-CONTRACT-READ-FIT-001): assert PARTIAL only on POSITIVE disproof of a full
+      // read, OR when the contract is CONFIDENTLY over the single-read cap (fit.fits === false) and the
+      // read was not confirmed full. A near-cap MARGINAL prediction (fit.fits === null) with no disproof
+      // reads "unconfirmed" — never the false PARTIAL that !fully_read produced for a marginal file.
+      result.contract_read_partial = verdict.confirmed_partial === true
+        || (fit.fits === false && verdict.fully_read !== true);
       result.contract_coverage_pct = verdict.coverage_pct;
       result.contract_read_basis = verdict.basis;
       result.contract_last_read_at = status.lastReadAt || null;
@@ -610,10 +616,14 @@ export function checkCoordinatorContractRead(repoRoot = REPO_ROOT, stateReader =
       // sentences" defect this same commit removed one function below, reintroduced by the fix for
       // it. A legacy bare-filename list carries NO coverage information; it is sufficient only when
       // the contract provably fits in one call, and that has to be measured, not asserted.
+      // A bare filename list carries no coverage evidence, so the fit prediction is the only signal.
+      // Assert PARTIAL only when the contract is CONFIDENTLY over-cap (fits === false); a marginal
+      // (null) or fitting (true) prediction cannot support a partial assertion (FR-2).
       const fit = opts.fit || singleReadFit(repoRoot, COORDINATOR_CONTRACT_FILE);
       result.contract_read = true;
-      result.contract_read_partial = fit.fits !== true;
-      result.contract_read_basis = fit.fits === true ? 'legacy_array_single_read_safe' : 'legacy_array_no_evidence';
+      result.contract_read_partial = fit.fits === false;
+      result.contract_read_basis = fit.fits === true ? 'legacy_array_single_read_safe'
+        : fit.fits === false ? 'legacy_array_no_evidence' : 'legacy_array_marginal_unconfirmed';
     }
   } catch { /* fail-open: tracking unavailable must never break coordinator startup */ }
   return result;
@@ -684,6 +694,13 @@ export function roleArmingStates(repoRoot = REPO_ROOT, fitter = null) {
     // Unmeasurable (including `fits: null`) => DISARMED. Absence of evidence is never promoted to
     // compliance; that promotion is the defect this whole SD exists to remove.
     if (!fit || fit.fits !== true) {
+      // SD-LEO-INFRA-CONTRACT-READ-FIT-001: a MARGINAL prediction (fits:null WITH a token count, basis
+      // 'predicted_marginal') is not "unmeasurable" — it is near-cap, inside the model's own error
+      // band. Report that honestly instead of borrowing the no-tokenizer message; otherwise FR-1 turns
+      // SOLOMON's specific "25236 > cap" reason into a vague "not measurable", a regression.
+      if (fit && fit.fits === null && fit.basis === 'predicted_marginal' && tokens !== null) {
+        return { role, file, tokens, bytes, armed: false, reason: `${file} is near the read cap (${tokens} tokens vs ${SINGLE_READ_TOKEN_BUDGET} cap, within the model's error band) — single-read fit unconfirmed` };
+      }
       if (!fit || fit.fits === null || fit.fits === undefined) {
         return { role, file, tokens, bytes, armed: false, reason: `${file} not measurable — cannot establish readability` };
       }

--- a/scripts/solomon-register.cjs
+++ b/scripts/solomon-register.cjs
@@ -267,9 +267,15 @@ function checkContractRead(projectDir) {
       // SD-LEO-INFRA-ROLE-CONTRACT-READ-GATE-001 / FR-3 — identical fix to adam-register.cjs, from
       // one shared implementation. This path had NO test coverage at all before this SD, which is
       // part of why the inversion survived here as long as it did.
-      const verdict = contractReadVerdict(status, contractLineCount(root, CONTRACT_FILE), { singleReadFit: singleReadFit(root, CONTRACT_FILE) });
+      const fit = singleReadFit(root, CONTRACT_FILE);
+      const verdict = contractReadVerdict(status, contractLineCount(root, CONTRACT_FILE), { singleReadFit: fit });
       result.contract_read = verdict.read;
-      result.contract_read_partial = !verdict.fully_read;
+      // FR-2 (SD-LEO-INFRA-CONTRACT-READ-FIT-001): assert PARTIAL only on POSITIVE disproof of a full
+      // read, OR when the contract is CONFIDENTLY over the single-read cap (fit.fits === false) and the
+      // read was not confirmed full. A near-cap MARGINAL prediction (fit.fits === null) with no disproof
+      // reads "unconfirmed" — this is the exact false PARTIAL every /solomon full read used to emit.
+      result.contract_read_partial = verdict.confirmed_partial === true
+        || (fit.fits === false && verdict.fully_read !== true);
       result.contract_coverage_pct = verdict.coverage_pct;
       result.contract_read_basis = verdict.basis;
       result.contract_last_read_at = status.lastReadAt || null;
@@ -279,10 +285,14 @@ function checkContractRead(projectDir) {
       // distinguish a full read from a silently truncated one, which is the defect this SD closes.
       // Measured on TOKENS, not bytes: the byte proxy this replaced disarmed CLAUDE_SOLOMON.md
       // (67,501 B but only 15,965 tokens) even though it reads in one call.
-      const legacyFits = singleReadFit(root, CONTRACT_FILE).fits === true;
+      // A bare filename list carries no coverage evidence, so the fit prediction is the only signal.
+      // Assert PARTIAL only when the contract is CONFIDENTLY over-cap (fits === false); a marginal
+      // (null) or fitting (true) prediction cannot support a partial assertion (FR-2).
+      const fit = singleReadFit(root, CONTRACT_FILE);
       result.contract_read = true;
-      result.contract_read_partial = !legacyFits;
-      result.contract_read_basis = legacyFits ? 'legacy_array_single_read_safe' : 'legacy_array_no_evidence';
+      result.contract_read_partial = fit.fits === false;
+      result.contract_read_basis = fit.fits === true ? 'legacy_array_single_read_safe'
+        : fit.fits === false ? 'legacy_array_no_evidence' : 'legacy_array_marginal_unconfirmed';
     }
   } catch { /* fail-open: tracking unavailable must never break role activation */ }
   return result;

--- a/tests/unit/contract-read-fit-marginal.test.js
+++ b/tests/unit/contract-read-fit-marginal.test.js
@@ -1,0 +1,154 @@
+// SD-LEO-INFRA-CONTRACT-READ-FIT-001 — a marginal fit prediction must read UNKNOWN, never PARTIAL.
+//
+// The defect: singleReadFit predicted CLAUDE_SOLOMON.md at 25,236 tokens (0.94% over the 25,000 cap,
+// inside the byte model's own documented 6.80% max error) and returned a hard fits:false. The three
+// role-activation consumers collapsed that to contract_read_partial = !verdict.fully_read, so every
+// /solomon full read banner-ed "was PARTIAL (offset/limit used)" for a file that reads clean in one
+// no-offset call — a prediction asserted as a measurement of the reader's behavior.
+//
+// These are BEHAVIORAL tests: they drive singleReadFit / contractReadVerdict directly, and the real
+// solomon-register.checkContractRead + contractReadBanner end-to-end against temp project dirs. No
+// source-pin slices (a positional slice is a guard whose subject moves).
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '../..');
+
+const cov = require(path.join(repoRoot, 'lib/protocol/contract-read-coverage.cjs'));
+const {
+  singleReadFit, contractReadVerdict, SINGLE_READ_MARGIN_TOKENS, SINGLE_READ_TOKEN_CAP,
+} = cov;
+const scale = require(path.join(repoRoot, 'lib/protocol/harness-token-scale.cjs'));
+const solomon = require(path.join(repoRoot, 'scripts/solomon-register.cjs'));
+
+// Force the session-state resolver onto the LEGACY per-project path so the temp-dir tests are
+// deterministic regardless of any ~/.claude-sessions registry on the running machine.
+let prevSessionsOverride;
+let tmpDirs = [];
+beforeAll(() => {
+  prevSessionsOverride = process.env.CLAUDE_SESSIONS_DIR_OVERRIDE;
+  process.env.CLAUDE_SESSIONS_DIR_OVERRIDE = fs.mkdtempSync(path.join(os.tmpdir(), 'crf-empty-sessions-'));
+});
+afterAll(() => {
+  if (prevSessionsOverride === undefined) delete process.env.CLAUDE_SESSIONS_DIR_OVERRIDE;
+  else process.env.CLAUDE_SESSIONS_DIR_OVERRIDE = prevSessionsOverride;
+  for (const d of tmpDirs) { try { fs.rmSync(d, { recursive: true, force: true }); } catch { /* best effort */ } }
+});
+
+/** Build a temp project dir with a CLAUDE_SOLOMON.md of the given byte size and a recorded read. */
+function makeProjectDir(contractBytes, status) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'crf-proj-'));
+  tmpDirs.push(dir);
+  // Prose-like filler so the density veto (cl100k on raw) stays well under the cap and the BYTE
+  // prediction is what decides — the exact path this SD is about.
+  const line = 'The coordinator reviews the contract and records the verdict for the fleet. ';
+  let body = '';
+  while (Buffer.byteLength(body, 'utf8') < contractBytes) body += line;
+  fs.writeFileSync(path.join(dir, 'CLAUDE_SOLOMON.md'), body.slice(0, contractBytes), 'utf8');
+  fs.mkdirSync(path.join(dir, '.claude'), { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, '.claude', 'unified-session-state.json'),
+    JSON.stringify({ protocolFileReadStatus: { 'CLAUDE_SOLOMON.md': status } }),
+    'utf8',
+  );
+  return dir;
+}
+
+describe('FR-1: the fit predictor margin-bands near-cap predictions to fits:null', () => {
+  it('CLAUDE_SOLOMON.md (near-cap) reads fits:null with basis predicted_marginal, not a confident boolean', () => {
+    const r = singleReadFit(repoRoot, 'CLAUDE_SOLOMON.md');
+    expect(r.fits).toBeNull();
+    expect(r.basis).toBe('predicted_marginal');
+    expect(r.evidence).toBe('predicted');
+    // it is genuinely near the cap — the whole justification for calling it unknown
+    expect(Math.abs(r.tokens - SINGLE_READ_TOKEN_CAP)).toBeLessThanOrEqual(SINGLE_READ_MARGIN_TOKENS);
+  });
+
+  it('a clearly-under contract (CLAUDE_PLAN.md) still reads fits:true', () => {
+    const r = singleReadFit(repoRoot, 'CLAUDE_PLAN.md');
+    expect(r.fits).toBe(true);
+    expect(Math.abs(r.tokens - SINGLE_READ_TOKEN_CAP)).toBeGreaterThan(SINGLE_READ_MARGIN_TOKENS);
+  });
+
+  it('a genuinely-oversized contract still reads fits:false (the band does not swallow real over-cap)', () => {
+    // ~75KB of prose -> ~31k predicted tokens, well past cap + band.
+    const dir = makeProjectDir(75000, { readCount: 1, lastReadWasPartial: false });
+    const r = singleReadFit(dir, 'CLAUDE_SOLOMON.md');
+    expect(r.fits).toBe(false);
+    expect(r.tokens - SINGLE_READ_TOKEN_CAP).toBeGreaterThan(SINGLE_READ_MARGIN_TOKENS);
+  });
+
+  it('the margin band is derived from the scale error fraction, not a hand-picked literal', () => {
+    expect(SINGLE_READ_MARGIN_TOKENS).toBeCloseTo(SINGLE_READ_TOKEN_CAP * scale.HARNESS_TOKEN_MAX_ERROR_FRACTION, 6);
+  });
+});
+
+describe('FR-2: contractReadVerdict.confirmed_partial is disproof-only, not mere inability-to-confirm', () => {
+  const fitMarginal = { fits: null, basis: 'predicted_marginal', tokens: 25236 };
+  const fitOver = { fits: false, basis: 'predicted_bytes', tokens: 31000 };
+
+  it('a marginal fit with only a >=95% REQUESTED union reads unconfirmed, not confirmed_partial', () => {
+    const status = { readCount: 2, lastReadWasPartial: false, ranges: [{ offset: 1, limit: 400 }], lastDelivered: null };
+    const v = contractReadVerdict(status, 400, { singleReadFit: fitMarginal });
+    expect(v.basis).toBe('requested_ranges_unconfirmed');
+    expect(v.fully_read).toBe(false);
+    expect(v.confirmed_partial).toBe(false);
+  });
+
+  it('a sub-95% REQUESTED union is positive disproof: confirmed_partial true', () => {
+    const status = { readCount: 1, lastReadWasPartial: true, ranges: [{ offset: 1, limit: 100 }], lastDelivered: null };
+    const v = contractReadVerdict(status, 400, { singleReadFit: fitOver });
+    expect(v.basis).toBe('requested_ranges_incomplete');
+    expect(v.confirmed_partial).toBe(true);
+  });
+
+  it('a no-offset read of a marginal contract lands in unknown_coverage, confirmed_partial false', () => {
+    const status = { readCount: 1, lastReadWasPartial: false }; // no ranges, no delivered
+    const v = contractReadVerdict(status, 400, { singleReadFit: fitMarginal });
+    expect(v.basis).toBe('unknown_coverage');
+    expect(v.confirmed_partial).toBe(false);
+  });
+
+  it('lastReadWasPartial === true is positive disproof even with no range evidence (offset/limit was used)', () => {
+    // The reader deliberately used offset/limit. That flag is reliable in the TRUE direction (only a
+    // silent truncation is unreliable, and that records FALSE), so it is confirmed_partial.
+    const status = { readCount: 1, lastReadWasPartial: true };
+    const v = contractReadVerdict(status, 400, { singleReadFit: fitMarginal });
+    expect(v.basis).toBe('unknown_coverage');
+    expect(v.confirmed_partial).toBe(true);
+  });
+
+  it('measured short delivery (delivered_ranges < 95%) is confirmed_partial true', () => {
+    const status = {
+      readCount: 1, lastReadWasPartial: false,
+      deliveredRanges: [{ offset: 1, limit: 100 }], lastDelivered: { totalLines: 400, numLines: 100 },
+    };
+    const v = contractReadVerdict(status, 400, { singleReadFit: fitOver });
+    expect(v.confirmed_partial).toBe(true);
+  });
+});
+
+describe('FR-2 end-to-end: solomon-register stops asserting PARTIAL on the marginal file, still flags oversized', () => {
+  it('a full no-offset read of the real-size (near-cap) CLAUDE_SOLOMON.md yields no PARTIAL banner', () => {
+    const dir = makeProjectDir(61013, { readCount: 1, lastReadWasPartial: false, lastReadAt: '2026-08-10T00:00:00Z' });
+    const check = solomon.checkContractRead(dir);
+    expect(check.contract_read).toBe(true);
+    expect(check.contract_read_partial).toBe(false);
+    expect(solomon.contractReadBanner(check)).toBeNull();
+  });
+
+  it('a full no-offset read of a genuinely oversized CLAUDE_SOLOMON.md STILL banners (criterion #2)', () => {
+    const dir = makeProjectDir(75000, { readCount: 1, lastReadWasPartial: false, lastReadAt: '2026-08-10T00:00:00Z' });
+    const check = solomon.checkContractRead(dir);
+    expect(check.contract_read).toBe(true);
+    expect(check.contract_read_partial).toBe(true);
+    expect(solomon.contractReadBanner(check)).toContain('READ REQUIRED');
+  });
+});


### PR DESCRIPTION
## Summary
`singleReadFit` predicted CLAUDE_SOLOMON.md at **25,236 tokens** (0.94% over the 25,000 cap, inside the byte model's documented **6.80% max error**) and returned a hard `fits:false`. The three role-activation consumers collapsed that to `contract_read_partial = !verdict.fully_read`, so every `/solomon` full read banner-ed *"was PARTIAL (offset/limit used)"* for a file that reads clean in one no-offset call — a prediction asserted as a measurement.

## Changes
- **FR-1** — `singleReadFit` margin-bands the predictor: a prediction within `HARNESS_TOKEN_MAX_ERROR_FRACTION` (6.80%, exported from `harness-token-scale.cjs`) of the cap returns the first-class `fits:null` (basis `predicted_marginal`) instead of a coin-flip boolean.
- **FR-2** — `contractReadVerdict` gains `confirmed_partial`, TRUE only on **positive disproof** of a full read (measured short delivery, sub-95% requested union, `lastReadWasPartial===true`), FALSE for the upper-bound-only / unknown paths. The three consumers derive `contract_read_partial = confirmed_partial || (fit.fits === false && !fully_read)` — a marginal contract reads unconfirmed (no banner), a genuinely oversized one still flags. `fully_read:true` is never over-claimed from a marginal prediction.
- Also fixes `roleArmingStates` so a marginal contract reports *"near the read cap … single-read fit unconfirmed"* instead of borrowing the no-tokenizer "not measurable" message.

## Blast radius
Contained to role-activation banners. **Handoff gating is untouched** — `protocol-file-read-gate.js` reads the tracker's `lastReadWasPartial` stamp, not this verdict.

## Verification
- 11 new tests (`tests/unit/contract-read-fit-marginal.test.js`), incl. end-to-end through the real `solomon-register.checkContractRead`.
- 122 existing coverage / groundtruth / register tests green.
- Live coordinator-startup-check confirmed: `solomon : disarmed — CLAUDE_SOLOMON.md is near the read cap (25236 tokens vs 25000 cap, within the model's error band) — single-read fit unconfirmed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)