### PR TITLE
feat(SD-LEO-INFRA-DRIVE-SCORE-PER-001): per-leg citations so the drive score is resolvable

### DIFF
--- a/lib/drive-loop/score/aggregate.js
+++ b/lib/drive-loop/score/aggregate.js
@@ -20,6 +20,26 @@
  * d50b9f12, coordinator scope ac704cbd). A leg cannot silently join the set — the SSOT's
  * ratified-marker rule + the guard test make a phantom leg a loud CI failure (drive-score-legs.js).
  *
+ * ── A CITATION NAMES ONE TABLE, SO IT MAY CARRY ONLY THAT TABLE'S IDS ─────────────────────
+ * SD-LEO-INFRA-DRIVE-SCORE-PER-001. This file used to union every measured leg's row_ids into one
+ * list and stamp its own home table, 'drive_reports', across the result. The legs do not share a
+ * table: leg1 cites roadmap_wave_items, leg2 cites strategic_directives_v2, leg4 cites none by
+ * design. Measured on the live rows: drive-2026-08-12 and drive-2026-08-13 each carried 12 ids
+ * labelled drive_reports of which ZERO existed there — 11 were roadmap_wave_items and 1 was
+ * strategic_directives_v2.
+ *
+ * Nothing was fabricated, and that is what made it durable: the defect was CITATION COMPOSITION,
+ * and the output looked more audited than an honest one would. A citation that cannot be resolved
+ * to its referent is provenance-SHAPED, not provenance.
+ *
+ * So the row grain now lives PER LEG in measured_legs, each id beside the table it actually lives
+ * in, and the top-level score citation carries NO row_ids at all. Emitting (table, row_ids) pairs
+ * up here instead was considered and rejected: once each leg carries its own ids, repeating them
+ * at the aggregate creates a SECOND representation of the same fact that can drift from the first
+ * — this defect again, one level up. Legs are verified against their own named tables before they
+ * reach this function (verify-leg-citations.js); an unresolvable leg arrives already converted to
+ * the unavailable shape, so the exclusion rule above handles it with no second code path.
+ *
  * ── CHAIRMAN DECISION LATENCY SITS BESIDE THE SCORE, UNGRADED ─────────────────────────────
  * Option A, ratified (SMS row 5d90338c, and the migration says so at :37). It is reported and never
  * folded into the total. Grading it would convert a measurement of the chairman's queue into a mark
@@ -38,8 +58,10 @@ export const POINTS_PER_LEG = 2;
  * @param {object} o
  * @param {Array<{leg:string, points?:object, unavailable?:object}>} o.legs each leg's output
  * @param {object} [o.decisionLatency] reported BESIDE the score, never added to it
+ * @param {object} [o.citationVerification] the verify-leg-citations.js verification node, reported
+ *   beside the score so an auditor can see WHAT WAS CHECKED without re-running the query
  */
-export function aggregateScore({ legs = [], decisionLatency = null } = {}) {
+export function aggregateScore({ legs = [], decisionLatency = null, citationVerification = null } = {}) {
   const measured = [];
   const unavailableLegs = [];
 
@@ -58,21 +80,21 @@ export function aggregateScore({ legs = [], decisionLatency = null } = {}) {
   const earned = measured.reduce((sum, l) => sum + l.points.value, 0);
   const possible = measured.length * POINTS_PER_LEG;
 
-  // row_ids: the union of what the measured legs cited. leg 4 deliberately cites NONE (FR-2 — a
-  // citation proves where you looked, not the inference), and that absence must not be read here as
-  // a missing grain. Legs without row_ids simply contribute nothing to the union.
-  const rowIds = [...new Set(measured.flatMap((l) => l.points.citation?.row_ids ?? []))];
-
   const out = {
     score: cite({
       value: earned,
+      // NO row_ids, and that is the fix. See the header: the union that used to live here fused
+      // ids from DIFFERENT tables under this one label. `table` stays 'drive_reports' because it
+      // is honest about THIS value — the score itself is what lives in drive_reports.drive_score —
+      // and the row grain now sits per-leg in measured_legs, beside the table it actually belongs to.
       table: 'drive_reports',
-      row_ids: rowIds,
       predicate: `sum of ${measured.length} MEASURED leg(s) at ${POINTS_PER_LEG} points each, out of `
         + `${possible}. UNAVAILABLE LEGS ARE EXCLUDED FROM THE DENOMINATOR, NOT SCORED ZERO — a `
         + `${earned}/${possible} from a stalled fleet and one from broken instruments are the same `
-        + 'number and opposite claims. Legs citing no rows (leg 4, by FR-2 design) contribute no '
-        + 'row_ids and that is not a missing grain',
+        + 'number and opposite claims. THIS CITATION CARRIES NO row_ids ON PURPOSE: row ids are '
+        + 'carried PER LEG in measured_legs, each beside the table it actually lives in. Resolve '
+        + 'them there. Legs citing no rows (leg 4, by FR-2 design) carry no row_ids and that is not '
+        + 'a missing grain',
       limitation: `Denominator RATIFIED at ${SPEC_LEG_COUNT} legs / ${SPEC_LEG_COUNT * POINTS_PER_LEG} `
         + `points (Adam ruling ${RATIFICATION.ruling}, coordinator scope ${RATIFICATION.scope_ruling}): `
         + 'the smallest-honest denominator over the legs actually defined. A new leg is an explicit '
@@ -82,9 +104,39 @@ export function aggregateScore({ legs = [], decisionLatency = null } = {}) {
       source: 'lib/drive-loop/score/aggregate.js aggregateScore',
     }),
     possible,
-    measured_legs: measured.map((l) => l.leg),
+    // PER-LEG CITATIONS (SD-LEO-INFRA-DRIVE-SCORE-PER-001 FR-1). This was `measured.map(l => l.leg)`
+    // — bare strings — which discarded every leg's provenance at exactly the moment the ids were
+    // being fused above. Nothing is measured again here: each leg scorer already knew its table at
+    // compute time and already built this citation, so this is COMPOSITION.
+    //
+    // BREAKING SHAPE CHANGE, disclosed rather than shimmed: string[] -> object[]. A two-agent
+    // census found ZERO runtime consumers of this field (only tests read it; drive-report-sms.mjs,
+    // the one real runtime reader of drive_score, reads score.value / possible /
+    // unavailable_legs.length and never this). A back-compat shim would have been a second
+    // representation to keep in sync for no reader.
+    measured_legs: measured.map((l) => {
+      const c = l.points.citation ?? {};
+      return {
+        leg: l.leg,
+        table: c.table ?? null,
+        // ABSENT, never []. An empty array reads as "we looked and found none", which is a
+        // different claim from "this leg has no row grain" — the distinction citation.js:112-114
+        // draws, and leg4 depends on it.
+        ...(Array.isArray(c.row_ids) ? { row_ids: c.row_ids } : {}),
+        // leg2's composite locator (sd row-id + claim_history index + timestamp). Dropping it here
+        // would discard the only thing that locates a claim EVENT, which has no id of its own.
+        ...(Array.isArray(c.grains) && c.grains.length > 0 ? { grains: c.grains } : {}),
+        ...(c.source ? { source: c.source } : {}),
+        predicate: l.points.predicate,
+      };
+    }),
     unavailable_legs: unavailableLegs,
   };
+
+  // The provenance check's own result, beside the score for the same reason the latency block is:
+  // a reader must be able to see what was verified without re-deriving it. Its ids_checked is the
+  // guard against a vacuous pass — 0 ids checked can then never read as "everything resolved".
+  if (citationVerification) out.citation_verification = citationVerification;
 
   // BESIDE the score, never inside it. Emitted whether or not it was measurable, so its absence is
   // visible rather than silent.

--- a/lib/drive-loop/score/verify-leg-citations.js
+++ b/lib/drive-loop/score/verify-leg-citations.js
@@ -1,0 +1,200 @@
+/**
+ * SD-LEO-INFRA-DRIVE-SCORE-PER-001 (FR-3) — resolve every cited row id in ITS OWN named table,
+ * at generation time, before the report is written.
+ *
+ * ── WHAT WENT WRONG, MEASURED ─────────────────────────────────────────────────────────────
+ * drive-2026-08-12 and drive-2026-08-13 each shipped a score citation carrying 12 row_ids under
+ * one label, table='drive_reports'. NONE of the 12 exist there: 11 are roadmap_wave_items (leg1)
+ * and 1 is strategic_directives_v2 (leg2). Nothing was fabricated — the aggregate unioned the
+ * legs' ids and stamped its OWN home table over the result. A citation that cannot be resolved to
+ * its referent is provenance-SHAPED, not provenance, and it reads as audited precisely because it
+ * looks like a citation.
+ *
+ * ── THE RESOLVER IS INJECTED, AND THAT IS THE POINT ───────────────────────────────────────
+ * Same contract every sibling in this directory already enforces: leg1 injects runGit /
+ * runGitLog, leg2 injects nowMs, leg4 injects computeVerdict / persist. The reason stated in
+ * leg1-landed.js:56-58 applies here verbatim and more sharply — a check that silently reaches
+ * for a DB client cannot be tested for WHICH TABLE IT ASKED ABOUT, and which table was asked is
+ * the entire defect. A test must be able to prove this queried roadmap_wave_items for leg1 and
+ * never 'drive_reports'.
+ *
+ * ── IT FAILS THE CITATION, NOT THE SCORE — AND IT NEVER THROWS ────────────────────────────
+ * An unresolvable leg is converted to the ordinary unavailable shape, so aggregate.js's existing
+ * exclusion machinery drops it from the DENOMINATOR rather than scoring it zero. Two failure
+ * modes were deliberately rejected:
+ *   - Keeping the leg's points while its citation is unresolvable. That converts a provenance
+ *     defect into a silent false positive — strictly worse than today, because today the bad
+ *     citation is at least visible on the row.
+ *   - Throwing. produce() in scripts/cron/drive-report-sweep.mjs has NO surrounding try/catch, so
+ *     an exception here would abort the whole daily report. A provenance check that can take the
+ *     chairman's report offline is a regression, not a guardrail.
+ *
+ * ── THE TRADE-OFF, DISCLOSED RATHER THAN SILENT ───────────────────────────────────────────
+ * A leg excluded here MAY have measured perfectly well; we discard its computed value because we
+ * could not verify where the number came from. That is deliberate and it follows the same rule
+ * DENOMINATOR-001 settled: an unverifiable number is not a measurement, so it does not belong in
+ * `possible`. It also means "we could not confirm the provenance" and "the instrument broke" both
+ * arrive as an unavailable leg — and the unavailable shape carries no discriminator field, only
+ * a reason string. So the reason string is the ONLY signal a downstream reader gets, and it
+ * carries CITATION_FAILURE_MARKER for exactly that purpose.
+ */
+
+import { unavailable } from '../report-posture.js';
+
+/**
+ * The stable, greppable marker on every reason this module produces.
+ *
+ * Exported so the tests and any downstream reader share ONE literal — a consumer hunting for
+ * citation failures by hard-coding the string would drift the moment the prose around it changed,
+ * and the whole point of the marker is that this failure class stays distinguishable from leg1's
+ * "unearnable rule" prose and leg4's "durable write failed" prose.
+ */
+export const CITATION_FAILURE_MARKER = 'CITATION_UNRESOLVED';
+
+const WHY_EXCLUDED = 'The measurement itself may have been sound; the leg is EXCLUDED because its '
+  + 'provenance could not be verified, and an unverifiable number is not a measurement. Excluded '
+  + 'from the denominator, never scored zero.';
+
+/** A leg is checkable only if it actually claims a row grain. */
+function citedRowIds(leg) {
+  const rowIds = leg?.points?.citation?.row_ids;
+  return Array.isArray(rowIds) && rowIds.length > 0 ? rowIds : null;
+}
+
+function reject(leg, reason) {
+  return { leg: leg?.leg ?? '(unnamed)', unavailable: unavailable(`${CITATION_FAILURE_MARKER}: ${reason} ${WHY_EXCLUDED}`) };
+}
+
+/**
+ * PostgREST returns at most ~1000 rows per request by default. A cited id list longer than that
+ * would come back truncated, and the missing tail would read as "these ids do not exist" — a
+ * FABRICATED failure, which is the same class of lie as a fabricated pass. Chunked well under the
+ * cap so the answer is never an artefact of the transport.
+ */
+export const RESOLVE_BATCH_SIZE = 500;
+
+/**
+ * The real, supabase-backed resolver. A FACTORY taking the client as an argument rather than a
+ * module that imports one, so this file stays free of I/O and both sweeps share ONE
+ * implementation — a second copy in the hourly CLI is exactly the drift this SD is about.
+ *
+ * @param {object} supabase
+ * @returns {(table: string, rowIds: string[]) => Promise<string[]>}
+ */
+export function makeRowResolver(supabase) {
+  if (!supabase || typeof supabase.from !== 'function') {
+    throw new Error('makeRowResolver(): a supabase client is required');
+  }
+  return async (table, rowIds) => {
+    const found = [];
+    for (let i = 0; i < rowIds.length; i += RESOLVE_BATCH_SIZE) {
+      const batch = rowIds.slice(i, i + RESOLVE_BATCH_SIZE);
+      const { data, error } = await supabase.from(table).select('id').in('id', batch);
+      // Throw rather than return []: verifyLegCitations turns this into an explicit measurement
+      // failure naming the table. Returning an empty array here would be indistinguishable from
+      // "queried cleanly, none of these ids exist" — the false-negative this whole file guards.
+      if (error) throw new Error(`${table}: ${error.message}${error.code ? ` (${error.code})` : ''}`);
+      if (!Array.isArray(data)) throw new Error(`${table}: expected rows, got ${data === null ? 'null' : typeof data}`);
+      for (const row of data) found.push(row.id);
+    }
+    return found;
+  };
+}
+
+/**
+ * @param {object} o
+ * @param {Array<object>} o.legs leg results, as handed to aggregateScore
+ * @param {(table: string, rowIds: string[]) => Promise<Array<*>>} o.resolveRows INJECTED. Returns
+ *   the ids that ACTUALLY EXIST in `table`, out of the ids asked for. Anything that is not an
+ *   array is treated as a measurement failure — never as "zero matched".
+ * @returns {Promise<{legs: Array<object>, verification: object}>}
+ */
+export async function verifyLegCitations({ legs = [], resolveRows } = {}) {
+  if (typeof resolveRows !== 'function') {
+    throw new Error('verifyLegCitations(): resolveRows must be injected — this check is defined by '
+      + 'WHICH TABLE it asks about, and a check that silently reaches for a DB client cannot be '
+      + 'tested for that (same contract as leg1 runGit, leg4 persist)');
+  }
+
+  const out = [];
+  const unresolved = [];
+  let legsChecked = 0;
+  let idsChecked = 0;
+  let idsResolved = 0;
+
+  for (const leg of legs) {
+    const rowIds = citedRowIds(leg);
+    // Legs already unavailable, and legs that legitimately cite no rows (leg4, by FR-2 design —
+    // ruling e6876fe6), pass through untouched. Their absence of a row grain is a decision, not a
+    // gap, and treating it as a failure here would re-litigate a settled ruling.
+    if (rowIds === null) { out.push(leg); continue; }
+
+    const table = leg?.points?.citation?.table;
+    if (typeof table !== 'string' || table.trim().length === 0) {
+      // row_ids with no table names ids that resolve NOWHERE. This is the defect's own shape at
+      // the leg level, and it must not pass merely because there is nothing to query.
+      unresolved.push({ leg: leg?.leg ?? '(unnamed)', table: table ?? null, missing_ids: [...new Set(rowIds)] });
+      out.push(reject(leg, `cited ${rowIds.length} row id(s) with no table naming where they live.`));
+      continue;
+    }
+
+    // Deduplicate BEFORE counting. A requested list containing the same id twice must not be able
+    // to inflate any count, and the comparison below is set-based for the same reason.
+    const requested = [...new Set(rowIds)];
+    legsChecked += 1;
+    idsChecked += requested.length;
+
+    let returned;
+    try {
+      returned = await resolveRows(table, requested);
+    } catch (err) {
+      unresolved.push({ leg: leg.leg, table, missing_ids: requested });
+      out.push(reject(leg, `resolving ${requested.length} row id(s) in ${table} threw — ${err?.message || String(err)}.`));
+      continue;
+    }
+
+    if (!Array.isArray(returned)) {
+      // A head-count against a table that does not exist returns no error and a null count, which
+      // is indistinguishable from "read cleanly, found nothing" unless it is named a failure here.
+      unresolved.push({ leg: leg.leg, table, missing_ids: requested });
+      out.push(reject(leg, `resolving row id(s) in ${table} returned ${returned === null ? 'null' : typeof returned} `
+        + 'rather than an array — treated as a measurement failure, never as "zero rows matched".'));
+      continue;
+    }
+
+    // SET membership, and NO coercion. Duplicates in the response collapse, so they cannot inflate
+    // a count; and because ids are compared as the values they are, a type or case mismatch is a
+    // MISS rather than a silent match. That is load-bearing for leg2, whose table
+    // (strategic_directives_v2) keys on authored VARCHAR slugs, not normalised UUIDs.
+    const found = new Set(returned);
+    const missing = requested.filter((id) => !found.has(id));
+    idsResolved += requested.length - missing.length;
+
+    if (missing.length > 0) {
+      unresolved.push({ leg: leg.leg, table, missing_ids: missing });
+      out.push(reject(leg, `cited ${requested.length} row id(s) in ${table}, of which ${missing.length} `
+        + `do not exist there (${missing.slice(0, 5).join(', ')}${missing.length > 5 ? ', …' : ''}).`));
+      continue;
+    }
+
+    out.push(leg);
+  }
+
+  return {
+    legs: out,
+    verification: {
+      legs_checked: legsChecked,
+      ids_checked: idsChecked,
+      ids_resolved: idsResolved,
+      unresolved,
+      // Emitted even when nothing was checkable, so a run in which no leg cites rows says so out
+      // loud instead of reading as a clean N/N pass over a population of zero.
+      note: legsChecked === 0
+        ? 'NO leg carried a row grain this run, so nothing was resolved. This is not a pass — it is '
+          + 'an empty check, and ids_checked: 0 is the disclosure.'
+        : `${idsResolved}/${idsChecked} cited row id(s) resolved in their OWN named table across `
+          + `${legsChecked} leg(s). Each leg was queried against the table its own citation names, `
+          + 'never against the aggregate\'s label.',
+    },
+  };
+}

--- a/scripts/cron/drive-report-hourly-sweep.mjs
+++ b/scripts/cron/drive-report-hourly-sweep.mjs
@@ -66,6 +66,7 @@
 
 import { isMainModule } from '../../lib/utils/is-main-module.js';
 import { buildGather } from './drive-report-sweep.mjs';
+import { makeRowResolver } from '../../lib/drive-loop/score/verify-leg-citations.js';
 import { produceDriveReport } from '../drive-report-produce.mjs';
 import { registerArmedMachinery, armedProcessKey } from '../../lib/machinery-class/armed-registration.js';
 import { LAST_RUN_FIELD } from '../../lib/drive-loop/report-posture.js';
@@ -183,6 +184,10 @@ if (isMainModule(import.meta.url)) {
       runGitLog: (args) => runHardenedGit(args, { cwd: process.cwd() }).split('\n').filter(Boolean),
       readLeg2Cohort: (nowMsArg, windowMsArg) => readRankedTop5Cohort(supabase, nowMsArg, windowMsArg),
       nowMs: cliNowMs,
+      // SD-LEO-INFRA-DRIVE-SCORE-PER-001 (FR-3): the SAME resolver factory the daily sweep uses,
+      // imported rather than re-declared — PRD TR-1's one-representation rule applies to the
+      // citation check exactly as it does to buildGather itself.
+      resolveRows: makeRowResolver(supabase),
     }),
     persist: async (row) => {
       const { data, error } = await supabase.from('drive_reports').insert(row).select('id').single();

--- a/scripts/cron/drive-report-sweep.mjs
+++ b/scripts/cron/drive-report-sweep.mjs
@@ -62,6 +62,7 @@ import { LEG_ID as LEG4_ID, scoreLeg4 } from '../../lib/drive-loop/score/leg4-ca
 import { computeBeltVerdict } from '../../lib/drive-loop/belt-verdict.js';
 import { BELT_BUFFER } from '../lib/capacity-inputs.mjs';
 import { aggregateScore } from '../../lib/drive-loop/score/aggregate.js';
+import { verifyLegCitations, makeRowResolver } from '../../lib/drive-loop/score/verify-leg-citations.js';
 import { unavailable, LAST_RUN_FIELD } from '../../lib/drive-loop/report-posture.js';
 import { armedProcessKey } from '../../lib/machinery-class/armed-registration.js';
 import { produceDriveReport } from '../drive-report-produce.mjs';
@@ -272,7 +273,7 @@ export async function computeLeg2({ readLeg2Cohort, nowMs }) {
  * "finishing" any of them — two are traps where the obvious wiring produces a confidently wrong
  * number rather than an incomplete one.
  */
-export function buildGather({ supabase, computePlanCheckStatus, gatherCapacity, persistVerdict, capacityRunId = null, runGitLog, readLeg2Cohort, nowMs }) {
+export function buildGather({ supabase, computePlanCheckStatus, gatherCapacity, persistVerdict, capacityRunId = null, runGitLog, readLeg2Cohort, nowMs, resolveRows }) {
   // SD-LEO-INFRA-PERSIST-BELT-CAPACITY-001 (FR-3): leg4's two injections are REQUIRED here, not
   // defaulted to the real implementations. A default would make this function look wired while the
   // CLI passed nothing — which is precisely how `persist` went missing from runDriveReportSweep and
@@ -297,6 +298,14 @@ export function buildGather({ supabase, computePlanCheckStatus, gatherCapacity, 
   if (typeof readLeg2Cohort !== 'function' || !Number.isFinite(nowMs)) {
     throw new Error('buildGather(): readLeg2Cohort (function) and nowMs (finite number) must be injected — '
       + 'leg2 refuses without them, for the same reason leg4 refuses without gatherCapacity/persistVerdict');
+  }
+  // SD-LEO-INFRA-DRIVE-SCORE-PER-001 (FR-3): same mandatory-injection contract, and here it is the
+  // point rather than a convention — the citation check is DEFINED by which table it queries, so a
+  // defaulted resolver would let a test prove the check ran while proving nothing about what it asked.
+  if (typeof resolveRows !== 'function') {
+    throw new Error('buildGather(): resolveRows must be injected — the citation check is defined by '
+      + 'WHICH TABLE it asks about (verify-leg-citations.js), and a defaulted resolver hides an '
+      + 'unwired CLI behind a green suite');
   }
 
   return async function gather() {
@@ -369,7 +378,19 @@ export function buildGather({ supabase, computePlanCheckStatus, gatherCapacity, 
       await scoreCapacityLeg({ gatherCapacity, persistVerdict, runId: capacityRunId }),
     ];
 
-    return { sections, driveScore: aggregateScore({ legs }) };
+    // SD-LEO-INFRA-DRIVE-SCORE-PER-001 (FR-3): resolve every cited row id against the table ITS OWN
+    // leg names, BEFORE aggregating and therefore before the insert. drive_score is append-only (a
+    // DB freeze trigger raises on UPDATE), so there is no repair path after this point — a citation
+    // that ships wrong ships wrong forever, which is how drive-2026-08-12 became permanent.
+    //
+    // Running it here rather than inside aggregateScore keeps that function synchronous and pure,
+    // and lets an unresolvable leg arrive as an ordinary unavailable leg — reusing the exclusion
+    // machinery instead of adding a second path. verifyLegCitations never throws on an unresolvable
+    // citation, deliberately: produce() below has no try/catch, so a throw here would take the
+    // chairman's daily report offline over a provenance defect.
+    const { legs: verifiedLegs, verification } = await verifyLegCitations({ legs, resolveRows });
+
+    return { sections, driveScore: aggregateScore({ legs: verifiedLegs, citationVerification: verification }) };
   };
 }
 
@@ -496,6 +517,9 @@ if (isMainModule(import.meta.url)) {
       // shape as gatherCapacity/persistVerdict above.
       readLeg2Cohort: (nowMsArg, windowMsArg) => readRankedTop5Cohort(supabase, nowMsArg, windowMsArg),
       nowMs: cliNowMs,
+      // SD-LEO-INFRA-DRIVE-SCORE-PER-001 (FR-3): supabase pre-bound at this CLI edge, same shape as
+      // the injections above. Shared with the hourly sweep rather than re-declared there.
+      resolveRows: makeRowResolver(supabase),
     }),
     persist: async (row) => {
       const { data, error } = await supabase.from('drive_reports').insert(row).select('id').single();

--- a/tests/database/drive-score-citation-resolves.db.test.js
+++ b/tests/database/drive-score-citation-resolves.db.test.js
@@ -1,0 +1,165 @@
+/**
+ * SD-LEO-INFRA-DRIVE-SCORE-PER-001 (TS-10) — the citation resolves in its NAMED table, for real.
+ *
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ * WHY THIS CANNOT BE A UNIT TEST, AND WHY THAT IS THE WHOLE POINT
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ * The unit suite (tests/unit/drive-loop/score/verify-leg-citations.test.js) proves the CONTROL's
+ * logic: which table it asks about, that a set comparison is used, that a null result is a failure.
+ * It cannot prove the one thing this SD is actually about — that a citation's table LABEL IS
+ * TRUE — because a unit fixture picks both the ids and the world they live in, so every id
+ * resolves by construction. Author-chosen data can never disagree with an author-chosen belief.
+ *
+ * That is exactly how the original defect survived: drive-2026-08-12 shipped 12 row_ids labelled
+ * table='drive_reports' of which ZERO existed there, and no test in the repo asked a real database
+ * whether the label was true. Only a query against real Postgres can answer that.
+ *
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ * WHERE THIS RUNS
+ * ══════════════════════════════════════════════════════════════════════════════════════════════
+ * It WRITES (it seeds the rows it then resolves), so it is a db-tier test and the db project is
+ * gated off production on purpose (vitest.config.js: DB_INCLUDE_GATED is empty unless DB_TARGET
+ * names an explicitly designated non-production database). Against production vitest never loads
+ * this file. That is deliberate and it is also a real limitation, stated rather than implied: this
+ * test is NOT part of the evidence that the change works in the production environment it was
+ * built in — the unit suite and the frozen negative fixture are. It is the check that runs where
+ * writing is safe.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createDatabaseClient } from '../../scripts/lib/supabase-connection.js';
+import { verifyLegCitations, makeRowResolver } from '../../lib/drive-loop/score/verify-leg-citations.js';
+import { aggregateScore } from '../../lib/drive-loop/score/aggregate.js';
+import { cite } from '../../lib/drive-loop/citation.js';
+
+let client;
+/** Only the top of the FK chain needs recording — roadmap_waves/items cascade from it. */
+let roadmapId = null;
+let sdKey = null;
+const seeded = { waveItemIds: [], sdId: null };
+
+/** The real resolver, expressed over the pg client this tier uses. Same contract as makeRowResolver. */
+const pgResolver = async (table, ids) => {
+  // Table names here are NEVER caller-controlled — they come from the legs' own citations, which
+  // are source-committed literals. Parameterised for the ids regardless.
+  const { rows } = await client.query(`SELECT id FROM ${table} WHERE id::text = ANY($1::text[])`, [ids.map(String)]);
+  return rows.map((r) => String(r.id));
+};
+
+beforeAll(async () => {
+  client = await createDatabaseClient();
+
+  const suffix = process.env.GITHUB_RUN_ID || `local-${process.pid}`;
+  sdKey = `SD-PER001-DBTEST-${suffix}`;
+
+  const roadmap = await client.query(
+    `INSERT INTO strategic_roadmaps (title, description, status)
+     VALUES ($1, 'PER-001 TS-10 fixture', 'draft') RETURNING id`,
+    [`PER-001 citation-resolution fixture ${suffix}`],
+  );
+  roadmapId = roadmap.rows[0].id;
+
+  const wave = await client.query(
+    `INSERT INTO roadmap_waves (roadmap_id, sequence_rank, title, status)
+     VALUES ($1, 1, 'PER-001 wave', 'draft') RETURNING id`,
+    [roadmapId],
+  );
+
+  for (const title of ['PER-001 item A', 'PER-001 item B']) {
+    const item = await client.query(
+      `INSERT INTO roadmap_wave_items (wave_id, source_type, title)
+       VALUES ($1, 'manual', $2) RETURNING id`,
+      [wave.rows[0].id, title],
+    );
+    seeded.waveItemIds.push(String(item.rows[0].id));
+  }
+
+  const sd = await client.query(
+    `INSERT INTO strategic_directives_v2 (sd_key, title, status, category, priority, description, rationale, scope, target_application, sd_type)
+     VALUES ($1, 'PER-001 TS-10 fixture', 'draft', 'Infrastructure', 'low', 'fixture', 'fixture', 'fixture', 'EHG_Engineer', 'infrastructure')
+     RETURNING id`,
+    [sdKey],
+  );
+  seeded.sdId = String(sd.rows[0].id);
+}, 60000);
+
+afterAll(async () => {
+  // Delete only what this suite created, by id. ON DELETE CASCADE takes the waves and items with
+  // the roadmap. No blanket predicate deletes — a teardown that tidies by pattern widens silently.
+  if (client) {
+    if (seeded.sdId) await client.query('DELETE FROM strategic_directives_v2 WHERE id = $1', [seeded.sdId]).catch(() => {});
+    if (roadmapId) await client.query('DELETE FROM strategic_roadmaps WHERE id = $1', [roadmapId]).catch(() => {});
+    await client.end();
+  }
+});
+
+const legFor = (name, table, rowIds) => ({
+  leg: name,
+  points: cite({ value: 2, table, predicate: `p:${name}`, row_ids: rowIds }),
+});
+
+describe('TS-10 — a cited row id resolves in the table its own leg names', () => {
+  it('a truthfully-labelled citation resolves N/N against real Postgres, with N > 0', async () => {
+    const { legs, verification } = await verifyLegCitations({
+      legs: [
+        legFor('leg1_landed', 'roadmap_wave_items', seeded.waveItemIds),
+        legFor('leg2_uptake', 'strategic_directives_v2', [seeded.sdId]),
+      ],
+      resolveRows: pgResolver,
+    });
+
+    expect(legs.every((l) => l.unavailable === undefined)).toBe(true);
+    expect(verification.unresolved).toEqual([]);
+    // The vacuity guard, against real data: a control that checked nothing must not read as a pass.
+    expect(verification.ids_checked).toBe(seeded.waveItemIds.length + 1);
+    expect(verification.ids_checked).toBeGreaterThan(0);
+    expect(verification.ids_resolved).toBe(verification.ids_checked);
+  });
+
+  it('[THE ORIGINAL DEFECT] the SAME ids under the WRONG table label are rejected by real Postgres', async () => {
+    // This is drive-2026-08-12 reproduced against a live database rather than a fixture: real ids
+    // that genuinely exist, labelled with the table they do NOT live in. The rows are real, the
+    // number would have been real, and the citation is still false.
+    const { legs, verification } = await verifyLegCitations({
+      legs: [legFor('fused_aggregate', 'drive_reports', seeded.waveItemIds)],
+      resolveRows: pgResolver,
+    });
+
+    expect(legs[0].unavailable, 'ids that exist in roadmap_wave_items must NOT resolve in drive_reports').toBeDefined();
+    expect(legs[0].unavailable.reason).toMatch(/CITATION_UNRESOLVED/);
+    expect(verification.unresolved[0]).toMatchObject({ table: 'drive_reports' });
+    expect(verification.unresolved[0].missing_ids.sort()).toEqual([...seeded.waveItemIds].sort());
+    expect(verification.ids_resolved).toBe(0);
+  });
+
+  it('end to end: a verified score emits per-leg citations that an auditor can resolve independently', async () => {
+    const { legs, verification } = await verifyLegCitations({
+      legs: [
+        legFor('leg1_landed', 'roadmap_wave_items', seeded.waveItemIds),
+        legFor('leg2_uptake', 'strategic_directives_v2', [seeded.sdId]),
+      ],
+      resolveRows: pgResolver,
+    });
+    const score = aggregateScore({ legs, citationVerification: verification });
+
+    // Re-resolve straight from the EMITTED structure, the way an auditor reading drive_reports
+    // would — not from the inputs we happened to hold. If the emission dropped or relabelled a
+    // grain, this fails even though the check above passed.
+    let checked = 0;
+    for (const entry of score.measured_legs) {
+      if (!entry.row_ids) continue;
+      const found = await pgResolver(entry.table, entry.row_ids);
+      expect(new Set(found)).toEqual(new Set(entry.row_ids.map(String)));
+      checked += entry.row_ids.length;
+    }
+    expect(checked).toBeGreaterThan(0);
+    expect(score.score.citation.row_ids, 'the aggregate must carry no fused id list').toBeUndefined();
+  });
+
+  it('makeRowResolver (the production supabase path) is the same contract this suite exercised', () => {
+    // The pg resolver above and makeRowResolver are two implementations of one contract. This does
+    // not prove they agree — it pins that the production one exists and refuses a missing client,
+    // so a future edit cannot quietly delete the injected-resolver requirement it depends on.
+    expect(() => makeRowResolver(null)).toThrow(/supabase client is required/);
+    expect(typeof makeRowResolver({ from: () => {} })).toBe('function');
+  });
+});

--- a/tests/fixtures/drive-score/drive-2026-08-12.json
+++ b/tests/fixtures/drive-score/drive-2026-08-12.json
@@ -1,0 +1,35 @@
+{
+  "_fixture_note": "FROZEN SNAPSHOT of the founding negative case for SD-LEO-INFRA-DRIVE-SCORE-PER-001 — the drive_score of drive_reports run_id='drive-2026-08-12' (row 71a08983-0d31-47eb-b99b-9d2e495976e9, generated_at 2026-08-12T10:15:10.403Z), captured verbatim on 2026-08-13. It is a STATIC snapshot on purpose, not a live re-query: drive_score is append-only (a DB freeze trigger raises on UPDATE, tests/ddl/drive-reports-ddl.db.test.js), so this row keeps its defective shape permanently, and a post-fix live query would be compared against data that structurally cannot match the new shape. MEASURED against the live database on 2026-08-13: of the 12 row_ids below, labelled table='drive_reports', ZERO exist in drive_reports; 11 exist in roadmap_wave_items and 1 (d9d9e778-bc23-440b-a323-b7d5fc7ff465, present in the 08-13 sibling row) in strategic_directives_v2. drive-2026-08-13 carried the identical shape, so the defect was live and recurring when this SD was built, not historical.",
+  "_measured_resolution": {
+    "measured_at": "2026-08-13",
+    "drive_reports": 0,
+    "roadmap_wave_items": 11,
+    "strategic_directives_v2": 1,
+    "total_cited": 12
+  },
+  "score": {
+    "value": 3.29,
+    "citation": {
+      "table": "drive_reports",
+      "source": "lib/drive-loop/score/aggregate.js aggregateScore",
+      "row_ids": [
+        "02c6786a-5897-41e2-863b-6cc0fa0e0ca8",
+        "154170cf-9ee5-4288-90c1-49fb89e5c10e",
+        "4389b444-dd30-45b5-a578-ccf9cb96e970",
+        "48e77173-ff3f-471a-bde4-5e615f1eef87",
+        "92a25049-6052-4815-9ee3-98df0a770d31",
+        "973c6c72-86c5-4cda-8da2-a4d7fb3aab21",
+        "9e3efa02-3787-43a2-92a1-9bcac047be14",
+        "d17390b7-9f16-4e63-a34c-28f79e2eb688",
+        "d2057c11-6f61-44cb-8bef-d8c03f77100b",
+        "e82c9fb6-c233-4095-88aa-22c3bd1be95c",
+        "ea5e452b-26e2-434d-9e1c-75bdcfbfb4b3",
+        "dff41959-beda-4b72-8b6b-d2eb12cbd273"
+      ]
+    },
+    "predicate": "sum of 3 MEASURED leg(s) at 2 points each, out of 6. UNAVAILABLE LEGS ARE EXCLUDED FROM THE DENOMINATOR, NOT SCORED ZERO — a 3.29/6 from a stalled fleet and one from broken instruments are the same number and opposite claims. Legs citing no rows (leg 4, by FR-2 design) contribute no row_ids and that is not a missing grain"
+  },
+  "possible": 6,
+  "measured_legs": ["leg1_landed", "leg2_uptake", "leg4_capacity"],
+  "unavailable_legs": []
+}

--- a/tests/unit/cron/drive-report-hourly-sweep.test.js
+++ b/tests/unit/cron/drive-report-hourly-sweep.test.js
@@ -220,6 +220,15 @@ describe('[SD-LEO-INFRA-HOURLY-DRIVE-SCORE-001 FR-6, AC-3] CLI wiring: capacityR
     expect(codeOnly).toMatch(/buildGather\(\{[\s\S]{0,400}?capacityRunId,/);
   });
 
+  it('resolveRows is actually PASSED to buildGather(), not just imported (SD-LEO-INFRA-DRIVE-SCORE-PER-001 FR-3)', () => {
+    // Same shape as the capacityRunId assertion above and for the same reason: importing
+    // makeRowResolver proves nothing about whether this sweep hands it to buildGather. Drop the
+    // property and buildGather would throw at runtime on every hourly tick while a source-text
+    // scan for the import stayed green.
+    const codeOnly = source.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+    expect(codeOnly).toMatch(/resolveRows:\s*makeRowResolver\(supabase\)/);
+  });
+
   it('[NEGATIVE CONTROL] the daily windowKey is never IMPORTED (executable usage, not this file\'s own prose explaining why)', () => {
     // The header comments explain the design decision by NAME-DROPPING windowKey() in prose,
     // which a bare word-boundary scan would also match — this checks the import statement

--- a/tests/unit/cron/drive-report-hourly-sweep.test.js
+++ b/tests/unit/cron/drive-report-hourly-sweep.test.js
@@ -244,6 +244,10 @@ function stubHourlyGather(nowMs, { persistVerdict = async () => ({ id: 'v1' }) }
     runGitLog: () => [], // HOURLY_STATUS.done is [] — never invoked, mandatory injection only.
     readLeg2Cohort: async () => null, // no ranked cohort in this fixture world — leg2 unavailable.
     nowMs,
+    // SD-LEO-INFRA-DRIVE-SCORE-PER-001 (FR-3): mandatory injection. Resolves whatever it is asked,
+    // because none of this file's assertions is about citation resolution — the control's real
+    // semantics are pinned in tests/unit/drive-loop/score/verify-leg-citations.test.js.
+    resolveRows: async (_table, ids) => ids,
   });
 }
 
@@ -256,7 +260,7 @@ describe('[SD-LEO-INFRA-HOURLY-DRIVE-SCORE-001 FR-3 AC-1] the hourly gather() ou
   it('measured_legs + unavailable_legs together equal RATIFIED_LEG_IDS, never more, never fewer', async () => {
     const gather = stubHourlyGather(Date.UTC(2026, 6, 15, 10, 0, 0)); // 06:00 ET
     const { driveScore } = await gather();
-    const producedLegIds = [...driveScore.measured_legs, ...driveScore.unavailable_legs.map((u) => u.leg)];
+    const producedLegIds = [...driveScore.measured_legs.map((m) => m.leg), ...driveScore.unavailable_legs.map((u) => u.leg)];
 
     expect(() => assertProducedLegsMatchSSOT(producedLegIds)).not.toThrow();
     expect(new Set(producedLegIds)).toEqual(new Set(RATIFIED_LEG_IDS));

--- a/tests/unit/cron/drive-report-sweep.test.js
+++ b/tests/unit/cron/drive-report-sweep.test.js
@@ -932,6 +932,14 @@ describe('FR-3 — leg4 is injected, not declared unavailable', () => {
       /readLeg2Cohort:\s*\([^)]*\)\s*=>\s*readRankedTop5Cohort\(supabase,/
     );
     expect(src, 'and the real report clock, not a second Date.now() read').toMatch(/nowMs:\s*cliNowMs/);
+    // SD-LEO-INFRA-DRIVE-SCORE-PER-001 (FR-3): the FOURTH injection, at the same CLI edge. Found
+    // missing by the EXEC testing-agent: buildGather REFUSES an absent resolveRows (so the
+    // behavioural tests all pass one), but nothing asserted the CLI passes the REAL one — the
+    // identical gap that let `persist` go missing from runDriveReportSweep with the suite green.
+    expect(src, 'the CLI must supply the real row resolver, bound to the real supabase client').toMatch(
+      /resolveRows:\s*makeRowResolver\(supabase\)/
+    );
+    expect(src, 'and the citation check must actually be CALLED, not merely imported').toMatch(/await\s+verifyLegCitations\(/);
     expect(src, 'the legs array must call computeLeg2').toMatch(/await\s+computeLeg2\(/);
   });
 });

--- a/tests/unit/cron/drive-report-sweep.test.js
+++ b/tests/unit/cron/drive-report-sweep.test.js
@@ -308,6 +308,7 @@ describe('gather — what this job can HONESTLY measure today', () => {
     // function here.
     runGitLog: () => [],
     readLeg2Cohort, nowMs: Date.parse('2026-08-07T09:00:00.000Z'),
+    resolveRows: TEST_RESOLVE_ROWS,
   });
 
   it('section 1 is REAL — the enriched remainder, not next.length', async () => {
@@ -428,7 +429,7 @@ describe('leg1 A-LOCAL wiring — measures for real when the completed-items win
         receivedOptions.push(options);
         return { open_total: 0, next: [], next_truncated: false, slipped: [], open_items_all: [], waves: [], done: [] };
       },
-      gatherCapacity, persistVerdict: persistTableAbsent, runGitLog, readLeg2Cohort, nowMs,
+      gatherCapacity, persistVerdict: persistTableAbsent, runGitLog, readLeg2Cohort, nowMs, resolveRows: TEST_RESOLVE_ROWS,
     });
     await gather();
     expect(receivedOptions, 'computePlanCheckStatus must be called exactly once (the dedupe this file already documents)').toHaveLength(1);
@@ -439,7 +440,7 @@ describe('leg1 A-LOCAL wiring — measures for real when the completed-items win
     const gather = buildGather({
       supabase: {},
       computePlanCheckStatus: async () => ({ open_total: 0, next: [], next_truncated: false, slipped: [], open_items_all: [], waves: [], done: [] }),
-      gatherCapacity, persistVerdict: persistTableAbsent, runGitLog, readLeg2Cohort, nowMs,
+      gatherCapacity, persistVerdict: persistTableAbsent, runGitLog, readLeg2Cohort, nowMs, resolveRows: TEST_RESOLVE_ROWS,
     });
     const { driveScore } = await gather();
     const reason = driveScore.unavailable_legs.find((l) => l.leg === 'leg1_landed').reason;
@@ -457,11 +458,11 @@ describe('leg1 A-LOCAL wiring — measures for real when the completed-items win
         open_items_all: [], waves: [],
         done: [{ item_id: 'd1', sd_key: 'SD-REALLY-LANDED-001', title: 'T', wave: 'W', completed_at: '2026-01-01T00:00:00Z' }],
       }),
-      gatherCapacity, persistVerdict: persistTableAbsent, runGitLog, readLeg2Cohort, nowMs,
+      gatherCapacity, persistVerdict: persistTableAbsent, runGitLog, readLeg2Cohort, nowMs, resolveRows: TEST_RESOLVE_ROWS,
     });
     const { driveScore } = await gather();
     expect(driveScore.unavailable_legs.map((l) => l.leg)).not.toContain('leg1_landed');
-    expect(driveScore.measured_legs).toContain('leg1_landed');
+    expect(driveScore.measured_legs.map((m) => m.leg)).toContain('leg1_landed');
   });
 
   it('[TS-4, WIRING population-discrimination guard] leg1 stays unavailable when open_items_all looks landed but done[] is empty — the wiring must never read from open_items_all', async () => {
@@ -479,11 +480,11 @@ describe('leg1 A-LOCAL wiring — measures for real when the completed-items win
         waves: [],
         done: [],
       }),
-      gatherCapacity, persistVerdict: persistTableAbsent, runGitLog, readLeg2Cohort, nowMs,
+      gatherCapacity, persistVerdict: persistTableAbsent, runGitLog, readLeg2Cohort, nowMs, resolveRows: TEST_RESOLVE_ROWS,
     });
     const { driveScore } = await gather();
     expect(driveScore.unavailable_legs.map((l) => l.leg), 'leg1 must stay unavailable -- done[] is empty regardless of what open_items_all contains').toContain('leg1_landed');
-    expect(driveScore.measured_legs).not.toContain('leg1_landed');
+    expect(driveScore.measured_legs.map((m) => m.leg)).not.toContain('leg1_landed');
   });
 
   it('[TS-4b, scorer-level population-discrimination guard] scoring the SAME predicate against open_items_all instead of done[] must NOT read as landed', async () => {
@@ -591,6 +592,7 @@ describe('SD-LEO-INFRA-DRIVE-SCORE-LEG2-001 — computeLeg2 wiring', () => {
       runGitLog: () => [],
       readLeg2Cohort: async () => { throw new Error('boom'); },
       nowMs: REPORT_NOW,
+      resolveRows: TEST_RESOLVE_ROWS,
     });
     const { driveScore } = await gather();
     const ids = driveScore.unavailable_legs.map((l) => l.leg);
@@ -613,6 +615,20 @@ describe('SD-LEO-INFRA-DRIVE-SCORE-LEG2-001 — computeLeg2 wiring', () => {
  */
 // Module-scoped (not describe-scoped) so the FR-4 AC-5 block below can reuse the identical real
 // gather() pipeline rather than re-declare a second, potentially-drifting fixture.
+/**
+ * SD-LEO-INFRA-DRIVE-SCORE-PER-001 (FR-3): buildGather now REFUSES an uninjected resolveRows, so
+ * every construction below supplies one. This stub resolves whatever it is asked, which is correct
+ * for THESE tests — none of them is about citation resolution, and their fixture ids exist in no
+ * real table, so a strict resolver would turn every unrelated pin into a citation failure.
+ *
+ * An echo resolver is precisely the vacuous shape the control must not have in production, and it
+ * is proven not to have one in tests/unit/drive-loop/score/verify-leg-citations.test.js, where the
+ * any-table resolver is asserted to ACCEPT the defective drive-2026-08-12 row while the
+ * table-scoped one rejects it. Named here so a later reader does not mistake this stub for the
+ * contract.
+ */
+const TEST_RESOLVE_ROWS = async (_table, ids) => ids;
+
 const E2E_STATUS = { open_total: 42, next: [{ item_id: 'i1' }], next_truncated: false, done: [], slipped: [] };
 const realGather = (nowMs = Date.UTC(...JULY, 10, 0, 0)) => buildGather({
   supabase: {}, computePlanCheckStatus: async () => E2E_STATUS,
@@ -623,6 +639,7 @@ const realGather = (nowMs = Date.UTC(...JULY, 10, 0, 0)) => buildGather({
   // fixture world; leg2 stays unavailable, unchanged from before this SD.
   readLeg2Cohort: async () => null,
   nowMs,
+  resolveRows: TEST_RESOLVE_ROWS,
 });
 
 describe('[END-TO-END] the sweep drives the REAL producer — no stub in between', () => {
@@ -879,8 +896,22 @@ describe('FR-3 — leg4 is injected, not declared unavailable', () => {
       .toThrow(/readLeg2Cohort \(function\) and nowMs \(finite number\) must be injected/);
     expect(() => buildGather({ ...okLeg4Args, readLeg2Cohort: async () => null }))
       .toThrow(/readLeg2Cohort \(function\) and nowMs \(finite number\) must be injected/); // nowMs still missing
-    expect(() => buildGather({ ...okLeg4Args, readLeg2Cohort: async () => null, nowMs: Date.now() }))
+    expect(() => buildGather({ ...okLeg4Args, readLeg2Cohort: async () => null, nowMs: Date.now(), resolveRows: TEST_RESOLVE_ROWS }))
       .not.toThrow();
+  });
+
+  // SD-LEO-INFRA-DRIVE-SCORE-PER-001 (FR-3): the fourth mandatory injection. Here the refusal is
+  // the requirement rather than a convention — the citation check is DEFINED by which table it
+  // queries, so a defaulted resolver would let the suite prove the check ran while proving nothing
+  // about what it asked, which is the exact blindness this SD exists to remove.
+  it('buildGather REFUSES an uninjected resolveRows rather than defaulting the citation check', () => {
+    const okArgs = {
+      supabase: {}, computePlanCheckStatus: async () => ({}),
+      gatherCapacity: async () => ({}), persistVerdict: async () => ({}),
+      runGitLog: () => [], readLeg2Cohort: async () => null, nowMs: Date.now(),
+    };
+    expect(() => buildGather(okArgs)).toThrow(/resolveRows must be injected/);
+    expect(() => buildGather({ ...okArgs, resolveRows: TEST_RESOLVE_ROWS })).not.toThrow();
   });
 
   it('[WIRING] the CLI passes the REAL gatherer and the REAL writer', () => {

--- a/tests/unit/drive-loop/score/aggregate.test.js
+++ b/tests/unit/drive-loop/score/aggregate.test.js
@@ -9,14 +9,25 @@ import { aggregateScore, POINTS_PER_LEG, SPEC_LEG_COUNT } from '../../../../lib/
 import { unavailable } from '../../../../lib/drive-loop/report-posture.js';
 import { cite } from '../../../../lib/drive-loop/citation.js';
 
-const leg = (name, points, rowIds = []) => ({
+/**
+ * SD-LEO-INFRA-DRIVE-SCORE-PER-001: `table` is now a PARAMETER, and that is load-bearing rather
+ * than tidier. It used to be hard-coded 't' for every fake leg, so this fixture COULD NOT BUILD
+ * two legs citing two different tables — which is precisely the shape of the live defect (leg1
+ * cites roadmap_wave_items, leg2 cites strategic_directives_v2, and the aggregate stamped
+ * 'drive_reports' over the union of both). A suite whose fixture cannot express the bug will
+ * report green through it forever.
+ */
+const leg = (name, points, rowIds = [], table = 't', extra = {}) => ({
   leg: name,
   points: cite({
-    value: points, table: 't', predicate: 'p', source: 's',
+    value: points, table, predicate: `p:${name}`, source: 's',
     ...(rowIds.length ? { row_ids: rowIds } : {}),
+    ...extra,
   }),
 });
 const brokenLeg = (name, reason) => ({ leg: name, unavailable: unavailable(reason) });
+/** measured_legs is now objects; most assertions below only care about which legs are in it. */
+const legNames = (r) => r.measured_legs.map((m) => m.leg);
 
 describe('aggregate — an unavailable leg is not a zero leg', () => {
   it('[THE RULE] excludes an unavailable leg from the DENOMINATOR rather than scoring it 0', () => {
@@ -25,7 +36,7 @@ describe('aggregate — an unavailable leg is not a zero leg', () => {
     const r = aggregateScore({ legs: [leg('a', 2), leg('b', 0), brokenLeg('c', 'query threw')] });
     expect(r.score.value).toBe(2);
     expect(r.possible).toBe(4);
-    expect(r.measured_legs).toEqual(['a', 'b']);
+    expect(legNames(r)).toEqual(['a', 'b']);
     expect(r.unavailable_legs).toEqual([{ leg: 'c', reason: 'query threw' }]);
   });
 
@@ -62,12 +73,11 @@ describe('aggregate — an unavailable leg is not a zero leg', () => {
     expect(r.score.limitation).not.toMatch(/X\/8/);
   });
 
-  it('unions row_ids, and a leg citing NONE is not treated as a gap', () => {
+  it('a leg citing NO rows is not treated as a gap', () => {
     // leg 4 deliberately cites no rows (FR-2). It must still count toward the score.
     const r = aggregateScore({ legs: [leg('a', 2, ['r1', 'r2']), leg('leg4_capacity', 2)] });
     expect(r.score.value).toBe(4);
     expect(r.possible).toBe(4);
-    expect(r.score.citation.row_ids).toEqual(['r1', 'r2']);
   });
 
   it('[VACUITY] no legs at all is 0/0, not full marks and not a silent zero', () => {
@@ -75,6 +85,96 @@ describe('aggregate — an unavailable leg is not a zero leg', () => {
     expect(r.score.value).toBe(0);
     expect(r.possible).toBe(0);
     expect(r.measured_legs).toEqual([]);
+  });
+});
+
+describe('aggregate — PER-001: a citation names one table, so it may carry only that table\'s ids', () => {
+  // The live defect, reproduced as a fixture: two legs, two DIFFERENT tables. Under the old code
+  // their ids were unioned into one array under table:'drive_reports'. Measured on the real rows —
+  // drive-2026-08-12 and drive-2026-08-13 each carried 12 such ids, 0 of which existed in
+  // drive_reports (11 were roadmap_wave_items, 1 was strategic_directives_v2).
+  const twoTables = () => aggregateScore({
+    legs: [
+      leg('leg1_landed', 2, ['rw-1', 'rw-2'], 'roadmap_wave_items'),
+      leg('leg2_uptake', 1, ['SD-ALPHA-001'], 'strategic_directives_v2', {
+        grains: [{ sd_id: 'SD-ALPHA-001', claim_index: 0, claimed_at: '2026-08-12T00:00:00Z' }],
+      }),
+      leg('leg4_capacity', 2, [], 'drive_reports'),
+    ],
+  });
+
+  it('[FR-2] the top-level score citation carries NO row_ids at all', () => {
+    const r = twoTables();
+    expect(r.score.citation.row_ids).toBeUndefined();
+    expect(Object.hasOwn(r.score.citation, 'row_ids')).toBe(false);
+    // The table stays drive_reports, which is honest — the SCORE is what lives there.
+    expect(r.score.citation.table).toBe('drive_reports');
+  });
+
+  it('[FR-2] NEGATIVE: no array anywhere in the output fuses ids from two different tables', () => {
+    const r = twoTables();
+    // The guard that would have caught the original bug. Walk every array of strings in the
+    // emitted object and assert none of them contains ids belonging to two different legs.
+    const fused = [];
+    const walk = (node, path) => {
+      if (Array.isArray(node)) {
+        const ids = node.filter((v) => typeof v === 'string');
+        if (ids.includes('rw-1') && ids.includes('SD-ALPHA-001')) fused.push(path);
+        node.forEach((v, i) => walk(v, `${path}[${i}]`));
+        return;
+      }
+      if (node && typeof node === 'object') for (const [k, v] of Object.entries(node)) walk(v, `${path}.${k}`);
+    };
+    walk(r, '$');
+    expect(fused, `row ids from two tables were fused at: ${fused.join(', ')}`).toEqual([]);
+  });
+
+  it('[FR-2] the predicate STATES the deferral, so the prose cannot go stale while the shape is right', () => {
+    // Without this, an implementation could drop row_ids and still describe a union in words —
+    // the number correct and the sentence beside it false.
+    const r = twoTables();
+    expect(r.score.predicate).toMatch(/CARRIES NO row_ids ON PURPOSE/);
+    expect(r.score.predicate).toMatch(/measured_legs/);
+  });
+
+  it('[FR-1] each measured leg carries its OWN table and its OWN ids, copied not re-derived', () => {
+    const r = twoTables();
+    const byLeg = Object.fromEntries(r.measured_legs.map((m) => [m.leg, m]));
+    expect(byLeg.leg1_landed.table).toBe('roadmap_wave_items');
+    expect(byLeg.leg1_landed.row_ids).toEqual(['rw-1', 'rw-2']);
+    expect(byLeg.leg2_uptake.table).toBe('strategic_directives_v2');
+    expect(byLeg.leg2_uptake.row_ids).toEqual(['SD-ALPHA-001']);
+    expect(byLeg.leg1_landed.predicate).toBe('p:leg1_landed');
+  });
+
+  it('[FR-1/TS-12] leg2 grains survive, and a leg with no row grain has row_ids ABSENT, not []', () => {
+    const r = twoTables();
+    const byLeg = Object.fromEntries(r.measured_legs.map((m) => [m.leg, m]));
+    // The composite locator is the only thing that locates a claim EVENT — claim_history rows have
+    // no id of their own. Dropping it would be a rationale shipped in place of the assertion.
+    expect(byLeg.leg2_uptake.grains).toEqual([
+      { sd_id: 'SD-ALPHA-001', claim_index: 0, claimed_at: '2026-08-12T00:00:00Z' },
+    ]);
+    // ABSENT vs []: "this leg has no row grain" and "we looked and found none" are different claims.
+    expect(Object.hasOwn(byLeg.leg4_capacity, 'row_ids')).toBe(false);
+    expect(byLeg.leg4_capacity.table).toBe('drive_reports');
+  });
+
+  it('[FR-1] measured_legs contains no bare strings — the shape downstream readers get is uniform', () => {
+    const r = twoTables();
+    expect(r.measured_legs.every((m) => m && typeof m === 'object' && !Array.isArray(m))).toBe(true);
+    expect(r.measured_legs.some((m) => typeof m === 'string')).toBe(false);
+    // .leg is still exposed, because the RATIFIED_LEG_IDS drift guard reads leg IDs off this array.
+    expect(r.measured_legs.map((m) => m.leg)).toEqual(['leg1_landed', 'leg2_uptake', 'leg4_capacity']);
+  });
+
+  it('[FR-3] the citation verification node is reported BESIDE the score, and omitted when absent', () => {
+    const v = { legs_checked: 2, ids_checked: 3, ids_resolved: 3, unresolved: [], note: 'n' };
+    const withV = aggregateScore({ legs: [leg('a', 2, ['r1'])], citationVerification: v });
+    expect(withV.citation_verification).toEqual(v);
+    // Never folded into the score itself.
+    expect(withV.score.value).toBe(2);
+    expect(aggregateScore({ legs: [leg('a', 2, ['r1'])] }).citation_verification).toBeUndefined();
   });
 });
 

--- a/tests/unit/drive-loop/score/verify-leg-citations.test.js
+++ b/tests/unit/drive-loop/score/verify-leg-citations.test.js
@@ -1,0 +1,303 @@
+/**
+ * SD-LEO-INFRA-DRIVE-SCORE-PER-001 (FR-3, FR-5) — the citation resolve control.
+ *
+ * The load-bearing tests here are the VACUITY ones. A resolve check is trivially easy to write in
+ * a form that passes while proving nothing, and every one of the seven modes below was named
+ * BEFORE the implementation (prospective testing-agent evidence d5d9218c and PLAN-phase evidence
+ * c1c4cc51) rather than discovered afterwards. Mode E is the sharpest: a "resolves in ANY table"
+ * check would have ACCEPTED the exact live data that motivated this SD.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { verifyLegCitations, CITATION_FAILURE_MARKER, makeRowResolver, RESOLVE_BATCH_SIZE } from '../../../../lib/drive-loop/score/verify-leg-citations.js';
+import { cite } from '../../../../lib/drive-loop/citation.js';
+import { unavailable } from '../../../../lib/drive-loop/report-posture.js';
+
+const leg = (name, table, rowIds, extra = {}) => ({
+  leg: name,
+  points: cite({
+    value: 2, table, predicate: `p:${name}`,
+    ...(rowIds ? { row_ids: rowIds } : {}),
+    ...extra,
+  }),
+});
+
+/** A resolver that knows a fixed world: {table -> ids that exist}. Records what it was ASKED. */
+const worldResolver = (world) => {
+  const calls = [];
+  const fn = async (table, rowIds) => {
+    calls.push({ table, rowIds: [...rowIds] });
+    const known = world[table] ?? [];
+    return rowIds.filter((id) => known.includes(id));
+  };
+  fn.calls = calls;
+  return fn;
+};
+
+const LIVE_WORLD = {
+  roadmap_wave_items: ['rw-1', 'rw-2'],
+  strategic_directives_v2: ['SD-ALPHA-001'],
+  drive_reports: [],
+};
+
+describe('verifyLegCitations — the resolver is injected, because WHICH TABLE was asked is the defect', () => {
+  it('[TS-14] refuses to run without an injected resolveRows', async () => {
+    await expect(verifyLegCitations({ legs: [] })).rejects.toThrow(/resolveRows must be injected/);
+  });
+
+  it('[TS-4 / vacuity B] queries each leg\'s OWN table, and NEVER the aggregate\'s label', async () => {
+    // The whole bug in one assertion. A check pointed at 'drive_reports' would re-derive the
+    // original defect one layer down while looking like a working control.
+    const resolve = worldResolver(LIVE_WORLD);
+    await verifyLegCitations({
+      legs: [leg('leg1_landed', 'roadmap_wave_items', ['rw-1']), leg('leg2_uptake', 'strategic_directives_v2', ['SD-ALPHA-001'])],
+      resolveRows: resolve,
+    });
+    expect(resolve.calls.map((c) => c.table)).toEqual(['roadmap_wave_items', 'strategic_directives_v2']);
+    expect(resolve.calls.some((c) => c.table === 'drive_reports')).toBe(false);
+  });
+
+  it('passes a fully-resolving set through untouched and counts what it checked', async () => {
+    const { legs, verification } = await verifyLegCitations({
+      legs: [leg('leg1_landed', 'roadmap_wave_items', ['rw-1', 'rw-2'])],
+      resolveRows: worldResolver(LIVE_WORLD),
+    });
+    expect(legs[0].unavailable).toBeUndefined();
+    expect(verification).toMatchObject({ legs_checked: 1, ids_checked: 2, ids_resolved: 2, unresolved: [] });
+  });
+});
+
+describe('verifyLegCitations — it fails the CITATION, not the SCORE, and never throws', () => {
+  it('[TS-8] converts an unresolvable leg to the ordinary unavailable shape and does not throw', async () => {
+    const { legs, verification } = await verifyLegCitations({
+      legs: [leg('leg1_landed', 'roadmap_wave_items', ['rw-1', 'ghost-id'])],
+      resolveRows: worldResolver(LIVE_WORLD),
+    });
+    expect(legs[0].unavailable.available).toBe(false);
+    expect(legs[0].leg).toBe('leg1_landed');
+    expect(verification.unresolved).toEqual([
+      { leg: 'leg1_landed', table: 'roadmap_wave_items', missing_ids: ['ghost-id'] },
+    ]);
+  });
+
+  it('[TS-17] the citation-failure reason is DISCRIMINABLE from a genuine instrument outage', async () => {
+    // The unavailable shape has no discriminator field — only a reason string — so the marker IS
+    // the signal. Without it, "we could not verify the provenance" and "the instrument broke"
+    // arrive at every downstream reader as the same thing.
+    const { legs } = await verifyLegCitations({
+      legs: [leg('leg1_landed', 'roadmap_wave_items', ['ghost-id'])],
+      resolveRows: worldResolver(LIVE_WORLD),
+    });
+    expect(legs[0].unavailable.reason).toContain(CITATION_FAILURE_MARKER);
+    // And it is genuinely distinct from the two real outage reasons the sweep emits.
+    const outage = unavailable('scoreLeg4 could not be scored this run: persistCapacityVerdict(): durable write failed');
+    expect(outage.reason).not.toContain(CITATION_FAILURE_MARKER);
+    // The reason also discloses the trade-off rather than hiding it.
+    expect(legs[0].unavailable.reason).toMatch(/unverifiable number is not a measurement/);
+  });
+
+  it('a resolver that THROWS becomes a measurement failure, not a crash and not a false pass', async () => {
+    const { legs, verification } = await verifyLegCitations({
+      legs: [leg('leg1_landed', 'roadmap_wave_items', ['rw-1'])],
+      resolveRows: async () => { throw new Error('connection reset'); },
+    });
+    expect(legs[0].unavailable.reason).toContain(CITATION_FAILURE_MARKER);
+    expect(legs[0].unavailable.reason).toMatch(/connection reset/);
+    expect(verification.unresolved).toHaveLength(1);
+  });
+
+  it('legs that are ALREADY unavailable, and legs citing no rows, pass through untouched', async () => {
+    const resolve = worldResolver(LIVE_WORLD);
+    const already = { leg: 'leg2_uptake', unavailable: unavailable('no elapsed cohort') };
+    const { legs, verification } = await verifyLegCitations({
+      legs: [already, leg('leg4_capacity', 'drive_reports', null)],
+      resolveRows: resolve,
+    });
+    expect(legs[0]).toBe(already);                          // byte-identical, FR-4
+    expect(legs[0].unavailable.reason).toBe('no elapsed cohort');
+    expect(legs[1].unavailable).toBeUndefined();            // leg4 still counts toward the score
+    expect(resolve.calls).toHaveLength(0);                  // nothing to ask
+    expect(verification.legs_checked).toBe(0);
+  });
+});
+
+describe('verifyLegCitations — the seven ways this control could be vacuously green', () => {
+  it('[TS-3 / mode A] N=0 is DISCLOSED as an empty check, never reported as "all resolved"', async () => {
+    // leg4 cites no rows by design, so a run of leg4 alone checks nothing. If that read as a pass,
+    // the control would certify a report it never examined.
+    const { verification } = await verifyLegCitations({
+      legs: [leg('leg4_capacity', 'drive_reports', null)],
+      resolveRows: worldResolver(LIVE_WORLD),
+    });
+    expect(verification.ids_checked).toBe(0);
+    expect(verification.legs_checked).toBe(0);
+    expect(verification.note).toMatch(/This is not a pass/);
+  });
+
+  it('[TS-5 / mode C] a leg whose row_ids is an EMPTY array is not counted as a resolved leg', async () => {
+    const resolve = worldResolver(LIVE_WORLD);
+    const { verification } = await verifyLegCitations({
+      legs: [leg('leg1_landed', 'roadmap_wave_items', [])],
+      resolveRows: resolve,
+    });
+    expect(resolve.calls).toHaveLength(0);   // .in('id', []) is never even asked
+    expect(verification.ids_checked).toBe(0);
+  });
+
+  it('[TS-6 / mode D] a null resolver result is a measurement failure, not "zero rows matched"', async () => {
+    // A head-count against a table that does not exist returns no error and a null count. Read as
+    // "found nothing", that silently converts a missing table into a clean bill of health.
+    const { legs, verification } = await verifyLegCitations({
+      legs: [leg('leg1_landed', 'roadmap_wave_items', ['rw-1'])],
+      resolveRows: async () => null,
+    });
+    expect(legs[0].unavailable.reason).toMatch(/returned null rather than an array/);
+    expect(legs[0].unavailable.reason).toMatch(/never as "zero rows matched"/);
+    expect(verification.unresolved).toHaveLength(1);
+  });
+
+  it('[TS-15 / mode F] duplicate ids in the RESPONSE cannot inflate the comparison', async () => {
+    // requested [a,b]; resolver echoes [a,a]. A length comparison passes. A set comparison does not.
+    const { legs } = await verifyLegCitations({
+      legs: [leg('leg1_landed', 'roadmap_wave_items', ['rw-1', 'rw-2'])],
+      resolveRows: async () => ['rw-1', 'rw-1'],
+    });
+    expect(legs[0].unavailable).toBeDefined();
+    expect(legs[0].unavailable.reason).toMatch(/rw-2/);
+  });
+
+  it('[TS-15 / mode F] duplicate ids in the REQUEST are deduped before being counted', async () => {
+    const resolve = worldResolver(LIVE_WORLD);
+    const { verification } = await verifyLegCitations({
+      legs: [leg('leg1_landed', 'roadmap_wave_items', ['rw-1', 'rw-1', 'rw-1'])],
+      resolveRows: resolve,
+    });
+    expect(verification.ids_checked).toBe(1);       // not 3 — a repeated id is one id
+    expect(resolve.calls[0].rowIds).toEqual(['rw-1']);
+  });
+
+  it('[TS-16 / mode G] ids are compared exactly, with no type or case coercion', async () => {
+    // Concrete for leg2, not theoretical: strategic_directives_v2.id is a VARCHAR carrying authored
+    // slugs, so a resolver returning a differently-cased or differently-typed value is a MISS.
+    const wrongCase = await verifyLegCitations({
+      legs: [leg('leg2_uptake', 'strategic_directives_v2', ['SD-ALPHA-001'])],
+      resolveRows: async () => ['sd-alpha-001'],
+    });
+    expect(wrongCase.legs[0].unavailable).toBeDefined();
+
+    const wrongType = await verifyLegCitations({
+      legs: [leg('leg1_landed', 'roadmap_wave_items', ['7'])],
+      resolveRows: async () => [7],
+    });
+    expect(wrongType.legs[0].unavailable).toBeDefined();
+  });
+
+  it('a citation carrying row_ids but NO table resolves nowhere, and is rejected rather than skipped', async () => {
+    // The defect's own shape at the leg level. Nothing to query must never mean nothing to check.
+    const resolve = worldResolver(LIVE_WORLD);
+    const { legs, verification } = await verifyLegCitations({
+      legs: [{ leg: 'malformed', points: { value: 2, citation: { row_ids: ['x'] }, predicate: 'p' } }],
+      resolveRows: resolve,
+    });
+    expect(legs[0].unavailable.reason).toMatch(/no table naming where they live/);
+    expect(verification.unresolved[0]).toMatchObject({ leg: 'malformed', table: null });
+  });
+});
+
+describe('verifyLegCitations — the founding negative case (FR-5)', () => {
+  const FIXTURE = JSON.parse(readFileSync(
+    fileURLToPath(new URL('../../../fixtures/drive-score/drive-2026-08-12.json', import.meta.url)),
+    'utf8',
+  ));
+
+  it('the frozen fixture still carries the defect it was captured for', () => {
+    // If this ever changes, the fixture stopped being the negative case and every test below is
+    // asserting against something else.
+    expect(FIXTURE.score.citation.table).toBe('drive_reports');
+    expect(FIXTURE.score.citation.row_ids).toHaveLength(12);
+    expect(FIXTURE.measured_legs.every((m) => typeof m === 'string')).toBe(true);
+    expect(FIXTURE._measured_resolution.drive_reports).toBe(0);
+  });
+
+  it('[TS-7] the control REJECTS the drive-2026-08-12 shape, naming the table it was labelled with', async () => {
+    // Reconstructed as a leg carrying exactly what that row claimed: 12 ids under drive_reports.
+    const asLeg = leg('fused_aggregate', 'drive_reports', FIXTURE.score.citation.row_ids);
+    const { legs, verification } = await verifyLegCitations({
+      legs: [asLeg],
+      // The real world: none of the 12 exist in drive_reports.
+      resolveRows: worldResolver({ drive_reports: [] }),
+    });
+    expect(legs[0].unavailable).toBeDefined();
+    expect(legs[0].unavailable.reason).toContain(CITATION_FAILURE_MARKER);
+    expect(legs[0].unavailable.reason).toMatch(/drive_reports/);
+    expect(verification.unresolved[0].missing_ids).toHaveLength(12);
+    expect(verification.ids_resolved).toBe(0);
+  });
+
+  it('[TS-7] PINS WHY per-leg-table is the requirement: an ANY-TABLE check would have ACCEPTED this row', async () => {
+    // This is the test that makes the strategy a requirement rather than a preference. All 12 ids
+    // DO exist somewhere — 11 in roadmap_wave_items, 1 in strategic_directives_v2 — so a resolver
+    // that searched "any table" would report a clean pass over the exact data that motivated the SD.
+    const ids = FIXTURE.score.citation.row_ids;
+    const anyTableResolver = async (_table, rowIds) => rowIds;   // "it exists somewhere" — the trap
+    const permissive = await verifyLegCitations({
+      legs: [leg('fused_aggregate', 'drive_reports', ids)],
+      resolveRows: anyTableResolver,
+    });
+    expect(permissive.legs[0].unavailable, 'an any-table resolver ACCEPTS the defective row — this is the trap').toBeUndefined();
+    expect(permissive.verification.unresolved).toEqual([]);
+
+    // Whereas the honest, table-scoped world rejects it. Same input, opposite verdict: the
+    // difference is entirely in WHICH TABLE was asked.
+    const scoped = await verifyLegCitations({
+      legs: [leg('fused_aggregate', 'drive_reports', ids)],
+      resolveRows: worldResolver({ drive_reports: [], roadmap_wave_items: ids.slice(0, 11), strategic_directives_v2: ids.slice(11) }),
+    });
+    expect(scoped.legs[0].unavailable).toBeDefined();
+  });
+});
+
+describe('makeRowResolver — the real supabase-backed resolver', () => {
+  it('requires a client', () => {
+    expect(() => makeRowResolver(null)).toThrow(/supabase client is required/);
+    expect(() => makeRowResolver({})).toThrow(/supabase client is required/);
+  });
+
+  it('queries the table it is GIVEN, selecting ids, and returns the ids that exist', async () => {
+    const asked = [];
+    const supabase = {
+      from: (table) => ({
+        select: () => ({
+          in: async (col, ids) => {
+            asked.push({ table, col, ids });
+            return { data: ids.filter((i) => i !== 'ghost').map((id) => ({ id })), error: null };
+          },
+        }),
+      }),
+    };
+    const resolve = makeRowResolver(supabase);
+    const found = await resolve('roadmap_wave_items', ['rw-1', 'ghost']);
+    expect(found).toEqual(['rw-1']);
+    expect(asked).toEqual([{ table: 'roadmap_wave_items', col: 'id', ids: ['rw-1', 'ghost'] }]);
+  });
+
+  it('throws on a query error rather than returning [] — an empty array would read as "none exist"', async () => {
+    const supabase = { from: () => ({ select: () => ({ in: async () => ({ data: null, error: { message: 'relation missing', code: 'PGRST205' } }) }) }) };
+    await expect(makeRowResolver(supabase)('nope', ['a'])).rejects.toThrow(/relation missing.*PGRST205/);
+  });
+
+  it('BATCHES beyond the PostgREST row cap, so a long id list is not silently truncated', async () => {
+    // A truncated response would report the missing tail as "these ids do not exist" — a
+    // FABRICATED failure, the same class of lie as a fabricated pass.
+    const batches = [];
+    const supabase = {
+      from: () => ({ select: () => ({ in: async (_col, ids) => { batches.push(ids.length); return { data: ids.map((id) => ({ id })), error: null }; } }) }),
+    };
+    const ids = Array.from({ length: RESOLVE_BATCH_SIZE + 7 }, (_, i) => `id-${i}`);
+    const found = await makeRowResolver(supabase)('t', ids);
+    expect(batches).toEqual([RESOLVE_BATCH_SIZE, 7]);
+    expect(found).toHaveLength(ids.length);
+  });
+});


### PR DESCRIPTION
## The defect, measured

The chairman's daily drive score shipped a citation that **could not be resolved to its referent**.

`lib/drive-loop/score/aggregate.js:64` unioned every measured leg's `row_ids` and line 69 stamped its own home table — `drive_reports` — across the result. The legs do not share a table:

| leg | cites |
|---|---|
| `leg1_landed` (leg1-landed-alocal.js) | `roadmap_wave_items` |
| `leg2_uptake` | `strategic_directives_v2` |
| `leg4_capacity` | none, by design (ruling e6876fe6) |

Measured against the live database:

| run_id | ids cited as `drive_reports` | resolve in `drive_reports` | actually in `roadmap_wave_items` | actually in `strategic_directives_v2` |
|---|---|---|---|---|
| `drive-2026-08-12` | 12 | **0** | 11 | 1 |
| `drive-2026-08-13` | 12 | **0** | 11 | 1 |

The 08-13 row was generated the same day this SD was built — the defect was **live and recurring**, not historical. Nothing was fabricated; the defect is citation **composition**, and the output read as *more* audited than an honest citation would.

## What shipped

- **FR-1** `measured_legs` is now per-leg objects `{leg, table, row_ids?, grains?, source?, predicate}` composed from each leg's own citation. Composition, not new measurement — the scorers already knew their table. `row_ids` is **absent** (never `[]`) for a leg with no row grain, preserving leg4's deliberate design and `citation.js`'s absent-vs-empty distinction. leg2's composite `grains` survive.
- **FR-2** The top-level score citation carries **no** `row_ids` and defers to the per-leg citations, with the predicate saying so. `table` stays `drive_reports`, which is honest — the score value itself lives there. Emitting `(table, row_ids)` *pairs* was considered and rejected: once each leg carries its own ids, repeating them at the aggregate is a second representation that can drift — this defect one level up.
- **FR-3** New `lib/drive-loop/score/verify-leg-citations.js` resolves each leg's ids against **that leg's own table**, wired into `gather()` before `aggregateScore` and therefore before the append-only insert. `resolveRows` is **injected** (house style: leg1 `runGit`, leg4 `persist`) because the check is *defined by which table it asks about*. It fails the **citation, not the score** — an unresolvable leg becomes an ordinary unavailable leg, so DENOMINATOR-001 honest-exclusion is intact — and it **never throws**, because `produce()` has no `try/catch` and a throw would take the daily report offline.
- **FR-4** Existing unavailable reason strings and exclusion semantics unchanged.
- **FR-5** `drive-2026-08-12` frozen as a static fixture the control must reject.

## Vacuity guards

A resolve check is easy to write in a form that passes while proving nothing. Seven modes were named *before* implementation and each is now a test: `N=0` (leg4 cites nothing), querying the aggregate label instead of the leg's table, empty id lists, a `null` result from a missing table, response duplicates inflating a count, id type/case coercion, and a citation with `row_ids` but no table.

The sharpest is pinned explicitly: **a "resolves in ANY table" check ACCEPTS `drive-2026-08-12`**, because all 12 ids do exist *somewhere*. Only the table-scoped check rejects it. That test is what makes the strategy a requirement rather than a preference.

## Verification

- **54 files / 722 tests green.**
- The 8 new aggregate guards were confirmed **RED** against pre-change `aggregate.js` before being trusted.
- The EXEC testing-agent independently re-confirmed by **mutating the source three ways** — re-adding the union, hard-coding the table, degrading the set comparison to a length check — and naming which test caught each.
- **Live read-only smoke**: the real 08-12 citation is rejected 0/12 in its labelled table; a truthful citation resolves 11/11 with N>0; top-level `row_ids` absent; leg4's `row_ids` key absent.
- SECURITY: **PASS**. `citation.table` values are source-committed literals at every producer; the resolver uses the PostgREST client, not raw SQL; no new data reaches the chairman SMS path, which reads only `score.value`/`possible`/`unavailable_legs.length`.

One fix site covers both cadences — the hourly sweep reuses `buildGather()`. The `string[] -> object[]` change ships without a shim: a two-agent census found **zero** runtime consumers.

## Size

944 insertions (+17 follow-up), ~65% tests, fixtures and house-style docblocks. Production delta: `aggregate.js` +62, `verify-leg-citations.js` 200, sweeps +33. Exceeds the 100-LOC target by deliberate scope (5 FRs, 17 test scenarios); the >500-LOC infrastructure path is the EXEC-TO-PLAN handoff, which passed at 87%.

## Known limitation

`tests/database/drive-score-citation-resolves.db.test.js` is db-tier and gated to non-production, so it **did not execute** in this environment. Its value is real but unrealised here — the evidence that the change works today is the unit suite plus the live read-only smoke run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
