### PR TITLE
feat(SD-LEO-INFRA-RECORD-VENTURE-ERROR-DEFINER-POSTURE-001): red test + cutover runbook for record_venture_error DEFINER/RLS gap

### DIFF
--- a/ops/runbooks/record-venture-error-cutover.md
+++ b/ops/runbooks/record-venture-error-cutover.md
@@ -62,9 +62,13 @@ The two wrong orderings are both **outages**, not merely suboptimal:
 3. **[External repo work, tracked separately — see §3]** Update altifyai, apexniche-ai, and
    marketlens to call `fn_submit_venture_error(p_venture_id, p_ingest_secret, ...)` with their
    provisioned secret, replacing the `record_venture_error` call.
-4. **[Verification]** Confirm all three callers are migrated and successfully submitting via the
-   new function (e.g. a period with zero new `record_venture_error`-originated rows, or explicit
-   confirmation from each repo's own deploy).
+4. **[Verification]** Confirm all three callers are migrated via explicit confirmation from each
+   repo's own deploy (e.g. a merged PR/release referencing the switch). A row-count check against
+   `public.feedback` is NOT a valid substitute: `record_venture_error` and `fn_submit_venture_error`
+   insert byte-identical rows (same columns, same `source_type='error_capture'` literal, `metadata`
+   populated from caller-supplied `p_context` in both) — nothing in the written row distinguishes
+   which function wrote it, so "zero new record_venture_error-originated rows" is unmeasurable and
+   must not be used as the gate in front of step 5.
 5. **[CHAIRMAN-GATED DDL, follow-up migration]** Only once step 4 is confirmed:
    `REVOKE EXECUTE ON FUNCTION record_venture_error FROM anon;` and, optionally, drop the
    function. This is a **separate**, later migration — not part of the 20260812 file.

--- a/ops/runbooks/record-venture-error-cutover.md
+++ b/ops/runbooks/record-venture-error-cutover.md
@@ -86,6 +86,14 @@ fixture exists in this test harness today. Before declaring step 5 complete, ver
 caller in a follow-up, or by an explicit live check that `authenticated` no longer holds EXECUTE
 (`information_schema.routine_privileges`).
 
+**Known census gap**: §1's caller list and step 4's verification cover only the three known
+EXTERNAL callers, which happen to use the `anon` key. Neither establishes that no `authenticated`
+-session caller exists anywhere (e.g. an in-app "report a bug" feature calling this RPC with a
+logged-in user's own session) — absence from the known-caller list is not proof of absence in
+general. Before executing the `authenticated` half of step 5, search the EHG frontend (and any
+other first-party authenticated client) for direct calls to `record_venture_error`, not only rely
+on this runbook's external-repo census.
+
 ## 3. External-repo caller migration — tracked dependency, not this SD's scope
 
 This repository (`EHG_Engineer`) cannot modify `altifyai`, `apexniche-ai`, or `marketlens` source

--- a/ops/runbooks/record-venture-error-cutover.md
+++ b/ops/runbooks/record-venture-error-cutover.md
@@ -70,8 +70,21 @@ The two wrong orderings are both **outages**, not merely suboptimal:
    which function wrote it, so "zero new record_venture_error-originated rows" is unmeasurable and
    must not be used as the gate in front of step 5.
 5. **[CHAIRMAN-GATED DDL, follow-up migration]** Only once step 4 is confirmed:
-   `REVOKE EXECUTE ON FUNCTION record_venture_error FROM anon;` and, optionally, drop the
-   function. This is a **separate**, later migration — not part of the 20260812 file.
+   `REVOKE EXECUTE ON FUNCTION record_venture_error FROM anon, authenticated;` and, optionally,
+   drop the function. **Both roles, not `anon` alone** — §0 documents that `anon`, `authenticated`,
+   AND `service_role` all currently hold EXECUTE, and the three known callers being anon-key
+   server processes does not make `authenticated` safe to leave granted: any logged-in platform
+   user could call the RPC directly via PostgREST with the identical cross-tenant forgery, a
+   materially wider surface than the three named external callers. This is a **separate**, later
+   migration — not part of the 20260812 file. `service_role` is intentionally left granted
+   (trusted, not caller-identity-constrained by design).
+
+**Known test-coverage gap**: TS-8 (this SD) exercises only the `anon` client — it will read green
+once `anon` alone is revoked, which is NOT sufficient (see above). No `authenticated`-session test
+fixture exists in this test harness today. Before declaring step 5 complete, verify the
+`authenticated` vector is also closed — either by extending TS-8 with an authenticated-session
+caller in a follow-up, or by an explicit live check that `authenticated` no longer holds EXECUTE
+(`information_schema.routine_privileges`).
 
 ## 3. External-repo caller migration — tracked dependency, not this SD's scope
 

--- a/ops/runbooks/record-venture-error-cutover.md
+++ b/ops/runbooks/record-venture-error-cutover.md
@@ -1,0 +1,84 @@
+# record_venture_error → fn_submit_venture_error Cutover Runbook
+
+- **Category**: Runbook
+- **Status**: Active (staged migration awaiting chairman ratification — see §0)
+- **Author**: SD-LEO-INFRA-RECORD-VENTURE-ERROR-DEFINER-POSTURE-001
+- **Last Updated**: 2026-08-13
+- **Evidence basis**: LEAD-phase live catalog re-verification (this SD), independent SECURITY sub-agent
+  pass (verdict FAIL, 95% confidence, fixture-proven), Explore sub-agent exhaustive census
+
+## 0. The vulnerability this runbook closes
+
+`public.record_venture_error` is `SECURITY DEFINER`, owned by role `postgres` (which has
+`rolbypassrls=true`). It validates that `p_venture_id` names an *eligible venture* but never
+that the *caller* has any relationship to that venture — there is no `auth.uid()`, `auth.jwt()`,
+or shared secret anywhere in the function body. `anon`/`authenticated`/`service_role` all hold
+EXECUTE. A sibling session independently reproduced the exploit live: an anon call with an
+attacker-chosen `p_venture_id` returns `{ok:true, action:created}` against a venture the caller
+has no relationship to.
+
+**`FORCE ROW LEVEL SECURITY` on `public.feedback` would NOT fix this** — empirically proven via a
+controlled fixture test: a role with the `BYPASSRLS` attribute (which `postgres` has) bypasses RLS
+regardless of `FORCE`. Dropping `SECURITY DEFINER` for `INVOKER` would fail CLOSED for every real
+caller (no permissive INSERT policy on `public.feedback` matches this function's write shape).
+Constraining the write surface via a column allow-list is already implemented in the exploited
+function and is insufficient on its own, because it validates the venture, never the caller.
+
+The sound fix — caller-identity binding via a per-venture ingest secret — is already authored in
+`database/chairman-gated/20260812_venture_ingest_key_binding.sql` (`fn_submit_venture_error`),
+confirmed **not yet applied** (absent from `pg_proc` as of 2026-08-13).
+
+## 1. The three live callers (out of this repo's direct control)
+
+| Repo | File | Notes |
+|---|---|---|
+| altifyai | Cloudflare Worker (error-capture path) | Separate repository |
+| apexniche-ai | `src/lib/error-capture.ts:151` | Separate repository |
+| marketlens | `src/lib/errorCapture.js:65` | Separate repository, Express |
+
+All three are **server-side** (Worker/Express) and hold only the `anon` key by construction — none
+is browser code. Each currently POSTs to `record_venture_error` with a deployment-pinned
+`venture_id`; that pinning is voluntary client-side convention, enforced nowhere in the database.
+
+## 2. Cutover order — DO NOT REORDER
+
+The two wrong orderings are both **outages**, not merely suboptimal:
+
+- **Revoke-first outage**: if `REVOKE EXECUTE ON record_venture_error FROM anon` runs before all
+  three callers have migrated to `fn_submit_venture_error`, every un-migrated caller's error
+  telemetry silently stops (their RPC call starts failing with a permission error).
+- **Retire-first outage**: dropping/renaming `record_venture_error` before all three callers have
+  migrated has the identical effect — the un-migrated callers call a function that no longer exists.
+
+**Correct sequence:**
+
+1. **[CHAIRMAN-GATED DDL]** Apply `database/chairman-gated/20260812_venture_ingest_key_binding.sql`.
+   This is additive-only: it creates `venture_ingest_keys`, `fn_provision_venture_ingest_key`,
+   `fn_submit_venture_feedback`, and `fn_submit_venture_error`. It does **not** touch
+   `record_venture_error` — its own `$verify$` block asserts that function's `pg_proc` row count
+   is unchanged. Both old and new functions are live simultaneously after this step.
+2. **[Service-role action]** For each of the ~146 currently-eligible ventures, call
+   `fn_provision_venture_ingest_key(p_venture_id)` to mint a per-venture secret.
+3. **[External repo work, tracked separately — see §3]** Update altifyai, apexniche-ai, and
+   marketlens to call `fn_submit_venture_error(p_venture_id, p_ingest_secret, ...)` with their
+   provisioned secret, replacing the `record_venture_error` call.
+4. **[Verification]** Confirm all three callers are migrated and successfully submitting via the
+   new function (e.g. a period with zero new `record_venture_error`-originated rows, or explicit
+   confirmation from each repo's own deploy).
+5. **[CHAIRMAN-GATED DDL, follow-up migration]** Only once step 4 is confirmed:
+   `REVOKE EXECUTE ON FUNCTION record_venture_error FROM anon;` and, optionally, drop the
+   function. This is a **separate**, later migration — not part of the 20260812 file.
+
+## 3. External-repo caller migration — tracked dependency, not this SD's scope
+
+This repository (`EHG_Engineer`) cannot modify `altifyai`, `apexniche-ai`, or `marketlens` source
+directly. Step 3 above must be escalated as explicit, discoverable follow-up work (coordinator
+routing or sibling SDs scoped to each venture repo) — not left as an implicit assumption in this
+runbook alone.
+
+## 4. Rollback
+
+Steps 1–2 are additive-only and reversible by construction (new table + new functions; nothing
+about `record_venture_error` changes). Step 5 (the revoke) is the only irreversible-in-practice
+step from a caller's perspective — reverting it (re-granting EXECUTE) is trivial DDL, but any
+caller that had already fully cut over to `fn_submit_venture_error` by then would need no action.

--- a/tests/integration/venture-error-aggregation.db.test.js
+++ b/tests/integration/venture-error-aggregation.db.test.js
@@ -164,6 +164,11 @@ describeDb('record_venture_error RPC — live aggregation, storm, security, revo
     }
   }, 30000);
 
+  // NOTE: this proves the anon-caller vector only. `authenticated` also holds EXECUTE today
+  // (see the cutover runbook's §0) and is an equally real, wider forgery surface (any logged-in
+  // platform user, not just the three known anon-key external callers) -- this harness has no
+  // authenticated-session test fixture to exercise it. See the runbook's "Known test-coverage
+  // gap" note: do not treat this test going green as proof the authenticated vector is closed.
   itDb('TS-8 [EXPECTED RED — SD-LEO-INFRA-RECORD-VENTURE-ERROR-DEFINER-POSTURE-001]: an anon caller with zero relationship to otherVentureId cannot forge a venture_error row attributed to it', async () => {
     const errorHash = hash(`ts8-forgery-${randomUUID()}`);
     const { data, error } = await anon.rpc('record_venture_error', {

--- a/tests/integration/venture-error-aggregation.db.test.js
+++ b/tests/integration/venture-error-aggregation.db.test.js
@@ -10,6 +10,17 @@ import { insertGuarded, CLASSIFICATION } from '../../lib/governance/fixture-prod
 // TS-5: anon role cannot forge occurrence_count/first_seen/last_seen directly.
 // TS-7: ingestion revocation is venture-scoped.
 //
+// SD-LEO-INFRA-RECORD-VENTURE-ERROR-DEFINER-POSTURE-001
+// TS-8: EXPECTED RED. record_venture_error validates that p_venture_id names an eligible
+// venture, never that the caller has any relationship to it -- there is no auth.uid(),
+// auth.jwt(), or shared secret anywhere in the function body. This test names the exploit
+// TS-3/TS-4/TS-5/TS-7 already exercise implicitly (every anon.rpc() call above succeeds for
+// a venture the bare anon client has no session tied to) so the vulnerability has an explicit,
+// intentionally-failing assertion rather than being merely implied by tests that don't
+// comment on it. Expected to start passing only once a caller-identity-bound replacement
+// (fn_submit_venture_error, staged in database/chairman-gated/20260812_venture_ingest_key_binding.sql)
+// is live and record_venture_error's anon EXECUTE grant is revoked -- see that SD's PRD FR-1/FR-3.
+//
 // All against the LIVE database (no mocks), per each scenario's acceptance criteria.
 // Uses a disposable fixture venture (created in beforeAll, deleted in afterAll) so
 // these tests never touch a real production venture's rows.
@@ -151,5 +162,21 @@ describeDb('record_venture_error RPC — live aggregation, storm, security, revo
     } finally {
       await svc.from('ventures').update({ metadata: {} }).eq('id', ventureId);
     }
+  }, 30000);
+
+  itDb('TS-8 [EXPECTED RED — SD-LEO-INFRA-RECORD-VENTURE-ERROR-DEFINER-POSTURE-001]: an anon caller with zero relationship to otherVentureId cannot forge a venture_error row attributed to it', async () => {
+    const errorHash = hash(`ts8-forgery-${randomUUID()}`);
+    const { data, error } = await anon.rpc('record_venture_error', {
+      p_venture_id: otherVentureId,
+      p_error_hash: errorHash,
+      p_message: 'attacker-controlled: this caller has no session, ownership, or relationship to otherVentureId',
+      p_context: { attack: 'cross-tenant-forgery-proof' },
+    });
+    // TODAY this call SUCCEEDS ({ok:true, action:'created'}) because record_venture_error
+    // only validates that otherVentureId names an eligible venture, never that the caller
+    // has any right to write on its behalf. This assertion states the correct behavior and
+    // is expected to FAIL until the fix lands -- do not loosen it to make the suite green.
+    expect(error).toBeNull();
+    expect(data?.ok).toBe(false);
   }, 30000);
 });

--- a/tests/integration/venture-error-aggregation.db.test.js
+++ b/tests/integration/venture-error-aggregation.db.test.js
@@ -174,9 +174,14 @@ describeDb('record_venture_error RPC — live aggregation, storm, security, revo
     });
     // TODAY this call SUCCEEDS ({ok:true, action:'created'}) because record_venture_error
     // only validates that otherVentureId names an eligible venture, never that the caller
-    // has any right to write on its behalf. This assertion states the correct behavior and
-    // is expected to FAIL until the fix lands -- do not loosen it to make the suite green.
-    expect(error).toBeNull();
-    expect(data?.ok).toBe(false);
+    // has any right to write on its behalf. Rejection can arrive either as a graceful
+    // {ok:false} (the function's own logic) or as a Postgres/PostgREST error (e.g. 42501
+    // once its anon EXECUTE grant is revoked per the cutover runbook's step 5, or PGRST202
+    // if the function is later dropped) -- accept either shape, never {ok:true}. Do not
+    // narrow this to require ONE specific shape: the planned fix closes this via a grant
+    // revocation, which produces an error, not a graceful ok:false response, and a
+    // conjunctive assertion (no error AND ok:false) can never go green after that fix lands.
+    expect(error !== null || data?.ok === false).toBe(true);
+    expect(data?.ok).not.toBe(true);
   }, 30000);
 });


### PR DESCRIPTION
## Summary

- `public.record_venture_error` is `SECURITY DEFINER` (owner `postgres`, `rolbypassrls=true`) and validates that `p_venture_id` names an eligible venture but never that the caller has any relationship to it -- a live, exploit-proven cross-tenant forgery vulnerability. Live-catalog re-verified at LEAD phase (not trusted from the SD's own stale description).
- The sound fix (`fn_submit_venture_error`, caller-identity-bound via a per-venture ingest secret) is already authored in `database/chairman-gated/20260812_venture_ingest_key_binding.sql` but intentionally NOT applied by this SD (chairman-gated DDL, out of EXEC scope per PRD TR-1).
- This PR delivers: an EXPECTED-RED integration test (TS-8) proving the exploit and pinned to go green only once the fix ships, plus a 5-step cutover runbook documenting the correct migration order (and the two outage-shaped misorderings to avoid), the 3 external callers that must migrate first, and escalation of that cross-repo dependency.
- `FORCE ROW LEVEL SECURITY` was independently fixture-tested and confirmed NOT sufficient on its own (BYPASSRLS bypasses it regardless of FORCE).

## Test plan

- [x] TS-8 collects/parses cleanly (`npx eslint` zero output; vitest collection-only pass, no ECONNREFUSED/parse errors)
- [ ] Live pass/fail unverifiable locally -- `DESIGNATED_NON_PROD_REFS` is deliberately empty repo-wide (QF-20260726-459, no non-prod Supabase project provisioned anywhere); documented honestly rather than claimed as a false pass
- [x] Adversarial review round 1 (interactive testing-agent): found and fixed a conjunctive-assertion bug in TS-8 that could never go green post-fix
- [x] Adversarial review round 2 (SECURITY sub-agent, evidence row `1fcdc91a-c7cd-4345-b5ce-56cc5a25ce2b`, CONDITIONAL_PASS 92%): found and fixed an unmeasurable runbook verification step

🤖 Generated with [Claude Code](https://claude.com/claude-code)