### PR TITLE
fix(QF-20260809-097): TESTING sub-agent cache key adds the phase dimension

### DIFF
--- a/lib/sub-agents/testing/phases/phase3-execution.js
+++ b/lib/sub-agents/testing/phases/phase3-execution.js
@@ -14,6 +14,7 @@ import {
   suggestTroubleshootingTactics,
   logTroubleshootingTactics
 } from '../utils/troubleshooting.js';
+import { normalizePhaseToken } from '../../../sub-agent-executor/phase-token.js';
 
 const DEFAULT_E2E_TIMEOUT_MS = 30 * 60 * 1000;
 
@@ -131,12 +132,27 @@ export function collectFailures(suite, failures) {
  * @param {Object} supabase - Supabase client
  * @returns {Promise<Object|null>} Cached results or null
  */
-async function getCachedTestResults(sdId, supabase) {
+export async function getCachedTestResults(sdId, supabase) {
+  // QF-20260809-097: the cache key omitted phase, so a BLOCKED verdict from an
+  // earlier phase (e.g. PLAN, nothing implemented yet) got silently reused
+  // within the 1h TTL by a later phase (e.g. EXEC) whose code IS implemented.
+  // normalizePhaseToken is the SAME SSOT results-storage.js's write path uses
+  // to derive/store the `phase` column -- a coarser LEAD/PLAN/EXEC-only bucket
+  // would re-collapse sub-phase distinctions the write side deliberately keeps.
+  const { data: sdRow } = await supabase
+    .from('strategic_directives_v2')
+    .select('current_phase')
+    .eq('id', sdId)
+    .maybeSingle();
+  const currentPhase = normalizePhaseToken(sdRow?.current_phase);
+  if (!currentPhase) return null;
+
   const { data: previousTest, error } = await supabase
     .from('sub_agent_execution_results')
-    .select('id, sd_id, sub_agent_code, verdict, confidence, metadata, created_at')
+    .select('id, sd_id, sub_agent_code, phase, verdict, confidence, metadata, created_at')
     .eq('sd_id', sdId)
     .eq('sub_agent_code', 'TESTING')
+    .eq('phase', currentPhase)
     .order('created_at', { ascending: false })
     .limit(1)
     .single();

--- a/tests/unit/testing-subagent/phase3-cached-results-phase-scoped.test.js
+++ b/tests/unit/testing-subagent/phase3-cached-results-phase-scoped.test.js
@@ -1,0 +1,116 @@
+/**
+ * QF-20260809-097 — getCachedTestResults keyed its 1h cache lookup on
+ * (sd_id, sub_agent_code) only, with no phase dimension. A PLAN-phase TESTING
+ * run that correctly BLOCKED (nothing implemented yet) got silently reused at
+ * EXEC within the hour: the console printed "All 10 user stories fully
+ * implemented" then emitted BLOCKED anyway, from a cached row with no
+ * recorded cause for the current run.
+ *
+ * Fix: resolve the SD's current_phase (via the same normalizePhaseToken SSOT
+ * results-storage.js's write path uses) and filter the cache query on it, so
+ * PLAN and EXEC runs never share a cached verdict.
+ */
+import { describe, it, expect } from 'vitest';
+import { getCachedTestResults } from '../../../lib/sub-agents/testing/phases/phase3-execution.js';
+
+function stubSupabase({ sdCurrentPhase, testingRows }) {
+  return {
+    from(table) {
+      if (table === 'strategic_directives_v2') {
+        return {
+          select() { return this; },
+          eq() { return this; },
+          maybeSingle: () => Promise.resolve({ data: { current_phase: sdCurrentPhase }, error: null }),
+        };
+      }
+      if (table === 'sub_agent_execution_results') {
+        const chain = {
+          select() { return chain; },
+          eq(col, val) {
+            chain._filters = chain._filters || {};
+            chain._filters[col] = val;
+            return chain;
+          },
+          order() { return chain; },
+          limit() { return chain; },
+          single() {
+            const matches = testingRows.filter(
+              (r) => r.sd_id === chain._filters.sd_id
+                && r.sub_agent_code === chain._filters.sub_agent_code
+                && r.phase === chain._filters.phase
+            );
+            if (matches.length === 0) return Promise.resolve({ data: null, error: { message: 'no rows' } });
+            // Most recent first (rows are pre-sorted in fixtures).
+            return Promise.resolve({ data: matches[0], error: null });
+          },
+        };
+        return chain;
+      }
+      throw new Error(`unexpected table: ${table}`);
+    },
+  };
+}
+
+const SD_ID = 'sd-uuid-1';
+
+describe('getCachedTestResults: phase-scoped cache key (QF-20260809-097)', () => {
+  it('does NOT reuse a PLAN-phase BLOCKED verdict for an EXEC-phase lookup', async () => {
+    const supabase = stubSupabase({
+      sdCurrentPhase: 'EXEC',
+      testingRows: [
+        {
+          sd_id: SD_ID, sub_agent_code: 'TESTING', phase: 'PLAN',
+          verdict: 'BLOCKED', confidence: 100, metadata: {},
+          created_at: new Date().toISOString(),
+        },
+      ],
+    });
+    const result = await getCachedTestResults(SD_ID, supabase);
+    expect(result).toBeNull();
+  });
+
+  it('reuses a same-phase (EXEC) cached verdict within the 1h TTL', async () => {
+    const supabase = stubSupabase({
+      sdCurrentPhase: 'EXEC',
+      testingRows: [
+        {
+          sd_id: SD_ID, sub_agent_code: 'TESTING', phase: 'EXEC',
+          verdict: 'PASS', confidence: 95,
+          metadata: { tests_executed: 10, tests_passed: 10, failed_tests: 0 },
+          created_at: new Date().toISOString(),
+        },
+      ],
+    });
+    const result = await getCachedTestResults(SD_ID, supabase);
+    expect(result).not.toBeNull();
+    expect(result.from_cache).toBe(true);
+    expect(result.tests_passed).toBe(10);
+  });
+
+  it('picks the EXEC-phase row over an older PLAN-phase row for the same SD', async () => {
+    const supabase = stubSupabase({
+      sdCurrentPhase: 'EXEC',
+      testingRows: [
+        {
+          sd_id: SD_ID, sub_agent_code: 'TESTING', phase: 'EXEC',
+          verdict: 'PASS', confidence: 95,
+          metadata: { tests_executed: 5, tests_passed: 5, failed_tests: 0 },
+          created_at: new Date().toISOString(),
+        },
+        {
+          sd_id: SD_ID, sub_agent_code: 'TESTING', phase: 'PLAN',
+          verdict: 'BLOCKED', confidence: 100, metadata: {},
+          created_at: new Date().toISOString(),
+        },
+      ],
+    });
+    const result = await getCachedTestResults(SD_ID, supabase);
+    expect(result.tests_passed).toBe(5);
+  });
+
+  it('returns null (no cache trust) when the SD current_phase cannot be resolved', async () => {
+    const supabase = stubSupabase({ sdCurrentPhase: null, testingRows: [] });
+    const result = await getCachedTestResults(SD_ID, supabase);
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- `getCachedTestResults` (lib/sub-agents/testing/phases/phase3-execution.js) keyed its 1h cache lookup on `(sd_id, sub_agent_code)` only, with no phase dimension.
- Consequence (measured live, worker aff4e6e8 on SD-LEO-FEAT-VENTURE-DEMAND-VALIDATION-001): a PLAN-phase TESTING run that correctly BLOCKED (nothing implemented yet) was silently reused at EXEC within the hour — console printed "All 10 user stories fully implemented" then emitted BLOCKED anyway, sourced from a cached row carrying zero critical issues, zero recommendations, and no recorded cause for the *current* run. Workaround was `--full-e2e` (the documented fresh-run path).
- Fix resolves the SD's `current_phase` and filters the cache lookup on it via `normalizePhaseToken` — the exact same SSOT `results-storage.js`'s write path already uses to derive/store the `phase` column on `sub_agent_execution_results` (which is already reliably populated on every row; only the read side never filtered on it).
- Deliberately did **not** use `getSDPhase()` (a coarser `{LEAD, PLAN, EXEC}`-only bucketer) — `phase-token.js`'s own docblock explicitly warns that coarse bucketing "would re-collapse sub-phase boundaries" the write side's SSOT preserves (e.g. `PLAN_PRD` vs `PLAN_VERIFICATION` must stay distinct).

## Test plan
- [x] New test file `tests/unit/testing-subagent/phase3-cached-results-phase-scoped.test.js` (4 cases): a PLAN-phase BLOCKED verdict is never reused for an EXEC lookup, a same-phase cache hit still works within TTL, the correct phase-matching row is picked when multiple phases exist for the SD, and an unresolvable `current_phase` fails closed (no cache trust) rather than falling back to the old cross-phase-blind behavior.
- [x] Full related suite: 96/96 test files passed (925/926 tests, 1 pre-existing skip) across `tests/unit/testing-subagent/`, `tests/unit/stories/`, `tests/unit/handoff/`, `lib/coordinator/dispatch.test.js` — zero regressions.
- [x] `npx eslint` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)