### PR TITLE
SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001: Drop telegram_bot_insert_feedback (venture-blind anon-INSERT policy)

### DIFF
--- a/.github/workflows/drive-reports-ddl.yml
+++ b/.github/workflows/drive-reports-ddl.yml
@@ -40,6 +40,11 @@ on:
       # migration and its ddl test would otherwise trigger nothing.
       - 'database/chairman-gated/20260812_venture_ingest_key_binding.sql'
       - 'tests/ddl/venture-ingest-key-binding-ddl.db.test.js'
+      # SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001. Same TR-5 fix, applied to a NEW pair rather than
+      # amended-in: this workflow's own paths filter is literal, so a PR touching only this SD's
+      # migration and its ddl test would otherwise trigger nothing.
+      - 'database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql'
+      - 'tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js'
       - 'vitest.ddl.config.mjs'
       # Self-validating: edits to this file re-run it.
       - '.github/workflows/drive-reports-ddl.yml'

--- a/database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql
+++ b/database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql
@@ -117,9 +117,12 @@ SET LOCAL search_path = public, pg_catalog;
 DROP POLICY IF EXISTS telegram_bot_insert_feedback ON public.feedback;
 
 -- ============================================================
--- 2. Self-verify: three-way, mutation-resistant (TR-2, TS-4a/TS-4b). A one-sided check (only
---    confirming the drop happened) cannot distinguish a correct surgical removal from an
---    accidental over-broad drop or a collaterally-revoked grant.
+-- 2. Self-verify: FIVE-way, mutation-resistant (TR-2, TS-4a/TS-4b) — CORRECTED (SECURITY sub-agent
+--    finding, EXEC re-review, L2): this was "three-way" until (d) relrowsecurity and (e)
+--    anon_feedback_ingress_bounds were added; a header undercounting its own assertions is the
+--    same "measures less than it claims" defect this whole SD exists to fix, in miniature. A
+--    one-sided check (only confirming the drop happened) cannot distinguish a correct surgical
+--    removal from an accidental over-broad drop or a collaterally-revoked grant.
 -- ============================================================
 DO $verify$
 DECLARE
@@ -164,15 +167,18 @@ BEGIN
     RAISE EXCEPTION 'VERIFY FAILED: public.feedback does not have RLS enabled';
   END IF;
 
-  -- (e) anon_feedback_ingress_bounds must remain present and RESTRICTIVE (DATABASE sub-agent
-  --     finding, EXEC review) — this file's own header now relies on that policy continuing to
-  --     bound severity/category/rate for every anon INSERT that reaches venture_user_insert_
-  --     feedback; if it were ever silently dropped or flipped to PERMISSIVE, this file's stated
-  --     safety posture would be false.
+  -- (e) anon_feedback_ingress_bounds must remain present, RESTRICTIVE, AND still apply to INSERT
+  --     (SECURITY sub-agent finding, EXEC re-review, L1: the cmd predicate was missing — a
+  --     same-named policy re-created for a different cmd or with roles/predicates stripped could
+  --     satisfy a name+permissive-only check while this file's stated posture became false) — this
+  --     file's own header now relies on that policy continuing to bound severity/category/rate for
+  --     every anon INSERT that reaches venture_user_insert_feedback; if it were ever silently
+  --     dropped, re-scoped off INSERT, or flipped to PERMISSIVE, this file's stated safety posture
+  --     would be false.
   IF (SELECT count(*) FROM pg_policies
       WHERE schemaname = 'public' AND tablename = 'feedback'
-        AND policyname = 'anon_feedback_ingress_bounds' AND permissive = 'RESTRICTIVE') <> 1 THEN
-    RAISE EXCEPTION 'VERIFY FAILED: anon_feedback_ingress_bounds is missing or is no longer RESTRICTIVE';
+        AND policyname = 'anon_feedback_ingress_bounds' AND cmd = 'INSERT' AND permissive = 'RESTRICTIVE') <> 1 THEN
+    RAISE EXCEPTION 'VERIFY FAILED: anon_feedback_ingress_bounds is missing, no longer applies to INSERT, or is no longer RESTRICTIVE';
   END IF;
 END
 $verify$;

--- a/database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql
+++ b/database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql
@@ -167,18 +167,21 @@ BEGIN
     RAISE EXCEPTION 'VERIFY FAILED: public.feedback does not have RLS enabled';
   END IF;
 
-  -- (e) anon_feedback_ingress_bounds must remain present, RESTRICTIVE, AND still apply to INSERT
-  --     (SECURITY sub-agent finding, EXEC re-review, L1: the cmd predicate was missing — a
-  --     same-named policy re-created for a different cmd or with roles/predicates stripped could
-  --     satisfy a name+permissive-only check while this file's stated posture became false) — this
-  --     file's own header now relies on that policy continuing to bound severity/category/rate for
-  --     every anon INSERT that reaches venture_user_insert_feedback; if it were ever silently
-  --     dropped, re-scoped off INSERT, or flipped to PERMISSIVE, this file's stated safety posture
-  --     would be false.
+  -- (e) anon_feedback_ingress_bounds must remain present, RESTRICTIVE, still apply to INSERT, AND
+  --     still apply to the public role (SECURITY sub-agent finding, EXEC re-review, L1: the cmd
+  --     predicate was missing; adversarial /ship review finding, this pass: the cmd+permissive-only
+  --     check still let a same-named policy survive with its ROLES stripped down to e.g.
+  --     `TO authenticated` — satisfying name+cmd+permissive while ceasing to bound anon traffic at
+  --     all, exactly the "roles/predicates stripped" threat this comment already named but did not
+  --     test) — this file's own header now relies on that policy continuing to bound
+  --     severity/category/rate for every anon INSERT that reaches venture_user_insert_feedback; if
+  --     it were ever silently dropped, re-scoped off INSERT or off the public role, or flipped to
+  --     PERMISSIVE, this file's stated safety posture would be false.
   IF (SELECT count(*) FROM pg_policies
       WHERE schemaname = 'public' AND tablename = 'feedback'
-        AND policyname = 'anon_feedback_ingress_bounds' AND cmd = 'INSERT' AND permissive = 'RESTRICTIVE') <> 1 THEN
-    RAISE EXCEPTION 'VERIFY FAILED: anon_feedback_ingress_bounds is missing, no longer applies to INSERT, or is no longer RESTRICTIVE';
+        AND policyname = 'anon_feedback_ingress_bounds' AND cmd = 'INSERT' AND permissive = 'RESTRICTIVE'
+        AND 'public' = ANY(roles)) <> 1 THEN
+    RAISE EXCEPTION 'VERIFY FAILED: anon_feedback_ingress_bounds is missing, no longer applies to INSERT, is no longer RESTRICTIVE, or no longer applies to the public role';
   END IF;
 END
 $verify$;

--- a/database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql
+++ b/database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql
@@ -1,0 +1,194 @@
+-- SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001 — drop the dead, unbounded telegram anon-INSERT policy
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- STAGED, NOT APPLIED. CHAIRMAN-GATED. DO NOT RUN THIS FILE.
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- AWAITING CHAIRMAN REVIEW — no @approved-by stamp exists for this file yet, deliberately, per the
+-- convention established by database/chairman-gated/20260812_venture_ingest_key_binding.sql.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- WHAT THIS DOES AND DOES NOT CLOSE (CORRECTED TWICE — see below; this is the version that holds)
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- public.feedback's telegram_bot_insert_feedback policy has WITH CHECK (source_type = 'telegram')
+-- ONLY — no venture predicate, no feedback_type constraint. This file DROPs it.
+--
+-- SECOND CORRECTION (EXEC-phase DATABASE sub-agent finding, this session): the FIRST correction
+-- (below, superseded) claimed anon_feedback_ingress_bounds would catch telegram-sourced writes
+-- once this policy is dropped, and separately claimed it was PERMISSIVE and already permitted the
+-- abuse this file targets. BOTH claims were wrong. MEASURED LIVE (the `permissive` column on
+-- pg_policies, not assumed): anon_feedback_ingress_bounds is RESTRICTIVE, roles={public}. A
+-- RESTRICTIVE policy never grants an INSERT by itself — it only narrows whatever a PERMISSIVE
+-- policy already authorized (PERMISSIVE policies OR together; the RESTRICTIVE set then ANDs onto
+-- that result). It was ALREADY constraining telegram_bot_insert_feedback's writes before this
+-- file — measured: a telegram-tagged write with severity='critical' or
+-- category='chairman_decision_deferred' was ALREADY refused pre-drop, attributed to
+-- anon_feedback_ingress_bounds specifically, and telegram traffic was already capped at 50/hour by
+-- that same policy's rate-limit CASE. "Zero rate-limit/content-bound protection at all" was false.
+--
+-- This DOES: remove the only anon-writable path on this table with NO VENTURE PREDICATE
+-- WHATSOEVER. Pre-drop, any anon-key holder could write a row with an arbitrary or ABSENT
+-- venture_id — no existence check, no ownership check — merely by tagging
+-- source_type='telegram' (still subject to anon_feedback_ingress_bounds' content/rate bounds,
+-- never subject to any venture check). Post-drop, the ONLY remaining permissive anon INSERT path
+-- is venture_user_insert_feedback, whose WITH CHECK requires feedback_type LIKE 'user_%' AND
+-- venture_id IS NOT NULL AND venture_exists_and_active(venture_id) AND a per-venture rate limit. A
+-- bare telegram-shaped write with no venture_id is refused post-drop because NO permissive policy
+-- authorizes it at all — not because it gets "routed through" the RESTRICTIVE policy, which was
+-- never a fallback grant and structurally cannot become one.
+--
+-- This does NOT: prove true venture OWNERSHIP. venture_exists_and_active() checks only that the
+-- venture_id EXISTS and is active — the same existence-only gap already present in
+-- venture_user_insert_feedback today, UNCHANGED by this file (not anon_feedback_ingress_bounds —
+-- see the correction above). An anon caller can still attribute a 'user_%' feedback row to any
+-- real, active venture_id it can guess or discover; this file closes the "arbitrary/absent
+-- venture_id, no check at all" hole, not spoofing against a real venture. That residual is tracked
+-- and governed separately (routed to Adam, advisory 9d3ddfce) and is explicitly OUT OF SCOPE here.
+--
+-- FIRST CORRECTION (superseded by the above, kept for the record rather than deleted): originally
+-- claimed this closes venture-ID spoofing outright; corrected mid-EXEC after a live pg_policies
+-- read surfaced anon_feedback_ingress_bounds as a fourth policy, but misread its permissive/
+-- restrictive column at the time.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- WHY DROP POLICY, NOT REVOKE (TR-1 — testing-agent T-1, confirmed live before authoring this file)
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- public.feedback has a SINGLE table-level anon-INSERT grant shared by TWO permissive anon INSERT
+-- policies: telegram_bot_insert_feedback (dropped here) and venture_user_insert_feedback (left
+-- untouched — still needs that grant). A REVOKE on the grant would break venture_user_insert_
+-- feedback too. DROP POLICY removes only the telegram-specific permission; PostgreSQL requires at
+-- least one remaining permissive policy to authorize any given row, so nothing opens up.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- SAFETY PREMISE — live traffic re-measured at EXEC time (FR-2/US-002), not inherited from LEAD
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- source_type='telegram' rows in the trailing 30 days: 0 (measured_at 2026-08-13T06:40:59.686Z,
+-- pooler connection, public.feedback). Matches the LEAD-phase snapshot and the coordinator's own
+-- independent spot-check during PLAN. This is a genuinely dead surface.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- SCOPE OF THIS FILE — explicitly excluded, do not read this as closing either of these (FR-5/TR-4)
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+--   record_venture_error's existence-only venture_id validation — owned by SD-LEO-INFRA-RECORD-
+--     VENTURE-ERROR-DEFINER-POSTURE-001, untouched by this file.
+--   venture_user_insert_feedback's existence-only (not ownership) venture_id check — deliberately
+--     left fully open; needs its own follow-on SD (auth.uid()-to-venture-membership design, not
+--     filed yet), untouched by this file. THIS is the mechanism that makes "does not prove true
+--     ownership" true above — not anon_feedback_ingress_bounds (see the correction above).
+--   telegram_bot_select_feedback (the sibling anon SELECT policy) — survives this migration
+--     unchanged. Not a new risk this file introduces: it already coexists with venture_user_
+--     insert_feedback's INSERT path today, so this narrow DROP does not change that pre-existing
+--     read exposure.
+--   anon_feedback_ingress_bounds — RESTRICTIVE, roles={public}, untouched by this file. Continues
+--     to bound severity/category/rate for every anon INSERT that reaches it, exactly as it did
+--     before this file, including for venture_user_insert_feedback's own writes (which it already
+--     covered, and still does).
+--
+-- Rollback: recreate the exact original policy (verbatim text below, foot of file). Additive-safe
+-- to reverse in one pass — no other object depends on this policy's absence.
+--
+-- KNOWN, OUT-OF-SCOPE TOOLING GAP (peer precedent: database/chairman-gated/20260812_venture_
+-- ingest_key_binding.sql's own header documents the identical exposure for itself): this file's
+-- named DO $verify$ tag means scripts/lib/supabase-connection.js's splitPostgreSQLStatements()
+-- would shred it into more fragments than its real statement count if ever run with
+-- --split-statements (no caller in this repo passes that flag on the default apply path). Not
+-- fixed here — shared mainline tooling, out of this SD's scope, flagged rather than silently
+-- inherited without mention.
+
+BEGIN;
+
+-- Bounded wait for the ACCESS EXCLUSIVE lock DROP POLICY needs on public.feedback — this table's
+-- own 2026-08-12 incident record (this SD family) is exactly an unbounded lock wait on this same
+-- table turning into a live-writer-blocking queue. Fail fast and let the chairman re-run at a
+-- quieter moment rather than queue indefinitely behind this transaction.
+SET LOCAL lock_timeout = '2s';
+
+-- SECURITY sub-agent finding (EXEC review, warning): the $verify$ block's sibling WITH CHECK
+-- byte-exact string compare is deparsed by pg_get_expr, which schema-qualifies a function name
+-- only when it is NOT visible under the session's search_path. Pinning it here makes that deparse
+-- deterministic, so the compare cannot false-FAIL at chairman-apply time under a hardened
+-- search_path (e.g. search_path='') or a role whose default omits public -- a false alarm at
+-- exactly the moment (chairman ceremony) when pressure to delete or weaken the check is highest.
+SET LOCAL search_path = public, pg_catalog;
+
+-- ============================================================
+-- 1. Drop the dead policy with no venture predicate. Policy-specific, never a table-level REVOKE
+--    (TR-1).
+-- ============================================================
+DROP POLICY IF EXISTS telegram_bot_insert_feedback ON public.feedback;
+
+-- ============================================================
+-- 2. Self-verify: three-way, mutation-resistant (TR-2, TS-4a/TS-4b). A one-sided check (only
+--    confirming the drop happened) cannot distinguish a correct surgical removal from an
+--    accidental over-broad drop or a collaterally-revoked grant.
+-- ============================================================
+DO $verify$
+DECLARE
+  v_sibling_with_check TEXT;
+BEGIN
+  -- (a) The target policy must be gone (TS-4a: RAISEs if the DROP above did not actually apply).
+  IF (SELECT count(*) FROM pg_policies
+      WHERE schemaname = 'public' AND tablename = 'feedback'
+        AND policyname = 'telegram_bot_insert_feedback') <> 0 THEN
+    RAISE EXCEPTION 'VERIFY FAILED: telegram_bot_insert_feedback still present in pg_policies';
+  END IF;
+
+  -- (b) The table-level anon-INSERT grant must remain PRESENT — venture_user_insert_feedback still
+  --     needs it. A grant that went missing here means a REVOKE happened instead of a DROP POLICY,
+  --     silently breaking the sibling policy's own reachability.
+  IF has_table_privilege('anon', 'public.feedback', 'INSERT') IS NOT TRUE THEN
+    RAISE EXCEPTION 'VERIFY FAILED: anon lost table-level INSERT privilege on public.feedback — venture_user_insert_feedback would be unreachable';
+  END IF;
+
+  -- (c) The sibling policy must survive UNCHANGED — both presence and its exact WITH CHECK text
+  --     (TS-4b: RAISEs if a typo'd policy name dropped or altered the sibling instead of/in
+  --     addition to the target).
+  SELECT with_check INTO v_sibling_with_check
+  FROM pg_policies
+  WHERE schemaname = 'public' AND tablename = 'feedback' AND policyname = 'venture_user_insert_feedback';
+
+  IF v_sibling_with_check IS NULL THEN
+    RAISE EXCEPTION 'VERIFY FAILED: venture_user_insert_feedback is missing from pg_policies';
+  END IF;
+
+  IF v_sibling_with_check IS DISTINCT FROM
+     '(((feedback_type)::text ~~ ''user_%''::text) AND (venture_id IS NOT NULL) AND venture_exists_and_active(venture_id) AND (NOT check_feedback_rate_limit(venture_id)))' THEN
+    RAISE EXCEPTION 'VERIFY FAILED: venture_user_insert_feedback WITH CHECK text changed unexpectedly: %', v_sibling_with_check;
+  END IF;
+
+  -- (d) RLS must remain enabled on public.feedback (DATABASE sub-agent finding, EXEC review) —
+  --     defense-in-depth, independent of the policy-level checks above. This file does not touch
+  --     this setting, but if it were ever disabled elsewhere, every policy this file relies on
+  --     staying in force (including venture_user_insert_feedback and anon_feedback_ingress_bounds)
+  --     would stop being evaluated at all, silently.
+  IF (SELECT relrowsecurity FROM pg_class WHERE oid = 'public.feedback'::regclass) IS NOT TRUE THEN
+    RAISE EXCEPTION 'VERIFY FAILED: public.feedback does not have RLS enabled';
+  END IF;
+
+  -- (e) anon_feedback_ingress_bounds must remain present and RESTRICTIVE (DATABASE sub-agent
+  --     finding, EXEC review) — this file's own header now relies on that policy continuing to
+  --     bound severity/category/rate for every anon INSERT that reaches venture_user_insert_
+  --     feedback; if it were ever silently dropped or flipped to PERMISSIVE, this file's stated
+  --     safety posture would be false.
+  IF (SELECT count(*) FROM pg_policies
+      WHERE schemaname = 'public' AND tablename = 'feedback'
+        AND policyname = 'anon_feedback_ingress_bounds' AND permissive = 'RESTRICTIVE') <> 1 THEN
+    RAISE EXCEPTION 'VERIFY FAILED: anon_feedback_ingress_bounds is missing or is no longer RESTRICTIVE';
+  END IF;
+END
+$verify$;
+
+-- PostgREST caches the schema; without this, the policy removal is correct in pg_catalog but not
+-- yet reflected for real anon clients until PostgREST's own reload cycle catches up.
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;
+
+-- ============================================================
+-- ROLLBACK (manual, if needed — recreates the exact original policy, verbatim, from
+-- database/migrations/20260223_telegram_bot_feedback_rls.sql:45-48):
+-- ============================================================
+-- CREATE POLICY telegram_bot_insert_feedback ON feedback
+--   FOR INSERT
+--   TO anon
+--   WITH CHECK (source_type = 'telegram');
+-- NOTIFY pgrst, 'reload schema';

--- a/scripts/security/rls-feedback-live-probe.cjs
+++ b/scripts/security/rls-feedback-live-probe.cjs
@@ -78,6 +78,14 @@ const CASES = [
   { name: "telegram + severity='critical', venture-owned",
     because: 'the RESTRICTIVE anon_feedback_ingress_bounds bars critical/high regardless of which permissive policy would otherwise grant — venture-owned so the RESTRICTIVE bound stays exercised even after telegram_bot_insert_feedback is dropped (it was never a fallback grant)',
     expect: VERDICT.REFUSED, needsVenture: true,
+    // SECURITY sub-agent finding (EXEC re-review, L3/R2): the default nonsenseControl below
+    // ({...row, severity:'critical'}) would be BYTE-IDENTICAL to this row (which already carries
+    // severity:'critical'), leaving the control unable to fail independently of the case it is
+    // meant to cross-check — exactly the "present as a field, absent as a check" failure
+    // lib/security/rls-probe-template.cjs's own header warns about. Override with a control denied
+    // by a GENUINELY different mechanism: venture_id:null trips venture_user_insert_feedback's own
+    // NOT NULL clause, independent of the RESTRICTIVE bound this case actually tests.
+    controlOverride: { venture_id: null },
     row: (m, v) => ({ ...base(m), source_type: 'telegram', feedback_type: 'user_bug', venture_id: v, severity: 'critical' }) },
   { name: "telegram + category='chairman_decision_deferred', venture-owned",
     because: 'the RESTRICTIVE bounds bar that category regardless of which permissive policy would otherwise grant — venture-owned so the bound stays exercised post-drop too',
@@ -161,10 +169,12 @@ async function main() {
     const row = c.row(marker, ventureId);
     const plan = buildProbePlan({
       table: 'feedback', validRow: row, fieldUnderTest: 'source_type', markerColumn: 'title',
-      // The control must be a row that CANNOT pass: the RESTRICTIVE bounds bar severity='critical'
-      // whatever any permissive policy grants. If this is ever ACCEPTED, runProbe withdraws the
-      // REFUSED verdict rather than reporting it.
-      nonsenseControl: { ...row, severity: 'critical' },
+      // The control must be a row that CANNOT pass, via a mechanism INDEPENDENT of what the case
+      // itself tests: the RESTRICTIVE bounds bar severity='critical' whatever any permissive policy
+      // grants. If this is ever ACCEPTED, runProbe withdraws the REFUSED verdict rather than
+      // reporting it. controlOverride (per-case) replaces the default when the default would
+      // collide with the row under test (L3/R2, see case 3 above).
+      nonsenseControl: { ...row, ...(c.controlOverride || { severity: 'critical' }) },
     });
     let verdict;
     try { verdict = await runProbe({ anon, service, plan, assertPrecondition }); }

--- a/scripts/security/rls-feedback-live-probe.cjs
+++ b/scripts/security/rls-feedback-live-probe.cjs
@@ -82,9 +82,16 @@ const CASES = [
     // ({...row, severity:'critical'}) would be BYTE-IDENTICAL to this row (which already carries
     // severity:'critical'), leaving the control unable to fail independently of the case it is
     // meant to cross-check — exactly the "present as a field, absent as a check" failure
-    // lib/security/rls-probe-template.cjs's own header warns about. Override with a control denied
-    // by a GENUINELY different mechanism: venture_id:null trips venture_user_insert_feedback's own
-    // NOT NULL clause, independent of the RESTRICTIVE bound this case actually tests.
+    // lib/security/rls-probe-template.cjs's own header warns about. Override with venture_id:null,
+    // which trips venture_user_insert_feedback's own NOT NULL clause POST-migration (once
+    // telegram_bot_insert_feedback is dropped and that's the only remaining permissive path) —
+    // a genuinely independent mechanism from the RESTRICTIVE bound this case tests. Adversarial
+    // /ship review finding (round 2): PRE-migration, telegram_bot_insert_feedback's own
+    // source_type-only WITH CHECK still authorizes this control regardless of venture_id, so in
+    // that window it is refused by the SAME anon_feedback_ingress_bounds severity bound as the row
+    // under test, not independently. Either way the control still correctly reads REFUSED (this
+    // case is not gated by requiresTelegramPolicy), so no verdict is ever wrong — only the
+    // cross-check's independence is window-dependent, not its correctness.
     controlOverride: { venture_id: null },
     row: (m, v) => ({ ...base(m), source_type: 'telegram', feedback_type: 'user_bug', venture_id: v, severity: 'critical' }) },
   { name: "telegram + category='chairman_decision_deferred', venture-owned",

--- a/scripts/security/rls-feedback-live-probe.cjs
+++ b/scripts/security/rls-feedback-live-probe.cjs
@@ -30,6 +30,33 @@
  * confirmation. runProbe refuses to start if the marker already matches a row (no OPEN from residue)
  * or if the baseline readback cannot be performed at all.
  *
+ * FIXED (SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001 T-4/TR-5): assertPrecondition's exec_sql call used
+ * `{ sql: ... }`, which does not match the live RPC's real parameter name `sql_text` — PostgREST
+ * 404'd on every run and the `if (error) return;` swallowed it silently, so this drift guard has
+ * NEVER actually executed despite the header above claiming "TEETH". Fixed to `{ sql_text: ... }`
+ * and a failed read now THROWS rather than silently no-op'ing, so a future signature drift fails
+ * loud, not silently, again. Fixing the call shape surfaced a SECOND, previously-invisible bug
+ * (exactly the risk this SD's own PRD flagged): public.exec_sql RETURNS TABLE(result jsonb), one
+ * row whose single column holds the ENTIRE aggregated result as a JSON array — `data` is
+ * `[{ result: [...] }]`, not one row per policy. The original `data.map(r => r.policyname)` would
+ * have silently produced an empty/garbage policy list forever, DRIFTED-failing on every run, had
+ * the call-shape bug ever been fixed without also fixing this. Also split EXPECTED_INSERT_POLICIES:
+ * telegram_bot_insert_feedback is
+ * measured (not hard-asserted) via ALWAYS_EXPECTED_INSERT_POLICIES + a live pg_policies read —
+ * once SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001's migration is chairman-applied, the ONE case whose
+ * premise depends on that policy granting the row SKIPs rather than FAILs.
+ *
+ * CORRECTED (DATABASE sub-agent finding, SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001 EXEC review):
+ * anon_feedback_ingress_bounds is RESTRICTIVE (measured live via the `permissive` column), not a
+ * fallback PERMISSIVE grant — it narrows whatever a PERMISSIVE policy already authorized, and it
+ * was already constraining telegram_bot_insert_feedback's writes before that migration, and
+ * continues to constrain venture_user_insert_feedback's writes after. The severity/category CASES
+ * below therefore do NOT need telegram_bot_insert_feedback to exist — they only need a row shaped
+ * to satisfy venture_user_insert_feedback (a real venture_id) so the RESTRICTIVE bound is actually
+ * reached and still provably fires post-migration. Only the plain "source_type='telegram'" case is
+ * genuinely telegram_bot_insert_feedback-dependent (nothing else grants that exact shape) and is
+ * the ONLY one gated to SKIP.
+ *
  * USAGE: node scripts/security/rls-feedback-live-probe.cjs        (exit 0 = policies unchanged)
  */
 require('dotenv').config({ quiet: true });
@@ -46,16 +73,16 @@ const CASES = [
     row: (m) => ({ ...base(m), source_type: 'auto_capture', feedback_type: 'user_bug' }) },
   { name: "source_type='telegram'",
     because: 'telegram_bot_insert_feedback grants it, and anon SELECT covers telegram so RETURNING works too',
-    expect: VERDICT.OPEN, needsVenture: false,
+    expect: VERDICT.OPEN, needsVenture: false, requiresTelegramPolicy: true,
     row: (m) => ({ ...base(m), source_type: 'telegram', feedback_type: 'user_bug' }) },
-  { name: "telegram + severity='critical'",
-    because: 'the RESTRICTIVE anon_feedback_ingress_bounds bars critical/high regardless of any grant',
-    expect: VERDICT.REFUSED, needsVenture: false,
-    row: (m) => ({ ...base(m), source_type: 'telegram', feedback_type: 'user_bug', severity: 'critical' }) },
-  { name: "telegram + category='chairman_decision_deferred'",
-    because: 'the RESTRICTIVE bounds bar that category regardless of any grant',
-    expect: VERDICT.REFUSED, needsVenture: false,
-    row: (m) => ({ ...base(m), source_type: 'telegram', feedback_type: 'user_bug', category: 'chairman_decision_deferred' }) },
+  { name: "telegram + severity='critical', venture-owned",
+    because: 'the RESTRICTIVE anon_feedback_ingress_bounds bars critical/high regardless of which permissive policy would otherwise grant — venture-owned so the RESTRICTIVE bound stays exercised even after telegram_bot_insert_feedback is dropped (it was never a fallback grant)',
+    expect: VERDICT.REFUSED, needsVenture: true,
+    row: (m, v) => ({ ...base(m), source_type: 'telegram', feedback_type: 'user_bug', venture_id: v, severity: 'critical' }) },
+  { name: "telegram + category='chairman_decision_deferred', venture-owned",
+    because: 'the RESTRICTIVE bounds bar that category regardless of which permissive policy would otherwise grant — venture-owned so the bound stays exercised post-drop too',
+    expect: VERDICT.REFUSED, needsVenture: true,
+    row: (m, v) => ({ ...base(m), source_type: 'telegram', feedback_type: 'user_bug', venture_id: v, category: 'chairman_decision_deferred' }) },
   { name: 'THE ASYMMETRIC CASE — auto_capture + ACTIVE venture_id',
     because: 'venture_user_insert_feedback grants the INSERT and places NO constraint on source_type, while anon SELECT is confined to telegram — so RETURNING fails and the bare write lands',
     expect: VERDICT.OPEN, needsVenture: true,
@@ -70,16 +97,48 @@ async function main() {
   // The drift guard has TEETH: it asserts the policy set these predictions are DERIVED FROM is still
   // the policy set in force. If the policies moved, every prediction below is about a table that no
   // longer exists as described, and reporting a verdict would be worse than reporting nothing.
-  const EXPECTED_INSERT_POLICIES = ['insert_feedback_policy', 'telegram_bot_insert_feedback', 'venture_user_insert_feedback'];
+  // telegram_bot_insert_feedback is MEASURED, not hard-asserted: SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001
+  // drops it via chairman-gated migration, and the CASES whose premise depends on it granting the row
+  // must SKIP once that lands, not FAIL forever.
+  const ALWAYS_EXPECTED_INSERT_POLICIES = ['insert_feedback_policy', 'venture_user_insert_feedback'];
+  // SECURITY sub-agent finding (EXEC review, condition C5): the old query filtered
+  // permissive='PERMISSIVE', which structurally EXCLUDES anon_feedback_ingress_bounds — the one
+  // RESTRICTIVE policy the severity/category CASES below depend on continuing to bound every anon
+  // INSERT. Its silent removal would previously have gone undetected by this drift guard.
+  const ALWAYS_EXPECTED_RESTRICTIVE_POLICY = 'anon_feedback_ingress_bounds';
+  let telegramPolicyPresent = true; // conservative default until measured below
   const assertPrecondition = async () => {
     const { data, error } = await service.rpc('exec_sql', {
-      sql: "select policyname from pg_policies where schemaname='public' and tablename='feedback' and cmd='INSERT' and permissive='PERMISSIVE'",
-    }).then((r) => r, (e) => ({ error: e }));
-    if (error) return;                      // rpc unavailable in this env — the row-level check below still runs
-    const names = (data || []).map((r) => r.policyname).sort();
-    const missing = EXPECTED_INSERT_POLICIES.filter((p) => !names.includes(p));
-    if (missing.length) throw new Error(`policy set DRIFTED — missing INSERT policies: ${missing.join(', ')}. Predictions in this file were derived from the old set.`);
+      sql_text: "select policyname, permissive from pg_policies where schemaname='public' and tablename='feedback' and cmd='INSERT'",
+    });
+    if (error) {
+      // FIXED (T-4): this used to be `if (error) return;`, silently no-op'ing on the exec_sql
+      // call-shape bug and making this drift guard never actually run. A failed policy-set read
+      // must not be treated as "policies unchanged" — it means this guard cannot see the truth.
+      throw new Error(`assertPrecondition: exec_sql RPC failed (${error.code ?? 'no code'}): ${error.message}`);
+    }
+    // SECOND bug found only once the call-shape fix let this code path actually execute (measured
+    // live, not assumed): public.exec_sql RETURNS TABLE(result jsonb) — one row whose single
+    // column is the WHOLE query's aggregated JSON array, not one row per policy. `data` is
+    // therefore `[{ result: [...] }]`; the policy rows live at `data[0].result`.
+    const rows = data?.[0]?.result || [];
+    const permissiveNames = rows.filter((r) => r.permissive === 'PERMISSIVE').map((r) => r.policyname).sort();
+    const restrictiveNames = rows.filter((r) => r.permissive === 'RESTRICTIVE').map((r) => r.policyname).sort();
+
+    const missing = ALWAYS_EXPECTED_INSERT_POLICIES.filter((p) => !permissiveNames.includes(p));
+    if (missing.length) throw new Error(`policy set DRIFTED — missing PERMISSIVE INSERT policies: ${missing.join(', ')}. Predictions in this file were derived from the old set.`);
+
+    if (!restrictiveNames.includes(ALWAYS_EXPECTED_RESTRICTIVE_POLICY)) {
+      throw new Error(`policy set DRIFTED — missing RESTRICTIVE INSERT policy: ${ALWAYS_EXPECTED_RESTRICTIVE_POLICY}. The severity/category CASES in this file rely on it continuing to bound every anon INSERT.`);
+    }
+
+    telegramPolicyPresent = permissiveNames.includes('telegram_bot_insert_feedback');
   };
+
+  // Measured once, up front, so the per-case SKIP decision below has the flag before the loop runs.
+  // runProbe() also invokes this same callback again per case (unchanged behavior) — that re-confirms
+  // the same live state rather than trusting a snapshot taken before any writes in this run.
+  await assertPrecondition();
 
   let ventureId = null;
   const { data: ventures } = await service.from('ventures').select('id,status').eq('status', 'active').limit(1);
@@ -88,6 +147,11 @@ async function main() {
   let failures = 0;
   let skipped = 0;
   for (const c of CASES) {
+    if (c.requiresTelegramPolicy && !telegramPolicyPresent) {
+      console.log(`SKIP  ${c.name} — telegram_bot_insert_feedback has been revoked (SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001); this case's premise no longer applies`);
+      skipped++;
+      continue;
+    }
     if (c.needsVenture && !ventureId) {
       console.log(`SKIP  ${c.name} — no active venture available to build the granted row`);
       skipped++;

--- a/scripts/security/rls-feedback-live-probe.cjs
+++ b/scripts/security/rls-feedback-live-probe.cjs
@@ -137,7 +137,7 @@ async function main() {
     if (missing.length) throw new Error(`policy set DRIFTED — missing PERMISSIVE INSERT policies: ${missing.join(', ')}. Predictions in this file were derived from the old set.`);
 
     if (!restrictiveNames.includes(ALWAYS_EXPECTED_RESTRICTIVE_POLICY)) {
-      throw new Error(`policy set DRIFTED — missing RESTRICTIVE INSERT policy: ${ALWAYS_EXPECTED_RESTRICTIVE_POLICY}. The severity/category CASES in this file rely on it continuing to bound every anon INSERT.`);
+      throw new Error(`policy set DRIFTED — missing RESTRICTIVE INSERT policy: ${ALWAYS_EXPECTED_RESTRICTIVE_POLICY}. The severity/category CASES in this file rely on it continuing to bound every anon write.`);
     }
 
     telegramPolicyPresent = permissiveNames.includes('telegram_bot_insert_feedback');

--- a/scripts/security/rls-feedback-live-probe.cjs
+++ b/scripts/security/rls-feedback-live-probe.cjs
@@ -117,7 +117,7 @@ async function main() {
   let telegramPolicyPresent = true; // conservative default until measured below
   const assertPrecondition = async () => {
     const { data, error } = await service.rpc('exec_sql', {
-      sql_text: "select policyname, permissive from pg_policies where schemaname='public' and tablename='feedback' and cmd='INSERT'",
+      sql_text: "select policyname, permissive, roles from pg_policies where schemaname='public' and tablename='feedback' and cmd='INSERT'",
     });
     if (error) {
       // FIXED (T-4): this used to be `if (error) return;`, silently no-op'ing on the exec_sql
@@ -131,13 +131,21 @@ async function main() {
     // therefore `[{ result: [...] }]`; the policy rows live at `data[0].result`.
     const rows = data?.[0]?.result || [];
     const permissiveNames = rows.filter((r) => r.permissive === 'PERMISSIVE').map((r) => r.policyname).sort();
-    const restrictiveNames = rows.filter((r) => r.permissive === 'RESTRICTIVE').map((r) => r.policyname).sort();
+    // Adversarial /ship review finding (INFO — same gap as the migration's own check (e)): a
+    // name+permissive-only filter would still call a RESTRICTIVE anon_feedback_ingress_bounds
+    // re-scoped to e.g. `TO authenticated` a live match, even though it would no longer bound any
+    // anon write at all. Requiring 'public' in the row's own roles array (exec_sql serializes
+    // pg_policies.roles as a JSON array of role-name strings, measured live) closes that gap.
+    const restrictiveNames = rows
+      .filter((r) => r.permissive === 'RESTRICTIVE' && Array.isArray(r.roles) && r.roles.includes('public'))
+      .map((r) => r.policyname)
+      .sort();
 
     const missing = ALWAYS_EXPECTED_INSERT_POLICIES.filter((p) => !permissiveNames.includes(p));
     if (missing.length) throw new Error(`policy set DRIFTED — missing PERMISSIVE INSERT policies: ${missing.join(', ')}. Predictions in this file were derived from the old set.`);
 
     if (!restrictiveNames.includes(ALWAYS_EXPECTED_RESTRICTIVE_POLICY)) {
-      throw new Error(`policy set DRIFTED — missing RESTRICTIVE INSERT policy: ${ALWAYS_EXPECTED_RESTRICTIVE_POLICY}. The severity/category CASES in this file rely on it continuing to bound every anon write.`);
+      throw new Error(`policy set DRIFTED — missing RESTRICTIVE INSERT policy (or it no longer applies to the public role): ${ALWAYS_EXPECTED_RESTRICTIVE_POLICY}. The severity/category CASES in this file rely on it continuing to bound every anon write.`);
     }
 
     telegramPolicyPresent = permissiveNames.includes('telegram_bot_insert_feedback');

--- a/scripts/telegram-feedback-anon-probe.mjs
+++ b/scripts/telegram-feedback-anon-probe.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * Tier C probe for SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001 FR-3/US-003 — proves telegram_bot_insert_
+ * feedback's bare, unbounded anon-INSERT path is unreachable on the REAL live instance once
+ * database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql is applied, WITHOUT
+ * false-passing before it is applied and WITHOUT mistaking the deliberate residual path for a
+ * fix failure.
+ *
+ * WHY A NEW FILE, MODELLED ON scripts/venture-ingest-keys-anon-probe.mjs. Same reasoning as that
+ * file's own header: the defect shape and expected verdict here are specific to public.feedback's
+ * TWO permissive anon INSERT policies (not a deny-all table), so this is its own probe — but it
+ * reuses (never re-derives) assertNotCommitFamily, assertRlsInForce and classifyError from
+ * scripts/anon-write-contract-probe.mjs, per this SD's TR-3.
+ *
+ * CORRECTED verdict mapping (testing-agent T-1, confirmed live before authoring this file):
+ * public.feedback's telegram_bot_insert_feedback and venture_user_insert_feedback share ONE
+ * table-level anon-INSERT grant. This migration DROPs the policy, not the grant — so the correct
+ * post-apply attribution for a bare telegram-sourced anon INSERT is POLICY_DENIED (grant present,
+ * no permissive policy authorizes this exact row), NOT GRANT_DENIED. A has_table_privilege=FALSE
+ * reading post-apply would mean an over-broad REVOKE happened and is flagged as a REGRESSION here,
+ * not accepted as "stronger than expected".
+ *
+ * PRE-APPLY DISCRIMINATOR (T-5): reads pg_policies for telegram_bot_insert_feedback's presence
+ * BEFORE `set local role anon`, not to_regclass(table) — the table always exists (it is not
+ * additive like venture_ingest_keys), so a to_regclass check would never distinguish pre/post.
+ *
+ * THE DELIBERATE RESIDUAL PATH (TS-2/TS-8): an anon INSERT satisfying venture_user_insert_
+ * feedback's own conditions (feedback_type LIKE 'user_%', a real active venture_id) MUST still
+ * LAND even when source_type='telegram' — a legitimate, venture-owned, telegram-tagged submission
+ * is not the abuse case this migration closes (the abuse was ANYONE, with no venture ownership
+ * check at all). This probe asserts that path explicitly LANDS, not merely that the bare path is
+ * refused — a probe that only checked the refusal could not tell "surgical fix" from "the whole
+ * table went deny-all", which would itself be a silent regression against venture_user_insert_
+ * feedback's live callers.
+ *
+ * SAFE AGAINST PRODUCTION, same invariant as its siblings: COMMIT-NEVER-ISSUED. No COMMIT-family
+ * statement appears in this file; every query is wrapped through assertNotCommitFamily, and every
+ * write attempt runs inside a SAVEPOINT that is always rolled back, win or lose.
+ *
+ * Usage:
+ *   node scripts/telegram-feedback-anon-probe.mjs
+ */
+
+import { createDatabaseClient } from './lib/supabase-connection.js';
+import {
+  assertNotCommitFamily,
+  assertRlsInForce,
+  classifyError,
+} from './anon-write-contract-probe.mjs';
+
+export const EXIT = { OK: 0, ERROR: 1, CONTRACT_CHANGED: 2, PROBE_INCONCLUSIVE: 4, RLS_NOT_IN_FORCE: 5 };
+
+const TABLE = 'public.feedback';
+
+/**
+ * Narrowed to this table's single relevant privilege (INSERT) — mirrors venture-ingest-keys-anon-
+ * probe.mjs's own local `attribute` helper rather than reusing attributeRefusal, whose form-name
+ * switch is specific to that OTHER probe's different set of write forms (TR-3 names only
+ * assertNotCommitFamily/assertRlsInForce/classifyError as required reuse, not attributeRefusal).
+ */
+async function attribute(q, err) {
+  if (err?.code !== '42501') return null;
+  const { rows: [p] } = await q(
+    "select has_table_privilege(current_user, $1::regclass, 'INSERT') as ok",
+    [TABLE],
+  );
+  return p?.ok === false ? 'GRANT_DENIED(INSERT)' : 'POLICY_DENIED(INSERT)';
+}
+
+async function probe(client, q) {
+  await q('BEGIN');
+  try {
+    await q("set local statement_timeout = '10s'");
+    await q("set local lock_timeout = '1s'");
+
+    // T-5 discriminator: read BEFORE role-switch, via pg_policies presence — public.feedback
+    // always exists, unlike an additive table, so to_regclass cannot distinguish pre/post-apply.
+    const { rows: [pol] } = await q(
+      `select count(*)::int as n from pg_policies
+       where schemaname = 'public' and tablename = 'feedback' and policyname = 'telegram_bot_insert_feedback'`,
+    );
+    if (pol.n > 0) {
+      return {
+        code: EXIT.PROBE_INCONCLUSIVE,
+        reason: 'telegram_bot_insert_feedback is still present in pg_policies — the chairman-gated '
+          + 'migration is staged, not applied. This is NOT a pass; re-run this probe after ratification and apply.',
+      };
+    }
+
+    // Real, active venture for the positive-path (TS-2/TS-8) attempt — read while still on the
+    // connecting role, before the role-switch below; a plain read, not part of the anon proof.
+    const { rows: [venture] } = await q(
+      `select id from public.ventures
+       where deleted_at is null and coalesce(metadata->>'telemetry_ingestion_enabled', 'true') <> 'false'
+         and not public.check_feedback_rate_limit(id)
+       limit 1`,
+    );
+    if (!venture) {
+      return { code: EXIT.PROBE_INCONCLUSIVE, reason: 'no active venture found to exercise the TS-8 residual-path assertion' };
+    }
+
+    await q('set local role anon');
+    const { rows: [p] } = await q('select pg_backend_pid() as pid');
+
+    const rls = await assertRlsInForce(q, TABLE, p.pid);
+    if (!rls.ok) {
+      return { code: EXIT.RLS_NOT_IN_FORCE, reason: `RLS not in force before probing: ${rls.problems.join(', ')}` };
+    }
+
+    const observed = {};
+    const attributions = {};
+
+    // --- Bare telegram-sourced attempt (no venture_id, feedback_type NOT matching user_%) ---
+    // Every column public.feedback requires NOT NULL with no default (type, source_application,
+    // title) is populated — a probe verdict must reflect a real, insertable row shape, not an
+    // incomplete one that would fail on an unrelated constraint regardless of RLS.
+    await q('SAVEPOINT sp_bare');
+    try {
+      await q(
+        assertNotCommitFamily(
+          `insert into ${TABLE} (source_type, feedback_type, venture_id, type, source_application, title)
+           values ('telegram', 'sentry_error', NULL, 'issue', 'telegram-feedback-anon-probe', 'probe row')`,
+        ),
+      );
+      observed.bare_telegram = 'LANDS';
+      await q('ROLLBACK TO SAVEPOINT sp_bare');
+    } catch (err) {
+      await q('ROLLBACK TO SAVEPOINT sp_bare');
+      observed.bare_telegram = classifyError(err);
+      attributions.bare_telegram = (await attribute(q, err)) ?? `${observed.bare_telegram}(${err.code})`;
+    }
+
+    // --- TS-2/TS-8: venture_user_insert_feedback-satisfying attempt, source_type='telegram' ---
+    await q('SAVEPOINT sp_residual');
+    try {
+      await q(
+        assertNotCommitFamily(
+          `insert into ${TABLE} (source_type, feedback_type, venture_id, type, source_application, title)
+           values ('telegram', 'user_bug', $1, 'issue', 'telegram-feedback-anon-probe', 'probe row')`,
+        ),
+        [venture.id],
+      );
+      observed.residual_telegram_tagged_venture_owned = 'LANDS';
+      await q('ROLLBACK TO SAVEPOINT sp_residual');
+    } catch (err) {
+      await q('ROLLBACK TO SAVEPOINT sp_residual');
+      observed.residual_telegram_tagged_venture_owned = classifyError(err);
+    }
+
+    // --- Verdict ---
+    if (observed.bare_telegram === 'LANDS') {
+      return {
+        code: EXIT.CONTRACT_CHANGED,
+        reason: 'OPEN: the bare telegram-sourced anon INSERT unexpectedly LANDED — the fix is not in effect',
+        observed, attributions,
+      };
+    }
+    if (observed.residual_telegram_tagged_venture_owned !== 'LANDS') {
+      return {
+        code: EXIT.CONTRACT_CHANGED,
+        reason: 'REGRESSION: the venture_user_insert_feedback residual path (TS-8) no longer lands — '
+          + 'this looks like an over-broad drop, not the surgical fix this migration ships',
+        observed, attributions,
+      };
+    }
+    if (observed.bare_telegram !== 'REFUSED' || attributions.bare_telegram !== 'POLICY_DENIED(INSERT)') {
+      return {
+        code: EXIT.CONTRACT_CHANGED,
+        reason: `bare attempt refused but NOT attributed to the expected POLICY_DENIED(INSERT): ${attributions.bare_telegram} — `
+          + 'a GRANT_DENIED reading here would mean an over-broad REVOKE happened instead of the surgical DROP POLICY',
+        observed, attributions,
+      };
+    }
+
+    return {
+      code: EXIT.OK,
+      reason: 'bare telegram-sourced INSERT refused (POLICY_DENIED, grant present) AND the venture_user_insert_feedback '
+        + 'residual path still LANDS — the surgical fix is in effect',
+      observed, attributions,
+    };
+  } finally {
+    await q('ROLLBACK');
+  }
+}
+
+export async function main() {
+  let client = null;
+  try {
+    client = await createDatabaseClient('engineer',
+      process.env.DATABASE_URL ? { connectionString: process.env.DATABASE_URL } : {});
+    const q = (sql, params) => client.query(assertNotCommitFamily(sql), params);
+    const r = await probe(client, q);
+    console.log(`\n=== ${TABLE} telegram_bot_insert_feedback (FR-3/US-003 anon-probe) ===`);
+    for (const [form, verdict] of Object.entries(r.observed || {})) {
+      console.log(`  ${form.padEnd(38)} ${String(verdict).padEnd(20)} ${r.attributions?.[form] ?? ''}`);
+    }
+    console.log(`  -> [${Object.keys(EXIT).find((k) => EXIT[k] === r.code)}] ${r.reason}`);
+    return r.code;
+  } catch (err) {
+    console.error(`probe error: ${err.message}`);
+    return EXIT.ERROR;
+  } finally {
+    if (client) await client.end().catch(() => {});
+  }
+}
+
+const invokedDirectly = process.argv[1] && import.meta.url.endsWith(process.argv[1].replace(/\\/g, '/').split('/').pop());
+if (invokedDirectly) main().then((code) => process.exit(code));

--- a/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
+++ b/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
@@ -385,9 +385,25 @@ describe('TS-4a/TS-4b: the REAL $verify$ block (extracted from the migration fil
     await client.query('BEGIN');
     try {
       await client.query('DROP POLICY IF EXISTS anon_feedback_ingress_bounds ON public.feedback');
-      // Message text updated (SECURITY sub-agent finding, EXEC re-review, L1) to match the migration's
-      // cmd='INSERT' pin added to this same assertion.
-      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/anon_feedback_ingress_bounds is missing, no longer applies to INSERT, or is no longer RESTRICTIVE/);
+      // Message text updated (adversarial /ship review finding, this pass) to match the migration's
+      // roles predicate added to this same assertion.
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/anon_feedback_ingress_bounds is missing, no longer applies to INSERT, is no longer RESTRICTIVE, or no longer applies to the public role/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('[M1c] RAISEs if anon_feedback_ingress_bounds survives name+cmd+permissive but is re-scoped off the public role (adversarial /ship review finding: a name+cmd+permissive-only check would silently pass a policy stripped down to e.g. TO authenticated, which bounds nothing for anon)', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query('DROP POLICY IF EXISTS anon_feedback_ingress_bounds ON public.feedback');
+      await client.query(`
+        CREATE POLICY anon_feedback_ingress_bounds ON public.feedback
+          AS RESTRICTIVE
+          FOR INSERT TO authenticated
+          WITH CHECK (true);
+      `);
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/anon_feedback_ingress_bounds is missing, no longer applies to INSERT, is no longer RESTRICTIVE, or no longer applies to the public role/);
     } finally {
       await client.query('ROLLBACK');
     }

--- a/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
+++ b/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
@@ -181,12 +181,13 @@ describe('the migration applied', () => {
     expect(rows[0].relrowsecurity).toBe(true);
   });
 
-  it('anon_feedback_ingress_bounds remains present and RESTRICTIVE (M1, DATABASE sub-agent finding — it was NEVER a permissive fallback grant)', async () => {
+  it('anon_feedback_ingress_bounds remains present, applies to INSERT, and is RESTRICTIVE (M1, DATABASE sub-agent finding — it was NEVER a permissive fallback grant; cmd pin added per SECURITY sub-agent finding L1)', async () => {
     const { rows } = await client.query(`
-      SELECT permissive FROM pg_policies
+      SELECT cmd, permissive FROM pg_policies
       WHERE schemaname='public' AND tablename='feedback' AND policyname='anon_feedback_ingress_bounds'
     `);
     expect(rows).toHaveLength(1);
+    expect(rows[0].cmd).toBe('INSERT');
     expect(rows[0].permissive).toBe('RESTRICTIVE');
   });
 });
@@ -372,7 +373,9 @@ describe('TS-4a/TS-4b: the REAL $verify$ block (extracted from the migration fil
     await client.query('BEGIN');
     try {
       await client.query('DROP POLICY IF EXISTS anon_feedback_ingress_bounds ON public.feedback');
-      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/anon_feedback_ingress_bounds is missing or is no longer RESTRICTIVE/);
+      // Message text updated (SECURITY sub-agent finding, EXEC re-review, L1) to match the migration's
+      // cmd='INSERT' pin added to this same assertion.
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/anon_feedback_ingress_bounds is missing, no longer applies to INSERT, or is no longer RESTRICTIVE/);
     } finally {
       await client.query('ROLLBACK');
     }

--- a/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
+++ b/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
@@ -192,22 +192,23 @@ describe('the migration applied', () => {
   });
 });
 
+// Strips full-line `--` comments before matching (DATABASE sub-agent finding, EXEC review, B1),
+// hoisted for reuse (testing-agent finding, EXEC re-review, T-19): the migration's own header
+// prose names record_venture_error AND states "never a table-level REVOKE" in plain English — a
+// raw-text match against MIGRATION_SQL would false-fail on either mention, deterministically, with
+// no database needed. Applied to every text-only TR-1/TR-4 assertion below, not just one.
+const MIGRATION_CODE_ONLY = MIGRATION_SQL.replace(/^\s*--.*$/gm, '');
+
 describe('TR-1: mechanism is DROP POLICY, never a table-level REVOKE', () => {
   it('the file text uses DROP POLICY IF EXISTS and never REVOKEs the table-level grant', () => {
-    expect(MIGRATION_SQL).toMatch(/DROP POLICY IF EXISTS telegram_bot_insert_feedback ON public\.feedback/);
-    expect(MIGRATION_SQL).not.toMatch(/REVOKE\s+(ALL|INSERT)\s+ON\s+(TABLE\s+)?(public\.)?feedback/i);
+    expect(MIGRATION_CODE_ONLY).toMatch(/DROP POLICY IF EXISTS telegram_bot_insert_feedback ON public\.feedback/);
+    expect(MIGRATION_CODE_ONLY).not.toMatch(/REVOKE\s+(ALL|INSERT)\s+ON\s+(TABLE\s+)?(public\.)?feedback/i);
   });
 });
 
 describe('TR-4: migration file stays out of excluded scope', () => {
   it('never references record_venture_error in executable SQL (comments are exempt — the header deliberately documents this exclusion, US-005/FR-5)', () => {
-    // Strips full-line `--` comments before matching (DATABASE sub-agent finding, EXEC review,
-    // B1): the header's own SCOPE-exclusion paragraph names record_venture_error by design, and a
-    // raw-text match against MIGRATION_SQL fails on that prose every time, deterministically, with
-    // no database needed — this is exactly the "I could not get a real green run locally" gap that
-    // concealed it.
-    const codeOnly = MIGRATION_SQL.replace(/^\s*--.*$/gm, '');
-    expect(codeOnly).not.toMatch(/record_venture_error/);
+    expect(MIGRATION_CODE_ONLY).not.toMatch(/record_venture_error/);
   });
 
   it('never CREATEs/ALTERs/DROPs venture_user_insert_feedback', () => {
@@ -222,14 +223,25 @@ describe('TS-1/TS-6: bare telegram-sourced anon INSERT is rejected post-migratio
     // which is also 42501 but a DIFFERENT message ("permission denied for table ..."). Asserting
     // the live-measured RLS message text closes that gap — confirmed live against the real
     // instance (via a rolled-back simulation, never committed) before pinning this string.
+    // CORRECTED (testing-agent finding, EXEC re-review, T-17): `toMatchObject({message: /regex/})`
+    // does NOT apply the regex as a matcher against a string property under this repo's vitest —
+    // it was silently ignored, so this assertion was equivalent to a bare `code: '42501'` check
+    // despite its comment claiming otherwise. Explicit try/catch enforces both properties for real
+    // (verified: a `permission denied for table` message now genuinely fails this assertion).
     await client.query('BEGIN');
     try {
       await client.query('SET LOCAL ROLE anon');
-      await expect(
-        client.query(
+      let err;
+      try {
+        await client.query(
           `INSERT INTO public.feedback (source_type, feedback_type, venture_id) VALUES ('telegram', 'sentry_error', NULL)`,
-        ),
-      ).rejects.toMatchObject({ code: '42501', message: /row-level security policy/ });
+        );
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeTruthy();
+      expect(err.code).toBe('42501');
+      expect(err.message).toMatch(/row-level security policy/);
     } finally {
       await client.query('ROLLBACK');
     }

--- a/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
+++ b/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
@@ -1,0 +1,384 @@
+// SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001 — the DDL tier for
+// database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql.
+//
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+// WHAT A GREEN RUN OF THIS FILE DOES **NOT** MEAN
+//
+// This runs against an EPHEMERAL vanilla PostgreSQL 16 with hand-stubbed roles AND a hand-stubbed
+// public.feedback/public.ventures pair, reproduced only as far as this migration's own DROP POLICY
+// and $verify$ block touch them. `SET LOCAL ROLE anon` inside a rolled-back transaction proves the
+// SQL-level RLS logic (which policy authorizes which row shape) — it does NOT prove the real
+// production grant surface, Supabase's ALTER DEFAULT PRIVILEGES posture, or the PostgREST schema
+// cache. The genuine "reachable over the real anon key" claim (TS-5/TS-6/TS-8) is Tier C's job
+// (scripts/telegram-feedback-anon-probe.mjs), not here. Read a passing run here as "the migration's
+// own DROP + $verify$ logic does what it claims", not as "the migration is safe to apply".
+//
+// FAIL-CLOSED, no skip branch: if this file cannot reach a database it fails loudly rather than
+// silently passing (matches tests/ddl/venture-ingest-key-binding-ddl.db.test.js's own convention).
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+
+const MIGRATION_PATH = fileURLToPath(
+  new URL('../../database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql', import.meta.url),
+);
+const MIGRATION_SQL = fs.readFileSync(MIGRATION_PATH, 'utf8');
+
+// Extracted from the REAL migration file text, not hand-copied — mutation tests below run the
+// actual $verify$ block this migration ships, so they cannot silently drift from what applies.
+function extractVerifyBlock(sql) {
+  // Anchored to start-of-line: the migration's own header prose mentions "DO $verify$" inside a
+  // comment (the L3 tooling-gap note), which a plain indexOf would find INSTEAD of the real
+  // statement opener, extracting the wrong (and syntactically invalid) slice.
+  const startMatch = /^DO \$verify\$$/m.exec(sql);
+  const marker = '$verify$;';
+  const markerIdx = startMatch ? sql.indexOf(marker, startMatch.index) : -1;
+  if (!startMatch || markerIdx === -1) {
+    throw new Error('could not locate DO $verify$ ... $verify$; block in migration SQL');
+  }
+  return sql.slice(startMatch.index, markerIdx + marker.length);
+}
+const VERIFY_BLOCK_SQL = extractVerifyBlock(MIGRATION_SQL);
+
+// Minimal stand-ins for the parts of the real schema this migration's DROP POLICY and $verify$
+// block read: the two pre-existing anon INSERT policies on public.feedback, the table-level anon
+// INSERT grant, and the two functions venture_user_insert_feedback's WITH CHECK calls (needed so
+// CREATE POLICY itself can resolve them).
+const STUB_SCHEMA = `
+DO $roles$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role')  THEN CREATE ROLE service_role NOLOGIN;  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon')          THEN CREATE ROLE anon NOLOGIN;          END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN CREATE ROLE authenticated NOLOGIN; END IF;
+END
+$roles$;
+
+CREATE TABLE IF NOT EXISTS public.ventures (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  deleted_at TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS public.feedback (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  feedback_type VARCHAR NOT NULL DEFAULT 'sentry_error',
+  source_type VARCHAR NOT NULL,
+  venture_id UUID,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+ALTER TABLE public.feedback ENABLE ROW LEVEL SECURITY;
+GRANT INSERT ON public.feedback TO anon;
+-- No explicit grant on public.ventures for the connecting role: it is that role's own table (table
+-- owner has full privileges regardless of grants), and the CI container's bootstrap superuser is
+-- named per POSTGRES_USER (ddl_runner), never literally "postgres" — granting to a hardcoded
+-- "postgres" role does not exist there and makes beforeAll fail with 42704 (DATABASE sub-agent
+-- finding, EXEC review, B2).
+
+-- SECURITY DEFINER, matching the LIVE function exactly (confirmed via pg_get_functiondef before
+-- authoring this stub) — without it, evaluating venture_exists_and_active(...) under SET LOCAL
+-- ROLE anon reads public.ventures with ANON's own privileges, which have no grant on it, turning
+-- TS-2/TS-8 into a false permission-denied that looks like (but is not) the over-broad-drop
+-- regression they exist to detect (DATABASE sub-agent finding, EXEC review, B3).
+CREATE OR REPLACE FUNCTION public.venture_exists_and_active(p_venture_id UUID)
+RETURNS BOOLEAN LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT EXISTS (SELECT 1 FROM public.ventures v WHERE v.id = p_venture_id AND v.deleted_at IS NULL);
+$$;
+
+-- SECURITY DEFINER for the same reason/fidelity, even though this stub's trivial body (a constant)
+-- does not itself require it today.
+CREATE OR REPLACE FUNCTION public.check_feedback_rate_limit(p_venture_id UUID)
+RETURNS BOOLEAN LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$ SELECT false; $$;
+
+-- Pre-existing, mirrors live state BEFORE this migration runs.
+CREATE POLICY telegram_bot_insert_feedback ON public.feedback
+  FOR INSERT TO anon
+  WITH CHECK (source_type = 'telegram');
+
+CREATE POLICY venture_user_insert_feedback ON public.feedback
+  FOR INSERT TO anon
+  WITH CHECK (
+    feedback_type LIKE 'user_%'
+    AND venture_id IS NOT NULL
+    AND venture_exists_and_active(venture_id)
+    AND (NOT check_feedback_rate_limit(venture_id))
+  );
+
+-- RESTRICTIVE, WITH CHECK(true) — the stub does not reproduce this policy's real content/rate
+-- bounds (that is Tier C's job, live), it exists ONLY so the migration's own $verify$ block (which
+-- now asserts this policy is present and RESTRICTIVE, DATABASE sub-agent finding M1) does not
+-- spuriously RAISE on this ephemeral database. Always-true, so it never changes any other test's
+-- observable behavior below.
+CREATE POLICY anon_feedback_ingress_bounds ON public.feedback
+  AS RESTRICTIVE
+  FOR INSERT TO public
+  WITH CHECK (true);
+`;
+
+let client;
+
+async function applyMigration() {
+  await client.query(MIGRATION_SQL);
+}
+
+async function makeVenture() {
+  const { rows } = await client.query('INSERT INTO public.ventures DEFAULT VALUES RETURNING id');
+  return rows[0].id;
+}
+
+beforeAll(async () => {
+  client = new pg.Client({
+    host: process.env.PGHOST || '127.0.0.1',
+    port: Number(process.env.PGPORT || 5432),
+    database: process.env.PGDATABASE || 'ddl_check',
+    user: process.env.PGUSER || 'postgres',
+    password: process.env.PGPASSWORD || 'postgres',
+  });
+  await client.connect();
+  await client.query(STUB_SCHEMA);
+  await applyMigration();
+}, 60_000);
+
+afterAll(async () => {
+  if (client) await client.end();
+});
+
+describe('the migration applied', () => {
+  it('telegram_bot_insert_feedback is gone from pg_policies', async () => {
+    const { rows } = await client.query(`
+      SELECT policyname FROM pg_policies
+      WHERE schemaname='public' AND tablename='feedback' AND policyname='telegram_bot_insert_feedback'
+    `);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('anon retains table-level INSERT privilege on feedback (grant not collaterally revoked, TR-1/TR-2)', async () => {
+    const { rows } = await client.query(`SELECT has_table_privilege('anon','public.feedback','INSERT') AS ok`);
+    expect(rows[0].ok).toBe(true);
+  });
+
+  it('venture_user_insert_feedback survives with its WITH CHECK clause unchanged', async () => {
+    const { rows } = await client.query(`
+      SELECT with_check FROM pg_policies
+      WHERE schemaname='public' AND tablename='feedback' AND policyname='venture_user_insert_feedback'
+    `);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].with_check).toMatch(/venture_exists_and_active/);
+    expect(rows[0].with_check).toMatch(/check_feedback_rate_limit/);
+  });
+
+  it('[TS-3] re-applying the full migration file is idempotent', async () => {
+    await applyMigration();
+  });
+
+  it('public.feedback still has RLS enabled (M1, DATABASE sub-agent finding)', async () => {
+    const { rows } = await client.query(`SELECT relrowsecurity FROM pg_class WHERE oid = 'public.feedback'::regclass`);
+    expect(rows[0].relrowsecurity).toBe(true);
+  });
+
+  it('anon_feedback_ingress_bounds remains present and RESTRICTIVE (M1, DATABASE sub-agent finding — it was NEVER a permissive fallback grant)', async () => {
+    const { rows } = await client.query(`
+      SELECT permissive FROM pg_policies
+      WHERE schemaname='public' AND tablename='feedback' AND policyname='anon_feedback_ingress_bounds'
+    `);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].permissive).toBe('RESTRICTIVE');
+  });
+});
+
+describe('TR-1: mechanism is DROP POLICY, never a table-level REVOKE', () => {
+  it('the file text uses DROP POLICY IF EXISTS and never REVOKEs the table-level grant', () => {
+    expect(MIGRATION_SQL).toMatch(/DROP POLICY IF EXISTS telegram_bot_insert_feedback ON public\.feedback/);
+    expect(MIGRATION_SQL).not.toMatch(/REVOKE\s+(ALL|INSERT)\s+ON\s+(TABLE\s+)?(public\.)?feedback/i);
+  });
+});
+
+describe('TR-4: migration file stays out of excluded scope', () => {
+  it('never references record_venture_error in executable SQL (comments are exempt — the header deliberately documents this exclusion, US-005/FR-5)', () => {
+    // Strips full-line `--` comments before matching (DATABASE sub-agent finding, EXEC review,
+    // B1): the header's own SCOPE-exclusion paragraph names record_venture_error by design, and a
+    // raw-text match against MIGRATION_SQL fails on that prose every time, deterministically, with
+    // no database needed — this is exactly the "I could not get a real green run locally" gap that
+    // concealed it.
+    const codeOnly = MIGRATION_SQL.replace(/^\s*--.*$/gm, '');
+    expect(codeOnly).not.toMatch(/record_venture_error/);
+  });
+
+  it('never CREATEs/ALTERs/DROPs venture_user_insert_feedback', () => {
+    expect(MIGRATION_SQL).not.toMatch(/(CREATE|ALTER|DROP)\s+POLICY\s+(IF EXISTS\s+)?venture_user_insert_feedback/i);
+  });
+});
+
+describe('TS-1/TS-6: bare telegram-sourced anon INSERT is rejected post-migration (POLICY_DENIED shape: grant present, policy absent)', () => {
+  it('a bare telegram-sourced row (no venture_id, non-user feedback_type) is refused with an RLS policy violation, not merely SOME 42501', async () => {
+    // TIGHTENED (testing-agent finding, EXEC review, T-16): a bare `code: '42501'` match cannot
+    // distinguish an RLS-policy refusal (what this test claims) from a missing-grant refusal,
+    // which is also 42501 but a DIFFERENT message ("permission denied for table ..."). Asserting
+    // the live-measured RLS message text closes that gap — confirmed live against the real
+    // instance (via a rolled-back simulation, never committed) before pinning this string.
+    await client.query('BEGIN');
+    try {
+      await client.query('SET LOCAL ROLE anon');
+      await expect(
+        client.query(
+          `INSERT INTO public.feedback (source_type, feedback_type, venture_id) VALUES ('telegram', 'sentry_error', NULL)`,
+        ),
+      ).rejects.toMatchObject({ code: '42501', message: /row-level security policy/ });
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('[T-11 control] the IDENTICAL row LANDS if telegram_bot_insert_feedback is put back — the refusal above is caused by the drop, not by some other property of this row shape', async () => {
+    // Testing-agent finding (EXEC review, T-11, independently re-measured live against production
+    // and offered as corroboration): TS-1 alone asserts a STATE (refused post-migration) but not
+    // CAUSATION (refused BECAUSE the policy is gone, not because this row shape could never have
+    // landed). Recreating the already-dropped policy inside a rolled-back sub-transaction proves
+    // the same exact statement that just failed above would have succeeded pre-migration.
+    await client.query('BEGIN');
+    try {
+      await client.query(`
+        CREATE POLICY telegram_bot_insert_feedback ON public.feedback
+          FOR INSERT TO anon WITH CHECK (source_type = 'telegram')
+      `);
+      await client.query('SET LOCAL ROLE anon');
+      // No RETURNING here either — telegram_bot_select_feedback would cover this specific row
+      // (source_type='telegram'), but confirming via a privileged read after RESET ROLE keeps this
+      // test's proof mechanism uniform with TS-2/TS-8 above rather than depending on it.
+      await client.query(
+        `INSERT INTO public.feedback (source_type, feedback_type, venture_id) VALUES ('telegram', 'sentry_error', NULL)`,
+      );
+      await client.query('RESET ROLE');
+      const { rows } = await client.query(
+        `SELECT id FROM public.feedback WHERE source_type = 'telegram' AND feedback_type = 'sentry_error' AND venture_id IS NULL`,
+      );
+      expect(rows.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+});
+
+describe('TS-2/TS-8: the venture_user_insert_feedback residual path still lands post-migration (deliberate, not a fix failure)', () => {
+  // NEITHER case uses RETURNING (live-measured correction, this pass): an auto_capture-sourced row
+  // has NO matching anon SELECT policy (telegram_bot_select_feedback covers only
+  // source_type='telegram' — the exact "asymmetric case" scripts/security/rls-feedback-live-
+  // probe.cjs's own header documents), so `INSERT ... RETURNING` for TS-2 throws 42501 even though
+  // the INSERT itself is fully authorized — confirmed live against production before writing this.
+  // That is a DIFFERENT policy dimension (SELECT coverage) than what TS-2/TS-8 test (INSERT
+  // authorization), so both cases confirm landing via a privileged read after RESET ROLE instead.
+  it('[TS-2] a valid venture-owned user_% submission succeeds regardless of source_type', async () => {
+    const ventureId = await makeVenture();
+    await client.query('BEGIN');
+    try {
+      await client.query('SET LOCAL ROLE anon');
+      await client.query(
+        `INSERT INTO public.feedback (source_type, feedback_type, venture_id) VALUES ('auto_capture', 'user_bug', $1)`,
+        [ventureId],
+      );
+      await client.query('RESET ROLE');
+      const { rows } = await client.query(
+        `SELECT id FROM public.feedback WHERE venture_id = $1 AND source_type = 'auto_capture'`,
+        [ventureId],
+      );
+      expect(rows).toHaveLength(1);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('[TS-8] the SAME shape with source_type=telegram ALSO still lands — the intended residual path, not a regression', async () => {
+    const ventureId = await makeVenture();
+    await client.query('BEGIN');
+    try {
+      await client.query('SET LOCAL ROLE anon');
+      await client.query(
+        `INSERT INTO public.feedback (source_type, feedback_type, venture_id) VALUES ('telegram', 'user_bug', $1)`,
+        [ventureId],
+      );
+      await client.query('RESET ROLE');
+      const { rows } = await client.query(
+        `SELECT id FROM public.feedback WHERE venture_id = $1 AND source_type = 'telegram'`,
+        [ventureId],
+      );
+      expect(rows).toHaveLength(1);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+});
+
+describe('TS-4a/TS-4b: the REAL $verify$ block (extracted from the migration file, not hand-copied) is mutation-resistant', () => {
+  it('[TS-4a] RAISEs if the target policy were NOT actually dropped', async () => {
+    await client.query('BEGIN');
+    try {
+      // Simulate "the DROP did not happen": recreate the policy this beforeAll already dropped.
+      await client.query(`
+        CREATE POLICY telegram_bot_insert_feedback ON public.feedback
+          FOR INSERT TO anon WITH CHECK (source_type = 'telegram')
+      `);
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/telegram_bot_insert_feedback still present/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('[TS-4b] RAISEs if the sibling policy were ALSO dropped (over-broad drop)', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query('DROP POLICY IF EXISTS venture_user_insert_feedback ON public.feedback');
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/venture_user_insert_feedback is missing/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('[M2a] RAISEs if the table-level anon-INSERT grant is collaterally REVOKEd instead of DROP POLICY being used (DATABASE sub-agent finding)', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query('REVOKE INSERT ON public.feedback FROM anon');
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/lost table-level INSERT privilege/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('[M2b] RAISEs if the sibling policy is left in place but its WITH CHECK is silently altered (DATABASE sub-agent finding)', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query('ALTER POLICY venture_user_insert_feedback ON public.feedback WITH CHECK (true)');
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/WITH CHECK text changed unexpectedly/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('[M1a] RAISEs if RLS is disabled on public.feedback (DATABASE sub-agent finding)', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query('ALTER TABLE public.feedback DISABLE ROW LEVEL SECURITY');
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/does not have RLS enabled/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('[M1b] RAISEs if anon_feedback_ingress_bounds is dropped or stops being RESTRICTIVE (DATABASE sub-agent finding)', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query('DROP POLICY IF EXISTS anon_feedback_ingress_bounds ON public.feedback');
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/anon_feedback_ingress_bounds is missing or is no longer RESTRICTIVE/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('does NOT raise in the correct post-migration state (two-sided — a verify block strict enough to always fail would never catch a REAL regression)', async () => {
+    await expect(client.query(VERIFY_BLOCK_SQL)).resolves.toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Chairman-gated migration (staged, NOT applied) that `DROP POLICY IF EXISTS telegram_bot_insert_feedback ON public.feedback` — the only anon-writable INSERT path on this table with zero venture predicate at all.
- Ships with a 5-way mutation-resistant `$verify$` block, a Tier A DDL test (20 cases, CI-only via `.github/workflows/drive-reports-ddl.yml`'s path filter), and a Tier C live anon-role probe (`scripts/telegram-feedback-anon-probe.mjs`).
- Fixes two previously-invisible bugs in the pre-existing `scripts/security/rls-feedback-live-probe.cjs` (wrong `exec_sql` RPC parameter name; wrong response-shape unwrap) that meant its drift guard had never actually executed despite claiming "TEETH".

## Corrected scope (important)
An earlier draft of this SD claimed `anon_feedback_ingress_bounds` was PERMISSIVE and already permitted the abuse this migration targets. That was wrong — live-measured via `pg_policies.permissive`, it is RESTRICTIVE, and RESTRICTIVE policies never authorize anything by themselves (they only narrow an existing PERMISSIVE grant). This was independently caught by all three EXEC-phase sub-agents (database, testing, security) and corrected across the migration header, PRD, and SD description.

**What this DOES close:** the only anon INSERT path on `public.feedback` with no venture predicate at all — pre-drop, any anon-key holder could write an arbitrary or absent `venture_id` merely by tagging `source_type='telegram'`.

**What this does NOT close:** true venture-ID spoofing. `venture_user_insert_feedback`'s `venture_exists_and_active()` check is existence-only, not ownership — an anon caller can still attribute a `user_%` feedback row to any real, active venture it can guess. That gap is tracked separately (routed to Adam, advisory correction sent this session) and is explicitly out of scope here.

## Test plan
- [x] Migration live-validated via safe `BEGIN...ROLLBACK`-only dry runs against production (happy path, forced-negative mutations for all 5 `$verify$` assertions, idempotent re-run) — nothing ever committed, live state confirmed unchanged after.
- [x] Tier C probe run live pre-apply: correctly returns `PROBE_INCONCLUSIVE`.
- [x] Fixed `rls-feedback-live-probe.cjs` run live: all 5 cases pass against the current (pre-apply) instance.
- [ ] Tier A DDL test: collects cleanly (20 tests), fails closed with `ECONNREFUSED` locally (no Postgres available in this environment) — needs one green CI run via the `postgres:16` service container in `drive-reports-ddl.yml`.
- [ ] Chairman review and apply (this migration is staged only, per convention — no `@approved-by` stamp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)