### PR TITLE
feat(SD-LEO-INFRA-APPLY-STATE-CEREMONY-PENDING-001): CEREMONY_PENDING coverage for database/chairman-gated/

### DIFF
--- a/.github/workflows/migration-deploy-drift-guard.yml
+++ b/.github/workflows/migration-deploy-drift-guard.yml
@@ -23,6 +23,10 @@ on:
       - 'database/functions/*.sql'
       - 'database/manual-updates/*.sql'
       - 'supabase/migrations/*.sql'
+      # SD-LEO-INFRA-APPLY-STATE-CEREMONY-PENDING-001 (FR-1): now a scanned root too — a
+      # chairman-gated merge must re-run the gate so its CEREMONY_PENDING status is visible
+      # promptly instead of waiting for the next unrelated migration push or the daily cron.
+      - 'database/chairman-gated/*.sql'
       - 'scripts/verify-migration-apply-state.mjs'
       - 'scripts/lib/migration-guards.js'
       - '.github/workflows/migration-deploy-drift-guard.yml'

--- a/scripts/verify-migration-apply-state.mjs
+++ b/scripts/verify-migration-apply-state.mjs
@@ -164,7 +164,17 @@ export const ARTIFACT_RE = /(_DOWN|_rollback|_DEFERRED)\.sql$/i;
  * left to verify. Any other readdir error stays fail-closed (MISCONFIG upstream), matching the
  * unreadable-entry posture in main().
  */
-export const DEFAULT_EXTRA_ROOTS = ['database/functions', 'database/manual-updates', 'supabase/migrations'];
+// SD-LEO-INFRA-APPLY-STATE-CEREMONY-PENDING-001 (FR-1): database/chairman-gated/ is
+// deliberately excluded from the AUTO-APPLY scanner (pending-migrations-check.js) as a
+// safety mechanism, but this READ-ONLY reporting verifier is a separate consumer — its
+// exclusion here was an accidental inheritance, not a safety boundary, and left a
+// chairman-gated migration invisible to both this report and the downstream
+// CHAIRMAN_APPLY_VERIFICATION gate for days. Scanning it here does not affect what
+// auto-applies; classifyFiles() (below) also gives it a distinct CEREMONY_PENDING status.
+export const DEFAULT_EXTRA_ROOTS = ['database/functions', 'database/manual-updates', 'supabase/migrations', 'database/chairman-gated'];
+
+/** Repo-relative-id prefix identifying a chairman-gated migration (FR-2). */
+const CHAIRMAN_GATED_PREFIX = 'database/chairman-gated/';
 const REPO_ROOT = path.resolve(__dirname, '..');
 
 export function listForwardMigrations({ primary = MIGRATIONS_DIR, extraRoots = DEFAULT_EXTRA_ROOTS, repoRoot = REPO_ROOT } = {}) {
@@ -451,8 +461,28 @@ async function resolveLive(client, expected) {
   return live;
 }
 
-/** Per-file classification from its SURVIVING expected objects (drop-aware). */
-export function classifyFiles(orderedFiles, expected, perFile, live) {
+/**
+ * Whole calendar days between a migrationDateToken() (YYYYMMDD-leading) and `now`. Pure and
+ * injectable (TR-2) — never reads a live clock itself, so classifyFiles stays unit-testable
+ * with a fixed reference date instead of drifting a fraction of a day per test run.
+ */
+function daysSinceToken(token, now) {
+  const y = Number(token.slice(0, 4));
+  const m = Number(token.slice(4, 6));
+  const d = Number(token.slice(6, 8));
+  const tokenUtc = Date.UTC(y, m - 1, d);
+  const nowUtc = Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate());
+  return Math.max(0, Math.round((nowUtc - tokenUtc) / 86400000));
+}
+
+/**
+ * Per-file classification from its SURVIVING expected objects (drop-aware).
+ *
+ * `now` defaults to the live clock for production callers but is an explicit injection point
+ * (TR-2) so age_days is deterministic under test — classifyFiles itself never calls
+ * Date.now()/new Date() unconditionally.
+ */
+export function classifyFiles(orderedFiles, expected, perFile, live, now = new Date()) {
   const survivingByFile = new Map();
   for (const { cls, name, file } of expected.values()) {
     if (!survivingByFile.has(file)) survivingByFile.set(file, []);
@@ -465,8 +495,42 @@ export function classifyFiles(orderedFiles, expected, perFile, live) {
     if (!surviving.length) return { file, status: 'APPLIED', missing: [], objects: 0, note: 'all objects superseded by later migrations' };
     const missing = surviving.filter((o) => !live.has(`${o.cls}:${o.name}`));
     const status = missing.length === 0 ? 'APPLIED' : missing.length === surviving.length ? 'NOT_APPLIED' : 'PARTIAL';
-    return { file, status, missing, objects: surviving.length };
+    const result = { file, status, missing, objects: surviving.length };
+    // FR-2: a chairman-gated file that would otherwise read NOT_APPLIED/PARTIAL is an
+    // EXPECTED wait state (merged, awaiting the chairman apply ceremony), not an ordinary
+    // gap — CEREMONY_PENDING says so explicitly and carries age_days so staleness is still
+    // visible. APPLIED/NO_DDL chairman-gated files are unaffected; every non-chairman-gated
+    // file keeps the four-value vocabulary above completely unchanged.
+    if (status !== 'APPLIED' && file.startsWith(CHAIRMAN_GATED_PREFIX)) {
+      result.status = 'CEREMONY_PENDING';
+      const token = migrationDateToken(file);
+      if (token) result.age_days = daysSinceToken(token, now);
+    }
+    return result;
   });
+}
+
+/**
+ * Pure post-classification aggregation: per-status summary counts plus the `gaps` array that
+ * feeds failSet/OUTCOME. Extracted (SD-LEO-INFRA-APPLY-STATE-CEREMONY-PENDING-001 FR-3) so the
+ * "CEREMONY_PENDING must flow into gaps, never just the summary counter" contract is
+ * unit-testable without a live DB or a full CLI run.
+ */
+export function summarizeResults(results, { scanned, excludedDown = 0, droppedLater = 0 } = {}) {
+  const summary = {
+    scanned: scanned ?? results.length,
+    excluded_down: excludedDown,
+    applied: results.filter((r) => r.status === 'APPLIED').length,
+    partial: results.filter((r) => r.status === 'PARTIAL').length,
+    not_applied: results.filter((r) => r.status === 'NOT_APPLIED').length,
+    no_ddl: results.filter((r) => r.status === 'NO_DDL').length,
+    ceremony_pending: results.filter((r) => r.status === 'CEREMONY_PENDING').length,
+    dropped_later: droppedLater,
+  };
+  const gaps = results
+    .filter((r) => r.status === 'PARTIAL' || r.status === 'NOT_APPLIED' || r.status === 'CEREMONY_PENDING')
+    .reverse(); // newest first
+  return { summary, gaps };
 }
 
 // ── CLI ───────────────────────────────────────────────────────────────────────
@@ -598,16 +662,9 @@ async function main() {
   }
 
   const results = classifyFiles(forward, expected, perFile, live);
-  const summary = {
-    scanned: forward.length,
-    excluded_down: down.length,
-    applied: results.filter((r) => r.status === 'APPLIED').length,
-    partial: results.filter((r) => r.status === 'PARTIAL').length,
-    not_applied: results.filter((r) => r.status === 'NOT_APPLIED').length,
-    no_ddl: results.filter((r) => r.status === 'NO_DDL').length,
-    dropped_later: droppedLater.length,
-  };
-  const gaps = results.filter((r) => r.status === 'PARTIAL' || r.status === 'NOT_APPLIED').reverse(); // newest first
+  const { summary, gaps } = summarizeResults(results, {
+    scanned: forward.length, excludedDown: down.length, droppedLater: droppedLater.length,
+  });
 
   // FR-2 recent-vs-legacy partition. failSet drives the --strict exit + GAPS marker + alert.
   // FR-6 layers ledger suppression on top: with no (or a broken) ledger every set below is

--- a/tests/unit/lead-final-chairman-apply-verification.test.js
+++ b/tests/unit/lead-final-chairman-apply-verification.test.js
@@ -129,6 +129,31 @@ describe('TS-5: PARTIAL is not APPLIED', () => {
   });
 });
 
+describe('SD-LEO-INFRA-APPLY-STATE-CEREMONY-PENDING-001 TS-6: CEREMONY_PENDING blocks with zero gate changes', () => {
+  it('blocks a chairman-gated migration reporting CEREMONY_PENDING, same as NOT_APPLIED/PARTIAL', async () => {
+    // Proves the FR-3 contract: this gate's status !== APPLIED && status !== NO_DDL check
+    // already generalizes to the new status value — no gates.js source change was required.
+    classifyMigrationApplyState.mockResolvedValue({
+      files: [{
+        file: 'database/chairman-gated/20260807_belt_capacity_verdicts.sql',
+        status: 'CEREMONY_PENDING', missing: ['table:belt_capacity_verdicts'], age_days: 4,
+      }],
+      error: null
+    });
+    const r = await gate().validator(sdWith({
+      requires_chairman_apply: true,
+      migration_files: ['database/chairman-gated/20260807_belt_capacity_verdicts.sql']
+    }));
+    expect(r.passed).toBe(false);
+    expect(r.score).toBe(0);
+    const text = r.issues.join('\n');
+    expect(text).toContain('database/chairman-gated/20260807_belt_capacity_verdicts.sql');
+    expect(text).toContain('CEREMONY_PENDING');
+    // gated-aware remediation text (line 1446-1448) must still fire for this status.
+    expect(text).toMatch(/chairman GO/i);
+  });
+});
+
 describe('TS-4: fail closed - could-not-determine BLOCKS, it never passes', () => {
   it('blocks when the classifier reports an error (e.g. database unreachable)', async () => {
     classifyMigrationApplyState.mockResolvedValue({ files: [], error: 'connect ECONNREFUSED' });

--- a/tests/unit/migration-multi-root-scan.test.js
+++ b/tests/unit/migration-multi-root-scan.test.js
@@ -174,10 +174,26 @@ describe('TS-3 — workflow and config static assertions (FR-B/FR-C)', () => {
     expect(block).toContain('test-service-role-key-not-real');
   });
 
-  it('the DEFAULT_EXTRA_ROOTS constant and the workflow filter name the same three roots (no drift)', () => {
+  it('the DEFAULT_EXTRA_ROOTS constant and the workflow filter name the same roots (no drift)', () => {
     for (const root2 of DEFAULT_EXTRA_ROOTS) {
       expect(wf, root2).toContain(`'${root2}/*.sql'`);
     }
-    expect(DEFAULT_EXTRA_ROOTS).toHaveLength(3);
+    // SD-LEO-INFRA-APPLY-STATE-CEREMONY-PENDING-001 (FR-1) added database/chairman-gated as a
+    // 4th scanned root — bumped from 3 deliberately, not silently, so a future 5th root drift
+    // still reds this assertion rather than the count quietly ratcheting with no test change.
+    expect(DEFAULT_EXTRA_ROOTS).toHaveLength(4);
+  });
+});
+
+describe('SD-LEO-INFRA-APPLY-STATE-CEREMONY-PENDING-001 FR-1 — database/chairman-gated/ is scanned', () => {
+  it('a chairman-gated file enters the scan with a repo-relative id under its own root', () => {
+    mkdirSync(path.join(root, 'database', 'chairman-gated'), { recursive: true });
+    writeFileSync(path.join(root, 'database', 'chairman-gated', '20260807_gated_thing.sql'), 'CREATE TABLE gated(x int);');
+    try {
+      const { forward } = listForwardMigrations({ primary, extraRoots: [...DEFAULT_EXTRA_ROOTS], repoRoot: root });
+      expect(forward).toContain('database/chairman-gated/20260807_gated_thing.sql');
+    } finally {
+      rmSync(path.join(root, 'database', 'chairman-gated'), { recursive: true, force: true });
+    }
   });
 });

--- a/tests/verify-migration-apply-state.test.js
+++ b/tests/verify-migration-apply-state.test.js
@@ -10,7 +10,7 @@ import { fileURLToPath } from 'node:url';
 import {
   extractDdlFacts, orderMigrations, foldLifecycle, classifyFiles, ARTIFACT_RE,
   isRecent, partitionRecentGaps, migrationDateToken, RETIRED_BEFORE,
-  hasAnyDbCredential, OUTCOME,
+  hasAnyDbCredential, OUTCOME, summarizeResults, DEFAULT_EXTRA_ROOTS,
 } from '../scripts/verify-migration-apply-state.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -142,6 +142,90 @@ describe('classification', () => {
     const { expected, perFile } = foldLifecycle(ff);
     const res = classifyFiles(['old.sql', 'newer.sql'], expected, perFile, new Set(['table:kept']));
     expect(res.find((r) => r.file === 'old.sql').status).toBe('APPLIED');
+  });
+});
+
+// SD-LEO-INFRA-APPLY-STATE-CEREMONY-PENDING-001 — database/chairman-gated/ visibility.
+// TS-1/TS-2/TS-3: chairman-gated files get a distinct CEREMONY_PENDING status carrying
+// age_days; every other file (including chairman-gated APPLIED/NO_DDL) is unaffected.
+describe('CEREMONY_PENDING classification (chairman-gated)', () => {
+  const NOW = new Date('2026-08-11T00:00:00Z');
+
+  it('TS-1: a merged-but-unapplied chairman-gated file classifies CEREMONY_PENDING with age_days', () => {
+    const ff = [{ file: 'database/chairman-gated/20260807_gated.sql', ...extractDdlFacts('CREATE TABLE gated (x int);') }];
+    const { expected, perFile } = foldLifecycle(ff);
+    const [row] = classifyFiles(['database/chairman-gated/20260807_gated.sql'], expected, perFile, new Set(), NOW);
+    expect(row.status).toBe('CEREMONY_PENDING');
+    expect(row.age_days).toBe(4); // 2026-08-07 -> 2026-08-11
+  });
+
+  it('TS-1b: a PARTIALLY-applied chairman-gated file also classifies CEREMONY_PENDING (not PARTIAL)', () => {
+    const ff = [{ file: 'database/chairman-gated/20260807_gated.sql', ...extractDdlFacts('CREATE TABLE g1 (x int); CREATE TABLE g2 (x int);') }];
+    const { expected, perFile } = foldLifecycle(ff);
+    const [row] = classifyFiles(['database/chairman-gated/20260807_gated.sql'], expected, perFile, new Set(['table:g1']), NOW);
+    expect(row.status).toBe('CEREMONY_PENDING');
+    expect(row.missing).toEqual([{ cls: 'table', name: 'g2' }]);
+  });
+
+  it('TS-2: a fully-applied chairman-gated file still classifies APPLIED, never CEREMONY_PENDING', () => {
+    const ff = [{ file: 'database/chairman-gated/20260807_gated.sql', ...extractDdlFacts('CREATE TABLE gated (x int);') }];
+    const { expected, perFile } = foldLifecycle(ff);
+    const [row] = classifyFiles(['database/chairman-gated/20260807_gated.sql'], expected, perFile, new Set(['table:gated']), NOW);
+    expect(row.status).toBe('APPLIED');
+    expect(row.age_days).toBeUndefined();
+  });
+
+  it('TS-2b: a NO_DDL chairman-gated file is unaffected', () => {
+    const ff = [{ file: 'database/chairman-gated/20260807_docs.sql', ...extractDdlFacts('-- comment only\nSELECT 1;') }];
+    const { expected, perFile } = foldLifecycle(ff);
+    const [row] = classifyFiles(['database/chairman-gated/20260807_docs.sql'], expected, perFile, new Set(), NOW);
+    expect(row.status).toBe('NO_DDL');
+  });
+
+  it('TS-3 (regression): an identical missing/surviving shape OUTSIDE chairman-gated keeps NOT_APPLIED/PARTIAL unchanged', () => {
+    const ff = [
+      { file: '20260807_plain.sql', ...extractDdlFacts('CREATE TABLE plain (x int);') },
+      { file: 'database/functions/20260807_fn.sql', ...extractDdlFacts('CREATE TABLE fnroot (x int);') },
+    ];
+    const { expected, perFile } = foldLifecycle(ff);
+    const res = classifyFiles(['20260807_plain.sql', 'database/functions/20260807_fn.sql'], expected, perFile, new Set(), NOW);
+    expect(res.find((r) => r.file === '20260807_plain.sql').status).toBe('NOT_APPLIED');
+    expect(res.find((r) => r.file === 'database/functions/20260807_fn.sql').status).toBe('NOT_APPLIED');
+    expect(res.every((r) => r.age_days === undefined)).toBe(true);
+  });
+
+  it('database/chairman-gated is one of the DEFAULT_EXTRA_ROOTS (FR-1 wiring)', () => {
+    expect(DEFAULT_EXTRA_ROOTS).toContain('database/chairman-gated');
+  });
+});
+
+// TS-5: CEREMONY_PENDING must flow through summarizeResults into `gaps`, not just the
+// dedicated counter — otherwise the OUTCOME marker (main(): failSet.length ? GAPS : PASS)
+// would silently read PASS for a run that in fact contains an unapplied chairman-gated file.
+describe('summarizeResults — CEREMONY_PENDING counts as a gap (FR-3)', () => {
+  it('a CEREMONY_PENDING-only result set is non-empty in `gaps` (would drive OUTCOME.GAPS)', () => {
+    const results = [{ file: 'database/chairman-gated/20260807_gated.sql', status: 'CEREMONY_PENDING', missing: [], objects: 1, age_days: 4 }];
+    const { summary, gaps } = summarizeResults(results, { scanned: 1 });
+    expect(summary.ceremony_pending).toBe(1);
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].status).toBe('CEREMONY_PENDING');
+  });
+
+  it('an APPLIED-only result set produces an empty gaps array (would drive OUTCOME.PASS)', () => {
+    const results = [{ file: 'a.sql', status: 'APPLIED', missing: [], objects: 1 }];
+    const { gaps } = summarizeResults(results, { scanned: 1 });
+    expect(gaps).toHaveLength(0);
+  });
+
+  it('summary counters partition APPLIED/PARTIAL/NOT_APPLIED/NO_DDL/CEREMONY_PENDING independently', () => {
+    const results = [
+      { file: 'a.sql', status: 'APPLIED' }, { file: 'b.sql', status: 'PARTIAL' },
+      { file: 'c.sql', status: 'NOT_APPLIED' }, { file: 'd.sql', status: 'NO_DDL' },
+      { file: 'database/chairman-gated/e.sql', status: 'CEREMONY_PENDING' },
+    ];
+    const { summary, gaps } = summarizeResults(results, { scanned: 5 });
+    expect(summary).toMatchObject({ applied: 1, partial: 1, not_applied: 1, no_ddl: 1, ceremony_pending: 1 });
+    expect(gaps.map((g) => g.file).sort()).toEqual(['b.sql', 'c.sql', 'database/chairman-gated/e.sql']);
   });
 });
 


### PR DESCRIPTION
## Summary
- FR-1: scan `database/chairman-gated/` as a `verify-migration-apply-state.mjs` root (was invisible to this read-only reporting tool, distinct from the deliberate AUTO-APPLY-scanner exclusion in `pending-migrations-check.js`, which is untouched); mirrored in the drift-guard CI push filter.
- FR-2: `classifyFiles()` reports a new `CEREMONY_PENDING` status + `age_days` for a chairman-gated file that would otherwise read `NOT_APPLIED`/`PARTIAL` — every other file's status vocabulary is unchanged.
- FR-3: extracted pure `summarizeResults()` so `CEREMONY_PENDING` flows into both the summary counters and the `gaps`/`failSet`/`OUTCOME` computation. `CHAIRMAN_APPLY_VERIFICATION` gate (`lead-final-approval/gates.js`) needed **zero** source changes — verified by a new regression test.

Live-verified against the real repo/DB: surfaced 2 real, previously-invisible pending chairman ceremonies (`20260802_sd_mutation_audit_trigger.sql`, `20260803_current_wave_must_carry_items.sql`). Flagged to the coordinator via `/signal` — out of scope for this SD to remediate; expect the `migration-deploy-drift-guard.yml` CI check to go red on/after merge until those are cleared, which is the intended visibility behavior.

## Test plan
- [x] `tests/verify-migration-apply-state.test.js` — 6 new CEREMONY_PENDING classification + summarizeResults tests
- [x] `tests/unit/migration-multi-root-scan.test.js` — chairman-gated root scan + updated root-count assertion
- [x] `tests/unit/lead-final-chairman-apply-verification.test.js` — gate regression test (CEREMONY_PENDING still blocks, zero gate changes)
- [x] `migration-gate` vitest project (DB-fenced) — 5/5 pass
- [x] Live end-to-end run against real DB — confirmed correct classification of all 11 chairman-gated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)