### PR TITLE
chore(adam-scribe): @approved-by marker — v_patterns_with_decay rebuild APPLIED 2026-08-15

### DIFF
--- a/database/migrations/20260801_refresh_v_patterns_with_decay_column_drift.sql
+++ b/database/migrations/20260801_refresh_v_patterns_with_decay_column_drift.sql
@@ -1,3 +1,5 @@
+-- @approved-by: codestreetlabs@gmail.com
+-- (chairman verbal approval in-session 2026-08-13 ~12:40Z: "I Approve rebuilding the v_patterns_with_decay view (DROP + CREATE)"; scribed by Adam per the chairman-verbal apply ceremony)
 -- Migration: rebuild v_patterns_with_decay so its column list matches issue_patterns again
 -- Date: 2026-08-01
 -- SD: SD-FDBK-ENH-LEARNING-LOOP-DESTROYS-001 (FR-5)


### PR DESCRIPTION
Chairman-verbal scribe ceremony (CLAUDE_ADAM.md §3c). Marker-only diff (2 comment lines) on `database/migrations/20260801_refresh_v_patterns_with_decay_column_drift.sql`; migration content unchanged since the chairman's verbal approval 2026-08-13 ~12:40Z ("I Approve rebuilding the v_patterns_with_decay view (DROP + CREATE)").

**Applied to prod 2026-08-15 ~12:55Z** from this branch's commit (`MIGRATION_APPLY_PROD_PASS`, 11 statements, 1 declared object).

**Post-apply readback (mandatory):** view now carries all 29 `issue_patterns` columns + 7 computed = 36 (was 30 with 6 table columns missing); 1200 rows; `GRANT SELECT` to anon/authenticated/service_role intact — anon-key probe returns count 1200.

Merging keeps `main`'s copy of the file equal to what was applied (staged-vs-applied drift guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)