### PR TITLE
feat(SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001): design per-venture secret-bound RPC fix for anon-writable feedback/error surfaces

### DIFF
--- a/.github/workflows/drive-reports-ddl.yml
+++ b/.github/workflows/drive-reports-ddl.yml
@@ -35,6 +35,11 @@ on:
       # Adding the paths is the whole fix; the tier still refuses to become a general one.
       - 'database/migrations/20260808_drive_state_verdicts.sql'
       - 'tests/ddl/drive-state-verdicts-ddl.db.test.js'
+      # SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001. Same TR-5 fix, applied to a NEW pair rather than
+      # amended-in: this workflow's own paths filter is literal, so a PR touching only this SD's
+      # migration and its ddl test would otherwise trigger nothing.
+      - 'database/chairman-gated/20260812_venture_ingest_key_binding.sql'
+      - 'tests/ddl/venture-ingest-key-binding-ddl.db.test.js'
       - 'vitest.ddl.config.mjs'
       # Self-validating: edits to this file re-run it.
       - '.github/workflows/drive-reports-ddl.yml'

--- a/database/chairman-gated/20260812_venture_ingest_key_binding.sql
+++ b/database/chairman-gated/20260812_venture_ingest_key_binding.sql
@@ -12,8 +12,15 @@
 -- otherwise correct.
 --
 -- ═══════════════════════════════════════════════════════════════════════════════════════════════
--- THE DEFECT THIS CLOSES (verified live, all probes rolled back — see PLAN-phase evidence
--- dff83abd (LEAD VALIDATION) and 3db8cfa8 (PLAN TESTING) on this SD)
+-- THE DEFECT THIS DESIGNS A FIX FOR (verified live, all probes rolled back — see PLAN-phase
+-- evidence dff83abd (LEAD VALIDATION) and 3db8cfa8 (PLAN TESTING) on this SD)
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- CORRECTED framing (EXEC-phase SECURITY sub-agent finding, evidence b99c9ec7, item MED-6): this
+-- file closes NEITHER hole below on its own. It ADDS a safer alternative path; the vulnerable
+-- surfaces (telegram_bot_insert_feedback, record_venture_error's original signature) remain
+-- exactly as reachable as before until the separate follow-on migrations named in "SCOPE OF THIS
+-- FILE" below are also ratified and applied, AFTER callers have migrated. Do not record this SD
+-- as having closed the vulnerability until that follow-on has actually landed.
 -- ═══════════════════════════════════════════════════════════════════════════════════════════════
 --   public.feedback policy telegram_bot_insert_feedback: WITH CHECK (source_type = 'telegram').
 --   No venture predicate at all — any anon caller can INSERT a row with ANY venture_id by setting
@@ -62,6 +69,23 @@
 -- Rollback: DROP the five functions and the venture_ingest_keys table (see foot of file); the
 -- ALTER TABLE feedback_type CHECK widening is additive (new value only) and safe to leave in place
 -- even on rollback — it does not change behavior for any existing feedback_type value.
+--
+-- TWO ARCHITECTURAL RESIDUALS, named rather than hidden (EXEC-phase SECURITY sub-agent finding,
+-- evidence b99c9ec7, items HIGH-2/HIGH-3), neither fixed by this file — both belong to Phase 3
+-- (caller migration), not Phase 1 (this file):
+--   HIGH-2: a per-venture secret shipped in a venture's own client-side bundle (the same delivery
+--     pattern as the CURRENT shared anon key) is still extractable by anyone who can read that
+--     bundle. This design converts GLOBAL forgery (any anon-key holder, any venture) into
+--     PER-VENTURE forgery (that venture's own key only) — closing cross-tenant spoofing, which is
+--     the stated threat model — but is not ownership proof against someone targeting one specific
+--     venture. Phase 3 should keep secret delivery server-side only where a venture's deployment
+--     architecture allows it, and should not assume client-bundle delivery is equivalent to a
+--     genuinely private credential.
+--   HIGH-3: fn_provision_venture_ingest_key's UPSERT has no rotation grace window — rotating a
+--     venture's secret immediately invalidates the old one, so rotation under suspected compromise
+--     guarantees an ingest outage for that venture until its deployment is updated. Phase 3 or a
+--     later amendment should consider a short-lived dual-valid window if rotation-under-suspicion
+--     becomes a real operational need.
 
 BEGIN;
 
@@ -73,7 +97,7 @@ BEGIN;
 -- ============================================================
 CREATE TABLE IF NOT EXISTS public.venture_ingest_keys (
   venture_id UUID PRIMARY KEY REFERENCES public.ventures(id),
-  ingest_secret TEXT NOT NULL,
+  ingest_secret_hash TEXT NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   rotated_at TIMESTAMPTZ
 );
@@ -81,14 +105,18 @@ CREATE TABLE IF NOT EXISTS public.venture_ingest_keys (
 COMMENT ON TABLE public.venture_ingest_keys IS
   'SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001: one secret per venture, used by fn_submit_venture_feedback '
   'and fn_submit_venture_error to bind an anon-authenticated write to a SPECIFIC venture, closing the '
-  'existence-only venture_id validation gap on public.feedback and record_venture_error. RLS-deny-all '
-  '(no policy for anon/authenticated/service_role) PLUS an explicit table-level REVOKE below — this '
-  'instance''s ALTER DEFAULT PRIVILEGES was measured live (migration dry-run, rolled back) to grant '
-  'every new public-schema table full SELECT/INSERT/UPDATE/DELETE to anon and authenticated BY '
-  'DEFAULT, independent of RLS. RLS alone would still functionally deny access, but the explicit '
-  'REVOKE means this table''s safety does not depend solely on RLS remaining enabled — the same '
-  'defense-in-depth posture database/migrations/20260803_drive_reports.sql already established for '
-  'a comparably sensitive table on this instance.';
+  'existence-only venture_id validation gap on public.feedback and record_venture_error. Stores only a '
+  'SHA-256 HASH (ingest_secret_hash), never the plaintext secret (EXEC-phase SECURITY sub-agent '
+  'correction, evidence b99c9ec7) — the plaintext exists only transiently in fn_provision_venture_'
+  'ingest_key''s local memory and the value returned to the caller once. RLS-deny-all (no policy for '
+  'anon/authenticated/service_role) PLUS an explicit table-level REVOKE below — this instance''s ALTER '
+  'DEFAULT PRIVILEGES was measured live (migration dry-run, rolled back) to grant every new public-'
+  'schema table full SELECT/INSERT/UPDATE/DELETE to anon and authenticated BY DEFAULT, independent of '
+  'RLS. RLS alone would still functionally deny access, but the explicit REVOKE means this table''s '
+  'safety does not depend solely on RLS remaining enabled — the same defense-in-depth posture database/'
+  'migrations/20260803_drive_reports.sql already established for a comparably sensitive table on this '
+  'instance. The SAME ALTER DEFAULT PRIVILEGES mechanism applies to newly created FUNCTIONS too, not '
+  'only tables (confirmed live) — every internal function below carries the equivalent explicit REVOKE.';
 
 ALTER TABLE public.venture_ingest_keys ENABLE ROW LEVEL SECURITY;
 
@@ -127,7 +155,16 @@ COMMENT ON FUNCTION public.fn_venture_ingest_prior_hour_count(UUID, TEXT) IS
   'global-per-source_type anon_feedback_ingress_bounds policy (which additionally never evaluates '
   'for a SECURITY DEFINER caller in the first place).';
 
-REVOKE ALL ON FUNCTION public.fn_venture_ingest_prior_hour_count(UUID, TEXT) FROM PUBLIC;
+-- CORRECTED (EXEC-phase SECURITY sub-agent finding, evidence b99c9ec7, FAIL/BLOCK-1): the same
+-- ALTER DEFAULT PRIVILEGES this file's own comments document for TABLES (see venture_ingest_keys
+-- above) ALSO applies to FUNCTIONS on this instance — confirmed live: a freshly created function
+-- gets EXECUTE granted directly to anon AND authenticated, not merely to PUBLIC. REVOKE ... FROM
+-- PUBLIC cannot remove a direct role grant. Every internal helper in this file must REVOKE FROM
+-- anon, authenticated explicitly, not only PUBLIC — the omission below-this-comment's ORIGINAL
+-- form would have made fn_provision_venture_ingest_key (further down) directly anon-callable,
+-- handing out any venture's plaintext-equivalent secret to any anon-key holder. Fixed here and at
+-- every other internal-function REVOKE in this file.
+REVOKE ALL ON FUNCTION public.fn_venture_ingest_prior_hour_count(UUID, TEXT) FROM PUBLIC, anon, authenticated;
 
 -- ============================================================
 -- 3. _verify_venture_ingest_secret: shared secret-check helper. Returns FALSE uniformly whether
@@ -136,32 +173,36 @@ REVOKE ALL ON FUNCTION public.fn_venture_ingest_prior_hour_count(UUID, TEXT) FRO
 --    (TS-6). Not anon/authenticated-executable for the same nested-call reason as above; also
 --    avoids handing out a standalone secret-guessing oracle independent of the RPCs' other
 --    business-logic latency.
---    Known residual limitation (documented, not fixed here): the equality check below is a plain
---    IS NOT DISTINCT FROM, not constant-time — identical to the precedent this migration follows
---    (fn_relay_insert_sms_candidate's p_relay_secret check, database/migrations/20260717_sms_
---    relay_staging.sql:103), not a new gap introduced by this file.
+--    CORRECTED (EXEC-phase SECURITY sub-agent finding, evidence b99c9ec7, item 2): compares
+--    against a SHA-256 hash, not the plaintext secret. This closes the timing-comparison residual
+--    for free (no non-constant-time plaintext comparison exists anywhere anymore) AND makes
+--    fn_provision_venture_ingest_key's COMMENT ("cannot be read back") literally true, which it
+--    was NOT while venture_ingest_keys stored plaintext — a service_role connection (or a future
+--    grant mistake) could previously read every venture's live secret directly off the table; now
+--    it can only read a hash. digest() is pgcrypto (extensions schema, per the search_path note
+--    on fn_provision_venture_ingest_key above).
 -- ============================================================
 CREATE OR REPLACE FUNCTION public._verify_venture_ingest_secret(p_venture_id UUID, p_ingest_secret TEXT)
 RETURNS BOOLEAN
 LANGUAGE sql
 STABLE
 SECURITY DEFINER
-SET search_path = public, pg_temp
+SET search_path = public, extensions, pg_temp
 AS $function$
   SELECT EXISTS (
     SELECT 1 FROM public.venture_ingest_keys k
     WHERE k.venture_id = p_venture_id
       AND p_ingest_secret IS NOT NULL
-      AND k.ingest_secret = p_ingest_secret
+      AND k.ingest_secret_hash = encode(digest(p_ingest_secret, 'sha256'), 'hex')
   );
 $function$;
 
 COMMENT ON FUNCTION public._verify_venture_ingest_secret(UUID, TEXT) IS
   'SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001: uniform venture-ownership check — FALSE for both a '
   'nonexistent venture_id and a real venture_id with the wrong secret, so response shape does not '
-  'enumerate venture existence (TS-6).';
+  'enumerate venture existence (TS-6). Compares a SHA-256 hash, never the plaintext secret.';
 
-REVOKE ALL ON FUNCTION public._verify_venture_ingest_secret(UUID, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public._verify_venture_ingest_secret(UUID, TEXT) FROM PUBLIC, anon, authenticated;
 
 -- ============================================================
 -- 4. fn_provision_venture_ingest_key: mints (or rotates) a venture's secret. service_role only —
@@ -188,10 +229,12 @@ BEGIN
   -- database/migrations/20260602_pin_search_path_invoker_functions.sql.
   v_secret := encode(gen_random_bytes(32), 'hex');
 
-  INSERT INTO public.venture_ingest_keys (venture_id, ingest_secret, created_at, rotated_at)
-  VALUES (p_venture_id, v_secret, now(), NULL)
+  -- Only the HASH is stored (see _verify_venture_ingest_secret's header note) — v_secret itself
+  -- exists only in this function's local memory and the value returned to the caller once.
+  INSERT INTO public.venture_ingest_keys (venture_id, ingest_secret_hash, created_at, rotated_at)
+  VALUES (p_venture_id, encode(digest(v_secret, 'sha256'), 'hex'), now(), NULL)
   ON CONFLICT (venture_id) DO UPDATE
-    SET ingest_secret = EXCLUDED.ingest_secret,
+    SET ingest_secret_hash = EXCLUDED.ingest_secret_hash,
         rotated_at = now();
 
   RETURN v_secret;
@@ -201,9 +244,16 @@ $$;
 COMMENT ON FUNCTION public.fn_provision_venture_ingest_key(UUID) IS
   'SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001 FR-5: mints or rotates a venture''s ingest secret. '
   'service_role only. Returns the plaintext secret ONCE — store it in that venture''s deployment '
-  'env immediately, it cannot be read back from venture_ingest_keys afterward.';
+  'env immediately. Only a SHA-256 hash is persisted; the plaintext genuinely cannot be read back '
+  'from venture_ingest_keys afterward, by any role.';
 
-REVOKE ALL ON FUNCTION public.fn_provision_venture_ingest_key(UUID) FROM PUBLIC;
+-- CORRECTED (EXEC-phase SECURITY sub-agent finding, evidence b99c9ec7, BLOCK-1, CRITICAL): the
+-- original REVOKE ... FROM PUBLIC alone left this function directly anon-EXECUTE-able via this
+-- instance's ALTER DEFAULT PRIVILEGES (confirmed live, same mechanism as the table-grant finding
+-- above) — any anon-key holder could have called this to read any venture's secret AND
+-- simultaneously invalidate that venture's real one via the rotation UPSERT. Explicit REVOKE FROM
+-- anon, authenticated closes it; this was the most severe defect this migration would have shipped.
+REVOKE ALL ON FUNCTION public.fn_provision_venture_ingest_key(UUID) FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.fn_provision_venture_ingest_key(UUID) TO service_role;
 
 -- ============================================================
@@ -288,11 +338,16 @@ DECLARE
 BEGIN
   -- Ownership check FIRST, before any business-logic branch, so a nonexistent venture_id and a
   -- real venture_id with the wrong secret are indistinguishable (TS-6).
-  IF NOT public._verify_venture_ingest_secret(p_venture_id, p_ingest_secret) THEN
+  -- IS NOT TRUE (not NOT ...), a defensive shape (EXEC-phase SECURITY sub-agent finding, evidence
+  -- b99c9ec7, item 1): both helpers are SELECT EXISTS(...), which never returns NULL today, so NOT
+  -- would be equally safe right now — but IF NOT <expr> is a fail-OPEN shape if that guarantee is
+  -- ever weakened by a future edit (NULL fails NOT's IF-branch silently). IS NOT TRUE fails closed
+  -- regardless of what the expression returns.
+  IF public._verify_venture_ingest_secret(p_venture_id, p_ingest_secret) IS NOT TRUE THEN
     RAISE EXCEPTION 'fn_submit_venture_feedback: unauthorized' USING ERRCODE = '28000';
   END IF;
 
-  IF NOT public.venture_exists_and_active(p_venture_id) THEN
+  IF public.venture_exists_and_active(p_venture_id) IS NOT TRUE THEN
     -- Defense-in-depth: a venture can be soft-deleted or have ingestion disabled after its key
     -- was provisioned. Same uniform code — do not distinguish "deactivated" from "unauthorized".
     RAISE EXCEPTION 'fn_submit_venture_feedback: unauthorized' USING ERRCODE = '28000';
@@ -320,7 +375,13 @@ BEGIN
 
   -- Rate limit, mirrored from anon_feedback_ingress_bounds for the same reason, PLUS the new
   -- per-venture scope (FR-4, TS-4) that policy never had.
-  IF public.fn_anon_ingress_prior_hour_count('venture_worker') >= 250 THEN
+  -- CORRECTED (EXEC-phase SECURITY sub-agent finding, evidence b99c9ec7, BLOCK-2): the global
+  -- threshold below must match the ELSE branch (50) of the live anon_feedback_ingress_bounds
+  -- CASE, not the auto_capture-specific 250 — 250 was ratified for auto_capture's OWN measured
+  -- peak of 213 (database/chairman-gated/20260804_ingress_bound_definer_basis.sql), which has
+  -- nothing to do with 'venture_worker' traffic, a brand-new source_type with zero measured
+  -- volume. Borrowing an unrelated number here was an inconsistency, not a considered choice.
+  IF public.fn_anon_ingress_prior_hour_count('venture_worker') >= 50 THEN
     RAISE EXCEPTION 'fn_submit_venture_feedback: rate limited' USING ERRCODE = '53400';
   END IF;
   IF public.fn_venture_ingest_prior_hour_count(p_venture_id, 'venture_worker') >= 50 THEN
@@ -379,13 +440,21 @@ DECLARE
   v_ceiling CONSTANT INTEGER := 20;
   v_window CONSTANT INTERVAL := interval '1 hour';
   v_distinct_count INTEGER;
-  v_watermark_hash TEXT := public._venture_error_storm_watermark_hash();
+  -- Assigned inside BEGIN, not here (EXEC-phase SECURITY sub-agent finding, evidence b99c9ec7,
+  -- item 1): a DECLARE-block default expression evaluates at function entry, before the ownership
+  -- check below — harmless today since this call is a pure IMMUTABLE constant with no venture-
+  -- specific input or side effect, but it made the file's own "check FIRST" claim literally false.
+  -- Moved so every expression genuinely runs after authorization, not merely every side effect.
+  v_watermark_hash TEXT;
   v_existing_row_id UUID;
 BEGIN
   -- Ownership check FIRST — same uniform code, same reasoning as fn_submit_venture_feedback (TS-6).
-  IF NOT public._verify_venture_ingest_secret(p_venture_id, p_ingest_secret) THEN
+  -- IS NOT TRUE, not NOT — see the matching note in fn_submit_venture_feedback above.
+  IF public._verify_venture_ingest_secret(p_venture_id, p_ingest_secret) IS NOT TRUE THEN
     RAISE EXCEPTION 'fn_submit_venture_error: unauthorized' USING ERRCODE = '28000';
   END IF;
+
+  v_watermark_hash := public._venture_error_storm_watermark_hash();
 
   IF p_error_hash IS NULL OR p_error_hash !~ '^[0-9a-f]{64}$' THEN
     RETURN jsonb_build_object('ok', false, 'reason', 'invalid_error_hash');
@@ -398,7 +467,7 @@ BEGIN
     p_context := jsonb_build_object('truncated', true);
   END IF;
 
-  IF NOT public.venture_exists_and_active(p_venture_id) THEN
+  IF public.venture_exists_and_active(p_venture_id) IS NOT TRUE THEN
     RAISE EXCEPTION 'fn_submit_venture_error: unauthorized' USING ERRCODE = '28000';
   END IF;
 
@@ -472,6 +541,55 @@ REVOKE ALL ON FUNCTION public.fn_submit_venture_error(UUID, TEXT, TEXT, TEXT, JS
 REVOKE ALL ON FUNCTION public.fn_submit_venture_error(UUID, TEXT, TEXT, TEXT, JSONB) FROM authenticated;
 GRANT EXECUTE ON FUNCTION public.fn_submit_venture_error(UUID, TEXT, TEXT, TEXT, JSONB) TO anon;
 GRANT EXECUTE ON FUNCTION public.fn_submit_venture_error(UUID, TEXT, TEXT, TEXT, JSONB) TO service_role;
+
+-- ============================================================
+-- 8. Self-verify the grant posture. EXEC-phase SECURITY sub-agent finding, evidence b99c9ec7,
+--    item 5: "add a fail-closed has_table_privilege/has_function_privilege assertion so it's a
+--    measured invariant, not a one-time act" — this instance's ALTER DEFAULT PRIVILEGES fires on
+--    every fresh CREATE, so a future re-run of the CREATE-side statements above without the
+--    matching REVOKE (a partial re-apply, a copy-paste into a new file, a restore that replays
+--    only some statements) could silently reintroduce exactly the BLOCK-1 defect this file's
+--    corrections just closed. This block turns "we revoked it" into "we assert it holds", and
+--    fails the whole transaction rather than applying half-fixed.
+-- ============================================================
+DO $verify$
+BEGIN
+  IF has_table_privilege('anon', 'public.venture_ingest_keys', 'SELECT')
+     OR has_table_privilege('authenticated', 'public.venture_ingest_keys', 'SELECT') THEN
+    RAISE EXCEPTION 'VERIFY FAILED: venture_ingest_keys is readable by anon or authenticated';
+  END IF;
+
+  IF has_function_privilege('anon', 'public.fn_provision_venture_ingest_key(uuid)', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public.fn_provision_venture_ingest_key(uuid)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'VERIFY FAILED: fn_provision_venture_ingest_key is callable by anon or authenticated';
+  END IF;
+
+  IF has_function_privilege('anon', 'public._verify_venture_ingest_secret(uuid,text)', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public._verify_venture_ingest_secret(uuid,text)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'VERIFY FAILED: _verify_venture_ingest_secret is callable by anon or authenticated';
+  END IF;
+
+  IF has_function_privilege('anon', 'public.fn_venture_ingest_prior_hour_count(uuid,text)', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public.fn_venture_ingest_prior_hour_count(uuid,text)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'VERIFY FAILED: fn_venture_ingest_prior_hour_count is callable by anon or authenticated';
+  END IF;
+
+  -- TWO-SIDED: the client-facing RPCs MUST still be anon-callable — a verify block strict enough
+  -- to reject every anon grant would silently no-op the two functions that exist specifically to
+  -- BE anon-callable, and this assertion would never catch that regression.
+  IF NOT has_function_privilege('anon', 'public.fn_submit_venture_feedback(uuid,text,text,text,text,text)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'VERIFY FAILED: fn_submit_venture_feedback is NOT anon-callable — the fix would be unreachable';
+  END IF;
+  IF NOT has_function_privilege('anon', 'public.fn_submit_venture_error(uuid,text,text,text,jsonb)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'VERIFY FAILED: fn_submit_venture_error is NOT anon-callable — the fix would be unreachable';
+  END IF;
+
+  -- TS-5: record_venture_error's original signature must be completely untouched.
+  IF (SELECT count(*) FROM pg_proc WHERE proname = 'record_venture_error') <> 1 THEN
+    RAISE EXCEPTION 'VERIFY FAILED: record_venture_error signature count changed — an overload may have been introduced';
+  END IF;
+END
+$verify$;
 
 COMMIT;
 

--- a/database/chairman-gated/20260812_venture_ingest_key_binding.sql
+++ b/database/chairman-gated/20260812_venture_ingest_key_binding.sql
@@ -577,10 +577,14 @@ BEGIN
   -- TWO-SIDED: the client-facing RPCs MUST still be anon-callable — a verify block strict enough
   -- to reject every anon grant would silently no-op the two functions that exist specifically to
   -- BE anon-callable, and this assertion would never catch that regression.
-  IF NOT has_function_privilege('anon', 'public.fn_submit_venture_feedback(uuid,text,text,text,text,text)', 'EXECUTE') THEN
+  -- IS NOT TRUE, not NOT, matching this file's own stated principle (re-verification finding,
+  -- evidence 83b9ce04, ADV-1) — has_function_privilege errors rather than returning NULL for a
+  -- malformed identity, so NOT was not exploitable here, but the inconsistency undercut the
+  -- principle the ownership checks above establish.
+  IF has_function_privilege('anon', 'public.fn_submit_venture_feedback(uuid,text,text,text,text,text)', 'EXECUTE') IS NOT TRUE THEN
     RAISE EXCEPTION 'VERIFY FAILED: fn_submit_venture_feedback is NOT anon-callable — the fix would be unreachable';
   END IF;
-  IF NOT has_function_privilege('anon', 'public.fn_submit_venture_error(uuid,text,text,text,jsonb)', 'EXECUTE') THEN
+  IF has_function_privilege('anon', 'public.fn_submit_venture_error(uuid,text,text,text,jsonb)', 'EXECUTE') IS NOT TRUE THEN
     RAISE EXCEPTION 'VERIFY FAILED: fn_submit_venture_error is NOT anon-callable — the fix would be unreachable';
   END IF;
 

--- a/database/chairman-gated/20260812_venture_ingest_key_binding.sql
+++ b/database/chairman-gated/20260812_venture_ingest_key_binding.sql
@@ -375,13 +375,26 @@ BEGIN
 
   -- Rate limit, mirrored from anon_feedback_ingress_bounds for the same reason, PLUS the new
   -- per-venture scope (FR-4, TS-4) that policy never had.
-  -- CORRECTED (EXEC-phase SECURITY sub-agent finding, evidence b99c9ec7, BLOCK-2): the global
-  -- threshold below must match the ELSE branch (50) of the live anon_feedback_ingress_bounds
-  -- CASE, not the auto_capture-specific 250 — 250 was ratified for auto_capture's OWN measured
-  -- peak of 213 (database/chairman-gated/20260804_ingress_bound_definer_basis.sql), which has
-  -- nothing to do with 'venture_worker' traffic, a brand-new source_type with zero measured
-  -- volume. Borrowing an unrelated number here was an inconsistency, not a considered choice.
-  IF public.fn_anon_ingress_prior_hour_count('venture_worker') >= 50 THEN
+  -- CORRECTED TWICE, and this is the version that actually holds (VERIFY-phase VALIDATION
+  -- finding, evidence 2df8275b, FR-4 FAIL): the EXEC-phase SECURITY correction (evidence
+  -- b99c9ec7, BLOCK-2) rightly flagged 250 as an arbitrary borrow from auto_capture's own
+  -- measured peak, but changing it to ALSO be 50 broke FR-4 itself — fn_venture_ingest_prior_
+  -- hour_count(venture, source_type) is a strict SUBSET of fn_anon_ingress_prior_hour_count
+  -- (source_type) (same predicate, plus a venture_id filter), so it can never exceed it. With
+  -- both thresholds equal, the GLOBAL check always trips first regardless of which venture is
+  -- responsible, making the per-venture check unreachable dead code and silently reintroducing
+  -- the exact cross-venture DoS FR-4 exists to prevent (one venture's 50 events/hour locks out
+  -- every other venture, identical to the status quo this migration is supposed to improve on).
+  -- The global threshold MUST be strictly greater than the per-venture one for FR-4 to mean
+  -- anything. 'venture_worker' has zero measured traffic (it's brand new), so there is no
+  -- peak to derive a number from the way auto_capture's 250 was derived — instead this uses a
+  -- reasoned multiplier: 10x the per-venture limit, i.e. enough headroom for 10 CONCURRENTLY
+  -- flooding ventures (currently 3 known near-term callers per FR-5: AltifyAI, apexniche-ai,
+  -- marketlens) before the shared source_type budget closes to everyone. This is a coarse
+  -- system-sanity backstop against a runaway/bug scenario, NOT the primary protection — the
+  -- primary protection is the per-venture check immediately below, which fires first for any
+  -- single flooding venture and leaves the shared budget intact for every other venture.
+  IF public.fn_anon_ingress_prior_hour_count('venture_worker') >= 500 THEN
     RAISE EXCEPTION 'fn_submit_venture_feedback: rate limited' USING ERRCODE = '53400';
   END IF;
   IF public.fn_venture_ingest_prior_hour_count(p_venture_id, 'venture_worker') >= 50 THEN

--- a/database/chairman-gated/20260812_venture_ingest_key_binding.sql
+++ b/database/chairman-gated/20260812_venture_ingest_key_binding.sql
@@ -1,0 +1,492 @@
+-- SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001 — per-venture secret-bound ingest RPCs
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- STAGED, NOT APPLIED. CHAIRMAN-GATED. DO NOT RUN THIS FILE.
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- AWAITING CHAIRMAN REVIEW — no @approved-by stamp exists for this file yet, deliberately. This
+-- SD's own LEAD-phase finding (signal 89b287e5) caught a SIBLING chairman-gated file whose header
+-- claimed "not applied" while pg_catalog showed it live — the fix for that class of drift is never
+-- writing an approval stamp until an approval actually happened, not writing one and hoping to
+-- correct it later. If this file is ever found APPLIED without an @approved-by line above this
+-- paragraph, that is itself a policy violation worth signaling, independent of whether the DDL is
+-- otherwise correct.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- THE DEFECT THIS CLOSES (verified live, all probes rolled back — see PLAN-phase evidence
+-- dff83abd (LEAD VALIDATION) and 3db8cfa8 (PLAN TESTING) on this SD)
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+--   public.feedback policy telegram_bot_insert_feedback: WITH CHECK (source_type = 'telegram').
+--   No venture predicate at all — any anon caller can INSERT a row with ANY venture_id by setting
+--   source_type='telegram', including forged votes/status/created_at.
+--
+--   public.record_venture_error: SECURITY DEFINER, anon-EXECUTE, validates venture_id via
+--   venture_exists_and_active() — EXISTENCE only, never OWNERSHIP. Any anon-key holder (the key
+--   ships in every venture's public bundle, confirmed in apexniche-ai and marketlens) can attribute
+--   an error to ANY venture_id, not just their own.
+--
+--   Neither surface can be fixed by tightening RLS alone: auth.uid() is NULL for anon, so a raw
+--   table policy structurally cannot express "this caller owns this venture". Ownership requires a
+--   caller-presented credential checked against a per-venture record — hence this migration.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- WHY THIS IS NOT AS SIMPLE AS "ADD A SECRET CHECK" — TWO CORRECTIONS FROM PLAN-PHASE TESTING
+-- (evidence 3db8cfa8, both incorporated below; the PRD text these functions implement was revised
+-- to match)
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- (1) A SECURITY DEFINER function owned by a role with rolbypassrls=true, writing to a table with
+--     relforcerowsecurity=false, NEVER evaluates that table's RLS policies — including the
+--     RESTRICTIVE anon_feedback_ingress_bounds rate-limit/content-integrity policy already live on
+--     public.feedback. This is the exact G1 mechanism already documented for record_venture_error.
+--     Every protection that policy provides (per-source_type rate limit, severity/category
+--     integrity) is therefore re-implemented EXPLICITLY inside fn_submit_venture_feedback's body
+--     below, not inherited. Skipping this would make the "fix" silently weaker than the status quo
+--     for every OTHER anon-writable path that still goes through RLS.
+-- (2) Adding a required parameter to record_venture_error's EXISTING signature would create a
+--     PostgREST same-name RPC overload (resolved by argument-name set), returning PGRST203
+--     (ambiguous function) for apexniche-ai/src/lib/error-capture.ts and
+--     marketlens/src/lib/errorCapture.js the instant this migration applies — before either repo's
+--     calling code has changed. fn_submit_venture_error below is therefore a NEW, separately-named
+--     function; record_venture_error's existing signature is left completely untouched and keeps
+--     serving unmigrated callers. Its anon-EXECUTE grant is revoked only as an explicit, separate,
+--     later follow-on once FR-5's caller migration is confirmed complete — not part of this file.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- SCOPE OF THIS FILE (Phase 1 only, per the PRD's implementation_approach)
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- This file ONLY adds new, additive objects (one table, five functions, two CHECK-constraint
+-- widenings) and does NOT touch any existing anon grant, policy, or function signature. Nothing
+-- existing stops working when this applies. Two follow-on steps are explicitly OUT of scope here
+-- and require separate chairman-ratified migrations once callers have migrated:
+--   (a) revoking anon-EXECUTE on record_venture_error's original signature
+--   (b) tightening or removing telegram_bot_insert_feedback / venture_user_insert_feedback
+-- Rollback: DROP the five functions and the venture_ingest_keys table (see foot of file); the
+-- ALTER TABLE feedback_type CHECK widening is additive (new value only) and safe to leave in place
+-- even on rollback — it does not change behavior for any existing feedback_type value.
+
+BEGIN;
+
+-- ============================================================
+-- 1. venture_ingest_keys: one secret per venture. RLS-deny-all — no policy is defined for
+--    any role, so only a SECURITY DEFINER function body or a service_role connection can read
+--    a row. Mirrors sms_relay_secret's access shape (database/migrations/20260717_sms_relay_
+--    staging.sql), keyed per-venture instead of a singleton.
+-- ============================================================
+CREATE TABLE IF NOT EXISTS public.venture_ingest_keys (
+  venture_id UUID PRIMARY KEY REFERENCES public.ventures(id),
+  ingest_secret TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  rotated_at TIMESTAMPTZ
+);
+
+COMMENT ON TABLE public.venture_ingest_keys IS
+  'SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001: one secret per venture, used by fn_submit_venture_feedback '
+  'and fn_submit_venture_error to bind an anon-authenticated write to a SPECIFIC venture, closing the '
+  'existence-only venture_id validation gap on public.feedback and record_venture_error. RLS-deny-all '
+  '(no policy for anon/authenticated/service_role) PLUS an explicit table-level REVOKE below — this '
+  'instance''s ALTER DEFAULT PRIVILEGES was measured live (migration dry-run, rolled back) to grant '
+  'every new public-schema table full SELECT/INSERT/UPDATE/DELETE to anon and authenticated BY '
+  'DEFAULT, independent of RLS. RLS alone would still functionally deny access, but the explicit '
+  'REVOKE means this table''s safety does not depend solely on RLS remaining enabled — the same '
+  'defense-in-depth posture database/migrations/20260803_drive_reports.sql already established for '
+  'a comparably sensitive table on this instance.';
+
+ALTER TABLE public.venture_ingest_keys ENABLE ROW LEVEL SECURITY;
+
+-- Explicit, belt-and-suspenders REVOKE (see COMMENT above for why this is not redundant with RLS).
+REVOKE ALL ON public.venture_ingest_keys FROM PUBLIC, anon, authenticated;
+GRANT ALL ON public.venture_ingest_keys TO service_role;
+
+-- ============================================================
+-- 2. fn_venture_ingest_prior_hour_count: per-venture, per-source_type counting basis for the
+--    rate limit the new RPC has to re-implement itself (see correction (1) above). Mirrors
+--    fn_anon_ingress_prior_hour_count's shape (database/chairman-gated/20260804_ingress_bound_
+--    definer_basis.sql) but keyed additionally by venture_id, closing the cross-venture DoS gap
+--    FR-4 describes (one venture's flood no longer exhausts another's budget).
+--    Deliberately NOT anon/authenticated-executable: it is only ever reached via a nested call
+--    from inside another SECURITY DEFINER function, which executes as the function owner
+--    regardless of grants — granting it directly to anon would additionally hand out a free
+--    "how many events has venture X submitted this hour" oracle with no ownership check.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.fn_venture_ingest_prior_hour_count(p_venture_id UUID, p_source_type TEXT)
+RETURNS BIGINT
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+  SELECT count(*)
+  FROM public.feedback f
+  WHERE f.venture_id = p_venture_id
+    AND f.source_type IS NOT DISTINCT FROM p_source_type
+    AND f.created_at > now() - interval '1 hour';
+$function$;
+
+COMMENT ON FUNCTION public.fn_venture_ingest_prior_hour_count(UUID, TEXT) IS
+  'SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001: per-venture-and-source_type prior-hour count, used '
+  'internally by fn_submit_venture_feedback to close the cross-venture DoS gap left by the existing '
+  'global-per-source_type anon_feedback_ingress_bounds policy (which additionally never evaluates '
+  'for a SECURITY DEFINER caller in the first place).';
+
+REVOKE ALL ON FUNCTION public.fn_venture_ingest_prior_hour_count(UUID, TEXT) FROM PUBLIC;
+
+-- ============================================================
+-- 3. _verify_venture_ingest_secret: shared secret-check helper. Returns FALSE uniformly whether
+--    the venture has no provisioned key at all, or has one that does not match — the caller
+--    cannot distinguish "venture unknown" from "venture known, wrong secret" from this alone
+--    (TS-6). Not anon/authenticated-executable for the same nested-call reason as above; also
+--    avoids handing out a standalone secret-guessing oracle independent of the RPCs' other
+--    business-logic latency.
+--    Known residual limitation (documented, not fixed here): the equality check below is a plain
+--    IS NOT DISTINCT FROM, not constant-time — identical to the precedent this migration follows
+--    (fn_relay_insert_sms_candidate's p_relay_secret check, database/migrations/20260717_sms_
+--    relay_staging.sql:103), not a new gap introduced by this file.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public._verify_venture_ingest_secret(p_venture_id UUID, p_ingest_secret TEXT)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $function$
+  SELECT EXISTS (
+    SELECT 1 FROM public.venture_ingest_keys k
+    WHERE k.venture_id = p_venture_id
+      AND p_ingest_secret IS NOT NULL
+      AND k.ingest_secret = p_ingest_secret
+  );
+$function$;
+
+COMMENT ON FUNCTION public._verify_venture_ingest_secret(UUID, TEXT) IS
+  'SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001: uniform venture-ownership check — FALSE for both a '
+  'nonexistent venture_id and a real venture_id with the wrong secret, so response shape does not '
+  'enumerate venture existence (TS-6).';
+
+REVOKE ALL ON FUNCTION public._verify_venture_ingest_secret(UUID, TEXT) FROM PUBLIC;
+
+-- ============================================================
+-- 4. fn_provision_venture_ingest_key: mints (or rotates) a venture's secret. service_role only —
+--    this is a chairman/operator/backend-only action per FR-5, never client-callable. Returns the
+--    plaintext secret ONCE, at mint time; after this call the table is unreadable to anything but
+--    a service_role connection or another SECURITY DEFINER function body.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.fn_provision_venture_ingest_key(p_venture_id UUID)
+RETURNS TEXT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, extensions, pg_temp
+AS $$
+DECLARE
+  v_secret TEXT;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.ventures WHERE id = p_venture_id) THEN
+    RAISE EXCEPTION 'fn_provision_venture_ingest_key: venture % does not exist', p_venture_id
+      USING ERRCODE = '22023';
+  END IF;
+
+  -- gen_random_bytes lives in the extensions schema (pgcrypto), not public — confirmed live via
+  -- pg_extension.extnamespace, matching the pinned search_path convention already established in
+  -- database/migrations/20260602_pin_search_path_invoker_functions.sql.
+  v_secret := encode(gen_random_bytes(32), 'hex');
+
+  INSERT INTO public.venture_ingest_keys (venture_id, ingest_secret, created_at, rotated_at)
+  VALUES (p_venture_id, v_secret, now(), NULL)
+  ON CONFLICT (venture_id) DO UPDATE
+    SET ingest_secret = EXCLUDED.ingest_secret,
+        rotated_at = now();
+
+  RETURN v_secret;
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_provision_venture_ingest_key(UUID) IS
+  'SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001 FR-5: mints or rotates a venture''s ingest secret. '
+  'service_role only. Returns the plaintext secret ONCE — store it in that venture''s deployment '
+  'env immediately, it cannot be read back from venture_ingest_keys afterward.';
+
+REVOKE ALL ON FUNCTION public.fn_provision_venture_ingest_key(UUID) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.fn_provision_venture_ingest_key(UUID) TO service_role;
+
+-- ============================================================
+-- 5. Widen feedback_type CHECK to add 'venture_feedback' — the new type this migration's
+--    feedback-path RPC writes, distinct from 'venture_error' (reserved for error-capture) and
+--    from every 'user_%' type (reserved for the existing human-submitted venture_user_insert_
+--    feedback path, which this migration does not touch). Additive only.
+-- ============================================================
+ALTER TABLE public.feedback
+  DROP CONSTRAINT IF EXISTS feedback_feedback_type_check;
+
+ALTER TABLE public.feedback
+  ADD CONSTRAINT feedback_feedback_type_check
+  CHECK (feedback_type IN (
+    'sentry_error',
+    'user_bug',
+    'user_feature_request',
+    'user_usability',
+    'user_other',
+    'venture_error',
+    'venture_feedback'
+  ));
+
+-- ============================================================
+-- 5b. Widen feedback_source_type_check to add 'venture_worker' — fn_submit_venture_feedback's
+--     source_type, distinct from every existing allowed value (manual_feedback, auto_capture,
+--     uat_failure, error_capture, uncaught_exception, unhandled_rejection, manual_capture,
+--     todoist_intake, youtube_intake, claude_code_intake, telegram, user_feedback), verified
+--     live via pg_get_constraintdef before writing this ALTER — 'venture_worker' does not
+--     collide with any of them. 'error_capture' (fn_submit_venture_error's source_type) is
+--     already in the existing list, matching record_venture_error's own convention — no change
+--     needed there. Additive only.
+-- ============================================================
+ALTER TABLE public.feedback
+  DROP CONSTRAINT IF EXISTS feedback_source_type_check;
+
+ALTER TABLE public.feedback
+  ADD CONSTRAINT feedback_source_type_check
+  CHECK (source_type IN (
+    'manual_feedback',
+    'auto_capture',
+    'uat_failure',
+    'error_capture',
+    'uncaught_exception',
+    'unhandled_rejection',
+    'manual_capture',
+    'todoist_intake',
+    'youtube_intake',
+    'claude_code_intake',
+    'telegram',
+    'user_feedback',
+    'venture_worker'
+  ));
+
+-- ============================================================
+-- 6. fn_submit_venture_feedback: the new, ownership-bound replacement write path for anon
+--    feedback submissions. Uniform ERRCODE=28000 for the ownership check (TS-1, TS-6); server-
+--    derived created_at/status/votes/assigned_to/triaged_by/user_id — none of these are
+--    parameters, so none can be client-forged (TS-2, FR-2 AC-2). Re-implements BOTH protections
+--    the RESTRICTIVE anon_feedback_ingress_bounds policy provides but which never evaluate for a
+--    SECURITY DEFINER caller: the per-source_type/per-venture rate limit (FR-4, TS-4), and the
+--    severity/category content-integrity bound the original policy also carries (mirrored here
+--    for parity — this is the same "RLS never evaluates" mechanism applied to a second existing
+--    protection, not just the rate limit).
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.fn_submit_venture_feedback(
+  p_venture_id UUID,
+  p_ingest_secret TEXT,
+  p_source_type TEXT,
+  p_severity TEXT,
+  p_category TEXT,
+  p_message TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_new_id UUID;
+  v_venture_name TEXT;
+BEGIN
+  -- Ownership check FIRST, before any business-logic branch, so a nonexistent venture_id and a
+  -- real venture_id with the wrong secret are indistinguishable (TS-6).
+  IF NOT public._verify_venture_ingest_secret(p_venture_id, p_ingest_secret) THEN
+    RAISE EXCEPTION 'fn_submit_venture_feedback: unauthorized' USING ERRCODE = '28000';
+  END IF;
+
+  IF NOT public.venture_exists_and_active(p_venture_id) THEN
+    -- Defense-in-depth: a venture can be soft-deleted or have ingestion disabled after its key
+    -- was provisioned. Same uniform code — do not distinguish "deactivated" from "unauthorized".
+    RAISE EXCEPTION 'fn_submit_venture_feedback: unauthorized' USING ERRCODE = '28000';
+  END IF;
+
+  IF p_source_type IS DISTINCT FROM 'venture_worker' THEN
+    RAISE EXCEPTION 'fn_submit_venture_feedback: invalid source_type' USING ERRCODE = '22004';
+  END IF;
+
+  IF p_message IS NULL OR length(trim(p_message)) = 0 THEN
+    RAISE EXCEPTION 'fn_submit_venture_feedback: message is required' USING ERRCODE = '22004';
+  END IF;
+  IF length(p_message) > 2000 THEN
+    p_message := left(p_message, 2000);
+  END IF;
+
+  -- Content-integrity bound, mirrored from anon_feedback_ingress_bounds (which does not
+  -- evaluate for this SECURITY DEFINER path — see file header correction (1)).
+  IF p_severity IS NOT NULL AND p_severity IN ('critical', 'high') THEN
+    RAISE EXCEPTION 'fn_submit_venture_feedback: severity not permitted on this path' USING ERRCODE = '22004';
+  END IF;
+  IF p_category IS NOT DISTINCT FROM 'chairman_decision_deferred' THEN
+    RAISE EXCEPTION 'fn_submit_venture_feedback: category not permitted on this path' USING ERRCODE = '22004';
+  END IF;
+
+  -- Rate limit, mirrored from anon_feedback_ingress_bounds for the same reason, PLUS the new
+  -- per-venture scope (FR-4, TS-4) that policy never had.
+  IF public.fn_anon_ingress_prior_hour_count('venture_worker') >= 250 THEN
+    RAISE EXCEPTION 'fn_submit_venture_feedback: rate limited' USING ERRCODE = '53400';
+  END IF;
+  IF public.fn_venture_ingest_prior_hour_count(p_venture_id, 'venture_worker') >= 50 THEN
+    RAISE EXCEPTION 'fn_submit_venture_feedback: rate limited' USING ERRCODE = '53400';
+  END IF;
+
+  SELECT name INTO v_venture_name FROM public.ventures WHERE id = p_venture_id;
+
+  INSERT INTO public.feedback (
+    venture_id, feedback_type, source_type, source_application,
+    severity, category, title, description, type, status
+  ) VALUES (
+    p_venture_id, 'venture_feedback', 'venture_worker', v_venture_name,
+    p_severity, p_category, left(p_message, 200), p_message, 'issue', 'new'
+  )
+  RETURNING id INTO v_new_id;
+
+  RETURN jsonb_build_object('ok', true, 'id', v_new_id);
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_submit_venture_feedback(UUID, TEXT, TEXT, TEXT, TEXT, TEXT) IS
+  'SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001 FR-2: ownership-bound replacement for anon feedback '
+  'writes. Uniform ERRCODE=28000 for every ownership-check reject path (TS-1, TS-6). Re-implements '
+  'the rate-limit and content-integrity checks that anon_feedback_ingress_bounds cannot provide for '
+  'a SECURITY DEFINER caller (TS-4). created_at/status/votes/assigned_to/triaged_by/user_id are '
+  'never parameters (TS-2).';
+
+REVOKE ALL ON FUNCTION public.fn_submit_venture_feedback(UUID, TEXT, TEXT, TEXT, TEXT, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.fn_submit_venture_feedback(UUID, TEXT, TEXT, TEXT, TEXT, TEXT) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.fn_submit_venture_feedback(UUID, TEXT, TEXT, TEXT, TEXT, TEXT) TO anon;
+GRANT EXECUTE ON FUNCTION public.fn_submit_venture_feedback(UUID, TEXT, TEXT, TEXT, TEXT, TEXT) TO service_role;
+
+-- ============================================================
+-- 7. fn_submit_venture_error: NEW, separately-named error-capture RPC (correction (2) above —
+--    NOT an overload of record_venture_error). Same dedup / per-venture distinct-fingerprint
+--    storm-ceiling logic as record_venture_error (database/migrations/20260704d_venture_error_
+--    aggregation_rpc.sql), reusing the SAME idx_feedback_venture_error_hash unique index and
+--    _venture_error_storm_watermark_hash() helper — both already exist and are untouched by this
+--    file — so rows from either the old or the new function dedup/aggregate together correctly.
+--    Only the caller-authentication differs: this path requires the per-venture secret first.
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.fn_submit_venture_error(
+  p_venture_id UUID,
+  p_ingest_secret TEXT,
+  p_error_hash TEXT,
+  p_message TEXT,
+  p_context JSONB DEFAULT '{}'::jsonb
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_ceiling CONSTANT INTEGER := 20;
+  v_window CONSTANT INTERVAL := interval '1 hour';
+  v_distinct_count INTEGER;
+  v_watermark_hash TEXT := public._venture_error_storm_watermark_hash();
+  v_existing_row_id UUID;
+BEGIN
+  -- Ownership check FIRST — same uniform code, same reasoning as fn_submit_venture_feedback (TS-6).
+  IF NOT public._verify_venture_ingest_secret(p_venture_id, p_ingest_secret) THEN
+    RAISE EXCEPTION 'fn_submit_venture_error: unauthorized' USING ERRCODE = '28000';
+  END IF;
+
+  IF p_error_hash IS NULL OR p_error_hash !~ '^[0-9a-f]{64}$' THEN
+    RETURN jsonb_build_object('ok', false, 'reason', 'invalid_error_hash');
+  END IF;
+
+  IF p_message IS NOT NULL AND length(p_message) > 2000 THEN
+    p_message := left(p_message, 2000);
+  END IF;
+  IF p_context IS NOT NULL AND octet_length(p_context::text) > 8000 THEN
+    p_context := jsonb_build_object('truncated', true);
+  END IF;
+
+  IF NOT public.venture_exists_and_active(p_venture_id) THEN
+    RAISE EXCEPTION 'fn_submit_venture_error: unauthorized' USING ERRCODE = '28000';
+  END IF;
+
+  SELECT id INTO v_existing_row_id
+  FROM public.feedback
+  WHERE venture_id = p_venture_id
+    AND feedback_type = 'venture_error'
+    AND error_hash = p_error_hash
+  LIMIT 1;
+
+  IF v_existing_row_id IS NOT NULL THEN
+    UPDATE public.feedback
+    SET occurrence_count = occurrence_count + 1,
+        last_seen = now(),
+        updated_at = now()
+    WHERE id = v_existing_row_id;
+
+    RETURN jsonb_build_object('ok', true, 'action', 'aggregated', 'id', v_existing_row_id);
+  END IF;
+
+  SELECT count(DISTINCT error_hash) INTO v_distinct_count
+  FROM public.feedback
+  WHERE venture_id = p_venture_id
+    AND feedback_type = 'venture_error'
+    AND error_hash <> v_watermark_hash
+    AND created_at > now() - v_window;
+
+  IF v_distinct_count >= v_ceiling THEN
+    INSERT INTO public.feedback (
+      venture_id, feedback_type, source_type, source_application,
+      error_hash, error_message, occurrence_count, first_seen, last_seen,
+      title, description, type, status, severity
+    ) VALUES (
+      p_venture_id, 'venture_error', 'error_capture',
+      (SELECT name FROM public.ventures WHERE id = p_venture_id),
+      v_watermark_hash, '[STORM SUPPRESSED] distinct-fingerprint ceiling exceeded',
+      1, now(), now(),
+      'Venture error storm watermark', 'Distinct-fingerprint ceiling exceeded for this venture in the trailing window',
+      'issue', 'new', 'high'
+    )
+    ON CONFLICT (venture_id, error_hash) WHERE feedback_type = 'venture_error' AND venture_id IS NOT NULL
+    DO UPDATE SET occurrence_count = feedback.occurrence_count + 1, last_seen = now(), updated_at = now();
+
+    RETURN jsonb_build_object('ok', true, 'action', 'storm_suppressed');
+  END IF;
+
+  INSERT INTO public.feedback (
+    venture_id, feedback_type, source_type, source_application,
+    error_hash, error_message, occurrence_count, first_seen, last_seen,
+    title, description, type, status, severity, metadata
+  ) VALUES (
+    p_venture_id, 'venture_error', 'error_capture',
+    (SELECT name FROM public.ventures WHERE id = p_venture_id),
+    p_error_hash, p_message, 1, now(), now(),
+    left(coalesce(p_message, 'Venture error'), 200), coalesce(p_message, ''),
+    'issue', 'new', 'medium', p_context
+  )
+  RETURNING id INTO v_existing_row_id;
+
+  RETURN jsonb_build_object('ok', true, 'action', 'created', 'id', v_existing_row_id);
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_submit_venture_error(UUID, TEXT, TEXT, TEXT, JSONB) IS
+  'SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001 FR-3: ownership-bound sibling of record_venture_error. '
+  'A NEW, separately-named function (not an added parameter on the existing signature) to avoid a '
+  'PostgREST same-name RPC overload (PGRST203) that would otherwise break every unmigrated caller '
+  'the instant this migration applies (TS-5). record_venture_error itself is untouched by this file.';
+
+REVOKE ALL ON FUNCTION public.fn_submit_venture_error(UUID, TEXT, TEXT, TEXT, JSONB) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.fn_submit_venture_error(UUID, TEXT, TEXT, TEXT, JSONB) FROM authenticated;
+GRANT EXECUTE ON FUNCTION public.fn_submit_venture_error(UUID, TEXT, TEXT, TEXT, JSONB) TO anon;
+GRANT EXECUTE ON FUNCTION public.fn_submit_venture_error(UUID, TEXT, TEXT, TEXT, JSONB) TO service_role;
+
+COMMIT;
+
+-- ============================================================
+-- ROLLBACK (manual, if needed — additive-only migration, safe to reverse in one pass):
+-- ============================================================
+-- REVOKE EXECUTE ON FUNCTION public.fn_submit_venture_error(UUID, TEXT, TEXT, TEXT, JSONB) FROM anon, service_role;
+-- DROP FUNCTION IF EXISTS public.fn_submit_venture_error(UUID, TEXT, TEXT, TEXT, JSONB);
+-- REVOKE EXECUTE ON FUNCTION public.fn_submit_venture_feedback(UUID, TEXT, TEXT, TEXT, TEXT, TEXT) FROM anon, service_role;
+-- DROP FUNCTION IF EXISTS public.fn_submit_venture_feedback(UUID, TEXT, TEXT, TEXT, TEXT, TEXT);
+-- REVOKE EXECUTE ON FUNCTION public.fn_provision_venture_ingest_key(UUID) FROM service_role;
+-- DROP FUNCTION IF EXISTS public.fn_provision_venture_ingest_key(UUID);
+-- DROP FUNCTION IF EXISTS public._verify_venture_ingest_secret(UUID, TEXT);
+-- DROP FUNCTION IF EXISTS public.fn_venture_ingest_prior_hour_count(UUID, TEXT);
+-- REVOKE ALL ON public.venture_ingest_keys FROM service_role;
+-- DROP TABLE IF EXISTS public.venture_ingest_keys;
+-- (feedback_type and source_type CHECK widenings are left in place — additive, no behavior
+--  change for any existing value)

--- a/database/chairman-gated/20260812_venture_ingest_key_binding.sql
+++ b/database/chairman-gated/20260812_venture_ingest_key_binding.sql
@@ -86,6 +86,35 @@
 --     guarantees an ingest outage for that venture until its deployment is updated. Phase 3 or a
 --     later amendment should consider a short-lived dual-valid window if rotation-under-suspicion
 --     becomes a real operational need.
+--
+-- THREE MORE, from an independent peer review (sec-rls-expert, this session, ranked "fix-before-
+-- Phase-3, not fix-before-apply" by the reviewer's own assessment — items 1/3/5/6 from that same
+-- review WERE treated as fix-before-apply and are fixed above/below):
+--   Failed-auth attempts (a wrong secret, a spoofed venture_id) are unmetered and unlogged — the
+--     28000 exceptions at the top of both RPCs raise before any rate check runs and nothing
+--     writes a failure row anywhere. Not a guessing risk at 256 bits of entropy, but a genuine
+--     observability gap: a cross-tenant attack in progress (the exact threat model this file
+--     exists for) is currently invisible. A later amendment should consider a lightweight
+--     failure-count mechanism, structured so it cannot itself become a new oracle.
+--   The feedback_type/source_type CHECK-constraint widenings (below) are DROP+ADD from a
+--     snapshot of the live constraint captured at authoring time, not asserted as a subset in the
+--     $verify$ block — a legitimate value added to either constraint between authoring and apply
+--     would be silently reverted by this file, and the $verify$ block as written cannot detect
+--     that. A later amendment could capture the pre-DROP value list and assert old ⊆ new. Related
+--     but separate: ADD CONSTRAINT here takes ACCESS EXCLUSIVE with full validation on the live
+--     table (~24.6k rows at authoring time) for the duration of this transaction — the same lock
+--     class the 2026-08-12 incident (see the incident record in this SD's metadata) held on
+--     production during an earlier, accidental apply. A NOT VALID + separate VALIDATE CONSTRAINT
+--     pattern would reduce that window; not done here to keep this file's DDL shape matching its
+--     own precedent (database/migrations/20260704d_venture_error_aggregation_rpc.sql uses the
+--     same plain DROP+ADD).
+--   fn_submit_venture_error's storm-suppression ON CONFLICT arbiter (idx_feedback_venture_error_
+--     hash) is only exercised once a venture crosses 20 distinct fingerprints in the trailing
+--     hour — a code path this SD's test suite cannot practically reach without a dedicated load
+--     scenario. A 42P10 (arbiter mismatch) would first surface during a real error storm, not
+--     during review. Flagged rather than fixed: the arbiter was independently verified to match
+--     the live index predicate exactly (byte-for-byte), so this is a coverage gap, not a known
+--     defect.
 
 BEGIN;
 
@@ -193,7 +222,7 @@ AS $function$
     SELECT 1 FROM public.venture_ingest_keys k
     WHERE k.venture_id = p_venture_id
       AND p_ingest_secret IS NOT NULL
-      AND k.ingest_secret_hash = encode(digest(p_ingest_secret, 'sha256'), 'hex')
+      AND k.ingest_secret_hash = encode(extensions.digest(p_ingest_secret, 'sha256'), 'hex')
   );
 $function$;
 
@@ -226,13 +255,19 @@ BEGIN
 
   -- gen_random_bytes lives in the extensions schema (pgcrypto), not public — confirmed live via
   -- pg_extension.extnamespace, matching the pinned search_path convention already established in
-  -- database/migrations/20260602_pin_search_path_invoker_functions.sql.
-  v_secret := encode(gen_random_bytes(32), 'hex');
+  -- database/migrations/20260602_pin_search_path_invoker_functions.sql. Schema-qualified
+  -- explicitly (peer review finding sec-rls-expert, Q3 item 5, this session), not merely relying
+  -- on search_path ordering: search_path here lists public BEFORE extensions, so an object named
+  -- public.gen_random_bytes/public.digest would shadow pgcrypto's real ones for a SECURITY
+  -- DEFINER function on the auth path. Not reachable today (measured: anon/authenticated lack
+  -- CREATE on public), but qualifying costs nothing and removes the class of risk entirely rather
+  -- than depending on a permission staying narrow.
+  v_secret := encode(extensions.gen_random_bytes(32), 'hex');
 
   -- Only the HASH is stored (see _verify_venture_ingest_secret's header note) — v_secret itself
   -- exists only in this function's local memory and the value returned to the caller once.
   INSERT INTO public.venture_ingest_keys (venture_id, ingest_secret_hash, created_at, rotated_at)
-  VALUES (p_venture_id, encode(digest(v_secret, 'sha256'), 'hex'), now(), NULL)
+  VALUES (p_venture_id, encode(extensions.digest(v_secret, 'sha256'), 'hex'), now(), NULL)
   ON CONFLICT (venture_id) DO UPDATE
     SET ingest_secret_hash = EXCLUDED.ingest_secret_hash,
         rotated_at = now();
@@ -244,8 +279,12 @@ $$;
 COMMENT ON FUNCTION public.fn_provision_venture_ingest_key(UUID) IS
   'SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001 FR-5: mints or rotates a venture''s ingest secret. '
   'service_role only. Returns the plaintext secret ONCE — store it in that venture''s deployment '
-  'env immediately. Only a SHA-256 hash is persisted; the plaintext genuinely cannot be read back '
-  'from venture_ingest_keys afterward, by any role.';
+  'env immediately. Only a SHA-256 hash is persisted; the plaintext cannot be READ BACK from '
+  'venture_ingest_keys afterward by any role (peer review correction, sec-rls-expert, this '
+  'session: this claim is about READING, not about every capability — service_role holds '
+  'rolbypassrls and a full table grant, so it can still WRITE a chosen ingest_secret_hash and '
+  'impersonate any venture; that is inherent to what service_role is, not something hashing '
+  'closes, and is the same trust boundary every table in this schema already depends on).';
 
 -- CORRECTED (EXEC-phase SECURITY sub-agent finding, evidence b99c9ec7, BLOCK-1, CRITICAL): the
 -- original REVOKE ... FROM PUBLIC alone left this function directly anon-EXECUTE-able via this
@@ -460,6 +499,7 @@ DECLARE
   -- Moved so every expression genuinely runs after authorization, not merely every side effect.
   v_watermark_hash TEXT;
   v_existing_row_id UUID;
+  v_updated_id UUID;
 BEGIN
   -- Ownership check FIRST — same uniform code, same reasoning as fn_submit_venture_feedback (TS-6).
   -- IS NOT TRUE, not NOT — see the matching note in fn_submit_venture_feedback above.
@@ -492,13 +532,39 @@ BEGIN
   LIMIT 1;
 
   IF v_existing_row_id IS NOT NULL THEN
+    -- Per-hash cooldown (peer review finding sec-rls-expert, Q3 item 1, this session): this
+    -- aggregation path previously had NO rate limit at all -- unlike fn_submit_venture_feedback,
+    -- which calls fn_venture_ingest_prior_hour_count, a repeated error_hash never creates a new
+    -- feedback row, so a row-COUNTING check can't see repeat-call volume; a secret holder could
+    -- increment occurrence_count without bound in a tight loop. A 1-second minimum interval
+    -- between increments for the SAME (venture, error_hash) caps that without new state --
+    -- genuine incident traffic (real repeated errors, typically seconds-to-minutes apart) is
+    -- unaffected; a pathological tight loop is capped at ~3600 increments/hour per hash instead
+    -- of unbounded.
+    -- clock_timestamp() throughout this cooldown, NOT now() (live dry-run finding, this session,
+    -- confirmed empirically): now()/CURRENT_TIMESTAMP is fixed at TRANSACTION START in Postgres,
+    -- not real wall-clock time. Using now() for the STORED value while comparing against
+    -- clock_timestamp() made the stored last_seen look artificially stale the instant more than
+    -- one real second had elapsed since the enclosing transaction began, regardless of true
+    -- call-to-call spacing -- exactly the false-immediate-pass a cooldown must not have. Using
+    -- clock_timestamp() consistently for both the stored value and the comparison ties the whole
+    -- check to real elapsed time, which is also the more precise semantic for a genuinely
+    -- "last SEEN" timestamp. Harmless for the normal case (a real PostgREST call is its own short
+    -- transaction, where now() and clock_timestamp() are indistinguishable) and correct for the
+    -- edge case (multiple calls batched in one caller-side transaction) that motivated using
+    -- clock_timestamp() for the comparison in the first place.
     UPDATE public.feedback
     SET occurrence_count = occurrence_count + 1,
-        last_seen = now(),
-        updated_at = now()
-    WHERE id = v_existing_row_id;
+        last_seen = clock_timestamp(),
+        updated_at = clock_timestamp()
+    WHERE id = v_existing_row_id
+      AND last_seen < clock_timestamp() - interval '1 second'
+    RETURNING id INTO v_updated_id;
 
-    RETURN jsonb_build_object('ok', true, 'action', 'aggregated', 'id', v_existing_row_id);
+    IF v_updated_id IS NOT NULL THEN
+      RETURN jsonb_build_object('ok', true, 'action', 'aggregated', 'id', v_updated_id);
+    END IF;
+    RETURN jsonb_build_object('ok', true, 'action', 'aggregated_rate_limited', 'id', v_existing_row_id);
   END IF;
 
   SELECT count(DISTINCT error_hash) INTO v_distinct_count
@@ -534,7 +600,10 @@ BEGIN
   ) VALUES (
     p_venture_id, 'venture_error', 'error_capture',
     (SELECT name FROM public.ventures WHERE id = p_venture_id),
-    p_error_hash, p_message, 1, now(), now(),
+    -- last_seen (not first_seen) is clock_timestamp() -- it is the field the cooldown check
+    -- above reads on the NEXT call for this hash, so it needs real elapsed time, matching the
+    -- clock_timestamp() correction on the aggregation branch above.
+    p_error_hash, p_message, 1, now(), clock_timestamp(),
     left(coalesce(p_message, 'Venture error'), 200), coalesce(p_message, ''),
     'issue', 'new', 'medium', p_context
   )
@@ -572,6 +641,25 @@ BEGIN
     RAISE EXCEPTION 'VERIFY FAILED: venture_ingest_keys is readable by anon or authenticated';
   END IF;
 
+  -- Three additions (peer review finding sec-rls-expert, Q3 item 3, this session): the block
+  -- above only checked SELECT for anon/authenticated, and nothing asserted RLS is actually
+  -- enabled, that zero policies exist, or that service_role can ACTUALLY execute the provisioning
+  -- RPC. The harness that validated this file so far called fn_provision_venture_ingest_key as
+  -- postgres (the owner, which retains EXECUTE regardless of any REVOKE) — a missing or typo'd
+  -- GRANT to service_role at the end of this file would pass every existing check while leaving
+  -- FR-5's provisioning path dead on arrival for the only role meant to use it.
+  IF (SELECT relrowsecurity FROM pg_class WHERE oid = 'public.venture_ingest_keys'::regclass) IS NOT TRUE THEN
+    RAISE EXCEPTION 'VERIFY FAILED: venture_ingest_keys does not have RLS enabled';
+  END IF;
+
+  IF (SELECT count(*) FROM pg_policies WHERE schemaname = 'public' AND tablename = 'venture_ingest_keys') <> 0 THEN
+    RAISE EXCEPTION 'VERIFY FAILED: venture_ingest_keys has a policy — it must remain deny-all-by-absence';
+  END IF;
+
+  IF has_function_privilege('service_role', 'public.fn_provision_venture_ingest_key(uuid)', 'EXECUTE') IS NOT TRUE THEN
+    RAISE EXCEPTION 'VERIFY FAILED: service_role cannot execute fn_provision_venture_ingest_key — FR-5 provisioning would be unreachable';
+  END IF;
+
   IF has_function_privilege('anon', 'public.fn_provision_venture_ingest_key(uuid)', 'EXECUTE')
      OR has_function_privilege('authenticated', 'public.fn_provision_venture_ingest_key(uuid)', 'EXECUTE') THEN
     RAISE EXCEPTION 'VERIFY FAILED: fn_provision_venture_ingest_key is callable by anon or authenticated';
@@ -607,6 +695,13 @@ BEGIN
   END IF;
 END
 $verify$;
+
+-- PostgREST caches the schema; without this, both new RPCs return 404/PGRST202 to real anon
+-- clients until PostgREST's own reload cycle catches up — a window where has_function_privilege
+-- (a grant check) already reads correctly but the fix is not yet reachable over the actual API
+-- surface (peer review finding sec-rls-expert, Q3 item 8, this session). Established convention
+-- in this codebase (e.g. database/migrations/20260426_add_claude_sessions_loop_state.sql).
+NOTIFY pgrst, 'reload schema';
 
 COMMIT;
 

--- a/database/chairman-gated/20260812_venture_ingest_key_binding_acceptance.mjs
+++ b/database/chairman-gated/20260812_venture_ingest_key_binding_acceptance.mjs
@@ -1,0 +1,192 @@
+// Behavioural acceptance for database/chairman-gated/20260812_venture_ingest_key_binding.sql
+// (SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001).
+//
+// NOT YET EXECUTED. Authored alongside the staged migration; the migration it tests is not
+// applied. This file makes no claim to have passed. It is the instrument, not the evidence.
+//
+// ── RUN IT TWICE. THE BASELINE IS NOT OPTIONAL. ───────────────────────────────────────────────
+//   node <this file> --baseline    BEFORE the apply. Every RPC call must fail with "could not
+//                                  find function" (PGRST202) — the objects do not exist yet.
+//   node <this file> --verify      AFTER  the apply. Every test below must PASS.
+//
+// A post-apply green proves nothing on its own unless the baseline first proved the probe CAN
+// fail. Matches the discriminator convention in the sibling
+// 20260803_bound_anon_ingress_source_type_qualifier_acceptance.mjs.
+//
+// ── METHOD ────────────────────────────────────────────────────────────────────────────────────
+// Goes through supabase-js exactly as a real caller (apexniche-ai/src/lib/error-capture.ts,
+// marketlens/src/lib/errorCapture.js) would — anon key, .rpc() — NOT a direct pg connection.
+// This is deliberately a DIFFERENT surface than the DDL tier (tests/ddl/venture-ingest-key-
+// binding-ddl.db.test.js) and the raw-pg live dry-run performed during EXEC: this is the one
+// that proves the objects are reachable the way production traffic actually reaches them
+// (through PostgREST's RPC resolution), which a direct pg connection cannot prove — PostgREST's
+// argument-name-based overload resolution (the exact TS-5 concern) is invisible to a raw driver.
+//
+// Every write goes through fn_submit_venture_feedback / fn_submit_venture_error using a secret
+// minted by THIS script (service-role only, matching FR-5's provisioning contract) for a REAL
+// existing venture, never a fabricated one — and is deleted in a finally block, including the
+// minted secret itself. Verification is by SERVICE-ROLE READBACK, never by trusting the RPC's
+// own reported {ok:true} alone.
+//
+// ── BLAST RADIUS, read before running ─────────────────────────────────────────────────────────
+// Mints and then deletes a venture_ingest_keys row for one real venture (chosen dynamically, the
+// first active venture returned). If that venture's secret was ALREADY provisioned by legitimate
+// prior use (a live caller migrated per FR-5 Phase 3), this script's fn_provision_venture_ingest_
+// key call ROTATES it — invalidating whatever secret that live caller was holding. Do not run
+// --verify against a venture already in live caller use once FR-5 Phase 3 has actually happened;
+// this acceptance script is written for the Phase 1 window where no caller has migrated yet.
+
+import 'dotenv/config';
+import { createClient } from '@supabase/supabase-js';
+
+const MODE = process.argv.includes('--baseline') ? 'baseline'
+           : process.argv.includes('--verify') ? 'verify'
+           : null;
+if (!MODE) {
+  console.error('Usage: node <this file> --baseline | --verify   (see the header: the baseline is not optional)');
+  process.exit(2);
+}
+
+const URL = process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
+const anon = createClient(URL, process.env.SUPABASE_ANON_KEY || process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);
+const svc = createClient(URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+const results = [];
+const record = (name, pass, detail) => { results.push({ name, pass, detail }); console.log(`  [${pass ? 'PASS' : 'FAIL'}] ${name}${detail ? ' — ' + detail : ''}`); };
+
+const createdFeedbackIds = [];
+let ventureA = null, ventureB = null, secretA = null;
+
+async function readback(id) {
+  const { data, error } = await svc.from('feedback').select('*').eq('id', id).maybeSingle();
+  if (error) throw new Error(`readback failed: ${error.message}`);
+  return data;
+}
+
+async function setup() {
+  const { data: ventures, error } = await svc.from('ventures').select('id, name').is('deleted_at', null).limit(2);
+  if (error || !ventures || ventures.length < 2) throw new Error('need at least 2 live ventures to run this acceptance script');
+  [ventureA, ventureB] = ventures;
+  console.log(`using ventures: A=${ventureA.id} (${ventureA.name}), B=${ventureB.id} (${ventureB.name})`);
+
+  if (MODE === 'verify') {
+    const { data, error: provErr } = await svc.rpc('fn_provision_venture_ingest_key', { p_venture_id: ventureA.id });
+    if (provErr) throw new Error(`provisioning failed in verify mode — the migration may not actually be applied: ${provErr.message}`);
+    secretA = data;
+    console.log(`provisioned secret for venture A (length ${secretA?.length})`);
+  }
+}
+
+async function teardown() {
+  if (createdFeedbackIds.length) {
+    const { error } = await svc.from('feedback').delete().in('id', createdFeedbackIds);
+    if (error) console.error(`CLEANUP WARNING: failed to delete probe feedback rows: ${error.message}`);
+  }
+  if (secretA !== null && ventureA) {
+    const { error } = await svc.from('venture_ingest_keys').delete().eq('venture_id', ventureA.id);
+    if (error) console.error(`CLEANUP WARNING: failed to delete provisioned test secret: ${error.message}`);
+    else console.log('cleaned up: provisioned test secret deleted');
+  }
+}
+
+async function runBaseline() {
+  console.log('\n--- BASELINE: every RPC must be UNREACHABLE (objects do not exist yet) ---');
+  const { error: e1 } = await anon.rpc('fn_submit_venture_feedback', {
+    p_venture_id: ventureA.id, p_ingest_secret: 'x', p_source_type: 'venture_worker',
+    p_severity: null, p_category: null, p_message: 'baseline probe',
+  });
+  record('fn_submit_venture_feedback is unreachable pre-apply', !!e1 && /could not find|PGRST202|does not exist/i.test(e1.message || ''), e1?.message);
+
+  const { error: e2 } = await anon.rpc('fn_submit_venture_error', {
+    p_venture_id: ventureA.id, p_ingest_secret: 'x', p_error_hash: 'a'.repeat(64), p_message: 'baseline probe',
+  });
+  record('fn_submit_venture_error is unreachable pre-apply', !!e2 && /could not find|PGRST202|does not exist/i.test(e2.message || ''), e2?.message);
+
+  const { error: e3 } = await anon.from('venture_ingest_keys').select('*').limit(1);
+  record('venture_ingest_keys is unreachable pre-apply', !!e3, e3?.message);
+}
+
+async function runVerify() {
+  console.log('\n--- VERIFY: post-apply behavioural contract ---');
+
+  // TS-1 / TS-6: cross-venture spoof rejected, uniform error.
+  const { error: spoofErr } = await anon.rpc('fn_submit_venture_feedback', {
+    p_venture_id: ventureB.id, p_ingest_secret: secretA, p_source_type: 'venture_worker',
+    p_severity: null, p_category: null, p_message: 'spoof attempt',
+  });
+  record('TS-1: cross-venture spoof rejected', !!spoofErr, spoofErr?.message);
+  record('TS-1: uniform ownership error code (28000)', spoofErr?.code === '28000' || /unauthorized/i.test(spoofErr?.message || ''), spoofErr?.message);
+
+  const { error: nonexistentErr } = await anon.rpc('fn_submit_venture_feedback', {
+    p_venture_id: '00000000-0000-0000-0000-000000000000', p_ingest_secret: secretA, p_source_type: 'venture_worker',
+    p_severity: null, p_category: null, p_message: 'nonexistent venture',
+  });
+  record('TS-6: nonexistent venture_id gives the SAME error as a wrong secret', nonexistentErr?.message === spoofErr?.message, `nonexistent="${nonexistentErr?.message}" vs spoof="${spoofErr?.message}"`);
+
+  // TS-2: valid submission, forgeable columns never land as client-supplied.
+  const { data: okResult, error: okErr } = await anon.rpc('fn_submit_venture_feedback', {
+    p_venture_id: ventureA.id, p_ingest_secret: secretA, p_source_type: 'venture_worker',
+    p_severity: 'medium', p_category: 'bug', p_message: 'acceptance probe — safe to delete',
+  });
+  record('valid submission succeeds', !okErr && okResult?.ok === true, okErr?.message);
+  if (okResult?.id) {
+    createdFeedbackIds.push(okResult.id);
+    const row = await readback(okResult.id);
+    record('TS-2: server-derived status/votes/assigned_to/triaged_by/user_id, never client-influenced', (
+      row?.status === 'new' && row?.votes === 0 && row?.assigned_to === null && row?.triaged_by === null && row?.user_id === null
+    ), JSON.stringify({ status: row?.status, votes: row?.votes }));
+  } else {
+    record('TS-2: server-derived columns', false, 'no row id returned — cannot verify');
+  }
+
+  // Content-integrity bound.
+  const { error: sevErr } = await anon.rpc('fn_submit_venture_feedback', {
+    p_venture_id: ventureA.id, p_ingest_secret: secretA, p_source_type: 'venture_worker',
+    p_severity: 'critical', p_category: null, p_message: 'should be rejected',
+  });
+  record('critical severity rejected (content-integrity bound re-implemented)', !!sevErr, sevErr?.message);
+
+  // FR-3/TS-1: error RPC, same ownership binding.
+  const errHash = 'c'.repeat(64);
+  const { data: errResult, error: errErr } = await anon.rpc('fn_submit_venture_error', {
+    p_venture_id: ventureA.id, p_ingest_secret: secretA, p_error_hash: errHash, p_message: 'acceptance probe error',
+  });
+  record('fn_submit_venture_error valid submission succeeds', !errErr && errResult?.ok === true, errErr?.message);
+  if (errResult?.id) createdFeedbackIds.push(errResult.id);
+
+  const { error: errSpoofErr } = await anon.rpc('fn_submit_venture_error', {
+    p_venture_id: ventureB.id, p_ingest_secret: secretA, p_error_hash: errHash, p_message: 'spoof',
+  });
+  record('fn_submit_venture_error cross-venture spoof rejected', !!errSpoofErr, errSpoofErr?.message);
+
+  // TS-5: record_venture_error is UNCHANGED and still callable with its ORIGINAL signature —
+  // proves no PostgREST overload/PGRST203 was introduced by this migration.
+  const { error: originalErr } = await anon.rpc('record_venture_error', {
+    p_venture_id: ventureA.id, p_error_hash: 'd'.repeat(64), p_message: 'original signature still works', p_context: {},
+  });
+  record('TS-5: record_venture_error original signature still callable, unambiguous (no PGRST203)', !originalErr || originalErr.code !== 'PGRST203', originalErr?.message);
+  if (!originalErr) {
+    const { data: rows } = await svc.from('feedback').select('id').eq('venture_id', ventureA.id).eq('error_hash', 'd'.repeat(64));
+    if (rows?.[0]?.id) createdFeedbackIds.push(rows[0].id);
+  }
+
+  // FR-1/GAP-1: venture_ingest_keys still unreadable by anon post-apply.
+  const { error: keysErr } = await anon.from('venture_ingest_keys').select('*').limit(1);
+  record('FR-1: venture_ingest_keys still unreadable by anon post-apply', !!keysErr, keysErr?.message);
+}
+
+(async () => {
+  try {
+    await setup();
+    if (MODE === 'baseline') await runBaseline();
+    else await runVerify();
+  } catch (e) {
+    console.error('ACCEPTANCE SCRIPT ERROR:', e.message);
+    process.exitCode = 1;
+  } finally {
+    await teardown();
+  }
+  const failed = results.filter((r) => !r.pass);
+  console.log(`\n=== ${MODE.toUpperCase()} RESULT: ${failed.length === 0 ? 'PASS' : `FAIL (${failed.length}/${results.length})`} ===`);
+  if (failed.length) process.exitCode = 1;
+})();

--- a/database/chairman-gated/20260812_venture_ingest_key_binding_acceptance.mjs
+++ b/database/chairman-gated/20260812_venture_ingest_key_binding_acceptance.mjs
@@ -1,8 +1,11 @@
 // Behavioural acceptance for database/chairman-gated/20260812_venture_ingest_key_binding.sql
 // (SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001).
 //
-// NOT YET EXECUTED. Authored alongside the staged migration; the migration it tests is not
-// applied. This file makes no claim to have passed. It is the instrument, not the evidence.
+// --baseline HAS been executed (2026-08-12, EXEC phase) and PASSED: all three discriminators
+// correctly reported the pre-apply state (both RPCs PGRST202, table absent from schema cache) --
+// proof the probe CAN fail, not proof the fix works. --verify has NOT been executed: the
+// migration itself remains staged, not chairman-ratified, not applied. This file's --verify mode
+// makes no claim to have passed.
 //
 // ── RUN IT TWICE. THE BASELINE IS NOT OPTIONAL. ───────────────────────────────────────────────
 //   node <this file> --baseline    BEFORE the apply. Every RPC call must fail with "could not

--- a/scripts/venture-ingest-keys-anon-probe.mjs
+++ b/scripts/venture-ingest-keys-anon-probe.mjs
@@ -1,0 +1,161 @@
+#!/usr/bin/env node
+/**
+ * Tier C probe for SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001 FR-1 — proves venture_ingest_keys is
+ * unreadable/unwritable by anon by any path, direct or inherited, on the REAL live instance.
+ *
+ * WHY THIS IS A SEPARATE FILE, NOT AN ADDITION TO scripts/anon-write-contract-probe.mjs. That
+ * probe's discovery (discoverAsymmetricTables) and ROW_BUILDERS target a DIFFERENT defect class:
+ * tables where anon CAN insert but SELECT coverage is asymmetric. venture_ingest_keys has ZERO
+ * policies for anon at all — canInsert never becomes true, so that probe's own discovery would
+ * never even surface it as a candidate. The defect shape here is simpler (deny-all, full stop)
+ * and the question is different: not "what can anon read back after writing", but "can anon
+ * reach this table by ANY of the four DML forms at all". Reusing that file's PROVEN safety
+ * primitives (assertRlsInForce, assertNotCommitFamily, classifyError, attributeRefusal) rather
+ * than re-deriving them is the point of the import below — those functions exist specifically
+ * because getting them wrong silently makes every verdict a lie (see that file's own header).
+ *
+ * WHY THE "NOT YET APPLIED" CASE MUST NOT LOOK LIKE A PASS. This migration is chairman-gated and
+ * staged, not applied (database/chairman-gated/20260812_venture_ingest_key_binding.sql). Running
+ * this probe today against production finds no such table. That is DISTINCT from "the table
+ * exists and correctly denies anon" — a probe that can't tell "not deployed" from "deployed and
+ * safe" would read as coverage before there is anything to cover. This file exits
+ * PROBE_INCONCLUSIVE (not OK) when the table is absent, with an unmistakable message, and is
+ * meant to be re-run for real once the migration is chairman-ratified and applied.
+ *
+ * SAFE AGAINST PRODUCTION for the same reason as its sibling: COMMIT-NEVER-ISSUED, not merely
+ * ROLLBACK-in-finally. No COMMIT-family statement appears in this file, and every query is
+ * wrapped through assertNotCommitFamily.
+ *
+ * Usage:
+ *   node scripts/venture-ingest-keys-anon-probe.mjs
+ */
+
+import { createDatabaseClient } from './lib/supabase-connection.js';
+import {
+  assertNotCommitFamily,
+  assertRlsInForce,
+  classifyError,
+} from './anon-write-contract-probe.mjs';
+
+export const EXIT = { OK: 0, ERROR: 1, CONTRACT_CHANGED: 2, PROBE_INCONCLUSIVE: 4, RLS_NOT_IN_FORCE: 5 };
+
+const TABLE = 'public.venture_ingest_keys';
+
+/**
+ * Mirrors anon-write-contract-probe.mjs's attributeRefusal, narrowed to this table's four forms.
+ * GRANT_DENIED means no table-level privilege exists at all (has_table_privilege returns false) —
+ * the strongest possible signal, since it means RLS was never even consulted. POLICY_DENIED means
+ * a grant exists but RLS's zero-policy default refused the row — still functionally safe, but a
+ * WEAKER signal (this migration's explicit REVOKE, added after a live dry-run caught this
+ * instance's ALTER DEFAULT PRIVILEGES auto-granting every new public-schema table to anon, exists
+ * specifically so this probe should observe GRANT_DENIED, not POLICY_DENIED).
+ */
+async function attribute(q, priv, err) {
+  if (err?.code !== '42501') return null;
+  const { rows: [p] } = await q('select has_table_privilege(current_user, $1::regclass, $2) as ok', [TABLE, priv]);
+  return p?.ok === false ? `GRANT_DENIED(${priv})` : `POLICY_DENIED(${priv})`;
+}
+
+async function probe(client, q) {
+  await q('BEGIN');
+  try {
+    await q("set local statement_timeout = '10s'");
+    await q("set local lock_timeout = '1s'");
+
+    const { rows: [t] } = await q(`select to_regclass($1) as t`, [TABLE]);
+    if (!t.t) {
+      return {
+        code: EXIT.PROBE_INCONCLUSIVE,
+        reason: 'venture_ingest_keys does not exist yet — the chairman-gated migration is staged, '
+          + 'not applied. This is NOT a pass; re-run this probe after ratification and apply.',
+      };
+    }
+
+    const { rows: [existing] } = await q(`select venture_id from ${TABLE} limit 1`);
+    // A live secret row would be exposed by a failed SELECT probe below only if the probe LANDS —
+    // this pre-check just confirms whether the table has any rows at all, for the report.
+    const hasRows = !!existing;
+
+    await q('set local role anon');
+    const { rows: [p] } = await q('select pg_backend_pid() as pid');
+
+    const rls = await assertRlsInForce(q, TABLE, p.pid);
+    if (!rls.ok) {
+      return { code: EXIT.RLS_NOT_IN_FORCE, reason: `RLS not in force before probing: ${rls.problems.join(', ')}` };
+    }
+
+    const forms = [
+      ['SELECT', `select 1 from ${TABLE} limit 1`],
+      ['INSERT', `insert into ${TABLE} (venture_id, ingest_secret) values (gen_random_uuid(), 'probe-value-never-lands')`],
+      ['UPDATE', `update ${TABLE} set ingest_secret = 'probe-value-never-lands' where true`],
+      ['DELETE', `delete from ${TABLE} where true`],
+    ];
+
+    const observed = {};
+    const attributions = {};
+    for (const [priv, sql] of forms) {
+      const sp = `sp_${priv.toLowerCase()}`;
+      await q(`SAVEPOINT ${sp}`);
+      try {
+        const r = await q(assertNotCommitFamily(sql));
+        // SELECT can "succeed" while returning zero rows — that is STILL a pass for this probe
+        // (GAP-1 cares about whether a secret is ever readable, not about statement success).
+        if (priv === 'SELECT') {
+          observed.SELECT = r.rows.length === 0 ? 'REFUSED_OR_EMPTY' : 'LANDS_WITH_ROWS';
+        } else {
+          observed[priv] = 'LANDS';
+        }
+        await q(`ROLLBACK TO SAVEPOINT ${sp}`);
+      } catch (err) {
+        await q(`ROLLBACK TO SAVEPOINT ${sp}`);
+        observed[priv] = classifyError(err);
+        attributions[priv] = (await attribute(q, priv, err)) ?? `${observed[priv]}(${err.code})`;
+      }
+    }
+
+    const bad = Object.entries(observed).filter(([k, v]) =>
+      (k === 'SELECT' && v === 'LANDS_WITH_ROWS') || (k !== 'SELECT' && v !== 'REFUSED'));
+    if (bad.length) {
+      return {
+        code: EXIT.CONTRACT_CHANGED,
+        reason: `anon can reach venture_ingest_keys: ${bad.map(([k, v]) => `${k}=${v}`).join(', ')}`,
+        observed, attributions, hasRows,
+      };
+    }
+
+    const notGrantDenied = Object.entries(attributions).filter(([, v]) => !v.startsWith('GRANT_DENIED'));
+    return {
+      code: EXIT.OK,
+      reason: notGrantDenied.length
+        ? `all four forms refused, but NOT all attributed to GRANT_DENIED (weaker signal): ${notGrantDenied.map(([k, v]) => `${k}=${v}`).join(', ')} — the explicit REVOKE this migration ships may be missing or was reverted`
+        : 'all four forms REFUSED and attributed to GRANT_DENIED — no table-level privilege exists for anon at all',
+      observed, attributions, hasRows,
+    };
+  } finally {
+    await q('ROLLBACK');
+  }
+}
+
+export async function main() {
+  let client = null;
+  try {
+    client = await createDatabaseClient('ehg',
+      process.env.DATABASE_URL ? { connectionString: process.env.DATABASE_URL } : {});
+    const q = (sql, params) => client.query(assertNotCommitFamily(sql), params);
+    const r = await probe(client, q);
+    console.log(`\n=== ${TABLE} (FR-1 / GAP-1 anon-probe) ===`);
+    for (const [form, verdict] of Object.entries(r.observed || {})) {
+      console.log(`  ${form.padEnd(8)} ${String(verdict).padEnd(20)} ${r.attributions?.[form] ?? ''}`);
+    }
+    console.log(`  -> [${Object.keys(EXIT).find((k) => EXIT[k] === r.code)}] ${r.reason}`);
+    return r.code;
+  } catch (err) {
+    console.error(`probe error: ${err.message}`);
+    return EXIT.ERROR;
+  } finally {
+    if (client) await client.end().catch(() => {});
+  }
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/').split('/').pop());
+if (invokedDirectly) main().then((code) => process.exit(code));

--- a/scripts/venture-ingest-keys-anon-probe.mjs
+++ b/scripts/venture-ingest-keys-anon-probe.mjs
@@ -86,8 +86,8 @@ async function probe(client, q) {
 
     const forms = [
       ['SELECT', `select 1 from ${TABLE} limit 1`],
-      ['INSERT', `insert into ${TABLE} (venture_id, ingest_secret) values (gen_random_uuid(), 'probe-value-never-lands')`],
-      ['UPDATE', `update ${TABLE} set ingest_secret = 'probe-value-never-lands' where true`],
+      ['INSERT', `insert into ${TABLE} (venture_id, ingest_secret_hash) values (gen_random_uuid(), 'probe-value-never-lands')`],
+      ['UPDATE', `update ${TABLE} set ingest_secret_hash = 'probe-value-never-lands' where true`],
       ['DELETE', `delete from ${TABLE} where true`],
     ];
 

--- a/tests/ddl/venture-ingest-key-binding-ddl.db.test.js
+++ b/tests/ddl/venture-ingest-key-binding-ddl.db.test.js
@@ -1,0 +1,448 @@
+// SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001 — the DDL tier for
+// database/chairman-gated/20260812_venture_ingest_key_binding.sql.
+//
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+// WHAT A GREEN RUN OF THIS FILE DOES **NOT** MEAN
+//
+// This runs against an EPHEMERAL vanilla PostgreSQL 16 with hand-stubbed roles AND hand-stubbed
+// versions of public.ventures / public.feedback / venture_exists_and_active / fn_anon_ingress_
+// prior_hour_count — the real schema this migration depends on, reproduced only as far as this
+// migration's own logic touches it. It proves the migration's OWN new logic (secret binding,
+// per-venture rate limit, content-integrity bound, uniform rejection). It does NOT prove:
+//   - production posture (Supabase role inheritance / ALTER DEFAULT PRIVILEGES are not
+//     reproduced by vanilla Postgres — see drive-reports-ddl.db.test.js's identical caveat)
+//   - that record_venture_error's ORIGINAL signature survives untouched (TS-5) — that requires
+//     the real record_venture_error to already exist, which is a live-schema fact, not something
+//     an ephemeral stub can honestly assert. TS-5 belongs to Tier B (the chairman-gated
+//     acceptance script), not here.
+//   - anon-readability of venture_ingest_keys (GAP-1 / FR-1's anon-probe acceptance criterion) —
+//     that requires the real PostgREST/Supabase grant surface, which is Tier C
+//     (scripts/anon-write-contract-probe.mjs), not this ephemeral Postgres.
+//
+// Read a passing run here as "the new functions' OWN logic does what it claims", not as "the
+// migration is safe to apply". Those are different claims.
+//
+// FAIL-CLOSED, no skip branch: if this file cannot reach a database it fails loudly rather than
+// silently passing (matches tests/ddl/drive-reports-ddl.db.test.js's own convention).
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+
+const MIGRATION_PATH = fileURLToPath(
+  new URL('../../database/chairman-gated/20260812_venture_ingest_key_binding.sql', import.meta.url),
+);
+const MIGRATION_SQL = fs.readFileSync(MIGRATION_PATH, 'utf8');
+
+// Minimal stand-ins for the parts of the real schema this migration's OWN functions read.
+// Deliberately narrow — this is not an attempt to reproduce public.ventures/public.feedback in
+// full, only the columns and functions fn_submit_venture_feedback / fn_submit_venture_error /
+// _verify_venture_ingest_secret actually touch.
+const STUB_SCHEMA = `
+DO $roles$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role')  THEN CREATE ROLE service_role NOLOGIN;  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon')          THEN CREATE ROLE anon NOLOGIN;          END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN CREATE ROLE authenticated NOLOGIN; END IF;
+END
+$roles$;
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS public.ventures (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT,
+  deleted_at TIMESTAMPTZ,
+  metadata JSONB DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS public.feedback (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  type VARCHAR NOT NULL DEFAULT 'issue',
+  source_application VARCHAR,
+  source_type VARCHAR NOT NULL,
+  title VARCHAR NOT NULL DEFAULT '',
+  description TEXT,
+  status VARCHAR DEFAULT 'new',
+  severity VARCHAR,
+  category VARCHAR,
+  error_message TEXT,
+  error_hash VARCHAR,
+  occurrence_count INTEGER DEFAULT 1,
+  first_seen TIMESTAMPTZ,
+  last_seen TIMESTAMPTZ,
+  votes INTEGER DEFAULT 0,
+  assigned_to VARCHAR,
+  triaged_by VARCHAR,
+  user_id UUID,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  metadata JSONB DEFAULT '{}'::jsonb,
+  venture_id UUID,
+  feedback_type VARCHAR NOT NULL DEFAULT 'sentry_error'
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_feedback_venture_error_hash
+  ON public.feedback (venture_id, error_hash)
+  WHERE feedback_type = 'venture_error' AND venture_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public._venture_error_storm_watermark_hash()
+RETURNS text LANGUAGE sql IMMUTABLE
+AS $$ SELECT 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'; $$;
+
+CREATE OR REPLACE FUNCTION public.venture_exists_and_active(p_venture_id UUID)
+RETURNS BOOLEAN LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.ventures v
+    WHERE v.id = p_venture_id
+      AND v.deleted_at IS NULL
+      AND COALESCE(v.metadata->>'telemetry_ingestion_enabled', 'true') <> 'false'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.fn_anon_ingress_prior_hour_count(p_source_type text)
+RETURNS bigint LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT count(*) FROM public.feedback f
+  WHERE f.source_type IS NOT DISTINCT FROM p_source_type
+    AND f.created_at > now() - interval '1 hour';
+$$;
+`;
+
+let client;
+
+async function applyMigration() {
+  await client.query(MIGRATION_SQL);
+}
+
+async function makeVenture(name = 'Test Venture') {
+  const { rows } = await client.query(
+    'INSERT INTO public.ventures (name) VALUES ($1) RETURNING id',
+    [name],
+  );
+  return rows[0].id;
+}
+
+async function provisionSecret(ventureId) {
+  const { rows } = await client.query(
+    'SELECT public.fn_provision_venture_ingest_key($1) AS secret',
+    [ventureId],
+  );
+  return rows[0].secret;
+}
+
+beforeAll(async () => {
+  client = new pg.Client({
+    host: process.env.PGHOST || '127.0.0.1',
+    port: Number(process.env.PGPORT || 5432),
+    database: process.env.PGDATABASE || 'ddl_check',
+    user: process.env.PGUSER || 'postgres',
+    password: process.env.PGPASSWORD || 'postgres',
+  });
+  await client.connect();
+  await client.query(STUB_SCHEMA);
+  await applyMigration();
+}, 60_000);
+
+afterAll(async () => {
+  if (client) await client.end();
+});
+
+describe('the migration applied', () => {
+  it('created venture_ingest_keys with RLS enabled and zero policies', async () => {
+    const { rows: t } = await client.query("SELECT to_regclass('public.venture_ingest_keys') AS t");
+    expect(t[0].t).toBe('venture_ingest_keys');
+
+    const { rows: rls } = await client.query(
+      "SELECT relrowsecurity FROM pg_class WHERE oid = 'public.venture_ingest_keys'::regclass",
+    );
+    expect(rls[0].relrowsecurity).toBe(true);
+
+    const { rows: pol } = await client.query(
+      "SELECT policyname FROM pg_policies WHERE schemaname='public' AND tablename='venture_ingest_keys'",
+    );
+    expect(pol).toHaveLength(0);
+  });
+
+  it('re-running the migration is idempotent', async () => {
+    await expect(applyMigration()).resolves.toBeTruthy();
+  });
+});
+
+describe('FR-1: venture_ingest_keys is not directly readable/writable by anon or authenticated', () => {
+  it('anon has no table-level privilege on venture_ingest_keys', async () => {
+    const { rows } = await client.query(`
+      SELECT count(*)::int AS n
+      FROM information_schema.role_table_grants
+      WHERE table_schema='public' AND table_name='venture_ingest_keys'
+        AND grantee IN ('anon', 'authenticated', 'PUBLIC')
+    `);
+    expect(rows[0].n).toBe(0);
+  });
+});
+
+describe('FR-5: fn_provision_venture_ingest_key', () => {
+  it('mints a secret and it round-trips through the RPC', async () => {
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    expect(typeof secret).toBe('string');
+    expect(secret.length).toBeGreaterThanOrEqual(32);
+  });
+
+  it('is not executable by anon or authenticated', async () => {
+    const { rows } = await client.query(`
+      SELECT count(*)::int AS n
+      FROM information_schema.role_routine_grants
+      WHERE routine_schema='public' AND routine_name='fn_provision_venture_ingest_key'
+        AND grantee IN ('anon', 'authenticated', 'PUBLIC')
+    `);
+    expect(rows[0].n).toBe(0);
+  });
+
+  it('rotating an existing venture updates rotated_at and the returned secret changes', async () => {
+    const ventureId = await makeVenture();
+    const first = await provisionSecret(ventureId);
+    const second = await provisionSecret(ventureId);
+    expect(second).not.toBe(first);
+    const { rows } = await client.query(
+      'SELECT rotated_at FROM public.venture_ingest_keys WHERE venture_id = $1',
+      [ventureId],
+    );
+    expect(rows[0].rotated_at).not.toBeNull();
+  });
+});
+
+describe('FR-2/TS-1/TS-6: fn_submit_venture_feedback ownership binding', () => {
+  it('a valid secret for the SAME venture succeeds', async () => {
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    const { rows } = await client.query(
+      'SELECT public.fn_submit_venture_feedback($1, $2, \'venture_worker\', \'medium\', \'bug\', \'it broke\') AS r',
+      [ventureId, secret],
+    );
+    expect(rows[0].r.ok).toBe(true);
+  });
+
+  it("[TS-1] venture A's valid secret with p_venture_id=B is rejected, uniform code", async () => {
+    const ventureA = await makeVenture('A');
+    const ventureB = await makeVenture('B');
+    const secretA = await provisionSecret(ventureA);
+    await expect(
+      client.query(
+        'SELECT public.fn_submit_venture_feedback($1, $2, \'venture_worker\', NULL, NULL, \'spoofed\') AS r',
+        [ventureB, secretA],
+      ),
+    ).rejects.toThrow(/unauthorized/);
+  });
+
+  it('[TS-6] a nonexistent venture_id and a real venture with the wrong secret raise the SAME error', async () => {
+    const ventureId = await makeVenture();
+    await provisionSecret(ventureId);
+
+    let errNonexistent;
+    try {
+      await client.query(
+        'SELECT public.fn_submit_venture_feedback(gen_random_uuid(), \'whatever-secret\', \'venture_worker\', NULL, NULL, \'x\') AS r',
+      );
+    } catch (e) { errNonexistent = e; }
+
+    let errWrongSecret;
+    try {
+      await client.query(
+        'SELECT public.fn_submit_venture_feedback($1, \'wrong-secret-entirely\', \'venture_worker\', NULL, NULL, \'x\') AS r',
+        [ventureId],
+      );
+    } catch (e) { errWrongSecret = e; }
+
+    expect(errNonexistent).toBeTruthy();
+    expect(errWrongSecret).toBeTruthy();
+    expect(errNonexistent.message).toBe(errWrongSecret.message);
+    expect(errNonexistent.code).toBe(errWrongSecret.code);
+    expect(errNonexistent.code).toBe('28000');
+  });
+
+  it('a NULL secret is rejected the same uniform way, not a distinct null-handling error', async () => {
+    const ventureId = await makeVenture();
+    await provisionSecret(ventureId);
+    await expect(
+      client.query(
+        'SELECT public.fn_submit_venture_feedback($1, NULL, \'venture_worker\', NULL, NULL, \'x\') AS r',
+        [ventureId],
+      ),
+    ).rejects.toThrow(/unauthorized/);
+  });
+});
+
+describe('FR-2/TS-2: forgeable workflow columns are never accepted as parameters', () => {
+  it('the function signature has no status/votes/created_at/assigned_to/triaged_by/user_id parameter', async () => {
+    const { rows } = await client.query(`
+      SELECT pg_get_function_arguments(p.oid) AS args
+      FROM pg_proc p WHERE p.proname = 'fn_submit_venture_feedback'
+    `);
+    const args = rows[0].args.toLowerCase();
+    for (const forged of ['status', 'votes', 'created_at', 'assigned_to', 'triaged_by', 'user_id']) {
+      expect(args).not.toContain(forged);
+    }
+  });
+
+  it('a successful insert gets server defaults for status/votes, never a caller-influenced value', async () => {
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    const { rows } = await client.query(
+      'SELECT (public.fn_submit_venture_feedback($1, $2, \'venture_worker\', NULL, NULL, \'test\'))->>\'id\' AS id',
+      [ventureId, secret],
+    );
+    const { rows: row } = await client.query(
+      'SELECT status, votes, assigned_to, triaged_by, user_id FROM public.feedback WHERE id = $1',
+      [rows[0].id],
+    );
+    expect(row[0].status).toBe('new');
+    expect(row[0].votes).toBe(0);
+    expect(row[0].assigned_to).toBeNull();
+    expect(row[0].triaged_by).toBeNull();
+    expect(row[0].user_id).toBeNull();
+  });
+});
+
+describe('content-integrity bound re-implemented (mirrors anon_feedback_ingress_bounds, which cannot see this SECURITY DEFINER path)', () => {
+  it('severity=critical is rejected', async () => {
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    await expect(
+      client.query(
+        'SELECT public.fn_submit_venture_feedback($1, $2, \'venture_worker\', \'critical\', NULL, \'x\') AS r',
+        [ventureId, secret],
+      ),
+    ).rejects.toThrow(/severity not permitted/);
+  });
+
+  it('severity=high is rejected', async () => {
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    await expect(
+      client.query(
+        'SELECT public.fn_submit_venture_feedback($1, $2, \'venture_worker\', \'high\', NULL, \'x\') AS r',
+        [ventureId, secret],
+      ),
+    ).rejects.toThrow(/severity not permitted/);
+  });
+
+  it('[TWO-SIDED] severity=medium is accepted — the bound must not reject everything', async () => {
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    const { rows } = await client.query(
+      'SELECT public.fn_submit_venture_feedback($1, $2, \'venture_worker\', \'medium\', NULL, \'x\') AS r',
+      [ventureId, secret],
+    );
+    expect(rows[0].r.ok).toBe(true);
+  });
+
+  it('category=chairman_decision_deferred is rejected', async () => {
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    await expect(
+      client.query(
+        'SELECT public.fn_submit_venture_feedback($1, $2, \'venture_worker\', NULL, \'chairman_decision_deferred\', \'x\') AS r',
+        [ventureId, secret],
+      ),
+    ).rejects.toThrow(/category not permitted/);
+  });
+});
+
+describe('FR-4/TS-4: rate limiting is enforced from INSIDE the function, per-venture', () => {
+  it('the function body contains an explicit rate-limit check, not merely assumed inherited RLS', async () => {
+    const { rows } = await client.query(
+      "SELECT pg_get_functiondef(p.oid) AS def FROM pg_proc p WHERE p.proname = 'fn_submit_venture_feedback'",
+    );
+    expect(rows[0].def).toMatch(/fn_venture_ingest_prior_hour_count/);
+    expect(rows[0].def).toMatch(/fn_anon_ingress_prior_hour_count/);
+  });
+
+  it('[THE DISCRIMINATING CASE] a venture exceeding ITS OWN per-venture threshold is rejected while a DIFFERENT venture under threshold is not', async () => {
+    const ventureA = await makeVenture('flooder');
+    const secretA = await provisionSecret(ventureA);
+    for (let i = 0; i < 50; i++) {
+      await client.query(
+        'SELECT public.fn_submit_venture_feedback($1, $2, \'venture_worker\', NULL, NULL, \'flood\') AS r',
+        [ventureA, secretA],
+      );
+    }
+    await expect(
+      client.query(
+        'SELECT public.fn_submit_venture_feedback($1, $2, \'venture_worker\', NULL, NULL, \'one too many\') AS r',
+        [ventureA, secretA],
+      ),
+    ).rejects.toThrow(/rate limited/);
+
+    // GAP-3 closed: a SIBLING venture on the same source_type, under its own threshold, is NOT
+    // rejected by venture A's flood — proving the scope is per-venture, not a re-check of a
+    // shared global limit that A's flood would also exhaust for B.
+    const ventureB = await makeVenture('sibling');
+    const secretB = await provisionSecret(ventureB);
+    const { rows } = await client.query(
+      'SELECT public.fn_submit_venture_feedback($1, $2, \'venture_worker\', NULL, NULL, \'unaffected\') AS r',
+      [ventureB, secretB],
+    );
+    expect(rows[0].r.ok).toBe(true);
+  }, 30_000);
+});
+
+describe('FR-3/TS-1/TS-6: fn_submit_venture_error ownership binding and dedup', () => {
+  const hash1 = 'a'.repeat(64);
+
+  it('a valid secret for the SAME venture succeeds and creates a row', async () => {
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    const { rows } = await client.query(
+      'SELECT public.fn_submit_venture_error($1, $2, $3, \'boom\') AS r',
+      [ventureId, secret, hash1],
+    );
+    expect(rows[0].r.ok).toBe(true);
+    expect(rows[0].r.action).toBe('created');
+  });
+
+  it('a repeat of the same fingerprint aggregates instead of duplicating', async () => {
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    await client.query('SELECT public.fn_submit_venture_error($1, $2, $3, \'boom\') AS r', [ventureId, secret, hash1]);
+    const { rows } = await client.query('SELECT public.fn_submit_venture_error($1, $2, $3, \'boom again\') AS r', [ventureId, secret, hash1]);
+    expect(rows[0].r.action).toBe('aggregated');
+  });
+
+  it("venture A's secret with p_venture_id=B is rejected, uniform 28000", async () => {
+    const ventureA = await makeVenture('A2');
+    const ventureB = await makeVenture('B2');
+    const secretA = await provisionSecret(ventureA);
+    await expect(
+      client.query('SELECT public.fn_submit_venture_error($1, $2, $3, \'spoof\') AS r', [ventureB, secretA, hash1]),
+    ).rejects.toThrow(/unauthorized/);
+  });
+
+  it('an invalid error_hash is rejected with a business-logic reason, AFTER the ownership check passes', async () => {
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    const { rows } = await client.query(
+      'SELECT public.fn_submit_venture_error($1, $2, \'not-a-valid-hash\', \'x\') AS r',
+      [ventureId, secret],
+    );
+    expect(rows[0].r.ok).toBe(false);
+    expect(rows[0].r.reason).toBe('invalid_error_hash');
+  });
+});
+
+describe('TS-5 (partial, structural half only): fn_submit_venture_error is a NEW function, not an overload', () => {
+  it('exactly one signature exists for fn_submit_venture_error', async () => {
+    const { rows } = await client.query(
+      "SELECT count(*)::int AS n FROM pg_proc WHERE proname = 'fn_submit_venture_error'",
+    );
+    expect(rows[0].n).toBe(1);
+  });
+
+  it('this migration defines no function named record_venture_error at all (the real coexistence-with-the-untouched-original claim is Tier B, not provable on a stub without it)', async () => {
+    expect(MIGRATION_SQL).not.toMatch(/CREATE (OR REPLACE )?FUNCTION public\.record_venture_error/);
+  });
+});

--- a/tests/ddl/venture-ingest-key-binding-ddl.db.test.js
+++ b/tests/ddl/venture-ingest-key-binding-ddl.db.test.js
@@ -28,6 +28,7 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import fs from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { createHash } from 'node:crypto';
 import pg from 'pg';
 
 const MIGRATION_PATH = fileURLToPath(
@@ -193,6 +194,22 @@ describe('FR-5: fn_provision_venture_ingest_key', () => {
     expect(secret.length).toBeGreaterThanOrEqual(32);
   });
 
+  it('stores exactly sha256(secret) as the hash — mutation-resistant, not merely "not the plaintext"', async () => {
+    // Peer review finding (sec-rls-expert, this session): asserting `stored !== plaintext` (the
+    // original check, in a since-deleted script) does not distinguish "correctly hashed" from
+    // "wrongly hashed" or even "garbage" — any non-plaintext value passes. This asserts the exact
+    // digest, which a mutant that hashed with the wrong algorithm, truncated the digest, or
+    // stored a random value would fail.
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    const { rows } = await client.query(
+      'SELECT ingest_secret_hash FROM public.venture_ingest_keys WHERE venture_id = $1',
+      [ventureId],
+    );
+    const expected = createHash('sha256').update(secret).digest('hex');
+    expect(rows[0].ingest_secret_hash).toBe(expected);
+  });
+
   it('is not executable by anon or authenticated', async () => {
     const { rows } = await client.query(`
       SELECT count(*)::int AS n
@@ -228,9 +245,18 @@ describe('FR-2/TS-1/TS-6: fn_submit_venture_feedback ownership binding', () => {
   });
 
   it("[TS-1] venture A's valid secret with p_venture_id=B is rejected, uniform code", async () => {
+    // CORRECTED (peer review sec-rls-expert, this session): the original version provisioned a
+    // secret for ventureA ONLY, so ventureB had NO row in venture_ingest_keys at all — the
+    // rejection was then produced entirely by "WHERE k.venture_id = p_venture_id" matching zero
+    // rows, never reaching the hash comparison. A mutant that deleted the hash-comparison clause
+    // entirely would still pass this test. Both ventures now get a REAL row, so the venture_id
+    // predicate matches (a row for B exists) and the hash comparison is what must reject A's
+    // secret against B's row — this is the only version of the test that actually exercises the
+    // ownership check it claims to validate.
     const ventureA = await makeVenture('A');
     const ventureB = await makeVenture('B');
     const secretA = await provisionSecret(ventureA);
+    await provisionSecret(ventureB);
     await expect(
       client.query(
         'SELECT public.fn_submit_venture_feedback($1, $2, \'venture_worker\', NULL, NULL, \'spoofed\') AS r',
@@ -414,9 +440,12 @@ describe('FR-3/TS-1/TS-6: fn_submit_venture_error ownership binding and dedup', 
   });
 
   it("venture A's secret with p_venture_id=B is rejected, uniform 28000", async () => {
+    // Same predicate-void correction as TS-1 above — ventureB needs its own real row or the
+    // venture_id predicate alone (not the hash comparison) produces the rejection.
     const ventureA = await makeVenture('A2');
     const ventureB = await makeVenture('B2');
     const secretA = await provisionSecret(ventureA);
+    await provisionSecret(ventureB);
     await expect(
       client.query('SELECT public.fn_submit_venture_error($1, $2, $3, \'spoof\') AS r', [ventureB, secretA, hash1]),
     ).rejects.toThrow(/unauthorized/);


### PR DESCRIPTION
## Summary

Designs (authors, does **not** apply — chairman-gated) a fix for two confirmed-live vulnerabilities where anon-callable, venture-scoped write surfaces validate `venture_id` by existence, not ownership:

- `public.feedback`'s `telegram_bot_insert_feedback` policy has no venture predicate at all
- `record_venture_error` RPC validates `venture_id` via `venture_exists_and_active()` — existence only

Any holder of the shared project anon key (shipped in every venture's public bundle) can currently attribute feedback/errors to any venture, not just their own.

**Fix**: `database/chairman-gated/20260812_venture_ingest_key_binding.sql` introduces a `venture_ingest_keys` table (one SHA-256-hashed secret per venture, RLS-deny-all + explicit REVOKE) and two ownership-bound SECURITY DEFINER RPCs — `fn_submit_venture_feedback` and `fn_submit_venture_error` (a **new** function, not an overload of `record_venture_error`, avoiding a PostgREST RPC-ambiguity that would otherwise break unmigrated callers). Both re-implement rate-limiting explicitly, since a SECURITY DEFINER function owned by a role with `rolbypassrls=true` never evaluates the existing RLS-based rate limit.

This migration went through **four independent review-and-fix cycles**, each catching and closing a real defect via live rolled-back dry-runs against production (see the retrospective, `retrospectives.id=701db370-17f1-42e5-8f1b-dbed0f6f58d9`, and `strategic_directives_v2.metadata` for this SD for full detail):
1. EXEC-phase SECURITY review: a critical `ALTER DEFAULT PRIVILEGES` grant gap on internal functions
2. VERIFY-phase VALIDATION: a rate-limit fix that silently disabled a different requirement
3. An independent peer review: a predicate-void flaw in this PR's own test suite, plus a genuinely unbounded-write gap
4. VERIFY-phase REGRESSION: confirmed zero backward-compatibility issues (PASS)

A separate, unrelated incident during authoring (a validation script bug accidentally committed this migration to production for real) was caught, signaled critical, fully reverted, and independently re-verified — durably recorded in this SD's metadata.

## Test plan

- [x] Tier A (ephemeral-Postgres logic tests): `tests/ddl/venture-ingest-key-binding-ddl.db.test.js`
- [x] Tier B (chairman-gated `--baseline`/`--verify` acceptance script): `database/chairman-gated/20260812_venture_ingest_key_binding_acceptance.mjs` — `--baseline` run and passed
- [x] Tier C (live anon-role `GRANT_DENIED` probe): `scripts/venture-ingest-keys-anon-probe.mjs` — run and correctly reports `PROBE_INCONCLUSIVE` (migration unapplied)
- [x] Migration logic live-validated via rolled-back dry-runs throughout authoring (multiple rounds, each round confirmed nothing persisted via a fresh connection)
- [ ] `--verify` mode and the CI-wired DDL test require the migration to actually be applied — that requires separate chairman ratification, out of scope for this SD

🤖 Generated with [Claude Code](https://claude.com/claude-code)