### PR TITLE
fix(QF-20260810-285): adam-chairman-sms CLI gains --reply-to-inbound so the shipped presence carve-out is reachable

### DIFF
--- a/scripts/adam-chairman-sms.mjs
+++ b/scripts/adam-chairman-sms.mjs
@@ -9,10 +9,13 @@ import { resolveAllowQuietHours } from '../lib/comms/adam-outbound/quiet-hours-e
 
 enforceCliSendGuard({
   scriptName: 'scripts/adam-chairman-sms.mjs',
-  flags: [{ name: '--dry-run' }, { name: '--body', takesValue: true }, { name: '--kind', takesValue: true }, { name: '--dedupe-key', takesValue: true }],
+  flags: [{ name: '--dry-run' }, { name: '--body', takesValue: true }, { name: '--kind', takesValue: true }, { name: '--dedupe-key', takesValue: true }, { name: '--reply-to-inbound' }],
 });
 
 const DRY = process.argv.includes('--dry-run');
+// QF-20260810-285: declares a reply-class send so the chairman-sms-gate's measured-presence
+// quiet-hours carve-out (chairman-sms-gate/index.js) is reachable from the CLI at all.
+const REPLY_TO_INBOUND = process.argv.includes('--reply-to-inbound');
 function argValue(flag) {
   const i = process.argv.indexOf(flag);
   return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : null;
@@ -33,7 +36,7 @@ if (DRY) {
 } else {
   // QF-20260720-824: honor a recorded chairman window-extension; default window unchanged.
   const now = new Date();
-  const context = { now, allowQuietHours: await resolveAllowQuietHours(now) };
+  const context = { now, allowQuietHours: await resolveAllowQuietHours(now), replyToInbound: REPLY_TO_INBOUND };
   const r = await sendChairmanSMS(message, context);
   console.log('ADAM-CHAIRMAN-SMS', JSON.stringify(r));
 }

--- a/scripts/adam-quiet-tick.mjs
+++ b/scripts/adam-quiet-tick.mjs
@@ -947,7 +947,7 @@ async function main() {
         console.log(`QUIET_TICK_SMS_SUPPRESSED=adam ${detail} — undrained chairman SMS, but SMS_RELAY_DRAIN_ENABLED is unset so scripts/sms-relay-drain.cjs is a no-op. Recorded so sms=${smsInbound.count} never coexists with zero surfaced rows; INFORMATIONAL, not a hard interrupt. Durable fix: complete the SMS drain cutover.`);
         continue;
       }
-      console.log(`QUIET_TICK_SMS_INBOUND=adam ${detail} — undrained chairman SMS; DRAIN+reply per CHAIRMAN SMS CHANNEL DUTY (node scripts/sms-relay-drain.cjs)`);
+      console.log(`QUIET_TICK_SMS_INBOUND=adam ${detail} — undrained chairman SMS; DRAIN+reply per CHAIRMAN SMS CHANNEL DUTY (node scripts/sms-relay-drain.cjs, then reply with node scripts/adam-chairman-sms.mjs --reply-to-inbound --kind heartbeat_status --body "<line>" to reach the quiet-hours measured-presence carve-out)`);
     }
     // SD-LEO-INFRA-CHAIRMAN-INBOUND-VISIBILITY-001 FR-2: a parked row already terminal-drained
     // (drained_at is set) as no_match/rate_limited, so it will NEVER appear in the smsInbound

--- a/tests/unit/comms/adam-chairman-sms-cli-reply-flag.test.js
+++ b/tests/unit/comms/adam-chairman-sms-cli-reply-flag.test.js
@@ -1,0 +1,48 @@
+/**
+ * QF-20260810-285 — adam-chairman-sms CLI gains --reply-to-inbound so the shipped
+ * measured-presence quiet-hours carve-out (chairman-sms-gate/index.js:219,
+ * presence-reply-window.js) is actually reachable. Before this fix the flag did not
+ * exist: enforceCliSendGuard's flag-strict guard (QF-20260709-211) rejected
+ * `--reply-to-inbound` as unknown and exited 1, so a reply-class send could never set
+ * context.replyToInbound and the resolver was never consulted.
+ *
+ * Full context.replyToInbound -> presenceResolver behavior is already covered at the
+ * gate level in tests/unit/comms/adam-outbound/presence-reply-window.test.js
+ * (TS-1..TS-6). What was untested -- and what broke in production -- is the CLI
+ * wiring itself, so this spins the real script as a subprocess (matching the
+ * apply-migration-cli.test.js convention) rather than re-testing the gate.
+ */
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO = path.resolve(__dirname, '..', '..', '..');
+const SCRIPT = path.join(REPO, 'scripts', 'adam-chairman-sms.mjs');
+
+function run(args) {
+  return spawnSync(process.execPath, [SCRIPT, ...args], { encoding: 'utf8', cwd: REPO });
+}
+
+describe('adam-chairman-sms CLI --reply-to-inbound', () => {
+  it('REGRESSION: is accepted by the flag-strict guard, not rejected as unknown', () => {
+    // --dry-run short-circuits before any send/DB call, so this exercises exactly the
+    // guard boundary that used to fail closed on this flag (QF-20260709-211 shape).
+    const res = run(['--dry-run', '--body', 'test', '--reply-to-inbound']);
+    expect(res.status).toBe(0);
+    expect(res.stderr).not.toMatch(/Unknown flag/);
+  });
+
+  it('is documented in --help usage', () => {
+    const res = run(['--help']);
+    expect(res.status).toBe(0);
+    expect(res.stdout).toContain('--reply-to-inbound');
+  });
+
+  it('an unrelated unknown flag still fails closed (guard is not globally disabled)', () => {
+    const res = run(['--dry-run', '--body', 'test', '--not-a-real-flag']);
+    expect(res.status).toBe(1);
+    expect(res.stderr).toMatch(/Unknown flag/);
+  });
+});


### PR DESCRIPTION
## Quick-Fix: QF-20260810-285

**Type:** bug
**Severity:** high

### Issue Description
Add --reply-to-inbound flag to scripts/adam-chairman-sms.mjs: sets context.replyToInbound=true and context.now=Date.now() (the gate lint requires a clock) before calling sendChairmanSMS. Update the quiet-tick SMS_INBOUND remediation text to name the flag. Fix shape verified at def-site: gate branch lib/comms/adam-outbound/chairman-sms-gate/index.js:220 fires only on that context key; resolver lib/comms/adam-outbound/presence-reply-window.js works when invoked (measured allowed:true on a live grant tonight).

### Steps to Reproduce
During ET quiet hours with chairman inbound <15min old: node scripts/adam-chairman-sms.mjs --kind heartbeat_status --body test

### Expected Behavior
Reply-class send passes via measured_presence_reply grant

### Actual Behavior
Blocked quiet_hours; carve-out unreachable (no flag sets the context)

### Changes
- **Files Changed:** 3
  - scripts/adam-chairman-sms.mjs
  - scripts/adam-quiet-tick.mjs
  - tests/unit/comms/adam-chairman-sms-cli-reply-flag.test.js
- **LOC:** 54 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol