### PR TITLE
fix(QF-20260812-724): map SUPABASE_DB_PASSWORD in DR rehearsal cron

### DIFF
--- a/.github/workflows/dr-restore-rehearsal-cron.yml
+++ b/.github/workflows/dr-restore-rehearsal-cron.yml
@@ -29,6 +29,7 @@ jobs:
     env:
       SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_DB_PASSWORD }}
       PGHOST: ${{ secrets.PGHOST_PROD }}
       PGPORT: ${{ secrets.PGPORT_PROD }}
       PGDATABASE: ${{ secrets.PGDATABASE_PROD }}


### PR DESCRIPTION
## Summary
- `scripts/dr/restore-rehearsal.mjs` connects via `scripts/lib/supabase-connection.js`, which reads `SUPABASE_DB_PASSWORD` or `EHG_DB_PASSWORD` from env
- The workflow's `env:` block only mapped `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE_KEY`/`PG*_PROD` — confirmed `PGPASSWORD` has zero references anywhere in `supabase-connection.js`, so those `PG*` mappings are vestigial for this purpose
- Every run failed immediately: `Database password not found. Set SUPABASE_DB_PASSWORD or EHG_DB_PASSWORD` (evidence: run 31598720486)
- The repo secret `SUPABASE_DB_PASSWORD` now exists (chairman-approved S1 item 5, set 2026-08-12) — this maps it into the workflow's env block

## Test plan
- [x] Verified the premise against current code: `scripts/lib/supabase-connection.js` reads exactly `SUPABASE_DB_PASSWORD`/`EHG_DB_PASSWORD`, no `PGPASSWORD` fallback exists
- [x] Workflow YAML lint (pre-push hook `workflow-path-filter-lint`) confirms the file still parses correctly
- [x] Minimal diff: 1 line added, nothing else touched
- [ ] Re-dispatch the workflow (`workflow_dispatch`) post-merge to confirm the rehearsal connects past the password step — recommend triggering this manually after merge since it's a cron/scheduled workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)