### PR TITLE
fix(QF-20260812-229): exclude status=invalid from /leo assist's issues stream

### DIFF
--- a/lib/quality/assist-engine.js
+++ b/lib/quality/assist-engine.js
@@ -209,7 +209,11 @@ class AssistEngine {
       items = await fetchAllPaginated(() => supabase
         .from('v_feedback_with_sensemaking')
         .select('*')
-        .not('status', 'in', '(resolved,wont_fix,shipped,snoozed)')
+        // QF-20260812-229: 'invalid' is a terminal, already-triaged status (used elsewhere for
+        // items reviewed and determined not to need action, with resolution_notes) that was
+        // missing from this exclude list -- a row closed as invalid kept resurfacing as an
+        // actionable issue on every subsequent /leo assist run.
+        .not('status', 'in', '(resolved,wont_fix,shipped,snoozed,invalid)')
         .order('priority', { ascending: true })
         .order('created_at', { ascending: true })
         .order('id', { ascending: true })); // unique tiebreaker: stable page boundaries (FR-6)


### PR DESCRIPTION
## Summary
`assist-engine.js`'s `loadInboxItems()` excludes `status IN (resolved,wont_fix,shipped,snoozed)` from the autonomous-fix issue stream, but not `invalid` — a terminal, already-triaged status used elsewhere in this codebase for items reviewed and determined not to need action (with `resolution_notes` explaining why). A row closed as `invalid` kept resurfacing as an actionable issue on every subsequent `/leo assist` run, identical to a never-triaged row.

Found while triaging the `/leo assist` inbox this session: closed a feedback row as `invalid` with clear resolution notes, then re-ran the inbox loader — it still showed up.

## Verification
- Live-verified against the real database (the mock in the existing test suite can't observe status filtering either way — it's a pure passthrough, so a synthetic test would be vacuous): before the fix, the closed row appeared in `loadInboxItems()`'s issues list; after, it doesn't. Issues count dropped from 23 to 21 (also caught one other pre-existing `invalid` row).
- `npx vitest run tests/unit/assist-engine-non-code-fixable-filter.test.js` — 12/12 pass, unaffected by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)