### PR TITLE
fix(QF-20260813-529): raise TestExecutionVerifier timeout above measured suite runtime

### DIFF
--- a/scripts/modules/shipping/TestExecutionVerifier.js
+++ b/scripts/modules/shipping/TestExecutionVerifier.js
@@ -17,7 +17,13 @@ import { join } from 'path';
 import { execSync } from 'child_process';
 
 const RECENT_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
-const TEST_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+// QF-20260813-529: this repo's own Unit Tier CI job measures 10-14min for the full
+// suite this shells out to (REGRESSION sub-agent measurement, SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001
+// PR #7017: "Run Unit Tier (quarantine-aware)" completed in 11m37s). The prior 5min
+// value guaranteed a SIGTERM kill on every real run without --skip-tests, producing
+// 'inconclusive' rather than a genuine pass/fail signal. 20min leaves headroom above
+// the measured ceiling.
+const TEST_TIMEOUT_MS = 20 * 60 * 1000; // 20 minutes
 
 /**
  * Standard locations for test result files.


### PR DESCRIPTION
## Summary
- `TestExecutionVerifier.js`'s `TEST_TIMEOUT_MS` was hardcoded to 5min while this repo's own Unit Tier CI job measures 10-14min for the same suite (confirmed: 11m37s on PR #7017's "Run Unit Tier" check).
- Every `ship-preflight` invocation without `--skip-tests` reliably hit the internal timeout, SIGTERM-killing the run before completion — classified `inconclusive`, never a real pass/fail signal.
- Raised `TEST_TIMEOUT_MS` from 5min to 20min, comfortably above the measured ceiling.

## Test plan
- [x] `npx vitest run scripts/modules/shipping/__tests__/TestExecutionVerifier.outputfile.test.js` — 6/6 pass, unaffected (tests exercise kill-classification logic via synthetic error shapes, not the literal timeout constant).
- [x] Tier 1 QF (7 net LOC, ≤30 LOC threshold).

QF-20260813-529