### PR TITLE
fix(QF-20260808-281): ResultBuilder.systemError renders real reason, not [object Object]

### DIFF
--- a/scripts/modules/handoff/ResultBuilder.js
+++ b/scripts/modules/handoff/ResultBuilder.js
@@ -77,7 +77,13 @@ export class ResultBuilder {
    */
   static systemError(error, sourceStep = null) {
     const isErrorInstance = error instanceof Error;
-    const rawMessage = isErrorInstance ? error.message : String(error);
+    // QF-20260808-281: String(plainObject) renders the literal '[object Object]', burying the
+    // real reason -- hit for non-Error throwables (e.g. a Supabase-style {message, code, ...}
+    // result passed through as `error`). Same extraction precedent as gateFailure's issues
+    // mapping above (QF-20260605-024): prefer .message, then .code, then a serialized fallback.
+    const rawMessage = isErrorInstance
+      ? error.message
+      : (typeof error === 'string' ? error : ((error && error.message) || (error && error.code) || JSON.stringify(error)));
     const errorClass = isErrorInstance ? (error.constructor?.name || 'Error') : 'Unknown';
     const errorName = isErrorInstance ? error.name : null;
     const stack = isErrorInstance && error.stack

--- a/tests/unit/handoff/result-builder-diagnostic.test.js
+++ b/tests/unit/handoff/result-builder-diagnostic.test.js
@@ -91,3 +91,39 @@ describe('ResultBuilder.systemError diagnostic enhancement (QF-20260423-200)', (
     expect(ResultBuilder.systemError(err).reasonCode).toBe('SYSTEM_ERROR');
   });
 });
+
+describe('ResultBuilder.systemError non-Error plain-object inputs (QF-20260808-281)', () => {
+  it('extracts .message from a plain object (e.g. a Supabase-style error) instead of stringifying it', () => {
+    const supabaseStyleError = { message: 'duplicate key value violates unique constraint', code: '23505', details: null, hint: null };
+    const result = ResultBuilder.systemError(supabaseStyleError);
+    expect(result.error).toBe('duplicate key value violates unique constraint');
+    expect(result.message).toBe('duplicate key value violates unique constraint');
+    expect(result.error).not.toBe('[object Object]');
+  });
+
+  it('falls back to .code when a plain object has no .message', () => {
+    const result = ResultBuilder.systemError({ code: 'PGRST116' });
+    expect(result.error).toBe('PGRST116');
+    expect(result.error).not.toBe('[object Object]');
+  });
+
+  it('falls back to a JSON-serialized form when a plain object has neither .message nor .code', () => {
+    const result = ResultBuilder.systemError({ detail: 'claim-reaffirm write failed', rows: 0 });
+    expect(result.error).not.toBe('[object Object]');
+    expect(JSON.parse(result.error)).toEqual({ detail: 'claim-reaffirm write failed', rows: 0 });
+  });
+
+  it('never renders the literal [object Object] on the operator line for any object-shaped input', () => {
+    const cases = [
+      { message: 'named error' },
+      { code: 'ERR_CODE' },
+      { arbitrary: 'shape' },
+      {},
+    ];
+    for (const input of cases) {
+      const result = ResultBuilder.systemError(input);
+      expect(result.error).not.toBe('[object Object]');
+      expect(result.message).not.toBe('[object Object]');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- The handoff/claim SYSTEM_ERROR operator-facing line stringified non-`Error` objects via `String(error)`, which renders the literal `'[object Object]'` for any plain-object-shaped error (e.g. a Supabase-style `{message, code, ...}` result passed through as `error`) — burying the real reason.
- This is a large part of why CODIFY's claim-expiry (an errored claim-reaffirm write) was hard to diagnose this session (provenance: coordinator asked Adam to mint this QF — advisory a6936561, Solomon concurred separate-ticket).
- Fix mirrors the exact same precedent already established in the same file for `gateFailure`'s issues mapping (QF-20260605-024): prefer `.message`, then `.code`, then a JSON-serialized fallback — never the bare `String()` coercion.

## Test plan
- [x] Added 4 new test cases to `tests/unit/handoff/result-builder-diagnostic.test.js`: Supabase-style `.message` extraction, `.code` fallback, JSON-serialized fallback, and a sweep asserting `[object Object]` never appears for any object-shaped input.
- [x] Full handoff + dispatch suite: 885/886 tests passed (1 pre-existing skip) across 91 files — zero regressions.
- [x] `npx eslint` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)