### PR TITLE
fix(QF-20260812-187): self-heal is_alive on every successful heartbeat tick

### DIFF
--- a/lib/heartbeat-manager.mjs
+++ b/lib/heartbeat-manager.mjs
@@ -343,6 +343,12 @@ async function sendHeartbeat() {
       consecutiveFailures = 0;
       lastSuccessfulHeartbeat = new Date();
 
+      // QF-20260812-187: is_alive is otherwise written once at startHeartbeat() and never
+      // reasserted — a failed/raced initial write leaves it stuck false for the session's whole
+      // lifetime despite a continuously ticking heartbeat. A successful tick IS the liveness
+      // proof, so reassert it here to self-heal that state within one interval.
+      setIsAlive(currentSessionId, true);
+
       // SD-LEO-INFRA-INTELLIGENT-CLAIM-HEALTH-001: Run self-heal on every successful heartbeat
       // SD-LEO-INFRA-FLEET-COORDINATION-RESILIENCE-001 (FR-004): Added timeout safeguard and failure logging
       const SELF_HEAL_TIMEOUT_MS = parseInt(process.env.SELF_HEAL_TIMEOUT_MS, 10) || 2000;

--- a/tests/unit/heartbeat-manager-is-alive-self-heal.test.js
+++ b/tests/unit/heartbeat-manager-is-alive-self-heal.test.js
@@ -1,0 +1,117 @@
+/**
+ * tests/unit/heartbeat-manager-is-alive-self-heal.test.js
+ *
+ * QF-20260812-187: claude_sessions.is_alive was written exactly ONCE at
+ * startHeartbeat() (true) and once at stopHeartbeat() (false) — never
+ * reasserted by the 30s recurring heartbeat tick (session-manager.mjs's
+ * updateHeartbeat only touches heartbeat_at/branch/telemetry fields, never
+ * is_alive). Measured live: a coordinator session with a fresh, ticking
+ * last_tool_at sat at is_alive=false for its whole lifetime — the one write
+ * at start must have failed or raced, and nothing downstream ever corrected
+ * it. Fix: reassert is_alive=true on every SUCCESSFUL tick in sendHeartbeat()
+ * (lib/heartbeat-manager.mjs), so a genuinely-alive session self-heals a
+ * stuck-false flag within one interval instead of carrying it forever.
+ *
+ * Test strategy: sendHeartbeat()/setIsAlive() are private (not exported),
+ * and hbSupabase is module-level singleton state set from lazyServiceClient()
+ * at import time — so the only way to unit-test this is the mocking pattern
+ * already established in heartbeat-manager-ownership-mode.test.js (mock
+ * lib/supabase-client.js, lib/session-manager.mjs, and the self-heal module,
+ * then drive the REAL module through its exported surface). forceHeartbeat()
+ * is the exported entry point that calls sendHeartbeat() directly, giving a
+ * deterministic single-tick trigger instead of racing the real 30s interval.
+ * startHeartbeat() ALSO writes is_alive=true once, synchronously, before this
+ * fix's code ever runs — so every test clears the spy AFTER start and before
+ * asserting, isolating the tick's own write from the pre-existing start-time
+ * write it must not be confused with.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+let updateSpy;
+let lastUpdatePayload;
+
+vi.mock('../../lib/supabase-client.js', () => {
+  const stubClient = {
+    from: () => ({
+      update: (payload) => {
+        lastUpdatePayload = payload;
+        updateSpy(payload);
+        return { eq: () => Promise.resolve({ error: null }) };
+      },
+    }),
+  };
+  return {
+    createSupabaseServiceClient: () => stubClient,
+    lazyServiceClient: () => stubClient,
+  };
+});
+
+vi.mock('../../lib/session-manager.mjs', () => ({
+  updateHeartbeat: vi.fn(() => Promise.resolve({ success: true })),
+  endSession: vi.fn(() => Promise.resolve({ success: true })),
+}));
+
+vi.mock('../../scripts/modules/claim-health/self-heal.js', () => ({
+  selfHeal: vi.fn(() => Promise.resolve({ released: [], errors: [] })),
+}));
+
+const { startHeartbeat, stopHeartbeat, forceHeartbeat, isHeartbeatActive } =
+  await import('../../lib/heartbeat-manager.mjs');
+
+async function flush() {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
+describe('heartbeat-manager is_alive self-heal (QF-20260812-187)', () => {
+  beforeEach(() => {
+    updateSpy = vi.fn();
+    lastUpdatePayload = null;
+  });
+
+  afterEach(() => {
+    if (isHeartbeatActive().active) stopHeartbeat();
+  });
+
+  it('reasserts is_alive=true on an ordinary successful tick, not just at start', async () => {
+    startHeartbeat('sess-tick-heal');
+    await flush(); // settle start()'s own explicit setIsAlive + fire-and-forget sendHeartbeat()
+    updateSpy.mockClear();
+
+    await forceHeartbeat();
+    await flush();
+
+    expect(updateSpy).toHaveBeenCalled();
+    expect(lastUpdatePayload).toMatchObject({ is_alive: true });
+  });
+
+  it('reasserts is_alive on EVERY successful tick, not only the first', async () => {
+    startHeartbeat('sess-tick-heal-2');
+    await flush();
+    updateSpy.mockClear();
+
+    await forceHeartbeat();
+    await flush();
+    const firstTickCalls = updateSpy.mock.calls.length;
+    expect(firstTickCalls).toBeGreaterThan(0);
+
+    await forceHeartbeat();
+    await flush();
+    expect(updateSpy.mock.calls.length).toBeGreaterThan(firstTickCalls);
+  });
+
+  it('does NOT reassert is_alive when the tick fails (no proof of liveness)', async () => {
+    startHeartbeat('sess-tick-fail');
+    await flush(); // settle start's own successful tick before arming the failure below
+    updateSpy.mockClear();
+
+    const { updateHeartbeat } = await import('../../lib/session-manager.mjs');
+    updateHeartbeat.mockResolvedValueOnce({ success: false });
+
+    await forceHeartbeat();
+    await flush();
+
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- `claude_sessions.is_alive` was written exactly once at `startHeartbeat()` (true) and once at `stopHeartbeat()` (false); the recurring 30s `sendHeartbeat()` tick never re-touched it, so a failed/raced initial write left it stuck false for a session's entire lifetime despite a continuously fresh heartbeat — measured live on a coordinator session with a seconds-fresh `last_tool_at` reading `is_alive=false` at every consecutive check.
- Reassert `is_alive: true` in `sendHeartbeat()`'s success branch, so a genuinely-alive session self-heals within one interval (~30s) instead of carrying the stuck flag forever.
- The reverse direction (dead session, `is_alive` stuck true after a hard crash) is deliberately left untouched: `lib/fleet/session-liveness.cjs`'s `isSessionAlive()` SSOT and `lib/claim-validity-gate.js`'s `ownerIsDeadByLiveness()` both intentionally never downgrade a raw-alive session (SD-LEO-INFRA-IS-ALIVE-LIVENESS-SSOT-001 / SD-LEO-INFRA-CLAIM-VALIDITY-ISALIVE-LAG-001) — reversing that would reopen the false-dead claim-reaping incidents those SDs were built to prevent. Every consequential consumer I audited (fleet-dashboard.cjs, worker-checkin.cjs, fleet-rollcall.cjs, dispatch.cjs) already cross-checks staleness independently rather than trusting raw `is_alive=true`, so that direction isn't load-bearing anywhere.

## Test plan
- [x] New regression suite `tests/unit/heartbeat-manager-is-alive-self-heal.test.js` (3 tests): reasserts on an ordinary tick, reasserts on every tick (not just the first), does NOT reassert when the tick itself fails.
- [x] Verified the fix is load-bearing: reverted `lib/heartbeat-manager.mjs` via `git stash` and confirmed the 2 positive tests fail without it, then restored.
- [x] Full `heartbeat-manager-*` suite (43 tests) passes with no regressions.
- [x] Broader liveness-consumer suite (`fleet/claim-release-guard`, `fleet/session-liveness`, `fleet/liveness-input-parity`, `fleet/pid-liveness-parent-acceptance`, `fleet/liveness-abandon-ceiling`, `fleet/liveness-abstention-is-not-death`, `fleet/view-backed-liveness-parity`, `coordinator/fleet-dashboard-palive-liveness`, 65 tests) passes with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)