### PR TITLE
fix(QF-20260812-365): SD_TYPE_THRESHOLD no longer blocks on synthetic 0% when totalWeight=0

### DIFF
--- a/scripts/modules/handoff/validation/ValidationOrchestrator.js
+++ b/scripts/modules/handoff/validation/ValidationOrchestrator.js
@@ -462,7 +462,13 @@ export class ValidationOrchestrator {
     // SD-LEO-INFRA-HARDENING-001: Enforce SD-type-specific thresholds
     // This ensures security SDs require 90%, features require 85%, etc.
     // SD-MAN-FEAT-VISION-DASHBOARD-VALIDATE-001: Check registry for DISABLED override
-    if (results.passed && context.sd?.sd_type) {
+    if (results.passed && context.sd?.sd_type && totalWeight === 0) {
+      // QF-20260812-365: totalWeight=0 means no weighted gates were applicable to this
+      // phase/sd_type combination -- normalizedScore is a synthetic 0 (no content ran),
+      // not a real score of zero. Comparing it against the threshold produces a misleading
+      // "requires 85%, got 0%" block on a handoff that has no weighted gate content to fail.
+      console.log('   [GatePolicyResolver] SKIPPED: SD_TYPE_THRESHOLD (no weighted gates applicable, totalWeight=0)');
+    } else if (results.passed && context.sd?.sd_type) {
       const sdType = context.sd.sd_type;
 
       // Check if SD_TYPE_THRESHOLD is DISABLED in validation_gate_registry

--- a/tests/unit/handoff/validation-orchestrator-zero-weight-threshold.test.js
+++ b/tests/unit/handoff/validation-orchestrator-zero-weight-threshold.test.js
@@ -1,0 +1,96 @@
+/**
+ * Unit test: ValidationOrchestrator SD_TYPE_THRESHOLD skip when totalWeight=0
+ * QF-20260812-365
+ *
+ * When an SD's applicable gate set has zero total weight (no weighted gates
+ * registered for the phase/sd_type combination), normalizedScore synthetically
+ * defaults to 0 -- that means "no weighted gate content ran", not "content
+ * scored zero". SD_TYPE_THRESHOLD must skip in that case instead of hard-
+ * blocking with a misleading "requires 85%, got 0%" message.
+ */
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../../../lib/telemetry/workflow-timer.js', () => ({
+  startSpan: vi.fn(),
+  endSpan: vi.fn(),
+}));
+
+vi.mock('../../../lib/utils/sd-type-validation.js', () => ({
+  shouldSkipCodeValidation: vi.fn(() => false),
+}));
+
+vi.mock('../../../scripts/modules/handoff/validation/sd-type-applicability-policy.js', () => ({
+  createSkippedResult: vi.fn(),
+  isSkippedResult: vi.fn(() => false),
+  ValidatorStatus: { PASS: 'PASS', FAIL: 'FAIL', SKIPPED: 'SKIPPED' },
+  SkipReasonCode: { NON_APPLICABLE_SD_TYPE: 'NON_APPLICABLE_SD_TYPE' },
+}));
+
+// Realistic, NONZERO threshold -- if the fix regresses (threshold re-applied against a
+// synthetic 0), this test must observe a real SD_TYPE_THRESHOLD block, not an incidental pass.
+vi.mock('../../../scripts/modules/sd-type-checker.js', () => ({
+  THRESHOLD_PROFILES: { default: { gateThreshold: 85 }, feature: { gateThreshold: 85 } },
+}));
+
+vi.mock('../../../scripts/modules/handoff/validation/gate-result-schema.js', () => ({
+  validateGateResult: vi.fn((result) => ({
+    passed: result.passed ?? true,
+    score: result.score ?? 100,
+    maxScore: result.maxScore ?? result.max_score ?? 100,
+    issues: result.issues || [],
+    warnings: result.warnings || [],
+  })),
+}));
+
+vi.mock('../../../scripts/modules/handoff/validation/ValidatorRegistry.js', () => ({
+  validatorRegistry: { getOrCreateFallback: vi.fn(), normalizeResult: vi.fn(r => r) },
+}));
+
+vi.mock('../../../scripts/modules/handoff/validation/oiv/index.js', () => {
+  class MockOIVGate { constructor() { this.validateHandoff = vi.fn(() => ({ passed: true, score: 100, issues: [] })); } }
+  return { OIVGate: MockOIVGate, OIV_GATE_WEIGHT: 0.15 };
+});
+
+vi.mock('../../../scripts/modules/handoff/validation/validator-registry/gate-context-preloader.js', () => ({
+  preloadGateContext: vi.fn(() => ({})),
+  getGateNumberForRule: vi.fn(() => null),
+}));
+
+vi.mock('../../../scripts/modules/handoff/ResultBuilder.js', () => ({
+  default: { logGateResult: vi.fn() },
+}));
+
+import { ValidationOrchestrator } from '../../../scripts/modules/handoff/validation/ValidationOrchestrator.js';
+
+const mockSupabase = { from: vi.fn(() => ({ select: () => ({ eq: () => ({ limit: () => Promise.resolve({ data: [], error: null }) }) }) })) };
+
+describe('ValidationOrchestrator — QF-20260812-365 zero-weight SD_TYPE_THRESHOLD skip', () => {
+  let orch;
+  beforeEach(() => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    orch = new ValidationOrchestrator(mockSupabase);
+  });
+
+  it('an empty applicable gate list (totalWeight=0) skips SD_TYPE_THRESHOLD instead of blocking on a synthetic 0%', async () => {
+    const r = await orch.validateGates([], { sd: { sd_type: 'feature' } });
+    expect(r.normalizedScore).toBe(0);
+    expect(r.passed).toBe(true);
+    expect(r.failedGate).not.toBe('SD_TYPE_THRESHOLD');
+    expect(r.thresholdViolation).toBeUndefined();
+    expect(r.issues.some((i) => /requires \d+% gate score/.test(i))).toBe(false);
+  });
+
+  it('control: a real weighted gate scoring below threshold still blocks (fix does not disable the real check)', async () => {
+    const lowScoreGate = {
+      name: 'SOME_GATE',
+      required: true,
+      weight: 1,
+      validator: async () => ({ passed: true, score: 10, max_score: 100, issues: [], warnings: [] }),
+    };
+    const r = await orch.validateGates([lowScoreGate], { sd: { sd_type: 'feature' } });
+    expect(r.normalizedScore).toBeLessThan(85);
+    expect(r.failedGate).toBe('SD_TYPE_THRESHOLD');
+    expect(r.thresholdViolation).toEqual({ sdType: 'feature', required: 85, actual: r.normalizedScore });
+  });
+});


### PR DESCRIPTION
## Summary
- `ValidationOrchestrator.validateGates()` computed `normalizedScore = totalWeight>0 ? weighted average : 0`, then unconditionally compared that against `SD_TYPE_THRESHOLD`.
- When an SD's applicable gate set has zero total weight (no weighted gates registered for the phase/sd_type combination), the synthetic 0 meant "no weighted content ran" but was scored identically to "content scored zero", hard-blocking valid handoffs with a misleading "requires 85%, got 0%" message.
- Confirmed recurring on multiple orchestrator children this session (worker signals `ba1b55c3`, `8878aaa1`), matching an earlier identical block on a sibling child. Already logged to harness_backlog (feedback rows `613c3c2a`, `7fd67cef`, `79937c21`).

## Fix
Skip the `SD_TYPE_THRESHOLD` check when `totalWeight===0` instead of enforcing it against a synthetic score. A real weighted gate scoring below threshold still blocks exactly as before (regression-guarded by a control test).

## Test plan
- [x] New unit test: empty gate list (totalWeight=0) → passes, no `SD_TYPE_THRESHOLD` block
- [x] Control test: a real weighted gate scoring below threshold still blocks (fix doesn't disable the real check)
- [x] Mutation-tested: reverted the fix, confirmed the empty-gate-list test fails exactly reproducing the original defect
- [x] Broader regression sweep: 1179/1179 tests passing across `tests/unit/handoff/`, `tests/unit/gates/`, and related gate-scoring test files, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)