### PR TITLE
fix(SD-LEO-INFRA-DRIVE-SCORE-LEG1-001): leg1's unavailable reason tells the measured truth — unearnable-as-ratified, not not-wired

### DIFF
--- a/.prd-payloads/PRD-SD-LEO-INFRA-DRIVE-SCORE-LEG1-001.json
+++ b/.prd-payloads/PRD-SD-LEO-INFRA-DRIVE-SCORE-LEG1-001.json
@@ -1,0 +1,49 @@
+{
+  "executive_summary": "Ruled down from full leg1 wiring to the honest-truth update (coordinator ruling fea8b4c4, Option B of the spec-conflict escalation; Option A — redefining the landing question — travels to the chairman via Adam in parallel). VALIDATION measured (evidence ab82da6b, SHA-accurate) that the ratified leg1 rule (merge-base --is-ancestor, d50b9f12) is unearnable in this delete-branch-on-merge flow: the named input set (open_items_all) is definitionally the not-landed set (live: 1 item, 0 promoted), and even over the favourable 111-completed-items population only 7 branches are ancestors (18 absent, 86 not-ancestor). Wiring as originally scoped would have moved the chairman drive score from an honest 0/0-unmeasured to a PERMANENT FALSE 0/2-measured — the exact harm the aggregate's own header forbids. This SD ships the one honest change that needs no chairman surface: the leg1 unavailable REASON stops claiming 'not wired' (now false — the leg is fully built) and records the measured unearnability with its evidence and ruling references, pinned so it cannot silently regress.",
+  "functional_requirements": [
+    {
+      "id": "FR-1",
+      "title": "The leg1 unavailable reason tells the measured truth",
+      "priority": "high",
+      "description": "scripts/cron/drive-report-sweep.mjs (~line 292): replace the leg1 unavailable reason — currently 'scoreLeg1 needs the same uncapped chain-item set as the belt sections, plus a git runner in the job; neither is wired into this cron', a claim now FALSE on both halves (the leg module is fully built and tested; the chain-item set is already fetched in this cron) — with the measured truth: the ratified ancestry rule (d50b9f12) is unearnable in a delete-branch-on-merge flow (7/111 ancestors over the favourable completed population, 18 branches absent, 86 not-ancestor; the open-item input set is definitionally not-landed), held pending the chairman decision on the landing-question redefinition, citing evidence ab82da6b and ruling fea8b4c4. leg1 REMAINS unavailable — no semantics change; the chairman score is never a false 0/2.",
+      "acceptance_criteria": [
+        "The stale not-wired reason text is gone from the sweep (grep-clean).",
+        "The new reason names: unearnable-as-ratified, the delete-branch-on-merge mechanism, the 7/111 measurement, evidence ab82da6b, ruling fea8b4c4, and that the redefinition is chairman-pending."
+      ]
+    },
+    {
+      "id": "FR-2",
+      "title": "Two-sided regression pin on the reason",
+      "priority": "high",
+      "description": "Add a test in tests/unit/cron/drive-report-sweep.test.js asserting the leg1 unavailable reason matches the load-bearing new phrases (unearnable + the ruling reference) AND does not match the old 'neither is wired' text — so the honest text cannot silently regress in either direction (back to the stale claim, or to some third unvetted wording that drops the provenance).",
+      "acceptance_criteria": [
+        "The pin reds when the reason is reverted to the old text (proven by mutation).",
+        "The pin reds when the ruling reference is dropped from the new text (proven by mutation)."
+      ]
+    },
+    {
+      "id": "FR-3",
+      "title": "The unavailability CONTRACT is byte-preserved — nothing else changes",
+      "priority": "medium",
+      "description": "The ruling's OUT boundary as a verifiable requirement: leg1 still resolves unavailable (driveScore.possible === 0, measured_legs === [], unavailable_legs length 3 — the existing pins at tests/unit/cron/drive-report-sweep.test.js :356-366 stay green byte-unchanged), and the diff touches ONLY the sweep and its test file: no leg module edits, no workflow edits, no wiring groundwork (that ships only after the chairman rules on Option A).",
+      "acceptance_criteria": [
+        "Existing leg-set and possible===0 pins pass without modification.",
+        "The three-dot PR diff contains exactly two files: scripts/cron/drive-report-sweep.mjs and tests/unit/cron/drive-report-sweep.test.js (plus the PRD payload)."
+      ]
+    }
+  ],
+  "technical_requirements": [
+    { "id": "TR-1", "title": "Truth over scaffolding", "description": "Only the reason string and its pin change. The ratified leg definition, the sweep's structure, the workflow, and all wiring groundwork are untouched — groundwork ships only after the chairman rules on Option A." }
+  ],
+  "test_scenarios": [
+    { "id": "TS-1", "scenario": "Gather with the fixture harness", "type": "unit", "expected": "leg1 unavailable with the NEW reason; possible 0; three unavailable legs" },
+    { "id": "TS-2", "scenario": "Reason regression pin", "type": "unit", "expected": "Matches unearnable+ruling phrases; rejects the old not-wired text" }
+  ],
+  "acceptance_criteria": [
+    "One-file source diff (sweep) plus its test file; existing pins green unchanged; the new pin two-sided (matches new, rejects old).",
+    "The chairman-facing surfaces keep rendering an honest unmeasured score."
+  ],
+  "risks": [
+    { "risk": "The reason text drifts from what Option A eventually decides.", "mitigation": "The text says chairman-pending and cites the ruling; the Option A SD (or amendment) supersedes it explicitly.", "severity": "low" }
+  ]
+}

--- a/scripts/cron/drive-report-sweep.mjs
+++ b/scripts/cron/drive-report-sweep.mjs
@@ -289,7 +289,15 @@ export function buildGather({ supabase, computePlanCheckStatus, gatherCapacity, 
     // fabricating a measurement. aggregateScore already discloses that the denominator is
     // unratified, and excludes unavailable legs from it rather than scoring them zero.
     const legs = [
-      { leg: LEG1_ID, unavailable: unavailable('scoreLeg1 needs the same uncapped chain-item set as the belt sections, plus a git runner in the job; neither is wired into this cron') },
+      // SD-LEO-INFRA-DRIVE-SCORE-LEG1-001 (Option B, coordinator ruling fea8b4c4): the old
+      // reason claimed "not wired", which became false on both halves — the leg module is fully
+      // built and tested, and the chain-item set is already fetched above. The TRUE blocker is
+      // the ratified rule itself, measured (VALIDATION evidence ab82da6b): ancestry-by-branch-ref
+      // cannot be earned in a delete-branch-on-merge flow, and the open-item input set is
+      // definitionally the not-landed set. Redefining the landing question is a chairman-surfaced
+      // spec change (parent SD's own gate), in flight via Adam. Until it lands, leg1 stays
+      // honestly UNAVAILABLE — never a false 0-of-2 measurement on the chairman's score.
+      { leg: LEG1_ID, unavailable: unavailable('scoreLeg1 is built but its ratified rule (merge-base ancestry, d50b9f12) is unearnable in this delete-branch-on-merge flow — measured 7/111 ancestors over even the favourable completed population (18 branches absent, 86 not-ancestor), and the open-item input set is definitionally not-landed (evidence ab82da6b). Held unavailable pending the chairman decision on the landing-question redefinition (ruling fea8b4c4).') },
       { leg: LEG2_ID, unavailable: unavailable('scoreLeg2 needs the ranked top-5 backlog, which this job does not query') },
       await scoreCapacityLeg({ gatherCapacity, persistVerdict, runId: capacityRunId }),
     ];

--- a/tests/unit/cron/drive-report-sweep.test.js
+++ b/tests/unit/cron/drive-report-sweep.test.js
@@ -367,6 +367,20 @@ describe('gather — what this job can HONESTLY measure today', () => {
     expect(ids.some((i) => /leg3/.test(i)), 'leg 3 appears zero times in the SD and the PRD').toBe(false);
   });
 
+  it('leg1 reason tells the MEASURED truth, with provenance — not the stale not-wired claim', async () => {
+    // SD-LEO-INFRA-DRIVE-SCORE-LEG1-001 (Option B, ruling fea8b4c4). This pin is the ONLY
+    // instrument that observes the reason text (measured: swapping it left 531/531 green), so
+    // both halves are load-bearing. Read through unavailable_legs — LEGS do not use the
+    // sections' `.unavailable.reason` idiom; copying it reads undefined and vacuously passes.
+    const { driveScore } = await gather();
+    const reason = driveScore.unavailable_legs.find((l) => l.leg === 'leg1_landed').reason;
+    expect(reason).toMatch(/unearnable/i);            // the finding, not a wiring excuse
+    expect(reason).toMatch(/7\/111/);                 // the population-scoped measurement
+    expect(reason).toMatch(/ab82da6b/);               // VALIDATION evidence provenance
+    expect(reason).toMatch(/fea8b4c4/);               // the coordinator ruling holding it
+    expect(reason).not.toMatch(/neither is wired/);   // the stale claim's unique fingerprint
+  });
+
   it('composes into a report the producer will accept', async () => {
     // The end-to-end shape, so "gather returns something" is not the claim — composeReport
     // refuses a sectionless report, and this proves the real gather clears that bar.


### PR DESCRIPTION
## Summary
- Option B of coordinator ruling **fea8b4c4** (Option A — the chairman-surfaced landing-question redefinition — travels via Adam in parallel). The leg1 `unavailable` reason in `scripts/cron/drive-report-sweep.mjs` stops claiming 'not wired' (false on both halves: the leg module is fully built; the chain-item set is already fetched) and records the **measured** truth: the ratified ancestry rule (d50b9f12) is unearnable in a delete-branch-on-merge flow — 7/111 ancestors over even the favourable completed population (18 absent, 86 not-ancestor), and the open-item input set is definitionally not-landed (VALIDATION evidence ab82da6b).
- **leg1 stays unavailable** — no semantics change, `possible` stays 0, the chairman score is never a false 0/2 (the exact harm the aggregate's own header forbids and the reason the original wiring scope was ruled down).
- New two-sided pin: the ONLY instrument observing the reason (measured: a reason-swap left 531/531 green pre-pin) — asserts the finding, the 7/111 measurement, both provenance refs, rejects the stale fingerprint; existing leg-set pins byte-unchanged (md5-verified).

## Test plan
- [x] 46/46 in-suite; 509 wider regression green; both author mutation reds OBSERVED (revert / provenance-drop) + 4 independent TESTING mutations killed (incl. loud-TypeError degradation, never vacuous)
- [x] TESTING PASS conf 95 (ef9fb653); SECURITY PASS conf 92 (ce8f0e0b — SMS surface reads counts only, no string passthrough)
- [x] Three-file diff: sweep + test + PRD payload; zero DDL

🤖 Generated with [Claude Code](https://claude.com/claude-code)