### PR TITLE
fix(SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-141): resolve chairmanZone once at the sendChairmanSMS choke point

### DIFF
--- a/lib/comms/adam-outbound/chairman-sms-gate/index.js
+++ b/lib/comms/adam-outbound/chairman-sms-gate/index.js
@@ -197,7 +197,7 @@ async function evalOverAsk(message, context, opts) {
  * The sole chairman-SMS send path.
  * @param {object} message - the message (see rubric-engine evaluate() shape)
  * @param {object} context - rubric context (quiet-hours, rate cap, chairmanInitiated?)
- * @param {object} opts - { sender?, evaluate?, console?, fallbackSend?, classifyOverAsk?, overAskAttested?, presenceResolver?, presenceResolverOpts? } injectable seams
+ * @param {object} opts - { sender?, evaluate?, console?, fallbackSend?, classifyOverAsk?, overAskAttested?, presenceResolver?, presenceResolverOpts?, resolveChairmanZone? } injectable seams
  * @returns {Promise<{sent:boolean, held?:boolean, routedToConsole?:boolean, transportFailed?:boolean, fallbackFired?:boolean, reason:string, verdict?:string, authorityClass?:string, blockedReasons?:string[], overAsk?:boolean}>}
  */
 export async function sendChairmanSMS(message = {}, context = {}, opts = {}) {
@@ -206,6 +206,31 @@ export async function sendChairmanSMS(message = {}, context = {}, opts = {}) {
   const fallbackSend = typeof opts.fallbackSend === 'function' ? opts.fallbackSend : defaultFallbackSend;
   const log = opts.console || console;
   const isDecision = effectiveType(message) === 'decision'; // classifier hardening (FR-4)
+
+  // SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-141 (PAT-LES-435dd6fee19f): resolve chairmanZone once,
+  // here at the choke point, instead of at every individual caller. A caller that omits both
+  // chairmanZone and the synchronous nowHourET override would otherwise silently fall through to
+  // lint.js's own DEFAULT_ET_ZONE two layers downstream -- raised at 3 separate review phases and
+  // each time patched at one more caller instead of the root. All 5 current callers already
+  // resolve zone themselves, so this fallback is inert for them today; its value is closing the
+  // gap for a future caller. Must run before BOTH downstream zone readers below (the presence
+  // reply-window check and the rubric gate) -- guarding only before evaluate() would leave the
+  // presence-reply branch on the silent ET default. Also guarded on !Number.isInteger(nowHourET):
+  // etHour() (lint.js) short-circuits on that override before ever reading chairmanZone, so this
+  // keeps the resolver off the hot path for every existing test that sets nowHourET. Degrade-safe
+  // (CONST-002): a resolver failure never blocks the send, matching the presence-resolver pattern
+  // immediately below.
+  if (context.chairmanZone === undefined && !Number.isInteger(context.nowHourET)) {
+    try {
+      const resolveZone = typeof opts.resolveChairmanZone === 'function'
+        ? opts.resolveChairmanZone
+        : (await import('../quiet-hours-extension.js')).resolveChairmanZone;
+      const { zone } = await resolveZone(new Date(context.now || Date.now()));
+      context = { ...context, chairmanZone: zone };
+    } catch (err) {
+      log.warn(`[chairman-sms-gate] chairmanZone resolution unavailable, proceeding without it (fail-open): ${err.message}`);
+    }
+  }
 
   // SD-LEO-INFRA-QUIET-HOURS-GATE-001: measured-presence reply window. Consulted ONLY when the
   // caller declares a reply-class send (context.replyToInbound === true), no allowance is already

--- a/tests/unit/comms/chairman-sms-gate-live-intercept.test.js
+++ b/tests/unit/comms/chairman-sms-gate-live-intercept.test.js
@@ -11,25 +11,31 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const passEval = async () => ({ verdict: 'pass', effectiveType: 'decision', authorityClass: 'sms', blockedReasons: [] });
 const blockEval = async () => ({ verdict: 'blocked', effectiveType: 'decision', authorityClass: 'sms', blockedReasons: ['bad_format'] });
 const throwEval = async () => { throw new Error('rubric down'); };
+// SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-141: every call in this file passes an empty context ({}),
+// so each one now takes the new chairmanZone-resolution fallback path. Inject a stub here instead
+// of letting the real resolveChairmanZone run -- it never throws, but under tests/setup.unit.js's
+// sentinel Supabase creds it attempts a real network fetch that hangs for tens of seconds before
+// its own internal catch swallows the error, silently slowing (not failing) every test below.
+const zoneStub = async () => ({ zone: 'America/New_York', source: 'test_stub' });
 
 describe('chairman-SMS gate — fail-closed guarantee (acceptance b / TS-1, TS-3)', () => {
   it('HOLDS a rubric-FAILING decision — no send (fail-closed)', async () => {
     const sender = { send: vi.fn().mockResolvedValue({ sid: 'x' }) };
-    const r = await sendChairmanSMS({ type: 'decision', body: 'unformatted' }, {}, { evaluate: blockEval, sender });
+    const r = await sendChairmanSMS({ type: 'decision', body: 'unformatted' }, {}, { evaluate: blockEval, sender, resolveChairmanZone: zoneStub });
     expect(r.sent).toBe(false);
     expect(r.held).toBe(true);
     expect(sender.send).not.toHaveBeenCalled(); // never reached the sender
   });
   it('HOLDS a decision when the rubric THROWS (fail-closed, NOT fail-open)', async () => {
     const sender = { send: vi.fn().mockResolvedValue({ sid: 'x' }) };
-    const r = await sendChairmanSMS({ type: 'decision', body: 'x' }, {}, { evaluate: throwEval, sender });
+    const r = await sendChairmanSMS({ type: 'decision', body: 'x' }, {}, { evaluate: throwEval, sender, resolveChairmanZone: zoneStub });
     expect(r.held).toBe(true);
     expect(r.reason).toBe('gate_unavailable');
     expect(sender.send).not.toHaveBeenCalled();
   });
   it('SENDS a rubric-PASS decision via the injected sender', async () => {
     const sender = { send: vi.fn().mockResolvedValue({ sid: 'obl-1' }) };
-    const r = await sendChairmanSMS({ type: 'decision', body: 'ok' }, {}, { evaluate: passEval, sender });
+    const r = await sendChairmanSMS({ type: 'decision', body: 'ok' }, {}, { evaluate: passEval, sender, resolveChairmanZone: zoneStub });
     expect(r.sent).toBe(true);
     expect(sender.send).toHaveBeenCalledOnce();
   });
@@ -51,7 +57,7 @@ describe('makeDefaultSender delegation (FR-2) — durable path, fail-soft, no Tw
     const prev = process.env.CHAIRMAN_PHONE;
     delete process.env.CHAIRMAN_PHONE;
     const fallbackSend = vi.fn(async () => ({ fired: true }));
-    const r = await sendChairmanSMS({ type: 'decision', body: 'ok' }, {}, { evaluate: passEval, fallbackSend });
+    const r = await sendChairmanSMS({ type: 'decision', body: 'ok' }, {}, { evaluate: passEval, fallbackSend, resolveChairmanZone: zoneStub });
     expect(r.sent).toBe(false); // did not throw, but honestly reports the transport drop
     expect(r.transportFailed).toBe(true);
     expect(r.reason).toBe('no_recipient_phone');

--- a/tests/unit/comms/chairman-sms-gate/chairman-sms-gate.test.js
+++ b/tests/unit/comms/chairman-sms-gate/chairman-sms-gate.test.js
@@ -112,3 +112,53 @@ describe('chairman-sms-gate sendChairmanSMS()', () => {
     expect(fallbackSend).not.toHaveBeenCalled();
   });
 });
+
+describe('FR-1/FR-4 (SD-LEARN-FIX-ADDRESS-PATTERN-LEARN-141): chairmanZone resolved at the choke point, not per-caller', () => {
+  // Measured discriminating fixture: at this instant, America/New_York reads 23:00 (inside the
+  // 22:00-06:00 quiet window) while America/Los_Angeles reads 20:00 (outside it) -- same message,
+  // same rubric, only the zone differs, and the verdict flips HELD -> SENT. This is what actually
+  // proves the fallback is invoked AND its result used, not merely that the code compiles.
+  const NOW = new Date('2026-01-15T04:00:00Z');
+
+  it("omitting chairmanZone AND nowHourET resolves via the real choke-point fallback and is held on the default zone's quiet hours", async () => {
+    const sender = makeSender();
+    const stub = vi.fn(async () => ({ zone: 'America/New_York', source: 'test_stub' }));
+    const ctx = { now: NOW, rateCap: 10, sentInWindow: 0 };
+    const res = await sendChairmanSMS(wellFormedDecision(), ctx, { sender, console: silentConsole, resolveChairmanZone: stub });
+    expect(res.sent).toBe(false);
+    expect((res.blockedReasons || []).join(',')).toMatch(/quiet_hours/);
+    expect(stub).toHaveBeenCalledTimes(1);
+    expect(stub).toHaveBeenCalledWith(expect.any(Date));
+    expect(sender.send).not.toHaveBeenCalled();
+    expect(ctx.chairmanZone).toBeUndefined(); // the caller's own context object was never mutated
+  });
+
+  it("the SAME instant with an injected non-ET zone resolves to SENT -- the fallback's result is what the rubric actually uses", async () => {
+    const sender = makeSender();
+    const stub = vi.fn(async () => ({ zone: 'America/Los_Angeles', source: 'test_stub' }));
+    const ctx = { now: NOW, rateCap: 10, sentInWindow: 0 };
+    const res = await sendChairmanSMS(wellFormedDecision(), ctx, { sender, console: silentConsole, resolveChairmanZone: stub });
+    expect(res.sent).toBe(true);
+    expect((res.blockedReasons || []).join(',')).not.toMatch(/quiet_hours/);
+    expect(stub).toHaveBeenCalledTimes(1);
+    expect(sender.send).toHaveBeenCalledTimes(1);
+    expect(ctx.chairmanZone).toBeUndefined(); // still never mutated, even on the SENT path
+  });
+
+  it('supplying nowHourET (the shape all TS-1..TS-8 tests above use) short-circuits the fallback -- zero calls to resolveChairmanZone', async () => {
+    const sender = makeSender();
+    const stub = vi.fn(async () => ({ zone: 'America/Los_Angeles', source: 'test_stub' }));
+    const res = await sendChairmanSMS(wellFormedDecision(), DAYTIME, { sender, console: silentConsole, resolveChairmanZone: stub });
+    expect(res.sent).toBe(true);
+    expect(stub).not.toHaveBeenCalled();
+  });
+
+  it('supplying chairmanZone explicitly (the shape all 5 production callers use today) short-circuits the fallback -- zero calls to resolveChairmanZone', async () => {
+    const sender = makeSender();
+    const stub = vi.fn(async () => ({ zone: 'America/Los_Angeles', source: 'test_stub' }));
+    const ctx = { now: NOW, chairmanZone: 'America/Los_Angeles', rateCap: 10, sentInWindow: 0 };
+    const res = await sendChairmanSMS(wellFormedDecision(), ctx, { sender, console: silentConsole, resolveChairmanZone: stub });
+    expect(res.sent).toBe(true);
+    expect(stub).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- `sendChairmanSMS` (`lib/comms/adam-outbound/chairman-sms-gate/index.js`) is the single choke point for all 5 production chairman-SMS send paths, but never resolved the chairman timezone itself — a caller omitting `context.chairmanZone` silently fell through to a hardcoded ET default two layers downstream in `lint.js`. This exact fix was recommended at 3 separate review phases and each time patched at one more individual caller instead of the root (PAT-LES-435dd6fee19f).
- Adds a guarded, injectable fallback inside `sendChairmanSMS` that resolves the zone via the existing `resolveChairmanZone` helper when a caller omits both `chairmanZone` and the synchronous `nowHourET` override — inert for all 5 current callers (all already pass zone explicitly), closing the gap for any future 6th caller.
- Guard also checks `!Number.isInteger(context.nowHourET)`, since `etHour()` already short-circuits on that override before reading the zone — keeps 4 of 5 existing unit test files untouched. Only `chairman-sms-gate-live-intercept.test.js` needed an injected stub (its real resolver's internal catch still attempts a real network fetch first under the unit tier's sentinel Supabase creds).
- This SD was auto-generated by `/learn` from 3 `issue_patterns`; LEAD-phase verification found 2 of the 3 already fixed by prior SDs and marked them resolved directly in `issue_patterns` — scope narrowed from 3 items to 1 (67% reduction).

## Test plan
- [x] 4 new positive-control tests using a measured discriminating fixture (one instant where `America/New_York` reads inside quiet hours and `America/Los_Angeles` does not) proving the fallback's resolved zone is actually what the rubric evaluates against.
- [x] Full `tests/unit/comms/` suite + `tests/unit/outbound-sink-conformance.test.js` regression ratchet — 147/147 passing, zero regressions, no new network I/O (wall-clock unchanged at ~1s for 147 tests).
- [x] Verified via two independent sub-agent reviews (Explore + validation-agent at LEAD, testing-agent at PLAN) before implementation — exact insertion point, leaner guard shape, and full test-file census confirmed against a live pre-implementation baseline (121/121, 579ms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)