### PR TITLE
fix(QF-20260812-166): add design_quality_scores retention policy to unblock weekly cron

### DIFF
--- a/lib/retention/policies.js
+++ b/lib/retention/policies.js
@@ -80,6 +80,22 @@ export const RETENTION_POLICIES = [
   // The only consumer (fetchLastKnown) reads the most recent row per account, so a 90-day hot
   // window cannot strand it — the reading it wants is minutes old, not months.
   { table: 'account_usage_snapshots', timestampColumn: 'created_at', hotDays: DEFAULT_HOT_DAYS, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
+  // Recurring live failure (GHA runs 31294087438 etc., weekly since 2026-07-19):
+  // sub_agent_execution_results' delete step fails with "violates foreign key constraint
+  // design_quality_scores_source_result_id_fkey" -- archive succeeds (rows ARE archived) but
+  // the delete never converges because design_quality_scores.source_result_id has no
+  // retention policy of its own to clear the reference first. Verified live
+  // (2026-08-12): every design_quality_scores row is created AT OR AFTER its parent
+  // sub_agent_execution_results row (never before), with a max observed skew of 27 days.
+  // Placed BEFORE sub_agent_execution_results in this array (processed in order) with a
+  // hotDays comfortably shorter than the parent's 90d by more than that skew (90-60=30d
+  // margin > 27d observed max), so by the time a parent row crosses 90d, every
+  // design_quality_scores row referencing it has already crossed ITS OWN 60d threshold and
+  // been archived+deleted in the same pass -- the FK is cleared before the parent's delete
+  // runs. (Two other FKs into these policies exist -- subagent_validation_results.execution_id
+  // and campaign_enrollments.consent_event_id -- but neither currently has any row that
+  // resolves to a live referenced row, so neither is a practical blocker today.)
+  { table: 'design_quality_scores', timestampColumn: 'created_at', hotDays: 60, mode: 'archive', perRunCap: DEFAULT_PER_RUN_CAP },
   // SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001 (FR-3): sub_agent_execution_results had no retention
   // policy despite high write volume (one row per sub-agent invocation). Verified every
   // automated consumer reads at most the last 30 days, so a 90-day hot window is safe.

--- a/tests/unit/retention/retention-policy.test.js
+++ b/tests/unit/retention/retention-policy.test.js
@@ -15,7 +15,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(__dirname, '../../../');
 
 describe('policy registry (TS-1)', () => {
-  it('registers all 15 unbounded tables with the VERIFIED timestamp columns', () => {
+  it('registers all 16 unbounded tables with the VERIFIED timestamp columns', () => {
     const m = Object.fromEntries(RETENTION_POLICIES.map((p) => [p.table, p.timestampColumn]));
     expect(m).toEqual({
       workflow_trace_log: 'created_at',
@@ -26,6 +26,11 @@ describe('policy registry (TS-1)', () => {
       permission_audit_log: 'created_at',
       // SD-REFILL-00LHUVME: eva_scheduler_metrics retention coverage
       eva_scheduler_metrics: 'created_at',
+      // Fixes the recurring "violates foreign key constraint
+      // design_quality_scores_source_result_id_fkey" delete failure on
+      // sub_agent_execution_results — a shorter hot window so this table's rows always
+      // clear the FK before their parent ages out. See the policies.js entry comment.
+      design_quality_scores: 'created_at',
       // SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001 FR-3
       sub_agent_execution_results: 'created_at',
       // SD-LEO-FEAT-TWO-WAY-CHAIRMAN-001: sms_inbound_log retention coverage
@@ -89,7 +94,31 @@ describe('policy registry (TS-1)', () => {
 
   it('default window is 90d (3x the 30d longest consumer lookback)', () => {
     expect(DEFAULT_HOT_DAYS).toBe(90);
-    for (const p of RETENTION_POLICIES) expect(effectiveHotDays(p, {})).toBe(90);
+    // design_quality_scores is the one deliberate exception: its shorter window exists
+    // specifically to age out ahead of its parent sub_agent_execution_results (see its
+    // policies.js entry comment) — every other table uses the shared default.
+    for (const p of RETENTION_POLICIES) {
+      if (p.table === 'design_quality_scores') continue;
+      expect(effectiveHotDays(p, {})).toBe(90);
+    }
+  });
+
+  it('design_quality_scores ages out well ahead of its parent (FK-clearing invariant)', () => {
+    const p = RETENTION_POLICIES.find((x) => x.table === 'design_quality_scores');
+    const parent = RETENTION_POLICIES.find((x) => x.table === 'sub_agent_execution_results');
+    expect(p).toBeDefined();
+    expect(p.timestampColumn).toBe('created_at');
+    expect(p.mode).toBe('archive');
+    // Observed live max skew (child created after parent) was 27 days -- require at least
+    // that much margin below the parent's window, or this invariant would silently stop
+    // protecting the fix if either window is ever tuned independently.
+    const OBSERVED_MAX_SKEW_DAYS = 27;
+    expect(effectiveHotDays(parent, {}) - effectiveHotDays(p, {})).toBeGreaterThan(OBSERVED_MAX_SKEW_DAYS);
+    // Must still clear the floor.
+    expect(effectiveHotDays(p, {})).toBeGreaterThanOrEqual(MIN_HOT_DAYS);
+    // Must be processed before its parent in the array (archive-order dependency).
+    const order = RETENTION_POLICIES.map((x) => x.table);
+    expect(order.indexOf('design_quality_scores')).toBeLessThan(order.indexOf('sub_agent_execution_results'));
   });
 
   it('floor assert: a window below MIN_HOT_DAYS refuses to run', () => {


### PR DESCRIPTION
## Summary
- The weekly retention-enforce cron's `sub_agent_execution_results` delete step has been failing since 2026-07-19 (5 occurrences on main) with `violates foreign key constraint design_quality_scores_source_result_id_fkey` — archive succeeds, delete never converges.
- Root cause: `design_quality_scores.source_result_id` has no retention policy of its own, so old rows referencing an aged-out `sub_agent_execution_results` row never get cleared first.
- Fix: add `design_quality_scores` as its own retention policy entry, positioned before its parent, with `hotDays=60` — verified (live skew query) to always age out at least 30 days ahead of the parent's 90-day window, comfortably clearing the observed 27-day max skew between parent and child creation.

## Verification
- Live-verified before writing the fix: pulled the actual GHA failure log (run 31294087438) for the exact error text; queried `pg_constraint` for the FK; queried the actual skew between every `design_quality_scores` row and its parent (0 rows older than parent, max skew 27 days); checked for other FKs into retention-policy tables (found 2 more, neither currently a practical blocker — 0 matching rows / negligible row count).
- `npx vitest run tests/unit/retention/retention-policy.test.js` — 17/17 pass (2 existing tests updated for the new entry, 1 new test asserting the FK-clearing invariant directly: correct margin over the observed skew, floor compliance, and array ordering).
- `npm run retention:check` (dry-run, no writes) — new `design_quality_scores >60d: 545 eligible` line appears correctly ordered before `sub_agent_execution_results`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)