### PR TITLE
fix(SD-LEO-FIX-CLOSE-ANON-VENTURE-001): ownership-bound RPC closes venture_user_insert_feedback gap

### DIFF
--- a/.github/workflows/drive-reports-ddl.yml
+++ b/.github/workflows/drive-reports-ddl.yml
@@ -48,6 +48,13 @@ on:
       # SD-LEO-INFRA-HOURLY-DRIVE-SCORE-001 FR-7 — same trap, same fix, applied again.
       - 'database/migrations/20260812_drive_reports_hourly_cadence.sql'
       - 'tests/ddl/drive-reports-hourly-cadence-ddl.db.test.js'
+      # SD-LEO-FIX-CLOSE-ANON-VENTURE-001. Same TR-5 fix, applied to a NEW pair rather than
+      # amended-in: this workflow's own paths filter is literal, so a PR touching only this SD's
+      # migration and its ddl test would otherwise trigger nothing. This migration also depends on
+      # SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001's Phase-1 migration (already listed above), applied
+      # first inside the test itself.
+      - 'database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql'
+      - 'tests/ddl/venture-user-feedback-ownership-rpc-ddl.db.test.js'
       - 'vitest.ddl.config.mjs'
       # Self-validating: edits to this file re-run it.
       - '.github/workflows/drive-reports-ddl.yml'

--- a/database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql
+++ b/database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql
@@ -1,0 +1,310 @@
+-- SD-LEO-FIX-CLOSE-ANON-VENTURE-001 — ownership-bound RPC replacing venture_user_insert_feedback
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- STAGED, NOT APPLIED. CHAIRMAN-GATED. DO NOT RUN THIS FILE.
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- AWAITING CHAIRMAN REVIEW — no @approved-by stamp exists for this file yet, deliberately (per the
+-- established convention on this exact database instance: never write an approval stamp until an
+-- approval actually happened — see database/chairman-gated/20260812_venture_ingest_key_binding.sql's
+-- own header for the incident this convention prevents).
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- THE DEFECT THIS CLOSES (measured live 2026-08-15, not inferred — see PRD PRD-SD-LEO-FIX-CLOSE-
+-- ANON-VENTURE-001, FR-1)
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- public.feedback's venture_user_insert_feedback policy (PERMISSIVE, anon, INSERT, applies to
+-- feedback_type LIKE 'user_%') requires venture_id IS NOT NULL and venture_exists_and_active(venture_id)
+-- — an EXISTENCE-only check (venture row exists, not soft-deleted, telemetry enabled) with NO
+-- correlation to caller identity. An anon caller can therefore attribute a user_bug/user_feature_
+-- request/user_usability/user_other row to ANY real active venture_id, not only one it has a
+-- legitimate relationship to. auth.uid() is NULL for anon, so no RLS predicate can express "this
+-- caller owns this venture" — ownership requires a caller-presented credential checked against a
+-- per-venture record, hence this migration.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- RELATIONSHIP TO SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001 PHASE-1 (completed 2026-08-13)
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- database/chairman-gated/20260812_venture_ingest_key_binding.sql ("Phase-1", still STAGED, NOT
+-- APPLIED as of 2026-08-15 — confirmed live: venture_ingest_keys and its four functions absent from
+-- pg_proc/pg_class) already built a per-venture-secret ownership mechanism, but for a DIFFERENT
+-- caller shape: fn_submit_venture_feedback targets source_type='venture_worker' (backend/service
+-- callers), not this policy's user_%-prefixed anon-browser traffic. Phase-1's own header explicitly
+-- names "tightening or removing ... venture_user_insert_feedback" as an out-of-scope, undesigned
+-- "Phase 3". THIS FILE IS THAT PHASE-3 WORK — it REUSES Phase-1's venture_ingest_keys table and
+-- _verify_venture_ingest_secret function exactly as-is (no fork, no reimplementation), adding only a
+-- new, separately-named RPC for this traffic shape.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- THE CALLER-TOPOLOGY RESIDUAL (documented, not silently accepted — PRD FR-4)
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- For a SERVER-SIDE secret holder (a backend service holding p_ingest_secret in process.env — e.g.
+-- marketlens/src/services/feedback.js), this closes ownership cleanly. For a BROWSER-EXPOSED caller
+-- (a secret shipped in a public client bundle — e.g. apexniche-ai/src/ui/api/feedbackClient.ts,
+-- ehg/src/integrations/feedback/feedbackDataAccess.ts), no credential delivered to an anonymous
+-- browser can remain secret from whoever loads that page — this is the SAME residual Phase-1's own
+-- header names (HIGH-2) for its RPC. This migration converts GLOBAL cross-venture forgery into
+-- PER-VENTURE forgery for such callers, a real reduction, but NOT full ownership proof against
+-- someone targeting that one specific venture. Do not represent this migration as closing that case
+-- fully — it narrows, it does not eliminate, for a browser-exposed secret.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- SEQUENCING DEPENDENCY (PRD FR-7 — operational, not a DDL-enforceable check within this file)
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql (sibling, from the
+-- completed SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001, also confirmed STAGED-NOT-APPLIED live 2026-08-15)
+-- has its OWN $verify$ block that asserts venture_user_insert_feedback remains PRESENT with an
+-- UNCHANGED WITH CHECK clause, and that anon retains table-level INSERT — all violated by THIS
+-- file's own DROP POLICY action below. BEFORE APPLYING THIS FILE: confirm via a live pg_policies
+-- read whether 20260813_revoke_telegram_bot_insert_feedback.sql has already landed (telegram_bot_
+-- insert_feedback absent = already applied, no action needed) or is still pending (telegram_bot_
+-- insert_feedback present = apply that migration first, or in the same ceremony immediately before
+-- this one). Applying THIS file first would cause that sibling migration's own next apply attempt
+-- to hard-fail on a confusing, seemingly-unrelated error.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- CORRECTIONS FROM PROSPECTIVE PLAN-PHASE TESTING REVIEW (evidence ffe58c4e-7c8d-4d53-8dbf-
+-- 8634b5f0ec62), applied before this file was first written, not discovered after
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- (1) The Phase-1 dependency check below is a PRE-FLIGHT guard (first statements after BEGIN),
+--     never a trailing $verify$ block: a LANGUAGE sql function body referencing a missing
+--     dependency would fail at CREATE FUNCTION parse time (check_function_bodies), before any
+--     trailing block would ever run. This function uses LANGUAGE plpgsql specifically so a missing-
+--     dependency failure, if the pre-flight guard were ever bypassed, would surface at CALL time
+--     rather than at CREATE time with a confusing raw 42883 — but the pre-flight guard is the
+--     primary, always-reached defense, tested per-branch (not OR-combined) so a typo in either
+--     branch cannot be masked by the other.
+-- (2) check_feedback_rate_limit returns TRUE when the caller IS rate-limited (confirmed live at
+--     database/migrations/20260401_venture_user_feedback_channel.sql:117, "AND NOT check_feedback_
+--     rate_limit(...)" in the existing policy) — the OPPOSITE polarity from _verify_venture_ingest_
+--     secret (TRUE=authorized). The function body below uses a direct truthy check for the rate
+--     limit and 'IS NOT TRUE' only for the ownership check — copying one idiom to both would invert
+--     one of them.
+-- (3) DROP POLICY only, NEVER a table-level REVOKE: the anon INSERT grant on public.feedback is
+--     SHARED with anon_feedback_ingress_bounds (RESTRICTIVE, still governs every anon insert) and
+--     possibly telegram_bot_insert_feedback (if the sibling revoke migration above hasn't landed
+--     yet) — a table-level REVOKE would collaterally break those sibling policies, exactly the class
+--     of defect tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js's own TR-1 assertion
+--     exists to catch for the analogous sibling removal.
+-- (4) This SECURITY DEFINER function never evaluates anon_feedback_ingress_bounds (rolbypassrls) —
+--     a global cross-venture ceiling (500/hour, 10x the per-venture 50/hour threshold, matching
+--     Phase-1's own documented reasoning for its equivalent backstop) is added below so this path
+--     does not silently lose the cross-venture DoS protection that RESTRICTIVE policy provided for
+--     the raw-INSERT path being replaced.
+--
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- ROLLBACK (manual, if needed — additive except for the one DROP POLICY, safe to reverse in one pass)
+-- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- REVOKE EXECUTE ON FUNCTION public.fn_submit_venture_user_feedback(UUID, TEXT, TEXT, TEXT, TEXT) FROM anon, service_role;
+-- DROP FUNCTION IF EXISTS public.fn_submit_venture_user_feedback(UUID, TEXT, TEXT, TEXT, TEXT);
+-- CREATE POLICY venture_user_insert_feedback ON public.feedback
+--   FOR INSERT TO anon
+--   WITH CHECK (
+--     feedback_type LIKE 'user_%'
+--     AND venture_id IS NOT NULL
+--     AND venture_exists_and_active(venture_id)
+--     AND (NOT check_feedback_rate_limit(venture_id))
+--   );
+
+BEGIN;
+
+-- ============================================================
+-- 0. PRE-FLIGHT GUARD (FR-5/TR-5): Phase-1 prerequisites must exist before any CREATE FUNCTION
+--    below. Two SEPARATE checks, not OR-combined, so a typo in one branch cannot be masked by
+--    the other passing.
+-- ============================================================
+DO $preflight$
+BEGIN
+  IF to_regclass('public.venture_ingest_keys') IS NULL THEN
+    RAISE EXCEPTION 'PRE-FLIGHT FAILED: public.venture_ingest_keys does not exist -- apply database/chairman-gated/20260812_venture_ingest_key_binding.sql (SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001 Phase-1) before this migration';
+  END IF;
+END
+$preflight$;
+
+DO $preflight2$
+BEGIN
+  IF (SELECT count(*) FROM pg_proc WHERE proname = '_verify_venture_ingest_secret' AND pronamespace = 'public'::regnamespace) = 0 THEN
+    RAISE EXCEPTION 'PRE-FLIGHT FAILED: public._verify_venture_ingest_secret does not exist -- apply database/chairman-gated/20260812_venture_ingest_key_binding.sql (SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001 Phase-1) before this migration';
+  END IF;
+END
+$preflight2$;
+
+-- ============================================================
+-- 1. fn_submit_venture_user_feedback (FR-1): the new ownership-bound RPC, the sole anon-callable
+--    write path for feedback_type LIKE 'user_%' rows once the policy below is dropped. Reuses
+--    Phase-1's venture_ingest_keys / _verify_venture_ingest_secret unmodified, and the pre-existing
+--    check_feedback_rate_limit unmodified (FR-2 — no duplicate threshold invented).
+-- ============================================================
+CREATE OR REPLACE FUNCTION public.fn_submit_venture_user_feedback(
+  p_venture_id UUID,
+  p_ingest_secret TEXT,
+  p_feedback_type TEXT,
+  p_title TEXT,
+  p_description TEXT
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_new_id UUID;
+  v_venture_name TEXT;
+  v_type TEXT;
+  v_global_count BIGINT;
+BEGIN
+  -- Ownership check FIRST (uniform ERRCODE=28000, matching fn_submit_venture_feedback's convention
+  -- so a wrong secret and a nonexistent venture_id are indistinguishable to the caller, TS-2/TS-3).
+  -- _verify_venture_ingest_secret returns TRUE=authorized -- IS NOT TRUE is the correct fail-closed
+  -- form HERE (contrast the rate-limit check below, which has the OPPOSITE polarity).
+  IF public._verify_venture_ingest_secret(p_venture_id, p_ingest_secret) IS NOT TRUE THEN
+    RAISE EXCEPTION 'fn_submit_venture_user_feedback: unauthorized' USING ERRCODE = '28000';
+  END IF;
+
+  -- Defense-in-depth: a venture can be soft-deleted or have telemetry ingestion disabled after its
+  -- key was provisioned. Same uniform code -- do not distinguish "deactivated" from "unauthorized"
+  -- (TS-7).
+  IF public.venture_exists_and_active(p_venture_id) IS NOT TRUE THEN
+    RAISE EXCEPTION 'fn_submit_venture_user_feedback: unauthorized' USING ERRCODE = '28000';
+  END IF;
+
+  IF p_feedback_type NOT IN ('user_bug', 'user_feature_request', 'user_usability', 'user_other') THEN
+    RAISE EXCEPTION 'fn_submit_venture_user_feedback: invalid feedback_type' USING ERRCODE = '22004';
+  END IF;
+
+  IF p_title IS NULL OR length(trim(p_title)) = 0 THEN
+    RAISE EXCEPTION 'fn_submit_venture_user_feedback: title is required' USING ERRCODE = '22004';
+  END IF;
+
+  -- FR-2/TR-6: check_feedback_rate_limit returns TRUE when the caller IS rate-limited (confirmed
+  -- live, database/migrations/20260401_venture_user_feedback_channel.sql:117) -- DIRECT TRUTHY
+  -- CHECK, never 'IS NOT TRUE' (that idiom belongs to the OPPOSITE-polarity ownership check above;
+  -- applying it here would invert this check).
+  IF public.check_feedback_rate_limit(p_venture_id) THEN
+    RAISE EXCEPTION 'fn_submit_venture_user_feedback: rate limited' USING ERRCODE = '53400';
+  END IF;
+
+  -- FR-2: global cross-venture ceiling, 10x the per-venture threshold (500/hour), matching Phase-1's
+  -- own documented derivation for its equivalent backstop (fn_anon_ingress_prior_hour_count usage in
+  -- database/chairman-gated/20260812_venture_ingest_key_binding.sql). This SECURITY DEFINER function
+  -- never evaluates the RESTRICTIVE anon_feedback_ingress_bounds policy (rolbypassrls), so without
+  -- this the cross-venture DoS protection that policy provided for the raw-INSERT path is silently
+  -- lost, not merely narrowed.
+  SELECT count(*) INTO v_global_count
+  FROM public.feedback
+  WHERE feedback_type IN ('user_bug', 'user_feature_request', 'user_usability', 'user_other')
+    AND created_at > now() - interval '1 hour';
+  IF v_global_count >= 500 THEN
+    RAISE EXCEPTION 'fn_submit_venture_user_feedback: rate limited' USING ERRCODE = '53400';
+  END IF;
+
+  -- type is a coarser issue/enhancement classifier distinct from feedback_type (confirmed live via
+  -- feedback_type_check vs feedback_feedback_type_check -- two separate CHECK constraints on two
+  -- separate columns). Both are NOT NULL with no default on type, so both must be supplied.
+  v_type := CASE WHEN p_feedback_type = 'user_feature_request' THEN 'enhancement' ELSE 'issue' END;
+
+  -- source_application is NOT NULL with no default (confirmed live via information_schema.columns)
+  -- -- mirrors fn_submit_venture_feedback's own convention of using the venture's name rather than a
+  -- generic literal, so this stays informative if multiple ventures use this same RPC.
+  SELECT coalesce(name, 'unknown-venture') INTO v_venture_name FROM public.ventures WHERE id = p_venture_id;
+
+  -- created_at/status/votes/assigned_to/triaged_by/user_id are never parameters -- none can be
+  -- client-forged (matches fn_submit_venture_feedback's established contract).
+  INSERT INTO public.feedback (
+    venture_id, feedback_type, type, source_type, source_application, title, description, status
+  ) VALUES (
+    p_venture_id, p_feedback_type, v_type, 'user_feedback', v_venture_name,
+    left(p_title, 255), left(p_description, 2000), 'new'
+  )
+  RETURNING id INTO v_new_id;
+
+  RETURN jsonb_build_object('ok', true, 'id', v_new_id);
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_submit_venture_user_feedback(UUID, TEXT, TEXT, TEXT, TEXT) IS
+  'SD-LEO-FIX-CLOSE-ANON-VENTURE-001 FR-1: ownership-bound replacement for the anon INSERT path on '
+  'venture_user_insert_feedback. Uniform ERRCODE=28000 for every ownership-check reject path '
+  '(TS-2/TS-3). created_at/status/votes/assigned_to/triaged_by/user_id are never parameters. For a '
+  'browser-exposed secret (see this file''s header), this narrows cross-venture forgery but does not '
+  'eliminate targeted forgery -- documented, not silently accepted.';
+
+-- TR-2: explicit REVOKE FROM PUBLIC, authenticated BEFORE GRANT TO anon, service_role -- this
+-- instance's ALTER DEFAULT PRIVILEGES grants EXECUTE directly to anon AND authenticated on every
+-- freshly created function (confirmed live, same mechanism documented in Phase-1's own header), so
+-- REVOKE FROM PUBLIC alone would not remove the direct authenticated grant.
+REVOKE ALL ON FUNCTION public.fn_submit_venture_user_feedback(UUID, TEXT, TEXT, TEXT, TEXT) FROM PUBLIC, authenticated;
+GRANT EXECUTE ON FUNCTION public.fn_submit_venture_user_feedback(UUID, TEXT, TEXT, TEXT, TEXT) TO anon, service_role;
+
+-- ============================================================
+-- 2. DROP the vulnerable policy (FR-3). DROP POLICY only, NEVER a table-level REVOKE -- see header
+--    correction (3). The table-level anon INSERT grant remains untouched and is asserted unchanged
+--    by the $verify$ block below.
+-- ============================================================
+DROP POLICY IF EXISTS venture_user_insert_feedback ON public.feedback;
+
+-- ============================================================
+-- 3. Self-verify (TR-3): static catalog assertions only -- the dynamic "a raw anon INSERT is now
+--    rejected" behavioral proof (TS-5) lives in this file's DDL test (rolled-back transactions with
+--    SET LOCAL ROLE anon), matching this SD family's established split between static $verify$
+--    checks here and dynamic behavioral tests in tests/ddl/.
+-- ============================================================
+DO $verify$
+BEGIN
+  -- FR-3: the vulnerable policy is gone.
+  IF (SELECT count(*) FROM pg_policies WHERE schemaname = 'public' AND tablename = 'feedback' AND policyname = 'venture_user_insert_feedback') <> 0 THEN
+    RAISE EXCEPTION 'VERIFY FAILED: venture_user_insert_feedback still present in pg_policies';
+  END IF;
+
+  -- FR-3(d): the table-level anon INSERT grant was NOT collaterally revoked -- it is shared with
+  -- anon_feedback_ingress_bounds and possibly telegram_bot_insert_feedback.
+  IF has_table_privilege('anon', 'public.feedback', 'INSERT') IS NOT TRUE THEN
+    RAISE EXCEPTION 'VERIFY FAILED: anon lost table-level INSERT privilege on public.feedback -- other anon-reachable policies on this table would become unreachable';
+  END IF;
+
+  -- Sibling policy integrity: anon_feedback_ingress_bounds must remain present, INSERT-scoped,
+  -- RESTRICTIVE, and still apply to the public role -- mutation-resistant per this SD family's
+  -- established discipline (mirrors telegram-revoke migration's own M1b/M1c assertions).
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public' AND tablename = 'feedback' AND policyname = 'anon_feedback_ingress_bounds'
+      AND cmd = 'INSERT' AND permissive = 'RESTRICTIVE' AND 'public' = ANY(roles)
+  ) THEN
+    RAISE EXCEPTION 'VERIFY FAILED: anon_feedback_ingress_bounds is missing, no longer applies to INSERT, is no longer RESTRICTIVE, or no longer applies to the public role';
+  END IF;
+
+  -- public.feedback still has RLS enabled.
+  IF (SELECT relrowsecurity FROM pg_class WHERE oid = 'public.feedback'::regclass) IS NOT TRUE THEN
+    RAISE EXCEPTION 'VERIFY FAILED: public.feedback does not have RLS enabled';
+  END IF;
+
+  -- TR-2/TR-3: full grant posture on the new function -- anon and service_role CAN execute it,
+  -- PUBLIC and authenticated CANNOT.
+  IF has_function_privilege('anon', 'public.fn_submit_venture_user_feedback(uuid,text,text,text,text)', 'EXECUTE') IS NOT TRUE THEN
+    RAISE EXCEPTION 'VERIFY FAILED: fn_submit_venture_user_feedback is NOT anon-callable -- the fix would be unreachable';
+  END IF;
+  IF has_function_privilege('authenticated', 'public.fn_submit_venture_user_feedback(uuid,text,text,text,text)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'VERIFY FAILED: fn_submit_venture_user_feedback is callable by authenticated -- should be anon/service_role only';
+  END IF;
+
+  -- TR-3: defense-in-depth re-check that Phase-1's own lockdown of the objects this function reuses
+  -- still holds (in case a manual grant mistake weakened it between Phase-1's apply and this one).
+  IF has_function_privilege('anon', 'public._verify_venture_ingest_secret(uuid,text)', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public._verify_venture_ingest_secret(uuid,text)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'VERIFY FAILED: _verify_venture_ingest_secret is callable by anon or authenticated -- Phase-1 lockdown appears weakened';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM information_schema.role_table_grants
+    WHERE table_schema = 'public' AND table_name = 'venture_ingest_keys'
+      AND grantee IN ('anon', 'authenticated', 'PUBLIC')
+  ) THEN
+    RAISE EXCEPTION 'VERIFY FAILED: venture_ingest_keys is reachable by anon/authenticated/PUBLIC -- Phase-1 lockdown appears weakened';
+  END IF;
+END
+$verify$;
+
+-- PostgREST caches the schema; without this, fn_submit_venture_user_feedback returns 404/PGRST202
+-- to real anon clients until PostgREST's own reload cycle catches up (established convention, e.g.
+-- database/chairman-gated/20260812_venture_ingest_key_binding.sql).
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql
+++ b/database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql
@@ -102,6 +102,17 @@
 -- exact order, in its own beforeAll, and asserts the source_type='telegram' bypass is rejected only
 -- once both have run — it does not claim closure from this file in isolation.
 --
+-- COORDINATOR ADVERSARIAL REVIEW FINDING (directive 679ac85f, 2026-08-15, CONDITIONAL_PASS — not a
+-- code change in this PR, sequencing precondition only): ehg/src/integrations/feedback/
+-- feedbackDataAccess.ts currently inserts feedback as anon THROUGH venture_user_insert_feedback,
+-- the exact policy this file DROPs — it has NOT been switched to call fn_submit_venture_user_feedback
+-- in this PR. Applying this migration BEFORE that app switch ships would break the EHG app's own
+-- feedback submissions (RLS-rejected the moment the policy is gone). REQUIRED ORDER: (1) EHG app
+-- switches its insert path to fn_submit_venture_user_feedback (with the venture ingest secret) and
+-- ships; (2) THEN apply this migration (after Phase-1 + telegram-revoke, per the sequencing above).
+-- Tracked as a hard precondition on strategic_directives_v2.metadata.apply_pending_ceremony and on
+-- successor SD-LEO-INFRA-CHAIRMAN-APPLY-CEREMONY-001 (FR-6).
+--
 -- ═══════════════════════════════════════════════════════════════════════════════════════════════
 -- CORRECTIONS FROM PROSPECTIVE PLAN-PHASE TESTING REVIEW (evidence ffe58c4e-7c8d-4d53-8dbf-
 -- 8634b5f0ec62), applied before this file was first written, not discovered after

--- a/database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql
+++ b/database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql
@@ -47,19 +47,49 @@
 -- someone targeting that one specific venture. Do not represent this migration as closing that case
 -- fully — it narrows, it does not eliminate, for a browser-exposed secret.
 --
+-- SEC-M3 (SECURITY sub-agent, EXEC review, documentation-only, evidence cefd6b89-cf93-4b34-8b4e-
+-- e9b348795bd2): GLOBAL-CEILING SCALING TRIPWIRE. A single browser-exposed secret can drive one
+-- venture to its own 50/hour per-venture threshold; the 500/hour global ceiling therefore starts
+-- meaningfully constraining LEGITIMATE traffic once roughly 10 browser-exposed ventures are each
+-- independently near their own per-venture cap in the same trailing hour -- at that point the global
+-- ceiling degrades from "cross-venture DoS backstop" toward "shared budget venture operators compete
+-- for." Not a blocker today (current traffic measured two orders of magnitude below this ceiling,
+-- per the SECURITY sub-agent's own live measurement), but worth revisiting if browser-exposed adoption
+-- grows materially past that scale.
+--
 -- ═══════════════════════════════════════════════════════════════════════════════════════════════
--- SEQUENCING DEPENDENCY (PRD FR-7 — operational, not a DDL-enforceable check within this file)
+-- SEQUENCING DEPENDENCY IS SECURITY-LOAD-BEARING, NOT MERE APPLY-ORDER HYGIENE (PRD FR-7 — CORRECTED
+-- post-EXEC, SECURITY sub-agent HIGH-1 finding, evidence cefd6b89-cf93-4b34-8b4e-e9b348795bd2)
 -- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- THIS MIGRATION ALONE DOES NOT FULLY CLOSE THE VENTURE-SPOOFING GAP. public.feedback's
+-- telegram_bot_insert_feedback policy (PERMISSIVE, anon, INSERT, WITH CHECK (source_type =
+-- 'telegram')) has NO venture_id or feedback_type constraint whatsoever. As long as it remains
+-- live, an anon caller can attribute a user_bug-shaped row to ANY venture by simply setting
+-- source_type='telegram' instead of calling fn_submit_venture_user_feedback — bypassing this
+-- migration's entire ownership check via a policy this file does not touch. Dropping
+-- venture_user_insert_feedback does not narrow that other policy; PostgreSQL PERMISSIVE policies OR
+-- together, so removing one still-flawed permissive policy does nothing while a MORE permissive
+-- sibling (zero venture constraint, strictly weaker than the existence check this file replaces)
+-- remains reachable. Acceptance criterion "no anon caller can spoof venture_id for user_%-type
+-- feedback" is therefore only TRUE once BOTH this file AND the sibling below have applied — not
+-- after this file alone.
+--
 -- database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql (sibling, from the
 -- completed SD-FDBK-INFRA-MIGRATE-ANON-INGEST-001, also confirmed STAGED-NOT-APPLIED live 2026-08-15)
--- has its OWN $verify$ block that asserts venture_user_insert_feedback remains PRESENT with an
--- UNCHANGED WITH CHECK clause, and that anon retains table-level INSERT — all violated by THIS
--- file's own DROP POLICY action below. BEFORE APPLYING THIS FILE: confirm via a live pg_policies
--- read whether 20260813_revoke_telegram_bot_insert_feedback.sql has already landed (telegram_bot_
--- insert_feedback absent = already applied, no action needed) or is still pending (telegram_bot_
--- insert_feedback present = apply that migration first, or in the same ceremony immediately before
--- this one). Applying THIS file first would cause that sibling migration's own next apply attempt
--- to hard-fail on a confusing, seemingly-unrelated error.
+-- drops that exact policy, and has its OWN $verify$ block that asserts venture_user_insert_feedback
+-- remains PRESENT with an UNCHANGED WITH CHECK clause, and that anon retains table-level INSERT —
+-- both violated by THIS file's own DROP POLICY action below. THE ORDER IS THEREFORE STRICT, not a
+-- convenience: the sibling MUST land first (or in the same ceremony immediately before this one).
+-- BEFORE APPLYING THIS FILE: confirm via a live pg_policies read whether
+-- 20260813_revoke_telegram_bot_insert_feedback.sql has already landed (telegram_bot_insert_feedback
+-- absent = already applied, safe to proceed) or is still pending (telegram_bot_insert_feedback
+-- present = apply that migration first). Applying THIS file first would ALSO cause that sibling
+-- migration's own next apply attempt to hard-fail (its byte-exact WITH CHECK compare would find
+-- venture_user_insert_feedback missing) — a real but secondary consequence; the primary one is the
+-- unclosed spoofing path above, which persists for however long the wrong order stands.
+-- tests/ddl/venture-user-feedback-ownership-rpc-ddl.db.test.js applies both migrations, in this
+-- exact order, in its own beforeAll, and asserts the source_type='telegram' bypass is rejected only
+-- once both have run — it does not claim closure from this file in isolation.
 --
 -- ═══════════════════════════════════════════════════════════════════════════════════════════════
 -- CORRECTIONS FROM PROSPECTIVE PLAN-PHASE TESTING REVIEW (evidence ffe58c4e-7c8d-4d53-8dbf-
@@ -93,9 +123,15 @@
 --
 -- ═══════════════════════════════════════════════════════════════════════════════════════════════
 -- ROLLBACK (manual, if needed — additive except for the one DROP POLICY, safe to reverse in one pass)
+-- SEC-L2 (SECURITY sub-agent, EXEC review): wrapped in its own transaction, with a trailing PostgREST
+-- reload -- matching this file's own apply block, so a rollback leaves the schema cache consistent
+-- with pg_catalog immediately rather than until PostgREST's own next reload cycle.
 -- ═══════════════════════════════════════════════════════════════════════════════════════════════
+-- BEGIN;
 -- REVOKE EXECUTE ON FUNCTION public.fn_submit_venture_user_feedback(UUID, TEXT, TEXT, TEXT, TEXT) FROM anon, service_role;
 -- DROP FUNCTION IF EXISTS public.fn_submit_venture_user_feedback(UUID, TEXT, TEXT, TEXT, TEXT);
+-- GRANT EXECUTE ON FUNCTION public.venture_exists_and_active(uuid) TO anon;
+-- GRANT EXECUTE ON FUNCTION public.check_feedback_rate_limit(uuid) TO anon, authenticated;
 -- CREATE POLICY venture_user_insert_feedback ON public.feedback
 --   FOR INSERT TO anon
 --   WITH CHECK (
@@ -104,8 +140,19 @@
 --     AND venture_exists_and_active(venture_id)
 --     AND (NOT check_feedback_rate_limit(venture_id))
 --   );
+-- NOTIFY pgrst, 'reload schema';
+-- COMMIT;
 
 BEGIN;
+
+-- SEC-L1 (SECURITY sub-agent, EXEC review, evidence cefd6b89-cf93-4b34-8b4e-e9b348795bd2): bounded
+-- wait for the ACCESS EXCLUSIVE lock DROP POLICY needs on public.feedback -- same rationale and
+-- precedent as the sibling telegram-revoke migration's identical guard (this table's own 2026-08-12
+-- incident record is exactly an unbounded lock wait here turning into a live-writer-blocking queue).
+-- 5s, not that sibling's 2s: this migration does strictly more work under the same lock (two extra
+-- REVOKEs, a richer $verify$ block) so a slightly wider window avoids a spurious fail-fast on an
+-- otherwise-healthy apply.
+SET LOCAL lock_timeout = '5s';
 
 -- ============================================================
 -- 0. PRE-FLIGHT GUARD (FR-5/TR-5): Phase-1 prerequisites must exist before any CREATE FUNCTION
@@ -189,9 +236,15 @@ BEGIN
   -- never evaluates the RESTRICTIVE anon_feedback_ingress_bounds policy (rolbypassrls), so without
   -- this the cross-venture DoS protection that policy provided for the raw-INSERT path is silently
   -- lost, not merely narrowed.
+  -- MEDIUM-2 (SECURITY sub-agent, EXEC review, evidence cefd6b89-cf93-4b34-8b4e-e9b348795bd2):
+  -- source_type = 'user_feedback' scopes the count to rows THIS RPC created. Without it, any other
+  -- writer of a user_%-type row (the pre-drop policy's own historical rows, a future service_role
+  -- insert, etc.) silently counts against a ceiling meant to bound only this anon-reachable path,
+  -- letting an unrelated writer exhaust the channel for every venture at once.
   SELECT count(*) INTO v_global_count
   FROM public.feedback
   WHERE feedback_type IN ('user_bug', 'user_feature_request', 'user_usability', 'user_other')
+    AND source_type = 'user_feedback'
     AND created_at > now() - interval '1 hour';
   IF v_global_count >= 500 THEN
     RAISE EXCEPTION 'fn_submit_venture_user_feedback: rate limited' USING ERRCODE = '53400';
@@ -243,6 +296,28 @@ GRANT EXECUTE ON FUNCTION public.fn_submit_venture_user_feedback(UUID, TEXT, TEX
 DROP POLICY IF EXISTS venture_user_insert_feedback ON public.feedback;
 
 -- ============================================================
+-- 2b. MEDIUM-1 (SECURITY sub-agent, EXEC review, evidence cefd6b89-cf93-4b34-8b4e-e9b348795bd2):
+--     close the now-orphaned direct-EXECUTE oracle. venture_exists_and_active was granted TO anon
+--     by database/migrations/20260704f_fix_venture_user_feedback_ventures_visibility.sql SPECIFICALLY
+--     because venture_user_insert_feedback's WITH CHECK evaluates it under RLS -- RLS policy
+--     expressions run as the querying role even for a SECURITY DEFINER function, so anon needed
+--     direct EXECUTE to invoke it there (confirmed live: that migration's own header, "so anon-role
+--     RLS policies (e.g. venture_user_insert_feedback) can gate on it"). check_feedback_rate_limit
+--     was, for the identical reason, the sole entry (count "(1)") kept off database/migrations/
+--     20260603_03_revoke_secdef_execute_from_anon_authenticated.sql's revoke sweep by its dynamic
+--     policy-usage scan. Both grants are now orphaned by the DROP above -- confirmed no OTHER live
+--     policy or direct .rpc() caller depends on either (anon_feedback_ingress_bounds only mentions
+--     them in a contrasting comment; every remaining caller -- this file's own function, Phase-1's
+--     fn_submit_venture_feedback/fn_submit_venture_error -- invokes them from INSIDE its own
+--     SECURITY DEFINER body, which runs under the FUNCTION OWNER's privileges for nested calls, not
+--     the caller's, so neither needs anon's direct grant). Leaving them live is an unauthenticated
+--     existence/rate-limit oracle with no write attached -- narrow, but unnecessary once the one
+--     policy that required it is gone.
+-- ============================================================
+REVOKE EXECUTE ON FUNCTION public.venture_exists_and_active(uuid) FROM PUBLIC, anon, authenticated;
+REVOKE EXECUTE ON FUNCTION public.check_feedback_rate_limit(uuid) FROM PUBLIC, anon, authenticated;
+
+-- ============================================================
 -- 3. Self-verify (TR-3): static catalog assertions only -- the dynamic "a raw anon INSERT is now
 --    rejected" behavioral proof (TS-5) lives in this file's DDL test (rolled-back transactions with
 --    SET LOCAL ROLE anon), matching this SD family's established split between static $verify$
@@ -291,6 +366,18 @@ BEGIN
   IF has_function_privilege('anon', 'public._verify_venture_ingest_secret(uuid,text)', 'EXECUTE')
      OR has_function_privilege('authenticated', 'public._verify_venture_ingest_secret(uuid,text)', 'EXECUTE') THEN
     RAISE EXCEPTION 'VERIFY FAILED: _verify_venture_ingest_secret is callable by anon or authenticated -- Phase-1 lockdown appears weakened';
+  END IF;
+
+  -- MEDIUM-1: the two REVOKEs above actually took effect -- neither helper remains a direct
+  -- existence/rate-limit oracle for anon or authenticated. This function's own internal calls to
+  -- both (inside this SECURITY DEFINER body) are unaffected by either revoke.
+  IF has_function_privilege('anon', 'public.venture_exists_and_active(uuid)', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public.venture_exists_and_active(uuid)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'VERIFY FAILED: venture_exists_and_active is still directly callable by anon or authenticated -- MEDIUM-1 revoke did not take effect';
+  END IF;
+  IF has_function_privilege('anon', 'public.check_feedback_rate_limit(uuid)', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public.check_feedback_rate_limit(uuid)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'VERIFY FAILED: check_feedback_rate_limit is still directly callable by anon or authenticated -- MEDIUM-1 revoke did not take effect';
   END IF;
   IF EXISTS (
     SELECT 1 FROM information_schema.role_table_grants

--- a/database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql
+++ b/database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql
@@ -21,6 +21,17 @@
 -- caller owns this venture" — ownership requires a caller-presented credential checked against a
 -- per-venture record, hence this migration.
 --
+-- NEW-1 (SECURITY sub-agent, EXEC re-review, evidence 378ea5c4-a693-456d-9c40-58b6b12a965f, non-
+-- blocking scope-precision note): this SD's own name can be over-read as closing ALL anon venture-
+-- spoofing. It does not. record_venture_error (a DIFFERENT anon-executable SECURITY DEFINER
+-- function) hardcodes feedback_type='venture_error'/source_type='error_capture' as literals, so it
+-- cannot be driven to emit a user_%-type row and this migration's own acceptance criterion is
+-- unaffected — but it retains the SAME existence-only (not ownership) venture_id check for the
+-- venture_error shape specifically, deliberately out of scope here and already named as deferred
+-- work in Phase-1's own header (database/chairman-gated/20260812_venture_ingest_key_binding.sql).
+-- User_%-shaped spoofing: closed by this file (plus its sibling, see below). Venture_error-shaped
+-- spoofing: still open, owned by SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001, not this SD.
+--
 -- ═══════════════════════════════════════════════════════════════════════════════════════════════
 -- RELATIONSHIP TO SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001 PHASE-1 (completed 2026-08-13)
 -- ═══════════════════════════════════════════════════════════════════════════════════════════════

--- a/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
+++ b/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
@@ -60,12 +60,46 @@ CREATE TABLE IF NOT EXISTS public.ventures (
   deleted_at TIMESTAMPTZ
 );
 
+-- T-1/T-2 (testing-agent, SD-LEO-FIX-CLOSE-ANON-VENTURE-001 EXEC review): this table shape now
+-- matches the live schema's full NOT NULL column set exactly (type, source_application, title
+-- included), the SAME definition SD-LEO-FIX-CLOSE-ANON-VENTURE-001's own ddl test declares for this
+-- shared table. Both files' CREATE TABLE IF NOT EXISTS now produce an IDENTICAL shape, so this file
+-- passes in isolation AND regardless of which file's beforeAll wins the shared-database race — no
+-- longer order-dependent (previously: this file's own bare INSERTs supplied type/source_application/
+-- title while this table never declared them, so this file could only pass if the OTHER file's
+-- richer definition happened to run first and win the race).
 CREATE TABLE IF NOT EXISTS public.feedback (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  feedback_type VARCHAR NOT NULL DEFAULT 'sentry_error',
-  source_type VARCHAR NOT NULL,
+  type VARCHAR(20) NOT NULL,
+  source_application VARCHAR(255) NOT NULL,
+  source_type VARCHAR(30) NOT NULL,
+  title VARCHAR(255) NOT NULL,
+  description TEXT,
+  status VARCHAR(20) DEFAULT 'new',
+  severity VARCHAR(20),
+  category VARCHAR(50),
+  error_message TEXT,
+  error_hash VARCHAR(64),
+  occurrence_count INTEGER DEFAULT 1,
+  first_seen TIMESTAMPTZ,
+  last_seen TIMESTAMPTZ,
+  votes INTEGER DEFAULT 0,
+  assigned_to VARCHAR(100),
+  triaged_by VARCHAR(100),
+  user_id UUID,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  metadata JSONB DEFAULT '{}'::jsonb,
   venture_id UUID,
-  created_at TIMESTAMPTZ DEFAULT now()
+  feedback_type VARCHAR(30) NOT NULL DEFAULT 'sentry_error',
+  CONSTRAINT feedback_feedback_type_check CHECK (feedback_type IN (
+    'sentry_error', 'user_bug', 'user_feature_request', 'user_usability', 'user_other', 'venture_error'
+  )),
+  CONSTRAINT feedback_source_type_check CHECK (source_type IN (
+    'manual_feedback', 'auto_capture', 'uat_failure', 'error_capture', 'uncaught_exception',
+    'unhandled_rejection', 'manual_capture', 'todoist_intake', 'youtube_intake',
+    'claude_code_intake', 'telegram', 'user_feedback'
+  ))
 );
 
 ALTER TABLE public.feedback ENABLE ROW LEVEL SECURITY;
@@ -247,8 +281,11 @@ describe('TS-1/TS-6: bare telegram-sourced anon INSERT is rejected post-migratio
         // type/source_application/title added (this SD's PR): the real public.feedback has these
         // as NOT NULL with no default (confirmed live, 2026-08-15) — irrelevant to THIS test since
         // RLS denial fires before row materialization, but kept consistent with the other inserts
-        // below so no bare insert in this file depends on which stub table definition happens to
-        // win the shared-database CREATE TABLE IF NOT EXISTS race.
+        // below. T-1/T-2 (testing-agent, EXEC review): this file's OWN CREATE TABLE IF NOT EXISTS
+        // above now declares these same NOT NULL columns, so this insert's shape is correct
+        // regardless of which file's beforeAll wins the shared-database table-creation race — no
+        // longer order-dependent (superseded an earlier version of this comment that claimed
+        // order-independence while the table definition below it did not yet match).
         await client.query(
           "INSERT INTO public.feedback (source_type, feedback_type, venture_id, type, source_application, title) VALUES ('telegram', 'sentry_error', NULL, 'issue', 'ddl-test-stub', 'stub row')",
         );

--- a/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
+++ b/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
@@ -129,6 +129,18 @@ RETURNS BOOLEAN LANGUAGE sql STABLE SECURITY DEFINER
 SET search_path = public, pg_catalog
 AS $$ SELECT false; $$;
 
+-- Explicit, unconditional re-GRANT (measured live in CI, this SD's fifth push): CREATE OR REPLACE
+-- FUNCTION preserves an EXISTING function's ACL rather than resetting it to default -- it does NOT
+-- restore a grant a PRIOR statement revoked. SD-LEO-FIX-CLOSE-ANON-VENTURE-001's own migration (also
+-- applied for real, earlier, in tests/ddl/venture-user-feedback-ownership-rpc-ddl.db.test.js, which
+-- shares this SAME physical database) now REVOKEs anon/authenticated EXECUTE on these same two
+-- function names as part of its own MEDIUM-1 fix -- correct for that migration's real target (the
+-- policy that needed the grant is dropped there), but this file's OWN stub venture_user_insert_
+-- feedback policy below STILL evaluates both under RLS as anon and needs the grant restored,
+-- regardless of which file's beforeAll happened to run first in this shared-database CI job.
+GRANT EXECUTE ON FUNCTION public.venture_exists_and_active(uuid) TO anon;
+GRANT EXECUTE ON FUNCTION public.check_feedback_rate_limit(uuid) TO anon;
+
 -- Pre-existing, mirrors live state BEFORE this migration runs.
 CREATE POLICY telegram_bot_insert_feedback ON public.feedback
   FOR INSERT TO anon

--- a/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
+++ b/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
@@ -244,8 +244,13 @@ describe('TS-1/TS-6: bare telegram-sourced anon INSERT is rejected post-migratio
       await client.query('SET LOCAL ROLE anon');
       let err;
       try {
+        // type/source_application/title added (this SD's PR): the real public.feedback has these
+        // as NOT NULL with no default (confirmed live, 2026-08-15) — irrelevant to THIS test since
+        // RLS denial fires before row materialization, but kept consistent with the other inserts
+        // below so no bare insert in this file depends on which stub table definition happens to
+        // win the shared-database CREATE TABLE IF NOT EXISTS race.
         await client.query(
-          'INSERT INTO public.feedback (source_type, feedback_type, venture_id) VALUES (\'telegram\', \'sentry_error\', NULL)',
+          "INSERT INTO public.feedback (source_type, feedback_type, venture_id, type, source_application, title) VALUES ('telegram', 'sentry_error', NULL, 'issue', 'ddl-test-stub', 'stub row')",
         );
       } catch (e) {
         err = e;
@@ -274,8 +279,10 @@ describe('TS-1/TS-6: bare telegram-sourced anon INSERT is rejected post-migratio
       // No RETURNING here either — telegram_bot_select_feedback would cover this specific row
       // (source_type='telegram'), but confirming via a privileged read after RESET ROLE keeps this
       // test's proof mechanism uniform with TS-2/TS-8 above rather than depending on it.
+      // type/source_application/title added (this SD's PR) -- see the note on the first bare
+      // insert above.
       await client.query(
-        'INSERT INTO public.feedback (source_type, feedback_type, venture_id) VALUES (\'telegram\', \'sentry_error\', NULL)',
+        "INSERT INTO public.feedback (source_type, feedback_type, venture_id, type, source_application, title) VALUES ('telegram', 'sentry_error', NULL, 'issue', 'ddl-test-stub', 'stub row')",
       );
       await client.query('RESET ROLE');
       const { rows } = await client.query(
@@ -301,8 +308,10 @@ describe('TS-2/TS-8: the venture_user_insert_feedback residual path still lands 
     await client.query('BEGIN');
     try {
       await client.query('SET LOCAL ROLE anon');
+      // type/source_application/title added (this SD's PR) -- see the note on the first bare
+      // insert in the describe block above.
       await client.query(
-        'INSERT INTO public.feedback (source_type, feedback_type, venture_id) VALUES (\'auto_capture\', \'user_bug\', $1)',
+        "INSERT INTO public.feedback (source_type, feedback_type, venture_id, type, source_application, title) VALUES ('auto_capture', 'user_bug', $1, 'issue', 'ddl-test-stub', 'stub row')",
         [ventureId],
       );
       await client.query('RESET ROLE');
@@ -321,8 +330,10 @@ describe('TS-2/TS-8: the venture_user_insert_feedback residual path still lands 
     await client.query('BEGIN');
     try {
       await client.query('SET LOCAL ROLE anon');
+      // type/source_application/title added (this SD's PR) -- see the note on the first bare
+      // insert in this file, above.
       await client.query(
-        'INSERT INTO public.feedback (source_type, feedback_type, venture_id) VALUES (\'telegram\', \'user_bug\', $1)',
+        "INSERT INTO public.feedback (source_type, feedback_type, venture_id, type, source_application, title) VALUES ('telegram', 'user_bug', $1, 'issue', 'ddl-test-stub', 'stub row')",
         [ventureId],
       );
       await client.query('RESET ROLE');

--- a/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
+++ b/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
@@ -100,6 +100,16 @@ CREATE POLICY telegram_bot_insert_feedback ON public.feedback
   FOR INSERT TO anon
   WITH CHECK (source_type = 'telegram');
 
+-- DROP IF EXISTS before these two CREATE POLICY statements (Postgres has no CREATE POLICY IF NOT
+-- EXISTS): SD-LEO-FIX-CLOSE-ANON-VENTURE-001's DDL test declares stub policies of these SAME two
+-- names for the same reason (its own migration's $verify$ block also reads them), and all
+-- tests/ddl/**/*.db.test.js files share ONE ephemeral Postgres container within a CI job
+-- (fileParallelism: false, sequential, but the database persists across files) — file run order is
+-- NOT guaranteed alphabetical (measured live in CI: this file ran both before and after that one
+-- across two consecutive runs of the same job), so whichever file's beforeAll runs second must not
+-- assume a clean slate. venture_user_insert_feedback and anon_feedback_ingress_bounds are the two
+-- names both files share; telegram_bot_insert_feedback is unique to this file and needs no guard.
+DROP POLICY IF EXISTS venture_user_insert_feedback ON public.feedback;
 CREATE POLICY venture_user_insert_feedback ON public.feedback
   FOR INSERT TO anon
   WITH CHECK (
@@ -114,6 +124,7 @@ CREATE POLICY venture_user_insert_feedback ON public.feedback
 -- now asserts this policy is present and RESTRICTIVE, DATABASE sub-agent finding M1) does not
 -- spuriously RAISE on this ephemeral database. Always-true, so it never changes any other test's
 -- observable behavior below.
+DROP POLICY IF EXISTS anon_feedback_ingress_bounds ON public.feedback;
 CREATE POLICY anon_feedback_ingress_bounds ON public.feedback
   AS RESTRICTIVE
   FOR INSERT TO public

--- a/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
+++ b/tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js
@@ -55,9 +55,23 @@ BEGIN
 END
 $roles$;
 
+-- T-9 (testing-agent, SD-LEO-FIX-CLOSE-ANON-VENTURE-001 EXEC re-review): same T-1/T-2 self-
+-- sufficiency treatment, applied to the OTHER table these tests/ddl/**/*.db.test.js files share.
+-- Vitest's sequencer sorts files by size DESCENDING with no cache, so growing this file's own
+-- public.feedback stub (T-1/T-2's fix) shifted which file wins the shared CREATE TABLE IF NOT
+-- EXISTS race for public.ventures too -- a minimal (id, deleted_at) shape here vs the richer
+-- (id, name, deleted_at, metadata) shape both venture-ingest-key-binding-ddl.db.test.js and
+-- venture-user-feedback-ownership-rpc-ddl.db.test.js declare. CI is green today only because this
+-- SD's own larger file happens to run first; trimming it back below either sibling's size would
+-- make THIS minimal shape win instead, breaking both siblings' own INSERT INTO public.ventures
+-- (name) and venture_exists_and_active's v.metadata reference. Matching the richer shape here
+-- removes the order-dependency the same way T-1/T-2 did for public.feedback, rather than relying
+-- on today's incidental file-size ordering.
 CREATE TABLE IF NOT EXISTS public.ventures (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  deleted_at TIMESTAMPTZ
+  name TEXT,
+  deleted_at TIMESTAMPTZ,
+  metadata JSONB DEFAULT '{}'::jsonb
 );
 
 -- T-1/T-2 (testing-agent, SD-LEO-FIX-CLOSE-ANON-VENTURE-001 EXEC review): this table shape now

--- a/tests/ddl/venture-user-feedback-ownership-rpc-ddl.db.test.js
+++ b/tests/ddl/venture-user-feedback-ownership-rpc-ddl.db.test.js
@@ -550,7 +550,13 @@ describe('FR-2/TS-10: global cross-venture ceiling (state-aware, must run last)'
       "SELECT count(*)::int AS n FROM public.feedback WHERE feedback_type IN ('user_bug','user_feature_request','user_usability','user_other') AND created_at > now() - interval '1 hour'",
     );
     const already = countRows[0].n;
-    const toLand = Math.max(0, GLOBAL_CEILING - already - 1); // leave exactly one slot open
+    // The migration's check reads the count via a SELECT BEFORE inserting the current row, so the
+    // count does NOT yet include the row being submitted. To make the BOUNDARY submission below be
+    // the one that trips "count >= 500", the count must already equal exactly 500 when its check
+    // runs -- so top up to GLOBAL_CEILING exactly, not GLOBAL_CEILING - 1 (off-by-one caught live in
+    // CI, this SD's fourth push: the boundary submission landed successfully as row #500 instead of
+    // being rejected as the 501st).
+    const toLand = Math.max(0, GLOBAL_CEILING - already);
 
     // Spread remaining submissions across enough ventures that no SINGLE venture's own 50/hour
     // per-venture threshold (a DIFFERENT check, FR-2 direct-truthy) can be the cause of a

--- a/tests/ddl/venture-user-feedback-ownership-rpc-ddl.db.test.js
+++ b/tests/ddl/venture-user-feedback-ownership-rpc-ddl.db.test.js
@@ -76,6 +76,10 @@ function extractDoBlock(sql, tagName, occurrence = 1) {
 const PREFLIGHT_1_SQL = extractDoBlock(MIGRATION_SQL, 'preflight');
 const PREFLIGHT_2_SQL = extractDoBlock(MIGRATION_SQL, 'preflight2');
 const VERIFY_BLOCK_SQL = extractDoBlock(MIGRATION_SQL, 'verify');
+// T-4 (testing-agent, EXEC re-review): the sibling's own $verify$ block, extracted the same way,
+// re-run later against this file's own post-migration state to prove the WRONG apply order is a
+// real, detected failure -- not only asserted in prose (see the 'T-4' describe block below).
+const TELEGRAM_VERIFY_BLOCK_SQL = extractDoBlock(TELEGRAM_REVOKE_SQL, 'verify');
 
 // Strips full-line `--` comments before matching (established convention, this SD family) — the
 // header prose above names things like "REVOKE" and "record_venture_error" in plain English.
@@ -349,14 +353,19 @@ describe('MEDIUM-1: the now-orphaned direct-EXECUTE oracle is closed', () => {
 });
 
 describe('MEDIUM-2: the global ceiling only counts rows THIS RPC created', () => {
-  it('a user_bug-shaped row inserted by a different writer (source_type != user_feedback) does not count against the ceiling', async () => {
+  it('500 user_bug-shaped rows from a different writer (source_type != user_feedback) do not count against the ceiling', async () => {
+    // T-10 (testing-agent, EXEC re-review): a single non-RPC row against a 500 ceiling cannot
+    // fail if the AND source_type = 'user_feedback' filter were reverted -- 1 or 2 counted rows
+    // is still nowhere near the threshold either way, so the original single-row version of this
+    // test proved the RPC works, not that the filter scopes the count. 500 rows is decisive:
+    // unfiltered, this alone reaches the >= 500 threshold regardless of how many legitimate RPC
+    // rows other tests have already landed by this point in the file; filtered (the fix under
+    // test), it contributes zero, and the RPC below must still succeed.
     const otherVentureId = await makeVenture('other-writer');
-    // Direct insert as the (superuser) test client, mirroring a writer that is NOT this RPC --
-    // e.g. a pre-migration historical row, or any future service_role writer that happens to use
-    // the same feedback_type values. Before MEDIUM-2 this would have counted against the same
-    // global ceiling as RPC-created rows; after, it must not.
     await client.query(
-      "INSERT INTO public.feedback (feedback_type, type, source_type, source_application, title, venture_id) VALUES ('user_bug', 'issue', 'manual_feedback', 'other-writer', 'not from the RPC', $1)",
+      `INSERT INTO public.feedback (feedback_type, type, source_type, source_application, title, venture_id)
+       SELECT 'user_bug', 'issue', 'manual_feedback', 'other-writer', 'bulk non-rpc row ' || gs, $1
+       FROM generate_series(1, 500) AS gs`,
       [otherVentureId],
     );
 
@@ -687,6 +696,20 @@ describe('HIGH-1: the telegram bypass is closed only once BOTH migrations have a
     } finally {
       await client.query('ROLLBACK');
     }
+  });
+});
+
+describe('T-4: applying migrations in the WRONG order is a real, detected failure, not only asserted in prose', () => {
+  it("telegram-revoke's own $verify$ block RAISEs when re-run after this migration has already dropped venture_user_insert_feedback", async () => {
+    // By this point in the file, beforeAll already applied telegram-revoke THEN this migration,
+    // in the strict order the migration header now documents as security-load-bearing -- so
+    // venture_user_insert_feedback is already gone. Re-running telegram-revoke's OWN $verify$
+    // block against that state is exactly what would happen if telegram-revoke were (incorrectly)
+    // applied AFTER this migration instead of before it: its byte-exact WITH CHECK compare finds
+    // the sibling policy missing and raises. This proves the migration header's claim ("applying
+    // this file first would cause that sibling migration's own next apply attempt to hard-fail")
+    // is a real, detected failure mode -- not only documented prose the suite never exercises.
+    await expect(client.query(TELEGRAM_VERIFY_BLOCK_SQL)).rejects.toThrow(/venture_user_insert_feedback is missing from pg_policies/);
   });
 });
 

--- a/tests/ddl/venture-user-feedback-ownership-rpc-ddl.db.test.js
+++ b/tests/ddl/venture-user-feedback-ownership-rpc-ddl.db.test.js
@@ -179,6 +179,13 @@ AS $$
 $$;
 
 -- Pre-existing policies, mirroring live state BEFORE this SD's migration runs.
+-- DROP IF EXISTS before each CREATE POLICY (Postgres has no CREATE POLICY IF NOT EXISTS): all
+-- tests/ddl/**/*.db.test.js files share ONE ephemeral Postgres container within a CI job
+-- (fileParallelism: false, sequential, but the DATABASE persists across files) — the sibling
+-- telegram-bot-insert-feedback-drop-ddl.db.test.js's own stub also declares
+-- anon_feedback_ingress_bounds, and whichever file's beforeAll runs second would otherwise hit
+-- 42710 "policy already exists" (measured live in CI, this SD's first push).
+DROP POLICY IF EXISTS venture_user_insert_feedback ON public.feedback;
 CREATE POLICY venture_user_insert_feedback ON public.feedback
   FOR INSERT TO anon
   WITH CHECK (
@@ -188,6 +195,7 @@ CREATE POLICY venture_user_insert_feedback ON public.feedback
     AND (NOT check_feedback_rate_limit(venture_id))
   );
 
+DROP POLICY IF EXISTS anon_feedback_ingress_bounds ON public.feedback;
 CREATE POLICY anon_feedback_ingress_bounds ON public.feedback
   AS RESTRICTIVE
   FOR INSERT TO public
@@ -386,24 +394,6 @@ describe('FR-2/TS-4/TS-9: rate-limit polarity — the discriminating case', () =
   }, 30_000);
 });
 
-describe('FR-2/TS-10: global cross-venture ceiling', () => {
-  it('[TS-10] the 501st submission across many different under-threshold ventures is rejected by the global ceiling', async () => {
-    // 500 submissions spread across 20 ventures (25 each, safely under each venture's own 50/hour
-    // per-venture threshold) so ONLY the global ceiling can be the cause of the 501st rejection.
-    const secrets = [];
-    for (let v = 0; v < 20; v++) {
-      const ventureId = await makeVenture(`global-${v}`);
-      secrets.push([ventureId, await provisionSecret(ventureId)]);
-    }
-    for (let i = 0; i < 500; i++) {
-      const [ventureId, secret] = secrets[i % 20];
-      await submit(ventureId, secret, 'user_bug', `g${i}`, null);
-    }
-    const [lastVentureId, lastSecret] = secrets[0];
-    await expect(submit(lastVentureId, lastSecret, 'user_bug', 'over global ceiling', null)).rejects.toThrow(/rate limited/);
-  }, 60_000);
-});
-
 describe('TR-1: no forgeable workflow columns as parameters', () => {
   it('the function signature has no status/votes/created_at/assigned_to/triaged_by/user_id parameter', () => {
     const sig = MIGRATION_CODE_ONLY.match(/CREATE OR REPLACE FUNCTION public\.fn_submit_venture_user_feedback\(([^)]*)\)/)[1];
@@ -542,4 +532,47 @@ describe('TS-5: raw anon INSERT against the bare table is rejected post-drop (by
       await client.query('ROLLBACK');
     }
   });
+});
+
+// MUST RUN LAST IN THE FILE (measured live in CI, this SD's first push): the global ceiling
+// (FR-2) counts ALL feedback_type IN ('user_bug', ...) rows created in the trailing hour, with
+// no reset between test blocks -- every prior test in this file that lands a real row (TS-1,
+// TS-4/TS-9's 51-row flood test, etc.) contributes to the SAME counter. A version of this test
+// that assumed a clean slate (submit exactly 500, expect the 501st to fail) crashed mid-loop
+// instead of reaching its own assertion, because earlier tests had already pushed the count
+// close to the ceiling -- and left the counter tripped for every test that ran AFTER it. This
+// version is state-aware (reads the current count first) and runs last, so it cannot pollute
+// any other test's global-ceiling budget.
+describe('FR-2/TS-10: global cross-venture ceiling (state-aware, must run last)', () => {
+  it('[TS-10] tops up to exactly the boundary, then asserts the NEXT submission is rejected by the global ceiling', async () => {
+    const GLOBAL_CEILING = 500;
+    const { rows: countRows } = await client.query(
+      "SELECT count(*)::int AS n FROM public.feedback WHERE feedback_type IN ('user_bug','user_feature_request','user_usability','user_other') AND created_at > now() - interval '1 hour'",
+    );
+    const already = countRows[0].n;
+    const toLand = Math.max(0, GLOBAL_CEILING - already - 1); // leave exactly one slot open
+
+    // Spread remaining submissions across enough ventures that no SINGLE venture's own 50/hour
+    // per-venture threshold (a DIFFERENT check, FR-2 direct-truthy) can be the cause of a
+    // rejection here -- only the global ceiling should fire in this test.
+    const perVenture = 30;
+    const venturesNeeded = Math.max(1, Math.ceil(toLand / perVenture));
+    const secrets = [];
+    for (let v = 0; v < venturesNeeded; v++) {
+      const ventureId = await makeVenture(`global-${v}`);
+      secrets.push([ventureId, await provisionSecret(ventureId)]);
+    }
+    for (let i = 0; i < toLand; i++) {
+      const [ventureId, secret] = secrets[Math.floor(i / perVenture) % secrets.length];
+      await submit(ventureId, secret, 'user_bug', `g${i}`, null);
+    }
+
+    // One fresh, never-before-used venture for the boundary assertion itself -- so a per-venture
+    // limit on a REUSED venture from the top-up loop above cannot be mistaken for the global one.
+    const boundaryVentureId = await makeVenture('global-boundary');
+    const boundarySecret = await provisionSecret(boundaryVentureId);
+    await expect(
+      submit(boundaryVentureId, boundarySecret, 'user_bug', 'over global ceiling', null),
+    ).rejects.toThrow(/rate limited/);
+  }, 120_000);
 });

--- a/tests/ddl/venture-user-feedback-ownership-rpc-ddl.db.test.js
+++ b/tests/ddl/venture-user-feedback-ownership-rpc-ddl.db.test.js
@@ -1,0 +1,545 @@
+// SD-LEO-FIX-CLOSE-ANON-VENTURE-001 — the DDL tier for
+// database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql.
+//
+// ═══════════════════════════════════════════════════════════════════════════════════════════
+// WHAT A GREEN RUN OF THIS FILE DOES **NOT** MEAN
+//
+// This runs against an EPHEMERAL vanilla PostgreSQL 16 with a hand-stubbed schema, reproduced only
+// as far as this migration (and its Phase-1 prerequisite, applied first for real, not stubbed) touch
+// it. It proves this migration's OWN new logic (ownership check, rate-limit polarity, policy
+// removal, pre-flight guard) does what it claims. It does NOT prove:
+//   - production posture (Supabase ALTER DEFAULT PRIVILEGES is not reproduced by vanilla Postgres)
+//   - that the FR-7 cross-migration sequencing constraint is respected at apply time — that is an
+//     operational/ceremony-level check (see this migration's own header), not provable here
+//   - anon-reachability over the real PostgREST/Supabase surface — that would be a Tier C live probe,
+//     not this ephemeral Postgres
+//
+// Unlike the sibling telegram-revoke DDL test (which stubs Phase-1's objects with fakes), THIS file
+// applies Phase-1's REAL migration file first, then this SD's migration on top — a closer rehearsal
+// of the real apply sequence, and the only way to test this migration's own pre-flight guard against
+// genuinely-present (not faked) Phase-1 objects.
+//
+// FAIL-CLOSED, no skip branch: if this file cannot reach a database it fails loudly rather than
+// silently passing (matches this SD family's established convention).
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import pg from 'pg';
+
+const PHASE1_MIGRATION_PATH = fileURLToPath(
+  new URL('../../database/chairman-gated/20260812_venture_ingest_key_binding.sql', import.meta.url),
+);
+const THIS_MIGRATION_PATH = fileURLToPath(
+  new URL('../../database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql', import.meta.url),
+);
+const PHASE1_SQL = fs.readFileSync(PHASE1_MIGRATION_PATH, 'utf8');
+const MIGRATION_SQL = fs.readFileSync(THIS_MIGRATION_PATH, 'utf8');
+
+// Anchored to start-of-line, matching tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js's
+// own extractor rationale: this migration's header prose mentions "$verify$" and "$preflight$"
+// inside comments, which a plain indexOf would find instead of the real statement opener.
+function extractDoBlock(sql, tagName, occurrence = 1) {
+  const startRe = new RegExp(`^DO \\$${tagName}\\$$`, 'gm');
+  let match;
+  let count = 0;
+  let startIdx = -1;
+  while ((match = startRe.exec(sql)) !== null) {
+    count += 1;
+    if (count === occurrence) {
+      startIdx = match.index;
+      break;
+    }
+  }
+  const marker = `$${tagName}$;`;
+  const markerIdx = startIdx === -1 ? -1 : sql.indexOf(marker, startIdx);
+  if (startIdx === -1 || markerIdx === -1) {
+    throw new Error(`could not locate DO $${tagName}$ ... $${tagName}$; block (occurrence ${occurrence}) in migration SQL`);
+  }
+  return sql.slice(startIdx, markerIdx + marker.length);
+}
+const PREFLIGHT_1_SQL = extractDoBlock(MIGRATION_SQL, 'preflight');
+const PREFLIGHT_2_SQL = extractDoBlock(MIGRATION_SQL, 'preflight2');
+const VERIFY_BLOCK_SQL = extractDoBlock(MIGRATION_SQL, 'verify');
+
+// Strips full-line `--` comments before matching (established convention, this SD family) — the
+// header prose above names things like "REVOKE" and "record_venture_error" in plain English.
+const MIGRATION_CODE_ONLY = MIGRATION_SQL.replace(/^\s*--.*$/gm, '');
+
+// Minimal stand-ins for the parts of the real schema Phase-1's migration (applied for real below)
+// and this SD's migration touch. The public.feedback columns match the LIVE schema exactly for the
+// NOT NULL columns this migration's INSERT must populate (type, source_application, source_type,
+// title all confirmed NOT NULL with no default via information_schema.columns, 2026-08-15 — not
+// assumed from Phase-1's own simplified stub, which gives some of these columns defaults the real
+// table does not have).
+const STUB_SCHEMA = `
+DO $roles$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'service_role')  THEN CREATE ROLE service_role NOLOGIN;  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'anon')          THEN CREATE ROLE anon NOLOGIN;          END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'authenticated') THEN CREATE ROLE authenticated NOLOGIN; END IF;
+END
+$roles$;
+
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA extensions;
+
+CREATE TABLE IF NOT EXISTS public.ventures (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT,
+  deleted_at TIMESTAMPTZ,
+  metadata JSONB DEFAULT '{}'::jsonb
+);
+
+CREATE TABLE IF NOT EXISTS public.feedback (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  type VARCHAR(20) NOT NULL,
+  source_application VARCHAR(255) NOT NULL,
+  source_type VARCHAR(30) NOT NULL,
+  title VARCHAR(255) NOT NULL,
+  description TEXT,
+  status VARCHAR(20) DEFAULT 'new',
+  severity VARCHAR(20),
+  category VARCHAR(50),
+  error_message TEXT,
+  error_hash VARCHAR(64),
+  occurrence_count INTEGER DEFAULT 1,
+  first_seen TIMESTAMPTZ,
+  last_seen TIMESTAMPTZ,
+  votes INTEGER DEFAULT 0,
+  assigned_to VARCHAR(100),
+  triaged_by VARCHAR(100),
+  user_id UUID,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now(),
+  metadata JSONB DEFAULT '{}'::jsonb,
+  venture_id UUID,
+  feedback_type VARCHAR(30) NOT NULL DEFAULT 'sentry_error',
+  CONSTRAINT feedback_feedback_type_check CHECK (feedback_type IN (
+    'sentry_error', 'user_bug', 'user_feature_request', 'user_usability', 'user_other', 'venture_error'
+  )),
+  CONSTRAINT feedback_source_type_check CHECK (source_type IN (
+    'manual_feedback', 'auto_capture', 'uat_failure', 'error_capture', 'uncaught_exception',
+    'unhandled_rejection', 'manual_capture', 'todoist_intake', 'youtube_intake',
+    'claude_code_intake', 'telegram', 'user_feedback'
+  ))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_feedback_venture_error_hash
+  ON public.feedback (venture_id, error_hash)
+  WHERE feedback_type = 'venture_error' AND venture_id IS NOT NULL;
+
+ALTER TABLE public.feedback ENABLE ROW LEVEL SECURITY;
+GRANT INSERT ON public.feedback TO anon;
+
+CREATE OR REPLACE FUNCTION public._venture_error_storm_watermark_hash()
+RETURNS text LANGUAGE sql IMMUTABLE
+AS $$ SELECT 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff'; $$;
+
+-- Stand-in for the pre-existing public.record_venture_error, needed only so Phase-1's own
+-- $verify$ block (pg_proc count=1 check) does not spuriously fail here.
+CREATE OR REPLACE FUNCTION public.record_venture_error(
+  p_venture_id uuid, p_error_hash text, p_message text, p_context jsonb DEFAULT '{}'::jsonb
+)
+RETURNS jsonb LANGUAGE sql
+AS $$ SELECT jsonb_build_object('ok', false, 'reason', 'stub_not_implemented'); $$;
+
+CREATE OR REPLACE FUNCTION public.venture_exists_and_active(p_venture_id UUID)
+RETURNS BOOLEAN LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.ventures v
+    WHERE v.id = p_venture_id
+      AND v.deleted_at IS NULL
+      AND COALESCE(v.metadata->>'telemetry_ingestion_enabled', 'true') <> 'false'
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.fn_anon_ingress_prior_hour_count(p_source_type text)
+RETURNS bigint LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+  SELECT count(*) FROM public.feedback f
+  WHERE f.source_type IS NOT DISTINCT FROM p_source_type
+    AND f.created_at > now() - interval '1 hour';
+$$;
+
+-- check_feedback_rate_limit: TRUE = blocked (this file's whole point is testing THIS polarity is
+-- used correctly), mirrors database/migrations/20260401_venture_user_feedback_channel.sql exactly.
+CREATE OR REPLACE FUNCTION public.check_feedback_rate_limit(p_venture_id uuid)
+RETURNS boolean LANGUAGE sql STABLE SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+  SELECT count(*) >= 50
+  FROM public.feedback
+  WHERE venture_id = p_venture_id
+    AND feedback_type LIKE 'user_%'
+    AND created_at > now() - interval '1 hour';
+$$;
+
+-- Pre-existing policies, mirroring live state BEFORE this SD's migration runs.
+CREATE POLICY venture_user_insert_feedback ON public.feedback
+  FOR INSERT TO anon
+  WITH CHECK (
+    feedback_type LIKE 'user_%'
+    AND venture_id IS NOT NULL
+    AND venture_exists_and_active(venture_id)
+    AND (NOT check_feedback_rate_limit(venture_id))
+  );
+
+CREATE POLICY anon_feedback_ingress_bounds ON public.feedback
+  AS RESTRICTIVE
+  FOR INSERT TO public
+  WITH CHECK (true);
+`;
+
+let client;
+
+async function applyPhase1() {
+  await client.query(PHASE1_SQL);
+}
+async function applyThisMigration() {
+  await client.query(MIGRATION_SQL);
+}
+async function makeVenture(name = 'Test Venture') {
+  const { rows } = await client.query('INSERT INTO public.ventures (name) VALUES ($1) RETURNING id', [name]);
+  return rows[0].id;
+}
+async function provisionSecret(ventureId) {
+  const { rows } = await client.query('SELECT public.fn_provision_venture_ingest_key($1) AS secret', [ventureId]);
+  return rows[0].secret;
+}
+async function submit(ventureId, secret, feedbackType, title, description) {
+  return client.query(
+    'SELECT public.fn_submit_venture_user_feedback($1, $2, $3, $4, $5) AS r',
+    [ventureId, secret, feedbackType, title, description],
+  );
+}
+
+beforeAll(async () => {
+  client = new pg.Client({
+    host: process.env.PGHOST || '127.0.0.1',
+    port: Number(process.env.PGPORT || 5432),
+    database: process.env.PGDATABASE || 'ddl_check',
+    user: process.env.PGUSER || 'postgres',
+    password: process.env.PGPASSWORD || 'postgres',
+  });
+  await client.connect();
+  await client.query(STUB_SCHEMA);
+  await applyPhase1();
+  await applyThisMigration();
+}, 60_000);
+
+afterAll(async () => {
+  if (client) await client.end();
+});
+
+describe('the migration applied', () => {
+  it('venture_user_insert_feedback is gone from pg_policies (FR-3)', async () => {
+    const { rows } = await client.query(`
+      SELECT policyname FROM pg_policies
+      WHERE schemaname='public' AND tablename='feedback' AND policyname='venture_user_insert_feedback'
+    `);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('anon retains table-level INSERT privilege (grant not collaterally revoked, FR-3(d)/TR-1)', async () => {
+    const { rows } = await client.query("SELECT has_table_privilege('anon','public.feedback','INSERT') AS ok");
+    expect(rows[0].ok).toBe(true);
+  });
+
+  it('anon_feedback_ingress_bounds survives, INSERT-scoped, RESTRICTIVE, still applies to public role', async () => {
+    const { rows } = await client.query(`
+      SELECT cmd, permissive, 'public' = ANY(roles) AS applies_to_public FROM pg_policies
+      WHERE schemaname='public' AND tablename='feedback' AND policyname='anon_feedback_ingress_bounds'
+    `);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].cmd).toBe('INSERT');
+    expect(rows[0].permissive).toBe('RESTRICTIVE');
+    expect(rows[0].applies_to_public).toBe(true);
+  });
+
+  it('re-running this migration is idempotent', async () => {
+    await applyThisMigration();
+  });
+});
+
+describe('TR-2: grant posture on the new function', () => {
+  it('anon CAN execute fn_submit_venture_user_feedback, authenticated CANNOT', async () => {
+    const { rows: anonRow } = await client.query(
+      "SELECT has_function_privilege('anon','public.fn_submit_venture_user_feedback(uuid,text,text,text,text)','EXECUTE') AS ok",
+    );
+    expect(anonRow[0].ok).toBe(true);
+    const { rows: authRow } = await client.query(
+      "SELECT has_function_privilege('authenticated','public.fn_submit_venture_user_feedback(uuid,text,text,text,text)','EXECUTE') AS ok",
+    );
+    expect(authRow[0].ok).toBe(false);
+  });
+});
+
+describe('FR-1/TS-1: legitimate submission', () => {
+  it('a valid secret for the SAME venture succeeds and the row lands with the correct venture_id', async () => {
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    const { rows } = await submit(ventureId, secret, 'user_bug', 'it broke', 'detailed repro');
+    expect(rows[0].r.ok).toBe(true);
+    expect(rows[0].r.id).toBeTruthy();
+
+    const { rows: landed } = await client.query(
+      'SELECT venture_id, feedback_type, type, source_type, title FROM public.feedback WHERE id = $1',
+      [rows[0].r.id],
+    );
+    expect(landed[0].venture_id).toBe(ventureId);
+    expect(landed[0].feedback_type).toBe('user_bug');
+    expect(landed[0].type).toBe('issue');
+    expect(landed[0].source_type).toBe('user_feedback');
+  });
+
+  it('user_feature_request maps to type=enhancement, not issue', async () => {
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    const { rows } = await submit(ventureId, secret, 'user_feature_request', 'add dark mode', null);
+    const { rows: landed } = await client.query('SELECT type FROM public.feedback WHERE id = $1', [rows[0].r.id]);
+    expect(landed[0].type).toBe('enhancement');
+  });
+});
+
+describe('FR-1/TS-2/TS-3: uniform ownership rejection, indistinguishable by error alone', () => {
+  async function captureError(ventureId, secret) {
+    try {
+      await submit(ventureId, secret, 'user_bug', 'x', null);
+      throw new Error('expected rejection, got success');
+    } catch (e) {
+      return { code: e.code, message: e.message };
+    }
+  }
+
+  it('[TS-2] venture B with venture A\'s secret is rejected, zero rows land, and the message names neither venture', async () => {
+    const ventureA = await makeVenture('A');
+    const ventureB = await makeVenture('B');
+    const secretA = await provisionSecret(ventureA);
+    const before = (await client.query('SELECT count(*)::int AS n FROM public.feedback')).rows[0].n;
+
+    const err = await captureError(ventureB, secretA);
+    expect(err.code).toBe('28000');
+    expect(err.message).not.toContain(ventureA);
+    expect(err.message).not.toContain(ventureB);
+
+    const after = (await client.query('SELECT count(*)::int AS n FROM public.feedback')).rows[0].n;
+    expect(after).toBe(before);
+  });
+
+  it('[TS-3] a nonexistent venture_id raises the SAME code and message text as TS-2, tuple-for-tuple', async () => {
+    const ventureA = await makeVenture('A2');
+    const ventureB = await makeVenture('B2');
+    const secretA = await provisionSecret(ventureA);
+    const spoofed = await captureError(ventureB, secretA);
+
+    const nonexistentId = '00000000-0000-0000-0000-000000000000';
+    const before = (await client.query('SELECT count(*)::int AS n FROM public.feedback')).rows[0].n;
+    const nonexistent = await captureError(nonexistentId, 'any-secret-value');
+    const after = (await client.query('SELECT count(*)::int AS n FROM public.feedback')).rows[0].n;
+
+    expect(nonexistent.code).toBe(spoofed.code);
+    expect(nonexistent.message).toBe(spoofed.message);
+    expect(after).toBe(before);
+  });
+});
+
+describe('FR-4/TS-7: soft-deleted or telemetry-disabled venture rejected even with a correct secret', () => {
+  it('a soft-deleted venture is rejected via defense-in-depth, same uniform code', async () => {
+    const { rows: vRows } = await client.query(
+      "INSERT INTO public.ventures (name, deleted_at) VALUES ('gone', now()) RETURNING id",
+    );
+    const ventureId = vRows[0].id;
+    const secret = await provisionSecret(ventureId);
+    await expect(submit(ventureId, secret, 'user_bug', 'x', null)).rejects.toMatchObject({ code: '28000' });
+  });
+
+  it('a telemetry-disabled venture is rejected via defense-in-depth', async () => {
+    const { rows: vRows } = await client.query(
+      "INSERT INTO public.ventures (name, metadata) VALUES ('quiet', '{\"telemetry_ingestion_enabled\": false}'::jsonb) RETURNING id",
+    );
+    const ventureId = vRows[0].id;
+    const secret = await provisionSecret(ventureId);
+    await expect(submit(ventureId, secret, 'user_bug', 'x', null)).rejects.toMatchObject({ code: '28000' });
+  });
+});
+
+describe('FR-2/TS-4/TS-9: rate-limit polarity — the discriminating case', () => {
+  it('[TS-4/TS-9] a venture exceeding its OWN 50/hour threshold is rejected while a DIFFERENT under-threshold venture is not — proves correct (non-inverted) polarity', async () => {
+    const ventureA = await makeVenture('flooder');
+    const secretA = await provisionSecret(ventureA);
+    for (let i = 0; i < 50; i++) {
+      await submit(ventureA, secretA, 'user_bug', `flood ${i}`, null);
+    }
+    await expect(submit(ventureA, secretA, 'user_bug', 'one too many', null)).rejects.toThrow(/rate limited/);
+
+    // If the polarity were inverted (IS NOT TRUE applied to check_feedback_rate_limit, which
+    // returns TRUE=blocked), this over-threshold call would have SUCCEEDED instead of the above
+    // rejecting -- this pair of assertions catches an inversion in EITHER direction.
+    const ventureB = await makeVenture('sibling');
+    const secretB = await provisionSecret(ventureB);
+    const { rows } = await submit(ventureB, secretB, 'user_bug', 'unaffected', null);
+    expect(rows[0].r.ok).toBe(true);
+  }, 30_000);
+});
+
+describe('FR-2/TS-10: global cross-venture ceiling', () => {
+  it('[TS-10] the 501st submission across many different under-threshold ventures is rejected by the global ceiling', async () => {
+    // 500 submissions spread across 20 ventures (25 each, safely under each venture's own 50/hour
+    // per-venture threshold) so ONLY the global ceiling can be the cause of the 501st rejection.
+    const secrets = [];
+    for (let v = 0; v < 20; v++) {
+      const ventureId = await makeVenture(`global-${v}`);
+      secrets.push([ventureId, await provisionSecret(ventureId)]);
+    }
+    for (let i = 0; i < 500; i++) {
+      const [ventureId, secret] = secrets[i % 20];
+      await submit(ventureId, secret, 'user_bug', `g${i}`, null);
+    }
+    const [lastVentureId, lastSecret] = secrets[0];
+    await expect(submit(lastVentureId, lastSecret, 'user_bug', 'over global ceiling', null)).rejects.toThrow(/rate limited/);
+  }, 60_000);
+});
+
+describe('TR-1: no forgeable workflow columns as parameters', () => {
+  it('the function signature has no status/votes/created_at/assigned_to/triaged_by/user_id parameter', () => {
+    const sig = MIGRATION_CODE_ONLY.match(/CREATE OR REPLACE FUNCTION public\.fn_submit_venture_user_feedback\(([^)]*)\)/)[1];
+    for (const forbidden of ['status', 'votes', 'created_at', 'assigned_to', 'triaged_by', 'user_id']) {
+      expect(sig).not.toMatch(new RegExp(`p_${forbidden}\\b`));
+    }
+  });
+
+  it('a successful insert gets server defaults for status/votes, never client-influenced', async () => {
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    const { rows } = await submit(ventureId, secret, 'user_bug', 'x', null);
+    const { rows: landed } = await client.query('SELECT status, votes FROM public.feedback WHERE id = $1', [rows[0].r.id]);
+    expect(landed[0].status).toBe('new');
+    expect(landed[0].votes).toBe(0);
+  });
+});
+
+describe('TS-6: pre-flight guard is per-branch mutation-resistant (extracted from the real migration file, not hand-copied)', () => {
+  it('[branch 1] RAISEs when venture_ingest_keys alone is absent', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query('ALTER TABLE public.venture_ingest_keys RENAME TO venture_ingest_keys_hidden');
+      await expect(client.query(PREFLIGHT_1_SQL)).rejects.toThrow(/venture_ingest_keys does not exist/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('[branch 2] RAISEs when _verify_venture_ingest_secret alone is absent', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query('DROP FUNCTION public._verify_venture_ingest_secret(uuid, text)');
+      await expect(client.query(PREFLIGHT_2_SQL)).rejects.toThrow(/_verify_venture_ingest_secret does not exist/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('neither branch raises when both prerequisites are present (two-sided — a guard that always fires would never catch a real regression)', async () => {
+    await expect(client.query(PREFLIGHT_1_SQL)).resolves.toBeDefined();
+    await expect(client.query(PREFLIGHT_2_SQL)).resolves.toBeDefined();
+  });
+});
+
+describe('$verify$ block (extracted from the real migration file) is mutation-resistant', () => {
+  it('RAISEs if venture_user_insert_feedback were NOT actually dropped', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query(`
+        CREATE POLICY venture_user_insert_feedback ON public.feedback
+          FOR INSERT TO anon WITH CHECK (
+            feedback_type LIKE 'user_%' AND venture_id IS NOT NULL AND venture_exists_and_active(venture_id)
+          )
+      `);
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/venture_user_insert_feedback still present/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('RAISEs if the table-level anon-INSERT grant were collaterally revoked', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query('REVOKE INSERT ON public.feedback FROM anon');
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/lost table-level INSERT privilege/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('RAISEs if anon_feedback_ingress_bounds is dropped or de-scoped', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query('DROP POLICY IF EXISTS anon_feedback_ingress_bounds ON public.feedback');
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/anon_feedback_ingress_bounds is missing/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('RAISEs if RLS is disabled on public.feedback', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query('ALTER TABLE public.feedback DISABLE ROW LEVEL SECURITY');
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/does not have RLS enabled/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('RAISEs if the new function loses its anon EXECUTE grant', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query('REVOKE EXECUTE ON FUNCTION public.fn_submit_venture_user_feedback(uuid,text,text,text,text) FROM anon');
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/NOT anon-callable/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('RAISEs if authenticated is granted EXECUTE on the new function', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query('GRANT EXECUTE ON FUNCTION public.fn_submit_venture_user_feedback(uuid,text,text,text,text) TO authenticated');
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/callable by authenticated/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('does NOT raise in the correct post-migration state (two-sided)', async () => {
+    await expect(client.query(VERIFY_BLOCK_SQL)).resolves.toBeDefined();
+  });
+});
+
+describe('TS-5: raw anon INSERT against the bare table is rejected post-drop (bypassing the RPC entirely)', () => {
+  it('a direct INSERT as anon with feedback_type=user_bug is rejected by RLS', async () => {
+    const ventureId = await makeVenture();
+    await client.query('BEGIN');
+    try {
+      await client.query('SET LOCAL ROLE anon');
+      let err;
+      try {
+        await client.query(
+          "INSERT INTO public.feedback (feedback_type, type, source_type, source_application, title, venture_id) VALUES ('user_bug', 'issue', 'user_feedback', 'x', 'raw insert attempt', $1)",
+          [ventureId],
+        );
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeTruthy();
+      expect(err.code).toBe('42501');
+      expect(err.message).toMatch(/row-level security policy/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+});

--- a/tests/ddl/venture-user-feedback-ownership-rpc-ddl.db.test.js
+++ b/tests/ddl/venture-user-feedback-ownership-rpc-ddl.db.test.js
@@ -5,19 +5,25 @@
 // WHAT A GREEN RUN OF THIS FILE DOES **NOT** MEAN
 //
 // This runs against an EPHEMERAL vanilla PostgreSQL 16 with a hand-stubbed schema, reproduced only
-// as far as this migration (and its Phase-1 prerequisite, applied first for real, not stubbed) touch
-// it. It proves this migration's OWN new logic (ownership check, rate-limit polarity, policy
-// removal, pre-flight guard) does what it claims. It does NOT prove:
+// as far as this migration (and its Phase-1 and telegram-revoke prerequisites, both applied first for
+// real, not stubbed) touch it. It proves this migration's OWN new logic (ownership check, rate-limit
+// polarity, policy removal, pre-flight guard) does what it claims, AND (HIGH-1, SECURITY sub-agent,
+// EXEC review) that the combined end-state after Phase-1 + telegram-revoke + this migration actually
+// closes the anon venture-spoofing gap this SD targets, including the source_type='telegram' bypass
+// this migration alone does not touch. It does NOT prove:
 //   - production posture (Supabase ALTER DEFAULT PRIVILEGES is not reproduced by vanilla Postgres)
-//   - that the FR-7 cross-migration sequencing constraint is respected at apply time — that is an
-//     operational/ceremony-level check (see this migration's own header), not provable here
+//   - that operators actually apply the three migrations in this order at chairman-ceremony time —
+//     this suite exercises the correct order and documents why it is required, it cannot enforce a
+//     human's real apply sequence
 //   - anon-reachability over the real PostgREST/Supabase surface — that would be a Tier C live probe,
 //     not this ephemeral Postgres
 //
-// Unlike the sibling telegram-revoke DDL test (which stubs Phase-1's objects with fakes), THIS file
-// applies Phase-1's REAL migration file first, then this SD's migration on top — a closer rehearsal
-// of the real apply sequence, and the only way to test this migration's own pre-flight guard against
-// genuinely-present (not faked) Phase-1 objects.
+// Unlike the sibling telegram-revoke DDL test (which stubs Phase-1's objects with fakes and tests
+// telegram-revoke ALONE), THIS file applies Phase-1's and telegram-revoke's REAL migration files
+// first, then this SD's migration on top — a closer rehearsal of the real apply sequence, the only
+// way to test this migration's own pre-flight guard against genuinely-present (not faked) Phase-1
+// objects, and the only way to test the fully-closed end state rather than this migration in
+// isolation.
 //
 // FAIL-CLOSED, no skip branch: if this file cannot reach a database it fails loudly rather than
 // silently passing (matches this SD family's established convention).
@@ -30,10 +36,19 @@ import pg from 'pg';
 const PHASE1_MIGRATION_PATH = fileURLToPath(
   new URL('../../database/chairman-gated/20260812_venture_ingest_key_binding.sql', import.meta.url),
 );
+// HIGH-1 (SECURITY sub-agent, EXEC review, evidence cefd6b89-cf93-4b34-8b4e-e9b348795bd2): applied
+// for real, between Phase-1 and this SD's own migration, matching the STRICT order this migration's
+// own header now documents as security-load-bearing (not mere apply-order hygiene) -- without this,
+// the fully-closed end state this test suite validates was never actually exercised, and TS-5 could
+// false-green against a bypass (source_type='telegram') it never attempted.
+const TELEGRAM_REVOKE_MIGRATION_PATH = fileURLToPath(
+  new URL('../../database/chairman-gated/20260813_revoke_telegram_bot_insert_feedback.sql', import.meta.url),
+);
 const THIS_MIGRATION_PATH = fileURLToPath(
   new URL('../../database/chairman-gated/20260815_venture_user_feedback_ownership_rpc.sql', import.meta.url),
 );
 const PHASE1_SQL = fs.readFileSync(PHASE1_MIGRATION_PATH, 'utf8');
+const TELEGRAM_REVOKE_SQL = fs.readFileSync(TELEGRAM_REVOKE_MIGRATION_PATH, 'utf8');
 const MIGRATION_SQL = fs.readFileSync(THIS_MIGRATION_PATH, 'utf8');
 
 // Anchored to start-of-line, matching tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js's
@@ -195,6 +210,15 @@ CREATE POLICY venture_user_insert_feedback ON public.feedback
     AND (NOT check_feedback_rate_limit(venture_id))
   );
 
+-- HIGH-1: pre-migration live state ALSO includes telegram_bot_insert_feedback (zero venture_id /
+-- feedback_type constraint) -- without stubbing this too, applying the telegram-revoke migration
+-- below would DROP POLICY IF EXISTS a policy that was never there, silently proving nothing about
+-- the bypass this SD's own migration does not by itself close.
+DROP POLICY IF EXISTS telegram_bot_insert_feedback ON public.feedback;
+CREATE POLICY telegram_bot_insert_feedback ON public.feedback
+  FOR INSERT TO anon
+  WITH CHECK (source_type = 'telegram');
+
 DROP POLICY IF EXISTS anon_feedback_ingress_bounds ON public.feedback;
 CREATE POLICY anon_feedback_ingress_bounds ON public.feedback
   AS RESTRICTIVE
@@ -206,6 +230,9 @@ let client;
 
 async function applyPhase1() {
   await client.query(PHASE1_SQL);
+}
+async function applyTelegramRevoke() {
+  await client.query(TELEGRAM_REVOKE_SQL);
 }
 async function applyThisMigration() {
   await client.query(MIGRATION_SQL);
@@ -236,6 +263,12 @@ beforeAll(async () => {
   await client.connect();
   await client.query(STUB_SCHEMA);
   await applyPhase1();
+  // Strict order (this migration's own header, "SEQUENCING DEPENDENCY IS SECURITY-LOAD-BEARING"):
+  // telegram-revoke MUST land before this SD's migration -- its own $verify$ block byte-compares
+  // venture_user_insert_feedback's WITH CHECK text and would hard-fail if that policy were already
+  // gone. Applying it here, in this order, is what makes every test below run against the FULLY
+  // closed end state (both anon-reachable bypass policies gone), not just this migration alone.
+  await applyTelegramRevoke();
   await applyThisMigration();
 }, 60_000);
 
@@ -286,6 +319,54 @@ describe('TR-2: grant posture on the new function', () => {
   });
 });
 
+describe('MEDIUM-1: the now-orphaned direct-EXECUTE oracle is closed', () => {
+  it('neither anon nor authenticated can directly execute venture_exists_and_active', async () => {
+    const { rows } = await client.query(`
+      SELECT
+        has_function_privilege('anon', 'public.venture_exists_and_active(uuid)', 'EXECUTE') AS anon_ok,
+        has_function_privilege('authenticated', 'public.venture_exists_and_active(uuid)', 'EXECUTE') AS auth_ok
+    `);
+    expect(rows[0].anon_ok).toBe(false);
+    expect(rows[0].auth_ok).toBe(false);
+  });
+
+  it('neither anon nor authenticated can directly execute check_feedback_rate_limit', async () => {
+    const { rows } = await client.query(`
+      SELECT
+        has_function_privilege('anon', 'public.check_feedback_rate_limit(uuid)', 'EXECUTE') AS anon_ok,
+        has_function_privilege('authenticated', 'public.check_feedback_rate_limit(uuid)', 'EXECUTE') AS auth_ok
+    `);
+    expect(rows[0].anon_ok).toBe(false);
+    expect(rows[0].auth_ok).toBe(false);
+  });
+
+  it('the new RPC still succeeds end-to-end despite the callee revokes (internal calls run under the SECURITY DEFINER owner, not the caller)', async () => {
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    const { rows } = await submit(ventureId, secret, 'user_bug', 'still works', null);
+    expect(rows[0].r.ok).toBe(true);
+  });
+});
+
+describe('MEDIUM-2: the global ceiling only counts rows THIS RPC created', () => {
+  it('a user_bug-shaped row inserted by a different writer (source_type != user_feedback) does not count against the ceiling', async () => {
+    const otherVentureId = await makeVenture('other-writer');
+    // Direct insert as the (superuser) test client, mirroring a writer that is NOT this RPC --
+    // e.g. a pre-migration historical row, or any future service_role writer that happens to use
+    // the same feedback_type values. Before MEDIUM-2 this would have counted against the same
+    // global ceiling as RPC-created rows; after, it must not.
+    await client.query(
+      "INSERT INTO public.feedback (feedback_type, type, source_type, source_application, title, venture_id) VALUES ('user_bug', 'issue', 'manual_feedback', 'other-writer', 'not from the RPC', $1)",
+      [otherVentureId],
+    );
+
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    const { rows } = await submit(ventureId, secret, 'user_bug', 'still under the ceiling', null);
+    expect(rows[0].r.ok).toBe(true);
+  });
+});
+
 describe('FR-1/TS-1: legitimate submission', () => {
   it('a valid secret for the SAME venture succeeds and the row lands with the correct venture_id', async () => {
     const ventureId = await makeVenture();
@@ -310,6 +391,30 @@ describe('FR-1/TS-1: legitimate submission', () => {
     const { rows } = await submit(ventureId, secret, 'user_feature_request', 'add dark mode', null);
     const { rows: landed } = await client.query('SELECT type FROM public.feedback WHERE id = $1', [rows[0].r.id]);
     expect(landed[0].type).toBe('enhancement');
+  });
+});
+
+describe('FR-1 AC-4 (T-3, testing-agent EXEC review): invalid feedback_type is rejected', () => {
+  it('a valid secret with an out-of-allowlist feedback_type raises 22004 and zero rows land', async () => {
+    const ventureId = await makeVenture();
+    const secret = await provisionSecret(ventureId);
+    const before = (await client.query('SELECT count(*)::int AS n FROM public.feedback')).rows[0].n;
+
+    let err;
+    try {
+      // Ownership passes (real venture, real secret) -- isolates the feedback_type allowlist check
+      // specifically. 'made_up_type' is not in ('user_bug','user_feature_request','user_usability',
+      // 'user_other'); deleting the migration's IF branch that raises 22004 would let this row land
+      // as a false pass without this test.
+      await submit(ventureId, secret, 'made_up_type', 'x', null);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeTruthy();
+    expect(err.code).toBe('22004');
+
+    const after = (await client.query('SELECT count(*)::int AS n FROM public.feedback')).rows[0].n;
+    expect(after).toBe(before);
   });
 });
 
@@ -505,6 +610,26 @@ describe('$verify$ block (extracted from the real migration file) is mutation-re
     }
   });
 
+  it('RAISEs (MEDIUM-1) if venture_exists_and_active is re-granted directly to anon', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query('GRANT EXECUTE ON FUNCTION public.venture_exists_and_active(uuid) TO anon');
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/venture_exists_and_active is still directly callable/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
+  it('RAISEs (MEDIUM-1) if check_feedback_rate_limit is re-granted directly to authenticated', async () => {
+    await client.query('BEGIN');
+    try {
+      await client.query('GRANT EXECUTE ON FUNCTION public.check_feedback_rate_limit(uuid) TO authenticated');
+      await expect(client.query(VERIFY_BLOCK_SQL)).rejects.toThrow(/check_feedback_rate_limit is still directly callable/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+
   it('does NOT raise in the correct post-migration state (two-sided)', async () => {
     await expect(client.query(VERIFY_BLOCK_SQL)).resolves.toBeDefined();
   });
@@ -534,6 +659,37 @@ describe('TS-5: raw anon INSERT against the bare table is rejected post-drop (by
   });
 });
 
+describe('HIGH-1: the telegram bypass is closed only once BOTH migrations have applied', () => {
+  it('a raw anon INSERT spoofing source_type=telegram is rejected (no permissive policy authorizes it post-drop)', async () => {
+    const ventureId = await makeVenture();
+    await client.query('BEGIN');
+    try {
+      await client.query('SET LOCAL ROLE anon');
+      let err;
+      try {
+        // Pre-telegram-revoke, this exact shape was the live bypass HIGH-1 flagged:
+        // telegram_bot_insert_feedback's WITH CHECK (source_type = 'telegram') has NO venture_id or
+        // feedback_type constraint at all, so a caller could attribute a user_bug row to ANY
+        // venture_id merely by tagging source_type='telegram' instead of calling the new RPC --
+        // completely bypassing this migration's ownership check. beforeAll applies telegram-revoke
+        // BEFORE this migration (the strict order its own header now documents as security-load-
+        // bearing), so by the time this test runs, no permissive policy authorizes this shape either.
+        await client.query(
+          "INSERT INTO public.feedback (feedback_type, type, source_type, source_application, title, venture_id) VALUES ('user_bug', 'issue', 'telegram', 'x', 'telegram-spoofed bypass attempt', $1)",
+          [ventureId],
+        );
+      } catch (e) {
+        err = e;
+      }
+      expect(err).toBeTruthy();
+      expect(err.code).toBe('42501');
+      expect(err.message).toMatch(/row-level security policy/);
+    } finally {
+      await client.query('ROLLBACK');
+    }
+  });
+});
+
 // MUST RUN LAST IN THE FILE (measured live in CI, this SD's first push): the global ceiling
 // (FR-2) counts ALL feedback_type IN ('user_bug', ...) rows created in the trailing hour, with
 // no reset between test blocks -- every prior test in this file that lands a real row (TS-1,
@@ -546,8 +702,12 @@ describe('TS-5: raw anon INSERT against the bare table is rejected post-drop (by
 describe('FR-2/TS-10: global cross-venture ceiling (state-aware, must run last)', () => {
   it('[TS-10] tops up to exactly the boundary, then asserts the NEXT submission is rejected by the global ceiling', async () => {
     const GLOBAL_CEILING = 500;
+    // MEDIUM-2: mirrors the migration's own (corrected) filter exactly, including source_type =
+    // 'user_feedback' -- without it, a non-RPC row inserted by the MEDIUM-2 test above (or any
+    // future test) would inflate `already` relative to what the migration itself counts, silently
+    // under-topping this test's own boundary math.
     const { rows: countRows } = await client.query(
-      "SELECT count(*)::int AS n FROM public.feedback WHERE feedback_type IN ('user_bug','user_feature_request','user_usability','user_other') AND created_at > now() - interval '1 hour'",
+      "SELECT count(*)::int AS n FROM public.feedback WHERE feedback_type IN ('user_bug','user_feature_request','user_usability','user_other') AND source_type = 'user_feedback' AND created_at > now() - interval '1 hour'",
     );
     const already = countRows[0].n;
     // The migration's check reads the count via a SELECT BEFORE inserting the current row, so the


### PR DESCRIPTION
## Summary
- `public.feedback`'s anon INSERT policy `venture_user_insert_feedback` validates `venture_id` via `venture_exists_and_active()` — existence only, no caller-identity correlation, so an anon caller can attribute a `user_bug`/`user_feature_request`/`user_usability`/`user_other` row to any of the ~146 real active ventures.
- Adds `fn_submit_venture_user_feedback`, a new ownership-bound SECURITY DEFINER RPC reusing Phase-1's per-venture secret infrastructure (`venture_ingest_keys`/`_verify_venture_ingest_secret` from the completed `SD-LEO-INFRA-FEEDBACK-ANON-RLS-GAPS-001`), then drops the vulnerable policy — DROP POLICY only, never a table-level REVOKE (that grant is shared with `anon_feedback_ingress_bounds`).
- **Chairman-gated, staged only.** This migration is NOT applied by this PR — it requires the `@approved-by` chairman-verbal ceremony per the Tiered Auto-Apply Policy (RLS/access-control change, TIER-2).
- **Documented residual, not silently accepted**: for server-side secret holders (e.g. a backend service), this closes ownership cleanly. For browser-exposed callers (a secret shipped in a public client bundle — 2 of 3 known real callers), no client-delivered credential can stay secret from whoever loads that page; this narrows cross-venture forgery to per-venture forgery but does not eliminate targeted forgery. Same residual Phase-1's own header names for its equivalent RPC.

## Corrections from prospective PLAN-phase TESTING review (before EXEC wrote any code)
A prospective testing-agent review of the PRD (evidence `ffe58c4e-7c8d-4d53-8dbf-8634b5f0ec62`) caught three defects that would otherwise have shipped:
1. **Rate-limit polarity inversion risk**: `check_feedback_rate_limit` returns `TRUE`=blocked — the opposite polarity from the ownership-check helper (`TRUE`=authorized). The PRD's original wording could have led to copy-pasting the same `IS NOT TRUE` idiom onto both, inverting the rate limit.
2. **Pre-flight guard placement**: a trailing `$verify$` block (as originally specified) would never be reached if the new function referenced a missing dependency in a `LANGUAGE sql` body — Postgres validates the body at `CREATE FUNCTION` time. The dependency guard is now a pre-flight check, first statement after `BEGIN`, tested per-branch (not OR-combined).
3. **Cross-migration apply-order collision**: the already-staged sibling `20260813_revoke_telegram_bot_insert_feedback.sql` has its own `$verify$` block asserting `venture_user_insert_feedback` remains present and unchanged — exactly what this migration removes. Documented as an explicit sequencing precondition in this migration's header (operational check, not DDL-enforceable within the file itself).

A fourth defect (my own, caught before writing SQL): the original plan called for a table-level `REVOKE` alongside the `DROP POLICY`, which would have collaterally broken `anon_feedback_ingress_bounds` and any not-yet-dropped sibling policy sharing the same grant — corrected to `DROP POLICY` only, matching this SD family's own established convention (`tests/ddl/telegram-bot-insert-feedback-drop-ddl.db.test.js`'s TR-1 assertion for the analogous case).

## Test plan
- [x] New DDL test (`tests/ddl/venture-user-feedback-ownership-rpc-ddl.db.test.js`) applies Phase-1's real migration then this one, against a hand-stubbed ephemeral Postgres 16 schema — 26 tests covering: legitimate submission, uniform ownership rejection (TS-2/TS-3, byte-identical error verified via row-count + message-content checks), soft-deleted/telemetry-disabled venture rejection, rate-limit polarity (the discriminating both-directions case), the new global cross-venture ceiling, forgeable-column rejection, raw-INSERT-post-drop rejection, and per-branch pre-flight + `$verify$` mutation testing (extracted from the real file text, not hand-copied).
- [x] Verified locally: test file collects correctly (26 tests recognized, no syntax/import errors) and fails with `ECONNREFUSED` as expected — this repo's DDL tier (`vitest.ddl.config.mjs`) is documented to only get real execution via a CI-provisioned ephemeral container; local runs without Docker/Postgres fail-closed by design, matching every sibling SD in this family.
- [x] Independently verified the migration's own SQL-block extraction (used by the test's mutation-resistance checks) against the real file — all three `DO` blocks extract cleanly with correct boundaries.
- [ ] **CI must run the DDL tier for real verification** — this is the actual pass/fail signal for this PR, not the local collection check above.
- [x] Confirmed via `vitest.config.js` that `tests/ddl/**` is excluded from the `unit`/`db` projects (owned solely by `vitest.ddl.config.mjs`), so this PR cannot affect the existing unit suite's collection or results — no full-suite regression risk from this diff.
- [ ] Migration NOT applied (chairman-gated) — no live database change from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)