### PR TITLE
fix(QF-20260812-090): add sms-relay-drain.cjs to RCA tick-exemption allowlist

### DIFF
--- a/scripts/hooks/recurring-tick-exemptions.json
+++ b/scripts/hooks/recurring-tick-exemptions.json
@@ -19,6 +19,10 @@
     {
       "script": "adam-startup-check.mjs",
       "reason": "Adam startup probe re-run on session/loop restarts — parity with the builtin-exempt coordinator-startup-check.mjs"
+    },
+    {
+      "script": "sms-relay-drain.cjs",
+      "reason": "Coordinator */5 cadence duty (STANDARD_LOOPS, QF-20260727-064), idempotent fail-soft exit-0 — hard-blocks at the 3rd invocation within its own 10-min schedule (QF-20260812-090). CAVEAT (recorded per this file's own tradeoff doc-comment, not silently assumed safe): this script never calls stampLastFired, so its periodic_process_registry row never leaves UNVERIFIED and the periodic-liveness watcher lane this file's doc-comment names as the compensating control does NOT actually cover it yet — exemption removes the only loop-detection net this script currently has. Follow-up: wire stampLastFired into sms-relay-drain.cjs to close that gap."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- `sms-relay-drain.cjs` is a `*/5`-scheduled coordinator cadence duty (STANDARD_LOOPS, QF-20260727-064), idempotent and fail-soft, but was the only one of 32 STANDARD_LOOPS entries missing from `scripts/hooks/recurring-tick-exemptions.json` — the RCA-tiered-enforcement allowlist for the "Bash invoked 3x on the same target within 10 minutes" guard.
- Repeatedly self-blocked coordinator cadence execution this session (confirmed via RCA agent investigation earlier this window). Root cause: two independently-maintained registries (`STANDARD_LOOPS` vs the exemption allowlist) with zero coupling.
- Adds the missing entry with a reason field that records a real compensating-control gap per the file's own tradeoff doc-comment: this script doesn't call `stampLastFired`, so the periodic-liveness watcher lane doesn't actually cover it yet. Follow-up flagged, not silently assumed safe.

## Test plan
- [x] `npx vitest run scripts/hooks/__tests__/retry-state-tick-exemptions-config.test.js` — 7/7 passed
- [x] JSON validated (`JSON.parse`)
- [x] Pre-commit hooks passed (LOC threshold, scope gate, smoke tests, secret scan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)