### PR TITLE
fix(QF-20260812-223): RETRO auto-generator PRD lookup misses UUID-keyed SDs

### DIFF
--- a/lib/sub-agents/retro/db-operations.js
+++ b/lib/sub-agents/retro/db-operations.js
@@ -146,6 +146,30 @@ export async function gatherSDMetadata(supabase, sdId) {
 }
 
 /**
+ * Fetch the PRD for an SD.
+ *
+ * QF-20260812-223: product_requirements_v2 stores the SD's UUID in sd_id but
+ * sd_key TEXT in directive_id (add-prd-to-database.js). Callers of this module
+ * may pass either format (gatherSDMetadata above already accepts both), so a
+ * single-column filter silently misses every PRD authored with the other
+ * format. Matches the sd_id/sd_key OR pattern already used elsewhere in this
+ * file (checkExistingRetrospective) and in auto-trigger-stories.mjs's getSDType.
+ *
+ * @param {Object} supabase - Supabase client
+ * @param {string} sdId - Strategic Directive ID (UUID or sd_key)
+ * @returns {Promise<Object>} { found, prd } or { found: false, error }
+ */
+export async function fetchPrdForSd(supabase, sdId) {
+  const { data, error } = await supabase
+    .from('product_requirements_v2')
+    .select('id, directive_id, title, functional_requirements, planned_end')
+    .or(`sd_id.eq.${sdId},directive_id.eq.${sdId}`)
+    .maybeSingle();
+
+  return data ? { found: true, prd: data } : { found: false, error: error?.message };
+}
+
+/**
  * Store retrospective in database
  * @param {Object} supabase - Supabase client
  * @param {Object} retrospective - Retrospective data to store

--- a/lib/sub-agents/retro/fetch-prd-for-sd.test.js
+++ b/lib/sub-agents/retro/fetch-prd-for-sd.test.js
@@ -1,0 +1,80 @@
+/**
+ * Regression test for QF-20260812-223.
+ *
+ * The RETRO auto-generator's PRD lookup filtered product_requirements_v2 by
+ * directive_id alone. add-prd-to-database.js writes the SD's UUID into sd_id
+ * and the sd_key TEXT into directive_id, and callers of this module (per
+ * gatherSDMetadata's own UUID-or-sd_key acceptance) may pass either format as
+ * sdId. A UUID sdId therefore never matched directive_id, silently returning
+ * "no PRD" and capping every such retro's quality_score at 60 — measured live
+ * on PRD-SD-ALTIFYAI-LEO-ORCH-SPRINT-2026-001-A (signal 63129ac5).
+ *
+ * The fix (fetchPrdForSd) queries sd_id OR directive_id so either format
+ * resolves correctly.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { fetchPrdForSd } from './db-operations.js';
+
+// Mock supabase that captures the exact .or() filter string fetchPrdForSd
+// builds and resolves the .from().select().or().maybeSingle() chain it uses.
+function makeMockSupabase(mockResult) {
+  const calls = { orFilter: null };
+  const supabase = {
+    from() {
+      return {
+        select() {
+          return {
+            or(filter) {
+              calls.orFilter = filter;
+              return {
+                maybeSingle: async () => mockResult,
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+  return { supabase, calls };
+}
+
+const UUID_SD_ID = '29d24771-78d0-4438-940d-c122401cf416';
+const SD_KEY = 'SD-ALTIFYAI-LEO-ORCH-SPRINT-2026-001-A';
+
+describe('fetchPrdForSd — sd_id/directive_id format mismatch (QF-20260812-223)', () => {
+  it('queries BOTH sd_id and directive_id, not directive_id alone', async () => {
+    const { supabase, calls } = makeMockSupabase({ data: null, error: null });
+    await fetchPrdForSd(supabase, UUID_SD_ID);
+    expect(calls.orFilter).toContain(`sd_id.eq.${UUID_SD_ID}`);
+    expect(calls.orFilter).toContain(`directive_id.eq.${UUID_SD_ID}`);
+  });
+
+  it('finds a PRD whose row only matches via sd_id (the exact defect this fixes)', async () => {
+    // Simulates a PRD row keyed by sd_id=UUID with a directive_id that does NOT
+    // equal the UUID sdId being queried -- the pre-fix .eq('directive_id', sdId)
+    // would have returned no row here.
+    const row = { id: 'PRD-' + SD_KEY, directive_id: SD_KEY, title: 'Test PRD' };
+    const { supabase } = makeMockSupabase({ data: row, error: null });
+    const result = await fetchPrdForSd(supabase, UUID_SD_ID);
+    expect(result.found).toBe(true);
+    expect(result.prd).toEqual(row);
+  });
+
+  it('still finds a PRD when sdId is passed as the sd_key (directive_id match)', async () => {
+    const row = { id: 'PRD-' + SD_KEY, directive_id: SD_KEY, title: 'Test PRD' };
+    const { supabase, calls } = makeMockSupabase({ data: row, error: null });
+    const result = await fetchPrdForSd(supabase, SD_KEY);
+    expect(calls.orFilter).toContain(`sd_id.eq.${SD_KEY}`);
+    expect(calls.orFilter).toContain(`directive_id.eq.${SD_KEY}`);
+    expect(result.found).toBe(true);
+    expect(result.prd).toEqual(row);
+  });
+
+  it('returns found=false with the error message when genuinely no PRD exists', async () => {
+    const { supabase } = makeMockSupabase({ data: null, error: { message: 'no rows' } });
+    const result = await fetchPrdForSd(supabase, UUID_SD_ID);
+    expect(result.found).toBe(false);
+    expect(result.error).toBe('no rows');
+  });
+});

--- a/lib/sub-agents/retro/index.js
+++ b/lib/sub-agents/retro/index.js
@@ -28,6 +28,7 @@ import { stripNestedFindings, semanticDeduplicateArray } from './utils.js';
 import {
   checkExistingRetrospective,
   gatherSDMetadata,
+  fetchPrdForSd,
   storeRetrospective,
   enhanceRetrospective,
   insertFeedbackForFutureEnhancements,
@@ -148,41 +149,38 @@ export async function execute(sdId, subAgent, options = {}) {
 
     console.log('\n⚡ Phases 2-4: Gathering PRD, handoffs, and sub-agent results in parallel...');
 
-    const batchResults = await batchQuery([
-      {
-        name: 'prd',
-        table: 'product_requirements_v2',
-        select: 'id, directive_id, title, functional_requirements, planned_end',
-        filters: { directive_id: sdId },
-        options: { maybeSingle: true }
-      },
-      {
-        name: 'handoffs',
-        table: 'sd_phase_handoffs',
-        select: 'id, sd_id, handoff_type, created_at',
-        filters: { sd_id: sdId },
-        options: { order: { column: 'created_at', ascending: true } }
-      },
-      {
-        name: 'sub_agent_results',
-        table: 'sub_agent_execution_results',
-        select: 'id, sd_id, sub_agent_code, sub_agent_name, verdict, confidence, created_at',
-        filters: { sd_id: sdId },
-        options: { order: { column: 'created_at', ascending: true } }
-      },
-      {
-        name: 'deliverables',
-        table: 'sd_scope_deliverables',
-        select: 'id, sd_id, deliverable_name, deliverable_type, priority, completion_status',
-        filters: { sd_id: sdId }
-      }
+    // QF-20260812-223: fetchPrdForSd handles the sd_id/directive_id format
+    // mismatch (see its docblock). Pulled out of batchQuery below since its
+    // filters helper only supports per-column .eq(), not .or(); run concurrently
+    // with it via Promise.all to preserve the original parallel-gather intent.
+    const [prdData, batchResults] = await Promise.all([
+      fetchPrdForSd(supabase, sdId),
+      batchQuery([
+        {
+          name: 'handoffs',
+          table: 'sd_phase_handoffs',
+          select: 'id, sd_id, handoff_type, created_at',
+          filters: { sd_id: sdId },
+          options: { order: { column: 'created_at', ascending: true } }
+        },
+        {
+          name: 'sub_agent_results',
+          table: 'sub_agent_execution_results',
+          select: 'id, sd_id, sub_agent_code, sub_agent_name, verdict, confidence, created_at',
+          filters: { sd_id: sdId },
+          options: { order: { column: 'created_at', ascending: true } }
+        },
+        {
+          name: 'deliverables',
+          table: 'sd_scope_deliverables',
+          select: 'id, sd_id, deliverable_name, deliverable_type, priority, completion_status',
+          filters: { sd_id: sdId }
+        }
+      ])
     ]);
 
     console.log(`   ⏱️  Parallel queries completed in ${batchResults.timing.total_ms}ms`);
 
-    const prdData = batchResults.data.prd
-      ? { found: true, prd: batchResults.data.prd }
-      : { found: false, error: batchResults.errors.prd };
     results.findings.prd_data = prdData;
 
     if (prdData.found) {


### PR DESCRIPTION
## Summary
- `product_requirements_v2` stores the SD's UUID in `sd_id` but the sd_key TEXT in `directive_id` (`add-prd-to-database.js`)
- The RETRO sub-agent's PRD lookup filtered `directive_id` alone, so a UUID `sdId` (the format most callers pass, since `gatherSDMetadata` accepts either) silently matched zero rows — "no PRD found" for every such retro, capping `quality_score` at 60 regardless of the SD's actual state
- Measured live on `PRD-SD-ALTIFYAI-LEO-ORCH-SPRINT-2026-001-A` (signal 63129ac5)
- Extracted the fetch into `fetchPrdForSd()` in `db-operations.js`, querying `sd_id OR directive_id` — the same OR pattern already used elsewhere in this file (`checkExistingRetrospective`) and in `auto-trigger-stories.mjs`'s `getSDType`
- Kept it running concurrently with the existing `batchQuery()` call via `Promise.all` to preserve the original parallel-gather intent (`batchQuery`'s filters helper only supports per-column `.eq()`, not `.or()`)

## Test plan
- [x] New regression test `lib/sub-agents/retro/fetch-prd-for-sd.test.js` (4 tests): asserts the `.or()` filter includes both columns, finds a PRD via `sd_id`-only match (the exact defect), still works when `sdId` is the sd_key, and returns `found: false` with error when genuinely absent
- [x] Full `lib/sub-agents/retro/` suite: 12/12 passing (3 files, no regressions)
- [x] Empirically verified against the exact cited defect: old `.eq('directive_id', sdId)` query returns `null` for `PRD-SD-ALTIFYAI-LEO-ORCH-SPRINT-2026-001-A`; new `.or()` query correctly finds it

🤖 Generated with [Claude Code](https://claude.com/claude-code)