### PR TITLE
fix(SD-LEO-INFRA-RECONCILE-20260711-ORCHESTRATOR-001): reconcile 20260711 orchestrator migration ledger

### DIFF
--- a/database/migrations/20260711_orchestrator_terminal_status_sql_parity.sql
+++ b/database/migrations/20260711_orchestrator_terminal_status_sql_parity.sql
@@ -52,6 +52,24 @@
 --   deliberate reconcile decision, not a guard bypass. Section (c) is superseded by the
 --   20260712 apply either way. Recorded by coordinator session 56f09320.
 --
+-- RECONCILED 2026-08-12 (SD-LEO-INFRA-RECONCILE-20260711-ORCHESTRATOR-001), closing the OPEN
+-- FINDING above with direct pg_proc.prosrc / pg_get_triggerdef catalog verification over the
+-- pooler (independently corroborated by a second read-only pass) rather than a re-apply:
+--   (a),(b) get_progress_breakdown(text|uuid) — NOT round-1. Superseded FORWARD of this file's
+--     round-2 by a later, independent, already-applied migration:
+--     database/migrations/20260724_fix_get_progress_breakdown_deferred_terminal.sql
+--     (QF-20260724-212), which took round-2 verbatim and additionally widened the terminal set
+--     to include 'deferred'. Live currently reads status IN ('completed','cancelled','deferred').
+--   (d) try_auto_complete_parent_orchestrator, (e) trg_auto_complete_parent_orchestrator —
+--     confirmed live-matching this file's round-2 content exactly. Not diverged.
+--   (c) complete_orchestrator_sd — confirmed superseded by
+--     database/migrations/20260712_orchestrator_ghost_complete_lead_final.sql (its own header,
+--     lines 15-19, states this explicitly).
+-- CONCLUSION: no object declared in this file needs any further DDL apply. This header edit
+-- (no DDL body changed) is itself the artifact that closes the apply-ledger reconciliation —
+-- see scripts/reconcile-20260711-orchestrator-migration-ledger.mjs and
+-- scripts/orchestrator-20260711-parity-status.mjs for the durable, re-runnable evidence trail.
+--
 -- ─── ROLLBACK (verbatim prior definitions, captured live via pg_get_functiondef/
 -- pg_get_triggerdef 2026-07-11) ───
 -- Re-run get_progress_breakdown(text), get_progress_breakdown(uuid),

--- a/scripts/orchestrator-20260711-parity-status.mjs
+++ b/scripts/orchestrator-20260711-parity-status.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+/**
+ * orchestrator-20260711-parity-status.mjs
+ * SD-LEO-INFRA-RECONCILE-20260711-ORCHESTRATOR-001
+ *
+ * READ-ONLY per-object live-vs-file parity check for the objects declared in
+ * database/migrations/20260711_orchestrator_terminal_status_sql_parity.sql sections
+ * (a),(b),(d),(e). Mirrors the sanctioned pattern in
+ * scripts/orchestrator-rpc-enforcement-status.mjs (inspect live pg_proc.prosrc /
+ * pg_get_triggerdef rather than trusting a migration file or the apply ledger alone --
+ * "migration files that exist and are git-tracked are NOT evidence they were applied").
+ *
+ * (c) complete_orchestrator_sd is intentionally NOT checked here -- it is owned by
+ * database/migrations/20260712_orchestrator_ghost_complete_lead_final.sql, which already
+ * supersedes 20260711's own (c) (see that file's header, lines 15-19).
+ *
+ * Exit 0 always (status report, not a gate). Prints a verdict per object.
+ */
+import { createDatabaseClient } from './lib/supabase-connection.js';
+
+const DEFERRED_TERMINAL_MARKER = "status IN ('completed', 'cancelled', 'deferred')";
+const ROUND2_MARKER = "status IN ('completed', 'cancelled')";
+const WIDENED_TRIGGER_MARKER = "ANY (ARRAY['completed'::text, 'cancelled'::text])";
+
+async function main() {
+  const client = await createDatabaseClient('engineer', { verify: true });
+  let allGood = true;
+  try {
+    const { rows: fns } = await client.query(
+      `SELECT p.proname, pg_get_function_identity_arguments(p.oid) AS args, p.prosrc
+       FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+       WHERE n.nspname = 'public' AND p.proname = ANY($1::text[])`,
+      [['get_progress_breakdown', 'try_auto_complete_parent_orchestrator']]
+    );
+
+    for (const fn of fns) {
+      if (fn.proname === 'get_progress_breakdown') {
+        // (a)/(b): expected superseded-forward by 20260724 (deferred also counted).
+        const ok = fn.prosrc.includes(DEFERRED_TERMINAL_MARKER);
+        console.log(`${ok ? '✅' : '⚠️ '} get_progress_breakdown(${fn.args}): ${ok ? "superseded-forward by 20260724 (deferred counted) -- OK" : 'UNEXPECTED STATE -- re-verify, does not match the reconciled expectation'}`);
+        if (!ok) allGood = false;
+      } else if (fn.proname === 'try_auto_complete_parent_orchestrator') {
+        // (d): expected round-2 (cancelled counted alongside completed).
+        const ok = fn.prosrc.includes(ROUND2_MARKER);
+        console.log(`${ok ? '✅' : '⚠️ '} try_auto_complete_parent_orchestrator(): ${ok ? 'round-2 (cancelled counted) -- OK, matches 20260711' : 'MISSING round-2 logic -- re-verify'}`);
+        if (!ok) allGood = false;
+      }
+    }
+    if (fns.length < 2) {
+      console.log(`⚠️  Expected 2 function name(s) found, got ${fns.length} row(s) -- one or both may be missing entirely.`);
+      allGood = false;
+    }
+
+    const { rows: trigs } = await client.query(
+      `SELECT pg_get_triggerdef(t.oid) AS def
+       FROM pg_trigger t
+       JOIN pg_class c ON c.oid = t.tgrelid
+       WHERE t.tgname = 'trg_auto_complete_parent_orchestrator' AND NOT t.tgisinternal`
+    );
+    if (trigs.length === 0) {
+      console.log('⚠️  trg_auto_complete_parent_orchestrator: TRIGGER NOT FOUND');
+      allGood = false;
+    } else {
+      // (e): expected widened WHEN clause (fires on transition into EITHER terminal state).
+      const ok = trigs[0].def.includes(WIDENED_TRIGGER_MARKER);
+      console.log(`${ok ? '✅' : '⚠️ '} trg_auto_complete_parent_orchestrator: ${ok ? 'widened WHEN clause -- OK, matches 20260711 round-2' : 'NOT widened -- re-verify'}`);
+      if (!ok) allGood = false;
+    }
+
+    console.log('');
+    console.log('(c) complete_orchestrator_sd: not checked here by design -- owned by');
+    console.log('    database/migrations/20260712_orchestrator_ghost_complete_lead_final.sql');
+    console.log('');
+    console.log(allGood
+      ? 'STATUS: RECONCILED -- all checked objects (a,b,d,e) match the expected reconciled state.'
+      : 'STATUS: UNEXPECTED -- one or more objects diverged from the LEAD-phase (2026-08-12) findings; re-investigate before trusting SD-LEO-INFRA-RECONCILE-20260711-ORCHESTRATOR-001s conclusions.');
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error('ERROR', err.message);
+  process.exit(1);
+});

--- a/scripts/reconcile-20260711-orchestrator-migration-ledger.mjs
+++ b/scripts/reconcile-20260711-orchestrator-migration-ledger.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * FR-1 (SD-LEO-INFRA-RECONCILE-20260711-ORCHESTRATOR-001): reconcile the apply-ledger
+ * entry for database/migrations/20260711_orchestrator_terminal_status_sql_parity.sql
+ * so MIGRATION_APPLY_PROD_FAIL_TAMPERED stops firing on it.
+ *
+ * WHY NOT A GENUINE APPLY ROW (TR-2): the DDL body was never re-run and did not need to
+ * be -- sections (a)/(b) get_progress_breakdown are already ahead of this file's round-2
+ * content via a later, independent migration (20260724_fix_get_progress_breakdown_deferred_terminal.sql,
+ * QF-20260724-212); sections (d)/(e) already match round-2 exactly, live-verified. Inserting a
+ * prod_deploy=true row would misrepresent that a deploy happened. This row is explicitly
+ * dry_run=true, prod_deploy=false -- honest that no DDL executed via this record -- while
+ * still being success=true with the CURRENT file's sha256, which is all readAuditLatestForPath()
+ * (scripts/apply-migration.js) checks: it filters WHERE success = true only, not on dry_run.
+ *
+ * Idempotent: re-running after this SD's first successful run is a no-op (the sha already matches).
+ */
+import 'dotenv/config';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+import { createDatabaseClient } from './lib/supabase-connection.js';
+
+// TWO distinct paths, deliberately kept separate:
+//  - CONTENT_PATH: co-located with THIS script (import.meta.url-relative), so it always
+//    reads the file from whichever checkout this script itself lives in (worktree or
+//    main tree) regardless of the invoking CWD.
+//  - LEDGER_PATH_KEY: repoRoot (git rev-parse --show-toplevel from the invoking CWD) +
+//    the relative migration path -- matches apply-migration.js's OWN path resolution
+//    exactly, so a future genuine invocation from the main repo root looks up the same
+//    key this script writes. Run this script from the MAIN repo root so this resolves
+//    to the canonical (non-worktree-specific) path.
+const MIGRATION_PATH_REL = 'database/migrations/20260711_orchestrator_terminal_status_sql_parity.sql';
+const CONTENT_PATH = new URL(`../${MIGRATION_PATH_REL}`, import.meta.url).pathname.replace(/^\/([A-Za-z]:)/, '$1');
+const REPO_ROOT = execSync('git rev-parse --show-toplevel', { encoding: 'utf8' }).trim();
+const LEDGER_PATH_KEY = path.join(REPO_ROOT.replace(/\//g, path.sep), ...MIGRATION_PATH_REL.split('/'));
+const SD_KEY = 'SD-LEO-INFRA-RECONCILE-20260711-ORCHESTRATOR-001';
+
+function sha256(s) { return crypto.createHash('sha256').update(s, 'utf8').digest('hex'); }
+function gitUserEmail() {
+  try { return execSync('git config --get user.email', { encoding: 'utf8' }).trim(); }
+  catch { return process.env.GIT_USER_EMAIL || 'unknown'; }
+}
+
+async function main() {
+  const sql = fs.readFileSync(CONTENT_PATH, 'utf8');
+  const sha = sha256(sql);
+  const client = await createDatabaseClient('engineer', { verify: true });
+  try {
+    const { rows } = await client.query(
+      `SELECT id, migration_sha256, applied_at FROM public.schema_migrations_applied
+        WHERE migration_path = $1 AND success = true ORDER BY applied_at DESC LIMIT 1`,
+      [LEDGER_PATH_KEY]
+    );
+    const prior = rows[0] || null;
+    if (prior && prior.migration_sha256 === sha) {
+      console.log(`ALREADY_RECONCILED: latest ledger row (id=${prior.id}, applied_at=${prior.applied_at}) already matches the current file's sha256=${sha}. No-op.`);
+      return;
+    }
+
+    const reconciliation_note = {
+      kind: 'ledger_reconciliation',
+      sd_key: SD_KEY,
+      no_ddl_executed: true,
+      reason: "sections (a)/(b) get_progress_breakdown already superseded-forward by 20260724_fix_get_progress_breakdown_deferred_terminal.sql (QF-20260724-212); sections (d)/(e) try_auto_complete_parent_orchestrator + trg_auto_complete_parent_orchestrator already match this file's round-2 content exactly. Section (c) complete_orchestrator_sd is out of scope, owned by 20260712_orchestrator_ghost_complete_lead_final.sql.",
+      verified_via: 'direct pg_proc.prosrc + pg_get_triggerdef catalog query over the pooler, LEAD phase 2026-08-12, corroborated by an independent Explore file-read pass',
+      mechanism_verifications_ref: `strategic_directives_v2.metadata.mechanism_verifications for ${SD_KEY}`,
+    };
+
+    const cols = {
+      migration_path: LEDGER_PATH_KEY,
+      migration_sha256: sha,
+      applied_by: gitUserEmail(),
+      prod_deploy: false,
+      dry_run: true,
+      statement_count: 0,
+      object_diffs: JSON.stringify(reconciliation_note),
+      success: true,
+    };
+    const colNames = Object.keys(cols);
+    const placeholders = colNames.map((_, i) => `$${i + 1}`).join(', ');
+    const insertSql = `INSERT INTO public.schema_migrations_applied (${colNames.join(', ')}) VALUES (${placeholders}) RETURNING id, applied_at`;
+    const { rows: inserted } = await client.query(insertSql, colNames.map((c) => cols[c]));
+    console.log(`RECONCILED: inserted ledger row id=${inserted[0].id} applied_at=${inserted[0].applied_at} sha256=${sha} (dry_run=true, prod_deploy=false -- no DDL executed).`);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((e) => { console.error('ERROR', e.message); process.exit(1); });


### PR DESCRIPTION
## Summary
- The apply ledger recorded `database/migrations/20260711_orchestrator_terminal_status_sql_parity.sql` as applied 2026-07-11 at an earlier revision; the file was later revised with round-2 fixes and never re-applied, so a re-apply attempt earlier today was correctly blocked by `MIGRATION_APPLY_PROD_FAIL_TAMPERED`.
- Direct `pg_proc`/`pg_trigger` catalog verification over the pooler (independently corroborated by a second read-only Explore pass) established the TRUE live state, which reverses the SD's own hedged premise: sections (a)/(b) `get_progress_breakdown` are actually **ahead** of this file's round-2 content via a later, independent, already-applied migration (`20260724_fix_get_progress_breakdown_deferred_terminal.sql`, QF-20260724-212), which took round-2 verbatim and additionally widened the terminal-status set to include `'deferred'`. Sections (d)/(e) `try_auto_complete_parent_orchestrator` + the trigger already match round-2 exactly. Section (c) is separately, explicitly superseded by `20260712_orchestrator_ghost_complete_lead_final.sql`.
- **Conclusion: zero live DDL changes are needed anywhere.** This PR is a ledger + documentation reconciliation only:
  - Updates the file's own header to record the full supersession chain (mirrors the ORDERING-note pattern already used in 20260712's header)
  - Adds a ledger reconciliation entry (`dry_run=true, prod_deploy=false` — honestly not a re-apply event, satisfies `readAuditLatestForPath`'s `success=true` check without misrepresenting that DDL executed)
  - Adds a durable, read-only per-object verification script (`scripts/orchestrator-20260711-parity-status.mjs`) mirroring the sanctioned pattern in `scripts/orchestrator-rpc-enforcement-status.mjs`, so this reconciliation is independently re-verifiable rather than trusted forever from a one-time finding

## Test plan
- [x] Live-verified via direct catalog query (LEAD phase): (a)/(b) match 20260724's widened predicate, (d)/(e) match round-2 exactly — captured in `strategic_directives_v2.metadata.mechanism_verifications` for this SD
- [x] Independently corroborated via a second Explore pass reading all 3 relevant migration files
- [x] `node scripts/orchestrator-20260711-parity-status.mjs` run live: all 4 objects (a,b,d,e) print ✅ RECONCILED
- [x] Ledger reconciliation confirmed: the new row's `migration_path` matches the canonical main-repo-root path `apply-migration.js` resolves, and its `migration_sha256` matches this PR's final file content
- [x] `npx eslint` clean on both new scripts; pre-commit hooks (secret scan, DB-test guard, smoke tests, Gate 0, scope gate, LOC threshold) all passed
- [x] No functional DDL changed — comment-only edit to the migration file, confirmed via diff (18 insertions, 0 deletions in the SQL file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)