### PR TITLE
fix(QF-20260728-468): refuse cross-role --advisory sender before reply-to-Adam and stamp

### DIFF
--- a/scripts/coordinator-ack-adam.cjs
+++ b/scripts/coordinator-ack-adam.cjs
@@ -331,6 +331,29 @@ function parseArgs(argv) {
 async function deliverReplyOrExit(supabase, { adv, replyBody, coordinatorSession }) {
   if (!replyBody) { console.error('ERROR: --reply requires a body.'); process.exit(2); }
   const originator = adv.sender_session;
+
+  // QF-20260728-468: refuse when --advisory names a row a NON-ADAM session sent. The reply target
+  // is always resolved to the CURRENT live Adam below (FR-1) — a STALE Adam sender_session
+  // legitimately differs from that target and must still be let through (retargeting is FR-1's
+  // whole point). What this catches is narrower: a sender_session whose REGISTERED ROLE is not
+  // 'adam' at all (e.g. Solomon) means --advisory named a THIRD PARTY's row. Replying to Adam and
+  // then stamping that row's actioned_at silently retires the third party's advisory unread, with
+  // the reply landing somewhere unrelated to it — reproduced 2026-07-28 (827b6a2e, a Solomon
+  // advisory, passed instead of 472027ac). Fail-open on everything else: a null/non-UUID sender
+  // (cron-emitted Adam advisories) or an unresolvable role lookup is unchanged.
+  if (isFullUuid(originator)) {
+    const { data: senderRow } = await supabase.from('claude_sessions').select('metadata').eq('session_id', originator).maybeSingle();
+    const senderRole = senderRow && senderRow.metadata && senderRow.metadata.role;
+    if (senderRole && senderRole !== 'adam') {
+      console.error(
+        `ERROR: --advisory ${adv.id} was sent by a '${senderRole}'-role session (${originator}), not Adam. `
+        + 'Refusing to reply-to-Adam-and-stamp-this-row: that would deliver the reply to Adam while '
+        + `silently retiring the ${senderRole} row unread. Pass the correct advisory id, or omit --reply to just ack this row.`
+      );
+      process.exit(1);
+    }
+  }
+
   const correlationId = adv.payload && adv.payload.correlation_id;
   if (!correlationId) { console.error('ERROR: advisory carries no payload.correlation_id (not replyable).'); process.exit(1); }
 

--- a/tests/unit/coordinator-ack-adam-sender-role-guard.test.js
+++ b/tests/unit/coordinator-ack-adam-sender-role-guard.test.js
@@ -1,0 +1,79 @@
+/**
+ * QF-20260728-468 — --advisory must not be actioned-and-replied-to-Adam when its own sender is a
+ * confirmed NON-ADAM role (e.g. Solomon). Two independent legs used to be uncorrelated: the reply
+ * always targets the CURRENT live Adam (resolveAdamReplyTarget, FR-1), and actioned_at is always
+ * stamped on whatever row --advisory names, regardless of who sent it. Passing a Solomon advisory id
+ * therefore delivered correctly to Adam while silently retiring the Solomon row unread — reproduced
+ * 2026-07-28 (827b6a2e passed instead of 472027ac).
+ *
+ * The fix must REFUSE (not warn) on a confirmed cross-role sender, while leaving two adjacent,
+ * already-shipped behaviours untouched:
+ *   - FR-1's retargeting: a STALE Adam sender_session legitimately differs from the resolved live
+ *     Adam target, and that must still be allowed through (checking ROLE, not literal id equality).
+ *   - QF-20260727-380 (B): a null/non-UUID sender (cron-emitted Adam advisories) must still be
+ *     repliable, unblocked by this guard.
+ *
+ * deliverReplyOrExit is not exported (it needs a live DB/env), so — matching the existing
+ * coordinator-ack-adam-reply-ordering.test.js convention — this asserts the guard's placement and
+ * subject in the source rather than shelling out to the live CLI.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = readFileSync(path.resolve(__dirname, '../../scripts/coordinator-ack-adam.cjs'), 'utf8');
+
+const idx = (needle) => SRC.indexOf(needle);
+const helper = SRC.slice(idx('async function deliverReplyOrExit'), idx('async function main()'));
+
+describe('QF-20260728-468: refuse a cross-role --advisory sender before delivering/stamping', () => {
+  it('checks the sender role BEFORE resolving the reply target and BEFORE any delivery', () => {
+    const guardIdx = helper.indexOf("senderRole !== 'adam'");
+    const resolveIdx = helper.indexOf('resolveAdamReplyTarget');
+    const sendIdx = helper.indexOf('sendCoordinatorReply(supabase');
+    expect(guardIdx).toBeGreaterThan(-1);
+    expect(resolveIdx).toBeGreaterThan(-1);
+    expect(sendIdx).toBeGreaterThan(-1);
+    expect(guardIdx).toBeLessThan(resolveIdx);
+    expect(guardIdx).toBeLessThan(sendIdx);
+  });
+
+  it('refuses (process.exit) rather than merely warning, on a confirmed non-adam sender', () => {
+    const block = helper.slice(helper.indexOf("senderRole !== 'adam'"), helper.indexOf("senderRole !== 'adam'") + 700);
+    expect(block).toMatch(/console\.error\(/);
+    expect(block).toMatch(/process\.exit\(1\)/);
+    expect(block).not.toMatch(/console\.warn/);
+  });
+
+  it('checks ROLE, not literal id equality against the resolved target — so FR-1 retargeting still works', () => {
+    // A stale-but-real Adam sender_session must NOT trip this guard just because it differs from
+    // the live-Adam target resolved a few lines later. Only a role fetched from claude_sessions
+    // that resolves to something OTHER than 'adam' may refuse.
+    expect(helper).toMatch(/senderRow\s*&&\s*senderRow\.metadata\s*&&\s*senderRow\.metadata\.role/);
+    expect(helper).not.toMatch(/originator\s*!==\s*adamSession/);
+  });
+
+  it('is gated on isFullUuid(originator) — a null/non-UUID sender is unchanged (QF-20260727-380 (B))', () => {
+    const guardGateIdx = helper.indexOf('if (isFullUuid(originator)) {');
+    const roleCheckIdx = helper.indexOf("senderRole !== 'adam'");
+    expect(guardGateIdx).toBeGreaterThan(-1);
+    expect(guardGateIdx).toBeLessThan(roleCheckIdx);
+  });
+
+  it('fails open when the role lookup finds no row (no destructured .error branch to force a refusal)', () => {
+    const lookupIdx = helper.indexOf("from('claude_sessions')");
+    expect(lookupIdx).toBeGreaterThan(-1);
+    // senderRole is derived via `senderRow && senderRow.metadata && senderRow.metadata.role`, which
+    // is falsy (undefined) for a missing row/error — the `senderRole && senderRole !== 'adam'` guard
+    // then short-circuits false, i.e. allowed through, not refused.
+    expect(helper).toMatch(/const senderRole = senderRow && senderRow\.metadata && senderRow\.metadata\.role;/);
+  });
+
+  it('names both parties in the refusal message: the wrong-role sender and its id', () => {
+    const block = helper.slice(helper.indexOf("senderRole !== 'adam'"), helper.indexOf("senderRole !== 'adam'") + 500);
+    expect(block).toMatch(/\$\{senderRole\}/);
+    expect(block).toMatch(/\$\{originator\}/);
+  });
+});


### PR DESCRIPTION
## Summary
- `coordinator-ack-adam.cjs --reply` always retargets to the current live Adam and always stamps `actioned_at` on whatever row `--advisory` names, with nothing cross-checking the two.
- Passing a Solomon advisory id therefore delivers correctly to Adam while silently retiring the Solomon row unread (reproduced 2026-07-28: `827b6a2e` passed instead of `472027ac`).
- Adds a guard in `deliverReplyOrExit` that reads the named advisory's `sender_session` role from `claude_sessions` and **refuses** (not warns) before any resolve/reply/stamp when that role is a confirmed non-`adam` value.
- Checks role, not literal id equality against the resolved target, so FR-1's own stale-Adam retargeting keeps working; a null/non-UUID sender (cron-emitted Adam advisories, QF-20260727-380 (B)) and an unresolvable lookup are both fail-open and unchanged.

## Test plan
- [x] `npx vitest run tests/unit/coordinator-ack-adam-sender-role-guard.test.js tests/unit/coordinator-ack-adam-reply-ordering.test.js tests/unit/coordinator-ack-adam-disposition.test.js` — 32/32 passed
- [x] Syntax check (`node -c`) on the modified script

QF-20260728-468

🤖 Generated with [Claude Code](https://claude.com/claude-code)