### PR TITLE
fix(QF-20260812-752): relay-drop-gauge recognizes worker-signal replies to review requests

### DIFF
--- a/lib/coordinator/relay-drop-gauge.cjs
+++ b/lib/coordinator/relay-drop-gauge.cjs
@@ -91,6 +91,24 @@ function satisfiesCorrelation(row) {
 }
 
 /**
+ * QF-20260812-752: the documented reply convention for a review_request/decision_request
+ * is "/signal feedback", which writes a worker_signal row (payload.signal_type='feedback')
+ * referencing the original only by an 8-char id prefix in free-text payload.body (e.g.
+ * "req cb5587b3") — it never populates payload.kind=relay_confirm or reply_to/in_reply_to,
+ * so satisfiesCorrelation() above can never match it. Checked against the SAME 8-char
+ * truncation the reply convention itself uses — a full-id substring check would just be a
+ * stricter version of the same match, since the convention only ever emits the short form.
+ * @param {object} row - a candidate outbound row
+ * @param {string} correlationId - a tracked inbound row's correlation id
+ * @returns {boolean}
+ */
+function satisfiesByBodyPrefix(row, correlationId) {
+  if (typeof correlationId !== 'string' || correlationId.length < 8) return false;
+  const body = row && row.payload && typeof row.payload.body === 'string' ? row.payload.body : '';
+  return body.length > 0 && body.includes(correlationId.slice(0, 8));
+}
+
+/**
  * CORE — pure, dependency-injected correlation decision. Given inbound rows (candidate
  * relay/decision/review requests) and outbound rows (candidate confirms/replies), flags
  * any inbound row aged past the window with NO matching outbound. Zero IO.
@@ -105,8 +123,9 @@ function decideRelayDrops(inboundRows, outboundRows, opts = {}) {
   const now = Number.isFinite(opts.now) ? opts.now : Date.now();
   const windowMs = Number.isFinite(opts.windowMs) ? opts.windowMs : DEFAULT_WINDOW_MS;
 
+  const outbound = outboundRows || [];
   const satisfiedCorrelations = new Set(
-    (outboundRows || [])
+    outbound
       .map(satisfiesCorrelation)
       .filter(Boolean)
   );
@@ -118,7 +137,8 @@ function decideRelayDrops(inboundRows, outboundRows, opts = {}) {
     const correlationId = correlationOf(row);
     const ageMs = now - tsMs(row.created_at);
 
-    if (correlationId && satisfiedCorrelations.has(correlationId)) {
+    if (correlationId && (satisfiedCorrelations.has(correlationId)
+      || outbound.some((o) => satisfiesByBodyPrefix(o, correlationId)))) {
       out.push({ action: 'ok', id, correlationId, ageMs, reason: 'matching outbound found' });
       continue;
     }
@@ -154,10 +174,9 @@ async function loadInboundCandidates(supabase, opts = {}) {
 }
 
 /**
- * IO: load candidate outbound rows (relay_confirm rows, in the same lookback window).
- * FAIL-SOFT: [] on error. Reply-kind rows (decision/review replies) are not payload.kind
- * scoped in this codebase — callers that also want those should pass them in via the
- * pure core directly rather than relying on this loader alone.
+ * IO: load candidate outbound rows (relay_confirm rows, PLUS feedback-typed worker_signal
+ * rows — QF-20260812-752, the documented "/signal feedback" reply convention — in the same
+ * lookback window). FAIL-SOFT: [] on error.
  */
 async function loadOutboundCandidates(supabase, opts = {}) {
   const { windowLookbackMs = 24 * 60 * 60 * 1000, now = Date.now() } = opts;
@@ -166,7 +185,7 @@ async function loadOutboundCandidates(supabase, opts = {}) {
     const { data } = await supabase
       .from('session_coordination')
       .select('id, payload, created_at')
-      .eq('payload->>kind', PAYLOAD_KINDS.RELAY_CONFIRM)
+      .or(`payload->>kind.eq.${PAYLOAD_KINDS.RELAY_CONFIRM},payload->>signal_type.eq.feedback`)
       .gte('created_at', since)
       .limit(200);
     return data || [];
@@ -209,6 +228,7 @@ module.exports = {
   isTrackedInbound,
   correlationOf,
   satisfiesCorrelation,
+  satisfiesByBodyPrefix,
   gaugeEnabled,
   resolveWindowMs,
   loadInboundCandidates,

--- a/tests/unit/coordinator/relay-drop-gauge-worker-signal-reply.test.js
+++ b/tests/unit/coordinator/relay-drop-gauge-worker-signal-reply.test.js
@@ -1,0 +1,125 @@
+/**
+ * QF-20260812-752 — relay-drop-gauge never recognized a worker-signal-shaped reply to a
+ * review_request/decision_request, guaranteeing a false positive for EVERY review answered
+ * via the documented reply convention.
+ *
+ * The coordinator's own periodic bidirectional-review-request mechanism instructs the
+ * recipient to reply via "/signal feedback", which writes a session_coordination row shaped
+ * like { payload: { signal_type: 'feedback', body: '...req <8-char-prefix>...' } } — it never
+ * populates payload.kind=relay_confirm or reply_to/in_reply_to, so the pre-fix
+ * satisfiesCorrelation() unconditionally returned null for it. Verified live 2026-08-12:
+ * Adam replied substantively to review-request cb5587b3/324acaff within 14 minutes (row
+ * 264a931f), yet the gauge flagged it as dropped and kept re-flagging it for 45+ minutes,
+ * since the reply's shape could never satisfy the matcher — a 100% guaranteed miss for this
+ * class of reply, not occasional flakiness.
+ *
+ * Test strategy: decideRelayDrops() is the pure, dependency-injected core (no IO), so the
+ * worker-signal-shaped reply's exact real-world payload shape can be constructed directly —
+ * no need to mock loadOutboundCandidates' DB query (covered separately below by a source-text
+ * assertion that the widened .or() filter is actually wired, since the pure core alone can't
+ * prove the row would ever have been FETCHED in production).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import {
+  decideRelayDrops,
+  satisfiesByBodyPrefix,
+  loadOutboundCandidates,
+} from '../../../lib/coordinator/relay-drop-gauge.cjs';
+import { PAYLOAD_KINDS } from '../../../lib/fleet/worker-status.cjs';
+
+const NOW = Date.parse('2026-08-12T21:43:00Z');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+describe('satisfiesByBodyPrefix', () => {
+  it('matches a worker_signal reply body containing the 8-char correlation prefix', () => {
+    const row = { payload: { signal_type: 'feedback', body: 'Reviewed and agree — req cb5587b3, ship it' } };
+    expect(satisfiesByBodyPrefix(row, 'cb5587b3-1234-5678-9abc-def012345678')).toBe(true);
+  });
+
+  it('does not match when the body references a DIFFERENT correlation id', () => {
+    const row = { payload: { signal_type: 'feedback', body: 'req 00000000, unrelated' } };
+    expect(satisfiesByBodyPrefix(row, 'cb5587b3-1234-5678-9abc-def012345678')).toBe(false);
+  });
+
+  it('does not match a row with no body text', () => {
+    expect(satisfiesByBodyPrefix({ payload: { signal_type: 'feedback' } }, 'cb5587b3-xxxx')).toBe(false);
+  });
+
+  it('does not match a correlation id shorter than the 8-char prefix window', () => {
+    expect(satisfiesByBodyPrefix({ payload: { body: 'req ab' } }, 'ab')).toBe(false);
+  });
+});
+
+describe('decideRelayDrops: worker-signal reply to a review_request (QF-20260812-752)', () => {
+  it('recognizes the REAL live shape as satisfying — no longer flags it', () => {
+    // Reproduces the live incident's actual row shapes (correlation cb5587b3..., review sent
+    // 20:42:44Z, worker-signal reply landed 20:56:43Z — well within the 15min window here
+    // because the check is now well past both, matching the sustained-false-flag symptom).
+    const inbound = [{
+      id: '324acaff',
+      payload: { kind: 'review_request', correlation_id: 'cb5587b3-aaaa-bbbb-cccc-111122223333' },
+      created_at: '2026-08-12T20:42:44Z',
+    }];
+    const outbound = [{
+      id: '264a931f',
+      payload: { signal_type: 'feedback', body: 'Substantive review of req cb5587b3 — looks solid, ADAM-COORD-FEEDBACK' },
+      created_at: '2026-08-12T20:56:43Z',
+    }];
+    const decisions = decideRelayDrops(inbound, outbound, { now: NOW });
+    expect(decisions).toHaveLength(1);
+    expect(decisions[0].action).toBe('ok');
+  });
+
+  it('REGRESSION CONTROL: still flags when genuinely nothing replied', () => {
+    const inbound = [{
+      id: '324acaff',
+      payload: { kind: 'review_request', correlation_id: 'cb5587b3-aaaa-bbbb-cccc-111122223333' },
+      created_at: '2026-08-12T20:42:44Z',
+    }];
+    const decisions = decideRelayDrops(inbound, [], { now: NOW });
+    expect(decisions[0].action).toBe('flag');
+  });
+
+  it('REGRESSION CONTROL: an unrelated worker-signal body does not falsely satisfy', () => {
+    const inbound = [{
+      id: '324acaff',
+      payload: { kind: 'review_request', correlation_id: 'cb5587b3-aaaa-bbbb-cccc-111122223333' },
+      created_at: '2026-08-12T20:42:44Z',
+    }];
+    const outbound = [{
+      id: 'unrelated1',
+      payload: { signal_type: 'feedback', body: 'idle-absorb claim hint acked, no correlation here' },
+      created_at: '2026-08-12T20:56:43Z',
+    }];
+    const decisions = decideRelayDrops(inbound, outbound, { now: NOW });
+    expect(decisions[0].action).toBe('flag');
+  });
+
+  it('a relay_confirm row still satisfies via the pre-existing exact-match path (unchanged)', () => {
+    const inbound = [{ id: 'in1', payload: { kind: PAYLOAD_KINDS.RELAY_REQUEST, correlation_id: 'c1' }, created_at: '2026-08-12T20:42:44Z' }];
+    const outbound = [{ id: 'out1', payload: { kind: PAYLOAD_KINDS.RELAY_CONFIRM, correlation_id: 'c1' }, created_at: '2026-08-12T20:56:43Z' }];
+    const decisions = decideRelayDrops(inbound, outbound, { now: NOW });
+    expect(decisions[0].action).toBe('ok');
+  });
+});
+
+describe('loadOutboundCandidates: the query must actually fetch feedback-signal rows', () => {
+  it('wires an .or() filter including payload->>signal_type.eq.feedback alongside relay_confirm', () => {
+    // The pure core above proves the MATCHING logic is correct, but decideRelayDrops can only
+    // act on rows it is HANDED — this closes the other half: without widening the DB-side
+    // query, the real fix (loadOutboundCandidates only ever selecting payload->>kind=
+    // relay_confirm) would still never fetch a worker-signal row for the core to evaluate.
+    const src = readFileSync(path.resolve(__dirname, '../../../lib/coordinator/relay-drop-gauge.cjs'), 'utf8');
+    const fnSrc = src.slice(src.indexOf('async function loadOutboundCandidates'), src.indexOf('async function planRelayDrops'));
+    expect(fnSrc).toMatch(/\.or\(/);
+    expect(fnSrc).toMatch(/payload->>signal_type\.eq\.feedback/);
+    expect(fnSrc).toMatch(/payload->>kind\.eq\./);
+  });
+
+  it('is exported and callable', () => {
+    expect(typeof loadOutboundCandidates).toBe('function');
+  });
+});


### PR DESCRIPTION
## Summary
- `lib/coordinator/relay-drop-gauge.cjs`'s `satisfiesCorrelation()` only recognized an outbound row as answering a tracked `review_request`/`decision_request` when it carried `payload.kind=relay_confirm` or `payload.reply_to`/`in_reply_to`.
- The coordinator's own periodic bidirectional-review-request mechanism instructs the recipient to reply via `/signal feedback` — which writes a worker_signal row (`payload.signal_type='feedback'`) referencing the original only by an 8-char id prefix in free-text `payload.body`. That shape can never satisfy either check, so this was a **guaranteed 100% miss** for every review answered via the documented reply convention, not occasional flakiness.
- Verified live 2026-08-12: Adam replied substantively to review-request `cb5587b3`/`324acaff` within 14 minutes, yet the gauge flagged it as dropped and kept re-flagging it for 45+ minutes.
- Fix has two halves, both required: (1) `satisfiesByBodyPrefix()` — a new pure helper checked against the same 8-char truncation the reply convention itself emits; (2) widens `loadOutboundCandidates`'s query (previously scoped to `payload->>kind=relay_confirm` only) to also fetch `payload->>signal_type=feedback` rows — without the query widening, the matching logic alone would never see a row to evaluate.

## Test plan
- [x] New regression suite `tests/unit/coordinator/relay-drop-gauge-worker-signal-reply.test.js` (10 tests): `satisfiesByBodyPrefix` unit tests, the pure `decideRelayDrops` core correctly resolving the exact live incident's row shapes to `action:'ok'`, two negative controls (genuinely no reply still flags; an unrelated worker-signal body doesn't falsely satisfy), confirms the pre-existing `relay_confirm` exact-match path is untouched, and a source-text assertion that the DB query is actually widened (the pure-core tests alone can't prove a row would ever be fetched in production).
- [x] Verified the fix is load-bearing: reverted via `git stash`, confirmed the key tests fail without it, then restored.
- [x] Existing `tests/unit/coordinator/relay-drop-gauge.test.js` (12 tests) passes unmodified — 22 tests total across both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)