### PR TITLE
fix(QF-20260812-281): belt-depth's recomputed gauge missing parentLeadPending gate

### DIFF
--- a/lib/fleet/belt-depth.cjs
+++ b/lib/fleet/belt-depth.cjs
@@ -19,7 +19,7 @@
  * running the classifier across every non-terminal SD, and worker Echo's /checkin returning
  * belt_ranked_claimable=8 with belt_claimable_at_my_tier=0 continuously for ~2.5h.
  */
-const { classifyDispatchIneligibility, draftDepsSatisfied } = require('./claim-eligibility.cjs');
+const { classifyDispatchIneligibility, draftDepsSatisfied, parentLeadPending } = require('./claim-eligibility.cjs');
 // The QF claimability predicate is OWNED by the coordinator's supply module. Imported, never
 // restated — see countClaimableQuickFixes below for why a local copy would be a gate failure.
 const { applyClaimableQfFilter } = require('../coordinator/qf-supply-predicate.cjs');
@@ -30,7 +30,9 @@ const { applyClaimableQfFilter } = require('../coordinator/qf-supply-predicate.c
 // `dependencies` column (metadata is already present for its metadata.* ref keys). WITHOUT this
 // column every row would look dependency-free and the dep gate would silently pass everything,
 // which is precisely the over-count this QF fixes.
-const ELIGIBILITY_COLUMNS = 'id, sd_key, sd_type, status, metadata, target_application, dependencies';
+// QF-20260812-281: + parent_sd_id — parentLeadPending(sb, row) reads row.parent_sd_id; without
+// it in the select, the check fails open on every row (looks wired, gates nothing).
+const ELIGIBILITY_COLUMNS = 'id, sd_key, sd_type, status, metadata, target_application, dependencies, parent_sd_id';
 
 // ---------------------------------------------------------------------------
 // LANE SCOPING — SD-LEO-INFRA-BOTH-BELT-GAUGES-001. REPORTING AND DIAGNOSIS ONLY.
@@ -156,8 +158,21 @@ async function countDispatchableBacklog(supabase, scope) {
     // no dependency refs, so only dep-carrying rows touch the DB.
     // throwOnError: a dep-query fault must PROPAGATE — this gauge's contract is fail-loud, and
     // silently treating an unverifiable row as dispatchable is the exact over-count being fixed.
-    if (await draftDepsSatisfied(supabase, row, { throwOnError: true })) dispatchable += 1;
-    else ineligible.dep_blocked = (ineligible.dep_blocked || 0) + 1;
+    if (!(await draftDepsSatisfied(supabase, row, { throwOnError: true }))) {
+      ineligible.dep_blocked = (ineligible.dep_blocked || 0) + 1;
+      continue;
+    }
+    // QF-20260812-281: computeClaimableLeaves (self_reported side, claimable-leaves.mjs:135-137)
+    // already applies this gate — a draft child of a not-yet-past-LEAD orchestrator parent is not
+    // dispatchable. Without it here, such a child counted as dispatchable on this (recomputed)
+    // side but not on self_reported, manufacturing a KPI-3 integrity divergence that did not
+    // reflect a real dispatch gap. Same reason string ('parent_lead_pending') evaluateDispatchEligibility
+    // already uses at :584, so the ineligible{} breakdown stays consistent across callers.
+    if (await parentLeadPending(supabase, row)) {
+      ineligible.parent_lead_pending = (ineligible.parent_lead_pending || 0) + 1;
+      continue;
+    }
+    dispatchable += 1;
   }
   return { dispatchable, raw: (rows || []).length, ineligible };
 }

--- a/tests/unit/fleet/belt-depth-parent-lead-pending.test.js
+++ b/tests/unit/fleet/belt-depth-parent-lead-pending.test.js
@@ -1,0 +1,101 @@
+/**
+ * Regression test for QF-20260812-281.
+ *
+ * countDispatchableBacklog (the "recomputed" side of KPI-3, adam-coordinator-health.mjs's
+ * computeFailLoudIntegrity) applied classifyDispatchIneligibility + draftDepsSatisfied only --
+ * it never called parentLeadPending, the check computeClaimableLeaves (the "self_reported" side,
+ * claimable-leaves.mjs:135-137) already applies. A draft child SD of a not-yet-past-LEAD
+ * orchestrator parent was therefore counted as dispatchable on this side but correctly excluded
+ * on the self_reported side, manufacturing a false integrity_ok=false KPI-3 breach every tick
+ * such a child existed -- continuously during an active orchestrator sprint.
+ *
+ * The fix also had to add parent_sd_id to ELIGIBILITY_COLUMNS: parentLeadPending(sb, row) reads
+ * row.parent_sd_id, and without it selected, the row always arrives undefined and the check
+ * fails open on every row regardless of the real parent state (looks wired, gates nothing) --
+ * the first test below would still pass a fix that added the call but not the column.
+ *
+ * Seam-injected fake client only -- no live DB.
+ */
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'module';
+const require = createRequire(import.meta.url);
+const { countDispatchableBacklog } = require('../../../lib/fleet/belt-depth.cjs');
+
+/**
+ * Extends the established belt-depth fakeClient pattern (belt-depth.test.js) with the
+ * parentLeadPending lookup shape: .from(...).select('status, current_phase').or(...).maybeSingle().
+ * Disambiguated from the dependency lookup (.select('id, sd_key, status').or(...), no
+ * .maybeSingle()) by the exact select-columns string, since both are .or() queries against the
+ * same table and this fake's .from() doesn't otherwise see the table name.
+ */
+function fakeClient(rows, { depRows = [], parentRows = {} } = {}) {
+  return {
+    from: () => ({
+      select: (cols) => ({
+        eq: () => ({
+          is: () => ({
+            range: (from, to) => Promise.resolve({ data: rows.slice(from, to + 1), error: null }),
+          }),
+        }),
+        or: (filter) => {
+          if (cols === 'status, current_phase') {
+            const ref = filter.split('.eq.')[1]?.split(',')[0];
+            const data = Object.prototype.hasOwnProperty.call(parentRows, ref) ? parentRows[ref] : null;
+            return {
+              then: (resolve) => resolve({ data, error: null }),
+              maybeSingle: () => Promise.resolve({ data, error: null }),
+            };
+          }
+          return Promise.resolve({ data: depRows, error: null });
+        },
+      }),
+    }),
+  };
+}
+
+const free = (i) => ({ id: `f${i}`, sd_key: `SD-FREE-${i}`, status: 'draft', metadata: {} });
+
+describe('countDispatchableBacklog — parentLeadPending gate (QF-20260812-281)', () => {
+  it('REGRESSION: excludes a draft child whose orchestrator parent has not passed LEAD', async () => {
+    const rows = [
+      { id: 'c1', sd_key: 'SD-CHILD-1', status: 'draft', metadata: {}, parent_sd_id: 'SD-PARENT-1' },
+      free(2),
+    ];
+    const parentRows = { 'SD-PARENT-1': { status: 'active', current_phase: 'LEAD' } };
+    const result = await countDispatchableBacklog(fakeClient(rows, { parentRows }));
+    expect(result.dispatchable).toBe(1); // only free(2); the pending-parent child is excluded
+    expect(result.raw).toBe(2);
+    expect(result.ineligible.parent_lead_pending).toBe(1);
+  });
+
+  it('counts a draft child whose orchestrator parent HAS passed LEAD', async () => {
+    const rows = [{ id: 'c1', sd_key: 'SD-CHILD-1', status: 'draft', metadata: {}, parent_sd_id: 'SD-PARENT-1' }];
+    const parentRows = { 'SD-PARENT-1': { status: 'active', current_phase: 'PLAN' } };
+    const result = await countDispatchableBacklog(fakeClient(rows, { parentRows }));
+    expect(result.dispatchable).toBe(1);
+    expect(result.ineligible).toEqual({});
+  });
+
+  it('counts a draft child whose orchestrator parent has COMPLETED', async () => {
+    const rows = [{ id: 'c1', sd_key: 'SD-CHILD-1', status: 'draft', metadata: {}, parent_sd_id: 'SD-PARENT-1' }];
+    const parentRows = { 'SD-PARENT-1': { status: 'completed', current_phase: 'LEAD_FINAL_APPROVAL' } };
+    const result = await countDispatchableBacklog(fakeClient(rows, { parentRows }));
+    expect(result.dispatchable).toBe(1);
+    expect(result.ineligible).toEqual({});
+  });
+
+  it('a non-child row (no parent_sd_id) is unaffected by the new gate', async () => {
+    const result = await countDispatchableBacklog(fakeClient([free(1)]));
+    expect(result.dispatchable).toBe(1);
+    expect(result.ineligible).toEqual({});
+  });
+
+  it('fails OPEN (still counts dispatchable) when the parent row cannot be resolved', async () => {
+    // Mirrors parentLeadPending's own fail-open contract: an unresolvable/absent parent must
+    // never strand the child.
+    const rows = [{ id: 'c1', sd_key: 'SD-CHILD-1', status: 'draft', metadata: {}, parent_sd_id: 'SD-GONE' }];
+    const result = await countDispatchableBacklog(fakeClient(rows, { parentRows: {} }));
+    expect(result.dispatchable).toBe(1);
+    expect(result.ineligible).toEqual({});
+  });
+});


### PR DESCRIPTION
## Summary
- `countDispatchableBacklog` (KPI-3's "recomputed" side) applied `classifyDispatchIneligibility` + `draftDepsSatisfied` only — it never called `parentLeadPending`, the check `computeClaimableLeaves` (the "self_reported" side, `claimable-leaves.mjs:135-137`) already applies
- A draft child SD of a not-yet-past-LEAD orchestrator parent was therefore counted as dispatchable on this side but correctly excluded on `self_reported`, manufacturing a false `integrity_ok=false` KPI-3 breach every tick such a child existed — continuously during an active orchestrator sprint
- Also added `parent_sd_id` to `ELIGIBILITY_COLUMNS`: `parentLeadPending(sb, row)` reads `row.parent_sd_id`, and without it selected the check fails open on every row regardless of the real parent state (looks wired, gates nothing) — verified this would be a silent no-op before adding the column
- Reuses the existing exported `parentLeadPending` from `claim-eligibility.cjs` (already imported by sibling gates in this file) and the same `'parent_lead_pending'` reason string `evaluateDispatchEligibility` already emits, keeping the `ineligible{}` breakdown's vocabulary consistent

## Test plan
- [x] New regression suite `tests/unit/fleet/belt-depth-parent-lead-pending.test.js` (5 tests): excludes a pending-parent child, counts a past-LEAD-parent child, counts a completed-parent child, leaves non-child rows unaffected, fails open on an unresolvable parent (mirrors `parentLeadPending`'s own fail-open contract)
- [x] Full `tests/unit/fleet/` suite: 158/158 files passing, 1966/1967 tests (1 pre-existing skip), no regressions
- [x] `belt-gauge-contract-freeze` / `belt-gauge-lane-scope` governance tests: still passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)