### PR TITLE
chore: approver header for chairman_preferences dedupe migration (decision #2)

### DIFF
--- a/supabase/migrations/20260811_chairman_preferences_nulls_not_distinct.sql
+++ b/supabase/migrations/20260811_chairman_preferences_nulls_not_distinct.sql
@@ -1,3 +1,10 @@
+-- @chairman-gated
+-- @approved-by: codestreetlabs@gmail.com
+-- (approval chain: chairman verbal A by SMS 2026-08-11 ~11:44Z on serialized decision #2,
+--  durable capture 5218a74c, relayed by Adam advisory 877cac62; ruling riders: DELETE scoped
+--  to exact-duplicate NULL-venture groups keeping newest + pre-apply count-check --
+--  measured pre-apply 2026-08-11: 1 dup group (notifications.quiet_hours_extended_until n=2),
+--  4 total rows, constraint plain UNIQUE. Coordinator seat 56f09320 executes the ceremony.)
 -- ============================================================================
 -- chairman_preferences: fix NULL-venture_id upsert bug via UNIQUE NULLS NOT DISTINCT
 -- SD-LEO-INFRA-CHAIRMAN-QUIET-WINDOW-001 (FR-1)


### PR DESCRIPTION
Header-only commit recording the chairman's verbal A (SMS ~11:44Z 2026-08-11, capture 5218a74c, relayed via Adam advisory 877cac62) on the staged dedupe apply. Pre-apply measurement embedded in the header. Apply ceremony runs from the coordinator seat after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)