### PR TITLE
docs(SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001): sync CLAUDE.md with the chairman sleep-window policy update

### DIFF
--- a/CLAUDE_ADAM.md
+++ b/CLAUDE_ADAM.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 355b0e33be6c4716 -->
+<!-- file_content_hash: 2447be82248b2ee2 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM.md - Adam Role Contract
 
-**Generated**: 2026-08-04 12:36:22 AM
+**Generated**: 2026-08-11 4:01:47 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Adam role contract — Chairman-attached advisory/analysis session
 **Load when**: Running /adam, or orienting an operator-attached advisory session
@@ -243,7 +243,7 @@ The Twilio bridge carries ONLY the Adam→chairman leg (worker → coordinator �
 - **(c) GATES ON EVERY SEND** — the pre-send rubric; **spend NEVER by SMS (console only)**; PROFESSIONAL-CASUAL plain English (complete sentences, no protocol shorthand); ≤2 messages; no secrets in bodies.
 - **(c2) RATIFIED FORMAT (not optional)** — every SMS-decide is self-contained: terse context → LABELED options (A/B/C, or YES/NO) → Adam's RECOMMENDED option + one-line rationale → explicit reply instruction. **ONE question per message; ONE decision outstanding at a time** (serialized; urgent jumps the queue). DETAILS returns fuller context. Unexpected replies get a CLARIFYING reply, **never a silent drop**; parsing accepts natural variants. **REDUCIBILITY RULE**: a question that cannot reduce to a small labeled option set is NOT an SMS-decide — send NOTIFY + console link. *The format IS the routing enforcement.*
 - **NO-REPLY POLICY** — retries up to TWO times at ~40-min intervals, then AUTO-APPLIES the stated default. **Guardrails**: only items with a genuinely SAFE default (reversible, non-spend) auto-proceed; an item with NO safe default STAYS HELD and escalates. **ALL spend is console-only, never auto.** Each retry restates the question and notes the pending auto-default.
-- **CHAIRMAN SLEEP WINDOW — 22:00–06:00 America/New_York, computed with the DST-aware IANA timezone (never a hardcoded UTC offset).** During the window: (a) NO outbound except a genuine can-wait-till-morning CRITICAL, written to be READ on waking and never expecting a reply — everything else QUEUES and FLUSHES at 06:00 ET as one tidy morning batch; (b) **the retry/auto-default clock is FROZEN** — nothing auto-defaults overnight; (c) INBOUND is still honored — if he texts, it is processed normally.
+- **CHAIRMAN SLEEP WINDOW — 22:00–06:00 in the chairman's actual location zone** (default America/New_York, DST-aware IANA timezone, never a hardcoded UTC offset; resolves to a different zone only when Adam has recorded a captured chairman-location ruling via `notifications.timezone` — SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001). During the window: (a) NO outbound except a genuine can-wait-till-morning CRITICAL, written to be READ on waking and never expecting a reply — everything else QUEUES and FLUSHES at 6:00 AM in that same zone as one tidy morning batch; (b) **the retry/auto-default clock is FROZEN** — nothing auto-defaults overnight; (c) INBOUND is still honored — if he texts, it is processed normally.
 - **(c3) ROUTINE HEARTBEAT = a brief HOURLY SMS, not the hourly email.** Cadence is **HOURLY** — chairman verbal 2026-07-31 ~16:10Z, *"make sure I am getting hourly updates via text per the documentation"*, which SUPERSEDES the 2026-07-19 temporary 30-minute override. Quiet hours 22:00–06:00 ET still apply. The EMAIL path is RESERVED for content that needs length: research findings, full decision packets, the NEEDS-YOU list.
 - **(c4) DAILY 6:00 AM ET MORNING BRIEF BY SMS** — plan-first, professional-casual, self-contained, riding the sleep-window flush. **Durable and self-healing without a live Adam session** (GHA cron with a per-ET-date dedupe key; a failed first attempt sends late on a later tick).
 - **(d) DEGRADED MODE** — with no live Adam session, chairman texts queue durably in staging. Nothing is lost; act on arrival-order at next session start.
@@ -398,6 +398,6 @@ _Hierarchy note (chairman-ratified D-0719-ORGCHART "A", 2026-07-19): this partne
 
 ---
 
-*Generated from database: 2026-08-04*
+*Generated from database: 2026-08-11*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_DIGEST.md
+++ b/CLAUDE_ADAM_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-03T13:37:56.000Z -->
-<!-- git_commit: 9809add6 -->
-<!-- db_snapshot_hash: 31945d3b870a9f44 -->
-<!-- file_content_hash: 80ea775ceed59e00 -->
+<!-- generated_at: 2026-08-11T09:01:47.097Z -->
+<!-- git_commit: dfb9f70c -->
+<!-- db_snapshot_hash: 8de3099c543fb99b -->
+<!-- file_content_hash: 5d1eb9c164d345cc -->
 
 # CLAUDE_ADAM_DIGEST.md - Adam Role (Enforcement)
 

--- a/CLAUDE_ADAM_MANUAL.md
+++ b/CLAUDE_ADAM_MANUAL.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 41ac71b8e45c6f71 -->
+<!-- file_content_hash: 97e8f960aea98ae2 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM_MANUAL.md — Adam Manual (how-to companion)
 
-**Generated**: 2026-08-04 12:36:22 AM
+**Generated**: 2026-08-11 4:01:47 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: How-to procedures lifted out of the role contract — SD creation field shapes, migration ceremony steps, gauge inputs
 **Load when**: At the MOMENT OF DOING the procedure — not at session start
@@ -113,6 +113,6 @@ It guards two opposed failure modes, both probed by the self-adherence review (`
 
 ---
 
-*Generated from database: 2026-08-04*
+*Generated from database: 2026-08-11*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_manual). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_ADAM_PROVENANCE.md
+++ b/CLAUDE_ADAM_PROVENANCE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 0d5f80568bbde47b -->
+<!-- file_content_hash: 5ca8f035ae31529e -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_ADAM_PROVENANCE.md — Adam Provenance (dated rationale)
 
-**Generated**: 2026-08-04 12:36:22 AM
+**Generated**: 2026-08-11 4:01:47 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Why each clause exists — dated chairman verbals, live witnesses, superseded cadences
 **Load when**: When you need to know WHY a rule exists, or before proposing to change one
@@ -65,6 +65,6 @@ Do not read a missing entry as "this rule has no provenance". Coverage is roughl
 
 ---
 
-*Generated from database: 2026-08-04*
+*Generated from database: 2026-08-11*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=adam_provenance). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_COORDINATOR.md
+++ b/CLAUDE_COORDINATOR.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: e8e789d722f53bac -->
+<!-- file_content_hash: a67d31b7ba97e500 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_COORDINATOR.md - Coordinator Role Contract
 
-**Generated**: 2026-08-04 12:36:22 AM
+**Generated**: 2026-08-11 4:01:47 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical coordinator role + SRE charter — fleet supervisor session
 **Load when**: Running /coordinator, or orienting a fleet-coordinator session
@@ -94,6 +94,6 @@ _Hierarchy note (chairman-ratified D-0719-ORGCHART "A", 2026-07-19): this partne
 
 ---
 
-*Generated from database: 2026-08-04*
+*Generated from database: 2026-08-11*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=coordinator_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_COORDINATOR_DIGEST.md
+++ b/CLAUDE_COORDINATOR_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-03T13:37:56.000Z -->
-<!-- git_commit: 9809add6 -->
-<!-- db_snapshot_hash: 31945d3b870a9f44 -->
-<!-- file_content_hash: d34b0d16e63399fa -->
+<!-- generated_at: 2026-08-11T09:01:47.097Z -->
+<!-- git_commit: dfb9f70c -->
+<!-- db_snapshot_hash: 8de3099c543fb99b -->
+<!-- file_content_hash: 6473b055b1c344b5 -->
 
 # CLAUDE_COORDINATOR_DIGEST.md - Coordinator Role (Enforcement)
 

--- a/CLAUDE_CORE.md
+++ b/CLAUDE_CORE.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 0f526e3d7ab3d6d9 -->
+<!-- file_content_hash: 01503bca1805094b -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_CORE.md - LEO Protocol Core Context
 
-**Generated**: 2026-08-04 12:36:22 AM
+**Generated**: 2026-08-11 4:01:47 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Essential workflow context for all sessions
 **Effort**: medium (core context; phase-specific files tag their own effort for phase work)
@@ -1591,7 +1591,7 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 |------------|----------|----------|-------|-------|--------------|
 | PAT-HF-PLANTOLEAD-27a62713 | handoff_failure | [HIGH] high | 7 | [STABLE] | N/A |
 | PAT-RETRO-PLANTOLEAD-27a62713 | session_retrospective | [HIGH] high | 7 | [STABLE] | N/A |
-| PAT-HF-PLANTOLEAD-e8842331 | handoff_failure | [HIGH] high | 6 | [STABLE] | N/A |
+| PAT-HF-LEADTOPLAN-90e39736 | handoff_failure | [HIGH] high | 6 | [STABLE] | N/A |
 | PAT-TEST-PINS-FACT-NOT-BEHAVIOUR-001 | testing | [HIGH] high | 6 | [STABLE] | Assert the RULE, not today's answer. The |
 | PAT-RETRO-PLANTOLEAD-e8842331 | session_retrospective | [HIGH] high | 6 | [STABLE] | N/A |
 
@@ -1608,15 +1608,7 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 
 ## Known Friction Points
 
-**From Worker Signals** — recurring friction observed by 3+ workers via `/signal`. Aggregated into harness-backlog by `lib/coordinator/signal-router.cjs` on every sweep cycle. Triage via `node scripts/sd-from-feedback.js`.
-
-| Signal Type | Workers | Severity | Title |
-|-------------|---------|----------|-------|
-| feedback | 6 | medium | online — entering autonomous loop |
-| feedback | 3 | medium | wakeup-armed +600s — idle, 0 claimable at my tier (unchanged |
-| feedback | 3 | medium | comms-check ack — read you |
-
-*Auto-updated from `feedback` table where `category='harness_backlog'` AND `metadata.contributing_workers` length ≥ 3.*
+*(No widespread friction signals tracked currently — workers can /signal to surface recurring issues.)*
 
 
 
@@ -1625,18 +1617,7 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 
 **From Published Retrospectives** - Apply these learnings proactively.
 
-### 1. Retrospective: SD-LEO-INFRA-CHAIRMAN-DECISION-SURFACING-001 — widen escalation to any raiser, arm the dormant SLA sweep notify-only [QUALITY]
-**Category**: APPLICATION_ISSUE | **Date**: 7/10/2026 | **Score**: 100
-
-**Key Improvements**:
-- The ALL-PATHS requirement (escalation must reach every producer of a blocking pending decision) coul...
-- Test-writing surfaced two real bugs in test design rather than product code: enforceDecisionSLAs cal...
-
-**Action Items**:
-- [ ] When arming a "registered but never dispatched" module (C2 dormant-machinery cla...
-- [ ] When a predicate change (e.g. shouldAutoEscalate) widens WHO triggers a downstre...
-
-### 2. SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-F: wiring assertLaunchContract at three spawn seams — and the SD reproducing its own defect (deletable enforcement) [QUALITY]
+### 1. SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-F: wiring assertLaunchContract at three spawn seams — and the SD reproducing its own defect (deletable enforcement) [QUALITY]
 **Category**: PROCESS_IMPROVEMENT | **Date**: 7/26/2026 | **Score**: 100
 
 **Key Improvements**:
@@ -1647,18 +1628,18 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 - [ ] File a work item covering the three spawn surfaces that never reach buildSession...
 - [ ] Document FLEET_CLAUDE_CMD and CLAUDE_CLI_PATH — neither appears in any doc today...
 
-### 3. SD-LEO-INFRA-FOLD-LEO-INTO-EHG-001 Retrospective — Fleet Sessions inside EHG (spawn, see, open) [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 7/25/2026 | **Score**: 100
+### 2. SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-D: pointer-file startup transport + callsign-keyed prompt selection — and six ways a 1096-green suite lied [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 7/26/2026 | **Score**: 100
 
 **Key Improvements**:
-- TEST-MASKING NEARLY SHIPPED, INTRODUCED BY EXEC ITSELF. The first version of the hook tests re-imple...
-- A VITEST FOOTGUN COST REAL DEBUGGING TIME. `beforeEach(() => mock.mockReset())` — the concise arrow ...
+- THE SD's OWN HEADLINE HAZARD WENT LIVE ON ITS OWN BRANCH, ARMED BY ITS OWN ENABLING COMMIT. FR-3 req...
+- NO GATE, TEST OR CHECKLIST RE-CHECKED THE EARLIER WORK AT THE MOMENT REACHABILITY CHANGED. 'Not reac...
 
 **Action Items**:
-- [ ] MERGE THE BRANCH (or stand up a worktree dev server) so http://localhost:8080/bu...
-- [ ] RECORD A PR-SIZE JUSTIFICATION IN THE SD (880 LOC total, ~437 source, vs a 400-L...
+- [ ] Adopt ARMING-COMMIT RE-CHECK as a standing EXEC rule: when a commit converts unr...
+- [ ] Adopt PAIRED-CONTROL FOR ABSENCE ASSERTIONS as a standing TESTING rule: every ne...
 
-### 4. SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 Retrospective [QUALITY]
+### 3. SD-LEO-INFRA-LAUNCHER-CAN-HOST-001 Retrospective [QUALITY]
 **Category**: APPLICATION_ISSUE | **Date**: 7/25/2026 | **Score**: 100
 
 **Key Improvements**:
@@ -1669,16 +1650,27 @@ Each SD should trace upward through this hierarchy. When evaluating or creating 
 - [ ] WIRE PROVISIONING INTO THE DRILL PATH (closes C4): add the provisionCanary call ...
 - [ ] VERIFY C5 (Open raises a window) with an actual observation of SetForegroundWind...
 
-### 5. SD-LEO-INFRA-SESSION-SPAWN-AND-PROMPT-LIBRARY-001-D: pointer-file startup transport + callsign-keyed prompt selection — and six ways a 1096-green suite lied [QUALITY]
-**Category**: PROCESS_IMPROVEMENT | **Date**: 7/26/2026 | **Score**: 100
+### 4. SD-LEO-INFRA-FOLD-LEO-INTO-EHG-001 Retrospective — Fleet Sessions inside EHG (spawn, see, open) [QUALITY]
+**Category**: PROCESS_IMPROVEMENT | **Date**: 7/25/2026 | **Score**: 100
 
 **Key Improvements**:
-- THE SD's OWN HEADLINE HAZARD WENT LIVE ON ITS OWN BRANCH, ARMED BY ITS OWN ENABLING COMMIT. FR-3 req...
-- NO GATE, TEST OR CHECKLIST RE-CHECKED THE EARLIER WORK AT THE MOMENT REACHABILITY CHANGED. 'Not reac...
+- TEST-MASKING NEARLY SHIPPED, INTRODUCED BY EXEC ITSELF. The first version of the hook tests re-imple...
+- A VITEST FOOTGUN COST REAL DEBUGGING TIME. `beforeEach(() => mock.mockReset())` — the concise arrow ...
 
 **Action Items**:
-- [ ] Adopt ARMING-COMMIT RE-CHECK as a standing EXEC rule: when a commit converts unr...
-- [ ] Adopt PAIRED-CONTROL FOR ABSENCE ASSERTIONS as a standing TESTING rule: every ne...
+- [ ] MERGE THE BRANCH (or stand up a worktree dev server) so http://localhost:8080/bu...
+- [ ] RECORD A PR-SIZE JUSTIFICATION IN THE SD (880 LOC total, ~437 source, vs a 400-L...
+
+### 5. SD-LEO-INFRA-CLAIM-LIVENESS-FENCE-001 Retrospective: fail-direction is a per-signal decision, and a green suite proved nothing about three unmutated checks [QUALITY]
+**Category**: TESTING_STRATEGY | **Date**: 7/26/2026 | **Score**: 100
+
+**Key Improvements**:
+- FR-3 (the QF lane, the lane every cited incident actually occurred on) has BEHAVIORAL test coverage ...
+- The classifier's recorded_pid_name_match branch (no tick pidfile, but the recorded claude_sessions.p...
+
+**Action Items**:
+- [ ] PLAN must explicitly decide between (a) continuing to route every JS claim-write...
+- [ ] scripts/qf-start.js and scripts/create-quick-fix.js are currently covered only b...
 
 
 *Lessons auto-generated from `retrospectives` table. Query for full details.*
@@ -1745,7 +1737,7 @@ Results MUST be persisted to `sub_agent_execution_results` table.
 
 ---
 
-*Generated from database: 2026-08-04*
+*Generated from database: 2026-08-11*
 *Protocol Version: 4.4.1*
 *Includes: Proposals (0) + Hot Patterns (5) + Lessons (5)*
 *Load this file first in all sessions*

--- a/CLAUDE_CORE_DIGEST.md
+++ b/CLAUDE_CORE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-03T13:37:56.000Z -->
-<!-- git_commit: 9809add6 -->
-<!-- db_snapshot_hash: 31945d3b870a9f44 -->
-<!-- file_content_hash: 8e793099b375a84d -->
+<!-- generated_at: 2026-08-11T09:01:47.097Z -->
+<!-- git_commit: dfb9f70c -->
+<!-- db_snapshot_hash: 8de3099c543fb99b -->
+<!-- file_content_hash: 739f7f8bb4753f13 -->
 
 # CLAUDE_CORE_DIGEST.md - Core Protocol (Enforcement)
 
@@ -294,5 +294,5 @@ These anti-patterns apply across ALL phases. Violating them leads to failed hand
 
 ---
 
-*DIGEST generated: 2026-08-03 9:37:56 AM*
+*DIGEST generated: 2026-08-11 4:01:47 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_DIGEST.md
+++ b/CLAUDE_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-03T13:37:56.000Z -->
-<!-- git_commit: 9809add6 -->
-<!-- db_snapshot_hash: 31945d3b870a9f44 -->
-<!-- file_content_hash: 364c61ae61d46577 -->
+<!-- generated_at: 2026-08-11T09:01:47.097Z -->
+<!-- git_commit: dfb9f70c -->
+<!-- db_snapshot_hash: 8de3099c543fb99b -->
+<!-- file_content_hash: 67092da26643a7ae -->
 
 # CLAUDE_DIGEST.md - LEO Protocol Router (Enforcement)
 
@@ -159,5 +159,5 @@ This command provides:
 
 ---
 
-*DIGEST generated: 2026-08-03 9:37:56 AM*
+*DIGEST generated: 2026-08-11 4:01:47 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_EXEC.md
+++ b/CLAUDE_EXEC.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 636da0e0051ecc02 -->
+<!-- file_content_hash: 20a95c4e0cdfffdd -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_EXEC.md - EXEC Phase Operations
 
-**Generated**: 2026-08-04 12:36:22 AM
+**Generated**: 2026-08-11 4:01:47 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: EXEC agent implementation requirements and testing
 **Effort**: xhigh (implementation + testing require maximum reasoning for agentic coding per Opus 4.8 guidance)
@@ -2148,6 +2148,6 @@ Verifies version consistency between CLAUDE*.md files and database. Use --fix to
 
 ---
 
-*Generated from database: 2026-08-04*
+*Generated from database: 2026-08-11*
 *Protocol Version: 4.4.1*
 *Load when: User mentions EXEC, implementation, coding, or testing*

--- a/CLAUDE_EXEC_DIGEST.md
+++ b/CLAUDE_EXEC_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-03T13:37:56.000Z -->
-<!-- git_commit: 9809add6 -->
-<!-- db_snapshot_hash: 31945d3b870a9f44 -->
-<!-- file_content_hash: f0b8d48af6ed1026 -->
+<!-- generated_at: 2026-08-11T09:01:47.097Z -->
+<!-- git_commit: dfb9f70c -->
+<!-- db_snapshot_hash: 8de3099c543fb99b -->
+<!-- file_content_hash: 97c64ec522e89d12 -->
 
 # CLAUDE_EXEC_DIGEST.md - EXEC Phase (Enforcement)
 
@@ -217,5 +217,5 @@ When starting implementation:
 
 ---
 
-*DIGEST generated: 2026-08-03 9:37:56 AM*
+*DIGEST generated: 2026-08-11 4:01:47 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD.md
+++ b/CLAUDE_LEAD.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 669a7bc3bfbc0666 -->
+<!-- file_content_hash: 7ce9693d84cb364d -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD.md - LEAD Phase Operations
 
-**Generated**: 2026-08-04 12:36:22 AM
+**Generated**: 2026-08-11 4:01:47 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: LEAD agent operations and strategic validation
 **Effort**: high (strategic framing, scope bounding, and sub-agent routing require full reasoning depth)
@@ -1390,6 +1390,6 @@ At LEAD-phase scope-lock, before running `add-prd-to-database.js`, invoke `testi
 
 ---
 
-*Generated from database: 2026-08-04*
+*Generated from database: 2026-08-11*
 *Protocol Version: 4.4.1*
 *Load when: User mentions LEAD, approval, strategic validation, or over-engineering*

--- a/CLAUDE_LEAD_DIGEST.md
+++ b/CLAUDE_LEAD_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-03T13:37:56.000Z -->
-<!-- git_commit: 9809add6 -->
-<!-- db_snapshot_hash: 31945d3b870a9f44 -->
-<!-- file_content_hash: e0b34896c77ea1ba -->
+<!-- generated_at: 2026-08-11T09:01:47.097Z -->
+<!-- git_commit: dfb9f70c -->
+<!-- db_snapshot_hash: 8de3099c543fb99b -->
+<!-- file_content_hash: aa559568b677ee7e -->
 
 # CLAUDE_LEAD_DIGEST.md - LEAD Phase (Enforcement)
 
@@ -132,5 +132,5 @@ These are kept for reference but should NEVER be used as templates.
 
 ---
 
-*DIGEST generated: 2026-08-03 9:37:56 AM*
+*DIGEST generated: 2026-08-11 4:01:47 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_LEAD_MANUAL.md
+++ b/CLAUDE_LEAD_MANUAL.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 132692e6ee6b869e -->
+<!-- file_content_hash: 8ff7e6b89fe31739 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_LEAD_MANUAL.md — LEAD Manual (reference companion)
 
-**Generated**: 2026-08-04 12:36:22 AM
+**Generated**: 2026-08-11 4:01:47 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Long-form LEAD reference — the Q9 strategic-validation rubric, parent/child SD governance, multi-track parallel execution, directive submission review
 **Load when**: At the MOMENT OF DOING one of these procedures — not at every LEAD phase entry
@@ -209,6 +209,6 @@ npm run sd:status    # Overall progress by track
 
 ---
 
-*Generated from database: 2026-08-04*
+*Generated from database: 2026-08-11*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=parent_child_sd_governance, multi_track_parallel_execution, lead_strategic_validation_q9). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_PLAN.md
+++ b/CLAUDE_PLAN.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 607dcb3d314a390f -->
+<!-- file_content_hash: 7e342084badaa42f -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN.md - PLAN Phase Operations
 
-**Generated**: 2026-08-04 12:36:22 AM
+**Generated**: 2026-08-11 4:01:47 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: PLAN agent operations, PRD creation, validation gates
 **Effort**: high (architecture decisions and PRD rubrics require full reasoning depth)
@@ -1390,6 +1390,6 @@ For every keyword-list FR expansion, include in acceptance_criteria: "Substring-
 
 ---
 
-*Generated from database: 2026-08-04*
+*Generated from database: 2026-08-11*
 *Protocol Version: 4.4.1*
 *Load when: User mentions PLAN, PRD, validation, or testing strategy*

--- a/CLAUDE_PLAN_DIGEST.md
+++ b/CLAUDE_PLAN_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-03T13:37:56.000Z -->
-<!-- git_commit: 9809add6 -->
-<!-- db_snapshot_hash: 31945d3b870a9f44 -->
-<!-- file_content_hash: 8872217b95a1d76b -->
+<!-- generated_at: 2026-08-11T09:01:47.097Z -->
+<!-- git_commit: dfb9f70c -->
+<!-- db_snapshot_hash: 8de3099c543fb99b -->
+<!-- file_content_hash: 1e2b0144b44537b8 -->
 
 # CLAUDE_PLAN_DIGEST.md - PLAN Phase (Enforcement)
 
@@ -163,5 +163,5 @@ On 2026-04-06 during SD-LEO-REFAC-STAGE-ADVANCEMENT-ENGINE-001 child decompositi
 
 ---
 
-*DIGEST generated: 2026-08-03 9:37:56 AM*
+*DIGEST generated: 2026-08-11 4:01:47 AM*
 *Protocol: 4.4.1*

--- a/CLAUDE_PLAN_MANUAL.md
+++ b/CLAUDE_PLAN_MANUAL.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 03675ab2b5b12df3 -->
+<!-- file_content_hash: 9f66c47ad465e023 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_PLAN_MANUAL.md — PLAN Manual (reference companion)
 
-**Generated**: 2026-08-04 12:36:22 AM
+**Generated**: 2026-08-11 4:01:47 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Long-form PLAN reference — gate scoring tables, PRD and presentation templates, parent/child decomposition, refactor-brief guide, Explore-before-validation, runtime-audit protocol
 **Load when**: At the MOMENT OF DOING one of these procedures — not at every PLAN phase entry
@@ -1074,6 +1074,6 @@ When creating a PRD during PLAN phase, connect functional requirements to releva
 
 ---
 
-*Generated from database: 2026-08-04*
+*Generated from database: 2026-08-11*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=workflow, handoff_quality_gates, parent_child_plan, plan_refactor_brief_guide, parent_child_validation, plan_verify_explore, prd_template_scaffold, governance_kr_linkage_plan, plan_presentation_template, cascade_invalidation_plan). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_SOLOMON.md
+++ b/CLAUDE_SOLOMON.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: 8d48057bbd4154e5 -->
+<!-- file_content_hash: 1dd006e166483e60 -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_SOLOMON.md - Solomon Role Contract
 
-**Generated**: 2026-08-04 12:36:22 AM
+**Generated**: 2026-08-11 4:01:47 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Canonical Solomon oracle role contract — deep-reasoning session
 **Load when**: Running /solomon, or orienting a deep-reasoning oracle session
@@ -304,6 +304,6 @@ gauges alone gives a permanent false trip. Flip both together or neither.
 
 ---
 
-*Generated from database: 2026-08-04*
+*Generated from database: 2026-08-11*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=solomon_role_contract). Do not hand-edit — edit the DB section and regenerate.*

--- a/CLAUDE_SOLOMON_DIGEST.md
+++ b/CLAUDE_SOLOMON_DIGEST.md
@@ -1,9 +1,9 @@
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 <!-- DIGEST FILE - Enforcement-focused protocol content -->
-<!-- generated_at: 2026-08-03T13:37:56.000Z -->
-<!-- git_commit: 9809add6 -->
-<!-- db_snapshot_hash: 31945d3b870a9f44 -->
-<!-- file_content_hash: 6fb9bbdcaa21f2fd -->
+<!-- generated_at: 2026-08-11T09:01:47.097Z -->
+<!-- git_commit: dfb9f70c -->
+<!-- db_snapshot_hash: 8de3099c543fb99b -->
+<!-- file_content_hash: 160a2f06859eb85b -->
 
 # CLAUDE_SOLOMON_DIGEST.md - Solomon Role (Oracle)
 

--- a/CLAUDE_SOLOMON_MANUAL.md
+++ b/CLAUDE_SOLOMON_MANUAL.md
@@ -1,8 +1,8 @@
-<!-- file_content_hash: b789a6b547d08b4c -->
+<!-- file_content_hash: 0f3aab48a643688d -->
 <!-- GENERATED FILE - DO NOT EDIT DIRECTLY. Source of truth: leo_protocol_sections (DB). Regenerate: node scripts/generate-claude-md-from-db.js. Drift check: node scripts/check-claude-md-drift.cjs -->
 # CLAUDE_SOLOMON_MANUAL.md — Solomon Manual (reference companion)
 
-**Generated**: 2026-08-04 12:36:22 AM
+**Generated**: 2026-08-11 4:01:47 AM
 **Protocol**: LEO 4.4.1
 **Purpose**: Long-form Solomon reference — origin history, the advice-outcome ledger and success metrics, the web-research routing rubric, crew-comms routing
 **Load when**: At the MOMENT OF DOING one of these procedures — not at every Solomon session start
@@ -94,6 +94,6 @@ Solomon operates under the canonical crew-comms routing protocol: `docs/protocol
 
 ---
 
-*Generated from database: 2026-08-04*
+*Generated from database: 2026-08-11*
 *Protocol Version: 4.4.1*
 *Source of truth: leo_protocol_sections (section_type=solomon_manual). Do not hand-edit — edit the DB section and regenerate.*

--- a/claude-generation-manifest.json
+++ b/claude-generation-manifest.json
@@ -1,179 +1,179 @@
 {
-  "generated_at": "2026-08-04T04:36:22.358Z",
-  "git_commit": "7af34994",
-  "db_snapshot_hash": "31945d3b870a9f44",
+  "generated_at": "2026-08-11T09:01:47.097Z",
+  "git_commit": "dfb9f70c",
+  "db_snapshot_hash": "8de3099c543fb99b",
   "files": {
     "CLAUDE.md": {
       "type": "full",
-      "chars": 19565,
-      "bytes": 19704,
-      "estimated_tokens": 4892,
+      "chars": 19564,
+      "bytes": 19703,
+      "estimated_tokens": 4891,
       "content_hash": "91b0c479ced58edc",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE.md"
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE.md"
     },
     "CLAUDE_CORE.md": {
       "type": "full",
-      "chars": 94930,
-      "bytes": 95531,
-      "estimated_tokens": 23733,
-      "content_hash": "0f526e3d7ab3d6d9",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_CORE.md"
+      "chars": 94415,
+      "bytes": 95006,
+      "estimated_tokens": 23604,
+      "content_hash": "01503bca1805094b",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_CORE.md"
     },
     "CLAUDE_LEAD.md": {
       "type": "full",
-      "chars": 58426,
-      "bytes": 58622,
+      "chars": 58425,
+      "bytes": 58621,
       "estimated_tokens": 14607,
-      "content_hash": "669a7bc3bfbc0666",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_LEAD.md"
+      "content_hash": "7ce9693d84cb364d",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_LEAD.md"
     },
     "CLAUDE_LEAD_MANUAL.md": {
       "type": "full",
-      "chars": 8819,
-      "bytes": 8863,
+      "chars": 8818,
+      "bytes": 8862,
       "estimated_tokens": 2205,
-      "content_hash": "132692e6ee6b869e",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_LEAD_MANUAL.md"
+      "content_hash": "8ff7e6b89fe31739",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_LEAD_MANUAL.md"
     },
     "CLAUDE_PLAN.md": {
       "type": "full",
-      "chars": 54929,
-      "bytes": 55186,
-      "estimated_tokens": 13733,
-      "content_hash": "607dcb3d314a390f",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_PLAN.md"
+      "chars": 54928,
+      "bytes": 55185,
+      "estimated_tokens": 13732,
+      "content_hash": "7e342084badaa42f",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_PLAN.md"
     },
     "CLAUDE_PLAN_MANUAL.md": {
       "type": "full",
-      "chars": 38354,
-      "bytes": 38461,
+      "chars": 38353,
+      "bytes": 38460,
       "estimated_tokens": 9589,
-      "content_hash": "03675ab2b5b12df3",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_PLAN_MANUAL.md"
+      "content_hash": "9f66c47ad465e023",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_PLAN_MANUAL.md"
     },
     "CLAUDE_EXEC.md": {
       "type": "full",
-      "chars": 89642,
-      "bytes": 90072,
+      "chars": 89641,
+      "bytes": 90071,
       "estimated_tokens": 22411,
-      "content_hash": "636da0e0051ecc02",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_EXEC.md"
+      "content_hash": "20a95c4e0cdfffdd",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_EXEC.md"
     },
     "CLAUDE_ADAM.md": {
       "type": "full",
-      "chars": 46748,
-      "bytes": 47258,
-      "estimated_tokens": 11687,
-      "content_hash": "355b0e33be6c4716",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_ADAM.md"
+      "chars": 46958,
+      "bytes": 47470,
+      "estimated_tokens": 11740,
+      "content_hash": "2447be82248b2ee2",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_ADAM.md"
     },
     "CLAUDE_ADAM_MANUAL.md": {
       "type": "full",
-      "chars": 15699,
-      "bytes": 15843,
+      "chars": 15698,
+      "bytes": 15842,
       "estimated_tokens": 3925,
-      "content_hash": "41ac71b8e45c6f71",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_ADAM_MANUAL.md"
+      "content_hash": "97e8f960aea98ae2",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_ADAM_MANUAL.md"
     },
     "CLAUDE_ADAM_PROVENANCE.md": {
       "type": "full",
-      "chars": 6925,
-      "bytes": 6989,
-      "estimated_tokens": 1732,
-      "content_hash": "0d5f80568bbde47b",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_ADAM_PROVENANCE.md"
+      "chars": 6924,
+      "bytes": 6988,
+      "estimated_tokens": 1731,
+      "content_hash": "5ca8f035ae31529e",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_ADAM_PROVENANCE.md"
     },
     "CLAUDE_COORDINATOR.md": {
       "type": "full",
-      "chars": 25317,
-      "bytes": 25515,
-      "estimated_tokens": 6330,
-      "content_hash": "e8e789d722f53bac",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_COORDINATOR.md"
+      "chars": 25316,
+      "bytes": 25514,
+      "estimated_tokens": 6329,
+      "content_hash": "a67d31b7ba97e500",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_COORDINATOR.md"
     },
     "CLAUDE_SOLOMON.md": {
       "type": "full",
-      "chars": 60474,
-      "bytes": 61013,
+      "chars": 60473,
+      "bytes": 61012,
       "estimated_tokens": 15119,
-      "content_hash": "8d48057bbd4154e5",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_SOLOMON.md"
+      "content_hash": "1dd006e166483e60",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_SOLOMON.md"
     },
     "CLAUDE_SOLOMON_MANUAL.md": {
       "type": "full",
-      "chars": 11228,
-      "bytes": 11325,
+      "chars": 11227,
+      "bytes": 11324,
       "estimated_tokens": 2807,
-      "content_hash": "b789a6b547d08b4c",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_SOLOMON_MANUAL.md"
+      "content_hash": "0f3aab48a643688d",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_SOLOMON_MANUAL.md"
     },
     "CLAUDE_DIGEST.md": {
       "type": "digest",
-      "chars": 9612,
-      "bytes": 9654,
+      "chars": 9611,
+      "bytes": 9653,
       "estimated_tokens": 2403,
-      "content_hash": "364c61ae61d46577",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_DIGEST.md"
+      "content_hash": "67092da26643a7ae",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_DIGEST.md"
     },
     "CLAUDE_CORE_DIGEST.md": {
       "type": "digest",
-      "chars": 13748,
-      "bytes": 13862,
+      "chars": 13747,
+      "bytes": 13861,
       "estimated_tokens": 3437,
-      "content_hash": "8e793099b375a84d",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_CORE_DIGEST.md"
+      "content_hash": "739f7f8bb4753f13",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_CORE_DIGEST.md"
     },
     "CLAUDE_LEAD_DIGEST.md": {
       "type": "digest",
-      "chars": 5552,
-      "bytes": 5572,
+      "chars": 5551,
+      "bytes": 5571,
       "estimated_tokens": 1388,
-      "content_hash": "e0b34896c77ea1ba",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_LEAD_DIGEST.md"
+      "content_hash": "aa559568b677ee7e",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_LEAD_DIGEST.md"
     },
     "CLAUDE_PLAN_DIGEST.md": {
       "type": "digest",
-      "chars": 8542,
-      "bytes": 8582,
+      "chars": 8541,
+      "bytes": 8581,
       "estimated_tokens": 2136,
-      "content_hash": "8872217b95a1d76b",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_PLAN_DIGEST.md"
+      "content_hash": "1e2b0144b44537b8",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_PLAN_DIGEST.md"
     },
     "CLAUDE_EXEC_DIGEST.md": {
       "type": "digest",
-      "chars": 10965,
-      "bytes": 11047,
-      "estimated_tokens": 2742,
-      "content_hash": "f0b8d48af6ed1026",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_EXEC_DIGEST.md"
+      "chars": 10964,
+      "bytes": 11046,
+      "estimated_tokens": 2741,
+      "content_hash": "97c64ec522e89d12",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_EXEC_DIGEST.md"
     },
     "CLAUDE_ADAM_DIGEST.md": {
       "type": "digest",
       "chars": 17736,
       "bytes": 18068,
       "estimated_tokens": 4434,
-      "content_hash": "80ea775ceed59e00",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_ADAM_DIGEST.md"
+      "content_hash": "5d1eb9c164d345cc",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_ADAM_DIGEST.md"
     },
     "CLAUDE_COORDINATOR_DIGEST.md": {
       "type": "digest",
       "chars": 6091,
       "bytes": 6161,
       "estimated_tokens": 1523,
-      "content_hash": "d34b0d16e63399fa",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_COORDINATOR_DIGEST.md"
+      "content_hash": "6473b055b1c344b5",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_COORDINATOR_DIGEST.md"
     },
     "CLAUDE_SOLOMON_DIGEST.md": {
       "type": "digest",
       "chars": 3969,
       "bytes": 4011,
       "estimated_tokens": 993,
-      "content_hash": "6fb9bbdcaa21f2fd",
-      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-SMS-LANE-001\\CLAUDE_SOLOMON_DIGEST.md"
+      "content_hash": "160a2f06859eb85b",
+      "path": "C:\\Users\\rickf\\Projects\\_EHG\\EHG_Engineer\\.worktrees\\SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001\\CLAUDE_SOLOMON_DIGEST.md"
     }
   },
   "section_digests": {
-    "global": "0824e5e03b4dd079",
+    "global": "8b9a3195afca0e24",
     "byId": {
       "94": "ef2f1e7ed617b5e0",
       "189": "6398659126897bbb",
@@ -427,7 +427,7 @@
       "596": "0251044882a17550",
       "597": "ca5efc991922f3b8",
       "599": "7ddd3e2178799aa8",
-      "601": "2688dac0629c7183",
+      "601": "6cad87d0a7fadc0f",
       "602": "52425599b58d0a12",
       "603": "98d7b093d064f76a",
       "605": "4a13b33776eb8b21",


### PR DESCRIPTION
## Summary
Follow-up to #6962 (already merged). \`leo_protocol_sections\` id=601 (Adam Role Contract)
said the chairman sleep window is "22:00-06:00 America/New_York" — true by default, but no
longer the whole story now that #6962 threaded the chairman's actual location zone through
the SMS quiet-window family. Updated the policy text and regenerated \`CLAUDE*.md\` from the
database.

The bulk of this diff beyond the one intentional edit (CLAUDE_ADAM.md's sleep-window
bullet) is the regeneration script picking up other sessions' retrospective/pattern entries
that accumulated in the database since the corpus was last regenerated on 2026-08-04 —
routine catch-up, not new content from this SD.

## Test plan
- [x] \`node scripts/generate-claude-md-from-db.js\` ran clean, all generator markers valid
- [x] Confirmed the new sleep-window text landed in CLAUDE_ADAM.md
- [x] Pre-commit CLAUDE*.md protection hook passed (regenerated, not manually edited)

🤖 Generated with [Claude Code](https://claude.com/claude-code)