### PR TITLE
fix(QF-20260808-951): gitignore + untrack .workflow-patterns.json auto-gen cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,12 @@ verification-packages/
 .worktree.json
 .worktree-nm-mode
 
+# QF-20260808-951: regenerable pattern-cache written by lib/workflow-review/pattern-cache.js.
+# Same class as above -- tracking it means a `git merge --ff-only origin/main` aborts with
+# "local changes would be overwritten" whenever the local process and an upstream commit
+# both touch it, blocking the shared root's fast-forward.
+.workflow-patterns.json
+
 # Backup files (git already provides versioning)
 *.backup
 *.bak

--- a/.workflow-patterns.json
+++ b/.workflow-patterns.json
@@ -1,8 +1,0 @@
-{
-  "error_recovery": [],
-  "confirmation_modals": [],
-  "form_validation": [],
-  "loading_patterns": [],
-  "navigation": [],
-  "last_scan": "2026-08-09T02:42:38.460Z"
-}


### PR DESCRIPTION
## Summary
`.workflow-patterns.json` is a tracked auto-generated cache (`lib/workflow-review/pattern-cache.js`). Both the local pattern-cache process and upstream commits mutate it, so `git merge --ff-only origin/main` aborts with "local changes would be overwritten" and the shared root can't fast-forward past it.

- Added `.workflow-patterns.json` to `.gitignore`
- `git rm --cached` it (file itself untouched on disk — cache still regenerates locally)

## Test plan
- [x] `git ls-files .workflow-patterns.json` returns empty (untracked)
- [x] `git check-ignore -v .workflow-patterns.json` confirms it's now ignored
- [x] File still present on disk at its original size (pattern-cache.js unaffected)

QF-20260808-951

🤖 Generated with [Claude Code](https://claude.com/claude-code)