### PR TITLE
feat(SD-LEO-INFRA-AGE-GAUGE-NON-001): STALE_HOLD_UNREVIEWED — age the hold, not the work

### DIFF
--- a/lib/oversight/coordinator-health-sharpenings.mjs
+++ b/lib/oversight/coordinator-health-sharpenings.mjs
@@ -14,6 +14,11 @@
 // ITERATES its reads (cohort conversion/latency, per-cohort handoffs) over growing tables;
 // a silent PostgREST 1000-row cap would understate conversion and hide rework. Paginate.
 import { fetchAllPaginated } from '../db/fetch-all-paginated.mjs';
+// SD-LEO-INFRA-AGE-GAUGE-NON-001 FR-2: reused, not reinvented -- classifyAllDispatchIneligibility
+// is the all-match variant (see its own docblock) needed so a child that is ALSO an
+// orchestrator/deferred/etc. still surfaces its human_action_required reason; CLAIM_WRITE_FENCE_AXES
+// is the existing "genuinely held pending a human/coordinator action" axis set.
+import { classifyAllDispatchIneligibility, CLAIM_WRITE_FENCE_AXES } from '../fleet/claim-eligibility.cjs';
 
 // ── Named, exported constants: thresholds are reviewable diffs, never inline
 // magic (the WAVE_LINKAGE lesson — a gauge is only trustworthy if changing its
@@ -25,6 +30,12 @@ export const LATENCY_CEILING_MS = 7 * 24 * 60 * 60 * 1000; // median claim->fina
 export const REWORK_CEILING = 0.3;          // rejected/failed handoff share above this => LATENCY_BLOWOUT (rework arm)
 export const STUCK_HOURS = 24;              // unclaimed in-flight SD older than this needs a hold reason
 export const FALSE_COMPLETION_SAMPLE = 5;   // completed SDs sampled per probe for merge-vs-main verification
+// SD-LEO-INFRA-AGE-GAUGE-NON-001 FR-1: a hold with no *_review_at convention falls back to this
+// ceiling. Deliberately longer than STUCK_HOURS -- holds are legitimately longer-lived than a
+// bare unclaimed row, so the ceiling must not fire on ordinary-duration holds. The RCA specimen
+// (SD-FDBK-ENH-LEARNING-LOOP-DESTROYS-001) sat held 8+ days past its own satisfied release
+// condition before this class existed to catch it.
+export const STALE_HOLD_CEILING_HOURS = 24 * 7;
 
 // S3: DISTRIBUTION-IN-A-BAND, not stamp coverage. 100%-roadmap-stamped is the
 // WRONG target (Solomon: live work is legitimately feedback/QF/incident-sourced;
@@ -46,6 +57,7 @@ export const REASON_BAND = Object.freeze({
 export const FAILURE_CLASSES = Object.freeze([
   'FALSE_COMPLETION',
   'STUCK_WITHOUT_HOLD_REASON',
+  'STALE_HOLD_UNREVIEWED',
   'IDLE_WITH_BACKLOG',
   'INTEGRITY_DIVERGENCE',
   'CONVERSION_COLLAPSE',
@@ -262,20 +274,45 @@ export function evaluateReasonBand(reasons, band = REASON_BAND, minCohort = MIN_
   return { band_ok: violations.length === 0, insufficient_n: false, violations };
 }
 
-/** S2 pure: does an in-flight, unclaimed, stale SD row lack ANY hold provenance? */
-export function lacksHoldReason(row, nowMs = Date.now(), stuckHours = STUCK_HOURS) {
+/**
+ * Is a child SD (of an orchestrator parent) genuinely held pending a human/coordinator action?
+ * All-match (not first-match) so a child that ALSO matches an earlier axis (e.g. is itself an
+ * orchestrator, or deferred) still surfaces its human-action hold if it has one — the exact
+ * first-match trap identified during LEAD-phase testing-agent review.
+ */
+function isChildHumanHeld(child) {
+  return classifyAllDispatchIneligibility(child).some((r) => CLAIM_WRITE_FENCE_AXES.has(r));
+}
+
+/**
+ * S2 pure: does an in-flight, unclaimed, stale SD row lack ANY hold provenance?
+ *
+ * SD-LEO-INFRA-AGE-GAUGE-NON-001 FR-2: `children` (optional, pre-fetched — this function stays
+ * pure/sync/DB-free) replaces the old blanket `sd_type === 'orchestrator' => never stuck`
+ * exemption. A parent is exempt ONLY when it has at least one child AND every child is
+ * human-held — a childless parent, or one with any non-held child, falls through to the normal
+ * checks below (NOT vacuously exempt; Array.prototype.every on [] is vacuously true, which is
+ * exactly the bug this guards against).
+ */
+export function lacksHoldReason(row, nowMs = Date.now(), stuckHours = STUCK_HOURS, children = []) {
   if (row?.claiming_session_id) return false;
-  // Orchestrator PARENTS are in_progress/unclaimed BY DESIGN while children run
-  // (parent lifecycle contract) — never the stuck class (live-verified false positive).
-  if (row?.sd_type === 'orchestrator') return false;
+  if (row?.sd_type === 'orchestrator') {
+    const kids = Array.isArray(children) ? children : [];
+    if (kids.length > 0 && kids.every(isChildHumanHeld)) return false;
+  }
   if (!['in_progress', 'pending_approval', 'active'].includes(row?.status)) return false;
   const updated = Date.parse(row?.updated_at || '');
   if (!Number.isFinite(updated) || nowMs - updated < stuckHours * 60 * 60 * 1000) return false;
   const md = row?.metadata || {};
-  return !HOLD_KEYS.some((k) => md[k] !== undefined && md[k] !== null && md[k] !== false);
+  return !HOLD_KEYS.some((k) => Boolean(md[k]));
 }
 
-/** S2 DB fetcher for the STUCK_WITHOUT_HOLD_REASON class (the ApexNiche class). */
+/**
+ * S2 DB fetcher for the STUCK_WITHOUT_HOLD_REASON class (the ApexNiche class). For any
+ * orchestrator row in the candidate set, also fetches its children (by parent_sd_id = the
+ * parent's id, live-verified convention) so lacksHoldReason's FR-2 exemption can evaluate real
+ * child state instead of a blanket sd_type skip.
+ */
 export async function fetchStuckWithoutHold(supabase, { nowMs = Date.now() } = {}) {
   const { data, error } = await supabase
     .from('strategic_directives_v2')
@@ -284,7 +321,62 @@ export async function fetchStuckWithoutHold(supabase, { nowMs = Date.now() } = {
     .is('claiming_session_id', null)
     .limit(500);
   if (error) throw new Error(`stuck-without-hold: query failed: ${error.message}`);
-  return (data || []).filter((r) => lacksHoldReason(r, nowMs));
+  const rows = data || [];
+  const childrenByParentId = await fetchChildrenByParentId(supabase, rows);
+  return rows.filter((r) => lacksHoldReason(r, nowMs, STUCK_HOURS, childrenByParentId.get(r.id) || []));
+}
+
+/** Shared helper: children of every orchestrator row in `rows`, keyed by parent id. */
+async function fetchChildrenByParentId(supabase, rows) {
+  const orchestratorIds = rows.filter((r) => r.sd_type === 'orchestrator').map((r) => r.id);
+  const byParentId = new Map();
+  if (!orchestratorIds.length) return byParentId;
+  const { data: kids, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('sd_key, sd_type, status, metadata, parent_sd_id')
+    .in('parent_sd_id', orchestratorIds);
+  if (error) throw new Error(`stuck-without-hold: children query failed: ${error.message}`);
+  for (const k of kids || []) {
+    if (!byParentId.has(k.parent_sd_id)) byParentId.set(k.parent_sd_id, []);
+    byParentId.get(k.parent_sd_id).push(k);
+  }
+  return byParentId;
+}
+
+/**
+ * S2 pure (FR-1): does this row carry a STALE, unreviewed hold? The complement of
+ * lacksHoldReason — fires only for rows that DO carry a HOLD_KEYS entry (the RCA-diagnosed gap:
+ * a hold is an unconditional, ageless mute with no staleness check anywhere). A `<key>_review_at`
+ * metadata field (the convention lib/fleet/exec-boundary-hold-writer.js already writes for
+ * exec_boundary_hold) takes precedence when present; hold keys with no review_at convention fall
+ * back to STALE_HOLD_CEILING_HOURS measured against `<key>_set_at`, else `created_at`.
+ */
+export function hasStaleUnreviewedHold(row, nowMs = Date.now(), ceilingHours = STALE_HOLD_CEILING_HOURS) {
+  const md = row?.metadata || {};
+  const activeKeys = HOLD_KEYS.filter((k) => Boolean(md[k]));
+  if (!activeKeys.length) return false;
+  for (const k of activeKeys) {
+    const reviewAt = Date.parse(md[`${k}_review_at`] || '');
+    if (Number.isFinite(reviewAt)) {
+      if (reviewAt <= nowMs) return true;
+      continue; // a real, not-yet-due review date — this key is not stale
+    }
+    const setAt = Date.parse(md[`${k}_set_at`] || row?.created_at || '');
+    if (Number.isFinite(setAt) && nowMs - setAt > ceilingHours * 60 * 60 * 1000) return true;
+  }
+  return false;
+}
+
+/** S2 DB fetcher for the STALE_HOLD_UNREVIEWED class — same base population as fetchStuckWithoutHold. */
+export async function fetchStaleUnreviewedHolds(supabase, { nowMs = Date.now() } = {}) {
+  const { data, error } = await supabase
+    .from('strategic_directives_v2')
+    .select('id, sd_key, sd_type, status, updated_at, created_at, claiming_session_id, metadata')
+    .in('status', ['in_progress', 'pending_approval', 'active'])
+    .is('claiming_session_id', null)
+    .limit(500);
+  if (error) throw new Error(`stale-hold-unreviewed: query failed: ${error.message}`);
+  return (data || []).filter((r) => hasStaleUnreviewedHold(r, nowMs));
 }
 
 /**
@@ -322,7 +414,7 @@ export function sampleFalseCompletions(completedRows, gitGrep) {
  * triggerable. Base signals (idle-with-backlog, integrity) are REUSED from the
  * base probe's outputs — never re-derived (one gauge per signal).
  */
-export function classifyFailureClasses({ outcomeFlow, utilization, integrity, stuckRows, falseCompletionSample }) {
+export function classifyFailureClasses({ outcomeFlow, utilization, integrity, stuckRows, staleHoldRows, falseCompletionSample }) {
   const of = outcomeFlow || {};
   const measured = of.status === 'measured' && of.cohort_size >= MIN_COHORT_FOR_ALARM;
   const classes = [
@@ -335,6 +427,11 @@ export function classifyFailureClasses({ outcomeFlow, utilization, integrity, st
       cls: 'STUCK_WITHOUT_HOLD_REASON',
       firing: Boolean(stuckRows && stuckRows.length),
       detail: stuckRows && stuckRows.length ? `fence-less parked: ${stuckRows.map((r) => r.sd_key).join(', ')}` : 'none',
+    },
+    {
+      cls: 'STALE_HOLD_UNREVIEWED',
+      firing: Boolean(staleHoldRows && staleHoldRows.length),
+      detail: staleHoldRows && staleHoldRows.length ? `held-past-review: ${staleHoldRows.map((r) => r.sd_key).join(', ')}` : 'none',
     },
     {
       cls: 'IDLE_WITH_BACKLOG',

--- a/scripts/adam-coordinator-health.mjs
+++ b/scripts/adam-coordinator-health.mjs
@@ -35,7 +35,7 @@ import { fetchAllPaginated, POSTGREST_MAX_ROWS } from '../lib/db/fetch-all-pagin
 // KPI-0 outcome/flow is the PRIMARY axis; the base 3 KPIs stay untouched below.
 import { execSync } from 'child_process';
 import {
-  computeOutcomeFlow, classifyFailureClasses, fetchStuckWithoutHold,
+  computeOutcomeFlow, classifyFailureClasses, fetchStuckWithoutHold, fetchStaleUnreviewedHolds,
   deriveDispatchReasons, evaluateReasonBand, sampleFalseCompletions, selectCohort,
   FALSE_COMPLETION_SAMPLE, OUTCOME_WINDOW_DAYS,
 } from '../lib/oversight/coordinator-health-sharpenings.mjs';
@@ -429,7 +429,7 @@ export function gitGrepMainForSd(sdKey) {
  */
 export async function computeSharpenings(supabase, { utilization, integrity, nowMs = Date.now(), gitGrep = gitGrepMainForSd } = {}) {
   let outcomeFlow = null; let dispatchReasons = null; let bandVerdict = null;
-  let stuckRows = []; let falseCompletionSample = null;
+  let stuckRows = []; let staleHoldRows = []; let staleHoldError = null; let falseCompletionSample = null;
   try { outcomeFlow = await computeOutcomeFlow(supabase, { nowMs }); } catch (e) { outcomeFlow = { status: 'error', error: e.message }; }
   try {
     // S3 classifies the SAME first-claim-in-window cohort KPI-0 measures —
@@ -450,7 +450,12 @@ export async function computeSharpenings(supabase, { utilization, integrity, now
     dispatchReasons = deriveDispatchReasons(selectCohort(data, nowMs));
     bandVerdict = evaluateReasonBand(dispatchReasons);
   } catch (e) { bandVerdict = { band_ok: true, error: e.message }; }
-  try { stuckRows = await fetchStuckWithoutHold(supabase, { nowMs }); } catch { stuckRows = []; }
+  // SD-LEO-INFRA-AGE-GAUGE-NON-001 FR-3b: preserve the error like the two sibling fetches in
+  // this function already do — a query failure collapsing to [] was indistinguishable from a
+  // genuinely clean result and nearly mis-diagnosed the RCA specimen as a detector bug.
+  let stuckRowsError = null;
+  try { stuckRows = await fetchStuckWithoutHold(supabase, { nowMs }); } catch (e) { stuckRows = []; stuckRowsError = e.message; }
+  try { staleHoldRows = await fetchStaleUnreviewedHolds(supabase, { nowMs }); } catch (e) { staleHoldRows = []; staleHoldError = e.message; }
   try {
     // Sample RECENT completions only (non-null completion_date within ~4 windows):
     // ancient/null-dated rows predate merge-trace conventions and would make the
@@ -465,8 +470,12 @@ export async function computeSharpenings(supabase, { utilization, integrity, now
       .limit(FALSE_COMPLETION_SAMPLE);
     falseCompletionSample = sampleFalseCompletions(recentCompleted || [], gitGrep);
   } catch (e) { falseCompletionSample = { samples: [], false_completions: [], error: e.message }; }
-  const failureClasses = classifyFailureClasses({ outcomeFlow, utilization, integrity, stuckRows, falseCompletionSample });
-  return { outcomeFlow, dispatchReasons, bandVerdict, failureClasses };
+  const failureClasses = classifyFailureClasses({ outcomeFlow, utilization, integrity, stuckRows, staleHoldRows, falseCompletionSample });
+  return {
+    outcomeFlow, dispatchReasons, bandVerdict, failureClasses,
+    // FR-3b: distinguishable from a genuinely clean run — null on success, the fetch error otherwise.
+    stuck_fetch_error: stuckRowsError, stale_hold_fetch_error: staleHoldError,
+  };
 }
 
 export async function runProbe(supabase, opts = {}) {

--- a/tests/database/coordinator-health-delta.test.js
+++ b/tests/database/coordinator-health-delta.test.js
@@ -24,14 +24,16 @@ describe('coordinator-health delta — live path (read-only)', () => {
   }, 30000);
 
   live('fetchStuckWithoutHold returns rows that all genuinely lack hold provenance', async () => {
+    // SD-LEO-INFRA-AGE-GAUGE-NON-001 FR-2: an orchestrator row CAN now appear here — the old
+    // blanket sd_type==='orchestrator' exemption was replaced with a live child-state check
+    // (a childless parent, or one with any non-fully-held child, is no longer vacuously exempt).
     const rows = await fetchStuckWithoutHold(sb);
     for (const r of rows) {
       expect(r.claiming_session_id).toBeNull();
-      expect(r.sd_type).not.toBe('orchestrator');
     }
   }, 30000);
 
-  live('computeSharpenings produces exactly the six classes + a band verdict on live data', async () => {
+  live('computeSharpenings produces exactly the seven classes + a band verdict on live data', async () => {
     const utilization = { idle: 0, dispatchable_backlog_size: 0 };
     const integrity = { integrity_ok: true, divergent_fields: [] };
     const s = await computeSharpenings(sb, { utilization, integrity, gitGrep: () => 'unverifiable' });

--- a/tests/unit/oversight/coordinator-health-sharpenings.test.js
+++ b/tests/unit/oversight/coordinator-health-sharpenings.test.js
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   deriveOutcomeFlow, classifyDispatchReason, deriveDispatchReasons, evaluateReasonBand,
-  lacksHoldReason, sampleFalseCompletions, classifyFailureClasses,
+  lacksHoldReason, hasStaleUnreviewedHold, sampleFalseCompletions, classifyFailureClasses,
   FAILURE_CLASSES, REASON_BAND, CONVERSION_FLOOR, LATENCY_CEILING_MS, MIN_COHORT_FOR_ALARM,
+  STALE_HOLD_CEILING_HOURS,
 } from '../../../lib/oversight/coordinator-health-sharpenings.mjs';
 
 const NOW = Date.parse('2026-07-16T12:00:00Z');
@@ -63,15 +64,16 @@ describe('TS-3 dispatch reason band (S3)', () => {
   });
 });
 
-describe('TS-2 six failure classes (S2)', () => {
+describe('TS-2 seven failure classes (S2)', () => {
   const healthy = {
     outcomeFlow: { status: 'measured', cohort_size: MIN_COHORT_FOR_ALARM + 2, conversion: 0.8, median_latency_ms: 1000, rework_rate: 0.1 },
     utilization: { idle: 0, dispatchable_backlog_size: 5 },
     integrity: { integrity_ok: true, divergent_fields: [] },
     stuckRows: [],
+    staleHoldRows: [],
     falseCompletionSample: { samples: [], false_completions: [] },
   };
-  it('exactly the 6 enumerated classes, all silent on healthy input', () => {
+  it('exactly the 7 enumerated classes, all silent on healthy input', () => {
     const classes = classifyFailureClasses(healthy);
     expect(classes.map((c) => c.cls)).toEqual([...FAILURE_CLASSES]);
     expect(classes.every((c) => c.firing === false)).toBe(true);
@@ -80,15 +82,16 @@ describe('TS-2 six failure classes (S2)', () => {
     const fire = (over) => classifyFailureClasses({ ...healthy, ...over });
     expect(fire({ falseCompletionSample: { samples: [], false_completions: ['SD-GHOST-001'] } })[0].firing).toBe(true);
     expect(fire({ stuckRows: [sd({ sd_key: 'SD-STUCK-001' })] })[1].firing).toBe(true);
-    expect(fire({ utilization: { idle: 2, dispatchable_backlog_size: 4 } })[2].firing).toBe(true);
-    expect(fire({ integrity: { integrity_ok: false, divergent_fields: ['dispatchable_count'] } })[3].firing).toBe(true);
-    expect(fire({ outcomeFlow: { ...healthy.outcomeFlow, conversion: CONVERSION_FLOOR - 0.05 } })[4].firing).toBe(true);
-    expect(fire({ outcomeFlow: { ...healthy.outcomeFlow, median_latency_ms: LATENCY_CEILING_MS + 1 } })[5].firing).toBe(true);
+    expect(fire({ staleHoldRows: [sd({ sd_key: 'SD-STALE-HOLD-001' })] })[2].firing).toBe(true);
+    expect(fire({ utilization: { idle: 2, dispatchable_backlog_size: 4 } })[3].firing).toBe(true);
+    expect(fire({ integrity: { integrity_ok: false, divergent_fields: ['dispatchable_count'] } })[4].firing).toBe(true);
+    expect(fire({ outcomeFlow: { ...healthy.outcomeFlow, conversion: CONVERSION_FLOOR - 0.05 } })[5].firing).toBe(true);
+    expect(fire({ outcomeFlow: { ...healthy.outcomeFlow, median_latency_ms: LATENCY_CEILING_MS + 1 } })[6].firing).toBe(true);
   });
   it('outcome classes never alarm on insufficient cohorts', () => {
     const classes = classifyFailureClasses({ ...healthy, outcomeFlow: { status: 'measured', cohort_size: 1, conversion: 0, median_latency_ms: 1e12, rework_rate: 1 } });
-    expect(classes[4].firing).toBe(false);
     expect(classes[5].firing).toBe(false);
+    expect(classes[6].firing).toBe(false);
   });
 });
 
@@ -102,9 +105,64 @@ describe('S2 STUCK_WITHOUT_HOLD_REASON predicate', () => {
     expect(lacksHoldReason({ ...stale, updated_at: daysAgo(0) }, NOW)).toBe(false);
     expect(lacksHoldReason({ ...stale, status: 'draft' }, NOW)).toBe(false);
   });
-  it('orchestrator parents are unclaimed BY DESIGN — never the stuck class', () => {
+  it('SD-LEO-INFRA-AGE-GAUGE-NON-001 FR-2: an orchestrator with NO children data is NOT vacuously exempt (corrects the old blanket sd_type skip)', () => {
     const parent = sd({ status: 'in_progress', updated_at: daysAgo(5), sd_type: 'orchestrator', metadata: {} });
-    expect(lacksHoldReason(parent, NOW)).toBe(false);
+    expect(lacksHoldReason(parent, NOW)).toBe(true); // no children arg -> defaults to [] -> not exempt
+    expect(lacksHoldReason(parent, NOW, 24, [])).toBe(true); // explicit empty array -> same
+  });
+  it('FR-2: an orchestrator whose children are ALL human-held IS exempt', () => {
+    const parent = sd({ status: 'in_progress', updated_at: daysAgo(5), sd_type: 'orchestrator', metadata: {} });
+    const heldChild = { sd_key: 'SD-CHILD-A', sd_type: 'bugfix', status: 'draft', metadata: { requires_human_action: true } };
+    expect(lacksHoldReason(parent, NOW, 24, [heldChild])).toBe(false);
+  });
+  it('FR-2: a MIXED-state orchestrator (one child held, one not) breaches — proves live per-child state, not a blanket skip', () => {
+    const parent = sd({ status: 'in_progress', updated_at: daysAgo(5), sd_type: 'orchestrator', metadata: {} });
+    const heldChild = { sd_key: 'SD-CHILD-A', sd_type: 'bugfix', status: 'draft', metadata: { requires_human_action: true } };
+    const notHeldChild = { sd_key: 'SD-CHILD-B', sd_type: 'bugfix', status: 'draft', metadata: {} };
+    expect(lacksHoldReason(parent, NOW, 24, [heldChild, notHeldChild])).toBe(true);
+  });
+  it('TS-7 regression: a stray falsy-but-not-strictly-false hold value (empty string) no longer counts as a hold', () => {
+    const stale = sd({ status: 'in_progress', updated_at: daysAgo(2) });
+    // Old check (!== false) treated '' as a hold (bug); new Boolean() check correctly does not.
+    expect(lacksHoldReason({ ...stale, metadata: { requires_human_action: '' } }, NOW)).toBe(true);
+    // Regression guard: a genuinely truthy hold of any shape still counts (object, not just boolean).
+    expect(lacksHoldReason({ ...stale, metadata: { lead_blocker: { reason: 'x' } } }, NOW)).toBe(false);
+  });
+});
+
+describe('SD-LEO-INFRA-AGE-GAUGE-NON-001 FR-1: hasStaleUnreviewedHold (STALE_HOLD_UNREVIEWED)', () => {
+  it('TS-1: a hold with no review_at, past the ceiling, is stale', () => {
+    const row = {
+      sd_key: 'SD-FDBK-ENH-LEARNING-LOOP-DESTROYS-001', status: 'pending_approval', claiming_session_id: null,
+      created_at: daysAgo(9), metadata: { requires_human_action: true, requires_human_action_reason: 'FORMAL FENCE' },
+    };
+    expect(hasStaleUnreviewedHold(row, NOW)).toBe(true);
+  });
+  it('TS-2: a hold with a future review_at stays silent', () => {
+    const row = {
+      sd_key: 'SD-X-001', created_at: daysAgo(9),
+      metadata: { requires_human_action: true, requires_human_action_review_at: new Date(NOW + 24 * 60 * 60 * 1000).toISOString() },
+    };
+    expect(hasStaleUnreviewedHold(row, NOW)).toBe(false);
+  });
+  it('TS-3: a past review_at fires even within the fallback ceiling window (review_at takes precedence)', () => {
+    const row = {
+      sd_key: 'SD-X-002', created_at: daysAgo(1), // within STALE_HOLD_CEILING_HOURS if using set_at fallback
+      metadata: { requires_human_action: true, requires_human_action_review_at: daysAgo(0.1) },
+    };
+    expect(hasStaleUnreviewedHold(row, NOW)).toBe(true);
+  });
+  it('a hold within the ceiling window and no review_at stays silent', () => {
+    const row = { sd_key: 'SD-X-003', created_at: daysAgo(1), metadata: { requires_human_action: true } };
+    expect(hasStaleUnreviewedHold(row, NOW)).toBe(false);
+    expect(STALE_HOLD_CEILING_HOURS).toBeGreaterThan(24); // deliberately longer than STUCK_HOURS
+  });
+  it('no hold at all -> never stale (that is lacksHoldReason\'s job, not this class)', () => {
+    expect(hasStaleUnreviewedHold({ sd_key: 'SD-X-004', created_at: daysAgo(30), metadata: {} }, NOW)).toBe(false);
+  });
+  it('exec_boundary_hold_set_at (lib/fleet/exec-boundary-hold-writer.js convention) is honored as the fallback clock', () => {
+    const row = { sd_key: 'SD-X-005', created_at: daysAgo(0), metadata: { exec_boundary_hold: true, exec_boundary_hold_set_at: daysAgo(9) } };
+    expect(hasStaleUnreviewedHold(row, NOW)).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary
- LEAD-phase investigation (Explore → VALIDATION → RCA) reframed this SD from "build a new gauge over unclaimed non-terminal SDs" to a much narrower, evidence-backed fix: the proposed population is already covered, at a *tighter* threshold, by the existing `STUCK_WITHOUT_HOLD_REASON` detector (`lib/oversight/coordinator-health-sharpenings.mjs`, already cron-wired). RCA determined the real gap: a formal hold fence (`metadata.requires_human_action=true`) correctly suppressed monitoring for 8+ days and stayed unlifted 4 days past its own satisfied release condition, because **no instrument ages hold staleness**.
- **FR-1**: new `STALE_HOLD_UNREVIEWED` failure class — fires when a hold key's `*_review_at` (a convention `lib/fleet/exec-boundary-hold-writer.js` already writes but nothing read) is past, or falls back to a 7-day ceiling for hold keys with no review_at convention.
- **FR-2**: `lacksHoldReason`'s blanket `sd_type === 'orchestrator' => never stuck` exemption replaced with a live per-child check (`classifyAllDispatchIneligibility` + `CLAIM_WRITE_FENCE_AXES`) — a childless parent, or one with any non-held child, is no longer vacuously exempt.
- **FR-3**: `HOLD_KEYS` truthiness tightened (`!== false` → `Boolean()`); `fetchStuckWithoutHold`/`fetchStaleUnreviewedHolds` errors now preserved instead of silently collapsing to `[]`.
- No new database column, migration, gauge-registry entry, or cron — ~70% smaller than the original plan (`scope_reduction_percentage=70`).

## Test plan
- [x] `tests/unit/oversight/coordinator-health-sharpenings.test.js` — 26/26 passing, including the RCA specimen's exact metadata shape reproduced as a fixture
- [x] `tests/database/coordinator-health-delta.test.js` — updated stale assertion (DB-tier fenced in CI, correctly)
- [x] Live end-to-end verification against production (read-only): confirmed `parent_sd_id` FK convention, confirmed both fetchers run clean with 0 false positives on the current in-flight population

🤖 Generated with [Claude Code](https://claude.com/claude-code)