### PR TITLE
fix(QF-20260813-683): self-heal coordinator_liveness metadata drift on a recurring cadence

### DIFF
--- a/lib/coordinator/resolve.cjs
+++ b/lib/coordinator/resolve.cjs
@@ -408,6 +408,46 @@ async function assertCoordinatorRpcsExist(supabase) {
   }
 }
 
+/**
+ * QF-20260813-683: idempotently re-stamp THIS session's metadata.is_coordinator=true, without
+ * touching drain/retire/succession/pointer-file state (unlike the full setActiveCoordinator).
+ * Extracted from setActiveCoordinator's own Step 2 below (byte-identical behavior, now shared)
+ * so a recurring cadence script can self-heal the flag if it silently drops mid-session —
+ * observed live: an active 17h+ coordinator lost metadata.is_coordinator with no traced write
+ * path, causing adam-coordinator-health.mjs's coordinator_liveness probe to false-negative as
+ * no_coordinator_row even though the file-based active-coordinator.json pointer stayed intact.
+ * FAIL-OPEN: never throws.
+ * @param {object} supabase
+ * @param {string} sessionId
+ */
+async function refreshCoordinatorFlag(supabase, sessionId) {
+  try {
+    const { error: setErr } = await supabase.rpc('set_coordinator_flag', { p_session_id: sessionId });
+    if (setErr) {
+      // SD-LEO-INFRA-COORDINATOR-FLAG-RPC-FALLBACK-001 (FR-1): if the RPC is ABSENT (unapplied
+      // migration), fall back to the read-merge-write upsert so registration self-heals instead
+      // of silently skipping the is_coordinator write.
+      if (isFunctionNotFoundError(setErr)) {
+        console.warn(`   ⚠️  [COORD_REGISTER_FALLBACK] set_coordinator_flag RPC absent (${setErr.message}); using read-merge-write upsert (no atomicity — apply the atomic-coordinator-flag migration) (non-fatal)`);
+        await upsertCoordinatorMetadata(supabase, sessionId);
+      } else {
+        console.warn(`   ⚠️  [COORD_REGISTER_FAILED] set_coordinator_flag(${sessionId}): ${setErr.message} (non-fatal)`);
+      }
+    }
+  } catch (e) {
+    // A THROW (not a returned error) on a missing RPC also routes to the fallback.
+    if (isFunctionNotFoundError(e)) {
+      console.warn(`   ⚠️  [COORD_REGISTER_FALLBACK] set_coordinator_flag RPC absent (${(e && e.message) || e}); using read-merge-write upsert (no atomicity) (non-fatal)`);
+      try { await upsertCoordinatorMetadata(supabase, sessionId); } catch (e2) {
+        console.warn(`   ⚠️  [COORD_REGISTER_FALLBACK_THREW] ${(e2 && e2.message) || e2} (non-fatal)`);
+      }
+    } else {
+      console.warn(`   ⚠️  [COORD_REGISTER_THREW] set_coordinator_flag(${sessionId}): ${(e && e.message) || e} (non-fatal)`);
+    }
+    /* fail-open */
+  }
+}
+
 async function setActiveCoordinator(supabase, sessionId) {
   if (!sessionId || typeof sessionId !== 'string') {
     throw new Error('setActiveCoordinator: sessionId required');
@@ -494,31 +534,10 @@ async function setActiveCoordinator(supabase, sessionId) {
   //   object — concurrent writers must not clobber each other's sibling keys.
   // Finding 3 (LOW observability): capture {error} and console.warn so a failed singleton-identity
   //   register is observable. FAIL-OPEN: never throw.
-  try {
-    const { error: setErr } = await supabase.rpc('set_coordinator_flag', { p_session_id: sessionId });
-    if (setErr) {
-      // SD-LEO-INFRA-COORDINATOR-FLAG-RPC-FALLBACK-001 (FR-1): if the RPC is ABSENT (unapplied
-      // migration), fall back to the read-merge-write upsert so startup self-registers instead of
-      // silently skipping the is_coordinator write and tripping the Step 6 registration gate.
-      if (isFunctionNotFoundError(setErr)) {
-        console.warn(`   ⚠️  [COORD_REGISTER_FALLBACK] set_coordinator_flag RPC absent (${setErr.message}); using read-merge-write upsert (no atomicity — apply the atomic-coordinator-flag migration) (non-fatal)`);
-        await upsertCoordinatorMetadata(supabase, sessionId);
-      } else {
-        console.warn(`   ⚠️  [COORD_REGISTER_FAILED] set_coordinator_flag(${sessionId}): ${setErr.message} (non-fatal)`);
-      }
-    }
-  } catch (e) {
-    // A THROW (not a returned error) on a missing RPC also routes to the fallback.
-    if (isFunctionNotFoundError(e)) {
-      console.warn(`   ⚠️  [COORD_REGISTER_FALLBACK] set_coordinator_flag RPC absent (${(e && e.message) || e}); using read-merge-write upsert (no atomicity) (non-fatal)`);
-      try { await upsertCoordinatorMetadata(supabase, sessionId); } catch (e2) {
-        console.warn(`   ⚠️  [COORD_REGISTER_FALLBACK_THREW] ${(e2 && e2.message) || e2} (non-fatal)`);
-      }
-    } else {
-      console.warn(`   ⚠️  [COORD_REGISTER_THREW] set_coordinator_flag(${sessionId}): ${(e && e.message) || e} (non-fatal)`);
-    }
-    /* fail-open */
-  }
+  // QF-20260813-683: the atomic-RPC-with-fallback stamp itself now lives in refreshCoordinatorFlag
+  // (shared with the recurring cadence self-heal call in coordinator-quiet-tick.mjs) — behavior
+  // here is byte-identical to before the extraction.
+  await refreshCoordinatorFlag(supabase, sessionId);
 
   // Step 2b (QF-20260727-088): now that this session is registered as coordinator, drop any stale
   // worker callsign the identity cron stamped on it. Deliberately placed AFTER step 2 and BEFORE
@@ -657,6 +676,7 @@ module.exports = {
   isUsableSessionId,
   getActiveCoordinatorId,
   setActiveCoordinator,
+  refreshCoordinatorFlag,
   clearActiveCoordinator,
   // SD-LEO-INFRA-ROLE-SESSION-HANDOFF-PROTOCOL-001-A (additive, flag-gated) — exported for
   // coordination-events.cjs auto-resolve (FR-2) and tests (TS-1/TS-2/TS-3).

--- a/scripts/coordinator-quiet-tick.mjs
+++ b/scripts/coordinator-quiet-tick.mjs
@@ -34,7 +34,7 @@ const { assessFleetActivity } = require('../lib/coordinator/fleet-quiescence.cjs
 const { decideCadence, detectSalientDelta, runCoresFailSoft } = require('../lib/coordinator/quiet-tick.cjs');
 // QF-20260725-342: single source of truth for the resurface threshold (see that module's header).
 const { thresholdArgs } = require('../lib/coordination/resurface-threshold.cjs');
-const { getActiveCoordinatorId } = require('../lib/coordinator/resolve.cjs');
+const { getActiveCoordinatorId, refreshCoordinatorFlag } = require('../lib/coordinator/resolve.cjs');
 const { hasUndeliveredChairmanEscalation } = require('../lib/coordinator/undelivered-escalation.cjs');
 // QF-20260719-138: emit the cross-party ping row ourselves (mechanical, byte-identical) rather
 // than instructing the coordinator to hand-insert it every tick (that tripped the RCA 3x guard).
@@ -294,9 +294,35 @@ export async function hasOutstandingChairmanDirective(sb) {
   }
 }
 
+/**
+ * QF-20260813-683: self-heal metadata.is_coordinator if THIS session IS the resolved active
+ * coordinator but its DB row's flag has silently drifted false (observed: a long session lost
+ * the stamp with no traced write path, causing a false coordinator_liveness no_coordinator_row
+ * even though the file-based active-coordinator.json pointer stayed intact). Guarded on session
+ * identity match against the file-pointer-authoritative resolver — this can only ever refresh an
+ * already-active coordinator's own flag, never promote a worker. Fail-soft: never throws.
+ * Deps are injectable so this is testable without a real DB.
+ * @returns {Promise<boolean>} true iff the refresh fired
+ */
+export async function selfHealCoordinatorFlag(sb, {
+  sessionId = process.env.CLAUDE_SESSION_ID,
+  getActiveCoordinatorIdFn = getActiveCoordinatorId,
+  refreshFn = refreshCoordinatorFlag,
+} = {}) {
+  try {
+    if (sessionId && (await getActiveCoordinatorIdFn(sb)) === sessionId) {
+      await refreshFn(sb, sessionId);
+      return true;
+    }
+  } catch { /* fail-soft — self-heal must never block the tick */ }
+  return false;
+}
+
 async function main() {
   const asJson = process.argv.includes('--json');
   const sb = makeClient();
+
+  await selfHealCoordinatorFlag(sb);
 
   // FR-5: mode decision from the canonical quiescence gate (do not re-derive).
   let quiescent = false;

--- a/tests/unit/coordinator/coordinator-flag-self-heal.test.js
+++ b/tests/unit/coordinator/coordinator-flag-self-heal.test.js
@@ -1,0 +1,121 @@
+/**
+ * QF-20260813-683 — coordinator_liveness false-negatives (no_coordinator_row) after
+ * long-session metadata drift.
+ *
+ * Root cause: setActiveCoordinator() stamps claude_sessions.metadata.is_coordinator=true
+ * ONCE, at initial registration. Nothing re-stamps it afterward. Verified live: an active,
+ * ~17h-running coordinator session had metadata.is_coordinator undefined (exact drift
+ * mechanism untraced — candidates include a non-merging metadata write elsewhere, or
+ * session-row recreation across a context-compaction restore), even though the file-based
+ * active-coordinator.json pointer correctly still named it. adam-coordinator-health.mjs's
+ * coordinator_liveness probe queries metadata->>is_coordinator='true' directly (by design,
+ * to independently verify the DB-side flag rather than trust the pointer) — so the drift
+ * produced a false "no_coordinator_row" alarm on a genuinely healthy coordinator.
+ *
+ * Fix, two pieces:
+ *   1. refreshCoordinatorFlag() (lib/coordinator/resolve.cjs) — the atomic-RPC-with-fallback
+ *      stamp, EXTRACTED from setActiveCoordinator's own Step 2 so it's independently callable
+ *      without re-running drain/retire/succession/pointer-file logic.
+ *   2. selfHealCoordinatorFlag() (scripts/coordinator-quiet-tick.mjs) — calls #1 every tick,
+ *      GUARDED on session-identity match against the authoritative resolver so it can only
+ *      ever refresh an ALREADY-active coordinator's own flag, never promote a worker.
+ *
+ * Test strategy: both functions take injectable deps (or a plain fake supabase client), so
+ * this is fully unit-testable without a live DB — matching the established pattern in
+ * tests/unit/coordinator-flag-rpc-fallback.test.js (which already covers the underlying
+ * atomic-RPC-with-fallback behavior THROUGH setActiveCoordinator; this file adds direct
+ * coverage of the extracted function plus the new self-heal guard, which that file predates).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+import { selfHealCoordinatorFlag } from '../../../scripts/coordinator-quiet-tick.mjs';
+
+const req = createRequire(import.meta.url);
+const { refreshCoordinatorFlag } = req('../../../lib/coordinator/resolve.cjs');
+
+function makeSupabase({ rpcImpl, sessionRow = null }) {
+  const calls = { rpc: [], upserts: [] };
+  return {
+    rpc: async (name, args) => { calls.rpc.push({ name, args }); return rpcImpl(name, args); },
+    from() {
+      const builder = {
+        select: () => builder,
+        eq: () => builder,
+        maybeSingle: async () => ({ data: sessionRow, error: null }),
+        upsert: (payload) => { calls.upserts.push(payload); return Promise.resolve({ data: null, error: null }); },
+      };
+      return builder;
+    },
+    _calls: calls,
+  };
+}
+
+describe('refreshCoordinatorFlag (extracted from setActiveCoordinator Step 2)', () => {
+  it('uses the atomic RPC when present — no fallback upsert', async () => {
+    const sb = makeSupabase({ rpcImpl: () => ({ error: null }) });
+    await refreshCoordinatorFlag(sb, 'sess-atomic');
+    expect(sb._calls.rpc).toEqual([{ name: 'set_coordinator_flag', args: { p_session_id: 'sess-atomic' } }]);
+    expect(sb._calls.upserts).toHaveLength(0);
+  });
+
+  it('falls back to the read-merge-write upsert when the RPC is absent (unapplied migration)', async () => {
+    const sb = makeSupabase({
+      rpcImpl: () => ({ error: { code: 'PGRST202', message: 'Could not find the function' } }),
+      sessionRow: { metadata: { existing: 'keep' } },
+    });
+    await refreshCoordinatorFlag(sb, 'sess-fallback');
+    expect(sb._calls.upserts).toHaveLength(1);
+    expect(sb._calls.upserts[0].metadata).toMatchObject({ is_coordinator: true, existing: 'keep' });
+  });
+
+  it('is fail-open: a thrown RPC error never propagates', async () => {
+    const sb = makeSupabase({ rpcImpl: () => { throw new Error('network blip'); } });
+    await expect(refreshCoordinatorFlag(sb, 'sess-throw')).resolves.toBeUndefined();
+  });
+});
+
+describe('selfHealCoordinatorFlag (QF-20260813-683 guard)', () => {
+  it('refreshes when THIS session IS the resolved active coordinator', async () => {
+    const refreshFn = vi.fn().mockResolvedValue(undefined);
+    const result = await selfHealCoordinatorFlag({}, {
+      sessionId: 'coord-abc',
+      getActiveCoordinatorIdFn: async () => 'coord-abc',
+      refreshFn,
+    });
+    expect(result).toBe(true);
+    expect(refreshFn).toHaveBeenCalledWith({}, 'coord-abc');
+  });
+
+  it('REGRESSION CONTROL: does NOT refresh (or promote) a worker session', async () => {
+    const refreshFn = vi.fn();
+    const result = await selfHealCoordinatorFlag({}, {
+      sessionId: 'worker-xyz',
+      getActiveCoordinatorIdFn: async () => 'coord-abc', // a DIFFERENT session is coordinator
+      refreshFn,
+    });
+    expect(result).toBe(false);
+    expect(refreshFn).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when CLAUDE_SESSION_ID is unset', async () => {
+    const refreshFn = vi.fn();
+    const result = await selfHealCoordinatorFlag({}, {
+      sessionId: undefined,
+      getActiveCoordinatorIdFn: async () => 'coord-abc',
+      refreshFn,
+    });
+    expect(result).toBe(false);
+    expect(refreshFn).not.toHaveBeenCalled();
+  });
+
+  it('fail-soft: an identity-resolution error never throws or blocks the tick', async () => {
+    const refreshFn = vi.fn();
+    const result = await selfHealCoordinatorFlag({}, {
+      sessionId: 'coord-abc',
+      getActiveCoordinatorIdFn: async () => { throw new Error('resolve.cjs hiccup'); },
+      refreshFn,
+    });
+    expect(result).toBe(false);
+    expect(refreshFn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- `setActiveCoordinator()` stamps `claude_sessions.metadata.is_coordinator=true` ONCE, at initial registration — nothing re-stamps it afterward.
- Verified live: an active ~17h-running coordinator session had the flag silently drop (exact drift mechanism untraced — candidates include a non-merging metadata write elsewhere, or session-row recreation across a context-compaction restore) while the file-based `active-coordinator.json` pointer stayed correct.
- `adam-coordinator-health.mjs`'s `coordinator_liveness` probe deliberately queries the DB-side flag directly (not the pointer, by design — it exists to independently verify the DB flag), so the drift produced a false `no_coordinator_row` alarm on a genuinely healthy, actively-ticking coordinator.
- Fix, two pieces:
  1. `refreshCoordinatorFlag()` (`lib/coordinator/resolve.cjs`) — the atomic-RPC-with-fallback stamp, **extracted** from `setActiveCoordinator`'s own Step 2 (byte-identical behavior, now independently callable without re-running drain/retire/succession/pointer-file logic).
  2. `selfHealCoordinatorFlag()` (`scripts/coordinator-quiet-tick.mjs`) — calls it every tick, **guarded on session-identity match** against the authoritative resolver (`getActiveCoordinatorId`) so it can only ever refresh an ALREADY-active coordinator's own flag — never promote a worker session.

## Test plan
- [x] New regression suite `tests/unit/coordinator/coordinator-flag-self-heal.test.js` (7 tests): `refreshCoordinatorFlag` uses the atomic RPC when present, falls back to the read-merge-write upsert when absent, is fail-open on a thrown error; `selfHealCoordinatorFlag` refreshes when the session IDs match, does NOT refresh/promote a worker session, no-ops with no `CLAUDE_SESSION_ID`, and is fail-soft on an identity-resolution error.
- [x] Verified the fix is load-bearing: reverted both files via `git stash`, confirmed 5 of 7 new tests fail without it (`TypeError: ... is not a function`), then restored.
- [x] Existing `coordinator-flag-rpc-fallback.test.js` (which already exercises the atomic-RPC-with-fallback behavior through `setActiveCoordinator`) confirms the extract-method refactor is byte-identical — passes unmodified.
- [x] Full combined suite (`coordinator-flag-rpc-fallback`, `coordinator-promotion-clears-fleet-identity`, `assign-fleet-identities-coordinator-filter`, `coordinator-quiet-tick-directive-wake`, new file) — 69 tests, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)