### PR TITLE
fix(QF-20260810-738): CONST-010 MANIPULATIVE_PATTERNS: bare 'urgent' must require an action-urging construction (negation-blind)

### DIFF
--- a/lib/adam/rationale-bar.js
+++ b/lib/adam/rationale-bar.js
@@ -119,8 +119,15 @@ export const REQUIRED_RATIONALE_FIELDS = [
 // its own governance gate. Both are worse than this.
 //
 // 'urgent' stays bare-blocked: verified it is NOT an enum value on any of those columns.
+//
+// QF-20260810-738 — 'urgent' was negation-blind: \burgent(?:ly)?\b matched THROUGH the hyphen
+// word-boundary in 'not-urgent'/'non-urgent', so factual severity REPORTING ("presses on
+// nothing urgent") refused two legitimate Adam->Solomon disposition sends 2026-08-09. Unlike
+// 'critical'/'immediately' above, 'urgent' still bare-blocks (it is not a live enum value) —
+// this only exempts the negated framing itself via a lookbehind, so 'act urgently' etc. are
+// untouched and still block.
 export const MANIPULATIVE_PATTERNS =
-  /\b(urgent(?:ly)?|act now|act fast|must act|(?:act|respond|reply|decide|approve|escalate)\s+immediately|critical(?:ly)?\s+(?:important|urgent)|(?:it'?s|it is|is)\s+critical\s+that|guaranteed|certainly|definitely|absolutely|you (?:need|have) to|don'?t miss|last chance)\b/i;
+  /\b((?<!not-)(?<!not )(?<!non-)(?<!non )(?<!nothing )urgent(?:ly)?|act now|act fast|must act|(?:act|respond|reply|decide|approve|escalate)\s+immediately|critical(?:ly)?\s+(?:important|urgent)|(?:it'?s|it is|is)\s+critical\s+that|guaranteed|certainly|definitely|absolutely|you (?:need|have) to|don'?t miss|last chance)\b/i;
 
 /**
  * Compute an OKR-weighted score for a candidate from the KR it cites.

--- a/lib/governance/guard-wiring-registry.js
+++ b/lib/governance/guard-wiring-registry.js
@@ -195,7 +195,7 @@ export const GUARD_REGISTRY = deepFreeze([
   {
     name: 'capabilityGapTerm',
     module: 'lib/adam/rationale-bar.js',
-    definedAt: 'lib/adam/rationale-bar.js:286',
+    definedAt: 'lib/adam/rationale-bar.js:293',
     gatedInput: 'capability',
     permissiveMeans: 'the capability-gap term contributes nothing to the rationale bar',
     expectedWired: false,

--- a/tests/unit/coordinator/adam-outbound-gate.test.js
+++ b/tests/unit/coordinator/adam-outbound-gate.test.js
@@ -83,6 +83,30 @@ describe('rationaleBar — advisory rationale bar (FR-2 / TS-1, TS-2)', () => {
     });
   });
 
+  // ── QF-20260810-738: 'urgent' was negation-blind — \burgent\b matched THROUGH the hyphen
+  // word-boundary in 'not-urgent'/'non-urgent'. Witnessed 2026-08-09: reworded two legitimate
+  // Adam->Solomon disposition sends to avoid this exact false positive. ──
+  describe('QF-20260810-738 — negated urgency reporting is not manipulation', () => {
+    it('the witnessed passing fixture: factual severity reporting with "nothing urgent"', () => {
+      const body = 'Overnight sweep presses on nothing urgent; rationale: routine backlog scan.';
+      expect(MANIPULATIVE_PATTERNS.test(body)).toBe(false);
+      const r = checkAdamOutbound({ body, kind: ADVISORY });
+      expect(r.checks.rationaleBar.pass).toBe(true);
+    });
+
+    it('hyphenated and spaced negation prefixes all pass', () => {
+      for (const body of ['not-urgent', 'non-urgent', 'not urgent', 'non urgent', 'nothing urgent']) {
+        expect(MANIPULATIVE_PATTERNS.test(body)).toBe(false);
+      }
+    });
+
+    it('STILL blocks genuine urgency framing around the same word (the witnessed blocking fixture)', () => {
+      for (const body of ['act urgently', 'urgent', 'urgently']) {
+        expect(MANIPULATIVE_PATTERNS.test(body)).toBe(true);
+      }
+    });
+  });
+
   it('passes a well-reasoned advisory', () => {
     const r = checkAdamOutbound({ body: 'Recommend parking Alt-Text because demand-test CHECK forbids truth_ metrics; rationale: no live anchor.', kind: ADVISORY });
     expect(r.checks.rationaleBar.pass).toBe(true);


### PR DESCRIPTION
## Quick-Fix: QF-20260810-738

**Type:** bug
**Severity:** medium

### Issue Description
lib/adam/rationale-bar.js MANIPULATIVE_PATTERNS bare-blocks \burgent(ly)?\b, so factual severity REPORTING like 'not-urgent'/'non-urgent' matches through the hyphen word-boundary and refused two legitimate Adam->Solomon disposition sends 2026-08-09 ~8:15pm ET (witnessed; reworded to pass). QF-20260727-129 already fixed this exact class for 'critical'/'immediately' (key on framing, not tokens-that-are-also-data) but left 'urgent' bare on an enum-check rationale that does not cover negated forms. Fix shape per the file's own precedent: require an action-urging construction around 'urgent' (act urgently / urgent: do X) or add a negative lookbehind for not-/non- prefixes; add the witnessed 'presses on nothing urgent' phrasing as a passing fixture and 'act urgently' as a blocking fixture.

### Steps to Reproduce
node scripts/adam-advisory.cjs send with a body containing 'not-urgent' and required rationale markers

### Expected Behavior
Send passes; severity reporting is not action-urging

### Actual Behavior
Blocked: rationaleBar manipulative/urgent/certainty framing (CONST-010)

### Changes
- **Files Changed:** 2
  - lib/adam/rationale-bar.js
  - tests/unit/coordinator/adam-outbound-gate.test.js
- **LOC:** 32 lines
- **Tests:** ✅ Passing
- **UAT:** ✅ Verified

### Verification
No additional notes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
Quick-Fix Workflow - LEO Protocol