### PR TITLE
fix(QF-20260811-495): derive is_simulation from venture launch_mode, not a hardcoded literal

### DIFF
--- a/lib/eva/utils/token-tracker.js
+++ b/lib/eva/utils/token-tracker.js
@@ -8,6 +8,7 @@
  */
 
 import { randomUUID } from 'crypto';
+import { getLaunchModeStrict, SIMULATED } from '../launch-mode.js';
 
 const BUDGET_CHECK_TIMEOUT_MS = 2000;
 const BUDGET_CACHE_TTL_MS = 60_000;
@@ -55,40 +56,47 @@ export function recordTokenUsage({ ventureId, stageId, usage, metadata = {} }, d
     logger.warn('[TokenTracker] Missing usage data — recording zeros');
   }
 
-  const row = {
-    id: randomUUID(),
-    venture_id: ventureId,
-    lifecycle_stage: stageId,
-    tokens_input: inputTokens,
-    tokens_output: outputTokens,
-    agent_type: metadata.agentType || null,
-    model_id: metadata.modelId || null,
-    operation_type: metadata.operationType || null,
-    budget_profile: metadata.budgetProfile || 'standard',
-    is_simulation: false,
-    metadata: {
-      step_id: metadata.stepId || null,
-      attempt: metadata.attempt || 1,
-      recorded_by: 'eva-token-tracker',
-    },
-    created_at: new Date().toISOString(),
-    created_by: 'eva-orchestrator',
-  };
-
-  // Fire-and-forget: do not await
-  supabase
-    .from('venture_token_ledger')
-    .insert(row)
-    .then(({ error }) => {
-      if (error) {
-        logger.warn(`[TokenTracker] Insert failed (non-fatal): ${error.message}`);
+  // Fire-and-forget: do not await. QF-20260811-495: is_simulation must derive from
+  // the venture's launch_mode, not a hardcoded literal — a hardcoded false mislabels
+  // every simulated-run row as real spend, inflating get_venture_token_budget_status.
+  // getLaunchModeStrict (not the fail-open-to-simulated getLaunchMode, which is only
+  // safe for harmless display consumers) lets a degraded read fail CLOSED to false —
+  // preserving the old literal's accidentally-safe behavior for real builds (Solomon
+  // R4) instead of flipping to the opposite hazard of hiding real spend as simulated.
+  getLaunchModeStrict(supabase, ventureId)
+    .then(({ mode, ok }) => {
+      const row = {
+        id: randomUUID(),
+        venture_id: ventureId,
+        lifecycle_stage: stageId,
+        tokens_input: inputTokens,
+        tokens_output: outputTokens,
+        agent_type: metadata.agentType || null,
+        model_id: metadata.modelId || null,
+        operation_type: metadata.operationType || null,
+        budget_profile: metadata.budgetProfile || 'standard',
+        is_simulation: ok && mode === SIMULATED,
+        metadata: {
+          step_id: metadata.stepId || null,
+          attempt: metadata.attempt || 1,
+          recorded_by: 'eva-token-tracker',
+        },
+        created_at: new Date().toISOString(),
+        created_by: 'eva-orchestrator',
+      };
+      return supabase.from('venture_token_ledger').insert(row);
+    })
+    .then((result) => {
+      if (result?.error) {
+        logger.warn(`[TokenTracker] Insert failed (non-fatal): ${result.error.message}`);
       }
     })
     .catch((err) => {
       logger.warn(`[TokenTracker] Insert error (non-fatal): ${err.message}`);
     });
 
-  // Invalidate budget cache for this venture since usage changed
+  // Invalidate budget cache for this venture since usage changed — synchronous,
+  // independent of the async mode read above.
   budgetCache.delete(ventureId);
 }
 

--- a/tests/unit/eva/token-tracker-is-simulation.test.js
+++ b/tests/unit/eva/token-tracker-is-simulation.test.js
@@ -1,0 +1,112 @@
+/**
+ * QF-20260811-495: token-tracker hardcoded is_simulation:false for every
+ * venture_token_ledger row, regardless of the venture's actual launch_mode.
+ *
+ * Measured 2026-08-11 (venture 50763b6a): 6721 simulation-era rows / 20.2M
+ * tokens recorded as REAL spend, driving get_venture_token_budget_status to
+ * 4043% and re-blocking the stage worker with budget_exceeded REQUIRE_REVIEW
+ * after every stage — the first-revenue factory stalled at s9 on phantom
+ * spend. Solomon R4: the hardcoded false was ACCIDENTALLY CORRECT during a
+ * real build (safety-by-coincidence) but wrong for every simulated run.
+ *
+ * Test strategy: recordTokenUsage() is fire-and-forget (never awaited by
+ * callers), and its is_simulation derivation now goes through an async
+ * getLaunchModeStrict() read before the insert — so every test gives the
+ * fire-and-forget chain a tick to settle before asserting on the inserted
+ * row, matching the pattern already established in token-tracker.test.js.
+ * The fake client disambiguates the two distinct query shapes this function
+ * now issues (a 'ventures' launch_mode lookup, then a 'venture_token_ledger'
+ * insert) by table name, since a single generic mock can't route both.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { recordTokenUsage } from '../../../lib/eva/utils/token-tracker.js';
+
+function makeFakeSupabase({ launchMode, launchModeError = null } = {}) {
+  const insert = vi.fn().mockResolvedValue({ error: null });
+  const from = vi.fn((table) => {
+    if (table === 'ventures') {
+      return {
+        select: () => ({
+          eq: () => ({
+            maybeSingle: () =>
+              launchModeError
+                ? Promise.resolve({ data: null, error: launchModeError })
+                : Promise.resolve({ data: { id: 'v-123', launch_mode: launchMode }, error: null }),
+          }),
+        }),
+      };
+    }
+    if (table === 'venture_token_ledger') {
+      return { insert };
+    }
+    throw new Error(`unexpected table: ${table}`);
+  });
+  return { client: { from }, insert };
+}
+
+async function settle() {
+  await new Promise((r) => setTimeout(r, 10));
+}
+
+describe('recordTokenUsage is_simulation derivation (QF-20260811-495)', () => {
+  it('lands is_simulation=TRUE for a write during launch_mode=simulated', async () => {
+    const { client, insert } = makeFakeSupabase({ launchMode: 'simulated' });
+
+    recordTokenUsage(
+      { ventureId: 'v-123', stageId: 5, usage: { inputTokens: 10, outputTokens: 5 } },
+      { supabase: client, logger: { warn: vi.fn() } }
+    );
+    await settle();
+
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({ is_simulation: true }));
+  });
+
+  it('lands is_simulation=FALSE for a write during launch_mode=live', async () => {
+    const { client, insert } = makeFakeSupabase({ launchMode: 'live' });
+
+    recordTokenUsage(
+      { ventureId: 'v-123', stageId: 5, usage: { inputTokens: 10, outputTokens: 5 } },
+      { supabase: client, logger: { warn: vi.fn() } }
+    );
+    await settle();
+
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({ is_simulation: false }));
+  });
+
+  it('fails CLOSED to is_simulation=FALSE when the launch_mode read errors (Solomon R4 safety)', async () => {
+    const { client, insert } = makeFakeSupabase({ launchModeError: { message: 'read failed' } });
+
+    recordTokenUsage(
+      { ventureId: 'v-123', stageId: 5, usage: { inputTokens: 10, outputTokens: 5 } },
+      { supabase: client, logger: { warn: vi.fn() } }
+    );
+    await settle();
+
+    expect(insert).toHaveBeenCalledWith(expect.objectContaining({ is_simulation: false }));
+  });
+
+  it('REGRESSION CONTROL: is_simulation genuinely derives from the mode input, not a re-hardcoded literal', async () => {
+    // Same call shape, two different modes — a hardcoded literal would produce
+    // an identical is_simulation value both times. This fails if it's ever
+    // reintroduced (the exact defect this QF fixes).
+    const simRun = makeFakeSupabase({ launchMode: 'simulated' });
+    const liveRun = makeFakeSupabase({ launchMode: 'live' });
+
+    recordTokenUsage(
+      { ventureId: 'v-123', stageId: 9, usage: { inputTokens: 1, outputTokens: 1 } },
+      { supabase: simRun.client, logger: { warn: vi.fn() } }
+    );
+    recordTokenUsage(
+      { ventureId: 'v-123', stageId: 9, usage: { inputTokens: 1, outputTokens: 1 } },
+      { supabase: liveRun.client, logger: { warn: vi.fn() } }
+    );
+    await settle();
+
+    const simValue = simRun.insert.mock.calls[0][0].is_simulation;
+    const liveValue = liveRun.insert.mock.calls[0][0].is_simulation;
+    expect(simValue).not.toBe(liveValue);
+    expect(simValue).toBe(true);
+    expect(liveValue).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- `recordTokenUsage()` in `lib/eva/utils/token-tracker.js` wrote `is_simulation: false` for every `venture_token_ledger` row as a literal, regardless of the venture's actual `launch_mode`. Measured 2026-08-11 (venture `50763b6a`): 6721 simulation-era rows / 20.2M tokens recorded as REAL spend, driving `get_venture_token_budget_status` to 4043% and re-blocking the stage worker with `budget_exceeded REQUIRE_REVIEW` after every stage — the first-revenue factory stalled at s9 on phantom spend.
- Solomon R4: the hardcoded `false` was *accidentally correct* during a real build (safety-by-coincidence) but wrong for every simulated run — this QF is the only durable stop, since every future simulated run otherwise re-accumulates mislabeled `false` rows from a 0 base.
- Fix: read the venture's `launch_mode` via the existing canonical `getLaunchModeStrict()` helper (`lib/eva/launch-mode.js`) before each insert, deliberately using the *strict* (not fail-open-to-simulated) variant so a degraded read fails CLOSED to `is_simulation: false` — preserving the old literal's accidentally-safe behavior for real builds instead of trading one mislabeling hazard for its opposite (hiding real spend as simulated).
- `budgetCache` invalidation stays synchronous, independent of the new async mode read (neither depends on the other; a prior test depends on this timing).

## Test plan
- [x] New regression suite `tests/unit/eva/token-tracker-is-simulation.test.js` (4 tests): `is_simulation=true` during `launch_mode=simulated`, `is_simulation=false` during `launch_mode=live`, fails closed to `false` when the mode read errors, and a regression control proving the value genuinely derives from the mode input rather than a re-hardcoded literal.
- [x] Verified the fix is load-bearing: reverted `token-tracker.js` via `git stash`, confirmed 2 of the 4 new tests fail without it (the exact defect this QF fixes), then restored.
- [x] Existing `tests/unit/eva/token-tracker.test.js` (17 tests) + `tests/unit/eva/launch-mode.test.js` pass with no regressions — 30 tests total.
- [x] Other `recordTokenUsage` callers' test suites (`apa/standing-assessment-round`, `marketing/owned-audience-content-loop`) pass unaffected — 16 tests, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)