### PR TITLE
fix(SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001): thread nursery_id through discovery_mode and pin nursery_reeval selection

### DIFF
--- a/lib/eva/stage-zero/chairman-review.js
+++ b/lib/eva/stage-zero/chairman-review.js
@@ -488,6 +488,12 @@ async function mintStageZeroGate(venture, brief, { supabase, logger = console, c
         archetype: brief.archetype,
         venture_score: brief.metadata?.venture_score ?? null,
         provenance: { minted_by: 'stage0-machine', chairman_action_required: true },
+        // SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001: restore visibility only — does not make
+        // this gate a blocking checkpoint. authorized_target is the originally-requested
+        // nursery_id (null off the nursery_reeval path); selected_target is what the run
+        // actually picked. A mismatch here is now detectable at review time.
+        authorized_target: brief.metadata?.authorized_nursery_id ?? null,
+        selected_target: brief.nursery_id ?? null,
       },
       forceDecisionCreation: true,
       supabase,

--- a/lib/eva/stage-zero/paths/discovery-mode.js
+++ b/lib/eva/stage-zero/paths/discovery-mode.js
@@ -105,13 +105,16 @@ export class LLMUndercountError extends Error {
  * @param {string} params.strategy - Discovery strategy to use
  * @param {Object} [params.constraints] - Optional constraints (budget_range, industries, automation_level)
  * @param {number} [params.candidateCount] - Number of candidates to generate (default: 5)
+ * @param {string} [params.nursery_id] - SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001: when set
+ *   (nursery_reeval strategy only), pins selection to this specific venture_nursery row
+ *   instead of re-scoring the whole pending pool.
  * @param {Object} deps - Injected dependencies
  * @param {Object} deps.supabase - Supabase client
  * @param {Object} [deps.logger] - Logger
  * @param {Object} [deps.llmClient] - LLM client override (for testing)
  * @returns {Promise<Object>} PathOutput
  */
-export async function executeDiscoveryMode({ strategy, constraints = {}, candidateCount = 5 }, deps = {}) {
+export async function executeDiscoveryMode({ strategy, constraints = {}, candidateCount = 5, nursery_id = null }, deps = {}) {
   const { supabase, logger = console, llmClient, strategicContext } = deps;
 
   if (!supabase) {
@@ -137,7 +140,7 @@ export async function executeDiscoveryMode({ strategy, constraints = {}, candida
   };
 
   const runner = runners[strategy];
-  const candidates = await runner({ constraints, candidateCount, strategyConfig }, { supabase, logger, llmClient, strategicContext });
+  const candidates = await runner({ constraints, candidateCount, strategyConfig, nursery_id }, { supabase, logger, llmClient, strategicContext });
 
   if (!candidates || candidates.length === 0) {
     logger.log('   No candidates found. Try different constraints or strategy.');
@@ -288,6 +291,12 @@ export async function executeDiscoveryMode({ strategy, constraints = {}, candida
         grade_distribution: gradeDistribution(gated),
         e0_sensitivity: e0Sensitivity,
       },
+      // SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001: the originally-requested target (null for
+      // every non-nursery_reeval strategy). Distinct from top_candidate.nursery_id, which is
+      // the LLM-echoed SELECTED target — carrying both to the chairman-review surface (via
+      // brief.metadata, which spreads pathOutput.metadata) makes a future authorized-vs-
+      // selected substitution detectable.
+      authorized_nursery_id: nursery_id,
     },
   });
 }
@@ -635,7 +644,7 @@ Return a JSON array:
 // so the test's scaffolding would dwarf its assertion and it would go red for unrelated reasons
 // whenever a new precondition lands. A test that usually fails for the wrong reason teaches nobody
 // anything; the seam keeps the assertion pointed at the wiring it is about.
-export async function runNurseryReeval({ constraints, candidateCount }, deps = {}) {
+export async function runNurseryReeval({ constraints, candidateCount, nursery_id = null }, deps = {}) {
   const { supabase, logger = console, llmClient, strategicContext } = deps;
   const client = llmClient || getValidationClient();
 
@@ -655,10 +664,19 @@ export async function runNurseryReeval({ constraints, candidateCount }, deps = {
   // compared it, and ordered created_at ASC — so the highest-scoring candidates (five
   // rows tie at 90) were never prioritised and the schedule column was decorative here
   // while checkNurseryTriggers treated the same column as a hard filter.
-  const { data: nurseryItems, error } = await applyPendingNurseryPredicate(
+  // SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001: when the request names a specific target
+  // (nursery_id), pin selection to that row instead of re-scoring the whole pending pool —
+  // otherwise a run authorised for one venture can re-select and promote a different,
+  // score-tied one. An unauthorized/already-promoted id simply yields zero rows below
+  // (same "nothing to re-evaluate" path as an empty pool), never a silent substitution.
+  let pendingQuery = applyPendingNurseryPredicate(
     supabase.from('venture_nursery').select(NURSERY_PENDING_COLUMNS),
     { now: deps.now }
-  ).limit(candidateCount * 2);
+  );
+  pendingQuery = nursery_id
+    ? pendingQuery.eq('id', nursery_id).limit(1)
+    : pendingQuery.limit(candidateCount * 2);
+  const { data: nurseryItems, error } = await pendingQuery;
 
   if (error) {
     throw new Error(`Failed to load nursery items: ${error.message}`);

--- a/lib/eva/stage-zero/paths/discovery-mode.js
+++ b/lib/eva/stage-zero/paths/discovery-mode.js
@@ -794,7 +794,18 @@ If no ventures are worth reviving, return an empty array: []`;
         }
       }
 
-      return parsed.map(c => {
+      // SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001: the query-level pin above only bounds
+      // WHICH ROWS the LLM sees; nothing bounded which nursery_id it hands back. A
+      // hallucinated or prompt-influenced id in the LLM's own JSON would otherwise still
+      // flow through to promotion untouched. Drop any candidate whose nursery_id was not
+      // part of the queried set, rather than silently trusting an unbounded model output.
+      const validated = parsed.filter(c => {
+        if (byId.has(c.nursery_id)) return true;
+        logger.warn?.(`   Nursery re-eval: dropping LLM-returned candidate with unrecognized nursery_id "${c.nursery_id}" (not in the queried set)`);
+        return false;
+      });
+
+      return validated.map(c => {
         const original = byId.get(c.nursery_id);
         const requiredCapabilities = original?.source_ref?.candidate?.required_capabilities;
         return {

--- a/lib/eva/stage-zero/paths/discovery-mode.js
+++ b/lib/eva/stage-zero/paths/discovery-mode.js
@@ -693,10 +693,15 @@ export async function runNurseryReeval({ constraints, candidateCount, nursery_id
     ? `\nConstraints: ${JSON.stringify(constraints)}`
     : '';
 
+  // SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001: the prompt previously never disclosed
+  // item.id, yet asked the LLM to echo back "the original ID" -- a model with no way to
+  // know the real id can only invent one, which the byId validation filter below would
+  // then reject on EVERY run, silently returning zero candidates. Disclosing the id is
+  // what makes that filter viable rather than a functional regression.
   const itemSummaries = nurseryItems.map(item => {
     const brief = item.source_ref?.brief || {};
     const parkedReason = item.source_ref?.park?.parked_reason;
-    return `- ${item.name}: "${brief.problem_statement || item.description || ''}" (Parked: ${parkedReason || 'unknown reason'}, Original score: ${item.current_score ?? 'N/A'})`;
+    return `- [id: ${item.id}] ${item.name}: "${brief.problem_statement || item.description || ''}" (Parked: ${parkedReason || 'unknown reason'}, Original score: ${item.current_score ?? 'N/A'})`;
   }).join('\n');
 
   const prompt = `You are an AI venture analyst for EHG re-evaluating parked venture ideas.
@@ -720,7 +725,7 @@ Score each venture on:
 
 Return a JSON array (only include ventures worth reviving, up to ${candidateCount}):
 [{
-  "nursery_id": "string (original ID)",
+  "nursery_id": "string (copy the exact id shown in brackets above, e.g. [id: abc-123] -> \"abc-123\")",
   "name": "string",
   "problem_statement": "string (updated if market changed)",
   "solution": "string (updated with new capabilities)",

--- a/scripts/stage-zero-queue-processor.js
+++ b/scripts/stage-zero-queue-processor.js
@@ -234,6 +234,10 @@ function mapRequestToParams(request) {
           // (camelCase); read both casings so the value is not silently dropped to the default.
           candidateCount: request.metadata?.candidate_count ?? request.metadata?.candidateCount ?? 5,
           constraints: request.metadata?.constraints || {},
+          // SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001: nursery_reeval requests name a specific
+          // target row via metadata.nursery_id (see nursery-reeval-request.js). Forward it so
+          // runNurseryReeval can pin selection instead of re-scoring the whole pending pool.
+          nursery_id: request.metadata?.nursery_id ?? null,
         },
         options: { nonInteractive: true },
       };
@@ -275,7 +279,12 @@ function discoveryDedupKey(metadata = {}) {
   const strategy = metadata.strategy || 'trend_scanner';
   const candidateCount = metadata.candidate_count ?? metadata.candidateCount ?? 5;
   const constraints = JSON.stringify(metadata.constraints || {});
-  return `${strategy}::${candidateCount}::${constraints}`;
+  // SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001: without nursery_id, every nursery_reeval
+  // request shares strategy=nursery_reeval/candidateCount=1/constraints={} and collides on
+  // an identical key — a request targeting one venture could return a cached result for a
+  // completely different one. Include it so distinct targets never share a dedup entry.
+  const nurseryId = metadata.nursery_id ?? '';
+  return `${strategy}::${candidateCount}::${constraints}::${nurseryId}`;
 }
 
 // SD-LEO-FIX-FIX-STAGE-QUEUE-001: conservative discovery_mode dedup. Discovery is intentionally

--- a/tests/unit/eva/stage-zero/chairman-review.test.js
+++ b/tests/unit/eva/stage-zero/chairman-review.test.js
@@ -288,6 +288,41 @@ describe('ChairmanReview', () => {
       expect(result.stage_zero_decision_id).toBe('decision-1');
     });
 
+    // SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001: authorized_target (the originally-requested
+    // nursery_id, carried on brief.metadata.authorized_nursery_id) and selected_target (what
+    // the run actually picked, brief.nursery_id) must both reach the minted chairman-decision
+    // brief, restoring visibility for a future authorized-vs-selected mismatch. Distinct fields
+    // with distinct provenance (see synthesis/index.js) — a mismatch here proves the substitution
+    // this SD exists to make detectable, without making the gate itself blocking.
+    it('stamps authorized_target and selected_target on the minted gate brief', async () => {
+      // brief.nursery_id is set, so persistVentureBrief also calls stampNurseryPromotion —
+      // needs the venture_nursery-aware mock (defined below), not the plain one.
+      const mockSupabase = createMockSupabaseWithNursery();
+      const briefWithNursery = {
+        ...validBrief,
+        nursery_id: 'n-selected',
+        metadata: { authorized_nursery_id: 'n-authorized' },
+      };
+      await persistVentureBrief(
+        { decision: 'ready', brief: briefWithNursery, validation: { valid: true, errors: [] } },
+        { supabase: mockSupabase, logger: silentLogger },
+      );
+      const mintArg = createOrReusePendingDecision.mock.calls[0][0];
+      expect(mintArg.briefData.authorized_target).toBe('n-authorized');
+      expect(mintArg.briefData.selected_target).toBe('n-selected');
+    });
+
+    it('both target fields are null off the non-nursery path (no regression for the common case)', async () => {
+      const mockSupabase = createMockSupabase();
+      await persistVentureBrief(
+        { decision: 'ready', brief: validBrief, validation: { valid: true, errors: [] } },
+        { supabase: mockSupabase, logger: silentLogger },
+      );
+      const mintArg = createOrReusePendingDecision.mock.calls[0][0];
+      expect(mintArg.briefData.authorized_target).toBeNull();
+      expect(mintArg.briefData.selected_target).toBeNull();
+    });
+
     it('never writes chairman_decisions directly — no machine-forged approval row exists', async () => {
       const mockSupabase = createMockSupabase();
       await persistVentureBrief(

--- a/tests/unit/eva/stage-zero/paths/discovery-mode-nursery.test.js
+++ b/tests/unit/eva/stage-zero/paths/discovery-mode-nursery.test.js
@@ -20,6 +20,7 @@ import {
   runNurseryReeval,
   LLMUndercountError,
 } from '../../../../../lib/eva/stage-zero/paths/discovery-mode.js';
+import { NURSERY_PENDING_COLUMNS } from '../../../../../lib/eva/stage-zero/venture-nursery.js';
 
 const silentLogger = { log: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
@@ -179,5 +180,127 @@ describe('runNurseryReeval — conservative gate (TS-11)', () => {
     expect(e.expected).toBe(3);
     expect(e.actual).toBe(0);
     expect(e.strategyName).toBe('nursery_reeval');
+  });
+});
+
+// ════════════════════════════════════════════════════════════════════════
+// SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001 — nursery_id threading + scoped
+// selection. AC-1 was UNPROVABLE AS SPECIFIED: an authorised run for one
+// venture could re-select and promote a different, score-tied one, because
+// nursery_id was discarded before it ever reached runNurseryReeval.
+// ════════════════════════════════════════════════════════════════════════
+
+describe('nursery_id scoped selection (SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001)', () => {
+  // Same heavy mock shape as TS-16a above (discovery_strategies + selection_postures +
+  // nursery_evaluation_log + the venture_nursery pending-predicate read), extended to
+  // record every .eq(col, val) issued against the PENDING-POOL select specifically —
+  // NOT venture_nursery's other traffic. recordNurseryEvaluation's witness loop calls
+  // advanceNurserySchedule for EVERY returned item regardless of scoping, which also
+  // reads/writes venture_nursery via .eq('id', ...); conflating that with the selection
+  // query's own .eq('id', ...) would make this test pass or fail for the wrong reason.
+  // v_unified_capabilities is served too — loadCapabilityEnvelope fails closed (spec R6)
+  // without it, which would abort the run before selection is ever exercised.
+  function scopedSupabase(items, eqCalls) {
+    return {
+      from: vi.fn((table) => {
+        if (table === 'discovery_strategies') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: { strategy_key: 'nursery_reeval', name: 'Nursery Re-eval', description: 'reeval', is_active: true },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'selection_postures') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockResolvedValue({
+              data: [{
+                id: 'posture-1', phase_key: 'test', version: 1, display_name: 'Test Posture',
+                criteria: { weights: { market: 1 } }, status: 'active',
+                ratified_by: 'test', ratified_at: '2026-01-01T00:00:00Z', expiry_condition: null,
+              }],
+              error: null,
+            }),
+          };
+        }
+        if (table === 'nursery_evaluation_log') {
+          return {
+            insert: vi.fn((row) => ({ select: vi.fn(() => ({ single: vi.fn().mockResolvedValue({ data: { id: 'log-1', ...row }, error: null }) })) })),
+          };
+        }
+        if (table === 'v_unified_capabilities') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            in: vi.fn().mockResolvedValue({ data: [], error: null }),
+          };
+        }
+        // venture_nursery. Track which select() this eq() belongs to so the pending-pool
+        // query (NURSERY_PENDING_COLUMNS) is distinguishable from advanceNurserySchedule's
+        // unrelated per-item schedule read/write.
+        let lastSelectCols = null;
+        const b = {
+          select: vi.fn((cols) => { lastSelectCols = cols; return b; }),
+          eq: vi.fn((col, val) => {
+            if (lastSelectCols === NURSERY_PENDING_COLUMNS) eqCalls.push([col, val]);
+            return b;
+          }),
+          is: vi.fn().mockReturnThis(),
+          or: vi.fn().mockReturnThis(),
+          in: vi.fn().mockReturnThis(),
+          not: vi.fn().mockReturnThis(),
+          gte: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          single: vi.fn().mockResolvedValue({ data: { evaluation_interval_days: 30 }, error: null }),
+          order: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue({ data: items, error: null }),
+          update: vi.fn().mockReturnThis(),
+        };
+        return b;
+      }),
+    };
+  }
+
+  const tiedSiblings = [
+    { id: 'n-authorized', name: 'Authorized Venture', current_score: 90, source_ref: { brief: {} }, next_evaluation_at: null },
+    { id: 'n-sibling', name: 'Tied Sibling', current_score: 90, source_ref: { brief: {} }, next_evaluation_at: null },
+  ];
+
+  // POSITIVE CONTROL — enters at executeDiscoveryMode (the boundary mapRequestToParams
+  // hands off to), not runNurseryReeval directly, so it fails if ANY of the three
+  // downstream hops (executeDiscoveryMode's destructure, the runner dispatch, or
+  // runNurseryReeval's own query) silently drops nursery_id again.
+  test('AC-1: a request naming nursery_id pins the query to that row, not the whole tied pool', async () => {
+    const eqCalls = [];
+    const llmClient = {
+      complete: vi.fn().mockResolvedValue(JSON.stringify([
+        { nursery_id: 'n-authorized', name: 'Authorized Venture', new_score: 91, revival_reason: 'still the target' },
+      ])),
+    };
+
+    await executeDiscoveryMode(
+      { strategy: 'nursery_reeval', candidateCount: 1, nursery_id: 'n-authorized' },
+      { supabase: scopedSupabase(tiedSiblings, eqCalls), logger: silentLogger, llmClient }
+    );
+
+    expect(eqCalls).toContainEqual(['id', 'n-authorized']);
+  });
+
+  // NEGATIVE / REGRESSION CONTROL — this is the exact pre-fix RED case: with no
+  // nursery_id (every other discovery strategy, and pre-fix nursery_reeval requests),
+  // selection must still scan the unscoped pending pool. Proves the fix is additive,
+  // not a behavior change for the unscoped path.
+  test('no nursery_id → selection stays unscoped (pre-fix / non-nursery_reeval behavior preserved)', async () => {
+    const eqCalls = [];
+    const llmClient = { complete: vi.fn().mockResolvedValue('[]') };
+
+    await executeDiscoveryMode(
+      { strategy: 'nursery_reeval', candidateCount: 5 },
+      { supabase: scopedSupabase(tiedSiblings, eqCalls), logger: silentLogger, llmClient }
+    );
+
+    expect(eqCalls.find(([col]) => col === 'id')).toBeUndefined();
   });
 });

--- a/tests/unit/eva/stage-zero/paths/discovery-mode-nursery.test.js
+++ b/tests/unit/eva/stage-zero/paths/discovery-mode-nursery.test.js
@@ -343,4 +343,36 @@ describe('nursery_id scoped selection (SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001)
     expect(result[0].nursery_id).toBe('n-real');
     expect(result.find(c => c.nursery_id === 'n-hallucinated')).toBeUndefined();
   });
+
+  // SECURITY sub-agent finding, second pass: the byId-validation filter above is only
+  // viable in production if the LLM was actually TOLD each item's real id — the prompt
+  // previously omitted item.id entirely while still asking the model to echo back "the
+  // original ID", which a model with no way to know it can only invent, so the filter
+  // would silently reject every candidate on every real run. Assert on the PROMPT itself
+  // (what the mock captures as its call argument), not on a mocked response — a mock can
+  // always fake a correct response even when the code that produces the real prompt is
+  // broken.
+  test('the prompt discloses every queried item\'s real id (so the byId filter is satisfiable)', async () => {
+    const items = [
+      { id: 'n-alpha', name: 'Alpha Venture', current_score: 90, source_ref: { brief: {} }, next_evaluation_at: null },
+      { id: 'n-beta', name: 'Beta Venture', current_score: 90, source_ref: { brief: {} }, next_evaluation_at: null },
+    ];
+    const llmClient = { complete: vi.fn().mockResolvedValue('[]') };
+    const supabase = {
+      from: vi.fn(() => ({
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockResolvedValue({ error: null }),
+        is: vi.fn().mockReturnThis(),
+        or: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: items, error: null }),
+      })),
+    };
+
+    await runNurseryReeval({ constraints: {}, candidateCount: 5 }, { supabase, logger: silentLogger, llmClient });
+
+    const [, sentPrompt] = llmClient.complete.mock.calls[0];
+    expect(sentPrompt).toContain('n-alpha');
+    expect(sentPrompt).toContain('n-beta');
+  });
 });

--- a/tests/unit/eva/stage-zero/paths/discovery-mode-nursery.test.js
+++ b/tests/unit/eva/stage-zero/paths/discovery-mode-nursery.test.js
@@ -303,4 +303,44 @@ describe('nursery_id scoped selection (SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001)
 
     expect(eqCalls.find(([col]) => col === 'id')).toBeUndefined();
   });
+
+  // SECURITY sub-agent finding (EXEC-TO-PLAN review): the query-level pin bounds WHICH
+  // ROWS the LLM sees, but nothing bounded which nursery_id it hands back in its own JSON
+  // response — a hallucinated or prompt-influenced id could still reach promotion
+  // untouched. Drives runNurseryReeval directly (candidateCount/constraints only, no
+  // executeDiscoveryMode scaffolding needed) since the defect is entirely inside this
+  // function's own response handling.
+  test('drops an LLM-returned candidate whose nursery_id was not in the queried pool', async () => {
+    const items = [
+      { id: 'n-real', name: 'Real Venture', current_score: 90, source_ref: { brief: {} }, next_evaluation_at: null },
+    ];
+    const llmClient = {
+      complete: vi.fn().mockResolvedValue(JSON.stringify([
+        { nursery_id: 'n-real', name: 'Real Venture', new_score: 91, revival_reason: 'still valid' },
+        { nursery_id: 'n-hallucinated', name: 'Never Queried', new_score: 99, revival_reason: 'model invented this' },
+      ])),
+    };
+    const supabase = {
+      from: vi.fn((table) => {
+        if (table === 'nursery_evaluation_log') {
+          return { insert: vi.fn((row) => ({ select: vi.fn(() => ({ single: vi.fn().mockResolvedValue({ data: { id: 'log-1', ...row }, error: null }) })) })) };
+        }
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockResolvedValue({ error: null }),
+          is: vi.fn().mockReturnThis(),
+          or: vi.fn().mockReturnThis(),
+          order: vi.fn().mockReturnThis(),
+          limit: vi.fn().mockResolvedValue({ data: items, error: null }),
+          update: vi.fn(() => ({ eq: vi.fn().mockResolvedValue({ error: null }) })),
+        };
+      }),
+    };
+
+    const result = await runNurseryReeval({ constraints: {}, candidateCount: 5 }, { supabase, logger: silentLogger, llmClient });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].nursery_id).toBe('n-real');
+    expect(result.find(c => c.nursery_id === 'n-hallucinated')).toBeUndefined();
+  });
 });

--- a/tests/unit/scripts/stage-zero-queue-processor.test.js
+++ b/tests/unit/scripts/stage-zero-queue-processor.test.js
@@ -209,6 +209,25 @@ describe('FR-6 — mapRequestToParams candidateCount casing (TS-5)', () => {
   });
 });
 
+// SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001 (BL-FINGERPRINT-001, hop 1 of 4): pre-fix,
+// mapRequestToParams's discovery_mode branch forwarded only strategy/candidateCount/
+// constraints — metadata.nursery_id (naming a chairman-confirmed target venture) was
+// discarded at the FIRST hop, before executeDiscoveryMode/the runner dispatch/
+// runNurseryReeval ever saw it. This is the queue-processor boundary entry point the
+// PLAN validation pass called out — testing runNurseryReeval alone would not have
+// caught this defect, since the field never reached that far.
+describe('AC-1/BL-FINGERPRINT-001 — mapRequestToParams forwards nursery_id (TS-boundary)', () => {
+  test('threads metadata.nursery_id into pathParams for discovery_mode', () => {
+    const params = mapRequestToParams({ metadata: { path: 'discovery_mode', strategy: 'nursery_reeval', nursery_id: 'nursery-a' } });
+    expect(params.pathParams.nursery_id).toBe('nursery-a');
+  });
+
+  test('defaults to null when absent (every non-nursery_reeval request)', () => {
+    const params = mapRequestToParams({ metadata: { path: 'discovery_mode', strategy: 'trend_scanner' } });
+    expect(params.pathParams.nursery_id).toBeNull();
+  });
+});
+
 describe('FR-1/FR-2 — request→venture idempotency guard', () => {
   test('findVentureForRequest resolves via the durable metadata back-reference when venture_id is NULL', async () => {
     const supabase = makeSupabaseV2({ ventures: [{ id: 'v-1', requestId: 'req-stale' }] });
@@ -301,5 +320,40 @@ describe('FR-5 — conservative discovery_mode dedup (TS-3)', () => {
     const supabase = makeSupabaseV2({ completed: [] });
     const dup = await checkForDuplicate(supabase, reqBase);
     expect(dup).toBeNull();
+  });
+});
+
+// SD-LEO-FIX-FINGERPRINT-STOP-CHAIRMAN-001 (BL-FINGERPRINT-002): pre-fix, every
+// nursery_reeval request shared the identical key strategy::candidateCount::constraints
+// (all nursery_reeval requests use candidateCount=1, constraints={}), so a request naming
+// one venture could dedup-hit a cached result for a completely different one — no score
+// tie required, weaker precondition than the runNurseryReeval selection defect above.
+describe('BL-FINGERPRINT-002 — nursery_id dedup-collision fix', () => {
+  const nurseryReqBase = {
+    id: 'req-new', requested_by: 'chairman-agent',
+    metadata: { path: 'discovery_mode', strategy: 'nursery_reeval', candidateCount: 1, constraints: {}, nursery_id: 'nursery-a' },
+  };
+
+  test('two nursery_reeval requests naming DIFFERENT ventures do not dedup-collide', async () => {
+    const supabase = makeSupabaseV2({
+      completed: [{
+        id: 'req-old', result: { ok: true },
+        metadata: { path: 'discovery_mode', strategy: 'nursery_reeval', candidateCount: 1, constraints: {}, nursery_id: 'nursery-b' },
+      }],
+    });
+    const dup = await checkForDuplicate(supabase, nurseryReqBase);
+    expect(dup).toBeNull();
+  });
+
+  test('same requester re-submitting for the SAME nursery_id within the window is still a dedup hit', async () => {
+    const supabase = makeSupabaseV2({
+      completed: [{
+        id: 'req-old', result: { ok: true },
+        metadata: { path: 'discovery_mode', strategy: 'nursery_reeval', candidateCount: 1, constraints: {}, nursery_id: 'nursery-a' },
+      }],
+    });
+    const dup = await checkForDuplicate(supabase, nurseryReqBase);
+    expect(dup).not.toBeNull();
+    expect(dup.id).toBe('req-old');
   });
 });


### PR DESCRIPTION
## Summary
- An authorised `nursery_reeval` run could promote a DIFFERENT, score-tied venture than the one it was authorised for: `mapRequestToParams` dropped `metadata.nursery_id` at hop 1, `executeDiscoveryMode`/the runner dispatch dropped it again, and `runNurseryReeval` re-scored the entire pending pool instead of the named row.
- A separate, easier-to-trigger dedup-key collision (`discoveryDedupKey` ignored `nursery_id`) could also return a cached result for a completely different venture — no score tie required.
- Threads `nursery_id` through all 4 hops; `runNurseryReeval` now pins selection via `.eq('id', nursery_id)` when present, unchanged otherwise.
- Includes `nursery_id` in `discoveryDedupKey` so distinct targets never share a dedup entry.
- Records `authorized_target`/`selected_target` on the chairman-decision brief for detectability (visibility only — the gate stays non-blocking).

## Test plan
- [x] Positive control at `mapRequestToParams` (hop 1 boundary)
- [x] Positive control at `executeDiscoveryMode` proving all 3 downstream hops forward `nursery_id` and pin selection (`.eq('id', ...)`)
- [x] Negative/regression control proving the unscoped path is unchanged when `nursery_id` is absent
- [x] Dedup-collision tests (distinct targets don't collide; same target still dedupes)
- [x] Full `tests/unit/eva/stage-zero/` suite (902 tests) + related chairman-review/discovery-mode/queue-processor suites (127 tests) — all green, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)