### PR TITLE
fix(QF-20260811-526): a no-correlation advisory can now be acked via --reply

### DIFF
--- a/scripts/coordinator-ack-adam.cjs
+++ b/scripts/coordinator-ack-adam.cjs
@@ -354,8 +354,18 @@ async function deliverReplyOrExit(supabase, { adv, replyBody, coordinatorSession
     }
   }
 
+  // QF-20260811-526: a missing correlation_id means THIS advisory can't carry a reply — it does NOT
+  // mean the row must stay unactioned. Exiting here (as this used to) skipped Stage 2 entirely,
+  // leaving a no-correlation advisory pending forever via the --reply path (worker signal a6067eb7;
+  // QF-20260728-468's filer measured three coordinator-health probes hit this). Fall through instead:
+  // main() proceeds to Stage 2 and reports the reply as skipped rather than sent. console.warn (not
+  // .error) deliberately — this is not a fatal branch, so it stays outside the 1:1
+  // fatal-console.error/process.exit pairing the reply-ordering test asserts on the rest of this fn.
   const correlationId = adv.payload && adv.payload.correlation_id;
-  if (!correlationId) { console.error('ERROR: advisory carries no payload.correlation_id (not replyable).'); process.exit(1); }
+  if (!correlationId) {
+    console.warn('  ⚠ --reply skipped: advisory carries no payload.correlation_id (not replyable) — proceeding to ack.');
+    return { skipped: true, reason: 'no_correlation_id' };
+  }
 
   // FR-1: target the CURRENT live Adam, never a stale originating session.
   const { target: adamSession, retargeted } = await resolveAdamReplyTarget(supabase, originator);
@@ -475,15 +485,19 @@ async function main() {
       process.exit(0);
     }
     // The send + delivery verification already happened above, BEFORE the advisory was retired.
-    console.log('✓ Coordinator reply sent to Adam (delivery verified)');
-    console.log('  reply_id:', replyOutcome.replyId);
-    console.log('  to_adam:', replyOutcome.adamSession);
-    console.log('  reply_to:', replyOutcome.correlationId);
+    if (replyOutcome && replyOutcome.skipped) {
+      console.log(`NOTE: --reply skipped (${replyOutcome.reason}) — advisory was still actioned.`);
+    } else {
+      console.log('✓ Coordinator reply sent to Adam (delivery verified)');
+      console.log('  reply_id:', replyOutcome.replyId);
+      console.log('  to_adam:', replyOutcome.adamSession);
+      console.log('  reply_to:', replyOutcome.correlationId);
+    }
   }
 }
 
 module.exports = {
-  isMatchableRef, parseArgs, recordLedgerDecision, inheritTailDecisions, VALID_DISPOSITIONS, resolveOutcomeRef, isNoArtifactRef, NO_ARTIFACT_MARKER, LINKAGE_REQUIRED_DISPOSITIONS };
+  isMatchableRef, parseArgs, recordLedgerDecision, inheritTailDecisions, VALID_DISPOSITIONS, resolveOutcomeRef, isNoArtifactRef, NO_ARTIFACT_MARKER, LINKAGE_REQUIRED_DISPOSITIONS, deliverReplyOrExit };
 
 if (require.main === module) {
   main().catch(err => { console.error('UNHANDLED:', err.message || err); process.exit(1); });

--- a/tests/unit/coordinator-ack-adam-no-correlation-skip.test.js
+++ b/tests/unit/coordinator-ack-adam-no-correlation-skip.test.js
@@ -1,0 +1,85 @@
+/**
+ * QF-20260811-526 — a no-correlation advisory must never stay pending forever via --reply.
+ *
+ * deliverReplyOrExit used to process.exit(1) when the advisory carried no
+ * payload.correlation_id, and that exit happened BEFORE main() reached Stage 2
+ * (stampActionedGroup) — so a --reply attempt against a non-replyable advisory
+ * silently left it unactioned forever. Worker signal a6067eb7 (sender c14a87ec)
+ * measured three coordinator-health probes hitting exactly this, deliberately
+ * excluded from the single-purpose QF-20260728-468/PR #6977.
+ *
+ * Fix: correlationId-missing now WARNS and returns { skipped: true, reason }
+ * instead of exiting, so main() falls through to Stage 2 regardless.
+ *
+ * Test strategy: deliverReplyOrExit's correlationId-missing branch returns
+ * before touching supabase at all (it's checked before resolveAdamReplyTarget/
+ * sendCoordinatorReply), so it's directly callable with a minimal fake advisory
+ * and no live DB — no need for the source-text-inspection style the sibling
+ * suite (coordinator-ack-adam-reply-ordering.test.js) uses for paths that
+ * genuinely require a live coordinator/Adam session. The "Stage 2 still runs"
+ * half of the contract IS asserted via source order there — this file adds the
+ * direct behavioral proof for the specific branch this QF changes.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+
+const require_ = createRequire(import.meta.url);
+const { deliverReplyOrExit } = require_('../../scripts/coordinator-ack-adam.cjs');
+
+describe('deliverReplyOrExit: no payload.correlation_id (QF-20260811-526)', () => {
+  it('returns { skipped: true } instead of exiting the process', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit should NOT be called for a missing correlation_id');
+    });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const adv = { id: 'adv-1', sender_session: null, payload: {} };
+    const result = await deliverReplyOrExit(
+      /* supabase */ {},
+      { adv, replyBody: 'some reply body', coordinatorSession: 'coord-session-1' }
+    );
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ skipped: true, reason: 'no_correlation_id' });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('correlation_id'));
+
+    exitSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it('also skips (not exits) when payload is entirely absent', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit should NOT be called');
+    });
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const adv = { id: 'adv-2', sender_session: 'adam-coordinator-health-cron', payload: null };
+    const result = await deliverReplyOrExit(
+      {},
+      { adv, replyBody: 'body', coordinatorSession: 'coord-session-1' }
+    );
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ skipped: true, reason: 'no_correlation_id' });
+
+    exitSpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it('REGRESSION CONTROL: still exits (never silently skips) when --reply has no body at all', async () => {
+    // Distinguishes "nothing to reply to" (this QF's fix) from "caller misused --reply"
+    // (unchanged, still fatal) — the two must not collapse into the same non-fatal path.
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code) => {
+      throw new Error(`EXIT:${code}`);
+    });
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const adv = { id: 'adv-3', sender_session: null, payload: { correlation_id: 'corr-1' } };
+    await expect(
+      deliverReplyOrExit({}, { adv, replyBody: '', coordinatorSession: 'coord-session-1' })
+    ).rejects.toThrow('EXIT:2');
+
+    vi.restoreAllMocks();
+  });
+});


### PR DESCRIPTION
## Summary
- `deliverReplyOrExit` in `scripts/coordinator-ack-adam.cjs` `process.exit(1)`'d when an advisory carried no `payload.correlation_id` (not repliable), and that exit happened BEFORE `main()` reached Stage 2 (`stampActionedGroup`) — so a `--reply` attempt against a non-replyable advisory silently left it pending forever.
- Worker signal `a6067eb7` (sender `c14a87ec`) measured three coordinator-health probes hitting exactly this; `QF-20260728-468`'s filer deliberately excluded the fix from that single-purpose PR (#6977).
- Fix: missing `correlation_id` now warns and returns `{ skipped: true, reason: 'no_correlation_id' }` instead of exiting, so `main()` falls through to Stage 2 and reports the reply as skipped rather than sent.
- Every other exit-before-Stage-2 branch in `deliverReplyOrExit` is untouched — those protect an in-flight reply body from being silently dropped (`QF-20260727-380`'s DELIVER-BEFORE-RETIRING principle), which doesn't apply here since there's no reply in flight to protect when the advisory was never repliable to begin with.

## Test plan
- [x] New regression suite `tests/unit/coordinator-ack-adam-no-correlation-skip.test.js` (3 tests, exporting `deliverReplyOrExit` for direct testing): returns `{skipped:true}` without exiting on a missing `correlation_id`, same for an entirely-absent `payload`, and a regression control confirming an unrelated fatal branch (`--reply` with no body) still exits as before — proving the two cases don't collapse into the same non-fatal path.
- [x] Verified the fix is load-bearing: reverted via `git stash`, confirmed all 3 new tests fail without it, then restored.
- [x] All 3 existing `coordinator-ack-adam-*` test suites (32 tests, including one that asserts a strict 1:1 fatal-`console.error`/`process.exit` pairing across this exact function) pass unmodified — the fix deliberately uses `console.warn` instead of `console.error` for the new skip path so it doesn't perturb that invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)