### PR TITLE
fix(SD-LEO-INFRA-EXCLUDE-MONITORING-TELEMETRY-001): mark non-code-fixable-categories.cjs wire-check exempt

### DIFF
--- a/lib/governance/non-code-fixable-categories.cjs
+++ b/lib/governance/non-code-fixable-categories.cjs
@@ -1,6 +1,13 @@
 'use strict';
 // SD-LEO-INFRA-EXCLUDE-MONITORING-TELEMETRY-001
 //
+// @wire-check-exempt: reached exclusively via lib/quality/assist-engine.js, which is
+// itself invoked only through the /leo assist markdown slash-command
+// (.claude/commands/assist.md and .claude/skills/assist.md, via require()) -- no
+// static JS/CJS/MJS entry point reaches this file. Same architectural shape as the
+// lib/eva-support/ / lib/ship/ KNOWN_DYNAMIC_PATTERNS exemptions in wire-check-gate.js
+// (markdown-invoked, no static reachability from the current entry-point set).
+//
 // Non-code-fixable feedback categories: rows in any of these are automated
 // monitoring/governance OUTPUT (gauge findings, comms-framing flags, cross-SD
 // verification-ledger records, Adam behavioral-drift telemetry, chairman decision


### PR DESCRIPTION
## Summary
Follow-up to #6983. WIRE_CHECK_GATE at LEAD-FINAL-APPROVAL flagged `lib/governance/non-code-fixable-categories.cjs` as unreachable from any entry point.

Root cause: its only real consumer, `lib/quality/assist-engine.js`, is itself invoked exclusively through the `/leo assist` markdown slash-command (`.claude/commands/assist.md` / `.claude/skills/assist.md`, via `require()`) — no static JS/CJS/MJS entry point reaches it. Static AST call-graph analysis can't trace through markdown. This is the same architectural shape as the existing `lib/eva-support/` and `lib/ship/` `KNOWN_DYNAMIC_PATTERNS` exemptions already documented in `wire-check-gate.js`.

Adds the documented `// @wire-check-exempt: <reason>` marker (the gate's own sanctioned escape hatch for this exact class of false positive) to the one new file, rather than a broader change to the gate itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)