### PR TITLE
docs(SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001): cross-reference the staged telegram policy removal

### DIFF
--- a/docs/audits/venture-ingest-anon-write-binding-audit.md
+++ b/docs/audits/venture-ingest-anon-write-binding-audit.md
@@ -73,6 +73,14 @@ remained open and is closed by this SD.
   (`database/chairman-gated/`), staged with no `@approved-by`. **The design is complete and
   merged to `main` as an unapplied artifact; the fix itself is not live until the chairman
   ratifies and applies it.**
+- **`telegram_bot_insert_feedback` update (2026-08-13):** left untouched by this migration (see
+  FR row above) — it now has its own, separate staged removal:
+  `database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql`
+  (SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001). Also staged, also unapplied. That migration removes the
+  "no `venture_id` predicate at all" carve-out this audit's Finding table flags — it is a narrower
+  fix (closes the unbounded write path, not venture-ID spoofing) and does not touch
+  `venture_exists_and_active()`'s existence-only check, which remains this audit's open residual.
+  See `docs/reference/anon-write-contract.md#related-telegram_bot_insert_feedback-removal-staged`.
 - **Rollback:** the migration's own `$verify$` self-verification block asserts the full grant
   posture (all 4 DML privileges × `anon`/`authenticated`, on both the table and all three
   internal functions) before `COMMIT` — a partial re-apply that loses a REVOKE fails closed

--- a/docs/reference/anon-write-contract.md
+++ b/docs/reference/anon-write-contract.md
@@ -2,9 +2,9 @@
 
 **Category**: Reference
 **Status**: Approved
-**Version**: 1.0.0
+**Version**: 1.1.0
 **Author**: SD-LEO-INFRA-DEAD-VENTURE-USER-001
-**Last Updated**: 2026-08-04
+**Last Updated**: 2026-08-13
 **Tags**: rls, postgres, anon, feedback, ingress
 
 ## Read this first
@@ -134,3 +134,17 @@ Distinct from the above, and easy to conflate — there are **two** rate limits 
 
 The remedy is filed as a separate chairman-gated SD rather than applied here: making a dormant limit
 suddenly bind would begin rejecting live traffic across four source types with existing volume.
+
+## Related: telegram_bot_insert_feedback removal staged
+
+`telegram_bot_insert_feedback` (the fourth writer form implied by "five anon-path writers" above)
+has a **staged, not-yet-applied** removal: `database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql`
+(SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001). It has `WITH CHECK (source_type = 'telegram')` only — no
+`venture_id` predicate, no content/rate bound of its own — the RESTRICTIVE `anon_feedback_ingress_bounds`
+policy above is what has always bounded its severity/category/rate, before and after this migration.
+The verdicts in [The contract](#the-contract) remain accurate **as measured today** — this table's
+policy set is unchanged until a chairman applies the migration. Post-apply, telegram-sourced writes
+route through `venture_user_insert_feedback` instead (requires a real `venture_id`) or are refused;
+re-run `scripts/anon-write-contract-probe.mjs --table public.feedback` to re-measure. This closes an
+unbounded carve-out, not venture-ID spoofing — `venture_user_insert_feedback`'s `venture_exists_and_active()`
+check remains existence-only, unchanged by this migration.


### PR DESCRIPTION
## Summary
- `/document` post-completion pass for SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001, now merged (#7017).
- Two existing reference/audit docs describe the anon-write surface on `public.feedback` and both predate the new chairman-gated migration; both now cross-reference it.
- `docs/reference/anon-write-contract.md`: new "Related" section — the staged removal, what it does/doesn't close, how to re-measure post-apply.
- `docs/audits/venture-ingest-anon-write-binding-audit.md`: notes that `telegram_bot_insert_feedback`, left untouched by that sibling SD's own migration, now has its own separate, narrower staged fix.
- No new doc files — the sibling precedent migration (`20260812_venture_ingest_key_binding.sql`) also has no standalone `docs/database/*.md`, so cross-referencing existing docs matches established convention.

## Test plan
- [x] Docs-only change, no code/behavior affected.
- [x] Verified both edited files' existing content/claims remain accurate (migration is staged, not applied — contract tables untouched).