### PR TITLE
fix(QF-20260815-099): let the DR restore rehearsal cron push its runbook witness commit

### DIFF
--- a/.github/workflows/dr-restore-rehearsal-cron.yml
+++ b/.github/workflows/dr-restore-rehearsal-cron.yml
@@ -59,6 +59,13 @@ jobs:
 
       - name: Commit runbook update
         if: always()
+        env:
+          # QF-20260815-099: .husky/pre-push's work-tracking guard also blocks this
+          # branch=main push in non-interactive mode (no SD-*/QF-* branch name to
+          # match) — a second, separate hook from the pre-commit one below. Same
+          # narrow justification: additive-only, single-file, CI-bot-authored
+          # record-keeping push, not real development work.
+          EHG_ALLOW_MAIN_PUSH: '1'
         run: |
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
@@ -75,5 +82,5 @@ jobs:
           🤖 Generated with [Claude Code](https://claude.com/claude-code)
 
           Co-Authored-By: GitHub Actions <noreply@github.com>"
-            git push || echo "Push skipped"
+            git push
           fi

--- a/ops/runbooks/disaster-recovery.md
+++ b/ops/runbooks/disaster-recovery.md
@@ -195,8 +195,8 @@ rewrites the witness below via `scripts/dr/stamp-rehearsal-result.mjs`.
 PRECONDITION for `SD-FDBK-FIX-BUS-RETENTION-CLEANUP-001`'s `retention_archive`
 365d TTL step: do not enable that TTL until a rehearsal PASS below is <90d old.
 
-**Latest live run — 2026-07-13T03:06:17.381Z: `PASS`** (scratch schema
-`dr_rehearsal_20260713_0306`, 1.3 s):
+**Latest live run — 2026-08-15T18:58:38.821Z: `PASS`** (scratch schema
+`dr_rehearsal_20260815_1858`, 3.2 s):
 
 | Drill | Result |
 |---|---|


### PR DESCRIPTION
## Summary
- The DR restore-rehearsal cron's runbook-witness commit step passed .husky/pre-commit (QF-20260813-589's --no-verify fix) but the following push was still silently rejected by a SEPARATE hook, .husky/pre-push's work-tracking guard, because branch=main has no SD-*/QF-* pattern to match in non-interactive CI mode.
- The failure was swallowed by a push-or-echo-skipped fallback, so the job showed green while the witness commit never reached main -- confirmed by re-dispatching the cron post-fix (run 31883847701) and finding no new commit on origin/main.
- Adds EHG_ALLOW_MAIN_PUSH=1 scoped to just this one step (same narrow rationale as the existing --no-verify) and removes the silent fallback so a real future failure fails loudly.

## Test plan
- [x] Live-verified on this branch: dispatched the cron against qf/QF-20260815-099 (run 31902579205) -- job green AND github-actions[bot]'s witness commit (67bc9319) is now present on origin/qf/QF-20260815-099, resolving the exact failure mode feedback item 93bf9a7f reported.
- [x] Change is a single-file, workflow-only YAML edit (no application source touched) -- unit/E2E app suites are not exercised by this path; skipped per --skip-tests (CI/CD edge case) with this live CI dispatch as the substantive verification instead.
- [x] YAML structure visually verified against the existing job-level env: block's indentation pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)